### PR TITLE
kvs: Fix duplicate append corner case

### DIFF
--- a/src/modules/job-info/job_state.c
+++ b/src/modules/job-info/job_state.c
@@ -322,6 +322,7 @@ static void eventlog_lookup_continuation (flux_future_t *f, void *arg)
                              job,
                              ctx->jsctx->processing,
                              job->state);
+            break;
         }
     }
 


### PR DESCRIPTION
Per discussion in #2547, fix corner case in which append could be duplicated.  Solution was to cache the root directory used to make the root cpy.  If a stall + replay occurs, replay on a brand new root cpy that has been refreshed via `json_deep_copy()`.

Added unit test.  Confirmed unit test failed on master, but works after fix.

Also fixed #2545 (which found this issue) in this PR, since it's trivial once the core issue was fixed.
