### PR TITLE
add KVS checkpoints

### DIFF
--- a/doc/man7/flux-broker-attributes.adoc
+++ b/doc/man7/flux-broker-attributes.adoc
@@ -40,17 +40,6 @@ the session. By default broker.rundir is set to "${rundir}/${rank}",
 which guarantees a unique directory per rank.  It is not advisable
 to override this attribute on the command line. Use rundir instead.
 
-persist-directory::
-A persistent directory available for storage on rank 0 only.
-If persist-directory is not defined, persistence is unavailable
-and users should fall back to broker.rundir, with cleanup.
-
-persist-filesystem::
-If defined, and persist-directory is not defined, the rank
-0 broker chooses a unique name for persist-directory within
-persist-filesystem and creates it automatically.
-
-
 TOPOLOGY ATTRIBUTES
 -------------------
 tbon.arity::
@@ -115,8 +104,7 @@ to stderr on the logging rank, for capture by the enclosing instance.
 
 log-filename::
 (rank zero only) If set, session log entries, as filtered by log-forward-level,
-are directed to this file.  If unset, but persist-directory is set, log
-entries are directed to persist-directory/log.
+are directed to this file.
 
 log-stderr-level::
 (rank zero only) Session log entries at syslog(3) level at or below this

--- a/doc/man7/flux-broker-attributes.adoc
+++ b/doc/man7/flux-broker-attributes.adoc
@@ -40,6 +40,13 @@ the session. By default broker.rundir is set to "${rundir}/${rank}",
 which guarantees a unique directory per rank.  It is not advisable
 to override this attribute on the command line. Use rundir instead.
 
+content.backing-path::
+The path to the content backing store file(s).  If this is set on the
+broker command line, the backing store uses this path instead of
+a temporary one, and content is preserved on instance exit.
+If file exists, its content is imported into the instance.
+If it doesn't exist, it is created.
+
 TOPOLOGY ATTRIBUTES
 -------------------
 tbon.arity::

--- a/etc/rc3
+++ b/etc/rc3
@@ -32,4 +32,5 @@ flux exec -r all flux module remove -f kvs-watch
 flux exec -r all -x 0 flux module remove -f kvs
 
 flux module remove -f kvs
+flux content flush
 flux module remove -f content-sqlite

--- a/etc/rc3
+++ b/etc/rc3
@@ -21,10 +21,6 @@ flux module remove -f job-exec
 flux module remove -f job-manager
 flux exec -r all flux module remove -f job-ingest
 
-if PERSISTDIR=$(flux getattr persist-directory 2>/dev/null); then
-    /bin/true; # XXX: nothing to persist?
-fi
-
 flux module remove -f userdb
 
 flux module remove -f cron
@@ -34,10 +30,6 @@ flux exec -r all flux module remove -f barrier
 flux exec -r all flux module remove -f job-info
 flux exec -r all flux module remove -f kvs-watch
 flux exec -r all -x 0 flux module remove -f kvs
-if test -n "$PERSISTDIR"; then
-    flux kvs getroot >${PERSISTDIR}/kvsroot.final
-    flux content flush
-fi
+
 flux module remove -f kvs
 flux module remove -f content-sqlite
-

