### PR TITLE
job-info: Add stats for number of jobs in each state

### DIFF
--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -53,6 +53,7 @@ int cmd_priority (optparse_t *p, int argc, char **argv);
 int cmd_eventlog (optparse_t *p, int argc, char **argv);
 int cmd_wait_event (optparse_t *p, int argc, char **argv);
 int cmd_info (optparse_t *p, int argc, char **argv);
+int cmd_stats (optparse_t *p, int argc, char **argv);
 int cmd_drain (optparse_t *p, int argc, char **argv);
 int cmd_undrain (optparse_t *p, int argc, char **argv);
 
@@ -272,6 +273,13 @@ static struct optparse_subcommand subcommands[] = {
       "id key ...",
       "Display info for a job",
       cmd_info,
+      0,
+      NULL
+    },
+    { "stats",
+      NULL,
+      "Get current job stats",
+      cmd_stats,
       0,
       NULL
     },
@@ -1919,6 +1927,27 @@ int cmd_info (optparse_t *p, int argc, char **argv)
         log_err_exit ("flux_reactor_run");
 
     json_decref (ctx.keys);
+    flux_close (h);
+    return (0);
+}
+
+int cmd_stats (optparse_t *p, int argc, char **argv)
+{
+    flux_t *h;
+    flux_future_t *f;
+    const char *topic = "job-info.job-stats";
+    const char *s;
+
+    if (!(h = flux_open (NULL, 0)))
+        log_err_exit ("flux_open");
+
+    if (!(f = flux_rpc (h, topic, NULL, FLUX_NODEID_ANY, 0)))
+        log_err_exit ("flux_rpc");
+    if (flux_rpc_get (f, &s) < 0)
+        log_msg_exit ("stats: %s", future_strerror (f, errno));
+
+    /* for time being, just output json object for result */
+    printf ("%s\n", s);
     flux_close (h);
     return (0);
 }

--- a/src/modules/job-info/job_state.c
+++ b/src/modules/job-info/job_state.c
@@ -184,6 +184,44 @@ static bool search_direction (struct job *job)
         return false;
 }
 
+static int *state_counter (struct info_ctx *ctx,
+                           struct job *job,
+                           flux_job_state_t state)
+{
+    if (state == FLUX_JOB_NEW)
+        return NULL;
+    else if (state == FLUX_JOB_DEPEND)
+        return &ctx->jsctx->depend_count;
+    else if (state == FLUX_JOB_SCHED)
+        return &ctx->jsctx->sched_count;
+    else if (state == FLUX_JOB_RUN)
+        return &ctx->jsctx->run_count;
+    else if (state == FLUX_JOB_CLEANUP)
+        return &ctx->jsctx->cleanup_count;
+    else if (state == FLUX_JOB_INACTIVE)
+        return &ctx->jsctx->inactive_count;
+
+    flux_log_error (ctx->h, "illegal state transition for job %llu: %d",
+                    (unsigned long long)job->id, state);
+    return NULL;
+}
+
+static void state_transition (struct info_ctx *ctx,
+                              struct job *job,
+                              flux_job_state_t new_state)
+{
+    int *decrement;
+    int *increment;
+
+    decrement = state_counter (ctx, job, job->state);
+    increment = state_counter (ctx, job, new_state);
+    job->state = new_state;
+    if (decrement)
+        (*decrement)--;
+    if (increment)
+        (*increment)++;
+}
+
 static void job_insert_list (struct job_state_ctx *jsctx,
                              struct job *job,
                              flux_job_state_t newstate)
@@ -336,14 +374,16 @@ static zlistx_t *get_list (struct job_state_ctx *jsctx, flux_job_state_t state)
         return jsctx->inactive;
 }
 
-static void update_job_state (struct job *job, flux_job_state_t newstate)
+static void update_job_state (struct info_ctx *ctx,
+                              struct job *job,
+                              flux_job_state_t newstate)
 {
     struct job_state_ctx *jsctx = job->ctx->jsctx;
 
     if (!job->job_info_retrieved) {
         /* job info still not retrieved, we can update the job
          * state but can't put it on a different list yet */
-        job->state = newstate;
+        state_transition (ctx, job, newstate);
     }
     else {
         if (job->state == FLUX_JOB_INACTIVE) {
@@ -359,7 +399,7 @@ static void update_job_state (struct job *job, flux_job_state_t newstate)
 
             if (oldlist != newlist)
                 job_change_list (jsctx, job, oldlist, newstate);
-            job->state = newstate;
+            state_transition (ctx, job, newstate);
         }
     }
 }
@@ -436,10 +476,10 @@ static void update_jobs (struct info_ctx *ctx, json_t *transitions)
                 flux_log_error (jsctx->h, "%s: zlistx_add_end", __FUNCTION__);
                 return;
             }
-            job->state = state;
+            state_transition (ctx, job, state);
         }
         else
-            update_job_state (job, state);
+            update_job_state (ctx, job, state);
     }
 
 }
@@ -508,10 +548,10 @@ static struct job *eventlog_parse (struct info_ctx *ctx,
             }
             job->t_submit = timestamp;
             job->job_info_retrieved = true;
