### PR TITLE
job-info: honor `max_entries` option in job-info.list

### DIFF
--- a/src/modules/job-info/list.c
+++ b/src/modules/job-info/list.c
@@ -22,10 +22,6 @@
 #include "list.h"
 #include "job_state.h"
 
-/* To avoid denial of service, the maxinum number of entries that can
- * be returned to the user will be capped */
-#define MAX_ENTRIES_CAP 1024
-
 /* For a given job, create a JSON object containing the jobid and any
  * additional requested attributes and their values.  Returns JSON
  * object which the caller must free.  On error, return NULL with
@@ -225,9 +221,6 @@ void list_cb (flux_t *h, flux_msg_handler_t *mh,
         errno = EPROTO;
         goto error;
     }
-
-    if (max_entries > MAX_ENTRIES_CAP)
-        max_entries = MAX_ENTRIES_CAP;
 
     /* If user sets no flags, assume they want all information */
     if (!flags)

--- a/t/t2204-job-info.t
+++ b/t/t2204-job-info.t
@@ -378,6 +378,13 @@ test_expect_success 'verify job names preserved across restart' '
 # job list special cases
 #
 
+test_expect_success 'list count / max_entries works' '
+        count=`flux job list --inactive -s -c 0 | wc -l` &&
+        test $count -gt 5 &&
+        count=`flux job list --inactive -s -c 5 | wc -l` &&
+        test $count -eq 5
+'
+
 test_expect_success HAVE_JQ 'list request with empty attrs works' '
         id=$(id -u) &&
         $jq -j -c -n  "{max_entries:5, userid:${id}, flags:0, attrs:[]}" \


### PR DESCRIPTION
Per discussion in #2589 