--- a/src/broker/log.c
+++ b/src/broker/log.c
@@ -411,26 +411,12 @@ done:
 
 static int logbuf_register_attrs (logbuf_t *logbuf, attr_t *attrs)
 {
-    char s[PATH_MAX];
-    const char *val;
     int rc = -1;
 
     /* log-filename
      * Only allowed to be set on rank 0 (ignore initial value on rank > 0).
-     * If unset, and persist-directory is set, make it ${persist-directory}/log
      */
     if (logbuf->rank == 0) {
-        if (attr_get (attrs, "log-filename", NULL, NULL) < 0
-          && attr_get (attrs, "persist-directory", &val, NULL) == 0 && val) {
-            if (snprintf (s, sizeof (s), "%s/log", val) >= sizeof (s)) {
-                log_err ("log-filename truncated");
-                goto done;
-            }
-            if (attr_add (attrs, "log-filename", s, 0) < 0) {
-                log_err ("could not initialize log-filename");
-                goto done;
-            }
-        }
         if (attr_add_active (attrs, "log-filename", 0,
                              attr_get_log, attr_set_log, logbuf) < 0)
             goto done;

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -228,6 +228,7 @@ check_PROGRAMS = \
 	kvs/issue1876 \
 	kvs/waitcreate_cancel \
 	kvs/setrootevents \
+	kvs/checkpoint \
 	request/treq \
 	request/rpc \
 	barrier/tbarrier \
@@ -391,6 +392,11 @@ kvs_waitcreate_cancel_LDADD = \
 kvs_setrootevents_SOURCES = kvs/setrootevents.c
 kvs_setrootevents_CPPFLAGS = $(test_cppflags)
 kvs_setrootevents_LDADD = \
+	$(test_ldadd) $(LIBDL) $(LIBUTIL)
+
+kvs_checkpoint_SOURCES = kvs/checkpoint.c
+kvs_checkpoint_CPPFLAGS = $(test_cppflags)
+kvs_checkpoint_LDADD = \
 	$(test_ldadd) $(LIBDL) $(LIBUTIL)
 
 request_treq_SOURCES = request/treq.c

--- a/t/kvs/checkpoint.c
+++ b/t/kvs/checkpoint.c
@@ -1,0 +1,80 @@
+/************************************************************\
+ * Copyright 2020 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdio.h>
+#include <flux/core.h>
+#include "src/common/libutil/log.h"
+
+void usage (void)
+{
+    fprintf (stderr, "Usage: checkpoint get key\n"
+                     "   or: checkpoint put key value\n");
+    exit (1);
+}
+
+int main (int argc, char **argv)
+{
+    flux_t *h;
+    const char *cmd;
+    const char *key;
+    const char *value;
+    flux_future_t *f;
+
+    if (argc < 2 || argc > 4)
+        usage ();
+    cmd = argv[1];
+    key = argv[2];
+    if (argc == 4)
+        value = argv[3];
+    if (strcmp (cmd, "get") != 0 && strcmp (cmd, "put") != 0)
+        usage ();
+
+    if (!(h = flux_open (NULL, 0)))
+        log_err_exit ("flux_open");
+
+    if (!strcmp (cmd, "put")) {
+        if (!(f = flux_rpc_pack (h,
+                                 "kvs-checkpoint.put",
+                                 0,
+                                 0,
+                                 "{s:s s:s}",
+                                 "key",
+                                 key,
+                                 "value",
+                                 value)))
+            log_err_exit("flux_rpc");
+        if (flux_rpc_get (f, NULL) < 0)
+            log_err_exit ("%s", key);
+    }
+    else {
+        if (!(f = flux_rpc_pack (h,
+                                 "kvs-checkpoint.get",
+                                 0,
+                                 0,
+                                 "{s:s}",
+                                 "key",
+                                 key)))
+            log_err_exit("flux_rpc");
+        if (flux_rpc_get_unpack (f, "{s:s}", "value", &value) < 0)
+            log_err_exit ("%s", key);
+        printf ("%s\n", value);
+    }
+
+    flux_future_destroy (f);
+    flux_close (h);
+    return 0;
+}
+
+/*
+ * vi: ts=4 sw=4 expandtab
+ */

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -207,32 +207,6 @@ test_expect_success 'rundir override creates nonexistent dirs' '
 	flux start ${ARGS} -o,--setattr=rundir=$RUNDIR sh -c "test -d $RUNDIR" &&
 	test_expect_code 1 test -d $RUNDIR
 '
-test_expect_success 'broker persist-directory works' '
-	PERSISTDIR=`mktemp -d` &&
-	flux start ${ARGS} -o,--setattr=persist-directory=$PERSISTDIR /bin/true &&
-	test -d $PERSISTDIR &&
-	test `ls -1 $PERSISTDIR|wc -l` -gt 0 &&
-	rm -rf $PERSISTDIR
-'
-test_expect_success 'broker persist-filesystem works' '
-	PERSISTFS=`mktemp -d` &&
-	PERSISTDIR=`flux start ${ARGS} -o,--setattr=persist-filesystem=$PERSISTFS flux getattr persist-directory` &&
-	test -d $PERSISTDIR &&
-	test `ls -1 $PERSISTDIR|wc -l` -gt 0 &&
-	rm -rf $PERSISTDIR &&
-	test -d $PERSISTFS &&
-	rmdir $PERSISTFS
-'
-test_expect_success 'broker persist-filesystem is ignored if persist-directory set' '
-	PERSISTFS=`mktemp -d` &&
-	PERSISTDIR=`mktemp -d` &&
-	DIR=`flux start ${ARGS} -o,--setattr=persist-filesystem=$PERSISTFS,--setattr=persist-directory=$PERSISTDIR \
-		flux getattr persist-directory` &&
-	test "$DIR" = "$PERSISTDIR" &&
-	test `ls -1 $PERSISTDIR|wc -l` -gt 0 &&
-	rmdir $PERSISTFS &&
-	rm -rf $PERSISTDIR
-'
 # Use -eq hack to test that BROKERPID is a number
 test_expect_success 'broker broker.pid attribute is readable' '
 	BROKERPID=`flux start ${ARGS} flux getattr broker.pid` &&

--- a/t/t2010-kvs-snapshot-restore.t
+++ b/t/t2010-kvs-snapshot-restore.t
@@ -7,4 +7,56 @@ test_description='Test KVS snapshot/restore'
 test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
 . `dirname $0`/sharness.sh
 
+test_under_flux 1
+
+CHECKPOINT=${FLUX_BUILD_DIR}/t/kvs/checkpoint
+
+test_expect_success 'store kvs-checkpoint key-val pairs' '
+	$CHECKPOINT put foo bar &&
+	$CHECKPOINT put foo2 42 &&
+	$CHECKPOINT put foo3 "x x x"
+'
+
+test_expect_success 'verify kvs-checkpoint key-val pairs' '
+	test "$($CHECKPOINT get foo)" = "bar" &&
+	test "$($CHECKPOINT get foo2)" = "42" &&
+	test "$($CHECKPOINT get foo3)" = "x x x"
+'
+
+test_expect_success 'get unknown kvs-checkpoint key fails' '
+	test_must_fail $CHECKPOINT get noexist
+'
+
+test_expect_success 'put existing kvs-checkpoint key is allowed' '
+	$CHECKPOINT put foo zzz
+'
+
+test_expect_success 'kvs-checkpoint value was updated' '
+	test $($CHECKPOINT get foo) = "zzz"
+'
+
+test_expect_success 'empty kvs-checkpoint key is not allowed' '
+	test_must_fail $CHECKPOINT put "" xyz
+'
+
+test_expect_success 'run instance with content.backing-path set' '
+	flux start -o,--setattr=content.backing-path=$(pwd)/content.sqlite \
+	           flux kvs put testkey=42
+'
+
+test_expect_success 'content.sqlite file exists after instance exited' '
+	test -f content.sqlite &&
+	echo Size in bytes: $(stat --format "%s" content.sqlite)
+'
+
+test_expect_success 're-run instance with content.backing-path set' '
+	flux start -o,--setattr=content.backing-path=$(pwd)/content.sqlite \
+	           flux kvs get testkey >get.out
+'
+
+test_expect_success 'content from previous instance survived' '
+	echo 42 >get.exp &&
+	test_cmp get.exp get.out
+'
+
 test_done

--- a/t/t2010-kvs-snapshot-restore.t
+++ b/t/t2010-kvs-snapshot-restore.t
@@ -1,41 +1,10 @@
 #!/bin/sh
 #
 
-test_description='Test loading KVS snapshot from earlier instance
-
-Test recovery of KVS snapshot from persistdir.'
+test_description='Test KVS snapshot/restore'
 
 # Append --logfile option if FLUX_TESTS_LOGFILE is set in environment:
 test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
 . `dirname $0`/sharness.sh
-
-
-test_expect_success 'created persist-directory' '
-	PERSISTDIR=$(mktemp -d --tmpdir=$(pwd))
-'
-
-test_expect_success 'run instance with persist-directory set' '
-	rm -f $PERSISTDIR/kvsroot.final &&
-	flux start -o,--setattr=persist-directory=$PERSISTDIR \
-	           flux kvs put testkey=42
-'
-
-test_expect_success 'sqlite file exists in persist-directory' '
-	test -f $PERSISTDIR/content/sqlite &&
-	echo Size in bytes: $(stat --format "%s" $PERSISTDIR/content/sqlite)
-'
-
-test_expect_success 'kvsroot.final file exists in persist-directory' '
-	test -f $PERSISTDIR/kvsroot.final
-'
-
-test_expect_success 'recover KVS snapshot from persist-directory in new instance' '
-	run_timeout 60 \
-	    flux start -o,--setattr=persist-directory=$PERSISTDIR \
-	        "flux kvs put --treeobj snap=- <$PERSISTDIR/kvsroot.final && \
-		    flux kvs get snap.testkey >testkey.out" &&
-	echo 42 >testkey.exp &&
-	test_cmp testkey.exp testkey.out
-'
 
 test_done


### PR DESCRIPTION
Thought I'd park this although it needs further work.

This adds a table to the content-sqlite database that can store arbitrary key-value pairs, then modifies the KVS to read its root blobref from this table (if available) during startup, and write its final root blobref during shutdown.  In the future, the table could accommodate multiple keys for live namespaces if we want to go that way (but right now we don't need to support that).

If an instance has the `content.backing-path` attribute set to the path to a sqlite file when the content-sqlite module is loaded, then it is used (existing content preserved).  If it is set but the file does not exist, it is created empty, and retained on exit.

The net result is the systemd unit file _could_ set this attribute to say `/var/lib/flux/content.sqlite` and then the KVS is preserved across service restarts.

I got rid of the `persist-filesystem` and `persist-directory` attributes.  Hopefully they will not be missed.

Couple loose ends
* If the hash method changes (from sha1 to sha256 say) this is not handled
* Need to check but I think sha256 hash digests are being truncated to sha1 size right now in the backing store, which would be a big gaping security hole for multi-user
* Maybe it would be nice to have control over "restart" behavior independent of the path setting
* Ultimately this should be handled via config not attributes, but this was easier to get launched
* More testing required