### PR TITLE
python: allow reactor_run() to be interrupted and other small improvements

### DIFF
--- a/scripts/pylint
+++ b/scripts/pylint
@@ -1,13 +1,14 @@
 #!/bin/bash
 
-if command -v pylint 2>&1 > /dev/null ; then
-    pylint --rcfile=scripts/.pylintrc src/bindings/python/flux
+pylint=$(command -v pylint3 pylint | head -1)
+if test -n "$pylint"; then
+    $pylint --rcfile=scripts/.pylintrc src/bindings/python/flux
 
     # awk cmd copied from:
     # https://unix.stackexchange.com/questions/66097/find-all-files-with-a-python-shebang
     find src/cmd -type f \( -name "*.py" -print -o \
          -exec awk ' /^#!.*python/{print FILENAME} {nextfile}' {} + \) \
-        | xargs pylint --rcfile=scripts/.pylintrc --disable=missing-docstring,no-member --module-rgx='[a-z-]+'
+        | xargs $pylint --rcfile=scripts/.pylintrc --disable=missing-docstring,no-member --module-rgx='[a-z-]+'
 else
   echo "pylint not found, python left unlinted"
 fi

--- a/src/bindings/python/_flux/callbacks.h
+++ b/src/bindings/python/_flux/callbacks.h
@@ -4,6 +4,7 @@ extern "Python" void message_handler_wrapper(flux_t *, flux_msg_handler_t *, con
 //flux_watcher_f
 extern "Python" void timeout_handler_wrapper(flux_reactor_t *, flux_watcher_t *, int, void *);
 extern "Python" void fd_handler_wrapper(flux_reactor_t *, flux_watcher_t *, int, void *);
+extern "Python" void signal_handler_wrapper(flux_reactor_t *, flux_watcher_t *, int, void *);
 
 //flux_continuation_f
 extern "Python" void continuation_callback(flux_future_t *, void *);

--- a/src/bindings/python/flux/core/handle.py
+++ b/src/bindings/python/flux/core/handle.py
@@ -163,6 +163,11 @@ class Flux(Wrapper):
 
         return TimerWatcher(self, after, callback, repeat=repeat, args=args)
 
+    def signal_watcher_create(self, signum, callback, args=None):
+        from flux.core.watchers import SignalWatcher
+
+        return SignalWatcher(self, signum, callback, args)
+
     def barrier(self, name, nprocs):
         self.flux_barrier(name, nprocs)
 

--- a/src/cmd/flux-jobs.py
+++ b/src/cmd/flux-jobs.py
@@ -248,7 +248,7 @@ def list_id_cb(future, arg):
 
     cbargs["count"] += 1
     if cbargs["count"] == cbargs["total"]:
-        cbargs["flux_handle"].reactor_stop(future.get_reactor())
+        cbargs["flux_handle"].reactor_stop()
 
 
 def fetch_jobs_ids(flux_handle, args, attrs):
@@ -261,7 +261,7 @@ def fetch_jobs_ids(flux_handle, args, attrs):
     for jobid in args.jobids:
         rpc_handle = flux.job.job_list_id(flux_handle, jobid, list(attrs))
         rpc_handle.then(list_id_cb, arg=(cbargs, jobid))
-    ret = flux_handle.reactor_run(rpc_handle.get_reactor(), 0)
+    ret = flux_handle.reactor_run()
     if ret < 0:
         sys.exit(1)
     return cbargs["jobs"]

--- a/src/modules/pymod/echo.py
+++ b/src/modules/pymod/echo.py
@@ -10,6 +10,11 @@ def echo_cb(h, typemask, message, arg):
 
 def mod_main(h, *args):
     with h.msg_watcher_create(echo_cb, topic_glob="echo.*") as mw:
-        if h.reactor_run(h.get_reactor(), 0) < 0:
+        # N.B.: *only* do not use the wrapped h.reactor_run() here, since
+        #  this will cause an assertion failure in libev. This is because
+        #  only one ev_signal watcher can be installed per-process, and
+        #  one is already being used in the broker.
+        #
+        if h.flux_reactor_run(h.get_reactor(), 0) < 0:
             h.fatal_error("reactor start failed!")
         h.log(syslog.LOG_INFO, "echo unloading")

--- a/t/job-info/list-id.py
+++ b/t/job-info/list-id.py
@@ -39,7 +39,7 @@ h = flux.Flux()
 for i in range(njobs):
     job.submit_async(h, jobspec).then(submit_cb)
 
-if h.reactor_run(h.get_reactor(), 0) < 0:
+if h.reactor_run() < 0:
     h.fatal_error("reactor_run failed")
 
 # vim: tabstop=4 shiftwidth=4 expandtab

--- a/t/python/t0007-watchers.py
+++ b/t/python/t0007-watchers.py
@@ -54,11 +54,11 @@ class TestTimer(unittest.TestCase):
 
         def cb(x, y, z, w):
             timer_ran[0] = True
-            x.reactor_stop(self.f.get_reactor())
+            x.reactor_stop()
 
         with self.f.timer_watcher_create(0.1, cb) as timer:
             self.assertIsNotNone(timer, msg="timeout create")
-            ret = self.f.reactor_run(self.f.get_reactor(), 0)
+            ret = self.f.reactor_run()
             self.assertEqual(ret, 0, msg="Reactor exit")
             self.assertTrue(timer_ran[0], msg="Timer did not run successfully")
 

--- a/t/python/t0007-watchers.py
+++ b/t/python/t0007-watchers.py
@@ -11,7 +11,8 @@
 ###############################################################
 
 import unittest
-
+import os
+import signal
 import flux
 from subflux import rerun_under_flux
 
@@ -76,8 +77,70 @@ class TestTimer(unittest.TestCase):
             self.assertIsNotNone(mw)
 
 
+class TestSignal(unittest.TestCase):
+    @classmethod
+    def setUpClass(self):
+        self.f = flux.Flux()
+
+    def test_signal_watcher_invalid(self):
+        """Add an invalid signal"""
+        with self.assertRaises(EnvironmentError):
+            self.f.signal_watcher_create(
+                -500, lambda x, y: x.fatal_error("signal should not fire")
+            )
+        with self.assertRaises(EnvironmentError):
+            self.f.signal_watcher_create(
+                0, lambda x, y: x.fatal_error("signal should not fire")
+            )
+        with self.assertRaises(EnvironmentError):
+            self.f.signal_watcher_create(
+                500, lambda x, y: x.fatal_error("signal should not fire")
+            )
+
+    def test_s0_signal_watcher_add(self):
+        """Add a signal watcher"""
+        with self.f.signal_watcher_create(
+            2, lambda x, y, z, w: x.fatal_error("signal should not fire")
+        ) as sigw:
+            self.assertIsNotNone(sigw)
+
+    def test_s1_signal_watcher_remove(self):
+        """Remove a timer"""
+        sigw = self.f.signal_watcher_create(
+            2, lambda x, y: x.fatal_error("signal should not fire")
+        )
+        sigw.stop()
+        sigw.destroy()
+
+    def test_signal_watcher(self):
+        cb_called = [False]
+
+        def cb(handle, watcher, signum, args):
+            cb_called[0] = True
+            handle.reactor_stop()
+
+        def raise_signal(handle, wathcer, revents, args):
+            os.kill(os.getpid(), signal.SIGUSR1)
+
+        def stop(h, w, r, y):
+            h.reactor_stop()
+
+        with self.f.signal_watcher_create(signal.SIGUSR1, cb) as watcher:
+            self.assertIsNotNone(watcher, msg="signalWatcher create")
+            to1 = self.f.timer_watcher_create(0.10, raise_signal)
+            to2 = self.f.timer_watcher_create(0.15, stop)
+            to1.start()
+            to2.start()
+            rc = self.f.reactor_run()
+            self.assertTrue(rc >= 0, msg="reactor exit")
+            self.assertTrue(cb_called[0], "Signal Watcher Called")
+
+
 if __name__ == "__main__":
     if rerun_under_flux(__flux_size()):
         from pycotap import TAPTestRunner
 
         unittest.main(testRunner=TAPTestRunner())
+
+
+# vi: ts=4 sw=4 expandtab

--- a/t/python/t0012-futures.py
+++ b/t/python/t0012-futures.py
@@ -78,7 +78,7 @@ class TestHandle(unittest.TestCase):
         self.f.rpc(b"cmb.ping", self.ping_payload).then(then_cb, arg=self.ping_payload)
         # force a full garbage collection pass to test that our anonymous RPC doesn't disappear
         gc.collect(2)
-        ret = self.f.reactor_run(self.f.get_reactor(), 0)
+        ret = self.f.reactor_run()
         self.assertGreaterEqual(ret, 0, msg="Reactor exited with {}".format(ret))
         self.assertTrue(cb_ran[0], msg="Callback did not run successfully")
 
@@ -119,7 +119,7 @@ class TestHandle(unittest.TestCase):
         def continuation_cb(future, arg):
             arg["count"] += 1
             if arg["count"] >= arg["target"]:
-                self.f.reactor_stop(self.f.get_reactor())
+                self.f.reactor_stop()
             future.reset()
 
         def service_cb(fh, t, msg, arg):
@@ -138,7 +138,7 @@ class TestHandle(unittest.TestCase):
         self.f.rpc("rpctest.multi", {"count": arg["target"]}).then(
             continuation_cb, arg=arg
         )
-        ret = self.f.reactor_run(self.f.get_reactor(), 0)
+        ret = self.f.reactor_run()
         self.assertEqual(arg["count"], arg["target"])
 
         watcher.stop()

--- a/t/python/t1000-service-add-remove.py
+++ b/t/python/t1000-service-add-remove.py
@@ -67,7 +67,7 @@ class TestServiceAddRemove(unittest.TestCase):
         def cb(f, t, msg, arg):
             cb_called[0] = True
             self.assertEqual(msg.payload, p)
-            f.reactor_stop(f.get_reactor())
+            f.reactor_stop()
 
         w2 = self.f.msg_watcher_create(cb, FLUX_MSGTYPE_RESPONSE, "foo.echo")
         w2.start()
@@ -80,7 +80,7 @@ class TestServiceAddRemove(unittest.TestCase):
         ret = self.f.send(m)
         self.assertEqual(ret, 0)
 
-        ret = self.f.reactor_run(self.f.get_reactor(), 0)
+        ret = self.f.reactor_run()
         self.assertTrue(ret >= 0)
         self.assertTrue(cb_called[0])
         w2.stop()


### PR DESCRIPTION
This PR most notably fixes #2707, where Python scripts using `flux_reactor_run()` can't be interrupted via SIGINT. The fix is pretty straightforward, a real binding for `reactor_run` is added to `flux.Flux` handles, which installs a signal watcher for SIGINT, stopping the loop and setting a sentinel which is checked before leaving the function. If the loop was interrupted, `KeyboardInterrupt` is thrown.

Along the way, #1779 was fixed, the default reactor for `reactor_run` is `handle.get_reactor()`, so Python users can now call simply `h.reactor_run()`. The same support was added for `reactor_stop` and `reactor_stop_error`.

To be able to use a signal watcher in the Flux class, a `SignalWatcher` class was added along with constructor `handle.signal_watcher_create()`.