### PR TITLE
shell: fix bug in cpu-affinity=per-task

### DIFF
--- a/src/shell/affinity.c
+++ b/src/shell/affinity.c
@@ -76,7 +76,7 @@ static hwloc_cpuset_t *distribute_tasks (hwloc_topology_t topo,
     /* NB: hwloc_distrib() will alloc ntasks cpusets in cpusetp, which
      *     later need to be destroyed with hwloc_bitmap_free().
      */
-    hwloc_distrib (topo, obj, 1, cpusetp, ntasks, HWLOC_OBJ_PU, 0);
+    hwloc_distrib (topo, obj, 1, cpusetp, ntasks, INT_MAX, 0);
     return (cpusetp);
 }
 


### PR DESCRIPTION
This fixes a bug in the shell affinity plugin found by @eleon.

I was unable to add a test, since the reproducer requires presence of HTs.

(We should test on corona before merging.)