### PR TITLE
use libuuid instead of zuuid

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ libsodium-devel   | libsodium-dev     | >= 1.0.14         |
 zeromq4-devel     | libzmq3-dev       | >= 4.0.4          |
 czmq-devel        | libczmq-dev       | >= 3.0.1          |
 jansson-devel     | libjansson-dev    | >= 2.6            |
+libuuid-devel     | uuid-dev          |                   |
 lz4-devel         | liblz4-dev        |                   |
 hwloc-devel       | libhwloc-dev      | >= v1.11.1, < 2.0 |
 sqlite-devel      | libsqlite3-dev    | >= 3.0.0          |
@@ -73,12 +74,12 @@ of asciidoc or asciidoctor is needed.  Asciidoc is used if both are installed.*
 
 ##### Installing RedHat/CentOS Packages
 ```
-yum install autoconf automake libtool libsodium-devel zeromq4-devel czmq-devel jansson-devel lz4-devel hwloc-devel sqlite-devel lua lua-devel lua-posix python36-devel python36-cffi python36-six python36-yaml python36-jsonschema asciidoc asciidoctor aspell valgrind mpich jq
+yum install autoconf automake libtool libsodium-devel zeromq4-devel czmq-devel libuuid-devel jansson-devel lz4-devel hwloc-devel sqlite-devel lua lua-devel lua-posix python36-devel python36-cffi python36-six python36-yaml python36-jsonschema asciidoc asciidoctor aspell valgrind mpich jq
 ```
 
 ##### Installing Ubuntu Packages
 ```
-apt install autoconf automake libtool libsodium-dev libzmq3-dev libczmq-dev libjansson-dev liblz4-dev libhwloc-dev libsqlite3-dev lua5.1 liblua5.1-dev lua-posix python3-dev python3-cffi python3-six python3-yaml python3-jsonschema asciidoc asciidoctor aspell valgrind mpich jq
+apt install autoconf automake libtool libsodium-dev libzmq3-dev libczmq-dev uuid-dev libjansson-dev liblz4-dev libhwloc-dev libsqlite3-dev lua5.1 liblua5.1-dev lua-posix python3-dev python3-cffi python3-six python3-yaml python3-jsonschema asciidoc asciidoctor aspell valgrind mpich jq
 ```
 
 ##### Building from Source

--- a/configure.ac
+++ b/configure.ac
@@ -313,6 +313,7 @@ PKG_CHECK_MODULES([HWLOC], [hwloc >= 1.11.1], [], [])
 PKG_CHECK_MODULES([LZ4], [liblz4], [], [])
 PKG_CHECK_MODULES([SQLITE], [sqlite3], [], [])
 PKG_CHECK_MODULES([LIBSODIUM], [libsodium >= 1.0.14], [], [])
+PKG_CHECK_MODULES([LIBUUID], [uuid], [], [])
 LX_FIND_MPI
 AM_CONDITIONAL([HAVE_MPI], [test "$have_C_mpi" = yes])
 AX_VALGRIND_H

--- a/doc/man3/Makefile.am
+++ b/doc/man3/Makefile.am
@@ -341,12 +341,12 @@ AM_CPPFLAGS = \
         -I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
 	-I$(top_builddir)/src/common/libflux \
-        $(ZMQ_CFLAGS)
+        $(ZMQ_CFLAGS) $(LIBUUID_CFLAGS)
 
 LDADD = \
         $(top_builddir)/src/common/libflux-internal.la \
         $(top_builddir)/src/common/libflux-core.la \
-        $(ZMQ_LIBS) $(LIBPTHREAD)
+        $(ZMQ_LIBS) $(LIBUUID_CFLAGS) $(LIBPTHREAD)
 
 check_PROGRAMS = \
 	topen \

--- a/src/bindings/lua/Makefile.am
+++ b/src/bindings/lua/Makefile.am
@@ -1,5 +1,5 @@
 AM_CFLAGS =	$(WARNING_CFLAGS) $(CODE_COVERAGE_CFLAGS) \
