### PR TITLE
job-exec: minimal support for multiuser exec

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,3 +28,34 @@ jobs:
         git clone https://github.com/flux-framework/flux-sched &&
         cd flux-sched &&
         src/test/docker/docker-run-checks.sh -j 4 -i bionic
+
+  check-asan:
+    name: address-sanitizer check
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+        fetch-depth: 0
+    - run: git fetch --tags
+    - name: docker-run-checks with ASan
+      env:
+        CC: gcc-8
+        CXX: g++-8
+        PRELOAD: /usr/lib/gcc/x86_64-linux-gnu/8/libasan.so
+        ASAN_OPTIONS: detect_leaks=0,start_deactivated=true
+        TAP_DRIVER_QUIET: t
+        FLUX_TEST_TIMEOUT: 300
+      run: >
+        src/test/docker/docker-run-checks.sh --image=bionic -j2 --
+        --with-flux-security --enable-sanitizer=address
+    - name: after failure
+      if: failure()
+      run: >
+        find . -name test-suite.log |
+        xargs -i sh -c 'printf "===XXX {} XXX===";cat {}' &&
+        find . -name t[0-9]*.output |
+        xargs -i sh -c 'printf "\033[31mFound {}\033[39m\n";cat {}'
+        find . -name *.asan.* |
+        xargs -i sh -c 'printf "\033[31mFound {}\033[39m\n";cat {}'

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -5,6 +5,7 @@ pull_request_rules:
       - status-success=Travis CI - Pull Request
       - status-success="validate commits"
       - status-success="flux-sched check"
+      - status-success="address-sanitizer check"
       - label="merge-when-passing"
       - label!="work-in-progress"
       - "approved-reviews-by=@flux-framework/core"

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,21 +82,21 @@ jobs:
       stage: test
       compiler: gcc
       env:
-       - ARGS="--with-flux-security --enable-caliper"
+       - ARGS="--prefix=/usr --sysconfdir=/etc --with-systemdsystemunitdir=/etc/systemd/system --with-flux-security --enable-caliper"
        - TEST_INSTALL=t
        - DOCKER_TAG=t
     - name: "Centos 7: security,caliper,docker-deploy"
       stage: test
       compiler: gcc
       env:
-       - ARGS="--with-flux-security --enable-caliper --prefix=/usr"
+       - ARGS="--prefix=/usr --sysconfdir=/etc --with-systemdsystemunitdir=/etc/systemd/system --with-flux-security --enable-caliper"
        - IMG=centos7
        - DOCKER_TAG=t
     - name: "Centos 8: security,caliper,docker-deploy"
       stage: test
       compiler: gcc
       env:
-       - ARGS="--with-flux-security --enable-caliper --prefix=/usr"
+       - ARGS="--prefix=/usr --sysconfdir=/etc --with-systemdsystemunitdir=/etc/systemd/system --with-flux-security --enable-caliper"
        - IMG=centos8
        - DOCKER_TAG=t
        - PYTHON_VERSION=3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,16 +45,6 @@ jobs:
        - DISTCHECK=t
        - PYTHON_VERSION=3.8
        - GITHUB_RELEASES_DEPLOY=t
-    - name: "Ubuntu: gcc-8 address-sanitizer --with-flux-security"
-      stage: test
-      compiler: gcc-8
-      env:
-       - CC=gcc-8
-       - CXX=g++-8
-       - ARGS="--with-flux-security --enable-sanitizer=address"
-       - PRELOAD=/usr/lib/gcc/x86_64-linux-gnu/8/libasan.so
-       - ASAN_OPTIONS=detect_leaks=0,start_deactivated=true # TODO: fix/suppress tests so we can turn this on
-       - PYTHON_VERSION=3.6
     - name: "Ubuntu: gcc-8 --with-flux-security/caliper, distcheck"
       stage: test
       compiler: gcc-8

