### PR TITLE
t/t2204-job-info: Add checks to avoid racyness

### DIFF
--- a/t/t2204-job-info.t
+++ b/t/t2204-job-info.t
@@ -613,11 +613,6 @@ test_expect_success 'flux job wait-event --timeout works' '
         grep "wait-event timeout" wait_event7.err
 '
 
-test_expect_success 'flux job wait-event hangs on no event' '
-        jobid=$(submit_job) &&
-        ! run_timeout 0.2 flux job wait-event $jobid foobar
-'
-
 test_expect_success 'flux job wait-event --format=json works' '
         jobid=$(submit_job) &&
 	flux job wait-event --format=json $jobid submit > wait_event_format1.out &&
@@ -685,12 +680,12 @@ test_expect_success 'flux job wait-event w/ match-context works (int)' '
 
 test_expect_success 'flux job wait-event w/ bad match-context fails (invalid key)' '
         jobid=$(submit_job) &&
-        ! run_timeout 0.2 flux job wait-event --match-context=foo=bar $jobid exception
+        test_must_fail flux job wait-event --match-context=foo=bar $jobid exception
 '
 
 test_expect_success 'flux job wait-event w/ bad match-context fails (invalid value)' '
         jobid=$(submit_job) &&
-        ! run_timeout 0.2 flux job wait-event --match-context=type=foo $jobid exception
+        test_must_fail flux job wait-event --match-context=type=foo $jobid exception
 '
 
 test_expect_success 'flux job wait-event w/ bad match-context fails (invalid input)' '

--- a/t/t2204-job-info.t
+++ b/t/t2204-job-info.t
@@ -294,9 +294,9 @@ test_expect_success HAVE_JQ 'flux job list job state timing outputs valid (job i
         flux job wait-event $jobid clean >/dev/null &&
         obj=$(flux job list -s inactive | grep $jobid) &&
         echo $obj | jq -e ".t_depend < .t_sched" &&
-        echo $obj | jq ".t_sched < .t_run" &&
-        echo $obj | jq ".t_run < .t_cleanup" &&
-        echo $obj | jq ".t_cleanup < .t_inactive"
+        echo $obj | jq -e ".t_sched < .t_run" &&
+        echo $obj | jq -e ".t_run < .t_cleanup" &&
+        echo $obj | jq -e ".t_cleanup < .t_inactive"
 '
 
 # since job is running, make sure latter states are 0.0000

--- a/t/t2204-job-info.t
+++ b/t/t2204-job-info.t
@@ -386,7 +386,7 @@ test_expect_success 'reload the job-info module' '
         flux exec -r all flux module load job-info
 '
 
-test_expect_success 'verify job names preserved across restart' '
+test_expect_success 'verify task count preserved across restart' '
         jobid1=`cat taskcount1.id` &&
         jobid2=`cat taskcount2.id` &&
         obj=$(flux job list -s inactive | grep ${jobid1}) &&

--- a/t/t2204-job-info.t
+++ b/t/t2204-job-info.t
@@ -493,7 +493,7 @@ test_expect_success 'flux job eventlog works on multiple entries' '
 '
 
 test_expect_success 'flux job eventlog fails on bad id' '
-	! flux job eventlog 12345
+	test_must_fail flux job eventlog 12345
 '
 
 test_expect_success 'flux job eventlog --format=json works' '
@@ -512,7 +512,7 @@ test_expect_success 'flux job eventlog --format=text works' '
 
 test_expect_success 'flux job eventlog --format=invalid fails' '
         jobid=$(submit_job) &&
-	! flux job eventlog --format=invalid $jobid
+	test_must_fail flux job eventlog --format=invalid $jobid
 '
 
 test_expect_success 'flux job eventlog --time-format=raw works' '
@@ -536,7 +536,7 @@ test_expect_success 'flux job eventlog --time-format=offset works' '
 
 test_expect_success 'flux job eventlog --time-format=invalid fails works' '
         jobid=$(submit_job) &&
-	! flux job eventlog --time-format=invalid $jobid
+	test_must_fail flux job eventlog --time-format=invalid $jobid
 '
 
 test_expect_success 'flux job eventlog -p works' '
@@ -553,7 +553,7 @@ test_expect_success 'flux job eventlog -p works (guest.exec.eventlog)' '
 
 test_expect_success 'flux job eventlog -p fails on invalid path' '
         jobid=$(submit_job) &&
-        ! flux job eventlog -p "foobar" $jobid
+        test_must_fail flux job eventlog -p "foobar" $jobid
 '
 
 #
@@ -568,7 +568,7 @@ test_expect_success 'flux job wait-event works' '
 
 test_expect_success NO_CHAIN_LINT 'flux job wait-event errors on non-event' '
         jobid=$(submit_job) &&
-        ! flux job wait-event $jobid foobar 2> wait_event2.err &&
+        test_must_fail flux job wait-event $jobid foobar 2> wait_event2.err &&
         grep "never received" wait_event2.err
 '
 
