### PR TITLE
tests: timeout in automake harness

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -98,6 +98,7 @@ stages:
 env:
   global:
    - TAP_DRIVER_QUIET=1
+   - FLUX_TEST_TIMEOUT=300
    - DOCKERREPO=fluxrm/flux-core
    - DOCKER_USERNAME=travisflux
    - secure: "Uga2i1Yu0PvWMFzOYvM9yxnAMDTgY17ZqeFlIN8MV3uoTCy6y61GULrMkKuhuI1sUfyugpFWVKIJo5jwTpsfG84f3o9lUTRgLPpTA2Xls8A/rmurF/QacVv6hZ2Zs2LQVlrM8BkT36TpT2NfWW2D2238kovqz3l5gIZKMClMvyk="

--- a/config/tap-driver.sh
+++ b/config/tap-driver.sh
@@ -119,6 +119,9 @@ else
   init_colors=''
 fi
 
+run_timeout() {
+    perl -e 'use Time::HiRes qw( ualarm ) ; ualarm ((shift @ARGV) * 1000000) ; exec @ARGV or die "$!"' "$@"
+}
 # :; is there to work around a bug in bash 3.2 (and earlier) which
 # does not always set '$?' properly on redirection failure.
 # See the Autoconf manual for more details.
@@ -144,7 +147,7 @@ fi
     else
       exec 2>&3
     fi
-    "$@"
+    run_timeout ${FLUX_TEST_TIMEOUT:-300} "$@"
     echo $?
   ) | LC_ALL=C ${AM_TAP_AWK-awk} \
         -v me="$me" \

--- a/config/tap-driver.sh
+++ b/config/tap-driver.sh
@@ -147,8 +147,8 @@ run_timeout() {
     else
       exec 2>&3
     fi
-    if test -n "$FLUX_TEST_TIMEOUT" ; then
-        run_timeout ${FLUX_TEST_TIMEOUT} "$@"
+    if test -n "${FLUX_TEST_TIMEOUT:-}" ; then
+        run_timeout "${FLUX_TEST_TIMEOUT}" "$@"
     else
        "$@"
     fi

--- a/config/tap-driver.sh
+++ b/config/tap-driver.sh
@@ -147,7 +147,11 @@ run_timeout() {
     else
       exec 2>&3
     fi
-    run_timeout ${FLUX_TEST_TIMEOUT:-300} "$@"
+    if test -n "$FLUX_TEST_TIMEOUT" ; then
+        run_timeout ${FLUX_TEST_TIMEOUT} "$@"
+    else
+       "$@"
+    fi
     echo $?
   ) | LC_ALL=C ${AM_TAP_AWK-awk} \
         -v me="$me" \


### PR DESCRIPTION
This is an alternative to #2833, it's immensely simpler but only works when the test is run under the automake test harness, and only works for full test executables.