### PR TITLE
job-ingest,python/job: switch to a py bindings based jobspec validator

### DIFF
--- a/src/bindings/python/flux/job.py
+++ b/src/bindings/python/flux/job.py
@@ -40,7 +40,15 @@ class JobWrapper(Wrapper):
 RAW = JobWrapper()
 
 
-def submit_async(flux_handle, jobspec, priority=lib.FLUX_JOB_PRIORITY_DEFAULT, flags=0):
+def _convert_jobspec_arg_to_string(jobspec):
+    """
+    Convert a jobspec argument into a string.  A valid jobspec argument is:
+    - An instance of the Jobspec class
+    - A string (i.e., bytes, str, or unicode)
+
+    :raises EnvironmentError: jobspec is None or NULL
+    :raises TypeError: jobspec is neither a Jobspec nor a string
+    """
     if isinstance(jobspec, Jobspec):
         jobspec = jobspec.dumps()
     elif isinstance(jobspec, six.text_type):
@@ -49,8 +57,14 @@ def submit_async(flux_handle, jobspec, priority=lib.FLUX_JOB_PRIORITY_DEFAULT, f
         # catch this here rather than in C for a better error message
         raise EnvironmentError(errno.EINVAL, "jobspec must not be None/NULL")
     elif not isinstance(jobspec, six.binary_type):
-        raise TypeError("jobpsec must be a string (either binary or unicode)")
+        raise TypeError(
+            "jobpsec must be a Jobspec or string (either binary or unicode)"
+        )
+    return jobspec
 
+
+def submit_async(flux_handle, jobspec, priority=lib.FLUX_JOB_PRIORITY_DEFAULT, flags=0):
+    jobspec = _convert_jobspec_arg_to_string(jobspec)
     future_handle = RAW.submit(flux_handle, jobspec, priority, flags)
     return Future(future_handle)
 
@@ -133,6 +147,37 @@ def _validate_keys(expected, given, keys_optional=False, allow_additional=False)
             raise ValueError("Extraneous key ({})".format(extraneous_key))
 
 
+def validate_jobspec(jobspec, require_version=None):
+    """
+    Validates the jobspec by attempting to construct a Jobspec object.  If no
+    exceptions are thrown during construction, then the jobspec is assumed to be
+    valid and this function returns True.  If the jobspec is invalid, the
+    relevant exception is thrown (i.e., TypeError, ValueError, EnvironmentError)
+
+    By default, the validation function will read the `version` key in the
+    jobspec to determine which Jobspec object to instantiate. An optional
+    `require_version` is included to override this behavior and force a
+    particular class to be used.
+
+    :param jobspec: a Jobspec object or JSON string
+    :param require_version: jobspec version to use, if not provided,
+                            the value of jobspec['version'] is used
+    :raises ValueError:
+    :raises TypeError:
+    :raises EnvironmentError:
+    """
+    jobspec_str = _convert_jobspec_arg_to_string(jobspec)
+    jobspec_obj = json.loads(jobspec_str)
+    if jobspec_obj is None:
+        return (1, "Unable to parse JSON")
+    _validate_keys(Jobspec.top_level_keys, jobspec_obj.keys())
+    if require_version == 1 or jobspec_obj.get("version", 0) == 1:
+        JobspecV1(**jobspec_obj)
+    else:
+        Jobspec(**jobspec_obj)
+    return True
+
+
 class Jobspec(object):
     top_level_keys = set(["resources", "tasks", "version", "attributes"])
 
@@ -147,6 +192,8 @@ class Jobspec(object):
         :param attributes: dictionary following the specification in RFC14 for
                            the `attributes` top-level key
         :param version: included to allow for usage like JobspecV1(**jobspec)
+        :raises ValueError:
+        :raises TypeError:
         """
 
         # ensure that no unknown keyword arguments are used

--- a/src/bindings/python/flux/job.py
+++ b/src/bindings/python/flux/job.py
@@ -153,7 +153,7 @@ class Jobspec(object):
         _validate_keys(
             ["attributes", "version"],
             kwargs,
-            keys_optional=True,
+            keys_optional=False,
             allow_additional=False,
         )
 

--- a/src/common/libflux/Makefile.am
+++ b/src/common/libflux/Makefile.am
@@ -35,8 +35,8 @@ installed_conf_cppflags = \
 	-DINSTALLED_NO_DOCS_PATH=\"${datadir}/flux/.nodocs\" \
 	-DINSTALLED_RUNDIR=\"${runstatedir}/flux\" \
 	-DINSTALLED_BINDIR=\"$(fluxcmddir)\" \
-	-DINSTALLED_JOBSPEC_VALIDATE_PATH=\"${fluxlibexecdir}/validate-schema.py\" \
-	-DINSTALLED_JOBSPEC_VALIDATOR_ARGS=\"--schema,${datadir}/flux/schema/jobspec/jobspec_v1.jsonschema\"
+	-DINSTALLED_JOBSPEC_VALIDATE_PATH=\"${fluxlibexecdir}/validate-jobspec.py\" \
+	-DINSTALLED_JOBSPEC_VALIDATOR_ARGS=\"\"
 
 intree_conf_cppflags = \
 	-DINTREE_MODULE_PATH=\"$(abs_top_builddir)/src/modules\" \
@@ -58,8 +58,8 @@ intree_conf_cppflags = \
 	-DINTREE_KEYDIR=\"${abs_top_builddir}/etc/flux\" \
 	-DINTREE_NO_DOCS_PATH=\"${abs_top_builddir}/etc/flux/.nodocs\" \
 	-DINTREE_BINDIR=\"${abs_top_builddir}/src/cmd\" \
-	-DINTREE_JOBSPEC_VALIDATE_PATH=\"${abs_top_srcdir}/src/modules/job-ingest/validators/validate-schema.py\" \
-	-DINTREE_JOBSPEC_VALIDATOR_ARGS=\"--schema,${abs_top_srcdir}/src/modules/job-ingest/schemas/jobspec_v1.jsonschema\"
+	-DINTREE_JOBSPEC_VALIDATE_PATH=\"${abs_top_srcdir}/src/modules/job-ingest/validators/validate-jobspec.py\" \
+	-DINTREE_JOBSPEC_VALIDATOR_ARGS=\"\"
 
 
 fluxcoreinclude_HEADERS = \

--- a/src/common/libflux/Makefile.am
+++ b/src/common/libflux/Makefile.am
@@ -36,7 +36,7 @@ installed_conf_cppflags = \
 	-DINSTALLED_RUNDIR=\"${runstatedir}/flux\" \
 	-DINSTALLED_BINDIR=\"$(fluxcmddir)\" \
 	-DINSTALLED_JOBSPEC_VALIDATE_PATH=\"${fluxlibexecdir}/validate-schema.py\" \
-	-DINSTALLED_JOBSPEC_SCHEMA_PATH=\"${datadir}/flux/schema/jobspec/jobspec_v1.jsonschema\"
+	-DINSTALLED_JOBSPEC_VALIDATOR_ARGS=\"--schema,${datadir}/flux/schema/jobspec/jobspec_v1.jsonschema\"
 
 intree_conf_cppflags = \
 	-DINTREE_MODULE_PATH=\"$(abs_top_builddir)/src/modules\" \
@@ -59,7 +59,7 @@ intree_conf_cppflags = \
 	-DINTREE_NO_DOCS_PATH=\"${abs_top_builddir}/etc/flux/.nodocs\" \
 	-DINTREE_BINDIR=\"${abs_top_builddir}/src/cmd\" \
 	-DINTREE_JOBSPEC_VALIDATE_PATH=\"${abs_top_srcdir}/src/modules/job-ingest/validators/validate-schema.py\" \
-	-DINTREE_JOBSPEC_SCHEMA_PATH=\"${abs_top_srcdir}/src/modules/job-ingest/schemas/jobspec_v1.jsonschema\"
+	-DINTREE_JOBSPEC_VALIDATOR_ARGS=\"--schema,${abs_top_srcdir}/src/modules/job-ingest/schemas/jobspec_v1.jsonschema\"
 
 
 fluxcoreinclude_HEADERS = \

--- a/src/common/libflux/conf.c
+++ b/src/common/libflux/conf.c
@@ -63,8 +63,8 @@ static struct builtin builtin_tab[] = {
     { "bindir",         INSTALLED_BINDIR,           INTREE_BINDIR },
     { "jobspec_validate_path", INSTALLED_JOBSPEC_VALIDATE_PATH,
                                             INTREE_JOBSPEC_VALIDATE_PATH },
-    { "jobspec_schema_path", INSTALLED_JOBSPEC_SCHEMA_PATH,
-                                            INTREE_JOBSPEC_SCHEMA_PATH },
+    { "jobspec_validator_args", INSTALLED_JOBSPEC_VALIDATOR_ARGS,
+                                            INTREE_JOBSPEC_VALIDATOR_ARGS },
     { NULL, NULL, NULL },
 };
 

--- a/src/modules/job-ingest/Makefile.am
+++ b/src/modules/job-ingest/Makefile.am
@@ -31,7 +31,8 @@ job_ingest_la_LIBADD = $(fluxmod_libadd) \
 		    $(ZMQ_LIBS)
 
 dist_fluxlibexec_SCRIPTS = \
-	validators/validate-schema.py
+	validators/validate-schema.py \
+	validators/validate-jobspec.py
 
 fluxschemadir = $(datadir)/flux/schema/jobspec/
 dist_fluxschema_DATA = \

--- a/src/modules/job-ingest/job-ingest.c
+++ b/src/modules/job-ingest/job-ingest.c
@@ -596,7 +596,7 @@ static const struct flux_msg_handler_spec htab[] = {
 };
 
 /* Configure the validator.
- * Use compiled in paths for validator program and schema,
+ * Use compiled in path and string for validator program and args,
  * unless overridden with validator=path or schema=path on module load
  * command line.
  */
@@ -606,21 +606,17 @@ int validate_initialize (flux_t *h,
                          struct validate **validate)
 {
     const char *usage_message = "Usage: flux module load [OPTIONS] job-ingest "
-                                " [schema=PATH] [validator=PATH]";
+                                " [validator-args=ARGS] [validator=PATH]";
     const char *valpath;
-    const char *schpath;
+    const char *valargs;
     struct validate *v;
     int i;
 
     valpath = flux_conf_builtin_get ("jobspec_validate_path", FLUX_CONF_AUTO);
-    schpath = flux_conf_builtin_get ("jobspec_schema_path", FLUX_CONF_AUTO);
+    valargs = flux_conf_builtin_get ("jobspec_validator_args", FLUX_CONF_AUTO);
     for (i = 0; i < argc; i++) {
-        if (!strncmp (argv[i], "schema=", 7)) {
-            schpath = argv[i] + 7;
-            if (access (schpath, R_OK) < 0) {
-                flux_log_error (h, "schema %s", schpath);
-                return -1;
-            }
+        if (!strncmp (argv[i], "validator-args=", 15)) {
+            valargs = argv[i] + 15;
         }
         else if (!strncmp (argv[i], "validator=", 10)) {
             valpath = argv[i] + 10;
@@ -636,7 +632,7 @@ int validate_initialize (flux_t *h,
             return -1;
         }
     }
-    if (!(v = validate_create (h, valpath, schpath))) {
+    if (!(v = validate_create (h, valpath, valargs))) {
         flux_log_error (h, "validate_create");
         return -1;
     }

--- a/src/modules/job-ingest/validate.h
+++ b/src/modules/job-ingest/validate.h
@@ -22,7 +22,7 @@ flux_future_t *validate_jobspec (struct validate *v, const char *buf, int len);
 
 struct validate *validate_create (flux_t *h,
                                   const char *validate_path,
-                                  const char *schema_path);
+                                  const char *validator_args);
 
 void validate_destroy (struct validate *v);
 

--- a/src/modules/job-ingest/validators/validate-jobspec.py
+++ b/src/modules/job-ingest/validators/validate-jobspec.py
@@ -1,0 +1,60 @@
+##############################################################
+#  Copyright 2018 Lawrence Livermore National Security, LLC
+#  (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+#  This file is part of the Flux resource manager framework.
+#  For details, see https://github.com/flux-framework.
+#
+#  SPDX-License-Identifier: LGPL-3.0
+##############################################################
+
+from __future__ import print_function
+
+import sys
+import json
+import argparse
+
+from flux.job import validate_jobspec
+
+
+def emit(object_dict):
+    s = json.dumps(object_dict, separators=(",", ":"))
+    print(s)
+    sys.stdout.flush()
+
+
+print("ready", file=sys.stderr)
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--require-version", type=int)
+args = parser.parse_args()
+
+if args.require_version is not None:
+    if args.require_version < 1:
+        print(
+            "Required version too low: {} is < 1".format(args.require_version),
+            file=sys.stderr,
+        )
+        exit(1)
+    elif args.require_version > 1:
+        print(
+            "Required version too high: {} is > 1".format(args.require_version),
+            file=sys.stderr,
+        )
+        exit(1)
+
+while True:
+    line = sys.stdin.readline()
+    if line == "":
+        break
+    errnum, errstr = (0, None)
+    try:
+        validate_jobspec(line, args.require_version)
+    except (ValueError, TypeError, EnvironmentError) as e:
+        errnum, errstr = (1, str(e))
+    if errstr != None:
+        emit({"errnum": errnum, "errstr": errstr})
+    else:
+        emit({"errnum": errnum})
+
+print("exiting", file=sys.stderr)

--- a/t/t2200-job-ingest.t
+++ b/t/t2200-job-ingest.t
@@ -59,16 +59,14 @@ test_expect_success 'job-ingest: submit fails without job-ingest' '
 test_expect_success 'job-ingest: job-ingest fails with bad option' '
 	test_must_fail flux module load job-ingest badopt=xyz
 '
+
 test_expect_success 'job-ingest: job-ingest fails with bad validator path' '
 	test_must_fail flux module load job-ingest validator=/noexist
-'
-test_expect_success 'job-ingest: job-ingest fails with bad schema path' '
-	test_must_fail flux module load job-ingest schema=/noexist
 '
 
 test_expect_success 'job-ingest: load job-ingest && job-info' '
 	flux exec -r all flux module load job-ingest \
-		schema=${SCHEMA} validator=${PY_VALIDATOR} &&
+		validator-args=--schema,${SCHEMA} validator=${PY_VALIDATOR} &&
 	flux exec -r all flux module load job-info
 '
 
@@ -154,7 +152,7 @@ test_expect_success 'submit request with empty payload fails with EPROTO(71)' '
 test_expect_success 'job-ingest: test non-python validator' '
 	flux exec -r all flux module remove job-ingest &&
 	flux exec -r all flux module load job-ingest \
-		schema=${SCHEMA} validator=${FAKE_VALIDATOR}
+		validator=${FAKE_VALIDATOR}
 '
 
 test_expect_success 'job-ingest: submit succeeds with non-python validator' '

--- a/t/t2300-sched-simple.t
+++ b/t/t2300-sched-simple.t
@@ -13,7 +13,9 @@ query=${FLUX_BUILD_DIR}/src/modules/sched-simple/rlist-query
 hwloc_by_rank='{"0-1": {"Core": 2, "cpuset": "0-1"}}'
 hwloc_by_rank_first_fit='{"0": {"Core": 2}, "1": {"Core": 1}}'
 
+
 SCHEMA=${FLUX_SOURCE_DIR}/src/modules/job-ingest/schemas/jobspec.jsonschema
+JSONSCHEMA_VALIDATOR=${FLUX_SOURCE_DIR}/src/modules/job-ingest/validators/validate-schema.py
 
 kvs_job_dir() {
 	flux job id --to=kvs $1
@@ -26,7 +28,8 @@ list_R() {
 
 test_expect_success 'sched-simple: reload ingest module with lax validator' '
         flux exec -r all flux module remove job-ingest &&
-	flux exec -r all flux module load job-ingest schema=${SCHEMA}
+	flux exec -r all flux module load job-ingest validator-args="--schema,${SCHEMA}" \
+         validator=${JSONSCHEMA_VALIDATOR}
 '
 test_expect_success 'sched-simple: generate jobspec for simple test job' '
         flux jobspec srun -n1 hostname >basic.json


### PR DESCRIPTION
Adds a new jobspec validator that uses the (also new) validation function within the python bindings rather than jsonschema to validate user-submitted jobspec.

Sets this new validator as the default for the job-ingest module since it should provide more meaningful error messages to the user than jsonschema does.  I haven't seen a huge performance difference on my local machine, but I'd expect it to be faster on a busy filesystem since it does not require reading in a jsonschema file.

Error output from the jsonschema validator on our invalid jobspec examples:
```
→ for x in ./*.json; do cat $x; echo ""; done | ../../../src/cmd/flux python ../../../src/modules/job-ingest/validators/validate-schema.py --schema ../../../src/modules/job-ingest/schemas/jobspec.jsonschema
ready
{"errnum":1,"errstr":"Additional properties are not allowed ('foo' was unexpected)"}
{"errnum":1,"errstr":"1 is not of type 'object', 'null'"}
{"errnum":1,"errstr":"'attributes' is a required property"}
{"errnum":1,"errstr":"'resources' is a required property"}
{"errnum":1,"errstr":"'tasks' is a required property"}
{"errnum":1,"errstr":"'version' is a required property"}
{"errnum":1,"errstr":"{'count': [1, 2], 'with': [{'count': 1, 'type': 'node'}], 'type': 'slot', 'label': 'foo'} is not valid under any of the given schemas"}
{"errnum":1,"errstr":"{'count': {'operator': '+', 'operand': 1, 'min': 1}, 'with': [{'count': 1, 'type': 'node'}], 'type': 'slot', 'label': 'foo'} is not valid under any of the given schemas"}
{"errnum":1,"errstr":"{'count': {'operator': '+', 'max': 2, 'operand': 1}, 'with': [{'count': 1, 'type': 'node'}], 'type': 'slot', 'label': 'foo'} is not valid under any of the given schemas"}
{"errnum":1,"errstr":"{'count': {'operator': '+', 'max': 2, 'min': 1}, 'with': [{'count': 1, 'type': 'node'}], 'type': 'slot', 'label': 'foo'} is not valid under any of the given schemas"}
{"errnum":1,"errstr":"{'count': {'operand': 1, 'max': 2, 'min': 1}, 'with': [{'count': 1, 'type': 'node'}], 'type': 'slot', 'label': 'foo'} is not valid under any of the given schemas"}
{"errnum":1,"errstr":"{'count': 'bar', 'with': [{'count': 1, 'type': 'node'}], 'type': 'slot', 'label': 'foo'} is not valid under any of the given schemas"}
{"errnum":1,"errstr":"{'count': 1, 'with': [{'count': 1, 'exclusive': 'blah', 'type': 'node'}], 'type': 'slot', 'label': 'foo'} is not valid under any of the given schemas"}
{"errnum":1,"errstr":"{'count': 1, 'exclusive': ['foo', 'bar'], 'type': 'slot', 'with': [{'count': 1, 'type': 'node'}], 'label': 'foo'} is not valid under any of the given schemas"}
{"errnum":1,"errstr":"{'count': 1, 'with': [{'count': 1, 'type': 'node'}], 'type': 'slot', 'id': ['foo', 'bar'], 'label': 'foo'} is not valid under any of the given schemas"}
{"errnum":1,"errstr":"{'count': 1, 'with': [{'count': 1, 'type': 'node'}], 'type': 'slot', 'label': ['foo', 'bar']} is not valid under any of the given schemas"}
{"errnum":1,"errstr":"{'count': 1, 'with': [{'type': 'node'}], 'type': 'slot', 'label': 'foo'} is not valid under any of the given schemas"}
{"errnum":1,"errstr":"{'count': 1, 'with': [{'count': 1}], 'type': 'slot', 'label': 'foo'} is not valid under any of the given schemas"}
{"errnum":1,"errstr":"[{'type': 'slot'}, {'count': 1}, {'label': 'foo'}, {'with': [{'count': 1, 'type': 'node'}]}] is not valid under any of the given schemas"}
{"errnum":1,"errstr":"{'count': 1, 'with': [{'count': 1, 'type': 'node'}], 'type': 'slot'} is not valid under any of the given schemas"}
{"errnum":1,"errstr":"{'count': 1, 'with': [{'count': 1, 'type': 'node'}], 'type': 'slot', 'label': 'foo'} is not of type 'array'"}
{"errnum":1,"errstr":"{'count': 1, 'with': [{'count': 1, 'type': 'node'}], 'type': 'slot', 'unit': ['foo', 'bar'], 'label': 'foo'} is not valid under any of the given schemas"}
{"errnum":1,"errstr":"'app' is not of type 'array'"}
{"errnum":1,"errstr":"1 is not of type 'object'"}
{"errnum":1,"errstr":"'command' is a required property"}
{"errnum":1,"errstr":"'count' is a required property"}
{"errnum":1,"errstr":"'slot' is a required property"}
{"errnum":1,"errstr":"'foo' is not of type 'object'"}
{"errnum":1,"errstr":"{'slot': 'foo', 'count': {'per_slot': 1}, 'command': ['app']} is not of type 'array'"}
{"errnum":1,"errstr":"4.2 is not of type 'integer'"}
{"errnum":1,"errstr":"{'foo': 1} is not of type 'integer'"}
exiting
```

Error output from the bindings validator on our invalid jobspec examples:
```
→ for x in ./*.json; do cat $x; echo ""; done | ../../../src/cmd/flux python ../../../src/modules/job-ingest/validators/validate-jobspec.py
ready
{"errnum":1,"errstr":"Extraneous key (foo)"}
{"errnum":1,"errstr":"attributes must be a mapping"}
{"errnum":1,"errstr":"Missing key (attributes)"}
{"errnum":1,"errstr":"Missing key (resources)"}
{"errnum":1,"errstr":"Missing key (tasks)"}
{"errnum":1,"errstr":"Missing key (version)"}
{"errnum":1,"errstr":"count must be an int or mapping"}
{"errnum":1,"errstr":"Missing key (max)"}
{"errnum":1,"errstr":"min must be in range"}
{"errnum":1,"errstr":"Missing key (operand)"}
{"errnum":1,"errstr":"Missing key (operator)"}
{"errnum":1,"errstr":"count must be an int or mapping"}
{"errnum":1,"errstr":"exclusive must be a boolean"}
{"errnum":1,"errstr":"exclusive must be a boolean"}
{"errnum":1,"errstr":"id must be a string"}
{"errnum":1,"errstr":"label must be a string"}
{"errnum":1,"errstr":"count is a required key for resources"}
{"errnum":1,"errstr":"type is a required key for resources"}
{"errnum":1,"errstr":"resource must be a mapping"}
{"errnum":1,"errstr":"slots must have labels"}
{"errnum":1,"errstr":"resources must be a sequence"}
{"errnum":1,"errstr":"unit must be a string"}
{"errnum":1,"errstr":"command must be a list of strings"}
{"errnum":1,"errstr":"count must be a mapping"}
{"errnum":1,"errstr":"Missing key (command)"}
{"errnum":1,"errstr":"Missing key (count)"}
{"errnum":1,"errstr":"Missing key (slot)"}
{"errnum":1,"errstr":"task must be a mapping"}
{"errnum":1,"errstr":"tasks must be a sequence"}
{"errnum":1,"errstr":"version must be an integer"}
{"errnum":1,"errstr":"version must be an integer"}
exiting
```