### PR TITLE
job-manager / job-info: get job data changes from job-manager to job-info so job listings will have up to date information

### DIFF
--- a/etc/rc1
+++ b/etc/rc1
@@ -23,9 +23,9 @@ modload all kvs
 modload all kvs-watch
 
 modload all resource
-modload 0 job-info
 modload 0 cron sync=hb
 modload 0 job-manager
+modload 0 job-info
 
 modload all job-ingest
 modload 0 job-exec

--- a/etc/rc3
+++ b/etc/rc3
@@ -25,6 +25,7 @@ shopt -u nullglob
 modrm 0 sched-simple
 modrm all resource
 modrm 0 job-exec
+modrm 0 job-info
 modrm 0 job-manager
 modrm all job-ingest
 
@@ -32,7 +33,6 @@ modrm 0 cron
 modrm all aggregator
 modrm all barrier
 
-modrm 0 job-info
 modrm all kvs-watch
 modrm all kvs
 

--- a/src/modules/job-info/job_state.c
+++ b/src/modules/job-info/job_state.c
@@ -468,7 +468,21 @@ static int eventlog_lookup_parse (struct info_ctx *ctx,
                           __FUNCTION__, (uintmax_t)job->id);
                 goto nonfatal_error;
             }
-            break;
+        }
+        else if (!strcmp (name, "priority")) {
+            if (!context) {
+                flux_log (ctx->h, LOG_ERR, "%s: no priority context for %ju",
+                          __FUNCTION__, (uintmax_t)job->id);
+                goto nonfatal_error;
+            }
+
+            if (json_unpack (context, "{ s:i }",
+                             "priority", &job->priority) < 0) {
+                flux_log (ctx->h, LOG_ERR,
+                          "%s: priority context for %ju invalid",
+                          __FUNCTION__, (uintmax_t)job->id);
+                goto nonfatal_error;
+            }
         }
     }
 

--- a/src/modules/job-info/job_state.c
+++ b/src/modules/job-info/job_state.c
@@ -240,6 +240,7 @@ void job_state_destroy (void *data)
         zhashx_destroy (&jsctx->index);
         zlistx_destroy (&jsctx->transitions);
         (void)flux_event_unsubscribe (jsctx->h, "job-state");
+        (void)flux_event_unsubscribe (jsctx->h, "job-annotations");
         free (jsctx);
     }
 }

--- a/src/modules/job-info/job_state.c
+++ b/src/modules/job-info/job_state.c
@@ -230,22 +230,15 @@ void job_state_destroy (void *data)
             }
             zlistx_destroy (&jsctx->futures);
         }
-        if (jsctx->early_annotations)
-            zhashx_destroy (&jsctx->early_annotations);
+        zhashx_destroy (&jsctx->early_annotations);
         /* Destroy index last, as it is the one that will actually
          * destroy the job objects */
-        if (jsctx->processing)
-            zlistx_destroy (&jsctx->processing);
-        if (jsctx->inactive)
-            zlistx_destroy (&jsctx->inactive);
-        if (jsctx->running)
-            zlistx_destroy (&jsctx->running);
-        if (jsctx->pending)
-            zlistx_destroy (&jsctx->pending);
-        if (jsctx->index)
-            zhashx_destroy (&jsctx->index);
-        if (jsctx->transitions)
-            zlistx_destroy (&jsctx->transitions);
+        zlistx_destroy (&jsctx->processing);
+        zlistx_destroy (&jsctx->inactive);
+        zlistx_destroy (&jsctx->running);
+        zlistx_destroy (&jsctx->pending);
+        zhashx_destroy (&jsctx->index);
+        zlistx_destroy (&jsctx->transitions);
         (void)flux_event_unsubscribe (jsctx->h, "job-state");
         free (jsctx);
     }

--- a/src/modules/job-info/job_state.c
+++ b/src/modules/job-info/job_state.c
@@ -275,8 +275,8 @@ static int *state_counter (struct info_ctx *ctx,
     else if (state == FLUX_JOB_INACTIVE)
         return &ctx->jsctx->inactive_count;
 
-    flux_log_error (ctx->h, "illegal state transition for job %ju: %d",
-                    (uintmax_t)job->id, state);
+    flux_log (ctx->h, LOG_ERR, "illegal state transition for job %ju: %d",
+              (uintmax_t)job->id, state);
     return NULL;
 }
 
@@ -454,8 +454,8 @@ static int eventlog_lookup_parse (struct info_ctx *ctx,
 
         if (!strcmp (name, "submit")) {
             if (!context) {
-                flux_log_error (ctx->h, "%s: no submit context for %ju",
-                                __FUNCTION__, (uintmax_t)job->id);
+                flux_log (ctx->h, LOG_ERR, "%s: no submit context for %ju",
+                          __FUNCTION__, (uintmax_t)job->id);
                 goto nonfatal_error;
             }
 
@@ -463,8 +463,8 @@ static int eventlog_lookup_parse (struct info_ctx *ctx,
                              "priority", &job->priority,
                              "userid", &job->userid,
                              "flags", &job->flags) < 0) {
-                flux_log_error (ctx->h, "%s: submit context for %ju invalid",
-                                __FUNCTION__, (uintmax_t)job->id);
+                flux_log (ctx->h, LOG_ERR, "%s: submit context for %ju invalid",
+                          __FUNCTION__, (uintmax_t)job->id);
                 goto nonfatal_error;
             }
             break;
@@ -1468,8 +1468,8 @@ static struct job *eventlog_restart_parse (struct info_ctx *ctx,
 
         if (!strcmp (name, "submit")) {
             if (!context) {
-                flux_log_error (ctx->h, "%s: no submit context for %ju",
-                                __FUNCTION__, (uintmax_t)job->id);
+                flux_log (ctx->h, LOG_ERR, "%s: no submit context for %ju",
+                          __FUNCTION__, (uintmax_t)job->id);
                 goto error;
             }
 
@@ -1477,8 +1477,8 @@ static struct job *eventlog_restart_parse (struct info_ctx *ctx,
                              "priority", &job->priority,
                              "userid", &job->userid,
                              "flags", &job->flags) < 0) {
-                flux_log_error (ctx->h, "%s: submit context for %ju invalid",
-                                __FUNCTION__, (uintmax_t)job->id);
+                flux_log (ctx->h, LOG_ERR, "%s: submit context for %ju invalid",
+                          __FUNCTION__, (uintmax_t)job->id);
                 goto error;
             }
             update_job_state (ctx, job, FLUX_JOB_DEPEND, timestamp);
@@ -1488,29 +1488,31 @@ static struct job *eventlog_restart_parse (struct info_ctx *ctx,
         }
         else if (!strcmp (name, "priority")) {
             if (!context) {
-                flux_log_error (ctx->h, "%s: no priority context for %ju",
-                                __FUNCTION__, (uintmax_t)job->id);
+                flux_log (ctx->h, LOG_ERR, "%s: no priority context for %ju",
+                          __FUNCTION__, (uintmax_t)job->id);
                 goto error;
             }
 
             if (json_unpack (context, "{ s:i }",
                                       "priority", &job->priority) < 0) {
-                flux_log_error (ctx->h, "%s: priority context for %ju invalid",
-                                __FUNCTION__, (uintmax_t)job->id);
+                flux_log (ctx->h, LOG_ERR,
+                          "%s: priority context for %ju invalid",
+                          __FUNCTION__, (uintmax_t)job->id);
                 goto error;
             }
         }
         else if (!strcmp (name, "exception")) {
             int severity;
             if (!context) {
-                flux_log_error (ctx->h, "%s: no exception context for %ju",
-                                __FUNCTION__, (uintmax_t)job->id);
+                flux_log (ctx->h, LOG_ERR, "%s: no exception context for %ju",
+                          __FUNCTION__, (uintmax_t)job->id);
                 goto error;
             }
 
             if (json_unpack (context, "{ s:i }", "severity", &severity) < 0) {
-                flux_log_error (ctx->h, "%s: exception context for %ju invalid",
-                                __FUNCTION__, (uintmax_t)job->id);
+                flux_log (ctx->h, LOG_ERR,
+                          "%s: exception context for %ju invalid",
+                          __FUNCTION__, (uintmax_t)job->id);
                 goto error;
             }
             if (severity == 0)
@@ -1542,8 +1544,8 @@ static struct job *eventlog_restart_parse (struct info_ctx *ctx,
     }
 
     if (job->state == FLUX_JOB_NEW) {
-        flux_log_error (ctx->h, "%s: eventlog has no transition events",
-                        __FUNCTION__);
+        flux_log (ctx->h, LOG_ERR, "%s: eventlog has no transition events",
+                  __FUNCTION__);
         goto error;
     }
 

--- a/src/modules/job-info/job_state.c
+++ b/src/modules/job-info/job_state.c
@@ -468,6 +468,7 @@ static int eventlog_lookup_parse (struct info_ctx *ctx,
                           __FUNCTION__, (uintmax_t)job->id);
                 goto nonfatal_error;
             }
+            job->priority_timestamp = timestamp;
         }
         else if (!strcmp (name, "priority")) {
             if (!context) {
@@ -483,6 +484,7 @@ static int eventlog_lookup_parse (struct info_ctx *ctx,
                           __FUNCTION__, (uintmax_t)job->id);
                 goto nonfatal_error;
             }
+            job->priority_timestamp = timestamp;
         }
     }
 
