### PR TITLE
Update terminology to use more inclusive words

### DIFF
--- a/src/broker/runat.c
+++ b/src/broker/runat.c
@@ -11,7 +11,7 @@
 /* runat.c - run named list of sequential commands
  *
  * Notes:
- * - Command env is inherited from broker, minus blacklist, plus FLUX_URI.
+ * - Command env is inherited from broker, minus blocklist, plus FLUX_URI.
  * - All commands in a list are executed, even if one fails.
  * - The exit code of the first failed command is captured.
  */
@@ -60,7 +60,7 @@ static void start_next_command (struct runat *r, struct runat_entry *entry);
 
 static const int abort_signal = SIGTERM;
 
-static const char *env_blacklist[] = {
+static const char *env_blocklist[] = {
     "PMI_FD",
     "PMI_RANK",
     "PMI_SIZE",
@@ -277,17 +277,17 @@ error:
     return NULL;
 }
 
-/* Unset blacklisted variables in command environment.
+/* Unset blocklisted variables in command environment.
  * Set FLUX_URI if local_uri is non-NULL.
  */
 static int runat_command_modenv (struct runat_command *cmd,
-                                 const char **blacklist,
+                                 const char **blocklist,
                                  const char *local_uri)
 {
-    if (blacklist) {
+    if (blocklist) {
         int i;
-        for (i = 0; blacklist[i] != NULL; i++)
-            flux_cmd_unsetenv (cmd->cmd, blacklist[i]);
+        for (i = 0; blocklist[i] != NULL; i++)
+            flux_cmd_unsetenv (cmd->cmd, blocklist[i]);
     }
     if (local_uri) {
         if (flux_cmd_setenvf (cmd->cmd, 1, "FLUX_URI", "%s", local_uri) < 0)
@@ -404,7 +404,7 @@ int runat_push_shell_command (struct runat *r,
         return -1;
     if (runat_command_set_cmdline (cmd, cmdline) < 0)
         goto error;
-    if (runat_command_modenv (cmd, env_blacklist, r->local_uri) < 0)
+    if (runat_command_modenv (cmd, env_blocklist, r->local_uri) < 0)
         goto error;
     if (runat_push (r, name, cmd) < 0)
         goto error;
@@ -426,7 +426,7 @@ int runat_push_shell (struct runat *r, const char *name)
         return -1;
     if (runat_command_set_cmdline (cmd, NULL) < 0)
         goto error;
-    if (runat_command_modenv (cmd, env_blacklist, r->local_uri) < 0)
+    if (runat_command_modenv (cmd, env_blocklist, r->local_uri) < 0)
         goto error;
     if (runat_push (r, name, cmd) < 0)
         goto error;
@@ -452,7 +452,7 @@ int runat_push_command (struct runat *r,
         return -1;
     if (runat_command_set_argz (cmd, argz, argz_len) < 0)
         goto error;
-    if (runat_command_modenv (cmd, env_blacklist, r->local_uri) < 0)
+    if (runat_command_modenv (cmd, env_blocklist, r->local_uri) < 0)
         goto error;
     if (runat_push (r, name, cmd) < 0)
         goto error;

--- a/src/common/libterminus/pty.h
+++ b/src/common/libterminus/pty.h
@@ -51,13 +51,13 @@ void flux_pty_set_log (struct flux_pty *pty,
                        pty_log_f log,
                        void *log_data);
 
-int flux_pty_master_fd (struct flux_pty *pty);
+int flux_pty_leader_fd (struct flux_pty *pty);
 
-/*  Return the slave name for this pty
+/*  Return the follower name for this pty
  */
 const char *flux_pty_name (struct flux_pty *pty);
 
-/*  Attach the current process to slave end of pty
+/*  Attach the current process to follower end of pty
  *  (e.g. called from pre_exec hook of a flux_subprocess_t)
  */
 int flux_pty_attach (struct flux_pty *pty);

--- a/src/common/libterminus/test/pty.c
+++ b/src/common/libterminus/test/pty.c
@@ -39,8 +39,8 @@ static void test_invalid_args ()
         "flux_pty_kill() with NULL pty returns EINVAL");
     ok (flux_pty_kill (pty, -1) < 0 && errno == EINVAL,
         "flux_pty_kill() with invalid signal returns EINVAL");
-    ok (flux_pty_master_fd (NULL) < 0 && errno == EINVAL,
-        "flux_pty_master_fd() returns EINVAL with NULL arg");
+    ok (flux_pty_leader_fd (NULL) < 0 && errno == EINVAL,
+        "flux_pty_leader_fd() returns EINVAL with NULL arg");
     ok (flux_pty_name (NULL) == NULL && errno == EINVAL,
         "flux_pty_name() returns EINVAL with NULL arg");
     ok (flux_pty_attach (NULL) < 0 && errno == EINVAL,
@@ -99,8 +99,8 @@ static void test_empty_server ()
 
     ok (pty != NULL,
         "flux_pty_open works");
-    ok (flux_pty_master_fd (pty) >= 0,
-        "pty master fd is valid");
+    ok (flux_pty_leader_fd (pty) >= 0,
+        "pty leader fd is valid");
     ok (flux_pty_client_count (pty) == 0,
         "pty client count is 0 for newly created pty server");
     flux_pty_close (pty, 0);

--- a/src/common/libtomlc99/test/toml.c
+++ b/src/common/libtomlc99/test/toml.c
@@ -214,7 +214,7 @@ struct entry {
     char *reason;
 };
 
-const struct entry bad_input_blacklist[] = {
+const struct entry bad_input_blocklist[] = {
     { NULL, NULL },
 };
 
@@ -245,9 +245,9 @@ void parse_bad_input (void)
         char errbuf[255];
         char *name = basename (results.gl_pathv[i]);
         const char *reason;
-        bool blacklisted = matchtab (name, bad_input_blacklist, &reason);
+        bool blocklist = matchtab (name, bad_input_blocklist, &reason);
 
-        skip (blacklisted, 1, "%s: %s", name, reason);
+        skip (blocklist, 1, "%s: %s", name, reason);
         ok (parse_bad_file (results.gl_pathv[i], errbuf, 255) == true,
             "%s: %s", name, errbuf);
         end_skip;

--- a/t/test-terminal.perl
+++ b/t/test-terminal.perl
@@ -67,14 +67,14 @@ sub copy_stdio {
 if ($#ARGV < 1) {
 	die "usage: test-terminal program args";
 }
-my $master_out = new IO::Pty;
-my $master_err = new IO::Pty;
-$master_out->set_raw();
-$master_err->set_raw();
-$master_out->slave->set_raw();
-$master_err->slave->set_raw();
-my $pid = start_child(\@ARGV, $master_out->slave, $master_err->slave);
-close $master_out->slave;
-close $master_err->slave;
-copy_stdio($master_out, $master_err);
+my $leader_out = new IO::Pty;
+my $leader_err = new IO::Pty;
+$leader_out->set_raw();
+$leader_err->set_raw();
+$leader_out->follower->set_raw();
+$leader_err->follower->set_raw();
+my $pid = start_child(\@ARGV, $leader_out->follower, $leader_err->follower);
+close $leader_out->follower;
+close $leader_err->follower;
+copy_stdio($leader_out, $leader_err);
 exit(finish_child($pid));


### PR DESCRIPTION
I was curious what scripts we had laying around that used the "master" branch, since github will be changing that.  Saw that `libterminus` still used "master-slave" terminology.  I converted to "leader-follower", picking "leader-follower" somewhat randomly.  Could pick an alternate word set too.