### PR TITLE
build and test fixes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,6 +45,7 @@ jobs:
         CXX: g++-8
         PRELOAD: /usr/lib/gcc/x86_64-linux-gnu/8/libasan.so
         ASAN_OPTIONS: detect_leaks=0,start_deactivated=true
+        FLUX_TEST_SIZE_MAX: 4
         TAP_DRIVER_QUIET: t
         FLUX_TEST_TIMEOUT: 300
       run: >

--- a/configure.ac
+++ b/configure.ac
@@ -244,7 +244,11 @@ if test "X$PYTHON_VERSION" = "X" ; then
     PYTHON_VERSION=3
   fi
 fi
+
+# Do not let AX_PYTHON_DEVEL set PYTHON_SITE_PKG
+saved_PYTHON_SITE_PKG=$PYTHON_SITE_PKG
 AX_PYTHON_DEVEL([>='3.6'])
+PYTHON_SITE_PKG=$saved_PYTHON_SITE_PKG
 
 AM_PATH_PYTHON([$ac_python_version])
 if test "X$PYTHON" = "X"; then

--- a/t/t0005-exec.t
+++ b/t/t0005-exec.t
@@ -184,8 +184,8 @@ test_expect_success 'signal forwarding works' '
 	exit \$?
 	EOF
 	chmod +x test_signal.sh &&
-	test_expect_code 130 run_timeout 10 ./test_signal.sh INT &&
-	test_expect_code 143 run_timeout 10 ./test_signal.sh TERM
+	test_expect_code 130 run_timeout 20 ./test_signal.sh INT &&
+	test_expect_code 143 run_timeout 20 ./test_signal.sh TERM
 '
 
 test_expect_success 'flux-exec: stdin bcast to all ranks (default)' '

--- a/t/t0007-ping.t
+++ b/t/t0007-ping.t
@@ -13,23 +13,23 @@ invalid_rank() {
 }
 
 test_expect_success 'ping: 10K 1K byte echo requests' '
-	run_timeout 10 flux ping --pad 1024 --count 10240 --interval 0 0
+	run_timeout 25 flux ping --pad 1024 --count 10240 --interval 0 0
 '
 
 test_expect_success 'ping: 1K 10K byte echo requests' '
-	run_timeout 5 flux ping --pad 10240 --count 1024 --interval 0 0
+	run_timeout 15 flux ping --pad 10240 --count 1024 --interval 0 0
 '
 
 test_expect_success 'ping: 100 100K byte echo requests' '
-	run_timeout 5 flux ping --pad 102400 --count 100 --interval 0 0
+	run_timeout 15 flux ping --pad 102400 --count 100 --interval 0 0
 '
 
 test_expect_success 'ping: 10 1M byte echo requests' '
-	run_timeout 5 flux ping --pad 1048576 --count 10 --interval 0 0
+	run_timeout 15 flux ping --pad 1048576 --count 10 --interval 0 0
 '
 
 test_expect_success 'ping: 10 1M byte echo requests (batched)' '
-	run_timeout 5 flux ping --pad 1048576 --count 10 --batch --interval 0 0
+	run_timeout 15 flux ping --pad 1048576 --count 10 --batch --interval 0 0
 '
 
 test_expect_success 'ping: 1K 10K byte echo requests (batched)' '
@@ -37,70 +37,70 @@ test_expect_success 'ping: 1K 10K byte echo requests (batched)' '
 '
 
 test_expect_success 'ping --rank 1 works' '
-	run_timeout 5 flux ping --rank 1 --count 10 --interval 0 cmb
+	run_timeout 15 flux ping --rank 1 --count 10 --interval 0 cmb
 '
 
 test_expect_success 'ping 1 works' '
-	run_timeout 5 flux ping --count 10 --interval 0 1
+	run_timeout 15 flux ping --count 10 --interval 0 1
 '
 
 test_expect_success 'ping 1!cmb works' '
-	run_timeout 5 flux ping --count 10 --interval 0 "1!cmb"
+	run_timeout 15 flux ping --count 10 --interval 0 "1!cmb"
 '
 
 test_expect_success 'ping fails on invalid rank (specified as target)' '