--- a/src/bindings/python/flux/job.py
+++ b/src/bindings/python/flux/job.py
@@ -98,6 +98,7 @@ def submit_async(
     priority=lib.FLUX_JOB_PRIORITY_DEFAULT,
     waitable=False,
     debug=False,
+    pre_signed=False,
 ):
     """Ask Flux to run a job, without waiting for a response
 
@@ -119,6 +120,9 @@ def submit_async(
     :param debug: enable job manager debugging events to job eventlog
         (default is False)
     :type debug: bool
+    :param pre_signed: jobspec argument is already signed
+        (default is False)
+    :type pre_signed: bool
     :returns: a Flux Future object for obtaining the assigned jobid
     :rtype: Future
     """
@@ -128,6 +132,8 @@ def submit_async(
         flags |= constants.FLUX_JOB_WAITABLE
     if debug:
         flags |= constants.FLUX_JOB_DEBUG
+    if pre_signed:
+        flags |= constants.FLUX_JOB_PRE_SIGNED
     future_handle = RAW.submit(flux_handle, jobspec, priority, flags)
     return SubmitFuture(future_handle)
 
@@ -159,6 +165,7 @@ def submit(
     priority=lib.FLUX_JOB_PRIORITY_DEFAULT,
     waitable=False,
     debug=False,
+    pre_signed=False,
 ):
     """Submit a job to Flux
 
@@ -179,10 +186,13 @@ def submit(
     :param debug: enable job manager debugging events to job eventlog
         (default is False)
     :type debug: bool
+    :param pre_signed: jobspec argument is already signed
+        (default is False)
+    :type pre_signed: bool
     :returns: job ID
     :rtype: int
     """
-    future = submit_async(flux_handle, jobspec, priority, waitable, debug)
+    future = submit_async(flux_handle, jobspec, priority, waitable, debug, pre_signed)
     return future.get_id()
 
 

--- a/src/bindings/python/flux/security.py
+++ b/src/bindings/python/flux/security.py
@@ -48,7 +48,7 @@ class SecurityContext(WrapperPimpl):
                 fun, name, fun_type, self.ffi, add_handle=add_handle
             )
 
-    def __init__(self, config_pattern, flags=0):
+    def __init__(self, config_pattern=None, flags=0):
         super().__init__()
         self.pimpl = self.InnerWrapper(flags)
         self.pimpl.configure(config_pattern)

--- a/src/bindings/python/flux/security.py
+++ b/src/bindings/python/flux/security.py
@@ -53,6 +53,14 @@ class SecurityContext(WrapperPimpl):
         self.pimpl = self.InnerWrapper(flags)
         self.pimpl.configure(config_pattern)
 
