### PR TITLE
add resource module

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -501,6 +501,7 @@ AC_CONFIG_FILES( \
   src/modules/job-exec/Makefile \
   src/modules/job-archive/Makefile \
   src/modules/sched-simple/Makefile \
+  src/modules/resource/Makefile \
   src/test/Makefile \
   etc/Makefile \
   etc/flux-core.pc \

--- a/etc/rc1
+++ b/etc/rc1
@@ -24,7 +24,7 @@ wait_check ${pids[@]}
 unset pids
 
 declare -a pids
-flux hwloc reload & pids+=($!)
+flux module load resource
 flux exec -r all flux module load job-info & pids+=($!)
 flux module load cron sync=hb & pids+=($!)
 flux module load job-manager & pids+=($!)

--- a/etc/rc3
+++ b/etc/rc3
@@ -17,6 +17,7 @@ done
 shopt -u nullglob
 
 flux module remove -f sched-simple
+flux module remove -f resource
 flux module remove -f job-exec
 flux module remove -f job-manager
 flux exec -r all flux module remove -f job-ingest

--- a/src/cmd/flux-kvs.c
+++ b/src/cmd/flux-kvs.c
@@ -1872,10 +1872,12 @@ void eventlog_get_continuation (flux_future_t *f, void *arg)
         log_err_exit ("eventlog_decode");
 
     json_array_foreach (a, index, value) {
-        if (optparse_hasopt (ctx->p, "unformatted"))
-            eventlog_unformatted_print (value);
-        else
-            eventlog_prettyprint (value);
+        if (ctx->maxcount == 0 || ctx->count < ctx->maxcount) {
+            if (optparse_hasopt (ctx->p, "unformatted"))
+                eventlog_unformatted_print (value);
+            else
+                eventlog_prettyprint (value);
+        }
         if (ctx->maxcount > 0 && ++ctx->count == ctx->maxcount)
             limit_reached = true;
     }

--- a/src/modules/Makefile.am
+++ b/src/modules/Makefile.am
@@ -12,4 +12,5 @@ SUBDIRS = \
  job-info \
  job-exec \
  job-archive \
+ resource \
  sched-simple

--- a/src/modules/resource/Makefile.am
+++ b/src/modules/resource/Makefile.am
@@ -1,0 +1,41 @@
+AM_CFLAGS = \
+	$(WARNING_CFLAGS) \
+	$(CODE_COVERAGE_CFLAGS)
+
+AM_LDFLAGS = \
+	$(CODE_COVERAGE_LIBS)
+
+AM_CPPFLAGS = \
+	-I$(top_srcdir) \
+	-I$(top_srcdir)/src/include \
+	-I$(top_builddir)/src/common/libflux \
+	$(ZMQ_CFLAGS)
+
+#
+# Comms module
+#
+fluxmod_LTLIBRARIES = resource.la
+
+resource_la_SOURCES = \
+	resource.c \
+	resource.h \
+	monitor.c \
+	monitor.h \
+	discover.c \
+	discover.h \
+	drain.c \
+	drain.h \
+	exclude.c \
+	exclude.h \
+	reslog.c \
+	reslog.h \
+	acquire.c \
+	acquire.h \
+	rutil.c \
+	rutil.h
+
+resource_la_LDFLAGS = $(fluxmod_ldflags) -module
+resource_la_LIBADD = $(fluxmod_libadd) \
+		    $(top_builddir)/src/common/libflux-internal.la \
+		    $(top_builddir)/src/common/libflux-core.la \
+		    $(ZMQ_LIBS)

--- a/src/modules/resource/Makefile.am
+++ b/src/modules/resource/Makefile.am
@@ -39,3 +39,32 @@ resource_la_LIBADD = $(fluxmod_libadd) \
 		    $(top_builddir)/src/common/libflux-internal.la \
 		    $(top_builddir)/src/common/libflux-core.la \
 		    $(ZMQ_LIBS)
+
+TESTS = test_rutil.t
+
+test_ldadd = \
+        $(top_builddir)/src/common/libflux-internal.la \
+        $(top_builddir)/src/common/libflux-core.la \
+        $(top_builddir)/src/common/libtap/libtap.la \
+        $(ZMQ_LIBS) $(LIBPTHREAD)
+
+test_ldflags = \
+        -no-install
+
+test_cppflags = \
+        $(AM_CPPFLAGS)
+
+check_PROGRAMS = $(TESTS)
+
+TEST_EXTENSIONS = .t
+T_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
+       $(top_srcdir)/config/tap-driver.sh
+
+test_rutil_t_SOURCES = test/rutil.c
+test_rutil_t_CPPFLAGS = $(test_cppflags)
+test_rutil_t_LDADD = \
+        $(top_builddir)/src/modules/resource/rutil.o \
+        $(test_ldadd)
+test_rutil_t_LDFLAGS = \
+        $(test_ldflags)
+

--- a/src/modules/resource/acquire.c
+++ b/src/modules/resource/acquire.c
@@ -1,0 +1,409 @@
+/************************************************************\
+ * Copyright 2020 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* acquire.c - let schedulers acquire resources and monitor their availability
+ *
+ * PROTOCOL
+ *
+ * Scheduler makes resource.acquire RPC.  Streaming responses are of the form:
+ *
+ * First response:
+ *   {resources:resource_object up:idset}
+ * Subsequent responses:
+ *   {up?:idset down?:idset}
+ *
+ * Where:
+ * - resource_object maps execution target ids to resources
+ *   (see RESOURCE OBJECT) below
+ * - idset is a set of execution target ids, encoded as a string.
+ *
+ * Execution targets that are excluded by configuration are omitted from
+ * resource_object in the initial response.  Targets should be considered
+ * "down" until they appear as a member of an "up" idset.
+ *
+ * As execution targets from the resource_object go online or are undrained,
+ * they are marked "up".  As they go offline or are drained, they are marked
+ * "down".
+ *
+ * If the exclusion configuration changes, any newly excluded execution
+ * targets from the resource_object are marked "down".  On the next
+ * scheduler reload, the resource set will omit those targets.
+ *
+ * RESOURCE OBJECT
+ *
+ * The hwloc.by_rank object format is used as a placeholder until
+ * design work on a proper format is completed.  by_rank is a JSON object
+ * whose top-level keys are idsets, and values are objects containing a
+ * a flat hwloc inventory, e.g.
+ *  {"[0-3]": {"Package": 1, "Core": 2, "PU": 2, "cpuset": "0-1"}}
+ *
+ * N.B. A scheduler that needs more inventory/hierarchy information than
+ * is present in the by_rank inventories MAY fetch resource.hwloc.xml.<rank>
+ * for each execution target listed in an idset key.
+ *
+ * LIMITATIONS
+ *
+ * Currently, only a single resource.acquire RPC is allowed to be pending
+ * at a time.  Upon scheduler unload, the automatically generated disconnect
+ * request frees up this slot.  If a scheduler wishes to terminate the RPC
+ * sooner, it may send a resource.acquire-cancel RPC containing the matchtag
+ * of the resource.acquire RPC.  Per RFC 6, the former does not receive a
+ * response, and the latter receives a (terminating) ECANCELED response.
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <jansson.h>
+#include <flux/core.h>
+
+#include "src/common/libidset/idset.h"
+#include "src/common/libutil/errno_safe.h"
+
+#include "resource.h"
+#include "reslog.h"
+#include "discover.h"
+#include "exclude.h"
+#include "drain.h"
+#include "acquire.h"
+#include "monitor.h"
+#include "rutil.h"
+
+struct acquire_request {
+    struct acquire *acquire;
+
+    const flux_msg_t *msg;              // orig request
+    int response_count;                 // count of response messages sent
+
+    json_t *resources;                  // resource object
+    struct idset *valid;                // valid targets
+    struct idset *up;                   // available targets
+};
+
+struct acquire {
+    struct resource_ctx *ctx;
+    flux_msg_handler_t **handlers;
+    struct acquire_request *request;    // N.B. there can be only one currently
+};
+
+
+static void acquire_request_destroy (struct acquire_request *ar)
+{
+    if (ar) {
+        flux_msg_decref (ar->msg);
+        json_decref (ar->resources);
+        idset_destroy (ar->valid);
+        idset_destroy (ar->up);
+        free (ar);
+    }
+}
+
+static struct acquire_request *acquire_request_create (struct acquire *acquire,
+                                                       const flux_msg_t *msg)
+{
+    struct acquire_request *ar;
+
+    if (!(ar = calloc (1, sizeof (*ar))))
+        return NULL;
+    ar->acquire = acquire;
+    ar->msg = flux_msg_incref (msg);
+    return ar;
+}
+
+/* Initialize request context once resource object is available.
+ * This may be called from acquire_cb() or reslog_cb().
+ */
+static int acquire_request_init (struct acquire_request *ar,
+                                 const json_t *resobj)
+{
+    struct resource_ctx *ctx = ar->acquire->ctx;
+
+    if (resobj == NULL) {
+        errno = EINVAL;
+        return -1;
+    }
+    ar->resources = rutil_resobj_sub (resobj, exclude_get (ctx->exclude));
+    if (!ar->resources)
+        return -1;
+    if (!(ar->valid = rutil_idset_from_resobj (ar->resources)))
+        return -1;
+    if (!(ar->up = idset_copy (ar->valid)))
+        return -1;
+    if (rutil_idset_sub (ar->up, drain_get (ctx->drain)) < 0)
+        return -1;
+    if (rutil_idset_sub (ar->up, monitor_get_down (ctx->monitor)) < 0)
+        return -1;
+    return 0;
+}
+
+/* reslog_cb() says 'name' event occurred.
+ * If anything changed with respect to target availability, populate
+ * up and/or down idsets with the changes.
+ * Replace ar->up with new set of available targets.
+ */
+static int acquire_request_update (struct acquire_request *ar,
+                                   const char *name,
+                                   struct idset **up,
+                                   struct idset **dn)
+{
+    struct resource_ctx *ctx = ar->acquire->ctx;
+    struct idset *new_up;
+
+    if (!(new_up = idset_copy (ar->valid)))
+        return -1;
+    if (rutil_idset_sub (new_up, drain_get (ctx->drain)) < 0)
+        goto error;
+    if (rutil_idset_sub (new_up, monitor_get_down (ctx->monitor)) < 0)
+        goto error;
+    if (rutil_idset_sub (new_up, exclude_get (ctx->exclude)) < 0)
+        goto error;
+    if (rutil_idset_diff (ar->up, new_up, up, dn) < 0)
+        goto error;
+    idset_destroy (ar->up);
+    ar->up = new_up;
+    return 0;
+error:
+    idset_destroy (new_up);
+    return -1;
+}
+
+/* Send the first response to resource.acquire request.  This presumes
+ * that acquire_request_init() has already prepared ar->resources and ar->up.
+ */
+static int acquire_respond_first (struct acquire_request *ar)
+{
+    json_t *o = NULL;
+
+    if (!(o = json_object()))
+        goto nomem;
+    if (json_object_set (o, "resources", ar->resources) < 0)
+        goto nomem;
+    if (rutil_set_json_idset (o, "up", ar->up) < 0)
+        goto error;
+    if (flux_respond_pack (ar->acquire->ctx->h, ar->msg, "O", o) < 0)
+        goto error;
+    json_decref (o);
+    ar->response_count++;
+    return 0;
+nomem:
+    errno = ENOMEM;
+error:
+    ERRNO_SAFE_WRAP (json_decref, o);
+    return -1;
+}
+
+/* Send a subsequent response to resource.acquire request, driven by
+ * reslog_cb().
+ */
+static int acquire_respond_next (struct acquire_request *ar,
+                                 struct idset *up,
+                                 struct idset *down)
+{
+    json_t *o;
+
+    if (!(o = json_object()))
+        goto nomem;
+    if (up && rutil_set_json_idset (o, "up", up) < 0)
+        goto error;
+    if (down && rutil_set_json_idset (o, "down", down) < 0)
+        goto error;
+    if (flux_respond_pack (ar->acquire->ctx->h, ar->msg, "O", o) < 0)
+        goto error;
+    json_decref (o);
+    ar->response_count++;
+    return 0;
+nomem:
+    errno = ENOMEM;
+error:
+    ERRNO_SAFE_WRAP (json_decref, o);
+    return -1;
+}
+
+/* Handle a resource.acquire request.
+ * Currently there is only one request slot.
+ * The response is deferred until resources are available.
+ */
+static void acquire_cb (flux_t *h,
+                        flux_msg_handler_t *mh,
+                        const flux_msg_t *msg,
+                        void *arg)
+{
+    struct acquire *acquire = arg;
+    const char *errmsg = NULL;
+    const json_t *resobj;
+
+    if (flux_request_decode (msg, NULL, NULL) < 0)
+        goto error;
+    if (acquire->request) {
+        errno = EBUSY;
+        goto error;
+    }
+    if (!(acquire->request = acquire_request_create (acquire, msg)))
+        goto error;
+    if (!(resobj = discover_get (acquire->ctx->discover)))
+        return; // defer response until discover event
+
+    if (acquire_request_init (acquire->request, resobj) < 0) {
+        acquire_request_destroy (acquire->request);
+        acquire->request = NULL;
+        goto error;
+    }
+    if (acquire_respond_first (acquire->request) < 0)
+        flux_log_error (h, "error responding to acquire request");
+    return;
+error:
+    if (flux_respond_error (h, msg, errno, errmsg) < 0)
+        flux_log_error (h, "error responding to acquire request");
+}
+
+/* Cancellation protocol per RFC 6.
+ * This RPC does not receive a response.  If a matching resource.acquire
+ * RPC is found, it is terminated with an ECANCELED response.
+ */
+static void cancel_cb (flux_t *h,
+                       flux_msg_handler_t *mh,
+                       const flux_msg_t *msg,
+                       void *arg)
+{
+    struct acquire *acquire = arg;
+    uint32_t matchtag1, matchtag2;
+
+    if (flux_request_unpack (msg, NULL, "{s:i}", "matchtag", &matchtag1) == 0
+            && acquire->request != NULL
+            && flux_msg_get_matchtag (acquire->request->msg, &matchtag2) == 0
+            && matchtag1 == matchtag2
+            && rutil_match_request_sender (acquire->request->msg, msg)) {
+
+        if (flux_respond_error (h, acquire->request->msg, ECANCELED, NULL) < 0)
+            flux_log_error (h, "error responding to acquire request");
+        acquire_request_destroy (acquire->request);
+        acquire->request = NULL;
+        flux_log (h, LOG_DEBUG, "%s: resource.acquire canceled", __func__);
+    }
+}
+
+/* If disconnect notification matches acquire->request, destroy the request
+ * to make the single request slot available.
+ */
+void acquire_disconnect (struct acquire *acquire, const flux_msg_t *msg)
+{
+    flux_t *h = acquire->ctx->h;
+
+    if (acquire->request
+            && rutil_match_request_sender (acquire->request->msg, msg)) {
+        acquire_request_destroy (acquire->request);
+        acquire->request = NULL;
+        flux_log (h, LOG_DEBUG, "%s: resource.acquire aborted", __func__);
+    }
+}
+
+/* An event was committed to resource.eventlog.
+ * Generate response to acquire->request as appropriate.
+ * FWIW, this function is not called until after the eventlog KVS
+ * commit completes.
+ */
+static void reslog_cb (struct reslog *reslog, const char *name, void *arg)
+{
+    struct acquire *acquire = arg;
+    struct resource_ctx *ctx = acquire->ctx;
+    const char *errmsg = NULL;
+
+    flux_log (ctx->h, LOG_DEBUG, "%s: %s event posted", __func__, name);
+
+    if (!acquire->request)
+        return;
+
+    if (!strcmp (name, "hwloc-discover-finish")) {
+        if (acquire->request->response_count == 0) {
+            if (acquire_request_init (acquire->request,
+                                      discover_get (ctx->discover)) < 0) {
+                errmsg = "error preparing first resource.acquire response";
+                goto error;
+
+            }
+            if (acquire_respond_first (acquire->request) < 0) {
+                flux_log_error (ctx->h,
+                                "error responding to resource.acquire (%s)",
+                                name);
+            }
+        }
+    }
+    else if (!strcmp (name, "online") || !strcmp (name, "offline")
+            || !strcmp (name, "exclude") || !strcmp (name, "unexclude")
+            || !strcmp (name, "drain") || !strcmp (name, "undrain")) {
+        if (acquire->request->response_count > 0) {
+            struct idset *up, *dn;
+            if (acquire_request_update (acquire->request, name, &up, &dn) < 0) {
+                errmsg = "error preparing resource.acquire update response";
+                goto error;
+            }
+            if (up || dn) {
+                if (acquire_respond_next (acquire->request, up, dn) < 0) {
+                    flux_log_error (ctx->h,
+                                    "error responding to resource.acquire (%s)",
+                                    name);
+                }
+                idset_destroy (up);
+                idset_destroy (dn);
+            }
+        }
+    }
+    return;
+error:
+    if (flux_respond_error (ctx->h, acquire->request->msg, errno, errmsg) < 0)
+        flux_log_error (ctx->h, "error responding to acquire request");
+    acquire_request_destroy (acquire->request);
+    acquire->request = NULL;
+}
+
+static const struct flux_msg_handler_spec htab[] = {
+    { FLUX_MSGTYPE_REQUEST,  MODULE_NAME ".acquire", acquire_cb, 0 },
+    { FLUX_MSGTYPE_REQUEST,  MODULE_NAME ".acquire-cancel", cancel_cb, 0 },
+    FLUX_MSGHANDLER_TABLE_END,
+};
+
+void acquire_destroy (struct acquire *acquire)
+{
+    if (acquire) {
+        int saved_errno = errno;
+        flux_msg_handler_delvec (acquire->handlers);
+        if (acquire->request) {
+            if (flux_respond_error (acquire->ctx->h,
+                                    acquire->request->msg,
+                                    ECANCELED,
+                                    "the resource module was unloaded") < 0)
+                flux_log_error (acquire->ctx->h,
+                                "error responding to acquire request");
+            acquire_request_destroy (acquire->request);
+        }
+        free (acquire);
+        errno = saved_errno;
+    }
+}
+
+struct acquire *acquire_create (struct resource_ctx *ctx)
+{
+    struct acquire *acquire;
+
+    if (!(acquire = calloc (1, sizeof (*acquire))))
+        return NULL;
+    acquire->ctx = ctx;
+    if (flux_msg_handler_addvec (ctx->h, htab, acquire, &acquire->handlers) < 0)
+        goto error;
+    reslog_set_callback (ctx->reslog, reslog_cb, acquire);
+    return acquire;
+error:
+    acquire_destroy (acquire);
+    return NULL;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/resource/acquire.h
+++ b/src/modules/resource/acquire.h
@@ -1,0 +1,24 @@
+/************************************************************\
+ * Copyright 2020 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _FLUX_RESOURCE_ACQUIRE_H
+#define _FLUX_RESOURCE_ACQUIRE_H
+
+struct acquire *acquire_create (struct resource_ctx *ctx);
+void acquire_destroy (struct acquire *acquire);
+
+void acquire_disconnect (struct acquire *acquire, const flux_msg_t *msg);
+
+#endif /* !_FLUX_RESOURCE_ACQUIRE_H */
+
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/resource/discover.c
+++ b/src/modules/resource/discover.c
@@ -1,0 +1,285 @@
+/************************************************************\
+ * Copyright 2020 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* discover.c - dynamic resource discovery
+ *
+ * Populate resource.hwloc and provide access to resource.hwloc.by_rank
+ * on demand.
+ *
+ * At initialization, the eventlog is replayed.  If events (or lack thereof)
+ * indicate that resource.hwloc is not already populated, run
+ * "flux hwloc reload".  Since that requires all ranks to be up, it is not run
+ * until the monitor subsystem says they are.
+ *
+ * In addition, once resource.hwloc is populated, the 'resource.hwloc.by_rank'
+ * object is looked up from the KVS and made available via discover_get().
+
+ * For testing, resource discovery may be defeated by populating
+ * resource.hwloc.by_rank with dummy resources and posting a fake
+ * hwloc-discover-finish event to 'resource.eventlog' before loading
+ * this module.
+ *
+ * Caveats:
+ * - resource.by_rank is a stand-in for future Flux concrete resource object
+ * - no support for statically configured resources yet
+ * - no support for obtaining resources from enclosing instance
+ * - all ranks have to be online before 'flux hwloc reload' can run
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <unistd.h>
+#include <jansson.h>
+#include <flux/core.h>
+
+#include "src/common/libidset/idset.h"
+#include "src/common/libeventlog/eventlog.h"
+
+#include "resource.h"
+#include "reslog.h"
+#include "discover.h"
+#include "monitor.h"
+
+struct discover {
+    struct resource_ctx *ctx;
+    flux_subprocess_t *p;
+    bool ready;             // all broker ranks are online
+    bool loaded;            // resource.hwloc is populated
+    flux_future_t *f;
+};
+
+static const char *auxkey = "flux::discover";
+
+const json_t *discover_get (struct discover *discover)
+{
+    json_t *by_rank;
+
+    if (!discover->f)
+        return NULL;
+    if (flux_kvs_lookup_get_unpack (discover->f, "o", &by_rank) < 0) {
+        flux_log_error (discover->ctx->h, "hwloc.by_rank");
+        return NULL;
+    }
+    return by_rank;
+}
+
+static void lookup_hwloc_continuation (flux_future_t *f, void *arg)
+{
+    struct discover *discover = arg;
+    struct resource_ctx *ctx = discover->ctx;
+
+    if (flux_future_get (f, NULL) < 0)
+        flux_log_error (ctx->h, "hwloc.by_rank");
+    /* discover->f remains valid so by_rank can be accessed later */
+}
+
+static int lookup_hwloc (struct discover *discover)
+{
+    struct resource_ctx *ctx = discover->ctx;
+
+    if (!(discover->f = flux_kvs_lookup (ctx->h,
+                                         NULL,
+                                         0,
+                                         "resource.hwloc.by_rank")))
+        return -1;
+    if (flux_future_then (discover->f,
+                          -1,
+                          lookup_hwloc_continuation,
+                          discover) < 0) {
+        flux_future_destroy (discover->f);
+        discover->f = NULL;
+        return -1;
+    }
+    return 0;
+}
+
+/* Post the end time of flux hwloc reload (and success status).
+ * This event is parsed by replay_eventlog() below.
+ */
+static void hwloc_reload_completion (flux_subprocess_t *p)
+{
+    struct discover *discover = flux_subprocess_aux_get (p, auxkey);
+    struct resource_ctx *ctx = discover->ctx;
+    int rc;
+    int signal = 0;
+    const char *cmd = "hwloc-reload";
+
+    if ((rc = flux_subprocess_exit_code (p)) == 0)
+        discover->loaded = true;
+    else if (rc > 0)
+        flux_log (ctx->h, LOG_ERR, "%s exited with rc=%d", cmd, rc);
+    else if ((signal = flux_subprocess_signaled (p)) > 0)
+        flux_log (ctx->h, LOG_ERR, "%s killed by %s", cmd, strsignal (signal));
+    else
+        flux_log (ctx->h, LOG_ERR, "%s completed (not signal or exit)", cmd);
+    if (reslog_post_pack (ctx->reslog,
+                          NULL,
+                          "hwloc-discover-finish",
+                          "{s:b}",
+                          "loaded",
+                          discover->loaded ? 1 : 0) < 0)
+        flux_log_error (ctx->h, "posting hwloc-discover-finish event");
+    if (discover->loaded) {
+        if (lookup_hwloc (discover) < 0)
+            flux_log_error (ctx->h, "resource.hwloc.by_rank");
+    }
+    flux_subprocess_destroy (p);
+    discover->p = NULL;
+}
+
+/* Post the start time of flux hwloc reload (and pid) for debugging.
+ */
+static void hwloc_reload_state_change (flux_subprocess_t *p,
+                                       flux_subprocess_state_t state)
+{
+    struct discover *discover = flux_subprocess_aux_get (p, auxkey);
+
+    if (state == FLUX_SUBPROCESS_RUNNING) {
+        if (reslog_post_pack (discover->ctx->reslog,
+                              NULL,
+                              "hwloc-discover-start",
+                              "{s:i}",
+                              "pid",
+                              flux_subprocess_pid (discover->p)) < 0)
+            flux_log_error (discover->ctx->h,
+                            "posting hwloc-discover-start event");
+    }
+}
+
+flux_subprocess_ops_t hwloc_reload_ops = {
+    .on_completion      = hwloc_reload_completion,
+    .on_state_change    = hwloc_reload_state_change,
+};
+
+static int hwloc_reload (struct discover *discover)
+{
+    flux_t *h = discover->ctx->h;
+    static char *argv[] = { "flux", "hwloc", "reload", NULL };
+    int argc = 3;
+    flux_cmd_t *cmd;
+    char path[1024];
+
+    if (!(cmd = flux_cmd_create (argc, argv, environ)))
+        return -1;
+    if (flux_cmd_setcwd (cmd, getcwd (path, sizeof (path))) < 0)
+        goto error;
+    if (!(discover->p = flux_rexec (h, 0, 0, cmd, &hwloc_reload_ops)))
+        goto error;
+    if (flux_subprocess_aux_set (discover->p, auxkey, discover, NULL) < 0)
+        goto error;
+    flux_cmd_destroy (cmd);
+    return 0;
+error:
+    flux_cmd_destroy (cmd);
+    return -1;
+}
+
+/* This is called when the idset of available brokers changes.
+ * On not-ready to ready (all brokers up) transition, initiate hwloc
+ * discover if not already done.
+ */
+static void monitor_cb (struct monitor *monitor, void *arg)
+{
+    struct discover *discover = arg;
+
+    if (!discover->ready) {
+        const struct idset *down = monitor_get_down (monitor);
+        if (!down || idset_count (down) == 0) {
+            discover->ready = true;
+            if (!discover->loaded)
+                if (hwloc_reload (discover) < 0) {
+                    flux_log_error (discover->ctx->h,
+                                    "error starting flux hwloc reload");
+                }
+        }
+    }
+}
+
+/* If restarting with eventlog, scan it for events that indicate that
+ * resource.hwloc is already populated.
+ */
+static int replay_eventlog (struct discover *discover, const json_t *eventlog)
+{
+    size_t index;
+    json_t *entry;
+    const char *name;
+    json_t *context;
+    int loaded = 0;
+
+    if (eventlog) {
+        json_array_foreach (eventlog, index, entry) {
+            if (eventlog_entry_parse (entry, NULL, &name, &context) < 0)
+                return -1;
+            if (!strcmp (name, "resource-init")) {
+                if (json_unpack (context,
+                                 "{s:b}",
+                                 "hwloc-discover",
+                                 &loaded) < 0)
+                    return -1;
+            }
+            else if (!strcmp (name, "hwloc-discover-finish")) {
+                if (json_unpack (context,
+                                 "{s:b}",
+                                 "loaded",
+                                 &loaded) < 0)
+                    return -1;
+            }
+        }
+        discover->loaded = loaded;
+    }
+    return 0;
+}
+
+void discover_destroy (struct discover *discover)
+{
+    if (discover) {
+        int saved_errno = errno;
+        flux_subprocess_destroy (discover->p);
+        flux_future_destroy (discover->f);
+        free (discover);
+        errno = saved_errno;
+    }
+}
+
+struct discover *discover_create (struct resource_ctx *ctx,
+                                  const json_t *eventlog)
+{
+    struct discover *discover;
+    const struct idset *down;
+
+    if (!(discover = calloc (1, sizeof (*discover))))
+        return NULL;
+    discover->ctx = ctx;
+    if (replay_eventlog (discover, eventlog) < 0)
+        goto error;
+    if (discover->loaded) {
+        if (lookup_hwloc (discover) < 0) {
+            flux_log_error (ctx->h, "resource.hwloc.by_rank");
+            goto error;
+        }
+    }
+    else if (!(down = monitor_get_down (ctx->monitor))
+                                            || idset_count (down) == 0) {
+        if (hwloc_reload (discover) < 0) {
+            flux_log_error (ctx->h, "error starting flux hwloc reload");
+            goto error;
+        }
+    }
+    monitor_set_callback (ctx->monitor, monitor_cb, discover);
+    return discover;
+error:
+    discover_destroy (discover);
+    return NULL;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/resource/discover.h
+++ b/src/modules/resource/discover.h
@@ -1,0 +1,36 @@
+/************************************************************\
+ * Copyright 2020 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _FLUX_RESOURCE_DISCOVER_H
+#define _FLUX_RESOURCE_DISCOVER_H
+
+struct discover *discover_create (struct resource_ctx *ctx,
+                                  const json_t *events);
+void discover_destroy (struct discover *discover);
+
+/* Notify this module of a change in exec target availability.
+ * (internally, flux hwloc reload is not run until all ranks are online)
+ */
+void discover_set_available (struct discover *discover,
+                             const struct idset *ids);
+
+/* Fetch resource object.
+ * If KVS lookup is in progress, block until it completes.
+ * If KVS lookup is not started, return NULL.
+ * (If it returns NULL, then retry after 'discover' is posted to eventlog)
+ */
+const json_t *discover_get (struct discover *discover);
+
+#endif /* !_FLUX_RESOURCE_DISCOVER_H */
+
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/resource/drain.c
+++ b/src/modules/resource/drain.c
@@ -1,0 +1,302 @@
+/************************************************************\
+ * Copyright 2020 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* drain.c - handle drain/undrain requests
+ *
+ * Drained execution targets should be excluded from scheduling,
+ * but may be used for determining job request satisfiability.
+ *
+ * Handle RPCs from front-end commands.
+ * - if a node in undrain target is not drained, request fails
+ * - if a node in drain target is already drained, request succeeds
+ * - if a node in drain/undrain target is "excluded", request fails
+ *
+ * Post events for each drain/undrain action.  Drain state is sticky
+ * across module reload / instance restart.  The state is reacquired
+ * by replaying the eventlog.
+ *
+ * N.B. the 'reason' for drain is recorded in the eventlog but is not
+ * part of the in-memory state here.
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/core.h>
+#include <jansson.h>
+
+#include "src/common/libidset/idset.h"
+#include "src/common/libeventlog/eventlog.h"
+
+#include "resource.h"
+#include "reslog.h"
+#include "exclude.h"
+#include "drain.h"
+#include "rutil.h"
+
+struct drain {
+    struct resource_ctx *ctx;
+    struct idset *idset;
+    flux_msg_handler_t **handlers;
+};
+
+const struct idset *drain_get (struct drain *drain)
+{
+    return drain->idset;
+}
+
+/* Decode string-encoded idset from drain/undrain request.
+ * Catch various errors common to both requests.
+ * On success, return idset object (caller must free).
+ * On error, capture human readable error in 'errbuf', set errno, return NULL.
+ */
+static struct idset *drain_idset_decode (struct drain *drain,
+                                         const char *ranks,
+                                         char *errbuf,
+                                         int errbufsize)
+{
+    struct idset *idset;
+    unsigned int id;
+
+    if (!(idset = idset_decode (ranks))) {
+        (void)snprintf (errbuf, errbufsize, "failed to decode idset");
+        return NULL;
+    }
+    if (idset_count (idset) == 0) {
+        (void)snprintf (errbuf, errbufsize, "idset is empty");
+        errno = EINVAL;
+        goto error;
+    }
+    if (idset_last (idset) >= drain->ctx->size) {
+        (void)snprintf (errbuf, errbufsize, "idset is out of range");
+        errno = EINVAL;
+        goto error;
+    }
+    id = idset_first (idset);
+    while (id != IDSET_INVALID_ID) {
+        if (exclude_test (drain->ctx->exclude, id)) {
+            (void)snprintf (errbuf,
+                            errbufsize,
+                            "%u is excluded by configuration",
+                            id);
+            errno = EINVAL;
+            goto error;
+        }
+        id = idset_next (idset, id);
+    }
+    return idset;
+error:
+    idset_destroy (idset);
+    return NULL;
+}
+
+/* Drain a set of ranked execution targets.
+ * If a reason was provided it is recorded in the eventlog (only).
+ */
+static void drain_cb (flux_t *h,
+                      flux_msg_handler_t *mh,
+                      const flux_msg_t *msg,
+                      void *arg)
+{
+    struct drain *drain = arg;
+    const char *s;
+    const char *reason = NULL;
+    struct idset *idset = NULL;
+    const char *errstr = NULL;
+    char errbuf[256];
+
+    if (flux_request_unpack (msg,
+                             NULL,
+                             "{s:s s?:s}",
+                             "idset",
+                             &s,
+                             "reason",
+                             &reason) < 0)
+        goto error;
+    if (!(idset = drain_idset_decode (drain, s, errbuf, sizeof (errbuf)))) {
+        errstr = errbuf;
+        goto error;
+    }
+    if (rutil_idset_add (drain->idset, idset) < 0)
+        goto error;
+    if (reslog_post_pack (drain->ctx->reslog,
+                          msg,
+                          "drain",
+                          "{s:s s:s}",
+                          "idset",
+                          s,
+                          "reason",
+                          reason ? reason : "unknown") < 0) {
+        int saved_errno = errno;
+        (void)rutil_idset_sub (drain->idset, idset); // restore orig.
+        errno = saved_errno;
+        goto error;
+    }
+    idset_destroy (idset);
+    return;
+error:
+    if (flux_respond_error (h, msg, errno, errstr) < 0)
+        flux_log_error (h, "error responding to undrain request");
+    idset_destroy (idset);
+}
+
+/* Un-drain a set of ranked execution targets.
+ * If any of the ranks are not drained, fail the whole request.
+ */
+static void undrain_cb (flux_t *h,
+                        flux_msg_handler_t *mh,
+                        const flux_msg_t *msg,
+                        void *arg)
+{
+    struct drain *drain = arg;
+    const char *s;
+    struct idset *idset = NULL;
+    unsigned int id;
+    const char *errstr = NULL;
+    char errbuf[256];
+
+    if (flux_request_unpack (msg,
+                             NULL,
+                             "{s:s}",
+                             "idset",
+                             &s) < 0)
+        goto error;
+    if (!(idset = drain_idset_decode (drain, s, errbuf, sizeof (errbuf)))) {
+        errstr = errbuf;
+        goto error;
+    }
+    id = idset_first (idset);
+    while (id != IDSET_INVALID_ID) {
+        if (!idset_test (drain->idset, id)) {
+            (void)snprintf (errbuf, sizeof (errbuf), "rank %u not drained", id);
+            errno = EINVAL;
+            errstr = errbuf;
+            goto error;
+        }
+        id = idset_next (idset, id);
+    }
+    if (rutil_idset_sub (drain->idset, idset) < 0)
+        goto error;
+    if (reslog_post_pack (drain->ctx->reslog,
+                          msg,
+                          "undrain",
+                          "{s:s}",
+                          "idset",
+                          s) < 0) {
+        int saved_errno = errno;
+        (void)rutil_idset_add (drain->idset, idset); // restore orig.
+        errno = saved_errno;
+        goto error;
+    }
+    idset_destroy (idset);
+    return;
+error:
+    if (flux_respond_error (h, msg, errno, errstr) < 0)
+        flux_log_error (h, "error responding to undrain request");
+    idset_destroy (idset);
+}
+
+/* Recover drained idset from eventlog.
+ */
+static int replay_eventlog (struct drain *drain, const json_t *eventlog)
+{
+    size_t index;
+    json_t *entry;
+
+    if (eventlog) {
+        json_array_foreach (eventlog, index, entry) {
+            const char *name;
+            json_t *context;
+            const char *s;
+            struct idset *idset;
+
+            if (eventlog_entry_parse (entry, NULL, &name, &context) < 0)
+                return -1;
+            if (!strcmp (name, "resource-init")) {
+                if (json_unpack (context, "{s:s}", "drain", &s) < 0) {
+                    errno = EPROTO;
+                    return -1;
+                }
+                idset_destroy (drain->idset);
+                if (!(drain->idset = idset_decode (s)))
+                    return -1;
+            }
+            else if (!strcmp (name, "drain")) {
+                if (json_unpack (context, "{s:s}", "idset", &s) < 0) {
+                    errno = EPROTO;
+                    return -1;
+                }
+                if (!(idset = idset_decode (s)))
+                    return -1;
+                if (rutil_idset_add (drain->idset, idset) < 0) {
+                    idset_destroy (idset);
+                    return -1;
+                }
+                idset_destroy (idset);
+            }
+            else if (!strcmp (name, "undrain")) {
+                if (json_unpack (context, "{s:s}", "idset", &s) < 0) {
+                    errno = EPROTO;
+                    return -1;
+                }
+                if (!(idset = idset_decode (s)))
+                    return -1;
+                if (rutil_idset_sub (drain->idset, idset) < 0) {
+                    idset_destroy (idset);
+                    return -1;
+                }
+                idset_destroy (idset);
+            }
+        }
+    }
+    return 0;
+}
+
+static const struct flux_msg_handler_spec htab[] = {
+    { FLUX_MSGTYPE_REQUEST,  MODULE_NAME ".drain", drain_cb, 0 },
+    { FLUX_MSGTYPE_REQUEST,  MODULE_NAME ".undrain", undrain_cb, 0 },
+    FLUX_MSGHANDLER_TABLE_END,
+};
+
+void drain_destroy (struct drain *drain)
+{
+    if (drain) {
+        int saved_errno = errno;
+        idset_destroy (drain->idset);
+        flux_msg_handler_delvec (drain->handlers);
+        free (drain);
+        errno = saved_errno;
+    }
+}
+
+struct drain *drain_create (struct resource_ctx *ctx, const json_t *eventlog)
+{
+    struct drain *drain;
+
+    if (!(drain = calloc (1, sizeof (*drain))))
+        return NULL;
+    drain->ctx = ctx;
+    if (!(drain->idset = idset_create (ctx->size, 0)))
+        goto error;
+    if (replay_eventlog (drain, eventlog) < 0) {
+        flux_log_error (ctx->h, "problem replaying eventlog drain state");
+        goto error;
+    }
+    if (flux_msg_handler_addvec (ctx->h, htab, drain, &drain->handlers) < 0)
+        goto error;
+    return drain;
+error:
+    drain_destroy (drain);
+    return NULL;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/resource/drain.h
+++ b/src/modules/resource/drain.h
@@ -1,0 +1,23 @@
+/************************************************************\
+ * Copyright 2020 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _FLUX_RESOURCE_DRAIN_H
+#define _FLUX_RESOURCE_DRAIN_H
+
+struct drain *drain_create (struct resource_ctx *ctx, const json_t *eventlog);
+void drain_destroy (struct drain *drain);
+
+const struct idset *drain_get (struct drain *drain);
+
+#endif /* !_FLUX_RESOURCE_DRAIN_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/resource/exclude.c
+++ b/src/modules/resource/exclude.c
@@ -1,0 +1,154 @@
+/************************************************************\
+ * Copyright 2020 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* exclude.c - maintain a list of exec targets excluded from scheduling
+ *
+ * Post exclude/unexclude event when configured exclusion set changes.
+ *
+ * Caveats:
+ * - There is no way to exclude at a finer granularity than execution target
+ *   (e.g. by core would be useful).
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/core.h>
+#include <jansson.h>
+
+#include "src/common/libidset/idset.h"
+
+#include "resource.h"
+#include "reslog.h"
+#include "exclude.h"
+#include "rutil.h"
+
+struct exclude {
+    struct resource_ctx *ctx;
+    struct idset *idset;
+};
+
+/* Check whether 'id' is excluded.
+ * Used by drain.c to catch someone trying to drain/undrain an excluded rank.
+ */
+bool exclude_test (struct exclude *exclude, unsigned int id)
+{
+    if (!exclude->idset || !idset_test (exclude->idset, id))
+        return false;
+    return true;
+}
+
+const struct idset *exclude_get (struct exclude *exclude)
+{
+    return exclude->idset;
+}
+
+/* Update exclusion set and post event.
+ */
+int exclude_update (struct exclude *exclude,
+                    const char *s,
+                    char *errbuf,
+                    int errbufsize)
+{
+    flux_t *h = exclude->ctx->h;
+    struct idset *idset = NULL;
+    struct idset *add;
+    struct idset *del;
+
+    if (s) {
+        if (!(idset = idset_decode (s))) {
+            snprintf (errbuf, errbufsize, "error decoding exclusion idset");
+            return -1;
+        }
+        if (idset_last (idset) >= exclude->ctx->size) {
+            snprintf (errbuf, errbufsize, "exclusion idset is out of range");
+            idset_destroy (idset);
+            errno = EINVAL;
+            return -1;
+        }
+    }
+    if (rutil_idset_diff (exclude->idset, idset, &add, &del) < 0) {
+        snprintf (errbuf, errbufsize, "error analyzing exclusion set update");
+        idset_destroy (idset);
+        return -1;
+    }
+    if (add) {
+        char *add_s = idset_encode (add, IDSET_FLAG_RANGE);
+        if (!add_s || reslog_post_pack (exclude->ctx->reslog,
+                                        NULL,
+                                        "exclude",
+                                        "{s:s}",
+                                        "idset",
+                                        add_s) < 0) {
+            flux_log_error (h, "error posting exclude event");
+        }
+        free (add_s);
+        idset_destroy (add);
+    }
+    if (del) {
+        char *del_s = idset_encode (del, IDSET_FLAG_RANGE);
+        if (!del_s || reslog_post_pack (exclude->ctx->reslog,
+                                        NULL,
+                                        "unexclude",
+                                        "{s:s}",
+                                        "idset",
+                                        del_s) < 0) {
+            flux_log_error (h, "error posting unexclude event");
+        }
+        free (del_s);
+        idset_destroy (del);
+    }
+    idset_destroy (exclude->idset);
+    exclude->idset = idset;
+    return 0;
+}
+
+void exclude_destroy (struct exclude *exclude)
+{
+    if (exclude) {
+        int saved_errno = errno;
+        idset_destroy (exclude->idset);
+        free (exclude);
+        errno = saved_errno;
+    }
+}
+
+struct exclude *exclude_create (struct resource_ctx *ctx,
+                                const char *exclude_idset)
+{
+    struct exclude *exclude;
+
+    if (!(exclude = calloc (1, sizeof (*exclude))))
+        return NULL;
+    exclude->ctx = ctx;
+    if (exclude_idset) {
+        if (!(exclude->idset = idset_decode (exclude_idset))) {
+            flux_log_error (ctx->h,
+                            "error decoding exclude set %s",
+                            exclude_idset);
+            goto error;
+        }
+        if (idset_last (exclude->idset) >= exclude->ctx->size) {
+            flux_log_error (ctx->h,
+                            "exclude set %s is out of range",
+                            exclude_idset);
+            goto error;
+        }
+    }
+    return exclude;
+error:
+    exclude_destroy (exclude);
+    return NULL;
+}
+
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/resource/exclude.h
+++ b/src/modules/resource/exclude.h
@@ -1,0 +1,30 @@
+/************************************************************\
+ * Copyright 2020 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _FLUX_RESOURCE_EXCLUDE_H
+#define _FLUX_RESOURCE_EXCLUDE_H
+
+struct exclude *exclude_create (struct resource_ctx *ctx, const char *idset);
+void exclude_destroy (struct exclude *exclude);
+
+int exclude_update (struct exclude *exclude,
+                    const char *idset,
+                    char *errbuf,
+                    int errbufsize);
+
+bool exclude_test (struct exclude *exclude, unsigned int rank);
+
+const struct idset *exclude_get (struct exclude *exclude);
+
+#endif /* !_FLUX_RESOURCE_EXCLUDE_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/resource/monitor.c
+++ b/src/modules/resource/monitor.c
@@ -1,0 +1,192 @@
+/************************************************************\
+ * Copyright 2020 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* monitor.c - resource monitoring
+ *
+ * Use the 'hello.idset' RPC to track broker ranks that come online.
+ * Maintain the set of "up" brokers internally, and call a callback
+ * each time that set changes.
+ *
+ * Post online/offline events with incremental changes to execution
+ * target availability since resource-init was posted.
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/core.h>
+#include <jansson.h>
+
+#include "src/common/libidset/idset.h"
+#include "src/common/libutil/errno_safe.h"
+
+#include "resource.h"
+#include "reslog.h"
+#include "monitor.h"
+#include "rutil.h"
+
+
+struct monitor {
+    struct resource_ctx *ctx;
+    flux_future_t *f;
+    struct idset *up;
+    struct idset *down; // only updated on access
+
+    monitor_cb_f cb;
+    void *cb_arg;
+};
+
+const struct idset *monitor_get_up (struct monitor *monitor)
+{
+    return monitor->up;
+}
+
+const struct idset *monitor_get_down (struct monitor *monitor)
+{
+    uint32_t size = monitor->ctx->size;
+    unsigned int id;
+
+    if (!monitor->down) {
+        if (!(monitor->down = idset_create (size, 0)))
+            return NULL;
+    }
+    for (id = 0; id < size; id++) {
+        if (idset_test (monitor->up, id))
+            (void)idset_clear (monitor->down, id);
+        else
+            (void)idset_set (monitor->down, id);
+    }
+    return monitor->down;
+}
+
+/* Handle updates to the idset of available brokers.
+ * Post online/offline events for any newly up or down ranks.
+ * Update monitor->up and call callback if any.
+ */
+static void hello_idset_continuation (flux_future_t *f, void *arg)
+{
+    struct monitor *monitor = arg;
+    flux_t *h = monitor->ctx->h;
+    const char *s;
+    struct idset *idset, *up, *dn;
+
+    if (flux_rpc_get_unpack (f, "{s:s}", "idset", &s) < 0
+            || !(idset = idset_decode (s))) {
+        flux_log_error (h, "error parsing hello.idset response");
+        return;
+    }
+    if (rutil_idset_diff (monitor->up, idset, &up, &dn) < 0) {
+        flux_log_error (h, "error analyzing hello.idset response");
+        idset_destroy (idset);
+        return;
+    }
+    if (up && idset_count (up) > 0) {
+        char *online;
+        if (!(online = idset_encode (up, IDSET_FLAG_RANGE))
+            || reslog_post_pack (monitor->ctx->reslog,
+                                 NULL,
+                                 "online",
+                                 "{s:s}",
+                                 "idset",
+                                 online) < 0)
+            flux_log_error (h, "error posting online event");
+        free (online);
+        idset_destroy (up);
+    }
+    if (dn && idset_count (dn) > 0) {
+        char *offline;
+        if (!(offline = idset_encode (dn, IDSET_FLAG_RANGE))
+            || reslog_post_pack (monitor->ctx->reslog,
+                                 NULL,
+                                 "offline",
+                                 "{s:s}",
+                                 "idset",
+                                 offline) < 0)
+            flux_log_error (h, "error posting offline event");
+        free (offline);
+        idset_destroy (dn);
+    }
+    idset_destroy (monitor->up);
+    monitor->up = idset;
+    if (monitor->cb)
+        monitor->cb (monitor, monitor->cb_arg);
+    flux_future_reset (monitor->f);
+}
+
+/* Send hello.idset request, process the first response (synchronously),
+ * set up continuation for next responses.
+ */
+static int hello_start (struct monitor *monitor)
+{
+    flux_future_t *f;
+    const char *s;
+    struct idset *idset = NULL;
+
+    if (!(f = flux_rpc (monitor->ctx->h,
+                        "hello.idset",
+                        NULL,
+                        0,
+                        FLUX_RPC_STREAMING)))
+        return -1;
+    if (flux_rpc_get_unpack (f, "{s:s}", "idset", &s) < 0)
+        goto error;
+    if (!(idset = idset_decode (s)))
+        goto error;
+    flux_future_reset (f);
+    if (flux_future_then (f, -1, hello_idset_continuation, monitor) < 0)
+        goto error;
+    monitor->f = f;
+    monitor->up = idset;
+    return 0;
+error:
+    ERRNO_SAFE_WRAP (idset_destroy, idset);
+    flux_future_destroy (f);
+    return -1;
+}
+
+void monitor_set_callback (struct monitor *monitor, monitor_cb_f cb, void *arg)
+{
+    monitor->cb = cb;
+    monitor->cb_arg = arg;
+}
+
+void monitor_destroy (struct monitor *monitor)
+{
+    if (monitor) {
+        int saved_errno = errno;
+        flux_future_destroy (monitor->f);
+        idset_destroy (monitor->up);
+        idset_destroy (monitor->down);
+        free (monitor);
+        errno = saved_errno;
+    }
+}
+
+struct monitor *monitor_create (struct resource_ctx *ctx)
+{
+    struct monitor *monitor;
+
+    if (!(monitor = calloc (1, sizeof (*monitor))))
+        return NULL;
+    monitor->ctx = ctx;
+    if (hello_start (monitor) < 0) {
+        flux_log_error (ctx->h, "hello.idset during initialization");
+        goto error;
+    }
+    return monitor;
+error:
+    monitor_destroy (monitor);
+    return NULL;
+}
+
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/resource/monitor.h
+++ b/src/modules/resource/monitor.h
@@ -1,0 +1,27 @@
+/************************************************************\
+ * Copyright 2020 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _FLUX_RESOURCE_MONITOR_H
+#define _FLUX_RESOURCE_MONITOR_H
+
+typedef void (*monitor_cb_f)(struct monitor *monitor, void *arg);
+
+struct monitor *monitor_create (struct resource_ctx *ctx);
+void monitor_destroy (struct monitor *monitor);
+void monitor_set_callback (struct monitor *monitor, monitor_cb_f cb, void *arg);
+
+const struct idset *monitor_get_down (struct monitor *monitor);
+const struct idset *monitor_get_up (struct monitor *monitor);
+
+#endif /* !_FLUX_RESOURCE_MONITOR_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/resource/reslog.c
+++ b/src/modules/resource/reslog.c
@@ -1,0 +1,209 @@
+/************************************************************\
+ * Copyright 2020 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/core.h>
+#include <czmq.h>
+
+#include "src/common/libutil/errno_safe.h"
+#include "src/common/libeventlog/eventlog.h"
+
+#include "reslog.h"
+
+struct event_info {
+    json_t *event;          // JSON form of event
+    const flux_msg_t *msg;  // optional request to be answered on commit
+};
+
+struct reslog {
+    flux_t *h;
+    zlist_t *pending;       // list of pending futures
+    reslog_cb_f cb;
+    void *cb_arg;
+};
+
+static const char *auxkey = "flux::event_info";
+
+/* Call registered callback, if any, with the event name that just completed.
+ */
+static void notify_callback (struct reslog *reslog, json_t *event)
+{
+    if (reslog->cb) {
+        const char *name;
+
+        if (json_unpack (event, "{s:s}", "name", &name) < 0) {
+            flux_log (reslog->h, LOG_ERR, "error unpacking event for callback");
+            return;
+        }
+        reslog->cb (reslog, name, reslog->cb_arg);
+    }
+}
+
+static void event_info_destroy (struct event_info *info)
+{
+    if (info) {
+        json_decref (info->event);
+        flux_msg_decref (info->msg);
+        ERRNO_SAFE_WRAP (free, info);
+    }
+}
+
+static struct event_info *event_info_create (json_t *event,
+                                             const flux_msg_t *request)
+{
+    struct event_info *info;
+
+    if (!(info = calloc (1, sizeof (*info))))
+        return NULL;
+    info->event = json_incref (event);
+    info->msg = flux_msg_incref (request);
+    return info;
+}
+
+int post_handler (struct reslog *reslog, flux_future_t *f)
+{
+    struct event_info *info = flux_future_aux_get (f, auxkey);
+    int rc;
+
+    if ((rc = flux_rpc_get (f, NULL)) < 0) {
+        flux_log_error (reslog->h, "committing to %s", RESLOG_KEY);
+        if (info->msg) {
+            if (flux_respond_error (reslog->h, info->msg, errno, NULL) < 0)
+                flux_log_error (reslog->h, "responding to request after post");
+        }
+        goto done;
+    }
+    else {
+        if (info->msg) {
+            if (flux_respond (reslog->h, info->msg, NULL) < 0)
+                flux_log_error (reslog->h, "responding to request after post");
+        }
+    }
+    notify_callback (reslog, info->event);
+done:
+    zlist_remove (reslog->pending, f);
+    flux_future_destroy (f);
+    return rc;
+}
+
+static void post_continuation (flux_future_t *f, void *arg)
+{
+    struct reslog *reslog = arg;
+
+    (void)post_handler (reslog, f);
+}
+
+int reslog_sync (struct reslog *reslog)
+{
+    flux_future_t *f;
+    while ((f = zlist_pop (reslog->pending))) {
+        if (post_handler (reslog, f) < 0)
+            return -1;
+    }
+    return 0;
+}
+
+int reslog_post_pack (struct reslog *reslog,
+                      const flux_msg_t *request,
+                      const char *name,
+                      const char *fmt,
+                      ...)
+{
+    va_list ap;
+    json_t *event;
+    char *val = NULL;
+    flux_kvs_txn_t *txn = NULL;
+    flux_future_t *f = NULL;
+    struct event_info *info;
+
+    va_start (ap, fmt);
+    event = eventlog_entry_vpack (0., name, fmt, ap);
+    va_end (ap);
+
+    if (!event)
+        return -1;
+    if (!(val = eventlog_entry_encode (event)))
+        goto error;
+    if (!(txn = flux_kvs_txn_create ()))
+        goto error;
+    if (flux_kvs_txn_put (txn, FLUX_KVS_APPEND, RESLOG_KEY, val) < 0)
+        goto error;
+    if (!(f = flux_kvs_commit (reslog->h, NULL, 0, txn)))
+        goto error;
+    if (!(info = event_info_create (event, request)))
+        goto error;
+    if (flux_future_aux_set (f,
+                             auxkey,
+                             info,
+                             (flux_free_f)event_info_destroy) < 0) {
+        event_info_destroy (info);
+        goto error;
+    }
+    if (flux_future_then (f, -1, post_continuation, reslog) < 0)
+        goto error;
+    if (zlist_append (reslog->pending, f) < 0) {
+        errno = ENOMEM;
+        goto error;
+    }
+    flux_kvs_txn_destroy (txn);
+    free (val);
+    json_decref (event);
+    return 0;
+error:
+    flux_future_destroy (f);
+    flux_kvs_txn_destroy (txn);
+    ERRNO_SAFE_WRAP (free, val);
+    ERRNO_SAFE_WRAP (json_decref, event);
+    return -1;
+}
+
+void reslog_set_callback (struct reslog *reslog, reslog_cb_f cb, void *arg)
+{
+    reslog->cb = cb;
+    reslog->cb_arg = arg;
+}
+
+void reslog_destroy (struct reslog *reslog)
+{
+    if (reslog) {
+        int saved_errno = errno;
+        if (reslog->pending) {
+            flux_future_t *f;
+            while ((f = zlist_pop (reslog->pending)))
+                (void)post_handler (reslog, f);
+            zlist_destroy (&reslog->pending);
+        }
+        free (reslog);
+        errno = saved_errno;
+    }
+}
+
+struct reslog *reslog_create (flux_t *h)
+{
+    struct reslog *reslog;
+
+    if (!(reslog = calloc (1, sizeof (*reslog))))
+        return NULL;
+    reslog->h = h;
+    if (!(reslog->pending = zlist_new ())) {
+        errno = ENOMEM;
+        goto error;
+    }
+    return reslog;
+error:
+    reslog_destroy (reslog);
+    return NULL;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/resource/reslog.h
+++ b/src/modules/resource/reslog.h
@@ -1,0 +1,48 @@
+/************************************************************\
+ * Copyright 2020 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _FLUX_RESOURCE_RESLOG_H
+#define _FLUX_RESOURCE_RESLOG_H
+
+struct reslog;
+
+typedef void (*reslog_cb_f)(struct reslog *reslog,
+                            const char *name,
+                            void *arg);
+
+struct reslog *reslog_create (flux_t *h);
+void reslog_destroy (struct reslog *reslog);
+
+/* Post an event to the eventlog.  This function returns immediately,
+ * and the commit to * the eventlog completes asynchronously.
+ * If 'request' is non-NULL, a success/fail response is sent upon commit
+ * completion.
+ */
+int reslog_post_pack (struct reslog *reslog,
+                      const flux_msg_t *request,
+                      const char *name,
+                      const char *fmt,
+                      ...);
+
+/* Force all pending commits to the eventlog to complete.
+ */
+int reslog_sync (struct reslog *reslog);
+
+/* Get a callback for each event.
+ */
+void reslog_set_callback (struct reslog *reslog, reslog_cb_f cb, void *arg);
+
+#define RESLOG_KEY "resource.eventlog"
+
+#endif /* !_FLUX_RESOURCE_RESLOG_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/resource/resource.c
+++ b/src/modules/resource/resource.c
@@ -1,0 +1,316 @@
+/************************************************************\
+ * Copyright 2020 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* resource.c - resource discovery and monitoring service
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <flux/core.h>
+#include <jansson.h>
+
+#include "src/common/libutil/errno_safe.h"
+#include "src/common/libidset/idset.h"
+#include "src/common/libeventlog/eventlog.h"
+
+#include "resource.h"
+#include "reslog.h"
+#include "discover.h"
+#include "monitor.h"
+#include "drain.h"
+#include "exclude.h"
+#include "acquire.h"
+#include "rutil.h"
+
+/* Parse [resource] table.
+ *
+ * exclude = "idset"
+ *   Exclude specified broker rank(s) from scheduling
+ */
+static int parse_config (struct resource_ctx *ctx,
+                         const flux_conf_t *conf,
+                         const char **excludep,
+                         char *errbuf,
+                         int errbufsize)
+{
+    flux_conf_error_t error;
+    const char *exclude  = NULL;
+
+    if (flux_conf_unpack (conf,
+                          &error,
+                          "{s?:{s?:s !}}",
+                          MODULE_NAME,
+                            "exclude",
+                            &exclude) < 0) {
+        (void)snprintf (errbuf,
+                        errbufsize,
+                        "error parsing [%s] configuration: %s",
+                        MODULE_NAME,
+                        error.errbuf);
+        return -1;
+    }
+    *excludep = exclude;
+    return 0;
+}
+
+/* Broker is sending us a new config object because 'flux config reload'
+ * was run.  Parse it and respond with human readable errors.
+ * If events are posted, block until they complete so that:
+ * - any KVS commit errors are captured by 'flux config reload'
+ * - tests can look for eventlog entry after running 'flux config reload'
+ */
+static void config_reload_cb (flux_t *h,
+                              flux_msg_handler_t *mh,
+                              const flux_msg_t *msg,
+                              void *arg)
+{
+    struct resource_ctx *ctx = arg;
+    const flux_conf_t *conf;
+    const char *exclude;
+    char errbuf[256];
+    const char *errstr = NULL;
+
+    if (flux_conf_reload_decode (msg, &conf) < 0)
+        goto error;
+    if (parse_config (ctx, conf, &exclude, errbuf, sizeof (errbuf)) < 0) {
+        errstr = errbuf;
+        goto error;
+    }
+    if (exclude_update (ctx->exclude, exclude, errbuf, sizeof (errbuf)) < 0) {
+        errstr = errbuf;
+        goto error;
+    }
+    if (flux_set_conf (h, flux_conf_incref (conf)) < 0) {
+        errstr = "error updating cached configuration";
+        goto error;
+    }
+    if (reslog_sync (ctx->reslog) < 0) {
+        errstr = "error posting to eventlog for reconfig";
+        goto error;
+    }
+    if (flux_respond (h, msg, NULL) < 0)
+        flux_log_error (h, "error responding to config-reload request");
+    return;
+error:
+    if (flux_respond_error (h, msg, errno, errstr) < 0)
+        flux_log_error (h, "error responding to config-reload request");
+}
+
+/* Handle client disconnect.
+ * Abort a streaming resource.acquire RPC, if it matches.
+ */
+static void disconnect_cb (flux_t *h,
+                           flux_msg_handler_t *mh,
+                           const flux_msg_t *msg,
+                           void *arg)
+{
+    struct resource_ctx *ctx = arg;
+
+    acquire_disconnect (ctx->acquire, msg);
+}
+
+static void resource_ctx_destroy (struct resource_ctx *ctx)
+{
+    if (ctx) {
+        int saved_errno = errno;
+        acquire_destroy (ctx->acquire);
+        drain_destroy (ctx->drain);
+        discover_destroy (ctx->discover);
+        monitor_destroy (ctx->monitor);
+        exclude_destroy (ctx->exclude);
+        reslog_destroy (ctx->reslog);
+        flux_msg_handler_delvec (ctx->handlers);
+        free (ctx);
+        errno = saved_errno;
+    }
+}
+
+static struct resource_ctx *resource_ctx_create (flux_t *h)
+{
+    struct resource_ctx *ctx;
+
+    if (!(ctx = calloc (1, sizeof (*ctx))))
+        return NULL;
+    ctx->h = h;
+    return ctx;
+}
+
+static const struct flux_msg_handler_spec htab[] = {
+    {
+        .typemask = FLUX_MSGTYPE_REQUEST,
+        .topic_glob = MODULE_NAME ".config-reload",
+        .cb = config_reload_cb,
+        .rolemask = 0
+    },
+    {
+        .typemask = FLUX_MSGTYPE_REQUEST,
+        .topic_glob = MODULE_NAME ".disconnect",
+        .cb = disconnect_cb,
+        .rolemask = 0
+    },
+    FLUX_MSGHANDLER_TABLE_END,
+};
+
+/* Post 'resource-init' event that summarizes the current discover, monitor,
+ * drain, and exclude state.  For replay purposes, all events prior to the
+ * most recent 'resource-init' can be ignored.
+ */
+int post_restart_event (struct resource_ctx *ctx, int restart)
+{
+    json_t *o;
+
+    if (!(o = json_pack ("{s:b s:b}",
+                         "restart",
+                         restart,
+                         "hwloc-discover",
+                         discover_get (ctx->discover) ? 1 : 0)))
+        goto nomem;
+    if (rutil_set_json_idset (o, "online", monitor_get_up (ctx->monitor)) < 0)
+        goto error;
+    if (rutil_set_json_idset (o, "drain", drain_get (ctx->drain)) < 0)
+        goto error;
+    if (rutil_set_json_idset (o, "exclude", exclude_get (ctx->exclude)) < 0)
+        goto error;
+    if (reslog_post_pack (ctx->reslog,
+                          NULL,
+                          "resource-init",
+                          "O",
+                          o) < 0)
+        goto error;
+    json_decref (o);
+    return 0;
+nomem:
+    errno = ENOMEM;
+error:
+    ERRNO_SAFE_WRAP (json_decref, o);
+    return -1;
+}
+
+/* Remove entries prior to the most recent 'resource-init' event from
+ * 'eventlog'. N.B. they remain in the KVS.
+ */
+static int prune_eventlog (json_t *eventlog)
+{
+    size_t index;
+    json_t *entry;
+    size_t last_entry = json_array_size (eventlog);
+    const char *name;
+
+    json_array_foreach (eventlog, index, entry) {
+        if (eventlog_entry_parse (entry, NULL, &name, NULL) == 0
+                && !strcmp (name, "resource-init"))
+            last_entry = index;
+    }
+    if (last_entry < json_array_size (eventlog)) {
+        for (index = 0; index < last_entry; index++) {
+            if (json_array_remove (eventlog, 0) < 0)
+                return -1;
+        }
+    }
+    return 0;
+}
+
+/* Synchronously read resource.eventlog, and parse into
+ * a JSON array for replay by the various subsystems.
+ * 'eventlog' is set to NULL if it doesn't exist (no error).
+ */
+static int reload_eventlog (flux_t *h, json_t **eventlog)
+{
+    flux_future_t *f;
+    const char *s;
+    json_t *o;
+
+    if (!(f = flux_kvs_lookup (h, NULL, 0, RESLOG_KEY)))
+        return -1;
+    if (flux_kvs_lookup_get (f, &s) < 0) {
+        if (errno != ENOENT) {
+            flux_log_error (h, "%s: lookup error", RESLOG_KEY);
+            goto error;
+        }
+        o = NULL;
+    }
+    else {
+        if (!(o = eventlog_decode (s))) {
+            flux_log_error (h, "%s: decode error", RESLOG_KEY);
+            goto error;
+        }
+        if (prune_eventlog (o) < 0) {
+            flux_log (h, LOG_ERR, "%s: pruning error", RESLOG_KEY);
+            ERRNO_SAFE_WRAP (json_decref, o);
+            goto error;
+        }
+    }
+    *eventlog = o;
+    flux_future_destroy (f);
+    return 0;
+error:
+    flux_future_destroy (f);
+    return -1;
+}
+
+int mod_main (flux_t *h, int argc, char **argv)
+{
+    struct resource_ctx *ctx;
+    char errbuf[256];
+    const char *exclude_idset;
+    json_t *eventlog = NULL;
+
+    if (!(ctx = resource_ctx_create (h)))
+        goto error;
+    if (flux_get_size (h, &ctx->size) < 0)
+        goto error;
+    if (reload_eventlog (h, &eventlog) < 0)
+        goto error;
+    if (!(ctx->reslog = reslog_create (h)))
+        goto error;
+    if (!(ctx->monitor = monitor_create (ctx))) // makes synchronous rpc
+        goto error;
+    if (!(ctx->discover = discover_create (ctx, eventlog))) // uses monitor
+        goto error;
+    if (!(ctx->drain = drain_create (ctx, eventlog)))
+        goto error;
+    if (!(ctx->acquire = acquire_create (ctx)))
+        goto error;
+    if (parse_config (ctx,
+                      flux_get_conf (h),
+                      &exclude_idset,
+                      errbuf,
+                      sizeof (errbuf)) < 0) {
+        flux_log (h, LOG_ERR, "%s", errbuf);
+        goto error;
+    }
+    if (!(ctx->exclude = exclude_create (ctx, exclude_idset)))
+        goto error;
+    if (post_restart_event (ctx, eventlog ? 1 : 0) < 0)
+        goto error;
+    if (reslog_sync (ctx->reslog) < 0)
+        goto error;
+    if (flux_msg_handler_addvec (h, htab, ctx, &ctx->handlers) < 0)
+        goto error;
+    if (flux_reactor_run (flux_get_reactor (h), 0) < 0) {
+        flux_log_error (h, "flux_reactor_run");
+        goto error;
+    }
+    resource_ctx_destroy (ctx);
+    json_decref (eventlog);
+    return 0;
+error:
+    resource_ctx_destroy (ctx);
+    json_decref (eventlog);
+    return -1;
+}
+
+MOD_NAME (MODULE_NAME);
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/resource/resource.h
+++ b/src/modules/resource/resource.h
@@ -1,0 +1,35 @@
+/************************************************************\
+ * Copyright 2020 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _FLUX_RESOURCE_H
+#define _FLUX_RESOURCE_H
+
+struct resource_ctx {
+    flux_t *h;
+    flux_msg_handler_t **handlers;
+    struct monitor *monitor;
+    struct discover *discover;
+    struct drain *drain;
+    struct exclude *exclude;
+    struct acquire *acquire;
+    struct reslog *reslog;
+
+    uint32_t size;
+};
+
+/* Module name, service name, config table name.
+ */
+#define MODULE_NAME "resource"
+
+#endif /* !_FLUX_RESOURCE_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/resource/rutil.c
+++ b/src/modules/resource/rutil.c
@@ -1,0 +1,230 @@
+/************************************************************\
+ * Copyright 2020 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* rutil.c - random standalone helper functions */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <jansson.h>
+#include <flux/core.h>
+
+#include "src/common/libidset/idset.h"
+#include "src/common/libutil/errno_safe.h"
+
+#include "rutil.h"
+
+int rutil_idset_sub (struct idset *ids1, const struct idset *ids2)
+{
+    if (!ids1) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (ids2) {
+        unsigned int id;
+        id = idset_first (ids2);
+        while (id != IDSET_INVALID_ID) {
+            if (idset_clear (ids1, id) < 0)
+                return -1;
+            id = idset_next (ids2, id);
+        }
+    }
+    return 0;
+}
+
+int rutil_idset_add (struct idset *ids1, const struct idset *ids2)
+{
+    if (!ids1) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (ids2) {
+        unsigned int id;
+        id = idset_first (ids2);
+        while (id != IDSET_INVALID_ID) {
+            if (idset_set (ids1, id) < 0)
+                return -1;
+            id = idset_next (ids2, id);
+        }
+    }
+    return 0;
+}
+
+int rutil_idset_diff (const struct idset *ids1,
+                      const struct idset *ids2,
+                      struct idset **addp,
+                      struct idset **subp)
+{
+    struct idset *add = NULL;
+    struct idset *sub = NULL;
+    unsigned int id;
+
+    if (!addp || !subp) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (ids1) { // find ids in ids1 but not in ids2, and add to 'sub'
+        id = idset_first (ids1);
+        while (id != IDSET_INVALID_ID) {
+            if (!ids2 || !idset_test (ids2, id)) {
+                if (!sub && !(sub = idset_create (0, IDSET_FLAG_AUTOGROW)))
+                    goto error;
+                if (idset_set (sub, id) < 0)
+                    goto error;
+            }
+            id = idset_next (ids1, id);
+        }
+    }
+    if (ids2) { // find ids in ids2 but not in ids1, and add to 'add'
+        id = idset_first (ids2);
+        while (id != IDSET_INVALID_ID) {
+            if (!ids1 || !idset_test (ids1, id)) {
+                if (!add && !(add = idset_create (0, IDSET_FLAG_AUTOGROW)))
+                    goto error;
+                if (idset_set (add, id) < 0)
+                    goto error;
+            }
+            id = idset_next (ids2, id);
+        }
+    }
+    *addp = add;
+    *subp = sub;
+    return 0;
+error:
+    idset_destroy (add);
+    idset_destroy (sub);
+    return -1;
+}
+
+int rutil_set_json_idset (json_t *o, const char *key, const struct idset *ids)
+{
+    json_t *val = NULL;
+    char *s = NULL;
+
+    if (o == NULL || key == NULL || strlen (key) == 0) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (ids && !(s = idset_encode (ids, IDSET_FLAG_RANGE)))
+        return -1;
+    if (!(val = json_string (s ? s : "")))
+        goto nomem;
+    if (json_object_set_new (o, key, val) < 0)
+        goto nomem;
+    free (s);
+    return 0;
+nomem:
+    errno = ENOMEM;
+    ERRNO_SAFE_WRAP (free, s);
+    ERRNO_SAFE_WRAP (json_decref, val);
+    return -1;
+}
+
+struct idset *rutil_idset_from_resobj (const json_t *resobj)
+{
+    struct idset *ids;
+    const char *key;
+    json_t *val;
+
+    if (!(ids = idset_create (0, IDSET_FLAG_AUTOGROW)))
+        return NULL;
+    if (resobj) {
+        json_object_foreach ((json_t *)resobj, key, val) {
+            struct idset *valset;
+            unsigned long id;
+
+            if (!(valset = idset_decode (key)))
+                goto error;
+            id = idset_first (valset);
+            while (id != IDSET_INVALID_ID) {
+                if (idset_set (ids, id) < 0) {
+                    idset_destroy (valset);
+                    goto error;
+                }
+                id = idset_next (valset, id);
+            }
+            idset_destroy (valset);
+        }
+    }
+    return ids;
+error:
+    idset_destroy (ids);
+    return NULL;
+}
+
+json_t *rutil_resobj_sub (const json_t *resobj, const struct idset *ids)
+{
+    const char *key;
+    json_t *val;
+    json_t *resobj2;
+
+    if (!resobj) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (!(resobj2 = json_object ())) {
+        errno = ENOMEM;
+        return NULL;
+    }
+    json_object_foreach ((json_t *)resobj, key, val) {
+        struct idset *valset;
+        char *key2;
+
+        if (!(valset = idset_decode (key)))
+            goto error;
+        if (rutil_idset_sub (valset, ids) < 0)
+            goto error;
+        if (idset_count (valset) > 0) {
+            if (!(key2 = idset_encode (valset, IDSET_FLAG_RANGE))) {
+                idset_destroy (valset);
+                goto error;
+            }
+            if (json_object_set (resobj2, key2, val) < 0) {
+                idset_destroy (valset);
+                ERRNO_SAFE_WRAP (free, key2);
+                goto error;
+            }
+            free (key2);
+        }
+        idset_destroy (valset);
+    }
+    return resobj2;
+error:
+    ERRNO_SAFE_WRAP (json_decref, resobj2);
+    return NULL;
+}
+
+
+bool rutil_match_request_sender (const flux_msg_t *msg1,
+                                 const flux_msg_t *msg2)
+{
+    char *sender1 = NULL;
+    char *sender2 = NULL;
+    bool match = false;
+
+    if (!msg1 || !msg2)
+        goto done;
+    if (flux_msg_get_route_first (msg1, &sender1) < 0)
+        goto done;
+    if (flux_msg_get_route_first (msg2, &sender2) < 0)
+        goto done;
+    if (!sender1 || !sender2)
+        goto done;
+    if (!strcmp (sender1, sender2))
+        match = true;
+done:
+    free (sender1);
+    free (sender2);
+    return match;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/resource/rutil.h
+++ b/src/modules/resource/rutil.h
@@ -1,0 +1,57 @@
+/************************************************************\
+ * Copyright 2020 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _FLUX_RESOURCE_RUTIL_H
+#define _FLUX_RESOURCE_RUTIL_H
+
+/* Clear/set all the ids from 'ids2' in 'ids1'.
+ * If ids2 == NULL, do nothing.
+ * Return 0 on success, -1 on failure with errno set.
+ */
+int rutil_idset_sub (struct idset *ids1, const struct idset *ids2);
+int rutil_idset_add (struct idset *ids1, const struct idset *ids2);
+
+/* Compare 'old_set' to 'new_set'.
+ * Create '*add' for ids in new_set but not in old_set (sets NULL if n/a).
+ * Create '*sub' for ids in old_set but not in new_set (sets NULL if n/a).
+ */
+int rutil_idset_diff (const struct idset *old_set,
+                      const struct idset *new_set,
+                      struct idset **add,
+                      struct idset **sub);
+
+/* Compute an idset that combines all the valid ranks in a resource object.
+ */
+struct idset *rutil_idset_from_resobj (const json_t *resobj);
+
+/* Clear any ranks from resource object keys that are present in 'ids'.
+ */
+json_t *rutil_resobj_sub (const json_t *resobj, const struct idset *ids);
+
+/* Set key=val in a json object, where val is the string
+ * representation of 'ids', or the empty string if 'ids' is NULL.
+ */
+int rutil_set_json_idset (json_t *o,
+                          const char *key,
+                          const struct idset *ids);
+
+/* Return true if requests have the same sender.
+ * Messages can be NULL or have no sender (returns false).
+ */
+bool rutil_match_request_sender (const flux_msg_t *msg1,
+                                 const flux_msg_t *msg2);
+
+
+#endif /* !_FLUX_RESOURCE_RUTIL_H */
+
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/resource/test/rutil.c
+++ b/src/modules/resource/test/rutil.c
@@ -1,0 +1,366 @@
+/************************************************************\
+ * Copyright 2020 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <jansson.h>
+#include <flux/core.h>
+
+#include "src/common/libtap/tap.h"
+#include "src/common/libidset/idset.h"
+
+#include "src/modules/resource/rutil.h"
+
+const char *by_rank = \
+"{"\
+"\"0-3\": {\"Package\": 1, \"Core\": 2, \"PU\": 2, \"cpuset\": \"0-1\"}," \
+"\"4-31\": {\"Package\": 2, \"Core\": 4, \"PU\": 4, \"cpuset\": \"0-3\"}" \
+"}";
+
+void test_match_request_sender (void)
+{
+    flux_msg_t *msg1, *msg2;
+
+    if (!(msg1 = flux_request_encode ("fubar.baz", NULL)))
+        BAIL_OUT ("flux_request_encode failed");
+    if (!(msg2 = flux_request_encode ("fubaz.bar", NULL)))
+        BAIL_OUT ("flux_request_encode failed");
+
+    ok (rutil_match_request_sender (msg1, NULL) == false,
+        "rutil_match_request_sender msg2=NULL = false");
+    ok (rutil_match_request_sender (NULL, msg2) == false,
+        "rutil_match_request_sender msg1=NULL = false");
+
+    ok (rutil_match_request_sender (msg1, msg2) == false,
+        "rutil_match_request_sender msg1=(no sender) = false");
+
+    if (flux_msg_push_route (msg1, "foo") < 0)
+        BAIL_OUT ("flux_msg_push_route failed");
+
+    ok (rutil_match_request_sender (msg1, msg2) == false,
+        "rutil_match_request_sender msg2=(no sender) = false");
+
+    if (flux_msg_push_route (msg2, "bar") < 0)
+        BAIL_OUT ("flux_msg_push_route failed");
+
+    ok (rutil_match_request_sender (msg1, msg2) == false,
+        "rutil_match_request_sender different senders = false");
+
+    char *id;
+    if (flux_msg_pop_route (msg2, &id) < 0)
+        BAIL_OUT ("flux_msg_clear_route failed");
+    free (id);
+    if (flux_msg_push_route (msg2, "foo") < 0)
+        BAIL_OUT ("flux_msg_push_route failed");
+
+    ok (rutil_match_request_sender (msg1, msg2) == true,
+        "rutil_match_request_sender same senders = true");
+
+    flux_msg_decref (msg1);
+    flux_msg_decref (msg2);
+}
+
+void test_idset_sub (void)
+{
+    struct idset *ids1;
+    struct idset *ids2;
+
+    if (!(ids1 = idset_create (1024, 0)))
+        BAIL_OUT ("idset_create failed");
+    if (!(ids2 = idset_create (1024, 0)))
+        BAIL_OUT ("idset_create failed");
+
+    errno = 0;
+    ok (rutil_idset_sub (NULL, ids2) < 0 && errno == EINVAL,
+        "rutil_idset_sub ids1=NULL fails with EINVAL");
+
+    ok (rutil_idset_sub (ids1, NULL) == 0 && idset_count (ids1) == 0,
+        "rutil_idset_sub ids2=NULL has no effect");
+
+    if (idset_set (ids1, 2) < 0)
+        BAIL_OUT ("idset_set failed");
+    if (idset_set (ids2, 42) < 0)
+        BAIL_OUT ("idset_set failed");
+
+    ok (rutil_idset_sub (ids1, ids2) == 0 && idset_count (ids1) == 1,
+        "rutil_idset_sub non-overlapping idsets has no effect");
+
+    if (idset_set (ids1, 42) < 0)
+        BAIL_OUT ("idset_set failed");
+    if (idset_set (ids2, 2) < 0)
+        BAIL_OUT ("idset_set failed");
+
+    ok (rutil_idset_sub (ids1, ids2) == 0 && idset_count (ids1) == 0,
+        "rutil_idset_sub with overlap works");
+
+    idset_destroy (ids1);
+    idset_destroy (ids2);
+}
+
+void test_idset_add (void)
+{
+    struct idset *ids1;
+    struct idset *ids2;
+
+    if (!(ids1 = idset_create (1024, 0)))
+        BAIL_OUT ("idset_create failed");
+    if (!(ids2 = idset_create (1024, 0)))
+        BAIL_OUT ("idset_create failed");
+
+    errno = 0;
+    ok (rutil_idset_add (NULL, ids2) < 0 && errno == EINVAL,
+        "rutil_idset_add ids1=NULL fails with EINVAL");
+
+    ok (rutil_idset_add (ids1, NULL) == 0 && idset_count (ids1) == 0,
+        "rutil_idset_add ids2=NULL has no effect");
+
+    if (idset_set (ids1, 2) < 0)
+        BAIL_OUT ("idset_set failed");
+    if (idset_set (ids2, 42) < 0)
+        BAIL_OUT ("idset_set failed");
+
+    ok (rutil_idset_add (ids1, ids2) == 0 && idset_count (ids1) == 2,
+        "rutil_idset_add of non-overlapping idset works");
+    ok (rutil_idset_add (ids1, ids2) == 0 && idset_count (ids1) == 2,
+        "rutil_idset_add of overlapping idset has no effect");
+
+    idset_destroy (ids1);
+    idset_destroy (ids2);
+}
+
+void test_idset_diff (void)
+{
+    struct idset *ids1;
+    struct idset *ids2;
+    struct idset *add;
+    struct idset *sub;
+
+    if (!(ids1 = idset_create (1024, 0)))
+        BAIL_OUT ("idset_create failed");
+    if (!(ids2 = idset_create (1024, 0)))
+        BAIL_OUT ("idset_create failed");
+
+    ok (rutil_idset_diff (NULL, ids2, &add, &sub) == 0
+        && add == NULL
+        && sub == NULL,
+        "rutil_idset_diff ids1=NULL works");
+    idset_destroy (add);
+    idset_destroy (sub);
+
+    ok (rutil_idset_diff (ids1, NULL, &add, &sub) == 0
+        && add == NULL
+        && sub == NULL,
+        "rutil_idset_diff ids2=NULL works");
+    idset_destroy (add);
+    idset_destroy (sub);
+
+    errno = 0;
+    ok (rutil_idset_diff (ids1, ids2, NULL, &sub) < 0 && errno == EINVAL,
+        "rutil_idset_diff add=NULL fails with EINVAL");
+    errno = 0;
+    ok (rutil_idset_diff (ids1, ids2, &add, NULL) < 0 && errno == EINVAL,
+        "rutil_idset_diff sub=NULL fails with EINVAL");
+
+    if (idset_set (ids1, 1) < 0 || idset_set (ids2, 2) < 0)
+        BAIL_OUT ("idset_set failed");
+    add = sub = NULL;
+    ok (rutil_idset_diff (ids1, ids2, &add, &sub) == 0
+        && add != NULL && idset_count (add) == 1 && idset_test (add, 2)
+        && sub != NULL && idset_count (sub) == 1 && idset_test (sub, 1),
+        "rutil_idset_diff [1] [2] sets add=[2] sub=[1]");
+    idset_destroy (add);
+    idset_destroy (sub);
+
+    add = sub = NULL;
+    ok (rutil_idset_diff (ids2, ids1, &add, &sub) == 0
+        && add != NULL && idset_count (add) == 1 && idset_test (add, 1)
+        && sub != NULL && idset_count (sub) == 1 && idset_test (sub, 2),
+        "rutil_idset_diff [2] [1] sets add=[1] sub=[2]");
+    idset_destroy (add);
+    idset_destroy (sub);
+
+    if (idset_set (ids1, 2) < 0)
+        BAIL_OUT ("idset_set failed");
+    add = sub = NULL;
+    ok (rutil_idset_diff (ids1, ids2, &add, &sub) == 0
+        && add == NULL
+        && sub != NULL && idset_count (sub) == 1 && idset_test (sub, 1),
+        "rutil_idset_diff [1-2] [2] sets add=NULL sub=[1]");
+    idset_destroy (add);
+    idset_destroy (sub);
+
+    add = sub = NULL;
+    ok (rutil_idset_diff (ids2, ids1, &add, &sub) == 0
+        && add != NULL && idset_count (add) == 1 && idset_test (add, 1)
+        && sub == NULL,
+        "rutil_idset_diff [2] [1-2] sets add=[1] sub=NULL");
+    idset_destroy (add);
+    idset_destroy (sub);
+
+    if (idset_set (ids2, 1) < 0)
+        BAIL_OUT ("idset_set failed");
+    add = sub = NULL;
+    ok (rutil_idset_diff (ids1, ids2, &add, &sub) == 0
+        && add == NULL
+        && sub == NULL,
+        "rutil_idset_diff [1-2] [1-2] sets add=NULL sub=NULL");
+    idset_destroy (add);
+    idset_destroy (sub);
+
+    idset_destroy (ids1);
+    idset_destroy (ids2);
+}
+
+void test_set_json_idset (void)
+{
+    json_t *o;
+    json_t *o2;
+    const char *s;
+    struct idset *ids;
+
+    if (!(ids= idset_create (1024, 0)))
+        BAIL_OUT ("idset_create failed");
+    if (idset_set (ids, 42) < 0)
+        BAIL_OUT ("idset_set failed");
+
+    if (!(o = json_object ()))
+        BAIL_OUT ("json_object failed");
+
+    errno = 0;
+    ok (rutil_set_json_idset (NULL, "foo", NULL) < 0 && errno == EINVAL,
+        "rutil_set_json_idset obj=NULL fails with EINVAL");
+    errno = 0;
+    ok (rutil_set_json_idset (o, NULL, NULL) < 0 && errno == EINVAL,
+        "rutil_set_json_idset key=NULL fails with EINVAL");
+    errno = 0;
+    ok (rutil_set_json_idset (o, "", NULL) < 0 && errno == EINVAL,
+        "rutil_set_json_idset key=(empty) fails with EINVAL");
+
+    ok (rutil_set_json_idset (o, "foo", NULL) == 0
+            && (o2 = json_object_get (o, "foo"))
+            && (s = json_string_value (o2))
+            && !strcmp (s, ""),
+        "rutil_set_json_idset ids=NULL sets empty string value");
+    ok (rutil_set_json_idset (o, "bar", ids) == 0
+            && (o2 = json_object_get (o, "bar"))
+            && (s = json_string_value (o2))
+            && !strcmp (s, "42"),
+        "rutil_set_json_idset ids=[42] sets encoded value");
+
+    json_decref (o);
+    idset_destroy (ids);
+}
+
+void test_idset_from_resobj (void)
+{
+    json_t *resobj;
+    struct idset *ids;
+
+    if (!(resobj = json_loads (by_rank, 0, NULL)))
+        BAIL_OUT ("json_loads failed");
+
+    ids = rutil_idset_from_resobj (NULL);
+    ok (ids != NULL && idset_count (ids) == 0,
+        "rutil_idset_from_resobj NULL returns empty idset");
+    idset_destroy (ids);
+
+    ids = rutil_idset_from_resobj (resobj);
+    ok (ids != NULL && idset_count (ids) == 32,
+        "rutil_idset_from_resobj works");
+    idset_destroy (ids);
+
+    json_decref (resobj);
+}
+
+void test_resobj_sub (void)
+{
+    json_t *resobj1;
+    json_t *resobj2;
+    struct idset *ids1;
+    struct idset *ids2;
+    struct idset *ids;
+
+    if (!(resobj1 = json_loads (by_rank, 0, NULL)))
+        BAIL_OUT ("json_loads failed");
+    if (!(ids1 = rutil_idset_from_resobj (resobj1)))
+        BAIL_OUT ("rutil_idset_from_resobj failed");
+
+    if (!(ids = idset_create (1024, 0)))
+        BAIL_OUT ("idset_create failed");
+    if (idset_range_set (ids, 2, 5) < 0)
+        BAIL_OUT ("idset_range_set failed");
+
+    errno = 0;
+    ok (rutil_resobj_sub (NULL, NULL) == NULL && errno == EINVAL,
+        "rutil_resobj_sub resobj=NULL fails with EINVAL");
+
+    resobj2 = rutil_resobj_sub (resobj1, NULL);
+    ok (resobj2 != NULL && json_equal (resobj1, resobj2) == 1,
+        "rutil_resobj_sub ids=NULL returns unchanged resobj");
+    if (!(ids2 = rutil_idset_from_resobj (resobj2)))
+        BAIL_OUT ("rutil_idset_from_resobj failed");
+    ok (idset_equal (ids1, ids2) == true,
+        "new and old resobj have identical idset");
+    idset_destroy (ids2);
+    json_decref (resobj2);
+
+    resobj2 = rutil_resobj_sub (resobj1, ids);
+    ok (resobj2 != NULL && json_equal (resobj1, resobj2) == 0,
+        "rutil_resobj_sub ids=[2-5] returns different resobj");
+    if (!(ids2 = rutil_idset_from_resobj (resobj2)))
+        BAIL_OUT ("rutil_idset_from_resobj failed");
+    ok (idset_count (ids1) - idset_count (ids2) == 4,
+        "new and old resobj idset differ by 4 ids");
+    idset_destroy (ids2);
+    json_decref (resobj2);
+
+    /* Kill one whole key in the resobj */
+    if (idset_range_set (ids, 0, 3) < 0)
+        BAIL_OUT ("idset_range_set failed");
+    resobj2 = rutil_resobj_sub (resobj1, ids);
+    ok (resobj2 != NULL && json_object_size (resobj2) == 1,
+        "rutil_resobj_sub ids=[0-5] returns resobj with 1 key");
+    json_decref (resobj2);
+
+    /* Kill entire resobj */
+    if (idset_range_set (ids, 0, 31) < 0)
+        BAIL_OUT ("idset_range_set failed");
+    resobj2 = rutil_resobj_sub (resobj1, ids);
+    ok (resobj2 != NULL && json_object_size (resobj2) == 0,
+        "rutil_resobj_sub ids=[0-31] returns resobj with no keys");
+    json_decref (resobj2);
+
+    idset_destroy (ids);
+    idset_destroy (ids1);
+    json_decref (resobj1);
+}
+
+
+int main (int argc, char *argv[])
+{
+    plan (NO_PLAN);
+
+    test_match_request_sender ();
+    test_idset_sub ();
+    test_idset_add ();
+    test_idset_diff ();
+    test_set_json_idset ();
+    test_idset_from_resobj ();
+    test_resobj_sub ();
+
+    done_testing ();
+    return (0);
+}
+
+
+/*
+ * vi:ts=4 sw=4 expandtab
+ */

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -247,6 +247,7 @@ check_PROGRAMS = \
 	kvs/checkpoint \
 	request/treq \
 	request/rpc \
+	request/rpc_stream \
 	barrier/tbarrier \
 	reactor/reactorcat \
 	rexec/rexec \
@@ -421,6 +422,11 @@ request_treq_LDADD = \
 request_rpc_SOURCES = request/rpc.c
 request_rpc_CPPFLAGS = $(test_cppflags)
 request_rpc_LDADD = \
+	$(test_ldadd) $(LIBDL) $(LIBUTIL)
+
+request_rpc_stream_SOURCES = request/rpc_stream.c
+request_rpc_stream_CPPFLAGS = $(test_cppflags)
+request_rpc_stream_LDADD = \
 	$(test_ldadd) $(LIBDL) $(LIBUTIL)
 
 module_parent_la_SOURCES = module/parent.c

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -109,6 +109,7 @@ TESTSCRIPTS = \
 	t2220-job-archive.t \
 	t2300-sched-simple.t \
 	t2301-schedutil-outstanding-requests.t \
+	t2310-resource-module.t \
 	t2400-job-exec-test.t \
 	t2401-job-exec-hello.t \
 	t2402-job-exec-dummy.t \

--- a/t/rc/rc1-job
+++ b/t/rc/rc1-job
@@ -7,6 +7,8 @@ set_fake_hwloc_by_rank() {
     by_rank="{\"${ranklist}\":{\"Core\":${cores},\"cpuset\":\"${corelist}\"}}"
     echo Setting fake by_rank="${by_rank}" >&2
     flux kvs put resource.hwloc.by_rank="${by_rank}"
+    flux kvs eventlog append resource.eventlog \
+        hwloc-discover-finish "{\"loaded\":true}"
 }
 
 flux module load content-sqlite
@@ -22,11 +24,8 @@ flux exec -r all flux module load job-info & pids="$pids $!"
 flux exec -r all flux module load barrier & pids="$pids $!"
 
 # Load a fake resource.hwloc.by_rank key for sched-simple
-# (avoids requirement to run "flux hwloc reload")
-#
-(set_fake_hwloc_by_rank ${TEST_UNDER_FLUX_CORES_PER_RANK:-2}) & pids="$pids $1"
-
-wait $pids
+set_fake_hwloc_by_rank ${TEST_UNDER_FLUX_CORES_PER_RANK:-2}
+flux module load resource
 
 flux module load job-exec
 

--- a/t/rc/rc3-job
+++ b/t/rc/rc3-job
@@ -6,6 +6,7 @@ flux queue idle
 
 flux module remove -f job-exec
 flux module remove -f sched-simple
+flux module remove -f resource
 flux module remove job-manager
 flux exec -r all flux module remove barrier
 flux exec -r all flux module remove job-info

--- a/t/request/rpc.c
+++ b/t/request/rpc.c
@@ -54,7 +54,7 @@ int main (int argc, char *argv[])
                               topic, errno, expected_errno);
         }
         else
-            log_err_exit ("%s", topic);
+            log_msg_exit ("%s: %s", topic, future_strerror (f, errno));
     }
     else {
         if (expected_errno > 0)

--- a/t/request/rpc_stream.c
+++ b/t/request/rpc_stream.c
@@ -1,0 +1,75 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <unistd.h>
+#include <jansson.h>
+#include <stdio.h>
+#include <flux/core.h>
+
+#include "src/common/libutil/read_all.h"
+#include "src/common/libutil/log.h"
+
+int main (int argc, char *argv[])
+{
+    flux_t *h;
+    flux_future_t *f;
+    const char *topic;
+    ssize_t inlen;
+    void *inbuf;
+    const char *out;
+    const char *end_key = NULL;
+
+    if (!(h = flux_open (NULL, 0)))
+        log_err_exit ("flux_open");
+
+    if (argc != 2 && argc != 3) {
+        fprintf (stderr, "Usage: rpc_stream topic [end-key] <payload\n");
+        exit (1);
+    }
+    topic = argv[1];
+    if (argc == 3)
+        end_key = argv[2];
+
+    if ((inlen = read_all (STDIN_FILENO, &inbuf)) < 0)
+        log_err_exit ("read from stdin");
+    if (inlen > 0)  // flux stringified JSON payloads are sent with \0-term
+        inlen++;    //  and read_all() ensures inbuf has one, not acct in inlen
+
+    if (!(f = flux_rpc_raw (h, topic, inbuf, inlen, FLUX_NODEID_ANY, FLUX_RPC_STREAMING)))
+        log_err_exit ("flux_rpc_raw %s", topic);
+    bool done = false;
+    do {
+        if (flux_rpc_get (f, &out) < 0)
+            log_msg_exit ("%s: %s", topic, future_strerror (f, errno));
+        printf ("%s\n", out);
+        fflush (stdout);
+        if (end_key) {
+            json_t *o = json_loads (out, 0, NULL);
+            if (!o)
+                log_msg_exit ("failed to parse response payload");
+            if (json_object_get (o, end_key))
+                done = true;
+            json_decref (o);
+        }
+        if (!done)
+            flux_future_reset (f);
+    } while (!done);
+    flux_future_destroy (f);
+    free (inbuf);
+    flux_close (h);
+    return (0);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/t/t2310-resource-module.t
+++ b/t/t2310-resource-module.t
@@ -1,0 +1,262 @@
+#!/bin/sh
+
+test_description='Test resource module'
+
+. `dirname $0`/sharness.sh
+
+# Start out with empty config object
+# Then we will reload after adding TOML to cwd
+export FLUX_CONF_DIR=$(pwd)
+
+# min SIZE=4
+SIZE=$(test_size_large)
+test_under_flux $SIZE kvs
+
+RESNAME=resource
+RPC=${FLUX_BUILD_DIR}/t/request/rpc
+RPC_STREAM=${FLUX_BUILD_DIR}/t/request/rpc_stream
+WAITFILE="${SHARNESS_TEST_SRCDIR}/scripts/waitfile.lua"
+
+# Usage: grep_event event-name <in >out
+grep_event () {
+	jq -c ". | select(.name == \"$1\") | .context"
+}
+has_event() {
+	flux kvs eventlog get resource.eventlog | awk '{ print $2 }' | grep $1
+}
+# Usage: wait_event tries name
+wait_event() {
+	count=$1
+	name=$2
+	while test $count -gt 0 && ! has_event $name; do
+		sleep 1
+		count=$(($count-1))
+	done
+}
+# Usage: drain_idset idset reason
+drain_idset() {
+	local idset=$1; shift
+	local reason="$@"
+	jq -j -c -n  "{idset:\"$idset\",reason:\"$reason\"}" \
+		| $RPC $RESNAME.drain
+}
+# Usage: drain_idset_noreason idset
+drain_idset_noreason() {
+	local idset=$1
+	jq -j -c -n  "{idset:\"$idset\"}" | $RPC $RESNAME.drain
+}
+# Usage: undrain_idset idset
+undrain_idset() {
+	local idset=$1
+	jq -j -c -n  "{idset:\"$idset\"}" | $RPC $RESNAME.undrain
+}
+# Usage: acquire_stream timeout outfile [end-event]
+acquire_stream() {
+	run_timeout $1 $RPC_STREAM $RESNAME.acquire $3 </dev/null >$2
+}
+
+
+test_expect_success 'load aggregator module needed for flux hwloc reload' '
+	flux exec -r all flux module load aggregator
+'
+
+test_expect_success 'load resource module' '
+	flux module load $RESNAME
+'
+
+test_expect_success HAVE_JQ 'resource.eventlog exists' '
+	flux kvs eventlog get -u resource.eventlog >eventlog.out
+'
+
+test_expect_success HAVE_JQ 'resource-init context says restart=false' '
+	test "$(grep_event resource-init <eventlog.out|jq .restart)" = "false"
+'
+
+test_expect_success 'reconfigure with rank 0 exclusion' '
+	cat >resource.toml <<-EOT &&
+	[$RESNAME]
+	exclude = "0"
+	EOT
+	flux config reload
+'
+
+test_expect_success HAVE_JQ 'exclude event was posted with expected idset' '
+	flux kvs eventlog get -u resource.eventlog \
+		| grep_event exclude >exclude.out &&
+	test "$(jq .idset <exclude.out)" = "\"0\""
+'
+
+test_expect_success 'wait until hwloc-discover-finish event is posted' '
+	wait_event 5 hwloc-discover-finish
+'
+
+test_expect_success 'resource.hwloc is populated after hwloc-discover-finish' '
+	flux kvs get resource.hwloc.by_rank >/dev/null &&
+	seq 0 $(($SIZE-1)) | sort >hwloc_xml.exp &&
+	flux kvs ls -1 resource.hwloc.xml >hwloc_xml.out &&
+	test_cmp hwloc_xml.exp hwloc_xml.out
+'
+
+test_expect_success HAVE_JQ 'drain works with no reason' '
+	drain_idset_noreason 1 &&
+	flux kvs eventlog get -u resource.eventlog \
+		| grep_event drain | tail -1 >drain.out &&
+	test $(jq .idset drain.out) = "\"1\""
+'
+
+test_expect_success HAVE_JQ 'drain works to update reason' '
+	drain_idset 1 reason_01 &&
+	flux kvs eventlog get -u resource.eventlog \
+		| grep_event drain | tail -1 >drain2.out &&
+	test $(jq .reason drain2.out) = "\"reason_01\""
+'
+
+test_expect_success HAVE_JQ 'undrain works' '
+	undrain_idset 1 &&
+	flux kvs eventlog get -u resource.eventlog \
+		| grep_event undrain | tail -1 >undrain.out &&
+	test $(jq .idset undrain.out) = "\"1\""
+'
+
+test_expect_success HAVE_JQ 'undrain fails if rank not drained' '
+	test_must_fail undrain_idset 1 2>undrain_not.err &&
+	grep "rank 1 not drained" undrain_not.err
+'
+
+test_expect_success HAVE_JQ 'drain fails if idset is malformed' '
+	test_must_fail drain_idset_noreason xxzz 2>drain_badset.err &&
+	grep "failed to decode idset" drain_badset.err
+'
+
+test_expect_success HAVE_JQ 'drain fails if idset is empty' '
+	test_must_fail drain_idset_noreason "" 2>drain_empty.err &&
+	grep "idset is empty" drain_empty.err
+'
+
+test_expect_success HAVE_JQ 'drain fails if idset is out of range' '
+	test_must_fail drain_idset_noreason "0-$SIZE" 2>drain_range.err &&
+	grep "idset is out of range" drain_range.err
+'
+
+test_expect_success 'reload resource module and re-capture eventlog' '
+	flux module remove $RESNAME &&
+	flux kvs eventlog get -u resource.eventlog >pre_restart.out &&
+	flux module load $RESNAME &&
+	flux kvs eventlog get -u resource.eventlog >restart.out &&
+	pre=$(wc -l <pre_restart.out) &&
+	post=$(wc -l <restart.out) &&
+	tail -$(($post-$pre)) restart.out > post_restart.out
+'
+
+test_expect_success HAVE_JQ 'new resource-init context says restart=true' '
+	test "$(grep_event resource-init <post_restart.out \
+		|jq .restart)" = "true"
+'
+
+test_expect_success 'reconfig with extra key fails' '
+	cat >resource.toml <<-EOT &&
+	[$RESNAME]
+	foo = 42
+	EOT
+	test_must_fail flux config reload
+'
+
+test_expect_success 'reconfig with bad exclude idset fails' '
+	cat >resource.toml <<-EOT &&
+	[$RESNAME]
+	exclude = "xxzz"
+	EOT
+	test_must_fail flux config reload
+'
+
+test_expect_success 'reconfig with out of range exclude idset fails' '
+	cat >resource.toml <<-EOT &&
+	[$RESNAME]
+	exclude = "0-$SIZE"
+	EOT
+	test_must_fail flux config reload
+'
+
+test_expect_success HAVE_JQ 'reconfig with no exclude idset generates event' '
+	cat >resource.toml <<-EOT &&
+	[$RESNAME]
+	EOT
+	flux config reload &&
+	flux kvs eventlog get -u resource.eventlog >reconfig.out &&
+	test "$(grep_event unexclude <reconfig.out | jq .idset)" = "\"0\""
+'
+
+test_expect_success HAVE_JQ 'acquire works and response contains up, resources' '
+	$RPC $RESNAME.acquire </dev/null >acquire.out &&
+	jq -c -e -a .resources acquire.out &&
+	jq -c -e -a .up acquire.out
+'
+
+test_expect_success 'acquire works again after first acquire disconnected' '
+	$RPC $RESNAME.acquire </dev/null
+'
+
+test_expect_success 'reload config/module excluding rank 0' '
+	cat >resource.toml <<-EOT &&
+	[$RESNAME]
+	exclude = "0"
+	EOT
+	flux config reload &&
+	flux module reload $RESNAME
+'
+
+test_expect_success HAVE_JQ 'acquire returns resources excluding rank 0' '
+	$RPC $RESNAME.acquire </dev/null >acquire2.out &&
+	jq -c -e -a .resources.\"1-$(($SIZE-1))\" acquire2.out
+'
+
+test_expect_success HAVE_JQ 'acquire returns up excluding rank 0' '
+	jq -c -e -a .up acquire2.out >acquire2_up.out &&
+	grep "^\"1-$(($SIZE-1))" acquire2_up.out
+'
+
+test_expect_success HAVE_JQ,NO_CHAIN_LINT 'drain rank 1 causes down response' '
+	acquire_stream 30 acquire3.out down &
+	pid=$! &&
+	$WAITFILE -t 10 -v -p \"resources\" acquire3.out &&
+	drain_idset_noreason "1" &&
+	wait $pid
+'
+
+test_expect_success HAVE_JQ,NO_CHAIN_LINT 'undrain/drain rank 1 causes up,down responses' '
+	acquire_stream 30 acquire4.out down &
+	pid=$! &&
+	$WAITFILE -t 10 -v -p \"resources\" acquire4.out &&
+	undrain_idset "1" &&
+	$WAITFILE -t 10 -v -p \"up\" -c 2 acquire4.out &&
+	drain_idset "1" &&
+	wait $pid
+'
+
+test_expect_success HAVE_JQ,NO_CHAIN_LINT 'add/remove new exclusion causes down/up response' '
+	acquire_stream 30 acquire5.out &
+	pid=$! &&
+	$WAITFILE -t 10 -v -p \"resources\" acquire5.out &&
+	cat >resource.toml <<-EOT &&
+	[$RESNAME]
+	exclude = "0,3"
+	EOT
+	flux config reload &&
+	$WAITFILE -t 10 -v -p \"down\" acquire5.out &&
+	cat >resource.toml <<-EOT &&
+	[$RESNAME]
+	exclude = "0"
+	EOT
+	flux config reload &&
+	$WAITFILE -t 10 -v -p \"up\" -c 2 acquire5.out &&
+	kill -15 $pid && wait $pid || true
+'
+
+test_expect_success 'unload resource module' '
+	flux module remove $RESNAME
+'
+test_expect_success 'unload aggregator module' '
+	flux exec -r all flux module remove aggregator
+'
+
+test_done


### PR DESCRIPTION
This is a bare bones starting point for a resource module as discussed in #2908.

It just tries to look up `resource.hwloc.by_rank`.  If that succeeds, do nothing.  If that fails, wait for all brokers to come online according to `hello.idset`, then run `flux hwloc reload` as a subprocess.  Since the schedulers both look up `resource.hwloc` keys using FLUX_KVS_WAITCREATE before they say HELLO to the job manager, they just work as before.

This allows `flux hwloc reload` to be taken out of rc1 so that rc1 on rank 0 can start up before the other brokers are online in a future PR.

I named the module `resource` but temporarily register its name internally with `MOD_NAME ("xresource")`, until flux-framework/flux-sched#485 is addressed.

I'm not sure if this is worthy of being merged on its own, but I can at least rebase the rc startup changes on this to make progress.