### PR TITLE
job-info: support listing jobs in specific states

### DIFF
--- a/doc/man1/flux-jobs.adoc
+++ b/doc/man1/flux-jobs.adoc
@@ -41,13 +41,21 @@ List jobs for a specific username or userid.  Specify 'all' for all users.
 Limit output to N jobs (default 1000)
 
 *-s, --states*'=STATES'::
-List jobs in specific states.  States can be 'pending', 'running', or
-'inactive'.  Multiple states can be listed separated by comma.
-Defaults to 'pending,running'.
+List jobs in specific job states or virtual job states.  Multiple
+states can be listed separated by comma.  See JOB STATES below for
+additional information.  Defaults to 'pending,running'.
 
 *-o, --format*'=FORMAT
 Specify output format using Python's string format syntax.  See OUTPUT
 FORMAT below for field names.
+
+JOB STATES
+----------
+Jobs may be observed to pass through five job states in Flux: DEPEND,
+SCHED, RUN, CLEANUP, and INACTIVE (see Flux RFC 21). For convenience
+and clarity, some options accept the following virtual job states:
+"pending", an alias for DEPEND,SCHED; "running", an alias for
+RUN,CLEANUP; "active", an alias for "pending,running".
 
 OUTPUT FORMAT
 -------------

--- a/src/bindings/python/flux/job.py
+++ b/src/bindings/python/flux/job.py
@@ -120,12 +120,12 @@ def wait(flux_handle, jobid=lib.FLUX_JOBID_ANY):
 # - Desired return value is json array, not a single value
 #
 # pylint: disable=dangerous-default-value
-def job_list(flux_handle, max_entries=0, attrs=[], userid=os.geteuid(), flags=0):
+def job_list(flux_handle, max_entries=0, attrs=[], userid=os.geteuid(), states=0):
     payload = {
         "max_entries": max_entries,
         "attrs": attrs,
         "userid": userid,
-        "flags": flags,
+        "states": states,
     }
     return flux_handle.rpc("job-info.list", payload)
 

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -938,16 +938,8 @@ int cmd_list (optparse_t *p, int argc, char **argv)
     else
         state_mask = FLUX_JOB_PENDING | FLUX_JOB_RUNNING;
 
-    /* Set request flags based on state mask.
-     * The returned list may need to be filtered down since the state_mask
-     * has a finer granularity than the flags.
-     */
-    if ((state_mask & FLUX_JOB_PENDING) != 0)
-        flags |= FLUX_JOB_LIST_PENDING;
-    if ((state_mask & FLUX_JOB_RUNNING) != 0)
-        flags |= FLUX_JOB_LIST_RUNNING;
-    if ((state_mask & FLUX_JOB_INACTIVE) != 0)
-        flags |= FLUX_JOB_LIST_INACTIVE;
+    /* Set request flags based on state mask. */
+    flags = state_mask;
 
     if (optparse_hasopt (p, "all"))
         userid = FLUX_USERID_UNKNOWN;
@@ -965,13 +957,11 @@ int cmd_list (optparse_t *p, int argc, char **argv)
         int state;
         if (json_unpack (value, "{s:i}", "state", &state) < 0)
             log_msg_exit ("error parsing list response (state is missing)");
-        if ((state & state_mask) != 0) {
-            str = json_dumps (value, 0);
-            if (!str)
-                log_msg_exit ("error parsing list response");
-            printf ("%s\n", str);
-            free (str);
-        }
+        str = json_dumps (value, 0);
+        if (!str)
+            log_msg_exit ("error parsing list response");
+        printf ("%s\n", str);
+        free (str);
     }
     flux_future_destroy (f);
     flux_close (h);

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -921,8 +921,7 @@ int cmd_list (optparse_t *p, int argc, char **argv)
     size_t index;
     json_t *value;
     uint32_t userid;
