### PR TITLE
pylint: Update pylint to 2.4.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ jobs:
       name: 'python lint'
       language: 'python'
       python: '3.6'
-      install: pip install 'pylint==2.2.2' --force-reinstall
+      install: pip install 'pylint==2.4.4' --force-reinstall
       script: ./scripts/pylint
       before_deploy: skip
       deploy: skip

--- a/scripts/.pylintrc
+++ b/scripts/.pylintrc
@@ -110,10 +110,10 @@ function-rgx=[a-z_][a-z0-9_]{2,30}$
 function-name-hint=[a-z_][a-z0-9_]{2,30}$
 
 # Regular expression matching correct variable names
-variable-rgx=[a-z_][a-z0-9_]{2,30}$
+variable-rgx=[a-zA-Z_][a-zA-Z0-9_]{2,30}$
 
 # Naming hint for variable names
-variable-name-hint=[a-z_][a-z0-9_]{2,30}$
+variable-name-hint=[a-zA-Z_][a-zA-Z0-9_]{2,30}$
 
 # Regular expression matching correct constant names
 const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$
@@ -122,16 +122,16 @@ const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$
 const-name-hint=(([A-Z_][A-Z0-9_]*)|(__.*__))$
 
 # Regular expression matching correct attribute names
-attr-rgx=[a-z_][a-z0-9_]{2,30}$
+attr-rgx=[a-zA-Z_][a-zA-Z0-9_]{2,30}$
 
 # Naming hint for attribute names
-attr-name-hint=[a-z_][a-z0-9_]{2,30}$
+attr-name-hint=[a-zA-Z_][a-zA-Z0-9_]{2,30}$
 
 # Regular expression matching correct argument names
-argument-rgx=[a-z_][a-z0-9_]{2,30}$
+argument-rgx=[a-zA-Z_][a-zA-Z0-9_]{2,30}$
 
 # Naming hint for argument names
-argument-name-hint=[a-z_][a-z0-9_]{2,30}$
+argument-name-hint=[a-zA-Z_][a-zA-Z0-9_]{2,30}$
 
 # Regular expression matching correct class attribute names
 class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$

--- a/scripts/.pylintrc
+++ b/scripts/.pylintrc
@@ -91,7 +91,7 @@ logging-modules=logging
 bad-functions=map,filter,apply,input,file
 
 # Good variable names which should always be accepted, separated by a comma
-good-names=i,j,k,x,y,z,ex,Run,_
+good-names=i,j,k,x,y,z,ex,io,rc,Run,_
 
 # Bad variable names which should always be refused, separated by a comma
 bad-names=foo,bar,baz,toto,tutu,tata

--- a/scripts/.pylintrc
+++ b/scripts/.pylintrc
@@ -44,7 +44,7 @@ symbols=no
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
-disable=missing-docstring, too-few-public-methods, too-many-arguments, star-args, arguments-differ, no-member, import-error, no-name-in-module, useless-object-inheritance, fixme, bad-continuation
+disable=missing-docstring, too-few-public-methods, too-many-arguments, star-args, arguments-differ, no-member, import-error, no-name-in-module, useless-object-inheritance, fixme, bad-continuation, too-many-lines
 
 
 [REPORTS]

--- a/src/bindings/python/flux/__init__.py
+++ b/src/bindings/python/flux/__init__.py
@@ -11,11 +11,11 @@
 """
 python bindings to flux-core, the main core of the flux resource manager
 """
+import flux.core.handle
+
 # Manually lazy
 # pylint: disable=invalid-name
 def Flux(*args, **kwargs):
-    import flux.core.handle
-
     return flux.core.handle.Flux(*args, **kwargs)
 
 

--- a/src/bindings/python/flux/core/handle.py
+++ b/src/bindings/python/flux/core/handle.py
@@ -191,11 +191,11 @@ class Flux(Wrapper):
 
         reactor_interrupted = False
 
-        def reactor_interrupt(h, *args):
+        def reactor_interrupt(handle, *args):
             #  ensure reactor_interrupted from enclosing scope:
             nonlocal reactor_interrupted
             reactor_interrupted = True
-            h.reactor_stop(reactor)
+            handle.reactor_stop(reactor)
 
         with self.signal_watcher_create(signal.SIGINT, reactor_interrupt):
             self.reactor_active_decref(reactor)

--- a/src/bindings/python/flux/core/handle.py
+++ b/src/bindings/python/flux/core/handle.py
@@ -8,8 +8,8 @@
 # SPDX-License-Identifier: LGPL-3.0
 ###############################################################
 
-import six
 import signal
+import six
 
 from flux.wrapper import Wrapper
 from flux.rpc import RPC

--- a/src/bindings/python/flux/core/handle.py
+++ b/src/bindings/python/flux/core/handle.py
@@ -16,6 +16,9 @@ from flux.rpc import RPC
 from flux.message import Message
 from flux.util import encode_topic, encode_payload
 from flux.core.inner import raw
