### PR TITLE
doc: add flux job shell API manpages

### DIFF
--- a/doc/man3/Makefile.am
+++ b/doc/man3/Makefile.am
@@ -1,6 +1,23 @@
 MAN3_FILES = $(MAN3_FILES_PRIMARY) $(MAN3_FILES_SECONDARY)
 
 MAN3_FILES_PRIMARY = \
+        flux_shell_task_channel_subscribe.3 \
+	flux_shell_add_completion_ref.3 \
+	flux_shell_add_event_context.3 \
+	flux_shell_add_event_handler.3 \
+	flux_shell_aux_set.3 \
+	flux_shell_current_task.3 \
+	flux_shell_get_flux.3 \
+	flux_shell_get_info.3 \
+	flux_shell_getenv.3 \
+	flux_shell_getopt.3 \
+	flux_shell_killall.3 \
+	flux_shell_log.3 \
+	flux_shell_plugstack_call.3 \
+	flux_shell_rpc_pack.3 \
+	flux_shell_service_register.3 \
+	flux_shell_task_get_info.3 \
+	flux_shell_task_subprocess.3 \
 	flux_open.3 \
 	flux_send.3 \
 	flux_recv.3 \
@@ -54,6 +71,24 @@ MAN3_FILES_PRIMARY = \
 # These files are generated as roff .so includes of a primary page.
 # A2X handles this automatically if mentioned in NAME section
 MAN3_FILES_SECONDARY = \
+	flux_shell_remove_completion_ref.3 \
+	flux_shell_aux_get.3 \
+	flux_shell_task_first.3 \
+	flux_shell_task_next.3 \
+	flux_shell_info_unpack.3 \
+	flux_shell_get_rank_info.3 \
+	flux_shell_rank_info_unpack.3 \
+	flux_shell_get_environ.3 \
+	flux_shell_setenvf.3 \
+	flux_shell_unsetenv.3 \
+	flux_shell_getopt_unpack.3 \
+	flux_shell_setopt.3 \
+	flux_shell_setopt_pack.3 \
+	flux_shell_err.3 \
+	flux_shell_fatal.3 \
+	flux_shell_log_setlevel.3 \
+	flux_shell_task_info_unpack.3 \
+	flux_shell_task_cmd.3 \
 	flux_clone.3 \
 	flux_close.3 \
 	flux_requeue_nocopy.3 \
@@ -198,7 +233,24 @@ stderr_devnull_0 = 2>/dev/null
 	    --attribute manmanual="Flux Programming Reference" \
 	    --destination-dir $(builddir) \
 	    --doctype manpage $(ADOC_FORMAT_OPT) manpage $< $(STDERR_DEVNULL)
-
+flux_shell_remove_completion_ref.3: flux_shell_add_completion_ref.3 
+flux_shell_aux_get.3: flux_shell_aux_set.3
+flux_shell_task_first.3: flux_shell_current_task.3
+flux_shell_task_next.3: flux_shell_current_task.3
+flux_shell_info_unpack.3: flux_shell_get_info.3
+flux_shell_get_rank_info.3: flux_shell_get_info.3
+flux_shell_rank_info_unpack.3: flux_shell_get_info.3
+flux_shell_get_environ.3: flux_shell_getenv.3
+flux_shell_setenvf.3: flux_shell_getenv.3
+flux_shell_unsetenv.3: flux_shell_getenv.3
+flux_shell_getopt_unpack.3: flux_shell_getopt.3
+flux_shell_setopt.3: flux_shell_getopt.3
+flux_shell_setopt_pack.3: flux_shell_getopt.3
+flux_shell_err.3: flux_shell_log.3
+flux_shell_fatal.3: flux_shell_log.3
+flux_shell_log_setlevel.3: flux_shell_log.3
+flux_shell_task_info_unpack.3: flux_shell_task_get_info.3
+flux_shell_task_cmd.3: flux_shell_task_subprocess.3
 flux_clone.3: flux_open.3
 flux_close.3: flux_open.3
 flux_requeue_nocopy.3: flux_requeue.3

