### PR TITLE
bash: top level command completions for flux

### DIFF
--- a/etc/Makefile.am
+++ b/etc/Makefile.am
@@ -32,6 +32,8 @@ endif
 clean-local:
 	-rm -rf flux
 
+CLEANFILES=completions/flux
+
 if WITH_PKG_CONFIG
 pkgconfig_DATA = flux-core.pc \
 	flux-pmi.pc \
@@ -40,5 +42,20 @@ pkgconfig_DATA = flux-core.pc \
 	flux-schedutil.pc
 endif
 
+noinst_SCRIPTS = \
+	completions/get_builtins.sh \
+	completions/flux.pre
+
 EXTRA_DIST = \
-	gen-cmdhelp.py
+	gen-cmdhelp.py \
+	$(noinst_SCRIPTS)
+
+completions/flux: $(srcdir)/completions/flux.pre
+	$(AM_V_GEN)test -d completions || mkdir completions && \
+	cp $< $@ && chmod +w $@ && \
+	$(srcdir)/completions/get_builtins.sh \
+	$(top_srcdir)/src/cmd/builtin >> $@
+
+fluxcompdir = $(sysconfdir)/bash_completion.d
+fluxcomp_SCRIPTS = \
+	completions/flux

--- a/etc/completions/flux.pre
+++ b/etc/completions/flux.pre
@@ -1,0 +1,64 @@
+#
+# Copyright 2020 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+#
+shopt -s extglob
+
+_flux_core()
+{
+    OIFS=$IFS
+    local cur prev opts
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+    __get_compopts
+
+    IFS=$OIFS
+    opts=$compopts
+
+    if [[ "${prev##*/}" == "flux" ]]; then
+        case "${cur}" in
+            @(-*))
+                COMPREPLY=( $(compgen -W "--help" -- "${cur}") )
+                ;;
+            *)
+                COMPREPLY=( $(compgen -W "${opts}" "${cur}") )
+                ;;
+        esac
+    else
+        case "${prev}" in
+        !(-h|--help|help))
+            COMPREPLY=( $(compgen -W "--help" -- "${cur}") )
+            ;;
+        esac
+    fi
+
+    return 0
+}
+
+__get_compopts() {
+    if [ -z $FLUX_EXEC_PATH ]; then
+        FLUX_EXEC_PATH=`flux env printenv FLUX_EXEC_PATH`
+    fi
+
+    IFS=":"
+    for op in $FLUX_EXEC_PATH/*; do
+        if [[ -x $op && "${op##*/}" == "flux-"* ]]; then
+            op="${op##*-}"
+            compopts+="${op%.*} "
+        fi
+    done
+
+    for builtin in $FLUX_BUILTINS; do
+        compopts+="$builtin "
+    done
+}
+
+complete -F _flux_core flux
+

--- a/etc/completions/get_builtins.sh
+++ b/etc/completions/get_builtins.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+#
+# Copyright 2020 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+#
+
+get_builtins() {
+    local FLUX_BUILTINS
+
+    builtin_path=$1
+
+    for builtin in $builtin_path/*; do
+        if [[ $builtin == *".c" && \
+              $builtin != *"attr"* ]]; then
+            builtin="${builtin%.*}"
+            FLUX_BUILTINS+="${builtin##*/}:"
+        fi
+    done
+
+    while read line; do
+        if [[ $line == *"optparse_reg_subcommand"* \
+              && $line == *"attr"* ]]; then
+             line="${line##*_}"
+            FLUX_BUILTINS+="${line%,*}:"
+        fi
+    done < $builtin_path/attr.c
+
+    echo FLUX_BUILTINS="$FLUX_BUILTINS"
+}
+
+get_builtins $1


### PR DESCRIPTION
This is a work in progress pr. It provides command completion for the top-level commands for flux-core in bash. This feature was requested in issue #1647. It still needs to be integrated into the makefile to be properly installed. For now, the completions can be sourced directly from flux-core/etc/completions/flux-core. 