### PR TITLE
kvs: improve append performance

### DIFF
--- a/src/common/libkvs/test/treeobj.c
+++ b/src/common/libkvs/test/treeobj.c
@@ -329,6 +329,10 @@ void test_dir (void)
             && treeobj_get_count (dir) == 2
             && treeobj_get_entry (dir, "nil") == val3,
         "treeobj_insert_entry accepts json_null value");
+    ok (treeobj_insert_entry_novalidate (dir, "novalidate", val1) == 0
+            && treeobj_get_count (dir) == 3
+            && treeobj_get_entry (dir, "novalidate") == val1,
+        "treeobj_insert_entry_novalidate works");
     ok (treeobj_validate (dir) == 0,
         "treeobj_validate likes populated dir");
 
@@ -347,6 +351,18 @@ void test_dir (void)
     errno = 0;
     ok (treeobj_insert_entry (dir, "baz", NULL) < 0 && errno == EINVAL,
         "treeobj_insert_entry fails with EINVAL on NULL value");
+    errno = 0;
+    ok (treeobj_insert_entry_novalidate (val1, "foo", val1) < 0
+        && errno == EINVAL,
+        "treeobj_insert_entry_novalidate fails with EINVAL on non-dir treeobj");
+    errno = 0;
+    ok (treeobj_insert_entry_novalidate (dir, NULL, val1) < 0
+        && errno == EINVAL,
+        "treeobj_insert_entry_novalidate fails with EINVAL on NULL key");
+    errno = 0;
+    ok (treeobj_insert_entry_novalidate (dir, "baz", NULL) < 0
+        && errno == EINVAL,
+        "treeobj_insert_entry_novalidate fails with EINVAL on NULL value");
     errno = 0;
     ok (treeobj_get_entry (dir, "noexist") == NULL && errno == ENOENT,
         "treeobj_get_entry fails with ENOENT on unknown key");

--- a/src/common/libkvs/treeobj.c
+++ b/src/common/libkvs/treeobj.c
@@ -326,6 +326,28 @@ int treeobj_insert_entry (json_t *obj, const char *name, json_t *obj2)
     return 0;
 }
 
