### PR TITLE
rc: load job-info on rank 0 only

### DIFF
--- a/etc/rc1
+++ b/etc/rc1
@@ -25,7 +25,7 @@ unset pids
 
 declare -a pids
 flux module load resource
-flux exec -r all flux module load job-info & pids+=($!)
+flux module load job-info & pids+=($!)
 flux module load cron sync=hb & pids+=($!)
 flux module load job-manager & pids+=($!)
 wait_check ${pids[@]}

--- a/etc/rc3
+++ b/etc/rc3
@@ -22,7 +22,7 @@ flux module remove -f cron
 flux exec -r all flux module remove -f aggregator
 flux exec -r all flux module remove -f barrier
 
-flux exec -r all flux module remove -f job-info
+flux module remove -f job-info
 flux exec -r all flux module remove -f kvs-watch
 flux exec -r all -x 0 flux module remove -f kvs
 

--- a/t/rc/rc1-job
+++ b/t/rc/rc1-job
@@ -20,7 +20,7 @@ flux module load job-manager
 flux module load job-ingest
 
 flux exec -r all -x 0 flux module load job-ingest & pids="$pids $!"
-flux exec -r all flux module load job-info & pids="$pids $!"
+flux module load job-info & pids="$pids $!"
 flux exec -r all flux module load barrier & pids="$pids $!"
 
 # Load a fake resource.hwloc.by_rank key for sched-simple

--- a/t/rc/rc3-job
+++ b/t/rc/rc3-job
@@ -9,7 +9,7 @@ flux module remove -f sched-simple
 flux module remove -f resource
 flux module remove job-manager
 flux exec -r all flux module remove barrier
-flux exec -r all flux module remove job-info
+flux module remove job-info
 flux exec -r all flux module remove kvs-watch
 flux exec -r all flux module remove job-ingest
 

--- a/t/t2200-job-ingest.t
+++ b/t/t2200-job-ingest.t
@@ -85,7 +85,7 @@ test_expect_success 'job-ingest: job-ingest fails with bad validator path' '
 test_expect_success 'job-ingest: load job-ingest && job-info' '
 	ingest_module load \
 		validator=${BINDINGS_VALIDATOR} &&
-	flux exec -r all flux module load job-info
+	flux module load job-info
 '
 
 test_expect_success HAVE_JQ 'job-ingest: dummy job-manager has expected max_jobid' '
@@ -217,7 +217,7 @@ test_expect_success 'job-ingest: validator unexpected exit is handled' '
 
 test_expect_success 'job-ingest: remove modules' '
 	flux module remove job-manager &&
-	flux exec -r all flux module remove job-info &&
+	flux module remove job-info &&
 	flux exec -r all flux module remove job-ingest
 '
 

--- a/t/t2202-job-manager.t
+++ b/t/t2202-job-manager.t
@@ -20,7 +20,7 @@ test_expect_success 'job-manager: load job-ingest, job-info, job-manager' '
 	flux module load job-manager &&
 	flux module load job-ingest &&
 	flux exec -r all -x 0 flux module load job-ingest &&
-	flux exec -r all flux module load job-info
+	flux module load job-info
 '
 
 test_expect_success HAVE_JQ 'job-manager: max_jobid=0 before jobs run' '
@@ -307,7 +307,7 @@ test_expect_success 'submit request with empty payload fails with EPROTO(71)' '
 
 test_expect_success 'job-manager: remove job-manager, job-info, job-ingest' '
 	flux module remove job-manager &&
-	flux exec -r all flux module remove job-info &&
+	flux module remove job-info &&
 	flux exec -r all flux module remove job-ingest
 '
 

--- a/t/t2203-job-manager-dummysched.t
+++ b/t/t2203-job-manager-dummysched.t
@@ -36,7 +36,7 @@ test_expect_success 'job-manager: load job-ingest, job-manager' '
 	flux module load job-manager &&
 	flux module load job-ingest &&
 	flux exec -r all -x 0 flux module load job-ingest &&
-	flux exec -r all flux module load job-info
+	flux module load job-info
 '
 
 test_expect_success 'job-manager: submit 5 jobs' '
@@ -162,7 +162,7 @@ test_expect_success 'job-manager: remove sched-dummy' '
 
 test_expect_success 'job-manager: remove job-manager, job-ingest' '
 	flux module remove job-manager &&
-	flux exec -r all flux module remove job-info &&
+	flux module remove job-info &&
 	flux exec -r all flux module remove job-ingest
 '
 

--- a/t/t2230-job-info-list.t
+++ b/t/t2230-job-info-list.t
@@ -354,7 +354,7 @@ wait_inactive() {
 
 test_expect_success 'reload the job-info module' '
         flux job list -a > before_reload.out &&
-        flux exec -r all flux module reload job-info &&
+        flux module reload job-info &&
         wait_inactive
 '
 
@@ -611,7 +611,7 @@ test_expect_success HAVE_JQ 'flux job lists full path for job name if basename f
 '
 
 test_expect_success 'reload the job-info module' '
-        flux exec -r all flux module reload job-info
+        flux module reload job-info
 '
 
 test_expect_success HAVE_JQ 'verify job names preserved across restart' '
@@ -648,7 +648,7 @@ test_expect_success HAVE_JQ 'flux job list outputs ntasks correctly (4 tasks)' '
 '
 
 test_expect_success 'reload the job-info module' '
-        flux exec -r all flux module reload job-info
+        flux module reload job-info
 '
 
 test_expect_success HAVE_JQ 'verify task count preserved across restart' '
@@ -749,7 +749,7 @@ test_expect_success HAVE_JQ 'flux job list outputs exceptions correctly (excepti
 '
 
 test_expect_success 'reload the job-info module' '
-        flux exec -r all flux module reload job-info
+        flux module reload job-info
 '
 
 test_expect_success HAVE_JQ 'verify nnodes preserved across restart' '


### PR DESCRIPTION
Problem: job-info might grow a significant memory footprint over time with some workloads, yet we are loading it on all broker ranks.

Load on rank 0 only for now.

Fixes #3007