### PR TITLE
speed up Flux instance initialization (rc1) and make it more reliable under valgrind

### DIFF
--- a/etc/rc1
+++ b/etc/rc1
@@ -2,6 +2,9 @@
 
 pids=""
 
+# Allow connector-local more time to start listening on socket in rc1 only
+export FLUX_LOCAL_CONNECTOR_RETRY_COUNT=10
+
 flux exec -r all flux module load barrier
 
 flux module load content-sqlite

--- a/etc/rc1
+++ b/etc/rc1
@@ -1,33 +1,43 @@
 #!/bin/bash -e
 
-pids=""
+# Usage: wait_check pid [pid ...]
+wait_check() {
+    local pid
+    for pid in $*; do wait $pid; done
+}
 
 # Allow connector-local more time to start listening on socket in rc1 only
 export FLUX_LOCAL_CONNECTOR_RETRY_COUNT=10
 
-flux exec -r all flux module load barrier
+declare -a pids
+flux exec -r all flux module load barrier & pids+=($!)
+flux module load content-sqlite & pids+=($!)
+flux exec -r all flux module load aggregator & pids+=($!)
+wait_check ${pids[@]}
+unset pids
 
-flux module load content-sqlite
-
+declare -a pids
 flux module load kvs
-flux exec -r all -x 0 flux module load kvs
-flux exec -r all flux module load kvs-watch
+flux exec -r all -x 0 flux module load kvs & pids+=($!)
+flux exec -r all flux module load kvs-watch & pids+=($!)
+wait_check ${pids[@]}
+unset pids
 
-flux exec -r all flux module load job-info
-flux exec -r all flux module load aggregator
+declare -a pids
+flux hwloc reload & pids+=($!)
+flux exec -r all flux module load job-info & pids+=($!)
+flux exec -r all flux module load job-ingest & pids+=($!)
+flux module load cron sync=hb & pids+=($!)
+flux module load userdb ${FLUX_USERDB_OPTIONS} & pids+=($!)
+flux module load job-manager & pids+=($!)
+wait_check ${pids[@]}
+unset pids
 
-flux hwloc reload & pids="$pids $!"
-
-flux module load cron sync=hb
-
-flux module load userdb ${FLUX_USERDB_OPTIONS}
-
-flux exec -r all flux module load job-ingest
-flux module load job-manager
-flux module load job-exec
-flux module load sched-simple
-
-wait $pids
+declare -a pids
+flux module load job-exec &  pids+=($!)
+flux module load sched-simple & pids+=($!)
+wait_check ${pids[@]}
+unset pids
 
 core_dir=$(cd ${0%/*} && pwd -P)
 all_dirs=$core_dir${FLUX_RC_EXTRA:+":$FLUX_RC_EXTRA"}

--- a/t/t5000-valgrind.t
+++ b/t/t5000-valgrind.t
@@ -35,7 +35,6 @@ VALGRIND_WORKLOAD=${SHARNESS_TEST_SRCDIR}/valgrind/valgrind-workload.sh
 BROKER=${FLUX_BUILD_DIR}/src/broker/flux-broker
 
 VALGRIND_NBROKERS=${VALGRIND_NBROKERS:-2}
-VALGRIND_SHUTDOWN_GRACE=${VALGRIND_SHUTDOWN_GRACE:-16}
 
 test_expect_success \
   "valgrind reports no new errors on $VALGRIND_NBROKERS broker run" '
@@ -52,7 +51,6 @@ test_expect_success \
 		--wrap=--leak-resolution=med \
 		--wrap=--error-exitcode=1 \
 		--wrap=--suppressions=$VALGRIND_SUPPRESSIONS \
-		-o,--shutdown-grace=${VALGRIND_SHUTDOWN_GRACE} \
 		 ${VALGRIND_WORKLOAD}
 '
 test_done

--- a/t/t5000-valgrind.t
+++ b/t/t5000-valgrind.t
@@ -34,8 +34,6 @@ VALGRIND_SUPPRESSIONS=${SHARNESS_TEST_SRCDIR}/valgrind/valgrind.supp
 VALGRIND_WORKLOAD=${SHARNESS_TEST_SRCDIR}/valgrind/valgrind-workload.sh
 BROKER=${FLUX_BUILD_DIR}/src/broker/flux-broker
 
-# broker run under valgrind may need extra retries in flux_open():
-export FLUX_LOCAL_CONNECTOR_RETRY_COUNT=10
 VALGRIND_NBROKERS=${VALGRIND_NBROKERS:-2}
 VALGRIND_SHUTDOWN_GRACE=${VALGRIND_SHUTDOWN_GRACE:-16}
 


### PR DESCRIPTION
This PR contains some simple changes to `rc1` to do some of its work in parallel (as worked out by @grondo in #2771).  It also increases the `flux_open()` timeout in `rc1` since some timing changes in PR #2733 make timing out more likely than before, especially under valgrind.

Drop the grace period and open timeout tunings from the valgrind sharness test, as these should no longer be necessary.