### PR TITLE
Update jobspec command to be list instead of list or string

### DIFF
--- a/src/modules/job-ingest/schemas/jobspec.jsonschema
+++ b/src/modules/job-ingest/schemas/jobspec.jsonschema
@@ -116,7 +116,7 @@
         "required": ["command", "slot", "count" ],
         "properties": {
           "command": {
-            "type": ["string", "array"],
+            "type": "array",
             "minItems": 1,
             "items": { "type": "string" }
           },

--- a/src/modules/job-ingest/schemas/jobspec_v1.jsonschema
+++ b/src/modules/job-ingest/schemas/jobspec_v1.jsonschema
@@ -109,7 +109,7 @@
         "required": ["command", "slot", "count" ],
         "properties": {
           "command": {
-            "type": ["string", "array"],
+            "type": "array",
             "minItems": 1,
             "items": { "type": "string" }
           },

--- a/src/shell/jobspec.c
+++ b/src/shell/jobspec.c
@@ -164,14 +164,7 @@ struct jobspec *jobspec_parse (const char *jobspec, json_error_t *error)
         set_error (error, "Unable to parse command");
         goto error;
     }
-    if (json_is_string (job->command)) {
-        job->command = json_pack ("[o]", job->command);
-        if (!job->command) {
-            set_error (error, "Failed to pack bare command into an array");
-            goto error;
-        }
-    }
-    else if (!json_is_array (job->command)) {
+    if (!json_is_array (job->command)) {
         set_error (error, "Malformed command entry");
         goto error;
     }

--- a/t/jobspec/invalid/attributes_bad_entry.yaml
+++ b/t/jobspec/invalid/attributes_bad_entry.yaml
@@ -7,7 +7,7 @@ resources:
       - type: node
         count: 1
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: foo
     count:
       per_slot: 1

--- a/t/jobspec/invalid/attributes_not_mapping.yaml
+++ b/t/jobspec/invalid/attributes_not_mapping.yaml
@@ -7,7 +7,7 @@ resources:
       - type: node
         count: 1
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: foo
     count:
       per_slot: 1

--- a/t/jobspec/invalid/missing_attributes.yaml
+++ b/t/jobspec/invalid/missing_attributes.yaml
@@ -7,7 +7,7 @@ resources:
       - type: node
         count: 1
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: foo
     count:
       per_slot: 1

--- a/t/jobspec/invalid/missing_resources.yaml
+++ b/t/jobspec/invalid/missing_resources.yaml
@@ -1,6 +1,6 @@
 version: 1
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: foo
     count:
       per_slot: 1

--- a/t/jobspec/invalid/missing_version.yaml
+++ b/t/jobspec/invalid/missing_version.yaml
@@ -6,7 +6,7 @@ resources:
       - type: node
         count: 1
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: foo
     count:
       per_slot: 1

--- a/t/jobspec/invalid/resource_count_bad_type.yaml
+++ b/t/jobspec/invalid/resource_count_bad_type.yaml
@@ -9,7 +9,7 @@ resources:
       - type: node
         count: 1
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: foo
     count:
       per_slot: 1

--- a/t/jobspec/invalid/resource_count_missing_max.yaml
+++ b/t/jobspec/invalid/resource_count_missing_max.yaml
@@ -10,7 +10,7 @@ resources:
       - type: node
         count: 1
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: foo
     count:
       per_slot: 1

--- a/t/jobspec/invalid/resource_count_missing_min.yaml
+++ b/t/jobspec/invalid/resource_count_missing_min.yaml
@@ -10,7 +10,7 @@ resources:
       - type: node
         count: 1
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: foo
     count:
       per_slot: 1

--- a/t/jobspec/invalid/resource_count_missing_operand.yaml
+++ b/t/jobspec/invalid/resource_count_missing_operand.yaml
@@ -10,7 +10,7 @@ resources:
       - type: node
         count: 1
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: foo
     count:
       per_slot: 1

--- a/t/jobspec/invalid/resource_count_missing_operator.yaml
+++ b/t/jobspec/invalid/resource_count_missing_operator.yaml
@@ -10,7 +10,7 @@ resources:
       - type: node
         count: 1
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: foo
     count:
       per_slot: 1

--- a/t/jobspec/invalid/resource_count_scalar_bad_value.yaml
+++ b/t/jobspec/invalid/resource_count_scalar_bad_value.yaml
@@ -7,7 +7,7 @@ resources:
       - type: node
         count: 1
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: foo
     count:
       per_slot: 1

--- a/t/jobspec/invalid/resource_exclusive_invalid.yaml
+++ b/t/jobspec/invalid/resource_exclusive_invalid.yaml
@@ -8,7 +8,7 @@ resources:
         count: 1
         exclusive: blah
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: foo
     count:
       per_slot: 1

--- a/t/jobspec/invalid/resource_exclusive_not_scalar.yaml
+++ b/t/jobspec/invalid/resource_exclusive_not_scalar.yaml
@@ -10,7 +10,7 @@ resources:
       - type: node
         count: 1
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: foo
     count:
       per_slot: 1

--- a/t/jobspec/invalid/resource_id_not_scalar.yaml
+++ b/t/jobspec/invalid/resource_id_not_scalar.yaml
@@ -10,7 +10,7 @@ resources:
       - type: node
         count: 1
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: foo
     count:
       per_slot: 1

--- a/t/jobspec/invalid/resource_label_not_scalar.yaml
+++ b/t/jobspec/invalid/resource_label_not_scalar.yaml
@@ -9,7 +9,7 @@ resources:
       - type: node
         count: 1
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: foo
     count:
       per_slot: 1

--- a/t/jobspec/invalid/resource_missing_count.yaml
+++ b/t/jobspec/invalid/resource_missing_count.yaml
@@ -6,7 +6,7 @@ resources:
     with:
       - type: node
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: foo
     count:
       per_slot: 1

--- a/t/jobspec/invalid/resource_missing_type.yaml
+++ b/t/jobspec/invalid/resource_missing_type.yaml
@@ -6,7 +6,7 @@ resources:
     with:
       - count: 1
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: foo
     count:
       per_slot: 1

--- a/t/jobspec/invalid/resource_not_mapping.yaml
+++ b/t/jobspec/invalid/resource_not_mapping.yaml
@@ -7,7 +7,7 @@ resources:
        - type: node
          count: 1
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: foo
     count:
       per_slot: 1

--- a/t/jobspec/invalid/resource_slot_not_labelled.yaml
+++ b/t/jobspec/invalid/resource_slot_not_labelled.yaml
@@ -6,7 +6,7 @@ resources:
       - type: node
         count: 1
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: foo
     count:
       per_slot: 1

--- a/t/jobspec/invalid/resource_unit_not_scalar.yaml
+++ b/t/jobspec/invalid/resource_unit_not_scalar.yaml
@@ -10,7 +10,7 @@ resources:
       - type: node
         count: 1
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: foo
     count:
       per_slot: 1

--- a/t/jobspec/invalid/resources_not_sequence.yaml
+++ b/t/jobspec/invalid/resources_not_sequence.yaml
@@ -7,7 +7,7 @@ resources:
     - type: node
       count: 1
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: foo
     count:
       per_slot: 1

--- a/t/jobspec/invalid/task_command_not_array.yaml
+++ b/t/jobspec/invalid/task_command_not_array.yaml
@@ -1,0 +1,14 @@
+version: 1
+resources:
+  - type: slot
+    count: 1
+    label: foo
+    with:
+      - type: node
+        count: 1
+tasks:
+  - command: app
+    slot: foo
+    count:
+      per_slot: 1
+attributes:

--- a/t/jobspec/invalid/task_count_not_mapping.yaml
+++ b/t/jobspec/invalid/task_count_not_mapping.yaml
@@ -7,7 +7,7 @@ resources:
       - type: node
         count: 1
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: foo
     count: 1
 attributes:

--- a/t/jobspec/invalid/task_missing_count.yaml
+++ b/t/jobspec/invalid/task_missing_count.yaml
@@ -7,6 +7,6 @@ resources:
       - type: node
         count: 1
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: foo
 attributes:

--- a/t/jobspec/invalid/task_missing_slot.yaml
+++ b/t/jobspec/invalid/task_missing_slot.yaml
@@ -7,7 +7,7 @@ resources:
       - type: node
         count: 1
 tasks:
-  - command: app
+  - command: [ "app" ]
     count:
       per_slot: 1
 attributes:

--- a/t/jobspec/invalid/tasks_not_sequence.yaml
+++ b/t/jobspec/invalid/tasks_not_sequence.yaml
@@ -7,7 +7,7 @@ resources:
       - type: node
         count: 1
 tasks:
-  command: app
+  command: [ "app" ]
   slot: foo
   count:
     per_slot: 1

--- a/t/jobspec/invalid/version_bad_number.yaml
+++ b/t/jobspec/invalid/version_bad_number.yaml
@@ -7,7 +7,7 @@ resources:
       - type: node
         count: 1
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: foo
     count:
       per_slot: 1

--- a/t/jobspec/invalid/version_not_scalar.yaml
+++ b/t/jobspec/invalid/version_not_scalar.yaml
@@ -8,7 +8,7 @@ resources:
       - type: node
         count: 1
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: foo
     count:
       per_slot: 1

--- a/t/jobspec/valid/attributes_system.yaml
+++ b/t/jobspec/valid/attributes_system.yaml
@@ -7,7 +7,7 @@ resources:
       - type: node
         count: 1
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: foo
     count:
       per_slot: 1

--- a/t/jobspec/valid/attributes_user.yaml
+++ b/t/jobspec/valid/attributes_user.yaml
@@ -7,7 +7,7 @@ resources:
       - type: node
         count: 1
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: foo
     count:
       per_slot: 1

--- a/t/jobspec/valid/basic.yaml
+++ b/t/jobspec/valid/basic.yaml
@@ -7,7 +7,7 @@ resources:
       - type: node
         count: 1
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: foo
     count:
       per_slot: 1

--- a/t/jobspec/valid/basic_v1.yaml
+++ b/t/jobspec/valid/basic_v1.yaml
@@ -7,7 +7,7 @@ resources:
       - type: core
         count: 1
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: foo
     count:
       per_slot: 1

--- a/t/jobspec/valid/example1.yaml
+++ b/t/jobspec/valid/example1.yaml
@@ -10,7 +10,7 @@ resources:
           - type: core
             count: 2
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/t/jobspec/valid/example2.yaml
+++ b/t/jobspec/valid/example2.yaml
@@ -7,7 +7,7 @@ resources:
       - type: node
         count: 1
 tasks:
-  - command: hostname
+  - command: [ "hostname" ]
     slot: default
     count:
       per_slot: 1

--- a/t/jobspec/valid/use_case_2.1.yaml
+++ b/t/jobspec/valid/use_case_2.1.yaml
@@ -7,7 +7,7 @@ resources:
       - type: node
         count: 1
 tasks:
-  - command: hostname
+  - command: [ "hostname" ]
     slot: default
     count:
       per_slot: 5

--- a/t/jobspec/valid/use_case_2.2.yaml
+++ b/t/jobspec/valid/use_case_2.2.yaml
@@ -7,7 +7,7 @@ resources:
       - type: node
         count: 1
 tasks:
-  - command: hostname
+  - command: [ "hostname" ]
     slot: myslot
     count:
       total: 5

--- a/t/jobspec/valid/use_case_2.3.yaml
+++ b/t/jobspec/valid/use_case_2.3.yaml
@@ -7,7 +7,7 @@ resources:
       - type: core
         count: 2
 tasks:
-  - command: myapp
+  - command: [ "myapp" ]
     slot: default
     count:
       per_slot: 1

--- a/t/jobspec/valid/use_case_2.4.yaml
+++ b/t/jobspec/valid/use_case_2.4.yaml
@@ -22,11 +22,11 @@ resources:
             count: 24
             unit: GB
 tasks:
-  - command: read-db
+  - command: [ "read-db" ]
     slot: read-db
     count:
       per_slot: 1
-  - command: db
+  - command: [ "db" ]
     slot: db
     count:
       per_slot: 1

--- a/t/jobspec/valid/use_case_2.5.yaml
+++ b/t/jobspec/valid/use_case_2.5.yaml
@@ -11,7 +11,7 @@ resources:
     - type: core
       count: 1
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/t/jobspec/valid/use_case_2.6.yaml
+++ b/t/jobspec/valid/use_case_2.6.yaml
@@ -12,7 +12,7 @@ resources:
             min: 4
           unit: GB
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: 4GB-node
     count:
       total: 10

--- a/t/jobspec/valid_v1/example1.yaml
+++ b/t/jobspec/valid_v1/example1.yaml
@@ -10,7 +10,7 @@ resources:
           - type: core
             count: 2
 tasks:
-  - command: app
+  - command: [ "app" ]
     slot: default
     count:
       per_slot: 1

--- a/t/jobspec/valid_v1/use_case_2.1.yaml
+++ b/t/jobspec/valid_v1/use_case_2.1.yaml
@@ -10,7 +10,7 @@ resources:
           - type: core
             count: 1
 tasks:
-  - command: hostname
+  - command: [ "hostname" ]
     slot: myslot
     count:
       total: 5

--- a/t/jobspec/valid_v1/use_case_2.2.yaml
+++ b/t/jobspec/valid_v1/use_case_2.2.yaml
@@ -7,7 +7,7 @@ resources:
       - type: core
         count: 2
 tasks:
-  - command: myapp
+  - command: [ "myapp" ]
     slot: default
     count:
       per_slot: 1


### PR DESCRIPTION
Per RFC PR https://github.com/flux-framework/rfc/pull/215, update the jobspec command to always be a list/array, instead of a list/array OR string.

This PR / work is "complete", but I labeled it as WIP b/c it was initially experimental to see how many changes would result b/c of the RFC update.

Ended up it wasn't too much.  One parsing change in the shell, updating the json schemas in `job-ingest`, and just updating tests.  Also added a test to ensure that a jobspec command listed as a string is invalid.

## Commit Message

Update jobspec command key per RFC 14 changes

Recent change to rfc14 requires the command key in jobspec tasks
section to be a strict array. A string is no longer a valid task command.