### PR TITLE
Use F58 as the default representation for JOBIDs in most user-facing commands

### DIFF
--- a/src/bindings/python/flux/job.py
+++ b/src/bindings/python/flux/job.py
@@ -137,6 +137,11 @@ class JobID(int):
         return id_encode(self, encoding)
 
     @property
+    def dec(self):
+        """Return decimal integer representation of a JobID"""
+        return self.encode()
+
+    @property
     def f58(self):
         """Return RFC19 F58 representation of a JobID"""
         return self.encode("f58")
@@ -165,7 +170,7 @@ class JobID(int):
         return self.encode()
 
     def __repr__(self):
-        return f"JobID({self})"
+        return f"JobID({self.dec})"
 
 
 class SubmitFuture(Future):

--- a/src/bindings/python/flux/job.py
+++ b/src/bindings/python/flux/job.py
@@ -167,7 +167,7 @@ class JobID(int):
         return self.encode("kvs")
 
     def __str__(self):
-        return self.encode()
+        return self.encode("f58")
 
     def __repr__(self):
         return f"JobID({self.dec})"

--- a/src/bindings/python/flux/job.py
+++ b/src/bindings/python/flux/job.py
@@ -49,7 +49,7 @@ def _convert_jobspec_arg_to_string(jobspec):
     if isinstance(jobspec, Jobspec):
         jobspec = jobspec.dumps()
     elif isinstance(jobspec, six.text_type):
-        jobspec = jobspec.encode("utf-8")
+        jobspec = jobspec.encode("utf-8", errors="surrogateescape")
     elif jobspec is None or jobspec == ffi.NULL:
         # catch this here rather than in C for a better error message
         raise EnvironmentError(errno.EINVAL, "jobspec must not be None/NULL")
@@ -986,7 +986,7 @@ class Jobspec(object):
         self.setattr("system.shell.options." + key, val)
 
     def dumps(self, **kwargs):
-        return json.dumps(self.jobspec, **kwargs)
+        return json.dumps(self.jobspec, ensure_ascii=False, **kwargs)
 
     @property
     def resources(self):

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -2288,20 +2288,28 @@ int cmd_id (optparse_t *p, int argc, char **argv)
     int optindex = optparse_option_index (p);
     char dst[256];
 
+    /*  Require at least one id to be processed for success.
+     *  Thus, `flux job id` with no input or args will exit with
+     *   non-zero exit code.
+     */
+    int rc = -1;
+
     if (optindex == argc) {
         char src[256];
         while ((fgets (src, sizeof (src), stdin))) {
             id_convert (p, trim_string (src), dst, sizeof (dst));
             printf ("%s\n", dst);
+            rc = 0;
         }
     }
     else {
         while (optindex < argc) {
             id_convert (p, argv[optindex++], dst, sizeof (dst));
             printf ("%s\n", dst);
+            rc = 0;
         }
     }
-    return 0;
+    return rc;
 }
 
 static void print_job_namespace (const char *src)

