### PR TITLE
flux job list: make filtering options match flux jobs(1)

### DIFF
--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -76,6 +76,12 @@ static struct optparse_option list_opts[] =  {
       .usage = "Limit output to specific userid. " \
                "Specify \"all\" for all users.",
     },
+    { .name = "all-user", .key = 'a', .has_arg = 0,
+      .usage = "List my jobs, regardless of state",
+    },
+    { .name = "all", .key = 'A', .has_arg = 0,
+      .usage = "List jobs for all users, regardless of state",
+    },
     OPTPARSE_TABLE_END
 };
 
@@ -637,6 +643,8 @@ int cmd_list (optparse_t *p, int argc, char **argv)
         else
             log_msg_exit ("error parsing --states: %s is unknown", arg);
     }
+    if (optparse_hasopt (p, "all-user") || optparse_hasopt (p, "all"))
+        state_mask = FLUX_JOB_ACTIVE | FLUX_JOB_INACTIVE;
     if ((state_mask & FLUX_JOB_PENDING) != 0)
         flags |= FLUX_JOB_LIST_PENDING;
     if ((state_mask & FLUX_JOB_RUNNING) != 0)
@@ -661,6 +669,8 @@ int cmd_list (optparse_t *p, int argc, char **argv)
                 log_msg_exit ("error parsing userid: \"%s\"", arg);
         }
     }
