### PR TITLE
shell: generate job exception on MPI_Abort

### DIFF
--- a/src/common/libpmi/pmi.c
+++ b/src/common/libpmi/pmi.c
@@ -91,6 +91,11 @@ int PMI_Finalize (void)
 
 int PMI_Abort (int exit_code, const char error_msg[])
 {
+    /* pmi_simple_client_abort() only returns on error, in which case
+     * we fall back to printing the message on stderr and call exit()
+     * (return code not checked because we don't do anything with it)
+     */
+    (void) pmi_simple_client_abort (pmi_global_ctx, exit_code, error_msg);
     fprintf (stderr, "PMI_Abort: (%d) %s\n",
              pmi_global_ctx ? pmi_global_ctx->rank : -1,
              error_msg);

--- a/src/common/libpmi/pmi2.c
+++ b/src/common/libpmi/pmi2.c
@@ -116,6 +116,11 @@ int PMI2_Initialized (void)
 
 int PMI2_Abort (int flag, const char msg[])
 {
+    /* pmi_simple_client_abort() only returns on error, in which case
+     * we fall back to printing the msg on stderr and call exit().
+     * (return code not checked because we don't do anything with it)
+     */
+    (void) pmi_simple_client_abort (pmi_global_ctx, 1, msg);
     fprintf (stderr, "PMI2_Abort: (%d) %s\n",
              pmi_global_ctx ? pmi_global_ctx->rank : -1,
              msg ? msg : "NULL");

--- a/src/common/libpmi/simple_client.c
+++ b/src/common/libpmi/simple_client.c
@@ -356,6 +356,28 @@ int pmi_simple_client_get_clique_ranks (struct pmi_simple_client *pmi,
     return result;
 }
 
+int pmi_simple_client_abort (struct pmi_simple_client *pmi,
+                             int exit_code,
+                             const char *msg)
+{
+    int result = PMI_FAIL;
+
+    if (!pmi || !pmi->initialized)
+        return PMI_ERR_INIT;
+    if (exit_code < 0)
+        return PMI_ERR_INVALID_ARG;
+    if (dprintf (pmi->fd,
+                 "cmd=abort exit_code=%d%s%s\n",
+                 exit_code,
+                 msg ? " error_msg=" : "",
+                 msg ? msg : "") < 0)
+        goto done;
+    exit (exit_code);
+    /* NOTREACHED */
+done:
+    return result;
+}
+
 void *pmi_simple_client_aux_get (struct pmi_simple_client *pmi,
                                  const char *name)
 {

--- a/src/common/libpmi/simple_client.h
+++ b/src/common/libpmi/simple_client.h
@@ -86,9 +86,14 @@ int pmi_simple_client_get_clique_ranks (struct pmi_simple_client *pmi,
                                         int ranks[],
                                         int length);
 
+/* Abort
+ */
+int pmi_simple_client_abort (struct pmi_simple_client *pmi,
+                             int exit_code,
+                             const char *msg);
 
 /* Not implemented (yet):
- * abort, publish, unpublish, lookup, spawn
+ * publish, unpublish, lookup, spawn
  */
 
 #endif /* _FLUX_CORE_PMI_SIMPLE_CLIENT_H */

--- a/src/common/libpmi/simple_server.h
+++ b/src/common/libpmi/simple_server.h
@@ -35,6 +35,8 @@ struct pmi_simple_ops {
     int (*barrier_enter)(void *arg);
     int (*response_send)(void *client, const char *buf);
     void (*debug_trace)(void *client, const char *buf);
+    void (*abort) (void *arg, void *cli,
+                   int exit_code, const char error_message[]);
 };
 
 enum {

--- a/src/common/libpmi/test/pmi_info.c
+++ b/src/common/libpmi/test/pmi_info.c
@@ -23,9 +23,10 @@
 #include "src/common/libpmi/pmi_strerror.h"
 #include "src/common/libpmi/clique.h"
 
-#define OPTIONS "c"
+#define OPTIONS "ca:"
 static const struct option longopts[] = {
     {"clique",       no_argument,        0, 'c'},
+    {"abort",        required_argument,  0, 'a'},
     {0, 0, 0, 0},
 };
 
@@ -37,11 +38,15 @@ int main(int argc, char *argv[])
     char *kvsname;
     int ch;
     int copt = 0;
+    int abort = -1;
 
     while ((ch = getopt_long (argc, argv, OPTIONS, longopts, NULL)) != -1) {
         switch (ch) {
             case 'c':   /* --clique */
                 copt++;
+                break;
+            case 'a':   /* --abort */
+                abort = atoi (optarg);
                 break;
         }
     }
@@ -113,6 +118,10 @@ int main(int argc, char *argv[])
         printf ("%d: size=%d appnum=%d maxes=%d:%d:%d kvsname=%s\n",
                 rank, size, appnum, kvsname_len, key_len, val_len, kvsname);
     }
+
+    if (abort == rank)
+        PMI_Abort (1, "Test abort error. ok. yeah!");
+
     e = PMI_Finalize ();
     if (e != PMI_SUCCESS)
         log_msg_exit ("%d: PMI_Finalize: %s", rank, pmi_strerror (e));

--- a/src/shell/log.c
+++ b/src/shell/log.c
@@ -218,6 +218,7 @@ int flux_shell_err (const char *file,
 void flux_shell_fatal (const char *file,
                        int line,
                        int errnum,
+                       int exit_code,
                        const char *fmt, ...)
 {
     flux_shell_t *shell = logger.shell;
@@ -258,7 +259,7 @@ void flux_shell_fatal (const char *file,
         else
             shell_log_set_exception_logged ();
     }
-    exit (1);
+    exit (exit_code);
 }
 
 void shell_log_set_exception_logged (void)
@@ -342,7 +343,7 @@ int shell_log_reinit (flux_shell_t *shell)
         shell->verbose = 2;
     }
     if (flux_shell_log_setlevel (FLUX_SHELL_NOTICE + shell->verbose, "any") < 0)
-        shell_die ("failed to set log level");
+        shell_die (1, "failed to set log level");
     return 0;
 }
 

--- a/src/shell/output.c
+++ b/src/shell/output.c
@@ -288,7 +288,7 @@ static void shell_output_kvs_init_completion (flux_future_t *f, void *arg)
     if (flux_future_get (f, NULL) < 0)
         /* failng to commit output-ready or header is a fatal
          * error.  Should be cleaner in future. Issue #2378 */
-        shell_die_errno ("shell_output_kvs_init");
+        shell_die_errno (1, "shell_output_kvs_init");
     flux_future_destroy (f);
 
     if (flux_shell_remove_completion_ref (out->shell, "output.kvs-init") < 0)
@@ -341,7 +341,7 @@ static void shell_output_kvs_completion (flux_future_t *f, void *arg)
     /* Error failing to commit is a fatal error.  Should be cleaner in
      * future. Issue #2378 */
     if (flux_future_get (f, NULL) < 0)
-        shell_die_errno ("shell_output_kvs");
+        shell_die_errno (1, "shell_output_kvs");
     flux_future_destroy (f);
 
     if (flux_shell_remove_completion_ref (out->shell, "output.kvs") < 0)
@@ -512,12 +512,12 @@ static void shell_output_write_cb (flux_t *h,
     if ((out->stdout_type == FLUX_OUTPUT_TYPE_TERM
          || (out->stderr_type == FLUX_OUTPUT_TYPE_TERM))) {
         if (shell_output_term (out) < 0)
-            shell_die_errno ("shell_output_term");
+            shell_die_errno (1, "shell_output_term");
     }
     if ((out->stdout_type == FLUX_OUTPUT_TYPE_KVS
          || (out->stderr_type == FLUX_OUTPUT_TYPE_KVS))) {
         if (shell_output_kvs (out) < 0)
-            shell_die_errno ("shell_output_kvs");
+            shell_die_errno (1, "shell_output_kvs");
     }
     if ((out->stdout_type == FLUX_OUTPUT_TYPE_FILE
          || (out->stderr_type == FLUX_OUTPUT_TYPE_FILE))) {

--- a/src/shell/pmi.c
+++ b/src/shell/pmi.c
@@ -90,6 +90,18 @@ struct shell_pmi {
     int cycle;      // count cycles of put / barrier / get
 };
 
+static void shell_pmi_abort (void *arg,
+                             void *client,
+                             int exit_code,
+                             const char *msg)
+{
+    /* Generate job exception (exit_code ignored for now) */
+    shell_die (exit_code,
+               "MPI_Abort%s%s",
+               msg ? ": " : "",
+               msg ? msg : "");
+}
+
 static int shell_pmi_kvs_put (void *arg,
                               const char *kvsname,
                               const char *key,
@@ -417,6 +429,7 @@ static struct pmi_simple_ops shell_pmi_ops = {
     .barrier_enter  = shell_pmi_barrier_enter,
     .response_send  = shell_pmi_response_send,
     .debug_trace    = shell_pmi_debug_trace,
+    .abort          = shell_pmi_abort,
 };
 
 

--- a/src/shell/shell.h
+++ b/src/shell/shell.h
@@ -264,11 +264,11 @@ enum {
 #define shell_log_errno(...) \
     flux_shell_err (__FILE__, __LINE__, errno, __VA_ARGS__)
 
-#define shell_die(...) \
-    flux_shell_fatal (__FILE__, __LINE__, 0, __VA_ARGS__)
+#define shell_die(code,...) \
+    flux_shell_fatal (__FILE__, __LINE__, 0, code, __VA_ARGS__)
 
-#define shell_die_errno(...) \
-    flux_shell_fatal (__FILE__, __LINE__, errno, __VA_ARGS__)
+#define shell_die_errno(code,...) \
+    flux_shell_fatal (__FILE__, __LINE__, errno, code, __VA_ARGS__)
 
 #define shell_set_verbose(n) \
     flux_shell_log_setlevel(FLUX_SHELL_NOTICE+n, NULL)
@@ -298,13 +298,14 @@ int flux_shell_err (const char *file,
 
 /*  Log a message at FLUX_SHELL_FATAL level and schedule termination of
  *   the job shell. May generate an exception if tasks are already
- *   running.
+ *   running. Exits with exit_code.
  */
 void flux_shell_fatal (const char *file,
                       int line,
                       int errnum,
+                      int exit_code,
                       const char *fmt, ...)
-                      __attribute__ ((format (printf, 4, 5)));
+                      __attribute__ ((format (printf, 5, 6)));
 
 /*  Set default severity of logging destination 'dest' to level.
  *   If dest == NULL then set the internal log dispatch level --

--- a/t/shell/plugins/log.c
+++ b/t/shell/plugins/log.c
@@ -48,11 +48,11 @@ static int check_shell_log (flux_plugin_t *p,
 
     shell_rank = get_shell_rank (shell);
     if (flux_shell_getopt_unpack (shell, "log-fatal-error", "s", &s) < 0)
-        shell_die ("error parsing log-fatal-error");
+        shell_die (1, "error parsing log-fatal-error");
 
     if (s) {
         if (strcmp (s, topic) == 0 && shell_rank == 1)
-            shell_die ("log-fatal-error requested!");
+            shell_die (1, "log-fatal-error requested!");
         /* For log-fatal-error test, avoid the remaining log testing
          *  below on the non-fatal ranks
          */

--- a/t/t2602-job-shell.t
+++ b/t/t2602-job-shell.t
@@ -112,7 +112,17 @@ test_expect_success 'job-shell: PMI KVS works' '
 	flux job attach $id >kvstest.out 2>kvstest.err &&
 	grep "t phase" kvstest.out
 '
-
+test_expect_success 'job-exec: decrease kill timeout for tests' '
+	flux setattr job-exec.kill_timeout 0.1
+'
+#  Use `!` here instead of test_must_fail because flux-job attach
+#   may exit with 143, killed by signal
+#
+test_expect_success 'job-shell: PMI_Abort works' '
+	! flux mini run -N4 -n4 ${PMI_INFO} --abort=1 >abort.log 2>&1 &&
+	test_debug "cat abort.log" &&
+	grep "job.exception.*MPI_Abort: Test abort error." abort.log
+'
 test_expect_success 'job-shell: create expected I/O output' '
 	${LPTEST} | sed -e "s/^/0: /" >lptest.exp &&
 	(for i in $(seq 0 3); do \


### PR DESCRIPTION
This is a quick proof-of-concept fix for #2252. I'm not sure at all if I've done this correctly, so I'm posting now before I have any tests.

As a demo, I modified `t/mpi/hello.c` to call `MPI_Abort()` after `MPI_Init` from task 1 only.
```console
$ flux mini run -N4 -n4 t/mpi/hello
[fluke108:mpi_rank_0][smpi_load_hwloc_topology] WARNING! Invalid my_local_id: -1, Disabling hwloc topology broadcast
0: completed MPI_Init in 0.715s.  There are 4 tasks
0.849s: flux-shell[1]: FATAL: MPI_Abort: application called MPI_Abort(MPI_COMM_WORLD, 1) - process 1
0.850s: job.exception type=exec severity=0 MPI_Abort: application called MPI_Abort(MPI_COMM_WORLD, 1) - process 1
flux-job: task(s) exited with exit code 143
```

The previous behavior is that the application would hang after the Abort.