### PR TITLE
flux-jobs: color completed, failed, cancelled jobs

### DIFF
--- a/doc/man1/flux-jobs.adoc
+++ b/doc/man1/flux-jobs.adoc
@@ -50,6 +50,10 @@ additional information.  Defaults to 'pending,running'.
 Specify output format using Python's string format syntax.  See OUTPUT
 FORMAT below for field names.
 
+*--color*'=WHEN'::
+Control output coloring.  WHEN can be 'never', 'always', or 'auto'.
+Defaults to 'auto'.
+
 JOB STATUS
 ----------
 Jobs may be observed to pass through five job states in Flux: DEPEND,


### PR DESCRIPTION
Built upon PR #2910 and utilizing the "result" attribute,  colorize "completed" and "failed" jobs green/red accordingly.  It's a super simple patch (just the last one in this commit stream).

![Screenshot from 2020-05-13 16-23-00](https://user-images.githubusercontent.com/274859/81876220-fe926100-9536-11ea-9eba-3a6bab2cece8.png)

- Added a `--color` option which takes `never` or `auto` as args, modeled it after the `ls --color` option.

- I decided not to color cancelled jobs, maybe I should?  I figure cancelled jobs, the user cancelled for a reason and knows.  They could be red?  Or another color?

- It'd be easy to support a configuration (environment variable or option) where we have rules to say "completed=34;failed=36" or whatever, where users can select color via the ansi code.  Easy to parse and easy to check inputs and then use in escape codes.  Feels like too much for now, given I'm only colorizing two outputs, but perhaps later.

- Contemplated only coloring the jobs of the user running the `flux-jobs` command, but not sure if that's a good idea given we will be supporting job submissions by guest users.  Perhaps of whatever user is passed in via `--user`?  But that might be confusing to an average user, why some failed jobs aren't being colored??  So I decided not to do it.

