### PR TITLE
job-info: support annotations (part 2)

### DIFF
--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -1000,7 +1000,8 @@ static const char *list_attrs =
     "\"name\",\"ntasks\",\"nnodes\",\"ranks\",\"expiration\",\"success\"," \
     "\"exception_occurred\",\"exception_severity\",\"exception_type\"," \
     "\"exception_note\",\"result\","                                    \
-    "\"t_depend\",\"t_sched\",\"t_run\",\"t_cleanup\",\"t_inactive\"]";
+    "\"t_depend\",\"t_sched\",\"t_run\",\"t_cleanup\",\"t_inactive\"," \
+    "\"annotations\"]";
 
 int cmd_list (optparse_t *p, int argc, char **argv)
 {

--- a/src/modules/job-info/job-info.c
+++ b/src/modules/job-info/job-info.c
@@ -178,6 +178,11 @@ static const struct flux_msg_handler_spec htab[] = {
       .cb           = job_state_cb,
       .rolemask     = 0
     },
+    { .typemask     = FLUX_MSGTYPE_EVENT,
+      .topic_glob   = "job-annotations",
+      .cb           = job_annotations_cb,
+      .rolemask     = 0
+    },
     FLUX_MSGHANDLER_TABLE_END,
 };
 

--- a/src/modules/job-info/job_state.c
+++ b/src/modules/job-info/job_state.c
@@ -1334,6 +1334,12 @@ static struct job *eventlog_restart_parse (struct info_ctx *ctx,
             update_job_state (ctx, job, FLUX_JOB_SCHED, timestamp);
         }
         else if (!strcmp (name, "priority")) {
+            if (!context) {
+                flux_log_error (ctx->h, "%s: no priority context for %ju",
+                                __FUNCTION__, (uintmax_t)job->id);
+                goto error;
+            }
+
             if (json_unpack (context, "{ s:i }",
                                       "priority", &job->priority) < 0) {
                 flux_log_error (ctx->h, "%s: priority context for %ju invalid",
@@ -1343,6 +1349,12 @@ static struct job *eventlog_restart_parse (struct info_ctx *ctx,
         }
         else if (!strcmp (name, "exception")) {
             int severity;
+            if (!context) {
+                flux_log_error (ctx->h, "%s: no exception context for %ju",
+                                __FUNCTION__, (uintmax_t)job->id);
+                goto error;
+            }
+
             if (json_unpack (context, "{ s:i }", "severity", &severity) < 0) {
                 flux_log_error (ctx->h, "%s: exception context for %ju invalid",
                                 __FUNCTION__, (uintmax_t)job->id);

--- a/src/modules/job-info/job_state.c
+++ b/src/modules/job-info/job_state.c
@@ -77,6 +77,7 @@ static void job_destroy (void *data)
     struct job *job = data;
     if (job) {
         json_decref (job->exception_context);
+        json_decref (job->annotations);
         json_decref (job->jobspec_job);
         json_decref (job->jobspec_cmd);
         json_decref (job->R);
@@ -162,6 +163,11 @@ struct job_state_ctx *job_state_create (flux_t *h)
     zlistx_set_destructor (jsctx->transitions, flux_msg_destroy_wrapper);
 
     if (flux_event_subscribe (h, "job-state") < 0) {
+        flux_log_error (h, "flux_event_subscribe");
+        goto error;
+    }
+
+    if (flux_event_subscribe (h, "job-annotations") < 0) {
         flux_log_error (h, "flux_event_subscribe");
         goto error;
     }
@@ -1237,6 +1243,73 @@ void job_state_cb (flux_t *h, flux_msg_handler_t *mh,
     return;
 }
 
+static void update_annotations (struct info_ctx *ctx, json_t *annotations)
+{
+    struct job_state_ctx *jsctx = ctx->jsctx;
+    size_t index;
+    json_t *value;
+
+    if (!json_is_array (annotations)) {
+        flux_log_error (ctx->h, "%s: annotations EPROTO", __FUNCTION__);
+        return;
+    }
+
+    json_array_foreach (annotations, index, value) {
+        struct job *job;
+        json_t *o;
+        flux_jobid_t id;
+
+        if (!json_is_array (value)) {
+            flux_log_error (jsctx->h, "%s: annotation EPROTO", __FUNCTION__);
+            return;
+        }
+
+        if (!(o = json_array_get (value, 0))
+            || !json_is_integer (o)) {
+            flux_log_error (jsctx->h, "%s: annotation EPROTO", __FUNCTION__);
+            return;
+        }
+
+        id = json_integer_value (o);
+
+        if (!(o = json_array_get (value, 1))
+            || (!json_is_object (o) && !json_is_null (o))) {
+            flux_log_error (jsctx->h, "%s: annotation EPROTO", __FUNCTION__);
+            return;
+        }
+
+        if ((job = zhashx_lookup (jsctx->index, &id))) {
+            json_decref (job->annotations);
+            if (json_is_null (o))
+                job->annotations = NULL;
+            else
+                job->annotations = json_incref (o);
+        }
+        else
+            flux_log_error (jsctx->h, "%s: job %ju not found",
+                            __FUNCTION__, (uintmax_t)id);
+    }
+
+}
+
+void job_annotations_cb (flux_t *h, flux_msg_handler_t *mh,
+                         const flux_msg_t *msg, void *arg)
+{
+    struct info_ctx *ctx = arg;
+    json_t *annotations;
+
+    if (flux_event_unpack (msg, NULL, "{s:o}",
+                           "annotations",
+                           &annotations) < 0) {
+        flux_log_error (h, "%s: flux_event_unpack", __FUNCTION__);
+        return;
+    }
+
+    update_annotations (ctx, annotations);
+
+    return;
+}
+
 void job_state_pause_cb (flux_t *h, flux_msg_handler_t *mh,
                          const flux_msg_t *msg, void *arg)
 {
@@ -1364,6 +1437,19 @@ static struct job *eventlog_restart_parse (struct info_ctx *ctx,
                 update_job_state (ctx, job, FLUX_JOB_CLEANUP, timestamp);
         }
         else if (!strcmp (name, "alloc")) {
+            /* context not required if no annotations */
+            if (context) {
+                json_t *annotations;
+                if (json_unpack (context,
+                                 "{ s:o }",
+                                 "annotations", &annotations) < 0) {
+                    flux_log_error (ctx->h, "%s: alloc context for %ju invalid",
+                                    __FUNCTION__, (uintmax_t)job->id);
+                    goto error;
+                }
+                job->annotations = json_incref (annotations);
+            }
+
             if (job->state == FLUX_JOB_SCHED)
                 update_job_state (ctx, job, FLUX_JOB_RUN, timestamp);
         }

--- a/src/modules/job-info/job_state.h
+++ b/src/modules/job-info/job_state.h
@@ -78,6 +78,7 @@ struct job {
     const char *exception_type;
     const char *exception_note;
     flux_job_result_t result;
+    json_t *annotations;
 
     /* cache of job information */
     json_t *jobspec_job;
@@ -122,6 +123,9 @@ void job_state_destroy (void *data);
 
 void job_state_cb (flux_t *h, flux_msg_handler_t *mh,
                    const flux_msg_t *msg, void *arg);
+
+void job_annotations_cb (flux_t *h, flux_msg_handler_t *mh,
+                         const flux_msg_t *msg, void *arg);
 
 void job_state_pause_cb (flux_t *h, flux_msg_handler_t *mh,
                          const flux_msg_t *msg, void *arg);

--- a/src/modules/job-info/job_util.c
+++ b/src/modules/job-info/job_util.c
@@ -156,6 +156,11 @@ json_t *job_to_json (struct job *job, json_t *attrs, job_info_error_t *errp)
                 continue;
             val = json_integer (job->result);
         }
+        else if (!strcmp (attr, "annotations")) {
+            if (!job->annotations)
+                continue;
+            val = json_incref (job->annotations);
+        }
         else {
             seterror (errp, "%s is not a valid attribute", attr);
             errno = EINVAL;

--- a/src/modules/job-info/list.c
+++ b/src/modules/job-info/list.c
@@ -570,7 +570,7 @@ void list_attrs_cb (flux_t *h, flux_msg_handler_t *mh,
                             "state", "name", "ntasks", "nnodes", "ranks",
                             "success", "exception_occurred", "exception_type",
                             "exception_severity", "exception_note", "result",
-                            "expiration", NULL };
+                            "expiration", "annotations", NULL };
     json_t *a = NULL;
     int i;
 

--- a/src/modules/job-manager/alloc.c
+++ b/src/modules/job-manager/alloc.c
@@ -180,6 +180,51 @@ int cancel_request (struct alloc *alloc, struct job *job)
     return 0;
 }
 
+/* we want to delete items set to 'null', so this is not the same
+ * as json_object_update_recursive() in jansson 2.13.1
+ */
+static void update_recursive (flux_t *h, struct job *job,
+                              json_t *orig, json_t *new)
+{
+    const char *key;
+    json_t *value;
+
+    json_object_foreach (new, key, value) {
+        if (!json_is_null (value)) {
+            json_t *orig_value = json_object_get (orig, key);
+
+            if (json_is_object (value)) {
+                if (!json_is_object (orig_value)) {
+                    json_t *o = json_object ();
+                    if (!o || json_object_set_new (orig, key, o) < 0) {
+                        flux_log (h,
+                                  LOG_ERR,
+                                  "%s: id=%ju create object=%s",
+                                  __FUNCTION__, (uintmax_t)job->id, key);
+                        json_decref (o);
+                        continue;
+                    }
+                    orig_value = o;
+                }
+                update_recursive (h, job, orig_value, value);
+                /* if object is now empty, remove it */
+                if (!json_object_size (orig_value))
+                    (void)json_object_del (orig, key);
+            }
+            else {
+                if (json_object_set (orig, key, value) < 0)
+                    flux_log (h,
+                              LOG_ERR,
+                              "%s: id=%ju update key=%s",
+                              __FUNCTION__, (uintmax_t)job->id, key);
+            }
+        }
+        else
+            /* not an error if key doesn't exist in orig */
+            (void)json_object_del (orig, key);
+    }
+}
+
 static void update_annotations (flux_t *h, struct job *job, flux_jobid_t id,
                                 json_t *annotations)
 {
@@ -192,21 +237,7 @@ static void update_annotations (flux_t *h, struct job *job, flux_jobid_t id,
                           __FUNCTION__, (uintmax_t)id);
         }
         if (job->annotations) {
-            const char *key;
-            json_t *value;
-
-            json_object_foreach (annotations, key, value) {
-                if (!json_is_null (value)) {
-                    if (json_object_set (job->annotations, key, value) < 0)
-                        flux_log (h,
-                                  LOG_ERR,
-                                  "%s: id=%ju update key=%s",
-                                  __FUNCTION__, (uintmax_t)id, key);
-                }
-                else
-                    /* not an error if key doesn't exist in job->annotations */
-                    (void)json_object_del (job->annotations, key);
-            }
+            update_recursive (h, job, job->annotations, annotations);
             /* Special case: if user cleared all entries, assume we no
              * longer need annotations object
              *

--- a/src/modules/job-manager/alloc.c
+++ b/src/modules/job-manager/alloc.c
@@ -51,11 +51,13 @@ struct alloc {
     unsigned int free_pending_count;
 };
 
-static void clear_annotations (struct job *job)
+static void clear_annotations (struct job *job, bool *cleared)
 {
     if (job->annotations) {
         json_decref (job->annotations);
         job->annotations = NULL;
+        if (cleared)
+            (*cleared) = true;
     }
 }
 
@@ -79,13 +81,16 @@ static void interface_teardown (struct alloc *alloc, char *s, int errnum)
             if (job->alloc_pending) {
                 bool fwd = job->priority > FLUX_JOB_PRIORITY_DEFAULT ? true
                                                                      : false;
+                bool cleared = false;
 
                 assert (job->handle == NULL);
                 if (!(job->handle = zlistx_insert (alloc->queue, job, fwd)))
                     flux_log_error (ctx->h, "%s: queue_insert", __FUNCTION__);
                 job->alloc_pending = 0;
                 job->alloc_queued = 1;
-                clear_annotations (job);
+                clear_annotations (job, &cleared);
+                if (cleared)
+                    event_batch_pub_annotations (ctx->event, job);
             }
             /* jobs with free request pending (much smaller window for this
              * to be true) need to be picked up again after 'ready'.
@@ -203,9 +208,14 @@ static void update_annotations (flux_t *h, struct job *job, flux_jobid_t id,
                     (void)json_object_del (job->annotations, key);
             }
             /* Special case: if user cleared all entries, assume we no
-             * longer need annotations object */
+             * longer need annotations object
+             *
+             * if cleared no need to call
+             * event_batch_pub_annotations(), should be handled by
+             * caller.
+             */
             if (!json_object_size (job->annotations))
-                clear_annotations (job);
+                clear_annotations (job, NULL);
         }
     }
 }
@@ -223,6 +233,7 @@ static void alloc_response_cb (flux_t *h, flux_msg_handler_t *mh,
     char *note = NULL;
     json_t *annotations = NULL;
     struct job *job;
+    bool cleared = false;
 
     if (flux_response_decode (msg, NULL, NULL) < 0)
         goto teardown; // ENOSYS here if scheduler not loaded/shutting down
@@ -257,6 +268,8 @@ static void alloc_response_cb (flux_t *h, flux_msg_handler_t *mh,
             goto teardown;
         }
         update_annotations (h, job, id, annotations);
+        if (annotations)
+            event_batch_pub_annotations (ctx->event, job);
         if (job->annotations) {
             if (event_job_post_pack (ctx->event, job, "alloc",
                                      "{ s:O }",
@@ -274,11 +287,14 @@ static void alloc_response_cb (flux_t *h, flux_msg_handler_t *mh,
             goto teardown;
         }
         update_annotations (h, job, id, annotations);
+        event_batch_pub_annotations (ctx->event, job);
         break;
     case FLUX_SCHED_ALLOC_DENY: // error
         alloc->alloc_pending_count--;
         job->alloc_pending = 0;
-        clear_annotations (job);
+        clear_annotations (job, &cleared);
+        if (cleared)
+            event_batch_pub_annotations (ctx->event, job);
         if (event_job_post_pack (ctx->event, job, "exception",
                                  "{ s:s s:i s:i s:s }",
                                  "type", "alloc",
@@ -290,7 +306,9 @@ static void alloc_response_cb (flux_t *h, flux_msg_handler_t *mh,
     case FLUX_SCHED_ALLOC_CANCEL:
         alloc->alloc_pending_count--;
         job->alloc_pending = 0;
-        clear_annotations (job);
+        clear_annotations (job, &cleared);
+        if (cleared)
+            event_batch_pub_annotations (ctx->event, job);
         if (event_job_action (ctx->event, job) < 0) {
             flux_log_error (h,
                             "event_job_action id=%ju on alloc cancel",

--- a/src/modules/job-manager/event.c
+++ b/src/modules/job-manager/event.c
@@ -183,7 +183,8 @@ void event_batch_destroy (struct event_batch *batch)
         if (batch->f)
             (void)flux_future_wait_for (batch->f, -1);
         if (batch->state_trans) {
-            event_publish_state (batch->event, batch->state_trans);
+            if (json_array_size (batch->state_trans) > 0)
+                event_publish_state (batch->event, batch->state_trans);
             json_decref (batch->state_trans);
         }
         if (batch->responses) {

--- a/src/modules/job-manager/event.h
+++ b/src/modules/job-manager/event.h
@@ -35,6 +35,10 @@ int event_job_update (struct job *job, json_t *event);
 int event_batch_pub_state (struct event *event, struct job *job,
                            double timestamp);
 
+/* Add notification of job's annotation change for publication.
+ */
+int event_batch_pub_annotations (struct event *event, struct job *job);
+
 /* Add add response to batch, to be sent upon batch completion.
  */
 int event_batch_respond (struct event *event, const flux_msg_t *msg);

--- a/src/modules/job-manager/raise.c
+++ b/src/modules/job-manager/raise.c
@@ -129,7 +129,7 @@ void raise_handle_request (flux_t *h,
     }
     if (!(job = zhashx_lookup (ctx->active_jobs, &id))) {
         errstr = "unknown job id";
-        errno = EINVAL;
+        errno = ENOENT;
         goto error;
     }
     if (flux_msg_cred_authorize (cred, job->userid) < 0) {

--- a/src/modules/sched-simple/sched.c
+++ b/src/modules/sched-simple/sched.c
@@ -217,8 +217,8 @@ static int try_alloc (flux_t *h, struct simple_sched *ss)
     if (schedutil_alloc_respond_success_pack (ss->util_ctx,
                                               job->msg,
                                               R,
-                                              "{ s:s }",
-                                              "sched.resource_summary", s) < 0)
+                                              "{ s:{s:s} }",
+                                              "sched", "resource_summary", s) < 0)
         flux_log_error (h, "schedutil_alloc_respond_success_pack");
 
     flux_log (h, LOG_DEBUG, "alloc: %ju: %s", (uintmax_t) job->id, s);

--- a/t/job-manager/sched-dummy.c
+++ b/t/job-manager/sched-dummy.c
@@ -94,8 +94,8 @@ static void respond_success_single (struct sched_ctx *sc,
     if (schedutil_alloc_respond_success_pack (sc->schedutil_ctx,
                                               job->msg,
                                               "1core",
-                                              "{ s:n }",
-                                              "sched.reason_pending") < 0)
+                                              "{ s:{s:n} }",
+                                              "sched", "reason_pending") < 0)
         flux_log_error (sc->h, "schedutil_alloc_respond_success_pack");
 }
 
@@ -105,10 +105,11 @@ static void respond_success_unlimited (struct sched_ctx *sc,
     if (schedutil_alloc_respond_success_pack (sc->schedutil_ctx,
                                               job->msg,
                                               "1core",
-                                              "{ s:s s:n s:n }",
-                                              "sched.resource_summary", "1core",
-                                              "sched.reason_pending",
-                                              "sched.jobs_ahead") < 0)
+                                              "{ s:{s:s s:n s:n} }",
+                                              "sched",
+                                              "resource_summary", "1core",
+                                              "reason_pending",
+                                              "jobs_ahead") < 0)
         flux_log_error (sc->h, "schedutil_alloc_respond_success_pack");
 }
 
@@ -117,8 +118,8 @@ static void respond_annotate_single (struct sched_ctx *sc,
 {
     if (schedutil_alloc_respond_annotate_pack (sc->schedutil_ctx,
                                                job->msg,
-                                               "{ s:s }",
-                                               "sched.reason_pending",
+                                               "{ s:{s:s} }",
+                                               "sched", "reason_pending",
                                                "no cores available") < 0)
         flux_log_error (sc->h, "schedutil_alloc_respond_annotate_pack");
 }
@@ -130,18 +131,19 @@ static void respond_annotate_unlimited (struct sched_ctx *sc,
     if (job->annotate_count) {
         if (schedutil_alloc_respond_annotate_pack (sc->schedutil_ctx,
                                                    job->msg,
-                                                   "{ s:i }",
-                                                   "sched.jobs_ahead",
+                                                   "{ s:{s:i} }",
+                                                   "sched", "jobs_ahead",
                                                    jobs_ahead_count) < 0)
             flux_log_error (sc->h, "schedutil_alloc_respond_annotate_pack");
     }
     else {
         if (schedutil_alloc_respond_annotate_pack (sc->schedutil_ctx,
                                                    job->msg,
-                                                   "{ s:s s:i }",
-                                                   "sched.reason_pending",
+                                                   "{ s:{s:s s:i} }",
+                                                   "sched",
+                                                   "reason_pending",
                                                    "no cores",
-                                                   "sched.jobs_ahead",
+                                                   "jobs_ahead",
                                                    jobs_ahead_count) < 0)
             flux_log_error (sc->h, "schedutil_alloc_respond_annotate_pack");
     }

--- a/t/job-manager/sched-helper.sh
+++ b/t/job-manager/sched-helper.sh
@@ -3,51 +3,51 @@
 
 # job-manager sched helper functions
 
-LIST_JOBS=${FLUX_BUILD_DIR}/t/job-manager/list-jobs
+JMGR_JOB_LIST=${FLUX_BUILD_DIR}/t/job-manager/list-jobs
 
-# internal function to get job state
+# internal function to get job state via job manager
 #
 # if job is not found by list-jobs, but the clean event exists
 # in the job's eventlog, return state as inactive
 #
 # arg1 - jobid
-_get_state() {
+_jmgr_get_state() {
         local id=$1
-        local state=$(${LIST_JOBS} | awk '$1 == "'${id}'" { print $2; }')
+        local state=$(${JMGR_JOB_LIST} | awk '$1 == "'${id}'" { print $2; }')
         test -z "$state" \
                 && flux job wait-event --timeout=5 ${id} clean >/dev/null \
                 && state=I
         echo $state
 }
 
-# verify if job is in specific state
+# verify if job is in specific state through job manager
 #
 # function will loop for up to 5 seconds in case state change is slow
 #
 # arg1 - jobid
 # arg2 - single character expected state (e.g. R = running)
-check_state() {
+jmgr_check_state() {
         local id=$1
         local wantstate=$2
         for try in $(seq 1 10); do
-                test $(_get_state $id) = $wantstate && return 0
+                test $(_jmgr_get_state $id) = $wantstate && return 0
                 sleep 0.5
         done
         return 1
 }
 
-# internal function to get job annotation key value
+# internal function to get job annotation key value via job manager
 #
 # arg1 - jobid
 # arg2 - key
-_get_annotation() {
+_jmgr_get_annotation() {
         local id=$1
         local key=$2
-        local note="$(${LIST_JOBS} | grep ${id} | cut -f 6- | jq .\"${key}\")"
+        local note="$(${JMGR_JOB_LIST} | grep ${id} | cut -f 6- | jq .\"${key}\")"
         echo $note
 }
 
-# verify if job contains specific annotation key & value
+# verify if job contains specific annotation key & value through job manager
 #
 # function will loop for up to 5 seconds in case annotation update
 # arrives slowly
@@ -57,34 +57,34 @@ _get_annotation() {
 # arg3 - value of key in annotation
 #
 # callers should set HAVE_JQ requirement
-check_annotation() {
+jmgr_check_annotation() {
         local id=$1
         local key=$2
         local value="$3"
         for try in $(seq 1 10); do
-                test "$(_get_annotation $id $key)" = "${value}" && return 0
+                test "$(_jmgr_get_annotation $id $key)" = "${value}" && return 0
                 sleep 0.5
         done
         return 1
 }
 
-# verify if job contains specific annotation key
+# verify if job contains specific annotation key through job manager
 #
 # arg1 - jobid
 # arg2 - key in annotation
 #
 # callers should set HAVE_JQ requirement
-check_annotation_exists() {
+jmgr_check_annotation_exists() {
         local id=$1
         local key=$2
-        ${LIST_JOBS} | grep ${id} | cut -f 6- | jq -e .\"${key}\" > /dev/null
+        ${JMGR_JOB_LIST} | grep ${id} | cut -f 6- | jq -e .\"${key}\" > /dev/null
 }
 
-# verify that job contains no annotations
+# verify that job contains no annotations through job manager
 #
 # arg1 - jobid
-check_no_annotations() {
+jmgr_check_no_annotations() {
         local id=$1
-        test -z "$(${LIST_JOBS} | grep ${id} | cut -f 6-)" && return 0
+        test -z "$(${JMGR_JOB_LIST} | grep ${id} | cut -f 6-)" && return 0
         return 1
 }

--- a/t/job-manager/sched-helper.sh
+++ b/t/job-manager/sched-helper.sh
@@ -43,7 +43,7 @@ jmgr_check_state() {
 _jmgr_get_annotation() {
         local id=$1
         local key=$2
-        local note="$(${JMGR_JOB_LIST} | grep ${id} | cut -f 6- | jq .\"${key}\")"
+        local note="$(${JMGR_JOB_LIST} | grep ${id} | cut -f 6- | jq ."${key}")"
         echo $note
 }
 
@@ -77,7 +77,7 @@ jmgr_check_annotation() {
 jmgr_check_annotation_exists() {
         local id=$1
         local key=$2
-        ${JMGR_JOB_LIST} | grep ${id} | cut -f 6- | jq -e .\"${key}\" > /dev/null
+        ${JMGR_JOB_LIST} | grep ${id} | cut -f 6- | jq -e ."${key}" > /dev/null
 }
 
 # verify that job contains no annotations through job manager
@@ -96,7 +96,7 @@ jmgr_check_no_annotations() {
 _jinfo_get_annotation() {
         local id=$1
         local key=$2
-        local note="$(flux job list -A | grep ${id} | jq .annotations | jq .\"${key}\")"
+        local note="$(flux job list -A | grep ${id} | jq .annotations | jq ."${key}")"
         echo $note
 }
 
@@ -141,5 +141,5 @@ jinfo_check_no_annotations() {
 jinfo_check_annotation_exists() {
         local id=$1
         local key=$2
-        flux job list -A | grep ${id} | jq .annotations | jq -e .\"${key}\" > /dev/null
+        flux job list -A | grep ${id} | jq .annotations | jq -e ."${key}" > /dev/null
 }

--- a/t/job-manager/sched-helper.sh
+++ b/t/job-manager/sched-helper.sh
@@ -88,3 +88,58 @@ jmgr_check_no_annotations() {
         test -z "$(${JMGR_JOB_LIST} | grep ${id} | cut -f 6-)" && return 0
         return 1
 }
+
+# internal function to get job annotation key value via flux job list
+#
+# arg1 - jobid
+# arg2 - key
+_jinfo_get_annotation() {
+        local id=$1
+        local key=$2
+        local note="$(flux job list -A | grep ${id} | jq .annotations | jq .\"${key}\")"
+        echo $note
+}
+
+# verify if annotation published to job-info
+#
+# function will loop for up to 5 seconds in case annotation update
+# arrives slowly
+#
+# arg1 - jobid
+# arg2 - key in annotation
+# arg3 - value of key in annotation
+#
+# callers should set HAVE_JQ requirement
+jinfo_check_annotation() {
+        local id=$1
+        local key=$2
+        local value="$3"
+        for try in $(seq 1 10); do
+                test "$(_jinfo_get_annotation $id $key)" = "${value}" && return 0
+                sleep 0.5
+        done
+        return 1
+}
+
+# verify that job contains no annotations via job-info
+#
+# arg1 - jobid
+#
+# callers should set HAVE_JQ requirement
+jinfo_check_no_annotations() {
+        local id=$1
+        flux job list -A | grep ${id} | jq -e .annotations > /dev/null && return 1
+        return 0
+}
+
+# verify if job contains specific annotation key through job-info
+#
+# arg1 - jobid
+# arg2 - key in annotation
+#
+# callers should set HAVE_JQ requirement
+jinfo_check_annotation_exists() {
+        local id=$1
+        local key=$2
+        flux job list -A | grep ${id} | jq .annotations | jq -e .\"${key}\" > /dev/null
+}

--- a/t/t2203-job-manager-dummysched-single.t
+++ b/t/t2203-job-manager-dummysched-single.t
@@ -32,19 +32,19 @@ test_expect_success 'job-manager: submit 5 jobs' '
 '
 
 test_expect_success 'job-manager: job state SSSSS (no scheduler)' '
-        check_state $(cat job1.id) S &&
-        check_state $(cat job2.id) S &&
-        check_state $(cat job3.id) S &&
-        check_state $(cat job4.id) S &&
-        check_state $(cat job5.id) S
+        jmgr_check_state $(cat job1.id) S &&
+        jmgr_check_state $(cat job2.id) S &&
+        jmgr_check_state $(cat job3.id) S &&
+        jmgr_check_state $(cat job4.id) S &&
+        jmgr_check_state $(cat job5.id) S
 '
 
 test_expect_success HAVE_JQ 'job-manager: no annotations (SSSSS)' '
-        check_no_annotations $(cat job1.id) &&
-        check_no_annotations $(cat job2.id) &&
-        check_no_annotations $(cat job3.id) &&
-        check_no_annotations $(cat job4.id) &&
-        check_no_annotations $(cat job5.id)
+        jmgr_check_no_annotations $(cat job1.id) &&
+        jmgr_check_no_annotations $(cat job2.id) &&
+        jmgr_check_no_annotations $(cat job3.id) &&
+        jmgr_check_no_annotations $(cat job4.id) &&
+        jmgr_check_no_annotations $(cat job5.id)
 '
 
 test_expect_success 'job-manager: load sched-dummy --cores=2' '
@@ -52,19 +52,19 @@ test_expect_success 'job-manager: load sched-dummy --cores=2' '
 '
 
 test_expect_success 'job-manager: job state RRSSS' '
-        check_state $(cat job1.id) R &&
-        check_state $(cat job2.id) R &&
-        check_state $(cat job3.id) S &&
-        check_state $(cat job4.id) S &&
-        check_state $(cat job5.id) S
+        jmgr_check_state $(cat job1.id) R &&
+        jmgr_check_state $(cat job2.id) R &&
+        jmgr_check_state $(cat job3.id) S &&
+        jmgr_check_state $(cat job4.id) S &&
+        jmgr_check_state $(cat job5.id) S
 '
 
 test_expect_success HAVE_JQ 'job-manager: annotate job id 3 (RRSSS)' '
-        check_no_annotations $(cat job1.id) &&
-        check_no_annotations $(cat job2.id) &&
-        check_annotation $(cat job3.id) "sched.reason_pending" "\"no cores available\"" &&
-        check_no_annotations $(cat job4.id) &&
-        check_no_annotations $(cat job5.id)
+        jmgr_check_no_annotations $(cat job1.id) &&
+        jmgr_check_no_annotations $(cat job2.id) &&
+        jmgr_check_annotation $(cat job3.id) "sched.reason_pending" "\"no cores available\"" &&
+        jmgr_check_no_annotations $(cat job4.id) &&
+        jmgr_check_no_annotations $(cat job5.id)
 '
 
 test_expect_success 'job-manager: running job has alloc event' '
@@ -76,19 +76,19 @@ test_expect_success 'job-manager: cancel 2' '
 '
 
 test_expect_success 'job-manager: job state RIRSS' '
-        check_state $(cat job1.id) R &&
-        check_state $(cat job2.id) I &&
-        check_state $(cat job3.id) R &&
-        check_state $(cat job4.id) S &&
-        check_state $(cat job5.id) S
+        jmgr_check_state $(cat job1.id) R &&
+        jmgr_check_state $(cat job2.id) I &&
+        jmgr_check_state $(cat job3.id) R &&
+        jmgr_check_state $(cat job4.id) S &&
+        jmgr_check_state $(cat job5.id) S
 '
 
 test_expect_success HAVE_JQ 'job-manager: annotate job id 4 (RIRSS)' '
-        check_no_annotations $(cat job1.id) &&
-        check_no_annotations $(cat job2.id) &&
-        check_no_annotations $(cat job3.id) &&
-        check_annotation $(cat job4.id) "sched.reason_pending" "\"no cores available\"" &&
-        check_no_annotations $(cat job5.id)
+        jmgr_check_no_annotations $(cat job1.id) &&
+        jmgr_check_no_annotations $(cat job2.id) &&
+        jmgr_check_no_annotations $(cat job3.id) &&
+        jmgr_check_annotation $(cat job4.id) "sched.reason_pending" "\"no cores available\"" &&
+        jmgr_check_no_annotations $(cat job5.id)
 '
 
 test_expect_success 'job-manager: first S job sent alloc, second S did not' '
@@ -121,19 +121,19 @@ test_expect_success 'job-manager: hello handshake userid is expected' '
 '
 
 test_expect_success 'job-manager: job state RIRRR' '
-        check_state $(cat job1.id) R &&
-        check_state $(cat job2.id) I &&
-        check_state $(cat job3.id) R &&
-        check_state $(cat job4.id) R &&
-        check_state $(cat job5.id) R
+        jmgr_check_state $(cat job1.id) R &&
+        jmgr_check_state $(cat job2.id) I &&
+        jmgr_check_state $(cat job3.id) R &&
+        jmgr_check_state $(cat job4.id) R &&
+        jmgr_check_state $(cat job5.id) R
 '
 
 test_expect_success HAVE_JQ 'job-manager: no annotations (RIRRR)' '
-        check_no_annotations $(cat job1.id) &&
-        check_no_annotations $(cat job2.id) &&
-        check_no_annotations $(cat job3.id) &&
-        check_no_annotations $(cat job4.id) &&
-        check_no_annotations $(cat job5.id)
+        jmgr_check_no_annotations $(cat job1.id) &&
+        jmgr_check_no_annotations $(cat job2.id) &&
+        jmgr_check_no_annotations $(cat job3.id) &&
+        jmgr_check_no_annotations $(cat job4.id) &&
+        jmgr_check_no_annotations $(cat job5.id)
 '
 
 test_expect_success 'job-manager: cancel 1' '
@@ -141,11 +141,11 @@ test_expect_success 'job-manager: cancel 1' '
 '
 
 test_expect_success 'job-manager: job state IIRRR' '
-        check_state $(cat job1.id) I &&
-        check_state $(cat job2.id) I &&
-        check_state $(cat job3.id) R &&
-        check_state $(cat job4.id) R &&
-        check_state $(cat job5.id) R
+        jmgr_check_state $(cat job1.id) I &&
+        jmgr_check_state $(cat job2.id) I &&
+        jmgr_check_state $(cat job3.id) R &&
+        jmgr_check_state $(cat job4.id) R &&
+        jmgr_check_state $(cat job5.id) R
 '
 
 test_expect_success 'job-manager: cancel all jobs' '
@@ -155,19 +155,19 @@ test_expect_success 'job-manager: cancel all jobs' '
 '
 
 test_expect_success 'job-manager: job state IIIII' '
-        check_state $(cat job1.id) I &&
-        check_state $(cat job2.id) I &&
-        check_state $(cat job3.id) I &&
-        check_state $(cat job4.id) I &&
-        check_state $(cat job5.id) I
+        jmgr_check_state $(cat job1.id) I &&
+        jmgr_check_state $(cat job2.id) I &&
+        jmgr_check_state $(cat job3.id) I &&
+        jmgr_check_state $(cat job4.id) I &&
+        jmgr_check_state $(cat job5.id) I
 '
 
 test_expect_success HAVE_JQ 'job-manager: no annotations (IIIII)' '
-        check_no_annotations $(cat job1.id) &&
-        check_no_annotations $(cat job2.id) &&
-        check_no_annotations $(cat job3.id) &&
-        check_no_annotations $(cat job4.id) &&
-        check_no_annotations $(cat job5.id)
+        jmgr_check_no_annotations $(cat job1.id) &&
+        jmgr_check_no_annotations $(cat job2.id) &&
+        jmgr_check_no_annotations $(cat job3.id) &&
+        jmgr_check_no_annotations $(cat job4.id) &&
+        jmgr_check_no_annotations $(cat job5.id)
 '
 
 test_expect_success 'job-manager: simulate alloc failure' '

--- a/t/t2203-job-manager-dummysched-single.t
+++ b/t/t2203-job-manager-dummysched-single.t
@@ -75,6 +75,14 @@ test_expect_success HAVE_JQ 'job-manager: annotate job id 3 in job-info (RRSSS)'
         jinfo_check_no_annotations $(cat job5.id)
 '
 
+test_expect_success 'job-manager: annotate job id 3 in flux-jobs (RRSSS)' '
+        fjobs_check_no_annotations $(cat job1.id) &&
+        fjobs_check_no_annotations $(cat job2.id) &&
+        fjobs_check_annotation $(cat job3.id) "annotations.sched.reason_pending" "no cores available" &&
+        fjobs_check_no_annotations $(cat job4.id) &&
+        fjobs_check_no_annotations $(cat job5.id)
+'
+
 test_expect_success 'job-manager: running job has alloc event' '
         flux job wait-event --timeout=5.0 $(cat job1.id) alloc
 '
@@ -99,12 +107,12 @@ test_expect_success HAVE_JQ 'job-manager: annotate job id 4 (RIRSS)' '
         jmgr_check_no_annotations $(cat job5.id)
 '
 
-test_expect_success HAVE_JQ 'job-manager: annotate job id 4 in job-info (RRSSS)' '
-        jinfo_check_no_annotations $(cat job1.id) &&
-        jinfo_check_no_annotations $(cat job2.id) &&
-        jinfo_check_no_annotations $(cat job3.id) &&
-        jinfo_check_annotation $(cat job4.id) "sched.reason_pending" "\"no cores available\"" &&
-        jinfo_check_no_annotations $(cat job5.id)
+test_expect_success 'job-manager: annotate job id 4 in flux jobs (RRSSS)' '
+        fjobs_check_no_annotations $(cat job1.id) &&
+        fjobs_check_no_annotations $(cat job2.id) &&
+        fjobs_check_no_annotations $(cat job3.id) &&
+        fjobs_check_annotation $(cat job4.id) "annotations.sched.reason_pending" "no cores available" &&
+        fjobs_check_no_annotations $(cat job5.id)
 '
 
 test_expect_success 'job-manager: first S job sent alloc, second S did not' '
@@ -160,6 +168,14 @@ test_expect_success HAVE_JQ 'job-manager: no annotations in job-info (RIRRR)' '
         jinfo_check_no_annotations $(cat job5.id)
 '
 
+test_expect_success 'job-manager: no annotations in flux jobs (RIRRR)' '
+        fjobs_check_no_annotations $(cat job1.id) &&
+        fjobs_check_no_annotations $(cat job2.id) &&
+        fjobs_check_no_annotations $(cat job3.id) &&
+        fjobs_check_no_annotations $(cat job4.id) &&
+        fjobs_check_no_annotations $(cat job5.id)
+'
+
 test_expect_success 'job-manager: cancel 1' '
         flux job cancel $(cat job1.id)
 '
@@ -200,6 +216,14 @@ test_expect_success HAVE_JQ 'job-manager: no annotations in job-info (IIIII)' '
         jinfo_check_no_annotations $(cat job3.id) &&
         jinfo_check_no_annotations $(cat job4.id) &&
         jinfo_check_no_annotations $(cat job5.id)
+'
+
+test_expect_success 'job-manager: no annotations in flux jobs (IIIII)' '
+        fjobs_check_no_annotations $(cat job1.id) &&
+        fjobs_check_no_annotations $(cat job2.id) &&
+        fjobs_check_no_annotations $(cat job3.id) &&
+        fjobs_check_no_annotations $(cat job4.id) &&
+        fjobs_check_no_annotations $(cat job5.id)
 '
 
 test_expect_success 'job-manager: simulate alloc failure' '

--- a/t/t2203-job-manager-dummysched-single.t
+++ b/t/t2203-job-manager-dummysched-single.t
@@ -62,7 +62,7 @@ test_expect_success 'job-manager: job state RRSSS' '
 test_expect_success HAVE_JQ 'job-manager: annotate job id 3 (RRSSS)' '
         check_no_annotations $(cat job1.id) &&
         check_no_annotations $(cat job2.id) &&
-        check_annotation $(cat job3.id) "sched.reason_pending" "\"no cores available\""&&
+        check_annotation $(cat job3.id) "sched.reason_pending" "\"no cores available\"" &&
         check_no_annotations $(cat job4.id) &&
         check_no_annotations $(cat job5.id)
 '

--- a/t/t2203-job-manager-dummysched-single.t
+++ b/t/t2203-job-manager-dummysched-single.t
@@ -67,6 +67,14 @@ test_expect_success HAVE_JQ 'job-manager: annotate job id 3 (RRSSS)' '
         jmgr_check_no_annotations $(cat job5.id)
 '
 
+test_expect_success HAVE_JQ 'job-manager: annotate job id 3 in job-info (RRSSS)' '
+        jinfo_check_no_annotations $(cat job1.id) &&
+        jinfo_check_no_annotations $(cat job2.id) &&
+        jinfo_check_annotation $(cat job3.id) "sched.reason_pending" "\"no cores available\"" &&
+        jinfo_check_no_annotations $(cat job4.id) &&
+        jinfo_check_no_annotations $(cat job5.id)
+'
+
 test_expect_success 'job-manager: running job has alloc event' '
         flux job wait-event --timeout=5.0 $(cat job1.id) alloc
 '
@@ -89,6 +97,14 @@ test_expect_success HAVE_JQ 'job-manager: annotate job id 4 (RIRSS)' '
         jmgr_check_no_annotations $(cat job3.id) &&
         jmgr_check_annotation $(cat job4.id) "sched.reason_pending" "\"no cores available\"" &&
         jmgr_check_no_annotations $(cat job5.id)
+'
+
+test_expect_success HAVE_JQ 'job-manager: annotate job id 4 in job-info (RRSSS)' '
+        jinfo_check_no_annotations $(cat job1.id) &&
+        jinfo_check_no_annotations $(cat job2.id) &&
+        jinfo_check_no_annotations $(cat job3.id) &&
+        jinfo_check_annotation $(cat job4.id) "sched.reason_pending" "\"no cores available\"" &&
+        jinfo_check_no_annotations $(cat job5.id)
 '
 
 test_expect_success 'job-manager: first S job sent alloc, second S did not' '
@@ -136,6 +152,14 @@ test_expect_success HAVE_JQ 'job-manager: no annotations (RIRRR)' '
         jmgr_check_no_annotations $(cat job5.id)
 '
 
+test_expect_success HAVE_JQ 'job-manager: no annotations in job-info (RIRRR)' '
+        jinfo_check_no_annotations $(cat job1.id) &&
+        jinfo_check_no_annotations $(cat job2.id) &&
+        jinfo_check_no_annotations $(cat job3.id) &&
+        jinfo_check_no_annotations $(cat job4.id) &&
+        jinfo_check_no_annotations $(cat job5.id)
+'
+
 test_expect_success 'job-manager: cancel 1' '
         flux job cancel $(cat job1.id)
 '
@@ -168,6 +192,14 @@ test_expect_success HAVE_JQ 'job-manager: no annotations (IIIII)' '
         jmgr_check_no_annotations $(cat job3.id) &&
         jmgr_check_no_annotations $(cat job4.id) &&
         jmgr_check_no_annotations $(cat job5.id)
+'
+
+test_expect_success HAVE_JQ 'job-manager: no annotations in job-info (IIIII)' '
+        jinfo_check_no_annotations $(cat job1.id) &&
+        jinfo_check_no_annotations $(cat job2.id) &&
+        jinfo_check_no_annotations $(cat job3.id) &&
+        jinfo_check_no_annotations $(cat job4.id) &&
+        jinfo_check_no_annotations $(cat job5.id)
 '
 
 test_expect_success 'job-manager: simulate alloc failure' '

--- a/t/t2204-job-manager-dummysched-unlimited.t
+++ b/t/t2204-job-manager-dummysched-unlimited.t
@@ -70,6 +70,17 @@ test_expect_success HAVE_JQ 'job-manager: annotate job id 3-5 (RRSSS)' '
         jmgr_check_annotation $(cat job5.id) "sched.jobs_ahead" "2"
 '
 
+test_expect_success HAVE_JQ 'job-manager: annotate job id 3-5 in job-info (RRSSS)' '
+        jinfo_check_annotation $(cat job1.id) "sched.resource_summary" "\"1core\"" &&
+        jinfo_check_annotation $(cat job2.id) "sched.resource_summary" "\"1core\"" &&
+        jinfo_check_annotation $(cat job3.id) "sched.reason_pending" "\"no cores\"" &&
+        jinfo_check_annotation $(cat job3.id) "sched.jobs_ahead" "0" &&
+        jinfo_check_annotation $(cat job4.id) "sched.reason_pending" "\"no cores\"" &&
+        jinfo_check_annotation $(cat job4.id) "sched.jobs_ahead" "1" &&
+        jinfo_check_annotation $(cat job5.id) "sched.reason_pending" "\"no cores\"" &&
+        jinfo_check_annotation $(cat job5.id) "sched.jobs_ahead" "2"
+'
+
 test_expect_success 'job-manager: cancel 2' '
         flux job cancel $(cat job2.id)
 '
@@ -92,6 +103,20 @@ test_expect_success HAVE_JQ 'job-manager: annotate job id 4-5 (RIRSS)' '
         jmgr_check_annotation $(cat job4.id) "sched.jobs_ahead" "0" &&
         jmgr_check_annotation $(cat job5.id) "sched.reason_pending" "\"no cores\"" &&
         jmgr_check_annotation $(cat job5.id) "sched.jobs_ahead" "1"
+'
+
+# compared to above, note that job id #2 retains annotations, it is
+# cached in job-info
+test_expect_success HAVE_JQ 'job-manager: annotate job id 4-5 in job-info (RIRSS)' '
+        jinfo_check_annotation $(cat job1.id) "sched.resource_summary" "\"1core\"" &&
+        jinfo_check_annotation $(cat job2.id) "sched.resource_summary" "\"1core\"" &&
+        jinfo_check_annotation $(cat job3.id) "sched.resource_summary" "\"1core\"" &&
+        test_must_fail jinfo_check_annotation_exists $(cat job3.id) "sched.reason_pending" &&
+        test_must_fail jinfo_check_annotation_exists $(cat job3.id) "sched.jobs_ahead" &&
+        jinfo_check_annotation $(cat job4.id) "sched.reason_pending" "\"no cores\"" &&
+        jinfo_check_annotation $(cat job4.id) "sched.jobs_ahead" "0" &&
+        jinfo_check_annotation $(cat job5.id) "sched.reason_pending" "\"no cores\"" &&
+        jinfo_check_annotation $(cat job5.id) "sched.jobs_ahead" "1"
 '
 
 test_expect_success 'job-manager: cancel 5' '
@@ -117,10 +142,25 @@ test_expect_success HAVE_JQ 'job-manager: annotate job id 4 (RIRSI)' '
         jmgr_check_no_annotations $(cat job5.id)
 '
 
+# compared to above, note that job id #2 retains annotations, it is
+# cached in job-info
+test_expect_success HAVE_JQ 'job-manager: annotate job id 4-5 in job-info (RIRSS)' '
+        jinfo_check_annotation $(cat job1.id) "sched.resource_summary" "\"1core\"" &&
+        jinfo_check_annotation $(cat job2.id) "sched.resource_summary" "\"1core\"" &&
+        jinfo_check_annotation $(cat job3.id) "sched.resource_summary" "\"1core\"" &&
+        test_must_fail jinfo_check_annotation_exists $(cat job3.id) "sched.reason_pending" &&
+        test_must_fail jinfo_check_annotation_exists $(cat job3.id) "sched.jobs_ahead" &&
+        jinfo_check_annotation $(cat job4.id) "sched.reason_pending" "\"no cores\"" &&
+        jinfo_check_annotation $(cat job4.id) "sched.jobs_ahead" "0" &&
+        jinfo_check_no_annotations $(cat job5.id)
+'
+
+# cancel non-running jobs first, to ensure they are not accidentally run when
+# running jobs free resources.
 test_expect_success 'job-manager: cancel all jobs' '
-        flux job cancel $(cat job1.id) &&
+        flux job cancel $(cat job4.id) &&
         flux job cancel $(cat job3.id) &&
-        flux job cancel $(cat job4.id)
+        flux job cancel $(cat job1.id)
 '
 
 test_expect_success 'job-manager: job state IIIII' '
@@ -137,6 +177,15 @@ test_expect_success HAVE_JQ 'job-manager: no annotations (IIIII)' '
         jmgr_check_no_annotations $(cat job3.id) &&
         jmgr_check_no_annotations $(cat job4.id) &&
         jmgr_check_no_annotations $(cat job5.id)
+'
+
+# compared to above, note that job ids that ran retain annotations
+test_expect_success HAVE_JQ 'job-manager: no annotations in canceled jobs in job-info (IIIII)' '
+        jinfo_check_annotation $(cat job1.id) "sched.resource_summary" "\"1core\"" &&
+        jinfo_check_annotation $(cat job2.id) "sched.resource_summary" "\"1core\"" &&
+        jinfo_check_annotation $(cat job3.id) "sched.resource_summary" "\"1core\"" &&
+        jinfo_check_no_annotations $(cat job4.id) &&
+        jinfo_check_no_annotations $(cat job5.id)
 '
 
 test_expect_success 'job-manager: remove sched-dummy' '

--- a/t/t2204-job-manager-dummysched-unlimited.t
+++ b/t/t2204-job-manager-dummysched-unlimited.t
@@ -32,19 +32,19 @@ test_expect_success 'job-manager: submit 5 jobs' '
 '
 
 test_expect_success 'job-manager: job state SSSSS (no scheduler)' '
-        check_state $(cat job1.id) S &&
-        check_state $(cat job2.id) S &&
-        check_state $(cat job3.id) S &&
-        check_state $(cat job4.id) S &&
-        check_state $(cat job5.id) S
+        jmgr_check_state $(cat job1.id) S &&
+        jmgr_check_state $(cat job2.id) S &&
+        jmgr_check_state $(cat job3.id) S &&
+        jmgr_check_state $(cat job4.id) S &&
+        jmgr_check_state $(cat job5.id) S
 '
 
 test_expect_success HAVE_JQ 'job-manager: no annotations (SSSSS)' '
-        check_no_annotations $(cat job1.id) &&
-        check_no_annotations $(cat job2.id) &&
-        check_no_annotations $(cat job3.id) &&
-        check_no_annotations $(cat job4.id) &&
-        check_no_annotations $(cat job5.id)
+        jmgr_check_no_annotations $(cat job1.id) &&
+        jmgr_check_no_annotations $(cat job2.id) &&
+        jmgr_check_no_annotations $(cat job3.id) &&
+        jmgr_check_no_annotations $(cat job4.id) &&
+        jmgr_check_no_annotations $(cat job5.id)
 '
 
 test_expect_success 'job-manager: load sched-dummy --cores=2' '
@@ -52,22 +52,22 @@ test_expect_success 'job-manager: load sched-dummy --cores=2' '
 '
 
 test_expect_success 'job-manager: job state RRSSS' '
-        check_state $(cat job1.id) R &&
-        check_state $(cat job2.id) R &&
-        check_state $(cat job3.id) S &&
-        check_state $(cat job4.id) S &&
-        check_state $(cat job5.id) S
+        jmgr_check_state $(cat job1.id) R &&
+        jmgr_check_state $(cat job2.id) R &&
+        jmgr_check_state $(cat job3.id) S &&
+        jmgr_check_state $(cat job4.id) S &&
+        jmgr_check_state $(cat job5.id) S
 '
 
 test_expect_success HAVE_JQ 'job-manager: annotate job id 3-5 (RRSSS)' '
-        check_annotation $(cat job1.id) "sched.resource_summary" "\"1core\"" &&
-        check_annotation $(cat job2.id) "sched.resource_summary" "\"1core\"" &&
-        check_annotation $(cat job3.id) "sched.reason_pending" "\"no cores\"" &&
-        check_annotation $(cat job3.id) "sched.jobs_ahead" "0" &&
-        check_annotation $(cat job4.id) "sched.reason_pending" "\"no cores\"" &&
-        check_annotation $(cat job4.id) "sched.jobs_ahead" "1" &&
-        check_annotation $(cat job5.id) "sched.reason_pending" "\"no cores\"" &&
-        check_annotation $(cat job5.id) "sched.jobs_ahead" "2"
+        jmgr_check_annotation $(cat job1.id) "sched.resource_summary" "\"1core\"" &&
+        jmgr_check_annotation $(cat job2.id) "sched.resource_summary" "\"1core\"" &&
+        jmgr_check_annotation $(cat job3.id) "sched.reason_pending" "\"no cores\"" &&
+        jmgr_check_annotation $(cat job3.id) "sched.jobs_ahead" "0" &&
+        jmgr_check_annotation $(cat job4.id) "sched.reason_pending" "\"no cores\"" &&
+        jmgr_check_annotation $(cat job4.id) "sched.jobs_ahead" "1" &&
+        jmgr_check_annotation $(cat job5.id) "sched.reason_pending" "\"no cores\"" &&
+        jmgr_check_annotation $(cat job5.id) "sched.jobs_ahead" "2"
 '
 
 test_expect_success 'job-manager: cancel 2' '
@@ -75,23 +75,23 @@ test_expect_success 'job-manager: cancel 2' '
 '
 
 test_expect_success 'job-manager: job state RIRSS' '
-        check_state $(cat job1.id) R &&
-        check_state $(cat job2.id) I &&
-        check_state $(cat job3.id) R &&
-        check_state $(cat job4.id) S &&
-        check_state $(cat job5.id) S
+        jmgr_check_state $(cat job1.id) R &&
+        jmgr_check_state $(cat job2.id) I &&
+        jmgr_check_state $(cat job3.id) R &&
+        jmgr_check_state $(cat job4.id) S &&
+        jmgr_check_state $(cat job5.id) S
 '
 
 test_expect_success HAVE_JQ 'job-manager: annotate job id 4-5 (RIRSS)' '
-        check_annotation $(cat job1.id) "sched.resource_summary" "\"1core\"" &&
-        check_no_annotations $(cat job2.id) &&
-        check_annotation $(cat job3.id) "sched.resource_summary" "\"1core\"" &&
-        test_must_fail check_annotation_exists $(cat job3.id) "sched.reason_pending" &&
-        test_must_fail check_annotation_exists $(cat job3.id) "sched.jobs_ahead" &&
-        check_annotation $(cat job4.id) "sched.reason_pending" "\"no cores\"" &&
-        check_annotation $(cat job4.id) "sched.jobs_ahead" "0" &&
-        check_annotation $(cat job5.id) "sched.reason_pending" "\"no cores\"" &&
-        check_annotation $(cat job5.id) "sched.jobs_ahead" "1"
+        jmgr_check_annotation $(cat job1.id) "sched.resource_summary" "\"1core\"" &&
+        jmgr_check_no_annotations $(cat job2.id) &&
+        jmgr_check_annotation $(cat job3.id) "sched.resource_summary" "\"1core\"" &&
+        test_must_fail jmgr_check_annotation_exists $(cat job3.id) "sched.reason_pending" &&
+        test_must_fail jmgr_check_annotation_exists $(cat job3.id) "sched.jobs_ahead" &&
+        jmgr_check_annotation $(cat job4.id) "sched.reason_pending" "\"no cores\"" &&
+        jmgr_check_annotation $(cat job4.id) "sched.jobs_ahead" "0" &&
+        jmgr_check_annotation $(cat job5.id) "sched.reason_pending" "\"no cores\"" &&
+        jmgr_check_annotation $(cat job5.id) "sched.jobs_ahead" "1"
 '
 
 test_expect_success 'job-manager: cancel 5' '
@@ -99,22 +99,22 @@ test_expect_success 'job-manager: cancel 5' '
 '
 
 test_expect_success 'job-manager: job state RIRSI' '
-        check_state $(cat job1.id) R &&
-        check_state $(cat job2.id) I &&
-        check_state $(cat job3.id) R &&
-        check_state $(cat job4.id) S &&
-        check_state $(cat job5.id) I
+        jmgr_check_state $(cat job1.id) R &&
+        jmgr_check_state $(cat job2.id) I &&
+        jmgr_check_state $(cat job3.id) R &&
+        jmgr_check_state $(cat job4.id) S &&
+        jmgr_check_state $(cat job5.id) I
 '
 
 test_expect_success HAVE_JQ 'job-manager: annotate job id 4 (RIRSI)' '
-        check_annotation $(cat job1.id) "sched.resource_summary" "\"1core\"" &&
-        check_no_annotations $(cat job2.id) &&
-        check_annotation $(cat job3.id) "sched.resource_summary" "\"1core\"" &&
-        test_must_fail check_annotation_exists $(cat job3.id) "sched.reason_pending" &&
-        test_must_fail check_annotation_exists $(cat job3.id) "sched.jobs_ahead" &&
-        check_annotation $(cat job4.id) "sched.reason_pending" "\"no cores\"" &&
-        check_annotation $(cat job4.id) "sched.jobs_ahead" "0" &&
-        check_no_annotations $(cat job5.id)
+        jmgr_check_annotation $(cat job1.id) "sched.resource_summary" "\"1core\"" &&
+        jmgr_check_no_annotations $(cat job2.id) &&
+        jmgr_check_annotation $(cat job3.id) "sched.resource_summary" "\"1core\"" &&
+        test_must_fail jmgr_check_annotation_exists $(cat job3.id) "sched.reason_pending" &&
+        test_must_fail jmgr_check_annotation_exists $(cat job3.id) "sched.jobs_ahead" &&
+        jmgr_check_annotation $(cat job4.id) "sched.reason_pending" "\"no cores\"" &&
+        jmgr_check_annotation $(cat job4.id) "sched.jobs_ahead" "0" &&
+        jmgr_check_no_annotations $(cat job5.id)
 '
 
 test_expect_success 'job-manager: cancel all jobs' '
@@ -124,19 +124,19 @@ test_expect_success 'job-manager: cancel all jobs' '
 '
 
 test_expect_success 'job-manager: job state IIIII' '
-        check_state $(cat job1.id) I &&
-        check_state $(cat job2.id) I &&
-        check_state $(cat job3.id) I &&
-        check_state $(cat job4.id) I &&
-        check_state $(cat job5.id) I
+        jmgr_check_state $(cat job1.id) I &&
+        jmgr_check_state $(cat job2.id) I &&
+        jmgr_check_state $(cat job3.id) I &&
+        jmgr_check_state $(cat job4.id) I &&
+        jmgr_check_state $(cat job5.id) I
 '
 
 test_expect_success HAVE_JQ 'job-manager: no annotations (IIIII)' '
-        check_no_annotations $(cat job1.id) &&
-        check_no_annotations $(cat job2.id) &&
-        check_no_annotations $(cat job3.id) &&
-        check_no_annotations $(cat job4.id) &&
-        check_no_annotations $(cat job5.id)
+        jmgr_check_no_annotations $(cat job1.id) &&
+        jmgr_check_no_annotations $(cat job2.id) &&
+        jmgr_check_no_annotations $(cat job3.id) &&
+        jmgr_check_no_annotations $(cat job4.id) &&
+        jmgr_check_no_annotations $(cat job5.id)
 '
 
 test_expect_success 'job-manager: remove sched-dummy' '

--- a/t/t2204-job-manager-dummysched-unlimited.t
+++ b/t/t2204-job-manager-dummysched-unlimited.t
@@ -81,6 +81,15 @@ test_expect_success HAVE_JQ 'job-manager: annotate job id 3-5 in job-info (RRSSS
         jinfo_check_annotation $(cat job5.id) "sched.jobs_ahead" "2"
 '
 
+# XXX: non-RFC27 defined annotations such as jobs_ahead not yet supported
+test_expect_success HAVE_JQ 'job-manager: annotate job id 3-5 in flux-jobs (RRSSS)' '
+        fjobs_check_annotation $(cat job1.id) "annotations.sched.resource_summary" "1core" &&
+        fjobs_check_annotation $(cat job2.id) "annotations.sched.resource_summary" "1core" &&
+        fjobs_check_annotation $(cat job3.id) "annotations.sched.reason_pending" "no cores" &&
+        fjobs_check_annotation $(cat job4.id) "annotations.sched.reason_pending" "no cores" &&
+        fjobs_check_annotation $(cat job5.id) "annotations.sched.reason_pending" "no cores"
+'
+
 test_expect_success 'job-manager: cancel 2' '
         flux job cancel $(cat job2.id)
 '
@@ -119,6 +128,18 @@ test_expect_success HAVE_JQ 'job-manager: annotate job id 4-5 in job-info (RIRSS
         jinfo_check_annotation $(cat job5.id) "sched.jobs_ahead" "1"
 '
 
+# compared to above, note that job id #2 retains annotations, it is
+# cached in job-info
+# XXX: non-RFC27 defined annotations such as jobs_ahead not yet supported
+test_expect_success HAVE_JQ 'job-manager: annotate job id 4-5 in flux-jobs (RIRSS)' '
+        fjobs_check_annotation $(cat job1.id) "annotations.sched.resource_summary" "1core" &&
+        fjobs_check_annotation $(cat job2.id) "annotations.sched.resource_summary" "1core" &&
+        fjobs_check_annotation $(cat job3.id) "annotations.sched.resource_summary" "1core" &&
+        test_must_fail fjobs_check_annotation_exists $(cat job3.id) "annotations.sched.reason_pending" &&
+        fjobs_check_annotation $(cat job4.id) "annotations.sched.reason_pending" "no cores" &&
+        fjobs_check_annotation $(cat job5.id) "annotations.sched.reason_pending" "no cores"
+'
+
 test_expect_success 'job-manager: cancel 5' '
         flux job cancel $(cat job5.id)
 '
@@ -155,6 +176,18 @@ test_expect_success HAVE_JQ 'job-manager: annotate job id 4-5 in job-info (RIRSS
         jinfo_check_no_annotations $(cat job5.id)
 '
 
+# compared to above, note that job id #2 retains annotations, it is
+# cached in job-info
+# XXX: non-RFC27 defined annotations such as jobs_ahead not yet supported
+test_expect_success HAVE_JQ 'job-manager: annotate job id 4-5 in flux jobs (RIRSS)' '
+        fjobs_check_annotation $(cat job1.id) "annotations.sched.resource_summary" "1core" &&
+        fjobs_check_annotation $(cat job2.id) "annotations.sched.resource_summary" "1core" &&
+        fjobs_check_annotation $(cat job3.id) "annotations.sched.resource_summary" "1core" &&
+        test_must_fail fjobs_check_annotation_exists $(cat job3.id) "annotations.sched.reason_pending" &&
+        fjobs_check_annotation $(cat job4.id) "annotations.sched.reason_pending" "no cores" &&
+        fjobs_check_no_annotations $(cat job5.id)
+'
+
 # cancel non-running jobs first, to ensure they are not accidentally run when
 # running jobs free resources.
 test_expect_success 'job-manager: cancel all jobs' '
@@ -186,6 +219,15 @@ test_expect_success HAVE_JQ 'job-manager: no annotations in canceled jobs in job
         jinfo_check_annotation $(cat job3.id) "sched.resource_summary" "\"1core\"" &&
         jinfo_check_no_annotations $(cat job4.id) &&
         jinfo_check_no_annotations $(cat job5.id)
+'
+
+# compared to above, note that job ids that ran retain annotations
+test_expect_success HAVE_JQ 'job-manager: no annotations in canceled jobs in flux jobs (IIIII)' '
+        fjobs_check_annotation $(cat job1.id) "annotations.sched.resource_summary" "1core" &&
+        fjobs_check_annotation $(cat job2.id) "annotations.sched.resource_summary" "1core" &&
+        fjobs_check_annotation $(cat job3.id) "annotations.sched.resource_summary" "1core" &&
+        fjobs_check_no_annotations $(cat job4.id) &&
+        fjobs_check_no_annotations $(cat job5.id)
 '
 
 test_expect_success 'job-manager: remove sched-dummy' '

--- a/t/t2230-job-info-list.t
+++ b/t/t2230-job-info-list.t
@@ -817,7 +817,8 @@ exception_type \
 exception_severity \
 exception_note \
 result \
-expiration
+expiration \
+annotations
 "
 
 test_expect_success HAVE_JQ 'list request with empty attrs works' '

--- a/t/t2300-sched-simple.t
+++ b/t/t2300-sched-simple.t
@@ -84,10 +84,10 @@ test_expect_success 'sched-simple: submit 5 jobs' '
 test_expect_success 'sched-simple: check allocations for running jobs' '
 	list_R $(cat job1.id job2.id job3.id job4.id) > allocs.out &&
 	cat <<-EOF >allocs.expected &&
-	annotations={"sched.resource_summary":"rank0/core0"}
-	annotations={"sched.resource_summary":"rank1/core0"}
-	annotations={"sched.resource_summary":"rank0/core1"}
-	annotations={"sched.resource_summary":"rank1/core1"}
+	annotations={"sched":{"resource_summary":"rank0/core0"}}
+	annotations={"sched":{"resource_summary":"rank1/core0"}}
+	annotations={"sched":{"resource_summary":"rank0/core1"}}
+	annotations={"sched":{"resource_summary":"rank1/core1"}}
 	EOF
 	test_cmp allocs.expected allocs.out
 '
@@ -101,7 +101,7 @@ test_expect_success 'sched-simple: cancel one job' '
 '
 test_expect_success 'sched-simple: waiting job now has alloc event' '
         flux job wait-event --timeout=5.0 $(cat job5.id) alloc &&
-	test "$(list_R $(cat job5.id))" = "annotations={\"sched.resource_summary\":\"rank0/core1\"}"
+	test "$(list_R $(cat job5.id))" = "annotations={\"sched\":{\"resource_summary\":\"rank0/core1\"}}"
 '
 test_expect_success 'sched-simple: cancel all jobs' '
 	flux job cancel $(cat job5.id) &&
@@ -127,10 +127,10 @@ test_expect_success 'sched-simple: submit 5 more jobs' '
 test_expect_success 'sched-simple: check allocations for running jobs' '
 	list_R $(cat job6.id job7.id job8.id job9.id) > best-fit-allocs.out &&
 	cat <<-EOF >best-fit-allocs.expected &&
-	annotations={"sched.resource_summary":"rank0/core0"}
-	annotations={"sched.resource_summary":"rank0/core1"}
-	annotations={"sched.resource_summary":"rank1/core0"}
-	annotations={"sched.resource_summary":"rank1/core1"}
+	annotations={"sched":{"resource_summary":"rank0/core0"}}
+	annotations={"sched":{"resource_summary":"rank0/core1"}}
+	annotations={"sched":{"resource_summary":"rank1/core0"}}
+	annotations={"sched":{"resource_summary":"rank1/core1"}}
 	EOF
 	test_cmp best-fit-allocs.expected best-fit-allocs.out
 '
@@ -172,9 +172,9 @@ test_expect_success 'sched-simple: check allocations for running jobs' '
 	list_R $(cat job11.id job12.id job13.id ) \
 		 > first-fit-allocs.out &&
 	cat <<-EOF >first-fit-allocs.expected &&
-	annotations={"sched.resource_summary":"rank0/core0"}
-	annotations={"sched.resource_summary":"rank0/core1"}
-	annotations={"sched.resource_summary":"rank1/core0"}
+	annotations={"sched":{"resource_summary":"rank0/core0"}}
+	annotations={"sched":{"resource_summary":"rank0/core1"}}
+	annotations={"sched":{"resource_summary":"rank1/core0"}}
 	EOF
 	test_cmp first-fit-allocs.expected first-fit-allocs.out
 '
@@ -211,9 +211,9 @@ test_expect_success 'sched-simple: check allocations for running jobs' '
 	list_R $(cat job11.id job12.id job13.id ) \
 		 > single-allocs.out &&
 	cat <<-EOF >first-fit-allocs.expected &&
-	annotations={"sched.resource_summary":"rank0/core0"}
-	annotations={"sched.resource_summary":"rank0/core1"}
-	annotations={"sched.resource_summary":"rank1/core0"}
+	annotations={"sched":{"resource_summary":"rank0/core0"}}
+	annotations={"sched":{"resource_summary":"rank0/core1"}}
+	annotations={"sched":{"resource_summary":"rank1/core0"}}
 	EOF
 	test_cmp first-fit-allocs.expected first-fit-allocs.out
 '

--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -662,7 +662,12 @@ test_expect_success 'flux-jobs: header included with all custom formats' '
 	flux jobs --format={expiration!d:%FT%T} | head -1 | grep "EXPIRATION" &&
 	flux jobs --format={t_remaining} | head -1 | grep "T_REMAINING" &&
 	flux jobs --format={t_remaining!F} | head -1 | grep "T_REMAINING" &&
-	flux jobs --format={t_remaining!H} | head -1 | grep "T_REMAINING"
+	flux jobs --format={t_remaining!H} | head -1 | grep "T_REMAINING" &&
+	flux jobs --format={annotations} | head -1 | grep "ANNOTATIONS" &&
+	flux jobs --format={annotations.sched} | head -1 | grep "SCHED" &&
+	flux jobs --format={annotations.sched.reason_pending} | head -1 | grep "REASON_PENDING" &&
+	flux jobs --format={annotations.sched.resource_summary} | head -1 | grep "RESOURCE_SUMMARY" &&
+	flux jobs --format={annotations.sched.t_estimate} | head -1 | grep "T_ESTIMATE"
 '
 
 test_expect_success 'flux-jobs: header still prints with conversion spec' '


### PR DESCRIPTION
This is built upon PR #2960, part #2 in the annotations work.  Annotations are distributed from the job-manager to job-info and available via the `job-info.list` service.  

I think this is a good stopping point for part 2.  Adding the ability for users to create their own annotations could possibly go into this PR as well, but I decided to hold off and maybe that'll be part 3 (as it will introduce security checks, thus security tests).  Presumably part #4 will be the final `flux-jobs` support.

I don't think there's anything too spectacular to mention about the PR.  The biggest decision, as discussed in #2608, is that annotations should be sent via an event from the job-manager, vs many of the other options discussed/prototyped.

As an FYI, the additions in this PR are the last 7 commits in this series.