### PR TITLE
libflux: disallow message send; prevent segfaults during flux_handle_destroy()

### DIFF
--- a/src/common/libflux/handle.c
+++ b/src/common/libflux/handle.c
@@ -75,6 +75,7 @@ struct flux_handle_struct {
     flux_fatal_f    fatal;
     void            *fatal_arg;
     bool            fatality;
+    bool            destroy_in_progress;
 #if HAVE_CALIPER
     struct profiling_context prof;
 #endif
@@ -395,6 +396,9 @@ void flux_handle_destroy (flux_t *h)
 {
     if (h && --h->usecount == 0) {
         int saved_errno = errno;
+        if (h->destroy_in_progress)
+            return;
+        h->destroy_in_progress = true;
         aux_destroy (&h->aux);
         if ((h->flags & FLUX_O_CLONE)) {
             flux_handle_destroy (h->parent); // decr usecount

--- a/src/common/libflux/handle.c
+++ b/src/common/libflux/handle.c
@@ -619,7 +619,7 @@ static void update_rx_stats (flux_t *h, const flux_msg_t *msg)
 int flux_send (flux_t *h, const flux_msg_t *msg, int flags)
 {
     h = lookup_clone_ancestor (h);
-    if (!h->ops->send) {
+    if (!h->ops->send || h->destroy_in_progress) {
         errno = ENOSYS;
         goto fatal;
     }

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -208,6 +208,7 @@ check_PROGRAMS = \
 	shmem/backtoback.t \
 	loop/logstderr \
 	loop/issue2337 \
+	loop/issue2711 \
 	kvs/torture \
 	kvs/dtree \
 	kvs/blobref \
@@ -298,6 +299,11 @@ loop_logstderr_LDADD = \
 loop_issue2337_SOURCES = loop/issue2337.c
 loop_issue2337_CPPFLAGS = $(test_cppflags)
 loop_issue2337_LDADD = \
+	$(test_ldadd) $(LIBDL) $(LIBUTIL)
+
+loop_issue2711_SOURCES = loop/issue2711.c
+loop_issue2711_CPPFLAGS = $(test_cppflags)
+loop_issue2711_LDADD = \
 	$(test_ldadd) $(LIBDL) $(LIBUTIL)
 
 mpi_hello_SOURCES = mpi/hello.c

--- a/t/issues/t2711-rpc-in-aux-item-destructor.sh
+++ b/t/issues/t2711-rpc-in-aux-item-destructor.sh
@@ -1,0 +1,9 @@
+#!/bin/sh -e
+
+#
+#  Attempt to use handle via RPC within an aux item destructor
+#   causes segfault.
+#  Also tests that flux_send returns ENOSYS when flux_t handle
+#   destruction is in-progress
+#
+${FLUX_BUILD_DIR}/t/loop/issue2711

--- a/t/loop/issue2711.c
+++ b/t/loop/issue2711.c
@@ -1,0 +1,58 @@
+/************************************************************\
+ * Copyright 2020 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <flux/core.h>
+
+struct bad_aux {
+    flux_t *h;
+} bad_aux;
+
+void bad_aux_destroy (void *arg)
+{
+    struct bad_aux *ba = arg;
+    flux_future_t *f = flux_rpc (ba->h, "foo", NULL, FLUX_NODEID_ANY, 0);
+    if (f != NULL) {
+        fprintf (stderr, "flux_send during flux_close not blocked!\n");
+        exit (1);
+    }
+    if (errno != ENOSYS) {
+        fprintf (stderr, "unexpected error from flux_rpc: %s\n",
+                         strerror (errno));
+        exit (1);
+    }
+    fprintf (stderr, "flux_rpc: got expected error: %s\n", strerror (errno));
+}
+
+int main (int argc, char *argv[])
+{
+    flux_t *h = NULL;
+
+    /*  Test that flux_send disabled during flux_close() */
+    if (!(h = flux_open ("loop://", 0))) {
+        perror ("flux_open");
+        exit (1);
+    }
+    bad_aux.h = h;
+    if (flux_aux_set (h, "bad_aux", &bad_aux, bad_aux_destroy) < 0) {
+        perror ("flux_aux_set");
+        exit (1);
+    }
+
+    flux_close (h);
+    exit (0);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */
+


### PR DESCRIPTION
This PR is split off #2710. It fixes two issues discussed there:

 1. Prevent use of flux_send and its derivatives during handle destruction (e.g. in aux_item destructors). Attempts to send messages when the handle is being destroyed will now return ENOSYS.
 2. Fix potential re-entry into `flux_handle_destroy()` by adding a `destroy_in_progress` flag to flux handles.

Also adds a trivial testcase that segfaulted before these fixes.