### PR TITLE
Support job state times in job listing service

### DIFF
--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -628,7 +628,8 @@ int cmd_list (optparse_t *p, int argc, char **argv)
 {
     int optindex = optparse_option_index (p);
     int max_entries = optparse_get_int (p, "count", 0);
-    char *attrs = "[\"userid\",\"priority\",\"t_submit\",\"state\",\"job-name\"]";
+    char *attrs = "[\"userid\",\"priority\",\"t_submit\",\"state\",\"job-name\"," \
+                  "\"t_depend\",\"t_sched\",\"t_run\",\"t_cleanup\",\"t_inactive\"]";
     flux_t *h;
     flux_future_t *f;
     json_t *jobs;

--- a/src/modules/job-info/job_state.c
+++ b/src/modules/job-info/job_state.c
@@ -48,7 +48,7 @@ static int job_running_cmp (const void *a1, const void *a2)
     const struct job *j1 = a1;
     const struct job *j2 = a2;
 
-    return NUMCMP (j2->t_running, j1->t_running);
+    return NUMCMP (j2->t_run, j1->t_run);
 }
 
 static int job_inactive_cmp (const void *a1, const void *a2)
@@ -211,7 +211,8 @@ static int *state_counter (struct info_ctx *ctx,
 
 static void state_transition (struct info_ctx *ctx,
                               struct job *job,
-                              flux_job_state_t new_state)
+                              flux_job_state_t new_state,
+                              double timestamp)
 {
     int *decrement;
     int *increment;
@@ -219,6 +220,16 @@ static void state_transition (struct info_ctx *ctx,
     decrement = state_counter (ctx, job, job->state);
     increment = state_counter (ctx, job, new_state);
     job->state = new_state;
+    if (job->state == FLUX_JOB_DEPEND)
+        job->t_submit = timestamp;
+    else if (job->state == FLUX_JOB_SCHED)
+        job->t_sched = timestamp;
+    else if (job->state == FLUX_JOB_RUN)
+        job->t_run = timestamp;
+    else if (job->state == FLUX_JOB_CLEANUP)
+        job->t_cleanup = timestamp;
+    else if (job->state == FLUX_JOB_INACTIVE)
+        job->t_inactive = timestamp;
     if (decrement)
         (*decrement)--;
     if (increment)
@@ -310,7 +321,10 @@ static int eventlog_lookup_parse (struct info_ctx *ctx,
                                 __FUNCTION__, (unsigned long long)job->id);
                 goto out;
             }
-            job->t_submit = timestamp;
+            if (timestamp != job->t_submit)
+                flux_log_error (ctx->h,
+                                "%s: eventlog submit timestamp invalid %llu",
+                                __FUNCTION__, (unsigned long long)job->id);
             job->job_info_retrieved = true;
             break;
         }
@@ -497,14 +511,15 @@ static zlistx_t *get_list (struct job_state_ctx *jsctx, flux_job_state_t state)
 
 static void update_job_state (struct info_ctx *ctx,
                               struct job *job,
-                              flux_job_state_t newstate)
+                              flux_job_state_t newstate,
+                              double timestamp)
 {
     struct job_state_ctx *jsctx = job->ctx->jsctx;
 
     if (!job->job_info_retrieved) {
         /* job info still not retrieved, we can update the job
          * state but can't put it on a different list yet */
-        state_transition (ctx, job, newstate);
+        state_transition (ctx, job, newstate, timestamp);
     }
     else {
         if (job->state == FLUX_JOB_INACTIVE) {
@@ -520,7 +535,7 @@ static void update_job_state (struct info_ctx *ctx,
 
             if (oldlist != newlist)
                 job_change_list (jsctx, job, oldlist, newstate);
-            state_transition (ctx, job, newstate);
+            state_transition (ctx, job, newstate, timestamp);
         }
     }
 }
@@ -541,6 +556,7 @@ static void update_jobs (struct info_ctx *ctx, json_t *transitions)
         json_t *o;
         flux_jobid_t id;
         flux_job_state_t state;
+        double timestamp;
 
         if (!json_is_array (value)) {
             flux_log_error (jsctx->h, "%s: transition EPROTO", __FUNCTION__);
@@ -565,6 +581,14 @@ static void update_jobs (struct info_ctx *ctx, json_t *transitions)
             flux_log_error (jsctx->h, "%s: transition EPROTO", __FUNCTION__);
             return;
         }
+
+        if (!(o = json_array_get (value, 2))
+            || !json_is_real (o)) {
+            flux_log_error (jsctx->h, "%s: transition EPROTO", __FUNCTION__);
+            return;
+        }
+
+        timestamp = json_real_value (o);
 
         if (!(job = zhashx_lookup (jsctx->index, &id))) {
             flux_future_t *f = NULL;
@@ -597,10 +621,10 @@ static void update_jobs (struct info_ctx *ctx, json_t *transitions)
                 flux_log_error (jsctx->h, "%s: zlistx_add_end", __FUNCTION__);
                 return;
             }
-            state_transition (ctx, job, state);
+            state_transition (ctx, job, state, timestamp);
         }
         else
