### PR TITLE
t1004-statwatcher: fix test on Ubuntu 19.10

### DIFF
--- a/t/lua/t1004-statwatcher.t
+++ b/t/lua/t1004-statwatcher.t
@@ -15,7 +15,7 @@ is (err, nil, "error is nil")
 -- Test timeout: 5s
 f:timer {
     timeout = 5000,
-    handler = function () f:reactor_stop_error () end
+    handler = function () f:reactor_stop_error ("test timed out") end
 }
 
 -- Create statwatcher for file "xyzzy"

--- a/t/lua/t1004-statwatcher.t
+++ b/t/lua/t1004-statwatcher.t
@@ -29,10 +29,9 @@ local s, err = f:statwatcher {
     handler = function (s, st, prev)
         ok (st, "got current stat ok")
         ok (prev, "got prev stat ok")
-        if not finfo.fp then
-            finfo.fp = io.open (file, "r")
-            ok (finfo.fp, "opened file")
-        end
+        finfo.fp = io.open (file, "r")
+        ok (finfo.fp, "opened file")
+        finfo.line = 0
         for line in finfo.fp:lines () do
             finfo.line = finfo.line + 1
             is (line, expected [finfo.line], "line "..finfo.line.." matches")
@@ -40,6 +39,8 @@ local s, err = f:statwatcher {
                 f:reactor_stop ()
             end
         end
+        finfo.fp:close()
+        finfo.fp = nil
     end
 }
 ok (s, "Created statwatcher")
@@ -67,7 +68,7 @@ local r, err = f:reactor ()
 ok (r, "reactor exited normally: "..tostring (err))
 
 -- Close fp so we do not carry a file reference into done_testing()
-finfo.fp:close ()
+if finfo.fp then finfo.fp:close () end
 
 done_testing ()
 


### PR DESCRIPTION
Running this test on Ubuntu 19.10 would always cause a timeout.  For
whatever reason, the second call to the statwatcher callback would not
read any additional data from the newly appended to file.  After
attempting to `strace` and `ltrace` the test, we concluded it is mostly
likely due to the EOF error flag being set on the FILE stream and not
being cleared before additional reads are attempted.

Fix by always open anew the file each time the statwatcher callback is
called.

Also add a reason string for the `reactor_stop_error` in the same test.

Fixes #2508