### PR TITLE
flux-queue: add idle subcommand

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,6 +1,7 @@
 Dong Ahn
 Jon Bringhurst
 Al Chu
+James Corbett
 Chris Dunlap
 Todd Gamblin
 Jim Garlick
@@ -9,8 +10,12 @@ Matthieu Hautreux
 Sam Heinz
 Stephen Herbein
 Don Lipari
+Andre Merzky
+Dan Milroy
 Chris Morrone
+Chris Moussa
 Tapasya Patki
 Suraj Prabhakaran
+Barry Rountree
 Tom Scogland
 Becky Springmeyer

--- a/etc/rc3
+++ b/etc/rc3
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+flux queue stop --quiet
+flux job cancelall --quiet -f --states RUN
+flux queue idle --quiet
+
 core_dir=$(cd ${0%/*} && pwd -P)
 all_dirs=$core_dir${FLUX_RC_EXTRA:+":$FLUX_RC_EXTRA"}
 IFS=:

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -97,6 +97,9 @@ static struct optparse_option cancelall_opts[] =  {
     { .name = "force", .key = 'f', .has_arg = 0,
       .usage = "Confirm the command",
     },
+    { .name = "quiet", .key = 'f', .has_arg = 0,
+      .usage = "Suppress output if no jobs match",
+    },
     OPTPARSE_TABLE_END
 };
 
@@ -901,7 +904,7 @@ int cmd_cancelall (optparse_t *p, int argc, char **argv)
         log_msg ("Command matched %d jobs (-f to confirm)", count);
     else if (count > 0 && !dry_run)
         log_msg ("Canceled %d jobs (%d errors)", count, errors);
-    else
+    else if (!optparse_hasopt (p, "quiet"))
         log_msg ("Command matched 0 jobs");
     flux_close (h);
     free (note);

--- a/src/cmd/flux-queue.c
+++ b/src/cmd/flux-queue.c
@@ -245,6 +245,7 @@ void alloc_admin (flux_t *h,
     int free_pending;
     int alloc_pending;
     int queue_length;
+    int running;
 
     if (!(f = flux_rpc_pack (h,
                              "job-manager.alloc-admin",
@@ -259,7 +260,7 @@ void alloc_admin (flux_t *h,
                              reason ? reason : "")))
         log_err_exit ("error sending alloc-admin request");
     if (flux_rpc_get_unpack (f,
-                             "{s:b s:s s:i s:i s:i}",
+                             "{s:b s:s s:i s:i s:i s:i}",
                              "enable",
                              &enable,
                              "reason",
@@ -269,7 +270,9 @@ void alloc_admin (flux_t *h,
                              "alloc_pending",
                              &alloc_pending,
                              "free_pending",
-                             &free_pending) < 0)
+                             &free_pending,
+                             "running",
+                             &running) < 0)
         log_msg_exit ("alloc-admin: %s", future_strerror (f, errno));
     log_msg ("Scheduling is %s%s%s",
              enable ? "enabled" : "disabled",
@@ -279,6 +282,7 @@ void alloc_admin (flux_t *h,
         log_msg ("%d alloc requests queued", queue_length);
         log_msg ("%d alloc requests pending to scheduler", alloc_pending);
         log_msg ("%d free requests pending to scheduler", free_pending);
+        log_msg ("%d running jobs", running);
     }
     flux_future_destroy (f);
 }

--- a/src/common/libflux/response.c
+++ b/src/common/libflux/response.c
@@ -197,10 +197,14 @@ error:
     return NULL;
 }
 
-static flux_msg_t *derive_response (const flux_msg_t *request, int errnum)
+flux_msg_t *flux_response_derive (const flux_msg_t *request, int errnum)
 {
     flux_msg_t *msg;
 
+    if (!request) {
+        errno = EINVAL;
+        return NULL;
+    }
     if (!(msg = flux_msg_copy (request, false)))
         return NULL;
     if (flux_msg_set_type (msg, FLUX_MSGTYPE_RESPONSE) < 0)
@@ -223,7 +227,7 @@ int flux_respond (flux_t *h, const flux_msg_t *request, const char *s)
 
     if (!h || !request)
         goto inval;
-    msg = derive_response (request, 0);
+    msg = flux_response_derive (request, 0);
     if (!msg)
         goto error;
     if (s && flux_msg_set_string (msg, s) < 0)
@@ -246,7 +250,7 @@ static int flux_respond_vpack (flux_t *h, const flux_msg_t *request,
 
     if (!h || !request || !fmt)
         goto inval;
-    msg = derive_response (request, 0);
+    msg = flux_response_derive (request, 0);
     if (!msg)
         goto error;
     if (flux_msg_vpack (msg, fmt, ap) < 0)
@@ -285,7 +289,7 @@ int flux_respond_raw (flux_t *h, const flux_msg_t *request,
 
     if (!h || !request)
         goto inval;
-    msg  = derive_response (request, 0);
+    msg  = flux_response_derive (request, 0);
     if (!msg)
         goto error;
     if (data && flux_msg_set_payload (msg, data, len) < 0)
@@ -308,7 +312,7 @@ int flux_respond_error (flux_t *h, const flux_msg_t *request,
 
     if (!h || !request || errnum == 0)
         goto inval;
-    msg = derive_response (request, errnum);
+    msg = flux_response_derive (request, errnum);
     if (!msg)
         goto error;
     if (errstr) {

--- a/src/common/libflux/response.h
+++ b/src/common/libflux/response.h
@@ -62,6 +62,11 @@ flux_msg_t *flux_response_encode_raw (const char *topic,
 flux_msg_t *flux_response_encode_error (const char *topic, int errnum,
                                         const char *errstr);
 
+/* Derive a response message from a request message, setting 'errnum' to
+ * the specified value (0 = success).
+ */
+flux_msg_t *flux_response_derive (const flux_msg_t *request, int errnum);
+
 /* Create a response to the provided request message with optional
  * string payload.
  */

--- a/src/common/libflux/test/response.c
+++ b/src/common/libflux/test/response.c
@@ -127,6 +127,11 @@ int main (int argc, char *argv[])
         "flux_response_decode_error includes error message");
     flux_msg_destroy (msg);
 
+    /* response_derive with msg=NULL */
+    errno = 0;
+    ok (flux_response_derive (NULL, 0) == NULL && errno == EINVAL,
+        "flux_response_derive msg=NULL fails with EINVAL");
+
     /* respond with h=NULL */
     msg = flux_request_encode ("foo", NULL);
     if (!msg)

--- a/src/modules/job-manager/alloc.c
+++ b/src/modules/job-manager/alloc.c
@@ -95,6 +95,7 @@
 #include "job.h"
 #include "alloc.h"
 #include "event.h"
+#include "drain.h"
 
 typedef enum {
     SCHED_SINGLE,       // only allow one outstanding sched.alloc request
@@ -152,6 +153,7 @@ static void interface_teardown (struct alloc *alloc, char *s, int errnum)
         alloc->ready = false;
         alloc->alloc_pending_count = 0;
         alloc->free_pending_count = 0;
+        drain_check (alloc->ctx->drain);
     }
 }
 
