### PR TITLE
shell: fix Spectrum 2020.06 bootstrap

### DIFF
--- a/src/shell/lua.d/spectrum.lua
+++ b/src/shell/lua.d/spectrum.lua
@@ -77,6 +77,8 @@ plugin.register {
             -- Approximately `ulimit -Ss 10240`
             -- Used to silence IBM MCM warnings
             setrlimit ("stack", 10485760)
+            local rank = task.info.rank
+            task.setenv ("OMPI_COMM_WORLD_RANK", rank)
             end
         }
     }

--- a/t/t3001-mpi-personalities.t
+++ b/t/t3001-mpi-personalities.t
@@ -60,4 +60,14 @@ test_expect_success NO_ASAN,HAVE_JQ "spectrum mpi only enabled with option" '
   grep /opt/ibm/spectrum spectrum.out
 '
 
+test_expect_success HAVE_JQ 'spectrum mpi sets OMPI_COMM_WORLD_RANK' '
+  flux jobspec srun -n${SIZE} -N${SIZE} printenv OMPI_COMM_WORLD_RANK \
+    | jq ".attributes.system.shell.options.mpi = \"spectrum\"" > j.spectrum &&
+  jobid=$(flux job submit j.spectrum) &&
+  flux job attach ${jobid} | sort -n > spectrum.rank.out &&
+  test_debug "cat spectrum.rank.out" &&
+  printf "0\n1\n2\n3\n" > spectrum.rank.expected &&
+  test_cmp spectrum.rank.expected spectrum.rank.out
+'
+
 test_done


### PR DESCRIPTION
Problem: running the latest SMPI under Flux causes the following error:
```
Error: OMPI_COMM_WORLD_RANK is not set in environment like it should be.
Error checking ibm license.
flux-job: task(s) exited with exit code 255
2020-08-28T21:46:20.722507Z broker.err[0]: rc2.0: flux mini run -N1 -n1
-o mpi=spectrum ./mpi-hello-spectrum-2020.06.25 Exited (rc=255) 0.8s
```

Solution: set OMPI_COMM_WORLD_RANK to `task.info.rank` for each task in
the job via the `spectrum` shell MPI personality