### PR TITLE
testsuite: fix possible hangs in rc3-job by loading sched-simple,job-exec modules by default

### DIFF
--- a/t/rc/rc1-job
+++ b/t/rc/rc1-job
@@ -3,8 +3,17 @@
 flux module load content-sqlite
 flux module load kvs
 flux exec -r all -x 0 flux module load kvs
+flux exec -r all flux module load aggregator
+flux hwloc reload & pids="$pids $!"
 
-flux exec -r all flux module load job-ingest
-flux exec -r all flux module load kvs-watch
-flux exec -r all flux module load job-info
+flux exec -r all flux module load job-ingest & pids="$pids $!"
+flux exec -r all flux module load kvs-watch & pids="$pids $!"
+flux exec -r all flux module load job-info & pids="$pids $!"
+flux exec -r all flux module load barrier & pids="$pids $!"
+
+wait $pids
+
 flux module load job-manager
+flux module load job-exec
+
+flux module load sched-simple

--- a/t/rc/rc1-job
+++ b/t/rc/rc1-job
@@ -1,15 +1,28 @@
 #!/bin/bash -e
 
+set_fake_hwloc_by_rank() {
+    cores=${1}
+    ranklist="0-$(($(flux getattr size) - 1))"
+    corelist="0-$((${cores} - 1))"
+    by_rank="{\"${ranklist}\":{\"Core\":${cores},\"cpuset\":\"${corelist}\"}}"
+    echo Setting fake by_rank="${by_rank}" >&2
+    flux kvs put resource.hwloc.by_rank="${by_rank}"
+}
+
 flux module load content-sqlite
 flux module load kvs
 flux exec -r all -x 0 flux module load kvs
-flux exec -r all flux module load aggregator
-flux hwloc reload & pids="$pids $!"
+flux exec -r all flux module load kvs-watch
+
 
 flux exec -r all flux module load job-ingest & pids="$pids $!"
-flux exec -r all flux module load kvs-watch & pids="$pids $!"
 flux exec -r all flux module load job-info & pids="$pids $!"
 flux exec -r all flux module load barrier & pids="$pids $!"
+
+# Load a fake resource.hwloc.by_rank key for sched-simple
+# (avoids requirement to run "flux hwloc reload")
+#
+(set_fake_hwloc_by_rank ${TEST_UNDER_FLUX_CORES_PER_RANK:-2}) & pids="$pids $1"
 
 wait $pids
 

--- a/t/rc/rc3-job
+++ b/t/rc/rc3-job
@@ -7,7 +7,6 @@ flux queue idle
 flux module remove -f job-exec
 flux module remove -f sched-simple
 flux module remove job-manager
-flux exec -r all flux module remove aggregator
 flux exec -r all flux module remove barrier
 flux exec -r all flux module remove job-info
 flux exec -r all flux module remove kvs-watch

--- a/t/rc/rc3-job
+++ b/t/rc/rc3-job
@@ -4,7 +4,11 @@ flux queue stop
 flux job cancelall -f --states RUN
 flux queue idle
 
+flux module remove -f job-exec
+flux module remove -f sched-simple
 flux module remove job-manager
+flux exec -r all flux module remove aggregator
+flux exec -r all flux module remove barrier
 flux exec -r all flux module remove job-info
 flux exec -r all flux module remove kvs-watch
 flux exec -r all flux module remove job-ingest

--- a/t/t2201-job-cmd.t
+++ b/t/t2201-job-cmd.t
@@ -18,8 +18,6 @@ MINJOBID_KVS="job.0000.0000.0000.0000"
 MINJOBID_HEX="0000.0000.0000.0000"
 MINJOBID_WORDS="academy-academy-academy--academy-academy-academy"
 
-hwloc_fake_config='{"0":{"Core":2,"cpuset":"0-1"}}'
-
 test_under_flux 1 job
 
 flux setattr log-stderr-level 1
@@ -566,7 +564,6 @@ test_expect_success 'flux-job: fatal cancel exception was raised' '
 '
 
 test_expect_success 'flux-job: load modules for live killall test' '
-	flux kvs put resource.hwloc.by_rank="$hwloc_fake_config" &&
         flux module load sched-simple &&
         flux module load job-exec
 '

