### PR TITLE
content-s3: add alternate backing store

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,14 +46,18 @@ jobs:
        - PYTHON_VERSION=3.8
        - GITHUB_RELEASES_DEPLOY=t
        - DOCKER_TAG=t
-    - name: "Ubuntu: gcc-8 --with-flux-security/caliper, distcheck"
+    - name: "Ubuntu: gcc-8 --with-flux-security/caliper --enable-content-s3, distcheck"
       stage: test
       compiler: gcc-8
       env:
        - CC=gcc-8
        - CXX=g++-8
-       - ARGS="--with-flux-security --enable-caliper"
+       - ARGS="--with-flux-security --enable-caliper --enable-content-s3"
        - DISTCHECK=t
+       - S3_ACCESS_KEY_ID=minioadmin
+       - S3_SECRET_ACCESS_KEY=minioadmin
+       - S3_HOSTNAME=127.0.0.1:9000
+       - S3_BUCKET=flux-minio
     - name: "Ubuntu: py3.7, clang-6.0 chain-lint --with-flux-security"
       stage: test
       compiler: clang-6.0
@@ -136,7 +140,8 @@ install:
      pip3 install --upgrade pip ; \
      pip3 install --upgrade --force-reinstall coverage ; \
    fi
-
+ - if test -n "$S3_HOSTNAME"; then docker run -d -p 9000:9000 minio/minio server /data; fi
+    
 script:
  # Unshallow repository so git describe works.
  # (The one inside docker-run-checks may fail if git version is too old)

--- a/configure.ac
+++ b/configure.ac
@@ -368,6 +368,15 @@ if test "$enable_caliper" = "yes"; then
     AC_DEFINE([HAVE_CALIPER], [1], [Define if you have libcaliper])
 fi
 
+AC_ARG_ENABLE([content-s3],
+    AS_HELP_STRING([--enable-content-s3], [Enable S3 storage backend]))
+
+AS_IF([test "x$enable_content_s3" = "xyes"], [
+    X_AC_CHECK_COND_LIB(s3, S3_initialize)
+])
+
+AM_CONDITIONAL([ENABLE_CONTENT_S3], [test "x$enable_content_s3" = "xyes"])
+
 ##
 # Check for systemd
 ##
@@ -495,6 +504,7 @@ AC_CONFIG_FILES( \
   src/modules/kvs-watch/Makefile \
   src/modules/content-sqlite/Makefile \
   src/modules/content-files/Makefile \
+  src/modules/content-s3/Makefile \
   src/modules/barrier/Makefile \
   src/modules/cron/Makefile \
   src/modules/aggregator/Makefile \

--- a/etc/rc3
+++ b/etc/rc3
@@ -28,5 +28,6 @@ flux exec -r all -x 0 flux module remove -f kvs
 
 flux module remove -f kvs
 flux content flush
-flux module remove -f content-sqlite
-flux module remove -f content-files
+
+backingmod=$(flux getattr content.backing-module 2>/dev/null) || true
+flux module remove -f ${backingmod:-content-sqlite}

--- a/src/modules/Makefile.am
+++ b/src/modules/Makefile.am
@@ -14,3 +14,7 @@ SUBDIRS = \
  job-archive \
  resource \
  sched-simple
+
+if ENABLE_CONTENT_S3
+SUBDIRS += content-s3
+endif

--- a/src/modules/content-files/content-files.c
+++ b/src/modules/content-files/content-files.c
@@ -319,6 +319,7 @@ int mod_main (flux_t *h, int argc, char **argv)
 {
     struct content_files *ctx;
     bool testing = false;
+    int rc = -1;
 
     if (parse_args (h, argc, argv, &testing) < 0)
         return -1;
@@ -342,9 +343,11 @@ int mod_main (flux_t *h, int argc, char **argv)
         if (content_unregister_backing_store (h) < 0)
             goto done;
     }
+
+    rc = 0;
 done:
     content_files_destroy (ctx);
-    return 0;
+    return rc;
 }
 
 MOD_NAME ("content-files");

