### PR TITLE
bindings/python and libev:  work around future leak

### DIFF
--- a/src/bindings/python/flux/job.py
+++ b/src/bindings/python/flux/job.py
@@ -52,7 +52,10 @@ def submit_get_id(future):
 
 def submit(flux_handle, jobspec, priority=lib.FLUX_JOB_PRIORITY_DEFAULT, flags=0):
     future = submit_async(flux_handle, jobspec, priority, flags)
-    return submit_get_id(future)
+    jid = submit_get_id(future)
+    # pylint: disable=protected-access
+    future.pimpl._clear()
+    return jid
 
 
 def wait_async(flux_handle, jobid=lib.FLUX_JOBID_ANY):
@@ -78,4 +81,7 @@ def wait_get_status(future):
 
 def wait(flux_handle, jobid=lib.FLUX_JOBID_ANY):
     future = wait_async(flux_handle, jobid)
-    return wait_get_status(future)
+    status = wait_get_status(future)
+    # pylint: disable=protected-access
+    future.pimpl._clear()
+    return status

--- a/src/bindings/python/flux/wrapper.py
+++ b/src/bindings/python/flux/wrapper.py
@@ -326,7 +326,7 @@ class Wrapper(WrapperBase):
         setattr(self, name, new_method)
         return new_method
 
-    def __clear(self):
+    def _clear(self):
         # avoid recursion
         if hasattr(self, "_handle") and self._handle is not None:
             handle = self._handle
@@ -354,14 +354,14 @@ class Wrapper(WrapperBase):
                     )
                 )
         if self._handle is not None:
-            self.__clear()
+            self._clear()
         self._handle = h
 
     def __del__(self):
-        self.__clear()
+        self._clear()
 
     def __enter__(self):
         return self
 
     def __exit__(self, type_arg, value, unused):
-        self.__clear()
+        self._clear()

--- a/src/common/libev/Makefile.am
+++ b/src/common/libev/Makefile.am
@@ -8,4 +8,9 @@ libev_la_SOURCES = \
 	ev_vars.h \
 	ev_wrap.h
 
-EXTRA_DIST = ev_select.c ev_poll.c ev_epoll.c libev.m4
+EXTRA_DIST = \
+	ev_select.c \
+	ev_poll.c \
+	ev_epoll.c \
+	ev_linuxaio.c \
+	libev.m4

--- a/src/common/libev/ev.c
+++ b/src/common/libev/ev.c
@@ -1,7 +1,7 @@
 /*
  * libev event processing core, watcher management
  *
- * Copyright (c) 2007-2018 Marc Alexander Lehmann <libev@schmorp.de>
+ * Copyright (c) 2007-2019 Marc Alexander Lehmann <libev@schmorp.de>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modifica-
@@ -115,6 +115,15 @@
 # else
 #  undef EV_USE_EPOLL
 #  define EV_USE_EPOLL 0
+# endif
+   
+# if HAVE_LINUX_AIO_ABI_H
+#  ifndef EV_USE_LINUXAIO
+#   define EV_USE_LINUXAIO EV_FEATURE_BACKENDS
+#  endif
+# else
+#  undef EV_USE_LINUXAIO
+#  define EV_USE_LINUXAIO 0
 # endif
    
 # if HAVE_KQUEUE && HAVE_SYS_EVENT_H
@@ -317,6 +326,14 @@
 # define EV_USE_PORT 0
 #endif
 
+#ifndef EV_USE_LINUXAIO
+# if __linux /* libev currently assumes linux/aio_abi.h is always available on linux */
+#  define EV_USE_LINUXAIO 1
+# else
+#  define EV_USE_LINUXAIO 0
+# endif
+#endif
+
 #ifndef EV_USE_INOTIFY
 # if __linux && (__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 4))
 #  define EV_USE_INOTIFY EV_FEATURE_OS
@@ -418,6 +435,14 @@
 /* hp-ux has it in sys/time.h, which we unconditionally include above */
 # if !defined _WIN32 && !defined __hpux
 #  include <sys/select.h>
+# endif
+#endif
+
+#if EV_USE_LINUXAIO
+# include <sys/syscall.h>
+# if !SYS_io_getevents || !EV_USE_EPOLL /* ev_linxaio uses ev_poll.c:ev_epoll_create */
+#  undef EV_USE_LINUXAIO
+#  define EV_USE_LINUXAIO 0
 # endif
 #endif
 
@@ -536,7 +561,7 @@ struct signalfd_siginfo
 #define ECB_H
 
 /* 16 bits major, 16 bits minor */
-#define ECB_VERSION 0x00010005
+#define ECB_VERSION 0x00010006
 
 #ifdef _WIN32
   typedef   signed char   int8_t;
@@ -660,6 +685,7 @@ struct signalfd_siginfo
 
 #ifndef ECB_MEMORY_FENCE
   #if ECB_GCC_VERSION(2,5) || defined __INTEL_COMPILER || (__llvm__ && __GNUC__) || __SUNPRO_C >= 0x5110 || __SUNPRO_CC >= 0x5110
+    #define ECB_MEMORY_FENCE_RELAXED __asm__ __volatile__ ("" : : : "memory")
     #if __i386 || __i386__
       #define ECB_MEMORY_FENCE         __asm__ __volatile__ ("lock; orb $0, -1(%%esp)" : : : "memory")
       #define ECB_MEMORY_FENCE_ACQUIRE __asm__ __volatile__ (""                        : : : "memory")
@@ -719,12 +745,14 @@ struct signalfd_siginfo
     #define ECB_MEMORY_FENCE         __atomic_thread_fence (__ATOMIC_SEQ_CST)
     #define ECB_MEMORY_FENCE_ACQUIRE __atomic_thread_fence (__ATOMIC_ACQUIRE)
     #define ECB_MEMORY_FENCE_RELEASE __atomic_thread_fence (__ATOMIC_RELEASE)
+    #define ECB_MEMORY_FENCE_RELAXED __atomic_thread_fence (__ATOMIC_RELAXED)
 
   #elif ECB_CLANG_EXTENSION(c_atomic)
     /* see comment below (stdatomic.h) about the C11 memory model. */
     #define ECB_MEMORY_FENCE         __c11_atomic_thread_fence (__ATOMIC_SEQ_CST)
     #define ECB_MEMORY_FENCE_ACQUIRE __c11_atomic_thread_fence (__ATOMIC_ACQUIRE)
     #define ECB_MEMORY_FENCE_RELEASE __c11_atomic_thread_fence (__ATOMIC_RELEASE)
+    #define ECB_MEMORY_FENCE_RELAXED __c11_atomic_thread_fence (__ATOMIC_RELAXED)
 
   #elif ECB_GCC_VERSION(4,4) || defined __INTEL_COMPILER || defined __clang__
     #define ECB_MEMORY_FENCE         __sync_synchronize ()
@@ -744,9 +772,10 @@ struct signalfd_siginfo
     #define ECB_MEMORY_FENCE         MemoryBarrier () /* actually just xchg on x86... scary */
   #elif __SUNPRO_C >= 0x5110 || __SUNPRO_CC >= 0x5110
     #include <mbarrier.h>
-    #define ECB_MEMORY_FENCE         __machine_rw_barrier ()
-    #define ECB_MEMORY_FENCE_ACQUIRE __machine_r_barrier  ()
-    #define ECB_MEMORY_FENCE_RELEASE __machine_w_barrier  ()
+    #define ECB_MEMORY_FENCE         __machine_rw_barrier  ()
+    #define ECB_MEMORY_FENCE_ACQUIRE __machine_acq_barrier ()
+    #define ECB_MEMORY_FENCE_RELEASE __machine_rel_barrier ()
+    #define ECB_MEMORY_FENCE_RELAXED __compiler_barrier ()
   #elif __xlC__
     #define ECB_MEMORY_FENCE         __sync ()
   #endif
@@ -757,15 +786,9 @@ struct signalfd_siginfo
     /* we assume that these memory fences work on all variables/all memory accesses, */
     /* not just C11 atomics and atomic accesses */
     #include <stdatomic.h>
