### PR TITLE
mergify: do not auto-merge PRs with invalid commits

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -3,6 +3,7 @@ pull_request_rules:
     conditions:
       - base=master
       - status-success=continuous-integration/travis-ci/pr
+      - status-success="validate commits"
       - label="merge-when-passing"
       - label!="work-in-progress"
       - "approved-reviews-by=@flux-framework/core"


### PR DESCRIPTION
Add a rule to `.mergify.yml` to avoid merging PRs that do not pass the GitHub pr-validator action. (Avoid merging PRs with fixup/squash commits)