--- a/t/t2201-job-cmd.t
+++ b/t/t2201-job-cmd.t
@@ -24,6 +24,11 @@ test_under_flux 1 job
 
 flux setattr log-stderr-level 1
 
+test_expect_success 'unload job-exec,sched-simple modules' '
+	flux module remove job-exec &&
+	flux module remove sched-simple
+'
+
 test_expect_success 'flux-job: generate jobspec for simple test job' '
         flux jobspec srun -n1 hostname >basic.json
 '
@@ -562,7 +567,6 @@ test_expect_success 'flux-job: fatal cancel exception was raised' '
 
 test_expect_success 'flux-job: load modules for live killall test' '
 	flux kvs put resource.hwloc.by_rank="$hwloc_fake_config" &&
-        flux exec -r all flux module load barrier &&
         flux module load sched-simple &&
         flux module load job-exec
 '
@@ -572,12 +576,6 @@ test_expect_success 'flux job: killall -f kills one job' '
         flux job wait-event $id start &&
         flux job killall -f &&
 	run_timeout 60 flux queue drain
-'
-
-test_expect_success 'flux job: unload modules' '
-        flux module remove job-exec &&
-        flux module remove sched-simple &&
-        flux exec -r all flux module remove barrier
 '
 
 test_done

--- a/t/t2204-job-info.t
+++ b/t/t2204-job-info.t
@@ -72,12 +72,10 @@ test_expect_success 'job-info: generate jobspec for simple test job' '
 
 hwloc_fake_config='{"0-3":{"Core":2,"cpuset":"0-1"}}'
 
-test_expect_success 'load job-exec,sched-simple modules' '
+test_expect_success 're-configure sched-simple module' '
         #  Add fake by_rank configuration to kvs:
         flux kvs put resource.hwloc.by_rank="$hwloc_fake_config" &&
-        flux exec -r all flux module load barrier &&
-        flux module load sched-simple &&
-        flux module load job-exec
+	flux module reload sched-simple
 '
 
 #
@@ -1175,14 +1173,4 @@ test_expect_success LONGTEST 'stress job-info.list-id' '
         flux python ${FLUX_SOURCE_DIR}/t/job-info/list-id.py 500 &&
         wait_jobs_finish
 '
-
-#
-# cleanup
-#
-test_expect_success 'remove sched-simple,job-exec modules' '
-        flux exec -r all flux module remove barrier &&
-        flux module remove sched-simple &&
-        flux module remove job-exec
-'
-
 test_done

--- a/t/t2204-job-info.t
+++ b/t/t2204-job-info.t
@@ -70,14 +70,6 @@ test_expect_success 'job-info: generate jobspec for simple test job' '
         flux jobspec --format json srun -N1 sleep 300 > sleeplong.json
 '
 
-hwloc_fake_config='{"0-3":{"Core":2,"cpuset":"0-1"}}'
-
-test_expect_success 're-configure sched-simple module' '
-        #  Add fake by_rank configuration to kvs:
-        flux kvs put resource.hwloc.by_rank="$hwloc_fake_config" &&
-	flux module reload sched-simple
-'
-
 #
 # job list tests
 #

--- a/t/t2205-job-info-security.t
+++ b/t/t2205-job-info-security.t
@@ -67,14 +67,6 @@ test_expect_success 'job-info: generate jobspec for simple test job' '
         flux jobspec --format json srun -N1 sleep 300 > sleeplong.json
 '
 
-hwloc_fake_config='{"0-1":{"Core":2,"cpuset":"0-1"}}'
-
-test_expect_success 'load fake scheduler resources' '
-        #  Add fake by_rank configuration to kvs:
-        flux kvs put resource.hwloc.by_rank="$hwloc_fake_config" &&
-        flux module reload sched-simple
-'
-
 #
 # job eventlog
 #

--- a/t/t2205-job-info-security.t
+++ b/t/t2205-job-info-security.t
@@ -69,11 +69,10 @@ test_expect_success 'job-info: generate jobspec for simple test job' '
 
 hwloc_fake_config='{"0-1":{"Core":2,"cpuset":"0-1"}}'
 
-test_expect_success 'load job-exec,sched-simple modules' '
+test_expect_success 'load fake scheduler resources' '
         #  Add fake by_rank configuration to kvs:
         flux kvs put resource.hwloc.by_rank="$hwloc_fake_config" &&
