### PR TITLE
libflux/message: add message cred helpers

### DIFF
--- a/src/cmd/builtin/proxy.c
+++ b/src/cmd/builtin/proxy.c
@@ -141,7 +141,7 @@ static void uconn_error (struct usock_conn *uconn, int errnum, void *arg)
     struct proxy_command *ctx = arg;
 
     if (errnum != EPIPE && errnum != EPROTO && errnum != ECONNRESET) {
-        const struct auth_cred *cred = usock_conn_get_cred (uconn);
+        const struct flux_msg_cred *cred = usock_conn_get_cred (uconn);
         errno = errnum;
         flux_log_error (ctx->h,
                         "client=%.5s userid=%u",
@@ -167,7 +167,7 @@ static void uconn_recv (struct usock_conn *uconn, flux_msg_t *msg, void *arg)
 static int uconn_send (const flux_msg_t *msg, void *arg)
 {
     struct usock_conn *uconn = arg;
-    const struct auth_cred *cred;
+    const struct flux_msg_cred *cred;
     int type;
 
     if (flux_msg_get_type (msg, &type) < 0)
@@ -190,7 +190,7 @@ static int uconn_send (const flux_msg_t *msg, void *arg)
 static void acceptor_cb (struct usock_conn *uconn, void *arg)
 {
     struct proxy_command *ctx = arg;
-    const struct auth_cred *cred;
+    const struct flux_msg_cred *cred;
     struct router_entry *entry;
 
     /* Userid is the user running flux-proxy (else reject).

--- a/src/cmd/builtin/relay.c
+++ b/src/cmd/builtin/relay.c
@@ -88,7 +88,7 @@ static void relay (int infd, int outfd, flux_t *h)
     struct router *router;
     struct router_entry *entry;
     struct usock_conn *uconn;
-    struct auth_cred cred;
+    struct flux_msg_cred cred;
     flux_reactor_t *r;
 
     if (!(r = flux_get_reactor (h)))

--- a/src/common/libflux/message.c
+++ b/src/common/libflux/message.c
@@ -448,9 +448,17 @@ bool flux_msg_is_streaming (const flux_msg_t *msg)
 
 int flux_msg_set_userid (flux_msg_t *msg, uint32_t userid)
 {
-    zframe_t *zf = zmsg_last (msg->zmsg);
-    if (!zf || proto_set_u32 (zframe_data (zf), zframe_size (zf),
-                              PROTO_IND_USERID, userid) < 0) {
+    zframe_t *zf;
+
+    if (!msg) {
+        errno = EINVAL;
+        return -1;
+    }
+    zf = zmsg_last (msg->zmsg);
+    if (!zf || proto_set_u32 (zframe_data (zf),
+                              zframe_size (zf),
+                              PROTO_IND_USERID,
+                              userid) < 0) {
         errno = EINVAL;
         return -1;
     }
@@ -459,9 +467,17 @@ int flux_msg_set_userid (flux_msg_t *msg, uint32_t userid)
 
 int flux_msg_get_userid (const flux_msg_t *msg, uint32_t *userid)
 {
-    zframe_t *zf = zmsg_last (msg->zmsg);
-    if (!zf || proto_get_u32 (zframe_data (zf), zframe_size (zf),
-                              PROTO_IND_USERID, userid) < 0) {
+    zframe_t *zf;
+
+    if (!msg || !userid) {
+        errno = EINVAL;
+        return -1;
+    }
+    zf = zmsg_last (msg->zmsg);
+    if (!zf || proto_get_u32 (zframe_data (zf),
+                              zframe_size (zf),
+                              PROTO_IND_USERID,
+                              userid) < 0) {
         errno = EPROTO;
         return -1;
     }
@@ -470,9 +486,17 @@ int flux_msg_get_userid (const flux_msg_t *msg, uint32_t *userid)
 
 int flux_msg_set_rolemask (flux_msg_t *msg, uint32_t rolemask)
 {
-    zframe_t *zf = zmsg_last (msg->zmsg);
-    if (!zf || proto_set_u32 (zframe_data (zf), zframe_size (zf),
-                              PROTO_IND_ROLEMASK, rolemask) < 0) {
+    zframe_t *zf;
+
+    if (!msg) {
+        errno = EINVAL;
+        return -1;
+    }
+    zf = zmsg_last (msg->zmsg);
+    if (!zf || proto_set_u32 (zframe_data (zf),
+                              zframe_size (zf),
+                              PROTO_IND_ROLEMASK,
+                              rolemask) < 0) {
         errno = EINVAL;
         return -1;
     }
@@ -481,9 +505,17 @@ int flux_msg_set_rolemask (flux_msg_t *msg, uint32_t rolemask)
 
 int flux_msg_get_rolemask (const flux_msg_t *msg, uint32_t *rolemask)
 {
-    zframe_t *zf = zmsg_last (msg->zmsg);
-    if (!zf || proto_get_u32 (zframe_data (zf), zframe_size (zf),
-                              PROTO_IND_ROLEMASK, rolemask) < 0) {
+    zframe_t *zf;
+
+    if (!msg || !rolemask) {
+        errno = EINVAL;
+        return -1;
+    }
+    zf = zmsg_last (msg->zmsg);
+    if (!zf || proto_get_u32 (zframe_data (zf),
+                              zframe_size (zf),
+                              PROTO_IND_ROLEMASK,
+                              rolemask) < 0) {
         errno = EPROTO;
         return -1;
     }

--- a/src/common/libflux/message.h
+++ b/src/common/libflux/message.h
@@ -222,6 +222,28 @@ enum {
 int flux_msg_set_rolemask (flux_msg_t *msg, uint32_t rolemask);
 int flux_msg_get_rolemask (const flux_msg_t *msg, uint32_t *rolemask);
 
+/* Combined rolemask, userid access for convenience
+ */
+struct flux_msg_cred {
+    uint32_t userid;
+    uint32_t rolemask;
+};
+int flux_msg_get_cred (const flux_msg_t *msg, struct flux_msg_cred *cred);
+int flux_msg_set_cred (flux_msg_t *msg, struct flux_msg_cred cred);
+
+/* Simple authorization for service access:
+ * If cred rolemask includes OWNER, grant (return 0).
+ * If cred rolemask includes USER and userid matches 'userid',
+ * and userid is not FLUX_USERID_UNKNOWN, grant (return 0).
+ * Otherwise deny (return -1, errno = EPERM).
+ */
+int flux_msg_cred_authorize (struct flux_msg_cred cred, uint32_t userid);
+
+/* Convenience functions that calls
+ * flux_msg_get_cred() + flux_msg_cred_authorize().
+ */
+int flux_msg_authorize (const flux_msg_t *msg, uint32_t userid);
+
 /* Get/set errnum (response/keepalive only)
  */
 int flux_msg_set_errnum (flux_msg_t *msg, int errnum);

--- a/src/common/libflux/test/rpc.c
+++ b/src/common/libflux/test/rpc.c
@@ -282,7 +282,8 @@ void test_service (flux_t *h)
     flux_msg_t *msg;
     const char *topic;
     int count;
-    uint32_t rolemask, userid, matchtag;
+    uint32_t matchtag;
+    struct flux_msg_cred cred;
     int rc;
 
     errno = 0;
@@ -305,12 +306,11 @@ void test_service (flux_t *h)
     rc = flux_msg_get_matchtag (msg, &matchtag);
     ok (rc == 0 && matchtag == 1,
         "response has first matchtag", matchtag);
-    rc = flux_msg_get_userid (msg, &userid);
-    ok (rc == 0 && userid == geteuid (),
-        "response has userid equal to effective uid of test");
-    rc = flux_msg_get_rolemask (msg, &rolemask);
-    ok (rc == 0 && (rolemask & FLUX_ROLE_OWNER) != 0,
-        "response has rolemask including instance owner");
+    rc = flux_msg_get_cred (msg, &cred);
+    ok (rc == 0
+        && cred.userid == geteuid ()
+        && (cred.rolemask & FLUX_ROLE_OWNER),
+        "response has cred.userid=EUID, cred.rolemask including OWNER");
     errno = 0;
     rc = flux_msg_get_route_count (msg);
     ok ((rc == -1 && errno == EINVAL) || (rc == 0),

--- a/src/common/librouter/auth.c
+++ b/src/common/librouter/auth.c
@@ -43,7 +43,7 @@ int auth_lookup_rolemask_get (flux_future_t *f, uint32_t *rolemask)
     return 0;
 }
 
-int auth_init_message (flux_msg_t *msg, const struct auth_cred *conn)
+int auth_init_message (flux_msg_t *msg, const struct flux_msg_cred *conn)
 {
     if (!msg || !conn) {
         errno = EINVAL;
@@ -65,7 +65,7 @@ int auth_init_message (flux_msg_t *msg, const struct auth_cred *conn)
      * If they have not been set, overwrite with connect creds, as above.
      */
     else {
-        struct auth_cred cred;
+        struct flux_msg_cred cred;
 
         if (flux_msg_get_userid (msg, &cred.userid) < 0)
             return -1;
@@ -85,7 +85,7 @@ int auth_init_message (flux_msg_t *msg, const struct auth_cred *conn)
 }
 
 int auth_check_event_privacy (const flux_msg_t *msg,
-                              const struct auth_cred *cred)
+                              const struct flux_msg_cred *cred)
 {
     if (!msg || !cred) {
         errno = EINVAL;

--- a/src/common/librouter/auth.h
+++ b/src/common/librouter/auth.h
@@ -13,11 +13,6 @@
 
 #include <flux/core.h>
 
-struct auth_cred {
-    uint32_t userid;
-    uint32_t rolemask;
-};
-
 /* Look up user in the 'userdb' to determine assigned roles.
  */
 flux_future_t *auth_lookup_rolemask (flux_t *h, uint32_t userid);
@@ -25,13 +20,13 @@ int auth_lookup_rolemask_get (flux_future_t *f, uint32_t *rolemask);
 
 /* Initialize received message creds based on the connected user's credentials.
  */
-int auth_init_message (flux_msg_t *msg, const struct auth_cred *conn);
+int auth_init_message (flux_msg_t *msg, const struct flux_msg_cred *conn);
 
 /* Determine whether event 'msg' may be received by a connection,
  * based on connected user's credentials.
  */
 int auth_check_event_privacy (const flux_msg_t *msg,
-                              const struct auth_cred *conn);
+                              const struct flux_msg_cred *conn);
 
 #endif /* !_ROUTER_AUTH_H */
 

--- a/src/common/librouter/test/auth.c
+++ b/src/common/librouter/test/auth.c
@@ -39,14 +39,12 @@ void lookup (void)
     flux_future_destroy (f);
 }
 
-int checkcred (const flux_msg_t *msg, struct auth_cred *cred)
+int checkcred (const flux_msg_t *msg, struct flux_msg_cred *cred)
 {
-    struct auth_cred msgcred;
+    struct flux_msg_cred msgcred;
 
-    if (flux_msg_get_rolemask (msg, &msgcred.rolemask) < 0)
-        BAIL_OUT ("flux_msg_get_rolemask faild");
-    if (flux_msg_get_userid (msg, &msgcred.userid) < 0)
-        BAIL_OUT ("flux_msg_get_userid faild");
+    if (flux_msg_get_cred (msg, &msgcred) < 0)
+        BAIL_OUT ("flux_msg_get_cred faild");
     if (msgcred.rolemask != cred->rolemask)
         return -1;
     if (msgcred.userid != cred->userid)
@@ -54,20 +52,18 @@ int checkcred (const flux_msg_t *msg, struct auth_cred *cred)
     return 0;
 }
 
-void setcred (flux_msg_t *msg, struct auth_cred *cred)
+void setcred (flux_msg_t *msg, struct flux_msg_cred cred)
 {
-    if (flux_msg_set_rolemask (msg, cred->rolemask) < 0)
-        BAIL_OUT ("flux_msg_set_rolemask failed");
-    if (flux_msg_set_userid (msg, cred->userid) < 0)
-        BAIL_OUT ("flux_msg_set_userid failed");
+    if (flux_msg_set_cred (msg, cred) < 0)
+        BAIL_OUT ("flux_msg_set_cred failed");
 }
 
 void init_message (void)
 {
-    struct auth_cred nocred = { .userid = FLUX_USERID_UNKNOWN,
+    struct flux_msg_cred nocred = { .userid = FLUX_USERID_UNKNOWN,
                                 .rolemask = FLUX_ROLE_NONE };
-    struct auth_cred ocred = { .userid = 0, .rolemask = FLUX_ROLE_OWNER };
-    struct auth_cred gcred = { .userid = 42, .rolemask = FLUX_ROLE_USER };
+    struct flux_msg_cred ocred = { .userid = 0, .rolemask = FLUX_ROLE_OWNER };
+    struct flux_msg_cred gcred = { .userid = 42, .rolemask = FLUX_ROLE_USER };
     flux_msg_t *msg;
 
     if (!(msg = flux_request_encode ("foo", NULL)))
@@ -75,21 +71,21 @@ void init_message (void)
 
     /* unint message gets connection creds (common case)
      */
-    setcred (msg, &nocred);
+    setcred (msg, nocred);
     ok (auth_init_message (msg, &ocred) == 0 && checkcred (msg, &ocred) == 0,
         "auth_init_message conn=owner uninit message cred set to owner");
 
-    setcred (msg, &nocred);
+    setcred (msg, nocred);
     ok (auth_init_message (msg, &gcred) == 0 && checkcred (msg, &gcred) == 0,
         "auth_init_message conn=guest uninit message cred set to guest");
 
     /* ability for connected owner message creds to pass through, not guest.
      */
-    setcred (msg, &gcred);
+    setcred (msg, gcred);
     ok (auth_init_message (msg, &ocred) == 0 && checkcred (msg, &gcred) == 0,
         "auth_init_message conn=owner init message creds pass through");
 
-    setcred (msg, &ocred);
+    setcred (msg, ocred);
     ok (auth_init_message (msg, &gcred) == 0 && checkcred (msg, &gcred) == 0,
         "auth_init_message conn=guest init message creds set to guest");
 
@@ -108,9 +104,9 @@ void init_message (void)
 
 void event_privacy (void)
 {
-    struct auth_cred ocred = { .userid = 0, .rolemask = FLUX_ROLE_OWNER };
-    struct auth_cred gcred = { .userid = 42, .rolemask = FLUX_ROLE_USER };
-    struct auth_cred g2cred = { .userid = 43, .rolemask = FLUX_ROLE_USER };
+    struct flux_msg_cred ocred = { .userid = 0, .rolemask = FLUX_ROLE_OWNER };
+    struct flux_msg_cred gcred = { .userid = 42, .rolemask = FLUX_ROLE_USER };
+    struct flux_msg_cred g2cred = { .userid = 43, .rolemask = FLUX_ROLE_USER };
     flux_msg_t *msg;
 
     if (!(msg = flux_event_encode ("foo", NULL)))
@@ -118,10 +114,10 @@ void event_privacy (void)
 
     /* public events visible to owner and guest
      */
-    setcred (msg, &ocred);
+    setcred (msg, ocred);
     ok (auth_check_event_privacy (msg, &ocred) == 0,
        "auth_check_event_privacy conn=owner can see owner public event");
-    setcred (msg, &gcred);
+    setcred (msg, gcred);
     ok (auth_check_event_privacy (msg, &ocred) == 0,
        "auth_check_event_privacy conn=owner can see guest public event");
 
@@ -130,26 +126,26 @@ void event_privacy (void)
 
     /* private events visible to owner
      */
-    setcred (msg, &ocred);
+    setcred (msg, ocred);
     ok (auth_check_event_privacy (msg, &ocred) == 0,
        "auth_check_event_privacy conn=owner can see owner private event");
-    setcred (msg, &gcred);
+    setcred (msg, gcred);
     ok (auth_check_event_privacy (msg, &ocred) == 0,
        "auth_check_event_privacy conn=owner can see guest private event");
 
     /* private event visibility to guests is limited to their own
      */
-    setcred (msg, &ocred);
+    setcred (msg, ocred);
     errno = 0;
     ok (auth_check_event_privacy (msg, &gcred) < 0 && errno == EPERM,
        "auth_check_event_privacy conn=guest cannot see owner private event");
 
-    setcred (msg, &g2cred);
+    setcred (msg, g2cred);
     errno = 0;
     ok (auth_check_event_privacy (msg, &gcred) < 0 && errno == EPERM,
        "auth_check_event_privacy conn=guest cannot see guest2 private event");
 
-    setcred (msg, &gcred);
+    setcred (msg, gcred);
     ok (auth_check_event_privacy (msg, &gcred) == 0,
        "auth_check_event_privacy conn=guest can see guest private event");
 

--- a/src/common/librouter/test/usock_echo.c
+++ b/src/common/librouter/test/usock_echo.c
@@ -68,7 +68,7 @@ static void server_error_cb (struct usock_conn *conn, int errnum, void *arg)
 
 static void server_acceptor (struct usock_conn *conn, void *arg)
 {
-    const struct auth_cred *cred;
+    const struct flux_msg_cred *cred;
 
     cred = usock_conn_get_cred (conn);
 

--- a/src/common/librouter/usock.c
+++ b/src/common/librouter/usock.c
@@ -78,7 +78,7 @@ struct usock_io {
 };
 
 struct usock_conn {
-    struct auth_cred cred;
+    struct flux_msg_cred cred;
     struct usock_io in;
     struct usock_io out;
     zlist_t *outqueue;
@@ -105,7 +105,7 @@ struct usock_client {
     struct iobuf out_iobuf;
 };
 
-const struct auth_cred *usock_conn_get_cred (struct usock_conn *conn)
+const struct flux_msg_cred *usock_conn_get_cred (struct usock_conn *conn)
 {
     return conn ? &conn->cred : NULL;
 }
@@ -256,7 +256,7 @@ static int write_char (int fd, unsigned char c)
  * then put the fd in nonblocking mode and start the recv watcher.
  */
 void usock_conn_accept (struct usock_conn *conn,
-                        const struct auth_cred *cred)
+                        const struct flux_msg_cred *cred)
 {
     if (conn && cred) {
         conn->cred = *cred;
@@ -349,7 +349,7 @@ void usock_server_destroy (struct usock_server *server)
     }
 }
 
-static int get_socket_peercred (int fd, struct auth_cred *cred)
+static int get_socket_peercred (int fd, struct flux_msg_cred *cred)
 {
     struct ucred ucred;
     socklen_t crlen;

--- a/src/common/librouter/usock.h
+++ b/src/common/librouter/usock.h
@@ -62,7 +62,7 @@ void usock_server_set_acceptor (struct usock_server *server,
 
 int usock_conn_send (struct usock_conn *conn, const flux_msg_t *msg);
 
-const struct auth_cred *usock_conn_get_cred (struct usock_conn *conn);
+const struct flux_msg_cred *usock_conn_get_cred (struct usock_conn *conn);
 
 const char *usock_conn_get_uuid (struct usock_conn *conn);
 
@@ -75,7 +75,7 @@ void usock_conn_set_recv_cb (struct usock_conn *conn,
                              void *arg);
 
 void usock_conn_accept (struct usock_conn *conn,
-                        const struct auth_cred *cred);
+                        const struct flux_msg_cred *cred);
 void usock_conn_reject (struct usock_conn *conn, int errnum);
 
 void *usock_conn_aux_get (struct usock_conn *conn, const char *name);

--- a/src/modules/connector-local/local.c
+++ b/src/modules/connector-local/local.c
@@ -56,7 +56,7 @@ static const char *route_auxkey = "flux::route";
 static int client_authenticate (flux_t *h,
                                 uint32_t instance_owner,
                                 uid_t cuid,
-                                struct auth_cred *cred)
+                                struct flux_msg_cred *cred)
 {
     uint32_t rolemask;
     flux_future_t *f;
@@ -110,7 +110,7 @@ static void uconn_error (struct usock_conn *uconn, int errnum, void *arg)
     struct connector_local *ctx = arg;
 
     if (errnum != EPIPE && errnum != EPROTO && errnum != ECONNRESET) {
-        const struct auth_cred *cred = usock_conn_get_cred (uconn);
+        const struct flux_msg_cred *cred = usock_conn_get_cred (uconn);
         errno = errnum;
         flux_log_error (ctx->h,
                         "client=%.5s userid=%u",
@@ -135,7 +135,7 @@ static void uconn_recv (struct usock_conn *uconn, flux_msg_t *msg, void *arg)
 static int uconn_send (const flux_msg_t *msg, void *arg)
 {
     struct usock_conn *uconn = arg;
-    const struct auth_cred *cred;
+    const struct flux_msg_cred *cred;
     int type;
 
     if (flux_msg_get_type (msg, &type) < 0)
@@ -158,8 +158,8 @@ static int uconn_send (const flux_msg_t *msg, void *arg)
 static void acceptor_cb (struct usock_conn *uconn, void *arg)
 {
     struct connector_local *ctx = arg;
-    const struct auth_cred *initial_cred;
-    struct auth_cred cred;
+    const struct flux_msg_cred *initial_cred;
+    struct flux_msg_cred cred;
     struct router_entry *entry;
 
     initial_cred = usock_conn_get_cred (uconn);

--- a/src/modules/job-manager/Makefile.am
+++ b/src/modules/job-manager/Makefile.am
@@ -53,6 +53,7 @@ TESTS = \
 	test_job.t \
 	test_list.t \
 	test_raise.t \
+	test_kill.t \
 	test_restart.t \
 	test_submit.t
 
@@ -94,6 +95,12 @@ test_raise_t_SOURCES = test/raise.c
 test_raise_t_CPPFLAGS = $(test_cppflags)
 test_raise_t_LDADD = \
         $(top_builddir)/src/modules/job-manager/raise.o \
+        $(test_ldadd)
+
+test_kill_t_SOURCES = test/kill.c
+test_kill_t_CPPFLAGS = $(test_cppflags)
+test_kill_t_LDADD = \
+        $(top_builddir)/src/modules/job-manager/kill.o \
         $(test_ldadd)
 
 test_restart_t_SOURCES = test/restart.c

--- a/src/modules/job-manager/kill.h
+++ b/src/modules/job-manager/kill.h
@@ -24,7 +24,6 @@ void kill_handle_request (flux_t *h,
 
 /* exposed for unit testing only */
 int kill_check_signal (int signum);
-int kill_allow (uint32_t rolemask, uint32_t userid, uint32_t job_userid);
 
 #endif /* ! _FLUX_JOB_MANAGER_RAISE_H */
 /*

--- a/src/modules/job-manager/priority.c
+++ b/src/modules/job-manager/priority.c
@@ -46,8 +46,7 @@ void priority_handle_request (flux_t *h,
                               void *arg)
 {
     struct job_manager *ctx = arg;
-    uint32_t userid;
-    uint32_t rolemask;
+    struct flux_msg_cred cred;
     flux_jobid_t id;
     struct job *job;
     int priority;
@@ -56,8 +55,7 @@ void priority_handle_request (flux_t *h,
     if (flux_request_unpack (msg, NULL, "{s:I s:i}",
                                         "id", &id,
                                         "priority", &priority) < 0
-                    || flux_msg_get_userid (msg, &userid) < 0
-                    || flux_msg_get_rolemask (msg, &rolemask) < 0)
+                    || flux_msg_get_cred (msg, &cred) < 0)
         goto error;
     if (priority < FLUX_JOB_PRIORITY_MIN || priority > FLUX_JOB_PRIORITY_MAX) {
         errstr = "priority value is out of range";
@@ -71,14 +69,13 @@ void priority_handle_request (flux_t *h,
     }
     /* Security: guests can only adjust jobs that they submitted.
      */
-    if (!(rolemask & FLUX_ROLE_OWNER) && userid != job->userid) {
+    if (flux_msg_cred_authorize (cred, job->userid) < 0) {
         errstr = "guests can only reprioritize their own jobs";
-        errno = EPERM;
         goto error;
     }
     /* Security: guests can only reduce priority, or increase up to default.
      */
-    if (!(rolemask & FLUX_ROLE_OWNER)
+    if (!(cred.rolemask & FLUX_ROLE_OWNER)
             && priority > MAXOF (FLUX_JOB_PRIORITY_DEFAULT, job->priority)) {
         errstr = "guests can only adjust priority <= default";
         errno = EPERM;
@@ -89,7 +86,7 @@ void priority_handle_request (flux_t *h,
     if (event_job_post_pack (ctx->event, job,
                              "priority",
                              "{ s:i s:i }",
-                             "userid", userid,
+                             "userid", cred.userid,
                              "priority", priority) < 0)
         goto error;
     alloc_pending_reorder (ctx->alloc, job);

--- a/src/modules/job-manager/raise.h
+++ b/src/modules/job-manager/raise.h
@@ -24,7 +24,6 @@ void raise_handle_request (flux_t *h,
 /* exposed for unit testing only */
 int raise_check_type (const char *type);
 int raise_check_severity (int severity);
-int raise_allow (uint32_t rolemask, uint32_t userid, uint32_t job_userid);
 
 #endif /* ! _FLUX_JOB_MANAGER_RAISE_H */
 /*

--- a/src/modules/job-manager/test/kill.c
+++ b/src/modules/job-manager/test/kill.c
@@ -1,0 +1,39 @@
+/************************************************************\
+ * Copyright 2018 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <jansson.h>
+
+#include "src/common/libtap/tap.h"
+
+#include "src/modules/job-manager/job.h"
+#include "src/modules/job-manager/kill.h"
+
+int main (int argc, char **argv)
+{
+    plan (NO_PLAN);
+
+    ok (kill_check_signal (SIGKILL) == 0,
+        "kill_check_signal signum=SIGKILL works");
+    ok (kill_check_signal (-1) < 0,
+        "kill_check_signal signum=-1 fails");
+    ok (kill_check_signal (SIGRTMAX + 1) < 0,
+        "kill_check_signal signum=SIGRTMAX+1 fails");
+
+    done_testing ();
+
+    return 0;
+}
+
+/*
+ * vi:ts=4 sw=4 expandtab
+ */

--- a/src/modules/job-manager/test/raise.c
+++ b/src/modules/job-manager/test/raise.c
@@ -46,15 +46,6 @@ int main (int argc, char **argv)
     ok (raise_check_severity (-1) < 0,
         "raise_check_severity sev=-1 fails");
 
-    ok (raise_allow (FLUX_ROLE_OWNER, 42, 43) == 0,
-        "raise_allow permits instance owner");
-    ok (raise_allow (FLUX_ROLE_USER, 42, 42) == 0,
-        "raise_allow permits job owner");
-    ok (raise_allow (FLUX_ROLE_USER, 42, 43) < 0,
-        "raise_allow denies guest non-job owner");
-    ok (raise_allow (FLUX_ROLE_NONE, FLUX_USERID_UNKNOWN, 43) < 0,
-        "raise_allow denies default message creds");
-
     done_testing ();
 
     return 0;

--- a/src/modules/kvs/kvsroot.c
+++ b/src/modules/kvs/kvsroot.c
@@ -258,23 +258,15 @@ void kvsroot_setroot (kvsroot_mgr_t *krm, struct kvsroot *root,
 }
 
 int kvsroot_check_user (kvsroot_mgr_t *krm, struct kvsroot *root,
-                        uint32_t rolemask, uint32_t userid)
+                        struct flux_msg_cred cred)
 {
     if (!root) {
         errno = EINVAL;
         return -1;
     }
-
-    if (rolemask & FLUX_ROLE_OWNER)
-        return 0;
-
-    if (rolemask & FLUX_ROLE_USER) {
-        if (userid == root->owner)
-            return 0;
-    }
-
-    errno = EPERM;
-    return -1;
+    if (flux_msg_cred_authorize (cred, root->owner) < 0)
+        return -1;
+    return 0;
 }
 
 /*

--- a/src/modules/kvs/kvsroot.h
+++ b/src/modules/kvs/kvsroot.h
@@ -74,8 +74,8 @@ int kvsroot_mgr_iter_roots (kvsroot_mgr_t *krm, kvsroot_root_f cb, void *arg);
 void kvsroot_setroot (kvsroot_mgr_t *krm, struct kvsroot *root,
                       const char *root_ref, int root_seq);
 
-int kvsroot_check_user (kvsroot_mgr_t *krm, struct kvsroot *root,
-                        uint32_t rolemask, uint32_t userid);
+int kvsroot_check_user (kvsroot_mgr_t *krm,struct kvsroot *root,
+                        struct flux_msg_cred cred);
 
 #endif /* !_FLUX_KVS_KVSROOT_H */
 

--- a/src/modules/kvs/lookup.c
+++ b/src/modules/kvs/lookup.c
@@ -65,8 +65,7 @@ struct lookup {
 
     flux_t *h;
 
-    uint32_t rolemask;
-    uint32_t userid;
+    struct flux_msg_cred cred;
 
     int flags;
 
@@ -251,10 +250,7 @@ static lookup_process_t symlink_check_namespace (lookup_t *lh,
         goto done;
     }
 
-    if (kvsroot_check_user (lh->krm,
-                            root,
-                            lh->rolemask,
-                            lh->userid) < 0) {
+    if (kvsroot_check_user (lh->krm, root, lh->cred) < 0) {
         lh->errnum = EPERM;
         goto done;
     }
@@ -521,8 +517,7 @@ lookup_t *lookup_create (struct cache *cache,
                          const char *root_ref,
                          int root_seq,
                          const char *path,
-                         uint32_t rolemask,
-                         uint32_t userid,
+                         struct flux_msg_cred cred,
                          int flags,
                          flux_t *h)
 {
@@ -573,8 +568,7 @@ lookup_t *lookup_create (struct cache *cache,
 
     lh->h = h;
 
-    lh->rolemask = rolemask;
-    lh->userid = userid;
+    lh->cred = cred;
     lh->flags = flags;
 
     lh->val = NULL;
@@ -758,10 +752,7 @@ static int namespace_still_valid (lookup_t *lh)
     /* Small chance root removed, then re-inserted, check security
      * checks again */
 
-    if (kvsroot_check_user (lh->krm,
-                            root,
-                            lh->rolemask,
-                            lh->userid) < 0) {
+    if (kvsroot_check_user (lh->krm, root, lh->cred) < 0) {
         lh->errnum = errno;
         return -1;
     }
@@ -955,10 +946,7 @@ lookup_process_t lookup (lookup_t *lh)
                     return LOOKUP_PROCESS_LOAD_MISSING_NAMESPACE;
                 }
 
-                if (kvsroot_check_user (lh->krm,
-                                        root,
-                                        lh->rolemask,
-                                        lh->userid) < 0) {
+                if (kvsroot_check_user (lh->krm, root, lh->cred) < 0) {
                     lh->errnum = errno;
                     goto error;
                 }

--- a/src/modules/kvs/lookup.h
+++ b/src/modules/kvs/lookup.h
@@ -45,8 +45,7 @@ lookup_t *lookup_create (struct cache *cache,
                          const char *root_ref,
                          int root_seq,
                          const char *path,
-                         uint32_t rolemask,
-                         uint32_t userid,
+                         struct flux_msg_cred cred,
                          int flags,
                          flux_t *h);
 

--- a/src/modules/kvs/test/kvsroot.c
+++ b/src/modules/kvs/test/kvsroot.c
@@ -28,6 +28,7 @@ void basic_api_tests (void)
     struct cache *cache;
     struct kvsroot *root;
     struct kvsroot *tmproot;
+    struct flux_msg_cred cred;
 
     cache = cache_create ();
 
@@ -81,21 +82,31 @@ void basic_api_tests (void)
     ok (root->seq == 18,
         "kvsroot_setroot set seq correctly");
 
-    ok (kvsroot_check_user (krm, NULL, FLUX_ROLE_OWNER, 0) < 0
+    cred.rolemask = FLUX_ROLE_OWNER;
+    cred.userid = 0;
+    ok (kvsroot_check_user (krm, NULL, cred) < 0
         && errno == EINVAL,
         "kvsroot_check_user failed with EINVAL on bad input");
 
-    ok (!kvsroot_check_user (krm, root, FLUX_ROLE_OWNER, 0),
+    cred.rolemask = FLUX_ROLE_OWNER;
+    cred.userid = 0;
+    ok (!kvsroot_check_user (krm, root, cred),
         "kvsroot_check_user works on role owner");
 
-    ok (!kvsroot_check_user (krm, root, FLUX_ROLE_USER, 1234),
+    cred.rolemask = FLUX_ROLE_OWNER;
+    cred.userid = 1234;
+    ok (!kvsroot_check_user (krm, root, cred),
         "kvsroot_check_user works on role user and correct id");
 
-    ok (kvsroot_check_user (krm, root, FLUX_ROLE_USER, 0) < 0
+    cred.rolemask = FLUX_ROLE_USER;
+    cred.userid = 0;
+    ok (kvsroot_check_user (krm, root, cred) < 0
         && errno == EPERM,
         "kvsroot_check_user fails with EPERM on role user and incorrect id");
 
-    ok (kvsroot_check_user (krm, root, 0, 0) < 0
+    cred.rolemask = 0;
+    cred.userid = 0;
+    ok (kvsroot_check_user (krm, root, cred) < 0
         && errno == EPERM,
         "kvsroot_check_user fails with EPERM on bad role");
 

--- a/src/modules/kvs/test/kvstxn.c
+++ b/src/modules/kvs/test/kvstxn.c
@@ -639,6 +639,7 @@ void verify_value (struct cache *cache,
 {
     lookup_t *lh;
     json_t *test, *o;
+    struct flux_msg_cred cred = { .rolemask = FLUX_ROLE_OWNER, .userid = 0 };
 
     ok ((lh = lookup_create (cache,
                              krm,
@@ -647,8 +648,7 @@ void verify_value (struct cache *cache,
                              root_ref,
                              0,
                              key,
-                             FLUX_ROLE_OWNER,
-                             0,
+                             cred,
                              0,
                              NULL)) != NULL,
         "lookup_create key %s", key);

--- a/src/modules/kvs/test/lookup.c
+++ b/src/modules/kvs/test/lookup.c
@@ -25,6 +25,9 @@
 #include "src/modules/kvs/lookup.h"
 #include "src/common/libutil/blobref.h"
 
+struct flux_msg_cred owner_cred = { .userid = 0, .rolemask = FLUX_ROLE_OWNER };
+struct flux_msg_cred user_cred = { .userid = 0, .rolemask = FLUX_ROLE_USER };
+
 struct lookup_ref_data
 {
     const char *ref;
@@ -220,8 +223,7 @@ void basic_api (void)
                              "root.ref.foo",
                              0,
                              "path.bar",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              FLUX_KVS_READLINK | FLUX_KVS_TREEOBJ,
                              NULL)) != NULL,
         "lookup_create works");
@@ -267,8 +269,7 @@ void basic_api_errors (void)
                        NULL,
                        0,
                        NULL,
-                       FLUX_ROLE_OWNER,
-                       0,
+                       owner_cred,
                        0,
                        NULL) == NULL,
         "lookup_create fails on bad input");
@@ -285,8 +286,7 @@ void basic_api_errors (void)
                              NULL,
                              0,
                              "path.bar",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              0,
                              NULL)) == NULL,
         "lookup_create fails on no namespace or root ref");
@@ -300,8 +300,7 @@ void basic_api_errors (void)
                              NULL,
                              0,
                              "path.bar",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              FLUX_KVS_READLINK | FLUX_KVS_TREEOBJ,
                              NULL)) != NULL,
         "lookup_create works");
@@ -380,8 +379,7 @@ void basic_lookup (void) {
                              NULL,
                              0,
                              "val",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              0,
                              NULL)) != NULL,
         "lookup_create basic works - no root_ref set");
@@ -403,8 +401,7 @@ void basic_lookup (void) {
                              root_ref,
                              18,
                              "val",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              0,
                              NULL)) != NULL,
         "lookup_create basic works - root_ref set");
@@ -607,8 +604,7 @@ void lookup_root (void) {
                              NULL,
                              0,
                              ".",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              0,
                              NULL)) != NULL,
         "lookup_create on root, no flags, works");
@@ -622,8 +618,7 @@ void lookup_root (void) {
                              NULL,
                              0,
                              ".",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              FLUX_KVS_READDIR,
                              NULL)) != NULL,
         "lookup_create on root w/ flag = FLUX_KVS_READDIR, works");
@@ -637,8 +632,7 @@ void lookup_root (void) {
                              NULL,
                              0,
                              ".",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              FLUX_KVS_TREEOBJ,
                              NULL)) != NULL,
         "lookup_create on root w/ flag = FLUX_KVS_TREEOBJ, works");
@@ -654,8 +648,7 @@ void lookup_root (void) {
                              valref_ref,
                              0,
                              ".",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              FLUX_KVS_READDIR,
                              NULL)) != NULL,
         "lookup_create on root w/ flag = FLUX_KVS_READDIR, bad root_ref, should EINVAL");
@@ -766,8 +759,7 @@ void lookup_basic (void) {
                              NULL,
                              0,
                              "dirref",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              FLUX_KVS_READDIR,
                              NULL)) != NULL,
         "lookup_create on path dirref");
@@ -781,8 +773,7 @@ void lookup_basic (void) {
                              NULL,
                              0,
                              "dirref.valref",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              0,
                              NULL)) != NULL,
         "lookup_create on path dirref.valref");
@@ -802,8 +793,7 @@ void lookup_basic (void) {
                              NULL,
                              0,
                              "dirref.valref_with_dirref",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              0,
                              NULL)) != NULL,
         "lookup_create on dirref.valref_with_dirref");
@@ -817,8 +807,7 @@ void lookup_basic (void) {
                              NULL,
                              0,
                              "dirref.valref_multi",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              0,
                              NULL)) != NULL,
         "lookup_create on valref_multi");
@@ -838,8 +827,7 @@ void lookup_basic (void) {
                              NULL,
                              0,
                              "dirref.valref_multi_with_dirref",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              0,
                              NULL)) != NULL,
         "lookup_create on dirref.valref_multi_with_dirref");
