### PR TITLE
libutil: replace fdwalk with version that uses getdents64

### DIFF
--- a/src/common/libutil/Makefile.am
+++ b/src/common/libutil/Makefile.am
@@ -120,7 +120,8 @@ TESTS = test_ev.t \
 	test_fdutils.t \
 	test_fsd.t \
 	test_zsecurity.t \
-	test_intree.t
+	test_intree.t \
+	test_fdwalk.t
 
 
 test_ldadd = \
@@ -245,3 +246,7 @@ test_zsecurity_t_LDADD = $(test_ldadd)
 test_intree_t_SOURCES = test/intree.c
 test_intree_t_CPPFLAGS = $(test_cppflags)
 test_intree_t_LDADD = $(test_ldadd)
+
+test_fdwalk_t_SOURCES = test/fdwalk.c
+test_fdwalk_t_CPPFLAGS = $(test_cppflags)
+test_fdwalk_t_LDADD = $(test_ldadd)

--- a/src/common/libutil/fdwalk.c
+++ b/src/common/libutil/fdwalk.c
@@ -112,9 +112,17 @@ static int parse_fd(const char *s) {
     return val;
 }
 
+int _fdwalk_portable (void (*func)(void *, int), void *data)
+{
+    int open_max = sysconf (_SC_OPEN_MAX);
+    for (int fd = 0; fd < open_max; fd++)
+        func (data, fd);
+    return 0;
+
+}
+
 int fdwalk (void (*func)(void *, int), void *data) {
     int fd;
-    int open_max;
     int rc = 0;
 
     /* On Linux use getdents64 to avoid malloc in opendir() and
@@ -142,12 +150,7 @@ int fdwalk (void (*func)(void *, int), void *data) {
         return rc;
     }
 #endif
-
-    open_max = sysconf (_SC_OPEN_MAX);
-
-    for (fd = 0; fd < open_max; fd++)
-        func (data, fd);
-    return rc;
+    return _fdwalk_portable (func, data);
 }
 
 /* vi: ts=4 sw=4 expandtab

--- a/src/common/libutil/fdwalk.h
+++ b/src/common/libutil/fdwalk.h
@@ -23,6 +23,12 @@ extern "C" {
 // The file descriptors that are enumerated will not include the file descriptor
 // used for the enumeration itself.
 int fdwalk(void (*func)(void *, int), void *opaque);
+
+#ifdef FDWALK_INTERFACE_TEST
+// Broken out "portable" version of fdwalk that iterates all possible
+// fds from 0 to _SC_OPEN_MAX calling func() for each fd.
+int _fdwalk_portable (void (*func)(void *, int), void *data);
+#endif /* FDWALK_INTERFACE_TEST */
 #ifdef __cplusplus
 }  // extern "C"
 #endif

--- a/src/common/libutil/test/fdwalk.c
+++ b/src/common/libutil/test/fdwalk.c
@@ -1,0 +1,116 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#include <unistd.h>
+#include <errno.h>
+#include <string.h>
+#include <fcntl.h>
+
+#include <sys/time.h>
+#include <sys/resource.h>
+
+#include "src/common/libtap/tap.h"
+#include "src/common/libutil/fdwalk.h"
+
+
+static int get_high_fd_number (void)
+{
+    struct rlimit rl = { 100, 100 };
+    ok (getrlimit (RLIMIT_NOFILE, &rl) == 0,
+        "getrlimit (RLIMIT_NOFILE)");
+    diag ("rlmit.nofile = %d", rl.rlim_cur);
+    // Let's be reasonable here
+    if (rl.rlim_cur > 10000)
+        rl.rlim_cur = 10000;
+    return rl.rlim_cur - 1;
+}
+
+static void set_fd (void *data, int fd)
+{
+    int *fds = data;
+    fds[fd]++;
+}
+
+static int * get_open_fds (int maxfd)
+{
+    /* Valgrind may show open fds > maxfd, so double the space
+     *  allocated so we don't overflow when run under valgrind.
+     */
+    int * fds = calloc (maxfd * 2, sizeof (int));
+    if (fds)
+        ok (fdwalk (set_fd, fds) == 0,
+            "fdwalk () worked");
+    return fds;
+}
+
+int main (int argc, char *argv[])
+{
+    int *openfds = NULL;
+    int *fds = NULL;
+    int i, maxfd;
+
+    plan (NO_PLAN);
+
+    maxfd = get_high_fd_number ();
+    ok (maxfd > 0,
+       "got maxfd = %d", maxfd);
+
+    if (!(openfds = get_open_fds (maxfd)))
+        BAIL_OUT ("Failed to create open fds");
+
+    for (i = 0; i < maxfd; i++) {
+        if (openfds[i])
+            ok (openfds[i] == 1, "fd=%d visited once", i);
+    }
+
+    /*  Open some more fds */
+    int pfds[2];
+    ok (pipe (pfds) == 0,
+       "Using pipe(2) to open arbitrary fds");
+
+    errno = 0;
+    ok (dup2 (pfds[0], maxfd) == maxfd,
+       "Using dup2(2) to open fd %d", maxfd);
+
+    if (!(fds = get_open_fds (maxfd)))
+        BAIL_OUT ("failed to get open fds");
+
+    ok (fds [pfds[0]] == 1,
+       "newly opened fd=%d found on second fdwalk()", pfds[0]);
+    ok (fds [pfds[1]] == 1,
+       "newly opened fd=%d found on second fdwalk()", pfds[1]);
+    ok (fds [maxfd] == 1,
+       "newly opened fd=%d found on second fdwalk()", maxfd);
+
+    close (pfds[0]);
+    close (pfds[1]);
+    close (maxfd);
+    free (fds);
+
+    if (!(fds = get_open_fds (maxfd)))
+        BAIL_OUT ("failed to get open fds");
+
+    ok (fds [pfds[0]] == 0,
+       "closed fd=%d not found on final fdwalk()", pfds[0]);
+    ok (fds [pfds[1]] == 0,
+       "closed fd=%d not found on final fdwalk()", pfds[1]);
+    ok (fds [maxfd] == 0,
+       "closed fd=%d not found on final fdwalk()", maxfd);
+
+    free (fds);
+    free (openfds);
+
+    done_testing ();
+    return 0;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */


### PR DESCRIPTION
This is an experimental alternative to #2476.

Instead of removing `fdwalk` completely, use an implementation inspired from glib's [safe_fdwalk](https://github.com/GNOME/glib/blob/master/glib/gspawn.c#L1189) that uses `getdents64` on Linux instead of `opendir`, which should make this call safe to use between fork and exec.

If not on Linux, or if `open (/proc/self/fd)` fails, fall back to iterating over all possible fds.

This is an experiment to see if it works and subsequently passes asan.