### PR TITLE
support job timelimits

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,8 +54,8 @@ jobs:
       if: failure()
       run: >
         find . -name test-suite.log |
-        xargs -i sh -c 'printf "===XXX {} XXX===";cat {}' &&
-        find . -name t[0-9]*.output |
-        xargs -i sh -c 'printf "\033[31mFound {}\033[39m\n";cat {}'
-        find . -name *.asan.* |
-        xargs -i sh -c 'printf "\033[31mFound {}\033[39m\n";cat {}'
+        xargs -i sh -c 'printf "===XXX {} XXX===";cat {}';
+        find . -name 't[0-9]*.output' |
+        xargs -i sh -c 'printf "\033[31mFound {}\033[39m\n";cat {}';
+        find . -name '*.asan.*' |
+        xargs -i sh -c 'printf "\033[31mFound {}\033[39m\n";cat {}' 

--- a/src/cmd/flux-jobs.py
+++ b/src/cmd/flux-jobs.py
@@ -43,6 +43,7 @@ RESULT_CONST_DICT = {
     "completed": flux.constants.FLUX_JOB_RESULT_COMPLETED,
     "failed": flux.constants.FLUX_JOB_RESULT_FAILED,
     "cancelled": flux.constants.FLUX_JOB_RESULT_CANCELLED,
+    "timeout": flux.constants.FLUX_JOB_RESULT_TIMEOUT,
 }
 
 
@@ -578,6 +579,8 @@ def color_setup(args, job):
                 sys.stdout.write("\033[01;31m")
             elif job.result == "CANCELLED":
                 sys.stdout.write("\033[37m")
+            elif job.result == "TIMEOUT":
+                sys.stdout.write("\033[01;31m")
             return True
     return False
 

--- a/src/common/libjob/job.c
+++ b/src/common/libjob/job.c
@@ -531,6 +531,8 @@ const char *flux_job_resulttostr (flux_job_result_t result, bool abbrev)
             return abbrev ? "F" : "FAILED";
         case FLUX_JOB_RESULT_CANCELLED:
             return abbrev ? "CA" : "CANCELLED";
+        case FLUX_JOB_RESULT_TIMEOUT:
+            return abbrev ? "TO" : "TIMEOUT";
     }
     return abbrev ? "?" : "(unknown)";
 }
@@ -545,6 +547,8 @@ int flux_job_strtoresult (const char *s, flux_job_result_t *result)
         *result = FLUX_JOB_RESULT_FAILED;
     else if (!strcasecmp (s, "CA") || !strcasecmp (s, "CANCELLED"))
         *result = FLUX_JOB_RESULT_CANCELLED;
+    else if (!strcasecmp (s, "TO") || !strcasecmp (s, "TIMEOUT"))
+        *result = FLUX_JOB_RESULT_TIMEOUT;
     else
         goto inval;
 

--- a/src/common/libjob/job.h
+++ b/src/common/libjob/job.h
@@ -58,6 +58,7 @@ typedef enum {
     FLUX_JOB_RESULT_COMPLETED = 1,
     FLUX_JOB_RESULT_FAILED = 2,
     FLUX_JOB_RESULT_CANCELLED = 4,
+    FLUX_JOB_RESULT_TIMEOUT = 8,
 } flux_job_result_t;
 
 typedef uint64_t flux_jobid_t;

--- a/src/common/libjob/test/job.c
+++ b/src/common/libjob/test/job.c
@@ -273,6 +273,7 @@ struct rr rrtab[] = {
     { FLUX_JOB_RESULT_COMPLETED, "CD", "COMPLETED" },
     { FLUX_JOB_RESULT_FAILED,    "F",  "FAILED" },
     { FLUX_JOB_RESULT_CANCELLED, "CA", "CANCELLED" },
+    { FLUX_JOB_RESULT_TIMEOUT,   "TO", "TIMEOUT" },
     { -1, NULL, NULL },
 };
 

