### PR TITLE
broker: only allow "<userid>-" prefixed services to be registered by guests

### DIFF
--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -1536,16 +1536,66 @@ error:
 
 
 static const struct flux_msg_handler_spec htab[] = {
-    { FLUX_MSGTYPE_REQUEST, "cmb.rmmod",      cmb_rmmod_cb, 0 },
-    { FLUX_MSGTYPE_REQUEST, "cmb.insmod",     cmb_insmod_cb, 0 },
-    { FLUX_MSGTYPE_REQUEST, "cmb.lsmod",      cmb_lsmod_cb, 0 },
-    { FLUX_MSGTYPE_REQUEST, "cmb.lspeer",     cmb_lspeer_cb, 0 },
-    { FLUX_MSGTYPE_REQUEST, "cmb.panic",      cmb_panic_cb, 0 },
-    { FLUX_MSGTYPE_REQUEST, "cmb.disconnect", cmb_disconnect_cb, 0 },
-    { FLUX_MSGTYPE_REQUEST, "cmb.sub",        cmb_sub_cb, 0 },
-    { FLUX_MSGTYPE_REQUEST, "cmb.unsub",      cmb_unsub_cb, 0 },
-    { FLUX_MSGTYPE_REQUEST, "service.add",    service_add_cb, 0 },
-    { FLUX_MSGTYPE_REQUEST, "service.remove", service_remove_cb, 0 },
+    {
+        FLUX_MSGTYPE_REQUEST,
+        "cmb.rmmod",
+        cmb_rmmod_cb,
+        0
+    },
+    {
+        FLUX_MSGTYPE_REQUEST,
+        "cmb.insmod",
+        cmb_insmod_cb,
+        0
+    },
+    {
+        FLUX_MSGTYPE_REQUEST,
+        "cmb.lsmod",
+        cmb_lsmod_cb,
+        0
+    },
+    {
+        FLUX_MSGTYPE_REQUEST,
+        "cmb.lspeer",
+        cmb_lspeer_cb,
+        0
+    },
+    {
+        FLUX_MSGTYPE_REQUEST,
+        "cmb.panic",
+        cmb_panic_cb,
+        0
+    },
+    {
+        FLUX_MSGTYPE_REQUEST,
+        "cmb.disconnect",
+        cmb_disconnect_cb,
+        0
+    },
+    {
+        FLUX_MSGTYPE_REQUEST,
+        "cmb.sub",
+        cmb_sub_cb,
+        0
+    },
+    {
+        FLUX_MSGTYPE_REQUEST,
+        "cmb.unsub",
+        cmb_unsub_cb,
+        0
+    },
+    {
+        FLUX_MSGTYPE_REQUEST,
+        "service.add",
+        service_add_cb,
+        0
+    },
+    {
+        FLUX_MSGTYPE_REQUEST,
+        "service.remove",
+        service_remove_cb,
+        0
+    },
     FLUX_MSGHANDLER_TABLE_END,
 };
 

--- a/src/shell/svc.c
+++ b/src/shell/svc.c
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
-/* Register a service named "shell-<jobid>" on each shell and provide
+/* Register a service named "<userid>-shell-<jobid>" on each shell and provide
  * helpers for registering request handlers for different "methods".
  *
  * Notes:
@@ -64,7 +64,8 @@ static int build_topic (struct shell_svc *svc,
 {
     if (snprintf (buf,
                   len,
-                  "shell-%ju%s%s",
+                  "%d-shell-%ju%s%s",
+                  svc->uid,
                   (uintmax_t)svc->shell->info->jobid,
                   method ? "." : "",
                   method ? method : "") >= len) {
@@ -191,6 +192,13 @@ struct shell_svc *shell_svc_create (flux_shell_t *shell)
             goto error;
         }
         flux_future_destroy (f);
+        if (flux_shell_add_event_context (shell,
+                                          "shell.init",
+                                          0,
+                                          "{s:s}",
+                                          "service",
+                                          svc->name) < 0)
+            goto error;
         svc->registered = 1;
     }
     return svc;

--- a/t/t2610-job-shell-mpir.t
+++ b/t/t2610-job-shell-mpir.t
@@ -16,6 +16,10 @@ shell_leader_rank() {
     flux job wait-event -f json -p guest.exec.eventlog $1 shell.init | \
         jq '.context["leader-rank"]'
 }
+shell_service() {
+    flux job wait-event -f json -p guest.exec.eventlog $1 shell.init | \
+        jq -r '.context["service"]'
+}
 
 for test in 1:1 2:2 2:4 4:4 4:8 4:7; do
     TASKS=${test#*:}
@@ -25,7 +29,7 @@ for test in 1:1 2:2 2:4 4:4 4:8 4:7; do
              -n${TASKS} -N${NODES} /bin/true)  &&
         flux job wait-event -vt 5 -p guest.exec.eventlog \
                 -m sync=true ${id} shell.start &&
-        ${mpir} $id $(shell_leader_rank $id) &&
+        ${mpir} $(shell_leader_rank $id) $(shell_service $id) &&
         flux job kill -s CONT ${id} &&
         flux job attach ${id}
     '


### PR DESCRIPTION
As discussed in #2385, this PR prepares for multi-user by reducing the allowable service names that can be registered by guests to names prefixed with `<userid>-`.  This prevents users from interfering with each others' shell services, and with instance services.  The shell service is renamed to `<userid>-shell-<jobid>` and is now emitted in the `guest.exec.eventlog` `shell.init` event and picked up by `flux job attach`.

I had to change `t/shell/mpir` to get the service name from the  eventlog instead of deriving it from the job id.  My guess is changes pending in #2654 will need adjustment too?

Edit:  I should probably squash the shell, flux-job, and related test changes into one commit to avoid breaking git-bisect.  Also I missed closing #2385 in any of the commits.  I'll leave the commits as is until I get a review.

Also: @grondo, thanks for `flux_shell_add_event_context()`.  Great forward thinking design saved me some effort.