### PR TITLE
python: allow Future.get() and wait_for() to be interrupted by Ctrl-C

### DIFF
--- a/src/bindings/python/flux/future.py
+++ b/src/bindings/python/flux/future.py
@@ -12,7 +12,7 @@ import errno
 
 from typing import Dict
 
-from flux.util import check_future_error
+from flux.util import check_future_error, interruptible
 from flux.wrapper import Wrapper, WrapperPimpl
 from flux.core.inner import ffi, lib, raw
 
@@ -141,10 +141,12 @@ class Future(WrapperPimpl):
     def is_ready(self):
         return self.pimpl.is_ready()
 
+    @interruptible
     def wait_for(self, timeout=-1.0):
         self.pimpl.wait_for(timeout)
         return self
 
+    @interruptible
     def get(self):
         """
         Base Future.get() method. Does not return a result, just blocks

--- a/src/bindings/python/flux/job/event.py
+++ b/src/bindings/python/flux/job/event.py
@@ -77,6 +77,8 @@ class JobEventWatchFuture(Future):
         """
         result = ffi.new("char *[1]")
         try:
+            #  Block until Future is ready:
+            self.wait_for()
             RAW.event_watch_get(self.pimpl, result)
         except OSError as exc:
             if exc.errno == errno.ENODATA:

--- a/src/bindings/python/flux/rpc.py
+++ b/src/bindings/python/flux/rpc.py
@@ -15,7 +15,7 @@ from flux.wrapper import Wrapper
 from flux.future import Future
 from flux.core.inner import ffi, lib, raw
 import flux.constants
-from flux.util import encode_payload, encode_topic
+from flux.util import encode_payload, encode_topic, interruptible
 
 
 class RPC(Future):
@@ -66,6 +66,7 @@ class RPC(Future):
             pimpl_t=self.RPCInnerWrapper,
         )
 
+    @interruptible
     def get_str(self):
         payload_str = ffi.new("char *[1]")
         self.pimpl.flux_rpc_get(payload_str)
@@ -73,6 +74,7 @@ class RPC(Future):
             return None
         return ffi.string(payload_str[0]).decode("utf-8")
 
+    @interruptible
     def get(self):
         resp_str = self.get_str()
         if resp_str is None:

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -200,13 +200,14 @@ EXTRA_DIST= \
 
 dist_check_SCRIPTS = \
 	$(TESTSCRIPTS) \
-        issues/t0441-kvs-put-get.sh \
-        issues/t0505-msg-handler-reg.lua \
-        issues/t0821-kvs-segfault.sh \
+	issues/t0441-kvs-put-get.sh \
+	issues/t0505-msg-handler-reg.lua \
+	issues/t0821-kvs-segfault.sh \
 	issues/t1760-kvs-use-after-free.sh \
 	issues/t2281-service-add-crash.sh \
 	issues/t2284-initial-program-format-chars.sh \
 	issues/t2686-shell-input-race.sh \
+	issues/t3186-python-future-get-sigint.sh \
 	python/__init__.py \
 	python/subflux.py \
 	python/tap \

--- a/t/issues/t3186-python-future-get-sigint.sh
+++ b/t/issues/t3186-python-future-get-sigint.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+# future/rpc.get() should be interruptible:
+
+SERVICE="t3186"
+waitfile=${SHARNESS_TEST_SRCDIR}/scripts/waitfile.lua
+
+log() { echo "t3186: $@" >&2; }
+die() { log "$@"; exit 1; }
+
+cat <<EOF >get-intr.py || die "Failed to create test script"
+import flux
+from flux.future import Future
+
+f = flux.Flux()
+Future(f.service_register("$SERVICE")).get()
+print("get-intr.py: Added service $SERVICE", flush=True)
+
+# The following should block until interrupted:
+f.rpc("${SERVICE}.echo").get()
+EOF
+
+log "Created test script get-intr.py"
+
+flux python get-intr.py >t3186.log 2>&1 &
+pid=$!
+
+log "Started PID=$pid"
+
+$waitfile --timeout=10 --pattern="Added service" t3186.log
+
+log "Sending SIGINT to $pid"
+kill -INT $pid || die "Failed to kill PID $pid"
+wait $!
+STATUS=$?
+test $STATUS -eq 130 || die "process exited with $STATUS expected 130"
+
+log "Python script exited with status $STATUS"

--- a/t/t4000-issues-test-driver.t
+++ b/t/t4000-issues-test-driver.t
@@ -11,7 +11,7 @@ echo "# $0: flux session size will be ${SIZE}"
 
 for testscript in ${FLUX_SOURCE_DIR}/t/issues/*; do
     testname=`basename $testscript`
-    test_expect_success  $testname $testscript
+    test_expect_success  $testname "run_timeout 30 $testscript"
 done
 
 test_done


### PR DESCRIPTION
As described in #3186, Python scripts that use synchronous RPC and Future `get()` or `wait_for()` and derived functions are not interruptible by Ctrl-C while blocked in these calls. This is because the Python default SIGINT handler waits until the program returns to Python from C to "deliver" the signal.

This PR takes the simple approach. These blocking functions are wrapped in a decorator that disables the Python default SIGINT handler for the duration the call is off in C-land. This allows the blocking calls to be interrupted, though the behavior in this case is to exit the program (i..e we never return back to Python to dump beautiful stack traces) However, the issue at hand is fixed.