### PR TITLE
flux-jobs: add support for job expiration and remaining time

### DIFF
--- a/doc/man1/flux-jobs.adoc
+++ b/doc/man1/flux-jobs.adoc
@@ -80,44 +80,62 @@ The '--format' option can be used to specify an output format to
 flux-jobs(1) using Python's string format syntax.  For example, the
 following is the format used for the default format:
 
-  {id:>18} {username:<8.8} {name:<10.10} {status:>6.6} {ntasks:>6} {nnodes:>6h} {runtime_fsd:>8h} {ranks:h}
+  {id:>18} {username:<8.8} {name:<10.10} {status:>6.6} {ntasks:>6} {nnodes:>6h} {runtime!F:>8h} {ranks:h}
 
-The conversion type 'h' can be used to convert an empty string, "0s",
-"0.0", or "0:00:00" to a hyphen.  For example, normally "{ranks}"
-would output an empty string if the job has not yet run.  By
-specifying, "{ranks:h}", a hyphen would be output instead.
+The special presentation type 'h' can be used to convert an empty
+string, "0s", "0.0", or "0:00:00" to a hyphen.  For example, normally
+"{ranks}" would output an empty string if the job has not yet run.
+By specifying, "{ranks:h}", a hyphen would be presented instead.
+
+Additionally, the custom job formatter supports a set of special
+conversion flags. Conversion flags follow the format field and are
+used to transform the value before formatting takes place. Currently,
+the following conversion flags are supported by 'flux-jobs':
+
+*!D*::
+convert a timestamp field to ISO8601 date and time (e.g. 2020-01-07T13:31:00)
+*!d*::
+convert a timestamp to a Python datetime object. This allows datetime specific
+format to be used, e.g. '{t_inactive!d:%H:%M:%S}'. However, note that width
+and alignment specifiers are not supported for datetime formatting.
+*!F*::
+convert a duration in floating point seconds to Flux Standard Duration (FSD)
+string.
+*!H*::
+convert a duration to hours:minutes:seconds form (e.g. '{runtime!H}')
+
 
 The field names that can be specified are:
 
-[horizontal]
-id:: job ID
-userid:: job submitter's userid
-username:: job submitter's username
-priority:: job priority
-status:: job status (PENDING, RUNNING, COMPLETED, FAILED, or CANCELLED)
-status_abbrev:: status but in a max 2 character abbreviation
-name:: job name
-ntasks:: job task count
-nnodes:: job node count (if job ran / is running), empty string otherwise
-ranks:: job ranks (if job ran / is running), empty string otherwise
-state:: job state (DEPEND, SCHED, RUN, CLEANUP, INACTIVE)
-state_single:: job state as a single character
-result:: job result if job is inactive (COMPLETED, FAILED, CANCELLED), empty string otherwise
-result_abbrev:: result but in a max 2 character abbreviation
-success:: True of False if job completed successfully, empty string otherwise
-exception.occurred:: True of False if job had an exception, empty string otherwise
-exception.severity:: If exception.occurred True, the highest severity, empty string otherwise
-exception.type:: If exception.occurred True, the highest severity exception type, empty string otherwise
-exception.note:: If exception.occurred True, the highest severity exception note, empty string otherwise
-t_submit:: time job was submitted
-t_depend:: time job entered depend state
-t_sched:: time job entered sched state
-t_run:: time job entered run state
-t_cleanup:: time job entered cleanup state
-t_inactive:: time job entered inactive state
-runtime:: job runtime
-runtime_fsd:: job runtime in Flux standard duration format
-runtime_hms:: job runtime in H:M:S format
+*id*:: job ID
+*userid*:: job submitter's userid
+*username*:: job submitter's username
+*priority*:: job priority
+*status*:: job status (PENDING, RUNNING, COMPLETED, FAILED, or CANCELLED)
+*status_abbrev*:: status but in a max 2 character abbreviation
+*name*:: job name
+*ntasks*:: job task count
+*nnodes*:: job node count (if job ran / is running), empty string otherwise
+*ranks*:: job ranks (if job ran / is running), empty string otherwise
+*state*:: job state (DEPEND, SCHED, RUN, CLEANUP, INACTIVE)
+*state_single*:: job state as a single character
+*result*:: job result if job is inactive (COMPLETED, FAILED, CANCELLED), empty string otherwise
+*result_abbrev*:: result but in a max 2 character abbreviation
+*success*:: True of False if job completed successfully, empty string otherwise
+*exception.occurred*:: True of False if job had an exception, empty string otherwise
+*exception.severity*:: If exception.occurred True, the highest severity, empty string otherwise
+*exception.type*:: If exception.occurred True, the highest severity exception type, empty string otherwise
+*exception.note*:: If exception.occurred True, the highest severity exception note, empty string otherwise
+*t_submit*:: time job was submitted
+*t_depend*:: time job entered depend state
+*t_sched*:: time job entered sched state
+*t_run*:: time job entered run state
+*t_cleanup*:: time job entered cleanup state
+*t_inactive*:: time job entered inactive state
+*runtime*:: job runtime
+*expiration*:: time at which job allocation was marked to expire
+*t_remaining*:: If job is running, amount of time remaining before expiration
+
 
 AUTHOR
 ------

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -489,3 +489,5 @@ CANCELLED
 enqueue
 nslots
 alloc
