### PR TITLE
Add support for hwloc v2.0+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,10 +38,11 @@ jobs:
     - name: "Ubuntu: no configure flags"
       stage: test
       compiler: gcc
-    - name: "Ubuntu: py3.8 distcheck"
+    - name: "Ubuntu 20.04: py3.8 distcheck"
       stage: test
       compiler: gcc
       env:
+       - IMG=focal
        - DISTCHECK=t
        - PYTHON_VERSION=3.8
        - GITHUB_RELEASES_DEPLOY=t

--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -12,7 +12,8 @@ AM_CPPFLAGS = \
 	$(FLUX_SECURITY_CFLAGS) \
 	$(ZMQ_CFLAGS) \
 	$(LIBUUID_CFLAGS) \
-	$(LIBSODIUM_CFLAGS)
+	$(LIBSODIUM_CFLAGS) \
+	$(HWLOC_CFLAGS)
 
 fluxcmd_ldadd = \
 	$(top_builddir)/src/common/libkvs/libkvs.la \

--- a/src/cmd/builtin/version.c
+++ b/src/cmd/builtin/version.c
@@ -8,6 +8,7 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#include <hwloc.h>
 #include <config.h>
 
 #include "builtin.h"
@@ -57,6 +58,11 @@ static int cmd_version (optparse_t *p, int ac, char *av[])
 #if HAVE_CALIPER
     printf ("+caliper");
 #endif
+    printf ("+hwloc==%d.%d.%d",
+            HWLOC_API_VERSION >> 16 & 0x000000ff,
+            HWLOC_API_VERSION >>  8 & 0x000000ff,
+            HWLOC_API_VERSION       & 0x000000ff
+            );
     printf ("\n");
     return (0);
 }

--- a/src/shell/Makefile.am
+++ b/src/shell/Makefile.am
@@ -10,7 +10,7 @@ AM_CPPFLAGS = \
 	-I$(top_builddir)/src/common/libflux \
 	$(ZMQ_CFLAGS) $(VALGRIND_CFLAGS) \
 	$(LUA_INCLUDE) \
-	$(HWLOC_INCLUDE)
+	$(HWLOC_CFLAGS)
 
 shellrcdir = \
 	$(fluxrcdir)/shell

--- a/src/shell/affinity.c
+++ b/src/shell/affinity.c
@@ -35,7 +35,6 @@ static int topology_restrict (hwloc_topology_t topo, hwloc_cpuset_t set)
     int flags = HWLOC_RESTRICT_FLAG_ADAPT_DISTANCES |
                 HWLOC_RESTRICT_FLAG_ADAPT_MISC |
                 HWLOC_RESTRICT_FLAG_ADAPT_IO;
-    flags = 0;
     if (hwloc_topology_restrict (topo, set, flags) < 0)
         return (-1);
     return (0);

