### PR TITLE
initial pty support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -471,6 +471,7 @@ AC_CONFIG_FILES( \
   src/common/librouter/Makefile \
   src/common/libyuarel/Makefile \
   src/common/libdebugged/Makefile \
+  src/common/libterminus/Makefile \
   src/bindings/Makefile \
   src/bindings/lua/Makefile \
   src/bindings/python/Makefile \

--- a/doc/man3/flux_shell_get_info.adoc
+++ b/doc/man3/flux_shell_get_info.adoc
@@ -37,6 +37,7 @@ with the following layout:
  "rank":i,
  "size":i,
  "ntasks";i,
+ "service";s,
  "options": { "verbose":b, "standalone":b },
  "jobspec":o,
  "R":o

--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -92,6 +92,7 @@ flux_job_LDADD = \
 	$(fluxcmd_ldadd) \
 	$(top_builddir)/src/shell/libmpir.la \
 	$(top_builddir)/src/common/libdebugged/libdebugged.la \
+	$(top_builddir)/src/common/libterminus/libterminus.la \
 	$(LIBUTIL)
 
 flux_terminus_LDADD = \

--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -70,6 +70,7 @@ dist_fluxcmd_SCRIPTS = \
 
 fluxcmd_PROGRAMS = \
 	flux-aggregate \
+	flux-terminus \
 	flux-ping \
 	flux-keygen \
 	flux-logger \
@@ -91,6 +92,14 @@ flux_job_LDADD = \
 	$(fluxcmd_ldadd) \
 	$(top_builddir)/src/shell/libmpir.la \
 	$(top_builddir)/src/common/libdebugged/libdebugged.la \
+	$(LIBUTIL)
+
+flux_terminus_LDADD = \
+	$(fluxcmd_ldadd) \
+	$(top_builddir)/src/common/libterminus/libterminus.la \
+	$(top_builddir)/src/common/libidset/libidset.la \
+	$(top_builddir)/src/common/libutil/libutil.la \
+	$(ZMQ_LIBS) \
 	$(LIBUTIL)
 
 #

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -42,6 +42,7 @@
 #include "src/common/libioencode/ioencode.h"
 #include "src/shell/mpir/proctable.h"
 #include "src/common/libdebugged/debugged.h"
+#include "src/common/libterminus/pty.h"
 
 #ifndef VOLATILE
 # if defined(__STDC__) || defined(__cplusplus)
@@ -1757,6 +1758,75 @@ static void attach_setup_stdin (struct attach_ctx *ctx)
     flux_watcher_start (ctx->stdin_w);
 }
 
