### PR TITLE
[WIP] job-manager / flux-job : Support user annotation service

### DIFF
--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -1000,7 +1000,8 @@ static const char *list_attrs =
     "\"name\",\"ntasks\",\"nnodes\",\"ranks\",\"expiration\",\"success\"," \
     "\"exception_occurred\",\"exception_severity\",\"exception_type\"," \
     "\"exception_note\",\"result\","                                    \
-    "\"t_depend\",\"t_sched\",\"t_run\",\"t_cleanup\",\"t_inactive\"]";
+    "\"t_depend\",\"t_sched\",\"t_run\",\"t_cleanup\",\"t_inactive\"," \
+    "\"annotations\"]";
 
 int cmd_list (optparse_t *p, int argc, char **argv)
 {

--- a/src/modules/job-info/job-info.c
+++ b/src/modules/job-info/job-info.c
@@ -178,6 +178,11 @@ static const struct flux_msg_handler_spec htab[] = {
       .cb           = job_state_cb,
       .rolemask     = 0
     },
+    { .typemask     = FLUX_MSGTYPE_EVENT,
+      .topic_glob   = "job-annotations",
+      .cb           = job_annotations_cb,
+      .rolemask     = 0
+    },
     FLUX_MSGHANDLER_TABLE_END,
 };
 

