### PR TITLE
job-info: Support task-count in listing service

### DIFF
--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -628,8 +628,9 @@ int cmd_list (optparse_t *p, int argc, char **argv)
 {
     int optindex = optparse_option_index (p);
     int max_entries = optparse_get_int (p, "count", 0);
-    char *attrs = "[\"userid\",\"priority\",\"t_submit\",\"state\",\"job-name\"," \
-                  "\"t_depend\",\"t_sched\",\"t_run\",\"t_cleanup\",\"t_inactive\"]";
+    char *attrs = "[\"userid\",\"priority\",\"t_submit\",\"state\"," \
+        "\"job-name\",\"task-count\",\"t_depend\",\"t_sched\",\"t_run\"," \
+        "\"t_cleanup\",\"t_inactive\"]";
     flux_t *h;
     flux_future_t *f;
     json_t *jobs;

--- a/src/modules/job-info/job_state.h
+++ b/src/modules/job-info/job_state.h
@@ -59,6 +59,7 @@ struct job {
     int flags;
     flux_job_state_t state;
     const char *job_name;
+    int task_count;
 
     /* cache of job information */
     json_t *jobspec_job;

--- a/src/modules/job-info/list.c
+++ b/src/modules/job-info/list.c
@@ -83,6 +83,9 @@ json_t *list_one_job (struct job *job, json_t *attrs)
         else if (!strcmp (attr, "job-name")) {
             val = json_string (job->job_name);
         }
+        else if (!strcmp (attr, "task-count")) {
+            val = json_integer (job->task_count);
+        }
         else {
             errno = EINVAL;
             goto error;
@@ -250,7 +253,7 @@ error:
 void list_attrs_cb (flux_t *h, flux_msg_handler_t *mh,
                     const flux_msg_t *msg, void *arg)
 {
-    if (flux_respond_pack (h, msg, "{s:[s,s,s,s,s,s,s,s,s,s]}",
+    if (flux_respond_pack (h, msg, "{s:[s,s,s,s,s,s,s,s,s,s,s]}",
                            "attrs",
                            "userid",
                            "priority",
@@ -261,7 +264,8 @@ void list_attrs_cb (flux_t *h, flux_msg_handler_t *mh,
                            "t_cleanup",
                            "t_inactive",
                            "state",
-                           "job-name") < 0) {
+                           "job-name",
+                           "task-count") < 0) {
         flux_log_error (h, "%s: flux_respond_pack", __FUNCTION__);
         goto error;
     }

--- a/t/t2204-job-info.t
+++ b/t/t2204-job-info.t
@@ -291,14 +291,10 @@ test_expect_success HAVE_JQ 'flux job list job state timing outputs valid (job i
         jobid=$(flux mini submit hostname) &&
         flux job wait-event $jobid clean >/dev/null &&
         obj=$(flux job list --inactive --json | grep $jobid) &&
-        ret=$(echo $obj | jq '.t_depend < .t_sched') &&
-        test "${ret}" == "true" &&
-        ret=$(echo $obj | jq '.t_sched < .t_run') &&
-        test "${ret}" == "true" &&
-        ret=$(echo $obj | jq '.t_run < .t_cleanup') &&
-        test "${ret}" == "true" &&
-        ret=$(echo $obj | jq '.t_cleanup < .t_inactive') &&
-        test "${ret}" == "true"
+        echo $obj | jq -e ".t_depend < .t_sched" &&
+        echo $obj | jq ".t_sched < .t_run" &&
+        echo $obj | jq ".t_run < .t_cleanup" &&
+        echo $obj | jq ".t_cleanup < .t_inactive"
 '
 
 # since job is running, make sure latter states are 0.0000
@@ -306,14 +302,10 @@ test_expect_success HAVE_JQ 'flux job list job state timing outputs valid (job r
         jobid=$(flux mini submit sleep 60) &&
         flux job wait-event $jobid start >/dev/null &&
         obj=$(flux job list --running --json | grep $jobid) &&
-        ret=$(echo $obj | jq '.t_depend < .t_sched') &&
-        test "${ret}" == "true" &&
-        ret=$(echo $obj | jq '.t_sched < .t_run') &&
-        test "${ret}" == "true" &&
-        ret=$(echo $obj | jq '.t_cleanup == 0.0') &&
-        test "${ret}" == "true" &&
-        ret=$(echo $obj | jq '.t_inactive == 0.0') &&
-        test "${ret}" == "true" &&
+        echo $obj | jq -e ".t_depend < .t_sched" &&
+        echo $obj | jq -e ".t_sched < .t_run" &&
+        echo $obj | jq -e ".t_cleanup == 0.0" &&
+        echo $obj | jq -e ".t_inactive == 0.0" &&
         flux job cancel $jobid &&
         flux job wait-event $jobid clean >/dev/null
 '


### PR DESCRIPTION
Nothing too surprising in this PR, it's pretty small:

- Support a new `task-count` field in job info job listing service.

- In order to parse the task count I basically cut & pasted the code that was in the job shell for the same purpose.  I contemplated writing a convenience library to do the parsing in both parts, but given we don't quite have all the parsing needs for the jobspec down yet, I figured writing a convenience library was a little premature?

- also did some unit test cleanup