### PR TITLE
doc: update idset manpages

### DIFF
--- a/doc/man3/Makefile.am
+++ b/doc/man3/Makefile.am
@@ -66,7 +66,8 @@ MAN3_FILES_PRIMARY = \
 	flux_kvs_getroot.3 \
 	flux_kvs_copy.3 \
 	flux_core_version.3 \
-	idset_create.3
+	idset_create.3 \
+	idset_encode.3
 
 # These files are generated as roff .so includes of a primary page.
 # A2X handles this automatically if mentioned in NAME section
@@ -205,13 +206,13 @@ MAN3_FILES_SECONDARY = \
 	flux_kvs_move.3 \
 	flux_core_version_string.3 \
 	idset_destroy.3 \
-	idset_encode.3 \
 	idset_decode.3 \
 	idset_set.3 \
 	idset_clear.3 \
 	idset_first.3 \
 	idset_next.3 \
-	idset_count.3
+	idset_count.3 \
+	idset_equal.3
 
 ADOC_FILES  = $(MAN3_FILES_PRIMARY:%.3=%.adoc)
 XML_FILES   = $(MAN3_FILES_PRIMARY:%.3=%.xml)
@@ -356,15 +357,16 @@ flux_kvs_txn_put_raw.3: flux_kvs_txn_create.3
 flux_kvs_namespace_remove.3: flux_kvs_namespace_create.3
 flux_kvs_move.3: flux_kvs_copy.3
 flux_core_version_string.3: flux_core_version.3
+
 idset_destroy.3: idset_create.3
-idset_encode.3: idset_create.3
-idset_decode.3: idset_create.3
 idset_set.3: idset_create.3
 idset_clear.3: idset_create.3
 idset_first.3: idset_create.3
 idset_next.3: idset_create.3
 idset_count.3: idset_create.3
-# N.B. exceeds max 8 stubs  idset_equal.3
+idset_equal.3: idset_create.3
+
+idset_decode.3: idset_encode.3
 
 flux_open.3: topen.c
 flux_send.3: tsend.c

--- a/doc/man3/Makefile.am
+++ b/doc/man3/Makefile.am
@@ -207,6 +207,7 @@ MAN3_FILES_SECONDARY = \
 	flux_core_version_string.3 \
 	idset_destroy.3 \
 	idset_decode.3 \
+	idset_ndecode.3 \
 	idset_set.3 \
 	idset_clear.3 \
 	idset_first.3 \
@@ -367,6 +368,7 @@ idset_count.3: idset_create.3
 idset_equal.3: idset_create.3
 
 idset_decode.3: idset_encode.3
+idset_ndecode.3: idset_encode.3
 
 flux_open.3: topen.c
 flux_send.3: tsend.c

--- a/doc/man3/Makefile.am
+++ b/doc/man3/Makefile.am
@@ -208,6 +208,7 @@ MAN3_FILES_SECONDARY = \
 	idset_destroy.3 \
 	idset_decode.3 \
 	idset_ndecode.3 \
+	idset_format_map.3 \
 	idset_set.3 \
 	idset_clear.3 \
 	idset_first.3 \
@@ -369,6 +370,7 @@ idset_equal.3: idset_create.3
 
 idset_decode.3: idset_encode.3
 idset_ndecode.3: idset_encode.3
+idset_format_map.3: idset_encode.3
 
 flux_open.3: topen.c
 flux_send.3: tsend.c

--- a/doc/man3/idset_create.adoc
+++ b/doc/man3/idset_create.adoc
@@ -125,11 +125,11 @@ compressed into hyphenated ranges in the encoded string.
 RETURN VALUE
 ------------
 
-`idset_create()`, `idset_encode()`, and `idset_copy()` return an
+`idset_create()`, `idset_decode()`, and `idset_copy()` return an
 idset on success which must be freed with `idset_destroy()`.
 On error, NULL is returned with errno set.
 
-`idset_decode()` returns a string on success which must be freed
+`idset_encode()` returns a string on success which must be freed
 with `free()`.  On error, NULL is returned with errno set.
 
 `idset_first()`, `idset_next()`, and `idset_last()` return an id,

--- a/doc/man3/idset_create.adoc
+++ b/doc/man3/idset_create.adoc
@@ -5,7 +5,7 @@ idset_create(3)
 
 NAME
 ----
-idset_create, idset_destroy, idset_encode, idset_decode, idset_set, idset_clear, idset_first, idset_next, idset_count, idset_equal - Manipulate numerically sorted sets of non-negative integers
+idset_create, idset_destroy, idset_set, idset_clear, idset_first, idset_next, idset_count, idset_equal - Manipulate numerically sorted sets of non-negative integers
 
 SYNOPSIS
 --------
