### PR TITLE
support systemctl reload flux

### DIFF
--- a/etc/flux.service.in
+++ b/etc/flux.service.in
@@ -11,6 +11,7 @@ ExecStart=@X_BINDIR@/flux broker \
   -Slog-stderr-level=6 \
   -Scontent.backing-path=@X_LOCALSTATEDIR@/lib/flux/content.sqlite \
   -Sbroker.rc2_none
+ExecReload=@X_BINDIR@/flux config reload
 User=flux
 Group=flux
 RuntimeDirectory=flux

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -1600,7 +1600,6 @@ struct internal_service {
 static struct internal_service services[] = {
     { "cmb",                NULL }, // kind of a catch-all, slowly deprecating
     { "log",                NULL },
-    { "seq",                "[0]" },
     { "content",            NULL },
     { "hello",              NULL },
     { "attr",               NULL },

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -59,8 +59,8 @@
 #include "src/common/libutil/errno_safe.h"
 
 #include "heartbeat.h"
-#include "brokercfg.h"
 #include "module.h"
+#include "brokercfg.h"
 #include "overlay.h"
 #include "service.h"
 #include "hello.h"
@@ -395,7 +395,10 @@ int main (int argc, char *argv[])
 
     /* Parse config.
      */
-    if (!(ctx.config = brokercfg_create (ctx.h, ctx.config_path, ctx.attrs)))
+    if (!(ctx.config = brokercfg_create (ctx.h,
+                                         ctx.config_path,
+                                         ctx.attrs,
+                                         ctx.modhash)))
         goto cleanup;
     conf = flux_get_conf (ctx.h);
 
@@ -1606,6 +1609,7 @@ static struct internal_service services[] = {
     { "heaptrace",          NULL },
     { "event",              "[0]" },
     { "service",            NULL },
+    { "config",             NULL },
     { NULL, NULL, },
 };
 

--- a/src/broker/brokercfg.c
+++ b/src/broker/brokercfg.c
@@ -16,23 +16,31 @@
 #endif
 #include <flux/core.h>
 #include <jansson.h>
+#include <assert.h>
 
 #include "src/common/libutil/log.h"
 
 #include "attr.h"
+#include "module.h"
 #include "brokercfg.h"
 
 
 struct brokercfg {
     flux_t *h;
     char *path;
+    flux_msg_handler_t **handlers;
+    modhash_t *modhash;
+    flux_future_t *reload_f;
 };
 
 /* Parse config object from TOML config files if path is set;
  * otherwise, create an empty config object.  Store the object
  * in ctx->h for later access by flux_conf_get().
  */
-static int brokercfg_parse (flux_t *h, const char *path)
+static int brokercfg_parse (flux_t *h,
+                            const char *path,
+                            char *errbuf,
+                            int errbufsize)
 {
     flux_conf_error_t error;
     flux_conf_t *conf;
@@ -40,26 +48,30 @@ static int brokercfg_parse (flux_t *h, const char *path)
     if (path) {
         if (!(conf = flux_conf_parse (path, &error))) {
             if (error.lineno == -1)
-                log_msg ("Config file error: %s%s%s",
-                         error.filename,
-                         *error.filename ? ": " : "",
-                         error.errbuf);
+                (void)snprintf (errbuf,
+                                errbufsize,
+                                "Config file error: %s%s%s",
+                                error.filename,
+                                *error.filename ? ": " : "",
+                                error.errbuf);
             else
-                log_msg ("Config file error: %s:%d: %s",
-                         error.filename,
-                         error.lineno,
-                         error.errbuf);
+                (void)snprintf (errbuf,
+                                errbufsize,
+                                "Config file error: %s:%d: %s",
+                                error.filename,
+                                error.lineno,
+                                error.errbuf);
             return -1;
         }
     }
     else {
         if (!(conf = flux_conf_create ())) {
-            log_err ("Error creating config object");
+            (void)snprintf (errbuf, errbufsize, "Error creating config object");
             return -1;
         }
     }
     if (flux_set_conf (h, conf) < 0) {
-        log_err ("Error storing config object in flux_t handle");
+        (void)snprintf (errbuf, errbufsize, "Error caching config object");
         flux_conf_decref (conf);
         return -1;
     }
@@ -67,30 +79,180 @@ static int brokercfg_parse (flux_t *h, const char *path)
     return 0;
 }
 
+/* Now that all modules have responded to '<name>.config-reload' request,
+ * send a response to the original broker 'config.reload' request.  If errors
+ * occurred (other than ENOSYS), include as much diagnostic info as possible
+ * in the response.
+ */
+static void reload_continuation (flux_future_t *cf, void *arg)
+{
+    const flux_msg_t *msg = flux_future_aux_get (cf, "flux::request");
+    struct brokercfg *cfg = arg;
+    const char *name;
+    flux_future_t *f;
+    char errbuf[4096];
+    int errnum = 0;
+    size_t offset = 0;
+
+    name = flux_future_first_child (cf);
+    while (name) {
+        f = flux_future_get_child (cf, name);
+
+        if (flux_future_get (f, NULL) < 0 && errno != ENOSYS) {
+            if (errnum == 0)
+                errnum = errno;
+            (void)snprintf (errbuf + offset,
+                            sizeof (errbuf) - offset,
+                            "%s%s: %s",
+                            offset > 0 ? "\n" : "",
+                            name,
+                            flux_future_error_string (f));
+            offset = strlen (errbuf);
+        }
+        name = flux_future_next_child (cf);
+    }
+    if (errnum != 0)
+        goto error;
+
+    if (flux_respond (cfg->h, msg, NULL) < 0)
+        flux_log_error (cfg->h, "reload: flux_respond");
+    flux_log (cfg->h, LOG_INFO, "configuration reloaded");
+    flux_future_destroy (cfg->reload_f);
+    cfg->reload_f = NULL;
+    return;
+
+error:
+    if (flux_respond_error (cfg->h, msg, errnum, errbuf) < 0)
+        flux_log_error (cfg->h, "reload: flux_respond_error");
+    flux_future_destroy (cfg->reload_f);
+    cfg->reload_f = NULL;
+    flux_log (cfg->h, LOG_ERR, "config reload failed");
+}
+
+/* Send a '<name>.config-reload' request to all loaded modules.
+ * On success, return a composite future that is fulfilled once all modules
+ * have responded.  On failure, return NULL with errno set.
+ */
+static flux_future_t *reload_module_configs (flux_t *h, struct brokercfg *cfg)
+{
+    flux_future_t *cf;
+    module_t *module;
+    json_t *conf;
+
+    if (flux_conf_unpack (flux_get_conf (h), NULL, "o", &conf) < 0)
+        return NULL;
+    if (!(cf = flux_future_wait_all_create ()))
+        return NULL;
+    flux_future_set_flux (cf, h);
+    module = module_first (cfg->modhash);
+    while (module) {
+        flux_future_t *f;
+        char topic[1024];
+
+        if (snprintf (topic,
+                      sizeof (topic),
+                      "%s.config-reload",
+                      module_get_name (module)) >= sizeof (topic)) {
+            errno = EOVERFLOW;
+            goto error;
+        }
+        if (!(f = flux_rpc_pack (h, topic, FLUX_NODEID_ANY, 0, "O", conf)))
+            goto error;
+        if (flux_future_push (cf, module_get_name (module), f) < 0) {
+            flux_future_destroy (f);
+            goto error;
+        }
+        module = module_next (cfg->modhash);
+    }
+    return cf;
+error:
+    flux_future_destroy (cf);
+    return NULL;
+}
+
+/* Handle request to re-parse config object from TOML config files.
+ * If files fail to parse, generate an immediate error response.
+ * Otherwise, initiate reload of config in all loaded modules
+ */
+static void reload_cb (flux_t *h,
+                       flux_msg_handler_t *mh,
+                       const flux_msg_t *msg,
+                       void *arg)
+{
+    struct brokercfg *cfg = arg;
+    char errbuf[1024];
+    const char *errmsg = NULL;
+    flux_future_t *f;
+
+    if (cfg->reload_f) {
+        errmsg = "reload in progress";
+        errno = EBUSY;
+        goto error;
+    }
+    if (brokercfg_parse (h, cfg->path, errbuf, sizeof (errbuf)) < 0) {
+        errmsg = errbuf;
+        goto error;
+    }
+    if (!(f = reload_module_configs (h, cfg)))
+        goto error;
+    if (flux_future_aux_set (f,
+                             "flux::request",
+                             (void *)flux_msg_incref (msg),
+                             (flux_free_f)flux_msg_decref) < 0) {
+        flux_future_destroy (f);
+        goto error;
+    }
+    if (flux_future_then (f, -1., reload_continuation, cfg) < 0) {
+        flux_future_destroy (f);
+        goto error;
+    }
+    cfg->reload_f = f;
+    return;
+error:
+    if (flux_respond_error (h, msg, errno, errmsg) < 0)
+        flux_log_error (h, "reload: flux_respond_error");
+}
+
+static const struct flux_msg_handler_spec htab[] = {
+    { FLUX_MSGTYPE_REQUEST,  "config.reload", reload_cb, 0 },
+    FLUX_MSGHANDLER_TABLE_END,
+};
+
 void brokercfg_destroy (struct brokercfg *cfg)
 {
     if (cfg) {
         int saved_errno = errno;
+        flux_msg_handler_delvec (cfg->handlers);
+        flux_future_destroy (cfg->reload_f);
         free (cfg->path);
         free (cfg);
         errno = saved_errno;
     }
 }
 
-struct brokercfg *brokercfg_create (flux_t *h, const char *path, attr_t *attrs)
+struct brokercfg *brokercfg_create (flux_t *h,
+                                    const char *path,
+                                    attr_t *attrs,
+                                    modhash_t *modhash)
 {
     struct brokercfg *cfg;
+    char errbuf[1024];
 
     if (!(cfg = calloc (1, sizeof (*cfg))))
         return NULL;
     cfg->h = h;
+    cfg->modhash = modhash;
     if (!path)
         path = getenv ("FLUX_CONF_DIR");
     if (path) {
         if (!(cfg->path = strdup (path)))
             goto error;
     }
-    if (brokercfg_parse (h, path) < 0)
+    if (brokercfg_parse (h, path, errbuf, sizeof (errbuf)) < 0) {
+        log_msg ("%s", errbuf);
+        goto error;
+    }
+    if (flux_msg_handler_addvec (h, htab, cfg, &cfg->handlers) < 0)
         goto error;
     if (attr_add (attrs, "config.path", path, FLUX_ATTRFLAG_IMMUTABLE) < 0)
         goto error;

--- a/src/broker/brokercfg.h
+++ b/src/broker/brokercfg.h
@@ -13,7 +13,10 @@
 
 struct brokercfg;
 
-struct brokercfg *brokercfg_create (flux_t *h, const char *path, attr_t *attr);
+struct brokercfg *brokercfg_create (flux_t *h,
+                                    const char *path,
+                                    attr_t *attr,
+                                    modhash_t *modhash);
 void brokercfg_destroy (struct brokercfg *cfg);
 
 #endif /* !_BROKER_BROKERCFG_H */

--- a/src/broker/module.c
+++ b/src/broker/module.c
@@ -891,6 +891,16 @@ done:
     return rc;
 }
 
+module_t *module_first (modhash_t *mh)
+{
+    return zhash_first (mh->zh_byuuid);
+}
+
+module_t *module_next (modhash_t *mh)
+{
+    return zhash_next (mh->zh_byuuid);
+}
+
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab
  */

--- a/src/broker/module.h
+++ b/src/broker/module.h
@@ -111,6 +111,11 @@ void module_mute (module_t *p);
  */
 json_t *module_get_modlist (modhash_t *mh, struct service_switch *sw);
 
+/* Iterator
+ */
+module_t *module_first (modhash_t *mh);
+module_t *module_next (modhash_t *mh);
+
 #endif /* !_BROKER_MODULE_H */
 
 /*

--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -44,6 +44,7 @@ flux_SOURCES = \
 	cmdhelp.c \
 	builtin.h \
 	builtin/attr.c \
+	builtin/config.c \
 	builtin/help.c \
 	builtin/dmesg.c \
 	builtin/env.c \

--- a/src/cmd/builtin/config.c
+++ b/src/cmd/builtin/config.c
@@ -1,0 +1,69 @@
+/************************************************************\
+ * Copyright 2020 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#include "builtin.h"
+
+static int internal_config_reload (optparse_t *p, int ac, char *av[])
+{
+    flux_t *h;
+    flux_future_t *f = NULL;
+
+    if (optparse_option_index (p) != ac) {
+        optparse_print_usage (p);
+        exit (1);
+    }
+    if (!(h = builtin_get_flux_handle (p)))
+        log_err_exit ("flux_open");
+    if (!(f = flux_rpc (h, "config.reload", NULL, FLUX_NODEID_ANY, 0)))
+        log_err_exit ("error constructing config.reload RPC");
+    if (flux_future_get (f, NULL) < 0)
+        log_msg_exit ("reload: %s", flux_future_error_string (f));
+    flux_future_destroy (f);
+    flux_close (h);
+    return (0);
+}
+
+int cmd_config (optparse_t *p, int ac, char *av[])
+{
+    log_init ("flux-config");
+
+    if (optparse_run_subcommand (p, ac, av) != OPTPARSE_SUCCESS)
+        exit (1);
+    return (0);
+}
+
+static struct optparse_subcommand config_subcmds[] = {
+    { "reload",
+      "[OPTIONS]",
+      "Reload configuration from files",
+      internal_config_reload,
+      0,
+      NULL,
+    },
+    OPTPARSE_SUBCMD_END
+};
+
+int subcommand_config_register (optparse_t *p)
+{
+    optparse_err_t e;
+
+    e = optparse_reg_subcommand (p,
+            "config", cmd_config, NULL, "Manage configuration", 0, NULL);
+    if (e != OPTPARSE_SUCCESS)
+        return (-1);
+
+    e = optparse_reg_subcommands (optparse_get_subcommand (p, "config"),
+                                  config_subcmds);
+    return (e == OPTPARSE_SUCCESS ? 0 : -1);
+}
+
+/*
+ * vi: ts=4 sw=4 expandtab
+ */

--- a/src/common/libflux/conf.c
+++ b/src/common/libflux/conf.c
@@ -337,6 +337,29 @@ int flux_conf_unpack (const flux_conf_t *conf,
     return rc;
 }
 
+int flux_conf_reload_decode (const flux_msg_t *msg, const flux_conf_t **confp)
+{
+    const char *auxkey = "flux::conf";
+    json_t *o;
+    flux_conf_t *conf;
+
+    if (!(conf = flux_msg_aux_get (msg, auxkey))) {
+        if (flux_request_unpack (msg, NULL, "o", &o) < 0)
+            return -1;
+        if (!(conf = flux_conf_create ()))
+            return -1;
+        json_decref (conf->obj);
+        conf->obj = json_incref (o);
+        if (flux_msg_aux_set (msg, auxkey, (flux_conf_t *)conf, (flux_free_f)flux_conf_decref) < 0) {
+            flux_conf_decref (conf);
+            return -1;
+        }
+    }
+    if (confp)
+        *confp = conf;
+    return 0;
+}
+
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab
  */

--- a/src/common/libflux/conf.h
+++ b/src/common/libflux/conf.h
@@ -49,6 +49,11 @@ flux_conf_t *flux_conf_copy (const flux_conf_t *conf);
 const flux_conf_t *flux_conf_incref (const flux_conf_t *conf);
 void flux_conf_decref (const flux_conf_t *conf);
 
+/* Decode config-reload request, setting 'conf' to a config object
+ * owned by 'msg'.
+ */
+int flux_conf_reload_decode (const flux_msg_t *msg, const flux_conf_t **conf);
+
 /* Parse *.toml in 'path' directory.
  */
 flux_conf_t *flux_conf_parse (const char *path, flux_conf_error_t *error);


### PR DESCRIPTION
This PR implements a command `flux config reload` which synchronously reloads the TOML config (e.g. after a change on disk).  It is wired into the system unit file via `ExecReload=` so `systemctl reload flux` works.

The `flux config reload` command seds a `config.reload` RPC to the broker.  The broker responds by 1) re-parsing TOML config, and 2) sending a  `<name>.config-reload` RPC to each loaded module.  The module may optionally implement a handler for this if it is capable of handling config changes on the fly.  Once the modules respond, a response is sent back to the command.

