### PR TITLE
shell: render output file template {{id}} as F58 by default, allow other id encodings

### DIFF
--- a/doc/man1/flux-mini.rst
+++ b/doc/man1/flux-mini.rst
@@ -108,17 +108,20 @@ KVS, where they may be accessed with the ``flux job attach`` command.
 In addition, ``flux-mini run`` processes standard I/O in real time,
 emitting the job's I/O to its stdout and stderr.
 
-**--output=FILENAME**
-   Redirect stdout to the specified FILENAME, bypassing the KVS.
-   The mustache template *{{id}}* is expanded to the numerical Job ID,
-   useful to ensure FILENAME is unique across multiple jobs. For
-   **flux mini batch** the default for FILENAME is *flux-{{id}}.out*.
-   To force output to go to KVS so it is available with ``flux job attach``,
-   set FILENAME to *none* or *kvs*.
+**--output=TEMPLATE**
+   Specify the filename *TEMPLATE* for stdout redirection, bypassing
+   the KVS.  *TEMPLATE* may be a mustache template which supports the
+   tags *{{id}}* and *{{jobid}}* which expand to the current jobid
+   in the F58 encoding.  If needed, an alternate encoding can be
+   selected by using a subkey with the name of the desired encoding,
+   e.g. *{{id.dec}}*. Supported encodings include *f58* (the default),
+   *dec*, *hex*, *dothex*, and *words*. For **flux mini batch** the
+   default *TEMPLATE* is *flux-{{id}}.out*. To force output to KVS so it is
+   available with ``flux job attach``, set *TEMPLATE* to *none* or *kvs*.
 
-**--error=FILENAME**
-   Redirect stderr to the specified FILENAME, bypassing the KVS.
-   The mustache template *{{id}}* is expanded as above.
+**--error=TEMPLATE**
+   Redirect stderr to the specified filename *TEMPLATE*, bypassing the KVS.
+   *TEMPLATE* is expanded as described above.
 
 **-l, --label-io**
    Add task rank prefixes to each line of output.

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -515,3 +515,6 @@ builtin
 OMP
 envfile
 regex
+encodings
+dec
+subkey

--- a/src/shell/Makefile.am
+++ b/src/shell/Makefile.am
@@ -83,7 +83,9 @@ flux_shell_SOURCES = \
 	pty.c \
 	batch.c \
 	mpir/mpir.c \
-	mpir/ptrace.c
+	mpir/ptrace.c \
+	mustache.h \
+	mustache.c
 
 flux_shell_LDADD = \
 	$(builddir)/libshell.la \

--- a/src/shell/Makefile.am
+++ b/src/shell/Makefile.am
@@ -110,6 +110,7 @@ EXTRA_DIST = \
 TESTS = \
 	test_jobspec.t \
 	test_plugstack.t \
+	test_mustache.t \
 	mpir/test_rangelist.t \
 	mpir/test_nodelist.t \
 	mpir/test_proctable.t
@@ -189,4 +190,16 @@ mpir_test_proctable_t_LDADD = \
 	$(builddir)/libmpir.la \
 	$(test_ldadd)
 mpir_test_proctable_t_LDFLAGS = \
+	$(test_ldflags)
+
+test_mustache_t_SOURCES = \
+	mustache.c \
+	mustache.h \
+	test/mustache.c
+test_mustache_t_CPPFLAGS = \
+	$(test_cppflags)
+test_mustache_t_LDADD = \
+	$(builddir)/libshell.la \
+	$(test_ldadd)
+test_mustache_t_LDFLAGS = \
 	$(test_ldflags)

--- a/src/shell/log.c
+++ b/src/shell/log.c
@@ -200,6 +200,27 @@ void flux_shell_log (int level,
     va_end (ap);
 }
 
+/* llog compatible wrapper for flux_shell_log
+ */
+void shell_llog (void *arg,
+                 const char *file,
+                 int line,
+                 const char *func,
+                 const char *subsys,
+                 int level,
+                 const char *fmt,
+                 va_list ap)
+{
+    char buf [4096];
+    int buflen = sizeof (buf);
+    int n = vsnprintf (buf, buflen, fmt, ap);
+    if (n >= buflen) {
+        buf[buflen-1] = '\0';
+        buf[buflen-2] = '+';
+    }
+    flux_shell_log (level, file, line, "%s", buf);
+}
+
 int flux_shell_err (const char *file,
                    int line,
                    int errnum,
@@ -353,6 +374,7 @@ void shell_log_fini (void)
     free (logger.prog);
     fclose (logger.fp);
 }
