### PR TITLE
broker: fix a problem bootstrapping under openpmix PMI-1 compat library

### DIFF
--- a/src/broker/pmiutil.h
+++ b/src/broker/pmiutil.h
@@ -14,7 +14,7 @@
 struct pmi_params {
     int rank;
     int size;
-    char kvsname[64];
+    char kvsname[1024];
 };
 
 struct pmi_handle;


### PR DESCRIPTION
This PR gets around an apparent incompatibility with openpmix's PMI compat library by increasing the PMI kvsname buffer size used in the broker.

Edit: dropped flux-pfoxy(1) since @dongahn already submitted it as a separate PR.