### PR TITLE
python: fix circular reference in `Future` class

### DIFF
--- a/src/bindings/python/flux/future.py
+++ b/src/bindings/python/flux/future.py
@@ -88,7 +88,11 @@ class Future(WrapperPimpl):
         flux_handle = self.pimpl.get_flux()
         if flux_handle == ffi.NULL:
             return None
-        return flux.core.handle.Flux(handle=flux_handle)
+        handle = flux.core.handle.Flux(handle=flux_handle)
+        # increment reference count to prevent destruction of the underlying handle
+        # (which is owned by the future) when the flux handle is garbage collected
+        handle.incref()
+        return handle
 
     def get_reactor(self):
         return self.pimpl.get_reactor()

--- a/src/bindings/python/flux/job.py
+++ b/src/bindings/python/flux/job.py
@@ -53,8 +53,6 @@ def submit_get_id(future):
 def submit(flux_handle, jobspec, priority=lib.FLUX_JOB_PRIORITY_DEFAULT, flags=0):
     future = submit_async(flux_handle, jobspec, priority, flags)
     jid = submit_get_id(future)
-    # pylint: disable=protected-access
-    future.pimpl._clear()
     return jid
 
 
@@ -82,6 +80,4 @@ def wait_get_status(future):
 def wait(flux_handle, jobid=lib.FLUX_JOBID_ANY):
     future = wait_async(flux_handle, jobid)
     status = wait_get_status(future)
-    # pylint: disable=protected-access
-    future.pimpl._clear()
     return status

--- a/src/bindings/python/flux/wrapper.py
+++ b/src/bindings/python/flux/wrapper.py
@@ -17,6 +17,8 @@ import re
 import os
 import errno
 import inspect
+import weakref
+
 import six
 
 
@@ -319,7 +321,7 @@ class Wrapper(WrapperBase):
             return fun
 
         new_fun = self.check_wrap(fun, name)
-        new_method = six.create_bound_method(new_fun, self)
+        new_method = six.create_bound_method(new_fun, weakref.proxy(self))
 
         # Store the wrapper function into the instance
         # to prevent a second lookup

--- a/t/python/t0012-futures.py
+++ b/t/python/t0012-futures.py
@@ -40,6 +40,14 @@ class TestHandle(unittest.TestCase):
         resp_payload = future.get()
         self.assertDictContainsSubset(self.ping_payload, resp_payload)
 
+    def test_02_get_flux(self):
+        future = self.f.rpc("cmb.ping", self.ping_payload)
+        future.get_flux()
+        # force a full garbage collection pass to test that the handle is not destructed
+        gc.collect(2)
+        resp_payload = future.get()
+        self.assertDictContainsSubset(self.ping_payload, resp_payload)
+
     def test_02_future_wait_for(self):
         future = self.f.rpc("cmb.ping", self.ping_payload)
         try:

--- a/t/python/t0012-futures.py
+++ b/t/python/t0012-futures.py
@@ -33,16 +33,15 @@ class TestHandle(unittest.TestCase):
     def setUpClass(self):
         """Create a handle, connect to flux"""
         self.f = flux.Flux()
+        self.ping_payload = {"seq": 1, "pad": "stuff"}
 
     def test_01_rpc_get(self):
-        payload = {"seq": 1, "pad": "stuff"}
-        future = self.f.rpc("cmb.ping", payload)
+        future = self.f.rpc("cmb.ping", self.ping_payload)
         resp_payload = future.get()
-        self.assertDictContainsSubset(payload, resp_payload)
+        self.assertDictContainsSubset(self.ping_payload, resp_payload)
 
     def test_02_future_wait_for(self):
-        payload = {"seq": 1, "pad": "stuff"}
-        future = self.f.rpc("cmb.ping", payload)
+        future = self.f.rpc("cmb.ping", self.ping_payload)
         try:
             future.wait_for(5)
             resp_payload = future.get()
@@ -51,7 +50,7 @@ class TestHandle(unittest.TestCase):
                 self.fail(msg="future fulfillment timed out")
             else:
                 raise
-        self.assertDictContainsSubset(payload, resp_payload)
+        self.assertDictContainsSubset(self.ping_payload, resp_payload)
 
     def test_03_future_then(self):
         """Register a 'then' cb and run the reactor to ensure it runs"""
@@ -68,8 +67,7 @@ class TestHandle(unittest.TestCase):
                 # ensure that reactor is always stopped, avoiding a hung test
                 flux_handle.reactor_stop(reactor)
 
-        payload = {"seq": 1, "pad": "stuff"}
-        self.f.rpc(b"cmb.ping", payload).then(then_cb, arg=payload)
+        self.f.rpc(b"cmb.ping", self.ping_payload).then(then_cb, arg=self.ping_payload)
         # force a full garbage collection pass to test that our anonymous RPC doesn't disappear
         gc.collect(2)
         ret = self.f.reactor_run(self.f.get_reactor(), 0)


### PR DESCRIPTION
As documented in #2566, futures are being leaked due to a circular reference in the `Wrapper` class.  Use `weakref` to avoid this.

Fix a reference counting bug in the `Flux` class exposed by the previous fix (along with a test for the issue).

Closes #2566.