### PR TITLE
job-info: Rename 'job-name' attribute to 'name' and 'task-count' attribute to 'ntasks'

### DIFF
--- a/doc/man1/flux-jobs.adoc
+++ b/doc/man1/flux-jobs.adoc
@@ -56,7 +56,7 @@ The '--format' option can be used to specify an output format to
 flux-jobs(1) using Python's string format syntax.  For example, the
 following is the format used for the default format:
 
-  {id:>18} {username:<8.8} {job_name:<10.10} {state:<8.8} {ntasks:>6} {runtime_fsd}
+  {id:>18} {username:<8.8} {name:<10.10} {state:<8.8} {ntasks:>6} {runtime_fsd}
 
 The field names that can be specified are:
 
@@ -67,7 +67,7 @@ username:: job submitter's username
 priority:: job priority
 state:: job state
 state_single:: job state as a single character
-job_name:: job name
+name:: job name
 ntasks:: job task count
 t_submit:: time job was submitted
 t_depend:: time job entered depend state

--- a/doc/man1/flux-jobs.adoc
+++ b/doc/man1/flux-jobs.adoc
@@ -56,7 +56,7 @@ The '--format' option can be used to specify an output format to
 flux-jobs(1) using Python's string format syntax.  For example, the
 following is the format used for the default format:
 
-  {id:>18} {username:<8.8} {job_name:<10.10} {state:<8.8} {task_count:>6} {runtime_fsd}
+  {id:>18} {username:<8.8} {job_name:<10.10} {state:<8.8} {ntasks:>6} {runtime_fsd}
 
 The field names that can be specified are:
 
@@ -68,7 +68,7 @@ priority:: job priority
 state:: job state
 state_single:: job state as a single character
 job_name:: job name
-task_count:: job task count
+ntasks:: job task count
 t_submit:: time job was submitted
 t_depend:: time job entered depend state
 t_sched:: time job entered sched state

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -609,7 +609,7 @@ int cmd_list (optparse_t *p, int argc, char **argv)
     int optindex = optparse_option_index (p);
     int max_entries = optparse_get_int (p, "count", 0);
     char *attrs = "[\"userid\",\"priority\",\"t_submit\",\"state\"," \
-        "\"job-name\",\"task-count\",\"t_depend\",\"t_sched\",\"t_run\"," \
+        "\"job-name\",\"ntasks\",\"t_depend\",\"t_sched\",\"t_run\"," \
         "\"t_cleanup\",\"t_inactive\"]";
     flux_t *h;
     flux_future_t *f;

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -609,7 +609,7 @@ int cmd_list (optparse_t *p, int argc, char **argv)
     int optindex = optparse_option_index (p);
     int max_entries = optparse_get_int (p, "count", 0);
     char *attrs = "[\"userid\",\"priority\",\"t_submit\",\"state\"," \
-        "\"job-name\",\"ntasks\",\"t_depend\",\"t_sched\",\"t_run\"," \
+        "\"name\",\"ntasks\",\"t_depend\",\"t_sched\",\"t_run\"," \
         "\"t_cleanup\",\"t_inactive\"]";
     flux_t *h;
     flux_future_t *f;

--- a/src/cmd/flux-jobs.py
+++ b/src/cmd/flux-jobs.py
@@ -74,7 +74,7 @@ def output_format(fmt, jobs):
             state=statetostr(job, False),
             state_single=statetostr(job, True),
             job_name=job["job-name"],
-            task_count=job["task-count"],
+            ntasks=job["ntasks"],
             t_submit=job["t_submit"],
             t_depend=job["t_depend"],
             t_sched=job["t_sched"],
@@ -146,7 +146,7 @@ def main():
         "priority",
         "state",
         "job-name",
-        "task-count",
+        "ntasks",
         "t_submit",
         "t_depend",
         "t_sched",
@@ -202,7 +202,7 @@ def main():
     else:
         fmt = (
             "{id:>18} {username:<8.8} {job_name:<10.10} {state:<8.8} "
-            "{task_count:>6} {runtime_fsd_hyphen}"
+            "{ntasks:>6} {runtime_fsd_hyphen}"
         )
         if not args.suppress_header:
             s = fmt.format(
@@ -210,7 +210,7 @@ def main():
                 username="USER",
                 job_name="NAME",
                 state="STATE",
-                task_count="NTASKS",
+                ntasks="NTASKS",
                 runtime_fsd_hyphen="TIME",
             )
             print(s)