-		$(ZMQ_CFLAGS) \
+		$(ZMQ_CFLAGS) $(LIBUUID_CFLAGS) \
 		-Wno-parentheses -Wno-error=parentheses
 AM_LDFLAGS =	$(CODE_COVERAGE_LIBS)
 AM_CPPFLAGS =	\
@@ -44,7 +44,7 @@ luamod_ldflags = \
 luamod_libadd = \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la \
-	$(LUA_LIB) $(ZMQ_LIBS)
+	$(LUA_LIB) $(ZMQ_LIBS) $(LIBUUID_LIBS)
 
 flux_la_LDFLAGS = \
 	$(luamod_ldflags)

--- a/src/bindings/python/_flux/Makefile.am
+++ b/src/bindings/python/_flux/Makefile.am
@@ -3,7 +3,7 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir) -I$(top_srcdir)/src/include \
 	-I$(top_srcdir)/src/common/libflux \
 	-I$(top_builddir)/src/common/libflux \
-	$(ZMQ_CFLAGS) $(PYTHON_CPPFLAGS) \
+	$(ZMQ_CFLAGS) $(LIBUUID_CFLAGS) $(PYTHON_CPPFLAGS) \
 	$(CODE_COVERAGE_CFLAGS)
 
 AM_LDFLAGS = \
@@ -16,7 +16,7 @@ SUFFIXES = _build.py
 
 common_libs = $(top_builddir)/src/common/libflux-core.la \
 	      $(top_builddir)/src/common/libflux-internal.la \
-	      $(ZMQ_LIBS) \
+	      $(ZMQ_LIBS) $(LIBUUID_LIBS) \
 	      $(PYTHON_LDFLAGS)
 
 _build.py.c:

--- a/src/broker/Makefile.am
+++ b/src/broker/Makefile.am
@@ -8,7 +8,9 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
 	-I$(top_builddir)/src/common/libflux \
-	$(ZMQ_CFLAGS) $(VALGRIND_CFLAGS)
+	$(ZMQ_CFLAGS) \
+	$(LIBUUID_CFLAGS) \
+	$(VALGRIND_CFLAGS)
 
 fluxcmd_PROGRAMS = flux-broker
 

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -287,8 +287,7 @@ static int increase_rlimits (void)
     struct rlimit rlim;
 
     /*  Increase number of open files to max to prevent potential failures
-     *   due to file descriptor exhaustion (e.g. zuuid_new() failure to
-     *   open /dev/urandom)
+     *   due to file descriptor exhaustion (e.g. failure to open /dev/urandom)
      */
     if (getrlimit (RLIMIT_NOFILE, &rlim) < 0) {
         log_err ("getrlimit");

--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -9,7 +9,10 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
 	-I$(top_builddir)/src/common/libflux \
-	$(ZMQ_CFLAGS) $(FLUX_SECURITY_CFLAGS) $(LIBSODIUM_CFLAGS)
+	$(FLUX_SECURITY_CFLAGS) \
+	$(ZMQ_CFLAGS) \
+	$(LIBUUID_CFLAGS) \
+	$(LIBSODIUM_CFLAGS)
 
 fluxcmd_ldadd = \
 	$(top_builddir)/src/common/libkvs/libkvs.la \
@@ -18,7 +21,12 @@ fluxcmd_ldadd = \
 	$(top_builddir)/src/common/libflux-core.la \
 	$(top_builddir)/src/common/libflux-optparse.la \
 	$(FLUX_SECURITY_LIBS) \
-	$(ZMQ_LIBS) $(LIBPTHREAD) $(LIBDL) $(HWLOC_LIBS) $(LIBSODIUM_LIBS)
+	$(ZMQ_LIBS) \
+	$(LIBUUID_LIBS) \
+	$(LIBPTHREAD) \
+	$(LIBDL) \
+	$(HWLOC_LIBS) \
+	$(LIBSODIUM_LIBS)
 
 LDADD = $(fluxcmd_ldadd)
 

--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -36,8 +36,15 @@ libflux_internal_la_LIBADD = \
 	$(builddir)/libeventlog/libeventlog.la \
 	$(builddir)/libioencode/libioencode.la \
 	$(builddir)/librouter/librouter.la \
-	$(JANSSON_LIBS) $(ZMQ_LIBS) $(LIBPTHREAD) $(LIBUTIL) \
-	$(LIBDL) $(LIBRT) $(FLUX_SECURITY_LIBS) $(LIBSODIUM_LIBS)
+	$(JANSSON_LIBS) \
+	$(ZMQ_LIBS) \
+	$(LIBUUID_LIBS) \
+	$(LIBPTHREAD) \
+	$(LIBUTIL) \
+	$(LIBDL) \
+	$(LIBRT) \
+	$(FLUX_SECURITY_LIBS) \
+	$(LIBSODIUM_LIBS)
 libflux_internal_la_LDFLAGS = $(san_ld_zdef_flag)
 
 lib_LTLIBRARIES = libflux-core.la \
@@ -65,7 +72,7 @@ libflux_optparse_la_LIBADD = \
 	$(builddir)/liboptparse/liboptparse.la \
 	$(builddir)/liblsd/liblsd.la \
 	$(builddir)/libutil/fsd.lo \
-	$(ZMQ_LIBS) $(LIBPTHREAD)
+	$(ZMQ_LIBS) $(LIBUUID_LIBS) $(LIBPTHREAD)
 libflux_optparse_la_LDFLAGS = \
         -Wl,--version-script=$(srcdir)/libflux-optparse.map \
 	-version-info @LIBFLUX_OPTPARSE_VERSION_INFO@ \

--- a/src/common/libflux/Makefile.am
+++ b/src/common/libflux/Makefile.am
@@ -10,7 +10,10 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir)/src/include \
 	-I$(top_builddir) \
 	-I$(top_builddir)/src/common/libflux \
