### PR TITLE
python: fix signal handler management in threads

### DIFF
--- a/src/bindings/python/flux/util.py
+++ b/src/bindings/python/flux/util.py
@@ -18,6 +18,7 @@ import math
 import argparse
 import traceback
 import signal
+import threading
 from datetime import timedelta
 from string import Formatter
 
@@ -63,10 +64,13 @@ def interruptible(func):
     """
 
     def func_wrapper(calling_obj, *args, **kwargs):
-        handler = signal.getsignal(signal.SIGINT)
-        signal.signal(signal.SIGINT, signal.SIG_DFL)
+        # python only allows `signal.signal` calls in the main thread
+        if threading.current_thread() is threading.main_thread():
+            handler = signal.getsignal(signal.SIGINT)
+            signal.signal(signal.SIGINT, signal.SIG_DFL)
         retval = func(calling_obj, *args, **kwargs)
-        signal.signal(signal.SIGINT, handler)
+        if threading.current_thread() is threading.main_thread():
+            signal.signal(signal.SIGINT, handler)
         return retval
 
     return func_wrapper


### PR DESCRIPTION
shield the signal handler code from being invoked in subthreads (i.e., not the main thread),
Python does not like that.  Since the KeyboardInterrupt which codes wants to enable arrives
in the MainThread anyway, this should be fine.  Subthreads are difficult to terminate then
though, it is adviseable to declare them as deamon threads so that MainThread interruptions
do not hang on pending thread activities.

This fixes #3264.

@grondo : I hope this helps - let me know if you think anything is missing.  For example, I was not sure if you want a unit test for this - it's a bit tricky to test as it is so timing sensitive, but it's certainly possible.