### PR TITLE
libflux: add flux_msg_last_json_error()

### DIFF
--- a/src/common/libflux/message.h
+++ b/src/common/libflux/message.h
@@ -198,6 +198,15 @@ int flux_msg_vpack (flux_msg_t *msg, const char *fmt, va_list ap);
 int flux_msg_unpack (const flux_msg_t *msg, const char *fmt, ...);
 int flux_msg_vunpack (const flux_msg_t *msg, const char *fmt, va_list ap);
 
+/* Return a string representation of the last error encountered for `msg`.
+ *
+ * If no last error is available, an empty string will be returned.
+ *
+ * Currently, only flux_msg_pack/unpack() (and related) functions will set
+ * the last error for `msg`. (Useful to get more detail from EPROTO errors)
+ */
+const char *flux_msg_last_error (const flux_msg_t *msg);
+
 /* Get/set nodeid (request only)
  */
 int flux_msg_set_nodeid (flux_msg_t *msg, uint32_t nodeid);


### PR DESCRIPTION
As discussed in #2900, add a `struct json_error_t` to `struct flux_msg` to capture the last error string from message pack/unpack functions. One drawback I hadn't considered is that this adds about 252 bytes to the allocated size of every `flux_msg_t`.

I didn't update any of the call sites. I figure maybe this could be done on an as needed basis, but could be convinced otherwise. 