@@ -853,8 +841,7 @@ void lookup_basic (void) {
                              NULL,
                              0,
                              "dirref.val",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              0,
                              NULL)) != NULL,
         "lookup_create on path dirref.val");
@@ -870,8 +857,7 @@ void lookup_basic (void) {
                              NULL,
                              0,
                              "dirref.dir",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              FLUX_KVS_READDIR,
                              NULL)) != NULL,
         "lookup_create on path dirref.dir");
@@ -885,8 +871,7 @@ void lookup_basic (void) {
                              NULL,
                              0,
                              "dirref.symlink",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              FLUX_KVS_READLINK,
                              NULL)) != NULL,
         "lookup_create on path dirref.symlink");
@@ -902,8 +887,7 @@ void lookup_basic (void) {
                              NULL,
                              0,
                              "dirref.symlinkNS",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              FLUX_KVS_READLINK,
                              NULL)) != NULL,
         "lookup_create on path dirref.symlinkNS");
@@ -919,8 +903,7 @@ void lookup_basic (void) {
                              NULL,
                              0,
                              "dirref",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              FLUX_KVS_TREEOBJ,
                              NULL)) != NULL,
         "lookup_create on path dirref (treeobj)");
@@ -936,8 +919,7 @@ void lookup_basic (void) {
                              NULL,
                              0,
                              "dirref.valref",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              FLUX_KVS_TREEOBJ,
                              NULL)) != NULL,
         "lookup_create on path dirref.valref (treeobj)");
