### PR TITLE
job-info: Support new "success" attribute

### DIFF
--- a/doc/man1/flux-jobs.adoc
+++ b/doc/man1/flux-jobs.adoc
@@ -84,6 +84,7 @@ name:: job name
 ntasks:: job task count
 nnodes:: job node count (if job ran / is running), empty string otherwise
 ranks:: job ranks (if job ran / is running), empty string otherwise
+success:: True of False if job completed successfully, empty string otherwise
 t_submit:: time job was submitted
 t_depend:: time job entered depend state
 t_sched:: time job entered sched state

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -1002,8 +1002,8 @@ int cmd_list (optparse_t *p, int argc, char **argv)
     int optindex = optparse_option_index (p);
     int max_entries = optparse_get_int (p, "count", 0);
     char *attrs = "[\"userid\",\"priority\",\"t_submit\",\"state\"," \
-        "\"name\",\"ntasks\",\"nnodes\",\"ranks\",\"t_depend\",\"t_sched\"," \
-        "\"t_run\",\"t_cleanup\",\"t_inactive\"]";
+        "\"name\",\"ntasks\",\"nnodes\",\"ranks\",\"success\",\"t_depend\"," \
+        "\"t_sched\",\"t_run\",\"t_cleanup\",\"t_inactive\"]";
     flux_t *h;
     flux_future_t *f;
     json_t *jobs;

--- a/src/cmd/flux-jobs.py
+++ b/src/cmd/flux-jobs.py
@@ -86,6 +86,7 @@ class JobInfo:
         t_inactive=0.0,
         nnodes="",
         ranks="",
+        success="",
     )
 
     def __init__(self, info_resp):
@@ -189,6 +190,7 @@ def fetch_jobs_flux(args, fields):
         ntasks=("ntasks",),
         nnodes=("nnodes",),
         ranks=("ranks",),
+        success=("success",),
         t_submit=("t_submit",),
         t_depend=("t_depend",),
         t_sched=("t_sched",),
@@ -337,6 +339,7 @@ class JobsOutputFormat(flux.util.OutputFormat):
         ntasks="NTASKS",
         nnodes="NNODES",
         ranks="RANKS",
+        success="SUCCESS",
         t_submit="T_SUBMIT",
         t_depend="T_DEPEND",
         t_sched="T_SCHED",

--- a/src/modules/job-info/job_state.h
+++ b/src/modules/job-info/job_state.h
@@ -70,6 +70,7 @@ struct job {
     int ntasks;
     int nnodes;
     char *ranks;
+    bool success;
 
     /* cache of job information */
     json_t *jobspec_job;

--- a/src/modules/job-info/job_util.c
+++ b/src/modules/job-info/job_util.c
@@ -102,6 +102,11 @@ json_t *job_to_json (struct job *job, json_t *attrs)
                 continue;
             val = json_string (job->ranks);
         }
