### PR TITLE
Improve error responses from job-info.list* RPCs

### DIFF
--- a/src/bindings/python/flux/job.py
+++ b/src/bindings/python/flux/job.py
@@ -338,9 +338,9 @@ def job_list(
     flux_handle, max_entries=1000, attrs=[], userid=os.getuid(), states=0, results=0
 ):
     payload = {
-        "max_entries": max_entries,
+        "max_entries": int(max_entries),
         "attrs": attrs,
-        "userid": userid,
+        "userid": int(userid),
         "states": states,
         "results": results,
     }
@@ -348,7 +348,7 @@ def job_list(
 
 
 def job_list_inactive(flux_handle, since=0.0, max_entries=1000, attrs=[], name=None):
-    payload = {"since": since, "max_entries": max_entries, "attrs": attrs}
+    payload = {"since": float(since), "max_entries": int(max_entries), "attrs": attrs}
     if name:
         payload["name"] = name
     return JobListRPC(flux_handle, "job-info.list-inactive", payload)
@@ -362,7 +362,7 @@ class JobListIdRPC(RPC):
 # list-id is not like list or list-inactive, it doesn't return an
 # array, so don't use JobListRPC
 def job_list_id(flux_handle, jobid, attrs=[]):
-    payload = {"id": jobid, "attrs": attrs}
+    payload = {"id": int(jobid), "attrs": attrs}
     return JobListIdRPC(flux_handle, "job-info.list-id", payload)
 
 

--- a/src/modules/job-info/job_state.c
+++ b/src/modules/job-info/job_state.c
@@ -357,9 +357,10 @@ static void list_id_respond (struct info_ctx *ctx,
                              struct idsync_data *isd,
                              struct job *job)
 {
+    job_info_error_t err;
     json_t *o;
 
-    if (!(o = job_to_json (job, isd->attrs)))
+    if (!(o = job_to_json (job, isd->attrs, &err)))
         goto error;
 
     if (flux_respond_pack (ctx->h, isd->msg, "{s:O}", "job", o) < 0) {
@@ -371,7 +372,7 @@ static void list_id_respond (struct info_ctx *ctx,
     return;
 
 error:
-    if (flux_respond_error (ctx->h, isd->msg, errno, NULL) < 0)
+    if (flux_respond_error (ctx->h, isd->msg, errno, err.text) < 0)
         flux_log_error (ctx->h, "%s: flux_respond_error", __FUNCTION__);
     json_decref (o);
 }

--- a/src/modules/job-info/job_util.h
+++ b/src/modules/job-info/job_util.h
@@ -15,7 +15,14 @@
 
 #include "job_state.h"
 
-json_t *job_to_json (struct job *job, json_t *attrs);
+typedef struct {
+    char text[160];
+} job_info_error_t;
+
+void __attribute__((format (printf, 2, 3)))
+seterror (job_info_error_t *errp, const char *fmt, ...);
+
+json_t *job_to_json (struct job *job, json_t *attrs, job_info_error_t *errp);
 
 #endif /* ! _FLUX_JOB_INFO_JOB_UTIL_H */
 

--- a/src/test/travis_run.sh
+++ b/src/test/travis_run.sh
@@ -41,7 +41,7 @@ fi
 ARGS="$@"
 JOBS=${JOBS:-2}
 MAKECMDS="${MAKE} -j ${JOBS}"
-CHECKCMDS="${MAKE} -k -j ${JOBS} ${DISTCHECK:+dist}check"
+CHECKCMDS="${MAKE} -j ${JOBS} ${DISTCHECK:+dist}check"
 
 # Add non-standard path for libfaketime to LD_LIBRARY_PATH:
 export LD_LIBRARY_PATH="/usr/lib/x86_64-linux-gnu/faketime"

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -225,6 +225,7 @@ dist_check_SCRIPTS = \
 	job-exec/dummy.sh \
 	job-exec/imp.sh \
 	job-info/list-id.py \
+	job-info/list-rpc.py \
 	job-archive/query.py \
 	schedutil/req_and_unload.py \
 	ingest/fake-validate.sh \

--- a/t/job-info/list-rpc.py
+++ b/t/job-info/list-rpc.py
@@ -1,0 +1,31 @@
+###############################################################
+# Copyright 2020 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+# Usage: flux python list-rpc.py < payload.json
+#
+#  Send constructed payloads to job-info list interfaces and
+#  print errors for benefit of testing
+
+import flux
+import sys
+
+h = flux.Flux()
+payload = sys.stdin.read()
+if len(sys.argv) > 1:
+    name = sys.argv[1]
+else:
+    name = "list"
+try:
+    print(h.rpc(f"job-info.{name}", payload).get())
+except OSError as err:
+    print(f"errno {err.errno}: {err.strerror}")
+
+
+# vim: tabstop=4 shiftwidth=4 expandtab


### PR DESCRIPTION
This PR addresses #2997 by
 
 * Adding an error string to `flux_respond_error(3)` in many EPROTO/EINVAL cases of the `job-info.list*` suite of RPCs.
 * In the Python bindings for these interfaces, attempt to cast values passed in by user to the appropriate type, so type errors are caught _before_ sending RPC. (e.g. jobid as string)

Fixes #2997
