### PR TITLE
broker: add interface for monitoring broker liveness

### DIFF
--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -114,7 +114,7 @@ typedef struct {
     int tbon_k;
     /* Bootstrap
      */
-    hello_t *hello;
+    struct hello *hello;
     struct runlevel *runlevel;
 
     char *init_shell_cmd;
@@ -131,7 +131,7 @@ static void parent_cb (struct overlay *ov, void *sock, void *arg);
 static void child_cb (struct overlay *ov, void *sock, void *arg);
 static void module_cb (module_t *p, void *arg);
 static void module_status_cb (module_t *p, int prev_state, void *arg);
-static void hello_update_cb (hello_t *h, void *arg);
+static void hello_update_cb (struct hello *h, void *arg);
 static void shutdown_cb (struct shutdown *s, void *arg);
 static void signal_cb (flux_reactor_t *r, flux_watcher_t *w,
                        int revents, void *arg);
@@ -851,7 +851,7 @@ static void init_attrs (attr_t *attrs, pid_t pid)
         log_err_exit ("attr_add version");
 }
 
-static void hello_update_cb (hello_t *hello, void *arg)
+static void hello_update_cb (struct hello *hello, void *arg)
 {
     broker_ctx_t *ctx = arg;
 

--- a/src/broker/hello.h
+++ b/src/broker/hello.h
@@ -17,40 +17,40 @@
 /* hello protocol is used to detect that TBON overlay has wired up.
  */
 
-typedef struct hello_struct hello_t;
+struct hello;
 
-typedef void (*hello_cb_f)(hello_t *hello, void *arg);
+typedef void (*hello_cb_f)(struct hello *hello, void *arg);
 
-hello_t *hello_create (void);
-void hello_destroy (hello_t *hello);
+struct hello *hello_create (void);
+void hello_destroy (struct hello *hello);
 
 /* Register handle
  */
-void hello_set_flux (hello_t *hello, flux_t *h);
+void hello_set_flux (struct hello *hello, flux_t *h);
 
 /* Set up broker attributes
  */
-int hello_register_attrs (hello_t *hello, attr_t *attrs);
+int hello_register_attrs (struct hello *hello, attr_t *attrs);
 
 /* Register callback for completion/progress.
  */
-void hello_set_callback (hello_t *hello, hello_cb_f cb, void *arg);
+void hello_set_callback (struct hello *hello, hello_cb_f cb, void *arg);
 
 /* Get time in seconds elapsed since hello_start()
  */
-double hello_get_time (hello_t *hello);
+double hello_get_time (struct hello *hello);
 
 /* Get number of ranks currently accounted for.
  */
-int hello_get_count (hello_t *hello);
+int hello_get_count (struct hello *hello);
 
 /* Get completion status
  */
-bool hello_complete (hello_t *hello);
+bool hello_complete (struct hello *hello);
 
 /* Start the hello protocol (call on all ranks).
  */
-int hello_start (hello_t *hello);
+int hello_start (struct hello *hello);
 
 #endif /* !_BROKER_HELLO_H */
 

--- a/src/broker/hello.h
+++ b/src/broker/hello.h
@@ -14,9 +14,6 @@
 #include <stdbool.h>
 #include "attr.h"
 
-/* hello protocol is used to detect that TBON overlay has wired up.
- */
-
 struct hello;
 
 typedef void (*hello_cb_f)(struct hello *hello, void *arg);
@@ -35,6 +32,10 @@ int hello_get_count (struct hello *hello);
 /* Get completion status
  */
 bool hello_complete (struct hello *hello);
+
+/* Get the current idset containing ranks that have checked in.
+ */
+const struct idset *hello_get_idset (struct hello *hello);
 
 /* Start the hello protocol (call on all ranks).
  */

--- a/src/broker/hello.h
+++ b/src/broker/hello.h
@@ -21,20 +21,8 @@ struct hello;
 
 typedef void (*hello_cb_f)(struct hello *hello, void *arg);
 
-struct hello *hello_create (void);
+struct hello *hello_create (flux_t *h, attr_t *attrs, hello_cb_f cb, void *arg);
 void hello_destroy (struct hello *hello);
-
-/* Register handle
- */
-void hello_set_flux (struct hello *hello, flux_t *h);
-
-/* Set up broker attributes
- */
-int hello_register_attrs (struct hello *hello, attr_t *attrs);
-
-/* Register callback for completion/progress.
- */
-void hello_set_callback (struct hello *hello, hello_cb_f cb, void *arg);
 
 /* Get time in seconds elapsed since hello_start()
  */

--- a/src/broker/test/hello.c
+++ b/src/broker/test/hello.c
@@ -54,10 +54,8 @@ int main (int argc, char **argv)
     ok (flux_get_rank (h, &rank) == 0 && rank == 0,
         "rank == 0");
 
-    ok ((hello = hello_create ()) != NULL,
+    ok ((hello = hello_create (h, NULL, hello_cb, &cb_counter)) != NULL,
         "hello_create works");
-    hello_set_flux (hello, h);
-    hello_set_callback (hello, hello_cb, &cb_counter);
     ok (hello_get_count (hello) == 0,
         "hello_get_count returned 0");
     ok (hello_complete (hello) == 0,
@@ -83,10 +81,8 @@ int main (int argc, char **argv)
         "rank == 0");
 
     cb_counter = 0;
-    ok ((hello = hello_create ()) != NULL,
+    ok ((hello = hello_create (h, NULL, hello_cb, &cb_counter)) != NULL,
         "hello_create works");
-    hello_set_flux (hello, h);
-    hello_set_callback (hello, hello_cb, &cb_counter);
     ok (hello_get_count (hello) == 0,
         "hello_get_count returned 0");
     ok (hello_complete (hello) == 0,

--- a/src/broker/test/hello.c
+++ b/src/broker/test/hello.c
@@ -23,7 +23,7 @@ void fatal_err (const char *message, void *arg)
     BAIL_OUT ("fatal error: %s", message);
 }
 
-void hello_cb (hello_t *hello, void *arg)
+void hello_cb (struct hello *hello, void *arg)
 {
     int *ip = arg;
     (*ip)++;
@@ -31,7 +31,7 @@ void hello_cb (hello_t *hello, void *arg)
 
 int main (int argc, char **argv)
 {
-    hello_t *hello;
+    struct hello *hello;
     uint32_t rank, size;
     int cb_counter = 0;
 

--- a/src/cmd/builtin/comms.c
+++ b/src/cmd/builtin/comms.c
@@ -12,6 +12,9 @@
 
 #include <inttypes.h>
 #include <argz.h>
+#include <assert.h>
+
+#include "src/common/libidset/idset.h"
 
 static int internal_comms_info (optparse_t *p, int ac, char *av[])
 {
@@ -86,6 +89,97 @@ static int internal_comms_lspeer (optparse_t *p, int ac, char *av[])
     return 0;
 }
 
+/* Return true if all members of 'idset1' are in 'idset2'.
+ */
+static bool is_subset_of (struct idset *idset1, struct idset *idset2)
+{
+    unsigned int id = idset_first (idset1); // IDSET_INVALID_ID if idset1=NULL
+    while (id != IDSET_INVALID_ID) {
+        if (!idset_test (idset2, id))       // idset_test()=false if idset2=NULL
+            return false;
+        id = idset_next (idset1, id);
+    }
+    return true;
+}
+
+/* Parse idset argument named 'name'.
+ * If its value is "all" then return an idset containing 0...size-1.
+ */
+struct idset *parse_idset_arg (optparse_t *p, const char *name, uint32_t size)
+{
+    const char *arg;
+    struct idset *idset;
+
+    if ((arg = optparse_get_str (p, name, NULL)) == NULL)
+        return NULL;
+
+    if (!strcmp (arg, "all")) {
+        if (!(idset = idset_create (size, 0)))
+            log_err_exit ("error creating 'all' idset");
+        if (idset_range_set (idset, 0, size - 1) < 0)
+            log_err_exit ("error populating 'all' idset");
+    }
+    else {
+        if (!(idset = idset_decode (arg)))
+            log_msg_exit ("%s argument cannot be parsed", name);
+        if (idset_last (idset) >= size)
+            log_msg_exit ("%s argument range error (size=%u)", name, size);
+    }
+    return idset;
+}
+
+static int internal_comms_up (optparse_t *p, int ac, char *av[])
+{
+    int optindex = optparse_option_index (p);
+    flux_t *h;
+    uint32_t size;
+    flux_future_t *f;
+    int flags = 0;
+    const char *s;
+    struct idset *target = NULL;
+    struct idset *cur;
+    bool done;
+
+    if (optindex != ac) {
+        optparse_print_usage (p);
+        exit (1);
+    }
+    if (!(h = builtin_get_flux_handle (p)))
+        log_err_exit ("flux_open");
+
+    if (flux_get_size (h, &size) < 0)
+        log_err_exit ("flux_get_size");
+
+    if ((target = parse_idset_arg (p, "wait-for", size)))
+        flags |= FLUX_RPC_STREAMING;
+
+    if (!(f = flux_rpc (h, "hello.idset", NULL, 0, flags)))
+        log_err_exit ("flux_rpc");
+    do {
+        if (flux_rpc_get_unpack (f, "{s:s}", "idset", &s) < 0)
+            log_msg_exit ("hello.idset: %s", flux_future_error_string (f));
+        if (!optparse_hasopt (p, "quiet"))
+            printf ("%s\n", s);
+        /* If target is non-NULL, then we keep listening until the
+         * returned idset includes all the ranks in target.
+         */
+        if (target) {
+            if (!(cur = idset_decode (s)))
+                log_msg_exit ("hello.idset: bad idset in response");
+            done = is_subset_of (target, cur);
+            idset_destroy (cur);
+        }
+        else
+            done = true;
+        flux_future_reset (f);
+    } while (!done);
+    flux_future_destroy (f);
+
+    idset_destroy (target);
+    flux_close (h);
+    return 0;
+}
+
 int cmd_comms (optparse_t *p, int ac, char *av[])
 {
     log_init ("flux-comms");
@@ -94,6 +188,21 @@ int cmd_comms (optparse_t *p, int ac, char *av[])
         exit (1);
     return (0);
 }
+
+static struct optparse_option up_opts[] = {
+    { .name = "wait-for",
+      .key = 'w',
+      .has_arg = 1,
+      .arginfo = "IDSET",
+      .usage = "Monitor idset changes until IDSET ranks are up",
+    },
+    { .name = "quiet",
+      .key = 'q',
+      .has_arg = 0,
+      .usage = "Suppress printing idset",
+    },
+    OPTPARSE_TABLE_END
+};
 
 static struct optparse_subcommand comms_subcmds[] = {
     { "lspeer",
@@ -116,6 +225,13 @@ static struct optparse_subcommand comms_subcmds[] = {
       internal_comms_panic,
       0,
       NULL,
+    },
+    { "up",
+      "[OPTIONS]",
+      "List available broker ranks",
+      internal_comms_up,
+      0,
+      up_opts,
     },
     OPTPARSE_SUBCMD_END
 };

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -75,6 +75,7 @@ TESTSCRIPTS = \
 	t0020-terminus.t \
 	t0021-flux-jobspec.t \
 	t0022-jj-reader.t \
+	t0023-comms.t \
 	t1000-kvs.t \
 	t1001-kvs-internals.t \
 	t1003-kvs-stress.t \

--- a/t/t0023-comms.t
+++ b/t/t0023-comms.t
@@ -1,0 +1,60 @@
+#!/bin/sh
+
+test_description='Test flux-comms utility'
+
+. `dirname $0`/sharness.sh
+
+SIZE=$(test_size_large)
+test_under_flux $SIZE minimal
+
+RPC=${FLUX_BUILD_DIR}/t/request/rpc
+
+test_expect_success 'flux comms up --wait-for=all works' '
+	flux comms up --wait-for=all >idset.out &&
+	cat >idset-all.exp <<-EOT &&
+	[0-$(($SIZE-1))]
+	EOT
+	tail -1 <idset.out >idset.out.1 &&
+	test_cmp idset-all.exp idset.out.1
+'
+
+test_expect_success 'flux comms up with no argument works' '
+	flux comms up >idset2.out &&
+	test_cmp idset-all.exp idset2.out
+'
+
+test_expect_success 'flux comms up --wait-for=all --quiet works' '
+	flux comms up --wait-for=all --quiet >idset_quiet.out &&
+	test $(wc -l <idset_quiet.out) -eq 0
+'
+
+test_expect_success 'flux comms up --wait-for single rank subset works' '
+	flux comms up --wait-for=0 --quiet
+'
+
+test_expect_success 'flux comms up -h prints usage' '
+	flux comms up -h 2>usage.err &&
+	grep Usage: usage.err
+'
+
+test_expect_success 'flux comms up with extra positional argument fails' '
+	test_must_fail flux comms up xyz
+'
+
+test_expect_success 'flux comms up with unknown argument fails' '
+	test_must_fail flux comms up --unknown
+'
+
+test_expect_success 'flux comms up --wait-for fails with bad argument' '
+	test_must_fail flux comms up --wait-for=badarg
+'
+
+test_expect_success 'flux comms up --wait-for fails with out of range argument' '
+	test_must_fail flux comms up --wait-for=0-$SIZE
+'
+
+test_expect_success 'hello.idset RPC directed to rank > 0 fails with EPROTO' '
+	flux exec -r 1 $RPC hello.idset 71 </dev/null
+'
+
+test_done


### PR DESCRIPTION
This PR modifies the "hello" protocol so that it reduces idsets rather than counts, and then adds an RPC that allows the current set of live brokers to be monitored.  It also adds a 'flux comms idset [--watch]' utility interface.

At the moment, the hello protocol waits for all brokers to report in, then starts rc1, so practically speaking, this will currently only return a "full" idset.  However that will change once #2641 is solved and brokers start up independently.

This may be useful for building the `resource` module described in #2908, which would provide execution target availability to schedulers, and fetch hwloc resource data on demand, or as targets come online.

TODO: tests