+
 
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab

--- a/src/shell/log.h
+++ b/src/shell/log.h
@@ -32,6 +32,17 @@ void shell_log_set_level (int level);
  */
 void shell_log_set_exception_logged (void);
 
+/*  Shell log function compatible with libutil llog interface
+ */
+void shell_llog (void *arg,
+                 const char *file,
+                 int line,
+                 const char *func,
+                 const char *subsys,
+                 int level,
+                 const char *fmt,
+                 va_list ap);
+
 #endif /* !_SHELL_RC_H */
 
 /* vi: ts=4 sw=4 expandtab

--- a/src/shell/mustache.c
+++ b/src/shell/mustache.c
@@ -1,0 +1,146 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdio.h>
+#include <string.h>
+
+#include "mustache.h"
+#include "src/common/libutil/llog.h"
+
+struct mustache_renderer {
+    mustache_tag_f tag_f;
+    void *tag_arg;
+
+    mustache_log_f llog;
+    void *llog_data;
+};
+
+void mustache_renderer_destroy (struct mustache_renderer *mr)
+{
+    free (mr);
+}
+
+
+struct mustache_renderer * mustache_renderer_create (mustache_tag_f tagfn,
+                                                     void *arg)
+{
+    struct mustache_renderer *mr = NULL;
+
+    if (!tagfn) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (!(mr = calloc (1, sizeof (*mr))))
+        return NULL;
+    mr->tag_f = tagfn;
+    mr->tag_arg = arg;
+    return (mr);
+}
+
+void mustache_renderer_set_log (struct mustache_renderer *mr,
+                                mustache_log_f log_f,
+                                void *log_arg)
+{
+    if (mr) {
+        mr->llog = log_f;
+        mr->llog_data = log_arg;
+    }
+}
+
+char *mustache_render (struct mustache_renderer *mr, const char *template)
+{
+    char name [1024];
+    size_t size;
+    char *result = NULL;
+    const char *pos = template;
+    FILE *fp = NULL;
+
+    if (mr == NULL || template == NULL) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (!(fp = open_memstream (&result, &size))) {
+        llog_error (mr, "open_memstream");
+        goto fail;
+    }
+    for (;;) {
+        int len;
+        char *end;
+
+        /*  Look for opening "{{"
+         */
+        char *start = strstr (pos, "{{");
+        if (start == NULL) {
+            /*  No more mustache tags, put rest of string and finish
+             */
+            if (fputs (pos, fp) < 0) {
+                llog_error (mr, "fputs(%s): %s", pos, strerror (errno));
+                goto fail;
+            }
+            break;
+        }
+        /*  Write any part of template from current position to next tag
+         */
+        if (start > pos && fwrite (pos, start - pos, 1, fp) == 0) {
+            llog_error (mr, "fwrite: %s", strerror (errno));
+            goto fail;
+        }
+        /*  Advance past opening braces
+         */
+        start += 2;
+
+        /*  Find end of template tag
+         */
+        end = strstr (start, "}}");
+        if (end == NULL) {
+            llog_error (mr, "mustache template error at pos=%d",
+                        (int)(start-template));
+            /*  Copy rest of template and exit
+             */
+            pos = start - 2;
+            if (fputs (pos, fp) < 0) {
+                llog_error (mr, "fputs(%s): %s", pos, strerror (errno));
+                goto fail;
+            }
+            break;
+        }
+        /*  Copy mustache tag into 'name' and substitute with callback
+         */
+        len = end - start;
+        memcpy (name, start, len);
+        name[len] = '\0';
+        if ((*mr->tag_f) (fp, name, mr->tag_arg) < 0) {
+            /*  If callback fails, just fail to expand the current mustache tag.
+             */
+            fprintf (fp, "{{%s}}", name);
+        }
+
+        /*  Advance past closing braces '}}' and continue processing
+         */
+        pos = end + 2;
+    }
+    fclose (fp);
+    return result;
+fail:
+    if (fp) {
+        fclose (fp);
+        free (result);
+    }
+    return strdup (template);
+}
+
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/shell/mustache.h
+++ b/src/shell/mustache.h
@@ -1,0 +1,60 @@
+/************************************************************\
+ * Copyright 2020 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _SHELL_MUSTACHE_H
+#define _SHELL_MUSTACHE_H
+
+#include <stdio.h>
+
+typedef void (*mustache_log_f) (void *arg,
+                                const char *file,
+                                int line,
+                                const char *func,
+                                const char *subsys,
+                                int level,
+                                const char *fmt,
+                                va_list args);
+
+/*  Mustache tag callback function prototype. This function is called
+ *   for any mustache tag 'name' found in the template by the mustache
+ *   template renderer. E.g. if {{foo}} then the tag callback will be
+ *   called with `tag == "foo"`. The function should just write the value
+ *   of `tag` to the FILE stream `fp` if found.
+ *
+ * This function should return < 0 on error, in which case the template
+ *   renderer will copy the unsubstituted mustache tag into the result.
+ */
+typedef int (*mustache_tag_f) (FILE *fp, const char *tag, void *arg);
+
+struct mustache_renderer;
+
+/*  Create a mustache renderer, with mustache tags expanded by tag
+ *   callback `cb`. (See callback definition above).
+ */
+struct mustache_renderer *mustache_renderer_create (mustache_tag_f cb,
+                                                    void *arg);
+
+void mustache_renderer_destroy (struct mustache_renderer *mr);
+
+/*  Set a custom logger for mustache renderer 'mr'.
+ */
+void mustache_renderer_set_log (struct mustache_renderer *mr,
+                                mustache_log_f log,
+                                void *log_data);
+                                
+/*  Render the mustache template 'template' with renderer 'mr'.
+ */
+char * mustache_render (struct mustache_renderer *mr, const char *template);
+
+#endif /* !_SHELL_MUSTACHE_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/shell/output.c
+++ b/src/shell/output.c
@@ -597,7 +597,7 @@ static int mustache_cb (FILE *fp, const char *name, void *arg)
     if (strncmp (name, "jobid", 5) == 0)
         name += 3;
     if (strncmp (name, "id", 2) == 0) {
-        const char *type = "dec";
+        const char *type = "f58";
         if (strlen (name) > 2) {
             if (name[2] != '.') {
                 shell_log_error ("Unknown mustache tag '%s'", name);

--- a/src/shell/pty.c
+++ b/src/shell/pty.c
@@ -24,25 +24,7 @@
 #include "src/common/libterminus/pty.h"
 #include "src/common/libterminus/terminus.h"
 #include "builtins.h"
-
-static void shlog (void *arg,
-                   const char *file,
-                   int line,
-                   const char *func,
-                   const char *subsys,
-                   int level,
-                   const char *fmt,
-                   va_list ap)
-{
-    char buf [4096];
-    int buflen = sizeof (buf);
-    int n = vsnprintf (buf, buflen, fmt, ap);
-    if (n >= buflen) {
-        buf[buflen-1] = '\0';
-        buf[buflen-2] = '+';
-    }
-    flux_shell_log (level, file, line, "%s", buf);
-}
+#include "log.h"
 
 static struct flux_terminus_server *
 shell_terminus_server_start (flux_shell_t *shell, const char *shell_service)
@@ -70,7 +52,7 @@ shell_terminus_server_start (flux_shell_t *shell, const char *shell_service)
                             t,
                             (flux_free_f) flux_terminus_server_destroy) < 0)
         return NULL;
-    flux_terminus_server_set_log (t, shlog, NULL);
+    flux_terminus_server_set_log (t, shell_llog, NULL);
 
     /* Ensure process knows it is a terminus session */
     flux_shell_setenvf (shell, 1, "FLUX_TERMINUS_SESSION", "0");

--- a/src/shell/test/mustache.c
+++ b/src/shell/test/mustache.c
@@ -1,0 +1,108 @@
+/************************************************************\
+ * Copyright 2020 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <errno.h>
+#include <string.h>
+#include <flux/core.h>
+
+#include "src/common/libtap/tap.h"
+
+#include "mustache.h"
+
+struct mustache_test {
+    const char *template;
+    const char *expected;
+    int errnum;
+};
+
+struct mustache_test tests[] = {
+    { "", "", 0 },
+    { "notemplate", "notemplate", 0 },
+    { "{{", "{{", 0 },
+    { "foo-{{", "foo-{{", 0 },
+    { "}}", "}}", 0 },
+    { "foo-}}", "foo-}}", 0 },
+    { "{{boop}}", "{{boop}}", 0 },
+    { "test-{{name}}", "test-foo", 0 },
+    { "test-{{name}}.out", "test-foo.out", 0 },
+    { "test-{{name}}.out", "test-foo.out", 0 },
+    { "{{number}}", "42", 0 },
+    { "{{name}}-{{number}}.out", "foo-42.out", 0 },
+    { "{{name}}-{{number}}.out", "foo-42.out", 0 },
+    { NULL, NULL, 0 },
+};
+
+
+int cb (FILE *fp, const char *tag, void *arg)
+{
+    ok (fp != NULL,
+        "cb passed valid FILE *");
+    ok (tag != NULL,
+        "cb passed valid tag");
+    ok (arg != NULL,
+        "cb passed valid arg");
+    if (strcmp (tag, "name") == 0)
+        return fputs ("foo", fp);
+    if (strcmp (tag, "number") == 0)
+        return fputs ("42", fp);
+    errno = ENOENT;
+    return -1;
+}
+
+int main (int argc, char **argv)
+{
+    struct mustache_test *mp = tests;
+    struct mustache_renderer *mr = NULL;
+
+    plan (NO_PLAN);
+
+    mr = mustache_renderer_create (NULL, NULL);
+    ok (mr == NULL && errno == EINVAL,
+        "mustache_renderer_create fails with invalid callback");
+
+    /*  Pass tests as tag_f argument so we have something non-NULL to test
+     *   in the callback
+     */
+    mr = mustache_renderer_create (cb, tests);
+    ok (mr != NULL,
+        "mustache_renderer_create");
+
+    ok (mustache_render (mr, NULL) == NULL && errno == EINVAL,
+        "mustache_render (mr, NULL) returns EINVAL");
+
+    while (mp->template != NULL) {
+        char * result = mustache_render (mr, mp->template);
+        if (mp->expected == NULL)
+            ok (result == NULL && errno == mp->errnum,
+                "mustache_render '%s' failed with errno = %d",
+                mp->template,
+                errno);
+        else
+            is (result, mp->expected,
+                "mustache_render '%s' returned '%s'",
+                mp->template,
+                result);
+        free (result);
+        mp++;
+    }
+
+    mustache_renderer_destroy (mr);
+    done_testing ();
+
+    return 0;
+}
+
+/*
+ * vi:ts=4 sw=4 expandtab
+ */

