### PR TITLE
mpir: add front-end support for parallel debugging

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -473,6 +473,7 @@ AC_CONFIG_FILES( \
   src/common/libioencode/Makefile \
   src/common/librouter/Makefile \
   src/common/libyuarel/Makefile \
+  src/common/libdebugged/Makefile \
   src/bindings/Makefile \
   src/bindings/lua/Makefile \
   src/bindings/python/Makefile \

--- a/src/bindings/python/_flux/Makefile.am
+++ b/src/bindings/python/_flux/Makefile.am
@@ -13,6 +13,7 @@ AM_LDFLAGS = \
 
 common_libs = $(top_builddir)/src/common/libflux-core.la \
 	      $(top_builddir)/src/common/libflux-internal.la \
+	      $(top_builddir)/src/common/libdebugged/libdebugged.la \
 	      $(ZMQ_LIBS) $(LIBUUID_LIBS) \
 	      $(PYTHON_LDFLAGS)
 
@@ -24,7 +25,9 @@ _core_clean.h: Makefile
 	$(PYTHON) $(srcdir)/make_clean_header.py \
 	  --path $(top_srcdir) \
 	  --search $(top_builddir)/src/common/libflux \
-	  --additional_headers src/bindings/python/_flux/callbacks.h \
+	  --additional_headers \
+	      src/bindings/python/_flux/callbacks.h \
+	      src/common/libdebugged/debugged.h \
 	  --output _core_clean.h \
 	  src/include/flux/core.h
 _core_preproc.h: _core_clean.h

--- a/src/bindings/python/_flux/_core_build.py
+++ b/src/bindings/python/_flux/_core_build.py
@@ -7,6 +7,7 @@ ffi.set_source(
     "_flux._core",
     """
 #include <src/include/flux/core.h>
+#include <src/common/libdebugged/debugged.h>
 
 
 void * unpack_long(ptrdiff_t num){

--- a/src/bindings/python/flux/Makefile.am
+++ b/src/bindings/python/flux/Makefile.am
@@ -8,7 +8,8 @@ fluxpy_PYTHON=\
 	      job.py \
 	      util.py \
 	      future.py \
-	      memoized_property.py
+	      memoized_property.py \
+	      debugged.py
 
 if HAVE_FLUX_SECURITY
 fluxpy_PYTHON += security.py

--- a/src/bindings/python/flux/debugged.py
+++ b/src/bindings/python/flux/debugged.py
@@ -1,0 +1,19 @@
+###############################################################
+# Copyright 2020 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+from _flux._core import lib
+
+
+def get_mpir_being_debugged():
+    return lib.get_mpir_being_debugged()
+
+
+def set_mpir_being_debugged(value):
+    return lib.set_mpir_being_debugged(value)

--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -87,6 +87,12 @@ flux_start_LDADD = \
 	$(top_builddir)/src/common/libpmi/libpmi_server.la \
 	$(LIBUTIL)
 
+flux_job_LDADD = \
+	$(fluxcmd_ldadd) \
+	$(top_builddir)/src/shell/libmpir.la \
+	$(top_builddir)/src/common/libdebugged/libdebugged.la \
+	$(LIBUTIL)
+
 #
 # Automatically build list of flux(1) builtins from
 #  builtin/*.c:

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -40,6 +40,30 @@
 #include "src/common/libidset/idset.h"
 #include "src/common/libeventlog/eventlog.h"
 #include "src/common/libioencode/ioencode.h"
+#include "src/shell/mpir/proctable.h"
+#include "src/common/libdebugged/debugged.h"
+
+#ifndef VOLATILE
+# if defined(__STDC__) || defined(__cplusplus)
+# define VOLATILE volatile
+# else
+# define VOLATILE
+# endif
+#endif
+
+#define MPIR_NULL                  0
+#define MPIR_DEBUG_SPAWNED         1
+#define MPIR_DEBUG_ABORTING        2
+
+VOLATILE int MPIR_debug_state    = MPIR_NULL;
+struct proctable *proctable      = NULL;
+MPIR_PROCDESC *MPIR_proctable    = NULL;
+int MPIR_proctable_size          = 0;
+char *MPIR_debug_abort_string    = NULL;
+int MPIR_i_am_starter            = 1;
+int MPIR_acquired_pre_main       = 1;
+int MPIR_force_to_main           = 1;
+int MPIR_partial_attach_ok       = 1;
 
 int cmd_list (optparse_t *p, int argc, char **argv);
 int cmd_list_inactive (optparse_t *p, int argc, char **argv);
@@ -197,6 +221,9 @@ static struct optparse_option attach_opts[] =  {
       .usage = "Increase verbosity" },
     { .name = "quiet", .key = 'q', .has_arg = 0,
       .usage = "Suppress warnings written to stderr from flux-job",
+    },
+    { .name = "debug-emulate", .has_arg = 0, .flags = OPTPARSE_OPT_HIDDEN,
+      .usage = "Set MPIR_being_debugged for testing",
     },
     OPTPARSE_TABLE_END
 };
@@ -1604,6 +1631,104 @@ void attach_output_start (struct attach_ctx *ctx)
     ctx->eventlog_watch_count++;
 }
 
+static void valid_or_exit_for_debug (struct attach_ctx *ctx)
+{
+    flux_future_t *f = NULL;
+    char *attrs = "[\"state\"]";
+    flux_job_state_t state = FLUX_JOB_INACTIVE;
+
+    if (!(f = flux_job_list_id (ctx->h, ctx->id, attrs)))
+        log_err_exit ("flux_job_list_id");
+
+    if (flux_rpc_get_unpack (f, "{s:{s:i}}", "job", "state", &state) < 0)
+        log_err_exit ("Invalid job id (%ju) for debugging", ctx->id);
+
+    flux_future_destroy (f);
+
+    if (state != FLUX_JOB_NEW && state != FLUX_JOB_DEPEND
+        && state != FLUX_JOB_SCHED && state != FLUX_JOB_RUN) {
+        errno = EINVAL;
+        log_err_exit ("Invalid job state (%s) for debugging",
+                      flux_job_statetostr(state, false));
+    }
+
+    return;
+}
+
+static void setup_mpir_proctable (const char *s)
+{
+    if (!(proctable = proctable_from_json_string (s))) {
+        errno = EINVAL;
+        log_err_exit ("proctable_from_json_string");
+    }
+    MPIR_proctable = proctable_get_mpir_proctable (proctable,
+                                                   &MPIR_proctable_size);
+    if (!MPIR_proctable) {
+        errno = EINVAL;
+        log_err_exit ("proctable_get_mpir_proctable");
+    }
+}
+
+static void gen_attach_signal (struct attach_ctx *ctx)
+{
+    flux_future_t *f = NULL;
+    if (!(f = flux_job_kill (ctx->h, ctx->id, SIGCONT)))
+        log_err_exit ("flux_job_kill");
+    if (flux_rpc_get (f, NULL) < 0)
+        log_msg_exit ("kill %ju: %s",
+                      (uintmax_t) ctx->id,
+                      future_strerror (f, errno));
+    flux_future_destroy (f);
+}
+
+static void setup_mpir_interface (struct attach_ctx *ctx, json_t *context)
+{
+    char topic [1024];
+    const char *s = NULL;
+    flux_future_t *f = NULL;
+    int stop_tasks_in_exec = 0;
+
+    if (json_unpack (context, "{s?:b}", "sync", &stop_tasks_in_exec) < 0)
+        log_err_exit ("error decoding shell.init context");
+
+    snprintf (topic, sizeof (topic), "%s.proctable", ctx->service);
+
+    if (!(f = flux_rpc_pack (ctx->h, topic, ctx->leader_rank, 0, "{}")))
+        log_err_exit ("flux_rpc_pack");
+    if (flux_rpc_get (f, &s) < 0)
+        log_err_exit ("%s", topic);
+
+    setup_mpir_proctable (s);
+    flux_future_destroy (f);
+
+    MPIR_debug_state = MPIR_DEBUG_SPAWNED;
+
+    /* Signal the parallel debugger */
+    MPIR_Breakpoint ();
+
+    if (stop_tasks_in_exec || optparse_hasopt (ctx->p, "debug-emulate")) {
+        /* To support MPIR_partial_attach_ok, we need to send SIGCONT to
+         * those MPI processes to which the debugger didn't attach.
+         * However, all of the debuggers that I know of do ignore
+         * additional SIGCONT being sent to the processes they attached to.
+         * Therefore, we send SIGCONT to *every* MPI process.
+         *
+         * We also send SIGCONT under the debug-emulate flag. This allows us
+         * to write a test for attach mode. The running job will exit
+         * on SIGCONT.
+         */
+        gen_attach_signal (ctx);
+    }
+}
+
+static void finish_mpir_interface ()
+{
+    MPIR_debug_state = MPIR_DEBUG_ABORTING;
+
+    /* Signal the parallel debugger */
+    MPIR_Breakpoint ();
+}
+
 /* Handle an event in the guest.exec eventlog.
  * This is a stream of responses, one response per event, terminated with
  * an ENODATA error response (or another error if something went wrong).
@@ -1671,6 +1796,12 @@ void attach_exec_event_continuation (flux_future_t *f, void *arg)
         flux_watcher_start (ctx->stdin_w);
 
         attach_output_start (ctx);
+    } else if (!strcmp (name, "shell.start")) {
+        if (MPIR_being_debugged)
+            setup_mpir_interface (ctx, context);
+    } else if (!strcmp (name, "complete")) {
+        if (MPIR_being_debugged)
+            finish_mpir_interface ();
     }
 
     /*  If job is complete, and we haven't started watching
@@ -1818,6 +1949,11 @@ int cmd_attach (optparse_t *p, int argc, char **argv)
         log_err_exit ("flux_open");
     if (!(r = flux_get_reactor (ctx.h)))
         log_err_exit ("flux_get_reactor");
+
+    if (optparse_hasopt (ctx.p, "debug-emulate"))
+        MPIR_being_debugged = 1;
+    if (MPIR_being_debugged)
+        valid_or_exit_for_debug (&ctx);
 
     if (!(ctx.eventlog_f = flux_job_event_watch (ctx.h,
                                                  ctx.id,

--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -16,7 +16,8 @@ SUBDIRS = libtap \
           libschedutil \
 	  libeventlog \
 	  libioencode \
-	  librouter
+	  librouter \
+	  libdebugged
 
 AM_CFLAGS = $(WARNING_CFLAGS) $(CODE_COVERAGE_CFLAGS)
 AM_LDFLAGS = $(CODE_COVERAGE_LIBS)

--- a/src/common/libdebugged/Makefile.am
+++ b/src/common/libdebugged/Makefile.am
@@ -1,0 +1,32 @@
+AM_CFLAGS = \
+	$(WARNING_CFLAGS) \
+	$(CODE_COVERAGE_CFLAGS)
+
+AM_LDFLAGS = \
+	$(CODE_COVERAGE_LIBS)
+
+AM_CPPFLAGS = \
+        -I$(top_srcdir)
+
+noinst_LTLIBRARIES = libdebugged.la
+libdebugged_la_SOURCES = debugged.c debugged.h
+
+libdebugged_la_CPPFLAGS = \
+	$(AM_CPPFLAGS)
+libdebugged_la_LDFLAGS = \
+	-avoid-version -module -shared -export-dynamic \
+	$(AM_LDFLAGS)
+
+TESTS = test_debugged.t
+
+check_PROGRAMS = $(TESTS)
+
+TEST_EXTENSIONS = .t
+T_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
+       $(top_srcdir)/config/tap-driver.sh
+
+test_debugged_t_SOURCES = test/test_debugged.c
+test_debugged_t_CPPFLAGS = $(AM_CPPFLAGS)
+test_debugged_t_LDADD = \
+        $(top_builddir)/src/common/libtap/libtap.la \
+        $(top_builddir)/src/common/libdebugged/libdebugged.la

--- a/src/common/libdebugged/debugged.c
+++ b/src/common/libdebugged/debugged.c
@@ -1,0 +1,36 @@
+/************************************************************\
+ * Copyright 2020 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "debugged.h"
+
+int MPIR_being_debugged = 0;
+
+void MPIR_Breakpoint ()
+{
+
+}
+
+int get_mpir_being_debugged ()
+{
+    return MPIR_being_debugged;
+}
+
+void set_mpir_being_debugged (int v)
+{
+    MPIR_being_debugged = v;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libdebugged/debugged.h
+++ b/src/common/libdebugged/debugged.h
@@ -1,0 +1,31 @@
+/************************************************************\
+ * Copyright 2020 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _FLUX_CORE_DEBUGGED_H
+#define _FLUX_CORE_DEBUGGED_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern int MPIR_being_debugged;
+extern void MPIR_Breakpoint (void);
+extern int get_mpir_being_debugged (void);
+extern void set_mpir_being_debugged (int v);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* !_FLUX_CORE_DEBUGGED_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libdebugged/test/test_debugged.c
+++ b/src/common/libdebugged/test/test_debugged.c
@@ -1,0 +1,44 @@
+/************************************************************\
+ * Copyright 2020 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "src/common/libtap/tap.h"
+#include "src/common/libdebugged/debugged.h"
+
+void test_initial_state (void)
+{
+    int debugged = get_mpir_being_debugged ();
+    ok (debugged == 0,
+        "mpir_being_debugged is initially 0");
+    set_mpir_being_debugged (1);
+    debugged = get_mpir_being_debugged ();
+    ok (debugged == 1,
+        "mpir_being_debugged is set to 1 (e.g., under debugger control)");
+    set_mpir_being_debugged (0);
+    debugged = get_mpir_being_debugged ();
+    ok (debugged == 0,
+        "mpir_being_debugged is unset to 0 (e.g., debugger detached)");
+}
+
+int main (int argc, char *argv[])
+{
+    plan (NO_PLAN);
+
+    test_initial_state ();
+
+    done_testing ();
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libflux-core.map
+++ b/src/common/libflux-core.map
@@ -1,6 +1,5 @@
 { global:
     flux_*;
-    JSC_*;
     __asan*;
     local: *;
 };

--- a/src/shell/mpir/nodelist.c
+++ b/src/shell/mpir/nodelist.c
@@ -150,10 +150,10 @@ static int nodelist_append_prefix_list (struct nodelist *nl,
 int nodelist_append (struct nodelist *nl, const char *host)
 {
     int suffix = -1;
-    char name [MAXHOSTNAMELEN+1];
+    char name [4096];
     struct prefix_list *pl = zlist_tail (nl->list);
 
-    if (strlen (host) > MAXHOSTNAMELEN) {
+    if (strlen (host) > sizeof(name) - 1) {
         errno = E2BIG;
         return -1;
     }
@@ -225,9 +225,9 @@ static struct prefix_list *prefix_list_from_json (json_t *o)
     /*  Special case, string is a single host
      */
     if (json_is_string (o)) {
-        char name [MAXHOSTNAMELEN+1];
+        char name [4096];
         int suffix = -1;
-        strcpy (name, json_string_value (o));
+        strncpy (name, json_string_value (o), sizeof (name) - 1);
         hostname_split (name, &suffix);
         return prefix_list_create (name, suffix);
     }

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -123,6 +123,7 @@ TESTSCRIPTS = \
 	t2608-job-shell-log.t \
 	t2609-job-shell-events.t \
 	t2610-job-shell-mpir.t \
+	t2611-debug-emulate.t \
 	t2700-mini-cmd.t \
 	t2800-jobs-cmd.t \
 	t3000-mpi-basic.t \
@@ -250,7 +251,8 @@ check_PROGRAMS = \
 	sched-simple/jj-reader \
 	shell/rcalc \
 	shell/lptest \
-	shell/mpir
+	shell/mpir \
+	debug/stall
 
 if HAVE_MPI
 check_PROGRAMS += \
@@ -456,6 +458,9 @@ shell_mpir_CPPFLAGS = $(test_cppflags)
 shell_mpir_LDADD = \
 	$(top_builddir)/src/shell/libmpir.la \
         $(test_ldadd) $(LIBDL) $(LIBUTIL)
+
+debug_stall_SOURCES = debug/stall.c
+debug_stall_CPPFLAGS = $(test_cppflags)
 
 reactor_reactorcat_SOURCES = reactor/reactorcat.c
 reactor_reactorcat_CPPFLAGS = $(test_cppflags)

--- a/t/debug/stall.c
+++ b/t/debug/stall.c
@@ -1,0 +1,64 @@
+/************************************************************\
+ * Copyright 2020 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* stall.c - test program for debugger support: stalling until SIGCONT */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <signal.h>
+
+void handle_sigcont (int sig)
+{
+    fprintf (stdout, "Caught SIGCONT\n");
+    exit (0);
+}
+
+int main (int argc, char *argv[])
+{
+    FILE *fptr = NULL;
+    int stall_sec = 0;
+
+    if (argc != 3) {
+        fprintf (stderr, "Usage: stall <filename> <stall_sec>\n");
+        exit (1);
+    }
+
+    signal (SIGCONT, handle_sigcont);
+
+    fprintf (stdout, "Signal handler for SIGCONT installed\n");
+
+    if ( !(fptr = fopen (argv[1], "w"))) {
+        fprintf (stderr, "Error: Can't write to %s\n", argv[1]);
+        exit (1);
+    }
+    fclose (fptr);
+
+    fprintf (stdout, "Sync file created: %s\n", argv[1]);
+
+    if ((stall_sec = atoi (argv[2])) < 0) {
+        fprintf (stderr, "Error: stall time (%d) must be > 0!\n", stall_sec);
+        exit (1);
+    }
+
+    fprintf (stdout, "Will sleep for: %d\n", stall_sec);
+
+    sleep (stall_sec);
+
+    return 0;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/t/t2611-debug-emulate.t
+++ b/t/t2611-debug-emulate.t
@@ -1,0 +1,71 @@
+#!/bin/sh
+#
+test_description='Test parallel debugger support in emulation mode'
+
+. `dirname $0`/sharness.sh
+
+stall="${SHARNESS_TEST_DIRECTORY}/debug/stall"
+waitfile="${SHARNESS_TEST_SRCDIR}/scripts/waitfile.lua"
+
+stop_tasks_test()     {
+        jq '.attributes.system.shell.options."stop-tasks-in-exec" = 1';
+}
+
+test_under_flux 2
+
+parse_jobid() {
+        outfile=$1
+        jobid=$(cat ${outfile} | grep jobid | awk '{ print $2 }')
+        echo ${jobid}
+}
+
+test_expect_success 'debugger: launching under debugger via flux-mini works' '
+        flux mini run -v --debug-emulate -N 2 -n 2 sleep 0 2> jobid.out &&
+        jobid=$(parse_jobid jobid.out) &&
+        echo ${jobid} > jobid &&
+        flux job wait-event -vt 2.5 ${jobid} finish
+'
+
+test_expect_success 'debugger: submitting under debugger via flux-mini works' '
+        jobid=$(flux mini submit -N 2 -n 2 -o stop-tasks-in-exec hostname) &&
+        flux job wait-event -vt 2.5  ${jobid} start &&
+        flux job attach --debug-emulate ${jobid} &&
+        flux job wait-event -vt 2.5  ${jobid} finish
+'
+
+test_expect_success 'debugger: submitting under debugger via flux-job works' '
+        flux jobspec srun -N2 -n 2 hostname | stop_tasks_test > stop_tasks.json &&
+        jobid=$(flux job submit stop_tasks.json) &&
+        flux job wait-event -vt 2.5  ${jobid} start &&
+        flux job attach --debug-emulate ${jobid} &&
+        flux job wait-event -vt 2.5  ${jobid} finish
+'
+
+test_expect_success 'debugger: SIGCONT can unlock a job in stop-tasks-in-exec' '
+        jobid=$(flux mini submit -N 2 -n 2 -o stop-tasks-in-exec hostname) &&
+        flux job wait-event -vt 2.5  ${jobid} start &&
+        flux job kill --signal=SIGCONT ${jobid} &&
+        flux job wait-event -vt 2.5  ${jobid} finish
+'
+
+test_expect_success 'debugger: attaching to a running job works' '
+        jobid=$(flux jobspec srun -n 1 ${stall} done 10 | flux job submit) &&
+        flux job wait-event -vt 2.5 ${jobid} start &&
+        ${waitfile} -v -t 2.5 done &&
+        flux job attach -v --debug-emulate ${jobid} &&
+        flux job wait-event -vt 2.5 ${jobid} finish
+'
+
+test_expect_success 'debugger: attaching to a finished job must fail' '
+        jobid=$(flux jobspec srun -n 2 hostname | flux job submit) &&
+        flux job wait-event -vt 2.5 ${jobid} finish &&
+        test_must_fail flux job attach --debug-emulate ${jobid}
+'
+
+test_expect_success 'debug-emulate: attaching to a failed job must fail' '
+        jobid=$(flux jobspec srun -n 2 ./bad_cmd | flux job submit) &&
+        flux job wait-event -vt 2.5 ${jobid} finish &&
+        test_must_fail flux job attach --debug-emulate ${jobid}
+'
+
+test_done


### PR DESCRIPTION
This PR is work in progress. At least three things are required before it can be merged.
- `flux-info` module provides a single job query, an equivalent of ba95bf6 and 
6068c24. Tagging @chu11 and @grondo for this as this is their planned task.
- I need to find a way to disable compilers to optimize (e.g., inlining) `MPIR_Breakpoint` (fec88d6) so that this function can remain empty as it should. (Currently, I added two printf statements lest totalview cannot reliably get its MPIR_Breakpoint event). Tagging @jdelsign in case he has some insight. 
- Test this on the LC environment as I did my manual totalview testing under my docker development environment. 

Having said that, this PR adds MPIR front-end support for parallel debuggers like totalview.

- Add the MPIR debug interface within `flux-job`’s `attach` command.
- Add an automatic debugger-attach detection scheme into `flux-mini.py` so that users don't have to specify `-o stop-tasks-in-exec` when they launch a job using `flux-mini run` under debugger control. To achieve this, a very thin debugger-attach detection library (`libdebugged`) has been added and the python binding has been extended to include that.
- Add tests, in particular a sharness test that drives this logic in an emulation environment. For this purpose, `--debug-emulate` option has been added to both the `flux-mini run` command as well as `flux-job attach` command. 

If anyone wants to do some manual testing with totalview:

For launch mode:
% totalview-install/toolworks/totalview.2019.3.14/bin/totalview -oldui -verbosity error --args flux mini run -N 2 -n 2 ./sleep_print 60 5

For attach mode:
totalview-install/toolworks/totalview.2019.3.14/bin/totalview -oldui -verbosity error --args flux job attach <JOBID>

I also tested both modes with subset attach whereby totalview only attaches to a subset of processes chosen. And this worked well, hence we define the `MPIR_partial_attach_ok` variable in `flux-job`.
 
Resolve #2597 and #2538.
