### PR TITLE
python: improve interface to flux.job functions with Future and RPC subclasses

### DIFF
--- a/src/bindings/python/flux/job.py
+++ b/src/bindings/python/flux/job.py
@@ -23,6 +23,7 @@ from flux import constants
 from flux.wrapper import Wrapper
 from flux.util import check_future_error, parse_fsd
 from flux.future import Future
+from flux.rpc import RPC
 from _flux._core import ffi, lib
 
 try:
@@ -234,6 +235,11 @@ def wait(flux_handle, jobid=lib.FLUX_JOBID_ANY):
     return future.get_status()
 
 
+class JobListRPC(RPC):
+    def get_jobs(self):
+        return self.get()["jobs"]
+
+
 # Due to subtleties in the python bindings and this call, this binding
 # is more of a reimplementation of flux_job_list() instead of calling
 # the flux_job_list() C function directly.  Some reasons:
@@ -249,7 +255,7 @@ def job_list(flux_handle, max_entries=0, attrs=[], userid=os.geteuid(), states=0
         "userid": userid,
         "states": states,
     }
-    return flux_handle.rpc("job-info.list", payload)
+    return JobListRPC(flux_handle, "job-info.list", payload)
 
 
 def job_list_get(rpc_handle):

--- a/src/bindings/python/flux/job.py
+++ b/src/bindings/python/flux/job.py
@@ -258,10 +258,6 @@ def job_list(flux_handle, max_entries=0, attrs=[], userid=os.geteuid(), states=0
     return JobListRPC(flux_handle, "job-info.list", payload)
 
 
-def job_list_get(rpc_handle):
-    return rpc_handle.get()["jobs"]
-
-
 def _validate_keys(expected, given, keys_optional=False, allow_additional=False):
     if not isinstance(expected, set):
         expected = set(expected)

--- a/src/cmd/flux-jobs.py
+++ b/src/cmd/flux-jobs.py
@@ -193,7 +193,7 @@ def fetch_jobs_flux(args):
 
     rpc_handle = flux.job.job_list(h, args.count, attrs, userid, states)
     try:
-        jobs = flux.job.job_list_get(rpc_handle)
+        jobs = rpc_handle.get_jobs()
     except EnvironmentError as e:
         print("{}: {}".format("rpc", e.strerror), file=sys.stderr)
         sys.exit(1)


### PR DESCRIPTION
As described in #2730, this PR subclasses the return values of some of the functions exported by `flux.job` for ease of use:

 * `job.wait_async()` returns `JobWaitFuture` with a custom `get_status()` getter
 * `job.submit_async()` returns `SubmitFuture` with a custom `get_id()` getter
 * `job.job_list` returns `JobListRPC` with a custom `get_jobs()` getter

(BTW, listing these above I notice the incongruity between the `job.` functions here. Should we rename `job.job_list` to `job.list()`?

In the case of `wait_async()` and `submit_async()`, the old functions `wait_get_status()` and `submit_get_id()` are retained since they've been around awhile.

For `job.job_list()` the `job_list_get()` function is removed after `flux-jobs.py` is updated.

Fixes #2730