### PR TITLE
Add porcelain flux jobs command

### DIFF
--- a/doc/man1/Makefile.am
+++ b/doc/man1/Makefile.am
@@ -21,7 +21,8 @@ MAN1_FILES_PRIMARY = \
 	flux-user.1 \
 	flux-event.1 \
 	flux-mini.1 \
-	flux-version.1
+	flux-version.1 \
+	flux-jobs.1
 
 # These files are generated as roff .so includes of a primary page.
 # A2X handles this automatically if mentioned in NAME section

--- a/doc/man1/flux-jobs.adoc
+++ b/doc/man1/flux-jobs.adoc
@@ -1,0 +1,100 @@
+// flux-help-include: true
+FLUX-JOBS(1)
+============
+:doctype: manpage
+
+
+NAME
+----
+flux-jobs - list jobs submitted to Flux
+
+
+SYNOPSIS
+--------
+*flux* *jobs* ['OPTIONS']
+
+
+DESCRIPTION
+-----------
+flux-jobs(1) is used to list jobs run under Flux.  By default only
+pending and running jobs for the current user are listed.  Additional
+jobs and information can be listed using options listed below.
+
+
+OPTIONS
+-------
+*-a*::
+List all jobs of the current user, including inactive jobs.
+Equivalent to specifying '--state=pending,running,inactive'.
+
+*-A*::
+List all jobs from all users, including inactive jobs.  Equivalent to
+specifying '--state=pending,running,inactive --user=all'.
+
+*--suppress-header*::
+For default output, do not output column headers.
+
+*-u, --user*'=[USERNAME|UID]'::
+List jobs for a specific username or userid.  Specify 'all' for all users.
+
+*-c, --count*'=N'::
+Limit output to N jobs (default 1000)
+
+*-s, --states*'=STATES'::
+List jobs in specific states.  States can be 'pending', 'running', or
+'inactive'.  Multiple states can be listed separated by comma.
+Defaults to 'pending,running'.
+
+*-o, --format*'=FORMAT
+Specify output format using Python's string format syntax.  See OUTPUT
+FORMAT below for field names.
+
+OUTPUT FORMAT
+-------------
+
+The '--format' option can be used to specify an output format to
+flux-jobs(1) using Python's string format syntax.  For example, the
+following is the format used for the default format:
+
+  {id:>18} {username:<8.8} {job_name:<10.10} {state:<8.8} {task_count:>6} {runtime_fsd}
+
+The field names that can be specified are:
+
+[horizontal]
+id:: job ID
+userid:: job submitter's userid
+username:: job submitter's username
+priority:: job priority
+state:: job state
+state_single:: job state as a single character
+job_name:: job name
+task_count:: job task count
+t_submit:: time job was submitted
+t_depend:: time job entered depend state
+t_sched:: time job entered sched state
+t_run:: time job entered run state
+t_cleanup:: time job entered cleanup state
+t_inactive:: time job entered inactive state
+runtime:: job runtime
+runtime_fsd:: job runtime in Flux standard duration format
+runtime_fsd_hyphen:: same as runtime_fsd, but '-' if runtime is 0s
+runtime_hms:: job runtime in H:M:S format
+
+AUTHOR
+------
+This page is maintained by the Flux community.
+
+
+RESOURCES
+---------
+Github: <http://github.com/flux-framework>
+
+
+COPYRIGHT
+---------
+include::COPYRIGHT.adoc[]
+
+
+SEE ALSO
+--------
+syslog(3)

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -467,3 +467,7 @@ idsets
 systemd
 toml
 unordered
+fsd
+hms
+username
+submitter's

--- a/src/bindings/python/flux/job.py
+++ b/src/bindings/python/flux/job.py
@@ -98,6 +98,28 @@ def wait(flux_handle, jobid=lib.FLUX_JOBID_ANY):
     return status
 
 