+    def sign_wrap_as(self, userid, payload, mech_type=ffi.NULL, flags=0):
+        if isinstance(payload, six.text_type):
+            payload = payload.encode("utf-8")
+        elif not isinstance(payload, six.binary_type):
+            errstr = "payload must be a text or binary type, not {}"
+            raise TypeError(errstr.format(type(payload)))
+        return self.pimpl.wrap_as(userid, payload, len(payload), mech_type, flags)
+
     def sign_wrap(self, payload, mech_type=ffi.NULL, flags=0):
         if isinstance(payload, six.text_type):
             payload = payload.encode("utf-8")

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -168,7 +168,7 @@ static struct optparse_option submit_opts[] =  {
     { .name = "priority", .key = 'p', .has_arg = 1, .arginfo = "N",
       .usage = "Set job priority (0-31, default=16)",
     },
-    { .name = "flags", .key = 'f', .has_arg = 3,
+    { .name = "flags", .key = 'f', .has_arg = 1,
       .flags = OPTPARSE_OPT_AUTOSPLIT,
       .usage = "Set submit comma-separated flags (e.g. debug, waitable)",
     },

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -1164,6 +1164,8 @@ int cmd_submit (optparse_t *p, int argc, char **argv)
                 flags |= FLUX_JOB_DEBUG;
             else if (!strcmp (name, "waitable"))
                 flags |= FLUX_JOB_WAITABLE;
+            else if (!strcmp (name, "signed"))
+                flags |= FLUX_JOB_PRE_SIGNED;
             else
                 log_msg_exit ("unknown flag: %s", name);
         }

--- a/src/common/liboptparse/optparse.h
+++ b/src/common/liboptparse/optparse.h
@@ -82,8 +82,7 @@ struct optparse_option {
 				If !isalnum(key), then this option is
                                 assumed to be a long option only.           */
 
-    int           has_arg; /*  0: no arg, 1: req'd arg, 2: optional arg
-                               3: list-arg (split on comma separate values) */
+    int           has_arg; /*  0: no arg, 1: req'd arg, 2: optional arg     */
     int           group;   /*  Grouping in --help output                    */
     int           flags;   /*  Extra flags. See Option FLAGS below          */
     const char *  arginfo; /*  arg info displayed after = in help output    */

--- a/src/modules/job-exec/bulk-exec.c
+++ b/src/modules/job-exec/bulk-exec.c
@@ -233,10 +233,14 @@ static struct exec_cmd *exec_cmd_create (const struct idset *ranks,
     struct exec_cmd *c = calloc (1, sizeof (*c));
     if (!c)
         return NULL;
-    if (!(c->ranks = idset_copy (ranks)))
+    if (!(c->ranks = idset_copy (ranks))) {
+        fprintf (stderr, "exec_cmd_create: idset_copy failed");
         goto err;
-    if (!(c->cmd = flux_cmd_copy (cmd)))
+    }
+    if (!(c->cmd = flux_cmd_copy (cmd))) {
+        fprintf (stderr, "exec_cmd_create: flux_cmd_copy failed");
         goto err;
+    }
     c->flags = flags;
     return (c);
 err:
@@ -504,6 +508,138 @@ flux_future_t *bulk_exec_kill (struct bulk_exec *exec, int signum)
     }
 
     return cf;
+}
+
+static void imp_kill_output (struct bulk_exec *kill,
+                             flux_subprocess_t *p,
+                             const char *stream,
+                             const char *data,
+                             int len,
+                             void *arg)
+{
+    int rank = flux_subprocess_rank (p);
+    flux_log (kill->h, LOG_INFO,
+              "rank%d: flux-imp kill: %s: %s",
+              rank,
+              stream,
+              data);
+}
+
+static void imp_kill_complete (struct bulk_exec *kill, void *arg)
+{
+    flux_future_t *f = arg;
+    if (bulk_exec_rc (kill) < 0)
+        flux_future_fulfill_error (f, 0, NULL);
+    else
+        flux_future_fulfill (f, NULL, NULL);
+}
+
+static void imp_kill_error (struct bulk_exec *kill,
+                            flux_subprocess_t *p,
+                            void *arg)
+{
+    flux_log_error (kill->h,
+                    "imp kill: rank=%d: failed",
+                    flux_subprocess_rank (p));
+}
+
+
+struct bulk_exec_ops imp_kill_ops = {
+    .on_output = imp_kill_output,
+    .on_error = imp_kill_error,
+    .on_complete = imp_kill_complete,
+};
+
+static int bulk_exec_push_one (struct bulk_exec *exec,
+                               int rank,
+                               flux_cmd_t *cmd,
+                               int flags)
+{
+    int rc = -1;
+    struct idset *ids = idset_create (0, IDSET_FLAG_AUTOGROW);
+    if (!ids || idset_set (ids, rank) < 0)
+        return -1;
+    rc = bulk_exec_push_cmd (exec, ids, cmd, flags);
+    idset_destroy (ids);
+    return rc;
+}
+
+/*  Kill all currently executing processes in bulk-exec object `exec`
+ *   using "flux-imp kill" helper for processes potentially running
+ *   under a different userid.
+ *
+ *  Spawns "flux-imp kill <signal> <pid>" on each rank.
+ */
+flux_future_t *bulk_exec_imp_kill (struct bulk_exec *exec,
+                                   const char *imp_path,
+                                   int signum)
+{
+    struct bulk_exec *killcmd = NULL;
+    flux_subprocess_t *p = NULL;
+    flux_future_t *f = NULL;
+    int count = 0;
+
+    /* Empty future for return value
+     */
+    if (!(f = flux_future_create (NULL, NULL))) {
+        flux_log_error (exec->h, "bulk_exec_imp_kill: future_create");
+        goto err;
+    }
+    flux_future_set_flux (f, exec->h);
+
+    if (!(killcmd = bulk_exec_create (&imp_kill_ops, f)))
+        return NULL;
+
+    /*  Tie bulk exec object destruction to future */
+    flux_future_aux_set (f, NULL, killcmd, (flux_free_f) bulk_exec_destroy);
+
+    p = zlist_first (exec->processes);
+    while (p) {
+        if ((flux_subprocess_state (p) == FLUX_SUBPROCESS_RUNNING
+            || flux_subprocess_state (p) == FLUX_SUBPROCESS_INIT)) {
+
+            pid_t pid = flux_subprocess_pid (p);
+            int rank = flux_subprocess_rank (p);
+            flux_cmd_t *cmd = flux_cmd_create (0, NULL, environ);
+
+            if (!cmd
+                || flux_cmd_setcwd (cmd, "/tmp") < 0
+                || flux_cmd_argv_append (cmd, imp_path) < 0
+                || flux_cmd_argv_append (cmd, "kill") < 0
+                || flux_cmd_argv_appendf (cmd, "%d", signum) < 0
+                || flux_cmd_argv_appendf (cmd, "%ld", (long) pid)) {
+                flux_log_error (exec->h,
+                                "bulk_exec_imp_kill: flux_cmd_argv_append");
+                goto err;
+            }
+
+            if (bulk_exec_push_one (killcmd, rank, cmd, 0) < 0) {
+                flux_log_error (exec->h, "bulk_exec_imp_kill: push_cmd");
+                goto err;
+            }
+
+            count++;
+            flux_cmd_destroy (cmd);
+        }
+        p = zlist_next (exec->processes);
+    }
+
+    if (count == 0) {
+        errno = ENOENT;
+        goto err;
+    }
+
+    bulk_exec_aux_set (killcmd, "future", f, NULL);
+
+    if (bulk_exec_start (exec->h, killcmd) < 0) {
+        flux_log_error (exec->h, "bulk_exec_start");
+        goto err;
+    }
+
+    return f;
+err:
+    flux_future_destroy (f);
+    return NULL;
 }
 
 int bulk_exec_aux_set (struct bulk_exec *exec, const char *key,

--- a/src/modules/job-exec/bulk-exec.c
+++ b/src/modules/job-exec/bulk-exec.c
@@ -328,14 +328,16 @@ static void check_cb (flux_reactor_t *r, flux_watcher_t *w,
 
 void bulk_exec_destroy (struct bulk_exec *exec)
 {
-    zlist_destroy (&exec->processes);
-    zlist_destroy (&exec->commands);
-    idset_destroy (exec->exit_batch);
-    flux_watcher_destroy (exec->prep);
-    flux_watcher_destroy (exec->check);
-    flux_watcher_destroy (exec->idle);
-    aux_destroy (&exec->aux);
-    free (exec);
+    if (exec) {
+        zlist_destroy (&exec->processes);
+        zlist_destroy (&exec->commands);
+        idset_destroy (exec->exit_batch);
+        flux_watcher_destroy (exec->prep);
+        flux_watcher_destroy (exec->check);
+        flux_watcher_destroy (exec->idle);
+        aux_destroy (&exec->aux);
+        free (exec);
+    }
 }
 
 struct bulk_exec * bulk_exec_create (struct bulk_exec_ops *ops, void *arg)

--- a/src/modules/job-exec/bulk-exec.h
+++ b/src/modules/job-exec/bulk-exec.h
@@ -74,6 +74,11 @@ int bulk_exec_rc (struct bulk_exec *exec);
 /* Returns current number of processes starting/running */
 int bulk_exec_current (struct bulk_exec *exec);
 
+int bulk_exec_write (struct bulk_exec *exec, const char *stream,
+                     const char *buf, size_t len);
+
+int bulk_exec_close (struct bulk_exec *exec, const char *stream);
+
 /* Returns total number of processes expected to run */
 int bulk_exec_total (struct bulk_exec *exec);
 

--- a/src/modules/job-exec/bulk-exec.h
+++ b/src/modules/job-exec/bulk-exec.h
@@ -66,6 +66,10 @@ int bulk_exec_start (flux_t *h, struct bulk_exec *exec);
 
 flux_future_t * bulk_exec_kill (struct bulk_exec *exec, int signal);
 
+flux_future_t *bulk_exec_imp_kill (struct bulk_exec *exec,
+                                   const char *imp_path,
+                                   int signal);
+
 int bulk_exec_cancel (struct bulk_exec *exec);
 
 /* Returns max wait status returned from all exited processes */

--- a/src/modules/job-exec/exec.c
+++ b/src/modules/job-exec/exec.c
@@ -290,7 +290,12 @@ static void exec_kill_cb (flux_future_t *f, void *arg)
 static int exec_kill (struct jobinfo *job, int signum)
 {
     struct  bulk_exec *exec = job->data;
-    flux_future_t *f = bulk_exec_kill (exec, signum);
+    flux_future_t *f;
+
+    if (job->multiuser)
+        f = bulk_exec_imp_kill (exec, flux_imp_path, signum);
+    else
+        f = bulk_exec_kill (exec, signum);
     if (!f) {
         if (errno != ENOENT)
             flux_log_error (job->h, "%ju: bulk_exec_kill", job->id);

--- a/src/modules/job-exec/job-exec.c
+++ b/src/modules/job-exec/job-exec.c
@@ -843,6 +843,7 @@ static flux_future_t *jobinfo_start_init (struct jobinfo *job)
     return f;
 err:
     flux_log_error (job->ctx->h, "jobinfo_kvs_lookup/namespace_create");
+    flux_future_destroy (f_kvs);
     flux_future_destroy (f);
     return NULL;
 }

--- a/src/modules/job-exec/job-exec.c
+++ b/src/modules/job-exec/job-exec.c
@@ -135,6 +135,7 @@ void jobinfo_decref (struct jobinfo *job)
         job->ctx = NULL;
         flux_msg_decref (job->req);
         job->req = NULL;
+        free (job->J);
         resource_set_destroy (job->R);
         json_decref (job->jobspec);
         free (job);
@@ -729,6 +730,13 @@ static void jobinfo_start_continue (flux_future_t *f, void *arg)
         jobinfo_fatal_error (job, errno, "reading R: %s", error.text);
         goto done;
     }
+    if (job->multiuser) {
+        const char *J = jobinfo_kvs_lookup_get (f, "J");
+        if (!J || !(job->J = strdup (J))) {
+            jobinfo_fatal_error (job, errno, "reading J: %s", error.text);
+            goto done;
+        }
+    }
     if (!(job->jobspec = json_loads (jobspec, 0, &error))) {
         jobinfo_fatal_error (job, errno, "reading jobspec: %s", error.text);
         goto done;
@@ -836,6 +844,11 @@ static flux_future_t *jobinfo_start_init (struct jobinfo *job)
     if (!(f_kvs = flux_jobid_kvs_lookup (h, job->id, 0, "jobspec"))
         || flux_future_push (f, "jobspec", f_kvs) < 0)
         goto err;
+    if (job->multiuser
+        && (!(f_kvs = flux_jobid_kvs_lookup (h, job->id, 0, "J"))
+        || flux_future_push (f, "J", f_kvs) < 0)) {
+        goto err;
+    }
     if (!(f_kvs = ns_create_and_link (h, job, 0))
         || flux_future_push (f, "ns", f_kvs))
         goto err;
@@ -874,6 +887,10 @@ static int job_start (struct job_exec_ctx *ctx, const flux_msg_t *msg)
         jobinfo_decref (job);
         return -1;
     }
+
+    if (job->userid != getuid ())
+        job->multiuser = 1;
+
     /*  Take a reference until initialization complete in case an
      *   exception is generated during this phase
      */

--- a/src/modules/job-exec/job-exec.h
+++ b/src/modules/job-exec/job-exec.h
@@ -66,7 +66,9 @@ struct jobinfo {
 
     struct resource_set * R;         /* Fetched and parsed resource set R */
     json_t *              jobspec;   /* Fetched jobspec */
+    char *                J;         /* Signed jobspec */
 
+    uint8_t               multiuser:1;
     uint8_t               has_namespace:1;
     uint8_t               exception_in_progress:1;
 

--- a/src/test/docker/docker-run-checks.sh
+++ b/src/test/docker/docker-run-checks.sh
@@ -8,7 +8,7 @@
 #
 # option Defaults:
 IMAGE=bionic
-FLUX_SECURITY_VERSION=0.2.0
+FLUX_SECURITY_VERSION=0.4.0
 JOBS=2
 MOUNT_HOME_ARGS="--volume=$HOME:/home/$USER -e HOME"
 

--- a/src/test/docker/travis/Dockerfile
+++ b/src/test/docker/travis/Dockerfile
@@ -20,7 +20,7 @@ RUN CCACHE_DISABLE=1 \
  && wget ${URL}/v${V}/${PKG}.tar.gz \
  && tar xvfz ${PKG}.tar.gz \
  && cd ${PKG} \
- && ./configure --prefix=/usr || cat config.log \
+ && ./configure --prefix=/usr --sysconfdir=/etc || cat config.log \
  && make -j 4 \
  && make install \
  && cd .. \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -109,6 +109,7 @@ TESTSCRIPTS = \
 	t2401-job-exec-hello.t \
 	t2402-job-exec-dummy.t \
 	t2403-job-exec-conf.t \
+	t2404-job-exec-multiuser.t \
 	t2500-job-attach.t \
 	t2501-job-status.t \
 	t2600-job-shell-rcalc.t \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -195,6 +195,7 @@ dist_check_SCRIPTS = \
 	scripts/waitfile.lua \
 	scripts/t0004-event-helper.sh \
 	scripts/tssh \
+	scripts/sign-as.py \
 	valgrind/valgrind-workload.sh \
 	valgrind/workload.d/job \
 	kvs/kvs-helper.sh \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -208,6 +208,7 @@ dist_check_SCRIPTS = \
 	job-manager/wait-interrupted.py \
 	job-attach/outputsleep.sh \
 	job-exec/dummy.sh \
+	job-exec/imp.sh \
 	job-info/list-id.py \
 	schedutil/req_and_unload.py \
 	ingest/fake-validate.sh \

--- a/t/job-exec/imp.sh
+++ b/t/job-exec/imp.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+cmd=$1
+case "$cmd" in
+    exec)
+        shift; 
+        printf "test-imp: Running $* \n" >&2
+        exec "$@" ;;
+    kill)
+        signal=$2;
+        pid=$3;
+        shift 3;
+        printf "test-imp: Kill pid $pid signal $signal\n" >&2
+        ps -fp $pid >&2
+        kill -$signal $pid ;;
+    *)
+        printf "test-imp: Fatal: Unknown cmd=$cmd\n" >&2; exit 1 ;;
+esac
+
+# vi: ts=4 sw=4 expandtab

--- a/t/scripts/sign-as.py
+++ b/t/scripts/sign-as.py
@@ -1,0 +1,13 @@
+import sys
+from flux.security import SecurityContext
+
+if len(sys.argv) < 2:
+    print("Usage: {0} USERID".format(sys.argv[0]))
+    sys.exit(1)
+
+userid = int(sys.argv[1])
+ctx = SecurityContext()
+payload = sys.stdin.read()
+
+print(ctx.sign_wrap_as(userid, payload, mech_type="none").decode("utf-8"))
+# vi: ts=4 sw=4 expandtab

--- a/t/t2404-job-exec-multiuser.t
+++ b/t/t2404-job-exec-multiuser.t
@@ -1,0 +1,72 @@
+#!/bin/sh
+
+test_description='Sanity checks for job-exec multiuser exec'
+
+. $(dirname $0)/sharness.sh
+
+flux version | grep -q libflux-security && test_set_prereq FLUX_SECURITY
+
+if ! test_have_prereq FLUX_SECURITY; then
+    skip_all='skipping multiuser exec tests, libflux-security or IMP not found'
+    test_done
+fi
+
+#  Set path to jq
+#
+jq=$(which jq 2>/dev/null)
+test -n "$jq" && test_set_prereq HAVE_JQ
+
+
+IMP=${SHARNESS_TEST_SRCDIR}/job-exec/imp.sh
+#  Configure dummy IMP
+if ! test -d conf.d; then
+	mkdir conf.d
+	cat <<-EOF >conf.d/exec.toml
+	[exec]
+	imp = "${IMP}"
+	EOF
+fi
+
+export FLUX_CONF_DIR=$(pwd)/conf.d
+test_under_flux 2 job
+
+test_expect_success 'job-exec: module configured to use IMP' '
+	flux dmesg | grep "using imp path ${IMP}"
+'
+test_expect_success 'job-exec: job as instance owner works' '
+	test "$(id -u)" = "$(flux mini run id -u)"
+'
+
+SIGN_AS=${SHARNESS_TEST_SRCDIR}/scripts/sign-as.py
+#  Use flux_sign_wrap_as(3) to create a fake sign-wrapped jobspec
+#  which will pass ingest signature check when submitted with
+#  FLUX_HANDLE_USERID.
+#
+#  This will trigger the job-exec module to run job under our fake IMP.
+#
+test_expect_success HAVE_JQ 'job-exec: job as guest tries to run IMP' '
+	FAKE_USERID=42 &&
+	flux jobspec srun -n1 id -u | \
+	    flux python ${SIGN_AS} ${FAKE_USERID} > job.signed &&
+	id=$(FLUX_HANDLE_USERID=${FAKE_USERID} \
+	    flux job submit --flags=signed job.signed) &&
+	flux job attach ${id} &&
+	flux job list-ids ${id} > ${id}.json &&
+	jq -e ".userid == 42" < ${id}.json &&
+	flux dmesg | grep "test-imp: Running.*${id}"
+'
+
+test_expect_success 'job-exec: kill multiuser job uses the IMP' '
+	FAKE_USERID=42 &&
+	flux mini run --dry-run -n2 -N2 sleep 1000 | \
+	    flux python ${SIGN_AS} ${FAKE_USERID} > sleep-job.signed &&
+	id=$(FLUX_HANDLE_USERID=${FAKE_USERID} \
+	    flux job submit --flags=signed sleep-job.signed) &&
+	flux job list-ids ${id} > ${id}.json &&
+	jq -e ".userid == 42" < ${id}.json &&
+	flux job wait-event -p guest.exec.eventlog -vt 30 ${id} shell.start &&
+	flux job cancel ${id} &&
+	test_expect_code 143 run_timeout 30 flux job status -v ${id} &&
+	flux dmesg | grep "test-imp: Kill .*signal 15"
+'
+test_done


### PR DESCRIPTION
This PR tweaks the job-exec 'exec' implementation to attempt to run the IMP for any multiuser job requests, i.e. those where job->userid != getuid().

The `exec.imp` config parameter must be set to a path of a `flux-imp` installed setuid for multiuser to be enabled. Currently, if the IMP isn't configured, multi-user job requests get an exec exception at start. `exec.imp` can be overridden by `imp=` on the module load cmdline.

This PR implments the bare minimum to get this working. We need to re-architect the  job-exec module soon anyway, so it wouldn't be prudent to spend extra time with an optimal integration.

The PR is still a WIP so I can add at least *some* testing.

Edit: this is built on top of #2821 

Also edit: the current work here doesn't check if the `flux_imp_path` is actually installed setuid. This could be done, but it will actually be handy for testing purposes not to require it (for `make check` we can replace the imp with a small shell script, mwahaha)