### PR TITLE
[WIP] implement remote job shell

### DIFF
--- a/doc/man1/flux-proxy.adoc
+++ b/doc/man1/flux-proxy.adoc
@@ -12,7 +12,7 @@ flux-proxy - create proxy environment for Flux instance
 
 SYNOPSIS
 --------
-*flux* *proxy* URI [command [args...]]
+*flux* *proxy* [OPTIONS] URI [command [args...]]
 
 
 DESCRIPTION
@@ -28,18 +28,34 @@ The purpose of *flux proxy* is to allow a connection to be reused,
 for example where connection establishment has high latency or
 requires authentication.
 
+Only the user that invoked flux-proxy is allowed to connect
+to the proxy socket, unless otherwise specified (see below).
+
+OPTIONS
+-------
+*-u, --allow-user=UID*::
+Allow one additional user to connect to the proxy socket.
+
+*-c, --chdir=DIR*::
+Change directory to DIR before running the command.
+
+*-e, --setenv=NAME=VAL*::
+Set NAME to VAL in the environment of the command.  If the environment
+variable is already set, its value is changed.  The FLUX_URI environment
+variable cannot be set with this option.
+
 EXAMPLES
 --------
 
 Connect to a job running on the localhost which has a FLUX_URI
-of local:///tmp/flux-123456-abcdef/0 and spawn an interactive
+of local:///tmp/flux-123456-abcdef/0/local and spawn an interactive
 shell:
 
-  $ flux proxy local:///tmp/flux-123456-abcdef/0
+  $ flux proxy local:///tmp/flux-123456-abcdef/0/local
 
 Connect to the same job remotely on host foo.com:
 
-  $ flux proxy ssh://foo.com/tmp/flux-123456-abcdef/0
+  $ flux proxy ssh://foo.com/tmp/flux-123456-abcdef/0/local
 
 
 AUTHOR

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -466,3 +466,4 @@ FSD
 enqueues
 cpus
 gpu
+chdir

--- a/etc/rc1
+++ b/etc/rc1
@@ -19,7 +19,7 @@ flux module load -r 0 userdb ${FLUX_USERDB_OPTIONS}
 flux module load -r all job-ingest
 flux module load -r 0 job-manager
 flux module load -r 0 job-exec
-flux module load -r 0 sched-simple
+flux module load -r 0 sched-simple res=resource.hwloc.by_rank
 
 wait $pids
 

--- a/etc/rc1
+++ b/etc/rc1
@@ -19,9 +19,10 @@ flux module load -r 0 userdb ${FLUX_USERDB_OPTIONS}
 flux module load -r all job-ingest
 flux module load -r 0 job-manager
 flux module load -r 0 job-exec
-flux module load -r 0 sched-simple res=resource.hwloc.by_rank
 
 wait $pids
