### PR TITLE
job-ingest: launch `.py` validators with configured python

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -496,11 +496,6 @@ AC_CONFIG_FILES( \
   t/fluxometer/conf.lua.installed \
 )
 
-AC_CONFIG_FILES( \
-  [src/modules/job-ingest/validators/validate-schema.py],
-      [chmod +x src/modules/job-ingest/validators/validate-schema.py] \
-)
-
 AC_CONFIG_LINKS([ \
   t/fluxometer.lua:t/fluxometer.lua \
 ])

--- a/src/common/libflux/Makefile.am
+++ b/src/common/libflux/Makefile.am
@@ -55,7 +55,7 @@ intree_conf_cppflags = \
 	-DINTREE_KEYDIR=\"${abs_top_builddir}/etc/flux\" \
 	-DINTREE_NO_DOCS_PATH=\"${abs_top_builddir}/etc/flux/.nodocs\" \
 	-DINTREE_BINDIR=\"${abs_top_builddir}/src/cmd\" \
-	-DINTREE_JOBSPEC_VALIDATE_PATH=\"${abs_top_builddir}/src/modules/job-ingest/validators/validate-schema.py\" \
+	-DINTREE_JOBSPEC_VALIDATE_PATH=\"${abs_top_srcdir}/src/modules/job-ingest/validators/validate-schema.py\" \
 	-DINTREE_JOBSPEC_SCHEMA_PATH=\"${abs_top_srcdir}/src/modules/job-ingest/schemas/jobspec_v1.jsonschema\"
 
 

--- a/src/modules/job-ingest/Makefile.am
+++ b/src/modules/job-ingest/Makefile.am
@@ -30,7 +30,7 @@ job_ingest_la_LIBADD = $(fluxmod_libadd) \
 		    $(FLUX_SECURITY_LIBS) \
 		    $(ZMQ_LIBS)
 
-fluxlibexec_SCRIPTS = \
+dist_fluxlibexec_SCRIPTS = \
 	validators/validate-schema.py
 
 fluxschemadir = $(datadir)/flux/schema/jobspec/

--- a/src/modules/job-ingest/validators/validate-schema.py
+++ b/src/modules/job-ingest/validators/validate-schema.py
@@ -1,5 +1,3 @@
-#!@PYTHON@
-
 ##############################################################
 #  Copyright 2018 Lawrence Livermore National Security, LLC
 #  (c.f. AUTHORS, NOTICE.LLNS, COPYING)

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -191,7 +191,8 @@ dist_check_SCRIPTS = \
 	job-manager/bulk-state.py \
 	job-attach/outputsleep.sh \
 	job-exec/dummy.sh \
-	schedutil/req_and_unload.py
+	schedutil/req_and_unload.py \
+	ingest/fake-validate.sh
 
 check_PROGRAMS = \
 	shmem/backtoback.t \

--- a/t/ingest/fake-validate.sh
+++ b/t/ingest/fake-validate.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+while read line
+do
+    echo '{"errnum": 0}'
+done <&0
+
+exit 0


### PR DESCRIPTION
`validate-schema.py.in` was an autoconf input file with a `#!@PYTHON@`
template at the top of the file.  This ensured that the
`validate-schema.py` script always ran with the python interpreter that
Flux was configured with.  This works as long as the python interpreter
path is short enough.  When the path is > 127 characters, the script
fails to execute due to kernel limits.

Rename `validate-schema.py.in` to `validate-schema.py` and remove the
`#!@PYTHON@` template shebang line.  Update the `job-ingest` module to
launch validators ending with `.py` with the configured python
interpreter.  `job-ingest` executes other scripts as before.

Add a test to ensure that non-python executables can still be launched
as validators.

Fixes #2491