### PR TITLE
README: update Travis CI badge after transition to travis-ci.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/flux-framework/flux-core.svg?branch=master)](https://travis-ci.org/flux-framework/flux-core)
+[![Build Status](https://travis-ci.com/flux-framework/flux-core.svg?branch=master)](https://travis-ci.com/flux-framework/flux-core)
 [![Coverage Status](https://coveralls.io/repos/flux-framework/flux-core/badge.svg?branch=master&service=github)](https://coveralls.io/github/flux-framework/flux-core?branch=master)
 
 _NOTE: The interfaces of flux-core are being actively developed


### PR DESCRIPTION
We recently switched from travis-ci.org to travis-ci.com. Update the CI badge link accordingly.