### PR TITLE
github: check flux-sched@master against submitted flux-core PRs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,3 +10,21 @@ jobs:
         fetch-depth: 0
     - run: git fetch origin master
     - uses: flux-framework/pr-validator@master
+
+  check-sched:
+    name: flux-sched check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+        fetch-depth: 0
+    - run: git fetch --tags
+    - run: >
+        src/test/docker/docker-run-checks.sh --install-only
+        --tag=fluxrm/flux-core:bionic
+    - run: >
+        cd .. &&
+        git clone https://github.com/flux-framework/flux-sched &&
+        cd flux-sched &&
+        src/test/docker/docker-run-checks.sh -j 4 -i bionic

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -4,6 +4,7 @@ pull_request_rules:
       - base=master
       - status-success=continuous-integration/travis-ci/pr
       - status-success="validate commits"
+      - status-success="flux-sched check"
       - label="merge-when-passing"
       - label!="work-in-progress"
       - "approved-reviews-by=@flux-framework/core"


### PR DESCRIPTION
This PR adds a github workflow that ensures flux-sched `make check` works against all submitted flux-core PRs.

This works by adding a new `--install-only` option to flux-core `docker-run-checks.sh` which skips flux-core `make check` (since this is already done in Travis-CI), and instead does just `make install` into an image (requires `--tag` also). 

This is used in the GitHub workflow to build a temporary `fluxrm/flux-core:bionic` image, which then is used as the base image by flux-sched's `docker-run-checks.sh`.

To see an example, check out test runs in my fork [here](https://github.com/grondo/flux-core/runs/409721815?check_suite_focus=true).