### PR TITLE
job-info: Refactor job-info to transition to any state after retrieving data from KVS

### DIFF
--- a/src/cmd/flux-jobs.py
+++ b/src/cmd/flux-jobs.py
@@ -27,11 +27,11 @@ logger = logging.getLogger("flux-jobs")
 
 
 def runtime(job, roundup):
-    if job["t_cleanup"] > 0.0 and job["t_run"] > 0.0:
+    if "t_cleanup" in job and "t_run" in job:
         t = job["t_cleanup"] - job["t_run"]
         if roundup:
             t = round(t + 0.5)
-    elif job["t_run"] > 0.0:
+    elif "t_run" in job:
         t = time.time() - job["t_run"]
         if roundup:
             t = round(t + 0.5)
@@ -89,10 +89,10 @@ def output_format(fmt, jobs):
             ntasks=job["ntasks"],
             t_submit=job["t_submit"],
             t_depend=job["t_depend"],
-            t_sched=job["t_sched"],
-            t_run=job["t_run"],
-            t_cleanup=job["t_cleanup"],
-            t_inactive=job["t_inactive"],
+            t_sched=job.get("t_sched", 0.0),
+            t_run=job.get("t_run", 0.0),
+            t_cleanup=job.get("t_cleanup", 0.0),
+            t_inactive=job.get("t_inactive", 0.0),
             runtime=runtime(job, False),
             runtime_fsd=runtime_fsd(job, False),
             runtime_fsd_hyphen=runtime_fsd(job, True),

