### PR TITLE
job-manager: support events journal

### DIFF
--- a/src/modules/job-info/job_state.c
+++ b/src/modules/job-info/job_state.c
@@ -207,7 +207,7 @@ struct job_state_ctx *job_state_create (struct info_ctx *ctx)
     }
 
     if (!(jsctx->events = flux_rpc_pack (jsctx->h,
-                                         "job-manager.events",
+                                         "job-manager.events-journal",
                                          FLUX_NODEID_ANY,
                                          FLUX_RPC_STREAMING,
                                          "{s:{s:i s:i}}",

--- a/src/modules/job-manager/Makefile.am
+++ b/src/modules/job-manager/Makefile.am
@@ -41,7 +41,9 @@ job_manager_la_SOURCES = \
 	priority.h \
 	priority.c \
 	annotate.h \
-	annotate.c
+	annotate.c \
+	journal.h \
+	journal.c
 
 job_manager_la_LDFLAGS = $(fluxmod_ldflags) -module
 job_manager_la_LIBADD = $(fluxmod_libadd) \
@@ -69,6 +71,7 @@ test_ldadd = \
         $(top_builddir)/src/modules/job-manager/submit.o \
         $(top_builddir)/src/modules/job-manager/wait.o \
         $(top_builddir)/src/modules/job-manager/annotate.o \
+        $(top_builddir)/src/modules/job-manager/journal.o \
 	$(top_builddir)/src/common/libtap/libtap.la \
 	$(top_builddir)/src/common/libjob/libjob.la \
 	$(top_builddir)/src/common/libflux-internal.la \

--- a/src/modules/job-manager/alloc.c
+++ b/src/modules/job-manager/alloc.c
@@ -191,6 +191,7 @@ static void alloc_response_cb (flux_t *h, flux_msg_handler_t *mh,
     json_t *annotations = NULL;
     struct job *job;
     bool cleared = false;
+    json_t *tmp = NULL;
 
     if (flux_response_decode (msg, NULL, NULL) < 0)
         goto teardown; // ENOSYS here if scheduler not loaded/shutting down
@@ -227,12 +228,18 @@ static void alloc_response_cb (flux_t *h, flux_msg_handler_t *mh,
         if (annotations_update (h, job, annotations) < 0)
             flux_log_error (h, "annotations_update: id=%ju", (uintmax_t)id);
         if (annotations) {
+            if (job->annotations) {
+                /* deep copy necessary for journal history, as
+                 * job->annotations can be modified in future */
+                if (!(tmp = json_deep_copy (job->annotations)))
+                    goto nomem;
+            }
             if (event_job_post_pack (ctx->event,
                                      job,
                                      "annotations",
                                      EVENT_JOURNAL_ONLY,
                                      "{s:O?}",
-                                     "annotations", job->annotations) < 0)
+                                     "annotations", tmp) < 0)
                 flux_log_error (ctx->h,
                                 "%s: event_job_post_pack: id=%ju",
                                 __FUNCTION__, (uintmax_t)id);
@@ -255,12 +262,18 @@ static void alloc_response_cb (flux_t *h, flux_msg_handler_t *mh,
         }
         if (annotations_update (h, job, annotations) < 0)
             flux_log_error (h, "annotations_update: id=%ju", (uintmax_t)id);
+        if (job->annotations) {
+            /* deep copy necessary for journal history, as
+             * job->annotations can be modified in future */
+            if (!(tmp = json_deep_copy (job->annotations)))
+                goto nomem;
+        }
         if (event_job_post_pack (ctx->event,
                                  job,
                                  "annotations",
                                  EVENT_JOURNAL_ONLY,
                                  "{s:O?}",
-                                 "annotations", job->annotations) < 0)
+                                 "annotations", tmp) < 0)
             flux_log_error (ctx->h,
                             "%s: event_job_post_pack: id=%ju",
                             __FUNCTION__, (uintmax_t)id);
@@ -309,8 +322,12 @@ static void alloc_response_cb (flux_t *h, flux_msg_handler_t *mh,
         errno = EINVAL;
         goto teardown;
     }
+    json_decref (tmp);
     return;
+nomem:
+    errno = ENOMEM;
 teardown:
+    json_decref (tmp);
     interface_teardown (alloc, "alloc response error", errno);
 }
 

--- a/src/modules/job-manager/event.c
+++ b/src/modules/job-manager/event.c
@@ -549,8 +549,9 @@ static int get_timestamp_now (double *timestamp)
     return 0;
 }
 
