### PR TITLE
job-info & job-manager& flux-jobs: Support job annotations (annotations part 3)

### DIFF
--- a/doc/man1/flux-jobs.rst
+++ b/doc/man1/flux-jobs.rst
@@ -111,11 +111,16 @@ the following conversion flags are supported by *flux-jobs*:
 **!H**
    convert a duration to hours:minutes:seconds form (e.g. *{runtime!H}*)
 
-Scheduler and user annotations can be retrieved via the *annotations*
-field name.  Specific keys and sub-object keys can be retrieved
-separated by a period (".").  For example, if the scheduler has
-annotated the job with a reason pending status, it can be retrieved
-via "{annotations.sched.reason_pending}".
+Annotations can be retrieved via the *annotations* field name.
+Specific keys and sub-object keys can be retrieved separated by a
+period (".").  For example, if the scheduler has annotated the job
+with a reason pending status, it can be retrieved via
+"{annotations.sched.reason_pending}".
+
+As a convenience, the field names *sched* and *user* can be used as
+substitutions for *annotations.sched* and *annotations.user*.  For
+example, a reason pending status can be retrieved via
+"{sched.reason_pending}".
 
 The field names that can be specified are:
 
@@ -206,6 +211,11 @@ The field names that can be specified are:
 **annotations**
    annotations metadata, use "." to get specific keys
 
+**sched**
+   short hand for *annotations.sched*
+
+**user**
+   short hand for *annotations.user*
 
 RESOURCES
 =========

--- a/doc/man1/flux-jobs.rst
+++ b/doc/man1/flux-jobs.rst
@@ -111,6 +111,12 @@ the following conversion flags are supported by *flux-jobs*:
 **!H**
    convert a duration to hours:minutes:seconds form (e.g. *{runtime!H}*)
 
+Scheduler and user annotations can be retrieved via the *annotations*
+field name.  Specific keys and sub-object keys can be retrieved
+separated by a period (".").  For example, if the scheduler has
+annotated the job with a reason pending status, it can be retrieved
+via "{annotations.sched.reason_pending}".
+
 The field names that can be specified are:
 
 **id**
@@ -196,6 +202,9 @@ The field names that can be specified are:
 
 **t_remaining**
    If job is running, amount of time remaining before expiration
+
+**annotations**
+   annotations metadata, use "." to get specific keys
 
 
 RESOURCES

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -1003,7 +1003,8 @@ static const char *list_attrs =
     "\"name\",\"ntasks\",\"nnodes\",\"ranks\",\"expiration\",\"success\"," \
     "\"exception_occurred\",\"exception_severity\",\"exception_type\"," \
     "\"exception_note\",\"result\","                                    \
-    "\"t_depend\",\"t_sched\",\"t_run\",\"t_cleanup\",\"t_inactive\"]";
+    "\"t_depend\",\"t_sched\",\"t_run\",\"t_cleanup\",\"t_inactive\"," \
+    "\"annotations\"]";
 
 int cmd_list (optparse_t *p, int argc, char **argv)
 {

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -85,6 +85,7 @@ int cmd_wait_event (optparse_t *p, int argc, char **argv);
 int cmd_info (optparse_t *p, int argc, char **argv);
 int cmd_stats (optparse_t *p, int argc, char **argv);
 int cmd_wait (optparse_t *p, int argc, char **argv);
+int cmd_annotate (optparse_t *p, int argc, char **argv);
 
 int stdin_flags;
 
@@ -441,6 +442,13 @@ static struct optparse_subcommand subcommands[] = {
       cmd_wait,
       0,
       wait_opts,
+    },
+    { "annotate",
+      "[OPTIONS] id key value",
+      "Annotate job with key and value",
+      cmd_annotate,
+      0,
+      NULL,
     },
     OPTPARSE_SUBCMD_END
 };
@@ -2825,6 +2833,64 @@ int cmd_wait (optparse_t *p, int argc, char **argv)
     }
     flux_close (h);
     return (rc);
+}
+
+int cmd_annotate (optparse_t *p, int argc, char **argv)
+{
+    int optindex = optparse_option_index (p);
+    flux_t *h;
+    flux_jobid_t id;
+    const char *key;
+    const char *value;
+    void *valbuf = NULL;
+    json_t *v;
+    json_error_t error;
+    json_t *a;
+    flux_future_t *f;
+
+    if ((argc - optindex) != 3) {
+        optparse_print_usage (p);
+        exit (1);
+    }
+    if (!(h = flux_open (NULL, 0)))
+        log_err_exit ("flux_open");
+
+    id = parse_jobid (argv[optindex]);
+    key = argv[optindex + 1];
+
+    if (!strcmp (argv[optindex + 2], "-")) {
+        ssize_t size;
+        if ((size = read_all (STDIN_FILENO, &valbuf)) < 0)
+            log_err_exit ("read_all");
+        value = (const char *)valbuf;
+    }
+    else
+        value = argv[optindex + 2];
+
+    /* if value is not legal json, assume string */
+    if (!(v = json_loads (value, JSON_DECODE_ANY, &error))) {
+        if (!(v = json_string (value)))
+            log_msg_exit ("json_string");
+    }
+
+    if (!(a = json_pack ("{s:{s:o}}", "user", key, v)))
+        log_err_exit ("json_pack");
+
+    if (!(f = flux_rpc_pack (h,
+                             "job-manager.annotate",
+                             FLUX_NODEID_ANY,
+                             0,
+                             "{s:I s:o}",
+                             "id", id,
+                             "annotations", a)))
+        log_err_exit ("flux_rpc_pack");
+    if (flux_rpc_get (f, NULL) < 0)
+        log_msg_exit ("annotate: %s", future_strerror (f, errno));
+
+    flux_future_destroy (f);
+    flux_close (h);
+    free (valbuf);
+    return (0);
 }
 
 /*

--- a/src/cmd/flux-jobs.py
+++ b/src/cmd/flux-jobs.py
@@ -632,6 +632,10 @@ class JobsOutputFormat(flux.util.OutputFormat):
         "exception.type": "EXCEPTION-TYPE",
         "exception.note": "EXCEPTION-NOTE",
         "annotations": "ANNOTATIONS",
+        # The following are special pre-defined cases per RFC27
+        "annotations.sched.t_estimate": "T_ESTIMATE",
+        "annotations.sched.reason_pending": "REASON",
+        "annotations.sched.resource_summary": "RESOURCES",
     }
 
     def __init__(self, fmt):
@@ -648,7 +652,11 @@ class JobsOutputFormat(flux.util.OutputFormat):
         """
         format_list = string.Formatter().parse(fmt)
         for (_, field, _, _) in format_list:
-            if field and field.startswith("annotations."):
+            if (
+                field
+                and not field in self.headings
+                and field.startswith("annotations.")
+            ):
                 field_heading = field[len("annotations.") :].upper()
                 self.headings[field] = field_heading
         super().__init__(self.headings, fmt, prepend="0.")

--- a/src/modules/job-info/job-info.c
+++ b/src/modules/job-info/job-info.c
@@ -178,6 +178,11 @@ static const struct flux_msg_handler_spec htab[] = {
       .cb           = job_state_cb,
       .rolemask     = 0
     },
+    { .typemask     = FLUX_MSGTYPE_EVENT,
+      .topic_glob   = "job-annotations",
+      .cb           = job_annotations_cb,
+      .rolemask     = 0
+    },
     FLUX_MSGHANDLER_TABLE_END,
 };
 

--- a/src/modules/job-info/job_state.c
+++ b/src/modules/job-info/job_state.c
@@ -77,6 +77,7 @@ static void job_destroy (void *data)
     struct job *job = data;
     if (job) {
         json_decref (job->exception_context);
+        json_decref (job->annotations);
         json_decref (job->jobspec_job);
         json_decref (job->jobspec_cmd);
         json_decref (job->R);
@@ -162,6 +163,11 @@ struct job_state_ctx *job_state_create (flux_t *h)
     zlistx_set_destructor (jsctx->transitions, flux_msg_destroy_wrapper);
 
     if (flux_event_subscribe (h, "job-state") < 0) {
+        flux_log_error (h, "flux_event_subscribe");
+        goto error;
+    }
+
+    if (flux_event_subscribe (h, "job-annotations") < 0) {
         flux_log_error (h, "flux_event_subscribe");
         goto error;
     }
@@ -1238,6 +1244,81 @@ void job_state_cb (flux_t *h, flux_msg_handler_t *mh,
     return;
 }
 
+static int parse_annotation (json_t *annotation, flux_jobid_t *id, json_t **aValue)
+{
+    json_t *o;
+
+    if (!json_is_array (annotation))
+        return -1;
+
+    if (!(o = json_array_get (annotation, 0))
+        || !json_is_integer (o))
+        return -1;
+
+    (*id) = json_integer_value (o);
+
+    if (!(o = json_array_get (annotation, 1))
+        || (!json_is_object (o) && !json_is_null (o)))
+        return -1;
+
+    (*aValue) = o;
+    return 0;
+}
+
+static void update_annotations (struct info_ctx *ctx, json_t *annotations)
+{
+    struct job_state_ctx *jsctx = ctx->jsctx;
+    size_t index;
+    json_t *value;
+
+    if (!json_is_array (annotations)) {
+        flux_log (ctx->h, LOG_ERR, "annotations event is not an array");
+        return;
+    }
+
+    json_array_foreach (annotations, index, value) {
+        struct job *job;
+        flux_jobid_t id;
+        json_t *aValue;
+
+        if (parse_annotation (value, &id, &aValue) < 0) {
+            flux_log (jsctx->h, LOG_ERR, "%s: annotation parse error",
+                      __FUNCTION__);
+            return;
+        }
+
+        if ((job = zhashx_lookup (jsctx->index, &id))) {
+            json_decref (job->annotations);
+            if (json_is_null (aValue))
+                job->annotations = NULL;
+            else
+                job->annotations = json_incref (aValue);
+        }
+        else
+            flux_log_error (jsctx->h, "%s: job %ju not found",
+                            __FUNCTION__, (uintmax_t)id);
+    }
+
+}
+
+void job_annotations_cb (flux_t *h, flux_msg_handler_t *mh,
+                         const flux_msg_t *msg, void *arg)
+{
+    struct info_ctx *ctx = arg;
+    json_t *annotations;
+
+    if (flux_event_unpack (msg, NULL, "{s:o}",
+                           "annotations",
+                           &annotations) < 0) {
+        flux_log_error (h, "%s: flux_event_unpack", __FUNCTION__);
+        return;
+    }
+
+    update_annotations (ctx, annotations);
+
+    return;
+}
+
 void job_state_pause_cb (flux_t *h, flux_msg_handler_t *mh,
                          const flux_msg_t *msg, void *arg)
 {
@@ -1365,6 +1446,18 @@ static struct job *eventlog_restart_parse (struct info_ctx *ctx,
                 update_job_state (ctx, job, FLUX_JOB_CLEANUP, timestamp);
         }
         else if (!strcmp (name, "alloc")) {
+            /* context not required if no annotations */
+            if (context) {
+                json_t *annotations;
+                if (!(annotations = json_object_get (context, "annotations"))) {
+                    flux_log (ctx->h, LOG_ERR,
+                              "%s: alloc context for %ju invalid",
+                              __FUNCTION__, (uintmax_t)job->id);
+                    goto error;
+                }
+                job->annotations = json_incref (annotations);
+            }
+
             if (job->state == FLUX_JOB_SCHED)
                 update_job_state (ctx, job, FLUX_JOB_RUN, timestamp);
         }

