### PR TITLE
Allow JobspecV1 to accept 0 gpus_per_task.

### DIFF
--- a/src/bindings/python/flux/job.py
+++ b/src/bindings/python/flux/job.py
@@ -602,15 +602,15 @@ class JobspecV1(Jobspec):
         if not isinstance(cores_per_task, int) or cores_per_task < 1:
             raise ValueError("cores per task must be an integer >= 1")
         if gpus_per_task is not None:
-            if not isinstance(gpus_per_task, int) or gpus_per_task < 1:
-                raise ValueError("gpus per task must be an integer >= 1")
+            if not isinstance(gpus_per_task, int) or gpus_per_task < 0:
+                raise ValueError("gpus per task must be an integer >= 0")
         if num_nodes is not None:
             if not isinstance(num_nodes, int) or num_nodes < 1:
                 raise ValueError("node count must be an integer >= 1 (if set)")
             if num_nodes > num_tasks:
                 raise ValueError("node count must not be greater than task count")
         children = [cls._create_resource("core", cores_per_task)]
-        if gpus_per_task is not None:
+        if gpus_per_task not in (None, 0):
             children.append(cls._create_resource("gpu", gpus_per_task))
         if num_nodes is not None:
             num_slots = int(math.ceil(num_tasks / float(num_nodes)))


### PR DESCRIPTION
I found myself a little annoyed when I couldn't pass `gpus_per_task=0` to the JobspecV1 constructor. I did notice that `mini run` won't accept an argument of `-g0`, though, so I suppose this introduces some minor API inconsistency. I think there are some reasons why `mini run` should accept `-g0`, but I think the reasons are stronger in this case, because 'mini run' commands are (I suspect, and certainly in my case) hard-coded or constructed piece-by-piece, while it makes less sense to have to make two different API calls based on the value of `gpus_per_task`.

If you don't like the change, I could very easily change my own code, I just thought I would propose this.