### PR TITLE
kvs: rename kvs namespace events to limit calls to `flux_event_subscribe()`

### DIFF
--- a/src/modules/kvs-watch/kvs-watch.c
+++ b/src/modules/kvs-watch/kvs-watch.c
@@ -187,7 +187,7 @@ static struct ns_monitor *namespace_create (struct watch_ctx *ctx,
         goto error;
     if (!(nsm->ns_name = strdup (ns)))
         goto error;
-    if (asprintf (&nsm->setroot_topic, "kvs.setroot-%s", ns) < 0)
+    if (asprintf (&nsm->setroot_topic, "kvs.namespace-%s-setroot", ns) < 0)
         goto error;
     if (asprintf (&nsm->created_topic, "kvs.namespace-created-%s", ns) < 0)
         goto error;
@@ -1099,7 +1099,7 @@ static const struct flux_msg_handler_spec htab[] = {
       .rolemask     = 0
     },
     { .typemask     = FLUX_MSGTYPE_EVENT,
-      .topic_glob   = "kvs.setroot-*",
+      .topic_glob   = "kvs.namespace-*-setroot",
       .cb           = setroot_cb,
       .rolemask     = 0
     },

--- a/src/modules/kvs-watch/kvs-watch.c
+++ b/src/modules/kvs-watch/kvs-watch.c
@@ -67,8 +67,8 @@ struct ns_monitor {
     bool setroot_subscribed;    // setroot subscription active
     char *created_topic;        // topic string for kvs.namespace-created
     bool created_subscribed;    // kvs.namespace-created subscription active
-    char *removed_topic;        // topic string for kvs.namespace-removed
-    bool removed_subscribed;    // kvs.namespace-removed subscription active
+    char *removed_topic;        // topic string for kvs.namespace-<NS>-removed
+    bool removed_subscribed;    // kvs.namespace-<NS>-removed subscription active
     flux_future_t *getrootf;    // initial getroot future
 };
 
@@ -191,7 +191,7 @@ static struct ns_monitor *namespace_create (struct watch_ctx *ctx,
         goto error;
     if (asprintf (&nsm->created_topic, "kvs.namespace-created-%s", ns) < 0)
         goto error;
-    if (asprintf (&nsm->removed_topic, "kvs.namespace-removed-%s", ns) < 0)
+    if (asprintf (&nsm->removed_topic, "kvs.namespace-%s-removed", ns) < 0)
         goto error;
     nsm->owner = FLUX_USERID_UNKNOWN;
     nsm->ctx = ctx;
@@ -428,12 +428,12 @@ static void handle_lookup_response (flux_future_t *f,
              * We cannot reach this function / point in the code if
              * the namespace has not been created.  So an ENOTSUP here
              * must mean that the namespace has been removed, but we
-             * did not yet receive the kvs.namespace-removed event.
+             * did not yet receive the kvs.namespace-<NS>-removed event.
              * We can safely return ENOTSUP to the user.
              *
              * Note that kvs-watch does not handle monitoring of
              * namespaces being removed and re-created.  On a
-             * kvs.namespace-removed event, monitoring in a namespace
+             * kvs.namespace-<NS>removed event, monitoring in a namespace
              * is torn down.  See fatal_errnum var.
              */
             goto error;
@@ -1089,7 +1089,7 @@ nomem:
 
 static const struct flux_msg_handler_spec htab[] = {
     { .typemask     = FLUX_MSGTYPE_EVENT,
-      .topic_glob   = "kvs.namespace-removed-*",
+      .topic_glob   = "kvs.namespace-*-removed",
       .cb           = removed_cb,
       .rolemask     = 0
     },

--- a/src/modules/kvs-watch/kvs-watch.c
+++ b/src/modules/kvs-watch/kvs-watch.c
@@ -49,7 +49,7 @@ struct commit {
     int rootseq;                // current root sequence number
     json_t *keys;               // keys changed by commit
                                 //  empty if data originates from getroot RPC
-                                //  or kvs.namespace-created event
+                                //  or kvs.namespace-<NS>-created event
 };
 
 
@@ -65,8 +65,8 @@ struct ns_monitor {
     zlist_t *watchers;          // list of watchers of this namespace
     char *setroot_topic;        // topic string for setroot subscription
     bool setroot_subscribed;    // setroot subscription active
-    char *created_topic;        // topic string for kvs.namespace-created
-    bool created_subscribed;    // kvs.namespace-created subscription active
+    char *created_topic;        // topic string for kvs.namespace-<NS>created
+    bool created_subscribed;    // kvs.namespace-<NS>created subscription active
     char *removed_topic;        // topic string for kvs.namespace-<NS>-removed
     bool removed_subscribed;    // kvs.namespace-<NS>-removed subscription active
     flux_future_t *getrootf;    // initial getroot future
@@ -189,7 +189,7 @@ static struct ns_monitor *namespace_create (struct watch_ctx *ctx,
         goto error;
     if (asprintf (&nsm->setroot_topic, "kvs.namespace-%s-setroot", ns) < 0)
         goto error;
-    if (asprintf (&nsm->created_topic, "kvs.namespace-created-%s", ns) < 0)
+    if (asprintf (&nsm->created_topic, "kvs.namespace-%s-created", ns) < 0)
         goto error;
     if (asprintf (&nsm->removed_topic, "kvs.namespace-%s-removed", ns) < 0)
         goto error;
@@ -1094,7 +1094,7 @@ static const struct flux_msg_handler_spec htab[] = {
       .rolemask     = 0
     },
     { .typemask     = FLUX_MSGTYPE_EVENT,
-      .topic_glob   = "kvs.namespace-created-*",
+      .topic_glob   = "kvs.namespace-*-created",
       .cb           = namespace_created_cb,
       .rolemask     = 0
     },

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -199,8 +199,7 @@ static int event_subscribe (kvs_ctx_t *ctx, const char *ns)
          * events, all of the time.  So subscribe to them just once on
          * rank 0. */
         if (ctx->rank == 0) {
-            if (flux_event_subscribe (ctx->h, "kvs.namespace") < 0
-                || flux_event_subscribe (ctx->h, "kvs.namespace-remove") < 0) {
+            if (flux_event_subscribe (ctx->h, "kvs.namespace") < 0) {
                 flux_log_error (ctx->h, "flux_event_subscribe");
                 goto cleanup;
             }
@@ -226,7 +225,7 @@ static int event_subscribe (kvs_ctx_t *ctx, const char *ns)
             goto cleanup;
         }
 
-        if (asprintf (&removed_topic, "kvs.namespace-removed-%s", ns) < 0)
+        if (asprintf (&removed_topic, "kvs.namespace-%s-removed", ns) < 0)
             goto cleanup;
 
         if (flux_event_subscribe (ctx->h, removed_topic) < 0) {
@@ -267,7 +266,7 @@ static int event_unsubscribe (kvs_ctx_t *ctx, const char *ns)
             goto cleanup;
         }
 
-        if (asprintf (&removed_topic, "kvs.namespace-removed-%s", ns) < 0)
+        if (asprintf (&removed_topic, "kvs.namespace-%s-removed", ns) < 0)
             goto cleanup;
 
         if (flux_event_subscribe (ctx->h, removed_topic) < 0) {
@@ -2547,7 +2546,7 @@ static int namespace_remove (kvs_ctx_t *ctx, const char *ns)
         goto done;
     }
 
-    if (asprintf (&topic, "kvs.namespace-removed-%s", ns) < 0) {
+    if (asprintf (&topic, "kvs.namespace-%s-removed", ns) < 0) {
         saved_errno = ENOMEM;
         goto cleanup;
     }
@@ -2826,7 +2825,7 @@ static const struct flux_msg_handler_spec htab[] = {
                             namespace_create_request_cb, 0 },
     { FLUX_MSGTYPE_REQUEST, "kvs.namespace-remove",
                             namespace_remove_request_cb, 0 },
-    { FLUX_MSGTYPE_EVENT,   "kvs.namespace-removed-*",
+    { FLUX_MSGTYPE_EVENT,   "kvs.namespace-*-removed",
                             namespace_removed_event_cb, 0 },
     { FLUX_MSGTYPE_REQUEST, "kvs.namespace-list",
                             namespace_list_request_cb, 0 },

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -200,7 +200,6 @@ static int event_subscribe (kvs_ctx_t *ctx, const char *ns)
          * rank 0. */
         if (ctx->rank == 0) {
             if (flux_event_subscribe (ctx->h, "kvs.namespace") < 0
-                || flux_event_subscribe (ctx->h, "kvs.error") < 0
                 || flux_event_subscribe (ctx->h, "kvs.namespace-remove") < 0) {
                 flux_log_error (ctx->h, "flux_event_subscribe");
                 goto cleanup;
@@ -219,7 +218,7 @@ static int event_subscribe (kvs_ctx_t *ctx, const char *ns)
             goto cleanup;
         }
 
-        if (asprintf (&error_topic, "kvs.error-%s", ns) < 0)
+        if (asprintf (&error_topic, "kvs.namespace-%s-error", ns) < 0)
             goto cleanup;
 
         if (flux_event_subscribe (ctx->h, error_topic) < 0) {
@@ -260,7 +259,7 @@ static int event_unsubscribe (kvs_ctx_t *ctx, const char *ns)
             goto cleanup;
         }
 
-        if (asprintf (&error_topic, "kvs.error-%s", ns) < 0)
+        if (asprintf (&error_topic, "kvs.namespace-%s-error", ns) < 0)
             goto cleanup;
 
         if (flux_event_unsubscribe (ctx->h, error_topic) < 0) {
@@ -881,7 +880,7 @@ static int error_event_send (kvs_ctx_t *ctx, const char *ns,
     char *error_topic = NULL;
     int saved_errno, rc = -1;
 
-    if (asprintf (&error_topic, "kvs.error-%s", ns) < 0) {
+    if (asprintf (&error_topic, "kvs.namespace-%s-error", ns) < 0) {
         saved_errno = ENOMEM;
         flux_log_error (ctx->h, "%s: asprintf", __FUNCTION__);
         goto done;
@@ -2804,7 +2803,7 @@ static const struct flux_msg_handler_spec htab[] = {
     { FLUX_MSGTYPE_REQUEST, "kvs.stats.clear",stats_clear_request_cb, 0 },
     { FLUX_MSGTYPE_EVENT,   "kvs.stats.clear",stats_clear_event_cb, 0 },
     { FLUX_MSGTYPE_EVENT,   "kvs.namespace-*-setroot",  setroot_event_cb, 0 },
-    { FLUX_MSGTYPE_EVENT,   "kvs.error-*",    error_event_cb, 0 },
+    { FLUX_MSGTYPE_EVENT,   "kvs.namespace-*-error",    error_event_cb, 0 },
     { FLUX_MSGTYPE_REQUEST, "kvs.getroot",
                             getroot_request_cb, FLUX_ROLE_USER },
     { FLUX_MSGTYPE_REQUEST, "kvs.dropcache",  dropcache_request_cb, 0 },

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -2409,7 +2409,7 @@ static int namespace_create (kvs_ctx_t *ctx, const char *ns,
         goto cleanup;
     }
 
-    if (asprintf (&topic, "kvs.namespace-created-%s", ns) < 0)
+    if (asprintf (&topic, "kvs.namespace-%s-created", ns) < 0)
         goto cleanup;
 
     if (!(msg = flux_event_pack (topic,

--- a/t/t0017-security.t
+++ b/t/t0017-security.t
@@ -282,33 +282,33 @@ test_expect_success 'dispatcher suppresses guest event to same guest connection'
 	! grep -q test.a ev8.out
 '
 
-# kvs.setroot is a "private" event
+# kvs.namespace-<NS>-setroot is a "private" event
 
 test_expect_success 'loaded kvs module' '
 	flux module load kvs
 '
 
-test_expect_success 'connector delivers kvs.setroot event to owner connection' '
+test_expect_success 'connector delivers kvs.namespace-primary-setroot event to owner connection' '
 	run_timeout 5 \
 	    $SHARNESS_TEST_SRCDIR/scripts/event-trace-bypass.lua \
 		kvs kvs.test.end \
                 "flux event pub kvs.test.a; \
                  flux kvs put --json ev9=42; \
                  flux event pub kvs.test.end" >ev9.out &&
-	grep -q kvs.setroot ev9.out
+	grep -q kvs.namespace-primary-setroot ev9.out
 '
 
-test_expect_success 'dispatcher delivers kvs.setroot event to owner connection' '
+test_expect_success 'dispatcher delivers kvs.namespace-primary-setroot event to owner connection' '
 	run_timeout 5 \
 	    $SHARNESS_TEST_SRCDIR/scripts/event-trace.lua \
 		kvs kvs.test.end \
                 "flux event pub kvs.test.a; \
                  flux kvs put --json ev10=42; \
                  flux event pub kvs.test.end" >ev10.out &&
-	grep -q kvs.setroot ev10.out
+	grep -q kvs.namespace-primary-setroot ev10.out
 '
 
-test_expect_success 'connector suppresses kvs.setroot event to guest connection' '
+test_expect_success 'connector suppresses kvs.namespace-primary-setroot event to guest connection' '
 	flux module debug --set 4 connector-local &&
 	run_timeout 5 \
 	    $SHARNESS_TEST_SRCDIR/scripts/event-trace-bypass.lua \
@@ -316,7 +316,7 @@ test_expect_success 'connector suppresses kvs.setroot event to guest connection'
                 "flux event pub kvs.test.a; \
                  flux kvs put --json ev11=42; \
                  flux event pub kvs.test.end" >ev11.out &&
-	! grep -q kvs.setroot ev11.out
+	! grep -q kvs.namespace-primary-setroot ev11.out
 '
 
 test_expect_success 'unloaded kvs module' '


### PR DESCRIPTION
Per discussion in #2779 

Did another run of experiments, over 5 runs with 1024 jobs

on master - average 67.6 jobs/s, high 68.2, low 66.9
on branch - average 67.76 jobs/s, high 69.1, low 67.1

Dunno if it was an unlucky run and perhaps NFS is busy or something, but not as good as the first set of runs I did last week.

Over 5 runs doing 4096 jobs.

on master - average 65.66 jobs/s, high 66.0, low 65.3
on branch - average 65.56 jobs/s, high 66.1, low 64.6

So average was actually worse in this case, as well as haven't the worst run.  Eek!  Dunno if my earlier runs were just lucky.

As we discussed, perhaps its still a net win on average for this change.  But it's not as obviously better than we had hoped for.