+datetime
+formatter

--- a/src/bindings/python/flux/core/handle.py
+++ b/src/bindings/python/flux/core/handle.py
@@ -198,7 +198,9 @@ class Flux(Wrapper):
             h.reactor_stop(reactor)
 
         with self.signal_watcher_create(signal.SIGINT, reactor_interrupt):
+            self.reactor_active_decref(reactor)
             rc = self.flux_reactor_run(reactor, flags)
+            self.reactor_active_incref(reactor)
             if reactor_interrupted:
                 raise KeyboardInterrupt
 

--- a/src/bindings/python/flux/util.py
+++ b/src/bindings/python/flux/util.py
@@ -232,6 +232,12 @@ class OutputFormat:
         for (text, field, spec, conv) in self.format_list:
             #  Remove number formatting on any spec:
             spec = re.sub(r"(0?\.)?(\d+)?[bcdoxXeEfFgGn%]$", r"\2", spec)
+            #  Only keep fill, align, and min width of the result.
+            #  This strips possible type-specific formatting spec that
+            #   will not apply to a heading, but keeps width and alignment.
+            match = re.match(r"(.?[<>=^])?(\d+)", spec)
+            if match is None:
+                 spec = ""
             format_list.append(self._fmt_tuple(text, field, spec, conv))
         fmt = "".join(format_list)
         return fmt

--- a/src/bindings/python/flux/util.py
+++ b/src/bindings/python/flux/util.py
@@ -237,8 +237,10 @@ class OutputFormat:
             #   will not apply to a heading, but keeps width and alignment.
             match = re.match(r"(.?[<>=^])?(\d+)", spec)
             if match is None:
-                 spec = ""
-            format_list.append(self._fmt_tuple(text, field, spec, conv))
+                spec = ""
+
+            #  Remove any conversion, these do not make sense for headings
+            format_list.append(self._fmt_tuple(text, field, spec, None))
         fmt = "".join(format_list)
         return fmt
 

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -997,7 +997,7 @@ int cmd_cancelall (optparse_t *p, int argc, char **argv)
 
 static const char *list_attrs =
     "[\"userid\",\"priority\",\"t_submit\",\"state\","          \
-    "\"name\",\"ntasks\",\"nnodes\",\"ranks\",\"success\","             \
+    "\"name\",\"ntasks\",\"nnodes\",\"ranks\",\"expiration\",\"success\"," \
     "\"exception_occurred\",\"exception_severity\",\"exception_type\"," \
     "\"exception_note\",\"result\","                                    \
     "\"t_depend\",\"t_sched\",\"t_run\",\"t_cleanup\",\"t_inactive\"]";

--- a/src/cmd/flux-jobs.py
+++ b/src/cmd/flux-jobs.py
@@ -47,7 +47,7 @@ RESULT_CONST_DICT = {
 }
 
 
-def fsd(secs, hyphenifzero):
+def fsd(secs):
     #  Round <1ms down to 0s for now
     if secs < 1.0e-3:
         strtmp = "0s"
@@ -61,8 +61,6 @@ def fsd(secs, hyphenifzero):
         strtmp = "%.4gh" % (secs / (60.0 * 60.0))
     else:
         strtmp = "%.4gd" % (secs / (60.0 * 60.0 * 24.0))
-    if hyphenifzero and strtmp == "0s":
-        return "-"
     return strtmp
 
 
@@ -195,7 +193,7 @@ class JobInfo:
 
     @memoized_property
     def runtime_fsd(self):
-        return fsd(self.runtime, False)
+        return fsd(self.runtime)
 
     @memoized_property
     def runtime_hms(self):

--- a/src/cmd/flux-jobs.py
+++ b/src/cmd/flux-jobs.py
@@ -115,6 +115,7 @@ class JobInfo:
         "t_run": 0.0,
         "t_cleanup": 0.0,
         "t_inactive": 0.0,
