### PR TITLE
shell: add R to shell info JSON object

### DIFF
--- a/src/shell/info.c
+++ b/src/shell/info.c
@@ -150,7 +150,11 @@ static int shell_init_jobinfo (flux_shell_t *shell,
         shell_log_error ("error parsing jobspec: %s", error.text);
         goto out;
     }
-    if (!(info->rcalc = rcalc_create (R))) {
+    if (!(info->R = json_loads (R, 0, &error))) {
+        shell_log_error ("error parsing R: %s", error.text);
+        goto out;
+    }
+    if (!(info->rcalc = rcalc_create_json (info->R))) {
         shell_log_error ("error decoding R");
         goto out;
     }
@@ -241,6 +245,7 @@ void shell_info_destroy (struct shell_info *info)
 {
     if (info) {
         int saved_errno = errno;
+        json_decref (info->R);
         jobspec_destroy (info->jobspec);
         rcalc_destroy (info->rcalc);
         free (info);

--- a/src/shell/info.h
+++ b/src/shell/info.h
@@ -26,6 +26,7 @@ struct shell_info {
     int shell_rank;
     int shell_size;
     int total_ntasks;
+    json_t *R;
     struct jobspec *jobspec;
     rcalc_t *rcalc;
     struct rcalc_rankinfo rankinfo;

--- a/src/shell/rcalc.c
+++ b/src/shell/rcalc.c
@@ -229,7 +229,7 @@ void rcalc_destroy (rcalc_t *r)
     free (r);
 }
 
-static rcalc_t * rcalc_create_json (json_t *o)
+rcalc_t * rcalc_create_json (json_t *o)
 {
     int i;
     int version;

--- a/src/shell/rcalc.h
+++ b/src/shell/rcalc.h
@@ -12,6 +12,7 @@
 #define SHELL_RCALC_H
 
 #include <sched.h>
+#include <jansson.h>
 #include <flux/core.h>
 
 typedef struct rcalc rcalc_t;
@@ -29,6 +30,10 @@ struct rcalc_rankinfo {
 
 /* Create resource calc object from JSON string in "Rlite" format */
 rcalc_t *rcalc_create (const char *json_in);
+
+/* As above, but from Jansson json_t object */
+rcalc_t *rcalc_create_json (json_t *R);
+
 /* Same as above, but read JSON input from file */
 rcalc_t *rcalc_createf (FILE *);
 

--- a/src/shell/shell.c
+++ b/src/shell/shell.c
@@ -343,13 +343,14 @@ static json_t *flux_shell_get_info_object (flux_shell_t *shell)
         return o;
 
     if (!(o = json_pack_ex (&err, 0,
-                            "{ s:I s:i s:i s:i s:s s:O s:{ s:i s:b }}",
+                            "{ s:I s:i s:i s:i s:s s:O s:O s:{ s:i s:b }}",
                             "jobid", shell->info->jobid,
                             "rank",  shell->info->shell_rank,
                             "size",  shell->info->shell_size,
                             "ntasks", shell->info->total_ntasks,
                             "service", shell_svc_name (shell->svc),
                             "jobspec", shell->info->jobspec->jobspec,
+                            "R", shell->info->R,
                             "options",
                                "verbose", shell->verbose,
                                "standalone", shell->standalone)))

--- a/t/shell/initrc/tests/0001-shell-info.lua
+++ b/t/shell/initrc/tests/0001-shell-info.lua
@@ -29,6 +29,8 @@ type_ok (info.rank, "number",
     "shell.info.rank is a number")
 type_ok (info.jobspec, "table",
      "info.jobspec is a table")
+type_ok (info.R, "table",
+    "info.R is a table")
 is (info.rank, 0,
     "shell.info.rank is expected value");
 ok (info.options.standalone,
@@ -37,6 +39,10 @@ ok (info.options.standalone,
 jobspec = shell.info.jobspec
 type_ok (jobspec, "table",
     "shell.info.jobspec is a table")
+
+R = shell.info.R
+type_ok (R, "table",
+    "shell.info.R is a table")
 
 rankinfo = shell.rankinfo
 type_ok (rankinfo, "table",


### PR DESCRIPTION
As described in #2967, the `R` member of the JSON object returned from `flux_shell_get_info(3)` is currently missing. Add it.