### PR TITLE
initial job-name support

### DIFF
--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -625,7 +625,7 @@ int cmd_list (optparse_t *p, int argc, char **argv)
 {
     int optindex = optparse_option_index (p);
     int max_entries = optparse_get_int (p, "count", 0);
-    char *attrs = "[\"userid\",\"priority\",\"t_submit\",\"state\"]";
+    char *attrs = "[\"userid\",\"priority\",\"t_submit\",\"state\",\"job-name\"]";
     flux_t *h;
     flux_future_t *f;
     json_t *jobs;
@@ -670,8 +670,8 @@ int cmd_list (optparse_t *p, int argc, char **argv)
     if (flux_rpc_get_unpack (f, "{s:o}", "jobs", &jobs) < 0)
         log_err_exit ("flux_job_list");
     if (!optparse_hasopt (p, "suppress-header"))
-        printf ("%s\t\t%s\t%s\t%s\t%s\n",
-                "JOBID", "STATE", "USERID", "PRI", "T_SUBMIT");
+        printf ("%s\t\t%s\t%s\t%s\t%s\t\t%s\n",
+                "JOBID", "STATE", "USERID", "PRI", "NAME", "T_SUBMIT");
     json_array_foreach (jobs, index, value) {
         flux_jobid_t id;
         int priority;
@@ -679,20 +679,23 @@ int cmd_list (optparse_t *p, int argc, char **argv)
         double t_submit;
         char timestr[80];
         flux_job_state_t state;
+        const char *job_name;
 
-        if (json_unpack (value, "{s:I s:i s:i s:f s:i}",
+        if (json_unpack (value, "{s:I s:i s:i s:f s:i s:s}",
                                 "id", &id,
                                 "priority", &priority,
                                 "userid", &userid,
                                 "t_submit", &t_submit,
-                                "state", &state) < 0)
+                                "state", &state,
+                                "job-name", &job_name) < 0)
             log_msg_exit ("error parsing job data");
         if (iso_timestr (t_submit, timestr, sizeof (timestr)) < 0)
             log_err_exit ("time conversion error");
-        printf ("%llu\t%s\t%lu\t%d\t%s\n", (unsigned long long)id,
+        printf ("%llu\t%s\t%lu\t%d\t%-15.15s\t%s\n", (unsigned long long)id,
                                        flux_job_statetostr (state, true),
                                        (unsigned long)userid,
                                        priority,
+                                       job_name,
                                        timestr);
     }
     flux_future_destroy (f);

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -201,7 +201,7 @@ static struct optparse_option drain_opts[] =  {
 static struct optparse_subcommand subcommands[] = {
     { "list",
       "[OPTIONS]",
-      "List active jobs",
+      "List jobs",
       cmd_list,
       0,
       list_opts

--- a/src/cmd/flux-mini.py
+++ b/src/cmd/flux-mini.py
@@ -279,6 +279,12 @@ class SubmitCmd:
             default=16,
         )
         parser.add_argument(
+            "--job-name",
+            type=str,
+            help="Set an optional name for job to NAME",
+            metavar="NAME",
+        )
+        parser.add_argument(
             "-o",
             "--setopt",
             action="append",
@@ -351,6 +357,9 @@ class SubmitCmd:
         jobspec.set_environment(dict(os.environ))
         if args.time_limit is not None:
             jobspec.set_duration(args.time_limit)
+
+        if args.job_name is not None:
+            jobspec.setattr("system.job.name", args.job_name)
 
         if args.input is not None:
             jobspec.setattr_shopt("input.stdin.type", "file")

--- a/src/modules/job-info/job_state.h
+++ b/src/modules/job-info/job_state.h
@@ -12,6 +12,7 @@
 #define _FLUX_JOB_INFO_JOB_STATE_H
 
 #include <flux/core.h>
+#include <jansson.h>
 
 #include "info.h"
 
@@ -57,6 +58,11 @@ struct job {
     double t_submit;
     int flags;
     flux_job_state_t state;
+    const char *job_name;
+
+    /* cache of job information */
+    json_t *jobspec_job;
+    json_t *jobspec_cmd;
 
     /* if userid, priority, t_submit, and flags have been set */
     bool job_info_retrieved;

--- a/src/modules/job-info/list.c
+++ b/src/modules/job-info/list.c
@@ -67,6 +67,9 @@ json_t *list_one_job (struct job *job, json_t *attrs)
         else if (!strcmp (attr, "state")) {
             val = json_integer (job->state);
         }
+        else if (!strcmp (attr, "job-name")) {
+            val = json_string (job->job_name);
+        }
         else {
             errno = EINVAL;
             goto error;
@@ -234,12 +237,13 @@ error:
 void list_attrs_cb (flux_t *h, flux_msg_handler_t *mh,
                     const flux_msg_t *msg, void *arg)
 {
-    if (flux_respond_pack (h, msg, "{s:[s,s,s,s]}",
+    if (flux_respond_pack (h, msg, "{s:[s,s,s,s,s]}",
                            "attrs",
                            "userid",
                            "priority",
                            "t_submit",
-                           "state") < 0) {
+                           "state",
+                           "job-name") < 0) {
         flux_log_error (h, "%s: flux_respond_pack", __FUNCTION__);
         goto error;
     }

--- a/t/t2700-mini-cmd.t
+++ b/t/t2700-mini-cmd.t
@@ -173,6 +173,12 @@ test_expect_success 'flux mini submit --gpus-per-task adds gpus to task slot' '
 	test $(jq ".resources[0].with[1].type" gpu.out) = "\"gpu\"" &&
 	test $(jq ".resources[0].with[1].count" gpu.out) = "2"
 '
+test_expect_success 'flux mini --jobname works' '
+	jobid=$(flux mini submit hostname) &&
+        flux job list --pending --running --inactive | grep $jobid | grep hostname &&
+	jobid=$(flux mini submit --job-name=foobar hostname) &&
+        flux job list --pending --running --inactive | grep $jobid | grep foobar
+'
 
 
 test_done


### PR DESCRIPTION
Per RFC PR https://github.com/flux-framework/rfc/pull/214, support job-names in the job-info module's job listing service, and then the `flux job list` tool.  Job names will be the first string in the command list OR can be set by the user.

example use case:

`flux mini submit --setattr system.job-name=myjobname hostname`

example output in job listing:

```
JOBID		STATE	USERID	PRI	NAME		T_SUBMIT
503064821760	I	8556	16	hostname       	2019-11-27T17:37:24Z
422450298880	I	8556	16	myjobname       2019-11-27T17:37:20Z
```

Note: I elected to close issue #2401 in one of the commits in this PR.  Issue #2401 is quite generic in this statement of having "wreck parity".  It's possible this isn't full wreck parity, but I figure it's close enough.