@@ -301,6 +303,7 @@ static void alloc_response_cb (flux_t *h, flux_msg_handler_t *mh,
                             (uintmax_t)id);
             goto teardown;
         }
+        drain_check (alloc->ctx->drain);
         break;
     default:
         errno = EINVAL;

--- a/src/modules/job-manager/alloc.c
+++ b/src/modules/job-manager/alloc.c
@@ -634,7 +634,7 @@ static void alloc_admin_cb (flux_t *h,
     }
     if (flux_respond_pack (h,
                            msg,
-                           "{s:b s:s s:i s:i s:i}",
+                           "{s:b s:s s:i s:i s:i s:i}",
                            "enable",
                            enable,
                            "reason",
@@ -644,7 +644,9 @@ static void alloc_admin_cb (flux_t *h,
                            "alloc_pending",
                            alloc->alloc_pending_count,
                            "free_pending",
-                           alloc->free_pending_count) < 0)
+                           alloc->free_pending_count,
+                           "running",
+                           alloc->ctx->running_jobs) < 0)
         flux_log_error (h, "%s: flux_respond", __FUNCTION__);
     return;
 error:

--- a/src/modules/job-manager/alloc.c
+++ b/src/modules/job-manager/alloc.c
@@ -592,9 +592,6 @@ static void cancel_all_pending (struct alloc *alloc)
  * return to alloc->queue).  The job manager continues to send free requests
  * to the scheduler as jobs relinquish resources.
  *
- * The response to this RPC is the current state, the reason (if disabled),
- * and a count of canceled alloc requests (if applicable).
- *
  * If allocation is adminstratively enabled, but the scheduler is not loaded,
  * the current state is reported as disabled with reason "Scheduler is offline".
  */

