### PR TITLE
shell: support stdio buffering options / default stderr to unbuffered

### DIFF
--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -1361,6 +1361,7 @@ static void handle_output_data (struct attach_ctx *ctx, json_t *context)
         if (optparse_hasopt (ctx->p, "label-io"))
             fprintf (fp, "%s: ", rank);
         fwrite (data, len, 1, fp);
+        fflush (fp);
     }
     free (data);
 }

--- a/src/shell/output.c
+++ b/src/shell/output.c
@@ -970,7 +970,7 @@ static void task_output_cb (struct shell_task *task,
     int len;
 
     data = flux_subprocess_getline (task->proc, stream, &len);
-    if (len < 0) {
+    if (!data) {
         shell_log_errno ("read %s task %d", stream, task->rank);
     }
     else if (len > 0) {

--- a/src/shell/output.c
+++ b/src/shell/output.c
@@ -950,7 +950,7 @@ struct shell_output *shell_output_create (flux_shell_t *shell)
         out->stderr_type = FLUX_OUTPUT_TYPE_KVS;
     }
     out->stdout_buffer_type = "line";
-    out->stderr_buffer_type = "line";
+    out->stderr_buffer_type = "none";
 
     if (shell_output_check_alternate_output (out) < 0)
         goto error;

--- a/t/t2602-job-shell.t
+++ b/t/t2602-job-shell.t
@@ -134,9 +134,11 @@ test_expect_success 'job-shell: verify output of 1-task lptest job' '
 # output.
 #
 
-test_expect_success 'job-shell: verify output of 1-task lptest job on stderr' '
-        id=$(flux jobspec srun -n1 bash -c "${LPTEST} >&2" \
-		| flux job submit) &&
+test_expect_success HAVE_JQ 'job-shell: verify output of 1-task lptest job on stderr' '
+	flux jobspec srun -n1 bash -c "${LPTEST} >&2" \
+	    | $jq ".attributes.system.shell.options.output.stderr.buffer.type = \"line\"" \
+	    > 1task_lptest.json &&
+	id=$(cat 1task_lptest.json | flux job submit) &&
 	flux job attach -l $id 2>lptest.err &&
         sed -i -e "/stdin EOF could not be sent/d" lptest.err &&
 	test_cmp lptest.exp lptest.err
@@ -147,9 +149,11 @@ test_expect_success 'job-shell: verify output of 4-task lptest job' '
 	sort -snk1 <lptest4_raw.out >lptest4.out &&
 	test_cmp lptest4.exp lptest4.out
 '
-test_expect_success 'job-shell: verify output of 4-task lptest job on stderr' '
-        id=$(flux jobspec srun -N4 bash -c "${LPTEST} 1>&2" \
-		| flux job submit) &&
+test_expect_success HAVE_JQ 'job-shell: verify output of 4-task lptest job on stderr' '
+	flux jobspec srun -N4 bash -c "${LPTEST} 1>&2" \
+	    | $jq ".attributes.system.shell.options.output.stderr.buffer.type = \"line\"" \
+	    > 4task_lptest.json &&
+	id=$(cat 4task_lptest.json | flux job submit) &&
 	flux job attach -l $id 2>lptest4_raw.err &&
 	sort -snk1 <lptest4_raw.err >lptest4.err &&
         sed -i -e "/stdin EOF could not be sent/d" lptest4.err &&


### PR DESCRIPTION
per discussion in #3041

part 1 of the PR, support a new "output.<stdout|stderr>.buffer.type" configuration in the shell, which determines if stdout/stderr will be line buffered or unbuffered.

part 2 of this PR per #3041, default stderr to be unbuffered by default.

update some tests as needed

note that for the moment I did not include this configuration as a new option in `flux-mini` as I wasn't sure if it was something truly needed.  Would be trivial to add of course.
