### PR TITLE
job-archive support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -499,6 +499,7 @@ AC_CONFIG_FILES( \
   src/modules/job-manager/Makefile \
   src/modules/job-info/Makefile \
   src/modules/job-exec/Makefile \
+  src/modules/job-archive/Makefile \
   src/modules/sched-simple/Makefile \
   src/test/Makefile \
   etc/Makefile \

--- a/src/modules/Makefile.am
+++ b/src/modules/Makefile.am
@@ -11,4 +11,5 @@ SUBDIRS = \
  job-manager \
  job-info \
  job-exec \
+ job-archive \
  sched-simple

--- a/src/modules/job-archive/Makefile.am
+++ b/src/modules/job-archive/Makefile.am
@@ -1,0 +1,26 @@
+AM_CFLAGS = \
+	$(WARNING_CFLAGS) \
+	$(CODE_COVERAGE_CFLAGS)
+
+AM_LDFLAGS = \
+	$(CODE_COVERAGE_LIBS)
+
+AM_CPPFLAGS = \
+	-I$(top_srcdir) \
+	-I$(top_srcdir)/src/include \
+	-I$(top_builddir)/src/common/libflux \
+	$(ZMQ_CFLAGS) $(SQLITE_CFLAGS) \
+	$(FLUX_SECURITY_CFLAGS) $(YAMLCPP_CFLAGS)
+
+fluxmod_LTLIBRARIES = job-archive.la
+
+job_archive_la_SOURCES = \
+	job-archive.c
+
+job_archive_la_LDFLAGS = $(fluxmod_ldflags) -module
+job_archive_la_LIBADD = $(fluxmod_libadd) \
+	$(top_builddir)/src/common/libjob/libjob.la \
+	$(top_builddir)/src/common/libflux-internal.la \
+	$(top_builddir)/src/common/libflux-core.la \
+	$(top_builddir)/src/common/libflux-optparse.la \
+	$(SQLITE_LIBS) $(ZMQ_LIBS)

--- a/src/modules/job-archive/job-archive.c
+++ b/src/modules/job-archive/job-archive.c
@@ -1,0 +1,601 @@
+/************************************************************\
+ * Copyright 2016 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* job-archive: archive job data service for flux */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdio.h>
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <unistd.h>
+#include <stdbool.h>
+#include <flux/core.h>
+#include <czmq.h>
+#include <sodium.h>
+#include <jansson.h>
+#include <sqlite3.h>
+
+#include "src/common/libutil/log.h"
+#include "src/common/libutil/fsd.h"
+
+#define PERIOD_DEFAULT       60.0
+#define BUSY_TIMEOUT_DEFAULT 50
+#define BUFSIZE              1024
+
+const char *sql_create_table = "CREATE TABLE if not exists jobs("
+                               "  id CHAR(16) PRIMARY KEY,"
+                               "  userid INT,"
+                               "  ranks TEXT,"
+                               "  t_submit REAL,"
+                               "  t_sched REAL,"
+                               "  t_run REAL,"
+                               "  t_cleanup REAL,"
+                               "  t_inactive REAL,"
+                               "  eventlog TEXT,"
+                               "  jobspec TEXT,"
+                               "  R TEXT"
+    ");";
+
+const char *sql_store =                               \
+    "INSERT INTO jobs"                                \
+    "("                                               \
+    "  id,userid,ranks,"                              \
+    "  t_submit,t_sched,t_run,t_cleanup,t_inactive,"  \
+    "  eventlog,jobspec,R"                            \
+    ") values ("                                      \
+    "  ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11"  \
+    ")";
+
+const char *sql_since = "SELECT MAX(t_inactive) FROM jobs;";
+
+struct job_archive_ctx {
+    flux_t *h;
+    char *dbpath;
+    double period;
+    unsigned int busy_timeout;
+    flux_watcher_t *w;
+    sqlite3 *db;
+    sqlite3_stmt *store_stmt;
+    double since;
+    int kvs_lookup_count;
+};
+
+static void log_sqlite_error (struct job_archive_ctx *ctx, const char *fmt, ...)
+{
+    char buf[128];
+    va_list ap;
+
+    va_start (ap, fmt);
+    (void)vsnprintf (buf, sizeof (buf), fmt, ap);
+    va_end (ap);
+
+    if (ctx->db) {
+        const char *errmsg = sqlite3_errmsg (ctx->db);
+        flux_log (ctx->h,
+                  LOG_ERR,
+                  "%s: %s(%d)",
+                  buf,
+                  errmsg ? errmsg : "unknown error code",
+                  sqlite3_extended_errcode (ctx->db));
+    }
+    else
+        flux_log (ctx->h, LOG_ERR, "%s: unknown error, no sqlite3 handle", buf);
+}
+
+static void job_archive_ctx_destroy (struct job_archive_ctx *ctx)
+{
+    if (ctx) {
+        free (ctx->dbpath);
+        flux_watcher_destroy (ctx->w);
+        if (ctx->store_stmt) {
+            if (sqlite3_finalize (ctx->store_stmt) != SQLITE_OK)
+                log_sqlite_error (ctx, "sqlite_finalize store_stmt");
+        }
+        if (ctx->db) {
+            if (sqlite3_close (ctx->db) != SQLITE_OK)
+                log_sqlite_error (ctx, "sqlite3_close");
+        }
+        free (ctx);
+    }
+}
+
+static struct job_archive_ctx * job_archive_ctx_create (flux_t *h)
+{
+    struct job_archive_ctx *ctx = calloc (1, sizeof (*ctx));
+
+    if (!ctx) {
+        flux_log_error (h, "job_archive_ctx_create");
+        goto error;
+    }
+
+    ctx->h = h;
+    ctx->period = PERIOD_DEFAULT;
+    ctx->busy_timeout = BUSY_TIMEOUT_DEFAULT;
+
+    return ctx;
+ error:
+    job_archive_ctx_destroy (ctx);
+    return (NULL);
+}
+
+int since_cb (void *arg, int argc, char **argv, char **colname)
+{
+    struct job_archive_ctx *ctx = arg;
+    char *endptr;
+    double tmp;
+
+    if (argv[0] == NULL)
+        return 0;
+
+    errno = 0;
+    tmp = strtod (argv[0], &endptr);
+    if (errno || *endptr != '\0') {
+        flux_log_error (ctx->h, "%s: invalid t_inactive", __FUNCTION__);
+        return -1;
+    }
+    if (tmp > ctx->since)
+        ctx->since = tmp;
+    return 0;
+}
+
+int job_archive_since_init (struct job_archive_ctx *ctx)
+{
+    char *errmsg = NULL;
+
+    if (sqlite3_exec (ctx->db,
+                      sql_since,
+                      since_cb,
+                      ctx,
+                      &errmsg) != SQLITE_OK) {
+        log_sqlite_error (ctx, "%s: getting max since value: %s",
+                          __FUNCTION__, errmsg);
+        return -1;
+    }
+
+    return 0;
+}
+
+int job_archive_init (struct job_archive_ctx *ctx)
+{
+    int flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE;
+    char buf[1024];
+    int rc = -1;
+
+    if (sqlite3_open_v2 (ctx->dbpath, &ctx->db, flags, NULL) != SQLITE_OK) {
+        log_sqlite_error (ctx, "opening %s", ctx->dbpath);
+        goto error;
+    }
+
+    if (sqlite3_exec (ctx->db,
+                      "PRAGMA journal_mode=OFF",
+                      NULL,
+                      NULL,
+                      NULL) != SQLITE_OK) {
+        log_sqlite_error (ctx, "setting sqlite 'journal_mode' pragma");
+        goto error;
+    }
+    if (sqlite3_exec (ctx->db,
+                      "PRAGMA synchronous=OFF",
+                      NULL,
+                      NULL,
+                      NULL) != SQLITE_OK) {
+        log_sqlite_error (ctx, "setting sqlite 'synchronous' pragma");
+        goto error;
+    }
+    snprintf (buf, 1024, "PRAGMA busy_timeout=%u;", ctx->busy_timeout);
+    if (sqlite3_exec (ctx->db,
+                      buf,
+                      NULL,
+                      NULL,
+                      NULL) != SQLITE_OK) {
+        log_sqlite_error (ctx, "setting sqlite 'busy_timeout' pragma");
+        goto error;
+    }
+    if (sqlite3_exec (ctx->db,
+                      sql_create_table,
+                      NULL,
+                      NULL,
+                      NULL) != SQLITE_OK) {
+        log_sqlite_error (ctx, "creating object table");
+        goto error;
+    }
+
+    if (sqlite3_prepare_v2 (ctx->db,
+                            sql_store,
+                            -1,
+                            &ctx->store_stmt,
+                            NULL) != SQLITE_OK) {
+        log_sqlite_error (ctx, "preparing store stmt");
+        goto error;
+    }
+
+    if (job_archive_since_init (ctx) < 0)
+        goto error;
+
+    rc = 0;
+error:
+    return rc;
+}
+
+int append_key (struct job_archive_ctx *ctx, json_t *keys, const char *key)
+{
+    json_t *s = NULL;
+    int rc = -1;
+
+    if (!(s = json_string (key))) {
+        flux_log_error (ctx->h, "%s: json_string", __FUNCTION__);
+        goto error;
+    }
+    if (json_array_append_new (keys, s) < 0) {
+        flux_log_error (ctx->h, "%s: json_array_append_new", __FUNCTION__);
+        goto error;
+    }
+    return 0;
+error:
+    json_decref (s);
+    return rc;
+}
+
+void json_decref_wrapper (void *arg)
+{
+    json_decref ((json_t *)arg);
+}
+
+void job_info_lookup_continuation (flux_future_t *f, void *arg)
+{
+    struct job_archive_ctx *ctx = arg;
+    json_t *job;
+    flux_jobid_t id;
+    uint32_t userid;
+    const char *ranks = NULL;
+    double t_submit = 0.0;
+    double t_sched = 0.0;
+    double t_run = 0.0;
+    double t_cleanup = 0.0;
+    double t_inactive = 0.0;
+    const char *eventlog = NULL;
+    const char *jobspec = NULL;
+    const char *R = NULL;
+    char idbuf[64];
+
+    if (flux_rpc_get_unpack (f, "{s:s s:s s?:s}",
+                             "eventlog", &eventlog,
+                             "jobspec", &jobspec,
+                             "R", &R) < 0) {
+        flux_log_error (ctx->h, "%s: flux_rpc_get_unpack", __FUNCTION__);
+        goto out;
+    }
+
+    if (!(job = flux_future_aux_get (f, "job"))) {
+        flux_log_error (ctx->h, "%s: flux_future_aux_get", __FUNCTION__);
+        goto out;
+    }
+
+    if (json_unpack (job, "{s:I s:i s?:s s:f s?:f s?:f s?:f s:f}",
+                     "id", &id,
+                     "userid", &userid,
+                     "ranks", &ranks,
+                     "t_submit", &t_submit,
+                     "t_sched", &t_sched,
+                     "t_run", &t_run,
+                     "t_cleanup", &t_cleanup,
+                     "t_inactive", &t_inactive) < 0) {
+        flux_log (ctx->h, LOG_ERR, "%s: parse job", __FUNCTION__);
+        goto out;
+    }
+
+    snprintf (idbuf, 64, "%llu", (unsigned long long)id);
+    if (sqlite3_bind_text (ctx->store_stmt,
+                           1,
+                           idbuf,
+                           strlen (idbuf),
+                           SQLITE_STATIC) != SQLITE_OK) {
+        log_sqlite_error (ctx, "store: binding id");
+        goto out;
+    }
+    if (sqlite3_bind_int (ctx->store_stmt,
+                          2,
+                          userid) != SQLITE_OK) {
+        log_sqlite_error (ctx, "store: binding userid");
+        goto out;
+    }
+    if (sqlite3_bind_text (ctx->store_stmt,
+                           3,
+                           ranks ? ranks: "",
+                           ranks ? strlen (ranks) : 0,
+                           SQLITE_STATIC) != SQLITE_OK) {
+        log_sqlite_error (ctx, "store: binding ranks");
+        goto out;
+    }
+    if (sqlite3_bind_double (ctx->store_stmt,
+                             4,
+                             t_submit) != SQLITE_OK) {
+        log_sqlite_error (ctx, "store: binding t_submit");
+        goto out;
+    }
+    if (sqlite3_bind_double (ctx->store_stmt,
+                             5,
+                             t_sched) != SQLITE_OK) {
+        log_sqlite_error (ctx, "store: binding t_sched");
+        goto out;
+    }
+    if (sqlite3_bind_double (ctx->store_stmt,
+                             6,
+                             t_run) != SQLITE_OK) {
+        log_sqlite_error (ctx, "store: binding t_run");
+        goto out;
+    }
+    if (sqlite3_bind_double (ctx->store_stmt,
+                             7,
+                             t_cleanup) != SQLITE_OK) {
+        log_sqlite_error (ctx, "store: binding t_cleanup");
+        goto out;
+    }
+    if (sqlite3_bind_double (ctx->store_stmt,
+                             8,
+                             t_inactive) != SQLITE_OK) {
+        log_sqlite_error (ctx, "store: binding t_inactive");
+        goto out;
+    }
+    if (sqlite3_bind_text (ctx->store_stmt,
+                           9,
+                           eventlog,
+                           strlen (eventlog),
+                           SQLITE_STATIC) != SQLITE_OK) {
+        log_sqlite_error (ctx, "store: binding eventlog");
+        goto out;
+    }
+    if (sqlite3_bind_text (ctx->store_stmt,
+                           10,
+                           jobspec,
+                           strlen (jobspec),
+                           SQLITE_STATIC) != SQLITE_OK) {
+        log_sqlite_error (ctx, "store: binding jobspec");
+        goto out;
+    }
+    if (sqlite3_bind_text (ctx->store_stmt,
+                           11,
+                           R ? R: "",
+                           R ? strlen (R) : 0,
+                           SQLITE_STATIC) != SQLITE_OK) {
+        log_sqlite_error (ctx, "store: binding R");
+        goto out;
+    }
+    while (sqlite3_step (ctx->store_stmt) != SQLITE_DONE) {
+        /* due to rounding errors in sqlite, duplicate entries could be
+         * written out on occassion leading to a SQLITE_CONSTRAINT error.
+         * We accept this and move on.
+         */
+        int err = sqlite3_errcode (ctx->db);
+        if (err == SQLITE_CONSTRAINT)
+            break;
+        else if (err == SQLITE_BUSY) {
+            /* In the rare case this cannot complete within the normal
+             * busytimeout, we elect to spin till it completes.  This
+             * may need to be revisited in the future: */
+            flux_log (ctx->h, LOG_DEBUG, "%s: BUSY", __FUNCTION__);
+            usleep (1000);
+            continue;
+        }
+        else {
+            log_sqlite_error (ctx, "store: executing stmt");
+            goto out;
+        }
+    }
+
+    if (t_inactive > ctx->since)
+        ctx->since = t_inactive;
+
+out:
+    sqlite3_reset (ctx->store_stmt);
+    flux_future_destroy (f);
+    if (ctx->kvs_lookup_count
+        && (--(ctx->kvs_lookup_count)) == 0) {
+        flux_timer_watcher_reset (ctx->w, ctx->period, 0.);
+        flux_watcher_start (ctx->w);
+    }
+}
+
+int job_info_lookup (struct job_archive_ctx *ctx, json_t *job)
+{
+    const char *topic = "job-info.lookup";
+    flux_future_t *f = NULL;
+    flux_jobid_t id;
+    json_t *keys = NULL;
+    double t_run = 0.0;
+
+    if (json_unpack (job, "{s:I s?:f}", "id", &id, "t_run", &t_run) < 0) {
+        flux_log (ctx->h, LOG_ERR, "%s: parse t_inactive", __FUNCTION__);
+        goto error;
+    }
+
+    if (!(keys = json_array ())) {
+        flux_log_error (ctx->h, "%s: json_array", __FUNCTION__);
+        goto error;
+    }
+    if (append_key (ctx, keys, "eventlog") < 0)
+        goto error;
+    if (append_key (ctx, keys, "jobspec") < 0)
+        goto error;
+    if (t_run > 0.0) {
+        if (append_key (ctx, keys, "R") < 0)
+            goto error;
+    }
+
+    if (!(f = flux_rpc_pack (ctx->h, topic, FLUX_NODEID_ANY, 0,
+                             "{s:I s:O s:i}",
+                             "id", id,
+                             "keys", keys,
+                             "flags", 0))) {
+        flux_log_error (ctx->h, "%s: flux_rpc_pack", __FUNCTION__);
+        goto error;
+    }
+    if (flux_future_then (f,
+                          -1.,
+                          job_info_lookup_continuation,
+                          ctx) < 0) {
+        flux_log_error (ctx->h, "%s: flux_future_then", __FUNCTION__);
+        goto error;
+    }
+    if (flux_future_aux_set (f,
+                             "job",
+                             json_incref (job),
+                             json_decref_wrapper) < 0) {
+        flux_log_error (ctx->h, "%s: flux_future_aux_set", __FUNCTION__);
+        goto error;
+    }
+
+    json_decref (keys);
+    ctx->kvs_lookup_count++;
+    return 0;
+
+error:
+    flux_future_destroy (f);
+    json_decref (keys);
+    return -1;
+}
+
+void job_list_inactive_continuation (flux_future_t *f, void *arg)
+{
+    struct job_archive_ctx *ctx = arg;
+    json_t *jobs;
+    size_t index;
+    json_t *value;
+
+    if (flux_rpc_get_unpack (f, "{s:o}", "jobs", &jobs) < 0) {
+        flux_log_error (ctx->h, "%s: flux_rpc_get_unpack", __FUNCTION__);
+        return;
+    }
+    json_array_foreach (jobs, index, value) {
+        if (job_info_lookup (ctx, value) < 0)
+            break;
+    }
+    /* If no new inactive jobs, still need to reset timer */
+    if (!ctx->kvs_lookup_count) {
+        flux_timer_watcher_reset (ctx->w, ctx->period, 0.);
+        flux_watcher_start (ctx->w);
+    }
+    flux_future_destroy (f);
+}
+
+void job_archive_cb (flux_reactor_t *r,
+                     flux_watcher_t *w,
+                     int revents,
+                     void *arg)
+{
+    struct job_archive_ctx *ctx = arg;
+    char *attrs = "[\"userid\", \"ranks\", \"t_submit\", \"t_sched\", " \
+                   "\"t_run\", \"t_cleanup\", \"t_inactive\"]";
+    flux_future_t *f;
+
+    if (!(f = flux_job_list_inactive (ctx->h, 0, ctx->since, attrs))) {
+        flux_log_error (ctx->h, "%s: flux_job_list_inactive", __FUNCTION__);
+        return;
+    }
+    if (flux_future_then (f, -1, job_list_inactive_continuation, ctx) < 0) {
+        flux_log_error (ctx->h, "%s: flux_future_then", __FUNCTION__);
+        return;
+    }
+}
+
+static void process_config (struct job_archive_ctx *ctx, int ac, char **av)
+{
+    flux_conf_error_t err;
+    const char *dbpath = NULL;
+    const char *period = NULL;
+    const char *busytimeout = NULL;
+    int i;
+
+    if (flux_conf_unpack (flux_get_conf (ctx->h),
+                          &err,
+                          "{s?{s?s s?s s?s}}",
+                          "archive",
+                            "dbpath", &dbpath,
+                            "period", &period,
+                            "busytimeout", &busytimeout) < 0) {
+        flux_log (ctx->h, LOG_ERR,
+                  "error reading archive config: %s",
+                  err.errbuf);
+        return;
+    }
+
+    /* module params override config file */
+    for (i = 0; i < ac; i++) {
+        if (strncmp (av[i], "dbpath=", 7) == 0)
+            dbpath = (av[i])+7;
+        else if (strncmp (av[i], "period=", 7) == 0)
+            period = (av[i])+7;
+        else if (strncmp (av[i], "busytimeout=", 12) == 0)
+            busytimeout = (av[i])+12;
+        else
+            flux_log (ctx->h, LOG_ERR, "Unknown option `%s'", av[i]);
+    }
+
+    if (dbpath) {
+        if (!(ctx->dbpath = strdup (dbpath)))
+            flux_log_error (ctx->h, "dbpath not configured");
+    }
+    if (period) {
+        if (fsd_parse_duration (period, &ctx->period) < 0)
+            flux_log_error (ctx->h, "period not configured");
+    }
+    if (busytimeout) {
+        double tmp;
+        if (fsd_parse_duration (busytimeout, &tmp) < 0)
+            flux_log_error (ctx->h, "busytimeout not configured");
+        else
+            ctx->busy_timeout = (int)(1000 * tmp);
+    }
+}
+
+int mod_main (flux_t *h, int ac, char **av)
+{
+    struct job_archive_ctx *ctx = job_archive_ctx_create (h);
+    int rc = -1;
+
+    if (!ctx)
+        return -1;
+
+    process_config (ctx, ac, av);
+
+    /* we do nothing if no dbpath specified */
+    if (ctx->dbpath) {
+        if (job_archive_init (ctx) < 0)
+            goto done;
+
+        if ((ctx->w = flux_timer_watcher_create (flux_get_reactor (h),
+                                                 ctx->period,
+                                                 0.,
+                                                 job_archive_cb,
+                                                 ctx)) < 0) {
+            flux_log_error (h, "flux_timer_watcher_create");
+            goto done;
+        }
+
+        flux_watcher_start (ctx->w);
+    }
+
+    if ((rc = flux_reactor_run (flux_get_reactor (h), 0)) < 0)
+        flux_log_error (h, "flux_reactor_run");
+
+done:
+    job_archive_ctx_destroy (ctx);
+    return rc;
+}
+
+MOD_NAME ("job-archive");
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -105,6 +105,7 @@ TESTSCRIPTS = \
 	t2207-job-manager-wait.t \
 	t2208-queue-cmd.t \
 	t2210-job-manager-bugs.t \
+	t2220-job-archive.t \
 	t2300-sched-simple.t \
 	t2301-schedutil-outstanding-requests.t \
 	t2400-job-exec-test.t \
@@ -216,6 +217,7 @@ dist_check_SCRIPTS = \
 	job-exec/dummy.sh \
 	job-exec/imp.sh \
 	job-info/list-id.py \
+	job-archive/query.py \
 	schedutil/req_and_unload.py \
 	ingest/fake-validate.sh \
 	ingest/bad-validate.sh

--- a/t/job-archive/query.py
+++ b/t/job-archive/query.py
@@ -1,0 +1,58 @@
+###############################################################
+# Copyright 2019 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+# Query a job-archive db for testing purposes
+
+# Usage: flux python query.py [OPTIONS] dbpath query
+
+import sys
+import argparse
+import sqlite3
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-t", "--timeout", type=str, metavar="MS", help="Set busytimeout"
+    )
+    parser.add_argument(
+        "dbpath", type=str, metavar="DBPATH", nargs=1, help="database path"
+    )
+    parser.add_argument("query", type=str, metavar="QUERY", nargs=1, help="query")
+    args = parser.parse_args()
+
+    try:
+        dburi = "file:" + args.dbpath[0] + "?mode=ro"
+        con = sqlite3.connect(dburi, uri=True)
+    except sqlite3.Error as e:
+        print(e)
+        sys.exit(1)
+
+    if args.timeout:
+        con.execute("PRAGMA busy_wait = " + args.timeout)
+
+    con.row_factory = sqlite3.Row
+    cursor = con.cursor()
+
+    try:
+        cursor.execute(args.query[0])
+    except sqlite3.Error as e:
+        print(e)
+        sys.exit(1)
+
+    rows = cursor.fetchall()
+
+    for row in rows:
+        for key in row.keys():
+            print(key + " = " + str(row[key]))
+
+    con.close()
+    sys.exit(0)
+
+# vim: tabstop=4 shiftwidth=4 expandtab

