### PR TITLE
cmd: add flux-job status command to get job completion status

### DIFF
--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -107,6 +107,7 @@ TESTSCRIPTS = \
 	t2401-job-exec-hello.t \
 	t2402-job-exec-dummy.t \
 	t2500-job-attach.t \
+	t2501-job-status.t \
 	t2600-job-shell-rcalc.t \
 	t2601-job-shell-standalone.t \
 	t2602-job-shell.t \

--- a/t/t2501-job-status.t
+++ b/t/t2501-job-status.t
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+test_description='Test flux job status'
+
+. $(dirname $0)/sharness.sh
+
+test_under_flux 2 job
+
+test_expect_success 'status: submit a series of jobs' '
+	zero=$(flux mini submit /bin/true) &&
+	one=$(flux mini submit /bin/false) &&
+	sigint=$(flux mini submit sh -c "kill -INT \$$") &&
+	shell_sigquit=$(flux mini submit sh -c "kill -QUIT \$PPID")
+'
+test_expect_success 'status: exits with error with no jobs specified' '
+	test_expect_code 1 flux job status
+'
+test_expect_success 'status: returns status 0 for successful job' '
+	run_timeout 10 flux job status ${zero}
+'
+test_expect_success 'status: returns status 1 for failed job' '
+	test_expect_code 1 flux job status ${one}
+'
+test_expect_success 'status: returns status 130 for SIGINT job' '
+	test_expect_code 130 flux job status -v ${sigint}
+'
+test_expect_success 'status: returns status 130 for SIGINT job' '
+	test_expect_code 130 flux job status -v ${sigint}
+'
+test_expect_success 'status: returns status 131 when job-shell gets SIGQUIT' '
+	test_expect_code 131 flux job status -v ${shell_sigquit}
+'
+test_expect_success 'status: returns highest status for multiple jobs' '
+	test_expect_code 130 flux job status -vv ${zero} ${one} ${sigint}
+'
+test_expect_success 'status: fails expectedly on non-existent job' '
+	test_expect_code 1 flux job status 123
+'
+test_done


### PR DESCRIPTION
In a recent meeting a question was brought up about how to get the completion status of jobs without having to do `flux job attach JOBID >/dev/null 2>&1`.

This PR adds a new `flux job status` command which fetches the `finish` event for one or more JOBIDs listed on the command line, exiting with the highest exit status over all listed jobs. This is much more heavyweight than `flux job wait`, but can be run on non-waitable jobs, or jobs on which the wait status has already been reaped from the job-manager. It is meant simply as an alternative to `flux job attach` when the user doesn't want to also dump all job output/logs/etc.

Since the command uses `flux_job_event_watch()` internally, `flux job status ID` can be run on jobs in any state. The command will return only after all listed JOBIDs have posted a `finish` event.