--- a/doc/man3/flux_shell_add_completion_ref.adoc
+++ b/doc/man3/flux_shell_add_completion_ref.adoc
@@ -1,0 +1,65 @@
+flux_shell_add_completion_ref(3) 
+================================
+:doctype: manpage
+
+NAME
+----
+flux_shell_add_completion_ref, flux_shell_remove_completion_ref - Manipulate conditions for job completion.
+
+SYNOPSIS
+--------
+ #include <flux/shell.h>
+ #include <errno.h>
+
+ int flux_shell_add_completion_ref (flux_shell_t *shell, 
+                                    const char *fmt, 
+                                    ...) 
+                                    __attribute__ ((format (printf, 2, 3)));
+
+ int flux_shell_remove_completion_ref (flux_shell_t *shell, 
+                                       const char *fmt, 
+                                       ...) 
+                                       __attribute__ ((format (printf, 2, 3)));
+
+DESCRIPTION
+-----------
+
+`flux_shell_add_completion_ref` creates a named "completion 
+reference" on the shell object `shell` so that the shell will
+not consider a job "complete" until the reference is released with
+`flux_shell_remove_completion_ref`. Once all references have been 
+removed, the shells reactor is stopped with 
+`flux_reactor_stop(shell->r)`.
+
+RETURN VALUE
+------------
+
+`flux_shell_add_completion_ref` returns the reference count for the 
+particular name, or -1 on error.
+ 
+`flux_shell_remove_completion_ref` returns 0 on success, -1 on failure.
+
+ERRORS
+------
+EINVAL::
+Either `shell` or `fmt` are NULL.
+
+AUTHOR
+------
+This page is maintained by the Flux community.
+
+
+RESOURCES
+---------
+Github: <http://github.com/flux-framework>
+
+
+COPYRIGHT
+---------
+include::COPYRIGHT.adoc[]
+
+
+SEE ALSO
+--------
+flux_reactor_stop(3)
+

--- a/doc/man3/flux_shell_add_event_context.adoc
+++ b/doc/man3/flux_shell_add_event_context.adoc
@@ -1,0 +1,54 @@
+flux_shell_add_event_context(3)
+===============================
+:doctype: manpage
+
+NAME
+----
+
+flux_shell_add_event_context - Add context information for standard shell events
+
+
+SYNOPSIS
+--------
+
+ #include <flux/shell.h>
+ #include <errno.h>
+
+ int flux_shell_add_event_context (flux_shell_t *shell, 
+                                   const char *name, 
+                                   int flags, 
+                                   const char *fmt, 
+                                   ...);
+
+DESCRIPTION
+-----------
+
+Add extra context that will be emitted with shell standard event
+`name` using Jansson `json_pack()` style arguments.  The `flags`
+parameter is currently unused.
+
+RETURN VALUE
+------------
+
+Returns 0 on success, -1 if `shell`, `name` or `fmt` are NULL.
+
+ERRORS
+------
+EINVAL::
+`shell`, `name` or `fmt` are NULL.  
+
+AUTHOR
+------
+This page is maintained by the Flux community.
+
+
+RESOURCES
+---------
+Github: <http://github.com/flux-framework>
+
+
+COPYRIGHT
+---------
+include::COPYRIGHT.adoc[]
+
+

--- a/doc/man3/flux_shell_add_event_handler.adoc
+++ b/doc/man3/flux_shell_add_event_handler.adoc
@@ -1,0 +1,54 @@
+flux_shell_add_event_handler(3)
+===============================
+:doctype: manpage
+
+NAME
+----
+flux_shell_add_event_handler - Add an event handler for a shell event
+
+SYNOPSIS
+--------
+
+ #include <flux/shell.h>
+ #include <errno.h>
+
+ int flux_shell_add_event_handler (flux_shell_t *shell, 
+                                   const char *subtopic, 
+                                   flux_msg_handler_f cb, 
+                                   void *arg);
+
+DESCRIPTION
+-----------
+When the shell initializes, it subscribes to all events with the
+substring `shell-JOBID.`, where `JOBID` is the jobid under which the
+shell is running. `flux_shell_add_event_handler()` registers a handler
+to be run for a *subtopic* within the shell's event namespace, e.g.
+registering a handler for `subtopic` `"kill"` will invoke the handler 
+`cb` whenever an event named `shell-JOBID.kill` is generated.
+
+RETURN VALUE
+------------
+
+Returns -1 if `shell`, `shell->h`, `subtopic` or `cb` are NULL, or if 
+underlying calls to `asprintf()` or `flux_msg_handler_create()` fail.
+
+ERRORS
+------
+EINVAL::
+`shell`, `shell->h`, `subtopic` or `cb` are NULL.  
+
+
+AUTHOR
+------
+This page is maintained by the Flux community.
+
+
+RESOURCES
+---------
+Github: <http://github.com/flux-framework>
+
+
+COPYRIGHT
+---------
+include::COPYRIGHT.adoc[]
+

