### PR TITLE
job-info: add new job-info.list-inactive service

### DIFF
--- a/src/common/libjob/job.c
+++ b/src/common/libjob/job.c
@@ -216,6 +216,33 @@ flux_future_t *flux_job_list (flux_t *h,
     return f;
 }
 
+flux_future_t *flux_job_list_inactive (flux_t *h,
+                                       int max_entries,
+                                       double timestamp,
+                                       const char *json_str)
+{
+    flux_future_t *f;
+    json_t *o = NULL;
+    int saved_errno;
+
+    if (!h || max_entries < 0 || timestamp < 0. || !json_str
+           || !(o = json_loads (json_str, 0, NULL))) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (!(f = flux_rpc_pack (h, "job-info.list-inactive", FLUX_NODEID_ANY, 0,
+                             "{s:i s:f s:o}",
+                             "max_entries", max_entries,
+                             "timestamp", timestamp,
+                             "attrs", o))) {
+        saved_errno = errno;
+        json_decref (o);
+        errno = saved_errno;
+        return NULL;
+    }
+    return f;
+}
+
 flux_future_t *flux_job_list_id (flux_t *h,
                                  flux_jobid_t id,
                                  const char *json_str)

--- a/src/common/libjob/job.h
+++ b/src/common/libjob/job.h
@@ -106,6 +106,14 @@ flux_future_t *flux_job_list (flux_t *h,
                               uint32_t userid,
                               int states);
 
+/* Similar to flux_job_list(), but retrieve inactive jobs newer
+ * than a timestamp.
+ */
+flux_future_t *flux_job_list_inactive (flux_t *h,
+                                       int max_entries,
+                                       double timestamp,
+                                       const char *json_str);
+
 /* Similar to flux_job_list(), but retrieve job info for a single
  * job id */
 flux_future_t *flux_job_list_id (flux_t *h,

--- a/src/common/libjob/test/job.c
+++ b/src/common/libjob/test/job.c
@@ -134,6 +134,24 @@ void check_corner_case (void)
     ok (flux_job_list (h, 0, "{}", 0, 0xFF) == NULL && errno == EINVAL,
         "flux_job_list states=(illegal states) fails with EINVAL");
 
+    /* flux_job_list_inactive */
+
+    errno = 0;
+    ok (flux_job_list_inactive (NULL, 0, 0., "{}") == NULL && errno == EINVAL,
+        "flux_job_list_inactive h=NULL fails with EINVAL");
+
+    errno = 0;
+    ok (flux_job_list_inactive (h, -1, 0., "{}") == NULL && errno == EINVAL,
+        "flux_job_list_inactive max_entries < 0 fails with EINVAL");
+
+    errno = 0;
+    ok (flux_job_list_inactive (h, 0, -1, "{}") == NULL && errno == EINVAL,
+        "flux_job_list_inactive timestamp < 0 fails with EINVAL");
+
+    errno = 0;
+    ok (flux_job_list_inactive (h, 0, 0, NULL) == NULL && errno == EINVAL,
+        "flux_job_list_inactive json_str=NULL fails with EINVAL");
+
     /* flux_job_list_id */
 
     errno = 0;

--- a/src/modules/job-info/job-info.c
+++ b/src/modules/job-info/job-info.c
@@ -134,6 +134,11 @@ static const struct flux_msg_handler_spec htab[] = {
       .rolemask     = FLUX_ROLE_USER
     },
     { .typemask     = FLUX_MSGTYPE_REQUEST,
+      .topic_glob   = "job-info.list-inactive",
+      .cb           = list_inactive_cb,
+      .rolemask     = FLUX_ROLE_USER
+    },
+    { .typemask     = FLUX_MSGTYPE_REQUEST,
       .topic_glob   = "job-info.list-id",
       .cb           = list_id_cb,
       .rolemask     = FLUX_ROLE_USER

--- a/src/modules/job-info/list.h
+++ b/src/modules/job-info/list.h
@@ -18,6 +18,9 @@
 void list_cb (flux_t *h, flux_msg_handler_t *mh,
               const flux_msg_t *msg, void *arg);
 
+void list_inactive_cb (flux_t *h, flux_msg_handler_t *mh,
+                       const flux_msg_t *msg, void *arg);
+
 void list_id_cb (flux_t *h, flux_msg_handler_t *mh,
                  const flux_msg_t *msg, void *arg);
 


### PR DESCRIPTION
Per discussion on #2683, this allows callers to get a subset of the inactive jobs in the job info module.  The subset is limited via a timestamp parameter, which allows callers to only get jobs newer than an inputted timestamp (i.e. job t_inactive > inputted timestamp).

This is quite specific for the issue problem and not very generic.  I went back and forth on making it a bit more generic, but eventually came to this very specific implementation.  One of the major reasons is b/c the pending jobs list is sorted in priority order, so making a generic "limit based on timestamp" service would have to scan the entire pending jobs list.

This is built on top of issue #2720.  It could be spliced out, but given the likely conflicts, just thought it'd be easier to build on top of it.