### PR TITLE
[WIP] job-manager: Part 2 - rename annotation "note" and make "note" an object

### DIFF
--- a/src/common/libschedutil/alloc.c
+++ b/src/common/libschedutil/alloc.c
@@ -53,18 +53,18 @@ static int schedutil_alloc_respond (flux_t *h, const flux_msg_t *msg,
 int schedutil_alloc_respond_note (schedutil_t *util, const flux_msg_t *msg,
                                   const char *note)
 {
-    return schedutil_alloc_respond (util->h, msg, 1, note);
+    return schedutil_alloc_respond (util->h, msg, FLUX_SCHED_ALLOC_NOTE, note);
 }
 
 int schedutil_alloc_respond_denied (schedutil_t *util, const flux_msg_t *msg,
                                     const char *note)
 {
-    return schedutil_alloc_respond (util->h, msg, 2, note);
+    return schedutil_alloc_respond (util->h, msg, FLUX_SCHED_ALLOC_DENIED, note);
 }
 
 int schedutil_alloc_respond_cancel (schedutil_t *util, const flux_msg_t *msg)
 {
-    return schedutil_alloc_respond (util->h, msg, 3, NULL);
+    return schedutil_alloc_respond (util->h, msg, FLUX_SCHED_ALLOC_CANCEL, NULL);
 }
 
 struct alloc {
@@ -124,7 +124,8 @@ static void alloc_continuation (flux_future_t *f, void *arg)
         goto error;
     }
     schedutil_remove_outstanding_future (util, f);
-    if (schedutil_alloc_respond (h, ctx->msg, 0, ctx->note) < 0) {
+    if (schedutil_alloc_respond (h, ctx->msg, FLUX_SCHED_ALLOC_SUCCESS,
+                                 ctx->note) < 0) {
         flux_log_error (h, "alloc response");
         goto error;
     }

--- a/src/common/libschedutil/alloc.c
+++ b/src/common/libschedutil/alloc.c
@@ -50,10 +50,11 @@ static int schedutil_alloc_respond (flux_t *h, const flux_msg_t *msg,
     return rc;
 }
 
-int schedutil_alloc_respond_note (schedutil_t *util, const flux_msg_t *msg,
-                                  const char *note)
+int schedutil_alloc_respond_metadata (schedutil_t *util, const flux_msg_t *msg,
+                                      const char *metadata)
 {
-    return schedutil_alloc_respond (util->h, msg, FLUX_SCHED_ALLOC_NOTE, note);
+    return schedutil_alloc_respond (util->h, msg, FLUX_SCHED_ALLOC_METADATA,
+                                    metadata);
 }
 
 int schedutil_alloc_respond_denied (schedutil_t *util, const flux_msg_t *msg,

--- a/src/common/libschedutil/alloc.h
+++ b/src/common/libschedutil/alloc.h
@@ -16,6 +16,13 @@
 
 #include "init.h"
 
+enum {
+    FLUX_SCHED_ALLOC_SUCCESS = 0,
+    FLUX_SCHED_ALLOC_NOTE    = 1,
+    FLUX_SCHED_ALLOC_DENIED  = 2,
+    FLUX_SCHED_ALLOC_CANCEL  = 3,
+};
+
 /* Decode an alloc request message.
  * Return 0 on success, -1 on error with errno set.
  */

--- a/src/common/libschedutil/alloc.h
+++ b/src/common/libschedutil/alloc.h
@@ -17,10 +17,10 @@
 #include "init.h"
 
 enum {
-    FLUX_SCHED_ALLOC_SUCCESS = 0,
-    FLUX_SCHED_ALLOC_NOTE    = 1,
-    FLUX_SCHED_ALLOC_DENIED  = 2,
-    FLUX_SCHED_ALLOC_CANCEL  = 3,
+    FLUX_SCHED_ALLOC_SUCCESS  = 0,
+    FLUX_SCHED_ALLOC_METADATA = 1,
+    FLUX_SCHED_ALLOC_DENIED   = 2,
+    FLUX_SCHED_ALLOC_CANCEL   = 3,
 };
 
 /* Decode an alloc request message.
@@ -37,8 +37,8 @@ int schedutil_alloc_request_decode (const flux_msg_t *msg,
  * is finally terminated with alloc_respond_denied() or alloc_respond_R().
  * Return 0 on success, -1 on error with errno set.
  */
-int schedutil_alloc_respond_note (schedutil_t *util, const flux_msg_t *msg,
-                                  const char *note);
+int schedutil_alloc_respond_metadata (schedutil_t *util, const flux_msg_t *msg,
+                                      const char *metadata);
 
 /* Respond to alloc request message - the job cannot run.
  * Include human readable error message in 'note'.

--- a/src/modules/job-manager/alloc.c
+++ b/src/modules/job-manager/alloc.c
@@ -90,6 +90,7 @@
 #include <jansson.h>
 #include <czmq.h>
 #include <flux/core.h>
+#include <flux/schedutil.h>
 #include <assert.h>
 
 #include "job.h"
@@ -265,7 +266,7 @@ static void alloc_response_cb (flux_t *h, flux_msg_handler_t *mh,
         goto teardown;
     }
     switch (type) {
-    case 0: // success
+    case FLUX_SCHED_ALLOC_SUCCESS:
         alloc->alloc_pending_count--;
         job->alloc_pending = 0;
         if (job->has_resources) {
@@ -281,9 +282,9 @@ static void alloc_response_cb (flux_t *h, flux_msg_handler_t *mh,
                                  "note", note ? note : "") < 0)
             goto teardown;
         break;
-    case 1: // annotation FIXME
+    case FLUX_SCHED_ALLOC_NOTE: // annotation FIXME
         break;
-    case 2: // error
+    case FLUX_SCHED_ALLOC_DENIED: // error
         alloc->alloc_pending_count--;
         job->alloc_pending = 0;
         if (event_job_post_pack (ctx->event, job, "exception",
@@ -294,7 +295,7 @@ static void alloc_response_cb (flux_t *h, flux_msg_handler_t *mh,
                                  "note", note ? note : "") < 0)
             goto teardown;
         break;
-    case 3: // canceled
+    case FLUX_SCHED_ALLOC_CANCEL:
         alloc->alloc_pending_count--;
         job->alloc_pending = 0;
         if (event_job_action (ctx->event, job) < 0) {

--- a/src/modules/job-manager/alloc.c
+++ b/src/modules/job-manager/alloc.c
@@ -286,12 +286,19 @@ static void alloc_response_cb (flux_t *h, flux_msg_handler_t *mh,
             goto teardown;
         break;
     case FLUX_SCHED_ALLOC_METADATA: // annotation
-        if (job->alloc_pending_metadata) {
+        if (metadata) {
+            if (job->alloc_pending_metadata) {
+                if (json_object_update (job->alloc_pending_metadata,
+                                        metadata) < 0)
+                    goto teardown;
+            }
+            else
+                job->alloc_pending_metadata = json_incref (metadata);
+        }
+        else {
             json_decref (job->alloc_pending_metadata);
             job->alloc_pending_metadata = NULL;
         }
-        if (metadata)
-            job->alloc_pending_metadata = json_incref (metadata);
         break;
     case FLUX_SCHED_ALLOC_DENIED: // error
         alloc->alloc_pending_count--;

--- a/src/modules/job-manager/alloc.c
+++ b/src/modules/job-manager/alloc.c
@@ -34,7 +34,7 @@
  *   {"id":I, "type":i, "note"?:s}
  * Where type is one of:
  * 0 - resources allocated (sched commits R to KVS before responding)
- * 1 - annotation (just updates note, see below)
+ * 1 - metadata annotation (adds metadata info about allocation, see below)
  * 2 - job cannot run (note is set to error string)
  * 3 - alloc was canceled
  * Type 0, 2, 3 are taken as final responses, type 1 is not.
@@ -75,8 +75,9 @@
  * 3) alloc/free requests and responses are matched using jobid, not
  *    the normal matchtag, for scalability.
  * 4) a normal RPC error response to alloc/free triggers teardown
- * 5) 'note' in alloc response is intended to be human readable note displayed
- *    with job info (could be estimated start time, or error detail)
+ * 5) 'metadata' in alloc response is intended to be human readable
+ *    note displayed with job info (could be estimated start time, or
+ *    error detail)
  *
  * TODO:
  * - handle type=1 annotation for queue listing (currently ignored)
@@ -282,13 +283,13 @@ static void alloc_response_cb (flux_t *h, flux_msg_handler_t *mh,
                                  "note", note ? note : "") < 0)
             goto teardown;
         break;
-    case FLUX_SCHED_ALLOC_NOTE: // annotation
-        if (job->alloc_pending_note) {
-            free (job->alloc_pending_note);
-            job->alloc_pending_note = NULL;
+    case FLUX_SCHED_ALLOC_METADATA: // annotation
+        if (job->alloc_pending_metadata) {
+            free (job->alloc_pending_metadata);
+            job->alloc_pending_metadata = NULL;
         }
         if (note) {
-            if (!(job->alloc_pending_note = strdup (note)))
+            if (!(job->alloc_pending_metadata = strdup (note)))
                 goto teardown;
         }
         break;

--- a/src/modules/job-manager/alloc.c
+++ b/src/modules/job-manager/alloc.c
@@ -282,7 +282,15 @@ static void alloc_response_cb (flux_t *h, flux_msg_handler_t *mh,
                                  "note", note ? note : "") < 0)
             goto teardown;
         break;
-    case FLUX_SCHED_ALLOC_NOTE: // annotation FIXME
+    case FLUX_SCHED_ALLOC_NOTE: // annotation
+        if (job->alloc_pending_note) {
+            free (job->alloc_pending_note);
+            job->alloc_pending_note = NULL;
+        }
+        if (note) {
+            if (!(job->alloc_pending_note = strdup (note)))
+                goto teardown;
+        }
         break;
     case FLUX_SCHED_ALLOC_DENIED: // error
         alloc->alloc_pending_count--;

--- a/src/modules/job-manager/job.c
+++ b/src/modules/job-manager/job.c
@@ -27,7 +27,7 @@ void job_decref (struct job *job)
         int saved_errno = errno;
         json_decref (job->end_event);
         flux_msg_decref (job->waiter);
-        free (job->alloc_pending_metadata);
+        json_decref (job->alloc_pending_metadata);
         free (job);
         errno = saved_errno;
     }

--- a/src/modules/job-manager/job.c
+++ b/src/modules/job-manager/job.c
@@ -27,7 +27,7 @@ void job_decref (struct job *job)
         int saved_errno = errno;
         json_decref (job->end_event);
         flux_msg_decref (job->waiter);
-        free (job->alloc_pending_note);
+        free (job->alloc_pending_metadata);
         free (job);
         errno = saved_errno;
     }

--- a/src/modules/job-manager/job.c
+++ b/src/modules/job-manager/job.c
@@ -27,6 +27,7 @@ void job_decref (struct job *job)
         int saved_errno = errno;
         json_decref (job->end_event);
         flux_msg_decref (job->waiter);
+        free (job->alloc_pending_note);
         free (job);
         errno = saved_errno;
     }

--- a/src/modules/job-manager/job.h
+++ b/src/modules/job-manager/job.h
@@ -32,6 +32,8 @@ struct job {
     uint8_t has_resources:1;
     uint8_t start_pending:1;// start request sent to job-exec
 
+    char *alloc_pending_note;
+
     void *handle;           // zlistx_t handle
     int refcount;           // private to job.c
 };

--- a/src/modules/job-manager/job.h
+++ b/src/modules/job-manager/job.h
@@ -32,7 +32,7 @@ struct job {
     uint8_t has_resources:1;
     uint8_t start_pending:1;// start request sent to job-exec
 
-    char *alloc_pending_note;
+    char *alloc_pending_metadata;
 
     void *handle;           // zlistx_t handle
     int refcount;           // private to job.c

--- a/src/modules/job-manager/job.h
+++ b/src/modules/job-manager/job.h
@@ -32,7 +32,7 @@ struct job {
     uint8_t has_resources:1;
     uint8_t start_pending:1;// start request sent to job-exec
 
-    char *alloc_pending_metadata;
+    json_t *alloc_pending_metadata;
 
     void *handle;           // zlistx_t handle
     int refcount;           // private to job.c

--- a/src/modules/job-manager/list.c
+++ b/src/modules/job-manager/list.c
@@ -54,9 +54,9 @@ int list_append_job (json_t *jobs, struct job *job)
         return -1;
     }
     if (job->alloc_pending && job->alloc_pending_metadata) {
-        json_t *metadata = json_string (job->alloc_pending_metadata);
-        if (!metadata || json_object_set_new (o, "metadata", metadata) < 0) {
-            json_decref (metadata);
+        if (json_object_set (o,
+                             "metadata",
+                             job->alloc_pending_metadata) < 0) {
             json_decref (o);
             errno = ENOMEM;
             return -1;

--- a/src/modules/job-manager/list.c
+++ b/src/modules/job-manager/list.c
@@ -53,10 +53,10 @@ int list_append_job (json_t *jobs, struct job *job)
         errno = ENOMEM;
         return -1;
     }
-    if (job->alloc_pending && job->alloc_pending_note) {
-        json_t *note = json_string (job->alloc_pending_note);
-        if (!note || json_object_set_new (o, "note", note) < 0) {
-            json_decref (note);
+    if (job->alloc_pending && job->alloc_pending_metadata) {
+        json_t *metadata = json_string (job->alloc_pending_metadata);
+        if (!metadata || json_object_set_new (o, "metadata", metadata) < 0) {
+            json_decref (metadata);
             json_decref (o);
             errno = ENOMEM;
             return -1;

--- a/src/modules/job-manager/list.c
+++ b/src/modules/job-manager/list.c
@@ -53,6 +53,15 @@ int list_append_job (json_t *jobs, struct job *job)
         errno = ENOMEM;
         return -1;
     }
+    if (job->alloc_pending && job->alloc_pending_note) {
+        json_t *note = json_string (job->alloc_pending_note);
+        if (!note || json_object_set_new (o, "note", note) < 0) {
+            json_decref (note);
+            json_decref (o);
+            errno = ENOMEM;
+            return -1;
+        }
+    }
     if (json_array_append_new (jobs, o) < 0) {
         json_decref (o);
         errno = ENOMEM;

--- a/t/job-manager/list-jobs.c
+++ b/t/job-manager/list-jobs.c
@@ -94,9 +94,10 @@ int main (int argc, char *argv[])
         double t_submit;
         char timestr[80];
         flux_job_state_t state;
-        char *metadata = NULL;
+        json_t *metadata = NULL;
+        char *metadata_str = NULL;
 
-        if (json_unpack (value, "{s:I s:i s:i s:f s:i s?:s}",
+        if (json_unpack (value, "{s:I s:i s:i s:f s:i s?:o}",
                                 "id", &id,
                                 "priority", &priority,
                                 "userid", &userid,
@@ -106,6 +107,8 @@ int main (int argc, char *argv[])
             log_msg_exit ("error parsing job data");
         if (iso_timestr (t_submit, timestr, sizeof (timestr)) < 0)
             log_err_exit ("time conversion error");
+        if (metadata)
+            metadata_str = json_dumps (metadata, 0);
         printf ("%ju\t%s\t%lu\t%d\t%s%s%s\n",
                 (uintmax_t)id,
                 flux_job_statetostr (state, true),
@@ -113,7 +116,8 @@ int main (int argc, char *argv[])
                 priority,
                 timestr,
                 metadata ? "\t" : "",
-                metadata ? metadata : "");
+                metadata_str ? metadata_str : "");
+        free (metadata_str);
     }
 
     flux_future_destroy (f);

--- a/t/job-manager/list-jobs.c
+++ b/t/job-manager/list-jobs.c
@@ -94,22 +94,26 @@ int main (int argc, char *argv[])
         double t_submit;
         char timestr[80];
         flux_job_state_t state;
+        char *note = NULL;
 
-        if (json_unpack (value, "{s:I s:i s:i s:f s:i}",
+        if (json_unpack (value, "{s:I s:i s:i s:f s:i s?:s}",
                                 "id", &id,
                                 "priority", &priority,
                                 "userid", &userid,
                                 "t_submit", &t_submit,
-                                "state", &state) < 0)
+                                "state", &state,
+                                "note", &note) < 0)
             log_msg_exit ("error parsing job data");
         if (iso_timestr (t_submit, timestr, sizeof (timestr)) < 0)
             log_err_exit ("time conversion error");
-        printf ("%ju\t%s\t%lu\t%d\t%s\n",
+        printf ("%ju\t%s\t%lu\t%d\t%s%s%s\n",
                 (uintmax_t)id,
                 flux_job_statetostr (state, true),
                 (unsigned long)userid,
                 priority,
-                timestr);
+                timestr,
+                note ? "\t" : "",
+                note ? note : "");
     }
 
     flux_future_destroy (f);

--- a/t/job-manager/list-jobs.c
+++ b/t/job-manager/list-jobs.c
@@ -94,7 +94,7 @@ int main (int argc, char *argv[])
         double t_submit;
         char timestr[80];
         flux_job_state_t state;
-        char *note = NULL;
+        char *metadata = NULL;
 
         if (json_unpack (value, "{s:I s:i s:i s:f s:i s?:s}",
                                 "id", &id,
@@ -102,7 +102,7 @@ int main (int argc, char *argv[])
                                 "userid", &userid,
                                 "t_submit", &t_submit,
                                 "state", &state,
-                                "note", &note) < 0)
+                                "metadata", &metadata) < 0)
             log_msg_exit ("error parsing job data");
         if (iso_timestr (t_submit, timestr, sizeof (timestr)) < 0)
             log_err_exit ("time conversion error");
@@ -112,8 +112,8 @@ int main (int argc, char *argv[])
                 (unsigned long)userid,
                 priority,
                 timestr,
-                note ? "\t" : "",
-                note ? note : "");
+                metadata ? "\t" : "",
+                metadata ? metadata : "");
     }
 
     flux_future_destroy (f);

--- a/t/job-manager/sched-dummy.c
+++ b/t/job-manager/sched-dummy.c
@@ -88,6 +88,7 @@ error:
 void try_alloc (struct sched_ctx *sc)
 {
     if (sc->job) {
+        const char *metadata = "{\"msg\":\"no cores available\"}";
         if (flux_module_debug_test (sc->h, DEBUG_FAIL_ALLOC, false)) {
             if (schedutil_alloc_respond_denied (sc->schedutil_ctx,
                                                 sc->job->msg,
@@ -103,7 +104,7 @@ void try_alloc (struct sched_ctx *sc)
             goto done;
         }
         if (schedutil_alloc_respond_metadata (sc->schedutil_ctx, sc->job->msg,
-                                              "no cores available") < 0)
+                                              metadata) < 0)
             flux_log_error (sc->h, "schedutil_alloc_respond_metadata");
     }
     return;

--- a/t/job-manager/sched-dummy.c
+++ b/t/job-manager/sched-dummy.c
@@ -102,9 +102,9 @@ void try_alloc (struct sched_ctx *sc)
             sc->cores_free--;
             goto done;
         }
-        if (schedutil_alloc_respond_note (sc->schedutil_ctx, sc->job->msg,
-                                          "no cores available") < 0)
-            flux_log_error (sc->h, "schedutil_alloc_respond_note");
+        if (schedutil_alloc_respond_metadata (sc->schedutil_ctx, sc->job->msg,
+                                              "no cores available") < 0)
+            flux_log_error (sc->h, "schedutil_alloc_respond_metadata");
     }
     return;
 done:

--- a/t/t2203-job-manager-dummysched.t
+++ b/t/t2203-job-manager-dummysched.t
@@ -35,10 +35,15 @@ get_annotation() {
         echo $note
 }
 
-check_annotation() {
+check_annotation_msg() {
 	local id=$1
 	for try in $(seq 1 10); do
-		test "$(get_annotation $id)" = "no cores available" && return 0
+                metadata="$(get_annotation $id)"
+                echo $metadata
+                if echo $metadata | jq -e ".msg == \"no cores available\""
+                then
+                    return 0
+                fi
                 sleep 0.5
 	done
 	return 1
@@ -100,7 +105,7 @@ test_expect_success 'job-manager: job state RRSSS' '
 test_expect_success 'job-manager: annotate job id 3 (RRSSS)' '
 	no_annotation $(cat job1.id) &&
 	no_annotation $(cat job2.id) &&
-        check_annotation $(cat job3.id) &&
+        check_annotation_msg $(cat job3.id) &&
 	no_annotation $(cat job4.id) &&
 	no_annotation $(cat job5.id)
 '
@@ -125,7 +130,7 @@ test_expect_success 'job-manager: annotate job id 4 (RIRSS)' '
 	no_annotation $(cat job1.id) &&
 	no_annotation $(cat job2.id) &&
 	no_annotation $(cat job3.id) &&
-        check_annotation $(cat job4.id) &&
+        check_annotation_msg $(cat job4.id) &&
 	no_annotation $(cat job5.id)
 '
 

--- a/t/t2203-job-manager-dummysched.t
+++ b/t/t2203-job-manager-dummysched.t
@@ -19,6 +19,7 @@ get_state() {
 		&& state=I
 	echo $state
 }
+
 check_state() {
 	local id=$1
 	local wantstate=$2
@@ -53,7 +54,6 @@ test_expect_success 'job-manager: job state SSSSS (no scheduler)' '
 	check_state $(cat job3.id) S &&
 	check_state $(cat job4.id) S &&
 	check_state $(cat job5.id) S
-
 '
 
 test_expect_success 'job-manager: load sched-dummy --cores=2' '


### PR DESCRIPTION
So this PR is a follow up to PR #2960.

The annotation has been converted from a string to a json object in this PR.

All functions / variables / docs have been changed to rename the "note" to "metadata".  I couldn't come up with a better than this, wondering if anyone has a better name.

The json object is updated rather than being overwritten.  If the user responds with a "metadata" message without data, it indicates that the json object should be cleared.  This is debatable, but I chose this b/c I think we should have a way to clear the object (could be via a new flag too).

Now that there are so many corner cases, I will have to write a new sched-dummy to test all of these cases.

- different metadata to different jobs
- can update metadata
- can delete metadata

So that's the remaining WIP part of this PR.  But wanted to get some comments on the above first.