--- a/doc/man3/flux_shell_aux_set.adoc
+++ b/doc/man3/flux_shell_aux_set.adoc
@@ -1,0 +1,100 @@
+flux_shell_aux_set(3)
+=====================
+:doctype: manpage
+
+
+NAME
+----
+flux_shell_aux_set, flux_shell_aux_get - get/set auxiliary handle data
+
+
+SYNOPSIS
+--------
+ #include <flux/shell.h>
+ #include <errno.h>
+
+ typedef void (*flux_free_f)(void *arg);
+
+ int flux_shell_aux_set (flux_shell_t *shell, 
+                         const char *name, 
+                         void *aux, 
+                         flux_free_f free_fn);
+
+ void * flux_shell_aux_get (flux_shell_t *shell, 
+                            const char *key);
+
+
+DESCRIPTION
+-----------
+flux_shell_aux_set() attaches application-specific data to the parent
+object. It stores data aux by key name, with optional destructor
+destroy.  The destructor, if non-NULL, is called when the parent
+object is destroyed, or when key is overwritten by a new value. If aux
+is NULL, the destructor for a previous value, if any is called, but no
+new value is stored. If name is NULL, aux is stored anonymously.
+
+flux_shell_aux_get() retrieves application-specific data by name. If
+the data was stored anonymously, it cannot be retrieved.
+
+The implementation (as opposed to the header file) uses the variable 
+names `shell`, `key`, `val` and `free_fn`, which may be more 
+intuitive.
+
+In most cases the key, value and free function will be non-null.  
+Several exceptions are supported.  
+
+First, if `key` and `val` are non-NULL but `free_fn` is null, the
+caller is responsible for memory management associated with the 
+value.
+
+Second, if `key` is NULL but `val` and `free_fun` are not NULL, 
+the lifetime of the object is tied to the lifetime of the underlying
+aux object; the object will be destroyed during the destruction
+of the aux.  The value cannot be retrieved.
+
+Third, a non-null `key` and a null `val` deletes the value previously
+associated with the key by calling its previously-associated `free_fn`,
+if the destructor exists.
+
+
+RETURN VALUE
+------------
+
+`flux_aux_set()` returns 0 on success, or -1 on failure, with errno set.
+
+`flux_shell_aux_get()` returns data on success, or NULL on failure, 
+with errno set.
+
+ERRORS
+------
+EINVAL::
+`shell` is null; or +
+both `name` (aka `key`) and `aux` (aka `val`) are null; or +
+`free_fn` is not null but `aux` is; or +
+`free_fn` and `name` are both null.
+
+ENOMEM::
+Out of memory.
+
+ENOENT::
+`flux_aux_get()` could not find an entry for _key_.
+
+
+AUTHOR
+------
+This page is maintained by the Flux community.
+
+
+RESOURCES
+---------
+Github: <http://github.com/flux-framework>
+
+
+COPYRIGHT
+---------
+include::COPYRIGHT.adoc[]
+
+
+SEE ALSO
+---------
+flux_aux_get(3), flux_aux_set(3)

--- a/doc/man3/flux_shell_current_task.adoc
+++ b/doc/man3/flux_shell_current_task.adoc
@@ -1,0 +1,58 @@
+flux_shell_current_task(3)
+==========================
+:doctype: manpage
+
+NAME
+----
+flux_shell_current_task, flux_shell_task_first, flux_shell_task_next - Get and iterate over shell tasks
+
+SYNOPSIS
+--------
+
+ #include <flux/shell.h>
+ #include <errno.h>
+
+ flux_shell_task_t *flux_shell_current_task (flux_shell_t *shell);
+
+ flux_shell_task_t *flux_shell_task_first (flux_shell_t *shell);
+
+ flux_shell_task_t *flux_shell_task_next (flux_shell_t *shell); 
+
+DESCRIPTION
+-----------
+
+flux_shell_task_first and flux_shell_task_next are used to iterate
+over all current tasks known to the shell.
+
+`flux_shell_current_task` returns the current task for `task_init`, 
+`task_exec` and `task_exec` callbacks and NULL in any other 
+context.
+
+`flux_shell_task_first` and `flux_shell_task_next` return the first 
+and next tasks, respectively.  
+
+RETURN VALUE
+------------
+The relevant `flux_shell_task_t*` value, or NULL on error.
+
+ERRORS
+------
+EINVAL:: 
+`shell` is NULL.
+
+EAGAIN:: 
+There are no tasks.
+
+AUTHOR
+------
+This page is maintained by the Flux community.
+
+
+RESOURCES
+---------
+Github: <http://github.com/flux-framework>
+
+
+COPYRIGHT
+---------
+include::COPYRIGHT.adoc[]

