### PR TITLE
shell: implement shell-specific log facility, add support for log events to output eventlog

### DIFF
--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -838,10 +838,10 @@ void print_eventlog_entry (FILE *fp,
         if (!(context_s = json_dumps (context, JSON_COMPACT)))
             log_err_exit ("%s: error re-encoding context", __func__);
     }
-    fprintf (stderr, "%-10s%s%.3f %s%s%s\n",
-             prefix ? prefix : "",
-             prefix ? ": " : "",
+    fprintf (stderr, "%.3fs: %s%s%s%s%s\n",
              timestamp,
+             prefix ? prefix : "",
+             prefix ? "." : "",
              name,
              context_s ? " " : "",
              context_s ? context_s : "");
@@ -1169,7 +1169,7 @@ void attach_exec_event_continuation (flux_future_t *f, void *arg)
 
     if (optparse_hasopt (ctx->p, "show-exec")) {
         print_eventlog_entry (stderr,
-                              "exec-event",
+                              "exec",
                               timestamp - ctx->timestamp_zero,
                               name,
                               context);
@@ -1266,7 +1266,7 @@ void attach_event_continuation (flux_future_t *f, void *arg)
     if (optparse_hasopt (ctx->p, "show-events")
                                     && strcmp (name, "exception") != 0) {
         print_eventlog_entry (stderr,
-                              "job-event",
+                              "job",
                               timestamp - ctx->timestamp_zero,
                               name,
                               context);

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -1227,10 +1227,11 @@ void attach_event_continuation (flux_future_t *f, void *arg)
                          "severity", &severity,
                          "note", &note) < 0)
             log_err_exit ("error decoding exception context");
-        fprintf (stderr, "job-event: exception type=%s severity=%d %s\n",
-                 type,
-                 severity,
-                 note ? note : "");
+        fprintf (stderr, "%.3fs: job.exception type=%s severity=%d %s\n",
+                         timestamp - ctx->timestamp_zero,
+                         type,
+                         severity,
+                         note ? note : "");
     }
     else if (!strcmp (name, "submit")) {
         if (!(ctx->exec_eventlog_f = flux_job_event_watch (ctx->h,

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -838,7 +838,7 @@ void print_eventlog_entry (FILE *fp,
         if (!(context_s = json_dumps (context, JSON_COMPACT)))
             log_err_exit ("%s: error re-encoding context", __func__);
     }
-    fprintf (stderr, "%s%s%.3f %s%s%s\n",
+    fprintf (stderr, "%-10s%s%.3f %s%s%s\n",
              prefix ? prefix : "",
              prefix ? ": " : "",
              timestamp,

--- a/src/common/libflux/plugin.c
+++ b/src/common/libflux/plugin.c
@@ -376,6 +376,14 @@ static int arg_set (flux_plugin_arg_t *args, int flags, json_t *o)
 {
     json_t **dstp;
     dstp = arg_get (args, flags);
+    if (flags & FLUX_PLUGIN_ARG_UPDATE && *dstp != NULL) {
+        /*  On update, the object 'o' is spiritually inherited by
+         *   args, so decref this object after attempting the update.
+         */
+        int rc = json_object_update (*dstp, o);
+        json_decref (o);
+        return rc;
+    }
     json_decref (*dstp);
     *dstp = o;
     return 0;

--- a/src/common/libflux/plugin.h
+++ b/src/common/libflux/plugin.h
@@ -116,8 +116,9 @@ const char *flux_plugin_arg_strerror (flux_plugin_arg_t *args);
 /*  Flags for flux_plugin_arg_get/set/pack/unpack
  */
 enum {
-    FLUX_PLUGIN_ARG_IN =  0, /* Operate on input args  */
-    FLUX_PLUGIN_ARG_OUT = 1  /* Operate on output args */
+    FLUX_PLUGIN_ARG_IN =  0,    /* Operate on input args    */
+    FLUX_PLUGIN_ARG_OUT = 1,    /* Operate on output args   */
+    FLUX_PLUGIN_ARG_UPDATE = 2  /* Update args for set/pack */
 };
 
 /*  Get/set arguments in plugin arg object using JSON encoded strings

--- a/src/common/libflux/test/plugin.c
+++ b/src/common/libflux/test/plugin.c
@@ -178,6 +178,39 @@ void test_plugin_args ()
     ok (arg == 5,
         "flux_plugin_arg_unpack returned valid value for arg");
 
+    ok (flux_plugin_arg_set (args,
+                             FLUX_PLUGIN_ARG_IN | FLUX_PLUGIN_ARG_UPDATE,
+                             "{\"b\":7}") == 0,
+        "flux_plugin_arg_set with FLUX_PLUGIN_ARG_UPDATE works");
+    ok (flux_plugin_arg_unpack (args, FLUX_PLUGIN_ARG_IN,
+                                "{s:i}", "b", &arg) == 0,
+        "flux_plugin_arg_unpack worked");
+    ok (arg == 7,
+        "flux_plugin_arg_unpack returned valid value for new arg");
+    ok (flux_plugin_arg_unpack (args, FLUX_PLUGIN_ARG_IN,
+                                "{s:i}", "a", &arg) == 0,
+        "flux_plugin_arg_unpack worked");
+    ok (arg == 5,
+        "flux_plugin_arg_unpack returned valid value for old arg");
+
+
+    /* Test update with unset args */
+    flux_plugin_arg_t *new = flux_plugin_arg_create ();
+    if (!new)
+        BAIL_OUT ("flux_plugin_arg_create failed");
+    ok (flux_plugin_arg_set (args,
+                             FLUX_PLUGIN_ARG_IN | FLUX_PLUGIN_ARG_UPDATE,
+                            "{\"count\": 29}") == 0,
+        "flux_plugin_arg_set with ARG_UPDATE works for empty args");
+    flux_plugin_arg_destroy (new);
+
+    ok (flux_plugin_arg_unpack (args, FLUX_PLUGIN_ARG_IN,
+                                "{s:i}", "count", &arg) == 0,
+        "flux_plugin_arg_unpack worked");
+    ok (arg == 29,
+        "flux_plugin_arg_unpack returned valid value for arg");
+
+
     /*  Test pack
      */
     ok (flux_plugin_arg_pack (args, FLUX_PLUGIN_ARG_IN,

--- a/src/modules/job-manager/raise.c
+++ b/src/modules/job-manager/raise.c
@@ -103,11 +103,6 @@ void raise_handle_request (flux_t *h, struct queue *queue,
         errno = EPERM;
         goto error;
     }
-    if (note && strchr (note, '=')) {
-        errstr = "exception note may not contain key=value attributes";
-        errno = EPROTO;
-        goto error;
-    }
     if (event_job_post_pack (event_ctx, job,
                              "exception",
                              "{ s:s s:i s:i s:s }",

--- a/src/shell/Makefile.am
+++ b/src/shell/Makefile.am
@@ -50,6 +50,8 @@ flux_shell_SOURCES = \
 	info.h \
 	task.c \
 	task.h \
+	log.c \
+	log.h \
 	pmi.c \
 	input.c \
 	output.c \

--- a/src/shell/Makefile.am
+++ b/src/shell/Makefile.am
@@ -62,7 +62,8 @@ flux_shell_SOURCES = \
 	kill.c \
 	signals.c \
 	affinity.c \
-	gpubind.c
+	gpubind.c \
+	evlog.c
 
 flux_shell_LDADD = \
 	$(builddir)/libshell.la \

--- a/src/shell/Makefile.am
+++ b/src/shell/Makefile.am
@@ -110,8 +110,8 @@ test_jobspec_t_SOURCES = test/jobspec.c
 test_jobspec_t_CPPFLAGS = $(test_cppflags)
 test_jobspec_t_LDADD = $(test_ldadd)
 
-test_plugstack_t_SOURCES = test/plugstack.c
-test_plugstack_t_CPPFLAGS = $(test_cppflags)
+test_plugstack_t_SOURCES = plugstack.c test/plugstack.c
+test_plugstack_t_CPPFLAGS = $(test_cppflags) -DPLUGSTACK_STANDALONE
 test_plugstack_t_LDADD = $(test_ldadd)
 
 test_a_plugin_la_SOURCES = test/plugin_test.c

--- a/src/shell/Makefile.am
+++ b/src/shell/Makefile.am
@@ -33,6 +33,8 @@ libshell_la_SOURCES = \
 	plugstack.h \
 	jobspec.c \
 	jobspec.h \
+	eventlogger.c \
+	eventlogger.h \
 	rcalc.c \
 	rcalc.h
 

--- a/src/shell/builtins.c
+++ b/src/shell/builtins.c
@@ -14,7 +14,7 @@
 #include "config.h"
 #endif
 
-#include "src/common/libutil/log.h"
+#include <flux/shell.h>
 
 #include "internal.h"
 #include "builtins.h"
@@ -29,6 +29,7 @@ static struct shell_builtin builtin_list_end = { 0 };
  *  Then, the name should be added to the 'builtins' list
  *  to get the builtin automatically loaded at shell startup.
  */
+extern struct shell_builtin builtin_log_eventlog;
 extern struct shell_builtin builtin_pmi;
 extern struct shell_builtin builtin_input;
 extern struct shell_builtin builtin_output;
@@ -38,6 +39,7 @@ extern struct shell_builtin builtin_affinity;
 extern struct shell_builtin builtin_gpubind;
 
 static struct shell_builtin * builtins [] = {
+    &builtin_log_eventlog,
     &builtin_pmi,
     &builtin_input,
     &builtin_output,
@@ -67,8 +69,7 @@ static int shell_load_builtin (flux_shell_t *shell,
         || flux_plugin_add_handler (p, "task.exit",  sb->task_exit, NULL) < 0)
         return -1;
 
-    if (shell->verbose)
-        log_msg ("loading builtin plugin \"%s\"", sb->name);
+    shell_debug ("loading builtin plugin \"%s\"", sb->name);
     if (plugstack_push (shell->plugstack, p) < 0)
         return -1;
     return (0);

--- a/src/shell/builtins.c
+++ b/src/shell/builtins.c
@@ -58,6 +58,7 @@ static int shell_load_builtin (flux_shell_t *shell,
     if (flux_plugin_aux_set (p, "flux::shell", shell, NULL) < 0
         || flux_plugin_set_name (p, sb->name) < 0
         || flux_plugin_add_handler (p, "shell.validate", sb->validate, NULL) < 0
+        || flux_plugin_add_handler (p, "shell.connect",  sb->connect, NULL) < 0
         || flux_plugin_add_handler (p, "shell.init", sb->init, NULL) < 0
         || flux_plugin_add_handler (p, "shell.exit", sb->exit, NULL) < 0
         || flux_plugin_add_handler (p, "task.init",  sb->task_init, NULL) < 0

--- a/src/shell/builtins.h
+++ b/src/shell/builtins.h
@@ -17,6 +17,7 @@
 struct shell_builtin {
     const char *name;
     flux_plugin_f validate;
+    flux_plugin_f connect;
     flux_plugin_f init;
     flux_plugin_f task_init;
     flux_plugin_f task_exec;

--- a/src/shell/eventlogger.c
+++ b/src/shell/eventlogger.c
@@ -1,0 +1,272 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <jansson.h>
+#include <czmq.h>
+#include <flux/core.h>
+
+#include "src/common/libeventlog/eventlog.h"
+#include "eventlogger.h"
+
+struct eventlog_batch {
+    zlist_t *entries;
+    flux_kvs_txn_t *txn;
+    flux_watcher_t *timer;
+    struct eventlogger *ev;
+};
+
+struct eventlogger {
+    int refcount;
+    flux_t *h;
+    double batch_timeout;
+    double commit_timeout;
+    zlist_t *pending;
+    struct eventlog_batch *current;
+    struct eventlogger_ops ops;
+    void *arg;
+};
+
+int eventlogger_set_commit_timeout (struct eventlogger *ev, double timeout)
+{
+    if (!ev || (timeout < 0. && timeout != -1.)) {
+        errno = EINVAL;
+        return -1;
+    }
+    ev->commit_timeout = timeout;
+    return 0;
+}
+
+static void eventlog_batch_destroy (struct eventlog_batch *batch)
+{
+    if (batch) {
+        if (batch->entries)
+            zlist_destroy (&batch->entries);
+        flux_kvs_txn_destroy (batch->txn);
+        flux_watcher_destroy (batch->timer);
+        free (batch);
+    }
+}
+
+static void eventlogger_batch_complete (struct eventlogger *ev,
+                                        struct eventlog_batch *batch)
+{
+    zlist_remove (ev->pending, batch);
+    if (--ev->refcount == 0 && ev->ops.idle)
+        (*ev->ops.idle) (ev, ev->arg);
+}
+
+static int eventlogger_batch_start (struct eventlogger *ev,
+                                    struct eventlog_batch *batch)
+{
+    if (zlist_append (ev->pending, batch) < 0)
+        return -1;
+    zlist_freefn (ev->pending,
+                  batch,
+                  (zlist_free_fn *) eventlog_batch_destroy,
+                  true);
+
+    /*  If refcount just increased to 1, notify that eventlogger is busy */
+    if (++ev->refcount == 1 && ev->ops.busy)
+        (*ev->ops.busy) (ev, ev->arg);
+    return 0;
+}
+
+static void eventlog_batch_error (struct eventlog_batch *batch, int errnum)
+{
+    struct eventlogger *ev = batch->ev;
+    json_t *entry;
+    if (!ev->ops.err)
+        return;
+    entry = zlist_first (batch->entries);
+    while (entry) {
+        (*ev->ops.err) (ev, errnum, entry);
+        entry = zlist_next (batch->entries);
+    }
+}
+
+static void commit_cb (flux_future_t *f, void *arg)
+{
+    struct eventlog_batch *batch = arg;
+    if (flux_future_get (f, NULL) < 0)
+        eventlog_batch_error (batch, errno);
+    eventlogger_batch_complete (batch->ev, batch);
+    flux_future_destroy (f);
+}
+
+static void
+timer_cb (flux_reactor_t *r, flux_watcher_t *w, int revents, void *arg)
+{
+    struct eventlog_batch *batch = arg;
+    struct eventlogger *ev = batch->ev;
+    flux_t *h = ev->h;
+    double timeout = ev->commit_timeout;
+    flux_future_t *f = NULL;
+
+    if (!(f = flux_kvs_commit (h, NULL, 0, batch->txn))
+        || flux_future_then (f, timeout, commit_cb, batch) < 0) {
+        eventlog_batch_error (batch, errno);
+        return;
+    }
+    batch->ev->current = NULL;
+}
+
+static struct eventlog_batch * eventlog_batch_create (struct eventlogger *ev)
+{
+    struct eventlog_batch *batch = calloc (1, sizeof (*batch));
+    if (!batch)
+        return NULL;
+    flux_reactor_t *r = flux_get_reactor (ev->h);
+    batch->ev = ev;
+    batch->entries = zlist_new ();
+    batch->txn = flux_kvs_txn_create ();
+    batch->timer = flux_timer_watcher_create (r,
+                                              ev->batch_timeout, 0.,
+                                              timer_cb,
+                                              batch);
+    if (!batch->entries || !batch->txn || !batch->timer) {
+        eventlog_batch_destroy (batch);
+        return NULL;
+    }
+    flux_watcher_start (batch->timer);
+    return batch;
+}
+
+void eventlogger_destroy (struct eventlogger *ev)
+{
+    if (ev) {
+        if (ev->pending)
+            zlist_destroy (&ev->pending);
+        free (ev);
+    }
+}
+
+struct eventlogger *eventlogger_create (flux_t *h,
+                                        double timeout,
+                                        struct eventlogger_ops *ops,
+                                        void *arg)
+{
+    struct eventlogger *ev = calloc (1, sizeof (*ev));
+    if (ev) {
+        ev->pending = zlist_new ();
+        if (!ev->pending) {
+            eventlogger_destroy (ev);
+            return NULL;
+        }
+        ev->h = h;
+        ev->batch_timeout = timeout;
+        ev->commit_timeout = -1.;
+        ev->current = NULL;
+        ev->ops = *ops;
+        ev->arg = arg;
+    }
+    return ev;
+}
+
+static struct eventlog_batch * eventlog_batch_get (struct eventlogger *ev)
+{
+    struct eventlog_batch *batch = ev->current;
+    if (!batch) {
+        if (!(ev->current = eventlog_batch_create (ev)))
+            return NULL;
+        batch = ev->current;
+        eventlogger_batch_start (ev, batch);
+    }
+    return batch;
+}
+
+static int append_wait (struct eventlogger *ev,
+                        const char *path,
+                        const char *entrystr)
+{
+    int rc = -1;
+    flux_future_t *f = NULL;
+
+    /*  append_wait also appends all pending transactions synchronously  */
+    struct eventlog_batch *batch = eventlog_batch_get (ev);
+    if (!batch)
+        return -1;
+
+    if (flux_kvs_txn_put (ev->current->txn,
+                          FLUX_KVS_APPEND,
+                          path, entrystr) < 0)
+        return -1;
+
+    if (!(f = flux_kvs_commit (ev->h, NULL, 0, ev->current->txn))
+        || flux_future_wait_for (f, ev->commit_timeout) < 0)
+        goto out;
+    if ((rc = flux_future_get (f, NULL)) < 0)
+        eventlog_batch_error (batch, errno);
+
+    eventlogger_batch_complete (ev, ev->current);
+    ev->current = NULL;
+out:
+    flux_future_destroy (f);
+    return rc;
+}
+
+static int append_async (struct eventlogger *ev,
+                         const char *path,
+                         json_t *entry,
+                         const char *entrystr)
+{
+    struct eventlog_batch *batch = eventlog_batch_get (ev);
+
+    if (!batch)
+        return -1;
+    if (flux_kvs_txn_put (ev->current->txn,
+                          FLUX_KVS_APPEND,
+                          path,
+                          entrystr) < 0)
+            return -1;
+
+    if (zlist_append (batch->entries, entry) < 0)
+        return -1;
+    json_incref (entry);
+    zlist_freefn (batch->entries,
+                  entry,
+                  (zlist_free_fn *) json_decref,
+                  true);
+    return 0;
+}
+
+int eventlogger_append (struct eventlogger *ev,
+                        int flags,
+                        const char *path,
+                        const char *name,
+                        const char *context)
+{
+    int rc = -1;
+    char *entrystr = NULL;
+    int wait = 0;
+    json_t *entry;
+
+    if (flags & EVENTLOGGER_FLAG_WAIT)
+        wait = 1;
+
+    if (!(entry = eventlog_entry_create (0., name, context))
+        || !(entrystr = eventlog_entry_encode (entry)))
+        goto out;
+
+    if (wait)
+        rc = append_wait (ev, path, entrystr);
+    else
+        rc = append_async (ev, path, entry, entrystr);
+out:
+    json_decref (entry);
+    free (entrystr);
+    return rc;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/shell/eventlogger.h
+++ b/src/shell/eventlogger.h
@@ -1,0 +1,62 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef FLUX_SHELL_EVENTLOGGER_H
+#define FLUX_SHELL_EVENTLOGGER_H
+
+#include <flux/core.h>
+#include <jansson.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct eventlogger;
+
+typedef void (*eventlogger_state_f) (struct eventlogger *ev, void *arg);
+typedef void (*eventlogger_err_f) (struct eventlogger *ev,
+                                   int err,
+                                   json_t *entry);
+
+struct eventlogger_ops {
+    eventlogger_state_f busy; /* Called after idle when starting a batch    */
+    eventlogger_state_f idle; /* Called when no more batches pending        */
+    eventlogger_err_f  err;   /* Called on error, once per failed entry     */
+};
+
+enum {
+    EVENTLOGGER_FLAG_ASYNC = 0,  /* Append entry to eventlog asynchronously */
+    EVENTLOGGER_FLAG_WAIT =  1,  /* Append entry to eventlog synchronously  */
+};
+
+/*  Create an eventlogger with batched eventlog appends at interval
+ *   `timeout`. Eventlogger will process user callbacks in `ops` as
+ *   defined above.
+ */
+struct eventlogger *eventlogger_create (flux_t *h,
+                                        double timeout,
+                                        struct eventlogger_ops *ops,
+                                        void *arg);
+
+void eventlogger_destroy (struct eventlogger *ev);
+
+int eventlogger_append (struct eventlogger *ev,
+                        int flags,
+                        const char *path,
+                        const char *name,
+                        const char *context);
+
+int eventlogger_set_commit_timeout (struct eventlogger *ev, double timeout);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* !FLUX_SHELL_EVENTLOGGER_H */

--- a/src/shell/evlog.c
+++ b/src/shell/evlog.c
@@ -1,0 +1,219 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/*  evlog - Write shell log messages to output eventlog as RFC 24
+ *   Log Events.
+ *
+ *  Log messages are forwarded to this plugin from the shell log
+ *   facility via a "shell.log" plugin hook, which provides plugin
+ *   argument in RFC 24 Log Event format. If the severity level of
+ *   the message is equal to or lower than the current set level,
+ *   then the message is appended to the output eventlog using
+ *   an "eventlogger" abstraction, which batches events when
+ *   possible.
+ *
+ *  Log messages at FLUX_SHELL_FATAL are never batched and instead
+ *   are written synchronously to the event log (i.e. the plugin
+ *   hook will not return until the kvs commit has posted).
+ *
+ *  The evlog plugin also subscribes to the "shell.log-setlevel"
+ *   plugin hook, which allows the level of one or more logging
+ *   plugins to be set independently of the main shell log
+ *   facility level.
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <jansson.h>
+#include <czmq.h>
+#include <flux/core.h>
+#include <flux/shell.h>
+
+#include "info.h"
+#include "internal.h"
+#include "builtins.h"
+#include "eventlogger.h"
+
+struct evlog {
+    int sync_mode;
+    int level;
+    flux_shell_t *shell;
+    struct eventlogger *ev;
+};
+
+static int log_eventlog (flux_plugin_t *p,
+                         const char *topic,
+                         flux_plugin_arg_t *args,
+                         void *data)
+{
+    int flags = 0;
+    int rc = 0;
+    int level = -1;
+    char *context = NULL;
+    struct evlog *evlog = NULL;
+
+    if (!(evlog = flux_plugin_aux_get (p, "evlog")))
+        return -1;
+    if (flux_plugin_arg_unpack (args, FLUX_PLUGIN_ARG_IN,
+                                "{s:i}", "level", &level) < 0)
+        return -1;
+    if (level > evlog->level)
+        return 0;
+    if (evlog->sync_mode || level == FLUX_SHELL_FATAL)
+        flags = EVENTLOGGER_FLAG_WAIT;
+    if (flux_plugin_arg_get (args, FLUX_PLUGIN_ARG_IN, &context) < 0
+        || eventlogger_append (evlog->ev, flags, "output", "log", context) < 0)
+        rc = -1;
+    free (context);
+    return rc;
+}
+
+static void evlog_destroy (struct evlog *evlog)
+{
+    eventlogger_destroy (evlog->ev);
+    free (evlog);
+}
+
+static void evlog_ref (struct eventlogger *ev, void *arg)
+{
+    struct evlog *evlog = arg;
+    flux_shell_add_completion_ref (evlog->shell, "eventlogger.txn");
+}
+
+static void evlog_unref (struct eventlogger *ev, void *arg)
+{
+    struct evlog *evlog = arg;
+    flux_shell_remove_completion_ref (evlog->shell, "eventlogger.txn");
+}
+
+static void evlog_error (struct eventlogger *ev, int errnum, json_t *entry)
+{
+    const char *msg;
+    if (json_unpack (entry, "{s:{s:s}}",
+                            "context",
+                            "message", &msg) < 0) {
+        fprintf (stderr, "evlog_error: failed to unpack message\n");
+        return;
+    }
+    fprintf (stderr, "flux-shell: evlog failure: %s: msg=%s\n",
+                     strerror (errnum), msg);
+}
+
+static struct evlog *evlog_create (flux_shell_t *shell)
+{
+    flux_t *h = flux_shell_get_flux (shell);
+    struct eventlogger_ops ops = {
+        .busy = evlog_ref,
+        .idle = evlog_unref,
+        .err =  evlog_error
+    };
+    struct evlog *evlog = calloc (1, sizeof (*evlog));
+
+    if (h == NULL) {
+        fprintf (stderr, "evlog_create failure due to no handle\n");
+        return NULL;
+    }
+    if (!evlog || !(evlog->ev = eventlogger_create (h, 0.01, &ops, evlog)))
+        goto err;
+    eventlogger_set_commit_timeout (evlog->ev, 5.);
+    evlog->level = FLUX_SHELL_NOTICE + shell->verbose;
+    evlog->shell = shell;
+    return evlog;
+err:
+    evlog_destroy (evlog);
+    return NULL;
+}
+
+/*  Check if a shell.log-setlevel request is for dest="any" or "eventlog"
+ *   and adjust our internal level if so
+ */
+static int log_eventlog_setlevel (flux_plugin_t *p,
+                                  const char *topic,
+                                  flux_plugin_arg_t *args,
+                                  void *data)
+{
+    struct evlog *evlog = data;
+    const char *name;
+    int level;
+
+    if (flux_plugin_arg_unpack (args, FLUX_PLUGIN_ARG_IN,
+                                "{ s:s s:i }",
+                                "dest", &name,
+                                "level", &level) < 0) {
+        fprintf (stderr, "log.eventlog: setlevel arg unpack error: %s\n",
+                         flux_plugin_arg_strerror (args));
+        return -1;
+    }
+    if (strcmp (name, "any") == 0 || strcmp (name, "eventlog") == 0)
+        evlog->level = level;
+    return 0;
+}
+
+static int evlog_shell_exit (flux_plugin_t *p,
+                             const char *topic,
+                             flux_plugin_arg_t *args,
+                             void *data)
+{
+    struct evlog *evlog = data;
+    /*
+     *  Write all log messages synchronously after shell.exit, since
+     *   there will no longer be a reactor.
+     */
+    evlog->sync_mode = 1;
+    return 0;
+}
+
+/*  Start the evenlog-based logger during shell.connect, just after the
+ *   shell has obtained a flux_t handle. This allows more early log
+ *   messages to make it into the eventlog, but some data (such as
+ *   the current shell_rank) is not available at this time.
+ */
+static int log_eventlog_start (flux_plugin_t *p,
+                               const char *topic,
+                               flux_plugin_arg_t *args,
+                               void *data)
+{
+    flux_shell_t *shell = flux_plugin_get_shell (p);
+    struct evlog *evlog = NULL;
+
+    /*  Do not activate eventlogger in standlone mode */
+    if (shell->standalone)
+        return 0;
+
+    if (!(evlog = evlog_create (shell)))
+        return -1;
+    if (flux_plugin_aux_set (p, "evlog", evlog,
+                             (flux_free_f) evlog_destroy ) < 0)
+        goto err;
+    if (flux_plugin_add_handler (p, "shell.log", log_eventlog, shell) < 0
+       || flux_plugin_add_handler (p, "shell.log-setlevel",
+                                   log_eventlog_setlevel,
+                                   evlog) < 0
+       || flux_plugin_add_handler (p, "shell.exit",
+                                   evlog_shell_exit,
+                                   evlog) < 0)
+        goto err;
+
+    flux_shell_log_setlevel (FLUX_SHELL_ERROR, "stderr");
+    return 0;
+err:
+    evlog_destroy (evlog);
+    return -1;
+}
+
+struct shell_builtin builtin_log_eventlog = {
+    .name = "evlog",
+    .connect = log_eventlog_start,
+};
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/shell/info.c
+++ b/src/shell/info.c
@@ -196,26 +196,6 @@ struct shell_info *shell_info_create (flux_shell_t *shell)
     }
     info->shell_size = rcalc_total_nodes (info->rcalc);
     info->shell_rank = info->rankinfo.nodeid;
-    if (shell->verbose) {
-        if (info->shell_rank == 0)
-            shell_debug ("0: task_count=%d slot_count=%d "
-                         "cores_per_slot=%d slots_per_node=%d",
-                         info->jobspec->task_count,
-                         info->jobspec->slot_count,
-                         info->jobspec->cores_per_slot,
-                         info->jobspec->slots_per_node);
-        if (info->rankinfo.ntasks > 1)
-            shell_debug ("%d: tasks [%d-%d] on cores %s",
-                         info->shell_rank,
-                         info->rankinfo.global_basis,
-                         info->rankinfo.global_basis+info->rankinfo.ntasks - 1,
-                         info->rankinfo.cores);
-        else
-            shell_debug ("%d: tasks [%d] on cores %s",
-                         info->shell_rank,
-                         info->rankinfo.global_basis,
-                         info->rankinfo.cores);
-    }
     return info;
 error:
     shell_info_destroy (info);

--- a/src/shell/info.c
+++ b/src/shell/info.c
@@ -16,7 +16,6 @@
 #include <flux/core.h>
 #include <jansson.h>
 
-#include "src/common/libutil/log.h"
 #include "src/common/libutil/read_all.h"
 
 #include "internal.h"
@@ -51,7 +50,7 @@ static int lookup_job_info_get (flux_future_t *f,
         goto error;
     return 0;
 error:
-    log_msg ("job-info: %s", future_strerror (f, errno));
+    shell_log_error ("job-info: %s", future_strerror (f, errno));
     return -1;
 }
 
@@ -69,7 +68,7 @@ static flux_future_t *lookup_job_info (flux_t *h,
     if (!(keys = json_array ())
             || (!R && array_append_string (keys, "R") < 0)
             || (!jobspec && array_append_string (keys, "jobspec") < 0)) {
-        log_msg ("error building json array");
+        shell_log_error ("error building json array");
         return NULL;
     }
     f = flux_rpc_pack (h,
@@ -81,7 +80,7 @@ static flux_future_t *lookup_job_info (flux_t *h,
                        "keys", keys,
                        "flags", 0);
     if (!f)
-        log_msg ("error sending job-info request");
+        shell_log_error ("error sending job-info request");
     json_decref (keys);
     return f;
 }
@@ -99,12 +98,12 @@ static char *parse_arg_file (const char *optarg)
         fd = STDIN_FILENO;
     else {
         if ((fd = open (optarg, O_RDONLY)) < 0) {
-            log_err ("error opening %s", optarg);
+            shell_log_errno ("error opening %s", optarg);
             return NULL;
         }
     }
     if ((size = read_all (fd, &buf)) < 0)
-        log_err ("error reading %s", optarg);
+        shell_log_errno ("error reading %s", optarg);
     if (fd != STDIN_FILENO)
         (void)close (fd);
     return buf;
@@ -140,7 +139,7 @@ static int shell_init_jobinfo (flux_shell_t *shell,
     if (!R || !jobspec) {
         /* Fetch missing jobinfo from broker job-info service */
         if (shell->standalone) {
-            log_msg ("Invalid arguments: standalone and R/jobspec are unset");
+            shell_log_error ("Invalid arguments: standalone and R/jobspec are unset");
             return -1;
         }
         if (!(f = lookup_job_info (shell->h, shell->jobid, jobspec, R))
@@ -148,11 +147,11 @@ static int shell_init_jobinfo (flux_shell_t *shell,
             goto out;
     }
     if (!(info->jobspec = jobspec_parse (jobspec, &error))) {
-        log_msg ("error parsing jobspec: %s", error.text);
+        shell_log_error ("error parsing jobspec: %s", error.text);
         goto out;
     }
     if (!(info->rcalc = rcalc_create (R))) {
-        log_msg ("error decoding R");
+        shell_log_error ("error decoding R");
         goto out;
     }
     rc = 0;
@@ -169,7 +168,7 @@ struct shell_info *shell_info_create (flux_shell_t *shell)
     int broker_rank = shell->broker_rank;
 
     if (!(info = calloc (1, sizeof (*info)))) {
-        log_err ("shell_info_create");
+        shell_log_errno ("shell_info_create");
         return NULL;
     }
     info->jobid = shell->jobid;
@@ -187,35 +186,35 @@ struct shell_info *shell_info_create (flux_shell_t *shell)
     free (R);
 
    if (rcalc_distribute (info->rcalc, info->jobspec->task_count) < 0) {
-        log_msg ("error distributing %d tasks over R",
-                 info->jobspec->task_count);
+        shell_log_error ("error distributing %d tasks over R",
+                         info->jobspec->task_count);
         goto error;
     }
     if (rcalc_get_rankinfo (info->rcalc, broker_rank, &info->rankinfo) < 0) {
-        log_msg ("error fetching rankinfo for rank %d", broker_rank);
+        shell_log_error ("error fetching rankinfo for rank %d", broker_rank);
         goto error;
     }
     info->shell_size = rcalc_total_nodes (info->rcalc);
     info->shell_rank = info->rankinfo.nodeid;
     if (shell->verbose) {
         if (info->shell_rank == 0)
-            log_msg ("0: task_count=%d slot_count=%d "
-                     "cores_per_slot=%d slots_per_node=%d",
-                     info->jobspec->task_count,
-                     info->jobspec->slot_count,
-                     info->jobspec->cores_per_slot,
-                     info->jobspec->slots_per_node);
+            shell_debug ("0: task_count=%d slot_count=%d "
+                         "cores_per_slot=%d slots_per_node=%d",
+                         info->jobspec->task_count,
+                         info->jobspec->slot_count,
+                         info->jobspec->cores_per_slot,
+                         info->jobspec->slots_per_node);
         if (info->rankinfo.ntasks > 1)
-            log_msg ("%d: tasks [%d-%d] on cores %s",
-                     info->shell_rank,
-                     info->rankinfo.global_basis,
-                     info->rankinfo.global_basis + info->rankinfo.ntasks - 1,
-                     info->rankinfo.cores);
+            shell_debug ("%d: tasks [%d-%d] on cores %s",
+                         info->shell_rank,
+                         info->rankinfo.global_basis,
+                         info->rankinfo.global_basis+info->rankinfo.ntasks - 1,
+                         info->rankinfo.cores);
         else
-            log_msg ("%d: tasks [%d] on cores %s",
-                     info->shell_rank,
-                     info->rankinfo.global_basis,
-                     info->rankinfo.cores);
+            shell_debug ("%d: tasks [%d] on cores %s",
+                         info->shell_rank,
+                         info->rankinfo.global_basis,
+                         info->rankinfo.cores);
     }
     return info;
 error:

--- a/src/shell/internal.h
+++ b/src/shell/internal.h
@@ -38,7 +38,7 @@ struct flux_shell {
 
     int rc;
 
-    bool verbose;
+    int verbose;
     bool standalone;
 
     struct aux_item *aux;

--- a/src/shell/jobspec.c
+++ b/src/shell/jobspec.c
@@ -14,8 +14,6 @@
 #include <flux/core.h>
 #include <jansson.h>
 
-#include "src/common/libutil/log.h"
-
 #include "jobspec.h"
 
 struct res_level {

--- a/src/shell/kill.c
+++ b/src/shell/kill.c
@@ -21,8 +21,6 @@
 #include <flux/core.h>
 #include <flux/shell.h>
 
-#include "src/common/libutil/log.h"
-
 #include "builtins.h"
 
 static void kill_cb (flux_t *h, flux_msg_handler_t *mh,
@@ -31,7 +29,7 @@ static void kill_cb (flux_t *h, flux_msg_handler_t *mh,
     flux_shell_t *shell = arg;
     int signum;
     if (flux_msg_unpack (msg, "{s:i}", "signum", &signum) < 0) {
-        log_msg ("kill: ignoring malformed event");
+        shell_warn ("kill: ignoring malformed event");
         return;
     }
     flux_shell_killall (shell, signum);

--- a/src/shell/log.c
+++ b/src/shell/log.c
@@ -1,0 +1,358 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* shell log facility
+ *
+ * Implements logging facility for shell components and plugins
+ * (see shell.h for public interfaces)
+ *
+ * By default all messages at logger.level or below are logged
+ * to stderr. If the shell plugin stack has been initialized
+ * logging messages are additionally sent to any "shell.log"
+ * callbacks, allowing other logging implementations to be loaded
+ * in the shell at runtime.
+ *
+ */
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <jansson.h>
+#include <flux/core.h>
+#include <flux/shell.h>
+
+#include "info.h"
+#include "internal.h"
+#include "log.h"
+
+static struct {
+    FILE *fp;
+    char *prog;
+    int level;
+    int fp_level;
+    int rank;
+    unsigned int active:1;
+    unsigned int exception_logged:1;
+    flux_shell_t *shell;
+} logger;
+
+const char *levelstr[] = {
+    "FATAL", "FATAL", "FATAL", "ERROR", "WARN", "INFO", "DEBUG", "TRACE"
+};
+
+/*  Format a log message in standard form to stream fp */
+static void log_fprintf (FILE *fp,
+                         int level,
+                         const char *component,
+                         const char *file,
+                         int line,
+                         const char *msg)
+{
+    const char *prefix = levelstr [level];
+
+    fprintf (logger.fp, "%s: ", logger.prog);
+    if (prefix)
+        fprintf (logger.fp, "%5s: ", prefix);
+    if (component)
+        fprintf (logger.fp, "%s: ", component);
+
+    /* Log file:line information if level >= FLUX_SHELL_DEBUG */
+    if (logger.level > FLUX_SHELL_NOTICE && file && line > 0)
+        fprintf (logger.fp, "%s:%d: ", file, line);
+
+    fprintf (logger.fp, "%s\n", msg);
+}
+
+static flux_plugin_arg_t *log_msg_args (int level,
+                                        int rank,
+                                        const char *component,
+                                        const char *file,
+                                        int line,
+                                        const char *msg)
+{
+    int rc = -1;
+    int flags = FLUX_PLUGIN_ARG_IN | FLUX_PLUGIN_ARG_UPDATE;
+    flux_plugin_arg_t *args = flux_plugin_arg_create ();
+
+    if (!args)
+        return NULL;
+    if (flux_plugin_arg_pack (args, flags,
+                              "{ s:i s:i s:s }",
+                              "rank", rank,
+                              "level", level,
+                              "message", msg) < 0)
+        goto out;
+    if (component && flux_plugin_arg_pack (args, flags,
+                                           "{ s:s }",
+                                           "component", component) < 0)
+        goto out;
+    if (file && flux_plugin_arg_pack (args, flags,
+                                      "{ s:s s:i }",
+                                      "file", file,
+                                      "line", line) < 0)
+        goto out;
+    rc = 0;
+out:
+    if (rc < 0) {
+        flux_plugin_arg_destroy (args);
+        return NULL;
+    }
+    return args;
+}
+
+
+static int log_event (int level,
+                      int rank,
+                      const char *component,
+                      const char *file,
+                      int line,
+                      const char *msg)
+{
+    int rc = 0;
+    flux_plugin_arg_t *args;
+
+    /*  If plugin stack is not initialized yet, or log level is at or
+     *   below our threshold, log the message to stderr
+     */
+    if (!logger.shell->plugstack || level <= logger.fp_level)
+        log_fprintf (stderr, level, component, file, line, msg);
+
+    /*  If plugin stack is initialized, and we're not actively processing
+     *   another log message then format log message args and call all
+     *   "shell.log" callbacks.
+     */
+    if (logger.shell->plugstack && !logger.active) {
+        logger.active = 1;
+        if (!(args = log_msg_args (level, rank, component, file, line, msg)))
+            return -1;
+        rc = flux_shell_plugstack_call (logger.shell, "shell.log", args);
+        flux_plugin_arg_destroy (args);
+        logger.active = 0;
+    }
+    return rc;
+}
+
+static void send_logmsg (const char *buf, int level, const char *file, int line)
+{
+    const char *component = plugstack_current_name (logger.shell->plugstack);
+    if (logger.rank < 0 && logger.shell->info)
+        logger.rank = logger.shell->info->shell_rank;
+    if (log_event (level, logger.rank, component, file, line, buf) < 0)
+        fprintf (stderr, "%s: log failure: %s\n", logger.prog, buf);
+}
+
+static int errorcat (int errnum, int start, char *buf, size_t len)
+{
+    char *p;
+    int n, size;
+
+    if (errnum == 0)
+        return 0;
+
+    size = len - start;
+    p = buf + start;
+    if ((n = snprintf (p, size, ": %s", strerror (errnum))) >= size)
+        return -1;
+    return n;
+}
+
+/*  Format message, printing an error to stderr on failure
+ *  If errnum > 0, then append result of strerror (errnum).
+ */
+static int msgfmt (char *buf,
+                   size_t len,
+                   int errnum,
+                   const char *fmt,
+                   va_list ap)
+{
+    int rc = vsnprintf (buf, len, fmt, ap);
+    if ((rc < 0 || rc >= len) || errorcat (errnum, rc, buf, len) < 0) {
+        fprintf (stderr,
+                 "%s: unable to format log msg (%s): %s\n",
+                 logger.prog,
+                 fmt,
+                 strerror (errno));
+        return -1;
+    }
+    /*  Clean up trailing newline, pointless here
+     */
+    if (buf[rc-1] == '\n')
+        buf[rc-1] = '\0';
+    return 0;
+}
+
+void flux_shell_log (int level,
+                     const char *file,
+                     int line,
+                     const char *fmt, ...)
+{
+    char buf [4096];
+    va_list ap;
+    va_start (ap, fmt);
+    if (msgfmt (buf, sizeof (buf), 0, fmt, ap) == 0)
+        send_logmsg (buf, level, file, line);
+    va_end (ap);
+}
+
+int flux_shell_err (const char *file,
+                   int line,
+                   int errnum,
+                   const char *fmt, ...)
+{
+    char buf [4096];
+    va_list ap;
+    va_start (ap, fmt);
+    if (msgfmt (buf, sizeof (buf), errnum, fmt, ap) == 0)
+        send_logmsg (buf, FLUX_SHELL_ERROR, file, line);
+    va_end (ap);
+    errno = errnum;
+    return -1;
+}
+
+void flux_shell_fatal (const char *file,
+                       int line,
+                       int errnum,
+                       const char *fmt, ...)
+{
+    flux_shell_t *shell = logger.shell;
+    flux_future_t *f = NULL;
+    char buf [4096];
+    va_list ap;
+
+    va_start (ap, fmt);
+    if (msgfmt (buf, sizeof (buf), errnum, fmt, ap) < 0)
+        sprintf (buf, "flux-shell: fatal error");
+    else
+        send_logmsg (buf, FLUX_SHELL_FATAL, file, line);
+    va_end (ap);
+
+    /*  Attempt to kill any running tasks
+     */
+    flux_shell_killall (shell, SIGKILL);
+
+    /*
+     *  Only need to generate an exception if we have a broker connection
+     *   and are not in standalone mode. O/w, exits immediately below.
+     */
+    if (shell->h && !shell->standalone && !logger.exception_logged) {
+        /*  Raise an exec exception.
+         *  Wait synchronously for response to ensure exception is
+         *   received by job-manager before shell potentially exits.
+         */
+        if (!(f = flux_job_raise (shell->h,
+                                  shell->info->jobid,
+                                  "exec",
+                                  0,
+                                  buf))
+           || flux_future_get (f, NULL) < 0) {
+            fprintf (stderr,
+                     "flux-shell: failed to raise job exception: %s\n",
+                     flux_future_error_string (f));
+        }
+        else
+            shell_log_set_exception_logged ();
+    }
+    exit (1);
+}
+
+void shell_log_set_exception_logged (void)
+{
+    logger.exception_logged = 1;
+}
+
+static int log_setlevel (flux_shell_t *shell, const char *dest, int level)
+{
+    int rc = -1;
+    flux_plugin_arg_t *args;
+
+    if (!shell || !dest) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (!shell->plugstack) {
+        errno = EAGAIN;
+        return -1;
+    }
+    if (!(args = flux_plugin_arg_create ()))
+        return -1;
+    if (flux_plugin_arg_pack (args, FLUX_PLUGIN_ARG_IN,
+                              "{ s:s s:i }",
+                              "dest", dest,
+                              "level", level) < 0)
+        goto out;
+    rc = flux_shell_plugstack_call (shell, "shell.log-setlevel", args);
+out:
+    flux_plugin_arg_destroy (args);
+    return rc;
+}
+
+int flux_shell_log_setlevel (int level, const char *dest)
+{
+    if (level < FLUX_SHELL_FATAL || level > FLUX_SHELL_TRACE) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    /*  Always set internal dispatch level.
+     *  In standalone mode, also set stderr level by default
+     */
+    if (level > logger.level)
+        logger.level = level;
+    if (logger.shell->standalone)
+        logger.fp_level = level;
+
+    if (dest == NULL)
+        return 0;
+
+    /*  If dest is set, then attempt to notify any loaded loggers of
+     *   the severity level change.
+     */
+    if (dest != NULL) {
+        if (strcmp (dest, "stderr") == 0)
+            logger.fp_level = level;
+        else
+            return log_setlevel (logger.shell, dest, level);
+    }
+    return 0;
+}
+
+int shell_log_init (flux_shell_t *shell, const char *progname)
+{
+    logger.shell = shell;
+    logger.level = FLUX_SHELL_NOTICE;
+    logger.fp_level = FLUX_SHELL_NOTICE;
+    logger.active = 0;
+    logger.fp = stderr;
+    logger.rank = -1;
+    if (progname && !(logger.prog = strdup (progname)))
+        return -1;
+    return 0;
+}
+
+int shell_log_reinit (flux_shell_t *shell)
+{
+   if (shell->verbose > 2) {
+        shell_warn ("Ignoring shell verbosity > 2");
+        shell->verbose = 2;
+    }
+    if (flux_shell_log_setlevel (FLUX_SHELL_NOTICE + shell->verbose, "any") < 0)
+        shell_die ("failed to set log level");
+    return 0;
+}
+
+void shell_log_fini (void)
+{
+    logger.shell = NULL;
+    free (logger.prog);
+    fclose (logger.fp);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/shell/log.h
+++ b/src/shell/log.h
@@ -1,0 +1,39 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _SHELL_LOG_H
+#define _SHELL_LOG_H
+
+#include <stdio.h>
+#include <flux/shell.h>
+
+/*  Initialize/finalize shell internal log facility:
+ */
+int shell_log_init (flux_shell_t *shell, const char *progname);
+void shell_log_fini (void);
+
+/*  Reinitialize shell log in case verbosity has changed:
+ */
+int shell_log_reinit (flux_shell_t *shell);
+
+/*  Adjust internal logging level
+ */
+void shell_log_set_level (int level);
+
+/*  Let logging system know an exception is already logged,
+ *   no need to log another.
+ */
+void shell_log_set_exception_logged (void);
+
+#endif /* !_SHELL_RC_H */
+
+/* vi: ts=4 sw=4 expandtab
+ */
+

--- a/src/shell/plugstack.h
+++ b/src/shell/plugstack.h
@@ -61,6 +61,10 @@ int plugstack_call (struct plugstack *st,
                     const char *name,
                     flux_plugin_arg_t *args);
 
+/*  Return currently active plugin name, or NULL if not in plugstack
+ */
+const char * plugstack_current_name (struct plugstack *st);
+
 #endif /* !_SHELL_PLUGSTACK_H */
 
 /* vi: ts=4 sw=4 expandtab

--- a/src/shell/rc.c
+++ b/src/shell/rc.c
@@ -22,10 +22,10 @@
 #include <lauxlib.h>
 #include <lualib.h>
 #include <flux/core.h>
+#include <flux/shell.h>
 
 #include "src/bindings/lua/jansson-lua.h"
 #include "src/bindings/lua/lutil.h"
-#include "src/common/libutil/log.h"
 #include "internal.h"
 #include "info.h"
 
@@ -149,13 +149,13 @@ static int lua_plugin_cb (flux_plugin_t *p,
     struct lua_plugin *lp = flux_plugin_aux_get (p, "lua.plugin");
     struct lua_plugref *ref = data;
     if (!ref) {
-        log_msg ("lua plugin: %s: no ref for topic %s", lp->name, topic);
+        shell_log_error ("lua plugin: %s: no ref for topic %s", lp->name, topic);
         return 0;
     }
     lua_rawgeti (L, LUA_REGISTRYINDEX, ref->lua_ref);
     lua_pushstring (L, topic);
     if (lua_pcall (L, 1, LUA_MULTRET, 0) != 0) {
-        log_msg ("lua plugin %s: %s", lp->name, lua_tostring (L, -1));
+        shell_log_error ("lua plugin %s: %s", lp->name, lua_tostring (L, -1));
         return -1;
     }
     if (lua_gettop (L) > 0) {
@@ -323,11 +323,11 @@ static int shell_run_rcfile (flux_shell_t *shell,
     /*  Compile rcfile onto stack
      */
     if (luaL_loadfile (L, rcfile) != 0) {
-        log_msg ("%s: %s", rcfile, lua_tostring (L, -1));
+        shell_log_error ("%s: %s", rcfile, lua_tostring (L, -1));
         return -1;
     }
     if (lua_pcall (L, 0, 0, 0) != 0) {
-        log_msg ("%s", lua_tostring (L, -1));
+        shell_log_error ("%s", lua_tostring (L, -1));
         return -1;
     }
     file_stack_pop ();

--- a/src/shell/rc.c
+++ b/src/shell/rc.c
@@ -87,7 +87,8 @@ static void lua_plugref_destroy (struct lua_plugref *ref)
 {
     if (ref) {
         free (ref->topic);
-        luaL_unref (L, LUA_REGISTRYINDEX, ref->lua_ref);
+        if (L)
+            luaL_unref (L, LUA_REGISTRYINDEX, ref->lua_ref);
         free (ref);
     }
 }
@@ -792,6 +793,7 @@ int shell_rc_close (void)
     rc_shell = NULL;
     if (L)
         lua_close (L);
+    L = NULL;
 
     /*  Destroy file stack
      */

--- a/src/shell/shell.c
+++ b/src/shell/shell.c
@@ -781,6 +781,10 @@ int main (int argc, char *argv[])
     if (flux_shell_getopt_unpack (&shell, "verbose", "i", &shell.verbose) < 0)
         shell_die ("failed to parse attributes.system.shell.verbose");
 
+    /* Reinitialize log facility with new verbosity/shell.info */
+    if (shell_log_reinit (&shell) < 0)
+        shell_die_errno ("shell_log_reinit");
+
     /* Now that verbosity may have changed, log shell startup info */
     shell_log_info (&shell);
 

--- a/src/shell/shell.c
+++ b/src/shell/shell.c
@@ -235,6 +235,8 @@ static void shell_connect_flux (flux_shell_t *shell)
             log_err ("error fetching broker rank");
         shell->broker_rank = rank;
     }
+    if (plugstack_call (shell->plugstack, "shell.connect", NULL) < 0)
+        log_err ("shell.connect");
 }
 
 flux_shell_t *flux_plugin_get_shell (flux_plugin_t *p)

--- a/src/shell/shell.c
+++ b/src/shell/shell.c
@@ -652,29 +652,114 @@ out:
     return (rc);
 }
 
+static void eventlog_cb (flux_future_t *f, void *arg)
+{
+    json_t *o = NULL;
+    json_t *context = NULL;
+    const char *name;
+    const char *entry;
+
+    if (flux_job_event_watch_get (f, &entry) < 0) {
+        if (errno == ENODATA)
+            return;
+        shell_log_errno ("flux_job_event_watch_get");
+        return;
+    }
+    if (!(o = eventlog_entry_decode (entry))) {
+        shell_log_errno ("eventlog_entry_decode: %s", entry);
+        return;
+    }
+    if (eventlog_entry_parse (o, NULL, &name, &context) < 0) {
+        shell_log_errno ("eventlog_entry_parse: %s", entry);
+        return;
+    }
+    if (strcmp (name, "exception") == 0) {
+        const char *type;
+        int severity;
+        const char *note = NULL;
+        if (json_unpack (context, "{s:s s:i s?s}",
+                         "type", &type,
+                         "severity", &severity,
+                         "note", &note) < 0) {
+            shell_log_errno ("exception event unpack");
+            return;
+        }
+        shell_log_set_exception_logged ();
+        shell_die ("job.exception during init barrier, aborting");
+    }
+    json_decref (o);
+    flux_future_reset (f);
+}
+
+static void barrier_cb (flux_future_t *f, void *arg)
+{
+    flux_reactor_t *r = flux_future_get_reactor (f);
+    if (flux_future_get (f, NULL) < 0) {
+        shell_log_errno ("flux_future_get: shell_barrier");
+        flux_reactor_stop_error (r);
+    }
+    else {
+        shell_trace ("shell barrier complete");
+        flux_reactor_stop (r);
+    }
+}
+
 static int shell_barrier (flux_shell_t *shell, const char *name)
 {
-    flux_future_t *f;
+    flux_future_t *log_f = NULL;
+    flux_future_t *f = NULL;
+    flux_t *h = NULL;
+    flux_jobid_t id;
     char fqname[128];
+    int rc = -1;
 
     if (shell->standalone || shell->info->shell_size == 1)
         return 0; // NO-OP
+    id = shell->info->jobid;
     if (snprintf (fqname,
                   sizeof (fqname),
                   "shell-%ju-%s",
-                  (uintmax_t)shell->info->jobid,
+                  (uintmax_t) id,
                    name) >= sizeof (fqname)) {
         errno = EINVAL;
         return -1;
     }
-    if (!(f = flux_barrier (shell->h, fqname, shell->info->shell_size)))
-        return -1;
-    if (flux_future_get (f, NULL) < 0) {
-        flux_future_destroy (f);
-        return -1;
+    /*  Clone shell flux handle so that only barrier and eventlog watch
+     *   messages are dispatched in the temporary reactor call here.
+     *   This allows messages from other shell services to be requeued
+     *   for the real reactor in main().
+     */
+    if (!(h = flux_clone (shell->h)))
+        shell_die_errno ("flux_handle_clone");
+
+    if (!(f = flux_barrier (h, fqname, shell->info->shell_size))) {
+        shell_log_errno ("flux_barrier");
+        goto out;
     }
+    if (!(log_f = flux_job_event_watch (h, id, "eventlog", 0))) {
+        shell_log_errno ("flux_job_event_watch");
+        goto out;
+    }
+    if (flux_future_then (log_f, -1., eventlog_cb, NULL) < 0
+        ||  flux_future_then (f, -1., barrier_cb, NULL) < 0) {
+        shell_log_errno ("flux_future_then");
+        goto out;
+    }
+    if (flux_future_then (f, -1., barrier_cb, shell) < 0) {
+        shell_log_errno ("flux_future_then");
+        goto out;
+    }
+    if (flux_reactor_run (flux_get_reactor (h), 0) >= 0)
+        rc = 0;
+    shell_trace ("exited barrier with rc = %d", rc);
+out:
+    flux_job_event_watch_cancel (log_f);
+    flux_future_destroy (log_f);
     flux_future_destroy (f);
-    return 0;
+
+    /*  Close the cloned handle */
+    flux_close (h);
+    return rc;
 }
 
 static int shell_init (flux_shell_t *shell)

--- a/src/shell/shell.c
+++ b/src/shell/shell.c
@@ -341,7 +341,7 @@ int flux_shell_get_info (flux_shell_t *shell, char **json_str)
         errno = EINVAL;
         return -1;
     }
-    if (!(o = json_pack_ex (&err, 0, "{ s:I s:i s:i s:i s:O s:{ s:b s:b }}",
+    if (!(o = json_pack_ex (&err, 0, "{ s:I s:i s:i s:i s:O s:{ s:i s:b }}",
                            "jobid", shell->info->jobid,
                            "rank",  shell->info->shell_rank,
                            "size",  shell->info->shell_size,
@@ -751,7 +751,7 @@ int main (int argc, char *argv[])
         exit (1);
 
     /* Set verbose flag if set in attributes.system.shell.verbose */
-    if (flux_shell_getopt_unpack (&shell, "verbose", "b", &shell.verbose) < 0)
+    if (flux_shell_getopt_unpack (&shell, "verbose", "i", &shell.verbose) < 0)
         log_msg_exit ("failed to parse attributes.system.shell.verbose");
 
     /* Register service on the leader shell.

--- a/src/shell/shell.c
+++ b/src/shell/shell.c
@@ -244,6 +244,11 @@ flux_shell_t *flux_plugin_get_shell (flux_plugin_t *p)
     return flux_plugin_aux_get (p, "flux::shell");
 }
 
+flux_t *flux_shell_get_flux (flux_shell_t *shell)
+{
+    return shell->h;
+}
+
 int flux_shell_aux_set (flux_shell_t *shell,
                         const char *key,
                         void *val,

--- a/src/shell/shell.c
+++ b/src/shell/shell.c
@@ -21,10 +21,10 @@
 #include <jansson.h>
 #include <czmq.h>
 #include <flux/core.h>
+#include <flux/shell.h>
 
 #include "src/common/liboptparse/optparse.h"
 #include "src/common/libeventlog/eventlog.h"
-#include "src/common/libutil/log.h"
 #include "src/common/libutil/intree.h"
 
 #include "internal.h"
@@ -33,6 +33,7 @@
 #include "svc.h"
 #include "task.h"
 #include "rc.h"
+#include "log.h"
 
 static char *shell_name = "flux-shell";
 static const char *shell_usage = "[OPTIONS] JOBID";
@@ -63,14 +64,10 @@ static int parse_jobid (const char *optarg, flux_jobid_t *jobid)
 
     errno = 0;
     i = strtoull (optarg, &endptr, 10);
-    if (errno != 0) {
-        log_err ("error parsing jobid");
-        return -1;
-    }
-    if (*endptr != '\0') {
-        log_msg ("error parsing jobid: garbage follows number");
-        return -1;
-    }
+    if (errno != 0)
+        return shell_log_errno ("error parsing jobid");
+    if (*endptr != '\0')
+        return shell_log_errno ("error parsing jobid: garbage follows number");
     *jobid = i;
     return 0;
 }
@@ -79,16 +76,16 @@ static void task_completion_cb (struct shell_task *task, void *arg)
 {
     struct flux_shell *shell = arg;
 
-    if (shell->verbose)
-        log_msg ("task %d complete status=%d", task->rank, task->rc);
+    shell_debug ("task %d complete status=%d", task->rank, task->rc);
 
     shell->current_task = task;
     if (plugstack_call (shell->plugstack, "task.exit", NULL) < 0)
-        log_err ("task.exit plugin(s) failed");
+        shell_log_errno ("task.exit plugin(s) failed");
     shell->current_task = NULL;
 
     if (flux_shell_remove_completion_ref (shell, "task%d", task->rank) < 0)
-        log_err ("failed to remove task%d completion reference", task->rank);
+        shell_log_errno ("failed to remove task%d completion reference",
+                         task->rank);
 }
 
 int flux_shell_setopt (flux_shell_t *shell,
@@ -172,7 +169,7 @@ int flux_shell_getopt_unpack (flux_shell_t *shell,
      *   attributes.system.shell.options which may not be an object or array.
      */
     if ((rc = json_vunpack_ex (o, &err, JSON_DECODE_ANY, fmt, ap)) < 0)
-        log_msg ("shell_getopt: unpack error: %s", err.text);
+        shell_log_error ("shell_getopt: unpack error: %s", err.text);
     else
         rc = 1;
     va_end (ap);
@@ -185,11 +182,11 @@ static void shell_parse_cmdline (flux_shell_t *shell, int argc, char *argv[])
     optparse_t *p = optparse_create (shell_name);
 
     if (p == NULL)
-        log_msg_exit ("optparse_create");
+        shell_die ("optparse_create");
     if (optparse_add_option_table (p, shell_opts) != OPTPARSE_SUCCESS)
-        log_msg_exit ("optparse_add_option_table failed");
+        shell_die ("optparse_add_option_table failed");
     if (optparse_set (p, OPTPARSE_USAGE, shell_usage) != OPTPARSE_SUCCESS)
-        log_msg_exit ("optparse_set usage failed");
+        shell_die ("optparse_set usage failed");
     if ((optindex = optparse_parse_args (p, argc, argv)) < 0)
         exit (1);
 
@@ -209,11 +206,12 @@ static void shell_parse_cmdline (flux_shell_t *shell, int argc, char *argv[])
         if (  !optparse_hasopt (p, "jobspec")
            || !optparse_hasopt (p, "resources")
            || !optparse_hasopt (p, "broker-rank"))
-            log_err_exit ("standalone mode requires --jobspec, "
-                          "--resources and --broker-rank");
+            shell_die ("standalone mode requires --jobspec, "
+                       "--resources and --broker-rank");
     }
 
-    shell->verbose = optparse_getopt (p, "verbose", NULL);
+    if ((shell->verbose = optparse_getopt (p, "verbose", NULL)))
+        shell_set_verbose (shell->verbose);
     shell->broker_rank = optparse_get_int (p, "broker-rank", -1);
     shell->p = p;
 }
@@ -221,7 +219,7 @@ static void shell_parse_cmdline (flux_shell_t *shell, int argc, char *argv[])
 static void shell_connect_flux (flux_shell_t *shell)
 {
     if (!(shell->h = flux_open (shell->standalone ? "loop://" : NULL, 0)))
-        log_err_exit ("flux_open");
+        shell_die_errno ("flux_open");
 
     /*  Set reactor for flux handle to our custom created reactor.
      */
@@ -232,11 +230,11 @@ static void shell_connect_flux (flux_shell_t *shell)
     if (shell->broker_rank < 0) {
         uint32_t rank;
         if (flux_get_rank (shell->h, &rank) < 0)
-            log_err ("error fetching broker rank");
+            shell_log_errno ("error fetching broker rank");
         shell->broker_rank = rank;
     }
     if (plugstack_call (shell->plugstack, "shell.connect", NULL) < 0)
-        log_err ("shell.connect");
+        shell_log_errno ("shell.connect");
 }
 
 flux_shell_t *flux_plugin_get_shell (flux_plugin_t *p)
@@ -406,12 +404,12 @@ int flux_shell_add_event_handler (flux_shell_t *shell,
                   "shell-%ju.%s",
                   (uintmax_t) shell->jobid,
                   subtopic) < 0) {
-        log_err ("add_event: asprintf");
+        shell_log_errno ("add_event: asprintf");
         return -1;
     }
     match.topic_glob = topic;
     if (!(mh = flux_msg_handler_create (shell->h, match, cb, arg))) {
-        log_err ("add_event: flux_msg_handler_create");
+        shell_log_errno ("add_event: flux_msg_handler_create");
         free (topic);
         return -1;
     }
@@ -481,9 +479,9 @@ static void shell_events_subscribe (flux_shell_t *shell)
     if (shell->h) {
         char *topic;
         if (asprintf (&topic, "shell-%ju.", (uintmax_t) shell->jobid) < 0)
-            log_err_exit ("shell subscribe: asprintf");
+            shell_die_errno ("shell subscribe: asprintf");
         if (flux_event_subscribe (shell->h, topic) < 0)
-            log_err_exit ("shell subscribe: flux_event_subscribe");
+            shell_die_errno ("shell subscribe: flux_event_subscribe");
         free (topic);
     }
 }
@@ -509,7 +507,10 @@ static void shell_finalize (flux_shell_t *shell)
         zlist_destroy (&shell->tasks);
     }
     aux_destroy (&shell->aux);
+
     plugstack_destroy (shell->plugstack);
+    shell->plugstack = NULL;
+
     shell_svc_destroy (shell->svc);
     shell_info_destroy (shell->info);
 
@@ -548,20 +549,20 @@ static void shell_initialize (flux_shell_t *shell)
 
     memset (shell, 0, sizeof (struct flux_shell));
     if (!(shell->completion_refs = zhashx_new ()))
-        log_err_exit ("zhashx_new");
+        shell_die_errno ("zhashx_new");
     zhashx_set_destructor (shell->completion_refs, item_free);
 
     if (!(shell->plugstack = plugstack_create ()))
-        log_err_exit ("plugstack_create");
+        shell_die_errno ("plugstack_create");
 
     if (plugstack_plugin_aux_set (shell->plugstack, "flux::shell", shell) < 0)
-        log_err_exit ("plugstack_plugin_aux_set");
+        shell_die_errno ("plugstack_plugin_aux_set");
 
     if (plugstack_set_searchpath (shell->plugstack, pluginpath) < 0)
-        log_err_exit ("plugstack_set_searchpath");
+        shell_die_errno ("plugstack_set_searchpath");
 
     if (shell_load_builtins (shell) < 0)
-        log_err_exit ("shell_load_builtins");
+        shell_die_errno ("shell_load_builtins");
 }
 
 void flux_shell_killall (flux_shell_t *shell, int signum)
@@ -572,7 +573,7 @@ void flux_shell_killall (flux_shell_t *shell, int signum)
     task = zlist_first (shell->tasks);
     while (task) {
         if (shell_task_kill (task, signum) < 0)
-            log_err ("kill task %d: signal %d", task->rank, signum);
+            shell_log_errno ("kill task %d: signal %d", task->rank, signum);
         task = zlist_next (shell->tasks);
     }
 }
@@ -683,14 +684,13 @@ static int shell_init (flux_shell_t *shell)
     /*  Only try loading initrc if the file is readable or required:
      */
     if (access (rcfile, R_OK) == 0 || required) {
-        if (shell->verbose)
-            log_msg ("Loading %s", rcfile);
+        shell_debug ("Loading %s", rcfile);
 
         if (shell_rc (shell, rcfile) < 0) {
-            if (errno)
-                log_err_exit ("loading rc file %s", rcfile);
-            else
-                log_msg_exit ("failed to load rc file %s", rcfile);
+            shell_die ("loading rc file %s%s%s",
+                       rcfile,
+                       errno ? ": " : "",
+                       errno ? strerror (errno) : "");
         }
     }
 
@@ -707,7 +707,7 @@ static void shell_task_exec (flux_shell_task_t *task, void *arg)
     flux_shell_t *shell = arg;
     shell->current_task->in_pre_exec = true;
     if (plugstack_call (shell->plugstack, "task.exec", NULL) < 0)
-        log_err ("task.exec plugin(s) failed");
+        shell_log_errno ("task.exec plugin(s) failed");
 }
 
 static int shell_task_forked (flux_shell_t *shell)
@@ -725,7 +725,7 @@ int main (int argc, char *argv[])
     flux_shell_t shell;
     int i;
 
-    log_init (shell_name);
+    shell_log_init (&shell, shell_name);
 
     shell_initialize (&shell);
 
@@ -734,7 +734,7 @@ int main (int argc, char *argv[])
     /* Get reactor capable of monitoring subprocesses.
      */
     if (!(shell.r = flux_reactor_create (FLUX_REACTOR_SIGCHLD)))
-        log_err_exit ("flux_reactor_create");
+        shell_die_errno ("flux_reactor_create");
 
     /* Connect to broker, or if standalone, open loopback connector.
      */
@@ -752,32 +752,32 @@ int main (int argc, char *argv[])
 
     /* Set verbose flag if set in attributes.system.shell.verbose */
     if (flux_shell_getopt_unpack (&shell, "verbose", "i", &shell.verbose) < 0)
-        log_msg_exit ("failed to parse attributes.system.shell.verbose");
+        shell_die ("failed to parse attributes.system.shell.verbose");
 
     /* Register service on the leader shell.
      */
     if (!(shell.svc = shell_svc_create (&shell)))
-        log_err_exit ("shell_svc_create");
+        shell_die ("shell_svc_create");
 
     /* Call shell initialization routines and "shell_init" plugins.
      */
     if (shell_init (&shell) < 0)
-        log_err_exit ("shell_prepare");
+        shell_die_errno ("shell_prepare");
 
     /* Barrier to ensure initialization has completed across all shells.
      */
     if (shell_barrier (&shell, "init") < 0)
-        log_err_exit ("shell_barrier");
+        shell_die_errno ("shell_barrier");
 
     /* Create tasks
      */
     if (!(shell.tasks = zlist_new ()))
-        log_msg_exit ("zlist_new failed");
+        shell_die ("zlist_new failed");
     for (i = 0; i < shell.info->rankinfo.ntasks; i++) {
         struct shell_task *task;
 
         if (!(task = shell_task_create (shell.info, i)))
-            log_err_exit ("shell_task_create index=%d", i);
+            shell_die ("shell_task_create index=%d", i);
 
         task->pre_exec_cb = shell_task_exec;
         task->pre_exec_arg = &shell;
@@ -786,21 +786,21 @@ int main (int argc, char *argv[])
         /*  Call all plugin task_init callbacks:
          */
         if (shell_task_init (&shell) < 0)
-            log_err_exit ("shell_task_init");
+            shell_die ("failed to initialize taskid=%d", i);
 
         if (shell_task_start (task, shell.r, task_completion_cb, &shell) < 0)
-            log_err_exit ("shell_task_start index=%d", i);
+            shell_die ("failed to start taskid=%d", i);
 
         if (zlist_append (shell.tasks, task) < 0)
-            log_msg_exit ("zlist_append failed");
+            shell_die ("zlist_append failed");
 
         if (flux_shell_add_completion_ref (&shell, "task%d", task->rank) < 0)
-            log_msg_exit ("flux_shell_add_completion_ref");
+            shell_die ("flux_shell_add_completion_ref");
 
         /*  Call all plugin task_fork callbacks:
          */
         if (shell_task_forked (&shell) < 0)
-            log_err_exit ("shell_task_forked");
+            shell_die ("shell_task_forked");
     }
     /*  Reset current task since we've left task-specific context:
      */
@@ -810,10 +810,10 @@ int main (int argc, char *argv[])
      * Exits when all completion references released
      */
     if (flux_reactor_run (shell.r, 0) < 0)
-        log_err ("flux_reactor_run");
+        shell_log_errno ("flux_reactor_run");
 
     if (shell_exit (&shell) < 0) {
-        log_msg ("shell_exit callback(s) failed");
+        shell_log_error ("shell_exit callback(s) failed");
         /* Preset shell.rc to failure so failure here is ensured
          *  to cause shell to exit with non-zero exit code.
          * XXX: this should be replaced with more general fatal
@@ -825,12 +825,11 @@ int main (int argc, char *argv[])
     shell_finalize (&shell);
 
     if (shell_rc_close ())
-        log_err ("shell_rc_close");
+        shell_log_errno ("shell_rc_close");
 
-    if (shell.verbose)
-        log_msg ("exit %d", shell.rc);
+    shell_debug ("exit %d", shell.rc);
 
-    log_fini ();
+    shell_log_fini ();
     exit (shell.rc);
 }
 

--- a/src/shell/shell.c
+++ b/src/shell/shell.c
@@ -582,7 +582,7 @@ void flux_shell_killall (flux_shell_t *shell, int signum)
         return;
     task = zlist_first (shell->tasks);
     while (task) {
-        if (shell_task_kill (task, signum) < 0)
+        if (shell_task_running (task) && shell_task_kill (task, signum) < 0)
             shell_log_errno ("kill task %d: signal %d", task->rank, signum);
         task = zlist_next (shell->tasks);
     }

--- a/src/shell/shell.h
+++ b/src/shell/shell.h
@@ -29,6 +29,10 @@ typedef void (*flux_shell_task_io_f) (flux_shell_task_t *task,
  */
 flux_shell_t * flux_plugin_get_shell (flux_plugin_t *p);
 
+/*  Get flux handle from shell
+ */
+flux_t * flux_shell_get_flux (flux_shell_t *shell);
+
 /* flux_shell_t interface */
 
 int flux_shell_aux_set (flux_shell_t *shell,

--- a/src/shell/shell.h
+++ b/src/shell/shell.h
@@ -226,6 +226,93 @@ int flux_shell_task_channel_subscribe (flux_shell_task_t *task,
                                        flux_shell_task_io_f cb,
                                        void *arg);
 
+/* shell logging functions:
+ *
+ * Logging levels are remapped from Internet RFC 5452 severity levels,
+ *  where here the enumeration identifiers are renamed to make sense
+ *  in the context of shell logging.
+ */
+enum {
+    FLUX_SHELL_FATAL  = 0,  /* LOG_EMERG   */
+    /* Level 1 Reserved */  /* LOG_ALERT   */
+    /* Level 2 Reserved */  /* LOG_CRIT    */
+    FLUX_SHELL_ERROR  = 3,  /* LOG_ERR     */
+    FLUX_SHELL_WARN   = 4,  /* LOG_WARNING */
+    FLUX_SHELL_NOTICE = 5,  /* LOG_NOTICE  */
+    FLUX_SHELL_DEBUG  = 6,  /* LOG_INFO    */
+    FLUX_SHELL_TRACE  = 7,  /* LOG_DEBUG   */
+};
+
+#define shell_trace(...) \
+    flux_shell_log (FLUX_SHELL_TRACE, __FILE__, __LINE__, __VA_ARGS__)
+
+#define shell_debug(...) \
+    flux_shell_log (FLUX_SHELL_DEBUG, __FILE__, __LINE__, __VA_ARGS__)
+
+#define shell_log(...) \
+    flux_shell_log (FLUX_SHELL_NOTICE, __FILE__, __LINE__, __VA_ARGS__)
+
+#define shell_warn(...) \
+    flux_shell_log (FLUX_SHELL_WARN, __FILE__, __LINE__, __VA_ARGS__)
+
+#define shell_log_error(...) \
+    flux_shell_log (FLUX_SHELL_ERROR, __FILE__, __LINE__, __VA_ARGS__)
+
+#define shell_log_errn(errn, ...) \
+    flux_shell_err (__FILE__, __LINE__, errn, __VA_ARGS__)
+
+#define shell_log_errno(...) \
+    flux_shell_err (__FILE__, __LINE__, errno, __VA_ARGS__)
+
+#define shell_die(...) \
+    flux_shell_fatal (__FILE__, __LINE__, 0, __VA_ARGS__)
+
+#define shell_die_errno(...) \
+    flux_shell_fatal (__FILE__, __LINE__, errno, __VA_ARGS__)
+
+#define shell_set_verbose(n) \
+    flux_shell_log_setlevel(FLUX_SHELL_NOTICE+n, NULL)
+
+#define shell_set_quiet(n) \
+    flux_shell_log_setlevel(FLUX_SHELL_NOTICE-n, NULL)
+
+/*  Log a message at level to all registered loggers at level or above
+ */
+void flux_shell_log (int level,
+                     const char *file,
+                     int line,
+                     const char *fmt, ...)
+                     __attribute__ ((format (printf, 4, 5)));
+
+/*  Log a message at FLUX_SHELL_ERROR level, additionally appending the
+ *   result of strerror (errnum) for convenience.
+ *
+ *  Returns -1 with errno = errnum, so that the function can be used as
+ *   return flux_shell_err (...);
+ */
+int flux_shell_err (const char *file,
+                    int line,
+                    int errnum,
+                    const char *fmt, ...)
+                    __attribute__ ((format (printf, 4, 5)));
+
+/*  Log a message at FLUX_SHELL_FATAL level and schedule termination of
+ *   the job shell. May generate an exception if tasks are already
+ *   running.
+ */
+void flux_shell_fatal (const char *file,
+                      int line,
+                      int errnum,
+                      const char *fmt, ...)
+                      __attribute__ ((format (printf, 4, 5)));
+
+/*  Set default severity of logging destination 'dest' to level.
+ *   If dest == NULL then set the internal log dispatch level --
+ *   (i.e. no messages above severity level will be logged to any
+ *    log destination)
+ */
+int flux_shell_log_setlevel (int level, const char *dest);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/shell/signals.c
+++ b/src/shell/signals.c
@@ -25,7 +25,6 @@
 #include <flux/core.h>
 #include <flux/shell.h>
 
-#include "src/common/libutil/log.h"
 #include "internal.h"
 #include "builtins.h"
 
@@ -34,8 +33,7 @@ static void signal_cb (flux_reactor_t *r, flux_watcher_t *w,
 {
     flux_shell_t *shell = arg;
     int sig = flux_signal_watcher_get_signum (w);
-    if (shell->verbose)
-        log_msg ("forwarding signal %d to tasks", sig);
+    shell_debug ("forwarding signal %d to tasks", sig);
     flux_shell_killall (shell, sig);
 }
 
@@ -60,7 +58,7 @@ static int signals_init (flux_plugin_t *p,
         return -1;
     /* forward local SIGINT, SIGTERM to tasks */
     if (trap_signal (shell, SIGINT) < 0 || trap_signal (shell, SIGTERM) < 0)
-        log_err ("failed to set up signal watchers");
+        shell_log_errno ("failed to set up signal watchers");
     return 0;
 }
 

--- a/src/shell/task.c
+++ b/src/shell/task.c
@@ -208,6 +208,13 @@ int shell_task_start (struct shell_task *task,
     return 0;
 }
 
+int shell_task_running (struct shell_task *task)
+{
+    if (!task->proc)
+        return 0;
+    return (flux_subprocess_state (task->proc) == FLUX_SUBPROCESS_RUNNING);
+}
+
 int shell_task_kill (struct shell_task *task, int signum)
 {
     int rc;

--- a/src/shell/task.h
+++ b/src/shell/task.h
@@ -59,6 +59,9 @@ int shell_task_start (struct shell_task *task,
 /* Send signal `signum` to shell task */
 int shell_task_kill (struct shell_task *task, int signum);
 
+/* Return 1 if `task` is running, 0 otherwise */
+int shell_task_running (struct shell_task *task);
+
 #endif /* !SHELL_TASK_H */
 
 /*

--- a/src/shell/test/plugstack.c
+++ b/src/shell/test/plugstack.c
@@ -39,6 +39,31 @@ static int bar (flux_plugin_t *p, const char *s,
                                  "{s:s}", "result", "called bar");
 }
 
+static int next_level (flux_plugin_t *p, const char *s,
+                       flux_plugin_arg_t *args, void *arg)
+{
+    struct plugstack *st = arg;
+    return flux_plugin_arg_pack (args,
+                                 FLUX_PLUGIN_ARG_OUT|FLUX_PLUGIN_ARG_UPDATE,
+                                 "{s:s}",
+                                 "next_name", plugstack_current_name (st));
+}
+
+static int check_name (flux_plugin_t *p, const char *s,
+                       flux_plugin_arg_t *args, void *arg)
+{
+    struct plugstack *st = arg;
+    int rc = flux_plugin_arg_pack (args,
+                                   FLUX_PLUGIN_ARG_OUT,
+                                   "{s:s}",
+                                   "name", plugstack_current_name (st));
+    ok (rc == 0,
+        "in check_name: flux_plugin_arg_pack worked");
+
+    /* Check a recursive call to plugstack_call () */
+    return plugstack_call (st, "next.level", args);
+}
+
 void test_invalid_args (struct plugstack *st, flux_plugin_t *p)
 {
     ok (plugstack_push (NULL, p) < 0 && errno == EINVAL,
@@ -60,6 +85,8 @@ void test_invalid_args (struct plugstack *st, flux_plugin_t *p)
         "plugstack_plugin_aux_set (NULL, ...) returns EINVAL");
     ok (plugstack_plugin_aux_set (st, NULL, NULL) < 0 && errno == EINVAL,
         "plugstack_plugin_aux_set (NULL, ...) returns EINVAL");
+    ok (plugstack_current_name (NULL) == NULL && errno == EINVAL,
+        "plugstack_current_name (NULL) returns EINVAL");
 }
 
 void test_load (void)
@@ -157,10 +184,14 @@ int main (int argc, char **argv)
 
     ok (flux_plugin_add_handler (p1, "callback", foo, NULL) == 0,
         "flux_plugin_add_handler (p1, 'callback', &foo)");
+    ok (flux_plugin_add_handler (p1, "check.name", check_name, st) == 0,
+        "flux_plugin_add_handler (p1, 'check.name', &check_name)");
     ok (flux_plugin_add_handler (p2, "callback", bar, NULL) == 0,
         "flux_plugin_add_handler (p2, 'callback', &bar)");
     ok (flux_plugin_add_handler (p3, "callback", bar, NULL) == 0,
         "flux_plugin_add_handler (p3, 'callback', &bar)");
+    ok (flux_plugin_add_handler (p3, "next.level", next_level, st) == 0,
+        "flux_plugin_add_handler (p3, 'next.level', &next_level)");
 
     if (!(args = flux_plugin_arg_create ()))
         BAIL_OUT ("flux_plugin_args_create");
@@ -177,7 +208,7 @@ int main (int argc, char **argv)
     ok (called_foo == 1,
         "called foo() one time");
 
-    called_foo = 0;
+   called_foo = 0;
     called_bar = 0;
     ok (plugstack_push (st, p3) == 0,
         "plugstack_push (st, p3)");
@@ -190,6 +221,26 @@ int main (int argc, char **argv)
         "flux_plugin_arg_unpack");
     is (result, "called bar",
         "plugstack_call called bar() last");
+
+    /*  Check plugin_current_name() and recursive plugstack_call()
+     *   between two plugins.
+     */
+    ok (plugstack_call (st, "check.name", args) == 0,
+        "plugstack_call (st, 'check.name')");
+    ok (flux_plugin_arg_unpack (args, FLUX_PLUGIN_ARG_OUT,
+                                "{s:s}", "name", &result) == 0,
+        "flux_plugin_arg_unpack");
+    is (result, "mikey",
+        "plugstack_current_name() worked");
+
+    ok (flux_plugin_arg_unpack (args, FLUX_PLUGIN_ARG_OUT,
+                                "{s:s}", "next_name", &result) == 0,
+        "flux_plugin_arg_unpack");
+    is (result, "joey",
+        "plugstack_current_name() worked");
+
+    ok (plugstack_current_name (st) == NULL,
+        "plugstack_current_name() outside of plugstack_call returns NULL");
 
     called_foo = 0;
     called_bar = 0;

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -240,7 +240,8 @@ check_LTLIBRARIES = \
 	shell/plugins/dummy.la \
 	shell/plugins/conftest.la \
 	shell/plugins/invalid-args.la \
-	shell/plugins/getopt.la
+	shell/plugins/getopt.la \
+	shell/plugins/log.la
 
 dist_check_DATA = \
 	hwloc-data/sierra2/0.xml \
@@ -486,5 +487,12 @@ shell_plugins_getopt_la_SOURCES = shell/plugins/getopt.c
 shell_plugins_getopt_la_CPPFLAGS = $(test_cppflags)
 shell_plugins_getopt_la_LDFLAGS = -module -rpath /nowhere
 shell_plugins_getopt_la_LIBADD = \
+	$(top_builddir)/src/common/libtap/libtap.la \
+        $(top_builddir)/src/common/libflux-core.la
+
+shell_plugins_log_la_SOURCES = shell/plugins/log.c
+shell_plugins_log_la_CPPFLAGS = $(test_cppflags)
+shell_plugins_log_la_LDFLAGS = -module -rpath /nowhere
+shell_plugins_log_la_LIBADD = \
 	$(top_builddir)/src/common/libtap/libtap.la \
         $(top_builddir)/src/common/libflux-core.la

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -112,6 +112,7 @@ TESTSCRIPTS = \
 	t2605-job-shell-output-redirection-standalone.t \
 	t2606-job-shell-output-redirection.t \
 	t2607-job-shell-input.t \
+	t2608-job-shell-log.t \
 	t2700-mini-cmd.t \
 	t3000-mpi-basic.t \
 	t3001-mpi-personalities.t \

--- a/t/shell/plugins/log.c
+++ b/t/shell/plugins/log.c
@@ -1,0 +1,91 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdio.h>
+#include <stdarg.h>
+#include <jansson.h>
+#include <flux/core.h>
+#include <flux/shell.h>
+
+#include "src/common/libtap/tap.h"
+
+static int get_shell_rank (flux_shell_t *shell)
+{
+    int rank = -1;
+    char *json_str = NULL;
+    json_t *o = NULL;
+
+    if (flux_shell_get_info (shell, &json_str) < 0
+        || !(o = json_loads (json_str, 0, NULL))
+        || json_unpack (o, "{s:i}", "rank", &rank) < 0)
+        shell_log_errno ("failed to get shell rank");
+    json_decref (o);
+    free (json_str);
+    return rank;
+}
+
+static int check_shell_log (flux_plugin_t *p,
+                            const char *topic,
+                            flux_plugin_arg_t *args,
+                            void *data)
+{
+    flux_shell_t *shell = flux_plugin_get_shell (p);
+    int shell_rank;
+    const char *s = NULL;
+
+    if (strcmp (topic, "shell.log") == 0)
+        return 0;
+
+    shell_rank = get_shell_rank (shell);
+    if (flux_shell_getopt_unpack (shell, "log-fatal-error", "s", &s) < 0)
+        shell_die ("error parsing log-fatal-error");
+
+    if (s) {
+        if (strcmp (s, topic) == 0 && shell_rank == 1)
+            shell_die ("log-fatal-error requested!");
+        /* For log-fatal-error test, avoid the remaining log testing
+         *  below on the non-fatal ranks
+         */
+        return 0;
+    }
+
+    shell_trace ("%s: trace message", topic);
+    shell_debug ("%s: debug message", topic);
+    shell_log ("%s: log message", topic);
+    shell_warn ("%s: warn message", topic);
+    shell_log_error ("%s: error message", topic);
+    ok (shell_log_errn (EPERM, "%s: log_errn message", topic) == -1
+        && errno == EPERM,
+        "shell_log_errn (errnum, ...) sets errno and returns < 0");
+
+    errno = EINVAL;
+    ok (shell_log_errno ("%s: log_errno message", topic) == -1,
+        "shell_log_errno returns -1");
+
+    if (strcmp (topic, "shell.exit") == 0 || strcmp (topic, "task.exec") == 0)
+        return exit_status () == 0 ? 0 : -1;
+    return 0;
+}
+
+int flux_plugin_init (flux_plugin_t *p)
+{
+    plan (NO_PLAN);
+    flux_plugin_set_name (p, "log");
+    ok (flux_plugin_add_handler (p, "*", check_shell_log, NULL) == 0,
+        "flux_plugin_add_handler works");
+    return 0;
+}
+
+/*
+ * vi: ts=4 sw=4 expandtab
+ */

--- a/t/t2202-job-manager.t
+++ b/t/t2202-job-manager.t
@@ -66,9 +66,9 @@ test_expect_success 'job-manager: raise non-fatal exception on job' '
 	grep -q "Mumble grumble" list1_exception.out
 '
 
-test_expect_success 'job-manager: exception note with embedded = is rejected' '
+test_expect_success 'job-manager: exception note with embedded = is accepted' '
 	jobid=$(cat list1_jobid.out) &&
-	! flux job raise --severity=1 --type=testing ${jobid} foo=bar
+	flux job raise --severity=1 --type=testing ${jobid} foo=bar
 '
 
 test_expect_success 'job-manager: queue contains 1 jobs' '

--- a/t/t2604-job-shell-affinity.t
+++ b/t/t2604-job-shell-affinity.t
@@ -57,8 +57,9 @@ test_expect_success 'flux-shell: affinity can be disabled' '
     test_cmp affinity-off.expected affinity-off.out
 '
 test_expect_success 'flux-shell: invalid option is ignored' '
-    flux mini run -ocpu-affinity=1 -n1 hwloc-bind --get &&
-    flux dmesg | grep "invalid option"
+    flux mini run -ocpu-affinity=1 -n1 hwloc-bind --get >invalid.out 2>&1 &&
+    test_debug "cat invalid.out" &&
+    grep "invalid option" invalid.out
 '
 #  GPU affinity tests use standalone shell since simple-sched doesnt
 #   schedule GPUs.


### PR DESCRIPTION
This PR switches flux-shell to its own log facility with support for sending log messages as RFC 24 Log Events to the job's output eventlog.

Along with this change, fatal errors encountered in the shell and logged with `flux_shell_log_fatal` or the `shell_die()` macro cause the shell to kill any local tasks *and* generate a job exception so that other shells involved in the job are terminated.

I'm posting the PR a bit early to get feedback as I still have to add some sort of tests, and fine tune some of the rough edges. So, this isn't ready for a full review quite yet, but an ACK/NACK of the overall approach by others would be good.

High level overview

 * New shell log facility in `src/shell/log.c` replaces libutil/log.h.
 * Log facility exported to shell and plugins via section in `flux/shell.h`, including basic logging functions `flux_shell_log()`, `flux_shell_err()`, and `flux_shell_fatal()`.
 * Convenience macros `shell_die()`, `shell_warn()`, `shell_log_error()`, `shell_debug()`, etc. call underlying logging functions and automatically capture file and line information.
 * Fatal error handling improved in `flux_shell_fatal` and its `shell_die()` wrapper. A fatal error will generate a job "exec" exception (if possible) and the shell will kill any local tasks before exiting. The job exception should cause other shells involved in the job to be terminated.
 * Log facility by default logs to stderr as before, but also sends log messages to any `shell.log` plugin callbacks, allowing arbitrary log destinations to be added with shell plugins.
 * A default "evlog" builtin plugin logs messages to a job's output eventlog in RFC 24 Log Event format, if configured to do so.
 * An "eventlogger" abstraction is provided for use by the `evlog` plugin to commit log events in batches. `FLUX_SHELL_FATAL` errors are committed synchronously so that the errors aren't lost when the shell exits.
 * `flux job attach` now prints `log` events in addition to `data` and `redirect` events from the output eventlog.
 * The format of other job and exec events was also modified in `flux job attach` for aesthetic reasons. If the new output is confusing for people, I have no problem changing it back:

Example:
```console
$ flux mini run -vvv -o verbose=2 -n2 hostname
jobid: 489307504640
0.000s: job.submit {"userid":6885,"priority":16,"flags":0}
0.014s: job.depend
0.017s: job.alloc {"note":"rank0/core[0-1]"}
0.024s: job.start
0.018s: exec.init
0.021s: exec.starting
0.024s: exec.running
0.061s: exec.input-ready {"leader-rank":0}
0.061s: exec.output-ready
0.044s: flux-shell[0]: DEBUG: 0: task_count=2 slot_count=2 cores_per_slot=1 slots_per_node=-1
0.045s: flux-shell[0]: DEBUG: 0: tasks [0-1] on cores 0-1
0.046s: flux-shell[0]: DEBUG: Loading /g/g0/grondo/git/f.git/src/shell/initrc.lua
0.067s: flux-shell[0]: TRACE: 0: C: pmi EOF
0.068s: flux-shell[0]: DEBUG: task 0 complete status=0
0.070s: flux-shell[0]: TRACE: 1: C: pmi EOF
0.071s: flux-shell[0]: DEBUG: task 1 complete status=0
fluke108
fluke108
0.078s: exec.complete {"status":0}
0.078s: exec.cleanup.start {"ranks":"all"}
0.080s: exec.cleanup.finish {"ranks":"all","rc":0}
0.081s: exec.done
0.078s: job.finish {"status":0}
0.084s: job.release {"ranks":"all","final":true}
0.085s: job.free
0.085s: job.clean
```

Other notes:
 
 * Since plugins now call plugins, the `plugstack_call()` implementation had be made reentrant safe. Unfortunately, at present this requires making a copy of the plugin list for each call. :-(
 * I'm not happy about the current way different log-level is set for the overall logging faciliy vs. `stderr` vs. the eventlog. What is there now is kind of hack that balances ease of use by users and early availability of a verbose or debug flag so logging of shell initialization can be seen in `flux-job attach`. This could perhaps be modified at a later time.
 * The `eventlogger` abstraction, while not too exciting, seemed like it might be reusable code, but I avoided putting it into `libeventlog` at this point. I may try experiment converting the `output` plugin to use an `eventlogger` (or maybe have one per shell?) and see if it is actually useful in general.
 