### PR TITLE
flux-jobs: Add custom conversion type to output '-'

### DIFF
--- a/doc/man1/flux-jobs.adoc
+++ b/doc/man1/flux-jobs.adoc
@@ -66,10 +66,10 @@ following is the format used for the default format:
 
   {id:>18} {username:<8.8} {name:<10.10} {state:<8.8} {ntasks:>6} {nnodes:>6h} {runtime_fsd:>8h} {ranks:h}
 
-The conversion type 'h' can be used to convert an empty string or the
-string "0s" to a hyphen.  For example, normally "{ranks}" would output
-an empty string if the job has not yet run.  By specifying,
-"{ranks:h}", a hyphen would be output instead.
+The conversion type 'h' can be used to convert an empty string, "0s",
+"0.0", or "0:00:00" to a hyphen.  For example, normally "{ranks}"
+would output an empty string if the job has not yet run.  By
+specifying, "{ranks:h}", a hyphen would be output instead.
 
 The field names that can be specified are:
 

--- a/doc/man1/flux-jobs.adoc
+++ b/doc/man1/flux-jobs.adoc
@@ -64,7 +64,7 @@ The '--format' option can be used to specify an output format to
 flux-jobs(1) using Python's string format syntax.  For example, the
 following is the format used for the default format:
 
-  {id:>18} {username:<8.8} {name:<10.10} {state:<8.8} {ntasks:>6} {nnodes_hyphen:>6} {runtime_fsd_hyphen:>8} {ranks_hyphen}
+  {id:>18} {username:<8.8} {name:<10.10} {state:<8.8} {ntasks:>6} {nnodes:>6h} {runtime_fsd:>8h} {ranks:h}
 
 The conversion type 'h' can be used to convert an empty string or the
 string "0s" to a hyphen.  For example, normally "{ranks}" would output
@@ -83,9 +83,7 @@ state_single:: job state as a single character
 name:: job name
 ntasks:: job task count
 nnodes:: job node count (if job ran / is running), empty string otherwise
-nnodes_hyphen:: same as nnodes, but '-' if job has not run yet / never ran
 ranks:: job ranks (if job ran / is running), empty string otherwise
-ranks_hyphen:: same as ranks, but '-' if job has not run yet / never ran
 t_submit:: time job was submitted
 t_depend:: time job entered depend state
 t_sched:: time job entered sched state
@@ -94,7 +92,6 @@ t_cleanup:: time job entered cleanup state
 t_inactive:: time job entered inactive state
 runtime:: job runtime
 runtime_fsd:: job runtime in Flux standard duration format
-runtime_fsd_hyphen:: same as runtime_fsd, but '-' if runtime is 0s
 runtime_hms:: job runtime in H:M:S format
 
 AUTHOR

--- a/doc/man1/flux-jobs.adoc
+++ b/doc/man1/flux-jobs.adoc
@@ -66,6 +66,11 @@ following is the format used for the default format:
 
   {id:>18} {username:<8.8} {name:<10.10} {state:<8.8} {ntasks:>6} {nnodes_hyphen:>6} {runtime_fsd_hyphen:>8} {ranks_hyphen}
 
+The conversion type 'h' can be used to convert an empty string or the
+string "0s" to a hyphen.  For example, normally "{ranks}" would output
+an empty string if the job has not yet run.  By specifying,
+"{ranks:h}", a hyphen would be output instead.
+
 The field names that can be specified are:
 
 [horizontal]

--- a/src/bindings/python/flux/util.py
+++ b/src/bindings/python/flux/util.py
@@ -219,7 +219,7 @@ class OutputFormat:
         conv = "!" + conv if conv else ""
         return "{0}{{{1}{2}{3}}}".format(text, field, conv, spec)
 
-    def header(self):
+    def header_format(self):
         """
         Return the header row formatted by the user-provided format spec,
         which will be made "safe" for use with string headings.
@@ -230,7 +230,10 @@ class OutputFormat:
             spec = re.sub(r"(0?\.)?(\d+)?[bcdoxXeEfFgGn%]$", r"\2", spec)
             format_list.append(self._fmt_tuple(text, field, spec, conv))
         fmt = "".join(format_list)
-        return fmt.format(**self.headings)
+        return fmt
+
+    def header(self):
+        return self.header_format().format(**self.headings)
 
     def get_format(self):
         """