--- a/src/modules/job-exec/job-exec.c
+++ b/src/modules/job-exec/job-exec.c
@@ -129,6 +129,7 @@ void jobinfo_decref (struct jobinfo *job)
     if (job && (--job->refcount == 0)) {
         int saved_errno = errno;
         flux_watcher_destroy (job->kill_timer);
+        flux_watcher_destroy (job->expiration_timer);
         zhashx_delete (job->ctx->jobs, &job->id);
         if (job->impl && job->impl->exit)
             (*job->impl->exit) (job);
@@ -252,9 +253,12 @@ int jobinfo_emit_event_pack_nowait (struct jobinfo *job,
     return rc;
 }
 
-static int jobid_respond_error (flux_t *h, flux_jobid_t id,
-                                const flux_msg_t *msg,
-                                int errnum, const char *text)
+static int jobid_exception (flux_t *h, flux_jobid_t id,
+                            const flux_msg_t *msg,
+                            const char *type,
+                            int severity,
+                            int errnum,
+                            const char *text)
 {
     char note [256];
     if (errnum)
@@ -268,15 +272,21 @@ static int jobid_respond_error (flux_t *h, flux_jobid_t id,
                                       "id", id,
                                       "type", "exception",
                                       "data",
-                                      "severity", 0,
-                                      "type", "exec",
+                                      "severity", severity,
+                                      "type", type,
                                       "note", note);
 }
 
 static int jobinfo_respond_error (struct jobinfo *job, int errnum,
                                   const char *msg)
 {
-    return jobid_respond_error (job->ctx->h, job->id, job->req, errnum, msg);
+    return jobid_exception (job->ctx->h,
+                            job->id,
+                            job->req,
+                            "exec",
+                            0,
+                            errnum,
+                            msg);
 }
 
 static int jobinfo_send_release (struct jobinfo *job,
@@ -343,6 +353,20 @@ static void kill_timer_cb (flux_reactor_t *r, flux_watcher_t *w,
     (*job->impl->kill) (job, SIGKILL);
 }
 
+
+static void jobinfo_killtimer_start (struct jobinfo *job, double after)
+{
+    /* Only start kill timer if not already running */
+    if (job->kill_timer == NULL) {
+        job->kill_timer = flux_timer_watcher_create (flux_get_reactor (job->h),
+                                                     after,
+                                                     0.,
+                                                     kill_timer_cb,
+                                                     job);
+        flux_watcher_start (job->kill_timer);
+    }
+}
+
 /*  Cancel any pending shells to execute with implementations cancel
  *   method, send SIGTERM to executing shells to notify them to terminate,
  *   schedule SIGKILL to be sent after kill_timeout seconds.
@@ -357,10 +381,7 @@ static void jobinfo_cancel (struct jobinfo *job)
         (*job->impl->cancel) (job);
 
     (*job->impl->kill) (job, SIGTERM);
-    job->kill_timer = flux_timer_watcher_create (flux_get_reactor (job->h),
-                                                 job->kill_timeout, 0.,
-                                                 kill_timer_cb, job);
-    flux_watcher_start (job->kill_timer);
+    jobinfo_killtimer_start (job, job->kill_timeout);
 }
 
 static int jobinfo_finalize (struct jobinfo *job);
@@ -696,6 +717,68 @@ static int jobinfo_load_implementation (struct jobinfo *job)
     return -1;
 }
 
+static void timelimit_cb (flux_reactor_t *r,
+                          flux_watcher_t *w,
+                          int revents,
+                          void *arg)
+{
+    struct jobinfo *job = arg;
+
+    /*  Timelimit reached. Generate "timeout" exception and send SIGALRM.
+     *  Wait for a gracetime then forcibly terminate job.
+     */
+    if (jobid_exception (job->h, job->id, job->req, "timeout", 0, 0,
+                         "resource allocation expired") < 0)
+        flux_log_error (job->h,
+                        "failed to generate timeout exception for %ju",
+                        job->id);
+    (*job->impl->kill) (job, SIGALRM);
+    flux_watcher_stop (w);
+    job->exception_in_progress = 1;
+    jobinfo_killtimer_start (job, job->kill_timeout);
+}
+
+static int jobinfo_set_expiration (struct jobinfo *job)
+{
+    flux_watcher_t *w = NULL;
+    double expiration = resource_set_expiration (job->R);
+    double offset;
+
+    if (expiration < 0.) {
+        jobinfo_fatal_error (job,
+                             EINVAL,
+                             "Invalid resource set expiration %.2f",
+                             expiration);
+        return -1;
+    }
+
+    /* Timelimit disabled if expiration is set to 0.
+     */
+    if (expiration == 0.)
+        return 0;
+
+    /* N.B. Use of flux_reactor_time(3) here instead of flux_reactor_now(3)
+     *  is purposeful, Since this is used to find the time the job has
+     *  remaining, we should be as accurate as possible.
+     */
+    offset = expiration - flux_reactor_time ();
+    if (offset <= 0.) {
+        jobinfo_fatal_error (job, 0, "job started after expiration");
+        return -1;
+    }
+    if (!(w = flux_timer_watcher_create (flux_get_reactor(job->h),
+                                         offset,
+                                         0.,
+                                         timelimit_cb,
+                                         job))) {
+        jobinfo_fatal_error (job, errno, "unable to start expiration timer");
+        return -1;
+    }
+    flux_watcher_start (w);
+    job->expiration_timer = w;
+    return 0;
+}
+
 /*  Completion for jobinfo_initialize(), finish init of jobinfo using
  *   data fetched from KVS
  */
@@ -730,6 +813,8 @@ static void jobinfo_start_continue (flux_future_t *f, void *arg)
         jobinfo_fatal_error (job, errno, "reading R: %s", error.text);
         goto done;
     }
