### PR TITLE
asan/lsan: in-progress making asan usable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,16 @@ jobs:
        - DISTCHECK=t
        - PYTHON_VERSION=3.6
        - GITHUB_RELEASES_DEPLOY=t
+    - name: "Ubuntu: gcc-8 address-sanitizer --with-flux-security"
+      stage: test
+      compiler: gcc-8
+      env:
+       - CC=gcc-8
+       - CXX=g++-8
+       - ARGS="--with-flux-security --enable-sanitizer=address"
+       - PRELOAD=/usr/lib/gcc/x86_64-linux-gnu/8/libasan.so
+       - ASAN_OPTIONS=detect_leaks=0 # TODO: fix/suppress tests so we can turn this on
+       - PYTHON_VERSION=3.6
     - name: "Ubuntu: gcc-8 --with-flux-security/caliper, distcheck"
       stage: test
       compiler: gcc-8

--- a/.travis.yml
+++ b/.travis.yml
@@ -167,6 +167,7 @@ after_failure:
  - find . -name test-suite.log | xargs -i sh -c 'printf "===XXX {} XXX===";cat {}'
  - find . -name t[0-9]*.output | xargs -i sh -c 'printf "\033[31mFound {}\033[39m\n";cat {}'
  - find . -name *.broker.log | xargs -i sh -c 'printf "\033[31mFound {}\033[39m\n";cat {}'
+ - find . -name *.asan.* | xargs -i sh -c 'printf "\033[31mFound {}\033[39m\n";cat {}'
  - src/test/backtrace-all.sh
  - grep -q 'configure. exit 1' config.log && cat config.log
 

--- a/config/x_ac_sanitize.m4
+++ b/config/x_ac_sanitize.m4
@@ -17,9 +17,9 @@ AC_DEFUN([X_AC_ENABLE_SANITIZER], [
     AC_MSG_RESULT($san_enabled)
 
     if test "x$san_enabled" = "xaddress" -o "x$san_enabled" = "xthread" ; then 
-        CFLAGS="$CFLAGS -fsanitize=$san_enabled -fno-omit-frame-pointer"
+        CFLAGS="$CFLAGS -fsanitize=$san_enabled -fno-omit-frame-pointer -fsanitize-recover=all"
         LDFLAGS="$LDFLAGS -fsanitize=$san_enabled"
-        AC_MSG_CHECKING([whether CC supports -fsanitizer=$san_enabled])
+        AC_MSG_CHECKING([whether CC supports -fsanitizer=$san_enabled and -fsanitize-recover=all])
             AC_COMPILE_IFELSE([AC_LANG_PROGRAM([])],
             [AC_MSG_RESULT([yes])],
             [AC_MSG_RESULT([no]) 

--- a/src/broker/module.c
+++ b/src/broker/module.c
@@ -358,7 +358,9 @@ static void module_destroy (module_t *p)
     flux_watcher_destroy (p->broker_w);
     zsock_destroy (&p->sock);
 
+#ifndef __SANITIZE_ADDRESS__
     dlclose (p->dso);
+#endif
     zuuid_destroy (&p->uuid);
     free (p->digest);
     free (p->argz);

--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -220,6 +220,7 @@ char *overlay_lspeer_encode (overlay_t *ov)
     }
     if (!(json_str = json_dumps (o, 0)))
         goto nomem;
+    json_decref (o);
     return json_str;
 nomem:
     json_decref (o);

--- a/src/broker/pmiutil.c
+++ b/src/broker/pmiutil.c
@@ -91,6 +91,8 @@ static struct pmi_dso *broker_pmi_dlopen (const char *pmi_library, int debug)
                 log_msg ("dlopen %s", name);
         }
     }
+    liblist_destroy (libs);
+    libs = NULL;
     if (!dso->dso)
         goto error;
     dso->init = dlsym (dso->dso, "PMI_Init");
@@ -112,7 +114,8 @@ static struct pmi_dso *broker_pmi_dlopen (const char *pmi_library, int debug)
     return dso;
 error:
     broker_pmi_dlclose (dso);
-    zlist_destroy (&libs);
+    if (libs)
+        liblist_destroy (libs);
     return NULL;
 }
 

