### PR TITLE
build: fix innocuous configure error

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -358,6 +358,10 @@ AC_ARG_ENABLE([content-s3],
 
 AS_IF([test "x$enable_content_s3" = "xyes"], [
     X_AC_CHECK_COND_LIB(s3, S3_initialize)
+    AS_IF([test "x$ac_cv_lib_s3_S3_initialize" != "xyes"], [
+      AC_MSG_ERROR([configured with --enable-content-s3, but libs3 not found])
+    ])
+
     AC_COMPILE_IFELSE(
         [AC_LANG_PROGRAM([#include <libs3.h>],
                          [S3_create_bucket (0,0,0,0,0,0,0,0,0,0,0);])],

--- a/configure.ac
+++ b/configure.ac
@@ -357,7 +357,7 @@ AC_ARG_ENABLE([content-s3],
     AS_HELP_STRING([--enable-content-s3], [Enable S3 storage backend]))
 
 AS_IF([test "x$enable_content_s3" = "xyes"], [
-    X_AC_CHECK_COND_LIB(s3, S3_initialize),
+    X_AC_CHECK_COND_LIB(s3, S3_initialize)
 	AC_COMPILE_IFELSE([AC_LANG_PROGRAM([#include <libs3.h>],
             [S3_create_bucket (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);])],
 		    [AC_DEFINE([HAVE_S3_AUTH_REGION], [1], 

--- a/configure.ac
+++ b/configure.ac
@@ -358,17 +358,17 @@ AC_ARG_ENABLE([content-s3],
 
 AS_IF([test "x$enable_content_s3" = "xyes"], [
     X_AC_CHECK_COND_LIB(s3, S3_initialize)
-	AC_COMPILE_IFELSE([AC_LANG_PROGRAM([#include <libs3.h>],
-            [S3_create_bucket (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);])],
-		    [AC_DEFINE([HAVE_S3_AUTH_REGION], [1], 
-                       [Use libs3 functions with auth region])],
-            []),
-	AC_COMPILE_IFELSE([AC_LANG_PROGRAM([#include <libs3.h>],
-            [S3_create_bucket (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);])],
-		    [AC_DEFINE([HAVE_S3_TIMEOUT_ARG], [1], 
-                       [Use libs3 functions with timeout arg])],
-            [])
-    ], [])
+    AC_COMPILE_IFELSE(
+        [AC_LANG_PROGRAM([#include <libs3.h>],
+                         [S3_create_bucket (0,0,0,0,0,0,0,0,0,0,0);])],
+        AC_DEFINE([HAVE_S3_AUTH_REGION], [1], [S3_create_bucket has 11 args]),
+        AC_COMPILE_IFELSE(
+            [AC_LANG_PROGRAM([#include <libs3.h>],
+                             [S3_create_bucket (0,0,0,0,0,0,0,0,0,0,0,0,0);])],
+            AC_DEFINE([HAVE_S3_TIMEOUT_ARG], [1], [S3_create_bucket has 13 args])
+        )
+    )
+])
 
 AM_CONDITIONAL([ENABLE_CONTENT_S3], [test "x$enable_content_s3" = "xyes"])
 


### PR DESCRIPTION
An extra comma in the libs3 API probing now performed by configure was causing an error to be emitted on configure's stderr.

While I was in there I moved the second compile test into the "else" leg of the first one, since only one can succeed and there is no need to always run both.

The indenting may be a bit easier to follow, although it's m4, so still pretty awful.