+        else if (!strcmp (attr, "success")) {
+            if (!(job->states_mask & FLUX_JOB_INACTIVE))
+                continue;
+            val = json_boolean (job->success);
+        }
         else {
             errno = EINVAL;
             goto error;

--- a/src/modules/job-info/list.c
+++ b/src/modules/job-info/list.c
@@ -491,7 +491,7 @@ error:
 void list_attrs_cb (flux_t *h, flux_msg_handler_t *mh,
                     const flux_msg_t *msg, void *arg)
 {
-    if (flux_respond_pack (h, msg, "{s:[s,s,s,s,s,s,s,s,s,s,s,s,s]}",
+    if (flux_respond_pack (h, msg, "{s:[s,s,s,s,s,s,s,s,s,s,s,s,s,s]}",
                            "attrs",
                            "userid",
                            "priority",
@@ -505,7 +505,8 @@ void list_attrs_cb (flux_t *h, flux_msg_handler_t *mh,
                            "name",
                            "ntasks",
                            "nnodes",
-                           "ranks") < 0) {
+                           "ranks",
+                           "success") < 0) {
         flux_log_error (h, "%s: flux_respond_pack", __FUNCTION__);
         goto error;
     }

--- a/src/modules/job-info/list.c
+++ b/src/modules/job-info/list.c
@@ -491,7 +491,7 @@ error:
 void list_attrs_cb (flux_t *h, flux_msg_handler_t *mh,
                     const flux_msg_t *msg, void *arg)
 {
-    if (flux_respond_pack (h, msg, "{s:[s,s,s,s,s,s,s,s,s,s,s,s]}",
+    if (flux_respond_pack (h, msg, "{s:[s,s,s,s,s,s,s,s,s,s,s,s,s]}",
                            "attrs",
                            "userid",
                            "priority",

--- a/t/t2204-job-info.t
+++ b/t/t2204-job-info.t
@@ -753,7 +753,6 @@ test_expect_success 'list count / max_entries works' '
         count=`flux job list -s inactive -c 5 | wc -l` &&
         test $count -eq 5
 '
-
 test_expect_success HAVE_JQ 'list request with empty attrs works' '
         id=$(id -u) &&
         $jq -j -c -n  "{max_entries:5, userid:${id}, states:0, attrs:[]}" \
@@ -761,15 +760,16 @@ test_expect_success HAVE_JQ 'list request with empty attrs works' '
         test_must_fail grep "userid" list_empty_attrs.out &&
         test_must_fail grep "priority" list_empty_attrs.out &&
         test_must_fail grep "t_submit" list_empty_attrs.out &&
-        test_must_fail grep "state" list_empty_attrs.out &&
-        test_must_fail grep "name" list_empty_attrs.out &&
-        test_must_fail grep "ntasks" list_empty_attrs.out &&
-        test_must_fail grep "nnodes" list_empty_attrs.out &&
         test_must_fail grep "t_depend" list_empty_attrs.out &&
         test_must_fail grep "t_sched" list_empty_attrs.out &&
         test_must_fail grep "t_run" list_empty_attrs.out &&
         test_must_fail grep "t_cleanup" list_empty_attrs.out &&
-        test_must_fail grep "t_inactive" list_empty_attrs.out
+        test_must_fail grep "t_inactive" list_empty_attrs.out &&
+        test_must_fail grep "state" list_empty_attrs.out &&
+        test_must_fail grep "name" list_empty_attrs.out &&
+        test_must_fail grep "ntasks" list_empty_attrs.out &&
+        test_must_fail grep "nnodes" list_empty_attrs.out &&
+        test_must_fail grep "ranks" list_empty_attrs.out
 '
 test_expect_success HAVE_JQ 'list request with excessive max_entries works' '
         id=$(id -u) &&
@@ -781,15 +781,16 @@ test_expect_success HAVE_JQ 'list-attrs works' '
         grep userid list_attrs.out &&
         grep priority list_attrs.out &&
         grep t_submit list_attrs.out &&
-        grep state list_attrs.out &&
-        grep name list_attrs.out &&
-        grep ntasks list_attrs.out &&
-        grep nnodes list_attrs.out &&
         grep t_depend list_attrs.out &&
         grep t_sched list_attrs.out &&
         grep t_run list_attrs.out &&
         grep t_cleanup list_attrs.out &&
-        grep t_inactive list_attrs.out
+        grep t_inactive list_attrs.out &&
+        grep state list_attrs.out &&
+        grep name list_attrs.out &&
+        grep ntasks list_attrs.out &&
+        grep nnodes list_attrs.out &&
+        grep ranks list_attrs.out
 '
 
 #

--- a/t/t2204-job-info.t
+++ b/t/t2204-job-info.t
@@ -720,6 +720,26 @@ test_expect_success 'flux job list outputs nnodes/ranks correctly (5 tasks, / 3 
         echo $obj | jq -e ".ranks == \"[0-2]\""
 '
 
+#
+# job success
+#
+
+test_expect_success 'flux job list outputs success correctly (true)' '
+        jobid=`flux mini submit hostname` &&
+        fj_wait_event $jobid clean >/dev/null &&
+        wait_jobid_state $jobid inactive &&
+        obj=$(flux job list -s inactive | grep $jobid) &&
+        echo $obj | jq -e ".success == true"
+'
+
+test_expect_success 'flux job list outputs success correctly (false)' '
+        jobid=`flux mini submit nosuchcommand` &&
+        fj_wait_event $jobid clean >/dev/null &&
+        wait_jobid_state $jobid inactive &&
+        obj=$(flux job list -s inactive | grep $jobid) &&
+        echo $obj | jq -e ".success == false"
+'
+
 test_expect_success 'reload the job-info module' '
         flux exec -r all flux module reload job-info
 '
@@ -769,7 +789,8 @@ test_expect_success HAVE_JQ 'list request with empty attrs works' '
         test_must_fail grep "name" list_empty_attrs.out &&
         test_must_fail grep "ntasks" list_empty_attrs.out &&
         test_must_fail grep "nnodes" list_empty_attrs.out &&
-        test_must_fail grep "ranks" list_empty_attrs.out
+        test_must_fail grep "ranks" list_empty_attrs.out &&
+        test_must_fail grep "success" list_empty_attrs.out
 '
 test_expect_success HAVE_JQ 'list request with excessive max_entries works' '
         id=$(id -u) &&
@@ -790,7 +811,8 @@ test_expect_success HAVE_JQ 'list-attrs works' '
         grep name list_attrs.out &&
         grep ntasks list_attrs.out &&
         grep nnodes list_attrs.out &&
-        grep ranks list_attrs.out
+        grep ranks list_attrs.out &&
+        grep success list_attrs.out
 '
 
 #

--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -377,6 +377,16 @@ test_expect_success 'flux-jobs --format={runtime},{runtime_fsd},{runtime_fsd:h},
         test $count -eq 13
 '
 
+test_expect_success 'flux-jobs --format={success},{success:h} works' '
+        flux jobs --suppress-header --state=pending,running --format="{success},{success:h}" > successPR.out &&
+        for i in `seq 1 14`; do echo ",-" >> successPR.exp; done &&
+        test_cmp successPR.out successPR.exp &&
+        flux jobs --suppress-header --state=inactive --format="{success},{success:h}" > successI.out &&
+        echo "False,False" >> successI.exp &&
+        for i in `seq 1 4`; do echo "True,True" >> successI.exp; done &&
+        test_cmp successI.out successI.exp
+'
+
 #
 # corner cases
 #


### PR DESCRIPTION
Just throwing this up for some initial reactions.

Support a new "success" attribute in the job list service, which simply returns True / False if a job completed successfully (status = 0 on `finished` in the eventlog).  I sort of dislike the attribute name of "success", but I couldn't really think of anything better.  I'll mull over that.

Added a new "success" and "success_hyphen" format option to `flux-jobs`, nothing too exciting
there.  Example output:

```
>flux jobs -A --format="{id} {success}"
JOBID SUCCESS
109734619250688 
10590399496192 True
335712092160 False
293936824320 True
```

```
>flux jobs -A --format="{id} {success_hyphen}"
JOBID SUCCESS
109734619250688 -
10590399496192 True
335712092160 False
293936824320 True
```

The interesting addition, which no idea if I did it well or not, is a new field name called `success_color` (name can be tweaked, trying to think better name).  It'll colorize unsuccessful jobs:

I have no idea how to cut & paste that output into github, so here's a screenshot as an example:

![Screenshot from 2020-03-12 21-13-52](https://user-images.githubusercontent.com/274859/76589284-c58e2f80-64a6-11ea-9154-76af5f76c8d2.png)

I mulled over other ways to do this (command line option?) but somehow this made the most sense to me.  If it was done via command line options, some refactoring will have to be done to have `flux-jobs`  request attributes from `job-info`, but not output them via the "output format" code already there.