### PR TITLE
python: add jobspec classes to main bindings

### DIFF
--- a/src/bindings/python/flux/job.py
+++ b/src/bindings/python/flux/job.py
@@ -18,7 +18,7 @@ import six
 import yaml
 
 from flux.wrapper import Wrapper
-from flux.util import check_future_error
+from flux.util import check_future_error, parse_fsd
 from flux.future import Future
 from _flux._core import ffi, lib
 
@@ -145,26 +145,6 @@ class Jobspec(object):
         slot["label"] = label
         return slot
 
-    def _parse_fsd(self, s):
-        m = re.match(r".*([smhd])$", s)
-        try:
-            n = float(s[:-1] if m else s)
-        except:
-            raise ValueError("invalid Flux standard duration")
-        unit = m.group(1) if m else "s"
-
-        if unit == "m":
-            seconds = timedelta(minutes=n).total_seconds()
-        elif unit == "h":
-            seconds = timedelta(hours=n).total_seconds()
-        elif unit == "d":
-            seconds = timedelta(days=n).total_seconds()
-        else:
-            seconds = n
-        if seconds < 0 or math.isnan(seconds) or math.isinf(seconds):
-            raise ValueError("invalid Flux standard duration")
-        return seconds
-
     def set_duration(self, duration):
         """
         Assign a time limit to the job.  The duration may be:
@@ -173,7 +153,7 @@ class Jobspec(object):
         A duration of zero is interpreted as "not set".
         """
         if isinstance(duration, six.string_types):
-            time = self._parse_fsd(duration)
+            time = parse_fsd(duration)
         elif isinstance(duration, float):
             time = duration
         else:

--- a/src/bindings/python/flux/job.py
+++ b/src/bindings/python/flux/job.py
@@ -357,7 +357,7 @@ class Jobspec(object):
         """
         self._set_treedict(self.jobspec, "attributes." + key, val)
 
-    def setattr_shopt(self, key, val):
+    def setattr_shell_option(self, key, val):
         """
         set job attribute: shell option
         """

--- a/src/bindings/python/flux/job.py
+++ b/src/bindings/python/flux/job.py
@@ -39,7 +39,9 @@ RAW = JobWrapper()
 
 
 def submit_async(flux_handle, jobspec, priority=lib.FLUX_JOB_PRIORITY_DEFAULT, flags=0):
-    if isinstance(jobspec, six.text_type):
+    if isinstance(jobspec, Jobspec):
+        jobspec = jobspec.dumps()
+    elif isinstance(jobspec, six.text_type):
         jobspec = jobspec.encode("utf-8")
     elif jobspec is None or jobspec == ffi.NULL:
         # catch this here rather than in C for a better error message
@@ -349,8 +351,8 @@ class Jobspec(object):
         """
         self.setattr("system.shell.options." + key, val)
 
-    def dumps(self):
-        return json.dumps(self.jobspec)
+    def dumps(self, **kwargs):
+        return json.dumps(self.jobspec, **kwargs)
 
     @property
     def resources(self):

--- a/src/cmd/flux-mini.py
+++ b/src/cmd/flux-mini.py
@@ -196,10 +196,10 @@ class SubmitCmd:
             gpus_per_task=args.gpus_per_task,
             num_nodes=args.nodes,
         )
-        jobspec.set_cwd(os.getcwd())
-        jobspec.set_environment(dict(os.environ))
+        jobspec.cwd = os.getcwd()
+        jobspec.environment = dict(os.environ)
         if args.time_limit is not None:
-            jobspec.set_duration(args.time_limit)
+            jobspec.duration = args.time_limit
 
         if args.job_name is not None:
             jobspec.setattr("system.job.name", args.job_name)

--- a/src/cmd/flux-mini.py
+++ b/src/cmd/flux-mini.py
@@ -205,20 +205,20 @@ class SubmitCmd:
             jobspec.setattr("system.job.name", args.job_name)
 
         if args.input is not None:
-            jobspec.setattr_shopt("input.stdin.type", "file")
-            jobspec.setattr_shopt("input.stdin.path", args.input)
+            jobspec.setattr_shell_option("input.stdin.type", "file")
+            jobspec.setattr_shell_option("input.stdin.path", args.input)
 
         if args.output is not None:
-            jobspec.setattr_shopt("output.stdout.type", "file")
-            jobspec.setattr_shopt("output.stdout.path", args.output)
+            jobspec.setattr_shell_option("output.stdout.type", "file")
+            jobspec.setattr_shell_option("output.stdout.path", args.output)
             if args.label_io:
-                jobspec.setattr_shopt("output.stdout.label", True)
+                jobspec.setattr_shell_option("output.stdout.label", True)
 
         if args.error is not None:
-            jobspec.setattr_shopt("output.stderr.type", "file")
-            jobspec.setattr_shopt("output.stderr.path", args.error)
+            jobspec.setattr_shell_option("output.stderr.type", "file")
+            jobspec.setattr_shell_option("output.stderr.path", args.error)
             if args.label_io:
-                jobspec.setattr_shopt("output.stderr.label", True)
+                jobspec.setattr_shell_option("output.stderr.label", True)
 
         if args.setopt is not None:
             for kv in args.setopt:
@@ -228,7 +228,7 @@ class SubmitCmd:
                     val = json.loads(val)
                 except:
                     pass
-                jobspec.setattr_shopt(key, val)
+                jobspec.setattr_shell_option(key, val)
 
         if args.setattr is not None:
             for kv in args.setattr:

--- a/src/cmd/flux-mini.py
+++ b/src/cmd/flux-mini.py
@@ -18,7 +18,7 @@ import json
 
 import flux
 from flux import job
-from flux.job import JobSpec
+from flux.job import JobspecV1
 from flux import util
 from flux import constants
 
@@ -189,7 +189,7 @@ class SubmitCmd:
         if not args.command:
             raise ValueError("job command and arguments are missing")
 
