### PR TITLE
job-info: Support new "exception" list attributes

### DIFF
--- a/doc/man1/flux-jobs.adoc
+++ b/doc/man1/flux-jobs.adoc
@@ -85,6 +85,10 @@ ntasks:: job task count
 nnodes:: job node count (if job ran / is running), empty string otherwise
 ranks:: job ranks (if job ran / is running), empty string otherwise
 success:: True of False if job completed successfully, empty string otherwise
+exception.occurred:: True of False if job had an exception, empty string otherwise
+exception.severity:: If exception.occurred True, the highest severity, empty string otherwise
+exception.type:: If exception.occurred True, the highest severity exception type, empty string otherwise
+exception.note:: If exception.occurred True, the highest severity exception note, empty string otherwise
 t_submit:: time job was submitted
 t_depend:: time job entered depend state
 t_sched:: time job entered sched state

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -999,8 +999,10 @@ int cmd_list (optparse_t *p, int argc, char **argv)
     int optindex = optparse_option_index (p);
     int max_entries = optparse_get_int (p, "count", 0);
     char *attrs = "[\"userid\",\"priority\",\"t_submit\",\"state\"," \
-        "\"name\",\"ntasks\",\"nnodes\",\"ranks\",\"success\",\"t_depend\"," \
-        "\"t_sched\",\"t_run\",\"t_cleanup\",\"t_inactive\"]";
+        "\"name\",\"ntasks\",\"nnodes\",\"ranks\",\"success\"," \
+        "\"exception_occurred\",\"exception_severity\",\"exception_type\"," \
+        "\"exception_note\"," \
+        "\"t_depend\",\"t_sched\",\"t_run\",\"t_cleanup\",\"t_inactive\"]";
     flux_t *h;
     flux_future_t *f;
     json_t *jobs;

--- a/src/cmd/flux-jobs.py
+++ b/src/cmd/flux-jobs.py
@@ -78,16 +78,16 @@ class JobInfo:
     """
 
     #  Default values for job properties.
-    defaults = dict(
-        t_depend=0.0,
-        t_sched=0.0,
-        t_run=0.0,
-        t_cleanup=0.0,
-        t_inactive=0.0,
-        nnodes="",
-        ranks="",
-        success="",
-    )
+    defaults = {
+        "t_depend": 0.0,
+        "t_sched": 0.0,
+        "t_run": 0.0,
+        "t_cleanup": 0.0,
+        "t_inactive": 0.0,
+        "nnodes": "",
+        "ranks": "",
+        "success": "",
+    }
 
     def __init__(self, info_resp):
         #  Set defaults, then update with job-info.list response items:
@@ -179,28 +179,28 @@ def fetch_jobs_flux(args, fields):
     flux_handle = flux.Flux()
 
     # Note there is no attr for "id", its always returned
-    fields2attrs = dict(
-        id=(),
-        userid=("userid",),
-        username=("userid",),
-        priority=("priority",),
-        state=("state",),
-        state_single=("state",),
-        name=("name",),
-        ntasks=("ntasks",),
-        nnodes=("nnodes",),
-        ranks=("ranks",),
-        success=("success",),
-        t_submit=("t_submit",),
-        t_depend=("t_depend",),
-        t_sched=("t_sched",),
-        t_run=("t_run",),
-        t_cleanup=("t_cleanup",),
-        t_inactive=("t_inactive",),
-        runtime=("t_run", "t_cleanup"),
-        runtime_fsd=("t_run", "t_cleanup"),
-        runtime_hms=("t_run", "t_cleanup"),
-    )
+    fields2attrs = {
+        "id": (),
+        "userid": ("userid",),
+        "username": ("userid",),
+        "priority": ("priority",),
+        "state": ("state",),
+        "state_single": ("state",),
+        "name": ("name",),
+        "ntasks": ("ntasks",),
+        "nnodes": ("nnodes",),
+        "ranks": ("ranks",),
+        "success": ("success",),
+        "t_submit": ("t_submit",),
+        "t_depend": ("t_depend",),
+        "t_sched": ("t_sched",),
+        "t_run": ("t_run",),
+        "t_cleanup": ("t_cleanup",),
+        "t_inactive": ("t_inactive",),
+        "runtime": ("t_run", "t_cleanup"),
+        "runtime_fsd": ("t_run", "t_cleanup"),
+        "runtime_hms": ("t_run", "t_cleanup"),
+    }
 
     attrs = set()
     for field in fields:
@@ -328,28 +328,28 @@ class JobsOutputFormat(flux.util.OutputFormat):
             return super().format_field(value, spec)
 
     #  List of legal format fields and their header names
-    headings = dict(
-        id="JOBID",
-        userid="UID",
-        username="USER",
-        priority="PRI",
-        state="STATE",
-        state_single="STATE",
-        name="NAME",
-        ntasks="NTASKS",
-        nnodes="NNODES",
-        ranks="RANKS",
-        success="SUCCESS",
-        t_submit="T_SUBMIT",
-        t_depend="T_DEPEND",
-        t_sched="T_SCHED",
-        t_run="T_RUN",
-        t_cleanup="T_CLEANUP",
-        t_inactive="T_INACTIVE",
-        runtime="RUNTIME",
-        runtime_fsd="RUNTIME",
-        runtime_hms="RUNTIME",
-    )
+    headings = {
+        "id": "JOBID",
+        "userid": "UID",
+        "username": "USER",
+        "priority": "PRI",
+        "state": "STATE",
+        "state_single": "STATE",
+        "name": "NAME",
+        "ntasks": "NTASKS",
+        "nnodes": "NNODES",
+        "ranks": "RANKS",
+        "success": "SUCCESS",
+        "t_submit": "T_SUBMIT",
+        "t_depend": "T_DEPEND",
+        "t_sched": "T_SCHED",
+        "t_run": "T_RUN",
+        "t_cleanup": "T_CLEANUP",
+        "t_inactive": "T_INACTIVE",
+        "runtime": "RUNTIME",
+        "runtime_fsd": "RUNTIME",
+        "runtime_hms": "RUNTIME",
+    }
 
     def __init__(self, fmt):
         """