-    int flags = 0;
-    int state_mask;
+    int states = 0;
 
     if (optindex != argc) {
         optparse_print_usage (p);
@@ -932,14 +931,11 @@ int cmd_list (optparse_t *p, int argc, char **argv)
         log_err_exit ("flux_open");
 
     if (optparse_hasopt (p, "all-user") || optparse_hasopt (p, "all"))
-        state_mask = FLUX_JOB_ACTIVE | FLUX_JOB_INACTIVE;
+        states = FLUX_JOB_ACTIVE | FLUX_JOB_INACTIVE;
     else if (optparse_hasopt (p, "states"))
-        state_mask = parse_arg_states (p, "states");
+        states = parse_arg_states (p, "states");
     else
-        state_mask = FLUX_JOB_PENDING | FLUX_JOB_RUNNING;
-
-    /* Set request flags based on state mask. */
-    flags = state_mask;
+        states = FLUX_JOB_PENDING | FLUX_JOB_RUNNING;
 
     if (optparse_hasopt (p, "all"))
         userid = FLUX_USERID_UNKNOWN;
@@ -948,7 +944,7 @@ int cmd_list (optparse_t *p, int argc, char **argv)
     else
         userid = geteuid ();
 
-    if (!(f = flux_job_list (h, max_entries, attrs, userid, flags)))
+    if (!(f = flux_job_list (h, max_entries, attrs, userid, states)))
         log_err_exit ("flux_job_list");
     if (flux_rpc_get_unpack (f, "{s:o}", "jobs", &jobs) < 0)
         log_err_exit ("flux_job_list");

--- a/src/cmd/flux-jobs.py
+++ b/src/cmd/flux-jobs.py
@@ -170,12 +170,25 @@ def fetch_jobs_flux(args):
 
     flags = 0
     for state in args.states.split(","):
-        if state.lower() == "pending":
+        # Note
+        # pending = depend & sched
+        # running = run & cleanup
+        if state.lower() == "depend":
+            flags |= flux.constants.FLUX_JOB_DEPEND
+        elif state.lower() == "sched":
+            flags |= flux.constants.FLUX_JOB_SCHED
+        elif state.lower() == "pending":
             flags |= flux.constants.FLUX_JOB_PENDING
+        elif state.lower() == "run":
+            flags |= flux.constants.FLUX_JOB_RUN
+        elif state.lower() == "cleanup":
+            flags |= flux.constants.FLUX_JOB_CLEANUP
         elif state.lower() == "running":
             flags |= flux.constants.FLUX_JOB_RUNNING
         elif state.lower() == "inactive":
             flags |= flux.constants.FLUX_JOB_INACTIVE
+        elif state.lower() == "active":
+            flags |= flux.constants.FLUX_JOB_ACTIVE
         else:
             print("Invalid state specified", file=sys.stderr)
             sys.exit(1)
@@ -224,7 +237,7 @@ def parse_args():
         type=str,
         metavar="STATES",
         default="pending,running",
-        help="List jobs in specific states(pending,running,inactive)",
+        help="List jobs in specific job states or virtual job states",
     )
     parser.add_argument(
         "--suppress-header",

--- a/src/cmd/flux-jobs.py
+++ b/src/cmd/flux-jobs.py
@@ -171,18 +171,18 @@ def fetch_jobs_flux(args):
     flags = 0
     for state in args.states.split(","):
         if state.lower() == "pending":
-            flags |= flux.constants.FLUX_JOB_LIST_PENDING
+            flags |= flux.constants.FLUX_JOB_PENDING
         elif state.lower() == "running":
-            flags |= flux.constants.FLUX_JOB_LIST_RUNNING
+            flags |= flux.constants.FLUX_JOB_RUNNING
         elif state.lower() == "inactive":
-            flags |= flux.constants.FLUX_JOB_LIST_INACTIVE
+            flags |= flux.constants.FLUX_JOB_INACTIVE
         else:
             print("Invalid state specified", file=sys.stderr)
             sys.exit(1)
 
     if flags == 0:
-        flags |= flux.constants.FLUX_JOB_LIST_PENDING
-        flags |= flux.constants.FLUX_JOB_LIST_RUNNING
+        flags |= flux.constants.FLUX_JOB_PENDING
+        flags |= flux.constants.FLUX_JOB_RUNNING
 
     rpc_handle = flux.job.job_list(h, args.count, attrs, userid, flags)
     try:

--- a/src/cmd/flux-jobs.py
+++ b/src/cmd/flux-jobs.py
@@ -184,7 +184,7 @@ def fetch_jobs_flux(args):
         try:
             states |= state_const_dict[state.lower()]
         except KeyError:
-            print("Invalid state specified", file=sys.stderr)
+            print("Invalid state specified: {}".format(state), file=sys.stderr)
             sys.exit(1)
 
     if states == 0:

--- a/src/cmd/flux-jobs.py
+++ b/src/cmd/flux-jobs.py
@@ -25,6 +25,17 @@ from flux.core.inner import raw
 
 logger = logging.getLogger("flux-jobs")
 
+state_const_dict = {
+    "depend": flux.constants.FLUX_JOB_DEPEND,
+    "sched": flux.constants.FLUX_JOB_SCHED,
+    "run": flux.constants.FLUX_JOB_RUN,
+    "cleanup": flux.constants.FLUX_JOB_CLEANUP,
+    "inactive": flux.constants.FLUX_JOB_INACTIVE,
+    "pending": flux.constants.FLUX_JOB_PENDING,
+    "running": flux.constants.FLUX_JOB_RUNNING,
+    "active": flux.constants.FLUX_JOB_ACTIVE,
+}
+
 
 def runtime(job, roundup):
     if "t_cleanup" in job and "t_run" in job:
@@ -170,26 +181,9 @@ def fetch_jobs_flux(args):
 
     states = 0
     for state in args.states.split(","):
-        # Note
-        # pending = depend & sched
-        # running = run & cleanup
-        if state.lower() == "depend":
-            states |= flux.constants.FLUX_JOB_DEPEND
-        elif state.lower() == "sched":
-            states |= flux.constants.FLUX_JOB_SCHED
-        elif state.lower() == "pending":
-            states |= flux.constants.FLUX_JOB_PENDING
-        elif state.lower() == "run":
-            states |= flux.constants.FLUX_JOB_RUN
-        elif state.lower() == "cleanup":
-            states |= flux.constants.FLUX_JOB_CLEANUP
-        elif state.lower() == "running":
-            states |= flux.constants.FLUX_JOB_RUNNING
-        elif state.lower() == "inactive":
-            states |= flux.constants.FLUX_JOB_INACTIVE
-        elif state.lower() == "active":
-            states |= flux.constants.FLUX_JOB_ACTIVE
-        else:
+        try:
+            states |= state_const_dict[state.lower()]
+        except KeyError:
             print("Invalid state specified", file=sys.stderr)
             sys.exit(1)
 

--- a/src/cmd/flux-jobs.py
+++ b/src/cmd/flux-jobs.py
@@ -168,36 +168,36 @@ def fetch_jobs_flux(args):
                 print("invalid user specified", file=sys.stderr)
                 sys.exit(1)
 
-    flags = 0
+    states = 0
     for state in args.states.split(","):
         # Note
         # pending = depend & sched
         # running = run & cleanup
         if state.lower() == "depend":
-            flags |= flux.constants.FLUX_JOB_DEPEND
+            states |= flux.constants.FLUX_JOB_DEPEND
         elif state.lower() == "sched":
-            flags |= flux.constants.FLUX_JOB_SCHED
+            states |= flux.constants.FLUX_JOB_SCHED
         elif state.lower() == "pending":
-            flags |= flux.constants.FLUX_JOB_PENDING
+            states |= flux.constants.FLUX_JOB_PENDING
         elif state.lower() == "run":
-            flags |= flux.constants.FLUX_JOB_RUN
+            states |= flux.constants.FLUX_JOB_RUN
         elif state.lower() == "cleanup":
-            flags |= flux.constants.FLUX_JOB_CLEANUP
+            states |= flux.constants.FLUX_JOB_CLEANUP
         elif state.lower() == "running":
-            flags |= flux.constants.FLUX_JOB_RUNNING
+            states |= flux.constants.FLUX_JOB_RUNNING
         elif state.lower() == "inactive":
-            flags |= flux.constants.FLUX_JOB_INACTIVE
+            states |= flux.constants.FLUX_JOB_INACTIVE
         elif state.lower() == "active":
-            flags |= flux.constants.FLUX_JOB_ACTIVE
+            states |= flux.constants.FLUX_JOB_ACTIVE
         else:
             print("Invalid state specified", file=sys.stderr)
             sys.exit(1)
 
-    if flags == 0:
-        flags |= flux.constants.FLUX_JOB_PENDING
-        flags |= flux.constants.FLUX_JOB_RUNNING
+    if states == 0:
+        states |= flux.constants.FLUX_JOB_PENDING
+        states |= flux.constants.FLUX_JOB_RUNNING
 
-    rpc_handle = flux.job.job_list(h, args.count, attrs, userid, flags)
+    rpc_handle = flux.job.job_list(h, args.count, attrs, userid, states)
     try:
         jobs = flux.job.job_list_get(rpc_handle)
     except EnvironmentError as e:

--- a/src/common/libjob/job.c
+++ b/src/common/libjob/job.c
@@ -187,18 +187,18 @@ flux_future_t *flux_job_list (flux_t *h,
                               int max_entries,
                               const char *json_str,
                               uint32_t userid,
-                              int flags)
+                              int states)
 {
     flux_future_t *f;
     json_t *o = NULL;
-    int valid_flags = (FLUX_JOB_PENDING
-                       | FLUX_JOB_RUNNING
-                       | FLUX_JOB_INACTIVE);
+    int valid_states = (FLUX_JOB_PENDING
+                        | FLUX_JOB_RUNNING
+                        | FLUX_JOB_INACTIVE);
     int saved_errno;
 
     if (!h || max_entries < 0 || !json_str
            || !(o = json_loads (json_str, 0, NULL))
-           || flags & ~valid_flags) {
+           || states & ~valid_states) {
         errno = EINVAL;
         return NULL;
     }
@@ -207,7 +207,7 @@ flux_future_t *flux_job_list (flux_t *h,
                              "max_entries", max_entries,
                              "attrs", o,
                              "userid", userid,
-                             "flags", flags))) {
+                             "states", states))) {
         saved_errno = errno;
         json_decref (o);
         errno = saved_errno;

--- a/src/common/libjob/job.c
+++ b/src/common/libjob/job.c
@@ -191,9 +191,9 @@ flux_future_t *flux_job_list (flux_t *h,
 {
     flux_future_t *f;
     json_t *o = NULL;
-    int valid_flags = (FLUX_JOB_LIST_PENDING
-                       | FLUX_JOB_LIST_RUNNING
-                       | FLUX_JOB_LIST_INACTIVE);
+    int valid_flags = (FLUX_JOB_PENDING
+                       | FLUX_JOB_RUNNING
+                       | FLUX_JOB_INACTIVE);
     int saved_errno;
 
     if (!h || max_entries < 0 || !json_str

--- a/src/common/libjob/job.h
+++ b/src/common/libjob/job.h
@@ -25,13 +25,6 @@ enum job_submit_flags {
     FLUX_JOB_WAITABLE = 4,      // flux_job_wait() will be used on this job
 };
 
-enum job_list_flags {
-    FLUX_JOB_LIST_ALL = 0,
-    FLUX_JOB_LIST_PENDING = 1,
-    FLUX_JOB_LIST_RUNNING = 2,
-    FLUX_JOB_LIST_INACTIVE = 4,
-};
-
 enum job_priority {
     FLUX_JOB_PRIORITY_MIN = 0,
     FLUX_JOB_PRIORITY_DEFAULT = 16,
@@ -103,9 +96,8 @@ int flux_job_wait_get_id (flux_future_t *f, flux_jobid_t *id);
  *   ...
  * ])
  *
- * flags can be set to an OR of FLUX_JOB_LIST_PENDING,
- * FLUX_JOB_LIST_RUNNING, and FLUX_JOB_LIST_INACTIVE, or to
- * FLUX_JOB_LIST_ALL to list all groups of jobs.
+ * flags can be set to an OR of any job state or any virtual
+ * job states or 0 for all jobs.
  */
 flux_future_t *flux_job_list (flux_t *h,
                               int max_entries,

--- a/src/common/libjob/job.h
+++ b/src/common/libjob/job.h
@@ -96,14 +96,15 @@ int flux_job_wait_get_id (flux_future_t *f, flux_jobid_t *id);
  *   ...
  * ])
  *
- * flags can be set to an OR of any job state or any virtual
- * job states or 0 for all jobs.
+ * states can be set to an OR of any job state or any virtual job
+ * states to retrieve jobs of only those states.  Specify 0 for all
+ * states.
  */
 flux_future_t *flux_job_list (flux_t *h,
                               int max_entries,
                               const char *json_str,
                               uint32_t userid,
-                              int flags);
+                              int states);
 
 /* Raise an exception for job.
  * Severity is 0-7, with severity=0 causing the job to abort.

--- a/src/common/libjob/test/job.c
+++ b/src/common/libjob/test/job.c
@@ -136,7 +136,7 @@ void check_corner_case (void)
 
     errno = 0;
     ok (flux_job_list (h, 0, "{}", 0, 0xFF) == NULL && errno == EINVAL,
-        "flux_job_list flags != 0 fails with EINVAL");
+        "flux_job_list states=(illegal states) fails with EINVAL");
 
     /* flux_job_raise */
 

--- a/t/t2204-job-info.t
+++ b/t/t2204-job-info.t
@@ -548,7 +548,7 @@ test_expect_success 'list count / max_entries works' '
 
 test_expect_success HAVE_JQ 'list request with empty attrs works' '
         id=$(id -u) &&
-        $jq -j -c -n  "{max_entries:5, userid:${id}, flags:0, attrs:[]}" \
+        $jq -j -c -n  "{max_entries:5, userid:${id}, states:0, attrs:[]}" \
           | $RPC job-info.list > list_empty_attrs.out &&
         test_must_fail grep "userid" list_empty_attrs.out &&
         test_must_fail grep "priority" list_empty_attrs.out &&
@@ -565,7 +565,7 @@ test_expect_success HAVE_JQ 'list request with empty attrs works' '
 '
 test_expect_success HAVE_JQ 'list request with excessive max_entries works' '
         id=$(id -u) &&
-        $jq -j -c -n  "{max_entries:100000, userid:${id}, flags:0, attrs:[]}" \
+        $jq -j -c -n  "{max_entries:100000, userid:${id}, states:0, attrs:[]}" \
           | $RPC job-info.list
 '
 test_expect_success HAVE_JQ 'list-attrs works' '
@@ -990,17 +990,17 @@ test_expect_success 'list request with empty payload fails with EPROTO(71)' '
 '
 test_expect_success HAVE_JQ 'list request with invalid input fails with EPROTO(71) (attrs not an array)' '
         id=$(id -u) &&
-        $jq -j -c -n  "{max_entries:5, userid:${id}, flags:0, attrs:5}" \
+        $jq -j -c -n  "{max_entries:5, userid:${id}, states:0, attrs:5}" \
           | $RPC job-info.list 71
 '
 test_expect_success HAVE_JQ 'list request with invalid input fails with EINVAL(22) (attrs non-string)' '
         id=$(id -u) &&
-        $jq -j -c -n  "{max_entries:5, userid:${id}, flags:0, attrs:[5]}" \
+        $jq -j -c -n  "{max_entries:5, userid:${id}, states:0, attrs:[5]}" \
           | $RPC job-info.list 22
 '
 test_expect_success HAVE_JQ 'list request with invalid input fails with EINVAL(22) (attrs illegal field)' '
         id=$(id -u) &&
-        $jq -j -c -n  "{max_entries:5, userid:${id}, flags:0, attrs:[\"foo\"]}" \
+        $jq -j -c -n  "{max_entries:5, userid:${id}, states:0, attrs:[\"foo\"]}" \
           | $RPC job-info.list 22
 '
 

--- a/t/t2204-job-info.t
+++ b/t/t2204-job-info.t
@@ -142,20 +142,39 @@ test_expect_success 'submit jobs for job list testing' '
         echo $id2 >> job_ids_pending.out &&
         echo $id3 >> job_ids_pending.out &&
         echo $id4 >> job_ids_pending.out &&
+        cat job_ids_pending.out > active.out &&
+        cat job_ids_running.out >> active.out &&
         wait_states
 '
 
+# Note: "running" = "run" & "cleanup", we also test just "run" state
+# since we happen to know all these jobs are in the "run" state given
+# checks above
+
 test_expect_success HAVE_JQ 'flux job list running jobs in started order' '
-        flux job list -s running | jq .id > list_started.out &&
-        test_cmp list_started.out job_ids_running.out
+        flux job list -s running | jq .id > list_started1.out &&
+        flux job list -s run,cleanup | jq .id > list_started2.out &&
+        flux job list -s run | jq .id > list_started3.out &&
+        test_cmp list_started1.out job_ids_running.out &&
+        test_cmp list_started2.out job_ids_running.out &&
+        test_cmp list_started3.out job_ids_running.out
 '
 
 test_expect_success HAVE_JQ 'flux job list running jobs with correct state' '
         for count in `seq 1 8`; do \
             echo "8" >> list_state_R.exp; \
         done &&
-        flux job list -s running | jq .state > list_state_R.out &&
-        test_cmp list_state_R.out list_state_R.exp
+        flux job list -s running | jq .state > list_state_R1.out &&
+        flux job list -s run,cleanup | jq .state > list_state_R2.out &&
+        flux job list -s run | jq .state > list_state_R3.out &&
+        test_cmp list_state_R1.out list_state_R.exp &&
+        test_cmp list_state_R2.out list_state_R.exp &&
+        test_cmp list_state_R3.out list_state_R.exp
+'
+
+test_expect_success HAVE_JQ 'flux job list no jobs in cleanup state' '
+        count=$(flux job list -s cleanup | wc -l) &&
+        test $count -eq 0
 '
 
 test_expect_success HAVE_JQ 'flux job list inactive jobs in completed order' '
@@ -171,9 +190,17 @@ test_expect_success HAVE_JQ 'flux job list inactive jobs with correct state' '
         test_cmp list_state_I.out list_state_I.exp
 '
 
+# Note: "pending" = "depend" & "sched", we also test just "sched"
+# state since we happen to know all these jobs are in the "sched"
+# state given checks above
+
 test_expect_success HAVE_JQ 'flux job list pending jobs in priority order' '
-        flux job list -s pending | jq .id > list_pending.out &&
-        test_cmp list_pending.out job_ids_pending.out
+        flux job list -s pending | jq .id > list_pending1.out &&
+        flux job list -s depend,sched | jq .id > list_pending2.out &&
+        flux job list -s sched | jq .id > list_pending3.out &&
+        test_cmp list_pending1.out job_ids_pending.out &&
+        test_cmp list_pending2.out job_ids_pending.out &&
+        test_cmp list_pending3.out job_ids_pending.out
 '
 
 test_expect_success HAVE_JQ 'flux job list pending jobs with correct priority' '
@@ -183,16 +210,37 @@ test_expect_success HAVE_JQ 'flux job list pending jobs with correct priority' '
 16
 0
 EOT
-        flux job list -s pending | jq .priority > list_priority.out &&
-        test_cmp list_priority.out list_priority.exp
+        flux job list -s pending | jq .priority > list_priority1.out &&
+        flux job list -s depend,sched | jq .priority > list_priority2.out &&
+        flux job list -s sched | jq .priority > list_priority3.out &&
+        test_cmp list_priority1.out list_priority.exp &&
+        test_cmp list_priority2.out list_priority.exp &&
+        test_cmp list_priority3.out list_priority.exp
 '
 
 test_expect_success HAVE_JQ 'flux job list pending jobs with correct state' '
         for count in `seq 1 4`; do \
             echo "4" >> list_state_S.exp; \
         done &&
-        flux job list -s pending | jq .state > list_state_S.out &&
-        test_cmp list_state_S.out list_state_S.exp
+        flux job list -s pending | jq .state > list_state_S1.out &&
+        flux job list -s depend,sched | jq .state > list_state_S2.out &&
+        flux job list -s sched | jq .state > list_state_S3.out &&
+        test_cmp list_state_S3.out list_state_S.exp
+'
+
+test_expect_success HAVE_JQ 'flux job list no jobs in depend state' '
+        count=$(flux job list -s depend | wc -l) &&
+        test $count -eq 0
+'
+
+# Note: "active" = "pending" & "running", i.e. depend, sched, run, cleanup
+test_expect_success HAVE_JQ 'flux job list active jobs in correct order' '
+        flux job list -s active | jq .id > list_active1.out &&
+        flux job list -s depend,sched,run,cleanup | jq .id > list_active2.out &&
+        flux job list -s sched,run | jq .id > list_active3.out &&
+        test_cmp list_active1.out active.out &&
+        test_cmp list_active2.out active.out &&
+        test_cmp list_active3.out active.out
 '
 
 test_expect_success HAVE_JQ 'flux job list jobs with correct userid' '

--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -149,6 +149,11 @@ test_expect_success 'flux-jobs --states works' '
         test $count -eq 0
 '
 
+test_expect_success 'flux-jobs --states with invalid state fails' '
+        test_must_fail flux jobs --states=foobar 2> invalidstate.err &&
+        grep "Invalid state specified: foobar" invalidstate.err
+'
+
 # ensure + prefix works
 # increment userid to ensure not current user for test
 test_expect_success 'flux-jobs --user=UID works' '

--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -141,7 +141,10 @@ test_expect_success 'flux-jobs --user=UID works' '
 test_expect_success 'flux-jobs --user=USERNAME works' '
         username=`whoami` &&
         count=`flux jobs --suppress-header --user=${username} | wc -l` &&
-        test $count -eq 14 &&
+        test $count -eq 14
+'
+
+test_expect_success 'flux-jobs --user with invalid username fails' '
         username="foobarfoobaz" &&
         test_must_fail flux jobs --suppress-header --user=${username}
 '


### PR DESCRIPTION
Per discussion in #2628.

Most of this PR shouldn't be that surprising, just mild modifications to use the virtual job states FLUX_JOB_PENDING/RUNNING/ACTIVE, use some bitmasks to return only the desired states to the user, adjust `flux-job` and `flux-jobs.py` accordingly to support settings states + "active", add new tests.

But after doing all of the above, you set various job states in the `flags` key of the RPC to `job-info.list`.  This didn't feel right, b/c its not really a flag, they are job states.  A completely different set of bitmasks compared to "flags".  So I created a new key in the `job-info.list` service called `states`.

This changes the `flux_job_list()` function to add a parameter, leading to fallthrough changes everywhere in the last commit (bindings, callers, tests, etc.).  This change is probably debatable.  