### PR TITLE
add capability to administratively suspend scheduling

### DIFF
--- a/src/cmd/flux-queue.c
+++ b/src/cmd/flux-queue.c
@@ -24,11 +24,34 @@
 
 int cmd_enable (optparse_t *p, int argc, char **argv);
 int cmd_disable (optparse_t *p, int argc, char **argv);
+int cmd_start (optparse_t *p, int argc, char **argv);
+int cmd_stop (optparse_t *p, int argc, char **argv);
 int cmd_status (optparse_t *p, int argc, char **argv);
 
 int stdin_flags;
 
 static struct optparse_option global_opts[] =  {
+    OPTPARSE_TABLE_END
+};
+
+static struct optparse_option stop_opts[] = {
+    { .name = "verbose", .key = 'v',
+      .usage = "Display more detail about internal job manager state",
+    },
+    OPTPARSE_TABLE_END
+};
+
+static struct optparse_option start_opts[] = {
+    { .name = "verbose", .key = 'v',
+      .usage = "Display more detail about internal job manager state",
+    },
+    OPTPARSE_TABLE_END
+};
+
+static struct optparse_option status_opts[] = {
+    { .name = "verbose", .key = 'v',
+      .usage = "Display more detail about internal job manager state",
+    },
     OPTPARSE_TABLE_END
 };
 
@@ -47,12 +70,26 @@ static struct optparse_subcommand subcommands[] = {
       0,
       NULL,
     },
+    { "start",
+      "[OPTIONS]",
+      "Start scheduling",
+      cmd_start,
+      0,
+      start_opts,
+    },
+    { "stop",
+      "[OPTIONS] [message ...]",
+      "Stop scheduling",
+      cmd_stop,
+      0,
+      stop_opts,
+    },
     { "status",
       "[OPTIONS]",
       "Get queue status",
       cmd_status,
       0,
-      NULL,
+      status_opts,
     },
     OPTPARSE_SUBCMD_END
 };
@@ -160,10 +197,59 @@ void submit_admin (flux_t *h,
         log_msg_exit ("submit-admin: %s", future_strerror (f, errno));
     log_msg ("Job submission is %s%s%s",
              enable ? "enabled" : "disabled",
-             enable ? "" : ", reason: ",
+             enable ? "" : ": ",
              enable ? "" : reason);
     flux_future_destroy (f);
 }
+
+void alloc_admin (flux_t *h,
+                  bool verbose,
+                  int query_only,
+                  int enable,
+                  const char *reason)
+{
+    flux_future_t *f;
+    int free_pending;
+    int alloc_pending;
+    int queue_length;
+
+    if (!(f = flux_rpc_pack (h,
+                             "job-manager.alloc-admin",
+                             FLUX_NODEID_ANY,
+                             0,
+                             "{s:b s:b s:s}",
+                             "query_only",
+                             query_only,
+                             "enable",
+                             enable,
+                             "reason",
+                             reason ? reason : "")))
+        log_err_exit ("error sending alloc-admin request");
+    if (flux_rpc_get_unpack (f,
+                             "{s:b s:s s:i s:i s:i}",
+                             "enable",
+                             &enable,
+                             "reason",
+                             &reason,
+                             "queue_length",
+                             &queue_length,
+                             "alloc_pending",
+                             &alloc_pending,
+                             "free_pending",
+                             &free_pending) < 0)
+        log_msg_exit ("alloc-admin: %s", future_strerror (f, errno));
+    log_msg ("Scheduling is %s%s%s",
+             enable ? "enabled" : "disabled",
+             reason && strlen (reason) > 0 ? ": " : "",
+             reason ? reason : "");
+    if (verbose) {
+        log_msg ("%d alloc requests queued", queue_length);
+        log_msg ("%d alloc requests pending to scheduler", alloc_pending);
+        log_msg ("%d free requests pending to scheduler", free_pending);
+    }
+    flux_future_destroy (f);
+}
+
 
 int cmd_enable (optparse_t *p, int argc, char **argv)
 {
@@ -199,6 +285,38 @@ int cmd_disable (optparse_t *p, int argc, char **argv)
     return (0);
 }
 
