### PR TITLE
shell: do not exit from shell initrc scripts when posix module not found

### DIFF
--- a/src/shell/lua.d/intel_mpi.lua
+++ b/src/shell/lua.d/intel_mpi.lua
@@ -1,3 +1,13 @@
+-------------------------------------------------------------
+-- Copyright 2020 Lawrence Livermore National Security, LLC
+-- (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+--
+-- This file is part of the Flux resource manager framework.
+-- For details, see https://github.com/flux-framework.
+--
+-- SPDX-License-Identifier: LGPL-3.0
+-------------------------------------------------------------
+
 -- Set environment specific to Intel MPI
 --
 -- Intel PMI is an MPICH derivative that bootstraps with the PMI-1 wire

--- a/src/shell/lua.d/mvapich.lua
+++ b/src/shell/lua.d/mvapich.lua
@@ -17,14 +17,21 @@ local function dirname (d)
     return d:match ("^(.*[^/])/.-$")
 end
 
-local libpmi = f:getattr ('conf.pmi_library_path')
-local ldpath = dirname (libpmi)
-local current = shell.getenv ('LD_LIBRARY_PATH')
-
-if current ~= nil then
-  ldpath = ldpath .. ':' .. current
+local function setenv_prepend (var, val)
+    local path = shell.getenv (var)
+    -- If path not already set, then set it to val
+    if not path then
+        shell.setenv (var, val)
+    -- O/w, if val is not already set in path, prepend it
+    elseif path:match ("^[^:]+") ~= val then
+        shell.setenv (var, val .. ':' .. path)
+    end
+    -- O/w, val already first in path. Do nothing
 end
-shell.setenv ("LD_LIBRARY_PATH", ldpath)
+
+local libpmi = f:getattr ('conf.pmi_library_path')
+
+setenv_prepend ("LD_LIBRARY_PATH", dirname (libpmi))
 shell.setenv ("MPIRUN_NTASKS", shell.info.ntasks)
 shell.setenv ("MPIRUN_RSH_LAUNCH", 1)
 

--- a/src/shell/lua.d/mvapich.lua
+++ b/src/shell/lua.d/mvapich.lua
@@ -1,3 +1,13 @@
+-------------------------------------------------------------
+-- Copyright 2020 Lawrence Livermore National Security, LLC
+-- (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+--
+-- This file is part of the Flux resource manager framework.
+-- For details, see https://github.com/flux-framework.
+--
+-- SPDX-License-Identifier: LGPL-3.0
+-------------------------------------------------------------
+
 local dirname = require 'flux.posix'.dirname
 
 local f, err = require 'flux'.new ()

--- a/src/shell/lua.d/mvapich.lua
+++ b/src/shell/lua.d/mvapich.lua
@@ -8,10 +8,14 @@
 -- SPDX-License-Identifier: LGPL-3.0
 -------------------------------------------------------------
 
-local dirname = require 'flux.posix'.dirname
-
 local f, err = require 'flux'.new ()
 if not f then error (err) end
+
+-- Lua implementation of dirname(3) to avoid pulling in posix module
+local function dirname (d)
+    if not d:match ("/") then return "." end
+    return d:match ("^(.*[^/])/.-$")
+end
 
 local libpmi = f:getattr ('conf.pmi_library_path')
 local ldpath = dirname (libpmi)

--- a/src/shell/lua.d/openmpi.lua
+++ b/src/shell/lua.d/openmpi.lua
@@ -1,3 +1,13 @@
+-------------------------------------------------------------
+-- Copyright 2020 Lawrence Livermore National Security, LLC
+-- (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+--
+-- This file is part of the Flux resource manager framework.
+-- For details, see https://github.com/flux-framework.
+--
+-- SPDX-License-Identifier: LGPL-3.0
+-------------------------------------------------------------
+
 local f = require 'flux'.new ()
 local rundir  = f:getattr ('broker.rundir')
 shell.setenv ("OMPI_MCA_orte_tmpdir_base", rundir)

--- a/src/shell/lua.d/spectrum.lua
+++ b/src/shell/lua.d/spectrum.lua
@@ -1,3 +1,13 @@
+-------------------------------------------------------------
+-- Copyright 2020 Lawrence Livermore National Security, LLC
+-- (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+--
+-- This file is part of the Flux resource manager framework.
+-- For details, see https://github.com/flux-framework.
+--
+-- SPDX-License-Identifier: LGPL-3.0
+-------------------------------------------------------------
+
 -- Set environment specific to spectrum_mpi (derived from openmpi)
 --
 if shell.options.mpi ~= "spectrum" then return end

--- a/t/t2603-job-shell-initrc.t
+++ b/t/t2603-job-shell-initrc.t
@@ -201,4 +201,30 @@ test_expect_success HAVE_JQ 'flux-shell: initrc: load getopt plugin' '
 		> ${name}.log 2>&1 &&
 	test_debug "cat ${name}.log"
 '
+test_expect_success 'flux-shell: initrc: shell log functions available' '
+	name=shell.log &&
+	cat >${name}.lua <<-EOF &&
+	shell.log ("test: shell.log")
+	shell.debug ("test: debug")
+
+	shell.log_error ("test: error")
+	EOF
+	${FLUX_SHELL} -v -s -r 0 -j j1 -R R1 --initrc=${name}.lua 0 \
+		> ${name}.log 2>&1 &&
+	grep "INFO: ${name}.lua:1: test: shell.log" ${name}.log &&
+	grep "DEBUG: ${name}.lua:2: test: debug" ${name}.log &&
+	grep "ERROR: ${name}.lua:4: test: error" ${name}.log
+'
+test_expect_success 'flux-shell: initrc: shell.die function works' '
+	name=shell.die &&
+	cat >${name}.lua <<-EOF &&
+        -- shell.die test
+	shell.die ("test: shell.die")
+	EOF
+	test_expect_code 1 \
+	    ${FLUX_SHELL} -v -s -r 0 -j j1 -R R1 --initrc=${name}.lua 0 \
+		> ${name}.log 2>&1 &&
+	grep "FATAL: ${name}.lua:2: test: shell.die" ${name}.log
+'
+
 test_done


### PR DESCRIPTION
This PR mainly fixes #2698, however some other deficiencies in the shell initrc were fixed along the way. While debugging this I found the lack of a logging interface from initrc.lua a bit frustrating, so that was added here as well.

Before, we see this if the posix module is not found:
```
$ flux mini run hostname
flux-job: No job output found
flux-job: task(s) exited with exit code 1
```

After, just a wee bit more detail.
```
$ flux mini run hostname
0.063s: flux-shell[0]: ERROR: /home/grondo/git/f.git/src/shell/lua.d/mvapich.lua:11: module 'posix' not found:
	no field package.preload['posix']
	no file '/home/grondo/git/f.git/src/bindings/lua/posix.lua'
	no file '/home/grondo/git/f.git/t/posix.lua'
	no file '/usr/local/share/lua/5.2/posix.lua'
	no file '/usr/local/share/lua/5.2/posix/init.lua'
	no file '/usr/local/lib/lua/5.2/posix.lua'
	no file '/usr/local/lib/lua/5.2/posix/init.lua'
	no file '/usr/share/lua/5.2/posix.lua'
	no file '/usr/share/lua/5.2/posix/init.lua'
	no file './posix.lua'
	no file '/home/grondo/git/f.git/src/bindings/lua/posix.so'
	no file '/usr/local/lib/lua/5.2/posix.so'
	no file '/usr/lib/x86_64-linux-gnu/lua/5.2/posix.so'
	no file '/usr/lib/lua/5.2/posix.so'
	no file '/usr/local/lib/lua/5.2/loadall.so'
	no file './posix.so'
0.063s: flux-shell[0]: ERROR: /home/grondo/git/f.git/src/shell/initrc.lua:8: source /home/grondo/git/f.git/src/shell/lua.d/mvapich.lua failed
0.063s: flux-shell[0]: FATAL: loading rc file /home/grondo/git/f.git/src/shell/initrc.lua
0.065s: job.exception type=exec severity=0 loading rc file /home/grondo/git/f.git/src/shell/initrc.lua
flux-job: task(s) exited with exit code 1

```


Actually it seemed silly to require the posix module for `dirname()`, so now the posix module is not required, except for the spectrum MPI case I think.

### Commit Message
shell: initrc: fix bad exit in mavpich rc script, add logging

 * add shell.log, shell.debug, shell.log_error and shell.die
   for use in shell rc scripts
 * avoid the use of `flux.posix` module in flux-shell rc scripts
  