### PR TITLE
shell: stdin write to exited task should not cause fatal job exception

### DIFF
--- a/src/shell/input.c
+++ b/src/shell/input.c
@@ -510,8 +510,12 @@ static void shell_task_input_kvs_input_cb (flux_future_t *f, void *arg)
                 if (flux_subprocess_write (task->proc,
                                            stream,
                                            data,
-                                           len) < 0)
-                    shell_die_errno (1, "flux_subprocess_write");
+                                           len) < 0) {
+                    if (errno != EPIPE)
+                        shell_die_errno (1, "flux_subprocess_write");
+                    else
+                        eof = true; /* Pretend that we got eof */
+                }
             }
             if (eof) {
                 if (flux_subprocess_close (task->proc, stream) < 0)

--- a/src/shell/input.c
+++ b/src/shell/input.c
@@ -67,7 +67,6 @@ struct shell_input {
     flux_shell_t *shell;
     int stdin_type;
     struct shell_task_input *task_inputs;
-    int task_inputs_count;
     int ntasks;
     struct shell_input_type_file stdin_file;
 };
@@ -556,6 +555,12 @@ static int shell_task_input_kvs_start (struct shell_task_input *ti)
     return 0;
 }
 
+static struct shell_task_input *get_task_input (struct shell_input *in,
+                                                flux_shell_task_t *task)
+{
+    return &in->task_inputs[task->index];
+}
+
 static int shell_input_task_init (flux_plugin_t *p,
                                   const char *topic,
                                   flux_plugin_arg_t *args,
@@ -569,7 +574,7 @@ static int shell_input_task_init (flux_plugin_t *p,
     if (!shell || !in || !(task = flux_shell_current_task (shell)))
         return -1;
 
-    task_input = &(in->task_inputs[in->task_inputs_count]);
+    task_input = get_task_input (in, task);
     task_input->in = in;
     task_input->task = task;
 
@@ -579,7 +584,6 @@ static int shell_input_task_init (flux_plugin_t *p,
             && shell_task_input_kvs_start (task_input) < 0)
             shell_die_errno (1, "shell_input_start_task_watch");
     }
-    in->task_inputs_count++;
     return 0;
 }
 

--- a/src/shell/input.c
+++ b/src/shell/input.c
@@ -74,6 +74,7 @@ struct shell_input {
 static void shell_task_input_kvs_cleanup (struct shell_task_input_kvs *kp)
 {
     flux_future_destroy (kp->input_f);
+    kp->input_f = NULL;
 }
 
 static void shell_task_input_cleanup (struct shell_task_input *tp)
@@ -529,8 +530,7 @@ static void shell_task_input_kvs_input_cb (flux_future_t *f, void *arg)
     flux_future_reset (f);
     return;
 done:
-    flux_future_destroy (f);
-    kp->input_f = NULL;
+    shell_task_input_kvs_cleanup (kp);
 }
 
 static int shell_task_input_kvs_start (struct shell_task_input *ti)

--- a/src/shell/input.c
+++ b/src/shell/input.c
@@ -47,7 +47,6 @@ enum {
 struct shell_task_input_kvs {
     flux_future_t *input_f;
     bool input_header_parsed;
-    bool eof_reached;
 };
 
 struct shell_task_input {
@@ -500,10 +499,6 @@ static void shell_task_input_kvs_input_cb (flux_future_t *f, void *arg)
             char *data = NULL;
             int len;
             bool eof;
-            if (kp->eof_reached) {
-                shell_die (1, "stream data after EOF");
-                goto out;
-            }
             if (iodecode (context, &stream, NULL, &data, &len, &eof) < 0)
                 shell_die (1, "malformed event context");
             if (len > 0) {


### PR DESCRIPTION
This PR fixes an issue found in the shell input plugin during testing. Currently, any error from `flux_subprocess_write()` is a fatal error and results in a fatal job exception. However, some write errors (e.g. EPIPE) should not cause the job to be killed (and in fact should probably just be ignored)

For example, if `flux mini run` is run with default arguments and some tasks (but not all) have exited, and the user types a character on the terminal running `flux mini run`, this will kill the job. This is because the `flux_subprocess_write()` to the exited/exiting tasks gets `EPIPE` which results in a fatal exception.

This can be reproduced simply as:
```console
$ flux mini run -o verbose -n2 sh -c 'sleep $FLUX_TASK_RANK'
0.043s: flux-shell[0]: DEBUG: 0: task_count=2 slot_count=2 cores_per_slot=1 slots_per_node=-1
0.043s: flux-shell[0]: DEBUG: 0: tasks [0-1] on cores 0-1
0.043s: flux-shell[0]: DEBUG: Loading /g/g0/grondo/git/flux-core.git/src/shell/initrc.lua
0.061s: flux-shell[0]: DEBUG: output: batch timeout = 0.500s
0.070s: flux-shell[0]: DEBUG: task 0 complete status=0

0.538s: flux-shell[0]: FATAL: flux_subprocess_write: Broken pipe
0.539s: job.exception type=exec severity=0 flux_subprocess_write: Broken pipe
flux-job: task(s) exited with exit code 1
```

i.e. wait until the first task exits, then hit enter, which will kill the job.

In this PR a couple steps are are taken to avoid this:

 * If `flux_subprocess_write()` returns `EPIPE`, treat it like EOF and close stdin and cancel the eventlog watch, directly handling the case above
 * Add a task.exit handler to the shell's `input` plugin which also cancels the watch on the input eventlog.

A few other cleanups were made along the way.

It actually might be trivial to add a test for this case (send stdin to a job where some tasks exited), so perhaps I'll quickly work on that next.