--- a/src/modules/job-manager/alloc.c
+++ b/src/modules/job-manager/alloc.c
@@ -238,8 +238,8 @@ static void alloc_response_cb (flux_t *h, flux_msg_handler_t *mh,
 {
     struct job_manager *ctx = arg;
     struct alloc *alloc = ctx->alloc;
-    flux_jobid_t id = 0;
-    int type = -1;
+    flux_jobid_t id;
+    int type;
     const char *note = NULL;
     struct job *job;
 
@@ -250,10 +250,6 @@ static void alloc_response_cb (flux_t *h, flux_msg_handler_t *mh,
                               "type", &type,
                               "note", &note) < 0)
         goto teardown;
-    if (type != 0 && type != 1 && type != 2 && type != 3) {
-        errno = EPROTO;
-        goto teardown;
-    }
     if (!(job = zhashx_lookup (ctx->active_jobs, &id))) {
         flux_log (h, LOG_ERR, "sched.alloc-response: id=%ju not active",
                   (uintmax_t)id);
@@ -266,22 +262,28 @@ static void alloc_response_cb (flux_t *h, flux_msg_handler_t *mh,
         errno = EINVAL;
         goto teardown;
     }
-
-    /* Handle job annotation update.
-     * This does not terminate the response stream.
-     */
-    if (type == 1) {
-        // FIXME
-        return;
-    }
-
-    alloc->alloc_pending_count--;
-    job->alloc_pending = 0;
-
-    /* Handle alloc error.
-     * Raise alloc exception and transition to CLEANUP state.
-     */
-    if (type == 2) { // error: alloc was rejected
+    switch (type) {
+    case 0: // success
+        alloc->alloc_pending_count--;
+        job->alloc_pending = 0;
+        if (job->has_resources) {
+            flux_log (h,
+                      LOG_ERR,
+                      "sched.alloc-response: id=%ju already allocated",
+                      (uintmax_t)id);
+            errno = EEXIST;
+            goto teardown;
+        }
+        if (event_job_post_pack (ctx->event, job, "alloc",
+                                 "{ s:s }",
+                                 "note", note ? note : "") < 0)
+            goto teardown;
+        break;
+    case 1: // annotation FIXME
+        break;
+    case 2: // error
+        alloc->alloc_pending_count--;
+        job->alloc_pending = 0;
         if (event_job_post_pack (ctx->event, job, "exception",
                                  "{ s:s s:i s:i s:s }",
                                  "type", "alloc",
@@ -289,38 +291,21 @@ static void alloc_response_cb (flux_t *h, flux_msg_handler_t *mh,
                                  "userid", FLUX_USERID_UNKNOWN,
                                  "note", note ? note : "") < 0)
             goto teardown;
-        return;
-    }
-
-    /* Alloc request was canceled.
-     * Run event_job_action() which will take action depending on job state:
-     * - SCHED: re-enqueue the job in alloc->queue.
-     * - CLEANUP: post the clean event to advance to INACTIVE state
-     */
-    if (type == 3) {
+        break;
+    case 3: // canceled
+        alloc->alloc_pending_count--;
+        job->alloc_pending = 0;
         if (event_job_action (ctx->event, job) < 0) {
             flux_log_error (h,
                             "event_job_action id=%ju on alloc cancel",
                             (uintmax_t)id);
             goto teardown;
         }
-        return;
-    }
-
-    /* Handle alloc success (type == 0)
-     * Log alloc event and transtion to RUN state.
-     */
-    if (job->has_resources) {
-        flux_log (h, LOG_ERR, "sched.alloc-response: id=%ju already allocated",
-                  (uintmax_t)id);
-        errno = EEXIST;
+        break;
+    default:
+        errno = EINVAL;
         goto teardown;
     }
-
-    if (event_job_post_pack (ctx->event, job, "alloc",
-                             "{ s:s }",
-                             "note", note ? note : "") < 0)
-        goto teardown;
     return;
 teardown:
     interface_teardown (alloc, "alloc response error", errno);

--- a/src/modules/job-manager/alloc.c
+++ b/src/modules/job-manager/alloc.c
@@ -548,6 +548,11 @@ void alloc_queue_reorder (struct alloc *alloc, struct job *job)
     zlistx_reorder (alloc->queue, job->handle, fwd);
 }
 
+int alloc_pending_count (struct alloc *alloc)
+{
+    return alloc->alloc_pending_count;
+}
+
 /* Cancel all pending alloc requests in preparation for disabling
  * resource allocation.
  */

--- a/src/modules/job-manager/alloc.h
+++ b/src/modules/job-manager/alloc.h
@@ -34,6 +34,10 @@ void alloc_dequeue_alloc_request (struct alloc *alloc, struct job *job);
  */
 int alloc_cancel_alloc_request (struct alloc *alloc, struct job *job);
 
+/* Accessor for the count of pending alloc requests.
+ */
+int alloc_pending_count (struct alloc *alloc);
+
 /* Call from CLEANUP state to release resources.
  * This function is a no-op if job->free_pending is set.
  */

--- a/src/modules/job-manager/drain.c
+++ b/src/modules/job-manager/drain.c
@@ -42,8 +42,10 @@ void drain_empty_notify (struct drain *drain)
     const flux_msg_t *msg;
 
     while ((msg = zlist_pop (drain->requests))) {
-        if (event_batch_drain_respond (drain->ctx->event, msg) < 0)
+        const flux_msg_t *rsp = flux_response_derive (msg, 0);
+        if (!rsp || event_batch_respond (drain->ctx->event, rsp) < 0)
             flux_log_error (drain->ctx->h, "error handing drain request off");
+        flux_msg_decref (rsp);
         flux_msg_decref (msg);
     }
 }

--- a/src/modules/job-manager/drain.h
+++ b/src/modules/job-manager/drain.h
@@ -16,7 +16,7 @@
 
 #include "job-manager.h"
 
-void drain_empty_notify (struct drain *drain);
+void drain_check (struct drain *drain);
 
 struct drain *drain_ctx_create (struct job_manager *ctx);
 void drain_ctx_destroy (struct drain *drain);

--- a/src/modules/job-manager/event.c
+++ b/src/modules/job-manager/event.c
@@ -350,8 +350,7 @@ int event_job_action (struct event *event, struct job *job)
             if ((job->flags & FLUX_JOB_WAITABLE))
                 wait_notify_inactive (ctx->wait, job);
             zhashx_delete (ctx->active_jobs, &job->id);
-            if (zhashx_size (ctx->active_jobs) == 0)
-                drain_empty_notify (ctx->drain);
+            drain_check (ctx->drain);
             break;
     }
     return 0;

--- a/src/modules/job-manager/event.h
+++ b/src/modules/job-manager/event.h
@@ -35,9 +35,9 @@ int event_job_update (struct job *job, json_t *event);
 int event_batch_pub_state (struct event *event, struct job *job,
                            double timestamp);
 
-/* Add add a completed drain request to batch.
+/* Add add response to batch, to be sent upon batch completion.
  */
-int event_batch_drain_respond (struct event *event, const flux_msg_t *msg);
+int event_batch_respond (struct event *event, const flux_msg_t *msg);
 
 /* Post event 'name' and optionally 'context' to 'job'.
  * Internally, calls event_job_update(), then event_job_action(), then commits

--- a/src/modules/job-manager/job-manager.h
+++ b/src/modules/job-manager/job-manager.h
@@ -15,6 +15,7 @@ struct job_manager {
     flux_t *h;
     flux_msg_handler_t **handlers;
     zhashx_t *active_jobs;
+    int running_jobs; // count of jobs in RUN | CLEANUP state
     struct start *start;
     struct alloc *alloc;
     struct event *event;

--- a/src/modules/job-manager/restart.c
+++ b/src/modules/job-manager/restart.c
@@ -150,10 +150,19 @@ int restart_from_kvs (struct job_manager *ctx)
     const char *dirname = "job";
     int dirskip = strlen (dirname);
     int count;
+    struct job *job;
 
     count = depthfirst_map (ctx->h, dirname, dirskip, restart_map_cb, ctx);
     if (count < 0)
         return -1;
+    /* Initialize the count of "running" jobs
+     */
+    job = zhashx_first (ctx->active_jobs);
+    while (job) {
+        if ((job->state & FLUX_JOB_RUNNING) != 0)
+            ctx->running_jobs++;
+        job = zhashx_next (ctx->active_jobs);
+    }
     flux_log (ctx->h, LOG_DEBUG, "%s: added %d jobs", __FUNCTION__, count);
     return 0;
 }

