### PR TITLE
rc: load sched-simple only if no other scheduler is loaded

### DIFF
--- a/etc/rc1
+++ b/etc/rc1
@@ -39,7 +39,6 @@ declare -a pids
 flux module load job-ingest
 flux exec -r all -x 0 flux module load job-ingest & pids+=($!)
 flux module load job-exec &  pids+=($!)
-flux module load sched-simple & pids+=($!)
 wait_check ${pids[@]}
 unset pids
 
@@ -54,6 +53,15 @@ for rcdir in $all_dirs; do
     done
 done
 shopt -u nullglob
+
+# Print module that has registered 'sched' service, if any
+lookup_sched_module() {
+    flux module list | awk '$6 == "sched" { print $1 }'
+}
+
+if test "${FLUX_SCHED_MODULE}" != "none" -a -z "$(lookup_sched_module)"; then
+    flux module load ${FLUX_SCHED_MODULE:-sched-simple}
+fi
 
 flux admin cleanup-push <<-EOT
 	flux queue stop --quiet


### PR DESCRIPTION
Problem: fluxion rc1 scripts have to unload sched-simple because
flux-core rc1 loads it unconditionally.

Change rc1 so that sched-simple is loaded only if an external
rc1 script did not load a module that registered the `sched` service.

This will require a fluxion PR as well - just wanted to post this to see whether people thought this was an acceptable stopgap to avoid the overhead of reloading the scheduler, in lieu of a comprehensive solution, such as one of those discussed in #2273.
