### PR TITLE
install shell.h: the public api for shell plugins

### DIFF
--- a/src/shell/Makefile.am
+++ b/src/shell/Makefile.am
@@ -48,6 +48,10 @@ libmpir_la_SOURCES = \
 	mpir/proctable.c \
 	mpir/proctable.h
 
+
+fluxinclude_HEADERS = \
+	shell.h
+
 fluxlibexec_PROGRAMS = flux-shell
 
 flux_shell_SOURCES = \

--- a/src/shell/shell.h
+++ b/src/shell/shell.h
@@ -12,7 +12,6 @@
 #define FLUX_SHELL_H
 
 #include <flux/core.h>
-#include <flux/optparse.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
It was an oversight that `shell.h` was never added to `fluxinclude_HEADERS` so it got installed in the include path.

This PR fixes that issue, plus removes `optparse.h` from the header, a leftover from when this was the main include file for the shell.