### PR TITLE
bindings/python: add boolean flags to job.submit(), submit_async()

### DIFF
--- a/src/bindings/python/flux/job.py
+++ b/src/bindings/python/flux/job.py
@@ -19,6 +19,7 @@ import collections
 import six
 import yaml
 
+from flux import constants
 from flux.wrapper import Wrapper
 from flux.util import check_future_error, parse_fsd
 from flux.future import Future
@@ -63,8 +64,19 @@ def _convert_jobspec_arg_to_string(jobspec):
     return jobspec
 
 
-def submit_async(flux_handle, jobspec, priority=lib.FLUX_JOB_PRIORITY_DEFAULT, flags=0):
+def submit_async(
+    flux_handle,
+    jobspec,
+    priority=lib.FLUX_JOB_PRIORITY_DEFAULT,
+    waitable=False,
+    debug=False,
+):
     jobspec = _convert_jobspec_arg_to_string(jobspec)
+    flags = 0
+    if waitable:
+        flags |= constants.FLUX_JOB_WAITABLE
+    if debug:
+        flags |= constants.FLUX_JOB_DEBUG
     future_handle = RAW.submit(flux_handle, jobspec, priority, flags)
     return Future(future_handle)
 
@@ -79,8 +91,14 @@ def submit_get_id(future):
     return int(jobid[0])
 
 
-def submit(flux_handle, jobspec, priority=lib.FLUX_JOB_PRIORITY_DEFAULT, flags=0):
-    future = submit_async(flux_handle, jobspec, priority, flags)
+def submit(
+    flux_handle,
+    jobspec,
+    priority=lib.FLUX_JOB_PRIORITY_DEFAULT,
+    waitable=False,
+    debug=False,
+):
+    future = submit_async(flux_handle, jobspec, priority, waitable, debug)
     jid = submit_get_id(future)
     return jid
 

--- a/src/cmd/flux-mini.py
+++ b/src/cmd/flux-mini.py
@@ -199,14 +199,15 @@ class SubmitCmd:
                     val = tmp[1]
                 jobspec.setattr(key, val)
 
-        flags = 0
+        arg_debug = False
+        arg_waitable = False
         if args.flags is not None:
             for tmp in args.flags:
                 for flag in tmp.split(","):
                     if flag == "debug":
-                        flags |= flux.constants.FLUX_JOB_DEBUG
+                        arg_debug = True
                     elif flag == "waitable":
-                        flags |= flux.constants.FLUX_JOB_WAITABLE
+                        arg_waitable = True
                     else:
                         raise ValueError("--flags: Unknown flag " + flag)
 
@@ -215,7 +216,13 @@ class SubmitCmd:
             sys.exit(0)
 
         h = flux.Flux()
-        return job.submit(h, jobspec.dumps(), priority=args.priority, flags=flags)
+        return job.submit(
+            h,
+            jobspec.dumps(),
+            priority=args.priority,
+            waitable=arg_waitable,
+            debug=arg_debug,
+        )
 
     def main(self, args):
         jobid = self.submit(args)

--- a/t/job-manager/submit-sliding-window.py
+++ b/t/job-manager/submit-sliding-window.py
@@ -30,13 +30,12 @@ if len(sys.argv) == 3:
 h = flux.Flux()
 
 jobspec = JobspecV1.from_command(["/bin/true"])
-flags = flux.constants.FLUX_JOB_WAITABLE
 done = 0
 running = 0
 
 while done < njobs:
     if running < fanout and done + running < njobs:
-        jobid = job.submit(h, jobspec, flags=flags)
+        jobid = job.submit(h, jobspec, waitable=True)
         print("submit: {}".format(jobid))
         running += 1
 

--- a/t/job-manager/submit-wait.py
+++ b/t/job-manager/submit-wait.py
@@ -30,13 +30,12 @@ h = flux.Flux()
 jobspec = JobspecV1.from_command(["/bin/true"])
 jobspec_fail = JobspecV1.from_command(["/bin/false"])
 jobs = []
-flags = flux.constants.FLUX_JOB_WAITABLE
 for i in range(njobs):
     if i < njobs / 2:
-        jobid = job.submit(h, jobspec, flags=flags)
+        jobid = job.submit(h, jobspec, waitable=True)
         print("submit: {} /bin/true".format(jobid))
     else:
-        jobid = job.submit(h, jobspec_fail, flags=flags)
+        jobid = job.submit(h, jobspec_fail, waitable=True)
         print("submit: {} /bin/false".format(jobid))
     jobs.append(jobid)
 

--- a/t/job-manager/submit-waitany.py
+++ b/t/job-manager/submit-waitany.py
@@ -29,13 +29,12 @@ h = flux.Flux()
 # Submit njobs test jobs (half will fail)
 jobspec = JobspecV1.from_command(["/bin/true"])
 jobspec_fail = JobspecV1.from_command(["/bin/false"])
-flags = flux.constants.FLUX_JOB_WAITABLE
 for i in range(njobs):
     if i < njobs / 2:
-        jobid = job.submit(h, jobspec, flags=flags)
+        jobid = job.submit(h, jobspec, waitable=True)
         print("submit: {} /bin/true".format(jobid))
     else:
-        jobid = job.submit(h, jobspec_fail, flags=flags)
+        jobid = job.submit(h, jobspec_fail, waitable=True)
         print("submit: {} /bin/false".format(jobid))
 
 

--- a/t/job-manager/wait-interrupted.py
+++ b/t/job-manager/wait-interrupted.py
@@ -30,9 +30,8 @@ h = flux.Flux()
 # Submit njobs test jobs
 jobspec = JobspecV1.from_command(["/bin/true"])
 jobs = []
-flags = flux.constants.FLUX_JOB_WAITABLE
 for i in range(njobs):
-    jobid = job.submit(h, jobspec, flags=flags)
+    jobid = job.submit(h, jobspec, waitable=True)
     print("submit: {} /bin/true".format(jobid))
     jobs.append(jobid)
 


### PR DESCRIPTION
This PR follows through on a suggestion in #2717 for a better public interface in `job.submit()` and `job.submit_async()`.  Add boolean `debug` and `waitable` flags so that user's don't have to OR values from `flux.constants`, which is more verbose and error prone.

I left the optional `flags` argument alone for now since using the binary flags would actually be slightly more code in `flux-mini.py`, and to avoid breaking just-committed workflow examples.  Maybe we should just go full speed ahead and get rid of it?

Feedback welcome.