-        flux module load sched-simple &&
-        flux module load job-exec
+        flux module reload sched-simple
 '
 
 #
@@ -286,14 +285,6 @@ test_expect_success 'flux job info foobar fails (wrong user)' '
         set_userid 9999 &&
         ! flux job info $jobid foobar &&
         unset_userid
-'
-#
-# cleanup
-#
-
-test_expect_success 'remove sched-simple,job-exec modules' '
-        flux module remove sched-simple &&
-        flux module remove job-exec
 '
 
 test_done

--- a/t/t2300-sched-simple.t
+++ b/t/t2300-sched-simple.t
@@ -26,6 +26,9 @@ list_R() {
 	done
 }
 
+test_expect_success 'unload job-exec module to prevent job execution' '
+	flux module remove job-exec
+'
 test_expect_success 'sched-simple: reload ingest module with lax validator' '
 	flux exec -r all flux module reload job-ingest validator-args="--schema,${SCHEMA}" \
          validator=${JSONSCHEMA_VALIDATOR}
@@ -37,8 +40,8 @@ test_expect_success 'sched-simple: load default by_rank' '
 	flux kvs put resource.hwloc.by_rank="$(echo $hwloc_by_rank)" &&
 	flux kvs get resource.hwloc.by_rank
 '
-test_expect_success 'sched-simple: load sched-simple' '
-	flux module load sched-simple &&
+test_expect_success 'sched-simple: reload sched-simple' '
+	flux module reload sched-simple &&
 	flux dmesg 2>&1 | grep "ready:.*rank\[0-1\]/core\[0-1\]" &&
 	test "$($query)" = "rank[0-1]/core[0-1]"
 '
@@ -211,9 +214,4 @@ test_expect_success 'sched-simple: load sched-simple and wait for queue drain' '
 	flux module load sched-simple &&
 	run_timeout 30 flux queue drain
 '
-
-test_expect_success 'sched-simple: remove sched-simple' '
-	flux module remove sched-simple
-'
-
 test_done

--- a/t/t2301-schedutil-outstanding-requests.t
+++ b/t/t2301-schedutil-outstanding-requests.t
@@ -6,7 +6,6 @@ test_description='check for responses from sched to outstanding requests'
 
 test_under_flux 1 job
 
-hwloc_by_rank='{"0-1": {"Core": 2, "cpuset": "0-1"}}'
 RPC=${FLUX_BUILD_DIR}/t/request/rpc
 SCHED_DUMMY=${FLUX_BUILD_DIR}/t/job-manager/.libs/sched-dummy.so
 REQ_AND_UNLOAD="flux python ${SHARNESS_TEST_SRCDIR}/schedutil/req_and_unload.py"
@@ -26,11 +25,6 @@ test_expect_success 'schedutil: set bit to hang alloc/free requests' '
 
 test_expect_success 'schedutil: alloc/free fail with ENOSYS(38) after unload' '
     ${REQ_AND_UNLOAD} sched-dummy
-'
-
-test_expect_success 'schedutil: load default by_rank' '
-	flux kvs put resource.hwloc.by_rank="$(echo $hwloc_by_rank)" &&
-	flux kvs get resource.hwloc.by_rank
 '
 
 test_expect_success 'schedutil: successfully loaded sched-simple' '

--- a/t/t2301-schedutil-outstanding-requests.t
+++ b/t/t2301-schedutil-outstanding-requests.t
@@ -11,6 +11,11 @@ RPC=${FLUX_BUILD_DIR}/t/request/rpc
 SCHED_DUMMY=${FLUX_BUILD_DIR}/t/job-manager/.libs/sched-dummy.so
 REQ_AND_UNLOAD="flux python ${SHARNESS_TEST_SRCDIR}/schedutil/req_and_unload.py"
 
+test_expect_success 'schedutil: remove sched-simple,job-exec modules' '
+	flux module remove sched-simple &&
+	flux module remove job-exec
+'
+
 test_expect_success 'schedutil: load sched-dummy --cores=2' '
 	flux module load ${SCHED_DUMMY} --cores=2
 '

--- a/t/t2400-job-exec-test.t
+++ b/t/t2400-job-exec-test.t
@@ -18,8 +18,6 @@ fi
 
 RPC=${FLUX_BUILD_DIR}/t/request/rpc
 
