### PR TITLE
Allow JSON null or missing key to designate empty set in flux-resource list

### DIFF
--- a/src/cmd/flux-resource.py
+++ b/src/cmd/flux-resource.py
@@ -13,6 +13,7 @@ import logging
 import argparse
 import re
 from itertools import count, groupby
+import json
 
 import flux
 from flux.rpc import RPC
@@ -100,9 +101,11 @@ class Rv1:
     Simple class encapsulating a Flux Rv1 resource set
     """
 
-    def __init__(self, rset, state=None):
+    def __init__(self, rset=None, state=None):
         # pylint: disable=invalid-name
-        self.R_lite = rset["execution"]["R_lite"]
+        self.R_lite = []
+        if rset is not None:
+            self.R_lite = rset["execution"]["R_lite"]
         if state:
             self._state = state
 
@@ -235,8 +238,8 @@ class SchedResourceList:
     """
 
     def __init__(self, resp):
-        for state in resp:
-            setattr(self, f"_{state}", Rv1(resp[state], state=state))
+        for state in ["all", "down", "allocated"]:
+            setattr(self, f"_{state}", Rv1(resp.get(state), state=state))
 
     def __getattr__(self, attr):
         if attr.startswith("_"):

--- a/src/cmd/flux-resource.py
+++ b/src/cmd/flux-resource.py
@@ -292,7 +292,10 @@ def list_handler(args):
 
     formatter = flux.util.OutputFormat(headings, fmt, prepend="0.")
 
-    resp = RPC(flux.Flux(), "sched.resource-status").get()
+    if args.from_stdin:
+        resp = json.load(sys.stdin)
+    else:
+        resp = RPC(flux.Flux(), "sched.resource-status").get()
     resources = SchedResourceList(resp)
 
     if not args.no_header:
@@ -349,6 +352,9 @@ def main():
     )
     list_parser.add_argument(
         "-n", "--no-header", action="store_true", help="Suppress header output"
+    )
+    list_parser.add_argument(
+        "--from-stdin", action="store_true", help=argparse.SUPPRESS
     )
     list_parser.set_defaults(func=list_handler)
 

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -115,6 +115,7 @@ TESTSCRIPTS = \
 	t2301-schedutil-outstanding-requests.t \
 	t2302-sched-simple-up-down.t \
 	t2310-resource-module.t \
+	t2350-resource-list.t \
 	t2400-job-exec-test.t \
 	t2401-job-exec-hello.t \
 	t2402-job-exec-dummy.t \
@@ -192,7 +193,8 @@ EXTRA_DIST= \
 	shell/initrc/tests \
 	flux-jobs/tests \
 	scripts/run_timeout.py \
-	jobspec
+	jobspec \
+	resource-status
 
 dist_check_SCRIPTS = \
 	$(TESTSCRIPTS) \

--- a/t/resource-status/fluxion.expected
+++ b/t/resource-status/fluxion.expected
@@ -1,0 +1,4 @@
+     STATE NNODES   NCORES    NGPUS
+      free      3        8        0
+ allocated      2        4        0
+      down      1        4        0

--- a/t/resource-status/fluxion.json
+++ b/t/resource-status/fluxion.json
@@ -1,0 +1,78 @@
+{
+  "all": {
+    "version": 1,
+    "execution": {
+      "R_lite": [
+        {
+          "rank": "0",
+          "node": "5b12c7ea7263",
+          "children": {
+            "core": "0-3"
+          }
+        },
+        {
+          "rank": "1",
+          "node": "5b12c7ea7263",
+          "children": {
+            "core": "0-3"
+          }
+        },
+        {
+          "rank": "2",
+          "node": "5b12c7ea7263",
+          "children": {
+            "core": "0-3"
+          }
+        },
+        {
+          "rank": "3",
+          "node": "5b12c7ea7263",
+          "children": {
+            "core": "0-3"
+          }
+        }
+      ],
+      "starttime": 0,
+      "expiration": 0
+    }
+  },
+  "down": {
+    "version": 1,
+    "execution": {
+      "R_lite": [
+        {
+          "rank": "3",
+          "node": "5b12c7ea7263",
+          "children": {
+            "core": "0-3"
+          }
+        }
+      ],
+      "starttime": 0,
+      "expiration": 0
+    }
+  },
+  "allocated": {
+    "version": 1,
+    "execution": {
+      "R_lite": [
+        {
+          "rank": "0",
+          "node": "5b12c7ea7263",
+          "children": {
+            "core": "2-3"
+          }
+        },
+        {
+          "rank": "1",
+          "node": "5b12c7ea7263",
+          "children": {
+            "core": "2-3"
+          }
+        }
+      ],
+      "starttime": 0,
+      "expiration": 0
+    }
+  }
+}

