### PR TITLE
README.md: fix required Lua version

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ libuuid-devel     | uuid-dev          |                   |
 lz4-devel         | liblz4-dev        |                   |
 hwloc-devel       | libhwloc-dev      | >= v1.11.1, < 2.0 |
 sqlite-devel      | libsqlite3-dev    | >= 3.0.0          |
-lua               | lua5.1            | >= 5.1, < 5.3     |
-lua-devel         | liblua5.1-dev     | >= 5.1, < 5.3     |
+lua               | lua5.1            | >= 5.1, < 5.4     |
+lua-devel         | liblua5.1-dev     | >= 5.1, < 5.4     |
 lua-posix         | lua-posix         |                   | *1*
 python36-devel    | python3-dev       | >= 3.6            |
 python36-cffi     | python3-cffi      | >= 1.1            |


### PR DESCRIPTION
As caught by @SteVwonder in #2921, the documented required version of Lua doesn't include 5.3. This PR simply adjusts the requirements table to allow 5.3.x.
