### PR TITLE
 cmd/flux-job: Output key options for job info

### DIFF
--- a/t/t2231-job-info-lookup.t
+++ b/t/t2231-job-info-lookup.t
@@ -34,6 +34,26 @@ test_expect_success 'job-info: generate jobspec for simple test job' '
 '
 
 #
+# job info lookup list w/o jobid & keys
+#
+
+test_expect_success 'flux job info fails without jobid' '
+        test_must_fail flux job info
+'
+
+test_expect_success 'flux job info listing of keys works' '
+        jobid=$(submit_job) &&
+        flux job info $jobid > list_keys.err 2>&1 &&
+        grep "^J" list_keys.err &&
+        grep "^R" list_keys.err &&
+        grep "^eventlog" list_keys.err &&
+        grep "^jobspec" list_keys.err &&
+        grep "^guest.exec.eventlog" list_keys.err &&
+        grep "^guest.input" list_keys.err &&
+        grep "^guest.output" list_keys.err
+'
+
+#
 # job info lookup tests
 #
 


### PR DESCRIPTION
Per idea from @SteVwonder  in #2851, when a key is not specified for flux job info, output possible keys by going through the list of KVS keys in the KVS job path.

I thought this was going to be super simple, so I was just going to program this up while I got woken up by the baby at 3am.  But it ended up being a tad trickier than I was hoping for.

Basically, there's always the chance that when you're going through all the possible KVS keys in the job path, there's a chance that the guest namespace will disappear and be re-absorbed back into the primary namespace.  To solve this, if I get a ENOTSUP indicating that the namespace has disappeared, I just re-do the entire KVS search again.  This leads to the code being more annoying that I'd like it to be.

Maybe it's overkill.  Instead, I could have just accepted the rare error when there is a walk through a KVS directory and the guest namespace disappears on you.