--- a/src/broker/pmiutil.c
+++ b/src/broker/pmiutil.c
@@ -48,8 +48,10 @@ struct pmi_handle {
 static void broker_pmi_dlclose (struct pmi_dso *dso)
 {
     if (dso) {
+#ifndef __SANITIZE_ADDRESS__
         if (dso->dso)
             dlclose (dso->dso);
+#endif
         free (dso);
     }
 }

--- a/src/cmd/builtin/version.c
+++ b/src/cmd/builtin/version.c
@@ -47,7 +47,17 @@ static int cmd_version (optparse_t *p, int ac, char *av[])
 # endif
 #endif
     print_broker_version (p);
-
+    printf ("build-options:\t\t");
+#if __SANITIZE_ADDRESS__
+    printf ("+asan");
+#endif
+#if __SANITIZE_THREAD__
+    printf ("+tsan");
+#endif
+#if HAVE_CALIPER
+    printf ("+caliper");
+#endif
+    printf ("\n");
     return (0);
 }
 

--- a/src/cmd/flux-exec.c
+++ b/src/cmd/flux-exec.c
@@ -450,6 +450,7 @@ int main (int argc, char *argv[])
      */
     idset_destroy (ns);
     free (cwd);
+    flux_cmd_destroy(cmd);
     flux_close (h);
     optparse_destroy (opts);
     log_fini ();

--- a/src/common/libflux-core.map
+++ b/src/common/libflux-core.map
@@ -1,6 +1,7 @@
 { global:
     flux_*;
     JSC_*;
+    __asan*;
     local: *;
 };
 

--- a/src/common/libflux-idset.map
+++ b/src/common/libflux-idset.map
@@ -1,5 +1,6 @@
 { global:
     idset_*;
+    __asan*;
     local: *;
 };
 

--- a/src/common/libflux-optparse.map
+++ b/src/common/libflux-optparse.map
@@ -1,5 +1,6 @@
 { global:
     optparse_*;
+    __asan*;
     local: *;
 };
 

--- a/src/common/libflux-schedutil.map
+++ b/src/common/libflux-schedutil.map
@@ -1,5 +1,6 @@
 { global:
     schedutil_*;
+    __asan*;
     local: *;
 };
 

--- a/src/common/libflux/handle.c
+++ b/src/common/libflux/handle.c
@@ -408,8 +408,10 @@ void flux_handle_destroy (flux_t *h)
             if ((h->flags & FLUX_O_MATCHDEBUG))
                 report_leaked_matchtags (h->tagpool);
             tagpool_destroy (h->tagpool);
+#ifndef __SANITIZE_ADDRESS__
             if (h->dso)
                 dlclose (h->dso);
+#endif
             msglist_destroy (h->queue);
             if (h->pollfd >= 0)
                 (void)close (h->pollfd);

--- a/src/common/libflux/plugin.c
+++ b/src/common/libflux/plugin.c
@@ -108,8 +108,10 @@ void flux_plugin_destroy (flux_plugin_t *p)
         free (p->path);
         free (p->name);
         aux_destroy (&p->aux);
+#ifndef __SANITIZE_ADDRESS__
         if (p->dso)
             dlclose (p->dso);
+#endif
         free (p);
         errno = saved_errno;
     }

--- a/src/common/libioencode/test/ioencode.c
+++ b/src/common/libioencode/test/ioencode.c
@@ -44,8 +44,8 @@ void basic (void)
         "iodecode success");
     ok (!strcmp (stream, "stdout")
         && !strcmp (rank, "1")
-        && !strcmp (data, "foo")
         && len == 3
+        && !strncmp (data, "foo", len)
         && eof == false,
         "iodecode returned correct info");
     free (data);
@@ -57,8 +57,8 @@ void basic (void)
         "iodecode success");
     ok (!strcmp (stream, "stdout")
         && !strcmp (rank, "[0-8]")
-        && !strcmp (data, "bar")
         && len == 3
+        && !strncmp (data, "bar", len)
         && eof == true,
         "iodecode returned correct info");
     free (data);