-	$(JANSSON_CFLAGS) $(ZMQ_CFLAGS) $(LIBSODIUM_CFLAGS)
+	$(JANSSON_CFLAGS) \
+	$(ZMQ_CFLAGS) \
+	$(LIBUUID_CFLAGS) \
+	$(LIBSODIUM_CFLAGS)
 
 installed_conf_cppflags = \
 	-DINSTALLED_MODULE_PATH=\"$(fluxmoddir)\" \
@@ -169,7 +172,11 @@ test_ldadd = \
 	$(top_builddir)/src/common/liblsd/liblsd.la \
 	$(top_builddir)/src/common/libtomlc99/libtomlc99.la \
 	$(top_builddir)/src/common/libev/libev.la \
-	$(ZMQ_LIBS) $(JANSSON_LIBS) $(LIBPTHREAD) $(LIBSODIUM_LIBS)
+	$(ZMQ_LIBS) \
+	$(LIBUUID_LIBS) \
+	$(JANSSON_LIBS) \
+	$(LIBPTHREAD) \
+	$(LIBSODIUM_LIBS)
 
 test_cppflags = \
         -I$(top_srcdir)/src/common/libtap \

--- a/src/common/libjob/Makefile.am
+++ b/src/common/libjob/Makefile.am
@@ -9,7 +9,10 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
 	-I$(top_builddir)/src/common/libflux \
-	$(ZMQ_CFLAGS) $(JANSSON_CFLAGS) $(FLUX_SECURITY_CFLAGS) \
+	$(ZMQ_CFLAGS) \
+	$(LIBUUID_CFLAGS) \
+	$(JANSSON_CFLAGS) \
+	$(FLUX_SECURITY_CFLAGS) \
 	$(LIBSODIUM_CFLAGS)
 
 noinst_LTLIBRARIES = libjob.la
@@ -38,8 +41,14 @@ test_ldadd = \
         $(top_builddir)/src/common/libflux/libflux.la \
         $(top_builddir)/src/common/libflux-internal.la \
         $(top_builddir)/src/common/libtap/libtap.la \
