### PR TITLE
mergify: update travis-ci check name

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -2,7 +2,7 @@ pull_request_rules:
   - name: rebase and merge when passing all checks
     conditions:
       - base=master
-      - status-success=continuous-integration/travis-ci/pr
+      - status-success=Travis CI - Pull Request
       - status-success="validate commits"
       - status-success="flux-sched check"
       - label="merge-when-passing"


### PR DESCRIPTION
Problem: The move of flux-core Travis-CI testing from travis-ci.org
to travis-ci.com changed the name of the status check, so mergify
cannot merge any PRs.

Update the name of the Travis status check to fix mergify.

This PR will need to be manually merged.