### PR TITLE
modules/job-info: handle annotations race

### DIFF
--- a/src/modules/job-info/job_state.h
+++ b/src/modules/job-info/job_state.h
@@ -51,6 +51,9 @@ struct job_state_ctx {
     int cleanup_count;
     int inactive_count;
 
+    /* annotations that arrived before job is known */
+    zhashx_t *early_annotations;
+
     /* debug/testing - if paused store job transitions on list for
      * processing later */
     bool pause;

--- a/t/t2230-job-info-list.t
+++ b/t/t2230-job-info-list.t
@@ -1097,7 +1097,6 @@ test_expect_success HAVE_JQ 'flux job list works on job with illegal eventlog' '
         done &&
         test "$i" -lt "5" &&
         flux job list --states=inactive --user=all | grep $jobid > list_illegal_eventlog.out &&
-        cat list_illegal_eventlog.out &&
         cat list_illegal_eventlog.out | $jq -e ".priority == -1" &&
         cat list_illegal_eventlog.out | $jq -e ".userid == 4294967295"
 '


### PR DESCRIPTION
There is a small chance that a job-annotation could arrive to the
job-info module before the job-info module is aware of a jobs
existance.

In the event this occurs, save the annotation off to a new
"early_annotations" hash.  When the job-info modules becomes
aware of the job via a job-state transition, load the annotation
out of the hash.

Fixes #3165