### PR TITLE
broker: state machine refactoring

### DIFF
--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -778,36 +778,6 @@ static void set_proctitle (uint32_t rank)
     (void)prctl (PR_SET_NAME, proctitle, 0, 0, 0);
 }
 
-static void runat_completion_cb (struct runat *r, const char *name, void *arg)
-{
-    broker_ctx_t *ctx = arg;
-    int rc = 1;
-
-    if (runat_get_exit_code (r, name, &rc) < 0)
-        log_err ("runat_get_exit_code %s", name);
-
-    if (!strcmp (name, "rc1")) {
-        if (rc != 0)
-            ctx->exit_rc = rc;
-        state_machine (ctx, rc == 0 ? "rc1-success" : "rc1-fail");
-    }
-    else if (!strcmp (name, "rc2")) {
-        if (rc != 0)
-            ctx->exit_rc = rc;
-        state_machine (ctx, rc == 0 ? "rc2-success" : "rc2-fail");
-    }
-    else if (!strcmp (name, "cleanup")) {
-        if (rc != 0)
-            ctx->exit_rc = rc;
-        state_machine (ctx, rc == 0 ? "cleanup-success" : "cleanup-fail");
-    }
-    else if (!strcmp (name, "rc3")) {
-        if (rc != 0)
-            ctx->exit_rc = rc;
-        state_machine (ctx, rc == 0 ? "rc3-success" : "rc3-fail");
-    }
-}
-
 static int create_runat_rc2 (struct runat *r, const char *argz, size_t argz_len)
 {
     if (argz == NULL) { // run interactive shell
@@ -846,10 +816,7 @@ static int create_runat_phases (broker_ctx_t *ctx)
         if (attr_get (ctx->attrs, "broker.rc2_none", NULL, NULL) == 0)
             rc2_none = true;
 
-        if (!(ctx->runat = runat_create (ctx->h,
-                                         local_uri,
-                                         runat_completion_cb,
-                                         ctx))) {
+        if (!(ctx->runat = runat_create (ctx->h, local_uri))) {
             log_err ("runat_create");
             return -1;
         }

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -425,8 +425,7 @@ int main (int argc, char *argv[])
     }
     ctx.rank = overlay_get_rank (ctx.overlay);
     ctx.size = overlay_get_size (ctx.overlay);
-    char rank_str[16];
-    snprintf (rank_str, sizeof (rank_str), "%"PRIu32, ctx.rank);
+    snprintf (ctx.uuid, sizeof (ctx.uuid), "%"PRIu32, ctx.rank);
 
     assert (ctx.size > 0);
 
@@ -520,7 +519,7 @@ int main (int argc, char *argv[])
         log_err ("exec_initialize");
         goto cleanup;
     }
-    if (ping_initialize (ctx.h, "cmb", rank_str) < 0) {
+    if (ping_initialize (ctx.h, "cmb", ctx.uuid) < 0) {
         log_err ("ping_initialize");
         goto cleanup;
     }
@@ -1859,12 +1858,10 @@ static int sendmsg_child_request (broker_ctx_t *ctx,
                                   uint32_t nodeid)
 {
     flux_msg_t *cpy = flux_msg_copy (msg, true);
-    int saved_errno;
     char uuid[16];
     int rc = -1;
 
-    snprintf (uuid, sizeof (uuid), "%"PRIu32, ctx->rank);
-    if (flux_msg_push_route (cpy, uuid) < 0)
+    if (flux_msg_push_route (cpy, ctx->uuid) < 0)
         goto done;
     snprintf (uuid, sizeof (uuid), "%"PRIu32, nodeid);
     if (flux_msg_push_route (cpy, uuid) < 0)
@@ -1873,9 +1870,7 @@ static int sendmsg_child_request (broker_ctx_t *ctx,
         goto done;
     rc = 0;
 done:
-    saved_errno = errno;
     flux_msg_destroy (cpy);
-    errno = saved_errno;
     return rc;
 }
 

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -120,8 +120,6 @@ static void init_attrs (attr_t *attrs, pid_t pid);
 
 static const struct flux_handle_ops broker_handle_ops;
 
-static int exit_rc = 1;
-
 #define OPTIONS "+vs:X:k:H:g:S:c:"
 static const struct option longopts[] = {
     {"verbose",         no_argument,        0, 'v'},
@@ -267,6 +265,8 @@ int main (int argc, char *argv[])
 
     memset (&ctx, 0, sizeof (ctx));
     log_init (argv[0]);
+
+    ctx.exit_rc = 1;
 
     if (!(ctx.sigwatchers = zlist_new ()))
         oom ();
@@ -590,7 +590,7 @@ int main (int argc, char *argv[])
     if (ctx.verbose)
         log_msg ("entering event loop");
     /* Once we enter the reactor, default exit_rc is now 0 */
-    exit_rc = 0;
+    ctx.exit_rc = 0;
     if (flux_reactor_run (ctx.reactor, 0) < 0)
         log_err ("flux_reactor_run");
     if (ctx.verbose)
@@ -640,7 +640,7 @@ cleanup:
     zlist_destroy (&ctx.subscriptions);
     free (ctx.init_shell_cmd);
 
-    return exit_rc;
+    return ctx.exit_rc;
 }
 
 struct attrmap {
@@ -789,22 +789,22 @@ static void runat_completion_cb (struct runat *r, const char *name, void *arg)
 
     if (!strcmp (name, "rc1")) {
         if (rc != 0)
-            exit_rc = rc;
+            ctx->exit_rc = rc;
         state_machine (ctx, rc == 0 ? "rc1-success" : "rc1-fail");
     }
     else if (!strcmp (name, "rc2")) {
         if (rc != 0)
-            exit_rc = rc;
+            ctx->exit_rc = rc;
         state_machine (ctx, rc == 0 ? "rc2-success" : "rc2-fail");
     }
     else if (!strcmp (name, "cleanup")) {
         if (rc != 0)
-            exit_rc = rc;
+            ctx->exit_rc = rc;
         state_machine (ctx, rc == 0 ? "cleanup-success" : "cleanup-fail");
     }
     else if (!strcmp (name, "rc3")) {
         if (rc != 0)
-            exit_rc = rc;
+            ctx->exit_rc = rc;
         state_machine (ctx, rc == 0 ? "rc3-success" : "rc3-fail");
     }
 }

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -1817,7 +1817,7 @@ static void signal_cb (flux_reactor_t *r, flux_watcher_t *w,
 
     flux_log (ctx->h, LOG_INFO, "signal %d", signum);
     if (ctx->rank == 0)
-        state_machine_abort (ctx->state_machine);
+        state_machine_kill (ctx->state_machine, signum);
 }
 
 /* Send a request message down the TBON.

--- a/src/broker/broker.h
+++ b/src/broker/broker.h
@@ -43,7 +43,7 @@ struct broker {
 
     struct hello *hello;
     struct runat *runat;
-    broker_state_t state;
+    struct state_machine *state_machine;
 
     char *init_shell_cmd;
     size_t init_shell_cmd_len;

--- a/src/broker/broker.h
+++ b/src/broker/broker.h
@@ -46,6 +46,8 @@ struct broker {
 
     char *init_shell_cmd;
     size_t init_shell_cmd_len;
+
+    int exit_rc;
 };
 
 typedef struct broker broker_ctx_t;

--- a/src/broker/broker.h
+++ b/src/broker/broker.h
@@ -18,6 +18,7 @@ struct broker {
     struct overlay *overlay;
     uint32_t rank;
     uint32_t size;
+    char uuid[16];
 
     struct broker_attr *attrs;
     struct flux_msg_cred cred;  /* instance owner */

--- a/src/broker/broker.h
+++ b/src/broker/broker.h
@@ -16,6 +16,8 @@ struct broker {
     flux_reactor_t *reactor;
 
     struct overlay *overlay;
+    uint32_t rank;
+    uint32_t size;
 
     struct broker_attr *attrs;
     struct flux_msg_cred cred;  /* instance owner */

--- a/src/broker/runat.c
+++ b/src/broker/runat.c
@@ -44,6 +44,7 @@ struct runat_entry {
     int exit_code;
     int count;
     bool aborted;
+    bool completed;
 };
 
 struct runat {
@@ -245,6 +246,7 @@ static void start_next_command (struct runat *r, struct runat_entry *entry)
         }
     }
     if (zlist_size (entry->commands) == 0) {
+        entry->completed = true;
         if (r->cb)
             r->cb (r, entry->name, r->cb_arg);
     }
@@ -492,6 +494,22 @@ int runat_start (struct runat *r, const char *name)
     }
     start_next_command (r, entry);
     return 0;
+}
+
+bool runat_is_defined (struct runat *r, const char *name)
+{
+    if (!r || !name || !zhashx_lookup (r->entries, name))
+        return false;
+    return true;
+}
+
+bool runat_is_completed (struct runat *r, const char *name)
+{
+    struct runat_entry *entry;
+
+    if (!r || !name || !(entry = zhashx_lookup (r->entries, name)))
+        return false;
+    return entry->completed;
 }
 
 int runat_abort (struct runat *r, const char *name)

--- a/src/broker/runat.h
+++ b/src/broker/runat.h
@@ -20,10 +20,7 @@ typedef void (*runat_completion_f)(struct runat *r,
                                    const char *name,
                                    void *arg);
 
-struct runat *runat_create (flux_t *h,
-                            const char *local_uri,
-                            runat_completion_f cb,
-                            void *arg);
+struct runat *runat_create (flux_t *h, const char *local_uri);
 void runat_destroy (struct runat *r);
 
 /* Push command, to be run under shell -c, onto named list.
@@ -57,7 +54,10 @@ int runat_get_exit_code (struct runat *r, const char *name, int *rc);
  * Completion callback is called once command finish execution.
  * The completion callback may call runat_get_exit_code().
  */
-int runat_start (struct runat *r, const char *name);
+int runat_start (struct runat *r,
+                 const char *name,
+                 runat_completion_f cb,
+                 void *arg);
 
 /* Abort execution of named list.
  * If a command is running, it is signaled.

--- a/src/broker/runat.h
+++ b/src/broker/runat.h
@@ -64,6 +64,14 @@ int runat_start (struct runat *r, const char *name);
  */
 int runat_abort (struct runat *r, const char *name);
 
+/* Test whether named list has been defined.
+ */
+bool runat_is_defined (struct runat *r, const char *name);
+
+/* Test whether named list has completed running.
+ */
+bool runat_is_completed (struct runat *r, const char *name);
+
 #endif /* !_BROKER_RUNAT_H */
 
 /*

--- a/src/broker/state_machine.c
+++ b/src/broker/state_machine.c
@@ -1,5 +1,5 @@
 /************************************************************\
- * Copyright 2014 Lawrence Livermore National Security, LLC
+ * Copyright 2020 Lawrence Livermore National Security, LLC
  * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
  *
  * This file is part of the Flux resource manager framework.

--- a/src/broker/state_machine.c
+++ b/src/broker/state_machine.c
@@ -23,119 +23,175 @@
 #include "runat.h"
 #include "overlay.h"
 
+struct state_machine {
+    struct broker *ctx;
+    broker_state_t state;
+};
+
+typedef void (*action_f)(struct state_machine *s);
+
+struct state {
+    const char *name;
+    action_f action;
+};
+
+struct state_next {
+    const char *event;
+    broker_state_t current;
+    broker_state_t next;
+};
+
+static void action_init (struct state_machine *s);
+static void action_run (struct state_machine *s);
+static void action_cleanup (struct state_machine *s);
+static void action_finalize (struct state_machine *s);
+static void action_shutdown (struct state_machine *s);
+
 static void runat_completion_cb (struct runat *r, const char *name, void *arg);
 
-const char *statestr (broker_state_t state)
+/* order assumes broker_state_t enum values can be used as array index */
+static struct state statetab[] = {
+    { "none",             NULL },
+    { "init",             action_init },
+    { "run",              action_run },
+    { "cleanup",          action_cleanup },
+    { "finalize",         action_finalize },
+    { "shutdown",         action_shutdown },
+};
+
+static struct state_next nexttab[] = {
+    { "wireup-complete",    STATE_NONE,         STATE_INIT },
+    { "rc1-success",        STATE_INIT,         STATE_RUN },
+    { "rc1-none",           STATE_INIT,         STATE_RUN },
+    { "rc1-fail",           STATE_INIT,         STATE_FINALIZE },
+    { "rc2-success",        STATE_RUN,          STATE_CLEANUP },
+    { "rc2-fail",           STATE_RUN,          STATE_CLEANUP },
+    { "rc2-abort",          STATE_RUN,          STATE_CLEANUP },
+    { "rc2-none",           STATE_RUN,          STATE_RUN },
+    { "cleanup-success",    STATE_CLEANUP,      STATE_FINALIZE},
+    { "cleanup-none",       STATE_CLEANUP,      STATE_FINALIZE},
+    { "cleanup-fail",       STATE_CLEANUP,      STATE_FINALIZE},
+    { "rc3-success",        STATE_FINALIZE,     STATE_SHUTDOWN },
+    { "rc3-none",           STATE_FINALIZE,     STATE_SHUTDOWN },
+    { "rc3-fail",           STATE_FINALIZE,     STATE_SHUTDOWN },
+    { NULL, 0, 0 },
+};
+
+static void state_action (struct state_machine *s, broker_state_t state)
 {
-    return (state == STATE_NONE ? "none" :
-            state == STATE_INIT ? "init" :
-            state == STATE_RUN ? "run" :
-            state == STATE_CLEANUP ? "cleanup" :
-            state == STATE_FINALIZE ? "finalize" :
-            state == STATE_SHUTDOWN ? "shutdown" : "???");
+    if (statetab[state].action)
+        statetab[state].action (s);
 }
 
-broker_state_t state_next (broker_state_t state, const char *event)
+static const char *statestr (broker_state_t state)
 {
-    if (!strcmp (event, "wireup-complete")) {
-        if (state == STATE_NONE)
-            state = STATE_INIT;
-    }
-    else if (!strcmp (event, "rc1-fail")) {
-        if (state == STATE_INIT)
-            state = STATE_FINALIZE;
-    }
-    else if (!strcmp (event, "rc1-success")) {
-        if (state == STATE_INIT)
-            state = STATE_RUN;
-    }
-    else if (!strcmp (event, "rc2-fail")
-          || !strcmp (event, "rc2-success")
-          || !strcmp (event, "rc2-abort-noscript")) {
-        if (state == STATE_RUN)
-            state = STATE_CLEANUP;
-    }
-    else if (!strcmp (event, "cleanup-fail")
-          || !strcmp (event, "cleanup-success")) {
-        if (state == STATE_CLEANUP)
-            state = STATE_FINALIZE;
-    }
-    else if (!strcmp (event, "rc3-fail")
-          || !strcmp (event, "rc3-success")) {
-        if (state == STATE_FINALIZE)
-            state = STATE_SHUTDOWN;
-    }
-    return state;
+    return statetab[state].name;
 }
 
-void state_action (struct broker *ctx, broker_state_t state)
+static broker_state_t state_next (broker_state_t current, const char *event)
 {
-    switch (state) {
-        case STATE_INIT:
-            if (runat_start (ctx->runat, "rc1", runat_completion_cb, ctx) < 0)
-                state_machine (ctx, "rc1-success");
-            break;
-        case STATE_RUN:
-            if (runat_start (ctx->runat, "rc2", runat_completion_cb, ctx) < 0)
-                flux_log (ctx->h, LOG_DEBUG, "no initial program defined");
-            break;
-        case STATE_CLEANUP:
-            if (runat_start (ctx->runat, "cleanup", runat_completion_cb, ctx) < 0)
-                state_machine (ctx, "cleanup-success");
-            break;
-        case STATE_FINALIZE:
-            if (runat_start (ctx->runat, "rc3", runat_completion_cb, ctx) < 0)
-                state_machine (ctx, "rc3-success");
-            break;
-        case STATE_SHUTDOWN:
-            shutdown_instance (ctx->shutdown);
-            break;
-        case STATE_NONE:
-            break;
+    int i;
+    for (i = 0; nexttab[i].event != NULL; i++) {
+        if (nexttab[i].current == current && !strcmp (event, nexttab[i].event))
+            return nexttab[i].next;
     }
+    return current;
 }
 
-void state_machine (struct broker *ctx, const char *event)
+static void action_init (struct state_machine *s)
+{
+    if (runat_is_defined (s->ctx->runat, "rc1")) {
+        if (runat_start (s->ctx->runat, "rc1", runat_completion_cb, s) < 0) {
+            flux_log_error (s->ctx->h, "runat_start rc1");
+            state_machine_post (s, "rc1-fail");
+        }
+    }
+    else
+        state_machine_post (s, "rc1-none");
+}
+
+static void action_run (struct state_machine *s)
+{
+    if (runat_is_defined (s->ctx->runat, "rc2")) {
+        if (runat_start (s->ctx->runat, "rc2", runat_completion_cb, s) < 0) {
+            flux_log_error (s->ctx->h, "runat_start rc2");
+            state_machine_post (s, "rc2-fail");
+        }
+    }
+    else
+        state_machine_post (s, "rc2-none");
+}
+
+static void action_cleanup (struct state_machine *s)
+{
+    if (runat_is_defined (s->ctx->runat, "cleanup")) {
+        if (runat_start (s->ctx->runat, "cleanup", runat_completion_cb, s) < 0) {
+            flux_log_error (s->ctx->h, "runat_start cleanup");
+            state_machine_post (s, "cleanup-fail");
+        }
+    }
+    else
+        state_machine_post (s, "cleanup-none");
+}
+
+static void action_finalize (struct state_machine *s)
+{
+    if (runat_is_defined (s->ctx->runat, "rc3")) {
+        if (runat_start (s->ctx->runat, "rc3", runat_completion_cb, s) < 0) {
+            flux_log_error (s->ctx->h, "runat_start rc3");
+            state_machine_post (s, "rc3-fail");
+        }
+    }
+    else
+        state_machine_post (s, "rc3-none");
+}
+
+static void action_shutdown (struct state_machine *s)
+{
+    shutdown_instance (s->ctx->shutdown);
+}
+
+void state_machine_post (struct state_machine *s, const char *event)
 {
     broker_state_t next_state;
 
-    next_state = state_next (ctx->state, event);
+    next_state = state_next (s->state, event);
 
-    if (next_state != ctx->state) {
-        flux_log (ctx->h,
+    if (next_state != s->state) {
+        flux_log (s->ctx->h,
                   LOG_INFO, "%s: %s->%s",
                   event,
-                  statestr (ctx->state),
+                  statestr (s->state),
                   statestr (next_state));
-        ctx->state = next_state;
-        state_action (ctx, ctx->state);
+        s->state = next_state;
+        state_action (s, s->state);
     }
     else {
-        flux_log (ctx->h,
+        flux_log (s->ctx->h,
                   LOG_INFO,
                   "%s: ignored in %s",
                   event,
-                  statestr (ctx->state));
+                  statestr (s->state));
     }
 }
 
-void state_abort (struct broker *ctx)
+void state_machine_abort (struct state_machine *s)
 {
-    switch (ctx->state) {
+    switch (s->state) {
         case STATE_NONE:
             break;
         case STATE_INIT:
-            (void)runat_abort (ctx->runat, "rc1");
+            (void)runat_abort (s->ctx->runat, "rc1");
             break;
         case STATE_RUN:
-            if (runat_abort (ctx->runat, "rc2") < 0)
-                state_machine (ctx, "rc2-abort-noscript");
+            if (runat_abort (s->ctx->runat, "rc2") < 0)
+                state_machine_post (s, "rc2-abort");
             break;
         case STATE_CLEANUP:
-            (void)runat_abort (ctx->runat, "cleanup");
+            (void)runat_abort (s->ctx->runat, "cleanup");
             break;
         case STATE_FINALIZE:
-            (void)runat_abort (ctx->runat, "rc3");
+            (void)runat_abort (s->ctx->runat, "rc3");
             break;
         case STATE_SHUTDOWN:
             break;
@@ -144,7 +200,7 @@ void state_abort (struct broker *ctx)
 
 static void runat_completion_cb (struct runat *r, const char *name, void *arg)
 {
-    broker_ctx_t *ctx = arg;
+    struct state_machine *s = arg;
     int rc = 1;
 
     if (runat_get_exit_code (r, name, &rc) < 0)
@@ -152,24 +208,45 @@ static void runat_completion_cb (struct runat *r, const char *name, void *arg)
 
     if (!strcmp (name, "rc1")) {
         if (rc != 0)
-            ctx->exit_rc = rc;
-        state_machine (ctx, rc == 0 ? "rc1-success" : "rc1-fail");
+            s->ctx->exit_rc = rc;
+        state_machine_post (s, rc == 0 ? "rc1-success" : "rc1-fail");
     }
     else if (!strcmp (name, "rc2")) {
         if (rc != 0)
-            ctx->exit_rc = rc;
-        state_machine (ctx, rc == 0 ? "rc2-success" : "rc2-fail");
+            s->ctx->exit_rc = rc;
+        state_machine_post (s, rc == 0 ? "rc2-success" : "rc2-fail");
     }
     else if (!strcmp (name, "cleanup")) {
         if (rc != 0)
-            ctx->exit_rc = rc;
-        state_machine (ctx, rc == 0 ? "cleanup-success" : "cleanup-fail");
+            s->ctx->exit_rc = rc;
+        state_machine_post (s, rc == 0 ? "cleanup-success" : "cleanup-fail");
     }
     else if (!strcmp (name, "rc3")) {
         if (rc != 0)
-            ctx->exit_rc = rc;
-        state_machine (ctx, rc == 0 ? "rc3-success" : "rc3-fail");
+            s->ctx->exit_rc = rc;
+        state_machine_post (s, rc == 0 ? "rc3-success" : "rc3-fail");
     }
+}
+
+void state_machine_destroy (struct state_machine *s)
+{
+    if (s) {
+        int saved_errno = errno;
+        free (s);
+        errno = saved_errno;
+    }
+}
+
+struct state_machine *state_machine_create (struct broker *ctx)
+{
+    struct state_machine *s;
+
+    if (!(s = calloc (1, sizeof (*s))))
+        return NULL;
+    s->ctx = ctx;
+    s->state = STATE_NONE;
+
+    return s;
 }
 
 /*

--- a/src/broker/state_machine.h
+++ b/src/broker/state_machine.h
@@ -32,7 +32,7 @@ broker_state_t state_machine_get_state (struct state_machine *s);
 
 void state_machine_shutdown (struct state_machine *s);
 
-void state_machine_abort (struct state_machine *s);
+void state_machine_kill (struct state_machine *s, int signum);
 
 #endif /* !_BROKER_STATE_MACHINE_H */
 

--- a/src/broker/state_machine.h
+++ b/src/broker/state_machine.h
@@ -22,9 +22,17 @@ typedef enum {
     STATE_SHUTDOWN,
 } broker_state_t;
 
-void state_machine (struct broker *ctx, const char *event);
 
-void state_abort (struct broker *ctx);
+struct state_machine *state_machine_create (struct broker *ctx);
+void state_machine_destroy (struct state_machine *s);
+
+void state_machine_post (struct state_machine *s, const char *event);
+
+broker_state_t state_machine_get_state (struct state_machine *s);
+
+void state_machine_shutdown (struct state_machine *s);
+
+void state_machine_abort (struct state_machine *s);
 
 #endif /* !_BROKER_STATE_MACHINE_H */
 

--- a/src/broker/test/runat.c
+++ b/src/broker/test/runat.c
@@ -75,9 +75,17 @@ void basic (flux_t *h)
 
     /* run true;true */
     clear_list (logs);
+    ok (runat_is_defined (r, "test1") == false,
+        "runat_is_defined name=test1 returns false");
+    ok (runat_is_completed (r, "test1") == false,
+        "runat_is_completed name=test1 returns false");
     ok (runat_push_shell_command (r, "test1", "/bin/true", false) == 0
         && runat_push_shell_command (r, "test1", "/bin/true", false) == 0,
         "pushed true;true");
+    ok (runat_is_defined (r, "test1") == true,
+        "runat_is_defined name=test1 returns true after creation");
+    ok (runat_is_completed (r, "test1") == false,
+        "runat_is_completed returns false");
     ok (runat_start (r, "test1") == 0,
         "runat_start works");
     completion_called = 0;
@@ -89,6 +97,8 @@ void basic (flux_t *h)
         "exit code is zero");
     ok (match_list (logs, "Exited") == 2,
         "Exited was logged twice");
+    ok (runat_is_completed (r, "test1") == true,
+        "runat_is_completed returns true");
 
     /* run false;true */
     clear_list (logs);
@@ -236,6 +246,15 @@ void badinput (flux_t *h)
 
     if (!(r = runat_create (h, NULL, NULL, NULL)))
         BAIL_OUT ("runat_create failed");
+
+    ok (runat_is_defined (NULL, "foo") == false,
+        "runat_is_defined r=NULL returns false");
+    ok (runat_is_defined (r, NULL) == false,
+        "runat_is_defined name=NULL returns false");
+    ok (runat_is_completed (NULL, "foo") == false,
+        "runat_is_completed r=NULL returns false");
+    ok (runat_is_completed (r, NULL) == false,
+        "runat_is_completed name=NULL returns false");
 
     errno = 0;
     ok (runat_start (NULL, "foo") < 0 && errno == EINVAL,

--- a/src/broker/test/runat.c
+++ b/src/broker/test/runat.c
@@ -69,7 +69,7 @@ void basic (flux_t *h)
 
     ctx.h = h;
 
-    r = runat_create (h, "local://notreally", test_completion, &ctx);
+    r = runat_create (h, "local://notreally");
     ok (r != NULL,
         "runat_create works");
 
@@ -86,7 +86,7 @@ void basic (flux_t *h)
         "runat_is_defined name=test1 returns true after creation");
     ok (runat_is_completed (r, "test1") == false,
         "runat_is_completed returns false");
-    ok (runat_start (r, "test1") == 0,
+    ok (runat_start (r, "test1", test_completion, &ctx) == 0,
         "runat_start works");
     completion_called = 0;
     ok (flux_reactor_run (flux_get_reactor (h), 0) >= 0
@@ -105,7 +105,7 @@ void basic (flux_t *h)
     ok (runat_push_shell_command (r, "test2", "/bin/true", false) == 0
         && runat_push_shell_command (r, "test2", "/bin/false", false) == 0,
         "pushed true;true");
-    ok (runat_start (r, "test2") == 0,
+    ok (runat_start (r, "test2", test_completion, &ctx) == 0,
         "runat_start works");
     completion_called = 0;
     ok (flux_reactor_run (flux_get_reactor (h), 0) >= 0
@@ -123,7 +123,7 @@ void basic (flux_t *h)
     ok (runat_push_command (r, "test3", "/bin/false", 11, false) == 0
         && runat_push_command (r, "test3", "/bin/true", 10, false) == 0,
         "pushed true;true");
-    ok (runat_start (r, "test3") == 0,
+    ok (runat_start (r, "test3", test_completion, &ctx) == 0,
         "runat_start works");
     completion_called = 0;
     ok (flux_reactor_run (flux_get_reactor (h), 0) >= 0
@@ -141,7 +141,7 @@ void basic (flux_t *h)
     ok (runat_push_shell_command (r, "test4", "echo test4-out", true) == 0
     && runat_push_shell_command (r, "test4", "echo test4-err>&2", true) == 0,
         "pushed echo;echo");
-    ok (runat_start (r, "test4") == 0,
+    ok (runat_start (r, "test4", test_completion, &ctx) == 0,
         "runat_start works");
     completion_called = 0;
     ok (flux_reactor_run (flux_get_reactor (h), 0) >= 0
@@ -162,7 +162,7 @@ void basic (flux_t *h)
     ok (runat_push_shell_command (r, "test5", "echo test5-out", true) == 0
         && runat_push_shell_command (r, "test5", "notfound", false) == 0,
         "pushed notfound;echo");
-    ok (runat_start (r, "test5") == 0,
+    ok (runat_start (r, "test5", test_completion, &ctx) == 0,
         "runat_start works");
     completion_called = 0;
     ok (flux_reactor_run (flux_get_reactor (h), 0) >= 0
@@ -180,7 +180,7 @@ void basic (flux_t *h)
     clear_list (logs);
     ok (runat_push_shell_command (r, "test6", "printenv FLUX_URI", true) == 0,
         "pushed printenv FLUX_URI");
-    ok (runat_start (r, "test6") == 0,
+    ok (runat_start (r, "test6", test_completion, &ctx) == 0,
         "runat_start works");
     completion_called = 0;
     ok (flux_reactor_run (flux_get_reactor (h), 0) >= 0
@@ -202,7 +202,7 @@ void basic (flux_t *h)
     ok (runat_push_shell_command (r, "test7", "/bin/true", false) == 0
             && runat_push_shell_command (r, "test7", "sleep 3600", false) == 0,
         "pushed /bin/true;sleep 3600");
-    ok (runat_start (r, "test7") == 0,
+    ok (runat_start (r, "test7", test_completion, &ctx) == 0,
         "runat_start works");
     ok (runat_abort (r, "test7") == 0,
         "runat_abort works");
@@ -244,7 +244,7 @@ void badinput (flux_t *h)
     struct runat *r;
     int rc;
 
-    if (!(r = runat_create (h, NULL, NULL, NULL)))
+    if (!(r = runat_create (h, NULL)))
         BAIL_OUT ("runat_create failed");
 
     ok (runat_is_defined (NULL, "foo") == false,
@@ -257,13 +257,13 @@ void badinput (flux_t *h)
         "runat_is_completed name=NULL returns false");
 
     errno = 0;
-    ok (runat_start (NULL, "foo") < 0 && errno == EINVAL,
+    ok (runat_start (NULL, "foo", NULL, NULL) < 0 && errno == EINVAL,
         "runat_start r=NULL fails with EINVAL");
     errno = 0;
-    ok (runat_start (r, NULL) < 0 && errno == EINVAL,
+    ok (runat_start (r, NULL, NULL, NULL) < 0 && errno == EINVAL,
         "runat_start name=NULL fails with EINVAL");
     errno = 0;
-    ok (runat_start (r, "noexit") < 0 && errno == ENOENT,
+    ok (runat_start (r, "noexit", NULL, NULL) < 0 && errno == ENOENT,
         "runat_start name=noexist fails with ENOENT");
 
     errno = 0;

--- a/t/rc/rc1-job
+++ b/t/rc/rc1-job
@@ -19,9 +19,9 @@ flux exec -r all flux module load kvs-watch
 flux module load job-manager
 flux module load job-ingest
 
-flux exec -r all -x 0 flux module load job-ingest & pids="$pids $!"
-flux module load job-info & pids="$pids $!"
-flux exec -r all flux module load barrier & pids="$pids $!"
+flux exec -r all -x 0 flux module load job-ingest
+flux module load job-info
+flux exec -r all flux module load barrier
 
 # Load a fake resource.hwloc.by_rank key for sched-simple
 set_fake_hwloc_by_rank ${TEST_UNDER_FLUX_CORES_PER_RANK:-2}


### PR DESCRIPTION
Here are some commits peeled off of #3057 that don't functionally change anything about how the broker bootstraps.  The primary component of this PR is the state machine refactor, in which it gets a more abstract interface, and internally becomes table-driven and reactive.  There are some other minor changes to the `runat` class, the broker's "global context", and couple other minor bits.

I thought peeling this off might decrease the complexity of #3057 a bit and make it easier to review.