### PR TITLE
cmd/flux-job: Use common attrs for list cmds

### DIFF
--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -995,15 +995,17 @@ int cmd_cancelall (optparse_t *p, int argc, char **argv)
     return 0;
 }
 
+static const char *list_attrs =
+    "[\"userid\",\"priority\",\"t_submit\",\"state\","          \
+    "\"name\",\"ntasks\",\"nnodes\",\"ranks\",\"success\","             \
+    "\"exception_occurred\",\"exception_severity\",\"exception_type\"," \
+    "\"exception_note\","                                               \
+    "\"t_depend\",\"t_sched\",\"t_run\",\"t_cleanup\",\"t_inactive\"]";
+
 int cmd_list (optparse_t *p, int argc, char **argv)
 {
     int optindex = optparse_option_index (p);
     int max_entries = optparse_get_int (p, "count", 0);
-    char *attrs = "[\"userid\",\"priority\",\"t_submit\",\"state\"," \
-        "\"name\",\"ntasks\",\"nnodes\",\"ranks\",\"success\"," \
-        "\"exception_occurred\",\"exception_severity\",\"exception_type\"," \
-        "\"exception_note\"," \
-        "\"t_depend\",\"t_sched\",\"t_run\",\"t_cleanup\",\"t_inactive\"]";
     flux_t *h;
     flux_future_t *f;
     json_t *jobs;
@@ -1033,7 +1035,7 @@ int cmd_list (optparse_t *p, int argc, char **argv)
     else
         userid = getuid ();
 
-    if (!(f = flux_job_list (h, max_entries, attrs, userid, states)))
+    if (!(f = flux_job_list (h, max_entries, list_attrs, userid, states)))
         log_err_exit ("flux_job_list");
     if (flux_rpc_get_unpack (f, "{s:o}", "jobs", &jobs) < 0)
         log_err_exit ("flux_job_list");
@@ -1056,9 +1058,6 @@ int cmd_list_inactive (optparse_t *p, int argc, char **argv)
     int optindex = optparse_option_index (p);
     int max_entries = optparse_get_int (p, "count", 0);
     double since = optparse_get_double (p, "since", 0.);
-    char *attrs = "[\"userid\",\"priority\",\"t_submit\",\"state\"," \
-        "\"name\",\"ntasks\",\"nnodes\",\"ranks\",\"t_depend\",\"t_sched\"," \
-        "\"t_run\",\"t_cleanup\",\"t_inactive\"]";
     flux_t *h;
     flux_future_t *f;
     json_t *jobs;
@@ -1072,7 +1071,7 @@ int cmd_list_inactive (optparse_t *p, int argc, char **argv)
     if (!(h = flux_open (NULL, 0)))
         log_err_exit ("flux_open");
 
-    if (!(f = flux_job_list_inactive (h, max_entries, since, attrs)))
+    if (!(f = flux_job_list_inactive (h, max_entries, since, list_attrs)))
         log_err_exit ("flux_job_list_inactive");
     if (flux_rpc_get_unpack (f, "{s:o}", "jobs", &jobs) < 0)
         log_err_exit ("flux_job_list_inactive");
@@ -1107,9 +1106,6 @@ void list_id_continuation (flux_future_t *f, void *arg)
 int cmd_list_ids (optparse_t *p, int argc, char **argv)
 {
     int optindex = optparse_option_index (p);
-    char *attrs = "[\"userid\",\"priority\",\"t_submit\",\"state\"," \
-        "\"name\",\"ntasks\",\"nnodes\",\"ranks\",\"t_depend\",\"t_sched\"," \
-        "\"t_run\",\"t_cleanup\",\"t_inactive\"]";
     flux_t *h;
     int i, ids_len;
 
@@ -1124,7 +1120,7 @@ int cmd_list_ids (optparse_t *p, int argc, char **argv)
     for (i = 0; i < ids_len; i++) {
         flux_jobid_t id = parse_arg_unsigned (argv[optindex + i], "id");
         flux_future_t *f;
-        if (!(f = flux_job_list_id (h, id, attrs)))
+        if (!(f = flux_job_list_id (h, id, list_attrs)))
             log_err_exit ("flux_job_list_id");
         if (flux_future_then (f, -1, list_id_continuation, NULL) < 0)
             log_err_exit ("flux_future_then");


### PR DESCRIPTION
This is a stupid fix.  i realized the new "success" and "exception" attrs were not supported in `flux job list inactive` or `flux job list-ids`, b/c I forgot to copy them in there.

I could stick this into another PR, but it seemed to be independent of other work.