### PR TITLE
Add support for RFC19 F58 encoded JOBIDs

### DIFF
--- a/src/bindings/python/flux/job.py
+++ b/src/bindings/python/flux/job.py
@@ -86,6 +86,88 @@ def job_kvs_guest(flux_handle, jobid):
     return flux.kvs.get_dir(flux_handle, kvs_key)
 
 
+def id_parse(jobid_str):
+    """
+    returns: An integer jobid
+    :rtype int
+    """
+    jobid = ffi.new("flux_jobid_t[1]")
+    RAW.id_parse(jobid_str, jobid)
+    return int(jobid[0])
+
+
+def id_encode(jobid, encoding="f58"):
+    """
+    returns: Jobid encoded in encoding
+    :rtype str
+    """
+    buflen = 128
+    buf = ffi.new("char[]", buflen)
+    RAW.id_encode(int(jobid), encoding, buf, buflen)
+    return ffi.string(buf, buflen).decode("utf-8")
+
+
+class JobID(int):
+    """Class used to represent a Flux JOBID
+
+    JobID is a subclass of `int`, so may be used in place of integer.
+    However, a JobID may be created from any valid RFC 19 FLUID
+    encoding, including:
+
+     - decimal integer (no prefix)
+     - hexidecimal integer (prefix 0x)
+     - dotted hex (dothex) (xxxx.xxxx.xxxx.xxxx)
+     - kvs dir (dotted hex with `job.` prefix)
+     - RFC19 F58: (Base58 encoding with prefix `ƒ` or `f`)
+
+    A JobID object also has properties for encoding a JOBID into each
+    of the above representations, e.g. jobid.f85, jobid.words, jobid.dothex...
+
+    """
+
+    def __new__(cls, value, *args, **kwargs):
+        if isinstance(value, int):
+            jobid = value
+        else:
+            jobid = id_parse(value)
+        return super(cls, cls).__new__(cls, jobid)
+
+    def encode(self, encoding="dec"):
+        """Encode a JobID to alternate supported format"""
+        return id_encode(self, encoding)
+
+    @property
+    def f58(self):
+        """Return RFC19 F58 representation of a JobID"""
+        return self.encode("f58")
+
+    @property
+    def hex(self):
+        """Return 0x-prefixed hexidecimal representation of a JobID"""
+        return self.encode("hex")
+
+    @property
+    def dothex(self):
+        """Return dotted hexidecimal representation of a JobID"""
+        return self.encode("dothex")
+
+    @property
+    def words(self):
+        """Return words (mnemonic) representation of a JobID"""
+        return self.encode("words")
+
+    @property
+    def kvs(self):
+        """Return KVS directory path of a JobID"""
+        return self.encode("kvs")
+
+    def __str__(self):
+        return self.encode()
+
+    def __repr__(self):
+        return f"JobID({self})"
+
+
 class SubmitFuture(Future):
     def get_id(self):
         return submit_get_id(self)

--- a/src/bindings/python/flux/wrapper.py
+++ b/src/bindings/python/flux/wrapper.py
@@ -190,7 +190,7 @@ class FunctionWrapper(object):
                 # Unpack wrapper objects
                 args[i] = args[i].handle
             elif isinstance(args[i], six.text_type):
-                args[i] = args[i].encode("utf-8")
+                args[i] = args[i].encode("utf-8", errors="surrogateescape")
 
         try:
             result = self.fun(*args)

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -505,6 +505,14 @@ int main (int argc, char *argv[])
     return (exitval);
 }
 
+static flux_jobid_t parse_jobid (const char *s)
+{
+    flux_jobid_t id;
+    if (flux_job_id_parse (s, &id) < 0)
+        log_msg_exit ("error parsing jobid: \"%s\"", s);
+    return id;
+}
+
 /* Parse a free argument 's', expected to be a 64-bit unsigned.
  * On error, exit complaining about parsing 'name'.
  */
@@ -604,7 +612,7 @@ int cmd_priority (optparse_t *p, int argc, char **argv)
     if (!(h = flux_open (NULL, 0)))
         log_err_exit ("flux_open");
 
-    id = parse_arg_unsigned (argv[optindex++], "jobid");
+    id = parse_jobid (argv[optindex++]);
     priority = parse_arg_unsigned (argv[optindex++], "priority");
 
     if (!(f = flux_job_set_priority (h, id, priority)))
@@ -631,7 +639,7 @@ int cmd_raise (optparse_t *p, int argc, char **argv)
         exit (1);
     }
 
-    id = parse_arg_unsigned (argv[optindex++], "jobid");
+    id = parse_jobid (argv[optindex++]);
     if (optindex < argc)
         note = parse_arg_message (argv + optindex, "message");
 
@@ -837,7 +845,7 @@ int cmd_kill (optparse_t *p, int argc, char **argv)
         exit (1);
     }
 
-    id = parse_arg_unsigned (argv[optindex++], "jobid");
+    id = parse_jobid (argv[optindex++]);
 
     s = optparse_get_str (p, "signal", "SIGTERM");
     if ((signum = str2signum (s))< 0)
@@ -927,7 +935,7 @@ int cmd_cancel (optparse_t *p, int argc, char **argv)
         exit (1);
     }
 
-    id = parse_arg_unsigned (argv[optindex++], "jobid");
+    id = parse_jobid (argv[optindex++]);
     if (optindex < argc)
         note = parse_arg_message (argv + optindex, "message");
 
