### PR TITLE
bindings/python: add 'flux_job_list_inactive' Python binding

### DIFF
--- a/src/bindings/python/flux/job.py
+++ b/src/bindings/python/flux/job.py
@@ -258,9 +258,9 @@ def job_list(flux_handle, max_entries=0, attrs=[], userid=os.geteuid(), states=0
     return JobListRPC(flux_handle, "job-info.list", payload)
 
 
-def job_list_inactive(flux_handle, timestamp, max_entries=1000, attrs=[]):
+def job_list_inactive(flux_handle, since, max_entries=1000, attrs=[]):
     payload = {
-        "timestamp": timestamp,
+        "since": since,
         "max_entries": max_entries,
         "attrs": attrs
     }

--- a/src/bindings/python/flux/job.py
+++ b/src/bindings/python/flux/job.py
@@ -248,7 +248,7 @@ class JobListRPC(RPC):
 # - Desired return value is json array, not a single value
 #
 # pylint: disable=dangerous-default-value
-def job_list(flux_handle, max_entries=0, attrs=[], userid=os.geteuid(), states=0):
+def job_list(flux_handle, max_entries=1000, attrs=[], userid=os.geteuid(), states=0):
     payload = {
         "max_entries": max_entries,
         "attrs": attrs,
@@ -258,12 +258,8 @@ def job_list(flux_handle, max_entries=0, attrs=[], userid=os.geteuid(), states=0
     return JobListRPC(flux_handle, "job-info.list", payload)
 
 
-def job_list_inactive(flux_handle, since, max_entries=1000, attrs=[]):
-    payload = {
-        "since": since,
-        "max_entries": max_entries,
-        "attrs": attrs
-    }
+def job_list_inactive(flux_handle, since=0.0, max_entries=1000, attrs=[]):
+    payload = {"since": since, "max_entries": max_entries, "attrs": attrs}
     return JobListRPC(flux_handle, "job-info.list-inactive", payload)
 
 

--- a/src/bindings/python/flux/job.py
+++ b/src/bindings/python/flux/job.py
@@ -258,6 +258,15 @@ def job_list(flux_handle, max_entries=0, attrs=[], userid=os.geteuid(), states=0
     return JobListRPC(flux_handle, "job-info.list", payload)
 
 
+def job_list_inactive(flux_handle, timestamp, max_entries=1000, attrs=[]):
+    payload = {
+        "timestamp": timestamp,
+        "max_entries": max_entries,
+        "attrs": attrs
+    }
+    return JobListRPC(flux_handle, "job-info.list-inactive", payload)
+
+
 def _validate_keys(expected, given, keys_optional=False, allow_additional=False):
     if not isinstance(expected, set):
         expected = set(expected)

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -93,8 +93,9 @@ static struct optparse_option list_inactive_opts[] =  {
     { .name = "count", .key = 'c', .has_arg = 1, .arginfo = "N",
       .usage = "Limit output to N jobs",
     },
-    { .name = "timestamp", .key = 't', .has_arg = 1, .arginfo = "T",
-      .usage = "Limit output to jobs newer than timestamp",
+    { .name = "since", .key = 's', .has_arg = 1, .arginfo = "T",
+      .usage = "Limit output to jobs that entered the inactive state since"
+               " timestamp T",
     },
     OPTPARSE_TABLE_END
 };
@@ -1027,7 +1028,7 @@ int cmd_list_inactive (optparse_t *p, int argc, char **argv)
 {
     int optindex = optparse_option_index (p);
     int max_entries = optparse_get_int (p, "count", 0);
-    double timestamp = optparse_get_double (p, "timestamp", 0.);
+    double since = optparse_get_double (p, "since", 0.);
     char *attrs = "[\"userid\",\"priority\",\"t_submit\",\"state\"," \
         "\"name\",\"ntasks\",\"nnodes\",\"ranks\",\"t_depend\",\"t_sched\"," \
         "\"t_run\",\"t_cleanup\",\"t_inactive\"]";
@@ -1044,7 +1045,7 @@ int cmd_list_inactive (optparse_t *p, int argc, char **argv)
     if (!(h = flux_open (NULL, 0)))
         log_err_exit ("flux_open");
 
-    if (!(f = flux_job_list_inactive (h, max_entries, timestamp, attrs)))
+    if (!(f = flux_job_list_inactive (h, max_entries, since, attrs)))
         log_err_exit ("flux_job_list_inactive");
     if (flux_rpc_get_unpack (f, "{s:o}", "jobs", &jobs) < 0)
         log_err_exit ("flux_job_list_inactive");

--- a/src/common/libjob/job.c
+++ b/src/common/libjob/job.c
@@ -218,14 +218,14 @@ flux_future_t *flux_job_list (flux_t *h,
 
 flux_future_t *flux_job_list_inactive (flux_t *h,
                                        int max_entries,
-                                       double timestamp,
+                                       double since,
                                        const char *json_str)
 {
     flux_future_t *f;
     json_t *o = NULL;
     int saved_errno;
 
-    if (!h || max_entries < 0 || timestamp < 0. || !json_str
+    if (!h || max_entries < 0 || since < 0. || !json_str
            || !(o = json_loads (json_str, 0, NULL))) {
         errno = EINVAL;
         return NULL;
@@ -233,7 +233,7 @@ flux_future_t *flux_job_list_inactive (flux_t *h,
     if (!(f = flux_rpc_pack (h, "job-info.list-inactive", FLUX_NODEID_ANY, 0,
                              "{s:i s:f s:o}",
                              "max_entries", max_entries,
-                             "timestamp", timestamp,
+                             "since", since,
                              "attrs", o))) {
         saved_errno = errno;
         json_decref (o);

--- a/src/common/libjob/job.h
+++ b/src/common/libjob/job.h
@@ -111,7 +111,7 @@ flux_future_t *flux_job_list (flux_t *h,
  */
 flux_future_t *flux_job_list_inactive (flux_t *h,
                                        int max_entries,
-                                       double timestamp,
+                                       double since,
                                        const char *json_str);
 
 /* Similar to flux_job_list(), but retrieve job info for a single

--- a/t/python/t0013-job-list-inactive.py
+++ b/t/python/t0013-job-list-inactive.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python
+
+###############################################################
+# Copyright 2014 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+import os
+import errno
+import sys
+import json
+import unittest
+import datetime
+import time
+from glob import glob
+
+import yaml
+import six
+
+import flux
+from flux import job
+from flux.job import Jobspec, JobspecV1, ffi
+
+
+def __flux_size():
+    return 1
+
+
+class TestJob(unittest.TestCase):
+    @classmethod
+    def setUpClass(self):
+        self.fh = flux.Flux()
+
+    @classmethod
+    def submitJob(self):
+        compute_jobreq = JobspecV1.from_command(
+            command=["sleep", "0"], num_tasks=2, num_nodes=1, cores_per_task=1
+        )
+        compute_jobreq.cwd = os.getcwd()
+        compute_jobreq.environment = dict(os.environ)
+        flux.job.submit(self.fh, compute_jobreq, waitable=True)
+
+    @classmethod
+    def getJobs(self, rpc_handle):
+        try:
+            jobs = rpc_handle.get_jobs()
+            return jobs
+        except EnvironmentError as e:
+            print("{}: {}".format("rpc", e.strerror), file=sys.stderr)
+            sys.exit(1)
+
+    # NOTE: the job-info module has eventual consistency with the jobs stored
+    # in the job-manager's queue. To ensure no raciness in tests, we spin
+    # until all of the inactive jobs have reached INACTIVE state.
+    @classmethod
+    def waitForConsistency(self, jobs_list_length):
+        jobs = []
+        while True:
+            rpc_handle = flux.job.job_list(
+                self.fh, 0, self.attrs, states=flux.constants.FLUX_JOB_INACTIVE
+            )
+            jobs = self.getJobs(rpc_handle)
+            if len(jobs) == jobs_list_length:
+                break
+
+    attrs = [
+        "userid",
+        "state",
+        "name",
+        "ntasks",
+        "t_submit",
+        "t_run",
+        "t_inactive",
+    ]
+
+    # should return an empty list if there are no inactive jobs
+    def test_00_list_inactive_expect_empty_list(self):
+        rpc_handle = flux.job.job_list_inactive(
+            self.fh, time.time() - 3600, 10, self.attrs
+        )
+
+        jobs = self.getJobs(rpc_handle)
+
+        self.assertEqual(len(jobs), 0)
+
+    # make sure one job is read from RPC
+    def test_01_list_inactive_success(self):
+        # submit a sleep 0 job
+        self.submitJob()
+
+        self.waitForConsistency(1)
+
+        rpc_handle = flux.job.job_list_inactive(
+            self.fh, time.time() - 3600, 10, self.attrs
+        )
+
+        jobs = self.getJobs(rpc_handle)
+
+        self.assertEqual(len(jobs), 1)
+
+    # multiple jobs submitted should return a longer list of inactive jobs
+    def test_02_list_multiple_inactive(self):
+        # submit a bundle of sleep 0 jobs
+        for i in range(10):
+            jobid = self.submitJob()
+
+        self.waitForConsistency(10)
+
+        rpc_handle = flux.job.job_list_inactive(
+            self.fh, time.time() - 3600, 20, self.attrs
+        )
+
+        jobs = self.getJobs(rpc_handle)
+
+        self.assertEqual(len(jobs), 10)
+
+    # flux job list-inactive with timestamp = 0.0 should return all inactive jobs
+    def test_03_list_all_inactive(self):
+        rpc_handle = flux.job.job_list_inactive(self.fh, 0.0, 20, self.attrs)
+
+        jobs = self.getJobs(rpc_handle)
+
+        self.assertEqual(len(jobs), 10)
+
+    # flux job list-inactive with max_entries = 5 should only return a subset
+    def test_04_list_subset_of_inactive(self):
+        rpc_handle = flux.job.job_list_inactive(self.fh, 0.0, 5, self.attrs)
+
+        jobs = self.getJobs(rpc_handle)
+
+        self.assertEqual(len(jobs), 5)
+
+    # flux job list-inactive with the most recent timestamp should return len(0)
+    def test_05_most_recent_inactive(self):
+        for i in range(5):
+            jobid = self.submitJob()
+
+        rpc_handle = flux.job.job_list(
+            self.fh, 1, ["t_inactive"], states=flux.constants.FLUX_JOB_INACTIVE
+        )
+
+        jobs = self.getJobs(rpc_handle)
+
+        rpc_handle = flux.job.job_list_inactive(
+            self.fh, jobs[0]["t_inactive"], 1, self.attrs
+        )
+
+        jobs_inactive = self.getJobs(rpc_handle)
+
+        self.assertEqual(len(jobs_inactive), 0)
+
+    # flux job list-inactive with second to most recent timestamp
+    def test_06_second_most_recent_timestamp(self):
+        for i in range(5):
+            jobid = self.submitJob()
+
+        rpc_handle = flux.job.job_list(
+            self.fh, 2, ["t_inactive"], states=flux.constants.FLUX_JOB_INACTIVE
+        )
+
+        jobs = self.getJobs(rpc_handle)
+
+        rpc_handle = flux.job.job_list_inactive(
+            self.fh, jobs[1]["t_inactive"], 1, self.attrs
+        )
+
+        jobs_inactive = self.getJobs(rpc_handle)
+
+        self.assertEqual(len(jobs_inactive), 1)
+        self.assertEqual(jobs_inactive[0]["t_inactive"], jobs[0]["t_inactive"])
+
+    # flux job list-inactive with oldest timestamp
+    def test_07_oldest_timestamp(self):
+        for i in range(5):
+            jobid = self.submitJob()
+
+        rpc_handle = flux.job.job_list(
+            self.fh, 5, ["t_inactive"], states=flux.constants.FLUX_JOB_INACTIVE
+        )
+
+        jobs = self.getJobs(rpc_handle)
+
+        rpc_handle = flux.job.job_list_inactive(
+            self.fh, jobs[4]["t_inactive"], 10, self.attrs
+        )
+
+        jobs_inactive = self.getJobs(rpc_handle)
+
+        self.assertEqual(len(jobs_inactive), 4)
+
+    # flux job list-inactive with middle timestamp #1
+    def test_08_middle_timestamp_1(self):
+        for i in range(11):
+            self.submitJob()
+
+        rpc_handle = flux.job.job_list(
+            self.fh, 20, ["t_inactive"], states=flux.constants.FLUX_JOB_INACTIVE
+        )
+
+        jobs = self.getJobs(rpc_handle)
+
+        rpc_handle = flux.job.job_list_inactive(
+            self.fh, jobs[5]["t_inactive"], 20, self.attrs
+        )
+
+        jobs_inactive = self.getJobs(rpc_handle)
+
+        self.assertEqual(len(jobs_inactive), 5)
+
+    # flux job list-inactive with middle timestamp #2
+    def test_09_middle_timestamp_2(self):
+        for i in range(11):
+            self.submitJob()
+
+        rpc_handle = flux.job.job_list(
+            self.fh, 20, ["t_inactive"], states=flux.constants.FLUX_JOB_INACTIVE
+        )
+
+        jobs = self.getJobs(rpc_handle)
+
+        rpc_handle = flux.job.job_list_inactive(
+            self.fh, jobs[7]["t_inactive"], 20, self.attrs
+        )
+
+        jobs_inactive = self.getJobs(rpc_handle)
+
+        self.assertEqual(len(jobs_inactive), 7)
+
+
+if __name__ == "__main__":
+    from subflux import rerun_under_flux
+
+    if rerun_under_flux(size=__flux_size(), personality="job"):
+        from pycotap import TAPTestRunner
+
+        unittest.main(testRunner=TAPTestRunner())

--- a/t/python/t0013-job-list-inactive.py
+++ b/t/python/t0013-job-list-inactive.py
@@ -119,7 +119,7 @@ class TestJob(unittest.TestCase):
 
         self.assertEqual(len(jobs), 10)
 
-    # flux job list-inactive with timestamp = 0.0 should return all inactive jobs
+    # flux job list-inactive with since = 0.0 should return all inactive jobs
     def test_03_list_all_inactive(self):
         rpc_handle = flux.job.job_list_inactive(self.fh, 0.0, 20, self.attrs)
 

--- a/t/t2204-job-info.t
+++ b/t/t2204-job-info.t
@@ -374,8 +374,8 @@ test_expect_success HAVE_JQ 'flux job list-inactive lists all inactive jobs' '
         test $count -eq 20
 '
 
-test_expect_success HAVE_JQ 'flux job list-inactive w/ timestamp 0 lists all inactive jobs' '
-        count=`flux job list-inactive --timestamp=0 | wc -l` &&
+test_expect_success HAVE_JQ 'flux job list-inactive w/ since 0 lists all inactive jobs' '
+        count=`flux job list-inactive --since=0 | wc -l` &&
         test $count -eq 20
 '
 
@@ -384,41 +384,41 @@ test_expect_success HAVE_JQ 'flux job list-inactive w/ count limits output of in
         test $count -eq 14
 '
 
-test_expect_success HAVE_JQ 'flux job list-inactive w/ timestamp -1 leads to error' '
-        test_must_fail flux job list-inactive --timestamp=-1
+test_expect_success HAVE_JQ 'flux job list-inactive w/ since -1 leads to error' '
+        test_must_fail flux job list-inactive --since=-1
 '
 
 test_expect_success HAVE_JQ 'flux job list-inactive w/ count -1 leads to error' '
         test_must_fail flux job list-inactive --count=-1
 '
 
-test_expect_success HAVE_JQ 'flux job list-inactive w/ timestamp (most recent timestamp)' '
+test_expect_success HAVE_JQ 'flux job list-inactive w/ since (most recent timestamp)' '
         timestamp=`cat list-inactive.out | head -n 1 | jq .t_inactive` &&
-        count=`flux job list-inactive --timestamp=${timestamp} | wc -l` &&
+        count=`flux job list-inactive --since=${timestamp} | wc -l` &&
         test $count -eq 0
 '
 
-test_expect_success HAVE_JQ 'flux job list-inactive w/ timestamp (second to most recent timestamp)' '
+test_expect_success HAVE_JQ 'flux job list-inactive w/ since (second to most recent timestamp)' '
         timestamp=`cat list-inactive.out | head -n 2 | tail -n 1 | jq .t_inactive` &&
-        count=`flux job list-inactive --timestamp=${timestamp} | wc -l` &&
+        count=`flux job list-inactive --since=${timestamp} | wc -l` &&
         test $count -eq 1
 '
 
-test_expect_success HAVE_JQ 'flux job list-inactive w/ timestamp (oldest timestamp)' '
+test_expect_success HAVE_JQ 'flux job list-inactive w/ since (oldest timestamp)' '
         timestamp=`cat list-inactive.out | tail -n 1 | jq .t_inactive` &&
-        count=`flux job list-inactive --timestamp=${timestamp} | wc -l` &&
+        count=`flux job list-inactive --since=${timestamp} | wc -l` &&
         test $count -eq 19
 '
 
-test_expect_success HAVE_JQ 'flux job list-inactive w/ timestamp (middle timestamp #1)' '
+test_expect_success HAVE_JQ 'flux job list-inactive w/ since (middle timestamp #1)' '
         timestamp=`cat list-inactive.out | head -n 8 | tail -n 1 | jq .t_inactive` &&
-        count=`flux job list-inactive --timestamp=${timestamp} | wc -l` &&
+        count=`flux job list-inactive --since=${timestamp} | wc -l` &&
         test $count -eq 7
 '
 
-test_expect_success HAVE_JQ 'flux job list-inactive w/ timestamp (middle timestamp #2)' '
+test_expect_success HAVE_JQ 'flux job list-inactive w/ since (middle timestamp #2)' '
         timestamp=`cat list-inactive.out | head -n 13 | tail -n 1 | jq .t_inactive` &&
-        count=`flux job list-inactive --timestamp=${timestamp} | wc -l` &&
+        count=`flux job list-inactive --since=${timestamp} | wc -l` &&
         test $count -eq 12
 '
 
@@ -1202,15 +1202,15 @@ test_expect_success 'list-inactive request with empty payload fails with EPROTO(
 	${RPC} job-info.list-inactive 71 </dev/null
 '
 test_expect_success HAVE_JQ 'list-inactive request with invalid input fails with EPROTO(71) (attrs not an array)' '
-        $jq -j -c -n  "{max_entries:5, timestamp:0.0, attrs:5}" \
+        $jq -j -c -n  "{max_entries:5, since:0.0, attrs:5}" \
           | $RPC job-info.list-inactive 71
 '
 test_expect_success HAVE_JQ 'list-inactive request with invalid input fails with EINVAL(22) (attrs non-string)' '
-        $jq -j -c -n  "{max_entries:5, timestamp:0.0, attrs:[5]}" \
+        $jq -j -c -n  "{max_entries:5, since:0.0, attrs:[5]}" \
           | $RPC job-info.list-inactive 22
 '
 test_expect_success HAVE_JQ 'list-inactive request with invalid input fails with EINVAL(22) (attrs illegal field)' '
-        $jq -j -c -n  "{max_entries:5, timestamp:0.0, attrs:[\"foo\"]}" \
+        $jq -j -c -n  "{max_entries:5, since:0.0, attrs:[\"foo\"]}" \
           | $RPC job-info.list-inactive 22
 '
 


### PR DESCRIPTION
As described in #2776, there is no Python binding for `flux job list-inactive`. This command is planned to be used by the Bank/Accounting interface for Flux, which for the time being is being written in Python. 

This PR proposes the following changes:

- adds a Python binding for `flux job list-inactive` so it can be used in an RPC to get job record data.
- renames the **timestamp** option to **since** to more accurately describe what the option is doing. 
- changes the default value of **max_entries** in `job_list()` to **1000** to match the default value in `job_list_inactive()` (discussed in the comments thread in #2776). 