-    /* Unfortunately, neither gcc 4.7 nor clang 3.1 generate any instructions for */
-    /* any fence other than seq_cst, which isn't very efficient for us. */
-    /* Why that is, we don't know - either the C11 memory model is quite useless */
-    /* for most usages, or gcc and clang have a bug */
-    /* I *currently* lean towards the latter, and inefficiently implement */
-    /* all three of ecb's fences as a seq_cst fence */
-    /* Update, gcc-4.8 generates mfence for all c++ fences, but nothing */
-    /* for all __atomic_thread_fence's except seq_cst */
     #define ECB_MEMORY_FENCE         atomic_thread_fence (memory_order_seq_cst)
+    #define ECB_MEMORY_FENCE_ACQUIRE atomic_thread_fence (memory_order_acquire)
+    #define ECB_MEMORY_FENCE_RELEASE atomic_thread_fence (memory_order_release)
   #endif
 #endif
 
@@ -793,6 +816,10 @@ struct signalfd_siginfo
 
 #if !defined ECB_MEMORY_FENCE_RELEASE && defined ECB_MEMORY_FENCE
   #define ECB_MEMORY_FENCE_RELEASE ECB_MEMORY_FENCE
+#endif
+
+#if !defined ECB_MEMORY_FENCE_RELAXED && defined ECB_MEMORY_FENCE
+  #define ECB_MEMORY_FENCE_RELAXED ECB_MEMORY_FENCE /* very heavy-handed */
 #endif
 
 /*****************************************************************************/
@@ -1545,8 +1572,7 @@ ecb_binary32_to_binary16 (uint32_t x)
 # define ABSPRI(w) (((W)w)->priority - EV_MINPRI)
 #endif
 
-#define EMPTY       /* required for microsofts broken pseudo-c compiler */
-#define EMPTY2(a,b) /* used to suppress some warnings */
+#define EMPTY /* required for microsofts broken pseudo-c compiler */
 
 typedef ev_watcher *W;
 typedef ev_watcher_list *WL;
@@ -1580,6 +1606,10 @@ static EV_ATOMIC_T have_monotonic; /* did clock_gettime (CLOCK_MONOTONIC) work? 
 #endif
 
 /*****************************************************************************/
+
+#if EV_USE_LINUXAIO
+# include <linux/aio_abi.h> /* probably only needed for aio_context_t */
+#endif
 
 /* define a suitable floor function (only used by periodics atm) */
 
@@ -1772,7 +1802,7 @@ typedef struct
   WL head;
   unsigned char events; /* the events watched for */
   unsigned char reify;  /* flag set when this ANFD needs reification (EV_ANFD_REIFY, EV__IOFDSET) */
-  unsigned char emask;  /* the epoll backend stores the actual kernel mask in here */
+  unsigned char emask;  /* some backends store the actual kernel mask in here */
   unsigned char unused;
 #if EV_USE_EPOLL
   unsigned int egen;    /* generation counter to counter epoll bugs */
@@ -1963,8 +1993,10 @@ array_realloc (int elem, void *base, int *cur, int cnt)
   return ev_realloc (base, elem * *cur);
 }
 
-#define array_init_zero(base,count)	\
-  memset ((void *)(base), 0, sizeof (*(base)) * (count))
+#define array_needsize_noinit(base,offset,count)
+
+#define array_needsize_zerofill(base,offset,count)	\
+  memset ((void *)(base + offset), 0, sizeof (*(base)) * (count))
 
 #define array_needsize(type,base,cur,cnt,init)			\
   if (expect_false ((cnt) > (cur)))				\
@@ -1972,7 +2004,7 @@ array_realloc (int elem, void *base, int *cur, int cnt)
       ecb_unused int ocur_ = (cur);				\
       (base) = (type *)array_realloc				\
          (sizeof (type), (base), &(cur), (cnt));		\
-      init ((base) + (ocur_), (cur) - ocur_);			\
+      init ((base), ocur_, ((cur) - ocur_));			\
     }
 
 #if 0
@@ -2009,7 +2041,7 @@ ev_feed_event (EV_P_ void *w, int revents) EV_NOEXCEPT
   else
     {
       w_->pending = ++pendingcnt [pri];
-      array_needsize (ANPENDING, pendings [pri], pendingmax [pri], w_->pending, EMPTY2);
+      array_needsize (ANPENDING, pendings [pri], pendingmax [pri], w_->pending, array_needsize_noinit);
       pendings [pri][w_->pending - 1].w      = w_;
       pendings [pri][w_->pending - 1].events = revents;
     }
@@ -2020,7 +2052,7 @@ ev_feed_event (EV_P_ void *w, int revents) EV_NOEXCEPT
 inline_speed void
 feed_reverse (EV_P_ W w)
 {
-  array_needsize (W, rfeeds, rfeedmax, rfeedcnt + 1, EMPTY2);
+  array_needsize (W, rfeeds, rfeedmax, rfeedcnt + 1, array_needsize_noinit);
   rfeeds [rfeedcnt++] = w;
 }
 
@@ -2117,7 +2149,7 @@ fd_reify (EV_P)
       unsigned char o_events = anfd->events;
       unsigned char o_reify  = anfd->reify;
 
-      anfd->reify  = 0;
+      anfd->reify = 0;
 
       /*if (expect_true (o_reify & EV_ANFD_REIFY)) probably a deoptimisation */
         {
@@ -2148,7 +2180,7 @@ fd_change (EV_P_ int fd, int flags)
   if (expect_true (!reify))
     {
       ++fdchangecnt;
-      array_needsize (int, fdchanges, fdchangemax, fdchangecnt, EMPTY2);
+      array_needsize (int, fdchanges, fdchangemax, fdchangecnt, array_needsize_noinit);
       fdchanges [fdchangecnt - 1] = fd;
     }
 }
@@ -2708,6 +2740,9 @@ childcb (EV_P_ ev_signal *sw, int revents)
 #if EV_USE_EPOLL
 # include "ev_epoll.c"
 #endif
+#if EV_USE_LINUXAIO
+# include "ev_linuxaio.c"
+#endif
 #if EV_USE_POLL
 # include "ev_poll.c"
 #endif
@@ -2745,11 +2780,12 @@ ev_supported_backends (void) EV_NOEXCEPT
 {
   unsigned int flags = 0;
 
-  if (EV_USE_PORT  ) flags |= EVBACKEND_PORT;
-  if (EV_USE_KQUEUE) flags |= EVBACKEND_KQUEUE;
-  if (EV_USE_EPOLL ) flags |= EVBACKEND_EPOLL;
-  if (EV_USE_POLL  ) flags |= EVBACKEND_POLL;
-  if (EV_USE_SELECT) flags |= EVBACKEND_SELECT;
+  if (EV_USE_PORT    ) flags |= EVBACKEND_PORT;
+  if (EV_USE_KQUEUE  ) flags |= EVBACKEND_KQUEUE;
+  if (EV_USE_EPOLL   ) flags |= EVBACKEND_EPOLL;
+  if (EV_USE_LINUXAIO) flags |= EVBACKEND_LINUXAIO;
+  if (EV_USE_POLL    ) flags |= EVBACKEND_POLL;
+  if (EV_USE_SELECT  ) flags |= EVBACKEND_SELECT;
   
   return flags;
 }
@@ -2772,6 +2808,11 @@ ev_recommended_backends (void) EV_NOEXCEPT
 #endif
 #ifdef __FreeBSD__
   flags &= ~EVBACKEND_POLL;   /* poll return value is unusable (http://forums.freebsd.org/archive/index.php/t-10270.html) */
+#endif
+
+  /* TODO: linuxaio is very experimental */
+#if !EV_RECOMMEND_LINUXAIO
+  flags &= ~EVBACKEND_LINUXAIO;
 #endif
 
   return flags;
@@ -2918,22 +2959,25 @@ loop_init (EV_P_ unsigned int flags) EV_NOEXCEPT
         flags |= ev_recommended_backends ();
 
 #if EV_USE_IOCP