+static void pty_client_exit_cb (struct flux_pty_client *c, void *arg)
+{
+    int status = 0;
+    if (flux_pty_client_exit_status (c, &status) < 0)
+        log_err ("Unable to get remote pty exit status");
+    flux_pty_client_restore_terminal ();
+
+    /*  Hm, should we force exit here?
+     *  Need to differentiate between pty detach and normal exit.
+     */
+    exit (status == 0 ? 0 : 1);
+}
+
+static void f_logf (void *arg,
+                    const char *file,
+                    int line,
+                    const char *func,
+                    const char *subsys,
+                    int level,
+                    const char *fmt,
+                    va_list ap)
+{
+    char buf [2048];
+    int buflen = sizeof (buf);
+    int n = vsnprintf (buf, buflen, fmt, ap);
+    if (n >= sizeof (buf)) {
+        buf[buflen - 1] = '\0';
+        buf[buflen - 1] = '+';
+    }
+    log_msg ("%s:%d: %s: %s", file, line, func, buf);
+}
+
+static int attach_pty (struct attach_ctx *ctx, const char *pty_service)
+{
+    int n;
+    char topic [128];
+    struct flux_pty_client *c;
+    int flags = FLUX_PTY_CLIENT_ATTACH_SYNC | FLUX_PTY_CLIENT_NOTIFY_ON_DETACH;
+
+    if (!(c = flux_pty_client_create ()))
+        log_err_exit ("flux_pty_client_create");
+
+    flux_pty_client_set_flags (c, flags);
+    flux_pty_client_set_log (c, f_logf, NULL);
+
+    n = snprintf (topic, sizeof (topic), "%s.%s", ctx->service, pty_service);
+    if (n >= sizeof (topic))
+        log_err_exit ("Failed to build pty service topic at %s.%s",
+                      ctx->service, pty_service);
+
+    /*  Attempt to attach to pty on rank 0 of this job.
+     *  The attempt may fail if this job is not currently running.
+     */
+    if (flux_pty_client_attach (c,
+                                ctx->h,
+                                ctx->leader_rank,
+                                topic) < 0) {
+        if (errno != ENOSYS)
+            log_err ("failed to attach to pty");
+        flux_pty_client_destroy (c);
+        return -1;
+    }
+
+    if (flux_pty_client_notify_exit (c, pty_client_exit_cb, NULL) < 0)
+        log_err_exit ("flux_pty_client_notify_exit");
+
+    return 0;
+}
+
 /* Handle an event in the guest.exec eventlog.
  * This is a stream of responses, one response per event, terminated with
  * an ENODATA error response (or another error if something went wrong).
@@ -1786,18 +1856,28 @@ void attach_exec_event_continuation (flux_future_t *f, void *arg)
         log_err_exit ("eventlog_entry_parse");
 
     if (!strcmp (name, "shell.init")) {
+        const char *pty_service = NULL;
         if (json_unpack (context,
-                         "{s:i s:s}",
+                         "{s:i s:s s?s}",
                          "leader-rank",
                          &ctx->leader_rank,
                          "service",
-                         &service) < 0)
+                         &service,
+                         "pty",
+                         &pty_service) < 0)
             log_err_exit ("error decoding shell.init context");
         if (!(ctx->service = strdup (service)))
             log_err_exit ("strdup service from shell.init");
 
-        attach_setup_stdin (ctx);
-        attach_output_start (ctx);
+        /*  If there is a pty service for this job, try to attach to it.
+         *  If there is not a pty service, or the pty attach fails, continue
+         *   to process normal stdio. (This may be because the job is
+         *   already complete).
+         */
+        if (!pty_service || attach_pty (ctx, pty_service) < 0) {
+            attach_setup_stdin (ctx);
+            attach_output_start (ctx);
+        }
     } else if (!strcmp (name, "shell.start")) {
         if (MPIR_being_debugged)
             setup_mpir_interface (ctx, context);

--- a/src/cmd/flux-terminus.c
+++ b/src/cmd/flux-terminus.c
@@ -1,0 +1,753 @@
+/************************************************************\
+ * Copyright 2020 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* flux-terminus.c - terminal session management service for Flux
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <string.h>
+#include <assert.h>
+#include <unistd.h>
+#include <time.h>
+
+#include <jansson.h>
+
+#include <flux/core.h>
+#include <flux/optparse.h>
+
+#include "src/common/libutil/fdwalk.h"
+#include "src/common/libutil/log.h"
+#include "src/common/libutil/llog.h"
+
+#include "src/common/libterminus/terminus.h"
+#include "src/common/libterminus/pty.h"
+
+#define TERMINUS_DOC "\
+Simple terminal session manager and multiplexer for Flux.\n\
+Options:\n"
+
+int cmd_start (optparse_t *p, int argc, char **argv);
+int cmd_attach (optparse_t *p, int argc, char **argv);
+int cmd_list (optparse_t *p, int argc, char **argv);
+int cmd_kill (optparse_t *p, int argc, char **argv);
+int cmd_kill_server (optparse_t *p, int argc, char **argv);
+
+static struct optparse_option global_opts[] =  {
+    OPTPARSE_TABLE_END
+};
+
+static struct optparse_option start_opts[] = {
+    { .name = "detach", .key = 'd',
+      .usage = "Start new session and immediately detach"
+    },
+    { .name = "wait", .key = 'w',
+      .usage = "Do not clear sessions from server on exit with --detach."
+               " Instead, hold session in an 'exited' state until at least"
+               " one client has attached."
+    },
+    { .name = "name", .key = 'n',
+      .has_arg = 1, .arginfo = "NAME",
+      .usage = "Set session name to NAME (default: arg0)",
+    },
+    { .name = "rank", .key = 'r',
+      .has_arg = 1, .arginfo = "RANK",
+      .usage = "Attach to session on rank RANK (default: local rank)",
+    },
+    { .name = "service", .key = 's',
+      .has_arg = 1, .arginfo = "NAME",
+      .usage = "Use service NAME (default USERID-terminus)."
+    },
+    { .name = "pipe", .key = 'p',
+      .usage = "Pipe stdin to the session and exit. Do not display output",
+      .flags = OPTPARSE_OPT_HIDDEN
+    },
+    OPTPARSE_TABLE_END
+};
+
+static struct optparse_option attach_opts[] = {
+    { .name = "rank", .key = 'r',
+      .has_arg = 1, .arginfo = "RANK",
+      .usage = "Attach to session on rank RANK (default: local rank)",
+    },
+    { .name = "service", .key = 's',
+      .has_arg = 1, .arginfo = "NAME",
+      .usage = "Attach at service NAME (default USERID-terminus)."
+    },
+    { .name = "pipe", .key = 'p',
+      .usage = "Pipe stdin to the session and exit. Do not display output",
+    },
+    OPTPARSE_TABLE_END
+};
+
+static struct optparse_option list_opts[] = {
+    { .name = "rank", .key = 'r',
+      .has_arg = 1, .arginfo = "RANK",
+      .usage = "Attach to session on rank RANK (default: local rank)",
+    },
+    { .name = "service", .key = 's',
+      .has_arg = 1, .arginfo = "NAME",
+      .usage = "Use service NAME (default USERID-terminus)."
+    },
+    OPTPARSE_TABLE_END
+};
+
+static struct optparse_option kill_opts[] = {
+    { .name = "rank", .key = 'r',
+      .has_arg = 1, .arginfo = "RANK",
+      .usage = "Kill session on rank RANK (default: local rank)",
+    },
+    { .name = "service", .key = 's',
+      .has_arg = 1, .arginfo = "NAME",
+      .usage = "Kill at service NAME (default USERID-terminus). "
+    },
+    OPTPARSE_TABLE_END
+};
+
+static struct optparse_option kill_server_opts[] = {
+    { .name = "rank", .key = 'r',
+      .has_arg = 1, .arginfo = "RANK",
+      .usage = "Kill server on rank RANK (default: local rank)",
+    },
+    { .name = "service", .key = 's',
+      .has_arg = 1, .arginfo = "NAME",
+      .usage = "Kill server at NAME (default USERID-terminus)."
+    },
+    OPTPARSE_TABLE_END
+};
+
+
+static struct optparse_subcommand subcommands[] = {
+    { "start",
+      "[OPTIONS] [COMMAND...]",
+      "Start a new session",
+      cmd_start,
+      0,
+      start_opts,
+    },
+    { "attach",
+      "[OPTIONS] ID",
+      "Attach to existing session",
+      cmd_attach,
+      0,
+      attach_opts,
+    },
+    { "list",
+      NULL,
+      "list active sessions",
+      cmd_list,
+      0,
+      list_opts,
+    },
+    { "kill",
+      "[OPTIONS] ID",
+      "kill active session ID",
+      cmd_kill,
+      0,
+      kill_opts,
+    },
+     { "kill-server",
+      NULL,
+      "tell terminus server to exit",
+      cmd_kill_server,
+      0,
+      kill_server_opts,
+    },
+    OPTPARSE_SUBCMD_END
+};
+
+int main (int argc, char *argv[])
+{
+    optparse_t *p;
+    int optindex;
+    int exitval;
+
+    log_init ("flux-terminus");
+
+    p = optparse_create ("flux-terminus");
+
+    if (optparse_add_option_table (p, global_opts) != OPTPARSE_SUCCESS)
+        log_msg_exit ("optparse_add_option_table() failed");
+
+    if (optparse_add_doc (p, TERMINUS_DOC, 0) != OPTPARSE_SUCCESS)
+        log_msg_exit ("optparse_add_doc failed");
+
+    if (optparse_reg_subcommands (p, subcommands) != OPTPARSE_SUCCESS)
+        log_msg_exit ("optparse_reg_subcommands");
+
+    if ((optindex = optparse_parse_args (p, argc, argv)) < 0)
+        exit (1);
+
+    if ((argc - optindex == 0)
+        || !optparse_get_subcommand (p, argv[optindex]))
+        optparse_fatal_usage (p, 1, NULL);
+
+    if ((exitval = optparse_run_subcommand (p, argc, argv)) < 0)
+        exit (1);
+
+    optparse_destroy (p);
+    log_fini ();
+    return (exitval);
+}
+
+char *service_name (optparse_t *p, const char *method,
+                          char *buf, int buflen)
+{
+    char default_service [64];
+    const char *service = NULL;
+
+    if (optparse_getopt (p, "service", &service) <= 0) {
+        /*  <userid>-terminus is guaranteed to fit in buffer:
+         */
+        (void) sprintf (default_service,
+                        "%u-terminus",
+                        (unsigned) getuid ());
+        service = default_service;
+    }
+    if (snprintf (buf,
+                  buflen,
+                  "%s%s%s",
+                  service,
+                  method ? "." : "",
+                  method ? method : "") >= buflen) {
+        log_msg ("service_name: service name too long");
+        return NULL;
+    }
+    return buf;
+}
+
+static void terminus_server_closefd (void *arg, int fd)
+{
+    int *savefd = arg;
+
+    if (fd != *savefd
+        && fd != STDIN_FILENO
+        && fd != STDOUT_FILENO
+        && fd != STDERR_FILENO)
+        (void) close (fd);
+}
+
+static void close_stdio ()
+{
+    int fd = open ("/dev/null", O_RDWR);
+    if (fd >= 0) {
+        dup2 (fd, STDIN_FILENO);
+        dup2 (fd, STDOUT_FILENO);
+        dup2 (fd, STDERR_FILENO);
+        close (fd);
+    }
+}
+
+static void f_logf (void *arg,
+                    const char *file,
+                    int line,
+                    const char *func,
+                    const char *subsys,
+                    int level,
+                    const char *fmt,
+                    va_list ap)
+{
+    flux_t *h = arg;
+    char buf [2048];
+    int buflen = sizeof (buf);
+    int n = vsnprintf (buf, buflen, fmt, ap);
+    if (n >= sizeof (buf)) {
+        buf[buflen - 1] = '\0';
+        buf[buflen - 1] = '+';
+    }
+    flux_log (h, level, "%s:%d: %s: %s", file, line, func, buf);
+}
+
+static void empty_cb (struct flux_terminus_server *ts,
+                      void *arg)
+{
+    flux_reactor_stop ((flux_reactor_t *) arg);
+}
+
+static int run_service (const char *service, int fd)
+{
+    flux_t *h;
+    struct flux_terminus_server *ts;
+    flux_future_t *f;
+    int rc = -1;
+    flux_reactor_t *r;
+
+    if (fdwalk (terminus_server_closefd, &fd) < 0) {
+        log_err ("fdwalk");
+        goto err;
+    }
+
+    r = flux_reactor_create (FLUX_REACTOR_SIGCHLD);
+    if (!r) {
+        log_err ("flux_reactor_create");
+        goto err;
+    }
+    if (!(h = flux_open (NULL, 0))) {
+        log_err ("flux_open");
+        goto err;
+    }
+    flux_set_reactor (h, r);
+    if (!(f = flux_service_register (h, service))
+        || flux_future_get (f, NULL) < 0) {
+        log_err ("flux_service_register (%s)", service);
+        goto err;
+    }
+    flux_future_destroy (f);
+
+    if (!(ts = flux_terminus_server_create (h, service))) {
+        log_err ("flux_terminus_server_create");
+        goto err;
+    }
+
+    /* Notify grandparent that we're ready */
+    close (fd);
+    close_stdio ();
+
+    flux_terminus_server_set_log (ts, f_logf, h);
+
+    /*  Set up to exit when the last session exits
+     */
+    flux_terminus_server_notify_empty (ts, empty_cb, r);
+
+    rc = flux_reactor_run (flux_get_reactor (h), 0);
+    flux_terminus_server_destroy (ts);
+    flux_reactor_destroy (r);
+    flux_close (h);
+    return rc;
+err:
+    if (write (fd, &errno, sizeof (int)) < 0)
+        log_err ("write");
+    return -1;
+}
+
+/*  Turn current process into daemon and start terminus server.
+ *   Close write end of pfds when ready.
+ */
+static int start_service_daemon (flux_t *orig_h, optparse_t *p)
+{
+    pid_t pid;
+    int pfds[2];
+    int result = 0;
+    char service [64];
+
+    if (!service_name (p, NULL, service, sizeof (service)))
+        log_msg_exit ("failed to get service name");
+
+    /*  Create pipe to allow server to signal readiness */
+    if (pipe (pfds) < 0)
+        log_msg_exit ("pipe");
+
+    if ((pid = fork ()) < 0)
+        log_err_exit ("fork");
+    else if (pid == 0) {
+        /* Child: cleanup, fork again and execute server */
+        flux_close (orig_h);
+        close (pfds[0]);
+        setsid ();
+        if ((pid = fork ()) < 0)
+            log_err_exit ("child: fork");
+        else if (pid == 0) {
+            /* Run server */
+            if (run_service (service, pfds[1]) < 0)
+                exit (1);
+            exit (0);
+        }
+        /* Parent: exit */
+        exit (0);
+    }
+
+    /*  Wait for child, wait for grandchild to close pipe */
+    waitpid (pid, NULL, 0);
+    close (pfds[1]);
+
+    /*  Read status from grandchild */
+    if (read (pfds[0], &result, sizeof (int)) < 0)
+        log_err_exit ("Failed to get status of server");
+    close (pfds[0]);
+
+    errno = result;
+    return result == 0 ? 0 : -1;
+}
+
+static json_t *build_cmd (optparse_t *p, int argc, char **argv)
+{
+    json_t *cmd = NULL;
+
+    if (!(cmd = json_array ()))
+        return NULL;
+
+    for (int i = 0; i < argc; i++) {
+        json_t *o = json_string (argv[i]);
+        if (o == NULL)
+            goto err;
+        if (json_array_append_new (cmd, o) < 0) {
+            json_decref (o);
+            goto err;
+        }
+    }
+    return cmd;
+err:
+    json_decref (cmd);
+    return NULL;
+}
+
+static int new_session (flux_t *h, optparse_t *p,
+                        const char *name,
+                        int argc,
+                        char **argv,
+                        char **pty_service)
+{
+    int rc = -1;
+    json_t *cmd = NULL;
+    flux_future_t *f = NULL;
+    char service [128];
+    const char *s;
+    int wait = 0;
+    int rank = optparse_get_int (p, "rank", FLUX_NODEID_ANY);
+
+    if (!(service_name (p, "new", service, sizeof (service))))
+        goto err;
+    cmd = build_cmd (p, argc, argv);
+
+    if (!optparse_hasopt (p, "detach") || optparse_hasopt (p, "wait"))
+        wait = 1;
+
+    if (!(f = flux_rpc_pack (h,
+                             service,
+                             rank,
+                             0,
+                             "{s:s s:o? s:i}",
+                             "name", name ? name : "",
+                             "cmd", cmd,
+                             "wait", wait)))
+        goto err;
+    if (flux_rpc_get_unpack (f,"{s:s}", "pty_service", &s) < 0) {
+        log_err ("new session: %s", future_strerror (f, errno));
+        goto err;
+    }
+    if (!(*pty_service = strdup (s)))
+        goto err;
+    rc = 0;
+err:
+    flux_future_destroy (f);
+    return rc;
+}
+
+flux_future_t * list_sessions (flux_t *h, optparse_t *p)
+{
+    char service [128];
+    int rank = optparse_get_int (p, "rank", FLUX_NODEID_ANY);
+
+    if (!(service_name (p, "list", service, sizeof (service))))
+        log_msg_exit ("Failed to build service name");
+
+    return flux_rpc (h, service, NULL, rank, 0);
+}
+
+static void exit_cb (struct flux_pty_client *c, void *arg)
+{
+    flux_t *h = arg;
+    flux_reactor_stop (flux_get_reactor (h));
+}
+
+static int attach_session (flux_t *h,
+                           optparse_t *p,
+                           const char *pty_service)
+{
+    int status = 0;
+    int flags = FLUX_PTY_CLIENT_CLEAR_SCREEN
+              | FLUX_PTY_CLIENT_NOTIFY_ON_DETACH
+              | FLUX_PTY_CLIENT_ATTACH_SYNC;
+    struct flux_pty_client *c = NULL;
+    int rank = optparse_get_int (p, "rank", FLUX_NODEID_ANY);
+
+    if (optparse_hasopt (p, "pipe")) {
+        flags = FLUX_PTY_CLIENT_STDIN_PIPE
+                | FLUX_PTY_CLIENT_ATTACH_SYNC
+                | FLUX_PTY_CLIENT_NORAW;
+    }
+
+    if (!(c = flux_pty_client_create ())
+        || flux_pty_client_set_flags (c, flags) < 0)
+        log_err_exit ("flux_pty_client_create");
+
+    if (flux_pty_client_attach (c, h, rank, pty_service) < 0) {
+        if (errno == ENOSYS)
+            log_msg_exit ("Invalid session or server at %s", pty_service);
+        else
+            log_err_exit ("flux_pty_client_attach");
+    }
+
+    if (flux_pty_client_notify_exit (c, exit_cb, h) < 0)
+        log_msg_exit ("flux_pty_client_notify_exit");
+
+    flux_reactor_run (flux_get_reactor (h), 0);
+
+    if (flux_pty_client_exit_status (c, &status) < 0)
+        log_err ("failed to get remote exit status");
+
+    /* Exit with semi "standard" exit code (as shell might have) */
+    if (status != 0) {
+        int code = 1;
+        if (WIFSIGNALED (status))
+            code = 128 + WTERMSIG (status);
+        else
+            code = WEXITSTATUS (status);
+        exit (code);
+    }
+    flux_pty_client_destroy (c);
+    return 0;
+}
+
+/*  from flux-job.c
+ */
+static bool isnumber (const char *s, int *result)
+{
+    char *endptr;
+    long int l;
+
+    errno = 0;
+    l = strtol (s, &endptr, 10);
+    if (errno
+        || *endptr != '\0'
+        || l < 0) {
+        return false;
+    }
+    *result = (int) l;
+    return true;
+}
+
+int cmd_attach (optparse_t *p, int argc, char **argv)
+{
+    flux_t *h;
+    const char *idstr;
+    char service [128];
+    int id;
+    int optindex = optparse_option_index (p);
+
+    if (getenv ("FLUX_TERMINUS_SESSION"))
+        log_msg_exit ("Nesting flux-terminus sessions not supported");
+
+    if (argc - optindex != 1)
+        optparse_fatal_usage (p, 1, "session ID required\n");
+
+    idstr = argv[optindex];
+    if (!isnumber (idstr, &id))
+        optparse_fatal_usage (p, 1, "session ID must be an integer\n");
+    if (!service_name (p, idstr, service, sizeof (service)))
+        log_msg_exit ("service_name");
+
+    if (!(h = flux_open (NULL, 0)))
+        log_err_exit ("flux_open");
+
+    if (attach_session (h, p, service) < 0)
+        log_msg_exit ("Failed to attach to session at %s", service);
+
+    flux_close (h);
+    return 0;
+}
+
+int cmd_start (optparse_t *p, int argc, char **argv)
+{
+    flux_t *h;
+    json_t *o = NULL;
+    const char *name = NULL;
+    char *pty_service = NULL;
+    flux_future_t *f = NULL;
+    int optindex = optparse_option_index (p);
+
+    if (getenv ("FLUX_TERMINUS_SESSION"))
+        log_msg_exit ("Nesting flux-terminus sessions not supported");
+
+    if (!(h = flux_open (NULL, 0)))
+        log_err_exit ("flux_open");
+
+    /*  If no server currently running at requested service endpoint,
+     *   then start one in background on this rank
+     */
+    if (!(f = list_sessions (h, p))
+        || flux_future_get (f, NULL) < 0) {
+        if (optparse_hasopt (p, "rank"))
+            log_msg_exit ("Unable to start a new server with --rank option");
+
+        flux_future_destroy (f);
+        f = NULL;
+
+        /*  Fork service daemon. Only parent returns */
+        if (start_service_daemon (h, p) < 0)
+            log_msg_exit ("Failed to start a new server");
+    }
+    json_decref (o);
+
+    argc -= optindex;
+    argv += optindex;
+
+    name = optparse_get_str (p, "name", NULL);
+    if (new_session (h, p, name, argc, argv, &pty_service) < 0)
+        log_msg_exit ("Failed to start new session");
+
+    if (!optparse_hasopt (p, "detach")
+        && attach_session (h, p, pty_service) < 0)
+        log_msg_exit ("Failed to attach to session at %s", pty_service);
+
+    free (pty_service);
+    flux_future_destroy (f);
+    flux_close (h);
+    return (0);
+}
+
+static const char *timestr (double ts, char *buf, size_t size)
+{
+    struct tm tm;
+    time_t sec = ts;
+    if (!gmtime_r (&sec, &tm)
+        || strftime (buf, size, "%c", &tm) == 0)
+        return "Unknown";
+    return buf;
+}
+
+static int print_session (json_t *o)
+{
+    int id;
+    int clients;
+    int exited;
+    const char *name;
+    double ctime;
+    char timebuf [64];
+
+    if (json_unpack (o, "{s:i s:i s:s s:i s:f}",
+                     "id", &id,
+                     "clients", &clients,
+                     "name", &name,
+                     "exited", &exited,
+                     "ctime", &ctime) < 0)
+        return -1;
+    printf ("%d: [%s]%s %d clients (created %s)\n",
+            id, name, exited ? " (exited)" : "",
+            clients, timestr (ctime, timebuf, sizeof (timebuf)));
+    return 0;
+}
+
+int cmd_list (optparse_t *p, int argc, char **argv)
+{
+    flux_future_t *f = NULL;
+    json_t *l = NULL;
+    const char *service;
+    char datestr [64];
+    int rank;
+    size_t n;
+    double ctime;
+    flux_t *h;
+
+    if (!(h = flux_open (NULL, 0)))
+        log_err_exit ("flux_open");
+    if (!(f= list_sessions (h, p)))
+        log_err_exit ("list_sessions");
+    if (flux_rpc_get_unpack (f, "{s:o s:{s:s s:i s:f}}",
+                             "sessions", &l,
+                             "server",
+                               "service", &service,
+                               "rank", &rank,
+                               "ctime", &ctime) < 0) {
+        char name[64];
+        if (errno == ENOSYS)
+            log_msg_exit ("no server running at %s",
+                          service_name (p, NULL, name, sizeof (name)));
+        else
+            log_err_exit ("list sessions failed");
+    }
+    timestr (ctime, datestr, sizeof (datestr));
+    printf ("server at %s running on rank %d since %s\n",
+            service,
+            rank,
+            datestr);
+    if ((n = json_array_size (l)))
+        printf ("%ld current session%s:\n", n, n > 1 ? "s" : "");
+    else
+        printf ("no sessions\n");
+    for (int i = 0; i < json_array_size (l); i++)
+        print_session (json_array_get (l, i));
+    flux_future_destroy (f);
+    flux_close (h);
+    return (0);
+}
+
+int cmd_kill (optparse_t *p, int argc, char **argv)
+{
+    flux_t *h;
+    flux_future_t *f;
+    char service [128];
+    const char *idstr;
+    int id;
+    int optindex = optparse_option_index (p);
+    int rank = optparse_get_int (p, "rank", FLUX_NODEID_ANY);
+
+    if (argc - optindex != 1)
+        optparse_fatal_usage (p, 1, "session ID required\n");
+
+    idstr = argv[optindex];
+    if (!isnumber (idstr, &id))
+        optparse_fatal_usage (p, 1, "session ID must be an integer\n");
+    if (!service_name (p, "kill", service, sizeof (service)))
+        log_msg_exit ("service_name");
+
+    if (!(h = flux_open (NULL, 0)))
+        log_err_exit ("flux_open");
+
+    if (!(f = flux_rpc_pack (h, service, rank, 0,
+                             "{s:i s:i s:i}",
+                             "id", id,
+                             "signal", SIGKILL,
+                             "wait", 1))
+        || flux_rpc_get (f, NULL) < 0) {
+        if (errno == ENOSYS)
+            log_msg_exit ("kill: no server running at %s",
+                          service_name (p, NULL, service, sizeof (service)));
+        log_err_exit ("kill failed");
+    }
+    flux_future_destroy (f);
+    flux_close (h);
+    return (0);
+}
+
+int cmd_kill_server (optparse_t *p, int argc, char **argv)
+{
+    flux_t *h;
+    flux_future_t *f;
+    char service [64];
+    int rank = optparse_get_int (p, "rank", FLUX_NODEID_ANY);
+    if (!(h = flux_open (NULL, 0)))
+        log_err_exit ("flux_open");
+
+    if (!service_name (p, "kill-server", service, sizeof (service)))
+        log_err_exit ("failed to build service name");
+
+    if (!(f = flux_rpc (h, service, NULL, rank, 0))
+        || flux_rpc_get (f, NULL) < 0) {
+        if (errno == ENOSYS)
+            log_msg_exit ("no server running at %s",
+                          service_name (p, NULL, service, sizeof (service)));
+        else
+            log_err_exit ("kill-server");
+    }
+    flux_future_destroy (f);
+    flux_close (h);
+    return (0);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -17,7 +17,8 @@ SUBDIRS = libtap \
 	  libeventlog \
 	  libioencode \
 	  librouter \
-	  libdebugged
+	  libdebugged \
+	  libterminus
 
 AM_CFLAGS = $(WARNING_CFLAGS) $(CODE_COVERAGE_CFLAGS)
 AM_LDFLAGS = $(CODE_COVERAGE_LIBS)

--- a/src/common/libterminus/Makefile.am
+++ b/src/common/libterminus/Makefile.am
@@ -24,3 +24,28 @@ libterminus_la_SOURCES = \
 	terminus.h \
 	terminus.c
 
+TESTS = \
+	test_pty.t
+
+check_PROGRAMS = \
+	$(TESTS)
+
+TEST_EXTENSIONS = .t
+T_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
+        $(top_srcdir)/config/tap-driver.sh
+
+test_ldadd = \
+	$(top_builddir)/src/common/libterminus/libterminus.la \
+	$(top_builddir)/src/common/libutil/libutil.la \
+	$(top_builddir)/src/common/libtestutil/libtestutil.la \
+        $(top_builddir)/src/common/libflux-internal.la \
+        $(top_builddir)/src/common/libflux-core.la \
+        $(top_builddir)/src/common/libtap/libtap.la
+
+test_cppflags = \
+	$(AM_CPPFLAGS) \
+	-I$(top_srcdir)/src/common/libtap
+
+test_pty_t_SOURCES = test/pty.c
+test_pty_t_CPPFLAGS = $(test_cppflags)
+test_pty_t_LDADD = $(test_ldadd)

--- a/src/common/libterminus/Makefile.am
+++ b/src/common/libterminus/Makefile.am
@@ -25,7 +25,8 @@ libterminus_la_SOURCES = \
 	terminus.c
 
 TESTS = \
-	test_pty.t
+	test_pty.t \
+	test_terminus.t
 
 check_PROGRAMS = \
 	$(TESTS)
@@ -49,3 +50,7 @@ test_cppflags = \
 test_pty_t_SOURCES = test/pty.c
 test_pty_t_CPPFLAGS = $(test_cppflags)
 test_pty_t_LDADD = $(test_ldadd)
+
+test_terminus_t_SOURCES = test/terminus.c
+test_terminus_t_CPPFLAGS = $(test_cppflags)
+test_terminus_t_LDADD = $(test_ldadd)

--- a/src/common/libterminus/Makefile.am
+++ b/src/common/libterminus/Makefile.am
@@ -1,0 +1,26 @@
+AM_CFLAGS = \
+	$(WARNING_CFLAGS) \
+	$(CODE_COVERAGE_CFLAGS)
+
+AM_LDFLAGS = \
+	$(CODE_COVERAGE_LIBS)
+
+AM_CPPFLAGS = \
+	-I$(top_srcdir) \
+	-I$(top_srcdir)/src/include \
+	-I$(top_builddir)/src/common/libflux \
+	$(ZMQ_CFLAGS) \
+	$(LIBUUID_CFLAGS) \
+	$(JANSSON_CFLAGS) \
+	$(FLUX_SECURITY_CFLAGS) \
+	$(LIBSODIUM_CFLAGS)
+
+noinst_LTLIBRARIES = libterminus.la
+
+libterminus_la_SOURCES = \
+	pty.c \
+	pty.h \
+	client.c \
+	terminus.h \
+	terminus.c
+

--- a/src/common/libterminus/client.c
+++ b/src/common/libterminus/client.c
@@ -1,0 +1,511 @@
+/************************************************************\
+ * Copyright 2020 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <unistd.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <string.h>
+#include <fcntl.h>
+#include <sys/ioctl.h>
+#include <signal.h>
+#include <termios.h>
+#include <czmq.h>
+
+#include <jansson.h>
+
+#include "src/common/libutil/fdutils.h"
+#include "src/common/libutil/llog.h"
+
+#include "pty.h"
+
+static struct termios orig_term;
+static bool term_needs_restoration = false;
+
+struct exit_waiter {
+    flux_pty_client_exit_f cb;
+    void *arg;
+};
+
+struct flux_pty_client {
+    flux_t *h;
+
+    pty_log_f llog;
+    void *llog_data;
+
+    int flags;
+    int rank;
+    char *service;
+    bool attached;
+
+    flux_watcher_t *fdw;  /* fd watcher for STDIN */
+    flux_watcher_t *sw;   /* signal watcher       */
+
+    struct termios term;
+
+    zlist_t *exit_waiters;
+    int wait_status;
+    char *exit_message;
+};
+
+static int get_winsize (struct winsize *ws)
+{
+    return ioctl (STDIN_FILENO, TIOCGWINSZ, ws);
+}
+
+void flux_pty_client_destroy (struct flux_pty_client *c)
+{
+    if (c) {
+        int saved_errno = errno;
+        flux_watcher_destroy (c->fdw);
+        flux_watcher_destroy (c->sw);
+        zlist_destroy (&c->exit_waiters);
+        free (c->exit_message);
+        free (c->service);
+        free (c);
+        errno = saved_errno;
+    }
+}
+
+int flux_pty_client_exit_status (struct flux_pty_client *c,
+                                 int *statusp)
+{
+    if (!c || !statusp) {
+        errno = EINVAL;
+        return -1;
+    }
+    *statusp = c->wait_status;
+    return 0;
+}
+
+struct flux_pty_client *flux_pty_client_create (void)
+{
+    struct flux_pty_client *c = calloc (1, sizeof (*c));
+    if (!c)
+        return NULL;
+    c->exit_waiters = zlist_new ();
+    if (!c->exit_waiters) {
+        flux_pty_client_destroy (c);
+        return NULL;
+    }
+    return c;
+}
+
+static void notify_exit (struct flux_pty_client *c)
+{
+    struct exit_waiter *w;
+    while ((w = zlist_pop (c->exit_waiters))) {
+        (*w->cb) (c, w->arg);
+        free (w);
+    }
+}
+
+int flux_pty_client_notify_exit (struct flux_pty_client *c,
+                                 flux_pty_client_exit_f fn,
+                                 void *arg)
+{
+    struct exit_waiter *w;
+
+    if (!c || !fn) {
+        errno = EINVAL;
+        return -1;
+    }
+    w = calloc (1, sizeof (*w));
+    if (!w)
+        return -1;
+    w->cb = fn;
+    w->arg = arg;
+    if (zlist_append (c->exit_waiters, w) < 0) {
+        free (w);
+        errno = ENOMEM;
+        return -1;
+    }
+    zlist_freefn (c->exit_waiters, w, (zlist_free_fn *) free, true);
+    return 0;
+}
+
+static int invalid_flags (int flags)
+{
+    const int valid_flags =
+        FLUX_PTY_CLIENT_ATTACH_SYNC
+        | FLUX_PTY_CLIENT_CLEAR_SCREEN
+        | FLUX_PTY_CLIENT_NOTIFY_ON_ATTACH
+        | FLUX_PTY_CLIENT_NOTIFY_ON_DETACH
+        | FLUX_PTY_CLIENT_NORAW
+        | FLUX_PTY_CLIENT_STDIN_PIPE;
+    return (flags & ~valid_flags);
+}
+
+int flux_pty_client_set_flags (struct flux_pty_client *c, int flags)
+{
+    if (!c || invalid_flags (flags)) {
+        errno = EINVAL;
+        return -1;
+    }
+    c->flags = flags;
+    return 0;
+}
+
+int flux_pty_client_get_flags (struct flux_pty_client *c)
+{
+    if (!c) {
+        errno = EINVAL;
+        return -1;
+    }
+    return c->flags;
+}
+
+void flux_pty_client_set_log (struct flux_pty_client *c,
+                              pty_log_f log,
+                              void *log_data)
+{
+    if (c) {
+        c->llog = log;
+        c->llog_data = log_data;
+    }
+}
+
+static void flux_pty_client_stop (struct flux_pty_client *c)
+{
+    flux_watcher_stop (c->fdw);
+    flux_watcher_stop (c->sw);
+}
+
+static int flux_pty_client_set_server (struct flux_pty_client *c,
+                                       int rank,
+                                       const char *service)
+{
+    if (!(c->service = strdup (service)))
+        return -1;
+    c->rank = rank;
+    return 0;
+}
+
+static void cls (void)
+{
+    /* ANSI clear screen + Home */
+    printf ("\033[2J\033[;H");
+    fflush (stdout);
+}
+
+void flux_pty_client_restore_terminal (void)
+{
+    if (term_needs_restoration) {
+        tcsetattr (STDIN_FILENO, TCSADRAIN, &orig_term);
+        /* https://en.wikipedia.org/wiki/ANSI_escape_code
+         * Best effort: attempt to ensure cursor is visible:
+         */
+        printf ("\033[?25h");
+        fflush (stdout);
+        term_needs_restoration = false;
+    }
+}
+
+static int setup_terminal (struct flux_pty_client *c)
+{
+    if (tcgetattr (STDIN_FILENO, &orig_term) < 0)
+        return -1;
+
+    c->term = orig_term;
+
+    cfmakeraw (&c->term);
+    c->term.c_cc[VLNEXT] = _POSIX_VDISABLE;
+    c->term.c_cc[VMIN] = 1;
+    c->term.c_cc[VTIME] = 0;
+    if (tcsetattr (STDIN_FILENO, TCSANOW, &c->term) < 0) {
+        llog_warning (c, "failed to setup terminal\n");
+        return -1;
+    }
+    term_needs_restoration = true;
+    atexit (flux_pty_client_restore_terminal);
+    return 0;
+}
+
+static void pty_client_attached (struct flux_pty_client *c)
+{
+    /*  Setup terminal, start watching stdin for data */
+    if (!(c->flags & FLUX_PTY_CLIENT_NORAW))
+        (void) setup_terminal (c);
+    if (c->flags & FLUX_PTY_CLIENT_CLEAR_SCREEN)
+        cls ();
+    if (c->flags & FLUX_PTY_CLIENT_NOTIFY_ON_ATTACH) {
+        printf ("[attached]\r\n");
+    }
+    flux_watcher_start (c->fdw);
+    if (!(c->flags & FLUX_PTY_CLIENT_STDIN_PIPE))
+        flux_watcher_start (c->sw);
+    c->attached = true;
+}
+
+static void pty_client_data (struct flux_pty_client *c, flux_future_t *f)
+{
+    const char *data;
+    size_t len;
+
+    if (flux_rpc_get_unpack (f, "{s:s%}", "data", &data, &len) < 0) {
+        llog_error (c, "unpack: %s", future_strerror (f, errno));
+        return;
+    }
+    if (write (STDIN_FILENO, data, len) < 0) {
+        llog_error (c, "data decode failed: %s", strerror (errno));
+        return;
+    }
+}
+
+static void client_resize_cb (flux_future_t *f, void *arg)
+{
+    if (flux_future_get (f, NULL) < 0) {
+        struct flux_pty_client *c = flux_future_aux_get (f, "pty_client");
+        if (c)
+            llog_error (c, "resize: %s", future_strerror (f, errno));
+    }
+    flux_future_destroy (f);
+}
+
+/*  Server requested winsize
+ */
+static void pty_client_resize (struct flux_pty_client *c)
+{
+    flux_future_t *f;
+    struct winsize ws;
+    if (get_winsize (&ws) < 0) {
+        llog_error (c, "get winsize failed: %s", strerror (errno));
+        return;
+    }
+    if (!(f = flux_rpc_pack (c->h, c->service, c->rank, 0,
+                             "{s:s s:{s:i s:i}}",
+                             "type", "resize",
+                             "winsize",
+                               "rows", ws.ws_row,
+                               "cols", ws.ws_col))) {
+        llog_error (c, "flux_rpc_pack type=resize: %s", flux_strerror (errno));
+        return;
+    }
+    (void) flux_future_aux_set (f, "pty_client", c, NULL);
+    if (flux_future_then (f, -1., client_resize_cb, c) < 0)
+        llog_error (c, "flux_future_then: %s", flux_strerror (errno));
+}
+
+static void pty_die (struct flux_pty_client *c, const char *message)
+{
+    if (c->attached && (c->flags & FLUX_PTY_CLIENT_NOTIFY_ON_DETACH)) {
+        printf ("\033[999H[detached: %s]\033[K\n\r", message);
+        fflush (stdout);
+    }
+    notify_exit (c);
+}
+
+static void pty_client_exit (struct flux_pty_client *c, flux_future_t *f)
+{
+    const char *message;
+
+    if (flux_rpc_get_unpack (f, "{s:s s:i}",
+                                "message", &message,
+                                "status", &c->wait_status) < 0) {
+        llog_error (c, "rpc unpack: %s", future_strerror (f, errno));
+        message="unknown reason";
+    }
+    c->exit_message = strdup (message);
+    flux_pty_client_stop (c);
+}
+
+static void pty_server_cb (flux_future_t *f, void *arg)
+{
+    struct flux_pty_client *c = arg;
+    const char *type;
+    if (flux_rpc_get_unpack (f, "{s:s}", "type", &type) < 0) {
+        const char *message = c->exit_message;
+        if (errno == ENOSYS)
+            message = "No such session";
+        else if (errno != ENODATA)
+            message = future_strerror (f, errno);
+        pty_die (c, message);
+        flux_future_destroy (f);
+        return;
+    }
+    if (strcmp (type, "attach") == 0)
+        pty_client_attached (c);
+    else if (strcmp (type, "data") == 0)
+        pty_client_data (c, f);
+    else if (strcmp (type, "resize") == 0)
+        pty_client_resize (c);
+    else if (strcmp (type, "exit") == 0)
+        pty_client_exit (c, f);
+    else {
+        llog_error (c, "unknown server response type=%s", type);
+        pty_die (c, "Protocol error");
+        flux_future_destroy (f);
+    }
+    flux_future_reset (f);
+}
+
+int flux_pty_client_detach (struct flux_pty_client *c)
+{
+    flux_future_t *f;
+
+    if (!(f = flux_rpc_pack (c->h, c->service, c->rank, 0,
+                             "{s:s}", "type", "detach"))) {
+        llog_error (c, "flux_rpc_pack: %s", flux_strerror (errno));
+        return -1;
+    }
+    flux_future_destroy (f);
+    return 0;
+}
+
+static void data_write_cb (flux_future_t *f, void *arg)
+{
+    if (flux_future_get (f, NULL) < 0) {
+        struct flux_pty_client *c = flux_future_aux_get (f, "pty_client");
+        if (c)
+            llog_error (c, "data_write: %s", future_strerror (f, errno));
+    }
+    flux_future_destroy (f);
+}
+
+flux_future_t *flux_pty_client_write (struct flux_pty_client *c,
+                                      const void *buf,
+                                      ssize_t len)
+{
+    if (!c || !buf || len <= 0) {
+        errno = EINVAL;
+        return NULL;
+    }
+    return flux_rpc_pack (c->h, c->service, c->rank, 0,
+                          "{s:s s:s%}",
+                          "type", "data",
+                          "data", buf, len);
+}
+
+static void pty_read_cb (flux_reactor_t *r,
+                         flux_watcher_t *w,
+                         int revents,
+                         void *arg)
+{
+    struct flux_pty_client *c = arg;
+    flux_future_t *f;
+    char buf[4096];
+    ssize_t len;
+
+    if ((len = read (STDIN_FILENO, buf, sizeof (buf))) < 0) {
+        if (errno != EAGAIN && errno != EINTR) {
+            llog_fatal (c, "read: %s", strerror (errno));
+            pty_client_exit (c, NULL);
+        }
+        return;
+    }
+    if (len == 0) {
+        flux_pty_client_stop (c);
+        if (c->flags & FLUX_PTY_CLIENT_STDIN_PIPE)
+            flux_pty_client_detach (c);
+        return;
+    }
+    if (buf[0] == '') { /* request detach */
+        (void ) flux_pty_client_detach (c);
+        return;
+    }
+    if (!(f = flux_pty_client_write (c, buf, len))) {
+        llog_error (c, "flux_pty_client_write: %s", strerror (errno));
+        return;
+    }
+    (void) flux_future_aux_set (f, "pty_client", c, NULL);
+    if (flux_future_then (f, -1., data_write_cb, c) < 0) {
+        llog_error (c, "flux_future_then: %s", strerror (errno));
+        flux_future_destroy (f);
+    }
+}
+
+static void sigwinch_cb (flux_reactor_t *r,
+                         flux_watcher_t *w,
+                         int revents,
+                         void *arg)
+{
+    pty_client_resize ((struct flux_pty_client *)arg);
+}
+
+int flux_pty_client_attach (struct flux_pty_client *c,
+                            flux_t *h,
+                            int rank,
+                            const char *service)
+{
+    flux_future_t *f;
+    struct winsize ws;
+    const char *mode;
+
+    if (!c || !h || !service) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    if (isatty (STDIN_FILENO) && get_winsize (&ws) < 0)
+        return -1;
+
+    /*  In some test conditions, get_winsize returns 0 for
+     *   rows or columns. Fix that here. It shouldn't be an
+     *   issue with a real tty.
+     */
+    if (ws.ws_row <= 0)
+        ws.ws_row = 1;
+    if (ws.ws_col <= 0)
+        ws.ws_col = 1;
+
+    if (flux_pty_client_set_server (c, rank, service) < 0)
+        return -1;
+
+    c->h = h;
+
+    c->fdw = flux_fd_watcher_create (flux_get_reactor (h),
+                                     STDIN_FILENO,
+                                     FLUX_POLLIN,
+                                     pty_read_cb,
+                                     c);
+    c->sw = flux_signal_watcher_create (flux_get_reactor (h),
+                                        SIGWINCH,
+                                        sigwinch_cb,
+                                        c);
+    if (!c->fdw || !c->sw)
+        return -1;
+
+    mode = c->flags & FLUX_PTY_CLIENT_STDIN_PIPE ? "wo" : "rw";
+
+    if (!(f = flux_rpc_pack (h, service, rank, FLUX_RPC_STREAMING,
+                             "{s:s s:s s:{s:i s:i}}",
+                             "type", "attach",
+                             "mode", mode,
+                             "winsize",
+                              "rows", ws.ws_row,
+                              "cols", ws.ws_col))) {
+            llog_error (c, "flux_rpc_pack: %s", flux_strerror (errno));
+            return -1;
+    }
+    if (c->flags & FLUX_PTY_CLIENT_ATTACH_SYNC) {
+        const char *type;
+        if (flux_rpc_get_unpack (f, "{s:s}", "type", &type) < 0
+            || strcmp (type, "attach") != 0) {
+            flux_future_destroy (f);
+            return -1;
+        }
+        /*  No need to reset future `f` here. The fulfilled future will
+         *   immediately invoke pty_server_cb(), which expects a message
+         *   of type=attach from server
+         */
+    }
+    if (flux_future_then (f, -1, pty_server_cb, c) < 0) {
+        flux_future_destroy (f);
+        return -1;
+    }
+    return 0;
+}
+
+/* vi: ts=4 sw=4 expandtab
+ */
+