@@ -1496,6 +1498,7 @@ static struct job *eventlog_restart_parse (struct info_ctx *ctx,
                           __FUNCTION__, (uintmax_t)job->id);
                 goto error;
             }
+            job->priority_timestamp = timestamp;
             update_job_state (ctx, job, FLUX_JOB_DEPEND, timestamp);
         }
         else if (!strcmp (name, "depend")) {
@@ -1515,6 +1518,7 @@ static struct job *eventlog_restart_parse (struct info_ctx *ctx,
                           __FUNCTION__, (uintmax_t)job->id);
                 goto error;
             }
+            job->priority_timestamp = timestamp;
         }
         else if (!strcmp (name, "exception")) {
             int severity;

--- a/src/modules/job-info/job_state.h
+++ b/src/modules/job-info/job_state.h
@@ -58,6 +58,9 @@ struct job_state_ctx {
      * processing later */
     bool pause;
     zlistx_t *transitions;
+
+    /* stream of job events from the job-manager */
+    flux_future_t *events;
 };
 
 struct job {

--- a/src/modules/job-info/job_state.h
+++ b/src/modules/job-info/job_state.h
@@ -66,6 +66,7 @@ struct job {
     flux_jobid_t id;
     uint32_t userid;
     int priority;
+    double priority_timestamp;
     double t_submit;
     int flags;
     flux_job_state_t state;

--- a/src/modules/job-manager/event.c
+++ b/src/modules/job-manager/event.c
@@ -987,6 +987,13 @@ error:
     return NULL;
 }
 
+int event_listeners_count (struct event *event)
+{
+    if (event)
+        return zlist_size (event->listeners);
+    return -1;
+}
+
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab
  */

--- a/src/modules/job-manager/event.c
+++ b/src/modules/job-manager/event.c
@@ -53,10 +53,12 @@ const double batch_timeout = 0.01;
 
 struct event {
     struct job_manager *ctx;
+    flux_msg_handler_t **handlers;
     struct event_batch *batch;
     flux_watcher_t *timer;
     zlist_t *pending;
     zlist_t *pub_futures;
+    zlist_t *listeners;
 };
 
 struct event_batch {
@@ -65,7 +67,15 @@ struct event_batch {
     flux_future_t *f;
     json_t *state_trans;
     json_t *annotations;
+    bool listener_response_available;
     zlist_t *responses; // responses deferred until batch complete
+};
+
+struct events_listener {
+    const flux_msg_t *request;
+    json_t *allow;
+    json_t *deny;
+    json_t *events;
 };
 
 struct event_batch *event_batch_create (struct event *event);
@@ -172,8 +182,42 @@ error:
     flux_reactor_stop_error (flux_get_reactor (ctx->h));
 }
 
+static void generate_listener_response (struct event *event,
+                                        struct events_listener *el)
+{
+    struct job_manager *ctx = event->ctx;
+    flux_msg_t *msg = NULL;
+    if (!(msg = flux_response_derive (el->request, 0))) {
+        flux_log_error (ctx->h, "%s: flux_response_derive",
+                        __FUNCTION__);
+        goto out;
+    }
+    if (flux_msg_pack (msg, "{s:O}", "events", el->events) < 0) {
+        flux_log_error (ctx->h, "%s: flux_msg_pack",
+                        __FUNCTION__);
+        goto out;
+    }
+    if (event_batch_respond (event, msg) < 0)
+        goto out;
+    json_array_clear (el->events);
+out:
+    flux_msg_decref (msg);
+}
+
+static void generate_listener_responses (struct event *event)
+{
+    struct events_listener *el;
+    el = zlist_first (event->listeners);
+    while (el) {
+        if (json_array_size (el->events) > 0)
+            generate_listener_response (event, el);
+        el = zlist_next (event->listeners);
+    }
+}
+
 /* Besides cleaning up, this function has the following side effects:
  * - publish state transition event (if any)
+ * - respond to listeners of events (if any)
  * - respond to deferred responses (if any)
  */
 void event_batch_destroy (struct event_batch *batch)
@@ -200,6 +244,8 @@ void event_batch_destroy (struct event_batch *batch)
                                batch->annotations);
             json_decref (batch->annotations);
         }
+        if (batch->listener_response_available)
+           generate_listener_responses (batch->event);
         if (batch->responses) {
             flux_msg_t *msg;
             flux_t *h = batch->event->ctx->h;
@@ -548,6 +594,77 @@ static int get_timestamp_now (double *timestamp)
     return 0;
 }
 
