### PR TITLE
python: rename job.job_list to job.list

### DIFF
--- a/src/bindings/python/flux/job.py
+++ b/src/bindings/python/flux/job.py
@@ -248,7 +248,7 @@ class JobListRPC(RPC):
 # - Desired return value is json array, not a single value
 #
 # pylint: disable=dangerous-default-value
-def job_list(flux_handle, max_entries=0, attrs=[], userid=os.geteuid(), states=0):
+def list(flux_handle, max_entries=0, attrs=[], userid=os.geteuid(), states=0):
     payload = {
         "max_entries": max_entries,
         "attrs": attrs,

--- a/src/cmd/flux-jobs.py
+++ b/src/cmd/flux-jobs.py
@@ -238,7 +238,7 @@ def fetch_jobs_flux(args):
         states |= flux.constants.FLUX_JOB_PENDING
         states |= flux.constants.FLUX_JOB_RUNNING
 
-    rpc_handle = flux.job.job_list(h, args.count, attrs, userid, states)
+    rpc_handle = flux.job.list(h, args.count, attrs, userid, states)
     try:
         jobs = rpc_handle.get_jobs()
     except EnvironmentError as e:


### PR DESCRIPTION
Thought I'd throw this one up even though it isn't too impactful. But if we're going to rename methods better do it sooner rather than later before there are users outside of the project.

It slightly bothered me that `flux.job.job_list()` didn't follow the naming convention of `flux.job.wait()` and `flux.job.submit()`. Since only `flux-jobs.py` is a user of the method, the change to `flux.job.list()` is trivial for now.

If the name didn't bother anyone else, I'm also fine retracting this PR. I just thought I'd give it a shot.