### PR TITLE
doc: Remove unicode characters, update build to assume utf-8 locale

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -50,6 +50,11 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 master_doc = 'index'
 source_suffix = '.rst'
 
+# Disable "smartquotes" to avoid things such as turning long-options
+#  "--" into en-dash in html output, which won't make much sense for
+#  manpages.
+smartquotes = False
+
 # -- Options for HTML output -------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for

--- a/doc/man1/flux-kvs.rst
+++ b/doc/man1/flux-kvs.rst
@@ -48,18 +48,18 @@ arguments are described below.
 COMMANDS
 ========
 
-**namespace create** [-o owner] *name* [*name…​*]
+**namespace create** [-o owner] *name* [*name* ...]
    Create a new kvs namespace. User may specify an alternate userid of a
    user that owns the namespace via *-o*. Specifying an alternate owner
    would allow a non-instance owner to read/write to a namespace.
 
-**namespace remove** *name* [*name…​*]
+**namespace remove** *name* [*name...*]
    Remove a kvs namespace.
 
 **namespace list**
    List all current namespaces and info on each namespace.
 
-**get** [-N ns] [-r|-t] [-a treeobj] [-l] [-W] [-w] [-u] [-A] [-f] [-c count] *key* [*key…​*]
+**get** [-N ns] [-r|-t] [-a treeobj] [-l] [-W] [-w] [-u] [-A] [-f] [-c count] *key* [*key* ...]
    Retrieve the value stored under *key*. If nothing has been stored
    under *key*, display an error message. Specify an alternate namespace
    to retrieve *key* from via *-N*. If no options, value is displayed
@@ -78,7 +78,7 @@ COMMANDS
    directory. The *-f* option can be specified to monitor for many of
    these special situations.
 
-**put** [-N ns] [-O|-s] [-r|-t] [-n] [-A] *key=value* [*key=value…​*]
+**put** [-N ns] [-O|-s] [-r|-t] [-n] [-A] *key=value* [*key=value* ...]
    Store *value* under *key* and commit it. Specify an alternate
    namespace to commit value(s) via *-N*. If it already has a value,
    overwrite it. If no options, value is stored directly. If *-r* or
@@ -91,7 +91,7 @@ COMMANDS
    *-s* can be specified to output the RFC11 treeobj or root sequence
    number of the root containing the put(s).
 
-**ls** [-N ns] [-R] [-d] [-F] [-w COLS] [-1] [*key* …​]
+**ls** [-N ns] [-R] [-d] [-F] [-w COLS] [-1] [*key* ...]
    Display directory referred to by *key*, or "." (root) if unspecified.
    Specify an alternate namespace to display via *-N*. Remaining options are
    roughly equivalent to a subset of ls(1) options. *-R* lists directory
@@ -111,7 +111,7 @@ COMMANDS
    treeobj* causes the lookup to be relative to an RFC 11 snapshot
    reference.
 
-**unlink** [-N ns] [-O|-s] [-R] [-f] *key* [*key…​*]
+**unlink** [-N ns] [-O|-s] [-R] [-f] *key* [*key* ...]
    Remove *key* from the KVS and commit the change. Specify an alternate
    namespace to commit to via *-N*. If *key* represents a directory,
    specify *-R* to remove all keys underneath it. If *-f* is specified,
@@ -127,7 +127,7 @@ COMMANDS
    successfully created link, *-O* or *-s* can be specified to output the
    RFC11 treeobj or root sequence number of the root containing the link.
 
-**readlink** [-N ns] [-a treeobj] [ -o \| -k ] *key* [*key…​*]
+**readlink** [-N ns] [-a treeobj] [ -o \| -k ] *key* [*key* ...]
    Retrieve the key a link refers to rather than its value, as would be
    returned by **get**. Specify an alternate namespace to retrieve from
    via *-N*. *-a treeobj* causes the lookup to be relative to an RFC 11
@@ -136,7 +136,7 @@ COMMANDS
    can be used to only output namespaces and the *-k* can be used to only
    output keys.
 
-**mkdir** [-N ns] [-O|-s] *key* [*key…​*]
+**mkdir** [-N ns] [-O|-s] *key* [*key* ...]
    Create an empty directory and commit the change. If *key* exists,
    it is overwritten. Specify an alternate namespace to commit to via
    *-N*. After a successful mkdir, *-O* or *-s* can be specified to
@@ -186,7 +186,7 @@ COMMANDS
    the number of events is limited with the *-c* option. Specify an
    alternate namespace to display from via *-N*.
 