--- a/src/modules/job-info/job_state.h
+++ b/src/modules/job-info/job_state.h
@@ -78,6 +78,7 @@ struct job {
     const char *exception_type;
     const char *exception_note;
     flux_job_result_t result;
+    json_t *annotations;
 
     /* cache of job information */
     json_t *jobspec_job;
@@ -122,6 +123,9 @@ void job_state_destroy (void *data);
 
 void job_state_cb (flux_t *h, flux_msg_handler_t *mh,
                    const flux_msg_t *msg, void *arg);
+
+void job_annotations_cb (flux_t *h, flux_msg_handler_t *mh,
+                         const flux_msg_t *msg, void *arg);
 
 void job_state_pause_cb (flux_t *h, flux_msg_handler_t *mh,
                          const flux_msg_t *msg, void *arg);

--- a/src/modules/job-info/job_util.c
+++ b/src/modules/job-info/job_util.c
@@ -156,6 +156,11 @@ json_t *job_to_json (struct job *job, json_t *attrs, job_info_error_t *errp)
                 continue;
             val = json_integer (job->result);
         }
+        else if (!strcmp (attr, "annotations")) {
+            if (!job->annotations)
+                continue;
+            val = json_incref (job->annotations);
+        }
         else {
             seterror (errp, "%s is not a valid attribute", attr);
             errno = EINVAL;

--- a/src/modules/job-info/list.c
+++ b/src/modules/job-info/list.c
@@ -570,7 +570,7 @@ void list_attrs_cb (flux_t *h, flux_msg_handler_t *mh,
                             "state", "name", "ntasks", "nnodes", "ranks",
                             "success", "exception_occurred", "exception_type",
                             "exception_severity", "exception_note", "result",
-                            "expiration", NULL };
+                            "expiration", "annotations", NULL };
     json_t *a = NULL;
     int i;
 

--- a/src/modules/job-manager/Makefile.am
+++ b/src/modules/job-manager/Makefile.am
@@ -39,7 +39,9 @@ job_manager_la_SOURCES = \
 	list.h \
 	list.c \
 	priority.h \
-	priority.c
+	priority.c \
+	annotate.h \
+	annotate.c
 
 job_manager_la_LDFLAGS = $(fluxmod_ldflags) -module
 job_manager_la_LIBADD = $(fluxmod_libadd) \
@@ -66,6 +68,7 @@ test_ldadd = \
         $(top_builddir)/src/modules/job-manager/drain.o \
         $(top_builddir)/src/modules/job-manager/submit.o \
         $(top_builddir)/src/modules/job-manager/wait.o \
+        $(top_builddir)/src/modules/job-manager/annotate.o \
 	$(top_builddir)/src/common/libtap/libtap.la \
 	$(top_builddir)/src/common/libjob/libjob.la \
 	$(top_builddir)/src/common/libflux-internal.la \

--- a/src/modules/job-manager/alloc.h
+++ b/src/modules/job-manager/alloc.h
@@ -52,12 +52,6 @@ struct job *alloc_queue_next (struct alloc *alloc);
  */
 void alloc_queue_reorder (struct alloc *alloc, struct job *job);
 
-/* exposed for unit testing only */
-typedef void (*annotate_log_f)(void *arg, const char *fmt, ...);
-
-void update_recursive (struct job *job, json_t *orig, json_t *new,
-                       annotate_log_f log_f, void *arg);
-
 #endif /* ! _FLUX_JOB_MANAGER_ALLOC_H */
 
 /*

--- a/src/modules/job-manager/annotate.c
+++ b/src/modules/job-manager/annotate.c
@@ -1,0 +1,200 @@
+/************************************************************\
+ * Copyright 2018 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* annotate - user requests to annotate a job
+ *
+ * Purpose:
+ *   Handle job-manager.annotate RPC
+ *
+ * Input:
+ * - job id, annotations
+ *
+ * Action:
+ *  -update annotations
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <ctype.h>
+#include <flux/core.h>
+
+#include "job.h"
+#include "event.h"
+#include "annotate.h"
+#include "job-manager.h"
+
+struct annotate {
+    struct job_manager *ctx;
+    flux_msg_handler_t **handlers;
+};
+
+void annotations_clear (struct job *job, bool *cleared)
+{
+    if (job->annotations) {
+        json_decref (job->annotations);
+        job->annotations = NULL;
+        if (cleared)
+            (*cleared) = true;
+    }
+}
+
+/* we want to delete items set to 'null', so this is not the same
+ * as json_object_update_recursive() in jansson 2.13.1
+ */
+int update_annotation_recursive (struct job *job, json_t *orig, json_t *new)
+{
+    const char *key;
+    json_t *value;
+
+    assert (job && orig && new);
+
+    json_object_foreach (new, key, value) {
+        if (!json_is_null (value)) {
+            json_t *orig_value = json_object_get (orig, key);
+
+            if (json_is_object (value)) {
+                if (!json_is_object (orig_value)) {
+                    json_t *o = json_object ();
+                    if (!o || json_object_set_new (orig, key, o) < 0) {
+                        errno = ENOMEM;
+                        json_decref (o);
+                        return -1;
+                    }
+                    orig_value = o;
+                }
+                if (update_annotation_recursive (job, orig_value, value) < 0)
+                    return -1;
+                /* if object is now empty, remove it */
+                if (!json_object_size (orig_value))
+                    (void)json_object_del (orig, key);
+            }
+            else {
+                if (json_object_set (orig, key, value) < 0) {
+                    errno = ENOMEM;
+                    return -1;
+                }
+            }
+        }
+        else
+            /* not an error if key doesn't exist in orig */
+            (void)json_object_del (orig, key);
+    }
+
+    return 0;
+}
+
+int annotations_update (flux_t *h, struct job *job, json_t *annotations)
+{
+    if (annotations) {
+        if (!job->annotations) {
+            if (!(job->annotations = json_object ())) {
+                errno = ENOMEM;
+                return -1;
+            }
+        }
+        if (job->annotations) {
+            if (update_annotation_recursive (job,
+                                             job->annotations,
+                                             annotations) < 0)
+                return -1;
+            /* Special case: if user cleared all entries, assume we no
+             * longer need annotations object
+             *
+             * if cleared no need to call
+             * event_batch_pub_annotations(), should be handled by
+             * caller.
+             */
+            if (!json_object_size (job->annotations))
+                annotations_clear (job, NULL);
+        }
+    }
+
+    return 0;
+}
+
+void annotate_handle_request (flux_t *h,
+                              flux_msg_handler_t *mh,
+                              const flux_msg_t *msg,
+                              void *arg)
+{
+    struct job_manager *ctx = arg;
+    struct flux_msg_cred cred;
+    flux_jobid_t id;
+    json_t *annotations = NULL;
+    struct job *job;
+    const char *errstr = NULL;
+
+    if (flux_request_unpack (msg, NULL, "{s:I s:o}",
+                                        "id", &id,
+                                        "annotations", &annotations) < 0
+        || flux_msg_get_cred (msg, &cred) < 0)
+        goto error;
+    if (!(job = zhashx_lookup (ctx->active_jobs, &id))) {
+        errstr = "unknown job id";
+        errno = ENOENT;
+        goto error;
+    }
+    if (flux_msg_cred_authorize (cred, job->userid) < 0) {
+        errstr = "guests can only annotate their own jobs";
+        goto error;
+    }
+    if (annotations_update (ctx->h, job, annotations) < 0)
+        goto error;
+    if (event_batch_pub_annotations (ctx->event, job) < 0) {
+        flux_log_error (h, "%s: event_batch_pub_annotations", __FUNCTION__);
+        goto error;
+    }
+    if (flux_respond (h, msg, NULL) < 0)
+        flux_log_error (h, "%s: flux_respond", __FUNCTION__);
+    return;
+error:
+    if (flux_respond_error (h, msg, errno, errstr) < 0)
+        flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
+}
+
+void annotate_ctx_destroy (struct annotate *annotate)
+{
+    if (annotate) {
+        int saved_errno = errno;
+        flux_msg_handler_delvec (annotate->handlers);
+        free (annotate);
+        errno = saved_errno;
+    }
+}
+
+static const struct flux_msg_handler_spec htab[] = {
+    {
+        FLUX_MSGTYPE_REQUEST,
+        "job-manager.annotate",
+        annotate_handle_request,
+        FLUX_ROLE_USER
+    },
+    FLUX_MSGHANDLER_TABLE_END,
+};
+
+struct annotate *annotate_ctx_create (struct job_manager *ctx)
+{
+    struct annotate *annotate;
+
+    if (!(annotate = calloc (1, sizeof (*annotate))))
+        return NULL;
+    annotate->ctx = ctx;
+    if (flux_msg_handler_addvec (ctx->h, htab, ctx, &annotate->handlers) < 0)
+        goto error;
+    return annotate;
+error:
+    annotate_ctx_destroy (annotate);
+    return NULL;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/job-manager/annotate.h
+++ b/src/modules/job-manager/annotate.h
@@ -1,0 +1,31 @@
+/************************************************************\
+ * Copyright 2018 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _FLUX_JOB_MANAGER_ANNOTATE_H
+#define _FLUX_JOB_MANAGER_ANNOTATE_H
+
+#include <stdint.h>
+
+#include "job.h"
+#include "job-manager.h"
+
+void annotations_clear (struct job *job, bool *cleared);
+int annotations_update (flux_t *h, struct job *job, json_t *annotations);
+
+struct annotate *annotate_ctx_create (struct job_manager *ctx);
+void annotate_ctx_destroy (struct annotate *annotate);
+
+/* exposed for unit testing only */
+int update_annotation_recursive (struct job *job, json_t *orig, json_t *new);
+
+#endif /* ! _FLUX_JOB_MANAGER_ANNOTATE_H */
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/job-manager/event.c
+++ b/src/modules/job-manager/event.c
@@ -64,6 +64,7 @@ struct event_batch {
     flux_kvs_txn_t *txn;
     flux_future_t *f;
     json_t *state_trans;
+    json_t *annotations;
     zlist_t *responses; // responses deferred until batch complete
 };
 
@@ -141,17 +142,18 @@ void timer_cb (flux_reactor_t *r, flux_watcher_t *w, int revents, void *arg)
     event_batch_commit (ctx->event);
 }
 