+# Due to subtleties in the python bindings and this call, this binding
+# is more of a reimplementation of flux_job_list() instead of calling
+# the flux_job_list() C function directly.  Some reasons:
+#
+# - Desire to return a Python RPC class and use its get() method
+# - Desired return value is json array, not a single value
+#
+# pylint: disable=dangerous-default-value
+def job_list(flux_handle, max_entries=0, attrs=[], userid=os.geteuid(), flags=0):
+    payload = {
+        "max_entries": max_entries,
+        "attrs": attrs,
+        "userid": userid,
+        "flags": flags,
+    }
+    return flux_handle.rpc("job-info.list", payload)
+
+
+def job_list_get(rpc_handle):
+    return rpc_handle.get()["jobs"]
+
+
 def _validate_keys(expected, given, keys_optional=False, allow_additional=False):
     if not isinstance(expected, set):
         expected = set(expected)

--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -65,7 +65,8 @@ nodist_flux_SOURCES = \
 dist_fluxcmd_SCRIPTS = \
 	flux-cron \
 	flux-jobspec.py \
-	flux-mini.py
+	flux-mini.py \
+	flux-jobs.py
 
 fluxcmd_PROGRAMS = \
 	flux-aggregate \

--- a/src/cmd/flux-jobs.py
+++ b/src/cmd/flux-jobs.py
@@ -1,0 +1,223 @@
+##############################################################
+# Copyright 2019 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+##############################################################
+
+from __future__ import print_function
+
+import os
+import sys
+import logging
+import argparse
+import time
+import pwd
+from datetime import timedelta
+
+import flux.job
+import flux.constants
+import flux.util
+from flux.core.inner import raw
+
+logger = logging.getLogger("flux-jobs")
+
+
+def runtime(job, roundup):
+    if job["t_cleanup"] > 0.0:
+        t = job["t_cleanup"] - job["t_run"]
+        if roundup:
+            t = round(t + 0.5)
+    elif job["t_run"] > 0.0:
+        t = time.time() - job["t_run"]
+        if roundup:
+            t = round(t + 0.5)
+    else:
+        t = 0.0
+    return t
+
+
+def runtime_fsd(job, hyphenifzero):
+    t = runtime(job, False)
+    if t < 60.0:
+        s = "%.2gs" % t
+    elif t < (60.0 * 60.0):
+        s = "%.2gm" % t
+    elif t < (60.0 * 60.0 * 24.0):
+        s = "%.2gh" % t
+    else:
+        s = "%.2gd" % t
+    if hyphenifzero and s == "0s":
+        return "-"
+    return s
+
+
+def runtime_hms(job):
+    t = runtime(job, True)
+    return str(timedelta(seconds=t))
+
+
+def statetostr(job, singlechar):
+    return raw.flux_job_statetostr(job["state"], singlechar).decode("utf-8")
+
+
+def output_format(fmt, jobs):
+    for job in jobs:
+        s = fmt.format(
+            id=job["id"],
+            userid=job["userid"],
+            username=pwd.getpwuid(job["userid"]).pw_name,
+            priority=job["priority"],
+            state=statetostr(job, False),
+            state_single=statetostr(job, True),
+            job_name=job["job-name"],
+            task_count=job["task-count"],
+            t_submit=job["t_submit"],
+            t_depend=job["t_depend"],
+            t_sched=job["t_sched"],
+            t_run=job["t_run"],
+            t_cleanup=job["t_cleanup"],
+            t_inactive=job["t_inactive"],
+            runtime=runtime(job, False),
+            runtime_fsd=runtime_fsd(job, False),
+            runtime_fsd_hyphen=runtime_fsd(job, True),
+            runtime_hms=runtime_hms(job),
+        )
+        print(s)
+
+
+@flux.util.CLIMain(logger)
+def main():
+    parser = argparse.ArgumentParser()
+    # -a equivalent to -s "pending,running,inactive" and -u set to userid
+    parser.add_argument(
+        "-a", action="store_true", help="List all jobs for current user"
+    )
+    # -A equivalent to -s "pending,running,inactive" and -u set to "all"
+    parser.add_argument("-A", action="store_true", help="List all jobs for all users")
+    parser.add_argument(
+        "-c",
+        "--count",
+        type=int,
+        metavar="N",
+        default=1000,
+        help="Limit output to N jobs(default 1000)",
+    )
+    parser.add_argument(
+        "-s",
+        "--states",
+        type=str,
+        metavar="STATES",
+        default="pending,running",
+        help="List jobs in specific states(pending,running,inactive)",
+    )
+    parser.add_argument(
+        "--suppress-header",
+        action="store_true",
+        help="Suppress printing of header line",
+    )
+    parser.add_argument(
+        "-u",
+        "--user",
+        type=str,
+        metavar="[USERNAME|UID]",
+        default=str(os.geteuid()),
+        help='Limit output to specific username or userid (Specify "all" for all users)',
+    )
+    parser.add_argument(
+        "-o",
+        "--format",
+        type=str,
+        metavar="FORMAT",
+        help="Specify output format using Python's string format syntax",
+    )
+
+    args = parser.parse_args()
+
+    h = flux.Flux()
+
+    # Future optimization, reduce attrs based on what is in output
+    # format, to reduce potentially large return RPC.
+    attrs = [
+        "userid",
+        "priority",
+        "state",
+        "job-name",
+        "task-count",
+        "t_submit",
+        "t_depend",
+        "t_sched",
+        "t_run",
+        "t_cleanup",
+        "t_inactive",
+    ]
+
+    if args.a:
+        args.user = str(os.geteuid())
+    if args.A:
+        args.user = str(flux.constants.FLUX_USERID_UNKNOWN)
+    if args.a or args.A:
+        args.states = "pending,running,inactive"
+
+    if args.user == "all":
+        userid = flux.constants.FLUX_USERID_UNKNOWN
+    else:
+        try:
+            userid = pwd.getpwnam(args.user).pw_uid
+        except KeyError:
+            try:
+                userid = int(args.user)
+            except ValueError:
+                print("invalid user specified", file=sys.stderr)
+                sys.exit(1)
+
+    flags = 0
+    for state in args.states.split(","):
+        if state.lower() == "pending":
+            flags |= flux.constants.FLUX_JOB_LIST_PENDING
+        elif state.lower() == "running":
+            flags |= flux.constants.FLUX_JOB_LIST_RUNNING
+        elif state.lower() == "inactive":
+            flags |= flux.constants.FLUX_JOB_LIST_INACTIVE
+        else:
+            print("Invalid state specified", file=sys.stderr)
+            sys.exit(1)
+
+    if flags == 0:
+        flags |= flux.constants.FLUX_JOB_LIST_PENDING
+        flags |= flux.constants.FLUX_JOB_LIST_RUNNING
+
+    rpc_handle = flux.job.job_list(h, args.count, attrs, userid, flags)
+    try:
+        jobs = flux.job.job_list_get(rpc_handle)
+    except EnvironmentError as e:
+        print("{}: {}".format("rpc", e.strerror), file=sys.stderr)
+        sys.exit(1)
+
+    if args.format:
+        output_format(args.format, jobs)
+    else:
+        fmt = (
+            "{id:>18} {username:<8.8} {job_name:<10.10} {state:<8.8} "
+            "{task_count:>6} {runtime_fsd_hyphen}"
+        )
+        if not args.suppress_header:
+            s = fmt.format(
+                id="JOBID",
+                username="USER",
+                job_name="NAME",
+                state="STATE",
+                task_count="NTASKS",
+                runtime_fsd_hyphen="TIME",
+            )
+            print(s)
+        output_format(fmt, jobs)
+
+
+if __name__ == "__main__":
+    main()
+
+# vi: ts=4 sw=4 expandtab

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -117,6 +117,7 @@ TESTSCRIPTS = \
 	t2609-job-shell-events.t \
 	t2610-job-shell-mpir.t \
 	t2700-mini-cmd.t \
