### PR TITLE
job-info: use job manager journal to track job state

### DIFF
--- a/src/modules/job-info/job-info.c
+++ b/src/modules/job-info/job-info.c
@@ -173,11 +173,6 @@ static const struct flux_msg_handler_spec htab[] = {
       .cb           = stats_cb,
       .rolemask     = 0
     },
-    { .typemask     = FLUX_MSGTYPE_EVENT,
-      .topic_glob   = "job-state",
-      .cb           = job_state_cb,
-      .rolemask     = 0
-    },
     FLUX_MSGHANDLER_TABLE_END,
 };
 

--- a/src/modules/job-info/job_state.c
+++ b/src/modules/job-info/job_state.c
@@ -37,6 +37,7 @@ struct state_transition {
 
 static void process_next_state (struct info_ctx *ctx, struct job *job);
 
+static int journal_process_events (struct job_state_ctx *jsctx, json_t *events);
 static void job_events_journal_continuation (flux_future_t *f, void *arg);
 
 /* Compare items for sorting in list, priority first (higher priority
@@ -111,14 +112,6 @@ static void job_id_destructor (void **item)
     free (idp);
 }
 
-static void flux_msg_destroy_wrapper (void **data)
-{
-    if (data) {
-        flux_msg_t **ptr = (flux_msg_t **)data;
-        flux_msg_destroy (*ptr);
-    }
-}
-
 static struct job *job_create (struct info_ctx *ctx, flux_jobid_t id)
 {
     struct job *job = NULL;
@@ -131,6 +124,7 @@ static struct job *job_create (struct info_ctx *ctx, flux_jobid_t id)
     job->userid = FLUX_USERID_UNKNOWN;
     job->priority = -1;
     job->result = FLUX_JOB_RESULT_FAILED;
+    job->eventlog_seq = -1;
 
     if (!(job->next_states = zlist_new ())) {
         errno = ENOMEM;
@@ -197,23 +191,16 @@ struct job_state_ctx *job_state_create (struct info_ctx *ctx)
     zhashx_set_key_destructor (jsctx->early_annotations, job_id_destructor);
     zhashx_set_destructor (jsctx->early_annotations, json_decref_wrapper);
 
-    if (!(jsctx->transitions = zlistx_new ()))
+    if (!(jsctx->events_journal_backlog = zlistx_new ()))
         goto error;
-    zlistx_set_destructor (jsctx->transitions, flux_msg_destroy_wrapper);
+    zlistx_set_destructor (jsctx->events_journal_backlog, json_decref_wrapper);
 
-    if (flux_event_subscribe (jsctx->h, "job-state") < 0) {
-        flux_log_error (jsctx->h, "flux_event_subscribe");
-        goto error;
-    }
-
+    /* no filters on events-journal, stream all events */
     if (!(jsctx->events = flux_rpc_pack (jsctx->h,
                                          "job-manager.events-journal",
                                          FLUX_NODEID_ANY,
                                          FLUX_RPC_STREAMING,
-                                         "{s:{s:i s:i}}",
-                                         "allow",
-                                           "priority", 1,
-                                           "annotations", 1))) {
+                                         "{}"))) {
         flux_log_error (jsctx->h, "flux_rpc_pack");
         goto error;
     }
@@ -260,9 +247,8 @@ void job_state_destroy (void *data)
         zlistx_destroy (&jsctx->running);
         zlistx_destroy (&jsctx->pending);
         zhashx_destroy (&jsctx->index);
-        zlistx_destroy (&jsctx->transitions);
+        zlistx_destroy (&jsctx->events_journal_backlog);
         flux_future_destroy (jsctx->events);
-        (void)flux_event_unsubscribe (jsctx->h, "job-state");
         free (jsctx);
     }
 }
@@ -447,75 +433,6 @@ static void check_waiting_id (struct info_ctx *ctx,
         }
         zhashx_delete (ctx->idsync_waits, &job->id);
     }
