### PR TITLE
shell: improve stdout/stderr performance

### DIFF
--- a/src/common/libkvs/Makefile.am
+++ b/src/common/libkvs/Makefile.am
@@ -21,6 +21,7 @@ libkvs_la_SOURCES = \
 	kvs_dir_private.h \
 	kvs_commit.c \
 	kvs_txn.c \
+	kvs_txn_compact.c \
 	kvs_txn_private.h \
 	treeobj.h \
 	treeobj.c \

--- a/src/common/libkvs/Makefile.am
+++ b/src/common/libkvs/Makefile.am
@@ -41,6 +41,7 @@ fluxcoreinclude_HEADERS = \
 TESTS = \
 	test_kvs.t \
 	test_kvs_txn.t \
+	test_kvs_txn_compact.t \
 	test_kvs_lookup.t \
 	test_kvs_dir.t \
 	test_kvs_commit.t \
@@ -74,6 +75,10 @@ test_kvs_t_LDADD = $(test_ldadd) $(LIBDL)
 test_kvs_txn_t_SOURCES = test/kvs_txn.c
 test_kvs_txn_t_CPPFLAGS = $(test_cppflags)
 test_kvs_txn_t_LDADD = $(test_ldadd) $(LIBDL)
+
+test_kvs_txn_compact_t_SOURCES = test/kvs_txn_compact.c
+test_kvs_txn_compact_t_CPPFLAGS = $(test_cppflags)
+test_kvs_txn_compact_t_LDADD = $(test_ldadd) $(LIBDL)
 
 test_kvs_lookup_t_SOURCES = test/kvs_lookup.c
 test_kvs_lookup_t_CPPFLAGS = $(test_cppflags)

--- a/src/common/libkvs/kvs_commit.c
+++ b/src/common/libkvs/kvs_commit.c
@@ -62,6 +62,12 @@ flux_future_t *flux_kvs_fence (flux_t *h, const char *ns, int flags,
             return NULL;
     }
 
