### PR TITLE
sched-simple: schedule cores instead of PUs by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ jobs:
       name: 'mypy'
       language: 'python'
       python: '3.6'
-      install: python3 -m pip install 'mypy' --force-reinstall
+      install: python3 -m pip install 'mypy==0.770' --force-reinstall
       script: mypy
       before_deploy: skip
       deploy: skip

--- a/src/modules/sched-simple/rlist.c
+++ b/src/modules/sched-simple/rlist.c
@@ -243,7 +243,10 @@ static int rlist_add_rnode (struct rlist *rl, struct rnode *n)
     return 0;
 }
 
-static int rlist_append (struct rlist *rl, const char *ranks, json_t *e)
+static int rlist_append (struct rlist *rl,
+                         const char *ranks,
+                         json_t *e,
+                         const char *name)
 {
     int rc = -1;
     unsigned int n;
@@ -255,7 +258,7 @@ static int rlist_append (struct rlist *rl, const char *ranks, json_t *e)
 
     if (!ids || json_unpack_ex (e, &err, 0, "{s:i,s?s}",
                                 "Core", &n,
-                                "cpuset", &corelist) < 0)
+                                name, &corelist) < 0)
         goto out;
     i = idset_first (ids);
     while (i != IDSET_INVALID_ID) {
@@ -275,7 +278,7 @@ out:
     return rc;
 }
 
