### PR TITLE
shell: add unpack-style helpers for get_info shell plugin api calls

### DIFF
--- a/src/shell/mpir/mpir.c
+++ b/src/shell/mpir/mpir.c
@@ -47,49 +47,25 @@ static char hostname [1024] = "";
 
 static int shell_task_rank (flux_shell_task_t *task)
 {
-    json_t *o = NULL;
     int rank = -1;
-    char *s = NULL;
-
-    if (flux_shell_task_get_info (task, &s) < 0
-        || !(o = json_loads (s, 0, NULL))
-        || json_unpack (o, "{s:i}", "rank", &rank) < 0)
-        goto out;
-out:
-    json_decref (o);
-    free (s);
+    if (flux_shell_task_info_unpack (task, "{s:i}", "rank", &rank) < 0)
+        return -1;
     return rank;
 }
 
 static int shell_size (flux_shell_t *shell)
 {
-    json_t *o = NULL;
     int size = -1;
-    char *s = NULL;
-
-    if (flux_shell_get_info (shell, &s) < 0
-        || !(o = json_loads (s, 0, NULL))
-        || json_unpack (o, "{s:i}", "size", &size) < 0)
-        goto out;
-out:
-    json_decref (o);
-    free (s);
+    if (flux_shell_info_unpack (shell, "{s:i}", "size", &size) < 0)
+        return -1;
     return size;
 }
 
 static int shell_rank (flux_shell_t *shell)
 {
-    json_t *o = NULL;
     int rank = -1;
-    char *s = NULL;
-
-    if (flux_shell_get_info (shell, &s) < 0
-        || !(o = json_loads (s, 0, NULL))
-        || json_unpack (o, "{s:i}", "rank", &rank) < 0)
-        goto out;
-out:
-    json_decref (o);
-    free (s);
+    if (flux_shell_info_unpack (shell, "{s:i}", "rank", &rank) < 0)
+        return -1;
     return rank;
 }
 

--- a/src/shell/mpir/ptrace.c
+++ b/src/shell/mpir/ptrace.c
@@ -46,17 +46,11 @@ static int ptrace_traceme (flux_plugin_t *p,
 
 int current_task_pid (flux_shell_t *shell)
 {
-    json_t *o = NULL;
     long pid = -1;
-    char *s = NULL;
-
-    if (flux_shell_task_get_info (flux_shell_current_task (shell), &s) < 0
-        || !(o = json_loads (s, 0, NULL))
-        || json_unpack (o, "{s:I}", "pid", &pid) < 0)
-        goto out;
-out:
-    json_decref (o);
-    free (s);
+    if (flux_shell_task_info_unpack (flux_shell_current_task (shell),
+                                     "{s:I}",
+                                     "pid", &pid) < 0)
+        return -1;
     return (int) pid;
 }
 

--- a/src/shell/shell.h
+++ b/src/shell/shell.h
@@ -109,6 +109,11 @@ int flux_shell_unsetenv (flux_shell_t *shell, const char *name);
 int flux_shell_get_info (flux_shell_t *shell, char **json_str);
 
 
+/*  Access shell info object with Jansson-style unpack args.
+ */
+int flux_shell_info_unpack (flux_shell_t *shell,
+                            const char *fmt, ...);
+
 /*  Return rank and task info for given shell rank as JSON string.
  *  {
  *   "broker_rank":i,
@@ -119,6 +124,12 @@ int flux_shell_get_info (flux_shell_t *shell, char **json_str);
 int flux_shell_get_rank_info (flux_shell_t *shell,
                               int shell_rank,
                               char **json_str);
+
+/*  Access shell rank info object with Jansson-style unpack args.
+ */
+int flux_shell_rank_info_unpack (flux_shell_t *shell,
+                                 int shell_rank,
+                                 const char *fmt, ...);
 
 /*
  *  Take a "completion reference" on the shell object `shell`.

--- a/src/shell/shell.h
+++ b/src/shell/shell.h
@@ -224,6 +224,11 @@ flux_shell_task_t *flux_shell_task_next (flux_shell_t *shell);
  */
 int flux_shell_task_get_info (flux_shell_task_t *task, char **json_str);
 
+/*  Get shell task info with unpack-style args.
+ */
+int flux_shell_task_info_unpack (flux_shell_task_t *task,
+                                 const char *fmt, ...);
+
 /*
  *  Return the cmd structure for a shell task.
  */

--- a/src/shell/task.c
+++ b/src/shell/task.c
@@ -338,26 +338,78 @@ static const char * task_state (flux_shell_task_t *task)
         return "Init";
 }
 
