### PR TITLE
shell/lua.d/openmpi: set env vars to force the use of flux plugins

### DIFF
--- a/src/shell/lua.d/openmpi.lua
+++ b/src/shell/lua.d/openmpi.lua
@@ -11,3 +11,5 @@
 local f = require 'flux'.new ()
 local rundir  = f:getattr ('broker.rundir')
 shell.setenv ("OMPI_MCA_orte_tmpdir_base", rundir)
+shell.setenv ("OMPI_MCA_pmix", "flux")
+shell.setenv ("OMPI_MCA_schizo", "flux")


### PR DESCRIPTION
Problem: OpenMPI fails to bootstrap under Flux on some systems, like
Cori at NERSC

Solution: automatically set OMPI_MCA_{schizo,pmix} to flux so that
flux's pmi is used rather than pmix or vendor-specific plugins like cray