### PR TITLE
docker: add default PS1 that includes flux instance size, depth

### DIFF
--- a/src/test/docker/bionic/Dockerfile
+++ b/src/test/docker/bionic/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update \
 # Utilities
 RUN apt-get update \
  && apt-get -qq install -y --no-install-recommends \
+        locales \
         ca-certificates \
         wget \
         man \
@@ -95,6 +96,8 @@ RUN apt-get update \
         aspell \
         aspell-en \
  && rm -rf /var/lib/apt/lists/*
+
+RUN locale-gen en_US.UTF-8
 
 # NOTE: luaposix installed by rocks due to Ubuntu bug: #1752082 https://bugs.launchpad.net/ubuntu/+source/lua-posix/+bug/1752082
 RUN luarocks install luaposix

--- a/src/test/docker/docker-run-checks.sh
+++ b/src/test/docker/docker-run-checks.sh
@@ -161,14 +161,14 @@ if test -n "$TAG"; then
         --user="root" \
 	travis-builder:${IMAGE} \
 	sh -c "make install && \
-               su -c 'flux keygen' flux && \
+               su -c 'flux keygen' fluxuser && \
                userdel $USER" \
 	|| (docker rm tmp.$$; die "docker run of 'make install' failed")
     docker commit \
 	--change 'ENTRYPOINT [ "/usr/local/sbin/entrypoint.sh" ]' \
 	--change 'CMD [ "/usr/bin/flux",  "start", "/bin/bash" ]' \
-	--change 'USER flux' \
-	--change 'WORKDIR /home/flux' \
+	--change 'USER fluxuser' \
+	--change 'WORKDIR /home/fluxuser' \
 	tmp.$$ $TAG \
 	|| die "docker commit failed"
     docker rm tmp.$$

--- a/src/test/docker/travis/Dockerfile
+++ b/src/test/docker/travis/Dockerfile
@@ -65,6 +65,9 @@ RUN mkdir -p /var/run/munge \
  && chmod 600 /etc/munge/munge.key
 
 COPY entrypoint.sh /usr/local/sbin/
+COPY bashrc /tmp
+RUN cat /tmp/bashrc >> ~flux/.bashrc \
+ && rm /tmp/bashrc
 
 ENV LANG=en_US.UTF-8
 ENV BASE_IMAGE=$BASE_IMAGE

--- a/src/test/docker/travis/Dockerfile
+++ b/src/test/docker/travis/Dockerfile
@@ -66,6 +66,7 @@ RUN mkdir -p /var/run/munge \
 
 COPY entrypoint.sh /usr/local/sbin/
 
+ENV LANG=en_US.UTF-8
 ENV BASE_IMAGE=$BASE_IMAGE
 USER $USER
 WORKDIR /home/$USER

--- a/src/test/docker/travis/Dockerfile
+++ b/src/test/docker/travis/Dockerfile
@@ -5,7 +5,7 @@ FROM $IMAGESRC
 # Allow flux-security version, username, UID, and GID to be overidden on
 #  docker build command line:
 #
-ARG USER=flux
+ARG USER=fluxuser
 ARG UID=1000
 ARG GID=1000
 ARG FLUX_SECURITY_VERSION
@@ -35,14 +35,14 @@ RUN set -x && groupadd -g $UID $USER \
 
 # Also add "flux" user to image with sudo access:
 #
-RUN set -x && groupadd flux \
- && useradd -g flux -d /home/flux -m flux \
- && printf "flux ALL= NOPASSWD: ALL\\n" >> /etc/sudoers
+RUN set -x && groupadd fluxuser \
+ && useradd -g fluxuser -d /home/fluxuser -m fluxuser -s /bin/bash \
+ && printf "fluxuser ALL= NOPASSWD: ALL\\n" >> /etc/sudoers
 
 # Make sure user in appropriate group for sudo on different platorms
 RUN case $BASE_IMAGE in \
-     bionic*) adduser $USER sudo && adduser flux sudo ;; \
-     centos*) usermod -G wheel $USER && usermod -G wheel flux ;; \
+     bionic*) adduser $USER sudo && adduser fluxuser sudo ;; \
+     centos*) usermod -G wheel $USER && usermod -G wheel fluxuser ;; \
      *) (>&2 echo "Unknown BASE_IMAGE") ;; \
     esac
 
@@ -66,7 +66,7 @@ RUN mkdir -p /var/run/munge \
 
 COPY entrypoint.sh /usr/local/sbin/
 COPY bashrc /tmp
-RUN cat /tmp/bashrc >> ~flux/.bashrc \
+RUN cat /tmp/bashrc >> ~fluxuser/.bashrc \
  && rm /tmp/bashrc
 
 ENV LANG=en_US.UTF-8

--- a/src/test/docker/travis/bashrc
+++ b/src/test/docker/travis/bashrc
@@ -1,0 +1,4 @@
+if ! echo "$PS1" | grep -q FLUX; then
+  PS1=$'${FLUX_URI+\u0192(s=$(flux getattr size),d=$(flux getattr instance-level)$(which flux|grep -q src/cmd && echo ,builddir))} '${PS1}
+fi
+


### PR DESCRIPTION
Based on a suggestion by @trws and @dongahn, add a default `PS1` to our published docker images that gives a hint to users that they are dropped into a flux instance of size=1.

```console
$ docker run -ti fluxrm/flux-core
ƒ(s=1,d=0) flux@5c453629442b:~$ flux mini run -n4 -o pty flux start
ƒ(s=4,d=1) flux@5c453629442b:~$ flux mini run -n2 -o pty flux start
ƒ(s=2,d=2) flux@5c453629442b:~$ 
```

Also includes `,builddir` if flux is running out of a build directory:

```console
ƒ(s=1,d=0) flux@5b2a9c5ab824:~/flux-core.git$ src/cmd/flux start -s 8
ƒ(s=8,d=0,builddir) flux@5b2a9c5ab824:~/flux-core.git$ 
```