--- a/t/t0025-broker-state-machine.t
+++ b/t/t0025-broker-state-machine.t
@@ -3,6 +3,8 @@
 
 test_description='Test broker state machine'
 
+# Append --logfile option if FLUX_TESTS_LOGFILE is set in environment:
+test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
 . `dirname $0`/sharness.sh
 
 RPC=${FLUX_BUILD_DIR}/t/request/rpc

--- a/t/t2605-job-shell-output-redirection-standalone.t
+++ b/t/t2605-job-shell-output-redirection-standalone.t
@@ -242,6 +242,25 @@ for type in f58 dec hex dothex words; do
  '
 done
 
+test_expect_success HAVE_JQ "flux-shell: bad output mustache template is not rendered" '
+	cat j1echoboth \
+	    |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
+	    |  $jq ".attributes.system.shell.options.output.stdout.path = \"{{idx}}.out\"" \
+	    > j1-mustache-error1 &&
+	${FLUX_SHELL} -v -s -r 0 -j j1-mustache-error1 -R R1 1234 &&
+	grep stdout:baz {{idx}}.out &&
+	grep stderr:baz {{idx}}.out
+'
+test_expect_success HAVE_JQ "flux-shell: bad output mustache template is not rendered" '
+	cat j1echoboth \
+	    |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
+	    |  $jq ".attributes.system.shell.options.output.stdout.path = \"{{id.x}}.out\"" \
+	    > j1-mustache-error2 &&
+	${FLUX_SHELL} -v -s -r 0 -j j1-mustache-error2 -R R1 1234 &&
+	grep stdout:baz {{id.x}}.out &&
+	grep stderr:baz {{id.x}}.out
+'
+
 #
 # output corner case tests
 #

