### PR TITLE
testsuite: fix unsafe getenv in libpmi tests, use of /tmp in sharness tests

### DIFF
--- a/src/common/libpmi/test/canonical.c
+++ b/src/common/libpmi/test/canonical.c
@@ -30,7 +30,6 @@ int main (int argc, char *argv[])
     int universe_size;
     char *kvsname;
     char *val;
-    char pmi_fd[16];
     char pmi_rank[16];
     char pmi_size[16];
     int result;
@@ -49,18 +48,20 @@ int main (int argc, char *argv[])
 
     plan (NO_PLAN);
 
-    srv = pmi_server_create (cfd, 1);
-
-    snprintf (pmi_fd, sizeof (pmi_fd), "%d", cfd[0]);
+    /* Modify environment before spawning server thread to avoid
+     *  racing with getenv() in libev during reactor initialization
+     */
     snprintf (pmi_rank, sizeof (pmi_rank), "%d", 0);
     snprintf (pmi_size, sizeof (pmi_size), "%d", 1);
 
-    setenv ("PMI_FD", pmi_fd, 1);
     setenv ("PMI_RANK", pmi_rank, 1);
     setenv ("PMI_SIZE", pmi_size, 1);
 
     setenv ("PMI_DEBUG", "1", 1);
     setenv ("PMI_SPAWNED", "0", 1);
+
+    /* PMI_FD exported in pmi_server_create */
+    srv = pmi_server_create (cfd, 1);
 
     /* Elicit PMI_ERR_INIT error by calling functions before PMI_Init()
      */

--- a/src/common/libpmi/test/canonical2.c
+++ b/src/common/libpmi/test/canonical2.c
@@ -29,7 +29,6 @@ int main (int argc, char *argv[])
     int cfd[1];
     char jobid[PMI2_MAX_ATTRVALUE + 1];
     char val[PMI2_MAX_VALLEN + 1];
-    char pmi_fd[16];
     char pmi_rank[16];
     char pmi_size[16];
     int result;
@@ -43,18 +42,20 @@ int main (int argc, char *argv[])
 
     plan (NO_PLAN);
 
-    srv = pmi_server_create (cfd, 1);
-
-    snprintf (pmi_fd, sizeof (pmi_fd), "%d", cfd[0]);
+    /* Modify environment before spawning server thread to avoid
+     *  racing with getenv() in libev during reactor initialization
+     */
     snprintf (pmi_rank, sizeof (pmi_rank), "%d", 0);
     snprintf (pmi_size, sizeof (pmi_size), "%d", 1);
 
-    setenv ("PMI_FD", pmi_fd, 1);
     setenv ("PMI_RANK", pmi_rank, 1);
     setenv ("PMI_SIZE", pmi_size, 1);
 
     setenv ("PMI2_DEBUG", "1", 1);
     setenv ("PMI_SPAWNED", "0", 1);
+
+    /* PMI_FD exported in pmi_server_create */
+    srv = pmi_server_create (cfd, 1);
 
     /* Elicit PMI2_ERR_INIT error by calling functions before PMI_Init()
      */

--- a/src/common/libpmi/test/server_thread.c
+++ b/src/common/libpmi/test/server_thread.c
@@ -165,6 +165,7 @@ void s_trace (void *arg, const char *buf)
 
 struct pmi_server_context *pmi_server_create (int *cfd, int size)
 {
+    char pmi_fd[16];
     struct pmi_simple_ops server_ops = {
         .kvs_put = s_kvs_put,
         .kvs_get = s_kvs_get,
@@ -207,6 +208,9 @@ struct pmi_server_context *pmi_server_create (int *cfd, int size)
                                          ctx);
     if (!ctx->pmi)
         BAIL_OUT ("pmi_simple_server_create failed");
+
+    snprintf (pmi_fd, sizeof (pmi_fd), "%d", cfd[0]);
+    setenv ("PMI_FD", pmi_fd, 1);
 
     if (pthread_create (&ctx->t, NULL, server_thread, ctx) != 0)
         BAIL_OUT ("pthread_create failed");

--- a/src/test/docker/centos7/Dockerfile
+++ b/src/test/docker/centos7/Dockerfile
@@ -85,3 +85,6 @@ RUN mkdir caliper \
  && rm -rf caliper
 
 COPY config.site /usr/share/config.site
+
+# Create /tmp -> /var/tmp link to ensure Flux tests work in this configuration
+RUN rm -rf /tmp && ln -sf /var/tmp /tmp

--- a/t/t0005-exec.t
+++ b/t/t0005-exec.t
@@ -15,6 +15,8 @@ invalid_rank() {
        echo $((${SIZE} + 1))
 }
 
+TMPDIR=$(cd /tmp && $(which pwd))
+
 test_expect_success 'basic exec functionality' '
 	flux exec -n /bin/true
 '
@@ -79,12 +81,12 @@ test_expect_success 'flux exec does not pass FLUX_URI' '
 '
 
 test_expect_success 'flux exec passes cwd' '
-	(cd /tmp &&
-	flux exec -n sh -c "test \`pwd\` = \"/tmp\"")
+	(cd ${TMPDIR} &&
+	flux exec -n sh -c "test \`pwd\` = \"${TMPDIR}\"")
 '
 
 test_expect_success 'flux exec -d option works' '
-	flux exec -n -d /tmp sh -c "test \`pwd\` = \"/tmp\""
+	flux exec -n -d ${TMPDIR} sh -c "test \`pwd\` = \"${TMPDIR}\""
 '
 
 # Run a script on ranks 0-3 simultaneously with each rank writing the

--- a/t/t0005-rexec.t
+++ b/t/t0005-rexec.t
@@ -22,9 +22,11 @@ test_expect_success 'basic rexec functionality (process fail)' '
 '
 
 test_expect_success 'basic rexec - cwd correct' '
-	(cd /tmp &&
-         cwd=`${FLUX_BUILD_DIR}/t/rexec/rexec pwd` &&
-         test "$cwd" = "/tmp")
+	pwd=$(which pwd) &&
+	tmpdir=$(cd /tmp && $pwd) &&
+	(cd ${tmpdir} &&
+         cwd=`${FLUX_BUILD_DIR}/t/rexec/rexec $pwd` &&
+         test "$cwd" = "$tmpdir")
 '
 
 test_expect_success 'basic rexec - env passed through' '

--- a/t/t0015-cron.t
+++ b/t/t0015-cron.t
@@ -127,10 +127,11 @@ test_expect_success '--preserve-env option works' '
     flux dmesg | grep "cron-${id}.*command=\"printenv FOO\": \"bar\""
 '
 test_expect_success '--working-dir option works' '
+    tmpdir=$(cd /tmp && $(which pwd)) &&
     id=$(flux_cron interval -c1 -d /tmp .01s pwd) &&
     sleep .1 &&
     cron_entry_check ${id} stopped true &&
-    flux dmesg | grep "cron-${id}.*command=\"pwd\": \"/tmp\""
+    flux dmesg | grep "cron-${id}.*command=\"pwd\": \"${tmpdir}\""
 '
 
 test_expect_success 'cron entry exec failure is recorded' '


### PR DESCRIPTION
This PR has some small fixes for tests, including fixes for #2668 and #2663.

The Dockerfile for centos 7 is also changed to make /tmp a symlink to /var/tmp, so that we don't accidentally commit future tests that have the same issue as described in #2663.

Once this PR is merged, I will push an update to our `fluxrm/testenv:centos7` image.