--- a/src/common/libterminus/pty.c
+++ b/src/common/libterminus/pty.c
@@ -1,0 +1,599 @@
+/************************************************************\
+ * Copyright 2020 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/*  pseudoterminal multiplexer like dtach, but using flux service
+ *   endpoint and messages rather than unix domain sockets.
+ *
+ *   Run and attach to a process anywhere in your Flux instance.
+ *
+ *  PROTOCOL:
+ *
+ *  Client attach to server:
+ *  { "type":"attach", "mode":s, "winsize":{"rows":i,"colums":i}}
+ *  where mode is one of "rw", "ro", or "rw"
+ *
+ *  Server response to attach:
+ *  { "type":"attach" }
+ *
+ *  Resize request: (client->server or server->client)
+ *  { "type":"resize", "winsize"?{"rows":i,"colums":i} }
+ *
+ *  Client/server write raw data to tty (string is utf-8)
+ *  { "type":"data", "data":s% }
+ *
+ *  Client detach:
+ *  { "type":"detach" }
+ *
+ *  Server tell client to exit (if process exited, include exit status):
+ *  { "type":"exit", "message":s, "status":i }
+ *
+ *  ENODATA: End of streaming RPC
+ *
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <unistd.h>
+#include <stdlib.h>
+#include <fcntl.h>
+#include <sys/ioctl.h>
+#include <termios.h>
+
+#include <jansson.h>
+#include <czmq.h>
+
+#include "src/common/libutil/fdutils.h"
+#include "src/common/libutil/errno_safe.h"
+
+#include "src/common/libutil/llog.h"
+
+#include "pty.h"
+
+struct pty_client {
+    char *uuid;
+    const flux_msg_t *req;
+
+    bool write_enabled;
+    bool read_enabled;
+};
+
+struct flux_pty {
+    flux_t *h;
+
+    pty_log_f llog;
+    void *llog_data;
+
+    int master;
+    char *slave;
+    flux_watcher_t *fdw;
+
+    int flags;
+    int exit_status;
+
+    zlist_t *clients;
+};
+
+static void pty_client_destroy (struct pty_client *c)
+{
+    if (c) {
+        int saved_errno = errno;
+        flux_msg_decref (c->req);
+        free (c->uuid);
+        free (c);
+        errno = saved_errno;
+    }
+}
+
+static struct pty_client *pty_client_create (const flux_msg_t *msg)
+{
+    char *uuid = NULL;
+    struct pty_client *c = NULL;
+
+    if (!(c = calloc (1, sizeof (*c))))
+        return NULL;
+    if (flux_msg_get_route_first (msg, &uuid) < 0)
+        return NULL;
+    c->req = flux_msg_incref (msg);
+    c->uuid = uuid;
+    return c;
+}
+
+static struct pty_client *pty_client_find (struct flux_pty *pty,
+                                           const char *uuid)
+{
+    struct pty_client *c = zlist_first (pty->clients);
+    while (c) {
+        if (strcmp (c->uuid, uuid) == 0)
+            break;
+        c = zlist_next (pty->clients);
+    }
+    return c;
+}
+
+static struct pty_client *pty_client_find_sender (struct flux_pty *pty,
+                                                  const flux_msg_t *msg)
+{
+    struct pty_client *c = NULL;
+    char *uuid = NULL;
+
+    if (flux_msg_get_route_first (msg, &uuid) < 0) {
+        llog_error (pty, "flux_msg_get_route_first: %s", strerror (errno));
+        return NULL;
+    }
+    if (uuid == NULL) {
+        llog_error (pty, "flux_msg_get_route_first: uuid is NULL!");
+        return NULL;
+    }
+    c = pty_client_find (pty, uuid);
+    free (uuid);
+
+    return c;
+}
+
+static int pty_client_send_exit (struct flux_pty *pty,
+                                 struct pty_client *c,
+                                 const char *message,
+                                 int status)
+{
+    if (flux_respond_pack (pty->h, c->req,
+                              "{s:s s:s? s:i}",
+                              "type", "exit",
+                              "message", message,
+                              "status", status) < 0)
+        return -1;
+    /* End of stream */
+    return flux_respond_error (pty->h, c->req, ENODATA, NULL);
+}
+
+static int pty_clients_notify_exit (struct flux_pty *pty, int status)
+{
+    struct pty_client *c = zlist_first (pty->clients);
+    while (c) {
+        if (pty_client_send_exit (pty, c, "session exiting", status) < 0)
+            llog_error (pty, "send_exit: %s", flux_strerror (errno));
+        c = zlist_next (pty->clients);
+    }
+    return 0;
+}
+
+static int pty_client_detach (struct flux_pty *pty, struct pty_client *c)
+{
+    if (c) {
+        pty_client_send_exit (pty, c, "Client requested detach", 0);
+        zlist_remove (pty->clients, c);
+        pty_client_destroy (c);
+    }
+    /* XXX: Resize remaining clients? */
+    return 0;
+}
+
+int flux_pty_disconnect_client (struct flux_pty *pty, const char *sender)
+{
+    if (!pty || !sender) {
+        errno = EINVAL;
+        return -1;
+    }
+    return pty_client_detach (pty, pty_client_find (pty, sender));
+}
+
+int flux_pty_kill (struct flux_pty *pty, int sig)
+{
+    pid_t pgrp = -1;
+    if (!pty || sig <= 0) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (ioctl (pty->master, TIOCSIG, sig) >= 0)
+        return 0;
+    llog_debug (pty, "ioctl (TIOCSIG): %s", strerror (errno));
+    if (ioctl (pty->master, TIOCGPGRP, &pgrp) >= 0
+        && pgrp > 0
+        && kill (-pgrp, sig) >= 0)
+        return 0;
+    llog_debug (pty, "ioctl (TIOCPGRP): %s", strerror (errno));
+    return -1;
+}
+
+static void pty_clients_destroy (struct flux_pty *pty)
+{
+    struct pty_client *c = zlist_first (pty->clients);
+    while (c) {
+        pty_client_destroy (c);
+        c = zlist_next (pty->clients);
+    }
+}
+
+void flux_pty_close (struct flux_pty *pty, int status)
+{
+    if (pty) {
+        flux_watcher_destroy (pty->fdw);
+        pty_clients_notify_exit (pty, status);
+        pty_clients_destroy (pty);
+        zlist_destroy (&pty->clients);
+        if (pty->master >= 0)
+            close (pty->master);
+        free (pty->slave);
+        free (pty);
+    }
+}
+
+static struct flux_pty * flux_pty_create ()
+{
+    struct flux_pty *pty = calloc (1, sizeof (*pty));
+    if (!pty)
+        return NULL;
+    pty->master = -1;
+    pty->clients = zlist_new ();
+    return pty;
+}
+
+int flux_pty_client_count (struct flux_pty *pty)
+{
+    if (pty) {
+        return zlist_size (pty->clients);
+    }
+    return 0;
+}
+
+struct flux_pty * flux_pty_open ()
+{
+    struct flux_pty *pty = flux_pty_create ();
+    const char *name;
+    struct winsize ws = { 0 };
+    if (!pty)
+        return NULL;
+    if ((pty->master = posix_openpt (O_RDWR | O_NOCTTY |O_CLOEXEC)) < 0
+        || grantpt (pty->master) < 0
+        || unlockpt (pty->master) < 0
+        || !(name = ptsname (pty->master))
+        || !(pty->slave = strdup (name)))
+        goto err;
+
+    /*  Set a default winsize, so it isn't 0,0 */
+    ws.ws_row = 25;
+    ws.ws_col = 80;
+    if (ioctl (pty->master, TIOCSWINSZ, &ws) < 0)
+        goto err;
+
+    return pty;
+err:
+    flux_pty_close (pty, 1);
+    return NULL;
+}
+
+void flux_pty_set_log (struct flux_pty *pty,
+                       pty_log_f log,
+                       void *log_data)
+{
+    if (pty) {
+        pty->llog = log;
+        pty->llog_data = log_data;
+    }
+}
+
+int flux_pty_master_fd (struct flux_pty *pty)
+{
+    if (!pty) {
+        errno = EINVAL;
+        return -1;
+    }
+    return pty->master;
+}
+
+const char *flux_pty_name (struct flux_pty *pty)
+{
+    if (!pty) {
+        errno = EINVAL;
+        return NULL;
+    }
+    return pty->slave;
+}
+
+int flux_pty_attach (struct flux_pty *pty)
+{
+    int fd;
+    if (!pty || !pty->slave) {
+        errno = EINVAL;
+        return -1;
+    }
+    if ((fd = open (pty->slave, O_RDWR|O_NOCTTY)) < 0)
+        return -1;
+
+    /*  New session so we can attach this process to tty */
+    (void) setsid ();
+
+    /*  Make the slave pty our controlling terminal */
+    if (ioctl (fd, TIOCSCTTY, NULL) < 0)
+        return -1;
+
+    /*  dup pty/in/out onto tty fd */
+    if (dup2 (fd, STDIN_FILENO) != STDIN_FILENO
+        || dup2 (fd, STDOUT_FILENO) != STDOUT_FILENO
+        || dup2 (fd, STDERR_FILENO) != STDERR_FILENO) {
+        llog_error (pty, "dup2: %s", strerror (errno));
+        return -1;
+    }
+    if (fd > 2)
+        (void) close (fd);
+    if (pty->master >= 0)
+        (void) close (pty->master);
+    return 0;
+}
+
+static void pty_client_send_data (struct flux_pty *pty, void *data, int len)
+{
+    struct pty_client *c = zlist_first (pty->clients);
+
+    while (c) {
+        if (c->read_enabled) {
+            if (flux_respond_pack (pty->h,
+                                   c->req,
+                                   "{s:s s:s#}",
+                                   "type", "data",
+                                   "data", (char *) data, len) < 0)
+                llog_error (pty, "send data: %s", strerror (errno));
+        }
+        c = zlist_next (pty->clients);
+    }
+}
+
+static void pty_read (flux_reactor_t *r,
+                      flux_watcher_t *w,
+                      int revents,
+                      void *arg)
+{
+    struct flux_pty *pty = arg;
+    ssize_t n;
+    char buf [4096];
+
+    /* XXX: notify all clients and exit */
+    if (revents & FLUX_POLLERR)
+        return;
+
+    n = read (pty->master, buf, sizeof (buf));
+    if (n < 0) {
+        if (errno == EAGAIN || errno == EINTR)
+            return;
+        /*
+         *  pty: EIO indicates pty slave has closed.
+         *   Stop the fd watcher and continue.
+         */
+        if (errno == EIO) {
+            flux_watcher_stop (pty->fdw);
+            return;
+        }
+        llog_error (pty, "read: %s", strerror (errno));
+        return;
+    }
+    else if (n > 0)
+        pty_client_send_data (pty, buf, n);
+}
+
+static int pty_resize (struct flux_pty *pty, const flux_msg_t *msg)
+{
+    struct winsize ws = { 0 };
+
+    if (flux_msg_unpack (msg,
+                         "{s:{s:i s:i}}",
+                         "winsize",
+                         "rows", &ws.ws_row,
+                         "cols", &ws.ws_col) < 0) {
+        llog_error (pty, "msg_unpack failed: %s", strerror (errno));
+        return -1;
+    }
+    llog_debug (pty, "resize: %dx%d", ws.ws_row, ws.ws_col);
+    if (ws.ws_row <= 0 || ws.ws_col <= 0) {
+        errno = EINVAL;
+        llog_error (pty, "bad resize: row=%d, col=%d", ws.ws_row, ws.ws_col);
+        return -1;
+    }
+    if (ioctl (pty->master, TIOCSWINSZ, &ws) < 0) {
+        llog_error (pty, "ioctl: TIOCSWINSZ: %s", strerror (errno));
+        return -1;
+    }
+
+    /*  notify foreground process to redraw (best effort) */
+    (void) flux_pty_kill (pty, SIGWINCH);
+
+    return 0;
+}
+
+int flux_pty_add_exit_watcher (struct flux_pty *pty, const flux_msg_t *msg)
+{
+    struct pty_client *c = pty_client_create (msg);
+    if (!c)
+        goto err;
+    if (zlist_append (pty->clients, c) < 0) {
+        errno = ENOMEM;
+        goto err;
+    }
+    return 0;
+err:
+    pty_client_destroy (c);
+    return -1;
+}
+
+static int pty_client_set_mode (struct flux_pty *pty,
+                                struct pty_client *c,
+                                const flux_msg_t *msg)
+{
+    const char *mode;
+    if (flux_msg_unpack (msg, "{s:s}", "mode", &mode) < 0)
+        return -1;
+    /*  Valid modes are currently only "ro", "wo", "rw" */
+    if (strcmp (mode, "rw") == 0)
+        c->read_enabled = c->write_enabled = true;
+    else if (strcmp (mode, "wo") == 0)
+        c->write_enabled = true;
+    else if (strcmp (mode, "ro") == 0)
+        c->read_enabled = true;
+    else {
+        llog_error (pty, "client=%s: invalid mode: %s", c->uuid, mode);
+        errno = EPROTO;
+        return -1;
+    }
+    return 0;
+}
+
+static int pty_attach (struct flux_pty *pty, const flux_msg_t *msg)
+{
+    int saved_errno;
+    struct pty_client *c = pty_client_create (msg);
+
+    if (!c)
+        goto err;
+    if (pty_client_set_mode (pty, c, msg) < 0)
+        goto err;
+
+    /*  Only start watching tty fd when first client attaches */
+    if (zlist_size (pty->clients) == 0)
+        flux_watcher_start (pty->fdw);
+    if (zlist_append (pty->clients, c) < 0) {
+        errno = ENOMEM;
+        goto err;
+    }
+    if (c->read_enabled
+        && c->write_enabled
+        && pty_resize (pty, msg) < 0)
+        goto err;
+    if (flux_respond_pack (pty->h, msg, "{s:s}", "type", "attach") < 0)
+        goto err;
+    return 0;
+err:
+    saved_errno = errno;
+    if (c)
+        zlist_remove (pty->clients, c);
+    pty_client_destroy (c);
+    errno = saved_errno;
+    return -1;
+}
+
+static int pty_write (struct flux_pty *pty, const flux_msg_t *msg)
+{
+    const char *data;
+    size_t len;
+    if (flux_msg_unpack (msg, "{s:s%}", "data", &data, &len) < 0) {
+        llog_error (pty, "msg_unpack failed");
+        return -1;
+    }
+    if (write (pty->master, data, len) < 0) {
+        llog_error (pty, "write: %s", strerror (errno));
+        return -1;
+    }
+    return 0;
+}
+
+int flux_pty_sendmsg (struct flux_pty *pty, const flux_msg_t *msg)
+{
+    struct pty_client *c;
+    uint32_t userid;
+    const char *type;
+
+    if (!pty || !pty->h || !msg) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (flux_msg_get_userid (msg, &userid) < 0)
+        goto err;
+    if (userid != getuid ()) {
+        errno = EPERM;
+        goto err;
+    }
+    if (flux_request_unpack (msg, NULL, "{s:s}", "type", &type) < 0) {
+        llog_error (pty, "request_unpack: failed to get message type");
+        goto err;
+    }
+    llog_debug (pty, "msg: userid=%u type=%s", userid, type);
+    c = pty_client_find_sender (pty, msg);
+
+    if (strcmp (type, "attach") == 0) {
+        /* It is an error for the same client to attach more than once */
+        if (c != NULL) {
+            errno = EEXIST;
+            goto err;
+        }
+        if (pty_attach (pty, msg) < 0)
+            goto err;
+        /* pty_attach() starts a streaming response. Skip singleton
+         * response below
+         */
+        return 0;
+    }
+
+    /*  It is an error for the remaining message types to come from
+     *   a sender that is not already attached.
+     */
+    if (c == NULL) {
+        errno = ENOENT;
+        goto err;
+    }
+    else if (strcmp (type, "resize") == 0) {
+       if (pty_resize (pty, msg) < 0)
+            goto err;
+    }
+    else if (strcmp (type, "data") == 0) {
+        if (c->write_enabled && pty_write (pty, msg) < 0) {
+            llog_error (pty, "pty_write: %s", strerror (errno));
+            goto err;
+        }
+    }
+    else if (strcmp (type, "detach") == 0) {
+        if (pty_client_detach (pty, c) < 0)
+            goto err;
+        if (zlist_size (pty->clients) == 0)
+            flux_watcher_stop (pty->fdw);
+    }
+    else {
+        const char *topic;
+        flux_msg_get_topic (msg, &topic);
+        llog_error (pty, "unhandled message type=%s", type);
+        errno = ENOSYS;
+        goto err;
+    }
+    if (flux_respond (pty->h, msg, NULL) < 0)
+        llog_error (pty, "flux_respond: %s", flux_strerror (errno));
+    return 0;
+err:
+    if (flux_respond_error (pty->h, msg, errno, NULL) < 0)
+        llog_error (pty, "flux_respond_error: %s", flux_strerror (errno));
+    return 0;
+}
+
+int flux_pty_set_flux (struct flux_pty *pty, flux_t *h)
+{
+    if (!pty || !h) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    pty->h = h;
+
+    /*  Create pty fd watcher here, but do not start it until the first
+     *   client attaches
+     */
+    pty->fdw = flux_fd_watcher_create (flux_get_reactor (h),
+                                       pty->master,
+                                       FLUX_POLLIN,
+                                       pty_read,
+                                       pty);
+    if (!pty->fdw)
+        return -1;
+
+    fd_set_nonblocking (pty->master);
+
+    return 0;
+}
+
+
+/* vi: ts=4 sw=4 expandtab
+ */
+

