### PR TITLE
shell: fix segfault if logging function is called in or after shell_finalize()

### DIFF
--- a/src/shell/shell.c
+++ b/src/shell/shell.c
@@ -510,6 +510,8 @@ static int shell_max_task_exit (flux_shell_t *shell)
 
 static void shell_finalize (flux_shell_t *shell)
 {
+    struct plugstack *plugstack = shell->plugstack;
+
     if (shell->tasks) {
         struct shell_task *task;
         while ((task = zlist_pop (shell->tasks)))
@@ -518,8 +520,12 @@ static void shell_finalize (flux_shell_t *shell)
     }
     aux_destroy (&shell->aux);
 
-    plugstack_destroy (shell->plugstack);
+    /*  Set shell->plugstack to NULL *before* calling plugstack_destroy()
+     *   to notify shell components that the plugin stack is no longer
+     *   safe to use.
+     */
     shell->plugstack = NULL;
+    plugstack_destroy (plugstack);
 
     shell_eventlogger_destroy (shell->ev);
     shell_svc_destroy (shell->svc);

--- a/src/shell/shell.c
+++ b/src/shell/shell.c
@@ -1017,8 +1017,13 @@ int main (int argc, char *argv[])
     if (shell_rc_close ())
         shell_log_errno ("shell_rc_close");
 
-    shell_log_fini ();
     shell_finalize (&shell);
+
+    /* Always close shell log after shell_finalize() in case shell
+     *  components attempt to log during cleanup
+     *  (e.g. plugin destructors)
+     */
+    shell_log_fini ();
     exit (shell.rc);
 }
 

--- a/t/shell/plugins/log.c
+++ b/t/shell/plugins/log.c
@@ -77,10 +77,19 @@ static int check_shell_log (flux_plugin_t *p,
     return 0;
 }
 
+static void destructor (void *arg)
+{
+    shell_log_error ("destructor: using log from plugin destructor works");
+}
+
 int flux_plugin_init (flux_plugin_t *p)
 {
     plan (NO_PLAN);
     flux_plugin_set_name (p, "log");
+
+    /*  Set a dummy aux item to force our destructor to be called */
+    flux_plugin_aux_set (p, NULL, p, destructor);
+
     ok (flux_plugin_add_handler (p, "*", check_shell_log, NULL) == 0,
         "flux_plugin_add_handler works");
     return 0;


### PR DESCRIPTION
Slightly rework shell finalization to avoid segfault caused by shell logging functions found by @chu11 in #2543.

Adds a test to ensure shell logging function in a plugin destructor does no harm.