### PR TITLE
README: add missing dependencies: aspell-en and make

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ flux-core requires the following packages to build:
 autoconf          | autoconf          |                   |
 automake          | automake          |                   |
 libtool           | libtool           |                   |
+make              | make              |                   |
 libsodium-devel   | libsodium-dev     | >= 1.0.14         |
 zeromq4-devel     | libzmq3-dev       | >= 4.0.4          |
 czmq-devel        | libczmq-dev       | >= 3.0.1          |
@@ -71,18 +72,19 @@ The following optional dependencies enable additional testing:
 **redhat**        | **ubuntu**        | **version**
 ----------        | ----------        | -----------
 aspell            | aspell            |
+aspell-en         | aspell-en         |
 valgrind-devel    | valgrind          |
 mpich-devel       | libmpich-dev      |
 jq                | jq                |
 
 ##### Installing RedHat/CentOS Packages
 ```
-yum install autoconf automake libtool libsodium-devel zeromq4-devel czmq-devel libuuid-devel jansson-devel lz4-devel hwloc-devel sqlite-devel lua lua-devel lua-posix python36-devel python36-cffi python36-six python36-yaml python36-jsonschema asciidoc asciidoctor aspell valgrind-devel mpich-devel jq
+yum install autoconf automake libtool make libsodium-devel zeromq4-devel czmq-devel libuuid-devel jansson-devel lz4-devel hwloc-devel sqlite-devel lua lua-devel lua-posix python36-devel python36-cffi python36-six python36-yaml python36-jsonschema asciidoc asciidoctor aspell aspell-en valgrind-devel mpich-devel jq
 ```
 
 ##### Installing Ubuntu Packages
 ```
-apt install autoconf automake libtool libsodium-dev libzmq3-dev libczmq-dev uuid-dev libjansson-dev liblz4-dev libhwloc-dev libsqlite3-dev lua5.1 liblua5.1-dev lua-posix python3-dev python3-cffi python3-six python3-yaml python3-jsonschema asciidoc asciidoctor aspell valgrind libmpich-dev jq
+apt install autoconf automake libtool make libsodium-dev libzmq3-dev libczmq-dev uuid-dev libjansson-dev liblz4-dev libhwloc-dev libsqlite3-dev lua5.1 liblua5.1-dev lua-posix python3-dev python3-cffi python3-six python3-yaml python3-jsonschema asciidoc asciidoctor aspell aspell-en valgrind libmpich-dev jq
 ```
 
 ##### Building from Source


### PR DESCRIPTION
make is not automatically pulled in by any other dependencies on a fresh
centos installation

installing aspell on centos does not also automatically install
aspell-en. I assume because the dictionary is in EPEL and the binary is
in the main package repo.

closes #2888