### PR TITLE
flux-hwloc: remove ignore of `HWLOC_OBJ_GROUP`

### DIFF
--- a/src/cmd/builtin/hwloc.c
+++ b/src/cmd/builtin/hwloc.c
@@ -177,8 +177,6 @@ static void topo_init_common (hwloc_topology_t *tp)
         log_err_exit ("hwloc_topology_set_flags");
     if (hwloc_topology_ignore_type (*tp, HWLOC_OBJ_CACHE) < 0)
         log_err_exit ("hwloc_topology_ignore_type OBJ_CACHE failed");
-    if (hwloc_topology_ignore_type (*tp, HWLOC_OBJ_GROUP) < 0)
-        log_err_exit ("hwloc_topology_ignore_type OBJ_GROUP failed");
 #else
     if (hwloc_topology_set_io_types_filter(*tp,
                                            HWLOC_TYPE_FILTER_KEEP_IMPORTANT)


### PR DESCRIPTION
Problem: When the `HWLOC_OBJ_GROUP` is ignored, the GPUs on the
Sierra/Lassen clusters are represented in the resource topology as
direct children of the node.  This topology ignores the fact that the
GPUs actually have locality with respect to the CPU sockets.  This
topology also is causing downstream affects with the fluxion scheduler
and its testsuite.  Depending on how the hwloc is read (either via
flux-core's flux-hwloc or directly via the hwloc API), the resource
topology changes (i.e., GPUs are children of the node versus the
sockets).  Also worth noting that the GPUs are children of the sockets
when using the hwloc V2 API, so ignoring the group creates a significant
difference in the topologies between hwloc versions.

Solution: remove the call to ignore `HWLOC_OBJ_GROUP` so that on the
Sierra/Lassen systems, the GPUs are children of the sockets.  This also
normalizes the resource topology across reading methods and hwloc
versions.  Now requesting a GPU on Sierra/Lassen can always be done with
a `node->socket->gpu` jobspec.

Related PR: flux-framework/flux-sched/pull/677