### PR TITLE
flux-job attach: don't ignore log messages on shell init failure, add -v option

### DIFF
--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -130,6 +130,8 @@ static struct optparse_option attach_opts[] =  {
     { .name = "label-io", .key = 'l', .has_arg = 0,
       .usage = "Label output by rank",
     },
+    { .name = "verbose", .key = 'v', .has_arg = 0,
+      .usage = "Increase verbosity" },
     { .name = "quiet", .key = 'q', .has_arg = 0,
       .usage = "Suppress warnings written to stderr from flux-job",
     },
@@ -935,6 +937,11 @@ static void handle_output_log (struct attach_ctx *ctx,
             fprintf (stderr, ": %s", label);
         if (component)
             fprintf (stderr, ": %s", component);
+        if (optparse_hasopt (ctx->p, "verbose") && file) {
+            fprintf (stderr, ": %s", file);
+            if (line > 0)
+                fprintf (stderr, ":%d", line);
+        }
         fprintf (stderr, ": %s\n", msg);
     }
 }

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -967,6 +967,10 @@ void attach_output_continuation (flux_future_t *f, void *arg)
     if (flux_job_event_watch_get (f, &entry) < 0) {
         if (errno == ENODATA)
             goto done;
+        if (errno == ENOENT) {
+            log_msg ("No job output found");
+            goto done;
+        }
         log_msg_exit ("flux_job_event_watch_get: %s",
                       future_strerror (f, errno));
     }
@@ -1157,6 +1161,24 @@ void attach_stdin_cb (flux_reactor_t *r, flux_watcher_t *w,
     }
 }
 