@@ -953,8 +935,7 @@ void lookup_basic (void) {
                              NULL,
                              0,
                              "dirref.val",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              FLUX_KVS_TREEOBJ,
                              NULL)) != NULL,
         "lookup_create on path dirref.val (treeobj)");
@@ -970,8 +951,7 @@ void lookup_basic (void) {
                              NULL,
                              0,
                              "dirref.dir",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              FLUX_KVS_TREEOBJ,
                              NULL)) != NULL,
         "lookup_create on path dirref.dir (treeobj)");
@@ -985,8 +965,7 @@ void lookup_basic (void) {
                              NULL,
                              0,
                              "dirref.symlink",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              FLUX_KVS_TREEOBJ,
                              NULL)) != NULL,
         "lookup_create on path dirref.symlink (treeobj)");
@@ -1002,8 +981,7 @@ void lookup_basic (void) {
                              NULL,
                              0,
                              "dirref.symlinkNS",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              FLUX_KVS_TREEOBJ,
                              NULL)) != NULL,
         "lookup_create on path dirref.symlinkNS (treeobj)");
@@ -1109,8 +1087,7 @@ void lookup_errors (void) {
                              NULL,
                              0,
                              "foo",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              0,
                              NULL)) != NULL,
         "lookup_create on bad path in path");