--- a/src/modules/job-info/job_state.c
+++ b/src/modules/job-info/job_state.c
@@ -901,7 +901,7 @@ static int depthfirst_map_one (struct info_ctx *ctx, const char *key,
 
     if (flux_job_kvs_key (path, sizeof (path), id, "jobspec") < 0) {
         errno = EINVAL;
-        return -1;
+        goto done;
     }
     if (!(f2 = flux_kvs_lookup (ctx->h, NULL, 0, path)))
         goto done;

--- a/src/modules/job-info/job_state.c
+++ b/src/modules/job-info/job_state.c
@@ -246,6 +246,7 @@ static void update_job_state (struct info_ctx *ctx,
         job->t_cleanup = timestamp;
     else if (job->state == FLUX_JOB_INACTIVE)
         job->t_inactive = timestamp;
+    job->states_mask |= job->state;
     if (decrement)
         (*decrement)--;
     if (increment)

--- a/src/modules/job-info/job_state.h
+++ b/src/modules/job-info/job_state.h
@@ -72,8 +72,11 @@ struct job {
      * has been seen, we don't immediately place it on the `pending`
      * list.  We wait until we've retrieved data such as userid,
      * priority, etc.
+     *
+     * Track which states we've seen via the states_mask;
      */
     zlist_t *next_states;
+    unsigned int states_mask;
     void *list_handle;
 
     /* timestamp of when we enter the state

--- a/src/modules/job-info/job_state.h
+++ b/src/modules/job-info/job_state.h
@@ -65,8 +65,15 @@ struct job {
     json_t *jobspec_job;
     json_t *jobspec_cmd;
 
-    /* if userid, priority, t_submit, and flags have been set */
-    bool job_info_retrieved;
+    /* Track which states we have seen and have completed transition
+     * to.  We do not immediately update to the new state and place
+     * onto a new list until we have retrieved any necessary data
+     * associated to that state.  For example, when the 'depend' state
+     * has been seen, we don't immediately place it on the `pending`
+     * list.  We wait until we've retrieved data such as userid,
+     * priority, etc.
+     */
+    zlist_t *next_states;
     void *list_handle;
 
     /* timestamp of when we enter the state

--- a/src/modules/job-info/list.c
+++ b/src/modules/job-info/list.c
@@ -59,18 +59,28 @@ json_t *list_one_job (struct job *job, json_t *attrs)
         }
         else if (!strcmp (attr, "t_submit")
                  || !strcmp (attr, "t_depend")) {
+            if (!(job->states_mask & FLUX_JOB_DEPEND))
+                continue;
             val = json_real (job->t_submit);
         }
         else if (!strcmp (attr, "t_sched")) {
+            if (!(job->states_mask & FLUX_JOB_SCHED))
+                continue;
             val = json_real (job->t_sched);
         }
         else if (!strcmp (attr, "t_run")) {
+            if (!(job->states_mask & FLUX_JOB_RUN))
+                continue;
             val = json_real (job->t_run);
         }
         else if (!strcmp (attr, "t_cleanup")) {
+            if (!(job->states_mask & FLUX_JOB_CLEANUP))
+                continue;
             val = json_real (job->t_cleanup);
         }
         else if (!strcmp (attr, "t_inactive")) {
+            if (!(job->states_mask & FLUX_JOB_INACTIVE))
+                continue;
             val = json_real (job->t_inactive);
         }
         else if (!strcmp (attr, "state")) {

--- a/t/flux-jobs/tests/issue#2634/description
+++ b/t/flux-jobs/tests/issue#2634/description
@@ -1,1 +1,1 @@
-t_run is correct for jobs rejected by scheduler
+t_run is not listed for jobs rejected by scheduler

--- a/t/flux-jobs/tests/issue#2634/input
+++ b/t/flux-jobs/tests/issue#2634/input
@@ -1,1 +1,1 @@
-{"id": 406008627200, "userid": 6885, "priority": 16, "t_submit": 1579133377.8522565, "state": 32, "name": "hostname", "ntasks": 128, "t_depend": 1579133377.8522565, "t_sched": 1579133377.8655972, "t_run": 0.0, "t_cleanup": 1579133377.8667088, "t_inactive": 1579133377.8667269}
+{"id": 406008627200, "userid": 6885, "priority": 16, "t_submit": 1579133377.8522565, "state": 32, "name": "hostname", "ntasks": 128, "t_depend": 1579133377.8522565, "t_sched": 1579133377.8655972, "t_cleanup": 1579133377.8667088, "t_inactive": 1579133377.8667269}

--- a/t/t2204-job-info.t
+++ b/t/t2204-job-info.t
@@ -327,15 +327,15 @@ test_expect_success HAVE_JQ 'flux job list job state timing outputs valid (job i
         echo $obj | jq -e ".t_cleanup < .t_inactive"
 '
 
-# since job is running, make sure latter states are 0.0000
+# since job is running, make sure latter states don't exist
 test_expect_success HAVE_JQ 'flux job list job state timing outputs valid (job running)' '
         jobid=$(flux mini submit sleep 60) &&
         flux job wait-event $jobid start >/dev/null &&
         obj=$(flux job list -s running | grep $jobid) &&
         echo $obj | jq -e ".t_depend < .t_sched" &&
         echo $obj | jq -e ".t_sched < .t_run" &&
-        echo $obj | jq -e ".t_cleanup == 0.0" &&
-        echo $obj | jq -e ".t_inactive == 0.0" &&
+        echo $obj | jq -e ".t_cleanup == null" &&
+        echo $obj | jq -e ".t_inactive == null" &&
         flux job cancel $jobid &&
         flux job wait-event $jobid clean >/dev/null
 '


### PR DESCRIPTION
This PR is a pre-PR for issue #2590.  Before supporting #2590, `job-info` has to be refactored.  I'll just use the comment from one of my commits to describe what had to be done and why.

```
    At the moment the only data that has to be retrieved from the KVS
    occurs when the job is submitted, i.e. state DEPEND.  Code was designed
    to not allow users to see a job in the DEPEND state until this data
    had been retrieved from the KVS.  After this point, it was assumed
    that no additional data would be retrieved from the KVS.
    
    During the time that data is retrieved from the KVS, there is a racy
    component of the list service, where additional state transitions could
    occur.  For example, the job could complete and be in INACTIVE state
    before data from the KVS is retrieved.  This is considered acceptable,
    since the job-info list service is eventually consistent.
    
    In the future, some data many not be available during state DEPEND.
    For example, R will become available during state RUN and another
    KVS lookup would be required to lookup R.  In this case, the race
    described above would be unnacceptable.  A user could see a job
    is in the RUN state, but cannot see the node count for the job.
    
    Therefore code had to be refactored to allow data to be retrieved after
    any state transition.  Users will not see that the job has transitioned
    until after the data has been retrieved.
```

after this, slightly altered the list service to not return attributes if the job has never reachd a particular state (e.g. `t_run` is not returned if state RUN was never reached).  Then updated callers of job-info accordingly.  Also got some cleanup patches in here too.

Side note: This will conflict with #2648 and @grondo's fix for #2634.  Will fix later.