--- a/t/rc/rc3-job
+++ b/t/rc/rc3-job
@@ -1,5 +1,9 @@
 #!/bin/bash -e
 
+flux queue stop
+flux job cancelall -f --states RUN
+flux queue idle
+
 flux module remove job-manager
 flux exec -r all flux module remove job-info
 flux exec -r all flux module remove kvs-watch


### PR DESCRIPTION
This PR provides a command `flux queue idle`, similar to `flux queue drain`, that waits until there are no pending alloc requests to the scheduler, and no jobs in RUN or CLEANUP state.  One can now cleanly terminate running work when shutting down an instance with

```console
$ flux queue stop
$ flux job cancelall -f --states=RUN
$ flux queue idle
```

The `stop` prevents the job manager from sending new alloc requests to the scheduler, and sends cancel messages for any pending ones.  The `cancelall` terminates running work.  The `idle` then blocks until the canceled jobs have transitioned to INACTIVE state (with eventlogs etc committed to the KVS).

I added this sequence to rc3 (speculatively).

As discussed in #2649, in a system instance this could be preceded with something like
```
$ flux queue stop
$ flux job raiseall -s1 --states=RUN checkpoint
$ sleep 600
```
which would allow jobs some time to respond to the `checkpoint` exception, including submitting new work`, before either terminating normally on their own or getting canceled in rc3.

Possibly we'll want to repackage this a `flux shutdown` or similar but for now, just getting some basic mechanisms ironed out.

Tests are still needed, but wanted to post this for early feedback.