### PR TITLE
systemd: add broker options for simple system instance support

### DIFF
--- a/etc/flux.service.in
+++ b/etc/flux.service.in
@@ -4,6 +4,7 @@ Description=Flux message broker
 [Service]
 Environment=FLUX_USERDB_OPTIONS=--default-rolemask=user
 TimeoutStopSec=90
+KillMode=mixed
 ExecStart=@X_BINDIR@/flux broker \
   -Srundir=@X_RUNSTATEDIR@/flux \
   -Slocal-uri=local://@X_RUNSTATEDIR@/flux/local \

--- a/etc/flux.service.in
+++ b/etc/flux.service.in
@@ -16,6 +16,10 @@ User=flux
 Group=flux
 RuntimeDirectory=flux
 RuntimeDirectoryMode=0755
+PermissionsStartOnly=true
+ExecStartPre=-/bin/mkdir -p @X_LOCALSTATEDIR@/lib/flux
+ExecStartPre=/bin/chown flux:flux @X_LOCALSTATEDIR@/lib/flux
+ExecStartPre=/bin/chmod 0700 @X_LOCALSTATEDIR@/lib/flux
 #
 # Delegate cgroup control to user flux, so that systemd doesn't reset
 #  cgroups for flux initiated processes, and to allow (some) cgroup

--- a/etc/flux.service.in
+++ b/etc/flux.service.in
@@ -9,6 +9,7 @@ ExecStart=@X_BINDIR@/flux broker \
   -Slocal-uri=local://@X_RUNSTATEDIR@/flux/local \
   -Sboot.method=config \
   -Slog-stderr-level=6 \
+  -Scontent.backing-path=@X_LOCALSTATEDIR@/lib/flux/content.sqlite \
   -Sbroker.rc2_none
 User=flux
 Group=flux

--- a/etc/flux.service.in
+++ b/etc/flux.service.in
@@ -3,7 +3,11 @@ Description=Flux message broker
 
 [Service]
 Environment=FLUX_USERDB_OPTIONS=--default-rolemask=user
-ExecStart=@X_BINDIR@/flux broker -Srundir=@X_RUNSTATEDIR@/flux -Slocal-uri=local://@X_RUNSTATEDIR@/flux/local -Sboot.method=config sleep inf
+ExecStart=@X_BINDIR@/flux broker \
+  -Srundir=@X_RUNSTATEDIR@/flux \
+  -Slocal-uri=local://@X_RUNSTATEDIR@/flux/local \
+  -Sboot.method=config \
+  sleep inf
 User=flux
 Group=flux
 RuntimeDirectory=flux

--- a/etc/flux.service.in
+++ b/etc/flux.service.in
@@ -7,7 +7,7 @@ ExecStart=@X_BINDIR@/flux broker \
   -Srundir=@X_RUNSTATEDIR@/flux \
   -Slocal-uri=local://@X_RUNSTATEDIR@/flux/local \
   -Sboot.method=config \
-  sleep inf
+  -Sbroker.rc2_none
 User=flux
 Group=flux
 RuntimeDirectory=flux

--- a/etc/flux.service.in
+++ b/etc/flux.service.in
@@ -3,6 +3,7 @@ Description=Flux message broker
 
 [Service]
 Environment=FLUX_USERDB_OPTIONS=--default-rolemask=user
+TimeoutStopSec=90
 ExecStart=@X_BINDIR@/flux broker \
   -Srundir=@X_RUNSTATEDIR@/flux \
   -Slocal-uri=local://@X_RUNSTATEDIR@/flux/local \

--- a/etc/flux.service.in
+++ b/etc/flux.service.in
@@ -8,6 +8,7 @@ ExecStart=@X_BINDIR@/flux broker \
   -Srundir=@X_RUNSTATEDIR@/flux \
   -Slocal-uri=local://@X_RUNSTATEDIR@/flux/local \
   -Sboot.method=config \
+  -Slog-stderr-level=6 \
   -Sbroker.rc2_none
 User=flux
 Group=flux

--- a/etc/rc3
+++ b/etc/rc3
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 flux queue stop --quiet
-flux job cancelall --quiet -f --states RUN
+flux job cancelall --user=all --quiet -f --states RUN
 flux queue idle --quiet
 
 core_dir=$(cd ${0%/*} && pwd -P)

--- a/src/broker/runlevel.c
+++ b/src/broker/runlevel.c
@@ -28,7 +28,6 @@ struct level {
     flux_subprocess_t *p;
     flux_cmd_t *cmd;
     struct timespec start;
-    bool aborting;
 };
 
 struct runlevel {
@@ -287,9 +286,8 @@ error:
 int runlevel_abort (struct runlevel *r)
 {
 
-    if (!r || r->rc[r->level].aborting)
+    if (!r)
         return -1;
-    r->rc[r->level].aborting = true;
     if (r->rc[r->level].p) {
         flux_future_t *f;
         if (!(f = flux_subprocess_kill (r->rc[r->level].p, SIGTERM))) {


### PR DESCRIPTION
Systemd unit file changes needed to stop flux cleanly via `systemctl stop flux` with reasonable logs and KVS content preserved.

This needs some more testing hence the WIP.  My initial results were that `TimeoutStopSec` needed to be set to avoid an immediate second SIGTERM, but I just saw that behavior recurring with `TimeoutStopSec` set.   More poking needed.

This relies on features of PR #2794