The `connector-local` `[access]` config now implements this handler.

Error handling:
* If TOML parsing fails, a textual error is sent back to the command and the broker continues on with the existing config.
* If TOML parsing succeeds, but one or more modules reject the change, then textual error string(s) are sent back to the command.  The broker and any successfully updated modules use the new config, while rejecting modules _should_ continue to use the old one.

In that latter case, I originally planned to completely revert the config back to the original, but then I wondered if it was perhaps OK to have accepted the working part of the new config as long as `systemctl reload flux` fails?

Here's a demo that a broken TOML parse triggers `systemctl reload flux` failure:
```console
$ cat /usr/local/etc/flux/system/conf.d/access.toml
[access]
allow-guest-user = true
allow-root-owner = true
meep
$ sudo systemctl reload flux
Job for flux.service failed because the control process exited with error code.
See "systemctl status flux.service" and "journalctl -xe" for details.
$ journalctl -xe
[snip]
Mar 30 16:49:47 spark systemd[1]: Reloading Flux message broker.
-- Subject: Unit flux.service has begun reloading its configuration
-- Defined-By: systemd
-- Support: http://www.ubuntu.com/support
--
-- Unit flux.service has begun reloading its configuration
Mar 30 16:49:47 spark flux[773]: flux-config: reload: Config file error: /usr/local/etc/flux/system/conf.d/access.toml:4: missing =
Mar 30 16:49:47 spark systemd[1]: flux.service: Control process exited, code=exited status=1
Mar 30 16:49:47 spark systemd[1]: Reload failed for Flux message broker.
-- Subject: Unit flux.service has finished reloading its configuration
-- Defined-By: systemd
-- Support: http://www.ubuntu.com/support
--
-- Unit flux.service has finished reloading its configuration
--
-- The result is RESULT.
```
Here's a demo of the second error case.  One of the `[access]` keys is misspelled, so `connector-local` catches the error.
```console
$ cat /usr/local/etc/flux/system/conf.d/access.toml
[access]
allow-guest-user = true
allow-roooooooooot-owner = true
$ sudo flux config reload
flux-config: reload: connector-local: error parsing [access] configuration: 1 object item(s) left unpacked: allow-roooooooooot-owner
$ echo $?
1
```

WIP because no tests yet and wanted to get feedback on handling of the second error case.