+	t2800-jobs-cmd.t \
 	t3000-mpi-basic.t \
 	t3001-mpi-personalities.t \
 	t4000-issues-test-driver.t \

--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -1,0 +1,281 @@
+#!/bin/sh
+
+test_description='Test flux jobs command'
+
+. $(dirname $0)/sharness.sh
+
+test_under_flux 4 job
+
+hwloc_fake_config='{"0-3":{"Core":2,"cpuset":"0-1"}}'
+
+test_expect_success 'load job-exec,sched-simple modules' '
+        #  Add fake by_rank configuration to kvs:
+        flux kvs put resource.hwloc.by_rank="$hwloc_fake_config" &&
+        flux exec -r all flux module load barrier &&
+        flux module load sched-simple &&
+        flux module load job-exec
+'
+
+# submit a whole bunch of jobs for job list testing
+#
+# - the first loop of job submissions are intended to have some jobs run
+#   quickly and complete
+# - the second loop of job submissions are intended to eat up all resources
+# - the last job submissions are intended to get a create a set of
+#   pending jobs, because jobs from the second loop have taken all resources
+# - job ids are stored in files in the order we expect them to be listed
+#   - pending jobs - by priority (highest first)
+#   - running jobs - by start time (most recent first)
+#   - inactive jobs - by completion time (most recent first)
+#
+# the job-info module has eventual consistency with the jobs stored in
+# the job-manager's queue.  To ensure no raciness in tests, we spin
+# until all of the pending jobs have rached SCHED state.
+#
+
+wait_sched() {
+        local i=0
+        while [ "$(flux jobs | grep SCHED | wc -l)" != "6" ]\
+               && [ $i -lt 50 ]
+        do
+                sleep 0.1
+                i=$((i + 1))
+        done
+        if [ "$i" -eq "50" ]
+        then
+            return 1
+        fi
+        return 0
+}
+
+test_expect_success 'submit jobs for job list testing' '
+        for i in `seq 1 4`; do \
+            jobid=`flux mini submit hostname`; \
+            flux job wait-event $jobid clean; \
+            echo $jobid >> job_ids1.out; \
+        done &&
+        tac job_ids1.out > job_ids_inactive.out &&
+        for i in `seq 1 8`; do \
+            jobid=`flux mini submit sleep 600`; \
+            flux job wait-event $jobid start; \
+            echo $jobid >> job_ids2.out; \
+        done &&
+        tac job_ids2.out > job_ids_running.out &&
+        flux mini submit --priority=30 sleep 600 >> job_ids_pending.out &&
+        flux mini submit --priority=25 sleep 600 >> job_ids_pending.out &&
+        flux mini submit --priority=20 sleep 600 >> job_ids_pending.out &&
+        flux mini submit --priority=15 sleep 600 >> job_ids_pending.out &&
+        flux mini submit --priority=10 sleep 600 >> job_ids_pending.out &&
+        flux mini submit --priority=5 sleep 600 >> job_ids_pending.out &&
+        wait_sched
+'
+
+#
+# basic tests
+#
+
+# careful with counting b/c of header
+test_expect_success 'flux-jobs default output works' '
+        count=`flux jobs | wc -l` &&
+        test $count -eq 15 &&
+        count=`flux jobs | grep SCHED | wc -l` &&
+        test $count -eq 6 &&
+        count=`flux jobs | grep RUN | wc -l` &&
+        test $count -eq 8 &&
+        count=`flux jobs | grep INACTIVE | wc -l` &&
+        test $count -eq 0
+'
+
+test_expect_success 'flux-jobs --suppress-header works' '
+        count=`flux jobs --suppress-header | wc -l` &&
+        test $count -eq 14
+'
+
+# TODO: need to submit jobs as another user and test -A again
+test_expect_success 'flux-jobs -a and -A works' '
+        count=`flux jobs --suppress-header -a | wc -l` &&
+        test $count -eq 18 &&
+        count=`flux jobs --suppress-header -a | wc -l` &&
+        test $count -eq 18
+'
+
+test_expect_success 'flux-jobs --states works' '
+        count=`flux jobs --suppress-header --states=pending | wc -l` &&
+        test $count -eq 6 &&
+        count=`flux jobs --suppress-header --states=running | wc -l` &&
+        test $count -eq 8 &&
+        count=`flux jobs --suppress-header --states=inactive | wc -l` &&
+        test $count -eq 4 &&
+        count=`flux jobs --suppress-header --states=pending,running | wc -l` &&
+        test $count -eq 14 &&
+        count=`flux jobs --suppress-header --states=pending,inactive | wc -l` &&
+        test $count -eq 10 &&
+        count=`flux jobs --suppress-header --states=running,inactive | wc -l` &&
+        test $count -eq 12 &&
+        count=`flux jobs --suppress-header --states=pending,running,inactive | wc -l` &&
+        test $count -eq 18
+'
+
+# ensure + prefix works
+# increment userid to ensure not current user for test
+test_expect_success 'flux-jobs --user=UID works' '
+        userid=`id -u` &&
+        count=`flux jobs --suppress-header --user=${userid} | wc -l` &&
+        test $count -eq 14 &&
+        count=`flux jobs --suppress-header --user="+${userid}" | wc -l` &&
+        test $count -eq 14 &&
+        userid=$((userid+1)) &&
+        count=`flux jobs --suppress-header --user=${userid} | wc -l` &&
+        test $count -eq 0
+'
+
+test_expect_success 'flux-jobs --user=USERNAME works' '
+        username=`whoami` &&
+        count=`flux jobs --suppress-header --user=${username} | wc -l` &&
+        test $count -eq 14 &&
+        username="foobarfoobaz" &&
+        test_must_fail flux jobs --suppress-header --user=${username}
+'
+
+test_expect_success 'flux-jobs --user=all works' '
+        count=`flux jobs --suppress-header --user=all | wc -l` &&
+        test $count -eq 14
+'
+
+test_expect_success 'flux-jobs --count works' '
+        count=`flux jobs --suppress-header -a --count=0 | wc -l` &&
+        test $count -eq 18 &&
+        count=`flux jobs --suppress-header -a --count=8 | wc -l` &&
+        test $count -eq 8
+'
+
+#
+# format tests
+#
+
+test_expect_success 'flux-jobs --format={id} works' '
+        flux jobs --suppress-header --state=pending --format="{id}" > idsP.out &&
+        test_cmp idsP.out job_ids_pending.out &&
+        flux jobs --suppress-header --state=running --format="{id}" > idsR.out &&
+        test_cmp idsR.out job_ids_running.out &&
+        flux jobs --suppress-header --state=inactive --format="{id}" > idsI.out &&
+        test_cmp idsI.out job_ids_inactive.out
+'
+
+test_expect_success 'flux-jobs --format={userid},{username} works' '
+        flux jobs --suppress-header -a --format="{userid},{username}" > user.out &&
+        id=`id -u` &&
+        name=`whoami` &&
+        for i in `seq 1 18`; do echo "${id},${name}" >> user.exp; done &&
+        test_cmp user.out user.exp
+'
+
+test_expect_success 'flux-jobs --format={state},{state_single} works' '
+        flux jobs --suppress-header --state=pending --format="{state},{state_single}" > stateP.out &&
+        for i in `seq 1 6`; do echo "SCHED,S" >> stateP.exp; done &&
+        test_cmp stateP.out stateP.exp &&
+        flux jobs --suppress-header --state=running --format="{state},{state_single}" > stateR.out &&
+        for i in `seq 1 8`; do echo "RUN,R" >> stateR.exp; done &&
+        test_cmp stateR.out stateR.exp &&
+        flux jobs --suppress-header --state=inactive --format="{state},{state_single}" > stateI.out &&
+        for i in `seq 1 4`; do echo "INACTIVE,I" >> stateI.exp; done &&
+        test_cmp stateI.out stateI.exp
+'
+
+test_expect_success 'flux-jobs --format={job_name} works' '
+        flux jobs --suppress-header --state=pending,running --format="{job_name}" > jobnamePR.out &&
+        for i in `seq 1 14`; do echo "sleep" >> jobnamePR.exp; done &&
+        test_cmp jobnamePR.out jobnamePR.exp &&
+        flux jobs --suppress-header --state=inactive --format="{job_name}" > jobnameI.out &&
+        for i in `seq 1 4`; do echo "hostname" >> jobnameI.exp; done &&
+        test_cmp jobnameI.out jobnameI.exp
+'
+
+test_expect_success 'flux-jobs --format={task_count} works' '
+        flux jobs --suppress-header -a --format="{task_count}" > taskcount.out &&
+        for i in `seq 1 18`; do echo "1" >> taskcount.exp; done &&
+        test_cmp taskcount.out taskcount.exp
+'
+
+# test just make sure numbers are zero or non-zero given state of job
+test_expect_success 'flux-jobs --format={t_XXX} works' '
+        flux jobs --suppress-header -a --format="{t_submit}" > t_submit.out &&
+        count=`cat t_submit.out | grep -v "^0.0$" | wc -l` &&
+        test $count -eq 18 &&
+        flux jobs --suppress-header -a --format="{t_depend}" > t_depend.out &&
+        count=`cat t_depend.out | grep -v "^0.0$" | wc -l` &&
+        test $count -eq 18 &&
+        flux jobs --suppress-header -a --format="{t_sched}" > t_sched.out &&
+        count=`cat t_sched.out | grep -v "^0.0$" | wc -l` &&
+        test $count -eq 18 &&
+        flux jobs --suppress-header --state=pending --format="{t_run}" > t_runP.out &&
+        flux jobs --suppress-header --state=running,inactive --format="{t_run}" > t_runRI.out &&
+        count=`cat t_runP.out | grep "^0.0$" | wc -l` &&
+        test $count -eq 6 &&
+        count=`cat t_runRI.out | grep -v "^0.0$" | wc -l` &&
+        test $count -eq 12 &&
+        flux jobs --suppress-header --state=pending,running --format="{t_cleanup}" > t_cleanupPR.out &&
+        flux jobs --suppress-header --state=inactive --format="{t_cleanup}" > t_cleanupI.out &&
+        count=`cat t_cleanupPR.out | grep "^0.0$" | wc -l` &&
+        test $count -eq 14 &&
+        count=`cat t_cleanupI.out | grep -v "^0.0$" | wc -l` &&
+        test $count -eq 4 &&
+        flux jobs --suppress-header --state=pending,running --format="{t_inactive}" > t_inactivePR.out &&
+        flux jobs --suppress-header --state=inactive --format="{t_inactive}" > t_inactiveI.out &&
+        count=`cat t_inactivePR.out | grep "^0.0$" | wc -l` &&
+        test $count -eq 14 &&
+        count=`cat t_inactiveI.out | grep -v "^0.0$" | wc -l` &&
+        test $count -eq 4
+'
+
+test_expect_success 'flux-jobs --format={runtime},{runtime_fsd},{runtime_fsd_hyphen},{runtime_hms} works' '
+        flux jobs --suppress-header --state=pending --format="{runtime},{runtime_fsd},{runtime_fsd_hyphen},{runtime_hms}" > runtimeP.out &&
+        for i in `seq 1 6`; do echo "0.0,0s,-,0:00:00" >> runtimeP.exp; done &&
+        test_cmp runtimeP.out runtimeP.exp &&
+        flux jobs --suppress-header --state=running,inactive --format="{runtime}" > runtimeRI_1.out &&
+        count=`cat runtimeRI_1.out | grep -v "^0.0$" | wc -l` &&
+        test $count -eq 12 &&
+        flux jobs --suppress-header --state=running,inactive --format="{runtime_fsd}" > runtimeRI_2.out &&
+        count=`cat runtimeRI_2.out | grep -v "^0s" | wc -l` &&
+        test $count -eq 12 &&
+        flux jobs --suppress-header --state=running,inactive --format="{runtime_fsd_hyphen}" > runtimeRI_3.out &&
+        count=`cat runtimeRI_3.out | grep -v "^-$" | wc -l` &&
+        test $count -eq 12 &&
+        flux jobs --suppress-header --state=running,inactive --format="{runtime_hms}" > runtimeRI_4.out &&
+        count=`cat runtimeRI_4.out | grep -v "^0:00:00" | wc -l` &&
+        test $count -eq 12
+'
+
+#
+# corner cases
+#
+
+test_expect_success 'flux-jobs illegal count leads to RPC error' '
+        test_must_fail flux jobs --count=-1
+'
+
+test_expect_success 'flux-jobs --format with illegal field is an error' '
+        test_must_fail flux jobs --format="{foobar}"
+'
+
+#
+# cleanup
+#
+test_expect_success 'cleanup job listing jobs ' '
+        for jobid in `cat job_ids_pending.out`; do \
+            flux job cancel $jobid; \
+            flux job wait-event $jobid clean; \
+        done &&
+        for jobid in `cat job_ids_running.out`; do \
+            flux job cancel $jobid; \
+            flux job wait-event $jobid clean; \
+        done
+'
+
+test_expect_success 'remove sched-simple,job-exec modules' '
+        flux exec -r all flux module remove barrier &&
+        flux module remove sched-simple &&
+        flux module remove job-exec
+'
+
+test_done


