### PR TITLE
add flux job raiaseall, cancelall, killall

### DIFF
--- a/src/modules/job-manager/event.h
+++ b/src/modules/job-manager/event.h
@@ -35,6 +35,10 @@ int event_job_update (struct job *job, json_t *event);
 int event_batch_pub_state (struct event *event, struct job *job,
                            double timestamp);
 
+/* Add add a completed drain request to batch.
+ */
+int event_batch_drain_respond (struct event *event, const flux_msg_t *msg);
+
 /* Post event 'name' and optionally 'context' to 'job'.
  * Internally, calls event_job_update(), then event_job_action(), then commits
  * the event to job KVS eventlog.  The KVS commit completes asynchronously.

--- a/src/modules/job-manager/job-manager.c
+++ b/src/modules/job-manager/job-manager.c
@@ -39,12 +39,6 @@ static const struct flux_msg_handler_spec htab[] = {
     },
     {
         FLUX_MSGTYPE_REQUEST,
-        "job-manager.raise",
-        raise_handle_request,
-        FLUX_ROLE_USER
-    },
-    {
-        FLUX_MSGTYPE_REQUEST,
         "job-manager.kill",
         kill_handle_request,
         FLUX_ROLE_USER
@@ -97,6 +91,10 @@ int mod_main (flux_t *h, int argc, char **argv)
         flux_log_error (h, "error creating wait interface");
         goto done;
     }
+    if (!(ctx.raise = raise_ctx_create (&ctx))) {
+        flux_log_error (h, "error creating raise interface");
+        goto done;
+    }
     if (flux_msg_handler_addvec (h, htab, &ctx, &ctx.handlers) < 0) {
         flux_log_error (h, "flux_msghandler_add");
         goto done;
@@ -112,6 +110,7 @@ int mod_main (flux_t *h, int argc, char **argv)
     rc = 0;
 done:
     flux_msg_handler_delvec (ctx.handlers);
+    raise_ctx_destroy (ctx.raise);
     wait_ctx_destroy (ctx.wait);
     drain_ctx_destroy (ctx.drain);
     start_ctx_destroy (ctx.start);

--- a/src/modules/job-manager/job-manager.c
+++ b/src/modules/job-manager/job-manager.c
@@ -39,12 +39,6 @@ static const struct flux_msg_handler_spec htab[] = {
     },
     {
         FLUX_MSGTYPE_REQUEST,
-        "job-manager.kill",
-        kill_handle_request,
-        FLUX_ROLE_USER
-    },
-    {
-        FLUX_MSGTYPE_REQUEST,
         "job-manager.priority",
         priority_handle_request,
         FLUX_ROLE_USER
@@ -95,6 +89,10 @@ int mod_main (flux_t *h, int argc, char **argv)
         flux_log_error (h, "error creating raise interface");
         goto done;
     }
+    if (!(ctx.kill = kill_ctx_create (&ctx))) {
+        flux_log_error (h, "error creating kill interface");
+        goto done;
+    }
     if (flux_msg_handler_addvec (h, htab, &ctx, &ctx.handlers) < 0) {
         flux_log_error (h, "flux_msghandler_add");
         goto done;
@@ -110,6 +108,7 @@ int mod_main (flux_t *h, int argc, char **argv)
     rc = 0;
 done:
     flux_msg_handler_delvec (ctx.handlers);
+    kill_ctx_destroy (ctx.kill);
     raise_ctx_destroy (ctx.raise);
     wait_ctx_destroy (ctx.wait);
     drain_ctx_destroy (ctx.drain);

--- a/src/modules/job-manager/job-manager.h
+++ b/src/modules/job-manager/job-manager.h
@@ -21,6 +21,7 @@ struct job_manager {
     struct submit *submit;
     struct drain *drain;
     struct waitjob *wait;
+    struct raise *raise;
 };
 
 #endif /* !_FLUX_JOB_MANAGER_H */

--- a/src/modules/job-manager/job-manager.h
+++ b/src/modules/job-manager/job-manager.h
@@ -22,6 +22,7 @@ struct job_manager {
     struct drain *drain;
     struct waitjob *wait;
     struct raise *raise;
+    struct kill *kill;
 };
 
 #endif /* !_FLUX_JOB_MANAGER_H */

