### PR TITLE
job-manager/job-info/annotations: misc cleanup + refactor (annotations part 2)

### DIFF
--- a/src/modules/job-info/job_state.c
+++ b/src/modules/job-info/job_state.c
@@ -1334,6 +1334,12 @@ static struct job *eventlog_restart_parse (struct info_ctx *ctx,
             update_job_state (ctx, job, FLUX_JOB_SCHED, timestamp);
         }
         else if (!strcmp (name, "priority")) {
+            if (!context) {
+                flux_log_error (ctx->h, "%s: no priority context for %ju",
+                                __FUNCTION__, (uintmax_t)job->id);
+                goto error;
+            }
+
             if (json_unpack (context, "{ s:i }",
                                       "priority", &job->priority) < 0) {
                 flux_log_error (ctx->h, "%s: priority context for %ju invalid",
@@ -1343,6 +1349,12 @@ static struct job *eventlog_restart_parse (struct info_ctx *ctx,
         }
         else if (!strcmp (name, "exception")) {
             int severity;
+            if (!context) {
+                flux_log_error (ctx->h, "%s: no exception context for %ju",
+                                __FUNCTION__, (uintmax_t)job->id);
+                goto error;
+            }
+
             if (json_unpack (context, "{ s:i }", "severity", &severity) < 0) {
                 flux_log_error (ctx->h, "%s: exception context for %ju invalid",
                                 __FUNCTION__, (uintmax_t)job->id);

--- a/src/modules/job-manager/Makefile.am
+++ b/src/modules/job-manager/Makefile.am
@@ -55,7 +55,8 @@ TESTS = \
 	test_raise.t \
 	test_kill.t \
 	test_restart.t \
-	test_submit.t
+	test_submit.t \
+	test_annotate.t
 
 test_ldadd = \
         $(top_builddir)/src/modules/job-manager/event.o \
@@ -127,4 +128,11 @@ test_submit_t_CPPFLAGS = $(test_cppflags)
 test_submit_t_LDADD = \
         $(test_ldadd)
 test_submit_t_LDFLAGS = \
+        $(test_ldflags)
+
+test_annotate_t_SOURCES = test/annotate.c
+test_annotate_t_CPPFLAGS = $(test_cppflags)
+test_annotate_t_LDADD = \
+        $(test_ldadd)
+test_annotate_t_LDFLAGS = \
         $(test_ldflags)

--- a/src/modules/job-manager/alloc.c
+++ b/src/modules/job-manager/alloc.c
@@ -175,14 +175,24 @@ int cancel_request (struct alloc *alloc, struct job *job)
     return 0;
 }
 
+void annotate_err (void *arg, const char *fmt, ...)
+{
+    flux_t *h = (flux_t *)arg;
+    va_list ap;
+    flux_vlog (h, LOG_ERR, fmt, ap);
+    va_end (ap);
+}
+
 /* we want to delete items set to 'null', so this is not the same
  * as json_object_update_recursive() in jansson 2.13.1
  */
-static void update_recursive (flux_t *h, struct job *job,
-                              json_t *orig, json_t *new)
+void update_recursive (struct job *job, json_t *orig, json_t *new,
+                       annotate_log_f log_f, void *arg)
 {
     const char *key;
     json_t *value;
+
+    assert (job && orig && new);
 
     json_object_foreach (new, key, value) {
         if (!json_is_null (value)) {
@@ -192,26 +202,27 @@ static void update_recursive (flux_t *h, struct job *job,
                 if (!json_is_object (orig_value)) {
                     json_t *o = json_object ();
                     if (!o || json_object_set_new (orig, key, o) < 0) {
-                        flux_log (h,
-                                  LOG_ERR,
-                                  "%s: id=%ju create object=%s",
-                                  __FUNCTION__, (uintmax_t)job->id, key);
+                        if (log_f)
+                            (*log_f)(arg,
+                                     "%s: id=%ju create object=%s",
+                                     __FUNCTION__, (uintmax_t)job->id, key);
                         json_decref (o);
                         continue;
                     }
                     orig_value = o;
                 }
-                update_recursive (h, job, orig_value, value);
+                update_recursive (job, orig_value, value, log_f, arg);
                 /* if object is now empty, remove it */
                 if (!json_object_size (orig_value))
                     (void)json_object_del (orig, key);
             }
             else {
-                if (json_object_set (orig, key, value) < 0)
-                    flux_log (h,
-                              LOG_ERR,
-                              "%s: id=%ju update key=%s",
-                              __FUNCTION__, (uintmax_t)job->id, key);
+                if (json_object_set (orig, key, value) < 0) {
+                    if (log_f)
+                        (*log_f)(arg,
+                                 "%s: id=%ju update key=%s",
+                                 __FUNCTION__, (uintmax_t)job->id, key);
+                }
             }
         }
         else
@@ -232,7 +243,8 @@ static void update_annotations (flux_t *h, struct job *job, flux_jobid_t id,
                           __FUNCTION__, (uintmax_t)id);
         }
         if (job->annotations) {
-            update_recursive (h, job, job->annotations, annotations);
+            update_recursive (job, job->annotations, annotations,
+                              annotate_err, h);
             /* Special case: if user cleared all entries, assume we no
              * longer need annotations object */
             if (!json_object_size (job->annotations))

--- a/src/modules/job-manager/alloc.c
+++ b/src/modules/job-manager/alloc.c
@@ -175,6 +175,51 @@ int cancel_request (struct alloc *alloc, struct job *job)
     return 0;
 }
 
+/* we want to delete items set to 'null', so this is not the same
+ * as json_object_update_recursive() in jansson 2.13.1
+ */
+static void update_recursive (flux_t *h, struct job *job,
+                              json_t *orig, json_t *new)
+{
+    const char *key;
+    json_t *value;
+
+    json_object_foreach (new, key, value) {
+        if (!json_is_null (value)) {
+            json_t *orig_value = json_object_get (orig, key);
+
+            if (json_is_object (value)) {
+                if (!json_is_object (orig_value)) {
+                    json_t *o = json_object ();
+                    if (!o || json_object_set_new (orig, key, o) < 0) {
+                        flux_log (h,
+                                  LOG_ERR,
+                                  "%s: id=%ju create object=%s",
+                                  __FUNCTION__, (uintmax_t)job->id, key);
+                        json_decref (o);
+                        continue;
+                    }
+                    orig_value = o;
+                }
+                update_recursive (h, job, orig_value, value);
+                /* if object is now empty, remove it */
+                if (!json_object_size (orig_value))
+                    (void)json_object_del (orig, key);
+            }
+            else {
+                if (json_object_set (orig, key, value) < 0)
+                    flux_log (h,
+                              LOG_ERR,
+                              "%s: id=%ju update key=%s",
+                              __FUNCTION__, (uintmax_t)job->id, key);
+            }
+        }
+        else
+            /* not an error if key doesn't exist in orig */
+            (void)json_object_del (orig, key);
+    }
+}
+
 static void update_annotations (flux_t *h, struct job *job, flux_jobid_t id,
                                 json_t *annotations)
 {
@@ -187,21 +232,7 @@ static void update_annotations (flux_t *h, struct job *job, flux_jobid_t id,
                           __FUNCTION__, (uintmax_t)id);
         }
         if (job->annotations) {
-            const char *key;
-            json_t *value;
-
-            json_object_foreach (annotations, key, value) {
-                if (!json_is_null (value)) {
-                    if (json_object_set (job->annotations, key, value) < 0)
-                        flux_log (h,
-                                  LOG_ERR,
-                                  "%s: id=%ju update key=%s",
-                                  __FUNCTION__, (uintmax_t)id, key);
-                }
-                else
-                    /* not an error if key doesn't exist in job->annotations */
-                    (void)json_object_del (job->annotations, key);
-            }
+            update_recursive (h, job, job->annotations, annotations);
             /* Special case: if user cleared all entries, assume we no
              * longer need annotations object */
             if (!json_object_size (job->annotations))

--- a/src/modules/job-manager/alloc.h
+++ b/src/modules/job-manager/alloc.h
@@ -52,6 +52,12 @@ struct job *alloc_queue_next (struct alloc *alloc);
  */
 void alloc_queue_reorder (struct alloc *alloc, struct job *job);
 
+/* exposed for unit testing only */
+typedef void (*annotate_log_f)(void *arg, const char *fmt, ...);
+
+void update_recursive (struct job *job, json_t *orig, json_t *new,
+                       annotate_log_f log_f, void *arg);
+
 #endif /* ! _FLUX_JOB_MANAGER_ALLOC_H */
 
 /*

--- a/src/modules/job-manager/event.c
+++ b/src/modules/job-manager/event.c
@@ -183,7 +183,8 @@ void event_batch_destroy (struct event_batch *batch)
         if (batch->f)
             (void)flux_future_wait_for (batch->f, -1);
         if (batch->state_trans) {
-            event_publish_state (batch->event, batch->state_trans);
+            if (json_array_size (batch->state_trans) > 0)
+                event_publish_state (batch->event, batch->state_trans);
             json_decref (batch->state_trans);
         }
         if (batch->responses) {

--- a/src/modules/job-manager/raise.c
+++ b/src/modules/job-manager/raise.c
@@ -129,7 +129,7 @@ void raise_handle_request (flux_t *h,
     }
     if (!(job = zhashx_lookup (ctx->active_jobs, &id))) {
         errstr = "unknown job id";
-        errno = EINVAL;
+        errno = ENOENT;
         goto error;
     }
     if (flux_msg_cred_authorize (cred, job->userid) < 0) {

--- a/src/modules/job-manager/test/annotate.c
+++ b/src/modules/job-manager/test/annotate.c
@@ -1,0 +1,247 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#include <jansson.h>
+#include <czmq.h>
+#include <flux/core.h>
+#include "src/common/libtap/tap.h"
+
+#include "src/modules/job-manager/alloc.h"
+
+void basic (void)
+{
+    struct job j = {0};
+    json_t *orig;
+    json_t *new;
+    json_t *cmp;
+
+    orig = json_object ();
+    new = json_object ();
+    cmp = json_object ();
+    if (!orig || !new || !cmp)
+        BAIL_OUT ("json_object() failed");
+
+    update_recursive (&j, orig, new, NULL, NULL);
+    ok (json_equal (orig, cmp) > 0,
+        "update_recursive does nothing on empty dictionary");
+
+    json_decref (new);
+    json_decref (cmp);
+
+    new = json_pack ("{s:n}", "blah");
+    cmp = json_object ();
+    if (!new || !cmp)
+        BAIL_OUT ("json_object() failed");
+
+    update_recursive (&j, orig, new, NULL, NULL);
+    ok (json_equal (orig, cmp) > 0,
+        "update_recursive does nothing removing non-existant key");
+
+    json_decref (new);
+    json_decref (cmp);
+
+    new = json_pack("{s:s s:i}", "str", "foo", "num", 1);
+    cmp = json_pack("{s:s s:i}", "str", "foo", "num", 1);
+    if (!new || !cmp)
+        BAIL_OUT ("json_pack() failed");
+
+    update_recursive (&j, orig, new, NULL, NULL);
+    ok (json_equal (orig, cmp) > 0,
+        "update_recursive updates orig appropriately");
+
+    json_decref (new);
+    json_decref (cmp);
+
+    new = json_pack("{s:s}", "str", "bar");
+    cmp = json_pack("{s:s s:i}", "str", "bar", "num", 1);
+    if (!new || !cmp)
+        BAIL_OUT ("json_pack() failed");
+
+    update_recursive (&j, orig, new, NULL, NULL);
+    ok (json_equal (orig, cmp) > 0,
+        "update_recursive overwrites existing key");
+
+    json_decref (new);
+    json_decref (cmp);
+
+    new = json_pack("{s:n}", "num");
+    cmp = json_pack("{s:s}", "str", "bar");
+    if (!new || !cmp)
+        BAIL_OUT ("json_pack() failed");
+
+    update_recursive (&j, orig, new, NULL, NULL);
+    ok (json_equal (orig, cmp) > 0,
+        "update_recursive removes value on json null setting");
+
+    json_decref (new);
+    json_decref (cmp);
+}
+
+void recursive (void)
+{
+    struct job j = {0};
+    json_t *orig;
+    json_t *new;
+    json_t *cmp;
+
+    orig = json_object ();
+    new = json_pack ("{s:{}}", "obj", "str", "foo");
+    cmp = json_pack ("{}");
+    if (!orig || !new || !cmp)
+        BAIL_OUT ("json_object/pack() failed");
+
+    update_recursive (&j, orig, new, NULL, NULL);
+    ok (json_equal (orig, cmp) > 0,
+        "update_recursive recursively does nothing on empty dictionary");
+
+    new = json_pack ("{s:{s:s}}", "obj", "str", "foo");
+    cmp = json_pack ("{s:{s:s}}", "obj", "str", "foo");
+    if (!new || !cmp)
+        BAIL_OUT ("json_pack() failed");
+
+    update_recursive (&j, orig, new, NULL, NULL);
+    ok (json_equal (orig, cmp) > 0,
+        "update_recursive sets dictionary");
+
+    json_decref (new);
+    json_decref (cmp);
+
+    new = json_pack ("{s:{s:n}}", "obj", "blah");
+    cmp = json_pack ("{s:{s:s}}", "obj", "str", "foo");
+    if (!new || !cmp)
+        BAIL_OUT ("json_pack() failed");
+
+    update_recursive (&j, orig, new, NULL, NULL);
+    ok (json_equal (orig, cmp) > 0,
+        "update_recursive recursively does nothing removing non-existant key");
+
+    json_decref (new);
+    json_decref (cmp);
+
+    new = json_pack("{s:{s:i}}", "obj", "num", 1);
+    cmp = json_pack("{s:{s:s s:i}}", "obj", "str", "foo", "num", 1);
+    if (!new || !cmp)
+        BAIL_OUT ("json_pack() failed");
+
+    update_recursive (&j, orig, new, NULL, NULL);
+    ok (json_equal (orig, cmp) > 0,
+        "update_recursive recursively updates orig appropriately");
+
+    json_decref (new);
+    json_decref (cmp);
+
+    new = json_pack("{s:{s:s}}", "obj", "str", "bar");
+    cmp = json_pack("{s:{s:s s:i}}", "obj", "str", "bar", "num", 1);
+    if (!new || !cmp)
+        BAIL_OUT ("json_pack() failed");
+
+    update_recursive (&j, orig, new, NULL, NULL);
+    ok (json_equal (orig, cmp) > 0,
+        "update_recursive recursively overwrites existing key");
+
+    json_decref (new);
+    json_decref (cmp);
+
+    new = json_pack("{s:{s:n}}", "obj", "num");
+    cmp = json_pack("{s:{s:s}}", "obj", "str", "bar");
+    if (!new || !cmp)
+        BAIL_OUT ("json_pack() failed");
+
+    update_recursive (&j, orig, new, NULL, NULL);
+    ok (json_equal (orig, cmp) > 0,
+        "update_recursive recursively removes value on json null setting");
+
+    json_decref (new);
+    json_decref (cmp);
+
+    new = json_pack("{s:{s:n}}", "obj", "str");
+    cmp = json_pack("{}");
+    if (!new || !cmp)
+        BAIL_OUT ("json_pack() failed");
+
+    update_recursive (&j, orig, new, NULL, NULL);
+    ok (json_equal (orig, cmp) > 0,
+        "update_recursive recursively removes empty sub-dictionaries");
+
+    json_decref (new);
+    json_decref (cmp);
+}
+
+void overwrite (void)
+{
+    struct job j = {0};
+    json_t *orig;
+    json_t *new;
+    json_t *cmp;
+
+    orig = json_object ();
+    new = json_pack ("{s:{s:s}}", "obj", "str", "foo");
+    cmp = json_pack ("{s:{s:s}}", "obj", "str", "foo");
+    if (!orig || !new || !cmp)
+        BAIL_OUT ("json_object/pack() failed");
+
+    update_recursive (&j, orig, new, NULL, NULL);
+    ok (json_equal (orig, cmp) > 0,
+        "update_recursive sets dictionary");
+
+    json_decref (new);
+    json_decref (cmp);
+
+    new = json_pack("{s:s}", "obj", "foo");
+    cmp = json_pack("{s:s}", "obj", "foo");
+    if (!new || !cmp)
+        BAIL_OUT ("json_pack() failed");
+
+    update_recursive (&j, orig, new, NULL, NULL);
+    ok (json_equal (orig, cmp) > 0,
+        "update_recursive overwrites object with non-object");
+
+    json_decref (new);
+    json_decref (cmp);
+
+    new = json_pack("{s:{s:s}}", "obj", "str", "bar");
+    cmp = json_pack("{s:{s:s}}", "obj", "str", "bar");
+    if (!new || !cmp)
+        BAIL_OUT ("json_pack() failed");
+
+    update_recursive (&j, orig, new, NULL, NULL);
+    ok (json_equal (orig, cmp) > 0,
+        "update_recursive overwrites non-object with object");
+
+    json_decref (new);
+    json_decref (cmp);
+
+    new = json_pack("{s:n}", "obj");
+    cmp = json_pack("{}");
+    if (!new || !cmp)
+        BAIL_OUT ("json_pack() failed");
+
+    update_recursive (&j, orig, new, NULL, NULL);
+    ok (json_equal (orig, cmp) > 0,
+        "update_recursive removes whole dict on json null setting");
+
+    json_decref (new);
+    json_decref (cmp);
+}
+
+int main (int argc, char *argv[])
+{
+    plan (NO_PLAN);
+
+    basic ();
+    recursive ();
+    overwrite ();
+
+    done_testing ();
+}
+
+/*
+ * vi:ts=4 sw=4 expandtab
+ */

--- a/src/modules/sched-simple/sched.c
+++ b/src/modules/sched-simple/sched.c
@@ -217,8 +217,8 @@ static int try_alloc (flux_t *h, struct simple_sched *ss)
     if (schedutil_alloc_respond_success_pack (ss->util_ctx,
                                               job->msg,
                                               R,
-                                              "{ s:s }",
-                                              "sched.resource_summary", s) < 0)
+                                              "{ s:{s:s} }",
+                                              "sched", "resource_summary", s) < 0)
         flux_log_error (h, "schedutil_alloc_respond_success_pack");
 
     flux_log (h, LOG_DEBUG, "alloc: %ju: %s", (uintmax_t) job->id, s);

--- a/t/job-manager/sched-dummy.c
+++ b/t/job-manager/sched-dummy.c
@@ -94,8 +94,8 @@ static void respond_success_single (struct sched_ctx *sc,
     if (schedutil_alloc_respond_success_pack (sc->schedutil_ctx,
                                               job->msg,
                                               "1core",
-                                              "{ s:n }",
-                                              "sched.reason_pending") < 0)
+                                              "{ s:{s:n} }",
+                                              "sched", "reason_pending") < 0)
         flux_log_error (sc->h, "schedutil_alloc_respond_success_pack");
 }
 
@@ -105,10 +105,11 @@ static void respond_success_unlimited (struct sched_ctx *sc,
     if (schedutil_alloc_respond_success_pack (sc->schedutil_ctx,
                                               job->msg,
                                               "1core",
-                                              "{ s:s s:n s:n }",
-                                              "sched.resource_summary", "1core",
-                                              "sched.reason_pending",
-                                              "sched.jobs_ahead") < 0)
+                                              "{ s:{s:s s:n s:n} }",
+                                              "sched",
+                                              "resource_summary", "1core",
+                                              "reason_pending",
+                                              "jobs_ahead") < 0)
         flux_log_error (sc->h, "schedutil_alloc_respond_success_pack");
 }
 