--- a/src/common/libpmi.map
+++ b/src/common/libpmi.map
@@ -1,6 +1,7 @@
 { global:
     PMI_*;
     flux_pmi_library;
+    __asan*;
     local: *;
 };
 

--- a/src/common/libpmi2.map
+++ b/src/common/libpmi2.map
@@ -1,6 +1,7 @@
 { global:
     PMI2_*;
     flux_pmi_library;
+    __asan*;
     local: *;
 };
 

--- a/src/modules/job-manager/raise.c
+++ b/src/modules/job-manager/raise.c
@@ -114,10 +114,14 @@ void raise_handle_request (flux_t *h,
                              "userid", userid,
                              "note", note ? note : "") < 0)
         goto error;
+    /* NB: job object may be destroyed in event_job_post_pack().
+     * Do not reference the object after this point:
+     */
+    job = NULL;
     if (!(f = flux_event_publish_pack (h, "job-exception",
                                        FLUX_MSGFLAG_PRIVATE,
                                        "{s:I s:s s:i}",
-                                       "id", job->id,
+                                       "id", id,
                                        "type", type,
                                        "severity", severity)))
         goto error;

--- a/src/shell/flux-shell.map
+++ b/src/shell/flux-shell.map
@@ -1,5 +1,6 @@
 { global:
     flux_shell_*;
     flux_plugin_get_shell;
+    __asan*;
   local: *;
 };

--- a/src/test/docker/docker-run-checks.sh
+++ b/src/test/docker/docker-run-checks.sh
@@ -125,6 +125,8 @@ docker run --rm \
     -e TRAVIS \
     -e TAP_DRIVER_QUIET \
     -e PYTHON_VERSION \
+    -e PRELOAD \
+    -e ASAN_OPTIONS \
     --cap-add SYS_PTRACE \
     --tty \
     ${INTERACTIVE:+--interactive} \

--- a/src/test/docker/docker-run-checks.sh
+++ b/src/test/docker/docker-run-checks.sh
@@ -17,8 +17,8 @@ declare -r prog=${0##*/}
 die() { echo -e "$prog: $@"; exit 1; }
 
 #
-declare -r long_opts="help,quiet,interactive,image:,flux-security-version:,jobs:,no-cache,no-home,distcheck,tag:"
-declare -r short_opts="hqIdi:S:j:t:"
+declare -r long_opts="help,quiet,interactive,image:,flux-security-version:,jobs:,no-cache,no-home,distcheck,tag:,build-directory:"
+declare -r short_opts="hqIdi:S:j:t:D:"
 declare -r usage="
 Usage: $prog [OPTIONS] -- [CONFIGURE_ARGS...]\n\
 Build docker image for travis builds, then run tests inside the new\n\
@@ -36,6 +36,7 @@ Options:\n\
  -S, --flux-security-version=N Install flux-security vers N (default=$FLUX_SECURITY_VERSION)\n
  -j, --jobs=N                  Value for make -j (default=$JOBS)\n
  -d, --distcheck               Run 'make distcheck' instead of 'make check'\n\
+ -D, --build-directory=DIRNAME Name of a subdir to build in, will be made\n\
  -I, --interactive             Instead of running travis build, run docker\n\
                                 image with interactive shell.\n\
 "
@@ -61,6 +62,7 @@ while true; do
       -j|--jobs)                   JOBS="$2";                  shift 2 ;;
       -I|--interactive)            INTERACTIVE="/bin/bash";    shift   ;;
       -d|--distcheck)              DISTCHECK=t;                shift   ;;
+      -D|--build-directory)        BUILD_DIR="$2";             shift 2 ;;
       --no-cache)                  NO_CACHE="--no-cache";      shift   ;;
       --no-home)                   MOUNT_HOME_ARGS="";         shift   ;;
       -t|--tag)                    TAG="$2";                   shift 2 ;;
@@ -101,6 +103,7 @@ echo "mounting $TOP as /usr/src"
 
 export JOBS
 export DISTCHECK
