### PR TITLE
shell: stdin per-task support

### DIFF
--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -756,14 +756,13 @@ struct attach_ctx {
     bool output_header_parsed;
     double timestamp_zero;
     int eventlog_watch_count;
-    int eventlog_watch_completed;
 };
 
-void attach_eventlog_watch_completed_check (struct attach_ctx *ctx)
+void attach_completed_check (struct attach_ctx *ctx)
 {
     /* eventlog and output watch are the two eventlog watches we need
      * to complete before shutting off reactor */
-    if (ctx->eventlog_watch_completed >= ctx->eventlog_watch_count) {
+    if (!ctx->eventlog_watch_count) {
         flux_watcher_stop (ctx->sigint_w);
         flux_watcher_stop (ctx->sigtstp_w);
     }
@@ -872,8 +871,8 @@ void attach_output_continuation (flux_future_t *f, void *arg)
 done:
     flux_future_destroy (f);
     ctx->output_f = NULL;
-    ctx->eventlog_watch_completed++;
-    attach_eventlog_watch_completed_check (ctx);
+    ctx->eventlog_watch_count--;
+    attach_completed_check (ctx);
 }
 
 void attach_cancel_continuation (flux_future_t *f, void *arg)
@@ -988,8 +987,8 @@ void attach_exec_event_continuation (flux_future_t *f, void *arg)
 done:
     flux_future_destroy (f);
     ctx->exec_eventlog_f = NULL;
-    ctx->eventlog_watch_completed++;
-    attach_eventlog_watch_completed_check (ctx);
+    ctx->eventlog_watch_count--;
+    attach_completed_check (ctx);
 }
 
 /* Handle an event in the main job eventlog.
@@ -1085,8 +1084,8 @@ void attach_event_continuation (flux_future_t *f, void *arg)
 done:
     flux_future_destroy (f);
     ctx->eventlog_f = NULL;
-    ctx->eventlog_watch_completed++;
-    attach_eventlog_watch_completed_check (ctx);
+    ctx->eventlog_watch_count--;
+    attach_completed_check (ctx);
 }
 
 int cmd_attach (optparse_t *p, int argc, char **argv)

--- a/src/cmd/flux-mini.py
+++ b/src/cmd/flux-mini.py
@@ -250,6 +250,12 @@ class SubmitCmd:
             metavar="KEY=VAL",
         )
         parser.add_argument(
+            "--input",
+            type=str,
+            help="Redirect job stdin from FILENAME, bypassing KVS",
+            metavar="FILENAME",
+        )
+        parser.add_argument(
             "--output",
             type=str,
             help="Redirect job stdout to FILENAME, bypassing KVS",
@@ -296,6 +302,10 @@ class SubmitCmd:
         jobspec.set_environment(dict(os.environ))
         if args.time_limit is not None:
             jobspec.set_duration(args.time_limit)
+
+        if args.input is not None:
+            jobspec.setattr_shopt("input.stdin.type", "file")
+            jobspec.setattr_shopt("input.stdin.path", args.input)
 
         if args.output is not None:
             jobspec.setattr_shopt("output.stdout.type", "file")

--- a/src/common/libsubprocess/local.c
+++ b/src/common/libsubprocess/local.c
@@ -169,66 +169,70 @@ static int channel_local_setup (flux_subprocess_t *p,
         goto error;
     }
 
-    if (socketpair (PF_LOCAL, SOCK_STREAM, 0, fds) < 0) {
-        flux_log_error (p->h, "socketpair");
-        goto error;
-    }
+    if ((channel_flags & CHANNEL_READ)
+        || (channel_flags & CHANNEL_WRITE)) {
 
-    c->parent_fd = fds[0];
-    c->child_fd = fds[1];
-
-    /* set fds[] to -1, on error is now subprocess_free()'s
-     * responsibility
-     */
-    fds[0] = -1;
-    fds[1] = -1;
-
-    if ((fd_flags = fd_set_nonblocking (c->parent_fd)) < 0) {
-        flux_log_error (p->h, "fd_set_nonblocking");
-        goto error;
-    }
-
-    if ((buffer_size = cmd_option_bufsize (p, name)) < 0) {
-        flux_log_error (p->h, "cmd_option_bufsize");
-        goto error;
-    }
-
-    if ((channel_flags & CHANNEL_WRITE) && in_cb) {
-        c->buffer_write_w = flux_buffer_write_watcher_create (p->reactor,
-                                                              c->parent_fd,
-                                                              buffer_size,
-                                                              in_cb,
-                                                              0,
-                                                              c);
-        if (!c->buffer_write_w) {
-            flux_log_error (p->h, "flux_buffer_write_watcher_create");
-            goto error;
-        }
-    }
-
-    if ((channel_flags & CHANNEL_READ) && out_cb) {
-        int wflag;
-
-        if ((wflag = cmd_option_line_buffer (p, name)) < 0) {
-            flux_log_error (p->h, "cmd_option_line_buffer");
+        if (socketpair (PF_LOCAL, SOCK_STREAM, 0, fds) < 0) {
+            flux_log_error (p->h, "socketpair");
             goto error;
         }
 
-        if (wflag)
-            c->line_buffered = true;
+        c->parent_fd = fds[0];
+        c->child_fd = fds[1];
 
-        c->buffer_read_w = flux_buffer_read_watcher_create (p->reactor,
-                                                            c->parent_fd,
-                                                            buffer_size,
-                                                            out_cb,
-                                                            wflag,
-                                                            c);
-        if (!c->buffer_read_w) {
-            flux_log_error (p->h, "flux_buffer_read_watcher_create");
+        /* set fds[] to -1, on error is now subprocess_free()'s
+         * responsibility
+         */
+        fds[0] = -1;
+        fds[1] = -1;
+
+        if ((fd_flags = fd_set_nonblocking (c->parent_fd)) < 0) {
+            flux_log_error (p->h, "fd_set_nonblocking");
             goto error;
         }
 
-        p->channels_eof_expected++;
+        if ((buffer_size = cmd_option_bufsize (p, name)) < 0) {
+            flux_log_error (p->h, "cmd_option_bufsize");
+            goto error;
+        }
+
+        if ((channel_flags & CHANNEL_WRITE) && in_cb) {
+            c->buffer_write_w = flux_buffer_write_watcher_create (p->reactor,
+                                                                  c->parent_fd,
+                                                                  buffer_size,
+                                                                  in_cb,
+                                                                  0,
+                                                                  c);
+            if (!c->buffer_write_w) {
+                flux_log_error (p->h, "flux_buffer_write_watcher_create");
+                goto error;
+            }
+        }
+
+        if ((channel_flags & CHANNEL_READ) && out_cb) {
+            int wflag;
+
+            if ((wflag = cmd_option_line_buffer (p, name)) < 0) {
+                flux_log_error (p->h, "cmd_option_line_buffer");
+                goto error;
+            }
+
+            if (wflag)
+                c->line_buffered = true;
+
+            c->buffer_read_w = flux_buffer_read_watcher_create (p->reactor,
+                                                                c->parent_fd,
+                                                                buffer_size,
+                                                                out_cb,
+                                                                wflag,
+                                                                c);
+            if (!c->buffer_read_w) {
+                flux_log_error (p->h, "flux_buffer_read_watcher_create");
+                goto error;
+            }
+
+            p->channels_eof_expected++;
+        }
     }
 
     if (channel_flags & CHANNEL_FD) {
@@ -455,26 +459,36 @@ static int local_child (flux_subprocess_t *p)
 
     if (!(p->flags & FLUX_SUBPROCESS_FLAGS_STDIO_FALLTHROUGH)) {
         if ((c = zhash_lookup (p->channels, "stdin"))) {
-            if (dup2 (c->child_fd, STDIN_FILENO) < 0) {
-                flux_log_error (p->h, "dup2");
-                _exit (1);
+            if (c->flags & CHANNEL_WRITE) {
+                if (dup2 (c->child_fd, STDIN_FILENO) < 0) {
+                    flux_log_error (p->h, "dup2");
+                    _exit (1);
+                }
             }
         }
 
         if ((c = zhash_lookup (p->channels, "stdout"))) {
-            if (dup2 (c->child_fd, STDOUT_FILENO) < 0) {
-                flux_log_error (p->h, "dup2");
-                _exit (1);
+            if (c->flags & CHANNEL_READ) {
+                if (dup2 (c->child_fd, STDOUT_FILENO) < 0) {
+                    flux_log_error (p->h, "dup2");
+                    _exit (1);
+                }
             }
+            else
+                close (STDOUT_FILENO);
         }
         else
             close (STDOUT_FILENO);
 
         if ((c = zhash_lookup (p->channels, "stderr"))) {
-            if (dup2 (c->child_fd, STDERR_FILENO) < 0) {
-                flux_log_error (p->h, "dup2");
-                _exit (1);
+            if (c->flags & CHANNEL_READ) {
+                if (dup2 (c->child_fd, STDERR_FILENO) < 0) {
+                    flux_log_error (p->h, "dup2");
+                    _exit (1);
+                }
             }
+            else
+                close (STDERR_FILENO);
         }
         else
             close (STDERR_FILENO);
@@ -676,15 +690,18 @@ static int start_local_watchers (flux_subprocess_t *p)
     c = zhash_first (p->channels);
     while (c) {
         int ret;
-        flux_watcher_start (c->buffer_write_w);
-        if ((ret = cmd_option_stream_stop (p, c->name)) < 0)
-            return -1;
-        if (ret) {
-            flux_watcher_start (c->buffer_read_stopped_w);
-        }
-        else {
-            flux_watcher_start (c->buffer_read_w);
-            c->buffer_read_w_started = true;
+        if (c->flags & CHANNEL_WRITE)
+            flux_watcher_start (c->buffer_write_w);
+        if (c->flags & CHANNEL_READ) {
+            if ((ret = cmd_option_stream_stop (p, c->name)) < 0)
+                return -1;
+            if (ret) {
+                flux_watcher_start (c->buffer_read_stopped_w);
+            }
+            else {
+                flux_watcher_start (c->buffer_read_w);
+                c->buffer_read_w_started = true;
+            }
         }
         c = zhash_next (p->channels);
     }

--- a/src/common/libsubprocess/subprocess.c
+++ b/src/common/libsubprocess/subprocess.c
@@ -50,6 +50,8 @@ void channel_destroy (void *arg)
             close (c->child_fd);
         if (c->input_fd != -1)
             close (c->input_fd);
+        if (c->output_fd != -1)
+            close (c->output_fd);
         flux_watcher_destroy (c->buffer_write_w);
         flux_watcher_destroy (c->buffer_read_w);
         flux_watcher_destroy (c->buffer_read_stopped_w);
@@ -94,6 +96,7 @@ struct subprocess_channel *channel_create (flux_subprocess_t *p,
     c->parent_fd = -1;
     c->child_fd = -1;
     c->input_fd = -1;
+    c->output_fd = -1;
     c->buffer_write_w = NULL;
     c->buffer_read_w = NULL;
     c->buffer_read_stopped_w = NULL;
@@ -671,6 +674,7 @@ static int check_local_only_cmd_options (const flux_cmd_t *cmd)
     /* check for options that do not apply to remote subprocesses */
     const char *substrings[] = { "STREAM_STOP",
                                  "INPUT_FD",
+                                 "OUTPUT_FD",
                                  NULL };
 
     return flux_cmd_find_opts (cmd, substrings);

--- a/src/common/libsubprocess/subprocess.c
+++ b/src/common/libsubprocess/subprocess.c
@@ -48,6 +48,8 @@ void channel_destroy (void *arg)
             close (c->parent_fd);
         if (c->child_fd != -1)
             close (c->child_fd);
+        if (c->input_fd != -1)
+            close (c->input_fd);
         flux_watcher_destroy (c->buffer_write_w);
         flux_watcher_destroy (c->buffer_read_w);
         flux_watcher_destroy (c->buffer_read_stopped_w);
@@ -91,6 +93,7 @@ struct subprocess_channel *channel_create (flux_subprocess_t *p,
 
     c->parent_fd = -1;
     c->child_fd = -1;
+    c->input_fd = -1;
     c->buffer_write_w = NULL;
     c->buffer_read_w = NULL;
     c->buffer_read_stopped_w = NULL;
@@ -666,7 +669,9 @@ flux_subprocess_t * flux_local_exec (flux_reactor_t *r, int flags,
 static int check_local_only_cmd_options (const flux_cmd_t *cmd)
 {
     /* check for options that do not apply to remote subprocesses */
-    const char *substrings[] = { "STREAM_STOP", NULL };
+    const char *substrings[] = { "STREAM_STOP",
+                                 "INPUT_FD",
+                                 NULL };
 
     return flux_cmd_find_opts (cmd, substrings);
 }

--- a/src/common/libsubprocess/subprocess.h
+++ b/src/common/libsubprocess/subprocess.h
@@ -294,6 +294,19 @@ int flux_cmd_add_channel (flux_cmd_t *cmd, const char *name);
  *    subprocesses.
  *
  *    - stdin_INPUT_FD - file descriptor for stdin
+ *
+ *  "OUTPUT_FD" option
+ *
+ *    By default, standard output is read from flux_subprocess_read()
+ *    (and family of functions) and the stream "stdout" or "stderr".
+ *    This option will inform the subprocess to redirect stdout /
+ *    stderr directly to a specified file descriptor.  Functions like
+ *    flux_subprocess_read() will return EINVAL when attempting to
+ *    read from stdout or stderr.  This option can only be used on
+ *    local subprocesses.
+ *
+ *    - stdout_OUTPUT_FD - file descriptor for stdout
+ *    - stderr_OUTPUT_FD - file descriptor for stderr
  */
 int flux_cmd_setopt (flux_cmd_t *cmd, const char *var, const char *val);
 const char *flux_cmd_getopt (flux_cmd_t *cmd, const char *var);

--- a/src/common/libsubprocess/subprocess.h
+++ b/src/common/libsubprocess/subprocess.h
@@ -282,6 +282,18 @@ int flux_cmd_add_channel (flux_cmd_t *cmd, const char *name);
  *    - name + "_STREAM_STOP" - configure start/stop on channel name
  *    - stdout_STREAM_STOP - configure start/stop for stdout
  *    - stderr_STREAM_STOP - configure start/stop for stderr
+ *
+ *  "INPUT_FD" option
+ *
+ *    By default, standard input is sent to a subprocess via the
+ *    flux_subprocess_write() call and the stream "stdin".  This
+ *    option will inform the subprocess to read stdin directly from a
+ *    specified file descriptor.  As a result, functions liked
+ *    flux_subprocess_write() will return EINVAL when attempting to
+ *    write to "stdin".  This option can only be used on local
+ *    subprocesses.
+ *
+ *    - stdin_INPUT_FD - file descriptor for stdin
  */
 int flux_cmd_setopt (flux_cmd_t *cmd, const char *var, const char *val);
 const char *flux_cmd_getopt (flux_cmd_t *cmd, const char *var);

--- a/src/common/libsubprocess/subprocess_private.h
+++ b/src/common/libsubprocess/subprocess_private.h
@@ -21,9 +21,10 @@
 
 #define CHANNEL_MAGIC    0xcafebeef
 
-#define CHANNEL_READ  0x01
-#define CHANNEL_WRITE 0x02
-#define CHANNEL_FD    0x04
+#define CHANNEL_READ     0x01
+#define CHANNEL_WRITE    0x02
+#define CHANNEL_FD       0x04
+#define CHANNEL_INPUT_FD 0x08
 
 struct subprocess_channel {
     int magic;
@@ -40,6 +41,7 @@ struct subprocess_channel {
     /* local */
     int parent_fd;
     int child_fd;
+    int input_fd;
     flux_watcher_t *buffer_write_w;
     flux_watcher_t *buffer_read_w;
     /* buffer_read_stopped_w is a "sub-in" watcher if buffer_read_w is

--- a/src/common/libsubprocess/subprocess_private.h
+++ b/src/common/libsubprocess/subprocess_private.h
@@ -21,10 +21,11 @@
 
 #define CHANNEL_MAGIC    0xcafebeef
 
-#define CHANNEL_READ     0x01
-#define CHANNEL_WRITE    0x02
-#define CHANNEL_FD       0x04
-#define CHANNEL_INPUT_FD 0x08
+#define CHANNEL_READ      0x01
+#define CHANNEL_WRITE     0x02
+#define CHANNEL_FD        0x04
+#define CHANNEL_INPUT_FD  0x08
+#define CHANNEL_OUTPUT_FD 0x10
 
 struct subprocess_channel {
     int magic;
@@ -42,6 +43,7 @@ struct subprocess_channel {
     int parent_fd;
     int child_fd;
     int input_fd;
+    int output_fd;
     flux_watcher_t *buffer_write_w;
     flux_watcher_t *buffer_read_w;
     /* buffer_read_stopped_w is a "sub-in" watcher if buffer_read_w is

--- a/src/common/libsubprocess/test/subprocess.c
+++ b/src/common/libsubprocess/test/subprocess.c
@@ -796,6 +796,21 @@ void multiple_lines_output_cb (flux_subprocess_t *p, const char *stream)
     (*counter)++;
 }
 
+void write_multiple_lines_to_stdin (flux_subprocess_t *p)
+{
+    ok (flux_subprocess_write (p, "stdin", "foo\n", 4) == 4,
+        "flux_subprocess_write success");
+
+    ok (flux_subprocess_write (p, "stdin", "bar\n", 4) == 4,
+        "flux_subprocess_write success");
+
+    ok (flux_subprocess_write (p, "stdin", "bo\n", 3) == 3,
+        "flux_subprocess_write success");
+
+    ok (flux_subprocess_close (p, "stdin") == 0,
+        "flux_subprocess_close success");
+}
+
 void test_basic_multiple_lines (flux_reactor_t *r)
 {
     char *av[] = { TEST_SUBPROCESS_DIR "test_echo", "-O", "-E", "-n", NULL };
@@ -818,17 +833,7 @@ void test_basic_multiple_lines (flux_reactor_t *r)
     ok (flux_subprocess_state (p) == FLUX_SUBPROCESS_RUNNING,
         "subprocess state == RUNNING after flux_local_exec");
 
-    ok (flux_subprocess_write (p, "stdin", "foo\n", 4) == 4,
-        "flux_subprocess_write success");
-
-    ok (flux_subprocess_write (p, "stdin", "bar\n", 4) == 4,
-        "flux_subprocess_write success");
-
-    ok (flux_subprocess_write (p, "stdin", "bo\n", 3) == 3,
-        "flux_subprocess_write success");
-
-    ok (flux_subprocess_close (p, "stdin") == 0,
-        "flux_subprocess_close success");
+    write_multiple_lines_to_stdin (p);
 
     int rc = flux_reactor_run (r, 0);
     ok (rc == 0, "flux_reactor_run returned zero status");

--- a/src/common/libsubprocess/test/test_echo.c
+++ b/src/common/libsubprocess/test/test_echo.c
@@ -134,8 +134,9 @@ main (int argc, char *argv[])
 
         memset (buf, '\0', 1024);
         while ((len = read (fd, buf, 1024)) > 0) {
-            char outbuf[1025]; /* add extra char for -Werror=format-overflow */
+            char outbuf[1026]; /* add extra char for -Werror=format-overflow */
 
+            memset (outbuf, '\0', sizeof (outbuf));
             sprintf (outbuf,
                      "%s%s",
                      buf,

--- a/src/common/libsubprocess/util.c
+++ b/src/common/libsubprocess/util.c
@@ -122,7 +122,10 @@ cleanup:
     return rv;
 }
 
-int cmd_option_input_fd (flux_subprocess_t *p, const char *name, int *fdp)
+static int cmd_option_fd (flux_subprocess_t *p,
+                          const char *name,
+                          const char *substring,
+                          int *fdp)
 {
     char *var;
     const char *val;
@@ -130,7 +133,7 @@ int cmd_option_input_fd (flux_subprocess_t *p, const char *name, int *fdp)
 
     (*fdp) = -1;
 
-    if (asprintf (&var, "%s_INPUT_FD", name) < 0)
+    if (asprintf (&var, "%s_%s", name, substring) < 0)
         goto cleanup;
 
     if ((val = flux_cmd_getopt (p->cmd, var))) {
@@ -151,6 +154,16 @@ int cmd_option_input_fd (flux_subprocess_t *p, const char *name, int *fdp)
 cleanup:
     free (var);
     return rv;
+}
+
+int cmd_option_input_fd (flux_subprocess_t *p, const char *name, int *fdp)
+{
+    return cmd_option_fd (p, name, "INPUT_FD", fdp);
+}
+
+int cmd_option_output_fd (flux_subprocess_t *p, const char *name, int *fdp)
+{
+    return cmd_option_fd (p, name, "OUTPUT_FD", fdp);
 }
 
 /*

--- a/src/common/libsubprocess/util.c
+++ b/src/common/libsubprocess/util.c
@@ -122,6 +122,37 @@ cleanup:
     return rv;
 }
 
+int cmd_option_input_fd (flux_subprocess_t *p, const char *name, int *fdp)
+{
+    char *var;
+    const char *val;
+    int rv = -1;
+
+    (*fdp) = -1;
+
+    if (asprintf (&var, "%s_INPUT_FD", name) < 0)
+        goto cleanup;
+
+    if ((val = flux_cmd_getopt (p->cmd, var))) {
+        char *endptr;
+        int tmp;
+        errno = 0;
+        tmp = strtol (val, &endptr, 10);
+        if (errno
+            || endptr[0] != '\0'
+            || tmp < 0) {
+            errno = EINVAL;
+            goto cleanup;
+        }
+        (*fdp) = tmp;
+    }
+
+    rv = 0;
+cleanup:
+    free (var);
+    return rv;
+}
+
 /*
  * vi: ts=4 sw=4 expandtab
  */

--- a/src/common/libsubprocess/util.h
+++ b/src/common/libsubprocess/util.h
@@ -26,4 +26,7 @@ int cmd_option_stream_stop (flux_subprocess_t *p, const char *name);
 /* sets fdp to -1 if user did not set INPUT_FD */
 int cmd_option_input_fd (flux_subprocess_t *p, const char *name, int *fdp);
 
+/* sets fdp to -1 if user did not set OUTPUT_FD */
+int cmd_option_output_fd (flux_subprocess_t *p, const char *name, int *fdp);
+
 #endif /* !_SUBPROCESS_UTIL_H */

--- a/src/common/libsubprocess/util.h
+++ b/src/common/libsubprocess/util.h
@@ -23,4 +23,7 @@ int cmd_option_line_buffer (flux_subprocess_t *p, const char *name);
 
 int cmd_option_stream_stop (flux_subprocess_t *p, const char *name);
 
+/* sets fdp to -1 if user did not set INPUT_FD */
+int cmd_option_input_fd (flux_subprocess_t *p, const char *name, int *fdp);
+
 #endif /* !_SUBPROCESS_UTIL_H */

--- a/src/shell/Makefile.am
+++ b/src/shell/Makefile.am
@@ -51,6 +51,7 @@ flux_shell_SOURCES = \
 	task.c \
 	task.h \
 	pmi.c \
+	input.c \
 	output.c \
 	svc.c \
 	svc.h \

--- a/src/shell/Makefile.am
+++ b/src/shell/Makefile.am
@@ -58,7 +58,9 @@ flux_shell_SOURCES = \
 	kill.c \
 	signals.c \
 	affinity.c \
-	gpubind.c
+	gpubind.c \
+	util.c \
+	util.h
 
 flux_shell_LDADD = \
 	$(builddir)/libshell.la \

--- a/src/shell/builtins.c
+++ b/src/shell/builtins.c
@@ -30,6 +30,7 @@ static struct shell_builtin builtin_list_end = { 0 };
  *  to get the builtin automatically loaded at shell startup.
  */
 extern struct shell_builtin builtin_pmi;
+extern struct shell_builtin builtin_input;
 extern struct shell_builtin builtin_output;
 extern struct shell_builtin builtin_kill;
 extern struct shell_builtin builtin_signals;
@@ -38,6 +39,7 @@ extern struct shell_builtin builtin_gpubind;
 
 static struct shell_builtin * builtins [] = {
     &builtin_pmi,
+    &builtin_input,
     &builtin_output,
     &builtin_kill,
     &builtin_signals,

--- a/src/shell/input.c
+++ b/src/shell/input.c
@@ -1,0 +1,643 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* std input handling
+ *
+ * Currently, only standard input via file is supported.
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdio.h>
+#include <string.h>
+#include <flux/core.h>
+
+#include "src/common/libutil/log.h"
+#include "src/common/libidset/idset.h"
+#include "src/common/libeventlog/eventlog.h"
+#include "src/common/libioencode/ioencode.h"
+
+#include "task.h"
+#include "internal.h"
+#include "builtins.h"
+
+struct shell_input;
+
+/* input type configured by user for input to the shell */
+enum {
+    FLUX_INPUT_TYPE_NONE = 1,
+    FLUX_INPUT_TYPE_FILE = 2,
+};
+
+/* how input will reach each task */
+enum {
+    FLUX_TASK_INPUT_KVS = 1,
+};
+
+struct shell_task_input_kvs {
+    flux_future_t *exec_f;
+    flux_future_t *input_f;
+    bool input_header_parsed;
+    bool eof_reached;
+};
+
+struct shell_task_input {
+    struct shell_input *in;
+    struct shell_task *task;
+    int type;
+    struct shell_task_input_kvs input_kvs;
+};
+
+struct shell_input_type_file {
+    const char *path;
+    int fd;
+    flux_watcher_t *w;
+    char *rankstr;
+};
+
+struct shell_input {
+    flux_shell_t *shell;
+    int stdin_type;
+    struct shell_task_input *task_inputs;
+    int task_inputs_count;
+    int ntasks;
+    struct shell_input_type_file stdin_file;
+};
+
+static void shell_task_input_kvs_cleanup (struct shell_task_input_kvs *kp)
+{
+    flux_future_destroy (kp->exec_f);
+    flux_future_destroy (kp->input_f);
+}
+
+static void shell_task_input_cleanup (struct shell_task_input *tp)
+{
+    shell_task_input_kvs_cleanup (&(tp->input_kvs));
+}
+
+static void shell_input_type_file_cleanup (struct shell_input_type_file *fp)
+{
+    close (fp->fd);
+    flux_watcher_destroy (fp->w);
+    free (fp->rankstr);
+}
+
+void shell_input_destroy (struct shell_input *in)
+{
+    if (in) {
+        int saved_errno = errno;
+        int i;
+        shell_input_type_file_cleanup (&(in->stdin_file));
+        for (i = 0; i < in->ntasks; i++)
+            shell_task_input_cleanup (&(in->task_inputs[i]));
+        free (in->task_inputs);
+        free (in);
+        errno = saved_errno;
+    }
+}
+
+static void shell_input_type_file_init (struct shell_input *in)
+{
+    struct shell_input_type_file *fp = &(in->stdin_file);
+    fp->fd = -1;
+}
+
+static int shell_input_parse_type (struct shell_input *in)
+{
+    const char *typestr = NULL;
+    int ret;
+
+    if ((ret = flux_shell_getopt_unpack (in->shell, "input",
+                                         "{s?:{s?:s}}",
+                                         "stdin", "type", &typestr)) < 0)
+        return -1;
+
+    if (!ret || !typestr)
+        return 0;
+
+    if (!strcmp (typestr, "file")) {
+        struct shell_input_type_file *fp = &(in->stdin_file);
+
+        in->stdin_type = FLUX_INPUT_TYPE_FILE;
+
+        if (flux_shell_getopt_unpack (in->shell, "input",
+                                      "{s:{s?:s}}",
+                                      "stdin", "path", &(fp->path)) < 0)
+            return -1;
+
+        if (fp->path == NULL) {
+            log_msg ("path for stdin file input not specified");
+            return -1;
+        }
+    }
+    else {
+        log_msg ("invalid input type specified '%s'", typestr);
+        return -1;
+    }
+
+    return 0;
+}
+
+/* log entry to exec.eventlog that we've created the input eventlog */
+static int shell_input_ready (struct shell_input *in, flux_kvs_txn_t *txn)
+{
+    json_t *entry = NULL;
+    char *entrystr = NULL;
+    const char *key = "exec.eventlog";
+    int saved_errno, rc = -1;
+
+    if (!(entry = eventlog_entry_create (0., "input-ready", NULL))) {
+        log_err ("eventlog_entry_create");
+        goto error;
+    }
+    if (!(entrystr = eventlog_entry_encode (entry))) {
+        log_err ("eventlog_entry_encode");
+        goto error;
+    }
+    if (flux_kvs_txn_put (txn, FLUX_KVS_APPEND, key, entrystr) < 0) {
+        log_err ("flux_kvs_txn_put");
+        goto error;
+    }
+    rc = 0;
+ error:
+    /* on error, future destroyed via shell_input destroy */
+    saved_errno = errno;
+    json_decref (entry);
+    free (entrystr);
+    errno = saved_errno;
+    return rc;
+}
+
+static void shell_input_kvs_init_completion (flux_future_t *f, void *arg)
+{
+    struct shell_input *in = arg;
+
+    if (flux_future_get (f, NULL) < 0)
+        /* failng to commit header is a fatal error.  Should be
+         * cleaner in future. Issue #2378 */
+        log_err_exit ("shell_input_kvs_init");
+    flux_future_destroy (f);
+
+    if (flux_shell_remove_completion_ref (in->shell, "input.kvs-init") < 0)
+        log_err ("flux_shell_remove_completion_ref");
+
+    if (in->stdin_type == FLUX_INPUT_TYPE_FILE)
+        flux_watcher_start (in->stdin_file.w);
+}
+
+static int shell_input_kvs_init (struct shell_input *in, json_t *header)
+{
+    flux_kvs_txn_t *txn = NULL;
+    flux_future_t *f = NULL;
+    char *headerstr = NULL;
+    int saved_errno;
+    int rc = -1;
+
+    if (!(headerstr = eventlog_entry_encode (header)))
+        goto error;
+    if (!(txn = flux_kvs_txn_create ()))
+        goto error;
+    if (flux_kvs_txn_put (txn, FLUX_KVS_APPEND, "input", headerstr) < 0)
+        goto error;
+    if (shell_input_ready (in, txn) < 0)
+        goto error;
+    if (!(f = flux_kvs_commit (in->shell->h, NULL, 0, txn)))
+        goto error;
+    if (flux_future_then (f, -1, shell_input_kvs_init_completion, in) < 0)
+        goto error;
+    if (flux_shell_add_completion_ref (in->shell, "input.kvs-init") < 0) {
+        log_err ("flux_shell_remove_completion_ref");
+        goto error;
+    }
+    /* f memory responsibility of shell_input_kvs_init_completion()
+     * callback */
+    f = NULL;
+    rc = 0;
+ error:
+    saved_errno = errno;
+    flux_kvs_txn_destroy (txn);
+    free (headerstr);
+    flux_future_destroy (f);
+    errno = saved_errno;
+    return rc;
+}
+
+static int shell_input_header (struct shell_input *in)
+{
+    json_t *o = NULL;
+    int rc = -1;
+
+    o = eventlog_entry_pack (0, "header",
+                             "{s:i s:{s:s} s:{s:i} s:{}}",
+                             "version", 1,
+                             "encoding",
+                             "stdin", "base64",
+                             "count",
+                             "stdin", 1,
+                             "options");
+    if (!o) {
+        errno = ENOMEM;
+        goto error;
+    }
+    if (!in->shell->standalone) {
+        if (shell_input_kvs_init (in, o) < 0)
+            log_err ("shell_input_kvs_init");
+    }
+    rc = 0;
+ error:
+    json_decref (o);
+    return rc;
+}
+
+static void shell_input_put_kvs_completion (flux_future_t *f, void *arg)
+{
+    struct shell_input *in = arg;
+
+    if (flux_future_get (f, NULL) < 0)
+        /* failng to write stdin to input is a fatal error.  Should be
+         * cleaner in future. Issue #2378 */
+        log_err_exit ("shell_input_put_kvs");
+    flux_future_destroy (f);
+
+    if (flux_shell_remove_completion_ref (in->shell, "input.kvs") < 0)
+        log_err ("flux_shell_remove_completion_ref");
+}
+
+static int shell_input_put_kvs (struct shell_input *in,
+                                void *buf,
+                                int len,
+                                bool eof)
+{
+    flux_kvs_txn_t *txn = NULL;
+    flux_future_t *f = NULL;
+    json_t *entry = NULL;
+    char *entrystr = NULL;
+    json_t *context = NULL;
+    int saved_errno;
+    int rc = -1;
+
+    if (!(context = ioencode ("stdin", in->stdin_file.rankstr, buf, len, eof)))
+        goto error;
+    if (!(entry = eventlog_entry_pack (0.0, "data", "O", context)))
+        goto error;
+    if (!(entrystr = eventlog_entry_encode (entry)))
+        goto error;
+    if (!(txn = flux_kvs_txn_create ()))
+        goto error;
+    if (flux_kvs_txn_put (txn, FLUX_KVS_APPEND, "input", entrystr) < 0)
+        goto error;
+    if (!(f = flux_kvs_commit (in->shell->h, NULL, 0, txn)))
+        goto error;
+    if (flux_future_then (f, -1, shell_input_put_kvs_completion, in) < 0)
+        goto error;
+    if (flux_shell_add_completion_ref (in->shell, "input.kvs") < 0) {
+        log_err ("flux_shell_remove_completion_ref");
+        goto error;
+    }
+    /* f memory responsibility of shell_input_put_kvs_completion()
+     * callback */
+    f = NULL;
+    rc = 0;
+ error:
+    saved_errno = errno;
+    flux_kvs_txn_destroy (txn);
+    json_decref (context);
+    free (entrystr);
+    json_decref (entry);
+    flux_future_destroy (f);
+    errno = saved_errno;
+    return rc;
+}
+
+static void shell_input_type_file_cb (flux_reactor_t *r, flux_watcher_t *w,
+                                      int revents, void *arg)
+{
+    struct shell_input *in = arg;
+    struct shell_input_type_file *fp = &(in->stdin_file);
+    long ps = sysconf (_SC_PAGESIZE);
+    char buf[ps];
+    ssize_t n;
+
+    assert (ps > 0);
+
+    /* Failure to read stdin in a fatal error.  Should be cleaner in
+     * future.  Issue #2378 */
+
+    while ((n = read (fp->fd, buf, ps)) > 0) {
+        if (shell_input_put_kvs (in, buf, n, false) < 0)
+            log_err_exit ("shell_input_put_kvs");
+    }
+
+    if (n < 0)
+        log_err_exit ("shell_input_put_kvs");
+
+    if (shell_input_put_kvs (in, NULL, 0, true) < 0)
+        log_err_exit ("shell_input_put_kvs");
+
+    flux_watcher_stop (w);
+}
+
+static int shell_input_type_file_setup (struct shell_input *in)
+{
+    struct shell_input_type_file *fp = &(in->stdin_file);
+
+    if ((fp->fd = open (fp->path, O_RDONLY)) < 0) {
+        log_err ("error opening input file '%s'", fp->path);
+        return -1;
+    }
+
+    if (!(fp->w = flux_fd_watcher_create (in->shell->r, fp->fd,
+                                          FLUX_POLLIN,
+                                          shell_input_type_file_cb,
+                                          in))) {
+        log_err ("flux_fd_watcher_create");
+        return -1;
+    }
+
+    if (in->shell->info->jobspec->task_count > 1) {
+        if (asprintf (&fp->rankstr, "[0-%d]",
+                      in->shell->info->jobspec->task_count) < 0) {
+            log_err ("asprintf");
+            return -1;
+        }
+    }
+    else {
+        if (!(fp->rankstr = strdup ("0"))) {
+            log_err ("asprintf");
+            return -1;
+        }
+    }
+
+    return 0;
+}
+
+struct shell_input *shell_input_create (flux_shell_t *shell)
+{
+    struct shell_input *in;
+    size_t task_inputs_size;
+    int i;
+
+    if (!(in = calloc (1, sizeof (*in))))
+        return NULL;
+    in->shell = shell;
+    in->stdin_type = FLUX_INPUT_TYPE_NONE;
+    in->ntasks = shell->info->rankinfo.ntasks;
+
+    task_inputs_size = sizeof (struct shell_task_input) * in->ntasks;
+    if (!(in->task_inputs = calloc (1, task_inputs_size)))
+        goto error;
+
+    for (i = 0; i < in->ntasks; i++)
+        in->task_inputs[i].type = FLUX_TASK_INPUT_KVS;
+
+    shell_input_type_file_init (in);
+
+    /* Check if user specified shell input */
+    if (shell_input_parse_type (in) < 0)
+        goto error;
+
+    if (shell->info->shell_rank == 0) {
+        /* can't use stdin in standalone, no kvs to write to */
+        if (!in->shell->standalone) {
+            if (shell_input_header (in) < 0)
+                goto error;
+
+            if (in->stdin_type == FLUX_INPUT_TYPE_FILE) {
+                if (shell_input_type_file_setup (in) < 0)
+                    goto error;
+            }
+        }
+    }
+
+    return in;
+error:
+    shell_input_destroy (in);
+    return NULL;
+}
+
+static int shell_input_init (flux_plugin_t *p,
+                             const char *topic,
+                             flux_plugin_arg_t *args,
+                             void *data)
+{
+    flux_shell_t *shell = flux_plugin_get_shell (p);
+    struct shell_input *in = shell_input_create (shell);
+    if (!in)
+        return -1;
+    if (flux_plugin_aux_set (p, "builtin.input", in,
+                            (flux_free_f) shell_input_destroy) < 0) {
+        shell_input_destroy (in);
+        return -1;
+    }
+    return 0;
+}
+
+static void shell_task_input_kvs_input_cb (flux_future_t *f, void *arg)
+{
+    struct shell_task_input *task_input = arg;
+    struct shell_task_input_kvs *kp = &(task_input->input_kvs);
+    const char *entry;
+    json_t *o;
+    const char *name;
+    json_t *context;
+
+    /* Failure to read stdin in a fatal error.  Should be cleaner in
+     * future.  Issue #2378 */
+
+    if (flux_job_event_watch_get (f, &entry) < 0) {
+        if (errno == ENODATA)
+            goto done;
+        log_msg_exit ("flux_job_event_watch_get: %s",
+                      future_strerror (f, errno));
+    }
+    if (!(o = eventlog_entry_decode (entry)))
+        log_err_exit ("eventlog_entry_decode");
+    if (eventlog_entry_parse (o, NULL, &name, &context) < 0)
+        log_err_exit ("eventlog_entry_parse");
+
+    if (!strcmp (name, "header")) {
+        /* Future: per-stream encoding */
+        kp->input_header_parsed = true;
+    }
+    else if (!strcmp (name, "data")) {
+        const char *rank = NULL;
+        bool data_ok = false;
+        if (!kp->input_header_parsed)
+            log_msg_exit ("stream data read before header");
+        if (iodecode (context, NULL, &rank, NULL, NULL, NULL) < 0)
+            log_msg_exit ("malformed event context");
+        if (!strcmp (rank, "all"))
+            data_ok = true;
+        else {
+            struct idset *idset;
+            if (!(idset = idset_decode (rank))) {
+                log_err ("idset_decode '%s'", rank);
+                goto out;
+            }
+            data_ok = idset_test (idset, task_input->task->rank);
+            idset_destroy (idset);
+        }
+        if (data_ok) {
+            const char *stream;
+            char *data = NULL;
+            int len;
+            bool eof;
+            if (kp->eof_reached) {
+                log_msg_exit ("stream data after EOF");
+                goto out;
+            }
+            if (iodecode (context, &stream, NULL, &data, &len, &eof) < 0)
+                log_msg_exit ("malformed event context");
+            if (len > 0) {
+                if (flux_subprocess_write (task_input->task->proc,
+                                           stream,
+                                           data,
+                                           len) < 0)
+                    log_err_exit ("flux_subprocess_write");
+            }
+            if (eof) {
+                if (flux_subprocess_close (task_input->task->proc, stream) < 0)
+                    log_err_exit ("flux_subprocess_close");
+                if (flux_job_event_watch_cancel (f) < 0)
+                    log_err_exit ("flux_job_event_watch_cancel");
+            }
+            free (data);
+        }
+    }
+
+out:
+    json_decref (o);
+    flux_future_reset (f);
+    return;
+done:
+    flux_future_destroy (f);
+    kp->input_f = NULL;
+}
+
+static void shell_task_input_kvs_exec_cb (flux_future_t *f, void *arg)
+{
+    struct shell_task_input *task_input = arg;
+    struct shell_task_input_kvs *kp = &(task_input->input_kvs);
+    flux_future_t *input_f = NULL;
+    const char *entry;
+    json_t *o;
+    const char *name;
+
+    /* Failure to read stdin in a fatal error.  Should be cleaner in
+     * future.  Issue #2378 */
+
+    if (flux_job_event_watch_get (f, &entry) < 0) {
+        if (errno == ENODATA)
+            goto done;
+        log_msg_exit ("flux_job_event_watch_get: %s",
+                      future_strerror (f, errno));
+    }
+    if (!(o = eventlog_entry_decode (entry)))
+        log_err_exit ("eventlog_entry_decode");
+    if (eventlog_entry_parse (o, NULL, &name, NULL) < 0)
+        log_err_exit ("eventlog_entry_parse");
+
+    if (!strcmp (name, "input-ready")) {
+        if (!(input_f = flux_job_event_watch (task_input->in->shell->h,
+                                              task_input->in->shell->info->jobid,
+                                              "guest.input",
+                                              0)))
+            log_err_exit ("flux_job_event_watch");
+
+        if (flux_future_then (input_f,
+                              -1.,
+                              shell_task_input_kvs_input_cb,
+                              arg) < 0) {
+            flux_future_destroy (input_f);
+            log_err_exit ("flux_future_then");
+        }
+
+        kp->input_f = input_f;
+    }
+
+    json_decref (o);
+    flux_future_reset (f);
+    return;
+ done:
+    flux_future_destroy (f);
+    kp->exec_f = NULL;
+}
+
+static int shell_task_input_kvs_setup (struct shell_task_input *task_input)
+{
+    /* Watch "guest.exec.eventlog" to determine when "guest.input" is ready */
+    struct shell_task_input_kvs *kp = &(task_input->input_kvs);
+    flux_future_t *f = NULL;
+    int saved_errno;
+
+    if (!(f = flux_job_event_watch (task_input->in->shell->h,
+                                    task_input->in->shell->info->jobid,
+                                    "guest.exec.eventlog",
+                                    0))) {
+        log_err ("flux_job_event_watch");
+        goto error;
+    }
+
+    if (flux_future_then (f,
+                          -1,
+                          shell_task_input_kvs_exec_cb,
+                          task_input) < 0) {
+        log_err ("flux_future_then");
+        goto error;
+    }
+
+    kp->exec_f = f;
+    return 0;
+ error:
+    saved_errno = errno;
+    flux_future_destroy (f);
+    errno = saved_errno;
+    return -1;
+}
+
+static int shell_input_task_init (flux_plugin_t *p,
+                                  const char *topic,
+                                  flux_plugin_arg_t *args,
+                                  void *data)
+{
+    flux_shell_t *shell = flux_plugin_get_shell (p);
+    struct shell_input *in = flux_plugin_aux_get (p, "builtin.input");
+    struct shell_task_input *task_input;
+    flux_shell_task_t *task;
+
+    if (!shell || !in || !(task = flux_shell_current_task (shell)))
+        return -1;
+
+    task_input = &(in->task_inputs[in->task_inputs_count]);
+    task_input->in = in;
+    task_input->task = task;
+
+    if (task_input->type == FLUX_TASK_INPUT_KVS) {
+        /* can't read stdin in standalone mode, no KVS to read from */
+        if (!task_input->in->shell->standalone) {
+            if (shell_task_input_kvs_setup (task_input) < 0)
+                return -1;
+        }
+    }
+
+    in->task_inputs_count++;
+    return 0;
+}
+
+struct shell_builtin builtin_input = {
+    .name = "input",
+    .init = shell_input_init,
+    .task_init = shell_input_task_init
+};
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/shell/input.c
+++ b/src/shell/input.c
@@ -10,7 +10,9 @@
 
 /* std input handling
  *
- * Currently, only standard input via file is supported.
+ * Depending on inputs from user, a service is started to receive
+ * stdin from front-end command or file is read for redirected
+ * standard input.
  */
 
 #if HAVE_CONFIG_H
@@ -26,6 +28,7 @@
 #include "src/common/libioencode/ioencode.h"
 
 #include "task.h"
+#include "svc.h"
 #include "internal.h"
 #include "builtins.h"
 
@@ -33,7 +36,7 @@ struct shell_input;
 
 /* input type configured by user for input to the shell */
 enum {
-    FLUX_INPUT_TYPE_NONE = 1,
+    FLUX_INPUT_TYPE_SERVICE = 1, /* default */
     FLUX_INPUT_TYPE_FILE = 2,
 };
 
@@ -104,6 +107,89 @@ void shell_input_destroy (struct shell_input *in)
     }
 }
 
+static void shell_input_put_kvs_completion (flux_future_t *f, void *arg)
+{
+    struct shell_input *in = arg;
+
+    if (flux_future_get (f, NULL) < 0)
+        /* failng to write stdin to input is a fatal error.  Should be
+         * cleaner in future. Issue #2378 */
+        log_err_exit ("shell_input_put_kvs");
+    flux_future_destroy (f);
+
+    if (flux_shell_remove_completion_ref (in->shell, "input.kvs") < 0)
+        log_err ("flux_shell_remove_completion_ref");
+}
+
+static int shell_input_put_kvs (struct shell_input *in, json_t *context)
+{
+    flux_kvs_txn_t *txn = NULL;
+    flux_future_t *f = NULL;
+    json_t *entry = NULL;
+    char *entrystr = NULL;
+    int saved_errno;
+    int rc = -1;
+
+    if (!(entry = eventlog_entry_pack (0.0, "data", "O", context)))
+        goto error;
+    if (!(entrystr = eventlog_entry_encode (entry)))
+        goto error;
+    if (!(txn = flux_kvs_txn_create ()))
+        goto error;
+    if (flux_kvs_txn_put (txn, FLUX_KVS_APPEND, "input", entrystr) < 0)
+        goto error;
+    if (!(f = flux_kvs_commit (in->shell->h, NULL, 0, txn)))
+        goto error;
+    if (flux_future_then (f, -1, shell_input_put_kvs_completion, in) < 0)
+        goto error;
+    if (flux_shell_add_completion_ref (in->shell, "input.kvs") < 0) {
+        log_err ("flux_shell_remove_completion_ref");
+        goto error;
+    }
+    /* f memory responsibility of shell_input_put_kvs_completion()
+     * callback */
+    f = NULL;
+    rc = 0;
+ error:
+    saved_errno = errno;
+    flux_kvs_txn_destroy (txn);
+    free (entrystr);
+    json_decref (entry);
+    flux_future_destroy (f);
+    errno = saved_errno;
+    return rc;
+}
+
+/* Convert 'iodecode' object to an valid RFC 24 data event.
+ * N.B. the iodecode object is a valid "context" for the event.
+ */
+static void shell_input_stdin_cb (flux_t *h,
+                                  flux_msg_handler_t *mh,
+                                  const flux_msg_t *msg,
+                                  void *arg)
+{
+    struct shell_input *in = arg;
+    bool eof = false;
+    json_t *o;
+
+    if (shell_svc_allowed (in->shell->svc, msg) < 0)
+        goto error;
+    if (flux_request_unpack (msg, NULL, "o", &o) < 0)
+        goto error;
+    if (iodecode (o, NULL, NULL, NULL, NULL, &eof) < 0)
+        goto error;
+    if (shell_input_put_kvs (in, o) < 0)
+        goto error;
+    if (eof)
+        flux_msg_handler_stop (mh);
+    if (flux_respond (in->shell->h, msg, NULL) < 0)
+        log_err ("flux_respond");
+    return;
+error:
+    if (flux_respond_error (in->shell->h, msg, errno, NULL) < 0)
+        log_err ("flux_respond");
+}
+
 static void shell_input_type_file_init (struct shell_input *in)
 {
     struct shell_input_type_file *fp = &(in->stdin_file);
@@ -123,7 +209,9 @@ static int shell_input_parse_type (struct shell_input *in)
     if (!ret || !typestr)
         return 0;
 
-    if (!strcmp (typestr, "file")) {
+    if (!strcmp (typestr, "service"))
+        in->stdin_type = FLUX_INPUT_TYPE_SERVICE;
+    else if (!strcmp (typestr, "file")) {
         struct shell_input_type_file *fp = &(in->stdin_file);
 
         in->stdin_type = FLUX_INPUT_TYPE_FILE;
@@ -146,15 +234,19 @@ static int shell_input_parse_type (struct shell_input *in)
     return 0;
 }
 
-/* log entry to exec.eventlog that we've created the input eventlog */
+/* log entry to exec.eventlog that we've created the input eventlog /
+ * started stdin service */
 static int shell_input_ready (struct shell_input *in, flux_kvs_txn_t *txn)
 {
     json_t *entry = NULL;
     char *entrystr = NULL;
     const char *key = "exec.eventlog";
+    int rank = in->shell->info->rankinfo.rank;
     int saved_errno, rc = -1;
 
-    if (!(entry = eventlog_entry_create (0., "input-ready", NULL))) {
+    if (!(entry = eventlog_entry_pack (0., "input-ready",
+                                       "{s:i}",
+                                       "leader-rank", rank))) {
         log_err ("eventlog_entry_create");
         goto error;
     }
@@ -257,62 +349,23 @@ static int shell_input_header (struct shell_input *in)
     return rc;
 }
 
-static void shell_input_put_kvs_completion (flux_future_t *f, void *arg)
+static int shell_input_put_kvs_raw (struct shell_input *in,
+                                    void *buf,
+                                    int len,
+                                    bool eof)
 {
-    struct shell_input *in = arg;
-
-    if (flux_future_get (f, NULL) < 0)
-        /* failng to write stdin to input is a fatal error.  Should be
-         * cleaner in future. Issue #2378 */
-        log_err_exit ("shell_input_put_kvs");
-    flux_future_destroy (f);
-
-    if (flux_shell_remove_completion_ref (in->shell, "input.kvs") < 0)
-        log_err ("flux_shell_remove_completion_ref");
-}
-
-static int shell_input_put_kvs (struct shell_input *in,
-                                void *buf,
-                                int len,
-                                bool eof)
-{
-    flux_kvs_txn_t *txn = NULL;
-    flux_future_t *f = NULL;
-    json_t *entry = NULL;
-    char *entrystr = NULL;
     json_t *context = NULL;
     int saved_errno;
     int rc = -1;
 
     if (!(context = ioencode ("stdin", in->stdin_file.rankstr, buf, len, eof)))
         goto error;
-    if (!(entry = eventlog_entry_pack (0.0, "data", "O", context)))
+    if (shell_input_put_kvs (in, context) < 0)
         goto error;
-    if (!(entrystr = eventlog_entry_encode (entry)))
-        goto error;
-    if (!(txn = flux_kvs_txn_create ()))
-        goto error;
-    if (flux_kvs_txn_put (txn, FLUX_KVS_APPEND, "input", entrystr) < 0)
-        goto error;
-    if (!(f = flux_kvs_commit (in->shell->h, NULL, 0, txn)))
-        goto error;
-    if (flux_future_then (f, -1, shell_input_put_kvs_completion, in) < 0)
-        goto error;
-    if (flux_shell_add_completion_ref (in->shell, "input.kvs") < 0) {
-        log_err ("flux_shell_remove_completion_ref");
-        goto error;
-    }
-    /* f memory responsibility of shell_input_put_kvs_completion()
-     * callback */
-    f = NULL;
     rc = 0;
  error:
     saved_errno = errno;
-    flux_kvs_txn_destroy (txn);
     json_decref (context);
-    free (entrystr);
-    json_decref (entry);
-    flux_future_destroy (f);
     errno = saved_errno;
     return rc;
 }
@@ -332,15 +385,15 @@ static void shell_input_type_file_cb (flux_reactor_t *r, flux_watcher_t *w,
      * future.  Issue #2378 */
 
     while ((n = read (fp->fd, buf, ps)) > 0) {
-        if (shell_input_put_kvs (in, buf, n, false) < 0)
-            log_err_exit ("shell_input_put_kvs");
+        if (shell_input_put_kvs_raw (in, buf, n, false) < 0)
+            log_err_exit ("shell_input_put_kvs_raw");
     }
 
     if (n < 0)
-        log_err_exit ("shell_input_put_kvs");
+        log_err_exit ("shell_input_put_kvs_raw");
 
-    if (shell_input_put_kvs (in, NULL, 0, true) < 0)
-        log_err_exit ("shell_input_put_kvs");
+    if (shell_input_put_kvs_raw (in, NULL, 0, true) < 0)
+        log_err_exit ("shell_input_put_kvs_raw");
 
     flux_watcher_stop (w);
 }
@@ -388,7 +441,7 @@ struct shell_input *shell_input_create (flux_shell_t *shell)
     if (!(in = calloc (1, sizeof (*in))))
         return NULL;
     in->shell = shell;
-    in->stdin_type = FLUX_INPUT_TYPE_NONE;
+    in->stdin_type = FLUX_INPUT_TYPE_SERVICE;
     in->ntasks = shell->info->rankinfo.ntasks;
 
     task_inputs_size = sizeof (struct shell_task_input) * in->ntasks;
@@ -407,6 +460,17 @@ struct shell_input *shell_input_create (flux_shell_t *shell)
     if (shell->info->shell_rank == 0) {
         /* can't use stdin in standalone, no kvs to write to */
         if (!in->shell->standalone) {
+            if (in->stdin_type == FLUX_INPUT_TYPE_SERVICE) {
+                if (flux_shell_service_register (in->shell,
+                                                 "stdin",
+                                                 shell_input_stdin_cb,
+                                                 in) < 0)
+                    log_err_exit ("flux_shell_service_register");
+
+                /* Do not add a completion reference for the stdin service, we
+                 * don't care if the user ever sends stdin */
+            }
+
             if (shell_input_header (in) < 0)
                 goto error;
 

--- a/src/shell/output.c
+++ b/src/shell/output.c
@@ -495,11 +495,11 @@ static void shell_output_write_cb (flux_t *h,
     json_t *o;
     json_t *entry;
 
+    if (shell_svc_allowed (out->shell->svc, msg) < 0)
+        goto error;
     if (flux_request_unpack (msg, NULL, "o", &o) < 0)
         goto error;
     if (iodecode (o, NULL, NULL, NULL, NULL, &eof) < 0)
-        goto error;
-    if (shell_svc_allowed (out->shell->svc, msg) < 0)
         goto error;
     if (!(entry = eventlog_entry_pack (0., "data", "O", o))) // increfs 'o'
         goto error;

--- a/src/shell/util.c
+++ b/src/shell/util.c
@@ -1,0 +1,55 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* job shell info */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/core.h>
+#include <jansson.h>
+#include <string.h>
+
+#include "src/common/libutil/log.h"
+
+#include "util.h"
+
+int shell_util_taskid_path (const char *path,
+                            int rank,
+                            char *pathbuf,
+                            int pathbuflen)
+{
+    char *ptr;
+    char buf[32];
+    int len, buflen, total_len;
+
+    if (!(ptr = strstr (path, "{{taskid}}"))) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    len = strlen (path);
+    buflen = snprintf (buf, sizeof (buf), "%d", rank);
+    /* -10 for {{taskid}}, +1 for NUL */
+    total_len = len - 10 + buflen + 1;
+    if (total_len > pathbuflen) {
+        errno = EOVERFLOW;
+        return -1;
+    }
+    memset (pathbuf, '\0', pathbuflen);
+    memcpy (pathbuf, path, ptr - path);
+    memcpy (pathbuf + (ptr - path), buf, buflen);
+    memcpy (pathbuf + (ptr - path) + buflen, ptr + 10, len - (ptr - path) - 10);
+    return 0;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/shell/util.h
+++ b/src/shell/util.h
@@ -1,0 +1,24 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _SHELL_UTIL_H
+#define _SHELL_UTIL_H
+
+/* substitute rank with {{taskid}} template in path */
+int shell_util_taskid_path (const char *path,
+                            int rank,
+                            char *pathbuf,
+                            int pathbuflen);
+
+#endif /* !_SHELL_UTIL_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -110,6 +110,7 @@ TESTSCRIPTS = \
 	t2604-job-shell-affinity.t \
 	t2605-job-shell-output-redirection-standalone.t \
 	t2606-job-shell-output-redirection.t \
+	t2607-job-shell-input.t \
 	t2700-mini-cmd.t \
 	t3000-mpi-basic.t \
 	t3001-mpi-personalities.t \

--- a/t/t2602-job-shell.t
+++ b/t/t2602-job-shell.t
@@ -125,10 +125,18 @@ test_expect_success 'job-shell: verify output of 1-task lptest job' '
 	flux job attach -l $id >lptest.out &&
 	test_cmp lptest.exp lptest.out
 '
+#
+# sharness will redirect /dev/null to stdin by default, leading to the
+# possibility of seeing an EOF warning on stdin.  We'll check for that
+# manually in a few of the tests and filter it out from the stderr
+# output.
+#
+
 test_expect_success 'job-shell: verify output of 1-task lptest job on stderr' '
         id=$(flux jobspec srun -n1 bash -c "${LPTEST} >&2" \
 		| flux job submit) &&
 	flux job attach -l $id 2>lptest.err &&
+        sed -i -e "/stdin EOF could not be sent/d" lptest.err &&
 	test_cmp lptest.exp lptest.err
 '
 test_expect_success 'job-shell: verify output of 4-task lptest job' '
@@ -142,6 +150,7 @@ test_expect_success 'job-shell: verify output of 4-task lptest job on stderr' '
 		| flux job submit) &&
 	flux job attach -l $id 2>lptest4_raw.err &&
 	sort -snk1 <lptest4_raw.err >lptest4.err &&
+        sed -i -e "/stdin EOF could not be sent/d" lptest4.err &&
 	test_cmp lptest4.exp lptest4.err
 '
 test_expect_success LONGTEST 'job-shell: verify 10K line lptest output works' '

--- a/t/t2605-job-shell-output-redirection-standalone.t
+++ b/t/t2605-job-shell-output-redirection-standalone.t
@@ -204,7 +204,7 @@ test_expect_success HAVE_JQ 'flux-shell: run 2-task echo job (stdout term/stderr
 '
 
 #
-# output file mustache tests
+# mustache {{id}} template tests
 #
 
 test_expect_success HAVE_JQ 'flux-shell: run 1-task echo job (mustache id stdout file/stderr file)' '
@@ -230,29 +230,252 @@ test_expect_success HAVE_JQ 'flux-shell: run 1-task echo job (mustache id stdout
 '
 
 #
+# 1 task output mustache {{taskid}} tests
+#
+
+test_expect_success HAVE_JQ 'flux-shell: run 1-task echo job ({{taskid}} stdout)' '
+        cat j1echostdout \
+            |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
+            |  $jq ".attributes.system.shell.options.output.stdout.path = \"out16-{{taskid}}\"" \
+            > j1echostdout-16 &&
+	${FLUX_SHELL} -v -s -r 0 -j j1echostdout-16 -R R1 16 &&
+	grep stdout:foo out16-0
+'
+
+test_expect_success HAVE_JQ 'flux-shell: run 1-task echo job ({{taskid}} stderr)' '
+        cat j1echostderr \
+            |  $jq ".attributes.system.shell.options.output.stderr.type = \"file\"" \
+            |  $jq ".attributes.system.shell.options.output.stderr.path = \"err17-{{taskid}}\"" \
+            > j1echostderr-17 &&
+	${FLUX_SHELL} -v -s -r 0 -j j1echostderr-17 -R R1 17 &&
+	grep stderr:bar err17-0
+'
+
+test_expect_success HAVE_JQ 'flux-shell: run 1-task echo job (stderr to stdout {{taskid}})' '
+        cat j1echostderr \
+            |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
+            |  $jq ".attributes.system.shell.options.output.stdout.path = \"out18-{{taskid}}\"" \
+            > j1echostderr-18 &&
+	${FLUX_SHELL} -v -s -r 0 -j j1echostderr-18 -R R1 18 &&
+	grep stderr:bar out18-0
+'
+
+test_expect_success HAVE_JQ 'flux-shell: run 1-task echo job ({{taskid}} stdout & stderr)' '
+        cat j1echoboth \
+            |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
+            |  $jq ".attributes.system.shell.options.output.stdout.path = \"out19-{{taskid}}\"" \
+            |  $jq ".attributes.system.shell.options.output.stderr.type = \"file\"" \
+            |  $jq ".attributes.system.shell.options.output.stderr.path = \"err19-{{taskid}}\"" \
+            > j1echoboth-19 &&
+	${FLUX_SHELL} -v -s -r 0 -j j1echoboth-19 -R R1 19 &&
+	grep stdout:baz out19-0 &&
+	grep stderr:baz err19-0
+'
+
+test_expect_success HAVE_JQ 'flux-shell: run 1-task echo job (stdout & stderr to stdout {{taskid}})' '
+        cat j1echoboth \
+            |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
+            |  $jq ".attributes.system.shell.options.output.stdout.path = \"out20-{{taskid}}\"" \
+            > j1echoboth-20 &&
+	${FLUX_SHELL} -v -s -r 0 -j j1echoboth-20 -R R1 20 &&
+	grep stdout:baz out20-0 &&
+	grep stderr:baz out20-0
+'
+
+test_expect_success HAVE_JQ 'flux-shell: run 1-task echo job ({{taskid}} stdout/stderr term)' '
+        cat j1echoboth \
+            |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
+            |  $jq ".attributes.system.shell.options.output.stdout.path = \"out21-{{taskid}}\"" \
+            |  $jq ".attributes.system.shell.options.output.stderr.type = \"term\"" \
+            > j1echoboth-21 &&
+	${FLUX_SHELL} -v -s -r 0 -j j1echoboth-21 -R R1 2> err21 21 &&
+	grep stdout:baz out21-0 &&
+	grep stderr:baz err21
+'
+
+test_expect_success HAVE_JQ 'flux-shell: run 1-task echo job (stdout term/{{taskid}} stderr)' '
+        cat j1echoboth \
+            |  $jq ".attributes.system.shell.options.output.stderr.type = \"file\"" \
+            |  $jq ".attributes.system.shell.options.output.stderr.path = \"err22-{{taskid}}\"" \
+            > j1echoboth-22 &&
+	${FLUX_SHELL} -v -s -r 0 -j j1echoboth-22 -R R1 > out22 22 &&
+	grep stdout:baz out22 &&
+	grep stderr:baz err22-0
+'
+
+#
+# 2 task output mustache {{taskid}} tests
+#
+
+test_expect_success HAVE_JQ 'flux-shell: run 2-task echo job ({{taskid}} stdout)' '
+        cat j2echostdout \
+            |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
+            |  $jq ".attributes.system.shell.options.output.stdout.path = \"out23-{{taskid}}\"" \
+            > j2echostdout-23 &&
+	${FLUX_SHELL} -v -s -r 0 -j j2echostdout-23 -R R2 23 &&
+	grep "stdout:foo" out23-0 &&
+	grep "stdout:foo" out23-1
+'
+
+test_expect_success HAVE_JQ 'flux-shell: run 2-task echo job ({{taskid}} stderr)' '
+        cat j2echostderr \
+            |  $jq ".attributes.system.shell.options.output.stderr.type = \"file\"" \
+            |  $jq ".attributes.system.shell.options.output.stderr.path = \"err24-{{taskid}}\"" \
+            > j2echostderr-24 &&
+	${FLUX_SHELL} -v -s -r 0 -j j2echostderr-24 -R R2 24 &&
+	grep "stderr:bar" err24-0 &&
+	grep "stderr:bar" err24-1
+'
+
+test_expect_success HAVE_JQ 'flux-shell: run 2-task echo job (stderr to stdout {{taskid}})' '
+        cat j2echostderr \
+            |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
+            |  $jq ".attributes.system.shell.options.output.stdout.path = \"out25-{{taskid}}\"" \
+            > j2echostderr-25 &&
+	${FLUX_SHELL} -v -s -r 0 -j j2echostderr-25 -R R2 25 &&
+	grep "stderr:bar" out25-0 &&
+	grep "stderr:bar" out25-1
+'
+
+test_expect_success HAVE_JQ 'flux-shell: run 2-task echo job ({{taskid}} stdout & stderr)' '
+        cat j2echoboth \
+            |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
+            |  $jq ".attributes.system.shell.options.output.stdout.path = \"out26-{{taskid}}\"" \
+            |  $jq ".attributes.system.shell.options.output.stderr.type = \"file\"" \
+            |  $jq ".attributes.system.shell.options.output.stderr.path = \"err26-{{taskid}}\"" \
+            > j2echoboth-26 &&
+	${FLUX_SHELL} -v -s -r 0 -j j2echoboth-26 -R R2 26 &&
+	grep "stdout:baz" out26-0 &&
+	grep "stdout:baz" out26-1 &&
+	grep "stderr:baz" err26-0 &&
+	grep "stderr:baz" err26-1
+'
+
+test_expect_success HAVE_JQ 'flux-shell: run 2-task echo job (stdout & stderr to stdout {{taskid}})' '
+        cat j2echoboth \
+            |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
+            |  $jq ".attributes.system.shell.options.output.stdout.path = \"out27-{{taskid}}\"" \
+            > j2echoboth-27 &&
+	${FLUX_SHELL} -v -s -r 0 -j j2echoboth-27 -R R2 27 &&
+	grep stdout:baz out27-0 &&
+	grep stdout:baz out27-1 &&
+	grep stderr:baz out27-0 &&
+	grep stderr:baz out27-1
+'
+
+test_expect_success HAVE_JQ 'flux-shell: run 2-task echo job ({{taskid}} stdout/stderr term)' '
+        cat j2echoboth \
+            |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
+            |  $jq ".attributes.system.shell.options.output.stdout.path = \"out28-{{taskid}}\"" \
+            |  $jq ".attributes.system.shell.options.output.stderr.type = \"term\"" \
+            > j2echoboth-28 &&
+	${FLUX_SHELL} -v -s -r 0 -j j2echoboth-28 -R R2 2> err28 28 &&
+	grep "stdout:baz" out28-0 &&
+	grep "stdout:baz" out28-1 &&
+	grep "0: stderr:baz" err28 &&
+	grep "1: stderr:baz" err28
+'
+
+test_expect_success HAVE_JQ 'flux-shell: run 2-task echo job (stdout term/{{taskid}} stderr)' '
+        cat j2echoboth \
+            |  $jq ".attributes.system.shell.options.output.stderr.type = \"file\"" \
+            |  $jq ".attributes.system.shell.options.output.stderr.path = \"err29-{{taskid}}\"" \
+            > j2echoboth-29 &&
+	${FLUX_SHELL} -v -s -r 0 -j j2echoboth-29 -R R2 > out29 29 &&
+	grep "0: stdout:baz" out29 &&
+	grep "1: stdout:baz" out29 &&
+	grep "stderr:baz" err29-0 &&
+	grep "stderr:baz" err29-1
+'
+
+test_expect_success HAVE_JQ 'flux-shell: run 2-task echo job ({{taskid}} stdout/stderr file)' '
+        cat j2echoboth \
+            |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
+            |  $jq ".attributes.system.shell.options.output.stdout.path = \"out30-{{taskid}}\"" \
+            |  $jq ".attributes.system.shell.options.output.stderr.type = \"file\"" \
+            |  $jq ".attributes.system.shell.options.output.stderr.path = \"err30\"" \
+            |  $jq ".attributes.system.shell.options.output.stderr.label = true" \
+            > j2echoboth-30 &&
+	${FLUX_SHELL} -v -s -r 0 -j j2echoboth-30 -R R2 30 &&
+	grep "stdout:baz" out30-0 &&
+	grep "stdout:baz" out30-1 &&
+	grep "0: stderr:baz" err30 &&
+	grep "1: stderr:baz" err30
+'
+
+test_expect_success HAVE_JQ 'flux-shell: run 2-task echo job (stdout file/{{taskid}} stderr)' '
+        cat j2echoboth \
+            |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
+            |  $jq ".attributes.system.shell.options.output.stdout.path = \"out31\"" \
+            |  $jq ".attributes.system.shell.options.output.stdout.label = true" \
+            |  $jq ".attributes.system.shell.options.output.stderr.type = \"file\"" \
+            |  $jq ".attributes.system.shell.options.output.stderr.path = \"err31-{{taskid}}\"" \
+            > j2echoboth-31 &&
+	${FLUX_SHELL} -v -s -r 0 -j j2echoboth-31 -R R2 31 &&
+	grep "0: stdout:baz" out31 &&
+	grep "1: stdout:baz" out31 &&
+	grep "stderr:baz" err31-0 &&
+	grep "stderr:baz" err31-1
+'
+
+#
+# test both {{id}} and {{taskid}}
+#
+
+test_expect_success HAVE_JQ 'flux-shell: run 1-task echo job (mustache id per-task stdout & stderr)' '
+        cat j1echoboth \
+            |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
+            |  $jq ".attributes.system.shell.options.output.stdout.path = \"out{{id}}-{{taskid}}\"" \
+            |  $jq ".attributes.system.shell.options.output.stderr.type = \"file\"" \
+            |  $jq ".attributes.system.shell.options.output.stderr.path = \"err{{id}}-{{taskid}}\"" \
+            > j1echoboth-32 &&
+	${FLUX_SHELL} -v -s -r 0 -j j1echoboth-32 -R R1 32 &&
+	grep stdout:baz out32-0 &&
+	grep stderr:baz err32-0
+'
+
+test_expect_success HAVE_JQ 'flux-shell: run 1-task echo job (mustache id stdout & stderr to stdout per-task)' '
+        cat j1echoboth \
+            |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
+            |  $jq ".attributes.system.shell.options.output.stdout.path = \"out{{id}}-{{taskid}}\"" \
+            > j1echoboth-33 &&
+	${FLUX_SHELL} -v -s -r 0 -j j1echoboth-33 -R R1 33 &&
+	grep stdout:baz out33-0 &&
+	grep stderr:baz out33-0
+'
+
+#
 # output corner case tests
 #
 
 test_expect_success HAVE_JQ 'flux-shell: error on bad output type' '
         cat j1echostdout \
             |  $jq ".attributes.system.shell.options.output.stdout.type = \"foobar\"" \
-            > j1echostdout-16 &&
-        ! ${FLUX_SHELL} -v -s -r 0 -j j1echostdout-16 -R R1 16
+            > j1echostdout-34 &&
+        ! ${FLUX_SHELL} -v -s -r 0 -j j1echostdout-34 -R R1 34
 '
 
 test_expect_success HAVE_JQ 'flux-shell: error on no path with file output' '
         cat j1echostdout \
             |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
-            > j1echostdout-17 &&
-        ! ${FLUX_SHELL} -v -s -r 0 -j j1echostdout-17 -R R1 17
+            > j1echostdout-35 &&
+        ! ${FLUX_SHELL} -v -s -r 0 -j j1echostdout-35 -R R1 35
 '
 
 test_expect_success HAVE_JQ 'flux-shell: error invalid path to file output' '
         cat j1echostdout \
             |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
             |  $jq ".attributes.system.shell.options.output.stdout.path = \"/foo/bar/baz\"" \
-            > j1echostdout-18 &&
-        ! ${FLUX_SHELL} -v -s -r 0 -j j1echostdout-18 -R R1 18
+            > j1echostdout-36 &&
+        ! ${FLUX_SHELL} -v -s -r 0 -j j1echostdout-36 -R R1 36
+'
+
+test_expect_success HAVE_JQ 'flux-shell: error invalid path to file output ({{taskid}})' '
+        cat j1echostdout \
+            |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
+            |  $jq ".attributes.system.shell.options.output.stdout.path = \"/foo/bar/baz{{taskid}}\"" \
+            > j1echostdout-37 &&
+        ! ${FLUX_SHELL} -v -s -r 0 -j j1echostdout-37 -R R1 37
 '
 
 test_done

--- a/t/t2606-job-shell-output-redirection.t
+++ b/t/t2606-job-shell-output-redirection.t
@@ -154,7 +154,7 @@ test_expect_success 'job-shell: run 2-task echo job (stdout kvs/stderr file)' '
 '
 
 #
-# output file mustache tests
+# mustache {{id}} template tests
 #
 
 test_expect_success 'job-shell: run 1-task echo job (mustache id stdout file/stderr file)' '
@@ -176,96 +176,287 @@ test_expect_success 'flux-shell: run 1-task echo job (mustache id stdout & stder
 '
 
 #
+# 1 task output mustache {{taskid}} tests
+#
+
+test_expect_success 'flux-shell: run 1-task echo job ({{taskid}} stdout)' '
+        flux mini run -n1 \
+             --output="out16-{{taskid}}" \
+             ${TEST_SUBPROCESS_DIR}/test_echo -P -O foo &&
+        grep stdout:foo out16-0
+'
+
+test_expect_success 'flux-shell: run 1-task echo job ({{taskid}} stderr)' '
+        flux mini run -n1 \
+             --error="err17-{{taskid}}" \
+             ${TEST_SUBPROCESS_DIR}/test_echo -P -E bar &&
+        grep stderr:bar err17-0
+'
+
+test_expect_success 'job-shell: run 1-task echo job (stderr to stdout {{taskid}})' '
+        flux mini run -n1 \
+             --output="out18-{{taskid}}" \
+             ${TEST_SUBPROCESS_DIR}/test_echo -P -E bar &&
+        grep "stderr:bar" out18-0
+'
+
+test_expect_success 'flux-shell: run 1-task echo job ({{taskid}} stdout & stderr)' '
+        flux mini run -n1 \
+             --output="out19-{{taskid}}" --error="err19-{{taskid}}" \
+             ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz &&
+        grep stdout:baz out19-0 &&
+        grep stderr:baz err19-0
+'
+
+test_expect_success 'flux-shell: run 1-task echo job (stdout & stderr to stdout {{taskid}})' '
+        flux mini run -n1 \
+             --output="out20-{{taskid}}" \
+             ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz &&
+        grep stdout:baz out20-0 &&
+        grep stderr:baz out20-0
+'
+
+test_expect_success 'flux-shell: run 1-task echo job ({{taskid}} stdout/stderr kvs)' '
+        id=$(flux mini submit -n1 \
+             --output="out21-{{taskid}}" --setopt "output.stderr.type=\"kvs\"" \
+             ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz) &&
+        flux job wait-event $id clean &&
+        flux job attach $id 2> err21 &&
+        grep stdout:baz out21-0 &&
+        grep stderr:baz err21
+'
+
+test_expect_success 'flux-shell: run 1-task echo job (stdout kvs/{{taskid}} stderr)' '
+        id=$(flux mini submit -n1 \
+             --error="err22-{{taskid}}" \
+             ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz) &&
+        flux job wait-event $id clean &&
+        flux job attach $id > out22 &&
+        grep stdout:baz out22 &&
+        grep stderr:baz err22-0
+'
+
+test_expect_success 'flux-shell: run 1-task echo job ({{taskid}} stdout/stderr file)' '
+        flux mini run -n1 \
+             --output="out23-{{taskid}}" --error="err23" \
+             ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz &&
+        grep stdout:baz out23-0 &&
+        grep stderr:baz err23
+'
+
+test_expect_success 'flux-shell: run 1-task echo job (stdout file/{{taskid}} stderr)' '
+        flux mini run -n1 \
+             --output="out24" --error="err24-{{taskid}}" \
+             ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz &&
+        grep stdout:baz out24 &&
+        grep stderr:baz err24-0
+'
+
+#
+# 2 task output mustache {{taskid}} tests
+#
+
+test_expect_success 'flux-shell: run 2-task echo job ({{taskid}} stdout)' '
+        flux mini run -n2 \
+             --output="out25-{{taskid}}" \
+             ${TEST_SUBPROCESS_DIR}/test_echo -P -O foo &&
+        grep "stdout:foo" out25-0 &&
+        grep "stdout:foo" out25-1
+'
+
+test_expect_success 'flux-shell: run 2-task echo job ({{taskid}} stderr)' '
+        flux mini run -n2 \
+             --error="err26-{{taskid}}" \
+             ${TEST_SUBPROCESS_DIR}/test_echo -P -E bar &&
+        grep "stderr:bar" err26-0 &&
+        grep "stderr:bar" err26-1
+'
+
+test_expect_success 'job-shell: run 2-task echo job (stderr to stdout {{taskid}})' '
+        flux mini run -n2 \
+             --output="out27-{{taskid}}" \
+             ${TEST_SUBPROCESS_DIR}/test_echo -P -E bar &&
+        grep "stderr:bar" out27-0 &&
+        grep "stderr:bar" out27-1
+'
+
+test_expect_success 'flux-shell: run 2-task echo job ({{taskid}} stdout & stderr)' '
+        flux mini run -n2 \
+             --output="out28-{{taskid}}" --error="err28-{{taskid}}" \
+             ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz &&
+        grep "stdout:baz" out28-0 &&
+        grep "stdout:baz" out28-1 &&
+        grep "stderr:baz" err28-0 &&
+        grep "stderr:baz" err28-1
+'
+
+test_expect_success 'job-shell: run 2-task echo job (stdout & stderr to stdout {{taskid}})' '
+        flux mini run -n2 \
+             --output="out29-{{taskid}}" \
+             ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz &&
+        grep "stdout:baz" out29-0 &&
+        grep "stdout:baz" out29-1 &&
+        grep "stderr:baz" out29-0 &&
+        grep "stderr:baz" out29-1
+'
+
+test_expect_success 'flux-shell: run 2-task echo job ({{taskid}} stdout/stderr kvs)' '
+        id=$(flux mini submit -n2 \
+             --output="out30-{{taskid}}" --setopt "output.stderr.type=\"kvs\"" \
+             ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz) &&
+        flux job wait-event $id clean &&
+        flux job attach -l $id 2> err30 &&
+        grep "stdout:baz" out30-0 &&
+        grep "stdout:baz" out30-1 &&
+        grep "0: stderr:baz" err30 &&
+        grep "1: stderr:baz" err30
+'
+
+test_expect_success 'flux-shell: run 2-task echo job (stdout kvs/{{taskid}} stderr)' '
+        id=$(flux mini submit -n2 \
+             --error="err31-{{taskid}}" \
+             ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz) &&
+        flux job wait-event $id clean &&
+        flux job attach -l $id > out31 &&
+        grep "0: stdout:baz" out31 &&
+        grep "1: stdout:baz" out31 &&
+        grep "stderr:baz" err31-0 &&
+        grep "stderr:baz" err31-1
+'
+
+test_expect_success 'flux-shell: run 2-task echo job ({{taskid}} stdout/stderr file)' '
+        flux mini run -n2 \
+             --output="out32-{{taskid}}" --error="err32" --label-io \
+             ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz &&
+        grep "stdout:baz" out32-0 &&
+        grep "stdout:baz" out32-1 &&
+        grep "0: stderr:baz" err32 &&
+        grep "1: stderr:baz" err32
+'
+
+test_expect_success 'flux-shell: run 2-task echo job (stdout file/{{taskid}} stderr)' '
+        flux mini run -n2 \
+             --output="out33" --label-io --error="err33-{{taskid}}" \
+             ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz &&
+        grep "0: stdout:baz" out33 &&
+        grep "1: stdout:baz" out33 &&
+        grep "stderr:baz" err33-0 &&
+        grep "stderr:baz" err33-1
+'
+
+#
+# test both {{id}} and {{taskid}}
+#
+
+test_expect_success 'flux-shell: run 1-task echo job ({{taskid}} stdout & stderr)' '
+        id=$(flux mini submit -n1 \
+             --output="out{{id}}-{{taskid}}" --error="err{{id}}-{{taskid}}" \
+             ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz) &&
+        flux job wait-event $id clean &&
+        grep stdout:baz out${id}-0 &&
+        grep stderr:baz err${id}-0
+'
+
+test_expect_success 'flux-shell: run 1-task echo job (stdout & stderr to stdout {{taskid}})' '
+        id=$(flux mini submit -n1 \
+             --output="out{{id}}-{{taskid}}" \
+             ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz) &&
+        flux job wait-event $id clean &&
+        grep stdout:baz out${id}-0 &&
+        grep stderr:baz out${id}-0
+'
+
+#
 # output file outputs correct information to guest.output
 #
 
 test_expect_success 'job-shell: redirect events appear in guest.output (1-task)' '
         id=$(flux mini submit -n1 \
-             --output=out16 --error=err16 \
+             --output=out36 --error=err36 \
              ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz) &&
         flux job wait-event $id clean &&
-        flux job eventlog -p guest.output $id > eventlog16.out &&
-        grep "stdout" eventlog16.out | grep redirect | grep "rank=\"0\"" | grep out16 &&
-        grep "stderr" eventlog16.out | grep redirect | grep "rank=\"0\"" | grep err16
+        flux job eventlog -p guest.output $id > eventlog36.out &&
+        grep "stdout" eventlog36.out | grep redirect | grep "rank=\"0\"" | grep out36 &&
+        grep "stderr" eventlog36.out | grep redirect | grep "rank=\"0\"" | grep err36
 '
 
 test_expect_success 'job-shell: redirect events appear in guest.output (1-task stderr to stdout)' '
         id=$(flux mini submit -n1 \
-             --output=out17 \
+             --output=out37 \
              ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz) &&
         flux job wait-event $id clean &&
-        flux job eventlog -p guest.output $id > eventlog17.out &&
-        grep "stdout" eventlog17.out | grep redirect | grep "rank=\"0\"" | grep out17 &&
-        grep "stderr" eventlog17.out | grep redirect | grep "rank=\"0\"" | grep out17
+        flux job eventlog -p guest.output $id > eventlog37.out &&
+        grep "stdout" eventlog37.out | grep redirect | grep "rank=\"0\"" | grep out37 &&
+        grep "stderr" eventlog37.out | grep redirect | grep "rank=\"0\"" | grep out37
 '
 
 test_expect_success 'job-shell: redirect events appear in guest.output (2-task)' '
         id=$(flux mini submit -n2 \
-             --output=out18 --error=err18 \
+             --output=out38 --error=err38 \
              ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz) &&
         flux job wait-event $id clean &&
-        flux job eventlog -p guest.output $id > eventlog18.out &&
-        grep "stdout" eventlog18.out | grep redirect | grep "0-1" | grep out18 &&
-        grep "stderr" eventlog18.out | grep redirect | grep "0-1" | grep err18
+        flux job eventlog -p guest.output $id > eventlog38.out &&
+        grep "stdout" eventlog38.out | grep redirect | grep "0-1" | grep out38 &&
+        grep "stderr" eventlog38.out | grep redirect | grep "0-1" | grep err38
 '
 
 test_expect_success 'job-shell: redirect events appear in guest.output (2-task stderr to stdout)' '
         id=$(flux mini submit -n2 \
-             --output=out19 \
+             --output=out39 \
              ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz) &&
         flux job wait-event $id clean &&
-        flux job eventlog -p guest.output $id > eventlog19.out &&
-        grep "stdout" eventlog19.out | grep redirect | grep "0-1" | grep out19 &&
-        grep "stderr" eventlog19.out | grep redirect | grep "0-1" | grep out19
+        flux job eventlog -p guest.output $id > eventlog39.out &&
+        grep "stdout" eventlog39.out | grep redirect | grep "0-1" | grep out39 &&
+        grep "stderr" eventlog39.out | grep redirect | grep "0-1" | grep out39
 '
 
 test_expect_success 'job-shell: attach shows redirected file (1-task)' '
         id=$(flux mini submit -n1 \
-             --output=out20 --error=err20 \
+             --output=out40 --error=err40 \
              ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz) &&
         flux job wait-event $id clean &&
-        flux job attach $id 2> attach20.err &&
-        grep "0: stdout redirected to out20" attach20.err &&
-        grep "0: stderr redirected to err20" attach20.err
+        flux job attach $id 2> attach40.err &&
+        grep "0: stdout redirected to out40" attach40.err &&
+        grep "0: stderr redirected to err40" attach40.err
 '
 
 test_expect_success 'job-shell: attach shows redirected file (1-task stderr to stdout)' '
         id=$(flux mini submit -n1 \
-             --output=out21 \
+             --output=out41 \
              ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz) &&
         flux job wait-event $id clean &&
-        flux job attach $id 2> attach21.err &&
-        grep "0: stdout redirected to out21" attach21.err &&
-        grep "0: stderr redirected to out21" attach21.err
+        flux job attach $id 2> attach41.err &&
+        grep "0: stdout redirected to out41" attach41.err &&
+        grep "0: stderr redirected to out41" attach41.err
 '
 
 test_expect_success 'job-shell: attach shows redirected file (2-task)' '
         id=$(flux mini submit -n2 \
-             --output=out22 --error=err22 \
+             --output=out42 --error=err42 \
              ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz) &&
         flux job wait-event $id clean &&
-        flux job attach $id 2> attach22.err &&
-        grep "[[0-1]]: stdout redirected to out22" attach22.err &&
-        grep "[[0-1]]: stderr redirected to err22" attach22.err
+        flux job attach $id 2> attach42.err &&
+        grep "[[0-1]]: stdout redirected to out42" attach42.err &&
+        grep "[[0-1]]: stderr redirected to err42" attach42.err
 '
 
 test_expect_success 'job-shell: attach shows redirected file (2-task stderr to stdout)' '
         id=$(flux mini submit -n2 \
-             --output=out23 \
+             --output=out43 \
              ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz) &&
         flux job wait-event $id clean &&
-        flux job attach $id 2> attach23.err &&
-        grep "[[0-1]]: stdout redirected to out23" attach23.err &&
-        grep "[[0-1]]: stderr redirected to out23" attach23.err
+        flux job attach $id 2> attach43.err &&
+        grep "[[0-1]]: stdout redirected to out43" attach43.err &&
+        grep "[[0-1]]: stderr redirected to out43" attach43.err
 '
 
 test_expect_success 'job-shell: attach --quiet suppresses redirected file (1-task)' '
         id=$(flux mini submit -n1 \
-             --output=out24 --error=err24 \
+             --output=out44 --error=err44 \
              ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz) &&
         flux job wait-event $id clean &&
-        flux job attach -q $id 2> attach24.err &&
-        ! grep "redirected" attach24.err
+        flux job attach -q $id 2> attach44.err &&
+        ! grep "redirected" attach44.err
 '
 
 #
@@ -281,36 +472,36 @@ test_expect_success 'job-shell: attach --quiet suppresses redirected file (1-tas
 
 test_expect_success 'job-shell: job attach exits cleanly if no kvs output (1-task)' '
         id=$(flux mini submit -n1 \
-             --output=out25 --error=err25 \
+             --output=out45 --error=err45 \
              ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz) &&
         flux job wait-event $id clean &&
-        flux job attach -q ${id} > out25.attach 2> err25.attach &&
-        grep stdout:baz out25 &&
-        grep stderr:baz err25 &&
-        ! test -s out25.attach &&
-        sed -i -e "/stdin EOF could not be sent/d" err25.attach &&
-        ! test -s err25.attach
+        flux job attach -q ${id} > out45.attach 2> err45.attach &&
+        grep stdout:baz out45 &&
+        grep stderr:baz err45 &&
+        ! test -s out45.attach &&
+        sed -i -e "/stdin EOF could not be sent/d" err45.attach &&
+        ! test -s err45.attach
 '
 
 test_expect_success 'job-shell: job attach exits cleanly if no kvs output (2-task)' '
         id=$(flux mini submit -n2 \
-             --output=out26 --error=err26 \
+             --output=out46 --error=err46 \
              ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz) &&
         flux job wait-event $id clean &&
-        flux job attach -q ${id} > out26.attach 2> err26.attach &&
-        grep stdout:baz out26 &&
-        grep stderr:baz err26 &&
-        ! test -s out26.attach &&
-        sed -i -e "/stdin EOF could not be sent/d" err26.attach &&
-        ! test -s err26.attach
+        flux job attach -q ${id} > out46.attach 2> err46.attach &&
+        grep stdout:baz out46 &&
+        grep stderr:baz err46 &&
+        ! test -s out46.attach &&
+        sed -i -e "/stdin EOF could not be sent/d" err46.attach &&
+        ! test -s err46.attach
 '
 
 test_expect_success NO_CHAIN_LINT 'job-shell: job attach waits if no kvs output (1-task, live job)' '
         id=$(flux mini submit -n1 \
-             --output=out27 --error=err27 \
+             --output=out47 --error=err47 \
              sleep 60)
         flux job wait-event $id start &&
-        flux job attach -E -X ${id} 2> attach27.err &
+        flux job attach -E -X ${id} 2> attach47.err &
         pid=$! &&
         flux job cancel $id &&
         ! wait $pid
@@ -318,10 +509,10 @@ test_expect_success NO_CHAIN_LINT 'job-shell: job attach waits if no kvs output 
 
 test_expect_success NO_CHAIN_LINT 'job-shell: job attach waits if no kvs output (2-task, live job)' '
         id=$(flux mini submit -n2 \
-             --output=out28 --error=err28 \
+             --output=out48 --error=err48 \
              sleep 60)
         flux job wait-event $id start &&
-        flux job attach -E -X ${id} 2> attach28.err &
+        flux job attach -E -X ${id} 2> attach48.err &
         pid=$! &&
         flux job cancel $id &&
         ! wait $pid

--- a/t/t2606-job-shell-output-redirection.t
+++ b/t/t2606-job-shell-output-redirection.t
@@ -272,6 +272,13 @@ test_expect_success 'job-shell: attach --quiet suppresses redirected file (1-tas
 # output corner case tests
 #
 
+#
+# sharness will redirect /dev/null to stdin by default, leading to the
+# possibility of seeing an EOF warning on stdin.  We'll check for that
+# manually in the next two tests and filter it out from the stderr
+# output.
+#
+
 test_expect_success 'job-shell: job attach exits cleanly if no kvs output (1-task)' '
         id=$(flux mini submit -n1 \
              --output=out25 --error=err25 \
@@ -281,6 +288,7 @@ test_expect_success 'job-shell: job attach exits cleanly if no kvs output (1-tas
         grep stdout:baz out25 &&
         grep stderr:baz err25 &&
         ! test -s out25.attach &&
+        sed -i -e "/stdin EOF could not be sent/d" err25.attach &&
         ! test -s err25.attach
 '
 
@@ -293,6 +301,7 @@ test_expect_success 'job-shell: job attach exits cleanly if no kvs output (2-tas
         grep stdout:baz out26 &&
         grep stderr:baz err26 &&
         ! test -s out26.attach &&
+        sed -i -e "/stdin EOF could not be sent/d" err26.attach &&
         ! test -s err26.attach
 '
 

--- a/t/t2607-job-shell-input.t
+++ b/t/t2607-job-shell-input.t
@@ -1,0 +1,93 @@
+#!/bin/sh
+#
+test_description='Test flux-shell'
+
+. `dirname $0`/sharness.sh
+
+test_under_flux 4 job
+
+flux setattr log-stderr-level 1
+
+TEST_SUBPROCESS_DIR=${FLUX_BUILD_DIR}/src/common/libsubprocess
+LPTEST=${SHARNESS_TEST_DIRECTORY}/shell/lptest
+
+hwloc_fake_config='{"0-3":{"Core":2,"cpuset":"0-1"}}'
+
+test_expect_success 'job-shell: load barrier,job-exec,sched-simple modules' '
+        #  Add fake by_rank configuration to kvs:
+        flux kvs put resource.hwloc.by_rank="$hwloc_fake_config" &&
+        flux module load barrier &&
+        flux module load -r 0 sched-simple &&
+        flux module load -r 0 job-exec
+'
+
+test_expect_success 'flux-shell: generate input for stdin input tests' '
+       echo "foo" > input_stdin_file &&
+       echo "doh" >> input_stdin_file &&
+       ${LPTEST} 79 10000 > lptestXXL_input
+'
+
+#
+# input file tests
+#
+
+test_expect_success 'flux-shell: run 1-task input file as stdin job' '
+        flux mini run -n1 --input=input_stdin_file \
+             ${TEST_SUBPROCESS_DIR}/test_echo -O -n > file0.out &&
+        test_cmp input_stdin_file file0.out
+'
+
+test_expect_success 'flux-shell: run 2-task input file as stdin job' '
+        flux mini run -n2 --input=input_stdin_file --label-io \
+             ${TEST_SUBPROCESS_DIR}/test_echo -O -n > file1.out &&
+        grep "0: foo" file1.out &&
+        grep "0: doh" file1.out &&
+        grep "1: foo" file1.out &&
+        grep "1: doh" file1.out
+'
+
+test_expect_success NO_CHAIN_LINT 'flux-shell: multiple jobs, each want stdin via file' '
+        id1=$(flux mini submit -n1 --input=input_stdin_file \
+              ${TEST_SUBPROCESS_DIR}/test_echo -O -n)
+        id2=$(flux mini submit -n1 --input=input_stdin_file \
+              ${TEST_SUBPROCESS_DIR}/test_echo -O -n)
+        id3=$(flux mini submit -n1 --input=input_stdin_file \
+              ${TEST_SUBPROCESS_DIR}/test_echo -O -n)
+        id4=$(flux mini submit -n1 --input=input_stdin_file \
+              ${TEST_SUBPROCESS_DIR}/test_echo -O -n)
+        flux job attach $id1 > file2_1.out 2> file2_1.err &
+        pid1=$!
+        flux job attach $id2 > file2_2.out 2> file2_2.err &
+        pid2=$!
+        flux job attach $id3 > file2_3.out 2> file2_3.err &
+        pid3=$!
+        flux job attach $id4 > file2_4.out 2> file2_4.err &
+        pid4=$!
+        wait $pid1 &&
+        wait $pid2 &&
+        wait $pid3 &&
+        wait $pid4 &&
+        test_cmp input_stdin_file file2_1.out &&
+        test_cmp input_stdin_file file2_2.out &&
+        test_cmp input_stdin_file file2_3.out &&
+        test_cmp input_stdin_file file2_4.out
+'
+
+test_expect_success LONGTEST 'flux-shell: 10K line lptest input works' '
+        flux mini run -n1 --input=lptestXXL_input \
+             ${TEST_SUBPROCESS_DIR}/test_echo -O -n > file3.out &&
+	test_cmp lptestXXL_input file3.out
+'
+
+test_expect_success 'flux-shell: input file invalid' '
+        test_must_fail flux mini run -n1 --input=/foo/bar/baz \
+             ${TEST_SUBPROCESS_DIR}/test_echo -O -n > file4.out
+'
+
+test_expect_success 'job-shell: unload job-exec & sched-simple modules' '
+        flux module remove -r 0 job-exec &&
+        flux module remove -r 0 sched-simple &&
+        flux module remove barrier
+'
+
+test_done

--- a/t/t2607-job-shell-input.t
+++ b/t/t2607-job-shell-input.t
@@ -74,10 +74,10 @@ test_expect_success NO_CHAIN_LINT 'flux-shell: attach twice, one with data' '
         pid1=$!
         flux job attach $id < input_stdin_file > pipe4B.out 2> pipe4B.err &
         pid2=$!
-        exec 100> stdin4.pipe &&
+        exec 9> stdin4.pipe &&
         wait $pid1 &&
         wait $pid2 &&
-        exec 100>&- &&
+        exec 9>&- &&
         test_cmp input_stdin_file pipe4A.out &&
         test_cmp input_stdin_file pipe4B.out
 '

--- a/t/t2607-job-shell-input.t
+++ b/t/t2607-job-shell-input.t
@@ -28,6 +28,120 @@ test_expect_success 'flux-shell: generate input for stdin input tests' '
 '
 
 #
+# pipe in stdin tests
+#
+
+test_expect_success 'flux-shell: run 1-task no pipe in stdin' '
+        id=$(flux mini submit -n1 echo foo) &&
+        flux job attach $id > pipe0.out &&
+        grep foo pipe0.out
+'
+
+test_expect_success 'flux-shell: run 1-task input file as stdin job' '
+        id=$(flux mini submit -n1 \
+             ${TEST_SUBPROCESS_DIR}/test_echo -O -n) &&
+        flux job attach $id < input_stdin_file > pipe1.out &&
+        test_cmp input_stdin_file pipe1.out
+'
+
+test_expect_success 'flux-shell: run 2-task input file as stdin job' '
+        id=$(flux mini submit -n2 \
+             ${TEST_SUBPROCESS_DIR}/test_echo -O -n) &&
+        flux job attach -l $id < input_stdin_file > pipe2.out &&
+        grep "0: foo" pipe2.out &&
+        grep "0: doh" pipe2.out &&
+        grep "1: foo" pipe2.out &&
+        grep "1: doh" pipe2.out
+'
+
+test_expect_success LONGTEST 'flux-shell: 10K line lptest piped input works' '
+        id=$(flux mini submit -n1 \
+             ${TEST_SUBPROCESS_DIR}/test_echo -O -n) &&
+        flux job attach $id < lptestXXL_input > pipe3.out &&
+	test_cmp lptestXXL_input pipe3.out
+'
+
+#
+# sharness will redirect /dev/null to stdin by default, so we create a named pipe
+# and pipe that in for tests in which we need "no stdin".
+#
+
+test_expect_success NO_CHAIN_LINT 'flux-shell: attach twice, one with data' '
+        mkfifo stdin4.pipe
+        id=$(flux mini submit -n1 \
+             ${TEST_SUBPROCESS_DIR}/test_echo -O -n)
+        flux job attach $id < stdin4.pipe > pipe4A.out 2> pipe4A.err &
+        pid1=$!
+        flux job attach $id < input_stdin_file > pipe4B.out 2> pipe4B.err &
+        pid2=$!
+        exec 100> stdin4.pipe &&
+        wait $pid1 &&
+        wait $pid2 &&
+        exec 100>&- &&
+        test_cmp input_stdin_file pipe4A.out &&
+        test_cmp input_stdin_file pipe4B.out
+'
+
+test_expect_success NO_CHAIN_LINT 'flux-shell: multiple jobs, each want stdin' '
+        id1=$(flux mini submit -n1 \
+              ${TEST_SUBPROCESS_DIR}/test_echo -O -n)
+        id2=$(flux mini submit -n1 \
+              ${TEST_SUBPROCESS_DIR}/test_echo -O -n)
+        id3=$(flux mini submit -n1 \
+              ${TEST_SUBPROCESS_DIR}/test_echo -O -n)
+        id4=$(flux mini submit -n1 \
+              ${TEST_SUBPROCESS_DIR}/test_echo -O -n)
+        flux job attach $id1 < input_stdin_file > pipe5_1.out 2> pipe5_1.err &
+        pid1=$!
+        flux job attach $id2 < input_stdin_file > pipe5_2.out 2> pipe5_2.err &
+        pid2=$!
+        flux job attach $id3 < input_stdin_file > pipe5_3.out 2> pipe5_3.err &
+        pid3=$!
+        flux job attach $id4 < input_stdin_file > pipe5_4.out 2> pipe5_4.err &
+        pid4=$!
+        wait $pid1 &&
+        wait $pid2 &&
+        wait $pid3 &&
+        wait $pid4 &&
+        test_cmp input_stdin_file pipe5_1.out &&
+        test_cmp input_stdin_file pipe5_2.out &&
+        test_cmp input_stdin_file pipe5_3.out &&
+        test_cmp input_stdin_file pipe5_4.out
+'
+
+test_expect_success NO_CHAIN_LINT 'flux-shell: no stdin desired in job' '
+        id=$(flux mini submit -n1 sleep 60)
+        flux job attach $id < input_stdin_file 2> pipe6A.err &
+        pid=$! &&
+        flux job wait-event -p guest.exec.eventlog $id input-ready 2> pipe6B.err &&
+        flux job wait-event -p guest.input -m eof=true $id data 2> pipe6C.err &&
+        flux job cancel $id 2> pipe6D.err &&
+        test_expect_code 143 wait $pid
+'
+
+test_expect_success 'flux-shell: task completed, try to pipe into stdin' '
+        id=$(flux mini submit -n1 echo foo) &&
+        flux job wait-event $id clean 2> pipe7A.err &&
+        test_must_fail flux job attach $id < input_stdin_file 2> pipe7B.err
+'
+
+test_expect_success NO_CHAIN_LINT 'flux-shell: pipe to stdin twice, second fails' '
+        id=$(flux mini submit -n1 sleep 60)
+        flux job attach $id < input_stdin_file 2> pipe8A.err &
+        pid=$!
+        flux job wait-event -p guest.exec.eventlog $id input-ready 2> pipe8B.err &&
+        flux job wait-event -p guest.input -m eof=true $id data 2> pipe8C.err &&
+        test_must_fail flux job attach $id < input_stdin_file 2> pipe8D.err &&
+        flux job cancel $id 2> pipe8E.err &&
+        test_expect_code 143 wait $pid
+'
+
+test_expect_success NO_CHAIN_LINT 'flux-shell: pipe in zero data' '
+        flux mini run -n1 echo < /dev/null &&
+        cat /dev/null | flux mini run -n1 cat
+'
+
+#
 # input file tests
 #
 
@@ -81,7 +195,42 @@ test_expect_success LONGTEST 'flux-shell: 10K line lptest input works' '
 
 test_expect_success 'flux-shell: input file invalid' '
         test_must_fail flux mini run -n1 --input=/foo/bar/baz \
-             ${TEST_SUBPROCESS_DIR}/test_echo -O -n > file4.out
+             ${TEST_SUBPROCESS_DIR}/test_echo -O -n
+'
+
+test_expect_success 'flux-shell: task stdin via file, try to pipe into stdin fails' '
+        id=$(flux mini submit -n1 --input=input_stdin_file sleep 60) &&
+        flux job wait-event $id start &&
+        test_must_fail flux job attach $id < input_stdin_file &&
+        flux job cancel $id
+'
+
+#
+# corner case tests
+#
+
+test_expect_success 'flux-shell: run 1-task input file with service type' '
+        id=$(flux mini submit -n1 \
+             --setopt "input.stdin.type=\"service\"" \
+             ${TEST_SUBPROCESS_DIR}/test_echo -O -n) &&
+        flux job attach $id < input_stdin_file > cc1.out &&
+        test_cmp input_stdin_file cc1.out
+'
+
+test_expect_success 'flux-shell: error on bad input type' '
+        id=$(flux mini submit -n1 \
+             --setopt "input.stdin.type=\"foobar\"" \
+             echo foo) &&
+        flux job wait-event $id clean &&
+        test_must_fail flux job attach $id
+'
+
+test_expect_success 'flux-shell: error on no path with file output' '
+        id=$(flux mini submit -n1 \
+             --label-io --setopt "input.stdin.type=\"file\"" \
+             echo foo) &&
+        flux job wait-event $id clean &&
+        test_must_fail flux job attach $id
 '
 
 test_expect_success 'job-shell: unload job-exec & sched-simple modules' '


### PR DESCRIPTION
This PR is built on PR #2345, #2396, and #2448 :-), sort of the last in the stdin/stdout support line.  After #2448 is merged, perhaps it could be combined into #2396 or perhaps #2345 & #2396 & this could be one PR.  I suppose we'll determine that later.

Nothing too notable to mention about this PR, stdin per-task support is based on a `{{taskid}}` template and uses the `INPUT_FD` option from #2345.