--- a/src/modules/content-s3/Makefile.am
+++ b/src/modules/content-s3/Makefile.am
@@ -1,0 +1,51 @@
+AM_CFLAGS = \
+	$(WARNING_CFLAGS) \
+	$(CODE_COVERAGE_CFLAGS)
+
+AM_LDFLAGS = \
+	$(CODE_COVERAGE_LIBS)
+
+AM_CPPFLAGS = \
+	-I$(top_srcdir) \
+	-I$(top_srcdir)/src/include \
+	-I$(top_builddir)/src/common/libflux \
+	$(ZMQ_CFLAGS)
+
+fluxmod_LTLIBRARIES = content-s3.la
+
+content_s3_la_SOURCES = \
+	content-s3.c \
+	s3.h \
+	s3.c
+
+content_s3_la_LDFLAGS = $(fluxmod_ldflags) -module
+content_s3_la_LIBADD = \
+		$(top_builddir)/src/common/libcontent/libcontent.la \
+		$(top_builddir)/src/common/libflux-internal.la \
+		$(top_builddir)/src/common/libflux-core.la \
+		$(ZMQ_LIBS) $(LIBS3)
+
+test_ldadd = \
+	$(top_builddir)/src/common/libflux-internal.la \
+	$(top_builddir)/src/common/libflux-core.la \
+	$(top_builddir)/src/common/libtap/libtap.la \
+	$(ZMQ_LIBS) $(LIBPTHREAD) $(LIBS3)
+
+test_ldflags = \
+	-no-install
+
+test_cppflags = $(AM_CPPFLAGS)
+
+check_PROGRAMS = \
+	test_load \
+	test_store
+
+test_load_SOURCES = test/load.c
+test_load_CPPFLAGS = $(test_cppflags)
+test_load_LDADD = $(builddir)/s3.o $(test_ldadd)
+test_load_LDFLAGS = $(test_ldflags)
+
+test_store_SOURCES = test/store.c
+test_store_CPPFLAGS = $(test_cppflags)
+test_store_LDADD = $(builddir)/s3.o $(test_ldadd)
+test_store_LDFLAGS = $(test_ldflags)