--- a/src/cmd/flux-jobs.py
+++ b/src/cmd/flux-jobs.py
@@ -73,7 +73,7 @@ def output_format(fmt, jobs):
             priority=job["priority"],
             state=statetostr(job, False),
             state_single=statetostr(job, True),
-            job_name=job["job-name"],
+            name=job["name"],
             ntasks=job["ntasks"],
             t_submit=job["t_submit"],
             t_depend=job["t_depend"],
@@ -145,7 +145,7 @@ def main():
         "userid",
         "priority",
         "state",
-        "job-name",
+        "name",
         "ntasks",
         "t_submit",
         "t_depend",
@@ -201,14 +201,14 @@ def main():
         output_format(args.format, jobs)
     else:
         fmt = (
-            "{id:>18} {username:<8.8} {job_name:<10.10} {state:<8.8} "
+            "{id:>18} {username:<8.8} {name:<10.10} {state:<8.8} "
             "{ntasks:>6} {runtime_fsd_hyphen}"
         )
         if not args.suppress_header:
             s = fmt.format(
                 id="JOBID",
                 username="USER",
-                job_name="NAME",
+                name="NAME",
                 state="STATE",
                 ntasks="NTASKS",
                 runtime_fsd_hyphen="TIME",

--- a/src/modules/job-info/job_state.c
+++ b/src/modules/job-info/job_state.c
@@ -482,11 +482,11 @@ static int jobspec_parse (struct info_ctx *ctx,
         goto error;
     }
 
-    /* Set job->task_count
+    /* Set job->ntasks
      */
     if (json_unpack_ex (tasks, NULL, 0,
                         "[{s:{s:i}}]",
-                        "count", "total", &job->task_count) < 0) {
+                        "count", "total", &job->ntasks) < 0) {
         int per_slot, slot_count = 0;
         struct res_level res[3];
 
@@ -539,7 +539,7 @@ static int jobspec_parse (struct info_ctx *ctx,
                       res[2].with ? "->..." : NULL);
             goto error;
         }
-        job->task_count = slot_count;
+        job->ntasks = slot_count;
     }
 
     rc = 0;

