### PR TITLE
Several minor fixes

### DIFF
--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -248,6 +248,7 @@ static int event_unsubscribe (kvs_ctx_t *ctx, const char *ns)
 {
     char *setroot_topic = NULL;
     char *error_topic = NULL;
+    char *removed_topic = NULL;
     int rc = -1;
 
     if (asprintf (&setroot_topic, "kvs.setroot-%s", ns) < 0) {
@@ -270,10 +271,21 @@ static int event_unsubscribe (kvs_ctx_t *ctx, const char *ns)
         goto cleanup;
     }
 
+    if (asprintf (&removed_topic, "kvs.namespace-removed-%s", ns) < 0) {
+        errno = ENOMEM;
+        goto cleanup;
+    }
+
+    if (flux_event_subscribe (ctx->h, removed_topic) < 0) {
+        flux_log_error (ctx->h, "flux_event_subscribe");
+        goto cleanup;
+    }
+
     rc = 0;
 cleanup:
     free (setroot_topic);
     free (error_topic);
+    free (removed_topic);
     return rc;
 }
 

--- a/t/sharness.d/flux-sharness.sh
+++ b/t/sharness.d/flux-sharness.sh
@@ -120,6 +120,10 @@ test_under_flux() {
         # Set log_path for ASan o/w errors from broker may be lost
         ASAN_OPTIONS=${ASAN_OPTIONS}:log_path=${TEST_NAME}.asan
     fi
+    # Extend timeouts if job personality, job cleanup can take awhile
+    if test -z "${gracetime}" -a "$personality" = "job"; then
+        gracetime="-o,-g,10"
+    fi
     logopts="-o -Slog-filename=${log_file},-Slog-forward-level=7"
     TEST_UNDER_FLUX_ACTIVE=t \
     TERM=${ORIGINAL_TERM} \


### PR DESCRIPTION
minor fixes per #2762, #2764

- i forgot to unsubscribe the `kvs.namespace-removed-NS` event in the kvs.

- increase grace-timeout for job personality tests, in `t2800-job-cmd`, there's quite a few jobs running at the end of file, so rc3 is taking a bit too long sometimes.