### PR DESCRIPTION
This is an initial hacked up `flux-queue.py` that I wrote up (built on top of PR #2580) just to get my python bearings.  Example output:

```
JOBID		STATE	TASKS	NAME	USERID	TIME
21357395968	R	1	sleep  	8556	0:00:01
18756927488	R	1	sleep  	8556	0:00:01
16190013440	R	1	sleep  	8556	0:00:01
```

Options are:

```
  -c N, --count N       Limit output to N jobs
  -p, --pending         List pending jobs
  -r, --running         List running jobs
  -i, --inactive        List inactive jobs
  -s, --suppress-header
                        Suppress printing of header line
  -u UID, --userid UID  Limit output to specific userid (Specify "all" for all
                        users)
```

So options aren't all that different from `flux job list` for the time being, but it:

A) lists task count
B) lists run time
C) caps output to 1000 jobs (random max I thought was acceptable)
D) defaults to showing running / pending jobs.

Notes:

- should priority be output by default?  Will average user care?  I suppose we need an option for this atleast.
- it's a little annoying having to build an rpc for `job-info.list` and passing it into `h.rpc()`.  Perhaps I need to make a binding for `flux_job_list()`.
- is it kosher to call `raw.flux_job_statetostr()` in such a tool?  I'm not sure if calling via `raw` should only be isolated to bindings?

perhaps should have a brainstorming / discussion of what we would like the defaults to be or what initial user options we'd like.  @garlick had some ideas in #2416 

I dislike the `--running`, `--pending`, `--inactive` options, as well as `-u UID`.  I think we should leave them in there, but I'll throw out the following as starters:

- `-a` - conceptually similar to `ps -a`, show all jobs associated with a user.  This would be shorthand for `--pending --running --inactive`.

- `-A` - conceptually similar to `ps -A`, show everything, inactive, all users, etc.  This would be shorthand for `--pending --running --inactive -u all`