-	! run_timeout 5 flux ping --count 1 $(invalid_rank) 2>stderr &&
+	test_must_fail run_timeout 15 flux ping --count 1 $(invalid_rank) 2>stderr &&
 	grep -q "No route to host" stderr
 '
 
 test_expect_success 'ping fails on invalid rank (specified in option)' '
-	! run_timeout 5 flux ping --count 1 --rank $(invalid_rank) cmb 2>stderr &&
+	test_must_fail run_timeout 15 flux ping --count 1 --rank $(invalid_rank) cmb 2>stderr &&
 	grep -q "No route to host" stderr
 '
 
 test_expect_success 'ping fails on invalid target' '
-	! run_timeout 5 flux ping --count 1 --rank 0 nosuchtarget 2>stderr &&
+	test_must_fail run_timeout 15 flux ping --count 1 --rank 0 nosuchtarget 2>stderr &&
 	grep -q "Function not implemented" stderr
 '
 
 test_expect_success 'ping output format for "any" rank is correct (default)' '
-	run_timeout 5 flux ping --count 1 cmb 1>stdout &&
+	run_timeout 15 flux ping --count 1 cmb 1>stdout &&
         grep -q "^cmb.ping" stdout &&
         grep -q -E "time=[0-9]+\.[0-9]+ ms" stdout
 '
 
 test_expect_success 'ping output format for "any" rank is correct (format 1)' '
-	run_timeout 5 flux ping --count 1 --rank any cmb 1>stdout &&
+	run_timeout 15 flux ping --count 1 --rank any cmb 1>stdout &&
         grep -q "^cmb.ping" stdout &&
         grep -q -E "time=[0-9]+\.[0-9]+ ms" stdout
 '
 
 test_expect_success 'ping output format for "any" rank is correct (format 2)' '
-	run_timeout 5 flux ping --count 1 any!cmb 1>stdout &&
+	run_timeout 15 flux ping --count 1 any!cmb 1>stdout &&
         grep -q "^cmb.ping" stdout &&
         grep -q -E "time=[0-9]+\.[0-9]+ ms" stdout
 '
 
 test_expect_success 'ping output format for "any" rank is correct (format 3)' '
-	run_timeout 5 flux ping --count 1 any 1>stdout &&
+	run_timeout 15 flux ping --count 1 any 1>stdout &&
         grep -q "^cmb.ping" stdout &&
         grep -q -E "time=[0-9]+\.[0-9]+ ms" stdout
 '
 
 test_expect_success 'ping output format for specific rank is correct (format 1)' '
-	run_timeout 5 flux ping --count 1 --rank 0 cmb 1>stdout &&
+	run_timeout 15 flux ping --count 1 --rank 0 cmb 1>stdout &&
         grep -q "^0!cmb.ping" stdout &&
         grep -q -E "time=[0-9]+\.[0-9]+ ms" stdout
 '
 
 test_expect_success 'ping output format for specific rank is correct (format 2)' '
-	run_timeout 5 flux ping --count 1 0!cmb 1>stdout &&
+	run_timeout 15 flux ping --count 1 0!cmb 1>stdout &&
         grep -q "^0!cmb.ping" stdout &&
         grep -q -E "time=[0-9]+\.[0-9]+ ms" stdout
 '
 
 test_expect_success 'ping output format for specific rank is correct (format 3)' '
-	run_timeout 5 flux ping --count 1 0 1>stdout &&
+	run_timeout 15 flux ping --count 1 0 1>stdout &&
         grep -q "^0!cmb.ping" stdout &&
         grep -q -E "time=[0-9]+\.[0-9]+ ms" stdout
 '
@@ -110,24 +110,24 @@ test_expect_success 'ping output format for specific rank is correct (format 3)'
 # rank 1 should work
 
 test_expect_success 'ping with "upstream" fails on rank 0' '
-        ! run_timeout 5 flux exec -n --rank 0 flux ping --count 1 --rank upstream cmb 2>stderr &&
+        test_must_fail run_timeout 15 flux exec -n --rank 0 flux ping --count 1 --rank upstream cmb 2>stderr &&
 	grep -q "No route to host" stderr
 '
 
 test_expect_success 'ping with "upstream" works (format 1)' '
