### PR TITLE
doc: flux_respond_raw doesn't take an errnum

### DIFF
--- a/doc/man3/flux_respond.adoc
+++ b/doc/man3/flux_respond.adoc
@@ -19,7 +19,7 @@ SYNOPSIS
                         const char *fmt, ...);
 
  int flux_respond_raw (flux_t *h, const flux_msg_t *request,
-                       int errnum, const void *data, int length);
+                       const void *data, int length);
 
  int flux_respond_error (flux_t *h, const flux_msg_t *request,
                          int errnum, const char *errmsg);


### PR DESCRIPTION
Small docfix that came up when I was digging around for the C++ wrapper interface over on sched.