--- a/src/modules/content-s3/content-s3.c
+++ b/src/modules/content-s3/content-s3.c
@@ -1,0 +1,277 @@
+/************************************************************\
+ * Copyright 2020 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/core.h>
+
+#include "src/common/libutil/blobref.h"
+#include "src/common/libutil/log.h"
+
+#include "src/common/libcontent/content-util.h"
+
+#include "s3.h"
+
+struct content_s3 {
+    flux_msg_handler_t **handlers;
+    struct s3_config *cfg;
+    flux_t *h;
+    const char *hashfun;
+};
+
+/* Handle a content-backing.load request from the rank 0 broker's
+ * content-cache service.  The raw request payload is a blobref string,
+ * including NULL terminator.  The raw response payload is the blob content.
+ * These payloads are specified in RFC 10.
+ */
+static void load_cb (flux_t *h, flux_msg_handler_t *mh, const flux_msg_t *msg, void *arg)
+{
+    struct content_s3 *ctx = arg;
+    const char *blobref;
+    int blobref_size;
+    void *data = NULL;
+    size_t size;
+    const char *errstr = NULL;
+
+    if (flux_request_decode_raw (msg,
+                                 NULL,
+                                 (const void **)&blobref,
+                                 &blobref_size) < 0)
+        goto error;
+    if (!blobref || blobref[blobref_size - 1] != '\0'
+                 || blobref_validate (blobref) < 0) {
+        errno = EPROTO;
+        errstr = "invalid blobref";
+        goto error;
+    }
+    if (s3_get (ctx->cfg, blobref, &data, &size, &errstr) < 0)
+        goto error;
+    if (flux_respond_raw (h, msg, data, size) < 0)
+        flux_log_error (h, "error responding to load request");
+    free (data);
+    return;
+
+error:
+    if (flux_respond_error (h, msg, errno, errstr) < 0)
+        flux_log_error (h, "error responding to load request");
+    free (data);
+}
+
+/* Handle a content-backing.store request from the rank 0 broker's
+ * content-cache service.  The raw request payload is the blob content.
+ * The raw response payload is a blobref string including NULL terminator.
+ * These payloads are specified in RFC 10.
+ */
+void store_cb (flux_t *h, flux_msg_handler_t *mh, const flux_msg_t *msg, void *arg)
+{
+    struct content_s3 *ctx = arg;
+    const void *data;
+    int size;
+    char blobref[BLOBREF_MAX_STRING_SIZE];
+    const char *errstr = NULL;
+
+    if (flux_request_decode_raw (msg, NULL, &data, &size) < 0)
+        goto error;
+    if (blobref_hash (ctx->hashfun,
+                      (uint8_t *)data,
+                      size,
+                      blobref,
+                      sizeof (blobref)) < 0)
+        goto error;
+    if (s3_put (ctx->cfg, blobref, data, size, &errstr) < 0)
+        goto error;
+    if (flux_respond_raw (h, msg, blobref, strlen (blobref) + 1) < 0)
+        flux_log_error (h, "error responding to store request");
+    return;
+
+error:
+    if (flux_respond_error (h, msg, errno, errstr) < 0)
+        flux_log_error (h, "error responding to store request");
+}
+
+/* Handle a kvs-checkpoint.get request from the rank 0 kvs module.
+ * The KVS stores its last root reference here for restart purposes.
+ *
+ * N.B. filedb_get() calls read_all() which ensures that the returned buffer
+ * is padded with an extra NULL not included in the returned length,
+ * so it is safe to use the result as a string argument in flux_respond_pack().
+ */
+void checkpoint_get_cb (flux_t *h, flux_msg_handler_t *mh, const flux_msg_t *msg, void *arg)
+{
+    const char *errstr = NULL;
+    struct content_s3 *ctx = arg;
+    const char *key;
+    void *data = NULL;
+    char *dup = NULL;
+    size_t size;
+
+    if (flux_request_unpack (msg, NULL, "{s:s}", "key", &key) < 0)
+        goto error;
+
+    if (s3_get (ctx->cfg, key, &data, &size, &errstr) < 0)
+        goto error;
+
+    if (!(dup = strndup (data, size)))
+        goto error;
+
+    if (flux_respond_pack (h,
+                           msg,
+                           "{s:s}",
+                           "value",
+                           size > 0 ? dup : "", 0) < 0) {
+        errno = EIO;
+        flux_log_error (h, "error responding to kvs-checkpoint.get request (pack)");
+    }
+    free (data);
+    free (dup);
+    return;
+
+error:
+    if (flux_respond_error (h, msg, errno, errstr) < 0)
+        flux_log_error (h, "error responding to kvs-checkpoint.get request");
+    free (data);
+    free (dup);
+}
+
+/* Handle a kvs-checkpoint.put request from the rank 0 kvs module.
+ * The KVS stores its last root reference here for restart purposes.
+ */
+void checkpoint_put_cb (flux_t *h, flux_msg_handler_t *mh, const flux_msg_t *msg, void *arg)
+{
+    struct content_s3 *ctx = arg;
+    const char *key;
+    const char *value;
+    const char *errstr = NULL;
+
+    if (flux_request_unpack (msg,
+                             NULL,
+                             "{s:s s:s}",
+                             "key",
+                             &key,
+                             "value",
+                             &value) < 0)
+        goto error;
+    if (s3_put (ctx->cfg, key, value, strlen (value), &errstr) < 0)
+        goto error;
+    if (flux_respond (h, msg, NULL) < 0)
+        flux_log_error (h, "error responding to kvs-checkpoint.put request (pack)");
+    return;
+
+error:
+    if (flux_respond_error (h, msg, errno, errstr) < 0)
+        flux_log_error (h, "error responding to kvs-checkpoint.put request");
+}
+
+/* Table of message handler callbacks registered below.
+ * The topic strings in the table consist of <service name>.<method>.
+ */
+static const struct flux_msg_handler_spec htab[] = {
+    { FLUX_MSGTYPE_REQUEST, "content-backing.load",    load_cb, 0 },
+    { FLUX_MSGTYPE_REQUEST, "content-backing.store",   store_cb, 0 },
+    { FLUX_MSGTYPE_REQUEST, "kvs-checkpoint.get", checkpoint_get_cb, 0 },
+    { FLUX_MSGTYPE_REQUEST, "kvs-checkpoint.put", checkpoint_put_cb, 0 },
+    FLUX_MSGHANDLER_TABLE_END,
+};
+
+/* Destroy module context.
+ */
+static void content_s3_destroy (struct content_s3 *ctx)
+{
+    if(ctx) {
+        int saved_errno = errno;
+        flux_msg_handler_delvec (ctx->handlers);
+        free (ctx->cfg);
+        free (ctx);
+        errno = saved_errno;
+    }
+
+    s3_cleanup();
+}
+
+/* Create the s3 context, initalize the connection, and
+ * create the working bucket
+ */
+static struct content_s3 *content_s3_create (flux_t *h)
+{
+    const char *errstr = NULL;
+    struct content_s3 *ctx;
+
+    if (!(ctx = calloc (1, sizeof (*ctx))))
+        return NULL;
+    ctx->h = h;
+
+    if (!(ctx->hashfun = flux_attr_get (h, "content.hash"))) {
+        flux_log_error (h, "content.hash");
+        goto error;
+    }
+
+    if (!(ctx->cfg = calloc (1, sizeof (*ctx->cfg))))
+        goto error;
+    
+    ctx->cfg->retries = 5;
+    ctx->cfg->bucket = getenv("S3_BUCKET");
+    ctx->cfg->access_key = getenv("S3_ACCESS_KEY_ID");
+    ctx->cfg->secret_key = getenv("S3_SECRET_ACCESS_KEY");
+    ctx->cfg->hostname = getenv("S3_HOSTNAME");
+
+    if (s3_init (ctx->cfg, &errstr) < 0) {
+        flux_log_error (h, "content-s3 init");
+        goto error;
+    }
+
+    if (s3_bucket_create (ctx->cfg, &errstr) < 0) {
+        flux_log_error (h, "content-s3 create bucket");
+        goto error;
+    }
+
+    if (flux_msg_handler_addvec (h, htab, ctx, &ctx->handlers) < 0)
+        goto error;
+
+    return ctx;
+
+error:
+    content_s3_destroy(ctx);
+    return ctx;
+}
+
+int mod_main (flux_t *h, int argc, char **argv)
+{
+    struct content_s3 *ctx;
+    int rc = -1;
+
+    if (!(ctx = content_s3_create (h))) {
+        flux_log_error (h, "content_s3_create failed");
+        return -1;
+    }
+    if (content_register_backing_store (h, "content-s3") < 0)
+        goto done;
+    if (content_register_service (h, "content-backing") < 0)
+        goto done;
+    if (content_register_service (h, "kvs-checkpoint") < 0)
+        goto done;
+    if (flux_reactor_run (flux_get_reactor (h), 0) < 0) {
+        flux_log_error (h, "flux_reactor_run");
+        goto done;
+    }
+    if (content_unregister_backing_store (h) < 0)
+        goto done;
+
+    rc = 0;
+done:
+    content_s3_destroy (ctx);
+    return rc;
+}
+
+MOD_NAME ("content-s3");
+
+/*
+ * vi:ts=4 sw=4 expandtab
+ */

