### PR TITLE
python: reformat with latest black formatter, then pin black version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ jobs:
       name: 'python format'
       language: 'python'
       python: '3.6'
-      install: pip install --upgrade black
+      install: pip install 'black==20.08.b1' --force-reinstall
       script: ./scripts/check-format
       before_deploy: skip
       deploy: skip

--- a/src/bindings/python/flux/core/handle.py
+++ b/src/bindings/python/flux/core/handle.py
@@ -24,11 +24,11 @@ from _flux._core import ffi, lib
 
 class Flux(Wrapper):
     """
-  The general Flux handle class, create one of these to connect to the
-  nearest enclosing flux instance
-  >>> flux.Flux() #doctest: +ELLIPSIS
-  <flux.core.Flux object at 0x...>
-  """
+    The general Flux handle class, create one of these to connect to the
+    nearest enclosing flux instance
+    >>> flux.Flux() #doctest: +ELLIPSIS
+    <flux.core.Flux object at 0x...>
+    """
 
     def __init__(self, url=ffi.NULL, flags=0, handle=None):
         super(Flux, self).__init__(
@@ -124,7 +124,7 @@ class Flux(Wrapper):
         return RPC(self, topic, payload, nodeid, flags)
 
     def event_create(self, topic, payload=None):
-        """ Create a new event message.
+        """Create a new event message.
 
         :param topic: A string, the event's topic
         :param payload: If a string, the payload is used unmodified, if it is

--- a/src/bindings/python/flux/job.py
+++ b/src/bindings/python/flux/job.py
@@ -480,8 +480,7 @@ class JobEventWatchFuture(Future):
         return event
 
     def cancel(self):
-        """Cancel a streaming job.event_watch_async() future
-        """
+        """Cancel a streaming job.event_watch_async() future"""
         RAW.event_watch_cancel(self.pimpl)
         self.needs_cancel = False
 

--- a/src/cmd/flux-admin.py
+++ b/src/cmd/flux-admin.py
@@ -31,7 +31,9 @@ def cleanup_push(args):
         commands = [line.strip() for line in sys.stdin]
 
     RPC(
-        flux.Flux(), "runat.push", {"name": "cleanup", "commands": commands[::-1]},
+        flux.Flux(),
+        "runat.push",
+        {"name": "cleanup", "commands": commands[::-1]},
     ).get()
 
 


### PR DESCRIPTION
As noted in #3166, spurious `black` format errors are appearing in travis-ci since we allow `black` to be upgraded before running `check-format`.

This PR pins `black` to the latest version, v20.08b1, and then reformats python files with this version.

This should avoid future CI failures due to format changes between `black` versions.

Fixes #3166