+        "expiration": 0.0,
         "nnodes": "",
         "ranks": "",
         "success": "",
@@ -170,6 +171,19 @@ class JobInfo:
         else:
             runtime = 0.0
         return runtime
+
+    def get_remaining_time(self):
+        status = str(self.status)
+        if status != "RUNNING":
+            return 0.0
+        tleft = self.expiration - time.time()
+        if tleft < 0.0:
+            return 0.0
+        return tleft
+
+    @property
+    def t_remaining(self):
+        return self.get_remaining_time()
 
     @memoized_property
     def state(self):
@@ -332,6 +346,8 @@ def fetch_jobs_flux(args, fields):
         "runtime_hms": ("t_run", "t_cleanup"),
         "status": ("state", "result"),
         "status_abbrev": ("state", "result"),
+        "expiration": ("expiration", "state", "result"),
+        "t_remaining": ("expiration", "state", "result"),
     }
 
     attrs = set()
@@ -543,6 +559,8 @@ class JobsOutputFormat(flux.util.OutputFormat):
         "name": "NAME",
         "ntasks": "NTASKS",
         "nnodes": "NNODES",
+        "expiration": "EXPIRATION",
+        "t_remaining": "T_REMAINING",
         "ranks": "RANKS",
         "success": "SUCCESS",
         "result": "RESULT",

--- a/src/cmd/flux-jobs.py
+++ b/src/cmd/flux-jobs.py
@@ -206,15 +206,6 @@ class JobInfo:
         return get_username(self.userid)
 
     @memoized_property
-    def runtime_fsd(self):
-        return fsd(self.runtime)
-
-    @memoized_property
-    def runtime_hms(self):
-        runtime = self.get_runtime(True)
-        return str(timedelta(seconds=runtime))
-
-    @memoized_property
     def runtime(self):
         return self.get_runtime()
 
@@ -342,8 +333,6 @@ def fetch_jobs_flux(args, fields):
         "t_cleanup": ("t_cleanup",),
         "t_inactive": ("t_inactive",),
         "runtime": ("t_run", "t_cleanup"),
-        "runtime_fsd": ("t_run", "t_cleanup"),
-        "runtime_hms": ("t_run", "t_cleanup"),
         "status": ("state", "result"),
         "status_abbrev": ("state", "result"),
         "expiration": ("expiration", "state", "result"),
@@ -572,8 +561,6 @@ class JobsOutputFormat(flux.util.OutputFormat):
         "t_cleanup": "T_CLEANUP",
         "t_inactive": "T_INACTIVE",
         "runtime": "RUNTIME",
-        "runtime_fsd": "RUNTIME",
-        "runtime_hms": "RUNTIME",
         "status": "STATUS",
         "status_abbrev": "STATUS",
     }
@@ -646,7 +633,7 @@ def main():
     else:
         fmt = (
             "{id:>18} {username:<8.8} {name:<10.10} {status_abbrev:>6.6} "
-            "{ntasks:>6} {nnodes:>6h} {runtime_fsd:>8h} "
+            "{ntasks:>6} {nnodes:>6h} {runtime!F:>8h} "
             "{ranks:h}"
         )
     try:

--- a/src/modules/job-info/job_state.c
+++ b/src/modules/job-info/job_state.c
@@ -798,9 +798,10 @@ static int R_lookup_parse (struct info_ctx *ctx,
     }
 
     if (json_unpack_ex (job->R, &error, 0,
-                        "{s:i s:{s:o}}",
+                        "{s:i s:{s?F s:o}}",
                         "version", &version,
                         "execution",
+                        "expiration", &job->expiration,
                         "R_lite", &R_lite) < 0) {
         flux_log (ctx->h, LOG_ERR,
                   "%s: job %ju invalid R: %s",

--- a/src/modules/job-info/job_state.h
+++ b/src/modules/job-info/job_state.h
@@ -70,6 +70,7 @@ struct job {
     int ntasks;
     int nnodes;
     char *ranks;
+    double expiration;
     bool success;
     bool exception_occurred;
     json_t *exception_context;

--- a/src/modules/job-info/job_util.c
+++ b/src/modules/job-info/job_util.c
@@ -102,6 +102,11 @@ json_t *job_to_json (struct job *job, json_t *attrs)
                 continue;
             val = json_string (job->ranks);
         }
+        else if (!strcmp (attr, "expiration")) {
+            if (!(job->states_mask & FLUX_JOB_RUN))
+                continue;
+            val = json_real (job->expiration);
+        }
         else if (!strcmp (attr, "success")) {
             if (!(job->states_mask & FLUX_JOB_INACTIVE))
                 continue;

--- a/src/modules/job-info/list.c
+++ b/src/modules/job-info/list.c
@@ -536,7 +536,7 @@ void list_attrs_cb (flux_t *h, flux_msg_handler_t *mh,
                             "state", "name", "ntasks", "nnodes", "ranks",
                             "success", "exception_occurred", "exception_type",
                             "exception_severity", "exception_note", "result",
-                            NULL };
+                            "expiration", NULL };
     json_t *a = NULL;
     int i;
 

--- a/t/flux-jobs/tests/issue#2634/format
+++ b/t/flux-jobs/tests/issue#2634/format
@@ -1,1 +1,1 @@
-{runtime_fsd:h} {runtime_fsd}
+{runtime!F:h} {runtime!F}

--- a/t/flux-jobs/tests/issue#2658/format
+++ b/t/flux-jobs/tests/issue#2658/format
@@ -1,1 +1,1 @@
-{runtime_fsd}
+{runtime!F}

--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -54,7 +54,7 @@ test_expect_success 'submit jobs for job list testing' '
         flux job wait-event $jobid clean &&
         echo $jobid >> job_ids1.out &&
         for i in `seq 1 8`; do \
-            jobid=`flux mini submit sleep 600`; \
+            jobid=`flux mini submit --time-limit=5m sleep 600`; \
             flux job wait-event $jobid start; \
             echo $jobid >> job_ids2.out; \
         done &&
@@ -431,11 +431,11 @@ test_expect_success 'flux-jobs --format={t_XXX} works' '
         test $count -eq 6
 '
 
-test_expect_success 'flux-jobs --format={runtime},{runtime_fsd},{runtime_fsd:h},{runtime_hms},{runtime_hms:h} works' '
-        flux jobs --suppress-header --filter=pending --format="{runtime},{runtime_fsd},{runtime_hms}" > runtimeP.out &&
+test_expect_success 'flux-jobs --format={runtime},{runtime!F},{runtime!F:h},{runtime!H},{runtime!H:h} works' '
+        flux jobs --suppress-header --filter=pending --format="{runtime},{runtime!F},{runtime!H}" > runtimeP.out &&
         for i in `seq 1 6`; do echo "0.0,0s,0:00:00" >> runtimeP.exp; done &&
         test_cmp runtimeP.out runtimeP.exp &&
-        flux jobs --suppress-header --filter=pending --format="{runtime_fsd:h},{runtime_hms:h}" > runtimeP_h.out &&
+        flux jobs --suppress-header --filter=pending --format="{runtime!F:h},{runtime!H:h}" > runtimeP_h.out &&
         for i in `seq 1 6`; do echo "-,-" >> runtimeP_h.exp; done &&
         test_cmp runtimeP_h.out runtimeP_h.exp &&
         flux jobs --suppress-header --filter=running --format="{runtime}" > runtimeR_1.out &&
@@ -444,16 +444,16 @@ test_expect_success 'flux-jobs --format={runtime},{runtime_fsd},{runtime_fsd:h},
         flux jobs --suppress-header --filter=running --format="{runtime:h}" > runtimeR_1_h.out &&
         count=`cat runtimeR_1_h.out | grep -v "^-$" | wc -l` &&
         test $count -eq 8 &&
-        flux jobs --suppress-header --filter=running --format="{runtime_fsd}" > runtimeR_2.out &&
+        flux jobs --suppress-header --filter=running --format="{runtime!F}" > runtimeR_2.out &&
         count=`cat runtimeR_2.out | grep -v "^0s" | wc -l` &&
         test $count -eq 8 &&
-        flux jobs --suppress-header --filter=running --format="{runtime_fsd:h}" > runtimeR_2_h.out &&
+        flux jobs --suppress-header --filter=running --format="{runtime!F:h}" > runtimeR_2_h.out &&
         count=`cat runtimeR_2_h.out | grep -v "^-$" | wc -l` &&
         test $count -eq 8 &&
-        flux jobs --suppress-header --filter=running --format="{runtime_hms}" > runtimeR_3.out &&
+        flux jobs --suppress-header --filter=running --format="{runtime!H}" > runtimeR_3.out &&
         count=`cat runtimeR_3.out | grep -v "^0:00:00$" | wc -l` &&
         test $count -eq 8 &&
-        flux jobs --suppress-header --filter=running --format="{runtime_hms:h}" > runtimeR_3_h.out &&
+        flux jobs --suppress-header --filter=running --format="{runtime!H:h}" > runtimeR_3_h.out &&
         count=`cat runtimeR_3_h.out | grep -v "^-$" | wc -l` &&
         test $count -eq 8 &&
         flux jobs --suppress-header --filter=inactive --format="{runtime}" > runtimeI_1.out &&
@@ -466,22 +466,22 @@ test_expect_success 'flux-jobs --format={runtime},{runtime_fsd},{runtime_fsd:h},
         test $count -eq 1 &&
         count=`tail -n 5 runtimeI_1_h.out | grep -v "^-$" | wc -l` &&
         test $count -eq 5 &&
-        flux jobs --suppress-header --filter=inactive --format="{runtime_fsd}" > runtimeI_2.out &&
+        flux jobs --suppress-header --filter=inactive --format="{runtime!F}" > runtimeI_2.out &&
         count=`head -n 1 runtimeI_2.out | grep "^0s" | wc -l` &&
         test $count -eq 1 &&
         count=`tail -n 5 runtimeI_2.out | grep -v "^0s" | wc -l` &&
         test $count -eq 5 &&
-        flux jobs --suppress-header --filter=inactive --format="{runtime_fsd:h}" > runtimeI_2_h.out &&
+        flux jobs --suppress-header --filter=inactive --format="{runtime!F:h}" > runtimeI_2_h.out &&
         count=`head -n 1 runtimeI_2_h.out | grep "^-$" | wc -l` &&
         test $count -eq 1 &&
         count=`tail -n 5 runtimeI_2_h.out | grep -v "^-$" | wc -l` &&
         test $count -eq 5 &&
-        flux jobs --suppress-header --filter=inactive --format="{runtime_hms}" > runtimeI_3.out &&
+        flux jobs --suppress-header --filter=inactive --format="{runtime!H}" > runtimeI_3.out &&
         count=`head -n 1 runtimeI_3.out | grep "^0:00:00$" | wc -l` &&
         test $count -eq 1 &&
         count=`tail -n 5 runtimeI_3.out | grep -v "^0:00:00$" | wc -l` &&
         test $count -eq 5 &&
-        flux jobs --suppress-header --filter=inactive --format="{runtime_hms:h}" > runtimeI_3_h.out &&
+        flux jobs --suppress-header --filter=inactive --format="{runtime!H:h}" > runtimeI_3_h.out &&
         count=`head -n 1 runtimeI_3_h.out | grep "^-$" | wc -l` &&
         test $count -eq 1 &&
         count=`tail -n 5 runtimeI_3_h.out | grep -v "^-$" | wc -l` &&
@@ -605,8 +605,8 @@ test_expect_success 'flux-jobs: header included with all custom formats' '
         flux jobs --format={t_cleanup} | head -1 | grep "T_CLEANUP" &&
         flux jobs --format={t_inactive} | head -1 | grep "T_INACTIVE" &&
         flux jobs --format={runtime} | head -1 | grep "RUNTIME" &&
-        flux jobs --format={runtime_fsd} | head -1 | grep "RUNTIME" &&
-        flux jobs --format={runtime_hms} | head -1 | grep "RUNTIME"
+        flux jobs --format={runtime!F} | head -1 | grep "RUNTIME" &&
+        flux jobs --format={runtime!H} | head -1 | grep "RUNTIME"
 '
 
 #


### PR DESCRIPTION
This PR adds support for collecting job `expiration` time from _R_ in job-info, along with the changes necessary to support the new fields `expiration` and `t_remaining` in `flux-jobs`.

So that it wasn't necessary to add `t_remaining_fsd` and `t_remaining_hms` etc fields in flux-jobs, support for custom "conversion specifiers" was added to the `JobFormatter` class. Now, a `!F` converts a float time to FSD, `!H` converts to H:M:S, and for datetime objects `!D` converts to an ISO 8601 date and time string (no timezone).
A `!d` was also added for flexibility to convert to a `datetime` object, which then has its own custom format spec (`strftime()` based):
```
$ flux jobs -ao '{t_inactive!d:%Y-%m-%d}'
T_INACTIVE
2020-06-15
2020-06-15
2020-06-15
```
However, this form doesn't allow for alignment so the `!D` is probably more useful in most circumstances.

As a result `runtime_fsd` and `runtime_hms` fields are removed in preference for `runtime!F` and `runtime!H`.

```
$ flux jobs -ao '{id:>20} {t_remaining!F:>12h}'
               JOBID  T_REMAINING
       2378002595840       18.77s
        318347673600       23.97h
        129754988544       2.746m
       1836585058304            -
        176026550272            -
```

Leaving this as a WIP to get comments on the general approach, naming of fields, etc.