### PR TITLE
python: add functions to facilitate watching job eventlog events

### DIFF
--- a/src/bindings/python/flux/job.py
+++ b/src/bindings/python/flux/job.py
@@ -321,6 +321,153 @@ def cancel(flux_handle, jobid, signum=None):
     return cancel_async(flux_handle, jobid, signum).get()
 
 
+class EventLogEvent:
+    """
+    wrapper class for a single KVS EventLog entry
+    """
+
+    def __init__(self, event):
+        """
+        "Initialize from a string or dict eventlog event
+        """
+        if type(event) is str:
+            event = json.loads(event)
+        self._name = event["name"]
+        self._timestamp = event["timestamp"]
+        self._context = {}
+        if "context" in event:
+            self._context = event["context"]
+
+    def __str__(self):
+        return "{0.timestamp:<0.5f}: {0.name} {0.context}".format(self)
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def timestamp(self):
+        return self._timestamp
+
+    @property
+    def context(self):
+        return self._context
+
+
+class JobEventWatchFuture(Future):
+    """
+    A future returned from job.event_watch_async().
+    Adds get_event() method to return an EventLogEntry event
+    """
+
+    def __del__(self):
+        if self.needs_cancel is not False:
+            self.cancel()
+        try:
+            super().__del__()
+        except AttributeError:
+            pass
+
+    def __init__(self, future_handle):
+        super().__init__(future_handle)
+        self.needs_cancel = True
+
+    def get_event(self, autoreset=True):
+        """
+        Return the next event from a JobEventWatchFuture, or None
+        if the event stream has terminated.
+
+        The future is auto-reset unless autoreset=False, so a subsequent
+        call to get_event() will try to fetch the next event and thus
+        may block.
+        """
+        result = ffi.new("char *[1]")
+        try:
+            RAW.event_watch_get(self.pimpl, result)
+        except OSError as exc:
+            if exc.errno == errno.ENODATA:
+                self.needs_cancel = False
+                return None
+            else:
+                # re-raise all other exceptions
+                raise
+        event = EventLogEvent(ffi.string(result[0]).decode("utf-8"))
+        if autoreset is True:
+            self.reset()
+        return event
+
+    def cancel(self):
+        """Cancel a streaming job.event_watch_async() future
+        """
+        RAW.event_watch_cancel(self.pimpl)
+        self.needs_cancel = False
+
+
+def event_watch_async(flux_handle, jobid, eventlog="eventlog"):
+    """Asynchronously get eventlog updates for a job
+
+    Asynchronously watch the events of a job eventlog, optionally only
+    returning events that match a glob pattern.
+
+    Returns a JobEventWatchFuture. Call .get_event() from the then
+    callback to get the currently returned event from the Future object.
+
+    :param flux_handle: handle for Flux broker from flux.Flux()
+    :type flux_handle: Flux
+    :param jobid: the job ID on which to watch events
+    :param name: The event name or glob pattern for which to wait (default: *)
+    :param eventlog: eventlog path in job kvs directory (default: eventlog)
+    :returns: a JobEventWatchFuture object
+    :rtype: JobEventWatchFuture
+    """
+
+    future = RAW.event_watch(flux_handle, int(jobid), eventlog, 0)
+    return JobEventWatchFuture(future)
+
+
+def event_watch(flux_handle, jobid, eventlog="eventlog"):
+    """Python generator to watch all events for a job
+
+    Synchronously watch events a job eventlog via a simple generator.
+    Use as:
+        for event in job.event_watch(flux_handle, jobid):
+            # do something with event...
+
+    :param flux_handle: handle for Flux broker from flux.Flux()
+    :type flux_handle: Flux
+    :param jobid: the job ID on which to watch events
+    :param name: The event name or glob pattern for which to wait (default: *)
+    :param eventlog: eventlog path in job kvs directory (default: eventlog)
+    """
+    watcher = event_watch_async(flux_handle, jobid, eventlog)
+    event = watcher.get_event()
+    while event is not None:
+        yield event
+        event = watcher.get_event()
+
+
+def event_wait(flux_handle, jobid, name, eventlog="eventlog"):
+    """Wait for a job eventlog entry 'name'
+
+    Wait synchronously for an eventlog entry named "name" and
+    return the entry to caller, raises OSError with ENODATA if
+    event never occurred
+
+    :param flux_handle: handle for Flux broker from flux.Flux()
+    :type flux_handle: Flux
+    :param jobid: the job ID on which to wait for eventlog events
+    :param name: The event name for which to wait
+    :param eventlog: eventlog path in job kvs directory (default: eventlog)
+    :returns: an EventLogEntry object, or raises OSError if eventlog
+     ended before matching event was found
+    :rtype: EventLogEntry
+    """
+    for event in event_watch(flux_handle, jobid, eventlog):
+        if event.name == name:
+            return event
+    raise OSError(errno.ENODATA, f"eventlog ended before event='{name}'")
+
+
 class JobListRPC(RPC):
     def get_jobs(self):
         return self.get()["jobs"]