@@ -1125,8 +1102,7 @@ void lookup_errors (void) {
                              NULL,
                              0,
                              "val.foo",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              0,
                              NULL)) != NULL,
         "lookup_create on val in path");
@@ -1141,8 +1117,7 @@ void lookup_errors (void) {
                              NULL,
                              0,
                              "valref.foo",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              0,
                              NULL)) != NULL,
         "lookup_create on valref in path");
@@ -1156,8 +1131,7 @@ void lookup_errors (void) {
                              NULL,
                              0,
                              "dir.foo",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              0,
                              NULL)) != NULL,
         "lookup_create on dir in path");
@@ -1171,8 +1145,7 @@ void lookup_errors (void) {
                              NULL,
                              0,
                              "symlink1",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              0,
                              NULL)) != NULL,
         "lookup_create on link loop");
@@ -1186,8 +1159,7 @@ void lookup_errors (void) {
                              NULL,
                              0,
                              "symlinkNS1",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              0,
                              NULL)) != NULL,
         "lookup_create on symlinkNS loop");
@@ -1201,8 +1173,7 @@ void lookup_errors (void) {
                              NULL,
                              0,
                              "symlinkNS2symlink",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              0,
                              NULL)) != NULL,
         "lookup_create on symlink (w/ & w/o namespace) loop");