-      if (!backend && (flags & EVBACKEND_IOCP  )) backend = iocp_init   (EV_A_ flags);
+      if (!backend && (flags & EVBACKEND_IOCP    )) backend = iocp_init      (EV_A_ flags);
 #endif
 #if EV_USE_PORT
-      if (!backend && (flags & EVBACKEND_PORT  )) backend = port_init   (EV_A_ flags);
+      if (!backend && (flags & EVBACKEND_PORT    )) backend = port_init      (EV_A_ flags);
 #endif
 #if EV_USE_KQUEUE
-      if (!backend && (flags & EVBACKEND_KQUEUE)) backend = kqueue_init (EV_A_ flags);
+      if (!backend && (flags & EVBACKEND_KQUEUE  )) backend = kqueue_init    (EV_A_ flags);
+#endif
+#if EV_USE_LINUXAIO
+      if (!backend && (flags & EVBACKEND_LINUXAIO)) backend = linuxaio_init  (EV_A_ flags);
 #endif
 #if EV_USE_EPOLL
-      if (!backend && (flags & EVBACKEND_EPOLL )) backend = epoll_init  (EV_A_ flags);
+      if (!backend && (flags & EVBACKEND_EPOLL   )) backend = epoll_init     (EV_A_ flags);
 #endif
 #if EV_USE_POLL
-      if (!backend && (flags & EVBACKEND_POLL  )) backend = poll_init   (EV_A_ flags);
+      if (!backend && (flags & EVBACKEND_POLL    )) backend = poll_init      (EV_A_ flags);
 #endif
 #if EV_USE_SELECT
-      if (!backend && (flags & EVBACKEND_SELECT)) backend = select_init (EV_A_ flags);
+      if (!backend && (flags & EVBACKEND_SELECT  )) backend = select_init    (EV_A_ flags);
 #endif
 
       ev_prepare_init (&pending_w, pendingcb);
@@ -2998,22 +3042,25 @@ ev_loop_destroy (EV_P)
     close (backend_fd);
 
 #if EV_USE_IOCP
-  if (backend == EVBACKEND_IOCP  ) iocp_destroy   (EV_A);
+  if (backend == EVBACKEND_IOCP    ) iocp_destroy     (EV_A);
 #endif
 #if EV_USE_PORT
-  if (backend == EVBACKEND_PORT  ) port_destroy   (EV_A);
+  if (backend == EVBACKEND_PORT    ) port_destroy     (EV_A);
 #endif
 #if EV_USE_KQUEUE
-  if (backend == EVBACKEND_KQUEUE) kqueue_destroy (EV_A);
+  if (backend == EVBACKEND_KQUEUE  ) kqueue_destroy   (EV_A);
+#endif
+#if EV_USE_LINUXAIO
+  if (backend == EVBACKEND_LINUXAIO) linuxaio_destroy (EV_A);
 #endif
 #if EV_USE_EPOLL
-  if (backend == EVBACKEND_EPOLL ) epoll_destroy  (EV_A);
+  if (backend == EVBACKEND_EPOLL   ) epoll_destroy    (EV_A);
 #endif
 #if EV_USE_POLL
-  if (backend == EVBACKEND_POLL  ) poll_destroy   (EV_A);
+  if (backend == EVBACKEND_POLL    ) poll_destroy     (EV_A);
 #endif
 #if EV_USE_SELECT
-  if (backend == EVBACKEND_SELECT) select_destroy (EV_A);
+  if (backend == EVBACKEND_SELECT  ) select_destroy   (EV_A);
 #endif
 
   for (i = NUMPRI; i--; )
@@ -3065,13 +3112,16 @@ inline_size void
 loop_fork (EV_P)
 {
 #if EV_USE_PORT
-  if (backend == EVBACKEND_PORT  ) port_fork   (EV_A);
+  if (backend == EVBACKEND_PORT    ) port_fork     (EV_A);
 #endif
 #if EV_USE_KQUEUE
-  if (backend == EVBACKEND_KQUEUE) kqueue_fork (EV_A);
+  if (backend == EVBACKEND_KQUEUE  ) kqueue_fork   (EV_A);
+#endif
+#if EV_USE_LINUXAIO
+  if (backend == EVBACKEND_LINUXAIO) linuxaio_fork (EV_A);
 #endif
 #if EV_USE_EPOLL
-  if (backend == EVBACKEND_EPOLL ) epoll_fork  (EV_A);
+  if (backend == EVBACKEND_EPOLL   ) epoll_fork    (EV_A);
 #endif
 #if EV_USE_INOTIFY
   infy_fork (EV_A);
@@ -3701,7 +3751,6 @@ ev_run (EV_P_ int flags)
             ev_feed_event (EV_A_ &pipe_w, EV_CUSTOM);
           }
 
-
         /* update ev_rt_now, do magic */
         time_update (EV_A_ waittime + sleeptime);
       }
@@ -3875,10 +3924,13 @@ ev_io_start (EV_P_ ev_io *w) EV_NOEXCEPT
   assert (("libev: ev_io_start called with negative fd", fd >= 0));
   assert (("libev: ev_io_start called with illegal event mask", !(w->events & ~(EV__IOFDSET | EV_READ | EV_WRITE))));
 
+#if EV_VERIFY >= 2
+  assert (("libev: ev_io_start called on watcher with invalid fd", fd_valid (fd)));
+#endif
   EV_FREQUENT_CHECK;
 
   ev_start (EV_A_ (W)w, 1);
-  array_needsize (ANFD, anfds, anfdmax, fd + 1, array_init_zero);
+  array_needsize (ANFD, anfds, anfdmax, fd + 1, array_needsize_zerofill);
   wlist_add (&anfds[fd].head, (WL)w);
 
   /* common bug, apparently */
@@ -3900,6 +3952,9 @@ ev_io_stop (EV_P_ ev_io *w) EV_NOEXCEPT
 
   assert (("libev: ev_io_stop called with illegal fd (must stay constant after start!)", w->fd >= 0 && w->fd < anfdmax));
 
+#if EV_VERIFY >= 2
+  assert (("libev: ev_io_stop called on watcher with invalid fd", fd_valid (w->fd)));
+#endif
   EV_FREQUENT_CHECK;
 
   wlist_del (&anfds[w->fd].head, (WL)w);
@@ -3925,7 +3980,7 @@ ev_timer_start (EV_P_ ev_timer *w) EV_NOEXCEPT
 
   ++timercnt;
   ev_start (EV_A_ (W)w, timercnt + HEAP0 - 1);
-  array_needsize (ANHE, timers, timermax, ev_active (w) + 1, EMPTY2);
+  array_needsize (ANHE, timers, timermax, ev_active (w) + 1, array_needsize_noinit);
   ANHE_w (timers [ev_active (w)]) = (WT)w;
   ANHE_at_cache (timers [ev_active (w)]);
   upheap (timers, ev_active (w));
@@ -4022,7 +4077,7 @@ ev_periodic_start (EV_P_ ev_periodic *w) EV_NOEXCEPT
 
   ++periodiccnt;
   ev_start (EV_A_ (W)w, periodiccnt + HEAP0 - 1);
-  array_needsize (ANHE, periodics, periodicmax, ev_active (w) + 1, EMPTY2);
+  array_needsize (ANHE, periodics, periodicmax, ev_active (w) + 1, array_needsize_noinit);
   ANHE_w (periodics [ev_active (w)]) = (WT)w;
   ANHE_at_cache (periodics [ev_active (w)]);
   upheap (periodics, ev_active (w));
@@ -4617,7 +4672,7 @@ ev_idle_start (EV_P_ ev_idle *w) EV_NOEXCEPT
     ++idleall;
     ev_start (EV_A_ (W)w, active);
 
-    array_needsize (ev_idle *, idles [ABSPRI (w)], idlemax [ABSPRI (w)], active, EMPTY2);
+    array_needsize (ev_idle *, idles [ABSPRI (w)], idlemax [ABSPRI (w)], active, array_needsize_noinit);
     idles [ABSPRI (w)][active - 1] = w;
   }
 
@@ -4657,7 +4712,7 @@ ev_prepare_start (EV_P_ ev_prepare *w) EV_NOEXCEPT
   EV_FREQUENT_CHECK;
 
   ev_start (EV_A_ (W)w, ++preparecnt);
