### PR TITLE
add 'unlimited' alloc mode to simple-sched

### DIFF
--- a/src/test/sched-bench.sh
+++ b/src/test/sched-bench.sh
@@ -8,8 +8,8 @@ declare prog=$(basename $0)
 declare NNODES=8
 declare CPN=32
 
-declare -r long_opts="help,nnodes:,cores-per-node:,jobs:,noexec"
-declare -r short_opts="hn:c:j:"
+declare -r long_opts="help,nnodes:,cores-per-node:,jobs:,noexec,sched-opts:verbose"
+declare -r short_opts="hvN:c:j:o:"
 declare -r usage="\
 \n\
 Usage: $prog [OPTIONS]\n\
@@ -17,13 +17,18 @@ Simple Flux sched/exec test benchmark.\n\
 \n\
 Options:\n\
  -h, --help              display this messages\n\
- -n, --nnodes=NNODES     set simulated number of nodes (default=${NNODES})\n\
+ -v, --verbose           run with extra verbose output\n\
+ -N, --nnodes=NNODES     set simulated number of nodes (default=${NNODES})\n\
  -c, --cores-per-node=N  set simulated cores per node (default=${CPN})\n\
  -j, --jobs=NJOBS        set number of jobs to run (default nnodes*cpn)\n\
+ -o, --sched-opts=OPTS   set scheduler module load options\n\
      --noexec            do not simulate execution, just scheduling\n"
+
 
 log() { local fmt=$1; shift; printf >&2 "$prog: $fmt" "$@"; }
 die() { log "$@" && exit 1; }
+
+verbose() { test $VERBOSE = "t" && log "$@"; }
 
 log_timing_msg() {
     local name=$1
@@ -43,9 +48,11 @@ fi
 eval set -- "$GETOPTS"
 while true; do
     case "$1" in
-      -n|--nnodes)          NNODES=$2;  shift 2 ;;
+      -v|--verbose)         VERBOSE=t;  shift   ;;
+      -N|--nnodes)          NNODES=$2;  shift 2 ;;
       -c|--cores-per-node)  CPN=$2;     shift 2 ;;
       -j|--jobs)            NJOBS=$2;   shift 2 ;;
+      -o|--sched-opts)      OPTS="$2";  shift 2 ;;
       --noexec)             NOEXEC=t;   shift   ;;
       --)                   shift ; break ;     ;;
       -h|--help)            echo -e "$usage" ; exit 0           ;;
@@ -64,32 +71,40 @@ log "broker.pid=$(flux getattr broker.pid)\n"
 flux module remove sched-simple
 flux kvs put --json \
     resource.hwloc.by_rank="{\"[0-$(($NNODES-1))]\":{\"Core\":$CPN}}"
-flux jobspec srun hostname | jq '.attributes.system.duration = .0001' > job.json
-flux module load sched-simple
+flux mini run --dry-run --setattr=system.exec.test.run_duration=.001s hostname \
+    > job.json
+
+log "Loading sched-simple: ${OPTS}\n"
+flux module load sched-simple ${OPTS} || die "Failed to load sched-simple"
 
 #  If not testing exec system, remove the job-exec module
 test "$NOEXEC" = "t" && flux module remove job-exec
 
 t_start=$(date +%s.%N)
-t/ingest/submitbench -f 24 -r $NJOBS job.json > job.list
+t/ingest/submitbench -f 1024 -r $NJOBS job.json > job.list
 t_ingest=$(date +%s.%N)
 log_timing_msg ingested $t_start $t_ingest
 
-first=$(flux job list -s -c 1 | awk '{print $1}')
-last=$(flux job list -s | tail -1 | awk '{print $1}')
+test "$VERBOSE" = "t" && flux queue status -v
+
+last=$(tail -1 job.list)
+first=$(head -1 job.list)
 
 starttime=$(flux job eventlog $first | awk '$2 == "submit" {print $1}')
 alloctime=$(flux job wait-event $last alloc | awk '$2 == "alloc" {print $1}')
 log_timing_msg allocated $starttime $alloctime
+
+test "$VERBOSE" = "t" && flux queue status -v
 
 if test -z "$NOEXEC"; then
     runtime=$(flux job wait-event $last clean | awk '{print $1}')
     log_timing_msg ran $starttime $runtime
 fi
 
-flux queue drain
+flux job cancelall -f
+flux queue idle --quiet
 
-flux job eventlog $last
+test "$VERBOSE" = "t" && flux queue status -v
 
 t_done=$(date +%s.%N)
 log_timing_msg "total walltime for" $t_start $t_done