--- a/src/modules/content-s3/s3.c
+++ b/src/modules/content-s3/s3.c
@@ -1,0 +1,284 @@
+/************************************************************\
+ * Copyright 2020 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <sys/types.h>
+#include <string.h>
+#include <errno.h>
+#include <stdio.h>
+#include <libs3.h>
+#include <stdlib.h>
+
+#include "src/common/libutil/errno_safe.h"
+
+#include "s3.h"
+
+static S3Protocol protocol = S3ProtocolHTTP;
+static S3UriStyle uri_style = S3UriStylePath;
+
+/* Data needed by the get object callback function
+ */
+struct cb_data {
+    size_t size;
+    void *data;
+    int count;
+    S3Status status;
+};
+
+static S3Status response_props_cb (const S3ResponseProperties *properties, void *data)
+{
+    return S3StatusOK;
+}
+
+static void response_complete_cb (S3Status status, const S3ErrorDetails *error, void *data)
+{
+    struct cb_data *ctx = data;
+    ctx->status = status;
+}
+
+/* Writes a chunk of 'data' to s3, returning
+ * the size of the data written.
+ */
+static int put_object_cb (int buff_size, char *buff, void *data)
+{
+    struct cb_data *ctx = data;
+    int size = (buff_size < ctx->size - ctx->count ? buff_size : ctx->size - ctx->count);
+
+    memcpy (buff, ctx->data + ctx->count, size);
+    ctx->count += size;
+
+    return size;
+}
+
+/* Gets the object from s3 storing it in in 'data->datap' as well
+ * as updating 'data->sizep' to hold the size of the data read.
+ */
+static S3Status get_object_cb (int buff_size, const char *buff, void *data)
+{
+    void *tmp = NULL;
+    struct cb_data *ctx = data;
+
+    if (! (tmp = realloc (ctx->data, buff_size + ctx->size)))
+        return S3StatusOutOfMemory;
+    ctx->data = tmp;
+
+    memcpy (ctx->data + ctx->size, buff, buff_size);
+    ctx->size += buff_size;
+
+    return S3StatusOK;
+}
+
+int s3_init (struct s3_config *cfg, const char **errstr)
+{
+    S3Status status = S3_initialize ("s3", S3_INIT_ALL, cfg->hostname);
+
+    if (status != S3StatusOK) {
+        errno = ECONNREFUSED;
+        if (errstr)
+            *errstr = S3_get_status_name (status);
+
+        return -1;
+    }
+    
+    return 0;
+}
+
+void s3_cleanup (void)
+{
+    S3_deinitialize ();
+}
+
+int s3_bucket_create (struct s3_config *cfg, const char **errstr)
+{
+    int retries = cfg->retries;
+    S3Status status = S3_validate_bucket_name (cfg->bucket, uri_style);
+
+    if (status != S3StatusOK) {
+        errno = ECONNREFUSED;
+        if (errstr)
+            *errstr = S3_get_status_name (status);
+
+        return -1;
+    }
+
+    S3ResponseHandler resp_hndl = {
+        .propertiesCallback = &response_props_cb,
+        .completeCallback = &response_complete_cb
+    };
+
+    struct cb_data ctx = {
+        .size = 0,
+        .data = NULL,
+        .count = 0,
+        .status = status,
+    };
+
+    do {
+        S3_create_bucket (protocol,
+                          cfg->access_key,
+                          cfg->secret_key,
+                          NULL, // hostName (NULL to use the same hostName passed to S3_initialize())
+                          cfg->bucket,
+                          S3CannedAclPrivate,
+                          NULL, // locationContstraint
+                          NULL, // requestContext (NULL for synchronous operation)
+                          &resp_hndl,
+                          &ctx);
+        retries--;
+    } while (S3_status_is_retryable (ctx.status) && retries > 0);
+
+    if (ctx.status != S3StatusOK && ctx.status != S3StatusErrorBucketAlreadyOwnedByYou) {
+        errno = EREMOTEIO;
+        if (errstr)
+            *errstr = S3_get_status_name (status);
+
+        return -1;
+    }
+
+    return 0;
+}
+
+int s3_put (struct s3_config *cfg, const char *key, const void *data, size_t size, const char **errstr)
+{
+    int retries = cfg->retries;
+    S3Status status = S3StatusOK;
+    
+    S3ResponseHandler resp_hndl = {
+        .propertiesCallback = &response_props_cb,
+        .completeCallback = &response_complete_cb
+    };
+
+    S3BucketContext bucket_ctx = {
+        .hostName = NULL,
+        .bucketName = cfg->bucket,
+        .protocol = protocol,
+        .uriStyle = uri_style,
+        .accessKeyId = cfg->access_key,
+        .secretAccessKey = cfg->secret_key
+    };
+
+    S3PutObjectHandler put_obj_hndl ={
+        .responseHandler = resp_hndl,
+        .putObjectDataCallback = &put_object_cb
+    };
+
+    if (strlen (key) == 0 || strchr (key, '/') || !strcmp (key, "..") || !strcmp (key, ".")) {
+        errno = EINVAL;
+        if (errstr)
+            *errstr = "invalid key";
+
+        return -1;
+    }
+
+    struct cb_data ctx = {
+        .size = size,
+        .data = (void *) data,
+        .count = 0,
+        .status = status
+    };
+
+    do {
+        S3_put_object (&bucket_ctx,
+                       key,
+                       size,
+                       NULL, // putPorperties (NULL for none)
+                       NULL, // requestContext (NULL for synchronous operation)
+                       &put_obj_hndl,
+                       &ctx);
+        retries--;
+    } while (S3_status_is_retryable (ctx.status) && retries > 0);
+
+    if (ctx.status != S3StatusOK) {
+        errno = EREMOTEIO;
+        if (errstr)
+            *errstr = S3_get_status_name (ctx.status);
+
+        return -1;
+    }
+
+    return 0;
+}
+
+int s3_get (struct s3_config *cfg, const char *key, void **datap, size_t *sizep, const char **errstr)
+{
+    int retries = cfg->retries;
+    size_t size = 0;
+    S3Status status = S3StatusOK;
+
+    S3ResponseHandler resp_hndl = {
+        .propertiesCallback = &response_props_cb,
+        .completeCallback = &response_complete_cb
+    };
+
+    S3BucketContext bucket_ctx = {
+        .hostName = NULL,
+        .bucketName = cfg->bucket,
+        .protocol = protocol,
+        .uriStyle = uri_style,
+        .accessKeyId = cfg->access_key,
+        .secretAccessKey = cfg->secret_key
+    };
+
+
+    S3GetObjectHandler get_obj_hndl = {
+        .responseHandler = resp_hndl,
+        .getObjectDataCallback =  &get_object_cb
+    };
+
+    struct cb_data ctx = {
+        .size = size,
+        .data = NULL,
+        .count = 0,
+        .status = status
+    };
+   
+    if (strlen (key) == 0 || strchr (key, '/') || !strcmp (key, "..") || !strcmp (key, ".")) {
+        errno = EINVAL;
+        if (errstr)
+            *errstr = "invalid key";
+
+        return -1;
+    }
+
+    do {
+        S3_get_object (&bucket_ctx, 
+                       key,
+                       NULL, // getConditions (NULL for none)
+                       0,    // startByte
+                       0,    // byteCount (0 indicates the entire object should be read)
+                       NULL, // requestContext (NULL for synchronous operation)
+                       &get_obj_hndl, &ctx);
+        retries--;
+    } while (S3_status_is_retryable (ctx.status) && retries > 0);
+
+    if (ctx.status != S3StatusOK) {
+        free(ctx.data);
+        if (ctx.status == S3StatusErrorNoSuchKey)
+            errno = ENOENT;
+        else
+            errno = EREMOTEIO;
+
+        if (errstr)
+            *errstr = S3_get_status_name (ctx.status);
+
+        return -1;
+    }
+
+    *datap = ctx.data;
+    *sizep = ctx.size;
+
+    return 0;
+}
+
+/*
+ * vi:ts=4 sw=4 expandtab
+ */

