### PR TITLE
ensure unit tests do not link against installed flux libraries

### DIFF
--- a/src/broker/Makefile.am
+++ b/src/broker/Makefile.am
@@ -89,6 +89,9 @@ test_ldadd = \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libtap/libtap.la
 
+test_ldflags = \
+	-no-install
+
 test_cppflags = \
         -I$(top_srcdir)/src/common/libtap \
         $(AM_CPPFLAGS)
@@ -103,31 +106,39 @@ T_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
 test_heartbeat_t_SOURCES = test/heartbeat.c
 test_heartbeat_t_CPPFLAGS = $(test_cppflags)
 test_heartbeat_t_LDADD = $(test_ldadd)
+test_heartbeat_t_LDFLAGS = $(test_ldflags)
 
 test_hello_t_SOURCES = test/hello.c
 test_hello_t_CPPFLAGS = $(test_cppflags)
 test_hello_t_LDADD = $(test_ldadd)
+test_hello_t_LDFLAGS = $(test_ldflags)
 
 test_attr_t_SOURCES = test/attr.c
 test_attr_t_CPPFLAGS = $(test_cppflags)
 test_attr_t_LDADD = $(test_ldadd)
+test_attr_t_LDFLAGS = $(test_ldflags)
 
 test_service_t_SOURCES = test/service.c
 test_service_t_CPPFLAGS = $(test_cppflags)
 test_service_t_LDADD = $(test_ldadd)
+test_service_t_LDFLAGS = $(test_ldflags)
 
 test_reduce_t_SOURCES = test/reduce.c
 test_reduce_t_CPPFLAGS = $(test_cppflags)
 test_reduce_t_LDADD = $(test_ldadd)
+test_reduce_t_LDFLAGS = $(test_ldflags)
 
 test_liblist_t_SOURCES = test/liblist.c
 test_liblist_t_CPPFLAGS = $(test_cppflags)
 test_liblist_t_LDADD = $(test_ldadd)
+test_liblist_t_LDFLAGS = $(test_ldflags)
 
 test_pmiutil_t_SOURCES = test/pmiutil.c
 test_pmiutil_t_CPPFLAGS = $(test_cppflags)
 test_pmiutil_t_LDADD = $(test_ldadd)
+test_pmiutil_t_LDFLAGS = $(test_ldflags)
 
 test_boot_config_t_SOURCES = test/boot_config.c
 test_boot_config_t_CPPFLAGS = $(test_cppflags)
 test_boot_config_t_LDADD = $(test_ldadd)
+test_boot_config_t_LDFLAGS = $(test_ldflags)

--- a/src/common/libioencode/Makefile.am
+++ b/src/common/libioencode/Makefile.am
@@ -34,6 +34,9 @@ test_ldadd = \
         $(top_builddir)/src/common/libflux-core.la \
         $(top_builddir)/src/common/libtap/libtap.la
 
+test_ldflags = \
+	-no-install
+
 test_cppflags = \
         $(AM_CPPFLAGS) \
 	-I$(top_srcdir)/src/common/libtap
@@ -41,3 +44,4 @@ test_cppflags = \
 test_ioencode_t_SOURCES = test/ioencode.c
 test_ioencode_t_CPPFLAGS = $(test_cppflags)
 test_ioencode_t_LDADD = $(test_ldadd)
+test_ioencode_t_LDFLAGS = $(test_ldflags)

--- a/src/common/librouter/Makefile.am
+++ b/src/common/librouter/Makefile.am
@@ -66,34 +66,45 @@ test_cppflags = \
         $(AM_CPPFLAGS) \
         -I$(top_srcdir)/src/common/libtap
 
+test_ldflags = \
+	-no-install
+
 test_sendfd_t_SOURCES = test/sendfd.c
 test_sendfd_t_CPPFLAGS = $(test_cppflags)
 test_sendfd_t_LDADD = $(test_ldadd)
