### PR TITLE
job-info: do not fail on invalid jobspec / R / eventlog

### DIFF
--- a/src/modules/job-info/job_state.c
+++ b/src/modules/job-info/job_state.c
@@ -110,6 +110,8 @@ static struct job *job_create (struct info_ctx *ctx, flux_jobid_t id)
     job->ctx = ctx;
     job->id = id;
     job->state = FLUX_JOB_NEW;
+    job->userid = FLUX_USERID_UNKNOWN;
+    job->priority = -1;
 
     if (!(job->next_states = zlist_new ())) {
         errno = ENOMEM;

--- a/src/modules/job-info/job_util.c
+++ b/src/modules/job-info/job_util.c
@@ -120,7 +120,11 @@ json_t *job_to_json (struct job *job, json_t *attrs, job_info_error_t *errp)
         else if (!strcmp (attr, "ranks")) {
             if (!(job->states_mask & FLUX_JOB_RUN))
                 continue;
-            val = json_string (job->ranks);
+            /* potentially NULL if R invalid */
+            if (job->ranks)
+                val = json_string (job->ranks);
+            else
+                val = json_string ("");
         }
         else if (!strcmp (attr, "expiration")) {
             if (!(job->states_mask & FLUX_JOB_RUN))

--- a/src/modules/job-info/job_util.c
+++ b/src/modules/job-info/job_util.c
@@ -103,7 +103,11 @@ json_t *job_to_json (struct job *job, json_t *attrs, job_info_error_t *errp)
             val = json_integer (job->state);
         }
         else if (!strcmp (attr, "name")) {
-            val = json_string (job->name);
+            /* potentially NULL if jobspec invalid */
+            if (job->name)
+                val = json_string (job->name);
+            else
+                val = json_string ("");
         }
         else if (!strcmp (attr, "ntasks")) {
             val = json_integer (job->ntasks);

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -233,6 +233,7 @@ dist_check_SCRIPTS = \
 	job-exec/imp.sh \
 	job-info/list-id.py \
 	job-info/list-rpc.py \
+	job-info/jobspec-permissive.jsonschema \
 	job-archive/query.py \
 	schedutil/req_and_unload.py \
 	ingest/fake-validate.sh \

--- a/t/job-info/jobspec-permissive.jsonschema
+++ b/t/job-info/jobspec-permissive.jsonschema
@@ -1,0 +1,7 @@
+{
+  "title": "permissive-jobspec",
+  "description": "Flux permissive jobspec",
+  "type": "object",
+  "properties": {
+  }
+}

--- a/t/t2230-job-info-list.t
+++ b/t/t2230-job-info-list.t
@@ -1078,6 +1078,44 @@ test_expect_success HAVE_JQ,NO_CHAIN_LINT 'flux job list-ids works on job with i
         cat list_id_illegal_R.out | $jq -e ".id == ${jobid}"
 '
 
+# we make the eventlog invalid by overwriting it in the KVS before job-info will
+# look it up.  Note that b/c the eventlog is corrupted, the userid for the job
+# is never established.  So we have to set --user=all.
+test_expect_success HAVE_JQ 'flux job list works on job with illegal eventlog' '
+	${RPC} job-info.job-state-pause 0 </dev/null &&
+        jobid=`flux job submit hostname.json | flux job id` &&
+        fj_wait_event $jobid clean >/dev/null &&
+        jobkvspath=`flux job id --to kvs $jobid` &&
+        flux kvs put "${jobkvspath}.eventlog=foobar" &&
+	${RPC} job-info.job-state-unpause 0 </dev/null &&
+        i=0 &&
+        while ! flux job list --states=inactive --user=all | grep $jobid > /dev/null \
+               && [ $i -lt 5 ]
+        do
+                sleep 1
+                i=$((i + 1))
+        done &&
+        test "$i" -lt "5" &&
+        flux job list --states=inactive --user=all | grep $jobid > list_illegal_eventlog.out &&
+        cat list_illegal_eventlog.out &&
+        cat list_illegal_eventlog.out | $jq -e ".priority == -1" &&
+        cat list_illegal_eventlog.out | $jq -e ".userid == 4294967295"
+'
+
+test_expect_success HAVE_JQ,NO_CHAIN_LINT 'flux job list-ids works on job with illegal eventlog' '
+	${RPC} job-info.job-state-pause 0 </dev/null
+        jobid=`flux job submit hostname.json | flux job id`
+        fj_wait_event $jobid clean >/dev/null
+        jobkvspath=`flux job id --to kvs $jobid` &&
+        flux kvs put "${jobkvspath}.eventlog=foobar" &&
+        flux job list-ids ${jobid} > list_id_illegal_eventlog.out &
+        pid=$!
+        wait_idsync 1 &&
+	${RPC} job-info.job-state-unpause 0 </dev/null &&
+        wait $pid &&
+        cat list_id_illegal_eventlog.out | $jq -e ".id == ${jobid}"
+'
+
 #
 # stress test
 #

--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -7,6 +7,8 @@ test_description='Test flux jobs command'
 test_under_flux 4 job
 
 runpty="${SHARNESS_TEST_SRCDIR}/scripts/runpty.py --line-buffer -f asciicast"
+PERMISSIVE_SCHEMA=${FLUX_SOURCE_DIR}/t/job-info/jobspec-permissive.jsonschema
+JSONSCHEMA_VALIDATOR=${FLUX_SOURCE_DIR}/src/modules/job-ingest/validators/validate-schema.py
 
 # submit a whole bunch of jobs for job list testing
 #
@@ -882,6 +884,54 @@ for d in ${ISSUES_DIR}/*; do
 		test_cmp ${d}/output ${issue}.output
 	'
 done
+
+
+test_expect_success 'cleanup job listing jobs ' '
+        for jobid in `cat active.ids`; do \
+            flux job cancel $jobid; \
+            flux job wait-event $jobid clean; \
+        done
+'
+
+# Following tests use invalid jobspecs, must load a more permissive validator
+
+ingest_module ()
+{
+        cmd=$1; shift
+        flux module ${cmd} job-ingest $*
+}
+
+test_expect_success 'reload job-ingest with more permissive validator' '
+        ingest_module reload \
+                validator=${JSONSCHEMA_VALIDATOR} validator-args=--schema,${PERMISSIVE_SCHEMA}
+'
+
+test_expect_success HAVE_JQ 'create illegal jobspec with empty command array' '
+        cat hostname.json | $jq ".tasks[0].command = []" > bad_jobspec.json
+'
+
+# to avoid potential racyness, wait up to 5 seconds for job to appear
+# in job list.  note that how a jobspec is illegal can affect what
+# values below are set vs not set.
+test_expect_success HAVE_JQ 'flux jobs works on job with illegal jobspec' '
+        jobid=`flux job submit bad_jobspec.json` &&
+	flux job wait-event $jobid clean &&
+        i=0 &&
+        while ! flux jobs --filter=inactive | grep $jobid > /dev/null \
+               && [ $i -lt 5 ]
+        do
+                sleep 1
+                i=$((i + 1))
+        done &&
+        test "$i" -lt "5" &&
+        flux jobs -no "{name},{ntasks}" $jobid > list_illegal_jobspec.out &&
+        echo ",0" > list_illegal_jobspec.exp &&
+        test_cmp list_illegal_jobspec.out list_illegal_jobspec.exp
+'
+
+test_expect_success 'reload job-ingest with defaults' '
+        ingest_module reload
+'
 
 #
 # leave job cleanup to rc3

--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -956,6 +956,29 @@ test_expect_success HAVE_JQ 'flux jobs works on job with illegal R' '
         test_cmp list_illegal_R.out list_illegal_R.exp
 '
 
+# we make the eventlog invalid by overwriting it in the KVS before job-info will
+# look it up.  Note that b/c the eventlog is corrupted, the userid for the job
+# is never established.  So we have to do "--all" and grep for the jobid.
+test_expect_success HAVE_JQ 'flux jobs works on job with illegal eventlog' '
+	${RPC} job-info.job-state-pause 0 </dev/null &&
+        jobid=`flux job submit hostname.json` &&
+        flux job wait-event $jobid clean >/dev/null &&
+        jobkvspath=`flux job id --to kvs $jobid` &&
+        flux kvs put "${jobkvspath}.eventlog=foobar" &&
+	${RPC} job-info.job-state-unpause 0 </dev/null &&
+        i=0 &&
+        while ! flux jobs --filter=inactive --user=all | grep $jobid > /dev/null \
+               && [ $i -lt 5 ]
+        do
+                sleep 1
+                i=$((i + 1))
+        done &&
+        test "$i" -lt "5" &&
+        flux jobs -no "{userid},{priority}" $jobid > list_illegal_eventlog.out &&
+        echo "4294967295,-1" > list_illegal_eventlog.exp &&
+        test_cmp list_illegal_eventlog.out list_illegal_eventlog.exp
+'
+
 #
 # leave job cleanup to rc3
 #

--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -6,6 +6,7 @@ test_description='Test flux jobs command'
 
 test_under_flux 4 job
 
+RPC=${FLUX_BUILD_DIR}/t/request/rpc
 runpty="${SHARNESS_TEST_SRCDIR}/scripts/runpty.py --line-buffer -f asciicast"
 PERMISSIVE_SCHEMA=${FLUX_SOURCE_DIR}/t/job-info/jobspec-permissive.jsonschema
 JSONSCHEMA_VALIDATOR=${FLUX_SOURCE_DIR}/src/modules/job-ingest/validators/validate-schema.py
@@ -931,6 +932,28 @@ test_expect_success HAVE_JQ 'flux jobs works on job with illegal jobspec' '
 
 test_expect_success 'reload job-ingest with defaults' '
         ingest_module reload
+'
+
+# we make R invalid by overwriting it in the KVS before job-info will
+# look it up
+test_expect_success HAVE_JQ 'flux jobs works on job with illegal R' '
+	${RPC} job-info.job-state-pause 0 </dev/null &&
+        jobid=`flux job submit hostname.json` &&
+        flux job wait-event $jobid clean >/dev/null &&
+        jobkvspath=`flux job id --to kvs $jobid` &&
+        flux kvs put "${jobkvspath}.R=foobar" &&
+	${RPC} job-info.job-state-unpause 0 </dev/null &&
+        i=0 &&
+        while ! flux jobs --filter=inactive | grep $jobid > /dev/null \
+               && [ $i -lt 5 ]
+        do
+                sleep 1
+                i=$((i + 1))
+        done &&
+        test "$i" -lt "5" &&
+        flux jobs -no "{ranks},{nnodes}" $jobid > list_illegal_R.out &&
+        echo ",0" > list_illegal_R.exp &&
+        test_cmp list_illegal_R.out list_illegal_R.exp
 '
 
 #


### PR DESCRIPTION
Per #3153 and #2964, there are issues if there is invalid data such as an invalid jobspec or R.  The job-info module would not know how to process this invalid data and never advance a job's state to the next state (e.g. from running to cleanup)

I also handled invalid eventlog data, but I wasn't 100% sure about this.  eventlog data should never be wrong b/c it comes from the
`job-manager` instead of the user (jobspec) or scheduler (R).  But I figured, why not just in case.

Have tests for invalid jobspec, but not for R or eventlog yet.  I *think* I can create tests by pausing the job-info module's job state
processing and then overwriting R / eventlog in the KVS to get the test I want.  But wanted to post this for now.  (Partially to feel like I'm contributing after being gone for a month :-)

Edit: and should add some `flux-jobs` tests to make sure the output still looks ok