### PR TITLE
[WIP] Add flux-kube command for Kubernetes and OpenShift interaction

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -22,6 +22,12 @@ ignore_missing_imports = True
 [mypy-pycotap]
 follow_imports = silent
 
+[mypy-kubernetes]
+ignore_missing_imports = True
+
+[mypy-openshift.dynamic]
+ignore_missing_imports = True
+
 # These are temporary while we find a way to generate stubs for flux.constants
 [mypy-flux.job.list]
 ignore_errors = True

--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -70,7 +70,8 @@ dist_fluxcmd_SCRIPTS = \
 	flux-mini.py \
 	flux-jobs.py \
 	flux-resource.py \
-	flux-admin.py
+	flux-admin.py \
+	flux-kube.py
 
 fluxcmd_PROGRAMS = \
 	flux-aggregate \

--- a/src/cmd/flux-kube.py
+++ b/src/cmd/flux-kube.py
@@ -1,0 +1,117 @@
+##############################################################
+# Copyright 2020 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+##############################################################
+
+import logging
+import argparse
+
+from kubernetes import client, config
+from openshift.dynamic import DynamicClient
+
+from flux import util
+
+
+class KubeCmd:
+    """
+    KubeCmd is the base class for all flux-kube subcommands
+    """
+
+    def __init__(self, **kwargs):
+        self.parser = self.create_parser()
+
+        k8s_client = config.new_client_from_config()
+        try:
+            self.dyn_client = DynamicClient(k8s_client)
+        except client.rest.ApiException as rest_exception:
+            if rest_exception.status == 403:
+                raise Exception(
+                    "You must be logged in to the K8s or OpenShift"
+                    " cluster to continue"
+                )
+            raise
+
+    @staticmethod
+    def create_parser():
+        """
+        Create default parser for kube subcommands
+        """
+        parser = argparse.ArgumentParser(add_help=False)
+
+        return parser
+
+    def get_parser(self):
+        return self.parser
+
+
+class GetDeploymentsCmd(KubeCmd):
+    """
+    GetDeploymentsCmd gets all the user's
+    deployments in the specified namespace
+    and prints all their attributes.
+    """
+
+    def __init__(self):
+        super().__init__()
+
+        self.parser.add_argument(
+            "-n",
+            "--namespace",
+            type=str,
+            metavar="N",
+            help="Namespace of deployment",
+        )
+
+    def main(self, args):
+        v1_depl = self.dyn_client.resources.get(api_version="v1", kind="Deployment")
+        try:
+            depl_list = v1_depl.get(namespace=args.namespace)
+        except client.rest.ApiException as rest_exception:
+            if rest_exception.status == 403:
+                raise Exception(
+                    "You do not have permission to list deployments in namespace",
+                    args.namespace,
+                )
+            raise
+
+        if depl_list.items:
+            for depl in depl_list.items:
+                print("Deployment name:", depl.metadata.name)
+                for item in depl:
+                    print(item)
+        else:
+            print("No deployments in namespace", args.namespace)
+
+
+LOGGER = logging.getLogger("flux-kube")
+
+
+@util.CLIMain(LOGGER)
+def main():
+
+    parser = argparse.ArgumentParser(prog="flux-kube")
+    subparsers = parser.add_subparsers(
+        title="supported subcommands", description="", dest="subcommand"
+    )
+    subparsers.required = True
+
+    getdeployments = GetDeploymentsCmd()
+    getdeployments_parser_sub = subparsers.add_parser(
+        "getdeployments",
+        parents=[getdeployments.get_parser()],
+        help="get K8s deployment details",
+        formatter_class=util.help_formatter(),
+    )
+    getdeployments_parser_sub.set_defaults(func=getdeployments.main)
+
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/test/docker/bionic/Dockerfile
+++ b/src/test/docker/bionic/Dockerfile
@@ -101,6 +101,9 @@ RUN locale-gen en_US.UTF-8
 # NOTE: luaposix installed by rocks due to Ubuntu bug: #1752082 https://bugs.launchpad.net/ubuntu/+source/lua-posix/+bug/1752082
 RUN luarocks install luaposix
 
+# OpenShift and Kubernetes API clients
+RUN python3 -m pip install openshift
+
 # Install caliper by hand for now:
 RUN mkdir caliper \
  && cd caliper \

--- a/src/test/docker/centos7/Dockerfile
+++ b/src/test/docker/centos7/Dockerfile
@@ -67,6 +67,9 @@ RUN yum -y update \
 # Sphinx packages for docs
 RUN python3 -m pip install sphinx sphinx-rtd-theme sphinxcontrib-spelling
 
+# OpenShift and Kubernetes API clients
+RUN python3 -m pip install openshift
+
 # The cmake from yum is incredibly ancient, download a less ancient one
 RUN wget -q --no-check-certificate https://cmake.org/files/v3.10/cmake-3.10.1-Linux-x86_64.tar.gz\
  && tar -xzf cmake-3.10.1-Linux-x86_64.tar.gz\

--- a/src/test/docker/centos8/Dockerfile
+++ b/src/test/docker/centos8/Dockerfile
@@ -77,6 +77,9 @@ RUN alternatives --install /usr/bin/mpicc mpicc /usr/lib64/mpich/bin/mpicc 100
 # Sphinx packages for docs
 RUN python3 -m pip install sphinx sphinx-rtd-theme sphinxcontrib-spelling
 
+# OpenShift and Kubernetes API clients
+RUN python3 -m pip install openshift
+
 # Install caliper by hand for now:
 RUN mkdir caliper \
  && cd caliper \


### PR DESCRIPTION
This PR adds `flux-kube`, a command modeled after `flux-mini` to provide RESTful interactions with a Kubernetes (K8s) or OpenShift API server.  In its current state, the command takes a user supplied argument specifying the K8s namespace and prints out the user's running deployment attributes.  It also provides rudimentary error handling.

The PR still needs testsuite additions, which I anticipate to be tricky to implement given the possible need to query a K8s APIserver running within a Travis VM or container.  Note that I've only tested the `flux-kube` command against an OpenShift APIserver, but the OpenShift Python API client _should_ work against both.

This is still _very_ WIP.