+test_sendfd_t_LDFLAGS = $(test_ldflags)
 
 test_disconnect_t_SOURCES = test/disconnect.c
 test_disconnect_t_CPPFLAGS = $(test_cppflags)
 test_disconnect_t_LDADD = $(test_ldadd)
+test_disconnect_t_LDFLAGS = $(test_ldflags)
 
 test_auth_t_SOURCES = test/auth.c
 test_auth_t_CPPFLAGS = $(test_cppflags)
 test_auth_t_LDADD = $(test_ldadd)
+test_auth_t_LDFLAGS = $(test_ldflags)
 
 test_usock_t_SOURCES = test/usock.c
 test_usock_t_CPPFLAGS = $(test_cppflags)
 test_usock_t_LDADD = $(test_ldadd)
+test_usock_t_LDFLAGS = $(test_ldflags)
 
 test_usock_echo_t_SOURCES = test/usock_echo.c
 test_usock_echo_t_CPPFLAGS = $(test_cppflags)
 test_usock_echo_t_LDADD = $(test_ldadd)
+test_usock_echo_t_LDFLAGS = $(test_ldflags)
 
 test_subhash_t_SOURCES = test/subhash.c
 test_subhash_t_CPPFLAGS = $(test_cppflags)
 test_subhash_t_LDADD = $(test_ldadd)
+test_subhash_t_LDFLAGS = $(test_ldflags)
 
 test_router_t_SOURCES = test/router.c
 test_router_t_CPPFLAGS = $(test_cppflags)
 test_router_t_LDADD = $(test_ldadd)
+test_router_t_LDFLAGS = $(test_ldflags)
 
 test_servhash_t_SOURCES = test/servhash.c
 test_servhash_t_CPPFLAGS = $(test_cppflags)
 test_servhash_t_LDADD = $(test_ldadd)
+test_servhash_t_LDFLAGS = $(test_ldflags)

--- a/src/common/libsubprocess/Makefile.am
+++ b/src/common/libsubprocess/Makefile.am
@@ -51,6 +51,9 @@ test_ldadd = \
         $(top_builddir)/src/common/libflux-core.la \
         $(top_builddir)/src/common/libtap/libtap.la
 
+test_ldflags = \
+	-no-install
+
 test_cppflags = \
         $(AM_CPPFLAGS) \
 	-I$(top_srcdir)/src/common/libtap
@@ -58,12 +61,14 @@ test_cppflags = \
 test_cmd_t_SOURCES = test/cmd.c
 test_cmd_t_CPPFLAGS = $(test_cppflags)
 test_cmd_t_LDADD = $(test_ldadd)
+test_cmd_t_LDFLAGS = $(test_ldflags)
 
 test_subprocess_t_SOURCES = test/subprocess.c
 test_subprocess_t_CPPFLAGS = \
 	-DTEST_SUBPROCESS_DIR=\"$(top_builddir)/src/common/libsubprocess/\" \
 	$(test_cppflags)
 test_subprocess_t_LDADD = $(test_ldadd)
+test_subprocess_t_LDFLAGS = $(test_ldflags)
 
 test_echo_SOURCES = test/test_echo.c
 

--- a/src/common/libterminus/Makefile.am
+++ b/src/common/libterminus/Makefile.am
@@ -43,6 +43,9 @@ test_ldadd = \
         $(top_builddir)/src/common/libflux-core.la \
         $(top_builddir)/src/common/libtap/libtap.la
 
+test_ldflags = \
+	-no-install
+
 test_cppflags = \
 	$(AM_CPPFLAGS) \
 	-I$(top_srcdir)/src/common/libtap
@@ -50,7 +53,9 @@ test_cppflags = \
 test_pty_t_SOURCES = test/pty.c
 test_pty_t_CPPFLAGS = $(test_cppflags)
 test_pty_t_LDADD = $(test_ldadd)
+test_pty_t_LDFLAGS = $(test_ldflags)
 
 test_terminus_t_SOURCES = test/terminus.c
 test_terminus_t_CPPFLAGS = $(test_cppflags)
 test_terminus_t_LDADD = $(test_ldadd)
+test_terminus_t_LDFLAGS = $(test_ldflags)

