### PR TITLE
job-manager: fix segfault when attempting to change priority of a running job

### DIFF
--- a/src/modules/job-manager/priority.c
+++ b/src/modules/job-manager/priority.c
@@ -92,6 +92,11 @@ void priority_handle_request (flux_t *h,
         errno = EINVAL;
         goto error;
     }
+    if (job->has_resources) {
+        errstr = "priority cannot be changed once resources are allocated";
+        errno = EINVAL;
+        goto error;
+    }
     /* Post event, change job's queue position, and respond.
      */
     if (event_job_post_pack (ctx->event, job,

--- a/t/t2201-job-cmd.t
+++ b/t/t2201-job-cmd.t
@@ -201,6 +201,10 @@ test_expect_success 'flux-job: priority fails with non-numeric priority' '
 	test_must_fail flux job priority ${validjob} foo
 '
 
+test_expect_success 'job-manager: flux job priority fails on invalid jobid' '
+	test_must_fail flux job priority 12345 31
+'
+
 test_expect_success 'flux-job: raise fails with bad FLUX_URI' '
 	! FLUX_URI=/wrong flux job raise ${validjob}
 '

--- a/t/t2210-job-manager-bugs.t
+++ b/t/t2210-job-manager-bugs.t
@@ -60,5 +60,15 @@ test_expect_success 'issue3051: clean up' '
 	flux queue drain
 '
 
+#
+# Issue 3218 job-manager: segfault when changing priority of running job
+#
+
+test_expect_success 'issue3218: priority change on running job doesnt segfault' '
+        id=$(flux mini submit sleep 600) &&
+        flux job wait-event $id start &&
+        test_must_fail flux job priority $id 0 &&
+        flux job cancel $id
+'
 
 test_done


### PR DESCRIPTION
An attempt to fix #3218.  I hit a segfault when I accidentally tried to re-prioritize a running job (vs a pending job).