--- a/t/t2605-job-shell-output-redirection-standalone.t
+++ b/t/t2605-job-shell-output-redirection-standalone.t
@@ -2,6 +2,8 @@
 #
 test_description='Test flux-shell in --standalone mode'
 
+# Append --logfile option if FLUX_TESTS_LOGFILE is set in environment:
+test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
 . `dirname $0`/sharness.sh
 
 #  Run flux-shell under flux command to get correct paths

--- a/t/t2605-job-shell-output-redirection-standalone.t
+++ b/t/t2605-job-shell-output-redirection-standalone.t
@@ -207,9 +207,9 @@ test_expect_success HAVE_JQ 'flux-shell: run 2-task echo job (stdout term/stderr
 test_expect_success HAVE_JQ 'flux-shell: run 1-task echo job (mustache id stdout file/stderr file)' '
         cat j1echoboth \
             |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
-            |  $jq ".attributes.system.shell.options.output.stdout.path = \"out{{id}}\"" \
+            |  $jq ".attributes.system.shell.options.output.stdout.path = \"out{{jobid}}\"" \
             |  $jq ".attributes.system.shell.options.output.stderr.type = \"file\"" \
-            |  $jq ".attributes.system.shell.options.output.stderr.path = \"err{{id}}\"" \
+            |  $jq ".attributes.system.shell.options.output.stderr.path = \"err{{jobid}}\"" \
             > j1echoboth-14 &&
 	${FLUX_SHELL} -v -s -r 0 -j j1echoboth-14 -R R1 14 &&
 	grep stdout:baz out14 &&