--- a/src/modules/job-exec/Makefile.am
+++ b/src/modules/job-exec/Makefile.am
@@ -62,6 +62,9 @@ test_ldadd = \
 	$(top_builddir)/src/common/libflux-core.la \
 	$(ZMQ_LIBS) $(LIBPTHREAD) $(JANSSON_LIBS)
 
+test_ldflags = \
+	-no-install
+
 test_cppflags = \
 	$(AM_CPPFLAGS)
 
@@ -79,3 +82,5 @@ test_rset_t_CPPFLAGS = \
 	$(test_cppflags)
 test_rset_t_LDADD = \
 	$(test_ldadd)
+test_rset_t_LDFLAGS = \
+	$(test_ldflags)

--- a/src/modules/job-manager/Makefile.am
+++ b/src/modules/job-manager/Makefile.am
@@ -74,6 +74,9 @@ test_ldadd = \
 test_cppflags = \
 	$(AM_CPPFLAGS)
 
+test_ldflags = \
+	-no-install
+
 check_PROGRAMS = $(TESTS)
 
 TEST_EXTENSIONS = .t
@@ -84,32 +87,44 @@ test_job_t_SOURCES = test/job.c
 test_job_t_CPPFLAGS = $(test_cppflags)
 test_job_t_LDADD = \
         $(test_ldadd)
+test_job_t_LDFLAGS = \
+        $(test_ldflags)
 
 test_list_t_SOURCES = test/list.c
 test_list_t_CPPFLAGS = $(test_cppflags)
 test_list_t_LDADD = \
         $(top_builddir)/src/modules/job-manager/list.o \
-        $(test_ldadd)
+	$(test_ldadd)
+test_list_t_LDFLAGS = \
+        $(test_ldflags)
 
 test_raise_t_SOURCES = test/raise.c
 test_raise_t_CPPFLAGS = $(test_cppflags)
 test_raise_t_LDADD = \
         $(top_builddir)/src/modules/job-manager/raise.o \
         $(test_ldadd)
+test_raise_t_LDFLAGS = \
+        $(test_ldflags)
 
 test_kill_t_SOURCES = test/kill.c
 test_kill_t_CPPFLAGS = $(test_cppflags)
 test_kill_t_LDADD = \
         $(top_builddir)/src/modules/job-manager/kill.o \
         $(test_ldadd)
+test_kill_t_LDFLAGS = \
+        $(test_ldflags)
 
 test_restart_t_SOURCES = test/restart.c
 test_restart_t_CPPFLAGS = $(test_cppflags)
 test_restart_t_LDADD = \
         $(top_builddir)/src/modules/job-manager/restart.o \
         $(test_ldadd)
+test_restart_t_LDFLAGS = \
+        $(test_ldflags)
 
 test_submit_t_SOURCES = test/submit.c
 test_submit_t_CPPFLAGS = $(test_cppflags)
 test_submit_t_LDADD = \
         $(test_ldadd)
+test_submit_t_LDFLAGS = \
+        $(test_ldflags)

--- a/src/modules/kvs/Makefile.am
+++ b/src/modules/kvs/Makefile.am
@@ -52,6 +52,9 @@ test_ldadd = \
 	$(top_builddir)/src/common/libtap/libtap.la \
         $(ZMQ_LIBS) $(LIBPTHREAD)
 
+test_ldflags = \
+	-no-install
+
 test_cppflags = \
         $(AM_CPPFLAGS) \
         -I$(top_srcdir)/src/common/libtap
@@ -67,6 +70,8 @@ test_waitqueue_t_CPPFLAGS = $(test_cppflags)
 test_waitqueue_t_LDADD = \
 	$(top_builddir)/src/modules/kvs/waitqueue.o \
 	$(test_ldadd)
+test_waitqueue_t_LDFLAGS = \
+	$(test_ldflags)
 
 test_cache_t_SOURCES = test/cache.c
 test_cache_t_CPPFLAGS = $(test_cppflags)
