### PR TITLE
github: enable a workflow to validate commits in a PR

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,12 @@
+on: pull_request
+jobs:
+  check-pr:
+    name: validate commits
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+        fetch-depth: 0
+    - run: git fetch origin master
+    - uses: flux-framework/pr-validator@master


### PR DESCRIPTION
This is an experimental PR which uses GitHub workflow support to support simple validation of commits in a pull request. The validation is performed via a custom "action" ( [flux-framework/pr-validator](https://github.com/flux-framework/pr-validator)), which currently just verifies that commits in a PR are not merge commits or have `fixup` or `squash` in the subject.

The custom GitHub action is kept separately from this repo so it can more easily be shared between flux-framework projects, and be updated out-of-band as new validations of PRs is required.

Example of validator functionality:
![sc](https://user-images.githubusercontent.com/741970/71537005-d9c08880-28ca-11ea-9f70-c0c64effd870.png)
