### PR TITLE
job-ingest: ensure duplicate jobids are not issued across instance restart

### DIFF
--- a/etc/rc1
+++ b/etc/rc1
@@ -26,7 +26,6 @@ unset pids
 declare -a pids
 flux hwloc reload & pids+=($!)
 flux exec -r all flux module load job-info & pids+=($!)
-flux exec -r all flux module load job-ingest & pids+=($!)
 flux module load cron sync=hb & pids+=($!)
 flux module load userdb ${FLUX_USERDB_OPTIONS} & pids+=($!)
 flux module load job-manager & pids+=($!)
@@ -34,6 +33,8 @@ wait_check ${pids[@]}
 unset pids
 
 declare -a pids
+flux module load job-ingest
+flux exec -r all -x 0 flux module load job-ingest & pids+=($!)
 flux module load job-exec &  pids+=($!)
 flux module load sched-simple & pids+=($!)
 wait_check ${pids[@]}

--- a/src/common/libutil/fluid.h
+++ b/src/common/libutil/fluid.h
@@ -26,17 +26,19 @@ typedef enum {
 
 struct fluid_generator {
     uint16_t id;
-    uint64_t epoch;
     uint16_t seq;
-    uint64_t last_ds;
+    uint64_t clock_zero;        // local clock value at fluid_init()
+    uint64_t clock_offset;      // clock offset due to starting timestamp
+    uint64_t timestamp;
 };
 
 typedef uint64_t fluid_t;
 
-/* Returns 0 on success, -1 on failure.
+/* Initialize generator 'id' with starting 'timestamp'.
+ * Returns 0 on success, -1 on failure.
  * Failures include id out of range, clock_gettime() error.
  */
-int fluid_init (struct fluid_generator *gen, uint32_t id);
+int fluid_init (struct fluid_generator *gen, uint32_t id, uint64_t timestamp);
 
 /* Returns 0 on success, -1 on failure.
  * Failures include timestamp out of range, clock_gettime() error.
@@ -44,6 +46,15 @@ int fluid_init (struct fluid_generator *gen, uint32_t id);
  * demand on each generator to at most 1024 FLUID's per ms.
  */
 int fluid_generate (struct fluid_generator *gen, fluid_t *fluid);
+
+/* Update and retrieve the internal timestamp.
+ * Returns 0 on success, -1 on failure.
+ */
+int fluid_save_timestamp (struct fluid_generator *gen, uint64_t *timestamp);
+
+/* Extract timestamp from a fluid.
+ */
+uint64_t fluid_get_timestamp (fluid_t fluid);
 
 /* Convert 'fluid' to NULL-terminated string 'buf' of specified type.
  * Return 0 on success, -1 on failure.

--- a/src/modules/job-ingest/job-ingest.c
+++ b/src/modules/job-ingest/job-ingest.c
@@ -746,7 +746,7 @@ int mod_main (flux_t *h, int argc, char **argv)
     /* fluid_init() will fail on rank > 16K.
      * Just skip loading the job module on those ranks.
      */
-    if (fluid_init (&ctx.gen, rank) < 0) {
+    if (fluid_init (&ctx.gen, rank, 0) < 0) {
         flux_log (h, LOG_ERR, "fluid_init failed");
         errno = EINVAL;
     }

--- a/src/modules/job-manager/job-manager.h
+++ b/src/modules/job-manager/job-manager.h
@@ -16,6 +16,7 @@ struct job_manager {
     flux_msg_handler_t **handlers;
     zhashx_t *active_jobs;
     int running_jobs; // count of jobs in RUN | CLEANUP state
+    flux_jobid_t max_jobid; // largest jobid allocated thus far
     struct start *start;
     struct alloc *alloc;
     struct event *event;

--- a/src/modules/job-manager/restart.h
+++ b/src/modules/job-manager/restart.h
@@ -20,6 +20,8 @@ int restart_from_kvs (struct job_manager *ctx);
 /* exposed for unit testing only */
 int restart_count_char (const char *s, char c);
 
+int checkpoint_to_kvs (struct job_manager *ctx);
+
 #endif /* _FLUX_JOB_MANAGER_RESTART_H */
 
 /*

--- a/src/modules/job-manager/submit.c
+++ b/src/modules/job-manager/submit.c
@@ -175,6 +175,7 @@ static void submit_cb (flux_t *h, flux_msg_handler_t *mh,
 
     /* Submitting user is being responded to with jobid's.
      * Now walk the list of new jobs and advance their state.
+     * Side effect: update ctx->max_jobid.
      */
     while ((job = zlist_pop (newjobs))) {
         if (submit_post_event (ctx->event, job) < 0)
@@ -183,6 +184,9 @@ static void submit_cb (flux_t *h, flux_msg_handler_t *mh,
 
         if ((job->flags & FLUX_JOB_WAITABLE))
             wait_notify_active (ctx->wait, job);
+        if (ctx->max_jobid < job->id)
+            ctx->max_jobid = job->id;
+
         job_decref (job);
     }
     zlist_destroy (&newjobs);

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -46,7 +46,8 @@ clean-local:
 #   in a reduced makespan overall.
 LONGTESTSCRIPTS = \
 	t5000-valgrind.t \
-	t3100-flux-in-flux.t
+	t3100-flux-in-flux.t \
+	t3200-instance-restart.t
 
 # This list is included in both TESTS and dist_check_SCRIPTS.
 TESTSCRIPTS = \

--- a/t/ingest/job-manager-dummy.c
+++ b/t/ingest/job-manager-dummy.c
@@ -135,8 +135,30 @@ error:
     flux_kvs_txn_destroy (txn);
 }
 
+void getinfo_cb (flux_t *h,
+                 flux_msg_handler_t *mh,
+                 const flux_msg_t *msg,
+                 void *arg)
+{
+    flux_jobid_t id = (1000UL * 1000) << 24; // fluid with 1000s timestamp
+    if (flux_request_decode (msg, NULL, NULL) < 0)
+        goto error;
+    if (flux_respond_pack (h,
+                           msg,
+                           "{s:I}",
+                           "max_jobid",
+                           id) < 0)
+        flux_log_error (h, "%s: flux_respond_pack", __FUNCTION__);
+    return;
+error:
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
+}
+
+
 static const struct flux_msg_handler_spec htab[] = {
     { FLUX_MSGTYPE_REQUEST,  "job-manager.submit", submit_cb, 0 },
+    { FLUX_MSGTYPE_REQUEST,  "job-manager.getinfo", getinfo_cb, 0 },
     FLUX_MSGHANDLER_TABLE_END,
 };
 

--- a/t/rc/rc1-job
+++ b/t/rc/rc1-job
@@ -14,8 +14,10 @@ flux module load kvs
 flux exec -r all -x 0 flux module load kvs
 flux exec -r all flux module load kvs-watch
 
+flux module load job-manager
+flux module load job-ingest
 
-flux exec -r all flux module load job-ingest & pids="$pids $!"
+flux exec -r all -x 0 flux module load job-ingest & pids="$pids $!"
 flux exec -r all flux module load job-info & pids="$pids $!"
 flux exec -r all flux module load barrier & pids="$pids $!"
 
@@ -26,7 +28,6 @@ flux exec -r all flux module load barrier & pids="$pids $!"
 
 wait $pids
 
-flux module load job-manager
 flux module load job-exec
 
 flux module load sched-simple

--- a/t/t2202-job-manager.t
+++ b/t/t2202-job-manager.t
@@ -17,9 +17,10 @@ test_expect_success 'job-manager: generate jobspec for simple test job' '
 '
 
 test_expect_success 'job-manager: load job-ingest, job-info, job-manager' '
-	flux exec -r all flux module load job-ingest &&
-	flux exec -r all flux module load job-info &&
-	flux module load job-manager
+	flux module load job-manager &&
+	flux module load job-ingest &&
+	flux exec -r all -x 0 flux module load job-ingest &&
+	flux exec -r all flux module load job-info
 '
 
 test_expect_success 'job-manager: submit one job' '

--- a/t/t2203-job-manager-dummysched.t
+++ b/t/t2203-job-manager-dummysched.t
@@ -33,9 +33,10 @@ test_expect_success 'flux-job: generate jobspec for simple test job' '
 '
 
 test_expect_success 'job-manager: load job-ingest, job-manager' '
-	flux exec -r all flux module load job-ingest &&
-	flux exec -r all flux module load job-info &&
-	flux module load job-manager
+	flux module load job-manager &&
+	flux module load job-ingest &&
+	flux exec -r all -x 0 flux module load job-ingest &&
+	flux exec -r all flux module load job-info
 '
 
 test_expect_success 'job-manager: submit 5 jobs' '

--- a/t/t2300-sched-simple.t
+++ b/t/t2300-sched-simple.t
@@ -30,8 +30,12 @@ test_expect_success 'unload job-exec module to prevent job execution' '
 	flux module remove job-exec
 '
 test_expect_success 'sched-simple: reload ingest module with lax validator' '
-	flux exec -r all flux module reload job-ingest validator-args="--schema,${SCHEMA}" \
-         validator=${JSONSCHEMA_VALIDATOR}
+	flux module reload job-ingest \
+		validator-args="--schema,${SCHEMA}" \
+		validator=${JSONSCHEMA_VALIDATOR} &&
+	flux exec -r all -x 0 flux module reload job-ingest \
+		validator-args="--schema,${SCHEMA}" \
+		validator=${JSONSCHEMA_VALIDATOR}
 '
 test_expect_success 'sched-simple: generate jobspec for simple test job' '
         flux jobspec srun -n1 hostname >basic.json

--- a/t/t3200-instance-restart.t
+++ b/t/t3200-instance-restart.t
@@ -1,0 +1,42 @@
+#!/bin/sh
+#
+
+test_description='Test instance restart'
+
+# Append --logfile option if FLUX_TESTS_LOGFILE is set in environment:
+test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
+. `dirname $0`/sharness.sh
+
+test_expect_success 'run a job in persistent instance' '
+	flux start -o,--setattr=content.backing-path=$(pwd)/content.sqlite \
+	           flux mini run -v /bin/true 2>&1 | sed "s/jobid: //" >id1.out
+'
+
+test_expect_success 'restart instance and run another job' '
+	flux start -o,--setattr=content.backing-path=$(pwd)/content.sqlite \
+	           flux mini run -v /bin/true 2>&1 | sed "s/jobid: //" >>id2.out
+'
+
+test_expect_success 'restart instance and run another job' '
+	flux start -o,--setattr=content.backing-path=$(pwd)/content.sqlite \
+	           flux mini run -v /bin/true 2>&1 | sed "s/jobid: //" >>id3.out
+'
+
+test_expect_success 'restart instance and list inactive jobs' '
+	flux start -o,--setattr=content.backing-path=$(pwd)/content.sqlite \
+	           flux jobs --suppress-header --format={id} \
+		   	--states=INACTIVE >list.out
+'
+
+test_expect_success 'inactive job list contains all jobs run before' '
+	grep $(cat id1.out) list.out &&
+	grep $(cat id2.out) list.out &&
+	grep $(cat id3.out) list.out
+'
+
+test_expect_success 'job IDs were issued in ascending order' '
+	test $(cat id1.out) -lt $(cat id2.out) &&
+	test $(cat id2.out) -lt $(cat id3.out)
+'
+
+test_done


### PR DESCRIPTION
As discussed in #2816 and #1545, the job-ingest module may issue duplicate jobid's if the module is reloaded on a live system, or if the instance restarts.

This PR adds the ability to start a FLUID generator at an initial timestamp other than zero.

The job manager now tracks the highest valid jobid and allows it to be queried by an RPC.  The job manager ensures this value remains valid across instance restart by saving it inside a JSON object to `checkpoint.job-manager`, which it reads back in on startup, if it exists.

The job ingest on rank 0 queries this `max_jobid` on startup and uses it to form the initial timestamp for its FLUID generator.   Job ingest on rank > 0 query the current timestamp for an upstream job-ingest module and use that to initialize their FLUID generator.

This adds constraints on the module loading order which now reflected in rc1 and tests:
1. job manager
2. job ingest rank 0
3. job ingest rank > 0

Anyway, after all that, systemd can restart flux without messing up the jobid order.

TODO: tests