### PR TITLE
content-s3: add toml config hook

### DIFF
--- a/src/modules/content-s3/s3.c
+++ b/src/modules/content-s3/s3.c
@@ -81,6 +81,11 @@ int s3_init (struct s3_config *cfg, const char **errstr)
 {
     S3Status status = S3_initialize ("s3", S3_INIT_ALL, cfg->hostname);
 
+    if (cfg->is_virtual_host)
+        uri_style = S3UriStyleVirtualHost;
+    if (cfg->is_secure)
+        protocol = S3ProtocolHTTPS;
+
     if (status != S3StatusOK) {
         errno = ECONNREFUSED;
         if (errstr)
@@ -88,7 +93,7 @@ int s3_init (struct s3_config *cfg, const char **errstr)
 
         return -1;
     }
-    
+
     return 0;
 }
 
@@ -151,7 +156,7 @@ int s3_put (struct s3_config *cfg, const char *key, const void *data, size_t siz
 {
     int retries = cfg->retries;
     S3Status status = S3StatusOK;
-    
+
     S3ResponseHandler resp_hndl = {
         .propertiesCallback = &response_props_cb,
         .completeCallback = &response_complete_cb
@@ -240,7 +245,7 @@ int s3_get (struct s3_config *cfg, const char *key, void **datap, size_t *sizep,
         .count = 0,
         .status = status
     };
-   
+
     if (strlen (key) == 0 || strchr (key, '/') || !strcmp (key, "..") || !strcmp (key, ".")) {
         errno = EINVAL;
         if (errstr)
@@ -250,7 +255,7 @@ int s3_get (struct s3_config *cfg, const char *key, void **datap, size_t *sizep,
     }
 
     do {
-        S3_get_object (&bucket_ctx, 
+        S3_get_object (&bucket_ctx,
                        key,
                        NULL, // getConditions (NULL for none)
                        0,    // startByte

--- a/src/modules/content-s3/s3.h
+++ b/src/modules/content-s3/s3.h
@@ -15,6 +15,8 @@
  */
 struct s3_config {
     int retries;        // number of times to retry each operation
+    int is_secure;
+    int is_virtual_host;
     char *bucket;       // the bucket name for the instance to use
     char *access_key;   // access key id string
     char *secret_key;   // secret access key id string

--- a/src/modules/content-s3/test/load.c
+++ b/src/modules/content-s3/test/load.c
@@ -25,6 +25,8 @@ int main (int argc, char **argv)
         fprintf(stderr, "calloc error");
     
     cfg->retries = 5;
+    cfg->is_virtual_host = 0;
+    cfg->is_secure = 0;
     cfg->bucket = getenv("S3_BUCKET");
     cfg->access_key = getenv("S3_ACCESS_KEY_ID");
     cfg->secret_key = getenv("S3_SECRET_ACCESS_KEY");

--- a/src/modules/content-s3/test/store.c
+++ b/src/modules/content-s3/test/store.c
@@ -24,6 +24,8 @@ int main (int argc, char **argv)
         fprintf(stderr, "calloc error");
     
     cfg->retries = 5;
+    cfg->is_virtual_host = 0;
+    cfg->is_secure = 0;
     cfg->bucket = getenv("S3_BUCKET");
     cfg->access_key = getenv("S3_ACCESS_KEY_ID");
     cfg->secret_key = getenv("S3_SECRET_ACCESS_KEY");

--- a/t/t0024-content-s3.t
+++ b/t/t0024-content-s3.t
@@ -4,14 +4,16 @@ test_description='Test content-s3 backing store service'
 
 . `dirname $0`/sharness.sh
 
-if test -z "$S3_ACCESS_KEY_ID"; then
-    skip_all='skipping content-s3 test since S3_ACCESS_KEY_ID not set'
-    test_done
+if test -z "$S3_HOSTNAME"; then
+	skip_all='skipping content-s3 test since S3_HOSTNAME not set'
+	test_done
 fi
 
 if test "$TEST_LONG" = "t"; then
     test_set_prereq LONGTEST
 fi
+
+export FLUX_CONF_DIR=$(pwd)
 
 test_under_flux 1 minimal
 
@@ -74,8 +76,30 @@ kvs_checkpoint_get() {
 # Tests of the module by itself (no content cache)
 ##
 
+test_expect_success 'create creds.toml from env' '
+	mkdir -p creds &&
+	cat >creds/creds.toml <<-CREDS
+	access-key-id = "$S3_ACCESS_KEY_ID"
+	secret-access-key = "$S3_SECRET_ACCESS_KEY"
+	CREDS
+'
+
+test_expect_success 'create content-s3.toml from env' '
+	cat >content-s3.toml <<-TOML
+	[content-s3]
+	credential-file = "$(pwd)/creds/creds.toml"
+	uri = "http://$S3_HOSTNAME"
+	bucket = "$S3_BUCKET"
+	virtual-host-style = false
+	TOML
+'
+
+test_expect_success 'reload broker config' '
+	flux config reload
+'
+
 test_expect_success 'load content-s3 module' '
-	flux module load content-s3 testing
+	flux module load content-s3
 '
 
 test_expect_success 'store/load/verify various size small blobs' '
@@ -115,7 +139,7 @@ test_expect_success HAVE_JQ 'kvs-checkpoint.get foo returned baz' '
 '
 
 test_expect_success 'reload content-s3 module' '
-	flux module reload content-s3 testing
+	flux module reload content-s3
 '
 
 test_expect_success 'reload/verify various size small blobs' '
@@ -139,13 +163,70 @@ test_expect_success HAVE_JQ 'kvs-checkpoint.get foo returns same value' '
         test_cmp value2.exp value2.out
 '
 
+test_expect_success 'config: reload config does not take effect immediately' '
+	flux config reload 2>/dev/null &&
+	flux dmesg | grep content-s3 | tail -1 >reload.log &&
+	grep "changes will not take effect until next flux restart" reload.log
+'
+
+test_expect_success 'save good config' '
+	cp content-s3.toml content-s3.save &&
+	cp creds/creds.toml creds/creds.save
+'
+
+test_expect_success 'config: reload with extra field fails' '
+	cp content-s3.save content-s3.toml &&
+	echo "extrafield = \"failure\"" >>content-s3.toml &&
+	test_must_fail flux config reload
+'
+
+test_expect_success 'config: reload with malformed uri fails' '
+	cp content-s3.save content-s3.toml &&
+	sed -i -e "s/uri =.*$/uri = \"baduri\"/" \
+		content-s3.toml &&
+	test_must_fail flux config reload
+'
+
+test_expect_success 'config: reload with bad credential path fails' '
+	cp content-s3.save content-s3.toml &&
+	sed -i -e "s/credential-file =.*$/credential-file = \"nocreds\"/" \
+		content-s3.toml &&
+	test_must_fail flux config reload
+'
+
+test_expect_success 'config: unload module' '
+	flux module remove content-s3
+'
+
+test_expect_success 'config: module fails to load without config file' '
+	rm -f content-s3.toml &&
+	cp creds/creds.save creds/creds.toml &&
+	test_must_fail flux config reload
+	flux config reload &&
+	test_must_fail flux module load content-s3
+'
+
+test_expect_success 'config: module fails to load without credentials file' '
+	rm -f creds/creds.toml &&
+	cp content-s3.save content-s3.toml &&
+	test_must_fail flux config reload
+	flux config reload &&
+	test_must_fail flux module load content-s3
+'
+
+test_expect_success 'config: restore good config' '
+	mv -f content-s3.save content-s3.toml &&
+	mv -f creds/creds.save creds/creds.toml &&
+	flux config reload
+'
+
+test_expect_success 'config: load module' '
+	flux module load content-s3
+'
+
 ##
 # Tests of the module acting as backing store for content cache
 ##
-
-test_expect_success 'reload content-s3 module without testing option' '
-	flux module reload content-s3
-'
 
 test_expect_success 'verify content.backing-module=content-s3' '
         test "$(flux getattr content.backing-module)" = "content-s3"

--- a/t/t3200-instance-restart.t
+++ b/t/t3200-instance-restart.t
@@ -9,6 +9,7 @@ test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
 
 if test -n "$S3_ACCESS_KEY_ID"; then
     test_set_prereq S3
+    export FLUX_CONF_DIR=$(pwd)
 fi
 
 test_expect_success 'run a job in persistent instance' '
@@ -59,6 +60,24 @@ test_expect_success 'restart instance and list inactive jobs' '
 
 test_expect_success 'inactive job list contains job from before restart' '
 	grep $(cat files_id1.out) files_list.out
+'
+
+test_expect_success S3 'create creds.toml from env' '
+	mkdir -p creds &&
+	cat >creds/creds.toml <<-CREDS
+	access-key-id = "$S3_ACCESS_KEY_ID"
+	secret-access-key = "$S3_SECRET_ACCESS_KEY"
+	CREDS
+'
+
+test_expect_success S3 'create content-s3.toml from env' '
+	cat >content-s3.toml <<-TOML
+	[content-s3]
+	credential-file = "$(pwd)/creds/creds.toml"
+	uri = "http://$S3_HOSTNAME"
+	bucket = "$S3_BUCKET"
+	virtual-host-style = false
+	TOML
 '
 
 test_expect_success S3 'run a job in persistent instance (content-s3)' '


### PR DESCRIPTION
This pr is a work in progress to allow the influential accessor information for the content-s3 module to be accessed from toml config files. There should be and initial conifg file passed into `flux start` with the `-o,--config-path=dir` option as well as an s3 credential file with the s3 access keys. Here is a example set up:

/home/user/config/config.toml:
```
[content-s3]
credential-file = "/home/user/.s3-creds"
uri = "http://my-s3-endpoint:9000"
bucket = "my-bucket"
virtual-host-style = false
```
/home/user/.s3-creds:
```
access-key-id = "access-key"
secret-access-key = "secret-key"
```

Note: the current sharness test will not work yet.