### PR TITLE
job-manager: add flux_job_wait()

### DIFF
--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -109,7 +109,7 @@ static struct optparse_option submit_opts[] =  {
     },
     { .name = "flags", .key = 'f', .has_arg = 3,
       .flags = OPTPARSE_OPT_AUTOSPLIT,
-      .usage = "Set submit comma-separated flags (e.g. debug)",
+      .usage = "Set submit comma-separated flags (e.g. debug, waitable)",
     },
 #if HAVE_FLUX_SECURITY
     { .name = "security-config", .key = 'c', .has_arg = 1, .arginfo = "pattern",
@@ -744,6 +744,8 @@ int cmd_submit (optparse_t *p, int argc, char **argv)
         while ((name = optparse_getopt_next (p, "flags"))) {
             if (!strcmp (name, "debug"))
                 flags |= FLUX_JOB_DEBUG;
+            else if (!strcmp (name, "waitable"))
+                flags |= FLUX_JOB_WAITABLE;
             else
                 log_msg_exit ("unknown flag: %s", name);
         }

--- a/src/cmd/flux-mini.py
+++ b/src/cmd/flux-mini.py
@@ -316,6 +316,9 @@ class SubmitCmd:
         )
         parser.add_argument("--debug", action="store_true", help="Set job debug flag")
         parser.add_argument(
+            "--waitable", action="store_true", help="Set job waitable flag"
+        )
+        parser.add_argument(
             "--dry-run",
             action="store_true",
             help="Don't actually submit job, just emit jobspec",
@@ -390,7 +393,9 @@ class SubmitCmd:
         h = flux.Flux()
         flags = 0
         if args.debug:
-            flags = flux.constants.FLUX_JOB_DEBUG
+            flags = flags | flux.constants.FLUX_JOB_DEBUG
+        if args.waitable:
+            flags = flags | flux.constants.FLUX_JOB_WAITABLE
         return job.submit(h, jobspec.dumps(), priority=args.priority, flags=flags)
 
     def main(self, args):

--- a/src/common/libjob/job.c
+++ b/src/common/libjob/job.c
@@ -127,6 +127,62 @@ int flux_job_submit_get_id (flux_future_t *f, flux_jobid_t *jobid)
     return 0;
 }
 
