### PR TITLE
broker: clean shutdown on SIGTERM, add broker.rc2_none attribute

### DIFF
--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -328,8 +328,6 @@ int main (int argc, char *argv[])
         oom ();
     if (!(ctx.cache = content_cache_create ()))
         oom ();
-    if (!(ctx.runlevel = runlevel_create ()))
-        oom ();
     if (!(ctx.publisher = publisher_create ()))
         oom ();
 
@@ -543,11 +541,6 @@ int main (int argc, char *argv[])
         const char *rc2 = ctx.init_shell_cmd;
         size_t rc2_len = ctx.init_shell_cmd_len;
 
-        if (runlevel_register_attrs (ctx.runlevel, ctx.attrs) < 0) {
-            log_err ("configuring runlevel attributes");
-            goto cleanup;
-        }
-
         if (attr_get (ctx.attrs, "local-uri", &uri, NULL) < 0) {
             log_err ("local-uri is not set");
             goto cleanup;
@@ -565,9 +558,13 @@ int main (int argc, char *argv[])
             goto cleanup;
         }
 
+        if (!(ctx.runlevel = runlevel_create (ctx.h, ctx.attrs))) {
+            log_err ("creating runlevel handler");
+            goto cleanup;
+        }
+
         runlevel_set_callback (ctx.runlevel, runlevel_cb, &ctx);
         runlevel_set_io_callback (ctx.runlevel, runlevel_io_cb, &ctx);