-        jobspec = JobSpec(
+        jobspec = JobspecV1.from_command(
             args.command,
             num_tasks=args.ntasks,
             cores_per_task=args.cores_per_task,

--- a/src/cmd/flux-mini.py
+++ b/src/cmd/flux-mini.py
@@ -10,174 +10,17 @@
 
 from __future__ import print_function
 
-import re
 import os
 import sys
-import math
 import logging
 import argparse
 import json
-import collections
 
-try:
-    collectionsAbc = collections.abc
-except AttributeError:
-    collectionsAbc = collections
-
-import six
 import flux
 from flux import job
+from flux.job import JobSpec
 from flux import util
 from flux import constants
-from datetime import timedelta
-
-
-class JobSpec:
-    def __init__(
-        self, command, num_tasks=1, cores_per_task=1, gpus_per_task=None, num_nodes=None
-    ):
-        """
-        Constructor builds the minimum legal v1 jobspec.
-        Use setters to assign additional properties.
-        """
-        if not isinstance(command, (list, tuple)) or not command:
-            raise ValueError("command must be a non-empty list or tuple")
-        if not isinstance(num_tasks, int) or num_tasks < 1:
-            raise ValueError("task count must be a integer >= 1")
-        if not isinstance(cores_per_task, int) or cores_per_task < 1:
-            raise ValueError("cores per task must be an integer >= 1")
-        if gpus_per_task is not None:
-            if not isinstance(gpus_per_task, int) or gpus_per_task < 1:
-                raise ValueError("gpus per task must be an integer >= 1")
-        if num_nodes is not None:
-            if not isinstance(num_nodes, int) or num_nodes < 1:
-                raise ValueError("node count must be an integer >= 1 (if set)")
-            if num_nodes > num_tasks:
-                raise ValueError("node count must not be greater than task count")
-        children = [self.__create_resource("core", cores_per_task)]
-        if gpus_per_task is not None:
-            children.append(self.__create_resource("gpu", gpus_per_task))
-        if num_nodes is not None:
-            num_slots = int(math.ceil(num_tasks / float(num_nodes)))
-            if num_tasks % num_nodes != 0:
-                # N.B. uneven distribution results in wasted task slots
-                task_count_dict = {"total": num_tasks}
-            else:
-                task_count_dict = {"per_slot": 1}
-            slot = self.__create_slot("task", num_slots, children)
-            resource_section = self.__create_resource("node", num_nodes, [slot])
-        else:
-            task_count_dict = {"per_slot": 1}
-            slot = self.__create_slot("task", num_tasks, children)
-            resource_section = slot
-
-        self.jobspec = {
-            "version": 1,
-            "resources": [resource_section],
-            "tasks": [{"command": command, "slot": "task", "count": task_count_dict}],
-            "attributes": {"system": {"duration": 0}},
-        }
-
-    def __create_resource(self, res_type, count, with_child=[]):
-        assert isinstance(
-            with_child, collectionsAbc.Sequence
-        ), "child resource must be a sequence"
-        assert not isinstance(
-            with_child, six.string_types
-        ), "child resource must not be a string"
-        assert count > 0, "resource count must be > 0"
-
-        res = {"type": res_type, "count": count}
-
-        if len(with_child) > 0:
-            res["with"] = with_child
-        return res
-
-    def __create_slot(self, label, count, with_child):
-        slot = self.__create_resource("slot", count, with_child)
-        slot["label"] = label
-        return slot
-
-    def __parse_fsd(self, s):
-        m = re.match(r".*([smhd])$", s)
-        try:
-            n = float(s[:-1] if m else s)
-        except:
-            raise ValueError("invalid Flux standard duration")
-        unit = m.group(1) if m else "s"
-
-        if unit == "m":
-            seconds = timedelta(minutes=n).total_seconds()
-        elif unit == "h":
-            seconds = timedelta(hours=n).total_seconds()
-        elif unit == "d":
-            seconds = timedelta(days=n).total_seconds()
-        else:
-            seconds = n
-        if seconds < 0 or math.isnan(seconds) or math.isinf(seconds):
-            raise ValueError("invalid Flux standard duration")
-        return seconds
-
-    def set_duration(self, duration):
-        """
-        Assign a time limit to the job.  The duration may be:
-        - a float in seconds
-        - a string in Flux Standard Duration
-        A duration of zero is interpreted as "not set".
-        """
-        if isinstance(duration, six.string_types):
-            t = self.__parse_fsd(duration)
-        elif isinstance(duration, float):
-            t = duration
-        else:
-            raise ValueError("duration must be a float or string")
-        if t < 0:
-            raise ValueError("duration must not be negative")
-        if math.isnan(t) or math.isinf(t):
-            raise ValueError("duration must be a normal, finite value")
-        self.jobspec["attributes"]["system"]["duration"] = t
-
-    def set_cwd(self, cwd):
-        """
-        Set working directory of job.
-        """
-        if not isinstance(cwd, six.string_types):
-            raise ValueError("cwd must be a string")
-        self.jobspec["attributes"]["system"]["cwd"] = cwd
-
-    def set_environment(self, environ):
-        """
-        Set (entire) environment of job.
-        """
-        if not isinstance(environ, collectionsAbc.Mapping):
-            raise ValueError("environment must be a mapping")
-        self.jobspec["attributes"]["system"]["environment"] = environ
-
-    def __set_treedict(self, d, key, val):
-        """
-        __set_treedict(d, "a.b.c", 42) is like d[a][b][c] = 42
-        but levels are created on demand.
-        """
-        path = key.split(".", 1)
-        if len(path) == 2:
-            self.__set_treedict(d.setdefault(path[0], {}), path[1], val)
-        else:
-            d[key] = val
-
-    def setattr(self, key, val):
-        """
-        set job attribute
-        """
-        self.__set_treedict(self.jobspec, "attributes." + key, val)
-
-    def setattr_shopt(self, key, val):
-        """
-        set job attribute: shell option
-        """
-        self.setattr("system.shell.options." + key, val)
-
-    def dumps(self):
-        return json.dumps(self.jobspec)
 
 
 class CleanFormatter(argparse.HelpFormatter):

--- a/t/job-manager/bulk-state.py
+++ b/t/job-manager/bulk-state.py
@@ -17,21 +17,11 @@
 
 import flux
 from flux import job
+from flux.job import JobspecV1
 import sys
 import subprocess
 
 expected_states = ["NEW", "DEPEND", "SCHED", "RUN", "CLEANUP", "INACTIVE"]
-
-# Return jobspec for a simple job
-def make_jobspec():
-    out = subprocess.Popen(
-        ["flux", "jobspec", "srun", "hostname"],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-    )
-    stdout, stderr = out.communicate()
-    return stdout
-
 
 # Return True if all jobs in the jobs dictionary have reached 'INACTIVE' state
 def all_inactive(jobs):
@@ -70,7 +60,7 @@ h.event_subscribe("job-state")
 # Submit several test jobs, building dictionary by jobid,
 # where each entry contains a list of job states
 # N.B. no notification is provided for the NEW state
-jobspec = make_jobspec()
+jobspec = JobspecV1.from_command(["hostname"])
 jobs = {}
 for i in range(njobs):
     jobid = job.submit(h, jobspec)

--- a/t/job-manager/submit-sliding-window.py
+++ b/t/job-manager/submit-sliding-window.py
@@ -15,19 +15,9 @@
 
 import flux
 from flux import job
+from flux.job import JobspecV1
 import sys
 import subprocess
-
-
-# Return jobspec for a simple job
-def make_jobspec(cmd):
-    out = subprocess.Popen(
-        ["flux", "jobspec", "srun", cmd],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-    )
-    stdout, stderr = out.communicate()
-    return stdout
 
 
 njobs = 10
@@ -40,7 +30,7 @@ if len(sys.argv) == 3:
 # Open connection to broker
 h = flux.Flux()
 
-jobspec = make_jobspec("/bin/true")
+jobspec = JobspecV1.from_command(["/bin/true"])
 flags = flux.constants.FLUX_JOB_WAITABLE
 done = 0
 running = 0

--- a/t/job-manager/submit-wait.py
+++ b/t/job-manager/submit-wait.py
@@ -15,19 +15,9 @@
 
 import flux
 from flux import job
+from flux.job import JobspecV1
 import sys
 import subprocess
-
-
-# Return jobspec for a simple job
-def make_jobspec(cmd):
-    out = subprocess.Popen(
-        ["flux", "jobspec", "srun", cmd],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-    )
-    stdout, stderr = out.communicate()
-    return stdout
 
 
 if len(sys.argv) != 2:
@@ -39,8 +29,8 @@ else:
 h = flux.Flux()
 
 # Submit njobs test jobs (half will fail)
-jobspec = make_jobspec("/bin/true")
-jobspec_fail = make_jobspec("/bin/false")
+jobspec = JobspecV1.from_command(["/bin/true"])
+jobspec_fail = JobspecV1.from_command(["/bin/false"])
 jobs = []
 flags = flux.constants.FLUX_JOB_WAITABLE
 for i in range(njobs):

--- a/t/job-manager/submit-waitany.py
+++ b/t/job-manager/submit-waitany.py
@@ -15,20 +15,9 @@
 
 import flux
 from flux import job
+from flux.job import JobspecV1
 import sys
 import subprocess
-
-
-# Return jobspec for a simple job
-def make_jobspec(cmd):
-    out = subprocess.Popen(
-        ["flux", "jobspec", "srun", cmd],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-    )
-    stdout, stderr = out.communicate()
-    return stdout
-
 
 if len(sys.argv) != 2:
     njobs = 10
@@ -39,8 +28,8 @@ else:
 h = flux.Flux()
 
 # Submit njobs test jobs (half will fail)
-jobspec = make_jobspec("/bin/true")
-jobspec_fail = make_jobspec("/bin/false")
+jobspec = JobspecV1.from_command(["/bin/true"])
+jobspec_fail = JobspecV1.from_command(["/bin/false"])
 flags = flux.constants.FLUX_JOB_WAITABLE
 for i in range(njobs):
     if i < njobs / 2:

--- a/t/job-manager/wait-interrupted.py
+++ b/t/job-manager/wait-interrupted.py
@@ -16,19 +16,9 @@
 
 import flux
 from flux import job
+from flux.job import JobspecV1
 import sys
 import subprocess
-
-
-# Return jobspec for a simple job
-def make_jobspec(cmd):
-    out = subprocess.Popen(
-        ["flux", "jobspec", "srun", cmd],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-    )
-    stdout, stderr = out.communicate()
-    return stdout
 
 
 if len(sys.argv) != 2:
@@ -40,7 +30,7 @@ else:
 h = flux.Flux()
 
 # Submit njobs test jobs
-jobspec = make_jobspec("/bin/true")
+jobspec = JobspecV1.from_command(["/bin/true"])
 jobs = []
 flags = flux.constants.FLUX_JOB_WAITABLE
 for i in range(njobs):

--- a/t/python/t0010-job.py
+++ b/t/python/t0010-job.py
@@ -14,11 +14,10 @@ import os
 import errno
 import sys
 import json
-import yaml
-
 import unittest
 from glob import glob
 
+import yaml
 
 import flux
 from flux import job
@@ -89,6 +88,22 @@ class TestJob(unittest.TestCase):
             os.path.join(self.jobspec_dir, "valid_v1", "*.yaml")
         ):
             JobspecV1.from_yaml_file(jobspec_filepath)
+
+    def test_06_iter(self):
+        jobspec_fname = os.path.join(self.jobspec_dir, "valid", "use_case_2.4.yaml")
+        jobspec = Jobspec.from_yaml_file(jobspec_fname)
+        self.assertEqual(len(list(jobspec)), 7)
+        self.assertEqual(len(list([x for x in jobspec if x["type"] == "core"])), 2)
+        self.assertEqual(len(list([x for x in jobspec if x["type"] == "slot"])), 2)
+
+    def test_07_count(self):
+        jobspec_fname = os.path.join(self.jobspec_dir, "valid", "use_case_2.4.yaml")
+        jobspec = Jobspec.from_yaml_file(jobspec_fname)
+        count_dict = jobspec.resource_counts()
+        self.assertEqual(count_dict["node"], 1)
+        self.assertEqual(count_dict["slot"], 11)
+        self.assertEqual(count_dict["core"], 16)
+        self.assertEqual(count_dict["memory"], 64)
 
 
 if __name__ == "__main__":

--- a/t/python/t0010-job.py
+++ b/t/python/t0010-job.py
@@ -105,6 +105,11 @@ class TestJob(unittest.TestCase):
         self.assertEqual(count_dict["core"], 16)
         self.assertEqual(count_dict["memory"], 64)
 
+    def test_08_jobspec_submit(self):
+        jobspec = Jobspec.from_yaml_stream(self.basic_jobspec)
+        jobid = job.submit(self.fh, jobspec)
+        self.assertGreater(jobid, 0)
+
 
 if __name__ == "__main__":
     from subflux import rerun_under_flux


### PR DESCRIPTION
Moves the `Jobspec` class out of `flux-mini` and into the main python bindings.  Includes refactoring, new `walk` features, and testing against valid and invalid jobspecs in `t/jobspec`.

Closes #2415 
Closes #2393 

I'd love some feedback on the arguments to the two `__init__` methods.   I initially did not want to have `version` in the JobspecV1 constructor, but that precludes the ability to do things like `JobspecV1(**yaml.safe_load(jobspec_yaml_file))`.  What I have right now is `Jobspec(resources, tasks, version, attributes=None)` and `JobspecV1(resources, tasks, attributes=None, version=1)`.   The re-ordering of the last two arguments is bothersome to me, but I'm not a fan of the idea of adding a default value to the `version` in `Jobspec`s constructor.