--- a/t/sharness.d/flux-sharness.sh
+++ b/t/sharness.d/flux-sharness.sh
@@ -111,6 +111,7 @@ test_under_flux() {
         valgrind="$valgrind,--trace-children=no,--child-silent-after-fork=yes"
         valgrind="$valgrind,--leak-resolution=med,--error-exitcode=1"
         valgrind="$valgrind,--suppressions=${VALGRIND_SUPPRESSIONS}"
+        gracetime="-o,-g,10"
     fi
     # Extend timeouts when running under AddressSanitizer
     if test_have_prereq ASAN; then


### PR DESCRIPTION
This is some experimental work I had laying around to add a simple queue in sched-simple so that `unlimited` alloc mode can be implemented (mostly for testing purposes)

I'm posting this here because it had some interesting testing results, and the selection of `unlimited` mode for the simple scheduler may help in testing flux-core facilities, and also so I don't lose track of the code.

The scheduler is still left in `single` alloc mode by default. This is because there are some ill side effects when you run many short jobs (i.e. my benchmark) with `unlimited` mode. In a larger instance, the storm of jobs moving from SCHED to RUN brings the exec system (likely the KVS) to its knees, and job throughput and interactivity suffers. There may be some easy work on batching we could do in the near future to rectify this when we have time.

The evidence of this effect can be seen by comparing the results of running 1024 `sleep 0` jobs across 16 nodes of fluke in both `single` and `unlimited` modes:
(BTW, this version of the benchmark stops the queue, submits all jobs, then starts the queue so that submission and allocation are not overlapping)

`single` (the default):
```
$  srun -N16 --pty --mpi=none --mpibind=off src/cmd/flux start sh -c 'flux python ./bulksubmit.py jobs/*.json && flux jobs -c 1024 -ano {runtime} | ~/.local/bin/hist -b 68 -p \| -c blue -r'
bulksubmit: Starting...
bulksubmit: scheduling disabled, reason=Testing
bulksubmit: submitted 1024 jobs in 1.81s. 565.07job/s
bulksubmit: scheduling enabled
bulksubmit: First job finished in about 0.235s
|██████████████████████████████████████████████████████████| 100.0% (49.6 job/s)
bulksubmit: Ran 1024 jobs in 20.6s. 49.6 job/s

 171|        |                                                            
 162|        |                                                            
 153|        |                                                            
 144|       |||                                                           
 135|       |||                                                           
 126|      ||||                                                           
 117|      ||||                                                           
 108|      ||||                                                           
  99|      |||||                                                          
  90|     ||||||                                                          
  81|     ||||||                                                          
  72|     ||||||                                                          
  63|     |||||||                                                         
  54|     |||||||                                                         
  45|     |||||||                                                         
  36|     |||||||                                                         
  27|    ||||||||                                                         
  18|    ||||||||| |                                                      
   9|    |||||||||||                                                      
   1| |||||||||||||||||||||||  ||||||||||||| |  |          |       |     |
     --------------------------------------------------------------------

--------------------------------
|           Summary            |
--------------------------------
|      observations: 1024      |
|     min value: 0.072978      |
|       mean : 0.117040        |
|     max value: 0.453697      |
--------------------------------
```

`unlimited` mode:
```
$ srun -N16 --pty --mpi=none --mpibind=off src/cmd/flux start sh -c 'flux module remove sched-simple; flux module load sched-simple unlimited; flux python ./bulksubmit.py jobs/*.json && flux jobs -c1024 -ano {runtime} | ~/.local/bin/hist -b 68 -p \| -c blue'
bulksubmit: Starting...
bulksubmit: scheduling disabled, reason=Testing
bulksubmit: submitted 1024 jobs in 1.60s. 639.78job/s
bulksubmit: scheduling enabled
bulksubmit: First job finished in about 2.843s
|██████████████████████████████████████████████████████████| 100.0% (47.2 job/s)
bulksubmit: Ran 1024 jobs in 21.7s. 47.2 job/s

 104|                                                  |                   
  99|                                                  |                   
  93|                                                  |                   
  88|                                                  |                   
  82|                                                  |                   
  77|                                                  |                   
  71|                                                  |                   
  66|                                                  | |                 
  60|                                |                 | |  |              
  55|                                |                || |  |              
  50|                                |                || |  ||             
  44|                                |              | || |  ||             
  39|                                |              | || |  ||             
  33|                                |    |     |   | || || |||            
  28|                     ||         |    |     |   | ||||||||||           
  22|                     ||         ||  ||     ||  | ||||||||||           
  17|                     ||         ||  ||     ||  | ||||||||||           
  11|                    |||       ||||| ||     || ||||||||||||||  |       
   6|            |  |    ||||    ||||||||||   | || ||||||||||||||  |       
   1| ||  |     ||||| |||||||  ||||||||||||| ||||||||||||||||||||||||     |
     ---------------------------------------------------------------------

-------------------------------
|           Summary           |
-------------------------------
|      observations: 1024     |
|     min value: 0.499866     |
|       mean : 1.522915       |
|     max value: 2.132833     |
-------------------------------
```

Note the huge increase in runtime for the second case. Though I didn't perform too deep an analysis, this slowdown appears to be due to the kvs being hit hard by many jobs starting at closer to the same time as compared to the `single` mode case.

A quick run of `perf` on the rank 0 node of one of these runs showed that a large percentage of time (~20% if I'm reading perf report correctly) was in `namespace_create`. This might be something to check out in the future, but I didn't do that here.

Another interesting set of results is a run with `sched-bench.sh`, set up such that we have N jobs being allocated to N cores with no exec system loaded. This measures the time it takes the system to "fill the system" with jobs, without having to contend with the exec system. I've modified the `sched-bench.sh` script to allow options to be passed to sched-simple, with results below: (also added calls to `flux queue status -v` for debugging.

These runs test against a fake cluster of 1024 nodes with 4 cores per node. 4K jobs are submitted and the test times how long submission and allocation stages take. We can see the `unlimited` mode unsurprisingly is more performant (though this is a contrived testcase)

The important result below is the allocation rate.

```console
$ src/cmd/flux start src/test/sched-bench.sh -n 1024 -c 4 -j 4096 --noexec
sched-bench.sh: On branch sched-simple-unlimited: v0.15.0-48-ge34d81d
sched-bench.sh: starting with 4096 jobs across 1024 nodes with 4 cores/node.
sched-bench.sh: broker.pid=2349
sched-bench.sh: Loading sched-simple: 
sched-bench.sh: ingested 4096 jobs in 5.779s (708.83 job/s)
flux-queue: Job submission is enabled
flux-queue: Scheduling is enabled
flux-queue: 4091 alloc requests queued
flux-queue: 1 alloc requests pending to scheduler
flux-queue: 0 free requests pending to scheduler
flux-queue: 4 running jobs
sched-bench.sh: allocated 4096 jobs in 26.431s (154.97 job/s)
flux-queue: Job submission is enabled
flux-queue: Scheduling is enabled
flux-queue: 0 alloc requests queued
flux-queue: 0 alloc requests pending to scheduler
flux-queue: 0 free requests pending to scheduler
flux-queue: 4096 running jobs
flux-job: Canceled 4096 jobs (0 errors)
flux-queue: 0 pending jobs
1581310222.486779 submit userid=6885 priority=16 flags=0
1581310223.599791 depend
1581310244.663860 alloc note="rank1023/core3"
1581310244.836625 exception type="cancel" severity=0 userid=6885 note=""
1581310246.087886 free
1581310246.087899 clean
sched-bench.sh: total walltime for 4096 jobs in 33.096s (123.76 job/s)
lt-flux-broker: module 'content-sqlite' was not cleanly shutdown
$ src/cmd/flux start src/test/sched-bench.sh -n 1024 -c 4 -j 4096 --noexec -o unlimited
sched-bench.sh: On branch sched-simple-unlimited: v0.15.0-48-ge34d81d
sched-bench.sh: starting with 4096 jobs across 1024 nodes with 4 cores/node.
sched-bench.sh: broker.pid=4042
sched-bench.sh: Loading sched-simple: unlimited
sched-bench.sh: ingested 4096 jobs in 9.511s (430.66 job/s)
flux-queue: Job submission is enabled
flux-queue: Scheduling is enabled
flux-queue: 0 alloc requests queued
flux-queue: 1240 alloc requests pending to scheduler
flux-queue: 0 free requests pending to scheduler
flux-queue: 2856 running jobs
sched-bench.sh: allocated 4096 jobs in 11.441s (358.00 job/s)
flux-queue: Job submission is enabled
flux-queue: Scheduling is enabled
flux-queue: 0 alloc requests queued
flux-queue: 0 alloc requests pending to scheduler
flux-queue: 0 free requests pending to scheduler
flux-queue: 4096 running jobs
flux-job: Canceled 4096 jobs (0 errors)
flux-queue: 0 pending jobs
1581310290.214762 submit userid=6885 priority=16 flags=0
1581310292.828680 depend
1581310295.149871 alloc note="rank1023/core3"
1581310295.884270 exception type="cancel" severity=0 userid=6885 note=""
1581310297.754207 free
1581310297.754214 clean
sched-bench.sh: total walltime for 4096 jobs in 18.498s (221.43 job/s)
```