### PR TITLE
cmd: Make label io options consistent

### DIFF
--- a/doc/man1/flux-exec.adoc
+++ b/doc/man1/flux-exec.adoc
@@ -11,7 +11,7 @@ flux-exec - Execute processes across flux ranks
 
 SYNOPSIS
 --------
-*flux* *exec* [--noinput] ['--labelio] ['--dir=DIR'] ['--rank=NODESET'] ['--verbose'] COMMANDS...
+*flux* *exec* [--noinput] ['--label-io] ['--dir=DIR'] ['--rank=NODESET'] ['--verbose'] COMMANDS...
 
 
 DESCRIPTION
@@ -46,7 +46,7 @@ exits with exit code 128+signo.
 OPTIONS
 -------
 
-*-l, --labelio*::
+*-l, --label-io*::
 Label lines of output with the source RANK.
 
 *-n, --noinput*::

--- a/doc/man1/flux-mini.adoc
+++ b/doc/man1/flux-mini.adoc
@@ -120,7 +120,7 @@ set FILENAME to 'none' or 'kvs'.
 Redirect stderr to the specified FILENAME, bypassing the KVS.
 The mustache template '{{id}}' is expanded as above.
 
-*--label-io*::
+*-l, --label-io*::
 Add task rank prefixes to each line of output.
 
 

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -97,7 +97,6 @@ hostname
 io
 jobid
 knowlege
-labelio
 libpmi
 lwj
 mpi

--- a/src/cmd/flux-exec.c
+++ b/src/cmd/flux-exec.c
@@ -32,7 +32,7 @@ static struct optparse_option cmdopts[] = {
       .usage = "Exclude ranks from target." },
     { .name = "dir", .key = 'd', .has_arg = 1, .arginfo = "PATH",
       .usage = "Set the working directory to PATH" },
-    { .name = "labelio", .key = 'l', .has_arg = 0,
+    { .name = "label-io", .key = 'l', .has_arg = 0,
       .usage = "Label lines of output with the source RANK" },
     { .name = "noinput", .key = 'n', .has_arg = 0,
       .usage = "Redirect stdin from /dev/null" },
@@ -191,7 +191,7 @@ void output_cb (flux_subprocess_t *p, const char *stream)
         log_err_exit ("flux_subprocess_getline");
 
     if (lenp) {
-        if (optparse_getopt (opts, "labelio", NULL) > 0)
+        if (optparse_getopt (opts, "label-io", NULL) > 0)
             fprintf (fstream, "%d: ", flux_subprocess_rank (p));
         fwrite (ptr, lenp, 1, fstream);
     }

--- a/src/cmd/flux-mini.py
+++ b/src/cmd/flux-mini.py
@@ -98,6 +98,7 @@ class MiniCmd:
             metavar="FILENAME",
         )
         parser.add_argument(
+            "-l",
             "--label-io",
             action="store_true",
             help="Add rank labels to stdout, stderr lines"


### PR DESCRIPTION
For consistency throughout flux commands, change --labelio to
--label-io in flux-exec.  Support -l short option in flux-mini.

Update documentation accordingly.

Fixes #2915