### PR TITLE
libutil/cleanup: improve out of memory handling, conform to RFC 7

### DIFF
--- a/src/common/libutil/cleanup.c
+++ b/src/common/libutil/cleanup.c
@@ -13,7 +13,6 @@
 #endif /* HAVE_CONFIG_H */
 
 #include "cleanup.h"
-#include "xzmalloc.h"
 #include "unlink_recursive.h"
 
 #include <stdio.h>
@@ -96,7 +95,9 @@ void cleanup_push (cleaner_fun_f *fun, void *arg)
 
 void cleanup_push_string (cleaner_fun_f *fun, const char *path)
 {
-    cleanup_push (fun, xstrdup (path));
+    char *cpy = strdup (path);
+    if (cpy)
+        cleanup_push (fun, cpy);
 }
 
 /*

--- a/src/common/libutil/cleanup.c
+++ b/src/common/libutil/cleanup.c
@@ -85,11 +85,14 @@ void cleanup_push (cleaner_fun_f *fun, void *arg)
         cleaner_pid = getpid ();
         atexit (cleanup_run);
     }
+    /* Ignore error, no way to return it to caller anyway... */
     struct cleaner *c = calloc (sizeof (struct cleaner), 1);
-    c->fun = fun;
-    c->arg = arg;
-    /* Ignore return code, no way to return it to caller anyway... */
-    (void)zlist_push (cleanup_list, c);
+    if (c) {
+        c->fun = fun;
+        c->arg = arg;
+        if (zlist_push (cleanup_list, c) < 0)
+            free (c);
+    }
     pthread_mutex_unlock (&mutex);
 }
 

--- a/src/common/libutil/cleanup.c
+++ b/src/common/libutil/cleanup.c
@@ -25,10 +25,12 @@
 #include <czmq.h>
 
 static pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
+static pid_t cleaner_pid = 0;
+static zlist_t *cleanup_list = NULL;
 
 struct cleaner {
-    cleaner_fun_f * fun;
-    void * arg;
+    cleaner_fun_f *fun;
+    void *arg;
 };
 
 void cleanup_directory_recursive (const struct cleaner *c)
@@ -40,63 +42,61 @@ void cleanup_directory_recursive (const struct cleaner *c)
 void cleanup_directory (const struct cleaner *c)
 {
     if(c && c->arg)
-        rmdir(c->arg);
+        rmdir (c->arg);
 }
 
 void cleanup_file (const struct cleaner *c)
 {
-    if(c && c->arg)
-        unlink(c->arg);
+    if (c && c->arg)
+        unlink (c->arg);
 }
 
-static pid_t cleaner_pid = 0;
-static zlist_t *cleanup_list = NULL;
 void cleanup_run (void)
 {
     struct cleaner *c;
-    pthread_mutex_lock(&mutex);
-    if ( ! cleanup_list || cleaner_pid != getpid())
+
+    pthread_mutex_lock (&mutex);
+    if (!cleanup_list || cleaner_pid != getpid ())
         goto out;
-    c = zlist_first(cleanup_list);
-    while (c){
+    c = zlist_first (cleanup_list);
+    while (c) {
         if (c && c->fun){
-            c->fun(c);
+            c->fun (c);
         }
         if (c->arg)
             free (c->arg);
         free (c);
-        c = zlist_next(cleanup_list);
+        c = zlist_next (cleanup_list);
     }
-    zlist_destroy(&cleanup_list);
+    zlist_destroy (&cleanup_list);
     cleanup_list = NULL;
 out:
-    pthread_mutex_unlock(&mutex);
+    pthread_mutex_unlock (&mutex);
 }
 
-void cleanup_push (cleaner_fun_f *fun, void * arg)
+void cleanup_push (cleaner_fun_f *fun, void *arg)
 {
-    pthread_mutex_lock(&mutex);
-    if (! cleanup_list || cleaner_pid != getpid())
-    {
+    pthread_mutex_lock (&mutex);
+    if (!cleanup_list || cleaner_pid != getpid ()) {
         // This odd dance is to handle forked processes that do not exec
         if (cleaner_pid != 0 && cleanup_list) {
-            zlist_destroy(&cleanup_list);
+            zlist_destroy (&cleanup_list);
         }
-        cleanup_list = zlist_new();
-        cleaner_pid = getpid();
+        cleanup_list = zlist_new ();
+        cleaner_pid = getpid ();
         atexit (cleanup_run);
     }
-    struct cleaner * c = calloc(sizeof(struct cleaner), 1);
+    struct cleaner *c = calloc (sizeof (struct cleaner), 1);
     c->fun = fun;
     c->arg = arg;
-    /* Ignore return code, no way to return it callery anyway... */
-    (void) zlist_push(cleanup_list, c);
-    pthread_mutex_unlock(&mutex);
+    /* Ignore return code, no way to return it to caller anyway... */
+    (void)zlist_push (cleanup_list, c);
+    pthread_mutex_unlock (&mutex);
 }
 
-void cleanup_push_string (cleaner_fun_f *fun, const char * path)
+void cleanup_push_string (cleaner_fun_f *fun, const char *path)
 {
-    cleanup_push(fun, xstrdup(path));
+    cleanup_push (fun, xstrdup (path));
 }
 
 /*

--- a/src/common/libutil/cleanup.h
+++ b/src/common/libutil/cleanup.h
@@ -12,14 +12,14 @@
 #define HAVE_LIBUTIL_CLEANUP_H 1
 
 struct cleaner;
-typedef void(cleaner_fun_f)(const struct cleaner*c);
+typedef void (cleaner_fun_f) (const struct cleaner*c);
 
 void cleanup_directory_recursive (const struct cleaner *c);
 void cleanup_directory (const struct cleaner *c);
 void cleanup_file (const struct cleaner *c);
 
-void cleanup_push (cleaner_fun_f *fun, void * arg);
-void cleanup_push_string (cleaner_fun_f *fun, const char * path);
+void cleanup_push (cleaner_fun_f *fun, void *arg);
+void cleanup_push_string (cleaner_fun_f *fun, const char *path);
 
 void cleanup_run (void);
 


### PR DESCRIPTION
This PR fixes a few style anomalies in the cleanup code, and cleans up out of memory error paths.

Split from #2783 to thin that one down a bit.