--- a/t/resource-status/missing.expected
+++ b/t/resource-status/missing.expected
@@ -1,0 +1,4 @@
+     STATE NNODES   NCORES    NGPUS
+      free      4       16        0
+ allocated      0        0        0
+      down      0        0        0

--- a/t/resource-status/missing.json
+++ b/t/resource-status/missing.json
@@ -1,0 +1,15 @@
+{
+  "all": {
+    "execution": {
+      "R_lite": [
+        {
+          "children": {
+            "core": "0-3"
+          },
+          "rank": "0-3"
+        }
+      ]
+    },
+    "version": 1
+  }
+}

--- a/t/resource-status/normal-input.expected
+++ b/t/resource-status/normal-input.expected
@@ -1,0 +1,4 @@
+     STATE NNODES   NCORES    NGPUS
+      free      4       16        0
+ allocated      0        0        0
+      down      0        0        0

--- a/t/resource-status/normal-input.json
+++ b/t/resource-status/normal-input.json
@@ -1,0 +1,27 @@
+{
+  "all": {
+    "execution": {
+      "R_lite": [
+        {
+          "children": {
+            "core": "0-3"
+          },
+          "rank": "0-3"
+        }
+      ]
+    },
+    "version": 1
+  },
+  "allocated": {
+    "execution": {
+      "R_lite": []
+    },
+    "version": 1
+  },
+  "down": {
+    "execution": {
+      "R_lite": []
+    },
+    "version": 1
+  }
+}

--- a/t/resource-status/null.expected
+++ b/t/resource-status/null.expected
@@ -1,0 +1,4 @@
+     STATE NNODES   NCORES    NGPUS
+      free      4       16        0
+ allocated      0        0        0
+      down      0        0        0

--- a/t/resource-status/null.json
+++ b/t/resource-status/null.json
@@ -1,0 +1,17 @@
+{
+  "all": {
+    "execution": {
+      "R_lite": [
+        {
+          "children": {
+            "core": "0-3"
+          },
+          "rank": "0-3"
+        }
+      ]
+    },
+    "version": 1
+  },
+  "allocated": null,
+  "down": null
+}

--- a/t/t2350-resource-list.t
+++ b/t/t2350-resource-list.t
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+test_description='flux-resource list tests'
+
+# Append --logfile option if FLUX_TESTS_LOGFILE is set in environment:
+test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
+. $(dirname $0)/sharness.sh
+
+for input in ${SHARNESS_TEST_SRCDIR}/resource-status/*.json; do
+    name=$(basename ${input%%.json})
+    test_expect_success "flux-resource list input check: $name" '
+        base=${input%%.json} &&
+        expected=${base}.expected &&
+        name=$(basename $base) &&
+        flux resource list --from-stdin < $input > $name.output 2>&1 &&
+        test_cmp $expected $name.output
+    '
+done
+
+test_done


### PR DESCRIPTION
This PR makes a small change to `flux  resource list` to allow missing  or null `all` `allocated` or `down` keys in the `sched.resource-status` RPC response to indicate the empty set.

This is meant to help other schedulers more succinctly emit this RPC response when some resource sets are empty.

/cc @dongahn