-struct rlist *rlist_from_hwloc_by_rank (const char *by_rank)
+struct rlist *rlist_from_hwloc_by_rank (const char *by_rank, bool sched_pus)
 {
     struct rlist *rl = NULL;
     const char *key = NULL;
@@ -288,7 +291,7 @@ struct rlist *rlist_from_hwloc_by_rank (const char *by_rank)
         goto err;
 
     json_object_foreach (o, key, entry) {
-        if (rlist_append (rl, key, entry) < 0)
+        if (rlist_append (rl, key, entry, sched_pus ? "cpuset" : "coreids") < 0)
             goto err;
     }
     json_decref (o);

--- a/src/modules/sched-simple/rlist.h
+++ b/src/modules/sched-simple/rlist.h
@@ -47,8 +47,9 @@ struct rlist *rlist_copy_down (const struct rlist *orig);
 struct rlist *rlist_copy_allocated (const struct rlist *orig);
 
 /*  Create an rlist object from resource.hwloc.by_rank JSON input
+ *  If sched_pus is true, then rlist contains PUs not cores.
  */
-struct rlist *rlist_from_hwloc_by_rank (const char *by_rank);
+struct rlist *rlist_from_hwloc_by_rank (const char *by_rank, bool sched_pus);
 
 /*  Destroy an rlist object */
 void rlist_destroy (struct rlist *rl);

--- a/src/modules/sched-simple/sched.c
+++ b/src/modules/sched-simple/sched.c
@@ -38,6 +38,7 @@ struct simple_sched {
 
     char *mode;             /* allocation mode */
     bool single;
+    bool sched_pus;         /* schedule PUs as cores */
     struct rlist *rlist;    /* list of resources */
     zlistx_t *queue;        /* job queue */
     schedutil_t *util_ctx;
@@ -469,7 +470,7 @@ static int ss_acquire_resources (flux_t *h, struct simple_sched *ss)
         flux_log_error (h, "json_dumps (by_rank)");
         goto out;
     }
-    if (!(ss->rlist = rlist_from_hwloc_by_rank (by_rank))) {
+    if (!(ss->rlist = rlist_from_hwloc_by_rank (by_rank, ss->sched_pus))) {
         flux_log_error (h, "rank_list_create");
         goto out;
     }
@@ -552,6 +553,9 @@ static int process_args (flux_t *h, struct simple_sched *ss,
         }
         else if (strcmp ("unlimited", argv[i]) == 0) {
             ss->single = false;
+        }
+        else if (strcmp ("sched-PUs", argv[i]) == 0) {
+            ss->sched_pus = true;
         }
         else {
             flux_log_error (h, "Unknown module option: '%s'", argv[i]);

--- a/src/modules/sched-simple/test/rlist.c
+++ b/src/modules/sched-simple/test/rlist.c
@@ -412,7 +412,7 @@ static void test_issue2202 (void)
     char *result = NULL;
     struct rlist *a = NULL;
 
-    struct rlist *rl = rlist_from_hwloc_by_rank (by_rank_issue2202);
+    struct rlist *rl = rlist_from_hwloc_by_rank (by_rank_issue2202, true);
     ok (rl != NULL, "issue2202: rlist_from_by_rank");
     if (!rl)
         BAIL_OUT ("unable to create rlist from by_rank_issue2202");
@@ -449,7 +449,7 @@ static void test_issue2202 (void)
 
     /*  Part B:  test with multiple cores per rank, same cpuset size
      */
-    rl = rlist_from_hwloc_by_rank (by_rank_issue2202b);
+    rl = rlist_from_hwloc_by_rank (by_rank_issue2202b, true);
     ok (rl != NULL, "issue2202: rlist_from_hwloc_by_rank");
     if (!rl)
         BAIL_OUT ("unable to create rlist from by_rank_issue2202b");
@@ -505,7 +505,7 @@ static void test_issue2473 (void)
     struct rlist *rl;
     struct rlist *a, *a2;
 
-    rl = rlist_from_hwloc_by_rank (by_rank_issue2473);
+    rl = rlist_from_hwloc_by_rank (by_rank_issue2473, true);
     ok (rl != NULL, "issue2473: add_hwloc_by_rank");
     if (rl == NULL)
         BAIL_OUT ("unable to create rlist from by_rank_issue2473");
@@ -577,6 +577,48 @@ static void test_issue2473 (void)
 
     rlist_destroy (rl);
 }
+
+
+const char by_rank_coreids[] = "{\
+\"0\": {\
+    \"Package\": 1,\
+    \"Core\": 4,\
+    \"PU\": 8,\
+    \"cpuset\": \"0-7\",\
+    \"coreids\": \"0-3\"\
+  },\
+\"1-2\": {\
+    \"Package\": 1,\
+    \"Core\": 2,\
+    \"PU\": 2,\
+    \"cpuset\": \"0-1\",\
+    \"coreids\": \"0-1\"\
+  }\
+}";
+
+
+static void test_by_rank_coreids (void)
+{
+    char *result;
+    struct rlist *rl;
+
+    rl = rlist_from_hwloc_by_rank (by_rank_coreids, false);
+    ok (rl != NULL, "by_rank_coreids: rlist_hwloc_by_rank");
+    if (rl == NULL)
+        BAIL_OUT ("unable to create rlist from by_rank_coreids");
+    ok (rl->total == 8,
+        "coreids: rlist contains only cores");
+    ok (rlist_nnodes (rl) == 3,
+        "coreids: created rlist with 3 nodes");
+    result = rlist_dumps (rl);
+    is (result,
+        "rank0/core[0-3] rank[1-2]/core[0-1]",
+        "coreids: rlist_dumps works");
+    free (result);
+    rlist_destroy (rl);
+    return;
+}
+
 
 static void test_dumps (void)
 {
@@ -689,6 +731,7 @@ int main (int ac, char *av[])
     run_test_entries (test_1024n_4c, 1024, 4);
     test_issue2202 ();
     test_issue2473 ();
+    test_by_rank_coreids ();
     test_updown ();
 
     done_testing ();

--- a/src/shell/affinity.c
+++ b/src/shell/affinity.c
@@ -32,12 +32,7 @@ struct shell_affinity {
  */
 static int topology_restrict (hwloc_topology_t topo, hwloc_cpuset_t set)
 {
-    int flags = HWLOC_RESTRICT_FLAG_ADAPT_MISC |
-                HWLOC_RESTRICT_FLAG_ADAPT_IO;
-#if HWLOC_API_VERSION < 0x20000
-    flags = flags | HWLOC_RESTRICT_FLAG_ADAPT_DISTANCES;
-#endif
-    if (hwloc_topology_restrict (topo, set, flags) < 0)
+    if (hwloc_topology_restrict (topo, set, 0) < 0)
         return (-1);
     return (0);
 }

--- a/t/rc/rc1-job
+++ b/t/rc/rc1-job
@@ -4,7 +4,7 @@ set_fake_hwloc_by_rank() {
     cores=${1}
     ranklist="0-$(($(flux getattr size) - 1))"
     corelist="0-$((${cores} - 1))"
-    by_rank="{\"${ranklist}\":{\"Core\":${cores},\"cpuset\":\"${corelist}\"}}"
+    by_rank="{\"${ranklist}\":{\"Core\":${cores},\"coreids\":\"${corelist}\"}}"
     echo Setting fake by_rank="${by_rank}" >&2
     flux kvs put resource.hwloc.by_rank="${by_rank}"
     flux kvs eventlog append resource.eventlog \

--- a/t/t2208-queue-cmd.t
+++ b/t/t2208-queue-cmd.t
@@ -9,6 +9,11 @@ flux setattr log-stderr-level 1
 
 LIST_JOBS=${FLUX_BUILD_DIR}/t/job-manager/list-jobs
 
+test_expect_success 'flux-queue: reload sched-simple with sched-PUs' '
+	flux module reload -f sched-simple sched-PUs &&
+	flux resource list -v
+'
+
 test_expect_success 'flux-queue: unknown sub-command fails with usage message' '
 	test_must_fail flux queue wrongsubcmd 2>usage.out &&
 	grep Usage: usage.out
@@ -119,7 +124,8 @@ test_expect_success 'flux-queue: queue empties out' '
 '
 
 test_expect_success 'flux-queue: start long job that uses all cores' '
-	id=$(flux mini submit -n $(nproc) sleep 600) &&
+	ncores=$(flux resource list -s up -no {ncores}) &&
+	id=$(flux mini submit -n ${ncores} sleep 600) &&
 	flux job wait-event ${id} start &&
 	echo ${id} >longjob
 '
@@ -192,7 +198,8 @@ test_expect_success 'flux-queue: job in queue ran' '
 '
 
 test_expect_success 'flux-queue: submit a long job that uses all cores' '
-	flux mini submit -n $(nproc) sleep 600
+	ncores=$(flux resource list -s up -no {ncores}) &&
+	flux mini submit -n ${ncores} sleep 600
 '
 
 test_expect_success 'flux-queue: submit 2 more jobs' '

--- a/t/t2210-job-manager-bugs.t
+++ b/t/t2210-job-manager-bugs.t
@@ -13,8 +13,9 @@ flux setattr log-stderr-level 1
 #
 
 test_expect_success 'issue2664: start three jobs ' '
-	echo Requesting $(nproc) cores &&
-	flux mini submit -n $(nproc) sleep 3600 >job1.out &&
+	ncores=$(flux resource list -s up -no {ncores}) &&
+	echo Requesting ${ncores} cores &&
+	flux mini submit -n ${ncores} sleep 3600 >job1.out &&
 	flux mini submit hostname >job2.out &&
 	flux mini submit hostname >job3.out
 '

--- a/t/t2300-sched-simple.t
+++ b/t/t2300-sched-simple.t
@@ -10,7 +10,7 @@ test_under_flux 4 job
 
 query="flux resource list --state=free -no {rlist}"
 
-hwloc_by_rank='{"0-1": {"Core": 2, "cpuset": "0-1"}}'
+hwloc_by_rank='{"0-1": {"Core": 2, "cpuset":"0-3", "coreids":"0-1" }}'
 hwloc_by_rank_first_fit='{"0": {"Core": 2}, "1": {"Core": 1}}'
 
 
@@ -146,6 +146,13 @@ test_expect_success 'sched-simple: cancel remaining jobs' '
 	flux job cancel $(cat job8.id) &&
 	flux job cancel $(cat job9.id) &&
 	flux job wait-event --timeout=5.0 $(cat job9.id) free
+'
+test_expect_success 'sched-simple: reload with sched-PUs option' '
+	flux module reload -f sched-simple sched-PUs
+'
+test_expect_success 'sched-simple: PUs now treated as cores' '
+	test_debug "flux resource list -v" &&
+	test "$($query)" = "rank[0-1]/core[0-3]"
 '
 test_expect_success 'sched-simple: reload in first-fit mode' '
         flux module remove sched-simple &&

--- a/t/t2302-sched-simple-up-down.t
+++ b/t/t2302-sched-simple-up-down.t
@@ -11,7 +11,7 @@ test_under_flux 4 job
 query="flux resource list --state=free -no {rlist}"
 
 
-hwloc_by_rank='{"0-1": {"Core": 2, "cpuset": "0-3"}}'
+hwloc_by_rank='{"0-1": {"Core": 4, "cpuset": "0-3", "coreids": "0-3"}}'
 
 
 SCHEMA=${FLUX_SOURCE_DIR}/src/modules/job-ingest/schemas/jobspec.jsonschema

--- a/t/t2700-mini-cmd.t
+++ b/t/t2700-mini-cmd.t
@@ -6,12 +6,19 @@ test_description='Test flux mini command'
 
 test_under_flux 4
 
-test $(nproc) -gt 1 && test_set_prereq HAVE_MULTICORE
-
 # Set CLIMain log level to logging.DEBUG (10), to enable stack traces
 export FLUX_PYCLI_LOGLEVEL=10
 
 flux setattr log-stderr-level 1
+
+#  Reload sched-simple with PU scheduling so we can treat single-core
+#  system with many threads per core as MULTICORE
+#
+test_expect_success 'reload sched-simple with sched-PUs' '
+	flux module reload -f sched-simple sched-PUs
+'
+
+test $(nproc) -gt 1 && test_set_prereq HAVE_MULTICORE
 
 test_expect_success 'flux mini fails with usage message' '
 	test_must_fail flux mini 2>usage.err &&


### PR DESCRIPTION
This fixes the issue @rountree reported in #2965, and probably will fix a similar complaint in #2961 (@garrettbslone if you could try this patch on your system that would be great)

The issue seemed to be that, at least on quartz, the flags that the shell affinity plugin was passing to `hwloc_topology_restrict()` were causing a re-indexing of core ids that then caused hwloc_distribute to pick incorrect cpuset ids. (TBH, I still don't really understand exactly what is going on, more evidence reported in the issue)

In any event, using the same flags in shell/affinity.c as used in flux-hwloc seemed prudent, so we make that change here.

I could not really think of a good reproducer that would work in CI, so this PR is only the fix, no new tests.