### PR TITLE
testsuite: fix race in python SIGINT test

### DIFF
--- a/t/issues/t3186-python-future-get-sigint.sh
+++ b/t/issues/t3186-python-future-get-sigint.sh
@@ -30,8 +30,16 @@ $waitfile --timeout=10 --pattern="Added service" t3186.log
 
 log "Sending SIGINT to $pid"
 kill -INT $pid || die "Failed to kill PID $pid"
+
+while kill -0 $pid; do
+    log "PID $pid still running, trying again"
+    kill -INT $pid
+    sleep 0.25
+done
+
+log "Waiting for $pid to exit"
 wait $!
 STATUS=$?
-test $STATUS -eq 130 || die "process exited with $STATUS expected 130"
 
+test $STATUS -eq 130 || die "process exited with $STATUS expected 130"
 log "Python script exited with status $STATUS"


### PR DESCRIPTION
This small change should fix the race in `t/issues/t3186-python-future-get-sigint.sh` which keeps hitting us in Travis. If the process at first don't die, try, try again. :shrug:

I tested this in my own branch against Travis-CI and ran several times with no failures (before, it used to hit on every other run or so)