### PR TITLE
flux-jobs: refactor using new JobInfo and OutputFormat classes

### DIFF
--- a/src/bindings/python/flux/Makefile.am
+++ b/src/bindings/python/flux/Makefile.am
@@ -7,7 +7,8 @@ fluxpy_PYTHON=\
 	      constants.py\
 	      job.py \
 	      util.py \
-	      future.py
+	      future.py \
+	      memoized_property.py
 
 if HAVE_FLUX_SECURITY
 fluxpy_PYTHON += security.py

--- a/src/bindings/python/flux/memoized_property.py
+++ b/src/bindings/python/flux/memoized_property.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2013, Steven Cummings
+# All rights reserved.
+#
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#  * Redistributions of source code must retain the above copyright notice,
+#  this list of conditions and the following disclaimer.
+#
+#  * Redistributions in binary form must reproduce the above copyright notice,
+#  this list of conditions and the following disclaimer in the documentation
+#  and/or other materials provided with the distribution.
+#
+#  * Neither the name of memoized_property nor the names of its contributors
+#  may be used to endorse or promote products derived from this software
+#  without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+# © 2020 GitHub, Inc.
+
+from functools import wraps
+
+
+def memoized_property(fget):
+    """
+    Return a property attribute for new-style classes that only calls its
+    getter on the first access. The result is stored and on subsequent
+    accesses is returned, preventing the need to call the getter any more.
+    Example::
+        >>> class C(object):
+        ...     load_name_count = 0
+        ...     @memoized_property
+        ...     def name(self):
+        ...         "name's docstring"
+        ...         self.load_name_count += 1
+        ...         return "the name"
+        >>> c = C()
+        >>> c.load_name_count
+        0
+        >>> c.name
+        "the name"
+        >>> c.load_name_count
+        1
+        >>> c.name
+        "the name"
+        >>> c.load_name_count
+        1
+    """
+    attr_name = "_{0}".format(fget.__name__)
+
+    @wraps(fget)
+    def fget_memoized(self):
+        if not hasattr(self, attr_name):
+            setattr(self, attr_name, fget(self))
+        return getattr(self, attr_name)
+
+    return property(fget_memoized)

--- a/src/cmd/flux-jobs.py
+++ b/src/cmd/flux-jobs.py
@@ -87,35 +87,6 @@ def job_username(job):
         return str(job["userid"])
 
 
-def output_format(fmt, jobs):
-    for job in jobs:
-        s = fmt.format(
-            id=job["id"],
-            userid=job["userid"],
-            username=job_username(job),
-            priority=job["priority"],
-            state=statetostr(job, False),
-            state_single=statetostr(job, True),
-            name=job["name"],
-            ntasks=job["ntasks"],
-            nnodes=job.get("nnodes", ""),
-            nnodes_hyphen=job.get("nnodes", "-"),
-            ranks=job.get("ranks", ""),
-            ranks_hyphen=job.get("ranks", "-"),
-            t_submit=job["t_submit"],
-            t_depend=job["t_depend"],
-            t_sched=job.get("t_sched", 0.0),
-            t_run=job.get("t_run", 0.0),
-            t_cleanup=job.get("t_cleanup", 0.0),
-            t_inactive=job.get("t_inactive", 0.0),
-            runtime=runtime(job, False),
-            runtime_fsd=runtime_fsd(job, False),
-            runtime_fsd_hyphen=runtime_fsd(job, True),
-            runtime_hms=runtime_hms(job),
-        )
-        print(s)
-
-
 def fetch_jobs_stdin(args):
     """
     Return a list of jobs gathered from a series of JSON objects, one per
@@ -260,9 +231,14 @@ def parse_args():
     )
     return parser.parse_args()
 
+class OutputFormat:
+    """
+    Store a parsed version of the program's output format,
+    allowing the fields to iterated without modifiers, building
+    a new format suitable for headers display, etc...
+    """
 
-def format_header(fmt):
-    # attr name to header name mapping:
+    #  List of legal format fields and their header names
     headings = dict(
         id="JOBID",
         userid="UID",
@@ -288,24 +264,92 @@ def format_header(fmt):
         runtime_hms="RUNTIME",
     )
 
-    def format_denumericalize(fmt):
+    def __init__(self, fmt):
         """