-**eventlog append** [-N ns] [-t SECONDS] *key* *name* [*context …​*]
+**eventlog append** [-N ns] [-t SECONDS] *key* *name* [*context* ...]
    Append an event to an RFC 18 KVS eventlog referred to by *key*.
    The event *name* and optional *context* are specified on the command line.
    The timestamp may optionally be specified with *-t* as decimal seconds since

--- a/doc/man3/flux_fd_watcher_create.rst
+++ b/doc/man3/flux_fd_watcher_create.rst
@@ -36,7 +36,7 @@ to monitor for events on a file descriptor *fd*. When events occur,
 the user-supplied *callback* is invoked.
 
 The *events* and *revents* arguments are a bitmask containing a logical
-“or” of the following bits. If a bit is set in *events*, it indicates
+OR of the following bits. If a bit is set in *events*, it indicates
 interest in this type of event. If a bit is set in *revents*, it
 indicates that this event has occurred.
 

--- a/doc/man3/flux_handle_watcher_create.rst
+++ b/doc/man3/flux_handle_watcher_create.rst
@@ -36,7 +36,7 @@ monitors for events on a Flux broker handle *h*. When events occur,
 the user-supplied *callback* is invoked.
 
 The *events* and *revents* arguments are a bitmask containing a
-logical “or” of the following bits. If a bit is set in *events*,
+logical OR of the following bits. If a bit is set in *events*,
 it indicates interest in this type of event. If a bit is set in *revents*,
 it indicates that this event has occurred.
 

--- a/doc/man3/flux_pollevents.rst
+++ b/doc/man3/flux_pollevents.rst
@@ -80,7 +80,7 @@ execute the prepare and check callbacks.
 The net results are 1) the edge-triggered notification provided by
 ``flux_pollfd()`` is integrated with libev's level-triggered watcher
 processing; 2) the handle is able to give control back to the event
-loop between handle event callbacks to preserve fairness—​in other words
+loop between handle event callbacks to preserve fairness, i.e.
 it doesn't have to consume events until they they are gone in one
 callback; and 3) the event loop is able to sleep when there are no
 handle events pending.

--- a/doc/man3/flux_stat_watcher_create.rst
+++ b/doc/man3/flux_stat_watcher_create.rst
@@ -47,7 +47,7 @@ The callback *revents* argument should be ignored.
 within *callback*. If non-NULL, *stat* receives the current status.
 If non-NULL, *prev* receives the previous status.
 
-If the object does not exist, stat→st_nlink will be zero and other
+If the object does not exist, stat->st_nlink will be zero and other
 status fields are undefined. The appearance/disappearance of a file
 is considered a status change like any other.
 

--- a/doc/man3/flux_zmq_watcher_create.rst
+++ b/doc/man3/flux_zmq_watcher_create.rst
@@ -36,7 +36,7 @@ monitors for events on a ZeroMQ socket *zsock*. When events occur,
 the user-supplied *callback* is invoked.
 
 The *events* and *revents* arguments are a bitmask containing a
-logical “or” of the following bits. If a bit is set in *events*,
+logical OR of the following bits. If a bit is set in *events*,
 it indicates interest in this type of event. If a bit is set in the
 *revents*, it indicates that this event has occurred.
 

--- a/doc/test/spellcheck
+++ b/doc/test/spellcheck
@@ -34,7 +34,8 @@ for f in $*; do
     filename=$(basename $f)
     dir=$(basename $(dirname $f))
     tmpfile=$(mktemp)
-    rc=$(cat $f | $ASPELL -p $dict -n list | sort | uniq | tee $tmpfile | wc -l)
+    rc=$(cat $f | $ASPELL -p $dict --encoding='utf-8' -n list \
+        | sort | uniq | tee $tmpfile | wc -l)
     if test $rc == 0; then
         echo "ok $count - spell check $dir/$filename"
     else

--- a/etc/gen-cmdhelp.py
+++ b/etc/gen-cmdhelp.py
@@ -34,7 +34,7 @@ for (path, cmd, descr, author, section) in man_pages:
     if section is not 1 or path in visited:
         continue
     visited[path] = True
-    with open(f"{docsdir}/{path}.rst", "r") as f:
+    with open(f"{docsdir}/{path}.rst", "r", encoding='utf-8') as f:
         include_flag = False
         for line in f:
             line = line.rstrip("\n")


### PR DESCRIPTION
Per discussion in #3071.  Not sure if others want to add other fixes on top of this one (such as #3076).

Please take note of my removal of unicode chars changes.  Some are obvious (unicode  `…` to plain old ascii `...`).  I replaced a "-- in other words" with an "i.e." and some `"or"` with `OR` instead of just reverting to what was in the original asciidoc files.