### PR TITLE
shell: fix race between stdin/out readers and eventlog creation

### DIFF
--- a/src/shell/input.c
+++ b/src/shell/input.c
@@ -276,8 +276,10 @@ static int shell_input_header (struct shell_input *in)
         errno = ENOMEM;
         goto error;
     }
-    if (shell_input_kvs_init (in, o) < 0)
+    if (shell_input_kvs_init (in, o) < 0) {
         shell_log_errno ("shell_input_kvs_init");
+        goto error;
+    }
     rc = 0;
  error:
     json_decref (o);

--- a/src/shell/input.c
+++ b/src/shell/input.c
@@ -276,10 +276,8 @@ static int shell_input_header (struct shell_input *in)
         errno = ENOMEM;
         goto error;
     }
-    if (!in->shell->standalone) {
-        if (shell_input_kvs_init (in, o) < 0)
-            shell_log_errno ("shell_input_kvs_init");
-    }
+    if (shell_input_kvs_init (in, o) < 0)
+        shell_log_errno ("shell_input_kvs_init");
     rc = 0;
  error:
     json_decref (o);

--- a/src/shell/output.c
+++ b/src/shell/output.c
@@ -828,8 +828,10 @@ static int shell_output_header (struct shell_output *out)
      * Call this as long as we're not standalone.
      */
     if (!out->shell->standalone) {
-        if (shell_output_kvs_init (out, o) < 0)
+        if (shell_output_kvs_init (out, o) < 0) {
             shell_log_errno ("shell_output_kvs_init");
+            goto error;
+        }
     }
     rc = 0;
 error:

--- a/src/shell/output.c
+++ b/src/shell/output.c
@@ -254,18 +254,6 @@ static int shell_output_redirect (struct shell_output *out, flux_kvs_txn_t *txn)
     return 0;
 }
 
-static void shell_output_kvs_init_completion (flux_future_t *f, void *arg)
-{
-    struct shell_output *out = arg;
-
-    if (flux_future_get (f, NULL) < 0)
-        shell_die_errno (1, "shell_output_kvs_init");
-    flux_future_destroy (f);
-
-    if (flux_shell_remove_completion_ref (out->shell, "output.kvs-init") < 0)
-        shell_log_errno ("flux_shell_remove_completion_ref");
-}
-
 static int shell_output_kvs_init (struct shell_output *out, json_t *header)
 {
     flux_kvs_txn_t *txn = NULL;
@@ -284,15 +272,12 @@ static int shell_output_kvs_init (struct shell_output *out, json_t *header)
         goto error;
     if (!(f = flux_kvs_commit (out->shell->h, NULL, 0, txn)))
         goto error;
-    if (flux_future_then (f, -1, shell_output_kvs_init_completion, out) < 0)
-        goto error;
-    if (flux_shell_add_completion_ref (out->shell, "output.kvs-init") < 0) {
-        shell_log_errno ("flux_shell_remove_completion_ref");
-        goto error;
-    }
-    /* f memory responsibility of shell_output_kvs_init_completion()
-     * callback */
-    f = NULL;
+    /* Wait synchronously for guest.output to be committed to kvs so
+     * that the output eventlog is guaranteed to exist before shell.init
+     * event is emitted to the exec.eventlog.
+     */
+    if (flux_future_get (f, NULL) < 0)
+        shell_die_errno (1, "failed to create header in output eventlog");
     rc = 0;
 error:
     saved_errno = errno;

--- a/src/shell/shell.c
+++ b/src/shell/shell.c
@@ -1079,7 +1079,7 @@ int main (int argc, char *argv[])
     /* Call shell initialization routines and "shell_init" plugins.
      */
     if (shell_init (&shell) < 0)
-        shell_die_errno (1, "shell_prepare");
+        shell_die_errno (1, "shell_init");
 
     /* Barrier to ensure initialization has completed across all shells.
      */

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -180,6 +180,7 @@ dist_check_SCRIPTS = \
 	issues/t1760-kvs-use-after-free.sh \
 	issues/t2281-service-add-crash.sh \
 	issues/t2284-initial-program-format-chars.sh \
+	issues/t2686-shell-input-race.sh \
 	python/__init__.py \
 	python/subflux.py \
 	python/tap \

--- a/t/issues/t2686-shell-input-race.sh
+++ b/t/issues/t2686-shell-input-race.sh
@@ -1,0 +1,39 @@
+#!/bin/sh -e
+#
+#  Multi-rank jobs race with creation of guest.input eventlog creation
+#
+
+SUBMITBENCH=${SHARNESS_TEST_DIRECTORY}/ingest/submitbench
+
+cat <<EOF >test.sh
+#!/bin/bash
+
+RC=0
+RANKS="[0-\$((\$(flux getattr size)-1))]"
+
+flux kvs put resource.hwloc.by_rank="{\"\$RANKS\": {\"Package\": 1, \"Core\": 16, \"PU\": 16, \"cpuset\": \"0-15\"}}"
+
+flux kvs get resource.hwloc.by_rank
+
+flux module remove sched-simple
+flux module load sched-simple
+
+flux dmesg | grep 'sched-simple.*ready'  | tail -1
+
+flux mini submit --dry-run -o cpu-affinity=off -N2 -n2 sleep 0 \
+    | ${SUBMITBENCH} -r 24 - >jobs.list
+
+cat jobs.list
+
+for id in \$(cat jobs.list); do
+    if ! flux job attach \$id >/dev/null 2>&1; then
+        printf "job %s\n" \$id
+        flux job eventlog -p guest.output \$id
+        RC=1
+    fi
+done
+
+exit \$RC
+EOF
+
+flux start -s 4 sh ./test.sh


### PR DESCRIPTION
As detailed in #2686 there's a potential race between guest.input eventlog creation, and the tasks which watch this eventlog for any input.

This is due to a confusing aspect of the shell design, where all initialization steps that must be guaranteed to be complete before the shell.init barrier must be done synchronously. In this case, the creation of `guest.input` eventlog was done asynchronously, and thus could race with readers (since there is no WAITCREATE feature for eventlogs)

This PR closes that race by synchronously ensuring the eventlog has been committed to the KVS before proceeding. 

I've also added a reproducer under the t4000-issues test driver, however, it wasn't 100% reproducible (more like 80%), but I figured it can't hurt. If it slows down Travis significantly, we may want to disable it by default somehow.
