### PR TITLE
job-manager: fix job lookup error handling

### DIFF
--- a/src/modules/job-manager/alloc.c
+++ b/src/modules/job-manager/alloc.c
@@ -157,14 +157,14 @@ static void free_response_cb (flux_t *h, flux_msg_handler_t *mh,
     if (flux_msg_unpack (msg, "{s:I}", "id", &id) < 0)
         goto teardown;
     if (!(job = zhashx_lookup (ctx->active_jobs, &id))) {
-        flux_log (h, LOG_ERR, "sched.free-response: id=%llu not active",
-                  (unsigned long long)id);
+        flux_log (h, LOG_ERR, "sched.free-response: id=%ju not active",
+                  (uintmax_t)id);
         errno = EINVAL;
         goto teardown;
     }
     if (!job->has_resources) {
-        flux_log (h, LOG_ERR, "sched.free-response: id=%lld not allocated",
-                  (unsigned long long)id);
+        flux_log (h, LOG_ERR, "sched.free-response: id=%ju not allocated",
+                  (uintmax_t)id);
         errno = EINVAL;
         goto teardown;
     }
@@ -221,14 +221,14 @@ static void alloc_response_cb (flux_t *h, flux_msg_handler_t *mh,
         goto teardown;
     }
     if (!(job = zhashx_lookup (ctx->active_jobs, &id))) {
-        flux_log (h, LOG_ERR, "sched.alloc-response: id=%llu not active",
-                  (unsigned long long)id);
+        flux_log (h, LOG_ERR, "sched.alloc-response: id=%ju not active",
+                  (uintmax_t)id);
         errno = EINVAL;
         goto teardown;
     }
     if (!job->alloc_pending) {
-        flux_log (h, LOG_ERR, "sched.alloc-response: id=%lld not requested",
-                  (unsigned long long)id);
+        flux_log (h, LOG_ERR, "sched.alloc-response: id=%ju not requested",
+                  (uintmax_t)id);
         errno = EINVAL;
         goto teardown;
     }
@@ -262,8 +262,8 @@ static void alloc_response_cb (flux_t *h, flux_msg_handler_t *mh,
      * Log alloc event and transtion to RUN state.
      */
     if (job->has_resources) {
-        flux_log (h, LOG_ERR, "sched.alloc-response: id=%lld already allocated",
-                  (unsigned long long)id);
+        flux_log (h, LOG_ERR, "sched.alloc-response: id=%ju already allocated",
+                  (uintmax_t)id);
         errno = EEXIST;
         goto teardown;
     }

--- a/src/modules/job-manager/alloc.c
+++ b/src/modules/job-manager/alloc.c
@@ -157,8 +157,9 @@ static void free_response_cb (flux_t *h, flux_msg_handler_t *mh,
     if (flux_msg_unpack (msg, "{s:I}", "id", &id) < 0)
         goto teardown;
     if (!(job = zhashx_lookup (ctx->active_jobs, &id))) {
-        flux_log_error (h, "sched.free-response: id=%llu not active",
-                        (unsigned long long)id);
+        flux_log (h, LOG_ERR, "sched.free-response: id=%llu not active",
+                  (unsigned long long)id);
+        errno = EINVAL;
         goto teardown;
     }
     if (!job->has_resources) {
@@ -220,8 +221,9 @@ static void alloc_response_cb (flux_t *h, flux_msg_handler_t *mh,
         goto teardown;
     }
     if (!(job = zhashx_lookup (ctx->active_jobs, &id))) {
-        flux_log_error (h, "sched.alloc-response: id=%llu not active",
-                        (unsigned long long)id);
+        flux_log (h, LOG_ERR, "sched.alloc-response: id=%llu not active",
+                  (unsigned long long)id);
+        errno = EINVAL;
         goto teardown;
     }
     if (!job->alloc_pending) {

--- a/src/modules/job-manager/priority.c
+++ b/src/modules/job-manager/priority.c
@@ -66,6 +66,7 @@ void priority_handle_request (flux_t *h,
     }
     if (!(job = zhashx_lookup (ctx->active_jobs, &id))) {
         errstr = "unknown job";
+        errno = EINVAL;
         goto error;
     }
     /* Security: guests can only adjust jobs that they submitted.

--- a/src/modules/job-manager/raise.c
+++ b/src/modules/job-manager/raise.c
@@ -98,6 +98,7 @@ void raise_handle_request (flux_t *h,
     }
     if (!(job = zhashx_lookup (ctx->active_jobs, &id))) {
         errstr = "unknown job id";
+        errno = EINVAL;
         goto error;
     }
     if (raise_allow (rolemask, userid, job->userid) < 0) {

--- a/src/modules/job-manager/restart.c
+++ b/src/modules/job-manager/restart.c
@@ -134,8 +134,8 @@ static int restart_map_cb (struct job *job, void *arg)
     if (zhashx_insert (ctx->active_jobs, &job->id, job) < 0)
         return -1;
     if (event_job_action (ctx->event, job) < 0) {
-        flux_log_error (ctx->h, "%s: event_job_action id=%llu",
-                        __FUNCTION__, (unsigned long long)job->id);
+        flux_log_error (ctx->h, "%s: event_job_action id=%ju",
+                        __FUNCTION__, (uintmax_t)job->id);
     }
     return 0;
 }

--- a/src/modules/job-manager/start.c
+++ b/src/modules/job-manager/start.c
@@ -192,8 +192,9 @@ static void start_response_cb (flux_t *h, flux_msg_handler_t *mh,
         goto error;
     }
     if (!(job = zhashx_lookup (ctx->active_jobs, &id))) {
-        flux_log_error (h, "start response: id=%llu not active",
-                        (unsigned long long)id);
+        flux_log (h, LOG_ERR, "start response: id=%llu not active",
+                  (unsigned long long)id);
+        errno = EINVAL;
         goto error;
     }
     if (!strcmp (type, "start")) {

--- a/src/modules/job-manager/start.c
+++ b/src/modules/job-manager/start.c
@@ -131,8 +131,8 @@ static void hello_cb (flux_t *h, flux_msg_handler_t *mh,
     while (job) {
         if (job->state == FLUX_JOB_RUN) {
             if (event_job_action (ctx->event, job) < 0)
-                flux_log_error (h, "%s: event_job_action id=%llu", __FUNCTION__,
-                                (unsigned long long)job->id);
+                flux_log_error (h, "%s: event_job_action id=%ju", __FUNCTION__,
+                                (uintmax_t)job->id);
         }
         job = zhashx_next (ctx->active_jobs);
     }
@@ -192,8 +192,8 @@ static void start_response_cb (flux_t *h, flux_msg_handler_t *mh,
         goto error;
     }
     if (!(job = zhashx_lookup (ctx->active_jobs, &id))) {
-        flux_log (h, LOG_ERR, "start response: id=%llu not active",
-                  (unsigned long long)id);
+        flux_log (h, LOG_ERR, "start response: id=%ju not active",
+                  (uintmax_t)id);
         errno = EINVAL;
         goto error;
     }

--- a/src/modules/job-manager/submit.c
+++ b/src/modules/job-manager/submit.c
@@ -176,8 +176,8 @@ static void submit_cb (flux_t *h, flux_msg_handler_t *mh,
      */
     while ((job = zlist_pop (newjobs))) {
         if (submit_post_event (ctx->event, job) < 0)
-            flux_log_error (h, "%s: submit_post_event id=%llu",
-                            __FUNCTION__, (unsigned long long)job->id);
+            flux_log_error (h, "%s: submit_post_event id=%ju",
+                            __FUNCTION__, (uintmax_t)job->id);
         job_decref (job);
     }
     zlist_destroy (&newjobs);

--- a/t/t2201-job-cmd.t
+++ b/t/t2201-job-cmd.t
@@ -203,6 +203,10 @@ test_expect_success 'flux-job: cancel fails with bad FLUX_URI' '
 	! FLUX_URI=/wrong flux job cancel ${validjob}
 '
 
+test_expect_success 'flux-job: cancel fails with unknown job id' '
+	test_must_fail flux job cancel 0
+'
+
 test_expect_success 'flux-job: cancel fails with no args' '
 	test_must_fail flux job cancel
 '


### PR DESCRIPTION
As @grondo noted in #2551, some error paths in the job manager, where job ID's are looked up, are no longer functioning properly.  This was due to my change in #2536 from `queue_lookup()` which set errno, to `zhashx_lookup()` which does not.

This puts things right, and also cleans up some error formatting that was nearby.