--- a/src/cmd/flux-jobs.py
+++ b/src/cmd/flux-jobs.py
@@ -140,20 +140,8 @@ class JobInfo:
         return get_username(self.userid)
 
     @memoized_property
-    def nnodes_hyphen(self):
-        return self.nnodes or "-"
-
-    @memoized_property
-    def ranks_hyphen(self):
-        return self.ranks or "-"
-
-    @memoized_property
     def runtime_fsd(self):
         return fsd(self.runtime, False)
-
-    @memoized_property
-    def runtime_fsd_hyphen(self):
-        return fsd(self.runtime, True)
 
     @memoized_property
     def runtime_hms(self):
@@ -200,9 +188,7 @@ def fetch_jobs_flux(args, fields):
         name=("name",),
         ntasks=("ntasks",),
         nnodes=("nnodes",),
-        nnodes_hyphen=("nnodes",),
         ranks=("ranks",),
-        ranks_hyphen=("ranks",),
         t_submit=("t_submit",),
         t_depend=("t_depend",),
         t_sched=("t_sched",),
@@ -211,7 +197,6 @@ def fetch_jobs_flux(args, fields):
         t_inactive=("t_inactive",),
         runtime=("t_run", "t_cleanup"),
         runtime_fsd=("t_run", "t_cleanup"),
-        runtime_fsd_hyphen=("t_run", "t_cleanup"),
         runtime_hms=("t_run", "t_cleanup"),
     )
 
@@ -350,9 +335,7 @@ class JobsOutputFormat(flux.util.OutputFormat):
         name="NAME",
         ntasks="NTASKS",
         nnodes="NNODES",
-        nnodes_hyphen="NNODES",
         ranks="RANKS",
-        ranks_hyphen="RANKS",
         t_submit="T_SUBMIT",
         t_depend="T_DEPEND",
         t_sched="T_SCHED",
@@ -361,7 +344,6 @@ class JobsOutputFormat(flux.util.OutputFormat):
         t_inactive="T_INACTIVE",
         runtime="RUNTIME",
         runtime_fsd="RUNTIME",
-        runtime_fsd_hyphen="RUNTIME",
         runtime_hms="RUNTIME",
     )
 
@@ -418,8 +400,8 @@ def main():
     else:
         fmt = (
             "{id:>18} {username:<8.8} {name:<10.10} {state:<8.8} "
-            "{ntasks:>6} {nnodes_hyphen:>6} {runtime_fsd_hyphen:>8} "
-            "{ranks_hyphen}"
+            "{ntasks:>6} {nnodes:>6h} {runtime_fsd:>8h} "
+            "{ranks:h}"
         )
     try:
         formatter = JobsOutputFormat(fmt)