@@ -1216,8 +1187,7 @@ void lookup_errors (void) {
                              NULL,
                              0,
                              "dirref",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              FLUX_KVS_READLINK,
                              NULL)) != NULL,
         "lookup_create on dirref");
@@ -1231,8 +1201,7 @@ void lookup_errors (void) {
                              NULL,
                              0,
                              "dir",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              FLUX_KVS_READLINK,
                              NULL)) != NULL,
         "lookup_create on dir");
@@ -1246,8 +1215,7 @@ void lookup_errors (void) {
                              NULL,
                              0,
                              "valref",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              FLUX_KVS_READLINK,
                              NULL)) != NULL,
         "lookup_create on valref");
@@ -1261,8 +1229,7 @@ void lookup_errors (void) {
                              NULL,
                              0,
                              "val",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              FLUX_KVS_READLINK,
                              NULL)) != NULL,
         "lookup_create on val");
@@ -1276,8 +1243,7 @@ void lookup_errors (void) {
                              NULL,
                              0,
                              "dirref",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              0,
                              NULL)) != NULL,
         "lookup_create on dirref");
@@ -1291,8 +1257,7 @@ void lookup_errors (void) {
                              NULL,
                              0,
                              "dir",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              0,
                              NULL)) != NULL,
         "lookup_create on dir");
