### PR TITLE
travis: tag a docker image for ubuntu 20.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,7 @@ jobs:
        - DISTCHECK=t
        - PYTHON_VERSION=3.8
        - GITHUB_RELEASES_DEPLOY=t
+       - DOCKER_TAG=t
     - name: "Ubuntu: gcc-8 --with-flux-security/caliper, distcheck"
       stage: test
       compiler: gcc-8


### PR DESCRIPTION
Will allow flux-sched to also build and test against 20.04