-        run_timeout 5 flux exec -n --rank 1 flux ping --count 1 --rank upstream cmb 1>stdout &&
+        run_timeout 15 flux exec -n --rank 1 flux ping --count 1 --rank upstream cmb 1>stdout &&
         grep -q "^upstream!cmb.ping" stdout &&
         grep -q -E "time=[0-9]+\.[0-9]+ ms" stdout
 '
 
 test_expect_success 'ping with "upstream" works (format 2)' '
-        run_timeout 5 flux exec -n --rank 1 flux ping --count 1 upstream!cmb 1>stdout &&
+        run_timeout 15 flux exec -n --rank 1 flux ping --count 1 upstream!cmb 1>stdout &&
         grep -q "^upstream!cmb.ping" stdout &&
         grep -q -E "time=[0-9]+\.[0-9]+ ms" stdout
 '
 
 test_expect_success 'ping with "upstream" works (format 3)' '
-        run_timeout 5 flux exec -n --rank 1 flux ping --count 1 upstream 1>stdout &&
+        run_timeout 15 flux exec -n --rank 1 flux ping --count 1 upstream 1>stdout &&
         grep -q "^upstream!cmb.ping" stdout &&
         grep -q -E "time=[0-9]+\.[0-9]+ ms" stdout
 '

--- a/t/t0014-runlevel.t
+++ b/t/t0014-runlevel.t
@@ -44,9 +44,12 @@ test_expect_success 'rc3 failure causes instance failure' '
 '
 
 test_expect_success 'broker.rc2_none terminates by signal without error' '
-	run_timeout -s ALRM 0.5 flux start \
+	for timeout in 0.5 1 2 4; do
+	    run_timeout -s ALRM $timeout flux start \
 		-o,-Slog-stderr-level=6 \
-		-o,-Sbroker.rc1_path=,-Sbroker.rc3_path=,-Sbroker.rc2_none
+		-o,-Sbroker.rc1_path=,-Sbroker.rc3_path=,-Sbroker.rc2_none &&
+	    break
+	done
 '
 
 test_expect_success 'flux admin cleanup-push /bin/true works' '

--- a/t/t0020-terminus.t
+++ b/t/t0020-terminus.t
@@ -10,6 +10,9 @@ Verify basic functionality of flux-terminus command
 SIZE=2
 test_under_flux ${SIZE} minimal
 
+# Unset any existing terminus session
+unset FLUX_TERMINUS_SESSION
+
 userid=$(id -u)
 default_service="${userid}-terminus"
 runpty="${SHARNESS_TEST_SRCDIR}/scripts/runpty.py -f asciicast"

--- a/t/t2400-job-exec-test.t
+++ b/t/t2400-job-exec-test.t
@@ -103,7 +103,7 @@ test_expect_success 'job-exec: R with invalid expiration raises exception' '
 #  epilog script which could be triggered by events. If this test becomes
 #  a problem, we can disable it until that time.
 #
-test_expect_success 'job-exec: exception during cleanup' '
+test_expect_success FLAKY_TESTS 'job-exec: exception during cleanup' '
 	flux jobspec srun hostname | \
 	  exec_testattr cleanup_duration 1s > cleanup-long.json &&
 	jobid=$(flux job submit cleanup-long.json) &&

--- a/t/t2612-job-shell-pty.t
+++ b/t/t2612-job-shell-pty.t
@@ -6,6 +6,9 @@ test_description='Test flux-shell pty support'
 
 test_under_flux 4 job
 
+# an existing FLUX_TERMINUS_SESSION will interfere with tests below
+unset FLUX_TERMINUS_SESSION
+
 FLUX_SHELL="${FLUX_BUILD_DIR}/src/shell/flux-shell"
 
 INITRC_TESTDIR="${SHARNESS_TEST_SRCDIR}/shell/initrc"

--- a/t/t2900-job-timelimits.t
+++ b/t/t2900-job-timelimits.t
@@ -9,7 +9,7 @@ test_under_flux 1
 # Set CLIMain log level to logging.DEBUG (10), to enable stack traces
 export FLUX_PYCLI_LOGLEVEL=10
 
