### PR TITLE
job-exec: drop use of broker attrs, use conf file or cmdline instead

### DIFF
--- a/src/modules/job-exec/exec.c
+++ b/src/modules/job-exec/exec.c
@@ -85,9 +85,7 @@ static const char *jobspec_get_job_shell (json_t *jobspec)
 static const char *job_shell_path (struct jobinfo *job)
 {
     const char *path = jobspec_get_job_shell (job->jobspec);
-    if (!path && !(path = flux_attr_get (job->h, "job-exec.job-shell")))
-        path = default_job_shell;
-    return path;
+    return path ? path : default_job_shell;
 }
 
 static const char *jobspec_get_cwd (json_t *jobspec)

--- a/src/modules/job-exec/job-exec.c
+++ b/src/modules/job-exec/job-exec.c
@@ -1048,6 +1048,7 @@ static const struct flux_msg_handler_spec htab[]  = {
 
 int mod_main (flux_t *h, int argc, char **argv)
 {
+    int saved_errno = 0;
     int rc = -1;
     struct job_exec_ctx *ctx = job_exec_ctx_create (h);
 
@@ -1070,9 +1071,11 @@ int mod_main (flux_t *h, int argc, char **argv)
 
     rc = flux_reactor_run (flux_get_reactor (h), 0);
 out:
+    saved_errno = errno;
     if (flux_event_unsubscribe (h, "job-exception") < 0)
         flux_log_error (h, "flux_event_unsubscribe ('job-exception')");
     job_exec_ctx_destroy (ctx);
+    errno = saved_errno;
     return rc;
 }
 

--- a/src/modules/job-exec/job-exec.c
+++ b/src/modules/job-exec/job-exec.c
@@ -1034,7 +1034,18 @@ static int job_exec_initialize (flux_t *h, int argc, char **argv)
         }
         flux_log (h, LOG_INFO, "using kill-timeout of %.4gs", kill_timeout);
     }
+    return 0;
+}
 
+static int configure_implementations (flux_t *h, int argc, char **argv)
+{
+    struct exec_implementation *impl;
+    int i = 0;
+    while ((impl = implementations[i]) && impl->name) {
+        if (impl->config && (*impl->config) (h, argc, argv) < 0)
+            return -1;
+        i++;
+    }
     return 0;
 }
 
@@ -1049,7 +1060,8 @@ int mod_main (flux_t *h, int argc, char **argv)
     int rc = -1;
     struct job_exec_ctx *ctx = job_exec_ctx_create (h);
 
-    if (job_exec_initialize (h, argc, argv) < 0) {
+    if (job_exec_initialize (h, argc, argv) < 0
+        || configure_implementations (h, argc, argv) < 0) {
         flux_log_error (h, "job-exec: module initialization failed");
         goto out;
     }

--- a/src/modules/job-exec/job-exec.c
+++ b/src/modules/job-exec/job-exec.c
@@ -847,15 +847,6 @@ err:
     return NULL;
 }
 
-static double job_get_kill_timeout (flux_t *h)
-{
-    double t = kill_timeout;
-    const char *kto = flux_attr_get (h, "job-exec.kill_timeout");
-    if (kto && fsd_parse_duration (kto, &t) < 0)
-        flux_log_error (h, "job-exec.kill_timeout=%s", kto);
-    return t;
-}
-
 static int job_start (struct job_exec_ctx *ctx, const flux_msg_t *msg)
 {
     flux_future_t *f = NULL;
@@ -869,7 +860,7 @@ static int job_start (struct job_exec_ctx *ctx, const flux_msg_t *msg)
      *  approach for now)
      */
     job->h = ctx->h;
-    job->kill_timeout = job_get_kill_timeout (job->h);
+    job->kill_timeout = kill_timeout;
 
     job->req = flux_msg_incref (msg);
 

--- a/src/modules/job-exec/job-exec.h
+++ b/src/modules/job-exec/job-exec.h
@@ -25,6 +25,8 @@ struct jobinfo;
  *
  *  An exec implementation must include the methods below:
  *
+ *   - config:  (optional) called once at module load for configuraiton
+ *
  *   - init:    allow selection and initialization of an exec implementation
  *              from jobspec and/or R. An implementation should return 0 to
  *              "pass" on handling this job, > 0 to denote successful