+flux module load -r 0 sched-simple res=resource.hwloc.by_rank
+
 
 core_dir=$(cd ${0%/*} && pwd -P)
 all_dirs=$core_dir${FLUX_RC_EXTRA:+":$FLUX_RC_EXTRA"}

--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -57,7 +57,8 @@ nodist_flux_SOURCES = \
 dist_fluxcmd_SCRIPTS = \
 	flux-cron \
 	flux-jobspec.py \
-	flux-mini.py
+	flux-mini.py \
+	flux-remote
 
 fluxcmd_PROGRAMS = \
 	flux-aggregate \

--- a/src/cmd/flux-remote
+++ b/src/cmd/flux-remote
@@ -55,12 +55,13 @@ make_local_socket_path() {
 }
 
 # Usage: make_remote_socket_path local_socket
+#  N.B. avoid using $TMPDIR since it may not exist remotely
 make_remote_socket_path() {
-         local local_socket=$1
+    local local_socket=$1
 
     # Embed hostname + local socket path in remote path
     # This somewhat uniquely identifies which socket is being forwarded
-    echo "${TMPDIR:-/tmp}/$(hostname)$(echo ${local_socket} | sed -e 's!/!-!g')"
+    echo "/tmp/$(hostname)$(echo ${local_socket} | sed -e 's!/!-!g')"
 }
 
 

--- a/src/cmd/flux-remote
+++ b/src/cmd/flux-remote
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+##############################################################
+# Copyright 2019 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+##############################################################
+
+#
+# flux-remote - run remote command with forwarded FLUX_URI
+#
+# This command makes use of OpenSSH UNIX domain socket "reverse forwarding".
+# Ensure that your server is configured to allow this, e.g.
+#   AllowStreamLocalForwarding all  # or set to "remote" (more restrictive)
+#   StreamLocalBindUnlink yes
+#
+# The remote command is run under flux-proxy.  This has the following effects:
+# - flux(1) initializes the environment e.g. for flux-shell to operate
+# - flux-proxy changes remote directory to match local directory
+# - (future) flux-proxy --allow USERID permits flux-shell as guest to connect
+# - flux-proxy scales to many connections
+#
+# The OpenSSH server doesn't unlink dead ssh proxy sockets.  We suggest
+# setting the StreamLocalBindUnlink server option which unlinks a proxy socket
+# (connected or not) that is in the way of a new one created by the same user.
+# This recycling of socket names should not pose a problem since:
+# - existing connections are undisturbed when the socket is unlinked
+# - flux-proxy will be the only user of any given ssh proxy socket,
+#   and will open it exactly once
+# - we choose socket names so they are unlikely to conflict
+# - sshd refuses to unlink an existing socket owned by another user
+# An alternative approach would be to add a second ssh command to this script
+# to unlink the socket on exit.
+#
+
+die() {
+    echo "flux-remote: FATAL: $@" >&2
+    exit 1
+}
+
+usage() {
+    echo "Usage: flux-remote hostname command ..." >&2
+    exit 1
+}
+
+# Usage: make_local_socket_path $FLUX_URI
+make_local_socket_path() {
+    local local_uri=$1
+
+    echo $local_uri | sed -e 's!^local://!!'
+}
+
+# Usage: make_remote_socket_path local_socket
+make_remote_socket_path() {
+         local local_socket=$1
+
+    # Embed hostname + local socket path in remote path
+    # This somewhat uniquely identifies which socket is being forwarded
+    echo "${TMPDIR:-/tmp}/$(hostname)$(echo ${local_socket} | sed -e 's!/!-!g')"
+}
+
+
+test $# -lt 2 && usage
+remote_host=$1; shift
+
+test -n "$FLUX_URI" || die "FLUX_URI is not set"
+flux_path=$(which flux)
+
+local_socket=$(make_local_socket_path ${FLUX_URI})
+remote_socket=$(make_remote_socket_path ${local_socket})
+remote_uri="local://${remote_socket}"
+
+opts="--chdir $(pwd)"
+if test -n "${FLUX_KVS_NAMESPACE}"; then
+    opts="${opts} --setenv FLUX_KVS_NAMESPACE=${FLUX_KVS_NAMESPACE}"
+fi
+
+exec ssh -tt \
+        -o ExitOnForwardFailure=yes \
+        -R ${remote_socket}:${local_socket} \
+        ${remote_host} \
+        exec ${flux_path} proxy ${opts} ${remote_uri} "$@"
+
+# vi: ts=4 sw=4 expandtab

--- a/src/modules/job-exec/job-exec.h
+++ b/src/modules/job-exec/job-exec.h
@@ -88,6 +88,16 @@ struct jobinfo {
 void jobinfo_incref (struct jobinfo *job);
 void jobinfo_decref (struct jobinfo *job);
 
+/* Map execution target rank to broker rank.
+ * A foreign target is launched from broker_rank to host.
+ * A native target is launched on broker_rank (host = NULL).
+ * Returns 0 on success, or -1 on json parse error (logs to broker).
+ */
+int jobinfo_lookup_target (struct jobinfo *job,
+                           unsigned int target_rank,
+                           unsigned int *broker_rank,
+                           const char **host);
+
 /* Emit an event to the exec.eventlog */
 int jobinfo_emit_event_pack_nowait (struct jobinfo *job,
                                      const char *name,

--- a/src/modules/sched-simple/rlist.c
+++ b/src/modules/sched-simple/rlist.c
@@ -201,29 +201,24 @@ out:
     return rc;
 }
 
-struct rlist *rlist_from_hwloc_by_rank (const char *by_rank)
+int rlist_add_hwloc_by_rank (struct rlist *rl, const char *by_rank)
 {
-    struct rlist *rl = NULL;
     const char *key = NULL;
     json_t *entry = NULL;
 
     json_t *o = json_loads (by_rank, 0, NULL);
     if (o == NULL)
-        return NULL;
-    if (!(rl = rlist_create ()))
-        goto err;
+        return -1;
 
     json_object_foreach (o, key, entry) {
         if (rlist_append (rl, key, entry) < 0)
             goto err;
     }
     json_decref (o);
-
-    return (rl);
+    return 0;
 err:
     json_decref (o);
-    rlist_destroy (rl);
-    return NULL;
+    return -1;
 }
 
 int rlist_append_rank (struct rlist *rl, unsigned int rank, const char *ids)

--- a/src/modules/sched-simple/rlist.h
+++ b/src/modules/sched-simple/rlist.h
@@ -32,9 +32,9 @@ struct rlist *rlist_create (void);
 /*  Create a copy of rlist rl with all cores available */
 struct rlist *rlist_copy_empty (const struct rlist *rl);
 
-/*  Create an rlist object from resource.hwloc.by_rank JSON input
+/*  Add resources from resource.hwloc.by_rank JSON input
  */
-struct rlist *rlist_from_hwloc_by_rank (const char *by_rank);
+int rlist_add_hwloc_by_rank (struct rlist *rl, const char *by_rank);
 
 /*  Destroy an rlist object */
 void rlist_destroy (struct rlist *rl);

--- a/src/modules/sched-simple/sched.c
+++ b/src/modules/sched-simple/sched.c
@@ -297,7 +297,7 @@ static int simple_sched_init (flux_t *h, struct simple_sched *ss)
     }
     key = zlist_first (ss->res);
     while (key) {
-        if (!(f = flux_kvs_lookup (h, NULL, FLUX_KVS_WAITCREATE, key))
+        if (!(f = flux_kvs_lookup (h, NULL, 0, key))
                || flux_kvs_lookup_get (f, &by_rank) < 0) {
             flux_log_error (h, "flux_kvs_lookup %s", key);
             goto out;

--- a/src/modules/sched-simple/test/rlist.c
+++ b/src/modules/sched-simple/test/rlist.c
@@ -261,10 +261,14 @@ static void test_issue2202 (void)
 {
     char *result = NULL;
     struct rlist *a = NULL;
+    int rc;
 
-    struct rlist *rl = rlist_from_hwloc_by_rank (by_rank_issue2202);
-    ok (rl != NULL, "issue2202: rlist_from_by_rank");
+    struct rlist *rl = rlist_create ();
     if (!rl)
+        BAIL_OUT ("rlist_create failed");
+    rc = rlist_add_hwloc_by_rank (rl, by_rank_issue2202);
+    ok (rc == 0, "issue2202: add_hwloc_by_rank");
+    if (rc < 0)
         BAIL_OUT ("unable to create rlist from by_rank_issue2202");
 
     result = rlist_dumps (rl);
@@ -299,9 +303,12 @@ static void test_issue2202 (void)
 
     /*  Part B:  test with multiple cores per rank, same cpuset size
      */
-    rl = rlist_from_hwloc_by_rank (by_rank_issue2202b);
-    ok (rl != NULL, "issue2202: rlist_from_hwloc_by_rank");
+    rl = rlist_create ();
     if (!rl)
+        BAIL_OUT ("rlist_create failed");
+    rc = rlist_add_hwloc_by_rank (rl, by_rank_issue2202b);
+    ok (rc == 0, "issue2202: rlist_add_hwloc_by_rank");
+    if (rc < 0)
         BAIL_OUT ("unable to create rlist from by_rank_issue2202b");
 
     result = rlist_dumps (rl);
@@ -354,10 +361,14 @@ static void test_issue2473 (void)
     char *result;
     struct rlist *rl;
     struct rlist *a, *a2;
+    int rc;
 
-    rl = rlist_from_hwloc_by_rank (by_rank_issue2473);
-    ok (rl != NULL, "issue2473: add_hwloc_by_rank");
-    if (rl == NULL)
+    rl = rlist_create ();
+    if (!rl)
+        BAIL_OUT ("rlist_create failed");
+    rc = rlist_add_hwloc_by_rank (rl, by_rank_issue2473);
+    ok (rc== 0, "issue2473: add_hwloc_by_rank");
+    if (rc < 0)
         BAIL_OUT ("unable to create rlist from by_rank_issue2473");
 
     ok (rlist_nnodes (rl) == 3,

--- a/src/shell/info.c
+++ b/src/shell/info.c
@@ -165,7 +165,7 @@ struct shell_info *shell_info_create (flux_shell_t *shell)
     struct shell_info *info;
     char *R = NULL;
     char *jobspec = NULL;
-    int broker_rank = shell->broker_rank;
+    int target_rank = shell->target_rank;
 
     if (!(info = calloc (1, sizeof (*info)))) {
         shell_log_errno ("shell_info_create");
@@ -190,8 +190,8 @@ struct shell_info *shell_info_create (flux_shell_t *shell)
                          info->jobspec->task_count);
         goto error;
     }
-    if (rcalc_get_rankinfo (info->rcalc, broker_rank, &info->rankinfo) < 0) {
-        shell_log_error ("error fetching rankinfo for rank %d", broker_rank);
+    if (rcalc_get_rankinfo (info->rcalc, target_rank, &info->rankinfo) < 0) {
+        shell_log_error ("error fetching rankinfo for rank %d", target_rank);
         goto error;
     }
     info->shell_size = rcalc_total_nodes (info->rcalc);

--- a/src/shell/info.h
+++ b/src/shell/info.h
@@ -31,7 +31,7 @@ struct shell_info {
 };
 
 /* Create shell_info.
- * Check for jobspec, R, and broker rank on cmdline or fetch from
+ * Check for jobspec, R, and execution target rank on cmdline or fetch from
  *  job-info service
  */
 struct shell_info *shell_info_create (flux_shell_t *shell);

--- a/src/shell/internal.h
+++ b/src/shell/internal.h
@@ -21,7 +21,7 @@
 
 struct flux_shell {
     flux_jobid_t jobid;
-    int broker_rank;
+    int target_rank;
 
     optparse_t *p;
     flux_t *h;

--- a/t/t1105-proxy.t
+++ b/t/t1105-proxy.t
@@ -30,6 +30,23 @@ test_expect_success 'flux-proxy exits with command return code' '
 	! flux proxy $TEST_URI /bin/false
 '
 
+test_expect_success 'flux-proxy --chdir works' '
+	mkdir tmprundir &&
+	echo "$(pwd)/tmprundir" >chdir.exp &&
+	flux proxy --chdir tmprundir $TEST_URI pwd >chdir.out &&
+	test_cmp chdir.exp chdir.out
+'
+
+test_expect_success 'flux-proxy --setenv works' '
+	cat >printenv.exp <<-EOT &&
+	bar
+	baz
+	EOT
+	flux proxy --setenv TESTAA=bar --setenv TESTBB=baz $TEST_URI \
+				printenv TESTAA TESTBB >printenv.out &&
+	test_cmp printenv.exp printenv.out
+'
+
 test_expect_success 'flux-proxy forwards getattr request' '
 	ATTR_SIZE=$(flux proxy $TEST_URI flux getattr size) &&
 	test "$ATTR_SIZE" = "$SIZE"

--- a/t/t2204-job-info.t
+++ b/t/t2204-job-info.t
@@ -70,9 +70,9 @@ hwloc_fake_config='{"0-3":{"Core":2,"cpuset":"0-1"}}'
 
 test_expect_success 'load job-exec,sched-simple modules' '
         #  Add fake by_rank configuration to kvs:
-        flux kvs put resource.hwloc.by_rank="$hwloc_fake_config" &&
+        flux kvs put resource.fake="$hwloc_fake_config" &&
         flux module load -r all barrier &&
-        flux module load -r 0 sched-simple &&
+        flux module load -r 0 sched-simple res=resource.fake &&
         flux module load -r 0 job-exec
 '
 

--- a/t/t2205-job-info-security.t
+++ b/t/t2205-job-info-security.t
@@ -71,8 +71,8 @@ hwloc_fake_config='{"0-1":{"Core":2,"cpuset":"0-1"}}'
 
 test_expect_success 'load job-exec,sched-simple modules' '
         #  Add fake by_rank configuration to kvs:
-        flux kvs put resource.hwloc.by_rank="$hwloc_fake_config" &&
-        flux module load -r 0 sched-simple &&
+        flux kvs put resource.fake="$hwloc_fake_config" &&
+        flux module load -r 0 sched-simple res=resource.fake &&
         flux module load -r 0 job-exec
 '
 

--- a/t/t2300-sched-simple.t
+++ b/t/t2300-sched-simple.t
@@ -32,11 +32,11 @@ test_expect_success 'sched-simple: generate jobspec for simple test job' '
         flux jobspec srun -n1 hostname >basic.json
 '
 test_expect_success 'sched-simple: load default by_rank' '
-	flux kvs put resource.hwloc.by_rank="$(echo $hwloc_by_rank)" &&
-	flux kvs get resource.hwloc.by_rank
+	flux kvs put resource.default="$(echo $hwloc_by_rank)" &&
+	flux kvs get resource.default
 '
 test_expect_success 'sched-simple: load sched-simple' '
-	flux module load -r 0 sched-simple &&
+	flux module load -r 0 sched-simple res=resource.default &&
 	flux dmesg 2>&1 | grep "ready:.*rank\[0-1\]/core\[0-1\]" &&
 	test "$($query)" = "rank[0-1]/core[0-1]"
 '
@@ -101,7 +101,7 @@ test_expect_success 'sched-simple: cancel all jobs' '
 '
 test_expect_success 'sched-simple: reload in best-fit mode' '
 	flux module remove -r 0 sched-simple &&
-	flux module load -r 0 sched-simple mode=best-fit
+	flux module load -r 0 sched-simple mode=best-fit res=resource.default
 '
 test_expect_success 'sched-simple: submit 5 more jobs' '
 	flux job submit basic.json >job6.id &&
@@ -137,8 +137,8 @@ test_expect_success 'sched-simple: cancel remaining jobs' '
 '
 test_expect_success 'sched-simple: reload in first-fit mode' '
         flux module remove -r 0 sched-simple &&
-	flux kvs put resource.hwloc.by_rank="$(echo $hwloc_by_rank_first_fit)" &&
-        flux module load -r 0 sched-simple mode=first-fit &&
+	flux kvs put resource.ff="$(echo $hwloc_by_rank_first_fit)" &&
+        flux module load -r 0 sched-simple mode=first-fit res=resource.ff &&
 	flux dmesg | grep "ready:.*rank0/core\[0-1\] rank1/core0"
 '
 test_expect_success 'sched-simple: submit 3 more jobs' '
@@ -159,7 +159,7 @@ test_expect_success 'sched-simple: check allocations for running jobs' '
 '
 test_expect_success 'sched-simple: reload with outstanding allocations' '
 	flux module remove -r 0 sched-simple &&
-	flux module load sched-simple &&
+	flux module load -r 0 sched-simple res=resource.ff &&
 	flux dmesg | grep "hello: alloc rank0/core0" &&
 	test "$($query)" = ""
 '

--- a/t/t2301-schedutil-outstanding-requests.t
+++ b/t/t2301-schedutil-outstanding-requests.t
@@ -23,13 +23,13 @@ test_expect_success 'schedutil: alloc/free fail with ENOSYS(38) after unload' '
     ${REQ_AND_UNLOAD} sched-dummy
 '
 
-test_expect_success 'schedutil: load default by_rank' '
-	flux kvs put resource.hwloc.by_rank="$(echo $hwloc_by_rank)" &&
-	flux kvs get resource.hwloc.by_rank
+test_expect_success 'schedutil: load fake by_rank' '
+	flux kvs put resource.fake="$(echo $hwloc_by_rank)" &&
+	flux kvs get resource.fake
 '
 
 test_expect_success 'schedutil: successfully loaded sched-simple' '
-	flux module load -r 0 sched-simple
+	flux module load -r 0 sched-simple res=resource.fake
 '
 
 test_expect_success 'schedutil: set bit to hang alloc/free requests' '

--- a/t/t2400-job-exec-test.t
+++ b/t/t2400-job-exec-test.t
@@ -33,8 +33,8 @@ test_expect_success 'job-exec: generate jobspec for simple test job' '
 '
 test_expect_success 'job-exec: load job-exec,sched-simple modules' '
 	#  Add fake by_rank configuration to kvs:
-	flux kvs put resource.hwloc.by_rank="$hwloc_fake_config" &&
-	flux module load -r 0 sched-simple &&
+	flux kvs put resource.fake="$hwloc_fake_config" &&
+	flux module load -r 0 sched-simple res=resource.fake &&
 	flux module load -r 0 job-exec
 '
 test_expect_success 'job-exec: basic job runs in simulated mode' '

--- a/t/t2401-job-exec-hello.t
+++ b/t/t2401-job-exec-hello.t
@@ -14,8 +14,8 @@ lastevent() { flux job eventlog $1 | awk 'END{print $2}'; }
 
 test_expect_success 'exec hello: load sched-simple module' '
 	#  Add fake by_rank configuration to kvs:
-	flux kvs put resource.hwloc.by_rank="$hwloc_fake_config" &&
-	flux module load -r 0 sched-simple
+	flux kvs put resource.fake="$hwloc_fake_config" &&
+	flux module load -r 0 sched-simple res=resource.fake
 '
 test_expect_success NO_CHAIN_LINT 'exec hello: start exec server-in-a-script' '
 	${execservice} test-exec > server1.log &

--- a/t/t2402-job-exec-dummy.t
+++ b/t/t2402-job-exec-dummy.t
@@ -21,8 +21,8 @@ exec_eventlog() { flux kvs get -r $(job_kvsdir $1).guest.exec.eventlog; }
 
 test_expect_success 'job-exec: load job-exec,sched-simple modules' '
 	#  Add fake by_rank configuration to kvs:
-	flux kvs put resource.hwloc.by_rank="$hwloc_fake_config" &&
-	flux module load -r 0 sched-simple &&
+	flux kvs put resource.fake="$hwloc_fake_config" &&
+	flux module load -r 0 sched-simple res=resource.fake &&
 	flux module load -r 0 job-exec
 '
 test_expect_success 'job-exec: set dummy test job shell' '

--- a/t/t2602-job-shell.t
+++ b/t/t2602-job-shell.t
@@ -18,7 +18,7 @@ test_expect_success 'job-shell: load barrier,job-exec,sched-simple modules' '
         #  Add fake by_rank configuration to kvs:
         flux kvs put resource.hwloc.by_rank="$hwloc_fake_config" &&
         flux module load barrier &&
-        flux module load -r 0 sched-simple &&
+        flux module load -r 0 sched-simple res=resource.hwloc.by_rank &&
         flux module load -r 0 job-exec
 '
 test_expect_success 'job-shell: execute across all ranks' '

--- a/t/t2606-job-shell-output-redirection.t
+++ b/t/t2606-job-shell-output-redirection.t
@@ -14,9 +14,9 @@ hwloc_fake_config='{"0-3":{"Core":2,"cpuset":"0-1"}}'
 
 test_expect_success 'job-shell: load barrier,job-exec,sched-simple modules' '
         #  Add fake by_rank configuration to kvs:
-        flux kvs put resource.hwloc.by_rank="$hwloc_fake_config" &&
+        flux kvs put resource.fake="$hwloc_fake_config" &&
         flux module load barrier &&
-        flux module load -r 0 sched-simple &&
+        flux module load -r 0 sched-simple res=resource.fake &&
         flux module load -r 0 job-exec
 '
 

--- a/t/t2607-job-shell-input.t
+++ b/t/t2607-job-shell-input.t
@@ -15,9 +15,9 @@ hwloc_fake_config='{"0-3":{"Core":2,"cpuset":"0-1"}}'
 
 test_expect_success 'job-shell: load barrier,job-exec,sched-simple modules' '
         #  Add fake by_rank configuration to kvs:
-        flux kvs put resource.hwloc.by_rank="$hwloc_fake_config" &&
+        flux kvs put resource.fake="$hwloc_fake_config" &&
         flux module load barrier &&
-        flux module load -r 0 sched-simple &&
+        flux module load -r 0 sched-simple res=resource.fake &&
         flux module load -r 0 job-exec
 '
 


### PR DESCRIPTION
This is a bit hacky, but it allows a size=1 flux instance to launch jobs on as many compute nodes as you like without running brokers on them.  

**environmental prerequisite**
sshd service must be set up on all compute nodes, configured to allow passwordless remote execution and to enable these options for UNIX domain socket forwarding:
```
AllowStreamLocalForwarding all
StreamLocalBindUnlink yes
```

**flux remote**
The first small step is the addition of a new command (bash script) called `flux-remote`.  In the flux environment, `flux remote hostname cmd` launches `cmd` on `hostname` with FLUX_URI set to forward back to the local broker socket.  So for example you can run something like:
```console
$ ./flux remote spark flux getattr version
0.13.0-71-g14ef8b6c5
```
The remote command is run under `flux-proxy`.  This is convenient, with the addition of some trivial options, for several reasons: 1) it can support access by a different user if shell is launched by the IMP (with `flux-proxy --allow-user UID`); 2) it sets up the Flux environment, allows individual env variables to be tweaked, and changes working directory (`--setenv NAME=VAL` and `--chdir DIR`); and 3) it is more scalable for handling multiple connections that it would be to share the ssh-forwarded socket.

It calls `flux` by fully qualified path, obtained from the "host" environment.  This was handy for testing.

Caveats:
* `flux-remote` runs ssh with `-tt` to force a pty.  It seems signal propagation does not work at all without this (try `ssh host sleep 60`, then ctrl-C the ssh, the sleep lives on).
* It is somewhat slower that launching a shell directly by the broker (by several times)
* No way to test multi-user capability.

**scheduler**
`sched-simple` loads its resources from `resource.hwloc.by_rank`.  I added a module option so that this is now explicit on the command line, and multiple KVS keys can be specified.  This allows additional resources to be loaded using the same representation.

We need to think of the idset key in `by_rank` as "execution target ranks" rather than broker ranks, because there is now a 1:N relationship between a broker a target.  The scheduler doesn't need to know this - it behaves as before, transferring resources to  _R_ referring to the the specific ones numerically as before.

Caveats:  
* "native" resources (e.g. owned by a broker) for now must continue to use the broker rank as the execution target rank
* "foreign" resources must use execution target ranks that do not overlap with the native resources.
* Not a sufficient model to support flux-sched yet

**job-exec**
The exec module needs to know which targets in a job's _R_ are "native" and which are "foreign".  I added an option to the module to specify a KVS key that maps exec targets to launching broker rank and hostname.   An execution target is considered to be native if no mapping is found, or no key is specified.

Native targets are launched as before.  Foreign targets are launched with `flux remote host` pushed in front of the command, and an option to the shell to tell it which exec target it is since the default of using the broker rank doesn't work for foreign resources.

**flux-shell**
The shell registers a service  `shell-<jobid>` on every rank.  For the follower ranks, I changed this to `shell-<jobid>-<shell_rank>` since now we have multiple shells registering on one broker and the service names must be unique.   The code for sending RPCs among shell peers builds the topic string anyway so this could be hidden away from users.

Those RPCs were routed based on using `rcalc` to map shell rank to broker rank.   However, now `rcalc` maps shell rank to the execution target rank (!= broker rank for remote shells).   I was running out of time and didn't devise a way to pass the mapping of target ranks to brokers on to shells.  Instead I assume the broker rank is 0 if the instance is size=1 and that allows a test to be conducted with a size=1 instance.

Caveats
* No mapping of target rank to broker rank for message routing
* Instance size limited to 1 for foreign resources

**Small test**
Laptop named `monstrosity` running size=1 instance, and two other computers `spark` and `sparky`.  Here's my script for configuring resources:
```sh
#!/bin/bash

flux module remove -r 0 sched-simple
flux module remove -r 0 job-exec

flux kvs put \
    resource.test='{"1-2": {"Package": 1, "Core": 2, "PU": 2, "cpuset": "0-1"}}'

flux kvs put \
    resource.targets='{"1":[0,"spark.local"], "2":[0,"sparky.local"]}'

flux module load -r 0 job-exec targets=resource.targets
flux module load -r 0 sched-simple res=resource.hwloc.by_rank res=resource.test
```
Works!
```console
$ flux mini run --label-io -n8 hostname
4: spark
5: spark
6: sparky
7: sparky
2: monstrosity
1: monstrosity
0: monstrosity
3: monstrosity
$ flux mini run --label-io -n8 ../common/libpmi/test_pmi_info
6: 6: size=8 appnum=0 maxes=64:64:1024 kvsname=61029002248192
4: 4: size=8 appnum=0 maxes=64:64:1024 kvsname=61029002248192
5: 5: size=8 appnum=0 maxes=64:64:1024 kvsname=61029002248192
7: 7: size=8 appnum=0 maxes=64:64:1024 kvsname=61029002248192
2: 2: size=8 appnum=0 maxes=64:64:1024 kvsname=61029002248192
1: 1: size=8 appnum=0 maxes=64:64:1024 kvsname=61029002248192
0: 0: size=8 appnum=0 maxes=64:64:1024 kvsname=61029002248192
3: 3: size=8 appnum=0 maxes=64:64:1024 kvsname=61029002248192
$  flux mini run --label-io -n8 ../common/libpmi/test_kvstest
0: 0: put phase: 4.850 msec
0: 0: get phase: 3.336 msec
```
MPI works fine on the laptop, or across the two remote hosts:
```console
$ flux mini run --label-io -n4 ../../t/mpi/hello
0: 0: completed MPI_Init in 0.025s.  There are 4 tasks
0: 0: completed first barrier in 0.000s
0: 0: completed MPI_Finalize in 0.002s
$ flux mini submit -n4 sleep 120
66078826823680
$ flux mini run --label-io -n4 ../../t/mpi/hello
0: 0: completed MPI_Init in 0.018s.  There are 4 tasks
0: 0: completed first barrier in 0.002s
0: 0: completed MPI_Finalize in 0.002s
```
but things go badly if I try to run across all three systems.  I'm not sure what's up with that.
```console
$ flux mini run --label-io -n8 ../../t/mpi/hello
6: Fatal error in PMPI_Barrier: Unknown error class, error stack:
7: Fatal error in PMPI_Barrier: Unknown error class, error stack:
6: PMPI_Barrier(414)...............: MPI_Barrier(MPI_COMM_WORLD) failed
7: PMPI_Barrier(414).......: MPI_Barrier(MPI_COMM_WORLD) failed
6: MPIR_Barrier_impl(321)..........: Failure during collective
7: MPIR_Barrier_impl(321)..: Failure during collective
```