--- a/doc/man3/flux_shell_get_flux.adoc
+++ b/doc/man3/flux_shell_get_flux.adoc
@@ -1,0 +1,72 @@
+flux_shell_get_flux(3)
+======================
+:doctype: manpage
+
+
+NAME
+----
+flux_shell_get_flux - Get a flux_t* object from flux shell handle
+
+
+SYNOPSIS
+--------
+ #include <flux/shell.h> 
+
+ flux_t *flux_shell_get_flux (flux_shell_t *shell);
+
+
+DESCRIPTION
+-----------
+
+Returns the Flux handle.  
+
+RETURN VALUE
+------------
+
+Returns the Flux handle.
+
+ERRORS
+------
+
+No error conditions are possible.
+
+
+EXAMPLE
+-------
+
+ // Set a timer in flux_plugin_init().
+
+ void flux_plugin_init (flux_plugin_t *p){
+ 
+ // Get the shell handle,
+ flux_shell_t *shell = flux_plugin_get_shell( p );       
+
+ // use that to get the flux handle,
+ flux_t *flux = flux_shell_get_flux( shell );            
+
+ // and use that to get the reactor handle.
+ flux_reactor_t *reactor = flux_get_reactor( flux );     
+ 
+ flux_watcher_t* timer   = flux_timer_watcher_create( reactor, 0.1, 0.1, timer_cb, NULL );
+ flux_watcher_start(timer);
+ 
+ ....
+ 
+
+
+AUTHOR
+------
+This page is maintained by the Flux community.
+
+
+RESOURCES
+---------
+Github: <http://github.com/flux-framework>
+
+
+COPYRIGHT
+---------
+include::COPYRIGHT.adoc[]
+
+
+

--- a/doc/man3/flux_shell_get_info.adoc
+++ b/doc/man3/flux_shell_get_info.adoc
@@ -1,0 +1,86 @@
+flux_shell_get_info(3)
+======================
+:doctype: manpage
+
+NAME
+----
+flux_shell_get_info, flux_shell_info_unpack, flux_shell_get_rank_info, flux_shell_rank_info_unpack - Manage shell info and rank info
+
+SYNOPSIS
+--------
+ #include <flux/shell.h>
+ #include <errno.h>
+
+ int flux_shell_get_info (flux_shell_t *shell, 
+                         char **json_str);
+
+ int flux_shell_info_unpack (flux_shell_t *shell, 
+                            const char *fmt, 
+                            ...);
+
+ int flux_shell_get_rank_info (flux_shell_t *shell, 
+                               int shell_rank, 
+                               char **json_str);
+ 
+ int flux_shell_rank_info_unpack (flux_shell_t *shell, 
+                                  int shell_rank, 
+                                  const char *fmt, 
+                                  ...);
+
+DESCRIPTION
+-----------
+
+`flux_shell_get_info()` returns shell information as a json string 
+with the following layout:
+
+ "jobid":I,
+ "rank":i,
+ "size":i,
+ "ntasks";i,
+ "options": { "verbose":b, "standalone":b },
+ "jobspec":o,
+ "R":o
+
+`flux_shell_get_rank_info()` returns shell rank information as a json
+string with the following layout:
+
+ "broker_rank":i,
+ "ntasks":i
+ "resources": { "cores":s, ... }
+
+`flux_shell_info_unpack()` and `flux_shell_rank_info_unpack()` 
+accomplished the same thing with Jansson-style formatting arguments.
+
+If `shell_rank` is set to -1, the current shell rank is used.
+
+RETURN VALUE
+------------
+
+All functions return 0 on success and -1 on error.
+
+ERRORS
+------
+EINVAL:: 
+if `shell` is NULL, or either `json_str` or `fmt` are NULL, or if 
+`shell_rank` is less than -1.
+
+
+SEE ALSO
+--------
+For an overview of the Jansson API, see https://jansson.readthedocs.io/en/2.8/apiref.html.
+
+AUTHOR
+------
+This page is maintained by the Flux community.
+
+
+RESOURCES
+---------
+Github: <http://github.com/flux-framework>
+
+
+COPYRIGHT
+---------
+include::COPYRIGHT.adoc[]
+
+

--- a/doc/man3/flux_shell_getenv.adoc
+++ b/doc/man3/flux_shell_getenv.adoc
@@ -1,0 +1,69 @@
+flux_shell_getenv(3)
+====================
+:doctype: manpage
+
+NAME
+----
+flux_shell_getenv, flux_shell_get_environ, flux_shell_setenvf, flux_shell_unsetenv - Get and set global environment variables
+
+SYNOPSIS
+--------
+
+ #include <flux/shell.h>
+ #include <errno.h>
+
+ const char * flux_shell_getenv (flux_shell_t *shell, 
+                                 const char *name);
+
+ int flux_shell_get_environ (flux_shell_t *shell, 
+                             char **json_str);
+
+ int flux_shell_setenvf (flux_shell_t *shell, 
+                         int overwrite, 
+                         const char *name, 
+                         const char *fmt, 
+                         ...) 
+                         __attribute__ ((format (printf, 4, 5)));
+
+ int flux_shell_unsetenv (flux_shell_t *shell, 
+                          const char *name);
+
+DESCRIPTION
+-----------
+`flux_shell_getenv()` returns the value of an environment variable from the global job environment.
+`flux_shell_get_environ()` returns 0 on success with `*json_str` set
+to an allocated JSON string, or -1 on failure with `errno` set.
+`flux_shell_setenvf()` sets an environment variable in the global job
+environment using `printf(3)` style format arguments.
+`flux_shell_unsetenv()` unsets the specified environment variable in the global job environment.
+
+RETURN VALUE
+------------
+`flux_shell_getenv()` returns NULL if either `shell` or `name` is NULL, or if the variable is not found.
+
+`flux_shell_get_environ()` returns a json string on success or NULL on failure.
+
+`flux_shell_setenvf()` and `flux_shell_unsetenv()` return 0 on success and -1 on failure.
+
+ERRORS
+------
+EINVAL::
+`shell`, `name` or `fmt` is NULL.
+
+EEXIST:: 
+The variable already exists and `overwrite` was not non-zero (`flux_shell_setenvf()`).
+
+AUTHOR
+------
+This page is maintained by the Flux community.
+
+
+RESOURCES
+---------
+Github: <http://github.com/flux-framework>
+
+
+COPYRIGHT
+---------
+include::COPYRIGHT.adoc[]
+

--- a/doc/man3/flux_shell_getopt.adoc
+++ b/doc/man3/flux_shell_getopt.adoc
@@ -1,0 +1,75 @@
+flux_shell_getopt(3)
+====================
+:doctype: manpage
+
+NAME
+----
+flux_shell_getopt, flux_shell_getopt_unpack, flux_shell_setopt, flux_shell_setopt_pack - Get and set shell options
+
+SYNOPSIS
+--------
+
+ #include <flux/shell.h>
+ #include <errno.h>
+
+ int flux_shell_getopt (flux_shell_t *shell, 
+                        const char *name, 
+                        char **json_str);
+
+ int flux_shell_getopt_unpack (flux_shell_t *shell, 
+                               const char *name, 
+                               const char *fmt, 
+                               ...);
+
+ int flux_shell_setopt (flux_shell_t *shell, 
+                        const char *name, 
+                        const char *json_str);
+
+ int flux_shell_setopt_pack (flux_shell_t *shell, 
+                             const char *name, 
+                             const char *fmt, 
+                             ...);
+
+DESCRIPTION
+-----------
+
+`flux_shell_getopt()` gets shell option `name` as a JSON string from jobspec
+`attributes.system.shell.options.name`.
+
+`flux_shell_setopt()` sets shell option `name`, making it available to 
+subsequent calls from `flux_shell_getopt()`.  If `json_str` is NULL,
+the option is unset.
+
+`flux_shell_getopt_unpack()` and `flux_shell_setopt_unpack()` use Jansson 
+format strings to accomplish the same functionality.
+
+RETURN VALUE
+------------
+`flux_shell_getopt()` and `flux_shell_getopt_unpack()` return 1 on success, 0 if `name` was not set, 
+and -1 on error, 
+
+`flux_shell_setopt()` and `flux_shell_setopt_pack` return 0 on success and -1 on error. 
+
+ERRORS
+------
+EINVAL::
+`name` or `shell` is NULL.
+
+ENOMEM::
+The process has exhausted its memory.
+
+AUTHOR
+------
+This page is maintained by the Flux community.
+
+
+RESOURCES
+---------
+Github: <http://github.com/flux-framework>
+
+
+COPYRIGHT
+---------
+include::COPYRIGHT.adoc[]
+
+

--- a/doc/man3/flux_shell_killall.adoc
+++ b/doc/man3/flux_shell_killall.adoc
@@ -1,0 +1,43 @@
+flux_shell_killall(3)
+=====================
+:doctype: manpage
+
+NAME
+----
+flux_shell_killall - Send the specified signal to all processes in the shell
+
+SYNOPSIS
+--------
+ #include <flux/shell.h>
+
+ void flux_shell_killall (flux_shell_t *shell, 
+                          int sig);
+
+DESCRIPTION
+-----------
+Sends the signal `sig` to all processes running in `shell`.  No errors are 
+set, but the call returns immediately if `shell` is NULL or if `sig` is 
+zero or negative.
+
+RETURN VALUE
+------------
+
+None.
+
+ERRORS
+------
+None.
+
+AUTHOR
+------
+This page is maintained by the Flux community.
+
+
+RESOURCES
+---------
+Github: <http://github.com/flux-framework>
+
+
+COPYRIGHT
+---------
+include::COPYRIGHT.adoc[]

--- a/doc/man3/flux_shell_log.adoc
+++ b/doc/man3/flux_shell_log.adoc
@@ -1,0 +1,135 @@
+flux_shell_log(3)
+=================
+:doctype: manpage
+
+
+NAME
+----
+flux_shell_log, flux_shell_err, flux_shell_fatal, flux_shell_log_setlevel - Log shell plugin messages to registered shell loggers
+
+
+SYNOPSIS
+--------
+ #include <flux/shell.h> 
+ #include <errno.h>
+
+ void flux_shell_log (int level, 
+                      const char *file, 
+                      int line, 
+                      const char *fmt, 
+                      ...)
+                      __attribute__ ((format (printf, 4, 5)));
+
+ int flux_shell_err (const char *file, 
+                     int line, 
+                     int errnum, 
+                     const char *fmt, 
+                     ...) 
+                     __attribute__ ((format (printf, 4, 5)));
+
+ void flux_shell_fatal (const char *file, 
+                        int line, 
+                        int errnum, 
+                        int exit_code, 
+                        const char *fmt, 
+                        ...) 
+                        __attribute__ ((format (printf, 5, 6)));
+
+ int flux_shell_log_setlevel (int level, 
+                              const char *dest);
+
+
+DESCRIPTION
+-----------
+
+`flux_shell_log()` logs a message at `level` to all loggers registered
+to receive messages at that severity or greater.  See `flux_log` for a
+list of supported levels.  The following macros handle common levels.
+
+ #define shell_trace(...) \
+ flux_shell_log (FLUX_SHELL_TRACE, __FILE__, __LINE__, __VA_ARGS__)
+
+ #define shell_debug(...) \
+ flux_shell_log (FLUX_SHELL_DEBUG, __FILE__, __LINE__, __VA_ARGS__)
+
+ #define shell_log(...) \
+ flux_shell_log (FLUX_SHELL_NOTICE, __FILE__, __LINE__, __VA_ARGS__)
+
+ #define shell_warn(...) \
+ flux_shell_log (FLUX_SHELL_WARN, __FILE__, __LINE__, __VA_ARGS__)
+
+ #define shell_log_error(...) \
+ flux_shell_log (FLUX_SHELL_ERROR, __FILE__, __LINE__, __VA_ARGS__)
+
+`flux_shell_err()` logs a message at FLUX_SHELL_ERROR level,
+additionally appending the result of strerror(`errnum`) for
+convenience.  Macros include:
+
+ #define shell_log_errn(errn, ...) \
+ flux_shell_err (__FILE__, __LINE__, errn, __VA_ARGS__)
+
+ #define shell_log_errno(...) \
+ flux_shell_err (__FILE__, __LINE__, errno, __VA_ARGS__)
+
+Note that `errno` is the standard global value defined in `errno.h` 
+and `errn` is a user-provided error code.
+
+`flux_shell_fatal()` logs a message at FLUX_SHELL_FATAL level and 
+schedules termination of the job shell.  This may generate an 
+exception if tasks are already running. Exits with `exit_code`.
+While the macro names are similar to those using `flux_shell_err()`,
+note that the choices of `errnum` are either 0 or `errno`.
+
+ #define shell_die(code,...) \
+ flux_shell_fatal (__FILE__, __LINE__, 0, code, __VA_ARGS__)
+
+ #define shell_die_errno(code,...) \
+ flux_shell_fatal (__FILE__, __LINE__, errno, code, __VA_ARGS__)
+
+`flux_shell_log_setlevel()` sets default severity of logging
+destination `dest` to `level`.  If `dest` is NULL then the internal
+log dispatch level is set (i.e. no messages above severity level will
+be logged to any log destination).  Macros include:
+
+ #define shell_set_verbose(n) \
+ flux_shell_log_setlevel(FLUX_SHELL_NOTICE+n, NULL)
+
+ #define shell_set_quiet(n) \
+ flux_shell_log_setlevel(FLUX_SHELL_NOTICE-n, NULL)
+
+
+RETURN VALUE
+------------
+
+`flux_shell_err()` returns -1 with errno = errnum, so that the
+function can be used as:
+ return flux_shell_err(...);
+
+`flux_shell_log_setlevel()` will return -1 and set `errno` to EINVAL
+if the requested `level` is not valid or if `dest` is not a valid 
+pointer to a logger shell.
+
+ERRORS:
+-------
+EINVAL::
+`level` or `dest` is not valid.
+
+AUTHOR
+------
+This page is maintained by the Flux community.
+
+
+RESOURCES
+---------
+Github: <http://github.com/flux-framework>
+
+
+COPYRIGHT
+---------
+include::COPYRIGHT.adoc[]
+
+
+SEE ALSO
+--------
+flux_log(3)
+

--- a/doc/man3/flux_shell_plugstack_call.adoc
+++ b/doc/man3/flux_shell_plugstack_call.adoc
@@ -1,0 +1,53 @@
+flux_shell_plugstack_call(3)
+============================
+:doctype: manpage
+
+NAME
+----
+flux_shell_plugstack_call - Calls the function referenced by topic.
+
+
+SYNOPSIS
+--------
+ #include <flux/shell.h>
+
+ int flux_shell_plugstack_call (flux_shell_t *shell, 
+                                const char *topic, 
+                                flux_plugin_arg_t *args);
+
+DESCRIPTION
+-----------
+
+The job shell implements a flexible plugin architecture which allows
+registration of one or more callback functions on arbitrary topic
+names. The stack of functions "listening" on a given topic string is
+called the "plugin stack". `flux_shell_plugstack_call()` exports the
+ability to call into the plugin stack so that plugins can invoke
+callbacks from other plugins.
+
+RETURN VALUE
+------------
+
+Returns 0 on success and -1 on failure, setting errno.
+
+ERRORS:
+-------
+EINVAL:: 
+`shell` or `topic` are NULL.
+
+
+AUTHOR
+------
+This page is maintained by the Flux community.
+
+
+RESOURCES
+---------
+Github: <http://github.com/flux-framework>
+
+
+COPYRIGHT
+---------
+include::COPYRIGHT.adoc[]
+ 
+

--- a/doc/man3/flux_shell_rpc_pack.adoc
+++ b/doc/man3/flux_shell_rpc_pack.adoc
@@ -1,0 +1,53 @@
+flux_shell_rpc_pack(3)
+======================
+:doctype: manpage
+
+NAME
+----
+flux_shell_rpc_pack - perform an rpc to a running flux shell using Jansson style pack arguments
+
+SYNOPSIS
+--------
+
+ #include <flux/shell.h>
+ #include <errno.h>
+
+ flux_future_t *flux_shell_rpc_pack (flux_shell_t *shell, 
+                                     const char *method, 
+                                     int shell_rank, 
+                                     int flags, 
+                                     const char *fmt, 
+                                     ...);
+
+DESCRIPTION
+-----------
+
+Send a remote procedure call `method` to another shell in the same 
+job at shell rank `shell_rank`.
+
+RETURN VALUE
+------------
+
+Returns NULL on failure.
+
+
+ERRORS
+------
+EINVAL::
+`shell`, `method` or `fmt` are NULL, or if `rank` is less than 0.  
+
+AUTHOR
+------
+This page is maintained by the Flux community.
+
+
+RESOURCES
+---------
+Github: <http://github.com/flux-framework>
+
+
+COPYRIGHT
+---------
+include::COPYRIGHT.adoc[]
+
+

--- a/doc/man3/flux_shell_service_register.adoc
+++ b/doc/man3/flux_shell_service_register.adoc
@@ -1,0 +1,55 @@
+flux_shell_service_register(3)
+==============================
+:doctype: manpage
+
+NAME
+----
+flux_shell_service_register - Register a service handler for `method` in the shell.
+
+SYNOPSIS
+--------
+
+ #include <flux/shell.h>
+
+ int flux_shell_service_register (flux_shell_t *shell, 
+                                  const char *method, 
+                                  flux_msg_handler_f cb, 
+                                  void *arg);
+
+DESCRIPTION
+-----------
+
+The job shell registers a unique service name with the flux broker on
+startup, and posts the topic string for this service in the context of
+the `shell.init` event.  `flux_shell_service_register()` allows
+registration of a request handler `cb` for subtopic `method`  on this
+service endpoint, allowing other job shells and/or flux commands to
+interact with arbitrary services within a job.
+
+RETURN VALUE
+------------
+
+Returns -1 on failure, 0 on success.
+
+ERRORS
+------
+EINVAL::
+`shell`, `method` or `cb` is NULL.  
+
+AUTHOR
+------
+This page is maintained by the Flux community.
+
+
+RESOURCES
+---------
+Github: <http://github.com/flux-framework>
+
+SEE ALSO
+--------
+`flux_msg_handler_create(3)`
+
+COPYRIGHT
+---------
+include::COPYRIGHT.adoc[]
+

--- a/doc/man3/flux_shell_task_channel_subscribe.adoc
+++ b/doc/man3/flux_shell_task_channel_subscribe.adoc
@@ -1,0 +1,54 @@
+flux_shell_task_channel_subscribe(3)
+====================================
+:doctype: manpage
+
+NAME
+----
+flux_shell_task_channel_subscribe - Call `cb` when `name` is ready for reading.
+
+SYNOPSIS
+--------
+
+ #include <flux/shell.h>
+
+ int flux_shell_task_channel_subscribe (flux_shell_task_t *task, 
+                                        const char *channel, 
+                                        flux_shell_task_io_f cb, 
+                                        void *arg);
+
+DESCRIPTION
+-----------
+
+Call `cb` when shell task output channel `name` is ready for reading.
+
+Callback can then call `flux_shell_task_get_subprocess()` and use
+`flux_subprocess_read()` or `getline()` on the result to get
+available data.  Only one subscriber per stream is allowed. 
+
+RETURN VALUE
+------------
+Returns 0 on success and -1 on error.
+
+Not yet implemented.
+
+ERRORS
+------
+EEXIST::
+`flux_shell_task_channel_subscribe()` is called on a stream with an 
+existing subscriber 
+
+AUTHOR
+------
+This page is maintained by the Flux community.
+
+
+RESOURCES
+---------
+Github: <http://github.com/flux-framework>
+
+
+COPYRIGHT
+---------
+include::COPYRIGHT.adoc[]
+
+

--- a/doc/man3/flux_shell_task_get_info.adoc
+++ b/doc/man3/flux_shell_task_get_info.adoc
@@ -1,0 +1,59 @@
+flux_shell_task_get_info(3)
+===========================
+:doctype: manpage
+
+NAME
+----
+flux_shell_task_get_info, flux_shell_task_info_unpack - interfaces for fetching task info
+
+SYNOPSIS
+--------
+ #include <flux/shell.h>
+
+ int flux_shell_task_get_info (flux_shell_task_t *task, 
+                               char **json_str);
+
+ int flux_shell_task_info_unpack (flux_shell_task_t *task, 
+                                  const char *fmt, ...);
+
+DESCRIPTION
+-----------
+
+Returns task info either as a json string (specified below) or 
+using Jansson-style parameters.  The structure of the former is:
+
+ "localid":i,
+ "rank":i,
+ "state":s,
+ "pid":I,
+ "wait_status":i,
+ "exitcode":i,
+ "signaled":i
+ 
+RETURN VALUE
+------------
+
+Returns 0 on success and -1 on failure.  A failure will not
+necessarily set errno.
+
+ERRORS
+------
+EINVAL::
+If `task` or `json_str` is NULL.
+
+AUTHOR
+------
+This page is maintained by the Flux community.
+
+
+RESOURCES
+---------
+Github: <http://github.com/flux-framework>
+
+
+COPYRIGHT
+---------
+include::COPYRIGHT.adoc[]
+
+
+

--- a/doc/man3/flux_shell_task_subprocess.adoc
+++ b/doc/man3/flux_shell_task_subprocess.adoc
@@ -1,0 +1,53 @@
+flux_shell_task_subprocess(3)
+=============================
+:doctype: manpage
+
+NAME
+----
+flux_shell_task_subprocess, flux_shell_task_cmd - return the subprocess and cmd structure of a shell task, respectively
+
+SYNOPSIS
+--------
+
+ #include <flux/shell.h>
+
+ flux_subprocess_t *flux_shell_task_subprocess (flux_shell_task_t *task)
+
+ flux_cmd_t *flux_shell_task_cmd (flux_shell_task_t *task)
+
+DESCRIPTION
+-----------
+ 
+`flux_shell_task_subprocess` returns the subprocess for a shell 
+task in `task_fork` and `task_exit` callbacks.
+
+`flux_shell_task_cmd` returns the cmd structure for a shell task.
+
+RETURN VALUE
+------------
+
+`flux_shell_task_subprocess` returns the `proc` field of the 
+`task`, and `flux_shell_task_cmd` returns the `cmd` field,  
+or NULL on error.
+
+ERRORS
+------
+EINVAL::
+`task` is NULL.
+
+AUTHOR
+------
+This page is maintained by the Flux community.
+
+
+RESOURCES
+---------
+Github: <http://github.com/flux-framework>
+
+
+COPYRIGHT
+---------
+include::COPYRIGHT.adoc[]
+
+
+

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -1,4 +1,19 @@
 personal_ws-1.1 en 0
+proc
+localid
+exitcode
+getline
+plugstack
+setlevel
+errn
+dest
+killall
+sig
+unsets
+setenvf
+environ
+substring
+asprintf
 KVS
 kvs
 api


### PR DESCRIPTION
These will need to be converted to rst.  Several files cover multiple functions; there should be one file per function eventually.

Here is the list of new files:

flux_shell_add_completion_ref.adoc
flux_shell_add_event_context.adoc
flux_shell_add_event_handler.adoc
flux_shell_aux_set.adoc
flux_shell_current_task.adoc
flux_shell_get_flux.adoc
flux_shell_get_info.adoc
flux_shell_getenv.adoc
flux_shell_getopt.adoc
flux_shell_killall.adoc
flux_shell_log.adoc
flux_shell_plugstack_call.adoc
flux_shell_rpc_pack.adoc
flux_shell_service_register.adoc
flux_shell_task_get_info.adoc
flux_shell_task_subprocess.adoc