-  array_needsize (ev_prepare *, prepares, preparemax, preparecnt, EMPTY2);
+  array_needsize (ev_prepare *, prepares, preparemax, preparecnt, array_needsize_noinit);
   prepares [preparecnt - 1] = w;
 
   EV_FREQUENT_CHECK;
@@ -4695,7 +4750,7 @@ ev_check_start (EV_P_ ev_check *w) EV_NOEXCEPT
   EV_FREQUENT_CHECK;
 
   ev_start (EV_A_ (W)w, ++checkcnt);
-  array_needsize (ev_check *, checks, checkmax, checkcnt, EMPTY2);
+  array_needsize (ev_check *, checks, checkmax, checkcnt, array_needsize_noinit);
   checks [checkcnt - 1] = w;
 
   EV_FREQUENT_CHECK;
@@ -4843,7 +4898,7 @@ ev_fork_start (EV_P_ ev_fork *w) EV_NOEXCEPT
   EV_FREQUENT_CHECK;
 
   ev_start (EV_A_ (W)w, ++forkcnt);
-  array_needsize (ev_fork *, forks, forkmax, forkcnt, EMPTY2);
+  array_needsize (ev_fork *, forks, forkmax, forkcnt, array_needsize_noinit);
   forks [forkcnt - 1] = w;
 
   EV_FREQUENT_CHECK;
@@ -4881,7 +4936,7 @@ ev_cleanup_start (EV_P_ ev_cleanup *w) EV_NOEXCEPT
   EV_FREQUENT_CHECK;
 
   ev_start (EV_A_ (W)w, ++cleanupcnt);
-  array_needsize (ev_cleanup *, cleanups, cleanupmax, cleanupcnt, EMPTY2);
+  array_needsize (ev_cleanup *, cleanups, cleanupmax, cleanupcnt, array_needsize_noinit);
   cleanups [cleanupcnt - 1] = w;
 
   /* cleanup watchers should never keep a refcount on the loop */
@@ -4926,7 +4981,7 @@ ev_async_start (EV_P_ ev_async *w) EV_NOEXCEPT
   EV_FREQUENT_CHECK;
 
   ev_start (EV_A_ (W)w, ++asynccnt);
-  array_needsize (ev_async *, asyncs, asyncmax, asynccnt, EMPTY2);
+  array_needsize (ev_async *, asyncs, asyncmax, asynccnt, array_needsize_noinit);
   asyncs [asynccnt - 1] = w;
 
   EV_FREQUENT_CHECK;