@@ -16,10 +16,6 @@ SYNOPSIS
  void idset_destroy (struct idset *idset);
 
  struct idset *idset_copy (const struct idset *idset);
-
- struct idset *idset_decode (const char *s);
-
- char *idset_encode (const struct idset *idset, int flags);
 
  int idset_set (struct idset *idset, unsigned int id);
 
@@ -67,24 +63,6 @@ numbered 'id' it can hold, plus one.  The size is fixed unless
 
 `idset_copy()` copies an idset.
 
-`idset_decode ()` creates an idset from a string 's'.  The string may
-have been produced by `idset_encode()`.  It must consist of comma-separated
-non-negative integer ids, and may also contain hyphenated ranges.
-If enclosed in square brackets, the brackets are ignored.  Some examples
-of valid input strings are:
-
-  1,2,5,4
-
-  1-4,7,9-10
-
-  42
-
-  [99-101]
-
-`idset_encode()` creates a string from 'idset'.  The string contains
-a comma-separated list of ids, potentially modified by 'flags'
-(see FLAGS below).
-
 `idset_set()` and `idset_clear()` set or clear 'id'.
 
 `idset_range_set()` and `idset_range_clear()` set or clear an inclusive
@@ -113,24 +91,12 @@ in size until until the new id can be inserted.  Resizing is a costly
 operation that requires all ids in the old tree to be inserted into
 the new one.
 
-IDSET_FLAG_BRACKETS::
-Valid for `idset_encode()` only.  If set, the encoded string will be
-enclosed in brackets, unless the idset is a singleton (contains only
-one id).
-
-IDSET_FLAG_RANGE::
-Valid for `idset_encode()` only.  If set, any consecutive ids are
-compressed into hyphenated ranges in the encoded string.
 
 RETURN VALUE
 ------------
 
-`idset_create()`, `idset_decode()`, and `idset_copy()` return an
-idset on success which must be freed with `idset_destroy()`.
-On error, NULL is returned with errno set.
-
-`idset_encode()` returns a string on success which must be freed
-with `free()`.  On error, NULL is returned with errno set.
+`idset_copy()` returns an idset on success which must be freed with
+`idset_destroy()`.  On error, NULL is returned with errno set.
 
 `idset_first()`, `idset_next()`, and `idset_last()` return an id,
 or IDSET_INVALID_ID if no id is available.
@@ -139,6 +105,7 @@ or IDSET_INVALID_ID if no id is available.
 or false if they are not equal, or either argument is 'NULL'.
 
 Other functions return 0 on success, or -1 on error with errno set.
+
 
 ERRORS
 ------
@@ -167,5 +134,6 @@ include::COPYRIGHT.adoc[]
 
 SEE ALSO
 --------
+idset_encode(3)
 
 https://github.com/flux-framework/rfc/blob/master/spec_22.adoc[RFC 22: Idset String Representation]

--- a/doc/man3/idset_encode.adoc
+++ b/doc/man3/idset_encode.adoc
@@ -5,7 +5,7 @@ idset_encode(3)
 
 NAME
 ----
-idset_encode, idset_decode - Convert idset to string and string to idset
+idset_encode, idset_decode, idset_ndecode - Convert idset to string and string to idset
 
 SYNOPSIS
 --------
@@ -14,6 +14,8 @@ SYNOPSIS
  char *idset_encode (const struct idset *idset, int flags);
 
  struct idset *idset_decode (const char *s);
+
+ struct idset *idset_ndecode (const char *s, size_t len);
 
 
 USAGE
@@ -44,6 +46,8 @@ of valid input strings are:
 
   [99-101]
 
+`idset_ndecode()` creates an idset from a sub-string 's' defined by
+length 'len'.
 
 
 FLAGS
@@ -61,8 +65,8 @@ compressed into hyphenated ranges in the encoded string.
 RETURN VALUE
 ------------
 
-`idset_decode()` returns idset on success which must be freed
-with `idset_destroy(3)`.  On error, NULL is returned with errno set.
+`idset_decode()` and `idset_ndecode()` return idset on success which must
+be freed with `idset_destroy(3)`.  On error, NULL is returned with errno set.
 
 `idset_encode()` returns a string on success which must be freed
 with `free()`.  On error, NULL is returned with errno set.