--- a/src/common/libterminus/pty.h
+++ b/src/common/libterminus/pty.h
@@ -1,0 +1,158 @@
+/************************************************************\
+ * Copyright 2020 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* Simple pty/terminal client/server over flux messages */
+
+#ifndef FLUX_PTY_H
+#define FLUX_PTY_H
+
+#include <flux/core.h>
+
+typedef void (*pty_log_f) (void *arg,
+                           const char *file,
+                           int line,
+                           const char *func,
+                           const char *subsys,
+                           int level,
+                           const char *fmt,
+                           va_list args);
+
+struct flux_pty;
+struct flux_pty_client;
+
+
+/* server:
+ */
+
+/*  Open a new server-side pty handle.
+ */
+struct flux_pty *flux_pty_open (void);
+
+/*  Close pty server - `status` may be set to the wait status of a
+ *   terminating child process of the pty. This status will be forwarded
+ *   to any currently connected clients.
+ */
+void flux_pty_close (struct flux_pty *pty, int status);
+
+/*  Send signal `sig` to the foreground process group of `pty`.
+ */
+int  flux_pty_kill (struct flux_pty *pty, int sig);
+
+/*  Set internal logger for this pty instance.
+ */
+void flux_pty_set_log (struct flux_pty *pty,
+                       pty_log_f log,
+                       void *log_data);
+
+int flux_pty_master_fd (struct flux_pty *pty);
+
+/*  Return the slave name for this pty
+ */
+const char *flux_pty_name (struct flux_pty *pty);
+
+/*  Attach the current process to slave end of pty
+ *  (e.g. called from pre_exec hook of a flux_subprocess_t)
+ */
+int flux_pty_attach (struct flux_pty *pty);
+
+int flux_pty_set_flux (struct flux_pty *pty, flux_t *h);
+
+/*  Return the current number of connected clients for pty
+ */
+int flux_pty_client_count (struct flux_pty *pty);
+
+/*  Send a request msg to the pty server pty. Used in a msg_handler
+ *   for the pty topic string for this pty service.
+ */
+int flux_pty_sendmsg (struct flux_pty *pty, const flux_msg_t *msg);
+
+/*  Add new client that recieves no data, only waits for pty to exit
+ */
+int flux_pty_add_exit_watcher (struct flux_pty *pty, const flux_msg_t *msg);
+
+/*  Disconnect any client mathing sender
+ */
+int flux_pty_disconnect_client (struct flux_pty *pty, const char *sender);
+
+
+/* client:
+ */
+
+enum {
+    FLUX_PTY_CLIENT_ATTACH_SYNC =      1,  /* Synchronous attach            */
+    FLUX_PTY_CLIENT_CLEAR_SCREEN =     2,  /* Clear screen on attach        */
+    FLUX_PTY_CLIENT_NOTIFY_ON_ATTACH = 4,  /* Informational msg on attach   */
+    FLUX_PTY_CLIENT_NOTIFY_ON_DETACH = 8,  /* Informational msg on attach   */
+    FLUX_PTY_CLIENT_NORAW =           16,  /* Do not set raw mode on attach */
+    FLUX_PTY_CLIENT_STDIN_PIPE =      32,  /* Pipe stdin to remote on attach*/
+};
+
+/*  Create a new pty client
+ */
+struct flux_pty_client *flux_pty_client_create (void);
+
+void flux_pty_client_destroy (struct flux_pty_client *c);
+
+int flux_pty_client_set_flags (struct flux_pty_client *c,
+                               int flags);
+int flux_pty_client_get_flags (struct flux_pty_client *c);
+
+/*  Set internal pty client logging function
+ */
+void flux_pty_client_set_log (struct flux_pty_client *c,
+                              pty_log_f log,
+                              void *log_data);
+
+
+/*  Attach pty client to server at rank,service endpoint. The current tty
+ *   will be put into "raw" mode. Terminal will be restored when process
+ *   exits, or flux_pty_client_restore_terminal() is called.
+ *
+ *  Will block until first attach response if FLUX_PTY_CLIENT_ATTACH_SYNC
+ *   was set in flags.
+ *
+ *  Screen is cleared on attach if FLUX_PTY_CLIENT_CLEAR_SCREEN is set.
+ */
+int flux_pty_client_attach (struct flux_pty_client *c,
+                            flux_t *h,
+                            int rank,
+                            const char *service);
+
+/*  Write data out-of-band to remote pty.
+ */
+flux_future_t *flux_pty_client_write (struct flux_pty_client *c,
+                                      const void *buf,
+                                      ssize_t len);
+
+/*  Send request to pty server to detach the current client.
+ *  Client will call exit callback when detach is complete.
+ */
+int flux_pty_client_detach (struct flux_pty_client *c);
+
+
+typedef void (*flux_pty_client_exit_f) (struct flux_pty_client *c,
+                                        void *arg);
+
+/*  Call supplied function when pty client `c` "exits" i.e. detaches
+ *   or remote pty exits.
+ */
+int flux_pty_client_notify_exit (struct flux_pty_client *c,
+                                 flux_pty_client_exit_f fn,
+                                 void *arg);
+
+int flux_pty_client_exit_status (struct flux_pty_client *c, int *statusp);
+
+void flux_pty_client_restore_terminal (void);
+
+#endif /* !FLUX_PTY_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libterminus/terminus.c
+++ b/src/common/libterminus/terminus.c
@@ -1,0 +1,897 @@
+/************************************************************\
+ * Copyright 2020 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* libterminus - Termin(al) User Services for Flux
+ *
+ * Manages multiple Flux pty sessions behind a common *-terminus
+ *  service endpoint. Supports;
+ *
+ * - Create new terminal session: *terminus.new
+ *
+ *   IN:   { "name":s "cmd":[] "environ":{} "cwd":s }
+ *   OUT:  { "name":s "pty_service":s "id":i }
+ *
+ * - List current terminal sessions: *terminus.list
+ *
+ *   IN:   {}
+ *   OUT:  { "server":{ "service":s "rank":i "ctime":f }
+ *           "sessions":[ { "id":i "name":s "clients"i
+ *                          "pid"i "ctime":f }, ...
+ *                      ]
+ *         }
+ *
+ * - Kill terminal sessions by ID: *terminus.kill
+ *   If 'wait', then reponse will be delayed until session exits
+ *
+ *   IN:   { "id":i "signal":i "wait"?i }
+ *   OUT:  {}
+ *
+ * - Kill all sessions: *terminus.kill-server
+ *
+ *   IN:   {}
+ *   OUT:  {} (response after all sessions exit)
+ *
+ *
+ * Sessions are managed on *terminus.ID service endpoints.
+ * Once the session ID is known, a client may connect directly to
+ * to the pty server at this service, using the protocol detailed
+ * in pty.c.
+ */
+
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <errno.h>
+#include <string.h>
+#include <czmq.h>
+
+#include <jansson.h>
+
+#include <flux/idset.h>
+
+#include "src/common/libutil/llog.h"
+#include "src/common/libterminus/pty.h"
+
+#include "terminus.h"
+
+extern char **environ;
+
+struct terminus_session {
+    struct flux_terminus_server *server;
+
+    char *name;
+    char topic[128];
+    flux_msg_handler_t *mh;
+
+    int id;
+    double ctime;
+
+    flux_subprocess_t *p;
+    flux_cmd_t *cmd;
+
+    bool wait_on_attach; /* wait at least one attach before reaping */
+    bool exited;         /* true if subprocess exited */
+
+    struct flux_pty *pty;
+};
+
+struct empty_waiter {
+    flux_terminus_server_empty_f cb;
+    void *arg;
+};
+
+struct flux_terminus_server {
+    flux_t *h;
+    uint32_t rank;
+
+    flux_msg_handler_t **handlers;
+
+    terminus_log_f llog;
+    void *llog_data;
+
+    char service[128];
+
+    struct idset *idset;
+
+    double ctime;
+    zlist_t *sessions;
+    zlist_t *empty_waiters;
+};
+
+static void notify_empty_waiters (struct flux_terminus_server *ts)
+{
+    struct empty_waiter *w;
+    while ((w = zlist_pop (ts->empty_waiters))) {
+        (*w->cb) (ts, w->arg);
+        free (w);
+    }
+}
+
+static void server_remove_session (struct flux_terminus_server *ts,
+                                   struct terminus_session *s)
+{
+    if (s) {
+        zlist_remove (ts->sessions, s);
+        if (zlist_size (ts->sessions) == 0)
+            notify_empty_waiters (ts);
+    }
+}
+
+
+static void try_session_close (struct terminus_session *s)
+{
+    if (!s->wait_on_attach) {
+        flux_pty_close (s->pty, flux_subprocess_status (s->p));
+        s->pty = NULL;
+        server_remove_session (s->server, s);
+    }
+}
+
+static void session_msg_handler (flux_t *h,
+                                 flux_msg_handler_t *mh,
+                                 const flux_msg_t *msg,
+                                 void *arg)
+{
+    struct terminus_session *s = arg;
+    if (flux_pty_sendmsg (s->pty, msg) < 0)
+        llog_error (s->server, "flux_pty_sendmsg: %s", strerror (errno));
+
+    /*  If session is waiting for first attach, and there is 1 or
+     *   more clients attached now, then wait can be disabled
+     */
+    if (s->wait_on_attach && flux_pty_client_count (s->pty) > 0)
+        s->wait_on_attach = false;
+    if (s->exited)
+        try_session_close (s);
+}
+
+static int terminus_msg_handler_start (struct terminus_session *s)
+{
+    struct flux_match match = FLUX_MATCH_REQUEST;
+
+    match.topic_glob = s->topic;
+    if (!(s->mh = flux_msg_handler_create (s->server->h,
+                                           match,
+                                           session_msg_handler,
+                                           s)))
+        return -1;
+    flux_msg_handler_allow_rolemask (s->mh, FLUX_ROLE_USER);
+    flux_msg_handler_start (s->mh);
+    return 0;
+}
+
+
+static void terminus_session_destroy (struct terminus_session *s)
+{
+    if (s) {
+        if (s->id >= 0)
+            idset_clear (s->server->idset, s->id);
+        /* Should already be closed when process exits, but
+         *  we try again anyway to avoid leaks
+         */
+        flux_pty_close (s->pty, 0);
+        flux_msg_handler_destroy (s->mh);
+        free (s->name);
+        flux_subprocess_destroy (s->p);
+        free (s);
+    }
+}
+
+static struct terminus_session *
+terminus_session_create (struct flux_terminus_server *ts,
+                         int id,
+                         const char *name,
+                         bool wait)
+{
+    struct terminus_session *s = calloc (1, sizeof (*s));
+    if (!s)
+        return NULL;
+
+    s->id = id;
+    s->server = ts;
+    s->wait_on_attach = wait;
+    s->ctime = flux_reactor_now (flux_get_reactor (ts->h));
+    if (name && !(s->name = strdup (name)))
+        goto error;
+    if (!(s->pty = flux_pty_open ()))
+        goto error;
+    flux_pty_set_flux (s->pty, ts->h);
+    if (ts->llog)
+        flux_pty_set_log (s->pty, ts->llog, ts->llog_data);
+    if (snprintf (s->topic,
+                  sizeof (s->topic),
+                  "%s.%d",
+                  s->server->service,
+                  s->id) >= sizeof (s->topic)) {
+        errno = EOVERFLOW;
+        goto error;
+    }
+    if (terminus_msg_handler_start (s) < 0)
+        goto error;
+    if (zlist_append (ts->sessions, s) < 0) {
+        errno = ENOMEM;
+        goto error;
+    }
+    if (!zlist_freefn (ts->sessions,
+                       s,
+                       (zlist_free_fn *) terminus_session_destroy,
+                       true)) {
+        errno = ENOENT;
+        goto error;
+    }
+    return s;
+error:
+    /*  On error we _possibly_ need remove session from zlist,
+     *   but definitely need to manually destroy session, since
+     *   zlist_freefn() is guaranteed not to have been called if
+     *   we got here.
+     */
+    if (s) {
+        int saved_errno = errno;
+        zlist_remove (ts->sessions, s);
+        terminus_session_destroy (s);
+        errno = saved_errno;
+    }
+    return NULL;
+}
+
+static int terminus_session_kill (struct terminus_session *s, int signum)
+{
+    /*  When killing a session, clear the wait flag so we don't hang
+     *   waiting on the first attach.
+     */
+    s->wait_on_attach = false;
+
+    /*  Session may have already exited if wait_on_attach.
+     *  Close the pty now to avoid a hang.
+     */
+    if (s->exited) {
+        try_session_close (s);
+        return 0;
+    }
+    /*  First kill processes using pty, then signal process group,
+     *   though they may be one in the same
+     */
+    if (flux_pty_kill (s->pty, signum) < 0
+        || kill (-flux_subprocess_pid (s->p), signum) < 0)
+        return -1;
+    return 0;
+}
+
+#if CODE_COVERAGE_ENABLED
+extern void __gcov_flush ();
+#endif
+static void terminus_pty_attach (flux_subprocess_t *p, void *arg)
+{
+    struct terminus_session *s = arg;
+    if (flux_pty_attach (s->pty) < 0) {
+        llog_fatal (s->server, "terminus: pty attach: %s\n", strerror (errno));
+        _exit (1);
+    }
+#if CODE_COVERAGE_ENABLED
+    __gcov_flush ();
+#endif
+}
+
+int flux_terminus_server_session_close (struct flux_terminus_server *ts,
+                                        struct flux_pty *pty,
+                                        int status)
+{
+    struct terminus_session *s;
+
+    if (!ts || !pty || status < 0) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    s = zlist_first (ts->sessions);
+    while (s) {
+        if (s->pty == pty)
+            break;
+        s = zlist_next (ts->sessions);
+    }
+    if (s)  {
+        flux_pty_close (s->pty, status);
+        s->pty = NULL;
+        server_remove_session (ts, s);
+        return 0;
+    }
+    errno = ENOENT;
+    return -1;
+}
+
+static void terminus_session_exit (flux_subprocess_t *p)
+{
+    struct terminus_session *s = flux_subprocess_aux_get (p, "terminus");
+    llog_debug (s->server, "session %d exit: pid=%ld status=%d",
+                s->id,
+                (long) flux_subprocess_pid (p),
+                flux_subprocess_status (p));
+    s->exited = true;
+    try_session_close (s);
+}
+
+static int terminus_session_start (struct terminus_session *s,
+                                   flux_cmd_t *cmd)
+{
+    int flags = FLUX_SUBPROCESS_FLAGS_STDIO_FALLTHROUGH;
+    flux_subprocess_hooks_t hooks = {
+        .pre_exec = terminus_pty_attach,
+        .pre_exec_arg = s,
+    };
+    flux_subprocess_ops_t ops = {
+        .on_completion = terminus_session_exit,
+    };
+    s->cmd = cmd;
+    s->p = flux_local_exec (flux_get_reactor (s->server->h),
+                            flags,
+                            cmd,
+                            &ops,
+                            &hooks);
+    if (!s->p)
+        goto cleanup;
+    if (flux_subprocess_aux_set (s->p, "terminus", s, NULL) < 0)
+        goto cleanup;
+    return 0;
+cleanup:
+    flux_subprocess_destroy (s->p);
+    s->p = NULL;
+    return -1;
+}
+
+static void flux_terminus_server_stop (struct flux_terminus_server *ts)
+{
+    flux_msg_handler_delvec (ts->handlers);
+    ts->handlers = NULL;
+}
+
+int flux_terminus_server_notify_empty (struct flux_terminus_server *ts,
+                                       flux_terminus_server_empty_f cb,
+                                       void *arg)
+{
+    struct empty_waiter *w;
+
+    if (!ts || !cb) {
+        errno = EINVAL;
+        return -1;
+    }
+    w = calloc (1, sizeof (*w));
+    if (!w)
+        return -1;
+    w->cb = cb;
+    w->arg = arg;
+    if (zlist_append (ts->empty_waiters, w) < 0) {
+        free (w);
+        return -1;
+    }
+    zlist_freefn (ts->empty_waiters, w, (zlist_free_fn *) free, true);
+    return 0;
+}
+
+void flux_terminus_server_destroy (struct flux_terminus_server *t)
+{
+    if (t) {
+        flux_terminus_server_stop (t);
+        zlist_destroy (&t->empty_waiters);
+        zlist_destroy (&t->sessions);
+        idset_destroy (t->idset);
+        free (t);
+    }
+}
+
+struct terminus_session * session_lookup (struct flux_terminus_server *ts,
+                                          int id)
+{
+    struct terminus_session *s = zlist_first (ts->sessions);
+    while (s) {
+        if (s->id == id)
+            return s;
+        s = zlist_next (ts->sessions);
+    }
+    return NULL;
+}
+
+/*  Build a flux_cmd_t from the msg 'msg'.
+ *  All of cmd, environ, and cwd are optional, with defaults '$SHELL'
+ *   current environment, and current working directory respectively.
+ */
+static flux_cmd_t *make_cmd (const flux_msg_t *msg)
+{
+    int i;
+    char cwd_buf [4096];
+    json_t *val;
+    json_t *cmd_array = NULL;
+    const char *cwd = NULL;
+    json_t *env = NULL;
+    flux_cmd_t *cmd = NULL;
+    const char *shell = getenv ("SHELL");
+
+    if (flux_msg_unpack (msg,
+                         "{s?o s?o s?s}",
+                         "cmd", &cmd_array,
+                         "environ", &env,
+                         "cwd", &cwd) < 0)
+        return NULL;
+
+    if ((cmd_array && !json_is_array (cmd_array))
+        || (env && !json_is_object (env))) {
+        errno = EPROTO;
+        goto err;
+    }
+
+    if (!(cmd = flux_cmd_create (0, NULL, env ? NULL: environ)))
+        goto err;
+
+    if (cmd_array && json_array_size (cmd_array) > 0) {
+        json_array_foreach (cmd_array, i, val) {
+            if (flux_cmd_argv_append (cmd, json_string_value (val)) < 0)
+                goto err;
+        }
+    }
+    else if (flux_cmd_argv_append (cmd, shell ? shell : "bash") < 0)
+        goto err;
+
+    if (!cwd)
+        cwd = getcwd (cwd_buf, sizeof (cwd_buf));
+    if (flux_cmd_setcwd (cmd, cwd) < 0)
+        goto err;
+
+    if (env) {
+        const char *key;
+        json_t *val;
+        json_object_foreach (env, key, val) {
+            const char *s = json_string_value (val);
+            if (flux_cmd_setenvf (cmd, 1, key, "%s", s) < 0)
+                goto err;
+        }
+    }
+
+    return cmd;
+err:
+    flux_cmd_destroy (cmd);
+    return NULL;
+}
+
+static int session_id (struct flux_terminus_server *ts)
+{
+    unsigned int i = 0;
+    while (idset_test (ts->idset, i))
+        ++i;
+    if (idset_set (ts->idset, i) < 0)
+        return -1;
+    return i;
+}
+
+static char *make_errmsg (char *buf, int buflen, const char *fmt, ...)
+{
+    va_list ap;
+    int saved_errno = errno;
+    va_start (ap, fmt);
+    vsnprintf (buf, buflen, fmt, ap);
+    va_end (ap);
+    errno = saved_errno;
+    return buf;
+}
+
+struct flux_pty *
+flux_terminus_server_session_open (struct flux_terminus_server *ts,
+                                   int id,
+                                   const char *name)
+{
+    struct terminus_session *s = NULL;
+
+    if (!ts || id < 0 || !name) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (idset_test (ts->idset, id)) {
+        errno = EEXIST;
+        return NULL;
+    }
+    if (idset_set (ts->idset, id) < 0)
+        goto error;
+    if (!(s = terminus_session_create (ts, id, name, false)))
+        goto error;
+    return s->pty;
+error:
+    idset_clear (ts->idset, id);
+    return NULL;
+}
+
+static int check_userid (const flux_msg_t *msg)
+{
+    uint32_t userid;
+
+    if (flux_msg_get_userid (msg, &userid) < 0)
+        return -1;
+    if (userid != getuid ()) {
+        errno = EPERM;
+        return -1;
+    }
+    return 0;
+}
+
+static void new_session (flux_t *h,
+                         flux_msg_handler_t *mh,
+                         const flux_msg_t *msg,
+                         void *arg)
+{
+    struct flux_terminus_server *ts = arg;
+    char errbuf [128];
+    const char *errmsg = NULL;
+    const char *name = NULL;
+    flux_cmd_t *cmd;
+    int id;
+    bool wait = true;
+    struct terminus_session *s = NULL;
+
+    if (check_userid (msg) < 0)
+        goto error;
+
+    if (flux_request_unpack (msg, NULL,
+                             "{s?s}",
+                             "name", &name) < 0) {
+        errno = EPROTO;
+        goto error;
+    }
+    if (!(cmd = make_cmd (msg))) {
+        errno = EPROTO;
+        errmsg = "failed to parse cmd field";
+        goto error;
+    }
+    if (!name || strlen (name) == 0)
+        name = flux_cmd_arg (cmd, 0);
+    if ((id = session_id (ts)) < 0) {
+        errmsg = "unable to get new session id";
+        goto error;
+    }
+    if (flux_cmd_setenvf (cmd, 1, "FLUX_TERMINUS_SESSION", "%d", id) < 0) {
+        errmsg = "failed to set FLUX_TERMINUS_SESSION in environment";
+        goto error;
+    }
+    if (!(s = terminus_session_create (ts, id, name, wait)))
+        goto error;
+    if (terminus_session_start (s, cmd) < 0) {
+        errmsg = make_errmsg (errbuf,
+                              sizeof (errbuf),
+                              "failed to run %s",
+                              flux_cmd_arg (cmd, 0));
+        goto error;
+    }
+    if (flux_respond_pack (h, msg,
+                          "{s:s s:s s:i}",
+                          "name", name,
+                          "pty_service", s->topic,
+                          "id", s->id) < 0) {
+        llog_error (ts, "flux_respond_pack: %s", strerror (errno));
+    }
+    flux_cmd_destroy (cmd);
+    return;
+error:
+    /* N.B.: triggers destruction of s
+     */
+    server_remove_session (ts, s);
+    if (flux_respond_error (h, msg, errno, errmsg) < 0)
+        llog_error (ts, "flux_respond_error: %s", strerror (errno));
+}
+
+static int list_append_session (json_t *l, struct terminus_session *s)
+{
+    json_t *o;
+
+    if (!(o = json_pack ("{s:i s:s s:i s:i s:i s:f}",
+                         "id", s->id,
+                         "name", s->name,
+                         "clients", flux_pty_client_count (s->pty),
+                         "pid", flux_subprocess_pid (s->p),
+                         "exited", s->exited,
+                         "ctime", s->ctime))) {
+        errno = ENOMEM;
+        return -1;
+    }
+    if (json_array_append_new (l, o) < 0) {
+        json_decref (o);
+        errno = ENOMEM;
+        return -1;
+    }
+    return 0;
+}
+
+json_t *server_info (struct flux_terminus_server *ts)
+{
+    return json_pack ("{s:s s:i s:f}",
+                      "service", ts->service,
+                      "rank", ts->rank,
+                      "ctime", ts->ctime);
+}
+
+static void list_sessions (flux_t *h,
+                           flux_msg_handler_t *mh,
+                           const flux_msg_t *msg,
+                           void *arg)
+{
+    struct flux_terminus_server *ts = arg;
+    struct terminus_session *s;
+    json_t *sessions = NULL;
+    json_t *info = NULL;
+
+    if (check_userid (msg) < 0)
+        goto error;
+
+    if (!(sessions = json_array ())) {
+        errno = ENOMEM;
+        goto error;
+    }
+    s = zlist_first (ts->sessions);
+    while (s) {
+        if (list_append_session (sessions, s) < 0)
+            goto error;
+        s = zlist_next (ts->sessions);
+    }
+    if (!(info = server_info (ts)))
+        goto error;
+    if (flux_respond_pack (h,
+                           msg,
+                           "{s:o s:o}",
+                           "sessions", sessions,
+                           "server", info) < 0)
+        llog_error (ts, "flux_respond_pack: %s", strerror (errno));
+    return;
+error:
+    json_decref (sessions);
+    json_decref (info);
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
+         llog_error (ts, "flux_respond_error: %s", strerror (errno));
+}
+
+static void kill_sessions (flux_t *h,
+                           flux_msg_handler_t *mh,
+                           const flux_msg_t *msg,
+                           void *arg)
+{
+    struct flux_terminus_server *ts = arg;
+    struct terminus_session *s;
+    int id;
+    int signum;
+    int wait = false;
+    char *errmsg = NULL;
+
+    if (check_userid (msg) < 0)
+        goto error;
+
+    if (flux_request_unpack (msg,
+                             NULL,
+                             "{s:i s:i s?i}",
+                             "id", &id,
+                             "signal", &signum,
+                             "wait", &wait) < 0)
+        goto error;
+    if (!(s = session_lookup (ts, id))) {
+        errno = ENOENT;
+        goto error;
+    }
+    if (terminus_session_kill (s, signum) < 0)
+        goto error;
+    /*
+     *  If 'wait' flag was specified, then attach a new client to pty
+     *   that will respond once the pty has fully exited. O/w simply
+     *   respond with Success now.
+     */
+    if (wait) {
+        if (flux_pty_add_exit_watcher (s->pty, msg) < 0)
+            goto error;
+    }
+    else if (flux_respond (ts->h, msg, NULL) < 0)
+        llog_error (ts, "flux_respond: %s", strerror (errno));
+    return;
+error:
+    if (flux_respond_error (ts->h, msg, errno, errmsg) < 0)
+        llog_error (ts, "flux_respond_error: %s", strerror (errno));
+}
+
+static void kill_server_exit (struct flux_terminus_server *ts, void *arg)
+{
+    const flux_msg_t *msg = arg;
+    flux_respond (ts->h, msg, NULL);
+    flux_msg_decref (msg);
+    flux_terminus_server_stop (ts);
+}
+
+static void kill_server (flux_t *h,
+                         flux_msg_handler_t *mh,
+                         const flux_msg_t *msg,
+                         void *arg)
+{
+    struct flux_terminus_server *ts = arg;
+    struct terminus_session *s;
+
+    if (check_userid (msg) < 0)
+        goto error;
+
+    /*  If no active sessions, exit server immediately */
+    if (zlist_size (ts->sessions) == 0) {
+        kill_server_exit (ts, (void *) flux_msg_incref (msg));
+        return;
+    }
+
+    /*  Grab reference to message so we can notify when all sessions
+     *   have been killed
+     */
+    flux_msg_incref (msg);
+
+    /*  Register empty callback so that server is stopped and response
+     *   goes out when last session exits.
+     */
+    if (flux_terminus_server_notify_empty (ts,
+                                           kill_server_exit,
+                                           (void *) msg) < 0) {
+        flux_msg_decref (msg);
+        goto error;
+    }
+
+    /*  Kill all active sessions */
+    s = zlist_first (ts->sessions);
+    while (s) {
+        (void) terminus_session_kill (s, SIGKILL);
+        s = zlist_next (ts->sessions);
+    }
+    return;
+error:
+    if (flux_respond_error (ts->h, msg, errno, NULL) < 0)
+        llog_error (ts, "flux_respond_error: %s", strerror (errno));
+}
+
+static void disconnect_cb (flux_t *h,
+                           flux_msg_handler_t *mh,
+                           const flux_msg_t *msg,
+                           void *arg)
+{
+    struct flux_terminus_server *ts = arg;
+    struct terminus_session *s;
+    char *sender = NULL;
+
+    if (flux_msg_get_route_first (msg, &sender) < 0) {
+        llog_error (ts, "flux_msg_get_route_first: %s", strerror (errno));
+        goto out;
+    }
+    s = zlist_first (ts->sessions);
+    while (s) {
+        flux_pty_disconnect_client (s->pty, sender);
+        s = zlist_next (ts->sessions);
+    }
+out:
+    free (sender);
+}
+
+static const struct flux_msg_handler_spec handler_tab[] = {
+    {
+        FLUX_MSGTYPE_REQUEST,
+        "%s.list",
+        list_sessions,
+        FLUX_ROLE_USER
+    },
+    {
+        FLUX_MSGTYPE_REQUEST,
+        "%s.new",
+        new_session,
+        FLUX_ROLE_USER
+    },
+    {
+        FLUX_MSGTYPE_REQUEST,
+        "%s.kill",
+        kill_sessions,
+        FLUX_ROLE_USER
+    },
+    {
+        FLUX_MSGTYPE_REQUEST,
+        "%s.kill-server",
+        kill_server,
+        FLUX_ROLE_USER
+    },
+    {
+        FLUX_MSGTYPE_REQUEST,
+        "%s.disconnect",
+        disconnect_cb,
+        0
+    },
+    FLUX_MSGHANDLER_TABLE_END,
+};
+
+static inline int
+msg_handler_count (const struct flux_msg_handler_spec htab[])
+{
+    int count = 0;
+    while (htab[count].topic_glob)
+        count++;
+    return count;
+}
+
+static int start_msghandlers (struct flux_terminus_server *ts,
+                              const struct flux_msg_handler_spec tab[])
+{
+    int i;
+    char topic[128];
+    int len = sizeof (topic);
+    struct flux_match match = FLUX_MATCH_REQUEST;
+    int count = msg_handler_count (tab);
+
+    ts->handlers = calloc (count+1, sizeof (*ts->handlers));
+    for (i = 0; i < count; i++) {
+        flux_msg_handler_t *mh = NULL;
+        if (snprintf (topic, len, tab[i].topic_glob, ts->service) >= len)
+            goto error;
+        match.topic_glob = topic;
+        match.typemask = tab[i].typemask;
+        if (!(mh = flux_msg_handler_create (ts->h, match, tab[i].cb, ts)))
+            goto error;
+        flux_msg_handler_allow_rolemask (mh, tab[i].rolemask);
+        flux_msg_handler_start (mh);
+        ts->handlers[i] = mh;
+    }
+    return 0;
+error:
+    flux_msg_handler_delvec (ts->handlers);
+    return -1;
+}
+
+struct flux_terminus_server *
+flux_terminus_server_create (flux_t *h, const char *service)
+{
+    struct flux_terminus_server *ts;
+
+    if (!h || !service) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (!(ts = calloc (1, sizeof (*ts)))
+        || !(ts->empty_waiters = zlist_new ())
+        || !(ts->sessions = zlist_new ())) {
+        goto err;
+    }
+    ts->h = h;
+    ts->ctime = flux_reactor_now (flux_get_reactor (h));
+
+    /*  In test mode, avoid flux_get_rank(3) as it will hang
+     */
+    if (getenv ("FLUX_TERMINUS_TEST_SERVER"))
+        ts->rank = -1;
+    else if (flux_get_rank (h, &ts->rank) < 0)
+        goto err;
+
+    if (!(ts->idset = idset_create (0, IDSET_FLAG_AUTOGROW)))
+        goto err;
+
+    if (strlen (service) > sizeof (ts->service) - 1)
+        goto err;
+    strcpy (ts->service, service);
+    
+    if (start_msghandlers (ts, handler_tab) < 0)
+        goto err;
+
+    return ts;
+err:
+    flux_terminus_server_destroy (ts);
+    return NULL;
+}
+
+void flux_terminus_server_set_log (struct flux_terminus_server *ts,
+                                   terminus_log_f log_fn,
+                                   void *log_arg)
+{
+    if (ts) {
+        ts->llog = log_fn;
+        ts->llog_data = log_arg;
+    }
+}
+
+/* vi: ts=4 sw=4 expandtab
+ */
+

