### PR TITLE
broker: add FINALIZING state to address possible module unload deadlock

### DIFF
--- a/src/broker/module.h
+++ b/src/broker/module.h
@@ -103,6 +103,10 @@ int module_start (module_t *p);
  */
 int module_stop (module_t *p);
 
+/*  Mute module. Do not send any more messages.
+ */
+void module_mute (module_t *p);
+
 /* Prepare RFC 5 'mods' array for lsmod response.
  */
 json_t *module_get_modlist (modhash_t *mh, struct service_switch *sw);


### PR DESCRIPTION
As described in #2709, there exists a potential broker deadlock during module unload if the broker tries to send a message to a module after it has closed its handle, but before  the module is removed from the modhash.

This PR introduces a "muted" flag for modules, which allows the broker to disable message send to modules while they are in the process of exiting. The documented but unused RFC 5 `FLUX_MODSTATE_FINALIZING` module state is used by modules to request from the broker that they be muted, and modules synchronize by waiting for the broker to reply that the mute operation is complete. After this synchronization, the module continues along the existing shutdown path.

There was one other bit of cleanup in the module state handling, since modules no longer go directly from `INIT` to `EXITED` on insmod failure, but hopefully that is self explanatory.

One other thing: this actually makes the devilish issue #666 even worse, since modules that try to send RPCs during `aux_destroy` will definitely not get a response, since the module is muted. My thought on this is that it is probably unwise to allow RPCs and messages to be sent over a flux handle during `flux_close()`. My inclination to deal with #666 would be to disallow `flux_send()` on handles that are in `flux_close()` (though perhaps I've forgotten an important use case here). This could be done with a flag set on handles first thing in `flux_handle_destroy()`.

Would that be an acceptable solution? 