### PR TITLE
libtomlc99: fix use after free

### DIFF
--- a/doc/man1/flux-jobs.adoc
+++ b/doc/man1/flux-jobs.adoc
@@ -93,8 +93,3 @@ Github: <http://github.com/flux-framework>
 COPYRIGHT
 ---------
 include::COPYRIGHT.adoc[]
-
-
-SEE ALSO
---------
-syslog(3)

--- a/src/common/libtomlc99/test/toml.c
+++ b/src/common/libtomlc99/test/toml.c
@@ -1,3 +1,13 @@
+/************************************************************\
+ * Copyright 2017 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif


### PR DESCRIPTION
This fixes #2630.  I tossed in a couple other minor fixes: a missed copyright header, and a cut-and-paste error in the `flux-jobs(1)` man page.