### PR TITLE
broker: send <service>.disconnect requests on module unload

### DIFF
--- a/src/broker/module.h
+++ b/src/broker/module.h
@@ -13,6 +13,8 @@
 
 #include <jansson.h>
 
+#include "src/common/librouter/disconnect.h"
+
 #include "heartbeat.h"
 #include "service.h"
 
@@ -57,6 +59,15 @@ void module_set_poller_cb (module_t *p, modpoller_cb_f cb, void *arg);
  */
 flux_msg_t *module_recvmsg (module_t *p);
 int module_sendmsg (module_t *p, const flux_msg_t *msg);
+
+/* Pass module's requests through this function to enable disconnect
+ * messages to be sent when the module is unloaded.  The callback will
+ * be used to send those messages.
+ */
+int module_disconnect_arm (module_t *p,
+                           const flux_msg_t *msg,
+                           disconnect_send_f cb,
+                           void *arg);
 
 /* Send an event message to all modules that have matching subscription.
  */

--- a/src/common/libflux/message.c
+++ b/src/common/libflux/message.c
@@ -385,9 +385,11 @@ int flux_msg_set_flags (flux_msg_t *msg, uint8_t fl)
 {
     const uint8_t valid_flags = FLUX_MSGFLAG_TOPIC | FLUX_MSGFLAG_PAYLOAD
                               | FLUX_MSGFLAG_ROUTE | FLUX_MSGFLAG_UPSTREAM
-                              | FLUX_MSGFLAG_PRIVATE | FLUX_MSGFLAG_STREAMING;
+                              | FLUX_MSGFLAG_PRIVATE | FLUX_MSGFLAG_STREAMING
+                              | FLUX_MSGFLAG_NORESPONSE;
 
-    if (!msg || (fl & ~valid_flags) != 0) {
+    if (!msg || fl & ~valid_flags || ((fl & FLUX_MSGFLAG_STREAMING)
+                                   && (fl & FLUX_MSGFLAG_NORESPONSE)) != 0) {
         errno = EINVAL;
         return -1;
     }
@@ -436,6 +438,7 @@ int flux_msg_set_streaming (flux_msg_t *msg)
     uint8_t flags;
     if (flux_msg_get_flags (msg, &flags) < 0)
         return -1;
+    flags &= ~FLUX_MSGFLAG_NORESPONSE;
     if (flux_msg_set_flags (msg, flags | FLUX_MSGFLAG_STREAMING) < 0)
         return -1;
     return 0;
@@ -447,6 +450,25 @@ bool flux_msg_is_streaming (const flux_msg_t *msg)
     if (flux_msg_get_flags (msg, &flags) < 0)
         return true;
     return (flags & FLUX_MSGFLAG_STREAMING) ? true : false;
+}
+
+int flux_msg_set_noresponse (flux_msg_t *msg)
+{
+    uint8_t flags;
+    if (flux_msg_get_flags (msg, &flags) < 0)
+        return -1;
+    flags &= ~FLUX_MSGFLAG_STREAMING;
+    if (flux_msg_set_flags (msg, flags | FLUX_MSGFLAG_NORESPONSE) < 0)
+        return -1;
+    return 0;
+}
+
+bool flux_msg_is_noresponse (const flux_msg_t *msg)
+{
+    uint8_t flags;
+    if (flux_msg_get_flags (msg, &flags) < 0)
+        return true;
+    return (flags & FLUX_MSGFLAG_NORESPONSE) ? true : false;
 }
 
 int flux_msg_set_userid (flux_msg_t *msg, uint32_t userid)

--- a/src/common/libflux/message.h
+++ b/src/common/libflux/message.h
@@ -36,6 +36,7 @@ enum {
 enum {
     FLUX_MSGFLAG_TOPIC      = 0x01,	/* message has topic string */
     FLUX_MSGFLAG_PAYLOAD    = 0x02,	/* message has payload */
+    FLUX_MSGFLAG_NORESPONSE = 0x04, /* request needs no response */
     FLUX_MSGFLAG_ROUTE      = 0x08,	/* message is routable */
     FLUX_MSGFLAG_UPSTREAM   = 0x10, /* request nodeid is sender (route away) */
     FLUX_MSGFLAG_PRIVATE    = 0x20, /* private to instance owner and sender */
@@ -155,6 +156,12 @@ bool flux_msg_is_private (const flux_msg_t *msg);
  */
 int flux_msg_set_streaming (flux_msg_t *msg);
 bool flux_msg_is_streaming (const flux_msg_t *msg);
+
+/* Get/set noresponse flag.
+ * Request is advisory and should not receive a response.
+ */
+int flux_msg_set_noresponse (flux_msg_t *msg);
+bool flux_msg_is_noresponse (const flux_msg_t *msg);
 
 /* Get/set/compare message topic string.
  * set adds/deletes/replaces topic frame as needed.

--- a/src/common/libflux/message.h
+++ b/src/common/libflux/message.h
@@ -34,10 +34,10 @@ enum {
 };
 
 enum {
-    FLUX_MSGFLAG_TOPIC      = 0x01,	/* message has topic string */
-    FLUX_MSGFLAG_PAYLOAD    = 0x02,	/* message has payload */
+    FLUX_MSGFLAG_TOPIC      = 0x01, /* message has topic string */
+    FLUX_MSGFLAG_PAYLOAD    = 0x02, /* message has payload */
     FLUX_MSGFLAG_NORESPONSE = 0x04, /* request needs no response */
-    FLUX_MSGFLAG_ROUTE      = 0x08,	/* message is routable */
+    FLUX_MSGFLAG_ROUTE      = 0x08, /* message is routable */
     FLUX_MSGFLAG_UPSTREAM   = 0x10, /* request nodeid is sender (route away) */
     FLUX_MSGFLAG_PRIVATE    = 0x20, /* private to instance owner and sender */
     FLUX_MSGFLAG_STREAMING  = 0x40, /* request/response is streaming RPC */

--- a/src/common/libflux/response.c
+++ b/src/common/libflux/response.c
@@ -201,7 +201,7 @@ flux_msg_t *flux_response_derive (const flux_msg_t *request, int errnum)
 {
     flux_msg_t *msg;
 
-    if (!request) {
+    if (!request || flux_msg_is_noresponse (request)) {
         errno = EINVAL;
         return NULL;
     }
@@ -227,6 +227,8 @@ int flux_respond (flux_t *h, const flux_msg_t *request, const char *s)
 
     if (!h || !request)
         goto inval;
+    if (flux_msg_is_noresponse (request))
+        return 0;
     msg = flux_response_derive (request, 0);
     if (!msg)
         goto error;
@@ -250,6 +252,8 @@ static int flux_respond_vpack (flux_t *h, const flux_msg_t *request,
 
     if (!h || !request || !fmt)
         goto inval;
+    if (flux_msg_is_noresponse (request))
+        return 0;
     msg = flux_response_derive (request, 0);
     if (!msg)
         goto error;
@@ -289,6 +293,8 @@ int flux_respond_raw (flux_t *h, const flux_msg_t *request,
 
     if (!h || !request)
         goto inval;
+    if (flux_msg_is_noresponse (request))
+        return 0;
     msg  = flux_response_derive (request, 0);
     if (!msg)
         goto error;
@@ -312,6 +318,8 @@ int flux_respond_error (flux_t *h, const flux_msg_t *request,
 
     if (!h || !request || errnum == 0)
         goto inval;
+    if (flux_msg_is_noresponse (request))
+        return 0;
     msg = flux_response_derive (request, errnum);
     if (!msg)
         goto error;

--- a/src/common/libflux/rpc.c
+++ b/src/common/libflux/rpc.c
@@ -259,6 +259,8 @@ static flux_future_t *flux_rpc_message_nocopy (flux_t *h,
     }
     if ((flags & FLUX_RPC_STREAMING))
         msgflags |= FLUX_MSGFLAG_STREAMING;
+    if ((flags & FLUX_RPC_NORESPONSE))
+        msgflags |= FLUX_MSGFLAG_NORESPONSE;
     if (flux_msg_set_flags (msg, msgflags) < 0)
         goto error;
     if (flux_msg_set_nodeid (msg, nodeid) < 0)

--- a/src/common/libflux/test/message.c
+++ b/src/common/libflux/test/message.c
@@ -896,6 +896,26 @@ void check_flags (void)
     ok (flux_msg_is_streaming (msg) == true,
         "flux_msg_is_streaming = true");
 
+    /* FLUX_MSGFLAG_NORESPONSE */
+    ok (flux_msg_is_noresponse (msg) == false,
+        "flux_msg_is_noresponse = false");
+    ok (flux_msg_set_noresponse (msg) == 0,
+        "flux_msg_set_noresponse_works");
+    ok (flux_msg_is_noresponse (msg) == true,
+        "flux_msg_is_noresponse = true");
+
+    /* noresponse and streaming are mutually exclusive */
+    ok (flux_msg_set_streaming (msg) == 0
+        && flux_msg_set_noresponse (msg) == 0
+        && flux_msg_is_streaming (msg) == false
+        && flux_msg_is_noresponse (msg) == true,
+        "flux_msg_set_noresponse clears streaming flag");
+    ok (flux_msg_set_noresponse (msg) == 0
+        && flux_msg_set_streaming (msg) == 0
+        && flux_msg_is_noresponse (msg) == false
+        && flux_msg_is_streaming (msg) == true,
+        "flux_msg_set_streaming clears noresponse flag");
+
     ok (flux_msg_set_topic (msg, "foo") == 0
         && flux_msg_get_flags (msg, &flags) == 0
         && (flags & FLUX_MSGFLAG_TOPIC),
@@ -928,7 +948,11 @@ void check_flags (void)
     errno = 0;
     ok (flux_msg_set_flags (msg, 0xff) < 0 && errno == EINVAL,
         "flux_msg_set_flags flags=(invalid) fails with EINVAL");
-
+    errno = 0;
+    ok (flux_msg_set_flags (msg, FLUX_MSGFLAG_STREAMING
+                                | FLUX_MSGFLAG_NORESPONSE) < 0
+        && errno == EINVAL,
+        "flux_msg_set_flags streaming|noresponse fails with EINVAL");
     errno = 0;
     ok (flux_msg_set_private (NULL) < 0 && errno == EINVAL,
         "flux_msg_set_private msg=NULL fails with EINVAL");
@@ -940,6 +964,12 @@ void check_flags (void)
         "flux_msg_set_streaming msg=NULL fails with EINVAL");
     ok (flux_msg_is_streaming (NULL) == true,
         "flux_msg_is_streaming msg=NULL returns true");
+
+    errno = 0;
+    ok (flux_msg_set_noresponse (NULL) < 0 && errno == EINVAL,
+        "flux_msg_set_noresponse msg=NULL fails with EINVAL");
+    ok (flux_msg_is_noresponse (NULL) == true,
+        "flux_msg_is_noresponse msg=NULL returns true");
 }
 
 void check_refcount (void)

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -269,6 +269,7 @@ check_LTLIBRARIES = \
 	request/req.la \
 	ingest/job-manager-dummy.la \
 	job-manager/sched-dummy.la \
+	disconnect/watcher.la \
 	shell/plugins/dummy.la \
 	shell/plugins/conftest.la \
 	shell/plugins/invalid-args.la \
@@ -503,6 +504,12 @@ job_manager_sched_dummy_la_CPPFLAGS = $(test_cppflags)
 job_manager_sched_dummy_la_LDFLAGS = $(fluxmod_ldflags) -module -rpath /nowhere
 job_manager_sched_dummy_la_LIBADD = \
         $(top_builddir)/src/common/libschedutil/libschedutil.la \
+        $(test_ldadd) $(LIBDL) $(LIBUTIL)
+
+disconnect_watcher_la_SOURCES = disconnect/watcher.c
+disconnect_watcher_la_CPPFLAGS = $(test_cppflags)
+disconnect_watcher_la_LDFLAGS = $(fluxmod_ldflags) -module -rpath /nowhere
+disconnect_watcher_la_LIBADD = \
         $(test_ldadd) $(LIBDL) $(LIBUTIL)
 
 sched_simple_jj_reader_SOURCES = sched-simple/jj-reader.c

--- a/t/disconnect/watcher.c
+++ b/t/disconnect/watcher.c
@@ -1,0 +1,44 @@
+/************************************************************\
+ * Copyright 2020 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* Try to watch a non-existent key from a module.
+ * Sharness code will verify that watch count goes up, and
+ * then when module unloads, watch count will go down
+ * because broker generated disconnect message.
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/core.h>
+
+int mod_main (flux_t *h, int argc, char *argv[])
+{
+    flux_future_t *f;
+    int rc;
+
+    if (!(f = flux_kvs_lookup (h,
+                               NULL,
+                               FLUX_KVS_WATCH | FLUX_KVS_WAITCREATE,
+                               "noexist"))) {
+        flux_log_error (h, "flux_kvs_lookup");
+        return -1;
+    }
+    if ((rc = flux_reactor_run (flux_get_reactor (h), 0)) < 0)
+        flux_log_error (h, "flux_reactor_run");
+
+    flux_future_destroy (f);
+    return rc;
+}
+MOD_NAME ("watcher");
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/t/request/req.c
+++ b/t/request/req.c
@@ -211,7 +211,7 @@ void xping_request_cb (flux_t *h, flux_msg_handler_t *mh,
     flux_log (h, LOG_DEBUG, "Tping seq=%d %d!%s", seq, rank, service);
 
     flux_future_t *f;
-    if (!(f = flux_rpc_pack (h, service, rank, FLUX_RPC_NORESPONSE,
+    if (!(f = flux_rpc_pack (h, service, rank, 0,
                              "{s:i}", "seq", seq)))
         goto error;
     flux_future_destroy (f);

--- a/t/request/treq.c
+++ b/t/request/treq.c
@@ -189,7 +189,7 @@ void test_nsrc (flux_t *h, uint32_t nodeid)
     json_t *o;
 
     if (!(f = flux_rpc_pack (h, "req.nsrc",
-                             FLUX_NODEID_ANY, FLUX_RPC_NORESPONSE,
+                             FLUX_NODEID_ANY, 0,
                              "{s:i}", "count", count)))
         log_err_exit ("%s", __FUNCTION__);
     flux_future_destroy (f);
@@ -231,7 +231,7 @@ void test_putmsg (flux_t *h, uint32_t nodeid)
         oom ();
 
     if (!(f = flux_rpc_pack (h, "req.nsrc",
-                             FLUX_NODEID_ANY, FLUX_RPC_NORESPONSE,
+                             FLUX_NODEID_ANY, 0,
                              "{s:i}", "count", count)))
         log_err_exit ("%s", __FUNCTION__);
     flux_future_destroy (f);


### PR DESCRIPTION
This PR solves two long standing problems:
1) Unlike clients of `connector-local`, modules that are unloaded do not cause `<service>.disconnect` messages to be sent to services used by the module, so modules using some services (for example KVS watch) would cause services to leak state when the modules are unloaded.
2) There is no way for the sender of a request to tell the recipient that a response should not be sent.  As a consequence, services that don't implement `disconnect` methods automatically respond to them with ENOSYS.

A new message flag: FLUX_MSGFLAG_NORESPONSE is added, and `flux_rpc*()` now sets this in requests when FLUX_RPC_NORESPONSE is specified.  If `flux_respond*()` is called on a message with this flag, the response is suppressed without error.

Disconnect messages now set this flag, so now if a service doesn't implement the `disconnect` method, an ENOSYS response is not generated.

The librouter/disconnect "class" is leveraged to add disconnect messages at module unload time with minimal new code in the broker.