-            update_job_state (ctx, job, state);
+            update_job_state (ctx, job, state, timestamp);
     }
 
 }
@@ -667,12 +691,11 @@ static struct job *eventlog_restart_parse (struct info_ctx *ctx,
                                 __FUNCTION__, (unsigned long long)job->id);
                 goto error;
             }
-            job->t_submit = timestamp;
             job->job_info_retrieved = true;
-            state_transition (ctx, job, FLUX_JOB_DEPEND);
+            state_transition (ctx, job, FLUX_JOB_DEPEND, timestamp);
         }
         else if (!strcmp (name, "depend")) {
-            state_transition (ctx, job, FLUX_JOB_SCHED);
+            state_transition (ctx, job, FLUX_JOB_SCHED, timestamp);
         }
         else if (!strcmp (name, "priority")) {
             if (json_unpack (context, "{ s:i }",
@@ -690,21 +713,18 @@ static struct job *eventlog_restart_parse (struct info_ctx *ctx,
                 goto error;
             }
             if (severity == 0)
-                state_transition (ctx, job, FLUX_JOB_CLEANUP);
+                state_transition (ctx, job, FLUX_JOB_CLEANUP, timestamp);
         }
         else if (!strcmp (name, "alloc")) {
-            if (job->state == FLUX_JOB_SCHED) {
-                state_transition (ctx, job, FLUX_JOB_RUN);
-                job->t_running = timestamp;
-            }
+            if (job->state == FLUX_JOB_SCHED)
+                state_transition (ctx, job, FLUX_JOB_RUN, timestamp);
         }
         else if (!strcmp (name, "finish")) {
             if (job->state == FLUX_JOB_RUN)
-                state_transition (ctx, job, FLUX_JOB_CLEANUP);
+                state_transition (ctx, job, FLUX_JOB_CLEANUP, timestamp);
         }
         else if (!strcmp (name, "clean")) {
-            state_transition (ctx, job, FLUX_JOB_INACTIVE);
-            job->t_inactive = timestamp;
+            state_transition (ctx, job, FLUX_JOB_INACTIVE, timestamp);
         }
     }
 

--- a/src/modules/job-info/job_state.c
+++ b/src/modules/job-info/job_state.c
@@ -689,10 +689,8 @@ static struct job *eventlog_restart_parse (struct info_ctx *ctx,
                                 __FUNCTION__, (unsigned long long)job->id);
                 goto error;
             }