@@ -225,6 +225,20 @@ test_expect_success HAVE_JQ 'flux-shell: run 1-task echo job (mustache id stdout
 	grep stdout:baz out15 &&
 	grep stderr:baz out15
 '
+
+for type in f58 dec hex dothex words; do
+  test_expect_success HAVE_JQ "flux-shell: output template {{id.$type}}" '
+    jobid=123456789 &&
+    id=$(flux job id --to=${type} ${jobid}) &&
+        cat j1echoboth \
+            |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
+            |  $jq ".attributes.system.shell.options.output.stdout.path = \"out{{id.${type}}}\"" \
+            > j1-mustache-${type} &&
+	${FLUX_SHELL} -v -s -r 0 -j j1-mustache-${type} -R R1 ${jobid} &&
+	grep stdout:baz out${id} &&
+	grep stderr:baz out${id}
+ '
+done
 
 #
 # output corner case tests

--- a/t/t2605-job-shell-output-redirection-standalone.t
+++ b/t/t2605-job-shell-output-redirection-standalone.t
@@ -205,6 +205,7 @@ test_expect_success HAVE_JQ 'flux-shell: run 2-task echo job (stdout term/stderr
 #
 
 test_expect_success HAVE_JQ 'flux-shell: run 1-task echo job (mustache id stdout file/stderr file)' '
+    id=$(flux job id --to=f58 14) &&
         cat j1echoboth \
             |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
             |  $jq ".attributes.system.shell.options.output.stdout.path = \"out{{jobid}}\"" \
@@ -212,18 +213,19 @@ test_expect_success HAVE_JQ 'flux-shell: run 1-task echo job (mustache id stdout
             |  $jq ".attributes.system.shell.options.output.stderr.path = \"err{{jobid}}\"" \
             > j1echoboth-14 &&
 	${FLUX_SHELL} -v -s -r 0 -j j1echoboth-14 -R R1 14 &&
-	grep stdout:baz out14 &&
-	grep stderr:baz err14
+	grep stdout:baz out${id} &&
+	grep stderr:baz err${id}
 '
 
 test_expect_success HAVE_JQ 'flux-shell: run 1-task echo job (mustache id stdout & stderr to stdout file)' '
+    id=$(flux job id --to=f58 15) &&
         cat j1echoboth \
             |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
             |  $jq ".attributes.system.shell.options.output.stdout.path = \"out{{id}}\"" \
             > j1echoboth-15 &&
 	${FLUX_SHELL} -v -s -r 0 -j j1echoboth-15 -R R1 15 &&
-	grep stdout:baz out15 &&
-	grep stderr:baz out15
+	grep stdout:baz out${id} &&
+	grep stderr:baz out${id}
 '
 
 for type in f58 dec hex dothex words; do

--- a/t/t2606-job-shell-output-redirection.t
+++ b/t/t2606-job-shell-output-redirection.t
@@ -150,8 +150,7 @@ test_expect_success 'job-shell: run 2-task echo job (stdout kvs/stderr file)' '
 test_expect_success 'job-shell: run 1-task echo job (mustache id stdout file/stderr file)' '
         id=$(flux mini submit -n1 \
              --output="out{{id}}" --error="err{{id}}" \
-             ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz \
-             | flux job id) &&
+             ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz) &&
         flux job wait-event $id clean &&
         grep stdout:baz out${id} &&
         grep stderr:baz err${id}
