### PR TITLE
cmd/flux-kvs: Remove legacy --json options and json output

### DIFF
--- a/doc/man1/flux-kvs.adoc
+++ b/doc/man1/flux-kvs.adoc
@@ -59,39 +59,37 @@ Remove a kvs namespace.
 *namespace list*::
 List all current namespaces and info on each namespace.
 
-*get* [-N ns] [-j|-r|-t] [-a treeobj] [-l] [-W] [-w] [-u] [-A] [-f] [-c count] 'key' ['key...']::
+*get* [-N ns] [-r|-t] [-a treeobj] [-l] [-W] [-w] [-u] [-A] [-f] [-c count] 'key' ['key...']::
 Retrieve the value stored under 'key'.  If nothing has been stored
 under 'key', display an error message.  Specify an alternate namespace
 to retrieve 'key' from via '-N'.  If no options, value is displayed
 with a newline appended (if value length is nonzero).  If '-l', a
-'key=' prefix is added. If '-j', value is interpreted as encoded JSON
-and formatted accordingly.  If '-r', value is displayed without a
-newline.  If '-t', the RFC 11 object is displayed.  '-a treeobj'
-causes the lookup to be relative to an RFC 11 snapshot reference.  If
-'-W' is specified and a key does not exist, wait until the key has
-been created.  If '-w', after the initial value, display the new value
-each time the key is written to until interrupted, or if '-c count' is
+'key=' prefix is added. If '-r', value is displayed without a newline.
+If '-t', the RFC 11 object is displayed.  '-a treeobj' causes the
+lookup to be relative to an RFC 11 snapshot reference.  If '-W' is
+specified and a key does not exist, wait until the key has been
+created.  If '-w', after the initial value, display the new value each
+time the key is written to until interrupted, or if '-c count' is
 specified, until 'count' values have been displayed.  If '-u' is
 specified, only writes that change the key value will be displayed.
-If '-A' is specified, only display appends that occur on a key.
-By default, only a direct write to a key is monitored, which may miss
+If '-A' is specified, only display appends that occur on a key.  By
+default, only a direct write to a key is monitored, which may miss
 several unique situations, such as the replacement of an entire parent
 directory.  The '-f' option can be specified to monitor for many of
 these special situations.
 
-*put* [-N ns] [-O|-s] [-j|-r|-t] [-n] [-A] 'key=value' ['key=value...']::
+*put* [-N ns] [-O|-s] [-r|-t] [-n] [-A] 'key=value' ['key=value...']::
 Store 'value' under 'key' and commit it.  Specify an alternate
 namespace to commit value(s) via '-N'.  If it already has a value,
-overwrite it.  If no options, value is stored directly.  If '-j', it
-is first encoded as JSON, then stored.  If '-r' or '-t', the value may
-optionally be read from standard input if specified as "-".  If '-r',
-the value may include embedded NULL bytes.  If '-t', value is stored
-as a RFC 11 object.  '-n' prevents the commit from being merged with
-with other contemporaneous commits.  '-A' appends the value to a key
-instead of overwriting the value.  Append is incompatible with the -j
-option.  After a successful put, '-O' or '-s' can be specified to
-output the RFC11 treeobj or root sequence number of the root
-containing the put(s).
+overwrite it.  If no options, value is stored directly.  If '-r' or
+'-t', the value may optionally be read from standard input if
+specified as "-".  If '-r', the value may include embedded NULL bytes.
+If '-t', value is stored as a RFC 11 object.  '-n' prevents the commit
+from being merged with with other contemporaneous commits.  '-A'
+appends the value to a key instead of overwriting the value.  Append
+is incompatible with the -j option.  After a successful put, '-O' or
+'-s' can be specified to output the RFC11 treeobj or root sequence
+number of the root containing the put(s).
 
 *ls* [-N ns] [-R] [-d] [-F] [-w COLS] [-1] ['key' ...]::
 Display directory referred to by _key_, or "." (root) if unspecified.

--- a/src/cmd/flux-kvs.c
+++ b/src/cmd/flux-kvs.c
@@ -634,40 +634,6 @@ static void kv_printf (const char *key, int maxcol, const char *fmt, ...)
     free (kv);
 }
 
