### PR TITLE
sharness: fix TEST_CHECK_PREREQS for tests using $jq

### DIFF
--- a/t/sharness.d/flux-sharness.sh
+++ b/t/sharness.d/flux-sharness.sh
@@ -249,7 +249,7 @@ fi
 # Sanitize PMI_* environment for all tests. This allows commands like
 #  `flux broker` in tests to boot as singleton even when run under a
 #  job of an existing RM.
-for var in $(env | grep ^PMI); do unset ${var%=*}; done
-for var in $(env | grep ^SLURM); do unset ${var%=*}; done
+for var in $(env | grep ^PMI); do unset ${var%%=*}; done
+for var in $(env | grep ^SLURM); do unset ${var%%=*}; done
 
 # vi: ts=4 sw=4 expandtab

--- a/t/sharness.d/flux-sharness.sh
+++ b/t/sharness.d/flux-sharness.sh
@@ -212,6 +212,8 @@ for prereq in $GLOBAL_PROGRAM_PREREQS; do
 		exit 1
 		EOF
 		chmod +x ${dir}/$prog
+		# Override $$prog to point to wrapper script:
+		eval "${prog}=${dir}/${prog}"
     fi
 done
 


### PR DESCRIPTION
As described in #2938, use of `$jq` subverts the `TEST_CHECK_PREREQS` wrapper script.

This PR fixes the issue by redirecting `$prog` to the wrapper script instead of the original program when `TEST_CHECK_PREREQS` is active.

