### PR TITLE
job-info: Store full job-history, allow users to query pending, running, and inactive jobs

### DIFF
--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -69,6 +69,19 @@ static struct optparse_option list_opts[] =  {
     { .name = "suppress-header", .key = 's', .has_arg = 0,
       .usage = "Suppress printing of header line",
     },
+    { .name = "pending", .key = 'p', .has_arg = 0,
+      .usage = "List pending jobs",
+    },
+    { .name = "running", .key = 'r', .has_arg = 0,
+      .usage = "List running jobs",
+    },
+    { .name = "inactive", .key = 'i', .has_arg = 0,
+      .usage = "List inactive jobs",
+    },
+    { .name = "userid", .key = 'u', .has_arg = 1, .arginfo = "UID",
+      .usage = "Limit output to specific userid. " \
+               "Specify \"all\" for all users.",
+    },
     OPTPARSE_TABLE_END
 };
 
@@ -602,6 +615,9 @@ int cmd_list (optparse_t *p, int argc, char **argv)
     json_t *jobs;
     size_t index;
     json_t *value;
+    uint32_t userid = geteuid ();
+    const char *userid_str;
+    int flags = 0;
 
     if (optindex != argc) {
         optparse_print_usage (p);
@@ -610,7 +626,30 @@ int cmd_list (optparse_t *p, int argc, char **argv)
     if (!(h = flux_open (NULL, 0)))
         log_err_exit ("flux_open");
 
-    if (!(f = flux_job_list (h, max_entries, attrs, FLUX_USERID_UNKNOWN, 0)))
+    if (optparse_hasopt (p, "pending"))
+        flags |= FLUX_JOB_LIST_PENDING;
+    if (optparse_hasopt (p, "running"))
+        flags |= FLUX_JOB_LIST_RUNNING;
+    if (optparse_hasopt (p, "inactive"))
+        flags |= FLUX_JOB_LIST_INACTIVE;
+    /* if no job listing specifics listed, default to listing pending
+     * & running jobs */
+    if (!flags)
+        flags = FLUX_JOB_LIST_PENDING | FLUX_JOB_LIST_RUNNING;
+
+    if ((userid_str = optparse_get_str (p, "userid", NULL))) {
+        if (!strcmp (userid_str, "all"))
+            userid = FLUX_USERID_UNKNOWN;
+        else {
+            char *endptr;
+            errno = 0;
+            userid = strtoul (userid_str, &endptr, 10);
+            if (errno != 0 || (*endptr) != '\0')
+                log_msg_exit ("error parsing userid: \"%s\"", userid_str);
+        }
+    }
+
+    if (!(f = flux_job_list (h, max_entries, attrs, userid, flags)))
         log_err_exit ("flux_job_list");
     if (flux_rpc_get_unpack (f, "{s:o}", "jobs", &jobs) < 0)
         log_err_exit ("flux_job_list");

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -596,7 +596,7 @@ int cmd_list (optparse_t *p, int argc, char **argv)
 {
     int optindex = optparse_option_index (p);
     int max_entries = optparse_get_int (p, "count", 0);
-    char *attrs = "[\"id\",\"userid\",\"priority\",\"t_submit\",\"state\"]";
+    char *attrs = "[\"userid\",\"priority\",\"t_submit\",\"state\"]";
     flux_t *h;
     flux_future_t *f;
     json_t *jobs;
@@ -610,7 +610,7 @@ int cmd_list (optparse_t *p, int argc, char **argv)
     if (!(h = flux_open (NULL, 0)))
         log_err_exit ("flux_open");
 
-    if (!(f = flux_job_list (h, max_entries, attrs)))
+    if (!(f = flux_job_list (h, max_entries, attrs, FLUX_USERID_UNKNOWN, 0)))
         log_err_exit ("flux_job_list");
     if (flux_rpc_get_unpack (f, "{s:o}", "jobs", &jobs) < 0)
         log_err_exit ("flux_job_list");

--- a/src/common/libjob/job.h
+++ b/src/common/libjob/job.h
@@ -67,11 +67,11 @@ flux_future_t *flux_job_submit (flux_t *h, const char *jobspec,
  */
 int flux_job_submit_get_id (flux_future_t *f, flux_jobid_t *id);
 
-/* Request a list of active jobs.
+/* Request a list of jobs.
  * If 'max_entries' > 0, fetch at most that many jobs.
  * 'json_str' is an encoded JSON array of attribute strings, e.g.
  * ["id","userid",...] that will be returned in response.
-
+ *
  * Process the response payload with flux_rpc_get() or flux_rpc_get_unpack().
  * It is a JSON object containing an array of job objects, e.g.
  * { "jobs":[
@@ -79,9 +79,16 @@ int flux_job_submit_get_id (flux_future_t *f, flux_jobid_t *id);
  *   {"id":m, "userid":n},
  *   ...
  * ])
+ *
+ * flags can be set to an OR of FLUX_JOB_LIST_PENDING,
+ * FLUX_JOB_LIST_RUNNING, and FLUX_JOB_LIST_INACTIVE, or to
+ * FLUX_JOB_LIST_ALL to list all groups of jobs.
  */
-flux_future_t *flux_job_list (flux_t *h, int max_entries,
-                              const char *json_str);
+flux_future_t *flux_job_list (flux_t *h,
+                              int max_entries,
+                              const char *json_str,
+                              uint32_t userid,
+                              int flags);
 
 /* Raise an exception for job.
  * Severity is 0-7, with severity=0 causing the job to abort.

--- a/src/common/libjob/job.h
+++ b/src/common/libjob/job.h
@@ -24,6 +24,13 @@ enum job_submit_flags {
     FLUX_JOB_DEBUG = 2,
 };
 
+enum job_list_flags {
+    FLUX_JOB_LIST_ALL = 0,
+    FLUX_JOB_LIST_PENDING = 1,
+    FLUX_JOB_LIST_RUNNING = 2,
+    FLUX_JOB_LIST_INACTIVE = 4,
+};
+
 enum job_priority {
     FLUX_JOB_PRIORITY_MIN = 0,
     FLUX_JOB_PRIORITY_DEFAULT = 16,

--- a/src/common/libjob/test/job.c
+++ b/src/common/libjob/test/job.c
@@ -115,24 +115,28 @@ void check_corner_case (void)
     /* flux_job_list */
 
     errno = 0;
-    ok (flux_job_list (NULL, 0, "{}") == NULL && errno == EINVAL,
+    ok (flux_job_list (NULL, 0, "{}", 0, 0) == NULL && errno == EINVAL,
         "flux_job_list h=NULL fails with EINVAL");
 
     errno = 0;
-    ok (flux_job_list (h, -1, "{}") == NULL && errno == EINVAL,
+    ok (flux_job_list (h, -1, "{}", 0, 0) == NULL && errno == EINVAL,
         "flux_job_list max_entries=-1 fails with EINVAL");
 
     errno = 0;
-    ok (flux_job_list (h, 0, NULL) == NULL && errno == EINVAL,
+    ok (flux_job_list (h, 0, NULL, 0, 0) == NULL && errno == EINVAL,
         "flux_job_list json_str=NULL fails with EINVAL");
 
     errno = 0;
-    ok (flux_job_list (h, 0, NULL) == NULL && errno == EINVAL,
+    ok (flux_job_list (h, 0, NULL, 0, 0) == NULL && errno == EINVAL,
         "flux_job_list json_str=NULL fails with EINVAL");
 
     errno = 0;
-    ok (flux_job_list (h, 0, "wrong") == NULL && errno == EINVAL,
+    ok (flux_job_list (h, 0, "wrong", 0, 0) == NULL && errno == EINVAL,
         "flux_job_list json_str=(inval JSON) fails with EINVAL");
+
+    errno = 0;
+    ok (flux_job_list (h, 0, "{}", 0, 0xFF) == NULL && errno == EINVAL,
+        "flux_job_list flags != 0 fails with EINVAL");
 
     /* flux_job_raise */
 

--- a/src/modules/job-info/Makefile.am
+++ b/src/modules/job-info/Makefile.am
@@ -18,6 +18,8 @@ job_info_la_SOURCES = \
 	info.h \
 	allow.h \
 	allow.c \
+	job_state.h \
+	job_state.c \
 	lookup.h \
 	lookup.c \
 	watch.h \

--- a/src/modules/job-info/Makefile.am
+++ b/src/modules/job-info/Makefile.am
@@ -20,6 +20,8 @@ job_info_la_SOURCES = \
 	allow.c \
 	job_state.h \
 	job_state.c \
+	list.h \
+	list.c \
 	lookup.h \
 	lookup.c \
 	watch.h \

--- a/src/modules/job-info/info.h
+++ b/src/modules/job-info/info.h
@@ -14,12 +14,15 @@
 #include <flux/core.h>
 #include <czmq.h>
 
+#include "job_state.h"
+
 struct info_ctx {
     flux_t *h;
     flux_msg_handler_t **handlers;
     zlist_t *lookups;
     zlist_t *watchers;
     zlist_t *guest_watchers;
+    struct job_state_ctx *jsctx;
 };
 
 #endif /* _FLUX_JOB_INFO_INFO_H */

--- a/src/modules/job-info/job-info.c
+++ b/src/modules/job-info/job-info.c
@@ -17,6 +17,7 @@
 #include "info.h"
 #include "allow.h"
 #include "job_state.h"
+#include "list.h"
 #include "lookup.h"
 #include "watch.h"
 #include "guest_watch.h"
@@ -86,6 +87,11 @@ static const struct flux_msg_handler_spec htab[] = {
     { .typemask     = FLUX_MSGTYPE_REQUEST,
       .topic_glob   = "job-info.guest-eventlog-watch-cancel",
       .cb           = guest_watch_cancel_cb,
+      .rolemask     = FLUX_ROLE_USER
+    },
+    { .typemask     = FLUX_MSGTYPE_REQUEST,
+      .topic_glob   = "job-info.list",
+      .cb           = list_cb,
       .rolemask     = FLUX_ROLE_USER
     },
     { .typemask     = FLUX_MSGTYPE_REQUEST,

--- a/src/modules/job-info/job-info.c
+++ b/src/modules/job-info/job-info.c
@@ -48,11 +48,17 @@ static void stats_cb (flux_t *h, flux_msg_handler_t *mh,
     int lookups = zlist_size (ctx->lookups);
     int watchers = zlist_size (ctx->watchers);
     int guest_watchers = zlist_size (ctx->guest_watchers);
-
-    if (flux_respond_pack (h, msg, "{s:i s:i s:i}",
+    int pending = zlistx_size (ctx->jsctx->pending);
+    int running = zlistx_size (ctx->jsctx->running);
+    int inactive = zlistx_size (ctx->jsctx->inactive);
+    if (flux_respond_pack (h, msg, "{s:i s:i s:i s:{s:i s:i s:i}}",
                            "lookups", lookups,
                            "watchers", watchers,
-                           "guest_watchers", guest_watchers) < 0) {
+                           "guest_watchers", guest_watchers,
+                           "jobs",
+                           "pending", pending,
+                           "running", running,
+                           "inactive", inactive) < 0) {
         flux_log_error (h, "%s: flux_respond_pack", __FUNCTION__);
         goto error;
     }

--- a/src/modules/job-info/job-info.c
+++ b/src/modules/job-info/job-info.c
@@ -101,6 +101,11 @@ static const struct flux_msg_handler_spec htab[] = {
       .rolemask     = FLUX_ROLE_USER
     },
     { .typemask     = FLUX_MSGTYPE_REQUEST,
+      .topic_glob   = "job-info.list-attrs",
+      .cb           = list_attrs_cb,
+      .rolemask     = FLUX_ROLE_USER
+    },
+    { .typemask     = FLUX_MSGTYPE_REQUEST,
       .topic_glob   = "job-info.disconnect",
       .cb           = disconnect_cb,
       .rolemask     = 0

--- a/src/modules/job-info/job_state.c
+++ b/src/modules/job-info/job_state.c
@@ -1,0 +1,482 @@
+/************************************************************\
+ * Copyright 2018 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* job_state.c - store information on state of jobs */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <czmq.h>
+#include <jansson.h>
+#include <flux/core.h>
+
+#include "src/common/libeventlog/eventlog.h"
+
+#include "job_state.h"
+
+/* To handle the common case of user queries on job state, we will
+ * store jobs in three different lists.
+ *
+ * - pending - these are jobs that have not yet in the RUN state, they
+ *   are sorted based on job priority, then job submission time.  -
+ * - running - these are jobs that have transitioned to the RUN state.
+ *   They are sorted by initial run start time.
+ * - inactive - these are jobs that are in the INACTIVE state, they
+ *   are sorted by job completion time.
+ *
+ * There is also an additional list `processing` that stores jobs that
+ * cannot yet be stored on one of the lists above.
+ *
+ * The list `futures` is used to store in process futures.
+ */
+
+struct job_state_ctx {
+    flux_t *h;
+    zhashx_t *index;
+    zlistx_t *pending;
+    zlistx_t *running;
+    zlistx_t *inactive;
+    zlistx_t *processing;
+    zlist_t *futures;
+};
+
+#define NUMCMP(a,b) ((a)==(b)?0:((a)<(b)?-1:1))
+
+/* Hash numerical jobid in 'key'.
+ * N.B. zhashx_hash_fn signature
+ */
+static size_t job_hasher (const void *key)
+{
+    const flux_jobid_t *id = key;
+    return *id;
+}
+
+/* Compare hash keys.
+ * N.B. zhashx_comparator_fn signature
+ */
+static int job_hash_key_cmp (const void *key1, const void *key2)
+{
+    const flux_jobid_t *id1 = key1;
+    const flux_jobid_t *id2 = key2;
+
+    return NUMCMP (*id1, *id2);
+}
+
+/* Compare items for sorting in list.
+ * N.B. zlistx_comparator_fn signature
+ */
+static int job_list_cmp (const void *a1, const void *a2)
+{
+    const struct job *j1 = a1;
+    const struct job *j2 = a2;
+    int rc;
+
+    if ((rc = (-1)*NUMCMP (j1->priority, j2->priority)) == 0)
+        rc = NUMCMP (j1->t_submit, j2->t_submit);
+    return rc;
+}
+
+static void job_destroy (void *data)
+{
+    struct job *job = data;
+    if (job)
+        free (job);
+}
+
+static void job_destroy_wrapper (void **data)
+{
+    struct job **job = (struct job **)data;
+    job_destroy (*job);
+}
+
+static struct job *job_create (struct info_ctx *ctx, flux_jobid_t id)
+{
+    struct job *job = NULL;
+
+    if (!(job = calloc (1, sizeof (*job))))
+        return NULL;
+    job->ctx = ctx;
+    job->id = id;
+    return job;
+}
+
+struct job_state_ctx *job_state_create (flux_t *h)
+{
+    struct job_state_ctx *jsctx = NULL;
+    int saved_errno;
+
+    if (!(jsctx = calloc (1, sizeof (*jsctx)))) {
+        flux_log_error (h, "calloc");
+        return NULL;
+    }
+    jsctx->h = h;
+
+    /* Index is the primary data structure holding the job data
+     * structures.  It is responsible for destruction.  Lists only
+     * contain desired sort of jobs.
+     */
+
+    if (!(jsctx->index = zhashx_new ()))
+        goto error;
+    zhashx_set_destructor (jsctx->index, job_destroy_wrapper);
+    zhashx_set_key_hasher (jsctx->index, job_hasher);
+    zhashx_set_key_comparator (jsctx->index, job_hash_key_cmp);
+    zhashx_set_key_duplicator (jsctx->index, NULL);
+    zhashx_set_key_destructor (jsctx->index, NULL);
+
+    if (!(jsctx->pending = zlistx_new ()))
+        goto error;
+    zlistx_set_comparator (jsctx->pending, job_list_cmp);
+
+    if (!(jsctx->running = zlistx_new ()))
+        goto error;
+
+    if (!(jsctx->inactive = zlistx_new ()))
+        goto error;
+
+    if (!(jsctx->processing = zlistx_new ()))
+        goto error;
+
+    if (!(jsctx->futures = zlistx_new ()))
+        goto error;
+
+    if (flux_event_subscribe (h, "job-state") < 0) {
+        flux_log_error (h, "flux_event_subscribe");
+        goto error;
+    }
+
+    return jsctx;
+
+error:
+    saved_errno = errno;
+    job_state_destroy (jsctx);
+    errno = saved_errno;
+    return NULL;
+}
+
+void job_state_destroy (void *data)
+{
+    struct job_state_ctx *jsctx = data;
+    if (jsctx) {
+        /* Don't destroy processing until futures are complete */
+        if (jsctx->futures) {
+            flux_future_t *f;
+            f = zlistx_first (jsctx->futures);
+            while (f) {
+                if (flux_future_get (f, NULL) < 0)
+                    flux_log_error (jsctx->h, "%s: flux_future_get",
+                                    __FUNCTION__);
+                flux_future_destroy (f);
+                f = zlistx_next (jsctx->futures);
+            }
+            zlistx_destroy (&jsctx->futures);
+        }
+        /* Destroy index last, as it is the one that will actually
+         * destroy the job objects */
+        if (jsctx->processing)
+            zlistx_destroy (&jsctx->processing);
+        if (jsctx->inactive)
+            zlistx_destroy (&jsctx->inactive);
+        if (jsctx->running)
+            zlistx_destroy (&jsctx->running);
+        if (jsctx->pending)
+            zlistx_destroy (&jsctx->pending);
+        if (jsctx->index)
+            zhashx_destroy (&jsctx->index);
+        free (jsctx);
+    }
+}
+
+/* zlistx_insert() and zlistx_reorder() take a 'low_value' parameter
+ * which indicates which end of the list to search from.
+ * false=search begins at tail (lowest priority, youngest)
+ * true=search begins at head (highest priority, oldest)
+ * Attempt to minimize search distance based on job priority.
+ */
+static bool search_direction (struct job *job)
+{
+    if (job->priority > FLUX_JOB_PRIORITY_DEFAULT)
+        return true;
+    else
+        return false;
+}
+
+/* remove job from one list and move it to another based on the
+ * newstate */
+static void job_change_list (struct job_state_ctx *jsctx,
+                             struct job *job,
+                             zlistx_t *oldlist,
+                             flux_job_state_t newstate)
+{
+    if (zlistx_detach (oldlist, job->list_handle) < 0)
+        flux_log_error (jsctx->h, "%s: zlistx_detach",
+                        __FUNCTION__);
+    job->list_handle = NULL;
+
+    if (newstate == FLUX_JOB_DEPEND
+        || newstate == FLUX_JOB_SCHED) {
+        if (!(job->list_handle = zlistx_insert (jsctx->pending,
+                                                job,
+                                                search_direction (job))))
+            flux_log_error (jsctx->h, "%s: zlistx_insert",
+                            __FUNCTION__);
+    }
+    else if (newstate == FLUX_JOB_RUN
+             || newstate == FLUX_JOB_CLEANUP) {
+        if (!(job->list_handle = zlistx_add_start (jsctx->running,
+                                                   job)))
+            flux_log_error (jsctx->h, "%s: zlistx_add_start",
+                            __FUNCTION__);
+    }
+    else { /* newstate == FLUX_JOB_INACTIVE */
+        if (!(job->list_handle = zlistx_add_start (jsctx->inactive,
+                                                   job)))
+            flux_log_error (jsctx->h, "%s: zlistx_add_start",
+                            __FUNCTION__);
+    }
+}
+
+static void eventlog_lookup_continuation (flux_future_t *f, void *arg)
+{
+    struct job *job = arg;
+    struct info_ctx *ctx = job->ctx;
+    const char *s;
+    json_t *a = NULL;
+    size_t index;
+    json_t *value;
+    void *handle;
+
+    if (flux_rpc_get_unpack (f, "{s:s}", "eventlog", &s) < 0) {
+        flux_log_error (ctx->h, "%s: error eventlog for %llu",
+                        __FUNCTION__, (unsigned long long)job->id);
+        return;
+    }
+
+    if (!(a = eventlog_decode (s))) {
+        flux_log_error (ctx->h, "%s: error parsing eventlog for %llu",
+                        __FUNCTION__, (unsigned long long)job->id);
+        return;
+    }
+
+    json_array_foreach (a, index, value) {
+        const char *name;
+        double timestamp;
+        json_t *context = NULL;
+
+        if (eventlog_entry_parse (value, &timestamp, &name, &context) < 0) {
+            flux_log_error (ctx->h, "%s: error parsing entry for %llu",
+                            __FUNCTION__, (unsigned long long)job->id);
+            goto out;
+        }
+
+        if (!strcmp (name, "submit")) {
+            if (!context) {
+                flux_log_error (ctx->h, "%s: no submit context for %llu",
+                                __FUNCTION__, (unsigned long long)job->id);
+                goto out;
+            }
+
+            if (json_unpack (context, "{ s:i s:i s:i }",
+                             "priority", &job->priority,
+                             "userid", &job->userid,
+                             "flags", &job->flags) < 0) {
+                flux_log_error (ctx->h, "%s: submit context for %llu invalid",
+                                __FUNCTION__, (unsigned long long)job->id);
+                goto out;
+            }
+            job->t_submit = timestamp;
+            job->job_info_retrieved = true;
+
+            /* move from processing to appropriate list */
+            job_change_list (ctx->jsctx,
+                             job,
+                             ctx->jsctx->processing,
+                             job->state);
+        }
+    }
+
+out:
+    json_decref (a);
+    handle = zlistx_find (ctx->jsctx->futures, f);
+    if (handle)
+        zlistx_detach (ctx->jsctx->futures, handle);
+    flux_future_destroy (f);
+}
+
+static flux_future_t *eventlog_lookup (struct job_state_ctx *jsctx,
+                                       struct job *job)
+{
+    flux_future_t *f = NULL;
+    int saved_errno;
+
+    if (!(f = flux_rpc_pack (jsctx->h, "job-info.lookup", FLUX_NODEID_ANY, 0,
+                             "{s:I s:[s] s:i}",
+                             "id", job->id,
+                             "keys", "eventlog",
+                             "flags", 0))) {
+        flux_log_error (jsctx->h, "%s: flux_rpc_pack", __FUNCTION__);
+        goto error;
+    }
+
+    if (flux_future_then (f, -1, eventlog_lookup_continuation, job) < 0) {
+        flux_log_error (jsctx->h, "%s: flux_future_then", __FUNCTION__);
+        goto error;
+    }
+
+    return f;
+
+ error:
+    saved_errno = errno;
+    flux_future_destroy (f);
+    errno = saved_errno;
+    return NULL;
+}
+
+static zlistx_t *get_list (struct job_state_ctx *jsctx, flux_job_state_t state)
+{
+    if (state == FLUX_JOB_DEPEND
+        || state == FLUX_JOB_SCHED)
+        return jsctx->pending;
+    else if (state == FLUX_JOB_RUN
+             || state == FLUX_JOB_CLEANUP)
+        return jsctx->running;
+    else /* state == FLUX_JOB_INACTIVE */
+        return jsctx->inactive;
+}
+
+static void update_job_state (struct job *job, flux_job_state_t newstate)
+{
+    struct job_state_ctx *jsctx = job->ctx->jsctx;
+
+    if (!job->job_info_retrieved) {
+        /* job info still not retrieved, we can update the job
+         * state but can't put it on a different list yet */
+        job->state = newstate;
+    }
+    else {
+        if (job->state == FLUX_JOB_INACTIVE) {
+            flux_log_error (jsctx->h,
+                            "%s: illegal transition: id=%llu state=%d",
+                            __FUNCTION__, (unsigned long long)job->id, newstate);
+        }
+        else {
+            zlistx_t *oldlist, *newlist;
+
+            oldlist = get_list (jsctx, job->state);
+            newlist = get_list (jsctx, newstate);
+
+            if (oldlist != newlist)
+                job_change_list (jsctx, job, oldlist, newstate);
+            job->state = newstate;
+        }
+    }
+}
+
+static void update_jobs (struct info_ctx *ctx, json_t *transitions)
+{
+    struct job_state_ctx *jsctx = ctx->jsctx;
+    size_t index;
+    json_t *value;
+
+    if (!json_is_array (transitions)) {
+        flux_log_error (ctx->h, "%s: transitions EPROTO", __FUNCTION__);
+        return;
+    }
+
+    json_array_foreach (transitions, index, value) {
+        struct job *job;
+        json_t *o;
+        flux_jobid_t id;
+        flux_job_state_t state;
+
+        if (!json_is_array (value)) {
+            flux_log_error (jsctx->h, "%s: transition EPROTO", __FUNCTION__);
+            return;
+        }
+
+        if (!(o = json_array_get (value, 0))
+            || !json_is_integer (o)) {
+            flux_log_error (jsctx->h, "%s: transition EPROTO", __FUNCTION__);
+            return;
+        }
+
+        id = json_integer_value (o);
+
+        if (!(o = json_array_get (value, 1))
+            || !json_is_string (o)) {
+            flux_log_error (jsctx->h, "%s: transition EPROTO", __FUNCTION__);
+            return;
+        }
+
+        if (flux_job_strtostate (json_string_value (o), &state) < 0) {
+            flux_log_error (jsctx->h, "%s: transition EPROTO", __FUNCTION__);
+            return;
+        }
+
+        if (!(job = zhashx_lookup (jsctx->index, &id))) {
+            flux_future_t *f = NULL;
+            void *handle;
+            if (!(job = job_create (ctx, id))){
+                flux_log_error (jsctx->h, "%s: job_create", __FUNCTION__);
+                return;
+            }
+            if (zhashx_insert (jsctx->index, &job->id, job) < 0) {
+                flux_log_error (jsctx->h, "%s: zhashx_insert", __FUNCTION__);
+                job_destroy (job);
+                return;
+            }
+
+            /* initial state transition does not provide information
+             * like userid, priority, t_submit, and flags.  We have to
+             * go get this information from the eventlog */
+            if (!(f = eventlog_lookup (jsctx, job))) {
+                flux_log_error (jsctx->h, "%s: eventlog_lookup", __FUNCTION__);
+                return;
+            }
+
+            if (!(handle = zlistx_add_end (jsctx->futures, f))) {
+                flux_log_error (jsctx->h, "%s: zlistx_add_end", __FUNCTION__);
+                flux_future_destroy (f);
+                return;
+            }
+
+            if (!(job->list_handle = zlistx_add_end (jsctx->processing, job))) {
+                flux_log_error (jsctx->h, "%s: zlistx_add_end", __FUNCTION__);
+                return;
+            }
+            job->state = state;
+        }
+        else
+            update_job_state (job, state);
+    }
+
+}
+
+void job_state_cb (flux_t *h, flux_msg_handler_t *mh,
+                   const flux_msg_t *msg, void *arg)
+{
+    struct info_ctx *ctx = arg;
+    json_t *transitions;
+
+    if (flux_event_unpack (msg, NULL, "{s:o}",
+                           "transitions",
+                           &transitions) < 0) {
+        flux_log_error (h, "%s: flux_event_unpack", __FUNCTION__);
+        return;
+    }
+
+    update_jobs (ctx, transitions);
+
+    return;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/job-info/job_state.c
+++ b/src/modules/job-info/job_state.c
@@ -21,32 +21,6 @@
 
 #include "job_state.h"
 
-/* To handle the common case of user queries on job state, we will
- * store jobs in three different lists.
- *
- * - pending - these are jobs that have not yet in the RUN state, they
- *   are sorted based on job priority, then job submission time.  -
- * - running - these are jobs that have transitioned to the RUN state.
- *   They are sorted by initial run start time.
- * - inactive - these are jobs that are in the INACTIVE state, they
- *   are sorted by job completion time.
- *
- * There is also an additional list `processing` that stores jobs that
- * cannot yet be stored on one of the lists above.
- *
- * The list `futures` is used to store in process futures.
- */
-
-struct job_state_ctx {
-    flux_t *h;
-    zhashx_t *index;
-    zlistx_t *pending;
-    zlistx_t *running;
-    zlistx_t *inactive;
-    zlistx_t *processing;
-    zlist_t *futures;
-};
-
 #define NUMCMP(a,b) ((a)==(b)?0:((a)<(b)?-1:1))
 
 /* Hash numerical jobid in 'key'.

--- a/src/modules/job-info/job_state.h
+++ b/src/modules/job-info/job_state.h
@@ -1,0 +1,70 @@
+/************************************************************\
+ * Copyright 2018 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _FLUX_JOB_INFO_JOB_STATE_H
+#define _FLUX_JOB_INFO_JOB_STATE_H
+
+#include <flux/core.h>
+
+#include "info.h"
+
+/* To handle the common case of user queries on job state, we will
+ * store jobs in three different lists.
+ *
+ * - pending - these are jobs that have not yet in the RUN state, they
+ *   are sorted based on job priority, then job submission time.
+ * - running - these are jobs that have transitioned to the RUN state.
+ *   They are sorted by initial run start time.
+ * - inactive - these are jobs that are in the INACTIVE state, they
+ *   are sorted by job completion time.
+ *
+ * There is also an additional list `processing` that stores jobs that
+ * cannot yet be stored on one of the lists above.
+ *
+ * The list `futures` is used to store in process futures.
+ */
+
+struct job_state_ctx {
+    flux_t *h;
+    zhashx_t *index;
+    zlistx_t *pending;
+    zlistx_t *running;
+    zlistx_t *inactive;
+    zlistx_t *processing;
+    zlistx_t *futures;
+};
+
+struct job {
+    struct info_ctx *ctx;
+
+    flux_jobid_t id;
+    uint32_t userid;
+    int priority;
+    double t_submit;
+    int flags;
+    flux_job_state_t state;
+
+    /* if userid, priority, t_submit, and flags have been set */
+    bool job_info_retrieved;
+    void *list_handle;
+};
+
+struct job_state_ctx *job_state_create (flux_t *h);
+
+void job_state_destroy (void *data);
+
+void job_state_cb (flux_t *h, flux_msg_handler_t *mh,
+                   const flux_msg_t *msg, void *arg);
+
+#endif /* ! _FLUX_JOB_INFO_JOB_STATE_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/job-info/list.c
+++ b/src/modules/job-info/list.c
@@ -231,6 +231,26 @@ error:
     json_decref (jobs);
 }
 
+void list_attrs_cb (flux_t *h, flux_msg_handler_t *mh,
+                    const flux_msg_t *msg, void *arg)
+{
+    if (flux_respond_pack (h, msg, "{s:[s,s,s,s]}",
+                           "attrs",
+                           "userid",
+                           "priority",
+                           "t_submit",
+                           "state") < 0) {
+        flux_log_error (h, "%s: flux_respond_pack", __FUNCTION__);
+        goto error;
+    }
+
+    return;
+
+error:
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
+}
+
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab
  */

--- a/src/modules/job-info/list.c
+++ b/src/modules/job-info/list.c
@@ -1,0 +1,212 @@
+/************************************************************\
+ * Copyright 2018 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* list.c - list jobs */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <czmq.h>
+#include <jansson.h>
+#include <flux/core.h>
+
+#include "src/common/libutil/errno_safe.h"
+
+#include "list.h"
+#include "job_state.h"
+
+/* To avoid denial of service, the maxinum number of entries that can
+ * be returned to the user will be capped */
+#define MAX_ENTRIES_CAP 1024
+
+/* For a given job, create a JSON object containing the jobid and any
+ * additional requested attributes and their values.  Returns JSON
+ * object which the caller must free.  On error, return NULL with
+ * errno set:
+ *
+ * EPROTO - malformed attrs array
+ * ENOMEM - out of memory
+ */
+json_t *list_one_job (struct job *job, json_t *attrs)
+{
+    size_t index;
+    json_t *value;
+    json_t *o;
+    json_t *val = NULL;
+
+    if (!(o = json_object ()))
+        goto error_nomem;
+    if (!(val = json_integer (job->id)))
+        goto error_nomem;
+    if (json_object_set_new (o, "id", val) < 0) {
+        json_decref (val);
+        goto error_nomem;
+    }
+    json_array_foreach (attrs, index, value) {
+        const char *attr = json_string_value (value);
+        if (!attr) {
+            errno = EINVAL;
+            goto error;
+        }
+        if (!strcmp (attr, "userid")) {
+            val = json_integer (job->userid);
+        }
+        else if (!strcmp (attr, "priority")) {
+            val = json_integer (job->priority);
+        }
+        else if (!strcmp (attr, "t_submit")) {
+            val = json_real (job->t_submit);
+        }
+        else if (!strcmp (attr, "state")) {
+            val = json_integer (job->state);
+        }
+        else {
+            errno = EINVAL;
+            goto error;
+        }
+        if (val == NULL)
+            goto error_nomem;
+        if (json_object_set_new (o, attr, val) < 0) {
+            json_decref (val);
+            goto error_nomem;
+        }
+    }
+    return o;
+ error_nomem:
+    errno = ENOMEM;
+ error:
+    ERRNO_SAFE_WRAP (json_decref, o);
+    return NULL;
+}
+
+/* Put jobs from list onto jobs array, breaking if max_entries has
+ * been reached. Returns 1 if jobs array is full, 0 if continue, -1
+ * one error with errno set:
+ *
+ * ENOMEM - out of memory
+ */
+int list_job_append (json_t *jobs,
+                     zlistx_t *list,
+                     int max_entries,
+                     json_t *attrs)
+{
+    struct job *job;
+
+    job = zlistx_first (list);
+    while (job) {
+        json_t *o;
+        if (!(o = list_one_job (job, attrs)))
+            return -1;
+        if (json_array_append_new (jobs, o) < 0) {
+            json_decref (o);
+            errno = ENOMEM;
+            return -1;
+        }
+        if (json_array_size (jobs) == max_entries)
+            return 1;
+        job = zlistx_next (list);
+    }
+
+    return 0;
+}
+
+/* Create a JSON array of 'job' objects.  'max_entries' determines the
+ * max number of jobs to return, 0=unlimited.  Returns JSON object
+ * which the caller must free.  On error, return NULL with errno set:
+ *
+ * EPROTO - malformed or empty attrs array, max_entries out of range
+ * ENOMEM - out of memory
+ */
+json_t *list_jobs (struct info_ctx *ctx, int max_entries, json_t *attrs)
+{
+    json_t *jobs = NULL;
+    int saved_errno;
+    int ret;
+
+    if (!(jobs = json_array ()))
+        goto error_nomem;
+
+    /* We return jobs in the following order, pending, running,
+     * inactive */
+
+    if ((ret = list_job_append (jobs,
+                                ctx->jsctx->pending,
+                                max_entries,
+                                attrs)) < 0)
+        goto error;
+
+    if (!ret) {
+        if ((ret = list_job_append (jobs,
+                                    ctx->jsctx->running,
+                                    max_entries,
+                                    attrs)) < 0)
+            goto error;
+    }
+
+    if (!ret) {
+        if ((ret = list_job_append (jobs,
+                                    ctx->jsctx->inactive,
+                                    max_entries,
+                                    attrs)) < 0)
+            goto error;
+    }
+
+    return jobs;
+
+error_nomem:
+    errno = ENOMEM;
+error:
+    saved_errno = errno;
+    json_decref (jobs);
+    errno = saved_errno;
+    return NULL;
+}
+
+void list_cb (flux_t *h, flux_msg_handler_t *mh,
+              const flux_msg_t *msg, void *arg)
+{
+    struct info_ctx *ctx = arg;
+    json_t *jobs = NULL;
+    json_t *attrs;
+    int max_entries;
+    int flags;
+
+    if (flux_request_unpack (msg, NULL, "{s:i s:o s:i}",
+                             "max_entries", &max_entries,
+                             "attrs", &attrs,
+                             "flags", &flags) < 0)
+        goto error;
+
+    if (max_entries < 0 || !json_is_array (attrs)) {
+        errno = EPROTO;
+        goto error;
+    }
+
+    if (max_entries > MAX_ENTRIES_CAP)
+        max_entries = MAX_ENTRIES_CAP;
+
+    if (!(jobs = list_jobs (ctx, max_entries, attrs)))
+        goto error;
+
+    if (flux_respond_pack (h, msg, "{s:O}", "jobs", jobs) < 0)
+        flux_log_error (h, "%s: flux_respond_pack", __FUNCTION__);
+
+    json_decref (jobs);
+    return;
+
+error:
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
+    json_decref (jobs);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/job-info/list.h
+++ b/src/modules/job-info/list.h
@@ -18,6 +18,9 @@
 void list_cb (flux_t *h, flux_msg_handler_t *mh,
               const flux_msg_t *msg, void *arg);
 
+void list_attrs_cb (flux_t *h, flux_msg_handler_t *mh,
+                    const flux_msg_t *msg, void *arg);
+
 #endif /* ! _FLUX_JOB_INFO_LIST_H */
 
 /*

--- a/src/modules/job-info/list.h
+++ b/src/modules/job-info/list.h
@@ -1,0 +1,25 @@
+/************************************************************\
+ * Copyright 2018 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _FLUX_JOB_INFO_LIST_H
+#define _FLUX_JOB_INFO_LIST_H
+
+#include <flux/core.h>
+
+#include "info.h"
+
+void list_cb (flux_t *h, flux_msg_handler_t *mh,
+              const flux_msg_t *msg, void *arg);
+
+#endif /* ! _FLUX_JOB_INFO_LIST_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -220,6 +220,7 @@ check_PROGRAMS = \
 	rexec/rexec_ps \
 	rexec/rexec_count_stdout \
 	rexec/rexec_getline \
+	job-manager/list-jobs \
 	ingest/submitbench \
 	sched-simple/jj-reader \
 	shell/rcalc \
@@ -446,6 +447,11 @@ ingest_job_manager_dummy_la_LIBADD = \
 ingest_submitbench_SOURCES = ingest/submitbench.c
 ingest_submitbench_CPPFLAGS = $(test_cppflags)
 ingest_submitbench_LDADD = \
+	$(test_ldadd) $(LIBDL) $(LIBUTIL)
+
+job_manager_list_jobs_SOURCES = job-manager/list-jobs.c
+job_manager_list_jobs_CPPFLAGS = $(test_cppflags)
+job_manager_list_jobs_LDADD = \
 	$(test_ldadd) $(LIBDL) $(LIBUTIL)
 
 job_manager_sched_dummy_la_SOURCES = job-manager/sched-dummy.c

--- a/t/job-manager/list-jobs.c
+++ b/t/job-manager/list-jobs.c
@@ -1,0 +1,127 @@
+/************************************************************\
+ * Copyright 2018 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdio.h>
+#include <string.h>
+#include <ctype.h>
+#include <assert.h>
+#include <czmq.h>
+#include <flux/core.h>
+#include <flux/optparse.h>
+#include <jansson.h>
+#if HAVE_FLUX_SECURITY
+#include <flux/security/sign.h>
+#endif
+#include "src/common/libutil/log.h"
+
+static struct optparse_option list_opts[] =  {
+    { .name = "count", .key = 'c', .has_arg = 1, .arginfo = "N",
+      .usage = "Limit output to N jobs",
+    },
+    OPTPARSE_TABLE_END
+};
+
+/* convert floating point timestamp (UNIX epoch, UTC) to ISO 8601 string,
+ * with second precision
+ */
+static int iso_timestr (double timestamp, char *buf, size_t size)
+{
+    time_t sec = timestamp;
+    struct tm tm;
+
+    if (!gmtime_r (&sec, &tm))
+        return -1;
+    if (strftime (buf, size, "%FT%TZ", &tm) == 0)
+        return -1;
+    return 0;
+}
+
+int main (int argc, char *argv[])
+{
+    flux_t *h;
+    optparse_t *opts;
+    int max_entries;
+    int optindex;
+    char *attrs = "[\"id\",\"userid\",\"priority\",\"t_submit\",\"state\"]";
+    flux_future_t *f;
+    json_t *jobs;
+    size_t index;
+    json_t *value;
+    json_t *attrs_array;
+
+    log_init ("list-jobs");
+
+    opts = optparse_create ("list-jobs");
+    if (optparse_add_option_table (opts, list_opts) != OPTPARSE_SUCCESS)
+        log_msg_exit ("optparse_add_option_table");
+    if ((optindex = optparse_parse_args (opts, argc, argv)) < 0)
+        exit (1);
+
+    max_entries = optparse_get_int (opts, "count", 0);
+
+    if (optindex != argc) {
+        optparse_print_usage (opts);
+        exit (1);
+    }
+
+    if (!(h = flux_open (NULL, 0)))
+        log_err_exit ("flux_open");
+
+    if (!(attrs_array = json_loads (attrs, 0, NULL)))
+        log_err_exit ("json_loads");
+
+    if (!(f = flux_rpc_pack (h, "job-manager.list", FLUX_NODEID_ANY, 0,
+                             "{s:i s:O}",
+                             "max_entries", max_entries,
+                             "attrs", attrs_array)))
+        log_err_exit ("flux_rpc_pack");
+
+    if (flux_rpc_get_unpack (f, "{s:o}", "jobs", &jobs) < 0)
+        log_err_exit ("flux_rpc_get_unpack");
+
+    json_array_foreach (jobs, index, value) {
+        flux_jobid_t id;
+        int priority;
+        uint32_t userid;
+        double t_submit;
+        char timestr[80];
+        flux_job_state_t state;
+
+        if (json_unpack (value, "{s:I s:i s:i s:f s:i}",
+                                "id", &id,
+                                "priority", &priority,
+                                "userid", &userid,
+                                "t_submit", &t_submit,
+                                "state", &state) < 0)
+            log_msg_exit ("error parsing job data");
+        if (iso_timestr (t_submit, timestr, sizeof (timestr)) < 0)
+            log_err_exit ("time conversion error");
+        printf ("%llu\t%s\t%lu\t%d\t%s\n",
+                (unsigned long long)id,
+                flux_job_statetostr (state, true),
+                (unsigned long)userid,
+                priority,
+                timestr);
+    }
+
+    json_decref (attrs_array);
+    flux_future_destroy (f);
+    flux_close (h);
+    log_fini ();
+
+    return 0;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/t/valgrind/workload.d/job-info
+++ b/t/valgrind/workload.d/job-info
@@ -8,3 +8,4 @@ id=$(flux jobspec srun -t 1 -n 1 /bin/true | flux job submit)
 flux job attach ${id}
 
 flux job info ${id} eventlog jobspec R >/dev/null
+flux job list --pending --running --inactive


### PR DESCRIPTION
This is an initial implementation for #2454.  This will not pass travis right now due to #2470.

- In this initial implementation, the internal lists of jobs in the `job-info` module grow without bound.

- Restart by loading job history from the KVS is not supported in this round.

- Per discussion, in #2454, three lists are used to store jobs.  `pending` jobs are sorted by priority first, then submission time.  `running` jobs are sorted by start time of running.  And `inactive` jobs are stored by time completed.  Note that the latter two lists don't need to be "sorted" per-se.  You can just append to the end of the list when events happen.

- Flags are supported to allow callers to ask for the `pending`, `running`, or `inactive` jobs.  `flux job list` defaults to `PENDING | RUNNING`.

- Per discussion, in order to maintain tests against `job-manager.list`, add new `t/job-manager/list-jobs` tool was added.

- Right now only instance owners can query.  That can be changed easily to `FLUX_ROLE_USER`, but wasn't sure if guest access needs to be supported?  Or filtering based on a userid needs to be supported?  Or would that be for a porcelain tool (#2416)?