@@ -5004,12 +5059,6 @@ void
 ev_once (EV_P_ int fd, int events, ev_tstamp timeout, void (*cb)(int revents, void *arg), void *arg) EV_NOEXCEPT
 {
   struct ev_once *once = (struct ev_once *)ev_malloc (sizeof (struct ev_once));
-
-  if (expect_false (!once))
-    {
-      cb (EV_ERROR | EV_READ | EV_WRITE | EV_TIMER, arg);
-      return;
-    }
 
   once->cb  = cb;
   once->arg = arg;

--- a/src/common/libev/ev.h
+++ b/src/common/libev/ev.h
@@ -1,7 +1,7 @@
 /*
  * libev native API header
  *
- * Copyright (c) 2007-2018 Marc Alexander Lehmann <libev@schmorp.de>
+ * Copyright (c) 2007-2019 Marc Alexander Lehmann <libev@schmorp.de>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modifica-
@@ -212,7 +212,7 @@ struct ev_loop;
 /*****************************************************************************/
 
 #define EV_VERSION_MAJOR 4
-#define EV_VERSION_MINOR 25
+#define EV_VERSION_MINOR 27
 
 /* eventmask, revents, events... */
 enum {
@@ -516,14 +516,15 @@ enum {
 
 /* method bits to be ored together */
 enum {
-  EVBACKEND_SELECT  = 0x00000001U, /* available just about anywhere */
-  EVBACKEND_POLL    = 0x00000002U, /* !win, !aix, broken on osx */
-  EVBACKEND_EPOLL   = 0x00000004U, /* linux */
-  EVBACKEND_KQUEUE  = 0x00000008U, /* bsd, broken on osx */
-  EVBACKEND_DEVPOLL = 0x00000010U, /* solaris 8 */ /* NYI */
-  EVBACKEND_PORT    = 0x00000020U, /* solaris 10 */
-  EVBACKEND_ALL     = 0x0000003FU, /* all known backends */
-  EVBACKEND_MASK    = 0x0000FFFFU  /* all future backends */
+  EVBACKEND_SELECT   = 0x00000001U, /* available just about anywhere */
+  EVBACKEND_POLL     = 0x00000002U, /* !win, !aix, broken on osx */
+  EVBACKEND_EPOLL    = 0x00000004U, /* linux */
+  EVBACKEND_KQUEUE   = 0x00000008U, /* bsd, broken on osx */
+  EVBACKEND_DEVPOLL  = 0x00000010U, /* solaris 8 */ /* NYI */
+  EVBACKEND_PORT     = 0x00000020U, /* solaris 10 */
+  EVBACKEND_LINUXAIO = 0x00000040U, /* Linuix AIO */
+  EVBACKEND_ALL      = 0x0000007FU, /* all known backends */
+  EVBACKEND_MASK     = 0x0000FFFFU  /* all future backends */
 };
 
 #if EV_PROTOTYPES

--- a/src/common/libev/ev_linuxaio.c
+++ b/src/common/libev/ev_linuxaio.c
@@ -1,0 +1,642 @@
+/*
+ * libev linux aio fd activity backend
+ *
+ * Copyright (c) 2019 Marc Alexander Lehmann <libev@schmorp.de>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modifica-
+ * tion, are permitted provided that the following conditions are met:
+ *
+ *   1.  Redistributions of source code must retain the above copyright notice,
+ *       this list of conditions and the following disclaimer.
+ *
+ *   2.  Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MER-
+ * CHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO
+ * EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPE-
+ * CIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTH-
+ * ERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * the GNU General Public License ("GPL") version 2 or any later version,
+ * in which case the provisions of the GPL are applicable instead of
+ * the above. If you wish to allow the use of your version of this file
+ * only under the terms of the GPL and not to allow others to use your
+ * version of this file under the BSD license, indicate your decision
+ * by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL. If you do not delete the
+ * provisions above, a recipient may use your version of this file under
+ * either the BSD or the GPL.
+ */
+
+/*
+ * general notes about linux aio:
+ *
+ * a) at first, the linux aio IOCB_CMD_POLL functionality introduced in
+ *    4.18 looks too good to be true: both watchers and events can be
+ *    batched, and events can even be handled in userspace using
+ *    a ring buffer shared with the kernel. watchers can be canceled
+ *    regardless of whether the fd has been closed. no problems with fork.
+ *    ok, the ring buffer is 200% undocumented (there isn't even a
+ *    header file), but otherwise, it's pure bliss!
+ * b) ok, watchers are one-shot, so you have to re-arm active ones
+ *    on every iteration. so much for syscall-less event handling,
+ *    but at least these re-arms can be batched, no big deal, right?
+ * c) well, linux as usual: the documentation lies to you: io_submit
+ *    sometimes returns EINVAL because the kernel doesn't feel like
+ *    handling your poll mask - ttys can be polled for POLLOUT,
+ *    POLLOUT|POLLIN, but polling for POLLIN fails. just great,
+ *    so we have to fall back to something else (hello, epoll),
+ *    but at least the fallback can be slow, because these are
+ *    exceptional cases, right?
+ * d) hmm, you have to tell the kernel the maximum number of watchers
+ *    you want to queue when initialising the aio context. but of
+ *    course the real limit is magically calculated in the kernel, and
+ *    is often higher then we asked for. so we just have to destroy
+ *    the aio context and re-create it a bit larger if we hit the limit.
+ *    (starts to remind you of epoll? well, it's a bit more deterministic
+ *    and less gambling, but still ugly as hell).
+ * e) that's when you find out you can also hit an arbitrary system-wide
+ *    limit. or the kernel simply doesn't want to handle your watchers.
+ *    what the fuck do we do then? you guessed it, in the middle
+ *    of event handling we have to switch to 100% epoll polling. and
+ *    that better is as fast as normal epoll polling, so you practically
+ *    have to use the normal epoll backend with all its quirks.
+ * f) end result of this train wreck: it inherits all the disadvantages
+ *    from epoll, while adding a number on its own. why even bother to use
+ *    it? because if conditions are right and your fds are supported and you
+ *    don't hit a limit, this backend is actually faster, doesn't gamble with
+ *    your fds, batches watchers and events and doesn't require costly state
+ *    recreates. well, until it does.
+ * g) all of this makes this backend use almost twice as much code as epoll.
+ *    which in turn uses twice as much code as poll. and that#s not counting
+ *    the fact that this backend also depends on the epoll backend, making
+ *    it three times as much code as poll, or kqueue.
+ * h) bleah. why can't linux just do kqueue. sure kqueue is ugly, but by now
+ *    it's clear that whatever linux comes up with is far, far, far worse.
+ */
+
+#include <sys/time.h> /* actually linux/time.h, but we must assume they are compatible */
+#include <poll.h>
+#include <linux/aio_abi.h>
+
+/*****************************************************************************/
+/* syscall wrapdadoop - this section has the raw api/abi definitions */
+
+#include <sys/syscall.h> /* no glibc wrappers */
+
+/* aio_abi.h is not versioned in any way, so we cannot test for its existance */
+#define IOCB_CMD_POLL 5
+
+/* taken from linux/fs/aio.c. yup, that's a .c file.
+ * not only is this totally undocumented, not even the source code
+ * can tell you what the future semantics of compat_features and
+ * incompat_features are, or what header_length actually is for.
+ */
+#define AIO_RING_MAGIC                  0xa10a10a1
+#define EV_AIO_RING_INCOMPAT_FEATURES   0
+struct aio_ring
+{
+  unsigned id;    /* kernel internal index number */
+  unsigned nr;    /* number of io_events */
+  unsigned head;  /* Written to by userland or by kernel. */
+  unsigned tail;
+
+  unsigned magic;
+  unsigned compat_features;
+  unsigned incompat_features;
+  unsigned header_length;  /* size of aio_ring */
+
+  struct io_event io_events[0];
+};
+
+/*
+ * define some syscall wrappers for common architectures
+ * this is mostly for nice looks during debugging, not performance.
+ * our syscalls return < 0, not == -1, on error. which is good
+ * enough for linux aio.
+ * TODO: arm is also common nowadays, maybe even mips and x86
+ * TODO: after implementing this, it suddenly looks like overkill, but its hard to remove...
+ */
+#if __GNUC__ && __linux && ECB_AMD64 && !defined __OPTIMIZE_SIZE__
+  /* the costly errno access probably kills this for size optimisation */
+
+  #define ev_syscall(nr,narg,arg1,arg2,arg3,arg4,arg5)                 \
+    ({                                                                 \
+        long res;                                                      \
+        register unsigned long r5 __asm__ ("r8" );                     \
+        register unsigned long r4 __asm__ ("r10");                     \
+        register unsigned long r3 __asm__ ("rdx");                     \
+        register unsigned long r2 __asm__ ("rsi");                     \
+        register unsigned long r1 __asm__ ("rdi");                     \
+        if (narg >= 5) r5 = (unsigned long)(arg5);                     \
+        if (narg >= 4) r4 = (unsigned long)(arg4);                     \
+        if (narg >= 3) r3 = (unsigned long)(arg3);                     \
+        if (narg >= 2) r2 = (unsigned long)(arg2);                     \
+        if (narg >= 1) r1 = (unsigned long)(arg1);                     \
+        __asm__ __volatile__ (                                         \
+          "syscall\n\t"                                                \
+          : "=a" (res)                                                 \
+          : "0" (nr), "r" (r1), "r" (r2), "r" (r3), "r" (r4), "r" (r5) \
+          : "cc", "r11", "cx", "memory");                              \
+        errno = -res;                                                  \
+        res;                                                           \
+    })
+
+#endif
+
+#ifdef ev_syscall
+  #define ev_syscall0(nr)                          ev_syscall (nr, 0,    0,    0,    0,    0,    0
+  #define ev_syscall1(nr,arg1)                     ev_syscall (nr, 1, arg1,    0,    0,    0,    0)
+  #define ev_syscall2(nr,arg1,arg2)                ev_syscall (nr, 2, arg1, arg2,    0,    0,    0)
+  #define ev_syscall3(nr,arg1,arg2,arg3)           ev_syscall (nr, 3, arg1, arg2, arg3,    0,    0)
+  #define ev_syscall4(nr,arg1,arg2,arg3,arg4)      ev_syscall (nr, 3, arg1, arg2, arg3, arg4,    0)
+  #define ev_syscall5(nr,arg1,arg2,arg3,arg4,arg5) ev_syscall (nr, 5, arg1, arg2, arg3, arg4, arg5)
+#else
+  #define ev_syscall0(nr)                          syscall (nr)
+  #define ev_syscall1(nr,arg1)                     syscall (nr, arg1)
+  #define ev_syscall2(nr,arg1,arg2)                syscall (nr, arg1, arg2)
+  #define ev_syscall3(nr,arg1,arg2,arg3)           syscall (nr, arg1, arg2, arg3)
+  #define ev_syscall4(nr,arg1,arg2,arg3,arg4)      syscall (nr, arg1, arg2, arg3, arg4)
+  #define ev_syscall5(nr,arg1,arg2,arg3,arg4,arg5) syscall (nr, arg1, arg2, arg3, arg4, arg5)
+#endif
+
+inline_size
+int
+evsys_io_setup (unsigned nr_events, aio_context_t *ctx_idp)
+{
+  return ev_syscall2 (SYS_io_setup, nr_events, ctx_idp);
+}
+
+inline_size
+int
+evsys_io_destroy (aio_context_t ctx_id)
+{
+  return ev_syscall1 (SYS_io_destroy, ctx_id);
+}
+
+inline_size
+int
+evsys_io_submit (aio_context_t ctx_id, long nr, struct iocb *cbp[])
+{
+  return ev_syscall3 (SYS_io_submit, ctx_id, nr, cbp);
+}
+
+inline_size
+int
+evsys_io_cancel (aio_context_t ctx_id, struct iocb *cbp, struct io_event *result)
+{
+  return ev_syscall3 (SYS_io_cancel, ctx_id, cbp, result);
+}
+
+inline_size
+int
+evsys_io_getevents (aio_context_t ctx_id, long min_nr, long nr, struct io_event *events, struct timespec *timeout)
+{
+  return ev_syscall5 (SYS_io_getevents, ctx_id, min_nr, nr, events, timeout);
+}
+
+/*****************************************************************************/
+/* actual backed implementation */
+
+ecb_cold
+static int
+linuxaio_nr_events (EV_P)
+{
+  /* we start with 16 iocbs and incraese from there
+   * that's tiny, but the kernel has a rather low system-wide
+   * limit that can be reached quickly, so let's be parsimonious
+   * with this resource.
+   * Rest assured, the kernel generously rounds up small and big numbers
+   * in different ways (but doesn't seem to charge you for it).
+   * The 15 here is because the kernel usually has a power of two as aio-max-nr,
+   * and this helps to take advantage of that limit.
+   */
+
+  /* we try to fill 4kB pages exactly.
+   * the ring buffer header is 32 bytes, every io event is 32 bytes.
+   * the kernel takes the io requests number, doubles it, adds 2
+   * and adds the ring buffer.
+   * the way we use this is by starting low, and then roughly doubling the
+   * size each time we hit a limit.
+   */
+
+  int requests   = 15 << linuxaio_iteration;
+  int one_page   =  (4096
+                    / sizeof (struct io_event)    ) / 2; /* how many fit into one page */
+  int first_page = ((4096 - sizeof (struct aio_ring))
+                    / sizeof (struct io_event) - 2) / 2; /* how many fit into the first page */
+
+  /* if everything fits into one page, use count exactly */
+  if (requests > first_page)
+    /* otherwise, round down to full pages and add the first page */
+    requests = requests / one_page * one_page + first_page;
+
+  return requests;
+}
+
+/* we use out own wrapper structure in case we ever want to do something "clever" */
+typedef struct aniocb
+{
+  struct iocb io;
+  /*int inuse;*/
+} *ANIOCBP;
+
+inline_size
+void
+linuxaio_array_needsize_iocbp (ANIOCBP *base, int offset, int count)
+{
+  while (count--)
+    {
+      /* TODO: quite the overhead to allocate every iocb separately, maybe use our own allocator? */
+      ANIOCBP iocb = (ANIOCBP)ev_malloc (sizeof (*iocb));
+
+      /* full zero initialise is probably not required at the moment, but
+       * this is not well documented, so we better do it.
+       */
+      memset (iocb, 0, sizeof (*iocb));
+
+      iocb->io.aio_lio_opcode = IOCB_CMD_POLL;
+      iocb->io.aio_data       = offset;
+      iocb->io.aio_fildes     = offset;
+
+      base [offset++] = iocb;
+    }
+}
+
+ecb_cold
+static void
+linuxaio_free_iocbp (EV_P)
+{
+  while (linuxaio_iocbpmax--)
+    ev_free (linuxaio_iocbps [linuxaio_iocbpmax]);
+
+  linuxaio_iocbpmax = 0; /* next resize will completely reallocate the array, at some overhead */
+}
+
+static void
+linuxaio_modify (EV_P_ int fd, int oev, int nev)
+{
+  array_needsize (ANIOCBP, linuxaio_iocbps, linuxaio_iocbpmax, fd + 1, linuxaio_array_needsize_iocbp);
+  ANIOCBP iocb = linuxaio_iocbps [fd];
+
+  if (iocb->io.aio_reqprio < 0)
+    {
+      /* we handed this fd over to epoll, so undo this first */
+      /* we do it manually because the optimisations on epoll_modify won't do us any good */
+      epoll_ctl (backend_fd, EPOLL_CTL_DEL, fd, 0);
+      anfds [fd].emask = 0;
+      iocb->io.aio_reqprio = 0;
+    }
+
+  if (iocb->io.aio_buf)
+    {
+      evsys_io_cancel (linuxaio_ctx, &iocb->io, (struct io_event *)0);
+      /* on relevant kernels, io_cancel fails with EINPROGRES if everything is fine */
+      assert (("libev: linuxaio unexpected io_cancel failed", errno == EINPROGRESS));
+    }
+
+  if (nev)
+    {
+      iocb->io.aio_buf =
+          (nev & EV_READ ? POLLIN : 0)
+          | (nev & EV_WRITE ? POLLOUT : 0);
+
+      /* queue iocb up for io_submit */
+      /* this assumes we only ever get one call per fd per loop iteration */
+      ++linuxaio_submitcnt;
+      array_needsize (struct iocb *, linuxaio_submits, linuxaio_submitmax, linuxaio_submitcnt, array_needsize_noinit);
+      linuxaio_submits [linuxaio_submitcnt - 1] = &iocb->io;
+    }
+}
+
+static void
+linuxaio_epoll_cb (EV_P_ struct ev_io *w, int revents)
+{
+  epoll_poll (EV_A_ 0);
+}
+
+inline_speed
+void
+linuxaio_fd_rearm (EV_P_ int fd)
+{
+  anfds [fd].events = 0;
+  linuxaio_iocbps [fd]->io.aio_buf = 0;
+  fd_change (EV_A_ fd, EV_ANFD_REIFY);
+}
+
+static void
+linuxaio_parse_events (EV_P_ struct io_event *ev, int nr)
+{
+  while (nr)
+    {
+      int fd  = ev->data;
+      int res = ev->res;
+
+      assert (("libev: iocb fd must be in-bounds", fd >= 0 && fd < anfdmax));
+
+      /* feed events, we do not expect or handle POLLNVAL */
+      fd_event (
+        EV_A_
+        fd,
+        (res & (POLLOUT | POLLERR | POLLHUP) ? EV_WRITE : 0)
+        | (res & (POLLIN | POLLERR | POLLHUP) ? EV_READ : 0)
+      );
+
+      /* linux aio is oneshot: rearm fd. TODO: this does more work than strictly needed */
+      linuxaio_fd_rearm (EV_A_ fd);
+
+      --nr;
+      ++ev;
+    }
+}
+
+/* get any events from ring buffer, return true if any were handled */
+static int
+linuxaio_get_events_from_ring (EV_P)
+{
+  struct aio_ring *ring = (struct aio_ring *)linuxaio_ctx;
+
+  /* the kernel reads and writes both of these variables, */
+  /* as a C extension, we assume that volatile use here */
+  /* both makes reads atomic and once-only */
+  unsigned head = *(volatile unsigned *)&ring->head;
+  unsigned tail = *(volatile unsigned *)&ring->tail;
+
+  if (head == tail)
+    return 0;
+
+  /* make sure the events up to tail are visible */
+  ECB_MEMORY_FENCE_ACQUIRE;
+
+  /* parse all available events, but only once, to avoid starvation */
+  if (tail > head) /* normal case around */
+    linuxaio_parse_events (EV_A_ ring->io_events + head, tail - head);
+  else /* wrapped around */
+    {
+      linuxaio_parse_events (EV_A_ ring->io_events + head, ring->nr - head);
+      linuxaio_parse_events (EV_A_ ring->io_events, tail);
+    }
+
+  ECB_MEMORY_FENCE_RELEASE;
+  /* as an extension to C, we hope that the volatile will make this atomic and once-only */
+  *(volatile unsigned *)&ring->head = tail;
+
+  return 1;
+}
+
+inline_size
+int
+linuxaio_ringbuf_valid (EV_P)
+{
+  struct aio_ring *ring = (struct aio_ring *)linuxaio_ctx;
+
+  return expect_true (ring->magic == AIO_RING_MAGIC)
+                      && ring->incompat_features == EV_AIO_RING_INCOMPAT_FEATURES
+                      && ring->header_length == sizeof (struct aio_ring); /* TODO: or use it to find io_event[0]? */
+}
+
+/* read at least one event from kernel, or timeout */
+inline_size
+void
+linuxaio_get_events (EV_P_ ev_tstamp timeout)
+{
+  struct timespec ts;
+  struct io_event ioev[8]; /* 256 octet stack space */
+  int want = 1; /* how many events to request */
+  int ringbuf_valid = linuxaio_ringbuf_valid (EV_A);
+
+  if (expect_true (ringbuf_valid))
+    {
+      /* if the ring buffer has any events, we don't wait or call the kernel at all */
+      if (linuxaio_get_events_from_ring (EV_A))
+        return;
+
+      /* if the ring buffer is empty, and we don't have a timeout, then don't call the kernel */
+      if (!timeout)
+        return;
+    }
+  else
+    /* no ringbuffer, request slightly larger batch */
+    want = sizeof (ioev) / sizeof (ioev [0]);
+
+  /* no events, so wait for some
+   * for fairness reasons, we do this in a loop, to fetch all events
+   */
+  for (;;)
+    {
+      int res;
+
+      EV_RELEASE_CB;
+
+      ts.tv_sec  = (long)timeout;
+      ts.tv_nsec = (long)((timeout - ts.tv_sec) * 1e9);
+
+      res = evsys_io_getevents (linuxaio_ctx, 1, want, ioev, &ts);
+
+      EV_ACQUIRE_CB;
+
+      if (res < 0)
+        if (errno == EINTR)
+          /* ignored, retry */;
+        else
+          ev_syserr ("(libev) linuxaio io_getevents");
+      else if (res)
+        {
+          /* at least one event available, handle them */
+          linuxaio_parse_events (EV_A_ ioev, res);
+
+          if (expect_true (ringbuf_valid))
+            {
+              /* if we have a ring buffer, handle any remaining events in it */
+              linuxaio_get_events_from_ring (EV_A);
+
+              /* at this point, we should have handled all outstanding events */
+              break;
+            }
+          else if (res < want)
+            /* otherwise, if there were fewere events than we wanted, we assume there are no more */
+            break;
+        }
+      else
+        break; /* no events from the kernel, we are done */
+
+      timeout = 0; /* only wait in the first iteration */
+    }
+}
+
+inline_size
+int
+linuxaio_io_setup (EV_P)
+{
+  linuxaio_ctx = 0;
+  return evsys_io_setup (linuxaio_nr_events (EV_A), &linuxaio_ctx);
+}
+
+static void
+linuxaio_poll (EV_P_ ev_tstamp timeout)
+{
+  int submitted;
+
+  /* first phase: submit new iocbs */
+
+  /* io_submit might return less than the requested number of iocbs */
+  /* this is, afaics, only because of errors, but we go by the book and use a loop, */
+  /* which allows us to pinpoint the erroneous iocb */
+  for (submitted = 0; submitted < linuxaio_submitcnt; )
+    {
+      int res = evsys_io_submit (linuxaio_ctx, linuxaio_submitcnt - submitted, linuxaio_submits + submitted);
+
+      if (expect_false (res < 0))
+        if (errno == EINVAL)
+          {
+            /* This happens for unsupported fds, officially, but in my testing,
+             * also randomly happens for supported fds. We fall back to good old
+             * poll() here, under the assumption that this is a very rare case.
+             * See https://lore.kernel.org/patchwork/patch/1047453/ to see
+             * discussion about such a case (ttys) where polling for POLLIN
+             * fails but POLLIN|POLLOUT works.
+             */
+            struct iocb *iocb = linuxaio_submits [submitted];
+            epoll_modify (EV_A_ iocb->aio_fildes, 0, anfds [iocb->aio_fildes].events);
+            iocb->aio_reqprio = -1; /* mark iocb as epoll */
+
+            res = 1; /* skip this iocb - another iocb, another chance */
+          }
+        else if (errno == EAGAIN)
+          {
+            /* This happens when the ring buffer is full, or some other shit we
+             * don't know and isn't documented. Most likely because we have too
+             * many requests and linux aio can't be assed to handle them.
+             * In this case, we try to allocate a larger ring buffer, freeing
+             * ours first. This might fail, in which case we have to fall back to 100%
+             * epoll.
+             * God, how I hate linux not getting its act together. Ever.
+             */
+            evsys_io_destroy (linuxaio_ctx);
+            linuxaio_submitcnt = 0;
+
+            /* rearm all fds with active iocbs */
+            {
+              int fd;
+	      for (fd = 0; fd < linuxaio_iocbpmax; ++fd)
+                if (linuxaio_iocbps [fd]->io.aio_buf)
+                  linuxaio_fd_rearm (EV_A_ fd);
+            }
+
+            ++linuxaio_iteration;
+            if (linuxaio_io_setup (EV_A) < 0)
+              {
+                /* to bad, we can't get a new aio context, go 100% epoll */
+                linuxaio_free_iocbp (EV_A);
+                ev_io_stop (EV_A_ &linuxaio_epoll_w);
+                ev_ref (EV_A);
+                linuxaio_ctx = 0;
+                backend_modify = epoll_modify;
+                backend_poll   = epoll_poll;
+              }
+
+            timeout = 0;
+            /* it's easiest to handle this mess in another iteration */
+            return;
+          }
+        else if (errno == EBADF)
+          {
+            assert (("libev: event loop rejected bad fd", errno != EBADF));
+            fd_kill (EV_A_ linuxaio_submits [submitted]->aio_fildes);
+
+            res = 1; /* skip this iocb */
+          }
+        else
+          ev_syserr ("(libev) linuxaio io_submit");
+
+      submitted += res;
+    }
+
+  linuxaio_submitcnt = 0;
+
+  /* second phase: fetch and parse events */
+
+  linuxaio_get_events (EV_A_ timeout);
+}
+
+inline_size
+int
+linuxaio_init (EV_P_ int flags)
+{
+  /* would be great to have a nice test for IOCB_CMD_POLL instead */
+  /* also: test some semi-common fd types, such as files and ttys in recommended_backends */
+  /* 4.18 introduced IOCB_CMD_POLL, 4.19 made epoll work, and we need that */
+  if (ev_linux_version () < 0x041300)
+    return 0;
+
+  if (!epoll_init (EV_A_ 0))
+    return 0;
+
+  linuxaio_iteration = 0;
+
+  if (linuxaio_io_setup (EV_A) < 0)
+    {
+      epoll_destroy (EV_A);
+      return 0;
+    }
+
+  ev_io_init  (EV_A_ &linuxaio_epoll_w, linuxaio_epoll_cb, backend_fd, EV_READ);
+  ev_set_priority (&linuxaio_epoll_w, EV_MAXPRI);
+  ev_io_start (EV_A_ &linuxaio_epoll_w);
+  ev_unref (EV_A); /* watcher should not keep loop alive */
+
+  backend_modify  = linuxaio_modify;
+  backend_poll    = linuxaio_poll;
+
+  linuxaio_iocbpmax = 0;
+  linuxaio_iocbps = 0;
+
+  linuxaio_submits = 0;
+  linuxaio_submitmax = 0;
+  linuxaio_submitcnt = 0;
+
+  return EVBACKEND_LINUXAIO;
+}
+
+inline_size
+void
+linuxaio_destroy (EV_P)
+{
+  epoll_destroy (EV_A);
+  linuxaio_free_iocbp (EV_A);
+  evsys_io_destroy (linuxaio_ctx); /* fails in child, aio context is destroyed */
+}
+
+inline_size
+void
+linuxaio_fork (EV_P)
+{
+  /* this frees all iocbs, which is very heavy-handed */
+  linuxaio_destroy (EV_A);
+  linuxaio_submitcnt = 0; /* all pointers were invalidated */
+
+  linuxaio_iteration = 0; /* we start over in the child */
+
+  while (linuxaio_io_setup (EV_A) < 0)
+    ev_syserr ("(libev) linuxaio io_setup");
+
+  /* forking epoll should also effectively unregister all fds from the backend */
+  epoll_fork (EV_A);
+
+  ev_io_stop  (EV_A_ &linuxaio_epoll_w);
+  ev_io_set   (EV_A_ &linuxaio_epoll_w, backend_fd, EV_READ);
+  ev_io_start (EV_A_ &linuxaio_epoll_w);
+
+  /* epoll_fork already did this. hopefully */
+  /*fd_rearm_all (EV_A);*/
+}
+

--- a/src/common/libev/ev_poll.c
+++ b/src/common/libev/ev_poll.c
@@ -1,7 +1,7 @@
 /*
  * libev poll fd activity backend
  *
- * Copyright (c) 2007,2008,2009,2010,2011 Marc Alexander Lehmann <libev@schmorp.de>
+ * Copyright (c) 2007,2008,2009,2010,2011,2016,2019 Marc Alexander Lehmann <libev@schmorp.de>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modifica-
@@ -41,10 +41,12 @@
 
 inline_size
 void
-pollidx_init (int *base, int count)
+array_needsize_pollidx (int *base, int offset, int count)
 {
-  /* consider using memset (.., -1, ...), which is practically guaranteed
-   * to work on all systems implementing poll */
+  /* using memset (.., -1, ...) is tempting, we we try
+   * to be ultraportable
+   */
+  base += offset;
   while (count--)
     *base++ = -1;
 }
@@ -57,14 +59,14 @@ poll_modify (EV_P_ int fd, int oev, int nev)
   if (oev == nev)
     return;
 
-  array_needsize (int, pollidxs, pollidxmax, fd + 1, pollidx_init);
+  array_needsize (int, pollidxs, pollidxmax, fd + 1, array_needsize_pollidx);
 
   idx = pollidxs [fd];
 
   if (idx < 0) /* need to allocate a new pollfd */
     {
       pollidxs [fd] = idx = pollcnt++;
-      array_needsize (struct pollfd, polls, pollmax, pollcnt, EMPTY2);
+      array_needsize (struct pollfd, polls, pollmax, pollcnt, array_needsize_noinit);
       polls [idx].fd = fd;
     }
 
@@ -108,14 +110,17 @@ poll_poll (EV_P_ ev_tstamp timeout)
   else
     for (p = polls; res; ++p)
       {
-        assert (("libev: poll() returned illegal result, broken BSD kernel?", p < polls + pollcnt));
+        assert (("libev: poll returned illegal result, broken BSD kernel?", p < polls + pollcnt));
 
         if (expect_false (p->revents)) /* this expect is debatable */
           {
             --res;
 
             if (expect_false (p->revents & POLLNVAL))
-              fd_kill (EV_A_ p->fd);
+              {
+                assert (("libev: poll found invalid fd in poll set", 0));
+                fd_kill (EV_A_ p->fd);
+              }
             else
               fd_event (
                 EV_A_

--- a/src/common/libev/ev_vars.h
+++ b/src/common/libev/ev_vars.h
@@ -1,7 +1,7 @@
 /*
  * loop member variable declarations
  *
- * Copyright (c) 2007,2008,2009,2010,2011,2012,2013 Marc Alexander Lehmann <libev@schmorp.de>
+ * Copyright (c) 2007,2008,2009,2010,2011,2012,2013,2019 Marc Alexander Lehmann <libev@schmorp.de>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modifica-
@@ -105,6 +105,17 @@ VARx(int, epoll_eventmax)
 VARx(int *, epoll_eperms)
 VARx(int, epoll_epermcnt)
 VARx(int, epoll_epermmax)
+#endif
+
+#if EV_USE_LINUXAIO || EV_GENWRAP
+VARx(aio_context_t, linuxaio_ctx)
+VARx(int, linuxaio_iteration)
+VARx(struct aniocb **, linuxaio_iocbps)
+VARx(int, linuxaio_iocbpmax)
+VARx(struct iocb **, linuxaio_submits)
+VARx(int, linuxaio_submitcnt)
+VARx(int, linuxaio_submitmax)
+VARx(ev_io, linuxaio_epoll_w)
 #endif
 
 #if EV_USE_KQUEUE || EV_GENWRAP

--- a/src/common/libev/ev_wrap.h
+++ b/src/common/libev/ev_wrap.h
@@ -50,6 +50,14 @@
 #define kqueue_eventmax ((loop)->kqueue_eventmax)
 #define kqueue_events ((loop)->kqueue_events)
 #define kqueue_fd_pid ((loop)->kqueue_fd_pid)
+#define linuxaio_ctx ((loop)->linuxaio_ctx)
+#define linuxaio_epoll_w ((loop)->linuxaio_epoll_w)
+#define linuxaio_iocbpmax ((loop)->linuxaio_iocbpmax)
+#define linuxaio_iocbps ((loop)->linuxaio_iocbps)
+#define linuxaio_iteration ((loop)->linuxaio_iteration)
+#define linuxaio_submitcnt ((loop)->linuxaio_submitcnt)
+#define linuxaio_submitmax ((loop)->linuxaio_submitmax)
+#define linuxaio_submits ((loop)->linuxaio_submits)
 #define loop_count ((loop)->loop_count)
 #define loop_depth ((loop)->loop_depth)
 #define loop_done ((loop)->loop_done)
@@ -149,6 +157,14 @@
 #undef kqueue_eventmax
 #undef kqueue_events
 #undef kqueue_fd_pid
+#undef linuxaio_ctx
+#undef linuxaio_epoll_w
+#undef linuxaio_iocbpmax
+#undef linuxaio_iocbps
+#undef linuxaio_iteration
+#undef linuxaio_submitcnt
+#undef linuxaio_submitmax
+#undef linuxaio_submits
 #undef loop_count
 #undef loop_depth
 #undef loop_done

--- a/src/common/libev/libev.m4
+++ b/src/common/libev/libev.m4
@@ -2,7 +2,8 @@ dnl this file is part of libev, do not make local modifications
 dnl http://software.schmorp.de/pkg/libev
 
 dnl libev support
-AC_CHECK_HEADERS(sys/inotify.h sys/epoll.h sys/event.h port.h poll.h sys/select.h sys/eventfd.h sys/signalfd.h)
+AC_CHECK_HEADERS(sys/inotify.h sys/epoll.h sys/event.h port.h poll.h)
+AC_CHECK_HEADERS(sys/select.h sys/eventfd.h sys/signalfd.h linux/aio_abi.h)
  
 AC_CHECK_FUNCS(inotify_init epoll_ctl kqueue port_create poll select eventfd signalfd)
  

--- a/src/common/libflux/ev_flux.c
+++ b/src/common/libflux/ev_flux.c
@@ -49,6 +49,12 @@ static void check_cb (struct ev_loop *loop, ev_check *w, int revents)
 {
     struct ev_flux *fw = (struct ev_flux *)((char *)w
                             - offsetof (struct ev_flux, check_w));
+
+    if (ev_is_pending (&fw->io_w)
+            && ev_clear_pending (loop, &fw->io_w) & EV_ERROR) {
+        fw->cb (loop, fw, EV_ERROR);
+        return;
+    }
     int events = get_pollevents (fw->h);
 
     ev_io_stop (loop, &fw->io_w);

--- a/src/common/libutil/ev_zmq.c
+++ b/src/common/libutil/ev_zmq.c
@@ -64,6 +64,9 @@ static void check_cb (struct ev_loop *loop, ev_check *w, int revents)
 
     if (handle == NULL)
         zw->cb (loop, zw, EV_ERROR);
+    else if (ev_is_pending (&zw->io_w)
+            && ev_clear_pending (loop, &zw->io_w) & EV_ERROR)
+        zw->cb (loop, zw, EV_ERROR);
     else if (zmq_getsockopt (handle, ZMQ_EVENTS, &zevents, &zevents_size) < 0)
         zw->cb (loop, zw, EV_ERROR);
     else if ((revents = ztoe (zevents) & zw->events))


### PR DESCRIPTION
It turns out that updating libev from 4.25 to 4.27 promotes the `epoll_ctl()` failure discussed in #2554 to an assertion failure:
```
ev_epoll.c:134: epoll_modify: Assertion `("libev: I/O watcher with invalid fd found in epoll_ctl", errno != EBADF && errno != ELOOP && errno != EINVAL)' failed.
```
so this PR updates the vendored copy of libev.

Additionally, it seems that our `ev_flux` and `ev_zmq` composite watchers mask errors thrown by libev.  They both embed io watchers, but use them for the side effect of unblocking the reactor so prep/check/idle callbacks can do the real event management.  However, when libev has a file descriptor problem on an io watcher, it calls `ev_feed_event()` to make an EV_ERROR event pending on the watcher.  Our composite watchers weren't checking for that, so I added a trivial fix for that and verified that in libev 4.25, this also caught the `epoll_ctl()` EINVAL failure.

Caveat: I don't understand it (and I poked at it _a lot_) but the 60 second pause we observed is still here even with the EV_ERROR event being handled.  As far as I can tell, the loop blocks with the EV_ERROR event pending on the fd for this period.  Then we handle it.  (Before we didn't handle it and  the check watcher ran when the loop unblocked, which allowed the future to be fulfilled) . I don't know where the timeout is coming from and I don't know why the pending EV_ERROR doesn't unblock the loop immediately.

Finally, pulled in the python binding workaround for the future leak in `job.submit()` and now `job.wait()` proposed by @andre-merzky, with @stevwonder's proposed change.  This is a temporary workaround until the circular reference pointed out by @stevwonder in #2549 is resolved.  I verified the fix with
```console
$ flux python t/job-manager/submit-waitany.py 512
submit: 778295050240 /bin/true
submit: 778781589504 /bin/true
submit: 779184242688 /bin/true
submit: 779620450304 /bin/true
[snip]
wait: 1659065335808 Error: task(s) exited with exit code 1
wait: 1659870642176 Error: task(s) exited with exit code 1
wait: 1661078601728 Error: task(s) exited with exit code 1
$
```
The exit code 1 results are expected - the point is it doesn't hang (libev 4.25) or assert (libev 4.27).