### PR TITLE
switch to utf-8 for subprocess and job io encoding

### DIFF
--- a/src/common/libflux/message.c
+++ b/src/common/libflux/message.c
@@ -1310,7 +1310,7 @@ int flux_msg_vunpack (const flux_msg_t *cmsg, const char *fmt, va_list ap)
             errno = EPROTO;
             goto done;
         }
-        if (!(msg->json = json_loads (json_str, 0, &err))) {
+        if (!(msg->json = json_loads (json_str, JSON_ALLOW_NUL, &err))) {
             msg_lasterr_set (msg, "%s", err.text);
             errno = EPROTO;
             goto done;

--- a/src/common/libflux/test/message.c
+++ b/src/common/libflux/test/message.c
@@ -291,6 +291,20 @@ void check_payload_json_formatted (void)
     ok (strlen (flux_msg_last_error (msg)) > 0,
         "flux_msg_last_error is %s", flux_msg_last_error (msg));
 
+    /* flux_msg_pack/unpack doesn't reject packed NUL chars */
+    char buf[4] = "foo";
+    char *result = NULL;
+    size_t len = -1;
+
+    ok (flux_msg_pack (msg, "{ss#}", "result", buf, 4) == 0,
+        "flux_msg_pack with NUL char works");
+    ok (flux_msg_unpack (msg, "{ss%}", "result", &result, &len) == 0,
+        "flux_msg_unpack with NUL char works");
+    ok (len == 4,
+        "flux_msg_unpack returned correct length");
+    ok (memcmp (buf, result, 4) == 0,
+        "original buffer and result match");
+
     flux_msg_destroy (msg);
 }
 

--- a/src/shell/input.c
+++ b/src/shell/input.c
@@ -266,7 +266,7 @@ static int shell_input_header (struct shell_input *in)
                              "{s:i s:{s:s} s:{s:i} s:{}}",
                              "version", 1,
                              "encoding",
-                             "stdin", "base64",
+                             "stdin", "UTF-8",
                              "count",
                              "stdin", 1,
                              "options");

--- a/src/shell/output.c
+++ b/src/shell/output.c
@@ -794,7 +794,7 @@ error:
 }
 
 /* Write RFC 24 header event to KVS.  Assume:
- * - fixed base64 encoding for stdout, stderr
+ * - fixed utf-8 encoding for stdout, stderr
  * - no options
  * - no stdlog
  */
@@ -807,8 +807,8 @@ static int shell_output_header (struct shell_output *out)
                              "{s:i s:{s:s s:s} s:{s:i s:i} s:{}}",
                              "version", 1,
                              "encoding",
-                               "stdout", "base64",
-                               "stderr", "base64",
+                               "stdout", "UTF-8",
+                               "stderr", "UTF-8",
                              "count",
                                "stdout", out->shell->info->total_ntasks,
                                "stderr", out->shell->info->total_ntasks,


### PR DESCRIPTION
This PR experimentally switches the encoding used by libioencode from base64 to utf-8.

The benefit of this change is to allow easier access to job IO from external entities, e.g. this will make it trivial for a Python script to get job output.

One change of note is that the flag `JSON_ALLOW_NUL` is added to `flux_msg_vunpack(3)` use of `json_loads`. This allows anything that could be base64 encoded to safely be encoded as UTF-8 (jansson will escape unencodable characters, e.g. `\u0000` for NUL).

