### PR TITLE
docker: start munge in published docker images

### DIFF
--- a/src/test/docker/docker-run-checks.sh
+++ b/src/test/docker/docker-run-checks.sh
@@ -165,7 +165,8 @@ if test -n "$TAG"; then
                userdel $USER" \
 	|| (docker rm tmp.$$; die "docker run of 'make install' failed")
     docker commit \
-	--change 'CMD "/usr/bin/flux"' \
+	--change 'ENTRYPOINT [ "/usr/local/sbin/entrypoint.sh" ]' \
+	--change 'CMD [ "/usr/bin/flux",  "start", "/bin/bash" ]' \
 	--change 'USER flux' \
 	--change 'WORKDIR /home/flux' \
 	tmp.$$ $TAG \

--- a/src/test/docker/travis/Dockerfile
+++ b/src/test/docker/travis/Dockerfile
@@ -64,6 +64,7 @@ RUN mkdir -p /var/run/munge \
  && chown -R munge /etc/munge/munge.key /var/run/munge \
  && chmod 600 /etc/munge/munge.key
 
+COPY entrypoint.sh /usr/local/sbin/
 
 ENV BASE_IMAGE=$BASE_IMAGE
 USER $USER

--- a/src/test/docker/travis/entrypoint.sh
+++ b/src/test/docker/travis/entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+sudo runuser -u munge /usr/sbin/munged
+exec "$@"


### PR DESCRIPTION
This PR adds an `ENTRYPOINT` to the flux-core docker images published from travis-ci which starts munged and runs its arguments by default, simply:
```sh
#!/bin/sh
sudo runuser -u munge /usr/sbin/munged
exec "$@"
```
`CMD`is set to `flux start /bin/bash` by default, and since `CMD` is passed to `ENTRYPOINT`, the docker image now runs `/usr/bin/flux start /bin/bash` when run with no arguments. If you pass args on the cmdline, this overrides `CMD`, so this also works:

```
$ docker run -ti fluxrm/flux-core flux start -s 4 bash
flux@01b99e4e0e24:~$ flux getattr size
4
flux@01b99e4e0e24:~$ flux mini run -N4 -n4 hostname
01b99e4e0e24
01b99e4e0e24
01b99e4e0e24
01b99e4e0e24
```

or, simply

```
$ docker run -ti fluxrm/flux-core bash
flux@01b99e4e0e24:~$ flux getattr size
flux: flux_open: No such file or directory
```