--- a/src/modules/job-info/job_state.c
+++ b/src/modules/job-info/job_state.c
@@ -451,7 +451,7 @@ static int jobspec_parse (struct info_ctx *ctx,
     if (job->jobspec_job) {
         if (json_unpack_ex (job->jobspec_job, &error, 0,
                             "{s?:s}",
-                            "name", &job->job_name) < 0) {
+                            "name", &job->name) < 0) {
             flux_log (ctx->h, LOG_ERR,
                       "%s: job %llu invalid job dictionary: %s",
                       __FUNCTION__, (unsigned long long)job->id, error.text);
@@ -461,7 +461,7 @@ static int jobspec_parse (struct info_ctx *ctx,
 
     /* If user did not specify job.name, we treat arg 0 of the command
      * as the job name */
-    if (!job->job_name) {
+    if (!job->name) {
         json_t *arg0 = json_array_get (job->jobspec_cmd, 0);
         if (!arg0 || !json_is_string (arg0)) {
             flux_log (ctx->h, LOG_ERR,
@@ -469,8 +469,8 @@ static int jobspec_parse (struct info_ctx *ctx,
                       __FUNCTION__, (unsigned long long)job->id);
             goto error;
         }
-        job->job_name = parse_job_name (json_string_value (arg0));
-        assert (job->job_name);
+        job->name = parse_job_name (json_string_value (arg0));
+        assert (job->name);
     }
 
     if (json_unpack_ex (jobspec, &error, 0,

--- a/src/modules/job-info/job_state.h
+++ b/src/modules/job-info/job_state.h
@@ -58,7 +58,7 @@ struct job {
     double t_submit;
     int flags;
     flux_job_state_t state;
-    const char *job_name;
+    const char *name;
     int ntasks;
 
     /* cache of job information */

--- a/src/modules/job-info/job_state.h
+++ b/src/modules/job-info/job_state.h
@@ -59,7 +59,7 @@ struct job {
     int flags;
     flux_job_state_t state;
     const char *job_name;
-    int task_count;
+    int ntasks;
 
     /* cache of job information */
     json_t *jobspec_job;

--- a/src/modules/job-info/list.c
+++ b/src/modules/job-info/list.c
@@ -79,8 +79,8 @@ json_t *list_one_job (struct job *job, json_t *attrs)
         else if (!strcmp (attr, "job-name")) {
             val = json_string (job->job_name);
         }
-        else if (!strcmp (attr, "task-count")) {
-            val = json_integer (job->task_count);
+        else if (!strcmp (attr, "ntasks")) {
+            val = json_integer (job->ntasks);
         }
         else {
             errno = EINVAL;
@@ -258,7 +258,7 @@ void list_attrs_cb (flux_t *h, flux_msg_handler_t *mh,
                            "t_inactive",
                            "state",
                            "job-name",
-                           "task-count") < 0) {
+                           "ntasks") < 0) {
         flux_log_error (h, "%s: flux_respond_pack", __FUNCTION__);
         goto error;
     }

--- a/src/modules/job-info/list.c
+++ b/src/modules/job-info/list.c
@@ -76,8 +76,8 @@ json_t *list_one_job (struct job *job, json_t *attrs)
         else if (!strcmp (attr, "state")) {
             val = json_integer (job->state);
         }
-        else if (!strcmp (attr, "job-name")) {
-            val = json_string (job->job_name);
+        else if (!strcmp (attr, "name")) {
+            val = json_string (job->name);
         }
         else if (!strcmp (attr, "ntasks")) {
             val = json_integer (job->ntasks);
@@ -257,7 +257,7 @@ void list_attrs_cb (flux_t *h, flux_msg_handler_t *mh,
                            "t_cleanup",
                            "t_inactive",
                            "state",
-                           "job-name",
+                           "name",
                            "ntasks") < 0) {
         flux_log_error (h, "%s: flux_respond_pack", __FUNCTION__);
         goto error;

--- a/t/t2204-job-info.t
+++ b/t/t2204-job-info.t
@@ -314,21 +314,21 @@ test_expect_success HAVE_JQ 'flux job list job state timing outputs valid (job r
 # job names
 #
 
-test_expect_success 'flux job list outputs user job-name' '
+test_expect_success 'flux job list outputs user job name' '
         jobid=`flux mini submit --setattr system.job.name=foobar A B C` &&
         echo $jobid > jobname1.id &&
         flux job wait-event $jobid clean >/dev/null &&
         flux job list -s inactive | grep $jobid | grep foobar
 '
 
-test_expect_success 'flux job lists first argument for job-name' '
+test_expect_success 'flux job lists first argument for job name' '
         jobid=`flux mini submit mycmd arg1 arg2` &&
         echo $jobid > jobname2.id &&
         flux job wait-event $jobid clean >/dev/null &&
         flux job list -s inactive | grep $jobid | grep mycmd
 '
 
-test_expect_success 'flux job lists basename of first argument for job-name' '
+test_expect_success 'flux job lists basename of first argument for job name' '
         jobid=`flux mini submit /foo/bar arg1 arg2` &&
         echo $jobid > jobname3.id &&
         flux job wait-event $jobid clean >/dev/null &&
@@ -336,7 +336,7 @@ test_expect_success 'flux job lists basename of first argument for job-name' '
         flux job list -s inactive | grep $jobid | grep -v foo
 '
 
-test_expect_success 'flux job lists full path for job-name if first argument not ok' '
+test_expect_success 'flux job lists full path for job name if first argument not ok' '
         jobid=`flux mini submit /foo/bar/ arg1 arg2` &&
         echo $jobid > jobname4.id &&
         flux job wait-event $jobid clean >/dev/null &&
@@ -412,7 +412,7 @@ test_expect_success HAVE_JQ 'list request with empty attrs works' '
         test_must_fail grep "priority" list_empty_attrs.out &&
         test_must_fail grep "t_submit" list_empty_attrs.out &&
         test_must_fail grep "state" list_empty_attrs.out &&
-        test_must_fail grep "job-name" list_empty_attrs.out &&
+        test_must_fail grep "name" list_empty_attrs.out &&
         test_must_fail grep "ntasks" list_empty_attrs.out &&
         test_must_fail grep "t_depend" list_empty_attrs.out &&
         test_must_fail grep "t_sched" list_empty_attrs.out &&
@@ -431,7 +431,7 @@ test_expect_success HAVE_JQ 'list-attrs works' '
         grep priority list_attrs.out &&
         grep t_submit list_attrs.out &&
         grep state list_attrs.out &&
-        grep job-name list_attrs.out &&
+        grep name list_attrs.out &&
         grep ntasks list_attrs.out &&
         grep t_depend list_attrs.out &&
         grep t_sched list_attrs.out &&

--- a/t/t2204-job-info.t
+++ b/t/t2204-job-info.t
@@ -363,20 +363,20 @@ test_expect_success 'verify job names preserved across restart' '
 # job task count
 #
 
-test_expect_success 'flux job list outputs task-count correctly (1 task)' '
+test_expect_success 'flux job list outputs ntasks correctly (1 task)' '
         jobid=`flux mini submit hostname` &&
         echo $jobid > taskcount1.id &&
         flux job wait-event $jobid clean >/dev/null &&
         obj=$(flux job list -s inactive | grep $jobid) &&
-        echo $obj | jq -e ".[\"task-count\"] == 1"
+        echo $obj | jq -e ".[\"ntasks\"] == 1"
 '
 
-test_expect_success 'flux job list outputs task-count correctly (4 tasks)' '
+test_expect_success 'flux job list outputs ntasks correctly (4 tasks)' '
         jobid=`flux mini submit -n4 hostname` &&
         echo $jobid > taskcount2.id &&
         flux job wait-event $jobid clean >/dev/null &&
         obj=$(flux job list -s inactive | grep $jobid) &&
-        echo $obj | jq -e ".[\"task-count\"] == 4"
+        echo $obj | jq -e ".[\"ntasks\"] == 4"
 '
 
 test_expect_success 'reload the job-info module' '
@@ -388,9 +388,9 @@ test_expect_success 'verify job names preserved across restart' '
         jobid1=`cat taskcount1.id` &&
         jobid2=`cat taskcount2.id` &&
         obj=$(flux job list -s inactive | grep ${jobid1}) &&
-        echo $obj | jq -e ".[\"task-count\"] == 1" &&
+        echo $obj | jq -e ".[\"ntasks\"] == 1" &&
         obj=$(flux job list -s inactive | grep ${jobid2}) &&
-        echo $obj | jq -e ".[\"task-count\"] == 4"
+        echo $obj | jq -e ".[\"ntasks\"] == 4"
 '
 
 #
@@ -413,7 +413,7 @@ test_expect_success HAVE_JQ 'list request with empty attrs works' '
         test_must_fail grep "t_submit" list_empty_attrs.out &&
         test_must_fail grep "state" list_empty_attrs.out &&
         test_must_fail grep "job-name" list_empty_attrs.out &&
-        test_must_fail grep "task-count" list_empty_attrs.out &&
+        test_must_fail grep "ntasks" list_empty_attrs.out &&
         test_must_fail grep "t_depend" list_empty_attrs.out &&
         test_must_fail grep "t_sched" list_empty_attrs.out &&
         test_must_fail grep "t_run" list_empty_attrs.out &&
@@ -432,7 +432,7 @@ test_expect_success HAVE_JQ 'list-attrs works' '
         grep t_submit list_attrs.out &&
         grep state list_attrs.out &&
         grep job-name list_attrs.out &&
-        grep task-count list_attrs.out &&
+        grep ntasks list_attrs.out &&
         grep t_depend list_attrs.out &&
         grep t_sched list_attrs.out &&
         grep t_run list_attrs.out &&

--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -182,11 +182,11 @@ test_expect_success 'flux-jobs --format={state},{state_single} works' '
         test_cmp stateI.out stateI.exp
 '
 
-test_expect_success 'flux-jobs --format={job_name} works' '
-        flux jobs --suppress-header --state=pending,running --format="{job_name}" > jobnamePR.out &&
+test_expect_success 'flux-jobs --format={name} works' '
+        flux jobs --suppress-header --state=pending,running --format="{name}" > jobnamePR.out &&
         for i in `seq 1 14`; do echo "sleep" >> jobnamePR.exp; done &&
         test_cmp jobnamePR.out jobnamePR.exp &&
-        flux jobs --suppress-header --state=inactive --format="{job_name}" > jobnameI.out &&
+        flux jobs --suppress-header --state=inactive --format="{name}" > jobnameI.out &&
         for i in `seq 1 4`; do echo "hostname" >> jobnameI.exp; done &&
         test_cmp jobnameI.out jobnameI.exp
 '

--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -191,8 +191,8 @@ test_expect_success 'flux-jobs --format={job_name} works' '
         test_cmp jobnameI.out jobnameI.exp
 '
 
-test_expect_success 'flux-jobs --format={task_count} works' '
-        flux jobs --suppress-header -a --format="{task_count}" > taskcount.out &&
+test_expect_success 'flux-jobs --format={ntasks} works' '
+        flux jobs --suppress-header -a --format="{ntasks}" > taskcount.out &&
         for i in `seq 1 18`; do echo "1" >> taskcount.exp; done &&
         test_cmp taskcount.out taskcount.exp
 '


### PR DESCRIPTION
Globally adjust tools, tests, manpages, variable names, etc.

Per discussion in #2640