@@ -74,6 +79,8 @@ test_cache_t_LDADD = \
 	$(top_builddir)/src/modules/kvs/cache.o \
 	$(top_builddir)/src/modules/kvs/waitqueue.o \
 	$(test_ldadd)
+test_cache_t_LDFLAGS = \
+	$(test_ldflags)
 
 test_lookup_t_SOURCES = test/lookup.c
 test_lookup_t_CPPFLAGS = $(test_cppflags)
@@ -85,12 +92,16 @@ test_lookup_t_LDADD = \
 	$(top_builddir)/src/modules/kvs/kvstxn.o \
 	$(top_builddir)/src/modules/kvs/treq.o \
 	$(test_ldadd)
+test_lookup_t_LDFLAGS = \
+	$(test_ldflags)
 
 test_treq_t_SOURCES = test/treq.c
 test_treq_t_CPPFLAGS = $(test_cppflags)
 test_treq_t_LDADD = \
 	$(top_builddir)/src/modules/kvs/treq.o \
 	$(test_ldadd)
+test_treq_t_LDFLAGS = \
+	$(test_ldflags)
 
 test_kvstxn_t_SOURCES = test/kvstxn.c
 test_kvstxn_t_CPPFLAGS = $(test_cppflags)
@@ -102,6 +113,8 @@ test_kvstxn_t_LDADD = \
 	$(top_builddir)/src/modules/kvs/treq.o \
 	$(top_builddir)/src/modules/kvs/waitqueue.o \
 	$(test_ldadd)
+test_kvstxn_t_LDFLAGS = \
+	$(test_ldflags)
 
 test_kvsroot_t_SOURCES = test/kvsroot.c
 test_kvsroot_t_CPPFLAGS = $(test_cppflags)
@@ -112,6 +125,8 @@ test_kvsroot_t_LDADD = \
 	$(top_builddir)/src/modules/kvs/cache.o \
 	$(top_builddir)/src/modules/kvs/treq.o \
 	$(test_ldadd)
+test_kvsroot_t_LDFLAGS = \
+	$(test_ldflags)
 
 test_kvssync_t_SOURCES = test/kvssync.c
 test_kvssync_t_CPPFLAGS = $(test_cppflags)
@@ -123,3 +138,5 @@ test_kvssync_t_LDADD = \
 	$(top_builddir)/src/modules/kvs/cache.o \
 	$(top_builddir)/src/modules/kvs/treq.o \
 	$(test_ldadd)
+test_kvssync_t_LDFLAGS = \
+	$(test_ldflags)

--- a/src/modules/sched-simple/Makefile.am
+++ b/src/modules/sched-simple/Makefile.am
@@ -53,6 +53,9 @@ test_ldadd = \
 test_cppflags = \
 	$(AM_CPPFLAGS)
 
+test_ldflags = \
+	-no-install
+
 TESTS = \
 	test_rnode.t \
 	test_rlist.t
@@ -69,6 +72,8 @@ test_rnode_t_CPPFLAGS = \
 	$(test_cppflags)
 test_rnode_t_LDADD = \
 	$(test_ldadd)
+test_rnode_t_LDFLAGS = \
+	$(test_ldflags)
 
 test_rlist_t_SOURCES = \
 	rnode.c \
@@ -80,6 +85,8 @@ test_rlist_t_CPPFLAGS = \
 	$(test_cppflags)
 test_rlist_t_LDADD = \
 	$(test_ldadd)
+test_rlist_t_LDFLAGS = \
+	$(test_ldflags)
 
 rlist_query_SOURCES = \
 	rnode.c \

--- a/src/shell/Makefile.am
+++ b/src/shell/Makefile.am
@@ -117,6 +117,9 @@ test_ldadd = \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libtap/libtap.la
 
+test_ldflags = \
+	-no-install
+
 test_cppflags = \
         -I$(top_srcdir)/src/common/libtap \
         $(AM_CPPFLAGS)
@@ -138,39 +141,49 @@ test_jobspec_t_CPPFLAGS = $(test_cppflags)
 test_jobspec_t_LDADD = \
 	$(builddir)/libshell.la \
 	$(test_ldadd)