-hwloc_fake_config='{"0-1":{"Core":2,"cpuset":"0-1"}}'
-
 job_kvsdir()    { flux job id --to=kvs $1; }
 exec_eventlog() { flux kvs get -r $(job_kvsdir $1).guest.exec.eventlog; }
 exec_test()     { ${jq} '.attributes.system.exec.test = {}'; }
@@ -30,11 +28,6 @@ exec_testattr() {
 
 test_expect_success 'job-exec: generate jobspec for simple test job' '
         flux jobspec srun -n1 hostname | exec_test > basic.json
-'
-test_expect_success 'job-exec: reload sched-simple with fake resources' '
-	#  Add fake by_rank configuration to kvs:
-	flux kvs put resource.hwloc.by_rank="$hwloc_fake_config" &&
-	flux module reload sched-simple
 '
 test_expect_success 'job-exec: basic job runs in simulated mode' '
 	jobid=$(flux job submit basic.json) &&

--- a/t/t2400-job-exec-test.t
+++ b/t/t2400-job-exec-test.t
@@ -31,11 +31,10 @@ exec_testattr() {
 test_expect_success 'job-exec: generate jobspec for simple test job' '
         flux jobspec srun -n1 hostname | exec_test > basic.json
 '
-test_expect_success 'job-exec: load job-exec,sched-simple modules' '
+test_expect_success 'job-exec: reload sched-simple with fake resources' '
 	#  Add fake by_rank configuration to kvs:
 	flux kvs put resource.hwloc.by_rank="$hwloc_fake_config" &&
-	flux module load sched-simple &&
-	flux module load job-exec
+	flux module reload sched-simple
 '
 test_expect_success 'job-exec: basic job runs in simulated mode' '
 	jobid=$(flux job submit basic.json) &&
@@ -121,9 +120,4 @@ test_expect_success 'job-exec: exception during cleanup' '
 test_expect_success 'start request with empty payload fails with EPROTO(71)' '
 	${RPC} job-exec.start 71 </dev/null
 '
-test_expect_success 'job-exec: remove sched-simple,job-exec modules' '
-	flux module remove sched-simple &&
-	flux module remove job-exec
-'
-
 test_done

--- a/t/t2400-job-exec-test.t
+++ b/t/t2400-job-exec-test.t
@@ -106,7 +106,7 @@ test_expect_success 'job-exec: exception during cleanup' '
 	jobid=$(flux job submit cleanup-long.json) &&
 	flux job wait-event -vt 2.5 ${jobid} finish &&
 	flux job cancel ${jobid} &&
-	flux job wait-event -t 2.5 ${jobid} clean &&
+	flux job wait-event -t 10 ${jobid} clean &&
 	exec_eventlog $jobid > exec.eventlog.$jobid &&
 	grep "cleanup\.finish" exec.eventlog.$jobid
 '

--- a/t/t2401-job-exec-hello.t
+++ b/t/t2401-job-exec-hello.t
@@ -12,10 +12,14 @@ execservice=${SHARNESS_TEST_SRCDIR}/job-manager/exec-service.lua
 
 lastevent() { flux job eventlog $1 | awk 'END{print $2}'; }
 
-test_expect_success 'exec hello: load sched-simple module' '
+test_expect_success 'exec hello: remove job-exec module' '
+	flux module remove job-exec
+'
+
+test_expect_success 'exec hello: reload sched-simple module with fake resources' '
 	#  Add fake by_rank configuration to kvs:
 	flux kvs put resource.hwloc.by_rank="$hwloc_fake_config" &&
-	flux module load sched-simple
+	flux module reload sched-simple
 '
 test_expect_success NO_CHAIN_LINT 'exec hello: start exec server-in-a-script' '
 	${execservice} test-exec > server1.log &
@@ -64,9 +68,6 @@ test_expect_success NO_CHAIN_LINT 'exec hello: terminate all jobs and servers' '
 	test_debug "cat server3.log" &&
 	flux job wait-event -t 2.5 ${id} clean &&
 	kill ${SERVER3}
-'
-test_expect_success 'job-exec: remove sched-simple module' '
-	flux module remove sched-simple
 '
 
 test_done

--- a/t/t2401-job-exec-hello.t
+++ b/t/t2401-job-exec-hello.t
@@ -7,19 +7,12 @@ test_description='Test flux job exec hello protocol with multiple providers'
 test_under_flux 1 job
 
 flux setattr log-stderr-level 1
-hwloc_fake_config='{"0-1":{"Core":2,"cpuset":"0-1"}}'
 execservice=${SHARNESS_TEST_SRCDIR}/job-manager/exec-service.lua
 
 lastevent() { flux job eventlog $1 | awk 'END{print $2}'; }
 
 test_expect_success 'exec hello: remove job-exec module' '
 	flux module remove job-exec
-'
-
-test_expect_success 'exec hello: reload sched-simple module with fake resources' '
-	#  Add fake by_rank configuration to kvs:
-	flux kvs put resource.hwloc.by_rank="$hwloc_fake_config" &&
-	flux module reload sched-simple
 '
 test_expect_success NO_CHAIN_LINT 'exec hello: start exec server-in-a-script' '
 	${execservice} test-exec > server1.log &

--- a/t/t2402-job-exec-dummy.t
+++ b/t/t2402-job-exec-dummy.t
@@ -19,11 +19,10 @@ hwloc_fake_config='{"0-3":{"Core":2,"cpuset":"0-1"}}'
 job_kvsdir()    { flux job id --to=kvs $1; }
 exec_eventlog() { flux kvs get -r $(job_kvsdir $1).guest.exec.eventlog; }
 
-test_expect_success 'job-exec: load job-exec,sched-simple modules' '
+test_expect_success 'job-exec: reload sched-simple with fake resources' '
 	#  Add fake by_rank configuration to kvs:
 	flux kvs put resource.hwloc.by_rank="$hwloc_fake_config" &&
-	flux module load sched-simple &&
-	flux module load job-exec
+	flux module reload sched-simple
 '
 test_expect_success 'job-exec: set dummy test job shell' '
 	flux setattr job-exec.job-shell $SHARNESS_TEST_SRCDIR/job-exec/dummy.sh
@@ -103,11 +102,5 @@ test_expect_success 'job-exec: exception while starting terminates job' '
 	     | $jq ".attributes.system.exec.bulkexec.mock_exception = \"starting\"" \
 	     | flux job submit) &&
 	flux job wait-event -vt 1 $id clean
-'
-test_expect_success 'job-exec: unload job-exec & sched-simple modules' '
-	flux job list &&
-	flux queue drain &&
-	flux module remove job-exec &&
-	flux module remove sched-simple
 '
 test_done

--- a/t/t2402-job-exec-dummy.t
+++ b/t/t2402-job-exec-dummy.t
@@ -14,16 +14,9 @@ test_under_flux 4 job
 
 flux setattr log-stderr-level 1
 
-hwloc_fake_config='{"0-3":{"Core":2,"cpuset":"0-1"}}'
-
 job_kvsdir()    { flux job id --to=kvs $1; }
 exec_eventlog() { flux kvs get -r $(job_kvsdir $1).guest.exec.eventlog; }
 
-test_expect_success 'job-exec: reload sched-simple with fake resources' '
-	#  Add fake by_rank configuration to kvs:
-	flux kvs put resource.hwloc.by_rank="$hwloc_fake_config" &&
-	flux module reload sched-simple
-'
 test_expect_success 'job-exec: set dummy test job shell' '
 	flux setattr job-exec.job-shell $SHARNESS_TEST_SRCDIR/job-exec/dummy.sh
 '

--- a/t/t2602-job-shell.t
+++ b/t/t2602-job-shell.t
@@ -12,13 +12,6 @@ PMI_INFO=${FLUX_BUILD_DIR}/src/common/libpmi/test_pmi_info
 KVSTEST=${FLUX_BUILD_DIR}/src/common/libpmi/test_kvstest
 LPTEST=${SHARNESS_TEST_DIRECTORY}/shell/lptest
 
-hwloc_fake_config='{"0-3":{"Core":2,"cpuset":"0-1"}}'
-
-test_expect_success 'job-shell: reload sched-simple with fake resources' '
-        #  Add fake by_rank configuration to kvs:
-        flux kvs put resource.hwloc.by_rank="$hwloc_fake_config" &&
-        flux module reload sched-simple
-'
 test_expect_success 'job-shell: execute across all ranks' '
         id=$(flux jobspec srun -N4 bash -c \
             "flux kvs put test1.\$FLUX_TASK_RANK=\$FLUX_TASK_LOCAL_ID" \

--- a/t/t2602-job-shell.t
+++ b/t/t2602-job-shell.t
@@ -14,12 +14,10 @@ LPTEST=${SHARNESS_TEST_DIRECTORY}/shell/lptest
 
 hwloc_fake_config='{"0-3":{"Core":2,"cpuset":"0-1"}}'
 
-test_expect_success 'job-shell: load barrier,job-exec,sched-simple modules' '
+test_expect_success 'job-shell: reload sched-simple with fake resources' '
         #  Add fake by_rank configuration to kvs:
         flux kvs put resource.hwloc.by_rank="$hwloc_fake_config" &&
-        flux exec -r all flux module load barrier &&
-        flux module load sched-simple &&
-        flux module load job-exec
+        flux module reload sched-simple
 '
 test_expect_success 'job-shell: execute across all ranks' '
         id=$(flux jobspec srun -N4 bash -c \
@@ -211,10 +209,4 @@ test_expect_success 'job-shell: shell kill event: kill(2) failure logged' '
 	grep "signal 199: Invalid argument" kill5.log &&
 	grep status=$((15+128<<8)) kill5.finish.out
 '
-test_expect_success 'job-shell: unload job-exec & sched-simple modules' '
-        flux module remove job-exec &&
-        flux module remove sched-simple &&
-        flux exec -r all flux module remove barrier
-'
-
 test_done

--- a/t/t2606-job-shell-output-redirection.t
+++ b/t/t2606-job-shell-output-redirection.t
@@ -12,12 +12,10 @@ TEST_SUBPROCESS_DIR=${FLUX_BUILD_DIR}/src/common/libsubprocess
 
 hwloc_fake_config='{"0-3":{"Core":2,"cpuset":"0-1"}}'
 
-test_expect_success 'job-shell: load barrier,job-exec,sched-simple modules' '
+test_expect_success 'job-shell: reload sched-simple module with fake resources' '
         #  Add fake by_rank configuration to kvs:
         flux kvs put resource.hwloc.by_rank="$hwloc_fake_config" &&
-        flux exec -r all flux module load barrier &&
-        flux module load sched-simple &&
-        flux module load job-exec
+        flux module reload sched-simple
 '
 
 #
@@ -326,11 +324,4 @@ test_expect_success NO_CHAIN_LINT 'job-shell: job attach waits if no kvs output 
         flux job cancel $id &&
         ! wait $pid
 '
-
-test_expect_success 'job-shell: unload job-exec & sched-simple modules' '
-        flux module remove job-exec &&
-        flux module remove sched-simple &&
-        flux exec -r all flux module remove barrier
-'
-
 test_done

--- a/t/t2606-job-shell-output-redirection.t
+++ b/t/t2606-job-shell-output-redirection.t
@@ -10,14 +10,6 @@ flux setattr log-stderr-level 1
 
 TEST_SUBPROCESS_DIR=${FLUX_BUILD_DIR}/src/common/libsubprocess
 
-hwloc_fake_config='{"0-3":{"Core":2,"cpuset":"0-1"}}'
-
-test_expect_success 'job-shell: reload sched-simple module with fake resources' '
-        #  Add fake by_rank configuration to kvs:
-        flux kvs put resource.hwloc.by_rank="$hwloc_fake_config" &&
-        flux module reload sched-simple
-'
-
 #
 # 1 task output file tests
 #

--- a/t/t2607-job-shell-input.t
+++ b/t/t2607-job-shell-input.t
@@ -13,12 +13,10 @@ LPTEST=${SHARNESS_TEST_DIRECTORY}/shell/lptest
 
 hwloc_fake_config='{"0-3":{"Core":2,"cpuset":"0-1"}}'
 
-test_expect_success 'job-shell: load barrier,job-exec,sched-simple modules' '
+test_expect_success 'job-shell: reload sched-simple module with fake resources' '
         #  Add fake by_rank configuration to kvs:
         flux kvs put resource.hwloc.by_rank="$hwloc_fake_config" &&
-        flux exec -r all flux module load barrier &&
-        flux module load sched-simple &&
-        flux module load job-exec
+        flux module reload sched-simple
 '
 
 test_expect_success 'flux-shell: generate input for stdin input tests' '
@@ -256,12 +254,4 @@ test_expect_success 'flux-shell: no fatal exception after stdin sent to exited t
 	echo | flux job attach -XE ${id} &&
 	flux job wait-event -t 5 -v ${id} clean
 '
-
-test_expect_success 'job-shell: unload job-exec & sched-simple modules' '
-        flux module remove job-exec &&
-        flux module remove sched-simple &&
-        flux exec -r all flux module remove barrier
-'
-
-
 test_done

--- a/t/t2607-job-shell-input.t
+++ b/t/t2607-job-shell-input.t
@@ -11,14 +11,6 @@ flux setattr log-stderr-level 1
 TEST_SUBPROCESS_DIR=${FLUX_BUILD_DIR}/src/common/libsubprocess
 LPTEST=${SHARNESS_TEST_DIRECTORY}/shell/lptest
 
-hwloc_fake_config='{"0-3":{"Core":2,"cpuset":"0-1"}}'
-
-test_expect_success 'job-shell: reload sched-simple module with fake resources' '
-        #  Add fake by_rank configuration to kvs:
-        flux kvs put resource.hwloc.by_rank="$hwloc_fake_config" &&
-        flux module reload sched-simple
-'
-
 test_expect_success 'flux-shell: generate input for stdin input tests' '
        echo "foo" > input_stdin_file &&
        echo "doh" >> input_stdin_file &&

--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -393,16 +393,6 @@ for d in ${ISSUES_DIR}/*; do
 done
 
 #
-# cleanup
+# leave job cleanup to rc3
 #
-test_expect_success 'cleanup job listing jobs ' '
-        for jobid in `cat job_ids_pending.out`; do \
-            flux job cancel $jobid; \
-            flux job wait-event $jobid clean; \
-        done &&
-        for jobid in `cat job_ids_running.out`; do \
-            flux job cancel $jobid; \
-            flux job wait-event $jobid clean; \
-        done
-'
 test_done

--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -13,12 +13,10 @@ test_under_flux 4 job
 
 hwloc_fake_config='{"0-3":{"Core":2,"cpuset":"0-1"}}'
 
-test_expect_success 'load job-exec,sched-simple modules' '
+test_expect_success 'reload sched-simple module with fake resources' '
         #  Add fake by_rank configuration to kvs:
         flux kvs put resource.hwloc.by_rank="$hwloc_fake_config" &&
-        flux exec -r all flux module load barrier &&
-        flux module load sched-simple &&
-        flux module load job-exec
+        flux module reload sched-simple
 '
 
 # submit a whole bunch of jobs for job list testing
@@ -407,11 +405,4 @@ test_expect_success 'cleanup job listing jobs ' '
             flux job wait-event $jobid clean; \
         done
 '
-
-test_expect_success 'remove sched-simple,job-exec modules' '
-        flux exec -r all flux module remove barrier &&
-        flux module remove sched-simple &&
-        flux module remove job-exec
-'
-
 test_done

--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -11,14 +11,6 @@ test -n "$jq" && test_set_prereq HAVE_JQ
 
 test_under_flux 4 job
 
-hwloc_fake_config='{"0-3":{"Core":2,"cpuset":"0-1"}}'
-
-test_expect_success 'reload sched-simple module with fake resources' '
-        #  Add fake by_rank configuration to kvs:
-        flux kvs put resource.hwloc.by_rank="$hwloc_fake_config" &&
-        flux module reload sched-simple
-'
-
 # submit a whole bunch of jobs for job list testing
 #
 # - the first loop of job submissions are intended to have some jobs run


### PR DESCRIPTION
This addresses issue #2739 by essentially allowing the job-exec and sched-simple modules to be loaded in `rc3-job` when `flux job cancelall -f --states RUN` is executed, so the command is able to actually terminate jobs in RUN state, avoiding a subsequent hang in `flux queue idle`.

All modules required for job execution are now loaded in the "job" `test_under_flux` personality, which long-term is probably less confusing. For the few tests that require no `job-exec` module because they need jobs to enter the RUN state without actually running, this module is removed.

One small cleanup to `t2800-job-cmd.t` was added here as well. Since jobs are terminated in `rc3-job` now, the "cleanup" section of the test was removed.