### PR TITLE
Allow fallback to ascii f prefix for F58 FLUIDs with FLUX_F58_FORCE_ASCII

### DIFF
--- a/src/common/libutil/fluid.c
+++ b/src/common/libutil/fluid.c
@@ -172,9 +172,10 @@ static int b58revenc (char *buf, int bufsz, fluid_t id)
 static inline int is_utf8_locale (void)
 {
     /* Assume if MB_CUR_MAX > 1, this locale can handle wide characters
-     *  and therefore will properly handle UTF-8.
+     *  and therefore will properly handle UTF-8, but allow ascii encoding
+     *  to be enforced if FLUX_F58_FORCE_ASCII is set.
      */
-    if (MB_CUR_MAX > 1)
+    if (MB_CUR_MAX > 1 && !getenv ("FLUX_F58_FORCE_ASCII"))
         return 1;
     return 0;
 }

--- a/src/common/libutil/test/fluid.c
+++ b/src/common/libutil/test/fluid.c
@@ -88,6 +88,15 @@ void test_f58 (void)
         tp++;
     }
 
+    if (setenv ("FLUX_F58_FORCE_ASCII", "1", 1) < 0)
+        BAIL_OUT ("Failed to setenv FLUX_F58_FORCE_ASCII");
+    ok (fluid_encode (buf, sizeof (buf), f58_tests->id, type) == 0,
+        "fluid_encode with FLUX_F58_FORCE_ASCII works");
+    is (buf, f58_tests->f58_alt,
+        "fluid_encode with FLUX_F58_FORCE_ASCII used ascii prefix");
+    if (unsetenv ("FLUX_F58_FORCE_ASCII") < 0)
+        BAIL_OUT ("Failed to unsetenv FLUX_F58_FORCE_ASCII");
+
     ok (fluid_encode (buf, 1, 1, type) < 0 && errno == EOVERFLOW,
         "fluid_encode (buf, 1, 1, F58) returns EOVERFLOW");
     errno = 0;


### PR DESCRIPTION
As discussed in #3199, if `FLUX_F58_FORCE_ASCII` is set force ascii `f` when encoding F58 FLUIDs.

This may be useful in situations where Python and C utilities are displaying differently, or when Python coercion of C locale to UTF-8 causes display or cut-and-paste problems.