### PR TITLE
replace exec "running" event with "shell.init" and "shell.start"

### DIFF
--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -1177,12 +1177,12 @@ void attach_exec_event_continuation (flux_future_t *f, void *arg)
     if (eventlog_entry_parse (o, &timestamp, &name, &context) < 0)
         log_err_exit ("eventlog_entry_parse");
 
-    if (!strcmp (name, "input-ready")) {
+    if (!strcmp (name, "shell.init")) {
         flux_watcher_t *w;
 
         if (json_unpack (context, "{s:i}",
                          "leader-rank", &ctx->leader_rank) < 0)
-            log_err_exit ("error decoding input-ready context");
+            log_err_exit ("error decoding shell.init context");
 
         /* flux_buffer_read_watcher_create() requires O_NONBLOCK on
          * stdin */
@@ -1208,8 +1208,6 @@ void attach_exec_event_continuation (flux_future_t *f, void *arg)
 
         ctx->stdin_w = w;
         flux_watcher_start (ctx->stdin_w);
-    }
-    else if (!strcmp (name, "shell.init")) {
         if (!(ctx->output_f = flux_job_event_watch (ctx->h,
                                                     ctx->id,
                                                     "guest.output",

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -1153,7 +1153,7 @@ void attach_stdin_cb (flux_reactor_t *r, flux_watcher_t *w,
 /* Handle an event in the guest.exec eventlog.
  * This is a stream of responses, one response per event, terminated with
  * an ENODATA error response (or another error if something went wrong).
- * On the output-ready event, start watching the guest.output eventlog.
+ * On the shell.init event, start watching the guest.output eventlog.
  * It is guaranteed to exist when guest.output is emitted.
  * If --show-exec was specified, print all events on stderr.
  */
@@ -1209,7 +1209,7 @@ void attach_exec_event_continuation (flux_future_t *f, void *arg)
         ctx->stdin_w = w;
         flux_watcher_start (ctx->stdin_w);
     }
-    else if (!strcmp (name, "output-ready")) {
+    else if (!strcmp (name, "shell.init")) {
         if (!(ctx->output_f = flux_job_event_watch (ctx->h,
                                                     ctx->id,
                                                     "guest.output",

--- a/src/modules/job-exec/job-exec.c
+++ b/src/modules/job-exec/job-exec.c
@@ -325,7 +325,6 @@ void jobinfo_started (struct jobinfo *job, const char *fmt, ...)
     if (h && job->req) {
         va_list ap;
         va_start (ap, fmt);
-        jobinfo_emit_event_vpack_nowait (job, "running", fmt, ap);
         job->running = 1;
         va_end (ap);
         if (jobinfo_respond (h, job, "start", 0) < 0)

--- a/src/shell/Makefile.am
+++ b/src/shell/Makefile.am
@@ -54,6 +54,8 @@ flux_shell_SOURCES = \
 	task.h \
 	log.c \
 	log.h \
+	events.c \
+	events.h \
 	pmi.c \
 	input.c \
 	output.c \

--- a/src/shell/events.c
+++ b/src/shell/events.c
@@ -1,0 +1,133 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/*  Shell exec.eventlog event emitter
+ *  Allows context for shell events to be added from multiple sources.
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <czmq.h>
+#include <jansson.h>
+
+#include <flux/shell.h>
+
+#include "eventlogger.h"
+
+struct shell_eventlogger {
+    flux_shell_t *shell;
+    zhashx_t *contexts;
+    struct eventlogger *ev;
+};
+
+static void json_free (void **item)
+{
+    if (item) {
+        json_t *o = *item;
+        json_decref (o);
+        *item = NULL;
+    }
+}
+
+static void shell_eventlogger_ref (struct eventlogger *ev, void *arg)
+{
+    struct shell_eventlogger *shev = arg;
+    flux_shell_add_completion_ref (shev->shell, "shell_eventlogger");
+}
+
+static void shell_eventlogger_unref (struct eventlogger *ev, void *arg)
+{
+    struct shell_eventlogger *shev = arg;
+    flux_shell_remove_completion_ref (shev->shell, "shell_eventlogger");
+}
+
+void shell_eventlogger_destroy (struct shell_eventlogger *shev)
+{
+    if (shev) {
+        zhashx_destroy (&shev->contexts);
+        eventlogger_destroy (shev->ev);
+        free (shev);
+    }
+}
+
+struct shell_eventlogger *shell_eventlogger_create (flux_shell_t *shell)
+{
+    flux_t *h;
+    struct eventlogger_ops ops = {
+        .busy = shell_eventlogger_ref,
+        .idle = shell_eventlogger_unref
+    };
+    struct shell_eventlogger *shev = calloc (1, sizeof (*shev));
+
+    if (!(h = flux_shell_get_flux (shell))
+        || !(shev->ev = eventlogger_create (h, 0.01, &ops, shev))
+        || !(shev->contexts = zhashx_new ())) {
+        shell_eventlogger_destroy (shev);
+        return NULL;
+    }
+    zhashx_set_destructor (shev->contexts, json_free);
+    return shev;
+}
+
+int shell_eventlogger_emit_event (struct shell_eventlogger *shev,
+                                  int flags,
+                                  const char *event)
+{
+    int rc;
+    char *context = NULL;
+    json_t *o = zhashx_lookup (shev->contexts, event);
+    if (o != NULL)
+        context = json_dumps (o, JSON_COMPACT);
+    rc = eventlogger_append (shev->ev,
+                             EVENTLOGGER_FLAG_WAIT,
+                             "exec.eventlog",
+                             event,
+                             context);
+    free (context);
+    return rc;
+}
+
+static int context_set (struct shell_eventlogger *shev,
+                        const char *name,
+                        int flags,
+                        json_t *o)
+{
+    json_t *orig = zhashx_lookup (shev->contexts, name);
+    if (orig != NULL) {
+        int rc = json_object_update (orig, o);
+        /*  mem for o now "owned" by orig */
+        json_decref (o);
+        return rc;
+    }
+    return zhashx_insert (shev->contexts, name, o);
+}
+
+int shell_eventlogger_context_vpack (struct shell_eventlogger *shev,
+                                     const char *event,
+                                     int flags,
+                                     const char *fmt,
+                                     va_list ap)
+{
+    json_t *o;
+    json_error_t err;
+    if (!shev || !fmt || !event) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (!(o = json_vpack_ex (&err, 0, fmt, ap)))
+        return -1;
+    return context_set (shev, event, flags, o);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/shell/events.h
+++ b/src/shell/events.h
@@ -1,0 +1,32 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _SHELL_EVENTS_H
+#define _SHELL_EVENTS_H
+
+struct shell_eventlogger;
+
+void shell_eventlogger_destroy (struct shell_eventlogger *shev);
+struct shell_eventlogger *shell_eventlogger_create (flux_shell_t *shell);
+
+int shell_eventlogger_emit_event (struct shell_eventlogger *shev,
+                                  int flags,
+                                  const char *event);
+
+int shell_eventlogger_context_vpack (struct shell_eventlogger *shev,
+                                     const char *event,
+                                     int flags,
+                                     const char *fmt,
+                                     va_list ap);
+#endif /* !_SHELL_EVENTS_H */
+
+/* vi: ts=4 sw=4 expandtab
+ */
+

--- a/src/shell/internal.h
+++ b/src/shell/internal.h
@@ -18,6 +18,7 @@
 
 #include "src/common/libutil/aux.h"
 #include "plugstack.h"
+#include "events.h"
 
 struct flux_shell {
     flux_jobid_t jobid;
@@ -33,6 +34,7 @@ struct flux_shell {
     flux_shell_task_t *current_task;
 
     struct plugstack *plugstack;
+    struct shell_eventlogger *ev;
 
     zhashx_t *completion_refs;
 

--- a/src/shell/shell.c
+++ b/src/shell/shell.c
@@ -644,6 +644,26 @@ out:
     return (rc);
 }
 
+/*  Public shell interface to request additional context in one of
+ *   the emitted shell events.
+ */
+int flux_shell_add_event_context (flux_shell_t *shell,
+                                  const char *name,
+                                  int flags,
+                                  const char *fmt,
+                                  ...)
+{
+    va_list ap;
+    if (!shell || !name || !fmt) {
+        errno = EINVAL;
+        return -1;
+    }
+    va_start (ap, fmt);
+    int rc = shell_eventlogger_context_vpack (shell->ev, name, 0, fmt, ap);
+    va_end (ap);
+    return rc;
+}
+
 static void eventlog_cb (flux_future_t *f, void *arg)
 {
     json_t *o = NULL;

--- a/src/shell/shell.c
+++ b/src/shell/shell.c
@@ -521,6 +521,7 @@ static void shell_finalize (flux_shell_t *shell)
     plugstack_destroy (shell->plugstack);
     shell->plugstack = NULL;
 
+    shell_eventlogger_destroy (shell->ev);
     shell_svc_destroy (shell->svc);
     shell_info_destroy (shell->info);
 

--- a/src/shell/shell.h
+++ b/src/shell/shell.h
@@ -177,6 +177,13 @@ int flux_shell_plugstack_call (flux_shell_t *shell,
                                const char *topic,
                                flux_plugin_arg_t *args);
 
+/*  Add context information for standard shell events
+ */
+int flux_shell_add_event_context (flux_shell_t *shell,
+                                  const char *name,
+                                  int flags,
+                                  const char *fmt, ...);
+
 /*  flux_shell_task_t API:
  */
 

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -113,6 +113,7 @@ TESTSCRIPTS = \
 	t2606-job-shell-output-redirection.t \
 	t2607-job-shell-input.t \
 	t2608-job-shell-log.t \
+	t2609-job-shell-events.t \
 	t2700-mini-cmd.t \
 	t3000-mpi-basic.t \
 	t3001-mpi-personalities.t \
@@ -243,7 +244,8 @@ check_LTLIBRARIES = \
 	shell/plugins/conftest.la \
 	shell/plugins/invalid-args.la \
 	shell/plugins/getopt.la \
-	shell/plugins/log.la
+	shell/plugins/log.la \
+	shell/plugins/test-event.la
 
 dist_check_DATA = \
 	hwloc-data/sierra2/0.xml \
@@ -501,4 +503,10 @@ shell_plugins_log_la_CPPFLAGS = $(test_cppflags)
 shell_plugins_log_la_LDFLAGS = -module -rpath /nowhere
 shell_plugins_log_la_LIBADD = \
 	$(top_builddir)/src/common/libtap/libtap.la \
+        $(top_builddir)/src/common/libflux-core.la
+
+shell_plugins_test_event_la_SOURCES = shell/plugins/test-event.c
+shell_plugins_test_event_la_CPPFLAGS = $(test_cppflags)
+shell_plugins_test_event_la_LDFLAGS = -module -rpath /nowhere
+shell_plugins_test_event_la_LIBADD = \
         $(top_builddir)/src/common/libflux-core.la

--- a/t/shell/plugins/invalid-args.c
+++ b/t/shell/plugins/invalid-args.c
@@ -140,6 +140,16 @@ static int shell_cb (flux_plugin_t *p,
     ok (flux_shell_remove_completion_ref (shell, NULL) < 0 && errno == EINVAL,
         "flux_shell_remove_completion_ref with NULL name returns EINVAL");
 
+    ok (flux_shell_add_event_context (NULL, NULL, 0, NULL) < 0
+        && errno == EINVAL,
+        "flux_shell_add_event_context with NULL args returns EINVAL");
+    ok (flux_shell_add_event_context (shell, NULL, 0, "{}") < 0
+        && errno == EINVAL,
+        "flux_shell_add_event_context with NULL name returns EINVAL");
+    ok (flux_shell_add_event_context (shell, "main", 0, NULL) < 0
+        && errno == EINVAL,
+        "flux_shell_add_event_context with NULL fmt returns EINVAL");
+
     if (strcmp (topic, "shell.init") == 0) {
         ok (flux_shell_current_task (NULL) == NULL && errno == EINVAL,
             "flux_shell_current_task with NULL shell returns EINVAL");
@@ -147,7 +157,6 @@ static int shell_cb (flux_plugin_t *p,
         ok (flux_shell_current_task (shell) == NULL && errno == 0,
             "flux_shell_current_task returns no task in shell.init");
     }
-
     if (strcmp (topic, "shell.exit") == 0)
         return exit_status () == 0 ? 0 : -1;
     return 0;

--- a/t/shell/plugins/test-event.c
+++ b/t/shell/plugins/test-event.c
@@ -1,0 +1,59 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdio.h>
+#include <stdarg.h>
+#include <jansson.h>
+#include <flux/core.h>
+#include <flux/shell.h>
+
+static int get_shell_rank (flux_shell_t *shell)
+{
+    int rank = -1;
+    char *json_str = NULL;
+    json_t *o = NULL;
+
+    if (flux_shell_get_info (shell, &json_str) < 0
+        || !(o = json_loads (json_str, 0, NULL))
+        || json_unpack (o, "{s:i}", "rank", &rank) < 0)
+        shell_log_errno ("failed to get shell rank");
+    json_decref (o);
+    free (json_str);
+    return rank;
+}
+
+static int check_event_context (flux_plugin_t *p,
+                                const char *topic,
+                                flux_plugin_arg_t *args,
+                                void *data)
+{
+    flux_shell_t *shell = data;
+    if (get_shell_rank (shell) != 0)
+        return 0;
+    return flux_shell_add_event_context (shell, "shell.init", 0,
+                                       " {s:s}",
+                                         "event-test", "foo");
+}
+
+int flux_plugin_init (flux_plugin_t *p)
+{
+    flux_plugin_set_name (p, "event-test");
+    return flux_plugin_add_handler (p,
+                                    "shell.init",
+                                    check_event_context,
+                                    flux_plugin_get_shell (p));
+}
+
+/*
+ * vi: ts=4 sw=4 expandtab
+ */

--- a/t/t2607-job-shell-input.t
+++ b/t/t2607-job-shell-input.t
@@ -113,7 +113,7 @@ test_expect_success NO_CHAIN_LINT 'flux-shell: no stdin desired in job' '
         id=$(flux mini submit -n1 sleep 60)
         flux job attach $id < input_stdin_file 2> pipe6A.err &
         pid=$! &&
-        flux job wait-event -p guest.exec.eventlog $id input-ready 2> pipe6B.err &&
+        flux job wait-event -p guest.exec.eventlog $id shell.init 2> pipe6B.err &&
         flux job wait-event -p guest.input -m eof=true $id data 2> pipe6C.err &&
         flux job cancel $id 2> pipe6D.err &&
         test_expect_code 143 wait $pid
@@ -136,7 +136,7 @@ test_expect_success NO_CHAIN_LINT 'flux-shell: pipe to stdin twice, second fails
         id=$(flux mini submit -n1 sleep 60)
         flux job attach $id < input_stdin_file 2> pipe8A.err &
         pid=$!
-        flux job wait-event -p guest.exec.eventlog $id input-ready 2> pipe8B.err &&
+        flux job wait-event -p guest.exec.eventlog $id shell.init 2> pipe8B.err &&
         flux job wait-event -p guest.input -m eof=true $id data 2> pipe8C.err &&
         test_must_fail flux job attach $id < input_stdin_file 2> pipe8D.err &&
         flux job cancel $id 2> pipe8E.err &&

--- a/t/t2609-job-shell-events.t
+++ b/t/t2609-job-shell-events.t
@@ -1,0 +1,42 @@
+#!/bin/sh
+#
+test_description='Test flux-shell emitted events'
+
+. `dirname $0`/sharness.sh
+
+test_under_flux 2
+
+FLUX_SHELL="${FLUX_BUILD_DIR}/src/shell/flux-shell"
+
+INITRC_TESTDIR="${SHARNESS_TEST_SRCDIR}/shell/initrc"
+INITRC_PLUGINPATH="${SHARNESS_TEST_DIRECTORY}/shell/plugins/.libs"
+
+test_expect_success 'flux-shell: 1N: init and start shell events are emitted' '
+	id=$(flux mini submit -n1 -N1 /bin/true)  &&
+	flux job wait-event -vt 5 -p guest.exec.eventlog \
+		-m leader-rank=0 ${id} shell.init &&
+	flux job wait-event -vt 5 -p guest.exec.eventlog \
+		-m size=1 ${id} shell.init  &&
+	flux job wait-event -vt 5 -p guest.exec.eventlog \
+		-m task-count=1 ${id} shell.start 
+'
+test_expect_success 'flux-shell: 2N: init and start shell events are emitted' '
+	id=$(flux mini submit -n4 -N2 /bin/true)  &&
+	flux job wait-event -vt 5 -p guest.exec.eventlog \
+		-m leader-rank=0  ${id} shell.init &&
+	flux job wait-event -vt 5 -p guest.exec.eventlog \
+		-m size=2 ${id} shell.init  &&
+	flux job wait-event -vt 5 -p guest.exec.eventlog \
+		-m task-count=4 ${id} shell.start 
+'
+test_expect_success 'flux-shell: plugin can add event context' '
+	cat >test-event.lua <<-EOT &&
+	plugin.searchpath = "${INITRC_PLUGINPATH}"
+	plugin.load { file = "test-event.so" }
+	EOT
+	id=$(flux mini submit -o initrc=test-event.lua -n2 -N2 hostname) &&
+	flux job wait-event -vt 5 -p guest.exec.eventlog \
+		-m event-test=foo ${id} shell.init
+
+'
+test_done


### PR DESCRIPTION
As discussed in #2539, this PR replaces the non-useful exec.eventlog "running" event emitted by the `job-exec` module with a `shell.init` event emitted by the shell after exit from the initialization barrier.

Since the `shell.init` event now guarantees all shells have completed shell initialization, the redundant `output-ready` and `input-ready` are removed, and `flux job attach` synchronizes on `shell.init` instead.

In addition to the `shell.init` event, a `shell.start` event is also added, which is used to indicate when all shells have launched all tasks. This does add another barrier in the shell, so it might be controversial. The event will be necessary for debugger/tool synchronization (the `sync` event) though, however the barrier could be reconfigured to only be triggered when necessary.

Also, in anticipation of a requirement for `sync` support, a new public shell function `flux_shell_add_event_context ()` is added, allowing plugins to add arbitrary context to the `shell.init` or `shell.start` events.

Fixes #2539