--- a/src/modules/job-info/job_state.h
+++ b/src/modules/job-info/job_state.h
@@ -71,6 +71,11 @@ struct job {
     int nnodes;
     char *ranks;
     bool success;
+    bool exception_occurred;
+    json_t *exception_context;
+    int exception_severity;
+    const char *exception_type;
+    const char *exception_note;
 
     /* cache of job information */
     json_t *jobspec_job;

--- a/src/modules/job-info/job_util.c
+++ b/src/modules/job-info/job_util.c
@@ -107,6 +107,29 @@ json_t *job_to_json (struct job *job, json_t *attrs)
                 continue;
             val = json_boolean (job->success);
         }
+        else if (!strcmp (attr, "exception_occurred")) {
+            if (!(job->states_mask & FLUX_JOB_INACTIVE))
+                continue;
+            val = json_boolean (job->exception_occurred);
+        }
+        else if (!strcmp (attr, "exception_severity")) {
+            if (!(job->states_mask & FLUX_JOB_INACTIVE)
+                || !job->exception_occurred)
+                continue;
+            val = json_integer (job->exception_severity);
+        }
+        else if (!strcmp (attr, "exception_type")) {
+            if (!(job->states_mask & FLUX_JOB_INACTIVE)
+                || !job->exception_occurred)
+                continue;
+            val = json_string (job->exception_type);
+        }
+        else if (!strcmp (attr, "exception_note")) {
+            if (!(job->states_mask & FLUX_JOB_INACTIVE)
+                || !job->exception_occurred)
+                continue;
+            val = json_string (job->exception_note);
+        }
         else {
             errno = EINVAL;
             goto error;

--- a/src/modules/job-info/list.c
+++ b/src/modules/job-info/list.c
@@ -509,7 +509,8 @@ void list_attrs_cb (flux_t *h, flux_msg_handler_t *mh,
     const char *attrs[] = { "userid", "priority", "t_submit", "t_depend",
                             "t_sched", "t_run", "t_cleanup", "t_inactive",
                             "state", "name", "ntasks", "nnodes", "ranks",
-                            "success", NULL };
+                            "success", "exception_occurred", "exception_type",
+                            "exception_severity", "exception_note", NULL };
     json_t *a = NULL;
     int i;
 

--- a/t/t2204-job-info.t
+++ b/t/t2204-job-info.t
@@ -598,7 +598,7 @@ test_expect_success 'flux job list outputs user job name' '
         echo $jobid > jobname1.id &&
         fj_wait_event $jobid clean >/dev/null &&
         wait_jobid_state $jobid inactive &&
-        flux job list -s inactive | grep $jobid | grep foobar
+        flux job list -s inactive | grep $jobid | jq -e ".name == \"foobar\""
 '
 
 test_expect_success 'flux job lists first argument for job name' '
@@ -606,7 +606,7 @@ test_expect_success 'flux job lists first argument for job name' '
         echo $jobid > jobname2.id &&
         fj_wait_event $jobid clean >/dev/null &&
         wait_jobid_state $jobid inactive &&
-        flux job list -s inactive | grep $jobid | grep mycmd
+        flux job list -s inactive | grep $jobid | jq -e ".name == \"mycmd\""
 '
 
 test_expect_success 'flux job lists basename of first argument for job name' '
@@ -614,8 +614,7 @@ test_expect_success 'flux job lists basename of first argument for job name' '
         echo $jobid > jobname3.id &&
         fj_wait_event $jobid clean >/dev/null &&
         wait_jobid_state $jobid inactive &&
-        flux job list -s inactive | grep $jobid | grep bar &&
-        flux job list -s inactive | grep $jobid | grep -v foo
+        flux job list -s inactive | grep $jobid | jq -e ".name == \"bar\""
 '
 
 test_expect_success 'flux job lists full path for job name if basename fails on first arg' '
@@ -623,7 +622,7 @@ test_expect_success 'flux job lists full path for job name if basename fails on 
         echo $jobid > jobname4.id &&
         fj_wait_event $jobid clean >/dev/null &&
         wait_jobid_state $jobid inactive &&
-        flux job list -s inactive | grep $jobid | grep "\/foo\/bar\/"
+        flux job list -s inactive | grep $jobid | jq -e ".name == \"\/foo\/bar\/\""
 '
 
 test_expect_success 'reload the job-info module' '
@@ -635,10 +634,10 @@ test_expect_success 'verify job names preserved across restart' '
         jobid2=`cat jobname2.id` &&
         jobid3=`cat jobname3.id` &&
         jobid4=`cat jobname4.id` &&
-        flux job list -s inactive | grep ${jobid1} | grep foobar &&
-        flux job list -s inactive | grep ${jobid2} | grep mycmd &&
-        flux job list -s inactive | grep ${jobid3} | grep bar &&
-        flux job list -s inactive | grep ${jobid4} | grep "\/foo\/bar\/"
+        flux job list -s inactive | grep ${jobid1} | jq -e ".name == \"foobar\"" &&
+        flux job list -s inactive | grep ${jobid2} | jq -e ".name == \"mycmd\"" &&
+        flux job list -s inactive | grep ${jobid3} | jq -e ".name == \"bar\"" &&
+        flux job list -s inactive | grep ${jobid4} | jq -e ".name == \"\/foo\/bar\/\""
 '
 
 #

--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -429,6 +429,36 @@ test_expect_success 'flux-jobs --format={exception.note},{exception.note:h} work
 '
 
 #
+# format header tests
+#
+test_expect_success 'flux-jobs: header included with all custom formats' '
+	flux jobs --format={id} | head -1 | grep "JOBID" &&
+        flux jobs --format={userid} | head -1 | grep "UID" &&
+        flux jobs --format={username} | head -1 | grep "USER" &&
+        flux jobs --format={priority} | head -1 | grep "PRI" &&
+        flux jobs --format={state} | head -1 | grep "STATE" &&
+        flux jobs --format={state_single} | head -1 | grep "STATE" &&
+        flux jobs --format={name} | head -1 | grep "NAME" &&
+        flux jobs --format={ntasks} | head -1 | grep "NTASKS" &&
+        flux jobs --format={nnodes} | head -1 | grep "NNODES" &&
+        flux jobs --format={ranks} | head -1 | grep "RANKS" &&
+        flux jobs --format={success} | head -1 | grep "SUCCESS" &&
+        flux jobs --format={exception.occurred} | head -1 | grep "EXCEPTION-OCCURRED" &&
+        flux jobs --format={exception.severity} | head -1 | grep "EXCEPTION-SEVERITY" &&
+        flux jobs --format={exception.type} | head -1 | grep "EXCEPTION-TYPE" &&
+        flux jobs --format={exception.note} | head -1 | grep "EXCEPTION-NOTE" &&
+        flux jobs --format={t_submit} | head -1 | grep "T_SUBMIT" &&
+        flux jobs --format={t_depend} | head -1 | grep "T_DEPEND" &&
+        flux jobs --format={t_sched} | head -1 | grep "T_SCHED" &&
+        flux jobs --format={t_run} | head -1 | grep "T_RUN" &&
+        flux jobs --format={t_cleanup} | head -1 | grep "T_CLEANUP" &&
+        flux jobs --format={t_inactive} | head -1 | grep "T_INACTIVE" &&
+        flux jobs --format={runtime} | head -1 | grep "RUNTIME" &&
+        flux jobs --format={runtime_fsd} | head -1 | grep "RUNTIME" &&
+        flux jobs --format={runtime_hms} | head -1 | grep "RUNTIME"
+'
+
+#
 # corner cases
 #
 

--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -387,6 +387,47 @@ test_expect_success 'flux-jobs --format={success},{success:h} works' '
         test_cmp successI.out successI.exp
 '
 
+test_expect_success 'flux-jobs --format={exception.occurred},{exception.occurred:h} works' '
+        flux jobs --suppress-header --state=pending,running --format="{exception.occurred},{exception.occurred:h}" > exception_occurredPR.out &&
+        for i in `seq 1 14`; do echo ",-" >> exception_occurredPR.exp; done &&
+        test_cmp exception_occurredPR.out exception_occurredPR.exp &&
+        flux jobs --suppress-header --state=inactive --format="{exception.occurred},{exception.occurred:h}" > exception_occurredI.out &&
+        echo "True,True" >> exception_occurredI.exp &&
+        for i in `seq 1 4`; do echo "False,False" >> exception_occurredI.exp; done &&
+        test_cmp exception_occurredI.out exception_occurredI.exp
+'
+
+test_expect_success 'flux-jobs --format={exception.severity},{exception.severity:h} works' '
+        flux jobs --suppress-header --state=pending,running --format="{exception.severity},{exception.severity:h}" > exception_severityPR.out &&
+        for i in `seq 1 14`; do echo ",-" >> exception_severityPR.exp; done &&
+        test_cmp exception_severityPR.out exception_severityPR.exp &&
+        flux jobs --suppress-header --state=inactive --format="{exception.severity},{exception.severity:h}" > exception_severityI.out &&
+        echo "0,0" >> exception_severityI.exp &&
+        for i in `seq 1 4`; do echo ",-" >> exception_severityI.exp; done &&
+        test_cmp exception_severityI.out exception_severityI.exp
+'
+
+test_expect_success 'flux-jobs --format={exception.type},{exception.type:h} works' '
+        flux jobs --suppress-header --state=pending,running --format="{exception.type},{exception.type:h}" > exception_typePR.out &&
+        for i in `seq 1 14`; do echo ",-" >> exception_typePR.exp; done &&
+        test_cmp exception_typePR.out exception_typePR.exp &&
+        flux jobs --suppress-header --state=inactive --format="{exception.type},{exception.type:h}" > exception_typeI.out &&
+        echo "exec,exec" >> exception_typeI.exp &&
+        for i in `seq 1 4`; do echo ",-" >> exception_typeI.exp; done &&
+        test_cmp exception_typeI.out exception_typeI.exp
+'
+
+test_expect_success 'flux-jobs --format={exception.note},{exception.note:h} works' '
+        flux jobs --suppress-header --state=pending,running --format="{exception.note},{exception.note:h}" > exception_notePR.out &&
+        for i in `seq 1 14`; do echo ",-" >> exception_notePR.exp; done &&
+        test_cmp exception_notePR.out exception_notePR.exp &&
+        flux jobs --suppress-header --state=inactive --format="{exception.note},{exception.note:h}" > exception_noteI.out &&
+        head -n 1 exception_noteI.out | grep "No such file or directory" &&
+        tail -n 4 exception_noteI.out > exception_noteI_tail.out &&
+        for i in `seq 1 4`; do echo ",-" >> exception_noteI.exp; done &&
+        test_cmp exception_noteI_tail.out exception_noteI.exp
+'
+
 #
 # corner cases
 #


### PR DESCRIPTION
Build on top of PR #2831, support 4 new job listing attributes, "exception", "exception_severity", "exception_type", and "exception_note".  Hopefully what these are don't require explanation.

If an exception occurred, return true/false for `exception`.  if true, the others will contain the values for the highest severity and the type/note that went along with it.

```
>flux jobs -A --format="{exception},{exception_severity},{exception_type},{exception_note}"
EXCEPTION,EXCEPTION-SEVERITY,EXCEPTION-TYPE,EXCEPTION-NOTE
True,0,exec,task 0: start failed: fdasfdasf: No such file or directory
```

I'm not the most excited about the long format names and the headers, but just put those in for place holders.  Wasn't sure of the best abbreviation ... google says abbreviation is "exc", but my gut says to use "excp"?  should headers just be severity, type, & note?