### PR TITLE
flux-mini: improve handling of --setattr and --setopt

### DIFF
--- a/doc/man1/flux-mini.adoc
+++ b/doc/man1/flux-mini.adoc
@@ -108,10 +108,11 @@ _(run only)_ Increase verbosity on stderr.  For example, currently `-v`
 displays jobid, `-vv` displays job events, and `-vvv` displays exec events.
 The specific output may change in the future.
 
-*-o, --setopt=KEY=VAL*::
+*-o, --setopt=KEY[=VAL]*::
 Set shell option.  Keys may include periods to denote hierarchy.
-VAL may be valid JSON (bare values, objects, or arrays), otherwise VAL
-is interpreted as a string.  See SHELL OPTIONS below.
+VAL is optional and may be valid JSON (bare values, objects, or arrays),
+otherwise VAL is interpreted as a string. If VAL is not set, then the
+default value is 1. See SHELL OPTIONS below.
 
 *--setattr=KEY=VAL*::
 Set jobspec attribute.  Keys may include periods to denote hierarchy.

--- a/src/cmd/flux-mini.py
+++ b/src/cmd/flux-mini.py
@@ -331,6 +331,8 @@ class SubmitCmd:
         if args.setattr is not None:
             for kv in args.setattr:
                 tmp = kv.split("=", 1)
+                if len(tmp) != 2:
+                    raise ValueError("--setattr: Missing value for attr " + kv)
                 key = tmp[0]
                 try:
                     val = json.loads(tmp[1])

--- a/src/cmd/flux-mini.py
+++ b/src/cmd/flux-mini.py
@@ -245,8 +245,8 @@ class SubmitCmd:
         parser.add_argument(
             "--setattr",
             action="append",
-            help="Set job attribute (multiple use OK)",
-            metavar="KEY=VAL",
+            help="Set job attribute ATTR to VAL (multiple use OK)",
+            metavar="ATTR=VAL",
         )
         parser.add_argument(
             "--input",

--- a/src/cmd/flux-mini.py
+++ b/src/cmd/flux-mini.py
@@ -238,8 +238,9 @@ class SubmitCmd:
             "-o",
             "--setopt",
             action="append",
-            help="Set shell option (multiple use OK)",
-            metavar="KEY=VAL",
+            help="Set shell option OPT. An optional value is supported with"
+            + " OPT=VAL (default VAL=1) (multiple use OK)",
+            metavar="OPT",
         )
         parser.add_argument(
             "--setattr",
@@ -319,12 +320,12 @@ class SubmitCmd:
 
         if args.setopt is not None:
             for kv in args.setopt:
-                tmp = kv.split("=", 1)
-                key = tmp[0]
+                # Split into key, val with a default for 1 if no val given:
+                key, val = (kv.split("=", 1) + [1])[:2]
                 try:
-                    val = json.loads(tmp[1])
+                    val = json.loads(val)
                 except:
-                    val = tmp[1]
+                    pass
                 jobspec.setattr_shopt(key, val)
 
         if args.setattr is not None:

--- a/t/t2700-mini-cmd.t
+++ b/t/t2700-mini-cmd.t
@@ -116,12 +116,22 @@ test_expect_success HAVE_JQ 'flux mini submit --setattr works' '
 	test $(jq ".attributes.user.foo2" attr.out) = "\"yyy\"" &&
 	test $(jq ".attributes.system.bar" attr.out) = "42"
 '
+test_expect_success 'flux mini submit --setattr fails without value' '
+	test_expect_code 1 \
+		flux mini submit --dry-run \
+		--setattr foo \
+		hostname >attr_fail.out 2>&1 &&
+	test_debug "cat attr_fail.out" &&
+	grep "Missing value for attr foo" attr_fail.out
+'
 test_expect_success HAVE_JQ 'flux mini submit --setopt works' '
 	flux mini submit --dry-run \
 		--setopt foo=true \
+		--setopt baz \
 		--setopt bar.baz=42 hostname >opt.out &&
 	test $(jq ".attributes.system.shell.options.foo" opt.out) = "true" &&
-	test $(jq ".attributes.system.shell.options.bar.baz" opt.out) = "42"
+	test $(jq ".attributes.system.shell.options.bar.baz" opt.out) = "42" &&
+	test $(jq ".attributes.system.shell.options.baz" opt.out) = "1"
 '
 test_expect_success HAVE_JQ 'flux mini submit --output passes through to shell' '
 	flux mini submit --dry-run --output=my/file hostname >output.out &&


### PR DESCRIPTION
Adjust `flux-mini -o, --setopt=OPT=VAL` to allow optional `VAL` (default = 1). This is useful for "flag" style options, allowing a user to use `-o verbose` to enable verbose shell logging for example.

For `--setattr`, improve the error when a value is not given (e.g. `--setattr=foo`) from
```
flux-mini: ERROR: list index out of range
```
to
```
flux-mini: ERROR: --setattr: Missing value for attr foo
```