### PR TITLE
shell: Update exit code for special cases

### DIFF
--- a/t/t2608-job-shell-log.t
+++ b/t/t2608-job-shell-log.t
@@ -133,10 +133,18 @@ for topic in "shell.init" "shell.exit" \
 done
 
 test_expect_success 'flux-shell: missing command logs fatal error' '
-	test_expect_code 1 flux mini run nosuchcommand 2>missing.err &&
+	test_expect_code 127 flux mini run nosuchcommand 2>missing.err &&
 	grep "flux-shell\[0\]: FATAL: task 0: start failed" missing.err &&
 	grep "job.exception type=exec severity=0 task 0: start failed" missing.err &&
         grep "No such file or directory" missing.err
+'
+
+test_expect_success 'flux-shell: illegal command logs fatal error' '
+	mkdir adirectory &&
+	test_expect_code 126 flux mini run ./adirectory 2>illegal.err &&
+	grep "flux-shell\[0\]: FATAL: task 0: start failed" illegal.err &&
+	grep "job.exception type=exec severity=0 task 0: start failed" illegal.err &&
+	grep "Permission denied" illegal.err
 '
 
 test_expect_success 'flux-shell: bad cwd emits message, but completes' '


### PR DESCRIPTION
Per discussion in #2752, quick fix to handle special case exit codes in the job shell.