+flux_future_t *flux_job_wait (flux_t *h, flux_jobid_t id)
+{
+    if (!h) {
+        errno = EINVAL;
+        return NULL;
+    }
+    return flux_rpc_pack (h,
+                          "job-manager.wait",
+                          FLUX_NODEID_ANY,
+                          0,
+                          "{s:I}",
+                          "id",
+                          id);
+}
+
+int flux_job_wait_get_status (flux_future_t *f,
+                              bool *successp,
+                              const char **errstrp)
+{
+    int success;
+    const char *errstr;
+
+    if (!f) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (flux_rpc_get_unpack (f,
+                             "{s:b s:s}",
+                             "success",
+                             &success,
+                             "errstr",
+                             &errstr) < 0)
+        return -1;
+    if (successp)
+        *successp = success ? true : false;
+    if (errstrp)
+        *errstrp = errstr;
+    return 0;
+}
+
+int flux_job_wait_get_id (flux_future_t *f, flux_jobid_t *jobid)
+{
+    flux_jobid_t id;
+
+    if (!f) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (flux_rpc_get_unpack (f, "{s:I}",
+                                "id", &id) < 0)
+        return -1;
+    if (jobid)
+        *jobid = id;
+    return 0;
+}
+
 flux_future_t *flux_job_list (flux_t *h,
                               int max_entries,
                               const char *json_str,

--- a/src/common/libjob/job.h
+++ b/src/common/libjob/job.h
@@ -68,6 +68,14 @@ flux_future_t *flux_job_submit (flux_t *h, const char *jobspec,
  */
 int flux_job_submit_get_id (flux_future_t *f, flux_jobid_t *id);
 
+/* Wait for jobid to enter INACTIVE state.
+ */
+flux_future_t *flux_job_wait (flux_t *h, flux_jobid_t id);
+int flux_job_wait_get_status (flux_future_t *f,
+                              bool *success,
+                              const char **errstr);
+int flux_job_wait_get_id (flux_future_t *f, flux_jobid_t *id);
+
 /* Request a list of jobs.
  * If 'max_entries' > 0, fetch at most that many jobs.
  * 'json_str' is an encoded JSON array of attribute strings, e.g.

--- a/src/common/libjob/job.h
+++ b/src/common/libjob/job.h
@@ -38,6 +38,10 @@ enum job_priority {
     FLUX_JOB_PRIORITY_MAX = 31,
 };
 
+enum {
+    FLUX_JOBID_ANY = 0xFFFFFFFFFFFFFFFF, // ~(uint64_t)0
+};
+
 typedef enum {
     FLUX_JOB_NEW                    = 1,
     FLUX_JOB_DEPEND                 = 2,
@@ -69,6 +73,8 @@ flux_future_t *flux_job_submit (flux_t *h, const char *jobspec,
 int flux_job_submit_get_id (flux_future_t *f, flux_jobid_t *id);
 
 /* Wait for jobid to enter INACTIVE state.
+ * If jobid=FLUX_JOBID_ANY, wait for the next waitable job.
+ * Fails with ECHILD if there is nothing to wait for.
  */
 flux_future_t *flux_job_wait (flux_t *h, flux_jobid_t id);
 int flux_job_wait_get_status (flux_future_t *f,

--- a/src/common/libjob/job.h
+++ b/src/common/libjob/job.h
@@ -22,6 +22,7 @@ extern "C" {
 enum job_submit_flags {
     FLUX_JOB_PRE_SIGNED = 1,    // 'jobspec' is already signed
     FLUX_JOB_DEBUG = 2,
+    FLUX_JOB_WAITABLE = 4,      // flux_job_wait() will be used on this job
 };
 
 enum job_list_flags {

--- a/src/common/libjob/test/job.c
+++ b/src/common/libjob/test/job.c
@@ -176,6 +176,19 @@ void check_corner_case (void)
     ok (flux_job_event_watch_cancel (NULL) < 0
         && errno == EINVAL,
         "flux_job_event_watch_cancel fails with EINVAL on bad input");
+
+    /* flux_job_wait */
+    errno = 0;
+    ok (flux_job_wait (NULL, 0) == NULL && errno == EINVAL,
+        "flux_job_wait h=NULL fails with EINVAL");
+
+    errno = 0;
+    ok (flux_job_wait_get_status (NULL, NULL, NULL) < 0 && errno == EINVAL,
+        "flux_job_wait_get_status f=NULL fails with EINVAL");
+
+    errno = 0;
+    ok (flux_job_wait_get_id (NULL, NULL) < 0 && errno == EINVAL,
+        "flux_job_wait_get_id f=NULL fails with EINVAL");
 }
 
 struct ss {

--- a/src/modules/job-manager/Makefile.am
+++ b/src/modules/job-manager/Makefile.am
@@ -22,6 +22,8 @@ job_manager_la_SOURCES = \
 	submit.h \
 	drain.c \
 	drain.h \
+	wait.c \
+	wait.h \
 	event.h \
 	event.c \
 	restart.h \
@@ -61,6 +63,7 @@ test_ldadd = \
         $(top_builddir)/src/modules/job-manager/start.o \
         $(top_builddir)/src/modules/job-manager/drain.o \
         $(top_builddir)/src/modules/job-manager/submit.o \
+        $(top_builddir)/src/modules/job-manager/wait.o \
 	$(top_builddir)/src/common/libtap/libtap.la \
 	$(top_builddir)/src/common/libjob/libjob.la \
 	$(top_builddir)/src/common/libflux-internal.la \

--- a/src/modules/job-manager/event.c
+++ b/src/modules/job-manager/event.c
@@ -365,6 +365,10 @@ int event_release_context_decode (json_t *context,
     return 0;
 }
 
+/* This function implements state transitions per RFC 21.
+ * If FLUX_JOB_WAITABLE flag is set, then on a fatal exception or
+ * cleanup event, capture the event in job->end_event for flux_job_wait().
+ */
 int event_job_update (struct job *job, json_t *event)
 {
     double timestamp;
@@ -400,8 +404,12 @@ int event_job_update (struct job *job, json_t *event)
             goto inval;
         if (event_exception_context_decode (context, &severity) < 0)
             goto error;
-        if (severity == 0)
+        if (severity == 0) {
+            if ((job->flags & FLUX_JOB_WAITABLE) && !job->end_event)
+                job->end_event = json_incref (event);
+
             job->state = FLUX_JOB_CLEANUP;
+        }
     }
     else if (!strcmp (name, "alloc")) {
         if (job->state != FLUX_JOB_SCHED && job->state != FLUX_JOB_CLEANUP)
@@ -418,8 +426,12 @@ int event_job_update (struct job *job, json_t *event)
     else if (!strcmp (name, "finish")) {
         if (job->state != FLUX_JOB_RUN && job->state != FLUX_JOB_CLEANUP)
             goto inval;
-        if (job->state == FLUX_JOB_RUN)
+        if (job->state == FLUX_JOB_RUN) {
+            if ((job->flags & FLUX_JOB_WAITABLE) && !job->end_event)
+                job->end_event = json_incref (event);
+
             job->state = FLUX_JOB_CLEANUP;
+        }
     }
     else if (!strcmp (name, "release")) {
         int final;

--- a/src/modules/job-manager/event.c
+++ b/src/modules/job-manager/event.c
@@ -43,6 +43,7 @@
 #include "alloc.h"
 #include "start.h"
 #include "drain.h"
+#include "wait.h"
 
 #include "event.h"
 
@@ -306,6 +307,8 @@ int event_job_action (struct event *event, struct job *job)
             }
             break;
         case FLUX_JOB_INACTIVE:
+            if ((job->flags & FLUX_JOB_WAITABLE))
+                wait_notify_inactive (ctx->wait, job);
             zhashx_delete (ctx->active_jobs, &job->id);
             if (zhashx_size (ctx->active_jobs) == 0)
                 drain_empty_notify (ctx->drain);

--- a/src/modules/job-manager/job-manager.c
+++ b/src/modules/job-manager/job-manager.c
@@ -26,6 +26,7 @@
 #include "start.h"
 #include "event.h"
 #include "drain.h"
+#include "wait.h"
 
 #include "job-manager.h"
 
@@ -92,6 +93,10 @@ int mod_main (flux_t *h, int argc, char **argv)
         flux_log_error (h, "error creating drain interface");
         goto done;
     }
+    if (!(ctx.wait = wait_ctx_create (&ctx))) {
+        flux_log_error (h, "error creating wait interface");
+        goto done;
+    }
     if (flux_msg_handler_addvec (h, htab, &ctx, &ctx.handlers) < 0) {
         flux_log_error (h, "flux_msghandler_add");
         goto done;
@@ -107,6 +112,7 @@ int mod_main (flux_t *h, int argc, char **argv)
     rc = 0;
 done:
     flux_msg_handler_delvec (ctx.handlers);
+    wait_ctx_destroy (ctx.wait);
     drain_ctx_destroy (ctx.drain);
     start_ctx_destroy (ctx.start);
     alloc_ctx_destroy (ctx.alloc);

--- a/src/modules/job-manager/job-manager.h
+++ b/src/modules/job-manager/job-manager.h
@@ -20,6 +20,7 @@ struct job_manager {
     struct event *event;
     struct submit *submit;
     struct drain *drain;
+    struct waitjob *wait;
 };
 
 #endif /* !_FLUX_JOB_MANAGER_H */

--- a/src/modules/job-manager/job.c
+++ b/src/modules/job-manager/job.c
@@ -26,6 +26,7 @@ void job_decref (struct job *job)
     if (job && --job->refcount == 0) {
         int saved_errno = errno;
         json_decref (job->end_event);
+        flux_msg_decref (job->waiter);
         free (job);
         errno = saved_errno;
     }

--- a/src/modules/job-manager/job.c
+++ b/src/modules/job-manager/job.c
@@ -25,6 +25,7 @@ void job_decref (struct job *job)
 {
     if (job && --job->refcount == 0) {
         int saved_errno = errno;
+        json_decref (job->end_event);
         free (job);
         errno = saved_errno;
     }

--- a/src/modules/job-manager/job.h
+++ b/src/modules/job-manager/job.h
@@ -24,6 +24,7 @@ struct job {
     int flags;
     flux_job_state_t state;
     json_t *end_event;      // event that caused transition to CLEANUP state
+    const flux_msg_t *waiter; // flux_job_wait() request
 
     uint8_t alloc_queued:1; // queued for alloc, but alloc request not sent
     uint8_t alloc_pending:1;// alloc request sent to sched

--- a/src/modules/job-manager/job.h
+++ b/src/modules/job-manager/job.h
@@ -13,6 +13,7 @@
 
 #include <stdint.h>
 #include <czmq.h>
+#include <jansson.h>
 #include "src/common/libjob/job.h"
 
 struct job {
@@ -22,6 +23,7 @@ struct job {
     double t_submit;
     int flags;
     flux_job_state_t state;
+    json_t *end_event;      // event that caused transition to CLEANUP state
 
     uint8_t alloc_queued:1; // queued for alloc, but alloc request not sent
     uint8_t alloc_pending:1;// alloc request sent to sched

--- a/src/modules/job-manager/restart.c
+++ b/src/modules/job-manager/restart.c
@@ -23,6 +23,7 @@
 #include "job.h"
 #include "restart.h"
 #include "event.h"
+#include "wait.h"
 
 /* restart_map callback should return -1 on error to stop map with error,
  * or 0 on success.  'job' is only valid for the duration of the callback.
@@ -133,6 +134,8 @@ static int restart_map_cb (struct job *job, void *arg)
 
     if (zhashx_insert (ctx->active_jobs, &job->id, job) < 0)
         return -1;
+    if ((job->flags & FLUX_JOB_WAITABLE))
+        wait_notify_active (ctx->wait, job);
     if (event_job_action (ctx->event, job) < 0) {
         flux_log_error (ctx->h, "%s: event_job_action id=%ju",
                         __FUNCTION__, (uintmax_t)job->id);

--- a/src/modules/job-manager/submit.c
+++ b/src/modules/job-manager/submit.c
@@ -20,6 +20,7 @@
 #include "job.h"
 #include "alloc.h"
 #include "event.h"
+#include "wait.h"
 
 #include "submit.h"
 
@@ -178,6 +179,9 @@ static void submit_cb (flux_t *h, flux_msg_handler_t *mh,
         if (submit_post_event (ctx->event, job) < 0)
             flux_log_error (h, "%s: submit_post_event id=%ju",
                             __FUNCTION__, (uintmax_t)job->id);
+
+        if ((job->flags & FLUX_JOB_WAITABLE))
+            wait_notify_active (ctx->wait, job);
         job_decref (job);
     }
     zlist_destroy (&newjobs);

--- a/src/modules/job-manager/wait.c
+++ b/src/modules/job-manager/wait.c
@@ -1,0 +1,445 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* wait.c - request a job's exit status
+ *
+ * Handle flux_job_wait (id) requests.
+ *
+ * The call blocks until the job transitions to INACTIVE, then
+ * a summary of the job result is returned:
+ * - a boolean success
+ * - a textual error string
+ *
+ * The event that transitions a waitable job to the CLEANUP state is
+ * captured in job->end_event.  RFC 21 dictates it must be a finish event
+ * containing a wait(2) style status byte, or a fatal exception.
+ * The event is converted to the summary above when the wait response
+ * is constructed.
+ *
+ * If the target job is active when the wait request is received,
+ * the request is tacked onto the 'struct job' and processed upon
+ * transtion to INACTIVE state.  If the target waitable job has already
+ * transitioned to INACTIVE, it is found in the wait->zombies hash
+ * and the request is processed immediately.
+ *
+ * Only jobs submitted with the FLUX_JOB_WAITABLE can be waited on.
+ *
+ * Wait is destructive; that is, job completion info is consumed by
+ * the first waiter.
+ *
+ * Guests are not permitted to wait on jobs or set FLUX_JOB_WAITABLE,
+ * to avoid possible unchecked zombie growth in a system instance.
+ *
+ * If the job id is FLUX_JOBID_ANY, then the response is:
+ * (1) result of the first job found in the wait->zombies hash
+ * (2) result of the next waitable job transitioning to INACTIVE,
+ *     without a waiter on the specific ID
+ * (3) ECHILD error if no waitable jobs are available, or there are
+ *     more waiters than jobs
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdbool.h>
+#include <czmq.h>
+#include <flux/core.h>
+
+#include "src/common/libutil/errno_safe.h"
+#include "src/common/libeventlog/eventlog.h"
+#include "src/common/libjob/job_hash.h"
+
+#include "drain.h"
+#include "submit.h"
+#include "job.h"
+
+struct waitjob {
+    struct job_manager *ctx;
+    flux_msg_handler_t **handlers;
+    zhashx_t *zombies;
+    int waiters; // count of waiters blocked on specific active jobs
+    int waitables; // count of active waitable jobs
+    zlistx_t *requests; // requests to wait in FLUX_JOBID_ANY
+};
+
+static int decode_job_result (struct job *job,
+                              bool *success,
+                              char *errbuf,
+                              int errbufsz)
+{
+    const char *name;
+    json_t *context;
+
+    if (!job->end_event)
+        return -1;
+    if (eventlog_entry_parse (job->end_event, NULL, &name, &context) < 0)
+        return -1;
+
+    /* Exception - set errbuf=description, set success=false
+     */
+    if (!strcmp (name, "exception")) {
+        const char *type;
+        const char *note = NULL;
+
+        if (json_unpack (context,
+                         "{s:s s?:s}",
+                         "type",
+                         &type,
+                         "note",
+                         &note) < 0)
+            return -1;
+        (void)snprintf (errbuf,
+                        errbufsz,
+                        "Fatal exception type=%s %s",
+                        type,
+                        note ? note : "");
+        *success = false;
+    }
+    /* Shells exited - set errbuf=decoded status byte,
+     * set success=true if all shells exited with 0, otherwise false.
+     */
+    else if (!strcmp (name, "finish")) {
+        int status;
+
+        if (json_unpack (context, "{s:i}", "status", &status) < 0)
+            return -1;
+        if (WIFSIGNALED (status)) {
+            (void)snprintf (errbuf,
+                            errbufsz,
+                            "task(s) %s",
+                            strsignal (WTERMSIG (status)));
+            *success = false;
+        }
+        else if (WIFEXITED (status)) {
+            (void)snprintf (errbuf,
+                            errbufsz,
+                            "task(s) exited with exit code %d",
+                            WEXITSTATUS (status));
+            *success = WEXITSTATUS (status) == 0 ? true : false;
+        }
+        else {
+            (void)snprintf (errbuf,
+                            errbufsz,
+                            "unexpected wait(2) status %d",
+                            status);
+            *success = false;
+        }
+    }
+    else
+        return -1;
+    return 0;
+}
+
+/* Respond to wait request 'msg' with completion info from 'job'.
+ */
+static void wait_respond (struct waitjob *wait,
+                          const flux_msg_t *msg,
+                          struct job *job)
+{
+    flux_t *h = wait->ctx->h;
+    char errbuf[1024];
+    bool success;
+
+    if (decode_job_result (job, &success, errbuf, sizeof (errbuf)) < 0) {
+        flux_log (h,
+                  LOG_ERR,
+                  "wait_respond id=%ju: result decode failure",
+                  (uintmax_t)job->id);
+        goto error;
+    }
+    if (flux_respond_pack (h,
+                           msg,
+                           "{s:I s:b s:s}",
+                           "id",
+                           job->id,
+                           "success",
+                           success ? 1 : 0,
+                           "errstr",
+                           errbuf) < 0)
+        flux_log_error (h, "wait_respond id=%ju", (uintmax_t)job->id);
+    return;
+error:
+    if (flux_respond_error (h, msg, errno, "Flux job wait internal error") < 0)
+        flux_log_error (h, "wait_respond id=%ju", (uintmax_t)job->id);
+}
+
+/* Callback from event_job_action().  The 'job' has entered INACTIVE state.
+ * Respond to a pending waiter, if any.  Otherwise insert into zombies
+ * hash for a future wait request.
+ */
+void wait_notify_inactive (struct waitjob *wait, struct job *job)
+{
+    flux_t *h = wait->ctx->h;
+    const flux_msg_t *req;
+
+    assert ((job->flags & FLUX_JOB_WAITABLE));
+
+    if (job->waiter) {
+        wait_respond (wait, job->waiter, job);
+        flux_msg_decref (job->waiter);
+        job->waiter = NULL;
+        wait->waiters--;
+    }
+    else if ((req = zlistx_detach (wait->requests, NULL))) {
+        wait_respond (wait, req, job);
+        flux_msg_decref (req);
+    }
+    else {
+        if (zhashx_insert (wait->zombies, &job->id, job) < 0) // increfs job
+            flux_log (h, LOG_ERR, "zhashx_insert into zombies hash failed");
+    }
+    wait->waitables--;
+}
+
+/* Callback from submit.c and restart.c where ctx->active_jobs is increased.
+ * Maintain count of waitable jobs.
+ */
+void wait_notify_active (struct waitjob *wait, struct job *job)
+{
+    assert ((job->flags & FLUX_JOB_WAITABLE));
+    wait->waitables++;
+}
+
+static void wait_rpc (flux_t *h,
+                      flux_msg_handler_t *mh,
+                      const flux_msg_t *msg,
+                      void *arg)
+{
+    struct job_manager *ctx = arg;
+    struct waitjob *wait = ctx->wait;
+    flux_jobid_t id;
+    struct job *job;
+    const char *errstr = NULL;
+
+    if (flux_request_unpack (msg, NULL, "{s:I}", "id", &id) < 0) {
+        errstr = "malformed wait request";
+        goto error;
+    }
+    if (id == FLUX_JOBID_ANY) {
+        /* If there's a zombie, respond and destroy it.
+         */
+        if ((job = zhashx_first (wait->zombies))) {
+            wait_respond (wait, msg, job);
+            zhashx_delete (wait->zombies, &job->id);
+        }
+        /* Enqueue request until a waitable job transitions to inactive.
+         */
+        else {
+            if (zlistx_add_end (wait->requests,
+                                (void *)flux_msg_incref (msg)) < 0) {
+                flux_msg_decref (msg);
+                errno = ENOMEM;
+                goto error;
+            }
+        }
+    }
+    else {
+        /* If job is already a zombie, respond and destroy zombie. Done!
+         */
+        if ((job = zhashx_lookup (wait->zombies, &id))) {
+            wait_respond (wait, msg, job);
+            zhashx_delete (wait->zombies, &id); // decrefs job
+        }
+        /* If job is still active, enqueue the request.
+         */
+        else if ((job = zhashx_lookup (ctx->active_jobs, &id))) {
+            if (job->waiter) {
+                errstr = "job id already has a waiter";
+                goto error_nojob;
+            }
+            if (!(job->flags & FLUX_JOB_WAITABLE)) {
+                errstr = "job was not submitted with FLUX_JOB_WAITABLE";
+                goto error_nojob;
+            }
+            job->waiter = flux_msg_incref (msg);
+            wait->waiters++;
+            return;
+        }
+        /* Invalid jobid, not waitable, or already waited on.
+         */
+        else {
+            errstr = "invalid job id, or job may be inactive and not waitable";
+            goto error_nojob;
+        }
+    }
+    /* Ensure that the action taken above does not result in more waiters than
+     * waitables.  Fail the most recently added FLUX_JOBID_ANY waiter if so.
+     * This could be due to
+     * (1) wait on specific ID increased wait->waiters, or
+     * (2) wait on FLUX_JOBID_ANY increased wait->requests.
+     */
+    if (zlistx_size (wait->requests) + wait->waiters > wait->waitables) {
+        const flux_msg_t *req = zlistx_last (wait->requests);
+
+        if (req) {
+            if (flux_respond_error (h,
+                                    req,
+                                    ECHILD,
+                                    "there are no more waitable jobs") < 0)
+                flux_log_error (h, "%s: flux_respond_error", __func__);
+            zlistx_detach_cur (wait->requests);
+            flux_msg_decref (req);
+        }
+    }
+    return;
+
+error_nojob:
+    errno = ECHILD; // mimic wait(2)
+error:
+    if (flux_respond_error (h, msg, errno, errstr) < 0)
+        flux_log_error (h, "%s: flux_respond_error", __func__);
+}
+
+/* A client has disconnected.  Destroy any waiters registered by that client.
+ */
+static void disconnect_rpc (flux_t *h,
+                            flux_msg_handler_t *mh,
+                            const flux_msg_t *msg,
+                            void *arg)
+{
+    struct job_manager *ctx = arg;
+    struct waitjob *wait = ctx->wait;
+    char *sender;
+    char *w_sender;
+    struct job *job;
+    const flux_msg_t *req;
+
+    if (flux_msg_get_route_first (msg, &sender) < 0)
+        return;
+    job = zhashx_first (ctx->active_jobs);
+    while (job && wait->waiters > 0) {
+        if (job->waiter) {
+            if (flux_msg_get_route_first (job->waiter, &w_sender) == 0) {
+                if (!strcmp (sender, w_sender)) {
+                    flux_msg_decref (job->waiter);
+                    job->waiter = NULL;
+                    wait->waiters--;
+                }
+            }
+            free (w_sender);
+        }
+        job = zhashx_next (ctx->active_jobs);
+    }
+    req = zlistx_first (wait->requests);
+    while (req) {
+        if (flux_msg_get_route_first (req, &w_sender) == 0) {
+            if (!strcmp (sender, w_sender)) {
+                zlistx_detach_cur (wait->requests);
+                flux_msg_decref (req);
+            }
+            free (w_sender);
+        }
+        req = zlistx_next (wait->requests);
+    }
+    free (sender);
+}
+
+struct job *wait_zombie_first (struct waitjob *wait)
+{
+    return zhashx_first (wait->zombies);
+}
+
+struct job *wait_zombie_next (struct waitjob *wait)
+{
+    return zhashx_next (wait->zombies);
+}
+
+static void respond_unloading (flux_t *h, const flux_msg_t *msg)
+{
+    if (flux_respond_error (h, msg, ENOSYS, "job-manager is unloading") < 0)
+        flux_log_error (h, "respond failed in wait teardown");
+}
+
+void wait_ctx_destroy (struct waitjob *wait)
+{
+    if (wait) {
+        flux_t *h = wait->ctx->h;
+        struct job *job;
+
+        int saved_errno = errno;
+        flux_msg_handler_delvec (wait->handlers);
+
+        /* Iterate through active jobs, sending ENOSYS response to
+         * any pending wait requests, indicating that the module is unloading.
+         * Use wait->waiters count to avoid unncessary scanning.
+         */
+        job = zhashx_first (wait->ctx->active_jobs);
+        while (job && wait->waiters > 0) {
+            if (job->waiter) {
+                respond_unloading (h, job->waiter);
+                flux_msg_decref (job->waiter);
+                job->waiter = NULL;
+                wait->waiters--;
+            }
+            job = zhashx_next (wait->ctx->active_jobs);
+        }
+
+        /* Send ENOSYS to any pending FLUX_JOBID_ANY wait requests,
+         * indicating that the module is unloading.
+         */
+        if (wait->requests) {
+            const flux_msg_t *msg;
+
+            while ((msg = zlistx_detach (wait->requests, NULL))) {
+                respond_unloading (h, msg);
+                flux_msg_decref (msg);
+            }
+            zlistx_destroy (&wait->requests);
+        }
+
+        zhashx_destroy (&wait->zombies);
+        free (wait);
+        errno = saved_errno;
+    }
+}
+
+static const struct flux_msg_handler_spec htab[] = {
+    {
+        .typemask = FLUX_MSGTYPE_REQUEST,
+        .topic_glob = "job-manager.wait",
+        .cb = wait_rpc,
+        .rolemask = 0
+    },
+    {
+        .typemask = FLUX_MSGTYPE_REQUEST,
+        .topic_glob = "job-manager.disconnect",
+        .cb = disconnect_rpc,
+        .rolemask = 0
+    },
+    FLUX_MSGHANDLER_TABLE_END,
+};
+
+struct waitjob *wait_ctx_create (struct job_manager *ctx)
+{
+    struct waitjob *wait;
+
+    if (!(wait = calloc (1, sizeof (*wait))))
+        return NULL;
+    wait->ctx = ctx;
+
+    if (!(wait->zombies = job_hash_create ()))
+        goto error;
+    zhashx_set_destructor (wait->zombies, job_destructor);
+    zhashx_set_duplicator (wait->zombies, job_duplicator);
+
+    if (!(wait->requests = zlistx_new ()))
+        goto error;
+
+    if (flux_msg_handler_addvec (ctx->h, htab, ctx, &wait->handlers) < 0)
+        goto error;
+    return wait;
+error:
+    wait_ctx_destroy (wait);
+    return NULL;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/job-manager/wait.h
+++ b/src/modules/job-manager/wait.h
@@ -1,0 +1,32 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _FLUX_JOB_MANAGER_WAIT_H
+#define _FLUX_JOB_MANAGER_WAIT_H
+
+#include <stdbool.h>
+#include <flux/core.h>
+
+#include "job-manager.h"
+
+void wait_notify_inactive (struct waitjob *wait, struct job *job);
+void wait_notify_active (struct waitjob *wait, struct job *job);
+
+struct waitjob *wait_ctx_create (struct job_manager *ctx);
+void wait_ctx_destroy (struct waitjob *wait);
+
+struct job *wait_zombie_first (struct waitjob *wait);
+struct job *wait_zombie_next (struct waitjob *wait);
+
+#endif /* ! _FLUX_JOB_MANAGER_WAIT_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -98,6 +98,7 @@ TESTSCRIPTS = \
 	t2204-job-info.t \
 	t2205-job-info-security.t \
 	t2206-job-manager-bulk-state.t \
+	t2207-job-manager-wait.t \
 	t2300-sched-simple.t \
 	t2301-schedutil-outstanding-requests.t \
 	t2400-job-exec-test.t \
@@ -191,6 +192,10 @@ dist_check_SCRIPTS = \
 	job-manager/drain-cancel.py \
 	job-manager/drain-undrain.py \
 	job-manager/bulk-state.py \
+	job-manager/submit-wait.py \
+	job-manager/submit-waitany.py \
+	job-manager/submit-sliding-window.py \
+	job-manager/wait-interrupted.py \
 	job-attach/outputsleep.sh \
 	job-exec/dummy.sh \
 	schedutil/req_and_unload.py \

--- a/t/job-manager/submit-sliding-window.py
+++ b/t/job-manager/submit-sliding-window.py
@@ -1,0 +1,63 @@
+###############################################################
+# Copyright 2019 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+# Usage: flux python submit-sliding-window.py njobs fanout
+#
+# Run 'njobs' jobs, keeping at most 'fanout' active at once
+#
+
+import flux
+from flux import job
+import sys
+import subprocess
+
+
+# Return jobspec for a simple job
+def make_jobspec(cmd):
+    out = subprocess.Popen(
+        ["flux", "jobspec", "srun", cmd],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    stdout, stderr = out.communicate()
+    return stdout
+
+
+njobs = 10
+fanout = 2
+if len(sys.argv) >= 2:
+    njobs = int(sys.argv[1])
+if len(sys.argv) == 3:
+    fanout = int(sys.argv[2])
+
+# Open connection to broker
+h = flux.Flux()
+
+jobspec = make_jobspec("/bin/true")
+flags = flux.constants.FLUX_JOB_WAITABLE
+done = 0
+running = 0
+
+while done < njobs:
+    if running < fanout and done + running < njobs:
+        jobid = job.submit(h, jobspec, flags=flags)
+        print("submit: {}".format(jobid))
+        running += 1
+
+    if running == fanout or done + running == njobs:
+        jobid, success, errstr = job.wait(h)
+        if success:
+            print("wait: {} Success".format(jobid))
+        else:
+            print("wait: {} Error: {}".format(jobid, errstr))
+        done += 1
+        running -= 1
+
+# vim: tabstop=4 shiftwidth=4 expandtab

--- a/t/job-manager/submit-wait.py
+++ b/t/job-manager/submit-wait.py
@@ -1,0 +1,63 @@
+###############################################################
+# Copyright 2019 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+# Usage: flux python submit-wait.py njobs
+#
+# Submit njobs jobs in a loop, then wait for them by id.
+#
+
+import flux
+from flux import job
+import sys
+import subprocess
+
+
+# Return jobspec for a simple job
+def make_jobspec(cmd):
+    out = subprocess.Popen(
+        ["flux", "jobspec", "srun", cmd],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    stdout, stderr = out.communicate()
+    return stdout
+
+
+if len(sys.argv) != 2:
+    njobs = 10
+else:
+    njobs = int(sys.argv[1])
+
+# Open connection to broker
+h = flux.Flux()
+
+# Submit njobs test jobs (half will fail)
+jobspec = make_jobspec("/bin/true")
+jobspec_fail = make_jobspec("/bin/false")
+jobs = []
+flags = flux.constants.FLUX_JOB_WAITABLE
+for i in range(njobs):
+    if i < njobs / 2:
+        jobid = job.submit(h, jobspec, flags=flags)
+        print("submit: {} /bin/true".format(jobid))
+    else:
+        jobid = job.submit(h, jobspec_fail, flags=flags)
+        print("submit: {} /bin/false".format(jobid))
+    jobs.append(jobid)
+
+# Wait for each job in turn
+for jobid in jobs:
+    result = job.wait(h, jobid)
+    if result.success:
+        print("wait: {} Success".format(result.jobid))
+    else:
+        print("wait: {} Error: {}".format(result.jobid, result.errstr))
+
+# vim: tabstop=4 shiftwidth=4 expandtab

--- a/t/job-manager/submit-waitany.py
+++ b/t/job-manager/submit-waitany.py
@@ -1,0 +1,62 @@
+###############################################################
+# Copyright 2019 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+# Usage: flux python submit-wait.py njobs
+#
+# Submit njobs jobs in a loop, then job.wait() njobs times
+#
+
+import flux
+from flux import job
+import sys
+import subprocess
+
+
+# Return jobspec for a simple job
+def make_jobspec(cmd):
+    out = subprocess.Popen(
+        ["flux", "jobspec", "srun", cmd],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    stdout, stderr = out.communicate()
+    return stdout
+
+
+if len(sys.argv) != 2:
+    njobs = 10
+else:
+    njobs = int(sys.argv[1])
+
+# Open connection to broker
+h = flux.Flux()
+
+# Submit njobs test jobs (half will fail)
+jobspec = make_jobspec("/bin/true")
+jobspec_fail = make_jobspec("/bin/false")
+flags = flux.constants.FLUX_JOB_WAITABLE
+for i in range(njobs):
+    if i < njobs / 2:
+        jobid = job.submit(h, jobspec, flags=flags)
+        print("submit: {} /bin/true".format(jobid))
+    else:
+        jobid = job.submit(h, jobspec_fail, flags=flags)
+        print("submit: {} /bin/false".format(jobid))
+
+
+# Wait for njobs jobs
+for i in range(njobs):
+    result = job.wait(h)
+    if result.success:
+        print("wait: {} Success".format(result.jobid))
+    else:
+        print("wait: {} Error: {}".format(result.jobid, result.errstr))
+
+# vim: tabstop=4 shiftwidth=4 expandtab

--- a/t/job-manager/wait-interrupted.py
+++ b/t/job-manager/wait-interrupted.py
@@ -1,0 +1,60 @@
+###############################################################
+# Copyright 2019 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+# Usage: flux python wait-interrupted.py njobs
+#
+# Submit njobs jobs in a loop, then wait for them asynchronously.
+# Exit before the waits complete, thus triggering disconnect cleanup.
+#
+
+import flux
+from flux import job
+import sys
+import subprocess
+
+
+# Return jobspec for a simple job
+def make_jobspec(cmd):
+    out = subprocess.Popen(
+        ["flux", "jobspec", "srun", cmd],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    stdout, stderr = out.communicate()
+    return stdout
+
+
+if len(sys.argv) != 2:
+    njobs = 10
+else:
+    njobs = int(sys.argv[1])
+
+# Open connection to broker
+h = flux.Flux()
+
+# Submit njobs test jobs
+jobspec = make_jobspec("/bin/true")
+jobs = []
+flags = flux.constants.FLUX_JOB_WAITABLE
+for i in range(njobs):
+    jobid = job.submit(h, jobspec, flags=flags)
+    print("submit: {} /bin/true".format(jobid))
+    jobs.append(jobid)
+
+# Async wait which we immediately abandon
+# Do half with jobid, half without to cover both disconnect loops
+# N.B. most likely this leaves some zombies so clean up after
+for i in range(njobs):
+    if i < njobs / 2:
+        f = job.wait_async(h, jobs[i])
+    else:
+        f = job.wait_async(h)
+
+# vim: tabstop=4 shiftwidth=4 expandtab

--- a/t/t2207-job-manager-wait.t
+++ b/t/t2207-job-manager-wait.t
@@ -1,0 +1,153 @@
+#!/bin/sh
+
+test_description='Test flux job manager wait handling'
+
+. $(dirname $0)/sharness.sh
+
+test_under_flux 1
+
+list_jobs=${FLUX_BUILD_DIR}/t/job-manager/list-jobs
+SUBMIT_WAIT="flux python ${FLUX_SOURCE_DIR}/t/job-manager/submit-wait.py"
+SUBMIT_WAITANY="flux python ${FLUX_SOURCE_DIR}/t/job-manager/submit-waitany.py"
+SUBMIT_SW="flux python ${FLUX_SOURCE_DIR}/t/job-manager/submit-sliding-window.py"
+SUBMIT_INTER="flux python ${FLUX_SOURCE_DIR}/t/job-manager/wait-interrupted.py"
+
+flux setattr log-stderr-level 1
+
+test_expect_success "wait works on waitable job run with flux-mini" '
+	JOBID=$(flux mini submit --flags waitable /bin/true) &&
+	flux job wait ${JOBID}
+'
+
+test_expect_success "wait works on waitable job run with flux-job" '
+	flux mini submit --dry-run /bin/true >true.jobspec &&
+	JOBID=$(flux job submit --flags=waitable true.jobspec) &&
+	flux job wait ${JOBID}
+'
+
+test_expect_success "wait works on inactive,waitable job" '
+	JOBID=$(flux mini submit --flags waitable /bin/true) &&
+	flux job wait-event ${JOBID} clean &&
+	flux job wait ${JOBID}
+'
+
+test_expect_success "waitable inactive jobs are listed as zombies" '
+	JOBID=$(flux mini submit --flags waitable /bin/true) &&
+	echo ${JOBID} >id1.out &&
+	flux job wait-event ${JOBID} clean &&
+	${list_jobs} >list1.out &&
+	test $(wc -l <list1.out) -eq 1 &&
+	test "$(cut -f2 <list1.out)" = "I"
+'
+
+test_expect_success "zombies go away after they are waited for" '
+	flux job wait $(cat id1.out) &&
+	${list_jobs} >list2.out &&
+	test $(wc -l <list2.out) -eq 0
+'
+
+test_expect_success "wait works on three waitable jobs in reverse order" '
+	JOB1=$(flux mini submit --flags waitable /bin/true) &&
+	JOB2=$(flux mini submit --flags waitable /bin/true) &&
+	JOB3=$(flux mini submit --flags waitable /bin/true) &&
+	flux job wait ${JOB3} &&
+	flux job wait ${JOB2} &&
+	flux job wait ${JOB1}
+'
+
+test_expect_success "wait FLUX_JOBID_ANY works on three waitable jobs" '
+	flux mini submit --flags waitable /bin/true >jobs.out &&
+	flux mini submit --flags waitable /bin/true >>jobs.out &&
+	flux mini submit --flags waitable /bin/true >>jobs.out &&
+	flux job wait >wait.out &&
+	flux job wait >>wait.out &&
+	flux job wait >>wait.out &&
+	sort -n jobs.out >jobs_s.out &&
+	sort -n wait.out >wait_s.out &&
+	test_cmp jobs_s.out wait_s.out
+'
+
+test_expect_success 'python submit-wait example works' '
+        ${SUBMIT_WAIT} >submit_wait.out &&
+        test $(grep Success submit_wait.out | wc -l) -eq 5
+'
+
+test_expect_success 'python submit-waitany example works' '
+        ${SUBMIT_WAITANY} >submit_waitany.out &&
+        test $(grep Success submit_waitany.out | wc -l) -eq 5
+'
+
+test_expect_success 'python submit-slidiing-window example works' '
+        ${SUBMIT_SW} >submit_sw.out &&
+        test $(grep Success submit_sw.out | wc -l) -eq 10
+'
+
+test_expect_success 'disconnect with async waits pending' '
+        ${SUBMIT_INTER} &&
+	count=0 &&
+	echo cleaning up zombies... &&
+	while flux job wait; do count=$(($count+1)); done &&
+	echo ...reaped $count of 10 zombies
+'
+
+test_expect_success "wait FLUX_JOBID_ANY fails with no waitable jobs" '
+	test_must_fail flux job wait
+'
+
+test_expect_success "wait works when job terminated by exception" '
+	JOBID=$(flux mini submit --flags waitable sleep 120) &&
+	flux job raise --severity=0 ${JOBID} my-exception-message &&
+	! flux job wait ${JOBID} 2>exception.out &&
+	grep my-exception-message exception.out
+'
+
+test_expect_success "wait works when job tasks exit 1" '
+	JOBID=$(flux mini submit --flags waitable /bin/false) &&
+	! flux job wait ${JOBID} 2>false.out &&
+	grep exit false.out
+'
+
+test_expect_success "wait works when job tasks exit 1" '
+	JOBID=$(flux mini submit --flags waitable /bin/false) &&
+	! flux job wait ${JOBID} 2>false.out &&
+	grep exit false.out
+'
+
+test_expect_success "wait fails on bad jobid, " '
+	test_must_fail flux job wait 1
+'
+
+test_expect_success "wait fails on non-waitable, active job" '
+	JOBID=$(flux mini submit sleep 0.5) &&
+	test_must_fail flux job wait ${JOBID}
+'
+
+test_expect_success "wait fails on non-waitable, inactive job" '
+	JOBID=$(flux mini submit /bin/true) &&
+	flux job wait-event ${JOBID} clean &&
+	test_must_fail flux job wait ${JOBID}
+'
+
+test_expect_success "a second wait fails on waitable, active job" '
+	JOBID=$(flux mini submit --flags waitable sleep 0.5) &&
+	flux job wait ${JOBID} &&
+	test_must_fail flux job wait ${JOBID}
+'
+
+test_expect_success "a second wait fails on waitable, inactive job" '
+	JOBID=$(flux mini submit --flags waitable /bin/true) &&
+	flux job wait-event ${JOBID} clean &&
+	flux job wait ${JOBID} &&
+	test_must_fail flux job wait ${JOBID}
+'
+
+test_expect_success "guest cannot submit job with WAITABLE flag" '
+	! FLUX_HANDLE_ROLEMASK=0x2 flux mini submit --flags waitable /bin/true
+'
+
+test_expect_success "guest cannot wait on a job" '
+	JOBID=$(flux mini submit --flags waitable /bin/true) &&
+	! FLUX_HANDLE_ROLEMASK=0x2 flux job wait ${JOBID}
+'
+
+test_done

--- a/t/t2700-mini-cmd.t
+++ b/t/t2700-mini-cmd.t
@@ -61,9 +61,17 @@ test_expect_success 'flux mini submit --priority=6 works' '
 	jobid=$(flux mini submit --priority=6 hostname) &&
 	flux job eventlog $jobid | grep submit | grep priority=6
 '
-test_expect_success 'flux mini submit --debug works' '
-	jobid=$(flux mini submit --debug hostname) &&
+test_expect_success 'flux mini submit --flags debug works' '
+	jobid=$(flux mini submit --flags debug hostname) &&
 	flux job eventlog $jobid | grep submit | grep flags=2
+'
+test_expect_success 'flux mini submit --flags waitable works' '
+	jobid=$(flux mini submit --flags waitable hostname) &&
+	flux job eventlog $jobid | grep submit | grep flags=4
+'
+test_expect_success 'flux mini submit --flags debug,waitable works' '
+	jobid=$(flux mini submit --flags debug,waitable hostname) &&
+	flux job eventlog $jobid | grep submit | grep flags=6
 '
 test_expect_success 'flux mini run -v produces jobid on stderr' '
 	flux mini run -v hostname 2>v.err &&

--- a/t/valgrind/workload.d/job-wait
+++ b/t/valgrind/workload.d/job-wait
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -x
+
+# Test job wait
+
+id=$(flux mini submit --flags waitable /bin/true)
+flux job wait ${id}
+
+# No leaks if zombie persists
+id=$(flux mini submit --flags waitable /bin/true)
+flux job wait-event ${id} clean


### PR DESCRIPTION
This PR adds a simple job synchronization mechanism.  One submits a job with a new flag, and then one can "wait' on the job and get back its status.   If the job is still active, "wait" blocks until it becomes inactive, as you might guess from the name.  The result of the job is distilled down to a boolean `success` and a human readable error string.

There is a new submit flag and a couple API calls:
```c
enum job_submit_flags {
    ...
    FLUX_JOB_WAITABLE = 4,      // flux_job_wait() will be used on this job
};

enum {
    FLUX_JOBID_ANY = 0xFFFFFFFFFFFFFFFF, // ~(uint64_t)0
};

/* Wait for jobid to enter INACTIVE state.
 * If jobid=FLUX_JOBID_ANY, wait for the next waitable job.
 * Fails with ECHILD if there is nothing to wait for.
 */
flux_future_t *flux_job_wait (flux_t *h, flux_jobid_t id);
int flux_job_wait_get_status (flux_future_t *f,
                              bool *success,
                              const char **errstr);
int flux_job_wait_get_id (flux_future_t *f, flux_jobid_t *id);
```

Only jobs submitted with the WAITABLE flag can be waited on.

Only the instance owner can use this, mainly to dodge the potential DoS that might arise if a user creates many "zombie" jobs, so potentially that could be changed if that concern is deemed low risk or we have an idea for mitigation.

The wait call can be made only once per job (it is destructive to the job completion state).

I had planned something like this all along, but after speaking with James Corbett the other day was reminded that it was still missing.

There is also a python binding, making e.g. this sort of thing possible:
```python
for i in range(njobs):
        jobid = job.submit(h, jobspec, flags=flux.constants.FLUX_JOB_WAITABLE)

for i in range(njobs):
    result = job.wait(h)  # missing jobid parameter == FLUX_JOBID_ANY
    if result.success:
        print("wait: {} Success".format(result.jobid))
    else:
        print("wait: {} Error: {}".format(result.jobid, result.errstr))
```