### PR TITLE
flux-shell: handle jobspec command as bare string

### DIFF
--- a/src/shell/jobspec.c
+++ b/src/shell/jobspec.c
@@ -166,6 +166,17 @@ struct jobspec *jobspec_parse (const char *jobspec, json_error_t *error)
         set_error (error, "Unable to parse command");
         goto error;
     }
+    if (json_is_string (job->command)) {
+        job->command = json_pack ("[o]", job->command);
+        if (!job->command) {
+            set_error (error, "Failed to pack bare command into an array");
+            goto error;
+        }
+    }
+    else if (!json_is_array (job->command)) {
+        set_error (error, "Malformed command entry");
+        goto error;
+    }
     return job;
 error:
     jobspec_destroy (job);

--- a/t/python/subflux.py
+++ b/t/python/subflux.py
@@ -48,7 +48,7 @@ def rerun_under_flux(size=1, personality="full"):
     command = [flux_exe, "start", "--bootstrap=selfpmi", "--size", str(size)]
     if personality != "full":
         for rc_num in [1, 3]:
-            attr = "broker.{}_path".format(rc_num)
+            attr = "broker.rc{}_path".format(rc_num)
             if personality == "minimal":
                 command.append("-o,-S{}=".format(attr))
             else:

--- a/t/python/t0010-job.py
+++ b/t/python/t0010-job.py
@@ -40,13 +40,6 @@ class TestJob(unittest.TestCase):
         jobspec_dir = os.path.abspath(
             os.path.join(os.environ["FLUX_SOURCE_DIR"], "t", "jobspec")
         )
-        ingest_dir = os.path.abspath(
-            os.path.join(os.environ["FLUX_BUILD_DIR"], "t", "ingest")
-        )
-
-        # load the dummy job manager
-        job_manager_path = os.path.join(ingest_dir, ".libs", "job-manager-dummy.so")
-        self.fh.mrpc_create("cmb.insmod", {"path": job_manager_path, "args": []})
 
         # get a valid jobspec
         basic_jobspec_fname = os.path.join(jobspec_dir, "valid", "basic_v1.yaml")


### PR DESCRIPTION
The python job test was submitting jobspec that represented the command as a bare string, rather than an array of string arguments.  This caused the `flux-shell` to segfault.  Since this is valid v1 jobspec, change the shell jobspec parser to detect this and convert it to an array of one string.

Also, noticed that there was a typo in the "rc personality" selection in the python subflux module that caused all tests to run under the "full" personality.  This explains why the shell was running in the first place, since the test had selected the "job" personality, which would not have loaded the exec module.

Finally, now that the "job" personality includes the full job manager, don't try to load the fake test one in the job test.  That must have been silently failing since the job manager was added to the "full" personality, so change is actually a no-op as far as the test is concerned.