### PR TITLE
job-ingest: fix validation of V1 jobspec

### DIFF
--- a/src/bindings/python/flux/job.py
+++ b/src/bindings/python/flux/job.py
@@ -446,7 +446,7 @@ class Jobspec(object):
             raise TypeError("tasks must be a sequence")
         if not isinstance(version, int):
             raise TypeError("version must be an integer")
-        if attributes is not None and not isinstance(attributes, abc.Mapping):
+        if not isinstance(attributes, abc.Mapping):
             raise TypeError("attributes must be a mapping")
         elif version < 1:
             raise ValueError("version must be >= 1")

--- a/src/bindings/python/flux/job.py
+++ b/src/bindings/python/flux/job.py
@@ -15,6 +15,7 @@ import json
 import errno
 import datetime
 import collections
+import numbers
 import signal
 
 import six
@@ -813,7 +814,29 @@ class JobspecV1(Jobspec):
             kwargs["version"] = 1
         elif kwargs["version"] != 1:
             raise ValueError("version must be 1")
+
         super(JobspecV1, self).__init__(resources, tasks, **kwargs)
+
+        # validate V1 specific requirements:
+        self._v1_validate(resources, tasks, kwargs)
+
+    @staticmethod
+    def _v1_validate(resources, tasks, kwargs):
+        # process extra V1 attributes requirements:
+
+        # attributes already required by base Jobspec validator
+        attributes = kwargs["attributes"]
+
+        # attributes.system.duration is required
+        if "system" not in attributes:
+            raise ValueError("attributes.system is a required key")
+        system = attributes["system"]
+        if not isinstance(system, abc.Mapping):
+            raise ValueError("attributes.system must be a mapping")
+        if "duration" not in system:
+            raise ValueError("attributes.system.duration is a required key")
+        if not isinstance(system["duration"], numbers.Number):
+            raise ValueError("attributes.system.duration must be a number")
 
     @classmethod
     def from_command(

--- a/src/cmd/flux-jobspec.py
+++ b/src/cmd/flux-jobspec.py
@@ -107,8 +107,10 @@ def create_slurm_style_jobspec(
         "tasks": [{"command": command, "slot": "task", "count": task_count_dict}],
         "attributes": {"system": {"cwd": os.getcwd(), "environment": environ}},
     }
-    if walltime:
-        jobspec["attributes"]["system"]["duration"] = walltime
+    if not walltime:
+        walltime = 0.0
+
+    jobspec["attributes"]["system"]["duration"] = walltime
 
     return jobspec
 

--- a/src/modules/job-exec/testexec.c
+++ b/src/modules/job-exec/testexec.c
@@ -155,7 +155,7 @@ static int start_timer (flux_t *h, struct testexec *te, struct jobinfo *job)
      */
     if (t < 0.)
         t = 1.e-5;
-    if (t > 0.) {
+    if (t >= 0.) {
         char timebuf[256];
         te->timer = flux_timer_watcher_create (r, t, 0., timer_cb, job);
         if (!te->timer) {

--- a/src/modules/job-ingest/schemas/jobspec.jsonschema
+++ b/src/modules/job-ingest/schemas/jobspec.jsonschema
@@ -92,7 +92,7 @@
     },
     "attributes": {
       "description": "system and user attributes",
-      "type": ["object", "null"],
+      "type": ["object"],
       "properties": {
         "system": {
           "type": "object",

--- a/src/modules/job-ingest/schemas/jobspec_v1.jsonschema
+++ b/src/modules/job-ingest/schemas/jobspec_v1.jsonschema
@@ -84,7 +84,7 @@
     },
     "attributes": {
       "description": "system and user attributes",
-      "type": ["object", "null"],
+      "type": ["object"],
       "properties": {
         "system": {
           "type": "object",

--- a/src/modules/job-ingest/schemas/jobspec_v1.jsonschema
+++ b/src/modules/job-ingest/schemas/jobspec_v1.jsonschema
@@ -85,9 +85,11 @@
     "attributes": {
       "description": "system and user attributes",
       "type": ["object"],
+      "required": ["system"],
       "properties": {
         "system": {
           "type": "object",
+          "required": ["duration"],
           "properties": {
             "duration": { "type": "number", "minimum": 0 },
             "cwd": { "type": "string" },

--- a/t/jobspec/invalid/attributes_null.yaml
+++ b/t/jobspec/invalid/attributes_null.yaml
@@ -1,0 +1,14 @@
+version: 1
+resources:
+  - type: slot
+    count: 1
+    label: foo
+    with:
+      - type: node
+        count: 1
+tasks:
+  - command: [ "app" ]
+    slot: foo
+    count:
+      per_slot: 1
+attributes:

--- a/t/jobspec/valid/attributes_system.yaml
+++ b/t/jobspec/valid/attributes_system.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 999
 resources:
   - type: slot
     count: 1

--- a/t/jobspec/valid/attributes_user.yaml
+++ b/t/jobspec/valid/attributes_user.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 999
 resources:
   - type: slot
     count: 1

--- a/t/jobspec/valid/basic.yaml
+++ b/t/jobspec/valid/basic.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 999
 resources:
   - type: slot
     count: 1
@@ -11,4 +11,4 @@ tasks:
     slot: foo
     count:
       per_slot: 1
-attributes:
+attributes: {}

--- a/t/t2300-sched-simple.t
+++ b/t/t2300-sched-simple.t
@@ -66,8 +66,8 @@ test_expect_success 'sched-simple: gpu request is canceled' '
 '
 Y2J="flux python ${SHARNESS_TEST_SRCDIR}/jobspec/y2j.py"
 SPEC=${SHARNESS_TEST_SRCDIR}/jobspec/valid/basic.yaml
-test_expect_success 'sched-simple: invalid minimal jobspec is canceled' '
-	${Y2J}<${SPEC} | flux job submit >job00.id &&
+test_expect_success HAVE_JQ 'sched-simple: invalid minimal jobspec is canceled' '
+	${Y2J}<${SPEC} | jq ".version = 1" | flux job submit >job00.id &&
 	jobid=$(cat job00.id) &&
         flux job wait-event --timeout=5.0 $jobid exception &&
 	flux job eventlog $jobid | grep "Unable to determine slot size"


### PR DESCRIPTION
`job-ingest` validators explicitly allowed `"attributes": null`, though this is not valid jobspec as documented in RFCs 14 and 25.

This PR fixes the jsonschema and Python Jobspec validators to  reject jobspec with `null` attributes, and updates `basic.yaml` to be valid jobspec.

Note also that RFC 25 at least specifies that the `system` key and specifically `system.duration` are required keys, but neither validator enforces this. I thought it best to leave that be for now, as fixing it may break existing users. Perhaps we should go back and fix the RFCs.

Edit: Also note: the `job-info` module *does* require `attributes.system`, so I wonder if actually it would be ok to fix validators and all the tests to make the `system` key in `attributes` required.