--- a/src/modules/content-s3/s3.h
+++ b/src/modules/content-s3/s3.h
@@ -1,0 +1,69 @@
+/************************************************************\
+ * Copyright 2020 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _CONTENT_S3_S3_H
+#define _CONTENT_S3_S3_H
+
+/* Configuration info needed for all s3 calls
+ */
+struct s3_config {
+    int retries;        // number of times to retry each operation
+    char *bucket;       // the bucket name for the instance to use
+    char *access_key;   // access key id string
+    char *secret_key;   // secret access key id string
+    char *hostname;     // hostname string
+};
+
+/* Initialize the s3 connection.
+ * On success, an s3 connection to the endpoint is created
+ * and S3StatusOK (0) is returned. On failure, a status
+ * > 0 will be returned.
+ */
+int s3_init(struct s3_config *cfg, const char **errstr);
+
+/* Close down the s3 connection.
+ */
+void s3_cleanup(void);
+
+/* Create a bucket on the s3 connection.
+ * On success, a bucket will be created and 0 will be returned.
+ * On failure, a -1 will be reuturned and a bucket
+ * will not be created.
+ */
+int s3_bucket_create(struct s3_config *cfg, const char **errstr);
+
+/* Put an object to the s3 bucket.
+ * On success, the data will be put into the bucket
+ * and 0 will be returned. On failure, the data will not put
+ * to the bucket and -1 will be returned.
+ */
+int s3_put(struct s3_config *cfg,
+           const char *key,
+           const void *data,
+           size_t size,
+           const char **errstr);
+
+/* Get an object's data from the s3 bucket.
+ * On success, the object with key 'key' will be retrieved
+ * from the bucket and the data written to 'datap'
+ * and 0 will be returned. On failure, the data will not
+ * be retrieved from the bucket and -1 will be returned.
+ */
+int s3_get(struct s3_config *cfg,
+           const char *key,
+           void **datap,
+           size_t *sizep,
+           const char **errstr);
+
+#endif
+
+/*
+ * vi:ts=4 sw=4 expandtab
+ */