--- a/doc/man3/idset_encode.adoc
+++ b/doc/man3/idset_encode.adoc
@@ -1,0 +1,101 @@
+idset_encode(3)
+===============
+:doctype: manpage
+
+
+NAME
+----
+idset_encode, idset_decode - Convert idset to string and string to idset
+
+SYNOPSIS
+--------
+ #include <flux/idset.h>
+
+ char *idset_encode (const struct idset *idset, int flags);
+
+ struct idset *idset_decode (const char *s);
+
+
+USAGE
+-----
+
+cc [flags] files -lflux-idset [libraries]
+
+DESCRIPTION
+-----------
+
+Refer to `idset_create(3)` for a general description of idsets.
+
+`idset_encode()` creates a string from 'idset'.  The string contains
+a comma-separated list of ids, potentially modified by 'flags'
+(see FLAGS below).
+
+`idset_decode()` creates an idset from a string 's'.  The string may
+have been produced by `idset_encode()`.  It must consist of comma-separated
+non-negative integer ids, and may also contain hyphenated ranges.
+If enclosed in square brackets, the brackets are ignored.  Some examples
+of valid input strings are:
+
+  1,2,5,4
+
+  1-4,7,9-10
+
+  42
+
+  [99-101]
+
+
+
+FLAGS
+-----
+
+IDSET_FLAG_BRACKETS::
+Valid for `idset_encode()` only.  If set, the encoded string will be
+enclosed in brackets, unless the idset is a singleton (contains only
+one id).
+
+IDSET_FLAG_RANGE::
+Valid for `idset_encode()` only.  If set, any consecutive ids are
+compressed into hyphenated ranges in the encoded string.
+
+RETURN VALUE
+------------
+
+`idset_decode()` returns idset on success which must be freed
+with `idset_destroy(3)`.  On error, NULL is returned with errno set.
+
+`idset_encode()` returns a string on success which must be freed
+with `free()`.  On error, NULL is returned with errno set.
+
+
+ERRORS
+------
+
+EINVAL::
+One or more arguments were invalid.
+
+ENOMEM::
+Out of memory.
+
+
+AUTHOR
+------
+This page is maintained by the Flux community.
+
+
+RESOURCES
+---------
+Github: <http://github.com/flux-framework>
+
+
+COPYRIGHT
+---------
+include::COPYRIGHT.adoc[]
+
+
+SEE ALSO
+--------
+
+idset_create(3)
+
+https://github.com/flux-framework/rfc/blob/master/spec_22.adoc[RFC 22: Idset String Representation]

--- a/doc/man3/idset_encode.adoc
+++ b/doc/man3/idset_encode.adoc
@@ -5,7 +5,7 @@ idset_encode(3)
 
 NAME
 ----
-idset_encode, idset_decode, idset_ndecode - Convert idset to string and string to idset
+idset_encode, idset_decode, idset_ndecode, idset_format_map - Convert idset to string and string to idset
 
 SYNOPSIS
 --------
@@ -16,6 +16,11 @@ SYNOPSIS
  struct idset *idset_decode (const char *s);
 
  struct idset *idset_ndecode (const char *s, size_t len);
+
+
+ typedef int (*idset_format_map_f)(const char *s, bool *stop, void *arg);
+
+ int idset_format_map (const char *s, idset_format_map_f fun, void *arg);
 
 
 USAGE
@@ -49,6 +54,16 @@ of valid input strings are:
 `idset_ndecode()` creates an idset from a sub-string 's' defined by
 length 'len'.
 
+`idset_format_map()` expands bracketed idset string(s) in 's', calling
+a map function 'fun()' for each expanded string.  The map function should
+return 0 on success, or -1 on failure with errno set.  Returning -1 causes
+`idset_format_map()` to immediately return -1.  The map function may may
+halt iteration without triggering an error by setting *stop = true.
+
+This function recursively expands multiple bracketed idset strings from
+left to right, so for example, "r[0-1]n[0-1]" expands to "r0n0", "r0n1",
+ * "r1n0", "r1n1".
+
 
 FLAGS
 -----
@@ -70,6 +85,9 @@ be freed with `idset_destroy(3)`.  On error, NULL is returned with errno set.
 
 `idset_encode()` returns a string on success which must be freed
 with `free()`.  On error, NULL is returned with errno set.
+
+`idset_format_map()` returns the number of times the map function was called
+(including the stopping one, if any), or -1 on failure with errno set.
 
 
 ERRORS

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -491,3 +491,4 @@ nslots
 alloc
 datetime
 formatter
+ndecode


### PR DESCRIPTION
This fixes the problem pointed out by @dongahn in #3011.  It also splits the single man page into two since it was getting a little busy and the 8-stub limit of a2x had already been exceeded.  Finally, it adds entries and stubs for `idset_ndecode()` and `idset_format_map()` which had been added without updating the documentation.