-        runlevel_set_flux (ctx.runlevel, ctx.h);
 
         if (runlevel_set_rc (ctx.runlevel,
                              1,

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -566,13 +566,15 @@ int main (int argc, char *argv[])
         runlevel_set_callback (ctx.runlevel, runlevel_cb, &ctx);
         runlevel_set_io_callback (ctx.runlevel, runlevel_io_cb, &ctx);
 
-        if (runlevel_set_rc (ctx.runlevel,
-                             1,
-                             rc1,
-                             rc1 ? strlen (rc1) + 1 : 0,
-                             uri) < 0) {
-            log_err ("runlevel_set_rc 1");
-            goto cleanup;
+        if (rc1 && strlen (rc1) > 0) {
+            if (runlevel_set_rc (ctx.runlevel,
+                                 1,
+                                 rc1,
+                                 strlen (rc1) + 1,
+                                 uri) < 0) {
+                log_err ("runlevel_set_rc 1");
+                goto cleanup;
+            }
         }
 
         if (runlevel_set_rc (ctx.runlevel,
@@ -584,13 +586,15 @@ int main (int argc, char *argv[])
             goto cleanup;
         }
 
-        if (runlevel_set_rc (ctx.runlevel,
-                             3,
-                             rc3,
-                             rc3 ? strlen (rc3) + 1 : 0,
-                             uri) < 0) {
-            log_err ("runlevel_set_rc 3");
-            goto cleanup;
+        if (rc3 && strlen (rc3) > 0) {
+            if (runlevel_set_rc (ctx.runlevel,
+                                 3,
+                                 rc3,
+                                 strlen (rc3) + 1,
+                                 uri) < 0) {
+                log_err ("runlevel_set_rc 3");
+                goto cleanup;
+            }
         }
     }
 

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -559,7 +559,6 @@ int main (int argc, char *argv[])
             goto cleanup;
         }
 
-        runlevel_set_size (ctx.runlevel, size);
         runlevel_set_callback (ctx.runlevel, runlevel_cb, &ctx);
         runlevel_set_io_callback (ctx.runlevel, runlevel_io_cb, &ctx);
         runlevel_set_flux (ctx.runlevel, ctx.h);

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -1860,8 +1860,10 @@ static void signal_cb (flux_reactor_t *r, flux_watcher_t *w,
     int rank = overlay_get_rank (ctx->overlay);
     int signum = flux_signal_watcher_get_signum (w);
 
-    log_msg ("signal %d (%s) on rank %u", signum, strsignal (signum), rank);
-    _exit (1);
+    if (rank > 0 || runlevel_abort (ctx->runlevel) < 0) {
+        log_msg ("signal %d (%s) on rank %u", signum, strsignal (signum), rank);
+        _exit (1);
+    }
 }
 
 /* Send a request message down the TBON.

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -546,11 +546,11 @@ int main (int argc, char *argv[])
             goto cleanup;
         }
         if (attr_get (ctx.attrs, "broker.rc1_path", &rc1, NULL) < 0) {
-            log_err ("conf.rc1_path is not set");
+            log_err ("broker.rc1_path is not set");
             goto cleanup;
         }
         if (attr_get (ctx.attrs, "broker.rc3_path", &rc3, NULL) < 0) {
-            log_err ("conf.rc3_path is not set");
+            log_err ("broker.rc3_path is not set");
             goto cleanup;
         }
         if (attr_get (ctx.attrs, "conf.pmi_library_path", &pmi, NULL) < 0) {

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -112,7 +112,7 @@ typedef struct {
     /* Bootstrap
      */
     hello_t *hello;
-    runlevel_t *runlevel;
+    struct runlevel *runlevel;
 
     char *init_shell_cmd;
     size_t init_shell_cmd_len;
@@ -144,10 +144,16 @@ static int unload_module_byname (broker_ctx_t *ctx, const char *name,
                                  const flux_msg_t *request);
 
 static void set_proctitle (uint32_t rank);
-static void runlevel_cb (runlevel_t *r, int level, int rc, double elapsed,
-                         const char *state, void *arg);
-static void runlevel_io_cb (runlevel_t *r, const char *name,
-                            const char *msg, void *arg);
+static void runlevel_cb (struct runlevel *r,
+                         int level,
+                         int rc,
+                         double elapsed,
+                         const char *state,
+                         void *arg);
+static void runlevel_io_cb (struct runlevel *r,
+                            const char *name,
+                            const char *msg,
+                            void *arg);
 
 static int create_rundir (attr_t *attrs);
 static int create_broker_rundir (overlay_t *ov, void *arg);
@@ -916,8 +922,10 @@ static void set_proctitle (uint32_t rank)
 
 /* Handle line by line output on stdout, stderr of runlevel subprocess.
  */
-static void runlevel_io_cb (runlevel_t *r, const char *name,
-                            const char *msg, void *arg)
+static void runlevel_io_cb (struct runlevel *r,
+                            const char *name,
+                            const char *msg,
+                            void *arg)
 {
     broker_ctx_t *ctx = arg;
     int loglevel = !strcmp (name, "stderr") ? LOG_ERR : LOG_INFO;
@@ -928,8 +936,12 @@ static void runlevel_io_cb (runlevel_t *r, const char *name,
 
 /* Handle completion of runlevel subprocess.
  */
-static void runlevel_cb (runlevel_t *r, int level, int rc, double elapsed,
-                         const char *exit_string, void *arg)
+static void runlevel_cb (struct runlevel *r,
+                         int level,
+                         int rc,
+                         double elapsed,
+                         const char *exit_string,
+                         void *arg)
 {
     broker_ctx_t *ctx = arg;
     int new_level = -1;

--- a/src/broker/runlevel.c
+++ b/src/broker/runlevel.c
@@ -69,10 +69,8 @@ void runlevel_destroy (struct runlevel *r)
         int saved_errno = errno;
         int i;
         for (i = 0; i < 4; i++) {
-            if (r->rc[i].p)
-                flux_subprocess_destroy (r->rc[i].p);
-            if (r->rc[i].cmd)
-                flux_cmd_destroy (r->rc[i].cmd);
+            flux_subprocess_destroy (r->rc[i].p);
+            flux_cmd_destroy (r->rc[i].cmd);
         }
         free (r);
         errno = saved_errno;

--- a/src/broker/runlevel.c
+++ b/src/broker/runlevel.c
@@ -38,7 +38,6 @@ struct runlevel {
     void *cb_arg;
     runlevel_io_cb_f io_cb;
     void *io_cb_arg;
-    char nodeset[64];
     const char *mode;
 };
 
@@ -140,18 +139,6 @@ int runlevel_register_attrs (runlevel_t *r, attr_t *attrs)
                          runlevel_attr_get, runlevel_attr_set, r) < 0)
         return -1;
     return 0;
-}
-
-void runlevel_set_size (runlevel_t *r, uint32_t size)
-{
-    int n;
-
-    if (size > 1)
-        n = snprintf (r->nodeset, sizeof (r->nodeset),
-                      "[0-%" PRIu32 "]", size - 1);
-    else
-        n = snprintf (r->nodeset, sizeof (r->nodeset), "[0]");
-    assert (n < sizeof (r->nodeset));
 }
 
 void runlevel_set_callback (runlevel_t *r, runlevel_cb_f cb, void *arg)
@@ -335,11 +322,6 @@ int runlevel_set_rc (runlevel_t *r, int level, const char *cmd_argz,
     if (local_uri && flux_cmd_setenvf (cmd, 1, "FLUX_URI",
                                        "%s", local_uri) < 0)
         goto error;
-    if (level == 1 || level == 3) {
-        if (flux_cmd_setenvf (cmd, 1, "FLUX_NODESET_MASK",
-                              "%s", r->nodeset) < 0)
-            goto error;
-    }
     r->rc[level].cmd = cmd;
     return 0;
 error:

--- a/src/broker/runlevel.c
+++ b/src/broker/runlevel.c
@@ -21,7 +21,6 @@
 
 #include "src/common/libutil/log.h"
 #include "src/common/libutil/monotime.h"
-#include "src/common/libutil/fsd.h"
 
 #include "runlevel.h"
 
@@ -29,8 +28,6 @@ struct level {
     flux_subprocess_t *p;
     flux_cmd_t *cmd;
     struct timespec start;
-    double timeout;
-    flux_watcher_t *timer;
 };
 
 struct runlevel {
@@ -65,7 +62,6 @@ void runlevel_destroy (runlevel_t *r)
                 flux_subprocess_destroy (r->rc[i].p);
             if (r->rc[i].cmd)
                 flux_cmd_destroy (r->rc[i].cmd);
-            flux_watcher_destroy (r->rc[i].timer);
         }
         free (r);
     }
@@ -98,11 +94,6 @@ static int runlevel_attr_get (const char *name, const char **val, void *arg)
         snprintf (s, sizeof (s), "%d", runlevel_get_level (r));
         if (val)
             *val = s;
-    } else if (!strcmp (name, "init.rc2_timeout")) {
-        static char s[16];
-        snprintf (s, sizeof (s), "%.1f", r->rc[2].timeout);
-        if (val)
-            *val = s;
     } else if (!strcmp (name, "init.mode")) {
         *val = r->mode;
     } else {
@@ -121,11 +112,6 @@ static int runlevel_attr_set (const char *name, const char *val, void *arg)
     if (!strcmp (name, "init.mode")) {
         if (runlevel_set_mode (r, val) < 0)
             goto error;
-    } else if (!strcmp (name, "init.rc2_timeout")) {
-        if (fsd_parse_duration (val, &r->rc[2].timeout) < 0) {
-            errno = EINVAL;
-            goto error;
-        }
     } else {
         errno = EINVAL;
         goto error;
@@ -153,16 +139,6 @@ int runlevel_register_attrs (runlevel_t *r, attr_t *attrs)
     if (attr_add_active (attrs, "init.mode", 0,
                          runlevel_attr_get, runlevel_attr_set, r) < 0)
         return -1;
-
-    if (attr_get (attrs, "init.rc2_timeout", &val, NULL) == 0) {
-        if ((fsd_parse_duration (val, &r->rc[2].timeout) < 0)
-                || attr_delete (attrs, "init.rc2_timeout", true) < 0)
-            return -1;
-    }
-    if (attr_add_active (attrs, "init.rc2_timeout", 0,
-                         runlevel_attr_get, runlevel_attr_set, r) < 0)
-        return -1;
-
     return 0;
 }
 
@@ -190,18 +166,6 @@ void runlevel_set_io_callback (runlevel_t *r, runlevel_io_cb_f cb, void *arg)
     r->io_cb_arg = arg;
 }
 
-static void runlevel_timeout (flux_reactor_t *reactor, flux_watcher_t *w,
-                              int revents, void *arg)
-{
-    runlevel_t *r = arg;
-    flux_future_t *f;
-    flux_log (r->h, LOG_ERR, "runlevel %d timeout, sending SIGTERM", r->level);
-    if (!(f = flux_subprocess_kill (r->rc[r->level].p, SIGTERM)))
-        flux_log_error (r->h, "flux_subprocess_kill");
-    /* don't care about response */
-    flux_future_destroy (f);
-}
-
 /* See POSIX 2008 Volume 3 Shell and Utilities, Issue 7
  * Section 2.8.2 Exit status for shell commands (page 2315)
  */
@@ -227,8 +191,6 @@ static void completion_cb (flux_subprocess_t *p)
 
     assert (r->rc[r->level].p == p);
     r->rc[r->level].p = NULL;
-
-    flux_watcher_stop (r->rc[r->level].timer);
 
     if (r->cb) {
         double elapsed = monotime_since (r->rc[r->level].start) / 1000;
@@ -271,7 +233,6 @@ static int runlevel_start_subprocess (runlevel_t *r, int level)
             .on_stdout = NULL,
             .on_stderr = NULL,
         };
-        flux_reactor_t *reactor = flux_get_reactor (r->h);
         int flags = 0;
 
         /* set alternate io callback for levels 1 and 3 */
@@ -293,17 +254,6 @@ static int runlevel_start_subprocess (runlevel_t *r, int level)
             goto error;
 
         monotime (&r->rc[level].start);
-        if (r->rc[level].timeout > 0.) {
-            flux_watcher_t *w;
-            if (!(w = flux_timer_watcher_create (reactor,
-                                                 r->rc[level].timeout, 0.,
-                                                 runlevel_timeout, r)))
-                goto error;
-            flux_watcher_start (w);
-            r->rc[level].timer = w;
-            flux_log (r->h, LOG_INFO, "runlevel %d (%.1fs) timer started",
-                      level, r->rc[level].timeout);
-        }
 
         r->rc[level].p = p;
     } else {

--- a/src/broker/runlevel.c
+++ b/src/broker/runlevel.c
@@ -40,9 +40,9 @@ struct runlevel {
     void *io_cb_arg;
 };
 
-runlevel_t *runlevel_create (void)
+struct runlevel *runlevel_create (void)
 {
-    runlevel_t *r = calloc (1, sizeof (*r));
+    struct runlevel *r = calloc (1, sizeof (*r));
     if (!r) {
         errno = ENOMEM;
         return NULL;
@@ -50,7 +50,7 @@ runlevel_t *runlevel_create (void)
     return r;
 }
 
-void runlevel_destroy (runlevel_t *r)
+void runlevel_destroy (struct runlevel *r)
 {
     if (r) {
         int i;
@@ -64,14 +64,14 @@ void runlevel_destroy (runlevel_t *r)
     }
 }
 
-void runlevel_set_flux (runlevel_t *r, flux_t *h)
+void runlevel_set_flux (struct runlevel *r, flux_t *h)
 {
     r->h = h;
 }
 
 static int runlevel_attr_get (const char *name, const char **val, void *arg)
 {
-    runlevel_t *r = arg;
+    struct runlevel *r = arg;
 
     if (!strcmp (name, "init.run-level")) {
         static char s[16];
@@ -87,7 +87,7 @@ error:
     return -1;
 }
 
-int runlevel_register_attrs (runlevel_t *r, attr_t *attrs)
+int runlevel_register_attrs (struct runlevel *r, attr_t *attrs)
 {
     if (attr_add_active (attrs, "init.run-level",
                          FLUX_ATTRFLAG_READONLY,
@@ -96,13 +96,13 @@ int runlevel_register_attrs (runlevel_t *r, attr_t *attrs)
     return 0;
 }
 
-void runlevel_set_callback (runlevel_t *r, runlevel_cb_f cb, void *arg)
+void runlevel_set_callback (struct runlevel *r, runlevel_cb_f cb, void *arg)
 {
     r->cb = cb;
     r->cb_arg = arg;
 }
 
-void runlevel_set_io_callback (runlevel_t *r, runlevel_io_cb_f cb, void *arg)
+void runlevel_set_io_callback (struct runlevel *r, runlevel_io_cb_f cb, void *arg)
 {
     r->io_cb = cb;
     r->io_cb_arg = arg;
@@ -113,7 +113,7 @@ void runlevel_set_io_callback (runlevel_t *r, runlevel_io_cb_f cb, void *arg)
  */
 static void completion_cb (flux_subprocess_t *p)
 {
-    runlevel_t *r = flux_subprocess_aux_get (p, "runlevel");
+    struct runlevel *r = flux_subprocess_aux_get (p, "runlevel");
     const char *exit_string = NULL;
     int rc;
 
@@ -143,7 +143,7 @@ static void completion_cb (flux_subprocess_t *p)
 
 static void io_cb (flux_subprocess_t *p, const char *stream)
 {
-    runlevel_t *r;
+    struct runlevel *r;
     const char *ptr;
     int lenp;
 
@@ -161,7 +161,7 @@ static void io_cb (flux_subprocess_t *p, const char *stream)
         r->io_cb (r, stream, ptr, r->io_cb_arg);
 }
 
-static int runlevel_start_subprocess (runlevel_t *r, int level)
+static int runlevel_start_subprocess (struct runlevel *r, int level)
 {
     flux_subprocess_t *p = NULL;
 
@@ -209,7 +209,7 @@ error:
     return -1;
 }
 
-int runlevel_set_level (runlevel_t *r, int level)
+int runlevel_set_level (struct runlevel *r, int level)
 {
     if (level < 1 || level > 3 || level <= r->level) {
         errno = EINVAL;
@@ -221,12 +221,12 @@ int runlevel_set_level (runlevel_t *r, int level)
     return 0;
 }
 
-int runlevel_get_level (runlevel_t *r)
+int runlevel_get_level (struct runlevel *r)
 {
     return r->level;
 }
 
-int runlevel_set_rc (runlevel_t *r, int level, const char *cmd_argz,
+int runlevel_set_rc (struct runlevel *r, int level, const char *cmd_argz,
                      size_t cmd_argz_len, const char *local_uri)
 {
     flux_subprocess_t *p = NULL;

--- a/src/broker/runlevel.c
+++ b/src/broker/runlevel.c
@@ -196,13 +196,13 @@ static int runlevel_start_subprocess (struct runlevel *r, int level)
         if (flux_subprocess_aux_set (p, "runlevel", r, NULL) < 0)
             goto error;
 
-        monotime (&r->rc[level].start);
-
         r->rc[level].p = p;
-    } else {
+    }
+    else if (level == 1 || level == 3) {
         if (r->cb)
             r->cb (r, r->level, 0, 0., "Not configured", r->cb_arg);
     }
+    monotime (&r->rc[level].start);
     return 0;
 
 error:

--- a/src/broker/runlevel.h
+++ b/src/broker/runlevel.h
@@ -16,43 +16,55 @@
 #include <stdint.h>
 #include <stddef.h> // for size_t
 
-typedef struct runlevel runlevel_t;
+struct runlevel;
 
-typedef void (*runlevel_cb_f)(runlevel_t *r, int level, int rc, double elapsed,
-                              const char *exit_string, void *arg);
-typedef void (*runlevel_io_cb_f)(runlevel_t *r, const char *name,
-                                 const char *msg, void *arg);
+typedef void (*runlevel_cb_f)(struct runlevel *r,
+                              int level,
+                              int rc,
+                              double elapsed,
+                              const char *exit_string,
+                              void *arg);
+
+typedef void (*runlevel_io_cb_f)(struct runlevel *r,
+                                 const char *name,
+                                 const char *msg,
+                                 void *arg);
 
 /* Initialize, finalize runlevel calss.
  */
-runlevel_t *runlevel_create (void);
-int runlevel_register_attrs (runlevel_t *r, attr_t *attr);
-void runlevel_set_flux (runlevel_t *r, flux_t *h);
-void runlevel_destroy (runlevel_t *r);
+struct runlevel *runlevel_create (void);
+int runlevel_register_attrs (struct runlevel *r, attr_t *attr);
+void runlevel_set_flux (struct runlevel *r, flux_t *h);
+void runlevel_destroy (struct runlevel *r);
 
 /* Handle run level subprocess completion.
  */
-void runlevel_set_callback (runlevel_t *r, runlevel_cb_f cb, void *arg);
+void runlevel_set_callback (struct runlevel *r, runlevel_cb_f cb, void *arg);
 
 /* Handle stdout, stderr output lines from subprocesses.
  */
-void runlevel_set_io_callback (runlevel_t *r, runlevel_io_cb_f cb, void *arg);
+void runlevel_set_io_callback (struct runlevel *r,
+                               runlevel_io_cb_f cb,
+                               void *arg);
 
 /* Associate 'command' with 'level'.  'local_uri' and 'library_path' are
  * used to set FLUX_URI and LD_LIBRARY_PATH in the subprocess environment.
  */
-int runlevel_set_rc (runlevel_t *r, int level, const char *cmd_argz,
-                     size_t cmd_argz_len, const char *local_uri);
+int runlevel_set_rc (struct runlevel *r,
+                     int level,
+                     const char *cmd_argz,
+                     size_t cmd_argz_len,
+                     const char *local_uri);
 
 /* Change the runlevel.  It is assumed that the previous run level (if any)
  * has completed and this is being called from the runlevel callback.
  * Transitions are completely driven by the broker.
  */
-int runlevel_set_level (runlevel_t *r, int level);
+int runlevel_set_level (struct runlevel *r, int level);
 
 /* Get the current runlevel.
  */
-int runlevel_get_level (runlevel_t *r);
+int runlevel_get_level (struct runlevel *r);
 
 #endif /* !_BROKER_RUNLEVEL_H */
 

--- a/src/broker/runlevel.h
+++ b/src/broker/runlevel.h
@@ -64,6 +64,13 @@ int runlevel_set_level (struct runlevel *r, int level);
  */
 int runlevel_get_level (struct runlevel *r);
 
+/* Terminate current runlevel.
+ * Asynchronously results in runlevel callback, so broker can advance state.
+ * If runlevel has no subprocess, callback is immediate with rc=0.
+ * Return 0 on success, -1 on failure.
+ */
+int runlevel_abort (struct runlevel *r);
+
 #endif /* !_BROKER_RUNLEVEL_H */
 
 /*

--- a/src/broker/runlevel.h
+++ b/src/broker/runlevel.h
@@ -27,7 +27,6 @@ typedef void (*runlevel_io_cb_f)(runlevel_t *r, const char *name,
  */
 runlevel_t *runlevel_create (void);
 int runlevel_register_attrs (runlevel_t *r, attr_t *attr);
-void runlevel_set_size (runlevel_t *r, uint32_t size);
 void runlevel_set_flux (runlevel_t *r, flux_t *h);
 void runlevel_destroy (runlevel_t *r);
 

--- a/src/broker/runlevel.h
+++ b/src/broker/runlevel.h
@@ -30,11 +30,9 @@ typedef void (*runlevel_io_cb_f)(struct runlevel *r,
                                  const char *msg,
                                  void *arg);
 
-/* Initialize, finalize runlevel calss.
+/* Initialize, finalize runlevel class.
  */
-struct runlevel *runlevel_create (void);
-int runlevel_register_attrs (struct runlevel *r, attr_t *attr);
-void runlevel_set_flux (struct runlevel *r, flux_t *h);
+struct runlevel *runlevel_create (flux_t *h, attr_t *attr);
 void runlevel_destroy (struct runlevel *r);
 
 /* Handle run level subprocess completion.
@@ -47,8 +45,8 @@ void runlevel_set_io_callback (struct runlevel *r,
                                runlevel_io_cb_f cb,
                                void *arg);
 
-/* Associate 'command' with 'level'.  'local_uri' and 'library_path' are
- * used to set FLUX_URI and LD_LIBRARY_PATH in the subprocess environment.
+/* Associate 'command' with 'level'.
+ * 'local_uri' is used to set FLUX_URI in the subprocess environment.
  */
 int runlevel_set_rc (struct runlevel *r,
                      int level,

--- a/t/rc/rc1-testenv
+++ b/t/rc/rc1-testenv
@@ -33,19 +33,3 @@ if test $runlevel -ne 1; then
 else
     echo "run level is 1"
 fi
-
-# This is used to limit which nodes can be targets of flux-module
-# and eventually other commands like flux-exec.
-# We expect it to be the full size of the session for now
-size=$(flux getattr size)
-if test $size -eq 1; then
-    expected_mask="[0]";
-else
-    expected_mask="[0-$(($size-1))]"
-fi
-if test "$FLUX_NODESET_MASK" != "$expected_mask"; then
-    echo "FLUX_NODESET_MASK=$FLUX_NODESET_MASK" >&2
-    echo "         expected=$expected_mask" >&2
-else
-    echo FLUX_NODESET_MASK=$FLUX_NODESET_MASK
-fi

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -37,12 +37,9 @@ test_expect_success 'flux-python command runs a python that finds flux' '
 	flux python -c "import flux"
 '
 
-# None of the individual tests should run over 10s
-ARGS="-o -Sinit.rc2_timeout=10"
-
 # Minimal is sufficient for these tests, but test_under_flux unavailable
 # clear the RC paths
-ARGS="$ARGS -o,-Sbroker.rc1_path=,-Sbroker.rc3_path="
+ARGS="-o,-Sbroker.rc1_path=,-Sbroker.rc3_path="
 
 test_expect_success 'broker --shutdown-grace option works' "
 	flux start ${ARGS} -s2 -o,--shutdown-grace=5 /bin/true
@@ -92,9 +89,6 @@ test_expect_success 'flux-start in subprocess/pmi mode works as initial program'
 	flux start --size=2 flux start ${ARGS} --size=1 flux comms info | grep size=1
 "
 
-test_expect_success 'flux-start init.rc2_timeout attribute works' "
-	test_expect_code 143 flux start ${ARGS} -o,-Sinit.rc2_timeout=0.1 sleep 5
-"
 test_expect_success 'flux-start --wrap option works' '
 	broker_path=$(flux start -vX 2>&1 | sed "s/^flux-start: *//g") &&
 	echo broker_path=${broker_path} &&

--- a/t/t0014-runlevel.t
+++ b/t/t0014-runlevel.t
@@ -75,6 +75,12 @@ test_expect_success 'rc3 failure causes instance failure' '
 	grep -q "Run level 3 Exited with non-zero status" false3.log
 '
 
+test_expect_success 'instance with no rc2 terminated cleanly by timeout' '
+	run_timeout 0.5 flux start \
+		-o,-Slog-stderr-level=6 \
+		-o,-Sbroker.rc1_path=,-Sbroker.rc3_path=,-Sbroker.rc2_none
+'
+
 test_expect_success 'rc1 environment is as expected' '
 	flux start \
 		-o,-Sbroker.rc1_path=${FLUX_SOURCE_DIR}/t/rc/rc1-testenv \

--- a/t/t0014-runlevel.t
+++ b/t/t0014-runlevel.t
@@ -7,11 +7,9 @@ test_description='Verify runlevels work properly
 . `dirname $0`/sharness.sh
 test_under_flux 1 minimal
 
-test_expect_success 'sharness minimal init.run-level=2 init.mode=normal' '
+test_expect_success 'sharness minimal init.run-level=2' '
 	runlevel=$(flux getattr init.run-level) &&
-	test $runlevel -eq 2 &&
-	runmode=$(flux getattr init.mode) &&
-	test $runmode = "normal"
+	test $runlevel -eq 2
 '
 
 test_expect_success 'sharness minimal has transitioned normally thus far' '
@@ -23,8 +21,8 @@ test_expect_success 'sharness minimal has transitioned normally thus far' '
 	! grep -q "Run level 3" default.log
 '
 
-test_expect_success 'new init.mode=normal instance transitions appropriately' '
-	flux start -o,-Slog-stderr-level=6,-Sinit.mode=normal \
+test_expect_success 'new instance transitions appropriately' '
+	flux start -o,-Slog-stderr-level=6 \
 		-o,-Sbroker.rc1_path=,-Sbroker.rc3_path= \
 		/bin/true 2>normal.log &&
 	grep -q "Run level 1 starting" normal.log &&
@@ -35,22 +33,10 @@ test_expect_success 'new init.mode=normal instance transitions appropriately' '
 	grep -q "Run level 3 Exited" normal.log
 '
 
-test_expect_success 'new init.mode=none instance transitions appropriately' '
-	flux start -o,-Slog-stderr-level=6,-Sinit.mode=none \
-		-o,-Sbroker.rc1_path=,-Sbroker.rc3_path= \
-		/bin/true 2>none.log &&
-	grep -q "Run level 1 starting" none.log &&
-	grep -q "Run level 1 Skipped mode=none" none.log &&
-	grep -q "Run level 2 starting" none.log &&
-	grep -q "Run level 2 Exited" none.log &&
-	grep -q "Run level 3 starting" none.log &&
-	grep -q "Run level 3 Skipped mode=none" none.log
-'
-
 test_expect_success 'rc1 failure transitions to rc3, fails instance' '
 	test_expect_code 1 flux start \
 		-o,-Sbroker.rc1_path=/bin/false,-Sbroker.rc3_path= \
-		-o,-Slog-stderr-level=6,-Sinit.mode=normal \
+		-o,-Slog-stderr-level=6 \
 		/bin/true 2>false.log &&
 	grep -q "Run level 1 starting" false.log &&
 	grep -q "Run level 1 Exited with non-zero status" false.log &&
@@ -65,7 +51,7 @@ test_expect_success 'rc1 bad path handled same as failure' '
 	  SHELL=/bin/sh &&
 	  test_expect_code 127 flux start \
 		-o,-Sbroker.rc1_path=rc1-nonexist,-Sbroker.rc3_path= \
-		-o,-Slog-stderr-level=6,-Sinit.mode=normal \
+		-o,-Slog-stderr-level=6 \
 		/bin/true 2>bad1.log
 	) &&
 	grep -q "Run level 1 starting" bad1.log &&
@@ -79,7 +65,7 @@ test_expect_success 'rc1 bad path handled same as failure' '
 test_expect_success 'rc3 failure causes instance failure' '
 	! flux start \
 		-o,-Sbroker.rc3_path=/bin/false \
-		-o,-Slog-stderr-level=6,-Sinit.mode=normal \
+		-o,-Slog-stderr-level=6 \
 		/bin/true 2>false3.log &&
 	grep -q "Run level 1 starting" false3.log &&
 	grep -q "Run level 1 Exited" false3.log &&
@@ -92,7 +78,7 @@ test_expect_success 'rc3 failure causes instance failure' '
 test_expect_success 'rc1 environment is as expected' '
 	flux start \
 		-o,-Sbroker.rc1_path=${FLUX_SOURCE_DIR}/t/rc/rc1-testenv \
-		-o,-Slog-stderr-level=6,-Sinit.mode=normal \
+		-o,-Slog-stderr-level=6 \
 		/bin/true 2>&1 | tee rc1-test.log &&
 	grep "stderr-" rc1-test.log | egrep -q broker.*err &&
 	grep "stdout-" rc1-test.log | egrep -q broker.*info

--- a/t/t0014-runlevel.t
+++ b/t/t0014-runlevel.t
@@ -15,9 +15,9 @@ test_expect_success 'sharness minimal init.run-level=2' '
 test_expect_success 'sharness minimal has transitioned normally thus far' '
 	flux dmesg >default.log &&
 	grep -q "Run level 1 starting" default.log &&
-	grep -q "Run level 1 Exited" default.log &&
+	grep -q "Run level 1 Not configured" default.log &&
 	grep -q "Run level 2 starting" default.log &&
-	! grep -q "Run level 2 Exited" default.log &&
+	! grep -q "Run level 2 Not configured" default.log &&
 	! grep -q "Run level 3" default.log
 '
 
@@ -26,11 +26,11 @@ test_expect_success 'new instance transitions appropriately' '
 		-o,-Sbroker.rc1_path=,-Sbroker.rc3_path= \
 		/bin/true 2>normal.log &&
 	grep -q "Run level 1 starting" normal.log &&
-	grep -q "Run level 1 Exited" normal.log &&
+	grep -q "Run level 1 Not configured" normal.log &&
 	grep -q "Run level 2 starting" normal.log &&
 	grep -q "Run level 2 Exited" normal.log &&
 	grep -q "Run level 3 starting" normal.log &&
-	grep -q "Run level 3 Exited" normal.log
+	grep -q "Run level 3 Not configured" normal.log
 '
 
 test_expect_success 'rc1 failure transitions to rc3, fails instance' '
@@ -43,7 +43,7 @@ test_expect_success 'rc1 failure transitions to rc3, fails instance' '
 	! grep -q "Run level 2 starting" false.log &&
 	! grep -q "Run level 2 Exited" false.log &&
 	grep -q "Run level 3 starting" false.log &&
-	grep -q "Run level 3 Exited" false.log
+	grep -q "Run level 3 Not configured" false.log
 '
 
 test_expect_success 'rc1 bad path handled same as failure' '
@@ -59,7 +59,7 @@ test_expect_success 'rc1 bad path handled same as failure' '
 	! grep -q "Run level 2 starting" bad1.log &&
 	! grep -q "Run level 2 Exited" bad1.log &&
 	grep -q "Run level 3 starting" bad1.log &&
-	grep -q "Run level 3 Exited" bad1.log
+	grep -q "Run level 3 Not configured" bad1.log
 '
 
 test_expect_success 'rc3 failure causes instance failure' '
@@ -78,6 +78,7 @@ test_expect_success 'rc3 failure causes instance failure' '
 test_expect_success 'rc1 environment is as expected' '
 	flux start \
 		-o,-Sbroker.rc1_path=${FLUX_SOURCE_DIR}/t/rc/rc1-testenv \
+		-o,-Sbroker.rc3_path= \
 		-o,-Slog-stderr-level=6 \
 		/bin/true 2>&1 | tee rc1-test.log &&
 	grep "stderr-" rc1-test.log | egrep -q broker.*err &&


### PR DESCRIPTION
This PR preps for a clean Flux shutdown on SIGTERM, which is how systemd will shut down the broker.

First, eliminate the requirement that there is always an initial program.  If the `broker.rc2_none` broker attribute is set, the broker enters rc2 and stays there until...

Second, handle SIGTERM (and other signals) by aborting the current runlevel.  If the runlevel has a subprocess, it is terminated (resulting in the broker exiting with a nozero exit code).  If it doesn't have a subprocess, it simply advances to the next runlevel without error.

The runlevel code was tidied up, some little used runlevel features removed, and minor runlevel bugs fixed.

Combining this PR and #2783 I was finally able to demonstrate saving the KVS content across a systemd stop/start of Flux. 

Edit: description edited to reflect systemd unit file will be updated in another PR.