### PR TITLE
docker: add image and travis tests on CentOS 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,12 +88,12 @@ jobs:
        - IMG=centos7
        - DOCKER_TAG=t
        - PYTHON_VERSION=2.7
-    - name: "Centos 7: py3.6 --with-flux-security"
+    - name: "Centos 8: py3.6 --with-flux-security"
       stage: test
       compiler: gcc
       env:
        - ARGS="--with-flux-security --prefix=/usr"
-       - IMG=centos7
+       - IMG=centos8
        - PYTHON_VERSION=3.6
 
 stages:

--- a/configure.ac
+++ b/configure.ac
@@ -304,7 +304,7 @@ AS_IF([test "x$enable_pylint" = "xyes"], [
 ])
 AM_CONDITIONAL([ENABLE_PYLINT], [test "x$PYLINT" = "xpylint"])
 
-AX_PROG_LUA([5.1],[5.3])
+AX_PROG_LUA([5.1],[5.4])
 AX_LUA_HEADERS
 AX_LUA_LIBS
 X_AC_ZEROMQ

--- a/src/test/docker/centos8/Dockerfile
+++ b/src/test/docker/centos8/Dockerfile
@@ -1,0 +1,98 @@
+FROM centos:8
+
+LABEL maintainer="Mark Grondona <mgrondona@llnl.gov>"
+
+#  Enable PowerTools for development packages
+RUN yum -y update \
+ && dnf -y install 'dnf-command(config-manager)' \
+ && yum config-manager --set-enabled PowerTools \
+ && yum -y update
+
+#  Enable EPEL
+RUN yum -y install epel-release
+
+#  Utilities
+RUN yum -y install \
+	wget \
+	man-db \
+	git \
+	sudo \
+	ruby \
+	munge \
+	ccache \
+	lua \
+	mpich \
+	valgrind \
+	jq \
+	which \
+	file \
+	vim
+
+#  Compilers, autotools
+RUN yum -y install \
+	pkgconfig \
+	libtool \
+	autoconf \
+	automake \
+	gcc \
+	gcc-c++ \
+	make \
+	cmake
+	
+#  Python
+RUN yum -y install \
+	python36 \
+	python3-devel \
+	python3-cffi \
+	python3-six \
+	python3-yaml \
+	python3-jsonschema
+
+#  Development dependencies
+RUN yum -y install \
+	libsodium-devel \
+        zeromq-devel \
+	czmq-devel \
+	jansson-devel \
+	munge-devel \
+	lz4-devel \
+	sqlite-devel \
+	libuuid-devel \
+	hwloc-devel \
+	mpich-devel \
+	lua-devel \
+	valgrind-devel
+
+#  Other deps
+RUN yum -y install \
+	perl-Time-HiRes \
+	lua-posix \
+	libfaketime \
+	cppcheck \
+	aspell \
+	aspell-en
+
+#  Clean up
+RUN yum clean all
+
+#  Set default /usr/bin/python to python3
+RUN alternatives --set python /usr/bin/python3
+
+#  Add /usr/bin/mpicc link so MPI tests are built
+RUN alternatives --install /usr/bin/mpicc mpicc /usr/lib64/mpich/bin/mpicc 100
+
+RUN /usr/bin/gem install asciidoctor
+
+# Install caliper by hand for now:
+RUN mkdir caliper \
+ && cd caliper \
+ && wget -O - https://github.com/LLNL/Caliper/archive/v1.7.0.tar.gz | tar xvz --strip-components 1 \
+ && mkdir build \
+ && cd build \
+ && cmake .. -DCMAKE_INSTALL_PREFIX=/usr \
+ && make -j 4 \
+ && make install \
+ && cd ../.. \
+ && rm -rf caliper
+
+COPY config.site /usr/share/config.site

--- a/src/test/docker/centos8/config.site
+++ b/src/test/docker/centos8/config.site
@@ -1,0 +1,6 @@
+# Force libdir to /usr/lib64 if prefix=/usr on this platform
+if test "$prefix" = "/usr" ; then
+    test $sysconfdir = "${prefix}/etc" && sysconfdir=/etc
+    libdir=/usr/lib64
+fi
+:


### PR DESCRIPTION
This PR adds a new Dockerfile for CentOS 8 in `src/test/docker/centos8/Dockerfile`. An image from this Dockerfile has already been pushed up to Docker Hub as `fluxrm/testenv:centos8`.

Additionally, one of the CentOS builds in Travis-CI is updated to CentOS 8 (python 3.6 build)