### PR TITLE
docker: small updates for testenv images, travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,12 +52,9 @@ jobs:
       env:
        - CC=gcc-8
        - CXX=g++-8
-       - ARGS="--with-flux-security --enable-caliper --enable-content-s3"
+       - ARGS="--with-flux-security --enable-caliper"
        - DISTCHECK=t
-       - S3_ACCESS_KEY_ID=minioadmin
-       - S3_SECRET_ACCESS_KEY=minioadmin
-       - S3_HOSTNAME=127.0.0.1:9000
-       - S3_BUCKET=flux-minio
+       - TEST_CONTENT_S3=t
     - name: "Ubuntu: py3.7, clang-6.0 chain-lint --with-flux-security"
       stage: test
       compiler: clang-6.0
@@ -118,6 +115,15 @@ before_install:
  # die if non-blocking is still enabled
  - python -c 'import os,sys,fcntl; flags = fcntl.fcntl(sys.stdout, fcntl.F_GETFL); exit(flags&os.O_NONBLOCK);'
  - if test -z "${IMG}"; then IMG="bionic"; fi
+ # set S3 environment if testing S3
+ - |
+  if test "$TEST_CONTENT_S3"; then
+    export S3_ACCESS_KEY_ID=minioadmin; \
+    export S3_SECRET_ACCESS_KEY=minioadmin; \
+    export S3_HOSTNAME=127.0.0.1:9000; \
+    export S3_BUCKET=flux-minio; \
+    export ARGS="$ARGS --enable-content-s3"; \
+  fi
  #
  #  Tag image if this build is on master or result of a tag:
  - |
@@ -140,7 +146,10 @@ install:
      pip3 install --upgrade pip ; \
      pip3 install --upgrade --force-reinstall coverage ; \
    fi
- - if test -n "$S3_HOSTNAME"; then docker run -d -p 9000:9000 minio/minio server /data; fi
+ - |
+  if test -n "$S3_HOSTNAME"; then \
+      docker run -d -p 9000:9000 minio/minio server /data; \
+  fi
     
 script:
  # Unshallow repository so git describe works.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build Status](https://travis-ci.com/flux-framework/flux-core.svg?branch=master)](https://travis-ci.com/flux-framework/flux-core)
