### PR TITLE
Improve rc3 reliability

### DIFF
--- a/doc/man1/flux-module.adoc
+++ b/doc/man1/flux-module.adoc
@@ -36,9 +36,10 @@ The service that will load the module is inferred
 from the module name.  When the load command completes successfully,
 the new module is ready to accept messages on all targeted ranks.
 
-*remove* 'name'::
+*remove* [--force] 'name'::
 Remove module 'name'.  The service that will unload the module is
-inferred from the name specified on the command line.
+inferred from the name specified on the command line. If '-f, --force'
+is used, then do not error if module 'name' is not loaded.
 
 *list* ['service']::
 List modules loaded by 'service', or by flux-broker(1) if 'service' is unspecified.

--- a/etc/rc3
+++ b/etc/rc3
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash
 
 core_dir=$(cd ${0%/*} && pwd -P)
 all_dirs=$core_dir${FLUX_RC_EXTRA:+":$FLUX_RC_EXTRA"}

--- a/etc/rc3
+++ b/etc/rc3
@@ -12,28 +12,28 @@ for rcdir in $all_dirs; do
 done
 shopt -u nullglob
 
-flux module remove sched-simple
-flux module remove job-exec
-flux module remove job-manager
-flux exec -r all flux module remove job-ingest
+flux module remove -f sched-simple
+flux module remove -f job-exec
+flux module remove -f job-manager
+flux exec -r all flux module remove -f job-ingest
 
 if PERSISTDIR=$(flux getattr persist-directory 2>/dev/null); then
     /bin/true; # XXX: nothing to persist?
 fi
 
-flux module remove userdb
+flux module remove -f userdb
 
-flux module remove cron
-flux exec -r all flux module remove aggregator
-flux exec -r all flux module remove barrier
+flux module remove -f cron
+flux exec -r all flux module remove -f aggregator
+flux exec -r all flux module remove -f barrier
 
-flux exec -r all flux module remove job-info
-flux exec -r all flux module remove kvs-watch
-flux exec -r all -x 0 flux module remove kvs
+flux exec -r all flux module remove -f job-info
+flux exec -r all flux module remove -f kvs-watch
+flux exec -r all -x 0 flux module remove -f kvs
 if test -n "$PERSISTDIR"; then
     flux kvs getroot >${PERSISTDIR}/kvsroot.final
     flux content flush
 fi
-flux module remove kvs
-flux module remove content-sqlite
+flux module remove -f kvs
+flux module remove -f content-sqlite
 

--- a/t/t0003-module.t
+++ b/t/t0003-module.t
@@ -134,7 +134,9 @@ test_expect_success 'module: remove fails on invalid module' '
 	test_must_fail flux module remove nosuchmodule 2>nosuch.err &&
 	grep "nosuchmodule: No such file or directory" nosuch.err
 '
-
+test_expect_sucess 'module: remove -f succeeds on nonexistent module' '
+	flux module remove -f nosuchmodule
+'
 test_expect_success 'module: info works' '
 	flux module info ${FLUX_BUILD_DIR}/t/module/.libs/parent.so
 '


### PR DESCRIPTION
This PR adds a `-f, --force` option to `flux module remove` which causes the program to ignore nonexisting modules.

The option is then added to all `flux module remove` commands in `rc3`. This improves the reliability of shutdown, where we only care that modules are unloaded, not that they are being unloaded by this specific `flux module remove` command.

The `-e` option to the shell is also removed under the assumption that `rc3` is running important shutdown work, and we should not skip all remaining commands just because of one error. Errors will still be printed but it is ok to move on.

These two changes should fix the annoying errors during shutdown for every instance that we are currently seeing with v0.14 + flux-sched v0.8.