-void event_publish_state (struct event *event, json_t *state_trans)
+void event_publish (struct event *event, const char *topic,
+                    const char *key, json_t *o)
 {
     struct job_manager *ctx = event->ctx;
     flux_future_t *f;
 
-    if (!(f = flux_event_publish_pack (ctx->h,
-                                       "job-state",
-                                       0,
-                                       "{s:O}",
-                                       "transitions",
-                                       state_trans))) {
+    /* O? support in jansson 2.8 */
+    if (o)
+        f = flux_event_publish_pack (ctx->h, topic, 0, "{s:O}", key, o);
+    else
+        f = flux_event_publish_pack (ctx->h, topic, 0, "{s:n}", key);
+    if (!f) {
         flux_log_error (ctx->h, "%s: flux_event_publish_pack", __FUNCTION__);
         goto error;
     }
@@ -184,8 +186,19 @@ void event_batch_destroy (struct event_batch *batch)
             (void)flux_future_wait_for (batch->f, -1);
         if (batch->state_trans) {
             if (json_array_size (batch->state_trans) > 0)
-                event_publish_state (batch->event, batch->state_trans);
+                event_publish (batch->event,
+                               "job-state",
+                               "transitions",
+                               batch->state_trans);
             json_decref (batch->state_trans);
+        }
+        if (batch->annotations) {
+            if (json_array_size (batch->annotations) > 0)
+                event_publish (batch->event,
+                               "job-annotations",
+                               "annotations",
+                               batch->annotations);
+            json_decref (batch->annotations);
         }
         if (batch->responses) {
             flux_msg_t *msg;
@@ -209,14 +222,8 @@ struct event_batch *event_batch_create (struct event *event)
 
     if (!(batch = calloc (1, sizeof (*batch))))
         return NULL;
-    if (!(batch->state_trans = json_array ()))
-        goto nomem;
     batch->event = event;
     return batch;
-nomem:
-    errno = ENOMEM;
-    event_batch_destroy (batch);
-    return NULL;
 }
 
 /* Create a new "batch" if there is none.
@@ -266,12 +273,47 @@ int event_batch_pub_state (struct event *event, struct job *job,
 
     if (event_batch_start (event) < 0)
         goto error;
+    if (!event->batch->state_trans) {
+        if (!(event->batch->state_trans = json_array ()))
+            goto nomem;
+    }
     if (!(o = json_pack ("[I,s,f]",
                          job->id,
                          flux_job_statetostr (job->state, false),
                          timestamp)))
         goto nomem;
     if (json_array_append_new (event->batch->state_trans, o)) {
+        json_decref (o);
+        goto nomem;
+    }
+    return 0;
+nomem:
+    errno = ENOMEM;
+error:
+    return -1;
+}
+
+int event_batch_pub_annotations (struct event *event, struct job *job)
+{
+    json_t *o;
+
+    /* do not check for job->annotations == NULL, all annotations
+     * being cleared is a possible change.
+     */
+    if (event_batch_start (event) < 0)
+        goto error;
+    if (!event->batch->annotations) {
+        if (!(event->batch->annotations = json_array ()))
+            goto nomem;
+    }
+    /* O? support in jansson 2.8 */
+    if (job->annotations)
+        o = json_pack ("[I,O]", job->id, job->annotations);
+    else
+        o = json_pack ("[I,n]", job->id);
+    if (!o)
+        goto nomem;
+    if (json_array_append_new (event->batch->annotations, o)) {
         json_decref (o);
         goto nomem;
     }

--- a/src/modules/job-manager/event.h
+++ b/src/modules/job-manager/event.h
@@ -35,6 +35,10 @@ int event_job_update (struct job *job, json_t *event);
 int event_batch_pub_state (struct event *event, struct job *job,
                            double timestamp);
 
+/* Add notification of job's annotation change for publication.
+ */
+int event_batch_pub_annotations (struct event *event, struct job *job);
+
 /* Add add response to batch, to be sent upon batch completion.
  */
 int event_batch_respond (struct event *event, const flux_msg_t *msg);

--- a/src/modules/job-manager/job-manager.c
+++ b/src/modules/job-manager/job-manager.c
@@ -27,6 +27,7 @@
 #include "event.h"
 #include "drain.h"
 #include "wait.h"
+#include "annotate.h"
 
 #include "job-manager.h"
 
@@ -120,6 +121,10 @@ int mod_main (flux_t *h, int argc, char **argv)
         flux_log_error (h, "error creating kill interface");
         goto done;
     }
+    if (!(ctx.annotate = annotate_ctx_create (&ctx))) {
+        flux_log_error (h, "error creating annotate interface");
+        goto done;
+    }
     if (flux_msg_handler_addvec (h, htab, &ctx, &ctx.handlers) < 0) {
         flux_log_error (h, "flux_msghandler_add");
         goto done;
@@ -139,6 +144,7 @@ int mod_main (flux_t *h, int argc, char **argv)
     rc = 0;
 done:
     flux_msg_handler_delvec (ctx.handlers);
+    annotate_ctx_destroy (ctx.annotate);
     kill_ctx_destroy (ctx.kill);
     raise_ctx_destroy (ctx.raise);
     wait_ctx_destroy (ctx.wait);

--- a/src/modules/job-manager/job-manager.h
+++ b/src/modules/job-manager/job-manager.h
@@ -25,6 +25,7 @@ struct job_manager {
     struct waitjob *wait;
     struct raise *raise;
     struct kill *kill;
+    struct annotate *annotate;
 };
 
 #endif /* !_FLUX_JOB_MANAGER_H */

--- a/src/modules/job-manager/test/annotate.c
+++ b/src/modules/job-manager/test/annotate.c
@@ -13,7 +13,7 @@
 #include <flux/core.h>
 #include "src/common/libtap/tap.h"
 
-#include "src/modules/job-manager/alloc.h"
+#include "src/modules/job-manager/annotate.h"
 
 void basic (void)
 {
@@ -21,6 +21,7 @@ void basic (void)
     json_t *orig;
     json_t *new;
     json_t *cmp;
+    int rc;
 
     orig = json_object ();
     new = json_object ();
@@ -28,9 +29,9 @@ void basic (void)
     if (!orig || !new || !cmp)
         BAIL_OUT ("json_object() failed");
 
-    update_recursive (&j, orig, new, NULL, NULL);
-    ok (json_equal (orig, cmp) > 0,
-        "update_recursive does nothing on empty dictionary");
+    rc = update_annotation_recursive (&j, orig, new);
+    ok (!rc && json_equal (orig, cmp) > 0,
+        "update_annotation_recursive does nothing on empty dictionary");
 
     json_decref (new);
     json_decref (cmp);
@@ -40,9 +41,9 @@ void basic (void)
     if (!new || !cmp)
         BAIL_OUT ("json_object() failed");
 
-    update_recursive (&j, orig, new, NULL, NULL);
-    ok (json_equal (orig, cmp) > 0,
-        "update_recursive does nothing removing non-existant key");
+    rc = update_annotation_recursive (&j, orig, new);
+    ok (!rc && json_equal (orig, cmp) > 0,
+        "update_annotation_recursive does nothing removing non-existant key");
 
     json_decref (new);
     json_decref (cmp);
@@ -52,9 +53,9 @@ void basic (void)
     if (!new || !cmp)
         BAIL_OUT ("json_pack() failed");
 
-    update_recursive (&j, orig, new, NULL, NULL);
-    ok (json_equal (orig, cmp) > 0,
-        "update_recursive updates orig appropriately");
+    rc = update_annotation_recursive (&j, orig, new);
+    ok (!rc && json_equal (orig, cmp) > 0,
+        "update_annotation_recursive updates orig appropriately");
 
     json_decref (new);
     json_decref (cmp);
@@ -64,9 +65,9 @@ void basic (void)
     if (!new || !cmp)
         BAIL_OUT ("json_pack() failed");
 
-    update_recursive (&j, orig, new, NULL, NULL);
-    ok (json_equal (orig, cmp) > 0,
-        "update_recursive overwrites existing key");
+    rc = update_annotation_recursive (&j, orig, new);
+    ok (!rc && json_equal (orig, cmp) > 0,
+        "update_annotation_recursive overwrites existing key");
 
     json_decref (new);
     json_decref (cmp);
@@ -76,9 +77,9 @@ void basic (void)
     if (!new || !cmp)
         BAIL_OUT ("json_pack() failed");
 
-    update_recursive (&j, orig, new, NULL, NULL);
-    ok (json_equal (orig, cmp) > 0,
-        "update_recursive removes value on json null setting");
+    rc = update_annotation_recursive (&j, orig, new);
+    ok (!rc && json_equal (orig, cmp) > 0,
+        "update_annotation_recursive removes value on json null setting");
 
     json_decref (new);
     json_decref (cmp);
@@ -90,6 +91,7 @@ void recursive (void)
     json_t *orig;
     json_t *new;
     json_t *cmp;
+    int rc;
 
     orig = json_object ();
     new = json_pack ("{s:{}}", "obj", "str", "foo");
@@ -97,18 +99,19 @@ void recursive (void)
     if (!orig || !new || !cmp)
         BAIL_OUT ("json_object/pack() failed");
 
-    update_recursive (&j, orig, new, NULL, NULL);
-    ok (json_equal (orig, cmp) > 0,
-        "update_recursive recursively does nothing on empty dictionary");
+    rc = update_annotation_recursive (&j, orig, new);
+    ok (!rc && json_equal (orig, cmp) > 0,
+        "update_annotation_recursive recursively does nothing on "
+        "empty dictionary");
 
     new = json_pack ("{s:{s:s}}", "obj", "str", "foo");
     cmp = json_pack ("{s:{s:s}}", "obj", "str", "foo");
     if (!new || !cmp)
         BAIL_OUT ("json_pack() failed");
 
-    update_recursive (&j, orig, new, NULL, NULL);
-    ok (json_equal (orig, cmp) > 0,
-        "update_recursive sets dictionary");
+    rc = update_annotation_recursive (&j, orig, new);
+    ok (!rc && json_equal (orig, cmp) > 0,
+        "update_annotation_recursive sets dictionary");
 
     json_decref (new);
     json_decref (cmp);
@@ -118,9 +121,10 @@ void recursive (void)
     if (!new || !cmp)
         BAIL_OUT ("json_pack() failed");
 
-    update_recursive (&j, orig, new, NULL, NULL);
-    ok (json_equal (orig, cmp) > 0,
-        "update_recursive recursively does nothing removing non-existant key");
+    rc = update_annotation_recursive (&j, orig, new);
+    ok (!rc && json_equal (orig, cmp) > 0,
+        "update_annotation_recursive recursively does nothing "
+        "removing non-existant key");
 
     json_decref (new);
     json_decref (cmp);
@@ -130,9 +134,9 @@ void recursive (void)
     if (!new || !cmp)
         BAIL_OUT ("json_pack() failed");
 
-    update_recursive (&j, orig, new, NULL, NULL);
-    ok (json_equal (orig, cmp) > 0,
-        "update_recursive recursively updates orig appropriately");
+    rc = update_annotation_recursive (&j, orig, new);
+    ok (!rc && json_equal (orig, cmp) > 0,
+        "update_annotation_recursive recursively updates orig appropriately");
 
     json_decref (new);
     json_decref (cmp);
@@ -142,9 +146,9 @@ void recursive (void)
     if (!new || !cmp)
         BAIL_OUT ("json_pack() failed");
 
-    update_recursive (&j, orig, new, NULL, NULL);
-    ok (json_equal (orig, cmp) > 0,
-        "update_recursive recursively overwrites existing key");
+    rc = update_annotation_recursive (&j, orig, new);
+    ok (!rc && json_equal (orig, cmp) > 0,
+        "update_annotation_recursive recursively overwrites existing key");
 
     json_decref (new);
     json_decref (cmp);
@@ -154,9 +158,10 @@ void recursive (void)
     if (!new || !cmp)
         BAIL_OUT ("json_pack() failed");
 
-    update_recursive (&j, orig, new, NULL, NULL);
-    ok (json_equal (orig, cmp) > 0,
-        "update_recursive recursively removes value on json null setting");
+    rc = update_annotation_recursive (&j, orig, new);
+    ok (!rc && json_equal (orig, cmp) > 0,
+        "update_annotation_recursive recursively removes value "
+        "on json null setting");
 
     json_decref (new);
     json_decref (cmp);
@@ -166,9 +171,10 @@ void recursive (void)
     if (!new || !cmp)
         BAIL_OUT ("json_pack() failed");
 
-    update_recursive (&j, orig, new, NULL, NULL);
-    ok (json_equal (orig, cmp) > 0,
-        "update_recursive recursively removes empty sub-dictionaries");
+    rc = update_annotation_recursive (&j, orig, new);
+    ok (!rc && json_equal (orig, cmp) > 0,
+        "update_annotation_recursive recursively removes empty "
+        "sub-dictionaries");
 
     json_decref (new);
     json_decref (cmp);
@@ -180,6 +186,7 @@ void overwrite (void)
     json_t *orig;
     json_t *new;
     json_t *cmp;
+    int rc;
 
     orig = json_object ();
     new = json_pack ("{s:{s:s}}", "obj", "str", "foo");
@@ -187,9 +194,9 @@ void overwrite (void)
     if (!orig || !new || !cmp)
         BAIL_OUT ("json_object/pack() failed");
 
-    update_recursive (&j, orig, new, NULL, NULL);
-    ok (json_equal (orig, cmp) > 0,
-        "update_recursive sets dictionary");
+    rc = update_annotation_recursive (&j, orig, new);
+    ok (!rc && json_equal (orig, cmp) > 0,
+        "update_annotation_recursive sets dictionary");
 
     json_decref (new);
     json_decref (cmp);
@@ -199,9 +206,9 @@ void overwrite (void)
     if (!new || !cmp)
         BAIL_OUT ("json_pack() failed");
 
-    update_recursive (&j, orig, new, NULL, NULL);
-    ok (json_equal (orig, cmp) > 0,
-        "update_recursive overwrites object with non-object");
+    rc = update_annotation_recursive (&j, orig, new);
+    ok (!rc && json_equal (orig, cmp) > 0,
+        "update_annotation_recursive overwrites object with non-object");
 
     json_decref (new);
     json_decref (cmp);
@@ -211,9 +218,9 @@ void overwrite (void)
     if (!new || !cmp)
         BAIL_OUT ("json_pack() failed");
 
-    update_recursive (&j, orig, new, NULL, NULL);
-    ok (json_equal (orig, cmp) > 0,
-        "update_recursive overwrites non-object with object");
+    rc = update_annotation_recursive (&j, orig, new);
+    ok (!rc && json_equal (orig, cmp) > 0,
+        "update_annotation_recursive overwrites non-object with object");
 
     json_decref (new);
     json_decref (cmp);
@@ -223,9 +230,9 @@ void overwrite (void)
     if (!new || !cmp)
         BAIL_OUT ("json_pack() failed");
 
-    update_recursive (&j, orig, new, NULL, NULL);
-    ok (json_equal (orig, cmp) > 0,
-        "update_recursive removes whole dict on json null setting");
+    rc = update_annotation_recursive (&j, orig, new);
+    ok (!rc && json_equal (orig, cmp) > 0,
+        "update_annotation_recursive removes whole dict on json null setting");
 
     json_decref (new);
     json_decref (cmp);

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -103,6 +103,7 @@ TESTSCRIPTS = \
 	t2202-job-manager.t \
 	t2203-job-manager-dummysched-single.t \
 	t2204-job-manager-dummysched-unlimited.t \
+	t2205-job-manager-annotate.t \
 	t2206-job-manager-bulk-state.t \
 	t2207-job-manager-wait.t \
 	t2208-queue-cmd.t \

--- a/t/job-manager/sched-helper.sh
+++ b/t/job-manager/sched-helper.sh
@@ -88,3 +88,58 @@ jmgr_check_no_annotations() {
         test -z "$(${JMGR_JOB_LIST} | grep ${id} | cut -f 6-)" && return 0
         return 1
 }
+
+# internal function to get job annotation key value via flux job list
+#
+# arg1 - jobid
+# arg2 - key
+_jinfo_get_annotation() {
+        local id=$1
+        local key=$2
+        local note="$(flux job list -A | grep ${id} | jq .annotations | jq ."${key}")"
+        echo $note
+}
+
+# verify if annotation published to job-info
+#
+# function will loop for up to 5 seconds in case annotation update
+# arrives slowly
+#
+# arg1 - jobid
+# arg2 - key in annotation
+# arg3 - value of key in annotation
+#
+# callers should set HAVE_JQ requirement
+jinfo_check_annotation() {
+        local id=$1
+        local key=$2
+        local value="$3"
+        for try in $(seq 1 10); do
+                test "$(_jinfo_get_annotation $id $key)" = "${value}" && return 0
+                sleep 0.5
+        done
+        return 1
+}
+
+# verify that job contains no annotations via job-info
+#
+# arg1 - jobid
+#
+# callers should set HAVE_JQ requirement
+jinfo_check_no_annotations() {
+        local id=$1
+        flux job list -A | grep ${id} | jq -e .annotations > /dev/null && return 1
+        return 0
+}
+
+# verify if job contains specific annotation key through job-info
+#
+# arg1 - jobid
+# arg2 - key in annotation
+#
+# callers should set HAVE_JQ requirement
+jinfo_check_annotation_exists() {
+        local id=$1
+        local key=$2
+        flux job list -A | grep ${id} | jq .annotations | jq -e ."${key}" > /dev/null
+}

--- a/t/t2203-job-manager-dummysched-single.t
+++ b/t/t2203-job-manager-dummysched-single.t
@@ -75,6 +75,14 @@ test_expect_success HAVE_JQ 'job-manager: annotate job id 3 in job-info (RRSSS)'
         jinfo_check_no_annotations $(cat job5.id)
 '
 
+test_expect_success 'job-manager: annotate job id 3 in flux-jobs (RRSSS)' '
+        fjobs_check_no_annotations $(cat job1.id) &&
+        fjobs_check_no_annotations $(cat job2.id) &&
+        fjobs_check_annotation $(cat job3.id) "annotations.sched.reason_pending" "no cores available" &&
+        fjobs_check_no_annotations $(cat job4.id) &&
+        fjobs_check_no_annotations $(cat job5.id)
+'
+
 test_expect_success 'job-manager: running job has alloc event' '
         flux job wait-event --timeout=5.0 $(cat job1.id) alloc
 '
@@ -99,12 +107,20 @@ test_expect_success HAVE_JQ 'job-manager: annotate job id 4 (RIRSS)' '
         jmgr_check_no_annotations $(cat job5.id)
 '
 
-test_expect_success HAVE_JQ 'job-manager: annotate job id 4 in job-info (RRSSS)' '
+test_expect_success HAVE_JQ 'job-manager: annotate job id 4 in job-info (RIRSS)' '
         jinfo_check_no_annotations $(cat job1.id) &&
         jinfo_check_no_annotations $(cat job2.id) &&
         jinfo_check_no_annotations $(cat job3.id) &&
         jinfo_check_annotation $(cat job4.id) "sched.reason_pending" "\"no cores available\"" &&
         jinfo_check_no_annotations $(cat job5.id)
+'
+
+test_expect_success 'job-manager: annotate job id 4 in flux jobs (RRSSS)' '
+        fjobs_check_no_annotations $(cat job1.id) &&
+        fjobs_check_no_annotations $(cat job2.id) &&
+        fjobs_check_no_annotations $(cat job3.id) &&
+        fjobs_check_annotation $(cat job4.id) "annotations.sched.reason_pending" "no cores available" &&
+        fjobs_check_no_annotations $(cat job5.id)
 '
 
 test_expect_success 'job-manager: first S job sent alloc, second S did not' '
@@ -160,6 +176,14 @@ test_expect_success HAVE_JQ 'job-manager: no annotations in job-info (RIRRR)' '
         jinfo_check_no_annotations $(cat job5.id)
 '
 
+test_expect_success 'job-manager: no annotations in flux jobs (RIRRR)' '
+        fjobs_check_no_annotations $(cat job1.id) &&
+        fjobs_check_no_annotations $(cat job2.id) &&
+        fjobs_check_no_annotations $(cat job3.id) &&
+        fjobs_check_no_annotations $(cat job4.id) &&
+        fjobs_check_no_annotations $(cat job5.id)
+'
+
 test_expect_success 'job-manager: cancel 1' '
         flux job cancel $(cat job1.id)
 '
@@ -200,6 +224,14 @@ test_expect_success HAVE_JQ 'job-manager: no annotations in job-info (IIIII)' '
         jinfo_check_no_annotations $(cat job3.id) &&
         jinfo_check_no_annotations $(cat job4.id) &&
         jinfo_check_no_annotations $(cat job5.id)
+'
+
+test_expect_success 'job-manager: no annotations in flux jobs (IIIII)' '
+        fjobs_check_no_annotations $(cat job1.id) &&
+        fjobs_check_no_annotations $(cat job2.id) &&
+        fjobs_check_no_annotations $(cat job3.id) &&
+        fjobs_check_no_annotations $(cat job4.id) &&
+        fjobs_check_no_annotations $(cat job5.id)
 '
 
 test_expect_success 'job-manager: simulate alloc failure' '

--- a/t/t2203-job-manager-dummysched-single.t
+++ b/t/t2203-job-manager-dummysched-single.t
@@ -67,6 +67,14 @@ test_expect_success HAVE_JQ 'job-manager: annotate job id 3 (RRSSS)' '
         jmgr_check_no_annotations $(cat job5.id)
 '
 
+test_expect_success HAVE_JQ 'job-manager: annotate job id 3 in job-info (RRSSS)' '
+        jinfo_check_no_annotations $(cat job1.id) &&
+        jinfo_check_no_annotations $(cat job2.id) &&
+        jinfo_check_annotation $(cat job3.id) "sched.reason_pending" "\"no cores available\"" &&
+        jinfo_check_no_annotations $(cat job4.id) &&
+        jinfo_check_no_annotations $(cat job5.id)
+'
+
 test_expect_success 'job-manager: running job has alloc event' '
         flux job wait-event --timeout=5.0 $(cat job1.id) alloc
 '
@@ -89,6 +97,14 @@ test_expect_success HAVE_JQ 'job-manager: annotate job id 4 (RIRSS)' '
         jmgr_check_no_annotations $(cat job3.id) &&
         jmgr_check_annotation $(cat job4.id) "sched.reason_pending" "\"no cores available\"" &&
         jmgr_check_no_annotations $(cat job5.id)
+'
+
+test_expect_success HAVE_JQ 'job-manager: annotate job id 4 in job-info (RRSSS)' '
+        jinfo_check_no_annotations $(cat job1.id) &&
+        jinfo_check_no_annotations $(cat job2.id) &&
+        jinfo_check_no_annotations $(cat job3.id) &&
+        jinfo_check_annotation $(cat job4.id) "sched.reason_pending" "\"no cores available\"" &&
+        jinfo_check_no_annotations $(cat job5.id)
 '
 
 test_expect_success 'job-manager: first S job sent alloc, second S did not' '
@@ -136,6 +152,14 @@ test_expect_success HAVE_JQ 'job-manager: no annotations (RIRRR)' '
         jmgr_check_no_annotations $(cat job5.id)
 '
 
+test_expect_success HAVE_JQ 'job-manager: no annotations in job-info (RIRRR)' '
+        jinfo_check_no_annotations $(cat job1.id) &&
+        jinfo_check_no_annotations $(cat job2.id) &&
+        jinfo_check_no_annotations $(cat job3.id) &&
+        jinfo_check_no_annotations $(cat job4.id) &&
+        jinfo_check_no_annotations $(cat job5.id)
+'
+
 test_expect_success 'job-manager: cancel 1' '
         flux job cancel $(cat job1.id)
 '
@@ -168,6 +192,14 @@ test_expect_success HAVE_JQ 'job-manager: no annotations (IIIII)' '
         jmgr_check_no_annotations $(cat job3.id) &&
         jmgr_check_no_annotations $(cat job4.id) &&
         jmgr_check_no_annotations $(cat job5.id)
+'
+
+test_expect_success HAVE_JQ 'job-manager: no annotations in job-info (IIIII)' '
+        jinfo_check_no_annotations $(cat job1.id) &&
+        jinfo_check_no_annotations $(cat job2.id) &&
+        jinfo_check_no_annotations $(cat job3.id) &&
+        jinfo_check_no_annotations $(cat job4.id) &&
+        jinfo_check_no_annotations $(cat job5.id)
 '
 
 test_expect_success 'job-manager: simulate alloc failure' '

--- a/t/t2204-job-manager-dummysched-unlimited.t
+++ b/t/t2204-job-manager-dummysched-unlimited.t
@@ -70,6 +70,17 @@ test_expect_success HAVE_JQ 'job-manager: annotate job id 3-5 (RRSSS)' '
         jmgr_check_annotation $(cat job5.id) "sched.jobs_ahead" "2"
 '
 
+test_expect_success HAVE_JQ 'job-manager: annotate job id 3-5 in job-info (RRSSS)' '
+        jinfo_check_annotation $(cat job1.id) "sched.resource_summary" "\"1core\"" &&
+        jinfo_check_annotation $(cat job2.id) "sched.resource_summary" "\"1core\"" &&
+        jinfo_check_annotation $(cat job3.id) "sched.reason_pending" "\"no cores\"" &&
+        jinfo_check_annotation $(cat job3.id) "sched.jobs_ahead" "0" &&
+        jinfo_check_annotation $(cat job4.id) "sched.reason_pending" "\"no cores\"" &&
+        jinfo_check_annotation $(cat job4.id) "sched.jobs_ahead" "1" &&
+        jinfo_check_annotation $(cat job5.id) "sched.reason_pending" "\"no cores\"" &&
+        jinfo_check_annotation $(cat job5.id) "sched.jobs_ahead" "2"
+'
+
 test_expect_success 'job-manager: cancel 2' '
         flux job cancel $(cat job2.id)
 '
@@ -92,6 +103,20 @@ test_expect_success HAVE_JQ 'job-manager: annotate job id 4-5 (RIRSS)' '
         jmgr_check_annotation $(cat job4.id) "sched.jobs_ahead" "0" &&
         jmgr_check_annotation $(cat job5.id) "sched.reason_pending" "\"no cores\"" &&
         jmgr_check_annotation $(cat job5.id) "sched.jobs_ahead" "1"
+'
+
+# compared to above, note that job id #2 retains annotations, it is
+# cached in job-info
+test_expect_success HAVE_JQ 'job-manager: annotate job id 4-5 in job-info (RIRSS)' '
+        jinfo_check_annotation $(cat job1.id) "sched.resource_summary" "\"1core\"" &&
+        jinfo_check_annotation $(cat job2.id) "sched.resource_summary" "\"1core\"" &&
+        jinfo_check_annotation $(cat job3.id) "sched.resource_summary" "\"1core\"" &&
+        test_must_fail jinfo_check_annotation_exists $(cat job3.id) "sched.reason_pending" &&
+        test_must_fail jinfo_check_annotation_exists $(cat job3.id) "sched.jobs_ahead" &&
+        jinfo_check_annotation $(cat job4.id) "sched.reason_pending" "\"no cores\"" &&
+        jinfo_check_annotation $(cat job4.id) "sched.jobs_ahead" "0" &&
+        jinfo_check_annotation $(cat job5.id) "sched.reason_pending" "\"no cores\"" &&
+        jinfo_check_annotation $(cat job5.id) "sched.jobs_ahead" "1"
 '
 
 test_expect_success 'job-manager: cancel 5' '
@@ -117,10 +142,24 @@ test_expect_success HAVE_JQ 'job-manager: annotate job id 4 (RIRSI)' '
         jmgr_check_no_annotations $(cat job5.id)
 '
 
+# compared to above, note that job id #2 retains annotations, it is
+# cached in job-info
+test_expect_success HAVE_JQ 'job-manager: annotate job id 4-5 in job-info (RIRSS)' '
+        jinfo_check_annotation $(cat job1.id) "sched.resource_summary" "\"1core\"" &&
+        jinfo_check_annotation $(cat job2.id) "sched.resource_summary" "\"1core\"" &&
+        jinfo_check_annotation $(cat job3.id) "sched.resource_summary" "\"1core\"" &&
+        test_must_fail jinfo_check_annotation_exists $(cat job3.id) "sched.reason_pending" &&
+        test_must_fail jinfo_check_annotation_exists $(cat job3.id) "sched.jobs_ahead" &&
+        jinfo_check_annotation $(cat job4.id) "sched.reason_pending" "\"no cores\"" &&
+        jinfo_check_annotation $(cat job4.id) "sched.jobs_ahead" "0" &&
+        jinfo_check_no_annotations $(cat job5.id)
+'
+
+# cancel non-running jobs first, to ensure they are not accidentally run when
+# running jobs free resources.
 test_expect_success 'job-manager: cancel all jobs' '
-        flux job cancel $(cat job1.id) &&
-        flux job cancel $(cat job3.id) &&
-        flux job cancel $(cat job4.id)
+        flux job cancelall --states=SCHED -f &&
+        flux job cancelall -f
 '
 
 test_expect_success 'job-manager: job state IIIII' '
@@ -137,6 +176,15 @@ test_expect_success HAVE_JQ 'job-manager: no annotations (IIIII)' '
         jmgr_check_no_annotations $(cat job3.id) &&
         jmgr_check_no_annotations $(cat job4.id) &&
         jmgr_check_no_annotations $(cat job5.id)
+'
+
+# compared to above, note that job ids that ran retain annotations
+test_expect_success HAVE_JQ 'job-manager: no annotations in canceled jobs in job-info (IIIII)' '
+        jinfo_check_annotation $(cat job1.id) "sched.resource_summary" "\"1core\"" &&
+        jinfo_check_annotation $(cat job2.id) "sched.resource_summary" "\"1core\"" &&
+        jinfo_check_annotation $(cat job3.id) "sched.resource_summary" "\"1core\"" &&
+        jinfo_check_no_annotations $(cat job4.id) &&
+        jinfo_check_no_annotations $(cat job5.id)
 '
 
 test_expect_success 'job-manager: remove sched-dummy' '

--- a/t/t2204-job-manager-dummysched-unlimited.t
+++ b/t/t2204-job-manager-dummysched-unlimited.t
@@ -81,6 +81,17 @@ test_expect_success HAVE_JQ 'job-manager: annotate job id 3-5 in job-info (RRSSS
         jinfo_check_annotation $(cat job5.id) "sched.jobs_ahead" "2"
 '
 
+test_expect_success HAVE_JQ 'job-manager: annotate job id 3-5 in flux-jobs (RRSSS)' '
+        fjobs_check_annotation $(cat job1.id) "annotations.sched.resource_summary" "1core" &&
+        fjobs_check_annotation $(cat job2.id) "annotations.sched.resource_summary" "1core" &&
+        fjobs_check_annotation $(cat job3.id) "annotations.sched.reason_pending" "no cores" &&
+        fjobs_check_annotation $(cat job3.id) "annotations.sched.jobs_ahead" "0" &&
+        fjobs_check_annotation $(cat job4.id) "annotations.sched.reason_pending" "no cores" &&
+        fjobs_check_annotation $(cat job4.id) "annotations.sched.jobs_ahead" "1" &&
+        fjobs_check_annotation $(cat job5.id) "annotations.sched.reason_pending" "no cores" &&
+        fjobs_check_annotation $(cat job5.id) "annotations.sched.jobs_ahead" "2"
+'
+
 test_expect_success 'job-manager: cancel 2' '
         flux job cancel $(cat job2.id)
 '
@@ -119,6 +130,20 @@ test_expect_success HAVE_JQ 'job-manager: annotate job id 4-5 in job-info (RIRSS
         jinfo_check_annotation $(cat job5.id) "sched.jobs_ahead" "1"
 '
 
+# compared to above, note that job id #2 retains annotations, it is
+# cached in job-info
+test_expect_success HAVE_JQ 'job-manager: annotate job id 4-5 in flux-jobs (RIRSS)' '
+        fjobs_check_annotation $(cat job1.id) "annotations.sched.resource_summary" "1core" &&
+        fjobs_check_annotation $(cat job2.id) "annotations.sched.resource_summary" "1core" &&
+        fjobs_check_annotation $(cat job3.id) "annotations.sched.resource_summary" "1core" &&
+        test_must_fail fjobs_check_annotation_exists $(cat job3.id) "annotations.sched.reason_pending" &&
+        test_must_fail fjobs_check_annotation_exists $(cat job3.id) "annotations.sched.jobs_ahead" &&
+        fjobs_check_annotation $(cat job4.id) "annotations.sched.reason_pending" "no cores" &&
+        fjobs_check_annotation $(cat job4.id) "annotations.sched.jobs_ahead" "0" &&
+        fjobs_check_annotation $(cat job5.id) "annotations.sched.reason_pending" "no cores" &&
+        fjobs_check_annotation $(cat job5.id) "annotations.sched.jobs_ahead" "1"
+'
+
 test_expect_success 'job-manager: cancel 5' '
         flux job cancel $(cat job5.id)
 '
@@ -155,6 +180,19 @@ test_expect_success HAVE_JQ 'job-manager: annotate job id 4-5 in job-info (RIRSS
         jinfo_check_no_annotations $(cat job5.id)
 '
 
+# compared to above, note that job id #2 retains annotations, it is
+# cached in job-info
+test_expect_success HAVE_JQ 'job-manager: annotate job id 4-5 in flux jobs (RIRSS)' '
+        fjobs_check_annotation $(cat job1.id) "annotations.sched.resource_summary" "1core" &&
+        fjobs_check_annotation $(cat job2.id) "annotations.sched.resource_summary" "1core" &&
+        fjobs_check_annotation $(cat job3.id) "annotations.sched.resource_summary" "1core" &&
+        test_must_fail fjobs_check_annotation_exists $(cat job3.id) "annotations.sched.reason_pending" &&
+        test_must_fail fjobs_check_annotation_exists $(cat job3.id) "annotations.sched.jobs_ahead" &&
+        fjobs_check_annotation $(cat job4.id) "annotations.sched.reason_pending" "no cores" &&
+        fjobs_check_annotation $(cat job4.id) "annotations.sched.jobs_ahead" "0" &&
+        fjobs_check_no_annotations $(cat job5.id)
+'
+
 # cancel non-running jobs first, to ensure they are not accidentally run when
 # running jobs free resources.
 test_expect_success 'job-manager: cancel all jobs' '
@@ -185,6 +223,15 @@ test_expect_success HAVE_JQ 'job-manager: no annotations in canceled jobs in job
         jinfo_check_annotation $(cat job3.id) "sched.resource_summary" "\"1core\"" &&
         jinfo_check_no_annotations $(cat job4.id) &&
         jinfo_check_no_annotations $(cat job5.id)
+'
+
+# compared to above, note that job ids that ran retain annotations
+test_expect_success HAVE_JQ 'job-manager: no annotations in canceled jobs in flux jobs (IIIII)' '
+        fjobs_check_annotation $(cat job1.id) "annotations.sched.resource_summary" "1core" &&
+        fjobs_check_annotation $(cat job2.id) "annotations.sched.resource_summary" "1core" &&
+        fjobs_check_annotation $(cat job3.id) "annotations.sched.resource_summary" "1core" &&
+        fjobs_check_no_annotations $(cat job4.id) &&
+        fjobs_check_no_annotations $(cat job5.id)
 '
 
 test_expect_success 'job-manager: remove sched-dummy' '

--- a/t/t2205-job-manager-annotate.t
+++ b/t/t2205-job-manager-annotate.t
@@ -1,0 +1,264 @@
+#!/bin/sh
+
+test_description='Test flux job manager annoate service with dummy scheduler'
+
+. `dirname $0`/job-manager/sched-helper.sh
+
+. $(dirname $0)/sharness.sh
+
+test_under_flux 4 kvs
+
+SCHED_DUMMY=${FLUX_BUILD_DIR}/t/job-manager/.libs/sched-dummy.so
+
+flux setattr log-stderr-level 1
+
+test_expect_success 'flux-job: generate jobspec for simple test job' '
+        flux jobspec srun -n1 hostname >basic.json
+'
+
+test_expect_success 'job-manager: load job-ingest, job-manager' '
+        flux module load job-manager &&
+        flux module load job-ingest &&
+        flux exec -r all -x 0 flux module load job-ingest &&
+        flux exec -r all flux module load job-info
+'
+
+test_expect_success 'job-manager: submit 5 jobs' '
+        flux job submit --flags=debug basic.json >job1.id &&
+        flux job submit --flags=debug basic.json >job2.id &&
+        flux job submit --flags=debug basic.json >job3.id &&
+        flux job submit --flags=debug basic.json >job4.id &&
+        flux job submit --flags=debug basic.json >job5.id
+'
+
+test_expect_success 'job-manager: job state SSSSS (no scheduler)' '
+        jmgr_check_state $(cat job1.id) S &&
+        jmgr_check_state $(cat job2.id) S &&
+        jmgr_check_state $(cat job3.id) S &&
+        jmgr_check_state $(cat job4.id) S &&
+        jmgr_check_state $(cat job5.id) S
+'
+
+test_expect_success HAVE_JQ 'job-manager: no annotations (SSSS)' '
+        jmgr_check_no_annotations $(cat job1.id) &&
+        jmgr_check_no_annotations $(cat job2.id) &&
+        jmgr_check_no_annotations $(cat job3.id) &&
+        jmgr_check_no_annotations $(cat job4.id) &&
+        jmgr_check_no_annotations $(cat job5.id)
+'
+
+test_expect_success HAVE_JQ 'job-manager: annotate job id 3-5 in job-info (RRSSS)' '
+        jinfo_check_no_annotations $(cat job1.id) &&
+        jinfo_check_no_annotations $(cat job2.id) &&
+        jinfo_check_no_annotations $(cat job3.id) &&
+        jinfo_check_no_annotations $(cat job4.id) &&
+        jinfo_check_no_annotations $(cat job5.id)
+'
+
+test_expect_success HAVE_JQ 'job-manager: user annotate invalid id' '
+        test_must_fail flux job annotate 123456789 mykey foo
+'
+
+test_expect_success HAVE_JQ 'job-manager: user annotate job id 1' '
+        flux job annotate $(cat job1.id) mykey foo
+'
+
+test_expect_success HAVE_JQ 'job-manager: user annotate job id 2' '
+        flux job annotate $(cat job2.id) mykey bar
+'
+
+test_expect_success HAVE_JQ 'job-manager: user annotate job id 3' '
+        flux job annotate $(cat job3.id) mykey "{\"baz\": 42}"
+'
+
+test_expect_success HAVE_JQ 'job-manager: user annotate job id 4' '
+        echo -n doh | flux job annotate $(cat job4.id) mykey -
+'
+
+test_expect_success HAVE_JQ 'job-manager: annotations in job id 1 & 2 (SSSSS)' '
+        jmgr_check_annotation $(cat job1.id) "user.mykey" "\"foo\"" &&
+        jmgr_check_annotation $(cat job2.id) "user.mykey" "\"bar\"" &&
+        jmgr_check_annotation $(cat job3.id) "user.mykey.baz" "42" &&
+        jmgr_check_annotation $(cat job4.id) "user.mykey" "\"doh\"" &&
+        jmgr_check_no_annotations $(cat job5.id)
+'
+
+test_expect_success HAVE_JQ 'job-manager: annotate job id 1 & 2 in job-info (SSSSS)' '
+        jinfo_check_annotation $(cat job1.id) "user.mykey" "\"foo\"" &&
+        jinfo_check_annotation $(cat job2.id) "user.mykey" "\"bar\"" &&
+        jinfo_check_annotation $(cat job3.id) "user.mykey.baz" "42" &&
+        jinfo_check_annotation $(cat job4.id) "user.mykey" "\"doh\"" &&
+        jinfo_check_no_annotations $(cat job5.id)
+'
+
+test_expect_success 'job-manager: load sched-dummy --cores=2' '
+        flux module load ${SCHED_DUMMY} --cores=2 --mode=unlimited
+'
+
+test_expect_success 'job-manager: job state RRSSS' '
+        jmgr_check_state $(cat job1.id) R &&
+        jmgr_check_state $(cat job2.id) R &&
+        jmgr_check_state $(cat job3.id) S &&
+        jmgr_check_state $(cat job4.id) S &&
+        jmgr_check_state $(cat job5.id) S
+'
+
+test_expect_success HAVE_JQ 'job-manager: annotate job id 1-4 (RRSSS)' '
+        jmgr_check_annotation $(cat job1.id) "user.mykey" "\"foo\"" &&
+        jmgr_check_annotation $(cat job1.id) "sched.resource_summary" "\"1core\"" &&
+        jmgr_check_annotation $(cat job2.id) "user.mykey" "\"bar\"" &&
+        jmgr_check_annotation $(cat job2.id) "sched.resource_summary" "\"1core\"" &&
+        jmgr_check_annotation $(cat job3.id) "user.mykey.baz" "42" &&
+        jmgr_check_annotation $(cat job3.id) "sched.reason_pending" "\"no cores\"" &&
+        jmgr_check_annotation $(cat job3.id) "sched.jobs_ahead" "0" &&
+        jmgr_check_annotation $(cat job4.id) "user.mykey" "\"doh\"" &&
+        jmgr_check_annotation $(cat job4.id) "sched.reason_pending" "\"no cores\"" &&
+        jmgr_check_annotation $(cat job4.id) "sched.jobs_ahead" "1" &&
+        jmgr_check_annotation $(cat job5.id) "sched.reason_pending" "\"no cores\"" &&
+        jmgr_check_annotation $(cat job5.id) "sched.jobs_ahead" "2"
+'
+
+test_expect_success HAVE_JQ 'job-manager: annotate job id 1-4 in job-info (RRSSS)' '
+        jinfo_check_annotation $(cat job1.id) "user.mykey" "\"foo\"" &&
+        jinfo_check_annotation $(cat job1.id) "sched.resource_summary" "\"1core\"" &&
+        jinfo_check_annotation $(cat job2.id) "user.mykey" "\"bar\"" &&
+        jinfo_check_annotation $(cat job2.id) "sched.resource_summary" "\"1core\"" &&
+        jinfo_check_annotation $(cat job3.id) "user.mykey.baz" "42" &&
+        jinfo_check_annotation $(cat job3.id) "sched.reason_pending" "\"no cores\"" &&
+        jinfo_check_annotation $(cat job3.id) "sched.jobs_ahead" "0" &&
+        jinfo_check_annotation $(cat job4.id) "user.mykey" "\"doh\"" &&
+        jinfo_check_annotation $(cat job4.id) "sched.reason_pending" "\"no cores\"" &&
+        jinfo_check_annotation $(cat job4.id) "sched.jobs_ahead" "1" &&
+        jinfo_check_annotation $(cat job5.id) "sched.reason_pending" "\"no cores\"" &&
+        jinfo_check_annotation $(cat job5.id) "sched.jobs_ahead" "2"
+'
+
+test_expect_success HAVE_JQ 'job-manager: user annotate job id 1 again' '
+        flux job annotate $(cat job1.id) mykey bozo
+'
+
+test_expect_success HAVE_JQ 'job-manager: user clear annotatation job id 2' '
+        flux job annotate $(cat job2.id) mykey null
+'
+
+test_expect_success HAVE_JQ 'job-manager: annotate job id 1-4 (RRSSS)' '
+        jmgr_check_annotation $(cat job1.id) "user.mykey" "\"bozo\"" &&
+        jmgr_check_annotation $(cat job1.id) "sched.resource_summary" "\"1core\"" &&
+        test_must_fail jmgr_check_annotation_exists $(cat job2.id) "user.mykey" &&
+        jmgr_check_annotation $(cat job2.id) "sched.resource_summary" "\"1core\"" &&
+        jmgr_check_annotation $(cat job3.id) "user.mykey.baz" "42" &&
+        jmgr_check_annotation $(cat job3.id) "sched.reason_pending" "\"no cores\"" &&
+        jmgr_check_annotation $(cat job3.id) "sched.jobs_ahead" "0" &&
+        jmgr_check_annotation $(cat job4.id) "user.mykey" "\"doh\"" &&
+        jmgr_check_annotation $(cat job4.id) "sched.reason_pending" "\"no cores\"" &&
+        jmgr_check_annotation $(cat job4.id) "sched.jobs_ahead" "1" &&
+        jmgr_check_annotation $(cat job5.id) "sched.reason_pending" "\"no cores\"" &&
+        jmgr_check_annotation $(cat job5.id) "sched.jobs_ahead" "2"
+'
+
+test_expect_success HAVE_JQ 'job-manager: annotate job id 1-4 in job-info (RRSSS)' '
+        jinfo_check_annotation $(cat job1.id) "user.mykey" "\"bozo\"" &&
+        jinfo_check_annotation $(cat job1.id) "sched.resource_summary" "\"1core\"" &&
+        test_must_fail jinfo_check_annotation_exists $(cat job2.id) "user.mykey" &&
+        jinfo_check_annotation $(cat job2.id) "sched.resource_summary" "\"1core\"" &&
+        jinfo_check_annotation $(cat job3.id) "user.mykey.baz" "42" &&
+        jinfo_check_annotation $(cat job3.id) "sched.reason_pending" "\"no cores\"" &&
+        jinfo_check_annotation $(cat job3.id) "sched.jobs_ahead" "0" &&
+        jinfo_check_annotation $(cat job4.id) "user.mykey" "\"doh\"" &&
+        jinfo_check_annotation $(cat job4.id) "sched.reason_pending" "\"no cores\"" &&
+        jinfo_check_annotation $(cat job4.id) "sched.jobs_ahead" "1" &&
+        jinfo_check_annotation $(cat job5.id) "sched.reason_pending" "\"no cores\"" &&
+        jinfo_check_annotation $(cat job5.id) "sched.jobs_ahead" "2"
+'
+
+test_expect_success 'job-manager: cancel 2' '
+        flux job cancel $(cat job2.id)
+'
+
+test_expect_success 'job-manager: job state RIRSS' '
+        jmgr_check_state $(cat job1.id) R &&
+        jmgr_check_state $(cat job2.id) I &&
+        jmgr_check_state $(cat job3.id) R &&
+        jmgr_check_state $(cat job4.id) S &&
+        jmgr_check_state $(cat job5.id) S
+'
+
+test_expect_success HAVE_JQ 'job-manager: annotate job id 1-4 (RIRSS)' '
+        jmgr_check_annotation $(cat job1.id) "user.mykey" "\"bozo\"" &&
+        jmgr_check_annotation $(cat job1.id) "sched.resource_summary" "\"1core\"" &&
+        jmgr_check_no_annotations $(cat job2.id) &&
+        jmgr_check_annotation $(cat job3.id) "user.mykey.baz" "42" &&
+        jmgr_check_annotation $(cat job3.id) "sched.resource_summary" "\"1core\"" &&
+        test_must_fail jmgr_check_annotation_exists $(cat job3.id) "sched.reason_pending" &&
+        test_must_fail jmgr_check_annotation_exists $(cat job3.id) "sched.jobs_ahead" &&
+        jmgr_check_annotation $(cat job4.id) "user.mykey" "\"doh\"" &&
+        jmgr_check_annotation $(cat job4.id) "sched.reason_pending" "\"no cores\"" &&
+        jmgr_check_annotation $(cat job4.id) "sched.jobs_ahead" "0" &&
+        jmgr_check_annotation $(cat job5.id) "sched.reason_pending" "\"no cores\"" &&
+        jmgr_check_annotation $(cat job5.id) "sched.jobs_ahead" "1"
+'
+
+# compared to above, note that job id #2 retains annotations, it is
+# cached in job-info
+test_expect_success HAVE_JQ 'job-manager: annotate job id 4-5 in job-info (RIRSS)' '
+        jinfo_check_annotation $(cat job1.id) "user.mykey" "\"bozo\"" &&
+        jinfo_check_annotation $(cat job1.id) "sched.resource_summary" "\"1core\"" &&
+        test_must_fail jinfo_check_annotation_exists $(cat job2.id) "user.mykey" &&
+        jinfo_check_annotation $(cat job2.id) "sched.resource_summary" "\"1core\"" &&
+        jinfo_check_annotation $(cat job3.id) "user.mykey.baz" "42" &&
+        jinfo_check_annotation $(cat job3.id) "sched.resource_summary" "\"1core\"" &&
+        test_must_fail jinfo_check_annotation_exists $(cat job3.id) "sched.reason_pending" &&
+        test_must_fail jinfo_check_annotation_exists $(cat job3.id) "sched.jobs_ahead" &&
+        jinfo_check_annotation $(cat job4.id) "user.mykey" "\"doh\"" &&
+        jinfo_check_annotation $(cat job4.id) "sched.reason_pending" "\"no cores\"" &&
+        jinfo_check_annotation $(cat job4.id) "sched.jobs_ahead" "0" &&
+        jinfo_check_annotation $(cat job5.id) "sched.reason_pending" "\"no cores\"" &&
+        jinfo_check_annotation $(cat job5.id) "sched.jobs_ahead" "1"
+'
+
+# cancel non-running jobs first, to ensure they are not accidentally run when
+# running jobs free resources.
+test_expect_success 'job-manager: cancel all jobs' '
+        flux job cancelall --states=SCHED -f &&
+        flux job cancelall -f
+'
+
+test_expect_success 'job-manager: job state IIIII' '
+        jmgr_check_state $(cat job1.id) I &&
+        jmgr_check_state $(cat job2.id) I &&
+        jmgr_check_state $(cat job3.id) I &&
+        jmgr_check_state $(cat job4.id) I &&
+        jmgr_check_state $(cat job5.id) I
+'
+
+test_expect_success HAVE_JQ 'job-manager: no annotations (IIIII)' '
+        jmgr_check_no_annotations $(cat job1.id) &&
+        jmgr_check_no_annotations $(cat job2.id) &&
+        jmgr_check_no_annotations $(cat job3.id) &&
+        jmgr_check_no_annotations $(cat job4.id) &&
+        jmgr_check_no_annotations $(cat job5.id)
+'
+
+# compared to above, note that job ids that ran retain annotations
+test_expect_success HAVE_JQ 'job-manager: no annotations in job-info (IIIII)' '
+        jinfo_check_annotation $(cat job1.id) "user.mykey" "\"bozo\"" &&
+        jinfo_check_annotation $(cat job1.id) "sched.resource_summary" "\"1core\"" &&
+        test_must_fail jinfo_check_annotation_exists $(cat job2.id) "user.mykey" &&
+        jinfo_check_annotation $(cat job2.id) "sched.resource_summary" "\"1core\"" &&
+        jinfo_check_annotation $(cat job3.id) "user.mykey.baz" "42" &&
+        jinfo_check_annotation $(cat job3.id) "sched.resource_summary" "\"1core\"" &&
+        jinfo_check_no_annotations $(cat job4.id) &&
+        jinfo_check_no_annotations $(cat job5.id)
+'
+
+test_expect_success 'job-manager: remove sched-dummy' '
+        flux module remove sched-dummy
+'
+
+test_expect_success 'job-manager: remove job-manager, job-ingest' '
+        flux module remove job-manager &&
+        flux exec -r all flux module remove job-info &&
+        flux exec -r all flux module remove job-ingest
+'
+
+test_done

--- a/t/t2205-job-manager-annotate.t
+++ b/t/t2205-job-manager-annotate.t
@@ -133,6 +133,21 @@ test_expect_success HAVE_JQ 'job-manager: annotate job id 1-4 in job-info (RRSSS
         jinfo_check_annotation $(cat job5.id) "sched.jobs_ahead" "2"
 '
 
+test_expect_success HAVE_JQ 'job-manager: annotate job id 1-4 in flux-jobs (RRSSS)' '
+        fjobs_check_annotation $(cat job1.id) "annotations.user.mykey" "foo" &&
+        fjobs_check_annotation $(cat job1.id) "annotations.sched.resource_summary" "1core" &&
+        fjobs_check_annotation $(cat job2.id) "annotations.user.mykey" "bar" &&
+        fjobs_check_annotation $(cat job2.id) "annotations.sched.resource_summary" "1core" &&
+        fjobs_check_annotation $(cat job3.id) "annotations.user.mykey.baz" "42" &&
+        fjobs_check_annotation $(cat job3.id) "annotations.sched.reason_pending" "no cores" &&
+        fjobs_check_annotation $(cat job3.id) "annotations.sched.jobs_ahead" "0" &&
+        fjobs_check_annotation $(cat job4.id) "annotations.user.mykey" "doh" &&
+        fjobs_check_annotation $(cat job4.id) "annotations.sched.reason_pending" "no cores" &&
+        fjobs_check_annotation $(cat job4.id) "annotations.sched.jobs_ahead" "1" &&
+        fjobs_check_annotation $(cat job5.id) "annotations.sched.reason_pending" "no cores" &&
+        fjobs_check_annotation $(cat job5.id) "annotations.sched.jobs_ahead" "2"
+'
+
 test_expect_success HAVE_JQ 'job-manager: user annotate job id 1 again' '
         flux job annotate $(cat job1.id) mykey bozo
 '
@@ -169,6 +184,21 @@ test_expect_success HAVE_JQ 'job-manager: annotate job id 1-4 in job-info (RRSSS
         jinfo_check_annotation $(cat job4.id) "sched.jobs_ahead" "1" &&
         jinfo_check_annotation $(cat job5.id) "sched.reason_pending" "\"no cores\"" &&
         jinfo_check_annotation $(cat job5.id) "sched.jobs_ahead" "2"
+'
+
+test_expect_success HAVE_JQ 'job-manager: annotate job id 1-4 in flux-jobs (RRSSS)' '
+        fjobs_check_annotation $(cat job1.id) "annotations.user.mykey" "bozo" &&
+        fjobs_check_annotation $(cat job1.id) "annotations.sched.resource_summary" "1core" &&
+        test_must_fail fjobs_check_annotation_exists $(cat job2.id) "annotations.user.mykey" &&
+        fjobs_check_annotation $(cat job2.id) "annotations.sched.resource_summary" "1core" &&
+        fjobs_check_annotation $(cat job3.id) "annotations.user.mykey.baz" "42" &&
+        fjobs_check_annotation $(cat job3.id) "annotations.sched.reason_pending" "no cores" &&
+        fjobs_check_annotation $(cat job3.id) "annotations.sched.jobs_ahead" "0" &&
+        fjobs_check_annotation $(cat job4.id) "annotations.user.mykey" "doh" &&
+        fjobs_check_annotation $(cat job4.id) "annotations.sched.reason_pending" "no cores" &&
+        fjobs_check_annotation $(cat job4.id) "annotations.sched.jobs_ahead" "1" &&
+        fjobs_check_annotation $(cat job5.id) "annotations.sched.reason_pending" "no cores" &&
+        fjobs_check_annotation $(cat job5.id) "annotations.sched.jobs_ahead" "2"
 '
 
 test_expect_success 'job-manager: cancel 2' '
@@ -216,6 +246,24 @@ test_expect_success HAVE_JQ 'job-manager: annotate job id 4-5 in job-info (RIRSS
         jinfo_check_annotation $(cat job5.id) "sched.jobs_ahead" "1"
 '
 
+# compared to above, note that job id #2 retains annotations, it is
+# cached in job-info
+test_expect_success HAVE_JQ 'job-manager: annotate job id 4-5 in flux-jobs (RIRSS)' '
+        fjobs_check_annotation $(cat job1.id) "annotations.user.mykey" "bozo" &&
+        fjobs_check_annotation $(cat job1.id) "annotations.sched.resource_summary" "1core" &&
+        test_must_fail fjobs_check_annotation_exists $(cat job2.id) "annotations.user.mykey" &&
+        fjobs_check_annotation $(cat job2.id) "annotations.sched.resource_summary" "1core" &&
+        fjobs_check_annotation $(cat job3.id) "annotations.user.mykey.baz" "42" &&
+        fjobs_check_annotation $(cat job3.id) "annotations.sched.resource_summary" "1core" &&
+        test_must_fail fjobs_check_annotation_exists $(cat job3.id) "annotations.sched.reason_pending" &&
+        test_must_fail fjobs_check_annotation_exists $(cat job3.id) "annotations.sched.jobs_ahead" &&
+        fjobs_check_annotation $(cat job4.id) "annotations.user.mykey" "doh" &&
+        fjobs_check_annotation $(cat job4.id) "annotations.sched.reason_pending" "no cores" &&
+        fjobs_check_annotation $(cat job4.id) "annotations.sched.jobs_ahead" "0" &&
+        fjobs_check_annotation $(cat job5.id) "annotations.sched.reason_pending" "no cores" &&
+        fjobs_check_annotation $(cat job5.id) "annotations.sched.jobs_ahead" "1"
+'
+
 # cancel non-running jobs first, to ensure they are not accidentally run when
 # running jobs free resources.
 test_expect_success 'job-manager: cancel all jobs' '
@@ -249,6 +297,19 @@ test_expect_success HAVE_JQ 'job-manager: no annotations in job-info (IIIII)' '
         jinfo_check_annotation $(cat job3.id) "sched.resource_summary" "\"1core\"" &&
         jinfo_check_no_annotations $(cat job4.id) &&
         jinfo_check_no_annotations $(cat job5.id)
+'
+
+# compared to above, note that job ids that ran retain annotations
+# note that user annotation on job4 is removed, as job was cancelled
+test_expect_success HAVE_JQ 'job-manager: no annotations in job-info (IIIII)' '
+        fjobs_check_annotation $(cat job1.id) "annotations.user.mykey" "bozo" &&
+        fjobs_check_annotation $(cat job1.id) "annotations.sched.resource_summary" "1core" &&
+        test_must_fail fjobs_check_annotation_exists $(cat job2.id) "annotations.user.mykey" &&
+        fjobs_check_annotation $(cat job2.id) "annotations.sched.resource_summary" "1core" &&
+        fjobs_check_annotation $(cat job3.id) "annotations.user.mykey.baz" "42" &&
+        fjobs_check_annotation $(cat job3.id) "annotations.sched.resource_summary" "1core" &&
+        fjobs_check_no_annotations $(cat job4.id) &&
+        fjobs_check_no_annotations $(cat job5.id)
 '
 
 test_expect_success 'job-manager: remove sched-dummy' '

--- a/t/t2230-job-info-list.t
+++ b/t/t2230-job-info-list.t
@@ -842,7 +842,8 @@ exception_type \
 exception_severity \
 exception_note \
 result \
-expiration
+expiration \
+annotations
 "
 
 test_expect_success HAVE_JQ 'list request with empty attrs works' '

--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -648,6 +648,25 @@ test_expect_success 'flux-jobs --format={expiration!D:h},{t_remaining!H:h} works
 #
 # as the schedulers in those tests do varied but testable annotations
 
+test_expect_success 'flux-jobs annotation "sched" short hands work' '
+	fmt="{annotations.sched},{annotations.sched.resource_summary}" &&
+	flux jobs -no "${fmt}" > sched_long_hand.out &&
+	fmt="{sched},{sched.resource_summary}" &&
+	flux jobs -no "${fmt}" > sched_short_hand.out &&
+	test_cmp sched_long_hand.out sched_short_hand.out
+'
+
+test_expect_success 'flux-jobs annotation "user" short hands work' '
+	for id in $(state_ids sched); do
+		flux job annotate $id foo 42
+	done &&
+	fmt="{annotations.user},{annotations.user.foo}" &&
+	flux jobs -no "${fmt}" > user_long_hand.out &&
+	fmt="{user},{user.foo}" &&
+	flux jobs -no "${fmt}" > user_short_hand.out &&
+	test_cmp user_long_hand.out user_short_hand.out
+'
+
 test_expect_success 'flux-jobs emits empty string on invalid annotations fields' '
 	fmt="{annotations.foo},{annotations.foo:h}" &&
 	fmt="${fmt},{annotations.sched.bar},{annotations.sched.bar:h}" &&
@@ -714,6 +733,13 @@ test_expect_success 'flux-jobs: header included with all custom formats' '
 	annotations.sched.reason_pending==REASON
 	annotations.sched.resource_summary==RESOURCES
 	annotations.sched.foobar==SCHED.FOOBAR
+	sched==SCHED
+	sched.t_estimate==T_ESTIMATE
+	sched.reason_pending==REASON
+	sched.resource_summary==RESOURCES
+	sched.foobar==SCHED.FOOBAR
+	user==USER
+	user.foobar==USER.FOOBAR
 	EOF
 	sed "s/\(.*\)==.*/\1=={\1}/" headers.expected > headers.fmt &&
 	flux jobs --from-stdin --format="$(cat headers.fmt)" \

--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -710,7 +710,9 @@ test_expect_success 'flux-jobs: header included with all custom formats' '
 	status_abbrev==ST
 	annotations==ANNOTATIONS
 	annotations.sched==SCHED
-	annotations.sched.reason_pending==SCHED.REASON_PENDING
+	annotations.sched.t_estimate==T_ESTIMATE
+	annotations.sched.reason_pending==REASON
+	annotations.sched.resource_summary==RESOURCES
 	annotations.sched.foobar==SCHED.FOOBAR
 	EOF
 	sed "s/\(.*\)==.*/\1=={\1}/" headers.expected > headers.fmt &&


### PR DESCRIPTION
Built on top of PR #3062, this PR completes phase 1 job annotation support in `flux-core`.

- job-manager - support a new annotations event, which will publish annotations

- job-info - read in annotations events from the above for querying by job-list services

- job-manager - support a new user annotation service, allowing users to annotate their jobs
  - add command support in `flux job annotate`
  - is the user interface ok?  I supported a simple `flux job annotate id key value` syntax, and `value` can be `-` for stdin.
  - by default, everything is put under the `user` object in the annotations.

- flux-jobs - support listing any annotations
  - the annotation fields listed by the user can be arbitrary.  `flux-jobs` has a rule that any annotation that doesn't exist results in an empty string.  So this is even if the user inputs bogus annotations.  The reason we have to do this is b/c there is no way to know what annotations  are legal or illegal, given any scheduler or user can come up with any annotations they want. 
  - do we want to support a few special case annotations such as `sched` and/or `user`?  So the user doesn't have to type "annotations." for each of them?
  - the output headers ok?  I chose to upper case everything after "annotations." as the header.

An example output for:

```
jobid=`flux mini submit sleep 1000`                                                                                                         
sleep 5                                                                                                                                     
flux job annotate $jobid foo 1234                                                                                                           
flux jobs -n --format="{id} --- {annotations}"                                                                                              
flux jobs -n --format="{id} --- {annotations.sched}"                                                                                        
flux jobs -n --format="{id} --- {annotations.user}"                                                                                         
flux jobs -n --format="{id} --- {annotations.sched.resource_summary}"                                                                       
flux jobs -n --format="{id} --- {annotations.sched.foobar}"                                                                                 
flux jobs -n --format="{id} --- {annotations.user.foo}"                                                                                     
flux jobs -n --format="{id} --- {annotations.user.a.illegal.key}"  
```

```
>src/cmd/flux start ./submit_annotate.sh
15804137472 --- {"sched": {"resource_summary": "rank0/core0"}, "user": {"foo": 1234}}
15804137472 --- {"resource_summary": "rank0/core0"}
15804137472 --- {"foo": 1234}
15804137472 --- rank0/core0
15804137472 --- 
15804137472 --- 1234
15804137472 --- 
```

example w/ output headers (sorta ugly for this example)

```
JOBID --- ANNOTATIONS
15854469120 --- {"sched": {"resource_summary": "rank0/core0"}, "user": {"foo": 1234}}
JOBID --- SCHED
15854469120 --- {"resource_summary": "rank0/core0"}
JOBID --- USER
15854469120 --- {"foo": 1234}
JOBID --- SCHED.RESOURCE_SUMMARY
15854469120 --- rank0/core0
JOBID --- SCHED.FOOBAR
15854469120 --- 
JOBID --- USER.FOO
15854469120 --- 1234
JOBID --- USER.A.ILLEGAL.KEY
15854469120 --- 
```