--- a/src/common/libterminus/terminus.h
+++ b/src/common/libterminus/terminus.h
@@ -1,0 +1,78 @@
+/************************************************************\
+ * Copyright 2020 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef FLUX_TERMINUS_H
+#define FLUX_TERMINUS_H
+
+#include <stdarg.h>
+
+#include <flux/core.h>
+
+
+struct flux_terminus_server;
+
+/*  Logging function prototype */
+typedef void (*terminus_log_f) (void *arg,
+                                const char *file,
+                                int line,
+                                const char *func,
+                                const char *subsys,
+                                int level,
+                                const char *fmt,
+                                va_list args);
+
+/*  Callback prototype for use when a terminus server becomes "empty",
+ *   i.e. the last running session exits. (Used for optional cleanup).
+ */
+typedef void (*flux_terminus_server_empty_f) (struct flux_terminus_server *ts,
+                                              void *arg);
+
+
+/*  Create a flux_terminus_server listening at topic `service`
+ */
+struct flux_terminus_server *
+flux_terminus_server_create (flux_t *h, const char *service);
+
+void flux_terminus_server_destroy (struct flux_terminus_server *ts);
+
+/*  Set internal libterminus logging function to 'log_fn'. If unset,
+ *   then logging from the library is disabled.
+ */
+void flux_terminus_server_set_log (struct flux_terminus_server *ts,
+                                   terminus_log_f log_fn,
+                                   void *log_data);
+
+/*  Call function `fn` when terminus server next becomes empty, i.e. goes
+ *   from having 1 or more sessions to no sessions. (if there are no
+ *   current sessions, then the empty cb will *not* be called immediately,
+ *   only after at least one session is created and destroyed)
+ *
+ *  Callbacks are oneshot, i.e. they are removed after being called.
+ */
+int flux_terminus_server_notify_empty (struct flux_terminus_server *ts,
+                                       flux_terminus_server_empty_f fn,
+                                       void *arg);
+
+/*  Open a session directly in the server ts (as oppopsed to via the
+ *   protocol.
+ */
+struct flux_pty *
+flux_terminus_server_session_open (struct flux_terminus_server *ts,
+                                   int id,
+                                   const char *name);
+
+int flux_terminus_server_session_close (struct flux_terminus_server *ts,
+                                        struct flux_pty *pty,
+                                        int status);
+#endif /* !FLUX_TERMINUS_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libterminus/test/pty.c
+++ b/src/common/libterminus/test/pty.c
@@ -1,0 +1,447 @@
+/************************************************************\
+ * Copyright 2020 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+
+#include <flux/core.h>
+#include "src/common/libterminus/pty.h"
+
+#include "src/common/libtap/tap.h"
+#include "src/common/libtestutil/util.h"
+
+static void test_invalid_args ()
+{
+    struct flux_pty *pty = flux_pty_open ();
+    struct flux_pty_client *c = flux_pty_client_create ();
+
+    if (pty == NULL || c == NULL)
+        BAIL_OUT ("Failed to create pty client/server!");
+
+    lives_ok ({flux_pty_set_log (NULL, NULL, NULL);},
+              "flux_pty_set_log does nothing with NULL args");
+    lives_ok ({flux_pty_close (NULL, 0);},
+              "flux_pty_close does nothing with NULL arg");
+
+    ok (flux_pty_kill (NULL, SIGINT) < 0 && errno == EINVAL,
+        "flux_pty_kill() with NULL pty returns EINVAL");
+    ok (flux_pty_kill (pty, -1) < 0 && errno == EINVAL,
+        "flux_pty_kill() with invalid signal returns EINVAL");
+    ok (flux_pty_master_fd (NULL) < 0 && errno == EINVAL,
+        "flux_pty_master_fd() returns EINVAL with NULL arg");
+    ok (flux_pty_name (NULL) == NULL && errno == EINVAL,
+        "flux_pty_name() returns EINVAL with NULL arg");
+    ok (flux_pty_attach (NULL) < 0 && errno == EINVAL,
+        "flux_pty_attach() returns EINVAL with NULL arg");
+    ok (flux_pty_set_flux (NULL, NULL) < 0 && errno == EINVAL,
+        "flux_pty_set_flux() returns EINVAL with NULL args");
+    ok (flux_pty_set_flux (pty, NULL) < 0 && errno == EINVAL,
+        "flux_pty_set_flux() returns EINVAL with NULL flux handle");
+    ok (flux_pty_client_count (NULL) == 0,
+        "flux_pty_client_count returns 0 for NULL pty");
+    ok (flux_pty_disconnect_client (NULL, NULL) < 0 && errno == EINVAL,
+        "flux_pty_disconnect_client returns EINVAL on NULL args");
+    ok (flux_pty_disconnect_client (pty, NULL) < 0 && errno == EINVAL,
+        "flux_pty_disconnect_client returns EINVAL on NULL sender");
+
+    lives_ok ({flux_pty_client_set_log (NULL, NULL, NULL);},
+              "flux_pty_client_set_log does nothing with NULL args");
+    lives_ok ({flux_pty_client_destroy (NULL);},
+              "flux_pty_client_destroy (NULL) does nothing");
+
+    ok (flux_pty_client_attach (c, NULL, 0, NULL) < 0
+        && errno == EINVAL,
+        "flux_pty_client_attach returns EINVAL with NULL args");
+    ok (flux_pty_client_attach (NULL, NULL, 0, NULL) < 0
+        && errno == EINVAL,
+        "flux_pty_client_attach returns EINVAL with NULL handle");
+
+    ok (flux_pty_client_notify_exit (NULL, NULL, NULL) < 0 && errno == EINVAL,
+        "flux_pty_client_notify_exit() returns EINVAL on NULL client");
+    ok (flux_pty_client_notify_exit (c, NULL, NULL) < 0 && errno == EINVAL,
+        "flux_pty_client_notify_exit() returns EINVAL on NULL args");
+
+    ok (flux_pty_client_write (NULL, NULL, 0) == NULL && errno == EINVAL,
+        "flux_pty_client_write() returns EINVAL on NULL args");
+
+    ok (flux_pty_client_set_flags (NULL, 0) < 0 && errno == EINVAL,
+        "flux_pty_client_set_flags returns EINVAL on NULL arg");
+    ok (flux_pty_client_set_flags (c, -1) < 0 && errno == EINVAL,
+        "flux_pty_client_set_flags returns EINVAL on bad flags");
+
+    ok (flux_pty_client_get_flags (NULL) < 0 && errno == EINVAL,
+        "flux_pty_client_gett_flags returns EINVAL on NULL arg");
+
+    ok (flux_pty_client_exit_status (NULL, NULL) < 0 && errno == EINVAL,
+        "flux_pty_client_get_exit_status returns EINVAL on NULL args");
+    ok (flux_pty_client_exit_status (c, NULL) < 0 && errno == EINVAL,
+        "flux_pty_client_get_exit_status returns EINVAL on NULL statusp");
+
+    flux_pty_close (pty, 0);
+    flux_pty_client_destroy (c);
+}
+
+static void test_empty_server ()
+{
+    struct flux_pty *pty = flux_pty_open ();
+
+    ok (pty != NULL,
+        "flux_pty_open works");
+    ok (flux_pty_master_fd (pty) >= 0,
+        "pty master fd is valid");
+    ok (flux_pty_client_count (pty) == 0,
+        "pty client count is 0 for newly created pty server");
+    flux_pty_close (pty, 0);
+}
+
+static void tap_logger (void *arg,
+                        const char *file,
+                        int line,
+                        const char *func,
+                        const char *subsys,
+                        int level,
+                        const char *fmt,
+                        va_list ap)
+{
+    struct flux_pty *pty = arg;
+    char buf [4096];
+    int len = sizeof (buf);
+    if (vsnprintf (buf, len, fmt, ap) >= len) {
+        buf[len-1] = '\0';
+        buf[len-2] = '+';
+    }
+    diag ("pty: %s: %s:%d %s(): %s",
+          flux_pty_name (pty), file, line, func, buf);
+}
+
+static void pty_server_cb (flux_t *h,
+                           flux_msg_handler_t *mh,
+                           const flux_msg_t *msg,
+                           void *arg)
+{
+    struct flux_pty *pty = arg;
+    if (flux_pty_sendmsg (pty, msg) < 0)
+        fail ("flux_pty_sendmsg returned -1: %s", strerror (errno));
+}
+
+static int pty_server (flux_t *h, void *arg)
+{
+    int rc = -1;
+    struct flux_pty * pty = NULL;
+    flux_msg_handler_t *mh = NULL;
+    struct flux_match match = FLUX_MATCH_REQUEST;
+
+    pty = flux_pty_open ();
+    if (!pty)
+        goto out;
+
+    flux_pty_set_log (pty, tap_logger, pty);
+    flux_pty_set_flux (pty, h);
+    diag ("pty_server: opened %s", flux_pty_name (pty));
+
+    mh = flux_msg_handler_create (h, match, pty_server_cb, pty);
+    if (!mh)
+        goto out;
+    flux_msg_handler_start (mh);
+
+    rc = flux_reactor_run (flux_get_reactor (h), 0);
+    diag ("pty server exiting");
+out:
+    flux_msg_handler_destroy (mh);
+    flux_pty_close (pty, 0);
+    return rc;
+}
+
+static void test_basic_protocol (void)
+{
+    flux_t *h = test_server_create (pty_server, NULL);
+    flux_future_t *f = NULL;
+    flux_future_t *f_attach = NULL;
+
+    /* invalid message, no msg type: */
+    ok ((f = flux_rpc_pack (h, "pty", 0, 0, "{}")) != NULL,
+        "request: empty payload");
+    ok (flux_rpc_get (f, NULL) < 0 && errno == EPROTO,
+        "response: EPROTO");
+    flux_future_destroy (f);
+
+
+    /* attach without terminal size: */
+    ok ((f = flux_rpc_pack (h, "pty", 0, FLUX_RPC_STREAMING,
+                            "{ s:s s:s }",
+                            "type", "attach",
+                            "mode", "rw")) != NULL,
+        "request: type attach, no winsize");
+    ok (flux_rpc_get (f, NULL) < 0 && errno == EPROTO,
+        "response: EPROTO");
+    flux_future_destroy (f);
+
+
+    /* attach without mode: */
+    ok ((f = flux_rpc_pack (h, "pty", 0, FLUX_RPC_STREAMING,
+                            "{ s:s s:{s:i s:i} }",
+                            "type", "attach",
+                            "winsize",
+                               "rows", 25,
+                               "cols", 80)) != NULL,
+        "request: type attach, no mode");
+    ok (flux_rpc_get (f, NULL) < 0 && errno == EPROTO,
+        "response: EPROTO");
+    flux_future_destroy (f);
+
+
+    /* attach: invalid mode: */
+    ok ((f = flux_rpc_pack (h, "pty", 0, FLUX_RPC_STREAMING,
+                            "{ s:s s:s s:{s:i s:i} }",
+                            "type", "attach",
+                            "mode", "x",
+                            "winsize",
+                               "rows", 25,
+                               "cols", 80)) != NULL,
+        "request: type attach, bad mode");
+    ok (flux_rpc_get (f, NULL) < 0 && errno == EPROTO,
+        "response: EPROTO");
+    flux_future_destroy (f);
+
+    /* write from unattached client: */
+    ok ((f = flux_rpc_pack (h, "pty", 0, 0,
+                            "{ s:s s:s }",
+                            "type", "data",
+                            "data", "\r")) != NULL,
+        "request: type data, unconnected client");
+    ok (flux_rpc_get (f, NULL) < 0 && errno == ENOENT,
+        "response: ENOENT");
+    flux_future_destroy (f);
+
+    /* resize from unattached client: */
+    ok ((f = flux_rpc_pack (h, "pty", 0, 0,
+                            "{s:s s:{s:i s:i}}",
+                            "type", "resize",
+                            "winsize",
+                               "rows", 25,
+                               "cols", 80)) != NULL,
+        "request: type resize, unconnected client");
+    ok (flux_rpc_get (f, NULL) < 0 && errno == ENOENT,
+        "response: ENOENT");
+    flux_future_destroy (f);
+
+
+    /* detach from unattached client: */
+    ok ((f = flux_rpc_pack (h, "pty", 0, 0,
+                            "{s:s}", "type", "detach")) != NULL,
+        "request: type detach, unconnected client");
+    ok (flux_rpc_get (f, NULL) < 0 && errno == ENOENT,
+        "response: ENOENT");
+    flux_future_destroy (f);
+
+
+    /* attach a client: */
+    ok ((f_attach = flux_rpc_pack (h, "pty", 0, FLUX_RPC_STREAMING,
+                                   "{s:s s:s s:{s:i s:i}}",
+                                   "type", "attach",
+                                   "mode", "rw",
+                                   "winsize",
+                                      "rows", 25,
+                                      "cols", 80)) != NULL,
+        "request: type attach");
+
+    const char *type = NULL;
+    ok (flux_rpc_get_unpack (f_attach, "{s:s}", "type", &type) == 0,
+        "response: OK errno=%s", strerror (errno));
+    is (type, "attach",
+        "response: type=attach");
+    flux_future_reset (f_attach);
+
+
+    /* attach client again should fail: */
+    ok ((f = flux_rpc_pack (h, "pty", 0, FLUX_RPC_STREAMING,
+                                   "{s:s s:s s:{s:i s:i}}",
+                                   "type", "attach",
+                                   "mode", "rw",
+                                   "winsize",
+                                      "rows", 25,
+                                      "cols", 80)) != NULL,
+        "request: type attach from same client");
+
+    ok (flux_rpc_get (f, NULL) < 0 && errno == EEXIST,
+        "response: EEXIST");
+    flux_future_destroy (f);
+
+
+   /* resize from attached client, invalid size */
+    ok ((f = flux_rpc_pack (h, "pty", 0, 0,
+                            "{s:s s:{s:i s:i}}",
+                            "type", "resize",
+                            "winsize",
+                               "rows", 0,
+                               "cols", 0)) != NULL,
+        "request: type resize, invalid winsize {0, 0}");
+    ok (flux_rpc_get (f, NULL) < 0 && errno == EINVAL,
+        "response: EINVAL");
+    flux_future_destroy (f);
+
+
+   /* resize from attached client, valid size */
+    ok ((f = flux_rpc_pack (h, "pty", 0, 0,
+                            "{s:s s:{s:i s:i}}",
+                            "type", "resize",
+                            "winsize",
+                               "rows", 25,
+                               "cols", 80)) != NULL,
+        "request: type resize, valid winsize {25, 80}");
+    ok (flux_rpc_get (f, NULL) == 0,
+        "response: OK");
+    flux_future_destroy (f);
+
+
+    /* write from attached client, invalid message */
+    ok ((f = flux_rpc_pack (h, "pty", 0, 0,
+                            "{s:s s:s}",
+                            "type", "data",
+                            "foo", "")) != NULL,
+        "request: type data, invald payload");
+    ok (flux_rpc_get (f, NULL) < 0 && errno == EPROTO,
+        "response: EPROTO");
+    flux_future_destroy (f);
+
+
+    /* write from attached client, invalid data */
+    ok ((f = flux_rpc_pack (h, "pty", 0, 0,
+                            "{s:s s:i}",
+                            "type", "data",
+                            "data", 2)) != NULL,
+        "request: type data, invald data type");
+    ok (flux_rpc_get (f, NULL) < 0 && errno == EPROTO,
+        "response: EPROTO");
+    flux_future_destroy (f);
+
+
+    /* invalid msg type from attached client */
+    ok ((f = flux_rpc_pack (h, "pty", 0, 0,
+                            "{s:s}",
+                            "type", "foo")) != NULL,
+        "request: type invalid");
+    ok (flux_rpc_get (f, NULL) < 0 && errno == ENOSYS,
+        "response: ENOSYS");
+    flux_future_destroy (f);
+
+
+    /* invalid msg type from attached client */
+    ok ((f = flux_rpc_pack (h, "pty", 0, 0,
+                            "{s:s}",
+                            "type", "foo")) != NULL,
+        "request: type invalid");
+    ok (flux_rpc_get (f, NULL) < 0 && errno == ENOSYS,
+        "response: ENOSYS");
+    flux_future_destroy (f);
+
+
+    /* detatch client */
+    ok ((f = flux_rpc_pack (h, "pty", 0, 0,
+                            "{s:s}",
+                            "type", "detach")) != NULL,
+        "request: type invalid");
+    ok (flux_rpc_get (f, NULL) == 0,
+        "response: OK");
+    flux_future_destroy (f);
+
+    const char *message = NULL;
+    ok (flux_rpc_get_unpack (f_attach,
+                             "{s:s s:s}",
+                             "type", &type,
+                             "message", &message) == 0,
+        "response to attach multi-response rpc");
+    is (type, "exit",
+        "response: type = exit");
+    is (message, "Client requested detach",
+        "response: message = 'Client requested detach'");
+    flux_future_reset (f_attach);
+
+    ok (flux_rpc_get (f_attach, NULL) < 0 && errno == ENODATA,
+        "response: ENODATA");
+    flux_future_destroy (f_attach);
+
+    test_server_stop (h);
+    flux_close (h);
+}
+
+static void pty_exit_cb (struct flux_pty_client *c, void *arg)
+{
+    flux_t *h = arg;
+    flux_reactor_stop (flux_get_reactor (h));
+}
+
+static void test_client()
+{
+    flux_t *h = test_server_create (pty_server, NULL);
+    flux_future_t *f = NULL;
+    int rc;
+    int flags = FLUX_PTY_CLIENT_ATTACH_SYNC
+                | FLUX_PTY_CLIENT_NORAW;
+
+    struct flux_pty_client *c = flux_pty_client_create ();
+    if (!c)
+        BAIL_OUT ("flux_pty_client_create failed");
+
+    ok (flux_pty_client_get_flags (c) == 0,
+        "initial pty client flags are 0");
+    ok (flux_pty_client_set_flags (c, -1) < 0 && errno == EINVAL,
+        "flux_pty_client_set_flags with invalid flags returns EINVAL");
+    ok (flux_pty_client_set_flags (c, flags) == 0,
+        "set client flags");
+
+    ok (flux_pty_client_notify_exit (c, pty_exit_cb, h) == 0,
+        "flux_pty_client_notify_exit");
+
+    ok (flux_pty_client_attach (c, h, 0, "pty") == 0,
+        "flux_pty_client_attach");
+
+    f = flux_pty_client_write (c, "foo\r", 4);
+    ok (f != NULL,
+        "flux_pty_client_write");
+    rc = flux_future_get (f, NULL);
+    ok (rc == 0,
+        "flux_pty_client_write: %s",
+        rc == 0 ? "Success" : strerror (errno));
+    flux_future_destroy (f);
+
+    ok (flux_pty_client_detach (c) == 0,
+        "flux_pty_client_detach");
+
+    /* Run reactor until pty client exits */
+    flux_reactor_run (flux_get_reactor (h), 0);
+
+    test_server_stop (h);
+    flux_pty_client_destroy (c);
+    flux_close (h);
+}
+
+int main (int argc, char *argv[])
+{
+    plan (NO_PLAN);
+
+    test_server_environment_init ("pty");
+    test_invalid_args ();
+    test_empty_server ();
+    test_basic_protocol ();
+    test_client ();
+
+    done_testing ();
+    return 0;
+}
+
+/*
+ * vi: ts=4 sw=4 expandtab
+ */

