### PR TITLE
job-info: use basename of arg0 for job-name

### DIFF
--- a/src/modules/job-info/job_state.c
+++ b/src/modules/job-info/job_state.c
@@ -367,6 +367,23 @@ static int parse_res_level (struct info_ctx *ctx,
     return 0;
 }
 
+/* Return basename of path if there is a '/' in path.  Otherwise return
+ * full path */
+const char *
+parse_job_name (const char *path)
+{
+    char *p = strrchr (path, '/');
+    if (p) {
+        p++;
+        /* user mistake, specified a directory with trailing '/',
+         * return full path */
+        if (*p == '\0')
+            return path;
+        return p;
+    }
+    return path;
+}
+
 static int jobspec_parse (struct info_ctx *ctx,
                           struct job *job,
                           const char *s)
@@ -452,7 +469,7 @@ static int jobspec_parse (struct info_ctx *ctx,
                       __FUNCTION__, (unsigned long long)job->id);
             goto error;
         }
-        job->job_name = json_string_value (arg0);
+        job->job_name = parse_job_name (json_string_value (arg0));
         assert (job->job_name);
     }
 

--- a/t/t2204-job-info.t
+++ b/t/t2204-job-info.t
@@ -328,6 +328,21 @@ test_expect_success 'flux job lists first argument for job-name' '
         flux job list --inactive | grep $jobid | grep mycmd
 '
 
+test_expect_success 'flux job lists basename of first argument for job-name' '
+        jobid=`flux mini submit /foo/bar arg1 arg2` &&
+        echo $jobid > jobname3.id &&
+        flux job wait-event $jobid clean >/dev/null &&
+        flux job list --inactive | grep $jobid | grep bar &&
+        flux job list --inactive | grep $jobid | grep -v foo
+'
+
+test_expect_success 'flux job lists full path for job-name if first argument not ok' '
+        jobid=`flux mini submit /foo/bar/ arg1 arg2` &&
+        echo $jobid > jobname4.id &&
+        flux job wait-event $jobid clean >/dev/null &&
+        flux job list --inactive | grep $jobid | grep "\/foo\/bar\/"
+'
+
 test_expect_success 'reload the job-info module' '
         flux module remove -r all job-info &&
         flux module load -r all job-info
@@ -336,8 +351,12 @@ test_expect_success 'reload the job-info module' '
 test_expect_success 'verify job names preserved across restart' '
         jobid1=`cat jobname1.id` &&
         jobid2=`cat jobname2.id` &&
+        jobid3=`cat jobname3.id` &&
+        jobid4=`cat jobname4.id` &&
         flux job list --inactive | grep ${jobid1} | grep foobar &&
-        flux job list --inactive | grep ${jobid2} | grep mycmd
+        flux job list --inactive | grep ${jobid2} | grep mycmd &&
+        flux job list --inactive | grep ${jobid3} | grep bar &&
+        flux job list --inactive | grep ${jobid4} | grep "\/foo\/bar\/"
 '
 
 #


### PR DESCRIPTION
Per issue #2588.

Only interesting question was to use posix vs gnu `basename()`.  I decided to use GNU version as that removes the need to create a copy of the arg0 string.  But there is corner case in which GNU `basename()` could return the empty string.

It wouldn't be the biggest deal in the world if we returned an empty string for the jobname if the user inputted something, but I disliked the idea of that.  So I decided to return the full arg0 if the user input something stupid on the command line.

e.g.

user runs: `/foo/bar`, job-name is `bar`
user runs: `/foo/bar/`, job-name is `/foo/bar/` (b/c of the trailing slash)