### PR TITLE
libflux: add flux_module_set_running()

### DIFF
--- a/etc/gen-cmdhelp.py
+++ b/etc/gen-cmdhelp.py
@@ -31,7 +31,7 @@ entries = []
 visited = dict()
 
 for (path, cmd, descr, author, section) in man_pages:
-    if section is not 1 or path in visited:
+    if section != 1 or path in visited:
         continue
     visited[path] = True
     with open(f"{docsdir}/{path}.rst", "r", encoding='utf-8') as f:

--- a/src/common/libflux/module.c
+++ b/src/common/libflux/module.c
@@ -19,6 +19,7 @@
 
 #include "module.h"
 #include "message.h"
+#include "keepalive.h"
 #include "rpc.h"
 
 #include "src/common/libutil/log.h"
@@ -123,6 +124,25 @@ bool flux_module_debug_test (flux_t *h, int flag, bool clear)
     if (clear)
         *flagsp &= ~flag;
     return true;
+}
+
+int flux_module_set_running (flux_t *h)
+{
+    flux_msg_t *msg;
+    int rc = -1;
+
+    if (!h) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (!(msg = flux_keepalive_encode (0, FLUX_MODSTATE_RUNNING)))
+        return -1;
+    if (flux_send (h, msg, 0) < 0)
+        goto done;
+    rc = 0;
+done:
+    flux_msg_decref (msg);
+    return rc;
 }
 
 /*

--- a/src/common/libflux/module.h
+++ b/src/common/libflux/module.h
@@ -62,6 +62,13 @@ char *flux_modfind (const char *searchpath, const char *modname,
  */
 bool flux_module_debug_test (flux_t *h, int flag, bool clear);
 
+/* Set module state to RUNNING.  This transition occurs automatically when the
+ * reactor is entered, but this function can set the state to RUNNING early,
+ * e.g. if flux module load must complete before the module enters the reactor.
+ * Returns 0 on success, -1 on error with errno set.
+ */
+int flux_module_set_running (flux_t *h);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/common/libflux/test/module.c
+++ b/src/common/libflux/test/module.c
@@ -20,6 +20,7 @@
 #include <flux/core.h>
 
 #include "src/common/libtap/tap.h"
+#include "src/common/libtestutil/util.h"
 
 /* N.B. FAKE1 and FAKE2 are defined with -D on the CC command line.
  * They are set to the full path of two test modules, module_fake1.so
@@ -182,6 +183,22 @@ void test_debug (void)
     flux_handle_destroy (h);
 }
 
+void test_set_running (void)
+{
+    flux_t *h;
+
+    if (!(h = loopback_create (0)))
+        BAIL_OUT ("loopback_create failed");
+
+    ok (flux_module_set_running (h) == 0,
+        "flux_module_set_running returns success");
+    errno = 0;
+    ok (flux_module_set_running (NULL) < 0 && errno == EINVAL,
+        "flux_module_set_running h=NULL fails with EINVAL");
+
+    flux_close (h);
+}
+
 int main (int argc, char *argv[])
 {
 
@@ -190,6 +207,7 @@ int main (int argc, char *argv[])
     test_modname ();
     test_modfind ();
     test_debug ();
+    test_set_running ();
 
     done_testing();
     return (0);

--- a/src/modules/sched-simple/sched.c
+++ b/src/modules/sched-simple/sched.c
@@ -643,6 +643,12 @@ int mod_main (flux_t *h, int argc, char **argv)
     zlistx_set_comparator (ss->queue, jobreq_cmp);
     zlistx_set_destructor (ss->queue, jobreq_destructor);
 
+    /* Let `flux module load simple-sched` return before synchronous
+     * initialization with resource and job-manager modules.
+     */
+    if (flux_module_set_running (h) < 0)
+        goto done;
+
     if (simple_sched_init (h, ss) < 0)
         goto done;
     if (flux_msg_handler_addvec (h, htab, ss, &handlers) < 0) {

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -287,6 +287,7 @@ endif
 check_LTLIBRARIES = \
 	module/parent.la \
 	module/child.la \
+	module/running.la \
 	request/req.la \
 	ingest/job-manager-dummy.la \
 	job-manager/sched-dummy.la \
@@ -454,6 +455,12 @@ module_child_la_SOURCES = module/child.c
 module_child_la_CPPFLAGS = $(test_cppflags)
 module_child_la_LDFLAGS = $(fluxmod_ldflags) -module -rpath /nowher
 module_child_la_LIBADD = \
+	$(test_ldadd) $(LIBDL) $(LIBUTIL)
+
+module_running_la_SOURCES = module/running.c
+module_running_la_CPPFLAGS = $(test_cppflags)
+module_running_la_LDFLAGS = $(fluxmod_ldflags) -module -rpath /nowher
+module_running_la_LIBADD = \
 	$(test_ldadd) $(LIBDL) $(LIBUTIL)
 
 barrier_tbarrier_SOURCES = barrier/tbarrier.c

--- a/t/module/running.c
+++ b/t/module/running.c
@@ -1,0 +1,47 @@
+/************************************************************\
+ * Copyright 2020 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/core.h>
+
+int mod_main (flux_t *h, int argc, char *argv[])
+{
+    flux_msg_t *msg;
+    struct flux_match match;
+
+    if (flux_event_subscribe (h, "running.go") < 0)
+        return -1;
+    if (flux_module_set_running (h) < 0)
+        return -1;
+    match = FLUX_MATCH_EVENT;
+    match.topic_glob = "running.go";
+    if (!(msg = flux_recv (h, match, 0))) {
+        flux_log_error (h, "flux_recv");
+        return -1;
+    }
+    flux_log (h, LOG_DEBUG, "received event");
+    flux_msg_destroy (msg);
+
+    if (flux_reactor_run (flux_get_reactor (h), 0) < 0) {
+        flux_log_error (h, "flux_reactor_run");
+        return -1;
+    }
+    return 0;
+}
+
+/* This dso extends a comms module named "parent".
+ */
+MOD_NAME ("running");
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/t/t0003-module.t
+++ b/t/t0003-module.t
@@ -267,4 +267,15 @@ test_expect_success 'flux module load "noexist" fails' '
 	grep -q "not found" noexist.out
 '
 
+test_expect_success 'flux_module_set_running - load test module' '
+	run_timeout 10 \
+		flux module load ${FLUX_BUILD_DIR}/t/module/.libs/running.so
+'
+test_expect_success 'flux_module_set_running - signal module to enter reactor' '
+	flux event pub running.go
+'
+test_expect_success 'flux_module_set_running - remove test module' '
+	flux module remove running
+'
+
 test_done


### PR DESCRIPTION
Problem: `flux module load` blocks until the module enters the reactor,
but in some cases it is desirable for the command to complete before
the reactor is entered.

Give modules control over when they enter RUNNING state, and therefore
when `flux module load` returns, by exposing a new function,
`flux_module_set_running ()`.

Change simple scheduler to call this before its synchronous resource and job-manager handshake, to prepare for broker startup changes in #3057.  This approach will be much easier to apply to the fluxion scheduler than the one in #3063