### PR TITLE
testsuite: fix tests when run as a job and disable MPI tests by default

### DIFF
--- a/src/test/travis_run.sh
+++ b/src/test/travis_run.sh
@@ -102,7 +102,7 @@ export FLUX_TEST_SIZE_MAX=5
 if test -f /usr/share/Modules/init/bash; then
     . /usr/share/Modules/init/bash && module load mpi
 fi
-export TEST_MPI=t
+export FLUX_TEST_MPI=t
 
 # Generate logfiles from sharness tests for extra information:
 export FLUX_TESTS_LOGFILE=t

--- a/t/sharness.d/flux-sharness.sh
+++ b/t/sharness.d/flux-sharness.sh
@@ -178,5 +178,10 @@ else
     test_set_prereq NO_ASAN
 fi
 
+# Sanitize PMI_* environment for all tests. This allows commands like
+#  `flux broker` in tests to boot as singleton even when run under a
+#  job of an existing RM.
+for var in $(env | grep ^PMI); do unset ${var//=*}; done
+for var in $(env | grep ^SLURM); do unset ${var//=*}; done
 
 # vi: ts=4 sw=4 expandtab

--- a/t/t3000-mpi-basic.t
+++ b/t/t3000-mpi-basic.t
@@ -5,6 +5,11 @@ test_description='Test that Flux can launch MPI'
 
 . `dirname $0`/sharness.sh
 
+if test -z "$FLUX_TEST_MPI"; then
+    skip_all='skipping MPI tests, FLUX_TEST_MPI not set'
+    test_done
+fi
+
 if ! test -x ${FLUX_BUILD_DIR}/t/mpi/hello; then
     skip_all='skipping MPI tests, MPI not available/configured'
     test_done


### PR DESCRIPTION
This fixes the testsuite when under under Slurm/Flux job as described in #2749.

I found a simpler approach than the patch described there. All `PMI_*` and `SLURM_*` environment variables are scrubbed at the beginning of each test by `flux-sharness.sh`.
This is more future proof than attempting to ensure `flux start` is always run with `-s1` or `--bootstrap=selfpmi`. Additionally, it works with `flux broker` which doesn't provide a way to force singleton mode.

Additionally, the MPI tests in t3001-mpi-basic.t are not disabled by default. 

This is WIP because, while `make check` seems to be reliable within a Slurm job, there are still some tests that fail when run as a Flux job.

However, when it does work you can do this fun thing:
```
$ srun -N16 --pty --mpi=none --mpibind=off  \
   ../src/cmd/flux start  prove -j 64 --merge --timer --exec 'flux mini run bash' *.t
[07:56:59] t2004-hydra.t .................................... skipped: skipping hydra-launching-flux tests, mpiexec.hydra unavailable
[07:56:59] t2007-caliper.t .................................. skipped: skipping Caliper tests, Flux not built with Caliper support
[07:56:59] t0016-cron-faketime.t ............................ skipped: libfaketime not found. Skipping all tests
[07:57:00] t2600-job-shell-rcalc.t .......................... ok        2 ms
[07:57:00] t0013-config-file.t .............................. ok        1 ms
[07:57:00] t0008-attr.t ..................................... ok        1 ms
[07:57:01] t1102-cmddriver.t ................................ ok        2 ms
[07:57:01] t3000-mpi-basic.t ................................ skipped: skipping MPI tests, FLUX_TEST_MPI not set
[07:57:01] t0009-dmesg.t .................................... ok        3 ms
[07:57:01] t0000-sharness.t ................................. ok        4 ms
[07:57:02] t2301-schedutil-outstanding-requests.t ........... ok     1264 ms
[07:57:02] t1008-kvs-eventlog.t ............................. ok        1 ms
[07:57:02] t1101-barrier-basic.t ............................ ok      143 ms
[07:57:02] t1103-apidisconnect.t ............................ ok        2 ms
[07:57:02] t0010-generic-utils.t ............................ ok        5 ms
[07:57:02] t0002-request.t .................................. ok        5 ms
[07:57:02] t1009-kvs-copy.t ................................. ok        4 ms
[07:57:02] t0014-runlevel.t ................................. ok        1 ms
[07:57:02] t0022-jj-reader.t ................................ ok        4 ms
[07:57:03] t1005-kvs-security.t ............................. ok        8 ms
[07:57:03] t2401-job-exec-hello.t ........................... ok     2078 ms
[07:57:03] t2005-hwloc-basic.t .............................. ok        4 ms
[07:57:03] t0003-module.t ................................... ok      907 ms
[07:57:03] t2605-job-shell-output-redirection-standalone.t .. ok        2 ms
[07:57:03] t0004-event.t .................................... ok        2 ms
[07:57:03] t2210-job-manager-bugs.t ......................... ok        1 ms
[07:57:03] t0017-security.t ................................. ok     3171 ms
[07:57:03] t2603-job-shell-initrc.t ......................... ok        3 ms
[07:57:04] t2010-kvs-snapshot-restore.t ..................... ok        1 ms
[07:57:04] t1105-proxy.t .................................... ok        3 ms
[07:57:04] t0005-rexec.t .................................... ok     3592 ms
[07:57:04] t2203-job-manager-dummysched.t ................... ok        3 ms
[07:57:04] t0005-exec.t ..................................... ok     3903 ms
[07:57:04] t2609-job-shell-events.t ......................... ok        1 ms
[07:57:04] t9001-pymod.t .................................... ok       17 ms
[07:57:05] t1106-ssh-connector.t ............................ ok        2 ms
[07:57:05] t2400-job-exec-test.t ............................ ok     4219 ms
[07:57:05] t2206-job-manager-bulk-state.t ................... ok        0 ms
[07:57:05] t2208-queue-cmd.t ................................ ok        5 ms
[07:57:05] t2202-job-manager.t .............................. ok        5 ms
[07:57:05] t0007-ping.t ..................................... ok        2 ms
[07:57:06] t2201-job-cmd.t .................................. ok     5250 ms
[07:57:06] t2500-job-attach.t ............................... ok        2 ms
[07:57:06] t2610-job-shell-mpir.t ........................... ok        1 ms
[07:57:06] t0011-content-cache.t ............................ ok        2 ms
[07:57:06] t2608-job-shell-log.t ............................ ok     3207 ms
[07:57:06] t0012-content-sqlite.t ........................... ok        2 ms
[07:57:06] t2601-job-shell-standalone.t ..................... ok        3 ms
[07:57:07] t3001-mpi-personalities.t ........................ ok        1 ms
[07:57:07] t0015-cron.t ..................................... ok        3 ms
[07:57:07] t2604-job-shell-affinity.t ....................... ok     4692 ms
[07:57:07] t2402-job-exec-dummy.t ........................... ok     6904 ms
[07:57:07] t2008-althash.t .................................. ok        1 ms
[07:57:08] t2300-sched-simple.t ............................. ok     7785 ms
[07:57:08] t2100-aggregate.t ................................ ok     2747 ms
[07:57:09] t2607-job-shell-input.t .......................... ok     8145 ms
[07:57:09] t2700-mini-cmd.t ................................. ok        3 ms
[07:57:09] t2207-job-manager-wait.t ......................... ok        2 ms
[07:57:09] t1004-kvs-namespace.t ............................ ok        4 ms
[07:57:09] t2606-job-shell-output-redirection.t ............. ok     9124 ms
[07:57:10] t2602-job-shell.t ................................ ok    10028 ms
[07:57:10] t3100-flux-in-flux.t ............................. ok        0 ms
[07:57:11] t2205-job-info-security.t ........................ ok    10726 ms
[07:57:12] t2200-job-ingest.t ............................... ok    11601 ms
[07:57:12] t1001-kvs-internals.t ............................ ok     8392 ms
[07:57:13] t2800-jobs-cmd.t ................................. ok    11573 ms
[07:57:15] t1007-kvs-lookup-watch.t ......................... ok        3 ms
[07:57:15] t4000-issues-test-driver.t ....................... ok    11148 ms
[07:57:15] t1000-kvs.t ...................................... ok     6331 ms
[07:57:17] t0021-flux-jobspec.t ............................. ok        2 ms
[07:57:25] t1003-kvs-stress.t ............................... ok        1 ms
[07:57:25] t0019-jobspec-schema.t ........................... ok        3 ms
[07:57:31] t2204-job-info.t ................................. ok    30997 ms
[07:57:31] t0001-basic.t .................................... ok       18 ms
[07:57:31] t5000-valgrind.t ................................. ok        0 ms
[07:57:32]
All tests successful.
Files=75, Tests=1989, 35 wallclock secs ( 0.39 usr  0.08 sys +  8.01 cusr  3.27 csys = 11.75 CPU)
Result: PASS
```