+int cmd_start (optparse_t *p, int argc, char **argv)
+{
+    flux_t *h;
+    int optindex = optparse_option_index (p);
+
+    if (argc - optindex > 0) {
+        optparse_print_usage (p);
+        exit (1);
+    }
+    if (!(h = flux_open (NULL, 0)))
+        log_err_exit ("flux_open");
+    alloc_admin (h, optparse_hasopt (p, "verbose"), 0, 1, NULL);
+    flux_close (h);
+    return (0);
+}
+
+int cmd_stop (optparse_t *p, int argc, char **argv)
+{
+    flux_t *h;
+    int optindex = optparse_option_index (p);
+    char *reason = NULL;
+
+    if (argc - optindex > 0)
+        reason = parse_arg_message (argv + optindex, "reason");
+    if (!(h = flux_open (NULL, 0)))
+        log_err_exit ("flux_open");
+    alloc_admin (h, optparse_hasopt (p, "verbose"), 0, 0, reason);
+    flux_close (h);
+    free (reason);
+    return (0);
+}
+
 int cmd_status (optparse_t *p, int argc, char **argv)
 {
     flux_t *h;
@@ -211,6 +329,7 @@ int cmd_status (optparse_t *p, int argc, char **argv)
     if (!(h = flux_open (NULL, 0)))
         log_err_exit ("flux_open");
     submit_admin (h, 1, 0, NULL);
+    alloc_admin (h, optparse_hasopt (p, "verbose"), 1, 0, NULL);
     flux_close (h);
     return (0);
 }

--- a/src/common/libschedutil/alloc.c
+++ b/src/common/libschedutil/alloc.c
@@ -62,6 +62,11 @@ int schedutil_alloc_respond_denied (schedutil_t *util, const flux_msg_t *msg,
     return schedutil_alloc_respond (util->h, msg, 2, note);
 }
 
