### PR TITLE
broker: log dropped responses sent down TBON

### DIFF
--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -76,9 +76,6 @@
 #include "boot_pmi.h"
 #include "publisher.h"
 
-/* Generally accepted max, although some go higher (IE is 2083) */
-#define ENDPOINT_MAX 2048
-
 typedef enum {
     ERROR_MODE_RESPOND,
     ERROR_MODE_RETURN,

--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -490,6 +490,7 @@ static int bind_child (overlay_t *ov, struct endpoint *ep)
     }
     if (child_monitor_init (ov, ep) < 0)
         return -1;
+    zsock_set_router_mandatory (ep->zs, 1);
     if (zsecurity_ssockinit (ov->sec, ep->zs) < 0) {
         log_msg ("zsecurity_ssockinit: %s", zsecurity_errstr (ov->sec));
         return -1;

--- a/src/common/libsubprocess/server.c
+++ b/src/common/libsubprocess/server.c
@@ -199,7 +199,6 @@ static void rexec_state_change_cb (flux_subprocess_t *p,
                                "pid", flux_subprocess_pid (p),
                                "state", state) < 0) {
             flux_log_error (rex->s->h, "%s: flux_respond_pack", __FUNCTION__);
-            goto error;
         }
     } else if (state == FLUX_SUBPROCESS_EXITED) {
         if (flux_respond_pack (rex->s->h, rex->msg, "{s:s s:i s:i s:i}",
@@ -208,7 +207,6 @@ static void rexec_state_change_cb (flux_subprocess_t *p,
                                "state", state,
                                "status", flux_subprocess_status (p)) < 0) {
             flux_log_error (rex->s->h, "%s: flux_respond_pack", __FUNCTION__);
-            goto error;
         }
     } else if (state == FLUX_SUBPROCESS_FAILED) {
         if (flux_respond_pack (rex->s->h, rex->msg, "{s:s s:i s:i s:i}",
@@ -217,7 +215,6 @@ static void rexec_state_change_cb (flux_subprocess_t *p,
                                "state", FLUX_SUBPROCESS_FAILED,
                                "errno", p->failed_errno) < 0) {
             flux_log_error (rex->s->h, "%s: flux_respond_pack", __FUNCTION__);
-            goto error;
         }
         subprocess_cleanup (p);
     } else {

--- a/src/modules/job-ingest/Makefile.am
+++ b/src/modules/job-ingest/Makefile.am
@@ -19,7 +19,8 @@ job_ingest_la_SOURCES = \
 	validate.c \
 	validate.h \
 	worker.c \
-	worker.h
+	worker.h \
+	types.h
 
 job_ingest_la_LDFLAGS = $(fluxmod_ldflags) -module
 job_ingest_la_LIBADD = $(fluxmod_libadd) \

--- a/src/modules/job-ingest/types.h
+++ b/src/modules/job-ingest/types.h
@@ -1,0 +1,20 @@
+/************************************************************\
+ * Copyright 2020 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _JOB_INGEST_TYPES_H
+#define _JOB_INGEST_TYPES_H
+
+typedef void (*process_exit_f)(void *arg);
+
+#endif /* !_JOB_INGEST_TYPES_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/job-ingest/validate.c
+++ b/src/modules/job-ingest/validate.c
@@ -86,6 +86,17 @@ static void validate_killall (struct validate *v)
     flux_future_destroy (cf);
 }
 
+int validate_stop_notify (struct validate *v, process_exit_f cb, void *arg)
+{
+    int i;
+    int count;
+
+    count = 0;
+    for (i = 0; i < MAX_WORKER_COUNT; i++)
+        count += worker_stop_notify (v->worker[i], cb, arg);
+    return count;
+}
+
 void validate_destroy (struct validate *v)
 {
     if (v) {

--- a/src/modules/job-ingest/validate.h
+++ b/src/modules/job-ingest/validate.h
@@ -13,12 +13,20 @@
 
 #include <flux/core.h>
 
+#include "types.h"
+
 struct validate *v;
 
 /* Submit jobspec ('buf, 'len') for validation.
  * Future is fulfilled once validation is complete.
  */
 flux_future_t *validate_jobspec (struct validate *v, const char *buf, int len);
+
+/* Tell validators to stop.
+ * Return a count of running processes.
+ * If nonzero, arrange for callback to be called each time a process exits.
+ */
+int validate_stop_notify (struct validate *v, process_exit_f cb, void *arg);
 
 struct validate *validate_create (flux_t *h,
                                   const char *validate_path,

--- a/src/modules/job-ingest/worker.h
+++ b/src/modules/job-ingest/worker.h
@@ -13,7 +13,10 @@
 
 #include <flux/core.h>
 
+#include "types.h"
+
 struct worker;
+
 
 flux_future_t *worker_request (struct worker *w, const char *s);
 
@@ -26,6 +29,12 @@ struct worker *worker_create (flux_t *h, double inactivity_timeout,
                               const char *worker_name,
                               int argc, char **argv);
 
+
+/* Tell worker to stop.
+ * Return a count of running processes.
+ * If nonzero, arrange for callback to be called each time a process exits.
+ */
+int worker_stop_notify (struct worker *w, process_exit_f cb, void *arg);
 
 #endif /* !_JOB_INGEST_VALIDATE_H */
 


### PR DESCRIPTION
(peeled off of #2733)

As discussed in #2751, his PR adds the zeromq ROUTER_MANDATORY flag to the ROUTER socket used to communicate with downstream (towards the leaves) TBON peers.  The this changes how the socket handles messages addressed to peers that are not connected.  Before, they would be silently dropped.  Now they cause an error that we can log. 

There is also some cleanup of the broker functions used to route messages, which had gotten a little crufty over time (or maybe weren't that great from the start).

Finally, since this change now logs errors for some expected loose response messages from the exec service following `job-ingest` validator cleanup, I added some code to try to stop validators by giving them an EOF on stdin and collect their completion info, under a 5s timeout.  If the timeout expires, it falls back to signaling the validators and exiting before exec completion is verified.

All this cleanup was motivated by the search for hangs in #2733.  One theory was that loose messages flying around during teardown might be the culprit, but another culprit was found.  Therefore this PR is no longer part of #2733 and should be viewed as more of a "cleanup, and prepare for more broker work" sort of change - low priority since it doesn't really "fix" anything.