### PR TITLE
content-s3: add support for different versions of libs3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,19 +78,21 @@ jobs:
       env:
        - TEST_INSTALL=t
        - DOCKER_TAG=t
-    - name: "Centos 7: security,caliper,docker-deploy"
+    - name: "Centos 7: security,caliper,enable-content-s3,docker-deploy"
       stage: test
       compiler: gcc
       env:
        - IMG=centos7
        - DOCKER_TAG=t
-    - name: "Centos 8: security,caliper,docker-deploy"
+       - TEST_CONTENT_S3=t
+    - name: "Centos 8: security,caliper,enable-content-s3,docker-deploy"
       stage: test
       compiler: gcc
       env:
        - IMG=centos8
        - DOCKER_TAG=t
        - PYTHON_VERSION=3.6
+       - TEST_CONTENT_S3=t
 
 stages:
   - 'style checks'

--- a/configure.ac
+++ b/configure.ac
@@ -357,8 +357,18 @@ AC_ARG_ENABLE([content-s3],
     AS_HELP_STRING([--enable-content-s3], [Enable S3 storage backend]))
 
 AS_IF([test "x$enable_content_s3" = "xyes"], [
-    X_AC_CHECK_COND_LIB(s3, S3_initialize)
-])
+    X_AC_CHECK_COND_LIB(s3, S3_initialize),
+	AC_COMPILE_IFELSE([AC_LANG_PROGRAM([#include <libs3.h>],
+            [S3_create_bucket (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);])],
+		    [AC_DEFINE([HAVE_S3_AUTH_REGION], [1], 
+                       [Use libs3 functions with auth region])],
+            []),
+	AC_COMPILE_IFELSE([AC_LANG_PROGRAM([#include <libs3.h>],
+            [S3_create_bucket (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);])],
+		    [AC_DEFINE([HAVE_S3_TIMEOUT_ARG], [1], 
+                       [Use libs3 functions with timeout arg])],
+            [])
+    ], [])
 
 AM_CONDITIONAL([ENABLE_CONTENT_S3], [test "x$enable_content_s3" = "xyes"])
 

--- a/src/modules/content-s3/s3.c
+++ b/src/modules/content-s3/s3.c
@@ -22,6 +22,20 @@
 
 #include "s3.h"
 
+#if HAVE_S3_AUTH_REGION
+#define S3_create_bucket(proto, access, secret, host, buck, acl, loc, req, cb, data) \
+    S3_create_bucket(proto, access, secret, NULL, host, buck, acl, loc, req, cb, data)
+#endif
+
+#if HAVE_S3_TIMEOUT_ARG
+#define S3_create_bucket(proto, access, secret, host, buck, acl, loc, req, cb, data) \
+    S3_create_bucket(proto, access, secret, NULL, host, buck, NULL, acl, loc, req, 0, cb, data)
+#define S3_put_object(ctx, key, size, prop, req, cb, data) \
+    S3_put_object(ctx, key, size, prop, req, 0, cb, data)
+#define S3_get_object(ctx, key, cond, start, cnt, req, cb, data) \
+    S3_get_object(ctx, key, cond, start, cnt, req, 0, cb, data)
+#endif
+
 static S3Protocol protocol = S3ProtocolHTTP;
 static S3UriStyle uri_style = S3UriStylePath;
 

--- a/src/test/docker/travis/Dockerfile
+++ b/src/test/docker/travis/Dockerfile
@@ -48,6 +48,10 @@ RUN case $BASE_IMAGE in \
     esac
 
 # Install extra dependencies if necessary here.
+RUN case BASE_IMAGE in \
+     centos*) yum install -y libs3-devel ;; \
+     *) (>&2 echo "not installing libs3") ;; \
+    esac
 
 # Do not forget to run `apt update` on Ubuntu/bionic.
 # Do NOT run `yum upgrade` on CentOS (this will unnecessarily upgrade


### PR DESCRIPTION
As noted in issues #3113 and #3114, libs3has multiple different package versions on different distros. This pr addresses that in configure, and adds the `--enable-content-s3` option to both the Centos 7 and 8 travis tests.

This pr is also from the previous version of the content-s3 module without the use of the TOML config parameters for right now. The TOML changes will be added after pr #3067 is merged.