-            if (severity == 0) {
+            if (severity == 0)
                 state_transition (ctx, job, FLUX_JOB_CLEANUP);
-                job->t_inactive = timestamp;
-            }
         }
         else if (!strcmp (name, "alloc")) {
             if (job->state == FLUX_JOB_SCHED) {

--- a/src/modules/job-info/job_state.h
+++ b/src/modules/job-info/job_state.h
@@ -67,8 +67,23 @@ struct job {
     /* if userid, priority, t_submit, and flags have been set */
     bool job_info_retrieved;
     void *list_handle;
-    double t_running;           /* for sorting */
-    double t_inactive;          /* for sorting */
+
+    /* timestamp of when we enter the state
+     *
+     * associated eventlog entries when restarting
+     *
+     * depend - "submit"
+     * sched - "depend"
+     * run - "alloc"
+     * cleanup - "finish" or "exception" w/ severity == 0
+     * inactive - "clean"
+     */
+    // t_depend is identical to t_submit above, use that
+    // double t_depend;
+    double t_sched;
+    double t_run;
+    double t_cleanup;
+    double t_inactive;
 };
 
 struct job_state_ctx *job_state_create (flux_t *h);

--- a/src/modules/job-info/list.c
+++ b/src/modules/job-info/list.c
@@ -61,8 +61,21 @@ json_t *list_one_job (struct job *job, json_t *attrs)
         else if (!strcmp (attr, "priority")) {
             val = json_integer (job->priority);
         }
-        else if (!strcmp (attr, "t_submit")) {
+        else if (!strcmp (attr, "t_submit")
+                 || !strcmp (attr, "t_depend")) {
             val = json_real (job->t_submit);
+        }
+        else if (!strcmp (attr, "t_sched")) {
+            val = json_real (job->t_sched);
+        }
+        else if (!strcmp (attr, "t_run")) {
+            val = json_real (job->t_run);
+        }
+        else if (!strcmp (attr, "t_cleanup")) {
+            val = json_real (job->t_cleanup);
+        }
+        else if (!strcmp (attr, "t_inactive")) {
+            val = json_real (job->t_inactive);
         }
         else if (!strcmp (attr, "state")) {
             val = json_integer (job->state);
@@ -237,11 +250,16 @@ error:
 void list_attrs_cb (flux_t *h, flux_msg_handler_t *mh,
                     const flux_msg_t *msg, void *arg)
 {
-    if (flux_respond_pack (h, msg, "{s:[s,s,s,s,s]}",
+    if (flux_respond_pack (h, msg, "{s:[s,s,s,s,s,s,s,s,s,s]}",
                            "attrs",
                            "userid",
                            "priority",
                            "t_submit",
+                           "t_depend",
+                           "t_sched",
+                           "t_run",
+                           "t_cleanup",
+                           "t_inactive",
                            "state",
                            "job-name") < 0) {
         flux_log_error (h, "%s: flux_respond_pack", __FUNCTION__);

--- a/src/modules/job-manager/event.h
+++ b/src/modules/job-manager/event.h
@@ -29,10 +29,11 @@ int event_job_action (struct event *event, struct job *job);
  */
 int event_job_update (struct job *job, json_t *event);
 
-/* Add notification of job's state transition to its current state
- * to batch for publication.
+/* Add notification of job's state transition to its current state and
+ * the timestamp of the change to batch for publication.
  */
-int event_batch_pub_state (struct event *event, struct job *job);
+int event_batch_pub_state (struct event *event, struct job *job,
+                           double timestamp);
 
 /* Post event 'name' and optionally 'context' to 'job'.
  * Internally, calls event_job_update(), then event_job_action(), then commits

--- a/src/modules/job-manager/submit.c
+++ b/src/modules/job-manager/submit.c
@@ -130,7 +130,7 @@ int submit_post_event (struct event *event, struct job *job)
         goto error;
     if (event_job_update (job, entry) < 0) /* NEW -> DEPEND */
         goto error;
-    if (event_batch_pub_state (event, job) < 0)
+    if (event_batch_pub_state (event, job, job->t_submit) < 0)
         goto error;
     if (event_job_action (event, job) < 0)
         goto error;


### PR DESCRIPTION
Wanted to post this WIP to mostly get comment on the first bullet below, since it's sort of fudgable.

- When the job "start" and "end" time occur is actually something we can wiggle to different states of the job.

  I decided the job start time goes with the job state `FLUX_JOB_RUN`  / eventlog event "alloc".  I don't think the start time will be too controversial

  I decided the end time goes with `FLUX_JOB_CLEANUP` and the eventlog event "finish" OR "exception" with severity 0.  We could have the end time be the "inactive" state instead.  But I think
having it be `FLUX_JOB_CLEANUP` makes more sense b/c that is the transition that can occur immediately after an exception.

- The `job-manager`'s transitions publication also publishes timestamps associated with the state transitions.  For example, the start time is published alongside the state transition to FLUX_JOB_RUN`.  For states that do not have meaningful timestamps associated with them, we just publish a timestamp of zero with that state.

  We could choose to only send timestamps with specific states, but I felt the code just ended up a bit ugly for that.

- `flux job list` simply lists the start/end times stupidly right now, lists the time at the 1970 epoch if it isn't relevant (i.e. if a job is running, `t_end` doesn't exist yet).

  Example output of some jobs, one complete and one still running

```
JOBID           STATE   USERID  PRI     NAME            T_SUBMIT                T_START                 T_END
381564223488    R       8556    16      sleep           2019-12-05T18:53:46Z    2019-12-05T18:53:46Z    1970-01-01T00:00:00Z
110477967360    I       8556    16      sleep           2019-12-05T18:53:30Z    2019-12-05T18:53:30Z    2019-12-05T18:54:00Z
```

  This output is clearly very long and sort of ugly.  I'm thinking I'll add a `--format=json` kind of option, so it can be parsed with `jq` for testing.  Thus the default output would be limited to what's currently there. (JOBID, STATE, USERID, PRI, NAME, T_SUBMIT)