-# Default timeout, extend under valgrind
+# Default timeout, extend under valgrind or ASAN
 TIMEOUT=0.25
 test -n "$FLUX_TEST_VALGRIND" && TIMEOUT=3
 test_have_prereq ASAN && TIMEOUT=3
@@ -26,25 +26,39 @@ test_expect_success 'result for expired jobs is TIMEOUT' '
 	test_debug "flux jobs -a" &&
 	flux jobs -ano {result} | grep -q TIMEOUT
 '
-test_expect_success 'expired jobs are sent SIGALRM, then SIGKILL' '
-	kill_timeout=$(test -z "$FLUX_TEST_VALGRIND" && echo 0.5 || echo 6) &&
-	test_debug "echo reloading job-exec with kill-timeout=$kill_timeout" &&
-	flux module reload \
-		job-exec kill-timeout=${kill_timeout} &&
-	test_expect_code 137 \
-	    flux mini run -vvv --time-limit=${TIMEOUT} bash -c \
+sigalrm_sigkill_test() {
+	timeout=$1
+	kill_timeout=$2
+	test_debug "echo testing with timeout=$timeout kill_timeout=$kill_timeout" &&
+	flux module reload job-exec kill-timeout=$kill_timeout &&
+	        test_expect_code 137 \
+            flux mini run -vvv --time-limit=${timeout} bash -c \
                "trap \"echo got SIGALRM>>trap.out\" SIGALRM;sleep 10;sleep 15" \
-		   > trap.out 2> trap.err &&
-	test_debug "grep . trap.*" &&
-	grep "resource allocation expired" trap.err &&
-	grep "got SIGALRM" trap.out
+                   > trap.out 2> trap.err &&
+        test_debug "grep . trap.*" &&
+        grep "resource allocation expired" trap.err &&
+        grep "got SIGALRM" trap.out
+}
+test_expect_success 'expired jobs are sent SIGALRM, then SIGKILL' '
+	kill_timeout=$(test -z "$FLUX_TEST_VALGRIND" && echo 0.25 || echo 3) &&
+        for scale in 1 2 4 8; do
+	    sigalrm_sigkill_test \
+	      $(perl -E "say $TIMEOUT*$scale") \
+	      $(perl -E "say $kill_timeout*$scale") && break
+	done
 '
-test_expect_success 'expired job can also be canceled' '
-	flux module reload job-exec kill-timeout=60 &&
-	id=$(flux mini submit --time-limit=$TIMEOUT bash -c \
-            "trap \"echo got SIGALRM>>trap2.out\" SIGALRM;sleep 10;sleep 10" ) &&
-	flux job wait-event --timeout=20 $id exception &&
+expired_cancel_test() {
+	id=$(flux mini submit --time-limit=$1 bash -c \
+            "trap \"echo got SIGALRM>>trap2.out\" SIGALRM;sleep 60;sleep 60" ) &&
+	flux job wait-event --timeout=30 $id exception &&
 	flux job cancel $id &&
 	test_expect_code 143 run_timeout 30 flux job attach $id
+
+}
+test_expect_success 'expired job can also be canceled' '
+	flux module reload job-exec kill-timeout=120 &&
+	for scale in 1 4 8 16; do
+	    expired_cancel_test $(perl -E "say $TIMEOUT*$scale") && break
+	done
 '
 test_done

