### PR TITLE
fix crash in is_intree() with EACCESS or ENOENT from builddir

### DIFF
--- a/src/common/libutil/intree.c
+++ b/src/common/libutil/intree.c
@@ -75,11 +75,12 @@ static int is_intree (void)
      *  If realpath(3) returns ENOENT, then BINDIR doesn't exist and flux
      *   clearly can't be from the installed path:
      */
-    if (!(builddir = realpath (ABS_TOP_BUILDDIR, NULL))
-       && (errno != ENOENT)
-       && (errno != EACCES))
-        ret = -1;
-    else if (strncmp (builddir, selfdir, strlen (builddir)) == 0)
+    if (!(builddir = realpath (ABS_TOP_BUILDDIR, NULL))) {
+        if ((errno == ENOENT) || (errno == EACCES))
+            return 0;
+        return -1;
+    }
+    if (strncmp (builddir, selfdir, strlen (builddir)) == 0)
         ret = 1;
     free (builddir);
     return ret;


### PR DESCRIPTION
A really dumb error in `is_intree()` caused the crash reported in #2467.

A NULL returned from `realpath(3)` should cause the function to return either `-1` or `0`, but in the case of `EACCES` or `ENOENT`, the function dropped through and called `strlen` on `NULL` value anyway. :roll_eyes: 

Sorry about that!

(I'm trying to think of a way to test this in the unit tests, but nothing simple comes to mind at the moment) 