@@ -117,8 +118,8 @@ static void respond_annotate_single (struct sched_ctx *sc,
 {
     if (schedutil_alloc_respond_annotate_pack (sc->schedutil_ctx,
                                                job->msg,
-                                               "{ s:s }",
-                                               "sched.reason_pending",
+                                               "{ s:{s:s} }",
+                                               "sched", "reason_pending",
                                                "no cores available") < 0)
         flux_log_error (sc->h, "schedutil_alloc_respond_annotate_pack");
 }
@@ -130,18 +131,19 @@ static void respond_annotate_unlimited (struct sched_ctx *sc,
     if (job->annotate_count) {
         if (schedutil_alloc_respond_annotate_pack (sc->schedutil_ctx,
                                                    job->msg,
-                                                   "{ s:i }",
-                                                   "sched.jobs_ahead",
+                                                   "{ s:{s:i} }",
+                                                   "sched", "jobs_ahead",
                                                    jobs_ahead_count) < 0)
             flux_log_error (sc->h, "schedutil_alloc_respond_annotate_pack");
     }
     else {
         if (schedutil_alloc_respond_annotate_pack (sc->schedutil_ctx,
                                                    job->msg,
-                                                   "{ s:s s:i }",
-                                                   "sched.reason_pending",
+                                                   "{ s:{s:s s:i} }",
+                                                   "sched",
+                                                   "reason_pending",
                                                    "no cores",
-                                                   "sched.jobs_ahead",
+                                                   "jobs_ahead",
                                                    jobs_ahead_count) < 0)
             flux_log_error (sc->h, "schedutil_alloc_respond_annotate_pack");
     }

--- a/t/job-manager/sched-helper.sh
+++ b/t/job-manager/sched-helper.sh
@@ -3,51 +3,51 @@
 
 # job-manager sched helper functions
 
-LIST_JOBS=${FLUX_BUILD_DIR}/t/job-manager/list-jobs
+JMGR_JOB_LIST=${FLUX_BUILD_DIR}/t/job-manager/list-jobs
 
-# internal function to get job state
+# internal function to get job state via job manager
 #
 # if job is not found by list-jobs, but the clean event exists
 # in the job's eventlog, return state as inactive
 #
 # arg1 - jobid
-_get_state() {
+_jmgr_get_state() {
         local id=$1
-        local state=$(${LIST_JOBS} | awk '$1 == "'${id}'" { print $2; }')
+        local state=$(${JMGR_JOB_LIST} | awk '$1 == "'${id}'" { print $2; }')
         test -z "$state" \
                 && flux job wait-event --timeout=5 ${id} clean >/dev/null \
                 && state=I
         echo $state
 }
 
-# verify if job is in specific state
+# verify if job is in specific state through job manager
 #
 # function will loop for up to 5 seconds in case state change is slow
 #
 # arg1 - jobid
 # arg2 - single character expected state (e.g. R = running)
-check_state() {
+jmgr_check_state() {
         local id=$1
         local wantstate=$2
         for try in $(seq 1 10); do
-                test $(_get_state $id) = $wantstate && return 0
+                test $(_jmgr_get_state $id) = $wantstate && return 0
                 sleep 0.5
         done
         return 1
 }
 
-# internal function to get job annotation key value
+# internal function to get job annotation key value via job manager
 #
 # arg1 - jobid
 # arg2 - key
-_get_annotation() {
+_jmgr_get_annotation() {
         local id=$1
         local key=$2
-        local note="$(${LIST_JOBS} | grep ${id} | cut -f 6- | jq .\"${key}\")"
+        local note="$(${JMGR_JOB_LIST} | grep ${id} | cut -f 6- | jq .\"${key}\")"
         echo $note
 }
 
-# verify if job contains specific annotation key & value
+# verify if job contains specific annotation key & value through job manager
 #
 # function will loop for up to 5 seconds in case annotation update
 # arrives slowly
@@ -57,34 +57,34 @@ _get_annotation() {
 # arg3 - value of key in annotation
 #
 # callers should set HAVE_JQ requirement
-check_annotation() {
+jmgr_check_annotation() {
         local id=$1
         local key=$2
         local value="$3"
         for try in $(seq 1 10); do
-                test "$(_get_annotation $id $key)" = "${value}" && return 0
+                test "$(_jmgr_get_annotation $id $key)" = "${value}" && return 0
                 sleep 0.5
         done
         return 1
 }
 
-# verify if job contains specific annotation key
+# verify if job contains specific annotation key through job manager
 #
 # arg1 - jobid
 # arg2 - key in annotation
 #
 # callers should set HAVE_JQ requirement
-check_annotation_exists() {
+jmgr_check_annotation_exists() {
         local id=$1
         local key=$2
-        ${LIST_JOBS} | grep ${id} | cut -f 6- | jq -e .\"${key}\" > /dev/null
+        ${JMGR_JOB_LIST} | grep ${id} | cut -f 6- | jq -e .\"${key}\" > /dev/null
 }
 
-# verify that job contains no annotations
+# verify that job contains no annotations through job manager
 #
 # arg1 - jobid
-check_no_annotations() {
+jmgr_check_no_annotations() {
         local id=$1
-        test -z "$(${LIST_JOBS} | grep ${id} | cut -f 6-)" && return 0
+        test -z "$(${JMGR_JOB_LIST} | grep ${id} | cut -f 6-)" && return 0
         return 1
 }

--- a/t/job-manager/sched-helper.sh
+++ b/t/job-manager/sched-helper.sh
@@ -43,7 +43,7 @@ jmgr_check_state() {
 _jmgr_get_annotation() {
         local id=$1
         local key=$2
-        local note="$(${JMGR_JOB_LIST} | grep ${id} | cut -f 6- | jq .\"${key}\")"
+        local note="$(${JMGR_JOB_LIST} | grep ${id} | cut -f 6- | jq ."${key}")"
         echo $note
 }
 
@@ -77,7 +77,7 @@ jmgr_check_annotation() {
 jmgr_check_annotation_exists() {
         local id=$1
         local key=$2
-        ${JMGR_JOB_LIST} | grep ${id} | cut -f 6- | jq -e .\"${key}\" > /dev/null
+        ${JMGR_JOB_LIST} | grep ${id} | cut -f 6- | jq -e ."${key}" > /dev/null
 }
 
 # verify that job contains no annotations through job manager

--- a/t/t2203-job-manager-dummysched-single.t
+++ b/t/t2203-job-manager-dummysched-single.t
@@ -32,19 +32,19 @@ test_expect_success 'job-manager: submit 5 jobs' '
 '
 
 test_expect_success 'job-manager: job state SSSSS (no scheduler)' '
-        check_state $(cat job1.id) S &&
-        check_state $(cat job2.id) S &&
-        check_state $(cat job3.id) S &&
-        check_state $(cat job4.id) S &&
-        check_state $(cat job5.id) S
+        jmgr_check_state $(cat job1.id) S &&
+        jmgr_check_state $(cat job2.id) S &&
+        jmgr_check_state $(cat job3.id) S &&
+        jmgr_check_state $(cat job4.id) S &&
+        jmgr_check_state $(cat job5.id) S
 '
 
 test_expect_success HAVE_JQ 'job-manager: no annotations (SSSSS)' '
-        check_no_annotations $(cat job1.id) &&
-        check_no_annotations $(cat job2.id) &&
-        check_no_annotations $(cat job3.id) &&
-        check_no_annotations $(cat job4.id) &&
-        check_no_annotations $(cat job5.id)
+        jmgr_check_no_annotations $(cat job1.id) &&
+        jmgr_check_no_annotations $(cat job2.id) &&
+        jmgr_check_no_annotations $(cat job3.id) &&
+        jmgr_check_no_annotations $(cat job4.id) &&
+        jmgr_check_no_annotations $(cat job5.id)
 '
 
 test_expect_success 'job-manager: load sched-dummy --cores=2' '
@@ -52,19 +52,19 @@ test_expect_success 'job-manager: load sched-dummy --cores=2' '
 '
 
 test_expect_success 'job-manager: job state RRSSS' '
-        check_state $(cat job1.id) R &&
-        check_state $(cat job2.id) R &&
-        check_state $(cat job3.id) S &&
-        check_state $(cat job4.id) S &&
-        check_state $(cat job5.id) S
+        jmgr_check_state $(cat job1.id) R &&
+        jmgr_check_state $(cat job2.id) R &&
+        jmgr_check_state $(cat job3.id) S &&
+        jmgr_check_state $(cat job4.id) S &&
+        jmgr_check_state $(cat job5.id) S
 '
 
 test_expect_success HAVE_JQ 'job-manager: annotate job id 3 (RRSSS)' '
-        check_no_annotations $(cat job1.id) &&
-        check_no_annotations $(cat job2.id) &&
-        check_annotation $(cat job3.id) "sched.reason_pending" "\"no cores available\"" &&
-        check_no_annotations $(cat job4.id) &&
-        check_no_annotations $(cat job5.id)
+        jmgr_check_no_annotations $(cat job1.id) &&
+        jmgr_check_no_annotations $(cat job2.id) &&
+        jmgr_check_annotation $(cat job3.id) "sched.reason_pending" "\"no cores available\"" &&
+        jmgr_check_no_annotations $(cat job4.id) &&
+        jmgr_check_no_annotations $(cat job5.id)
 '
 
 test_expect_success 'job-manager: running job has alloc event' '
@@ -76,19 +76,19 @@ test_expect_success 'job-manager: cancel 2' '
 '
 
 test_expect_success 'job-manager: job state RIRSS' '
-        check_state $(cat job1.id) R &&
-        check_state $(cat job2.id) I &&
-        check_state $(cat job3.id) R &&
-        check_state $(cat job4.id) S &&
-        check_state $(cat job5.id) S
+        jmgr_check_state $(cat job1.id) R &&
+        jmgr_check_state $(cat job2.id) I &&
+        jmgr_check_state $(cat job3.id) R &&
+        jmgr_check_state $(cat job4.id) S &&
+        jmgr_check_state $(cat job5.id) S
 '
 
 test_expect_success HAVE_JQ 'job-manager: annotate job id 4 (RIRSS)' '
-        check_no_annotations $(cat job1.id) &&
-        check_no_annotations $(cat job2.id) &&
-        check_no_annotations $(cat job3.id) &&
-        check_annotation $(cat job4.id) "sched.reason_pending" "\"no cores available\"" &&
-        check_no_annotations $(cat job5.id)
+        jmgr_check_no_annotations $(cat job1.id) &&
+        jmgr_check_no_annotations $(cat job2.id) &&
+        jmgr_check_no_annotations $(cat job3.id) &&
+        jmgr_check_annotation $(cat job4.id) "sched.reason_pending" "\"no cores available\"" &&
+        jmgr_check_no_annotations $(cat job5.id)
 '
 
 test_expect_success 'job-manager: first S job sent alloc, second S did not' '
@@ -121,19 +121,19 @@ test_expect_success 'job-manager: hello handshake userid is expected' '
 '
 
 test_expect_success 'job-manager: job state RIRRR' '
-        check_state $(cat job1.id) R &&
-        check_state $(cat job2.id) I &&
-        check_state $(cat job3.id) R &&
-        check_state $(cat job4.id) R &&
-        check_state $(cat job5.id) R
+        jmgr_check_state $(cat job1.id) R &&
+        jmgr_check_state $(cat job2.id) I &&
+        jmgr_check_state $(cat job3.id) R &&
+        jmgr_check_state $(cat job4.id) R &&
+        jmgr_check_state $(cat job5.id) R
 '
 
 test_expect_success HAVE_JQ 'job-manager: no annotations (RIRRR)' '
-        check_no_annotations $(cat job1.id) &&
-        check_no_annotations $(cat job2.id) &&
-        check_no_annotations $(cat job3.id) &&
-        check_no_annotations $(cat job4.id) &&
-        check_no_annotations $(cat job5.id)
+        jmgr_check_no_annotations $(cat job1.id) &&
+        jmgr_check_no_annotations $(cat job2.id) &&
+        jmgr_check_no_annotations $(cat job3.id) &&
+        jmgr_check_no_annotations $(cat job4.id) &&
+        jmgr_check_no_annotations $(cat job5.id)
 '
 
 test_expect_success 'job-manager: cancel 1' '
@@ -141,11 +141,11 @@ test_expect_success 'job-manager: cancel 1' '
 '
 
 test_expect_success 'job-manager: job state IIRRR' '
-        check_state $(cat job1.id) I &&
-        check_state $(cat job2.id) I &&
-        check_state $(cat job3.id) R &&
-        check_state $(cat job4.id) R &&
-        check_state $(cat job5.id) R
+        jmgr_check_state $(cat job1.id) I &&
+        jmgr_check_state $(cat job2.id) I &&
+        jmgr_check_state $(cat job3.id) R &&
+        jmgr_check_state $(cat job4.id) R &&
+        jmgr_check_state $(cat job5.id) R
 '
 
 test_expect_success 'job-manager: cancel all jobs' '
@@ -155,19 +155,19 @@ test_expect_success 'job-manager: cancel all jobs' '
 '
 
 test_expect_success 'job-manager: job state IIIII' '
-        check_state $(cat job1.id) I &&
-        check_state $(cat job2.id) I &&
-        check_state $(cat job3.id) I &&
-        check_state $(cat job4.id) I &&
-        check_state $(cat job5.id) I
+        jmgr_check_state $(cat job1.id) I &&
+        jmgr_check_state $(cat job2.id) I &&
+        jmgr_check_state $(cat job3.id) I &&
+        jmgr_check_state $(cat job4.id) I &&
+        jmgr_check_state $(cat job5.id) I
 '
 
 test_expect_success HAVE_JQ 'job-manager: no annotations (IIIII)' '
-        check_no_annotations $(cat job1.id) &&
-        check_no_annotations $(cat job2.id) &&
-        check_no_annotations $(cat job3.id) &&
-        check_no_annotations $(cat job4.id) &&
-        check_no_annotations $(cat job5.id)
+        jmgr_check_no_annotations $(cat job1.id) &&
+        jmgr_check_no_annotations $(cat job2.id) &&
+        jmgr_check_no_annotations $(cat job3.id) &&
+        jmgr_check_no_annotations $(cat job4.id) &&
+        jmgr_check_no_annotations $(cat job5.id)
 '
 
 test_expect_success 'job-manager: simulate alloc failure' '

--- a/t/t2203-job-manager-dummysched-single.t
+++ b/t/t2203-job-manager-dummysched-single.t
@@ -62,7 +62,7 @@ test_expect_success 'job-manager: job state RRSSS' '
 test_expect_success HAVE_JQ 'job-manager: annotate job id 3 (RRSSS)' '
         check_no_annotations $(cat job1.id) &&
         check_no_annotations $(cat job2.id) &&
-        check_annotation $(cat job3.id) "sched.reason_pending" "\"no cores available\""&&
+        check_annotation $(cat job3.id) "sched.reason_pending" "\"no cores available\"" &&
         check_no_annotations $(cat job4.id) &&
         check_no_annotations $(cat job5.id)
 '

--- a/t/t2204-job-manager-dummysched-unlimited.t
+++ b/t/t2204-job-manager-dummysched-unlimited.t
@@ -32,19 +32,19 @@ test_expect_success 'job-manager: submit 5 jobs' '
 '
 
 test_expect_success 'job-manager: job state SSSSS (no scheduler)' '
-        check_state $(cat job1.id) S &&
-        check_state $(cat job2.id) S &&
-        check_state $(cat job3.id) S &&
-        check_state $(cat job4.id) S &&
-        check_state $(cat job5.id) S
+        jmgr_check_state $(cat job1.id) S &&
+        jmgr_check_state $(cat job2.id) S &&
+        jmgr_check_state $(cat job3.id) S &&
+        jmgr_check_state $(cat job4.id) S &&
+        jmgr_check_state $(cat job5.id) S
 '
 
 test_expect_success HAVE_JQ 'job-manager: no annotations (SSSSS)' '
-        check_no_annotations $(cat job1.id) &&
-        check_no_annotations $(cat job2.id) &&
-        check_no_annotations $(cat job3.id) &&
-        check_no_annotations $(cat job4.id) &&
-        check_no_annotations $(cat job5.id)
+        jmgr_check_no_annotations $(cat job1.id) &&
+        jmgr_check_no_annotations $(cat job2.id) &&
+        jmgr_check_no_annotations $(cat job3.id) &&
+        jmgr_check_no_annotations $(cat job4.id) &&
+        jmgr_check_no_annotations $(cat job5.id)
 '
 
 test_expect_success 'job-manager: load sched-dummy --cores=2' '
@@ -52,22 +52,22 @@ test_expect_success 'job-manager: load sched-dummy --cores=2' '
 '
 
 test_expect_success 'job-manager: job state RRSSS' '
-        check_state $(cat job1.id) R &&
-        check_state $(cat job2.id) R &&
-        check_state $(cat job3.id) S &&
-        check_state $(cat job4.id) S &&
-        check_state $(cat job5.id) S
+        jmgr_check_state $(cat job1.id) R &&
+        jmgr_check_state $(cat job2.id) R &&
+        jmgr_check_state $(cat job3.id) S &&
+        jmgr_check_state $(cat job4.id) S &&
+        jmgr_check_state $(cat job5.id) S
 '
 
 test_expect_success HAVE_JQ 'job-manager: annotate job id 3-5 (RRSSS)' '
-        check_annotation $(cat job1.id) "sched.resource_summary" "\"1core\"" &&
-        check_annotation $(cat job2.id) "sched.resource_summary" "\"1core\"" &&
-        check_annotation $(cat job3.id) "sched.reason_pending" "\"no cores\"" &&
-        check_annotation $(cat job3.id) "sched.jobs_ahead" "0" &&
-        check_annotation $(cat job4.id) "sched.reason_pending" "\"no cores\"" &&
-        check_annotation $(cat job4.id) "sched.jobs_ahead" "1" &&
-        check_annotation $(cat job5.id) "sched.reason_pending" "\"no cores\"" &&
-        check_annotation $(cat job5.id) "sched.jobs_ahead" "2"
+        jmgr_check_annotation $(cat job1.id) "sched.resource_summary" "\"1core\"" &&
+        jmgr_check_annotation $(cat job2.id) "sched.resource_summary" "\"1core\"" &&
+        jmgr_check_annotation $(cat job3.id) "sched.reason_pending" "\"no cores\"" &&
+        jmgr_check_annotation $(cat job3.id) "sched.jobs_ahead" "0" &&
+        jmgr_check_annotation $(cat job4.id) "sched.reason_pending" "\"no cores\"" &&
+        jmgr_check_annotation $(cat job4.id) "sched.jobs_ahead" "1" &&
+        jmgr_check_annotation $(cat job5.id) "sched.reason_pending" "\"no cores\"" &&
+        jmgr_check_annotation $(cat job5.id) "sched.jobs_ahead" "2"
 '
 
 test_expect_success 'job-manager: cancel 2' '
@@ -75,23 +75,23 @@ test_expect_success 'job-manager: cancel 2' '
 '
 
 test_expect_success 'job-manager: job state RIRSS' '
-        check_state $(cat job1.id) R &&
-        check_state $(cat job2.id) I &&
-        check_state $(cat job3.id) R &&
-        check_state $(cat job4.id) S &&
-        check_state $(cat job5.id) S
+        jmgr_check_state $(cat job1.id) R &&
+        jmgr_check_state $(cat job2.id) I &&
+        jmgr_check_state $(cat job3.id) R &&
+        jmgr_check_state $(cat job4.id) S &&
+        jmgr_check_state $(cat job5.id) S
 '
 
 test_expect_success HAVE_JQ 'job-manager: annotate job id 4-5 (RIRSS)' '
-        check_annotation $(cat job1.id) "sched.resource_summary" "\"1core\"" &&
-        check_no_annotations $(cat job2.id) &&
-        check_annotation $(cat job3.id) "sched.resource_summary" "\"1core\"" &&
-        test_must_fail check_annotation_exists $(cat job3.id) "sched.reason_pending" &&
-        test_must_fail check_annotation_exists $(cat job3.id) "sched.jobs_ahead" &&
-        check_annotation $(cat job4.id) "sched.reason_pending" "\"no cores\"" &&
-        check_annotation $(cat job4.id) "sched.jobs_ahead" "0" &&
-        check_annotation $(cat job5.id) "sched.reason_pending" "\"no cores\"" &&
-        check_annotation $(cat job5.id) "sched.jobs_ahead" "1"
+        jmgr_check_annotation $(cat job1.id) "sched.resource_summary" "\"1core\"" &&
+        jmgr_check_no_annotations $(cat job2.id) &&
+        jmgr_check_annotation $(cat job3.id) "sched.resource_summary" "\"1core\"" &&
+        test_must_fail jmgr_check_annotation_exists $(cat job3.id) "sched.reason_pending" &&
+        test_must_fail jmgr_check_annotation_exists $(cat job3.id) "sched.jobs_ahead" &&
+        jmgr_check_annotation $(cat job4.id) "sched.reason_pending" "\"no cores\"" &&
+        jmgr_check_annotation $(cat job4.id) "sched.jobs_ahead" "0" &&
+        jmgr_check_annotation $(cat job5.id) "sched.reason_pending" "\"no cores\"" &&
+        jmgr_check_annotation $(cat job5.id) "sched.jobs_ahead" "1"
 '
 
 test_expect_success 'job-manager: cancel 5' '
@@ -99,22 +99,22 @@ test_expect_success 'job-manager: cancel 5' '
 '
 
 test_expect_success 'job-manager: job state RIRSI' '
-        check_state $(cat job1.id) R &&
-        check_state $(cat job2.id) I &&
-        check_state $(cat job3.id) R &&
-        check_state $(cat job4.id) S &&
-        check_state $(cat job5.id) I
+        jmgr_check_state $(cat job1.id) R &&
+        jmgr_check_state $(cat job2.id) I &&
+        jmgr_check_state $(cat job3.id) R &&
+        jmgr_check_state $(cat job4.id) S &&
+        jmgr_check_state $(cat job5.id) I
 '
 
 test_expect_success HAVE_JQ 'job-manager: annotate job id 4 (RIRSI)' '
-        check_annotation $(cat job1.id) "sched.resource_summary" "\"1core\"" &&
-        check_no_annotations $(cat job2.id) &&
-        check_annotation $(cat job3.id) "sched.resource_summary" "\"1core\"" &&
-        test_must_fail check_annotation_exists $(cat job3.id) "sched.reason_pending" &&
-        test_must_fail check_annotation_exists $(cat job3.id) "sched.jobs_ahead" &&
-        check_annotation $(cat job4.id) "sched.reason_pending" "\"no cores\"" &&
-        check_annotation $(cat job4.id) "sched.jobs_ahead" "0" &&
-        check_no_annotations $(cat job5.id)
+        jmgr_check_annotation $(cat job1.id) "sched.resource_summary" "\"1core\"" &&
+        jmgr_check_no_annotations $(cat job2.id) &&
+        jmgr_check_annotation $(cat job3.id) "sched.resource_summary" "\"1core\"" &&
+        test_must_fail jmgr_check_annotation_exists $(cat job3.id) "sched.reason_pending" &&
+        test_must_fail jmgr_check_annotation_exists $(cat job3.id) "sched.jobs_ahead" &&
+        jmgr_check_annotation $(cat job4.id) "sched.reason_pending" "\"no cores\"" &&
+        jmgr_check_annotation $(cat job4.id) "sched.jobs_ahead" "0" &&
+        jmgr_check_no_annotations $(cat job5.id)
 '
 
 test_expect_success 'job-manager: cancel all jobs' '
@@ -124,19 +124,19 @@ test_expect_success 'job-manager: cancel all jobs' '
 '
 
 test_expect_success 'job-manager: job state IIIII' '
-        check_state $(cat job1.id) I &&
-        check_state $(cat job2.id) I &&
-        check_state $(cat job3.id) I &&
-        check_state $(cat job4.id) I &&
-        check_state $(cat job5.id) I
+        jmgr_check_state $(cat job1.id) I &&
+        jmgr_check_state $(cat job2.id) I &&
+        jmgr_check_state $(cat job3.id) I &&
+        jmgr_check_state $(cat job4.id) I &&
+        jmgr_check_state $(cat job5.id) I
 '
 
 test_expect_success HAVE_JQ 'job-manager: no annotations (IIIII)' '
-        check_no_annotations $(cat job1.id) &&
-        check_no_annotations $(cat job2.id) &&
-        check_no_annotations $(cat job3.id) &&
-        check_no_annotations $(cat job4.id) &&
-        check_no_annotations $(cat job5.id)
+        jmgr_check_no_annotations $(cat job1.id) &&
+        jmgr_check_no_annotations $(cat job2.id) &&
+        jmgr_check_no_annotations $(cat job3.id) &&
+        jmgr_check_no_annotations $(cat job4.id) &&
+        jmgr_check_no_annotations $(cat job5.id)
 '
 
 test_expect_success 'job-manager: remove sched-dummy' '

--- a/t/t2300-sched-simple.t
+++ b/t/t2300-sched-simple.t
@@ -84,10 +84,10 @@ test_expect_success 'sched-simple: submit 5 jobs' '
 test_expect_success 'sched-simple: check allocations for running jobs' '
 	list_R $(cat job1.id job2.id job3.id job4.id) > allocs.out &&
 	cat <<-EOF >allocs.expected &&
-	annotations={"sched.resource_summary":"rank0/core0"}
-	annotations={"sched.resource_summary":"rank1/core0"}
-	annotations={"sched.resource_summary":"rank0/core1"}
-	annotations={"sched.resource_summary":"rank1/core1"}
+	annotations={"sched":{"resource_summary":"rank0/core0"}}
+	annotations={"sched":{"resource_summary":"rank1/core0"}}
+	annotations={"sched":{"resource_summary":"rank0/core1"}}
+	annotations={"sched":{"resource_summary":"rank1/core1"}}
 	EOF
 	test_cmp allocs.expected allocs.out
 '
@@ -101,7 +101,7 @@ test_expect_success 'sched-simple: cancel one job' '
 '
 test_expect_success 'sched-simple: waiting job now has alloc event' '
         flux job wait-event --timeout=5.0 $(cat job5.id) alloc &&
-	test "$(list_R $(cat job5.id))" = "annotations={\"sched.resource_summary\":\"rank0/core1\"}"
+	test "$(list_R $(cat job5.id))" = "annotations={\"sched\":{\"resource_summary\":\"rank0/core1\"}}"
 '
 test_expect_success 'sched-simple: cancel all jobs' '
 	flux job cancel $(cat job5.id) &&
@@ -127,10 +127,10 @@ test_expect_success 'sched-simple: submit 5 more jobs' '
 test_expect_success 'sched-simple: check allocations for running jobs' '
 	list_R $(cat job6.id job7.id job8.id job9.id) > best-fit-allocs.out &&
 	cat <<-EOF >best-fit-allocs.expected &&
-	annotations={"sched.resource_summary":"rank0/core0"}
-	annotations={"sched.resource_summary":"rank0/core1"}
-	annotations={"sched.resource_summary":"rank1/core0"}
-	annotations={"sched.resource_summary":"rank1/core1"}
+	annotations={"sched":{"resource_summary":"rank0/core0"}}
+	annotations={"sched":{"resource_summary":"rank0/core1"}}
+	annotations={"sched":{"resource_summary":"rank1/core0"}}
+	annotations={"sched":{"resource_summary":"rank1/core1"}}
 	EOF
 	test_cmp best-fit-allocs.expected best-fit-allocs.out
 '
@@ -172,9 +172,9 @@ test_expect_success 'sched-simple: check allocations for running jobs' '
 	list_R $(cat job11.id job12.id job13.id ) \
 		 > first-fit-allocs.out &&
 	cat <<-EOF >first-fit-allocs.expected &&
-	annotations={"sched.resource_summary":"rank0/core0"}
-	annotations={"sched.resource_summary":"rank0/core1"}
-	annotations={"sched.resource_summary":"rank1/core0"}
+	annotations={"sched":{"resource_summary":"rank0/core0"}}
+	annotations={"sched":{"resource_summary":"rank0/core1"}}
+	annotations={"sched":{"resource_summary":"rank1/core0"}}
 	EOF
 	test_cmp first-fit-allocs.expected first-fit-allocs.out
 '
@@ -211,9 +211,9 @@ test_expect_success 'sched-simple: check allocations for running jobs' '
 	list_R $(cat job11.id job12.id job13.id ) \
 		 > single-allocs.out &&
 	cat <<-EOF >first-fit-allocs.expected &&
-	annotations={"sched.resource_summary":"rank0/core0"}
-	annotations={"sched.resource_summary":"rank0/core1"}
-	annotations={"sched.resource_summary":"rank1/core0"}
+	annotations={"sched":{"resource_summary":"rank0/core0"}}
+	annotations={"sched":{"resource_summary":"rank0/core1"}}
+	annotations={"sched":{"resource_summary":"rank1/core0"}}
 	EOF
 	test_cmp first-fit-allocs.expected first-fit-allocs.out
 '


### PR DESCRIPTION
Spun out of my annotations work the following is a set of misc cleanups.  

The most major change is the re-working of annotations to in sub-objects, not at the top level.  What I mean is:

- re-worked annotations to store "namespace" keys within an object of a key. i.e.

  `{"sched.reason_pending": "no cores"}`

  is now

  `{"sched":{"reason_pending": "no cores"}}`

- re-worked annotations updates to be "recursive". e.g.

  updating

  `{"sched": { "reason_pending": "no cores"}}`

  with

  `{"sched": { "t_estimate": 1234}}`

  should result in

  `{"sched": { "reason_pending": "no cores", "t_estimate": 1234}}`


Of the minor cleanups, perhaps the only one worth debating is e32391bec4914985e954fd8852cc50611bc01a1f, should the error be ENOENT instead of EINVAL?



