### PR TITLE
content-sqlite, content-cache: cleanup and refactoring

### DIFF
--- a/doc/man1/flux-content.adoc
+++ b/doc/man1/flux-content.adoc
@@ -68,10 +68,9 @@ cache of its availability, which triggers the cache to begin
 offloading entries.  Once entries are offloaded, they are eligible
 for expiration from the rank 0 cache.
 
-If the module is unloaded, its contents are transferred back
-to the cache.  This operation may fail if more content has
-been stored than can fit in memory, and so is only advisable early
-in the life of an instance.
+To avoid data loss, once a content backing module is loaded,
+do not unload it unless the content cache on rank 0 has been flushed
+and the system is shutting down.
 
 
 CACHE EXPIRATION

--- a/src/broker/content-cache.c
+++ b/src/broker/content-cache.c
@@ -629,42 +629,57 @@ static int cache_flush (content_cache_t *cache)
     return rc;
 }
 
-static void content_backing_request (flux_t *h, flux_msg_handler_t *mh,
-                                     const flux_msg_t *msg, void *arg)
+static void content_register_backing_request (flux_t *h,
+                                              flux_msg_handler_t *mh,
+                                              const flux_msg_t *msg,
+                                              void *arg)
 {
     content_cache_t *cache = arg;
     const char *name;
-    int backing;
 
-    if (flux_request_unpack (msg, NULL, "{ s:b s:s }",
-                             "backing", &backing,
-                             "name", &name) < 0)
+    if (flux_request_unpack (msg, NULL, "{s:s}", "name", &name) < 0)
         goto error;
-    if (cache->rank != 0) {
+    if (cache->rank != 0 || cache->backing) {
         errno = EINVAL;
         goto error;
     }
-    if (!cache->backing && backing) {
-        if (!(cache->backing_name = strdup (name)))
-            goto error;
-        cache->backing = 1;
-        flux_log (h, LOG_DEBUG,
-                "content backing store: enabled %s", name);
-        (void)cache_flush (cache);
-    } else if (cache->backing && !backing) {
-        cache->backing = 0;
-        if (cache->backing_name)
-            free (cache->backing_name);
-        cache->backing_name = NULL;
-        flux_log (h, LOG_DEBUG, "content backing store: disabled %s", name);
-    }
+    if (!(cache->backing_name = strdup (name)))
+        goto error;
+    cache->backing = 1;
+    flux_log (h, LOG_DEBUG, "content backing store: enabled %s", name);
     if (flux_respond (h, msg, NULL) < 0)
         flux_log_error (h, "content backing");
+    (void)cache_flush (cache);
     return;
 error:
     if (flux_respond_error (h, msg, errno, NULL) < 0)
         flux_log_error (h, "content backing");
 };
+
+static void content_unregister_backing_request (flux_t *h,
+                                                flux_msg_handler_t *mh,
+                                                const flux_msg_t *msg,
+                                                void *arg)
+{
+    content_cache_t *cache = arg;
+
+    if (flux_request_decode (msg, NULL, NULL) < 0)
+        goto error;
+    if (!cache->backing) {
+        errno = EINVAL;
+        goto error;
+    }
+    cache->backing = 0;
+    free (cache->backing_name);
+    cache->backing_name = NULL;
+    flux_log (h, LOG_DEBUG, "content backing store: disabled");
+    if (flux_respond (h, msg, NULL) < 0)
+        flux_log_error (h, "flux_respond");
+    return;
+error:
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "flux_respond_error");
+}
 
 /* Forcibly drop all entries from the cache that can be dropped
  * without data loss.
@@ -863,8 +878,14 @@ static const struct flux_msg_handler_spec htab[] = {
     },
     {
         FLUX_MSGTYPE_REQUEST,
-        "content.backing",
-        content_backing_request,
+        "content.unregister-backing",
+        content_unregister_backing_request,
+        0
+    },
+    {
+        FLUX_MSGTYPE_REQUEST,
+        "content.register-backing",
+        content_register_backing_request,
         0
     },
     {

--- a/src/broker/content-cache.c
+++ b/src/broker/content-cache.c
@@ -849,15 +849,48 @@ static void heartbeat_event (flux_t *h, flux_msg_handler_t *mh,
  */
 
 static const struct flux_msg_handler_spec htab[] = {
-    { FLUX_MSGTYPE_REQUEST, "content.load",      content_load_request,
-      FLUX_ROLE_USER },
-    { FLUX_MSGTYPE_REQUEST, "content.store",     content_store_request,
-      FLUX_ROLE_USER },
-    { FLUX_MSGTYPE_REQUEST, "content.backing",   content_backing_request, 0 },
-    { FLUX_MSGTYPE_REQUEST, "content.dropcache", content_dropcache_request, 0 },
-    { FLUX_MSGTYPE_REQUEST, "content.stats.get", content_stats_request, 0 },
-    { FLUX_MSGTYPE_REQUEST, "content.flush",     content_flush_request, 0 },
-    { FLUX_MSGTYPE_EVENT,   "hb",                heartbeat_event, 0 },
+    {
+        FLUX_MSGTYPE_REQUEST,
+        "content.load",
+        content_load_request,
+        FLUX_ROLE_USER
+    },
+    {
+        FLUX_MSGTYPE_REQUEST,
+        "content.store",
+        content_store_request,
+        FLUX_ROLE_USER
+    },
+    {
+        FLUX_MSGTYPE_REQUEST,
+        "content.backing",
+        content_backing_request,
+        0
+    },
+    {
+        FLUX_MSGTYPE_REQUEST,
+        "content.dropcache",
+        content_dropcache_request,
+        0
+    },
+    {
+        FLUX_MSGTYPE_REQUEST,
+        "content.stats.get",
+        content_stats_request,
+        0
+    },
+    {
+        FLUX_MSGTYPE_REQUEST,
+        "content.flush",
+        content_flush_request,
+        0
+    },
+    {
+        FLUX_MSGTYPE_EVENT,
+        "hb",
+        heartbeat_event,
+        0
+    },
     FLUX_MSGHANDLER_TABLE_END,
 };
 