--- a/t/t3001-mpi-personalities.t
+++ b/t/t3001-mpi-personalities.t
@@ -19,7 +19,7 @@ run_program() {
 CONF_PMI_LIBRARY_PATH=$(flux getattr conf.pmi_library_path | sed 's|/libpmi.so||')
 
 test_expect_success 'mvapich mpi prepends to LD_LIBRARY_PATH for tasks' '
-  run_program 5 ${SIZE} ${SIZE} printenv LD_LIBRARY_PATH > mvapich.ld.out &&
+  run_program 15 ${SIZE} ${SIZE} printenv LD_LIBRARY_PATH > mvapich.ld.out &&
   result="$(uniq mvapich.ld.out | cut -d: -f1)" &&
   echo $result &&
   echo $CONF_PMI_LIBRARY_PATH &&
@@ -27,7 +27,7 @@ test_expect_success 'mvapich mpi prepends to LD_LIBRARY_PATH for tasks' '
 '
 
 test_expect_success 'mvapich mpi sets MPIRUN_RANK for tasks' '
-  run_program 5 ${SIZE} ${SIZE} printenv MPIRUN_RANK \
+  run_program 15 ${SIZE} ${SIZE} printenv MPIRUN_RANK \
     | sort > mvapich.rank.out &&
   test_debug "cat mvapich.rank.out" &&
   printf "0\n1\n2\n3\n" > mvapich.rank.expected &&
@@ -37,13 +37,13 @@ test_expect_success 'mvapich mpi sets MPIRUN_RANK for tasks' '
 test_expect_success "intel mpi rewrites I_MPI_MPI_LIBRARY" '
   export I_MPI_PMI_LIBRARY="foobar" &&
   test_when_finished "unset I_MPI_PMI_LIBRARY" &&
-  run_program 5 ${SIZE} ${SIZE} printenv I_MPI_PMI_LIBRARY > intel-mpi.set &&
+  run_program 15 ${SIZE} ${SIZE} printenv I_MPI_PMI_LIBRARY > intel-mpi.set &&
   test "$(uniq intel-mpi.set)" = "$(flux getattr conf.pmi_library_path)"
 '
 
 test_expect_success "intel mpi only rewrites when necessary" '
    echo $I_MPI_PMI_LIBRARY &&
-   run_program 5 ${SIZE} ${SIZE} printenv | grep I_MPI_PMI_LIBRARY \
+   run_program 15 ${SIZE} ${SIZE} printenv | grep I_MPI_PMI_LIBRARY \
        | tee intel-mpi.unset &&
    test "$(wc -l intel-mpi.unset | cut -f 1 -d " ")" = "0"
 '
@@ -54,7 +54,7 @@ test_expect_success NO_ASAN,HAVE_JQ "spectrum mpi only enabled with option" '
   test_when_finished "export LD_PRELOAD=${LD_PRELOAD_saved}" &&
   flux jobspec srun -n${SIZE} -N${SIZE} printenv LD_PRELOAD \
     | jq ".attributes.system.shell.options.mpi = \"spectrum\"" > j.spectrum &&
-  test_expect_code 1 run_program 5 ${SIZE} ${SIZE} printenv LD_PRELOAD &&
+  test_expect_code 1 run_program 15 ${SIZE} ${SIZE} printenv LD_PRELOAD &&
   jobid=$(flux job submit j.spectrum) &&
   flux job attach ${jobid} > spectrum.out &&
   grep /opt/ibm/spectrum spectrum.out

--- a/t/t5000-valgrind.t
+++ b/t/t5000-valgrind.t
@@ -38,7 +38,7 @@ VALGRIND_NBROKERS=${VALGRIND_NBROKERS:-2}
 
 test_expect_success \
   "valgrind reports no new errors on $VALGRIND_NBROKERS broker run" '
-	run_timeout 120 \
+	run_timeout 300 \
 	flux start -s ${VALGRIND_NBROKERS} \
 		--killer-timeout=120 \
 		--wrap=libtool,e,${VALGRIND} \


### PR DESCRIPTION
Collecting a set of fixes for build and test problems found during or just after the release.
This is still a WIP as there are some other failing tests with `make -j N` where N is arguably a bit too big :wink:

However, this at least fixes tests that were failing reliably, and running all tests as Flux jobs works, so we can do this again (run all tests in parallel under `prove`, each as a Flux job, so whole testsuite completes in the time of the slowest test)

```
ƒ(s=95,builddir) grondo@fluke2:~/git/flux-core.git/t$ prove -j128 --merge --timer --exec="flux mini run -c4" ./t*.t
[17:37:46] ./t0016-cron-faketime.t ............................ skipped: libfaketime not found. Skipping all tests
[17:37:47] ./t2004-hydra.t .................................... skipped: skipping hydra-launching-flux tests, mpiexec.hydra unavailable
[17:37:47] ./t0008-attr.t ..................................... ok        4 ms
[17:37:47] ./t0002-request.t .................................. ok        5 ms
[17:37:47] ./t2007-caliper.t .................................. skipped: skipping Caliper tests, Flux not built with Caliper support
[17:37:47] ./t2404-job-exec-multiuser.t ....................... skipped: skipping multiuser exec tests, libflux-security or IMP not found
[17:37:47] ./t0023-comms.t .................................... ok        2 ms
[17:37:47] ./t0013-config-file.t .............................. ok        2 ms
[17:37:47] ./t3000-mpi-basic.t ................................ skipped: skipping MPI tests, FLUX_TEST_MPI not set
[17:37:48] ./t0009-dmesg.t .................................... ok        3 ms
[17:37:48] ./t1102-cmddriver.t ................................ ok        3 ms
[17:37:48] ./t0000-sharness.t ................................. ok        5 ms
[17:37:48] ./t2600-job-shell-rcalc.t .......................... ok        6 ms
[17:37:48] ./t2006-hwloc-versions.t ........................... ok        1 ms
[17:37:49] ./t1101-barrier-basic.t ............................ ok      139 ms
[17:37:49] ./t0010-generic-utils.t ............................ ok        2 ms
[17:37:49] ./t2603-job-shell-initrc.t ......................... ok        7 ms
[17:37:49] ./t1103-apidisconnect.t ............................ ok        1 ms
[17:37:49] ./t2301-schedutil-outstanding-requests.t ........... ok     1174 ms
[17:37:49] ./t0003-module.t ................................... ok     1632 ms
[17:37:49] ./t1008-kvs-eventlog.t ............................. ok        1 ms
[17:37:50] ./t2605-job-shell-output-redirection-standalone.t .. ok        4 ms
[17:37:50] ./t2005-hwloc-basic.t .............................. ok        4 ms
[17:37:50] ./t1009-kvs-copy.t ................................. ok        7 ms
[17:37:50] ./t0004-event.t .................................... ok        2 ms
[17:37:50] ./t2401-job-exec-hello.t ........................... ok     1776 ms
[17:37:50] ./t0017-security.t ................................. ok     3137 ms
[17:37:50] ./t2210-job-manager-bugs.t ......................... ok        1 ms
[17:37:50] ./t1005-kvs-security.t ............................. ok        6 ms
[17:37:50] ./t2206-job-manager-bulk-state.t ................... ok        0 ms
[17:37:50] ./t1105-proxy.t .................................... ok        2 ms
[17:37:50] ./t0005-rexec.t .................................... ok     3533 ms
[17:37:50] ./t0014-runlevel.t ................................. ok        2 ms
[17:37:50] ./t0022-jj-reader.t ................................ ok        4 ms
[17:37:50] ./t2609-job-shell-events.t ......................... ok     1780 ms
[17:37:51] ./t2613-job-shell-batch.t .......................... ok     2225 ms
[17:37:51] ./t2501-job-status.t ............................... ok     2598 ms
[17:37:51] ./t2203-job-manager-dummysched.t ................... ok        3 ms
[17:37:51] ./t2601-job-shell-standalone.t ..................... ok        4 ms
[17:37:51] ./t0020-terminus.t ................................. ok        4 ms
[17:37:51] ./t2611-debug-emulate.t ............................ ok        1 ms
[17:37:51] ./t0005-exec.t ..................................... ok     4461 ms
[17:37:52] ./t0007-ping.t ..................................... ok        2 ms
[17:37:52] ./t1106-ssh-connector.t ............................ ok        2 ms
[17:37:52] ./t2010-kvs-snapshot-restore.t ..................... ok        1 ms
[17:37:52] ./t3001-mpi-personalities.t ........................ ok        1 ms
[17:37:52] ./t2310-resource-module.t .......................... ok     1198 ms
[17:37:52] ./t0011-content-cache.t ............................ ok        2 ms
[17:37:52] ./t2400-job-exec-test.t ............................ ok     3962 ms
[17:37:52] ./t2500-job-attach.t ............................... ok        2 ms
[17:37:52] ./t2231-job-info-lookup.t .......................... ok     4345 ms
[17:37:52] ./t2202-job-manager.t .............................. ok        6 ms
[17:37:52] ./t2100-aggregate.t ................................ ok     1594 ms
[17:37:53] ./t2608-job-shell-log.t ............................ ok     3917 ms
[17:37:53] ./t2402-job-exec-dummy.t ........................... ok     4276 ms
[17:37:53] ./t2610-job-shell-mpir.t ........................... ok     3763 ms
[17:37:53] ./t2900-job-timelimits.t ........................... ok        1 ms
[17:37:53] ./t2302-sched-simple-up-down.t ..................... ok     4713 ms
[17:37:54] ./t2201-job-cmd.t .................................. ok     5631 ms
[17:37:54] ./t0015-cron.t ..................................... ok        3 ms
[17:37:54] ./t2008-althash.t .................................. ok        1 ms
[17:37:54] ./t0012-content-sqlite.t ........................... ok        3 ms
[17:37:54] ./t2220-job-archive.t .............................. ok     5910 ms
[17:37:54] ./t2208-queue-cmd.t ................................ ok        4 ms
[17:37:55] ./t2300-sched-simple.t ............................. ok     6347 ms
[17:37:55] ./t2607-job-shell-input.t .......................... ok     6393 ms
[17:37:55] ./t2602-job-shell.t ................................ ok     6584 ms
[17:37:56] ./t2606-job-shell-output-redirection.t ............. ok     7378 ms
[17:37:56] ./t3200-instance-restart.t ......................... ok        1 ms
[17:37:56] ./t2604-job-shell-affinity.t ....................... ok     5966 ms
[17:37:56] ./t1004-kvs-namespace.t ............................ ok        4 ms
[17:37:56] ./t2702-mini-alloc.t ............................... ok     7429 ms
[17:37:56] ./t3100-flux-in-flux.t ............................. ok        1 ms
[17:37:56] ./t2700-mini-cmd.t ................................. ok        4 ms
[17:37:57] ./t4000-issues-test-driver.t ....................... ok     7235 ms
[17:37:57] ./t2233-job-info-security.t ........................ ok     8809 ms
[17:37:57] ./t0021-flux-jobspec.t ............................. ok        2 ms
[17:37:58] ./t2232-job-info-eventlog-watch.t .................. ok     9481 ms
[17:37:58] ./t2207-job-manager-wait.t ......................... ok        2 ms
[17:37:58] ./t0019-jobspec-schema.t ........................... ok        4 ms
[17:37:59] ./t2200-job-ingest.t ............................... ok    11208 ms
[17:37:59] ./t2403-job-exec-conf.t ............................ ok    10937 ms
[17:38:00] ./t2701-mini-batch.t ............................... ok    10925 ms
[17:38:00] ./t1001-kvs-internals.t ............................ ok     8173 ms
[17:38:01] ./t2612-job-shell-pty.t ............................ ok    12057 ms
[17:38:02] ./t1007-kvs-lookup-watch.t ......................... ok        3 ms
[17:38:02] ./t1000-kvs.t ...................................... ok     6089 ms
[17:38:07] ./t2230-job-info-list.t ............................ ok    18495 ms
[17:38:14] ./t5000-valgrind.t ................................. ok        0 ms
[17:38:17] ./t1003-kvs-stress.t ............................... ok        1 ms
[17:38:17] ./t0001-basic.t .................................... ok       19 ms
[17:38:17] ./t2800-jobs-cmd.t ................................. ok    32577 ms
[17:38:21]
All tests successful.
Files=92, Tests=2259, 38 wallclock secs ( 0.50 usr  0.08 sys + 16.74 cusr  3.87 csys = 21.19 CPU)
Result: PASS
```

Note that `prove` gets some timing results wrong though, bummer. However, no problem, `flux jobs` to the rescue:

```
ƒ(s=95,builddir) grondo@fluke2:~/git/flux-core.git$ flux jobs -c92 -ano '{runtime:8.2f} {name:<45.45}' | sort -k 1,1n
    0.28 t2004-hydra.t                                
    0.32 t0016-cron-faketime.t                        
    0.34 t2404-job-exec-multiuser.t                   
    0.36 t2007-caliper.t                              
    0.38 t3000-mpi-basic.t                            
    0.88 t0008-attr.t                                 
    1.21 t0023-comms.t                                
    1.39 t2600-job-shell-rcalc.t                      
    1.46 t0013-config-file.t                          
    1.79 t1102-cmddriver.t                            
    1.82 t0009-dmesg.t                                
    1.86 t2603-job-shell-initrc.t                     
    2.33 t2006-hwloc-versions.t                       
    2.55 t1101-barrier-basic.t                        
    2.60 t2301-schedutil-outstanding-requests.t       
    2.68 t2605-job-shell-output-redirection-standalone
    2.72 t1103-apidisconnect.t                        
    2.80 t0002-request.t                              
    2.84 t0010-generic-utils.t                        
    3.21 t1008-kvs-eventlog.t                         
    3.29 t2401-job-exec-hello.t                       
    3.33 t2005-hwloc-basic.t                          
    3.41 t1009-kvs-copy.t                             
    3.59 t2210-job-manager-bugs.t                     
    3.63 t2609-job-shell-events.t                     
    3.86 t2206-job-manager-bulk-state.t               
    3.91 t0000-sharness.t                             
    3.96 t2613-job-shell-batch.t                      
    3.97 t1005-kvs-security.t                         
    4.18 t0017-security.t                             
    4.23 t1105-proxy.t                                
    4.26 t2501-job-status.t                           
    4.40 t2601-job-shell-standalone.t                 
    4.44 t0022-jj-reader.t                            
    4.53 t2611-debug-emulate.t                        
    4.61 t0014-runlevel.t                             
    4.64 t0005-rexec.t                                
    4.76 t2203-job-manager-dummysched.t               
    4.89 t3001-mpi-personalities.t                    
    5.25 t0020-terminus.t                             
    5.33 t2310-resource-module.t                      
    5.46 t2400-job-exec-test.t                        
    5.49 t0003-module.t                               
    5.51 t1106-ssh-connector.t                        
    5.55 t2500-job-attach.t                           
    5.57 t2010-kvs-snapshot-restore.t                 
    5.61 t2608-job-shell-log.t                        
    5.62 t2900-job-timelimits.t                       
    5.64 t2610-job-shell-mpir.t                       
    5.67 t0004-event.t                                
    5.77 t0005-exec.t                                 
    5.79 t2231-job-info-lookup.t                      
    5.91 t2402-job-exec-dummy.t                       
    5.99 t2202-job-manager.t                          
    6.05 t0007-ping.t                                 
    6.21 t0011-content-cache.t                        
    6.29 t2100-aggregate.t                            
    6.44 t2302-sched-simple-up-down.t                 
    7.17 t2201-job-cmd.t                              
    7.52 t2220-job-archive.t                          
    7.58 t2208-queue-cmd.t                            
    7.60 t2008-althash.t                              
    7.87 t0015-cron.t                                 
    7.98 t0012-content-sqlite.t                       
    8.00 t2607-job-shell-input.t                      
    8.05 t2300-sched-simple.t                         
    8.40 t2602-job-shell.t                            
    8.76 t3200-instance-restart.t                     
    8.98 t2606-job-shell-output-redirection.t         
    9.07 t2702-mini-alloc.t                           
    9.20 t2604-job-shell-affinity.t                   
    9.38 t3100-flux-in-flux.t                         
    9.48 t2700-mini-cmd.t                             
    9.82 t4000-issues-test-driver.t                   
   10.14 t1004-kvs-namespace.t                        
   10.54 t2233-job-info-security.t                    
   11.16 t0021-flux-jobspec.t                         
   11.29 t2232-job-info-eventlog-watch.t              
   11.76 t2207-job-manager-wait.t                     
   12.41 t0019-jobspec-schema.t                       
   12.63 t2701-mini-batch.t                           
   12.65 t2403-job-exec-conf.t                        
   13.02 t2200-job-ingest.t                           
   13.65 t2612-job-shell-pty.t                        
   13.94 t1001-kvs-internals.t                        
   16.08 t1007-kvs-lookup-watch.t                     
   16.31 t1000-kvs.t                                  
   20.17 t2230-job-info-list.t                        
   27.13 t5000-valgrind.t                             
   30.81 t1003-kvs-stress.t                           
   32.10 t0001-basic.t                                
   34.21 t2800-jobs-cmd.t                             
```