+int schedutil_alloc_respond_cancel (schedutil_t *util, const flux_msg_t *msg)
+{
+    return schedutil_alloc_respond (util->h, msg, 3, NULL);
+}
+
 struct alloc {
     char *note;
     const flux_msg_t *msg;

--- a/src/common/libschedutil/alloc.h
+++ b/src/common/libschedutil/alloc.h
@@ -47,6 +47,10 @@ int schedutil_alloc_respond_denied (schedutil_t *util, const flux_msg_t *msg,
 int schedutil_alloc_respond_R (schedutil_t *util, const flux_msg_t *msg,
                                const char *R, const char *note);
 
+/* Respond to an alloc request message - canceled.
+ * N.B. 'msg' is the alloc request, not the cancel request.
+ */
+int schedutil_alloc_respond_cancel (schedutil_t *util, const flux_msg_t *msg);
 
 #endif /* !_FLUX_SCHEDUTIL_ALLOC_H */
 

--- a/src/common/libschedutil/init.c
+++ b/src/common/libschedutil/init.c
@@ -31,12 +31,12 @@ enum module_debug_flags {
 schedutil_t *schedutil_create (flux_t *h,
                                schedutil_alloc_cb_f *alloc_cb,
                                schedutil_free_cb_f *free_cb,
-                               schedutil_exception_cb_f *exception_cb,
+                               schedutil_cancel_cb_f *cancel_cb,
                                void *cb_arg)
 {
     schedutil_t *util;
 
-    if (!h || !alloc_cb || !free_cb || !exception_cb) {
+    if (!h || !alloc_cb || !free_cb || !cancel_cb) {
         errno = EINVAL;
         return NULL;
     }
@@ -46,13 +46,11 @@ schedutil_t *schedutil_create (flux_t *h,
     util->h = h;
     util->alloc_cb = alloc_cb;
     util->free_cb = free_cb;
-    util->exception_cb = exception_cb;
+    util->cancel_cb = cancel_cb;
     util->cb_arg = cb_arg;
     if ((util->outstanding_futures = zlistx_new ()) == NULL)
         goto error;
     if (schedutil_ops_register (util) < 0)
-        goto error;
-    if (flux_event_subscribe (h, "job-exception") < 0)
         goto error;
 
     return util;
@@ -121,3 +119,7 @@ int schedutil_remove_outstanding_future (schedutil_t *util, flux_future_t *fut)
         return -1;
     return 0;
 }
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libschedutil/init.h
+++ b/src/common/libschedutil/init.h
@@ -26,7 +26,7 @@ typedef struct schedutil_ctx schedutil_t;
 schedutil_t *schedutil_create (flux_t *h,
                                schedutil_alloc_cb_f *alloc_cb,
                                schedutil_free_cb_f *free_cb,
-                               schedutil_exception_cb_f *exception_cb,
+                               schedutil_cancel_cb_f *cancel_cb,
                                void *cb_arg);
 
 /* Destory the handle for the schedutil conveinence library.

--- a/src/common/libschedutil/ops.h
+++ b/src/common/libschedutil/ops.h
@@ -35,17 +35,17 @@ typedef void (schedutil_free_cb_f)(flux_t *h,
                                    const char *R,
                                    void *arg);
 
-/* An exception occurred for job 'id'.
- * If the severity is zero, and there is an allocation pending for 'id',
- * you must fail it immediately using schedutil_alloc_respond_denied(),
- * setting the note field to something like "alloc aborted due to
- * exception type=%s"
+/* The job manager wants to cancel a pending alloc request.
+ * The scheduler should look up the job in its queue.  If not found, do nothing.
+ * If found, call schedutil_alloc_respond_cancel() and dequeue.
+ * N.B. same calling footprint as former exception callback to facilitate
+ * transition.
  */
-typedef void (schedutil_exception_cb_f)(flux_t *h,
-                                        flux_jobid_t id,
-                                        const char *type,
-                                        int severity,
-                                        void *arg);
+typedef void (schedutil_cancel_cb_f)(flux_t *h,
+                                     flux_jobid_t id,
+                                     const char *unused_arg1,
+                                     int unused_arg2,
+                                     void *arg);
 
 #endif /* !_FLUX_SCHEDUTIL_OPS_H */
 

--- a/src/common/libschedutil/schedutil_private.h
+++ b/src/common/libschedutil/schedutil_private.h
@@ -22,7 +22,7 @@ struct schedutil_ctx {
     flux_msg_handler_t **handlers;
     schedutil_alloc_cb_f *alloc_cb;
     schedutil_free_cb_f *free_cb;
-    schedutil_exception_cb_f *exception_cb;
+    schedutil_cancel_cb_f *cancel_cb;
     void *cb_arg;
     zlistx_t *outstanding_futures;
 };
@@ -38,7 +38,7 @@ int schedutil_add_outstanding_future (schedutil_t *util, flux_future_t *fut);
 int schedutil_remove_outstanding_future (schedutil_t *util,
                                          flux_future_t *fut);
 
-/* (Un-)register callbacks for alloc, free, exception.
+/* (Un-)register callbacks for alloc, free, cancel.
  */
 int schedutil_ops_register (schedutil_t *util);
 void schedutil_ops_unregister (schedutil_t *util);

--- a/src/modules/job-manager/alloc.c
+++ b/src/modules/job-manager/alloc.c
@@ -532,6 +532,16 @@ void alloc_dequeue_alloc_request (struct alloc *alloc, struct job *job)
     }
 }
 
+/* called from event_job_action() FLUX_JOB_CLEANUP */
+int alloc_cancel_alloc_request (struct alloc *alloc, struct job *job)
+{
+    if (job->alloc_pending) {
+        if (cancel_request (alloc, job) < 0)
+            return -1;
+    }
+    return 0;
+}
+
 /* called from list_handle_request() */
 struct job *alloc_queue_first (struct alloc *alloc)
 {

--- a/src/modules/job-manager/alloc.h
+++ b/src/modules/job-manager/alloc.h
@@ -29,6 +29,11 @@ int alloc_enqueue_alloc_request (struct alloc *alloc, struct job *job);
  */
 void alloc_dequeue_alloc_request (struct alloc *alloc, struct job *job);
 
+/* Send a request to cancel pending alloc request.
+ * This function is a no-op if job->alloc_pending is not set.
+ */
+int alloc_cancel_alloc_request (struct alloc *alloc, struct job *job);
+
 /* Call from CLEANUP state to release resources.
  * This function is a no-op if job->free_pending is set.
  */

--- a/src/modules/job-manager/event.c
+++ b/src/modules/job-manager/event.c
@@ -320,6 +320,8 @@ int event_job_action (struct event *event, struct job *job)
                 return -1;
             break;
         case FLUX_JOB_CLEANUP:
+            if (job->alloc_pending)
+                alloc_cancel_alloc_request (ctx->alloc, job);
             if (job->alloc_queued)
                 alloc_dequeue_alloc_request (ctx->alloc, job);
 
@@ -328,7 +330,8 @@ int event_job_action (struct event *event, struct job *job)
              * response with final=true.  Thus once the flag is clear,
              * it is safe to release all resources to the scheduler.
              */
-            if (job->has_resources && !job->start_pending) {
+            if (job->has_resources && !job->start_pending
+                                   && !job->free_pending) {
                 if (alloc_send_free_request (ctx->alloc, job) < 0)
                     return -1;
             }

--- a/src/modules/job-manager/raise.c
+++ b/src/modules/job-manager/raise.c
@@ -17,7 +17,7 @@
  * - job id, severity, type, note (optional)
  *
  * Action:
- * - publish exception event (for e.g. scheduler to abort queued requests)
+ * - publish exception event
  * - update kvs event log
  * - transition state to CLEANUP for severity=0
  *

--- a/src/test/sched-bench.sh
+++ b/src/test/sched-bench.sh
@@ -87,7 +87,7 @@ if test -z "$NOEXEC"; then
     log_timing_msg ran $starttime $runtime
 fi
 
-flux job drain
+flux queue drain
 
 flux job eventlog $last
 

--- a/t/t2201-job-cmd.t
+++ b/t/t2201-job-cmd.t
@@ -395,7 +395,7 @@ test_expect_success 'flux job: cancelall --force works' '
 '
 
 test_expect_success 'flux job: the queue is empty' '
-	run_timeout 60 flux job drain
+	run_timeout 60 flux queue drain
 '
 
 test_expect_success 'flux-job: cancelall --user all fails for guest' '
@@ -540,7 +540,7 @@ test_expect_success 'flux-job: cancelall -f returns correct count' '
 '
 
 test_expect_success 'flux job: the queue is empty' '
-	run_timeout 60 flux job drain
+	run_timeout 60 flux queue drain
 '
 test_expect_success 'flux job: retrieve eventlogs' '
 	for id in $(cat jobs); do flux job eventlog ${id} >>eventlogs; done
@@ -571,7 +571,7 @@ test_expect_success 'flux job: killall -f kills one job' '
         id=$(flux mini submit sleep 600) &&
         flux job wait-event $id start &&
         flux job killall -f &&
-	run_timeout 60 flux job drain
+	run_timeout 60 flux queue drain
 '
 
 test_expect_success 'flux job: unload modules' '

--- a/t/t2202-job-manager.t
+++ b/t/t2202-job-manager.t
@@ -254,8 +254,8 @@ test_expect_success 'job-manager: flux job submit works after queue enable' '
 	flux job submit basic.json
 '
 
-test_expect_success 'job-manager: flux job drain -t 0.01 receives timeout error' '
-	! flux job drain -t 0.01 2>drain.err &&
+test_expect_success 'job-manager: flux queue drain -t 0.01 receives timeout error' '
+	! flux queue drain -t 0.01 2>drain.err &&
 	grep timeout drain.err
 '
 

--- a/t/t2208-queue-cmd.t
+++ b/t/t2208-queue-cmd.t
@@ -36,4 +36,162 @@ test_expect_success 'flux-queue: status with bad broker connection fails' '
 	! FLUX_URI=/wrong flux queue status
 '
 
+test_expect_success 'flux-queue: disable with bad broker connection fails' '
+	! FLUX_URI=/wrong flux queue disable foo
+'
+
+test_expect_success 'flux-queue: enable with bad broker connection fails' '
+	! FLUX_URI=/wrong flux queue enable
+'
+
+test_expect_success 'flux-queue: disable works' '
+        flux queue disable system is fubar
+'
+
+test_expect_success 'flux-queue: job submit fails with queue disabled' '
+        test_must_fail flux mini run /bin/true
+'
+
+test_expect_success 'flux-queue: enable works' '
+        flux queue enable
+'
+
+test_expect_success 'flux-queue: flux mini run works after enable' '
+        run_timeout 60 flux mini run /bin/true
+'
+
+test_expect_success 'flux-queue: stop with bad broker connection fails' '
+	! FLUX_URI=/wrong flux queue stop
+'
+
+test_expect_success 'flux-queue: start with bad broker connection fails' '
+	! FLUX_URI=/wrong flux queue start
+'
+
+test_expect_success 'flux-queue: start with extra free args fails' '
+	test_must_fail flux queue start xyz 2>start_xargs.out &&
+	grep Usage: start_xargs.out
+'
+
+test_expect_success 'flux-queue: stop works' '
+	flux queue stop my unique message
+'
+
+test_expect_success 'flux-queue: status reports reason for stop' '
+	flux queue status 2>status.out &&
+	cat <<-EOT >status.exp &&
+	flux-queue: Job submission is enabled
+	flux-queue: Scheduling is disabled: my unique message
+	EOT
+	test_cmp status.exp status.out
+'
+
+test_expect_success 'flux-queue: submit 3 jobs' '
+	for i in $(seq 1 3); do flux mini submit /bin/true; done
+'
+
+test_expect_success 'flux-queue: start scheduling' '
+	flux queue start
+'
+
+test_expect_success 'flux-queue: queue empties out' '
+	run_timeout 60 flux job drain
+'
+
+test_expect_success 'flux-queue: start long job that uses all cores' '
+	id=$(flux mini submit -n $(nproc) sleep 600) &&
+	flux job wait-event ${id} start &&
+	echo ${id} >longjob
+'
+
+test_expect_success 'flux-queue: submit a job and make sure alloc sent' '
+	id=$(flux mini submit --flags debug /bin/true) &&
+	flux job wait-event ${id} debug.alloc-request
+'
+
+test_expect_success 'flux-queue: stop canceled alloc request' '
+	flux queue stop -v 2>stop.err &&
+	grep "flux-queue: 1 alloc requests pending to scheduler" stop.err
+'
+
+test_expect_success 'flux-queue: start scheduling and cancel long job' '
+	flux queue start &&
+	flux job cancel $(cat longjob)
+'
+
+test_expect_success 'flux-queue: queue empties out' '
+	flux queue start &&
+	flux job drain
+'
+
+test_expect_success 'flux-queue: unload scheduler' '
+	flux module remove sched-simple
+'
+
+test_expect_success 'flux-queue: submit a job to ping scheduler' '
+	flux mini submit --flags debug /bin/true
+'
+
+wait_for_sched_offline() {
+	local n=$1
+	for try in $(seq 1 $n); do
+		echo Check queue status for offline, try ${try} of $n 2>&1
+		flux queue status 2>&1 | grep disabled && return
+	done
+}
+
+test_expect_success 'flux-queue: queue says scheduling disabled' '
+	wait_for_sched_offline 10 &&
+	flux queue status 2>sched_stat.err &&
+	cat <<-EOT >sched_stat.exp &&
+	flux-queue: Job submission is enabled
+	flux-queue: Scheduling is disabled: Scheduler is offline
+	EOT
+	test_cmp sched_stat.exp sched_stat.err
+'
+
+test_expect_success 'flux-queue: load scheduler' '
+	flux module load sched-simple
+'
+
+test_expect_success 'flux-queue: queue says scheduling is enabled' '
+	flux queue status 2>sched_stat2.err &&
+	cat <<-EOT >sched_stat2.exp &&
+	flux-queue: Job submission is enabled
+	flux-queue: Scheduling is enabled
+	EOT
+	test_cmp sched_stat2.exp sched_stat2.err
+'
+
+runas_guest() {
+        local userid=$(($(id -u)+1))
+        FLUX_HANDLE_USERID=$userid FLUX_HANDLE_ROLEMASK=0x2 "$@"
+}
+
+test_expect_success 'flux-queue: stop denied for guest' '
+	test_must_fail runas_guest flux queue stop 2>guest_stop.err &&
+	cat <<-EOT >guest_alloc.exp &&
+	flux-queue: alloc-admin: Request requires owner credentals
+	EOT
+	test_cmp guest_alloc.exp guest_stop.err
+'
+
+test_expect_success 'flux-queue: start denied for guest' '
+	test_must_fail runas_guest flux queue start 2>guest_start.err &&
+	test_cmp guest_alloc.exp guest_start.err
+'
+
+test_expect_success 'flux-queue: disable denied for guest' '
+	test_must_fail runas_guest flux queue disable foo 2>guest_dis.err &&
+	cat <<-EOT >guest_submit.exp &&
+	flux-queue: submit-admin: Request requires owner credentals
+	EOT
+	test_cmp guest_submit.exp guest_dis.err
+'
+
+test_expect_success 'flux-queue: enable denied for guest' '
+	test_must_fail runas_guest flux queue enable 2>guest_ena.err &&
+	test_cmp guest_submit.exp guest_ena.err
+'
+
 test_done

--- a/t/t2208-queue-cmd.t
+++ b/t/t2208-queue-cmd.t
@@ -95,7 +95,7 @@ test_expect_success 'flux-queue: start scheduling' '
 '
 
 test_expect_success 'flux-queue: queue empties out' '
-	run_timeout 60 flux job drain
+	run_timeout 60 flux queue drain
 '
 
 test_expect_success 'flux-queue: start long job that uses all cores' '
@@ -121,7 +121,7 @@ test_expect_success 'flux-queue: start scheduling and cancel long job' '
 
 test_expect_success 'flux-queue: queue empties out' '
 	flux queue start &&
-	flux job drain
+	flux queue drain
 '
 
 test_expect_success 'flux-queue: unload scheduler' '

--- a/t/t2210-job-manager-bugs.t
+++ b/t/t2210-job-manager-bugs.t
@@ -32,7 +32,7 @@ test_expect_success 'issue2664: submit job 4' '
 # Hangs here (hitting timeout)
 test_expect_success 'issue2664: cancel job 1 and drain (cleanup)' '
 	flux job cancel $(cat job1.out) &&
-	run_timeout 5 flux job drain
+	run_timeout 5 flux queue drain
 '
 
 test_done

--- a/t/t2300-sched-simple.t
+++ b/t/t2300-sched-simple.t
@@ -166,6 +166,27 @@ test_expect_success 'sched-simple: reload with outstanding allocations' '
 	flux dmesg | grep "hello: alloc rank0/core0" &&
 	test "$($query)" = ""
 '
+test_expect_success 'sched-simple: verify three jobs are active' '
+	count=$(flux job list | wc -l) &&
+	test ${count} -eq 3
+'
+
+test_expect_success 'sched-simple: remove sched-simple and cancel jobs' '
+	flux module remove sched-simple &&
+	flux job cancelall -f
+'
+
+test_expect_success 'sched-simple: there are no outstanding sched requests' '
+	flux queue status -v 2>queue_status.out &&
+	grep "0 alloc requests pending to scheduler" queue_status.out &&
+	grep "0 free requests pending to scheduler" queue_status.out
+'
+
+test_expect_success 'sched-simple: load sched-simple and wait for queue drain' '
+	flux module load sched-simple &&
+	run_timeout 30 flux queue drain
+'
+
 test_expect_success 'sched-simple: remove sched-simple' '
 	flux module remove sched-simple
 '

--- a/t/t2402-job-exec-dummy.t
+++ b/t/t2402-job-exec-dummy.t
@@ -106,7 +106,7 @@ test_expect_success 'job-exec: exception while starting terminates job' '
 '
 test_expect_success 'job-exec: unload job-exec & sched-simple modules' '
 	flux job list &&
-	flux job drain &&
+	flux queue drain &&
 	flux module remove job-exec &&
 	flux module remove sched-simple
 '


### PR DESCRIPTION
This PR adds `flux queue stop [reason]` and `flux queue start` to tell the job manager to stop allocating resources temporarily, without affecting the ability to submit new work. This is one step towards being able to cleanly shutdown an instance, as discussed in #2649. 

To implement this, I added a `sched.cancel`  RPC between job manager and scheduler.  All pending alloc requests are canceled when resource allocation is stopped.  This cancels the requests so new jobs won't start as running ones complete, but the jobs remain in SCHED state.

The cancel request is also a solution for the job cancellation race described in #2279, where a job canceled at just the right time could theoretically get stuck in CLEANUP state until the scheduler allocated resources for it.  This was because the only way to cancel an alloc request was to have the scheduler catch the exception event, but the exception event might get there before the alloc request and be ignored.  The new cancel request is always received _after_ the alloc request since requests are ordered.

flux-sched will need to replace its libschedutil exception callback with a cleanup callback _eventually_.  I retained the exception callback footprint in libschedutil, but changed it so it is invoked only when the new `sched.cancel` request is received,  not on every exception.   If nothing is changed, job cancellation continues to work but running `flux queue stop` will kill any jobs that have pending alloc requests.  Since updating flux-sched would break compatibility with the current Flux-core release, maybe a good plan would be to do it after the next flux-core release (which we discussed doing fairly soon).

Commands look like this:
```console
$ flux queue stop
flux-queue: Scheduling is disabled
flux-queue: canceled 1 alloc requests
$ flux queue status
flux-queue: Job submission is enabled
flux-queue: Scheduling is disabled
$ flux queue start
flux-queue: Scheduling is enabled
```