--- a/src/broker/content-cache.c
+++ b/src/broker/content-cache.c
@@ -675,6 +675,8 @@ static void content_unregister_backing_request (flux_t *h,
     flux_log (h, LOG_DEBUG, "content backing store: disabled");
     if (flux_respond (h, msg, NULL) < 0)
         flux_log_error (h, "flux_respond");
+    if (cache->acct_dirty > 0)
+        flux_log (h, LOG_ERR, "%d unflushables", cache->acct_dirty);
     return;
 error:
     if (flux_respond_error (h, msg, errno, NULL) < 0)

--- a/src/broker/content-cache.c
+++ b/src/broker/content-cache.c
@@ -596,15 +596,6 @@ error:
  * informs the content service of its availability, and entries are
  * asynchronously duplicated on the backing store and made eligible for
  * dropping from the rank 0 cache.
- *
- * At module unload time, Backing store is disabled and content.backing
- * synchronously transfers content back to the cache.  This allows the
- * module providing the backing store to be replaced early at runtime,
- * before the amount of content exceeds the cache's ability to hold it.
- *
- * If the broker is being shutdown, this transfer is skipped by
- * to avoid unnecessary and possibly OOM-triggering data movement into
- * the cache.
  */
 
 static int cache_flush (content_cache_t *cache)

--- a/src/modules/content-sqlite/content-sqlite.c
+++ b/src/modules/content-sqlite/content-sqlite.c
@@ -121,9 +121,6 @@ void load_cb (flux_t *h, flux_msg_handler_t *mh,
     int size = 0;
     int uncompressed_size;
     int rc = -1;
-    int old_state;
-    //delay cancellation to ensure lock-correctness in sqlite
-    pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, &old_state);
 
     if (flux_request_decode_raw (msg, NULL, (const void **)&blobref,
                                  &blobref_size) < 0) {
@@ -192,7 +189,6 @@ done:
             flux_log_error (h, "load: flux_respond_raw");
     }
     (void )sqlite3_reset (ctx->load_stmt);
-    pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, &old_state);
 }
 
 void store_cb (flux_t *h, flux_msg_handler_t *mh,
@@ -205,9 +201,6 @@ void store_cb (flux_t *h, flux_msg_handler_t *mh,
     char blobref[BLOBREF_MAX_STRING_SIZE] = "-";
     int uncompressed_size = -1;
     int rc = -1;
-    int old_state;
-    //delay cancellation to ensure lock-correctness in sqlite
-    pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, &old_state);
 
     if (flux_request_decode_raw (msg, NULL, &data, &size) < 0) {
         flux_log_error (h, "store: request decode failed");
@@ -270,7 +263,6 @@ done:
             flux_log_error (h, "store: flux_respond_raw");
     }
     (void) sqlite3_reset (ctx->store_stmt);
-    pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, &old_state);
 }
 
 int register_backing_store (flux_t *h, bool value, const char *name)

--- a/src/modules/content-sqlite/content-sqlite.c
+++ b/src/modules/content-sqlite/content-sqlite.c
@@ -353,18 +353,24 @@ static int content_sqlite_opendb (struct content_sqlite *ctx)
                       "PRAGMA journal_mode=OFF",
                       NULL,
                       NULL,
