### PR TITLE
bindings/python: destroy future after use

### DIFF
--- a/src/bindings/python/flux/future.py
+++ b/src/bindings/python/flux/future.py
@@ -115,6 +115,9 @@ class Future(WrapperPimpl):
         # For example `f.rpc('topic').then(cb).wait_for(-1)
         return self
 
+    def destroy(self):
+        self.pimpl.destroy()
+
     def reset(self):
         self.pimpl.reset()
 

--- a/src/bindings/python/flux/job.py
+++ b/src/bindings/python/flux/job.py
@@ -51,4 +51,6 @@ def submit_get_id(future):
 
 def submit(flux_handle, jobspec, priority=lib.FLUX_JOB_PRIORITY_DEFAULT, flags=0):
     future = submit_async(flux_handle, jobspec, priority, flags)
-    return submit_get_id(future)
+    jid = submit_get_id(future)
+    future.destroy()
+    return jid


### PR DESCRIPTION
Following a suggestion by @grondo, the `submit_get_id`-future sees
delayed / no garbage collection and causes a significant slowdowns due to
apparent limits in the future layer.  This commit adds explicit
destruction after future completion, thus avoiding that issue.

I am not familiar with your PR policies: what branch to point to, what additional information to provide, etc.  Please let me know this is off...

This closes #2549 