### PR TITLE
README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,12 +77,12 @@ jq                | jq                |
 
 ##### Installing RedHat/CentOS Packages
 ```
-yum install autoconf automake libtool libsodium-devel zeromq4-devel czmq-devel libuuid-devel jansson-devel lz4-devel hwloc-devel sqlite-devel lua lua-devel lua-posix python36-devel python36-cffi python36-six python36-yaml python36-jsonschema asciidoc asciidoctor aspell valgrind mpich jq
+yum install autoconf automake libtool libsodium-devel zeromq4-devel czmq-devel libuuid-devel jansson-devel lz4-devel hwloc-devel sqlite-devel lua lua-devel lua-posix python36-devel python36-cffi python36-six python36-yaml python36-jsonschema asciidoc asciidoctor aspell valgrind-devel mpich-devel jq
 ```
 
 ##### Installing Ubuntu Packages
 ```
-apt install autoconf automake libtool libsodium-dev libzmq3-dev libczmq-dev uuid-dev libjansson-dev liblz4-dev libhwloc-dev libsqlite3-dev lua5.1 liblua5.1-dev lua-posix python3-dev python3-cffi python3-six python3-yaml python3-jsonschema asciidoc asciidoctor aspell valgrind mpich jq
+apt install autoconf automake libtool libsodium-dev libzmq3-dev libczmq-dev uuid-dev libjansson-dev liblz4-dev libhwloc-dev libsqlite3-dev lua5.1 liblua5.1-dev lua-posix python3-dev python3-cffi python3-six python3-yaml python3-jsonschema asciidoc asciidoctor aspell valgrind libmpich-dev jq
 ```
 
 ##### Building from Source

--- a/README.md
+++ b/README.md
@@ -85,18 +85,10 @@ apt install autoconf automake libtool libsodium-dev libzmq3-dev libczmq-dev uuid
 ##### Building from Source
 ```
 ./autogen.sh   # skip if building from a release tarball
-PYTHON_VERSION=3.6 ./configure
+./configure
 make
 make check
 ```
-Note: the `PYTHON_VERSION` environment variable adds a suffix to the
-python interpreter executable.  Configure would look for `python3.6` in
-the example above.  If unset, `python` is used, which is often Python 2.
-
-If you want Flux to use Python 2 and generate (only) Python 2 bindings,
-alter the prerequisite package names above, and set (or don't set)
-`PYTHON_VERSION` accordingly.  Python 2 support should be considered
-deprecated, although it continues to work for now.
 
 #### Bootstrapping a Flux instance
 

--- a/README.md
+++ b/README.md
@@ -56,10 +56,6 @@ python36-yaml     | python3-yaml      | >= 3.10.0         |
 python36-jsonschema | python3-jsonschema | >= 2.3.0       |
 asciidoc          | asciidoc          |                   | *2*
 asciidoctor       | asciidoctor       | >= 1.5.7          | *2*
-aspell            | aspell            |                   | *3*
-valgrind          | valgrind          |                   | *3*
-mpich             | mpich             |                   | *3*
-jq                | jq                |                   | *3*
 
 *Note 1 - Due to a packaging issue, Ubuntu lua-posix may need the
 following symlink (true for version 33.4.0-2):*
@@ -70,7 +66,14 @@ $ sudo ln -s posix_c.so /usr/lib/x86_64-linux-gnu/lua/5.1/posix.so
 *Note 2 - only needed if optional man pages are to be created.  Only one
 of asciidoc or asciidoctor is needed.  Asciidoc is used if both are installed.*
 
-*Note 3 - optional, for enabling additional tests*.
+The following optional dependencies enable additional testing:
+
+**redhat**        | **ubuntu**        | **version**
+----------        | ----------        | -----------
+aspell            | aspell            |
+valgrind-devel    | valgrind          |
+mpich-devel       | libmpich-dev      |
+jq                | jq                |
 
 ##### Installing RedHat/CentOS Packages
 ```


### PR DESCRIPTION
Here are a couple of tweaks to the README.md, following up on comments in #2737.

There might be a few more items to tack on here from #2737.   I removed the python2 vestiges, separated test-only dependencies to their own table, and listed `libmpich-dev` / `libmpich-devel` instead of `mpich`.

I didn't find a `libvalgrind-dev` or `valgrind-dev` for ubuntu so didn't act on that suggestion.