### PR TITLE
job-info,job-shell: allow non-V1 jobspec

### DIFF
--- a/src/modules/job-info/job_state.c
+++ b/src/modules/job-info/job_state.c
@@ -643,7 +643,7 @@ static int jobspec_parse (struct info_ctx *ctx,
             slot_count = res[0].count * res[1].count;
         }
         else {
-            flux_log (ctx->h, LOG_ERR,
+            flux_log (ctx->h, LOG_WARNING,
                       "%s: job %ju: Unexpected resources: %s->%s->%s%s",
                       __FUNCTION__,
                       (uintmax_t)job->id,
@@ -651,7 +651,7 @@ static int jobspec_parse (struct info_ctx *ctx,
                       res[1].type ? res[1].type : "NULL",
                       res[2].type ? res[2].type : "NULL",
                       res[2].with ? "->..." : NULL);
-            goto error;
+            slot_count = -1;
         }
         job->ntasks = slot_count;
     }

--- a/src/shell/jobspec.c
+++ b/src/shell/jobspec.c
@@ -71,6 +71,104 @@ void jobspec_destroy (struct jobspec *job)
     }
 }
 
+static int recursive_parse_helper (struct jobspec *job,
+                                  json_t *curr_resource,
+                                  json_error_t *error,
+                                  struct res_level *res,
+                                  int level,
+                                  int with_multiplier,
+                                  int num_nodes
+                                  )
+{
+    size_t size = json_array_size (curr_resource);
+
+    if (size == 0) {
+        set_error (error, "Malformed jobspec: resource entry is not a list");
+        return -1;
+    }
+    if (parse_res_level (curr_resource, level, res, error) < 0) {
+        return -1;
+    }
+    if (size > 1 && res->with != NULL) {
+        set_error (error,
+                   "Unsupported jobspec: multiple resources at non-leaf level %d",
+                   level);
+        return -1;
+    }
+
+    with_multiplier = with_multiplier * res->count;
+
+    if (!strcmp (res->type, "node")) {
+        if (job->slot_count > 0) {
+            set_error (error, "node resource encountered after slot resource");
+            return -1;
+        }
+
+        num_nodes = with_multiplier;
+    } else if (!strcmp (res->type, "slot")) {
+        job->slot_count = with_multiplier;
+
+        // Reset the with_multiplier since we are now looking
+        // to calculate the cores_per_slot value
+        with_multiplier = 1;
+
+        // Check if we already encountered the `node` resource
+        if (num_nodes > 0) {
+            // N.B.: with a strictly enforced ordering of node then slot
+            // (with arbitrary non-core resources in between)
+            // the slots_per_node will always be a perfectly round integer
+            // (i.e., job->slot_count % num_nodes == 0)
+            job->slots_per_node = job->slot_count / num_nodes;
+        }
+    } else if (!strcmp (res->type, "core")) {
+        if (job->slot_count < 1) {
+            set_error (error, "core resource encountered before slot resource");
+            return -1;
+        }
+
+        job->cores_per_slot = with_multiplier;
+        // We've found everything we needed, we can stop recursing
+        return 0;
+    }
+
+    if (res->with != NULL) {
+        return recursive_parse_helper (job,
+                                       res->with,
+                                       error,
+                                       res,
+                                       level+1,
+                                       with_multiplier,
+                                       num_nodes);
+    }
+    return 0;
+}
+
+/* This function requires that the jobspec resource ordering is the
+ * same as the ordering specified in V1, but it allows additional
+ * resources before and in between the V1 resources
+ * (i.e., node, slot, and core).
+ * In shorthand, it requires that the jobspec follows the form
+ * ...->[node]->...->slot->...->core.  Where `node` is optional,
+ * and `...` represents any non-V1 resources.
+ */
+static int recursive_parse_jobspec_resources (struct jobspec *job,
+                                              json_t *curr_resource,
+                                              json_error_t *error)
+{
+    struct res_level res;
+
+    if (curr_resource == NULL) {
+        set_error (error, "jobspec top-level resources empty");
+        return -1;
+    }
+
+    // Set slots_per_node to -1 ahead of time, if the recursive descent
+    // encounters node->...->slot, it will overwrite this value
+    job->slots_per_node = -1;
+
+    return recursive_parse_helper (job, curr_resource, error, &res, 0, 1, -1);
+}
+
 struct jobspec *jobspec_parse (const char *jobspec, json_error_t *error)
 {
     struct jobspec *job;
@@ -153,12 +251,8 @@ struct jobspec *jobspec_parse (const char *jobspec, json_error_t *error)
         job->cores_per_slot = res[2].count;
         job->slots_per_node = res[1].count;
     }
