### PR TITLE
job-info: Fix pending jobs ordering

### DIFF
--- a/src/modules/job-info/job_state.c
+++ b/src/modules/job-info/job_state.c
@@ -327,10 +327,13 @@ static void update_job_state_and_list (struct info_ctx *ctx,
     oldlist = get_list (jsctx, job->state);
     newlist = get_list (jsctx, newstate);
 
+    /* must call before job_change_list(), to ensure timestamps are
+     * set before any sorting based on timestamps are done
+     */
+    update_job_state (ctx, job, newstate, timestamp);
+
     if (oldlist != newlist)
         job_change_list (jsctx, job, oldlist, newstate);
-
-    update_job_state (ctx, job, newstate, timestamp);
 }
 
 static int eventlog_lookup_parse (struct info_ctx *ctx,

--- a/src/modules/job-info/job_state.c
+++ b/src/modules/job-info/job_state.c
@@ -34,8 +34,9 @@ struct state_transition {
 
 static void process_next_state (struct info_ctx *ctx, struct job *job);
 
-/* Compare items for sorting in list, priority first, t_submit second
- * N.B. zlistx_comparator_fn signature
+/* Compare items for sorting in list, priority first (higher priority
+ * before lower priority), t_submit second (earlier submission time
+ * first) N.B. zlistx_comparator_fn signature
  */
 static int job_priority_cmp (const void *a1, const void *a2)
 {
@@ -49,8 +50,9 @@ static int job_priority_cmp (const void *a1, const void *a2)
 }
 
 /* Compare items for sorting in list by timestamp (note that sorting
- * is in reverse order, most recently running/completed comes first).
- * N.B. zlistx_comparator_fn signature
+ * is in reverse order, most recently (i.e. bigger timestamp)
+ * running/completed comes first).  N.B. zlistx_comparator_fn
+ * signature
  */
 static int job_running_cmp (const void *a1, const void *a2)
 {

--- a/src/modules/job-info/job_state.h
+++ b/src/modules/job-info/job_state.h
@@ -20,11 +20,14 @@
  * store jobs in three different lists.
  *
  * - pending - these are jobs that have not yet in the RUN state, they
- *   are sorted based on job priority, then job submission time.
+ *   are sorted based on job priority (highest first), then job
+ *   submission time (earlier submission time first).
  * - running - these are jobs that have transitioned to the RUN state.
- *   They are sorted by initial run start time.
+ *   They are sorted by initial run start time (later run start
+ *   times first).
  * - inactive - these are jobs that are in the INACTIVE state, they
- *   are sorted by job completion time.
+ *   are sorted by job completion time (later completion times
+ *   first)
  *
  * There is also an additional list `processing` that stores jobs that
  * cannot yet be stored on one of the lists above.


### PR DESCRIPTION
PR #2655 introduced a bug in which pending jobs were not ordered correctly.  This fixes it & adds tests & some extra comments.

Confirmed that the tests passed on a tree that was before #2655 as well.