+    if (jobinfo_set_expiration (job) < 0)
+        goto done;
     if (job->multiuser) {
         const char *J = jobinfo_kvs_lookup_get (f, "J");
         if (!J || !(job->J = strdup (J))) {

--- a/src/modules/job-exec/job-exec.h
+++ b/src/modules/job-exec/job-exec.h
@@ -80,6 +80,7 @@ struct jobinfo {
 
     double                kill_timeout; /* grace time between sigterm,kill */
     flux_watcher_t       *kill_timer;
+    flux_watcher_t       *expiration_timer;
 
     /* Exec implementation for this job */
     struct exec_implementation *impl;

--- a/src/modules/job-exec/rset.c
+++ b/src/modules/job-exec/rset.c
@@ -86,10 +86,10 @@ static int rset_read_time_window (struct resource_set *r, json_error_t *errp)
         errno = EINVAL;
         return -1;
     }
-    /*  Default values: < 0 indicates "unset"
+    /*  Default values: 0. indicates "unset"
      */
-    r->expiration = -1.;
-    r-> starttime = -1.;
+    r->expiration = 0.;
+    r-> starttime = 0.;
     if (json_unpack_ex (r->R, errp, 0,
                         "{s:{s?F s?F}}",
                         "execution",

--- a/src/modules/job-info/job_state.c
+++ b/src/modules/job-info/job_state.c
@@ -964,16 +964,16 @@ error:
 static int eventlog_inactive_finish (struct info_ctx *ctx,
                                      struct job *job)
 {
+    /* Default result is failed, overridden below */
+    job->result = FLUX_JOB_RESULT_FAILED;
     if (job->success)
         job->result = FLUX_JOB_RESULT_COMPLETED;
-    else {
-        if (job->exception_occurred
-            && !strcmp (job->exception_type, "cancel"))
+    else if (job->exception_occurred) {
+        if (!strcmp (job->exception_type, "cancel"))
             job->result = FLUX_JOB_RESULT_CANCELLED;
-        else
-            job->result = FLUX_JOB_RESULT_FAILED;
+        else if (!strcmp (job->exception_type, "timeout"))
+            job->result = FLUX_JOB_RESULT_TIMEOUT;
     }
-
     return 0;
 }
 

--- a/src/modules/job-info/list.c
+++ b/src/modules/job-info/list.c
@@ -185,7 +185,8 @@ void list_cb (flux_t *h, flux_msg_handler_t *mh,
     if (!results)
         results = (FLUX_JOB_RESULT_COMPLETED
                    | FLUX_JOB_RESULT_FAILED
-                   | FLUX_JOB_RESULT_CANCELLED);
+                   | FLUX_JOB_RESULT_CANCELLED
+                   | FLUX_JOB_RESULT_TIMEOUT);
 
     if (!(jobs = get_jobs (ctx, max_entries, attrs, userid, states, results)))
         goto error;

--- a/src/modules/sched-simple/libjj.c
+++ b/src/modules/sched-simple/libjj.c
@@ -98,12 +98,20 @@ int libjj_get_counts (const char *spec, struct jj_counts *jj)
         errno = EINVAL;
         return -1;
     }
-
-    if (json_unpack_ex (o, &error, 0, "{s:i,s:o}",
+    if (json_unpack_ex (o, &error, 0, "{s:i s:o}",
                         "version", &version,
                         "resources", &resources) < 0) {
         snprintf (jj->error, sizeof (jj->error) - 1,
                   "at top level: %s", error.text);
+        errno = EINVAL;
+        goto err;
+    }
+    if (json_unpack_ex (o, &error, 0, "{s:{s?{s?F}}}",
+                        "attributes",
+                          "system",
+                            "duration", &jj->duration) < 0) {
+        snprintf (jj->error, sizeof (jj->error) - 1,
+                  "at top level: getting duration: %s", error.text);
         errno = EINVAL;
         goto err;
     }

--- a/src/modules/sched-simple/libjj.h
+++ b/src/modules/sched-simple/libjj.h
@@ -22,6 +22,8 @@ struct jj_counts {
     int nslots;    /* total number of slots requested */
     int slot_size; /* number of cores per slot        */
 
+    double duration; /* attributes.system.duration if set */
+
     char error[JJ_ERROR_TEXT_LENGTH]; /* On error, contains error description */
 };
 

--- a/src/modules/sched-simple/sched.c
+++ b/src/modules/sched-simple/sched.c
@@ -139,12 +139,39 @@ static struct simple_sched * simple_sched_create (void)
     return ss;
 }
 
-static char *Rstring_create (struct rlist *l)
+static int R_add_expiration (json_t *R, double now, double timelimit)
+{
+    int rc = -1;
+    json_t *exec = NULL;
+    json_t *o = NULL;
+    double starttime = now;
+    double expiration = now + timelimit;
+
+    if (!(exec = json_object_get (R, "execution"))
+        || (!(o = json_real (starttime)))
+        || json_object_set_new (exec, "starttime", o) < 0) {
+        json_decref (o);
+        goto out;
+    }
+    if (!(o = json_real (expiration))
+        || json_object_set_new (exec, "expiration", o) < 0) {
+        json_decref (o);
+        goto out;
+    }
+    rc = 0;
+out:
+    return rc;
+}
+
+static char *Rstring_create (struct rlist *l, double now, double timelimit)
 {
     char *s = NULL;
     json_t *R = rlist_to_R (l);
     if (R) {
+        if (timelimit > 0. &&  R_add_expiration (R, now, timelimit) < 0)
+            goto out;
         s = json_dumps (R, JSON_COMPACT);
+out:
         json_decref (R);
     }
     return (s);
@@ -158,6 +185,8 @@ static int try_alloc (flux_t *h, struct simple_sched *ss)
     struct jj_counts *jj = NULL;
     char *R = NULL;
     struct jobreq *job = zlistx_first (ss->queue);
+    double now = flux_reactor_now (flux_get_reactor (h));
+
     if (!job)
         return -1;
     jj = &job->jj;
@@ -176,7 +205,8 @@ static int try_alloc (flux_t *h, struct simple_sched *ss)
         goto out;
     }
     s = rlist_dumps (alloc);
-    if (!(R = Rstring_create (alloc)))
+
+    if (!(R = Rstring_create (alloc, now, jj->duration)))
         flux_log_error (h, "Rstring_create");
 
     if (R && schedutil_alloc_respond_R (ss->util_ctx, job->msg, R, s) < 0)
@@ -279,9 +309,10 @@ static void alloc_cb (flux_t *h, const flux_msg_t *msg,
         jobreq_destroy (job);
         return;
     }
-    flux_log (h, LOG_DEBUG, "req: %ju: spec={%d,%d,%d}",
+    flux_log (h, LOG_DEBUG, "req: %ju: spec={%d,%d,%d} duration=%.1f",
                             (uintmax_t) job->id, job->jj.nnodes,
-                            job->jj.nslots, job->jj.slot_size);
+                            job->jj.nslots, job->jj.slot_size,
+                            job->jj.duration);
     job->handle = zlistx_insert (ss->queue,
                                  job,
                                  job->priority > FLUX_JOB_PRIORITY_DEFAULT);

--- a/src/shell/signals.c
+++ b/src/shell/signals.c
@@ -56,8 +56,10 @@ static int signals_init (flux_plugin_t *p,
     flux_shell_t *shell = flux_plugin_get_shell (p);
     if (!shell)
         return -1;
-    /* forward local SIGINT, SIGTERM to tasks */
-    if (trap_signal (shell, SIGINT) < 0 || trap_signal (shell, SIGTERM) < 0)
+    /* forward local SIGINT, SIGTERM, SIGALRM to tasks */
+    if (trap_signal (shell, SIGINT) < 0
+        || trap_signal (shell, SIGTERM) < 0
+        || trap_signal (shell, SIGALRM) < 0)
         shell_log_errno ("failed to set up signal watchers");
     return 0;
 }

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -138,6 +138,7 @@ TESTSCRIPTS = \
 	t2701-mini-batch.t \
 	t2702-mini-alloc.t \
 	t2800-jobs-cmd.t \
+	t2900-job-timelimits.t \
 	t3000-mpi-basic.t \
 	t3001-mpi-personalities.t \
 	t4000-issues-test-driver.t \

--- a/t/sched-simple/jj-reader.c
+++ b/t/sched-simple/jj-reader.c
@@ -27,8 +27,8 @@ int main (int ac, char *av[])
         log_err_exit ("Failed to read stdin");
     if (libjj_get_counts (s, &jj) < 0)
         log_msg_exit ("%s", jj.error);
-    printf ("nnodes=%d nslots=%d slot_size=%d\n",
-            jj.nnodes, jj.nslots, jj.slot_size);
+    printf ("nnodes=%d nslots=%d slot_size=%d duration=%.1f\n",
+            jj.nnodes, jj.nslots, jj.slot_size, jj.duration);
     log_fini ();
     free (s);
     return 0;

--- a/t/t0022-jj-reader.t
+++ b/t/t0022-jj-reader.t
@@ -109,6 +109,9 @@ srun -n4 -c4      ==nnodes=0 nslots=4 slot_size=4 duration=0.0
 srun -n4 -c4      ==nnodes=0 nslots=4 slot_size=4 duration=0.0
 srun -n4 -c1      ==nnodes=0 nslots=4 slot_size=1 duration=0.0
 srun -N4 -n4 -c4  ==nnodes=4 nslots=4 slot_size=4 duration=0.0
+srun -t 1 -N4     ==nnodes=4 nslots=4 slot_size=1 duration=60.0
+srun -t 0:5 -N4   ==nnodes=4 nslots=4 slot_size=1 duration=5.0
+srun -t 1:0:0 -N4 ==nnodes=4 nslots=4 slot_size=1 duration=3600.0
 EOF
 
 while read line; do

--- a/t/t0022-jj-reader.t
+++ b/t/t0022-jj-reader.t
@@ -101,14 +101,14 @@ done <invalid.txt
 # <jobspec command args> == <expected result>
 #
 cat <<EOF >inputs.txt
-srun              ==nnodes=0 nslots=1 slot_size=1
-srun -N1          ==nnodes=1 nslots=1 slot_size=1
-srun -N1 -n4      ==nnodes=1 nslots=4 slot_size=1
-srun -N1 -n4 -c4  ==nnodes=1 nslots=4 slot_size=4
-srun -n4 -c4      ==nnodes=0 nslots=4 slot_size=4
-srun -n4 -c4      ==nnodes=0 nslots=4 slot_size=4
-srun -n4 -c1      ==nnodes=0 nslots=4 slot_size=1
-srun -N4 -n4 -c4  ==nnodes=4 nslots=4 slot_size=4
+srun              ==nnodes=0 nslots=1 slot_size=1 duration=0.0
+srun -N1          ==nnodes=1 nslots=1 slot_size=1 duration=0.0
+srun -N1 -n4      ==nnodes=1 nslots=4 slot_size=1 duration=0.0
+srun -N1 -n4 -c4  ==nnodes=1 nslots=4 slot_size=4 duration=0.0
+srun -n4 -c4      ==nnodes=0 nslots=4 slot_size=4 duration=0.0
+srun -n4 -c4      ==nnodes=0 nslots=4 slot_size=4 duration=0.0
+srun -n4 -c1      ==nnodes=0 nslots=4 slot_size=1 duration=0.0
+srun -N4 -n4 -c4  ==nnodes=4 nslots=4 slot_size=4 duration=0.0
 EOF
 
 while read line; do

--- a/t/t2233-job-info-security.t
+++ b/t/t2233-job-info-security.t
@@ -14,7 +14,7 @@ update_job_userid() {
         if test -n "$userid"; then
             local kvsdir=$(flux job id --to=kvs $jobid)
             flux kvs get --raw ${kvsdir}.eventlog \
-                | sed -e 's/\("userid":\)[0-9]*/\1'${userid}/ \
+                | sed -e 's/\("userid":\)-*[0-9]*/\1'${userid}/ \
                 | flux kvs put --raw ${kvsdir}.eventlog=-
         fi
 }

--- a/t/t2400-job-exec-test.t
+++ b/t/t2400-job-exec-test.t
@@ -88,6 +88,15 @@ test_expect_success 'job-exec: simulate epilog/cleanup tasks' '
 	grep "cleanup\.start" exec.eventlog.$jobid &&
 	grep "cleanup\.finish" exec.eventlog.$jobid
 '
+test_expect_success 'job-exec: R with invalid expiration raises exception' '
+	flux module unload job-exec &&
+	jobid=$(flux job submit basic.json) &&
+	key=$(flux job id --to=kvs $jobid).R &&
+	R=$(flux kvs get --wait $key | jq -c ".execution.expiration = -1.") &&
+	flux kvs put ${key}=${R} &&
+	flux module load job-exec &&
+	flux job wait-event -v $jobid exception
+'
 #
 # XXX: Trying to generate an exception during cleanup is racy, however,
 #  there is not currently another way to do this until we have a *real*

--- a/t/t2900-job-timelimits.t
+++ b/t/t2900-job-timelimits.t
@@ -1,0 +1,50 @@
+#!/bin/sh
+
+test_description='Test job time limit functionality'
+
+. $(dirname $0)/sharness.sh
+
+test_under_flux 1
+
+# Set CLIMain log level to logging.DEBUG (10), to enable stack traces
+export FLUX_PYCLI_LOGLEVEL=10
+
+# Default timeout, extend under valgrind
+TIMEOUT=0.25
+test -n "$FLUX_TEST_VALGRIND" && TIMEOUT=3
+test_have_prereq ASAN && TIMEOUT=3
+
+test_expect_success 'job time limits are enforced' '
+	test_expect_code 142 \
+		flux mini run --time-limit=${TIMEOUT} sleep 10 2>limit1.err &&
+	grep "resource allocation expired" limit1.err
+'
+test_expect_success 'job may exit before time limit' '
+        flux mini run --time-limit=5m sleep 0.25
+'
+test_expect_success 'result for expired jobs is TIMEOUT' '
+	test_debug "flux jobs -a" &&
+	flux jobs -ano {result} | grep -q TIMEOUT
+'
+test_expect_success 'expired jobs are sent SIGALRM, then SIGKILL' '
+	kill_timeout=$(test -z "$FLUX_TEST_VALGRIND" && echo 0.5 || echo 6) &&
+	test_debug "echo reloading job-exec with kill-timeout=$kill_timeout" &&
+	flux module reload \
+		job-exec kill-timeout=${kill_timeout} &&
+	test_expect_code 137 \
+	    flux mini run -vvv --time-limit=${TIMEOUT} bash -c \
+               "trap \"echo got SIGALRM>>trap.out\" SIGALRM;sleep 10;sleep 15" \
+		   > trap.out 2> trap.err &&
+	test_debug "grep . trap.*" &&
+	grep "resource allocation expired" trap.err &&
+	grep "got SIGALRM" trap.out
+'
+test_expect_success 'expired job can also be canceled' '
+	flux module reload job-exec kill-timeout=60 &&
+	id=$(flux mini submit --time-limit=$TIMEOUT bash -c \
+            "trap \"echo got SIGALRM>>trap2.out\" SIGALRM;sleep 10;sleep 10" ) &&
+	flux job wait-event --timeout=20 $id exception &&
+	flux job cancel $id &&
+	test_expect_code 143 run_timeout 30 flux job attach $id
+'
+test_done


### PR DESCRIPTION
This PR makes the minimal changes necessary to support enforcing job time limits.
It requires changes in #2994, so is currently based on top of that branch. 

The `starttime` and `expiration` keys are now set in `R` by sched-simple, and `job-exec` "expires" jobs when the resource allocation expiration time is reached.

(Side note: I have a nagging worry about using an absolute time for  `expiration`, what happens if a job is assigned just before a DST change, for example. We may be setting ourselves up for bugs here. However, I'm ignoring all that for now)

When a job reaches its limit a `timeout` exception is thrown and `SIGALRM` is sent to the shells of the job, which forward on to the job tasks. In case `SIGALRM` is blocked by the job, this is followed up by `SIGKILL` after kill_timeout seconds (default 5s).

A new "TIMEOUT" job result was added, available with flux-jobs, etc.

No tests are added yet, in case there was severe pushback on any of the design choices. However, it basically works:

```
ƒ(s=4,d=0,builddir) grondo@asp:~/git/flux-core.git$ flux mini run -t 1 sleep 10
1.017s: job.exception type=timeout severity=0 resource allocation expired
flux-job: task(s) exited with exit code 142
ƒ(s=4,d=0,builddir) grondo@asp:~/git/flux-core.git$ flux jobs -a
             JOBID USER     NAME       STATUS NTASKS NNODES  RUNTIME RANKS
    36033584431104 grondo   sleep          TO      1      1   0.998s 0
```