### PR TITLE
shell: Add new shell init call to chdir() into current working directory

### DIFF
--- a/src/common/libsubprocess/local.c
+++ b/src/common/libsubprocess/local.c
@@ -492,7 +492,7 @@ static int local_child (flux_subprocess_t *p)
     // Change working directory
     if ((cwd = flux_cmd_getcwd (p->cmd)) && chdir (cwd) < 0) {
         fprintf (stderr,
-                 "Couldn't change dir to %s: going to /tmp instead: %s\n",
+                 "Could not change dir to %s: %s. Going to /tmp instead\n",
                  cwd, strerror (errno));
         if (chdir ("/tmp") < 0)
             _exit (1);

--- a/src/shell/shell.c
+++ b/src/shell/shell.c
@@ -929,6 +929,21 @@ static int shell_init (flux_shell_t *shell)
         }
     }
 
+    /* Change current working directory once before all tasks are
+     * created, so that each task does not need to chdir().
+     */
+    if (shell->info->jobspec->cwd) {
+        if (chdir (shell->info->jobspec->cwd) < 0) {
+            shell_log_error ("Could not change dir to %s: %s. "
+                             "Going to /tmp instead",
+                             shell->info->jobspec->cwd, strerror (errno));
+            if (chdir ("/tmp") < 0) {
+                shell_log_errno ("Could not change dir to /tmp");
+                return -1;
+            }
+        }
+    }
+
     return plugstack_call (shell->plugstack, "shell.init", NULL);
 }
 

--- a/t/t2608-job-shell-log.t
+++ b/t/t2608-job-shell-log.t
@@ -139,6 +139,11 @@ test_expect_success 'flux-shell: missing command logs fatal error' '
         grep "No such file or directory" missing.err
 '
 
+test_expect_success 'flux-shell: bad cwd emits message, but completes' '
+	flux mini run --setattr="system.cwd=/foo" pwd 2>badcwd.err &&
+        grep "Could not change dir to /foo: No such file or directory" badcwd.err
+'
+
 test_expect_success 'job-exec: set kill-timeout to low value for testing' '
 	flux setattr job-exec.kill_timeout 0.25
 '


### PR DESCRIPTION
In order to solve #2679, create a new `shell.init` call that will `chdir()` into the job's current working directory, so that each task does not have to `chdir()` into it.

Example output:

```
>src/cmd/flux start flux mini run --setattr="system.cwd=/foo" pwd
0.088s: flux-shell[0]: ERROR: tasks: Could not change dir to /foo: going to /tmp instead: No such file or directory
/tmp

```

Notes/Thoughts:

- I could have stuck the `chdir()` in any number locations, but in keeping with the plugstack architecture in the job-shell, I created the new "shell.init" function.  Putting it in `task.c` didn't feel 100% right, but I disliked the idea of creating a new file for just this `chdir()`.  Maybe I should have.  It's one of the reasons that the plugstack function is labeled "tasks" instead of "task", to differentiate from the other functions.

- Should message be level "WARN" instead of "ERROR"?  On the one hand, it feels like more of a warning.  But outputting the `errno` string make it seem like an error.

- I changed the `libsubprocess` error message from "Couldn't" to "Could not", partially b/c it's more formal, mostly b/c working around the single apostrophe in sharness was annoying.