--- a/src/cmd/flux-jobs.py
+++ b/src/cmd/flux-jobs.py
@@ -42,20 +42,20 @@ STATE_CONST_DICT = {
 def fsd(secs, hyphenifzero):
     #  Round <1ms down to 0s for now
     if secs < 1.0e-3:
-        string = "0s"
+        strtmp = "0s"
     elif secs < 10.0:
-        string = "%.03fs" % secs
+        strtmp = "%.03fs" % secs
     elif secs < 60.0:
-        string = "%.4gs" % secs
+        strtmp = "%.4gs" % secs
     elif secs < (60.0 * 60.0):
-        string = "%.4gm" % (secs / 60.0)
+        strtmp = "%.4gm" % (secs / 60.0)
     elif secs < (60.0 * 60.0 * 24.0):
-        string = "%.4gh" % (secs / (60.0 * 60.0))
+        strtmp = "%.4gh" % (secs / (60.0 * 60.0))
     else:
-        string = "%.4gd" % (secs / (60.0 * 60.0 * 24.0))
-    if hyphenifzero and string == "0s":
+        strtmp = "%.4gd" % (secs / (60.0 * 60.0 * 24.0))
+    if hyphenifzero and strtmp == "0s":
         return "-"
-    return string
+    return strtmp
 
 
 def statetostr(stateid, singlechar=False):

--- a/src/cmd/flux-jobs.py
+++ b/src/cmd/flux-jobs.py
@@ -16,6 +16,7 @@ import logging
 import argparse
 import time
 import pwd
+import string
 from datetime import timedelta
 
 import flux.job
@@ -331,6 +332,13 @@ class JobsOutputFormat(flux.util.OutputFormat):
     a new format suitable for headers display, etc...
     """
 
+    class JobFormatter(string.Formatter):
+        def format_field(self, value, spec):
+            if spec.endswith("h"):
+                value = "-" if value in ("", "0s") else str(value)
+                spec = spec[:-1] + "s"
+            return super().format_field(value, spec)
+
     #  List of legal format fields and their header names
     headings = dict(
         id="JOBID",
@@ -387,6 +395,18 @@ class JobsOutputFormat(flux.util.OutputFormat):
         # pylint: disable=attribute-defined-outside-init
         self._jobfmt = "".join(lst)
         return self._jobfmt
+
+    def format(self, obj):
+        """
+        format object with our JobFormatter
+        """
+        return self.JobFormatter().format(self.get_format(), obj)
+
+    def header(self):
+        """
+        format header with our JobFormatter
+        """
+        return self.JobFormatter().format(self.header_format(), **self.headings)
 
 
 @flux.util.CLIMain(LOGGER)

--- a/src/cmd/flux-jobs.py
+++ b/src/cmd/flux-jobs.py
@@ -320,7 +320,8 @@ class JobsOutputFormat(flux.util.OutputFormat):
     class JobFormatter(string.Formatter):
         def format_field(self, value, spec):
             if spec.endswith("h"):
-                value = "-" if value in ("", "0s") else str(value)
+                basecases = ("", "0s", "0.0", "0:00:00")
+                value = "-" if str(value) in basecases else str(value)
                 spec = spec[:-1] + "s"
             return super().format_field(value, spec)
 

--- a/t/flux-jobs/tests/issue#2634/format
+++ b/t/flux-jobs/tests/issue#2634/format
@@ -1,1 +1,1 @@
-{runtime_fsd_hyphen} {runtime_fsd}
+{runtime_fsd:h} {runtime_fsd}

--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -239,11 +239,11 @@ test_expect_success 'flux-jobs --format={ntasks} works' '
         test_cmp taskcount.out taskcount.exp
 '
 
-test_expect_success 'flux-jobs --format={nnodes},{nnodes_hyphen} works' '
-        flux jobs --suppress-header --state=pending --format="{nnodes},{nnodes_hyphen}" > nodecountP.out &&
+test_expect_success 'flux-jobs --format={nnodes},{nnodes:h} works' '
+        flux jobs --suppress-header --state=pending --format="{nnodes},{nnodes:h}" > nodecountP.out &&
         for i in `seq 1 6`; do echo ",-" >> nodecountP.exp; done &&
         test_cmp nodecountP.out nodecountP.exp &&
-        flux jobs --suppress-header --state=running,inactive --format="{nnodes},{nnodes_hyphen}" > nodecountRI.out &&
+        flux jobs --suppress-header --state=running,inactive --format="{nnodes},{nnodes:h}" > nodecountRI.out &&
         for i in `seq 1 12`; do echo "1,1" >> nodecountRI.exp; done &&
         test_cmp nodecountRI.out nodecountRI.exp
 '
@@ -288,11 +288,11 @@ test_expect_success 'flux-jobs emits useful error on invalid format specifier' '
 
 
 # node ranks assumes sched-simple default of mode='worst-fit'
-test_expect_success 'flux-jobs --format={ranks},{ranks_hyphen} works' '
-        flux jobs --suppress-header --state=pending --format="{ranks},{ranks_hyphen}" > ranksP.out &&
+test_expect_success 'flux-jobs --format={ranks},{ranks:h} works' '
+        flux jobs --suppress-header --state=pending --format="{ranks},{ranks:h}" > ranksP.out &&
         for i in `seq 1 6`; do echo ",-" >> ranksP.exp; done &&
         test_cmp ranksP.out ranksP.exp &&
-        flux jobs --suppress-header --state=running --format="{ranks},{ranks_hyphen}" > ranksR.out &&
+        flux jobs --suppress-header --state=running --format="{ranks},{ranks:h}" > ranksR.out &&
         for i in `seq 1 2`; \
         do \
             echo "3,3" >> ranksR.exp; \
@@ -301,7 +301,7 @@ test_expect_success 'flux-jobs --format={ranks},{ranks_hyphen} works' '
             echo "0,0" >> ranksR.exp; \
         done &&
         test_cmp ranksR.out ranksR.exp &&
-        flux jobs --suppress-header --state=inactive --format="{ranks},{ranks_hyphen}" > ranksI.out &&
+        flux jobs --suppress-header --state=inactive --format="{ranks},{ranks:h}" > ranksI.out &&
         for i in `seq 1 4`; do echo "0,0" >> ranksI.exp; done &&
         test_cmp ranksI.out ranksI.exp
 '
@@ -337,8 +337,8 @@ test_expect_success 'flux-jobs --format={t_XXX} works' '
         test $count -eq 4
 '
 
-test_expect_success 'flux-jobs --format={runtime},{runtime_fsd},{runtime_fsd_hyphen},{runtime_hms} works' '
-        flux jobs --suppress-header --state=pending --format="{runtime},{runtime_fsd},{runtime_fsd_hyphen},{runtime_hms}" > runtimeP.out &&
+test_expect_success 'flux-jobs --format={runtime},{runtime_fsd},{runtime_fsd:h},{runtime_hms} works' '
+        flux jobs --suppress-header --state=pending --format="{runtime},{runtime_fsd},{runtime_fsd:h},{runtime_hms}" > runtimeP.out &&
         for i in `seq 1 6`; do echo "0.0,0s,-,0:00:00" >> runtimeP.exp; done &&
         test_cmp runtimeP.out runtimeP.exp &&
         flux jobs --suppress-header --state=running,inactive --format="{runtime}" > runtimeRI_1.out &&
@@ -347,7 +347,7 @@ test_expect_success 'flux-jobs --format={runtime},{runtime_fsd},{runtime_fsd_hyp
         flux jobs --suppress-header --state=running,inactive --format="{runtime_fsd}" > runtimeRI_2.out &&
         count=`cat runtimeRI_2.out | grep -v "^0s" | wc -l` &&
         test $count -eq 12 &&
-        flux jobs --suppress-header --state=running,inactive --format="{runtime_fsd_hyphen}" > runtimeRI_3.out &&
+        flux jobs --suppress-header --state=running,inactive --format="{runtime_fsd:h}" > runtimeRI_3.out &&
         count=`cat runtimeRI_3.out | grep -v "^-$" | wc -l` &&
         test $count -eq 12 &&
         flux jobs --suppress-header --state=running,inactive --format="{runtime_hms}" > runtimeRI_4.out &&

--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -318,40 +318,58 @@ test_expect_success 'flux-jobs --format={t_XXX} works' '
         count=`cat t_sched.out | grep -v "^0.0$" | wc -l` &&
         test $count -eq 18 &&
         flux jobs --suppress-header --state=pending --format="{t_run}" > t_runP.out &&
+        flux jobs --suppress-header --state=pending --format="{t_run:h}" > t_runP_h.out &&
         flux jobs --suppress-header --state=running,inactive --format="{t_run}" > t_runRI.out &&
         count=`cat t_runP.out | grep "^0.0$" | wc -l` &&
+        test $count -eq 6 &&
+        count=`cat t_runP_h.out | grep "^-$" | wc -l` &&
         test $count -eq 6 &&
         count=`cat t_runRI.out | grep -v "^0.0$" | wc -l` &&
         test $count -eq 12 &&
         flux jobs --suppress-header --state=pending,running --format="{t_cleanup}" > t_cleanupPR.out &&
+        flux jobs --suppress-header --state=pending,running --format="{t_cleanup:h}" > t_cleanupPR_h.out &&
         flux jobs --suppress-header --state=inactive --format="{t_cleanup}" > t_cleanupI.out &&
         count=`cat t_cleanupPR.out | grep "^0.0$" | wc -l` &&
+        test $count -eq 14 &&
+        count=`cat t_cleanupPR_h.out | grep "^-$" | wc -l` &&
         test $count -eq 14 &&
         count=`cat t_cleanupI.out | grep -v "^0.0$" | wc -l` &&
         test $count -eq 4 &&
         flux jobs --suppress-header --state=pending,running --format="{t_inactive}" > t_inactivePR.out &&
+        flux jobs --suppress-header --state=pending,running --format="{t_inactive:h}" > t_inactivePR_h.out &&
         flux jobs --suppress-header --state=inactive --format="{t_inactive}" > t_inactiveI.out &&
         count=`cat t_inactivePR.out | grep "^0.0$" | wc -l` &&
+        test $count -eq 14 &&
+        count=`cat t_inactivePR_h.out | grep "^-$" | wc -l` &&
         test $count -eq 14 &&
         count=`cat t_inactiveI.out | grep -v "^0.0$" | wc -l` &&
         test $count -eq 4
 '
 
-test_expect_success 'flux-jobs --format={runtime},{runtime_fsd},{runtime_fsd:h},{runtime_hms} works' '
-        flux jobs --suppress-header --state=pending --format="{runtime},{runtime_fsd},{runtime_fsd:h},{runtime_hms}" > runtimeP.out &&
-        for i in `seq 1 6`; do echo "0.0,0s,-,0:00:00" >> runtimeP.exp; done &&
+test_expect_success 'flux-jobs --format={runtime},{runtime_fsd},{runtime_fsd:h},{runtime_hms},{runtime_hms:h} works' '
+        flux jobs --suppress-header --state=pending --format="{runtime},{runtime_fsd},{runtime_hms}" > runtimeP.out &&
+        for i in `seq 1 6`; do echo "0.0,0s,0:00:00" >> runtimeP.exp; done &&
         test_cmp runtimeP.out runtimeP.exp &&
+        flux jobs --suppress-header --state=pending --format="{runtime_fsd:h},{runtime_hms:h}" > runtimeP_h.out &&
+        for i in `seq 1 6`; do echo "-,-" >> runtimeP_h.exp; done &&
+        test_cmp runtimeP_h.out runtimeP_h.exp &&
         flux jobs --suppress-header --state=running,inactive --format="{runtime}" > runtimeRI_1.out &&
         count=`cat runtimeRI_1.out | grep -v "^0.0$" | wc -l` &&
+        test $count -eq 12 &&
+        flux jobs --suppress-header --state=running,inactive --format="{runtime:h}" > runtimeRI_1_h.out &&
+        count=`cat runtimeRI_1_h.out | grep -v "^-$" | wc -l` &&
         test $count -eq 12 &&
         flux jobs --suppress-header --state=running,inactive --format="{runtime_fsd}" > runtimeRI_2.out &&
         count=`cat runtimeRI_2.out | grep -v "^0s" | wc -l` &&
         test $count -eq 12 &&
-        flux jobs --suppress-header --state=running,inactive --format="{runtime_fsd:h}" > runtimeRI_3.out &&
-        count=`cat runtimeRI_3.out | grep -v "^-$" | wc -l` &&
+        flux jobs --suppress-header --state=running,inactive --format="{runtime_fsd:h}" > runtimeRI_2_h.out &&
+        count=`cat runtimeRI_2_h.out | grep -v "^-$" | wc -l` &&
         test $count -eq 12 &&
-        flux jobs --suppress-header --state=running,inactive --format="{runtime_hms}" > runtimeRI_4.out &&
-        count=`cat runtimeRI_4.out | grep -v "^0:00:00" | wc -l` &&
+        flux jobs --suppress-header --state=running,inactive --format="{runtime_hms}" > runtimeRI_3.out &&
+        count=`cat runtimeRI_3.out | grep -v "^0:00:00$" | wc -l` &&
+        test $count -eq 12 &&
+        flux jobs --suppress-header --state=running,inactive --format="{runtime_hms:h}" > runtimeRI_3_h.out &&
+        count=`cat runtimeRI_3_h.out | grep -v "^-$" | wc -l` &&
         test $count -eq 12
 '
 


### PR DESCRIPTION
Per issue #2859, create a new conversion type to output a hyphen (`-`) instead of several special cases when data is not yet available (such as "0s" or an empty string).

This allows us to remove the `_hyphen` format specifiers throughout the code and tests, which began to explode in PR #2831 and #2858.

note to self: #2831 and #2858 will have to be adjusted