@@ -576,12 +576,12 @@ test_expect_success NO_CHAIN_LINT 'flux job wait-event does not see event after 
         jobid=$(submit_job) &&
         kvsdir=$(flux job id --to=kvs $jobid) &&
 	flux kvs eventlog append ${kvsdir}.eventlog foobar &&
-        ! flux job wait-event -v $jobid foobar 2> wait_event3.err &&
+        test_must_fail flux job wait-event -v $jobid foobar 2> wait_event3.err &&
         grep "never received" wait_event3.err
 '
 
 test_expect_success 'flux job wait-event fails on bad id' '
-	! flux job wait-event 12345 foobar
+	test_must_fail flux job wait-event 12345 foobar
 '
 
 test_expect_success 'flux job wait-event --quiet works' '
@@ -608,7 +608,7 @@ test_expect_success 'flux job wait-event --verbose doesnt show events after wait
 
 test_expect_success 'flux job wait-event --timeout works' '
         jobid=$(submit_job_live sleeplong.json) &&
-        ! flux job wait-event --timeout=0.2 $jobid clean 2> wait_event7.err &&
+        test_must_fail flux job wait-event --timeout=0.2 $jobid clean 2> wait_event7.err &&
         flux job cancel $jobid &&
         grep "wait-event timeout" wait_event7.err
 '
@@ -629,7 +629,7 @@ test_expect_success 'flux job wait-event --format=text works' '
 
 test_expect_success 'flux job wait-event --format=invalid fails' '
         jobid=$(submit_job) &&
-	! flux job wait-event --format=invalid $jobid submit
+	test_must_fail flux job wait-event --format=invalid $jobid submit
 '
 
 test_expect_success 'flux job wait-event --time-format=raw works' '
@@ -654,7 +654,7 @@ test_expect_success 'flux job wait-event --time-format=offset works' '
 
 test_expect_success 'flux job wait-event --time-format=invalid fails works' '
         jobid=$(submit_job) &&
-	! flux job wait-event --time-format=invalid $jobid submit
+	test_must_fail flux job wait-event --time-format=invalid $jobid submit
 '
 
 test_expect_success 'flux job wait-event w/ match-context works (string w/ quotes)' '
@@ -690,7 +690,7 @@ test_expect_success 'flux job wait-event w/ bad match-context fails (invalid val
 
 test_expect_success 'flux job wait-event w/ bad match-context fails (invalid input)' '
         jobid=$(submit_job) &&
-        ! flux job wait-event --match-context=foo $jobid exception
+        test_must_fail flux job wait-event --match-context=foo $jobid exception
 '
 
 test_expect_success 'flux job wait-event -p works (eventlog)' '
@@ -715,12 +715,12 @@ test_expect_success 'flux job wait-event -p works (non-guest eventlog)' '
 
 test_expect_success 'flux job wait-event -p fails on invalid path' '
         jobid=$(submit_job) &&
-        ! flux job wait-event -p "foobar" $jobid submit
+        test_must_fail flux job wait-event -p "foobar" $jobid submit
 '
 
 test_expect_success 'flux job wait-event -p fails on path "guest."' '
         jobid=$(submit_job) &&
-        ! flux job wait-event -p "guest." $jobid submit
+        test_must_fail flux job wait-event -p "guest." $jobid submit
 '
 
 test_expect_success 'flux job wait-event -p hangs on non-guest eventlog' '
@@ -810,7 +810,7 @@ test_expect_success 'flux job info eventlog works' '
 '
 
 test_expect_success 'flux job info eventlog fails on bad id' '
-	! flux job info 12345 eventlog
+	test_must_fail flux job info 12345 eventlog
 '
 
 test_expect_success 'flux job info jobspec works' '
@@ -820,7 +820,7 @@ test_expect_success 'flux job info jobspec works' '
 '
 
 test_expect_success 'flux job info jobspec fails on bad id' '
-	! flux job info 12345 jobspec
+	test_must_fail flux job info 12345 jobspec
 '
 
 #
@@ -835,21 +835,21 @@ test_expect_success 'flux job info multiple keys works' '
 '
 
 test_expect_success 'flux job info multiple keys fails on bad id' '
-	! flux job info 12345 eventlog jobspec J
+	test_must_fail flux job info 12345 eventlog jobspec J
 '
 
 test_expect_success 'flux job info multiple keys fails on 1 bad entry (include eventlog)' '
         jobid=$(submit_job) &&
         kvsdir=$(flux job id --to=kvs $jobid) &&
         flux kvs unlink ${kvsdir}.jobspec &&
-	! flux job info $jobid eventlog jobspec J > all_info_b.out
+	test_must_fail flux job info $jobid eventlog jobspec J > all_info_b.out
 '
 
 test_expect_success 'flux job info multiple keys fails on 1 bad entry (no eventlog)' '
         jobid=$(submit_job) &&
         kvsdir=$(flux job id --to=kvs $jobid) &&
         flux kvs unlink ${kvsdir}.jobspec &&
-	! flux job info $jobid jobspec J > all_info_b.out
+	test_must_fail flux job info $jobid jobspec J > all_info_b.out
 '
 
 #