-            job->state = FLUX_JOB_DEPEND;
+            state_transition (ctx, job, FLUX_JOB_DEPEND);
         }
         else if (!strcmp (name, "depend")) {
-            job->state = FLUX_JOB_SCHED;
+            state_transition (ctx, job, FLUX_JOB_SCHED);
         }
         else if (!strcmp (name, "priority")) {
             if (json_unpack (context, "{ s:i }",
@@ -529,22 +569,22 @@ static struct job *eventlog_parse (struct info_ctx *ctx,
                 goto error;
             }
             if (severity == 0) {
-                job->state = FLUX_JOB_CLEANUP;
+                state_transition (ctx, job, FLUX_JOB_CLEANUP);
                 job->t_inactive = timestamp;
             }
         }
         else if (!strcmp (name, "alloc")) {
             if (job->state == FLUX_JOB_SCHED) {
-                job->state = FLUX_JOB_RUN;
+                state_transition (ctx, job, FLUX_JOB_RUN);
                 job->t_running = timestamp;
             }
         }
         else if (!strcmp (name, "finish")) {
             if (job->state == FLUX_JOB_RUN)
-                job->state = FLUX_JOB_CLEANUP;
+                state_transition (ctx, job, FLUX_JOB_CLEANUP);
         }
         else if (!strcmp (name, "clean")) {
-            job->state = FLUX_JOB_INACTIVE;
+            state_transition (ctx, job, FLUX_JOB_INACTIVE);
             job->t_inactive = timestamp;
         }
     }

--- a/src/modules/job-info/job_state.c
+++ b/src/modules/job-info/job_state.c
@@ -80,6 +80,7 @@ static struct job *job_create (struct info_ctx *ctx, flux_jobid_t id)
         return NULL;
     job->ctx = ctx;
     job->id = id;
+    job->state = FLUX_JOB_NEW;
     return job;
 }
 
@@ -472,7 +473,6 @@ static struct job *eventlog_parse (struct info_ctx *ctx,
 
     if (!(job = job_create (ctx, id)))
         goto error;
-    job->state = FLUX_JOB_NEW;
 
     if (!(a = eventlog_decode (eventlog))) {
         flux_log_error (ctx->h, "%s: error parsing eventlog for %llu",

--- a/src/modules/job-info/job_state.h
+++ b/src/modules/job-info/job_state.h
@@ -39,6 +39,13 @@ struct job_state_ctx {
     zlistx_t *inactive;
     zlistx_t *processing;
     zlistx_t *futures;
+
+    /* count current jobs in what states */
+    int depend_count;
+    int sched_count;
+    int run_count;
+    int cleanup_count;
+    int inactive_count;
 };
 
 struct job {

--- a/t/t2204-job-info.t
+++ b/t/t2204-job-info.t
@@ -679,12 +679,12 @@ test_expect_success 'flux job info multiple keys fails on 1 bad entry (no eventl
 #
 
 test_expect_success 'job-info stats works' '
-        flux module stats job-info | grep "lookups" &&
-        flux module stats job-info | grep "watchers" &&
-        flux module stats job-info | grep "guest_watchers" &&
-        flux module stats job-info | grep "pending" &&
-        flux module stats job-info | grep "running" &&
-        flux module stats job-info | grep "inactive"
+        flux module stats --parse lookups job-info &&
+        flux module stats --parse watchers job-info &&
+        flux module stats --parse guest_watchers job-info &&
+        flux module stats --parse jobs.pending job-info &&
+        flux module stats --parse jobs.running job-info &&
+        flux module stats --parse jobs.inactive job-info
 '
 
 test_expect_success 'lookup request with empty payload fails with EPROTO(71)' '

--- a/t/t2204-job-info.t
+++ b/t/t2204-job-info.t
@@ -234,6 +234,15 @@ test_expect_success 'flux job list all jobs works' '
         test_cmp list_all_jobids.exp list_all_jobids.out
 '
 
+test_expect_success HAVE_JQ 'job stats lists jobs in correct state (mix)' '
+        flux job stats | jq -e ".job_states.depend == 0" &&
+        flux job stats | jq -e ".job_states.sched == 4" &&
+        flux job stats | jq -e ".job_states.run == 8" &&
+        flux job stats | jq -e ".job_states.cleanup == 0" &&
+        flux job stats | jq -e ".job_states.inactive == 4" &&
+        flux job stats | jq -e ".job_states.total == 16"
+'
+
 test_expect_success 'cleanup job listing jobs ' '
         for jobid in `cat job_ids_pending.out`; do \
             flux job cancel $jobid; \
@@ -262,6 +271,15 @@ test_expect_success 'job-info: list successfully reconstructed' '
         cat job_ids_inactive.out >> list_reload_ids.exp &&
         cat list_reload.out | cut -f1 > list_reload_ids.out &&
         test_cmp list_reload_ids.exp list_reload_ids.out
+'
+
+test_expect_success HAVE_JQ 'job stats lists jobs in correct state (all inactive)' '
+        flux job stats | jq -e ".job_states.depend == 0" &&
+        flux job stats | jq -e ".job_states.sched == 0" &&
+        flux job stats | jq -e ".job_states.run == 0" &&
+        flux job stats | jq -e ".job_states.cleanup == 0" &&
+        flux job stats | jq -e ".job_states.inactive == 16" &&
+        flux job stats | jq -e ".job_states.total == 16"
 '
 
 #


### PR DESCRIPTION
Per discussion in #2498, have a way to supply the number of jobs in each of the various job states.  I expose the counters via stats.

The meat of this PR is the job state counting.  How the user gets the data could be something else, but I decided to do it via stats.