### PR TITLE
testsuite: remove use of -S option in run_timeout

### DIFF
--- a/t/sharness.d/flux-sharness.sh
+++ b/t/sharness.d/flux-sharness.sh
@@ -8,7 +8,7 @@
 #
 run_timeout() {
     if test -z "$LD_PRELOAD" ; then
-        "${PYTHON:-python3}" -S "${SHARNESS_TEST_SRCDIR}/scripts/run_timeout.py" "$@"
+        "${PYTHON:-python3}" "${SHARNESS_TEST_SRCDIR}/scripts/run_timeout.py" "$@"
     else
         (
             TIMEOUT_PRELOAD="$LD_PRELOAD"


### PR DESCRIPTION
This reverts commit a63df26c3d4a1ef810780cc6afb0d483cb531b67.

When building in a virtual environment, site packages may be needed
for testing.

Fixes #3074