### PR TITLE
msg_handler: make topic_glob const char *, fix fallout

### DIFF
--- a/src/broker/modservice.c
+++ b/src/broker/modservice.c
@@ -183,7 +183,7 @@ static int register_event (modservice_ctx_t *ctx, const char *name,
     flux_msg_handler_t *mh = NULL;
     int rc = -1;
 
-    if (asprintf (&match.topic_glob,
+    if (flux_match_asprintf (&match,
                   "%s.%s",
                   module_get_name (ctx->p),
                   name) < 0) {
@@ -209,7 +209,7 @@ static int register_event (modservice_ctx_t *ctx, const char *name,
     rc = 0;
 cleanup:
     flux_msg_handler_destroy (mh);
-    free (match.topic_glob);
+    flux_match_free (match);
     return rc;
 }
 
@@ -220,7 +220,7 @@ static int register_request (modservice_ctx_t *ctx, const char *name,
     flux_msg_handler_t *mh = NULL;
     int rc = -1;
 
-    if (asprintf (&match.topic_glob,
+    if (flux_match_asprintf (&match,
                   "%s.%s",
                   module_get_name (ctx->p),
                   name) < 0) {
@@ -242,7 +242,7 @@ static int register_request (modservice_ctx_t *ctx, const char *name,
     rc = 0;
 cleanup:
     flux_msg_handler_destroy (mh);
-    free (match.topic_glob);
+    flux_match_free (match);
     return rc;
 }
 

--- a/src/broker/ping.c
+++ b/src/broker/ping.c
@@ -109,7 +109,7 @@ int ping_initialize (flux_t *h, const char *service)
         goto error;
     }
     match.typemask = FLUX_MSGTYPE_REQUEST;
-    if (asprintf (&match.topic_glob, "%s.ping", service) < 0) {
+    if (flux_match_asprintf (&match, "%s.ping", service) < 0) {
         errno = ENOMEM;
         goto error;
     }
@@ -118,10 +118,10 @@ int ping_initialize (flux_t *h, const char *service)
     flux_msg_handler_allow_rolemask (p->mh, FLUX_ROLE_ALL);
     flux_msg_handler_start (p->mh);
     flux_aux_set (h, "flux::ping", p, ping_finalize);
-    free (match.topic_glob);
+    flux_match_free (match);
     return 0;
 error:
-    free (match.topic_glob);
+    flux_match_free (match);
     if (p)
         ping_finalize (p);
     return -1;

--- a/src/broker/rusage.c
+++ b/src/broker/rusage.c
@@ -73,7 +73,7 @@ int rusage_initialize (flux_t *h, const char *service)
         goto error;
     }
     match.typemask = FLUX_MSGTYPE_REQUEST;
-    if (asprintf (&match.topic_glob, "%s.rusage", service) < 0) {
+    if (flux_match_asprintf (&match, "%s.rusage", service) < 0) {
         errno = ENOMEM;
         goto error;
     }
@@ -81,12 +81,12 @@ int rusage_initialize (flux_t *h, const char *service)
         goto error;
     flux_msg_handler_start (r->mh);
     flux_aux_set (h, "flux::rusage", r, rusage_finalize);
-    free (match.topic_glob);
+    flux_match_free (match);
     return 0;
 error:
     if (r)
         rusage_finalize (r);
-    free (match.topic_glob);
+    flux_match_free (match);
     return -1;
 }
 

--- a/src/common/libflux/message.c
+++ b/src/common/libflux/message.c
@@ -1465,6 +1465,31 @@ int flux_msg_frames (const flux_msg_t *msg)
     return zmsg_size (msg->zmsg);
 }
 
+struct flux_match flux_match_init (int typemask,
+                                     uint32_t matchtag,
+                                     const char *topic_glob)
+{
+    struct flux_match m = {typemask, matchtag, topic_glob};
+    return m;
+}
+
+void flux_match_free (struct flux_match m)
+{
+    free ((char *)m.topic_glob);
+}
+
+int flux_match_asprintf (struct flux_match *m, const char *topic_glob_fmt, ...)
+{
+    va_list args;
+    va_start (args, topic_glob_fmt);
+    char *topic = NULL;
+    int res = vasprintf (&topic, topic_glob_fmt, args);
+    va_end (args);
+    m->topic_glob = topic;
+    return res;
+}
+
+
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab
  */

--- a/src/common/libflux/message.h
+++ b/src/common/libflux/message.h
@@ -15,6 +15,7 @@
 #include <stdint.h>
 #include <stdarg.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include "types.h"
 
 #ifdef __cplusplus
@@ -53,29 +54,37 @@ enum {
 struct flux_match {
     int typemask;           /* bitmask of matching message types (or 0) */
     uint32_t matchtag;      /* matchtag (or FLUX_MATCHTAG_NONE) */
-    char *topic_glob;       /* glob matching topic string (or NULL) */
+    const char *topic_glob;       /* glob matching topic string (or NULL) */
 };
 
-#define FLUX_MATCH_ANY (struct flux_match){ \
-    .typemask = FLUX_MSGTYPE_ANY, \
-    .matchtag = FLUX_MATCHTAG_NONE, \
-    .topic_glob = NULL, \
-}
-#define FLUX_MATCH_EVENT (struct flux_match){ \
-    .typemask = FLUX_MSGTYPE_EVENT, \
-    .matchtag = FLUX_MATCHTAG_NONE, \
-    .topic_glob = NULL, \
-}
-#define FLUX_MATCH_REQUEST (struct flux_match){ \
-    .typemask = FLUX_MSGTYPE_REQUEST, \
-    .matchtag = FLUX_MATCHTAG_NONE, \
-    .topic_glob = NULL, \
-}
-#define FLUX_MATCH_RESPONSE (struct flux_match){ \
-    .typemask = FLUX_MSGTYPE_RESPONSE, \
-    .matchtag = FLUX_MATCHTAG_NONE, \
-    .topic_glob = NULL, \
-}
+struct flux_match flux_match_init (int typemask,
+                                                   uint32_t matchtag,
+                                                   const char *topic_glob);
+
+void flux_match_free (struct flux_match m);
+
+int flux_match_asprintf (struct flux_match *m, const char *topic_glob_fmt, ...);
+
+#define FLUX_MATCH_ANY flux_match_init( \
+    FLUX_MSGTYPE_ANY, \
+    FLUX_MATCHTAG_NONE, \
+    NULL \
+)
+#define FLUX_MATCH_EVENT flux_match_init( \
+    FLUX_MSGTYPE_EVENT, \
+    FLUX_MATCHTAG_NONE, \
+    NULL \
+)
+#define FLUX_MATCH_REQUEST flux_match_init( \
+    FLUX_MSGTYPE_REQUEST, \
+    FLUX_MATCHTAG_NONE, \
+    NULL \
+)
+#define FLUX_MATCH_RESPONSE flux_match_init( \
+    FLUX_MSGTYPE_RESPONSE, \
+    FLUX_MATCHTAG_NONE, \
+    NULL \
+)
 
 /* Create a new Flux message.
  * Returns new message or null on failure, with errno set (e.g. ENOMEM, EINVAL)

--- a/src/common/libflux/msg_handler.c
+++ b/src/common/libflux/msg_handler.c
@@ -209,8 +209,8 @@ static size_t matchtag_hasher (const void *key)
 static int copy_match (struct flux_match *dst,
                        const struct flux_match src)
 {
-    if (dst->topic_glob)
-        free (dst->topic_glob);
+
+    flux_match_free (*dst);
     *dst = src;
     if (src.topic_glob) {
         if (!(dst->topic_glob = strdup (src.topic_glob)))
@@ -477,8 +477,7 @@ static void free_msg_handler (flux_msg_handler_t *mh)
     if (mh) {
         int saved_errno = errno;
         assert (mh->magic == HANDLER_MAGIC);
-        if (mh->match.topic_glob)
-            free (mh->match.topic_glob);
+        flux_match_free (mh->match);
         mh->magic = ~HANDLER_MAGIC;
         free (mh);
         errno = saved_errno;


### PR DESCRIPTION
The C++ compiler was squawking about assigning const strings into topic_glob.  How exactly we never had this issue on the C compiler eludes me, but we didn't as far as I can tell.  This cleans that up.