### PR TITLE
bindings/python: reinstate python2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ jobs:
       stage: test
       compiler: gcc
       env:
-       - PYTHON_VERSION=3.6
+       - PYTHON_VERSION=2.7
     - name: "Ubuntu: py3.6 distcheck"
       stage: test
       compiler: gcc
@@ -45,7 +45,7 @@ jobs:
        - CXX=g++-8
        - ARGS="--with-flux-security --enable-caliper"
        - DISTCHECK=t
-       - PYTHON_VERSION=3.6
+       - PYTHON_VERSION=2.7
     - name: "Ubuntu: clang-6.0 chain-lint --with-flux-security"
       stage: test
       compiler: clang-6.0
@@ -54,14 +54,14 @@ jobs:
        - CXX=clang++-6.0
        - chain_lint=t
        - ARGS="--with-flux-security"
-       - PYTHON_VERSION=3.6
+       - PYTHON_VERSION=2.7
     - name: "Ubuntu: COVERAGE=t, --with-flux-security --enable-caliper"
       stage: test
       compiler: gcc
       env:
        - COVERAGE=t
        - ARGS="--with-flux-security --enable-caliper"
-       - PYTHON_VERSION=3.6
+       - PYTHON_VERSION=2.7
     - name: "Ubuntu: TEST_INSTALL docker-deploy"
       stage: test
       compiler: gcc
@@ -69,7 +69,7 @@ jobs:
        - ARGS="--with-flux-security --enable-caliper"
        - TEST_INSTALL=t
        - DOCKER_TAG=t
-       - PYTHON_VERSION=3.6
+       - PYTHON_VERSION=2.7
     - name: "Centos 7: --with-flux-security --enable-caliper docker-deploy"
       stage: test
       compiler: gcc
@@ -77,7 +77,7 @@ jobs:
        - ARGS="--with-flux-security --enable-caliper --prefix=/usr"
        - IMG=centos7
        - DOCKER_TAG=t
-       - PYTHON_VERSION=3.6
+       - PYTHON_VERSION=2.7
     - name: "Centos 7: py3.6 --with-flux-security"
       stage: test
       compiler: gcc

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ sqlite-devel	| libsqlite3-dev	| >= 3.0.0		|
 lua		| lua5.1		| >= 5.1, < 5.3		|
 lua-devel	| liblua5.1-dev		| >= 5.1, < 5.3		|
 lua-posix 	| lua-posix             | 			| *1*
-python-devel	| python-dev		| >= 3.6		|
+python-devel	| python-dev		| >= 2.7		|
 python-cffi	| python-cffi		| >= 1.1		|
 python-six	| python-six		| >= 1.9		|
 python-yaml	| python-yaml		| >= 3.10.0		|

--- a/README.md
+++ b/README.md
@@ -48,11 +48,11 @@ sqlite-devel	| libsqlite3-dev	| >= 3.0.0		|
 lua		| lua5.1		| >= 5.1, < 5.3		|
 lua-devel	| liblua5.1-dev		| >= 5.1, < 5.3		|
 lua-posix 	| lua-posix             | 			| *1*
-python36-devel	| python3-dev		| >= 3.6		|
-python36-cffi	| python3-cffi		| >= 1.1		|
-python36-six	| python3-six		| >= 1.9		|
-python36-yaml	| python3-yaml		| >= 3.10.0		|
-python36-jsonschema | python3-jsonschema | >= 2.3.0		|
+python-devel	| python-dev		| >= 3.6		|
+python-cffi	| python-cffi		| >= 1.1		|
+python-six	| python-six		| >= 1.9		|
+python-yaml	| python-yaml		| >= 3.10.0		|
+python-jsonschema | python-jsonschema	| >= 2.3.0		|
 asciidoc	| asciidoc         	| 			| *2*
 asciidoctor	| asciidoctor         	| >= 1.5.7		| *2*
 aspell		| aspell		|			| *3*

--- a/config/ax_python_devel.m4
+++ b/config/ax_python_devel.m4
@@ -74,28 +74,15 @@ AC_DEFUN([AX_PYTHON_DEVEL],[
 	#
 	# Allow the use of a (user set) custom python version
 	#
-	# N.B. modified for Flux:
-	# If PYTHON_VERSION is unset, look for "python3" first, then "python".
-	# Most os's now install the v2 interpreter as "python" and v3 as
-	# "python3" so users on those os's would otherwise be required to run
-	# "$PYTHON_VERSION=3 ./configure" to get a working python for Flux.
-	#
 	AC_ARG_VAR([PYTHON_VERSION],[The installed Python
 		version to use, for example '2.3'. This string
 		will be appended to the Python interpreter
 		canonical name.])
 
-	if test -n "$PYTHON_VERSION"; then
-		AC_PATH_PROG([PYTHON],[python[$PYTHON_VERSION]])
-		if test -z "$PYTHON"; then
-		   AC_MSG_ERROR([Cannot find python$PYTHON_VERSION in your system path])
-		   PYTHON_VERSION=""
-		fi
-	else
-		AC_PATH_PROGS([PYTHON],[python3 python])
-		if test -z "$PYTHON"; then
-		   AC_MSG_ERROR([Cannot find python in your system path])
-		fi
+	AC_PATH_PROG([PYTHON],[python[$PYTHON_VERSION]])
+	if test -z "$PYTHON"; then
+	   AC_MSG_ERROR([Cannot find python$PYTHON_VERSION in your system path])
+	   PYTHON_VERSION=""
 	fi
 
 	#

--- a/configure.ac
+++ b/configure.ac
@@ -225,7 +225,7 @@ AC_CHECK_LIB(m, floor)
 saved_PATH=$PATH
 export PATH=$(echo $PATH | sed "s|$(pwd)/src/cmd:*||")
 
-AX_PYTHON_DEVEL([>='3.6'])
+AX_PYTHON_DEVEL([>='2.7'])
 
 AM_PATH_PYTHON([$ac_python_version])
 if test "X$PYTHON" = "X"; then
@@ -247,7 +247,6 @@ AM_CHECK_PYMOD(cffi,
                ,
                [AC_MSG_ERROR([could not find python module cffi, version 1.1+ required])]
                )
-# TODO: remove this dependency when time permits, only needed for 2/3 compat
 AM_CHECK_PYMOD(six,
                [StrictVersion(six.__version__) >= StrictVersion('1.9.0')],
                ,
@@ -269,7 +268,7 @@ AM_CHECK_PYMOD(jsonschema,
 # search can lead to linking problems.
 #
 # Logic below assumes only newer Python versions, protected by
-# above check for atleast Python 3.6.
+# above check for atleast Python 2.7.
 if test "$ac_python_ldflags_set_by_user" != "true"; then
   AC_CHECK_LIB([$ac_python_library], [PyArg_ParseTuple],
                [ac_python_in_ld_path=true])


### PR DESCRIPTION
Drop the minimum version of python back from 3.6 => 2.7.

Update docs, travis, and revert autoconf macro hack to find `python3` before `python3`.

Fixes #2480 and #2478 (hopefully).