+/* identical to treeobj_insert_entry() but does not call
+ * treeobj_validate() */
+int treeobj_insert_entry_novalidate (json_t *obj,
+                                     const char *name,
+                                     json_t *obj2)
+{
+    const char *type;
+    json_t *data;
+
+    if (!name || !obj2 || treeobj_unpack (obj, &type, &data) < 0
+            || strcmp (type, "dir") != 0
+            || treeobj_peek (obj2, NULL, NULL) < 0) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (json_object_set (data, name, obj2) < 0) {
+        errno = EINVAL;
+        return -1;
+    }
+    return 0;
+}
+
 const json_t *treeobj_peek_entry (const json_t *obj, const char *name)
 {
     const char *type;

--- a/src/common/libkvs/treeobj.h
+++ b/src/common/libkvs/treeobj.h
@@ -86,6 +86,15 @@ json_t *treeobj_get_entry (json_t *obj, const char *name);
 int treeobj_insert_entry (json_t *obj, const char *name, json_t *obj2);
 int treeobj_delete_entry (json_t *obj, const char *name);
 
+/* faster version of treeobj_insert_entry(), which does not do a full
+ * treeobj_validate() call on `obj2`.  Can vastly improve performance
+ * when `obj2` is extremely large, such as an extremely long valref
+ * array or large dir object.
+ */
+int treeobj_insert_entry_novalidate (json_t *obj,
+                                     const char *name,
+                                     json_t *obj2);
+
 /* peek directory entry
  * identical to treeobj_get_entry(), but is a const equivalent.  Good
  * to use when modifications will not occur.

--- a/src/modules/kvs/kvstxn.c
+++ b/src/modules/kvs/kvstxn.c
@@ -474,7 +474,16 @@ static int kvstxn_append (kvstxn_t *kt, int current_epoch, json_t *dirent,
             return -1;
         }
 
-        if (treeobj_insert_entry (dir, final_name, cpy) < 0) {
+        /* To improve performance, call
+         * treeobj_insert_entry_novalidate() instead of
+         * treeobj_insert_entry(), as the former will not call
+         * treeobj_validate() on the internal valref treeobj array,
+         * thus avoiding expensive checks if the array is long.  Since
+         * we're appending a blobref to this KVS entry, we really only
+         * need to check the new blobref for validity.  The check done
+         * by treeobj_append_blobref() should be sufficient. */
+
+        if (treeobj_insert_entry_novalidate (dir, final_name, cpy) < 0) {
             json_decref (cpy);
             return -1;
         }


### PR DESCRIPTION
As discussed in issue #2505, this fixes performance issue "part 1" by trying to reduce calls to `treeobj_validate()` (which calls `blobref_validate()`) on appends.  The constant interating through
append blobref arrays eats up tons of CPU time.

I was originally going to create a function like `treeobj_append_blobref_to_entry (dir, key, blobref)`, but as I implemented it, the function became stupid.  Basically just a cut & paste of:

```
treeobj_get_entry()
treeobj_deep_copy()
treeobj_append_blobref()
treeobj_insert_entry()
```

which was basically the the exact same code for appending in `kvstxn.c`, except I'd replace
`treeobj_insert_entry()` with an implementation without calling `treeobj_validate()`.

So I instead created a new function which is exactly the same as `treeobj_insert_entry()` without the `treeobj_validate()` call.  I call this brand spanking new function `treeobj_insert_entry2()`
... b/c I am not creative :-)  (I just couldn't come up with something I liked.  `treeobj_insert_entry_quick()`, `no_validate()`?)

Another option is to simply write a function internal to the KVS module that does the work of `treeobj_insert_entry2()` and just not make it public.  Tree objects are public knowledge in RFCs afterall.

Running `perf record src/cmd/flux start --size=64 flux mini run -n64 t/shell/lptest 80 500`

before

```
  18.69%        265648  flux-broker-0    kvs.so                     [.] blobref_validate
  12.26%        182796  flux-broker-0    libc-2.17.so               [.] _int_malloc
   8.82%        125456  flux-broker-0    libc-2.17.so               [.] malloc_consolidate
   6.00%         91512  flux-broker-0    libc-2.17.so               [.] _int_free
   5.10%        222610  lt-flux-shell    libflux-core.so.2.0.0      [.] cbuf_is_valid
   4.69%         67577  flux-broker-0    libc-2.17.so               [.] malloc
   2.91%         41611  flux-broker-0    libc-2.17.so               [.] __strcmp_sse42
   2.84%        124329  lt-flux-shell    libpthread-2.17.so         [.] pthread_mutex_trylock
   2.31%         32737  flux-broker-0    libjansson.so.4.10.0       [.] json_string_value
   2.29%         32631  flux-broker-0    libc-2.17.so               [.] __strlen_sse2_pminub
   1.86%         27390  flux-broker-0    libc-2.17.so               [.] free
```

after

```
  18.93%        175242  flux-broker-0    libc-2.17.so                  [.] _int_malloc
  14.00%        121656  flux-broker-0    libc-2.17.so                  [.] malloc_consolidate
   9.43%         92052  flux-broker-0    libc-2.17.so                  [.] _int_free
   7.68%         67754  flux-broker-0    libc-2.17.so                  [.] malloc
   4.54%        122239  lt-flux-shell    libflux-core.so.2.0.0         [.] cbuf_is_valid
   2.85%         26445  flux-broker-0    libc-2.17.so                  [.] free
   2.58%         69517  lt-flux-shell    libpthread-2.17.so            [.] pthread_mutex_trylock
   2.04%         17650  flux-broker-0    libjansson.so.4.10.0          [.] json_delete
   1.73%         15027  flux-broker-0    libjansson.so.4.10.0          [.] json_deep_copy
   1.64%         44402  lt-flux-shell    libflux-core.so.2.0.0         [.] epoll_poll
```

before and after run-times of just `src/cmd/flux start --size=64 flux mini run -n64 t/shell/lptest 80 500` using `time`.

before

`435.153u 339.150s 4:31.15 285.5%        0+0k 0+0io 0pf+0w`

after

`268.189u 290.647s 2:45.43 337.7%        0+0k 0+0io 0pf+0w`


not the the most accurate benchmark, but the `blobref_validate()` was clearly having an impact.
