### PR TITLE
job-manager: fix counting problem that leads to scheduler sadness

### DIFF
--- a/src/modules/job-manager/alloc.c
+++ b/src/modules/job-manager/alloc.c
@@ -477,7 +477,6 @@ void alloc_dequeue_alloc_request (struct alloc *alloc, struct job *job)
         zlistx_delete (alloc->pending, job->handle);
         job->handle = NULL;
         job->alloc_queued = 0;
-        alloc->active_alloc_count--;
     }
 }
 

--- a/src/modules/sched-simple/sched.c
+++ b/src/modules/sched-simple/sched.c
@@ -192,6 +192,7 @@ static void alloc_cb (flux_t *h, const flux_msg_t *msg,
 
     if (ss->job) {
         flux_log (h, LOG_ERR, "alloc received before previous one handled");
+        errno = EINVAL;
         goto err;
     }
     if (!(ss->job = jobreq_create (msg, jobspec))) {

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -99,6 +99,7 @@ TESTSCRIPTS = \
 	t2205-job-info-security.t \
 	t2206-job-manager-bulk-state.t \
 	t2207-job-manager-wait.t \
+	t2210-job-manager-bugs.t \
 	t2300-sched-simple.t \
 	t2301-schedutil-outstanding-requests.t \
 	t2400-job-exec-test.t \

--- a/t/t2204-job-info.t
+++ b/t/t2204-job-info.t
@@ -98,9 +98,6 @@ test_expect_success 'load job-exec,sched-simple modules' '
 #   - inactive jobs - by completion time (most recent first)
 #
 # TODO
-# - in order to test sorting, jobs should be submitted below in an
-#   unordered fashion.  However, issues exist that do not allow for
-#   such testing at this moment.  See Issue #2470.
 # - alternate userid job listing
 #
 # the job-info module has eventual consistency with the jobs stored in
@@ -137,9 +134,9 @@ test_expect_success 'submit jobs for job list testing' '
             flux job wait-event `tail -n 1 job_ids2.out` start; \
         done &&
         tac job_ids2.out > job_ids_running.out &&
-        id1=$(flux job submit -p31 hostname.json) &&
         id2=$(flux job submit -p20 hostname.json) &&
         id3=$(flux job submit      hostname.json) &&
+        id1=$(flux job submit -p31 hostname.json) &&
         id4=$(flux job submit -p0  hostname.json) &&
         echo $id1 >> job_ids_pending.out &&
         echo $id2 >> job_ids_pending.out &&

--- a/t/t2210-job-manager-bugs.t
+++ b/t/t2210-job-manager-bugs.t
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+test_description='Regression tests for job-manager bugs'
+
+. $(dirname $0)/sharness.sh
+
+test_under_flux 1
+
+flux setattr log-stderr-level 1
+
+#
+# Issue 2664 job-manager: counting error
+#
+
+test_expect_success 'issue2664: start three jobs ' '
+	echo Requesting $(nproc) cores &&
+	flux mini submit -n $(nproc) sleep 3600 >job1.out &&
+	flux mini submit hostname >job2.out &&
+	flux mini submit hostname >job3.out
+'
+# canceling job that has not yet sent alloc to scheduler improperly
+# decrements count of outstanding alloc requests
+test_expect_success 'issue2664: cancel job 3' '
+	flux job cancel $(cat job3.out)
+'
+# Next job submitted triggers another alloc request when ther are no
+# more slots, which triggers error response from scheduler that is fatal
+# to job manager.
+test_expect_success 'issue2664: submit job 4' '
+	flux mini submit hostname >job4.out
+'
+# Hangs here (hitting timeout)
+test_expect_success 'issue2664: cancel job 1 and drain (cleanup)' '
+	flux job cancel $(cat job1.out) &&
+	run_timeout 5 flux job drain
+'
+
+test_done


### PR DESCRIPTION
This is the trivial fix for issue #2664, where the right combination of submits and cancels results in the scheduler complaining of
```
sched-simple.err[0]: alloc received before previous one handled
sched-simple.err[0]: alloc: flux_respond_error: Invalid argument
```
because the job manager loses count of how many alloc requests it has sent to the scheduler.