### PR TITLE
python/job: Update state_single default header

### DIFF
--- a/src/bindings/python/flux/job/info.py
+++ b/src/bindings/python/flux/job/info.py
@@ -324,7 +324,7 @@ class JobInfoFormat(flux.util.OutputFormat):
         "username": "USER",
         "priority": "PRI",
         "state": "STATE",
-        "state_single": "ST",
+        "state_single": "S",
         "name": "NAME",
         "ntasks": "NTASKS",
         "nnodes": "NNODES",

--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -718,7 +718,7 @@ test_expect_success 'flux-jobs: header included with all custom formats' '
 	username==USER
 	priority==PRI
 	state==STATE
-	state_single==ST
+	state_single==S
 	name==NAME
 	ntasks==NTASKS
 	nnodes==NNODES


### PR DESCRIPTION
Problem: the header of state_single and status are both "ST", which
can be confusing since both may output identical states.

Solution: rename the header of state_single to the single character
"S".

Update test appropriately.

Fixes #3214