-                      NULL) != SQLITE_OK
-            || sqlite3_exec (ctx->db,
-                             "PRAGMA synchronous=OFF",
-                             NULL,
-                             NULL,
-                             NULL) != SQLITE_OK
-            || sqlite3_exec (ctx->db,
-                             "PRAGMA locking_mode=EXCLUSIVE",
-                             NULL,
-                             NULL,
-                             NULL) != SQLITE_OK) {
-        log_sqlite_error (ctx, "setting sqlite pragmas");
+                      NULL) != SQLITE_OK) {
+        log_sqlite_error (ctx, "setting sqlite 'journal_mode' pragma");
+        goto error;
+    }
+    if (sqlite3_exec (ctx->db,
+                      "PRAGMA synchronous=OFF",
+                      NULL,
+                      NULL,
+                      NULL) != SQLITE_OK) {
+        log_sqlite_error (ctx, "setting sqlite 'synchronous' pragma");
+        goto error;
+    }
+    if (sqlite3_exec (ctx->db,
+                      "PRAGMA locking_mode=EXCLUSIVE",
+                      NULL,
+                      NULL,
+                      NULL) != SQLITE_OK) {
+        log_sqlite_error (ctx, "setting sqlite 'locking_mode' pragma");
         goto error;
     }
     if (sqlite3_exec (ctx->db,

--- a/src/modules/content-sqlite/content-sqlite.c
+++ b/src/modules/content-sqlite/content-sqlite.c
@@ -296,7 +296,6 @@ done:
 int register_backing_store (flux_t *h, bool value, const char *name)
 {
     flux_future_t *f;
-    int saved_errno = 0;
     int rc = -1;
 
     if (!(f = flux_rpc_pack (h,
@@ -313,22 +312,18 @@ int register_backing_store (flux_t *h, bool value, const char *name)
         goto done;
     rc = 0;
 done:
-    saved_errno = errno;
     flux_future_destroy (f);
-    errno = saved_errno;
     return rc;
 }
 
 int register_content_backing_service (flux_t *h)
 {
-    int rc, saved_errno;
+    int rc;
     flux_future_t *f;
     if (!(f = flux_service_register (h, "content-backing")))
         return -1;
     rc = flux_future_get (f, NULL);
-    saved_errno = errno;
     flux_future_destroy (f);
-    errno = saved_errno;
     return rc;
 }
 

--- a/t/t0011-content-cache.t
+++ b/t/t0011-content-cache.t
@@ -158,8 +158,8 @@ test_expect_success 'store 1K blobs from all ranks using async RPC' '
 test_expect_success 'load request with empty payload fails with EPROTO(71)' '
 	${RPC} content.load 71 </dev/null
 '
-test_expect_success 'backing request with empty payload fails with EPROTO(71)' '
-	${RPC} content.backing 71 </dev/null
+test_expect_success 'register-backing request with empty payload fails with EPROTO(71)' '
+	${RPC} content.register-backing 71 </dev/null
 '
 
 test_done

--- a/t/t0011-content-cache.t
+++ b/t/t0011-content-cache.t
@@ -147,12 +147,12 @@ test_expect_success 'rank 0 cache is all valid' '
 
 # Write 8192 blobs, allowing 1024 requests to be outstanding
 test_expect_success 'store 8K blobs from rank 0 using async RPC' '
-	flux content spam 8192 1024
+	flux content spam 8192 1024 >/dev/null
 '
 
 # Write 1024 blobs per rank
 test_expect_success 'store 1K blobs from all ranks using async RPC' '
-	flux exec -n flux content spam 1024 256
+	flux exec -n flux content spam 1024 256 >/dev/null
 '
 
 test_expect_success 'load request with empty payload fails with EPROTO(71)' '

--- a/t/t2501-job-status.t
+++ b/t/t2501-job-status.t
@@ -13,8 +13,6 @@ test_expect_success 'status: submit a series of jobs' '
 	shell_sigquit=$(flux mini submit sh -c "kill -QUIT \$PPID") &&
 	unsatisfiable=$(flux mini submit -n 1024 hostname) &&
 	killed=$(flux mini submit sleep 600) &&
-	flux job wait-event ${killed} start &&
-	flux job cancel ${killed} &&
 	flux queue stop &&
 	canceled=$(flux mini submit -n 1024 hostname) &&
 	flux job cancel ${canceled} &&
@@ -49,6 +47,8 @@ test_expect_success 'status: --exception-exit-code works' '
 	test_expect_code 255 flux job status -v --exception-exit-code=255 ${unsatisfiable}
 '
 test_expect_success 'status: returns 143 (SIGTERM) for canceled running job' '
+	flux job wait-event -p guest.exec.eventlog ${killed} shell.start &&
+	flux job cancel ${killed} &&
 	test_expect_code 143 flux job status -v ${killed}
 '
 test_expect_success 'status: returns highest status for multiple jobs' '


### PR DESCRIPTION
This is primarily a refactoring and cleanup of the content-sqlite module, with a bit of content-cache involvement, in preparation for changes to come for KVS checkpoint/restart.

Splitting a (hopefully) easily digestible chunk from #2783 