+/* we need to send the job id along with each eventlog entry, so wrap
+ * the eventlog entry in another object with the job id
+ */
+static json_t *wrap_events_entry (struct job *job, json_t *entry)
+{
+    json_t *wrapped_entry;
+    if (!(wrapped_entry = json_pack ("{s:I s:O}",
+                                     "id", job->id,
+                                     "entry", entry))) {
+        errno = ENOMEM;
+        return NULL;
+    }
+    return wrapped_entry;
+}
+
+static bool allow_deny_check (struct events_listener *el, const char *name)
+{
+    bool add_entry = true;
+
+    if (el->allow) {
+        add_entry = false;
+        if (json_object_get (el->allow, name))
+            add_entry = true;
+    }
+
+    if (add_entry && el->deny) {
+        if (json_object_get (el->deny, name))
+            add_entry = false;
+    }
+
+    return add_entry;
+}
+
+int event_batch_process_event_entry (struct event *event,
+                                     struct job *job,
+                                     const char *name,
+                                     json_t *entry)
+{
+    struct events_listener *el;
+    json_t *wrapped_entry = NULL;
+    int saved_errno;
+
+    if (event_batch_start (event) < 0)
+        goto error;
+
+    el = zlist_first (event->listeners);
+    while (el) {
+        if (allow_deny_check (el, name)) {
+            if (!wrapped_entry) {
+                if (!(wrapped_entry = wrap_events_entry (job, entry)))
+                    goto error;
+            }
+            if (json_array_append (el->events, wrapped_entry) < 0)
+                goto nomem;
+            event->batch->listener_response_available = true;
+        }
+
+        el = zlist_next (event->listeners);
+    }
+    json_decref (wrapped_entry);
+    return 0;
+
+nomem:
+    errno = ENOMEM;
+error:
+    saved_errno = errno;
+    json_decref (wrapped_entry);
+    errno = saved_errno;
+    return -1;
+}
+
 int event_job_post_pack (struct event *event,
                          struct job *job,
                          const char *name,
@@ -568,6 +685,8 @@ int event_job_post_pack (struct event *event,
     if (event_job_update (job, entry) < 0) // modifies job->state
         goto error;
     if (event_batch_commit_event (event, job, entry) < 0)
+        goto error;
+    if (event_batch_process_event_entry (event, job, name, entry) < 0)
         goto error;
     if (job->state != old_state) {
         if (event_batch_pub_state (event, job, timestamp) < 0)
@@ -596,12 +715,198 @@ error:
     return -1;
 }
 
+static void events_listener_destroy (void *data)
+{
+    struct events_listener *el = (struct events_listener *)data;
+    if (el) {
+        int saved_errno = errno;
+        flux_msg_decref (el->request);
+        json_decref (el->allow);
+        json_decref (el->deny);
+        json_decref (el->events);
+        free (el);
+        errno = saved_errno;
+    }
+}
+
+static struct events_listener *events_listener_create (const flux_msg_t *msg,
+                                                       json_t *allow,
+                                                       json_t *deny)
+{
+    struct events_listener *el;
+
+    if (!(el = calloc (1, sizeof (*el))))
+        goto error;
+    el->request = flux_msg_incref (msg);
+    el->allow = json_incref (allow);
+    el->deny = json_incref (deny);
+    if (!(el->events = json_array ())) {
+        errno = ENOMEM;
+        goto error;
+    }
+    return el;
+error:
+    events_listener_destroy (el);
+    return NULL;
+}
+
+void events_handle_request (flux_t *h,
+                            flux_msg_handler_t *mh,
+                            const flux_msg_t *msg,
+                            void *arg)
+{
+    struct job_manager *ctx = arg;
+    struct event *event = ctx->event;
+    struct events_listener *el = NULL;
+    const char *errstr = NULL;
+    json_t *allow = NULL;
+    json_t *deny = NULL;
+
+    if (flux_request_unpack (msg, NULL, "{s?o s?o}",
+                             "allow", &allow,
+                             "deny", &deny) < 0)
+        goto error;
+
+    if (!flux_msg_is_streaming (msg)) {
+        errno = EPROTO;
+        errstr = "job-manager.events requires streaming RPC flag";
+        goto error;
+    }
+
+    if (allow && !json_is_object (allow)) {
+        errno = EPROTO;
+        errstr = "job-manager.events allow should be an object";
+        goto error;
+    }
+
+    if (deny && !json_is_object (deny)) {
+        errno = EPROTO;
+        errstr = "job-manager.events deny should be an object";
+        goto error;
+    }
+
+    if (!(el = events_listener_create (msg, allow, deny)))
+        goto error;
+
+    if (zlist_append (event->listeners, el) < 0) {
+        errno = ENOMEM;
+        goto error;
+    }
+    zlist_freefn (event->listeners, el, events_listener_destroy, false);
+
+    return;
+
+error:
+    if (flux_respond_error (h, msg, errno, errstr) < 0)
+        flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
+    events_listener_destroy (el);
+}
+
+static bool match_events_listener (struct events_listener *el,
+                                   uint32_t matchtag,
+                                   const char *sender)
+{
+    uint32_t t;
+    char *s = NULL;
+    bool found = false;
+
+    if (!flux_msg_get_matchtag (el->request, &t)
+        && matchtag == t
+        && !flux_msg_get_route_first (el->request, &s)
+        && !strcmp (sender, s))
+        found = true;
+    free (s);
+    return found;
+}
+
+void events_cancel_request (flux_t *h, flux_msg_handler_t *mh,
+                            const flux_msg_t *msg, void *arg)
+{
+    struct job_manager *ctx = arg;
+    struct event *event = ctx->event;
+    struct events_listener *el;
+    uint32_t matchtag;
+    char *sender = NULL;
+
+    if (flux_request_unpack (msg, NULL, "{s:i}", "matchtag", &matchtag) < 0
+        || flux_msg_get_route_first (msg, &sender) < 0) {
+        flux_log_error (h, "error decoding events-cancel request");
+        return;
+    }
+    el = zlist_first (event->listeners);
+    while (el) {
+        if (match_events_listener (el, matchtag, sender))
+            break;
+        el = zlist_next (event->listeners);
+    }
+    if (el) {
+        if (flux_respond_error (h, el->request, ENODATA, NULL) < 0)
+            flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
+        zlist_remove (event->listeners, el);
+    }
+    free (sender);
+}
+
+static int create_zlist_and_append (zlist_t **lp, void *item)
+{
+    if (!*lp && !(*lp = zlist_new ())) {
+        errno = ENOMEM;
+        return -1;
+    }
+    if (zlist_append (*lp, item) < 0) {
+        errno = ENOMEM;
+        return -1;
+    }
+    return 0;
+}
+
+void event_listeners_disconnect_rpc (flux_t *h,
+                                     flux_msg_handler_t *mh,
+                                     const flux_msg_t *msg,
+                                     void *arg)
+{
+    struct job_manager *ctx = arg;
+    struct event *event = ctx->event;
+    struct events_listener *el;
+    char *sender;
+    zlist_t *tmplist = NULL;
+
+    if (flux_msg_get_route_first (msg, &sender) < 0)
+        return;
+    el = zlist_first (event->listeners);
+    while (el) {
+        char *tmpsender;
+        if (flux_msg_get_route_first (el->request, &tmpsender) == 0) {
+            if (!strcmp (sender, tmpsender)) {
+                /* cannot remove from zlist while iterating, so we
+                 * store off entries to remove on another list */
+                if (create_zlist_and_append (&tmplist, el) < 0) {
+                    flux_log_error (h, "job-manager.disconnect: "
+                                    "failed to remove event listener");
+                    free (tmpsender);
+                    goto error;
+                }
+            }
+            free (tmpsender);
+        }
+        el = zlist_next (event->listeners);
+    }
+    if (tmplist) {
+        while ((el = zlist_pop (tmplist)))
+            zlist_remove (event->listeners, el);
+    }
+    free (sender);
+error:
+    zlist_destroy (&tmplist);
+}
+
 /* Finalizes in-flight batch KVS commits and event pubs (synchronously).
  */
 void event_ctx_destroy (struct event *event)
 {
     if (event) {
         int saved_errno = errno;
+        flux_msg_handler_delvec (event->handlers);
         flux_watcher_destroy (event->timer);
         event_batch_commit (event);
         if (event->pending) {
@@ -620,10 +925,38 @@ void event_ctx_destroy (struct event *event)
             }
         }
         zlist_destroy (&event->pub_futures);
+        if (event->listeners) {
+            struct events_listener *el;
+            while ((el = zlist_pop (event->listeners))) {
+                if (flux_respond_error (event->ctx->h,
+                                        el->request,
+                                        ENODATA, NULL) < 0)
+                    flux_log_error (event->ctx->h, "%s: flux_respond_error",
+                                    __FUNCTION__);
+                events_listener_destroy (el);
+            }
+            zlist_destroy (&event->listeners);
+        }
         free (event);
         errno = saved_errno;
     }
 }
+
+static const struct flux_msg_handler_spec htab[] = {
+    {
+        FLUX_MSGTYPE_REQUEST,
+        "job-manager.events",
+        events_handle_request,
+        0
+    },
+    {
+        FLUX_MSGTYPE_REQUEST,
+        "job-manager.events-cancel",
+        events_cancel_request,
+        0
+    },
+    FLUX_MSGHANDLER_TABLE_END,
+};
 
 struct event *event_ctx_create (struct job_manager *ctx)
 {
@@ -632,6 +965,8 @@ struct event *event_ctx_create (struct job_manager *ctx)
     if (!(event = calloc (1, sizeof (*event))))
         return NULL;
     event->ctx = ctx;
+    if (flux_msg_handler_addvec (ctx->h, htab, ctx, &event->handlers) < 0)
+        goto error;
     if (!(event->timer = flux_timer_watcher_create (flux_get_reactor (ctx->h),
                                                     0.,
                                                     0.,
@@ -641,6 +976,8 @@ struct event *event_ctx_create (struct job_manager *ctx)
     if (!(event->pending = zlist_new ()))
         goto nomem;
     if (!(event->pub_futures = zlist_new ()))
+        goto nomem;
+    if (!(event->listeners = zlist_new ()))
         goto nomem;
     return event;
 nomem:

--- a/src/modules/job-manager/event.h
+++ b/src/modules/job-manager/event.h
@@ -70,6 +70,8 @@ void event_listeners_disconnect_rpc (flux_t *h,
                                      const flux_msg_t *msg,
                                      void *arg);
 
+int event_listeners_count (struct event *event);
+
 #endif /* _FLUX_JOB_MANAGER_EVENT_H */
 
 /*

--- a/src/modules/job-manager/event.h
+++ b/src/modules/job-manager/event.h
@@ -39,6 +39,13 @@ int event_batch_pub_state (struct event *event, struct job *job,
  */
 int event_batch_pub_annotations (struct event *event, struct job *job);
 
+/* Add notification of job event to send to listeners.
+ */
+int event_batch_process_event_entry (struct event *event,
+                                     struct job *job,
+                                     const char *name,
+                                     json_t *entry);
+
 /* Add add response to batch, to be sent upon batch completion.
  */
 int event_batch_respond (struct event *event, const flux_msg_t *msg);
@@ -57,6 +64,11 @@ int event_job_post_pack (struct event *event,
 
 void event_ctx_destroy (struct event *event);
 struct event *event_ctx_create (struct job_manager *ctx);
+
+void event_listeners_disconnect_rpc (flux_t *h,
+                                     flux_msg_handler_t *mh,
+                                     const flux_msg_t *msg,
+                                     void *arg);
 
 #endif /* _FLUX_JOB_MANAGER_EVENT_H */
 

--- a/src/modules/job-manager/job-manager.c
+++ b/src/modules/job-manager/job-manager.c
@@ -58,6 +58,7 @@ void disconnect_rpc (flux_t *h,
                      void *arg)
 {
     wait_disconnect_rpc (h, mh, msg, arg);
+    event_listeners_disconnect_rpc (h, mh, msg, arg);
 }
 
 static const struct flux_msg_handler_spec htab[] = {

--- a/src/modules/job-manager/job-manager.c
+++ b/src/modules/job-manager/job-manager.c
@@ -52,6 +52,14 @@ error:
         flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
 }
 
+void disconnect_rpc (flux_t *h,
+                     flux_msg_handler_t *mh,
+                     const flux_msg_t *msg,
+                     void *arg)
+{
+    wait_disconnect_rpc (h, mh, msg, arg);
+}
+
 static const struct flux_msg_handler_spec htab[] = {
     {
         FLUX_MSGTYPE_REQUEST,
@@ -70,6 +78,12 @@ static const struct flux_msg_handler_spec htab[] = {
         "job-manager.getinfo",
         getinfo_handle_request,
         FLUX_ROLE_USER
+    },
+    {
+        FLUX_MSGTYPE_REQUEST,
+        "job-manager.disconnect",
+        disconnect_rpc,
+        0
     },
     FLUX_MSGHANDLER_TABLE_END,
 };

--- a/src/modules/job-manager/submit.c
+++ b/src/modules/job-manager/submit.c
@@ -133,6 +133,8 @@ int submit_post_event (struct event *event, struct job *job)
         goto error;
     if (event_batch_pub_state (event, job, job->t_submit) < 0)
         goto error;
+    if (event_batch_process_event_entry (event, job, "submit", entry) < 0)
+        goto error;
     if (event_job_action (event, job) < 0)
         goto error;
     rv = 0;

--- a/src/modules/job-manager/wait.c
+++ b/src/modules/job-manager/wait.c
@@ -299,10 +299,10 @@ error:
 
 /* A client has disconnected.  Destroy any waiters registered by that client.
  */
-static void disconnect_rpc (flux_t *h,
-                            flux_msg_handler_t *mh,
-                            const flux_msg_t *msg,
-                            void *arg)
+void wait_disconnect_rpc (flux_t *h,
+                          flux_msg_handler_t *mh,
+                          const flux_msg_t *msg,
+                          void *arg)
 {
     struct job_manager *ctx = arg;
     struct waitjob *wait = ctx->wait;
@@ -405,12 +405,6 @@ static const struct flux_msg_handler_spec htab[] = {
         .typemask = FLUX_MSGTYPE_REQUEST,
         .topic_glob = "job-manager.wait",
         .cb = wait_rpc,
-        .rolemask = 0
-    },
-    {
-        .typemask = FLUX_MSGTYPE_REQUEST,
-        .topic_glob = "job-manager.disconnect",
-        .cb = disconnect_rpc,
         .rolemask = 0
     },
     FLUX_MSGHANDLER_TABLE_END,

--- a/src/modules/job-manager/wait.h
+++ b/src/modules/job-manager/wait.h
@@ -22,6 +22,11 @@ void wait_notify_active (struct waitjob *wait, struct job *job);
 struct waitjob *wait_ctx_create (struct job_manager *ctx);
 void wait_ctx_destroy (struct waitjob *wait);
 
+void wait_disconnect_rpc (flux_t *h,
+                          flux_msg_handler_t *mh,
+                          const flux_msg_t *msg,
+                          void *arg);
+
 struct job *wait_zombie_first (struct waitjob *wait);
 struct job *wait_zombie_next (struct waitjob *wait);
 

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -108,11 +108,13 @@ TESTSCRIPTS = \
 	t2207-job-manager-wait.t \
 	t2208-queue-cmd.t \
 	t2210-job-manager-bugs.t \
+	t2211-job-manager-events.t \
 	t2220-job-archive.t \
 	t2230-job-info-list.t \
 	t2231-job-info-lookup.t \
 	t2232-job-info-eventlog-watch.t \
 	t2233-job-info-security.t \
+	t2234-job-info-list-update.t \
 	t2300-sched-simple.t \
 	t2301-schedutil-outstanding-requests.t \
 	t2302-sched-simple-up-down.t \
@@ -272,6 +274,7 @@ check_PROGRAMS = \
 	rexec/rexec_count_stdout \
 	rexec/rexec_getline \
 	job-manager/list-jobs \
+	job-manager/event_stream \
 	ingest/submitbench \
 	sched-simple/jj-reader \
 	shell/rcalc \
@@ -536,6 +539,11 @@ ingest_submitbench_LDADD = \
 job_manager_list_jobs_SOURCES = job-manager/list-jobs.c
 job_manager_list_jobs_CPPFLAGS = $(test_cppflags)
 job_manager_list_jobs_LDADD = \
+	$(test_ldadd) $(LIBDL) $(LIBUTIL)
+
+job_manager_event_stream_SOURCES = job-manager/event_stream.c
+job_manager_event_stream_CPPFLAGS = $(test_cppflags)
+job_manager_event_stream_LDADD = \
 	$(test_ldadd) $(LIBDL) $(LIBUTIL)
 
 job_manager_sched_dummy_la_SOURCES = job-manager/sched-dummy.c

--- a/t/job-manager/event_stream.c
+++ b/t/job-manager/event_stream.c
@@ -1,0 +1,93 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <unistd.h>
+#include <jansson.h>
+#include <signal.h>
+#include <stdio.h>
+#include <flux/core.h>
+
+#include "src/common/libutil/read_all.h"
+#include "src/common/libutil/log.h"
+
+flux_t *h;
+flux_future_t *f;
+
+void cancel_cb (int sig)
+{
+    flux_future_t *f2;
+    if (!(f2 = flux_rpc_pack (h,
+                              "job-manager.events-cancel",
+                              FLUX_NODEID_ANY,
+                              FLUX_RPC_NORESPONSE,
+                              "{s:i}",
+                              "matchtag", (int)flux_rpc_get_matchtag (f))))
+        log_err_exit ("flux_rpc_pack");
+    flux_future_destroy (f2);
+}
+
+int main (int argc, char *argv[])
+{
+    ssize_t inlen;
+    void *inbuf;
+
+    if (!(h = flux_open (NULL, 0)))
+        log_err_exit ("flux_open");
+
+    if (argc != 1) {
+        fprintf (stderr, "Usage: event_stream <payload\n");
+        exit (1);
+    }
+
+    if ((inlen = read_all (STDIN_FILENO, &inbuf)) < 0)
+        log_err_exit ("read from stdin");
+    if (inlen > 0)  // flux stringified JSON payloads are sent with \0-term
+        inlen++;    //  and read_all() ensures inbuf has one, not acct in inlen
+
+    if (!(f = flux_rpc_raw (h,
+                            "job-manager.events",
+                            inbuf,
+                            inlen,
+                            FLUX_NODEID_ANY,
+                            FLUX_RPC_STREAMING)))
+        log_err_exit ("flux_rpc_raw");
+
+    if (signal (SIGUSR1, cancel_cb) == SIG_ERR)
+        log_err_exit ("signal");
+
+    while (1) {
+        json_t *events;
+        size_t index;
+        json_t *value;
+        if (flux_rpc_get_unpack (f, "{s:o}", "events", &events) < 0) {
+            if (errno == ENODATA)
+                break;
+            log_msg_exit ("job-manager.events: %s", future_strerror (f, errno));
+        }
+        json_array_foreach (events, index, value) {
+            char *s = json_dumps (value, 0);
+            printf ("%s\n", s);
+            fflush (stdout);
+            free (s);
+        }
+        flux_future_reset (f);
+    }
+    flux_future_destroy (f);
+    free (inbuf);
+    flux_close (h);
+    return (0);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/t/rc/rc3-job
+++ b/t/rc/rc3-job
@@ -13,9 +13,9 @@ modrm() {
 modrm 0 job-exec
 modrm 0 sched-simple
 modrm all resource
+modrm 0 job-info
 modrm 0 job-manager
 modrm all barrier
-modrm 0 job-info
 modrm all kvs-watch
 modrm all job-ingest
 

--- a/t/t2200-job-ingest.t
+++ b/t/t2200-job-ingest.t
@@ -82,10 +82,9 @@ test_expect_success 'job-ingest: job-ingest fails with bad validator path' '
 	test_must_fail flux module load job-ingest validator=/noexist
 '
 
-test_expect_success 'job-ingest: load job-ingest && job-info' '
+test_expect_success 'job-ingest: load job-ingest' '
 	ingest_module load \
-		validator=${BINDINGS_VALIDATOR} &&
-	flux module load job-info
+		validator=${BINDINGS_VALIDATOR}
 '
 
 test_expect_success HAVE_JQ 'job-ingest: dummy job-manager has expected max_jobid' '
@@ -124,9 +123,10 @@ test_expect_success 'job-ingest: job announced to job manager' '
 
 test_expect_success 'job-ingest: submit event logged with userid, priority' '
 	jobid=$(flux job submit --priority=11 basic.json) &&
-	flux job eventlog $jobid |grep submit >eventlog.out &&
-	grep -q priority=11 eventlog.out &&
-	grep -q userid=$(id -u) eventlog.out
+	kvspath=`flux job id --to=kvs ${jobid}` &&
+	flux kvs eventlog get ${kvspath}.eventlog |grep submit >eventlog.out &&
+	grep -q "\"priority\":11" eventlog.out &&
+	grep -q "\"userid\":$(id -u)" eventlog.out
 '
 
 test_expect_success 'job-ingest: instance owner can submit priority=31' '
@@ -217,7 +217,6 @@ test_expect_success 'job-ingest: validator unexpected exit is handled' '
 
 test_expect_success 'job-ingest: remove modules' '
 	flux module remove job-manager &&
-	flux module remove job-info &&
 	flux exec -r all flux module remove job-ingest
 '
 

--- a/t/t2202-job-manager.t
+++ b/t/t2202-job-manager.t
@@ -305,6 +305,11 @@ test_expect_success 'submit request with empty payload fails with EPROTO(71)' '
 	${RPC} job-manager.submit 71 </dev/null
 '
 
+test_expect_success HAVE_JQ 'job-manager stats works' '
+        flux module stats job-manager > stats.out &&
+        cat stats.out | $jq -e .events.listeners
+'
+
 test_expect_success 'job-manager: remove job-manager, job-info, job-ingest' '
 	flux module remove job-manager &&
 	flux module remove job-info &&

--- a/t/t2202-job-manager.t
+++ b/t/t2202-job-manager.t
@@ -173,8 +173,11 @@ test_expect_success HAVE_JQ 'job-manager: save max_jobid' '
 	${RPC} job-manager.getinfo | jq .max_jobid >max2.exp
 '
 
+# job-info module depends on job-manager, unload and reload it too
 test_expect_success 'job-manager: reload the job manager' '
-	flux module reload job-manager
+	flux module remove job-info &&
+	flux module reload job-manager &&
+	flux module load job-info
 '
 
 test_expect_success 'job-manager: queue was successfully reconstructed' '
@@ -246,8 +249,11 @@ test_expect_success 'job-manager: no jobs in the queue' '
 	test $(${LIST_JOBS} | wc -l) -eq 0
 '
 
+# job-info module depends on job-manager, unload and reload it too
 test_expect_success 'job-manager: reload the job manager' '
-	flux module reload job-manager
+	flux module remove job-info &&
+	flux module reload job-manager &&
+	flux module load job-info
 '
 
 test_expect_success 'job-manager: still no jobs in the queue' '
@@ -310,9 +316,9 @@ test_expect_success HAVE_JQ 'job-manager stats works' '
         cat stats.out | $jq -e .events.listeners
 '
 
-test_expect_success 'job-manager: remove job-manager, job-info, job-ingest' '
-	flux module remove job-manager &&
+test_expect_success 'job-manager: remove job-info, job-manager, job-ingest' '
 	flux module remove job-info &&
+	flux module remove job-manager &&
 	flux exec -r all flux module remove job-ingest
 '
 

--- a/t/t2203-job-manager-dummysched-single.t
+++ b/t/t2203-job-manager-dummysched-single.t
@@ -248,8 +248,8 @@ test_expect_success 'job-manager: remove sched-dummy' '
 '
 
 test_expect_success 'job-manager: remove job-manager, job-ingest' '
-        flux module remove job-manager &&
         flux module remove job-info &&
+        flux module remove job-manager &&
         flux exec -r all flux module remove job-ingest
 '
 

--- a/t/t2204-job-manager-dummysched-unlimited.t
+++ b/t/t2204-job-manager-dummysched-unlimited.t
@@ -238,9 +238,9 @@ test_expect_success 'job-manager: remove sched-dummy' '
         flux module remove sched-dummy
 '
 
-test_expect_success 'job-manager: remove job-manager, job-ingest' '
-        flux module remove job-manager &&
+test_expect_success 'job-manager: remove job-info, job-manager, job-ingest' '
         flux exec -r all flux module remove job-info &&
+        flux module remove job-manager &&
         flux exec -r all flux module remove job-ingest
 '
 

--- a/t/t2205-job-manager-annotate.t
+++ b/t/t2205-job-manager-annotate.t
@@ -316,9 +316,9 @@ test_expect_success 'job-manager: remove sched-dummy' '
         flux module remove sched-dummy
 '
 
-test_expect_success 'job-manager: remove job-manager, job-ingest' '
-        flux module remove job-manager &&
+test_expect_success 'job-manager: remove job-info, job-manager, job-ingest' '
         flux exec -r all flux module remove job-info &&
+        flux module remove job-manager &&
         flux exec -r all flux module remove job-ingest
 '
 

--- a/t/t2211-job-manager-events.t
+++ b/t/t2211-job-manager-events.t
@@ -1,0 +1,204 @@
+#!/bin/sh
+
+test_description='Test flux job manager events service'
+
+. $(dirname $0)/sharness.sh
+
+test_under_flux 4
+
+RPC=${FLUX_BUILD_DIR}/t/request/rpc
+EVENT_STREAM=${FLUX_BUILD_DIR}/t/job-manager/event_stream
+waitfile="${SHARNESS_TEST_SRCDIR}/scripts/waitfile.lua"
+
+flux setattr log-stderr-level 1
+
+test_expect_success 'flux-job: generate jobspec for simple test job' '
+        flux jobspec srun -n1 hostname >basic.json
+'
+
+wait_events_listeners() {
+        num=$1
+        i=0
+        while [ "$(flux module stats --parse events.listeners job-manager 2> /dev/null)" != "$num" ] \
+              && [ $i -lt 50 ]
+        do
+                sleep 0.1
+                i=$((i + 1))
+        done
+        if [ "$i" -eq "50" ]
+        then
+            return 1
+        fi
+        return 0
+}
+
+# to avoid raciness in tests below, ensure job-info is synced to the
+# job-manager and won't be part of the events.listeners counts below
+test_expect_success 'wait for job-info to sync with job-manager' '
+        wait_events_listeners 1
+'
+
+check_event_name() {
+        name="$1"
+        filename=$2
+        if cat $filename | $jq -e ".entry.name == \"${name}\"" | grep -q "true"
+        then
+            return 0
+        fi
+        return 1
+}
+
+test_expect_success HAVE_JQ,NO_CHAIN_LINT 'job-manager: events with no filters shows all events' '
+        before=`flux module stats --parse events.listeners job-manager`
+        count=$((before + 1))
+        $jq -j -c -n "{}" \
+          | $EVENT_STREAM > events1.out &
+        pid=$! &&
+        wait_events_listeners $count &&
+        flux job submit basic.json &&
+        $waitfile --count=1 --timeout=5 --pattern="clean" events1.out &&
+        check_event_name submit events1.out &&
+        check_event_name depend events1.out &&
+        check_event_name alloc events1.out &&
+        check_event_name start events1.out &&
+        check_event_name finish events1.out &&
+        check_event_name release events1.out &&
+        check_event_name free events1.out &&
+        check_event_name clean events1.out &&
+        kill -s USR1 $pid &&
+        wait $pid &&
+        wait_events_listeners $before
+'
+
+test_expect_success HAVE_JQ,NO_CHAIN_LINT 'job-manager: events with allow works' '
+        before=`flux module stats --parse events.listeners job-manager`
+        count=$((before + 1))
+        $jq -j -c -n "{allow:{clean:1}}" \
+          | $EVENT_STREAM > events2.out &
+        pid=$! &&
+        wait_events_listeners $count &&
+        flux job submit basic.json &&
+        $waitfile --count=1 --timeout=5 --pattern="clean" events2.out &&
+        test_must_fail check_event_name submit events2.out &&
+        test_must_fail check_event_name depend events2.out &&
+        test_must_fail check_event_name alloc events2.out &&
+        test_must_fail check_event_name start events2.out &&
+        test_must_fail check_event_name finish events2.out &&
+        test_must_fail check_event_name release events2.out &&
+        test_must_fail check_event_name free events2.out &&
+        check_event_name clean events2.out &&
+        kill -s USR1 $pid &&
+        wait $pid &&
+        wait_events_listeners $before
+'
+
+test_expect_success HAVE_JQ,NO_CHAIN_LINT 'job-manager: events with allow works (multiple)' '
+        before=`flux module stats --parse events.listeners job-manager`
+        count=$((before + 1))
+        $jq -j -c -n "{allow:{depend:1, finish:1, clean:1}}" \
+          | $EVENT_STREAM > events3.out &
+        pid=$! &&
+        wait_events_listeners $count &&
+        flux job submit basic.json &&
+        $waitfile --count=1 --timeout=5 --pattern="clean" events3.out &&
+        test_must_fail check_event_name submit events3.out &&
+        check_event_name depend events3.out &&
+        test_must_fail check_event_name alloc events3.out &&
+        test_must_fail check_event_name start events3.out &&
+        check_event_name finish events3.out &&
+        test_must_fail check_event_name release events3.out &&
+        test_must_fail check_event_name free events3.out &&
+        check_event_name clean events3.out &&
+        kill -s USR1 $pid &&
+        wait $pid &&
+        wait_events_listeners $before
+'
+
+test_expect_success HAVE_JQ,NO_CHAIN_LINT 'job-manager: events with deny works' '
+        before=`flux module stats --parse events.listeners job-manager`
+        count=$((before + 1))
+        $jq -j -c -n "{deny:{finish:1}}" \
+          | $EVENT_STREAM > events4.out &
+        pid=$! &&
+        wait_events_listeners $count &&
+        flux job submit basic.json &&
+        $waitfile --count=1 --timeout=5 --pattern="clean" events4.out &&
+        check_event_name submit events4.out &&
+        check_event_name depend events4.out &&
+        check_event_name alloc events4.out &&
+        check_event_name start events4.out &&
+        test_must_fail check_event_name finish events4.out &&
+        check_event_name release events4.out &&
+        check_event_name free events4.out &&
+        check_event_name clean events4.out &&
+        kill -s USR1 $pid &&
+        wait $pid &&
+        wait_events_listeners $before
+'
+
+test_expect_success HAVE_JQ,NO_CHAIN_LINT 'job-manager: events with deny works (multiple)' '
+        before=`flux module stats --parse events.listeners job-manager`
+        count=$((before + 1))
+        $jq -j -c -n "{deny:{depend:1, finish:1, release:1}}" \
+          | $EVENT_STREAM > events5.out &
+        pid=$! &&
+        wait_events_listeners $count &&
+        flux job submit basic.json &&
+        $waitfile --count=1 --timeout=5 --pattern="clean" events5.out &&
+        check_event_name submit events5.out &&
+        test_must_fail check_event_name depend events5.out &&
+        check_event_name alloc events5.out &&
+        check_event_name start events5.out &&
+        test_must_fail check_event_name finish events5.out &&
+        test_must_fail check_event_name release events5.out &&
+        check_event_name free events5.out &&
+        check_event_name clean events5.out &&
+        kill -s USR1 $pid &&
+        wait $pid &&
+        wait_events_listeners $before
+'
+
+test_expect_success HAVE_JQ,NO_CHAIN_LINT 'job-manager: events with allow & deny works' '
+        before=`flux module stats --parse events.listeners job-manager`
+        count=$((before + 1))
+        $jq -j -c -n "{allow:{depend:1, finish:1, clean:1}, deny:{depend:1}}" \
+          | $EVENT_STREAM > events6.out &
+        pid=$! &&
+        wait_events_listeners $count &&
+        flux job submit basic.json &&
+        $waitfile --count=1 --timeout=5 --pattern="clean" events6.out &&
+        test_must_fail check_event_name submit events6.out &&
+        test_must_fail check_event_name depend events6.out &&
+        test_must_fail check_event_name alloc events6.out &&
+        test_must_fail check_event_name start events6.out &&
+        check_event_name finish events6.out &&
+        test_must_fail check_event_name release events6.out &&
+        test_must_fail check_event_name free events6.out &&
+        check_event_name clean events6.out &&
+        kill -s USR1 $pid &&
+        wait $pid &&
+        wait_events_listeners $before
+'
+
+test_expect_success 'job-manager: events request fails with EPROTO on empty payload' '
+        $RPC job-manager.events 71 < /dev/null
+'
+
+test_expect_success HAVE_JQ 'job-manager: events request fails if not streaming RPC' '
+        $jq -j -c -n "{}" > cc1.in &&
+        test_must_fail $RPC job-manager.events < cc1.in
+'
+
+test_expect_success HAVE_JQ 'job-manager: events request fails if allow not an object' '
+        $jq -j -c -n "{allow:5}" > cc2.in &&
+        test_must_fail $EVENT_STREAM < cc2.in 2> cc2.err &&
+        grep "allow should be an object" cc2.err
+'
+
+test_expect_success HAVE_JQ 'job-manager: events request fails if deny not an object' '
+        $jq -j -c -n "{deny:5}" > cc3.in &&
+        test_must_fail $EVENT_STREAM < cc3.in 2> cc3.err &&
+        grep "deny should be an object" cc3.err
+'
+
+test_done

--- a/t/t2234-job-info-list-update.t
+++ b/t/t2234-job-info-list-update.t
@@ -1,0 +1,238 @@
+#!/bin/sh
+
+test_description='Test flux job info list services w/ changing job data'
+
+. $(dirname $0)/sharness.sh
+
+test_under_flux 4 job
+
+RPC=${FLUX_BUILD_DIR}/t/request/rpc
+
+if test "$TEST_LONG" = "t"; then
+    test_set_prereq LONGTEST
+fi
+
+fj_wait_event() {
+  flux job wait-event --timeout=20 "$@"
+}
+
+wait_jobid_state() {
+        local jobid=$(flux job id $1)
+        local state=$2
+        local i=0
+        while ! flux job list --states=${state} | grep $jobid > /dev/null \
+               && [ $i -lt 50 ]
+        do
+                sleep 0.1
+                i=$((i + 1))
+        done
+        if [ "$i" -eq "50" ]
+        then
+            return 1
+        fi
+        return 0
+}
+
+#
+# job list tests
+#
+# these tests come first, as we do not want job submissions below to
+# interfere with expected results
+#
+
+# submit a whole bunch of jobs for job list testing
+#
+# - the first loop of job submissions are intended to have some jobs run
+#   quickly and complete
+# - the second loop of job submissions are intended to eat up all resources
+# - the last job submissions are intended to get a create a set of
+#   pending jobs, because jobs from the second loop have taken all resources
+#   - we desire pending jobs sorted in priority order, so we need to
+#   create the sorted list for comparison later.
+# - job ids are stored in files in the order we expect them to be listed
+#   - pending jobs - by priority (highest first), submission time
+#                    (earlier first)
+#   - running jobs - by start time (most recent first)
+#   - inactive jobs - by completion time (most recent first)
+#
+# TODO
+# - alternate userid job listing
+
+# Return the expected jobids list in a given state:
+#   "all", "pending", "running", "inactive", "active",
+#   "completed", "cancelled", "failed"
+#
+state_ids() {
+    for f in "$@"; do
+        cat ${f}.ids
+    done
+}
+
+# Return the expected count of jobs in a given state (See above for list)
+#
+state_count() {
+    state_ids "$@" | wc -l
+}
+
+# the job-info module has eventual consistency with the jobs stored in
+# the job-manager's queue.  To ensure no raciness in tests, we spin
+# until all of the pending jobs have reached SCHED state, running jobs
+# have reached RUN state, and inactive jobs have reached INACTIVE
+# state.
+
+wait_states() {
+        pending=$(state_count pending)
+        running=$(state_count running)
+        inactive=$(state_count inactive)
+        local i=0
+        while ( [ "$(flux job list --states=sched | wc -l)" != "$pending" ] \
+                || [ "$(flux job list --states=run | wc -l)" != "$running" ] \
+                || [ "$(flux job list --states=inactive | wc -l)" != "$inactive" ]) \
+               && [ $i -lt 50 ]
+        do
+                sleep 0.1
+                i=$((i + 1))
+        done
+        if [ "$i" -eq "50" ]
+        then
+            return 1
+        fi
+        return 0
+}
+
+test_expect_success 'submit jobs for job list testing' '
+        #  Create `hostname` and `sleep` jobspec
+        #
+        flux jobspec --format json srun -N1 hostname > hostname.json &&
+        flux jobspec --format json srun -N1 sleep 300 > sleeplong.json &&
+        #
+        # submit jobs that will complete
+        #
+        for i in $(seq 0 3); do \
+                flux job submit hostname.json >> inactiveids; \
+                fj_wait_event `tail -n 1 inactiveids` clean ; \
+        done &&
+        #
+        #  Currently all inactive ids are "completed"
+        #
+        tac inactiveids | flux job id > completed.ids &&
+        #
+        #  Submit 8 sleep jobs to fill up resources
+        #
+        for i in $(seq 0 7); do
+                flux job submit sleeplong.json >> runningids
+        done &&
+        tac runningids | flux job id > running.ids &&
+        #
+        #  Submit a set of jobs with misc priorities
+        #
+        id1=$(flux job submit -p20 hostname.json) &&
+        id2=$(flux job submit      hostname.json) &&
+        id3=$(flux job submit -p31 hostname.json) &&
+        id4=$(flux job submit -p0  hostname.json) &&
+        id5=$(flux job submit -p20 hostname.json) &&
+        id6=$(flux job submit      hostname.json) &&
+        id7=$(flux job submit -p31 hostname.json) &&
+        id8=$(flux job submit -p0  hostname.json) &&
+        flux job id $id3 > pending.ids &&
+        flux job id $id7 >> pending.ids &&
+        flux job id $id1 >> pending.ids &&
+        flux job id $id5 >> pending.ids &&
+        flux job id $id2 >> pending.ids &&
+        flux job id $id6 >> pending.ids &&
+        flux job id $id4 >> pending.ids &&
+        flux job id $id8 >> pending.ids &&
+        cat pending.ids > active.ids &&
+        cat running.ids >> active.ids &&
+        tac inactiveids | flux job id > inactive.ids &&
+        cat active.ids > all.ids &&
+        cat inactive.ids >> all.ids &&
+        #
+        #  Synchronize all expected states
+        #
+        wait_states
+'
+
+# Note: "running" = "run" & "cleanup", we also test just "run" state
+# since we happen to know all these jobs are in the "run" state given
+# checks above
+
+test_expect_success HAVE_JQ 'flux job list running jobs in started order' '
+        flux job list -s running | jq .id > list_started.out &&
+        test_cmp list_started.out running.ids
+'
+
+test_expect_success HAVE_JQ 'flux job list inactive jobs in completed order' '
+        flux job list -s inactive | jq .id > list_inactive.out &&
+        test_cmp list_inactive.out inactive.ids
+'
+
+# Note: "pending" = "depend" & "sched", we also test just "sched"
+# state since we happen to know all these jobs are in the "sched"
+# state given checks above
+
+test_expect_success HAVE_JQ 'flux job list pending jobs in priority order' '
+        flux job list -s pending | jq .id > list_pending.out &&
+        test_cmp list_pending.out pending.ids
+'
+
+test_expect_success HAVE_JQ 'flux job list pending jobs with correct priority' '
+        cat >list_priority.exp <<-EOT &&
+31
+31
+20
+20
+16
+16
+0
+0
+EOT
+        flux job list -s pending | jq .priority > list_priority.out &&
+        test_cmp list_priority.out list_priority.exp
+'
+
+test_expect_success HAVE_JQ 'change a job priority' '
+        jobid=`head -n 1 pending.ids` &&
+        flux job priority ${jobid} 1
+'
+
+test_expect_success HAVE_JQ 'wait for job-info to see job priority change' '
+        jobidhead=`head -n 6 pending.ids | tail -n 5 > pending_after.ids` &&
+        jobidchange=`head -n 1 pending.ids >> pending_after.ids` &&
+        jobidend=`tail -n2 pending.ids >> pending_after.ids` &&
+        i=0 &&
+        while flux job list -s pending | jq .id > list_pending_after.out && \
+              ! test_cmp list_pending_after.out pending_after.ids && \
+              [ $i -lt 5 ]
+        do
+                sleep 1
+                i=$((i + 1))
+        done &&
+        test "$i" -lt "5" &&
+        flux job list -s pending | jq .id > list_pending_after.out &&
+        test_cmp list_pending_after.out pending_after.ids
+'
+
+test_expect_success HAVE_JQ 'flux job list pending jobs with correct priority' '
+        cat >list_priority_after.exp <<-EOT &&
+31
+20
+20
+16
+16
+1
+0
+0
+EOT
+        flux job list -s pending | jq .priority > list_priority_after.out &&
+        test_cmp list_priority_after.out list_priority_after.exp
+'
+
+test_expect_success 'cleanup job listing jobs ' '
+        for jobid in `cat active.ids`; do \
+            flux job cancel $jobid; \
+            fj_wait_event $jobid clean; \
+        done
+'
+
+test_done


### PR DESCRIPTION
Per discussion in #3052, the `job-manager` did not have a way to inform the `job-info` module that a job's priority had changed, thus leading to invalid job listings.

Several issues were discussed in #3052, this PR just tried to look at the notification of the priority change between `job-manager` & `job-info`.

For prototyping purposes, I implemented about the most straightforward thing I could think of, adding a new `job-updates` event that the `job-manager` publishes.  It publishes a change record of "jobid, timestamp, field that changed, value", such as "JOBID, TIMESTAMP, "priority", 14" would be a potential change.  I transfer the "value" as a json object.  In the future, I believe a json null can serve as "cache invalidate", when the data that has changed isn't known to the `job-manager`.

In the `job-info` module, it has to keep track of the timestamp of when the `priority` field was last set, to avoid any racing that can occur.

- b/c the priority field is (currently) the only job data that can change, I think this implementation is ok.  But as more data can change, this approach will become cumbersome, managing timestamps of when all of the job data was last updated.  So a refactoring would be necessary.

- The `job-updates` and `job-annotations` events could be combined into one event.  If we go with this approach, I think that would be a commit to add to the top of this series.

Any thoughts / comments?