@@ -1113,7 +1121,7 @@ int cmd_list_ids (optparse_t *p, int argc, char **argv)
 
     ids_len = argc - optindex;
     for (i = 0; i < ids_len; i++) {
-        flux_jobid_t id = parse_arg_unsigned (argv[optindex + i], "id");
+        flux_jobid_t id = parse_jobid (argv[optindex + i]);
         flux_future_t *f;
         if (!(f = flux_job_list_id (h, id, list_attrs)))
             log_err_exit ("flux_job_list_id");
@@ -2015,7 +2023,7 @@ int cmd_attach (optparse_t *p, int argc, char **argv)
         optparse_print_usage (p);
         exit (1);
     }
-    ctx.id = parse_arg_unsigned (argv[optindex++], "jobid");
+    ctx.id = parse_jobid (argv[optindex++]);
     ctx.p = p;
 
     if (!(ctx.h = flux_open (NULL, 0)))
@@ -2186,7 +2194,7 @@ int cmd_status (optparse_t *p, int argc, char **argv)
 
     for (i = 0; i < njobs; i++) {
         struct job_status *stat = &stats[i];
-        stat->id = parse_arg_unsigned (argv[optindex+i], "jobid");
+        stat->id = parse_jobid (argv[optindex+i]);
         stat->exception_exit_code = exception_exit_code;
 
         if (!(f = flux_job_event_watch (h, stat->id, "eventlog", 0)))
@@ -2290,7 +2298,7 @@ int cmd_id (optparse_t *p, int argc, char **argv)
 static void print_job_namespace (const char *src)
 {
     char ns[64];
-    flux_jobid_t id = parse_arg_unsigned (src, "jobid");
+    flux_jobid_t id = parse_jobid (src);
     if (flux_job_kvs_namespace (ns, sizeof (ns), id) < 0)
         log_msg_exit ("error getting kvs namespace for %ju", id);
     printf ("%s\n", ns);
@@ -2466,7 +2474,7 @@ int cmd_eventlog (optparse_t *p, int argc, char **argv)
         exit (1);
     }
 
-    ctx.id = parse_arg_unsigned (argv[optindex++], "jobid");
+    ctx.id = parse_jobid (argv[optindex++]);
     ctx.path = optparse_get_str (p, "path", "eventlog");
     ctx.p = p;
     entry_format_parse_options (p, &ctx.e);
@@ -2621,7 +2629,7 @@ int cmd_wait_event (optparse_t *p, int argc, char **argv)
         optparse_print_usage (p);
         exit (1);
     }
-    ctx.id = parse_arg_unsigned (argv[optindex++], "jobid");
+    ctx.id = parse_jobid (argv[optindex++]);
     ctx.p = p;
     ctx.wait_event = argv[optindex++];
     ctx.timeout = optparse_get_duration (p, "timeout", -1.0);
@@ -2699,7 +2707,7 @@ int cmd_info (optparse_t *p, int argc, char **argv)
         exit (1);
     }
 
-    ctx.id = parse_arg_unsigned (argv[optindex++], "jobid");
+    ctx.id = parse_jobid (argv[optindex++]);
 
     if (!(ctx.keys = json_array ()))
         log_msg_exit ("json_array");
@@ -2765,7 +2773,7 @@ int cmd_wait (optparse_t *p, int argc, char **argv)
         exit (1);
     }
     if (optindex < argc) {
-        id = parse_arg_unsigned (argv[optindex++], "jobid");
+        id = parse_jobid (argv[optindex++]);
         if (optparse_hasopt (p, "all"))
             log_err_exit ("jobid not supported with --all");
     }

--- a/src/cmd/flux-jobs.py
+++ b/src/cmd/flux-jobs.py
@@ -584,7 +584,7 @@ class JobsOutputFormat(flux.util.OutputFormat):
         "t_inactive": "T_INACTIVE",
         "runtime": "RUNTIME",
         "status": "STATUS",
-        "status_abbrev": "STATUS",
+        "status_abbrev": "ST",
         "exception.occurred": "EXCEPTION-OCCURRED",
         "exception.severity": "EXCEPTION-SEVERITY",
         "exception.type": "EXCEPTION-TYPE",
@@ -649,7 +649,7 @@ def main():
         fmt = args.format
     else:
         fmt = (
-            "{id.f58:>12} {username:<8.8} {name:<10.10} {status_abbrev:>6.6} "
+            "{id.f58:>12} {username:<8.8} {name:<10.10} {status_abbrev:>2.2} "
             "{ntasks:>6} {nnodes:>6h} {runtime!F:>8h} "
             "{ranks:h}"
         )

--- a/src/cmd/flux-jobs.py
+++ b/src/cmd/flux-jobs.py
@@ -649,7 +649,7 @@ def main():
         fmt = args.format
     else:
         fmt = (
-            "{id:>18} {username:<8.8} {name:<10.10} {status_abbrev:>6.6} "
+            "{id.f58:>12} {username:<8.8} {name:<10.10} {status_abbrev:>6.6} "
             "{ntasks:>6} {nnodes:>6h} {runtime!F:>8h} "
             "{ranks:h}"
         )

--- a/src/cmd/flux-jobs.py
+++ b/src/cmd/flux-jobs.py
@@ -22,11 +22,11 @@ import fileinput
 import json
 from datetime import datetime, timedelta
 
-import flux.job
 import flux.constants
 import flux.util
 from flux.core.inner import raw
 from flux.memoized_property import memoized_property
+from flux.job import JobID
 
 LOGGER = logging.getLogger("flux-jobs")
 
@@ -128,6 +128,9 @@ class JobInfo:
         #  Set defaults, then update with job-info.list response items:
         combined_dict = self.defaults.copy()
         combined_dict.update(info_resp)
+
+        #  Cast jobid to JobID
+        combined_dict["id"] = JobID(combined_dict["id"])
 
         #  Rename "state" to "state_id" and "result" to "result_id"
         #  until returned state is a string:
@@ -305,6 +308,11 @@ def fetch_jobs_flux(args, fields):
     # Note there is no attr for "id", its always returned
     fields2attrs = {
         "id": (),
+        "id.hex": (),
+        "id.f58": (),
+        "id.kvs": (),
+        "id.words": (),
+        "id.dothex": (),
         "userid": ("userid",),
         "username": ("userid",),
         "priority": ("priority",),
@@ -477,8 +485,8 @@ def parse_args():
     )
     parser.add_argument(
         "jobids",
-        type=int,
         metavar="JOBID",
+        type=JobID,
         nargs="*",
         help="Limit output to specific Job IDs",
     )
@@ -549,6 +557,11 @@ class JobsOutputFormat(flux.util.OutputFormat):
     #  List of legal format fields and their header names
     headings = {
         "id": "JOBID",
+        "id.hex": "JOBID",
+        "id.f58": "JOBID",
+        "id.kvs": "JOBID",
+        "id.words": "JOBID",
+        "id.dothex": "JOBID",
         "userid": "UID",
         "username": "USER",
         "priority": "PRI",

--- a/src/common/libjob/job.c
+++ b/src/common/libjob/job.c
@@ -13,6 +13,7 @@
 #endif
 #include <unistd.h>
 #include <sys/types.h>
+#include <ctype.h>
 #include <flux/core.h>
 #if HAVE_FLUX_SECURITY
 #include <flux/security/sign.h>
@@ -556,6 +557,85 @@ int flux_job_strtoresult (const char *s, flux_job_result_t *result)
 inval:
     errno = EINVAL;
     return -1;
+}
+
+int flux_job_id_parse (const char *s, flux_jobid_t *idp)
+{
+    int len;
+    const char *p = s;
+    if (s == NULL
+        || idp == NULL
+        || (len = strlen (s)) == 0) {
+        errno = EINVAL;
+        return -1;
+    }
+    /*  Remove leading whitespace
+     */
+    while (isspace(*p))
+        p++;
+    /*  Ignore any `job.` prefix. This allows a "kvs" encoding
+     *   created by flux_job_id_encode(3) to properly decode.
+     */
+    if (strncmp (p, "job.", 4) == 0)
+        p += 4;
+    return fluid_parse (p, idp);
+}
+
+int flux_job_id_encode (flux_jobid_t id,
+                        const char *type,
+                        char *buf,
+                        size_t bufsz)
+{
+    fluid_string_type_t t;
+    if (buf == NULL) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (type == NULL || strcasecmp (type, "dec") == 0) {
+        int len = snprintf (buf, bufsz, "%ju", (uintmax_t) id);
+        if (len >= bufsz) {
+            errno = ENOSPC;
+            return -1;
+        }
+        return 0;
+    }
+    if (strcasecmp (type, "hex") == 0) {
+        int len = snprintf (buf, bufsz, "0x%jx", (uintmax_t) id);
+        if (len >= bufsz) {
+            errno = ENOSPC;
+            return -1;
+        }
+        return 0;
+    }
+
+    /* The following encodings all use fluid_encode(3).
+     */
+    if (strcasecmp (type, "kvs") == 0) {
+        /* kvs: prepend "job." to "dothex" encoding.
+         */
+        int len = snprintf (buf, bufsz, "job.");
+        if (len >= bufsz) {
+            errno = ENOSPC;
+            return -1;
+        }
+        buf += len;
+        bufsz -= len;
+        type = "dothex";
+    }
+    if (strcasecmp (type, "dothex") == 0)
+        t = FLUID_STRING_DOTHEX;
+    else if (strcasecmp (type, "words") == 0)
+        t = FLUID_STRING_MNEMONIC;
+    else if (strcasecmp (type, "f58") == 0)
+        t = FLUID_STRING_F58;
+    else {
+        /*  Return EPROTO for invalid type to differentiate from
+         *   other invalid arguments.
+         */
+        errno = EPROTO;
+        return -1;
+    }
+    return fluid_encode (buf, bufsz, id, t);
 }
 
 /*

--- a/src/common/libjob/job.h
+++ b/src/common/libjob/job.h
@@ -63,6 +63,22 @@ typedef enum {
 
 typedef uint64_t flux_jobid_t;
 
+/*  Parse a jobid from NULL-teminated string 's' in any supported encoding.
+ *  Returns 0 on success, -1 on failure.
+ */
+int flux_job_id_parse (const char *s, flux_jobid_t *id);
+
+/*  Encode a jobid into encoding "type", writing the result to buffer
+ *   buf of size bufsz.
+ *  Supported encoding types include:
+ *   "dec", "hex", "kvs", "dothex", "words", or "f58".
+ *  Returns 0 on success, -1 on failure with errno set:
+ *   EPROTO: Invalid encoding type
+ *   EINVAL: Invalid other argument
+ */
+int flux_job_id_encode (flux_jobid_t id, const char *type,
+                        char *buf, size_t bufsz);
+
 const char *flux_job_statetostr (flux_job_state_t state, bool single_char);
 
 int flux_job_strtostate (const char *s, flux_job_state_t *state);

--- a/src/common/libutil/fluid.c
+++ b/src/common/libutil/fluid.c
@@ -178,11 +178,14 @@ int fluid_decode (const char *s, fluid_t *fluidp, fluid_string_type_t type)
              * Also, 's' is not modified so it is safe to cast away const.
              */
             rc = mn_decode ((char *)s, (void *)&fluid, sizeof (fluid_t));
-            if (rc != 8)
+            if (rc != 8) {
+                errno = EINVAL;
                 return -1;
+            }
             break;
 
         default:
+            errno = EINVAL;
             return -1;
     }
     if (fluid_validate (fluid) < 0)

