### PR TITLE
job-info: Add service to list jobs of specific job IDs

### DIFF
--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -950,9 +950,6 @@ int cmd_list (optparse_t *p, int argc, char **argv)
         log_err_exit ("flux_job_list");
     json_array_foreach (jobs, index, value) {
         char *str;
-        int state;
-        if (json_unpack (value, "{s:i}", "state", &state) < 0)
-            log_msg_exit ("error parsing list response (state is missing)");
         str = json_dumps (value, 0);
         if (!str)
             log_msg_exit ("error parsing list response");

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -42,6 +42,7 @@
 #include "src/common/libioencode/ioencode.h"
 
 int cmd_list (optparse_t *p, int argc, char **argv);
+int cmd_list_ids (optparse_t *p, int argc, char **argv);
 int cmd_submit (optparse_t *p, int argc, char **argv);
 int cmd_attach (optparse_t *p, int argc, char **argv);
 int cmd_id (optparse_t *p, int argc, char **argv);
@@ -243,6 +244,13 @@ static struct optparse_subcommand subcommands[] = {
       cmd_list,
       0,
       list_opts
+    },
+    { "list-ids",
+      "[OPTIONS] ID [ID ...]",
+      "List job(s) by id",
+      cmd_list_ids,
+      0,
+      NULL,
     },
     { "priority",
       "[OPTIONS] id priority",
@@ -960,6 +968,54 @@ int cmd_list (optparse_t *p, int argc, char **argv)
     flux_close (h);
 
    return (0);
+}
+
+void list_id_continuation (flux_future_t *f, void *arg)
+{
+    json_t *job;
+    char *str;
+    if (flux_rpc_get_unpack (f, "{s:o}", "job", &job) < 0)
+        log_err_exit ("flux_job_list_id");
+    str = json_dumps (job, 0);
+    if (!str)
+        log_msg_exit ("error parsing list-id response");
+    printf ("%s\n", str);
+    free (str);
+    flux_future_destroy (f);
+}
+
+int cmd_list_ids (optparse_t *p, int argc, char **argv)
+{
+    int optindex = optparse_option_index (p);
+    char *attrs = "[\"userid\",\"priority\",\"t_submit\",\"state\"," \
+        "\"name\",\"ntasks\",\"nnodes\",\"ranks\",\"t_depend\",\"t_sched\"," \
+        "\"t_run\",\"t_cleanup\",\"t_inactive\"]";
+    flux_t *h;
+    int i, ids_len;
+
+    if ((argc - optindex) < 1) {
+        optparse_print_usage (p);
+        exit (1);
+    }
+    if (!(h = flux_open (NULL, 0)))
+        log_err_exit ("flux_open");
+
+    ids_len = argc - optindex;
+    for (i = 0; i < ids_len; i++) {
+        flux_jobid_t id = parse_arg_unsigned (argv[optindex + i], "id");
+        flux_future_t *f;
+        if (!(f = flux_job_list_id (h, id, attrs)))
+            log_err_exit ("flux_job_list_id");
+        if (flux_future_then (f, -1, list_id_continuation, NULL) < 0)
+            log_err_exit ("flux_future_then");
+    }
+
+    if (flux_reactor_run (flux_get_reactor (h), 0) < 0)
+        log_err_exit ("flux_reactor_run");
+
+    flux_close (h);
+
+    return (0);
 }
 
 /* Read entire file 'name' ("-" for stdin).  Exit program on error.

--- a/src/common/libjob/job.c
+++ b/src/common/libjob/job.c
@@ -216,6 +216,35 @@ flux_future_t *flux_job_list (flux_t *h,
     return f;
 }
 
+flux_future_t *flux_job_list_id (flux_t *h,
+                                 flux_jobid_t id,
+                                 const char *json_str)
+{
+    flux_future_t *f;
+    json_t *o = NULL;
+    int saved_errno;
+
+    if (!h || !json_str
+           || !(o = json_loads (json_str, 0, NULL))) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (!(f = flux_rpc_pack (h, "job-info.list-id", FLUX_NODEID_ANY, 0,
+                             "{s:I s:O}",
+                             "id", id,
+                             "attrs", o)))
+        goto error;
+
+    json_decref (o);
+    return f;
+
+error:
+    saved_errno = errno;
+    json_decref (o);
+    errno = saved_errno;
+    return NULL;
+}
+
 flux_future_t *flux_job_raise (flux_t *h, flux_jobid_t id,
                                const char *type, int severity, const char *note)
 {

--- a/src/common/libjob/job.h
+++ b/src/common/libjob/job.h
@@ -106,6 +106,12 @@ flux_future_t *flux_job_list (flux_t *h,
                               uint32_t userid,
                               int states);
 
+/* Similar to flux_job_list(), but retrieve job info for a single
+ * job id */
+flux_future_t *flux_job_list_id (flux_t *h,
+                                 flux_jobid_t id,
+                                 const char *json_str);
+
 /* Raise an exception for job.
  * Severity is 0-7, with severity=0 causing the job to abort.
  * Note may be NULL or a human readable message.

--- a/src/common/libjob/test/job.c
+++ b/src/common/libjob/test/job.c
@@ -127,10 +127,6 @@ void check_corner_case (void)
         "flux_job_list json_str=NULL fails with EINVAL");
 
     errno = 0;
-    ok (flux_job_list (h, 0, NULL, 0, 0) == NULL && errno == EINVAL,
-        "flux_job_list json_str=NULL fails with EINVAL");
-
-    errno = 0;
     ok (flux_job_list (h, 0, "wrong", 0, 0) == NULL && errno == EINVAL,
         "flux_job_list json_str=(inval JSON) fails with EINVAL");
 

--- a/src/common/libjob/test/job.c
+++ b/src/common/libjob/test/job.c
@@ -134,6 +134,23 @@ void check_corner_case (void)
     ok (flux_job_list (h, 0, "{}", 0, 0xFF) == NULL && errno == EINVAL,
         "flux_job_list states=(illegal states) fails with EINVAL");
 
+    /* flux_job_list_id */
+
+    errno = 0;
+    ok (flux_job_list_id (NULL, 0, "{}") == NULL
+        && errno == EINVAL,
+        "flux_job_list_id h=NULL fails with EINVAL");
+
+    errno = 0;
+    ok (flux_job_list_id (h, 0, NULL) == NULL
+        && errno == EINVAL,
+        "flux_job_list_id json_str=NULL fails with EINVAL");
+
+    errno = 0;
+    ok (flux_job_list_id (h, 0, "wrong") == NULL
+        && errno == EINVAL,
+        "flux_job_list_id json_str=(inval JSON) fails with EINVAL");
+
     /* flux_job_raise */
 
     errno = 0;

--- a/src/modules/job-exec/job-exec.c
+++ b/src/modules/job-exec/job-exec.c
@@ -432,7 +432,7 @@ static void namespace_copy (flux_future_t *f, void *arg)
     struct jobinfo *job = arg;
     flux_t *h = job->ctx->h;
     flux_future_t *fnext = NULL;
-    char dst [265];
+    char dst [256];
 
     if (flux_job_kvs_key (dst, sizeof (dst), job->id, "guest") < 0) {
         flux_log_error (h, "namespace_move: flux_job_kvs_key");

--- a/src/modules/job-info/guest_watch.c
+++ b/src/modules/job-info/guest_watch.c
@@ -39,7 +39,7 @@
  *
  * 2) If the guest namespace is already copied into the main namespace
  *    (event "release" and "final=true"), we watch the eventlog in the
- *    main namespace (main_namespace_lookup()).  This is a This is "easy" case
+ *    main namespace (main_namespace_lookup()).  This is the "easy" case
  *    and is not so different from a typical call to
  *    'job-info.eventlog-watch'.
  *

--- a/src/modules/job-info/job-info.c
+++ b/src/modules/job-info/job-info.c
@@ -128,6 +128,11 @@ static const struct flux_msg_handler_spec htab[] = {
       .rolemask     = FLUX_ROLE_USER
     },
     { .typemask     = FLUX_MSGTYPE_REQUEST,
+      .topic_glob   = "job-info.list-id",
+      .cb           = list_id_cb,
+      .rolemask     = FLUX_ROLE_USER
+    },
+    { .typemask     = FLUX_MSGTYPE_REQUEST,
       .topic_glob   = "job-info.list-attrs",
       .cb           = list_attrs_cb,
       .rolemask     = FLUX_ROLE_USER

--- a/src/modules/job-info/list.c
+++ b/src/modules/job-info/list.c
@@ -257,8 +257,10 @@ void list_cb (flux_t *h, flux_msg_handler_t *mh,
     if (!(jobs = get_jobs (ctx, max_entries, attrs, userid, states)))
         goto error;
 
-    if (flux_respond_pack (h, msg, "{s:O}", "jobs", jobs) < 0)
+    if (flux_respond_pack (h, msg, "{s:O}", "jobs", jobs) < 0) {
         flux_log_error (h, "%s: flux_respond_pack", __FUNCTION__);
+        goto error;
+    }
 
     json_decref (jobs);
     return;

--- a/src/modules/job-info/list.h
+++ b/src/modules/job-info/list.h
@@ -18,6 +18,9 @@
 void list_cb (flux_t *h, flux_msg_handler_t *mh,
               const flux_msg_t *msg, void *arg);
 
+void list_id_cb (flux_t *h, flux_msg_handler_t *mh,
+                 const flux_msg_t *msg, void *arg);
+
 void list_attrs_cb (flux_t *h, flux_msg_handler_t *mh,
                     const flux_msg_t *msg, void *arg);
 


### PR DESCRIPTION
This is pre-PR for issue #2592.  This PR supports the ability for the user to get job listing data for only the specific jobs passed in by the user via a new service `job-info.list-ids`.

It doesn't solve #2592, as the potential eventual consistency racyness is not handled.  Getting the new service up, commands, tests, etc. was enough I figure I'd split it out into its own PR before trying to tackle the actual meat of the issue.

I supported passing job ids via a new `flux job list-ids` subcommand, but did not add anything to `flux jobs`.  The default behavior was not initially obvious to me and I figured it could be dealt with another
day.  For example, should `--user` or `--states` matter when a user lists IDs?  I can see the case for yes and no.

(As an aside, I initially had `job-info.list-ids` filter based on states & user id just like `job-info.list`, but eventually removed it as it seemed not that useful considering the issue at hand.).

Couple of minor cleanups mixed in as well.