--- a/src/modules/job-info/job_state.c
+++ b/src/modules/job-info/job_state.c
@@ -1334,6 +1334,12 @@ static struct job *eventlog_restart_parse (struct info_ctx *ctx,
             update_job_state (ctx, job, FLUX_JOB_SCHED, timestamp);
         }
         else if (!strcmp (name, "priority")) {
+            if (!context) {
+                flux_log_error (ctx->h, "%s: no priority context for %ju",
+                                __FUNCTION__, (uintmax_t)job->id);
+                goto error;
+            }
+
             if (json_unpack (context, "{ s:i }",
                                       "priority", &job->priority) < 0) {
                 flux_log_error (ctx->h, "%s: priority context for %ju invalid",
@@ -1343,6 +1349,12 @@ static struct job *eventlog_restart_parse (struct info_ctx *ctx,
         }
         else if (!strcmp (name, "exception")) {
             int severity;
+            if (!context) {
+                flux_log_error (ctx->h, "%s: no exception context for %ju",
+                                __FUNCTION__, (uintmax_t)job->id);
+                goto error;
+            }
+
             if (json_unpack (context, "{ s:i }", "severity", &severity) < 0) {
                 flux_log_error (ctx->h, "%s: exception context for %ju invalid",
                                 __FUNCTION__, (uintmax_t)job->id);

--- a/src/modules/job-info/job_state.c
+++ b/src/modules/job-info/job_state.c
@@ -77,6 +77,7 @@ static void job_destroy (void *data)
     struct job *job = data;
     if (job) {
         json_decref (job->exception_context);
+        json_decref (job->annotations);
         json_decref (job->jobspec_job);
         json_decref (job->jobspec_cmd);
         json_decref (job->R);
@@ -162,6 +163,11 @@ struct job_state_ctx *job_state_create (flux_t *h)
     zlistx_set_destructor (jsctx->transitions, flux_msg_destroy_wrapper);
 
     if (flux_event_subscribe (h, "job-state") < 0) {
+        flux_log_error (h, "flux_event_subscribe");
+        goto error;
+    }
+
+    if (flux_event_subscribe (h, "job-annotations") < 0) {
         flux_log_error (h, "flux_event_subscribe");
         goto error;
     }
@@ -1237,6 +1243,73 @@ void job_state_cb (flux_t *h, flux_msg_handler_t *mh,
     return;
 }
 
+static void update_annotations (struct info_ctx *ctx, json_t *annotations)
+{
+    struct job_state_ctx *jsctx = ctx->jsctx;
+    size_t index;
+    json_t *value;
+
+    if (!json_is_array (annotations)) {
+        flux_log_error (ctx->h, "%s: annotations EPROTO", __FUNCTION__);
+        return;
+    }
+
+    json_array_foreach (annotations, index, value) {
+        struct job *job;
+        json_t *o;
+        flux_jobid_t id;
+
+        if (!json_is_array (value)) {
+            flux_log_error (jsctx->h, "%s: annotation EPROTO", __FUNCTION__);
+            return;
+        }
+
+        if (!(o = json_array_get (value, 0))
+            || !json_is_integer (o)) {
+            flux_log_error (jsctx->h, "%s: annotation EPROTO", __FUNCTION__);
+            return;
+        }
+
+        id = json_integer_value (o);
+
+        if (!(o = json_array_get (value, 1))
+            || (!json_is_object (o) && !json_is_null (o))) {
+            flux_log_error (jsctx->h, "%s: annotation EPROTO", __FUNCTION__);
+            return;
+        }
+
+        if ((job = zhashx_lookup (jsctx->index, &id))) {
+            json_decref (job->annotations);
+            if (json_is_null (o))
+                job->annotations = NULL;
+            else
+                job->annotations = json_incref (o);
+        }
+        else
+            flux_log_error (jsctx->h, "%s: job %ju not found",
+                            __FUNCTION__, (uintmax_t)id);
+    }
+
+}
+
+void job_annotations_cb (flux_t *h, flux_msg_handler_t *mh,
+                         const flux_msg_t *msg, void *arg)
+{
+    struct info_ctx *ctx = arg;
+    json_t *annotations;
+
+    if (flux_event_unpack (msg, NULL, "{s:o}",
+                           "annotations",
+                           &annotations) < 0) {
+        flux_log_error (h, "%s: flux_event_unpack", __FUNCTION__);
+        return;
+    }
+
+    update_annotations (ctx, annotations);
+
+    return;
+}
+
 void job_state_pause_cb (flux_t *h, flux_msg_handler_t *mh,
                          const flux_msg_t *msg, void *arg)
 {
@@ -1364,6 +1437,19 @@ static struct job *eventlog_restart_parse (struct info_ctx *ctx,
                 update_job_state (ctx, job, FLUX_JOB_CLEANUP, timestamp);
         }
         else if (!strcmp (name, "alloc")) {
+            /* context not required if no annotations */
+            if (context) {
+                json_t *annotations;
+                if (json_unpack (context,
+                                 "{ s:o }",
+                                 "annotations", &annotations) < 0) {
+                    flux_log_error (ctx->h, "%s: alloc context for %ju invalid",
+                                    __FUNCTION__, (uintmax_t)job->id);
+                    goto error;
+                }
+                job->annotations = json_incref (annotations);
+            }
+
             if (job->state == FLUX_JOB_SCHED)
                 update_job_state (ctx, job, FLUX_JOB_RUN, timestamp);
         }

--- a/src/modules/job-info/job_state.h
+++ b/src/modules/job-info/job_state.h
@@ -78,6 +78,7 @@ struct job {
     const char *exception_type;
     const char *exception_note;
     flux_job_result_t result;
+    json_t *annotations;
 
     /* cache of job information */
     json_t *jobspec_job;
@@ -122,6 +123,9 @@ void job_state_destroy (void *data);
 
 void job_state_cb (flux_t *h, flux_msg_handler_t *mh,
                    const flux_msg_t *msg, void *arg);
+
+void job_annotations_cb (flux_t *h, flux_msg_handler_t *mh,
+                         const flux_msg_t *msg, void *arg);
 
 void job_state_pause_cb (flux_t *h, flux_msg_handler_t *mh,
                          const flux_msg_t *msg, void *arg);

--- a/src/modules/job-info/job_util.c
+++ b/src/modules/job-info/job_util.c
@@ -156,6 +156,11 @@ json_t *job_to_json (struct job *job, json_t *attrs, job_info_error_t *errp)
                 continue;
             val = json_integer (job->result);
         }
+        else if (!strcmp (attr, "annotations")) {
+            if (!job->annotations)
+                continue;
+            val = json_incref (job->annotations);
+        }
         else {
             seterror (errp, "%s is not a valid attribute", attr);
             errno = EINVAL;

--- a/src/modules/job-info/list.c
+++ b/src/modules/job-info/list.c
@@ -570,7 +570,7 @@ void list_attrs_cb (flux_t *h, flux_msg_handler_t *mh,
                             "state", "name", "ntasks", "nnodes", "ranks",
                             "success", "exception_occurred", "exception_type",
                             "exception_severity", "exception_note", "result",
-                            "expiration", NULL };
+                            "expiration", "annotations", NULL };
     json_t *a = NULL;
     int i;
 

--- a/src/modules/job-manager/Makefile.am
+++ b/src/modules/job-manager/Makefile.am
@@ -39,7 +39,9 @@ job_manager_la_SOURCES = \
 	list.h \
 	list.c \
 	priority.h \
-	priority.c
+	priority.c \
+	annotate.h \
+	annotate.c
 
 job_manager_la_LDFLAGS = $(fluxmod_ldflags) -module
 job_manager_la_LIBADD = $(fluxmod_libadd) \
@@ -65,6 +67,7 @@ test_ldadd = \
         $(top_builddir)/src/modules/job-manager/drain.o \
         $(top_builddir)/src/modules/job-manager/submit.o \
         $(top_builddir)/src/modules/job-manager/wait.o \
+        $(top_builddir)/src/modules/job-manager/annotate.o \
 	$(top_builddir)/src/common/libtap/libtap.la \
 	$(top_builddir)/src/common/libjob/libjob.la \
 	$(top_builddir)/src/common/libflux-internal.la \

--- a/src/modules/job-manager/alloc.c
+++ b/src/modules/job-manager/alloc.c
@@ -51,11 +51,13 @@ struct alloc {
     unsigned int free_pending_count;
 };
 
-static void clear_annotations (struct job *job)
+static void clear_annotations (struct job *job, bool *cleared)
 {
     if (job->annotations) {
         json_decref (job->annotations);
         job->annotations = NULL;
+        if (cleared)
+            (*cleared) = true;
     }
 }
 
@@ -79,13 +81,16 @@ static void interface_teardown (struct alloc *alloc, char *s, int errnum)
             if (job->alloc_pending) {
                 bool fwd = job->priority > FLUX_JOB_PRIORITY_DEFAULT ? true
                                                                      : false;
+                bool cleared = false;
 
                 assert (job->handle == NULL);
                 if (!(job->handle = zlistx_insert (alloc->queue, job, fwd)))
                     flux_log_error (ctx->h, "%s: queue_insert", __FUNCTION__);
                 job->alloc_pending = 0;
                 job->alloc_queued = 1;
-                clear_annotations (job);
+                clear_annotations (job, &cleared);
+                if (cleared)
+                    event_batch_pub_annotations (ctx->event, job);
             }
             /* jobs with free request pending (much smaller window for this
              * to be true) need to be picked up again after 'ready'.
@@ -203,9 +208,14 @@ static void update_annotations (flux_t *h, struct job *job, flux_jobid_t id,
                     (void)json_object_del (job->annotations, key);
             }
             /* Special case: if user cleared all entries, assume we no
-             * longer need annotations object */
+             * longer need annotations object
+             *
+             * if cleared no need to call
+             * event_batch_pub_annotations(), should be handled by
+             * caller.
+             */
             if (!json_object_size (job->annotations))
-                clear_annotations (job);
+                clear_annotations (job, NULL);
         }
     }
 }
@@ -223,6 +233,7 @@ static void alloc_response_cb (flux_t *h, flux_msg_handler_t *mh,
     char *note = NULL;
     json_t *annotations = NULL;
     struct job *job;
+    bool cleared = false;
 
     if (flux_response_decode (msg, NULL, NULL) < 0)
         goto teardown; // ENOSYS here if scheduler not loaded/shutting down
@@ -257,6 +268,8 @@ static void alloc_response_cb (flux_t *h, flux_msg_handler_t *mh,
             goto teardown;
         }
         update_annotations (h, job, id, annotations);
+        if (annotations)
+            event_batch_pub_annotations (ctx->event, job);
         if (job->annotations) {
             if (event_job_post_pack (ctx->event, job, "alloc",
                                      "{ s:O }",
@@ -274,11 +287,14 @@ static void alloc_response_cb (flux_t *h, flux_msg_handler_t *mh,
             goto teardown;
         }
         update_annotations (h, job, id, annotations);
+        event_batch_pub_annotations (ctx->event, job);
         break;
     case FLUX_SCHED_ALLOC_DENY: // error
         alloc->alloc_pending_count--;
         job->alloc_pending = 0;
-        clear_annotations (job);
+        clear_annotations (job, &cleared);
+        if (cleared)
+            event_batch_pub_annotations (ctx->event, job);
         if (event_job_post_pack (ctx->event, job, "exception",
                                  "{ s:s s:i s:i s:s }",
                                  "type", "alloc",
@@ -290,7 +306,9 @@ static void alloc_response_cb (flux_t *h, flux_msg_handler_t *mh,
     case FLUX_SCHED_ALLOC_CANCEL:
         alloc->alloc_pending_count--;
         job->alloc_pending = 0;
-        clear_annotations (job);
+        clear_annotations (job, &cleared);
+        if (cleared)
+            event_batch_pub_annotations (ctx->event, job);
         if (event_job_action (ctx->event, job) < 0) {
             flux_log_error (h,
                             "event_job_action id=%ju on alloc cancel",

--- a/src/modules/job-manager/annotate.c
+++ b/src/modules/job-manager/annotate.c
@@ -1,0 +1,161 @@
+/************************************************************\
+ * Copyright 2018 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* annotate - user requests to annotate a job
+ *
+ * Purpose:
+ *   Handle job-manager.annotate RPC
+ *
+ * Input:
+ * - job id, annotations
+ *
+ * Action:
+ *  -update annotations
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <ctype.h>
+#include <flux/core.h>
+
+#include "job.h"
+#include "event.h"
+#include "annotate.h"
+#include "job-manager.h"
+
+struct annotate {
+    struct job_manager *ctx;
+    flux_msg_handler_t **handlers;
+};
+
+void annotations_clear (struct job *job, bool *cleared)
+{
+    if (job->annotations) {
+        json_decref (job->annotations);
+        job->annotations = NULL;
+        if (cleared)
+            (*cleared) = true;
+    }
+}
+
+void annotations_update (flux_t *h, struct job *job, json_t *annotations)
+{
+    if (annotations) {
+        if (!job->annotations) {
+            if (!(job->annotations = json_object ()))
+                flux_log (h,
+                          LOG_ERR,
+                          "%s: id=%ju json_object",
+                          __FUNCTION__, (uintmax_t)job->id);
+        }
+        if (job->annotations) {
+            const char *key;
+            json_t *value;
+
+            json_object_foreach (annotations, key, value) {
+                if (!json_is_null (value)) {
+                    if (json_object_set (job->annotations, key, value) < 0)
+                        flux_log (h,
+                                  LOG_ERR,
+                                  "%s: id=%ju update key=%s",
+                                  __FUNCTION__, (uintmax_t)job->id, key);
+                }
+                else
+                    /* not an error if key doesn't exist in job->annotations */
+                    (void)json_object_del (job->annotations, key);
+            }
+            /* Special case: if user cleared all entries, assume we no
+             * longer need annotations object
+             *
+             * if cleared no need to call
+             * event_batch_pub_annotations(), should be handled by
+             * caller.
+             */
+            if (!json_object_size (job->annotations))
+                annotations_clear (job, NULL);
+        }
+    }
+}
+
+void annotate_handle_request (flux_t *h,
+                              flux_msg_handler_t *mh,
+                              const flux_msg_t *msg,
+                              void *arg)
+{
+    struct job_manager *ctx = arg;
+    struct flux_msg_cred cred;
+    flux_jobid_t id;
+    json_t *annotations = NULL;
+    struct job *job;
+    const char *errstr = NULL;
+
+    if (flux_request_unpack (msg, NULL, "{s:I s:o}",
+                                        "id", &id,
+                                        "annotations", &annotations) < 0
+        || flux_msg_get_cred (msg, &cred) < 0)
+        goto error;
+    if (!(job = zhashx_lookup (ctx->active_jobs, &id))) {
+        errstr = "unknown job id";
+        errno = ENOENT;
+        goto error;
+    }
+    if (flux_msg_cred_authorize (cred, job->userid) < 0) {
+        errstr = "guests can only annotate their own jobs";
+        goto error;
+    }
+    annotations_update (ctx->h, job, annotations);
+    event_batch_pub_annotations (ctx->event, job);
+    if (flux_respond (h, msg, NULL) < 0)
+        flux_log_error (h, "%s: flux_respond", __FUNCTION__);
+    return;
+error:
+    if (flux_respond_error (h, msg, errno, errstr) < 0)
+        flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
+}
+
+void annotate_ctx_destroy (struct annotate *annotate)
+{
+    if (annotate) {
+        int saved_errno = errno;
+        flux_msg_handler_delvec (annotate->handlers);
+        free (annotate);
+        errno = saved_errno;
+    }
+}
+
+static const struct flux_msg_handler_spec htab[] = {
+    {
+        FLUX_MSGTYPE_REQUEST,
+        "job-manager.annotate",
+        annotate_handle_request,
+        FLUX_ROLE_USER
+    },
+    FLUX_MSGHANDLER_TABLE_END,
+};
+
+struct annotate *annotate_ctx_create (struct job_manager *ctx)
+{
+    struct annotate *annotate;
+
+    if (!(annotate = calloc (1, sizeof (*annotate))))
+        return NULL;
+    annotate->ctx = ctx;
+    if (flux_msg_handler_addvec (ctx->h, htab, ctx, &annotate->handlers) < 0)
+        goto error;
+    return annotate;
+error:
+    annotate_ctx_destroy (annotate);
+    return NULL;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/job-manager/annotate.h
+++ b/src/modules/job-manager/annotate.h
@@ -1,0 +1,27 @@
+/************************************************************\
+ * Copyright 2018 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _FLUX_JOB_MANAGER_ANNOTATE_H
+#define _FLUX_JOB_MANAGER_ANNOTATE_H
+
+#include <stdint.h>
+
+#include "job-manager.h"
+
+void annotations_clear (struct job *job, bool *cleared);
+void annotations_update (flux_t *h, struct job *job, json_t *annotations);
+
+struct annotate *annotate_ctx_create (struct job_manager *ctx);
+void annotate_ctx_destroy (struct annotate *annotate);
+
+#endif /* ! _FLUX_JOB_MANAGER_ANNOTATE_H */
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/job-manager/event.c
+++ b/src/modules/job-manager/event.c
@@ -183,7 +183,8 @@ void event_batch_destroy (struct event_batch *batch)
         if (batch->f)
             (void)flux_future_wait_for (batch->f, -1);
         if (batch->state_trans) {
-            event_publish_state (batch->event, batch->state_trans);
+            if (json_array_size (batch->state_trans) > 0)
+                event_publish_state (batch->event, batch->state_trans);
             json_decref (batch->state_trans);
         }
         if (batch->responses) {

--- a/src/modules/job-manager/event.h
+++ b/src/modules/job-manager/event.h
@@ -35,6 +35,10 @@ int event_job_update (struct job *job, json_t *event);
 int event_batch_pub_state (struct event *event, struct job *job,
                            double timestamp);
 
+/* Add notification of job's annotation change for publication.
+ */
+int event_batch_pub_annotations (struct event *event, struct job *job);
+
 /* Add add response to batch, to be sent upon batch completion.
  */
 int event_batch_respond (struct event *event, const flux_msg_t *msg);

--- a/src/modules/job-manager/job-manager.c
+++ b/src/modules/job-manager/job-manager.c
@@ -27,6 +27,7 @@
 #include "event.h"
 #include "drain.h"
 #include "wait.h"
+#include "annotate.h"
 
 #include "job-manager.h"
 
@@ -120,6 +121,10 @@ int mod_main (flux_t *h, int argc, char **argv)
         flux_log_error (h, "error creating kill interface");
         goto done;
     }
+    if (!(ctx.annotate = annotate_ctx_create (&ctx))) {
+        flux_log_error (h, "error creating annotate interface");
+        goto done;
+    }
     if (flux_msg_handler_addvec (h, htab, &ctx, &ctx.handlers) < 0) {
         flux_log_error (h, "flux_msghandler_add");
         goto done;
@@ -139,6 +144,7 @@ int mod_main (flux_t *h, int argc, char **argv)
     rc = 0;
 done:
     flux_msg_handler_delvec (ctx.handlers);
+    annotate_ctx_destroy (ctx.annotate);
     kill_ctx_destroy (ctx.kill);
     raise_ctx_destroy (ctx.raise);
     wait_ctx_destroy (ctx.wait);

--- a/src/modules/job-manager/job-manager.h
+++ b/src/modules/job-manager/job-manager.h
@@ -25,6 +25,7 @@ struct job_manager {
     struct waitjob *wait;
     struct raise *raise;
     struct kill *kill;
+    struct annotate *annotate;
 };
 
 #endif /* !_FLUX_JOB_MANAGER_H */

--- a/src/modules/job-manager/raise.c
+++ b/src/modules/job-manager/raise.c
@@ -129,7 +129,7 @@ void raise_handle_request (flux_t *h,
     }
     if (!(job = zhashx_lookup (ctx->active_jobs, &id))) {
         errstr = "unknown job id";
-        errno = EINVAL;
+        errno = ENOENT;
         goto error;
     }
     if (flux_msg_cred_authorize (cred, job->userid) < 0) {

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -102,6 +102,7 @@ TESTSCRIPTS = \
 	t2202-job-manager.t \
 	t2203-job-manager-dummysched-single.t \
 	t2204-job-manager-dummysched-unlimited.t \
+	t2205-job-manager-annotate.t \
 	t2206-job-manager-bulk-state.t \
 	t2207-job-manager-wait.t \
 	t2208-queue-cmd.t \

--- a/t/job-manager/sched-helper.sh
+++ b/t/job-manager/sched-helper.sh
@@ -3,51 +3,51 @@
 
 # job-manager sched helper functions
 
-LIST_JOBS=${FLUX_BUILD_DIR}/t/job-manager/list-jobs
+JMGR_JOB_LIST=${FLUX_BUILD_DIR}/t/job-manager/list-jobs
 
-# internal function to get job state
+# internal function to get job state via job manager
 #
 # if job is not found by list-jobs, but the clean event exists
 # in the job's eventlog, return state as inactive
 #
 # arg1 - jobid
-_get_state() {
+_jmgr_get_state() {
         local id=$1
-        local state=$(${LIST_JOBS} | awk '$1 == "'${id}'" { print $2; }')
+        local state=$(${JMGR_JOB_LIST} | awk '$1 == "'${id}'" { print $2; }')
         test -z "$state" \
                 && flux job wait-event --timeout=5 ${id} clean >/dev/null \
                 && state=I
         echo $state
 }
 
-# verify if job is in specific state
+# verify if job is in specific state through job manager
 #
 # function will loop for up to 5 seconds in case state change is slow
 #
 # arg1 - jobid
 # arg2 - single character expected state (e.g. R = running)
-check_state() {
+jmgr_check_state() {
         local id=$1
         local wantstate=$2
         for try in $(seq 1 10); do
-                test $(_get_state $id) = $wantstate && return 0
+                test $(_jmgr_get_state $id) = $wantstate && return 0
                 sleep 0.5
         done
         return 1
 }
 
-# internal function to get job annotation key value
+# internal function to get job annotation key value via job manager
 #
 # arg1 - jobid
 # arg2 - key
-_get_annotation() {
+_jmgr_get_annotation() {
         local id=$1
         local key=$2
-        local note="$(${LIST_JOBS} | grep ${id} | cut -f 6- | jq .\"${key}\")"
+        local note="$(${JMGR_JOB_LIST} | grep ${id} | cut -f 6- | jq .\"${key}\")"
         echo $note
 }
 
-# verify if job contains specific annotation key & value
+# verify if job contains specific annotation key & value through job manager
 #
 # function will loop for up to 5 seconds in case annotation update
 # arrives slowly
@@ -57,34 +57,34 @@ _get_annotation() {
 # arg3 - value of key in annotation
 #
 # callers should set HAVE_JQ requirement
-check_annotation() {
+jmgr_check_annotation() {
         local id=$1
         local key=$2
         local value="$3"
         for try in $(seq 1 10); do
-                test "$(_get_annotation $id $key)" = "${value}" && return 0
+                test "$(_jmgr_get_annotation $id $key)" = "${value}" && return 0
                 sleep 0.5
         done
         return 1
 }
 
-# verify if job contains specific annotation key
+# verify if job contains specific annotation key through job manager
 #
 # arg1 - jobid
 # arg2 - key in annotation
 #
 # callers should set HAVE_JQ requirement
-check_annotation_exists() {
+jmgr_check_annotation_exists() {
         local id=$1
         local key=$2
-        ${LIST_JOBS} | grep ${id} | cut -f 6- | jq -e .\"${key}\" > /dev/null
+        ${JMGR_JOB_LIST} | grep ${id} | cut -f 6- | jq -e .\"${key}\" > /dev/null
 }
 
-# verify that job contains no annotations
+# verify that job contains no annotations through job manager
 #
 # arg1 - jobid
-check_no_annotations() {
+jmgr_check_no_annotations() {
         local id=$1
-        test -z "$(${LIST_JOBS} | grep ${id} | cut -f 6-)" && return 0
+        test -z "$(${JMGR_JOB_LIST} | grep ${id} | cut -f 6-)" && return 0
         return 1
 }

--- a/t/job-manager/sched-helper.sh
+++ b/t/job-manager/sched-helper.sh
@@ -88,3 +88,58 @@ jmgr_check_no_annotations() {
         test -z "$(${JMGR_JOB_LIST} | grep ${id} | cut -f 6-)" && return 0
         return 1
 }
+
+# internal function to get job annotation key value via flux job list
+#
+# arg1 - jobid
+# arg2 - key
+_jinfo_get_annotation() {
+        local id=$1
+        local key=$2
+        local note="$(flux job list -A | grep ${id} | jq .annotations | jq .\"${key}\")"
+        echo $note
+}
+
+# verify if annotation published to job-info
+#
+# function will loop for up to 5 seconds in case annotation update
+# arrives slowly
+#
+# arg1 - jobid
+# arg2 - key in annotation
+# arg3 - value of key in annotation
+#
+# callers should set HAVE_JQ requirement
+jinfo_check_annotation() {
+        local id=$1
+        local key=$2
+        local value="$3"
+        for try in $(seq 1 10); do
+                test "$(_jinfo_get_annotation $id $key)" = "${value}" && return 0
+                sleep 0.5
+        done
+        return 1
+}
+
+# verify that job contains no annotations via job-info
+#
+# arg1 - jobid
+#
+# callers should set HAVE_JQ requirement
+jinfo_check_no_annotations() {
+        local id=$1
+        flux job list -A | grep ${id} | jq -e .annotations > /dev/null && return 1
+        return 0
+}
+
+# verify if job contains specific annotation key through job-info
+#
+# arg1 - jobid
+# arg2 - key in annotation
+#
+# callers should set HAVE_JQ requirement
+jinfo_check_annotation_exists() {
+        local id=$1
+        local key=$2
+        flux job list -A | grep ${id} | jq .annotations | jq -e .\"${key}\" > /dev/null
+}

--- a/t/t2203-job-manager-dummysched-single.t
+++ b/t/t2203-job-manager-dummysched-single.t
@@ -32,19 +32,19 @@ test_expect_success 'job-manager: submit 5 jobs' '
 '
 
 test_expect_success 'job-manager: job state SSSSS (no scheduler)' '
-        check_state $(cat job1.id) S &&
-        check_state $(cat job2.id) S &&
-        check_state $(cat job3.id) S &&
-        check_state $(cat job4.id) S &&
-        check_state $(cat job5.id) S
+        jmgr_check_state $(cat job1.id) S &&
+        jmgr_check_state $(cat job2.id) S &&
+        jmgr_check_state $(cat job3.id) S &&
+        jmgr_check_state $(cat job4.id) S &&
+        jmgr_check_state $(cat job5.id) S
 '
 
 test_expect_success HAVE_JQ 'job-manager: no annotations (SSSSS)' '
-        check_no_annotations $(cat job1.id) &&
-        check_no_annotations $(cat job2.id) &&
-        check_no_annotations $(cat job3.id) &&
-        check_no_annotations $(cat job4.id) &&
-        check_no_annotations $(cat job5.id)
+        jmgr_check_no_annotations $(cat job1.id) &&
+        jmgr_check_no_annotations $(cat job2.id) &&
+        jmgr_check_no_annotations $(cat job3.id) &&
+        jmgr_check_no_annotations $(cat job4.id) &&
+        jmgr_check_no_annotations $(cat job5.id)
 '
 
 test_expect_success 'job-manager: load sched-dummy --cores=2' '
@@ -52,19 +52,19 @@ test_expect_success 'job-manager: load sched-dummy --cores=2' '
 '
 
 test_expect_success 'job-manager: job state RRSSS' '
-        check_state $(cat job1.id) R &&
-        check_state $(cat job2.id) R &&
-        check_state $(cat job3.id) S &&
-        check_state $(cat job4.id) S &&
-        check_state $(cat job5.id) S
+        jmgr_check_state $(cat job1.id) R &&
+        jmgr_check_state $(cat job2.id) R &&
+        jmgr_check_state $(cat job3.id) S &&
+        jmgr_check_state $(cat job4.id) S &&
+        jmgr_check_state $(cat job5.id) S
 '
 
 test_expect_success HAVE_JQ 'job-manager: annotate job id 3 (RRSSS)' '
-        check_no_annotations $(cat job1.id) &&
-        check_no_annotations $(cat job2.id) &&
-        check_annotation $(cat job3.id) "sched.reason_pending" "\"no cores available\""&&
-        check_no_annotations $(cat job4.id) &&
-        check_no_annotations $(cat job5.id)
+        jmgr_check_no_annotations $(cat job1.id) &&
+        jmgr_check_no_annotations $(cat job2.id) &&
+        jmgr_check_annotation $(cat job3.id) "sched.reason_pending" "\"no cores available\""&&
+        jmgr_check_no_annotations $(cat job4.id) &&
+        jmgr_check_no_annotations $(cat job5.id)
 '
 
 test_expect_success 'job-manager: running job has alloc event' '
@@ -76,19 +76,19 @@ test_expect_success 'job-manager: cancel 2' '
 '
 
 test_expect_success 'job-manager: job state RIRSS' '
-        check_state $(cat job1.id) R &&
-        check_state $(cat job2.id) I &&
-        check_state $(cat job3.id) R &&
-        check_state $(cat job4.id) S &&
-        check_state $(cat job5.id) S
+        jmgr_check_state $(cat job1.id) R &&
+        jmgr_check_state $(cat job2.id) I &&
+        jmgr_check_state $(cat job3.id) R &&
+        jmgr_check_state $(cat job4.id) S &&
+        jmgr_check_state $(cat job5.id) S
 '
 
 test_expect_success HAVE_JQ 'job-manager: annotate job id 4 (RIRSS)' '
-        check_no_annotations $(cat job1.id) &&
-        check_no_annotations $(cat job2.id) &&
-        check_no_annotations $(cat job3.id) &&
-        check_annotation $(cat job4.id) "sched.reason_pending" "\"no cores available\"" &&
-        check_no_annotations $(cat job5.id)
+        jmgr_check_no_annotations $(cat job1.id) &&
+        jmgr_check_no_annotations $(cat job2.id) &&
+        jmgr_check_no_annotations $(cat job3.id) &&
+        jmgr_check_annotation $(cat job4.id) "sched.reason_pending" "\"no cores available\"" &&
+        jmgr_check_no_annotations $(cat job5.id)
 '
 
 test_expect_success 'job-manager: first S job sent alloc, second S did not' '
@@ -121,19 +121,19 @@ test_expect_success 'job-manager: hello handshake userid is expected' '
 '
 
 test_expect_success 'job-manager: job state RIRRR' '
-        check_state $(cat job1.id) R &&
-        check_state $(cat job2.id) I &&
-        check_state $(cat job3.id) R &&
-        check_state $(cat job4.id) R &&
-        check_state $(cat job5.id) R
+        jmgr_check_state $(cat job1.id) R &&
+        jmgr_check_state $(cat job2.id) I &&
+        jmgr_check_state $(cat job3.id) R &&
+        jmgr_check_state $(cat job4.id) R &&
+        jmgr_check_state $(cat job5.id) R
 '
 
 test_expect_success HAVE_JQ 'job-manager: no annotations (RIRRR)' '
-        check_no_annotations $(cat job1.id) &&
-        check_no_annotations $(cat job2.id) &&
-        check_no_annotations $(cat job3.id) &&
-        check_no_annotations $(cat job4.id) &&
-        check_no_annotations $(cat job5.id)
+        jmgr_check_no_annotations $(cat job1.id) &&
+        jmgr_check_no_annotations $(cat job2.id) &&
+        jmgr_check_no_annotations $(cat job3.id) &&
+        jmgr_check_no_annotations $(cat job4.id) &&
+        jmgr_check_no_annotations $(cat job5.id)
 '
 
 test_expect_success 'job-manager: cancel 1' '
@@ -141,11 +141,11 @@ test_expect_success 'job-manager: cancel 1' '
 '
 
 test_expect_success 'job-manager: job state IIRRR' '
-        check_state $(cat job1.id) I &&
-        check_state $(cat job2.id) I &&
-        check_state $(cat job3.id) R &&
-        check_state $(cat job4.id) R &&
-        check_state $(cat job5.id) R
+        jmgr_check_state $(cat job1.id) I &&
+        jmgr_check_state $(cat job2.id) I &&
+        jmgr_check_state $(cat job3.id) R &&
+        jmgr_check_state $(cat job4.id) R &&
+        jmgr_check_state $(cat job5.id) R
 '
 
 test_expect_success 'job-manager: cancel all jobs' '
@@ -155,19 +155,19 @@ test_expect_success 'job-manager: cancel all jobs' '
 '
 
 test_expect_success 'job-manager: job state IIIII' '
-        check_state $(cat job1.id) I &&
-        check_state $(cat job2.id) I &&
-        check_state $(cat job3.id) I &&
-        check_state $(cat job4.id) I &&
-        check_state $(cat job5.id) I
+        jmgr_check_state $(cat job1.id) I &&
+        jmgr_check_state $(cat job2.id) I &&
+        jmgr_check_state $(cat job3.id) I &&
+        jmgr_check_state $(cat job4.id) I &&
+        jmgr_check_state $(cat job5.id) I
 '
 
 test_expect_success HAVE_JQ 'job-manager: no annotations (IIIII)' '
-        check_no_annotations $(cat job1.id) &&
-        check_no_annotations $(cat job2.id) &&
-        check_no_annotations $(cat job3.id) &&
-        check_no_annotations $(cat job4.id) &&
-        check_no_annotations $(cat job5.id)
+        jmgr_check_no_annotations $(cat job1.id) &&
+        jmgr_check_no_annotations $(cat job2.id) &&
+        jmgr_check_no_annotations $(cat job3.id) &&
+        jmgr_check_no_annotations $(cat job4.id) &&
+        jmgr_check_no_annotations $(cat job5.id)
 '
 
 test_expect_success 'job-manager: simulate alloc failure' '

--- a/t/t2203-job-manager-dummysched-single.t
+++ b/t/t2203-job-manager-dummysched-single.t
@@ -67,6 +67,14 @@ test_expect_success HAVE_JQ 'job-manager: annotate job id 3 (RRSSS)' '
         jmgr_check_no_annotations $(cat job5.id)
 '
 
+test_expect_success HAVE_JQ 'job-manager: annotate job id 3 in job-info (RRSSS)' '
+        jinfo_check_no_annotations $(cat job1.id) &&
+        jinfo_check_no_annotations $(cat job2.id) &&
+        jinfo_check_annotation $(cat job3.id) "sched.reason_pending" "\"no cores available\""&&
+        jinfo_check_no_annotations $(cat job4.id) &&
+        jinfo_check_no_annotations $(cat job5.id)
+'
+
 test_expect_success 'job-manager: running job has alloc event' '
         flux job wait-event --timeout=5.0 $(cat job1.id) alloc
 '
@@ -89,6 +97,14 @@ test_expect_success HAVE_JQ 'job-manager: annotate job id 4 (RIRSS)' '
         jmgr_check_no_annotations $(cat job3.id) &&
         jmgr_check_annotation $(cat job4.id) "sched.reason_pending" "\"no cores available\"" &&
         jmgr_check_no_annotations $(cat job5.id)
+'
+
+test_expect_success HAVE_JQ 'job-manager: annotate job id 4 in job-info (RRSSS)' '
+        jinfo_check_no_annotations $(cat job1.id) &&
+        jinfo_check_no_annotations $(cat job2.id) &&
+        jinfo_check_no_annotations $(cat job3.id) &&
+        jinfo_check_annotation $(cat job4.id) "sched.reason_pending" "\"no cores available\"" &&
+        jinfo_check_no_annotations $(cat job5.id)
 '
 
 test_expect_success 'job-manager: first S job sent alloc, second S did not' '
@@ -136,6 +152,14 @@ test_expect_success HAVE_JQ 'job-manager: no annotations (RIRRR)' '
         jmgr_check_no_annotations $(cat job5.id)
 '
 
+test_expect_success HAVE_JQ 'job-manager: no annotations in job-info (RIRRR)' '
+        jinfo_check_no_annotations $(cat job1.id) &&
+        jinfo_check_no_annotations $(cat job2.id) &&
+        jinfo_check_no_annotations $(cat job3.id) &&
+        jinfo_check_no_annotations $(cat job4.id) &&
+        jinfo_check_no_annotations $(cat job5.id)
+'
+
 test_expect_success 'job-manager: cancel 1' '
         flux job cancel $(cat job1.id)
 '
@@ -168,6 +192,14 @@ test_expect_success HAVE_JQ 'job-manager: no annotations (IIIII)' '
         jmgr_check_no_annotations $(cat job3.id) &&
         jmgr_check_no_annotations $(cat job4.id) &&
         jmgr_check_no_annotations $(cat job5.id)
+'
+
+test_expect_success HAVE_JQ 'job-manager: no annotations in job-info (IIIII)' '
+        jinfo_check_no_annotations $(cat job1.id) &&
+        jinfo_check_no_annotations $(cat job2.id) &&
+        jinfo_check_no_annotations $(cat job3.id) &&
+        jinfo_check_no_annotations $(cat job4.id) &&
+        jinfo_check_no_annotations $(cat job5.id)
 '
 
 test_expect_success 'job-manager: simulate alloc failure' '

--- a/t/t2204-job-manager-dummysched-unlimited.t
+++ b/t/t2204-job-manager-dummysched-unlimited.t
@@ -32,19 +32,19 @@ test_expect_success 'job-manager: submit 5 jobs' '
 '
 
 test_expect_success 'job-manager: job state SSSSS (no scheduler)' '
-        check_state $(cat job1.id) S &&
-        check_state $(cat job2.id) S &&
-        check_state $(cat job3.id) S &&
-        check_state $(cat job4.id) S &&
-        check_state $(cat job5.id) S
+        jmgr_check_state $(cat job1.id) S &&
+        jmgr_check_state $(cat job2.id) S &&
+        jmgr_check_state $(cat job3.id) S &&
+        jmgr_check_state $(cat job4.id) S &&
+        jmgr_check_state $(cat job5.id) S
 '
 
 test_expect_success HAVE_JQ 'job-manager: no annotations (SSSSS)' '
-        check_no_annotations $(cat job1.id) &&
-        check_no_annotations $(cat job2.id) &&
-        check_no_annotations $(cat job3.id) &&
-        check_no_annotations $(cat job4.id) &&
-        check_no_annotations $(cat job5.id)
+        jmgr_check_no_annotations $(cat job1.id) &&
+        jmgr_check_no_annotations $(cat job2.id) &&
+        jmgr_check_no_annotations $(cat job3.id) &&
+        jmgr_check_no_annotations $(cat job4.id) &&
+        jmgr_check_no_annotations $(cat job5.id)
 '
 
 test_expect_success 'job-manager: load sched-dummy --cores=2' '
@@ -52,22 +52,22 @@ test_expect_success 'job-manager: load sched-dummy --cores=2' '
 '
 
 test_expect_success 'job-manager: job state RRSSS' '
-        check_state $(cat job1.id) R &&
-        check_state $(cat job2.id) R &&
-        check_state $(cat job3.id) S &&
-        check_state $(cat job4.id) S &&
-        check_state $(cat job5.id) S
+        jmgr_check_state $(cat job1.id) R &&
+        jmgr_check_state $(cat job2.id) R &&
+        jmgr_check_state $(cat job3.id) S &&
+        jmgr_check_state $(cat job4.id) S &&
+        jmgr_check_state $(cat job5.id) S
 '
 
 test_expect_success HAVE_JQ 'job-manager: annotate job id 3-5 (RRSSS)' '
-        check_annotation $(cat job1.id) "sched.resource_summary" "\"1core\"" &&
-        check_annotation $(cat job2.id) "sched.resource_summary" "\"1core\"" &&
-        check_annotation $(cat job3.id) "sched.reason_pending" "\"no cores\"" &&
-        check_annotation $(cat job3.id) "sched.jobs_ahead" "0" &&
-        check_annotation $(cat job4.id) "sched.reason_pending" "\"no cores\"" &&
-        check_annotation $(cat job4.id) "sched.jobs_ahead" "1" &&
-        check_annotation $(cat job5.id) "sched.reason_pending" "\"no cores\"" &&
-        check_annotation $(cat job5.id) "sched.jobs_ahead" "2"
+        jmgr_check_annotation $(cat job1.id) "sched.resource_summary" "\"1core\"" &&
+        jmgr_check_annotation $(cat job2.id) "sched.resource_summary" "\"1core\"" &&
+        jmgr_check_annotation $(cat job3.id) "sched.reason_pending" "\"no cores\"" &&
+        jmgr_check_annotation $(cat job3.id) "sched.jobs_ahead" "0" &&
+        jmgr_check_annotation $(cat job4.id) "sched.reason_pending" "\"no cores\"" &&
+        jmgr_check_annotation $(cat job4.id) "sched.jobs_ahead" "1" &&
+        jmgr_check_annotation $(cat job5.id) "sched.reason_pending" "\"no cores\"" &&
+        jmgr_check_annotation $(cat job5.id) "sched.jobs_ahead" "2"
 '
 
 test_expect_success 'job-manager: cancel 2' '
@@ -75,23 +75,23 @@ test_expect_success 'job-manager: cancel 2' '
 '
 
 test_expect_success 'job-manager: job state RIRSS' '
-        check_state $(cat job1.id) R &&
-        check_state $(cat job2.id) I &&
-        check_state $(cat job3.id) R &&
-        check_state $(cat job4.id) S &&
-        check_state $(cat job5.id) S
+        jmgr_check_state $(cat job1.id) R &&
+        jmgr_check_state $(cat job2.id) I &&
+        jmgr_check_state $(cat job3.id) R &&
+        jmgr_check_state $(cat job4.id) S &&
+        jmgr_check_state $(cat job5.id) S
 '
 
 test_expect_success HAVE_JQ 'job-manager: annotate job id 4-5 (RIRSS)' '
-        check_annotation $(cat job1.id) "sched.resource_summary" "\"1core\"" &&
-        check_no_annotations $(cat job2.id) &&
-        check_annotation $(cat job3.id) "sched.resource_summary" "\"1core\"" &&
-        test_must_fail check_annotation_exists $(cat job3.id) "sched.reason_pending" &&
-        test_must_fail check_annotation_exists $(cat job3.id) "sched.jobs_ahead" &&
-        check_annotation $(cat job4.id) "sched.reason_pending" "\"no cores\"" &&
-        check_annotation $(cat job4.id) "sched.jobs_ahead" "0" &&
-        check_annotation $(cat job5.id) "sched.reason_pending" "\"no cores\"" &&
-        check_annotation $(cat job5.id) "sched.jobs_ahead" "1"
+        jmgr_check_annotation $(cat job1.id) "sched.resource_summary" "\"1core\"" &&
+        jmgr_check_no_annotations $(cat job2.id) &&
+        jmgr_check_annotation $(cat job3.id) "sched.resource_summary" "\"1core\"" &&
+        test_must_fail jmgr_check_annotation_exists $(cat job3.id) "sched.reason_pending" &&
+        test_must_fail jmgr_check_annotation_exists $(cat job3.id) "sched.jobs_ahead" &&
+        jmgr_check_annotation $(cat job4.id) "sched.reason_pending" "\"no cores\"" &&
+        jmgr_check_annotation $(cat job4.id) "sched.jobs_ahead" "0" &&
+        jmgr_check_annotation $(cat job5.id) "sched.reason_pending" "\"no cores\"" &&
+        jmgr_check_annotation $(cat job5.id) "sched.jobs_ahead" "1"
 '
 
 test_expect_success 'job-manager: cancel 5' '
@@ -99,22 +99,22 @@ test_expect_success 'job-manager: cancel 5' '
 '
 
 test_expect_success 'job-manager: job state RIRSI' '
-        check_state $(cat job1.id) R &&
-        check_state $(cat job2.id) I &&
-        check_state $(cat job3.id) R &&
-        check_state $(cat job4.id) S &&
-        check_state $(cat job5.id) I
+        jmgr_check_state $(cat job1.id) R &&
+        jmgr_check_state $(cat job2.id) I &&
+        jmgr_check_state $(cat job3.id) R &&
+        jmgr_check_state $(cat job4.id) S &&
+        jmgr_check_state $(cat job5.id) I
 '
 
 test_expect_success HAVE_JQ 'job-manager: annotate job id 4 (RIRSI)' '
-        check_annotation $(cat job1.id) "sched.resource_summary" "\"1core\"" &&
-        check_no_annotations $(cat job2.id) &&
-        check_annotation $(cat job3.id) "sched.resource_summary" "\"1core\"" &&
-        test_must_fail check_annotation_exists $(cat job3.id) "sched.reason_pending" &&
-        test_must_fail check_annotation_exists $(cat job3.id) "sched.jobs_ahead" &&
-        check_annotation $(cat job4.id) "sched.reason_pending" "\"no cores\"" &&
-        check_annotation $(cat job4.id) "sched.jobs_ahead" "0" &&
-        check_no_annotations $(cat job5.id)
+        jmgr_check_annotation $(cat job1.id) "sched.resource_summary" "\"1core\"" &&
+        jmgr_check_no_annotations $(cat job2.id) &&
+        jmgr_check_annotation $(cat job3.id) "sched.resource_summary" "\"1core\"" &&
+        test_must_fail jmgr_check_annotation_exists $(cat job3.id) "sched.reason_pending" &&
+        test_must_fail jmgr_check_annotation_exists $(cat job3.id) "sched.jobs_ahead" &&
+        jmgr_check_annotation $(cat job4.id) "sched.reason_pending" "\"no cores\"" &&
+        jmgr_check_annotation $(cat job4.id) "sched.jobs_ahead" "0" &&
+        jmgr_check_no_annotations $(cat job5.id)
 '
 
 test_expect_success 'job-manager: cancel all jobs' '
@@ -124,19 +124,19 @@ test_expect_success 'job-manager: cancel all jobs' '
 '
 
 test_expect_success 'job-manager: job state IIIII' '
-        check_state $(cat job1.id) I &&
-        check_state $(cat job2.id) I &&
-        check_state $(cat job3.id) I &&
-        check_state $(cat job4.id) I &&
-        check_state $(cat job5.id) I
+        jmgr_check_state $(cat job1.id) I &&
+        jmgr_check_state $(cat job2.id) I &&
+        jmgr_check_state $(cat job3.id) I &&
+        jmgr_check_state $(cat job4.id) I &&
+        jmgr_check_state $(cat job5.id) I
 '
 
 test_expect_success HAVE_JQ 'job-manager: no annotations (IIIII)' '
-        check_no_annotations $(cat job1.id) &&
-        check_no_annotations $(cat job2.id) &&
-        check_no_annotations $(cat job3.id) &&
-        check_no_annotations $(cat job4.id) &&
-        check_no_annotations $(cat job5.id)
+        jmgr_check_no_annotations $(cat job1.id) &&
+        jmgr_check_no_annotations $(cat job2.id) &&
+        jmgr_check_no_annotations $(cat job3.id) &&
+        jmgr_check_no_annotations $(cat job4.id) &&
+        jmgr_check_no_annotations $(cat job5.id)
 '
 
 test_expect_success 'job-manager: remove sched-dummy' '

--- a/t/t2204-job-manager-dummysched-unlimited.t
+++ b/t/t2204-job-manager-dummysched-unlimited.t
@@ -70,6 +70,17 @@ test_expect_success HAVE_JQ 'job-manager: annotate job id 3-5 (RRSSS)' '
         jmgr_check_annotation $(cat job5.id) "sched.jobs_ahead" "2"
 '
 
+test_expect_success HAVE_JQ 'job-manager: annotate job id 3-5 in job-info (RRSSS)' '
+        jinfo_check_annotation $(cat job1.id) "sched.resource_summary" "\"1core\"" &&
+        jinfo_check_annotation $(cat job2.id) "sched.resource_summary" "\"1core\"" &&
+        jinfo_check_annotation $(cat job3.id) "sched.reason_pending" "\"no cores\"" &&
+        jinfo_check_annotation $(cat job3.id) "sched.jobs_ahead" "0" &&
+        jinfo_check_annotation $(cat job4.id) "sched.reason_pending" "\"no cores\"" &&
+        jinfo_check_annotation $(cat job4.id) "sched.jobs_ahead" "1" &&
+        jinfo_check_annotation $(cat job5.id) "sched.reason_pending" "\"no cores\"" &&
+        jinfo_check_annotation $(cat job5.id) "sched.jobs_ahead" "2"
+'
+
 test_expect_success 'job-manager: cancel 2' '
         flux job cancel $(cat job2.id)
 '
@@ -92,6 +103,20 @@ test_expect_success HAVE_JQ 'job-manager: annotate job id 4-5 (RIRSS)' '
         jmgr_check_annotation $(cat job4.id) "sched.jobs_ahead" "0" &&
         jmgr_check_annotation $(cat job5.id) "sched.reason_pending" "\"no cores\"" &&
         jmgr_check_annotation $(cat job5.id) "sched.jobs_ahead" "1"
+'
+
+# compared to above, note that job id #2 retains annotations, it is
+# cached in job-info
+test_expect_success HAVE_JQ 'job-manager: annotate job id 4-5 in job-info (RIRSS)' '
+        jinfo_check_annotation $(cat job1.id) "sched.resource_summary" "\"1core\"" &&
+        jinfo_check_annotation $(cat job2.id) "sched.resource_summary" "\"1core\"" &&
+        jinfo_check_annotation $(cat job3.id) "sched.resource_summary" "\"1core\"" &&
+        test_must_fail jinfo_check_annotation_exists $(cat job3.id) "sched.reason_pending" &&
+        test_must_fail jinfo_check_annotation_exists $(cat job3.id) "sched.jobs_ahead" &&
+        jinfo_check_annotation $(cat job4.id) "sched.reason_pending" "\"no cores\"" &&
+        jinfo_check_annotation $(cat job4.id) "sched.jobs_ahead" "0" &&
+        jinfo_check_annotation $(cat job5.id) "sched.reason_pending" "\"no cores\"" &&
+        jinfo_check_annotation $(cat job5.id) "sched.jobs_ahead" "1"
 '
 
 test_expect_success 'job-manager: cancel 5' '
@@ -117,10 +142,25 @@ test_expect_success HAVE_JQ 'job-manager: annotate job id 4 (RIRSI)' '
         jmgr_check_no_annotations $(cat job5.id)
 '
 
+# compared to above, note that job id #2 retains annotations, it is
+# cached in job-info
+test_expect_success HAVE_JQ 'job-manager: annotate job id 4-5 in job-info (RIRSS)' '
+        jinfo_check_annotation $(cat job1.id) "sched.resource_summary" "\"1core\"" &&
+        jinfo_check_annotation $(cat job2.id) "sched.resource_summary" "\"1core\"" &&
+        jinfo_check_annotation $(cat job3.id) "sched.resource_summary" "\"1core\"" &&
+        test_must_fail jinfo_check_annotation_exists $(cat job3.id) "sched.reason_pending" &&
+        test_must_fail jinfo_check_annotation_exists $(cat job3.id) "sched.jobs_ahead" &&
+        jinfo_check_annotation $(cat job4.id) "sched.reason_pending" "\"no cores\"" &&
+        jinfo_check_annotation $(cat job4.id) "sched.jobs_ahead" "0" &&
+        jinfo_check_no_annotations $(cat job5.id)
+'
+
+# cancel non-running jobs first, to ensure they are not accidentally run when
+# running jobs free resources.
 test_expect_success 'job-manager: cancel all jobs' '
-        flux job cancel $(cat job1.id) &&
+        flux job cancel $(cat job4.id) &&
         flux job cancel $(cat job3.id) &&
-        flux job cancel $(cat job4.id)
+        flux job cancel $(cat job1.id)
 '
 
 test_expect_success 'job-manager: job state IIIII' '
@@ -137,6 +177,15 @@ test_expect_success HAVE_JQ 'job-manager: no annotations (IIIII)' '
         jmgr_check_no_annotations $(cat job3.id) &&
         jmgr_check_no_annotations $(cat job4.id) &&
         jmgr_check_no_annotations $(cat job5.id)
+'
+
+# compared to above, note that job ids that ran retain annotations
+test_expect_success HAVE_JQ 'job-manager: no annotations in job-info (IIIII)' '
+        jinfo_check_annotation $(cat job1.id) "sched.resource_summary" "\"1core\"" &&
+        jinfo_check_annotation $(cat job2.id) "sched.resource_summary" "\"1core\"" &&
+        jinfo_check_annotation $(cat job3.id) "sched.resource_summary" "\"1core\"" &&
+        jinfo_check_no_annotations $(cat job4.id) &&
+        jinfo_check_no_annotations $(cat job5.id)
 '
 
 test_expect_success 'job-manager: remove sched-dummy' '

--- a/t/t2205-job-manager-annotate.t
+++ b/t/t2205-job-manager-annotate.t
@@ -1,0 +1,228 @@
+#!/bin/sh
+
+test_description='Test flux job manager annoate service with dummy scheduler'
+
+. `dirname $0`/job-manager/sched-helper.sh
+
+. $(dirname $0)/sharness.sh
+
+test_under_flux 4 kvs
+
+SCHED_DUMMY=${FLUX_BUILD_DIR}/t/job-manager/.libs/sched-dummy.so
+
+flux setattr log-stderr-level 1
+
+test_expect_success 'flux-job: generate jobspec for simple test job' '
+        flux jobspec srun -n1 hostname >basic.json
+'
+
+test_expect_success 'job-manager: load job-ingest, job-manager' '
+        flux module load job-manager &&
+        flux module load job-ingest &&
+        flux exec -r all -x 0 flux module load job-ingest &&
+        flux exec -r all flux module load job-info
+'
+
+test_expect_success 'job-manager: submit 5 jobs' '
+        flux job submit --flags=debug basic.json >job1.id &&
+        flux job submit --flags=debug basic.json >job2.id &&
+        flux job submit --flags=debug basic.json >job3.id &&
+        flux job submit --flags=debug basic.json >job4.id
+'
+
+test_expect_success HAVE_JQ 'job-manager: no annotations (SSSS)' '
+        jmgr_check_no_annotations $(cat job1.id) &&
+        jmgr_check_no_annotations $(cat job2.id) &&
+        jmgr_check_no_annotations $(cat job3.id) &&
+        jmgr_check_no_annotations $(cat job4.id)
+'
+
+test_expect_success HAVE_JQ 'job-manager: annotate job id 3-5 in job-info (RRSS)' '
+        jinfo_check_no_annotations $(cat job1.id) &&
+        jinfo_check_no_annotations $(cat job2.id) &&
+        jinfo_check_no_annotations $(cat job3.id) &&
+        jinfo_check_no_annotations $(cat job4.id)
+'
+
+test_expect_success HAVE_JQ 'job-manager: user annotate job id 1' '
+        flux job annotate $(cat job1.id) user.key \"foo\"
+'
+
+test_expect_success HAVE_JQ 'job-manager: user annotate job id 2' '
+        flux job annotate $(cat job2.id) user.key \"bar\"
+'
+
+test_expect_success HAVE_JQ 'job-manager: user annotate job id 4' '
+        flux job annotate $(cat job4.id) user.key \"baz\"
+'
+
+test_expect_success HAVE_JQ 'job-manager: annotations in job id 1 & 2 (SSSS)' '
+        jmgr_check_annotation $(cat job1.id) "user.key" "\"foo\"" &&
+        jmgr_check_annotation $(cat job2.id) "user.key" "\"bar\"" &&
+        jmgr_check_no_annotations $(cat job3.id) &&
+        jmgr_check_annotation $(cat job4.id) "user.key" "\"baz\""
+'
+
+test_expect_success HAVE_JQ 'job-manager: annotate job id 1 & 2 in job-info (SSSS)' '
+        jinfo_check_annotation $(cat job1.id) "user.key" "\"foo\"" &&
+        jinfo_check_annotation $(cat job2.id) "user.key" "\"bar\"" &&
+        jinfo_check_no_annotations $(cat job3.id) &&
+        jinfo_check_annotation $(cat job4.id) "user.key" "\"baz\""
+'
+
+test_expect_success 'job-manager: load sched-dummy --cores=2' '
+        flux module load ${SCHED_DUMMY} --cores=2 --mode=unlimited
+'
+
+test_expect_success HAVE_JQ 'job-manager: annotate job id 1-4 (RRSS)' '
+        jmgr_check_annotation $(cat job1.id) "user.key" "\"foo\"" &&
+        jmgr_check_annotation $(cat job1.id) "sched.resource_summary" "\"1core\"" &&
+        jmgr_check_annotation $(cat job2.id) "user.key" "\"bar\"" &&
+        jmgr_check_annotation $(cat job2.id) "sched.resource_summary" "\"1core\"" &&
+        jmgr_check_annotation $(cat job3.id) "sched.reason_pending" "\"no cores\"" &&
+        jmgr_check_annotation $(cat job3.id) "sched.jobs_ahead" "0" &&
+        jmgr_check_annotation $(cat job4.id) "user.key" "\"baz\"" &&
+        jmgr_check_annotation $(cat job4.id) "sched.reason_pending" "\"no cores\"" &&
+        jmgr_check_annotation $(cat job4.id) "sched.jobs_ahead" "1"
+'
+
+test_expect_success HAVE_JQ 'job-manager: annotate job id 1-4 in job-info (RRSS)' '
+        jinfo_check_annotation $(cat job1.id) "user.key" "\"foo\"" &&
+        jinfo_check_annotation $(cat job1.id) "sched.resource_summary" "\"1core\"" &&
+        jinfo_check_annotation $(cat job2.id) "user.key" "\"bar\"" &&
+        jinfo_check_annotation $(cat job2.id) "sched.resource_summary" "\"1core\"" &&
+        jinfo_check_annotation $(cat job3.id) "sched.reason_pending" "\"no cores\"" &&
+        jinfo_check_annotation $(cat job3.id) "sched.jobs_ahead" "0" &&
+        jinfo_check_annotation $(cat job4.id) "user.key" "\"baz\"" &&
+        jinfo_check_annotation $(cat job4.id) "sched.reason_pending" "\"no cores\"" &&
+        jinfo_check_annotation $(cat job4.id) "sched.jobs_ahead" "1"
+'
+
+test_expect_success HAVE_JQ 'job-manager: user annotate job id 1 again' '
+        flux job annotate $(cat job1.id) user.key \"bozo\"
+'
+
+test_expect_success HAVE_JQ 'job-manager: user clear annotatation job id 2' '
+        flux job annotate $(cat job2.id) user.key null
+'
+
+test_expect_success HAVE_JQ 'job-manager: annotate job id 1-4 (RRSS)' '
+        jmgr_check_annotation $(cat job1.id) "user.key" "\"bozo\"" &&
+        jmgr_check_annotation $(cat job1.id) "sched.resource_summary" "\"1core\"" &&
+        test_must_fail jmgr_check_annotation_exists $(cat job2.id) "user.key" &&
+        jmgr_check_annotation $(cat job2.id) "sched.resource_summary" "\"1core\"" &&
+        jmgr_check_annotation $(cat job3.id) "sched.reason_pending" "\"no cores\"" &&
+        jmgr_check_annotation $(cat job3.id) "sched.jobs_ahead" "0" &&
+        jmgr_check_annotation $(cat job4.id) "user.key" "\"baz\"" &&
+        jmgr_check_annotation $(cat job4.id) "sched.reason_pending" "\"no cores\"" &&
+        jmgr_check_annotation $(cat job4.id) "sched.jobs_ahead" "1"
+'
+
+test_expect_success HAVE_JQ 'job-manager: annotate job id 1-4 in job-info (RRSS)' '
+        jinfo_check_annotation $(cat job1.id) "user.key" "\"bozo\"" &&
+        jinfo_check_annotation $(cat job1.id) "sched.resource_summary" "\"1core\"" &&
+        test_must_fail jinfo_check_annotation_exists $(cat job2.id) "user.key" &&
+        jinfo_check_annotation $(cat job2.id) "sched.resource_summary" "\"1core\"" &&
+        jinfo_check_annotation $(cat job3.id) "sched.reason_pending" "\"no cores\"" &&
+        jinfo_check_annotation $(cat job3.id) "sched.jobs_ahead" "0" &&
+        jinfo_check_annotation $(cat job4.id) "user.key" "\"baz\"" &&
+        jinfo_check_annotation $(cat job4.id) "sched.reason_pending" "\"no cores\"" &&
+        jinfo_check_annotation $(cat job4.id) "sched.jobs_ahead" "1"
+'
+
+test_expect_success 'job-manager: cancel 2' '
+        flux job cancel $(cat job2.id)
+'
+
+test_expect_success HAVE_JQ 'job-manager: annotate job id 1-4 (RIRS)' '
+        jmgr_check_annotation $(cat job1.id) "user.key" "\"bozo\"" &&
+        jmgr_check_annotation $(cat job1.id) "sched.resource_summary" "\"1core\"" &&
+        jmgr_check_no_annotations $(cat job2.id) &&
+        jmgr_check_annotation $(cat job3.id) "sched.resource_summary" "\"1core\"" &&
+        test_must_fail jmgr_check_annotation_exists $(cat job3.id) "sched.reason_pending" &&
+        test_must_fail jmgr_check_annotation_exists $(cat job3.id) "sched.jobs_ahead" &&
+        jmgr_check_annotation $(cat job4.id) "user.key" "\"baz\"" &&
+        jmgr_check_annotation $(cat job4.id) "sched.reason_pending" "\"no cores\"" &&
+        jmgr_check_annotation $(cat job4.id) "sched.jobs_ahead" "0"
+'
+
+# compared to above, note that job id #2 retains annotations, it is
+# cached in job-info
+test_expect_success HAVE_JQ 'job-manager: annotate job id 4-5 in job-info (RIRSS)' '
+        jinfo_check_annotation $(cat job1.id) "user.key" "\"bozo\"" &&
+        jinfo_check_annotation $(cat job1.id) "sched.resource_summary" "\"1core\"" &&
+        test_must_fail jinfo_check_annotation_exists $(cat job2.id) "user.key" &&
+        jinfo_check_annotation $(cat job2.id) "sched.resource_summary" "\"1core\"" &&
+        jinfo_check_annotation $(cat job3.id) "sched.resource_summary" "\"1core\"" &&
+        test_must_fail jinfo_check_annotation_exists $(cat job3.id) "sched.reason_pending" &&
+        test_must_fail jinfo_check_annotation_exists $(cat job3.id) "sched.jobs_ahead" &&
+        jinfo_check_annotation $(cat job4.id) "user.key" "\"baz\"" &&
+        jinfo_check_annotation $(cat job4.id) "sched.reason_pending" "\"no cores\"" &&
+        jinfo_check_annotation $(cat job4.id) "sched.jobs_ahead" "0"
+'
+
+test_expect_success 'job-manager: cancel 4' '
+        flux job cancel $(cat job4.id)
+'
+
+# note that job4.id loses user annotation due to cancellation of non-running job
+test_expect_success HAVE_JQ 'job-manager: annotate job id 1-4 (RIRI)' '
+        jmgr_check_annotation $(cat job1.id) "user.key" "\"bozo\"" &&
+        jmgr_check_annotation $(cat job1.id) "sched.resource_summary" "\"1core\"" &&
+        jmgr_check_no_annotations $(cat job2.id) &&
+        jmgr_check_annotation $(cat job3.id) "sched.resource_summary" "\"1core\"" &&
+        test_must_fail jmgr_check_annotation_exists $(cat job3.id) "sched.reason_pending" &&
+        test_must_fail jmgr_check_annotation_exists $(cat job3.id) "sched.jobs_ahead" &&
+        jmgr_check_no_annotations $(cat job4.id)
+'
+
+# compared to above, note that job id #2 retains annotations, it is
+# cached in job-info
+test_expect_success HAVE_JQ 'job-manager: annotate job id 1-4 in job-info (RIRI)' '
+        jinfo_check_annotation $(cat job1.id) "user.key" "\"bozo\"" &&
+        jinfo_check_annotation $(cat job1.id) "sched.resource_summary" "\"1core\"" &&
+        test_must_fail jinfo_check_annotation_exists $(cat job2.id) "user.key" &&
+        jinfo_check_annotation $(cat job2.id) "sched.resource_summary" "\"1core\"" &&
+        jinfo_check_annotation $(cat job3.id) "sched.resource_summary" "\"1core\"" &&
+        test_must_fail jinfo_check_annotation_exists $(cat job3.id) "sched.reason_pending" &&
+        test_must_fail jinfo_check_annotation_exists $(cat job3.id) "sched.jobs_ahead" &&
+        jinfo_check_no_annotations $(cat job4.id)
+'
+
+test_expect_success 'job-manager: cancel all jobs' '
+        flux job cancel $(cat job1.id) &&
+        flux job cancel $(cat job3.id)
+'
+
+test_expect_success HAVE_JQ 'job-manager: no annotations (IIII)' '
+        jmgr_check_no_annotations $(cat job1.id) &&
+        jmgr_check_no_annotations $(cat job2.id) &&
+        jmgr_check_no_annotations $(cat job3.id) &&
+        jmgr_check_no_annotations $(cat job4.id)
+'
+
+# compared to above, note that job ids that ran retain annotations
+test_expect_success HAVE_JQ 'job-manager: no annotations in job-info (IIII)' '
+        jinfo_check_annotation $(cat job1.id) "user.key" "\"bozo\"" &&
+        jinfo_check_annotation $(cat job1.id) "sched.resource_summary" "\"1core\"" &&
+        test_must_fail jinfo_check_annotation_exists $(cat job2.id) "user.key" &&
+        jinfo_check_annotation $(cat job2.id) "sched.resource_summary" "\"1core\"" &&
+        jinfo_check_annotation $(cat job3.id) "sched.resource_summary" "\"1core\"" &&
+        jinfo_check_no_annotations $(cat job4.id)
+'
+
+test_expect_success HAVE_JQ 'job-manager: user annotate invalid id' '
+        test_must_fail flux job annotate 123456789 user.key \"foo\"
+'
+
+test_expect_success 'job-manager: remove sched-dummy' '
+        flux module remove sched-dummy
+'
+
+test_expect_success 'job-manager: remove job-manager, job-ingest' '
+        flux module remove job-manager &&
+        flux exec -r all flux module remove job-info &&
+        flux exec -r all flux module remove job-ingest
+'
+
+test_done

--- a/t/t2230-job-info-list.t
+++ b/t/t2230-job-info-list.t
@@ -817,7 +817,8 @@ exception_type \
 exception_severity \
 exception_note \
 result \
-expiration
+expiration \
+annotations
 "
 
 test_expect_success HAVE_JQ 'list request with empty attrs works' '


### PR DESCRIPTION
Built on top of #3037, the last 4 commits are what matters.

There's nothing too unexpected for this PR..  I think the bigger question is the user interface and any semantics we would like.

- in `flux-job` I supported a very simple `flux job annotate id key value` interface for now.  But unsure if that will be the way the average user would want to use this.  I could see `flux job annotate id key=value ...`?  I could see `flux job annotate id key - ` for stdin for advanced users?

- secondly, what namespace should user annotations should go into?  `user` is the obvious choice.  I can do a PR for RFC27.

- but if the user does `flux job annotate id key value` should `flux-job` automatically add it to the `user` namespace?  Thus the user has to know the grab `user.key` for their annotation?  Or should the user be required to input `user.key`?  Or should we allow users to add into any namespace they wish?