-/* we need to send the job id along with each eventlog entry, so wrap
- * the eventlog entry in another object with the job id
+/* wrap the eventlog entry in another object with the job id.  The job
+ * id is necessary so listeners can determine which job the event is
+ * associated with.
  */
 static json_t *wrap_events_entry (flux_jobid_t id, json_t *entry)
 {

--- a/src/modules/job-manager/event.c
+++ b/src/modules/job-manager/event.c
@@ -641,7 +641,7 @@ int event_job_post_pack (struct event *event,
         return -1;
     if (event_batch_process_event_entry (event, job->id, name, entry) < 0)
         goto error;
-    if (EVENT_JOURNAL_ONLY & flags)
+    if ((flags & EVENT_JOURNAL_ONLY))
         goto out;
     if (event_job_update (job, entry) < 0) // modifies job->state
         goto error;

--- a/src/modules/job-manager/event.h
+++ b/src/modules/job-manager/event.h
@@ -43,6 +43,7 @@ int event_batch_pub_state (struct event *event, struct job *job,
  */
 int event_batch_process_event_entry (struct event *event,
                                      flux_jobid_t id,
+                                     int eventlog_seq,
                                      const char *name,
                                      json_t *entry);
 

--- a/src/modules/job-manager/event.h
+++ b/src/modules/job-manager/event.h
@@ -42,7 +42,7 @@ int event_batch_pub_state (struct event *event, struct job *job,
 /* Add notification of job event to send to listeners.
  */
 int event_batch_process_event_entry (struct event *event,
-                                     struct job *job,
+                                     flux_jobid_t id,
                                      const char *name,
                                      json_t *entry);
 

--- a/src/modules/job-manager/event.h
+++ b/src/modules/job-manager/event.h
@@ -39,14 +39,6 @@ int event_job_update (struct job *job, json_t *event);
 int event_batch_pub_state (struct event *event, struct job *job,
                            double timestamp);
 
-/* Add notification of job event to send to listeners.
- */
-int event_batch_process_event_entry (struct event *event,
-                                     flux_jobid_t id,
-                                     int eventlog_seq,
-                                     const char *name,
-                                     json_t *entry);
-
 /* Add add response to batch, to be sent upon batch completion.
  */
 int event_batch_respond (struct event *event, const flux_msg_t *msg);
@@ -71,8 +63,6 @@ void event_listeners_disconnect_rpc (flux_t *h,
                                      flux_msg_handler_t *mh,
                                      const flux_msg_t *msg,
                                      void *arg);
-
-int event_listeners_count (struct event *event);
 
 #endif /* _FLUX_JOB_MANAGER_EVENT_H */
 

--- a/src/modules/job-manager/job-manager.c
+++ b/src/modules/job-manager/job-manager.c
@@ -68,7 +68,7 @@ static void stats_cb (flux_t *h, flux_msg_handler_t *mh,
     struct job_manager *ctx = arg;
     int journal_listeners = journal_listeners_count (ctx->journal);
     if (flux_respond_pack (h, msg, "{s:{s:i}}",
-                           "events",
+                           "journal",
                              "listeners", journal_listeners) < 0) {
         flux_log_error (h, "%s: flux_respond_pack", __FUNCTION__);
         goto error;

--- a/src/modules/job-manager/job-manager.h
+++ b/src/modules/job-manager/job-manager.h
@@ -26,6 +26,7 @@ struct job_manager {
     struct raise *raise;
     struct kill *kill;
     struct annotate *annotate;
+    struct journal *journal;
 };
 
 #endif /* !_FLUX_JOB_MANAGER_H */

--- a/src/modules/job-manager/job.c
+++ b/src/modules/job-manager/job.c
@@ -71,6 +71,7 @@ struct job *job_create_from_eventlog (flux_jobid_t id, const char *s)
     json_array_foreach (a, index, event) {
         if (event_job_update (job, event) < 0)
             goto error;
+        job->eventlog_seq++;
     }
 
     if (job->state == FLUX_JOB_NEW)

--- a/src/modules/job-manager/job.h
+++ b/src/modules/job-manager/job.h
@@ -22,6 +22,7 @@ struct job {
     int priority;
     double t_submit;
     int flags;
+    int eventlog_seq;           // eventlog count / sequence number
     flux_job_state_t state;
     json_t *end_event;      // event that caused transition to CLEANUP state
     const flux_msg_t *waiter; // flux_job_wait() request

--- a/src/modules/job-manager/journal.c
+++ b/src/modules/job-manager/journal.c
@@ -379,13 +379,13 @@ void journal_ctx_destroy (struct journal *journal)
 static const struct flux_msg_handler_spec htab[] = {
     {
         FLUX_MSGTYPE_REQUEST,
-        "job-manager.events",
+        "job-manager.events-journal",
         journal_handle_request,
         0
     },
     {
         FLUX_MSGTYPE_REQUEST,
-        "job-manager.events-cancel",
+        "job-manager.events-journal-cancel",
         journal_cancel_request,
         0
     },

--- a/src/modules/job-manager/journal.c
+++ b/src/modules/job-manager/journal.c
@@ -1,0 +1,440 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* journal.c - job event journaling and streaming to listeners
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <czmq.h>
+#include <jansson.h>
+#include <flux/core.h>
+
+#include "journal.h"
+
+#include "src/common/libeventlog/eventlog.h"
+
+#define EVENTS_MAXLEN 1000
+
+struct journal {
+    struct job_manager *ctx;
+    flux_msg_handler_t **handlers;
+    zlist_t *listeners;
+    /* holds most recent events for listeners */
+    zlist_t *events;
+    int events_maxlen;
+};
+
+struct journal_listener {
+    const flux_msg_t *request;
+    json_t *allow;
+    json_t *deny;
+};
+
+static bool allow_deny_check (struct journal_listener *jl, const char *name)
+{
+    bool add_entry = true;
+
+    if (jl->allow) {
+        add_entry = false;
+        if (json_object_get (jl->allow, name))
+            add_entry = true;
+    }
+
+    if (add_entry && jl->deny) {
+        if (json_object_get (jl->deny, name))
+            add_entry = false;
+    }
+
+    return add_entry;
+}
+
+/* wrap the eventlog entry in another object with the job id and
+ * eventlog_seq.
+ *
+ * The job id is necessary so listeners can determine which job the
+ * event is associated with.
+ *
+ * The eventlog sequence number is necessary so users can determine if the
+ * event is a duplicate if they are reading events from another source
+ * (i.e. they could be reading events from the job's eventlog in the
+ * KVS).
+ */
+static json_t *wrap_events_entry (flux_jobid_t id,
+                                  int eventlog_seq,
+                                  json_t *entry)
+{
+    json_t *wrapped_entry;
+    if (!(wrapped_entry = json_pack ("{s:I s:i s:O}",
+                                     "id", id,
+                                     "eventlog_seq", eventlog_seq,
+                                     "entry", entry))) {
+        errno = ENOMEM;
+        return NULL;
+    }
+    return wrapped_entry;
+}
+
+static void json_decref_wrapper (void *data)
+{
+    json_t *o = (json_t *)data;
+    json_decref (o);
+}
+
+int journal_process_event (struct journal *journal,
+                           flux_jobid_t id,
+                           int eventlog_seq,
+                           const char *name,
+                           json_t *entry)
+{
+    struct journal_listener *jl;
+    json_t *wrapped_entry = NULL;
+    int saved_errno;
+
+    if (!(wrapped_entry = wrap_events_entry (id, eventlog_seq, entry)))
+        goto error;
+
+    jl = zlist_first (journal->listeners);
+    while (jl) {
+        if (allow_deny_check (jl, name)) {
+            if (flux_respond_pack (journal->ctx->h, jl->request,
+                                   "{s:[O]}", "events", wrapped_entry) < 0)
+                flux_log_error (journal->ctx->h, "%s: flux_respond_pack",
+                                __FUNCTION__);
+        }
+        jl = zlist_next (journal->listeners);
+    }
+
+    if (zlist_size (journal->events) > journal->events_maxlen)
+        zlist_remove (journal->events, zlist_head (journal->events));
+    if (zlist_append (journal->events, json_incref (wrapped_entry)) < 0)
+        goto nomem;
+    zlist_freefn (journal->events,
+                  wrapped_entry,
+                  json_decref_wrapper,
+                  true);
+
+    json_decref (wrapped_entry);
+    return 0;
+
+nomem:
+    errno = ENOMEM;
+error:
+    saved_errno = errno;
+    json_decref (wrapped_entry);
+    errno = saved_errno;
+    return -1;
+}
+
+static void journal_listener_destroy (void *data)
+{
+    struct journal_listener *jl = (struct journal_listener *)data;
+    if (jl) {
+        int saved_errno = errno;
+        flux_msg_decref (jl->request);
+        json_decref (jl->allow);
+        json_decref (jl->deny);
+        free (jl);
+        errno = saved_errno;
+    }
+}
+
+static struct journal_listener *journal_listener_create (const flux_msg_t *msg,
+                                                         json_t *allow,
+                                                         json_t *deny)
+{
+    struct journal_listener *jl;
+
+    if (!(jl = calloc (1, sizeof (*jl))))
+        goto error;
+    jl->request = flux_msg_incref (msg);
+    jl->allow = json_incref (allow);
+    jl->deny = json_incref (deny);
+    return jl;
+ error:
+    journal_listener_destroy (jl);
+    return NULL;
+}
+
+static void journal_handle_request (flux_t *h,
+                                    flux_msg_handler_t *mh,
+                                    const flux_msg_t *msg,
+                                    void *arg)
+{
+    struct job_manager *ctx = arg;
+    struct journal *journal = ctx->journal;
+    struct journal_listener *jl = NULL;
+    const char *errstr = NULL;
+    json_t *allow = NULL;
+    json_t *deny = NULL;
+    json_t *a = NULL;
+    json_t *wrapped_entry;
+
+    if (flux_request_unpack (msg, NULL, "{s?o s?o}",
+                             "allow", &allow,
+                             "deny", &deny) < 0)
+        goto error;
+
+    if (!flux_msg_is_streaming (msg)) {
+        errno = EPROTO;
+        errstr = "job-manager.events requires streaming RPC flag";
+        goto error;
+    }
+
+    if (allow && !json_is_object (allow)) {
+        errno = EPROTO;
+        errstr = "job-manager.events allow should be an object";
+        goto error;
+    }
+
+    if (deny && !json_is_object (deny)) {
+        errno = EPROTO;
+        errstr = "job-manager.events deny should be an object";
+        goto error;
+    }
+
+    if (!(jl = journal_listener_create (msg, allow, deny)))
+        goto error;
+
+    if (zlist_append (journal->listeners, jl) < 0) {
+        errno = ENOMEM;
+        goto error;
+    }
+    zlist_freefn (journal->listeners, jl, journal_listener_destroy, true);
+
+    wrapped_entry = zlist_first (journal->events);
+    while (wrapped_entry) {
+        const char *name;
+
+        if (json_unpack (wrapped_entry,
+                         "{s:{s:s}}",
+                         "entry",
+                           "name", &name) < 0) {
+            flux_log (ctx->h, LOG_ERR, "invalid wrapped entry");
+            goto error;
+        }
+
+        if (allow_deny_check (jl, name)) {
+            if (!a) {
+                if (!(a = json_array ()))
+                    goto nomem;
+            }
+            if (json_array_append (a, wrapped_entry) < 0)
+                goto nomem;
+        }
+        wrapped_entry = zlist_next (journal->events);
+    }
+
+    if (a && json_array_size (a) > 0) {
+        if (flux_respond_pack (ctx->h, jl->request,
+                               "{s:O}", "events", a) < 0) {
+            flux_log_error (ctx->h, "%s: flux_respond_pack",
+                            __FUNCTION__);
+            goto error;
+        }
+    }
+
+    json_decref (a);
+    return;
+
+nomem:
+    errno = ENOMEM;
+error:
+    if (flux_respond_error (h, msg, errno, errstr) < 0)
+        flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
+    journal_listener_destroy (jl);
+    json_decref (a);
+}
+
+static bool match_journal_listener (struct journal_listener *jl,
+                                    uint32_t matchtag,
+                                    const char *sender)
+{
+    uint32_t t;
+    char *s = NULL;
+    bool found = false;
+
+    if (!flux_msg_get_matchtag (jl->request, &t)
+        && matchtag == t
+        && !flux_msg_get_route_first (jl->request, &s)
+        && !strcmp (sender, s))
+        found = true;
+    free (s);
+    return found;
+}
+
+static void journal_cancel_request (flux_t *h, flux_msg_handler_t *mh,
+                                    const flux_msg_t *msg, void *arg)
+{
+    struct job_manager *ctx = arg;
+    struct journal *journal = ctx->journal;
+    struct journal_listener *jl;
+    uint32_t matchtag;
+    char *sender = NULL;
+
+    if (flux_request_unpack (msg, NULL, "{s:i}", "matchtag", &matchtag) < 0
+        || flux_msg_get_route_first (msg, &sender) < 0) {
+        flux_log_error (h, "error decoding events-cancel request");
+        return;
+    }
+    jl = zlist_first (journal->listeners);
+    while (jl) {
+        if (match_journal_listener (jl, matchtag, sender))
+            break;
+        jl = zlist_next (journal->listeners);
+    }
+    if (jl) {
+        if (flux_respond_error (h, jl->request, ENODATA, NULL) < 0)
+            flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
+        zlist_remove (journal->listeners, jl);
+    }
+    free (sender);
+}
+
+static int create_zlist_and_append (zlist_t **lp, void *item)
+{
+    if (!*lp && !(*lp = zlist_new ())) {
+        errno = ENOMEM;
+        return -1;
+    }
+    if (zlist_append (*lp, item) < 0) {
+        errno = ENOMEM;
+        return -1;
+    }
+    return 0;
+}
+
+void journal_listeners_disconnect_rpc (flux_t *h,
+                                       flux_msg_handler_t *mh,
+                                       const flux_msg_t *msg,
+                                       void *arg)
+{
+    struct job_manager *ctx = arg;
+    struct journal *journal = ctx->journal;
+    struct journal_listener *jl;
+    char *sender;
+    zlist_t *tmplist = NULL;
+
+    if (flux_msg_get_route_first (msg, &sender) < 0)
+        return;
+    jl = zlist_first (journal->listeners);
+    while (jl) {
+        char *tmpsender;
+        if (flux_msg_get_route_first (jl->request, &tmpsender) == 0) {
+            if (!strcmp (sender, tmpsender)) {
+                /* cannot remove from zlist while iterating, so we
+                 * store off entries to remove on another list */
+                if (create_zlist_and_append (&tmplist, jl) < 0) {
+                    flux_log_error (h, "job-manager.disconnect: "
+                                    "failed to remove journal listener");
+                    free (tmpsender);
+                    goto error;
+                }
+            }
+            free (tmpsender);
+        }
+        jl = zlist_next (journal->listeners);
+    }
+    if (tmplist) {
+        while ((jl = zlist_pop (tmplist)))
+            zlist_remove (journal->listeners, jl);
+    }
+    free (sender);
+error:
+    zlist_destroy (&tmplist);
+}
+
+void journal_ctx_destroy (struct journal *journal)
+{
+    if (journal) {
+        int saved_errno = errno;
+        flux_msg_handler_delvec (journal->handlers);
+        if (journal->listeners) {
+            struct journal_listener *jl;
+            while ((jl = zlist_pop (journal->listeners))) {
+                if (flux_respond_error (journal->ctx->h,
+                                        jl->request,
+                                        ENODATA, NULL) < 0)
+                    flux_log_error (journal->ctx->h, "%s: flux_respond_error",
+                                    __FUNCTION__);
+                journal_listener_destroy (jl);
+            }
+            zlist_destroy (&journal->listeners);
+        }
+        if (journal->events)
+            zlist_destroy (&journal->events);
+        free (journal);
+        errno = saved_errno;
+    }
+}
+
+static const struct flux_msg_handler_spec htab[] = {
+    {
+        FLUX_MSGTYPE_REQUEST,
+        "job-manager.events",
+        journal_handle_request,
+        0
+    },
+    {
+        FLUX_MSGTYPE_REQUEST,
+        "job-manager.events-cancel",
+        journal_cancel_request,
+        0
+    },
+    FLUX_MSGHANDLER_TABLE_END,
+};
+
+struct journal *journal_ctx_create (struct job_manager *ctx)
+{
+    struct journal *journal;
+    flux_conf_error_t err;
+
+    if (!(journal = calloc (1, sizeof (*journal))))
+        return NULL;
+    journal->ctx = ctx;
+    if (flux_msg_handler_addvec (ctx->h, htab, ctx, &journal->handlers) < 0)
+        goto error;
+    if (!(journal->listeners = zlist_new ()))
+        goto nomem;
+    if (!(journal->events = zlist_new ()))
+        goto nomem;
+    journal->events_maxlen = EVENTS_MAXLEN;
+
+    if (flux_conf_unpack (flux_get_conf (ctx->h),
+                          &err,
+                          "{s?{s?i}}",
+                          "job-manager",
+                            "events_maxlen",
+                            &journal->events_maxlen) < 0) {
+        flux_log (ctx->h, LOG_ERR,
+                  "error reading job-manager config: %s",
+                  err.errbuf);
+    }
+
+    return journal;
+nomem:
+    errno = ENOMEM;
+error:
+    journal_ctx_destroy (journal);
+    return NULL;
+}
+
+int journal_listeners_count (struct journal *journal)
+{
+    if (journal)
+        return zlist_size (journal->listeners);
+    return -1;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */
+

--- a/src/modules/job-manager/journal.h
+++ b/src/modules/job-manager/journal.h
@@ -1,0 +1,45 @@
+
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _FLUX_JOB_MANAGER_JOURNAL_H
+#define _FLUX_JOB_MANAGER_JOURNAL_H
+
+#include <stdarg.h>
+#include <flux/core.h>
+#include <jansson.h>
+
+#include "job-manager.h"
+
+/* Process the event by sending to any listeners that request the
+ * event and append to the journal history.
+ */
+int journal_process_event (struct journal *journal,
+                           flux_jobid_t id,
+                           int eventlog_seq,
+                           const char *name,
+                           json_t *entry);
+
+void journal_ctx_destroy (struct journal *journal);
+struct journal *journal_ctx_create (struct job_manager *ctx);
+
+void journal_listeners_disconnect_rpc (flux_t *h,
+                                       flux_msg_handler_t *mh,
+                                       const flux_msg_t *msg,
+                                       void *arg);
+
+int journal_listeners_count (struct journal *journal);
+
+#endif /* _FLUX_JOB_MANAGER_JOURNAL_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */
+

--- a/src/modules/job-manager/submit.c
+++ b/src/modules/job-manager/submit.c
@@ -20,6 +20,7 @@
 #include "job.h"
 #include "alloc.h"
 #include "event.h"
+#include "journal.h"
 #include "wait.h"
 
 #include "submit.h"
@@ -116,7 +117,7 @@ error:
  * We instead re-create the event and run it directly through
  * event_job_update() and event_job_action().
  */
-static int submit_post_event (struct event *event, struct job *job)
+static int submit_post_event (struct job_manager *ctx, struct job *job)
 {
     json_t *entry = NULL;
     int rv = -1;
@@ -130,18 +131,18 @@ static int submit_post_event (struct event *event, struct job *job)
     if (!entry)
         goto error;
     /* call before eventlog_seq increment below */
-    if (event_batch_process_event_entry (event,
-                                         job->id,
-                                         job->eventlog_seq,
-                                         "submit",
-                                         entry) < 0)
+    if (journal_process_event (ctx->journal,
+                               job->id,
+                               job->eventlog_seq,
+                               "submit",
+                               entry) < 0)
         goto error;
     if (event_job_update (job, entry) < 0) /* NEW -> DEPEND */
         goto error;
     job->eventlog_seq++;
-    if (event_batch_pub_state (event, job, job->t_submit) < 0)
+    if (event_batch_pub_state (ctx->event, job, job->t_submit) < 0)
         goto error;
-    if (event_job_action (event, job) < 0)
+    if (event_job_action (ctx->event, job) < 0)
         goto error;
     rv = 0;
  error:
@@ -184,7 +185,7 @@ static void submit_cb (flux_t *h, flux_msg_handler_t *mh,
      * Side effect: update ctx->max_jobid.
      */
     while ((job = zlist_pop (newjobs))) {
-        if (submit_post_event (ctx->event, job) < 0)
+        if (submit_post_event (ctx, job) < 0)
             flux_log_error (h, "%s: submit_post_event id=%ju",
                             __FUNCTION__, (uintmax_t)job->id);
 

--- a/src/modules/job-manager/submit.c
+++ b/src/modules/job-manager/submit.c
@@ -116,7 +116,7 @@ error:
  * We instead re-create the event and run it directly through
  * event_job_update() and event_job_action().
  */
-int submit_post_event (struct event *event, struct job *job)
+static int submit_post_event (struct event *event, struct job *job)
 {
     json_t *entry = NULL;
     int rv = -1;

--- a/src/modules/job-manager/submit.c
+++ b/src/modules/job-manager/submit.c
@@ -129,11 +129,17 @@ static int submit_post_event (struct event *event, struct job *job)
                                  "flags", job->flags);
     if (!entry)
         goto error;
+    /* call before eventlog_seq increment below */
+    if (event_batch_process_event_entry (event,
+                                         job->id,
+                                         job->eventlog_seq,
+                                         "submit",
+                                         entry) < 0)
+        goto error;
     if (event_job_update (job, entry) < 0) /* NEW -> DEPEND */
         goto error;
+    job->eventlog_seq++;
     if (event_batch_pub_state (event, job, job->t_submit) < 0)
-        goto error;
-    if (event_batch_process_event_entry (event, job->id, "submit", entry) < 0)
         goto error;
     if (event_job_action (event, job) < 0)
         goto error;

--- a/src/modules/job-manager/submit.c
+++ b/src/modules/job-manager/submit.c
@@ -133,7 +133,7 @@ static int submit_post_event (struct event *event, struct job *job)
         goto error;
     if (event_batch_pub_state (event, job, job->t_submit) < 0)
         goto error;
-    if (event_batch_process_event_entry (event, job, "submit", entry) < 0)
+    if (event_batch_process_event_entry (event, job->id, "submit", entry) < 0)
         goto error;
     if (event_job_action (event, job) < 0)
         goto error;

--- a/src/modules/job-manager/submit.h
+++ b/src/modules/job-manager/submit.h
@@ -26,7 +26,6 @@ void submit_ctx_destroy (struct submit *submit);
 int submit_add_one_job (zhashx_t *active_jobs, zlist_t *newjobs, json_t *o);
 void submit_add_jobs_cleanup (zhashx_t *active_jobs, zlist_t *newjobs);
 zlist_t *submit_add_jobs (zhashx_t *active_jobs, json_t *jobs);
-int submit_post_event (struct event *event, struct job *job);
 
 #endif /* ! _FLUX_JOB_MANAGER_SUBMIT_H */
 

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -108,7 +108,7 @@ TESTSCRIPTS = \
 	t2207-job-manager-wait.t \
 	t2208-queue-cmd.t \
 	t2210-job-manager-bugs.t \
-	t2211-job-manager-events.t \
+	t2211-job-manager-events-journal.t \
 	t2220-job-archive.t \
 	t2230-job-info-list.t \
 	t2231-job-info-lookup.t \
@@ -275,7 +275,7 @@ check_PROGRAMS = \
 	rexec/rexec_count_stdout \
 	rexec/rexec_getline \
 	job-manager/list-jobs \
-	job-manager/event_stream \
+	job-manager/events_journal_stream \
 	ingest/submitbench \
 	sched-simple/jj-reader \
 	shell/rcalc \
@@ -542,9 +542,9 @@ job_manager_list_jobs_CPPFLAGS = $(test_cppflags)
 job_manager_list_jobs_LDADD = \
 	$(test_ldadd) $(LIBDL) $(LIBUTIL)
 
-job_manager_event_stream_SOURCES = job-manager/event_stream.c
-job_manager_event_stream_CPPFLAGS = $(test_cppflags)
-job_manager_event_stream_LDADD = \
+job_manager_events_journal_stream_SOURCES = job-manager/events_journal_stream.c
+job_manager_events_journal_stream_CPPFLAGS = $(test_cppflags)
+job_manager_events_journal_stream_LDADD = \
 	$(test_ldadd) $(LIBDL) $(LIBUTIL)
 
 job_manager_sched_dummy_la_SOURCES = job-manager/sched-dummy.c

--- a/t/job-manager/event_stream.c
+++ b/t/job-manager/event_stream.c
@@ -27,7 +27,7 @@ void cancel_cb (int sig)
 {
     flux_future_t *f2;
     if (!(f2 = flux_rpc_pack (h,
-                              "job-manager.events-cancel",
+                              "job-manager.events-journal-cancel",
                               FLUX_NODEID_ANY,
                               FLUX_RPC_NORESPONSE,
                               "{s:i}",
@@ -55,7 +55,7 @@ int main (int argc, char *argv[])
         inlen++;    //  and read_all() ensures inbuf has one, not acct in inlen
 
     if (!(f = flux_rpc_raw (h,
-                            "job-manager.events",
+                            "job-manager.events-journal",
                             inbuf,
                             inlen,
                             FLUX_NODEID_ANY,
@@ -72,7 +72,8 @@ int main (int argc, char *argv[])
         if (flux_rpc_get_unpack (f, "{s:o}", "events", &events) < 0) {
             if (errno == ENODATA)
                 break;
-            log_msg_exit ("job-manager.events: %s", future_strerror (f, errno));
+            log_msg_exit ("job-manager.events-journal: %s",
+                          future_strerror (f, errno));
         }
         json_array_foreach (events, index, value) {
             char *s = json_dumps (value, 0);

--- a/t/job-manager/events_journal_stream.c
+++ b/t/job-manager/events_journal_stream.c
@@ -45,7 +45,7 @@ int main (int argc, char *argv[])
         log_err_exit ("flux_open");
 
     if (argc != 1) {
-        fprintf (stderr, "Usage: event_stream <payload\n");
+        fprintf (stderr, "Usage: events_journal_stream <payload\n");
         exit (1);
     }
 

--- a/t/t2202-job-manager.t
+++ b/t/t2202-job-manager.t
@@ -313,7 +313,7 @@ test_expect_success 'submit request with empty payload fails with EPROTO(71)' '
 
 test_expect_success HAVE_JQ 'job-manager stats works' '
         flux module stats job-manager > stats.out &&
-        cat stats.out | $jq -e .events.listeners
+        cat stats.out | $jq -e .journal.listeners
 '
 
 test_expect_success 'job-manager: remove job-info, job-manager, job-ingest' '

--- a/t/t2211-job-manager-events.t
+++ b/t/t2211-job-manager-events.t
@@ -341,12 +341,12 @@ test_expect_success HAVE_JQ,NO_CHAIN_LINT 'job-manager: eventlog seqs are correc
         wait $pid
 '
 test_expect_success 'job-manager: events request fails with EPROTO on empty payload' '
-        $RPC job-manager.events 71 < /dev/null
+        $RPC job-manager.events-journal 71 < /dev/null
 '
 
 test_expect_success HAVE_JQ 'job-manager: events request fails if not streaming RPC' '
         $jq -j -c -n "{}" > cc1.in &&
-        test_must_fail $RPC job-manager.events < cc1.in
+        test_must_fail $RPC job-manager.events-journal < cc1.in
 '
 
 test_expect_success HAVE_JQ 'job-manager: events request fails if allow not an object' '

--- a/t/t2211-job-manager-events.t
+++ b/t/t2211-job-manager-events.t
@@ -26,28 +26,6 @@ test_expect_success 'flux-job: generate jobspec for simple test job' '
         flux jobspec srun -n1 hostname >basic.json
 '
 
-wait_events_listeners() {
-        num=$1
-        i=0
-        while [ "$(flux module stats --parse events.listeners job-manager 2> /dev/null)" != "$num" ] \
-              && [ $i -lt 50 ]
-        do
-                sleep 0.1
-                i=$((i + 1))
-        done
-        if [ "$i" -eq "50" ]
-        then
-            return 1
-        fi
-        return 0
-}
-
-# to avoid raciness in tests below, ensure job-info is synced to the
-# job-manager and won't be part of the events.listeners counts below
-test_expect_success 'wait for job-info to sync with job-manager' '
-        wait_events_listeners 1
-'
-
 check_event() {
         jobid="$1"
         key=$2
@@ -113,12 +91,9 @@ wait_event_annotation() {
 }
 
 test_expect_success HAVE_JQ,NO_CHAIN_LINT 'job-manager: events with no filters shows all events' '
-        before=`flux module stats --parse events.listeners job-manager`
-        count=$((before + 1))
         $jq -j -c -n "{}" \
           | $EVENT_STREAM > events1.out &
         pid=$! &&
-        wait_events_listeners $count &&
         jobid=`flux job submit basic.json | flux job id` &&
         wait_event_name ${jobid} clean events1.out &&
         check_event_name ${jobid} submit events1.out &&
@@ -130,17 +105,13 @@ test_expect_success HAVE_JQ,NO_CHAIN_LINT 'job-manager: events with no filters s
         check_event_name ${jobid} free events1.out &&
         check_event_name ${jobid} clean events1.out &&
         kill -s USR1 $pid &&
-        wait $pid &&
-        wait_events_listeners $before
+        wait $pid
 '
 
 test_expect_success HAVE_JQ,NO_CHAIN_LINT 'job-manager: events with allow works' '
-        before=`flux module stats --parse events.listeners job-manager`
-        count=$((before + 1))
         $jq -j -c -n "{allow:{clean:1}}" \
           | $EVENT_STREAM > events2.out &
         pid=$! &&
-        wait_events_listeners $count &&
         jobid=`flux job submit basic.json | flux job id` &&
         wait_event_name ${jobid} clean events2.out &&
         test_must_fail check_event_name ${jobid} submit events2.out &&
@@ -152,17 +123,13 @@ test_expect_success HAVE_JQ,NO_CHAIN_LINT 'job-manager: events with allow works'
         test_must_fail check_event_name ${jobid} free events2.out &&
         check_event_name ${jobid} clean events2.out &&
         kill -s USR1 $pid &&
-        wait $pid &&
-        wait_events_listeners $before
+        wait $pid
 '
 
 test_expect_success HAVE_JQ,NO_CHAIN_LINT 'job-manager: events with allow works (multiple)' '
-        before=`flux module stats --parse events.listeners job-manager`
-        count=$((before + 1))
         $jq -j -c -n "{allow:{depend:1, finish:1, clean:1}}" \
           | $EVENT_STREAM > events3.out &
         pid=$! &&
-        wait_events_listeners $count &&
         jobid=`flux job submit basic.json | flux job id` &&
         wait_event_name ${jobid} clean events3.out &&
         test_must_fail check_event_name ${jobid} submit events3.out &&
@@ -174,17 +141,13 @@ test_expect_success HAVE_JQ,NO_CHAIN_LINT 'job-manager: events with allow works 
         test_must_fail check_event_name ${jobid} free events3.out &&
         check_event_name ${jobid} clean events3.out &&
         kill -s USR1 $pid &&
-        wait $pid &&
-        wait_events_listeners $before
+        wait $pid
 '
 
 test_expect_success HAVE_JQ,NO_CHAIN_LINT 'job-manager: events with deny works' '
-        before=`flux module stats --parse events.listeners job-manager`
-        count=$((before + 1))
         $jq -j -c -n "{deny:{finish:1}}" \
           | $EVENT_STREAM > events4.out &
         pid=$! &&
-        wait_events_listeners $count &&
         jobid=`flux job submit basic.json | flux job id` &&
         wait_event_name ${jobid} clean events4.out &&
         check_event_name ${jobid} submit events4.out &&
@@ -196,17 +159,13 @@ test_expect_success HAVE_JQ,NO_CHAIN_LINT 'job-manager: events with deny works' 
         check_event_name ${jobid} free events4.out &&
         check_event_name ${jobid} clean events4.out &&
         kill -s USR1 $pid &&
-        wait $pid &&
-        wait_events_listeners $before
+        wait $pid
 '
 
 test_expect_success HAVE_JQ,NO_CHAIN_LINT 'job-manager: events with deny works (multiple)' '
-        before=`flux module stats --parse events.listeners job-manager`
-        count=$((before + 1))
         $jq -j -c -n "{deny:{depend:1, finish:1, release:1}}" \
           | $EVENT_STREAM > events5.out &
         pid=$! &&
-        wait_events_listeners $count &&
         jobid=`flux job submit basic.json | flux job id` &&
         wait_event_name ${jobid} clean events5.out &&
         check_event_name ${jobid} submit events5.out &&
@@ -218,17 +177,13 @@ test_expect_success HAVE_JQ,NO_CHAIN_LINT 'job-manager: events with deny works (
         check_event_name ${jobid} free events5.out &&
         check_event_name ${jobid} clean events5.out &&
         kill -s USR1 $pid &&
-        wait $pid &&
-        wait_events_listeners $before
+        wait $pid
 '
 
 test_expect_success HAVE_JQ,NO_CHAIN_LINT 'job-manager: events with allow & deny works' '
-        before=`flux module stats --parse events.listeners job-manager`
-        count=$((before + 1))
         $jq -j -c -n "{allow:{depend:1, finish:1, clean:1}, deny:{depend:1}}" \
           | $EVENT_STREAM > events6.out &
         pid=$! &&
-        wait_events_listeners $count &&
         jobid=`flux job submit basic.json | flux job id` &&
         wait_event_name ${jobid} clean events6.out &&
         test_must_fail check_event_name ${jobid} submit events6.out &&
@@ -240,8 +195,7 @@ test_expect_success HAVE_JQ,NO_CHAIN_LINT 'job-manager: events with allow & deny
         test_must_fail check_event_name ${jobid} free events6.out &&
         check_event_name ${jobid} clean events6.out &&
         kill -s USR1 $pid &&
-        wait $pid &&
-        wait_events_listeners $before
+        wait $pid
 '
 
 test_expect_success HAVE_JQ,NO_CHAIN_LINT 'job-manager: events journaling works' '
@@ -249,12 +203,9 @@ test_expect_success HAVE_JQ,NO_CHAIN_LINT 'job-manager: events journaling works'
         jobid2=`flux job submit basic.json | flux job id`
         flux job wait-event ${jobid1} clean
         flux job wait-event ${jobid2} clean
-        before=`flux module stats --parse events.listeners job-manager`
-        count=$((before + 1))
         $jq -j -c -n "{allow:{depend:1, clean:1}}" \
           | $EVENT_STREAM > events7.out &
         pid=$! &&
-        wait_events_listeners $count &&
         jobid3=`flux job submit basic.json | flux job id` &&
         wait_event_name ${jobid3} clean events7.out &&
         test_must_fail check_event_name ${jobid1} submit events7.out &&
@@ -282,17 +233,13 @@ test_expect_success HAVE_JQ,NO_CHAIN_LINT 'job-manager: events journaling works'
         test_must_fail check_event_name ${jobid3} free events7.out &&
         check_event_name ${jobid3} clean events7.out &&
         kill -s USR1 $pid &&
-        wait $pid &&
-        wait_events_listeners $before
+        wait $pid
 '
 
 test_expect_success HAVE_JQ,NO_CHAIN_LINT 'job-manager: events works with annotations' '
-        before=`flux module stats --parse events.listeners job-manager`
-        count=$((before + 1))
         $jq -j -c -n "{allow:{annotations:1, clean:1}}" \
           | $EVENT_STREAM > events8.out &
         pid=$! &&
-        wait_events_listeners $count &&
         flux queue stop &&
         jobid=`flux job submit basic.json | flux job id` &&
         echo ${jobid} > annotation_job1.id &&
@@ -316,18 +263,14 @@ test_expect_success HAVE_JQ,NO_CHAIN_LINT 'job-manager: events works with annota
         check_event_annotation ${jobid} foo 1234567 events8.out &&
         check_event_name ${jobid} clean events8.out &&
         kill -s USR1 $pid &&
-        wait $pid &&
-        wait_events_listeners $before
+        wait $pid
 '
 
 test_expect_success HAVE_JQ,NO_CHAIN_LINT 'job-manager: events journaling works with annotations' '
         jobid1=`cat annotation_job1.id`
-        before=`flux module stats --parse events.listeners job-manager`
-        count=$((before + 1))
         $jq -j -c -n "{allow:{annotations:1, clean:1}}" \
           | $EVENT_STREAM > events9.out &
         pid=$! &&
-        wait_events_listeners $count &&
         flux queue stop &&
         jobid2=`flux job submit basic.json | flux job id` &&
         flux job annotate ${jobid2} bar hijklmnop &&
@@ -361,8 +304,7 @@ test_expect_success HAVE_JQ,NO_CHAIN_LINT 'job-manager: events journaling works 
         check_event_annotation ${jobid2} bar 89012345 events9.out &&
         check_event_name ${jobid2} clean events9.out &&
         kill -s USR1 $pid &&
-        wait $pid &&
-        wait_events_listeners $before
+        wait $pid
 '
 
 check_event_name_eventlog_seq() {
@@ -381,12 +323,9 @@ check_event_name_eventlog_seq() {
 
 # annotations event below comes from sched-simple scheduler
 test_expect_success HAVE_JQ,NO_CHAIN_LINT 'job-manager: eventlog seqs are correct' '
-        before=`flux module stats --parse events.listeners job-manager`
-        count=$((before + 1))
         $jq -j -c -n "{}" \
           | $EVENT_STREAM > events9.out &
         pid=$! &&
-        wait_events_listeners $count &&
         jobid=`flux job submit basic.json | flux job id` &&
         wait_event_name ${jobid} clean events9.out &&
         check_event_name_eventlog_seq ${jobid} 0 submit events9.out &&
@@ -399,8 +338,7 @@ test_expect_success HAVE_JQ,NO_CHAIN_LINT 'job-manager: eventlog seqs are correc
         check_event_name_eventlog_seq ${jobid} 6 free events9.out &&
         check_event_name_eventlog_seq ${jobid} 7 clean events9.out &&
         kill -s USR1 $pid &&
-        wait $pid &&
-        wait_events_listeners $before
+        wait $pid
 '
 test_expect_success 'job-manager: events request fails with EPROTO on empty payload' '
         $RPC job-manager.events 71 < /dev/null

--- a/t/t2211-job-manager-events.t
+++ b/t/t2211-job-manager-events.t
@@ -4,6 +4,17 @@ test_description='Test flux job manager events service'
 
 . $(dirname $0)/sharness.sh
 
+export FLUX_CONF_DIR=$(pwd)
+
+# set events_journal_maxlen to something more sensible in testing,
+# otherwise we'll be parsing 100s of entries regularly.  50 is a good
+# number, since it will always cover the prior 4 jobs that were
+# executed.
+cat >job-manager.toml <<EOF
+[job-manager]
+events_journal_maxlen = 50
+EOF
+
 test_under_flux 4
 
 RPC=${FLUX_BUILD_DIR}/t/request/rpc
@@ -233,34 +244,122 @@ test_expect_success HAVE_JQ,NO_CHAIN_LINT 'job-manager: events with allow & deny
         wait_events_listeners $before
 '
 
+test_expect_success HAVE_JQ,NO_CHAIN_LINT 'job-manager: events journaling works' '
+        jobid1=`flux job submit basic.json | flux job id`
+        jobid2=`flux job submit basic.json | flux job id`
+        flux job wait-event ${jobid1} clean
+        flux job wait-event ${jobid2} clean
+        before=`flux module stats --parse events.listeners job-manager`
+        count=$((before + 1))
+        $jq -j -c -n "{allow:{depend:1, clean:1}}" \
+          | $EVENT_STREAM > events7.out &
+        pid=$! &&
+        wait_events_listeners $count &&
+        jobid3=`flux job submit basic.json | flux job id` &&
+        wait_event_name ${jobid3} clean events7.out &&
+        test_must_fail check_event_name ${jobid1} submit events7.out &&
+        check_event_name ${jobid1} depend events7.out &&
+        test_must_fail check_event_name ${jobid1} alloc events7.out &&
+        test_must_fail check_event_name ${jobid1} start events7.out &&
+        test_must_fail check_event_name ${jobid1} finish events7.out &&
+        test_must_fail check_event_name ${jobid1} release events7.out &&
+        test_must_fail check_event_name ${jobid1} free events7.out &&
+        check_event_name ${jobid1} clean events7.out &&
+        test_must_fail check_event_name ${jobid2} submit events7.out &&
+        check_event_name ${jobid2} depend events7.out &&
+        test_must_fail check_event_name ${jobid2} alloc events7.out &&
+        test_must_fail check_event_name ${jobid2} start events7.out &&
+        test_must_fail check_event_name ${jobid2} finish events7.out &&
+        test_must_fail check_event_name ${jobid2} release events7.out &&
+        test_must_fail check_event_name ${jobid2} free events7.out &&
+        check_event_name ${jobid2} clean events7.out &&
+        test_must_fail check_event_name ${jobid3} submit events7.out &&
+        check_event_name ${jobid3} depend events7.out &&
+        test_must_fail check_event_name ${jobid3} alloc events7.out &&
+        test_must_fail check_event_name ${jobid3} start events7.out &&
+        test_must_fail check_event_name ${jobid3} finish events7.out &&
+        test_must_fail check_event_name ${jobid3} release events7.out &&
+        test_must_fail check_event_name ${jobid3} free events7.out &&
+        check_event_name ${jobid3} clean events7.out &&
+        kill -s USR1 $pid &&
+        wait $pid &&
+        wait_events_listeners $before
+'
+
 test_expect_success HAVE_JQ,NO_CHAIN_LINT 'job-manager: events works with annotations' '
         before=`flux module stats --parse events.listeners job-manager`
         count=$((before + 1))
         $jq -j -c -n "{allow:{annotations:1, clean:1}}" \
-          | $EVENT_STREAM > events7.out &
+          | $EVENT_STREAM > events8.out &
         pid=$! &&
         wait_events_listeners $count &&
         flux queue stop &&
         jobid=`flux job submit basic.json | flux job id` &&
+        echo ${jobid} > annotation_job1.id &&
         flux job annotate $jobid foo abcdefg &&
-        wait_event_annotation ${jobid} foo \"abcdefg\" events7.out &&
+        wait_event_annotation ${jobid} foo \"abcdefg\" events8.out &&
         flux job annotate $jobid foo ABCDEFG &&
-        wait_event_annotation ${jobid} foo \"ABCDEFG\" events7.out &&
+        wait_event_annotation ${jobid} foo \"ABCDEFG\" events8.out &&
         flux job annotate $jobid foo 1234567 &&
-        wait_event_annotation ${jobid} foo 1234567 events7.out &&
+        wait_event_annotation ${jobid} foo 1234567 events8.out &&
         flux queue start &&
-        wait_event_name ${jobid} clean events7.out &&
-        test_must_fail check_event_name ${jobid} submit events7.out &&
-        test_must_fail check_event_name ${jobid} depend events7.out &&
-        test_must_fail check_event_name ${jobid} alloc events7.out &&
-        test_must_fail check_event_name ${jobid} start events7.out &&
-        test_must_fail check_event_name ${jobid} finish events7.out &&
-        test_must_fail check_event_name ${jobid} release events7.out &&
-        test_must_fail check_event_name ${jobid} free events7.out &&
-        check_event_annotation ${jobid} foo \"abcdefg\" events7.out &&
-        check_event_annotation ${jobid} foo \"ABCDEFG\" events7.out &&
-        check_event_annotation ${jobid} foo 1234567 events7.out &&
-        check_event_name ${jobid} clean events7.out &&
+        wait_event_name ${jobid} clean events8.out &&
+        test_must_fail check_event_name ${jobid} submit events8.out &&
+        test_must_fail check_event_name ${jobid} depend events8.out &&
+        test_must_fail check_event_name ${jobid} alloc events8.out &&
+        test_must_fail check_event_name ${jobid} start events8.out &&
+        test_must_fail check_event_name ${jobid} finish events8.out &&
+        test_must_fail check_event_name ${jobid} release events8.out &&
+        test_must_fail check_event_name ${jobid} free events8.out &&
+        check_event_annotation ${jobid} foo \"abcdefg\" events8.out &&
+        check_event_annotation ${jobid} foo \"ABCDEFG\" events8.out &&
+        check_event_annotation ${jobid} foo 1234567 events8.out &&
+        check_event_name ${jobid} clean events8.out &&
+        kill -s USR1 $pid &&
+        wait $pid &&
+        wait_events_listeners $before
+'
+
+test_expect_success HAVE_JQ,NO_CHAIN_LINT 'job-manager: events journaling works with annotations' '
+        jobid1=`cat annotation_job1.id`
+        before=`flux module stats --parse events.listeners job-manager`
+        count=$((before + 1))
+        $jq -j -c -n "{allow:{annotations:1, clean:1}}" \
+          | $EVENT_STREAM > events9.out &
+        pid=$! &&
+        wait_events_listeners $count &&
+        flux queue stop &&
+        jobid2=`flux job submit basic.json | flux job id` &&
+        flux job annotate ${jobid2} bar hijklmnop &&
+        wait_event_annotation ${jobid2} bar \"hijklmnop\" events9.out &&
+        flux job annotate $jobid2 bar HIJKLMNOP &&
+        wait_event_annotation ${jobid2} bar \"HIJKLMNOP\" events9.out &&
+        flux job annotate $jobid2 bar 89012345 &&
+        wait_event_annotation ${jobid2} bar 89012345 events9.out &&
+        flux queue start &&
+        wait_event_name ${jobid2} clean events9.out &&
+        test_must_fail check_event_name ${jobid1} submit events9.out &&
+        test_must_fail check_event_name ${jobid1} depend events9.out &&
+        test_must_fail check_event_name ${jobid1} alloc events9.out &&
+        test_must_fail check_event_name ${jobid1} start events9.out &&
+        test_must_fail check_event_name ${jobid1} finish events9.out &&
+        test_must_fail check_event_name ${jobid1} release events9.out &&
+        test_must_fail check_event_name ${jobid1} free events9.out &&
+        check_event_annotation ${jobid1} foo \"abcdefg\" events9.out &&
+        check_event_annotation ${jobid1} foo \"ABCDEFG\" events9.out &&
+        check_event_annotation ${jobid1} foo 1234567 events9.out &&
+        check_event_name ${jobid1} clean events9.out &&
+        test_must_fail check_event_name ${jobid2} submit events9.out &&
+        test_must_fail check_event_name ${jobid2} depend events9.out &&
+        test_must_fail check_event_name ${jobid2} alloc events9.out &&
+        test_must_fail check_event_name ${jobid2} start events9.out &&
+        test_must_fail check_event_name ${jobid2} finish events9.out &&
+        test_must_fail check_event_name ${jobid2} release events9.out &&
+        test_must_fail check_event_name ${jobid2} free events9.out &&
+        check_event_annotation ${jobid2} bar \"hijklmnop\" events9.out &&
+        check_event_annotation ${jobid2} bar \"HIJKLMNOP\" events9.out &&
+        check_event_annotation ${jobid2} bar 89012345 events9.out &&
+        check_event_name ${jobid2} clean events9.out &&
         kill -s USR1 $pid &&
         wait $pid &&
         wait_events_listeners $before


### PR DESCRIPTION
Built on top of PR #3254.  It's the final in my series of job-manager / job-info refactoring / changes.

A few notes (mostly same notes as my prior attempted PR on this, #3238)

- introduces a `seq` into the wrapped entries, so listeners can determine if they have seen the event for a job before (via the KVS).

- b/c the `annotations` object of a job can change, we have to  `json_deep_copy()` job annotations that go into the journal so they can be preserved.

- i made the maximum journal length configurable.  The default is 1000 entries, which translates to 100-125 jobs on average (8 entries for a typical successful job, not counting any extra annotations that may come from the scheduler).  Dunno if this is too small?  Would we want longer?

- b/c of the journaling, I don't really need to synchronize on the `job-manager.events.listeners` stat anymore.  I could remove the stat, but left it in there for the time being since it doesn't hurt to have it there.
