### PR TITLE
have future take a ref on flux_t handle

### DIFF
--- a/src/common/libflux/future.c
+++ b/src/common/libflux/future.c
@@ -303,6 +303,7 @@ void flux_future_destroy (flux_future_t *f)
         now_context_destroy (f->now);
         then_context_destroy (f->then);
         zlist_destroy (&f->queue);
+        flux_decref (f->h);
         free (f);
         errno = saved_errno;
     }
@@ -411,7 +412,8 @@ inval:
 void flux_future_set_flux (flux_future_t *f, flux_t *h)
 {
     if (f) {
-        f->h = h;
+        flux_decref (f->h);
+        f->h = flux_incref (h);
         if (h && !f->r)
             f->r = flux_get_reactor (h);
     }

--- a/src/common/libflux/handle.c
+++ b/src/common/libflux/handle.c
@@ -372,10 +372,9 @@ flux_t *flux_clone (flux_t *orig)
     flux_t *h = calloc (1, sizeof (*h));
     if (!h)
         goto nomem;
-    h->parent = orig;
+    h->parent = flux_incref (orig);
     h->usecount = 1;
     h->flags = orig->flags | FLUX_O_CLONE;
-    flux_incref (orig);
     return h;
 nomem:
     free (h);
@@ -420,9 +419,16 @@ void flux_handle_destroy (flux_t *h)
     }
 }
 
-void flux_incref (flux_t *h)
+flux_t *flux_incref (flux_t *h)
 {
-    h->usecount++;
+    if (h)
+        h->usecount++;
+    return h;
+}
+
+void flux_decref (flux_t *h)
+{
+    flux_handle_destroy (h);
 }
 
 void flux_flags_set (flux_t *h, int flags)

--- a/src/common/libflux/handle.h
+++ b/src/common/libflux/handle.h
@@ -84,7 +84,8 @@ void flux_close (flux_t *h);
 
 /* Increment internal reference count on 'h'.
  */
-void flux_incref (flux_t *h);
+flux_t *flux_incref (flux_t *h);
+void flux_decref(flux_t *h);
 
 /* Create a new handle that is an alias for 'orig' in all respects
  * except it adds FLUX_O_CLONE to flags and has its own 'aux' hash


### PR DESCRIPTION
This is maybe a solution to the use-after-free reported in #2567 

The first straightforward thing I tried seems to have worked (just have future call flux_incref() on the handle).  I was not expecting that - hence the unit test added to libflux/test/future.c does more work than it needs to to simulate the use after free in a way that I thought I could more readily debug.

I ran the unit test under valgrind and it seems OK.  If this gets through travis-ci, we should probably try the unit test under ASAN, and retry the python test that was failing in #2567 too.

Also: I tweaked `flux_incref()` to return a `flux_t *` instead of void, and added a `flux_decref()` that's identical to `flux_close()` but the asymmetry was bugging me.