+export BUILD_DIR
 export chain_lint
 
 docker run --rm \
@@ -127,6 +130,7 @@ docker run --rm \
     -e PYTHON_VERSION \
     -e PRELOAD \
     -e ASAN_OPTIONS \
+    -e BUILD_DIR \
     --cap-add SYS_PTRACE \
     --tty \
     ${INTERACTIVE:+--interactive} \

--- a/src/test/travis_run.sh
+++ b/src/test/travis_run.sh
@@ -108,6 +108,7 @@ export TEST_MPI=t
 export FLUX_TESTS_LOGFILE=t
 export DISTCHECK_CONFIGURE_FLAGS="${ARGS}"
 
+
 if test "$CPPCHECK" = "t"; then
     sh -x src/test/cppcheck.sh
 fi
@@ -116,7 +117,13 @@ echo "Starting MUNGE"
 sudo /sbin/runuser -u munge /usr/sbin/munged
 
 travis_fold "autogen.sh" "./autogen.sh..." ./autogen.sh
-travis_fold "configure"  "./configure ${ARGS}..." ./configure ${ARGS}
+
+if test -n "$BUILD_DIR" ; then
+  mkdir -p "$BUILD_DIR"
+  cd "$BUILD_DIR"
+fi
+
+travis_fold "configure"  "/usr/src/configure ${ARGS}..." /usr/src/configure ${ARGS}
 travis_fold "make_clean" "make clean..." make clean
 
 echo running: ${MAKECMDS}

--- a/src/test/travis_run.sh
+++ b/src/test/travis_run.sh
@@ -13,6 +13,7 @@
 #  TEST_INSTALL  Run `make check` against installed flux-core
 #  CPPCHECK      Run cppcheck if set to "t"
 #  DISTCHECK     Run `make distcheck` if set
+#  PRELOAD       Set as LD_PRELOAD for make and tests
 #  chain_lint    Run sharness with --chain-lint if chain_lint=t
 #
 #  And, obviously, some crucial variables that configure itself cares about:
@@ -39,7 +40,7 @@ fi
 
 ARGS="$@"
 JOBS=${JOBS:-2}
-MAKECMDS="${MAKE} -j ${JOBS} ${DISTCHECK:+dist}check"
+MAKECMDS="${MAKE} -k -j ${JOBS} ${DISTCHECK:+dist}check"
 
 # Add non-standard path for libfaketime to LD_LIBRARY_PATH:
 export LD_LIBRARY_PATH="/usr/lib/x86_64-linux-gnu/faketime"
@@ -87,6 +88,10 @@ elif test "$TEST_INSTALL" = "t"; then
               FLUX_TEST_INSTALLED_PATH=/usr/bin ${MAKE} -j $JOBS check"
 fi
 
+if test -n "$PRELOAD" ; then
+  MAKECMDS="/usr/bin/env 'LD_PRELOAD=$PRELOAD' ${MAKECMDS}"
+fi
+
 # Travis has limited resources, even though number of processors might
 #  might appear to be large. Limit session size for testing to 5 to avoid
 #  spurious timeouts.
@@ -114,4 +119,5 @@ travis_fold "autogen.sh" "./autogen.sh..." ./autogen.sh
 travis_fold "configure"  "./configure ${ARGS}..." ./configure ${ARGS}
 travis_fold "make_clean" "make clean..." make clean
 
+echo running: ${MAKECMDS}
 eval ${MAKECMDS}

