### PR TITLE
travis-ci: Add --localstatedir=/var to docker tag builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -125,7 +125,7 @@ before_install:
      export TAGNAME="${DOCKERREPO}:${IMG}${TRAVIS_TAG:+-${TRAVIS_TAG}}"
      echo "Tagging new image $TAGNAME"
      #  Force ARGS to correct prefix, etc for docker image
-     export ARGS="--prefix=/usr --sysconfdir=/etc --with-systemdsystemunitdir=/etc/systemd/system --with-flux-security --enable-caliper"
+     export ARGS="--prefix=/usr --sysconfdir=/etc --with-systemdsystemunitdir=/etc/systemd/system --localstatedir=/var --with-flux-security --enable-caliper"
   fi
 
 script:


### PR DESCRIPTION
Problem: flux-core docker images are built with localstatedir
set to `/usr/var` instead of `/var`. This causes persistent state
files to be written to an incorrect path under /usr, which may
cause confusion.

Add --localstatedir=/var to the DOCKER_TAG configure args to force
the correct value.