### PR TITLE
job-exec: fix memory errors detected by valgrind

### DIFF
--- a/src/modules/job-exec/job-exec.c
+++ b/src/modules/job-exec/job-exec.c
@@ -348,6 +348,10 @@ static void kill_timer_cb (flux_reactor_t *r, flux_watcher_t *w,
  */
 static void jobinfo_cancel (struct jobinfo *job)
 {
+    /*  If a kill-timer is already active, the cancellation is in progress */
+    if (job->kill_timer)
+        return;
+
     if (job->impl->cancel)
         (*job->impl->cancel) (job);
 

--- a/src/modules/job-exec/job-exec.c
+++ b/src/modules/job-exec/job-exec.c
@@ -864,11 +864,6 @@ static int job_start (struct job_exec_ctx *ctx, const flux_msg_t *msg)
     if (!(job = jobinfo_new ()))
         return -1;
 
-    /*  Take a reference until initialization complete in case an
-     *   exception is generated during this phase
-     */
-    jobinfo_incref (job);
-
     /* Copy flux handle for each job to allow implementation access.
      * (This could also be done with an accessor, but choose the simpler
      *  approach for now)
@@ -887,6 +882,11 @@ static int job_start (struct job_exec_ctx *ctx, const flux_msg_t *msg)
         jobinfo_decref (job);
         return -1;
     }
+    /*  Take a reference until initialization complete in case an
+     *   exception is generated during this phase
+     */
+    jobinfo_incref (job);
+
     if (flux_job_kvs_namespace (job->ns, sizeof (job->ns), job->id) < 0) {
         jobinfo_fatal_error (job, errno, "failed to create ns name for job");
         flux_log_error (ctx->h, "job_ns_create");


### PR DESCRIPTION
This PR fixes the main valgrind error detected in #2519, along with a leak caused by the EPROTO test.

Valgrind now runs clean on `t2400-job-exec-test.t` on my system, but this could use a test Ubuntu 19.10 for good measure.