### PR TITLE
libflux: fix comment in module.h to reference readthedocs

### DIFF
--- a/src/common/libflux/module.h
+++ b/src/common/libflux/module.h
@@ -12,7 +12,7 @@
 #define _FLUX_CORE_MODULE_H
 
 /* Module management messages are constructed according to Flux RFC 5.
- * https://github.com/flux-framework/rfc/blob/master/spec_5.adoc
+ * https://flux-framework.rtfd.io/projects/flux-rfc/en/latest/spec_5.html
  */
 
 #include <stdint.h>


### PR DESCRIPTION
Problem: A comment in libflux/module.h references an old URL for RFC 5.

Update the URL to the readthedocs site, which will be a more readable
version of the RFC anyway.