### PR TITLE
resource: mark nodes down when they are stopped

### DIFF
--- a/etc/flux.service.in
+++ b/etc/flux.service.in
@@ -6,6 +6,7 @@ TimeoutStopSec=90
 KillMode=mixed
 ExecStart=@X_BINDIR@/flux broker \
   --config-path=@X_SYSCONFDIR@/flux/system/conf.d \
+  --k-ary=256 \
   -Srundir=@X_RUNSTATEDIR@/flux \
   -Slocal-uri=local://@X_RUNSTATEDIR@/flux/local \
   -Slog-stderr-level=6 \

--- a/etc/rc1
+++ b/etc/rc1
@@ -22,7 +22,7 @@ modload all aggregator
 modload all kvs
 modload all kvs-watch
 
-modload 0 resource
+modload all resource
 modload 0 job-info
 modload 0 cron sync=hb
 modload 0 job-manager

--- a/etc/rc3
+++ b/etc/rc3
@@ -23,7 +23,7 @@ done
 shopt -u nullglob
 
 modrm 0 sched-simple
-modrm 0 resource
+modrm all resource
 modrm 0 job-exec
 modrm 0 job-manager
 modrm all job-ingest

--- a/src/broker/state_machine.c
+++ b/src/broker/state_machine.c
@@ -30,8 +30,6 @@
 static const double quorum_batch_timeout = 0.1;
 
 struct quorum {
-    zlist_t *requests;
-
     struct idset *want;
     struct idset *have; // cumulative on rank 0, batch buffer on rank > 0
     flux_watcher_t *batch_timer;
@@ -92,9 +90,6 @@ static void monitor_update (flux_t *h, zlist_t *requests, broker_state_t state);
 static void join_check_parent (struct state_machine *s);
 static int quorum_add_self (struct state_machine *s);
 static void quorum_check_parent (struct state_machine *s);
-static void quorum_monitor_update (flux_t *h,
-                                   zlist_t *requests,
-                                   struct idset *idset);
 static void run_check_parent (struct state_machine *s);
 
 static struct state statetab[] = {
@@ -197,7 +192,6 @@ static void action_quorum (struct state_machine *s)
     if (s->ctx->rank == 0) {
         if (idset_equal (s->quorum.want, s->quorum.have))
             state_machine_post (s, "quorum-full");
-        quorum_monitor_update (s->ctx->h, s->quorum.requests, s->quorum.have);
     }
     else
         quorum_check_parent (s);
@@ -548,7 +542,6 @@ static void quorum_batch (flux_reactor_t *r,
         if (s->state == STATE_QUORUM
                 && idset_equal (s->quorum.want, s->quorum.have))
             state_machine_post (s, "quorum-full");
-        quorum_monitor_update (s->ctx->h, s->quorum.requests, s->quorum.have);
     }
     else {
         flux_future_t *f;
@@ -695,30 +688,6 @@ static flux_watcher_t *quorum_create_batch_timer (struct state_machine *s)
                                       s);
 }
 
-/* (rank 0 only) Update any queued 'state-machine.quorum-monitor' requests.
- *
- */
-static void quorum_monitor_update (flux_t *h,
-                                   zlist_t *requests,
-                                   struct idset *idset)
-{
-    const flux_msg_t *msg;
-    char *tmp;
-
-    if (!(tmp = idset_encode (idset,
-                              IDSET_FLAG_RANGE | IDSET_FLAG_BRACKETS))) {
-        flux_log_error (h, "error responding to quorum-monitor requests");
-        return;
-    }
-    msg = zlist_first (requests);
-    while (msg) {
-        if (flux_respond_pack (h, msg, "{s:s}", "idset", tmp) < 0)
-            flux_log_error (h, "error responding to quorum-monitor request");
-        msg = zlist_next (requests);
-    }
-    free (tmp);
-}
-
 static void quorum_monitor_cb (flux_t *h,
                                flux_msg_handler_t *mh,
                                const flux_msg_t *msg,
@@ -740,14 +709,6 @@ static void quorum_monitor_cb (flux_t *h,
         goto error;
     if (flux_respond_pack (h, msg, "{s:s}", "idset", tmp) < 0)
         goto error;
-    if (flux_msg_is_streaming (msg)) {
-        if (zlist_append (s->quorum.requests,
-                          (flux_msg_t *)flux_msg_incref (msg)) < 0) {
-            flux_msg_decref (msg);
-            errno = ENOMEM;
-            goto error;
-        }
-    }
     free (tmp);
     return;
 error:
@@ -905,8 +866,6 @@ static void disconnect_cb (flux_t *h,
     int count = 0;
 
     if (flux_msg_get_route_first (msg, &sender) == 0) {
-        while (msglist_drop_sender (s->quorum.requests, sender))
-            count++;
         while (msglist_drop_sender (s->monitor.requests, sender))
             count++;
         free (sender);
@@ -949,7 +908,6 @@ void state_machine_destroy (struct state_machine *s)
         flux_msg_handler_delvec (s->handlers);
         flux_future_destroy (s->monitor.f);
         msglist_destroy (s->monitor.requests);
-        msglist_destroy (s->quorum.requests);
         idset_destroy (s->quorum.want);
         idset_destroy (s->quorum.have);
         flux_watcher_destroy (s->quorum.batch_timer);
@@ -986,8 +944,6 @@ struct state_machine *state_machine_create (struct broker *ctx)
         if (!(s->monitor.f = monitor_parent (ctx->h, s)))
             goto error;
     }
-    if (!(s->quorum.requests = zlist_new ()))
-        goto nomem;
     if (!(s->quorum.have = idset_create (ctx->size, 0)))
         goto error;
     if (quorum_configure (s) < 0)

--- a/src/modules/resource/acquire.c
+++ b/src/modules/resource/acquire.c
@@ -369,8 +369,8 @@ error:
 }
 
 static const struct flux_msg_handler_spec htab[] = {
-    { FLUX_MSGTYPE_REQUEST,  MODULE_NAME ".acquire", acquire_cb, 0 },
-    { FLUX_MSGTYPE_REQUEST,  MODULE_NAME ".acquire-cancel", cancel_cb, 0 },
+    { FLUX_MSGTYPE_REQUEST,  "resource.acquire", acquire_cb, 0 },
+    { FLUX_MSGTYPE_REQUEST,  "resource.acquire-cancel", cancel_cb, 0 },
     FLUX_MSGHANDLER_TABLE_END,
 };
 

--- a/src/modules/resource/acquire.c
+++ b/src/modules/resource/acquire.c
@@ -379,6 +379,7 @@ void acquire_destroy (struct acquire *acquire)
     if (acquire) {
         int saved_errno = errno;
         flux_msg_handler_delvec (acquire->handlers);
+        reslog_set_callback (acquire->ctx->reslog, NULL, NULL);
         if (acquire->request) {
             if (flux_respond_error (acquire->ctx->h,
                                     acquire->request->msg,

--- a/src/modules/resource/discover.c
+++ b/src/modules/resource/discover.c
@@ -278,6 +278,7 @@ void discover_destroy (struct discover *discover)
 {
     if (discover) {
         int saved_errno = errno;
+        monitor_set_callback (discover->ctx->monitor, NULL, NULL);
         flux_subprocess_destroy (discover->p);
         flux_future_destroy (discover->f);
         flux_msg_handler_delvec (discover->handlers);

--- a/src/modules/resource/drain.c
+++ b/src/modules/resource/drain.c
@@ -260,8 +260,8 @@ static int replay_eventlog (struct drain *drain, const json_t *eventlog)
 }
 
 static const struct flux_msg_handler_spec htab[] = {
-    { FLUX_MSGTYPE_REQUEST,  MODULE_NAME ".drain", drain_cb, 0 },
-    { FLUX_MSGTYPE_REQUEST,  MODULE_NAME ".undrain", undrain_cb, 0 },
+    { FLUX_MSGTYPE_REQUEST,  "resource.drain", drain_cb, 0 },
+    { FLUX_MSGTYPE_REQUEST,  "resource.undrain", undrain_cb, 0 },
     FLUX_MSGHANDLER_TABLE_END,
 };
 

--- a/src/modules/resource/monitor.c
+++ b/src/modules/resource/monitor.c
@@ -8,14 +8,18 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
-/* monitor.c - resource monitoring
+/* monitor.c - track execution targets joining/leaving the instance
  *
- * Use the 'state-machine.quorum-monitor' RPC to track broker ranks that come
- * online.  Maintain the set of "up" brokers internally, and call a callback
- * each time that set changes.
+ * On rank 0 only:
+ * - call registered callback on 'up' set changes.
+ * - post 'online' / 'offline' events to resource.eventlog on 'up' set changes,
+ *   relative to initial 'online' set posted with 'restart' event.
+ * - publish 'resource.monitor-restart' event.
  *
- * Post online/offline events with incremental changes to execution
- * target availability since resource-init was posted.
+ * On other ranks:
+ * - say hello to rank 0 at startup, and on receipt of monitor-restart event.
+ * - say goodbye to rank 0 at teardown.
+ * - hello/goodbye messages are batched and reduced on the way to rank 0.
  */
 
 #if HAVE_CONFIG_H
@@ -32,16 +36,35 @@
 #include "monitor.h"
 #include "rutil.h"
 
+/* This is a simple batching of hello and goodbye RPCs to avoid
+ * a storm at rank 0.  They will tend to come in waves as rc1 completes
+ * at each tree level, and again in reverse for rc3, but ranks within a level
+ * that complete relatively close in time can can be batched.
+ */
+static const double batch_timeout_seconds = 0.1;
+
+struct batch {
+    struct idset *hello;
+    struct idset *goodbye;
+};
 
 struct monitor {
     struct resource_ctx *ctx;
-    flux_future_t *f;
+    struct batch *batch;
+    flux_watcher_t *batch_timer;
+
     struct idset *up;
-    struct idset *down; // only updated on access
+
+    flux_msg_handler_t **handlers;
 
     monitor_cb_f cb;
     void *cb_arg;
+    struct idset *down; // cached result of monitor_get_down()
 };
+
+static int goodbye_idset (flux_t *h, const char *s);
+static int hello_idset (flux_t *h, const char *s);
+
 
 const struct idset *monitor_get_up (struct monitor *monitor)
 {
@@ -66,102 +89,335 @@ const struct idset *monitor_get_down (struct monitor *monitor)
     return monitor->down;
 }
 
-/* Handle updates to the idset of available brokers.
- * Post online/offline events for any newly up or down ranks.
- * Update monitor->up and call callback if any.
- */
-static void quorum_monitor_continuation (flux_future_t *f, void *arg)
-{
-    struct monitor *monitor = arg;
-    flux_t *h = monitor->ctx->h;
-    const char *s;
-    struct idset *idset, *up, *dn;
-
-    if (flux_rpc_get_unpack (f, "{s:s}", "idset", &s) < 0
-            || !(idset = idset_decode (s))) {
-        flux_log_error (h, "error parsing quorum-monitor response");
-        return;
-    }
-    if (rutil_idset_diff (monitor->up, idset, &up, &dn) < 0) {
-        flux_log_error (h, "error analyzing quorum_monitor response");
-        idset_destroy (idset);
-        return;
-    }
-    if (up && idset_count (up) > 0) {
-        char *online;
-        if (!(online = idset_encode (up, IDSET_FLAG_RANGE))
-            || reslog_post_pack (monitor->ctx->reslog,
-                                 NULL,
-                                 "online",
-                                 "{s:s}",
-                                 "idset",
-                                 online) < 0)
-            flux_log_error (h, "error posting online event");
-        free (online);
-        idset_destroy (up);
-    }
-    if (dn && idset_count (dn) > 0) {
-        char *offline;
-        if (!(offline = idset_encode (dn, IDSET_FLAG_RANGE))
-            || reslog_post_pack (monitor->ctx->reslog,
-                                 NULL,
-                                 "offline",
-                                 "{s:s}",
-                                 "idset",
-                                 offline) < 0)
-            flux_log_error (h, "error posting offline event");
-        free (offline);
-        idset_destroy (dn);
-    }
-    idset_destroy (monitor->up);
-    monitor->up = idset;
-    if (monitor->cb)
-        monitor->cb (monitor, monitor->cb_arg);
-    flux_future_reset (monitor->f);
-}
-
-/* Send state-machine.quorum-monitor request, process the first response
- * (synchronously), set up continuation for next responses.
- */
-static int quorum_monitor_start (struct monitor *monitor)
-{
-    flux_future_t *f;
-    const char *s;
-    struct idset *idset = NULL;
-
-    if (!(f = flux_rpc (monitor->ctx->h,
-                        "state-machine.quorum-monitor",
-                        NULL,
-                        0,
-                        FLUX_RPC_STREAMING)))
-        return -1;
-    if (flux_rpc_get_unpack (f, "{s:s}", "idset", &s) < 0)
-        goto error;
-    if (!(idset = idset_decode (s)))
-        goto error;
-    flux_future_reset (f);
-    if (flux_future_then (f, -1, quorum_monitor_continuation, monitor) < 0)
-        goto error;
-    monitor->f = f;
-    monitor->up = idset;
-    return 0;
-error:
-    ERRNO_SAFE_WRAP (idset_destroy, idset);
-    flux_future_destroy (f);
-    return -1;
-}
-
 void monitor_set_callback (struct monitor *monitor, monitor_cb_f cb, void *arg)
 {
     monitor->cb = cb;
     monitor->cb_arg = arg;
 }
 
+static void batch_destroy (struct batch *batch)
+{
+    if (batch) {
+        int saved_errno = errno;
+        idset_destroy (batch->hello);
+        idset_destroy (batch->goodbye);
+        free (batch);
+        errno = saved_errno;
+    }
+}
+
+static struct batch *batch_create (struct monitor *monitor)
+{
+    struct batch *b;
+
+    if (!(b = calloc (1, sizeof (*b))))
+        return NULL;
+    if (!(b->hello = idset_create (monitor->ctx->size, 0)))
+        goto error;
+    if (!(b->goodbye = idset_create (monitor->ctx->size, 0)))
+        goto error;
+    flux_timer_watcher_reset (monitor->batch_timer, batch_timeout_seconds, 0.);
+    flux_watcher_start (monitor->batch_timer);
+    return b;
+error:
+    batch_destroy (b);
+    return NULL;
+}
+
+/* Leader: batch contains hello/goodbye info from one or more downstream peers.
+ * Update monitor->up accordingly, and
+ * 1) Post online/offline events to resource.eventlog
+ * 2) Notify discover subsystem via callback
+ * Avoid posting event or notifying discover if nothing changed,
+ * e.g. if 'monitor-force-up' option pre-set all targets up.
+ */
+static int batch_timeout_leader (struct monitor *monitor)
+{
+    struct batch *b = monitor->batch;
+    flux_t *h = monitor->ctx->h;
+    char *hello = NULL;
+    char *goodbye = NULL;
+    struct idset *cpy;
+    int rc = -1;
+
+    if (!(cpy = idset_copy (monitor->up)))
+        return -1;
+    if (idset_count (b->hello) > 0) {
+        if (!(hello = idset_encode (b->hello, IDSET_FLAG_RANGE)))
+            goto done;
+        flux_log (h, LOG_DEBUG, "monitor-batch: hello %s", hello);
+        if (rutil_idset_add (monitor->up, b->hello) < 0)
+            goto done;
+    }
+    if (idset_count (b->goodbye) > 0) {
+        if (!(goodbye = idset_encode (b->goodbye, IDSET_FLAG_RANGE)))
+            goto done;
+        flux_log (h, LOG_DEBUG, "monitor-batch: goodbye %s", goodbye);
+        if (rutil_idset_sub (monitor->up, b->goodbye) < 0)
+            goto done;
+    }
+    if (!idset_equal (monitor->up, cpy)) {
+        if (hello && reslog_post_pack (monitor->ctx->reslog,
+                                       NULL,
+                                       "online",
+                                       "{s:s}",
+                                       "idset",
+                                       hello) < 0) {
+            flux_log_error (h, "monitor-batch: error posting online event");
+            goto done;
+        }
+        if (goodbye && reslog_post_pack (monitor->ctx->reslog,
+                                         NULL,
+                                         "offline",
+                                         "{s:s}",
+                                         "idset",
+                                         goodbye) < 0) {
+            flux_log_error (h, "monitor-batch: error posting offline event");
+            goto done;
+        }
+        if (monitor->cb)
+            monitor->cb (monitor, monitor->cb_arg);
+    }
+    rc = 0;
+done:
+    free (hello);
+    free (goodbye);
+    idset_destroy (cpy);
+    return rc;
+}
+
+/* Follower: batch contains hello/goodbye info from one or more downstream
+ * peers.  Forward the reduced info upstream.
+ */
+static int batch_timeout_follower (struct monitor *monitor)
+{
+    struct batch *b = monitor->batch;
+    char *hello = NULL;
+    char *goodbye = NULL;
+    int rc = -1;
+
+    if (idset_count (b->hello) > 0) {
+        if (!(hello = idset_encode (b->hello, IDSET_FLAG_RANGE)))
+            goto done;
+        if (hello_idset (monitor->ctx->h, hello) < 0)
+            goto done;
+    }
+    if (idset_count (b->goodbye) > 0) {
+        if (!(goodbye = idset_encode (b->goodbye, IDSET_FLAG_RANGE)))
+            goto done;
+        if (goodbye_idset (monitor->ctx->h, goodbye) < 0)
+            goto done;
+    }
+    rc = 0;
+done:
+    free (hello);
+    free (goodbye);
+    return rc;
+}
+
+/* The batch timer has expired.
+ */
+static void batch_timeout (flux_reactor_t *r,
+                           flux_watcher_t *w,
+                           int revents,
+                           void *arg)
+{
+    struct monitor *monitor = arg;
+    int rc;
+
+    if (monitor->batch) {
+        if (monitor->ctx->rank == 0)
+            rc = batch_timeout_leader (monitor);
+        else
+            rc = batch_timeout_follower (monitor);
+        if (rc < 0)
+            flux_log_error (monitor->ctx->h, "monitor-batch");
+        batch_destroy (monitor->batch);
+        monitor->batch = NULL;
+    }
+}
+
+static void hello_cb (flux_t *h,
+                      flux_msg_handler_t *mh,
+                      const flux_msg_t *msg,
+                      void *arg)
+{
+    struct monitor *monitor = arg;
+    uint32_t rank = FLUX_NODEID_ANY;
+    const char *s = NULL;
+
+    if (flux_request_unpack (msg,
+                             NULL,
+                             "{s?s s?i}",
+                             "idset",
+                             &s,
+                             "rank",
+                             &rank) < 0) {
+        flux_log_error (h, "hello: error unpacking request");
+        return;
+    }
+    if (!monitor->batch) {
+        if (!(monitor->batch = batch_create (monitor)))
+            goto error;
+    }
+    if (rank != FLUX_NODEID_ANY) {
+        if (idset_set (monitor->batch->hello, rank)  < 0)
+            goto error;
+    }
+    if (s) {
+        if (rutil_idset_decode_add (monitor->batch->hello, s) < 0)
+            goto error;
+    }
+    return;
+error:
+    flux_log_error (h, "monitor-hello: error processing request");
+}
+
+static void goodbye_cb (flux_t *h,
+                        flux_msg_handler_t *mh,
+                        const flux_msg_t *msg,
+                        void *arg)
+{
+    struct monitor *monitor = arg;
+    const char *s = NULL;
+    uint32_t rank = FLUX_NODEID_ANY;
+
+    if (flux_request_unpack (msg,
+                             NULL,
+                             "{s?s s?i}",
+                             "idset",
+                             &s,
+                             "rank",
+                             &rank) < 0) {
+        flux_log_error (h, "goodbye: error unpacking request");
+        return;
+    }
+    if (!monitor->batch) {
+        if (!(monitor->batch = batch_create (monitor)))
+            goto error;
+    }
+    if (rank != FLUX_NODEID_ANY) {
+        if (idset_set (monitor->batch->goodbye, rank) < 0)
+            goto error;
+    }
+    if (s) {
+        if (rutil_idset_decode_add (monitor->batch->goodbye, s) < 0)
+            goto error;
+    }
+    return;
+error:
+    flux_log_error (h, "goodbye: error processing request");
+}
+
+static int hello_idset (flux_t *h, const char *s)
+{
+    flux_future_t *f;
+
+    if (!(f = flux_rpc_pack (h,
+                             "resource.monitor-hello",
+                             FLUX_NODEID_UPSTREAM,
+                             FLUX_RPC_NORESPONSE,
+                             "{s:s}",
+                             "idset",
+                             s)))
+        return -1;
+    flux_future_destroy (f);
+    return 0;
+}
+
+static int goodbye_idset (flux_t *h, const char *s)
+{
+    flux_future_t *f;
+
+    if (!(f = flux_rpc_pack (h,
+                             "resource.monitor-goodbye",
+                             FLUX_NODEID_UPSTREAM,
+                             FLUX_RPC_NORESPONSE,
+                             "{s:s}",
+                             "idset",
+                             s)))
+        return -1;
+    flux_future_destroy (f);
+    return 0;
+}
+
+static int hello_rank (flux_t *h, uint32_t rank)
+{
+    flux_future_t *f;
+    if (!(f = flux_rpc_pack (h,
+                             "resource.monitor-hello",
+                             FLUX_NODEID_UPSTREAM,
+                             FLUX_RPC_NORESPONSE,
+                             "{s:i}",
+                             "rank",
+                             rank)))
+        return -1;
+    flux_future_destroy (f);
+    return 0;
+}
+
+static int goodbye_rank (flux_t *h, uint32_t rank)
+{
+    flux_future_t *f;
+    if (!(f = flux_rpc_pack (h,
+                             "resource.monitor-goodbye",
+                             FLUX_NODEID_UPSTREAM,
+                             FLUX_RPC_NORESPONSE,
+                             "{s:i}",
+                             "rank",
+                             rank)))
+        return -1;
+    flux_future_destroy (f);
+    return 0;
+}
+
+/* Say hello (again) when requested by rank 0.
+ */
+static void reload_cb (flux_t *h,
+                       flux_msg_handler_t *mh,
+                       const flux_msg_t *msg,
+                       void *arg)
+{
+    struct monitor *monitor = arg;
+
+    if (flux_event_decode (msg, NULL, NULL) < 0) {
+        flux_log_error (h, "monitor-reload: error parsing event message");
+        return;
+    }
+    if (hello_rank (h, monitor->ctx->rank) < 0)
+        flux_log_error (h, "monitor-reload: error sending hello message");
+}
+
+/* Tell any loaded ranks to say hello again.
+ */
+static int publish_reload (flux_t *h)
+{
+    flux_future_t *f;
+
+    if (!(f = flux_event_publish (h, "resource.monitor-reload", 0, NULL)))
+        return -1;
+    flux_future_destroy (f);
+    return 0;
+}
+
+static const struct flux_msg_handler_spec htab[] = {
+    { FLUX_MSGTYPE_REQUEST,  "resource.monitor-goodbye", goodbye_cb, 0 },
+    { FLUX_MSGTYPE_REQUEST,  "resource.monitor-hello", hello_cb, 0 },
+    { FLUX_MSGTYPE_EVENT,    "resource.monitor-reload", reload_cb, 0 },
+    FLUX_MSGHANDLER_TABLE_END,
+};
+
 void monitor_destroy (struct monitor *monitor)
 {
     if (monitor) {
         int saved_errno = errno;
-        flux_future_destroy (monitor->f);
+        if (monitor->ctx->rank > 0) {
+            if (goodbye_rank (monitor->ctx->h, monitor->ctx->rank) < 0)
+                flux_log_error (monitor->ctx->h, "monitor.goodbye failed");
+        }
+        batch_destroy (monitor->batch);
+        flux_watcher_destroy (monitor->batch_timer);
+        flux_msg_handler_delvec (monitor->handlers);
         idset_destroy (monitor->up);
         idset_destroy (monitor->down);
         free (monitor);
@@ -169,19 +425,46 @@ void monitor_destroy (struct monitor *monitor)
     }
 }
 
-struct monitor *monitor_create (struct resource_ctx *ctx)
+struct monitor *monitor_create (struct resource_ctx *ctx,
+                                bool monitor_force_up)
 {
     struct monitor *monitor;
 
     if (!(monitor = calloc (1, sizeof (*monitor))))
         return NULL;
     monitor->ctx = ctx;
-    if (ctx->rank == 0) {
-        if (quorum_monitor_start (monitor) < 0) {
-            flux_log_error (ctx->h, "state-machine.quorum-monitor "
-                            "during initialization");
+    if (flux_msg_handler_addvec (ctx->h, htab, monitor, &monitor->handlers) < 0)
+        goto error;
+    if (!(monitor->batch_timer = flux_timer_watcher_create (
+                                                flux_get_reactor (ctx->h),
+                                                batch_timeout_seconds,
+                                                0.,
+                                                batch_timeout,
+                                                monitor)))
+        goto error;
+    if (monitor->ctx->rank > 0) {
+        if (hello_rank (ctx->h, ctx->rank) < 0)
             goto error;
+        if (flux_event_subscribe (ctx->h, "resource.monitor-reload") < 0)
+            goto error;
+    }
+    else {
+        /* Initialize up to "0" unless 'monitor_force_up' is true.
+         * N.B. Initial up value will appear in 'restart' event posted
+         * to resource.eventlog.
+         */
+        if (!(monitor->up = idset_create (ctx->size, 0)))
+            goto error;
+        if (monitor_force_up) {
+            if (idset_range_set (monitor->up, 0, ctx->size - 1) < 0)
+                goto error;
         }
+        else {
+            if (idset_set (monitor->up, 0) < 0)
+                goto error;
+        }
+        if (publish_reload (ctx->h) < 0)
+            goto error;
     }
     return monitor;
 error:

--- a/src/modules/resource/monitor.c
+++ b/src/modules/resource/monitor.c
@@ -176,9 +176,12 @@ struct monitor *monitor_create (struct resource_ctx *ctx)
     if (!(monitor = calloc (1, sizeof (*monitor))))
         return NULL;
     monitor->ctx = ctx;
-    if (quorum_monitor_start (monitor) < 0) {
-        flux_log_error (ctx->h, "state-machine.quorum-monitor during initialization");
-        goto error;
+    if (ctx->rank == 0) {
+        if (quorum_monitor_start (monitor) < 0) {
+            flux_log_error (ctx->h, "state-machine.quorum-monitor "
+                            "during initialization");
+            goto error;
+        }
     }
     return monitor;
 error:

--- a/src/modules/resource/monitor.h
+++ b/src/modules/resource/monitor.h
@@ -13,7 +13,8 @@
 
 typedef void (*monitor_cb_f)(struct monitor *monitor, void *arg);
 
-struct monitor *monitor_create (struct resource_ctx *ctx);
+struct monitor *monitor_create (struct resource_ctx *ctx,
+                                bool monitor_force_up);
 void monitor_destroy (struct monitor *monitor);
 void monitor_set_callback (struct monitor *monitor, monitor_cb_f cb, void *arg);
 

--- a/src/modules/resource/resource.c
+++ b/src/modules/resource/resource.c
@@ -48,13 +48,12 @@ static int parse_config (struct resource_ctx *ctx,
     if (flux_conf_unpack (conf,
                           &error,
                           "{s?:{s?:s !}}",
-                          MODULE_NAME,
+                          "resource",
                             "exclude",
                             &exclude) < 0) {
         (void)snprintf (errbuf,
                         errbufsize,
-                        "error parsing [%s] configuration: %s",
-                        MODULE_NAME,
+                        "error parsing [resource] configuration: %s",
                         error.errbuf);
         return -1;
     }
@@ -147,13 +146,13 @@ static struct resource_ctx *resource_ctx_create (flux_t *h)
 static const struct flux_msg_handler_spec htab[] = {
     {
         .typemask = FLUX_MSGTYPE_REQUEST,
-        .topic_glob = MODULE_NAME ".config-reload",
+        .topic_glob = "resource.config-reload",
         .cb = config_reload_cb,
         .rolemask = 0
     },
     {
         .typemask = FLUX_MSGTYPE_REQUEST,
-        .topic_glob = MODULE_NAME ".disconnect",
+        .topic_glob = "resource.disconnect",
         .cb = disconnect_cb,
         .rolemask = 0
     },
@@ -309,7 +308,7 @@ error:
     return -1;
 }
 
-MOD_NAME (MODULE_NAME);
+MOD_NAME ("resource");
 
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab

--- a/src/modules/resource/resource.h
+++ b/src/modules/resource/resource.h
@@ -21,6 +21,7 @@ struct resource_ctx {
     struct acquire *acquire;
     struct reslog *reslog;
 
+    uint32_t rank;
     uint32_t size;
 };
 

--- a/src/modules/resource/resource.h
+++ b/src/modules/resource/resource.h
@@ -24,10 +24,6 @@ struct resource_ctx {
     uint32_t size;
 };
 
-/* Module name, service name, config table name.
- */
-#define MODULE_NAME "resource"
-
 #endif /* !_FLUX_RESOURCE_H */
 
 /*

--- a/src/modules/resource/rutil.c
+++ b/src/modules/resource/rutil.c
@@ -57,6 +57,18 @@ int rutil_idset_add (struct idset *ids1, const struct idset *ids2)
     return 0;
 }
 
+int rutil_idset_decode_add (struct idset *ids1, const char *s)
+{
+    struct idset *ids2;
+    int rc;
+
+    if (!(ids2 = idset_decode (s)))
+        return -1;
+    rc = rutil_idset_add (ids1, ids2);
+    idset_destroy (ids2);
+    return rc;
+}
+
 int rutil_idset_diff (const struct idset *ids1,
                       const struct idset *ids2,
                       struct idset **addp,

--- a/src/modules/resource/rutil.h
+++ b/src/modules/resource/rutil.h
@@ -18,6 +18,10 @@
 int rutil_idset_sub (struct idset *ids1, const struct idset *ids2);
 int rutil_idset_add (struct idset *ids1, const struct idset *ids2);
 
+/* Same as above but ids2 is in string-encoded form.
+ */
+int rutil_idset_decode_add (struct idset *ids1, const char *s);
+
 /* Compare 'old_set' to 'new_set'.
  * Create '*add' for ids in new_set but not in old_set (sets NULL if n/a).
  * Create '*sub' for ids in old_set but not in new_set (sets NULL if n/a).

--- a/src/modules/resource/test/rutil.c
+++ b/src/modules/resource/test/rutil.c
@@ -136,6 +136,27 @@ void test_idset_add (void)
     idset_destroy (ids2);
 }
 
+void test_idset_decode_add (void)
+{
+    struct idset *ids1;
+
+    if (!(ids1 = idset_create (1024, 0)))
+        BAIL_OUT ("idset_create failed");
+
+    errno = 0;
+    ok (rutil_idset_decode_add (NULL, "0") < 0 && errno == EINVAL,
+        "rutil_idset_decode_add ids1=NULL fails with EINVAL");
+    errno = 0;
+    ok (rutil_idset_decode_add (ids1, NULL) < 0 && errno == EINVAL,
+        "rutil_idset_decode_add s=NULL fails with EINVAL");
+    ok (rutil_idset_decode_add (ids1, "0") == 0 && idset_count (ids1) == 1,
+        "rutil_idset_decode_add s=0 works");
+    ok (rutil_idset_decode_add (ids1, "1") == 0 && idset_count (ids1) == 2,
+        "rutil_idset_decode_add s=1 works");
+
+    idset_destroy (ids1);
+}
+
 void test_idset_diff (void)
 {
     struct idset *ids1;
@@ -351,6 +372,7 @@ int main (int argc, char *argv[])
     test_match_request_sender ();
     test_idset_sub ();
     test_idset_add ();
+    test_idset_decode_add ();
     test_idset_diff ();
     test_set_json_idset ();
     test_idset_from_resobj ();

--- a/t/rc/rc1-job
+++ b/t/rc/rc1-job
@@ -36,7 +36,7 @@ if test $RANK -eq 0; then
     # Load a fake resource.hwloc.by_rank key for sched-simple
     set_fake_hwloc_by_rank ${TEST_UNDER_FLUX_CORES_PER_RANK:-2}
 fi
-modload 0 resource
+modload all resource
 
 modload 0 job-exec
 

--- a/t/rc/rc3-job
+++ b/t/rc/rc3-job
@@ -12,7 +12,7 @@ modrm() {
 
 modrm 0 job-exec
 modrm 0 sched-simple
-modrm 0 resource
+modrm all resource
 modrm 0 job-manager
 modrm all barrier
 modrm 0 job-info

--- a/t/t0010-generic-utils.t
+++ b/t/t0010-generic-utils.t
@@ -9,7 +9,7 @@ Verify basic functionality of generic flux utils
 . `dirname $0`/sharness.sh
 SIZE=4
 LASTRANK=$((SIZE-1))
-test_under_flux ${SIZE} kvs
+test_under_flux ${SIZE} minimal
 
 RPC=${FLUX_BUILD_DIR}/t/request/rpc
 

--- a/t/t0025-broker-state-machine.t
+++ b/t/t0025-broker-state-machine.t
@@ -95,13 +95,6 @@ test_expect_success HAVE_JQ 'quorum-monitor singleton RPC works' '
 	jq -cea .idset qm0.out
 '
 
-test_expect_success HAVE_JQ 'quorum-monitor streaming RPC works' '
-	flux start ${ARGS} \
-		$SRPC state-machine.quorum-monitor idset \
-		</dev/null >qms.out &&
-	jq -cea .idset qms.out
-'
-
 test_expect_success 'quorum-monitor RPC fails on rank > 0' '
 	test_must_fail flux start -s2 ${ARGS} \
 		flux exec -r1 $RPC state-machine.quorum-monitor \

--- a/t/t0025-broker-state-machine.t
+++ b/t/t0025-broker-state-machine.t
@@ -13,7 +13,7 @@ ARGS="-o,-Sbroker.rc1_path=,-Sbroker.rc3_path="
 
 test_expect_success 'create qget.sh script to query quorum' '
 	cat >qget.sh <<-EOT &&
-	$RPC state-machine.quorum-monitor | jq -r .idset
+	$RPC state-machine.quorum-get | jq -r .idset
 	EOT
 	chmod +x qget.sh
 '
@@ -88,16 +88,16 @@ test_expect_success HAVE_JQ 'instance functions with late-joiner' '
 	test_cmp late.exp late.out
 '
 
-test_expect_success HAVE_JQ 'quorum-monitor singleton RPC works' '
+test_expect_success HAVE_JQ 'quorum-get RPC works' '
 	flux start ${ARGS} \
-		$RPC state-machine.quorum-monitor \
+		$RPC state-machine.quorum-get \
 		</dev/null >qm0.out &&
 	jq -cea .idset qm0.out
 '
 
-test_expect_success 'quorum-monitor RPC fails on rank > 0' '
+test_expect_success 'quorum-get RPC fails on rank > 0' '
 	test_must_fail flux start -s2 ${ARGS} \
-		flux exec -r1 $RPC state-machine.quorum-monitor \
+		flux exec -r1 $RPC state-machine.quorum-get \
 		</dev/null 2>qm1.err &&
 	grep "only available on rank 0" qm1.err
 '

--- a/t/t2300-sched-simple.t
+++ b/t/t2300-sched-simple.t
@@ -46,7 +46,7 @@ test_expect_success 'sched-simple: load default by_rank' '
 '
 test_expect_success 'sched-simple: reload sched-simple' '
 	flux module unload sched-simple &&
-	flux module reload resource &&
+	flux module reload resource monitor-force-up &&
 	flux module load sched-simple &&
 	flux dmesg 2>&1 >reload.dmesg.log &&
 	grep "ready:.*rank\[0-1\]/core\[0-1\]" reload.dmesg.log &&

--- a/t/t2302-sched-simple-up-down.t
+++ b/t/t2302-sched-simple-up-down.t
@@ -47,7 +47,7 @@ test_expect_success 'sched-simple: load default by_rank' '
 '
 test_expect_success 'sched-simple: reload sched-simple' '
 	flux module unload sched-simple &&
-	flux module reload resource &&
+	flux module reload resource monitor-force-up &&
 	flux module load sched-simple &&
 	flux dmesg 2>&1 >reload.dmesg.log &&
 	test_debug "grep sched-simple reload.dmesg.log" &&

--- a/t/t2310-resource-module.t
+++ b/t/t2310-resource-module.t
@@ -60,7 +60,7 @@ test_expect_success 'load aggregator module needed for flux hwloc reload' '
 '
 
 test_expect_success 'load resource module' '
-	flux module load resource
+	flux exec -r all flux module load resource
 '
 
 test_expect_success HAVE_JQ 'resource.eventlog exists' '
@@ -201,7 +201,7 @@ test_expect_success 'reload config/module excluding rank 0' '
 	exclude = "0"
 	EOT
 	flux config reload &&
-	flux module reload resource
+	flux module reload resource monitor-force-up
 '
 
 test_expect_success HAVE_JQ 'acquire returns resources excluding rank 0' '
@@ -252,7 +252,7 @@ test_expect_success HAVE_JQ,NO_CHAIN_LINT 'add/remove new exclusion causes down/
 '
 
 test_expect_success 'unload resource module' '
-	flux module remove resource
+	flux exec -r all flux module remove resource
 '
 test_expect_success 'unload aggregator module' '
 	flux exec -r all flux module remove aggregator


### PR DESCRIPTION
This PR changes the resource module's monitoring code so that it's now possible to `systemctl stop flux` on a compute node and have it be marked down for scheduling automatically.

The resource module is now loaded on all ranks, and when the broker is shutdown and unloads the module on a rank > 0, the resource module sends a "goodbye" message upstream.  For symmetry, it also sends a "hello" message upstream when the module is loaded.  These two messages are reduced as they move towards rank 0.  With the addition of the "hello" message, it was trivial to decouple the resource module from the broker "quorum" code - prob a good thing to let that remain as simple as possible, while this one learns how to detect non-responsive execution targets however we want to define that, etc..

There is a mechanism to trigger another round of "hello" if the rank 0 resource module is reloaded (e.g. in test), and a module option to force all ranks to be initially up, also useful in test where we already know the entire instance is live.

Also tacked on to this PR: a small commit to set `--k-ary=256` in the systemd unit file to keep system instance TBONs flat for the time being.

Marking WIP pending addition of tests and also some manual, small scale system instance testing.