@@ -1306,8 +1271,7 @@ void lookup_errors (void) {
                              NULL,
                              0,
                              "valref",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              FLUX_KVS_READDIR,
                              NULL)) != NULL,
         "lookup_create on valref");
@@ -1321,8 +1285,7 @@ void lookup_errors (void) {
                              NULL,
                              0,
                              "val",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              FLUX_KVS_READDIR,
                              NULL)) != NULL,
         "lookup_create on val");
@@ -1336,8 +1299,7 @@ void lookup_errors (void) {
                              NULL,
                              0,
                              "symlink",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              FLUX_KVS_READLINK | FLUX_KVS_READDIR,
                              NULL)) != NULL,
         "lookup_create on symlink");
@@ -1351,8 +1313,7 @@ void lookup_errors (void) {
                              NULL,
                              0,
                              "symlinkNS",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              FLUX_KVS_READLINK | FLUX_KVS_READDIR,
                              NULL)) != NULL,
         "lookup_create on symlinkNS");
@@ -1366,8 +1327,7 @@ void lookup_errors (void) {
                              NULL,
                              0,
                              "dirref_bad",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              FLUX_KVS_READDIR,
                              NULL)) != NULL,
         "lookup_create on dirref_bad");
@@ -1382,8 +1342,7 @@ void lookup_errors (void) {
                              NULL,
                              0,
                              "dirref_bad.val",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              FLUX_KVS_READDIR,
                              NULL)) != NULL,
         "lookup_create on dirref_bad, in middle of path");
@@ -1397,8 +1356,7 @@ void lookup_errors (void) {
                              valref_ref,
                              0,
                              "val",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              0,
                              NULL)) != NULL,
         "lookup_create on bad root_ref");
@@ -1412,8 +1370,7 @@ void lookup_errors (void) {
                              NULL,
                              0,
                              "dirref_multi",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              FLUX_KVS_READDIR,
                              NULL)) != NULL,
         "lookup_create on dirref_multi");
@@ -1428,8 +1385,7 @@ void lookup_errors (void) {
                              NULL,
                              0,
                              "dirref_multi.foo",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              0,
                              NULL)) != NULL,
         "lookup_create on dirref_multi, part of path");
@@ -1447,8 +1403,7 @@ void lookup_errors (void) {
                              valref_ref,
                              0,
                              "val",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              0,
                              NULL)) != NULL,
         "lookup_create on bad root_ref for double call test");
@@ -1473,6 +1428,11 @@ void lookup_security (void) {
     kvsroot_mgr_t *krm;
     lookup_t *lh;
     char root_ref[BLOBREF_MAX_STRING_SIZE];
+    struct flux_msg_cred owner_5 = { .userid = 5, .rolemask = FLUX_ROLE_OWNER };
+    struct flux_msg_cred user_6 = { .userid = 6, .rolemask = FLUX_ROLE_USER};
+    struct flux_msg_cred owner_6 = { .userid = 6, .rolemask = FLUX_ROLE_OWNER};
+    struct flux_msg_cred owner_7 = { .userid = 7, .rolemask = FLUX_ROLE_OWNER};
+    struct flux_msg_cred user_7 = { .userid = 7, .rolemask = FLUX_ROLE_USER};
 
     ok ((cache = cache_create ()) != NULL,
         "cache_create works");
@@ -1502,8 +1462,7 @@ void lookup_security (void) {
                              NULL,
                              0,
                              "val",
-                             FLUX_ROLE_OWNER,
-                             5,
+                             owner_5,
                              0,
                              NULL)) != NULL,
         "lookup_create on val with rolemask owner and valid owner");
@@ -1518,8 +1477,7 @@ void lookup_security (void) {
                              NULL,
                              0,
                              "val",
-                             FLUX_ROLE_USER,
-                             5,
+                             owner_5,
                              0,
                              NULL)) != NULL,
         "lookup_create on val with rolemask user and valid owner");
@@ -1534,8 +1492,7 @@ void lookup_security (void) {
                              NULL,
                              0,
                              "val",
-                             FLUX_ROLE_USER,
-                             6,
+                             user_6,
                              0,
                              NULL)) != NULL,
         "lookup_create on val with rolemask user and invalid owner");
@@ -1549,8 +1506,7 @@ void lookup_security (void) {
                              root_ref,
                              0,
                              "val",
-                             FLUX_ROLE_USER,
-                             6,
+                             user_6,
                              0,
                              NULL)) != NULL,
         "lookup_create on val with rolemask user and invalid owner w/ root_ref");
@@ -1565,8 +1521,7 @@ void lookup_security (void) {
                              NULL,
                              0,
                              "val",
-                             FLUX_ROLE_OWNER,
-                             6,
+                             owner_6,
                              0,
                              NULL)) != NULL,
         "lookup_create on val on namespace altnamespace with rolemask owner and valid owner");
@@ -1581,8 +1536,7 @@ void lookup_security (void) {
                              NULL,
                              0,
                              "val",
-                             FLUX_ROLE_OWNER,
-                             7,
+                             owner_7,
                              0,
                              NULL)) != NULL,
         "lookup_create on val on namespace altnamespace with rolemask owner and invalid owner");
@@ -1597,8 +1551,7 @@ void lookup_security (void) {
                              NULL,
                              0,
                              "val",
-                             FLUX_ROLE_USER,
-                             6,
+                             user_6,
                              0,
                              NULL)) != NULL,
         "lookup_create on val on namespace altnamespace with rolemask user and valid owner");
@@ -1613,8 +1566,7 @@ void lookup_security (void) {
                              NULL,
                              0,
                              "val",
-                             FLUX_ROLE_USER,
-                             7,
+                             user_7,
                              0,
                              NULL)) != NULL,
         "lookup_create on val on namespace altnamespace with rolemask user and invalid owner");
@@ -1719,8 +1671,7 @@ void lookup_links (void) {
                              NULL,
                              0,
                              "dirref1.link2dirref.symlink",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              0,
                              NULL)) != NULL,
         "lookup_create link to val via two links");
@@ -1736,8 +1687,7 @@ void lookup_links (void) {
                              NULL,
                              0,
                              "dirref1.link2dirref.val",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              0,
                              NULL)) != NULL,
         "lookup_create link to val");
@@ -1753,8 +1703,7 @@ void lookup_links (void) {
                              NULL,
                              0,
                              "dirref1.link2dirref.valref",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              0,
                              NULL)) != NULL,
         "lookup_create link to valref");
@@ -1770,8 +1719,7 @@ void lookup_links (void) {
                              NULL,
                              0,
                              "dirref1.link2dirref.dir",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              FLUX_KVS_READDIR,
                              NULL)) != NULL,
         "lookup_create link to dir");
@@ -1785,8 +1733,7 @@ void lookup_links (void) {
                              NULL,
                              0,
                              "dirref1.link2dirref.dirref",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              FLUX_KVS_READDIR,
                              NULL)) != NULL,
         "lookup_create link to dirref");
@@ -1800,8 +1747,7 @@ void lookup_links (void) {
                              NULL,
                              0,
                              "dirref1.link2dirref.symlink",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              FLUX_KVS_READLINK,
                              NULL)) != NULL,
         "lookup_create link to symlink");
@@ -1817,8 +1763,7 @@ void lookup_links (void) {
                              NULL,
                              0,
                              "dirref1.link2val",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              0,
                              NULL)) != NULL,
         "lookup_create link to val (last part path)");
@@ -1834,8 +1779,7 @@ void lookup_links (void) {
                              NULL,
                              0,
                              "dirref1.link2valref",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              0,
                              NULL)) != NULL,
         "lookup_create link to valref (last part path)");
