### PR TITLE
doc: fix flux-help(1) output and rendering of NODESET.rst

### DIFF
--- a/doc/man1/flux-exec.rst
+++ b/doc/man1/flux-exec.rst
@@ -66,7 +66,7 @@ OPTIONS
 NODESET FORMAT
 ==============
 
-.. literalinclude:: NODESET.rst
+.. include:: NODESET.rst
 
 
 RESOURCES

--- a/doc/man1/flux-hwloc.rst
+++ b/doc/man1/flux-hwloc.rst
@@ -61,7 +61,7 @@ are
 NODESET FORMAT
 ==============
 
-.. literalinclude:: NODESET.rst
+.. include:: NODESET.rst
 
 
 RESOURCES

--- a/etc/gen-cmdhelp.py
+++ b/etc/gen-cmdhelp.py
@@ -40,6 +40,8 @@ for (path, cmd, descr, author, section) in man_pages:
             line = line.rstrip("\n")
             if ".. flux-help-" in line:
                 include_flag = True
+                if cmd.startswith("flux-"):
+                    cmd = cmd[5:]
                 if ".. flux-help-description: " in line:
                     descr = " ".join(line.split(" ")[2:])
                 if ".. flux-help-command: " in line:


### PR DESCRIPTION
A couple minor doc fixes:

 * Fix `literalinclude` of `NODESET.rst` in `flux-exec(1)` and `flux-hwloc(1)`
 * Fix a bug in `gen-cmdhelp.py` which resulted in `flux-` prefix on some commands in `flux-help` output, e.g.
```
Usage: flux [OPTIONS] COMMAND ARGS
  -h, --help             Display this message.
  -V, --version          Display command and component versions
  -p, --parent           Set environment of parent instead of current instance
  -v, --verbose          Be verbose about environment and command search

Common commands from flux-core:
   flux-broker        Invoke Flux comms message broker daemon
   content            Access instance content storage
   flux-cron          Schedule tasks on timers and events
   flux-dmesg         manipulate broker log ring buffer
   flux-env           Print the flux environment or execute a command inside it
   flux-event         Send and receive Flux events
   flux-exec          Execute processes across flux ranks
   get,set,lsattr     Access, modify, and list broker attributes
   hwloc              Control/query resource-hwloc service
   flux-jobs          list jobs submitted to Flux
   flux-keygen        generate keys for Flux security
   flux-kvs           Flux key-value store utility
   flux-logger        create a Flux log entry
   flux-mini          Minimal Job Submission Tool
   flux-module        manage Flux extension modules
   flux-ping          measure round-trip latency to Flux services
   proxy              Create proxy environment for Flux instance
   flux-start         bootstrap a local Flux instance
   flux-version       Display flux version information
```