### PR TITLE
testsuite: fix racy job-shell pty test

### DIFF
--- a/t/scripts/runpty.py
+++ b/t/scripts/runpty.py
@@ -67,6 +67,7 @@ class EventLogOutput(OutputHandler):
             ),
         )
         self.fp.write("{}\n".format(json.dumps(header)))
+        self.fp.flush()
 
     def format_entry(self, data):
         entry = dict(
@@ -88,6 +89,7 @@ class AsciicastOutput(OutputHandler):
         ts = int(self.t0)
         header = dict(version=2, width=self.width, height=self.height, timestamp=ts)
         self.fp.write("{}\n".format(json.dumps(header)))
+        self.fp.flush()
 
     def format_entry(self, data):
         dt = time.time() - self.t0


### PR DESCRIPTION
This will hopefully fix the race in final set of tests in `t2612-job-shell-pty.t` that we've been seeing in Travis.