@@ -1851,8 +1795,7 @@ void lookup_links (void) {
                              NULL,
                              0,
                              "dirref1.link2dir",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              FLUX_KVS_READDIR,
                              NULL)) != NULL,
         "lookup_create link to dir (last part path)");
@@ -1866,8 +1809,7 @@ void lookup_links (void) {
                              NULL,
                              0,
                              "dirref1.link2dirref",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              FLUX_KVS_READDIR,
                              NULL)) != NULL,
         "lookup_create link to dirref (last part path)");
@@ -1881,8 +1823,7 @@ void lookup_links (void) {
                              NULL,
                              0,
                              "dirref1.link2symlink",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              FLUX_KVS_READLINK,
                              NULL)) != NULL,
         "lookup_create link to symlink (last part path)");
@@ -1956,8 +1897,7 @@ void lookup_alt_root (void) {
                              dirref1_ref,
                              0,
                              "val",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              0,
                              NULL)) != NULL,
         "lookup_create val w/ dirref1 root_ref");
@@ -1973,8 +1913,7 @@ void lookup_alt_root (void) {
                              dirref2_ref,
                              0,
                              "val",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              0,
                              NULL)) != NULL,
         "lookup_create val w/ dirref2 root_ref");
@@ -1990,8 +1929,7 @@ void lookup_alt_root (void) {
                              dirref1_ref,
                              0,
                              "val",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              0,
                              NULL)) != NULL,
         "lookup_create val w/ dirref1 root_ref & input namespace");
@@ -2007,8 +1945,7 @@ void lookup_alt_root (void) {
                              dirref2_ref,
                              0,
                              "val",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              0,
                              NULL)) != NULL,
         "lookup_create val w/ dirref2 root_ref & input namespace");
@@ -2079,8 +2016,7 @@ void lookup_root_symlink (void) {
                              NULL,
                              0,
                              "symlinkroot",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              0,
                              NULL)) != NULL,
         "lookup_create on symlinkroot, no flags, works");
@@ -2094,8 +2030,7 @@ void lookup_root_symlink (void) {
                              NULL,
                              0,
                              "symlinkroot",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              FLUX_KVS_READDIR,
                              NULL)) != NULL,
         "lookup_create on symlinkroot w/ flag = FLUX_KVS_READDIR, works");
@@ -2109,8 +2044,7 @@ void lookup_root_symlink (void) {
                              NULL,
                              0,
                              "dirref.symlinkroot",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              FLUX_KVS_READDIR,
                              NULL)) != NULL,
         "lookup_create on dirref.symlinkroot w/ flag = FLUX_KVS_READDIR, works");
@@ -2125,8 +2059,7 @@ void lookup_root_symlink (void) {
                              NULL,
                              0,
                              "symlinkroot",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              FLUX_KVS_TREEOBJ,
                              NULL)) != NULL,
         "lookup_create on symlinkroot w/ flag = FLUX_KVS_TREEOBJ, works");
@@ -2141,8 +2074,7 @@ void lookup_root_symlink (void) {
                              NULL,
                              0,
                              "symlinkroot.val",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              0,
                              NULL)) != NULL,
         "lookup_create on symlinkroot.val, works");
@@ -2158,8 +2090,7 @@ void lookup_root_symlink (void) {
                              dirref_ref,
                              0,
                              "symlinkroot",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              FLUX_KVS_READDIR,
                              NULL)) != NULL,
         "lookup_create on symlinkroot w/ flag = FLUX_KVS_READDIR, and alt root_ref, works");
@@ -2173,8 +2104,7 @@ void lookup_root_symlink (void) {
                              valref_ref,
                              0,
                              "symlinkroot",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              FLUX_KVS_READDIR,
                              NULL)) != NULL,
         "lookup_create on symlinkroot w/ flag = FLUX_KVS_READDIR, bad root_ref, should EINVAL");
@@ -2245,8 +2175,7 @@ void lookup_symlinkNS (void) {
                              NULL,
                              0,
                              "symlinkNS2A-invalid",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              0,
                              NULL)) != NULL,
         "lookup_create symlinkNS2A-invalid on namespace A");
@@ -2259,8 +2188,7 @@ void lookup_symlinkNS (void) {
                              NULL,
                              0,
                              "symlinkNS2B-invalid",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              0,
                              NULL)) != NULL,
         "lookup_create symlinkNS2B-invalid on namespace A");
@@ -2273,8 +2201,7 @@ void lookup_symlinkNS (void) {
                              NULL,
                              0,
                              "symlinkNS2A.val",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              0,
                              NULL)) != NULL,
         "lookup_create symlinkNS2A.val on namespace A");
@@ -2289,8 +2216,7 @@ void lookup_symlinkNS (void) {
                              NULL,
                              0,
                              "symlinkNS2B.val",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              0,
                              NULL)) != NULL,
         "lookup_create symlinkNS2B.val on namespace A");
@@ -2305,8 +2231,7 @@ void lookup_symlinkNS (void) {
                              NULL,
                              0,
                              "symlinkNS2A-val",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              0,
                              NULL)) != NULL,
         "lookup_create symlinkNS2A-val on namespace A");
@@ -2321,8 +2246,7 @@ void lookup_symlinkNS (void) {
                              NULL,
                              0,
                              "symlinkNS2B-val",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              0,
                              NULL)) != NULL,
         "lookup_create symlinkNS2B-val on namespace A");
@@ -2337,8 +2261,7 @@ void lookup_symlinkNS (void) {
                              NULL,
                              0,
                              "symlinkNS2A",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              FLUX_KVS_READDIR,
                              NULL)) != NULL,
         "lookup_create symlinkNS2A on namespace A, readdir");
@@ -2351,8 +2274,7 @@ void lookup_symlinkNS (void) {
                              NULL,
                              0,
                              "symlinkNS2B",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              FLUX_KVS_READDIR,
                              NULL)) != NULL,
         "lookup_create symlinkNS2B on namespace A, readdir");
@@ -2375,6 +2297,10 @@ void lookup_symlinkNS_security (void) {
     char root_refA[BLOBREF_MAX_STRING_SIZE];
     char root_refB[BLOBREF_MAX_STRING_SIZE];
     char root_refC[BLOBREF_MAX_STRING_SIZE];
+    struct flux_msg_cred owner_1000 = { .rolemask = FLUX_ROLE_OWNER,
+                                        .userid = 1000 };
+    struct flux_msg_cred user_1000 = { .rolemask = FLUX_ROLE_USER,
+                                       .userid = 1000 };
 
     ok ((cache = cache_create ()) != NULL,
         "cache_create works");
@@ -2426,8 +2352,7 @@ void lookup_symlinkNS_security (void) {
                              NULL,
                              0,
                              "symlinkNS2B.val",
-                             FLUX_ROLE_OWNER,
-                             1000,
+                             owner_1000,
                              0,
                              NULL)) != NULL,
         "lookup_create on symlinkNS2B.val with rolemask owner");
@@ -2442,8 +2367,7 @@ void lookup_symlinkNS_security (void) {
                              NULL,
                              0,
                              "symlinkNS2C.val",
-                             FLUX_ROLE_OWNER,
-                             1000,
+                             owner_1000,
                              0,
                              NULL)) != NULL,
         "lookup_create on symlinkNS2C.val with rolemask owner");
@@ -2458,8 +2382,7 @@ void lookup_symlinkNS_security (void) {
                              NULL,
                              0,
                              "symlinkNS2B.val",
-                             FLUX_ROLE_USER,
-                             1000,
+                             user_1000,
                              0,
                              NULL)) != NULL,
         "lookup_create on symlinkNS2B.val with rolemask user and valid owner");
@@ -2474,8 +2397,7 @@ void lookup_symlinkNS_security (void) {
                              NULL,
                              0,
                              "symlinkNS2C.val",
-                             FLUX_ROLE_USER,
-                             1000,
+                             user_1000,
                              0,
                              NULL)) != NULL,
         "lookup_create on symlinkNS2C.val with rolemask user and invalid owner");
@@ -2536,8 +2458,7 @@ void lookup_stall_namespace (void) {
                              NULL,
                              0,
                              "val",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              0,
                              NULL)) != NULL,
         "lookup_create stalltest");
@@ -2563,8 +2484,7 @@ void lookup_stall_namespace (void) {
                              NULL,
                              0,
                              "val",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              0,
                              NULL)) != NULL,
         "lookup_create stalltest #2");
@@ -2581,8 +2501,7 @@ void lookup_stall_namespace (void) {
                              NULL,
                              0,
                              "val",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              0,
                              NULL)) != NULL,
         "lookup_create stalltest");