+/*  Start the guest.output eventlog watcher
+ */
+void attach_output_start (struct attach_ctx *ctx)
+{
+    if (!(ctx->output_f = flux_job_event_watch (ctx->h,
+                                                ctx->id,
+                                                "guest.output",
+                                                0)))
+        log_err_exit ("flux_job_event_watch");
+
+    if (flux_future_then (ctx->output_f, -1.,
+                          attach_output_continuation,
+                          ctx) < 0)
+        log_err_exit ("flux_future_then");
+
+    ctx->eventlog_watch_count++;
+}
+
 /* Handle an event in the guest.exec eventlog.
  * This is a stream of responses, one response per event, terminated with
  * an ENODATA error response (or another error if something went wrong).
@@ -1215,20 +1237,16 @@ void attach_exec_event_continuation (flux_future_t *f, void *arg)
 
         ctx->stdin_w = w;
         flux_watcher_start (ctx->stdin_w);
-        if (!(ctx->output_f = flux_job_event_watch (ctx->h,
-                                                    ctx->id,
-                                                    "guest.output",
-                                                    0)))
-            log_err_exit ("flux_job_event_watch");
 
-        if (flux_future_then (ctx->output_f,
-                              -1.,
-                              attach_output_continuation,
-                              ctx) < 0)
-            log_err_exit ("flux_future_then");
-
-        ctx->eventlog_watch_count++;
+        attach_output_start (ctx);
     }
+
+    /*  If job is complete, and we haven't started watching
+     *   output eventlog, then start now in case shell.init event
+     *   was never emitted (failure in iniitialization)
+     */
+    if (!strcmp (name, "complete") && !ctx->output_f)
+        attach_output_start (ctx);
 
     if (optparse_hasopt (ctx->p, "show-exec")) {
         print_eventlog_entry (stderr,

--- a/src/common/liboptparse/optparse.c
+++ b/src/common/liboptparse/optparse.c
@@ -165,6 +165,10 @@ static int option_info_cmp (struct option_info *x, struct option_info *y)
             return (-1);
         else if (y->isdoc)
             return (1);
+        else if (strcmp (o1->name, "help") == 0)
+            return -1;
+        else if (strcmp (o2->name, "help") == 0)
+            return 1;
         else if (isalnum (o1->key) && isalnum (o2->key))
             return (o1->key - o2->key);
         else

--- a/src/common/liboptparse/test/optparse.c
+++ b/src/common/liboptparse/test/optparse.c
@@ -80,8 +80,8 @@ void test_usage_output (void)
 
     usage_ok (p, "\
 Usage: prog-foo [OPTIONS]\n\
-  -T, --test2=N          Enable a test option N.\n\
   -h, --help             Display this message.\n\
+  -T, --test2=N          Enable a test option N.\n\
   -t, --test             Enable a test option.\n",
         "Usage output as expected");
 
@@ -96,8 +96,8 @@ Usage: prog-foo [OPTIONS]\n\
     ok (e == OPTPARSE_SUCCESS, "optparse_add_option. group 1.");
     usage_ok (p, "\
 Usage: prog-foo [OPTIONS]\n\
-  -T, --test2=N          Enable a test option N.\n\
   -h, --help             Display this message.\n\
+  -T, --test2=N          Enable a test option N.\n\
   -t, --test             Enable a test option.\n",
         "Usage output as expected");
 
@@ -108,8 +108,8 @@ Usage: prog-foo [OPTIONS]\n\
 
     usage_ok (p, "\
 Usage: prog-foo [OPTIONS]\n\
--T, --test2=N            Enable a test option N.\n\
 -h, --help               Display this message.\n\
+-T, --test2=N            Enable a test option N.\n\
 -t, --test               Enable a test option.\n",
         "Usage output as expected w/ left margin");
 
@@ -122,8 +122,8 @@ Usage: prog-foo [OPTIONS]\n\
 
     usage_ok (p, "\
 Usage: prog-foo [OPTIONS]\n\
-  -T, --test2=N          Enable a test option N.\n\
-  -h, --help             Display this message.\n",
+  -h, --help             Display this message.\n\
+  -T, --test2=N          Enable a test option N.\n",
         "Usage output as expected after option removal");
 
     // Add doc sections
@@ -132,8 +132,8 @@ Usage: prog-foo [OPTIONS]\n\
     usage_ok (p, "\
 Usage: prog-foo [OPTIONS]\n\
 This is some doc in header\n\
-  -T, --test2=N          Enable a test option N.\n\
-  -h, --help             Display this message.\n",
+  -h, --help             Display this message.\n\
+  -T, --test2=N          Enable a test option N.\n",
         "Usage output as with doc");
 
     // Add a longer option in group 1:
@@ -148,8 +148,8 @@ This is some doc in header\n\
     usage_ok (p, "\
 Usage: prog-foo [OPTIONS]\n\
 This is some doc in header\n\
-  -T, --test2=N          Enable a test option N.\n\
   -h, --help             Display this message.\n\
+  -T, --test2=N          Enable a test option N.\n\
   -A, --long-option=ARGINFO\n\
                          Enable a long option with argument info ARGINFO.\n",
         "Usage output with option in group 1");
@@ -160,8 +160,8 @@ This is some doc in header\n\
     usage_ok (p, "\
 Usage: prog-foo [OPTIONS]\n\
 This is some doc in header\n\
-  -T, --test2=N          Enable a test option N.\n\
   -h, --help             Display this message.\n\
+  -T, --test2=N          Enable a test option N.\n\
 This is some doc for group 1\n\
   -A, --long-option=ARGINFO\n\
                          Enable a long option with argument info ARGINFO.\n",
@@ -174,8 +174,8 @@ This is some doc for group 1\n\
     usage_ok (p, "\
 Usage: prog-foo [OPTIONS]\n\
 This is some doc in header\n\
-  -T, --test2=N               Enable a test option N.\n\
   -h, --help                  Display this message.\n\
+  -T, --test2=N               Enable a test option N.\n\
 This is some doc for group 1\n\
   -A, --long-option=ARGINFO   Enable a long option with argument info ARGINFO.\n",
         "Usage output with increased option width");
@@ -191,8 +191,8 @@ This is some doc for group 1\n\
     usage_ok (p, "\
 Usage: prog-foo [OPTIONS]\n\
 This is some doc in header\n\
-  -T, --test2=N               Enable a test option N.\n\
   -h, --help                  Display this message.\n\
+  -T, --test2=N               Enable a test option N.\n\
 This is some doc for group 1\n\
   -A, --long-option=ARGINFO   Enable a long option with argument info ARGINFO.\n\
   -B, --option-B              This option has a very long description. It should\n\
@@ -210,8 +210,8 @@ This is some doc for group 1\n\
     usage_ok (p, "\
 Usage: prog-foo [OPTIONS]\n\
 This is some doc in header\n\
-  -T, --test2=N               Enable a test option N.\n\
   -h, --help                  Display this message.\n\
+  -T, --test2=N               Enable a test option N.\n\
 This is some doc for group 1\n\
   -A, --long-option=ARGINFO   Enable a long option with argument info ARGINFO.\n\
   -B, --option-B              This option has a very long description. It should\n\
@@ -224,8 +224,8 @@ This is some doc for group 1\n\
     usage_ok (p, "\
 Usage: prog-foo [OPTIONS]\n\
 This is some doc in header\n\
-  -T, --test2=N               Enable a test option N.\n\
   -h, --help                  Display this message.\n\
+  -T, --test2=N               Enable a test option N.\n\
 This is some doc for group 1\n\
   -A, --long-option=ARGINFO   Enable a long option with argument info ARGINFO.\n\
   -B, --option-B              This option has a very long description. It should be split across lines nicely.\n\
@@ -246,8 +246,8 @@ This is some doc for group 1\n\
     usage_ok (p, "\
 Usage: prog-foo [OPTIONS]\n\
 This is some doc in header\n\
-  -T, --test2=N               Enable a test option N.\n\
   -h, --help                  Display this message.\n\
+  -T, --test2=N               Enable a test option N.\n\
 This is some doc for group 1\n\
       --long-only             This option is long only\n\
   -A, --long-option=ARGINFO   Enable a long option with argument info ARGINFO.\n\

--- a/t/t2500-job-attach.t
+++ b/t/t2500-job-attach.t
@@ -95,4 +95,13 @@ test_expect_success NO_CHAIN_LINT 'attach: output appears before cancel' '
         ! grep after attach5.out
 '
 
+test_expect_success 'attach: output events processed after shell.init failure' '
+	jobid=$(flux mini submit -o initrc=noinitrc hostname) &&
+	flux job wait-event -v ${jobid} clean &&
+	flux job eventlog -p guest.output ${jobid} &&
+	(flux job attach ${jobid} >init-failure.output 2>&1 || true) &&
+	test_debug "cat init-failure.output" &&
+	grep "FATAL:.*noinitrc: No such file or directory" init-failure.output
+'
+
 test_done


### PR DESCRIPTION
It is slightly inconvenient that to dump all log information from the `guest.output` eventlog, a call to `flux job eventlog` is required, since there's no way to entice `flux-job attach` to dump file and line info.

This PR started by adding a `-v, --verbose` option to `flux job attach` which presently just adds the file and line prefix to log messages if present. Therefore we can just tell users to run `flux job attach -v ...` to get this info into issue reports etc. We can expand `-v` to add other verbosity later.
 I'm amenable to a different option name if someone has an idea.

Along the way, I was annoyed that log messages are ignored when the shell fails to initialize (#2490). I thought of a workaround for that and added it here. If a "complete" event is seen in the exec.eventlog, and we still haven't started watching ouptut, then assume a shell initialization failure and start processing output events so that any log messages will be displayed. A missing output eventlog is now just a warning and not a fatal error.

Edit: also realized it was a bit strange to sort `--help` along with the other options in optparse usage output, so I added a quick fix to always put `--help` first (for now).

Also:
Fixes #2693

## Commit Message
cmd/flux-job: attach: fix missing log messages on shell.init failure

 * Ensure `flux job attach` attempts to fetch log messages for jobs even
   if job fails during shell initialization
 * Add `-v` option to flux-job attach. Currently adds file,line info to log messages
 * Always display `--help` usage message first in command help output.

