### PR TITLE
job-ingest: fixes for validation worker management

### DIFF
--- a/src/broker/module.c
+++ b/src/broker/module.c
@@ -319,12 +319,6 @@ int module_sendmsg (module_t *p, const flux_msg_t *msg)
         /* Muted modules only accept keepalive messages */
         const char *topic;
         (void) flux_msg_get_topic (msg, &topic);
-        flux_log (p->h,
-                  LOG_DEBUG,
-                  "module_sendmsg: muted %s %s to %s",
-                  topic,
-                  flux_msg_typestr (type),
-                  p->name);
         errno = ENOSYS;
         goto done;
     }

--- a/src/modules/job-ingest/validate.c
+++ b/src/modules/job-ingest/validate.c
@@ -61,11 +61,37 @@ struct validate {
     struct worker *worker[MAX_WORKER_COUNT];
 };
 
+static void validate_killall (struct validate *v)
+{
+    flux_future_t *cf = flux_future_wait_all_create ();
+    flux_future_t *f;
+    int i;
+    if (!cf) {
+        flux_log_error (v->h, "validate_destroy: flux_future_wait_all_create");
+        return;
+    }
+    flux_future_set_flux (cf, v->h);
+    for (i = 0; i < MAX_WORKER_COUNT; i++) {
+        if ((f = worker_kill (v->worker[i], SIGKILL)))
+            flux_future_push (cf, NULL, f);
+    }
+    /* Wait for up to 5s for response that signals have been delivered
+     *  to all workers before continuing. This should ensure no workers
+     *  are left around after removal of the job-ingest module.
+     *  (report, but otherwise ignore errors)
+     */
+    if (flux_future_wait_for (cf, 5.) < 0
+        || flux_future_get (cf, NULL) < 0)
+        flux_log_error (v->h, "validate_destroy: killing workers");
+    flux_future_destroy (cf);
+}
+
 void validate_destroy (struct validate *v)
 {
     if (v) {
         int saved_errno = errno;
         int i;
+        validate_killall (v);
         for (i = 0; i < MAX_WORKER_COUNT; i++)
             worker_destroy (v->worker[i]);
         free (v);

--- a/src/modules/job-ingest/validate.c
+++ b/src/modules/job-ingest/validate.c
@@ -127,6 +127,7 @@ struct validate *validate_create (flux_t *h,
 
     for (i = 0; i < MAX_WORKER_COUNT; i++) {
         if (!(v->worker[i] = worker_create (h, worker_inactivity_timeout,
+                                            validate_path,
                                             argc, argv)))
             goto error;
     }

--- a/src/modules/job-ingest/worker.c
+++ b/src/modules/job-ingest/worker.c
@@ -306,6 +306,19 @@ static void worker_stop (struct worker *w)
     }
 }
 
+flux_future_t *worker_kill (struct worker *w, int signo)
+{
+    flux_future_t *f = NULL;
+    if (w->p) {
+        flux_log (w->h, LOG_DEBUG,
+                  "killing %s (pid=%ld)",
+                  w->name,
+                  (long) flux_subprocess_pid (w->p));
+        f = flux_subprocess_kill (w->p, signo);
+    }
+    return f;
+}
+
 static int worker_start (struct worker *w)
 {
     if (!w->p) {

--- a/src/modules/job-ingest/worker.c
+++ b/src/modules/job-ingest/worker.c
@@ -324,6 +324,7 @@ void worker_destroy (struct worker *w)
 }
 
 struct worker *worker_create (flux_t *h, double inactivity_timeout,
+                              const char *name,
                               int argc, char **argv)
 {
     struct worker *w;
@@ -339,7 +340,7 @@ struct worker *worker_create (flux_t *h, double inactivity_timeout,
         goto error;
     if (!(w->trash = zlist_new()))
         goto error;
-    if (!(w->name = strdup (basename (argv[0]))))
+    if (!(w->name = strdup (basename (name))))
         goto error;
     if (!(w->queue = zlist_new ()))
         goto error;

--- a/src/modules/job-ingest/worker.h
+++ b/src/modules/job-ingest/worker.h
@@ -20,6 +20,7 @@ flux_future_t *worker_request (struct worker *w, const char *s);
 int worker_queue_depth (struct worker *w);
 bool worker_is_running (struct worker *w);
 
+flux_future_t *worker_kill (struct worker *w, int signo);
 void worker_destroy (struct worker *w);
 struct worker *worker_create (flux_t *h, double inactivity_timeout,
                               const char *worker_name,

--- a/src/modules/job-ingest/worker.h
+++ b/src/modules/job-ingest/worker.h
@@ -22,6 +22,7 @@ bool worker_is_running (struct worker *w);
 
 void worker_destroy (struct worker *w);
 struct worker *worker_create (flux_t *h, double inactivity_timeout,
+                              const char *worker_name,
                               int argc, char **argv);
 
 

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -202,7 +202,8 @@ dist_check_SCRIPTS = \
 	job-attach/outputsleep.sh \
 	job-exec/dummy.sh \
 	schedutil/req_and_unload.py \
-	ingest/fake-validate.sh
+	ingest/fake-validate.sh \
+	ingest/bad-validate.sh
 
 check_PROGRAMS = \
 	shmem/backtoback.t \

--- a/t/ingest/bad-validate.sh
+++ b/t/ingest/bad-validate.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+read line
+exit 1

--- a/t/t2200-job-ingest.t
+++ b/t/t2200-job-ingest.t
@@ -24,6 +24,7 @@ SCHEMA=${FLUX_SOURCE_DIR}/src/modules/job-ingest/schemas/jobspec.jsonschema
 BINDINGS_VALIDATOR=${FLUX_SOURCE_DIR}/src/modules/job-ingest/validators/validate-jobspec.py
 JSONSCHEMA_VALIDATOR=${FLUX_SOURCE_DIR}/src/modules/job-ingest/validators/validate-schema.py
 FAKE_VALIDATOR=${SHARNESS_TEST_SRCDIR}/ingest/fake-validate.sh
+BAD_VALIDATOR=${SHARNESS_TEST_SRCDIR}/ingest/bad-validate.sh
 
 DUMMY_EVENTLOG=test.ingest.eventlog
 
@@ -186,6 +187,14 @@ test_expect_success 'job-ingest: valid jobspecs accepted by jsonschema validator
 
 test_expect_success 'job-ingest: invalid jobs rejected by jsonschema validator' '
 	test_invalid ${JOBSPEC}/invalid/*
+'
+
+test_expect_success 'job-ingest: validator unexpected exit is handled' '
+	flux exec -r all flux module remove job-ingest &&
+	flux exec -r all flux module load job-ingest \
+		validator=${BAD_VALIDATOR} &&
+	test_must_fail flux job submit basic.json 2>badvalidator.out &&
+	grep "unexpectedly exited" badvalidator.out
 '
 
 test_expect_success 'job-ingest: remove modules' '


### PR DESCRIPTION
Ok, this is the PR from which the past 3 or 4 PRs have spawned. The idea was to fix just a few minor issues in the job-ingest modules management of its validation workers. These fixes include:

 * When logging, print the basename of the script, not of the python interpreter.
 * When the validator script unexpectedly exits, don't "leave the submitter hanging"
 * Signal any active worker processes on module unload, o/w they will stay running for-evah

Also, this fixes a *very bad no good* bug I introduced in #2710: When messages to modules were dropped due to `p->muted` a debug message was logged, but unfortunately *using the module's flux_t handle*! This caused Bad Things:tm: when the broker and the module used the handle at the same time :frowning_face:

For now I just dropped the debug message. 