+    if (flags & FLUX_KVS_TXN_COMPACT) {
+        if (txn_compact (txn) < 0)
+            return NULL;
+        flags &= ~FLUX_KVS_TXN_COMPACT;
+    }
+
     if (!(ops = txn_get_ops (txn))) {
         errno = EINVAL;
         return NULL;
@@ -106,6 +112,12 @@ flux_future_t *flux_kvs_commit (flux_t *h, const char *ns, int flags,
     if (!ns) {
         if (!(ns = kvs_get_namespace ()))
             return NULL;
+    }
+
+    if (flags & FLUX_KVS_TXN_COMPACT) {
+        if (txn_compact (txn) < 0)
+            return NULL;
+        flags &= ~FLUX_KVS_TXN_COMPACT;
     }
 
     if (!(ops = txn_get_ops (txn))) {

--- a/src/common/libkvs/kvs_commit.h
+++ b/src/common/libkvs/kvs_commit.h
@@ -15,8 +15,19 @@
 extern "C" {
 #endif
 
+/* FLUX_KVS_TXN_COMPACT will currently consolidate appends to the same
+ * key.  For example, an append of "A" to the key "foo" and the append
+ * "B" to the key "foo" maybe consolidated into a single append of
+ * "AB".
+ *
+ * Compacting transactions means that certain ordered lists of
+ * operations will be illegal to compact and result in an error.  Most
+ * notably, if a key has data appended to it, then is overwritten in
+ * the same transaction, a compaction of appends is not possible.
+ */
 enum kvs_commit_flags {
     FLUX_KVS_NO_MERGE = 1, /* disallow commits to be mergeable with others */
+    FLUX_KVS_TXN_COMPACT = 2, /* try to combine ops on same key within txn */
 };
 
 flux_future_t *flux_kvs_commit (flux_t *h, const char *ns, int flags,

--- a/src/common/libkvs/kvs_txn.c
+++ b/src/common/libkvs/kvs_txn.c
@@ -13,6 +13,7 @@
 #endif
 #include <jansson.h>
 #include <flux/core.h>
+#include <czmq.h>
 #include <string.h>
 
 #include "kvs_txn_private.h"

--- a/src/common/libkvs/kvs_txn.c
+++ b/src/common/libkvs/kvs_txn.c
@@ -35,9 +35,6 @@
  * flux_kvs_txn_put (value=NULL) or flux_kvs_txn_put_raw (data=NULL,len=0).
  * A NULL format string passed to flux_kvs_txn_pack() is invalid.
  */
-struct flux_kvs_txn {
-    json_t *ops;
-};
 
 void flux_kvs_txn_destroy (flux_kvs_txn_t *txn)
 {

--- a/src/common/libkvs/kvs_txn_compact.c
+++ b/src/common/libkvs/kvs_txn_compact.c
@@ -1,0 +1,316 @@
+/************************************************************\
+ * Copyright 2017 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <jansson.h>
+#include <flux/core.h>
+#include <czmq.h>
+#include <string.h>
+
+#include "kvs_txn_private.h"
+#include "treeobj.h"
+
+/* Some KVS entries, such as event logs, can have many appends.
+ * Internally, a treeobject stores these appends as blobrefs in an
+ * array.  Over time, these arrays can get very long, leading to
+ * performance issues.
+ *
+ * One way to improve performance is to "compact" these appends in KVS
+ * transactions before they are commited to the KVS.  If multiple
+ * appends to the same key exist in a KVS transaction, combine them
+ * into a single append.  For example, an append of "A" to the key
+ * "foo", followed by an append of "B" to the key "foo", could be
+ * combined into a single append of "AB".
+ *
+ * By combining these appends, we can decrease the number of blobrefs
+ * stored in the blobref array.
+ *
+ * There can be complications with this approach, most notably if a
+ * user overwrites an appended value in a single transaction.  For
+ * example, if a user performs these operations to the same key in the
+ * same KVS transaction:
+ *
+ * append "A"
+ * write "B"
+ * append "c"
+ *
+ * we cannot combine the appends of "A" and "C".  In this scenario, we
+ * generate an EINVAL error to the caller, indicating that the
+ * transaction will not allow compaction.
+ */
+
+struct append_data {
+    void *data;
+    int len;
+};
+
+struct compact_key {
+    zlist_t *appends;
+    int total_len;
+    int index;
+};
+
+static void append_data_destroy (void *data)
+{
+    struct append_data *ad = data;
+    if (ad) {
+        free (ad->data);
+        free (ad);
+    }
+}
+
+static int append_data_save (struct compact_key *ck, json_t *dirent)
+{
+    struct append_data *ad = NULL;
+    int saved_errno;
+
+    if (!(ad = calloc (1, sizeof (*ad))))
+        goto error;
+
+    if (treeobj_decode_val (dirent, &ad->data, &ad->len) < 0)
+        goto error;
+
+    if (zlist_append (ck->appends, ad) < 0) {
+        errno = ENOMEM;
+        goto error;
+    }
+    zlist_freefn (ck->appends, ad, append_data_destroy, true);
+
+    ck->total_len += ad->len;
+    return 0;
+
+error:
+    saved_errno = errno;
+    append_data_destroy (ad);
+    errno = saved_errno;
+    return -1;
+}
+
+static void compact_key_destroy (void *data)
+{
+    struct compact_key *ck = data;
+    if (ck) {
+        zlist_destroy (&ck->appends);
+        free (ck);
+    }
+}
+
+static struct compact_key *compact_key_create (int index)
+{
+    struct compact_key *ck = NULL;
+    int saved_errno;
+
+    if (!(ck = calloc (1, sizeof (*ck))))
+        goto error;
+
+    if (!(ck->appends = zlist_new ()))
+        goto error;
+
+    ck->index = index;
+    return ck;
+
+error:
+    saved_errno = errno;
+    compact_key_destroy (ck);
+    errno = saved_errno;
+    return NULL;
+}
+
+static int append_compact (struct compact_key *ck, json_t *ops_new)
+{
+    struct append_data *ad;
+    json_t *dst;
+    const char *dst_key;
+    int dst_flags;
+    json_t *dst_dirent;
+    char *buf = NULL;
+    int saved_errno, rc = -1;
+    json_t *op = NULL;
+    json_t *new_dirent = NULL;
+    int offset = 0;
+
+    /* if there is only one append total, it's just the original, we
+     * don't have to do anything */
+    if (zlist_size (ck->appends) == 1)
+        return 0;
+
+    /* zero length appends are legal, if all are zero length, no
+     * modification necessary */
+    if (!ck->total_len)
+        return 0;
+
+    if (!(dst = json_array_get (ops_new, ck->index))) {
+        errno = EINVAL;
+        goto error;
+    }
+
+    if (txn_decode_op (dst, &dst_key, &dst_flags, &dst_dirent) < 0) {
+        errno = EINVAL;
+        goto error;
+    }
+
+    if (!treeobj_is_val (dst_dirent)) {
+        errno = EINVAL;
+        goto error;
+    }
+
+    if (!(buf = malloc (ck->total_len)))
+        goto error;
+
+    ad = zlist_first (ck->appends);
+    while (ad) {
+        memcpy (buf + offset, ad->data, ad->len);
+        offset += ad->len;
+        ad = zlist_next (ck->appends);
+    }
+
+    if (!(new_dirent = treeobj_create_val (buf, offset)))
+        goto error;
+
+    if (txn_encode_op (dst_key, dst_flags, new_dirent, &op) < 0)
+        goto error;
+
+    if (json_array_set_new (ops_new, ck->index, op) < 0) {
+        errno = ENOMEM;
+        goto error;
+    }
+    op = NULL;
+
+    rc = 0;
+error:
+    saved_errno = errno;
+    json_decref (op);
+    json_decref (new_dirent);
+    free (buf);
+    errno = saved_errno;
+    return rc;
+}
+
+int txn_compact (flux_kvs_txn_t *txn)
+{
+    struct compact_key *ck;
+    zhash_t *append_keys = NULL;
+    json_t *ops_new;
+    size_t len;
+    int saved_errno, i;
+
+    if (!txn) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    len = json_array_size (txn->ops);
+    if (!len)
+        return 0;
+
+    if (!(ops_new = json_array ())) {
+        errno = ENOMEM;
+        goto error;
+    }
+
+    if (!(append_keys = zhash_new ())) {
+        errno = ENOMEM;
+        goto error;
+    }
+
+    for (i = 0; i < len; i++) {
+        json_t *entry;
+        const char *key;
+        int flags;
+        json_t *dirent;
+
+        if (!(entry = json_array_get (txn->ops, i))) {
+            errno = EINVAL;
+            goto error;
+        }
+
+        if (txn_decode_op (entry, &key, &flags, &dirent) < 0)
+            goto error;
+
+        ck = zhash_lookup (append_keys, key);
+        if (ck) {
+            /* If ops array has a non-append after an append, we
+             * consider this an error.  We will not allow
+             * consolidation under these special cases */
+            if (flags != FLUX_KVS_APPEND) {
+                errno = EINVAL;
+                goto error;
+            }
+            else {
+                if (append_data_save (ck, dirent) < 0)
+                    goto error;
+            }
+        }
+        else {
+            if (flags == FLUX_KVS_APPEND) {
+                json_t *cpy;
+                int index;
+
+                /* create copy of object, don't want to modify
+                 * original
+                 */
+                if (!(cpy = json_copy (entry))) {
+                    errno = ENOMEM;
+                    goto error;
+                }
+                if (json_array_append_new (ops_new, cpy) < 0) {
+                    json_decref (cpy);
+                    errno = ENOMEM;
+                    goto error;
+                }
+                index = json_array_size (ops_new) - 1;
+
+                if (!(ck = compact_key_create (index))) {
+                    errno = ENOMEM;
+                    goto error;
+                }
+                if (zhash_insert (append_keys, key, ck) < 0) {
+                    errno = ENOMEM;
+                    goto error;
+                }
+                zhash_freefn (append_keys, key, compact_key_destroy);
+
+                if (append_data_save (ck, dirent) < 0)
+                    goto error;
+            }
+            else {
+                if (json_array_append (ops_new, entry) < 0) {
+                    errno = ENOMEM;
+                    goto error;
+                }
+            }
+        }
+    }
+
+    ck = zhash_first (append_keys);
+    while (ck) {
+        if (append_compact (ck, ops_new) < 0)
+            goto error;
+        ck = zhash_next (append_keys);
+    }
+
+    json_decref (txn->ops);
+    txn->ops = ops_new;
+    zhash_destroy (&append_keys);
+    return 0;
+
+error:
+    saved_errno = errno;
+    json_decref (ops_new);
+    zhash_destroy (&append_keys);
+    errno = saved_errno;
+    return -1;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libkvs/kvs_txn_private.h
+++ b/src/common/libkvs/kvs_txn_private.h
@@ -11,6 +11,10 @@
 #ifndef _KVS_TXN_PRIVATE_H
 #define _KVS_TXN_PRIVATE_H
 
+struct flux_kvs_txn {
+    json_t *ops;
+};
+
 int txn_get_op_count (flux_kvs_txn_t *txn);
 
 json_t *txn_get_ops (flux_kvs_txn_t *txn);

--- a/src/common/libkvs/kvs_txn_private.h
+++ b/src/common/libkvs/kvs_txn_private.h
@@ -25,6 +25,8 @@ int txn_decode_op (json_t *op, const char **key, int *flags, json_t **dirent);
 
 int txn_encode_op (const char *key, int flags, json_t *dirent, json_t **op);
 
+int txn_compact (flux_kvs_txn_t *txn);
+
 #endif /* !_KVS_TXN_PRIVATE_H */
 
 /*

--- a/src/common/libkvs/test/kvs_txn.c
+++ b/src/common/libkvs/test/kvs_txn.c
@@ -1,4 +1,4 @@
-/************************************************************\
+/************************************************************   \
  * Copyright 2014 Lawrence Livermore National Security, LLC
  * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
  *
@@ -114,6 +114,21 @@ int check_string_value (json_t *dirent, const char *expected)
     }
     json_decref (val);
     return 0;
+}
+
+int check_raw_value (json_t *dirent, const char *expected, int expected_len)
+{
+    char *data;
+    int len;
+
+    if (treeobj_decode_val (dirent, (void **)&data, &len) < 0) {
+        diag ("%s: initial base64 decode failed", __FUNCTION__);
+        return -1;
+    }
+    if (len == expected_len
+        && memcmp (data, expected, len) == 0)
+        return 0;
+    return -1;
 }
 
 void basic (void)

--- a/src/common/libkvs/test/kvs_txn_compact.c
+++ b/src/common/libkvs/test/kvs_txn_compact.c
@@ -1,0 +1,418 @@
+/************************************************************   \
+ * Copyright 2014 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <jansson.h>
+#include <string.h>
+#include <errno.h>
+
+#include "kvs.h"
+#include "kvs_txn_private.h"
+#include "treeobj.h"
+
+#include "src/common/libtap/tap.h"
+
+/* Decode a 'val' containing base64 encoded emptiness.
+ */
+int check_null_value (json_t *dirent)
+{
+    char *data = "";
+    int len = -1;
+
+    if (treeobj_decode_val (dirent, (void **)&data, &len) < 0) {
+        diag ("%s: initial base64 decode failed", __FUNCTION__);
+        return -1;
+    }
+    if (len != 0 || data != NULL) {
+        diag ("%s: len=%d data=%p", __FUNCTION__, len, data);
+        return -1;
+    }
+    return 0;
+}
+
+int check_raw_value (json_t *dirent, const char *expected, int expected_len)
+{
+    char *data;
+    int len;
+
+    if (treeobj_decode_val (dirent, (void **)&data, &len) < 0) {
+        diag ("%s: initial base64 decode failed", __FUNCTION__);
+        return -1;
+    }
+    if (len == expected_len
+        && memcmp (data, expected, len) == 0)
+        return 0;
+    return -1;
+}
+
+int main (int argc, char *argv[])
+{
+    flux_kvs_txn_t *txn;
+    int rc;
+    const char *key;
+    json_t *entry, *dirent;
+    int flags;
+
+    plan (NO_PLAN);
+
+    errno = 0;
+    ok (txn_compact (NULL) < 0
+        && errno == EINVAL,
+        "txn_compact fails on bad input");
+
+    /* Test 0: append consolidate corner cases
+     */
+    txn = flux_kvs_txn_create ();
+    ok (txn != NULL,
+        "flux_kvs_txn_create works");
+
+    ok (txn_compact (txn) == 0,
+        "txn_compact returns success on 0 length txns");
+
+    flux_kvs_txn_destroy (txn);
+
+    /* Test 1: basic consolidation works */
+
+    txn = flux_kvs_txn_create ();
+    ok (txn != NULL,
+        "flux_kvs_txn_create works");
+
+    rc = flux_kvs_txn_put (txn, FLUX_KVS_APPEND, "foo", "A");
+    ok (rc == 0,
+        "flux_kvs_txn_put flags=FLUX_KVS_APPEND works");
+    rc = flux_kvs_txn_put (txn, FLUX_KVS_APPEND, "foo", "B");
+    ok (rc == 0,
+        "flux_kvs_txn_put flags=FLUX_KVS_APPEND works");
+    rc = flux_kvs_txn_put (txn, FLUX_KVS_APPEND, "foo", "C");
+    ok (rc == 0,
+        "flux_kvs_txn_put flags=FLUX_KVS_APPEND works");
+
+    /* Verify transaction contents
+     */
+    ok (txn_get_op_count (txn) == 3,
+        "txn contains 3 ops");
+
+    ok (txn_compact (txn) == 0,
+        "txn_compact returns success");
+
+    ok (txn_get_op_count (txn) == 1,
+        "txn contains 1 ops");
+    ok (txn_get_op (txn, 0, &entry) == 0
+        && entry != NULL,
+        "1: retrieved");
+    ok (txn_decode_op (entry, &key, &flags, &dirent) == 0,
+        "1: txn_decode_op works");
+    ok (!strcmp (key, "foo")
+        && flags == FLUX_KVS_APPEND
+        && check_raw_value (dirent, "ABC", 3) == 0,
+        "1: consolidated foo = ABC");
+
+    flux_kvs_txn_destroy (txn);
+
+    /* Test 2: other keys aren't affected */
+
+    txn = flux_kvs_txn_create ();
+    ok (txn != NULL,
+        "flux_kvs_txn_create works");
+
+    rc = flux_kvs_txn_put (txn, FLUX_KVS_APPEND, "foo", "A");
+    ok (rc == 0,
+        "flux_kvs_txn_put flags=FLUX_KVS_APPEND works");
+    rc = flux_kvs_txn_put (txn, FLUX_KVS_APPEND, "bar", "B");
+    ok (rc == 0,
+        "flux_kvs_txn_put flags=FLUX_KVS_APPEND works");
+    rc = flux_kvs_txn_put (txn, FLUX_KVS_APPEND, "foo", "C");
+    ok (rc == 0,
+        "flux_kvs_txn_put flags=FLUX_KVS_APPEND works");
+
+    /* Verify transaction contents
+     */
+    ok (txn_get_op_count (txn) == 3,
+        "txn contains 3 ops");
+
+    ok (txn_compact (txn) == 0,
+        "txn_compact returns success");
+
+    ok (txn_get_op_count (txn) == 2,
+        "txn contains 2 ops");
+    ok (txn_get_op (txn, 0, &entry) == 0
+        && entry != NULL,
+        "1: retrieved");
+    ok (txn_decode_op (entry, &key, &flags, &dirent) == 0,
+        "1: txn_decode_op works");
+    ok (!strcmp (key, "foo")
+        && flags == FLUX_KVS_APPEND
+        && check_raw_value (dirent, "AC", 2) == 0,
+        "1: consolidated foo = AC");
+    ok (txn_get_op (txn, 1, &entry) == 0
+        && entry != NULL,
+        "2: retrieved");
+    ok (txn_decode_op (entry, &key, &flags, &dirent) == 0,
+        "2: txn_decode_op works");
+    ok (!strcmp (key, "bar")
+        && flags == FLUX_KVS_APPEND
+        && check_raw_value (dirent, "B", 1) == 0,
+        "2: bar = B");
+
+    flux_kvs_txn_destroy (txn);
+
+    /* Test 3: can consolidate on multiple keys */
+
+    txn = flux_kvs_txn_create ();
+    ok (txn != NULL,
+        "flux_kvs_txn_create works");
+
+    rc = flux_kvs_txn_put (txn, FLUX_KVS_APPEND, "foo", "A");
+    ok (rc == 0,
+        "flux_kvs_txn_put flags=FLUX_KVS_APPEND works");
+    rc = flux_kvs_txn_put (txn, FLUX_KVS_APPEND, "bar", "B");
+    ok (rc == 0,
+        "flux_kvs_txn_put flags=FLUX_KVS_APPEND works");
+    rc = flux_kvs_txn_put (txn, FLUX_KVS_APPEND, "foo", "C");
+    ok (rc == 0,
+        "flux_kvs_txn_put flags=FLUX_KVS_APPEND works");
+    rc = flux_kvs_txn_put (txn, FLUX_KVS_APPEND, "bar", "D");
+    ok (rc == 0,
+        "flux_kvs_txn_put flags=FLUX_KVS_APPEND works");
+
+    /* Verify transaction contents
+     */
+    ok (txn_get_op_count (txn) == 4,
+        "txn contains 3 ops");
+
+    ok (txn_compact (txn) == 0,
+        "txn_compact returns success");
+
+    ok (txn_get_op_count (txn) == 2,
+        "txn contains 2 ops");
+    ok (txn_get_op (txn, 0, &entry) == 0
+        && entry != NULL,
+        "1: retrieved");
+    ok (txn_decode_op (entry, &key, &flags, &dirent) == 0,
+        "1: txn_decode_op works");
+    ok (!strcmp (key, "foo")
+        && flags == FLUX_KVS_APPEND
+        && check_raw_value (dirent, "AC", 2) == 0,
+        "1: consolidated foo = AC");
+    ok (txn_get_op (txn, 1, &entry) == 0
+        && entry != NULL,
+        "2: retrieved");
+    ok (txn_decode_op (entry, &key, &flags, &dirent) == 0,
+        "2: txn_decode_op works");
+    ok (!strcmp (key, "bar")
+        && flags == FLUX_KVS_APPEND
+        && check_raw_value (dirent, "BD", 2) == 0,
+        "2: bar = BD");
+
+    flux_kvs_txn_destroy (txn);
+
+    /* Test 4: non-append before appends ok */
+
+    txn = flux_kvs_txn_create ();
+    ok (txn != NULL,
+        "flux_kvs_txn_create works");
+
+    rc = flux_kvs_txn_put (txn, 0, "foo", "A");
+    ok (rc == 0,
+        "flux_kvs_txn_put flags=0 works");
+    rc = flux_kvs_txn_put (txn, FLUX_KVS_APPEND, "foo", "B");
+    ok (rc == 0,
+        "flux_kvs_txn_put flags=FLUX_KVS_APPEND works");
+    rc = flux_kvs_txn_put (txn, FLUX_KVS_APPEND, "foo", "C");
+    ok (rc == 0,
+        "flux_kvs_txn_put flags=FLUX_KVS_APPEND works");
+
+    /* Verify transaction contents
+     */
+    ok (txn_get_op_count (txn) == 3,
+        "txn contains 3 ops");
+
+    ok (txn_compact (txn) == 0,
+        "txn_compact returns success");
+
+    ok (txn_get_op_count (txn) == 2,
+        "txn contains 2 ops");
+    ok (txn_get_op (txn, 0, &entry) == 0
+        && entry != NULL,
+        "1: retrieved");
+    ok (txn_decode_op (entry, &key, &flags, &dirent) == 0,
+        "1: txn_decode_op works");
+    ok (!strcmp (key, "foo")
+        && flags == 0
+        && check_raw_value (dirent, "A", 1) == 0,
+        "1: consolidated foo = A");
+    ok (txn_get_op (txn, 1, &entry) == 0
+        && entry != NULL,
+        "2: retrieved");
+    ok (txn_decode_op (entry, &key, &flags, &dirent) == 0,
+        "2: txn_decode_op works");
+    ok (!strcmp (key, "foo")
+        && flags == FLUX_KVS_APPEND
+        && check_raw_value (dirent, "BC", 2) == 0,
+        "2: foo = BC");
+
+    flux_kvs_txn_destroy (txn);
+
+    /* Test 5: non-append after append leads to error */
+
+    txn = flux_kvs_txn_create ();
+    ok (txn != NULL,
+        "flux_kvs_txn_create works");
+
+    rc = flux_kvs_txn_put (txn, FLUX_KVS_APPEND, "foo", "A");
+    ok (rc == 0,
+        "flux_kvs_txn_put flags=0 works");
+    rc = flux_kvs_txn_put (txn, 0, "foo", "B");
+    ok (rc == 0,
+        "flux_kvs_txn_put flags=0 works");
+
+    ok (txn_compact (txn) < 0
+        && errno == EINVAL,
+        "txn_compact errors on non-append after append on key \"foo\"");
+
+    flux_kvs_txn_destroy (txn);
+
+    /* Test 6: zero length append consolidation works */
+
+    txn = flux_kvs_txn_create ();
+    ok (txn != NULL,
+        "flux_kvs_txn_create works");
+
+    rc = flux_kvs_txn_put (txn, FLUX_KVS_APPEND, "foo", "A");
+    ok (rc == 0,
+        "flux_kvs_txn_put flags=FLUX_KVS_APPEND works");
+    rc = flux_kvs_txn_put_raw (txn, FLUX_KVS_APPEND, "foo", NULL, 0);
+    ok (rc == 0,
+        "flux_kvs_txn_put_raw flags=FLUX_KVS_APPEND works");
+    rc = flux_kvs_txn_put_raw (txn, FLUX_KVS_APPEND, "foo", NULL, 0);
+    ok (rc == 0,
+        "flux_kvs_txn_put_raw flags=FLUX_KVS_APPEND works");
+
+    /* Verify transaction contents
+     */
+    ok (txn_get_op_count (txn) == 3,
+        "txn contains 3 ops");
+
+    ok (txn_compact (txn) == 0,
+        "txn_compact returns success");
+
+    ok (txn_get_op_count (txn) == 1,
+        "txn contains 1 ops");
+    ok (txn_get_op (txn, 0, &entry) == 0
+        && entry != NULL,
+        "1: retrieved");
+    ok (txn_decode_op (entry, &key, &flags, &dirent) == 0,
+        "1: txn_decode_op works");
+    ok (!strcmp (key, "foo")
+        && flags == FLUX_KVS_APPEND
+        && check_raw_value (dirent, "A", 1) == 0,
+        "1: consolidated foo = A");
+
+    flux_kvs_txn_destroy (txn);
+
+    /* Test 7: all zero length append consolidation works */
+
+    txn = flux_kvs_txn_create ();
+    ok (txn != NULL,
+        "flux_kvs_txn_create works");
+
+    rc = flux_kvs_txn_put_raw (txn, FLUX_KVS_APPEND, "foo", NULL, 0);
+    ok (rc == 0,
+        "flux_kvs_txn_put_raw flags=FLUX_KVS_APPEND works");
+    rc = flux_kvs_txn_put_raw (txn, FLUX_KVS_APPEND, "foo", NULL, 0);
+    ok (rc == 0,
+        "flux_kvs_txn_put_raw flags=FLUX_KVS_APPEND works");
+    rc = flux_kvs_txn_put_raw (txn, FLUX_KVS_APPEND, "foo", NULL, 0);
+    ok (rc == 0,
+        "flux_kvs_txn_put_raw flags=FLUX_KVS_APPEND works");
+
+    /* Verify transaction contents
+     */
+    ok (txn_get_op_count (txn) == 3,
+        "txn contains 3 ops");
+
+    ok (txn_compact (txn) == 0,
+        "txn_compact returns success");
+
+    ok (txn_get_op_count (txn) == 1,
+        "txn contains 1 ops");
+    ok (txn_get_op (txn, 0, &entry) == 0
+        && entry != NULL,
+        "1: retrieved");
+    ok (txn_decode_op (entry, &key, &flags, &dirent) == 0,
+        "1: txn_decode_op works");
+    ok (!strcmp (key, "foo")
+        && flags == FLUX_KVS_APPEND
+        && check_null_value (dirent) == 0,
+        "1: consolidated foo = A");
+
+    /* Test 8: single append is a no-op */
+
+    txn = flux_kvs_txn_create ();
+    ok (txn != NULL,
+        "flux_kvs_txn_create works");
+
+    rc = flux_kvs_txn_put (txn, FLUX_KVS_APPEND, "foo", "A");
+    ok (rc == 0,
+        "flux_kvs_txn_put flags=0 works");
+
+    /* Verify transaction contents
+     */
+    ok (txn_get_op_count (txn) == 1,
+        "txn contains 1 ops");
+
+    ok (txn_compact (txn) == 0,
+        "txn_compact returns success");
+
+    ok (txn_get_op_count (txn) == 1,
+        "txn contains 1 ops");
+
+    flux_kvs_txn_destroy (txn);
+
+    /* Test 9: no appending is a no-op */
+
+    txn = flux_kvs_txn_create ();
+    ok (txn != NULL,
+        "flux_kvs_txn_create works");
+
+    rc = flux_kvs_txn_put (txn, 0, "foo", "A");
+    ok (rc == 0,
+        "flux_kvs_txn_put flags=0 works");
+    rc = flux_kvs_txn_put (txn, 0, "foo", "B");
+    ok (rc == 0,
+        "flux_kvs_txn_put flags=0 works");
+    rc = flux_kvs_txn_put (txn, 0, "foo", "C");
+    ok (rc == 0,
+        "flux_kvs_txn_put flags=0 works");
+
+    /* Verify transaction contents
+     */
+    ok (txn_get_op_count (txn) == 3,
+        "txn contains 3 ops");
+
+    ok (txn_compact (txn) == 0,
+        "txn_compact returns success");
+
+    ok (txn_get_op_count (txn) == 3,
+        "txn contains 3 ops");
+
+    flux_kvs_txn_destroy (txn);
+
+    done_testing();
+    return (0);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */
+

--- a/src/shell/eventlogger.c
+++ b/src/shell/eventlogger.c
@@ -111,8 +111,9 @@ timer_cb (flux_reactor_t *r, flux_watcher_t *w, int revents, void *arg)
     flux_t *h = ev->h;
     double timeout = ev->commit_timeout;
     flux_future_t *f = NULL;
+    int flags = FLUX_KVS_TXN_COMPACT;
 
-    if (!(f = flux_kvs_commit (h, NULL, 0, batch->txn))
+    if (!(f = flux_kvs_commit (h, NULL, flags, batch->txn))
         || flux_future_then (f, timeout, commit_cb, batch) < 0) {
         eventlog_batch_error (batch, errno);
         return;
@@ -267,11 +268,12 @@ int eventlogger_flush (struct eventlogger *ev)
     int rc = -1;
     flux_future_t *f = NULL;
     struct eventlog_batch *batch;
+    int flags = FLUX_KVS_TXN_COMPACT;
 
     if (!(batch = eventlog_batch_get (ev)))
         return -1;
 
-    if (!(f = flux_kvs_commit (ev->h, NULL, 0, ev->current->txn))
+    if (!(f = flux_kvs_commit (ev->h, NULL, flags, ev->current->txn))
         || flux_future_wait_for (f, ev->commit_timeout) < 0)
         goto out;
     if ((rc = flux_future_get (f, NULL)) < 0)

--- a/src/shell/eventlogger.h
+++ b/src/shell/eventlogger.h
@@ -60,6 +60,8 @@ int eventlogger_append_entry (struct eventlogger *ev,
 
 int eventlogger_set_commit_timeout (struct eventlogger *ev, double timeout);
 
+int eventlogger_flush (struct eventlogger *ev);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/shell/eventlogger.h
+++ b/src/shell/eventlogger.h
@@ -53,6 +53,11 @@ int eventlogger_append (struct eventlogger *ev,
                         const char *name,
                         const char *context);
 
+int eventlogger_append_entry (struct eventlogger *ev,
+                              int flags,
+                              const char *path,
+                              json_t *entry);
+
 int eventlogger_set_commit_timeout (struct eventlogger *ev, double timeout);
 
 #ifdef __cplusplus

--- a/src/shell/output.c
+++ b/src/shell/output.c
@@ -491,6 +491,13 @@ static void shell_output_write_cb (flux_t *h,
             flux_msg_handler_stop (mh);
             if (flux_shell_remove_completion_ref (out->shell, "output.write") < 0)
                 shell_log_errno ("flux_shell_remove_completion_ref");
+            /* no more output is coming, flush the last batch of
+             * output */
+            if ((out->stdout_type == FLUX_OUTPUT_TYPE_KVS
+                 || (out->stderr_type == FLUX_OUTPUT_TYPE_KVS))) {
+                if (eventlogger_flush (out->ev) < 0)
+                    shell_log_errno ("eventlogger_flush");
+            }
         }
     }
     if (flux_respond (out->shell->h, msg, NULL) < 0)

--- a/t/kvs/fence_invalid.c
+++ b/t/kvs/fence_invalid.c
@@ -89,12 +89,12 @@ int main (int argc, char *argv[])
 
     /* alter flags to generate an error on second fence */
 
-    if (!(f1 = flux_kvs_fence (h, NULL, 0x1, fence_name, 2, txn1))) {
+    if (!(f1 = flux_kvs_fence (h, NULL, 0x10, fence_name, 2, txn1))) {
         log_err ("flux_kvs_fence");
         goto done;
     }
 
-    if (!(f2 = flux_kvs_fence (h, NULL, 0x2, fence_name, 2, txn2))) {
+    if (!(f2 = flux_kvs_fence (h, NULL, 0x20, fence_name, 2, txn2))) {
         log_err ("flux_kvs_fence");
         goto done;
     }


### PR DESCRIPTION
Per discussion in #2528 (and #2505), improve performance of shell stdout/stderr by reducing

A) the number of times we call KVS commit

This is accomplished using the shell `eventlogger` API, patch provided by @grondo.  I added an additional `eventlogger_flush()` call so that we flush all pending KVS transactions when we receive all EOFs we're going to get.

@grondo, I left your patch intact except for removing some lingering `fprintf()` calls.  In order to avoid unit test failures due to an additional log output, tweaked your parsing of `batch-timeout`.  I left it as a separate commit, but we could just squash that into your commit later.

B) the number of appends on the output eventlog

This is accomplished with a new function `flux_kvs_txn_append_consolidate()`.  In a single KVS transaction, it will consolidate all appends to a key into a single append.

`perf record` results running `src/cmd/flux start --size=64 flux mini run -n64 t/shell/lptest 80 500`

before

```
  19.04%        180918  flux-broker-0    libc-2.17.so               [.] _int_malloc
  13.98%        124022  flux-broker-0    libc-2.17.so               [.] malloc_consolidate
   9.56%         95375  flux-broker-0    libc-2.17.so               [.] _int_free
   7.40%         67031  flux-broker-0    libc-2.17.so               [.] malloc
   4.64%        122248  lt-flux-shell    libflux-core.so.2.0.0      [.] cbuf_is_valid
   2.81%         26481  flux-broker-0    libc-2.17.so               [.] free
   2.58%         67936  lt-flux-shell    libpthread-2.17.so         [.] pthread_mutex_trylock
   1.99%         17648  flux-broker-0    libjansson.so.4.10.0       [.] json_delete
   1.87%         49914  lt-flux-shell    libflux-core.so.2.0.0      [.] epoll_poll
   1.75%         15453  flux-broker-0    libjansson.so.4.10.0       [.] json_deep_copy
```

after


```
   4.99%          5228  flux-broker-0    libsodium.so.23.3.0        [.] sodium_base642bin
   2.04%          9923  flux-broker-0    libc-2.17.so               [.] __libc_calloc
   1.98%          3180  flux-broker-0    libc-2.17.so               [.] __memcpy_ssse3_back
   1.72%          1913  flux-broker-0    libsodium.so.23.3.0        [.] sodium_bin2base64
   1.51%          6915  flux-broker-0    libc-2.17.so               [.] _int_malloc
   1.16%          5255  flux-broker-0    libc-2.17.so               [.] _int_free
   0.87%           998  flux-broker-0    libjansson.so.4.10.0       [.] 0x0000000000007e3a
   0.80%           916  flux-broker-0    libjansson.so.4.10.0       [.] 0x0000000000007e33
   0.67%          1873  lt-flux-broker   libsodium.so.23.3.0        [.] crypto_core_hsalsa20
   0.57%          1586  lt-flux-shell    libc-2.17.so               [.] _int_malloc
```

We see the desired effect of reducing the number of append calls, which reduces a large number of `json_deep_copy()` calls, which cause a ton of mallocs.

And running `time`:

before

`269.044u 294.428s 2:45.30 340.8%       0+0k 0+0io 0pf+0w`

after

`37.825u 221.158s 0:28.00 924.8%        0+0k 0+0io 0pf+0w`

So going from about 2:45 to 0:28 ~ 87% wallclock time drop.  Seems pretty good :-)