-int flux_shell_task_get_info (flux_shell_task_t *task, char **json_str)
+static json_t *get_task_object (flux_shell_task_t *task)
 {
     json_error_t err;
+    json_t *o;
+    char key [128];
+
+    if (!task)
+        return NULL;
+
+    /* Save one copy of object per task "state", since the information
+     *  and available fields may be different as the task state evolves.
+     */
+    if (snprintf (key,
+                  sizeof (key),
+                  "shell::task:%s",
+                  task_state (task)) >= sizeof (key))
+        return NULL;
+    if ((o = aux_get (task->aux, key)))
+        return o;
+
+    if (!(o = json_pack_ex (&err, 0, "{ s:i s:i s:s }",
+                                     "localid", task->index,
+                                     "rank", task->rank,
+                                     "state", task_state (task))))
+        return NULL;
+
+    if ((task->proc && add_process_info_to_json (task->proc, o) < 0)
+        || aux_set (&task->aux, key, o, (flux_free_f) json_decref) < 0) {
+        json_decref (o);
+        return NULL;
+    }
+    return o;
+}
+
+int flux_shell_task_get_info (flux_shell_task_t *task, char **json_str)
+{
     json_t *o = NULL;
     if (!task || !json_str) {
         errno = EINVAL;
         return -1;
     }
-    if (!(o = json_pack_ex (&err, 0, "{ s:i s:i s:s }",
-                                     "localid", task->index,
-                                     "rank", task->rank,
-                                     "state", task_state (task))))
+    if (!(o = get_task_object (task)))
         return -1;
-    if (task->proc && add_process_info_to_json (task->proc, o) < 0) {
-        json_decref (o);
+    *json_str = json_dumps (o, JSON_COMPACT);
+    return (*json_str ? 0 : -1);
+}
+
+int flux_shell_task_info_vunpack (flux_shell_task_t *task,
+                                  const char *fmt,
+                                  va_list ap)
+{
+    json_t *o;
+    json_error_t err;
+    if (!task || !fmt) {
+        errno = EINVAL;
         return -1;
     }
-    *json_str = json_dumps (o, JSON_COMPACT);
-    json_decref (o);
-    return (*json_str ? 0 : -1);
+    if (!(o = get_task_object (task)))
+        return -1;
+    return json_vunpack_ex (o, &err, 0, fmt, ap);
+}
+
+int flux_shell_task_info_unpack (flux_shell_task_t *task,
+                                 const char *fmt,
+                                 ...)
+{
+    int rc;
+    va_list ap;
+    va_start (ap, fmt);
+    rc = flux_shell_task_info_vunpack (task, fmt, ap);
+    va_end (ap);
+    return rc;
 }
 
 /*

--- a/src/shell/task.c
+++ b/src/shell/task.c
@@ -63,6 +63,7 @@ void shell_task_destroy (struct shell_task *task)
 {
     if (task) {
         int saved_errno = errno;
+        aux_destroy (&task->aux);
         flux_cmd_destroy (task->cmd);
         flux_subprocess_destroy (task->proc);
         zhashx_destroy (&task->subscribers);

--- a/src/shell/task.h
+++ b/src/shell/task.h
@@ -12,9 +12,11 @@
 #define SHELL_TASK_H
 
 #include <flux/core.h>
+#include <czmq.h>
+
+#include "src/common/libutil/aux.h"
 #include "info.h"
 
-#include <czmq.h>
 
 struct shell_task;
 
@@ -45,6 +47,8 @@ struct shell_task {
 
     shell_task_io_ready_f io_cb;
     void *io_cb_arg;
+
+    struct aux_item *aux;
 };
 
 void shell_task_destroy (struct shell_task *task);

--- a/t/shell/plugins/invalid-args.c
+++ b/t/shell/plugins/invalid-args.c
@@ -91,6 +91,11 @@ static int shell_cb (flux_plugin_t *p,
     ok (flux_shell_get_info (shell, NULL) < 0 && errno == EINVAL,
         "flux_shell_get_info with NUll json_str returns EINVAL");
 
+    ok (flux_shell_info_unpack (NULL, NULL) < 0 && errno == EINVAL,
+        "flux_shell_info_unpack with NUll arg returns EINVAL");
+    ok (flux_shell_info_unpack (shell, NULL) < 0 && errno == EINVAL,
+        "flux_shell_info_unpack with NULL fmt returns EINVAL");
+
     ok (flux_shell_get_rank_info (NULL, -1, NULL) < 0 && errno == EINVAL,
         "flux_shell_get_rank_info (NULL, ..) returns EINVAL");
     ok (flux_shell_get_rank_info (shell, -1, NULL) < 0 && errno == EINVAL,
@@ -102,6 +107,19 @@ static int shell_cb (flux_plugin_t *p,
         "flux_shell_get_rank_info with invalid rank returns EINVAL");
     ok (flux_shell_get_rank_info (shell, -2, &json_str) < 0 && errno == EINVAL,
         "flux_shell_get_rank_info with rank < -1 returns EINVAL");
+
+    ok (flux_shell_rank_info_unpack (NULL, -1, NULL) < 0 && errno == EINVAL,
+        "flux_shell_rank_info_unpack (NULL, ..) returns EINVAL");
+    ok (flux_shell_get_rank_info (shell, -1, NULL) < 0 && errno == EINVAL,
+        "flux_shell_rank_info_unpack (NULL, ..) returns EINVAL");
+
+    int n;
+    ok (flux_shell_rank_info_unpack (shell, 12, "{s:i}", "ntasks", &n) < 0
+        && errno == EINVAL,
+        "flux_shell_rank_info_unpack with invalid rank returns EINVAL");
+    ok (flux_shell_rank_info_unpack (shell, -2, "{s:i}", "ntasks", &n) < 0
+        && errno == EINVAL,
+        "flux_shell_rank_info_unpack with rank < -1 returns EINVAL");
 
     ok (flux_shell_add_event_handler (NULL, NULL, NULL, NULL) < 0
         && errno == EINVAL,

--- a/t/shell/plugins/invalid-args.c
+++ b/t/shell/plugins/invalid-args.c
@@ -206,6 +206,11 @@ static int task_cb (flux_plugin_t *p,
     ok (flux_shell_task_get_info (task, NULL) < 0 && errno == EINVAL,
         "flux_shell_task_get_info with NULL task returns EINVAL");
 
+    ok (flux_shell_task_info_unpack (NULL, NULL) < 0 && errno == EINVAL,
+        "flux_shell_task_info_unpack with NULL args returns EINVAL");
+    ok (flux_shell_task_info_unpack (task, NULL) < 0 && errno == EINVAL,
+        "flux_shell_task_info_unpack with NULL fmt returns EINVAL");
+
     ok (!flux_shell_task_subprocess (NULL) && errno == EINVAL,
         "flux_shell_task_subprocess with NULL task returns EINVAL");
 


### PR DESCRIPTION
The `flux_shell_get_info`, `flux_shell_get_rank_info` and `flux_shell_task_get_info` calls are all very cumbersome to use from C shell plugins. The internal shell/task information is encoded into a Jansson object, dumped to a string, only to be immediately parsed on the caller side, then unpacked.

This results in a fair bit of boilerplate code, extra mallocs, etc -- duplicated between plugins. (many of the builtin plugins sidestep this issue by dereferencing the `shell` and `task` objects directly)

This PR adds unpack-style getters for these calls. The Jansson `json_t` objects are cached as aux data in the shell or task objects for later destruction, ensuring that `const char *` strings that are unpacked stay valid for the duration of the shell/task. O/w, the new calls just wrap `json_unpack`.

In the case of task objects, the task information may change for multiple states, so a separate `json_t *` is stored for each task state by appending the state to the aux item "key".

Finally shell builtin plugins (affinity, gpubind, mpir, and ptrace) which used the inconvenient interface are updated as appropriate.