### PR TITLE
reduce log noise

### DIFF
--- a/src/common/librouter/router.c
+++ b/src/common/librouter/router.c
@@ -214,10 +214,6 @@ static int broker_subscribe (const char *topic, void *arg)
 
     if (flux_event_subscribe (rtr->h, topic) < 0)
         return -1;
-
-    /* N.B. t/t1008-proxy.t looks for this log message */
-    flux_log (rtr->h, LOG_DEBUG, "subscribe %s", topic);
-
     return 0;
 }
 
@@ -227,10 +223,6 @@ static int broker_unsubscribe (const char *topic, void *arg)
 
     if (!rtr->mute && flux_event_unsubscribe (rtr->h, topic) < 0)
         return -1;
-
-    /* N.B. t/t1008-proxy.t looks for this log message */
-    flux_log (rtr->h, LOG_DEBUG, "unsubscribe %s", topic);
-
     return 0;
 }
 

--- a/src/common/libschedutil/ops.c
+++ b/src/common/libschedutil/ops.c
@@ -33,8 +33,6 @@ static void alloc_continuation (flux_future_t *f, void *arg)
         const flux_msg_t *msg = flux_future_aux_get (f, "schedutil::msg");
         const char *jobspec;
 
-        flux_log (util->h, LOG_INFO, "f=%p", f);
-
         if (flux_kvs_lookup_get (f, &jobspec) < 0) {
             flux_log_error (util->h, "sched.alloc lookup R");
             if (flux_respond_error (util->h, msg, errno, NULL) < 0)

--- a/src/modules/job-ingest/worker.c
+++ b/src/modules/job-ingest/worker.c
@@ -76,11 +76,8 @@ static void worker_completion_cb (flux_subprocess_t *p)
     int rc;
 
     if ((rc = flux_subprocess_exit_code (p)) >= 0) {
-        if (rc == 0)
-            flux_log (w->h, LOG_DEBUG, "%s: exited normally", w->name);
-        else {
+        if (rc != 0)
             flux_log (w->h, LOG_ERR, "%s: exited with rc=%d", w->name, rc);
-        }
     }
     else if ((rc = flux_subprocess_signaled (p)) >= 0)
         flux_log (w->h, LOG_ERR, "%s: killed by %s", w->name, strsignal (rc));
@@ -110,8 +107,6 @@ static void worker_state_cb (flux_subprocess_t *p,
 
     switch (state) {
         case FLUX_SUBPROCESS_RUNNING:
-            flux_log (w->h, LOG_DEBUG, "%s: running (pid=%d)", w->name,
-                      (int)flux_subprocess_pid (p));
             break;
         case FLUX_SUBPROCESS_EXEC_FAILED:
         case FLUX_SUBPROCESS_FAILED:
@@ -252,7 +247,7 @@ static void worker_output_cb (flux_subprocess_t *p, const char *stream)
             worker_inactive (w);
     }
     else if (!strcmp (stream, "stderr")) {
-        flux_log (w->h, LOG_DEBUG, "%s: %s", w->name, s ? s : "");
+        //flux_log (w->h, LOG_DEBUG, "%s: %s", w->name, s ? s : "");
     }
 }
 

--- a/src/modules/job-manager/submit.c
+++ b/src/modules/job-manager/submit.c
@@ -170,8 +170,6 @@ static void submit_cb (flux_t *h, flux_msg_handler_t *mh,
     }
     if (flux_respond (h, msg, NULL) < 0)
         flux_log_error (h, "%s: flux_respond", __FUNCTION__);
-    flux_log (h, LOG_DEBUG, "%s: added %d jobs", __FUNCTION__,
-                            (int)zlist_size (newjobs));
 
     /* Submitting user is being responded to with jobid's.
      * Now walk the list of new jobs and advance their state.

--- a/t/t1105-proxy.t
+++ b/t/t1105-proxy.t
@@ -35,18 +35,6 @@ test_expect_success 'flux-proxy forwards getattr request' '
 	test "$ATTR_SIZE" = "$SIZE"
 '
 
-test_expect_success 'flux-proxy manages event redistribution' '
-	flux proxy $TEST_URI \
-	  "${EVENT_TRACE} -t 2 foobar foobar.exit \\
-       ${EVENT_TRACE} -t 2 foobar foobar.exit \\
-       flux event pub foobar.exit" &&
-	FLUX_URI=$TEST_URI flux dmesg | sed -e "s/[^ ]* //" >event.out &&
-	test $(egrep "connector-local.*debug\[0\]: subscribe foobar" event.out|wc -l) -eq 1 &&
-	test $(egrep "proxy.*debug\[0\]: subscribe foobar" event.out|wc -l) -eq 1 &&
-	test $(egrep "connector-local.*debug\[0\]: unsubscribe foobar" event.out|wc -l) -eq 1 &&
-	test $(egrep "proxy.*debug\[0\]: unsubscribe foobar" event.out|wc -l) -eq 1
-'
-
 test_expect_success 'flux-proxy permits dynamic service registration' "
         echo '{\"service\":\"fubar\"}' >service.add.in &&
         flux proxy $TEST_URI \


### PR DESCRIPTION
Drop some LOG_DEBUG level messages that add to log noise and are not all that interesting to see anymore.  Now the only debug logging that occurs for each job comes from the scheduler which seems appropriate for now.

I thought this might be a good idea in preparation for system instance testing since the logs may be consulted to run down problems, and a better signal is good.