-    else {
-        set_error (error, "Unexpected resource hierarchy: %s->%s->%s%s",
-                   res[0].type ? res[0].type : "NULL",
-                   res[1].type ? res[1].type : "NULL",
-                   res[2].type ? res[2].type : "NULL",
-                   res[2].with ? "->..." : NULL);
+    else if (recursive_parse_jobspec_resources (job, resources, error) < 0) {
+        // recursive_parse_jobspec_resources calls set_error
         goto error;
     }
     /* Set job->task_count

--- a/src/shell/test/jobspec.c
+++ b/src/shell/test/jobspec.c
@@ -22,12 +22,44 @@ struct input {
     const char *s;
 };
 
+struct output {
+    int task_count;
+    int slot_count;
+    int cores_per_slot;
+    int slots_per_node;
+};
+
 struct input good_input[] = {
     {
         "flux jobspec srun hostname",
         "{\"tasks\": [{\"slot\": \"task\", \"count\": {\"per_slot\": 1}, \"command\": [\"hostname\"], \"attributes\": {}}], \"attributes\": {\"system\": {\"cwd\": \"/home/garlick/proj/flux-core/src/cmd\"}}, \"version\": 1, \"resources\": [{\"count\": 1, \"with\": [{\"count\": 1, \"type\": \"core\"}], \"type\": \"slot\", \"label\": \"task\"}]}",
     },
+    {
+        "node->socket->slot->core",
+        "{\"resources\": [{\"type\": \"node\", \"count\": 1, \"with\": [{\"type\": \"socket\", \"count\": 1, \"with\": [{\"type\": \"slot\", \"count\": 1, \"with\": [{\"type\": \"core\", \"count\": 1}], \"label\": \"task\"}]}]}], \"tasks\": [{\"command\": [\"hostname\"], \"slot\": \"task\", \"count\": {\"per_slot\": 1}}], \"attributes\": {\"system\": {\"duration\": 0, \"cwd\": \"/usr/libexec/flux\", \"environment\": {}}}, \"version\": 1}",
+    },
+    {
+        "node[2]->socket[3]->slot[5]->core[3]",
+        "{\"resources\": [{\"type\": \"node\", \"count\": 2, \"with\": [{\"type\": \"socket\", \"count\": 3, \"with\": [{\"type\": \"slot\", \"count\": 5, \"with\": [{\"type\": \"core\", \"count\": 3}], \"label\": \"task\"}]}]}], \"tasks\": [{\"command\": [\"hostname\"], \"slot\": \"task\", \"count\": {\"per_slot\": 1}}], \"attributes\": {\"system\": {\"duration\": 0, \"cwd\": \"/usr/libexec/flux\", \"environment\": {}}}, \"version\": 1}",
+    },
+    {
+        "slot[5]->socket[2]->core[3]",
+        "{\"resources\": [{\"type\": \"slot\", \"count\": 5, \"label\": \"task\", \"with\": [{\"type\": \"socket\", \"count\": 2, \"with\": [{\"type\": \"core\", \"count\": 3}]}]}], \"tasks\": [{\"command\": [\"hostname\"], \"slot\": \"task\", \"count\": {\"per_slot\": 1}}], \"attributes\": {\"system\": {\"duration\": 0, \"cwd\": \"/usr/libexec/flux\", \"environment\": {}}}, \"version\": 1}",
+    },
+    {
+        "node->socket->slot->(core[2],gpu)",
+        "{\"resources\": [{\"type\": \"node\", \"count\": 1, \"with\": [{\"type\": \"socket\", \"count\": 1, \"with\": [{\"type\": \"slot\", \"label\": \"task\", \"count\": 1, \"with\": [{\"type\": \"core\", \"count\": 2}, {\"type\": \"gpu\", \"count\": 1}]}]}]}], \"tasks\": [{\"command\": [\"hostname\"], \"slot\": \"task\", \"count\": {\"per_slot\": 1}}], \"attributes\": {\"system\": {\"duration\": 0, \"cwd\": \"/usr/libexec/flux\", \"environment\": {}}}, \"version\": 1}",
+    },
     { NULL, NULL },
+};
+struct output good_output[] =
+    {
+     {1, 1, 1, -1},
+     {1, 1, 1, 1},
+     {30, 30, 3, 15},
+     {5, 5, 6, -1},
+     {1, 1, 2, 1},
+     {0, 0, 0, 0},
 };
 struct input bad_input[] = {
     {
@@ -70,6 +102,14 @@ struct input bad_input[] = {
         "missing command",
         "{\"tasks\": [{\"slot\": \"task\", \"count\": {\"per_slot\": 1}, \"attributes\": {}}], \"attributes\": {\"system\": {\"cwd\": \"/home/garlick/proj/flux-core/src/cmd\"}}, \"version\": 1, \"resources\": [{\"count\": 1, \"with\": [{\"count\": 1, \"type\": \"core\"}], \"type\": \"slot\", \"label\": \"task\"}]}",
     },
+    {
+        "slot->node->core",
+        "{\"resources\": [{\"type\": \"slot\", \"label\": \"task\", \"count\": 1, \"with\": [{\"type\": \"node\", \"count\": 1, \"with\": [{\"type\": \"core\", \"count\": 1}]}]}], \"tasks\": [{\"command\": [\"hostname\"], \"slot\": \"task\", \"count\": {\"per_slot\": 1}}], \"attributes\": {\"system\": {\"duration\": 0, \"cwd\": \"/usr/libexec/flux\", \"environment\": {}}}, \"version\": 1}",
+    },
+    {
+        "node->core->slot",
+        "{\"resources\": [{\"type\": \"node\", \"count\": 1, \"with\": [{\"type\": \"core\", \"count\": 1, \"with\": [{\"type\": \"slot\", \"label\": \"task\", \"count\": 1}]}]}], \"tasks\": [{\"command\": [\"hostname\"], \"slot\": \"task\", \"count\": {\"per_slot\": 1}}], \"attributes\": {\"system\": {\"duration\": 0, \"cwd\": \"/usr/libexec/flux\", \"environment\": {}}}, \"version\": 1}",
+    },
     { NULL, NULL },
 };
 
@@ -77,16 +117,43 @@ int main (int argc, char **argv)
 {
     plan (NO_PLAN);
     struct jobspec *js;
+    struct output *expect;
     json_error_t error;
     int i;
 
     for (i = 0; good_input[i].desc; i++) {
         js = jobspec_parse (good_input[i].s, &error);
         ok (js != NULL, "good.%d (%s) works", i, good_input[i].desc);
-        if (!js)
+        if (!js) {
             diag ("%s", error.text);
-        else
+        } else {
+            expect = &good_output[i];
+            ok (js->task_count == expect->task_count,
+                "good.%d (%s) task count (%d) == %d",
+                i,
+                good_input[i].desc,
+                js->task_count,
+                expect->task_count);
+            ok (js->slot_count == expect->slot_count,
+                "good.%d (%s) slot count (%d) == %d",
+                i,
+                good_input[i].desc,
+                js->slot_count,
+                expect->slot_count);
+            ok (js->cores_per_slot == expect->cores_per_slot,
+                "good.%d (%s) cores per slot (%d) == %d",
+                i,
+                good_input[i].desc,
+                js->cores_per_slot,
+                expect->cores_per_slot);
+            ok (js->slots_per_node == expect->slots_per_node,
+                "good.%d (%s) slots per node (%d) == %d",
+                i,
+                good_input[i].desc,
+                js->slots_per_node,
+                expect->slots_per_node);
             jobspec_destroy (js);
+        }
     }
 
     for (i = 0; bad_input[i].desc; i++) {

--- a/src/shell/test/jobspec.c
+++ b/src/shell/test/jobspec.c
@@ -50,6 +50,14 @@ struct input good_input[] = {
         "node->socket->slot->(core[2],gpu)",
         "{\"resources\": [{\"type\": \"node\", \"count\": 1, \"with\": [{\"type\": \"socket\", \"count\": 1, \"with\": [{\"type\": \"slot\", \"label\": \"task\", \"count\": 1, \"with\": [{\"type\": \"core\", \"count\": 2}, {\"type\": \"gpu\", \"count\": 1}]}]}]}], \"tasks\": [{\"command\": [\"hostname\"], \"slot\": \"task\", \"count\": {\"per_slot\": 1}}], \"attributes\": {\"system\": {\"duration\": 0, \"cwd\": \"/usr/libexec/flux\", \"environment\": {}}}, \"version\": 1}",
     },
+    {
+        "node->socket->slot->(gpu,core)",
+        "{\"resources\": [{\"type\": \"node\", \"count\": 1, \"with\": [{\"type\": \"socket\", \"count\": 1, \"with\": [{\"type\": \"slot\", \"label\": \"task\", \"count\": 1, \"with\": [{\"type\": \"gpu\", \"count\": 1}, {\"type\": \"core\", \"count\": 1}]}]}]}], \"tasks\": [{\"command\": [\"hostname\"], \"slot\": \"task\", \"count\": {\"per_slot\": 1}}], \"attributes\": {\"system\": {\"duration\": 0, \"cwd\": \"/usr/libexec/flux\", \"environment\": {}}}, \"version\": 1}",
+    },
+    {
+        "node->socket->slot->(core[2]->PU,gpu)",
+        "{\"resources\": [{\"type\": \"node\", \"count\": 1, \"with\": [{\"type\": \"socket\", \"count\": 1, \"with\": [{\"type\": \"slot\", \"label\": \"task\", \"count\": 1, \"with\": [{\"type\": \"core\", \"count\": 2, \"with\": [{\"type\": \"PU\", \"count\": 1}]}, {\"type\": \"gpu\", \"count\": 1}]}]}]}], \"tasks\": [{\"command\": [\"hostname\"], \"slot\": \"task\", \"count\": {\"per_slot\": 1}}], \"attributes\": {\"system\": {\"duration\": 0, \"cwd\": \"/usr/libexec/flux\", \"environment\": {}}}, \"version\": 1}",
+    },
     { NULL, NULL },
 };
 struct output good_output[] =
@@ -58,6 +66,8 @@ struct output good_output[] =
      {1, 1, 1, 1},
      {30, 30, 3, 15},
      {5, 5, 6, -1},
+     {1, 1, 2, 1},
+     {1, 1, 1, 1},
      {1, 1, 2, 1},
      {0, 0, 0, 0},
 };
@@ -109,6 +119,14 @@ struct input bad_input[] = {
     {
         "node->core->slot",
         "{\"resources\": [{\"type\": \"node\", \"count\": 1, \"with\": [{\"type\": \"core\", \"count\": 1, \"with\": [{\"type\": \"slot\", \"label\": \"task\", \"count\": 1}]}]}], \"tasks\": [{\"command\": [\"hostname\"], \"slot\": \"task\", \"count\": {\"per_slot\": 1}}], \"attributes\": {\"system\": {\"duration\": 0, \"cwd\": \"/usr/libexec/flux\", \"environment\": {}}}, \"version\": 1}",
+    },
+    {
+        "node->(storage,slot->core)",
+        "{\"resources\": [{\"type\": \"node\", \"count\": 1, \"with\": [{\"type\": \"storage\", \"count\": 1}, {\"type\": \"slot\", \"label\": \"task\", \"count\": 1, \"with\": [{\"type\": \"core\", \"count\": 1}]}]}], \"tasks\": [{\"command\": [\"hostname\"], \"slot\": \"task\", \"count\": {\"per_slot\": 1}}], \"attributes\": {\"system\": {\"duration\": 0, \"cwd\": \"/usr/libexec/flux\", \"environment\": {}}}, \"version\": 1}",
+    },
+    {
+        "node->slot->(PU,gpu)",
+        "{\"resources\": [{\"type\": \"node\", \"count\": 1, \"with\": [{\"type\": \"slot\", \"label\": \"task\", \"count\": 1, \"with\": [{\"type\": \"PU\", \"count\": 1}, {\"type\": \"gpu\", \"count\": 1}]}]}], \"tasks\": [{\"command\": [\"hostname\"], \"slot\": \"task\", \"count\": {\"per_slot\": 1}}], \"attributes\": {\"system\": {\"duration\": 0, \"cwd\": \"/usr/libexec/flux\", \"environment\": {}}}, \"version\": 1}",
     },
     { NULL, NULL },
 };


### PR DESCRIPTION
Non-V1 jobspec causes a fatal error in `job-info` when it is calculating the number of tasks and in `job-shell` when it is calculating the number of slots, cores-per-slot, and slots-per-node.

Drop the `job-info` error to just a warning and add a recursive parser of jobspec that allows non-V1 resources to be interspersed within the resource tree of an otherwise v1-compliant jobspec.

Enable the jobspec in #3152 (i.e., `node->socket->(core[2],gpu)`) to work properly.

Close #3151