--- a/t/t2204-job-info.t
+++ b/t/t2204-job-info.t
@@ -370,7 +370,7 @@ test_expect_success 'flux job list outputs ntasks correctly (1 task)' '
         echo $jobid > taskcount1.id &&
         flux job wait-event $jobid clean >/dev/null &&
         obj=$(flux job list -s inactive | grep $jobid) &&
-        echo $obj | jq -e ".[\"ntasks\"] == 1"
+        echo $obj | jq -e ".ntasks == 1"
 '
 
 test_expect_success 'flux job list outputs ntasks correctly (4 tasks)' '
@@ -378,7 +378,7 @@ test_expect_success 'flux job list outputs ntasks correctly (4 tasks)' '
         echo $jobid > taskcount2.id &&
         flux job wait-event $jobid clean >/dev/null &&
         obj=$(flux job list -s inactive | grep $jobid) &&
-        echo $obj | jq -e ".[\"ntasks\"] == 4"
+        echo $obj | jq -e ".ntasks == 4"
 '
 
 test_expect_success 'reload the job-info module' '
@@ -390,9 +390,9 @@ test_expect_success 'verify task count preserved across restart' '
         jobid1=`cat taskcount1.id` &&
         jobid2=`cat taskcount2.id` &&
         obj=$(flux job list -s inactive | grep ${jobid1}) &&
-        echo $obj | jq -e ".[\"ntasks\"] == 1" &&
+        echo $obj | jq -e ".ntasks == 1" &&
         obj=$(flux job list -s inactive | grep ${jobid2}) &&
-        echo $obj | jq -e ".[\"ntasks\"] == 4"
+        echo $obj | jq -e ".ntasks == 4"
 '
 
 #

--- a/t/t2204-job-info.t
+++ b/t/t2204-job-info.t
@@ -727,7 +727,7 @@ test_expect_success 'flux job wait-event -p hangs on non-guest eventlog' '
         jobid=$(submit_job) &&
         kvsdir=$(flux job id --to=kvs $jobid) &&
 	flux kvs eventlog append ${kvsdir}.foobar.eventlog foo &&
-        ! run_timeout 0.2 flux job wait-event -p "foobar.eventlog" $jobid bar
+        test_expect_code 142 run_timeout 0.2 flux job wait-event -p "foobar.eventlog" $jobid bar
 '
 
 test_expect_success NO_CHAIN_LINT 'flux job wait-event -p guest.exec.eventlog works (live job)' '
@@ -745,7 +745,7 @@ test_expect_success NO_CHAIN_LINT 'flux job wait-event -p guest.exec.eventlog wo
 
 test_expect_success 'flux job wait-event -p times out on no event (live job)' '
         jobid=$(submit_job_live sleeplong.json) &&
-        ! run_timeout 0.2 flux job wait-event -p "guest.exec.eventlog" $jobid foobar &&
+        test_expect_code 142 run_timeout 0.2 flux job wait-event -p "guest.exec.eventlog" $jobid foobar &&
         flux job cancel $jobid
 '
 
@@ -777,7 +777,7 @@ test_expect_success NO_CHAIN_LINT 'flux job wait-event -p guest.exec.eventlog wo
 test_expect_success 'flux job wait-event -p times out on no event (wait job)' '
         jobidall=$(submit_job_live sleeplong-all-rsrc.json) &&
         jobid=$(submit_job_wait) &&
-        ! run_timeout 0.2 flux job wait-event -p "guest.exec.eventlog" $jobid foobar &&
+        test_expect_code 142 run_timeout 0.2 flux job wait-event -p "guest.exec.eventlog" $jobid foobar &&
         flux job cancel $jobidall &&
         flux job cancel $jobid
 '

--- a/t/t2204-job-info.t
+++ b/t/t2204-job-info.t
@@ -246,9 +246,11 @@ test_expect_success HAVE_JQ 'job stats lists jobs in correct state (mix)' '
 test_expect_success 'cleanup job listing jobs ' '
         for jobid in `cat job_ids_pending.out`; do \
             flux job cancel $jobid; \
+            flux job wait-event $jobid clean; \
         done &&
         for jobid in `cat job_ids_running.out`; do \
             flux job cancel $jobid; \
+            flux job wait-event $jobid clean; \
         done
 '
 

--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -35,7 +35,7 @@ test_expect_success 'load job-exec,sched-simple modules' '
 #
 # the job-info module has eventual consistency with the jobs stored in
 # the job-manager's queue.  To ensure no raciness in tests, we spin
-# until all of the pending jobs have rached SCHED state.
+# until all of the pending jobs have reached SCHED state.
 #
 
 wait_sched() {


### PR DESCRIPTION
Per issue #2665, this will fix some eventual consistency racyness in `t2204-job-info`.  It won't fix all racyness (such as the one @dongahn saw in #2654), some will be fixed later via issue #2592.

There's some tiny cleanups in here.  Assuming this PR will go in first, I went ahead and cherry-picked some cheapo cleanups from PR #2655 too.