--- a/src/modules/content-s3/test/load.c
+++ b/src/modules/content-s3/test/load.c
@@ -1,0 +1,59 @@
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <unistd.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "src/common/libutil/read_all.h"
+#include "src/common/libutil/log.h"
+
+#include "src/modules/content-s3/s3.h"
+
+int main (int argc, char **argv)
+{
+    const char *errstr = NULL;
+    void *data = NULL;
+    size_t size;
+
+
+    struct s3_config *cfg;
+
+    if (!(cfg = calloc (1, sizeof (*cfg))))
+        fprintf(stderr, "calloc error");
+    
+    cfg->retries = 5;
+    cfg->bucket = getenv("S3_BUCKET");
+    cfg->access_key = getenv("S3_ACCESS_KEY_ID");
+    cfg->secret_key = getenv("S3_SECRET_ACCESS_KEY");
+    cfg->hostname = getenv("S3_HOSTNAME");
+
+    if (s3_init (cfg, &errstr) < 0) {
+        fprintf(stderr, "S3 init error\n%s\n", errstr);
+    }
+
+    if (s3_bucket_create (cfg, &errstr) < 0) {
+        fprintf(stderr, "S3 create bucket error\n%s\n", errstr);
+    }
+
+    if (argc != 2) {
+        fprintf (stderr, "Usage: test_load key >output\n");
+        exit (1);
+    }
+    if (s3_get (cfg, argv[1], &data, &size, &errstr) < 0)
+        log_msg_exit ("s3_get: %s", errstr ? errstr : strerror (errno));
+
+    log_msg ("%zu bytes", size);
+
+    if (write_all (STDOUT_FILENO, data, size) < 0)
+        log_err_exit ("writing to stdout");
+
+    free (data);
+    exit (0);
+}
+
+/*
+ * vi:ts=4 sw=4 expandtab
+ */

--- a/src/modules/content-s3/test/store.c
+++ b/src/modules/content-s3/test/store.c
@@ -1,0 +1,59 @@
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <unistd.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "src/common/libutil/read_all.h"
+#include "src/common/libutil/log.h"
+
+#include "src/modules/content-s3/s3.h"
+
+int main (int argc, char **argv)
+{
+    const char *errstr = NULL;
+    void *data;
+    size_t size;
+
+    struct s3_config *cfg;
+
+    if (!(cfg = calloc (1, sizeof (*cfg))))
+        fprintf(stderr, "calloc error");
+    
+    cfg->retries = 5;
+    cfg->bucket = getenv("S3_BUCKET");
+    cfg->access_key = getenv("S3_ACCESS_KEY_ID");
+    cfg->secret_key = getenv("S3_SECRET_ACCESS_KEY");
+    cfg->hostname = getenv("S3_HOSTNAME");
+
+
+    if (s3_init (cfg, &errstr) < 0) {
+        fprintf(stderr, "S3 init error\n%s\n", errstr);
+    }
+
+    if (s3_bucket_create (cfg, &errstr) < 0) {
+        fprintf(stderr, "S3 create bucket error\n%s\n", errstr);
+    }
+
+    if (argc != 2) {
+        fprintf (stderr, "Usage: test_store key <input\n");
+        exit (1);
+    }
+    size = read_all (STDIN_FILENO, &data);
+    if (size < 0)
+        log_err_exit ("error reading stdin");
+
+    if (s3_put (cfg, argv[1], data, size, &errstr) < 0)
+        log_msg_exit ("s3_put : %s", errstr ? errstr : "failed");
+
+    free (data);
+
+    exit (0);
+}
+
+/*
+ * vi:ts=4 sw=4 expandtab
+ */

--- a/src/test/docker/docker-run-checks.sh
+++ b/src/test/docker/docker-run-checks.sh
@@ -155,9 +155,14 @@ else
         -e PRELOAD \
         -e ASAN_OPTIONS \
         -e BUILD_DIR \
+        -e S3_ACCESS_KEY_ID \
+        -e S3_SECRET_ACCESS_KEY \
+        -e S3_HOSTNAME \
+        -e S3_BUCKET \
         --cap-add SYS_PTRACE \
         --tty \
         ${INTERACTIVE:+--interactive} \
