### PR TITLE
hwloc: add printing of num GPUs to `flux hwloc info`

### DIFF
--- a/src/cmd/builtin/hwloc.c
+++ b/src/cmd/builtin/hwloc.c
@@ -29,6 +29,7 @@
 #define XML_BASEDIR "resource.hwloc.xml"
 
 extern char **environ;
+static int hwloc_gpu_count (hwloc_topology_t topology);
 
 /*  idset helpers:
  */
@@ -323,7 +324,7 @@ static int cmd_info (optparse_t *p, int ac, char *av[])
     char **xmlv = NULL;
     char *xml = NULL;
     uint32_t size = 0, i = 0;
-    int ncores = 0, npu = 0, nnodes = 0;
+    int ncores = 0, npu = 0, nnodes = 0, ngpus = 0;
     hwloc_topology_t topo;
 
     flux_hwloc_xml (p, &xmlv, &size);
@@ -336,11 +337,17 @@ static int cmd_info (optparse_t *p, int ac, char *av[])
         ncores += hwloc_get_nbobjs_by_type (topo, HWLOC_OBJ_CORE);
         npu    += hwloc_get_nbobjs_by_type (topo, HWLOC_OBJ_PU);
         nnodes += hwloc_get_nbobjs_by_type (topo, HWLOC_OBJ_MACHINE);
+        ngpus += hwloc_gpu_count (topo);
         hwloc_topology_destroy (topo);
     }
 
-    printf ("%d Machine%s, %d Cores, %d PUs\n",
+    printf ("%d Machine%s, %d Cores, %d PUs",
             nnodes, nnodes > 1 ? "s" : "", ncores, npu);
+    if (ngpus > 0) {
+        printf (", %d GPU%s\n", ngpus, ngpus > 1 ? "s" : "");
+    } else {
+        printf ("\n");
+    }
 
     string_array_destroy (xmlv, size);
     return (0);

--- a/t/t2005-hwloc-basic.t
+++ b/t/t2005-hwloc-basic.t
@@ -112,6 +112,17 @@ test_expect_success HAVE_JQ 'hwloc: reload xml with GPU resources' '
     $jq -e ".\"[0-1]\".cpuset == \"0-175\"" < sierra.out
 '
 
+#  Keep this test after 'reload sierra' above so we're processing
+#   known topology xml with GPUs from reload.
+#
+test_expect_success 'hwloc: flux-hwloc info reports expected GPU resources' '
+    cat <<-EOF > hwloc-info.expected3 &&
+	2 Machines, 88 Cores, 352 PUs, 8 GPUs
+	EOF
+    flux hwloc info > hwloc-info.out3 &&
+    test_cmp hwloc-info.expected3 hwloc-info.out3
+'
+
 test_expect_success 'hwloc: return an error code on an invalid DIR' '
     test_expect_code 1 flux hwloc reload nonexistence
 '


### PR DESCRIPTION
Problem: On GPU-enabled clusters, `flux hwloc info` only prints `X
Machines, Y Cores, Z PUs`.  This makes it more difficult to debug
unsatisfiable jobspecs and if the hwloc that Flux is using was
configured with CUDA support.

Solution: add counting of the number of GPUs to `cmd_info` so that the
output on GPU-enabled clusters is now `X Machines, Y Cores, Z PUs, W GPUs`.
The output on non-GPU clusters is unaffected.

Closes #3216