### PR TITLE
job-ingest: fix handling of unexpected validation worker exit

### DIFF
--- a/src/modules/job-ingest/worker.c
+++ b/src/modules/job-ingest/worker.c
@@ -36,13 +36,6 @@
  * - Work is sent to the coprocess with flux_subprocess_write() regardless
  *   of the current queue depth, which may challenge subprocess buffer
  *   management.
- *
- * - Worker is stopped by closing stdin, but worker_stop() may return
- *   before it is known to have stopped, leaving the broker to clean up
- *   with no possibility of reporting errors to the caller.
- *
- * - Subprocess state change and completion callbacks just log at this point,
- *   and don't initiate cleanup should the subprocess prematurely exit.
  */
 
 #if HAVE_CONFIG_H


### PR DESCRIPTION
As described in #2718, a race was introduced in PR #2716 in the handling of unexpected subprocess exits. If a process exiting normally races with the startup of a new process, the request for the new process is rejected with "validator exited unexpectedly"

This PR fixes that issue, as well as fixing a minor related issue in `worker_completion_cb`