### PR TITLE
libflux: fall back to builtin connector search path

### DIFF
--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -1043,7 +1043,7 @@ static int create_broker_rundir (overlay_t *ov, void *arg)
     }
 
     if (attr_get (attrs, "local-uri", &local_uri, NULL) < 0) {
-        if (asprintf (&uri, "local://%s", broker_rundir) < 0) {
+        if (asprintf (&uri, "local://%s/local", broker_rundir) < 0) {
             log_err ("create_broker_rundir: asprintf (uri)");
             goto cleanup;
         }

--- a/src/broker/test/heartbeat.c
+++ b/src/broker/test/heartbeat.c
@@ -58,9 +58,6 @@ int main (int argc, char **argv)
 
     check_codec ();
 
-    (void)setenv ("FLUX_CONNECTOR_PATH",
-                  flux_conf_builtin_get ("connector_path",
-                                         FLUX_CONF_INTREE), 0);
     ok ((h = flux_open ("loop://", 0)) != NULL,
         "opened loop connector");
     if (!h)

--- a/src/broker/test/hello.c
+++ b/src/broker/test/hello.c
@@ -37,9 +37,6 @@ int main (int argc, char **argv)
 
     plan (NO_PLAN);
 
-    (void)setenv ("FLUX_CONNECTOR_PATH",
-                  flux_conf_builtin_get ("connector_path",
-                                         FLUX_CONF_INTREE), 0);
     ok ((h = flux_open ("loop://", 0)) != NULL,
         "opened loop connector");
     if (!h)

--- a/src/broker/test/reduce.c
+++ b/src/broker/test/reduce.c
@@ -357,9 +357,6 @@ int main (int argc, char *argv[])
 
     plan (NO_PLAN);
 
-    (void)setenv ("FLUX_CONNECTOR_PATH",
-                  flux_conf_builtin_get ("connector_path",
-                                         FLUX_CONF_INTREE), 0);
     ok ((h = flux_open ("loop://", 0)) != NULL,
         "opened loop connector");
     if (!h)

--- a/src/broker/test/shutdown.c
+++ b/src/broker/test/shutdown.c
@@ -78,9 +78,6 @@ int main (int argc, char **argv)
 
     check_codec ();
 
-    (void)setenv ("FLUX_CONNECTOR_PATH",
-                  flux_conf_builtin_get ("connector_path",
-                                         FLUX_CONF_INTREE), 0);
     ok ((h = flux_open ("loop://", 0)) != NULL,
         "opened loop connector");
     if (!h)

--- a/src/cmd/builtin/proxy.c
+++ b/src/cmd/builtin/proxy.c
@@ -63,7 +63,7 @@ static void completion_cb (flux_subprocess_t *p)
 static int child_create (struct proxy_command *ctx,
                          int ac,
                          char **av,
-                         const char *workpath)
+                         const char *sockpath)
 {
     const char *shell = getenv ("SHELL");
     char *argz = NULL;
@@ -107,7 +107,7 @@ static int child_create (struct proxy_command *ctx,
             goto error;
     }
 
-    if (flux_cmd_setenvf (cmd, 1, "FLUX_URI", "local://%s", workpath) < 0)
+    if (flux_cmd_setenvf (cmd, 1, "FLUX_URI", "local://%s", sockpath) < 0)
         goto error;
 
     /* We want stdio fallthrough so subprocess can capture tty if
@@ -276,7 +276,7 @@ static int cmd_proxy (optparse_t *p, int ac, char *av[])
 
     /* Create child
      */
-    if (child_create (&ctx, ac - optindex, av + optindex, workpath) < 0)
+    if (child_create (&ctx, ac - optindex, av + optindex, sockpath) < 0)
         log_err_exit ("child_create");
 
     /* Start reactor

--- a/src/common/libflux/handle.c
+++ b/src/common/libflux/handle.c
@@ -284,7 +284,7 @@ flux_t *flux_open (const char *uri, int flags)
     if (!uri)
         conf = parse_conf_flux_uri (&uri);
     if (!uri) {
-        if (asprintf (&default_uri, "local://%s",
+        if (asprintf (&default_uri, "local://%s/local",
                       flux_conf_builtin_get ("rundir",
                                              FLUX_CONF_INSTALLED)) < 0)
             goto error;

--- a/src/common/libflux/handle.c
+++ b/src/common/libflux/handle.c
@@ -209,10 +209,8 @@ static connector_init_f *find_connector (const char *scheme, void **dsop)
     void *dso = NULL;
     connector_init_f *connector_init = NULL;
 
-    if (!searchpath) {
-        errno = ENOENT;
-        return NULL;
-    }
+    if (!searchpath)
+        searchpath = flux_conf_builtin_get ("connector_path", FLUX_CONF_AUTO);
     if (snprintf (name, sizeof (name), "%s.so", scheme) >= sizeof (name)) {
         errno = ENAMETOOLONG;
         return NULL;

--- a/src/common/libsubprocess/test/subprocess.c
+++ b/src/common/libsubprocess/test/subprocess.c
@@ -147,10 +147,6 @@ void test_basic_errors (flux_reactor_t *r)
     char *avbad[] = { NULL };
     flux_cmd_t *cmd;
 
-    (void)setenv ("FLUX_CONNECTOR_PATH",
-                  flux_conf_builtin_get ("connector_path",
-                                         FLUX_CONF_INTREE), 0);
-
     ok ((h = flux_open ("loop://", 0)) != NULL,
         "flux_open on loop works");
 

--- a/src/connectors/local/local.c
+++ b/src/connectors/local/local.c
@@ -203,16 +203,9 @@ static int override_retry_count (struct usock_retry_params *retry)
 flux_t *connector_init (const char *path, int flags)
 {
     struct local_connector *ctx;
-    char sockpath[PATH_MAX + 1];
-    int n;
     struct usock_retry_params retry = USOCK_RETRY_DEFAULT;
 
     if (!path || override_retry_count (&retry) < 0) {
-        errno = EINVAL;
-        return NULL;
-    }
-    n = snprintf (sockpath, sizeof (sockpath), "%s/local", path);
-    if (n >= sizeof (sockpath)) {
         errno = EINVAL;
         return NULL;
     }
@@ -222,7 +215,7 @@ flux_t *connector_init (const char *path, int flags)
     ctx->testing_userid = FLUX_USERID_UNKNOWN;
     ctx->testing_rolemask = FLUX_ROLE_NONE;
 
-    ctx->fd = usock_client_connect (sockpath, retry);
+    ctx->fd = usock_client_connect (path, retry);
     if (ctx->fd < 0)
         goto error;
     if (!(ctx->uclient = usock_client_create (ctx->fd)))

--- a/src/modules/connector-local/local.c
+++ b/src/modules/connector-local/local.c
@@ -192,9 +192,9 @@ error:
 int mod_main (flux_t *h, int argc, char **argv)
 {
     struct connector_local ctx;
-    char sockpath[PATH_MAX + 1];
     const char *local_uri = NULL;
     char *tmpdir;
+    const char *sockpath;
     int rc = -1;
 
     memset (&ctx, 0, sizeof (ctx));
@@ -216,8 +216,7 @@ int mod_main (flux_t *h, int argc, char **argv)
         flux_log (h, LOG_ERR, "malformed local-uri");
         goto done;
     }
-    tmpdir += strlen ("local://");
-    snprintf (sockpath, sizeof (sockpath), "%s/local", tmpdir);
+    sockpath = tmpdir + 8;
 
     /* Create listen socket and watcher to handle new connections
      */

--- a/t/loop/issue2337.c
+++ b/t/loop/issue2337.c
@@ -32,10 +32,6 @@ int main (int argc, char *argv[])
 
     begin = fdcount ();
 
-    (void)setenv ("FLUX_CONNECTOR_PATH",
-                  flux_conf_builtin_get ("connector_path",
-                                         FLUX_CONF_INTREE), 0);
-
     if (!(h = flux_open ("loop://", 0))) {
         perror ("flux_open");
         exit (1);

--- a/t/shmem/backtoback.c
+++ b/t/shmem/backtoback.c
@@ -23,9 +23,6 @@ int main (int argc, char *argv[])
 
     plan (NO_PLAN);
 
-    (void)setenv ("FLUX_CONNECTOR_PATH",
-                  flux_conf_builtin_get ("connector_path",
-                                         FLUX_CONF_INTREE), 0);
     ok ((h_srv = flux_open ("shmem://test&bind", 0)) != NULL,
         "created server handle");
     ok ((h_cli = flux_open ("shmem://test&connect", 0)) != NULL,


### PR DESCRIPTION
This PR addresses two issues with `flux_open()` when running outside of an instance
* Use builtin FLUX_CONNECTOR_PATH If unset in environment (e.g. not run under `flux(1)`)
* Try to get `flux_uri` from TOML config file before resorting to builtin path

The specific use case I was hoping to enable by the last one is setting up flux utilities on a login node to connect to a remote instance when a broker is not running locally.   Sys admins could set `flux_uri` in `/etc/flux/conf.d/flux.toml`.

Finally, somewhat unrelated:  I cherry-picked the commit from #2464 that includes the final socket component in `local://` URI's, rather than ending the URI with the directory, with final component hardwired to `local`.  That made it easier to tunnel broker sockets through ssh, and unwinds some unnecessary obfuscation.
