### PR TITLE
Rountree documentation

### DIFF
--- a/doc/man1/flux-dmesg.adoc
+++ b/doc/man1/flux-dmesg.adoc
@@ -1,5 +1,5 @@
 // flux-help-description: manipulate broker log ring buffer
-FLUX-GETATTR(1)
+FLUX-DMESG(1)
 ===============
 :doctype: manpage
 

--- a/doc/man3/idset_create.adoc
+++ b/doc/man3/idset_create.adoc
@@ -53,7 +53,7 @@ DESCRIPTION
 -----------
 
 An idset is a set of numerically sorted, non-negative integers.
-It is internally represented as a Van Embde Boas (or vEB) tree.
+It is internally represented as a van Embde Boas (or vEB) tree.
 Functionally it behaves like a bitmap, and has space efficiency
 comparable to a bitmap, but performs operations (insert, delete,
 lookup, findNext, findPrevious) in O(log(m)) time, where pow (2,m)


### PR DESCRIPTION
Two patches on this branches to fix trivial typos.