### PR TITLE
kvs: eliminate per-job namespace event subscriptions on rank 0

### DIFF
--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -211,30 +211,24 @@ static int event_subscribe (kvs_ctx_t *ctx, const char *ns)
     }
 
     if (ctx->rank != 0) {
-        if (asprintf (&setroot_topic, "kvs.setroot-%s", ns) < 0) {
-            errno = ENOMEM;
+        if (asprintf (&setroot_topic, "kvs.setroot-%s", ns) < 0)
             goto cleanup;
-        }
 
         if (flux_event_subscribe (ctx->h, setroot_topic) < 0) {
             flux_log_error (ctx->h, "flux_event_subscribe");
             goto cleanup;
         }
 
-        if (asprintf (&error_topic, "kvs.error-%s", ns) < 0) {
-            errno = ENOMEM;
+        if (asprintf (&error_topic, "kvs.error-%s", ns) < 0)
             goto cleanup;
-        }
 
         if (flux_event_subscribe (ctx->h, error_topic) < 0) {
             flux_log_error (ctx->h, "flux_event_subscribe");
             goto cleanup;
         }
 
-        if (asprintf (&removed_topic, "kvs.namespace-removed-%s", ns) < 0) {
-            errno = ENOMEM;
+        if (asprintf (&removed_topic, "kvs.namespace-removed-%s", ns) < 0)
             goto cleanup;
-        }
 
         if (flux_event_subscribe (ctx->h, removed_topic) < 0) {
             flux_log_error (ctx->h, "flux_event_subscribe");
@@ -258,30 +252,24 @@ static int event_unsubscribe (kvs_ctx_t *ctx, const char *ns)
     int rc = -1;
 
     if (ctx->rank != 0) {
-        if (asprintf (&setroot_topic, "kvs.setroot-%s", ns) < 0) {
-            errno = ENOMEM;
+        if (asprintf (&setroot_topic, "kvs.setroot-%s", ns) < 0)
             goto cleanup;
-        }
 
         if (flux_event_unsubscribe (ctx->h, setroot_topic) < 0) {
             flux_log_error (ctx->h, "flux_event_subscribe");
             goto cleanup;
         }
 
-        if (asprintf (&error_topic, "kvs.error-%s", ns) < 0) {
-            errno = ENOMEM;
+        if (asprintf (&error_topic, "kvs.error-%s", ns) < 0)
             goto cleanup;
-        }
 
         if (flux_event_unsubscribe (ctx->h, error_topic) < 0) {
             flux_log_error (ctx->h, "flux_event_subscribe");
             goto cleanup;
         }
 
-        if (asprintf (&removed_topic, "kvs.namespace-removed-%s", ns) < 0) {
-            errno = ENOMEM;
+        if (asprintf (&removed_topic, "kvs.namespace-removed-%s", ns) < 0)
             goto cleanup;
-        }
 
         if (flux_event_subscribe (ctx->h, removed_topic) < 0) {
             flux_log_error (ctx->h, "flux_event_subscribe");
@@ -2423,10 +2411,8 @@ static int namespace_create (kvs_ctx_t *ctx, const char *ns,
         goto cleanup;
     }
 
-    if (asprintf (&topic, "kvs.namespace-created-%s", ns) < 0) {
-        errno = ENOMEM;
+    if (asprintf (&topic, "kvs.namespace-created-%s", ns) < 0)
         goto cleanup;
-    }
 
     if (!(msg = flux_event_pack (topic,
                                  "{ s:s s:i s:s s:i }",

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -188,17 +188,9 @@ static int event_subscribe (kvs_ctx_t *ctx, const char *ns)
         /* These belong to all namespaces, subscribe once the first
          * time we init a namespace */
 
-        if (flux_event_subscribe (ctx->h, "hb") < 0) {
-            flux_log_error (ctx->h, "flux_event_subscribe");
-            goto cleanup;
-        }
-
-        if (flux_event_subscribe (ctx->h, "kvs.stats.clear") < 0) {
-            flux_log_error (ctx->h, "flux_event_subscribe");
-            goto cleanup;
-        }
-
-        if (flux_event_subscribe (ctx->h, "kvs.dropcache") < 0) {
+        if (flux_event_subscribe (ctx->h, "hb") < 0
+            || flux_event_subscribe (ctx->h, "kvs.stats.clear") < 0
+            || flux_event_subscribe (ctx->h, "kvs.dropcache") < 0) {
             flux_log_error (ctx->h, "flux_event_subscribe");
             goto cleanup;
         }

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -240,6 +240,7 @@ static int event_unsubscribe (kvs_ctx_t *ctx, const char *ns)
 {
     char *setroot_topic = NULL;
     char *error_topic = NULL;
+    char *removed_topic = NULL;
     int rc = -1;
 
     if (asprintf (&setroot_topic, "kvs.setroot-%s", ns) < 0) {
@@ -262,10 +263,21 @@ static int event_unsubscribe (kvs_ctx_t *ctx, const char *ns)
         goto cleanup;
     }
 
+    if (asprintf (&removed_topic, "kvs.namespace-removed-%s", ns) < 0) {
+        errno = ENOMEM;
+        goto cleanup;
+    }
+
+    if (flux_event_subscribe (ctx->h, removed_topic) < 0) {
+        flux_log_error (ctx->h, "flux_event_subscribe");
+        goto cleanup;
+    }
+
     rc = 0;
 cleanup:
     free (setroot_topic);
     free (error_topic);
+    free (removed_topic);
     return rc;
 }
 


### PR DESCRIPTION
Per discussion in #2727.  I'll just throw up my commit message here:

```
    On rank 0, we have to subscribe to all events on all KVS namespaces,
    as rank 0 must have knowledge of all KVS namespaces.  On the other
    hand, workers only need to know about the KVS namespaces that
    callers are using on that rank.
    
    To improve KVS namespace create performance, subscribe to all KVS
    namespaces on rank 0 once on initialization, instead of subscribing
    to each KVS namespace as it is created.  On workers, subscribe
    to only the KVS namespaces that are necessary.
```

Also threw in a fix for #2762 