--- a/t/t2220-job-archive.t
+++ b/t/t2220-job-archive.t
@@ -1,0 +1,273 @@
+#!/bin/sh
+
+test_description='Tests for job-archive'
+
+. $(dirname $0)/sharness.sh
+
+export FLUX_CONF_DIR=$(pwd)
+test_under_flux 4 job
+
+ARCHIVEDIR=`pwd`
+ARCHIVEDB="${ARCHIVEDIR}/jobarchive.db"
+
+QUERYCMD="flux python ${FLUX_SOURCE_DIR}/t/job-archive/query.py"
+
+fj_wait_event() {
+  flux job wait-event --timeout=20 "$@"
+}
+
+wait_jobid_state() {
+        local jobid=$1
+        local state=$2
+        local i=0
+        while ! flux job list --states=${state} | grep $jobid > /dev/null \
+               && [ $i -lt 50 ]
+        do
+                sleep 0.1
+                i=$((i + 1))
+        done
+        if [ "$i" -eq "50" ]
+        then
+            return 1
+        fi
+        return 0
+}
+
+wait_db() {
+        local jobid=$1
+        local dbpath=$2
+        local i=0
+        query="select id from jobs;"
+        while ! ${QUERYCMD} -t 100 ${dbpath} "${query}" | grep $jobid > /dev/null \
+               && [ $i -lt 50 ]
+        do
+                sleep 0.1
+                i=$((i + 1))
+        done
+        if [ "$i" -eq "50" ]
+        then
+            return 1
+        fi
+        return 0
+}
+
+db_count_entries() {
+        local dbpath=$1
+        query="select id from jobs;"
+        count=`${QUERYCMD} -t 10000 ${dbpath} "${query}" | grep "^id =" | wc -l`
+        echo $count
+}
+
+db_check_entries() {
+        local id=$1
+        local dbpath=$2
+        query="select * from jobs where id=$id;"
+        ${QUERYCMD} -t 10000 ${dbpath} "${query}" > query.out
+        if grep -q "^id = " query.out \
+            && grep -q "userid = " query.out \
+            && grep -q "ranks = " query.out \
+            && grep -q "t_submit = " query.out \
+            && grep -q "t_sched = " query.out \
+            && grep -q "t_run = " query.out \
+            && grep -q "t_cleanup = " query.out \
+            && grep -q "t_inactive = " query.out \
+            && grep -q "eventlog = " query.out \
+            && grep -q "jobspec = " query.out \
+            && grep -q "R = " query.out
+        then
+            return 0
+        fi
+        return 1
+}
+
+get_db_values() {
+        local id=$1
+        local dbpath=$2
+        query="select * from jobs where id=$id;"
+        ${QUERYCMD} -t 10000 ${dbpath} "${query}" > query.out
+        userid=`grep "userid = " query.out | awk '{print \$3}'`
+        ranks=`grep "ranks = " query.out | awk '{print \$3}'`
+        t_submit=`grep "t_submit = " query.out | awk '{print \$3}'`
+        t_sched=`grep "t_sched = " query.out | awk '{print \$3}'`
+        t_run=`grep "t_run = " query.out | awk '{print \$3}'`
+        t_cleanup=`grep "t_cleanup = " query.out | awk '{print \$3}'`
+        t_inactive=`grep "t_inactive = " query.out | awk '{print \$3}'`
+        eventlog=`grep "eventlog = " query.out | awk '{print \$3}'`
+        jobspec=`grep "jobspec = " query.out | awk '{print \$3}'`
+        R=`grep "R = " query.out | awk '{print \$3}'`
+}
+
+db_check_values_run() {
+        local id=$1
+        local dbpath=$2
+        get_db_values $id $dbpath
+        if [ -z "$userid" ] \
+            || [ -z "$ranks" ] \
+            || [ "$t_submit" == "0.0" ] \
+            || [ "$t_sched" == "0.0" ] \
+            || [ "$t_run" == "0.0" ] \
+            || [ "$t_cleanup" == "0.0" ] \
+            || [ "$t_inactive" == "0.0" ] \
+            || [ -z "$eventlog" ] \
+            || [ -z "$jobspec" ] \
+            || [ -z "$R" ]
+        then
+            return 1
+        fi
+        return 0
+}
+
+db_check_values_no_run() {
+        local id=$1
+        local dbpath=$2
+        get_db_values $id $dbpath
+        if [ -z "$userid" ] \
+            || [ -n "$ranks" ] \
+            || [ "$t_submit" == "0.0" ] \
+            || [ "$t_sched" == "0.0" ] \
+            || [ "$t_run" != "0.0" ] \
+            || [ "$t_cleanup" == "0.0" ] \
+            || [ "$t_inactive" == "0.0" ] \
+            || [ -z "$eventlog" ] \
+            || [ -z "$jobspec" ] \
+            || [ -n "$R" ]
+        then
+            return 1
+        fi
+        return 0
+}
+
+test_expect_success 'job-archive: load module without specifying dbpath, should work' '
+        flux module load job-archive
+'
+
+test_expect_success 'job-archive: unload module' '
+        flux module unload job-archive
+'
+
+test_expect_success 'job-archive: setup config file' '
+        cat >archive.toml <<EOF &&
+[archive]
+dbpath = "${ARCHIVEDB}"
+period = "0.5s"
+busytimeout = "0.1s"
+EOF
+	flux config reload
+'
+
+test_expect_success 'job-archive: load module' '
+        flux module load job-archive
+'
+
+test_expect_success 'job-archive: stores inactive job info (job good)' '
+        jobid=`flux mini submit hostname` &&
+        fj_wait_event $jobid clean &&
+        wait_jobid_state $jobid inactive &&
+        wait_db $jobid ${ARCHIVEDB} &&
+        db_check_entries $jobid ${ARCHIVEDB} &&
+        db_check_values_run $jobid ${ARCHIVEDB}
+'
+
+test_expect_success 'job-archive: stores inactive job info (job fail)' '
+        jobid=`flux mini submit nosuchcommand` &&
+        fj_wait_event $jobid clean &&
+        wait_jobid_state $jobid inactive &&
+        wait_db $jobid ${ARCHIVEDB} &&
+        db_check_entries $jobid ${ARCHIVEDB} &&
+        db_check_values_run $jobid ${ARCHIVEDB}
+'
+
+# to ensure job canceled before we run, we submit a job to eat up all
+# resources first.
+test_expect_success 'job-archive: stores inactive job info (job cancel)' '
+        jobid1=`flux mini submit -N4 -n8 sleep 500` &&
+        fj_wait_event $jobid1 start &&
+        jobid2=`flux mini submit hostname` &&
+        fj_wait_event $jobid2 submit &&
+        flux job cancel $jobid2 &&
+        fj_wait_event $jobid2 clean &&
+        flux job cancel $jobid1 &&
+        fj_wait_event $jobid1 clean &&
+        wait_jobid_state $jobid2 inactive &&
+        wait_db $jobid2 ${ARCHIVEDB} &&
+        db_check_entries $jobid2 ${ARCHIVEDB} &&
+        db_check_values_no_run $jobid2 ${ARCHIVEDB}
+'
+
+test_expect_success 'job-archive: stores inactive job info (resources)' '
+        jobid=`flux mini submit -N1000 -n1000 hostname` &&
+        fj_wait_event $jobid clean &&
+        wait_jobid_state $jobid inactive &&
+        wait_db $jobid ${ARCHIVEDB} &&
+        db_check_entries $jobid ${ARCHIVEDB} &&
+        db_check_values_no_run $jobid ${ARCHIVEDB}
+'
+
+test_expect_success 'job-archive: all jobs stored' '
+        count=`db_count_entries ${ARCHIVEDB}` &&
+        test $count -eq 5
+'
+
+test_expect_success 'job-archive: reload module' '
+        flux module reload job-archive
+'
+
+test_expect_success 'job-archive: doesnt restore old data' '
+        count=`db_count_entries ${ARCHIVEDB}` &&
+        test $count -eq 5
+'
+
+test_expect_success 'job-archive: stores more inactive job info' '
+        jobid1=`flux mini submit hostname` &&
+        jobid2=`flux mini submit hostname` &&
+        fj_wait_event $jobid1 clean &&
+        fj_wait_event $jobid2 clean &&
+        wait_jobid_state $jobid1 inactive &&
+        wait_jobid_state $jobid2 inactive &&
+        wait_db $jobid1 ${ARCHIVEDB} &&
+        wait_db $jobid2 ${ARCHIVEDB} &&
+        db_check_entries $jobid1 ${ARCHIVEDB} &&
+        db_check_entries $jobid2 ${ARCHIVEDB} &&
+        db_check_values_run $jobid1 ${ARCHIVEDB} &&
+        db_check_values_run $jobid2 ${ARCHIVEDB}
+'
+
+test_expect_success 'job-archive: all jobs stored' '
+        count=`db_count_entries ${ARCHIVEDB}` &&
+        test $count -eq 7
+'
+
+test_expect_success 'job-archive: unload module' '
+        flux module unload job-archive
+'
+
+test_expect_success 'job-archive: db exists after module unloaded' '
+        count=`db_count_entries ${ARCHIVEDB}` &&
+        test $count -eq 7
+'
+
+test_expect_success 'job-archive: load module, params override config' '
+        flux module load job-archive dbpath=${ARCHIVEDB}-NEW
+'
+
+test_expect_success 'job-archive: store inactive job info in new db' '
+        jobid=`flux mini submit hostname` &&
+        fj_wait_event $jobid clean &&
+        wait_jobid_state $jobid inactive &&
+        wait_db $jobid ${ARCHIVEDB}-NEW &&
+        db_check_entries $jobid ${ARCHIVEDB}-NEW &&
+        db_check_values_run $jobid ${ARCHIVEDB}-NEW
+'
+
+test_expect_success 'job-archive: unload module' '
+        flux module unload job-archive
+'
+
+test_expect_success 'job-archive: both db exists after module unloaded' '
+        count=`db_count_entries ${ARCHIVEDB}` &&
+        test $count -eq 7 &&
+        count=`db_count_entries ${ARCHIVEDB}-NEW` &&
+        test $count -eq 8
+'
+
+test_done


### PR DESCRIPTION
Per #2863, part 1 first attempt at job-archival.  Instead of going into a DB, it just goes into a text file.  Just want to get the basics working and get some basic tests written up.  Some things to consider:

- how should user consider period / location of file.  I just have command line args to the module right now.  Perhaps need an equivalent to `content-backing.patch` for the file location (and eventual DB location).
- Working on #2778 (job-info list RPC restart) may be important to do to avoid huge returns from job-info