+    if (optparse_hasopt (p, "all"))
+        userid = FLUX_USERID_UNKNOWN;
 
     if (!(f = flux_job_list (h, max_entries, attrs, userid, flags)))
         log_err_exit ("flux_job_list");

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -68,14 +68,9 @@ static struct optparse_option list_opts[] =  {
     { .name = "count", .key = 'c', .has_arg = 1, .arginfo = "N",
       .usage = "Limit output to N jobs",
     },
-    { .name = "pending", .key = 'p', .has_arg = 0,
-      .usage = "List pending jobs",
-    },
-    { .name = "running", .key = 'r', .has_arg = 0,
-      .usage = "List running jobs",
-    },
-    { .name = "inactive", .key = 'i', .has_arg = 0,
-      .usage = "List inactive jobs",
+    { .name = "states", .key = 's', .has_arg = 1, .arginfo = "STATES",
+      .flags = OPTPARSE_OPT_AUTOSPLIT,
+      .usage = "List jobs in specific states",
     },
     { .name = "userid", .key = 'u', .has_arg = 1, .arginfo = "UID",
       .usage = "Limit output to specific userid. " \
@@ -616,8 +611,9 @@ int cmd_list (optparse_t *p, int argc, char **argv)
     size_t index;
     json_t *value;
     uint32_t userid = geteuid ();
-    const char *userid_str;
+    const char *arg;
     int flags = 0;
+    int state_mask = 0;
 
     if (optindex != argc) {
         optparse_print_usage (p);
@@ -626,26 +622,43 @@ int cmd_list (optparse_t *p, int argc, char **argv)
     if (!(h = flux_open (NULL, 0)))
         log_err_exit ("flux_open");
 
-    if (optparse_hasopt (p, "pending"))
+    optparse_getopt_iterator_reset (p, "states");
+    while ((arg = optparse_getopt_next (p, "states"))) {
+        flux_job_state_t state;
+
+        if (flux_job_strtostate (arg, &state) == 0)
+            state_mask |= state;
+        else if (!strcasecmp (arg, "pending"))
+            state_mask |= FLUX_JOB_PENDING;
+        else if (!strcasecmp (arg, "running"))
+            state_mask |= FLUX_JOB_RUNNING;
+        else if (!strcasecmp (arg, "active"))
+            state_mask |= FLUX_JOB_ACTIVE;
+        else
+            log_msg_exit ("error parsing --states: %s is unknown", arg);
+    }
+    if ((state_mask & FLUX_JOB_PENDING) != 0)
         flags |= FLUX_JOB_LIST_PENDING;
-    if (optparse_hasopt (p, "running"))
+    if ((state_mask & FLUX_JOB_RUNNING) != 0)
         flags |= FLUX_JOB_LIST_RUNNING;
-    if (optparse_hasopt (p, "inactive"))
+    if ((state_mask & FLUX_JOB_INACTIVE) != 0)
         flags |= FLUX_JOB_LIST_INACTIVE;
     /* if no job listing specifics listed, default to listing pending
      * & running jobs */
-    if (!flags)
+    if (!flags) {
         flags = FLUX_JOB_LIST_PENDING | FLUX_JOB_LIST_RUNNING;
+        state_mask = FLUX_JOB_PENDING | FLUX_JOB_RUNNING;
+    }
 
-    if ((userid_str = optparse_get_str (p, "userid", NULL))) {
-        if (!strcmp (userid_str, "all"))
+    if ((arg = optparse_get_str (p, "userid", NULL))) {
+        if (!strcmp (arg, "all"))
             userid = FLUX_USERID_UNKNOWN;
         else {
             char *endptr;
             errno = 0;
-            userid = strtoul (userid_str, &endptr, 10);
+            userid = strtoul (arg, &endptr, 10);
             if (errno != 0 || (*endptr) != '\0')
-                log_msg_exit ("error parsing userid: \"%s\"", userid_str);
+                log_msg_exit ("error parsing userid: \"%s\"", arg);
         }
     }
 
@@ -655,12 +668,16 @@ int cmd_list (optparse_t *p, int argc, char **argv)
         log_err_exit ("flux_job_list");
     json_array_foreach (jobs, index, value) {
         char *str;
-
-        str = json_dumps (value, 0);
-        if (!str)
-            log_msg_exit ("json_dumps");
-        printf ("%s\n", str);
-        free (str);
+        int state;
+        if (json_unpack (value, "{s:i}", "state", &state) < 0)
+            log_msg_exit ("error parsing list response (state is missing)");
+        if ((state & state_mask) != 0) {
+            str = json_dumps (value, 0);
+            if (!str)
+                log_msg_exit ("error parsing list response");
+            printf ("%s\n", str);
+            free (str);
+        }
     }
     flux_future_destroy (f);
     flux_close (h);

--- a/src/common/libjob/job.h
+++ b/src/common/libjob/job.h
@@ -51,6 +51,14 @@ typedef enum {
     FLUX_JOB_INACTIVE               = 32,   // captive end state
 } flux_job_state_t;
 
+/* Virtual states, for convenience.
+ */
+enum {
+    FLUX_JOB_PENDING    = 6,    // (FLUX_JOB_DEPEND | FLUX_JOB_SCHED)
+    FLUX_JOB_RUNNING    = 24,   // (FLUX_JOB_RUN | FLUX_JOB_CLEANUP)
+    FLUX_JOB_ACTIVE     = 30,   // (FLUX_JOB_PENDING | FLUX_JOB_RUNNING)
+};
+
 typedef uint64_t flux_jobid_t;
 
 const char *flux_job_statetostr (flux_job_state_t state, bool single_char);

--- a/t/t2204-job-info.t
+++ b/t/t2204-job-info.t
@@ -187,7 +187,7 @@ test_expect_success HAVE_JQ 'flux job list jobs with correct userid' '
         for count in `seq 1 16`; do \
             id -u >> list_userid.exp; \
         done &&
-        flux job list -s pending,running,inactive | jq .userid > list_userid.out &&
+        flux job list -a | jq .userid > list_userid.out &&
         test_cmp list_userid.out list_userid.exp
 '
 
@@ -215,7 +215,7 @@ test_expect_success 'flux job list --userid=all works' '
 '
 
 test_expect_success HAVE_JQ 'flux job list --count works' '
-        flux job list -s pending,running,inactive --count=8 > list_count.out &&
+        flux job list -s active,inactive --count=8 > list_count.out &&
         count=$(wc -l < list_count.out) &&
         test "$count" = "8" &&
         head -n 4 list_count.out | jq .id > list_count_pending.out &&
@@ -226,7 +226,7 @@ test_expect_success HAVE_JQ 'flux job list --count works' '
 '
 
 test_expect_success HAVE_JQ 'flux job list all jobs works' '
-        flux job list -s pending,running,inactive > list_all.out &&
+        flux job list -a > list_all.out &&
         cat list_all.out | jq .id > list_all_jobids.out &&
         cat job_ids_pending.out >> list_all_jobids.exp &&
         cat job_ids_running.out >> list_all_jobids.exp &&
@@ -260,7 +260,7 @@ test_expect_success 'reload the job-info module' '
 # inactive jobs are listed by most recently completed first, so must
 # construct order based on order of jobs canceled above
 test_expect_success HAVE_JQ 'job-info: list successfully reconstructed' '
-        flux job list -s pending,running,inactive > list_reload.out &&
+        flux job list -a > list_reload.out &&
         for count in `seq 1 16`; do \
             echo "32" >> list_reload_state.exp; \
         done &&

--- a/t/t2204-job-info.t
+++ b/t/t2204-job-info.t
@@ -134,7 +134,7 @@ test_expect_success 'submit jobs for job list testing' '
 #
 
 test_expect_success HAVE_JQ 'flux job list running jobs in started order' '
-        flux job list --running | jq .id > list_started.out &&
+        flux job list -s running | jq .id > list_started.out &&
         test_cmp list_started.out job_ids_running.out
 '
 
@@ -142,12 +142,12 @@ test_expect_success HAVE_JQ 'flux job list running jobs with correct state' '
         for count in `seq 1 8`; do \
             echo "8" >> list_state_R.exp; \
         done &&
-        flux job list --running | jq .state > list_state_R.out &&
+        flux job list -s running | jq .state > list_state_R.out &&
         test_cmp list_state_R.out list_state_R.exp
 '
 
 test_expect_success HAVE_JQ 'flux job list inactive jobs in completed order' '
-        flux job list --inactive | jq .id > list_inactive.out &&
+        flux job list -s inactive | jq .id > list_inactive.out &&
         test_cmp list_inactive.out job_ids_inactive.out
 '
 
@@ -155,12 +155,12 @@ test_expect_success HAVE_JQ 'flux job list inactive jobs with correct state' '
         for count in `seq 1 4`; do \
             echo "32" >> list_state_I.exp; \
         done &&
-        flux job list --inactive | jq .state > list_state_I.out &&
+        flux job list -s inactive | jq .state > list_state_I.out &&
         test_cmp list_state_I.out list_state_I.exp
 '
 
 test_expect_success HAVE_JQ 'flux job list pending jobs in priority order' '
-        flux job list --pending | jq .id > list_pending.out &&
+        flux job list -s pending | jq .id > list_pending.out &&
         test_cmp list_pending.out job_ids_pending.out
 '
 
@@ -171,7 +171,7 @@ test_expect_success HAVE_JQ 'flux job list pending jobs with correct priority' '
 16
 0
 EOT
-        flux job list --pending | jq .priority > list_priority.out &&
+        flux job list -s pending | jq .priority > list_priority.out &&
         test_cmp list_priority.out list_priority.exp
 '
 
@@ -179,7 +179,7 @@ test_expect_success HAVE_JQ 'flux job list pending jobs with correct state' '
         for count in `seq 1 4`; do \
             echo "4" >> list_state_S.exp; \
         done &&
-        flux job list --pending | jq .state > list_state_S.out &&
+        flux job list -s pending | jq .state > list_state_S.out &&
         test_cmp list_state_S.out list_state_S.exp
 '
 
@@ -187,7 +187,7 @@ test_expect_success HAVE_JQ 'flux job list jobs with correct userid' '
         for count in `seq 1 16`; do \
             id -u >> list_userid.exp; \
         done &&
-        flux job list --pending --running --inactive | jq .userid > list_userid.out &&
+        flux job list -s pending,running,inactive | jq .userid > list_userid.out &&
         test_cmp list_userid.out list_userid.exp
 '
 
@@ -215,7 +215,7 @@ test_expect_success 'flux job list --userid=all works' '
 '
 
 test_expect_success HAVE_JQ 'flux job list --count works' '
-        flux job list --pending --running --inactive --count=8 > list_count.out &&
+        flux job list -s pending,running,inactive --count=8 > list_count.out &&
         count=$(wc -l < list_count.out) &&
         test "$count" = "8" &&
         head -n 4 list_count.out | jq .id > list_count_pending.out &&
@@ -226,7 +226,7 @@ test_expect_success HAVE_JQ 'flux job list --count works' '
 '
 
 test_expect_success HAVE_JQ 'flux job list all jobs works' '
-        flux job list --pending --running --inactive > list_all.out &&
+        flux job list -s pending,running,inactive > list_all.out &&
         cat list_all.out | jq .id > list_all_jobids.out &&
         cat job_ids_pending.out >> list_all_jobids.exp &&
         cat job_ids_running.out >> list_all_jobids.exp &&
@@ -260,7 +260,7 @@ test_expect_success 'reload the job-info module' '
 # inactive jobs are listed by most recently completed first, so must
 # construct order based on order of jobs canceled above
 test_expect_success HAVE_JQ 'job-info: list successfully reconstructed' '
-        flux job list --pending --running --inactive > list_reload.out &&
+        flux job list -s pending,running,inactive > list_reload.out &&
         for count in `seq 1 16`; do \
             echo "32" >> list_reload_state.exp; \
         done &&
@@ -290,7 +290,7 @@ test_expect_success HAVE_JQ 'job stats lists jobs in correct state (all inactive
 test_expect_success HAVE_JQ 'flux job list job state timing outputs valid (job inactive)' '
         jobid=$(flux mini submit hostname) &&
         flux job wait-event $jobid clean >/dev/null &&
-        obj=$(flux job list --inactive | grep $jobid) &&
+        obj=$(flux job list -s inactive | grep $jobid) &&
         echo $obj | jq -e ".t_depend < .t_sched" &&
         echo $obj | jq ".t_sched < .t_run" &&
         echo $obj | jq ".t_run < .t_cleanup" &&
@@ -301,7 +301,7 @@ test_expect_success HAVE_JQ 'flux job list job state timing outputs valid (job i
 test_expect_success HAVE_JQ 'flux job list job state timing outputs valid (job running)' '
         jobid=$(flux mini submit sleep 60) &&
         flux job wait-event $jobid start >/dev/null &&
-        obj=$(flux job list --running | grep $jobid) &&
+        obj=$(flux job list -s running | grep $jobid) &&
         echo $obj | jq -e ".t_depend < .t_sched" &&
         echo $obj | jq -e ".t_sched < .t_run" &&
         echo $obj | jq -e ".t_cleanup == 0.0" &&
@@ -318,29 +318,29 @@ test_expect_success 'flux job list outputs user job-name' '
         jobid=`flux mini submit --setattr system.job.name=foobar A B C` &&
         echo $jobid > jobname1.id &&
         flux job wait-event $jobid clean >/dev/null &&
-        flux job list --inactive | grep $jobid | grep foobar
+        flux job list -s inactive | grep $jobid | grep foobar
 '
 
 test_expect_success 'flux job lists first argument for job-name' '
         jobid=`flux mini submit mycmd arg1 arg2` &&
         echo $jobid > jobname2.id &&
         flux job wait-event $jobid clean >/dev/null &&
-        flux job list --inactive | grep $jobid | grep mycmd
+        flux job list -s inactive | grep $jobid | grep mycmd
 '
 
 test_expect_success 'flux job lists basename of first argument for job-name' '
         jobid=`flux mini submit /foo/bar arg1 arg2` &&
         echo $jobid > jobname3.id &&
         flux job wait-event $jobid clean >/dev/null &&
-        flux job list --inactive | grep $jobid | grep bar &&
-        flux job list --inactive | grep $jobid | grep -v foo
+        flux job list -s inactive | grep $jobid | grep bar &&
+        flux job list -s inactive | grep $jobid | grep -v foo
 '
 
 test_expect_success 'flux job lists full path for job-name if first argument not ok' '
         jobid=`flux mini submit /foo/bar/ arg1 arg2` &&
         echo $jobid > jobname4.id &&
         flux job wait-event $jobid clean >/dev/null &&
-        flux job list --inactive | grep $jobid | grep "\/foo\/bar\/"
+        flux job list -s inactive | grep $jobid | grep "\/foo\/bar\/"
 '
 
 test_expect_success 'reload the job-info module' '
@@ -353,10 +353,10 @@ test_expect_success 'verify job names preserved across restart' '
         jobid2=`cat jobname2.id` &&
         jobid3=`cat jobname3.id` &&
         jobid4=`cat jobname4.id` &&
-        flux job list --inactive | grep ${jobid1} | grep foobar &&
-        flux job list --inactive | grep ${jobid2} | grep mycmd &&
-        flux job list --inactive | grep ${jobid3} | grep bar &&
-        flux job list --inactive | grep ${jobid4} | grep "\/foo\/bar\/"
+        flux job list -s inactive | grep ${jobid1} | grep foobar &&
+        flux job list -s inactive | grep ${jobid2} | grep mycmd &&
+        flux job list -s inactive | grep ${jobid3} | grep bar &&
+        flux job list -s inactive | grep ${jobid4} | grep "\/foo\/bar\/"
 '
 
 #
@@ -367,7 +367,7 @@ test_expect_success 'flux job list outputs task-count correctly (1 task)' '
         jobid=`flux mini submit hostname` &&
         echo $jobid > taskcount1.id &&
         flux job wait-event $jobid clean >/dev/null &&
-        obj=$(flux job list --inactive | grep $jobid) &&
+        obj=$(flux job list -s inactive | grep $jobid) &&
         echo $obj | jq -e ".[\"task-count\"] == 1"
 '
 
@@ -375,7 +375,7 @@ test_expect_success 'flux job list outputs task-count correctly (4 tasks)' '
         jobid=`flux mini submit -n4 hostname` &&
         echo $jobid > taskcount2.id &&
         flux job wait-event $jobid clean >/dev/null &&
-        obj=$(flux job list --inactive | grep $jobid) &&
+        obj=$(flux job list -s inactive | grep $jobid) &&
         echo $obj | jq -e ".[\"task-count\"] == 4"
 '
 
@@ -387,9 +387,9 @@ test_expect_success 'reload the job-info module' '
 test_expect_success 'verify job names preserved across restart' '
         jobid1=`cat taskcount1.id` &&
         jobid2=`cat taskcount2.id` &&
-        obj=$(flux job list --inactive | grep ${jobid1}) &&
+        obj=$(flux job list -s inactive | grep ${jobid1}) &&
         echo $obj | jq -e ".[\"task-count\"] == 1" &&
-        obj=$(flux job list --inactive | grep ${jobid2}) &&
+        obj=$(flux job list -s inactive | grep ${jobid2}) &&
         echo $obj | jq -e ".[\"task-count\"] == 4"
 '
 
@@ -398,9 +398,9 @@ test_expect_success 'verify job names preserved across restart' '
 #
 
 test_expect_success 'list count / max_entries works' '
-        count=`flux job list --inactive -c 0 | wc -l` &&
+        count=`flux job list -s inactive -c 0 | wc -l` &&
         test $count -gt 5 &&
-        count=`flux job list --inactive -c 5 | wc -l` &&
+        count=`flux job list -s inactive -c 5 | wc -l` &&
         test $count -eq 5
 '
 

--- a/t/valgrind/workload.d/job-info
+++ b/t/valgrind/workload.d/job-info
@@ -8,4 +8,4 @@ id=$(flux jobspec srun -t 1 -n 1 /bin/true | flux job submit)
 flux job attach ${id}
 
 flux job info ${id} eventlog jobspec R >/dev/null
-flux job list --pending --running --inactive
+flux job list -s pending,running,inactive

--- a/t/valgrind/workload.d/job-info
+++ b/t/valgrind/workload.d/job-info
@@ -8,4 +8,4 @@ id=$(flux jobspec srun -t 1 -n 1 /bin/true | flux job submit)
 flux job attach ${id}
 
 flux job info ${id} eventlog jobspec R >/dev/null
-flux job list -s pending,running,inactive
+flux job list -A


### PR DESCRIPTION
This updates state filtering options in the `flux job list` plumbing command to match those in `flux-jobs(1)`, namely:
* Drop `--pending`, `--running`, and `--inactive` options
* Add `--states=STATES` where STATES a comma-separated list of states (virtual or real)
* Add `-A,--all-jobs` (all users, any job state)
* Add `-a,--all-my-jobs` (my jobs, any job state)

I went ahead and defined the `FLUX_JOB_PENDING`, `FLUX_JOB_RUNNING`, and `FLUX_JOB_ACTIVE` "virtual states" as a mask of actual RFC 21 states in `job.h`.  I structured `flux job list` to construct a state mask and derive the `job-info.list` request flags from that, to minimize required changes when #2628 (job-info: support listing jobs in specific states) lands.

Note that I had suggested that `t/job-manager/list-jobs` could be removed once this is done.  I misspoke - it actually needs to stay since it directly queries the job manager, since `job-info` is "eventually consistent".