@@ -160,8 +159,7 @@ test_expect_success 'job-shell: run 1-task echo job (mustache id stdout file/std
 test_expect_success 'flux-shell: run 1-task echo job (mustache id stdout & stderr to stdout file)' '
         id=$(flux mini submit -n1 \
              --output="out{{id}}" \
-             ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz \
-             | flux job id) &&
+             ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz) &&
         flux job wait-event $id clean &&
         grep stdout:baz out${id} &&
         grep stderr:baz out${id}

--- a/t/t2606-job-shell-output-redirection.t
+++ b/t/t2606-job-shell-output-redirection.t
@@ -165,6 +165,15 @@ test_expect_success 'flux-shell: run 1-task echo job (mustache id stdout & stder
         grep stderr:baz out${id}
 '
 
+test_expect_success 'flux-shell: bad mustache template still writes output' '
+        id=$(flux mini submit -n1 \
+             --output="out{{invalid" \
+             ${TEST_SUBPROCESS_DIR}/test_echo -P -O -E baz) &&
+        flux job wait-event $id clean &&
+        grep stdout:baz out{{invalid &&
+        grep stderr:baz out{{invalid
+'
+
 #
 # output file outputs correct information to guest.output
 #

--- a/t/t2701-mini-batch.t
+++ b/t/t2701-mini-batch.t
@@ -61,9 +61,9 @@ test_expect_success 'flux-mini batch fails for file without she-bang' '
 	test_expect_code 1 flux mini batch -n1 invalid-script.sh
 '
 test_expect_success 'flux-mini batch: submit a series of jobs' '
-	id1=$(flux mini batch --flags=waitable -n1 batch-script.sh | flux job id) &&
-	id2=$(flux mini batch --flags=waitable -n4 batch-script.sh | flux job id) &&
-	id3=$(flux mini batch --flags=waitable -N2 -n4 batch-script.sh | flux job id) &&
+	id1=$(flux mini batch --flags=waitable -n1 batch-script.sh) &&
+	id2=$(flux mini batch --flags=waitable -n4 batch-script.sh) &&
+	id3=$(flux mini batch --flags=waitable -N2 -n4 batch-script.sh) &&
 	flux job wait --all
 '
 test_expect_success 'flux-mini batch: job results are expected' '
@@ -80,9 +80,9 @@ test_expect_success 'flux-mini batch: --output=kvs directs output to kvs' '
 '
 test_expect_success 'flux-mini batch: --broker-opts works' '
 	id=$(flux mini batch -n1 --flags=waitable \
-	     --broker-opts=-v batch-script.sh | flux job id) &&
+	     --broker-opts=-v batch-script.sh) &&
 	id2=$(flux mini batch -n1 --flags=waitable \
-	     --broker-opts=-v,-H5 batch-script.sh | flux job id) &&
+	     --broker-opts=-v,-H5 batch-script.sh) &&
 	flux job wait $id &&
 	test_debug "cat flux-${id}.out" &&
 	grep "boot: rank=0 size=1" flux-${id}.out &&


### PR DESCRIPTION
Use the F58 encoding for jobids by default when expanding `{{id}}` in output file mustache template in the job shell. This makes the default output file from `flux mini batch` consistent with the default output of `flux jobs`.

Also, accept `{{jobid}}` as an alternate for `{{id}}`.

Finally, allow alternate encodings to be specified if desired by specifying `{{id.<type>}}` where `type` is any encoding supported by `flux_job_id_encode(3)`, e.g.

```
ƒ(s=1,d=0,builddir) grondo@asp:~/git/flux-core.git$ flux mini run --output=flux-{{id}}.out hostname
0: stdout redirected to flux-ƒEMqPeRm.out
0: stderr redirected to flux-ƒEMqPeRm.out
ƒ(s=1,d=0,builddir) grondo@asp:~/git/flux-core.git$ flux mini run --output=flux-{{id.dec}}.out hostname
0: stdout redirected to flux-662515482624.out
0: stderr redirected to flux-662515482624.out
ƒ(s=1,d=0,builddir) grondo@asp:~/git/flux-core.git$ flux mini run --output=flux-{{id.hex}}.out hostname
0: stdout redirected to flux-0x145e1000000.out
0: stderr redirected to flux-0x145e1000000.out
ƒ(s=1,d=0,builddir) grondo@asp:~/git/flux-core.git$ flux mini run --output=flux-{{id.words}}.out hostname
0: stdout redirected to flux-hilton-story-james--jacket-academy-academy.out
0: stderr redirected to flux-hilton-story-james--jacket-academy-academy.out
```