### PR TITLE
python: cache python wrappers in the class

### DIFF
--- a/src/bindings/python/flux/future.py
+++ b/src/bindings/python/flux/future.py
@@ -68,9 +68,11 @@ class Future(WrapperPimpl):
             func = super(Future.InnerWrapper, self).check_wrap(fun, name)
             return check_future_error(func)
 
-    def __init__(self, future_handle, prefixes=None):
+    def __init__(self, future_handle, prefixes=None, pimpl_t=None):
         super(Future, self).__init__()
-        self.pimpl = self.InnerWrapper(handle=future_handle, prefixes=prefixes)
+        if pimpl_t is None:
+            pimpl_t = self.InnerWrapper
+        self.pimpl = pimpl_t(handle=future_handle, prefixes=prefixes)
         self.then_cb = None
         self.then_arg = None
         self.cb_handle = None

--- a/src/bindings/python/flux/rpc.py
+++ b/src/bindings/python/flux/rpc.py
@@ -20,6 +20,9 @@ from flux.util import encode_payload, encode_topic
 class RPC(Future):
     """An RPC state object"""
 
+    class RPCInnerWrapper(Future.InnerWrapper):
+        pass
+
     def __init__(
         self,
         flux_handle,
@@ -37,7 +40,11 @@ class RPC(Future):
         payload = encode_payload(payload)
 
         future_handle = raw.flux_rpc(flux_handle, topic, payload, nodeid, flags)
-        super(RPC, self).__init__(future_handle, prefixes=["flux_rpc_", "flux_future_"])
+        super(RPC, self).__init__(
+            future_handle,
+            prefixes=["flux_rpc_", "flux_future_"],
+            pimpl_t=self.RPCInnerWrapper,
+        )
 
     def get_str(self):
         payload_str = ffi.new("char *[1]")


### PR DESCRIPTION
Rather than caching in the instance, this should remove dangling
reference issues like in #2671, and hopefully also be somewhat faster in
that the lookup happens once per *type* rather than once per *instance*.

I'm not sure where best to put this, but hopefully it will address some of the weakref issues.