--- a/src/common/libterminus/test/terminus.c
+++ b/src/common/libterminus/test/terminus.c
@@ -1,0 +1,489 @@
+/************************************************************  \
+ * Copyright 2020 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+#include <jansson.h>
+
+#include <flux/core.h>
+#include "src/common/libterminus/terminus.h"
+#include "src/common/libterminus/pty.h"
+
+#include "src/common/libtap/tap.h"
+#include "src/common/libtestutil/util.h"
+
+static void test_invalid_args (void)
+{
+    ok (flux_terminus_server_create (NULL, NULL) == NULL && errno == EINVAL,
+        "flux_terminus_server_create with NULL args returns EINVAL");
+
+    lives_ok ({flux_terminus_server_destroy (NULL);},
+        "flux_terminus_server_destroy (NULL) does nothing");
+    lives_ok ({flux_terminus_server_set_log (NULL, NULL, NULL);},
+        "flux_terminus_server_set_log (NULL) does nothing");
+
+    ok (flux_terminus_server_notify_empty (NULL, NULL, NULL) < 0
+        && errno == EINVAL,
+        "flux_terminus_server_notify_empty returns EINVAL on NULL args");
+
+    ok (flux_terminus_server_session_open (NULL, 0, NULL) == NULL,
+        "flux_terminus_server_session_open with NULL args returns NULL");
+    ok (flux_terminus_server_session_close (NULL, NULL, 0) == -1
+        && errno == EINVAL,
+        "flux_terminus_server_session_close with NULL args returns EINVAL");
+}
+
+static void tap_logger (void *arg,
+                        const char *file,
+                        int line,
+                        const char *func,
+                        const char *subsys,
+                        int level,
+                        const char *fmt,
+                        va_list ap)
+{
+    char buf [4096];
+    int len = sizeof (buf);
+    if (vsnprintf (buf, len, fmt, ap) >= len) {
+        buf[len-1] = '\0';
+        buf[len-2] = '+';
+    }
+    diag ("%s:%d %s(): %s", file, line, func, buf);
+}
+
+static int terminus_server (flux_t *h, void *arg)
+{
+    int rc = -1;
+    struct flux_terminus_server *t;
+
+    /*  set rank == -1 for testing. Avoid flux_get_rank(3) */
+    setenv ("FLUX_TERMINUS_TEST_SERVER", "t", 1);
+
+    /*  N.B.: test_server handle `h` already has reactor with SIGCHLD
+     *   flag set.
+     */
+    t = flux_terminus_server_create (h, "terminus");
+    if (!t)
+        BAIL_OUT ("flux_terminus_server_create");
+
+    flux_terminus_server_set_log (t, tap_logger, NULL);
+
+    rc = flux_reactor_run (flux_get_reactor (h), 0);
+    flux_terminus_server_destroy (t);
+    //flux_close (h);
+    return rc;
+}
+
+static void test_kill_server_empty (void)
+{
+    int rc;
+    flux_future_t *f = NULL;
+    flux_t *h = test_server_create (terminus_server, NULL);
+
+    /* kill-server
+     */
+    f = flux_rpc_pack (h, "terminus.kill-server", 0, 0, "{}");
+    ok (f != NULL,
+        "terminus.kill-server");
+    rc = flux_rpc_get (f, NULL);
+    ok (rc == 0,
+        "terminus.kill-server: OK");
+    flux_future_destroy (f);
+
+    /* list, now fails
+     */
+    f = flux_rpc_pack (h, "terminus.list", 0, 0, "{}");
+    ok (f != NULL,
+        "terminus.list");
+    rc = flux_rpc_get (f, NULL);
+    ok (rc < 0 && errno == ENOSYS,
+        "terminus.list: ENOSYS");
+    flux_future_destroy (f);
+
+    test_server_stop (h);
+    flux_close (h);
+}
+
+static void test_protocol (void)
+{
+    int rc;
+    json_t *o = NULL;
+    flux_future_t *f = NULL;
+    flux_t *h = test_server_create (terminus_server, NULL);
+
+    const char *service = NULL;
+    const char *name = NULL;
+    const char *message = NULL;
+    const char *type = NULL;
+    int rank = -1;
+    int status = -1;
+    int id;
+    double ctime;
+
+    /* list, no sessions
+     */
+    f = flux_rpc_pack (h, "terminus.list", 0, 0, "{}");
+    ok (f != NULL,
+        "terminus.list");
+    rc = flux_rpc_get_unpack (f,
+                              "{s:{s:s s:i s:f} s:[]}",
+                              "server",
+                                 "service", &service,
+                                 "rank", &rank,
+                                 "ctime", &ctime,
+                              "sessions");
+    ok (rc == 0,
+        "terminus.list: OK");
+    is (service, "terminus",
+        "terminus.list returned service = terminus");
+    ok (rank == -1,
+        "terminus.list returned expected rank");
+    flux_future_destroy (f);
+
+
+    /* new, add a session, invalid proto
+     */
+    f = flux_rpc_pack (h, "terminus.new",
+                       0, 0,
+                      "{s:s}",
+                      "cmd", "/bin/bash");
+    ok (f != NULL,
+        "terminus.new: invalid proto");
+    errno = 0;
+    rc = flux_rpc_get_unpack (f, NULL);
+    ok (rc < 0 && errno == EPROTO,
+        "terminus.new (invalid proto): %s", strerror (errno));
+    flux_future_destroy (f);
+
+
+    /* new, add a session, no args
+     */
+    f = flux_rpc_pack (h, "terminus.new", 0, 0, "{}");
+    ok (f != NULL,
+        "terminus.new: no args");
+    errno = 0;
+    name = NULL;
+    service = NULL;
+    rc = flux_rpc_get_unpack (f,
+                              "{s:s s:s s:i}",
+                              "name", &name,
+                              "pty_service", &service,
+                              "id", &id);
+    ok (rc == 0,
+        "terminus.new (no args): %s", strerror (errno));
+    is (name, getenv ("SHELL"),
+        "terminus.new (no args): name is %s", getenv ("SHELL"));
+    ok (id == 0,
+        "terminus.new (no args): id is 0");
+    is (service, "terminus.0",
+        "terminus.new (no args): service is terminus.0");
+    flux_future_destroy (f);
+
+
+    /* new, add a session, full args
+     */
+    errno = 0;
+    f = flux_rpc_pack (h,
+                       "terminus.new",
+                        0, 0,
+                        "{s:s s:[ss] s:{s:s s:s}}",
+                        "name", "test-name",
+                        "cmd", "sleep", "1000",
+                        "environ",
+                           "PATH", "/bin:/usr/bin",
+                           "HOME", "/home/user1");
+    ok (f != NULL,
+        "terminus.new: full args");
+    service = NULL;
+    name = NULL;
+    errno = 0;
+    rc = flux_rpc_get_unpack (f,
+                              "{s:s s:s s:i}",
+                              "name", &name,
+                              "pty_service", &service,
+                              "id", &id);
+    ok (rc == 0,
+        "terminus.new (full args): %s", future_strerror (f, errno));
+    is (name, "test-name",
+        "terminus.new (full args): name is %s", "test-name");
+    ok (id == 1,
+        "terminus.new (full args): id is 1");
+    is (service, "terminus.1",
+        "terminus.new (full args): service is terminus.1");
+    flux_future_destroy (f);
+
+
+    /* new, add a session, cmd only
+     */
+    f = flux_rpc_pack (h,
+                       "terminus.new",
+                        0, 0,
+                        "{s:[ss]}",
+                        "cmd", "sleep", "1000");
+    ok (f != NULL,
+        "terminus.new: cmd only");
+    rc = flux_rpc_get_unpack (f,
+                              "{s:s s:s s:i}",
+                              "name", &name,
+                              "pty_service", &service,
+                              "id", &id);
+    ok (rc == 0,
+        "terminus.new (cmd only): OK");
+    is (name, "sleep",
+        "terminus.new (cmd only): name is %s", "sleep");
+    ok (id == 2,
+        "terminus.new (cmd only): id is 2");
+    is (service, "terminus.2",
+        "terminus.new (cmd only): service is terminus.2");
+    flux_future_destroy (f);
+
+
+    /* list, 3 sessions
+     */
+    f = flux_rpc_pack (h, "terminus.list", 0, 0, "{}");
+    ok (f != NULL,
+        "terminus.list");
+    service = NULL;
+    name = NULL;
+    errno = 0;
+    rc = flux_rpc_get_unpack (f,
+                              "{s:{s:s s:i s:f} s:o}",
+                              "server",
+                                 "service", &service,
+                                 "rank", &rank,
+                                 "ctime", &ctime,
+                              "sessions", &o);
+    ok (rc == 0,
+        "terminus.list: OK");
+    is (service, "terminus",
+        "terminus.list returned service = terminus");
+    ok (rank == -1,
+        "terminus.list returned expected rank");
+    ok (o != NULL && json_is_array (o),
+        "terminus.list returned sessions list");
+    ok (json_array_size (o) == 3,
+        "terminus.list returned 3 sessions");
+    flux_future_destroy (f);
+
+
+    /* kill session
+     */
+    f = flux_rpc_pack (h,
+                       "terminus.kill",
+                       0, FLUX_RPC_STREAMING,
+                       "{s:i s:i s:i}",
+                       "id", 0,
+                       "signal", SIGKILL,
+                       "wait", 1);
+    ok (f != NULL,
+        "terminus.kill (wait)");
+    errno = 0;
+    rc = flux_rpc_get_unpack (f,
+                              "{s:s s:s s:i}",
+                              "type", &type,
+                              "message", &message,
+                              "status", &status);
+    ok (rc == 0,
+        "terminus.kill (wait): OK");
+    is (type, "exit",
+        "terminus.kill (wait): response is of type exit");
+    ok (status == 0x9,
+        "terminus.kill (wait): status == 0x9");
+    flux_future_reset (f);
+    rc = flux_rpc_get (f, NULL);
+    ok (rc < 0 && errno == ENODATA,
+        "terminus.kill (wait): ENODATA (end of streaming response)");
+    flux_future_destroy (f);
+
+
+    /* kill: invalid session
+     */
+    f = flux_rpc_pack (h,
+                       "terminus.kill",
+                       0, 0,
+                       "{s:i s:i}",
+                       "id", 0,
+                       "signal", SIGKILL);
+    ok (f != NULL,
+        "terminus.kill (invalid session)");
+    errno = 0;
+    rc = flux_rpc_get (f, NULL);
+    ok (rc == -1 && errno == ENOENT,
+        "terminus.kill: ENOENT (got %s)", strerror (errno));
+    flux_future_destroy (f);
+
+
+    /* list, 2 sessions
+     */
+    f = flux_rpc_pack (h, "terminus.list", 0, 0, "{}");
+    ok (f != NULL,
+        "terminus.list");
+    service = NULL;
+    name = NULL;
+    errno = 0;
+    o = NULL;
+    rc = flux_rpc_get_unpack (f,
+                              "{s:{s:s s:i s:f} s:o !}",
+                              "server",
+                                 "service", &service,
+                                 "rank", &rank,
+                                 "ctime", &ctime,
+                              "sessions", &o);
+    ok (rc == 0,
+        "terminus.list: OK");
+    ok (o && json_is_array (o) && json_array_size (o) == 2,
+        "terminus.list: now returns 2 seesions");
+    flux_future_destroy (f);
+
+
+    /* kill session (no wait)
+     */
+    f = flux_rpc_pack (h,
+                       "terminus.kill",
+                       0, 0,
+                       "{s:i s:i}",
+                       "id", 1,
+                       "signal", SIGKILL);
+    ok (f != NULL,
+        "terminus.kill (no wait)");
+    errno = 0;
+    rc = flux_rpc_get (f, NULL);
+    ok (rc == 0,
+        "terminus.kill (no wait): OK");
+    flux_future_destroy (f);
+
+
+    /* kill-server
+     */
+    f = flux_rpc_pack (h, "terminus.kill-server", 0, 0, "{}");
+    ok (f != NULL,
+        "terminus.kill-server");
+    errno = 0;
+    rc = flux_rpc_get (f, NULL);
+    ok (rc == 0,
+        "terminus.kill-server: OK (%s)",
+        rc == 0 ? "Success": strerror (errno));
+    flux_future_destroy (f);
+
+
+    /* list, now fails
+     */
+    f = flux_rpc_pack (h, "terminus.list", 0, 0, "{}");
+    ok (f != NULL,
+        "terminus.list");
+    rc = flux_rpc_get (f, NULL);
+    ok (rc < 0 && errno == ENOSYS,
+        "terminus.list: ENOSYS");
+    flux_future_destroy (f);
+
+    test_server_stop (h);
+    flux_close (h);
+}
+
+void test_open_close_session (void)
+{
+    int rc;
+    struct flux_pty *pty = NULL;
+    struct flux_pty *pty0 = NULL;
+    struct flux_pty *pty1 = NULL;
+    struct flux_terminus_server *t = NULL;
+    struct flux_terminus_server *t2 = NULL;
+    flux_t *h = loopback_create (0);
+    flux_reactor_t *r = flux_reactor_create (FLUX_REACTOR_SIGCHLD);
+
+    if (!h || !r)
+        BAIL_OUT ("Failed to create loopback handle/reactor");
+    flux_set_reactor (h, r);
+    flux_aux_set (h, NULL, r, (flux_free_f) flux_reactor_destroy);
+
+    t = flux_terminus_server_create (h, "terminus");
+    ok (t != NULL,
+        "flux_terminus_server_create()");
+    t2 = flux_terminus_server_create (h, "terminus2");
+    ok (t2 != NULL,
+        "flux_terminus_server_create()");
+
+    flux_terminus_server_set_log (t, tap_logger, NULL);
+    flux_terminus_server_set_log (t2, tap_logger, NULL);
+
+    pty = flux_terminus_server_session_open (t, -1, "test session");
+    ok (pty == NULL && errno == EINVAL,
+        "flux_terminus_server_session_open with invalid id returns EINVAL");
+    pty = flux_terminus_server_session_open (t, 0, NULL);
+    ok (pty == NULL && errno == EINVAL,
+        "flux_terminus_server_session_open with NULL name returns EINVAL");
+
+    pty0 = flux_terminus_server_session_open (t, 0, "test session");
+    ok (pty0 != NULL,
+        "flux_terminus_server_session_open works");
+
+    pty1 = flux_terminus_server_session_open (t, 1, "another test session");
+    ok (pty1 != NULL,
+        "flux_terminus_server_session_open again works");
+    rc = flux_terminus_server_session_close (t, pty1, 0);
+    ok (pty1 != NULL,
+        "flux_terminus_server_close");
+
+    pty = flux_terminus_server_session_open (t, 0, "duplicate");
+    ok (pty == NULL && errno == EEXIST,
+        "flux_terminus_server_session_open with duplicate id returns EEXIST");
+
+    rc = flux_terminus_server_session_close (t, NULL, 0);
+    ok (rc < 0 && errno == EINVAL,
+        "flux_terminus_session_close with NULL pty returns EINVAL");
+
+    rc = flux_terminus_server_session_close (t, pty0, -1);
+    ok (rc < 0 && errno == EINVAL,
+        "flux_terminus_session_close with invalid status returns EINVAL");
+
+    rc = flux_terminus_server_session_close (t, pty0, 0);
+    ok (rc == 0,
+        "flux_terminus_session_close works");
+
+    pty0 = flux_terminus_server_session_open (t2, 0, "session0");
+    ok (pty0 != NULL,
+        "flux_terminus_server_session_open on second server");
+    rc = flux_terminus_server_session_close (t, pty0, 0);
+    ok (rc < 0 && errno == ENOENT,
+        "flux_terminus_server_session_close wrong server returns ENOENT");
+    rc = flux_terminus_server_session_close (t2, pty0, 0);
+    ok (rc == 0,
+        "flux_terminus_server_session_close right server works");
+
+    flux_terminus_server_destroy (t);
+    flux_terminus_server_destroy (t2);
+    flux_close (h);
+}
+
+
+int main (int argc, char *argv[])
+{
+    plan (NO_PLAN);
+    /* Make sure SHELL is set in environment.
+     */
+    if (getenv ("SHELL") == NULL)
+        setenv ("SHELL", "/bin/sh", 1);
+    test_server_environment_init ("terminus");
+    test_invalid_args ();
+    test_kill_server_empty ();
+    test_protocol ();
+    test_open_close_session ();
+    done_testing ();
+    return 0;
+}
+
+/*
+ * vi: ts=4 sw=4 expandtab
+ */

--- a/src/common/libtestutil/util.c
+++ b/src/common/libtestutil/util.c
@@ -221,11 +221,26 @@ static int test_connector_send (void *impl, const flux_msg_t *msg, int flags)
 {
     struct test_connector *tcon = impl;
     flux_msg_t *cpy;
+    int type;
 
     if (!(cpy = flux_msg_copy (msg, true)))
         return -1;
     if (flux_msg_set_cred (cpy, tcon->cred) < 0)
         goto error;
+    if (flux_msg_get_type (cpy, &type) < 0)
+        goto error;
+    switch (type) {
+        case FLUX_MSGTYPE_REQUEST:
+            if (flux_msg_enable_route (cpy) < 0)
+                goto error;
+            if (flux_msg_push_route (cpy, "test") < 0)
+                goto error;
+            break;
+        case FLUX_MSGTYPE_RESPONSE:
+            if (flux_msg_pop_route (cpy, NULL) < 0)
+                goto error;
+            break;
+    }
     if (flux_msg_sendzsock (tcon->sock, cpy) < 0)
         goto error;
     flux_msg_destroy (cpy);

--- a/src/common/libtestutil/util.c
+++ b/src/common/libtestutil/util.c
@@ -313,6 +313,15 @@ static flux_t *test_connector_create (const char *shmem_name,
     }
     if (!(tcon->h = flux_handle_create (tcon, &handle_ops, flags)))
         BAIL_OUT ("flux_handle_create");
+    /* Allow server to have children
+     */
+    if (server) {
+        flux_reactor_t *r = flux_reactor_create (FLUX_REACTOR_SIGCHLD);
+        if (!r || flux_set_reactor (tcon->h, r) < 0)
+            BAIL_OUT ("failed to set reactor for flux handle");
+        /* Schedule custom reactor for destruction on flux_close() */
+        flux_aux_set (tcon->h, NULL, r, (flux_free_f) flux_reactor_destroy);
+    }
     return tcon->h;
 }
 