--- a/src/modules/job-manager/kill.c
+++ b/src/modules/job-manager/kill.c
@@ -110,6 +110,90 @@ error:
         flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
 }
 
+/* Send a signal to all jobs belonging to 'userid'.
+ * Consider userid == FLUX_USERID_UNKNOWN to be a wildcard matching all users.
+ */
+void killall_handle_request (flux_t *h,
+                             flux_msg_handler_t *mh,
+                             const flux_msg_t *msg,
+                             void *arg)
+{
+    struct job_manager *ctx = arg;
+    uint32_t userid;
+    int signum;
+    const char *errstr = NULL;
+    char topic [64];
+    struct job *job;
+    flux_future_t *f;
+    int dry_run;
+    int count = 0;
+    int error_count = 0;
+
+    if (flux_request_unpack (msg,
+                             NULL,
+                             "{s:b s:i s:i}",
+                             "dry_run",
+                             &dry_run,
+                             "userid",
+                             &userid,
+                             "signum",
+                             &signum) < 0) {
+        errstr = "error decoding request";
+        goto error;
+    }
+    /* Only the instance owner gets to use the userid wildcard.
+     * Guests must specify 'userid' = themselves.
+     */
+    if (flux_msg_authorize (msg, userid) < 0) {
+        errstr = "guests can only kill their own jobs";
+        goto error;
+    }
+    if (kill_check_signal (signum) < 0) {
+        errstr = "Invalid signal number";
+        errno = EINVAL;
+        goto error;
+    }
+    job = zhashx_first (ctx->active_jobs);
+    while (job) {
+        if (job->state != FLUX_JOB_RUN)
+            goto next;
+        if (userid != FLUX_USERID_UNKNOWN && userid != job->userid)
+            goto next;
+        count++;
+        if (!dry_run) {
+            if (kill_event_topic_str (topic, sizeof (topic), job->id) < 0) {
+                error_count++;
+                goto next;
+            }
+            if (!(f = flux_event_publish_pack (h,
+                                               topic,
+                                               0,
+                                               "{s:i}",
+                                               "signum",
+                                               signum))) {
+                error_count++;
+                goto next;
+            }
+            flux_future_destroy (f);
+        }
+next:
+        job = zhashx_next (ctx->active_jobs);
+    }
+    if (flux_respond_pack (h,
+                           msg,
+                           "{s:i s:i}",
+                           "count",
+                           count,
+                           "errors",
+                           error_count) < 0)
+        flux_log_error (h, "%s: flux_respond", __FUNCTION__);
+    return;
+error:
+    if (flux_respond_error (h, msg, errno, errstr) < 0)
+        flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
+}
+
+
 void kill_ctx_destroy (struct kill *kill)
 {
     if (kill) {
@@ -125,6 +209,12 @@ static const struct flux_msg_handler_spec htab[] = {
         FLUX_MSGTYPE_REQUEST,
         "job-manager.kill",
         kill_handle_request,
+        FLUX_ROLE_USER
+    },
+    {
+        FLUX_MSGTYPE_REQUEST,
+        "job-manager.killall",
+        killall_handle_request,
         FLUX_ROLE_USER
     },
     FLUX_MSGHANDLER_TABLE_END,

--- a/src/modules/job-manager/kill.h
+++ b/src/modules/job-manager/kill.h
@@ -14,12 +14,8 @@
 #include <stdint.h>
 #include "job-manager.h"
 
-/* Handle a request to raise an exception on job.
- */
-void kill_handle_request (flux_t *h,
-                          flux_msg_handler_t *mh,
-                          const flux_msg_t *msg,
-                          void *arg);
+struct kill *kill_ctx_create (struct job_manager *ctx);
+void kill_ctx_destroy (struct kill *kill);
 
 
 /* exposed for unit testing only */

--- a/src/modules/job-manager/raise.c
+++ b/src/modules/job-manager/raise.c
@@ -60,6 +60,42 @@ int raise_check_severity (int severity)
     return 0;
 }
 
+/* NB: job object may be destroyed in event_job_post_pack().
+ * Do not reference the object after calling this function.
+ * Do not call this function and continue to iterate on the job hash
+ * with zhash_next().
+ */
+int raise_job (struct job_manager *ctx,
+               const char *type,
+               int severity,
+               uint32_t userid,
+               const char *note,
+               struct job *job)
+{
+    flux_jobid_t id = job->id;
+    flux_future_t *f;
+
+    if (event_job_post_pack (ctx->event,
+                             job,
+                             "exception",
+                             "{ s:s s:i s:i s:s }",
+                             "type", type,
+                             "severity", severity,
+                             "userid", userid,
+                             "note", note ? note : "") < 0)
+        return -1;
+    if (!(f = flux_event_publish_pack (ctx->h,
+                                       "job-exception",
+                                       FLUX_MSGFLAG_PRIVATE,
+                                       "{s:I s:s s:i}",
+                                       "id", id,
+                                       "type", type,
+                                       "severity", severity)))
+        return -1;
+    flux_future_destroy (f);
+    return 0;
+}
+
 void raise_handle_request (flux_t *h,
                            flux_msg_handler_t *mh,
                            const flux_msg_t *msg,
@@ -72,7 +108,6 @@ void raise_handle_request (flux_t *h,
     int severity;
     const char *type;
     const char *note = NULL;
-    flux_future_t *f;
     const char *errstr = NULL;
 
     if (flux_request_unpack (msg, NULL, "{s:I s:i s:s s?:s}",
@@ -101,32 +136,139 @@ void raise_handle_request (flux_t *h,
         errstr = "guests can only raise exceptions on their own jobs";
         goto error;
     }
-    if (event_job_post_pack (ctx->event, job,
-                             "exception",
-                             "{ s:s s:i s:i s:s }",
-                             "type", type,
-                             "severity", severity,
-                             "userid", cred.userid,
-                             "note", note ? note : "") < 0)
+    if (raise_job (ctx, type, severity, cred.userid, note, job) < 0)
         goto error;
     /* NB: job object may be destroyed in event_job_post_pack().
      * Do not reference the object after this point:
      */
     job = NULL;
-    if (!(f = flux_event_publish_pack (h, "job-exception",
-                                       FLUX_MSGFLAG_PRIVATE,
-                                       "{s:I s:s s:i}",
-                                       "id", id,
-                                       "type", type,
-                                       "severity", severity)))
-        goto error;
-    flux_future_destroy (f);
     if (flux_respond (h, msg, NULL) < 0)
         flux_log_error (h, "%s: flux_respond", __FUNCTION__);
     return;
 error:
     if (flux_respond_error (h, msg, errno, errstr) < 0)
         flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
+}
+
+/* Create a list of jobs matching userid, state_mask criteria.
+ * FLUX_USERID_UNKNOWN is a wildcard that matches any user.
+ */
+int find_jobs (struct job_manager *ctx,
+               uint32_t userid,
+               int state_mask,
+               zlistx_t **lp)
+{
+    zlistx_t *l;
+    struct job *job;
+
+    if (!(l = zlistx_new()))
+        goto nomem;
+    zlistx_set_destructor (l, job_destructor);
+    zlistx_set_duplicator (l, job_duplicator);
+
+    job = zhashx_first (ctx->active_jobs);
+    while (job) {
+        if (!(job->state & state_mask))
+            goto next;
+        if (userid != FLUX_USERID_UNKNOWN && userid != job->userid)
+            goto next;
+        if (!zlistx_add_end (l, job))
+            goto nomem;
+next:
+        job = zhashx_next (ctx->active_jobs);
+    }
+    *lp = l;
+    return 0;
+nomem:
+    zlistx_destroy (&l);
+    errno = ENOMEM;
+    return -1;
+}
+
+/* Raise exception on all jobs of 'userid' with state matching 'mask'.
+ * Consider userid == FLUX_USERID_UNKNOWN to be a wildcard matching all users.
+ */
+void raiseall_handle_request (flux_t *h,
+                              flux_msg_handler_t *mh,
+                              const flux_msg_t *msg,
+                              void *arg)
+{
+    struct job_manager *ctx = arg;
+    uint32_t userid;
+    struct flux_msg_cred cred;
+    int dry_run;
+    int state_mask;
+    int severity;
+    const char *type;
+    const char *note = NULL;
+    const char *errstr = NULL;
+    zlistx_t *target_jobs = NULL;
+    struct job *job;
+    int error_count = 0;
+
+    if (flux_request_unpack (msg,
+                             NULL,
+                             "{s:b s:i s:i s:i s:s s?:s}",
+                             "dry_run",
+                             &dry_run,
+                             "userid",
+                             &userid,
+                             "states",
+                             &state_mask,
+                             "severity",
+                             &severity,
+                             "type",
+                             &type,
+                             "note",
+                             &note) < 0)
+        goto error;
+    if (flux_msg_get_cred (msg, &cred) < 0)
+        goto error;
+    /* Only the instance owner gets to use the userid wildcard.
+     * Guests must specify 'userid' = themselves.
+     */
+    if (flux_msg_cred_authorize (cred, userid) < 0) {
+        errstr = "guests can only raise exceptions on their own jobs";
+        goto error;
+    }
+    if (raise_check_severity (severity)) {
+        errstr = "invalid exception severity";
+        errno = EPROTO;
+        goto error;
+    }
+    if (raise_check_type (type) < 0) {
+        errstr = "invalid exception type";
+        errno = EPROTO;
+        goto error;
+    }
+    if (find_jobs (ctx, userid, state_mask, &target_jobs) < 0)
+        goto error;
+    if (!dry_run) {
+        job = zlistx_first (target_jobs);
+        while (job) {
+            if (raise_job (ctx, type, severity, cred.userid, note, job) < 0) {
+                flux_log_error (h,
+                                "error raising exception on id=%ju",
+                                (uintmax_t)job->id);
+                error_count++;
+            }
+            job = zlistx_next (target_jobs);
+        }
+    }
+    if (flux_respond_pack (h,
+                           msg,
+                           "{s:i s:i}",
+                           "count",
+                           zlistx_size (target_jobs),
+                           "errors",
+                           error_count) < 0)
+        flux_log_error (h, "%s: flux_respond", __FUNCTION__);
+    zlistx_destroy (&target_jobs);
+    return;
+error:
+    if (flux_respond_error (h, msg, errno, errstr) < 0)
+        flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
+    zlistx_destroy (&target_jobs);
 }
 
 void raise_ctx_destroy (struct raise *raise)
@@ -145,6 +287,12 @@ static const struct flux_msg_handler_spec htab[] = {
         "job-manager.raise",
         raise_handle_request,
         FLUX_ROLE_USER
+    },
+    {
+        FLUX_MSGTYPE_REQUEST,
+        "job-manager.raiseall",
+        raiseall_handle_request,
+        FLUX_ROLE_USER,
     },
     FLUX_MSGHANDLER_TABLE_END,
 };

--- a/src/modules/job-manager/raise.h
+++ b/src/modules/job-manager/raise.h
@@ -13,13 +13,10 @@
 
 #include <stdint.h>
 
-/* Handle a request to raise an exception on job.
- */
-void raise_handle_request (flux_t *h,
-                           flux_msg_handler_t *mh,
-                           const flux_msg_t *msg,
-                           void *arg);
+#include "job-manager.h"
 
+struct raise *raise_ctx_create (struct job_manager *ctx);
+void raise_ctx_destroy (struct raise *raise);
 
 /* exposed for unit testing only */
 int raise_check_type (const char *type);

--- a/t/t2201-job-cmd.t
+++ b/t/t2201-job-cmd.t
@@ -18,6 +18,8 @@ MINJOBID_KVS="job.0000.0000.0000.0000"
 MINJOBID_HEX="0000.0000.0000.0000"
 MINJOBID_WORDS="academy-academy-academy--academy-academy-academy"
 
+hwloc_fake_config='{"0":{"Core":2,"cpuset":"0-1"}}'
+
 test_under_flux 1 job
 
 flux setattr log-stderr-level 1
@@ -290,7 +292,6 @@ test_expect_success 'flux-job: kill fails with invalid signal number' '
 	EOF
 	test_cmp kill.expected2 kill.err2
 '
-
 runas() {
 	userid=$1 && shift
 	FLUX_HANDLE_USERID=$userid FLUX_HANDLE_ROLEMASK=0x2 "$@"
@@ -303,6 +304,280 @@ test_expect_success 'flux-job: kill fails for wrong userid' '
 	flux-job: kill ${validjob}: guests may only send signals to their own jobs
 	EOF
 	test_cmp kill.guest.expected kill.guest.err
+'
+
+# Verify that the above tests left some jobs in the queue since
+# some tests below rely on it
+test_expect_success 'flux job: the queue contains active jobs' '
+	count=$(flux job list | wc -l) &&
+	test ${count} -gt 0
+'
+
+# Note: in this script job-exec is not loaded so there cannot
+# be any running jobs to kill
+
+test_expect_success 'flux job: killall with no args works' '
+	flux job killall 2>killall_0.err &&
+	cat <<-EOT >killall_0.exp &&
+	flux-job: Command matched 0 jobs
+	EOT
+	test_cmp killall_0.exp killall_0.err
+'
+
+test_expect_success 'flux-job: killall with bad broker connection fails' '
+	! FLUX_URI=/wrong flux job killall
+'
+
+test_expect_success 'flux job: killall with extra free args prints usage' '
+	test_must_fail flux job killall foo 2>killall_xargs.err &&
+	grep Usage killall_xargs.err
+'
+
+test_expect_success 'flux job: killall --force works' '
+	flux job killall --force 2>killall_0f.err &&
+	test_cmp killall_0.exp killall_0f.err
+'
+
+test_expect_success 'flux job: killall fails for invalid signal name' '
+	test_must_fail flux job killall -s SIGFAKE 2>killall.err &&
+	cat <<-EOT >killall.exp &&
+	flux-job: killall: Invalid signal SIGFAKE
+	EOT
+	test_cmp killall.exp killall.err
+'
+
+test_expect_success 'flux-job: killall --user all fails for guest' '
+	id=$(($(id -u)+1)) &&
+        test_must_fail runas ${id} \
+		flux job killall --user all 2> killall_all_guest.err &&
+	cat <<-EOF >killall_all_guest.exp &&
+	flux-job: killall: guests can only kill their own jobs
+	EOF
+	test_cmp killall_all_guest.exp killall_all_guest.err
+'
+
+test_expect_success 'flux-job: killall --user <guest_uid> works for guest' '
+	id=$(($(id -u)+1)) &&
+        runas ${id} \
+		flux job killall --user ${id} 2> killall_guest.err
+'
+
+test_expect_success 'flux job: the queue contains active jobs' '
+	count=$(flux job list | wc -l) &&
+	test ${count} -gt 0
+'
+
+test_expect_success 'flux job: cancelall with no args works' '
+	count=$(flux job list | wc -l) &&
+	flux job cancelall 2>cancelall.err &&
+	cat <<-EOT >cancelall.exp &&
+	flux-job: Command matched ${count} jobs (-f to confirm)
+	EOT
+	test_cmp cancelall.exp cancelall.err
+'
+
+test_expect_success 'flux-job: cancelall with bad broker connection fails' '
+	! FLUX_URI=/wrong flux job cancelall
+'
+
+test_expect_success 'flux job: cancelall with reason works' '
+	flux job cancelall this is a reason 2>cancelall_reason.err &&
+	test_cmp cancelall.exp cancelall_reason.err
+'
+
+test_expect_success 'flux job: cancelall --force works' '
+	count=$(flux job list | wc -l) &&
+	flux job cancelall --force 2>cancelall_f.err &&
+	cat <<-EOT >cancelall_f.exp &&
+	flux-job: Canceled ${count} jobs (0 errors)
+	EOT
+	test_cmp cancelall_f.exp cancelall_f.err
+'
+
+test_expect_success 'flux job: the queue is empty' '
+	run_timeout 60 flux job drain
+'
+
+test_expect_success 'flux-job: cancelall --user all fails for guest' '
+	id=$(($(id -u)+1)) &&
+        test_must_fail runas ${id} \
+		flux job cancelall --user all 2> cancelall_all_guest.err &&
+	cat <<-EOF >cancelall_all_guest.exp &&
+	flux-job: raiseall: guests can only raise exceptions on their own jobs
+	EOF
+	test_cmp cancelall_all_guest.exp cancelall_all_guest.err
+'
+
+test_expect_success 'flux-job: cancelall --user <guest uid> works for guest' '
+	id=$(($(id -u)+1)) &&
+        runas ${id} \
+		flux job cancelall --user ${id} 2> cancelall_guest.err
+'
+
+test_expect_success 'flux job: cancelall with unknown state fails' '
+	test_must_fail flux job cancelall --states=FOO 2>cancelall_bs.err &&
+	cat <<-EOT >cancelall_bs.exp &&
+	flux-job: error parsing --states: FOO is unknown
+	EOT
+	test_cmp cancelall_bs.exp cancelall_bs.err
+'
+
+test_expect_success 'flux job: raiseall with no args prints Usage' '
+	test_must_fail flux job raiseall 2>raiseall_na.err &&
+	grep Usage: raiseall_na.err
+'
+
+test_expect_success 'flux job: raiseall with type works' '
+	flux job raiseall test 2>raiseall.err &&
+	cat <<-EOT >raiseall.exp &&
+	flux-job: Command matched 0 jobs
+	EOT
+	test_cmp raiseall.exp raiseall.err
+'
+
+test_expect_success 'flux-job: raiseall with bad broker connection fails' '
+	! FLUX_URI=/wrong flux job raiseall test
+'
+
+test_expect_success 'flux job: raiseall with type and reason works' '
+	flux job raiseall test I have a raisin 2>raiseall_reason.err &&
+	test_cmp raiseall.exp raiseall_reason.err
+'
+
+test_expect_success 'flux job: raiseall with --force works' '
+	flux job raiseall --force test 2>raiseall_f.err &&
+	test_cmp raiseall.exp raiseall_f.err
+'
+
+test_expect_success 'flux job: raiseall with unknown state fails' '
+	test_must_fail flux job raiseall --states=FOO test 2>raiseall_bs.err &&
+	cat <<-EOT >raiseall_bs.exp &&
+	flux-job: error parsing --states: FOO is unknown
+	EOT
+	test_cmp raiseall_bs.exp raiseall_bs.err
+'
+
+test_expect_success 'flux job: raiseall with --state=inactive fails' '
+	test_must_fail flux job raiseall \
+		--states=inactive test 2>raiseall_inactive.err &&
+	cat <<-EOT >raiseall_inactive.exp &&
+	flux-job: Exceptions cannot be raised on inactive jobs
+	EOT
+	test_cmp raiseall_inactive.exp raiseall_inactive.err
+'
+
+test_expect_success 'flux job: raiseall with empty statemask fails' '
+	test_must_fail flux job raiseall --states="" test 2>raiseall_bs2.err &&
+	cat <<-EOT >raiseall_bs2.exp &&
+	flux-job: no states specified
+	EOT
+	test_cmp raiseall_bs2.exp raiseall_bs2.err
+'
+
+test_expect_success 'flux job: raiseall with invalid severity fails' '
+	test_must_fail flux job raiseall --severity=9 test 2>raiseall_sev.err &&
+	cat <<-EOT >raiseall_sev.exp &&
+	flux-job: raiseall: invalid exception severity
+	EOT
+	test_cmp raiseall_sev.exp raiseall_sev.err
+'
+
+test_expect_success 'flux job: raiseall with invalid type fails' '
+	test_must_fail flux job raiseall "bad type" 2>raiseall_bt.err &&
+	cat <<-EOT >raiseall_bt.exp &&
+	flux-job: raiseall: invalid exception type
+	EOT
+	test_cmp raiseall_bt.exp raiseall_bt.err
+'
+
+test_expect_success 'flux-job: raiseall --user all fails for guest' '
+	id=$(($(id -u)+1)) &&
+        test_must_fail runas ${id} \
+		flux job raiseall --user all test 2> raiseall_all_guest.err &&
+	cat <<-EOT >raiseall_all_guest.exp &&
+	flux-job: raiseall: guests can only raise exceptions on their own jobs
+	EOT
+	test_cmp raiseall_all_guest.exp raiseall_all_guest.err
+'
+
+test_expect_success 'flux-job: raiseall --user <guest_uid> works for guest' '
+	id=$(($(id -u)+1)) &&
+        runas ${id} \
+		flux job raiseall --user ${id} test 2> raiseall_guest.err
+'
+
+test_expect_success 'flux-job: raiseall --user name works' '
+	name=$(id -un) &&
+	flux job raiseall --user ${name} test 2> raiseall_name.err
+'
+
+test_expect_success 'submit 3 test jobs' '
+	for i in $(seq 1 3); do flux mini submit sleep 60 >>jobs; done
+'
+
+test_expect_success 'flux-job: raiseall returns correct count' '
+	flux job raiseall -s 7 test not_raised 2>raiseall_test.err &&
+	cat <<-EOT >raiseall_test.exp &&
+	flux-job: Command matched 3 jobs (-f to confirm)
+	EOT
+	test_cmp raiseall_test.exp raiseall_test.err
+'
+
+test_expect_success 'flux-job: raiseall -f returns correct count' '
+	flux job raiseall -s 7 -f test raised1 2>raiseall_testf.err &&
+	cat <<-EOT >raiseall_testf.exp &&
+	flux-job: Raised exception on 3 jobs (0 errors)
+	EOT
+	test_cmp raiseall_testf.exp raiseall_testf.err
+'
+
+test_expect_success 'flux-job: cancelall -f returns correct count' '
+	flux job cancelall -f 2>cancelall_testf.err &&
+	cat <<-EOT >cancelall_testf.exp &&
+	flux-job: Canceled 3 jobs (0 errors)
+	EOT
+	test_cmp cancelall_testf.exp cancelall_testf.err
+'
+
+test_expect_success 'flux job: the queue is empty' '
+	run_timeout 60 flux job drain
+'
+test_expect_success 'flux job: retrieve eventlogs' '
+	for id in $(cat jobs); do flux job eventlog ${id} >>eventlogs; done
+'
+
+test_expect_success 'flux-job: unconfirmed exception was not raised' '
+	test_must_fail grep not_raised eventlogs
+'
+
+test_expect_success 'flux-job: confirmed non-fatal exception was raised' '
+	count=$(grep raised1 eventlogs | wc -l) &&
+	test ${count} -eq 3
+'
+
+test_expect_success 'flux-job: fatal cancel exception was raised' '
+	count=$(grep cancel eventlogs | wc -l) &&
+	test ${count} -eq 3
+'
+
+test_expect_success 'flux-job: load modules for live killall test' '
+	flux kvs put resource.hwloc.by_rank="$hwloc_fake_config" &&
+        flux exec -r all flux module load barrier &&
+        flux module load sched-simple &&
+        flux module load job-exec
+'
+
+test_expect_success 'flux job: killall -f kills one job' '
+        id=$(flux mini submit sleep 600) &&
+        flux job wait-event $id start &&
+        flux job killall -f &&
+	run_timeout 60 flux job drain
+'
+
+test_expect_success 'flux job: unload modules' '
+        flux module remove job-exec &&
+        flux module remove sched-simple &&
+        flux exec -r all flux module remove barrier
 '
 
 test_done

--- a/t/t2204-job-info.t
+++ b/t/t2204-job-info.t
@@ -213,15 +213,15 @@ test_expect_success HAVE_JQ 'flux job list defaults to listing pending & running
         test_cmp list_default_pending.out job_ids_pending.out
 '
 
-test_expect_success 'flux job list --userid=userid works' '
+test_expect_success 'flux job list --user=userid works' '
         uid=$(id -u) &&
-        flux job list --userid=$uid> list_userid.out &&
+        flux job list --user=$uid> list_userid.out &&
         count=$(wc -l < list_userid.out) &&
         test "$count" = "12"
 '
 
-test_expect_success 'flux job list --userid=all works' '
-        flux job list --userid=all > list_all.out &&
+test_expect_success 'flux job list --user=all works' '
+        flux job list --user=all > list_all.out &&
         count=$(wc -l < list_all.out) &&
         test "$count" = "12"
 '


### PR DESCRIPTION
This PR adds job manager support for sending signals and raising exceptions on groups of jobs, and adds `flux job killalll`, `flux job raiseall`, and `flux job cancelall` front end commands.   By default these commands target the jobs of the invoking user. The instance owner can additionally specify a `--user` option to target the jobs of a specific user, or `all` for all users.  The commands by default run in a "dry run" mode where the number of affected jobs is reported, and must be run with `--force` to have any effect.   Example:
```
$ fflux job cancelall
flux-job: Command matched 44 jobs (-f to confirm)
$ flux job cancelall -f
flux-job: Canceled 44 jobs (0 errors)
$ flux job cancelall
flux-job: Command matched 0 jobs
```

Still need to write tests, but wanted to get some feedback on the user interface first.