### PR TITLE
cronodate: fix failures and memory errors on Ubuntu 19.10

### DIFF
--- a/src/common/libutil/test/cronodate.c
+++ b/src/common/libutil/test/cronodate.c
@@ -33,6 +33,7 @@ static bool string_to_tv (char *s, struct timeval *tvp)
     struct tm tm;
     char *p = strptime (s, "%Y-%m-%d %H:%M:%S", &tm);
 
+    tm.tm_isdst = -1;
     if ((t = mktime (&tm)) == (time_t) -1)
         return (false);
 


### PR DESCRIPTION
test_cronodate.t was nondeterministically failing with large, negative
values that changed with each failure.

set `tm.tm_isdst = -1` so that `mktime` tries to determine
whether DST is in effect at the specified time.

Fixes #2512