### PR TITLE
content-files: add alternate content backing store

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -461,6 +461,7 @@ AC_CONFIG_FILES( \
   src/common/libflux/version.h \
   src/common/libtestutil/Makefile \
   src/common/libkvs/Makefile \
+  src/common/libcontent/Makefile \
   src/common/libjob/Makefile \
   src/common/libsubprocess/Makefile \
   src/common/liboptparse/Makefile \

--- a/configure.ac
+++ b/configure.ac
@@ -494,6 +494,7 @@ AC_CONFIG_FILES( \
   src/modules/kvs/Makefile \
   src/modules/kvs-watch/Makefile \
   src/modules/content-sqlite/Makefile \
+  src/modules/content-files/Makefile \
   src/modules/barrier/Makefile \
   src/modules/cron/Makefile \
   src/modules/aggregator/Makefile \

--- a/doc/man7/flux-broker-attributes.adoc
+++ b/doc/man7/flux-broker-attributes.adoc
@@ -138,8 +138,8 @@ this rank, excluding overhead.
 content.acct-valid::
 The number of valid cache entries on this rank.
 
-content.backing::
-The selected backing store, if any.  This attribute is only
+content.backing-module::
+The selected backing store module, if any.  This attribute is only
 set on rank 0 where the content backing store is active.
 
 content.blob-size-limit::

--- a/etc/rc1
+++ b/etc/rc1
@@ -9,9 +9,13 @@ wait_check() {
 # Allow connector-local more time to start listening on socket in rc1 only
 export FLUX_LOCAL_CONNECTOR_RETRY_COUNT=10
 
+if ! content_backing=$(flux getattr content.backing-module 2>/dev/null); then
+    content_backing=content-sqlite
+fi
+
 declare -a pids
 flux exec -r all flux module load barrier & pids+=($!)
-flux module load content-sqlite & pids+=($!)
+flux module load ${content_backing} & pids+=($!)
 flux exec -r all flux module load aggregator & pids+=($!)
 wait_check ${pids[@]}
 unset pids

--- a/etc/rc3
+++ b/etc/rc3
@@ -29,3 +29,4 @@ flux exec -r all -x 0 flux module remove -f kvs
 flux module remove -f kvs
 flux content flush
 flux module remove -f content-sqlite
+flux module remove -f content-files

--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -18,7 +18,8 @@ SUBDIRS = libtap \
 	  libioencode \
 	  librouter \
 	  libdebugged \
-	  libterminus
+	  libterminus \
+	  libcontent
 
 AM_CFLAGS = $(WARNING_CFLAGS) $(CODE_COVERAGE_CFLAGS)
 AM_LDFLAGS = $(CODE_COVERAGE_LIBS)

--- a/src/common/libcontent/Makefile.am
+++ b/src/common/libcontent/Makefile.am
@@ -1,0 +1,18 @@
+AM_CFLAGS = \
+	$(WARNING_CFLAGS) \
+	$(CODE_COVERAGE_CFLAGS)
+
+AM_LDFLAGS = \
+	$(CODE_COVERAGE_LIBS)
+
+AM_CPPFLAGS = \
+	-I$(top_srcdir) \
+	-I$(top_srcdir)/src/include \
+	-I$(top_builddir)/src/common/libflux \
+	$(ZMQ_CFLAGS)
+
+noinst_LTLIBRARIES = libcontent.la
+
+libcontent_la_SOURCES = \
+        content-util.h \
+        content-util.c

--- a/src/common/libcontent/content-util.c
+++ b/src/common/libcontent/content-util.c
@@ -1,0 +1,77 @@
+/************************************************************\
+ * Copyright 2020 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/core.h>
+
+#include "content-util.h"
+
+int content_register_backing_store (flux_t *h, const char *name)
+{
+    flux_future_t *f;
+
+    if (!(f = flux_rpc_pack (h,
+                             "content.register-backing",
+                             0,
+                             0,
+                             "{s:s}",
+                             "name",
+                             name))) {
+        flux_log_error (h, "register-backing");
+        return -1;
+    }
+    if (flux_future_get (f, NULL) < 0) {
+        flux_log_error (h, "register-backing: %s", future_strerror (f, errno));
+        flux_future_destroy (f);
+        return -1;
+    }
+    flux_future_destroy (f);
+    return 0;
+}
+
+int content_unregister_backing_store (flux_t *h)
+{
+    flux_future_t *f;
+
+    if (!(f = flux_rpc (h, "content.unregister-backing", NULL, 0, 0))) {
+        flux_log_error (h, "unregister-backing");
+        return -1;
+    }
+    if (flux_future_get (f, NULL) < 0) {
+        flux_log_error (h, "unregister-backing: %s", future_strerror (f, errno));
+        flux_future_destroy (f);
+        return -1;
+    }
+    flux_future_destroy (f);
+    return 0;
+}
+
+int content_register_service (flux_t *h, const char *name)
+{
+    flux_future_t *f;
+
+    if (!(f = flux_service_register (h, name))) {
+        flux_log_error (h, "register %s", name);
+        return -1;
+    }
+    if (flux_future_get (f, NULL) < 0) {
+        flux_log_error (h, "register %s: %s", name, future_strerror (f, errno));
+        flux_future_destroy (f);
+        return -1;
+    }
+    flux_future_destroy (f);
+    return 0;
+}
+
+/*
+ * vi:ts=4 sw=4 expandtab
+ */

--- a/src/common/libcontent/content-util.h
+++ b/src/common/libcontent/content-util.h
@@ -1,0 +1,36 @@
+/************************************************************\
+ * Copyright 2020 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* NOTE: these functions all log error messages to the broker.
+ */
+
+#ifndef _FLUX_CONTENT_UTIL_H
+#define _FLUX_CONTENT_UTIL_H
+
+/* Let the rank 0 content-cache service know the backing store is available.
+ * This function blocks while waiting for the RPC response.
+ */
+int content_register_backing_store (flux_t *h, const char *name);
+
+/* Let the rank 0 content-cache service know the backing store is not available.
+ * This function blocks while waiting for the RPC response.
+ */
+int content_unregister_backing_store (flux_t *h);
+
+/* Wrapper to synchronously register a flux service.
+ * This function blocks while waiting for the RPC response.
+ */
+int content_register_service (flux_t *h, const char *name);
+
+#endif /* !_FLUX_CONTENT_UTIL_H */
+
+/*
+ * vi:ts=4 sw=4 expandtab
+ */

--- a/src/modules/Makefile.am
+++ b/src/modules/Makefile.am
@@ -4,6 +4,7 @@ SUBDIRS = \
  kvs \
  kvs-watch \
  content-sqlite \
+ content-files \
  cron \
  aggregator \
  job-ingest \

--- a/src/modules/content-files/Makefile.am
+++ b/src/modules/content-files/Makefile.am
@@ -1,0 +1,51 @@
+AM_CFLAGS = \
+	$(WARNING_CFLAGS) \
+	$(CODE_COVERAGE_CFLAGS)
+
+AM_LDFLAGS = \
+	$(CODE_COVERAGE_LIBS)
+
+AM_CPPFLAGS = \
+	-I$(top_srcdir) \
+	-I$(top_srcdir)/src/include \
+	-I$(top_builddir)/src/common/libflux \
+	$(ZMQ_CFLAGS)
+
+fluxmod_LTLIBRARIES = content-files.la
+
+content_files_la_SOURCES = \
+	content-files.c \
+	filedb.h \
+	filedb.c
+
+content_files_la_LDFLAGS = $(fluxmod_ldflags) -module
+content_files_la_LIBADD = \
+		$(top_builddir)/src/common/libcontent/libcontent.la \
+		$(top_builddir)/src/common/libflux-internal.la \
+		$(top_builddir)/src/common/libflux-core.la \
+		$(ZMQ_LIBS)
+
+test_ldadd = \
+	$(top_builddir)/src/common/libflux-internal.la \
+	$(top_builddir)/src/common/libflux-core.la \
+	$(top_builddir)/src/common/libtap/libtap.la \
+	$(ZMQ_LIBS) $(LIBPTHREAD)
+
+test_ldflags = \
+	-no-install
+
+test_cppflags = $(AM_CPPFLAGS)
+
+check_PROGRAMS = \
+	test_load \
+	test_store
+
+test_load_SOURCES = test/load.c
+test_load_CPPFLAGS = $(test_cppflags)
+test_load_LDADD = $(builddir)/filedb.o $(test_ldadd)
+test_load_LDFLAGS = $(test_ldflags)
+
+test_store_SOURCES = test/store.c
+test_store_CPPFLAGS = $(test_cppflags)
+test_store_LDADD = $(builddir)/filedb.o $(test_ldadd)
+test_store_LDFLAGS = $(test_ldflags)

--- a/src/modules/content-files/Makefile.am
+++ b/src/modules/content-files/Makefile.am
@@ -25,6 +25,8 @@ content_files_la_LIBADD = \
 		$(top_builddir)/src/common/libflux-core.la \
 		$(ZMQ_LIBS)
 
+TESTS = test_filedb.t
+
 test_ldadd = \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la \
@@ -38,7 +40,13 @@ test_cppflags = $(AM_CPPFLAGS)
 
 check_PROGRAMS = \
 	test_load \
-	test_store
+	test_store \
+	test_filedb.t
+
+TEST_EXTENSIONS = .t
+T_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
+	$(top_srcdir)/config/tap-driver.sh
+
 
 test_load_SOURCES = test/load.c
 test_load_CPPFLAGS = $(test_cppflags)
@@ -49,3 +57,8 @@ test_store_SOURCES = test/store.c
 test_store_CPPFLAGS = $(test_cppflags)
 test_store_LDADD = $(builddir)/filedb.o $(test_ldadd)
 test_store_LDFLAGS = $(test_ldflags)
+
+test_filedb_t_SOURCES = test/filedb.c
+test_filedb_t_CPPFLAGS = $(test_cppflags)
+test_filedb_t_LDADD = $(builddir)/filedb.o $(test_ldadd)
+test_filedb_t_LDFLAGS = $(test_ldflags)

--- a/src/modules/content-files/content-files.c
+++ b/src/modules/content-files/content-files.c
@@ -1,0 +1,354 @@
+/************************************************************\
+ * Copyright 2020 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* content-files.c - content addressable storage with files back end
+ *
+ * This is mainly for demo/experimentation purposes.
+ * The "store" is a flat directory with blobrefs as filenames.
+ * As such, it is hungry for inodes and may run the file system out of them
+ * if used in anger!
+ *
+ * There are four main operations (RPC handlers):
+ *
+ * content-backing.load:
+ * Given a blobref, lookup blob and return it or a "not found" error.
+ *
+ * content-backing.store:
+ * Given a blob, store it and return its blobref
+ *
+ * kvs-checkpoint.get:
+ * Given a string key, lookup string value and return it or a "not found" error.
+ *
+ * kvs-checkpoint.put:
+ * Given a string key and string value, store it and return.
+ * If the key exists, overwrite.
+ *
+ * The content operations are per RFC 10 and are the main storage behind
+ * the Flux KVS.
+ *
+ * The kvs-checkpoint operations allow the current KVS root reference to
+ * be saved/restored along with the content so it can persist across a Flux
+ * instance restart.  Multiple KVS namespaces (each with an independent root)
+ * are technically supported, although currently only the main KVS namespace
+ * is saved/restored by the KVS module.
+ *
+ * The main client of this module is the rank 0 content-cache.  The content
+ * cache is hierarchical:  each broker resolves missing content-cache entries
+ * by asking its TBON parent if it has the missing item.  Rank 0, the TBON
+ * root, asks the content backing store module.
+ *
+ * Once loaded this module can also be exercised directly using
+ * flux-content(1) with the --bypass-cache option.
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/core.h>
+
+#include "src/common/libutil/blobref.h"
+#include "src/common/libutil/log.h"
+
+#include "src/common/libcontent/content-util.h"
+
+#include "filedb.h"
+
+struct content_files {
+    flux_msg_handler_t **handlers;
+    char *dbpath;
+    flux_t *h;
+    const char *hashfun;
+};
+
+/* Handle a content-backing.load request from the rank 0 broker's
+ * content-cache service.  The raw request payload is a blobref string,
+ * including NULL terminator.  The raw response payload is the blob content.
+ * These payloads are specified in RFC 10.
+ */
+static void load_cb (flux_t *h,
+                     flux_msg_handler_t *mh,
+                     const flux_msg_t *msg,
+                     void *arg)
+{
+    struct content_files *ctx = arg;
+    const char *blobref;
+    int blobref_size;
+    void *data = NULL;
+    size_t size;
+    const char *errstr = NULL;
+
+    if (flux_request_decode_raw (msg,
+                                 NULL,
+                                 (const void **)&blobref,
+                                 &blobref_size) < 0)
+        goto error;
+    if (!blobref || blobref[blobref_size - 1] != '\0'
+                 || blobref_validate (blobref) < 0) {
+        errno = EPROTO;
+        errstr = "invalid blobref";
+        goto error;
+    }
+    if (filedb_get (ctx->dbpath, blobref, &data, &size, &errstr) < 0)
+        goto error;
+    if (flux_respond_raw (h, msg, data, size) < 0)
+        flux_log_error (h, "error responding to load request");
+    free (data);
+    return;
+error:
+    if (flux_respond_error (h, msg, errno, errstr) < 0)
+        flux_log_error (h, "error responding to load request");
+    free (data);
+}
+
+/* Handle a content-backing.store request from the rank 0 broker's
+ * content-cache service.  The raw request payload is the blob content.
+ * The raw response payload is a blobref string including NULL terminator.
+ * These payloads are specified in RFC 10.
+ */
+void store_cb (flux_t *h,
+               flux_msg_handler_t *mh,
+               const flux_msg_t *msg,
+               void *arg)
+{
+    struct content_files *ctx = arg;
+    const void *data;
+    int size;
+    char blobref[BLOBREF_MAX_STRING_SIZE];
+    const char *errstr = NULL;
+
+    if (flux_request_decode_raw (msg, NULL, &data, &size) < 0)
+        goto error;
+    if (blobref_hash (ctx->hashfun,
+                      (uint8_t *)data,
+                      size,
+                      blobref,
+                      sizeof (blobref)) < 0)
+        goto error;
+    if (filedb_put (ctx->dbpath, blobref, data, size, &errstr) < 0)
+        goto error;
+    if (flux_respond_raw (h, msg, blobref, strlen (blobref) + 1) < 0)
+        flux_log_error (h, "error responding to store request");
+    return;
+error:
+    if (flux_respond_error (h, msg, errno, errstr) < 0)
+        flux_log_error (h, "error responding to store request");
+}
+
+/* Handle a kvs-checkpoint.get request from the rank 0 kvs module.
+ * The KVS stores its last root reference here for restart purposes.
+ *
+ * N.B. filedb_get() calls read_all() which ensures that the returned buffer
+ * is padded with an extra NULL not included in the returned length,
+ * so it is safe to use the result as a string argument in flux_respond_pack().
+ */
+void checkpoint_get_cb (flux_t *h,
+                        flux_msg_handler_t *mh,
+                        const flux_msg_t *msg,
+                        void *arg)
+{
+    struct content_files *ctx = arg;
+    const char *key;
+    void *data = NULL;
+    size_t size;
+    const char *errstr = NULL;
+
+    if (flux_request_unpack (msg, NULL, "{s:s}", "key", &key) < 0)
+        goto error;
+    if (filedb_get (ctx->dbpath, key, &data, &size, &errstr) < 0)
+        goto error;
+    if (flux_respond_pack (h,
+                           msg,
+                           "{s:s}",
+                           "value",
+                           size > 0 ? data : "", 0) < 0)
+        flux_log_error (h, "error responding to kvs-checkpoint.get request");
+    free (data);
+    return;
+error:
+    if (flux_respond_error (h, msg, errno, errstr) < 0)
+        flux_log_error (h, "error responding to kvs-checkpoint.get request");
+    free (data);
+}
+
+/* Handle a kvs-checkpoint.put request from the rank 0 kvs module.
+ * The KVS stores its last root reference here for restart purposes.
+ */
+void checkpoint_put_cb (flux_t *h,
+                        flux_msg_handler_t *mh,
+                        const flux_msg_t *msg,
+                        void *arg)
+{
+    struct content_files *ctx = arg;
+    const char *key;
+    const char *value;
+    const char *errstr = NULL;
+
+    if (flux_request_unpack (msg,
+                             NULL,
+                             "{s:s s:s}",
+                             "key",
+                             &key,
+                             "value",
+                             &value) < 0)
+        goto error;
+    if (filedb_put (ctx->dbpath, key, value, strlen (value), &errstr) < 0)
+        goto error;
+    if (flux_respond (h, msg, NULL) < 0)
+        flux_log_error (h, "error responding to kvs-checkpoint.put request");
+    return;
+error:
+    if (flux_respond_error (h, msg, errno, errstr) < 0)
+        flux_log_error (h, "error responding to kvs-checkpoint.put request");
+}
+
+/* Destroy module context.
+ */
+static void content_files_destroy (struct content_files *ctx)
+{
+    if (ctx) {
+        int saved_errno = errno;
+        flux_msg_handler_delvec (ctx->handlers);
+        free (ctx->dbpath);
+        free (ctx);
+        errno = saved_errno;
+    }
+}
+
+/* Table of message handler callbacks registered below.
+ * The topic strings in the table consist of <service name>.<method>.
+ */
+static const struct flux_msg_handler_spec htab[] = {
+    { FLUX_MSGTYPE_REQUEST, "content-backing.load",    load_cb, 0 },
+    { FLUX_MSGTYPE_REQUEST, "content-backing.store",   store_cb, 0 },
+    { FLUX_MSGTYPE_REQUEST, "kvs-checkpoint.get", checkpoint_get_cb, 0 },
+    { FLUX_MSGTYPE_REQUEST, "kvs-checkpoint.put", checkpoint_put_cb, 0 },
+    FLUX_MSGHANDLER_TABLE_END,
+};
+
+/* Create module context and perform some initialization.
+ */
+static struct content_files *content_files_create (flux_t *h)
+{
+    struct content_files *ctx;
+    const char *backing_path;
+
+    if (!(ctx = calloc (1, sizeof (*ctx))))
+        return NULL;
+    ctx->h = h;
+
+    /* Some tunables:
+     * - the hash function, e.g. sha1, sha256
+     * - path to sqlite file
+     */
+    if (!(ctx->hashfun = flux_attr_get (h, "content.hash"))) {
+        flux_log_error (h, "content.hash");
+        goto error;
+    }
+
+    /* If 'content.backing-path' attribute is already set, then:
+     * - value is the db directory
+     * - if it exists, preserve existing content; else create empty
+     * Otherwise:
+     * - ${rundir}/content.files is the backing path
+     * - set 'content.backing-path' to this name
+     * - ${rundir} is cleaned up recursively by broker atexit(3) handler
+     */
+    backing_path = flux_attr_get (h, "content.backing-path");
+    if (backing_path) {
+        if (!(ctx->dbpath = strdup (backing_path)))
+            goto error;
+        if (mkdir (ctx->dbpath, 0700) < 0 && errno != EEXIST)
+            goto error;
+    }
+    else {
+        const char *rundir = flux_attr_get (h, "rundir");
+        if (!rundir) {
+            flux_log_error (h, "rundir");
+            goto error;
+        }
+        if (asprintf (&ctx->dbpath, "%s/content.files", rundir) < 0)
+            goto error;
+        if (flux_attr_set (h, "content.backing-path", ctx->dbpath) < 0)
+            goto error;
+        if (mkdir (ctx->dbpath, 0700) < 0)
+            goto error;
+    }
+    if (flux_msg_handler_addvec (h, htab, ctx, &ctx->handlers) < 0)
+        goto error;
+    return ctx;
+error:
+    content_files_destroy (ctx);
+    return NULL;
+}
+
+static int parse_args (flux_t *h, int argc, char **argv, bool *testing)
+{
+    int i;
+    for (i = 0; i < argc; i++) {
+        if (!strcmp (argv[i], "testing"))
+            *testing = true;
+        else {
+            errno = EINVAL;
+            flux_log_error (h, "%s", argv[i]);
+            return -1;
+        }
+    }
+    return 0;
+}
+
+/* The module thread enters here with broker handle 'h' pre-connected.
+ * The pattern used by most flux modules is to perform some initialization
+ * including installing message handlers, then enter the flux reactor loop.
+ * When the broker sends handle 'h' request messages that we registered
+ * to receive during initialization, the reactor ensures that our message
+ * handlers are called to deal with them.
+ *
+ * The reactor loop runs until it is stopped, e.g. with
+ * 'flux module remove <modname>' is run on this module.
+ *
+ * This function should return 0, or -1 on failure with errno set.
+ */
+int mod_main (flux_t *h, int argc, char **argv)
+{
+    struct content_files *ctx;
+    bool testing = false;
+
+    if (parse_args (h, argc, argv, &testing) < 0)
+        return -1;
+    if (!(ctx = content_files_create (h))) {
+        flux_log_error (h, "content_files_create failed");
+        return -1;
+    }
+    if (!testing) {
+        if (content_register_backing_store (h, "content-files") < 0)
+            goto done;
+    }
+    if (content_register_service (h, "content-backing") < 0)
+        goto done;
+    if (content_register_service (h, "kvs-checkpoint") < 0)
+        goto done;
+    if (flux_reactor_run (flux_get_reactor (h), 0) < 0) {
+        flux_log_error (h, "flux_reactor_run");
+        goto done;
+    }
+    if (!testing) {
+        if (content_unregister_backing_store (h) < 0)
+            goto done;
+    }
+done:
+    content_files_destroy (ctx);
+    return 0;
+}
+
+MOD_NAME ("content-files");
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/content-files/filedb.c
+++ b/src/modules/content-files/filedb.c
@@ -1,0 +1,103 @@
+/************************************************************\
+ * Copyright 2020 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+#include <errno.h>
+#include <stdio.h>
+
+#include "src/common/libutil/read_all.h"
+#include "src/common/libutil/errno_safe.h"
+
+#include "filedb.h"
+
+
+int filedb_get (const char *dbpath,
+                const char *key,
+                void **datap,
+                size_t *sizep,
+                const char **errstr)
+{
+    char path[1024];
+    int fd;
+    void *data;
+    ssize_t size;
+
+    if (strlen (key) == 0 || strchr (key, '/') || !strcmp (key, "..")
+                          || !strcmp (key, ".")) {
+        errno = EINVAL;
+        if (errstr)
+            *errstr = "invalid key name";
+        return -1;
+    }
+    if (snprintf (path, sizeof (path), "%s/%s", dbpath, key) >= sizeof (path)) {
+        errno = EOVERFLOW;
+        if (errstr)
+            *errstr = "key name too long for internal buffer";
+        return -1;
+    }
+    if ((fd = open (path, O_RDONLY)) < 0)
+        return -1;
+    if ((size = read_all (fd, &data)) < 0) {
+        ERRNO_SAFE_WRAP (close, fd);
+        return -1;
+    }
+    if (close (fd) < 0) {
+        ERRNO_SAFE_WRAP (free, data);
+        return -1;
+    }
+    *datap = data;
+    *sizep = size;
+    return 0;
+}
+
+int filedb_put (const char *dbpath,
+                const char *key,
+                const void *data,
+                size_t size,
+                const char **errstr)
+{
+    char path[1024];
+    int fd;
+
+    if (strlen (key) == 0 || strchr (key, '/') || !strcmp (key, "..")
+                          || !strcmp (key, ".")) {
+        errno = EINVAL;
+        if (errstr)
+            *errstr = "invalid key";
+        return -1;
+    }
+    if (snprintf (path, sizeof (path), "%s/%s", dbpath, key) >= sizeof (path)) {
+        errno = EOVERFLOW;
+        if (errstr)
+            *errstr = "key name too long for internal buffer";
+        return -1;
+    }
+    if ((fd = open (path, O_WRONLY | O_CREAT, 0666)) < 0)
+        return -1;
+    if (write_all (fd, data, size) < 0) {
+        ERRNO_SAFE_WRAP (close, fd);
+        return -1;
+    }
+    if (close (fd) < 0)
+        return -1;
+    return 0;
+}
+
+/*
+ * vi:ts=4 sw=4 expandtab
+ */

--- a/src/modules/content-files/filedb.h
+++ b/src/modules/content-files/filedb.h
@@ -1,0 +1,44 @@
+/************************************************************\
+ * Copyright 2020 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _CONTENT_FILES_FILEDB_H
+#define _CONTENT_FILES_FILEDB_H
+
+/* Read file named 'key' from the dbpath directory.
+ * On success, 'datap' and 'sizep' are assigned the contents and size
+ * and 0 is returned (*datap must be freed).
+ * On failure, -1 is returned with errno set.
+ * Pass '*errstr' in pre-set to NULL and if a human readable error message
+ * is appropriate, it is assigned on error (do not free).
+ */
+int filedb_get (const char *dbpath,
+                const char *key,
+                void **datap,
+                size_t *sizep,
+                const char **errstr);
+
+
+/* Put file named 'key' with content 'data' and length 'size' to the
+ * dbpath directory.  On success, 0 is returned.
+ * On failure, -1 is returned with errno set.
+ * Pass '*errstr' in pre-set to NULL and if a human readable error message
+ * is appropriate, it is assigned on error (do not free).
+ */
+int filedb_put (const char *dbpath,
+                const char *key,
+                const void *data,
+                size_t size,
+                const char **errstr);
+
+#endif /* !_CONTENT_FILES_FILEDB_H */
+
+/*
+ * vi:ts=4 sw=4 expandtab
+ */

--- a/src/modules/content-files/test/filedb.c
+++ b/src/modules/content-files/test/filedb.c
@@ -1,0 +1,128 @@
+/************************************************************\
+ * Copyright 2020 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+
+#include "src/common/libtap/tap.h"
+#include "src/modules/content-files/filedb.h"
+#include "src/common/libutil/unlink_recursive.h"
+
+void test_badargs (const char *dbpath)
+{
+    void *data;
+    size_t size;
+    const char *errstr;
+    char longkey[8192];
+
+    memset (longkey, 'x', sizeof (longkey));
+    longkey[sizeof (longkey) - 1] = '\0';
+
+    /* get */
+
+    errno = 0;
+    errstr = NULL;
+    ok (filedb_get (dbpath, "/", &data, &size, &errstr) < 0 && errno == EINVAL,
+        "filedb_get key=\"/\" failed with EINVAL");
+    ok (errstr != NULL,
+        "and error string was set");
+
+    errno = 0;
+    errstr = NULL;
+    ok (filedb_get (dbpath, longkey, &data, &size, &errstr) < 0
+        && errno == EOVERFLOW,
+        "filedb_get key=<long> failed with EOVERFLOW");
+    ok (errstr != NULL,
+        "and error string was set");
+
+    errno = 0;
+    ok (filedb_get (dbpath, "noexist", &data, &size, &errstr) < 0
+        && errno == ENOENT,
+        "filedb_get key=\"\" failed with ENOENT");
+
+    /* put */
+
+    errno = 0;
+    errstr = NULL;
+    ok (filedb_put (dbpath, "", "", 1, &errstr) < 0 && errno == EINVAL,
+        "filedb_put key=\"\" failed with EINVAL");
+    ok (errstr != NULL,
+        "and error string was set");
+
+    errno = 0;
+    errstr = NULL;
+    ok (filedb_put (dbpath, longkey, "", 1, &errstr) < 0
+        && errno == EOVERFLOW,
+        "filedb_put key=<long> failed with EOVERFLOW");
+    ok (errstr != NULL,
+        "and error string was set");
+}
+
+void test_simple (const char *dbpath)
+{
+    char val1[] = { 'a', 'b', 'c' };
+    char val2[] = { 'z', 'y', 'x', 'w', 'v', 'u'};
+    const char *errstr;
+    void *data;
+    size_t size;
+
+    /* simple put, get */
+
+    ok (filedb_put (dbpath, "key1", val1, sizeof (val1), &errstr) == 0,
+        "filedb_put key1={abc} works");
+    size = 0;
+    data = NULL;
+    ok (filedb_get (dbpath, "key1", &data, &size, &errstr) == 0,
+        "filedb_get key1 works");
+    ok (data && size == sizeof (val1) && memcmp (data, val1, size) == 0,
+        "and returned data matches");
+    free (data);
+
+    /* overwrite key is allowed (e.g. for checkpoint support) */
+
+    ok (filedb_put (dbpath, "key1", val2, sizeof (val2), &errstr) == 0,
+        "filedb_put key1={zyxwvu} works (overwrite)");
+    ok (filedb_get (dbpath, "key1", &data, &size, &errstr) == 0,
+        "filedb_get key1 works");
+    ok (data && size == sizeof (val2) && memcmp (data, val2, size) == 0,
+        "and returned the updated data");
+}
+
+int main (int argc, char *argv[])
+{
+    char dir[1024];
+    const char *tmp = getenv ("TMPDIR");
+
+    plan (NO_PLAN);
+
+    if (!tmp)
+        tmp = "/tmp";
+    if (snprintf (dir, sizeof (dir), "%s/filedb.XXXXXX", tmp) >= sizeof (dir))
+        BAIL_OUT ("internal buffer ovverflow");
+    if (!mkdtemp (dir))
+        BAIL_OUT ("mkdtemp failed");
+    diag ("mkdir %s", dir);
+
+    test_badargs (dir);
+    test_simple (dir);
+
+    if (unlink_recursive (dir) < 0)
+        BAIL_OUT ("unlink_recursive failed");
+
+    done_testing ();
+    return (0);
+}
+
+// vi: ts=4 sw=4 expandtab

--- a/src/modules/content-files/test/load.c
+++ b/src/modules/content-files/test/load.c
@@ -1,0 +1,40 @@
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <unistd.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "src/common/libutil/read_all.h"
+#include "src/common/libutil/log.h"
+
+#include "src/modules/content-files/filedb.h"
+
+int main (int argc, char **argv)
+{
+    const char *errstr = NULL;
+    void *data;
+    size_t size;
+
+    if (argc != 3) {
+        fprintf (stderr, "Usage: test_load dbpath key >output\n");
+        exit (1);
+    }
+    if (filedb_get (argv[1], argv[2], &data, &size, &errstr) < 0)
+        log_msg_exit ("filedb_get: %s", errstr ? errstr : strerror (errno));
+
+    log_msg ("%zu bytes", size);
+
+    if (write_all (STDOUT_FILENO, data, size) < 0)
+        log_err_exit ("writing to stdout");
+
+    free (data);
+    exit (0);
+}
+
+/*
+ * vi:ts=4 sw=4 expandtab
+ */
+

--- a/src/modules/content-files/test/store.c
+++ b/src/modules/content-files/test/store.c
@@ -1,0 +1,40 @@
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <unistd.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "src/common/libutil/read_all.h"
+#include "src/common/libutil/log.h"
+
+#include "src/modules/content-files/filedb.h"
+
+int main (int argc, char **argv)
+{
+    const char *errstr = NULL;
+    void *data;
+    size_t size;
+
+    if (argc != 3) {
+        fprintf (stderr, "Usage: test_store dbpath key <input\n");
+        exit (1);
+    }
+    size = read_all (STDIN_FILENO, &data);
+    if (size < 0)
+        log_err_exit ("error reading stdin");
+
+    if (filedb_put (argv[1], argv[2], data, size, &errstr) < 0)
+        log_msg_exit ("filedb_put : %s", errstr ? errstr : "failed");
+
+    free (data);
+
+    exit (0);
+}
+
+/*
+ * vi:ts=4 sw=4 expandtab
+ */
+

--- a/src/modules/content-sqlite/Makefile.am
+++ b/src/modules/content-sqlite/Makefile.am
@@ -18,6 +18,8 @@ content_sqlite_la_SOURCES = \
 	content-sqlite.c
 
 content_sqlite_la_LDFLAGS = $(fluxmod_ldflags) -module
-content_sqlite_la_LIBADD = $(top_builddir)/src/common/libflux-internal.la \
+content_sqlite_la_LIBADD = \
+		$(top_builddir)/src/common/libcontent/libcontent.la \
+		$(top_builddir)/src/common/libflux-internal.la \
 		$(top_builddir)/src/common/libflux-core.la \
 		$(ZMQ_LIBS) $(SQLITE_LIBS) $(LZ4_LIBS)

--- a/src/modules/content-sqlite/content-sqlite.c
+++ b/src/modules/content-sqlite/content-sqlite.c
@@ -23,6 +23,8 @@
 #include "src/common/libutil/log.h"
 #include "src/common/libutil/errno_safe.h"
 
+#include "src/common/libcontent/content-util.h"
+
 const size_t lzo_buf_chunksize = 1024*1024;
 const size_t compression_threshold = 256; /* compress blobs >= this size */
 
@@ -55,7 +57,6 @@ struct content_sqlite {
     sqlite3_stmt *checkpt_put_stmt;
     flux_t *h;
     const char *hashfun;
-    uint32_t blob_size_limit;
     size_t lzo_bufsize;
     void *lzo_buf;
 };
@@ -213,10 +214,6 @@ static int content_sqlite_store (struct content_sqlite *ctx,
     int hash_len;
     int uncompressed_size = -1;
 
-    if (size > ctx->blob_size_limit) {
-        errno = EFBIG;
-        return -1;
-    }
     if (blobref_hash (ctx->hashfun,
                       (uint8_t *)data,
                       size,
@@ -427,48 +424,6 @@ error:
     (void )sqlite3_reset (ctx->checkpt_put_stmt);
 }
 
-
-int register_backing_store (flux_t *h, const char *name)
-{
-    flux_future_t *f;
-    int rc;
-
-    if (!(f = flux_rpc_pack (h,
-                             "content.register-backing",
-                             0,
-                             0,
-                             "{s:s}",
-                             "name",
-                             name)))
-        return -1;
-    rc = flux_future_get (f, NULL);
-    flux_future_destroy (f);
-    return rc;
-}
-
-int unregister_backing_store (flux_t *h)
-{
-    flux_future_t *f;
-    int rc;
-
-    if (!(f = flux_rpc (h, "content.unregister-backing", NULL, 0, 0)))
-        return -1;
-    rc = flux_future_get (f, NULL);
-    flux_future_destroy (f);
-    return rc;
-}
-
-static int register_service (flux_t *h, const char *name)
-{
-    int rc;
-    flux_future_t *f;
-    if (!(f = flux_service_register (h, name)))
-        return -1;
-    rc = flux_future_get (f, NULL);
-    flux_future_destroy (f);
-    return rc;
-}
-
 static void content_sqlite_closedb (struct content_sqlite *ctx)
 {
     if (ctx) {
@@ -609,7 +564,6 @@ static struct content_sqlite *content_sqlite_create (flux_t *h)
 {
     struct content_sqlite *ctx;
     const char *backing_path;
-    const char *tmp;
 
     if (!(ctx = calloc (1, sizeof (*ctx))))
         return NULL;
@@ -627,11 +581,6 @@ static struct content_sqlite *content_sqlite_create (flux_t *h)
         flux_log_error (h, "content.hash");
         goto error;
     }
-    if (!(tmp = flux_attr_get (h, "content.blob-size-limit"))) {
-        flux_log_error (h, "content.blob-size-limit");
-        goto error;
-    }
-    ctx->blob_size_limit = strtoul (tmp, NULL, 10);
 
     /* If 'content.backing-path' attribute is already set, then:
      * - value is the sqlite backing file
@@ -677,26 +626,18 @@ int mod_main (flux_t *h, int argc, char **argv)
     }
     if (content_sqlite_opendb(ctx) < 0)
         goto done;
-    if (register_backing_store (h, "content-sqlite") < 0) {
-        flux_log_error (h, "registering backing store");
+    if (content_register_backing_store (h, "content-sqlite") < 0)
         goto done;
-    }
-    if (register_service (h, "content-backing") < 0) {
-        flux_log_error (h, "service.add: content-backing");
+    if (content_register_service (h, "content-backing") < 0)
         goto done;
-    }
-    if (register_service (h, "kvs-checkpoint") < 0) {
-        flux_log_error (h, "service.add: kvs-checkpiont");
+    if (content_register_service (h, "kvs-checkpoint") < 0)
         goto done;
-    }
     if (flux_reactor_run (flux_get_reactor (h), 0) < 0) {
         flux_log_error (h, "flux_reactor_run");
         goto done;
     }
-    if (unregister_backing_store (h) < 0) {
-        flux_log_error (h, "unregistering backing store");
+    if (content_unregister_backing_store (h) < 0)
         goto done;
-    }
 done:
     content_sqlite_closedb (ctx);
     content_sqlite_destroy (ctx);

--- a/src/modules/content-sqlite/content-sqlite.c
+++ b/src/modules/content-sqlite/content-sqlite.c
@@ -19,7 +19,6 @@
 #include <flux/core.h>
 
 #include "src/common/libutil/blobref.h"
-#include "src/common/libutil/cleanup.h"
 #include "src/common/libutil/log.h"
 #include "src/common/libutil/errno_safe.h"
 
@@ -585,10 +584,9 @@ static struct content_sqlite *content_sqlite_create (flux_t *h)
     /* If 'content.backing-path' attribute is already set, then:
      * - value is the sqlite backing file
      * - if it exists, preserve existing content; else create empty
-     * - ensure that file perists when the instance exits
      * Otherwise:
      * - ${rundir}/content.sqlite is the backing file
-     * - ensure that file is cleaned up when the instance exits
+     * - ${rundir} is normally recursively cleaned up when the instance exits
      * - set 'content.backing-path' to this name
      */
     backing_path = flux_attr_get (h, "content.backing-path");
@@ -606,7 +604,6 @@ static struct content_sqlite *content_sqlite_create (flux_t *h)
             goto error;
         if (flux_attr_set (h, "content.backing-path", ctx->dbfile) < 0)
             goto error;
-        cleanup_push_string (cleanup_file, ctx->dbfile);
     }
     if (flux_msg_handler_addvec (h, htab, ctx, &ctx->handlers) < 0)
         goto error;

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -71,6 +71,7 @@ TESTSCRIPTS = \
 	t0015-cron.t \
 	t0016-cron-faketime.t \
 	t0017-security.t \
+	t0018-content-files.t \
 	t0019-jobspec-schema.t \
 	t0020-terminus.t \
 	t0021-flux-jobspec.t \

--- a/t/t0012-content-sqlite.t
+++ b/t/t0012-content-sqlite.t
@@ -12,7 +12,6 @@ echo "# $0: flux session size will be ${SIZE}"
 BLOBREF=${FLUX_BUILD_DIR}/t/kvs/blobref
 RPC=${FLUX_BUILD_DIR}/t/request/rpc
 
-MAXBLOB=`flux getattr content.blob-size-limit`
 HASHFUN=`flux getattr content.hash`
 
 
@@ -50,12 +49,6 @@ test_expect_success 'store blobs bypassing cache' '
         flux content store --bypass-cache <4k.0.store >4k.0.hash &&
         dd if=/dev/urandom count=256 bs=4096 >1m.0.store 2>/dev/null &&
         flux content store --bypass-cache <1m.0.store >1m.0.hash
-'
-
-test_expect_success LONGTEST "cannot store blob that exceeds max size of $MAXBLOB" '
-        dd if=/dev/zero count=$(($MAXBLOB/4096+1)) bs=4096 \
-			skip=$(($MAXBLOB/4096)) >toobig 2>/dev/null &&
-        test_must_fail flux content store --bypass-cache <toobig
 '
 
 test_expect_success 'load 0b blob bypassing cache' '

--- a/t/t0012-content-sqlite.t
+++ b/t/t0012-content-sqlite.t
@@ -27,6 +27,10 @@ test_expect_success 'load content-sqlite module on rank 0' '
 	flux module load content-sqlite
 '
 
+test_expect_success 'verify content.backing-module=content-sqlite' '
+	test "$(flux getattr content.backing-module)" = "content-sqlite"
+'
+
 test_expect_success 'store 100 blobs on rank 0' '
 	store_junk test 100 &&
         TOTAL=`flux module stats --type int --parse count content` &&
@@ -78,7 +82,7 @@ test_expect_success 'load 1m blob bypassing cache' '
 '
 
 # Verify same blobs on all ranks
-# forcing content to fault in from the content.backing service
+# forcing content to fault in from the content backing service
 
 test_expect_success 'load and verify 64b blob on all ranks' '
         HASHSTR=`cat 64.0.hash` &&

--- a/t/t0018-content-files.t
+++ b/t/t0018-content-files.t
@@ -1,0 +1,197 @@
+#!/bin/sh
+
+test_description='Test content-files backing store service'
+
+. `dirname $0`/sharness.sh
+
+if test "$TEST_LONG" = "t"; then
+    test_set_prereq LONGTEST
+fi
+
+test_under_flux 1 minimal
+
+BLOBREF=${FLUX_BUILD_DIR}/t/kvs/blobref
+RPC=${FLUX_BUILD_DIR}/t/request/rpc
+TEST_LOAD=${FLUX_BUILD_DIR}/src/modules/content-files/test_load
+TEST_STORE=${FLUX_BUILD_DIR}/src/modules/content-files/test_store
+
+SIZES="0 1 64 100 1000 1024 1025 8192 65536 262144 1048576 4194304"
+LARGE_SIZES="8388608 10000000 16777216 33554432 67108864"
+
+##
+# Functions used by tests
+##
+
+# Usage: backing_load blobref
+backing_load() {
+        echo -n $1 | $RPC content-backing.load
+}
+# Usage: backing_store <blob >blobref
+backing_store() {
+        $RPC -r content-backing.store
+}
+# Usage: make_blob size >blob
+make_blob() {
+	if test $1 -eq 0; then
+		dd if=/dev/null 2>/dev/null
+	else
+		dd if=/dev/urandom count=1 bs=$1 2>/dev/null
+	fi
+}
+# Usage: check_blob size
+# Leaves behind blob.<size> and blobref.<size>
+check_blob() {
+	make_blob $1 >blob.$1 &&
+	backing_store <blob.$1 >blobref.$1 &&
+	backing_load $(cat blobref.$1) >blob.$1.check &&
+	test_cmp blob.$1 blob.$1.check
+}
+# Usage: check_blob size
+# Relies on existence of blob.<size> and blobref.<size>
+recheck_blob() {
+	backing_load $(cat blobref.$1) >blob.$1.recheck &&
+	test_cmp blob.$1 blob.$1.recheck
+}
+# Usage: recheck_cache_blob size
+# Relies on existence of blob.<size> and blobref.<size>
+recheck_cache_blob() {
+	flux content load $(cat blobref.$1) >blob.$1.cachecheck &&
+	test_cmp blob.$1 blob.$1.cachecheck
+}
+# Usage: kvs_checkpoint_put key value
+kvs_checkpoint_put() {
+        jq -j -c -n  "{key:\"$1\",value:\"$2\"}" | $RPC kvs-checkpoint.put
+}
+# Usage: kvs_checkpoint_get key >value
+kvs_checkpoint_get() {
+        jq -j -c -n  "{key:\"$1\"}" | $RPC kvs-checkpoint.get
+}
+
+##
+# Tests of the module by itself (no content cache)
+##
+
+test_expect_success 'load content-files module' '
+	flux module load content-files testing
+'
+
+test_expect_success 'content.backing-path attribute is set' '
+	FILEDB=$(flux getattr content.backing-path) &&
+	test -d ${FILEDB}
+'
+
+test_expect_success 'load/store/verify key-values stored directly' '
+	make_blob 140 >rawblob.140 &&
+	$TEST_STORE $FILEDB testkey1 <rawblob.140 &&
+	$TEST_LOAD $FILEDB testkey1 >rawblob.140.out &&
+	test_cmp rawblob.140 rawblob.140.out
+'
+
+test_expect_success 'store/load/verify various size small blobs' '
+	err=0 &&
+	for size in $SIZES; do \
+		if ! check_blob $size; then err=$(($err+1)); fi; \
+	done &&
+	test $err -eq 0
+'
+
+test_expect_success LONGTEST 'store/load/verify various size large blobs' '
+	err=0 &&
+	for size in $LARGE_SIZES; do \
+		if ! check_blob $size; then err=$(($err+1)); fi; \
+	done &&
+	test $err -eq 0
+'
+
+test_expect_success HAVE_JQ 'kvs-checkpoint.put foo=bar' '
+        kvs_checkpoint_put foo bar
+'
+
+test_expect_success HAVE_JQ 'kvs-checkpoint.get foo returned bar' '
+        echo bar >value.exp &&
+        kvs_checkpoint_get foo | jq -r .value >value.out &&
+        test_cmp value.exp value.out
+'
+
+test_expect_success HAVE_JQ 'kvs-checkpoint.put updates foo=baz' '
+        kvs_checkpoint_put foo baz
+'
+
+test_expect_success HAVE_JQ 'kvs-checkpoint.get foo returned baz' '
+        echo baz >value2.exp &&
+        kvs_checkpoint_get foo | jq -r .value >value2.out &&
+        test_cmp value2.exp value2.out
+'
+
+test_expect_success 'reload content-files module' '
+	flux module reload content-files testing
+'
+
+test_expect_success 'reload/verify various size small blobs' '
+	err=0 &&
+	for size in $SIZES; do \
+		if ! recheck_blob $size; then err=$(($err+1)); fi; \
+	done &&
+	test $err -eq 0
+'
+
+test_expect_success LONGTEST 'reload/verify various size large blobs' '
+	err=0 &&
+	for size in $LARGE_SIZES; do \
+		if ! recheck_blob $size; then err=$(($err+1)); fi; \
+	done &&
+	test $err -eq 0
+'
+
+test_expect_success HAVE_JQ 'kvs-checkpoint.get foo returns same value' '
+        kvs_checkpoint_get foo | jq -r .value >value2.out &&
+        test_cmp value2.exp value2.out
+'
+
+test_expect_success 'load with invalid blobref fails' '
+	test_must_fail backing_load notblobref 2>notblobref.err &&
+	grep "invalid blobref" notblobref.err
+'
+test_expect_success 'kvs-checkpoint.get bad request fails with EPROTO' '
+	test_must_fail $RPC kvs-checkpoint.get </dev/null 2>badget.err &&
+	grep "Protocol error" badget.err
+'
+test_expect_success 'kvs-checkpoint.get bad request fails with EPROTO' '
+	test_must_fail $RPC kvs-checkpoint.put </dev/null 2>badput.err &&
+	grep "Protocol error" badput.err
+'
+
+##
+# Tests of the module acting as backing store for content cache
+##
+
+test_expect_success 'reload content-files module without testing option' '
+	flux module reload content-files
+'
+
+test_expect_success 'verify content.backing-module=content-files' '
+        test "$(flux getattr content.backing-module)" = "content-files"
+'
+
+test_expect_success 'reload/verify various size small blobs through cache' '
+	err=0 &&
+	for size in $SIZES; do \
+		if ! recheck_cache_blob $size; then err=$(($err+1)); fi; \
+	done &&
+	test $err -eq 0
+'
+
+test_expect_success LONGTEST 'reload/verify various size large blobs through cache' '
+	err=0 &&
+	for size in $LARGE_SIZES; do \
+		if ! recheck_cache_blob $size; then err=$(($err+1)); fi; \
+	done &&
+	test $err -eq 0
+'
+
+test_expect_success 'remove content-files module' '
+	flux module remove content-files
+'
+
+
+test_done

--- a/t/t2008-althash.t
+++ b/t/t2008-althash.t
@@ -22,6 +22,14 @@ test_expect_success 'Started instance with content.hash=sha256' '
           flux getattr content.hash) && test "$OUT" = "sha256"
 '
 
+test_expect_success 'Started instance with content.hash=sha256,content-files' '
+    OUT=$(flux start -o,-Scontent.hash=sha256 \
+          -o,-Scontent.backing-module=content-files \
+          -o,-Scontent.backing-path=$(pwd)/content.files \
+          flux getattr content.hash) && test "$OUT" = "sha256" &&
+    ls -1 content.files | tail -1 | grep sha256
+'
+
 test_expect_success 'Content store nil returns correct hash for sha256' '
     OUT=$(flux start -o,-Scontent.hash=sha256 \
           flux content store </dev/null) &&

--- a/t/t3200-instance-restart.t
+++ b/t/t3200-instance-restart.t
@@ -39,4 +39,23 @@ test_expect_success 'job IDs were issued in ascending order' '
 	test $(cat id2.out) -lt $(cat id3.out)
 '
 
+test_expect_success 'run a job in persistent instance (content-files)' '
+	flux start \
+	    -o,-Scontent.backing-module=content-files \
+	    -o,-Scontent.backing-path=$(pwd)/content.files \
+	    flux mini run -v /bin/true 2>&1 | sed "s/jobid: //" >files_id1.out
+'
+test_expect_success 'restart instance and list inactive jobs' '
+	flux start \
+	    -o,-Scontent.backing-module=content-files \
+	    -o,-Scontent.backing-path=$(pwd)/content.files \
+	    flux jobs --suppress-header --format={id} \
+	        --filter=INACTIVE >files_list.out
+'
+
+test_expect_success 'inactive job list contains job from before restart' '
+	grep $(cat files_id1.out) files_list.out
+'
+
+
 test_done


### PR DESCRIPTION
This PR adds a new content backing store option, mainly as a demo, with lots of inline comments.

For now it just stores objects in one big flat directory using blobrefs as the file names, which will not be very scalable (depending on the file system used).

To allow flux to be invoked with a non-default backing store module, one can start flux with e.g.
```
flux start -o,-Scontent.backing-module=content-files
```
This attribute is peeked at by the rc1 script.  This needs more thought and probably isn't the complete or final solution to #2984.

Still more to do here but wanted to get this up early for @garrettbslone to peek at when he's ready.