### PR TITLE
job-manager: avoid segfault on priority change with pending alloc

### DIFF
--- a/src/modules/job-manager/priority.c
+++ b/src/modules/job-manager/priority.c
@@ -81,6 +81,17 @@ void priority_handle_request (flux_t *h,
         errno = EPERM;
         goto error;
     }
+    /* RFC 27 does not yet handle priority changes after alloc request
+     * has been sent to the scheduler.  Also, alloc_queue_reorder() will
+     * segfault if job->handle is NULL, which is the case if the job is
+     * no longer in alloc->queue.
+     */
+    if (job->alloc_pending) {
+        errstr = "job has made an alloc request to scheduler, "
+                 "priority cannot be changed";
+        errno = EINVAL;
+        goto error;
+    }
     /* Post event, change job's queue position, and respond.
      */
     if (event_job_post_pack (ctx->event, job,

--- a/t/t2210-job-manager-bugs.t
+++ b/t/t2210-job-manager-bugs.t
@@ -30,10 +30,35 @@ test_expect_success 'issue2664: cancel job 3' '
 test_expect_success 'issue2664: submit job 4' '
 	flux mini submit hostname >job4.out
 '
-# Hangs here (hitting timeout)
+# Hangs here (hitting timeout) when bug is present
 test_expect_success 'issue2664: cancel job 1 and drain (cleanup)' '
 	flux job cancel $(cat job1.out) &&
 	run_timeout 5 flux queue drain
 '
+
+#
+# Issue 3051 job-manager: segfault on priority change with pending alloc
+#
+
+test_expect_success 'issue3051: submit full system job' '
+	ncores=$(flux resource list -s up -no {ncores}) &&
+	flux mini submit -n ${ncores} sleep 3600 >issue3051.job1
+'
+test_expect_success 'issue3051: submit one more job and wait for alloc' '
+	flux mini submit --flags=debug /bin/true >issue3051.job2 &&
+	flux job wait-event -t 5 $(cat issue3051.job2) debug.alloc-request
+'
+test_expect_success 'issue3051: cannot reprioritize job with pending alloc' '
+	test_must_fail flux job priority $(cat issue3051.job2) 0 2>issue3051.err
+'
+test_expect_success 'issue3051: human message is reasonable' '
+	grep alloc issue3051.err
+'
+test_expect_success 'issue3051: clean up' '
+	flux job cancel $(cat issue3051.job2) &&
+	flux job cancel $(cat issue3051.job1) &&
+	flux queue drain
+'
+
 
 test_done


### PR DESCRIPTION
This adds @grondo's fix for the job manager segfault reported by @dongahn in #3051 plus a regression test.