--- a/src/shell/affinity.c
+++ b/src/shell/affinity.c
@@ -32,9 +32,11 @@ struct shell_affinity {
  */
 static int topology_restrict (hwloc_topology_t topo, hwloc_cpuset_t set)
 {
-    int flags = HWLOC_RESTRICT_FLAG_ADAPT_DISTANCES |
-                HWLOC_RESTRICT_FLAG_ADAPT_MISC |
+    int flags = HWLOC_RESTRICT_FLAG_ADAPT_MISC |
                 HWLOC_RESTRICT_FLAG_ADAPT_IO;
+#if HWLOC_API_VERSION < 0x20000
+    flags = flags | HWLOC_RESTRICT_FLAG_ADAPT_DISTANCES;
+#endif
     if (hwloc_topology_restrict (topo, set, flags) < 0)
         return (-1);
     return (0);

--- a/src/shell/affinity.c
+++ b/src/shell/affinity.c
@@ -125,6 +125,10 @@ static hwloc_cpuset_t shell_affinity_get_cpuset (struct shell_affinity *sa,
             shell_log_error ("affinity: core%d not in topology", i);
             goto err;
         }
+        if (!core->cpuset) {
+            shell_log_error ("affinity: core%d cpuset is null", i);
+            goto err;
+        }
         hwloc_bitmap_or (resultset, resultset, core->cpuset);
         i = hwloc_bitmap_next (coreset, i);
     }

--- a/src/test/docker/README.md
+++ b/src/test/docker/README.md
@@ -13,9 +13,9 @@ or a tagged version of flux-core.
 
 #### fluxrm/testenv Docker images
 
-The Dockerfiles under `bionic/Dockerfile` and
+The Dockerfiles under `bionic/Dockerfile`, `focal/Dockerfile` and
 `centos7/Dockerfile` describe the images built under the
-`fluxrm/testenv:bionic` and `fluxrm/testenv:centos7`
+`fluxrm/testenv:bionic`, `fluxrm/testenv:focal` and `fluxrm/testenv:centos7`
 respectively, and include the base dependencies required to build
 flux-core. These images are updated manually by flux-core maintainers, but
 the Dockerfiles should be kept up to date for a single point of management.

--- a/src/test/docker/focal/Dockerfile
+++ b/src/test/docker/focal/Dockerfile
@@ -1,0 +1,113 @@
+FROM ubuntu:focal
+
+LABEL maintainer="Stephen Herbein <herbein1@llnl.gov>"
+
+# avoid debconf from asking for input
+ENV DEBIAN_FRONTEND noninteractive
+
+# Update pkg caches, install latest pkg utils:
+RUN apt-get update \
+ && apt-get -qq install -y --no-install-recommends \
+        apt-utils \
+ && rm -rf /var/lib/apt/lists/*
+
+# Ubuntu's minimal image installs a bonus `man` binary, breaking some of our
+# tests (i.e., `flux help foo`).  Remove their wrapper and install the real
+# thing, without installing every man page under the sun (which the `unminimize`
+# command would do)
+RUN rm -f /usr/bin/man && dpkg-divert --quiet --remove --rename /usr/bin/man \
+    && apt-get update \
+    && apt-get -qq install -y --no-install-recommends man-db \
+    && rm -rf /var/lib/apt/lists/*
+
+# Utilities
+RUN apt-get update \
+ && apt-get -qq install -y --no-install-recommends \
+        locales \
+        ca-certificates \
+        wget \
+        man \
+        git \
+        sudo \
+        vim \
+        munge \
+        lcov \
+        ccache \
+        lua5.2 \
+        lua-posix \
+        mpich \
+        valgrind \
+        asciidoctor \
+        jq \
+ && rm -rf /var/lib/apt/lists/*
+
+# Compilers, autotools
+RUN apt-get update \
+ && apt-get -qq install -y --no-install-recommends \
+        build-essential \
+        pkg-config \
+        autotools-dev \
+        libtool \
+        autoconf \
+        automake \
+        make \
+        cmake \
+        clang \
+        clang-tidy \
+ && rm -rf /var/lib/apt/lists/*
+
+# Python
+RUN apt-get update \
+ && apt-get -qq install -y --no-install-recommends \
+        python3-dev \
+        python3.8-dev \
+        python3-pip \
+        python3-setuptools \
+        python3-wheel \
+        python3-cffi \
+        python3-six \
+        python3-yaml \
+        python3-jsonschema \
+ && rm -rf /var/lib/apt/lists/*
+
+# Other deps
+RUN apt-get update \
+ && apt-get -qq install -y --no-install-recommends \
+        libsodium-dev \
+        libzmq3-dev \
+        libczmq-dev \
+        libjansson-dev \
+        libmunge-dev \
+        liblua5.2-dev \
+        lua-posix-dev \
+        liblz4-dev \
+        libsqlite3-dev \
+        uuid-dev \
+        libhwloc-dev \
+        libmpich-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+# Testing utils and libs
+RUN apt-get update \
+ && apt-get -qq install -y --no-install-recommends \
+        faketime \
+        libfaketime \
+        pylint \
+        cppcheck \
+        aspell \
+        aspell-en \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN locale-gen en_US.UTF-8
+
+# Install caliper by hand for now:
+RUN mkdir caliper \
+ && cd caliper \
+ && wget -O - https://github.com/LLNL/Caliper/archive/v1.7.0.tar.gz | tar xvz --strip-components 1 \
+ && mkdir build \
+ && cd build \
+ && CC=gcc CXX=g++ cmake .. -DCMAKE_INSTALL_PREFIX=/usr \
+ && make -j 4 \
+ && make install \
+ && cd ../.. \
+ && rm -rf caliper

--- a/src/test/docker/travis/Dockerfile
+++ b/src/test/docker/travis/Dockerfile
@@ -39,9 +39,10 @@ RUN set -x && groupadd fluxuser \
  && useradd -g fluxuser -d /home/fluxuser -m fluxuser -s /bin/bash \
  && printf "fluxuser ALL= NOPASSWD: ALL\\n" >> /etc/sudoers
 
-# Make sure user in appropriate group for sudo on different platorms
+# Make sure user in appropriate group for sudo on different platforms
 RUN case $BASE_IMAGE in \
      bionic*) adduser $USER sudo && adduser fluxuser sudo ;; \
+     focal*)  adduser $USER sudo && adduser fluxuser sudo ;; \
      centos*) usermod -G wheel $USER && usermod -G wheel fluxuser ;; \
      *) (>&2 echo "Unknown BASE_IMAGE") ;; \
     esac
@@ -54,6 +55,7 @@ RUN case $BASE_IMAGE in \
 #
 RUN case $BASE_IMAGE in \
      bionic*) ;; \
+     focal*) ;; \
      centos*) ;; \
      *) (>&2 echo "Unknown BASE_IMAGE") ;; \
     esac

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -91,6 +91,7 @@ TESTSCRIPTS = \
 	t1106-ssh-connector.t \
 	t2004-hydra.t \
 	t2005-hwloc-basic.t \
+	t2006-hwloc-versions.t \
 	t2007-caliper.t \
 	t2008-althash.t \
 	t2010-kvs-snapshot-restore.t \
@@ -258,7 +259,9 @@ check_PROGRAMS = \
 	shell/rcalc \
 	shell/lptest \
 	shell/mpir \
-	debug/stall
+	debug/stall \
+	hwloc/hwloc-convert \
+	hwloc/hwloc-version
 
 if HAVE_MPI
 check_PROGRAMS += \
@@ -286,6 +289,9 @@ dist_check_DATA = \
 	hwloc-data/1N/shared/02-brokers/1.xml \
 	hwloc-data/1N/nonoverlapping/02-brokers/0.xml \
 	hwloc-data/1N/nonoverlapping/02-brokers/1.xml \
+	hwloc-data/1N/hwloc-versions/v1.11.11/0.xml \
+	hwloc-data/1N/hwloc-versions/v2.1.0/0.xml \
+	hwloc-data/1N/hwloc-versions/v2to1/0.xml \
 	valgrind/valgrind.supp
 
 test_ldadd = \
@@ -554,3 +560,13 @@ shell_plugins_test_event_la_CPPFLAGS = $(test_cppflags)
 shell_plugins_test_event_la_LDFLAGS = -module -rpath /nowhere
 shell_plugins_test_event_la_LIBADD = \
         $(top_builddir)/src/common/libflux-core.la
+
+hwloc_hwloc_convert_SOURCES = hwloc/hwloc-convert.c
+hwloc_hwloc_convert_CPPFLAGS = $(HWLOC_CFLAGS) $(test_cppflags)
+hwloc_hwloc_convert_LDADD = $(HWLOC_LIBS) \
+	$(test_ldadd)
+
+hwloc_hwloc_version_SOURCES = hwloc/hwloc-version.c
+hwloc_hwloc_version_CPPFLAGS = $(HWLOC_CFLAGS) $(test_cppflags)
+hwloc_hwloc_version_LDADD = $(HWLOC_LIBS) \
+	$(test_ldadd)

--- a/t/hwloc-data/1N/hwloc-versions/v1.11.11/0.xml
+++ b/t/hwloc-data/1N/hwloc-versions/v1.11.11/0.xml
@@ -1,0 +1,987 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topology SYSTEM "hwloc.dtd">
+<topology>
+  <object type="Machine" os_index="0" cpuset="0xffffffff,0xffffffff,0xffffffff" complete_cpuset="0xffffffff,0xffffffff,0xffffffff" online_cpuset="0xffffffff,0xffffffff,0xffffffff" allowed_cpuset="0xffffffff,0xffffffff,0xffffffff" nodeset="0x000000ff" complete_nodeset="0x000000ff" allowed_nodeset="0x000000ff">
+    <page_type size="4096" count="0"/>
+    <page_type size="2097152" count="0"/>
+    <page_type size="1073741824" count="0"/>
+    <info name="DMIProductName" value="Altus XO1114GT"/>
+    <info name="DMIProductVersion" value="0100"/>
+    <info name="DMIBoardVendor" value="GIGABYTE"/>
+    <info name="DMIBoardName" value="MZ71-OP0-ZB"/>
+    <info name="DMIBoardVersion" value="01000100"/>
+    <info name="DMIBoardAssetTag" value="01234567890123456789AB"/>
+    <info name="DMIChassisVendor" value="Penguin Computing"/>
+    <info name="DMIChassisType" value="23"/>
+    <info name="DMIChassisVersion" value="01234567"/>
+    <info name="DMIChassisAssetTag" value="01234567890123456789AB"/>
+    <info name="DMIBIOSVendor" value="GIGABYTE"/>
+    <info name="DMIBIOSVersion" value="F06c"/>
+    <info name="DMIBIOSDate" value="12/14/2018"/>
+    <info name="DMISysVendor" value="Penguin Computing"/>
+    <info name="Backend" value="Linux"/>
+    <info name="LinuxCgroup" value="/"/>
+    <info name="OSName" value="Linux"/>
+    <info name="OSRelease" value="3.10.0-1127.0.0.1chaos.ch6.x86_64"/>
+    <info name="OSVersion" value="#1 SMP Fri Apr 3 08:56:52 PDT 2020"/>
+    <info name="HostName" value="corona40"/>
+    <info name="Architecture" value="x86_64"/>
+    <info name="hwlocVersion" value="1.11.11"/>
+    <info name="ProcessName" value="lstopo"/>
+    <distances nbobjs="8" relative_depth="2" latency_base="10.000000">
+      <latency value="1.000000"/>
+      <latency value="1.600000"/>
+      <latency value="1.600000"/>
+      <latency value="1.600000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="1.600000"/>
+      <latency value="1.000000"/>
+      <latency value="1.600000"/>
+      <latency value="1.600000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="1.600000"/>
+      <latency value="1.600000"/>
+      <latency value="1.000000"/>
+      <latency value="1.600000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="1.600000"/>
+      <latency value="1.600000"/>
+      <latency value="1.600000"/>
+      <latency value="1.000000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="1.000000"/>
+      <latency value="1.600000"/>
+      <latency value="1.600000"/>
+      <latency value="1.600000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="1.600000"/>
+      <latency value="1.000000"/>
+      <latency value="1.600000"/>
+      <latency value="1.600000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="1.600000"/>
+      <latency value="1.600000"/>
+      <latency value="1.000000"/>
+      <latency value="1.600000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="1.600000"/>
+      <latency value="1.600000"/>
+      <latency value="1.600000"/>
+      <latency value="1.000000"/>
+    </distances>
+    <object type="Package" os_index="0" cpuset="0x000000ff,0xffff0000,0x00ffffff" complete_cpuset="0x000000ff,0xffff0000,0x00ffffff" online_cpuset="0x000000ff,0xffff0000,0x00ffffff" allowed_cpuset="0x000000ff,0xffff0000,0x00ffffff" nodeset="0x0000000f" complete_nodeset="0x0000000f" allowed_nodeset="0x0000000f">
+      <info name="CPUVendor" value="AuthenticAMD"/>
+      <info name="CPUFamilyNumber" value="23"/>
+      <info name="CPUModelNumber" value="1"/>
+      <info name="CPUModel" value="AMD EPYC 7401 24-Core Processor"/>
+      <info name="CPUStepping" value="2"/>
+      <object type="NUMANode" os_index="0" cpuset="0x003f0000,0x0000003f" complete_cpuset="0x003f0000,0x0000003f" online_cpuset="0x003f0000,0x0000003f" allowed_cpuset="0x003f0000,0x0000003f" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" local_memory="33299529728">
+        <page_type size="4096" count="8129768"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+        <object type="Cache" cpuset="0x00070000,0x00000007" complete_cpuset="0x00070000,0x00000007" online_cpuset="0x00070000,0x00000007" allowed_cpuset="0x00070000,0x00000007" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x00010000,0x00000001" complete_cpuset="0x00010000,0x00000001" online_cpuset="0x00010000,0x00000001" allowed_cpuset="0x00010000,0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00010000,0x00000001" complete_cpuset="0x00010000,0x00000001" online_cpuset="0x00010000,0x00000001" allowed_cpuset="0x00010000,0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00010000,0x00000001" complete_cpuset="0x00010000,0x00000001" online_cpuset="0x00010000,0x00000001" allowed_cpuset="0x00010000,0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="0" cpuset="0x00010000,0x00000001" complete_cpuset="0x00010000,0x00000001" online_cpuset="0x00010000,0x00000001" allowed_cpuset="0x00010000,0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="48" cpuset="0x00010000,0x0" complete_cpuset="0x00010000,0x0" online_cpuset="0x00010000,0x0" allowed_cpuset="0x00010000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00020000,0x00000002" complete_cpuset="0x00020000,0x00000002" online_cpuset="0x00020000,0x00000002" allowed_cpuset="0x00020000,0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00020000,0x00000002" complete_cpuset="0x00020000,0x00000002" online_cpuset="0x00020000,0x00000002" allowed_cpuset="0x00020000,0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00020000,0x00000002" complete_cpuset="0x00020000,0x00000002" online_cpuset="0x00020000,0x00000002" allowed_cpuset="0x00020000,0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="1" cpuset="0x00020000,0x00000002" complete_cpuset="0x00020000,0x00000002" online_cpuset="0x00020000,0x00000002" allowed_cpuset="0x00020000,0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="49" cpuset="0x00020000,0x0" complete_cpuset="0x00020000,0x0" online_cpuset="0x00020000,0x0" allowed_cpuset="0x00020000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00040000,0x00000004" complete_cpuset="0x00040000,0x00000004" online_cpuset="0x00040000,0x00000004" allowed_cpuset="0x00040000,0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00040000,0x00000004" complete_cpuset="0x00040000,0x00000004" online_cpuset="0x00040000,0x00000004" allowed_cpuset="0x00040000,0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00040000,0x00000004" complete_cpuset="0x00040000,0x00000004" online_cpuset="0x00040000,0x00000004" allowed_cpuset="0x00040000,0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="2" cpuset="0x00040000,0x00000004" complete_cpuset="0x00040000,0x00000004" online_cpuset="0x00040000,0x00000004" allowed_cpuset="0x00040000,0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="50" cpuset="0x00040000,0x0" complete_cpuset="0x00040000,0x0" online_cpuset="0x00040000,0x0" allowed_cpuset="0x00040000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Cache" cpuset="0x00380000,0x00000038" complete_cpuset="0x00380000,0x00000038" online_cpuset="0x00380000,0x00000038" allowed_cpuset="0x00380000,0x00000038" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x00080000,0x00000008" complete_cpuset="0x00080000,0x00000008" online_cpuset="0x00080000,0x00000008" allowed_cpuset="0x00080000,0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00080000,0x00000008" complete_cpuset="0x00080000,0x00000008" online_cpuset="0x00080000,0x00000008" allowed_cpuset="0x00080000,0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00080000,0x00000008" complete_cpuset="0x00080000,0x00000008" online_cpuset="0x00080000,0x00000008" allowed_cpuset="0x00080000,0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="4" cpuset="0x00080000,0x00000008" complete_cpuset="0x00080000,0x00000008" online_cpuset="0x00080000,0x00000008" allowed_cpuset="0x00080000,0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="51" cpuset="0x00080000,0x0" complete_cpuset="0x00080000,0x0" online_cpuset="0x00080000,0x0" allowed_cpuset="0x00080000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00100000,0x00000010" complete_cpuset="0x00100000,0x00000010" online_cpuset="0x00100000,0x00000010" allowed_cpuset="0x00100000,0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00100000,0x00000010" complete_cpuset="0x00100000,0x00000010" online_cpuset="0x00100000,0x00000010" allowed_cpuset="0x00100000,0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00100000,0x00000010" complete_cpuset="0x00100000,0x00000010" online_cpuset="0x00100000,0x00000010" allowed_cpuset="0x00100000,0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="5" cpuset="0x00100000,0x00000010" complete_cpuset="0x00100000,0x00000010" online_cpuset="0x00100000,0x00000010" allowed_cpuset="0x00100000,0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" online_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="52" cpuset="0x00100000,0x0" complete_cpuset="0x00100000,0x0" online_cpuset="0x00100000,0x0" allowed_cpuset="0x00100000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00200000,0x00000020" complete_cpuset="0x00200000,0x00000020" online_cpuset="0x00200000,0x00000020" allowed_cpuset="0x00200000,0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00200000,0x00000020" complete_cpuset="0x00200000,0x00000020" online_cpuset="0x00200000,0x00000020" allowed_cpuset="0x00200000,0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00200000,0x00000020" complete_cpuset="0x00200000,0x00000020" online_cpuset="0x00200000,0x00000020" allowed_cpuset="0x00200000,0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="6" cpuset="0x00200000,0x00000020" complete_cpuset="0x00200000,0x00000020" online_cpuset="0x00200000,0x00000020" allowed_cpuset="0x00200000,0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" online_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="53" cpuset="0x00200000,0x0" complete_cpuset="0x00200000,0x0" online_cpuset="0x00200000,0x0" allowed_cpuset="0x00200000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="0" bridge_type="0-1" depth="0" bridge_pci="0000:[00-07]">
+          <object type="Bridge" os_index="17" name="Advanced Micro Devices, Inc. [AMD] Family 17h (Models 00h-0fh) PCIe GPP Bridge" bridge_type="1-1" depth="1" bridge_pci="0000:[01-01]" pci_busid="0000:00:01.1" pci_type="0604 [1022:1453] [0000:0000] 00" pci_link_speed="3.938462">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+            <info name="PCIDevice" value="Family 17h (Models 00h-0fh) PCIe GPP Bridge"/>
+            <object type="PCIDev" os_index="4096" name="HGST, Inc. Ultrastar SN200 Series NVMe SSD" pci_busid="0000:01:00.0" pci_type="0108 [1c58:0023] [1c58:0023] 02" pci_link_speed="3.938462">
+              <info name="PCIVendor" value="HGST, Inc."/>
+              <info name="PCIDevice" value="Ultrastar SN200 Series NVMe SSD"/>
+              <info name="PCISlot" value="1"/>
+              <object type="OSDev" name="nvme0n1" osdev_type="0">
+                <info name="LinuxDeviceID" value="259:0"/>
+                <info name="Model" value="HUSMR7616BDP301"/>
+                <info name="SerialNumber" value="SDM0000107A5"/>
+                <info name="Type" value="Disk"/>
+              </object>
+            </object>
+          </object>
+          <object type="Bridge" os_index="19" name="Advanced Micro Devices, Inc. [AMD] Family 17h (Models 00h-0fh) PCIe GPP Bridge" bridge_type="1-1" depth="1" bridge_pci="0000:[03-03]" pci_busid="0000:00:01.3" pci_type="0604 [1022:1453] [0000:0000] 00" pci_link_speed="1.000000">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+            <info name="PCIDevice" value="Family 17h (Models 00h-0fh) PCIe GPP Bridge"/>
+            <object type="PCIDev" os_index="12288" name="Intel Corporation I350 Gigabit Network Connection" pci_busid="0000:03:00.0" pci_type="0200 [8086:1521] [1458:0000] 01" pci_link_speed="1.000000">
+              <info name="PCIVendor" value="Intel Corporation"/>
+              <info name="PCIDevice" value="I350 Gigabit Network Connection"/>
+              <object type="OSDev" name="enp3s0f0" osdev_type="2">
+                <info name="Address" value="e0:d5:5e:ca:b0:22"/>
+              </object>
+            </object>
+            <object type="PCIDev" os_index="12289" name="Intel Corporation I350 Gigabit Network Connection" pci_busid="0000:03:00.1" pci_type="0200 [8086:1521] [1458:0000] 01" pci_link_speed="1.000000">
+              <info name="PCIVendor" value="Intel Corporation"/>
+              <info name="PCIDevice" value="I350 Gigabit Network Connection"/>
+              <object type="OSDev" name="enp3s0f1" osdev_type="2">
+                <info name="Address" value="e0:d5:5e:ca:b0:23"/>
+              </object>
+            </object>
+          </object>
+          <object type="Bridge" os_index="22" name="Advanced Micro Devices, Inc. [AMD] Family 17h (Models 00h-0fh) PCIe GPP Bridge" bridge_type="1-1" depth="1" bridge_pci="0000:[04-05]" pci_busid="0000:00:01.6" pci_type="0604 [1022:1453] [0000:0000] 00" pci_link_speed="0.250000">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+            <info name="PCIDevice" value="Family 17h (Models 00h-0fh) PCIe GPP Bridge"/>
+            <object type="Bridge" os_index="16384" name="ASPEED Technology, Inc. AST1150 PCI-to-PCI Bridge" bridge_type="1-1" depth="2" bridge_pci="0000:[05-05]" pci_busid="0000:04:00.0" pci_type="0604 [1a03:1150] [0000:0000] 04" pci_link_speed="0.250000">
+              <info name="PCIVendor" value="ASPEED Technology, Inc."/>
+              <info name="PCIDevice" value="AST1150 PCI-to-PCI Bridge"/>
+              <object type="PCIDev" os_index="20480" name="ASPEED Technology, Inc. ASPEED Graphics Family" pci_busid="0000:05:00.0" pci_type="0300 [1a03:2000] [1458:1000] 41" pci_link_speed="0.000000">
+                <info name="PCIVendor" value="ASPEED Technology, Inc."/>
+                <info name="PCIDevice" value="ASPEED Graphics Family"/>
+                <object type="OSDev" name="card0" osdev_type="1"/>
+                <object type="OSDev" name="controlD64" osdev_type="1"/>
+              </object>
+            </object>
+          </object>
+          <object type="Bridge" os_index="129" name="Advanced Micro Devices, Inc. [AMD] Family 17h (Models 00h-0fh) Internal PCIe GPP Bridge 0 to Bus B" bridge_type="1-1" depth="1" bridge_pci="0000:[07-07]" pci_busid="0000:00:08.1" pci_type="0604 [1022:1454] [0000:0000] 00" pci_link_speed="15.753846">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+            <info name="PCIDevice" value="Family 17h (Models 00h-0fh) Internal PCIe GPP Bridge 0 to Bus B"/>
+            <object type="PCIDev" os_index="28674" name="Advanced Micro Devices, Inc. [AMD] FCH SATA Controller [AHCI mode]" pci_busid="0000:07:00.2" pci_type="0106 [1022:7901] [1458:1000] 51" pci_link_speed="15.753846">
+              <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+              <info name="PCIDevice" value="FCH SATA Controller [AHCI mode]"/>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="NUMANode" os_index="1" cpuset="0x0fc00000,0x00000fc0" complete_cpuset="0x0fc00000,0x00000fc0" online_cpuset="0x0fc00000,0x00000fc0" allowed_cpuset="0x0fc00000,0x00000fc0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" local_memory="33819570176">
+        <page_type size="4096" count="8256731"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+        <object type="Cache" cpuset="0x01c00000,0x000001c0" complete_cpuset="0x01c00000,0x000001c0" online_cpuset="0x01c00000,0x000001c0" allowed_cpuset="0x01c00000,0x000001c0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x00400000,0x00000040" complete_cpuset="0x00400000,0x00000040" online_cpuset="0x00400000,0x00000040" allowed_cpuset="0x00400000,0x00000040" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00400000,0x00000040" complete_cpuset="0x00400000,0x00000040" online_cpuset="0x00400000,0x00000040" allowed_cpuset="0x00400000,0x00000040" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00400000,0x00000040" complete_cpuset="0x00400000,0x00000040" online_cpuset="0x00400000,0x00000040" allowed_cpuset="0x00400000,0x00000040" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="8" cpuset="0x00400000,0x00000040" complete_cpuset="0x00400000,0x00000040" online_cpuset="0x00400000,0x00000040" allowed_cpuset="0x00400000,0x00000040" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" online_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="54" cpuset="0x00400000,0x0" complete_cpuset="0x00400000,0x0" online_cpuset="0x00400000,0x0" allowed_cpuset="0x00400000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00800000,0x00000080" complete_cpuset="0x00800000,0x00000080" online_cpuset="0x00800000,0x00000080" allowed_cpuset="0x00800000,0x00000080" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00800000,0x00000080" complete_cpuset="0x00800000,0x00000080" online_cpuset="0x00800000,0x00000080" allowed_cpuset="0x00800000,0x00000080" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00800000,0x00000080" complete_cpuset="0x00800000,0x00000080" online_cpuset="0x00800000,0x00000080" allowed_cpuset="0x00800000,0x00000080" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="9" cpuset="0x00800000,0x00000080" complete_cpuset="0x00800000,0x00000080" online_cpuset="0x00800000,0x00000080" allowed_cpuset="0x00800000,0x00000080" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" online_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="55" cpuset="0x00800000,0x0" complete_cpuset="0x00800000,0x0" online_cpuset="0x00800000,0x0" allowed_cpuset="0x00800000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x01000000,0x00000100" complete_cpuset="0x01000000,0x00000100" online_cpuset="0x01000000,0x00000100" allowed_cpuset="0x01000000,0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x01000000,0x00000100" complete_cpuset="0x01000000,0x00000100" online_cpuset="0x01000000,0x00000100" allowed_cpuset="0x01000000,0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x01000000,0x00000100" complete_cpuset="0x01000000,0x00000100" online_cpuset="0x01000000,0x00000100" allowed_cpuset="0x01000000,0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="10" cpuset="0x01000000,0x00000100" complete_cpuset="0x01000000,0x00000100" online_cpuset="0x01000000,0x00000100" allowed_cpuset="0x01000000,0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="8" cpuset="0x00000100" complete_cpuset="0x00000100" online_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="56" cpuset="0x01000000,0x0" complete_cpuset="0x01000000,0x0" online_cpuset="0x01000000,0x0" allowed_cpuset="0x01000000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Cache" cpuset="0x0e000000,0x00000e00" complete_cpuset="0x0e000000,0x00000e00" online_cpuset="0x0e000000,0x00000e00" allowed_cpuset="0x0e000000,0x00000e00" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x02000000,0x00000200" complete_cpuset="0x02000000,0x00000200" online_cpuset="0x02000000,0x00000200" allowed_cpuset="0x02000000,0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x02000000,0x00000200" complete_cpuset="0x02000000,0x00000200" online_cpuset="0x02000000,0x00000200" allowed_cpuset="0x02000000,0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x02000000,0x00000200" complete_cpuset="0x02000000,0x00000200" online_cpuset="0x02000000,0x00000200" allowed_cpuset="0x02000000,0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="12" cpuset="0x02000000,0x00000200" complete_cpuset="0x02000000,0x00000200" online_cpuset="0x02000000,0x00000200" allowed_cpuset="0x02000000,0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" online_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="57" cpuset="0x02000000,0x0" complete_cpuset="0x02000000,0x0" online_cpuset="0x02000000,0x0" allowed_cpuset="0x02000000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x04000000,0x00000400" complete_cpuset="0x04000000,0x00000400" online_cpuset="0x04000000,0x00000400" allowed_cpuset="0x04000000,0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x04000000,0x00000400" complete_cpuset="0x04000000,0x00000400" online_cpuset="0x04000000,0x00000400" allowed_cpuset="0x04000000,0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x04000000,0x00000400" complete_cpuset="0x04000000,0x00000400" online_cpuset="0x04000000,0x00000400" allowed_cpuset="0x04000000,0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="13" cpuset="0x04000000,0x00000400" complete_cpuset="0x04000000,0x00000400" online_cpuset="0x04000000,0x00000400" allowed_cpuset="0x04000000,0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="10" cpuset="0x00000400" complete_cpuset="0x00000400" online_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="58" cpuset="0x04000000,0x0" complete_cpuset="0x04000000,0x0" online_cpuset="0x04000000,0x0" allowed_cpuset="0x04000000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x08000000,0x00000800" complete_cpuset="0x08000000,0x00000800" online_cpuset="0x08000000,0x00000800" allowed_cpuset="0x08000000,0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x08000000,0x00000800" complete_cpuset="0x08000000,0x00000800" online_cpuset="0x08000000,0x00000800" allowed_cpuset="0x08000000,0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x08000000,0x00000800" complete_cpuset="0x08000000,0x00000800" online_cpuset="0x08000000,0x00000800" allowed_cpuset="0x08000000,0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="14" cpuset="0x08000000,0x00000800" complete_cpuset="0x08000000,0x00000800" online_cpuset="0x08000000,0x00000800" allowed_cpuset="0x08000000,0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="11" cpuset="0x00000800" complete_cpuset="0x00000800" online_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="59" cpuset="0x08000000,0x0" complete_cpuset="0x08000000,0x0" online_cpuset="0x08000000,0x0" allowed_cpuset="0x08000000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="1" bridge_type="0-1" depth="0" bridge_pci="0000:[10-15]">
+          <object type="Bridge" os_index="65553" name="Advanced Micro Devices, Inc. [AMD] Family 17h (Models 00h-0fh) PCIe GPP Bridge" bridge_type="1-1" depth="1" bridge_pci="0000:[11-13]" pci_busid="0000:10:01.1" pci_type="0604 [1022:1453] [0000:0000] 00" pci_link_speed="3.938462">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+            <info name="PCIDevice" value="Family 17h (Models 00h-0fh) PCIe GPP Bridge"/>
+            <object type="Bridge" os_index="69632" name="Advanced Micro Devices, Inc. [AMD/ATI]" bridge_type="1-1" depth="2" bridge_pci="0000:[12-13]" pci_busid="0000:11:00.0" pci_type="0604 [1002:14a0] [0000:0000] 02" pci_link_speed="3.938462">
+              <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD/ATI]"/>
+              <object type="Bridge" os_index="73728" name="Advanced Micro Devices, Inc. [AMD/ATI]" bridge_type="1-1" depth="3" bridge_pci="0000:[13-13]" pci_busid="0000:12:00.0" pci_type="0604 [1002:14a1] [0000:0000] 00" pci_link_speed="31.507692">
+                <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD/ATI]"/>
+                <object type="PCIDev" os_index="77824" name="Advanced Micro Devices, Inc. [AMD/ATI] Vega 20" pci_busid="0000:13:00.0" pci_type="0380 [1002:66a1] [1002:0834] 02" pci_link_speed="31.507692">
+                  <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD/ATI]"/>
+                  <info name="PCIDevice" value="Vega 20"/>
+                  <object type="OSDev" name="card1" osdev_type="1"/>
+                  <object type="OSDev" name="renderD128" osdev_type="1"/>
+                  <object type="OSDev" name="controlD65" osdev_type="1"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="NUMANode" os_index="2" cpuset="0x00000003,0xf0000000,0x0003f000" complete_cpuset="0x00000003,0xf0000000,0x0003f000" online_cpuset="0x00000003,0xf0000000,0x0003f000" allowed_cpuset="0x00000003,0xf0000000,0x0003f000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" local_memory="33819574272">
+        <page_type size="4096" count="8256732"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+        <object type="Cache" cpuset="0x70000000,0x00007000" complete_cpuset="0x70000000,0x00007000" online_cpuset="0x70000000,0x00007000" allowed_cpuset="0x70000000,0x00007000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x10000000,0x00001000" complete_cpuset="0x10000000,0x00001000" online_cpuset="0x10000000,0x00001000" allowed_cpuset="0x10000000,0x00001000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x10000000,0x00001000" complete_cpuset="0x10000000,0x00001000" online_cpuset="0x10000000,0x00001000" allowed_cpuset="0x10000000,0x00001000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x10000000,0x00001000" complete_cpuset="0x10000000,0x00001000" online_cpuset="0x10000000,0x00001000" allowed_cpuset="0x10000000,0x00001000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="16" cpuset="0x10000000,0x00001000" complete_cpuset="0x10000000,0x00001000" online_cpuset="0x10000000,0x00001000" allowed_cpuset="0x10000000,0x00001000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004">
+                  <object type="PU" os_index="12" cpuset="0x00001000" complete_cpuset="0x00001000" online_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                  <object type="PU" os_index="60" cpuset="0x10000000,0x0" complete_cpuset="0x10000000,0x0" online_cpuset="0x10000000,0x0" allowed_cpuset="0x10000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x20000000,0x00002000" complete_cpuset="0x20000000,0x00002000" online_cpuset="0x20000000,0x00002000" allowed_cpuset="0x20000000,0x00002000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x20000000,0x00002000" complete_cpuset="0x20000000,0x00002000" online_cpuset="0x20000000,0x00002000" allowed_cpuset="0x20000000,0x00002000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x20000000,0x00002000" complete_cpuset="0x20000000,0x00002000" online_cpuset="0x20000000,0x00002000" allowed_cpuset="0x20000000,0x00002000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="17" cpuset="0x20000000,0x00002000" complete_cpuset="0x20000000,0x00002000" online_cpuset="0x20000000,0x00002000" allowed_cpuset="0x20000000,0x00002000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004">
+                  <object type="PU" os_index="13" cpuset="0x00002000" complete_cpuset="0x00002000" online_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                  <object type="PU" os_index="61" cpuset="0x20000000,0x0" complete_cpuset="0x20000000,0x0" online_cpuset="0x20000000,0x0" allowed_cpuset="0x20000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x40000000,0x00004000" complete_cpuset="0x40000000,0x00004000" online_cpuset="0x40000000,0x00004000" allowed_cpuset="0x40000000,0x00004000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x40000000,0x00004000" complete_cpuset="0x40000000,0x00004000" online_cpuset="0x40000000,0x00004000" allowed_cpuset="0x40000000,0x00004000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x40000000,0x00004000" complete_cpuset="0x40000000,0x00004000" online_cpuset="0x40000000,0x00004000" allowed_cpuset="0x40000000,0x00004000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="18" cpuset="0x40000000,0x00004000" complete_cpuset="0x40000000,0x00004000" online_cpuset="0x40000000,0x00004000" allowed_cpuset="0x40000000,0x00004000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004">
+                  <object type="PU" os_index="14" cpuset="0x00004000" complete_cpuset="0x00004000" online_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                  <object type="PU" os_index="62" cpuset="0x40000000,0x0" complete_cpuset="0x40000000,0x0" online_cpuset="0x40000000,0x0" allowed_cpuset="0x40000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Cache" cpuset="0x00000003,0x80000000,0x00038000" complete_cpuset="0x00000003,0x80000000,0x00038000" online_cpuset="0x00000003,0x80000000,0x00038000" allowed_cpuset="0x00000003,0x80000000,0x00038000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x80000000,0x00008000" complete_cpuset="0x80000000,0x00008000" online_cpuset="0x80000000,0x00008000" allowed_cpuset="0x80000000,0x00008000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x80000000,0x00008000" complete_cpuset="0x80000000,0x00008000" online_cpuset="0x80000000,0x00008000" allowed_cpuset="0x80000000,0x00008000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x80000000,0x00008000" complete_cpuset="0x80000000,0x00008000" online_cpuset="0x80000000,0x00008000" allowed_cpuset="0x80000000,0x00008000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="20" cpuset="0x80000000,0x00008000" complete_cpuset="0x80000000,0x00008000" online_cpuset="0x80000000,0x00008000" allowed_cpuset="0x80000000,0x00008000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004">
+                  <object type="PU" os_index="15" cpuset="0x00008000" complete_cpuset="0x00008000" online_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                  <object type="PU" os_index="63" cpuset="0x80000000,0x0" complete_cpuset="0x80000000,0x0" online_cpuset="0x80000000,0x0" allowed_cpuset="0x80000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000001,,0x00010000" complete_cpuset="0x00000001,,0x00010000" online_cpuset="0x00000001,,0x00010000" allowed_cpuset="0x00000001,,0x00010000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000001,,0x00010000" complete_cpuset="0x00000001,,0x00010000" online_cpuset="0x00000001,,0x00010000" allowed_cpuset="0x00000001,,0x00010000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000001,,0x00010000" complete_cpuset="0x00000001,,0x00010000" online_cpuset="0x00000001,,0x00010000" allowed_cpuset="0x00000001,,0x00010000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="21" cpuset="0x00000001,,0x00010000" complete_cpuset="0x00000001,,0x00010000" online_cpuset="0x00000001,,0x00010000" allowed_cpuset="0x00000001,,0x00010000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004">
+                  <object type="PU" os_index="16" cpuset="0x00010000" complete_cpuset="0x00010000" online_cpuset="0x00010000" allowed_cpuset="0x00010000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                  <object type="PU" os_index="64" cpuset="0x00000001,,0x0" complete_cpuset="0x00000001,,0x0" online_cpuset="0x00000001,,0x0" allowed_cpuset="0x00000001,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000002,,0x00020000" complete_cpuset="0x00000002,,0x00020000" online_cpuset="0x00000002,,0x00020000" allowed_cpuset="0x00000002,,0x00020000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000002,,0x00020000" complete_cpuset="0x00000002,,0x00020000" online_cpuset="0x00000002,,0x00020000" allowed_cpuset="0x00000002,,0x00020000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000002,,0x00020000" complete_cpuset="0x00000002,,0x00020000" online_cpuset="0x00000002,,0x00020000" allowed_cpuset="0x00000002,,0x00020000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="22" cpuset="0x00000002,,0x00020000" complete_cpuset="0x00000002,,0x00020000" online_cpuset="0x00000002,,0x00020000" allowed_cpuset="0x00000002,,0x00020000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004">
+                  <object type="PU" os_index="17" cpuset="0x00020000" complete_cpuset="0x00020000" online_cpuset="0x00020000" allowed_cpuset="0x00020000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                  <object type="PU" os_index="65" cpuset="0x00000002,,0x0" complete_cpuset="0x00000002,,0x0" online_cpuset="0x00000002,,0x0" allowed_cpuset="0x00000002,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="2" bridge_type="0-1" depth="0" bridge_pci="0000:[20-25]">
+          <object type="Bridge" os_index="131121" name="Advanced Micro Devices, Inc. [AMD] Family 17h (Models 00h-0fh) PCIe GPP Bridge" bridge_type="1-1" depth="1" bridge_pci="0000:[21-23]" pci_busid="0000:20:03.1" pci_type="0604 [1022:1453] [0000:0000] 00" pci_link_speed="3.938462">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+            <info name="PCIDevice" value="Family 17h (Models 00h-0fh) PCIe GPP Bridge"/>
+            <object type="Bridge" os_index="135168" name="Advanced Micro Devices, Inc. [AMD/ATI]" bridge_type="1-1" depth="2" bridge_pci="0000:[22-23]" pci_busid="0000:21:00.0" pci_type="0604 [1002:14a0] [0000:0000] 02" pci_link_speed="3.938462">
+              <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD/ATI]"/>
+              <object type="Bridge" os_index="139264" name="Advanced Micro Devices, Inc. [AMD/ATI]" bridge_type="1-1" depth="3" bridge_pci="0000:[23-23]" pci_busid="0000:22:00.0" pci_type="0604 [1002:14a1] [0000:0000] 00" pci_link_speed="31.507692">
+                <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD/ATI]"/>
+                <object type="PCIDev" os_index="143360" name="Advanced Micro Devices, Inc. [AMD/ATI] Vega 20" pci_busid="0000:23:00.0" pci_type="0380 [1002:66a1] [1002:0834] 02" pci_link_speed="31.507692">
+                  <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD/ATI]"/>
+                  <info name="PCIDevice" value="Vega 20"/>
+                  <object type="OSDev" name="card2" osdev_type="1"/>
+                  <object type="OSDev" name="renderD129" osdev_type="1"/>
+                  <object type="OSDev" name="controlD66" osdev_type="1"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="NUMANode" os_index="3" cpuset="0x000000fc,,0x00fc0000" complete_cpuset="0x000000fc,,0x00fc0000" online_cpuset="0x000000fc,,0x00fc0000" allowed_cpuset="0x000000fc,,0x00fc0000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" local_memory="33802997760">
+        <page_type size="4096" count="8252685"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+        <object type="Cache" cpuset="0x0000001c,,0x001c0000" complete_cpuset="0x0000001c,,0x001c0000" online_cpuset="0x0000001c,,0x001c0000" allowed_cpuset="0x0000001c,,0x001c0000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x00000004,,0x00040000" complete_cpuset="0x00000004,,0x00040000" online_cpuset="0x00000004,,0x00040000" allowed_cpuset="0x00000004,,0x00040000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000004,,0x00040000" complete_cpuset="0x00000004,,0x00040000" online_cpuset="0x00000004,,0x00040000" allowed_cpuset="0x00000004,,0x00040000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000004,,0x00040000" complete_cpuset="0x00000004,,0x00040000" online_cpuset="0x00000004,,0x00040000" allowed_cpuset="0x00000004,,0x00040000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="24" cpuset="0x00000004,,0x00040000" complete_cpuset="0x00000004,,0x00040000" online_cpuset="0x00000004,,0x00040000" allowed_cpuset="0x00000004,,0x00040000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008">
+                  <object type="PU" os_index="18" cpuset="0x00040000" complete_cpuset="0x00040000" online_cpuset="0x00040000" allowed_cpuset="0x00040000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                  <object type="PU" os_index="66" cpuset="0x00000004,,0x0" complete_cpuset="0x00000004,,0x0" online_cpuset="0x00000004,,0x0" allowed_cpuset="0x00000004,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000008,,0x00080000" complete_cpuset="0x00000008,,0x00080000" online_cpuset="0x00000008,,0x00080000" allowed_cpuset="0x00000008,,0x00080000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000008,,0x00080000" complete_cpuset="0x00000008,,0x00080000" online_cpuset="0x00000008,,0x00080000" allowed_cpuset="0x00000008,,0x00080000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000008,,0x00080000" complete_cpuset="0x00000008,,0x00080000" online_cpuset="0x00000008,,0x00080000" allowed_cpuset="0x00000008,,0x00080000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="25" cpuset="0x00000008,,0x00080000" complete_cpuset="0x00000008,,0x00080000" online_cpuset="0x00000008,,0x00080000" allowed_cpuset="0x00000008,,0x00080000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008">
+                  <object type="PU" os_index="19" cpuset="0x00080000" complete_cpuset="0x00080000" online_cpuset="0x00080000" allowed_cpuset="0x00080000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                  <object type="PU" os_index="67" cpuset="0x00000008,,0x0" complete_cpuset="0x00000008,,0x0" online_cpuset="0x00000008,,0x0" allowed_cpuset="0x00000008,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000010,,0x00100000" complete_cpuset="0x00000010,,0x00100000" online_cpuset="0x00000010,,0x00100000" allowed_cpuset="0x00000010,,0x00100000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000010,,0x00100000" complete_cpuset="0x00000010,,0x00100000" online_cpuset="0x00000010,,0x00100000" allowed_cpuset="0x00000010,,0x00100000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000010,,0x00100000" complete_cpuset="0x00000010,,0x00100000" online_cpuset="0x00000010,,0x00100000" allowed_cpuset="0x00000010,,0x00100000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="26" cpuset="0x00000010,,0x00100000" complete_cpuset="0x00000010,,0x00100000" online_cpuset="0x00000010,,0x00100000" allowed_cpuset="0x00000010,,0x00100000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008">
+                  <object type="PU" os_index="20" cpuset="0x00100000" complete_cpuset="0x00100000" online_cpuset="0x00100000" allowed_cpuset="0x00100000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                  <object type="PU" os_index="68" cpuset="0x00000010,,0x0" complete_cpuset="0x00000010,,0x0" online_cpuset="0x00000010,,0x0" allowed_cpuset="0x00000010,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Cache" cpuset="0x000000e0,,0x00e00000" complete_cpuset="0x000000e0,,0x00e00000" online_cpuset="0x000000e0,,0x00e00000" allowed_cpuset="0x000000e0,,0x00e00000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x00000020,,0x00200000" complete_cpuset="0x00000020,,0x00200000" online_cpuset="0x00000020,,0x00200000" allowed_cpuset="0x00000020,,0x00200000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000020,,0x00200000" complete_cpuset="0x00000020,,0x00200000" online_cpuset="0x00000020,,0x00200000" allowed_cpuset="0x00000020,,0x00200000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000020,,0x00200000" complete_cpuset="0x00000020,,0x00200000" online_cpuset="0x00000020,,0x00200000" allowed_cpuset="0x00000020,,0x00200000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="28" cpuset="0x00000020,,0x00200000" complete_cpuset="0x00000020,,0x00200000" online_cpuset="0x00000020,,0x00200000" allowed_cpuset="0x00000020,,0x00200000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008">
+                  <object type="PU" os_index="21" cpuset="0x00200000" complete_cpuset="0x00200000" online_cpuset="0x00200000" allowed_cpuset="0x00200000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                  <object type="PU" os_index="69" cpuset="0x00000020,,0x0" complete_cpuset="0x00000020,,0x0" online_cpuset="0x00000020,,0x0" allowed_cpuset="0x00000020,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000040,,0x00400000" complete_cpuset="0x00000040,,0x00400000" online_cpuset="0x00000040,,0x00400000" allowed_cpuset="0x00000040,,0x00400000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000040,,0x00400000" complete_cpuset="0x00000040,,0x00400000" online_cpuset="0x00000040,,0x00400000" allowed_cpuset="0x00000040,,0x00400000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000040,,0x00400000" complete_cpuset="0x00000040,,0x00400000" online_cpuset="0x00000040,,0x00400000" allowed_cpuset="0x00000040,,0x00400000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="29" cpuset="0x00000040,,0x00400000" complete_cpuset="0x00000040,,0x00400000" online_cpuset="0x00000040,,0x00400000" allowed_cpuset="0x00000040,,0x00400000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008">
+                  <object type="PU" os_index="22" cpuset="0x00400000" complete_cpuset="0x00400000" online_cpuset="0x00400000" allowed_cpuset="0x00400000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                  <object type="PU" os_index="70" cpuset="0x00000040,,0x0" complete_cpuset="0x00000040,,0x0" online_cpuset="0x00000040,,0x0" allowed_cpuset="0x00000040,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000080,,0x00800000" complete_cpuset="0x00000080,,0x00800000" online_cpuset="0x00000080,,0x00800000" allowed_cpuset="0x00000080,,0x00800000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000080,,0x00800000" complete_cpuset="0x00000080,,0x00800000" online_cpuset="0x00000080,,0x00800000" allowed_cpuset="0x00000080,,0x00800000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000080,,0x00800000" complete_cpuset="0x00000080,,0x00800000" online_cpuset="0x00000080,,0x00800000" allowed_cpuset="0x00000080,,0x00800000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="30" cpuset="0x00000080,,0x00800000" complete_cpuset="0x00000080,,0x00800000" online_cpuset="0x00000080,,0x00800000" allowed_cpuset="0x00000080,,0x00800000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008">
+                  <object type="PU" os_index="23" cpuset="0x00800000" complete_cpuset="0x00800000" online_cpuset="0x00800000" allowed_cpuset="0x00800000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                  <object type="PU" os_index="71" cpuset="0x00000080,,0x0" complete_cpuset="0x00000080,,0x0" online_cpuset="0x00000080,,0x0" allowed_cpuset="0x00000080,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="3" bridge_type="0-1" depth="0" bridge_pci="0000:[30-36]">
+          <object type="Bridge" os_index="196657" name="Advanced Micro Devices, Inc. [AMD] Family 17h (Models 00h-0fh) PCIe GPP Bridge" bridge_type="1-1" depth="1" bridge_pci="0000:[31-34]" pci_busid="0000:30:03.1" pci_type="0604 [1022:1453] [0000:0000] 00" pci_link_speed="15.753846">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+            <info name="PCIDevice" value="Family 17h (Models 00h-0fh) PCIe GPP Bridge"/>
+            <object type="Bridge" os_index="200704" name="PLX Technology, Inc. PEX 8747 48-Lane, 5-Port PCI Express Gen 3 (8.0 GT/s) Switch" bridge_type="1-1" depth="2" bridge_pci="0000:[32-34]" pci_busid="0000:31:00.0" pci_type="0604 [10b5:8747] [0000:0000] ca" pci_link_speed="15.753846">
+              <info name="PCIVendor" value="PLX Technology, Inc."/>
+              <info name="PCIDevice" value="PEX 8747 48-Lane, 5-Port PCI Express Gen 3 (8.0 GT/s) Switch"/>
+              <object type="Bridge" os_index="204928" name="PLX Technology, Inc. PEX 8747 48-Lane, 5-Port PCI Express Gen 3 (8.0 GT/s) Switch" bridge_type="1-1" depth="3" bridge_pci="0000:[33-33]" pci_busid="0000:32:08.0" pci_type="0604 [10b5:8747] [0000:0000] ca" pci_link_speed="15.753846">
+                <info name="PCIVendor" value="PLX Technology, Inc."/>
+                <info name="PCIDevice" value="PEX 8747 48-Lane, 5-Port PCI Express Gen 3 (8.0 GT/s) Switch"/>
+                <object type="PCIDev" os_index="208896" name="Mellanox Technologies MT28908 Family [ConnectX-6]" pci_busid="0000:33:00.0" pci_type="0207 [15b3:101b] [15b3:0006] 00" pci_link_speed="15.753846">
+                  <info name="PCIVendor" value="Mellanox Technologies"/>
+                  <info name="PCIDevice" value="MT28908 Family [ConnectX-6]"/>
+                  <object type="OSDev" name="hsi0" osdev_type="2">
+                    <info name="Address" value="80:00:01:07:fe:80:00:00:00:00:00:00:98:03:9b:03:00:82:9d:b4"/>
+                    <info name="Port" value="1"/>
+                  </object>
+                  <object type="OSDev" name="mlx5_0" osdev_type="3">
+                    <info name="NodeGUID" value="9803:9b03:0082:9db4"/>
+                    <info name="SysImageGUID" value="9803:9b03:0082:9db4"/>
+                    <info name="Port1State" value="4"/>
+                    <info name="Port1LID" value="0x1c"/>
+                    <info name="Port1LMC" value="0"/>
+                    <info name="Port1GID0" value="fe80:0000:0000:0000:9803:9b03:0082:9db4"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+    </object>
+    <object type="Package" os_index="1" cpuset="0xffffff00,0x0000ffff,0xff000000" complete_cpuset="0xffffff00,0x0000ffff,0xff000000" online_cpuset="0xffffff00,0x0000ffff,0xff000000" allowed_cpuset="0xffffff00,0x0000ffff,0xff000000" nodeset="0x000000f0" complete_nodeset="0x000000f0" allowed_nodeset="0x000000f0">
+      <info name="CPUVendor" value="AuthenticAMD"/>
+      <info name="CPUFamilyNumber" value="23"/>
+      <info name="CPUModelNumber" value="1"/>
+      <info name="CPUModel" value="AMD EPYC 7401 24-Core Processor"/>
+      <info name="CPUStepping" value="2"/>
+      <object type="NUMANode" os_index="4" cpuset="0x00003f00,,0x3f000000" complete_cpuset="0x00003f00,,0x3f000000" online_cpuset="0x00003f00,,0x3f000000" allowed_cpuset="0x00003f00,,0x3f000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" local_memory="33819574272">
+        <page_type size="4096" count="8256732"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+        <object type="Cache" cpuset="0x00000700,,0x07000000" complete_cpuset="0x00000700,,0x07000000" online_cpuset="0x00000700,,0x07000000" allowed_cpuset="0x00000700,,0x07000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x00000100,,0x01000000" complete_cpuset="0x00000100,,0x01000000" online_cpuset="0x00000100,,0x01000000" allowed_cpuset="0x00000100,,0x01000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000100,,0x01000000" complete_cpuset="0x00000100,,0x01000000" online_cpuset="0x00000100,,0x01000000" allowed_cpuset="0x00000100,,0x01000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000100,,0x01000000" complete_cpuset="0x00000100,,0x01000000" online_cpuset="0x00000100,,0x01000000" allowed_cpuset="0x00000100,,0x01000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="0" cpuset="0x00000100,,0x01000000" complete_cpuset="0x00000100,,0x01000000" online_cpuset="0x00000100,,0x01000000" allowed_cpuset="0x00000100,,0x01000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010">
+                  <object type="PU" os_index="24" cpuset="0x01000000" complete_cpuset="0x01000000" online_cpuset="0x01000000" allowed_cpuset="0x01000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
+                  <object type="PU" os_index="72" cpuset="0x00000100,,0x0" complete_cpuset="0x00000100,,0x0" online_cpuset="0x00000100,,0x0" allowed_cpuset="0x00000100,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000200,,0x02000000" complete_cpuset="0x00000200,,0x02000000" online_cpuset="0x00000200,,0x02000000" allowed_cpuset="0x00000200,,0x02000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000200,,0x02000000" complete_cpuset="0x00000200,,0x02000000" online_cpuset="0x00000200,,0x02000000" allowed_cpuset="0x00000200,,0x02000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000200,,0x02000000" complete_cpuset="0x00000200,,0x02000000" online_cpuset="0x00000200,,0x02000000" allowed_cpuset="0x00000200,,0x02000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="1" cpuset="0x00000200,,0x02000000" complete_cpuset="0x00000200,,0x02000000" online_cpuset="0x00000200,,0x02000000" allowed_cpuset="0x00000200,,0x02000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010">
+                  <object type="PU" os_index="25" cpuset="0x02000000" complete_cpuset="0x02000000" online_cpuset="0x02000000" allowed_cpuset="0x02000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
+                  <object type="PU" os_index="73" cpuset="0x00000200,,0x0" complete_cpuset="0x00000200,,0x0" online_cpuset="0x00000200,,0x0" allowed_cpuset="0x00000200,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000400,,0x04000000" complete_cpuset="0x00000400,,0x04000000" online_cpuset="0x00000400,,0x04000000" allowed_cpuset="0x00000400,,0x04000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000400,,0x04000000" complete_cpuset="0x00000400,,0x04000000" online_cpuset="0x00000400,,0x04000000" allowed_cpuset="0x00000400,,0x04000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000400,,0x04000000" complete_cpuset="0x00000400,,0x04000000" online_cpuset="0x00000400,,0x04000000" allowed_cpuset="0x00000400,,0x04000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="2" cpuset="0x00000400,,0x04000000" complete_cpuset="0x00000400,,0x04000000" online_cpuset="0x00000400,,0x04000000" allowed_cpuset="0x00000400,,0x04000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010">
+                  <object type="PU" os_index="26" cpuset="0x04000000" complete_cpuset="0x04000000" online_cpuset="0x04000000" allowed_cpuset="0x04000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
+                  <object type="PU" os_index="74" cpuset="0x00000400,,0x0" complete_cpuset="0x00000400,,0x0" online_cpuset="0x00000400,,0x0" allowed_cpuset="0x00000400,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Cache" cpuset="0x00003800,,0x38000000" complete_cpuset="0x00003800,,0x38000000" online_cpuset="0x00003800,,0x38000000" allowed_cpuset="0x00003800,,0x38000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x00000800,,0x08000000" complete_cpuset="0x00000800,,0x08000000" online_cpuset="0x00000800,,0x08000000" allowed_cpuset="0x00000800,,0x08000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000800,,0x08000000" complete_cpuset="0x00000800,,0x08000000" online_cpuset="0x00000800,,0x08000000" allowed_cpuset="0x00000800,,0x08000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000800,,0x08000000" complete_cpuset="0x00000800,,0x08000000" online_cpuset="0x00000800,,0x08000000" allowed_cpuset="0x00000800,,0x08000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="4" cpuset="0x00000800,,0x08000000" complete_cpuset="0x00000800,,0x08000000" online_cpuset="0x00000800,,0x08000000" allowed_cpuset="0x00000800,,0x08000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010">
+                  <object type="PU" os_index="27" cpuset="0x08000000" complete_cpuset="0x08000000" online_cpuset="0x08000000" allowed_cpuset="0x08000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
+                  <object type="PU" os_index="75" cpuset="0x00000800,,0x0" complete_cpuset="0x00000800,,0x0" online_cpuset="0x00000800,,0x0" allowed_cpuset="0x00000800,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00001000,,0x10000000" complete_cpuset="0x00001000,,0x10000000" online_cpuset="0x00001000,,0x10000000" allowed_cpuset="0x00001000,,0x10000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00001000,,0x10000000" complete_cpuset="0x00001000,,0x10000000" online_cpuset="0x00001000,,0x10000000" allowed_cpuset="0x00001000,,0x10000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00001000,,0x10000000" complete_cpuset="0x00001000,,0x10000000" online_cpuset="0x00001000,,0x10000000" allowed_cpuset="0x00001000,,0x10000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="5" cpuset="0x00001000,,0x10000000" complete_cpuset="0x00001000,,0x10000000" online_cpuset="0x00001000,,0x10000000" allowed_cpuset="0x00001000,,0x10000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010">
+                  <object type="PU" os_index="28" cpuset="0x10000000" complete_cpuset="0x10000000" online_cpuset="0x10000000" allowed_cpuset="0x10000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
+                  <object type="PU" os_index="76" cpuset="0x00001000,,0x0" complete_cpuset="0x00001000,,0x0" online_cpuset="0x00001000,,0x0" allowed_cpuset="0x00001000,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00002000,,0x20000000" complete_cpuset="0x00002000,,0x20000000" online_cpuset="0x00002000,,0x20000000" allowed_cpuset="0x00002000,,0x20000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00002000,,0x20000000" complete_cpuset="0x00002000,,0x20000000" online_cpuset="0x00002000,,0x20000000" allowed_cpuset="0x00002000,,0x20000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00002000,,0x20000000" complete_cpuset="0x00002000,,0x20000000" online_cpuset="0x00002000,,0x20000000" allowed_cpuset="0x00002000,,0x20000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="6" cpuset="0x00002000,,0x20000000" complete_cpuset="0x00002000,,0x20000000" online_cpuset="0x00002000,,0x20000000" allowed_cpuset="0x00002000,,0x20000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010">
+                  <object type="PU" os_index="29" cpuset="0x20000000" complete_cpuset="0x20000000" online_cpuset="0x20000000" allowed_cpuset="0x20000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
+                  <object type="PU" os_index="77" cpuset="0x00002000,,0x0" complete_cpuset="0x00002000,,0x0" online_cpuset="0x00002000,,0x0" allowed_cpuset="0x00002000,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="NUMANode" os_index="5" cpuset="0x000fc000,0x0000000f,0xc0000000" complete_cpuset="0x000fc000,0x0000000f,0xc0000000" online_cpuset="0x000fc000,0x0000000f,0xc0000000" allowed_cpuset="0x000fc000,0x0000000f,0xc0000000" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" local_memory="33819570176">
+        <page_type size="4096" count="8256731"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+        <object type="Cache" cpuset="0x0001c000,0x00000001,0xc0000000" complete_cpuset="0x0001c000,0x00000001,0xc0000000" online_cpuset="0x0001c000,0x00000001,0xc0000000" allowed_cpuset="0x0001c000,0x00000001,0xc0000000" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x00004000,,0x40000000" complete_cpuset="0x00004000,,0x40000000" online_cpuset="0x00004000,,0x40000000" allowed_cpuset="0x00004000,,0x40000000" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00004000,,0x40000000" complete_cpuset="0x00004000,,0x40000000" online_cpuset="0x00004000,,0x40000000" allowed_cpuset="0x00004000,,0x40000000" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00004000,,0x40000000" complete_cpuset="0x00004000,,0x40000000" online_cpuset="0x00004000,,0x40000000" allowed_cpuset="0x00004000,,0x40000000" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="8" cpuset="0x00004000,,0x40000000" complete_cpuset="0x00004000,,0x40000000" online_cpuset="0x00004000,,0x40000000" allowed_cpuset="0x00004000,,0x40000000" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020">
+                  <object type="PU" os_index="30" cpuset="0x40000000" complete_cpuset="0x40000000" online_cpuset="0x40000000" allowed_cpuset="0x40000000" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
+                  <object type="PU" os_index="78" cpuset="0x00004000,,0x0" complete_cpuset="0x00004000,,0x0" online_cpuset="0x00004000,,0x0" allowed_cpuset="0x00004000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00008000,,0x80000000" complete_cpuset="0x00008000,,0x80000000" online_cpuset="0x00008000,,0x80000000" allowed_cpuset="0x00008000,,0x80000000" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00008000,,0x80000000" complete_cpuset="0x00008000,,0x80000000" online_cpuset="0x00008000,,0x80000000" allowed_cpuset="0x00008000,,0x80000000" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00008000,,0x80000000" complete_cpuset="0x00008000,,0x80000000" online_cpuset="0x00008000,,0x80000000" allowed_cpuset="0x00008000,,0x80000000" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="9" cpuset="0x00008000,,0x80000000" complete_cpuset="0x00008000,,0x80000000" online_cpuset="0x00008000,,0x80000000" allowed_cpuset="0x00008000,,0x80000000" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020">
+                  <object type="PU" os_index="31" cpuset="0x80000000" complete_cpuset="0x80000000" online_cpuset="0x80000000" allowed_cpuset="0x80000000" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
+                  <object type="PU" os_index="79" cpuset="0x00008000,,0x0" complete_cpuset="0x00008000,,0x0" online_cpuset="0x00008000,,0x0" allowed_cpuset="0x00008000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00010000,0x00000001,0x0" complete_cpuset="0x00010000,0x00000001,0x0" online_cpuset="0x00010000,0x00000001,0x0" allowed_cpuset="0x00010000,0x00000001,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00010000,0x00000001,0x0" complete_cpuset="0x00010000,0x00000001,0x0" online_cpuset="0x00010000,0x00000001,0x0" allowed_cpuset="0x00010000,0x00000001,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00010000,0x00000001,0x0" complete_cpuset="0x00010000,0x00000001,0x0" online_cpuset="0x00010000,0x00000001,0x0" allowed_cpuset="0x00010000,0x00000001,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="10" cpuset="0x00010000,0x00000001,0x0" complete_cpuset="0x00010000,0x00000001,0x0" online_cpuset="0x00010000,0x00000001,0x0" allowed_cpuset="0x00010000,0x00000001,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020">
+                  <object type="PU" os_index="32" cpuset="0x00000001,0x0" complete_cpuset="0x00000001,0x0" online_cpuset="0x00000001,0x0" allowed_cpuset="0x00000001,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
+                  <object type="PU" os_index="80" cpuset="0x00010000,,0x0" complete_cpuset="0x00010000,,0x0" online_cpuset="0x00010000,,0x0" allowed_cpuset="0x00010000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Cache" cpuset="0x000e0000,0x0000000e,0x0" complete_cpuset="0x000e0000,0x0000000e,0x0" online_cpuset="0x000e0000,0x0000000e,0x0" allowed_cpuset="0x000e0000,0x0000000e,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x00020000,0x00000002,0x0" complete_cpuset="0x00020000,0x00000002,0x0" online_cpuset="0x00020000,0x00000002,0x0" allowed_cpuset="0x00020000,0x00000002,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00020000,0x00000002,0x0" complete_cpuset="0x00020000,0x00000002,0x0" online_cpuset="0x00020000,0x00000002,0x0" allowed_cpuset="0x00020000,0x00000002,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00020000,0x00000002,0x0" complete_cpuset="0x00020000,0x00000002,0x0" online_cpuset="0x00020000,0x00000002,0x0" allowed_cpuset="0x00020000,0x00000002,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="12" cpuset="0x00020000,0x00000002,0x0" complete_cpuset="0x00020000,0x00000002,0x0" online_cpuset="0x00020000,0x00000002,0x0" allowed_cpuset="0x00020000,0x00000002,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020">
+                  <object type="PU" os_index="33" cpuset="0x00000002,0x0" complete_cpuset="0x00000002,0x0" online_cpuset="0x00000002,0x0" allowed_cpuset="0x00000002,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
+                  <object type="PU" os_index="81" cpuset="0x00020000,,0x0" complete_cpuset="0x00020000,,0x0" online_cpuset="0x00020000,,0x0" allowed_cpuset="0x00020000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00040000,0x00000004,0x0" complete_cpuset="0x00040000,0x00000004,0x0" online_cpuset="0x00040000,0x00000004,0x0" allowed_cpuset="0x00040000,0x00000004,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00040000,0x00000004,0x0" complete_cpuset="0x00040000,0x00000004,0x0" online_cpuset="0x00040000,0x00000004,0x0" allowed_cpuset="0x00040000,0x00000004,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00040000,0x00000004,0x0" complete_cpuset="0x00040000,0x00000004,0x0" online_cpuset="0x00040000,0x00000004,0x0" allowed_cpuset="0x00040000,0x00000004,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="13" cpuset="0x00040000,0x00000004,0x0" complete_cpuset="0x00040000,0x00000004,0x0" online_cpuset="0x00040000,0x00000004,0x0" allowed_cpuset="0x00040000,0x00000004,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020">
+                  <object type="PU" os_index="34" cpuset="0x00000004,0x0" complete_cpuset="0x00000004,0x0" online_cpuset="0x00000004,0x0" allowed_cpuset="0x00000004,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
+                  <object type="PU" os_index="82" cpuset="0x00040000,,0x0" complete_cpuset="0x00040000,,0x0" online_cpuset="0x00040000,,0x0" allowed_cpuset="0x00040000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00080000,0x00000008,0x0" complete_cpuset="0x00080000,0x00000008,0x0" online_cpuset="0x00080000,0x00000008,0x0" allowed_cpuset="0x00080000,0x00000008,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00080000,0x00000008,0x0" complete_cpuset="0x00080000,0x00000008,0x0" online_cpuset="0x00080000,0x00000008,0x0" allowed_cpuset="0x00080000,0x00000008,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00080000,0x00000008,0x0" complete_cpuset="0x00080000,0x00000008,0x0" online_cpuset="0x00080000,0x00000008,0x0" allowed_cpuset="0x00080000,0x00000008,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="14" cpuset="0x00080000,0x00000008,0x0" complete_cpuset="0x00080000,0x00000008,0x0" online_cpuset="0x00080000,0x00000008,0x0" allowed_cpuset="0x00080000,0x00000008,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020">
+                  <object type="PU" os_index="35" cpuset="0x00000008,0x0" complete_cpuset="0x00000008,0x0" online_cpuset="0x00000008,0x0" allowed_cpuset="0x00000008,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
+                  <object type="PU" os_index="83" cpuset="0x00080000,,0x0" complete_cpuset="0x00080000,,0x0" online_cpuset="0x00080000,,0x0" allowed_cpuset="0x00080000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="5" bridge_type="0-1" depth="0" bridge_pci="0000:[50-55]">
+          <object type="Bridge" os_index="327697" name="Advanced Micro Devices, Inc. [AMD] Family 17h (Models 00h-0fh) PCIe GPP Bridge" bridge_type="1-1" depth="1" bridge_pci="0000:[51-53]" pci_busid="0000:50:01.1" pci_type="0604 [1022:1453] [0000:0000] 00" pci_link_speed="3.938462">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+            <info name="PCIDevice" value="Family 17h (Models 00h-0fh) PCIe GPP Bridge"/>
+            <object type="Bridge" os_index="331776" name="Advanced Micro Devices, Inc. [AMD/ATI]" bridge_type="1-1" depth="2" bridge_pci="0000:[52-53]" pci_busid="0000:51:00.0" pci_type="0604 [1002:14a0] [0000:0000] 02" pci_link_speed="3.938462">
+              <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD/ATI]"/>
+              <object type="Bridge" os_index="335872" name="Advanced Micro Devices, Inc. [AMD/ATI]" bridge_type="1-1" depth="3" bridge_pci="0000:[53-53]" pci_busid="0000:52:00.0" pci_type="0604 [1002:14a1] [0000:0000] 00" pci_link_speed="31.507692">
+                <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD/ATI]"/>
+                <object type="PCIDev" os_index="339968" name="Advanced Micro Devices, Inc. [AMD/ATI] Vega 20" pci_busid="0000:53:00.0" pci_type="0380 [1002:66a1] [1002:0834] 02" pci_link_speed="31.507692">
+                  <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD/ATI]"/>
+                  <info name="PCIDevice" value="Vega 20"/>
+                  <object type="OSDev" name="card3" osdev_type="1"/>
+                  <object type="OSDev" name="renderD130" osdev_type="1"/>
+                  <object type="OSDev" name="controlD67" osdev_type="1"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="NUMANode" os_index="6" cpuset="0x03f00000,0x000003f0,0x0" complete_cpuset="0x03f00000,0x000003f0,0x0" online_cpuset="0x03f00000,0x000003f0,0x0" allowed_cpuset="0x03f00000,0x000003f0,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" local_memory="33819574272">
+        <page_type size="4096" count="8256732"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+        <object type="Cache" cpuset="0x00700000,0x00000070,0x0" complete_cpuset="0x00700000,0x00000070,0x0" online_cpuset="0x00700000,0x00000070,0x0" allowed_cpuset="0x00700000,0x00000070,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x00100000,0x00000010,0x0" complete_cpuset="0x00100000,0x00000010,0x0" online_cpuset="0x00100000,0x00000010,0x0" allowed_cpuset="0x00100000,0x00000010,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00100000,0x00000010,0x0" complete_cpuset="0x00100000,0x00000010,0x0" online_cpuset="0x00100000,0x00000010,0x0" allowed_cpuset="0x00100000,0x00000010,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00100000,0x00000010,0x0" complete_cpuset="0x00100000,0x00000010,0x0" online_cpuset="0x00100000,0x00000010,0x0" allowed_cpuset="0x00100000,0x00000010,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="16" cpuset="0x00100000,0x00000010,0x0" complete_cpuset="0x00100000,0x00000010,0x0" online_cpuset="0x00100000,0x00000010,0x0" allowed_cpuset="0x00100000,0x00000010,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040">
+                  <object type="PU" os_index="36" cpuset="0x00000010,0x0" complete_cpuset="0x00000010,0x0" online_cpuset="0x00000010,0x0" allowed_cpuset="0x00000010,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
+                  <object type="PU" os_index="84" cpuset="0x00100000,,0x0" complete_cpuset="0x00100000,,0x0" online_cpuset="0x00100000,,0x0" allowed_cpuset="0x00100000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00200000,0x00000020,0x0" complete_cpuset="0x00200000,0x00000020,0x0" online_cpuset="0x00200000,0x00000020,0x0" allowed_cpuset="0x00200000,0x00000020,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00200000,0x00000020,0x0" complete_cpuset="0x00200000,0x00000020,0x0" online_cpuset="0x00200000,0x00000020,0x0" allowed_cpuset="0x00200000,0x00000020,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00200000,0x00000020,0x0" complete_cpuset="0x00200000,0x00000020,0x0" online_cpuset="0x00200000,0x00000020,0x0" allowed_cpuset="0x00200000,0x00000020,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="17" cpuset="0x00200000,0x00000020,0x0" complete_cpuset="0x00200000,0x00000020,0x0" online_cpuset="0x00200000,0x00000020,0x0" allowed_cpuset="0x00200000,0x00000020,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040">
+                  <object type="PU" os_index="37" cpuset="0x00000020,0x0" complete_cpuset="0x00000020,0x0" online_cpuset="0x00000020,0x0" allowed_cpuset="0x00000020,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
+                  <object type="PU" os_index="85" cpuset="0x00200000,,0x0" complete_cpuset="0x00200000,,0x0" online_cpuset="0x00200000,,0x0" allowed_cpuset="0x00200000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00400000,0x00000040,0x0" complete_cpuset="0x00400000,0x00000040,0x0" online_cpuset="0x00400000,0x00000040,0x0" allowed_cpuset="0x00400000,0x00000040,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00400000,0x00000040,0x0" complete_cpuset="0x00400000,0x00000040,0x0" online_cpuset="0x00400000,0x00000040,0x0" allowed_cpuset="0x00400000,0x00000040,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00400000,0x00000040,0x0" complete_cpuset="0x00400000,0x00000040,0x0" online_cpuset="0x00400000,0x00000040,0x0" allowed_cpuset="0x00400000,0x00000040,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="18" cpuset="0x00400000,0x00000040,0x0" complete_cpuset="0x00400000,0x00000040,0x0" online_cpuset="0x00400000,0x00000040,0x0" allowed_cpuset="0x00400000,0x00000040,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040">
+                  <object type="PU" os_index="38" cpuset="0x00000040,0x0" complete_cpuset="0x00000040,0x0" online_cpuset="0x00000040,0x0" allowed_cpuset="0x00000040,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
+                  <object type="PU" os_index="86" cpuset="0x00400000,,0x0" complete_cpuset="0x00400000,,0x0" online_cpuset="0x00400000,,0x0" allowed_cpuset="0x00400000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Cache" cpuset="0x03800000,0x00000380,0x0" complete_cpuset="0x03800000,0x00000380,0x0" online_cpuset="0x03800000,0x00000380,0x0" allowed_cpuset="0x03800000,0x00000380,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x00800000,0x00000080,0x0" complete_cpuset="0x00800000,0x00000080,0x0" online_cpuset="0x00800000,0x00000080,0x0" allowed_cpuset="0x00800000,0x00000080,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00800000,0x00000080,0x0" complete_cpuset="0x00800000,0x00000080,0x0" online_cpuset="0x00800000,0x00000080,0x0" allowed_cpuset="0x00800000,0x00000080,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00800000,0x00000080,0x0" complete_cpuset="0x00800000,0x00000080,0x0" online_cpuset="0x00800000,0x00000080,0x0" allowed_cpuset="0x00800000,0x00000080,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="20" cpuset="0x00800000,0x00000080,0x0" complete_cpuset="0x00800000,0x00000080,0x0" online_cpuset="0x00800000,0x00000080,0x0" allowed_cpuset="0x00800000,0x00000080,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040">
+                  <object type="PU" os_index="39" cpuset="0x00000080,0x0" complete_cpuset="0x00000080,0x0" online_cpuset="0x00000080,0x0" allowed_cpuset="0x00000080,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
+                  <object type="PU" os_index="87" cpuset="0x00800000,,0x0" complete_cpuset="0x00800000,,0x0" online_cpuset="0x00800000,,0x0" allowed_cpuset="0x00800000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x01000000,0x00000100,0x0" complete_cpuset="0x01000000,0x00000100,0x0" online_cpuset="0x01000000,0x00000100,0x0" allowed_cpuset="0x01000000,0x00000100,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x01000000,0x00000100,0x0" complete_cpuset="0x01000000,0x00000100,0x0" online_cpuset="0x01000000,0x00000100,0x0" allowed_cpuset="0x01000000,0x00000100,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x01000000,0x00000100,0x0" complete_cpuset="0x01000000,0x00000100,0x0" online_cpuset="0x01000000,0x00000100,0x0" allowed_cpuset="0x01000000,0x00000100,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="21" cpuset="0x01000000,0x00000100,0x0" complete_cpuset="0x01000000,0x00000100,0x0" online_cpuset="0x01000000,0x00000100,0x0" allowed_cpuset="0x01000000,0x00000100,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040">
+                  <object type="PU" os_index="40" cpuset="0x00000100,0x0" complete_cpuset="0x00000100,0x0" online_cpuset="0x00000100,0x0" allowed_cpuset="0x00000100,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
+                  <object type="PU" os_index="88" cpuset="0x01000000,,0x0" complete_cpuset="0x01000000,,0x0" online_cpuset="0x01000000,,0x0" allowed_cpuset="0x01000000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x02000000,0x00000200,0x0" complete_cpuset="0x02000000,0x00000200,0x0" online_cpuset="0x02000000,0x00000200,0x0" allowed_cpuset="0x02000000,0x00000200,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x02000000,0x00000200,0x0" complete_cpuset="0x02000000,0x00000200,0x0" online_cpuset="0x02000000,0x00000200,0x0" allowed_cpuset="0x02000000,0x00000200,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x02000000,0x00000200,0x0" complete_cpuset="0x02000000,0x00000200,0x0" online_cpuset="0x02000000,0x00000200,0x0" allowed_cpuset="0x02000000,0x00000200,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="22" cpuset="0x02000000,0x00000200,0x0" complete_cpuset="0x02000000,0x00000200,0x0" online_cpuset="0x02000000,0x00000200,0x0" allowed_cpuset="0x02000000,0x00000200,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040">
+                  <object type="PU" os_index="41" cpuset="0x00000200,0x0" complete_cpuset="0x00000200,0x0" online_cpuset="0x00000200,0x0" allowed_cpuset="0x00000200,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
+                  <object type="PU" os_index="89" cpuset="0x02000000,,0x0" complete_cpuset="0x02000000,,0x0" online_cpuset="0x02000000,,0x0" allowed_cpuset="0x02000000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="NUMANode" os_index="7" cpuset="0xfc000000,0x0000fc00,0x0" complete_cpuset="0xfc000000,0x0000fc00,0x0" online_cpuset="0xfc000000,0x0000fc00,0x0" allowed_cpuset="0xfc000000,0x0000fc00,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" local_memory="33819033600">
+        <page_type size="4096" count="8256600"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+        <object type="Cache" cpuset="0x1c000000,0x00001c00,0x0" complete_cpuset="0x1c000000,0x00001c00,0x0" online_cpuset="0x1c000000,0x00001c00,0x0" allowed_cpuset="0x1c000000,0x00001c00,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x04000000,0x00000400,0x0" complete_cpuset="0x04000000,0x00000400,0x0" online_cpuset="0x04000000,0x00000400,0x0" allowed_cpuset="0x04000000,0x00000400,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x04000000,0x00000400,0x0" complete_cpuset="0x04000000,0x00000400,0x0" online_cpuset="0x04000000,0x00000400,0x0" allowed_cpuset="0x04000000,0x00000400,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x04000000,0x00000400,0x0" complete_cpuset="0x04000000,0x00000400,0x0" online_cpuset="0x04000000,0x00000400,0x0" allowed_cpuset="0x04000000,0x00000400,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="24" cpuset="0x04000000,0x00000400,0x0" complete_cpuset="0x04000000,0x00000400,0x0" online_cpuset="0x04000000,0x00000400,0x0" allowed_cpuset="0x04000000,0x00000400,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080">
+                  <object type="PU" os_index="42" cpuset="0x00000400,0x0" complete_cpuset="0x00000400,0x0" online_cpuset="0x00000400,0x0" allowed_cpuset="0x00000400,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
+                  <object type="PU" os_index="90" cpuset="0x04000000,,0x0" complete_cpuset="0x04000000,,0x0" online_cpuset="0x04000000,,0x0" allowed_cpuset="0x04000000,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x08000000,0x00000800,0x0" complete_cpuset="0x08000000,0x00000800,0x0" online_cpuset="0x08000000,0x00000800,0x0" allowed_cpuset="0x08000000,0x00000800,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x08000000,0x00000800,0x0" complete_cpuset="0x08000000,0x00000800,0x0" online_cpuset="0x08000000,0x00000800,0x0" allowed_cpuset="0x08000000,0x00000800,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x08000000,0x00000800,0x0" complete_cpuset="0x08000000,0x00000800,0x0" online_cpuset="0x08000000,0x00000800,0x0" allowed_cpuset="0x08000000,0x00000800,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="25" cpuset="0x08000000,0x00000800,0x0" complete_cpuset="0x08000000,0x00000800,0x0" online_cpuset="0x08000000,0x00000800,0x0" allowed_cpuset="0x08000000,0x00000800,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080">
+                  <object type="PU" os_index="43" cpuset="0x00000800,0x0" complete_cpuset="0x00000800,0x0" online_cpuset="0x00000800,0x0" allowed_cpuset="0x00000800,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
+                  <object type="PU" os_index="91" cpuset="0x08000000,,0x0" complete_cpuset="0x08000000,,0x0" online_cpuset="0x08000000,,0x0" allowed_cpuset="0x08000000,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x10000000,0x00001000,0x0" complete_cpuset="0x10000000,0x00001000,0x0" online_cpuset="0x10000000,0x00001000,0x0" allowed_cpuset="0x10000000,0x00001000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x10000000,0x00001000,0x0" complete_cpuset="0x10000000,0x00001000,0x0" online_cpuset="0x10000000,0x00001000,0x0" allowed_cpuset="0x10000000,0x00001000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x10000000,0x00001000,0x0" complete_cpuset="0x10000000,0x00001000,0x0" online_cpuset="0x10000000,0x00001000,0x0" allowed_cpuset="0x10000000,0x00001000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="26" cpuset="0x10000000,0x00001000,0x0" complete_cpuset="0x10000000,0x00001000,0x0" online_cpuset="0x10000000,0x00001000,0x0" allowed_cpuset="0x10000000,0x00001000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080">
+                  <object type="PU" os_index="44" cpuset="0x00001000,0x0" complete_cpuset="0x00001000,0x0" online_cpuset="0x00001000,0x0" allowed_cpuset="0x00001000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
+                  <object type="PU" os_index="92" cpuset="0x10000000,,0x0" complete_cpuset="0x10000000,,0x0" online_cpuset="0x10000000,,0x0" allowed_cpuset="0x10000000,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Cache" cpuset="0xe0000000,0x0000e000,0x0" complete_cpuset="0xe0000000,0x0000e000,0x0" online_cpuset="0xe0000000,0x0000e000,0x0" allowed_cpuset="0xe0000000,0x0000e000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x20000000,0x00002000,0x0" complete_cpuset="0x20000000,0x00002000,0x0" online_cpuset="0x20000000,0x00002000,0x0" allowed_cpuset="0x20000000,0x00002000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x20000000,0x00002000,0x0" complete_cpuset="0x20000000,0x00002000,0x0" online_cpuset="0x20000000,0x00002000,0x0" allowed_cpuset="0x20000000,0x00002000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x20000000,0x00002000,0x0" complete_cpuset="0x20000000,0x00002000,0x0" online_cpuset="0x20000000,0x00002000,0x0" allowed_cpuset="0x20000000,0x00002000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="28" cpuset="0x20000000,0x00002000,0x0" complete_cpuset="0x20000000,0x00002000,0x0" online_cpuset="0x20000000,0x00002000,0x0" allowed_cpuset="0x20000000,0x00002000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080">
+                  <object type="PU" os_index="45" cpuset="0x00002000,0x0" complete_cpuset="0x00002000,0x0" online_cpuset="0x00002000,0x0" allowed_cpuset="0x00002000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
+                  <object type="PU" os_index="93" cpuset="0x20000000,,0x0" complete_cpuset="0x20000000,,0x0" online_cpuset="0x20000000,,0x0" allowed_cpuset="0x20000000,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x40000000,0x00004000,0x0" complete_cpuset="0x40000000,0x00004000,0x0" online_cpuset="0x40000000,0x00004000,0x0" allowed_cpuset="0x40000000,0x00004000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x40000000,0x00004000,0x0" complete_cpuset="0x40000000,0x00004000,0x0" online_cpuset="0x40000000,0x00004000,0x0" allowed_cpuset="0x40000000,0x00004000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x40000000,0x00004000,0x0" complete_cpuset="0x40000000,0x00004000,0x0" online_cpuset="0x40000000,0x00004000,0x0" allowed_cpuset="0x40000000,0x00004000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="29" cpuset="0x40000000,0x00004000,0x0" complete_cpuset="0x40000000,0x00004000,0x0" online_cpuset="0x40000000,0x00004000,0x0" allowed_cpuset="0x40000000,0x00004000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080">
+                  <object type="PU" os_index="46" cpuset="0x00004000,0x0" complete_cpuset="0x00004000,0x0" online_cpuset="0x00004000,0x0" allowed_cpuset="0x00004000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
+                  <object type="PU" os_index="94" cpuset="0x40000000,,0x0" complete_cpuset="0x40000000,,0x0" online_cpuset="0x40000000,,0x0" allowed_cpuset="0x40000000,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x80000000,0x00008000,0x0" complete_cpuset="0x80000000,0x00008000,0x0" online_cpuset="0x80000000,0x00008000,0x0" allowed_cpuset="0x80000000,0x00008000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x80000000,0x00008000,0x0" complete_cpuset="0x80000000,0x00008000,0x0" online_cpuset="0x80000000,0x00008000,0x0" allowed_cpuset="0x80000000,0x00008000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x80000000,0x00008000,0x0" complete_cpuset="0x80000000,0x00008000,0x0" online_cpuset="0x80000000,0x00008000,0x0" allowed_cpuset="0x80000000,0x00008000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="30" cpuset="0x80000000,0x00008000,0x0" complete_cpuset="0x80000000,0x00008000,0x0" online_cpuset="0x80000000,0x00008000,0x0" allowed_cpuset="0x80000000,0x00008000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080">
+                  <object type="PU" os_index="47" cpuset="0x00008000,0x0" complete_cpuset="0x00008000,0x0" online_cpuset="0x00008000,0x0" allowed_cpuset="0x00008000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
+                  <object type="PU" os_index="95" cpuset="0x80000000,,0x0" complete_cpuset="0x80000000,,0x0" online_cpuset="0x80000000,,0x0" allowed_cpuset="0x80000000,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" os_index="7" bridge_type="0-1" depth="0" bridge_pci="0000:[70-75]">
+          <object type="Bridge" os_index="458801" name="Advanced Micro Devices, Inc. [AMD] Family 17h (Models 00h-0fh) PCIe GPP Bridge" bridge_type="1-1" depth="1" bridge_pci="0000:[71-73]" pci_busid="0000:70:03.1" pci_type="0604 [1022:1453] [0000:0000] 00" pci_link_speed="3.938462">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+            <info name="PCIDevice" value="Family 17h (Models 00h-0fh) PCIe GPP Bridge"/>
+            <object type="Bridge" os_index="462848" name="Advanced Micro Devices, Inc. [AMD/ATI]" bridge_type="1-1" depth="2" bridge_pci="0000:[72-73]" pci_busid="0000:71:00.0" pci_type="0604 [1002:14a0] [0000:0000] 02" pci_link_speed="3.938462">
+              <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD/ATI]"/>
+              <object type="Bridge" os_index="466944" name="Advanced Micro Devices, Inc. [AMD/ATI]" bridge_type="1-1" depth="3" bridge_pci="0000:[73-73]" pci_busid="0000:72:00.0" pci_type="0604 [1002:14a1] [0000:0000] 00" pci_link_speed="31.507692">
+                <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD/ATI]"/>
+                <object type="PCIDev" os_index="471040" name="Advanced Micro Devices, Inc. [AMD/ATI] Vega 20" pci_busid="0000:73:00.0" pci_type="0380 [1002:66a1] [1002:0834] 02" pci_link_speed="31.507692">
+                  <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD/ATI]"/>
+                  <info name="PCIDevice" value="Vega 20"/>
+                  <object type="OSDev" name="card4" osdev_type="1"/>
+                  <object type="OSDev" name="renderD131" osdev_type="1"/>
+                  <object type="OSDev" name="controlD68" osdev_type="1"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+    </object>
+  </object>
+</topology>

--- a/t/hwloc-data/1N/hwloc-versions/v2.1.0/0.xml
+++ b/t/hwloc-data/1N/hwloc-versions/v2.1.0/0.xml
@@ -1,0 +1,940 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topology SYSTEM "hwloc2.dtd">
+<topology version="2.0">
+  <object type="Machine" os_index="0" cpuset="0xffffffff,0xffffffff,0xffffffff" complete_cpuset="0xffffffff,0xffffffff,0xffffffff" allowed_cpuset="0xffffffff,0xffffffff,0xffffffff" nodeset="0x000000ff" complete_nodeset="0x000000ff" allowed_nodeset="0x000000ff" gp_index="1">
+    <info name="DMIProductName" value="Altus XO1114GT"/>
+    <info name="DMIProductVersion" value="0100"/>
+    <info name="DMIBoardVendor" value="GIGABYTE"/>
+    <info name="DMIBoardName" value="MZ71-OP0-ZB"/>
+    <info name="DMIBoardVersion" value="01000100"/>
+    <info name="DMIBoardAssetTag" value="01234567890123456789AB"/>
+    <info name="DMIChassisVendor" value="Penguin Computing"/>
+    <info name="DMIChassisType" value="23"/>
+    <info name="DMIChassisVersion" value="01234567"/>
+    <info name="DMIChassisAssetTag" value="01234567890123456789AB"/>
+    <info name="DMIBIOSVendor" value="GIGABYTE"/>
+    <info name="DMIBIOSVersion" value="F06c"/>
+    <info name="DMIBIOSDate" value="12/14/2018"/>
+    <info name="DMISysVendor" value="Penguin Computing"/>
+    <info name="Backend" value="Linux"/>
+    <info name="LinuxCgroup" value="/"/>
+    <info name="OSName" value="Linux"/>
+    <info name="OSRelease" value="3.10.0-1127.0.0.1chaos.ch6.x86_64"/>
+    <info name="OSVersion" value="#1 SMP Fri Apr 3 08:56:52 PDT 2020"/>
+    <info name="HostName" value="corona40"/>
+    <info name="Architecture" value="x86_64"/>
+    <info name="hwlocVersion" value="2.1.0"/>
+    <info name="ProcessName" value="lstopo"/>
+    <object type="Package" os_index="0" cpuset="0x000000ff,0xffff0000,0x00ffffff" complete_cpuset="0x000000ff,0xffff0000,0x00ffffff" nodeset="0x0000000f" complete_nodeset="0x0000000f" gp_index="3">
+      <info name="CPUVendor" value="AuthenticAMD"/>
+      <info name="CPUFamilyNumber" value="23"/>
+      <info name="CPUModelNumber" value="1"/>
+      <info name="CPUModel" value="AMD EPYC 7401 24-Core Processor                "/>
+      <info name="CPUStepping" value="2"/>
+      <object type="Group" cpuset="0x003f0000,0x0000003f" complete_cpuset="0x003f0000,0x0000003f" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="316" kind="1001" subkind="0">
+        <object type="NUMANode" os_index="0" cpuset="0x003f0000,0x0000003f" complete_cpuset="0x003f0000,0x0000003f" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="308" local_memory="33299529728">
+          <page_type size="4096" count="8129768"/>
+          <page_type size="2097152" count="0"/>
+          <page_type size="1073741824" count="0"/>
+        </object>
+        <object type="L3Cache" cpuset="0x00070000,0x00000007" complete_cpuset="0x00070000,0x00000007" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="8" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L2Cache" cpuset="0x00010000,0x00000001" complete_cpuset="0x00010000,0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="7" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" cpuset="0x00010000,0x00000001" complete_cpuset="0x00010000,0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="5" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" cpuset="0x00010000,0x00000001" complete_cpuset="0x00010000,0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="6" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="0" cpuset="0x00010000,0x00000001" complete_cpuset="0x00010000,0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="2">
+                  <object type="PU" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="4"/>
+                  <object type="PU" os_index="48" cpuset="0x00010000,0x0" complete_cpuset="0x00010000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="260"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" cpuset="0x00020000,0x00000002" complete_cpuset="0x00020000,0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="13" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" cpuset="0x00020000,0x00000002" complete_cpuset="0x00020000,0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="11" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" cpuset="0x00020000,0x00000002" complete_cpuset="0x00020000,0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="12" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="1" cpuset="0x00020000,0x00000002" complete_cpuset="0x00020000,0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="9">
+                  <object type="PU" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="10"/>
+                  <object type="PU" os_index="49" cpuset="0x00020000,0x0" complete_cpuset="0x00020000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="261"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" cpuset="0x00040000,0x00000004" complete_cpuset="0x00040000,0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="18" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" cpuset="0x00040000,0x00000004" complete_cpuset="0x00040000,0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="16" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" cpuset="0x00040000,0x00000004" complete_cpuset="0x00040000,0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="17" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="2" cpuset="0x00040000,0x00000004" complete_cpuset="0x00040000,0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="14">
+                  <object type="PU" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="15"/>
+                  <object type="PU" os_index="50" cpuset="0x00040000,0x0" complete_cpuset="0x00040000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="262"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L3Cache" cpuset="0x00380000,0x00000038" complete_cpuset="0x00380000,0x00000038" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="24" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L2Cache" cpuset="0x00080000,0x00000008" complete_cpuset="0x00080000,0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="23" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" cpuset="0x00080000,0x00000008" complete_cpuset="0x00080000,0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="21" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" cpuset="0x00080000,0x00000008" complete_cpuset="0x00080000,0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="22" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="4" cpuset="0x00080000,0x00000008" complete_cpuset="0x00080000,0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="19">
+                  <object type="PU" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="20"/>
+                  <object type="PU" os_index="51" cpuset="0x00080000,0x0" complete_cpuset="0x00080000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="263"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" cpuset="0x00100000,0x00000010" complete_cpuset="0x00100000,0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="29" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" cpuset="0x00100000,0x00000010" complete_cpuset="0x00100000,0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="27" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" cpuset="0x00100000,0x00000010" complete_cpuset="0x00100000,0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="28" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="5" cpuset="0x00100000,0x00000010" complete_cpuset="0x00100000,0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="25">
+                  <object type="PU" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="26"/>
+                  <object type="PU" os_index="52" cpuset="0x00100000,0x0" complete_cpuset="0x00100000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="264"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" cpuset="0x00200000,0x00000020" complete_cpuset="0x00200000,0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="34" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" cpuset="0x00200000,0x00000020" complete_cpuset="0x00200000,0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="32" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" cpuset="0x00200000,0x00000020" complete_cpuset="0x00200000,0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="33" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="6" cpuset="0x00200000,0x00000020" complete_cpuset="0x00200000,0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="30">
+                  <object type="PU" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="31"/>
+                  <object type="PU" os_index="53" cpuset="0x00200000,0x0" complete_cpuset="0x00200000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="265"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" gp_index="375" bridge_type="0-1" depth="0" bridge_pci="0000:[00-07]">
+          <object type="Bridge" gp_index="328" bridge_type="1-1" depth="1" bridge_pci="0000:[01-01]" pci_busid="0000:00:01.1" pci_type="0604 [1022:1453] [1458:1000] 00" pci_link_speed="3.938462">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+            <info name="PCIDevice" value="Family 17h (Models 00h-0fh) PCIe GPP Bridge"/>
+            <object type="PCIDev" gp_index="334" pci_busid="0000:01:00.0" pci_type="0108 [1c58:0023] [1c58:0023] 02" pci_link_speed="3.938462">
+              <info name="PCISlot" value="1"/>
+              <info name="PCIVendor" value="HGST, Inc."/>
+              <info name="PCIDevice" value="Ultrastar SN200 Series NVMe SSD"/>
+              <object type="OSDev" gp_index="384" name="nvme0n1" subtype="Disk" osdev_type="0">
+                <info name="Size" value="1562813784"/>
+                <info name="SectorSize" value="4096"/>
+                <info name="LinuxDeviceID" value="259:0"/>
+                <info name="Model" value="HUSMR7616BDP301"/>
+                <info name="SerialNumber" value="SDM0000107A5"/>
+              </object>
+            </object>
+          </object>
+          <object type="Bridge" gp_index="330" bridge_type="1-1" depth="1" bridge_pci="0000:[03-03]" pci_busid="0000:00:01.3" pci_type="0604 [1022:1453] [1458:1000] 00" pci_link_speed="1.000000">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+            <info name="PCIDevice" value="Family 17h (Models 00h-0fh) PCIe GPP Bridge"/>
+            <object type="PCIDev" gp_index="339" pci_busid="0000:03:00.0" pci_type="0200 [8086:1521] [1458:0000] 01" pci_link_speed="1.000000">
+              <info name="PCIVendor" value="Intel Corporation"/>
+              <info name="PCIDevice" value="I350 Gigabit Network Connection"/>
+              <object type="OSDev" gp_index="387" name="enp3s0f0" osdev_type="2">
+                <info name="Address" value="e0:d5:5e:ca:b0:22"/>
+              </object>
+            </object>
+            <object type="PCIDev" gp_index="340" pci_busid="0000:03:00.1" pci_type="0200 [8086:1521] [1458:0000] 01" pci_link_speed="1.000000">
+              <info name="PCIVendor" value="Intel Corporation"/>
+              <info name="PCIDevice" value="I350 Gigabit Network Connection"/>
+              <object type="OSDev" gp_index="386" name="enp3s0f1" osdev_type="2">
+                <info name="Address" value="e0:d5:5e:ca:b0:23"/>
+              </object>
+            </object>
+          </object>
+          <object type="Bridge" gp_index="331" bridge_type="1-1" depth="1" bridge_pci="0000:[04-05]" pci_busid="0000:00:01.6" pci_type="0604 [1022:1453] [1458:1000] 00" pci_link_speed="0.250000">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+            <info name="PCIDevice" value="Family 17h (Models 00h-0fh) PCIe GPP Bridge"/>
+            <object type="Bridge" gp_index="342" bridge_type="1-1" depth="2" bridge_pci="0000:[05-05]" pci_busid="0000:04:00.0" pci_type="0604 [1a03:1150] [1a03:1150] 04" pci_link_speed="0.250000">
+              <info name="PCIVendor" value="ASPEED Technology, Inc."/>
+              <info name="PCIDevice" value="AST1150 PCI-to-PCI Bridge"/>
+              <object type="PCIDev" gp_index="344" pci_busid="0000:05:00.0" pci_type="0300 [1a03:2000] [1458:1000] 41" pci_link_speed="0.000000">
+                <info name="PCIVendor" value="ASPEED Technology, Inc."/>
+                <info name="PCIDevice" value="ASPEED Graphics Family"/>
+              </object>
+            </object>
+          </object>
+          <object type="Bridge" gp_index="333" bridge_type="1-1" depth="1" bridge_pci="0000:[07-07]" pci_busid="0000:00:08.1" pci_type="0604 [1022:1454] [1000:1458] 00" pci_link_speed="15.753846">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+            <info name="PCIDevice" value="Family 17h (Models 00h-0fh) Internal PCIe GPP Bridge 0 to Bus B"/>
+            <object type="PCIDev" gp_index="345" pci_busid="0000:07:00.2" pci_type="0106 [1022:7901] [1458:1000] 51" pci_link_speed="15.753846">
+              <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+              <info name="PCIDevice" value="FCH SATA Controller [AHCI mode]"/>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="Group" cpuset="0x0fc00000,0x00000fc0" complete_cpuset="0x0fc00000,0x00000fc0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="317" kind="1001" subkind="0">
+        <object type="NUMANode" os_index="1" cpuset="0x0fc00000,0x00000fc0" complete_cpuset="0x0fc00000,0x00000fc0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="309" local_memory="33819570176">
+          <page_type size="4096" count="8256731"/>
+          <page_type size="2097152" count="0"/>
+          <page_type size="1073741824" count="0"/>
+        </object>
+        <object type="L3Cache" cpuset="0x01c00000,0x000001c0" complete_cpuset="0x01c00000,0x000001c0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="40" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L2Cache" cpuset="0x00400000,0x00000040" complete_cpuset="0x00400000,0x00000040" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="39" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" cpuset="0x00400000,0x00000040" complete_cpuset="0x00400000,0x00000040" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="37" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" cpuset="0x00400000,0x00000040" complete_cpuset="0x00400000,0x00000040" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="38" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="8" cpuset="0x00400000,0x00000040" complete_cpuset="0x00400000,0x00000040" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="35">
+                  <object type="PU" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="36"/>
+                  <object type="PU" os_index="54" cpuset="0x00400000,0x0" complete_cpuset="0x00400000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="266"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" cpuset="0x00800000,0x00000080" complete_cpuset="0x00800000,0x00000080" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="45" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" cpuset="0x00800000,0x00000080" complete_cpuset="0x00800000,0x00000080" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="43" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" cpuset="0x00800000,0x00000080" complete_cpuset="0x00800000,0x00000080" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="44" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="9" cpuset="0x00800000,0x00000080" complete_cpuset="0x00800000,0x00000080" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="41">
+                  <object type="PU" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="42"/>
+                  <object type="PU" os_index="55" cpuset="0x00800000,0x0" complete_cpuset="0x00800000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="267"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" cpuset="0x01000000,0x00000100" complete_cpuset="0x01000000,0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="50" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" cpuset="0x01000000,0x00000100" complete_cpuset="0x01000000,0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="48" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" cpuset="0x01000000,0x00000100" complete_cpuset="0x01000000,0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="49" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="10" cpuset="0x01000000,0x00000100" complete_cpuset="0x01000000,0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="46">
+                  <object type="PU" os_index="8" cpuset="0x00000100" complete_cpuset="0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="47"/>
+                  <object type="PU" os_index="56" cpuset="0x01000000,0x0" complete_cpuset="0x01000000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="268"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L3Cache" cpuset="0x0e000000,0x00000e00" complete_cpuset="0x0e000000,0x00000e00" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="56" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L2Cache" cpuset="0x02000000,0x00000200" complete_cpuset="0x02000000,0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="55" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" cpuset="0x02000000,0x00000200" complete_cpuset="0x02000000,0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="53" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" cpuset="0x02000000,0x00000200" complete_cpuset="0x02000000,0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="54" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="12" cpuset="0x02000000,0x00000200" complete_cpuset="0x02000000,0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="51">
+                  <object type="PU" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="52"/>
+                  <object type="PU" os_index="57" cpuset="0x02000000,0x0" complete_cpuset="0x02000000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="269"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" cpuset="0x04000000,0x00000400" complete_cpuset="0x04000000,0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="61" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" cpuset="0x04000000,0x00000400" complete_cpuset="0x04000000,0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="59" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" cpuset="0x04000000,0x00000400" complete_cpuset="0x04000000,0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="60" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="13" cpuset="0x04000000,0x00000400" complete_cpuset="0x04000000,0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="57">
+                  <object type="PU" os_index="10" cpuset="0x00000400" complete_cpuset="0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="58"/>
+                  <object type="PU" os_index="58" cpuset="0x04000000,0x0" complete_cpuset="0x04000000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="270"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" cpuset="0x08000000,0x00000800" complete_cpuset="0x08000000,0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="66" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" cpuset="0x08000000,0x00000800" complete_cpuset="0x08000000,0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="64" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" cpuset="0x08000000,0x00000800" complete_cpuset="0x08000000,0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="65" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="14" cpuset="0x08000000,0x00000800" complete_cpuset="0x08000000,0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="62">
+                  <object type="PU" os_index="11" cpuset="0x00000800" complete_cpuset="0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="63"/>
+                  <object type="PU" os_index="59" cpuset="0x08000000,0x0" complete_cpuset="0x08000000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="271"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" gp_index="376" bridge_type="0-1" depth="0" bridge_pci="0000:[10-15]">
+          <object type="Bridge" gp_index="346" bridge_type="1-1" depth="1" bridge_pci="0000:[11-13]" pci_busid="0000:10:01.1" pci_type="0604 [1022:1453] [1458:1000] 00" pci_link_speed="3.938462">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+            <info name="PCIDevice" value="Family 17h (Models 00h-0fh) PCIe GPP Bridge"/>
+            <object type="Bridge" gp_index="349" bridge_type="1-1" depth="2" bridge_pci="0000:[12-13]" pci_busid="0000:11:00.0" pci_type="0604 [1002:14a0] [0000:0000] 02" pci_link_speed="3.938462">
+              <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD/ATI]"/>
+              <object type="Bridge" gp_index="350" bridge_type="1-1" depth="3" bridge_pci="0000:[13-13]" pci_busid="0000:12:00.0" pci_type="0604 [1002:14a1] [1002:14a1] 00" pci_link_speed="31.507692">
+                <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD/ATI]"/>
+                <object type="PCIDev" gp_index="351" pci_busid="0000:13:00.0" pci_type="0380 [1002:66a1] [1002:0834] 02" pci_link_speed="31.507692">
+                  <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD/ATI]"/>
+                  <info name="PCIDevice" value="Vega 20"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="Group" cpuset="0x00000003,0xf0000000,0x0003f000" complete_cpuset="0x00000003,0xf0000000,0x0003f000" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="318" kind="1001" subkind="0">
+        <object type="NUMANode" os_index="2" cpuset="0x00000003,0xf0000000,0x0003f000" complete_cpuset="0x00000003,0xf0000000,0x0003f000" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="310" local_memory="33819574272">
+          <page_type size="4096" count="8256732"/>
+          <page_type size="2097152" count="0"/>
+          <page_type size="1073741824" count="0"/>
+        </object>
+        <object type="L3Cache" cpuset="0x70000000,0x00007000" complete_cpuset="0x70000000,0x00007000" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="72" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L2Cache" cpuset="0x10000000,0x00001000" complete_cpuset="0x10000000,0x00001000" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="71" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" cpuset="0x10000000,0x00001000" complete_cpuset="0x10000000,0x00001000" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="69" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" cpuset="0x10000000,0x00001000" complete_cpuset="0x10000000,0x00001000" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="70" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="16" cpuset="0x10000000,0x00001000" complete_cpuset="0x10000000,0x00001000" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="67">
+                  <object type="PU" os_index="12" cpuset="0x00001000" complete_cpuset="0x00001000" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="68"/>
+                  <object type="PU" os_index="60" cpuset="0x10000000,0x0" complete_cpuset="0x10000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="272"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" cpuset="0x20000000,0x00002000" complete_cpuset="0x20000000,0x00002000" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="77" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" cpuset="0x20000000,0x00002000" complete_cpuset="0x20000000,0x00002000" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="75" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" cpuset="0x20000000,0x00002000" complete_cpuset="0x20000000,0x00002000" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="76" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="17" cpuset="0x20000000,0x00002000" complete_cpuset="0x20000000,0x00002000" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="73">
+                  <object type="PU" os_index="13" cpuset="0x00002000" complete_cpuset="0x00002000" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="74"/>
+                  <object type="PU" os_index="61" cpuset="0x20000000,0x0" complete_cpuset="0x20000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="273"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" cpuset="0x40000000,0x00004000" complete_cpuset="0x40000000,0x00004000" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="82" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" cpuset="0x40000000,0x00004000" complete_cpuset="0x40000000,0x00004000" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="80" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" cpuset="0x40000000,0x00004000" complete_cpuset="0x40000000,0x00004000" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="81" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="18" cpuset="0x40000000,0x00004000" complete_cpuset="0x40000000,0x00004000" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="78">
+                  <object type="PU" os_index="14" cpuset="0x00004000" complete_cpuset="0x00004000" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="79"/>
+                  <object type="PU" os_index="62" cpuset="0x40000000,0x0" complete_cpuset="0x40000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="274"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L3Cache" cpuset="0x00000003,0x80000000,0x00038000" complete_cpuset="0x00000003,0x80000000,0x00038000" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="88" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L2Cache" cpuset="0x80000000,0x00008000" complete_cpuset="0x80000000,0x00008000" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="87" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" cpuset="0x80000000,0x00008000" complete_cpuset="0x80000000,0x00008000" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="85" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" cpuset="0x80000000,0x00008000" complete_cpuset="0x80000000,0x00008000" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="86" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="20" cpuset="0x80000000,0x00008000" complete_cpuset="0x80000000,0x00008000" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="83">
+                  <object type="PU" os_index="15" cpuset="0x00008000" complete_cpuset="0x00008000" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="84"/>
+                  <object type="PU" os_index="63" cpuset="0x80000000,0x0" complete_cpuset="0x80000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="275"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" cpuset="0x00000001,,0x00010000" complete_cpuset="0x00000001,,0x00010000" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="93" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" cpuset="0x00000001,,0x00010000" complete_cpuset="0x00000001,,0x00010000" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="91" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" cpuset="0x00000001,,0x00010000" complete_cpuset="0x00000001,,0x00010000" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="92" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="21" cpuset="0x00000001,,0x00010000" complete_cpuset="0x00000001,,0x00010000" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="89">
+                  <object type="PU" os_index="16" cpuset="0x00010000" complete_cpuset="0x00010000" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="90"/>
+                  <object type="PU" os_index="64" cpuset="0x00000001,,0x0" complete_cpuset="0x00000001,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="276"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" cpuset="0x00000002,,0x00020000" complete_cpuset="0x00000002,,0x00020000" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="98" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" cpuset="0x00000002,,0x00020000" complete_cpuset="0x00000002,,0x00020000" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="96" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" cpuset="0x00000002,,0x00020000" complete_cpuset="0x00000002,,0x00020000" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="97" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="22" cpuset="0x00000002,,0x00020000" complete_cpuset="0x00000002,,0x00020000" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="94">
+                  <object type="PU" os_index="17" cpuset="0x00020000" complete_cpuset="0x00020000" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="95"/>
+                  <object type="PU" os_index="65" cpuset="0x00000002,,0x0" complete_cpuset="0x00000002,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="277"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" gp_index="377" bridge_type="0-1" depth="0" bridge_pci="0000:[20-25]">
+          <object type="Bridge" gp_index="352" bridge_type="1-1" depth="1" bridge_pci="0000:[21-23]" pci_busid="0000:20:03.1" pci_type="0604 [1022:1453] [1458:1000] 00" pci_link_speed="3.938462">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+            <info name="PCIDevice" value="Family 17h (Models 00h-0fh) PCIe GPP Bridge"/>
+            <object type="Bridge" gp_index="355" bridge_type="1-1" depth="2" bridge_pci="0000:[22-23]" pci_busid="0000:21:00.0" pci_type="0604 [1002:14a0] [0000:0000] 02" pci_link_speed="3.938462">
+              <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD/ATI]"/>
+              <object type="Bridge" gp_index="356" bridge_type="1-1" depth="3" bridge_pci="0000:[23-23]" pci_busid="0000:22:00.0" pci_type="0604 [1002:14a1] [1002:14a1] 00" pci_link_speed="31.507692">
+                <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD/ATI]"/>
+                <object type="PCIDev" gp_index="357" pci_busid="0000:23:00.0" pci_type="0380 [1002:66a1] [1002:0834] 02" pci_link_speed="31.507692">
+                  <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD/ATI]"/>
+                  <info name="PCIDevice" value="Vega 20"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="Group" cpuset="0x000000fc,,0x00fc0000" complete_cpuset="0x000000fc,,0x00fc0000" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="319" kind="1001" subkind="0">
+        <object type="NUMANode" os_index="3" cpuset="0x000000fc,,0x00fc0000" complete_cpuset="0x000000fc,,0x00fc0000" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="311" local_memory="33802997760">
+          <page_type size="4096" count="8252685"/>
+          <page_type size="2097152" count="0"/>
+          <page_type size="1073741824" count="0"/>
+        </object>
+        <object type="L3Cache" cpuset="0x0000001c,,0x001c0000" complete_cpuset="0x0000001c,,0x001c0000" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="104" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L2Cache" cpuset="0x00000004,,0x00040000" complete_cpuset="0x00000004,,0x00040000" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="103" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" cpuset="0x00000004,,0x00040000" complete_cpuset="0x00000004,,0x00040000" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="101" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" cpuset="0x00000004,,0x00040000" complete_cpuset="0x00000004,,0x00040000" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="102" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="24" cpuset="0x00000004,,0x00040000" complete_cpuset="0x00000004,,0x00040000" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="99">
+                  <object type="PU" os_index="18" cpuset="0x00040000" complete_cpuset="0x00040000" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="100"/>
+                  <object type="PU" os_index="66" cpuset="0x00000004,,0x0" complete_cpuset="0x00000004,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="278"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" cpuset="0x00000008,,0x00080000" complete_cpuset="0x00000008,,0x00080000" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="109" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" cpuset="0x00000008,,0x00080000" complete_cpuset="0x00000008,,0x00080000" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="107" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" cpuset="0x00000008,,0x00080000" complete_cpuset="0x00000008,,0x00080000" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="108" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="25" cpuset="0x00000008,,0x00080000" complete_cpuset="0x00000008,,0x00080000" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="105">
+                  <object type="PU" os_index="19" cpuset="0x00080000" complete_cpuset="0x00080000" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="106"/>
+                  <object type="PU" os_index="67" cpuset="0x00000008,,0x0" complete_cpuset="0x00000008,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="279"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" cpuset="0x00000010,,0x00100000" complete_cpuset="0x00000010,,0x00100000" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="114" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" cpuset="0x00000010,,0x00100000" complete_cpuset="0x00000010,,0x00100000" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="112" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" cpuset="0x00000010,,0x00100000" complete_cpuset="0x00000010,,0x00100000" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="113" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="26" cpuset="0x00000010,,0x00100000" complete_cpuset="0x00000010,,0x00100000" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="110">
+                  <object type="PU" os_index="20" cpuset="0x00100000" complete_cpuset="0x00100000" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="111"/>
+                  <object type="PU" os_index="68" cpuset="0x00000010,,0x0" complete_cpuset="0x00000010,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="280"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L3Cache" cpuset="0x000000e0,,0x00e00000" complete_cpuset="0x000000e0,,0x00e00000" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="120" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L2Cache" cpuset="0x00000020,,0x00200000" complete_cpuset="0x00000020,,0x00200000" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="119" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" cpuset="0x00000020,,0x00200000" complete_cpuset="0x00000020,,0x00200000" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="117" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" cpuset="0x00000020,,0x00200000" complete_cpuset="0x00000020,,0x00200000" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="118" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="28" cpuset="0x00000020,,0x00200000" complete_cpuset="0x00000020,,0x00200000" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="115">
+                  <object type="PU" os_index="21" cpuset="0x00200000" complete_cpuset="0x00200000" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="116"/>
+                  <object type="PU" os_index="69" cpuset="0x00000020,,0x0" complete_cpuset="0x00000020,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="281"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" cpuset="0x00000040,,0x00400000" complete_cpuset="0x00000040,,0x00400000" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="125" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" cpuset="0x00000040,,0x00400000" complete_cpuset="0x00000040,,0x00400000" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="123" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" cpuset="0x00000040,,0x00400000" complete_cpuset="0x00000040,,0x00400000" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="124" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="29" cpuset="0x00000040,,0x00400000" complete_cpuset="0x00000040,,0x00400000" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="121">
+                  <object type="PU" os_index="22" cpuset="0x00400000" complete_cpuset="0x00400000" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="122"/>
+                  <object type="PU" os_index="70" cpuset="0x00000040,,0x0" complete_cpuset="0x00000040,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="282"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" cpuset="0x00000080,,0x00800000" complete_cpuset="0x00000080,,0x00800000" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="130" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" cpuset="0x00000080,,0x00800000" complete_cpuset="0x00000080,,0x00800000" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="128" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" cpuset="0x00000080,,0x00800000" complete_cpuset="0x00000080,,0x00800000" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="129" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="30" cpuset="0x00000080,,0x00800000" complete_cpuset="0x00000080,,0x00800000" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="126">
+                  <object type="PU" os_index="23" cpuset="0x00800000" complete_cpuset="0x00800000" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="127"/>
+                  <object type="PU" os_index="71" cpuset="0x00000080,,0x0" complete_cpuset="0x00000080,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="283"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" gp_index="378" bridge_type="0-1" depth="0" bridge_pci="0000:[30-36]">
+          <object type="Bridge" gp_index="358" bridge_type="1-1" depth="1" bridge_pci="0000:[31-34]" pci_busid="0000:30:03.1" pci_type="0604 [1022:1453] [1458:1000] 00" pci_link_speed="15.753846">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+            <info name="PCIDevice" value="Family 17h (Models 00h-0fh) PCIe GPP Bridge"/>
+            <object type="Bridge" gp_index="361" bridge_type="1-1" depth="2" bridge_pci="0000:[32-34]" pci_busid="0000:31:00.0" pci_type="0604 [10b5:8747] [10b5:8747] ca" pci_link_speed="15.753846">
+              <info name="PCIVendor" value="PLX Technology, Inc."/>
+              <info name="PCIDevice" value="PEX 8747 48-Lane, 5-Port PCI Express Gen 3 (8.0 GT/s) Switch"/>
+              <object type="Bridge" gp_index="362" bridge_type="1-1" depth="3" bridge_pci="0000:[33-33]" pci_busid="0000:32:08.0" pci_type="0604 [10b5:8747] [10b5:8747] ca" pci_link_speed="15.753846">
+                <info name="PCIVendor" value="PLX Technology, Inc."/>
+                <info name="PCIDevice" value="PEX 8747 48-Lane, 5-Port PCI Express Gen 3 (8.0 GT/s) Switch"/>
+                <object type="PCIDev" gp_index="364" pci_busid="0000:33:00.0" pci_type="0207 [15b3:101b] [15b3:0006] 00" pci_link_speed="15.753846">
+                  <info name="PCIVendor" value="Mellanox Technologies"/>
+                  <info name="PCIDevice" value="MT28908 Family [ConnectX-6]"/>
+                  <object type="OSDev" gp_index="385" name="hsi0" osdev_type="2">
+                    <info name="Address" value="80:00:01:07:fe:80:00:00:00:00:00:00:98:03:9b:03:00:82:9d:b4"/>
+                    <info name="Port" value="1"/>
+                  </object>
+                  <object type="OSDev" gp_index="388" name="mlx5_0" osdev_type="3">
+                    <info name="NodeGUID" value="9803:9b03:0082:9db4"/>
+                    <info name="SysImageGUID" value="9803:9b03:0082:9db4"/>
+                    <info name="Port1State" value="4"/>
+                    <info name="Port1LID" value="0x1c"/>
+                    <info name="Port1LMC" value="0"/>
+                    <info name="Port1GID0" value="fe80:0000:0000:0000:9803:9b03:0082:9db4"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+    </object>
+    <object type="Package" os_index="1" cpuset="0xffffff00,0x0000ffff,0xff000000" complete_cpuset="0xffffff00,0x0000ffff,0xff000000" nodeset="0x000000f0" complete_nodeset="0x000000f0" gp_index="132">
+      <info name="CPUVendor" value="AuthenticAMD"/>
+      <info name="CPUFamilyNumber" value="23"/>
+      <info name="CPUModelNumber" value="1"/>
+      <info name="CPUModel" value="AMD EPYC 7401 24-Core Processor                "/>
+      <info name="CPUStepping" value="2"/>
+      <object type="Group" cpuset="0x00003f00,,0x3f000000" complete_cpuset="0x00003f00,,0x3f000000" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="320" kind="1001" subkind="0">
+        <object type="NUMANode" os_index="4" cpuset="0x00003f00,,0x3f000000" complete_cpuset="0x00003f00,,0x3f000000" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="312" local_memory="33819574272">
+          <page_type size="4096" count="8256732"/>
+          <page_type size="2097152" count="0"/>
+          <page_type size="1073741824" count="0"/>
+        </object>
+        <object type="L3Cache" cpuset="0x00000700,,0x07000000" complete_cpuset="0x00000700,,0x07000000" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="137" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L2Cache" cpuset="0x00000100,,0x01000000" complete_cpuset="0x00000100,,0x01000000" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="136" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" cpuset="0x00000100,,0x01000000" complete_cpuset="0x00000100,,0x01000000" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="134" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" cpuset="0x00000100,,0x01000000" complete_cpuset="0x00000100,,0x01000000" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="135" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="0" cpuset="0x00000100,,0x01000000" complete_cpuset="0x00000100,,0x01000000" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="131">
+                  <object type="PU" os_index="24" cpuset="0x01000000" complete_cpuset="0x01000000" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="133"/>
+                  <object type="PU" os_index="72" cpuset="0x00000100,,0x0" complete_cpuset="0x00000100,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="284"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" cpuset="0x00000200,,0x02000000" complete_cpuset="0x00000200,,0x02000000" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="142" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" cpuset="0x00000200,,0x02000000" complete_cpuset="0x00000200,,0x02000000" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="140" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" cpuset="0x00000200,,0x02000000" complete_cpuset="0x00000200,,0x02000000" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="141" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="1" cpuset="0x00000200,,0x02000000" complete_cpuset="0x00000200,,0x02000000" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="138">
+                  <object type="PU" os_index="25" cpuset="0x02000000" complete_cpuset="0x02000000" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="139"/>
+                  <object type="PU" os_index="73" cpuset="0x00000200,,0x0" complete_cpuset="0x00000200,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="285"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" cpuset="0x00000400,,0x04000000" complete_cpuset="0x00000400,,0x04000000" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="147" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" cpuset="0x00000400,,0x04000000" complete_cpuset="0x00000400,,0x04000000" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="145" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" cpuset="0x00000400,,0x04000000" complete_cpuset="0x00000400,,0x04000000" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="146" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="2" cpuset="0x00000400,,0x04000000" complete_cpuset="0x00000400,,0x04000000" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="143">
+                  <object type="PU" os_index="26" cpuset="0x04000000" complete_cpuset="0x04000000" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="144"/>
+                  <object type="PU" os_index="74" cpuset="0x00000400,,0x0" complete_cpuset="0x00000400,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="286"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L3Cache" cpuset="0x00003800,,0x38000000" complete_cpuset="0x00003800,,0x38000000" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="153" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L2Cache" cpuset="0x00000800,,0x08000000" complete_cpuset="0x00000800,,0x08000000" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="152" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" cpuset="0x00000800,,0x08000000" complete_cpuset="0x00000800,,0x08000000" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="150" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" cpuset="0x00000800,,0x08000000" complete_cpuset="0x00000800,,0x08000000" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="151" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="4" cpuset="0x00000800,,0x08000000" complete_cpuset="0x00000800,,0x08000000" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="148">
+                  <object type="PU" os_index="27" cpuset="0x08000000" complete_cpuset="0x08000000" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="149"/>
+                  <object type="PU" os_index="75" cpuset="0x00000800,,0x0" complete_cpuset="0x00000800,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="287"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" cpuset="0x00001000,,0x10000000" complete_cpuset="0x00001000,,0x10000000" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="158" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" cpuset="0x00001000,,0x10000000" complete_cpuset="0x00001000,,0x10000000" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="156" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" cpuset="0x00001000,,0x10000000" complete_cpuset="0x00001000,,0x10000000" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="157" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="5" cpuset="0x00001000,,0x10000000" complete_cpuset="0x00001000,,0x10000000" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="154">
+                  <object type="PU" os_index="28" cpuset="0x10000000" complete_cpuset="0x10000000" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="155"/>
+                  <object type="PU" os_index="76" cpuset="0x00001000,,0x0" complete_cpuset="0x00001000,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="288"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" cpuset="0x00002000,,0x20000000" complete_cpuset="0x00002000,,0x20000000" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="163" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" cpuset="0x00002000,,0x20000000" complete_cpuset="0x00002000,,0x20000000" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="161" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" cpuset="0x00002000,,0x20000000" complete_cpuset="0x00002000,,0x20000000" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="162" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="6" cpuset="0x00002000,,0x20000000" complete_cpuset="0x00002000,,0x20000000" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="159">
+                  <object type="PU" os_index="29" cpuset="0x20000000" complete_cpuset="0x20000000" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="160"/>
+                  <object type="PU" os_index="77" cpuset="0x00002000,,0x0" complete_cpuset="0x00002000,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="289"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="Group" cpuset="0x000fc000,0x0000000f,0xc0000000" complete_cpuset="0x000fc000,0x0000000f,0xc0000000" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="321" kind="1001" subkind="0">
+        <object type="NUMANode" os_index="5" cpuset="0x000fc000,0x0000000f,0xc0000000" complete_cpuset="0x000fc000,0x0000000f,0xc0000000" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="313" local_memory="33819570176">
+          <page_type size="4096" count="8256731"/>
+          <page_type size="2097152" count="0"/>
+          <page_type size="1073741824" count="0"/>
+        </object>
+        <object type="L3Cache" cpuset="0x0001c000,0x00000001,0xc0000000" complete_cpuset="0x0001c000,0x00000001,0xc0000000" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="169" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L2Cache" cpuset="0x00004000,,0x40000000" complete_cpuset="0x00004000,,0x40000000" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="168" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" cpuset="0x00004000,,0x40000000" complete_cpuset="0x00004000,,0x40000000" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="166" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" cpuset="0x00004000,,0x40000000" complete_cpuset="0x00004000,,0x40000000" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="167" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="8" cpuset="0x00004000,,0x40000000" complete_cpuset="0x00004000,,0x40000000" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="164">
+                  <object type="PU" os_index="30" cpuset="0x40000000" complete_cpuset="0x40000000" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="165"/>
+                  <object type="PU" os_index="78" cpuset="0x00004000,,0x0" complete_cpuset="0x00004000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="290"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" cpuset="0x00008000,,0x80000000" complete_cpuset="0x00008000,,0x80000000" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="174" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" cpuset="0x00008000,,0x80000000" complete_cpuset="0x00008000,,0x80000000" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="172" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" cpuset="0x00008000,,0x80000000" complete_cpuset="0x00008000,,0x80000000" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="173" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="9" cpuset="0x00008000,,0x80000000" complete_cpuset="0x00008000,,0x80000000" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="170">
+                  <object type="PU" os_index="31" cpuset="0x80000000" complete_cpuset="0x80000000" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="171"/>
+                  <object type="PU" os_index="79" cpuset="0x00008000,,0x0" complete_cpuset="0x00008000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="291"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" cpuset="0x00010000,0x00000001,0x0" complete_cpuset="0x00010000,0x00000001,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="179" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" cpuset="0x00010000,0x00000001,0x0" complete_cpuset="0x00010000,0x00000001,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="177" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" cpuset="0x00010000,0x00000001,0x0" complete_cpuset="0x00010000,0x00000001,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="178" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="10" cpuset="0x00010000,0x00000001,0x0" complete_cpuset="0x00010000,0x00000001,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="175">
+                  <object type="PU" os_index="32" cpuset="0x00000001,0x0" complete_cpuset="0x00000001,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="176"/>
+                  <object type="PU" os_index="80" cpuset="0x00010000,,0x0" complete_cpuset="0x00010000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="292"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L3Cache" cpuset="0x000e0000,0x0000000e,0x0" complete_cpuset="0x000e0000,0x0000000e,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="185" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L2Cache" cpuset="0x00020000,0x00000002,0x0" complete_cpuset="0x00020000,0x00000002,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="184" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" cpuset="0x00020000,0x00000002,0x0" complete_cpuset="0x00020000,0x00000002,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="182" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" cpuset="0x00020000,0x00000002,0x0" complete_cpuset="0x00020000,0x00000002,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="183" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="12" cpuset="0x00020000,0x00000002,0x0" complete_cpuset="0x00020000,0x00000002,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="180">
+                  <object type="PU" os_index="33" cpuset="0x00000002,0x0" complete_cpuset="0x00000002,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="181"/>
+                  <object type="PU" os_index="81" cpuset="0x00020000,,0x0" complete_cpuset="0x00020000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="293"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" cpuset="0x00040000,0x00000004,0x0" complete_cpuset="0x00040000,0x00000004,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="190" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" cpuset="0x00040000,0x00000004,0x0" complete_cpuset="0x00040000,0x00000004,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="188" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" cpuset="0x00040000,0x00000004,0x0" complete_cpuset="0x00040000,0x00000004,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="189" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="13" cpuset="0x00040000,0x00000004,0x0" complete_cpuset="0x00040000,0x00000004,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="186">
+                  <object type="PU" os_index="34" cpuset="0x00000004,0x0" complete_cpuset="0x00000004,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="187"/>
+                  <object type="PU" os_index="82" cpuset="0x00040000,,0x0" complete_cpuset="0x00040000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="294"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" cpuset="0x00080000,0x00000008,0x0" complete_cpuset="0x00080000,0x00000008,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="195" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" cpuset="0x00080000,0x00000008,0x0" complete_cpuset="0x00080000,0x00000008,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="193" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" cpuset="0x00080000,0x00000008,0x0" complete_cpuset="0x00080000,0x00000008,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="194" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="14" cpuset="0x00080000,0x00000008,0x0" complete_cpuset="0x00080000,0x00000008,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="191">
+                  <object type="PU" os_index="35" cpuset="0x00000008,0x0" complete_cpuset="0x00000008,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="192"/>
+                  <object type="PU" os_index="83" cpuset="0x00080000,,0x0" complete_cpuset="0x00080000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="295"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" gp_index="380" bridge_type="0-1" depth="0" bridge_pci="0000:[50-55]">
+          <object type="Bridge" gp_index="369" bridge_type="1-1" depth="1" bridge_pci="0000:[51-53]" pci_busid="0000:50:01.1" pci_type="0604 [1022:1453] [1458:1000] 00" pci_link_speed="3.938462">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+            <info name="PCIDevice" value="Family 17h (Models 00h-0fh) PCIe GPP Bridge"/>
+            <object type="Bridge" gp_index="372" bridge_type="1-1" depth="2" bridge_pci="0000:[52-53]" pci_busid="0000:51:00.0" pci_type="0604 [1002:14a0] [0000:0000] 02" pci_link_speed="3.938462">
+              <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD/ATI]"/>
+              <object type="Bridge" gp_index="373" bridge_type="1-1" depth="3" bridge_pci="0000:[53-53]" pci_busid="0000:52:00.0" pci_type="0604 [1002:14a1] [1002:14a1] 00" pci_link_speed="31.507692">
+                <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD/ATI]"/>
+                <object type="PCIDev" gp_index="374" pci_busid="0000:53:00.0" pci_type="0380 [1002:66a1] [1002:0834] 02" pci_link_speed="31.507692">
+                  <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD/ATI]"/>
+                  <info name="PCIDevice" value="Vega 20"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="Group" cpuset="0x03f00000,0x000003f0,0x0" complete_cpuset="0x03f00000,0x000003f0,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="322" kind="1001" subkind="0">
+        <object type="NUMANode" os_index="6" cpuset="0x03f00000,0x000003f0,0x0" complete_cpuset="0x03f00000,0x000003f0,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="314" local_memory="33819574272">
+          <page_type size="4096" count="8256732"/>
+          <page_type size="2097152" count="0"/>
+          <page_type size="1073741824" count="0"/>
+        </object>
+        <object type="L3Cache" cpuset="0x00700000,0x00000070,0x0" complete_cpuset="0x00700000,0x00000070,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="201" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L2Cache" cpuset="0x00100000,0x00000010,0x0" complete_cpuset="0x00100000,0x00000010,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="200" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" cpuset="0x00100000,0x00000010,0x0" complete_cpuset="0x00100000,0x00000010,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="198" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" cpuset="0x00100000,0x00000010,0x0" complete_cpuset="0x00100000,0x00000010,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="199" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="16" cpuset="0x00100000,0x00000010,0x0" complete_cpuset="0x00100000,0x00000010,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="196">
+                  <object type="PU" os_index="36" cpuset="0x00000010,0x0" complete_cpuset="0x00000010,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="197"/>
+                  <object type="PU" os_index="84" cpuset="0x00100000,,0x0" complete_cpuset="0x00100000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="296"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" cpuset="0x00200000,0x00000020,0x0" complete_cpuset="0x00200000,0x00000020,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="206" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" cpuset="0x00200000,0x00000020,0x0" complete_cpuset="0x00200000,0x00000020,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="204" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" cpuset="0x00200000,0x00000020,0x0" complete_cpuset="0x00200000,0x00000020,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="205" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="17" cpuset="0x00200000,0x00000020,0x0" complete_cpuset="0x00200000,0x00000020,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="202">
+                  <object type="PU" os_index="37" cpuset="0x00000020,0x0" complete_cpuset="0x00000020,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="203"/>
+                  <object type="PU" os_index="85" cpuset="0x00200000,,0x0" complete_cpuset="0x00200000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="297"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" cpuset="0x00400000,0x00000040,0x0" complete_cpuset="0x00400000,0x00000040,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="211" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" cpuset="0x00400000,0x00000040,0x0" complete_cpuset="0x00400000,0x00000040,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="209" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" cpuset="0x00400000,0x00000040,0x0" complete_cpuset="0x00400000,0x00000040,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="210" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="18" cpuset="0x00400000,0x00000040,0x0" complete_cpuset="0x00400000,0x00000040,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="207">
+                  <object type="PU" os_index="38" cpuset="0x00000040,0x0" complete_cpuset="0x00000040,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="208"/>
+                  <object type="PU" os_index="86" cpuset="0x00400000,,0x0" complete_cpuset="0x00400000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="298"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L3Cache" cpuset="0x03800000,0x00000380,0x0" complete_cpuset="0x03800000,0x00000380,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="217" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L2Cache" cpuset="0x00800000,0x00000080,0x0" complete_cpuset="0x00800000,0x00000080,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="216" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" cpuset="0x00800000,0x00000080,0x0" complete_cpuset="0x00800000,0x00000080,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="214" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" cpuset="0x00800000,0x00000080,0x0" complete_cpuset="0x00800000,0x00000080,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="215" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="20" cpuset="0x00800000,0x00000080,0x0" complete_cpuset="0x00800000,0x00000080,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="212">
+                  <object type="PU" os_index="39" cpuset="0x00000080,0x0" complete_cpuset="0x00000080,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="213"/>
+                  <object type="PU" os_index="87" cpuset="0x00800000,,0x0" complete_cpuset="0x00800000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="299"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" cpuset="0x01000000,0x00000100,0x0" complete_cpuset="0x01000000,0x00000100,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="222" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" cpuset="0x01000000,0x00000100,0x0" complete_cpuset="0x01000000,0x00000100,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="220" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" cpuset="0x01000000,0x00000100,0x0" complete_cpuset="0x01000000,0x00000100,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="221" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="21" cpuset="0x01000000,0x00000100,0x0" complete_cpuset="0x01000000,0x00000100,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="218">
+                  <object type="PU" os_index="40" cpuset="0x00000100,0x0" complete_cpuset="0x00000100,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="219"/>
+                  <object type="PU" os_index="88" cpuset="0x01000000,,0x0" complete_cpuset="0x01000000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="300"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" cpuset="0x02000000,0x00000200,0x0" complete_cpuset="0x02000000,0x00000200,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="227" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" cpuset="0x02000000,0x00000200,0x0" complete_cpuset="0x02000000,0x00000200,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="225" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" cpuset="0x02000000,0x00000200,0x0" complete_cpuset="0x02000000,0x00000200,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="226" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="22" cpuset="0x02000000,0x00000200,0x0" complete_cpuset="0x02000000,0x00000200,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="223">
+                  <object type="PU" os_index="41" cpuset="0x00000200,0x0" complete_cpuset="0x00000200,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="224"/>
+                  <object type="PU" os_index="89" cpuset="0x02000000,,0x0" complete_cpuset="0x02000000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="301"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="Group" cpuset="0xfc000000,0x0000fc00,0x0" complete_cpuset="0xfc000000,0x0000fc00,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="323" kind="1001" subkind="0">
+        <object type="NUMANode" os_index="7" cpuset="0xfc000000,0x0000fc00,0x0" complete_cpuset="0xfc000000,0x0000fc00,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="315" local_memory="33819033600">
+          <page_type size="4096" count="8256600"/>
+          <page_type size="2097152" count="0"/>
+          <page_type size="1073741824" count="0"/>
+        </object>
+        <object type="L3Cache" cpuset="0x1c000000,0x00001c00,0x0" complete_cpuset="0x1c000000,0x00001c00,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="233" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L2Cache" cpuset="0x04000000,0x00000400,0x0" complete_cpuset="0x04000000,0x00000400,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="232" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" cpuset="0x04000000,0x00000400,0x0" complete_cpuset="0x04000000,0x00000400,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="230" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" cpuset="0x04000000,0x00000400,0x0" complete_cpuset="0x04000000,0x00000400,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="231" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="24" cpuset="0x04000000,0x00000400,0x0" complete_cpuset="0x04000000,0x00000400,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="228">
+                  <object type="PU" os_index="42" cpuset="0x00000400,0x0" complete_cpuset="0x00000400,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="229"/>
+                  <object type="PU" os_index="90" cpuset="0x04000000,,0x0" complete_cpuset="0x04000000,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="302"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" cpuset="0x08000000,0x00000800,0x0" complete_cpuset="0x08000000,0x00000800,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="238" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" cpuset="0x08000000,0x00000800,0x0" complete_cpuset="0x08000000,0x00000800,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="236" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" cpuset="0x08000000,0x00000800,0x0" complete_cpuset="0x08000000,0x00000800,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="237" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="25" cpuset="0x08000000,0x00000800,0x0" complete_cpuset="0x08000000,0x00000800,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="234">
+                  <object type="PU" os_index="43" cpuset="0x00000800,0x0" complete_cpuset="0x00000800,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="235"/>
+                  <object type="PU" os_index="91" cpuset="0x08000000,,0x0" complete_cpuset="0x08000000,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="303"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" cpuset="0x10000000,0x00001000,0x0" complete_cpuset="0x10000000,0x00001000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="243" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" cpuset="0x10000000,0x00001000,0x0" complete_cpuset="0x10000000,0x00001000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="241" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" cpuset="0x10000000,0x00001000,0x0" complete_cpuset="0x10000000,0x00001000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="242" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="26" cpuset="0x10000000,0x00001000,0x0" complete_cpuset="0x10000000,0x00001000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="239">
+                  <object type="PU" os_index="44" cpuset="0x00001000,0x0" complete_cpuset="0x00001000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="240"/>
+                  <object type="PU" os_index="92" cpuset="0x10000000,,0x0" complete_cpuset="0x10000000,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="304"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L3Cache" cpuset="0xe0000000,0x0000e000,0x0" complete_cpuset="0xe0000000,0x0000e000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="249" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L2Cache" cpuset="0x20000000,0x00002000,0x0" complete_cpuset="0x20000000,0x00002000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="248" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" cpuset="0x20000000,0x00002000,0x0" complete_cpuset="0x20000000,0x00002000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="246" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" cpuset="0x20000000,0x00002000,0x0" complete_cpuset="0x20000000,0x00002000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="247" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="28" cpuset="0x20000000,0x00002000,0x0" complete_cpuset="0x20000000,0x00002000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="244">
+                  <object type="PU" os_index="45" cpuset="0x00002000,0x0" complete_cpuset="0x00002000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="245"/>
+                  <object type="PU" os_index="93" cpuset="0x20000000,,0x0" complete_cpuset="0x20000000,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="305"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" cpuset="0x40000000,0x00004000,0x0" complete_cpuset="0x40000000,0x00004000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="254" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" cpuset="0x40000000,0x00004000,0x0" complete_cpuset="0x40000000,0x00004000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="252" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" cpuset="0x40000000,0x00004000,0x0" complete_cpuset="0x40000000,0x00004000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="253" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="29" cpuset="0x40000000,0x00004000,0x0" complete_cpuset="0x40000000,0x00004000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="250">
+                  <object type="PU" os_index="46" cpuset="0x00004000,0x0" complete_cpuset="0x00004000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="251"/>
+                  <object type="PU" os_index="94" cpuset="0x40000000,,0x0" complete_cpuset="0x40000000,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="306"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" cpuset="0x80000000,0x00008000,0x0" complete_cpuset="0x80000000,0x00008000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="259" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" cpuset="0x80000000,0x00008000,0x0" complete_cpuset="0x80000000,0x00008000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="257" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" cpuset="0x80000000,0x00008000,0x0" complete_cpuset="0x80000000,0x00008000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="258" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="30" cpuset="0x80000000,0x00008000,0x0" complete_cpuset="0x80000000,0x00008000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="255">
+                  <object type="PU" os_index="47" cpuset="0x00008000,0x0" complete_cpuset="0x00008000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="256"/>
+                  <object type="PU" os_index="95" cpuset="0x80000000,,0x0" complete_cpuset="0x80000000,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="307"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" gp_index="382" bridge_type="0-1" depth="0" bridge_pci="0000:[70-75]">
+          <object type="Bridge" gp_index="335" bridge_type="1-1" depth="1" bridge_pci="0000:[71-73]" pci_busid="0000:70:03.1" pci_type="0604 [1022:1453] [1458:1000] 00" pci_link_speed="3.938462">
+            <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+            <info name="PCIDevice" value="Family 17h (Models 00h-0fh) PCIe GPP Bridge"/>
+            <object type="Bridge" gp_index="338" bridge_type="1-1" depth="2" bridge_pci="0000:[72-73]" pci_busid="0000:71:00.0" pci_type="0604 [1002:14a0] [0000:0000] 02" pci_link_speed="3.938462">
+              <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD/ATI]"/>
+              <object type="Bridge" gp_index="341" bridge_type="1-1" depth="3" bridge_pci="0000:[73-73]" pci_busid="0000:72:00.0" pci_type="0604 [1002:14a1] [1002:14a1] 00" pci_link_speed="31.507692">
+                <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD/ATI]"/>
+                <object type="PCIDev" gp_index="343" pci_busid="0000:73:00.0" pci_type="0380 [1002:66a1] [1002:0834] 02" pci_link_speed="31.507692">
+                  <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD/ATI]"/>
+                  <info name="PCIDevice" value="Vega 20"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+    </object>
+    <object type="OSDev" gp_index="383" name="sda" subtype="Disk" osdev_type="0">
+      <info name="Size" value="26214400"/>
+      <info name="SectorSize" value="512"/>
+      <info name="LinuxDeviceID" value="8:0"/>
+      <info name="Vendor" value="LIO-ORG"/>
+      <info name="Model" value="FILEIO"/>
+      <info name="Revision" value="4.0"/>
+      <info name="SerialNumber" value="60014054e2824b7073e3300794400382"/>
+    </object>
+  </object>
+  <distances2 type="NUMANode" nbobjs="8" kind="5" name="NUMALatency" indexing="os">
+    <indexes length="16">0 1 2 3 4 5 6 7 </indexes>
+    <u64values length="30">10 16 16 16 32 32 32 32 16 10 </u64values>
+    <u64values length="30">16 16 32 32 32 32 16 16 10 16 </u64values>
+    <u64values length="30">32 32 32 32 16 16 16 10 32 32 </u64values>
+    <u64values length="30">32 32 32 32 32 32 10 16 16 16 </u64values>
+    <u64values length="30">32 32 32 32 16 10 16 16 32 32 </u64values>
+    <u64values length="30">32 32 16 16 10 16 32 32 32 32 </u64values>
+    <u64values length="12">16 16 16 10 </u64values>
+  </distances2>
+</topology>

--- a/t/hwloc-data/1N/hwloc-versions/v2to1/0.xml
+++ b/t/hwloc-data/1N/hwloc-versions/v2to1/0.xml
@@ -1,0 +1,568 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topology SYSTEM "hwloc.dtd">
+<topology>
+  <object type="Machine" os_index="0" cpuset="0xffffffff,0xffffffff,0xffffffff" complete_cpuset="0xffffffff,0xffffffff,0xffffffff" online_cpuset="0xffffffff,0xffffffff,0xffffffff" allowed_cpuset="0xffffffff,0xffffffff,0xffffffff" nodeset="0x000000ff" complete_nodeset="0x000000ff" allowed_nodeset="0x000000ff">
+    <info name="DMIProductName" value="Altus XO1114GT"/>
+    <info name="DMIProductVersion" value="0100"/>
+    <info name="DMIBoardVendor" value="GIGABYTE"/>
+    <info name="DMIBoardName" value="MZ71-OP0-ZB"/>
+    <info name="DMIBoardVersion" value="01000100"/>
+    <info name="DMIBoardAssetTag" value="01234567890123456789AB"/>
+    <info name="DMIChassisVendor" value="Penguin Computing"/>
+    <info name="DMIChassisType" value="23"/>
+    <info name="DMIChassisVersion" value="01234567"/>
+    <info name="DMIChassisAssetTag" value="01234567890123456789AB"/>
+    <info name="DMIBIOSVendor" value="GIGABYTE"/>
+    <info name="DMIBIOSVersion" value="F06c"/>
+    <info name="DMIBIOSDate" value="12/14/2018"/>
+    <info name="DMISysVendor" value="Penguin Computing"/>
+    <info name="Backend" value="Linux"/>
+    <info name="LinuxCgroup" value="/"/>
+    <info name="OSName" value="Linux"/>
+    <info name="OSRelease" value="3.10.0-1127.0.0.1chaos.ch6.x86_64"/>
+    <info name="OSVersion" value="#1 SMP Fri Apr 3 08:56:52 PDT 2020"/>
+    <info name="HostName" value="corona40"/>
+    <info name="Architecture" value="x86_64"/>
+    <info name="hwlocVersion" value="1.11.11"/>
+    <info name="ProcessName" value="lstopo"/>
+    <distances nbobjs="8" relative_depth="3" latency_base="1.000000">
+      <latency value="10.000000"/>
+      <latency value="16.000000"/>
+      <latency value="16.000000"/>
+      <latency value="16.000000"/>
+      <latency value="32.000000"/>
+      <latency value="32.000000"/>
+      <latency value="32.000000"/>
+      <latency value="32.000000"/>
+      <latency value="16.000000"/>
+      <latency value="10.000000"/>
+      <latency value="16.000000"/>
+      <latency value="16.000000"/>
+      <latency value="32.000000"/>
+      <latency value="32.000000"/>
+      <latency value="32.000000"/>
+      <latency value="32.000000"/>
+      <latency value="16.000000"/>
+      <latency value="16.000000"/>
+      <latency value="10.000000"/>
+      <latency value="16.000000"/>
+      <latency value="32.000000"/>
+      <latency value="32.000000"/>
+      <latency value="32.000000"/>
+      <latency value="32.000000"/>
+      <latency value="16.000000"/>
+      <latency value="16.000000"/>
+      <latency value="16.000000"/>
+      <latency value="10.000000"/>
+      <latency value="32.000000"/>
+      <latency value="32.000000"/>
+      <latency value="32.000000"/>
+      <latency value="32.000000"/>
+      <latency value="32.000000"/>
+      <latency value="32.000000"/>
+      <latency value="32.000000"/>
+      <latency value="32.000000"/>
+      <latency value="10.000000"/>
+      <latency value="16.000000"/>
+      <latency value="16.000000"/>
+      <latency value="16.000000"/>
+      <latency value="32.000000"/>
+      <latency value="32.000000"/>
+      <latency value="32.000000"/>
+      <latency value="32.000000"/>
+      <latency value="16.000000"/>
+      <latency value="10.000000"/>
+      <latency value="16.000000"/>
+      <latency value="16.000000"/>
+      <latency value="32.000000"/>
+      <latency value="32.000000"/>
+      <latency value="32.000000"/>
+      <latency value="32.000000"/>
+      <latency value="16.000000"/>
+      <latency value="16.000000"/>
+      <latency value="10.000000"/>
+      <latency value="16.000000"/>
+      <latency value="32.000000"/>
+      <latency value="32.000000"/>
+      <latency value="32.000000"/>
+      <latency value="32.000000"/>
+      <latency value="16.000000"/>
+      <latency value="16.000000"/>
+      <latency value="16.000000"/>
+      <latency value="10.000000"/>
+    </distances>
+    <object type="Socket" os_index="0" cpuset="0x000000ff,0xffff0000,0x00ffffff" complete_cpuset="0x000000ff,0xffff0000,0x00ffffff" online_cpuset="0x000000ff,0xffff0000,0x00ffffff" allowed_cpuset="0x000000ff,0xffff0000,0x00ffffff" nodeset="0x0000000f" complete_nodeset="0x0000000f" allowed_nodeset="0x0000000f">
+      <info name="CPUVendor" value="AuthenticAMD"/>
+      <info name="CPUFamilyNumber" value="23"/>
+      <info name="CPUModelNumber" value="1"/>
+      <info name="CPUModel" value="AMD EPYC 7401 24-Core Processor"/>
+      <info name="CPUStepping" value="2"/>
+      <object type="NUMANode" os_index="0" cpuset="0x003f0000,0x0000003f" complete_cpuset="0x003f0000,0x0000003f" online_cpuset="0x003f0000,0x0000003f" allowed_cpuset="0x003f0000,0x0000003f" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" local_memory="33299529728">
+        <page_type size="4096" count="8129768"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+        <object type="Group" cpuset="0x003f0000,0x0000003f" complete_cpuset="0x003f0000,0x0000003f" online_cpuset="0x003f0000,0x0000003f" allowed_cpuset="0x003f0000,0x0000003f" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" depth="0">
+          <object type="Cache" cpuset="0x00070000,0x00000007" complete_cpuset="0x00070000,0x00000007" online_cpuset="0x00070000,0x00000007" allowed_cpuset="0x00070000,0x00000007" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="0" cpuset="0x00010000,0x00000001" complete_cpuset="0x00010000,0x00000001" online_cpuset="0x00010000,0x00000001" allowed_cpuset="0x00010000,0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+              <object type="PU" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+              <object type="PU" os_index="48" cpuset="0x00010000,0x0" complete_cpuset="0x00010000,0x0" online_cpuset="0x00010000,0x0" allowed_cpuset="0x00010000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+            </object>
+            <object type="Core" os_index="1" cpuset="0x00020000,0x00000002" complete_cpuset="0x00020000,0x00000002" online_cpuset="0x00020000,0x00000002" allowed_cpuset="0x00020000,0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+              <object type="PU" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+              <object type="PU" os_index="49" cpuset="0x00020000,0x0" complete_cpuset="0x00020000,0x0" online_cpuset="0x00020000,0x0" allowed_cpuset="0x00020000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+            </object>
+            <object type="Core" os_index="2" cpuset="0x00040000,0x00000004" complete_cpuset="0x00040000,0x00000004" online_cpuset="0x00040000,0x00000004" allowed_cpuset="0x00040000,0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+              <object type="PU" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+              <object type="PU" os_index="50" cpuset="0x00040000,0x0" complete_cpuset="0x00040000,0x0" online_cpuset="0x00040000,0x0" allowed_cpuset="0x00040000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00380000,0x00000038" complete_cpuset="0x00380000,0x00000038" online_cpuset="0x00380000,0x00000038" allowed_cpuset="0x00380000,0x00000038" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="4" cpuset="0x00080000,0x00000008" complete_cpuset="0x00080000,0x00000008" online_cpuset="0x00080000,0x00000008" allowed_cpuset="0x00080000,0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+              <object type="PU" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+              <object type="PU" os_index="51" cpuset="0x00080000,0x0" complete_cpuset="0x00080000,0x0" online_cpuset="0x00080000,0x0" allowed_cpuset="0x00080000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+            </object>
+            <object type="Core" os_index="5" cpuset="0x00100000,0x00000010" complete_cpuset="0x00100000,0x00000010" online_cpuset="0x00100000,0x00000010" allowed_cpuset="0x00100000,0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+              <object type="PU" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" online_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+              <object type="PU" os_index="52" cpuset="0x00100000,0x0" complete_cpuset="0x00100000,0x0" online_cpuset="0x00100000,0x0" allowed_cpuset="0x00100000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+            </object>
+            <object type="Core" os_index="6" cpuset="0x00200000,0x00000020" complete_cpuset="0x00200000,0x00000020" online_cpuset="0x00200000,0x00000020" allowed_cpuset="0x00200000,0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+              <object type="PU" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" online_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+              <object type="PU" os_index="53" cpuset="0x00200000,0x0" complete_cpuset="0x00200000,0x0" online_cpuset="0x00200000,0x0" allowed_cpuset="0x00200000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+            </object>
+          </object>
+          <object type="Bridge" os_index="0" bridge_type="0-1" depth="0" bridge_pci="0000:[00-07]">
+            <object type="Bridge" os_index="17" name="Advanced Micro Devices, Inc. [AMD] Family 17h (Models 00h-0fh) PCIe GPP Bridge" bridge_type="1-1" depth="1" bridge_pci="0000:[01-01]" pci_busid="0000:00:01.1" pci_type="0604 [1022:1453] [0000:0000] 00" pci_link_speed="3.938462">
+              <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+              <info name="PCIDevice" value="Family 17h (Models 00h-0fh) PCIe GPP Bridge"/>
+              <object type="PCIDev" os_index="4096" name="HGST, Inc. Ultrastar SN200 Series NVMe SSD" pci_busid="0000:01:00.0" pci_type="0108 [1c58:0023] [1c58:0023] 02" pci_link_speed="3.938462">
+                <info name="PCIVendor" value="HGST, Inc."/>
+                <info name="PCIDevice" value="Ultrastar SN200 Series NVMe SSD"/>
+                <info name="PCISlot" value="1"/>
+                <object type="OSDev" name="nvme0n1" osdev_type="0">
+                  <info name="LinuxDeviceID" value="259:0"/>
+                  <info name="Model" value="HUSMR7616BDP301"/>
+                  <info name="SerialNumber" value="SDM0000107A5"/>
+                  <info name="Type" value="Disk"/>
+                </object>
+              </object>
+            </object>
+            <object type="Bridge" os_index="19" name="Advanced Micro Devices, Inc. [AMD] Family 17h (Models 00h-0fh) PCIe GPP Bridge" bridge_type="1-1" depth="1" bridge_pci="0000:[03-03]" pci_busid="0000:00:01.3" pci_type="0604 [1022:1453] [0000:0000] 00" pci_link_speed="1.000000">
+              <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+              <info name="PCIDevice" value="Family 17h (Models 00h-0fh) PCIe GPP Bridge"/>
+              <object type="PCIDev" os_index="12288" name="Intel Corporation I350 Gigabit Network Connection" pci_busid="0000:03:00.0" pci_type="0200 [8086:1521] [1458:0000] 01" pci_link_speed="1.000000">
+                <info name="PCIVendor" value="Intel Corporation"/>
+                <info name="PCIDevice" value="I350 Gigabit Network Connection"/>
+                <object type="OSDev" name="enp3s0f0" osdev_type="2">
+                  <info name="Address" value="e0:d5:5e:ca:b0:22"/>
+                </object>
+              </object>
+              <object type="PCIDev" os_index="12289" name="Intel Corporation I350 Gigabit Network Connection" pci_busid="0000:03:00.1" pci_type="0200 [8086:1521] [1458:0000] 01" pci_link_speed="1.000000">
+                <info name="PCIVendor" value="Intel Corporation"/>
+                <info name="PCIDevice" value="I350 Gigabit Network Connection"/>
+                <object type="OSDev" name="enp3s0f1" osdev_type="2">
+                  <info name="Address" value="e0:d5:5e:ca:b0:23"/>
+                </object>
+              </object>
+            </object>
+            <object type="Bridge" os_index="22" name="Advanced Micro Devices, Inc. [AMD] Family 17h (Models 00h-0fh) PCIe GPP Bridge" bridge_type="1-1" depth="1" bridge_pci="0000:[04-05]" pci_busid="0000:00:01.6" pci_type="0604 [1022:1453] [0000:0000] 00" pci_link_speed="0.250000">
+              <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+              <info name="PCIDevice" value="Family 17h (Models 00h-0fh) PCIe GPP Bridge"/>
+              <object type="Bridge" os_index="16384" name="ASPEED Technology, Inc. AST1150 PCI-to-PCI Bridge" bridge_type="1-1" depth="2" bridge_pci="0000:[05-05]" pci_busid="0000:04:00.0" pci_type="0604 [1a03:1150] [0000:0000] 04" pci_link_speed="0.250000">
+                <info name="PCIVendor" value="ASPEED Technology, Inc."/>
+                <info name="PCIDevice" value="AST1150 PCI-to-PCI Bridge"/>
+                <object type="PCIDev" os_index="20480" name="ASPEED Technology, Inc. ASPEED Graphics Family" pci_busid="0000:05:00.0" pci_type="0300 [1a03:2000] [1458:1000] 41" pci_link_speed="0.000000">
+                  <info name="PCIVendor" value="ASPEED Technology, Inc."/>
+                  <info name="PCIDevice" value="ASPEED Graphics Family"/>
+                  <object type="OSDev" name="card0" osdev_type="1"/>
+                  <object type="OSDev" name="controlD64" osdev_type="1"/>
+                </object>
+              </object>
+            </object>
+            <object type="Bridge" os_index="129" name="Advanced Micro Devices, Inc. [AMD] Family 17h (Models 00h-0fh) Internal PCIe GPP Bridge 0 to Bus B" bridge_type="1-1" depth="1" bridge_pci="0000:[07-07]" pci_busid="0000:00:08.1" pci_type="0604 [1022:1454] [0000:0000] 00" pci_link_speed="15.753846">
+              <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+              <info name="PCIDevice" value="Family 17h (Models 00h-0fh) Internal PCIe GPP Bridge 0 to Bus B"/>
+              <object type="PCIDev" os_index="28674" name="Advanced Micro Devices, Inc. [AMD] FCH SATA Controller [AHCI mode]" pci_busid="0000:07:00.2" pci_type="0106 [1022:7901] [1458:1000] 51" pci_link_speed="15.753846">
+                <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+                <info name="PCIDevice" value="FCH SATA Controller [AHCI mode]"/>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="NUMANode" os_index="1" cpuset="0x0fc00000,0x00000fc0" complete_cpuset="0x0fc00000,0x00000fc0" online_cpuset="0x0fc00000,0x00000fc0" allowed_cpuset="0x0fc00000,0x00000fc0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" local_memory="33819570176">
+        <page_type size="4096" count="8256731"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+        <object type="Group" cpuset="0x0fc00000,0x00000fc0" complete_cpuset="0x0fc00000,0x00000fc0" online_cpuset="0x0fc00000,0x00000fc0" allowed_cpuset="0x0fc00000,0x00000fc0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" depth="0">
+          <object type="Cache" cpuset="0x01c00000,0x000001c0" complete_cpuset="0x01c00000,0x000001c0" online_cpuset="0x01c00000,0x000001c0" allowed_cpuset="0x01c00000,0x000001c0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="8" cpuset="0x00400000,0x00000040" complete_cpuset="0x00400000,0x00000040" online_cpuset="0x00400000,0x00000040" allowed_cpuset="0x00400000,0x00000040" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+              <object type="PU" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" online_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+              <object type="PU" os_index="54" cpuset="0x00400000,0x0" complete_cpuset="0x00400000,0x0" online_cpuset="0x00400000,0x0" allowed_cpuset="0x00400000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+            </object>
+            <object type="Core" os_index="9" cpuset="0x00800000,0x00000080" complete_cpuset="0x00800000,0x00000080" online_cpuset="0x00800000,0x00000080" allowed_cpuset="0x00800000,0x00000080" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+              <object type="PU" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" online_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+              <object type="PU" os_index="55" cpuset="0x00800000,0x0" complete_cpuset="0x00800000,0x0" online_cpuset="0x00800000,0x0" allowed_cpuset="0x00800000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+            </object>
+            <object type="Core" os_index="10" cpuset="0x01000000,0x00000100" complete_cpuset="0x01000000,0x00000100" online_cpuset="0x01000000,0x00000100" allowed_cpuset="0x01000000,0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+              <object type="PU" os_index="8" cpuset="0x00000100" complete_cpuset="0x00000100" online_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+              <object type="PU" os_index="56" cpuset="0x01000000,0x0" complete_cpuset="0x01000000,0x0" online_cpuset="0x01000000,0x0" allowed_cpuset="0x01000000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x0e000000,0x00000e00" complete_cpuset="0x0e000000,0x00000e00" online_cpuset="0x0e000000,0x00000e00" allowed_cpuset="0x0e000000,0x00000e00" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="12" cpuset="0x02000000,0x00000200" complete_cpuset="0x02000000,0x00000200" online_cpuset="0x02000000,0x00000200" allowed_cpuset="0x02000000,0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+              <object type="PU" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" online_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+              <object type="PU" os_index="57" cpuset="0x02000000,0x0" complete_cpuset="0x02000000,0x0" online_cpuset="0x02000000,0x0" allowed_cpuset="0x02000000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+            </object>
+            <object type="Core" os_index="13" cpuset="0x04000000,0x00000400" complete_cpuset="0x04000000,0x00000400" online_cpuset="0x04000000,0x00000400" allowed_cpuset="0x04000000,0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+              <object type="PU" os_index="10" cpuset="0x00000400" complete_cpuset="0x00000400" online_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+              <object type="PU" os_index="58" cpuset="0x04000000,0x0" complete_cpuset="0x04000000,0x0" online_cpuset="0x04000000,0x0" allowed_cpuset="0x04000000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+            </object>
+            <object type="Core" os_index="14" cpuset="0x08000000,0x00000800" complete_cpuset="0x08000000,0x00000800" online_cpuset="0x08000000,0x00000800" allowed_cpuset="0x08000000,0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+              <object type="PU" os_index="11" cpuset="0x00000800" complete_cpuset="0x00000800" online_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+              <object type="PU" os_index="59" cpuset="0x08000000,0x0" complete_cpuset="0x08000000,0x0" online_cpuset="0x08000000,0x0" allowed_cpuset="0x08000000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+            </object>
+          </object>
+          <object type="Bridge" os_index="1" bridge_type="0-1" depth="0" bridge_pci="0000:[10-15]">
+            <object type="Bridge" os_index="65553" name="Advanced Micro Devices, Inc. [AMD] Family 17h (Models 00h-0fh) PCIe GPP Bridge" bridge_type="1-1" depth="1" bridge_pci="0000:[11-13]" pci_busid="0000:10:01.1" pci_type="0604 [1022:1453] [0000:0000] 00" pci_link_speed="3.938462">
+              <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+              <info name="PCIDevice" value="Family 17h (Models 00h-0fh) PCIe GPP Bridge"/>
+              <object type="Bridge" os_index="69632" name="Advanced Micro Devices, Inc. [AMD/ATI]" bridge_type="1-1" depth="2" bridge_pci="0000:[12-13]" pci_busid="0000:11:00.0" pci_type="0604 [1002:14a0] [0000:0000] 02" pci_link_speed="3.938462">
+                <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD/ATI]"/>
+                <object type="Bridge" os_index="73728" name="Advanced Micro Devices, Inc. [AMD/ATI]" bridge_type="1-1" depth="3" bridge_pci="0000:[13-13]" pci_busid="0000:12:00.0" pci_type="0604 [1002:14a1] [0000:0000] 00" pci_link_speed="31.507692">
+                  <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD/ATI]"/>
+                  <object type="PCIDev" os_index="77824" name="Advanced Micro Devices, Inc. [AMD/ATI] Vega 20" pci_busid="0000:13:00.0" pci_type="0380 [1002:66a1] [1002:0834] 02" pci_link_speed="31.507692">
+                    <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD/ATI]"/>
+                    <info name="PCIDevice" value="Vega 20"/>
+                    <object type="OSDev" name="card1" osdev_type="1"/>
+                    <object type="OSDev" name="renderD128" osdev_type="1"/>
+                    <object type="OSDev" name="controlD65" osdev_type="1"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="NUMANode" os_index="2" cpuset="0x00000003,0xf0000000,0x0003f000" complete_cpuset="0x00000003,0xf0000000,0x0003f000" online_cpuset="0x00000003,0xf0000000,0x0003f000" allowed_cpuset="0x00000003,0xf0000000,0x0003f000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" local_memory="33819574272">
+        <page_type size="4096" count="8256732"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+        <object type="Group" cpuset="0x00000003,0xf0000000,0x0003f000" complete_cpuset="0x00000003,0xf0000000,0x0003f000" online_cpuset="0x00000003,0xf0000000,0x0003f000" allowed_cpuset="0x00000003,0xf0000000,0x0003f000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" depth="0">
+          <object type="Cache" cpuset="0x70000000,0x00007000" complete_cpuset="0x70000000,0x00007000" online_cpuset="0x70000000,0x00007000" allowed_cpuset="0x70000000,0x00007000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="16" cpuset="0x10000000,0x00001000" complete_cpuset="0x10000000,0x00001000" online_cpuset="0x10000000,0x00001000" allowed_cpuset="0x10000000,0x00001000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004">
+              <object type="PU" os_index="12" cpuset="0x00001000" complete_cpuset="0x00001000" online_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+              <object type="PU" os_index="60" cpuset="0x10000000,0x0" complete_cpuset="0x10000000,0x0" online_cpuset="0x10000000,0x0" allowed_cpuset="0x10000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+            </object>
+            <object type="Core" os_index="17" cpuset="0x20000000,0x00002000" complete_cpuset="0x20000000,0x00002000" online_cpuset="0x20000000,0x00002000" allowed_cpuset="0x20000000,0x00002000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004">
+              <object type="PU" os_index="13" cpuset="0x00002000" complete_cpuset="0x00002000" online_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+              <object type="PU" os_index="61" cpuset="0x20000000,0x0" complete_cpuset="0x20000000,0x0" online_cpuset="0x20000000,0x0" allowed_cpuset="0x20000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+            </object>
+            <object type="Core" os_index="18" cpuset="0x40000000,0x00004000" complete_cpuset="0x40000000,0x00004000" online_cpuset="0x40000000,0x00004000" allowed_cpuset="0x40000000,0x00004000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004">
+              <object type="PU" os_index="14" cpuset="0x00004000" complete_cpuset="0x00004000" online_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+              <object type="PU" os_index="62" cpuset="0x40000000,0x0" complete_cpuset="0x40000000,0x0" online_cpuset="0x40000000,0x0" allowed_cpuset="0x40000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000003,0x80000000,0x00038000" complete_cpuset="0x00000003,0x80000000,0x00038000" online_cpuset="0x00000003,0x80000000,0x00038000" allowed_cpuset="0x00000003,0x80000000,0x00038000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="20" cpuset="0x80000000,0x00008000" complete_cpuset="0x80000000,0x00008000" online_cpuset="0x80000000,0x00008000" allowed_cpuset="0x80000000,0x00008000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004">
+              <object type="PU" os_index="15" cpuset="0x00008000" complete_cpuset="0x00008000" online_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+              <object type="PU" os_index="63" cpuset="0x80000000,0x0" complete_cpuset="0x80000000,0x0" online_cpuset="0x80000000,0x0" allowed_cpuset="0x80000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+            </object>
+            <object type="Core" os_index="21" cpuset="0x00000001,,0x00010000" complete_cpuset="0x00000001,,0x00010000" online_cpuset="0x00000001,,0x00010000" allowed_cpuset="0x00000001,,0x00010000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004">
+              <object type="PU" os_index="16" cpuset="0x00010000" complete_cpuset="0x00010000" online_cpuset="0x00010000" allowed_cpuset="0x00010000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+              <object type="PU" os_index="64" cpuset="0x00000001,,0x0" complete_cpuset="0x00000001,,0x0" online_cpuset="0x00000001,,0x0" allowed_cpuset="0x00000001,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+            </object>
+            <object type="Core" os_index="22" cpuset="0x00000002,,0x00020000" complete_cpuset="0x00000002,,0x00020000" online_cpuset="0x00000002,,0x00020000" allowed_cpuset="0x00000002,,0x00020000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004">
+              <object type="PU" os_index="17" cpuset="0x00020000" complete_cpuset="0x00020000" online_cpuset="0x00020000" allowed_cpuset="0x00020000" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+              <object type="PU" os_index="65" cpuset="0x00000002,,0x0" complete_cpuset="0x00000002,,0x0" online_cpuset="0x00000002,,0x0" allowed_cpuset="0x00000002,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+            </object>
+          </object>
+          <object type="Bridge" os_index="2" bridge_type="0-1" depth="0" bridge_pci="0000:[20-25]">
+            <object type="Bridge" os_index="131121" name="Advanced Micro Devices, Inc. [AMD] Family 17h (Models 00h-0fh) PCIe GPP Bridge" bridge_type="1-1" depth="1" bridge_pci="0000:[21-23]" pci_busid="0000:20:03.1" pci_type="0604 [1022:1453] [0000:0000] 00" pci_link_speed="3.938462">
+              <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+              <info name="PCIDevice" value="Family 17h (Models 00h-0fh) PCIe GPP Bridge"/>
+              <object type="Bridge" os_index="135168" name="Advanced Micro Devices, Inc. [AMD/ATI]" bridge_type="1-1" depth="2" bridge_pci="0000:[22-23]" pci_busid="0000:21:00.0" pci_type="0604 [1002:14a0] [0000:0000] 02" pci_link_speed="3.938462">
+                <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD/ATI]"/>
+                <object type="Bridge" os_index="139264" name="Advanced Micro Devices, Inc. [AMD/ATI]" bridge_type="1-1" depth="3" bridge_pci="0000:[23-23]" pci_busid="0000:22:00.0" pci_type="0604 [1002:14a1] [0000:0000] 00" pci_link_speed="31.507692">
+                  <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD/ATI]"/>
+                  <object type="PCIDev" os_index="143360" name="Advanced Micro Devices, Inc. [AMD/ATI] Vega 20" pci_busid="0000:23:00.0" pci_type="0380 [1002:66a1] [1002:0834] 02" pci_link_speed="31.507692">
+                    <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD/ATI]"/>
+                    <info name="PCIDevice" value="Vega 20"/>
+                    <object type="OSDev" name="card2" osdev_type="1"/>
+                    <object type="OSDev" name="renderD129" osdev_type="1"/>
+                    <object type="OSDev" name="controlD66" osdev_type="1"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="NUMANode" os_index="3" cpuset="0x000000fc,,0x00fc0000" complete_cpuset="0x000000fc,,0x00fc0000" online_cpuset="0x000000fc,,0x00fc0000" allowed_cpuset="0x000000fc,,0x00fc0000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" local_memory="33802997760">
+        <page_type size="4096" count="8252685"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+        <object type="Group" cpuset="0x000000fc,,0x00fc0000" complete_cpuset="0x000000fc,,0x00fc0000" online_cpuset="0x000000fc,,0x00fc0000" allowed_cpuset="0x000000fc,,0x00fc0000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" depth="0">
+          <object type="Cache" cpuset="0x0000001c,,0x001c0000" complete_cpuset="0x0000001c,,0x001c0000" online_cpuset="0x0000001c,,0x001c0000" allowed_cpuset="0x0000001c,,0x001c0000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="24" cpuset="0x00000004,,0x00040000" complete_cpuset="0x00000004,,0x00040000" online_cpuset="0x00000004,,0x00040000" allowed_cpuset="0x00000004,,0x00040000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008">
+              <object type="PU" os_index="18" cpuset="0x00040000" complete_cpuset="0x00040000" online_cpuset="0x00040000" allowed_cpuset="0x00040000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+              <object type="PU" os_index="66" cpuset="0x00000004,,0x0" complete_cpuset="0x00000004,,0x0" online_cpuset="0x00000004,,0x0" allowed_cpuset="0x00000004,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+            </object>
+            <object type="Core" os_index="25" cpuset="0x00000008,,0x00080000" complete_cpuset="0x00000008,,0x00080000" online_cpuset="0x00000008,,0x00080000" allowed_cpuset="0x00000008,,0x00080000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008">
+              <object type="PU" os_index="19" cpuset="0x00080000" complete_cpuset="0x00080000" online_cpuset="0x00080000" allowed_cpuset="0x00080000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+              <object type="PU" os_index="67" cpuset="0x00000008,,0x0" complete_cpuset="0x00000008,,0x0" online_cpuset="0x00000008,,0x0" allowed_cpuset="0x00000008,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+            </object>
+            <object type="Core" os_index="26" cpuset="0x00000010,,0x00100000" complete_cpuset="0x00000010,,0x00100000" online_cpuset="0x00000010,,0x00100000" allowed_cpuset="0x00000010,,0x00100000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008">
+              <object type="PU" os_index="20" cpuset="0x00100000" complete_cpuset="0x00100000" online_cpuset="0x00100000" allowed_cpuset="0x00100000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+              <object type="PU" os_index="68" cpuset="0x00000010,,0x0" complete_cpuset="0x00000010,,0x0" online_cpuset="0x00000010,,0x0" allowed_cpuset="0x00000010,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x000000e0,,0x00e00000" complete_cpuset="0x000000e0,,0x00e00000" online_cpuset="0x000000e0,,0x00e00000" allowed_cpuset="0x000000e0,,0x00e00000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="28" cpuset="0x00000020,,0x00200000" complete_cpuset="0x00000020,,0x00200000" online_cpuset="0x00000020,,0x00200000" allowed_cpuset="0x00000020,,0x00200000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008">
+              <object type="PU" os_index="21" cpuset="0x00200000" complete_cpuset="0x00200000" online_cpuset="0x00200000" allowed_cpuset="0x00200000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+              <object type="PU" os_index="69" cpuset="0x00000020,,0x0" complete_cpuset="0x00000020,,0x0" online_cpuset="0x00000020,,0x0" allowed_cpuset="0x00000020,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+            </object>
+            <object type="Core" os_index="29" cpuset="0x00000040,,0x00400000" complete_cpuset="0x00000040,,0x00400000" online_cpuset="0x00000040,,0x00400000" allowed_cpuset="0x00000040,,0x00400000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008">
+              <object type="PU" os_index="22" cpuset="0x00400000" complete_cpuset="0x00400000" online_cpuset="0x00400000" allowed_cpuset="0x00400000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+              <object type="PU" os_index="70" cpuset="0x00000040,,0x0" complete_cpuset="0x00000040,,0x0" online_cpuset="0x00000040,,0x0" allowed_cpuset="0x00000040,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+            </object>
+            <object type="Core" os_index="30" cpuset="0x00000080,,0x00800000" complete_cpuset="0x00000080,,0x00800000" online_cpuset="0x00000080,,0x00800000" allowed_cpuset="0x00000080,,0x00800000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008">
+              <object type="PU" os_index="23" cpuset="0x00800000" complete_cpuset="0x00800000" online_cpuset="0x00800000" allowed_cpuset="0x00800000" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+              <object type="PU" os_index="71" cpuset="0x00000080,,0x0" complete_cpuset="0x00000080,,0x0" online_cpuset="0x00000080,,0x0" allowed_cpuset="0x00000080,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+            </object>
+          </object>
+          <object type="Bridge" os_index="3" bridge_type="0-1" depth="0" bridge_pci="0000:[30-36]">
+            <object type="Bridge" os_index="196657" name="Advanced Micro Devices, Inc. [AMD] Family 17h (Models 00h-0fh) PCIe GPP Bridge" bridge_type="1-1" depth="1" bridge_pci="0000:[31-34]" pci_busid="0000:30:03.1" pci_type="0604 [1022:1453] [0000:0000] 00" pci_link_speed="15.753846">
+              <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+              <info name="PCIDevice" value="Family 17h (Models 00h-0fh) PCIe GPP Bridge"/>
+              <object type="Bridge" os_index="200704" name="PLX Technology, Inc. PEX 8747 48-Lane, 5-Port PCI Express Gen 3 (8.0 GT/s) Switch" bridge_type="1-1" depth="2" bridge_pci="0000:[32-34]" pci_busid="0000:31:00.0" pci_type="0604 [10b5:8747] [0000:0000] ca" pci_link_speed="15.753846">
+                <info name="PCIVendor" value="PLX Technology, Inc."/>
+                <info name="PCIDevice" value="PEX 8747 48-Lane, 5-Port PCI Express Gen 3 (8.0 GT/s) Switch"/>
+                <object type="Bridge" os_index="204928" name="PLX Technology, Inc. PEX 8747 48-Lane, 5-Port PCI Express Gen 3 (8.0 GT/s) Switch" bridge_type="1-1" depth="3" bridge_pci="0000:[33-33]" pci_busid="0000:32:08.0" pci_type="0604 [10b5:8747] [0000:0000] ca" pci_link_speed="15.753846">
+                  <info name="PCIVendor" value="PLX Technology, Inc."/>
+                  <info name="PCIDevice" value="PEX 8747 48-Lane, 5-Port PCI Express Gen 3 (8.0 GT/s) Switch"/>
+                  <object type="PCIDev" os_index="208896" name="Mellanox Technologies MT28908 Family [ConnectX-6]" pci_busid="0000:33:00.0" pci_type="0207 [15b3:101b] [15b3:0006] 00" pci_link_speed="15.753846">
+                    <info name="PCIVendor" value="Mellanox Technologies"/>
+                    <info name="PCIDevice" value="MT28908 Family [ConnectX-6]"/>
+                    <object type="OSDev" name="hsi0" osdev_type="2">
+                      <info name="Address" value="80:00:01:07:fe:80:00:00:00:00:00:00:98:03:9b:03:00:82:9d:b4"/>
+                      <info name="Port" value="1"/>
+                    </object>
+                    <object type="OSDev" name="mlx5_0" osdev_type="3">
+                      <info name="NodeGUID" value="9803:9b03:0082:9db4"/>
+                      <info name="SysImageGUID" value="9803:9b03:0082:9db4"/>
+                      <info name="Port1State" value="4"/>
+                      <info name="Port1LID" value="0x1c"/>
+                      <info name="Port1LMC" value="0"/>
+                      <info name="Port1GID0" value="fe80:0000:0000:0000:9803:9b03:0082:9db4"/>
+                    </object>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+    </object>
+    <object type="Socket" os_index="1" cpuset="0xffffff00,0x0000ffff,0xff000000" complete_cpuset="0xffffff00,0x0000ffff,0xff000000" online_cpuset="0xffffff00,0x0000ffff,0xff000000" allowed_cpuset="0xffffff00,0x0000ffff,0xff000000" nodeset="0x000000f0" complete_nodeset="0x000000f0" allowed_nodeset="0x000000f0">
+      <info name="CPUVendor" value="AuthenticAMD"/>
+      <info name="CPUFamilyNumber" value="23"/>
+      <info name="CPUModelNumber" value="1"/>
+      <info name="CPUModel" value="AMD EPYC 7401 24-Core Processor"/>
+      <info name="CPUStepping" value="2"/>
+      <object type="NUMANode" os_index="4" cpuset="0x00003f00,,0x3f000000" complete_cpuset="0x00003f00,,0x3f000000" online_cpuset="0x00003f00,,0x3f000000" allowed_cpuset="0x00003f00,,0x3f000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" local_memory="33819574272">
+        <page_type size="4096" count="8256732"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+        <object type="Group" cpuset="0x00003f00,,0x3f000000" complete_cpuset="0x00003f00,,0x3f000000" online_cpuset="0x00003f00,,0x3f000000" allowed_cpuset="0x00003f00,,0x3f000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" depth="0">
+          <object type="Cache" cpuset="0x00000700,,0x07000000" complete_cpuset="0x00000700,,0x07000000" online_cpuset="0x00000700,,0x07000000" allowed_cpuset="0x00000700,,0x07000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="0" cpuset="0x00000100,,0x01000000" complete_cpuset="0x00000100,,0x01000000" online_cpuset="0x00000100,,0x01000000" allowed_cpuset="0x00000100,,0x01000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010">
+              <object type="PU" os_index="24" cpuset="0x01000000" complete_cpuset="0x01000000" online_cpuset="0x01000000" allowed_cpuset="0x01000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
+              <object type="PU" os_index="72" cpuset="0x00000100,,0x0" complete_cpuset="0x00000100,,0x0" online_cpuset="0x00000100,,0x0" allowed_cpuset="0x00000100,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
+            </object>
+            <object type="Core" os_index="1" cpuset="0x00000200,,0x02000000" complete_cpuset="0x00000200,,0x02000000" online_cpuset="0x00000200,,0x02000000" allowed_cpuset="0x00000200,,0x02000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010">
+              <object type="PU" os_index="25" cpuset="0x02000000" complete_cpuset="0x02000000" online_cpuset="0x02000000" allowed_cpuset="0x02000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
+              <object type="PU" os_index="73" cpuset="0x00000200,,0x0" complete_cpuset="0x00000200,,0x0" online_cpuset="0x00000200,,0x0" allowed_cpuset="0x00000200,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
+            </object>
+            <object type="Core" os_index="2" cpuset="0x00000400,,0x04000000" complete_cpuset="0x00000400,,0x04000000" online_cpuset="0x00000400,,0x04000000" allowed_cpuset="0x00000400,,0x04000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010">
+              <object type="PU" os_index="26" cpuset="0x04000000" complete_cpuset="0x04000000" online_cpuset="0x04000000" allowed_cpuset="0x04000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
+              <object type="PU" os_index="74" cpuset="0x00000400,,0x0" complete_cpuset="0x00000400,,0x0" online_cpuset="0x00000400,,0x0" allowed_cpuset="0x00000400,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00003800,,0x38000000" complete_cpuset="0x00003800,,0x38000000" online_cpuset="0x00003800,,0x38000000" allowed_cpuset="0x00003800,,0x38000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="4" cpuset="0x00000800,,0x08000000" complete_cpuset="0x00000800,,0x08000000" online_cpuset="0x00000800,,0x08000000" allowed_cpuset="0x00000800,,0x08000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010">
+              <object type="PU" os_index="27" cpuset="0x08000000" complete_cpuset="0x08000000" online_cpuset="0x08000000" allowed_cpuset="0x08000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
+              <object type="PU" os_index="75" cpuset="0x00000800,,0x0" complete_cpuset="0x00000800,,0x0" online_cpuset="0x00000800,,0x0" allowed_cpuset="0x00000800,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
+            </object>
+            <object type="Core" os_index="5" cpuset="0x00001000,,0x10000000" complete_cpuset="0x00001000,,0x10000000" online_cpuset="0x00001000,,0x10000000" allowed_cpuset="0x00001000,,0x10000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010">
+              <object type="PU" os_index="28" cpuset="0x10000000" complete_cpuset="0x10000000" online_cpuset="0x10000000" allowed_cpuset="0x10000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
+              <object type="PU" os_index="76" cpuset="0x00001000,,0x0" complete_cpuset="0x00001000,,0x0" online_cpuset="0x00001000,,0x0" allowed_cpuset="0x00001000,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
+            </object>
+            <object type="Core" os_index="6" cpuset="0x00002000,,0x20000000" complete_cpuset="0x00002000,,0x20000000" online_cpuset="0x00002000,,0x20000000" allowed_cpuset="0x00002000,,0x20000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010">
+              <object type="PU" os_index="29" cpuset="0x20000000" complete_cpuset="0x20000000" online_cpuset="0x20000000" allowed_cpuset="0x20000000" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
+              <object type="PU" os_index="77" cpuset="0x00002000,,0x0" complete_cpuset="0x00002000,,0x0" online_cpuset="0x00002000,,0x0" allowed_cpuset="0x00002000,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="NUMANode" os_index="5" cpuset="0x000fc000,0x0000000f,0xc0000000" complete_cpuset="0x000fc000,0x0000000f,0xc0000000" online_cpuset="0x000fc000,0x0000000f,0xc0000000" allowed_cpuset="0x000fc000,0x0000000f,0xc0000000" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" local_memory="33819570176">
+        <page_type size="4096" count="8256731"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+        <object type="Group" cpuset="0x000fc000,0x0000000f,0xc0000000" complete_cpuset="0x000fc000,0x0000000f,0xc0000000" online_cpuset="0x000fc000,0x0000000f,0xc0000000" allowed_cpuset="0x000fc000,0x0000000f,0xc0000000" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" depth="0">
+          <object type="Cache" cpuset="0x0001c000,0x00000001,0xc0000000" complete_cpuset="0x0001c000,0x00000001,0xc0000000" online_cpuset="0x0001c000,0x00000001,0xc0000000" allowed_cpuset="0x0001c000,0x00000001,0xc0000000" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="8" cpuset="0x00004000,,0x40000000" complete_cpuset="0x00004000,,0x40000000" online_cpuset="0x00004000,,0x40000000" allowed_cpuset="0x00004000,,0x40000000" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020">
+              <object type="PU" os_index="30" cpuset="0x40000000" complete_cpuset="0x40000000" online_cpuset="0x40000000" allowed_cpuset="0x40000000" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
+              <object type="PU" os_index="78" cpuset="0x00004000,,0x0" complete_cpuset="0x00004000,,0x0" online_cpuset="0x00004000,,0x0" allowed_cpuset="0x00004000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
+            </object>
+            <object type="Core" os_index="9" cpuset="0x00008000,,0x80000000" complete_cpuset="0x00008000,,0x80000000" online_cpuset="0x00008000,,0x80000000" allowed_cpuset="0x00008000,,0x80000000" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020">
+              <object type="PU" os_index="31" cpuset="0x80000000" complete_cpuset="0x80000000" online_cpuset="0x80000000" allowed_cpuset="0x80000000" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
+              <object type="PU" os_index="79" cpuset="0x00008000,,0x0" complete_cpuset="0x00008000,,0x0" online_cpuset="0x00008000,,0x0" allowed_cpuset="0x00008000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
+            </object>
+            <object type="Core" os_index="10" cpuset="0x00010000,0x00000001,0x0" complete_cpuset="0x00010000,0x00000001,0x0" online_cpuset="0x00010000,0x00000001,0x0" allowed_cpuset="0x00010000,0x00000001,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020">
+              <object type="PU" os_index="32" cpuset="0x00000001,0x0" complete_cpuset="0x00000001,0x0" online_cpuset="0x00000001,0x0" allowed_cpuset="0x00000001,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
+              <object type="PU" os_index="80" cpuset="0x00010000,,0x0" complete_cpuset="0x00010000,,0x0" online_cpuset="0x00010000,,0x0" allowed_cpuset="0x00010000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x000e0000,0x0000000e,0x0" complete_cpuset="0x000e0000,0x0000000e,0x0" online_cpuset="0x000e0000,0x0000000e,0x0" allowed_cpuset="0x000e0000,0x0000000e,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="12" cpuset="0x00020000,0x00000002,0x0" complete_cpuset="0x00020000,0x00000002,0x0" online_cpuset="0x00020000,0x00000002,0x0" allowed_cpuset="0x00020000,0x00000002,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020">
+              <object type="PU" os_index="33" cpuset="0x00000002,0x0" complete_cpuset="0x00000002,0x0" online_cpuset="0x00000002,0x0" allowed_cpuset="0x00000002,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
+              <object type="PU" os_index="81" cpuset="0x00020000,,0x0" complete_cpuset="0x00020000,,0x0" online_cpuset="0x00020000,,0x0" allowed_cpuset="0x00020000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
+            </object>
+            <object type="Core" os_index="13" cpuset="0x00040000,0x00000004,0x0" complete_cpuset="0x00040000,0x00000004,0x0" online_cpuset="0x00040000,0x00000004,0x0" allowed_cpuset="0x00040000,0x00000004,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020">
+              <object type="PU" os_index="34" cpuset="0x00000004,0x0" complete_cpuset="0x00000004,0x0" online_cpuset="0x00000004,0x0" allowed_cpuset="0x00000004,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
+              <object type="PU" os_index="82" cpuset="0x00040000,,0x0" complete_cpuset="0x00040000,,0x0" online_cpuset="0x00040000,,0x0" allowed_cpuset="0x00040000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
+            </object>
+            <object type="Core" os_index="14" cpuset="0x00080000,0x00000008,0x0" complete_cpuset="0x00080000,0x00000008,0x0" online_cpuset="0x00080000,0x00000008,0x0" allowed_cpuset="0x00080000,0x00000008,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020">
+              <object type="PU" os_index="35" cpuset="0x00000008,0x0" complete_cpuset="0x00000008,0x0" online_cpuset="0x00000008,0x0" allowed_cpuset="0x00000008,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
+              <object type="PU" os_index="83" cpuset="0x00080000,,0x0" complete_cpuset="0x00080000,,0x0" online_cpuset="0x00080000,,0x0" allowed_cpuset="0x00080000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
+            </object>
+          </object>
+          <object type="Bridge" os_index="5" bridge_type="0-1" depth="0" bridge_pci="0000:[50-55]">
+            <object type="Bridge" os_index="327697" name="Advanced Micro Devices, Inc. [AMD] Family 17h (Models 00h-0fh) PCIe GPP Bridge" bridge_type="1-1" depth="1" bridge_pci="0000:[51-53]" pci_busid="0000:50:01.1" pci_type="0604 [1022:1453] [0000:0000] 00" pci_link_speed="3.938462">
+              <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+              <info name="PCIDevice" value="Family 17h (Models 00h-0fh) PCIe GPP Bridge"/>
+              <object type="Bridge" os_index="331776" name="Advanced Micro Devices, Inc. [AMD/ATI]" bridge_type="1-1" depth="2" bridge_pci="0000:[52-53]" pci_busid="0000:51:00.0" pci_type="0604 [1002:14a0] [0000:0000] 02" pci_link_speed="3.938462">
+                <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD/ATI]"/>
+                <object type="Bridge" os_index="335872" name="Advanced Micro Devices, Inc. [AMD/ATI]" bridge_type="1-1" depth="3" bridge_pci="0000:[53-53]" pci_busid="0000:52:00.0" pci_type="0604 [1002:14a1] [0000:0000] 00" pci_link_speed="31.507692">
+                  <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD/ATI]"/>
+                  <object type="PCIDev" os_index="339968" name="Advanced Micro Devices, Inc. [AMD/ATI] Vega 20" pci_busid="0000:53:00.0" pci_type="0380 [1002:66a1] [1002:0834] 02" pci_link_speed="31.507692">
+                    <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD/ATI]"/>
+                    <info name="PCIDevice" value="Vega 20"/>
+                    <object type="OSDev" name="card3" osdev_type="1"/>
+                    <object type="OSDev" name="renderD130" osdev_type="1"/>
+                    <object type="OSDev" name="controlD67" osdev_type="1"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="NUMANode" os_index="6" cpuset="0x03f00000,0x000003f0,0x0" complete_cpuset="0x03f00000,0x000003f0,0x0" online_cpuset="0x03f00000,0x000003f0,0x0" allowed_cpuset="0x03f00000,0x000003f0,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" local_memory="33819574272">
+        <page_type size="4096" count="8256732"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+        <object type="Group" cpuset="0x03f00000,0x000003f0,0x0" complete_cpuset="0x03f00000,0x000003f0,0x0" online_cpuset="0x03f00000,0x000003f0,0x0" allowed_cpuset="0x03f00000,0x000003f0,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" depth="0">
+          <object type="Cache" cpuset="0x00700000,0x00000070,0x0" complete_cpuset="0x00700000,0x00000070,0x0" online_cpuset="0x00700000,0x00000070,0x0" allowed_cpuset="0x00700000,0x00000070,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="16" cpuset="0x00100000,0x00000010,0x0" complete_cpuset="0x00100000,0x00000010,0x0" online_cpuset="0x00100000,0x00000010,0x0" allowed_cpuset="0x00100000,0x00000010,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040">
+              <object type="PU" os_index="36" cpuset="0x00000010,0x0" complete_cpuset="0x00000010,0x0" online_cpuset="0x00000010,0x0" allowed_cpuset="0x00000010,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
+              <object type="PU" os_index="84" cpuset="0x00100000,,0x0" complete_cpuset="0x00100000,,0x0" online_cpuset="0x00100000,,0x0" allowed_cpuset="0x00100000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
+            </object>
+            <object type="Core" os_index="17" cpuset="0x00200000,0x00000020,0x0" complete_cpuset="0x00200000,0x00000020,0x0" online_cpuset="0x00200000,0x00000020,0x0" allowed_cpuset="0x00200000,0x00000020,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040">
+              <object type="PU" os_index="37" cpuset="0x00000020,0x0" complete_cpuset="0x00000020,0x0" online_cpuset="0x00000020,0x0" allowed_cpuset="0x00000020,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
+              <object type="PU" os_index="85" cpuset="0x00200000,,0x0" complete_cpuset="0x00200000,,0x0" online_cpuset="0x00200000,,0x0" allowed_cpuset="0x00200000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
+            </object>
+            <object type="Core" os_index="18" cpuset="0x00400000,0x00000040,0x0" complete_cpuset="0x00400000,0x00000040,0x0" online_cpuset="0x00400000,0x00000040,0x0" allowed_cpuset="0x00400000,0x00000040,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040">
+              <object type="PU" os_index="38" cpuset="0x00000040,0x0" complete_cpuset="0x00000040,0x0" online_cpuset="0x00000040,0x0" allowed_cpuset="0x00000040,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
+              <object type="PU" os_index="86" cpuset="0x00400000,,0x0" complete_cpuset="0x00400000,,0x0" online_cpuset="0x00400000,,0x0" allowed_cpuset="0x00400000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x03800000,0x00000380,0x0" complete_cpuset="0x03800000,0x00000380,0x0" online_cpuset="0x03800000,0x00000380,0x0" allowed_cpuset="0x03800000,0x00000380,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="20" cpuset="0x00800000,0x00000080,0x0" complete_cpuset="0x00800000,0x00000080,0x0" online_cpuset="0x00800000,0x00000080,0x0" allowed_cpuset="0x00800000,0x00000080,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040">
+              <object type="PU" os_index="39" cpuset="0x00000080,0x0" complete_cpuset="0x00000080,0x0" online_cpuset="0x00000080,0x0" allowed_cpuset="0x00000080,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
+              <object type="PU" os_index="87" cpuset="0x00800000,,0x0" complete_cpuset="0x00800000,,0x0" online_cpuset="0x00800000,,0x0" allowed_cpuset="0x00800000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
+            </object>
+            <object type="Core" os_index="21" cpuset="0x01000000,0x00000100,0x0" complete_cpuset="0x01000000,0x00000100,0x0" online_cpuset="0x01000000,0x00000100,0x0" allowed_cpuset="0x01000000,0x00000100,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040">
+              <object type="PU" os_index="40" cpuset="0x00000100,0x0" complete_cpuset="0x00000100,0x0" online_cpuset="0x00000100,0x0" allowed_cpuset="0x00000100,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
+              <object type="PU" os_index="88" cpuset="0x01000000,,0x0" complete_cpuset="0x01000000,,0x0" online_cpuset="0x01000000,,0x0" allowed_cpuset="0x01000000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
+            </object>
+            <object type="Core" os_index="22" cpuset="0x02000000,0x00000200,0x0" complete_cpuset="0x02000000,0x00000200,0x0" online_cpuset="0x02000000,0x00000200,0x0" allowed_cpuset="0x02000000,0x00000200,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040">
+              <object type="PU" os_index="41" cpuset="0x00000200,0x0" complete_cpuset="0x00000200,0x0" online_cpuset="0x00000200,0x0" allowed_cpuset="0x00000200,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
+              <object type="PU" os_index="89" cpuset="0x02000000,,0x0" complete_cpuset="0x02000000,,0x0" online_cpuset="0x02000000,,0x0" allowed_cpuset="0x02000000,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="NUMANode" os_index="7" cpuset="0xfc000000,0x0000fc00,0x0" complete_cpuset="0xfc000000,0x0000fc00,0x0" online_cpuset="0xfc000000,0x0000fc00,0x0" allowed_cpuset="0xfc000000,0x0000fc00,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" local_memory="33819033600">
+        <page_type size="4096" count="8256600"/>
+        <page_type size="2097152" count="0"/>
+        <page_type size="1073741824" count="0"/>
+        <object type="Group" cpuset="0xfc000000,0x0000fc00,0x0" complete_cpuset="0xfc000000,0x0000fc00,0x0" online_cpuset="0xfc000000,0x0000fc00,0x0" allowed_cpuset="0xfc000000,0x0000fc00,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" depth="0">
+          <object type="Cache" cpuset="0x1c000000,0x00001c00,0x0" complete_cpuset="0x1c000000,0x00001c00,0x0" online_cpuset="0x1c000000,0x00001c00,0x0" allowed_cpuset="0x1c000000,0x00001c00,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="24" cpuset="0x04000000,0x00000400,0x0" complete_cpuset="0x04000000,0x00000400,0x0" online_cpuset="0x04000000,0x00000400,0x0" allowed_cpuset="0x04000000,0x00000400,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080">
+              <object type="PU" os_index="42" cpuset="0x00000400,0x0" complete_cpuset="0x00000400,0x0" online_cpuset="0x00000400,0x0" allowed_cpuset="0x00000400,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
+              <object type="PU" os_index="90" cpuset="0x04000000,,0x0" complete_cpuset="0x04000000,,0x0" online_cpuset="0x04000000,,0x0" allowed_cpuset="0x04000000,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
+            </object>
+            <object type="Core" os_index="25" cpuset="0x08000000,0x00000800,0x0" complete_cpuset="0x08000000,0x00000800,0x0" online_cpuset="0x08000000,0x00000800,0x0" allowed_cpuset="0x08000000,0x00000800,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080">
+              <object type="PU" os_index="43" cpuset="0x00000800,0x0" complete_cpuset="0x00000800,0x0" online_cpuset="0x00000800,0x0" allowed_cpuset="0x00000800,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
+              <object type="PU" os_index="91" cpuset="0x08000000,,0x0" complete_cpuset="0x08000000,,0x0" online_cpuset="0x08000000,,0x0" allowed_cpuset="0x08000000,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
+            </object>
+            <object type="Core" os_index="26" cpuset="0x10000000,0x00001000,0x0" complete_cpuset="0x10000000,0x00001000,0x0" online_cpuset="0x10000000,0x00001000,0x0" allowed_cpuset="0x10000000,0x00001000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080">
+              <object type="PU" os_index="44" cpuset="0x00001000,0x0" complete_cpuset="0x00001000,0x0" online_cpuset="0x00001000,0x0" allowed_cpuset="0x00001000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
+              <object type="PU" os_index="92" cpuset="0x10000000,,0x0" complete_cpuset="0x10000000,,0x0" online_cpuset="0x10000000,,0x0" allowed_cpuset="0x10000000,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0xe0000000,0x0000e000,0x0" complete_cpuset="0xe0000000,0x0000e000,0x0" online_cpuset="0xe0000000,0x0000e000,0x0" allowed_cpuset="0xe0000000,0x0000e000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Core" os_index="28" cpuset="0x20000000,0x00002000,0x0" complete_cpuset="0x20000000,0x00002000,0x0" online_cpuset="0x20000000,0x00002000,0x0" allowed_cpuset="0x20000000,0x00002000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080">
+              <object type="PU" os_index="45" cpuset="0x00002000,0x0" complete_cpuset="0x00002000,0x0" online_cpuset="0x00002000,0x0" allowed_cpuset="0x00002000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
+              <object type="PU" os_index="93" cpuset="0x20000000,,0x0" complete_cpuset="0x20000000,,0x0" online_cpuset="0x20000000,,0x0" allowed_cpuset="0x20000000,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
+            </object>
+            <object type="Core" os_index="29" cpuset="0x40000000,0x00004000,0x0" complete_cpuset="0x40000000,0x00004000,0x0" online_cpuset="0x40000000,0x00004000,0x0" allowed_cpuset="0x40000000,0x00004000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080">
+              <object type="PU" os_index="46" cpuset="0x00004000,0x0" complete_cpuset="0x00004000,0x0" online_cpuset="0x00004000,0x0" allowed_cpuset="0x00004000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
+              <object type="PU" os_index="94" cpuset="0x40000000,,0x0" complete_cpuset="0x40000000,,0x0" online_cpuset="0x40000000,,0x0" allowed_cpuset="0x40000000,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
+            </object>
+            <object type="Core" os_index="30" cpuset="0x80000000,0x00008000,0x0" complete_cpuset="0x80000000,0x00008000,0x0" online_cpuset="0x80000000,0x00008000,0x0" allowed_cpuset="0x80000000,0x00008000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080">
+              <object type="PU" os_index="47" cpuset="0x00008000,0x0" complete_cpuset="0x00008000,0x0" online_cpuset="0x00008000,0x0" allowed_cpuset="0x00008000,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
+              <object type="PU" os_index="95" cpuset="0x80000000,,0x0" complete_cpuset="0x80000000,,0x0" online_cpuset="0x80000000,,0x0" allowed_cpuset="0x80000000,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
+            </object>
+          </object>
+          <object type="Bridge" os_index="7" bridge_type="0-1" depth="0" bridge_pci="0000:[70-75]">
+            <object type="Bridge" os_index="458801" name="Advanced Micro Devices, Inc. [AMD] Family 17h (Models 00h-0fh) PCIe GPP Bridge" bridge_type="1-1" depth="1" bridge_pci="0000:[71-73]" pci_busid="0000:70:03.1" pci_type="0604 [1022:1453] [0000:0000] 00" pci_link_speed="3.938462">
+              <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD]"/>
+              <info name="PCIDevice" value="Family 17h (Models 00h-0fh) PCIe GPP Bridge"/>
+              <object type="Bridge" os_index="462848" name="Advanced Micro Devices, Inc. [AMD/ATI]" bridge_type="1-1" depth="2" bridge_pci="0000:[72-73]" pci_busid="0000:71:00.0" pci_type="0604 [1002:14a0] [0000:0000] 02" pci_link_speed="3.938462">
+                <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD/ATI]"/>
+                <object type="Bridge" os_index="466944" name="Advanced Micro Devices, Inc. [AMD/ATI]" bridge_type="1-1" depth="3" bridge_pci="0000:[73-73]" pci_busid="0000:72:00.0" pci_type="0604 [1002:14a1] [0000:0000] 00" pci_link_speed="31.507692">
+                  <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD/ATI]"/>
+                  <object type="PCIDev" os_index="471040" name="Advanced Micro Devices, Inc. [AMD/ATI] Vega 20" pci_busid="0000:73:00.0" pci_type="0380 [1002:66a1] [1002:0834] 02" pci_link_speed="31.507692">
+                    <info name="PCIVendor" value="Advanced Micro Devices, Inc. [AMD/ATI]"/>
+                    <info name="PCIDevice" value="Vega 20"/>
+                    <object type="OSDev" name="card4" osdev_type="1"/>
+                    <object type="OSDev" name="renderD131" osdev_type="1"/>
+                    <object type="OSDev" name="controlD68" osdev_type="1"/>
+                  </object>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+    </object>
+  </object>
+</topology>

--- a/t/hwloc/hwloc-convert.c
+++ b/t/hwloc/hwloc-convert.c
@@ -1,0 +1,74 @@
+#include <errno.h>
+#include <string.h>
+#include <stdio.h>
+
+#include <hwloc.h>
+
+int main(int argc, char *argv[])
+{
+#if HWLOC_API_VERSION < 0x20000
+    fprintf(stderr, "hwloc-convert requires hwloc v2.0+\n");
+    return 1;
+#else
+    const char* usage = "USAGE: hwloc-convert input_xml output_xml";
+    if (argc != 3) {
+        printf("Incorrect arguments supplied.\n");
+        printf("%s\n", usage);
+    }
+
+    const char *inpath = argv[1];
+    int rc = 0, exit_code = 0;
+
+    hwloc_topology_t topology;
+    if (hwloc_topology_init (&topology) < 0) {
+        fprintf(stderr, "Error initializing hwloc topology\n");
+        exit_code = 1;
+        goto ret;
+    }
+    if (hwloc_topology_set_io_types_filter(topology,
+                                           HWLOC_TYPE_FILTER_KEEP_IMPORTANT)
+        < 0) {
+        fprintf(stderr, "hwloc_topology_set_io_types_filter\n");
+        exit_code = errno;
+        goto ret;
+    }
+    if (hwloc_topology_set_cache_types_filter(topology,
+                                              HWLOC_TYPE_FILTER_KEEP_STRUCTURE)
+        < 0) {
+        fprintf(stderr, "hwloc_topology_set_cache_types_filter\n");
+        exit_code = errno;
+        goto ret;
+    }
+    if (hwloc_topology_set_icache_types_filter(topology,
+                                               HWLOC_TYPE_FILTER_KEEP_STRUCTURE)
+        < 0) {
+        fprintf(stderr, "hwloc_topology_set_icache_types_filter\n");
+        exit_code = errno;
+        goto ret;
+    }
+    if ((rc = hwloc_topology_set_xml(topology, inpath)) < 0) {
+        fprintf(stderr, "Error reading XML: %s\n", strerror(errno));
+        exit_code = errno;
+        goto ret;
+    }
+    if ((rc = hwloc_topology_load(topology)) < 0) {
+        fprintf(stderr, "Error loading topology\n");
+        exit_code = 1;
+        goto ret;
+    }
+
+    const char *outpath = argv[2];
+    if ((rc = hwloc_topology_export_xml(topology, outpath,
+                                        HWLOC_TOPOLOGY_EXPORT_XML_FLAG_V1))
+        < 0) {
+        fprintf(stderr, "Error exporting XML\n");
+        exit_code = 1;
+        goto ret;
+
+    }
+
+ret:
+    hwloc_topology_destroy (topology);
+    return exit_code;
+#endif
+}

--- a/t/hwloc/hwloc-version.c
+++ b/t/hwloc/hwloc-version.c
@@ -1,0 +1,12 @@
+#include <stdio.h>
+#include <hwloc.h>
+
+int main(void)
+{
+#if HWLOC_API_VERSION >= 0x20000
+    printf("2\n");
+#else
+    printf("1\n");
+#endif
+    return 0;
+}

--- a/t/t2005-hwloc-basic.t
+++ b/t/t2005-hwloc-basic.t
@@ -149,31 +149,10 @@ test_expect_success 'hwloc: reload with invalid rank fails' '
     test_expect_code 1 flux hwloc reload -r foo
 '
 
-test_expect_success HAVE_LSTOPO 'hwloc: lstopo works' '
-    flux hwloc reload $exclu2 &&
-    flux hwloc lstopo > lstopo.out1 &&
-    sed -n 1p lstopo.out1 | grep "^System (32G.*"
-'
-
-test_expect_success HAVE_LSTOPO 'hwloc: lstopo subcommand passes options to lstopo' '
-    flux hwloc lstopo --help | grep ^Usage
-'
-
-test_expect_success HAVE_LSTOPO 'hwloc: topology subcommand works' '
-    flux hwloc topology > topology.out2 &&
-    flux hwloc lstopo > lstopo.out2 &&
-    $lstopo --if xml -i topology.out2 --of console > lstopo.out3 &&
-    test_cmp lstopo.out2 lstopo.out3
-'
-
 test_expect_success 'hwloc: reload with no args reloads system topology' '
     flux hwloc reload &&
     flux hwloc topology > system.out4 &&
     test_cmp system.xml system.out4
-'
-
-test_expect_success HAVE_LSTOPO 'hwloc: test failure of lstopo command' '
-    test_must_fail flux hwloc lstopo --input f:g:y
 '
 
 test_expect_success 'hwloc: unload aggregator' '

--- a/t/t2005-hwloc-basic.t
+++ b/t/t2005-hwloc-basic.t
@@ -11,6 +11,10 @@ Ensure flux-hwloc reload subcommand works
 SIZE=2
 test_under_flux ${SIZE} kvs
 
+HWLOC_VERSION=$(${SHARNESS_TEST_SRCDIR}/hwloc/hwloc-version)
+[ $HWLOC_VERSION -eq 1 ] && test_set_prereq HWLOC1
+[ $HWLOC_VERSION -eq 2 ] && test_set_prereq HWLOC2
+
 HWLOC_DATADIR="${SHARNESS_TEST_SRCDIR}/hwloc-data"
 shared2=$(readlink -e ${HWLOC_DATADIR}/1N/shared/02-brokers)
 exclu2=$(readlink -e  ${HWLOC_DATADIR}/1N/nonoverlapping/02-brokers)
@@ -42,14 +46,17 @@ test_expect_success 'hwloc: ensure we have system lstopo output' '
     flux hwloc topology > system.topology.out &&
     test -f system.topology.out &&
     test -s system.topology.out &&
-    grep "<object type=\"Machine\" os_index=\"0\">" system.topology.out
+    test 2 -eq \
+         $(grep "<object type=\"Machine\" os_index=\"0\"" system.topology.out | \
+           wc -l)
 '
 
 test_expect_success 'hwloc: each rank reloads a non-overlapping set of a node ' '
     flux hwloc reload $exclu2
 '
 
-test_expect_success HAVE_JQ 'hwloc: internal aggregate-load cmd works' '
+test_expect_success HAVE_JQ,HAVE_HWLOC1 \
+                    'hwloc: internal aggregate-load cmd works' '
     flux exec -r all \
         flux hwloc aggregate-load --key=foo --unpack=bar --print-result | \
 	$jq -S . >aggregate.out &&
@@ -67,14 +74,47 @@ test_expect_success HAVE_JQ 'hwloc: internal aggregate-load cmd works' '
     test_cmp aggregate.expected aggregate.out
 '
 
+test_expect_success HAVE_JQ,HAVE_HWLOC2 \
+                    'hwloc: internal aggregate-load cmd works' '
+    flux exec -r all \
+        flux hwloc aggregate-load --key=foo --unpack=bar --print-result | \
+	$jq -S . >aggregate.out &&
+    test_debug "flux kvs get bar" &&
+    cat <<-EOF | $jq -S . >aggregate.expected &&
+	{ "count": 2, "total": 2,
+	  "entries": {
+	    "0": { "Core": 8, "PU": 8, "Package": 1,
+                   "cpuset": "0-7" },
+	    "1": { "Core": 8, "PU": 8, "Package": 1,
+	           "cpuset": "8-15"}
+	  }
+	}
+	EOF
+    test_cmp aggregate.expected aggregate.out
+'
 
-test_expect_success HAVE_JQ 'hwloc: by_rank aggregate key exists after reload' '
+test_expect_success HAVE_JQ,HAVE_HWLOC1 \
+                    'hwloc: by_rank aggregate key exists after reload' '
     flux kvs get resource.hwloc.by_rank | $jq -S . >  by_rank.out &&
     cat <<-EOF | $jq -S . >by_rank.expected &&
 	{
 	  "0": { "Core": 8, "NUMANode": 1, "PU": 8, "Package": 1,
                  "cpuset": "0-7" },
 	  "1": { "Core": 8, "NUMANode": 1, "PU": 8, "Package": 1,
+	         "cpuset": "8-15"}
+	}
+	EOF
+    test_cmp by_rank.expected by_rank.out
+'
+
+test_expect_success HAVE_JQ,HAVE_HWLOC2 \
+                    'hwloc: by_rank aggregate key exists after reload' '
+    flux kvs get resource.hwloc.by_rank | $jq -S . >  by_rank.out &&
+    cat <<-EOF | $jq -S . >by_rank.expected &&
+	{
+	  "0": { "Core": 8, "PU": 8, "Package": 1,
+                 "cpuset": "0-7" },
+	  "1": { "Core": 8, "PU": 8, "Package": 1,
 	         "cpuset": "8-15"}
 	}
 	EOF
@@ -109,7 +149,8 @@ test_expect_success 'hwloc: every rank reloads the same xml of a node' '
     test_cmp hwloc-info.expected2 hwloc-info.out2
 '
 
-test_expect_success HAVE_JQ 'hwloc: only one rank reloads an xml file' '
+test_expect_success HAVE_JQ,HAVE_HWLOC1 \
+                    'hwloc: only one rank reloads an xml file' '
     flux hwloc reload --rank="[0]" $exclu2 &&
     flux kvs get resource.hwloc.by_rank | $jq -S . > mixed.out &&
     cat <<-EOF | $jq -S . >mixed.expected &&
@@ -123,13 +164,40 @@ test_expect_success HAVE_JQ 'hwloc: only one rank reloads an xml file' '
     test_cmp mixed.expected mixed.out
 '
 
-test_expect_success HAVE_JQ 'hwloc: reload xml with GPU resources' '
+test_expect_success HAVE_JQ,HAVE_HWLOC2 \
+                    'hwloc: only one rank reloads an xml file' '
+    flux hwloc reload --rank="[0]" $exclu2 &&
+    flux kvs get resource.hwloc.by_rank | $jq -S . > mixed.out &&
+    cat <<-EOF | $jq -S . >mixed.expected &&
+	{
+	 "0": {"Package": 1, "Core": 8, "PU": 8,
+               "cpuset": "0-7" },
+	 "1": {"Package": 2, "Core": 16, "PU": 16,
+	       "cpuset": "0-15" }
+	}
+	EOF
+    test_cmp mixed.expected mixed.out
+'
+
+test_expect_success HAVE_JQ,HAVE_HWLOC1 'hwloc: reload xml with GPU resources' '
     flux hwloc reload --rank=all $sierra &&
     flux kvs get resource.hwloc.by_rank | $jq -S . > sierra.out &&
     cat <<-EOF | $jq -S . > sierra.expected &&
 	{"[0-1]":
           {"NUMANode": 6, "Package": 2, "Core": 44, "PU": 176, "GPU": 4,
            "cpuset": "0-175" }
+        }
+	EOF
+    test_cmp sierra.expected sierra.out
+'
+
+test_expect_success HAVE_JQ,HAVE_HWLOC2 'hwloc: reload xml with GPU resources' '
+    flux hwloc reload --rank=all $sierra &&
+    flux kvs get resource.hwloc.by_rank | $jq -S . > sierra.out &&
+    cat <<-EOF | $jq -S . > sierra.expected &&
+	{"[0-1]":
+          {"Group": 6, "Package": 2, "Core": 44, "PU": 176, "GPU": 4,
+           "cpuset": "0-175", "L3Cache": 23}
         }
 	EOF
     test_cmp sierra.expected sierra.out

--- a/t/t2005-hwloc-basic.t
+++ b/t/t2005-hwloc-basic.t
@@ -39,10 +39,10 @@ invalid_rank() {
 }
 
 test_expect_success 'hwloc: ensure we have system lstopo output' '
-    flux hwloc topology > system.xml &&
-    test -f system.xml &&
-    test -s system.xml &&
-    grep "<object type=\"System\" os_index=\"0\">" system.xml
+    flux hwloc topology > system.topology.out &&
+    test -f system.topology.out &&
+    test -s system.topology.out &&
+    grep "<object type=\"Machine\" os_index=\"0\">" system.topology.out
 '
 
 test_expect_success 'hwloc: each rank reloads a non-overlapping set of a node ' '
@@ -152,7 +152,7 @@ test_expect_success 'hwloc: reload with invalid rank fails' '
 test_expect_success 'hwloc: reload with no args reloads system topology' '
     flux hwloc reload &&
     flux hwloc topology > system.out4 &&
-    test_cmp system.xml system.out4
+    test_cmp system.topology.out system.out4
 '
 
 test_expect_success 'hwloc: unload aggregator' '

--- a/t/t2005-hwloc-basic.t
+++ b/t/t2005-hwloc-basic.t
@@ -82,7 +82,7 @@ test_expect_success HAVE_JQ 'hwloc: by_rank aggregate key exists after reload' '
 '
 
 #  Keep this test after 'reload exclu2' above so we're processing
-#   know topology xml from reload.
+#   known topology xml from reload.
 #
 test_expect_success 'hwloc: flux-hwloc info reports expected resources' '
     cat <<-EOF > hwloc-info.expected1 &&

--- a/t/t2006-hwloc-versions.t
+++ b/t/t2006-hwloc-versions.t
@@ -1,0 +1,67 @@
+#!/bin/sh
+#set -x
+
+test_description='Test flux-hwloc with various versions of XML output
+
+Ensure flux-hwloc reload works with XML produced by hwloc by v1 and v2
+'
+
+. `dirname $0`/sharness.sh
+
+SIZE=1
+test_under_flux ${SIZE} kvs
+
+HWLOC_VERSION=$(${SHARNESS_TEST_SRCDIR}/hwloc/hwloc-version)
+[ $HWLOC_VERSION -eq 2 ] && test_set_prereq HWLOC2
+
+HWLOC_DATADIR="${SHARNESS_TEST_SRCDIR}/hwloc-data"
+hwloc1_11=$(readlink -e  ${HWLOC_DATADIR}/1N/hwloc-versions/v1.11.11)
+hwloc2_1=$(readlink -e  ${HWLOC_DATADIR}/1N/hwloc-versions/v2.1.0)
+hwloc2to1=$(readlink -e  ${HWLOC_DATADIR}/1N/hwloc-versions/v2to1)
+
+test_debug '
+    echo ${hwloc1_11} &&
+    echo ${hwloc2_1} &&
+    echo ${hwloc2to1} &&
+    echo ${HWLOC_VERSION}
+'
+
+test_expect_success 'hwloc: load aggregator module' '
+    flux exec -r all flux module load aggregator
+'
+test_expect_success 'hwloc: load hwloc xml' '
+    flux hwloc reload -v
+'
+
+test_expect_success 'hwloc: loading v1.11 xml works' '
+    flux hwloc reload $hwloc1_11 &&
+    cat <<-EOF > hwloc-info.expected3 &&
+	1 Machine, 48 Cores, 96 PUs
+	EOF
+    flux hwloc info > hwloc-info.out3 &&
+    test_cmp hwloc-info.expected3 hwloc-info.out3
+'
+
+test_expect_success HWLOC2 'hwloc: loading v2.1 xml works' '
+    flux hwloc reload $hwloc2_1 &&
+    cat <<-EOF > hwloc-info.expected4 &&
+	1 Machine, 48 Cores, 96 PUs
+	EOF
+    flux hwloc info > hwloc-info.out4 &&
+    test_cmp hwloc-info.expected4 hwloc-info.out4
+'
+
+test_expect_success 'hwloc: loading xml converted to v1 works' '
+    flux hwloc reload $hwloc2to1 &&
+    cat <<-EOF > hwloc-info.expected5 &&
+	1 Machine, 48 Cores, 96 PUs
+	EOF
+    flux hwloc info > hwloc-info.out5 &&
+    test_cmp hwloc-info.expected5 hwloc-info.out5
+'
+
+test_expect_success 'hwloc: unload aggregator' '
+    flux exec -r all flux module remove aggregator
+'
+
+test_done

--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -760,7 +760,7 @@ test_expect_success 'flux-jobs --from-stdin fails with invalid input' '
 '
 
 find_invalid_userid() {
-	python -c 'import pwd; \
+	flux python -c 'import pwd; \
                    ids = [e.pw_uid for e in pwd.getpwall()]; \
                    print (next(i for i in range(65536) if not i in ids));'
 }


### PR DESCRIPTION
Problem: Hwloc v2.0+ is needed to detect on-node storage.  v2.0+ deprecates custom topologies (used to build a full-system topology aggregated from many, single-node topologies) and replaced several functions with new ones.  The XML format also changed, but v2.0+ is capable of outputing v1-compatible XML.

Solution: drop the `lstopo` command and refactor the `topology` command to avoid using custom topologies.  Add `#ifdef`s with usage of the new interfaces, including a flag that ensures all exported XML is v1-compatible.

Side-notes: Also adds the hwloc version to the `build-options` output of `flux version`.  Hwloc 2.0+ no longer has `NUMANode`s be parents of a package/cores, it is a sibling of them.  Rather than increase the complexity of `flux hwloc aggregate-load` with special cases to handle this and still capture `NUMANode` counts, tweak a few of the tests in `t2005-hwloc-basic.t` to not check for `NUMAnode`s in 2.0+. 

Closes #1377