--- a/src/common/libutil/Makefile.am
+++ b/src/common/libutil/Makefile.am
@@ -91,7 +91,8 @@ libutil_la_SOURCES = \
 	zsecurity.h \
 	errno_safe.h \
 	intree.c \
-	intree.h
+	intree.h \
+	llog.h
 
 EXTRA_DIST = veb_mach.c
 

--- a/src/common/libutil/llog.h
+++ b/src/common/libutil/llog.h
@@ -1,0 +1,232 @@
+/************************************************************\
+ * Copyright 2020 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* Flux internal library logging interface.
+ *
+ * Mostly taken from libtsm shl-llog.h, with updates for Flux
+ * typedef naming styles.
+ *
+ * https://www.freedesktop.org/wiki/Software/kmscon/libtsm/
+ *
+ * SHL - Library Log/Debug Interface
+ *
+ * Copyright (c) 2010-2013 David Herrmann <dh.herrmann@gmail.com>
+ * Dedicated to the Public Domain
+ *
+ * libtsm COPYRIGHT notice:
+
+This software is licensed under the terms of the MIT license. Please see each
+source file for the related copyright notice and license.
+
+If a file does not contain a copright notice, the following license shall
+apply:
+
+	Copyright (c) 2011-2013 David Herrmann <dh.herrmann@gmail.com>
+
+	Permission is hereby granted, free of charge, to any person obtaining
+	a copy of this software and associated documentation files
+	(the "Software"), to deal in the Software without restriction, including
+	without limitation the rights to use, copy, modify, merge, publish,
+	distribute, sublicense, and/or sell copies of the Software, and to
+	permit persons to whom the Software is furnished to do so, subject to
+	the following conditions:
+
+	The above copyright notice and this permission notice shall be included
+	in all copies or substantial portions of the Software.
+
+	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+	OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+	MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+	IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+	CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+	TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+	SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+ */
+
+/*
+ * Library Log/Debug Interface
+ * Libraries should always avoid producing side-effects. This includes writing
+ * log-messages of any kind. However, you often don't want to disable debugging
+ * entirely, therefore, the core objects often contain a pointer to a function
+ * which performs logging. If that pointer is NULL (default), logging is
+ * disabled.
+ *
+ * This header should never be installed into the system! This is _no_ public
+ * header. Instead, copy it into your application if you want and use it there.
+ * Your public library API should include something like this:
+ *
+ *   typedef void (*MYPREFIX_log_t) (void *data,
+ *                                   const char *file,
+ *                                   int line,
+ *                                   const char *func,
+ *                                   const char *subs,
+ *                                   unsigned int sev,
+ *                                   const char *format,
+ *                                   va_list args);
+ *
+ * And then the user can supply such a function when creating a new context
+ * object of your library or simply supply NULL. Internally, you have a field of
+ * type "MYPREFIX_log_t llog" in your main structure. If you pass this to the
+ * convenience helpers like llog_dbg(), llog_warn() etc. it will automatically
+ * use the "llog" field to print the message. If it is NULL, nothing is done.
+ *
+ * The arguments of the log-function are defined as:
+ *   data: User-supplied data field that is passed straight through.
+ *   file: Zero terminated string of the file-name where the log-message
+ *         occurred. Can be NULL.
+ *   line: Line number of @file where the message occurred. Set to 0 or smaller
+ *         if not available.
+ *   func: Function name where the log-message occurred. Can be NULL.
+ *   subs: Subsystem where the message occurred (zero terminated). Can be NULL.
+ *   sev: Severity of log-message. An integer between 0 and 7 as defined below.
+ *        These are identical to the linux-kernel severities so there is no need
+ *        to include these in your public API. Every app can define them
+ *        themselves, if they need it.
+ *   format: Format string. Must not be NULL.
+ *   args: Argument array
+ *
+ * The user should also be able to optionally provide a data field which is
+ * always passed unmodified as first parameter to the log-function. This allows
+ * to add context to the logger.
+ */
+
+#ifndef _UTIL_LLOG_H
+#define _UTIL_LLOG_H
+
+#include <errno.h>
+#include <stdarg.h>
+#include <stdlib.h>
+#include "errno_safe.h"
+
+enum llog_severity {
+        LLOG_FATAL = 0,
+        LLOG_ALERT = 1,
+        LLOG_CRITICAL = 2,
+        LLOG_ERROR = 3,
+        LLOG_WARNING = 4,
+        LLOG_NOTICE = 5,
+        LLOG_INFO = 6,
+        LLOG_DEBUG = 7,
+        LLOG_SEV_NUM,
+};
+
+typedef void (*llog_writer_f) (void *arg,
+                               const char *file,
+                               int line,
+                               const char *func,
+                               const char *subsys,
+                               int level,
+                               const char *fmt,
+                               va_list args);
+
+static inline  __attribute__((format(printf, 8, 9)))
+void llog_format (llog_writer_f llog,
+                               void *arg,
+                               const char *file,
+                               int line,
+                               const char *func,
+                               const char *subsys,
+                               int level,
+                               const char *fmt,
+                               ...)
+{
+    if (llog) {
+        int saved_errno = errno;
+        va_list ap;
+        va_start (ap, fmt);
+        errno = saved_errno;
+        llog (arg, file, line, func, subsys, level, fmt, ap);
+        va_end (ap);
+        errno = saved_errno;
+    }
+}
+
+#ifndef LLOG_SUBSYSTEM
+static const char *LLOG_SUBSYSTEM __attribute__((__unused__));
+#endif
+
+#define LLOG_DEFAULT __FILE__, __LINE__, __func__, LLOG_SUBSYSTEM
+
+#define llog_printf(obj, sev, format, ...) \
+        llog_format((obj)->llog, \
+                    (obj)->llog_data, \
+                    LLOG_DEFAULT, \
+                    (sev), \
+                    (format), \
+                    ##__VA_ARGS__)
+#define llog_dprintf(obj, data, sev, format, ...) \
+        llog_format((obj), \
+                    (data), \
+                    LLOG_DEFAULT, \
+                    (sev), \
+                    (format), \
+                    ##__VA_ARGS__)
+
+static inline __attribute__((format(printf, 4, 5)))
+void llog_dummyf(llog_writer_f llog, void *data, unsigned int sev,
+                 const char *format, ...)
+{
+}
+
+/*
+ * Helpers
+ * They pick up all the default values and submit the message to the
+ * llog-subsystem. The llog_debug() function will discard the message unless
+ * LLOG_ENABLE_DEBUG is defined.
+ */
+#ifdef LLOG_ENABLE_DEBUG
+        #define llog_ddebug(obj, data, format, ...) \
+                llog_dprintf((obj), (data), LLOG_DEBUG, (format), ##__VA_ARGS__)
+        #define llog_debug(obj, format, ...) \
+                llog_ddebug((obj)->llog, (obj)->llog_data, (format), ##__VA_ARGS__)
+#else
+        #define llog_ddebug(obj, data, format, ...) \
+                llog_dummyf((obj), (data), LLOG_DEBUG, (format), ##__VA_ARGS__)
+        #define llog_debug(obj, format, ...) \
+                llog_ddebug((obj)->llog, (obj)->llog_data, (format), ##__VA_ARGS__)
+#endif
+
+
+#define llog_info(obj, format, ...) \
+        llog_printf((obj), LLOG_INFO, (format), ##__VA_ARGS__)
+#define llog_dinfo(obj, data, format, ...) \
+        llog_dprintf((obj), (data), LLOG_INFO, (format), ##__VA_ARGS__)
+#define llog_notice(obj, format, ...) \
+        llog_printf((obj), LLOG_NOTICE, (format), ##__VA_ARGS__)
+#define llog_dnotice(obj, data, format, ...) \
+        llog_dprintf((obj), (data), LLOG_NOTICE, (format), ##__VA_ARGS__)
+#define llog_warning(obj, format, ...) \
+        llog_printf((obj), LLOG_WARNING, (format), ##__VA_ARGS__)
+#define llog_dwarning(obj, data, format, ...) \
+        llog_dprintf((obj), (data), LLOG_WARNING, (format), ##__VA_ARGS__)
+#define llog_error(obj, format, ...) \
+        llog_printf((obj), LLOG_ERROR, (format), ##__VA_ARGS__)
+#define llog_derror(obj, data, format, ...) \
+        llog_dprintf((obj), (data), LLOG_ERROR, (format), ##__VA_ARGS__)
+#define llog_critical(obj, format, ...) \
+        llog_printf((obj), LLOG_CRITICAL, (format), ##__VA_ARGS__)
+#define llog_dcritical(obj, data, format, ...) \
+        llog_dprintf((obj), (data), LLOG_CRITICAL, (format), ##__VA_ARGS__)
+#define llog_alert(obj, format, ...) \
+        llog_printf((obj), LLOG_ALERT, (format), ##__VA_ARGS__)
+#define llog_dalert(obj, data, format, ...) \
+        llog_dprintf((obj), (data), LLOG_ALERT, (format), ##__VA_ARGS__)
+#define llog_fatal(obj, format, ...) \
+        llog_printf((obj), LLOG_FATAL, (format), ##__VA_ARGS__)
+#define llog_dfatal(obj, data, format, ...) \
+        llog_dprintf((obj), (data), LLOG_FATAL, (format), ##__VA_ARGS__)
+
+
+#endif /* !_UTIL_LLOG_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/shell/Makefile.am
+++ b/src/shell/Makefile.am
@@ -80,6 +80,7 @@ flux_shell_SOURCES = \
 	affinity.c \
 	gpubind.c \
 	evlog.c \
+	pty.c \
 	mpir/mpir.c \
 	mpir/ptrace.c
 
@@ -91,6 +92,8 @@ flux_shell_LDADD = \
 	$(top_builddir)/src/common/libpmi/libpmi_server.la \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-optparse.la \
+	$(top_builddir)/src/common/libterminus/libterminus.la \
+	$(top_builddir)/src/common/libutil/libutil.la \
 	$(LUA_LIB) \
 	$(HWLOC_LIBS)
 

--- a/src/shell/builtins.c
+++ b/src/shell/builtins.c
@@ -39,6 +39,7 @@ extern struct shell_builtin builtin_affinity;
 extern struct shell_builtin builtin_gpubind;
 extern struct shell_builtin builtin_mpir;
 extern struct shell_builtin builtin_ptrace;
+extern struct shell_builtin builtin_pty;
 
 static struct shell_builtin * builtins [] = {
     &builtin_log_eventlog,
@@ -51,6 +52,7 @@ static struct shell_builtin * builtins [] = {
     &builtin_gpubind,
     &builtin_mpir,
     &builtin_ptrace,
+    &builtin_pty,
     &builtin_list_end,
 };
 

--- a/src/shell/pty.c
+++ b/src/shell/pty.c
@@ -1,0 +1,216 @@
+/************************************************************\
+ * Copyright 2020 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <unistd.h>
+#include <stdlib.h>
+#include <fcntl.h>
+#include <sys/ioctl.h>
+#include <termios.h>
+
+#include <flux/core.h>
+#include <flux/shell.h>
+
+#include "src/common/libterminus/pty.h"
+#include "src/common/libterminus/terminus.h"
+#include "builtins.h"
+
+static void shlog (void *arg,
+                   const char *file,
+                   int line,
+                   const char *func,
+                   const char *subsys,
+                   int level,
+                   const char *fmt,
+                   va_list ap)
+{
+    char buf [4096];
+    int buflen = sizeof (buf);
+    int n = vsnprintf (buf, buflen, fmt, ap);
+    if (n >= buflen) {
+        buf[buflen-1] = '\0';
+        buf[buflen-2] = '+';
+    }
+    flux_shell_log (level, file, line, "%s", buf);
+}
+
+static struct flux_terminus_server *
+shell_terminus_server_start (flux_shell_t *shell, const char *shell_service)
+{
+    char service[128];
+    struct flux_terminus_server *t;
+
+    if (snprintf (service,
+                  sizeof (service),
+                  "%s.terminus",
+                  shell_service) >= sizeof (service)) {
+        shell_log_errno ("Failed to build terminus service name");
+        return NULL;
+    }
+
+    /*  Create a terminus server in this shell. 1 per shell */
+    t = flux_terminus_server_create (flux_shell_get_flux (shell),
+                                     service);
+    if (!t) {
+        shell_log_errno ("flux_terminus_server_create");
+        return NULL;
+    }
+    if (flux_shell_aux_set (shell,
+                            "builtin::terminus",
+                            t,
+                            (flux_free_f) flux_terminus_server_destroy) < 0)
+        return NULL;
+    flux_terminus_server_set_log (t, shlog, NULL);
+
+    /* Ensure process knows it is a terminus session */
+    flux_shell_setenvf (shell, 1, "FLUX_TERMINUS_SESSION", "0");
+
+    return t;
+}
+
+static int pty_init (flux_plugin_t *p,
+                     const char *topic,
+                     flux_plugin_arg_t *args,
+                     void *arg)
+{
+    const char *shell_service;
+    int shell_rank = -1;
+    flux_shell_t *shell;
+    struct flux_pty *pty;
+    struct flux_terminus_server *t;
+
+    if (!(shell = flux_plugin_get_shell (p)))
+        return shell_log_errno ("flux_plugin_get_shell");
+
+    if (flux_shell_info_unpack (shell,
+                                "{s:i s:s}",
+                                "rank", &shell_rank,
+                                "service", &shell_service) < 0)
+        return shell_log_errno ("flux_shell_info_unpack: service");
+
+    if (!(t = shell_terminus_server_start (shell, shell_service)))
+        return -1;
+
+    /*  Only create a session for rank 0 if the pty option was specified
+     */
+    if (flux_shell_getopt (shell, "pty", NULL) != 1)
+        return 0;
+
+    /* On rank 0, open a pty for task 0 only. It is important that the
+     *   pty service be started before the shell.init event, since a client
+     *   may attempt to attach to the pty immediately after this event.
+     */
+    if (shell_rank == 0) {
+        pty = flux_terminus_server_session_open (t, 0, "task0");
+        if (!pty)
+            return shell_log_errno ("terminus_session_open");
+
+        if (flux_shell_aux_set (shell, "builtin::pty.0", pty, NULL) < 0)
+            goto error;
+
+        if (flux_shell_add_event_context (shell,
+                                          "shell.init",
+                                          0,
+                                          "{s:s}",
+                                          "pty", "terminus.0") < 0) {
+            shell_log_errno ("flux_shell_service_register");
+            goto error;
+        }
+    }
+    return 0;
+error:
+    flux_terminus_server_destroy (t);
+    return -1;
+}
+
+static int pty_task_exec (flux_plugin_t *p,
+                          const char *topic,
+                          flux_plugin_arg_t *args,
+                          void *arg)
+{
+    flux_shell_t *shell = flux_plugin_get_shell (p);
+    flux_shell_task_t *task;
+    int rank;
+
+    if (!shell)
+        return shell_log_errno ("failed to get shell object");
+
+    if (flux_shell_getopt (shell, "pty", NULL) != 1)
+        return 0;
+
+    if (!(task = flux_shell_current_task (shell))
+        || flux_shell_task_info_unpack (task, "{s:i}", "rank", &rank) < 0)
+        return shell_log_errno ("unable to get task rank");
+
+    /*  pty on rank 0 only for now */
+    if (rank == 0) {
+        struct flux_pty *pty = flux_shell_aux_get (shell, "builtin::pty.0");
+
+        /*  Redirect stdio to 'pty'
+         */
+        if (pty && flux_pty_attach (pty) < 0)
+            return shell_log_errno ("pty attach failed");
+
+        /*  Set environment variable so process knows it is running
+         *   under a terminus server.
+         */
+        flux_shell_setenvf (shell, 1, "FLUX_TERMINUS_SESSION", "%d", rank);
+    }
+    return (0);
+}
+
+static int pty_task_exit (flux_plugin_t *p,
+                          const char *topic,
+                          flux_plugin_arg_t *args,
+                          void *arg)
+{
+    flux_shell_t *shell = flux_plugin_get_shell (p);
+    flux_shell_task_t *task;
+    int rank;
+
+    if (!shell)
+        return shell_log_errno ("failed to get shell object");
+
+    if (flux_shell_getopt (shell, "pty", NULL) != 1)
+        return 0;
+
+    if (!(task = flux_shell_current_task (shell))
+        || flux_shell_task_info_unpack (task, "{s:i}", "rank", &rank) < 0)
+        return shell_log_errno ("unable to get task rank");
+
+    /*  pty is present only on rank 0 only for now */
+    if (rank == 0) {
+        struct flux_terminus_server *t = NULL;
+        struct flux_pty *pty;
+        int status = flux_subprocess_status (flux_shell_task_subprocess (task));
+
+        if (!(t = flux_shell_aux_get (shell, "builtin::terminus"))
+            || !(pty = flux_shell_aux_get (shell, "builtin::pty.0")))
+            return shell_log_errno ("failed to get terminus and pty objects");
+
+        if (t && pty
+            && flux_terminus_server_session_close (t, pty, status) < 0)
+            shell_die_errno (1, "pty attach failed");
+    }
+    return (0);
+}
+
+struct shell_builtin builtin_pty = {
+    .name = "pty",
+    .init = pty_init,
+    .task_exec = pty_task_exec,
+    .task_exit = pty_task_exit,
+};
+
+/* vi: ts=4 sw=4 expandtab
+ */

--- a/src/shell/shell.c
+++ b/src/shell/shell.c
@@ -343,11 +343,12 @@ static json_t *flux_shell_get_info_object (flux_shell_t *shell)
         return o;
 
     if (!(o = json_pack_ex (&err, 0,
-                            "{ s:I s:i s:i s:i s:O s:{ s:i s:b }}",
+                            "{ s:I s:i s:i s:i s:s s:O s:{ s:i s:b }}",
                             "jobid", shell->info->jobid,
                             "rank",  shell->info->shell_rank,
                             "size",  shell->info->shell_size,
                             "ntasks", shell->info->rankinfo.ntasks,
+                            "service", shell_svc_name (shell->svc),
                             "jobspec", shell->info->jobspec->jobspec,
                             "options",
                                "verbose", shell->verbose,

--- a/src/shell/shell.c
+++ b/src/shell/shell.c
@@ -1003,12 +1003,18 @@ static int shell_task_init (flux_shell_t *shell)
     return plugstack_call (shell->plugstack, "task.init", NULL);
 }
 
+#if CODE_COVERAGE_ENABLED
+extern void __gcov_flush ();
+#endif
 static void shell_task_exec (flux_shell_task_t *task, void *arg)
 {
     flux_shell_t *shell = arg;
     shell->current_task->in_pre_exec = true;
     if (plugstack_call (shell->plugstack, "task.exec", NULL) < 0)
         shell_log_errno ("task.exec plugin(s) failed");
+#if CODE_COVERAGE_ENABLED
+    __gcov_flush ();
+#endif
 }
 
 static int shell_task_forked (flux_shell_t *shell)

--- a/src/shell/shell.h
+++ b/src/shell/shell.h
@@ -100,6 +100,7 @@ int flux_shell_unsetenv (flux_shell_t *shell, const char *name);
  *   "rank":i,
  *   "size":i,
  *   "ntasks";i,
+ *   "service":s,
  *   "options": { "verbose":b, "standalone":b },
  *   "jobspec":o,
  *   "R":o

--- a/src/shell/svc.c
+++ b/src/shell/svc.c
@@ -207,6 +207,11 @@ error:
     return NULL;
 }
 
+const char *shell_svc_name (struct shell_svc *svc)
+{
+    return svc->name;
+}
+
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab
  */

--- a/src/shell/svc.h
+++ b/src/shell/svc.h
@@ -55,6 +55,10 @@ int shell_svc_register (struct shell_svc *svc,
  */
 int shell_svc_allowed (struct shell_svc *svc, const flux_msg_t *msg);
 
+/* Return the service name under which shell svc methods are registerd:
+ */
+const char *shell_svc_name (struct shell_svc *svc);
+
 #endif /* !SHELL_SVC_H */
 
 /*

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -72,6 +72,7 @@ TESTSCRIPTS = \
 	t0016-cron-faketime.t \
 	t0017-security.t \
 	t0019-jobspec-schema.t \
+	t0020-terminus.t \
 	t0021-flux-jobspec.t \
 	t0022-jj-reader.t \
 	t1000-kvs.t \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -198,6 +198,7 @@ dist_check_SCRIPTS = \
 	scripts/t0004-event-helper.sh \
 	scripts/tssh \
 	scripts/sign-as.py \
+	scripts/runpty.py \
 	valgrind/valgrind-workload.sh \
 	valgrind/workload.d/job \
 	kvs/kvs-helper.sh \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -125,6 +125,7 @@ TESTSCRIPTS = \
 	t2609-job-shell-events.t \
 	t2610-job-shell-mpir.t \
 	t2611-debug-emulate.t \
+	t2612-job-shell-pty.t \
 	t2700-mini-cmd.t \
 	t2800-jobs-cmd.t \
 	t3000-mpi-basic.t \

--- a/t/scripts/runpty.py
+++ b/t/scripts/runpty.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""
+Run command in a pty, logging the output one of a set of formats that
+is safe and useful for later processing.
+"""
+
+import os
+import sys
+import logging
+import pty
+import termios
+import fcntl
+import struct
+import time
+import json
+import argparse
+
+from flux import util
+from signal import signal, SIGUSR1, SIGWINCH, SIGTERM, SIGINT
+
+
+def setwinsize(fd, rows, cols):
+    s = struct.pack("HHHH", rows, cols, 0, 0)
+    fcntl.ioctl(fd, termios.TIOCSWINSZ, s)
+
+
+def getwinsize(fd):
+    tsize = os.get_terminal_size()
+    return (tsize.lines, tsize.columns)
+
+
+def status_to_exitcode(status):
+    code = 0
+    if os.WIFSIGNALED(status):
+        code = 128 + os.WTERMSIG(status)
+    else:
+        code = os.WEXITSTATUS(status)
+    return code
+
+
+class OutputHandler:
+    def __init__(self, filename, width=80, height=25):
+        self.filename = filename
+        self.width = width
+        self.height = height
+        if self.filename == "-" or self.filename == "stdout":
+            self.fp = sys.stdout
+        else:
+            self.fp = open(filename, "w")
+
+    def format_entry(self, data):
+        return data.decode("utf-8", "replace")
+
+    def write_entry(self, data):
+        self.fp.write(self.format_entry(data))
+        self.fp.flush()
+
+
+class EventLogOutput(OutputHandler):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        header = dict(
+            timestamp=time.time(),
+            name="header",
+            context=dict(
+                version=1, width=self.width, height=self.height, encoding="utf-8"
+            ),
+        )
+        self.fp.write("{}\n".format(json.dumps(header)))
+
+    def format_entry(self, data):
+        entry = dict(
+            timestamp=time.time(),
+            name="data",
+            context=dict(data=data.decode("utf-8", "replace")),
+        )
+        return "{}\n".format(json.dumps(entry))
+
+
+class AsciicastOutput(OutputHandler):
+    """
+    https://github.com/asciinema/asciinema/blob/develop/doc/asciicast-v2.md
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.t0 = time.time()
+        ts = int(self.t0)
+        header = dict(version=2, width=self.width, height=self.height, timestamp=ts)
+        self.fp.write("{}\n".format(json.dumps(header)))
+
+    def format_entry(self, data):
+        dt = time.time() - self.t0
+        entry = [dt, "o", data.decode("utf-8", "replace")]
+        return "{}\n".format(json.dumps(entry))
+
+
+formats = {
+    "raw": OutputHandler,
+    "asciicast": AsciicastOutput,
+    "eventlog": EventLogOutput,
+}
+
+
+def parse_args():
+    try:
+        ws_default = "{0.columns}x{0.lines}".format(os.get_terminal_size())
+    except OSError:
+        ws_default = "80x25"
+
+    format_list = ",".join(formats.keys())
+
+    parser = argparse.ArgumentParser(
+        description="run command with a pty, log output to a file",
+        formatter_class=util.help_formatter(),
+    )
+    parser.add_argument(
+        "-o", "--output", help="set output file. Default=stdout", default="-"
+    )
+    parser.add_argument(
+        "-f",
+        "--format",
+        help=f"set output format ({format_list}). Default=raw",
+        default="raw",
+    )
+    parser.add_argument(
+        "-w",
+        "--window-size",
+        metavar="WxH",
+        help=f"set pty window size in WIDTHxHEIGHT (default is {ws_default})",
+        default=ws_default,
+    )
+    parser.add_argument(
+        "-c",
+        "--quit-char",
+        metavar="C",
+        help=f"Set the QUIT character (written to pty on SIGUSR1)",
+        default="",
+    )
+    parser.add_argument("COMMAND")
+    parser.add_argument("ARGS", nargs=argparse.REMAINDER)
+    return parser.parse_args()
+
+
+log = logging.getLogger("runpty")
+
+
+@util.CLIMain(log)
+def main():
+
+    args = parse_args()
+
+    try:
+        formatter = formats[args.format]
+    except KeyError as e:
+        log.error(f'Unknown output format "{args.format}"')
+        sys.exit(1)
+
+    (width, height) = map(int, args.window_size.split("x"))
+    quit_char = args.quit_char.encode()
+
+    (pid, fd) = pty.fork()
+
+    if pid == pty.CHILD:
+        """
+        In child
+        """
+        setwinsize(pty.STDIN_FILENO, height, width)
+        os.execvp(args.COMMAND, [args.COMMAND, *args.ARGS])
+    else:
+        """
+        In parent, open log file and read output from child
+        """
+
+        signal(SIGWINCH, lambda sig, _: os.kill(pid, sig))
+        signal(SIGTERM, lambda sig, _: os.kill(pid, sig))
+        signal(SIGINT, lambda sig, _: os.kill(pid, sig))
+        signal(SIGUSR1, lambda sig, _: os.write(fd, quit_char))
+
+        ofile = formatter(args.output, width=width, height=height)
+
+        while True:
+            try:
+                data = os.read(fd, 1024)
+            except OSError as e:
+                data = None
+            if not data:
+                (pid, status) = os.waitpid(pid, 0)
+                log.info("child exited with status %s", hex(status))
+                sys.exit(status_to_exitcode(status))
+            else:
+                ofile.write_entry(data)
+
+
+if __name__ == "__main__":
+    main()
+
+# vi: ts=4 sw=4 expandtab

--- a/t/sharness.d/01-setup.sh
+++ b/t/sharness.d/01-setup.sh
@@ -23,7 +23,7 @@ if test -z "$FLUX_BUILD_DIR"; then
 fi
 if test -z "$FLUX_SOURCE_DIR"; then
     if test -z "${srcdir}"; then
-        FLUX_SOURCE_DIR="$(cd .. && pwd)"
+        FLUX_SOURCE_DIR="$(cd ${SHARNESS_TEST_SRCDIR}/.. && pwd)"
     else
         FLUX_SOURCE_DIR="$(cd ${srcdir}/.. && pwd)"
     fi

--- a/t/sharness.d/flux-sharness.sh
+++ b/t/sharness.d/flux-sharness.sh
@@ -190,7 +190,7 @@ fi
 # Sanitize PMI_* environment for all tests. This allows commands like
 #  `flux broker` in tests to boot as singleton even when run under a
 #  job of an existing RM.
-for var in $(env | grep ^PMI); do unset ${var//=*}; done
-for var in $(env | grep ^SLURM); do unset ${var//=*}; done
+for var in $(env | grep ^PMI); do unset ${var%=*}; done
+for var in $(env | grep ^SLURM); do unset ${var%=*}; done
 
 # vi: ts=4 sw=4 expandtab

--- a/t/t0020-terminus.t
+++ b/t/t0020-terminus.t
@@ -1,0 +1,245 @@
+#!/bin/sh
+#
+
+test_description='Test flux-terminus command
+
+Verify basic functionality of flux-terminus command
+'
+
+. `dirname $0`/sharness.sh
+SIZE=2
+test_under_flux ${SIZE} minimal
+
+userid=$(id -u)
+default_service="${userid}-terminus"
+runpty="${SHARNESS_TEST_SRCDIR}/scripts/runpty.py -f asciicast"
+waitfile="${SHARNESS_TEST_SRCDIR}/scripts/waitfile.lua"
+
+test_expect_success 'flux-terminus: list reports error with no server' '
+	name="list-no-server" &&
+	test_expect_code 1 flux terminus list >log.${name} 2>&1 &&
+	grep "no server running at ${default_service}" log.${name} &&
+	test_expect_code 1 flux terminus list -r 1 >log.${name}.1 2>&1 &&
+	grep "no server running at ${default_service}" log.${name}.1 &&
+	test_expect_code 1 flux terminus list -s foo >log.${name}.foo 2>&1 &&
+	grep "no server running at foo" log.${name}.foo
+'
+test_expect_success 'flux-terminus: kill reports error with no server' '
+	name="kill-no-server" &&
+	test_expect_code 1 flux terminus kill 0 >log.${name} 2>&1 &&
+	grep "no server running at ${default_service}" log.${name}
+'
+test_expect_success 'flux-terminus: attach fails with error on no server' '
+	test_expect_code 1 flux terminus attach 0
+'
+test_expect_success 'flux-terminus: kill-server reports error with no server' '
+	name="kill-server-no-server" &&
+	test_expect_code 1 flux terminus kill-server >log.${name} 2>&1 &&
+	grep "no server running at ${default_service}" log.${name}
+'
+test_expect_success 'flux-terminus: list reports error with bad rank/service' '
+	name="list-bad-args" &&
+	test_expect_code 1 flux terminus list -r -1 >log.${name} 2>&1 &&
+	grep "no server running at ${default_service}" log.${name} &&
+	test_expect_code 1 flux terminus list -r 1 >log.${name}.1 2>&1 &&
+	grep "no server running at ${default_service}" log.${name}.1 &&
+	test_expect_code 1 flux terminus list -s foo >log.${name}.foo 2>&1 &&
+	grep "no server running at foo" log.${name}.foo
+'
+test_expect_success 'flux-terminus: attach fails with invalid id' '
+	test_expect_code 1 flux terminus attach foo >log.attach-badid 2>&1 &&
+	grep "session ID must be an integer" log.attach-badid
+'
+test_expect_success 'flux-terminus: kill fails with invalid id' '
+	test_expect_code 1 flux terminus kill foo >log.kill-badid 2>&1 &&
+	grep "session ID must be an integer" log.kill-badid
+'
+test_expect_success 'flux-terminus: start with invalid command fails' '
+	test_expect_code 1 flux terminus start /nosuchthing >log.badcmd 2>&1 &&
+	grep "failed to run /nosuchthing" log.badcmd
+'
+test_expect_success 'flux-terminus: start detached starts server' '
+	flux terminus start -d &&
+	flux terminus list >log.list &&
+	test_debug "cat log.list" &&
+	grep -q "1 current session" log.list
+'
+test_expect_success 'flux-terminus: start detached starts another session' '
+	flux terminus start -d &&
+	flux terminus list >log.list &&
+	test_debug "cat log.list" &&
+	grep -q "2 current sessions" log.list
+'
+test_expect_success 'flux-terminus: kill session works' '
+	flux terminus kill 0 &&
+	flux terminus list >log.list &&
+	test_debug "cat log.list" &&
+	grep -q "1 current session" log.list
+'
+test_expect_success 'flux-terminus: start --name option works' '
+	flux terminus start -d --name=test-name &&
+	flux terminus list >log.list &&
+	test_debug "cat log.list" &&
+	grep -q test-name log.list
+'
+test_expect_success 'flux-terminus: kill-server works' '
+	flux terminus kill-server &&
+	test_expect_code 1 flux terminus list
+'
+test_expect_success 'flux-terminus: start server on remote rank' '
+	flux exec -r 1 flux terminus start -d &&
+	flux terminus list -r 1 >log.list-remote &&
+	test_debug "cat log.list-remote"  &&
+	grep -q "1 current session" log.list-remote
+'
+test_expect_success 'flux-terminus: start on remote rank' '
+	flux terminus start -dr 1 &&
+	flux terminus list -r 1 >log.list-remote &&
+	test_debug "cat log.list-remote"  &&
+	grep -q "2 current sessions" log.list-remote
+'
+test_expect_success 'flux-terminus: kill on remote rank' '
+	flux terminus kill -r 1  0 &&
+	flux terminus list -r 1 >log.list-remote &&
+	test_debug "cat log.list-remote"  &&
+	grep -q "1 current session" log.list-remote
+'
+test_expect_success 'flux-terminus: kill-server on remote rank' '
+	flux terminus kill-server -r 1 &&
+	test_expect_code 1 flux terminus list -r 1
+'
+test_expect_success 'flux-terminus: start on invalid service name gives error' '
+	test_must_fail flux terminus start -s . >log.invalid-service 2>&1 &&
+	test_debug "cat log.invalid-service" &&
+	grep -q "Invalid argument" log.invalid-service
+'
+test_expect_success 'flux-terminus: start server on alternate service name' '
+	flux terminus start -ds foo &&
+	flux terminus list -s foo >log.list-foo &&
+	test_debug "cat log.list-foo"  &&
+	grep -q "1 current session" log.list-foo
+'
+test_expect_success 'flux-terminus: start session on alternate service name' '
+	flux terminus start -ds foo &&
+	flux terminus list -s foo >log.list-foo &&
+	test_debug "cat log.list-foo"  &&
+	grep -q "2 current sessions" log.list-foo
+'
+test_expect_success 'flux-terminus: kill on alternate service name' '
+	flux terminus kill -s foo  0 &&
+	flux terminus list -s foo >log.list-foo &&
+	test_debug "cat log.list-foo"  &&
+	grep -q "1 current session" log.list-foo
+'
+test_expect_success 'flux-terminus: kill-server on alternate service name' '
+	flux terminus kill-server -s foo &&
+	test_expect_code 1 flux terminus list -s foo
+'
+test_expect_success 'flux-terminus: start can set session name' '
+	flux terminus start -d -n test-name &&
+	flux terminus list | grep "\[test-name\]"
+'
+test_expect_success 'flux-terminus: start and set --wait' '
+	flux terminus start --wait -d -n waiter true &&
+	flux terminus list >log.start-wait 2>&1 &&
+	test_debug "cat log.start-wait" &&
+	grep -q "\[waiter\]" log.start-wait
+'
+test_expect_success 'flux-terminus: clean up' '
+	flux terminus kill-server
+'
+# list w/ backoff waiting for server to exit
+server_list_thrice() {
+	flux terminus list &&
+	sleep 0.25 &&
+	flux terminus list &&
+	sleep 1 &&
+	flux terminus list
+}
+test_expect_success 'flux-terminus: basic start, server exits after session' '
+	$runpty flux terminus start sleep 0 &&
+	test_expect_code 1 server_list_thrice
+'
+test_expect_success 'flux-terminus: attach reports exit status' '
+	flux terminus start -w -d true &&
+	$runpty flux terminus attach 0 &&
+	flux terminus start -w -d sh -c "exit 7" &&
+	test_expect_code 7 $runpty flux terminus attach 0 &&
+	flux terminus start -w -d sh -c "kill -INT \$$" &&
+	test_expect_code 130 $runpty flux terminus attach 0
+'
+# N.B.: We use !wait $pid below because we expect pid to have been
+#  stopped by SIGKILL, something neither test_must_fail() nor
+#  test_expect_code() handles.
+#
+test_expect_success NO_CHAIN_LINT 'flux-terminus: start, try a resize' '
+	$runpty -o log.resize flux terminus start sleep 1000 &
+	pid=$! &&
+	$waitfile -t 20 -v -p \"o\" log.resize &&
+	test_debug "echo pid=$pid" &&
+	kill -WINCH $pid &&
+	flux terminus kill 0 &&
+	test_debug "cat log.resize" &&
+	! wait $pid
+'
+test_expect_success NO_CHAIN_LINT 'flux-terminus: detach works' '
+	$runpty -o log.detach flux terminus start -n test-detach &
+	pid=$! &&
+	$waitfile -t 20 -v -p \"o\" log.detach &&
+	kill -USR1 $pid &&
+	$waitfile -t 20 -v -p detached log.detach &&
+	wait $pid &&
+	flux terminus list >detach.list 2>&1 &&
+	test_debug "cat detach.list" &&
+	grep "test-detach.*0 clients" detach.list
+'
+test_expect_success NO_CHAIN_LINT 'flux-terminus: reattach' '
+	$runpty -o log.reattach flux terminus attach 0 &
+	pid=$! &&
+	$waitfile -t 20 -v -p \"o\" log.reattach &&
+	flux terminus list >reattach.list 2>&1 &&
+	test_debug "cat reattach.list" &&
+	grep -q "1 client" reattach.list
+	flux terminus kill 0 &&
+	! wait $pid
+'
+test_expect_success NO_CHAIN_LINT 'flux-terminus: copy stdin' '
+	$runpty -o log.pipe-stdin flux terminus start &
+	pid=$! &&
+	$waitfile -t 20 -v -p \"o\" log.pipe-stdin &&
+	printf "echo hello\r" | flux terminus attach -p 0 &&
+	$waitfile -t 20 -v -p hello log.pipe-stdin &&
+	printf "exit\r" | flux terminus attach -p 0 &&
+	$waitfile -t 20 -v -p detached log.pipe-stdin &&
+	wait $pid
+'
+test_expect_success NO_CHAIN_LINT 'flux-terminus: disconnect works' '
+	flux terminus kill-server
+	$runpty -o log.disconnect flux terminus start &
+	pid=$! &&
+	$waitfile -t 20 -v -p \"o\" log.disconnect &&
+	kill -TERM $pid &&
+	test_expect_code 143 wait $pid &&
+	flux terminus list >disconnect.list &&
+	test_debug "cat disconnect.list" &&
+	grep -q "0 clients" disconnect.list &&
+	flux terminus kill 0
+'
+test_expect_success 'flux-terminus: nesting not allowed' '
+	test_expect_code 1 \
+	    $runpty flux terminus start \
+	    flux terminus start true
+'
+test_expect_success 'flux-terminus: requests from invalid userid are rejected' '
+	flux terminus start -d &&
+	( SERVICE="$(id -u)-terminus" &&
+          export FLUX_HANDLE_USERID=$(($(id -u) + 1)) &&
+	  export FLUX_HANDLE_ROLEMASK=0x2 &&
+	  test_expect_code 1 flux terminus attach -s $SERVICE 0 &&
+	  test_expect_code 1 flux terminus list -s $SERVICE &&
+	  test_expect_code 1 flux terminus start -s $SERVICE &&
+	  test_expect_code 1 flux terminus kill -s $SERVICE 0 &&
+	  test_expect_code 1 flux terminus kill-server -s $SERVICE
+	)
+'
+test_done

--- a/t/t2612-job-shell-pty.t
+++ b/t/t2612-job-shell-pty.t
@@ -1,0 +1,61 @@
+#!/bin/sh
+#
+test_description='Test flux-shell pty support'
+
+. `dirname $0`/sharness.sh
+
+test_under_flux 4 job
+
+FLUX_SHELL="${FLUX_BUILD_DIR}/src/shell/flux-shell"
+
+INITRC_TESTDIR="${SHARNESS_TEST_SRCDIR}/shell/initrc"
+INITRC_PLUGINPATH="${SHARNESS_TEST_DIRECTORY}/shell/plugins/.libs"
+runpty="${SHARNESS_TEST_SRCDIR}/scripts/runpty.py -f asciicast"
+waitfile="${SHARNESS_TEST_SRCDIR}/scripts/waitfile.lua"
+
+shell_leader_rank() {
+    flux job wait-event -f json -p guest.exec.eventlog $1 shell.init | \
+        jq '.context["leader-rank"]'
+}
+shell_service() {
+    flux job wait-event -f json -p guest.exec.eventlog $1 shell.init | \
+        jq -r '.context["service"]'
+}
+terminus_jobid() {
+    test $# -lt 2 && return 1
+    local jobid=$1
+    local cmd=$2
+    shift 2
+    flux terminus $cmd \
+        -r $(shell_leader_rank $jobid) \
+        -s $(shell_service $jobid).terminus "$@"
+}
+
+test_expect_success 'pty: submit a job with pty' '
+	id=$(flux mini submit --flags waitable -o pty bash) &&
+	terminus_jobid $id list &&
+	flux job cancel ${id} &&
+	test_must_fail flux job wait $id
+'
+test_expect_success NO_CHAIN_LINT 'pty: run job with pty' '
+	printf "PS1=XXX:\n" >ps1.rc
+	id=$(flux mini submit -o pty bash --rcfile ps1.rc)
+	$runpty -o log.job-pty flux job attach ${id} &
+	pid=$! &&
+	terminus_jobid ${id} list &&
+	$waitfile -t 20 -vp "XXX:" log.job-pty &&
+	printf "printenv FLUX_JOB_ID\r" | terminus_jobid ${id} attach -p 0 &&
+	$waitfile -t 20 -vp ${id} log.job-pty &&
+	printf "exit\r\n" | terminus_jobid ${id} attach -p 0 &&
+	$waitfile -t 20 -vp exit log.job-pty &&
+	wait $pid
+'
+# Interactively attach to pty many times to ensure no hangs, etc.
+test_expect_success 'pty: interactive job with pty' '
+	for i in `seq 0 10`; do
+	    run_timeout 10 $runpty -w 80x25 -o log.interactive \
+	        flux mini run -n1 -o pty stty size &&
+	    $waitfile -t 20 -vp "25 80" log.interactive
+	done
+'
+test_done


### PR DESCRIPTION
This PR introduces the *simple* pty support for Flux jobs mentioned in #282 (wow has it really been 5 years). It started out as an attempt to tunnel a basic terminal session manager like [`dtach`](https://github.com/crigler/dtach) or [`abduco`](https://github.com/martanne/abduco) over flux message endpoints, but it ended up being much easier to implement a clone of these utilities, rather than implementing something like transparent Unix domain socket tunneling.

At some point in the future we can implement a more featured solution using a per-job ssh and/or tmux session to get perfect pty support, but for now this interim solution should work for the 90% use case.

### TL;DR

Try:
```
$ flux mini run -o pty bash
```
also
```
$ flux terminus start
^\ # (detach)
$ flux terminus list
server at 1000-terminus running on rank 0 since Tue Apr  7 01:01:32 2020
1 current session:
0: [/bin/bash] 0 clients (created Tue Apr  7 01:01:32 2020)
$ flux terminus attach 0
```


The PR has 3 main parts, see below. The PR is still a wip while I try to figure out a strategy for adding reasonable tests. Also please give the new facilities a try and give feedback, I've only tested on my local system with one terminal environment. (A weak point here may be restoring terminal settings on the client side. We may have to eventually link with ncurses to get more robust in this area)

Still TODO:

 - [ ] tests (including memleak tests)
 - [ ] look into batching tty updates (tty is in character-at-a-time mode, so this might currently generate a lot of messages)
 - [ ] add a mode or option for `flux job attach` to ignore pty option (w/a caveats when attaching to pty)
 - [ ] consider if we want/need a mode where more than just rank 0 gets a pty. We could also start a "terminus" server in the shell to allow users to "log in" to their job (?)

### libterminus 

Support for remote ptys and terminal session management is introduced in a new library `libterminus` (*termin*al *u*ser *s*ervices (or *s*essions or *s*omething)), which implements the following features:

 * `pty.c`: pseudoterminal multiplexer as a service -- like `dtach` but uses flux service and messages instead of Unix domain socket. Supports multiple clients, attach and detach. See comment at top of file for remote pty protocol (it is simple).
 * `client.c`: client side code for attaching to pty service. This contains the setup code to put the local terminal in raw mode, as well as process the detach character (`^\`), and handle window resize events. No other special processing of terminal data is done.
 * `terminus.[ch]`:  wraps the pty server class in an outer service which allows management of multiple terminal "sessions" under a common service endpoint. Clients can request new sesssions, attach to sessions, kill sessions etc.

### flux-terminus

A new command `flux-terminus` is also introduced which uses `libterminus` to implement a user interface to the `terminus` service. Originally this started as a simple test program, but it seemed like it might be useful or at least a bit entertaining as a flux command. 

`flux-terminus` offers simple terminal session management similar to `dtach`, but since it is using flux services and messages instead of a Unix domain socket, you can start sessions on one broker rank and attach from any other rank within the instance.

To start a new session try, `flux terminus start`. If no `flux-terminus` server is already running this will cause the utility to fork itself into the background and register on service `<userid>-terminus` by default. The client will then attach to the newly created session. You can detach with the detach character (Currently `^\`), then reattach later with `flux terminus attach 0`. Multiple sessions can be created and listed with `flux terminus list`.

### shell pty plugin

For resolution of #282, this PR introduces a very simple `pty` plugin for the shell. If the "pty" shell option is enabled, the plugin creates a pty server for rank 0 *only* at shell service method "pty.0", and drops the pty service name into the `shell.init` event context.

On the `flux-job attach` side, if there is a pty enabled, we create a new pty client and attach it to the remote instead of watching the normal stdio. Please see the caveats in the commit that introduces this support.

As a demo try `flux mini run -o pty bash` or `flux mini run -o pty flux start`.