### PR TITLE
python: add stdio properties to Jobspec class

### DIFF
--- a/src/bindings/python/flux/job.py
+++ b/src/bindings/python/flux/job.py
@@ -829,6 +829,56 @@ class Jobspec(object):
             raise ValueError("environment must be a mapping")
         self.setattr("system.environment", environ)
 
+    @property
+    def stdin(self):
+        return self._get_io_path("input", "stdin")
+
+    @stdin.setter
+    def stdin(self, path):
+        """Redirect stdin to a file given by `path`"""
+        self._set_io_path("input", "stdin", path)
+
+    @property
+    def stdout(self):
+        return self._get_io_path("output", "stdout")
+
+    @stdout.setter
+    def stdout(self, path):
+        """Redirect stdout to a file given by `path`"""
+        self._set_io_path("output", "stdout", path)
+
+    @property
+    def stderr(self):
+        return self._get_io_path("output", "stderr")
+
+    @stderr.setter
+    def stderr(self, path):
+        """Redirect stderr to a file given by `path`"""
+        self._set_io_path("output", "stderr", path)
+
+    def _get_io_path(self, io, stream_name):
+        """Get the path of a stdio stream, if set.
+
+        :param io: the stream type, one of `"input"` or `"output"`
+        :param stream_name: the name of the io stream
+        """
+        try:
+            return self.jobspec["attributes"]["system"]["shell"]["options"][io][
+                stream_name
+            ]["path"]
+        except KeyError:
+            return None
+
+    def _set_io_path(self, io, stream_name, path):
+        """Set the path of a stdio stream.
+
+        :param io: the stream type, one of `"input"` or `"output"`
+        :param stream_name: the name of the io stream
+        :param path: the path to redirect the stream
+        """
+        self.setattr_shell_option("{}.{}.type".format(io, stream_name), "file")
+        self.setattr_shell_option("{}.{}.path".format(io, stream_name), path)
+
     def _set_treedict(self, in_dict, key, val):
         """
         _set_treedict(d, "a.b.c", 42) is like d[a][b][c] = 42

--- a/src/cmd/flux-mini.py
+++ b/src/cmd/flux-mini.py
@@ -144,18 +144,15 @@ class MiniCmd:
             jobspec.setattr("system.job.name", args.job_name)
 
         if args.input is not None:
-            jobspec.setattr_shell_option("input.stdin.type", "file")
-            jobspec.setattr_shell_option("input.stdin.path", args.input)
+            jobspec.stdin = args.input
 
         if args.output is not None and args.output not in ["none", "kvs"]:
-            jobspec.setattr_shell_option("output.stdout.type", "file")
-            jobspec.setattr_shell_option("output.stdout.path", args.output)
+            jobspec.stdout = args.output
             if args.label_io:
                 jobspec.setattr_shell_option("output.stdout.label", True)
 
         if args.error is not None:
-            jobspec.setattr_shell_option("output.stderr.type", "file")
-            jobspec.setattr_shell_option("output.stderr.path", args.error)
+            jobspec.stderr = args.error
             if args.label_io:
                 jobspec.setattr_shell_option("output.stderr.label", True)
 
@@ -442,8 +439,7 @@ class BatchCmd(MiniCmd):
         # Default output is flux-{{jobid}}.out
         # overridden by either --output=none or --output=kvs
         if not args.output:
-            jobspec.setattr_shell_option("output.stdout.type", "file")
-            jobspec.setattr_shell_option("output.stdout.path", "flux-{{id}}.out")
+            jobspec.stdout = "flux-{{id}}.out"
         return jobspec
 
     def main(self, args):

--- a/t/python/t0010-job.py
+++ b/t/python/t0010-job.py
@@ -264,7 +264,7 @@ class TestJob(unittest.TestCase):
         self.assertIsInstance(future, job.JobEventWatchFuture)
         event = future.get_event()
         self.assertIsInstance(event, job.EventLogEvent)
-        self.assertEquals(event.name, "submit")
+        self.assertEqual(event.name, "submit")
         future.cancel()
 
     def test_20_004_job_event_watch(self):
@@ -337,6 +337,15 @@ class TestJob(unittest.TestCase):
         except OSError as err:
             self.assertEqual(err.errno, errno.ENODATA)
         self.assertIs(event, None)
+
+    def test_21_stdio(self):
+        """Test getter/setter methods for stdio properties"""
+        jobspec = Jobspec.from_yaml_stream(self.basic_jobspec)
+        for stream in ("stderr", "stdout", "stdin"):
+            self.assertEqual(getattr(jobspec, stream), None)
+            for path in ("foo.txt", "bar.md", "foo.json"):
+                setattr(jobspec, stream, path)
+                self.assertEqual(getattr(jobspec, stream), path)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
One of the features that is still lacking in the python bindings with respect to the CLI is the ability to redirect the stdio streams. All of the UQP's jobs have their stdio redirected, so I thought I would go ahead and implement it.