### PR TITLE
t: fix tests prone to races or timeouts on constrained systems

### DIFF
--- a/t/scripts/event-trace.lua
+++ b/t/scripts/event-trace.lua
@@ -56,11 +56,6 @@ local fn = assert (loadstring ("local topic,msg = ...; "..code))
 
 -- Connect to flux, subscribe, and launch command in background
 local f,err = flux.new()
-f:subscribe (s)
-
---- XXX: switch to posix.fork so we can capture failure of cmd?
-os.execute (cmd .. " &")
-
 -- Add timer if -t, --timeout was supplied
 local tw
 if opts.t then
@@ -84,5 +79,14 @@ local mh, err = f:msghandler {
 	end
     end
 }
+if err then
+   io.stderr:write("Error in registering exit event watcher\n")
+   os.exit(1)
+end
+assert (f:subscribe (s))
+
+
+--- XXX: switch to posix.fork so we can capture failure of cmd?
+os.execute (cmd .. " &")
 
 f:reactor()

--- a/t/scripts/t0004-event-helper.sh
+++ b/t/scripts/t0004-event-helper.sh
@@ -1,16 +1,15 @@
-#!/bin/sh
+#!/bin/sh -x
 
 # This is a helper for t0004-events.t
 
-if test $# -gt 0; then
-    rank=$1
-    flux exec -r $rank flux event pub testcase.foo
-    flux exec -r $rank flux event pub testcase.bar
-    flux exec -r $rank flux event pub testcase.baz
-    flux exec -r $rank flux event pub testcase.eof
-else
-    for suffix in foo bar baz; do
-       echo testcase.$suffix
+base=$1
+if test $# -gt 1; then
+    rank=$2
+    for suffix in foo bar baz eof; do
+        flux exec -r $rank flux event pub ${base}.${suffix}
     done
-    echo testcase.eof
+else
+    for suffix in foo bar baz eof; do
+       echo ${base}.${suffix}
+    done
 fi

--- a/t/t0004-event.t
+++ b/t/t0004-event.t
@@ -18,21 +18,21 @@ test_expect_success 'heartbeat is received on all ranks' '
 '
 
 test_expect_success 'events from rank 0 received correctly on rank 0' '
-	run_timeout 5 \
-          $SHARNESS_TEST_SRCDIR/scripts/event-trace.lua \
-            testcase testcase.eof \
-	      $SHARNESS_TEST_SRCDIR/scripts/t0004-event-helper.sh 0 >trace &&
-        $SHARNESS_TEST_SRCDIR/scripts/t0004-event-helper.sh >trace.expected &&
-        test_cmp trace.expected trace
+	run_timeout 15 \
+         $SHARNESS_TEST_SRCDIR/scripts/event-trace.lua \
+         t1 t1.eof \
+         $SHARNESS_TEST_SRCDIR/scripts/t0004-event-helper.sh t1 0 >trace &&
+         $SHARNESS_TEST_SRCDIR/scripts/t0004-event-helper.sh t1 >trace.expected &&
+         test_cmp trace.expected trace
 '
 
 test_expect_success "events from rank $LASTRANK received correctly on rank 0" '
-	run_timeout 5 \
-          $SHARNESS_TEST_SRCDIR/scripts/event-trace.lua \
-            testcase testcase.eof \
-	      $SHARNESS_TEST_SRCDIR/scripts/t0004-event-helper.sh $LASTRANK >trace &&
-        $SHARNESS_TEST_SRCDIR/scripts/t0004-event-helper.sh >trace.expected &&
-        test_cmp trace.expected trace
+	run_timeout 15 \
+         $SHARNESS_TEST_SRCDIR/scripts/event-trace.lua \
+         t2 t2.eof \
+         $SHARNESS_TEST_SRCDIR/scripts/t0004-event-helper.sh t2 $LASTRANK >trace &&
+         $SHARNESS_TEST_SRCDIR/scripts/t0004-event-helper.sh t2 >trace.expected &&
+         test_cmp trace.expected trace
 '
 
 test_expect_success 'publish event with no payload (loopback)' '

--- a/t/t2402-job-exec-dummy.t
+++ b/t/t2402-job-exec-dummy.t
@@ -48,11 +48,11 @@ test_expect_success 'job-exec: job shell output sent to flux log' '
 test_expect_success 'job-exec: job shell failure recorded' '
 	id=$(flux jobspec srun -N4  "test \$JOB_SHELL_RANK = 0 && exit 1" \
 	     | flux job submit) &&
-	flux job wait-event -vt 1 $id finish | grep status=256
+	flux job wait-event -vt 3 $id finish | grep status=256
 '
 test_expect_success 'job-exec: status is maximum job shell exit codes' '
 	id=$(flux jobspec srun -N4 "exit \$JOB_SHELL_RANK" | flux job submit) &&
-	flux job wait-event -vt 1 $id finish | grep status=768
+	flux job wait-event -vt 3 $id finish | grep status=768
 '
 test_expect_success 'job-exec: job exception kills job shells' '
 	id=$(flux jobspec srun -N4 sleep 300 | flux job submit) &&


### PR DESCRIPTION
`t0004-event.t`, `t1105-proxy.t`, and `t2404-job-exec-dummy.t` were all failing when run under `make -j` and occasionally failing on Travis.

This PR prevents races by switching to `event-trace.lua`, reduce timeouts by increasing the timeout windows, and avoids tests interfering with one another by removing duplicate event names.

Closes #2522
Closes #2518 
Closes #2517 