@@ -2608,8 +2527,7 @@ void lookup_stall_namespace (void) {
                              NULL,
                              0,
                              "val",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              0,
                              NULL)) != NULL,
         "lookup_create stalltest #2");
@@ -2626,8 +2544,7 @@ void lookup_stall_namespace (void) {
                              NULL,
                              0,
                              ".",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              FLUX_KVS_TREEOBJ,
                              NULL)) != NULL,
         "lookup_create stalltest on root .");
@@ -2686,8 +2603,7 @@ void lookup_stall_ref_root (void) {
                              NULL,
                              0,
                              ".",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              FLUX_KVS_READDIR,
                              NULL)) != NULL,
         "lookup_create stalltest \".\"");
@@ -2706,8 +2622,7 @@ void lookup_stall_ref_root (void) {
                              NULL,
                              0,
                              ".",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              FLUX_KVS_READDIR,
                              NULL)) != NULL,
         "lookup_create stalltest \".\"");
@@ -2828,8 +2743,7 @@ void lookup_stall_ref (void) {
                              NULL,
                              0,
                              "dirref1.val",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              0,
                              NULL)) != NULL,
         "lookup_create stalltest dirref1.val");
@@ -2855,8 +2769,7 @@ void lookup_stall_ref (void) {
                              NULL,
                              0,
                              "dirref1.val",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              0,
                              NULL)) != NULL,
         "lookup_create dirref1.val");
@@ -2872,8 +2785,7 @@ void lookup_stall_ref (void) {
                              root_ref,
                              0,
                              "symlink.val",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              0,
                              NULL)) != NULL,
         "lookup_create stalltest symlink.val");
@@ -2894,8 +2806,7 @@ void lookup_stall_ref (void) {
                              NULL,
                              0,
                              "symlink.val",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              0,
                              NULL)) != NULL,
         "lookup_create symlink.val");
@@ -2911,8 +2822,7 @@ void lookup_stall_ref (void) {
                              NULL,
                              0,
                              "dirref1.valref",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              0,
                              NULL)) != NULL,
         "lookup_create stalltest dirref1.valref");
@@ -2933,8 +2843,7 @@ void lookup_stall_ref (void) {
                              NULL,
                              0,
                              "dirref1.valref",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              0,
                              NULL)) != NULL,
         "lookup_create stalltest dirref1.valref");
@@ -2950,8 +2859,7 @@ void lookup_stall_ref (void) {
                              NULL,
                              0,
                              "dirref1.valref_multi",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              0,
                              NULL)) != NULL,
         "lookup_create stalltest dirref1.valref_multi");
@@ -2974,8 +2882,7 @@ void lookup_stall_ref (void) {
                              NULL,
                              0,
                              "dirref1.valref_multi",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              0,
                              NULL)) != NULL,
         "lookup_create stalltest dirref1.valref");
@@ -2991,8 +2898,7 @@ void lookup_stall_ref (void) {
                              NULL,
                              0,
                              "dirref1.valref_multi2",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              0,
                              NULL)) != NULL,
         "lookup_create stalltest dirref1.valref_multi2");
@@ -3015,8 +2921,7 @@ void lookup_stall_ref (void) {
                              NULL,
                              0,
                              "dirref1.valref_multi2",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              0,
                              NULL)) != NULL,
         "lookup_create stalltest dirref1.valref");
@@ -3032,8 +2937,7 @@ void lookup_stall_ref (void) {
                              NULL,
                              0,
                              "dirref1.valrefmisc",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              0,
                              NULL)) != NULL,
         "lookup_create stalltest dirref1.valrefmisc");
@@ -3055,8 +2959,7 @@ void lookup_stall_ref (void) {
                              NULL,
                              0,
                              "dirref1.valrefmisc_multi",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              0,
                              NULL)) != NULL,
         "lookup_create stalltest dirref1.valrefmisc_multi");
@@ -3139,8 +3042,7 @@ void lookup_stall_namespace_removed (void) {
                              NULL,
                              0,
                              "dirref.valref",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              0,
                              NULL)) != NULL,
         "lookup_create stalltest dirref.valref");
@@ -3168,8 +3070,7 @@ void lookup_stall_namespace_removed (void) {
                              NULL,
                              0,
                              "dirref.valref",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              0,
                              NULL)) != NULL,
         "lookup_create stalltest dirref.valref");
@@ -3195,8 +3096,7 @@ void lookup_stall_namespace_removed (void) {
                              NULL,
                              0,
                              "dirref.valref",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              0,
                              NULL)) != NULL,
         "lookup_create stalltest dirref.valref");
@@ -3230,8 +3130,7 @@ void lookup_stall_namespace_removed (void) {
                              NULL,
                              0,
                              "dirref.valref",
-                             FLUX_ROLE_USER,
-                             0,
+                             user_cred,
                              0,
                              NULL)) != NULL,
         "lookup_create stalltest dirref.valref");
@@ -3262,8 +3161,7 @@ void lookup_stall_namespace_removed (void) {
                              NULL,
                              0,
                              "dirref.valref",
-                             FLUX_ROLE_USER,
-                             0,
+                             user_cred,
                              0,
                              NULL)) != NULL,
         "lookup_create stalltest dirref.valref");
@@ -3293,8 +3191,7 @@ void lookup_stall_namespace_removed (void) {
                              NULL,
                              0,
                              "dirref.valref",
-                             FLUX_ROLE_USER,
-                             0,
+                             user_cred,
                              0,
                              NULL)) != NULL,
         "lookup_create stalltest dirref.valref");
@@ -3331,8 +3228,7 @@ void lookup_stall_namespace_removed (void) {
                              root_ref,
                              0,
                              "dirref.valref",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              0,
                              NULL)) != NULL,
         "lookup_create stalltest dirref.valref w/ root_ref");
@@ -3373,8 +3269,7 @@ void lookup_stall_namespace_removed (void) {
                              root_ref,
                              0,
                              "dirref.valref",
-                             FLUX_ROLE_USER,
-                             0,
+                             user_cred,
                              0,
                              NULL)) != NULL,
         "lookup_create stalltest dirref.valref w/ root_ref & role user ");
@@ -3484,8 +3379,7 @@ void lookup_stall_ref_expire_cache_entries (void) {
                              NULL,
                              0,
                              "dirref1.val",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              0,
                              NULL)) != NULL,
         "lookup_create stalltest dirref1.val");
@@ -3524,8 +3418,7 @@ void lookup_stall_ref_expire_cache_entries (void) {
                              root_ref,
                              0,
                              "symlink.val",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              0,
                              NULL)) != NULL,
         "lookup_create stalltest symlink.val");
@@ -3564,8 +3457,7 @@ void lookup_stall_ref_expire_cache_entries (void) {
                              NULL,
                              0,
                              "dirref1.valref",
-                             FLUX_ROLE_OWNER,
-                             0,
+                             owner_cred,
                              0,
                              NULL)) != NULL,
         "lookup_create stalltest dirref1.valref");


### PR DESCRIPTION
In the course of adding more job manager services,  I found myself repeating the authorization check for 1) is the requestor the instance owner?  2) If no, is the requestor the owner of the job being manipulated?  I also noted that one such instance in the job manager didn't have tests, and that not all implementations are consistent with regard to whether FLUX_ROLE_USER is required in addition to a userid match, and whether a match on FLUX_USERID_UNKNOWN is allowed.

It's a little bit verbose to make this check, and although the authorization code is simple, repeating it all over the place seems like a bad idea, so I added the following helpers in message.h:
```c
/* Combined rolemask, userid access for convenience
 */
struct flux_msg_cred {
    uint32_t userid;
    uint32_t rolemask;
};
int flux_msg_get_cred (const flux_msg_t *msg, struct flux_msg_cred *cred);
int flux_msg_set_cred (flux_msg_t *msg, struct flux_msg_cred cred);

/* Simple authorization for service access:
 * If cred rolemask includes OWNER, grant (return 0).
 * If cred rolemask includes USER and userid matches 'userid',
 * and userid is not FLUX_USERID_UNKNOWN, grant (return 0).
 * Otherwise deny (return -1, errno = EPERM).
 */
int flux_msg_cred_authorize (struct flux_msg_cred cred, uint32_t userid);

/* Convenience functions that calls
 * flux_msg_get_cred() + flux_msg_cred_authorize().
 */
int flux_msg_authorize (const flux_msg_t *msg, uint32_t userid);
```
Adding this (and its tests) was simple.  Unfortunately updating all the places where it could be employed touched a lot of code.  We'll see from the coverage how well tested it all is.