-        Make a format string suitable for str types only, i.e. remove
-        all floating-point and number format specifiers, but keep width
-        and justification. Used to modify user-provided format string
-        for use with headings.
+        Parse the input format fmt with string.Formatter.
+        Save off the fields and list of format tokens for later use,
+        (converting None to "" in the process)
+
+        Throws an exception if any format fields do not match the allowed
+        list of headings above.
+        """
+        from string import Formatter
+
+        self.fmt = fmt
+        #  Parse format into list of (string, field, spec, conv) tuples,
+        #   replacing any None values with empty string "" (this makes
+        #   substitution back into a format string in self.header() and
+        #   self.get_format() much simpler below)
+        l = Formatter().parse(fmt)
+        self.format_list = [[s or "" for s in t] for t in l]
+
+        #  Store list of requested fields in self.fields
+        self.fields = [field for (s, field, spec, conv) in self.format_list]
+
+        #  Throw an exception if any requested fields are invalid:
+        for field in self.fields:
+            if field and not field in self.headings:
+                raise ValueError("Unknown format field: " + field)
+
+    def _fmt_tuple(self, s, field, spec, conv):
+        #  If field is empty string or None, then the result of the
+        #   format (besides 's') doesn't make sense, just return 's'
+        if not field:
+            return s
+        #  The prefix of spec and conv are stripped by formatter.parse()
+        #   replace them here if the values are not empty:
+        spec = ":" + spec if spec else ""
+        conv = "!" + conv if conv else ""
+        return "{0}{{{1}{2}{3}}}".format(s, field, conv, spec)
+
+    def header(self):
+        """
+        Return the header row formatted by the user-provided format spec,
+        which will be made "safe" for use with string headings.
         """
         import re
 
-        return re.sub(r"\.\d+[bcdoxXeEfFgGn%]}", "}", fmt)
+        l = []
+        for (s, field, spec, conv) in self.format_list:
+            #  Remove floating point formatting on any spec:
+            spec = re.sub(r"\.\d+[bcdoxXeEfFgGn%]$", "", spec)
+            l.append(self._fmt_tuple(s, field, spec, conv))
+        fmt = "".join(l)
+        return fmt.format(**self.headings)
 
-    return format_denumericalize(fmt).format(**headings)
+    def format(self, job):
+        """
+        format job entry job with internal format
+        """
+        return self.fmt.format(
+            id=job["id"],
+            userid=job["userid"],
+            username=job_username(job),
+            priority=job["priority"],
+            state=statetostr(job, False),
+            state_single=statetostr(job, True),
+            name=job["name"],
+            ntasks=job["ntasks"],
+            nnodes=job.get("nnodes", ""),
+            nnodes_hyphen=job.get("nnodes", "-"),
+            ranks=job.get("ranks", ""),
+            ranks_hyphen=job.get("ranks", "-"),
+            t_submit=job["t_submit"],
+            t_depend=job["t_depend"],
+            t_sched=job.get("t_sched", 0.0),
+            t_run=job.get("t_run", 0.0),
+            t_cleanup=job.get("t_cleanup", 0.0),
+            t_inactive=job.get("t_inactive", 0.0),
+            runtime=runtime(job, False),
+            runtime_fsd=runtime_fsd(job, False),
+            runtime_fsd_hyphen=runtime_fsd(job, True),
+            runtime_hms=runtime_hms(job),
+        )
 
 
 @flux.util.CLIMain(logger)
 def main():
     args = parse_args()
-    jobs = fetch_jobs(args)
 
     if args.format:
         fmt = args.format
@@ -315,10 +359,18 @@ def main():
             "{ntasks:>6} {nnodes_hyphen:>6} {runtime_fsd_hyphen:>8} "
             "{ranks_hyphen}"
         )
+    try:
+        of = OutputFormat(fmt)
+    except ValueError as e:
+        raise ValueError("Error in user format: " + str(e))
+
+    jobs = fetch_jobs(args)
 
     if not args.suppress_header:
-        print(format_header(fmt))
-    output_format(fmt, jobs)
+        print(of.header())
+
+    for job in jobs:
+        print(of.format(job))
 
 
 if __name__ == "__main__":

--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -248,6 +248,18 @@ test_expect_success 'flux-jobs --format={nnodes},{nnodes_hyphen} works' '
         test_cmp nodecountRI.out nodecountRI.exp
 '
 
+test_expect_success 'flux-jobs emits useful error on invalid format' '
+	test_expect_code 1 flux jobs --format="{runtime" >invalid.out 2>&1 &&
+	test_debug "cat invalid.out" &&
+	grep "Error in user format" invalid.out
+'
+
+test_expect_success 'flux-jobs emits useful error on invalid format field' '
+	test_expect_code 1 flux jobs --format="{footime}" >invalid-field.out 2>&1 &&
+	test_debug "cat invalid-field.out" &&
+	grep "Unknown format field" invalid-field.out
+'
+
 # node ranks assumes sched-simple default of mode='worst-fit'
 test_expect_success 'flux-jobs --format={ranks},{ranks_hyphen} works' '
         flux jobs --suppress-header --state=pending --format="{ranks},{ranks_hyphen}" > ranksP.out &&


### PR DESCRIPTION
This is another bit of experimental work I had stashed away that I figured I'd propose as a PR.

This work doesn't change too much functionality in `flux jobs`, but it will hopefully make future additions to the utility slightly easier, as well as some other minor improvements in error handling of user-supplied formats.

I realized that parsing of Python's string.format specifiers is publicly available via a `string.Formatter` class. This PR adds an `OutputFormat` class which uses a `string.Formatter` internally to pick apart the current format and put it back together depending on context (e.g. a "string safe" version for headers, and a modified version for jobs due the 2nd change described below). Another benefit is that format string errors can be caught early (before fetching jobs and attempting to `.format` the first one), and we can iterate the requested fields and do something with it (for now, unknown fields generate a sensible error).

The second part of this PR provides a `JobInfo` class wrapper around the data returned by the `job-info.list` RPC. This class hides job data behind a getattr interface, so that computed results are only generated as they are requested. Unfortunately, this means that the format fields must use `0.` to invoke the `JobInfo` objects getattr method, but this is handled easily by the `OutputFormat` class.

This change doesn't affect the performance of `flux jobs` with the default format, however, the tool is now much faster if you only request a specific field, e.g. `{id}`:

New:
```
$ time flux jobs -a -o {id} -c 0 | wc -l
3107

real	0m0.197s
user	0m0.131s
sys	0m0.027s
```

Old:
```
$ time flux jobs-old -a -o {id} -c 0 | wc -l
3107

real	0m0.479s
user	0m0.276s
sys	0m0.111s
```