+test_jobspec_t_LDFLAGS = \
+	$(test_ldflags)
 
 test_plugstack_t_SOURCES = plugstack.c test/plugstack.c
 test_plugstack_t_CPPFLAGS = $(test_cppflags) -DPLUGSTACK_STANDALONE
 test_plugstack_t_LDADD = \
 	$(builddir)/libshell.la \
 	$(test_ldadd)
+test_plugstack_t_LDFLAGS = \
+	$(test_ldflags)
 
 test_a_plugin_la_SOURCES = test/plugin_test.c
 test_a_plugin_la_CPPFLAGS = $(test_cppflags) -DTEST_PLUGIN_RESULT=\"A\"
-test_a_plugin_la_LDFLAGS = -module -rpath /nowhere
+test_a_plugin_la_LDFLAGS = -module -rpath /nowhere $(test_ldflags)
 
 test_b_plugin_la_SOURCES = test/plugin_test.c
 test_b_plugin_la_CPPFLAGS = $(test_cppflags) -DTEST_PLUGIN_RESULT=\"B\"
-test_b_plugin_la_LDFLAGS = -module -rpath /nowhere
+test_b_plugin_la_LDFLAGS = -module -rpath /nowhere $(test_ldflags)
 
 test_c_plugin_la_SOURCES = test/plugin_test.c
 test_c_plugin_la_CPPFLAGS = $(test_cppflags) -DTEST_PLUGIN_RESULT=\"C\"
-test_c_plugin_la_LDFLAGS = -module -rpath /nowhere
+test_c_plugin_la_LDFLAGS = -module -rpath /nowhere $(test_ldflags)
 
 mpir_test_rangelist_t_SOURCES = mpir/test/rangelist.c
 mpir_test_rangelist_t_CPPFLAGS = $(test_cppflags)
 mpir_test_rangelist_t_LDADD = \
 	$(builddir)/libmpir.la \
 	$(test_ldadd)
+mpir_test_rangelist_t_LDFLAGS = \
+	$(test_ldflags)
 
 mpir_test_nodelist_t_SOURCES = mpir/test/nodelist.c
 mpir_test_nodelist_t_CPPFLAGS = $(test_cppflags)
 mpir_test_nodelist_t_LDADD = \
 	$(builddir)/libmpir.la \
 	$(test_ldadd)
+mpir_test_nodelist_t_LDFLAGS = \
+	$(test_ldflags)
 
 mpir_test_proctable_t_SOURCES = mpir/test/proctable.c
 mpir_test_proctable_t_CPPFLAGS = $(test_cppflags)
 mpir_test_proctable_t_LDADD = \
 	$(builddir)/libmpir.la \
 	$(test_ldadd)
+mpir_test_proctable_t_LDFLAGS = \
+	$(test_ldflags)

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -366,6 +366,18 @@ test_expect_success 'flux-start: rank 0 Killed' '
 	egrep "flux-start: 0 .* Killed" panic.err
 '
 
+test_expect_success 'no unit tests built with libtool wrapper' '
+	find ${FLUX_BUILD_DIR} \
+		-name "test_*.t" \
+		-type f \
+		-executable \
+		-printf "%h\n" \
+		| uniq \
+		| xargs -i basename {} > test_dirs &&
+	test_debug "cat test_dirs" &&
+	test_must_fail grep -q "\.libs" test_dirs
+'
+
 # Note: flux-start auto-removes rundir
 
 test_done


### PR DESCRIPTION
As described in #2916, add the libtool `-no-install` flag to all unit tests that were currently being built with libtool wrappers. This not only removes the built wrapper scripts, but also fixes the issue where some unit tests were being built against installed flux libs when using `--with-flux-security`.

I wanted to add a `make check` test to ensure no unit tests are built with libtool wrappers in the future, but the `check-local` target runs at the wrong time during the build, so I ended up adding a test to `t0001-basic.t`. Not sure if that is an acceptable approach...