-        $(ZMQ_LIBS) $(JANSSON_LIBS) $(LIBPTHREAD) $(LIBRT) \
-        $(FLUX_SECURITY_LIBS) $(LIBDL) $(LIBSODIUM_LIBS)
+        $(ZMQ_LIBS) \
+	$(LIBUUID_LIBS) \
+	$(JANSSON_LIBS) \
+	$(LIBPTHREAD) \
+	$(LIBRT) \
+        $(FLUX_SECURITY_LIBS) \
+	$(LIBDL) \
+	$(LIBSODIUM_LIBS)
 
 test_cppflags = \
         $(AM_CPPFLAGS) \

--- a/src/common/libkvs/Makefile.am
+++ b/src/common/libkvs/Makefile.am
@@ -9,7 +9,8 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
 	-I$(top_builddir)/src/common/libflux \
-	$(ZMQ_CFLAGS)
+	$(ZMQ_CFLAGS) \
+	$(LIBUUID_CFLAGS)
 
 noinst_LTLIBRARIES = libkvs.la
 
@@ -62,7 +63,12 @@ test_ldadd = \
 	$(top_builddir)/src/common/libflux/libflux.la \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libtap/libtap.la \
-	$(ZMQ_LIBS) $(JANSSON_LIBS) $(LIBPTHREAD) $(LIBRT) $(LIBDL)
+	$(ZMQ_LIBS) \
+	$(LIBUUID_LIBS) \
+	$(JANSSON_LIBS) \
+	$(LIBPTHREAD) \
+	$(LIBRT) \
+	$(LIBDL)
 
 test_cppflags = \
 	$(AM_CPPFLAGS) \

--- a/src/common/libpmi/Makefile.am
+++ b/src/common/libpmi/Makefile.am
@@ -9,7 +9,8 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
 	-I$(top_builddir)/src/common/libflux \
-	$(ZMQ_CFLAGS)
+	$(ZMQ_CFLAGS) \
+	$(LIBUUID_CFLAGS)
 
 noinst_LTLIBRARIES = \
 	libpmi_client.la \
@@ -56,8 +57,12 @@ test_ldadd = \
 	$(top_builddir)/src/common/liblsd/liblsd.la \
 	$(top_builddir)/src/common/libtomlc99/libtomlc99.la \
 	$(top_builddir)/src/common/libev/libev.la \
-	$(ZMQ_LIBS) $(JANSSON_LIBS) $(LIBPTHREAD) \
-	$(LIBRT) $(LIBDL)
+	$(ZMQ_LIBS) \
+	$(LIBUUID_LIBS) \
+	$(JANSSON_LIBS) \
+	$(LIBPTHREAD) \
+	$(LIBRT) \
+	$(LIBDL)
 
 test_cppflags = \
 	-I$(top_srcdir)/src/common/libtap \

--- a/src/common/librouter/Makefile.am
+++ b/src/common/librouter/Makefile.am
@@ -9,7 +9,8 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
 	-I$(top_builddir)/src/common/libflux \
-	$(ZMQ_CFLAGS)
+	$(ZMQ_CFLAGS) \
+	$(LIBUUID_CFLAGS)
 
 noinst_LTLIBRARIES = \
 	librouter.la

--- a/src/common/libtestutil/Makefile.am
+++ b/src/common/libtestutil/Makefile.am
@@ -9,7 +9,8 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
 	-I$(top_builddir)/src/common/libflux \
-	$(ZMQ_CFLAGS)
+	$(ZMQ_CFLAGS) \
+	$(LIBUUID_CFLAGS)
 
 check_LTLIBRARIES = libtestutil.la
 

--- a/src/common/libutil/Makefile.am
+++ b/src/common/libutil/Makefile.am
@@ -2,6 +2,7 @@ AM_CFLAGS = \
 	$(WARNING_CFLAGS) \
 	$(CODE_COVERAGE_CFLAGS) \
 	$(ZMQ_CFLAGS) \