--- a/src/common/libutil/fluid.h
+++ b/src/common/libutil/fluid.h
@@ -22,7 +22,7 @@
 typedef enum {
     FLUID_STRING_DOTHEX = 1,    // x.x.x.x
     FLUID_STRING_MNEMONIC = 2,  // mnemonicode x-x-x--x-x-x
-    FLUID_STRING_F58 = 3,       // base58 ƒXXXX
+    FLUID_STRING_F58 = 3,       // FLUID base58 enc: ƒXXXX or fXXXX
 } fluid_string_type_t;
 
 struct fluid_generator {
@@ -68,6 +68,20 @@ int fluid_encode (char *buf, int bufsz, fluid_t fluid,
  */
 int fluid_decode (const char *s, fluid_t *fluid,
                   fluid_string_type_t type);
+
+/* Attempt to detect the string type of encoded FLUID in `s`.
+ *  returns the string type or 0 if not one the defined encodings above.
+ *  (FLUID may still be encoded as integer in decimal or hex)
+ */
+fluid_string_type_t fluid_string_detect_type (const char *s);
+
+/* Convert NULL-terminated string 's' to 'fluid' by auto-detecting
+ *  the encoding in 's'.
+ * Supported encodings include any fluid_string_type_t, or an integer
+ *  in decimal or hexidecimal prefixed with "0x".
+ * Return 0 on success, -1 on failure.
+ */
+int fluid_parse (const char *s, fluid_t *fluid);
 
 #endif /* !_UTIL_FLUID_H */
 

--- a/src/common/libutil/fluid.h
+++ b/src/common/libutil/fluid.h
@@ -22,6 +22,7 @@
 typedef enum {
     FLUID_STRING_DOTHEX = 1,    // x.x.x.x
     FLUID_STRING_MNEMONIC = 2,  // mnemonicode x-x-x--x-x-x
+    FLUID_STRING_F58 = 3,       // base58 ƒXXXX
 } fluid_string_type_t;
 
 struct fluid_generator {

--- a/src/common/libutil/test/fluid.c
+++ b/src/common/libutil/test/fluid.c
@@ -100,6 +100,95 @@ void test_f58 (void)
         "fluid_decode ('x1', FLUID_STRING_F58) returns EINVAL");
 }
 
+struct fluid_parse_test {
+    fluid_t id;
+    const char *input;
+};
+
+struct fluid_parse_test fluid_parse_tests [] = {
+    { 0, "ƒ1" },
+    { 1, "ƒ2" },
+    { 57, "ƒz" },
+    { 1234, "ƒNH" },
+    { 1888, "ƒZZ" },
+    { 3363, "ƒzz" },
+    { 3364, "ƒ211" },
+    { 4369, "ƒ2JL" },
+    { 65535, "ƒLUv" },
+    { 4294967295, "ƒ7YXq9G" },
+    { 633528662, "ƒxyzzy" },
+    { 6731191091817518LL, "ƒuZZybuNNy" },
+    { 18446744073709551614UL, "ƒjpXCZedGfVP" },
+    { 18446744073709551615UL, "ƒjpXCZedGfVQ" },
+    { 0, "f1" },
+    { 1, "f2" },
+    { 4294967295, "f7YXq9G" },
+    { 633528662, "fxyzzy" },
+    { 18446744073709551614UL, "fjpXCZedGfVP" },
+    { 18446744073709551615UL, "fjpXCZedGfVQ" },
+    { 1234, "1234" },
+    { 1888, "1888" },
+    { 3363, "3363" },
+    { 3364, "3364" },
+    { 4369, "4369" },
+    { 6731191091817518LL, "6731191091817518" },
+    { 18446744073709551614UL, "18446744073709551614" },
+    { 18446744073709551615UL, "18446744073709551615" },
+    { 0, "0x0" },
+    { 1, "0x1" },
+    { 57, "0x39" },
+    { 1234, "0x4d2" },
+    { 1888, "0x760" },
+    { 3363, "0xd23" },
+    { 4369, "0x1111" },
+    { 65535, "0xffff" },
+    { 4294967295, "0xffffffff" },
+    { 633528662,  "0x25c2e156" },
+    { 6731191091817518LL, "0x17e9fb8df16c2e" },
+    { 18446744073709551615UL, "0xffffffffffffffff" },
+    { 0, "0.0.0.0" },
+    { 1, "0000.0000.0000.0001" },
+    { 57, "0.0.0.0039" },
+    { 1234, "0000.0000.0000.04d2" },
+    { 1888, "0000.0000.0000.0760" },
+    { 4369, "0000.0000.0000.1111" },
+    { 65535, "0.0.0.ffff" },
+    { 4294967295, "0000.0000.ffff.ffff" },
+    { 18446744073709551615UL, "ffff.ffff.ffff.ffff" },
+    { 0, NULL },
+};
+
+static void test_fluid_parse (void)
+{
+    fluid_t id;
+    struct fluid_parse_test *tp = fluid_parse_tests;
+    while (tp->input != NULL) {
+        id = 0;
+        ok (fluid_parse (tp->input, &id) == 0,
+            "fluid_parse (%s) works", tp->input);
+        ok (id == tp->id,
+            "%s -> %ju", tp->input, (uintmax_t) id);
+        tp++;
+    }
+
+    ok (fluid_parse (" 0xffff   ", &id) == 0,
+        "flux_parse() works with leading/trailing whitespace");
+    ok (id == 65535,
+        "flux_parse with whitespace works");
+
+    id = 0;
+    ok (fluid_parse (NULL, &id) < 0 && errno == EINVAL,
+        "fluid_parse returns EINVAL for with NULL string");
+    ok (fluid_parse ("", &id) < 0 && errno == EINVAL,
+        "fluid_parse returns EINVAL for with empty string");
+    ok (fluid_parse ("boo", &id) < 0 && errno == EINVAL,
+        "fluid_parse returns EINVAL for 'boo'");
+    ok (fluid_parse ("f", &id) < 0 && errno == EINVAL,
+        "fluid_parse returns EINVAL for 'f'");
+    ok (fluid_parse ("-1", &id) < 0 && errno == EINVAL,
+        "fluid_parse returns EINVAL for '-1'");
+}
+
 void test_basic (void)
 {
     struct fluid_generator gen;
@@ -231,6 +320,7 @@ int main (int argc, char *argv[])
 
     test_basic ();
     test_f58 ();
+    test_fluid_parse ();
 
     done_testing ();
     return 0;

--- a/src/common/libutil/test/fluid.c
+++ b/src/common/libutil/test/fluid.c
@@ -8,10 +8,99 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#include <errno.h>
+
 #include "src/common/libtap/tap.h"
 #include "src/common/libutil/fluid.h"
 
-int main (int argc, char *argv[])
+struct f58_test {
+    fluid_t id;
+    const char *f58;
+};
+
+struct f58_test f58_tests [] = {
+    { 0, "ƒ1" },
+    { 1, "ƒ2" },
+    { 57, "ƒz" },
+    { 1234, "ƒNH" },
+    { 1888, "ƒZZ" },
+    { 3363, "ƒzz" },
+    { 3364, "ƒ211" },
+    { 4369, "ƒ2JL" },
+    { 65535, "ƒLUv" },
+    { 4294967295, "ƒ7YXq9G" },
+    { 633528662, "ƒxyzzy" },
+    { 6731191091817518LL, "ƒuZZybuNNy" },
+    { 18446744073709551614UL, "ƒjpXCZedGfVP" },
+    { 18446744073709551615UL, "ƒjpXCZedGfVQ" },
+    { 0, NULL },
+};
+
+struct f58_test f58_alt_tests [] = {
+    { 0, "f1" },
+    { 0, "f111" },
+    { 1, "f2" },
+    { 57, "fz" },
+    { 1234, "fNH" },
+    { 1888, "fZZ" },
+    { 3363, "fzz" },
+    { 3364, "f211" },
+    { 4369, "f2JL" },
+    { 65535, "fLUv" },
+    { 4294967295, "f7YXq9G" },
+    { 633528662, "fxyzzy" },
+    { 6731191091817518LL, "fuZZybuNNy" },
+    { 18446744073709551614UL, "fjpXCZedGfVP" },
+    { 18446744073709551615UL, "fjpXCZedGfVQ" },
+    { 0, NULL },
+};
+
+void test_f58 (void)
+{
+    fluid_string_type_t type = FLUID_STRING_F58;
+    char buf[16];
+    fluid_t id;
+    struct f58_test *tp = f58_tests;
+    while (tp->f58 != NULL) {
+        ok (fluid_encode (buf, sizeof(buf), tp->id, type) == 0,
+            "f58_encode (%ju)", tp->id);
+        is (buf, tp->f58,
+            "f58_encode %ju -> %s", tp->id, buf);
+        ok (fluid_decode (tp->f58, &id, type) == 0,
+            "f58_decode (%s)", tp->f58);
+        ok (id == tp->id,
+            "%s -> %ju", tp->f58, (uintmax_t) id);
+        tp++;
+    }
+    tp = f58_alt_tests;
+    while (tp->f58 != NULL) {
+        ok (fluid_decode (tp->f58, &id, type) == 0,
+            "f58_decode (%s)", tp->f58);
+        ok (id == tp->id,
+            "%s -> %ju", tp->f58, (uintmax_t) id);
+        tp++;
+    }
+
+    ok (fluid_encode (buf, 1, 1, type) < 0 && errno == EOVERFLOW,
+        "fluid_encode (buf, 1, 1, F58) returns EOVERFLOW");
+    ok (fluid_encode (buf, 5, 65535, type) < 0 && errno == EOVERFLOW,
+        "fluid_encode (buf, 5, 65535, F58) returns EOVERFLOW");
+
+    ok (fluid_decode ("1234", &id, type) < 0 && errno == EINVAL,
+        "fluid_decode ('aaa', FLUID_STRING_F58) returns EINVAL");
+    ok (fluid_decode ("aaa", &id, type) < 0 && errno == EINVAL,
+        "fluid_decode ('aaa', FLUID_STRING_F58) returns EINVAL");
+    ok (fluid_decode ("f", &id, type) < 0 && errno == EINVAL,
+        "fluid_decode ('f', FLUID_STRING_F58) returns EINVAL");
+    ok (fluid_decode ("flux", &id, type) < 0 && errno == EINVAL,
+        "fluid_decode ('flux', FLUID_STRING_F58) returns EINVAL");
+    ok (fluid_decode ("f1230", &id, type) < 0 && errno == EINVAL,
+        "fluid_decode ('f1230', FLUID_STRING_F58) returns EINVAL");
+    ok (fluid_decode ("x1", &id, type) < 0 && errno == EINVAL,
+        "fluid_decode ('x1', FLUID_STRING_F58) returns EINVAL");
+}
+
+void test_basic (void)
 {
     struct fluid_generator gen;
     fluid_t id, id2;
@@ -20,8 +109,6 @@ int main (int argc, char *argv[])
     int generate_errors;
     int encode_errors;
     int decode_errors;
-
-    plan (NO_PLAN);
 
     ok (fluid_init (&gen, 0, 0) == 0,
         "fluid_init id=0 timestamp=0 works");
@@ -136,6 +223,14 @@ int main (int argc, char *argv[])
         "fluid_decode type=MNEMONIC fails on input=bogus");
     ok (fluid_decode ("a-a-a--a-a-a", &id, FLUID_STRING_MNEMONIC) < 0,
         "fluid_decode type=MNEMONIC fails on unknown words xx-xx-xx--xx-xx-xx");
+}
+
+int main (int argc, char *argv[])
+{
+    plan (NO_PLAN);
+
+    test_basic ();
+    test_f58 ();
 
     done_testing ();
     return 0;

--- a/t/python/t0010-job.py
+++ b/t/python/t0010-job.py
@@ -365,6 +365,66 @@ class TestJob(unittest.TestCase):
         jobid = job.submit(self.fh, JobspecV1.from_nest_command(["sleep", "0"]))
         self.assertGreater(jobid, 0)
 
+    def test_24_jobid(self):
+        """Test JobID class"""
+        parse_tests = [
+            {
+                "int": 0,
+                "dec": "0",
+                "hex": "0x0",
+                "dothex": "0000.0000.0000.0000",
+                "kvs": "job.0000.0000.0000.0000",
+                "f58": "ƒ1",
+                "words": "academy-academy-academy--academy-academy-academy",
+            },
+            {
+                "int": 1,
+                "dec": "1",
+                "hex": "0x1",
+                "dothex": "0000.0000.0000.0001",
+                "kvs": "job.0000.0000.0000.0001",
+                "f58": "ƒ2",
+                "words": "acrobat-academy-academy--academy-academy-academy",
+            },
+            {
+                "int": 65535,
+                "dec": "65535",
+                "hex": "0xffff",
+                "dothex": "0000.0000.0000.ffff",
+                "kvs": "job.0000.0000.0000.ffff",
+                "f58": "ƒLUv",
+                "words": "nevada-archive-academy--academy-academy-academy",
+            },
+            {
+                "int": 6787342413402046,
+                "dec": "6787342413402046",
+                "hex": "0x181d0d4d850fbe",
+                "dothex": "0018.1d0d.4d85.0fbe",
+                "kvs": "job.0018.1d0d.4d85.0fbe",
+                "f58": "ƒuzzybunny",
+                "words": "cake-plume-nepal--neuron-pencil-academy",
+            },
+            {
+                "int": 18446744073709551614,
+                "dec": "18446744073709551614",
+                "hex": "0xfffffffffffffffe",
+                "dothex": "ffff.ffff.ffff.fffe",
+                "kvs": "job.ffff.ffff.ffff.fffe",
+                "f58": "ƒjpXCZedGfVP",
+                "words": "mustang-analyze-verbal--natural-analyze-verbal",
+            },
+        ]
+        for test in parse_tests:
+            for key in test:
+                jobid_int = test["int"]
+                jobid = job.JobID(test[key])
+                self.assertEqual(jobid, jobid_int)
+                jobid_repr = repr(jobid)
+                self.assertEqual(jobid_repr, f"JobID({jobid_int})")
+                if key not in ["int", "dec"]:
+                    # Ensure encode back to same type works
+                    self.assertEqual(getattr(jobid, key), test[key])
+
 
 if __name__ == "__main__":
     from subflux import rerun_under_flux

--- a/t/t2201-job-cmd.t
+++ b/t/t2201-job-cmd.t
@@ -9,12 +9,20 @@ fi
 
 # 2^64 - 1
 MAXJOBID_DEC=18446744073709551615
+MAXJOBID_HEX="0xffffffffffffffff"
 MAXJOBID_KVS="job.ffff.ffff.ffff.ffff"
+MAXJOBID_DOTHEX="ffff.ffff.ffff.ffff"
 MAXJOBID_WORDS="natural-analyze-verbal--natural-analyze-verbal"
+MAXJOBID_F58="ƒjpXCZedGfVQ"
+MAXJOBIDS_LIST="$MAXJOBID_DEC $MAXJOBID_HEX $MAXJOBID_KVS $MAXJOBID_DOTHEX $MAXJOBID_WORDS $MAXJOBID_F58"
 
 MINJOBID_DEC=0
+MINJOBID_HEX="0x0"
 MINJOBID_KVS="job.0000.0000.0000.0000"
+MINJOBID_DOTHEX="0000.0000.0000.0000"
 MINJOBID_WORDS="academy-academy-academy--academy-academy-academy"
+MINJOBID_F58="ƒ1"
+MINJOBIDS_LIST="$MINJOBID_DEC $MINJOBID_HEX $MINJOBID_KVS $MINJOBID_DOTHEX $MINJOBID_WORDS $MINJOBID_F58"
 
 test_under_flux 1 job
 
@@ -95,6 +103,19 @@ test_expect_success 'flux-job: id with invalid --to arg fails' '
 	test_must_fail flux job id --to=invalid 42
 '
 
+test_expect_success 'flux-job: id works with min/max jobids' '
+    for max in $MAXJOBIDS_LIST; do
+        jobid=$(flux job id $max) &&
+        test_debug "echo flux jobid $max -> $jobid" &&
+        test "$jobid" = "$MAXJOBID_DEC"
+    done &&
+    for min in $MINJOBIDS_LIST; do
+        jobid=$(flux job id $min) &&
+        test_debug "echo flux jobid $min -> $jobid" &&
+        test "$jobid" = "$MINJOBID_DEC"
+    done
+'
+
 test_expect_success 'flux-job: id --to=dec works' '
 	jobid=$(flux job id --to=dec $MAXJOBID_DEC) &&
 	test "$jobid" = "$MAXJOBID_DEC" &&
@@ -114,6 +135,43 @@ test_expect_success 'flux-job: id --to=kvs works' '
 	test "$jobid" = "$MAXJOBID_KVS" &&
 	jobid=$(flux job id --to=kvs $MINJOBID_DEC) &&
 	test "$jobid" = "$MINJOBID_KVS"
+'
+
+test_expect_success 'flux-job: id --to=hex works' '
+	jobid=$(flux job id --to=hex $MAXJOBID_DEC) &&
+	test "$jobid" = "$MAXJOBID_HEX" &&
+	jobid=$(flux job id --to=hex $MINJOBID_DEC) &&
+	test "$jobid" = "$MINJOBID_HEX"
+'
+
+test_expect_success 'flux-job: id --to=dothex works' '
+	jobid=$(flux job id --to=dothex $MAXJOBID_DEC) &&
+	test "$jobid" = "$MAXJOBID_DOTHEX" &&
+	jobid=$(flux job id --to=dothex $MINJOBID_DEC) &&
+	test "$jobid" = "$MINJOBID_DOTHEX"
+'
+
+test_expect_success 'flux-job: id --to=f58 works' '
+	jobid=$(flux job id --to=f58 $MAXJOBID_DEC) &&
+	test "$jobid" = "$MAXJOBID_F58" &&
+	jobid=$(flux job id --to=f58 $MINJOBID_DEC) &&
+	test "$jobid" = "$MINJOBID_F58"
+'
+
+test_expect_success 'flux-job: id fails on bad input' '
+	test_must_fail flux job id badstring &&
+	test_must_fail flux job id job.0000.0000 &&
+	test_must_fail flux job id job.0000.0000.0000.000P
+'
+
+test_expect_success 'flux-job: id fails on bad input' '
+	test_must_fail flux job id 42plusbad &&
+	test_must_fail flux job id meep &&
+	test_must_fail flux job id 18446744073709551616
+'
+
+test_expect_success 'flux-job: id fails on bad words input' '
+	test_must_fail flux job id bad-words
 '
 
 test_expect_success 'flux-job: priority fails with bad FLUX_URI' '

--- a/t/t2201-job-cmd.t
+++ b/t/t2201-job-cmd.t
@@ -10,12 +10,10 @@ fi
 # 2^64 - 1
 MAXJOBID_DEC=18446744073709551615
 MAXJOBID_KVS="job.ffff.ffff.ffff.ffff"
-MAXJOBID_HEX="ffff.ffff.ffff.ffff"
 MAXJOBID_WORDS="natural-analyze-verbal--natural-analyze-verbal"
 
 MINJOBID_DEC=0
 MINJOBID_KVS="job.0000.0000.0000.0000"
-MINJOBID_HEX="0000.0000.0000.0000"
 MINJOBID_WORDS="academy-academy-academy--academy-academy-academy"
 
 test_under_flux 1 job
@@ -83,7 +81,7 @@ test_expect_success 'flux-job: can submit jobspec on stdin without -' '
         flux job submit <basic.json
 '
 
-test_expect_success 'flux-job: id without from/to args is dec to dec' '
+test_expect_success 'flux-job: id without to arg is dec to dec' '
 	jobid=$(flux job id 42) &&
 	test "$jobid" = "42"
 '
@@ -93,37 +91,8 @@ test_expect_success 'flux-job: id from stdin works' '
 	test "$jobid" = "42"
 '
 
-test_expect_success 'flux-job: id with invalid from/to arg fails' '
-	test_must_fail flux job id --from=invalid 42 &&
+test_expect_success 'flux-job: id with invalid --to arg fails' '
 	test_must_fail flux job id --to=invalid 42
-'
-
-test_expect_success 'flux-job: id --from=dec works' '
-	jobid=$(flux job id --from=dec $MAXJOBID_DEC) &&
-	test "$jobid" = "$MAXJOBID_DEC" &&
-	jobid=$(flux job id --from=dec $MINJOBID_DEC) &&
-	test "$jobid" = "$MINJOBID_DEC"
-'
-
-test_expect_success 'flux-job: id --from=words works' '
-	jobid=$(flux job id --from=words $MAXJOBID_WORDS) &&
-	test "$jobid" = "$MAXJOBID_DEC" &&
-	jobid=$(flux job id --from=words $MINJOBID_WORDS) &&
-	test "$jobid" = "$MINJOBID_DEC"
-'
-
-test_expect_success 'flux-job: id --from=kvs works' '
-	jobid=$(flux job id --from=kvs $MAXJOBID_KVS) &&
-	test "$jobid" = "$MAXJOBID_DEC" &&
-	jobid=$(flux job id --from=kvs $MINJOBID_KVS) &&
-	test "$jobid" = "$MINJOBID_DEC"
-'
-
-test_expect_success 'flux-job: id --from=hex works' '
-	jobid=$(flux job id --from=hex $MAXJOBID_HEX) &&
-	test "$jobid" = "$MAXJOBID_DEC" &&
-	jobid=$(flux job id --from=hex $MINJOBID_HEX) &&
-	test "$jobid" = "$MINJOBID_DEC"
 '
 
 test_expect_success 'flux-job: id --to=dec works' '
@@ -145,31 +114,6 @@ test_expect_success 'flux-job: id --to=kvs works' '
 	test "$jobid" = "$MAXJOBID_KVS" &&
 	jobid=$(flux job id --to=kvs $MINJOBID_DEC) &&
 	test "$jobid" = "$MINJOBID_KVS"
-'
-
-test_expect_success 'flux-job: id --to=hex works' '
-	jobid=$(flux job id --to=hex $MAXJOBID_DEC) &&
-	test "$jobid" = "$MAXJOBID_HEX" &&
-	jobid=$(flux job id --to=hex $MINJOBID_DEC) &&
-	test "$jobid" = "$MINJOBID_HEX"
-'
-
-test_expect_success 'flux-job: id --from=kvs fails on bad input' '
-	test_must_fail flux job id --from=kvs badstring &&
-	test_must_fail flux job id --from=kvs \
-	    job.0000.0000 &&
-	test_must_fail flux job id --from=kvs \
-	    job.0000.0000.0000.000P
-'
-
-test_expect_success 'flux-job: id --from=dec fails on bad input' '
-	test_must_fail flux job id --from=dec 42plusbad &&
-	test_must_fail flux job id --from=dec meep &&
-	test_must_fail flux job id --from=dec 18446744073709551616
-'
-
-test_expect_success 'flux-job: id --from=words fails on bad input' '
-	test_must_fail flux job id --from=words badwords
 '
 
 test_expect_success 'flux-job: priority fails with bad FLUX_URI' '

--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -293,6 +293,16 @@ test_expect_success 'flux-jobs specific IDs works' '
 	done
 '
 
+test_expect_success 'flux jobs can take specific IDs in any form' '
+	id=$(head -1 run.ids) &&
+	for f in f58 hex dothex kvs words; do
+		flux job id --to=${f} ${id}
+	done > ids.specific.list &&
+	flux jobs -no {id} $(cat ids.specific.list) > ids.specific.out &&
+	for i in $(seq 1 5); do echo $id >>ids.specific.expected; done &&
+	test_cmp ids.specific.expected ids.specific.out
+'
+
 test_expect_success 'flux-jobs error on bad IDs' '
 	flux jobs --suppress-header 0 1 2 2> ids.err &&
 	count=`grep -i unknown ids.err | wc -l` &&
@@ -325,6 +335,21 @@ test_expect_success 'flux-jobs --format={id} works' '
 	test_cmp idsR.out run.ids &&
 	flux jobs --suppress-header --filter=inactive --format="{id}" > idsI.out &&
 	test_cmp idsI.out inactive.ids
+'
+
+test_expect_success 'flux-jobs --format={id.f58},{id.hex},{id.dothex},{id.words} works' '
+	flux jobs -ano {id},{id.f58},{id.hex},{id.kvs},{id.dothex},{id.words} \
+	    | sort -n > ids.XX.out &&
+	for id in $(cat all.ids); do
+		printf "%s,%s,%s,%s,%s,%s\n" \
+		       $id \
+		       $(flux job id --to=f58 $id) \
+		       $(flux job id --to=hex $id) \
+		       $(flux job id --to=kvs $id) \
+		       $(flux job id --to=dothex $id) \
+		       $(flux job id --to=words $id)
+	done | sort -n > ids.XX.expected &&
+	test_cmp ids.XX.expected ids.XX.out
 '
 
 test_expect_success 'flux-jobs --format={userid},{username} works' '
@@ -624,6 +649,10 @@ test_expect_success 'flux-jobs --format={expiration!D:h},{t_remaining!H:h} works
 test_expect_success 'flux-jobs: header included with all custom formats' '
 	cat <<-EOF >headers.expected &&
 	id==JOBID
+	id.f58==JOBID
+	id.hex==JOBID
+	id.dothex==JOBID
+	id.words==JOBID
 	userid==UID
 	username==USER
 	priority==PRI

--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -687,6 +687,8 @@ test_expect_success 'flux-jobs: header included with all custom formats' '
 	t_inactive!d==T_INACTIVE
 	t_cleanup!D==T_CLEANUP
 	t_run!F==T_RUN
+	status==STATUS
+	status_abbrev==ST
 	EOF
 	sed "s/\(.*\)==.*/\1=={\1}/" headers.expected > headers.fmt &&
 	flux jobs --from-stdin --format="$(cat headers.fmt)" \


### PR DESCRIPTION
This PR adds support for the proposed RFC19 F58 encoded JOBIDs.

It is a WIP because the final set of testing is not in place yet, in case the result is not acceptable for merging.

At its core, this PR adds a new FLUID string type `FLUID_STRING_F58`, which represents the Base58 encoding of FLUIDS (and therefore Flux JOBIDs).

Since all supported FLUID string representations are somewhat unambiguous, a `fluid_parse()` function is introduced which can automatically parse a FLUID from a string in any supported encoding.

The `fluid_parse()` function is then used to implement a `flux_job_id_parse()` to the public API (FLUIDs do not seem to be directly exposed in libflux API). `flux_job_id_parse()` is then used throughout `flux-job.c` to allow input of a JOBID in any supported encoding, instead of just decimal integers.

This also allowed dropping the need for the `flux job id --from` option, since the encoding of input is now auto-detected, e.g. 

```
$ flux job id ƒNH
1234
$ flux job id --to words ƒNH
turtle-academy-academy--academy-academy-academy
$ flux job id turtle-academy-academy--academy-academy-academy
1234
```

The JOBID conversion functions are then added to python bindings, and JobID class introduced, which allows easy conversion to/from the different JOBID representations.

Finally, the JobID class is introduced into `flux-jobs`, which allows various output fields like `id.hex` `id.dothex` `id.words`. `id.f58` is then made the default:

```
$ flux jobs -a -c 10
       JOBID USER     NAME       STATUS NTASKS NNODES  RUNTIME RANKS
  ƒQsm1jrTzf grondo   hostname       CD      1      1   0.072s 0
  ƒC7RLWTWPq grondo   hostname       CD      1      1   0.080s 0
  ƒ8jd8DVmwM grondo   sleep          CD      1      1   2.079s 0
  ƒ8fSahkXpB grondo   hostname       CD      1      1   0.074s 0
  ƒ8fPukZbVq grondo   hostname       CD      1      1   0.073s 0
  ƒ8fLxAEij1 grondo   hostnaem        F      1      1   0.078s 0
  ƒ8e2dCmHDy grondo   hostname       CD      1      1   0.084s 0
``` 