+from flux.message import MessageWatcher
+from flux.core.watchers import TimerWatcher
+from flux.core.watchers import SignalWatcher
 from _flux._core import ffi, lib
 
 
@@ -155,18 +158,12 @@ class Flux(Wrapper):
         args=None,
         match_tag=raw.FLUX_MATCHTAG_NONE,
     ):
-        from flux.message import MessageWatcher
-
         return MessageWatcher(self, type_mask, callback, topic_glob, match_tag, args)
 
     def timer_watcher_create(self, after, callback, repeat=0.0, args=None):
-        from flux.core.watchers import TimerWatcher
-
         return TimerWatcher(self, after, callback, repeat=repeat, args=args)
 
     def signal_watcher_create(self, signum, callback, args=None):
-        from flux.core.watchers import SignalWatcher
-
         return SignalWatcher(self, signum, callback, args)
 
     def barrier(self, name, nprocs):

--- a/src/bindings/python/flux/future.py
+++ b/src/bindings/python/flux/future.py
@@ -15,6 +15,7 @@ from flux.wrapper import Wrapper, WrapperPimpl
 from flux.core.inner import ffi, lib, raw
 from typing import Dict
 
+import flux.core.handle
 
 # Reference count dictionary to keep futures with a pending `then` callback
 # alive, even if there are no remaining references to the future in the user's
@@ -86,8 +87,6 @@ class Future(WrapperPimpl):
 
     def get_flux(self):
         # pylint: disable=cyclic-import
-        import flux.core.handle
-
         flux_handle = self.pimpl.get_flux()
         if flux_handle == ffi.NULL:
             return None

--- a/src/bindings/python/flux/future.py
+++ b/src/bindings/python/flux/future.py
@@ -10,10 +10,11 @@
 
 import errno
 
+from typing import Dict
+
 from flux.util import check_future_error
 from flux.wrapper import Wrapper, WrapperPimpl
 from flux.core.inner import ffi, lib, raw
-from typing import Dict
 
 import flux.core.handle
 

--- a/src/bindings/python/flux/job.py
+++ b/src/bindings/python/flux/job.py
@@ -13,10 +13,9 @@ import json
 import errno
 import datetime
 import collections
+import collections.abc as abc
 import numbers
 import signal
-
-import collections.abc as abc
 
 import six
 import yaml

--- a/src/bindings/python/flux/job.py
+++ b/src/bindings/python/flux/job.py
@@ -853,28 +853,28 @@ class Jobspec(object):
         """Redirect stderr to a file given by `path`"""
         self._set_io_path("output", "stderr", path)
 
-    def _get_io_path(self, io, stream_name):
+    def _get_io_path(self, iotype, stream_name):
         """Get the path of a stdio stream, if set.
 
-        :param io: the stream type, one of `"input"` or `"output"`
+        :param iotype: the stream type, one of `"input"` or `"output"`
         :param stream_name: the name of the io stream
         """
         try:
-            return self.jobspec["attributes"]["system"]["shell"]["options"][io][
+            return self.jobspec["attributes"]["system"]["shell"]["options"][iotype][
                 stream_name
             ]["path"]
         except KeyError:
             return None
 
-    def _set_io_path(self, io, stream_name, path):
+    def _set_io_path(self, iotype, stream_name, path):
         """Set the path of a stdio stream.
 
-        :param io: the stream type, one of `"input"` or `"output"`
+        :param iotype: the stream type, one of `"input"` or `"output"`
         :param stream_name: the name of the io stream
         :param path: the path to redirect the stream
         """
-        self.setattr_shell_option("{}.{}.type".format(io, stream_name), "file")
-        self.setattr_shell_option("{}.{}.path".format(io, stream_name), path)
+        self.setattr_shell_option("{}.{}.type".format(iotype, stream_name), "file")
+        self.setattr_shell_option("{}.{}.path".format(iotype, stream_name), path)
 
     def _set_treedict(self, in_dict, key, val):
         """

--- a/src/bindings/python/flux/job.py
+++ b/src/bindings/python/flux/job.py
@@ -16,6 +16,8 @@ import collections
 import numbers
 import signal
 
+import collections.abc as abc
+
 import six
 import yaml
 
@@ -26,8 +28,6 @@ from flux.util import check_future_error, parse_fsd
 from flux.future import Future
 from flux.rpc import RPC
 from _flux._core import ffi, lib
-
-import collections.abc as abc
 
 
 class JobWrapper(Wrapper):

--- a/src/bindings/python/flux/job.py
+++ b/src/bindings/python/flux/job.py
@@ -613,7 +613,7 @@ class Jobspec(object):
             raise TypeError("version must be an integer")
         if not isinstance(attributes, abc.Mapping):
             raise TypeError("attributes must be a mapping")
-        elif version < 1:
+        if version < 1:
             raise ValueError("version must be >= 1")
 
         self.jobspec = {
@@ -654,7 +654,7 @@ class Jobspec(object):
                 continue
             if not isinstance(range_dict[key], six.integer_types):
                 raise TypeError("{} must be an int".format(key))
-            elif range_dict[key] < 1:
+            if range_dict[key] < 1:
                 raise ValueError("{} must be > 0".format(key))
         valid_operator_values = ["+", "*", "^"]
         if (
@@ -734,7 +734,7 @@ class Jobspec(object):
     def _create_resource(res_type, count, with_child=None):
         if with_child is not None and not isinstance(with_child, abc.Sequence):
             raise TypeError("child resource must None or a sequence")
-        elif with_child is not None and isinstance(with_child, six.string_types):
+        if with_child is not None and isinstance(with_child, six.string_types):
             raise TypeError("child resource must not be a string")
         if not count > 0:
             raise ValueError("resource count must be > 0")

--- a/src/bindings/python/flux/job.py
+++ b/src/bindings/python/flux/job.py
@@ -328,7 +328,7 @@ class EventLogEvent:
         """
         "Initialize from a string or dict eventlog event
         """
-        if type(event) is str:
+        if isinstance(event, str):
             event = json.loads(event)
         self._name = event["name"]
         self._timestamp = event["timestamp"]

--- a/src/bindings/python/flux/job.py
+++ b/src/bindings/python/flux/job.py
@@ -386,9 +386,8 @@ class JobEventWatchFuture(Future):
             if exc.errno == errno.ENODATA:
                 self.needs_cancel = False
                 return None
-            else:
-                # re-raise all other exceptions
-                raise
+            # re-raise all other exceptions
+            raise
         event = EventLogEvent(ffi.string(result[0]).decode("utf-8"))
         if autoreset is True:
             self.reset()

--- a/src/bindings/python/flux/kvs.py
+++ b/src/bindings/python/flux/kvs.py
@@ -13,10 +13,10 @@ from __future__ import print_function
 import json
 import errno
 
+import collections.abc as abc
+
 from _flux._core import ffi, lib
 from flux.wrapper import Wrapper, WrapperPimpl
-
-import collections.abc as abc
 
 
 class KVSWrapper(Wrapper):

--- a/src/bindings/python/flux/util.py
+++ b/src/bindings/python/flux/util.py
@@ -16,7 +16,9 @@ import logging
 import os
 import math
 import argparse
+import traceback
 from datetime import timedelta
+from string import Formatter
 
 import six
 
@@ -137,8 +139,6 @@ class CLIMain(object):
         except Exception as ex:  # pylint: disable=broad-except
             exit_code = 1
             self.logger.error(str(ex))
-            import traceback
-
             self.logger.debug(traceback.format_exc())
         finally:
             logging.shutdown()
@@ -182,8 +182,6 @@ class OutputFormat:
         Throws an exception if any format fields do not match the allowed
         list of headings.
         """
-        from string import Formatter
-
         self.headings = valid_headings
         self.fmt = fmt
         #  Parse format into list of (string, field, spec, conv) tuples,

--- a/src/bindings/python/flux/util.py
+++ b/src/bindings/python/flux/util.py
@@ -67,7 +67,7 @@ def encode_topic(topic):
     # Convert topic to utf-8 binary string
     if topic is None or topic == ffi.NULL:
         raise EnvironmentError(errno.EINVAL, "Topic must not be None/NULL")
-    elif isinstance(topic, six.text_type):
+    if isinstance(topic, six.text_type):
         topic = topic.encode("UTF-8")
     elif not isinstance(topic, six.binary_type):
         errmsg = "Topic must be a string, not {}".format(type(topic))

--- a/src/cmd/flux-jobs.py
+++ b/src/cmd/flux-jobs.py
@@ -18,6 +18,8 @@ import time
 import pwd
 import string
 import errno
+import fileinput
+import json
 from datetime import datetime, timedelta
 
 import flux.job
@@ -225,9 +227,6 @@ def fetch_jobs_stdin():
     flux-jobs utility, and thus, all filtering options are currently
     ignored.
     """
-    import fileinput
-    import json
-
     jobs = []
     for line in fileinput.input("-"):
         try:

--- a/src/cmd/flux-resource.py
+++ b/src/cmd/flux-resource.py
@@ -11,6 +11,7 @@
 import sys
 import logging
 import argparse
+import re
 from itertools import count, groupby
 
 import flux
@@ -74,8 +75,6 @@ def bracket(setstr):
     """
     Add brackets to idset if not already present and idset is not single number
     """
-    import re
-
     if not setstr or setstr[0] == "[" or re.match(r"^[^,-]+$", setstr):
         return setstr
     return f"[{setstr}]"


### PR DESCRIPTION
Per #3034, update pylint from 2.2.2 to 2.4.4 to get around `isort` module errors.  Update python to handle new pylint errors.

Most of the Python changes should be simple and obvious.  Perhaps the only one to consider was the `invalid-name` fixes.  New variable names acceptable?  I chose to disable `invalid-name` for one function parameter (`raiseJobException`), which seemed quite specific.  I did change the variable name for another function parameter (`io` -> `iotype`).

Also, i chose to ignore `too-many-lines` errorrs.  Could increase the max-lines instead (default 1000)?