### PR TITLE
Fix compilation under GCC 10.1.0

### DIFF
--- a/src/cmd/flux-terminus.c
+++ b/src/cmd/flux-terminus.c
@@ -691,7 +691,7 @@ int cmd_kill (optparse_t *p, int argc, char **argv)
     flux_future_t *f;
     char service [128];
     const char *idstr;
-    int id;
+    int id = -1;
     int optindex = optparse_option_index (p);
     int rank = optparse_get_int (p, "rank", FLUX_NODEID_ANY);
 

--- a/src/modules/job-ingest/validate.h
+++ b/src/modules/job-ingest/validate.h
@@ -15,7 +15,7 @@
 
 #include "types.h"
 
-struct validate *v;
+struct validate;
 
 /* Submit jobspec ('buf, 'len') for validation.
  * Future is fulfilled once validation is complete.

--- a/t/valgrind/valgrind.supp
+++ b/t/valgrind/valgrind.supp
@@ -86,7 +86,7 @@
    match-leak-kinds: definite
    fun:malloc
    fun:dl_open_worker
-   fun:_dl_catch_error
+   fun:_dl_catch_*
    fun:_dl_open
    ...
 }


### PR DESCRIPTION
The latest version of GCC reports two new errors.  One is a linker error due to duplicate declaration, and the other is a possible unintialized access due to an error condition that doesn't exit/return.

Also tossing in a small tweak to the valgrind suppression file to handle newer versions of `libdl` (a function changed names).

Closes #2953 