+        --network=host \
         travis-builder:${IMAGE} \
         ${INTERACTIVE:-./src/test/travis_run.sh ${CONFIGURE_ARGS}} \
     || die "docker run failed"

--- a/src/test/docker/travis/Dockerfile
+++ b/src/test/docker/travis/Dockerfile
@@ -48,7 +48,11 @@ RUN case $BASE_IMAGE in \
     esac
 
 # Install extra dependencies if necessary here.
-#
+RUN case $BASE_IMAGE in \
+     bionic*) apt-get update -y && apt-get install -y libs3-dev ;; \
+     *) (>&2 echo "Not installing libs3") ;; \
+    esac
+
 # Do not forget to run `apt update` on Ubuntu/bionic.
 # Do NOT run `yum upgrade` on CentOS (this will unnecessarily upgrade
 #  existing packages)

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -66,6 +66,7 @@ TESTSCRIPTS = \
 	t0010-generic-utils.t \
 	t0011-content-cache.t \
 	t0012-content-sqlite.t \
+	t0024-content-s3.t \
 	t0013-config-file.t \
 	t0014-runlevel.t \
 	t0015-cron.t \

--- a/t/t0024-content-s3.t
+++ b/t/t0024-content-s3.t
@@ -1,0 +1,174 @@
+#!/bin/sh
+
+test_description='Test content-s3 backing store service'
+
+. `dirname $0`/sharness.sh
+
+if test -z "$S3_ACCESS_KEY_ID"; then
+    skip_all='skipping content-s3 test since S3_ACCESS_KEY_ID not set'
+    test_done
+fi
+
+if test "$TEST_LONG" = "t"; then
+    test_set_prereq LONGTEST
+fi
+
+test_under_flux 1 minimal
+
+BLOBREF=${FLUX_BUILD_DIR}/t/kvs/blobref
+RPC=${FLUX_BUILD_DIR}/t/request/rpc
+
+SIZES="0 1 64 100 1000 1024 1025 8192 65536 262144 1048576 4194304"
+LARGE_SIZES="8388608 10000000 16777216 33554432 67108864"
+
+##
+# Functions used by tests
+##
+
+# Usage: backing_load blobref
+backing_load() {
+        echo -n $1 | $RPC content-backing.load
+}
+# Usage: backing_store <blob >blobref
+backing_store() {
+        $RPC -r content-backing.store
+}
+# Usage: make_blob size >blob
+make_blob() {
+	if test $1 -eq 0; then
+		dd if=/dev/null 2>/dev/null
+	else
+		dd if=/dev/urandom count=1 bs=$1 2>/dev/null
+	fi
+}
+# Usage: check_blob size
+# Leaves behind blob.<size> and blobref.<size>
+check_blob() {
+	make_blob $1 >blob.$1 &&
+	backing_store <blob.$1 >blobref.$1 &&
+	backing_load $(cat blobref.$1) >blob.$1.check &&
+	test_cmp blob.$1 blob.$1.check
+}
+# Usage: check_blob size
+# Relies on existence of blob.<size> and blobref.<size>
+recheck_blob() {
+	backing_load $(cat blobref.$1) >blob.$1.recheck &&
+	test_cmp blob.$1 blob.$1.recheck
+}
+# Usage: recheck_cache_blob size
+# Relies on existence of blob.<size> and blobref.<size>
+recheck_cache_blob() {
+	flux content load $(cat blobref.$1) >blob.$1.cachecheck &&
+	test_cmp blob.$1 blob.$1.cachecheck
+}
+# Usage: kvs_checkpoint_put key value
+kvs_checkpoint_put() {
+        jq -j -c -n  "{key:\"$1\",value:\"$2\"}" | $RPC kvs-checkpoint.put
+}
+# Usage: kvs_checkpoint_get key >value
+kvs_checkpoint_get() {
+        jq -j -c -n  "{key:\"$1\"}" | $RPC kvs-checkpoint.get
+}
+
+##
+# Tests of the module by itself (no content cache)
+##
+
+test_expect_success 'load content-s3 module' '
+	flux module load content-s3 testing
+'
+
+test_expect_success 'store/load/verify various size small blobs' '
+	err=0 &&
+	for size in $SIZES; do \
+		if ! check_blob $size; then err=$(($err+1)); fi; \
+	done &&
+	test $err -eq 0
+'
+
+test_expect_success LONGTEST 'store/load/verify various size large blobs' '
+	err=0 &&
+	for size in $LARGE_SIZES; do \
+		if ! check_blob $size; then err=$(($err+1)); fi; \
+	done &&
+	test $err -eq 0
+'
+
+test_expect_success HAVE_JQ 'kvs-checkpoint.put foo=bar' '
+        kvs_checkpoint_put foo bar
+'
+
+test_expect_success HAVE_JQ 'kvs-checkpoint.get foo returned bar' '
+        echo bar >value.exp &&
+        kvs_checkpoint_get foo | jq -r .value >value.out &&
+        test_cmp value.exp value.out
+'
+
+test_expect_success HAVE_JQ 'kvs-checkpoint.put updates foo=baz' '
+        kvs_checkpoint_put foo baz
+'
+
+test_expect_success HAVE_JQ 'kvs-checkpoint.get foo returned baz' '
+        echo baz >value2.exp &&
+        kvs_checkpoint_get foo | jq -r .value >value2.out &&
+        test_cmp value2.exp value2.out
+'
+
+test_expect_success 'reload content-s3 module' '
+	flux module reload content-s3 testing
+'
+
+test_expect_success 'reload/verify various size small blobs' '
+	err=0 &&
+	for size in $SIZES; do \
+		if ! recheck_blob $size; then err=$(($err+1)); fi; \
+	done &&
+	test $err -eq 0
+'
+
+test_expect_success LONGTEST 'reload/verify various size large blobs' '
+	err=0 &&
+	for size in $LARGE_SIZES; do \
+		if ! recheck_blob $size; then err=$(($err+1)); fi; \
+	done &&
+	test $err -eq 0
+'
+
+test_expect_success HAVE_JQ 'kvs-checkpoint.get foo returns same value' '
+        kvs_checkpoint_get foo | jq -r .value >value2.out &&
+        test_cmp value2.exp value2.out
+'
+
+##
+# Tests of the module acting as backing store for content cache
+##
+
+test_expect_success 'reload content-s3 module without testing option' '
+	flux module reload content-s3
+'
+
+test_expect_success 'verify content.backing-module=content-s3' '
+        test "$(flux getattr content.backing-module)" = "content-s3"
+'
+
+test_expect_success 'reload/verify various size small blobs through cache' '
+	err=0 &&
+	for size in $SIZES; do \
+		if ! recheck_cache_blob $size; then err=$(($err+1)); fi; \
+	done &&
+	test $err -eq 0
+'
+
+test_expect_success LONGTEST 'reload/verify various size large blobs through cache' '
+	err=0 &&
+	for size in $LARGE_SIZES; do \
+		if ! recheck_cache_blob $size; then err=$(($err+1)); fi; \
+	done &&
+	test $err -eq 0
+'
+
+test_expect_success 'remove content-s3 module' '
+	flux module remove content-s3
+'
+
+test_done

