### PR TITLE
flux-ping: fix problems with route string

### DIFF
--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -483,6 +483,8 @@ int main (int argc, char *argv[])
     }
     uint32_t rank = overlay_get_rank (ctx.overlay);
     uint32_t size = overlay_get_size (ctx.overlay);
+    char rank_str[16];
+    snprintf (rank_str, sizeof (rank_str), "%"PRIu32, rank);
 
     assert (size > 0);
 
@@ -633,7 +635,7 @@ int main (int argc, char *argv[])
         log_err ("exec_initialize");
         goto cleanup;
     }
-    if (ping_initialize (ctx.h, "cmb") < 0) {
+    if (ping_initialize (ctx.h, "cmb", rank_str) < 0) {
         log_err ("ping_initialize");
         goto cleanup;
     }

--- a/src/broker/modservice.c
+++ b/src/broker/modservice.c
@@ -263,7 +263,9 @@ int modservice_register (flux_t *h, module_t *p)
     if (register_request (ctx, "debug", debug_cb, FLUX_ROLE_OWNER) < 0)
         return -1;
 
-    if (ping_initialize (h, module_get_name (ctx->p)) < 0) {
+    if (ping_initialize (h,
+                         module_get_name (ctx->p),
+                         module_get_uuid (ctx->p)) < 0) {
         log_err ("ping_initialize");
         return -1;
     }

--- a/src/broker/ping.h
+++ b/src/broker/ping.h
@@ -13,7 +13,7 @@
 
 #include <flux/core.h>
 
-int ping_initialize (flux_t *h, const char *service);
+int ping_initialize (flux_t *h, const char *service, const char *uuid);
 
 #endif /* BROKER_PING_H */
 

--- a/src/common/libflux/message.c
+++ b/src/common/libflux/message.c
@@ -37,6 +37,7 @@
 #include <jansson.h>
 
 #include "src/common/libutil/aux.h"
+#include "src/common/libutil/errno_safe.h"
 
 #include "message.h"
 
@@ -1016,15 +1017,13 @@ char *flux_msg_get_route_string (const flux_msg_t *msg)
                     || (len = flux_msg_get_route_size (msg)) < 0) {
         return NULL;
     }
-    if (!(cp = buf = malloc (len + hops + 1))) {
-        errno = ENOMEM;
+    if (!(cp = buf = malloc (len + hops + 1)))
         return NULL;
-    }
     for (n = hops - 1; n >= 0; n--) {
         if (cp > buf)
             *cp++ = '!';
         if (!(zf = flux_msg_get_route_nth (msg, n))) {
-            free (buf);
+            ERRNO_SAFE_WRAP (free, buf);
             return NULL;
         }
         int cpylen = zframe_size (zf);

--- a/src/common/libflux/message.c
+++ b/src/common/libflux/message.c
@@ -1027,8 +1027,8 @@ char *flux_msg_get_route_string (const flux_msg_t *msg)
             return NULL;
         }
         int cpylen = zframe_size (zf);
-        if (cpylen == 32) /* abbreviate long UUID */
-            cpylen = 5;
+        if (cpylen == 36) /* abbreviate long UUID */
+            cpylen = 8;
         assert (cp - buf + cpylen < len + hops);
         memcpy (cp, zframe_data (zf), cpylen);
         cp += cpylen;

--- a/src/common/libflux/message.c
+++ b/src/common/libflux/message.c
@@ -1551,7 +1551,7 @@ struct flux_match flux_match_init (int typemask,
 
 void flux_match_free (struct flux_match m)
 {
-    free ((char *)m.topic_glob);
+    ERRNO_SAFE_WRAP (free, (char *)m.topic_glob);
 }
 
 int flux_match_asprintf (struct flux_match *m, const char *topic_glob_fmt, ...)


### PR DESCRIPTION
This fixes problems with the ping response generated for the broker and modules, as described in #2281 

Before:
```console
$ flux ping kvs
kvs.ping pad=0 seq=0 time=0.550 ms (09df78ee-5eeb-4642-b9c5-76f880b2f0c4!55c52d64-1ebd-460e-96d3-b74b7c5ca2aa!0!0)
kvs.ping pad=0 seq=1 time=0.637 ms (09df78ee-5eeb-4642-b9c5-76f880b2f0c4!55c52d64-1ebd-460e-96d3-b74b7c5ca2aa!0!0)
kvs.ping pad=0 seq=2 time=0.637 ms (09df78ee-5eeb-4642-b9c5-76f880b2f0c4!55c52d64-1ebd-460e-96d3-b74b7c5ca2aa!0!0)
```

after
```console
$ flux ping kvs
kvs.ping pad=0 seq=0 time=1.006 ms (8966cd4a!4d6e745a!0!5a516989)
kvs.ping pad=0 seq=1 time=1.220 ms (8966cd4a!4d6e745a!0!5a516989)
kvs.ping pad=0 seq=2 time=1.260 ms (8966cd4a!4d6e745a!0!5a516989)
```
Now the output more or less matches the example in the `flux-ping(1)` man page.

There's also a bit of cleanup in there.