### PR TITLE
docker: really actually fix Ubuntu 20.04 (focal) docker tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,12 +38,11 @@ jobs:
     - name: "Ubuntu: no configure flags"
       stage: test
       compiler: gcc
-    - name: "Ubuntu 20.04: py3.8 distcheck"
+    - name: "Ubuntu 20.04: py3.8"
       stage: test
       compiler: gcc
       env:
        - IMG=focal
-       - DISTCHECK=t
        - PYTHON_VERSION=3.8
        - GITHUB_RELEASES_DEPLOY=t
        - DOCKER_TAG=t

--- a/src/test/docker/docker-run-checks.sh
+++ b/src/test/docker/docker-run-checks.sh
@@ -167,7 +167,7 @@ if test -n "$TAG"; then
     # Re-run 'make install' in fresh image, otherwise we get all
     # the context from the build above
     docker run --name=tmp.$$ \
-	--workdir=/usr/src \
+	--workdir=/usr/src/${BUILD_DIR} \
         --volume=$TOP:/usr/src \
         --user="root" \
 	travis-builder:${IMAGE} \

--- a/src/test/docker/docker-run-checks.sh
+++ b/src/test/docker/docker-run-checks.sh
@@ -79,6 +79,16 @@ TOP=$(git rev-parse --show-toplevel 2>&1) \
 which docker >/dev/null \
     || die "unable to find a docker binary"
 
+# distcheck incompatible with some configure args
+if test "$DISTCHECK" = "t"; then
+    for arg in "$@"; do
+        case $arg in
+          --sysconfdir=*|systemdsystemunitdir=*)
+            die "distcheck incompatible with configure arg $arg"
+        esac
+    done
+fi
+
 CONFIGURE_ARGS="$@"
 
 . ${TOP}/src/test/travis-lib.sh


### PR DESCRIPTION
It appears that the problem causing the Ubuntu focal builder to fail when attempting to push a new docker image is due to an incompatibility with the `configure` args used for a docker image and the `make distcheck` target. `make distcheck` tries to do reconfigure the project by appending a new `--prefix` to its special `_inst` directory, but it keeps previous `configure` args, so `--sysconfdir=/etc` tries to install files outside of `_inst` which fails.

This PR adds a new fatal error if `docker-run-checks.sh --distcheck` is used with a couple common `configure` args like `--sysconfdir` or `--with-systemdsystemunitdir`. Then the `DISTCHECK=t` flag is removed from the Ubuntu 20.04 builder. 

This will hopefully finally cause the docker tag to work and be automatically pushed to dockerhub.

