### PR TITLE
travis-ci: fix ARGS when DOCKER_TAG set

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -136,7 +136,7 @@ before_install:
      export TAGNAME="${DOCKERREPO}:${IMG}${TRAVIS_TAG:+-${TRAVIS_TAG}}"
      echo "Tagging new image $TAGNAME"
      #  Force ARGS to correct prefix, etc for docker image
-     export ARGS="--prefix=/usr --sysconfdir=/etc --with-systemdsystemunitdir=/etc/systemd/system --localstatedir=/var --with-flux-security --enable-caliper"
+     export ARGS="$ARGS --prefix=/usr --sysconfdir=/etc --with-systemdsystemunitdir=/etc/systemd/system --localstatedir=/var --with-flux-security --enable-caliper"
   fi
 
 install:


### PR DESCRIPTION
Problem: When DOCKER_TAG is set, ARGS is overwritten with the correct
installation configure arguments. This erases other required args
for the build including --enable-content-s3.

Be sure to keep existing ARGS when setting the DOCKER_TAG args.

This fixes a problem with builds on master because `--enable-content-s3` is being overwritten by the installation args enforced by `DOCKER_TAG=t`. This only affects merges to master.

