### PR TITLE
doc: remove spelling plugin from sphinx conf.py

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -39,18 +39,6 @@ release = '0.13.0'
 
 # -- General configuration ---------------------------------------------------
 
-# Add any Sphinx extension module names here, as strings. They can be
-# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
-# ones.
-extensions = [
-    'sphinxcontrib.spelling',
-]
-
-# sphinxcontrib.spelling settings
-spelling_word_list_filename = [
-    'test/spell.en.pws'
-]
-
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,3 +1,2 @@
 sphinx
 sphinx-rtd-theme
-sphinxcontrib-spelling


### PR DESCRIPTION
Problem: The spelling plugin defined in doc/conf.py sphinx config
requires users to have the plugin installed, even though it is unused.
This unnecessarily breaks the build for users.

Remove the unused plugin and its associated configuration.

Fixes #3083