### PR TITLE
testsuite: add ability to ensure programs are used under appropriate prereqs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,7 @@ jobs:
        - CC=clang-6.0
        - CXX=clang++-6.0
        - chain_lint=t
+       - TEST_CHECK_PREREQS=t
        - ARGS="--with-flux-security"
        - PYTHON_VERSION=3.7
     - name: "Ubuntu: COVERAGE=t, --with-flux-security --enable-caliper"

--- a/src/test/docker/docker-run-checks.sh
+++ b/src/test/docker/docker-run-checks.sh
@@ -140,6 +140,7 @@ else
         -e USER \
         -e TRAVIS \
         -e TAP_DRIVER_QUIET \
+        -e TEST_CHECK_PREREQS \
         -e PYTHON_VERSION \
         -e PRELOAD \
         -e ASAN_OPTIONS \

--- a/t/sharness.d/flux-sharness.sh
+++ b/t/sharness.d/flux-sharness.sh
@@ -162,6 +162,63 @@ test_on_rank() {
     flux exec --rank=${ranks} "$@"
 }
 
+#
+# Check for a program and skip all tests immediately if not found.
+# Exports the program in SHARNESS_test_skip_all_prereq for later
+# check in TEST_CHECK_PREREQS
+#
+skip_all_unless_have()
+{
+    prog_path=$(which $1 2>/dev/null)
+    if test -z "$prog_path"; then
+        skip_all="$1 not found. Skipping all tests"
+        test_done
+    fi
+    eval "$1=$prog_path"
+    export SHARNESS_test_skip_all_prereq="$SHARNESS_test_skip_all_prereq,$1"
+}
+
+GLOBAL_PROGRAM_PREREQS="HAVE_JQ:jq"
+
+#
+#  Check for programs in GLOBAL_PROGRAM_PREREQS and set prereq and
+#   "<name>=<program_path>" if found. If TEST_CHECK_PREREQS is set, then
+#   create a wrapper script in trash-directory/bin which will ensure the
+#   prereq (or global skip_all above) has been used before each invocation
+#   of program. This will catch places in testsuite where program is used
+#   without testing the prerequisite.
+#
+for prereq in $GLOBAL_PROGRAM_PREREQS; do
+    prog=${prereq#*:}
+    path_prog=$(which ${prog} 2>/dev/null || echo "/bin/false")
+    req=${prereq%:*}
+    test "${path_prog}" = "/bin/false" || test_set_prereq ${req}
+    eval "${prog}=${path_prog}"
+    if test -n "$TEST_CHECK_PREREQS"; then
+		dir=${SHARNESS_TRASH_DIRECTORY}/bin
+		mkdir -p ${dir}
+		cat <<-EOF > ${dir}/$prog
+		#!/bin/sh
+		saved_IFS=\$IFS
+		IFS=,
+		for x in \$test_prereq; do
+		  test "\$x" = "$req" && ok=t
+		done
+		for x in \$SHARNESS_test_skip_all_prereq; do
+		  test "\$x" = "$prog" && ok=t
+		done
+		test -n "\$ok" && exec $path_prog "\$@"
+		echo >&2 "Use of $prog without prereq $req!"
+		exit 1
+		EOF
+		chmod +x ${dir}/$prog
+    fi
+done
+
+if test -n "$TEST_CHECK_PREREQS"; then
+    export PATH=${SHARNESS_TRASH_DIRECTORY}/bin:${PATH}
+fi
+
 #  Export a shorter name for this test
 TEST_NAME=$SHARNESS_TEST_NAME
 export TEST_NAME

--- a/t/t0002-request.t
+++ b/t/t0002-request.t
@@ -10,11 +10,6 @@ Verify basic request/response/rpc handling.
 . `dirname $0`/sharness.sh
 test_under_flux 2 minimal
 
-#  Set path to jq(1)
-#
-jq=$(which jq 2>/dev/null)
-test -n "$jq" && test_set_prereq HAVE_JQ
-
 RPC=${FLUX_BUILD_DIR}/t/request/rpc
 
 test_expect_success 'flux_rpc(3) example runs' '

--- a/t/t0017-security.t
+++ b/t/t0017-security.t
@@ -8,9 +8,6 @@ test_description='Test broker security'
 export FLUX_CONF_DIR=$(pwd)
 test_under_flux 4 minimal
 
-jq=$(which jq 2>/dev/null)
-test -z "$jq" || test_set_prereq HAVE_JQ
-
 RPC=${FLUX_BUILD_DIR}/t/request/rpc
 
 test_expect_success 'connector-local starts with private access policy' '

--- a/t/t0021-flux-jobspec.t
+++ b/t/t0021-flux-jobspec.t
@@ -10,11 +10,6 @@ SCHEMA=${FLUX_SOURCE_DIR}/src/modules/job-ingest/schemas/jobspec.jsonschema
 MINI_SCHEMA=${FLUX_SOURCE_DIR}/src/modules/job-ingest/schemas/jobspec_v1.jsonschema
 SUMMARIZE="flux python ${JOBSPEC}/summarize-minimal-jobspec.py"
 
-#  Set path to jq
-#
-jq=$(which jq 2>/dev/null)
-test -n "$jq" && test_set_prereq HAVE_JQ
-
 validate_emission() {
     flux jobspec $@ | ${VALIDATE} --schema ${SCHEMA}
 }

--- a/t/t0022-jj-reader.t
+++ b/t/t0022-jj-reader.t
@@ -4,10 +4,6 @@ test_description='Test json-jobspec *cough* parser *cough*'
 
 . `dirname $0`/sharness.sh
 
-#  Set path to jq
-#
-jq=$(which jq 2>/dev/null)
-test -n "$jq" && test_set_prereq HAVE_JQ
 jj=${FLUX_BUILD_DIR}/t/sched-simple/jj-reader
 y2j="flux python ${SHARNESS_TEST_SRCDIR}/jobspec/y2j.py"
 

--- a/t/t2005-hwloc-basic.t
+++ b/t/t2005-hwloc-basic.t
@@ -34,11 +34,6 @@ test_expect_success 'hwloc: load hwloc xml' '
 lstopo=$(which lstopo 2>/dev/null || which lstopo-no-graphics 2>/dev/null)
 test -n "$lstopo" && test_set_prereq HAVE_LSTOPO
 
-#  Set path to jq
-#
-jq=$(which jq 2>/dev/null)
-test -n "$jq" && test_set_prereq HAVE_JQ
-
 invalid_rank() {
 	echo $((${SIZE} + 1))
 }

--- a/t/t2100-aggregate.t
+++ b/t/t2100-aggregate.t
@@ -8,13 +8,7 @@ RPC=${FLUX_BUILD_DIR}/t/request/rpc
 
 test_under_flux 8
 
-#  Set path to jq
-#
-jq=$(which jq 2>/dev/null)
-if test -z "$jq"; then
-    skip_all='jq not found. Skipping all tests'
-    test_done
-fi
+skip_all_unless_have jq
 
 kvs_json_check() {
     flux kvs get $1 | $jq -e "$2"

--- a/t/t2200-job-ingest.t
+++ b/t/t2200-job-ingest.t
@@ -12,9 +12,6 @@ if ${FLUX_BUILD_DIR}/t/ingest/submitbench --help 2>&1 | grep -q sign-type; then
     SUBMITBENCH_OPT_R="--reuse-signature"
 fi
 
-jq=$(which jq 2>/dev/null)
-test -n "$jq" && test_set_prereq HAVE_JQ
-
 test_under_flux 4 kvs
 
 flux setattr log-stderr-level 1

--- a/t/t2202-job-manager.t
+++ b/t/t2202-job-manager.t
@@ -6,9 +6,6 @@ test_description='Test flux job manager service'
 
 test_under_flux 4 kvs
 
-jq=$(which jq 2>/dev/null)
-test -n "$jq" && test_set_prereq HAVE_JQ
-
 flux setattr log-stderr-level 1
 
 DRAIN_CANCEL="flux python ${FLUX_SOURCE_DIR}/t/job-manager/drain-cancel.py"

--- a/t/t2204-job-info.t
+++ b/t/t2204-job-info.t
@@ -8,8 +8,6 @@ test_description='Test flux job info service'
 
 test_under_flux 4 job
 
-jq=$(which jq 2>/dev/null)
-test -n "$jq" && test_set_prereq HAVE_JQ
 RPC=${FLUX_BUILD_DIR}/t/request/rpc
 
 if test "$TEST_LONG" = "t"; then

--- a/t/t2400-job-exec-test.t
+++ b/t/t2400-job-exec-test.t
@@ -8,13 +8,7 @@ test_under_flux 1 job
 
 flux setattr log-stderr-level 1
 
-#  Set path to jq(1)
-#
-jq=$(which jq 2>/dev/null)
-if test -z "$jq"; then
-    skip_all='jq not found. Skipping all tests'
-    test_done
-fi
+skip_all_unless_have jq
 
 RPC=${FLUX_BUILD_DIR}/t/request/rpc
 

--- a/t/t2402-job-exec-dummy.t
+++ b/t/t2402-job-exec-dummy.t
@@ -4,11 +4,7 @@ test_description='Test flux job execution service with dummy job shell'
 
 . $(dirname $0)/sharness.sh
 
-jq=$(which jq 2>/dev/null)
-if test -z "$jq" ; then
-	skip_all 'no jq found, skipping all tests'
-	test_done
-fi
+skip_all_unless_have jq
 
 #  Configure dummy job shell:
 if ! test -f dummy.toml; then

--- a/t/t2404-job-exec-multiuser.t
+++ b/t/t2404-job-exec-multiuser.t
@@ -11,12 +11,6 @@ if ! test_have_prereq FLUX_SECURITY; then
     test_done
 fi
 
-#  Set path to jq
-#
-jq=$(which jq 2>/dev/null)
-test -n "$jq" && test_set_prereq HAVE_JQ
-
-
 IMP=${SHARNESS_TEST_SRCDIR}/job-exec/imp.sh
 #  Configure dummy IMP
 if ! test -d conf.d; then

--- a/t/t2404-job-exec-multiuser.t
+++ b/t/t2404-job-exec-multiuser.t
@@ -50,7 +50,7 @@ test_expect_success HAVE_JQ 'job-exec: job as guest tries to run IMP' '
 	flux dmesg | grep "test-imp: Running.*${id}"
 '
 
-test_expect_success 'job-exec: kill multiuser job uses the IMP' '
+test_expect_success HAVE_JQ 'job-exec: kill multiuser job uses the IMP' '
 	FAKE_USERID=42 &&
 	flux mini run --dry-run -n2 -N2 sleep 1000 | \
 	    flux python ${SIGN_AS} ${FAKE_USERID} > sleep-job.signed &&

--- a/t/t2500-job-attach.t
+++ b/t/t2500-job-attach.t
@@ -104,9 +104,6 @@ test_expect_success 'attach: output events processed after shell.init failure' '
 	grep "FATAL:.*noinitrc: No such file or directory" init-failure.output
 '
 
-which jq >/dev/null 2>&1 && test_set_prereq HAVE_JQ
-
-
 # use a shell function to make sane quoting possible
 filter_log_context() {
     jq -c '. | select(.name == "log") | .context'

--- a/t/t2603-job-shell-initrc.t
+++ b/t/t2603-job-shell-initrc.t
@@ -4,9 +4,6 @@ test_description='Test flux-shell initrc.lua implementation'
 
 . `dirname $0`/sharness.sh
 
-jq=$(which jq 2>/dev/null)
-test -z "$jq" || test_set_prereq HAVE_JQ
-
 FLUX_SHELL="${FLUX_BUILD_DIR}/src/shell/flux-shell"
 
 INITRC_TESTDIR="${SHARNESS_TEST_SRCDIR}/shell/initrc"

--- a/t/t2605-job-shell-output-redirection-standalone.t
+++ b/t/t2605-job-shell-output-redirection-standalone.t
@@ -4,9 +4,6 @@ test_description='Test flux-shell in --standalone mode'
 
 . `dirname $0`/sharness.sh
 
-jq=$(which jq 2>/dev/null)
-test -n "$jq" && test_set_prereq HAVE_JQ
-
 #  Run flux-shell under flux command to get correct paths
 FLUX_SHELL="flux ${FLUX_BUILD_DIR}/src/shell/flux-shell"
 

--- a/t/t2610-job-shell-mpir.t
+++ b/t/t2610-job-shell-mpir.t
@@ -4,6 +4,8 @@ test_description='Test flux-shell MPIR and ptrace support'
 
 . `dirname $0`/sharness.sh
 
+skip_all_unless_have jq
+
 test_under_flux 4 job
 
 FLUX_SHELL="${FLUX_BUILD_DIR}/src/shell/flux-shell"
@@ -11,12 +13,6 @@ FLUX_SHELL="${FLUX_BUILD_DIR}/src/shell/flux-shell"
 INITRC_TESTDIR="${SHARNESS_TEST_SRCDIR}/shell/initrc"
 INITRC_PLUGINPATH="${SHARNESS_TEST_DIRECTORY}/shell/plugins/.libs"
 mpir="${SHARNESS_TEST_DIRECTORY}/shell/mpir"
-
-test -z "$jq" || test_set_prereq HAVE_JQ
-if ! test_have_prereq HAVE_JQ; then
-    skip_all='skipping tests, jq not available'
-    test_done
-fi
 
 shell_leader_rank() {
     flux job wait-event -f json -p guest.exec.eventlog $1 shell.init | \

--- a/t/t2611-debug-emulate.t
+++ b/t/t2611-debug-emulate.t
@@ -33,7 +33,7 @@ test_expect_success 'debugger: submitting under debugger via flux-mini works' '
         flux job wait-event -vt 2.5  ${jobid} finish
 '
 
-test_expect_success 'debugger: submitting under debugger via flux-job works' '
+test_expect_success HAVE_JQ 'debugger: submitting under debugger via flux-job works' '
         flux jobspec srun -N2 -n 2 hostname | stop_tasks_test > stop_tasks.json &&
         jobid=$(flux job submit stop_tasks.json) &&
         flux job wait-event -vt 2.5  ${jobid} start &&

--- a/t/t2700-mini-cmd.t
+++ b/t/t2700-mini-cmd.t
@@ -6,8 +6,6 @@ test_description='Test flux mini command'
 
 test_under_flux 4
 
-jq=$(which jq 2>/dev/null)
-test -z "$jq" || test_set_prereq HAVE_JQ
 test $(nproc) -gt 1 && test_set_prereq HAVE_MULTICORE
 
 # Set CLIMain log level to logging.DEBUG (10), to enable stack traces

--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -4,11 +4,6 @@ test_description='Test flux jobs command'
 
 . $(dirname $0)/sharness.sh
 
-#  Set path to jq(1)
-#
-jq=$(which jq 2>/dev/null)
-test -n "$jq" && test_set_prereq HAVE_JQ
-
 test_under_flux 4 job
 
 # submit a whole bunch of jobs for job list testing

--- a/t/t3001-mpi-personalities.t
+++ b/t/t3001-mpi-personalities.t
@@ -8,9 +8,6 @@ test_description="Test that Flux's MPI personalities work"
 SIZE=4
 test_under_flux ${SIZE}
 
-jq=$(which jq 2>/dev/null)
-test -z "$jq" || test_set_prereq HAVE_JQ
-
 run_program() {
         local timeout=$1
 	local nnodes=$2


### PR DESCRIPTION
As described in #2935 add a way for the testsuite to check that use of `jq` occurs either under `HAVE_JQ` or in a tests script that would otherwise be skipped if `jq` is not present.

This is done by optionally creating a wrapper script in `$SHARNESS_TRASH_DIRECTORY/bin` for each prereq (currently, only `jq`), and putting that directory first in `PATH`. The script(s) check that an appropriate prereq occurs in `test_prereq` environment variable, and invoke the real program if so. Otherwise an error is generated.

The above works for `HAVE_JQ`, but fails when entire test script is skipped at the top due to missing prereq. For this case, a new `skip_all_unless_have()` function is added, which replaces the existing duplicated tests for `jq` with subsequent `skip_all`, and additionally exports a list of skip_all prereqs used by the test script in `SHARNESS_test_skip_all_prereq=`, so that this can be checked by the wrapper script.

Finally, this PR adds `TEST_CHECK_PREREQS=t` to the same builder that does `chain-lint`, and finally fixes a couple spots where `HAVE_JQ` was still missing (as detected by the new logic)