--- a/src/cmd/flux-jobs.py
+++ b/src/cmd/flux-jobs.py
@@ -346,6 +346,7 @@ def fetch_jobs_flux(args, fields):
     # Note there is no attr for "id", its always returned
     fields2attrs = {
         "id": (),
+        "id.dec": (),
         "id.hex": (),
         "id.f58": (),
         "id.kvs": (),
@@ -608,6 +609,7 @@ class JobsOutputFormat(flux.util.OutputFormat):
     #  List of legal format fields and their header names
     headings = {
         "id": "JOBID",
+        "id.dec": "JOBID",
         "id.hex": "JOBID",
         "id.f58": "JOBID",
         "id.kvs": "JOBID",

--- a/src/cmd/flux-mini.py
+++ b/src/cmd/flux-mini.py
@@ -8,8 +8,6 @@
 # SPDX-License-Identifier: LGPL-3.0
 ##############################################################
 
-from __future__ import print_function
-
 # pylint: disable=duplicate-code
 import os
 import sys
@@ -487,8 +485,12 @@ LOGGER = logging.getLogger("flux-mini")
 @util.CLIMain(LOGGER)
 def main():
 
-    sys.stdout = open(sys.stdout.fileno(), "w", encoding="utf8")
-    sys.stderr = open(sys.stderr.fileno(), "w", encoding="utf8")
+    sys.stdout = open(
+        sys.stdout.fileno(), "w", encoding="utf8", errors="surrogateescape"
+    )
+    sys.stderr = open(
+        sys.stderr.fileno(), "w", encoding="utf8", errors="surrogateescape"
+    )
 
     parser = argparse.ArgumentParser(prog="flux-mini")
     subparsers = parser.add_subparsers(

--- a/src/cmd/flux-mini.py
+++ b/src/cmd/flux-mini.py
@@ -20,7 +20,7 @@ from itertools import chain
 
 import flux
 from flux import job
-from flux.job import JobspecV1
+from flux.job import JobspecV1, JobID
 from flux import util
 from flux import debugged
 
@@ -203,13 +203,14 @@ class MiniCmd:
             sys.exit(0)
 
         flux_handle = flux.Flux()
-        return job.submit(
+        jobid = job.submit(
             flux_handle,
             jobspec.dumps(),
             priority=args.priority,
             waitable=arg_waitable,
             debug=arg_debug,
         )
+        return JobID(jobid)
 
     def get_parser(self):
         return self.parser
@@ -310,7 +311,7 @@ class RunCmd(SubmitCmd):
             attach_args.append("--show-exec")
         if args.debug_emulate:
             attach_args.append("--debug-emulate")
-        attach_args.append(str(jobid))
+        attach_args.append(jobid.f58.encode("utf-8", errors="surrogateescape"))
 
         # Exec flux-job attach, searching for it in FLUX_EXEC_PATH.
         os.environ["PATH"] = os.environ["FLUX_EXEC_PATH"] + ":" + os.environ["PATH"]
@@ -473,7 +474,7 @@ class AllocCmd(MiniCmd):
 
         # Build args for flux job attach
         attach_args = ["flux-job", "attach"]
-        attach_args.append(str(jobid))
+        attach_args.append(jobid.f58.encode("utf-8", errors="surrogateescape"))
 
         # Exec flux-job attach, searching for it in FLUX_EXEC_PATH.
         os.environ["PATH"] = os.environ["FLUX_EXEC_PATH"] + ":" + os.environ["PATH"]
@@ -485,6 +486,10 @@ LOGGER = logging.getLogger("flux-mini")
 
 @util.CLIMain(LOGGER)
 def main():
+
+    sys.stdout = open(sys.stdout.fileno(), "w", encoding="utf8")
+    sys.stderr = open(sys.stderr.fileno(), "w", encoding="utf8")
+
     parser = argparse.ArgumentParser(prog="flux-mini")
     subparsers = parser.add_subparsers(
         title="supported subcommands", description="", dest="subcommand"

--- a/src/common/libschedutil/init.c
+++ b/src/common/libschedutil/init.c
@@ -48,7 +48,8 @@ schedutil_t *schedutil_create (flux_t *h,
     util->free_cb = free_cb;
     util->cancel_cb = cancel_cb;
     util->cb_arg = cb_arg;
-    if ((util->outstanding_futures = zlistx_new ()) == NULL)
+    if (!(util->outstanding_futures = zlistx_new ())
+        || !(util->alloc_queue = zlistx_new ()))
         goto error;
     if (schedutil_ops_register (util) < 0)
         goto error;
@@ -92,6 +93,7 @@ void schedutil_destroy (schedutil_t *util)
         int saved_errno = errno;
         respond_to_outstanding_msgs (util);
         zlistx_destroy (&util->outstanding_futures);
+        zlistx_destroy (&util->alloc_queue);
         schedutil_ops_unregister (util);
         free (util);
         errno = saved_errno;
@@ -118,6 +120,30 @@ int schedutil_remove_outstanding_future (schedutil_t *util, flux_future_t *fut)
     if (zlistx_detach_cur (util->outstanding_futures) == NULL)
         return -1;
     return 0;
+}
+
+int schedutil_enqueue_alloc (schedutil_t *util, flux_future_t *f)
+{
+    if (schedutil_add_outstanding_future (util, f) < 0
+        || zlistx_add_end (util->alloc_queue, f) == NULL)
+        return -1;
+    return 0;
+}
+
+flux_future_t *schedutil_peek_alloc (schedutil_t *util)
+{
+    return zlistx_first (util->alloc_queue);
+}
+
+int schedutil_dequeue_alloc (schedutil_t *util)
+{
+    flux_future_t *f = zlistx_first (util->alloc_queue);
+    if (f) {
+        if (!zlistx_detach_cur (util->alloc_queue))
+            return -1;
+        return schedutil_remove_outstanding_future (util, f);
+    }
+    return -1;
 }
 
 /*

--- a/src/common/libschedutil/schedutil_private.h
+++ b/src/common/libschedutil/schedutil_private.h
@@ -25,6 +25,7 @@ struct schedutil_ctx {
     schedutil_cancel_cb_f *cancel_cb;
     void *cb_arg;
     zlistx_t *outstanding_futures;
+    zlistx_t *alloc_queue;
 };
 
 /*
@@ -37,6 +38,14 @@ struct schedutil_ctx {
 int schedutil_add_outstanding_future (schedutil_t *util, flux_future_t *fut);
 int schedutil_remove_outstanding_future (schedutil_t *util,
                                          flux_future_t *fut);
+
+/* Enqueue and dequeue pending alloc requests while they are waiting on
+ *  async operations to complete. Ensures alloc callback of scheduler is
+ *  called in the same order as alloc requests recvd by schedutil.
+ */
+int schedutil_enqueue_alloc (schedutil_t *util, flux_future_t *f);
+flux_future_t *schedutil_peek_alloc (schedutil_t *util);
+int schedutil_dequeue_alloc (schedutil_t *util);
 
 /* (Un-)register callbacks for alloc, free, cancel.
  */

--- a/src/shell/pmi.c
+++ b/src/shell/pmi.c
@@ -443,7 +443,17 @@ static struct shell_pmi *pmi_create (flux_shell_t *shell)
     if (!(pmi = calloc (1, sizeof (*pmi))))
         return NULL;
     pmi->shell = shell;
-    snprintf (kvsname, sizeof (kvsname), "%ju", (uintmax_t)shell->jobid);
+
+    /* Use F58 representation of jobid for "kvsname", since the broker
+     * will pull the kvsname and use it as the broker 'jobid' attribute.
+     * This allows the broker attribute to be in the "common" user-facing
+     * jobid representation.
+     */
+    if (flux_job_id_encode (shell->jobid,
+                            "f58",
+                            kvsname,
+                            sizeof (kvsname)) < 0)
+        goto error;
     if (!(pmi->server = pmi_simple_server_create (shell_pmi_ops,
                                                   0, // appnum
                                                   info->total_ntasks,

--- a/t/job-manager/sched-helper.sh
+++ b/t/job-manager/sched-helper.sh
@@ -12,7 +12,7 @@ JMGR_JOB_LIST=${FLUX_BUILD_DIR}/t/job-manager/list-jobs
 #
 # arg1 - jobid
 _jmgr_get_state() {
-        local id=$1
+        local id=$(flux job id $1)
         local state=$(${JMGR_JOB_LIST} | awk '$1 == "'${id}'" { print $2; }')
         test -z "$state" \
                 && flux job wait-event --timeout=5 ${id} clean >/dev/null \
@@ -41,7 +41,7 @@ jmgr_check_state() {
 # arg1 - jobid
 # arg2 - key
 _jmgr_get_annotation() {
-        local id=$1
+        local id=$(flux job id $1)
         local key=$2
         local note="$(${JMGR_JOB_LIST} | grep ${id} | cut -f 6- | jq ."${key}")"
         echo $note
@@ -75,7 +75,7 @@ jmgr_check_annotation() {
 #
 # callers should set HAVE_JQ requirement
 jmgr_check_annotation_exists() {
-        local id=$1
+        local id=$(flux job id $1)
         local key=$2
         ${JMGR_JOB_LIST} | grep ${id} | cut -f 6- | jq -e ."${key}" > /dev/null
 }
@@ -84,7 +84,7 @@ jmgr_check_annotation_exists() {
 #
 # arg1 - jobid
 jmgr_check_no_annotations() {
-        local id=$1
+        local id=$(flux job id $1)
         test -z "$(${JMGR_JOB_LIST} | grep ${id} | cut -f 6-)" && return 0
         return 1
 }
@@ -94,7 +94,7 @@ jmgr_check_no_annotations() {
 # arg1 - jobid
 # arg2 - key
 _jinfo_get_annotation() {
-        local id=$1
+        local id=$(flux job id $1)
         local key=$2
         local note="$(flux job list -A | grep ${id} | jq .annotations | jq ."${key}")"
         echo $note
@@ -127,7 +127,7 @@ jinfo_check_annotation() {
 #
 # callers should set HAVE_JQ requirement
 jinfo_check_no_annotations() {
-        local id=$1
+        local id=$(flux job id $1)
         flux job list -A | grep ${id} | jq -e .annotations > /dev/null && return 1
         return 0
 }
@@ -139,7 +139,7 @@ jinfo_check_no_annotations() {
 #
 # callers should set HAVE_JQ requirement
 jinfo_check_annotation_exists() {
-        local id=$1
+        local id=$(flux job id $1)
         local key=$2
         flux job list -A | grep ${id} | jq .annotations | jq -e ."${key}" > /dev/null
 }
@@ -153,7 +153,7 @@ jinfo_check_annotation_exists() {
 # arg2 - key in annotation
 # arg3 - value of key in annotation
 fjobs_check_annotation() {
-        local id=$1
+        local id=$(flux job id $1)
         local key=$2
         local value="$3"
         for try in $(seq 1 10); do

--- a/t/t2200-job-ingest.t
+++ b/t/t2200-job-ingest.t
@@ -115,7 +115,7 @@ test_expect_success 'job-ingest: jobspec stored accurately in KVS' '
 '
 
 test_expect_success 'job-ingest: job announced to job manager' '
-	jobid=$(flux job submit --priority=10 basic.json) &&
+	jobid=$(flux job submit --priority=10 basic.json | flux job id) &&
 	flux kvs eventlog get ${DUMMY_EVENTLOG} \
 		| grep "\"id\":${jobid}" >jobman.out &&
 	grep -q "\"priority\":10" jobman.out &&

--- a/t/t2201-job-cmd.t
+++ b/t/t2201-job-cmd.t
@@ -259,7 +259,7 @@ test_expect_success 'flux-job: attach fails without jobid argument' '
 '
 
 test_expect_success 'flux-job: attach fails on invalid jobid' '
-	test_must_fail flux job attach $((${validjob}+1))
+	test_must_fail flux job attach $(($(flux job id ${validjob})+1))
 '
 
 test_expect_success 'flux-job: kill fails without jobid argument' '
@@ -267,7 +267,7 @@ test_expect_success 'flux-job: kill fails without jobid argument' '
 '
 
 test_expect_success 'flux-job: kill fails on invalid jobid' '
-	test_expect_code 1 flux job kill $((${validjob}+1))
+	test_expect_code 1 flux job kill $(($(flux job id ${validjob})+1))
 '
 
 test_expect_success 'flux-job: kill fails on non-running job' '

--- a/t/t2201-job-cmd.t
+++ b/t/t2201-job-cmd.t
@@ -103,6 +103,10 @@ test_expect_success 'flux-job: id with invalid --to arg fails' '
 	test_must_fail flux job id --to=invalid 42
 '
 
+test_expect_success 'flux-job: fails with no input and no args' '
+	test_expect_code 1 flux job id < /dev/null
+'
+
 test_expect_success 'flux-job: id works with min/max jobids' '
     for max in $MAXJOBIDS_LIST; do
         jobid=$(flux job id $max) &&

--- a/t/t2202-job-manager.t
+++ b/t/t2202-job-manager.t
@@ -28,7 +28,7 @@ test_expect_success HAVE_JQ 'job-manager: max_jobid=0 before jobs run' '
 '
 
 test_expect_success 'job-manager: submit one job' '
-	flux job submit basic.json >submit1.out
+	flux job submit basic.json | flux job id >submit1.out
 '
 
 test_expect_success HAVE_JQ 'job-manager: max_jobid=last' '
@@ -97,9 +97,9 @@ test_expect_success 'job-manager: queue contains 0 jobs' '
 '
 
 test_expect_success 'job-manager: submit jobs with priority=min,default,max' '
-	flux job submit -p0  basic.json >submit_min.out &&
-	flux job submit      basic.json >submit_def.out &&
-	flux job submit -p31 basic.json >submit_max.out
+	flux job submit -p0  basic.json | flux job id >submit_min.out &&
+	flux job submit      basic.json | flux job id >submit_def.out &&
+	flux job submit -p31 basic.json | flux job id >submit_max.out
 '
 
 test_expect_success 'job-manager: queue contains 3 jobs' '
@@ -139,7 +139,7 @@ test_expect_success 'job-manager: queue contains 0 jobs' '
 test_expect_success 'job-manager: submit 10 jobs of equal priority' '
 	rm -f submit10.out &&
 	for i in $(seq 1 10); do \
-	    flux job submit basic.json >>submit10.out; \
+	    flux job submit basic.json | flux job id >>submit10.out; \
 	done
 '
 

--- a/t/t2203-job-manager-dummysched-single.t
+++ b/t/t2203-job-manager-dummysched-single.t
@@ -140,8 +140,8 @@ test_expect_success 'job-manager: reload sched-dummy --cores=4' '
 '
 
 test_expect_success 'job-manager: hello handshake found jobs 1 3' '
-        grep id=$(cat job1.id) hello.dmesg &&
-        grep id=$(cat job3.id) hello.dmesg
+        grep id=$(flux job id < job1.id) hello.dmesg &&
+        grep id=$(flux job id < job3.id) hello.dmesg
 '
 
 test_expect_success 'job-manager: hello handshake priority is default' '

--- a/t/t2220-job-archive.t
+++ b/t/t2220-job-archive.t
@@ -17,7 +17,7 @@ fj_wait_event() {
 }
 
 wait_jobid_state() {
-        local jobid=$1
+        local jobid=$(flux job id $1)
         local state=$2
         local i=0
         while ! flux job list --states=${state} | grep $jobid > /dev/null \
@@ -34,7 +34,7 @@ wait_jobid_state() {
 }
 
 wait_db() {
-        local jobid=$1
+        local jobid=$(flux job id $1)
         local dbpath=$2
         local i=0
         query="select id from jobs;"
@@ -59,7 +59,7 @@ db_count_entries() {
 }
 
 db_check_entries() {
-        local id=$1
+        local id=$(flux job id $1)
         local dbpath=$2
         query="select * from jobs where id=$id;"
         ${QUERYCMD} -t 10000 ${dbpath} "${query}" > query.out
@@ -81,7 +81,7 @@ db_check_entries() {
 }
 
 get_db_values() {
-        local id=$1
+        local id=$(flux job id $1)
         local dbpath=$2
         query="select * from jobs where id=$id;"
         ${QUERYCMD} -t 10000 ${dbpath} "${query}" > query.out
@@ -98,7 +98,7 @@ get_db_values() {
 }
 
 db_check_values_run() {
-        local id=$1
+        local id=$(flux job id $1)
         local dbpath=$2
         get_db_values $id $dbpath
         if [ -z "$userid" ] \
@@ -118,7 +118,7 @@ db_check_values_run() {
 }
 
 db_check_values_no_run() {
-        local id=$1
+        local id=$(flux job id $1)
         local dbpath=$2
         get_db_values $id $dbpath
         if [ -z "$userid" ] \

--- a/t/t2401-job-exec-hello.t
+++ b/t/t2401-job-exec-hello.t
@@ -20,7 +20,7 @@ test_expect_success NO_CHAIN_LINT 'exec hello: start exec server-in-a-script' '
 	id=$(flux jobspec srun hostname | flux job submit --flags=debug) &&
 	flux job wait-event ${id} clean &&
 	test_debug "cat server1.log" &&
-	grep "start: ${id}" server1.log
+	grep "start: $(flux job id ${id})" server1.log
 '
 test_expect_success NO_CHAIN_LINT 'exec hello: takeover: start new service' '
 	${execservice} test-exec2 > server2.log &
@@ -28,7 +28,7 @@ test_expect_success NO_CHAIN_LINT 'exec hello: takeover: start new service' '
 	flux kvs get -c 1 --watch --waitcreate test.exec-hello.test-exec2 &&
 	id=$(flux jobspec srun hostname | flux job submit --flags=debug) &&
 	flux job wait-event ${id} clean &&
-	grep "start: ${id}" server2.log
+	grep "start: $(flux job id ${id})" server2.log
 '
 test_expect_success NO_CHAIN_LINT 'exec hello: teardown existing servers' "
 	kill -9 ${SERVER1} && kill -9 ${SERVER2} &&
@@ -51,7 +51,7 @@ test_expect_success NO_CHAIN_LINT 'exec hello: start server with job timer' '
 test_expect_success NO_CHAIN_LINT 'exec hello: paused job now has start event' '
 	flux job wait-event -t 2 ${id} start &&
 	test_debug "cat server3.log" &&
-	grep "test-exec3: start: ${id}" server3.log
+	grep "test-exec3: start: $(flux job id ${id})" server3.log
 '
 test_expect_success NO_CHAIN_LINT 'exec hello: hello now returns error due to running job' '
 	test_expect_code 1 run_timeout 5 ${execservice} testexecfoo

--- a/t/t2402-job-exec-dummy.t
+++ b/t/t2402-job-exec-dummy.t
@@ -38,7 +38,7 @@ test_expect_success 'job-exec: job shell output sent to flux log' '
 	id=$(flux jobspec srun -n 1 "echo Hello from job \$JOBID" \
 	     | flux job submit) &&
 	flux job wait-event $id clean &&
-	flux dmesg | grep "Hello from job $id"
+	flux dmesg | grep "Hello from job $(flux job id $id)"
 '
 test_expect_success 'job-exec: job shell failure recorded' '
 	id=$(flux jobspec srun -N4  "test \$JOB_SHELL_RANK = 0 && exit 1" \
@@ -76,7 +76,7 @@ test_expect_success 'job-exec: job exception uses SIGKILL after kill-timeout' '
 		trap-ready &&
 	flux job cancel $id &&
 	sleep 0.2 &&
-	flux dmesg | grep $id &&
+	flux dmesg | grep $(flux job id $id) &&
 	flux job wait-event -vt 5 $id clean &&
 	flux dmesg | grep "trap-sigterm got SIGTERM" &&
 	flux module reload job-exec

--- a/t/t2404-job-exec-multiuser.t
+++ b/t/t2404-job-exec-multiuser.t
@@ -47,7 +47,7 @@ test_expect_success HAVE_JQ 'job-exec: job as guest tries to run IMP' '
 	flux job attach ${id} &&
 	flux job list-ids ${id} > ${id}.json &&
 	jq -e ".userid == 42" < ${id}.json &&
-	flux dmesg | grep "test-imp: Running.*${id}"
+	flux dmesg | grep "test-imp: Running.*$(flux job id ${id})"
 '
 
 test_expect_success HAVE_JQ 'job-exec: kill multiuser job uses the IMP' '

--- a/t/t2601-job-shell-standalone.t
+++ b/t/t2601-job-shell-standalone.t
@@ -99,7 +99,8 @@ test_expect_success 'flux-shell: 1: FLUX_TASK_LOCAL_ID, TASK_RANK set' '
 test_expect_success 'flux-shell: FLUX_JOB_SIZE, JOB_NNODES, JOB_ID set' '
 	grep FLUX_JOB_SIZE=2 printenv.out &&
 	grep FLUX_JOB_NNODES=1 printenv.out &&
-	grep FLUX_JOB_ID=42 printenv.out
+	(grep FLUX_JOB_ID=$(flux job id --to=f58 42) printenv.out ||
+	 grep FLUX_JOB_ID=42 printenv.out)
 '
 test_expect_success 'flux-shell: FLUX_URI is not set by shell' '
 	test_must_fail grep FLUX_URI printenv.out

--- a/t/t2602-job-shell.t
+++ b/t/t2602-job-shell.t
@@ -182,7 +182,7 @@ test_expect_success 'job-shell: test shell kill event handling: numeric signal' 
 	grep status=$((2+128<<8)) kill3.finish.out
 '
 test_expect_success 'job-shell: mangled shell kill event logged' '
-	id=$(flux jobspec srun -N4 sleep 60 | flux job submit) &&
+	id=$(flux jobspec srun -N4 sleep 60 | flux job submit | flux job id) &&
 	flux job wait-event $id start &&
 	flux event pub shell-${id}.kill "{}" &&
 	flux job kill ${id} &&
@@ -192,7 +192,7 @@ test_expect_success 'job-shell: mangled shell kill event logged' '
 	grep "ignoring malformed event" kill4.log
 '
 test_expect_success 'job-shell: shell kill event: kill(2) failure logged' '
-	id=$(flux jobspec srun -N4 sleep 60 | flux job submit) &&
+	id=$(flux jobspec srun -N4 sleep 60 | flux job submit | flux job id) &&
 	flux job wait-event $id start &&
 	flux event pub shell-${id}.kill "{\"signum\":199}" &&
 	flux job kill ${id} &&

--- a/t/t2606-job-shell-output-redirection.t
+++ b/t/t2606-job-shell-output-redirection.t
@@ -150,7 +150,8 @@ test_expect_success 'job-shell: run 2-task echo job (stdout kvs/stderr file)' '
 test_expect_success 'job-shell: run 1-task echo job (mustache id stdout file/stderr file)' '
         id=$(flux mini submit -n1 \
              --output="out{{id}}" --error="err{{id}}" \
-             ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz) &&
+             ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz \
+             | flux job id) &&
         flux job wait-event $id clean &&
         grep stdout:baz out${id} &&
         grep stderr:baz err${id}
@@ -159,7 +160,8 @@ test_expect_success 'job-shell: run 1-task echo job (mustache id stdout file/std
 test_expect_success 'flux-shell: run 1-task echo job (mustache id stdout & stderr to stdout file)' '
         id=$(flux mini submit -n1 \
              --output="out{{id}}" \
-             ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz) &&
+             ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz \
+             | flux job id) &&
         flux job wait-event $id clean &&
         grep stdout:baz out${id} &&
         grep stderr:baz out${id}

--- a/t/t2612-job-shell-pty.t
+++ b/t/t2612-job-shell-pty.t
@@ -42,12 +42,12 @@ test_expect_success HAVE_JQ 'pty: submit a job with pty' '
 '
 test_expect_success HAVE_JQ,NO_CHAIN_LINT 'pty: run job with pty' '
 	printf "PS1=XXX:\n" >ps1.rc
-	id=$(flux mini submit -o pty bash --rcfile ps1.rc)
+	id=$(flux mini submit -o pty bash --rcfile ps1.rc | flux job id)
 	$runpty -o log.job-pty flux job attach ${id} &
 	pid=$! &&
 	terminus_jobid ${id} list &&
 	$waitfile -t 20 -vp "XXX:" log.job-pty &&
-	printf "printenv FLUX_JOB_ID\r" | terminus_jobid ${id} attach -p 0 &&
+	printf "flux job id \$FLUX_JOB_ID\r" | terminus_jobid ${id} attach -p 0 &&
 	$waitfile -t 20 -vp ${id} log.job-pty &&
 	printf "exit\r\n" | terminus_jobid ${id} attach -p 0 &&
 	$waitfile -t 20 -vp exit log.job-pty &&

--- a/t/t2701-mini-batch.t
+++ b/t/t2701-mini-batch.t
@@ -61,9 +61,9 @@ test_expect_success 'flux-mini batch fails for file without she-bang' '
 	test_expect_code 1 flux mini batch -n1 invalid-script.sh
 '
 test_expect_success 'flux-mini batch: submit a series of jobs' '
-	id1=$(flux mini batch --flags=waitable -n1 batch-script.sh) &&
-	id2=$(flux mini batch --flags=waitable -n4 batch-script.sh) &&
-	id3=$(flux mini batch --flags=waitable -N2 -n4 batch-script.sh) &&
+	id1=$(flux mini batch --flags=waitable -n1 batch-script.sh | flux job id) &&
+	id2=$(flux mini batch --flags=waitable -n4 batch-script.sh | flux job id) &&
+	id3=$(flux mini batch --flags=waitable -N2 -n4 batch-script.sh | flux job id) &&
 	flux job wait --all
 '
 test_expect_success 'flux-mini batch: job results are expected' '
@@ -80,9 +80,9 @@ test_expect_success 'flux-mini batch: --output=kvs directs output to kvs' '
 '
 test_expect_success 'flux-mini batch: --broker-opts works' '
 	id=$(flux mini batch -n1 --flags=waitable \
-	     --broker-opts=-v batch-script.sh) &&
+	     --broker-opts=-v batch-script.sh | flux job id) &&
 	id2=$(flux mini batch -n1 --flags=waitable \
-	     --broker-opts=-v,-H5 batch-script.sh) &&
+	     --broker-opts=-v,-H5 batch-script.sh | flux job id) &&
 	flux job wait $id &&
 	test_debug "cat flux-${id}.out" &&
 	grep "boot: rank=0 size=1" flux-${id}.out &&

--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -66,7 +66,9 @@ wait_states() {
 export FLUX_PYCLI_LOGLEVEL=10
 
 listjobs() {
-	${FLUX_BUILD_DIR}/t/job-manager/list-jobs | awk '{print $1}'
+	${FLUX_BUILD_DIR}/t/job-manager/list-jobs \
+	    | awk '{print $1}' \
+	    | flux job id --to=f58
 }
 
 test_expect_success 'submit jobs for job list testing' '
@@ -338,11 +340,11 @@ test_expect_success 'flux-jobs --format={id} works' '
 '
 
 test_expect_success 'flux-jobs --format={id.f58},{id.hex},{id.dothex},{id.words} works' '
-	flux jobs -ano {id},{id.f58},{id.hex},{id.kvs},{id.dothex},{id.words} \
+	flux jobs -ano {id.dec},{id.f58},{id.hex},{id.kvs},{id.dothex},{id.words} \
 	    | sort -n > ids.XX.out &&
 	for id in $(cat all.ids); do
 		printf "%s,%s,%s,%s,%s,%s\n" \
-		       $id \
+		       $(flux job id --to=dec $id) \
 		       $(flux job id --to=f58 $id) \
 		       $(flux job id --to=hex $id) \
 		       $(flux job id --to=kvs $id) \

--- a/t/t3200-instance-restart.t
+++ b/t/t3200-instance-restart.t
@@ -39,8 +39,8 @@ test_expect_success 'inactive job list contains all jobs run before' '
 '
 
 test_expect_success 'job IDs were issued in ascending order' '
-	test $(cat id1.out) -lt $(cat id2.out) &&
-	test $(cat id2.out) -lt $(cat id3.out)
+	test $(cat id1.out | flux job id) -lt $(cat id2.out | flux job id) &&
+	test $(cat id2.out | flux job id) -lt $(cat id3.out | flux job id)
 '
 
 test_expect_success 'run a job in persistent instance (content-files)' '


### PR DESCRIPTION
This PR updates many user-facing commands to represent JOBIDs in the RFC 19 F58 encoding.

This first required "normalizing" the use of jobids throughout the testsuite, such that tests which assumed integer jobids, or a a common jobid representation between "plumbing" tools (such as `flux job list`) and "porcelain" tools (like `flux jobs`, `flux mini`, etc), would not break. In most spots, the jobids were normalized by passing them to `flux job id`, which can ingest a jobid in any format and will output integer jobid by default.

I will check if any tests break in flux-sched due to these changes and make a similar fix. Since the normalization doesn't require F58 jobid output, the changes to the flux-sched testsuite should not depend on this PR.

Once the the testsuite was prepared, then `flux mini` and `flux job` commands that output JOBIDs were updated to emit F58 by default. This was done for  the Python commands by adjusting the default `__str__` method of the `JobID` class to use the F58 encoding.

Additionally, it was confusing that many `flux job` subcommands could take a JOBID in any encoding, but logging and error messages would always use the integer jobid representation. This is fixed in this branch:

e.g.
```
ƒ(s=4,d=0,builddir) grondo@asp:~/git/flux-core.git$ flux mini submit sleep 30
ƒC55Fpcym
ƒ(s=4,d=0,builddir) grondo@asp:~/git/flux-core.git$ flux mini run -v hostname
jobid: ƒC81PeCgw
asp
ƒ(s=4,d=0,builddir) grondo@asp:~/git/flux-core.git$ flux job kill ƒC81PeCgw
flux-job: kill ƒC81PeCgw: unknown job id

```

Fixes #3109