--- a/t/t2008-althash.t
+++ b/t/t2008-althash.t
@@ -12,6 +12,10 @@ nil256="sha256-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
 . `dirname $0`/sharness.sh
 
+if test -n "$S3_ACCESS_KEY_ID"; then
+    test_set_prereq S3
+fi
+
 test_expect_success 'Started instance with content.hash=sha1' '
     OUT=$(flux start -o,-Scontent.hash=sha1 \
           flux getattr content.hash) && test "$OUT" = "sha1"
@@ -30,19 +34,25 @@ test_expect_success 'Started instance with content.hash=sha256,content-files' '
     ls -1 content.files | tail -1 | grep sha256
 '
 
-test_expect_success 'Content store nil returns correct hash for sha256' '
+test_expect_success S3 'Started instance with content.hash=sha256,content-s3' '
+    OUT=$(flux start -o,-Scontent.hash=sha256 \
+          -o,-Scontent.backing-module=content-s3 \
+          flux getattr content.hash) && test "$OUT" = "sha256" &&
+    ls -1 content.files | tail -1 | grep sha256
+'
+test_expect_success S3 'Content store nil returns correct hash for sha256' '
     OUT=$(flux start -o,-Scontent.hash=sha256 \
           flux content store </dev/null) &&
         test "$OUT" = "$nil256"
 '
 
-test_expect_success 'Content store nil returns correct hash for sha1' '
+test_expect_success S3 'Content store nil returns correct hash for sha1' '
     OUT=$(flux start -o,-Scontent.hash=sha1 \
           flux content store </dev/null) &&
         test "$OUT" = "$nil1"
 '
 
-test_expect_success 'Attempt to start instance with invalid hash fails hard' '
+test_expect_success S3 'Attempt to start instance with invalid hash fails hard' '
     test_must_fail flux start -o,-Scontent.hash=wronghash /bin/true
 '
 


### PR DESCRIPTION
This is a work in progress pr that adds an s3 backing store. It is very light weight and doesn't have much error checking at this point. This pr is based on #2992. 

For testing, I suggest pulling down [Minio](https://www.google.com/search?client=ubuntu&channel=fs&q=minio+quickstart+guide&ie=utf-8&oe=utf-8) and following these steps:

1. Install the s3 library: `apt/yum install libs3-dev`
2. From your flux build directory spin up the Minio server: `minio server ./s3-data &`
3. Set the necessary env vars: 
        `S3_HOSTNAME=127.0.0.1:9000`
        `S3_SECRET_ACCESS_KEY={secretkey}`
        `S3_ACCESS_KEY_ID={accesskey}`
        `S3_BUCKET=flux-bucket`
4. Invoke the content-s3 backing store: `src/cmd/flux start -o,-Scontent.backing-module=content-s3`

TODOs:
1. Add error checking
2. Add TOML config hook
3. Add sharness tests