@@ -44,6 +46,7 @@ struct jobinfo;
  */
 struct exec_implementation {
     const char *name;
+    int  (*config)  (flux_t *h, int argc, char **argv);
     int  (*init)    (struct jobinfo *job);
     void (*exit)    (struct jobinfo *job);
     int  (*start)   (struct jobinfo *job);

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -106,6 +106,7 @@ TESTSCRIPTS = \
 	t2400-job-exec-test.t \
 	t2401-job-exec-hello.t \
 	t2402-job-exec-dummy.t \
+	t2403-job-exec-conf.t \
 	t2500-job-attach.t \
 	t2501-job-status.t \
 	t2600-job-shell-rcalc.t \

--- a/t/t2403-job-exec-conf.t
+++ b/t/t2403-job-exec-conf.t
@@ -1,0 +1,86 @@
+#!/bin/sh
+
+test_description='Test flux job exec configuration'
+
+. $(dirname $0)/sharness.sh
+
+test_under_flux 1 job
+
+test_expect_success 'job-exec: can specify kill-timeout on cmdline' '
+	flux dmesg -C &&
+	flux module reload job-exec kill-timeout=1m &&
+	flux dmesg | grep "using kill-timeout of 60s"
+'
+test_expect_success 'job-exec: bad kill-timeout value causes module failure' '
+	flux dmesg -C &&
+	test_expect_code 1 flux module reload job-exec kill-timeout=1f &&
+	flux dmesg | grep "invalid kill-timeout: 1f"
+'
+test_expect_success 'job-exec: kill-timeout can be set in exec conf' '
+	name=killconf &&
+	mkdir ${name}.d &&
+	cat <<-EOF > ${name}.d/exec.toml &&
+	[exec]
+	kill-timeout = ".5m"
+	EOF
+	( export FLUX_CONF_DIR=${name}.d &&
+	  flux start -s1 flux dmesg > ${name}.log 2>&1
+	) &&
+	grep "using kill-timeout of 30s" ${name}.log
+'
+test_expect_success 'job-exec: bad kill-timeout config causes module failure' '
+	name=bad-killconf &&
+	mkdir ${name}.d &&
+	cat <<-EOF > ${name}.d/exec.toml &&
+	[exec]
+	kill-timeout = "foo"
+	EOF
+	( export FLUX_CONF_DIR=${name}.d &&
+	  test_must_fail flux start -s1 flux dmesg > ${name}.log 2>&1
+	) &&
+	grep "invalid kill-timeout: foo" ${name}.log
+'
+test_expect_success 'job-exec: can specify default-shell on cmdline' '
+	flux dmesg -C &&
+	flux module reload -f job-exec job-shell=/path/to/shell &&
+	flux dmesg &&
+	flux dmesg | grep "default shell path /path/to/shell"
+'
+test_expect_success 'job-exec: job-shell can be set in exec conf' '
+	name=shellconf &&
+	mkdir ${name}.d &&
+	cat <<-EOF > ${name}.d/exec.toml &&
+	[exec]
+	job-shell = "my-flux-shell"
+	EOF
+	( export FLUX_CONF_DIR=${name}.d &&
+	  flux start -s1 flux dmesg > ${name}.log 2>&1
+	) &&
+	grep "using default shell path my-flux-shell" ${name}.log
+'
+test_expect_success 'job-exec: bad job-shell config causes module failure' '
+	name=bad-shellconf &&
+	mkdir ${name}.d &&
+	cat <<-EOF > ${name}.d/exec.toml &&
+	[exec]
+	job-shell = 42
+	EOF
+	( export FLUX_CONF_DIR=${name}.d &&
+	  test_must_fail flux start -s1 flux dmesg > ${name}.log 2>&1
+	) &&
+	grep "error reading config value exec.job-shell" ${name}.log
+'
+test_expect_success 'job-exec: bad TOML config causes module failure' '
+	#  Need to first start an instance with good config files, then
+        #   replace with bad config files, and finally reload module
+	name=badtoml &&
+	mkdir ${name}.d &&
+	touch ${name}.d/exec.toml &&
+	( export FLUX_CONF_DIR=${name}.d &&
+	  test_must_fail flux start -s1 sh -c "\
+	    echo \[exec >${name}.d/exec.toml && flux module reload job-exec" \
+	    >${name}.log 2>&1
+	) &&
+	grep "config file error: ${name}.d/exec.toml" ${name}.log
+'
+test_done

--- a/t/t2602-job-shell.t
+++ b/t/t2602-job-shell.t
@@ -104,7 +104,7 @@ test_expect_success 'job-shell: PMI KVS works' '
 	grep "t phase" kvstest.out
 '
 test_expect_success 'job-exec: decrease kill timeout for tests' '
-	flux setattr job-exec.kill_timeout 0.1
+	flux module reload job-exec kill-timeout=0.1
 '
 #  Use `!` here instead of test_must_fail because flux-job attach
 #   may exit with 143, killed by signal

--- a/t/t2608-job-shell-log.t
+++ b/t/t2608-job-shell-log.t
@@ -153,7 +153,7 @@ test_expect_success 'flux-shell: bad cwd emits message, but completes' '
 '
 
 test_expect_success 'job-exec: set kill-timeout to low value for testing' '
-	flux setattr job-exec.kill_timeout 0.25
+	flux module reload job-exec kill-timeout=0.25
 '
 
 #  Fatal error tests below must exit with failure, but exit due to


### PR DESCRIPTION
This PR switches the job-exec module away from using broker attributes for "configuration" to using config file and/or module cmdline args. The standard precedence is observed, the conf file overrides build-time defaults, and the cmdline overrides the config (or defaults if config not set).

The only two config parameters in the `job-exec` module were mainly for testing, and included the job-shell path and "kill timeout" for jobs (interval after the first SIGTERM when SIGKILL will be sent), so there is not much user visible change here. However, this prepares the way for a coming required config parameter, the path to the IMP.

As a side benefit, two calls to `flux_attr_get(3)` that were made *for every job* are removed as a result.