--- a/t/sharness.d/flux-sharness.sh
+++ b/t/sharness.d/flux-sharness.sh
@@ -112,7 +112,11 @@ test_under_flux() {
         valgrind="$valgrind,--leak-resolution=med,--error-exitcode=1"
         valgrind="$valgrind,--suppressions=${VALGRIND_SUPPRESSIONS}"
     fi
-
+    # Extend timeouts when running under AddressSanitizer
+    if test_have_prereq ASAN; then
+        gracetime="-o,-g,10"
+        timeout="-o -Sinit.rc2_timeout=800"
+    fi
     logopts="-o -Slog-filename=${log_file},-Slog-forward-level=7"
     TEST_UNDER_FLUX_ACTIVE=t \
     TERM=${ORIGINAL_TERM} \
@@ -121,6 +125,7 @@ test_under_flux() {
                       ${RC3_PATH+-o -Sbroker.rc3_path=${RC3_PATH}} \
                       ${logopts} \
                       ${timeout} \
+                      ${gracetime} \
                       ${valgrind} \
                      "sh $0 ${flags}"
 }
@@ -161,6 +166,13 @@ test "$chain_lint" = "t" || test_set_prereq NO_CHAIN_LINT
 #  Set LONGTEST prereq
 if test "$TEST_LONG" = "t" || test "$LONGTEST" = "t"; then
     test_set_prereq LONGTEST
+fi
+
+#  Set ASAN or NO_ASAN prereq
+if flux version | grep -q +asan; then
+    test_set_prereq ASAN
+else
+    test_set_prereq NO_ASAN
 fi
 
 

--- a/t/sharness.d/flux-sharness.sh
+++ b/t/sharness.d/flux-sharness.sh
@@ -116,6 +116,8 @@ test_under_flux() {
     if test_have_prereq ASAN; then
         gracetime="-o,-g,10"
         timeout="-o -Sinit.rc2_timeout=800"
+        # Set log_path for ASan o/w errors from broker may be lost
+        ASAN_OPTIONS=${ASAN_OPTIONS}:log_path=${TEST_NAME}.asan
     fi
     logopts="-o -Slog-filename=${log_file},-Slog-forward-level=7"
     TEST_UNDER_FLUX_ACTIVE=t \

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -133,7 +133,8 @@ test_expect_success 'flux-start dies gracefully when run from removed dir' '
 '
 
 
-test_expect_success 'test_under_flux works' '
+# too slow under ASAN
+test_expect_success NO_ASAN 'test_under_flux works' '
 	echo >&2 "$(pwd)" &&
         mkdir -p test-under-flux && (
         cd test-under-flux &&

--- a/t/t0005-exec.t
+++ b/t/t0005-exec.t
@@ -108,13 +108,13 @@ test_expect_success 'flux exec exits with code 126 for non executable' '
 test_expect_success 'flux exec exits with code 68 (EX_NOHOST) for rank not found' '
 	test_expect_code 68 run_timeout 2 flux exec -n -r 1000 ./nosuchprocess
 '
-test_expect_success 'flux exec passes non-zero exit status' '
+test_expect_success NO_ASAN 'flux exec passes non-zero exit status' '
 	test_expect_code 2 flux exec -n sh -c "exit 2" &&
 	test_expect_code 3 flux exec -n sh -c "exit 3" &&
 	test_expect_code 139 flux exec -n sh -c "kill -11 \$\$"
 '
 
-test_expect_success 'flux exec outputs tasks with errors' '
+test_expect_success NO_ASAN 'flux exec outputs tasks with errors' '
 	! flux exec -n sh -c "exit 2" > 2.out 2>&1 &&
         grep "\[0-3\]: Exit 2" 2.out &&
 	! flux exec -n sh -c "exit 3" > 3.out 2>&1 &&

--- a/t/t0016-cron-faketime.t
+++ b/t/t0016-cron-faketime.t
@@ -3,6 +3,10 @@
 test_description='Test flux cron service'
 
 . $(dirname $0)/sharness.sh
+if ! test_have_prereq NO_ASAN; then
+    skip_all='skipping faketime tests since AddressSanitizer is active'
+    test_done
+fi
 
 #  Check for libfaketimeMT using known epoch with /bin/date:
 t=$(LD_PRELOAD=libfaketimeMT.so.1 FAKETIME="1973-11-29 21:33:09 UTC" date +%s)

--- a/t/t1003-kvs-stress.t
+++ b/t/t1003-kvs-stress.t
@@ -5,6 +5,12 @@ test_description='Stress test KVS in flux session'
 
 . `dirname $0`/sharness.sh
 
+# kvs-stress takes too long with ASAN
+if ! test_have_prereq NO_ASAN; then
+    skip_all='skipping kvs-stress tests since AddressSanitizer is active'
+    test_done
+fi
+
 # Size the session to one more than the number of cores, minimum of 4
 SIZE=$(test_size_large)
 test_under_flux ${SIZE} kvs

--- a/t/t2700-mini-cmd.t
+++ b/t/t2700-mini-cmd.t
@@ -175,9 +175,11 @@ test_expect_success 'flux mini submit --gpus-per-task adds gpus to task slot' '
 '
 test_expect_success 'flux mini --jobname works' '
 	jobid=$(flux mini submit hostname) &&
-        flux job list --pending --running --inactive | grep $jobid | grep hostname &&
+	flux job wait-event $jobid submit &&
+	flux job list --pending --running --inactive | grep $jobid | grep hostname &&
 	jobid=$(flux mini submit --job-name=foobar hostname) &&
-        flux job list --pending --running --inactive | grep $jobid | grep foobar
+	flux job wait-event $jobid submit &&
+	flux job list --pending --running --inactive | grep $jobid | grep foobar
 '
 
 

--- a/t/t3001-mpi-personalities.t
+++ b/t/t3001-mpi-personalities.t
@@ -51,7 +51,7 @@ test_expect_success "intel mpi only rewrites when necessary" '
    test "$(wc -l intel-mpi.unset | cut -f 1 -d " ")" = "0"
 '
 
-test_expect_success HAVE_JQ "spectrum mpi only enabled with option" '
+test_expect_success NO_ASAN,HAVE_JQ "spectrum mpi only enabled with option" '
   LD_PRELOAD_saved=${LD_PRELOAD} &&
   unset LD_PRELOAD &&
   test_when_finished "export LD_PRELOAD=${LD_PRELOAD_saved}" &&

--- a/t/t5000-valgrind.t
+++ b/t/t5000-valgrind.t
@@ -10,6 +10,10 @@ if ! which valgrind >/dev/null; then
     skip_all='skipping valgrind tests since no valgrind executable found'
     test_done
 fi
+if ! test_have_prereq NO_ASAN; then
+    skip_all='skipping valgrind tests since AddressSanitizer is active'
+    test_done
+fi
 
 # Do not run test by default unless valgrind/valgrind.h was found, since
 #  this has been known to introduce false positives (#1097). However, allow


### PR DESCRIPTION
This is in progress, but showing some general promise.  I am slightly ashamed to admit I don't know how to manipulate M4 well enough to add the check for the new flag to the sanitizer file, but this is the configure line I'm using for testing:

`../configure --prefix=/usr/local --enable-sanitizer=address CC=gcc CXX=g++ CFLAGS='-Og -g -fsanitize-recover=address' LDFLAGS='-fsanitize-recover=address'`

The significant thing is that asan can recover and continue when built with the recover flag as above.  Tests run with ASAN_OPTIONS=detect_leaks=0 for now almost all *run* (not necessarily *pass* mind you, but *run* at least).  There is one significant exception that I'm really perplexed by.  @grondo and I have passed some messages back and forth on this, but the jist of it is that when built this way **and run under sharness** sometimes the rc2_timeout and shutdown-grace timers do not fire in t0001_basic.t.   All of the individual tests in there seem to run when run directly, but when run under sharness that test hangs somewhere between test 8 and test 16, every single time.  It's non-deterministic, which worries me, but all I can say for sure is that the rc2 timer always gets set, but sometimes never actually executes.  I've tried adding a repeat time to it, and prints in a few places to try and track it down but nothing seems to be certain.

One thing I am sure of though is that in at least some cases it's hanging in fdwalk trying to get opendir on /proc/self/fd to open, inside of malloc under libc.  This is really peculiar but it's the next thing I plan to dig into, the test that exercises this is really simple too:

`ASAN_OPTIONS=detect_leaks=0 ./src/cmd/flux env ./src/broker/.libs/flux-broker -Sbroker.rc1_path= -Sbroker.rc3_path= -Sboot.method=pmi /bin/true`