--- a/t/python/t0010-job.py
+++ b/t/python/t0010-job.py
@@ -33,22 +33,6 @@ def __flux_size():
     return 1
 
 
-def job_event_wait(h, jobid, name, eventlog="eventlog", flags=0):
-    """
-    Synchronously wait for job event 'name' in eventlog 'eventlog'
-    """
-    result = ffi.new("char *[1]")
-    future = Future(h.job_event_watch(int(jobid), eventlog, flags))
-    while True:
-        h.job_event_watch_get(future, result)
-        if result == ffi.NULL:
-            return None
-        event = json.loads(ffi.string(result[0]).decode("utf-8"))
-        if event["name"] == name:
-            return event
-        future.reset()
-
-
 def yaml_to_json(s):
     obj = yaml.safe_load(s)
     return json.dumps(obj, separators=(",", ":"))
@@ -203,7 +187,8 @@ class TestJob(unittest.TestCase):
         jobid = job.submit(self.fh, self.sleep_jobspec, waitable=True)
 
         #  Wait for shell to fully start to avoid delay in signal
-        job_event_wait(
+        job.event_wait(self.fh, jobid, name="start")
+        job.event_wait(
             self.fh, jobid, name="shell.start", eventlog="guest.exec.eventlog"
         )
         job.kill(self.fh, jobid, signum=signal.SIGKILL)
@@ -211,6 +196,128 @@ class TestJob(unittest.TestCase):
         return_id, success, errmsg = fut.get_status()
         self.assertEqual(return_id, jobid)
         self.assertFalse(success)
+
+    def test_20_001_job_event_functions_invalid_args(self):
+        with self.assertRaises(OSError) as cm:
+            for event in job.event_watch(self.fh, 123):
+                print(event)
+        self.assertEqual(cm.exception.errno, errno.ENOENT)
+        with self.assertRaises(OSError) as cm:
+            job.event_wait(self.fh, 123, "start")
+        self.assertEqual(cm.exception.errno, errno.ENOENT)
+        with self.assertRaises(OSError) as cm:
+            job.event_wait(None, 123, "start")
+        self.assertEqual(cm.exception.errno, errno.EINVAL)
+
+    def test_20_001_job_event_watch_async(self):
+        myarg = dict(a=1, b=2)
+        events = []
+
+        def cb(future, arg):
+            self.assertEqual(arg, myarg)
+            event = future.get_event()
+            if event is None:
+                future.get_flux().reactor_stop()
+                return
+            self.assertIsInstance(event, job.EventLogEvent)
+            events.append(event.name)
+
+        jobid = job.submit(self.fh, JobspecV1.from_command(["sleep", "0"]))
+        self.assertTrue(jobid > 0)
+        future = job.event_watch_async(self.fh, jobid)
+        self.assertIsInstance(future, job.JobEventWatchFuture)
+        future.then(cb, myarg)
+        rc = self.fh.reactor_run()
+        self.assertGreaterEqual(rc, 0)
+        self.assertEqual(len(events), 8)
+        self.assertEqual(events[0], "submit")
+        self.assertEqual(events[-1], "clean")
+
+    def test_20_002_job_event_watch_no_autoreset(self):
+        jobid = job.submit(self.fh, JobspecV1.from_command(["sleep", "0"]))
+        self.assertTrue(jobid > 0)
+        future = job.event_watch_async(self.fh, jobid)
+        self.assertIsInstance(future, job.JobEventWatchFuture)
+
+        # First event should be "submit"
+        event = future.get_event(autoreset=False)
+        self.assertIsInstance(event, job.EventLogEvent)
+        self.assertEqual(event.name, "submit")
+
+        # get_event() again with no reset returns same event:
+        event = future.get_event(autoreset=False)
+        self.assertIsInstance(event, job.EventLogEvent)
+        self.assertEqual(event.name, "submit")
+
+        # reset, then get_event() should get next event
+        future.reset()
+        event = future.get_event(autoreset=False)
+        self.assertIsInstance(event, job.EventLogEvent)
+        self.assertEqual(event.name, "depend")
+
+        future.cancel()
+
+    def test_20_003_job_event_watch_sync(self):
+        jobid = job.submit(self.fh, JobspecV1.from_command(["sleep", "0"]))
+        self.assertTrue(jobid > 0)
+        future = job.event_watch_async(self.fh, jobid)
+        self.assertIsInstance(future, job.JobEventWatchFuture)
+        event = future.get_event()
+        self.assertIsInstance(event, job.EventLogEvent)
+        self.assertEquals(event.name, "submit")
+        future.cancel()
+
+    def test_20_004_job_event_watch(self):
+        jobid = job.submit(self.fh, JobspecV1.from_command(["sleep", "0"]))
+        self.assertTrue(jobid > 0)
+        events = []
+        for event in job.event_watch(self.fh, jobid):
+            self.assertIsInstance(event, job.EventLogEvent)
+            self.assertTrue(hasattr(event, "timestamp"))
+            self.assertTrue(hasattr(event, "name"))
+            self.assertTrue(hasattr(event, "context"))
+            self.assertIs(type(event.timestamp), float)
+            self.assertIs(type(event.name), str)
+            self.assertIs(type(event.context), dict)
+            events.append(event.name)
+        self.assertEqual(len(events), 8)
+
+    def test_20_005_job_event_watch_with_cancel(self):
+        jobid = job.submit(
+            self.fh, JobspecV1.from_command(["sleep", "3"]), waitable=True
+        )
+        self.assertTrue(jobid > 0)
+        events = []
+        future = job.event_watch_async(self.fh, jobid)
+        while True:
+            event = future.get_event()
+            if event is None:
+                break
+            if event.name == "start":
+                future.cancel()
+            events.append(event.name)
+        self.assertEqual(event, None)
+        # Should have less than the expected number of events due to cancel
+        self.assertLess(len(events), 8)
+        job.cancel(self.fh, jobid)
+        job.wait(self.fh, jobid)
+
+    def test_20_006_job_event_wait(self):
+        jobid = job.submit(self.fh, JobspecV1.from_command(["sleep", "0"]))
+        self.assertTrue(jobid > 0)
+        event = job.event_wait(self.fh, jobid, "start")
+        self.assertIsInstance(event, job.EventLogEvent)
+        self.assertEqual(event.name, "start")
+        event = job.event_wait(
+            self.fh, jobid, "shell.init", eventlog="guest.exec.eventlog"
+        )
+        self.assertIsInstance(event, job.EventLogEvent)
+        self.assertEqual(event.name, "shell.init")
+        event = job.event_wait(self.fh, jobid, "clean")
+        self.assertIsInstance(event, job.EventLogEvent)
+        self.assertEqual(event.name, "clean")
+        with self.assertRaises(OSError):
+            job.event_wait(self.fh, jobid, "foo")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This is a WIP stab at adding both synchronous and asynchronous Python functions that use the job eventlogs. This PR adds the following new functions to the `job` module:

 * `job.event_wait(h, jobid, name, eventlog="eventlog")`: Wait for an event named `name` in `eventlog` synchronously. Blocks and returns an `EventLogEvent` for the matched event, or `None` if the eventlog ended with no match.

e.g.
```python
import sys
import flux
from flux import job

jobid = int(sys.argv[1])
name = sys.argv[2]
print(f"waiting for {name}")
print (job.event_wait (flux.Flux(), jobid, name))
```
```console
$ flux python we.py $(flux mini submit sleep 3) 'finish'
1591649139.01139: finish {'status': 0}
```

 * `job.event_watch_async(h, jobid, name="*", eventlog="eventlog")`: returns a JobEventWatchFuture which can be used to asynchronously watch job events via a `.then()` callback. Optionally filter events on the `name` glob (default all events). A JobEventWatchFuture internally queues events for consumption in the continuation with `future.get_event()`. `future.reset()` must be called to "consume" the event.

Example:
```python
import sys
import flux
from flux import job

def cb(future, handle):
    event = future.get_event()
    if event is None:
        # End of stream
        handle.reactor_stop(handle.get_reactor())
        return
    print (event)
    future.reset()

jobid = int(sys.argv[1])
name = sys.argv[2]
h = flux.Flux()
job.event_watch_async(h, jobid, name=name).then(cb, h)

h.reactor_run(h.get_reactor(), 0)
```
```console
$ flux python we.py $(flux mini submit sleep 3) '*'
1591649414.75405: submit {'userid': 1000, 'priority': 16, 'flags': 0}
1591649414.76828: depend {}
1591649414.77174: alloc {'note': 'rank0/core0'}
1591649414.78085: start {}
1591649417.83567: finish {'status': 0}
1591649417.84228: release {'ranks': 'all', 'final': True}
1591649417.84311: free {}
1591649417.84313: clean {}

$ flux python we.py $(flux mini submit sleep 3) 'finish'
1591649450.16344: finish {'status': 0}
```

I initially wanted to build the synchronous function here through the use of the async version, e.g.

```python
future = job.event_watch_async(handle, jobid, name="start")
# block until future fulfilled
future.get_event()
```

However, this doesn't work:
```
Traceback (most recent call last):
  File "we.py", line 9, in <module>
    print(job.event_watch_async(h, jobid, name=name).get_event())
  File "/home/grondo/git/flux-core.git/src/bindings/python/flux/job.py", line 330, in get_event
    raise OSError(ffi.errno, self.error_string())
OSError: [Errno 0] None
```

I *think* this is because the empty `JobWaitEventFuture` returned by `event_watch_async()` returns -1 on the first `.get()`. This might be becuase it doesn't have a way to initialize with the `now` reactor created by the synchronous `.get()`. We may need  a way to register future `init` callbacks from Python. (still looking into it)

Until then, I'm not sure this should be merged. (But maybe the synchronous version is ok)