-static void output_key_json_object (const char *key, json_t *o, int maxcol)
-{
-    char *s;
-
-    switch (json_typeof (o)) {
-    case JSON_NULL:
-        kv_printf (key, maxcol, "nil");
-        break;
-    case JSON_TRUE:
-        kv_printf (key, maxcol, "true");
-        break;
-    case JSON_FALSE:
-        kv_printf (key, maxcol, "false");
-        break;
-    case JSON_REAL:
-        kv_printf (key, maxcol, "%f", json_real_value (o));
-        break;
-    case JSON_INTEGER:
-        kv_printf (key, maxcol, "%lld", (long long)json_integer_value (o));
-        break;
-    case JSON_STRING:
-        kv_printf (key, maxcol, "%s", json_string_value (o));
-        break;
-    case JSON_ARRAY:
-    case JSON_OBJECT:
-    default:
-        if (!(s = json_dumps (o, JSON_SORT_KEYS)))
-            log_msg_exit ("json_dumps failed");
-        kv_printf (key, maxcol, "%s", s);
-        free (s);
-        break;
-    }
-}
-
 struct lookup_ctx {
     optparse_t *p;
     int maxcount;
@@ -1174,18 +1140,10 @@ static char *process_key (const char *key)
 
 static void dump_kvs_val (const char *key, int maxcol, const char *value)
 {
-    json_t *o;
-
-    if (!value) {
+    if (!value)
         kv_printf (key, maxcol, "");
-    }
-    else if ((o = json_loads (value, JSON_DECODE_ANY, NULL))) {
-        output_key_json_object (key, o, maxcol);
-        json_decref (o);
-    }
-    else {
+    else
         kv_printf (key, maxcol, value);
-    }
 }
 
 static void dump_kvs_dir (const flux_kvsdir_t *dir, int maxcol,

--- a/src/test/sched-bench.sh
+++ b/src/test/sched-bench.sh
@@ -69,7 +69,7 @@ log "broker.pid=$(flux getattr broker.pid)\n"
 
 #  Reload scheduler so we can insert a fake resource set:
 flux module remove sched-simple
-flux kvs put --json \
+flux kvs put \
     resource.hwloc.by_rank="{\"[0-$(($NNODES-1))]\":{\"Core\":$CPN}}"
 flux mini run --dry-run --setattr=system.exec.test.run_duration=.001s hostname \
     > job.json

--- a/t/issues/t0441-kvs-put-get.sh
+++ b/t/issues/t0441-kvs-put-get.sh
@@ -3,8 +3,8 @@
 
 TEST=issue441
 
-flux kvs put --json ${TEST}.x=foo
+flux kvs put ${TEST}.x=foo
 
-flux kvs get --json ${TEST}.x.y && test $? -eq 1
+flux kvs get ${TEST}.x.y && test $? -eq 1
 
-flux kvs get --json ${TEST}.x   # fails if broker died
+flux kvs get ${TEST}.x   # fails if broker died

--- a/t/issues/t0821-kvs-segfault.sh
+++ b/t/issues/t0821-kvs-segfault.sh
@@ -2,6 +2,6 @@
 # kvs put test="large string", get test.x fails without panic
 
 TEST=issue0821
-flux kvs put --json ${TEST}="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-flux kvs get --json ${TEST}.x && test $? -eq 1
-flux kvs get --json ${TEST}   # fails if broker died
+flux kvs put ${TEST}="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+flux kvs get ${TEST}.x && test $? -eq 1
+flux kvs get ${TEST}   # fails if broker died

--- a/t/kvs/kvs-helper.sh
+++ b/t/kvs/kvs-helper.sh
@@ -20,7 +20,7 @@ loophandlereturn() {
 # arg1 - key to retrieve
 # arg2 - expected value
 test_kvs_key() {
-	flux kvs get --json "$1" >output
+	flux kvs get "$1" >output
 	echo "$2" >expected
 	test_cmp expected output
 }
@@ -29,7 +29,7 @@ test_kvs_key() {
 # arg2 - key to retrieve
 # arg3 - expected value
 test_kvs_key_namespace() {
-	flux kvs get --namespace="$1" --json "$2" >output
+	flux kvs get --namespace="$1" "$2" >output
 	echo "$3" >expected
 	test_cmp expected output
 }

--- a/t/sharness.d/flux-sharness.sh
+++ b/t/sharness.d/flux-sharness.sh
@@ -158,7 +158,7 @@ TEST_NAME=$SHARNESS_TEST_NAME
 export TEST_NAME
 
 #  Test requirements for testsuite
-if ! run_timeout 1.0 lua -e 'require "posix"'; then
+if ! run_timeout 10.0 lua -e 'require "posix"'; then
     error "failed to find lua posix module in path"
 fi
 

--- a/t/t0017-security.t
+++ b/t/t0017-security.t
@@ -293,7 +293,7 @@ test_expect_success 'connector delivers kvs.namespace-primary-setroot event to o
 	    $SHARNESS_TEST_SRCDIR/scripts/event-trace-bypass.lua \
 		kvs kvs.test.end \
                 "flux event pub kvs.test.a; \
-                 flux kvs put --json ev9=42; \
+                 flux kvs put ev9=42; \
                  flux event pub kvs.test.end" >ev9.out &&
 	grep -q kvs.namespace-primary-setroot ev9.out
 '
@@ -303,7 +303,7 @@ test_expect_success 'dispatcher delivers kvs.namespace-primary-setroot event to 
 	    $SHARNESS_TEST_SRCDIR/scripts/event-trace.lua \
 		kvs kvs.test.end \
                 "flux event pub kvs.test.a; \
-                 flux kvs put --json ev10=42; \
+                 flux kvs put ev10=42; \
                  flux event pub kvs.test.end" >ev10.out &&
 	grep -q kvs.namespace-primary-setroot ev10.out
 '
@@ -314,7 +314,7 @@ test_expect_success 'connector suppresses kvs.namespace-primary-setroot event to
 	    $SHARNESS_TEST_SRCDIR/scripts/event-trace-bypass.lua \
 		kvs kvs.test.end \
                 "flux event pub kvs.test.a; \
-                 flux kvs put --json ev11=42; \
+                 flux kvs put ev11=42; \
                  flux event pub kvs.test.end" >ev11.out &&
 	! grep -q kvs.namespace-primary-setroot ev11.out
 '

--- a/t/t1000-kvs.t
+++ b/t/t1000-kvs.t
@@ -162,11 +162,11 @@ test_expect_success 'kvs: dir -R DIR' '
 	flux kvs dir -R $DIR | sort >output &&
 	cat >expected <<EOF &&
 $DIR.a = 42
-$DIR.b = 3.140000
+$DIR.b = 3.14
 $DIR.c = foo
 $DIR.d = true
-$DIR.e = [1, 3, 5]
-$DIR.f = {"a": 42}
+$DIR.e = [1,3,5]
+$DIR.f = {"a":42}
 EOF
 	test_cmp expected output
 '
@@ -187,11 +187,11 @@ test_expect_success 'kvs: kvs dir -R DIR with period end' '
 	flux kvs dir -R $DIR. | sort >output &&
         cat >expected <<EOF &&
 $DIR.a = 42
-$DIR.b = 3.140000
+$DIR.b = 3.14
 $DIR.c = foo
 $DIR.d = true
-$DIR.e = [1, 3, 5]
-$DIR.f = {"a": 42}
+$DIR.e = [1,3,5]
+$DIR.f = {"a":42}
 EOF
         test_cmp expected output
 '
@@ -213,11 +213,11 @@ test_expect_success 'kvs: kvs dir -R on root "."' '
 	flux kvs dir -R "." | sort >output &&
         cat >expected <<EOF &&
 $DIR.a = 42
-$DIR.b = 3.140000
+$DIR.b = 3.14
 $DIR.c = foo
 $DIR.d = true
-$DIR.e = [1, 3, 5]
-$DIR.f = {"a": 42}
+$DIR.e = [1,3,5]
+$DIR.f = {"a":42}
 EOF
         test_cmp expected output
 '
@@ -270,13 +270,13 @@ test_expect_success 'kvs: create a dir with keys and subdir' '
 	flux kvs put $DIR.a=69 &&
         flux kvs put $DIR.b=70 &&
         flux kvs put $DIR.c.d.e.f.g=3.14 &&
-        flux kvs put $DIR.d=\"snerg\" &&
+        flux kvs put $DIR.d=snerg &&
         flux kvs put $DIR.e=true &&
 	flux kvs dir -R $DIR | sort >output &&
 	cat >expected <<EOF &&
 $DIR.a = 69
 $DIR.b = 70
-$DIR.c.d.e.f.g = 3.140000
+$DIR.c.d.e.f.g = 3.14
 $DIR.d = snerg
 $DIR.e = true
 EOF
@@ -288,13 +288,13 @@ test_expect_success 'kvs: directory with multiple subdirs' '
 	flux kvs put $DIR.a=69 &&
         flux kvs put $DIR.b.c.d.e.f.g=70 &&
         flux kvs put $DIR.c.a.b=3.14 &&
-        flux kvs put $DIR.d=\"snerg\" &&
+        flux kvs put $DIR.d=snerg &&
         flux kvs put $DIR.e=true &&
 	flux kvs dir -R $DIR | sort >output &&
 	cat >expected <<EOF &&
 $DIR.a = 69
 $DIR.b.c.d.e.f.g = 70
-$DIR.c.a.b = 3.140000
+$DIR.c.a.b = 3.14
 $DIR.d = snerg
 $DIR.e = true
 EOF
@@ -576,13 +576,13 @@ test_expect_success 'kvs: put using --no-merge flag' '
 	flux kvs put --no-merge $DIR.a=69 &&
         flux kvs put --no-merge $DIR.b.c.d.e.f.g=70 &&
         flux kvs put --no-merge $DIR.c.a.b=3.14 &&
-        flux kvs put --no-merge $DIR.d=\"snerg\" &&
+        flux kvs put --no-merge $DIR.d=snerg &&
         flux kvs put --no-merge $DIR.e=true &&
 	flux kvs dir -R $DIR | sort >output &&
 	cat >expected <<EOF &&
 $DIR.a = 69
 $DIR.b.c.d.e.f.g = 70
-$DIR.c.a.b = 3.140000
+$DIR.c.a.b = 3.14
 $DIR.d = snerg
 $DIR.e = true
 EOF
@@ -1084,7 +1084,7 @@ test_expect_success 'kvs: directory with multiple subdirs using dir --at' '
 	flux kvs put $DIR.a=69 &&
         flux kvs put $DIR.b.c.d.e.f.g=70 &&
         flux kvs put $DIR.c.a.b=3.14 &&
-        flux kvs put $DIR.d=\"snerg\" &&
+        flux kvs put $DIR.d=snerg &&
         flux kvs put $DIR.e=true &&
         flux kvs link $DIR.a $DIR.f &&
         DIRREF=$(flux kvs get --treeobj $DIR) &&
@@ -1092,7 +1092,7 @@ test_expect_success 'kvs: directory with multiple subdirs using dir --at' '
 	cat >expected <<EOF &&
 a = 69
 b.c.d.e.f.g = 70
-c.a.b = 3.140000
+c.a.b = 3.14
 d = snerg
 e = true
 f -> $DIR.a

--- a/t/t1000-kvs.t
+++ b/t/t1000-kvs.t
@@ -28,31 +28,31 @@ SUBDIR2=test.a.b.e
 #
 
 test_expect_success 'kvs: integer put' '
-	flux kvs put --json $KEY.integer=42
+	flux kvs put $KEY.integer=42
 '
 test_expect_success 'kvs: double put' '
-	flux kvs put --json $KEY.double=3.14
+	flux kvs put $KEY.double=3.14
 '
 test_expect_success 'kvs: string put' '
-	flux kvs put --json $KEY.string=foo
+	flux kvs put $KEY.string=foo
 '
 test_expect_success 'kvs: boolean true put' '
-	flux kvs put --json $KEY.booleantrue=true
+	flux kvs put $KEY.booleantrue=true
 '
 test_expect_success 'kvs: boolean false put' '
-	flux kvs put --json $KEY.booleanfalse=false
+	flux kvs put $KEY.booleanfalse=false
 '
 test_expect_success 'kvs: array put' '
-	flux kvs put --json $KEY.array="[1,3,5]"
+	flux kvs put $KEY.array="[1,3,5]"
 '
 test_expect_success 'kvs: object put' '
-	flux kvs put --json $KEY.object="{\"a\":42}"
+	flux kvs put $KEY.object="{\"a\":42}"
 '
 test_expect_success 'kvs: integer get' '
 	test_kvs_key $KEY.integer 42
 '
 test_expect_success 'kvs: double get' '
-	test_kvs_key $KEY.double 3.140000
+	test_kvs_key $KEY.double 3.14
 '
 test_expect_success 'kvs: string get' '
 	test_kvs_key $KEY.string foo
@@ -64,38 +64,38 @@ test_expect_success 'kvs: boolean false get' '
 	test_kvs_key $KEY.booleanfalse false
 '
 test_expect_success 'kvs: array get' '
-	test_kvs_key $KEY.array "[1, 3, 5]"
+	test_kvs_key $KEY.array "[1,3,5]"
 '
 test_expect_success 'kvs: object get' '
-	test_kvs_key $KEY.object "{\"a\": 42}"
+	test_kvs_key $KEY.object "{\"a\":42}"
 '
 test_expect_success 'kvs: unlink works' '
 	flux kvs unlink $KEY.integer &&
-	  test_must_fail flux kvs get --json $KEY.integer
+	  test_must_fail flux kvs get $KEY.integer
 '
 test_expect_success 'kvs: unlink works' '
 	flux kvs unlink $KEY.double &&
-	  test_must_fail flux kvs get --json $KEY.double
+	  test_must_fail flux kvs get $KEY.double
 '
 test_expect_success 'kvs: unlink works' '
 	flux kvs unlink $KEY.string &&
-	  test_must_fail flux kvs get --json $KEY.string
+	  test_must_fail flux kvs get $KEY.string
 '
 test_expect_success 'kvs: unlink works' '
 	flux kvs unlink $KEY.booleantrue &&
-	  test_must_fail flux kvs get --json $KEY.booleantrue
+	  test_must_fail flux kvs get $KEY.booleantrue
 '
 test_expect_success 'kvs: unlink works' '
 	flux kvs unlink $KEY.booleanfalse &&
-	  test_must_fail flux kvs get --json $KEY.booleanfalse
+	  test_must_fail flux kvs get $KEY.booleanfalse
 '
 test_expect_success 'kvs: unlink works' '
 	flux kvs unlink $KEY.array &&
-	  test_must_fail flux kvs get --json $KEY.array
+	  test_must_fail flux kvs get $KEY.array
 '
 test_expect_success 'kvs: unlink works' '
 	flux kvs unlink $KEY.object &&
-	  test_must_fail flux kvs get --json $KEY.object
+	  test_must_fail flux kvs get $KEY.object
 '
 
 #
@@ -103,28 +103,28 @@ test_expect_success 'kvs: unlink works' '
 #
 
 test_expect_success 'kvs: put (multiple)' '
-	flux kvs put --json $KEY.a=42 $KEY.b=3.14 $KEY.c=foo $KEY.d=true $KEY.e="[1,3,5]" $KEY.f="{\"a\":42}"
+	flux kvs put $KEY.a=42 $KEY.b=3.14 $KEY.c=foo $KEY.d=true $KEY.e="[1,3,5]" $KEY.f="{\"a\":42}"
 '
 test_expect_success 'kvs: get (multiple)' '
-	flux kvs get --json $KEY.a $KEY.b $KEY.c $KEY.d $KEY.e $KEY.f >output &&
+	flux kvs get $KEY.a $KEY.b $KEY.c $KEY.d $KEY.e $KEY.f >output &&
 	cat >expected <<EOF &&
 42
-3.140000
+3.14
 foo
 true
-[1, 3, 5]
-{"a": 42}
+[1,3,5]
+{"a":42}
 EOF
 	test_cmp expected output
 '
 test_expect_success 'kvs: unlink (multiple)' '
 	flux kvs unlink $KEY.a $KEY.b $KEY.c $KEY.d $KEY.e $KEY.f &&
-          test_must_fail flux kvs get --json $KEY.a &&
-          test_must_fail flux kvs get --json $KEY.b &&
-          test_must_fail flux kvs get --json $KEY.c &&
-          test_must_fail flux kvs get --json $KEY.d &&
-          test_must_fail flux kvs get --json $KEY.e &&
-          test_must_fail flux kvs get --json $KEY.f
+          test_must_fail flux kvs get $KEY.a &&
+          test_must_fail flux kvs get $KEY.b &&
+          test_must_fail flux kvs get $KEY.c &&
+          test_must_fail flux kvs get $KEY.d &&
+          test_must_fail flux kvs get $KEY.e &&
+          test_must_fail flux kvs get $KEY.f
 '
 
 #
@@ -158,7 +158,7 @@ EOF
 	test_cmp expected output
 '
 test_expect_success 'kvs: dir -R DIR' '
-	flux kvs put --json $DIR.a=42 $DIR.b=3.14 $DIR.c=foo $DIR.d=true $DIR.e="[1,3,5]" $DIR.f="{\"a\":42}" &&
+	flux kvs put $DIR.a=42 $DIR.b=3.14 $DIR.c=foo $DIR.d=true $DIR.e="[1,3,5]" $DIR.f="{\"a\":42}" &&
 	flux kvs dir -R $DIR | sort >output &&
 	cat >expected <<EOF &&
 $DIR.a = 42
@@ -267,11 +267,11 @@ EOF
 
 test_expect_success 'kvs: create a dir with keys and subdir' '
 	flux kvs unlink -Rf $DIR &&
-	flux kvs put --json $DIR.a=69 &&
-        flux kvs put --json $DIR.b=70 &&
-        flux kvs put --json $DIR.c.d.e.f.g=3.14 &&
-        flux kvs put --json $DIR.d=\"snerg\" &&
-        flux kvs put --json $DIR.e=true &&
+	flux kvs put $DIR.a=69 &&
+        flux kvs put $DIR.b=70 &&
+        flux kvs put $DIR.c.d.e.f.g=3.14 &&
+        flux kvs put $DIR.d=\"snerg\" &&
+        flux kvs put $DIR.e=true &&
 	flux kvs dir -R $DIR | sort >output &&
 	cat >expected <<EOF &&
 $DIR.a = 69
@@ -285,11 +285,11 @@ EOF
 
 test_expect_success 'kvs: directory with multiple subdirs' '
 	flux kvs unlink -Rf $DIR &&
-	flux kvs put --json $DIR.a=69 &&
-        flux kvs put --json $DIR.b.c.d.e.f.g=70 &&
-        flux kvs put --json $DIR.c.a.b=3.14 &&
-        flux kvs put --json $DIR.d=\"snerg\" &&
-        flux kvs put --json $DIR.e=true &&
+	flux kvs put $DIR.a=69 &&
+        flux kvs put $DIR.b.c.d.e.f.g=70 &&
+        flux kvs put $DIR.c.a.b=3.14 &&
+        flux kvs put $DIR.d=\"snerg\" &&
+        flux kvs put $DIR.e=true &&
 	flux kvs dir -R $DIR | sort >output &&
 	cat >expected <<EOF &&
 $DIR.a = 69
@@ -306,11 +306,11 @@ EOF
 #
 
 test_expect_success 'kvs: get a nonexistent key' '
-	test_must_fail flux kvs get --json NOT.A.KEY
+	test_must_fail flux kvs get NOT.A.KEY
 '
 test_expect_success 'kvs: try to retrieve a directory as key should fail' '
         flux kvs mkdir $DIR.a.b.c &&
-	test_must_fail flux kvs get --json $DIR
+	test_must_fail flux kvs get $DIR
 '
 
 #
@@ -318,22 +318,10 @@ test_expect_success 'kvs: try to retrieve a directory as key should fail' '
 #
 
 test_expect_success 'kvs: put with invalid input' '
-	test_must_fail flux kvs put --json NOVALUE
+	test_must_fail flux kvs put NOVALUE
 '
 test_expect_success 'kvs: put key of . fails' '
-	test_must_fail flux kvs put --json .=1
-'
-
-#
-# get/put --json corner case tests
-#
-test_expect_success 'kvs: null is converted to json null' '
-	flux kvs put --json $DIR.jsonnull=null &&
-        test_kvs_key $DIR.jsonnull nil
-'
-test_expect_success 'kvs: quoted null is converted to json string' '
-	flux kvs put --json $DIR.strnull=\"null\" &&
-        test_kvs_key $DIR.strnull null
+	test_must_fail flux kvs put .=1
 '
 
 #
@@ -346,7 +334,7 @@ test_empty_directory() {
 }
 
 test_expect_success 'kvs: try to retrieve key as directory should fail' '
-        flux kvs put --json $DIR.a.b.c.d=42 &&
+        flux kvs put $DIR.a.b.c.d=42 &&
 	test_must_fail flux kvs dir $DIR.a.b.c.d
 '
 test_expect_success 'kvs: empty directory can be created' '
@@ -380,7 +368,7 @@ test_expect_success 'kvs: unlink -R works' '
 '
 test_expect_success 'kvs: empty directory remains after key removed' '
 	flux kvs unlink -Rf $DIR &&
-        flux kvs put --json $DIR.a=1 &&
+        flux kvs put $DIR.a=1 &&
         test_kvs_key $DIR.a 1 &&
         flux kvs unlink $DIR.a &&
 	test_empty_directory $DIR
@@ -416,20 +404,6 @@ test_expect_success 'kvs: put/get empty string' '
 	test_cmp output expected
 '
 test_expect_success 'kvs: dir can read and display empty string' '
-	flux kvs dir -R $DIR | sort >output &&
-	cat >expected <<EOF &&
-$DIR.a = 
-EOF
-	test_cmp expected output
-'
-test_expect_success 'kvs: no value with --json is json empty string' '
-	flux kvs unlink -Rf $DIR &&
-	flux kvs put --json $DIR.a= &&
-	flux kvs get --json $DIR.a >output &&
-        echo "" > expected &&
-	test_cmp output expected
-'
-test_expect_success 'kvs: dir can read and display json empty string' '
 	flux kvs dir -R $DIR | sort >output &&
 	cat >expected <<EOF &&
 $DIR.a = 
@@ -525,10 +499,10 @@ test_expect_success 'kvs: treeobj can be used to create arbitrary snapshot' '
 
 test_expect_success 'kvs: put --treeobj: clobbers destination' '
 	flux kvs unlink -Rf $DIR &&
-	flux kvs put --json $DIR.a=42 &&
+	flux kvs put $DIR.a=42 &&
 	flux kvs get --treeobj . >snapshot2 &&
 	flux kvs put --treeobj $DIR.a="`cat snapshot2`" &&
-	! flux kvs get --json $DIR.a &&
+	! flux kvs get $DIR.a &&
 	flux kvs dir $DIR.a
 '
 test_expect_success 'kvs: put --treeobj: fails bad dirent: not JSON' '
@@ -599,11 +573,11 @@ test_expect_success 'kvs: basic append works with newlines' '
 #
 test_expect_success 'kvs: put using --no-merge flag' '
 	flux kvs unlink -Rf $DIR &&
-	flux kvs put --no-merge --json $DIR.a=69 &&
-        flux kvs put --no-merge --json $DIR.b.c.d.e.f.g=70 &&
-        flux kvs put --no-merge --json $DIR.c.a.b=3.14 &&
-        flux kvs put --no-merge --json $DIR.d=\"snerg\" &&
-        flux kvs put --no-merge --json $DIR.e=true &&
+	flux kvs put --no-merge $DIR.a=69 &&
+        flux kvs put --no-merge $DIR.b.c.d.e.f.g=70 &&
+        flux kvs put --no-merge $DIR.c.a.b=3.14 &&
+        flux kvs put --no-merge $DIR.d=\"snerg\" &&
+        flux kvs put --no-merge $DIR.e=true &&
 	flux kvs dir -R $DIR | sort >output &&
 	cat >expected <<EOF &&
 $DIR.a = 69
@@ -639,7 +613,7 @@ test_expect_success 'kvs: ls -1F . works' '
 '
 test_expect_success 'kvs: ls -1F DIR works' '
 	flux kvs unlink -Rf $DIR &&
-	flux kvs put --json $DIR.a=69 &&
+	flux kvs put $DIR.a=69 &&
 	flux kvs mkdir $DIR.b &&
 	flux kvs link b $DIR.c &&
 	flux kvs link --target-namespace=foo c $DIR.d &&
@@ -664,7 +638,7 @@ test_expect_success 'kvs: ls -1F DIR. works' '
 '
 test_expect_success 'kvs: ls -1Fd DIR.a DIR.b DIR.c DIR.d works' '
 	flux kvs unlink -Rf $DIR &&
-	flux kvs put --json $DIR.a=69 &&
+	flux kvs put $DIR.a=69 &&
 	flux kvs mkdir $DIR.b &&
 	flux kvs link b $DIR.c &&
 	flux kvs link --target-namespace=foo c $DIR.d &&
@@ -679,8 +653,8 @@ test_expect_success 'kvs: ls -1Fd DIR.a DIR.b DIR.c DIR.d works' '
 '
 test_expect_success 'kvs: ls -1RF shows directory titles' '
 	flux kvs unlink -Rf $DIR &&
-	flux kvs put --json $DIR.a=69 &&
-	flux kvs put --json $DIR.b.d=42 &&
+	flux kvs put $DIR.a=69 &&
+	flux kvs put $DIR.b.d=42 &&
 	flux kvs link b $DIR.c &&
 	flux kvs ls -1RF $DIR | grep : | wc -l >output &&
 	cat >expected <<-EOF &&
@@ -757,7 +731,7 @@ test_expect_success 'kvs: ls key. works' '
 '
 test_expect_success 'kvs: ls key. fails if key is not a directory' '
 	flux kvs unlink -Rf $DIR &&
-	flux kvs put --json $DIR.a=42 &&
+	flux kvs put $DIR.a=42 &&
 	test_must_fail flux kvs ls -d $DIR.a.
 '
 test_expect_success 'kvs: ls key. fails if key does not exist' '
@@ -829,7 +803,7 @@ test_expect_success 'kvs: namespace create setup' '
 '
 test_expect_success 'kvs: ls --namespace -1F DIR works' '
 	flux kvs unlink --namespace=TESTLSNS -Rf $DIR.ns &&
-	flux kvs put --namespace=TESTLSNS --json $DIR.ns.a=69 &&
+	flux kvs put --namespace=TESTLSNS $DIR.ns.a=69 &&
 	flux kvs mkdir --namespace=TESTLSNS $DIR.ns.b &&
 	flux kvs link --namespace=TESTLSNS b $DIR.ns.c &&
 	flux kvs link --namespace=TESTLSNS --target-namespace=foo c $DIR.ns.d &&
@@ -852,14 +826,14 @@ test_expect_success 'kvs: namespace remove cleanup' '
 
 test_expect_success 'kvs: link works' '
 	TARGET=$DIR.target &&
-	flux kvs put --json $TARGET=\"foo\" &&
+	flux kvs put $TARGET="foo" &&
 	flux kvs link $TARGET $DIR.link &&
-	OUTPUT=$(flux kvs get --json $DIR.link) &&
+	OUTPUT=$(flux kvs get $DIR.link) &&
 	test "$OUTPUT" = "foo"
 '
 test_expect_success 'kvs: readlink works' '
 	TARGET=$DIR.target &&
-	flux kvs put --json $TARGET=\"foo\" &&
+	flux kvs put $TARGET="foo" &&
 	flux kvs link $TARGET $DIR.link &&
 	OUTPUT=$(flux kvs readlink $DIR.link) &&
 	test "$OUTPUT" = "$TARGET"
@@ -867,8 +841,8 @@ test_expect_success 'kvs: readlink works' '
 test_expect_success 'kvs: readlink works (multiple inputs)' '
 	TARGET1=$DIR.target1 &&
 	TARGET2=$DIR.target2 &&
-	flux kvs put --json $TARGET1=\"foo1\" &&
-	flux kvs put --json $TARGET2=\"foo2\" &&
+	flux kvs put $TARGET1="foo1" &&
+	flux kvs put $TARGET2="foo2" &&
 	flux kvs link $TARGET1 $DIR.link1 &&
 	flux kvs link $TARGET2 $DIR.link2 &&
 	flux kvs readlink $DIR.link1 $DIR.link2 >output &&
@@ -880,14 +854,14 @@ EOF
 '
 test_expect_success 'kvs: link: path resolution when intermediate component is a link' '
 	flux kvs unlink -Rf $DIR &&
-	flux kvs put --json $DIR.a.b.c=42 &&
+	flux kvs put $DIR.a.b.c=42 &&
 	flux kvs link $DIR.a.b $DIR.Z.Y &&
-	OUTPUT=$(flux kvs get --json $DIR.Z.Y.c) &&
+	OUTPUT=$(flux kvs get $DIR.Z.Y.c) &&
 	test "$OUTPUT" = "42"
 '
 test_expect_success 'kvs: link: intermediate link points to another link' '
 	flux kvs unlink -Rf $DIR &&
-	flux kvs put --json $DIR.a.b.c=42 &&
+	flux kvs put $DIR.a.b.c=42 &&
 	flux kvs link $DIR.a.b $DIR.Z.Y &&
 	flux kvs link $DIR.Z.Y $DIR.X.W &&
 	test_kvs_key $DIR.X.W.c 42
@@ -897,7 +871,7 @@ test_expect_success 'kvs: link: intermediate links are followed by put' '
 	flux kvs mkdir $DIR.a &&
 	flux kvs link $DIR.a $DIR.link &&
 	flux kvs readlink $DIR.link >/dev/null &&
-	flux kvs put --json $DIR.link.X=42 &&
+	flux kvs put $DIR.link.X=42 &&
 	flux kvs readlink $DIR.link >/dev/null &&
 	test_kvs_key $DIR.link.X 42 &&
 	test_kvs_key $DIR.a.X 42
@@ -907,7 +881,7 @@ test_expect_success 'kvs: link: copy removes linked destination' '
 	flux kvs unlink -Rf $DIR &&
 	flux kvs mkdir $DIR.a &&
 	flux kvs link $DIR.a $DIR.link &&
-	flux kvs put --json $DIR.a.X=42 &&
+	flux kvs put $DIR.a.X=42 &&
 	flux kvs copy $DIR.a $DIR.link &&
 	! flux kvs readlink $DIR.link >/dev/null &&
 	test_kvs_key $DIR.link.X 42
@@ -917,7 +891,7 @@ test_expect_success 'kvs: link: move works' '
 	flux kvs unlink -Rf $DIR &&
 	flux kvs mkdir $DIR.a &&
 	flux kvs link $DIR.a $DIR.link &&
-	flux kvs put --json $DIR.a.X=42 &&
+	flux kvs put $DIR.a.X=42 &&
 	flux kvs move $DIR.a $DIR.link &&
 	! flux kvs readlink $DIR.link >/dev/null &&
 	test_kvs_key $DIR.link.X 42 &&
@@ -925,7 +899,7 @@ test_expect_success 'kvs: link: move works' '
 '
 test_expect_success 'kvs: link: copy does not follow links (top)' '
 	flux kvs unlink -Rf $DIR &&
-	flux kvs put --json $DIR.a.X=42 &&
+	flux kvs put $DIR.a.X=42 &&
 	flux kvs link $DIR.a $DIR.link &&
 	flux kvs copy $DIR.link $DIR.copy &&
 	LINKVAL=$(flux kvs readlink $DIR.copy) &&
@@ -933,7 +907,7 @@ test_expect_success 'kvs: link: copy does not follow links (top)' '
 '
 test_expect_success 'kvs: link: copy does not follow links (mid)' '
 	flux kvs unlink -Rf $DIR &&
-	flux kvs put --json $DIR.a.b.X=42 &&
+	flux kvs put $DIR.a.b.X=42 &&
 	flux kvs link $DIR.a.b $DIR.a.link &&
 	flux kvs copy $DIR.a $DIR.copy &&
 	LINKVAL=$(flux kvs readlink $DIR.copy.link) &&
@@ -941,7 +915,7 @@ test_expect_success 'kvs: link: copy does not follow links (mid)' '
 '
 test_expect_success 'kvs: link: copy does not follow links (bottom)' '
 	flux kvs unlink -Rf $DIR &&
-	flux kvs put --json $DIR.a.b.X=42 &&
+	flux kvs put $DIR.a.b.X=42 &&
 	flux kvs link $DIR.a.b.X $DIR.a.b.link &&
 	flux kvs copy $DIR.a $DIR.copy &&
 	LINKVAL=$(flux kvs readlink $DIR.copy.b.link) &&
@@ -964,7 +938,7 @@ test_expect_success 'kvs: link: readlink on dangling link' '
 
 test_expect_success 'kvs: readlink fails on regular value' '
         flux kvs unlink -Rf $DIR &&
-	flux kvs put --json $DIR.target=42 &&
+	flux kvs put $DIR.target=42 &&
 	! flux kvs readlink $DIR.target
 '
 test_expect_success 'kvs: readlink fails on directory' '
@@ -975,7 +949,7 @@ test_expect_success 'kvs: readlink fails on directory' '
 test_expect_success 'kvs: link: path resolution with intermediate link and nonexistent key' '
 	flux kvs unlink -Rf $DIR &&
 	flux kvs link $DIR.a.b $DIR.Z.Y &&
-	test_must_fail flux kvs get --json $DIR.Z.Y
+	test_must_fail flux kvs get $DIR.Z.Y
 '
 
 #
@@ -987,20 +961,20 @@ test_expect_success 'kvs: namespace create setup' '
 '
 test_expect_success 'kvs: symlink w/ Namespace works' '
 	TARGET=$DIR.target &&
-	flux kvs put --namespace=TESTSYMLINKNS --json $TARGET=\"foo\" &&
+	flux kvs put --namespace=TESTSYMLINKNS $TARGET="foo" &&
 	flux kvs link --target-namespace=TESTSYMLINKNS $TARGET $DIR.symlinkNS &&
-	OUTPUT=$(flux kvs get --json $DIR.symlinkNS) &&
+	OUTPUT=$(flux kvs get $DIR.symlinkNS) &&
 	test "$OUTPUT" = "foo"
 '
 test_expect_success 'kvs: symlink w/ Namespace fails on bad namespace' '
 	TARGET=$DIR.target &&
-	flux kvs put --json $TARGET=\"foo\" &&
+	flux kvs put $TARGET="foo" &&
 	flux kvs link --target-namespace=TESTSYMLINKNS-FAKE $TARGET $DIR.symlinkNS &&
-	! flux kvs get --json $DIR.symlinkNS
+	! flux kvs get $DIR.symlinkNS
 '
 test_expect_success 'kvs: readlink on symlink w/ Namespace works' '
 	TARGET=$DIR.target &&
-	flux kvs put --json $TARGET=\"foo\" &&
+	flux kvs put $TARGET="foo" &&
 	flux kvs link --target-namespace=TESTSYMLINKNS $TARGET $DIR.symlinkNS &&
 	OUTPUT=$(flux kvs readlink $DIR.symlinkNS) &&
 	test "$OUTPUT" = "TESTSYMLINKNS::$TARGET"
@@ -1008,8 +982,8 @@ test_expect_success 'kvs: readlink on symlink w/ Namespace works' '
 test_expect_success 'kvs: readlink works with nslnks (multiple inputs)' '
 	TARGET1=$DIR.target1 &&
 	TARGET2=$DIR.target2 &&
-	flux kvs put --namespace=TESTSYMLINKNS --json $TARGET1=\"foo1\" &&
-	flux kvs put --namespace=TESTSYMLINKNS --json $TARGET2=\"foo2\" &&
+	flux kvs put --namespace=TESTSYMLINKNS $TARGET1="foo1" &&
+	flux kvs put --namespace=TESTSYMLINKNS $TARGET2="foo2" &&
 	flux kvs link --target-namespace=TESTSYMLINKNS $TARGET1 $DIR.symlinkNS1 &&
 	flux kvs link --target-namespace=TESTSYMLINKNS $TARGET2 $DIR.symlinkNS2 &&
 	flux kvs readlink $DIR.symlinkNS1 $DIR.symlinkNS2 >output &&
@@ -1022,15 +996,15 @@ EOF
 test_expect_success 'kvs: symlinkNS: path resolution when intermediate component is a link' '
 	flux kvs unlink -Rf $DIR &&
 	flux kvs unlink --namespace=TESTSYMLINKNS -Rf $DIR &&
-	flux kvs put --namespace=TESTSYMLINKNS --json $DIR.a.b.c=42 &&
+	flux kvs put --namespace=TESTSYMLINKNS $DIR.a.b.c=42 &&
 	flux kvs link --target-namespace=TESTSYMLINKNS $DIR.a.b $DIR.Z.Y &&
-	OUTPUT=$(flux kvs get --json $DIR.Z.Y.c) &&
+	OUTPUT=$(flux kvs get $DIR.Z.Y.c) &&
 	test "$OUTPUT" = "42"
 '
 test_expect_success 'kvs: symlinkNS: intermediate link points to another namespace link' '
 	flux kvs unlink -Rf $DIR &&
 	flux kvs unlink --namespace=TESTSYMLINKNS -Rf $DIR &&
-	flux kvs put --namespace=TESTSYMLINKNS --json $DIR.a.b.c=42 &&
+	flux kvs put --namespace=TESTSYMLINKNS $DIR.a.b.c=42 &&
 	flux kvs link --namespace=TESTSYMLINKNS --target-namespace=TESTSYMLINKNS $DIR.a.b $DIR.Z.Y &&
 	flux kvs link --target-namespace=TESTSYMLINKNS $DIR.Z.Y $DIR.X.W &&
 	test_kvs_key $DIR.X.W.c 42
@@ -1038,7 +1012,7 @@ test_expect_success 'kvs: symlinkNS: intermediate link points to another namespa
 test_expect_success 'kvs: symlinkNS: intermediate link points to another symlink' '
 	flux kvs unlink -Rf $DIR &&
 	flux kvs unlink --namespace=TESTSYMLINKNS -Rf $DIR &&
-	flux kvs put --namespace=TESTSYMLINKNS --json $DIR.a.b.c=42 &&
+	flux kvs put --namespace=TESTSYMLINKNS $DIR.a.b.c=42 &&
 	flux kvs link --namespace=TESTSYMLINKNS $DIR.a.b $DIR.Z.Y &&
 	flux kvs link --target-namespace=TESTSYMLINKNS $DIR.Z.Y $DIR.X.W &&
 	test_kvs_key $DIR.X.W.c 42
@@ -1048,7 +1022,7 @@ test_expect_success 'kvs: symlinkNS: put cant cross namespace' '
 	flux kvs unlink --namespace=TESTSYMLINKNS -Rf $DIR &&
 	flux kvs mkdir --namespace=TESTSYMLINKNS $DIR.a &&
 	flux kvs link --target-namespace=TESTSYMLINKNS $DIR.a $DIR.link &&
-	! flux kvs put --json $DIR.link.X=42
+	! flux kvs put $DIR.link.X=42
 '
 test_expect_success 'kvs: symlinkNS: dangling link' '
 	flux kvs unlink -Rf $DIR &&
@@ -1072,21 +1046,21 @@ test_expect_success 'kvs: namespace remove cleanup' '
 
 test_expect_success 'kvs: get --at: works on root from get --treeobj' '
 	flux kvs unlink -Rf $DIR &&
-	flux kvs put --json $DIR.a.b.c=42 &&
+	flux kvs put $DIR.a.b.c=42 &&
 	test $(flux kvs get --at $(flux kvs get --treeobj .) $DIR.a.b.c) = 42
 '
 
 test_expect_success 'kvs: get --at: works on subdir from get --treeobj' '
 	flux kvs unlink -Rf $DIR &&
-	flux kvs put --json $DIR.a.b.c=42 &&
+	flux kvs put $DIR.a.b.c=42 &&
 	test $(flux kvs get --at $(flux kvs get --treeobj $DIR.a.b) c) = 42
 '
 
 test_expect_success 'kvs: get --at: works on outdated root' '
 	flux kvs unlink -Rf $DIR &&
-	flux kvs put --json $DIR.a.b.c=42 &&
+	flux kvs put $DIR.a.b.c=42 &&
 	ROOTREF=$(flux kvs get --treeobj .) &&
-	flux kvs put --json $DIR.a.b.c=43 &&
+	flux kvs put $DIR.a.b.c=43 &&
 	test $(flux kvs get --at $ROOTREF $DIR.a.b.c) = 42
 '
 test_expect_success 'kvs: readlink --at works after symlink unlinked' '
@@ -1107,11 +1081,11 @@ test_expect_success 'kvs: readlink --at works after symlink w/ Namespace unlinke
 '
 test_expect_success 'kvs: directory with multiple subdirs using dir --at' '
 	flux kvs unlink -Rf $DIR &&
-	flux kvs put --json $DIR.a=69 &&
-        flux kvs put --json $DIR.b.c.d.e.f.g=70 &&
-        flux kvs put --json $DIR.c.a.b=3.14 &&
-        flux kvs put --json $DIR.d=\"snerg\" &&
-        flux kvs put --json $DIR.e=true &&
+	flux kvs put $DIR.a=69 &&
+        flux kvs put $DIR.b.c.d.e.f.g=70 &&
+        flux kvs put $DIR.c.a.b=3.14 &&
+        flux kvs put $DIR.d=\"snerg\" &&
+        flux kvs put $DIR.e=true &&
         flux kvs link $DIR.a $DIR.f &&
         DIRREF=$(flux kvs get --treeobj $DIR) &&
 	flux kvs dir -R --at $DIRREF . | sort >output &&
@@ -1192,7 +1166,7 @@ test_expect_success NO_CHAIN_LINT 'kvs: version and wait' '
         VERS=$((VERS + 1))
         flux kvs wait $VERS &
         kvswaitpid=$! &&
-        flux kvs put --json $DIR.xxx=99 &&
+        flux kvs put $DIR.xxx=99 &&
         test_expect_code 0 wait $kvswaitpid
 '
 

--- a/t/t1003-kvs-stress.t
+++ b/t/t1003-kvs-stress.t
@@ -41,8 +41,8 @@ test_expect_success 'kvs: store 2x4 directory tree and walk' '
 
 test_expect_success 'kvs: add other types to 2x4 directory and walk' '
 	flux kvs link $DIR.dtree $DIR.dtree.link &&
-	flux kvs put --json $DIR.dtree.double=3.14 &&
-	flux kvs put --json $DIR.dtree.booelan=true &&
+	flux kvs put $DIR.dtree.double=3.14 &&
+	flux kvs put $DIR.dtree.booelan=true &&
 	test $(flux kvs dir -R $DIR.dtree | wc -l) = 19
 '
 

--- a/t/t1004-kvs-namespace.t
+++ b/t/t1004-kvs-namespace.t
@@ -101,29 +101,29 @@ test_expect_success 'kvs: remove primary namespace fails' '
 '
 
 test_expect_success 'kvs: get with primary namespace works' '
-        flux kvs put --json $DIR.test=1 &&
+        flux kvs put $DIR.test=1 &&
         test_kvs_key_namespace $PRIMARYNAMESPACE $DIR.test 1
 '
 
 test_expect_success 'kvs: put with primary namespace works' '
-        flux kvs put --namespace=$PRIMARYNAMESPACE --json $DIR.test=2 &&
+        flux kvs put --namespace=$PRIMARYNAMESPACE $DIR.test=2 &&
         test_kvs_key $DIR.test 2
 '
 
 test_expect_success 'kvs: put/get with primary namespace works' '
-        flux kvs put --namespace=$PRIMARYNAMESPACE --json $DIR.test=3 &&
+        flux kvs put --namespace=$PRIMARYNAMESPACE $DIR.test=3 &&
         test_kvs_key_namespace $PRIMARYNAMESPACE $DIR.test 3
 '
 
 test_expect_success 'kvs: unlink with primary namespace works' '
         flux kvs unlink --namespace=$PRIMARYNAMESPACE $DIR.test &&
-        test_must_fail flux kvs get --json $DIR.test
+        test_must_fail flux kvs get $DIR.test
 '
 
 test_expect_success 'kvs: dir with primary namespace works' '
-        flux kvs put --json $DIR.a=1 &&
-        flux kvs put --json $DIR.b=2 &&
-        flux kvs put --json $DIR.c=3 &&
+        flux kvs put $DIR.a=1 &&
+        flux kvs put $DIR.b=2 &&
+        flux kvs put $DIR.c=3 &&
         flux kvs dir --namespace=$PRIMARYNAMESPACE $DIR | sort > output &&
         cat >expected <<EOF &&
 $DIR.a = 1
@@ -143,7 +143,7 @@ test_expect_success NO_CHAIN_LINT 'kvs: wait on primary namespace works' '
         VERS=$((VERS + 1))
         flux kvs wait --namespace=$PRIMARYNAMESPACE $VERS &
         kvswaitpid=$!
-        flux kvs put --namespace=$PRIMARYNAMESPACE --json $DIR.xxx=99
+        flux kvs put --namespace=$PRIMARYNAMESPACE $DIR.xxx=99
         test_expect_code 0 wait $kvswaitpid
 '
 
@@ -168,19 +168,19 @@ test_expect_success 'kvs: new namespace exists/is listed' '
 '
 
 test_expect_success 'kvs: put/get value in new namespace works' '
-        flux kvs put --namespace=$NAMESPACETEST --json $DIR.test=1 &&
+        flux kvs put --namespace=$NAMESPACETEST $DIR.test=1 &&
         test_kvs_key_namespace $NAMESPACETEST $DIR.test 1
 '
 
 test_expect_success 'kvs: unlink in new namespace works' '
         flux kvs unlink --namespace=$NAMESPACETEST $DIR.test &&
-        ! flux kvs get --namespace=$NAMESPACETEST --json $DIR.test
+        ! flux kvs get --namespace=$NAMESPACETEST $DIR.test
 '
 
 test_expect_success 'kvs: dir in new namespace works' '
-        flux kvs put --namespace=$NAMESPACETEST --json $DIR.a=4 &&
-        flux kvs put --namespace=$NAMESPACETEST --json $DIR.b=5 &&
-        flux kvs put --namespace=$NAMESPACETEST --json $DIR.c=6 &&
+        flux kvs put --namespace=$NAMESPACETEST $DIR.a=4 &&
+        flux kvs put --namespace=$NAMESPACETEST $DIR.b=5 &&
+        flux kvs put --namespace=$NAMESPACETEST $DIR.c=6 &&
         flux kvs dir --namespace=$NAMESPACETEST $DIR | sort > output &&
         cat >expected <<EOF &&
 $DIR.a = 4
@@ -200,7 +200,7 @@ test_expect_success NO_CHAIN_LINT 'kvs: wait in new namespace works' '
         VERS=$((VERS + 1))
         flux kvs wait --namespace=$NAMESPACETEST $VERS &
         kvswaitpid=$!
-        flux kvs put --namespace=$NAMESPACETEST --json $DIR.xxx=99
+        flux kvs put --namespace=$NAMESPACETEST $DIR.xxx=99
         test_expect_code 0 wait $kvswaitpid
 '
 
@@ -210,10 +210,10 @@ test_expect_success 'kvs: namespace remove non existing namespace silently passe
 
 test_expect_success 'kvs: namespace remove works' '
 	flux kvs namespace create $NAMESPACETMP-BASIC &&
-        flux kvs put --namespace=$NAMESPACETMP-BASIC --json $DIR.tmp=1 &&
+        flux kvs put --namespace=$NAMESPACETMP-BASIC $DIR.tmp=1 &&
         test_kvs_key_namespace $NAMESPACETMP-BASIC $DIR.tmp 1 &&
 	flux kvs namespace remove $NAMESPACETMP-BASIC &&
-        ! flux kvs get --namespace=$NAMESPACETMP-BASIC --json $DIR.tmp
+        ! flux kvs get --namespace=$NAMESPACETMP-BASIC $DIR.tmp
 '
 
 # A namespace create races against the namespace remove above, as we
@@ -222,10 +222,10 @@ test_expect_success 'kvs: namespace remove works' '
 # namespace create many times until it succeeds.
 test_expect_success 'kvs: namespace can be re-created after remove' '
         namespace_create_loop $NAMESPACETMP-BASIC &&
-        flux kvs put --namespace=$NAMESPACETMP-BASIC --json $DIR.recreate=1 &&
+        flux kvs put --namespace=$NAMESPACETMP-BASIC $DIR.recreate=1 &&
         test_kvs_key_namespace $NAMESPACETMP-BASIC $DIR.recreate 1 &&
 	flux kvs namespace remove $NAMESPACETMP-BASIC &&
-        ! flux kvs get --namespace=$NAMESPACETMP-BASIC --json $DIR.recreate
+        ! flux kvs get --namespace=$NAMESPACETMP-BASIC $DIR.recreate
 '
 
 test_expect_success 'kvs: removed namespace not listed' '
@@ -238,7 +238,7 @@ test_expect_success 'kvs: removed namespace not listed' '
 
 test_expect_success 'kvs: put value in new namespace, available on other ranks' '
         flux kvs unlink --namespace=$NAMESPACETEST -Rf $DIR &&
-        flux kvs put --namespace=$NAMESPACETEST --json $DIR.all=1 &&
+        flux kvs put --namespace=$NAMESPACETEST $DIR.all=1 &&
         VERS=`flux kvs version --namespace=$NAMESPACETEST` &&
         flux exec -n sh -c "flux kvs wait --namespace=$NAMESPACETEST ${VERS} && \
                          flux kvs get --namespace=$NAMESPACETEST $DIR.all"
@@ -255,7 +255,7 @@ test_expect_success 'kvs: unlink value in new namespace, does not exist all rank
 # get_kvs_namespace_fails_all_ranks_loop()
 test_expect_success 'kvs: namespace remove works, recognized on other ranks' '
 	flux kvs namespace create $NAMESPACETMP-ALL &&
-        flux kvs put --namespace=$NAMESPACETMP-ALL --json $DIR.all=1 &&
+        flux kvs put --namespace=$NAMESPACETMP-ALL $DIR.all=1 &&
         VERS=`flux kvs version --namespace=$NAMESPACETMP-ALL` &&
         flux exec -n sh -c "flux kvs wait --namespace=$NAMESPACETMP-ALL ${VERS} && \
                          flux kvs get --namespace=$NAMESPACETMP-ALL $DIR.all" &&
@@ -274,7 +274,7 @@ test_expect_success 'kvs: namespace remove works, recognized on other ranks' '
 # kvs wait, b/c the version may work against an old namespace.
 test_expect_success 'kvs: namespace can be re-created after remove, recognized on other ranks' '
         namespace_create_loop $NAMESPACETMP-ALL &&
-        flux kvs put --namespace=$NAMESPACETMP-ALL --json $DIR.recreate=1 &&
+        flux kvs put --namespace=$NAMESPACETMP-ALL $DIR.recreate=1 &&
         get_kvs_namespace_all_ranks_loop $NAMESPACETMP-ALL $DIR.recreate &&
 	flux kvs namespace remove $NAMESPACETMP-ALL
 '
@@ -354,7 +354,7 @@ test_expect_success 'kvs: namespace create on existing namespace fails on rank 1
 '
 
 test_expect_success 'kvs: get fails on invalid namespace' '
-        ! flux kvs get --namespace=$NAMESPACEBAD --json $DIR.test
+        ! flux kvs get --namespace=$NAMESPACEBAD $DIR.test
 '
 
 test_expect_success 'kvs: get fails on invalid namespace on rank 1' '
@@ -362,7 +362,7 @@ test_expect_success 'kvs: get fails on invalid namespace on rank 1' '
 '
 
 test_expect_success 'kvs: put fails on invalid namespace' '
-	! flux kvs put --namespace=$NAMESPACEBAD --json $DIR.test=1
+	! flux kvs put --namespace=$NAMESPACEBAD $DIR.test=1
 '
 
 test_expect_success 'kvs: put fails on invalid namespace on rank 1' '
@@ -433,34 +433,34 @@ test_expect_success NO_CHAIN_LINT 'kvs: wait recognizes removed namespace' '
 #
 
 test_expect_success 'kvs: put/get in different namespaces works' '
-        flux kvs put --namespace=$PRIMARYNAMESPACE --json $DIR.test=1 &&
-        flux kvs put --namespace=$NAMESPACETEST --json $DIR.test=2 &&
+        flux kvs put --namespace=$PRIMARYNAMESPACE $DIR.test=1 &&
+        flux kvs put --namespace=$NAMESPACETEST $DIR.test=2 &&
         test_kvs_key_namespace $PRIMARYNAMESPACE $DIR.test 1 &&
         test_kvs_key_namespace $NAMESPACETEST $DIR.test 2
 '
 
 test_expect_success 'kvs: unlink in different namespaces works' '
-        flux kvs put --namespace=$PRIMARYNAMESPACE --json $DIR.testA=1 &&
-        flux kvs put --namespace=$PRIMARYNAMESPACE --json $DIR.testB=1 &&
-        flux kvs put --namespace=$NAMESPACETEST --json $DIR.testA=2 &&
-        flux kvs put --namespace=$NAMESPACETEST --json $DIR.testB=2 &&
+        flux kvs put --namespace=$PRIMARYNAMESPACE $DIR.testA=1 &&
+        flux kvs put --namespace=$PRIMARYNAMESPACE $DIR.testB=1 &&
+        flux kvs put --namespace=$NAMESPACETEST $DIR.testA=2 &&
+        flux kvs put --namespace=$NAMESPACETEST $DIR.testB=2 &&
         flux kvs unlink --namespace=$PRIMARYNAMESPACE $DIR.testA &&
         flux kvs unlink --namespace=$NAMESPACETEST $DIR.testB &&
         test_kvs_key_namespace $PRIMARYNAMESPACE $DIR.testB 1 &&
         test_kvs_key_namespace $NAMESPACETEST $DIR.testA 2 &&
-        ! flux kvs get --namespace=$PRIMARYNAMESPACE --json $DIR.testA &&
-        ! flux kvs get --namespace=$NAMESPACETEST --json $DIR.testB
+        ! flux kvs get --namespace=$PRIMARYNAMESPACE $DIR.testA &&
+        ! flux kvs get --namespace=$NAMESPACETEST $DIR.testB
 '
 
 test_expect_success 'kvs: dir in different namespace works' '
         flux kvs unlink --namespace=$PRIMARYNAMESPACE -Rf $DIR &&
         flux kvs unlink --namespace=$NAMESPACETEST -Rf $DIR &&
-        flux kvs put --namespace=$PRIMARYNAMESPACE --json $DIR.a=10 &&
-        flux kvs put --namespace=$PRIMARYNAMESPACE --json $DIR.b=11 &&
-        flux kvs put --namespace=$PRIMARYNAMESPACE --json $DIR.c=12 &&
-        flux kvs put --namespace=$NAMESPACETEST --json $DIR.a=13 &&
-        flux kvs put --namespace=$NAMESPACETEST --json $DIR.b=14 &&
-        flux kvs put --namespace=$NAMESPACETEST --json $DIR.c=15 &&
+        flux kvs put --namespace=$PRIMARYNAMESPACE $DIR.a=10 &&
+        flux kvs put --namespace=$PRIMARYNAMESPACE $DIR.b=11 &&
+        flux kvs put --namespace=$PRIMARYNAMESPACE $DIR.c=12 &&
+        flux kvs put --namespace=$NAMESPACETEST $DIR.a=13 &&
+        flux kvs put --namespace=$NAMESPACETEST $DIR.b=14 &&
+        flux kvs put --namespace=$NAMESPACETEST $DIR.c=15 &&
         flux kvs dir --namespace=$PRIMARYNAMESPACE $DIR | sort > primaryoutput &&
         flux kvs dir --namespace=$NAMESPACETEST $DIR | sort > testoutput &&
         cat >primaryexpected <<EOF &&
@@ -478,14 +478,14 @@ EOF
 '
 
 test_expect_success 'kvs: unlink dir in different namespaces works' '
-        flux kvs put --namespace=$PRIMARYNAMESPACE --json $DIR.subdirA.A=A &&
-        flux kvs put --namespace=$PRIMARYNAMESPACE --json $DIR.subdirA.B=B &&
-        flux kvs put --namespace=$PRIMARYNAMESPACE --json $DIR.subdirB.A=A &&
-        flux kvs put --namespace=$PRIMARYNAMESPACE --json $DIR.subdirB.A=B &&
-        flux kvs put --namespace=$NAMESPACETEST --json $DIR.subdirA.A=A &&
-        flux kvs put --namespace=$NAMESPACETEST --json $DIR.subdirA.B=B &&
-        flux kvs put --namespace=$NAMESPACETEST --json $DIR.subdirB.A=A &&
-        flux kvs put --namespace=$NAMESPACETEST --json $DIR.subdirB.A=B &&
+        flux kvs put --namespace=$PRIMARYNAMESPACE $DIR.subdirA.A=A &&
+        flux kvs put --namespace=$PRIMARYNAMESPACE $DIR.subdirA.B=B &&
+        flux kvs put --namespace=$PRIMARYNAMESPACE $DIR.subdirB.A=A &&
+        flux kvs put --namespace=$PRIMARYNAMESPACE $DIR.subdirB.A=B &&
+        flux kvs put --namespace=$NAMESPACETEST $DIR.subdirA.A=A &&
+        flux kvs put --namespace=$NAMESPACETEST $DIR.subdirA.B=B &&
+        flux kvs put --namespace=$NAMESPACETEST $DIR.subdirB.A=A &&
+        flux kvs put --namespace=$NAMESPACETEST $DIR.subdirB.A=B &&
         flux kvs unlink --namespace=$PRIMARYNAMESPACE -Rf $DIR.subdirA &&
         flux kvs unlink --namespace=$NAMESPACETEST -Rf $DIR.subdirB &&
         ! flux kvs dir --namespace=$PRIMARYNAMESPACE $DIR.subdirA &&
@@ -505,8 +505,8 @@ test_expect_success NO_CHAIN_LINT 'kvs: wait in different namespaces works' '
         flux kvs wait --namespace=$NAMESPACETEST $TESTVERS &
         testkvswaitpid=$!
 
-        flux kvs put --namespace=$PRIMARYNAMESPACE --json $DIR.xxx=X
-        flux kvs put --namespace=$NAMESPACETEST --json $DIR.xxx=X
+        flux kvs put --namespace=$PRIMARYNAMESPACE $DIR.xxx=X
+        flux kvs put --namespace=$NAMESPACETEST $DIR.xxx=X
 
         test_expect_code 0 wait $primarykvswaitpid
         test_expect_code 0 wait $testkvswaitpid

--- a/t/t1005-kvs-security.t
+++ b/t/t1005-kvs-security.t
@@ -54,18 +54,18 @@ test_expect_success 'kvs: namespace create works (owner)' '
 
 test_expect_success 'kvs: put fails (user)' '
         set_userid 9999 &&
-      	! flux kvs put --namespace=$NAMESPACETMP-OWNER --json $DIR.test=1 &&
+      	! flux kvs put --namespace=$NAMESPACETMP-OWNER $DIR.test=1 &&
         unset_userid
 '
 
 test_expect_success 'kvs: put works (owner)' '
-        flux kvs put --namespace=$NAMESPACETMP-OWNER --json $DIR.test=1 &&
+        flux kvs put --namespace=$NAMESPACETMP-OWNER $DIR.test=1 &&
         test_kvs_key_namespace $NAMESPACETMP-OWNER $DIR.test 1
 '
 
 test_expect_success 'kvs: get fails (user)' '
         set_userid 9999 &&
-	! flux kvs get --namespace=$NAMESPACETMP-OWNER --json $DIR.test &&
+	! flux kvs get --namespace=$NAMESPACETMP-OWNER $DIR.test &&
         unset_userid
 '
 
@@ -117,10 +117,10 @@ test_expect_success 'kvs: namespace remove fails (user)' '
 '
 
 test_expect_success 'kvs: namespace remove works (owner)' '
-        flux kvs put --namespace=$NAMESPACETMP-OWNER --json $DIR.tmp=1 &&
+        flux kvs put --namespace=$NAMESPACETMP-OWNER $DIR.tmp=1 &&
         test_kvs_key_namespace $NAMESPACETMP-OWNER $DIR.tmp 1 &&
         flux kvs namespace remove $NAMESPACETMP-OWNER &&
-        ! flux kvs get --namespace=$NAMESPACETMP-OWNER --json $DIR.tmp
+        ! flux kvs get --namespace=$NAMESPACETMP-OWNER $DIR.tmp
 '
 
 #
@@ -137,19 +137,19 @@ test_expect_success 'kvs: namespace listed with correct owner' '
 
 test_expect_success 'kvs: namespace put/get works (user)' '
         set_userid 9999 &&
-        flux kvs put --namespace=$NAMESPACETMP-USER --json $DIR.test=1 &&
+        flux kvs put --namespace=$NAMESPACETMP-USER $DIR.test=1 &&
         test_kvs_key_namespace $NAMESPACETMP-USER $DIR.test 1 &&
         unset_userid
 '
 
 test_expect_success 'kvs: put/get works (owner)' '
-        flux kvs put --namespace=$NAMESPACETMP-USER --json $DIR.test=2 &&
+        flux kvs put --namespace=$NAMESPACETMP-USER $DIR.test=2 &&
         test_kvs_key_namespace $NAMESPACETMP-USER $DIR.test 2
 '
 
 test_expect_success 'kvs: put fails (wrong user)' '
         set_userid 9000 &&
-      	! flux kvs put --namespace=$NAMESPACETMP-USER --json $DIR.test=1 &&
+      	! flux kvs put --namespace=$NAMESPACETMP-USER $DIR.test=1 &&
         unset_userid
 '
 
@@ -165,7 +165,7 @@ test_expect_success 'kvs: get works on other ranks (owner)' '
 
 test_expect_success 'kvs: get fails (wrong user)' '
         set_userid 9000 &&
-        ! flux kvs get --namespace=$NAMESPACETMP-USER --json $DIR.test &&
+        ! flux kvs get --namespace=$NAMESPACETMP-USER $DIR.test &&
         unset_userid
 '
 
@@ -180,7 +180,7 @@ test_expect_success 'kvs: get works (wrong user, but with at reference)' '
         ref=`flux kvs get --namespace=$NAMESPACETMP-USER --treeobj .` &&
         unset_userid &&
         set_userid 9000 &&
-        flux kvs get --namespace=$NAMESPACETMP-USER --at ${ref} --json $DIR.test &&
+        flux kvs get --namespace=$NAMESPACETMP-USER --at ${ref} $DIR.test &&
         unset_userid
 '
 
@@ -190,7 +190,7 @@ test_expect_success NO_CHAIN_LINT 'kvs: version & wait works (user)' '
         VERS=$((VERS + 1))
         flux kvs wait --namespace=$NAMESPACETMP-USER $VERS &
         kvswaitpid=$!
-        flux kvs put --namespace=$NAMESPACETMP-USER --json $DIR.xxx=99
+        flux kvs put --namespace=$NAMESPACETMP-USER $DIR.xxx=99
         unset_userid
         test_expect_code 0 wait $kvswaitpid
 '
@@ -249,10 +249,10 @@ test_expect_success 'kvs: namespace remove still fails (user)' '
 '
 
 test_expect_success 'kvs: namespace remove still works (owner)' '
-        flux kvs put --namespace=$NAMESPACETMP-USER --json $DIR.tmp=1 &&
+        flux kvs put --namespace=$NAMESPACETMP-USER $DIR.tmp=1 &&
         test_kvs_key_namespace $NAMESPACETMP-USER $DIR.tmp 1 &&
         flux kvs namespace remove $NAMESPACETMP-USER &&
-        ! flux kvs get --namespace=$NAMESPACETMP-USER --json $DIR.tmp
+        ! flux kvs get --namespace=$NAMESPACETMP-USER $DIR.tmp
 '
 
 #

--- a/t/t2100-aggregate.t
+++ b/t/t2100-aggregate.t
@@ -17,7 +17,7 @@ if test -z "$jq"; then
 fi
 
 kvs_json_check() {
-    flux kvs get --json $1 | $jq -e "$2"
+    flux kvs get $1 | $jq -e "$2"
 }
 
 test_expect_success 'have aggregator module' '

--- a/t/t2100-aggregate.t
+++ b/t/t2100-aggregate.t
@@ -24,29 +24,29 @@ test_expect_success 'have aggregator module' '
     flux exec -r all flux module list | grep aggregator
 '
 
-test_expect_success 'flux-aggreagate: works' '
+test_expect_success 'flux-aggregate: works' '
     run_timeout 5 flux exec -n -r 0-7 flux aggregate -v test 1 &&
     kvs_json_check test ".count == 8 and .min == 1 and .max == 1"
 '
 
-test_expect_success 'flux-aggreagate: works for floating-point numbers' '
+test_expect_success 'flux-aggregate: works for floating-point numbers' '
     run_timeout 5 flux exec -n -r 0-7 flux aggregate test 1.825 &&
     kvs_json_check test ".count == 8 and .min == 1.825 and .max == 1.825"
 '
-test_expect_success 'flux-aggreagate: works for strings' '
+test_expect_success 'flux-aggregate: works for strings' '
     run_timeout 5 flux exec -n -r 0-7 flux aggregate test \"foo\" &&
     flux kvs get test &&
     kvs_json_check test ".count == 8" &&
     kvs_json_check test ".entries.\"[0-7]\" == \"foo\""
 '
-test_expect_success 'flux-aggreagate: works for arrays' '
+test_expect_success 'flux-aggregate: works for arrays' '
     run_timeout 5 flux exec -n -r 0-7 flux aggregate test "[7,8,9]" &&
     flux kvs get test &&
     kvs_json_check test ".count == 8" &&
     kvs_json_check test "(.entries | length) == 1" &&
     kvs_json_check test ".entries.\"[0-7]\" == [7,8,9]"
 '
-test_expect_success 'flux-aggreagate: works for objects' '
+test_expect_success 'flux-aggregate: works for objects' '
     run_timeout 5 flux exec -n -r 0-7 flux aggregate test \
                   "{\"foo\":42, \"bar\": {\"baz\": 2}}" &&
     flux kvs get test &&


### PR DESCRIPTION
Per #2796, remove legacy `--json` options in flux kvs and remove json output from `flux kvs dir`.

The meat of this PR is the changing on the tests, which is in 1 huge commit.  Outside of just removing the `--json` calls, there had to be tweaks to the tests and the removal of a few that were `--json` specific.