-[![Coverage Status](https://coveralls.io/repos/flux-framework/flux-core/badge.svg?branch=master&service=github)](https://coveralls.io/github/flux-framework/flux-core?branch=master)
+[![codecov](https://codecov.io/gh/flux-framework/flux-core/branch/master/graph/badge.svg)](https://codecov.io/gh/flux-framework/flux-core)
 
 _NOTE: The interfaces of flux-core are being actively developed
 and are not yet stable._ The github issue tracker is the primary

--- a/src/test/docker/bionic/Dockerfile
+++ b/src/test/docker/bionic/Dockerfile
@@ -80,6 +80,7 @@ RUN apt-get update \
         uuid-dev \
         libhwloc-dev \
         libmpich-dev \
+        libs3-dev \
  && rm -rf /var/lib/apt/lists/*
 
 # Testing utils and libs

--- a/src/test/docker/bionic/Dockerfile
+++ b/src/test/docker/bionic/Dockerfile
@@ -113,3 +113,5 @@ RUN mkdir caliper \
  && make install \
  && cd ../.. \
  && rm -rf caliper
+
+ENV LANG=C.UTF-8

--- a/src/test/docker/centos7/Dockerfile
+++ b/src/test/docker/centos7/Dockerfile
@@ -61,6 +61,7 @@ RUN yum -y update \
       devtoolset-7-make \
       lz4-devel \
       jq \
+      libs3-devel \
  && yum clean all
 
 # The cmake from yum is incredibly ancient, download a less ancient one

--- a/src/test/docker/centos7/Dockerfile
+++ b/src/test/docker/centos7/Dockerfile
@@ -87,5 +87,7 @@ RUN mkdir caliper \
 
 COPY config.site /usr/share/config.site
 
+ENV LANG=en_US.UTF-8
+
 # Create /tmp -> /var/tmp link to ensure Flux tests work in this configuration
 RUN rm -rf /tmp && ln -sf /var/tmp /tmp

--- a/src/test/docker/centos8/Dockerfile
+++ b/src/test/docker/centos8/Dockerfile
@@ -26,7 +26,9 @@ RUN yum -y install \
 	jq \
 	which \
 	file \
-	vim
+	vim \
+	patch \
+	diffutils
 
 #  Compilers, autotools
 RUN yum -y install \

--- a/src/test/docker/centos8/Dockerfile
+++ b/src/test/docker/centos8/Dockerfile
@@ -51,7 +51,7 @@ RUN yum -y install \
 #  Development dependencies
 RUN yum -y install \
 	libsodium-devel \
-        zeromq-devel \
+	zeromq-devel \
 	czmq-devel \
 	jansson-devel \
 	munge-devel \
@@ -61,7 +61,8 @@ RUN yum -y install \
 	hwloc-devel \
 	mpich-devel \
 	lua-devel \
-	valgrind-devel
+	valgrind-devel \
+	libs3-devel
 
 #  Other deps
 RUN yum -y install \

--- a/src/test/docker/centos8/Dockerfile
+++ b/src/test/docker/centos8/Dockerfile
@@ -96,4 +96,6 @@ RUN mkdir caliper \
  && cd ../.. \
  && rm -rf caliper
 
+ENV LANG=C.UTF-8
+
 COPY config.site /usr/share/config.site

--- a/src/test/docker/focal/Dockerfile
+++ b/src/test/docker/focal/Dockerfile
@@ -100,6 +100,7 @@ RUN apt-get update \
  && rm -rf /var/lib/apt/lists/*
 
 RUN locale-gen en_US.UTF-8
+ENV LANG=C.UTF-8
 
 # Install caliper by hand for now:
 RUN mkdir caliper \

--- a/src/test/docker/focal/Dockerfile
+++ b/src/test/docker/focal/Dockerfile
@@ -85,6 +85,7 @@ RUN apt-get update \
         uuid-dev \
         libhwloc-dev \
         libmpich-dev \
+        libs3-dev \
  && rm -rf /var/lib/apt/lists/*
 
 # Testing utils and libs

--- a/src/test/docker/travis/Dockerfile
+++ b/src/test/docker/travis/Dockerfile
@@ -71,7 +71,6 @@ COPY bashrc /tmp
 RUN cat /tmp/bashrc >> ~fluxuser/.bashrc \
  && rm /tmp/bashrc
 
-ENV LANG=en_US.UTF-8
 ENV BASE_IMAGE=$BASE_IMAGE
 USER $USER
 WORKDIR /home/$USER

--- a/src/test/docker/travis/Dockerfile
+++ b/src/test/docker/travis/Dockerfile
@@ -48,10 +48,6 @@ RUN case $BASE_IMAGE in \
     esac
 
 # Install extra dependencies if necessary here.
-RUN case $BASE_IMAGE in \
-     bionic*) apt-get update -y && apt-get install -y libs3-dev ;; \
-     *) (>&2 echo "Not installing libs3") ;; \
-    esac
 
 # Do not forget to run `apt update` on Ubuntu/bionic.
 # Do NOT run `yum upgrade` on CentOS (this will unnecessarily upgrade


### PR DESCRIPTION
This PR makes some small updates to the base `testenv` build images.

 - Consistently handle `LANG` across our docker containers. Use `C.UTF-8` where supported, `en_US.UTF-8` otherwise.
 - Move `libs3-dev` out of the travis Dockerfile into the base images.
 - In expectation of adding more content-s3 tests, slightly refactor content-s3 env vars in `.travis.yml`
 - Add patch and diffutils to CentOS 8 images

This might make conflicts for #3033. Sorry, I can help resolve if necessary.

I've already pushed up the new images to DockerHub.