### PR TITLE
Python interface to 'mini batch'

### DIFF
--- a/t/python/t0010-job.py
+++ b/t/python/t0010-job.py
@@ -347,6 +347,24 @@ class TestJob(unittest.TestCase):
                 setattr(jobspec, stream, path)
                 self.assertEqual(getattr(jobspec, stream), path)
 
+    def test_22_from_batch_command(self):
+        """Test that `from_batch_command` produces a valid jobspec"""
+        jobid = job.submit(
+            self.fh, JobspecV1.from_batch_command("#!/bin/sh\nsleep 0", "nested sleep")
+        )
+        self.assertGreater(jobid, 0)
+        # test that a shebang is required
+        with self.assertRaises(ValueError):
+            job.submit(
+                self.fh,
+                JobspecV1.from_batch_command("sleep 0", "nested sleep with no shebang"),
+            )
+
+    def test_23_from_nest_command(self):
+        """Test that `from_batch_command` produces a valid jobspec"""
+        jobid = job.submit(self.fh, JobspecV1.from_nest_command(["sleep", "0"]))
+        self.assertGreater(jobid, 0)
+
 
 if __name__ == "__main__":
     from subflux import rerun_under_flux


### PR DESCRIPTION
I like #2962 so much I want to start using it in the UQP---and in the Python bindings in particular. This PR would add a `flux.job.Jobspec` interface to `mini batch` behavior (and in fact changes the `mini batch` implementation to use the new interface). It adds a new method `from_batch_command` that is a little different than `from_command`: it takes the _contents_ of the script as a string, rather than the _path_ to the script as a string (technically as one string in a sequence). This is because the script contents are copied over to the broker, and also because the `mini batch` command can read in the "script" from stdin. The arguments to the script are accepted separately, as are broker options.

Let me know what you think, and if you generally like it I'll add some tests.