-}
-
-static int eventlog_lookup_parse (struct info_ctx *ctx,
-                                  struct job *job,
-                                  const char *s)
-{
-    json_t *a = NULL;
-    size_t index;
-    json_t *value;
-    int rc = -1;
-
-    if (!(a = eventlog_decode (s))) {
-        flux_log_error (ctx->h, "%s: error parsing eventlog for %ju",
-                        __FUNCTION__, (uintmax_t)job->id);
-        goto nonfatal_error;
-    }
-
-    json_array_foreach (a, index, value) {
-        const char *name;
-        double timestamp;
-        json_t *context = NULL;
-
-        if (eventlog_entry_parse (value, &timestamp, &name, &context) < 0) {
-            flux_log_error (ctx->h, "%s: error parsing entry for %ju",
-                            __FUNCTION__, (uintmax_t)job->id);
-            continue;
-        }
-
-        if (!strcmp (name, "submit")) {
-            if (!context) {
-                flux_log (ctx->h, LOG_ERR, "%s: no submit context for %ju",
-                          __FUNCTION__, (uintmax_t)job->id);
-                goto nonfatal_error;
-            }
-
-            if (json_unpack (context, "{ s:i s:i s:i }",
-                             "priority", &job->priority,
-                             "userid", &job->userid,
-                             "flags", &job->flags) < 0) {
-                flux_log (ctx->h, LOG_ERR, "%s: submit context for %ju invalid",
-                          __FUNCTION__, (uintmax_t)job->id);
-                goto nonfatal_error;
-            }
-            job->priority_timestamp = timestamp;
-        }
-        else if (!strcmp (name, "priority")) {
-            if (!context) {
-                flux_log (ctx->h, LOG_ERR, "%s: no priority context for %ju",
-                          __FUNCTION__, (uintmax_t)job->id);
-                goto nonfatal_error;
-            }
-
-            if (json_unpack (context, "{ s:i }",
-                             "priority", &job->priority) < 0) {
-                flux_log (ctx->h, LOG_ERR,
-                          "%s: priority context for %ju invalid",
-                          __FUNCTION__, (uintmax_t)job->id);
-                goto nonfatal_error;
-            }
-            job->priority_timestamp = timestamp;
-        }
-    }
-
-    /* nonfatal error - eventlog illegal, but we'll continue on.  job
-     * listing will get initialized data */
-nonfatal_error:
-    rc = 0;
-    json_decref (a);
-    return rc;
 }
 
 struct res_level {
@@ -741,15 +658,6 @@ static void state_depend_lookup_continuation (flux_future_t *f, void *arg)
     const char *s;
     void *handle;
 
-    if (flux_rpc_get_unpack (f, "{s:s}", "eventlog", &s) < 0) {
-        flux_log_error (ctx->h, "%s: error eventlog for %ju",
-                        __FUNCTION__, (uintmax_t)job->id);
-        goto out;
-    }
-
-    if (eventlog_lookup_parse (ctx, job, s) < 0)
-        goto out;
-
     if (flux_rpc_get_unpack (f, "{s:s}", "jobspec", &s) < 0) {
         flux_log_error (ctx->h, "%s: error jobspec for %ju",
                         __FUNCTION__, (uintmax_t)job->id);
@@ -780,9 +688,9 @@ static flux_future_t *state_depend_lookup (struct job_state_ctx *jsctx,
     int saved_errno;
 
     if (!(f = flux_rpc_pack (jsctx->h, "job-info.lookup", FLUX_NODEID_ANY, 0,
-                             "{s:I s:[ss] s:i}",
+                             "{s:I s:[s] s:i}",
                              "id", job->id,
-                             "keys", "eventlog", "jobspec",
+                             "keys", "jobspec",
                              "flags", 0))) {
         flux_log_error (jsctx->h, "%s: flux_rpc_pack", __FUNCTION__);
         goto error;
@@ -968,84 +876,6 @@ static flux_future_t *state_run_lookup (struct job_state_ctx *jsctx,
     return NULL;
 }
 
-static int eventlog_inactive_parse (struct info_ctx *ctx,
-                                    struct job *job,
-                                    const char *s)
-{
-    json_t *a = NULL;
-    size_t index;
-    json_t *value;
-    int rc = -1;
-
-    if (!(a = eventlog_decode (s))) {
-        flux_log (ctx->h, LOG_ERR,
-                  "%s: job %ju eventlog_decode: %s",
-                  __FUNCTION__, (uintmax_t)job->id, strerror (errno));
-        goto nonfatal_error;
-    }
-
-    json_array_foreach (a, index, value) {
-        const char *name = NULL;
-        json_t *context = NULL;
-
-        if (eventlog_entry_parse (value, NULL, &name, &context) < 0) {
-            flux_log (ctx->h, LOG_ERR,
-                      "%s: job %ju eventlog_entry_parse: %s",
-                      __FUNCTION__, (uintmax_t)job->id,
-                      strerror (errno));
-            continue;
-        }
-
-        /* There is no need to check for "exception" events for the
-         * "success" attribute.  "success" is always false unless the
-         * job completes ("finish") without error.
-         */
-        if (!strcmp (name, "finish")) {
-            int status;
-            if (json_unpack (context, "{s:i}", "status", &status) < 0) {
-                flux_log (ctx->h, LOG_ERR,
-                          "%s: job %ju parse finish status",
-                          __FUNCTION__, (uintmax_t)job->id);
-                goto nonfatal_error;
-            }
-            if (!status)
-                job->success = true;
-        }
-        else if (!strcmp (name, "exception")) {
-            const char *type;
-            int severity;
-            const char *note = NULL;
-
-            if (json_unpack (context,
-                             "{s:s s:i s?:s}",
-                             "type", &type,
-                             "severity", &severity,
-                             "note", &note) < 0) {
-                flux_log (ctx->h, LOG_ERR,
-                          "%s: job %ju parse exception",
-                          __FUNCTION__, (uintmax_t)job->id);
-                goto nonfatal_error;
-            }
-            if (!job->exception_occurred
-                || severity < job->exception_severity) {
-                job->exception_occurred = true;
-                job->exception_severity = severity;
-                job->exception_type = type;
-                job->exception_note = note;
-                json_decref (job->exception_context);
-                job->exception_context = json_incref (context);
-            }
-        }
-    }
-
-    /* nonfatal error - eventlog illegal, but we'll continue on.  job
-     * listing will get initialized data */
-nonfatal_error:
-    rc = 0;
-    json_decref (a);
-    return rc;
-}
-
 /* calculate any remaining fields */
 static void eventlog_inactive_complete (struct info_ctx *ctx,
                                         struct job *job)
@@ -1059,64 +889,6 @@ static void eventlog_inactive_complete (struct info_ctx *ctx,
         else if (!strcmp (job->exception_type, "timeout"))
             job->result = FLUX_JOB_RESULT_TIMEOUT;
     }
-}
-
-static void state_inactive_lookup_continuation (flux_future_t *f, void *arg)
-{
-    struct job *job = arg;
-    struct info_ctx *ctx = job->ctx;
-    struct state_transition *st;
-    const char *s;
-    void *handle;
-
-    if (flux_rpc_get_unpack (f, "{s:s}", "eventlog", &s) < 0) {
-        flux_log_error (ctx->h, "%s: error eventlog for %ju",
-                        __FUNCTION__, (uintmax_t)job->id);
-        goto out;
-    }
-
-    if (eventlog_inactive_parse (ctx, job, s) < 0)
-        goto out;
-
-    eventlog_inactive_complete (ctx, job);
-
-    st = zlist_head (job->next_states);
-    assert (st);
-    update_job_state_and_list (ctx, job, st->state, st->timestamp);
-    zlist_remove (job->next_states, st);
-    process_next_state (ctx, job);
-
-out:
-    handle = zlistx_find (ctx->jsctx->futures, f);
-    if (handle)
-        zlistx_detach (ctx->jsctx->futures, handle);
-    flux_future_destroy (f);
-}
-
-static flux_future_t *state_inactive_lookup (struct job_state_ctx *jsctx,
-                                           struct job *job)
-{
-    flux_future_t *f = NULL;
-
-    if (!(f = flux_rpc_pack (jsctx->h, "job-info.lookup", FLUX_NODEID_ANY, 0,
-                             "{s:I s:[s] s:i}",
-                             "id", job->id,
-                             "keys", "eventlog",
-                             "flags", 0))) {
-        flux_log_error (jsctx->h, "%s: flux_rpc_pack", __FUNCTION__);
-        goto error;
-    }
-
-    if (flux_future_then (f, -1, state_inactive_lookup_continuation, job) < 0) {
-        flux_log_error (jsctx->h, "%s: flux_future_then", __FUNCTION__);
-        goto error;
-    }
-
-    return f;
-
- error:
-    flux_future_destroy (f);
-    return NULL;
 }
 
 static void state_transition_destroy (void *data)
@@ -1133,6 +905,9 @@ static int add_state_transition (struct job *job,
     struct state_transition *st = NULL;
     int saved_errno;
 
+    if (newstate & job->states_events_mask)
+        return 0;
+
     if (!(st = calloc (1, sizeof (*st))))
         return -1;
     st->state = newstate;
@@ -1145,6 +920,7 @@ static int add_state_transition (struct job *job,
     }
     zlist_freefn (job->next_states, st, state_transition_destroy, true);
 
+    job->states_events_mask |= newstate;
     return 0;
 
  cleanup:
@@ -1162,30 +938,20 @@ static void process_next_state (struct info_ctx *ctx, struct job *job)
     while ((st = zlist_head (job->next_states))
            && !st->processed) {
         if (st->state == FLUX_JOB_DEPEND
-            || st->state == FLUX_JOB_RUN
-            || st->state == FLUX_JOB_INACTIVE) {
+            || st->state == FLUX_JOB_RUN) {
             flux_future_t *f = NULL;
 
             if (st->state == FLUX_JOB_DEPEND) {
-                /* get initial job information, such as userid,
-                 * priority, t_submit, flags, and jobspec info */
+                /* get initial jobspec */
                 if (!(f = state_depend_lookup (jsctx, job))) {
                     flux_log_error (jsctx->h, "%s: state_depend_lookup", __FUNCTION__);
                     return;
                 }
             }
-            else if (st->state == FLUX_JOB_RUN) {
+            else { /* st->state == FLUX_JOB_RUN */
                 /* get R to get node count, etc. */
                 if (!(f = state_run_lookup (jsctx, job))) {
                     flux_log_error (jsctx->h, "%s: state_run_lookup", __FUNCTION__);
-                    return;
-                }
-            }
-            else { /* st->state == FLUX_JOB_INACTIVE */
-                /* get eventlog to success=true|false and exception info */
-                if (!(f = state_inactive_lookup (jsctx, job))) {
-                    flux_log_error (jsctx->h, "%s: state_inactive_lookup",
-                                    __FUNCTION__);
                     return;
                 }
             }
@@ -1202,129 +968,15 @@ static void process_next_state (struct info_ctx *ctx, struct job *job)
         else {
             /* FLUX_JOB_SCHED */
             /* FLUX_JOB_CLEANUP */
+            /* FLUX_JOB_INACTIVE */
+
+            if (st->state == FLUX_JOB_INACTIVE)
+                eventlog_inactive_complete (ctx, job);
+
             update_job_state_and_list (ctx, job, st->state, st->timestamp);
             zlist_remove (job->next_states, st);
         }
     }
-}
-
-static int parse_transition (json_t *transition, flux_jobid_t *id,
-                             flux_job_state_t *state, double *timestamp)
-{
-    json_t *o;
-
-    if (!json_is_array (transition))
-        return -1;
-
-    if (!(o = json_array_get (transition, 0))
-        || !json_is_integer (o))
-        return -1;
-
-    (*id) = json_integer_value (o);
-
-    if (!(o = json_array_get (transition, 1))
-        || !json_is_string (o))
-        return -1;
-
-    if (flux_job_strtostate (json_string_value (o), state) < 0)
-        return -1;
-
-    if (!(o = json_array_get (transition, 2))
-        || !json_is_real (o))
-        return -1;
-
-    (*timestamp) = json_real_value (o);
-    return 0;
-}
-
-static void update_jobs (struct info_ctx *ctx, json_t *transitions)
-{
-    struct job_state_ctx *jsctx = ctx->jsctx;
-    size_t index;
-    json_t *value;
-
-    if (!json_is_array (transitions)) {
-        flux_log (ctx->h, LOG_ERR, "%s: transitions EPROTO", __FUNCTION__);
-        return;
-    }
-
-    json_array_foreach (transitions, index, value) {
-        struct job *job;
-        flux_jobid_t id;
-        flux_job_state_t state;
-        double timestamp;
-
-        if (parse_transition (value, &id, &state, &timestamp) < 0) {
-            flux_log (jsctx->h, LOG_ERR, "%s: transition EPROTO", __FUNCTION__);
-            return;
-        }
-
-        if (!(job = zhashx_lookup (jsctx->index, &id))) {
-            json_t *annotations;
-            if (!(job = job_create (ctx, id))){
-                flux_log_error (jsctx->h, "%s: job_create", __FUNCTION__);
-                return;
-            }
-            if (zhashx_insert (jsctx->index, &job->id, job) < 0) {
-                flux_log_error (jsctx->h, "%s: zhashx_insert", __FUNCTION__);
-                job_destroy (job);
-                return;
-            }
-            /* in rare case, annotation may have arrived before we
-             * knew of this job */
-            if ((annotations = zhashx_lookup (jsctx->early_annotations, &id))) {
-                if (!json_is_null (annotations))
-                    job->annotations = json_incref (annotations);
-                zhashx_delete (jsctx->early_annotations, &id);
-            }
-            /* job always starts off on processing list */
-            if (!(job->list_handle = zlistx_add_end (jsctx->processing, job))) {
-                flux_log_error (jsctx->h, "%s: zlistx_add_end", __FUNCTION__);
-                return;
-            }
-        }
-
-        if (add_state_transition (job, state, timestamp) < 0) {
-            flux_log_error (jsctx->h, "%s: add_state_transition",
-                            __FUNCTION__);
-            return;
-        }
-
-        process_next_state (ctx, job);
-    }
-
-}
-
-void job_state_cb (flux_t *h, flux_msg_handler_t *mh,
-                   const flux_msg_t *msg, void *arg)
-{
-    struct info_ctx *ctx = arg;
-    json_t *transitions;
-
-    if (ctx->jsctx->pause) {
-        flux_msg_t *cpy;
-
-        if (!(cpy = flux_msg_copy (msg, true))) {
-            flux_log_error (h, "%s: flux_msg_copy", __FUNCTION__);
-            return;
-        }
-        if (!zlistx_add_end (ctx->jsctx->transitions, cpy)) {
-            flux_log_error (h, "%s: zlistx_add_end", __FUNCTION__);
-            flux_msg_destroy (cpy);
-        }
-    }
-    else {
-        if (flux_event_unpack (msg, NULL, "{s:o}",
-                               "transitions",
-                               &transitions) < 0) {
-            flux_log_error (h, "%s: flux_event_unpack", __FUNCTION__);
-            return;
-        }
-
-        update_jobs (ctx, transitions);
-    }
-
-    return;
 }
 
 void job_state_pause_cb (flux_t *h, flux_msg_handler_t *mh,
@@ -1350,14 +1002,14 @@ void job_state_unpause_cb (flux_t *h, flux_msg_handler_t *mh,
                            const flux_msg_t *msg, void *arg)
 {
     struct info_ctx *ctx = arg;
-    flux_msg_t *tmsg;
+    json_t *o;
 
     ctx->jsctx->pause = false;
 
-    tmsg = zlistx_first (ctx->jsctx->transitions);
-    while (tmsg) {
-        job_state_cb (h, mh, tmsg, ctx);
-        tmsg = zlistx_next (ctx->jsctx->transitions);
+    o = zlistx_first (ctx->jsctx->events_journal_backlog);
+    while (o) {
+        (void)journal_process_events (ctx->jsctx, o);
+        o = zlistx_next (ctx->jsctx->events_journal_backlog);
     }
 
     if (flux_respond (h, msg, NULL) < 0) {
@@ -1365,13 +1017,13 @@ void job_state_unpause_cb (flux_t *h, flux_msg_handler_t *mh,
         goto error;
     }
 
-    zlistx_purge (ctx->jsctx->transitions);
+    zlistx_purge (ctx->jsctx->events_journal_backlog);
     return;
 
  error:
     if (flux_respond_error (h, msg, errno, NULL) < 0)
         flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
-    zlistx_purge (ctx->jsctx->transitions);
+    zlistx_purge (ctx->jsctx->events_journal_backlog);
 }
 
 static struct job *eventlog_restart_parse (struct info_ctx *ctx,
@@ -1403,6 +1055,7 @@ static struct job *eventlog_restart_parse (struct info_ctx *ctx,
             goto error;
         }
 
+        job->eventlog_seq++;
         if (!strcmp (name, "submit")) {
             if (!context) {
                 flux_log (ctx->h, LOG_ERR, "%s: no submit context for %ju",
@@ -1445,7 +1098,10 @@ static struct job *eventlog_restart_parse (struct info_ctx *ctx,
             job->priority_timestamp = timestamp;
         }
         else if (!strcmp (name, "exception")) {
+            const char *type;
             int severity;
+            const char *note = NULL;
+
             if (!context) {
                 flux_log (ctx->h, LOG_ERR, "%s: no exception context for %ju",
                           __FUNCTION__, (uintmax_t)job->id);
@@ -1453,13 +1109,28 @@ static struct job *eventlog_restart_parse (struct info_ctx *ctx,
                 goto error;
             }
 
-            if (json_unpack (context, "{ s:i }", "severity", &severity) < 0) {
+            if (json_unpack (context,
+                             "{s:s s:i s?:s}",
+                             "type", &type,
+                             "severity", &severity,
+                             "note", &note) < 0) {
                 flux_log (ctx->h, LOG_ERR,
                           "%s: exception context for %ju invalid",
                           __FUNCTION__, (uintmax_t)job->id);
                 errno = EPROTO;
                 goto error;
             }
+
+            if (!job->exception_occurred
+                || severity < job->exception_severity) {
+                job->exception_occurred = true;
+                job->exception_severity = severity;
+                job->exception_type = type;
+                job->exception_note = note;
+                json_decref (job->exception_context);
+                job->exception_context = json_incref (context);
+            }
+
             if (severity == 0)
                 update_job_state (ctx, job, FLUX_JOB_CLEANUP, timestamp);
         }
@@ -1482,6 +1153,26 @@ static struct job *eventlog_restart_parse (struct info_ctx *ctx,
                 update_job_state (ctx, job, FLUX_JOB_RUN, timestamp);
         }
         else if (!strcmp (name, "finish")) {
+            int status;
+
+            if (!context) {
+                flux_log (ctx->h, LOG_ERR, "%s: no finish context for %ju",
+                          __FUNCTION__, (uintmax_t)job->id);
+                errno = EPROTO;
+                goto error;
+            }
+
+            if (json_unpack (context, "{ s:i }", "status", &status) < 0) {
+                flux_log (ctx->h, LOG_ERR,
+                          "%s: finish context for %ju invalid",
+                          __FUNCTION__, (uintmax_t)job->id);
+                errno = EPROTO;
+                goto error;
+            }
+
+            if (!status)
+                job->success = true;
+
             if (job->state == FLUX_JOB_RUN)
                 update_job_state (ctx, job, FLUX_JOB_CLEANUP, timestamp);
         }
@@ -1572,12 +1263,8 @@ static int depthfirst_map_one (struct info_ctx *ctx, const char *key,
             goto done;
     }
 
-    if (job->states_mask & FLUX_JOB_INACTIVE) {
-        if (eventlog_inactive_parse (ctx, job, eventlog) < 0)
-            goto done;
-
+    if (job->states_mask & FLUX_JOB_INACTIVE)
         eventlog_inactive_complete (ctx, job);
-    }
 
     if (zhashx_insert (ctx->jsctx->index, &job->id, job) < 0) {
         flux_log_error (ctx->h, "%s: zhashx_insert", __FUNCTION__);
@@ -1661,8 +1348,159 @@ int job_state_init_from_kvs (struct info_ctx *ctx)
     return 0;
 }
 
+static int job_update_eventlog_seq (struct job_state_ctx *jsctx,
+                                    struct job *job,
+                                    int latest_eventlog_seq)
+{
+    if (latest_eventlog_seq <= job->eventlog_seq) {
+        flux_log (jsctx->h, LOG_INFO,
+                  "%s: job %ju duplicate event (last = %d, latest = %d)",
+                  __FUNCTION__, (uintmax_t)job->id,
+                  job->eventlog_seq, latest_eventlog_seq);
+        return 1;
+    }
+    if (latest_eventlog_seq > (job->eventlog_seq + 1))
+        flux_log (jsctx->h, LOG_INFO,
+                  "%s: job %ju missed event (last = %d, latest = %d)",
+                  __FUNCTION__, (uintmax_t)job->id,
+                  job->eventlog_seq, latest_eventlog_seq);
+    job->eventlog_seq = latest_eventlog_seq;
+    return 0;
+}
+
+static int job_transition_state (struct job_state_ctx *jsctx,
+                                 struct job *job,
+                                 flux_job_state_t newstate,
+                                 double timestamp)
+{
+    if (add_state_transition (job, newstate, timestamp) < 0) {
+        flux_log_error (jsctx->h, "%s: add_state_transition",
+                        __FUNCTION__);
+        return -1;
+    }
+    process_next_state (jsctx->ctx, job);
+    return 0;
+}
+
+static int journal_advance_job (struct job_state_ctx *jsctx,
+                                flux_jobid_t id,
+                                flux_job_state_t newstate,
+                                int eventlog_seq,
+                                double timestamp)
+{
+    struct job *job;
+
+    if (!(job = zhashx_lookup (jsctx->index, &id))) {
+        flux_log_error (jsctx->h, "%s: job %ju not in hash",
+                        __FUNCTION__, (uintmax_t)id);
+        /* do not return error, we consider it a non-fatal error */
+        return 0;
+    }
+
+    if (job_update_eventlog_seq (jsctx, job, eventlog_seq) == 1)
+        return 0;
+
+    return job_transition_state (jsctx, job, newstate, timestamp);
+}
+
+static int journal_submit_event (struct job_state_ctx *jsctx,
+                                 flux_jobid_t id,
+                                 int eventlog_seq,
+                                 double timestamp,
+                                 json_t *context)
+{
+    struct job *job;
+    int priority;
+    int userid;
+    int flags;
+
+    if (!context
+        || json_unpack (context,
+                        "{ s:i s:i s:i }",
+                        "priority", &priority,
+                        "userid", &userid,
+                        "flags", &flags) < 0) {
+        flux_log (jsctx->h, LOG_ERR, "%s: submit context invalid: %ju",
+                  __FUNCTION__, (uintmax_t)id);
+        errno = EPROTO;
+        return -1;
+    }
+
+    if (!(job = zhashx_lookup (jsctx->index, &id))) {
+        if (!(job = job_create (jsctx->ctx, id))){
+            flux_log_error (jsctx->h, "%s: job_create", __FUNCTION__);
+            return -1;
+        }
+        if (zhashx_insert (jsctx->index, &job->id, job) < 0) {
+            flux_log_error (jsctx->h, "%s: zhashx_insert", __FUNCTION__);
+            job_destroy (job);
+            errno = ENOMEM;
+            return -1;
+        }
+        /* job always starts off on processing list */
+        if (!(job->list_handle = zlistx_add_end (jsctx->processing, job))) {
+            flux_log_error (jsctx->h, "%s: zlistx_add_end", __FUNCTION__);
+            errno = ENOMEM;
+            return -1;
+        }
+    }
+
+    if (job_update_eventlog_seq (jsctx, job, eventlog_seq) == 1)
+        return 0;
+
+    job->userid = userid;
+    job->priority = priority;
+    job->priority_timestamp = timestamp;
+
+    return job_transition_state (jsctx,
+                                 job,
+                                 FLUX_JOB_DEPEND,
+                                 timestamp);
+}
+
+static int journal_finish_event (struct job_state_ctx *jsctx,
+                                 flux_jobid_t id,
+                                 int eventlog_seq,
+                                 double timestamp,
+                                 json_t *context)
+{
+    struct job *job;
+    int status;
+
+    if (!context
+        || json_unpack (context, "{ s:i }", "status", &status) < 0) {
+        flux_log (jsctx->h, LOG_ERR, "%s: finish context invalid: %ju",
+                  __FUNCTION__, (uintmax_t)id);
+        errno = EPROTO;
+        return -1;
+    }
+
+    if (!(job = zhashx_lookup (jsctx->index, &id))) {
+        flux_log_error (jsctx->h, "%s: job %ju not in hash",
+                        __FUNCTION__, (uintmax_t)id);
+        /* do not return error, we consider it a non-fatal error */
+        return 0;
+    }
+
+    if (job_update_eventlog_seq (jsctx, job, eventlog_seq) == 1)
+        return 0;
+
+    /* There is no need to check for "exception" events for the
+     * "success" attribute.  "success" is always false unless the
+     * job completes ("finish") without error.
+     */
+    if (!status)
+        job->success = true;
+
+    return job_transition_state (jsctx,
+                                 job,
+                                 FLUX_JOB_CLEANUP,
+                                 timestamp);
+}
+
 static int journal_priority_event (struct job_state_ctx *jsctx,
                                    flux_jobid_t id,
+                                   int eventlog_seq,
                                    double timestamp,
                                    json_t *context)
 {
@@ -1684,12 +1522,14 @@ static int journal_priority_event (struct job_state_ctx *jsctx,
      * initial reading of data from KVS
      */
     if ((job = zhashx_lookup (jsctx->index, &id))) {
+        if (job_update_eventlog_seq (jsctx, job, eventlog_seq) == 1)
+            return 0;
+
         if (job->priority_timestamp > 0.0
             && job->priority_timestamp < timestamp) {
             int orig_priority = job->priority;
             job->priority = priority;
             job->priority_timestamp = timestamp;
-
             if (job->state & FLUX_JOB_PENDING
                 && job->priority != orig_priority)
                 zlistx_reorder (jsctx->pending,
@@ -1697,6 +1537,57 @@ static int journal_priority_event (struct job_state_ctx *jsctx,
                                 search_direction (job));
         }
     }
+    return 0;
+}
+
+static int journal_exception_event (struct job_state_ctx *jsctx,
+                                    flux_jobid_t id,
+                                    int eventlog_seq,
+                                    double timestamp,
+                                    json_t *context)
+{
+    struct job *job;
+    const char *type;
+    int severity;
+    const char *note = NULL;
+
+    if (!context
+        || json_unpack (context,
+                        "{s:s s:i s?:s}",
+                        "type", &type,
+                        "severity", &severity,
+                        "note", &note) < 0) {
+        flux_log (jsctx->h, LOG_ERR, "%s: exception context invalid: %ju",
+                  __FUNCTION__, (uintmax_t)id);
+        errno = EPROTO;
+        return -1;
+    }
+
+    if (!(job = zhashx_lookup (jsctx->index, &id))) {
+        flux_log_error (jsctx->h, "%s: job %ju not in hash",
+                        __FUNCTION__, (uintmax_t)id);
+        /* do not return error, we consider it a non-fatal error */
+        return 0;
+    }
+
+    if (job_update_eventlog_seq (jsctx, job, eventlog_seq) == 1)
+        return 0;
+
+    if (!job->exception_occurred
+        || severity < job->exception_severity) {
+        job->exception_occurred = true;
+        job->exception_severity = severity;
+        job->exception_type = type;
+        job->exception_note = note;
+        json_decref (job->exception_context);
+        job->exception_context = json_incref (context);
+    }
+
+    if (severity == 0)
+        return job_transition_state (jsctx,
+                                     job,
+                                     FLUX_JOB_CLEANUP,
+                                     timestamp);
 
     return 0;
 }
@@ -1710,6 +1601,7 @@ static int update_early_annotations (struct job_state_ctx *jsctx,
                            &id,
                            json_incref (annotations)) < 0) {
             flux_log_error (jsctx->h, "%s: zhashx_insert", __FUNCTION__);
+            errno = ENOMEM;
             return -1;
         }
     }
@@ -1726,7 +1618,7 @@ static int journal_annotations_event (struct job_state_ctx *jsctx,
                                       json_t *context)
 {
     struct job *job;
-    json_t *annotations;
+    json_t *annotations = NULL;
 
     if (!context
         || json_unpack (context, "{ s:o }", "annotations", &annotations) < 0) {
@@ -1755,11 +1647,118 @@ static int journal_annotations_event (struct job_state_ctx *jsctx,
     return 0;
 }
 
+static int journal_process_event (struct job_state_ctx *jsctx, json_t *event)
+{
+    flux_jobid_t id;
+    int eventlog_seq;
+    json_t *entry;
+    double timestamp;
+    const char *name;
+    json_t *context = NULL;
+
+    if (json_unpack (event, "{s:I s:i s:o}",
+                     "id", &id,
+                     "eventlog_seq", &eventlog_seq,
+                     "entry", &entry) < 0
+        || eventlog_entry_parse (entry, &timestamp, &name, &context) < 0) {
+        flux_log (jsctx->h, LOG_ERR, "%s: error parsing record",
+                  __FUNCTION__);
+        errno = EPROTO;
+        return -1;
+    }
+
+    if (!strcmp (name, "submit")) {
+        if (journal_submit_event (jsctx,
+                                  id,
+                                  eventlog_seq,
+                                  timestamp,
+                                  context) < 0)
+            return -1;
+    }
+    else if (!strcmp (name, "depend")) {
+        if (journal_advance_job (jsctx,
+                                 id,
+                                 FLUX_JOB_SCHED,
+                                 eventlog_seq,
+                                 timestamp) < 0)
+            return -1;
+    }
+    else if (!strcmp (name, "alloc")) {
+        /* alloc event contains annotations, but we only update
+         * annotations via "annotations" events */
+        if (journal_advance_job (jsctx,
+                                 id,
+                                 FLUX_JOB_RUN,
+                                 eventlog_seq,
+                                 timestamp) < 0)
+            return -1;
+    }
+    else if (!strcmp (name, "finish")) {
+        if (journal_finish_event (jsctx,
+                                  id,
+                                  eventlog_seq,
+                                  timestamp,
+                                  context) < 0)
+            return -1;
+    }
+    else if (!strcmp (name, "clean")) {
+        if (journal_advance_job (jsctx,
+                                 id,
+                                 FLUX_JOB_INACTIVE,
+                                 eventlog_seq,
+                                 timestamp) < 0)
+            return -1;
+    }
+    else if (!strcmp (name, "priority")) {
+        if (journal_priority_event (jsctx,
+                                    id,
+                                    eventlog_seq,
+                                    timestamp,
+                                    context) < 0)
+            return -1;
+    }
+    else if (!strcmp (name, "exception")) {
+        if (journal_exception_event (jsctx,
+                                     id,
+                                     eventlog_seq,
+                                     timestamp,
+                                     context) < 0)
+            return -1;
+    }
+    else if (!strcmp (name, "annotations")) {
+        if (journal_annotations_event (jsctx, id, context) < 0)
+            return -1;
+    }
+    else {
+        struct job *job;
+        if (!(job = zhashx_lookup (jsctx->index, &id))) {
+            flux_log_error (jsctx->h, "%s: job %ju not in hash",
+                            __FUNCTION__, (uintmax_t)id);
+            /* do not return error, we consider it a non-fatal error */
+            return 0;
+        }
+        (void) job_update_eventlog_seq (jsctx, job, eventlog_seq);
+    }
+
+    return 0;
+}
+
+static int journal_process_events (struct job_state_ctx *jsctx, json_t *events)
+{
+    size_t index;
+    json_t *value;
+
+    json_array_foreach (events, index, value) {
+        if (journal_process_event (jsctx, value) < 0)
+            return -1;
+    }
+
+    return 0;
+}
+
 static void job_events_journal_continuation (flux_future_t *f, void *arg)
 {
     struct job_state_ctx *jsctx = arg;
-    size_t index;
-    json_t *value;
     json_t *events;
 
     if (flux_rpc_get_unpack (f, "{s:o}", "events", &events) < 0) {
@@ -1773,29 +1772,18 @@ static void job_events_journal_continuation (flux_future_t *f, void *arg)
         goto error;
     }
 
-    json_array_foreach (events, index, value) {
-        flux_jobid_t id;
-        json_t *entry;
-        const char *name;
-        double timestamp;
-        json_t *context = NULL;
-
-        if (json_unpack (value, "{s:I s:o}", "id", &id, "entry", &entry) < 0
-            || eventlog_entry_parse (entry, &timestamp, &name, &context) < 0) {
-            flux_log (jsctx->h, LOG_ERR, "%s: error parsing record",
-                      __FUNCTION__);
-            errno = EPROTO;
+    if (jsctx->pause) {
+        json_t *o = json_incref (events);
+        if (!zlistx_add_end (jsctx->events_journal_backlog, o)) {
+            flux_log_error (jsctx->h, "%s: zlistx_add_end", __FUNCTION__);
+            json_decref (o);
+            errno = ENOMEM;
             goto error;
         }
-
-        if (!strcmp (name, "priority")) {
-            if (journal_priority_event (jsctx, id, timestamp, context) < 0)
-                goto error;
-        }
-        else if (!strcmp (name, "annotations")) {
-            if (journal_annotations_event (jsctx, id, context) < 0)
-                goto error;
-        }
+    }
+    else {
+        if (journal_process_events (jsctx, events) < 0)
+            goto error;
     }
 
     flux_future_reset (f);

--- a/src/modules/job-info/job_state.c
+++ b/src/modules/job-info/job_state.c
@@ -1408,6 +1408,7 @@ static struct job *eventlog_restart_parse (struct info_ctx *ctx,
             if (!context) {
                 flux_log (ctx->h, LOG_ERR, "%s: no submit context for %ju",
                           __FUNCTION__, (uintmax_t)job->id);
+                errno = EPROTO;
                 goto error;
             }
 
@@ -1417,6 +1418,7 @@ static struct job *eventlog_restart_parse (struct info_ctx *ctx,
                              "flags", &job->flags) < 0) {
                 flux_log (ctx->h, LOG_ERR, "%s: submit context for %ju invalid",
                           __FUNCTION__, (uintmax_t)job->id);
+                errno = EPROTO;
                 goto error;
             }
             job->priority_timestamp = timestamp;
@@ -1429,6 +1431,7 @@ static struct job *eventlog_restart_parse (struct info_ctx *ctx,
             if (!context) {
                 flux_log (ctx->h, LOG_ERR, "%s: no priority context for %ju",
                           __FUNCTION__, (uintmax_t)job->id);
+                errno = EPROTO;
                 goto error;
             }
 
@@ -1437,6 +1440,7 @@ static struct job *eventlog_restart_parse (struct info_ctx *ctx,
                 flux_log (ctx->h, LOG_ERR,
                           "%s: priority context for %ju invalid",
                           __FUNCTION__, (uintmax_t)job->id);
+                errno = EPROTO;
                 goto error;
             }
             job->priority_timestamp = timestamp;
@@ -1446,6 +1450,7 @@ static struct job *eventlog_restart_parse (struct info_ctx *ctx,
             if (!context) {
                 flux_log (ctx->h, LOG_ERR, "%s: no exception context for %ju",
                           __FUNCTION__, (uintmax_t)job->id);
+                errno = EPROTO;
                 goto error;
             }
 
@@ -1453,6 +1458,7 @@ static struct job *eventlog_restart_parse (struct info_ctx *ctx,
                 flux_log (ctx->h, LOG_ERR,
                           "%s: exception context for %ju invalid",
                           __FUNCTION__, (uintmax_t)job->id);
+                errno = EPROTO;
                 goto error;
             }
             if (severity == 0)
@@ -1466,6 +1472,7 @@ static struct job *eventlog_restart_parse (struct info_ctx *ctx,
                     flux_log (ctx->h, LOG_ERR,
                               "%s: alloc context for %ju invalid",
                               __FUNCTION__, (uintmax_t)job->id);
+                    errno = EPROTO;
                     goto error;
                 }
                 if (!json_is_null (annotations))
@@ -1487,6 +1494,7 @@ static struct job *eventlog_restart_parse (struct info_ctx *ctx,
     if (job->state == FLUX_JOB_NEW) {
         flux_log (ctx->h, LOG_ERR, "%s: eventlog has no transition events",
                   __FUNCTION__);
+        errno = EPROTO;
         goto error;
     }
 

--- a/src/modules/job-info/job_state.c
+++ b/src/modules/job-info/job_state.c
@@ -1668,6 +1668,7 @@ static int job_events_priority (struct job_state_ctx *jsctx,
             || priority > FLUX_JOB_PRIORITY_MAX)) {
         flux_log (jsctx->h, LOG_ERR, "%s: priority context invalid: %ju",
                   __FUNCTION__, (uintmax_t)id);
+        errno = EPROTO;
         return -1;
     }
 
@@ -1765,6 +1766,7 @@ static int job_events_annotations (struct job_state_ctx *jsctx,
         flux_log (jsctx->h, LOG_ERR,
                   "%s: annotations event context invalid: %ju",
                   __FUNCTION__, (uintmax_t)id);
+        errno = EPROTO;
         return -1;
     }
 
@@ -1803,6 +1805,7 @@ static void job_events_continuation (flux_future_t *f, void *arg)
 
     if (!json_is_array (events)) {
         flux_log (jsctx->h, LOG_ERR, "%s: events EPROTO", __FUNCTION__);
+        errno = EPROTO;
         goto error;
     }
 
@@ -1817,6 +1820,7 @@ static void job_events_continuation (flux_future_t *f, void *arg)
             || eventlog_entry_parse (entry, &timestamp, &name, &context) < 0) {
             flux_log (jsctx->h, LOG_ERR, "%s: error parsing record",
                       __FUNCTION__);
+            errno = EPROTO;
             goto error;
         }
 

--- a/src/modules/job-info/job_state.h
+++ b/src/modules/job-info/job_state.h
@@ -52,9 +52,6 @@ struct job_state_ctx {
     int cleanup_count;
     int inactive_count;
 
-    /* annotations that arrived before job is known */
-    zhashx_t *early_annotations;
-
     /* debug/testing - if paused store job events journal on list for
      * processing later */
     bool pause;
@@ -70,7 +67,6 @@ struct job {
     flux_jobid_t id;
     uint32_t userid;
     int priority;
-    double priority_timestamp;
     double t_submit;
     int flags;
     flux_job_state_t state;

--- a/src/modules/job-info/job_state.h
+++ b/src/modules/job-info/job_state.h
@@ -86,7 +86,6 @@ struct job {
     const char *exception_type;
     const char *exception_note;
     flux_job_result_t result;
-    double annotations_timestamp;
     json_t *annotations;
 
     /* cache of job information */

--- a/src/modules/job-info/job_state.h
+++ b/src/modules/job-info/job_state.h
@@ -55,10 +55,10 @@ struct job_state_ctx {
     /* annotations that arrived before job is known */
     zhashx_t *early_annotations;
 
-    /* debug/testing - if paused store job transitions on list for
+    /* debug/testing - if paused store job events journal on list for
      * processing later */
     bool pause;
-    zlistx_t *transitions;
+    zlistx_t *events_journal_backlog;
 
     /* stream of job events from the job-manager */
     flux_future_t *events;
@@ -87,6 +87,7 @@ struct job {
     const char *exception_note;
     flux_job_result_t result;
     json_t *annotations;
+    int eventlog_seq;           /* last event seq read */
 
     /* cache of job information */
     json_t *jobspec_job;
@@ -102,9 +103,12 @@ struct job {
      * priority, etc.
      *
      * Track which states we've seen via the states_mask.
+     *
+     * Track states seen via events stream in states_events_mask.
      */
     zlist_t *next_states;
     unsigned int states_mask;
+    unsigned int states_events_mask;
     void *list_handle;
 
     /* timestamp of when we enter the state
@@ -128,9 +132,6 @@ struct job {
 struct job_state_ctx *job_state_create (struct info_ctx *ctx);
 
 void job_state_destroy (void *data);
-
-void job_state_cb (flux_t *h, flux_msg_handler_t *mh,
-                   const flux_msg_t *msg, void *arg);
 
 void job_state_pause_cb (flux_t *h, flux_msg_handler_t *mh,
                          const flux_msg_t *msg, void *arg);

--- a/t/t2230-job-info-list.t
+++ b/t/t2230-job-info-list.t
@@ -1078,29 +1078,6 @@ test_expect_success HAVE_JQ,NO_CHAIN_LINT 'flux job list-ids works on job with i
         cat list_id_illegal_R.out | $jq -e ".id == ${jobid}"
 '
 
-# we make the eventlog invalid by overwriting it in the KVS before job-info will
-# look it up.  Note that b/c the eventlog is corrupted, the userid for the job
-# is never established.  So we have to set --user=all.
-test_expect_success HAVE_JQ 'flux job list works on job with illegal eventlog' '
-	${RPC} job-info.job-state-pause 0 </dev/null &&
-        jobid=`flux job submit hostname.json | flux job id` &&
-        fj_wait_event $jobid clean >/dev/null &&
-        jobkvspath=`flux job id --to kvs $jobid` &&
-        flux kvs put "${jobkvspath}.eventlog=foobar" &&
-	${RPC} job-info.job-state-unpause 0 </dev/null &&
-        i=0 &&
-        while ! flux job list --states=inactive --user=all | grep $jobid > /dev/null \
-               && [ $i -lt 5 ]
-        do
-                sleep 1
-                i=$((i + 1))
-        done &&
-        test "$i" -lt "5" &&
-        flux job list --states=inactive --user=all | grep $jobid > list_illegal_eventlog.out &&
-        cat list_illegal_eventlog.out | $jq -e ".priority == -1" &&
-        cat list_illegal_eventlog.out | $jq -e ".userid == 4294967295"
-'
-
 test_expect_success HAVE_JQ,NO_CHAIN_LINT 'flux job list-ids works on job with illegal eventlog' '
 	${RPC} job-info.job-state-pause 0 </dev/null
         jobid=`flux job submit hostname.json | flux job id`

--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -974,29 +974,6 @@ test_expect_success HAVE_JQ 'flux jobs works on job with illegal R' '
         test_cmp list_illegal_R.out list_illegal_R.exp
 '
 
-# we make the eventlog invalid by overwriting it in the KVS before job-info will
-# look it up.  Note that b/c the eventlog is corrupted, the userid for the job
-# is never established.  So we have to do "--user=all" and grep for the jobid.
-test_expect_success HAVE_JQ 'flux jobs works on job with illegal eventlog' '
-	${RPC} job-info.job-state-pause 0 </dev/null &&
-        jobid=`flux job submit hostname.json` &&
-        flux job wait-event $jobid clean >/dev/null &&
-        jobkvspath=`flux job id --to kvs $jobid` &&
-        flux kvs put "${jobkvspath}.eventlog=foobar" &&
-	${RPC} job-info.job-state-unpause 0 </dev/null &&
-        i=0 &&
-        while ! flux jobs --filter=inactive --user=all | grep $jobid > /dev/null \
-               && [ $i -lt 5 ]
-        do
-                sleep 1
-                i=$((i + 1))
-        done &&
-        test "$i" -lt "5" &&
-        flux jobs -no "{userid},{priority}" $jobid > list_illegal_eventlog.out &&
-        echo "4294967295,-1" > list_illegal_eventlog.exp &&
-        test_cmp list_illegal_eventlog.out list_illegal_eventlog.exp
-'
-
 #
 # leave job cleanup to rc3
 #


### PR DESCRIPTION
Built on top of #3253.

Per issue #3234, refactor the job-info module to use only the job-manager event stream, not job-state transitions.