+	$(LIBUUID_CFLAGS) \
 	-Wno-strict-aliasing -Wno-error=strict-aliasing \
 	-Wno-parentheses -Wno-error=parentheses
 
@@ -127,7 +128,11 @@ test_ldadd = \
 	$(top_builddir)/src/common/liblsd/liblsd.la \
 	$(top_builddir)/src/common/libev/libev.la \
 	$(top_builddir)/src/common/libtomlc99/libtomlc99.la \
-	$(ZMQ_LIBS) $(LIBPTHREAD) $(LIBRT) $(JANSSON_LIBS)
+	$(ZMQ_LIBS) \
+	$(LIBUUID_LIBS) \
+	$(LIBPTHREAD) \
+	$(LIBRT) \
+	$(JANSSON_LIBS)
 
 test_cppflags = \
 	-I$(top_srcdir)/src/common/libtap \

--- a/src/connectors/local/Makefile.am
+++ b/src/connectors/local/Makefile.am
@@ -9,7 +9,8 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
 	-I$(top_builddir)/src/common/libflux \
-	$(ZMQ_CFLAGS)
+	$(ZMQ_CFLAGS) \
+	$(LIBUUID_CFLAGS)
 
 fluxconnector_LTLIBRARIES = local.la
 
@@ -22,4 +23,5 @@ local_la_LDFLAGS = -module $(san_ld_zdef_flag) \
 local_la_LIBADD = \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la \
-	$(ZMQ_LIBS)
+	$(ZMQ_LIBS) \
+	$(LIBUUID_LIBS)

--- a/src/connectors/loop/Makefile.am
+++ b/src/connectors/loop/Makefile.am
@@ -9,7 +9,8 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
 	-I$(top_builddir)/src/common/libflux \
-	$(ZMQ_CFLAGS)
+	$(ZMQ_CFLAGS) \
+	$(LIBUUID_CFLAGS)
 
 fluxconnector_LTLIBRARIES = loop.la
 
@@ -22,4 +23,5 @@ loop_la_LDFLAGS = -module $(san_ld_zdef_flag) \
 loop_la_LIBADD = \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la \
-	$(ZMQ_LIBS)
+	$(ZMQ_LIBS) \
+	$(LIBUUID_LIBS)

--- a/src/connectors/shmem/Makefile.am
+++ b/src/connectors/shmem/Makefile.am
@@ -9,7 +9,8 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
 	-I$(top_builddir)/src/common/libflux \
-	$(ZMQ_CFLAGS)
+	$(ZMQ_CFLAGS) \
+	$(LIBUUID_CFLAGS)
 
 fluxconnector_LTLIBRARIES = shmem.la
 
@@ -22,4 +23,5 @@ shmem_la_LDFLAGS = -module $(san_ld_zdef_flag) \
 shmem_la_LIBADD = \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la \
-	$(ZMQ_LIBS)
+	$(ZMQ_LIBS) \
+	$(LIBUUID_LIBS)

--- a/src/connectors/ssh/Makefile.am
+++ b/src/connectors/ssh/Makefile.am
@@ -9,7 +9,8 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
 	-I$(top_builddir)/src/common/libflux \
-	$(ZMQ_CFLAGS)
+	$(ZMQ_CFLAGS) \
+	$(LIBUUID_CFLAGS)
 
 fluxconnector_LTLIBRARIES = ssh.la
 
@@ -22,4 +23,5 @@ ssh_la_LDFLAGS = -module $(san_ld_zdef_flag) \
 ssh_la_LIBADD = \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la \
-	$(ZMQ_LIBS)
+	$(ZMQ_LIBS) \
+	$(LIBUUID_LIBS)


### PR DESCRIPTION
Since zuuid asserts when `/dev/urandom` cannot be opened (as hit recently in #2593), this PR replaces it with `libuuid`, a better option because it implements an internal fallback to pseudo-random when that happens, and also because its functions don't require error checking.

Unfortunately, this adds a new dependency, but one we already required in flux-security.

This fixes #2281 
