### PR TITLE
shell: make registered services secure by default

### DIFF
--- a/src/shell/input.c
+++ b/src/shell/input.c
@@ -167,8 +167,6 @@ static void shell_input_stdin_cb (flux_t *h,
     bool eof = false;
     json_t *o;
 
-    if (shell_svc_allowed (in->shell->svc, msg) < 0)
-        goto error;
     if (flux_request_unpack (msg, NULL, "o", &o) < 0)
         goto error;
     if (iodecode (o, NULL, NULL, NULL, NULL, &eof) < 0)

--- a/src/shell/output.c
+++ b/src/shell/output.c
@@ -403,8 +403,6 @@ static void shell_output_write_cb (flux_t *h,
     json_t *o;
     json_t *entry;
 
-    if (shell_svc_allowed (out->shell->svc, msg) < 0)
-        goto error;
     if (flux_request_unpack (msg, NULL, "o", &o) < 0)
         goto error;
     if (iodecode (o, NULL, NULL, NULL, NULL, &eof) < 0)


### PR DESCRIPTION
Wrap all message handlers registered with `flux_shell_service_register(3)` and check `shell_svc_allowed` before calling the real msg handler. This makes shell services accessible only to the shell user (and instance owner) by default, instead of having services "open to all" when first registered. This should greatly reduce the potential for accidental security vulnerabilities introduced by shell plugins.

If ever there is a need for a shell service that is open to all users, we can add a new shell.h API call which *explicitly* registers a multiuser accessible service.
