### PR TITLE
shell / exec: Improve error messages to users on exec failures

### DIFF
--- a/src/cmd/flux-exec.c
+++ b/src/cmd/flux-exec.c
@@ -157,10 +157,14 @@ void state_cb (flux_subprocess_t *p, flux_subprocess_state_t state)
 
     if (state == FLUX_SUBPROCESS_EXEC_FAILED
         || state == FLUX_SUBPROCESS_FAILED) {
+        flux_cmd_t *cmd = flux_subprocess_get_cmd (p);
         int errnum = flux_subprocess_fail_errno (p);
         int ec = 1;
 
-        log_err ("Error: rank %d: %s", flux_subprocess_rank (p), strerror (errnum));
+        log_msg ("Error: rank %d: %s: %s",
+                 flux_subprocess_rank (p),
+                 flux_cmd_arg (cmd, 0),
+                 strerror (errnum));
 
         /* bash standard, 126 for permission/access denied, 127 for
          * command not found.  68 (EX_NOHOST) for No route to host.

--- a/src/common/libsubprocess/local.c
+++ b/src/common/libsubprocess/local.c
@@ -409,6 +409,8 @@ static void closefd_child (void *arg, int fd)
  *   signal to proceed. This is done by writing 1 byte to child side of
  *   socketpair, and waiting for parent to write one byte back.
  *
+ * Call fprintf instead of flux_log_error(), errors in child should
+ *  go to parent error streams.
  */
 static int local_child_ready (flux_subprocess_t *p)
 {
@@ -417,11 +419,12 @@ static int local_child_ready (flux_subprocess_t *p)
     char c = 0;
 
     if (write (fd, &c, sizeof (c)) != 1) {
-        flux_log_error (p->h, "local_child_ready: write");
+        fprintf (stderr, "local_child_ready: write: %s\n", strerror (errno));
         return -1;
     }
     if ((n = read (fd, &c, sizeof (c))) != 1) {
-        flux_log_error (p->h, "local_child_ready: read (fd=%d): rc=%d", fd, n);
+        fprintf (stderr, "local_child_ready: read (fd=%d): rc=%d: %s\n",
+                 fd, n, strerror (errno));
         return -1;
     }
     return 0;
@@ -430,10 +433,13 @@ static int local_child_ready (flux_subprocess_t *p)
 static void local_child_report_exec_failed_errno (flux_subprocess_t *p, int e)
 {
     int fd = p->sync_fds[1];
+    /* Call fprintf instead of flux_log_error(), errors in child
+     * should go to parent error streams. */
     if (write (fd, &e, sizeof (e)) != sizeof (e))
-        flux_log_error (p->h, "local_child_report_exec_failed_errno");
+        fprintf (stderr, "local_child_report_exec_failed_errno: %s\n",
+                 strerror (errno));
 }
- 
+
 #if CODE_COVERAGE_ENABLED
 void __gcov_flush (void);
 #endif
@@ -446,24 +452,27 @@ static int local_child (flux_subprocess_t *p)
 
     /* Throughout this function use _exit() instead of exit(), to
      * avoid calling any atexit() routines of parent.
+     *
+     * Call fprintf instead of flux_log_error(), errors in child
+     * should go to parent error streams.
      */
 
     if (sigmask_unblock_all () < 0)
-        flux_log_error (p->h, "sigprocmask");
+        fprintf (stderr, "sigprocmask: %s\n", strerror (errno));
 
     close_parent_fds (p);
 
     if (!(p->flags & FLUX_SUBPROCESS_FLAGS_STDIO_FALLTHROUGH)) {
         if ((c = zhash_lookup (p->channels, "stdin"))) {
             if (dup2 (c->child_fd, STDIN_FILENO) < 0) {
-                flux_log_error (p->h, "dup2");
+                fprintf (stderr, "dup2: %s\n", strerror (errno));
                 _exit (1);
             }
         }
 
         if ((c = zhash_lookup (p->channels, "stdout"))) {
             if (dup2 (c->child_fd, STDOUT_FILENO) < 0) {
-                flux_log_error (p->h, "dup2");
+                fprintf (stderr, "dup2: %s\n", strerror (errno));
                 _exit (1);
             }
         }
@@ -472,7 +481,7 @@ static int local_child (flux_subprocess_t *p)
 
         if ((c = zhash_lookup (p->channels, "stderr"))) {
             if (dup2 (c->child_fd, STDERR_FILENO) < 0) {
-                flux_log_error (p->h, "dup2");
+                fprintf (stderr, "dup2: %s\n", strerror (errno));
                 _exit (1);
             }
         }
@@ -482,7 +491,9 @@ static int local_child (flux_subprocess_t *p)
 
     // Change working directory
     if ((cwd = flux_cmd_getcwd (p->cmd)) && chdir (cwd) < 0) {
-        flux_log_error (p->h, "Couldn't change dir to %s: going to /tmp instead", cwd);
+        fprintf (stderr,
+                 "Couldn't change dir to %s: going to /tmp instead: %s\n",
+                 cwd, strerror (errno));
         if (chdir ("/tmp") < 0)
             _exit (1);
     }
@@ -493,7 +504,7 @@ static int local_child (flux_subprocess_t *p)
 
     // Close fds
     if (fdwalk (closefd_child, (void *) p) < 0) {
-        flux_log_error (p->h, "Failed closing all fds");
+        fprintf (stderr, "Failed closing all fds: %s", strerror (errno));
         _exit (1);
     }
 
@@ -508,7 +519,7 @@ static int local_child (flux_subprocess_t *p)
 
     if (p->flags & FLUX_SUBPROCESS_FLAGS_SETPGRP) {
         if (setpgrp () < 0) {
-            flux_log_error (p->h, "setpgrp");
+            fprintf (stderr, "setpgrp: %s\n", strerror (errno));
             _exit (1);
         }
     }

--- a/src/shell/shell.c
+++ b/src/shell/shell.c
@@ -1098,8 +1098,10 @@ int main (int argc, char *argv[])
         if (shell_task_init (&shell) < 0)
             shell_die (1, "failed to initialize taskid=%d", i);
 
-        if (shell_task_start (task, shell.r, task_completion_cb, &shell) < 0)
-            shell_die (1, "failed to start taskid=%d", i);
+        if (shell_task_start (task, shell.r, task_completion_cb, &shell) < 0) {
+            shell_die (1, "task %d: start failed: %s: %s",
+                       i, flux_cmd_arg (task->cmd, 0), strerror (errno));
+        }
 
         if (zlist_append (shell.tasks, task) < 0)
             shell_die (1, "zlist_append failed");

--- a/t/t0005-exec.t
+++ b/t/t0005-exec.t
@@ -111,6 +111,11 @@ test_expect_success 'flux exec exits with code 127 for file not found' '
 	test_expect_code 127 run_timeout 2 flux exec -n ./nosuchprocess
 '
 
+test_expect_success 'flux exec outputs appropriate error message for file not found' '
+	test_expect_code 127 flux exec -n ./nosuchprocess 2> exec.stderr &&
+        grep "No such file or directory" exec.stderr
+'
+
 test_expect_success 'flux exec exits with code 126 for non executable' '
 	test_expect_code 126 flux exec -n /dev/null
 '

--- a/t/t2608-job-shell-log.t
+++ b/t/t2608-job-shell-log.t
@@ -134,8 +134,9 @@ done
 
 test_expect_success 'flux-shell: missing command logs fatal error' '
 	test_expect_code 1 flux mini run nosuchcommand 2>missing.err &&
-	grep "flux-shell\[0\]: FATAL: failed to start taskid=0" missing.err &&
-	grep "job.exception type=exec severity=0 failed to start taskid=0" missing.err
+	grep "flux-shell\[0\]: FATAL: task 0: start failed" missing.err &&
+	grep "job.exception type=exec severity=0 task 0: start failed" missing.err &&
+        grep "No such file or directory" missing.err
 '
 
 test_expect_success 'job-exec: set kill-timeout to low value for testing' '


### PR DESCRIPTION
Quick attempt to improve error messages per discussion in #2481.

BEFORE

```
>flux mini run nosuchprocess
0.451s: flux-shell[0]: FATAL: failed to start taskid=0
0.453s: job.exception type=exec severity=0 failed to start taskid=0
flux-job: task(s) exited with exit code 1

>flux exec nosuchprocess
flux-exec: Error: rank 0: No such file or directory: Success
```

AFTER

```
>flux mini run nosuchprocess
0.249s: flux-shell[0]: FATAL: task 0 failed: nosuchprocess: No such file or directory
0.251s: job.exception type=exec severity=0 task 0 failed: nosuchprocess: No such file or directory
flux-job: task(s) exited with exit code 1

>flux exec nosuchprocess
flux-exec: Error: rank 0: nosuchprocess: No such file or directory
```

I debated how to tweak the one in the shell.  I didn't want to output `exec failed` as suggested by @grondo, b/c that might suggest `execvp()` failed, but technically there could be another failure cause (hypothetically `dup2()` fails due to file descriptor max being hit).  But maybe that's just me, perhaps the word `exec` is generic enough to not necessarily suggest `execvp()`?

The error message in `exec` is much better, and also removes that extraneous strerror output (due to call to `log_err()` instead of `log_msg()`)

I went ahead and peeled off #2384 from #2460 into this PR as well.