### PR TITLE
python: add bindings for job cancel and kill

### DIFF
--- a/src/bindings/python/flux/future.py
+++ b/src/bindings/python/flux/future.py
@@ -135,3 +135,10 @@ class Future(WrapperPimpl):
 
     def wait_for(self, timeout=-1.0):
         self.pimpl.wait_for(timeout)
+
+    def get(self):
+        """
+        Base Future.get() method. Does not return a result, just blocks
+        until future is fulfilled and throws OSError on failure.
+        """
+        self.pimpl.flux_future_get(ffi.NULL)

--- a/src/bindings/python/flux/future.py
+++ b/src/bindings/python/flux/future.py
@@ -135,6 +135,7 @@ class Future(WrapperPimpl):
 
     def wait_for(self, timeout=-1.0):
         self.pimpl.wait_for(timeout)
+        return self
 
     def get(self):
         """

--- a/src/bindings/python/flux/job.py
+++ b/src/bindings/python/flux/job.py
@@ -15,6 +15,7 @@ import json
 import errno
 import datetime
 import collections
+import signal
 
 import six
 import yaml
@@ -265,6 +266,58 @@ def wait(flux_handle, jobid=lib.FLUX_JOBID_ANY):
     """
     future = wait_async(flux_handle, jobid)
     return future.get_status()
+
+
+def kill_async(flux_handle, jobid, signum=None):
+    """Send a signal to a running job asynchronously
+
+    :param flux_handle: handle for Flux broker from flux.Flux()
+    :type flux_handle: Flux
+    :param jobid: the job ID of the job to kill
+    :param signum: signal to send (default SIGTERM)
+    :returns: a Future
+    :rtype: Future
+    """
+    if not signum:
+        signum = signal.SIGTERM
+    return Future(RAW.kill(flux_handle, int(jobid), signum))
+
+
+def kill(flux_handle, jobid, signum=None):
+    """Send a signal to a running job.
+
+    :param flux_handle: handle for Flux broker from flux.Flux()
+    :type flux_handle: Flux
+    :param jobid: the job ID of the job to kill
+    :param signum: signal to send (default SIGTERM)
+    """
+    return kill_async(flux_handle, jobid, signum).get()
+
+
+def cancel_async(flux_handle, jobid, reason=None):
+    """Cancel a pending or or running job asynchronously
+
+    :param flux_handle: handle for Flux broker from flux.Flux()
+    :type flux_handle: Flux
+    :param jobid: the job ID of the job to cancel
+    :returns: a Future
+    :rtype: Future
+
+    """
+    if not reason:
+        reason = ffi.NULL
+    return Future(RAW.cancel(flux_handle, int(jobid), reason))
+
+
+def cancel(flux_handle, jobid, signum=None):
+    """Cancel a pending or or running job
+
+    :param flux_handle: handle for Flux broker from flux.Flux()
+    :type flux_handle: Flux
+    :param jobid: the job ID of the job to cancel
+
+    """
+    return cancel_async(flux_handle, jobid, signum).get()
 
 
 class JobListRPC(RPC):


### PR DESCRIPTION
This PR adds Python bindings for `flux_job_cancel(3)` and `flux_job_kill(3)` as described in #2893 .

As part of this work, a default `.get()` method was added to the `Future` base type. This makes it so that *every* method returning a future with no result doesn't have to subclass the `Future` type. If there's a better way to accomplish that, let me know.

In order to test `kill` I needed an implementation of `job_wait_event` (see #2652). Currently, a synchronous version is sitting in `t0010-job.py`. Maybe that should be promoted to public function in `job`?

I also have a version of `job_wait_event()` that returns a `Future` and thus can be used with a `.then()` method. Unfortunately, this version fails when `.get()` is used synchronously (probably because there is no way to register a future "init" callback from python).

Maybe what I'll do is put up both version in a WIP PR.