### PR TITLE
cmd: display jobid with flux-mini alloc -v, --verbose

### DIFF
--- a/doc/man1/flux-mini.rst
+++ b/doc/man1/flux-mini.rst
@@ -263,8 +263,10 @@ OTHER OPTIONS
    with priority in the range of 0 to 31 (default 16).
 
 **-v, --verbose**
-   *(run only)* Increase verbosity on stderr. For example, currently ``-v``
-   displays jobid, ``-vv`` displays job events, and ``-vvv`` displays exec events.
+   *(run,alloc)* Increase verbosity on stderr. For example, currently
+   ``flux mini run -v`` displays jobid, ``-vv`` displays job events, and
+   ``-vvv`` displays exec events. ``flux mini alloc -v`` forces the command
+   to print the submitted jobid on stderr.
    The specific output may change in the future.
 
 **-o, --setopt=KEY[=VAL]**

--- a/src/cmd/flux-mini.py
+++ b/src/cmd/flux-mini.py
@@ -591,6 +591,13 @@ class AllocCmd(MiniCmd):
         super().__init__(exclude_io=True)
         add_batch_alloc_args(self.parser)
         self.parser.add_argument(
+            "-v",
+            "--verbose",
+            action="count",
+            default=0,
+            help="Increase verbosity on stderr (multiple use OK)",
+        )
+        self.parser.add_argument(
             "COMMAND",
             nargs=argparse.REMAINDER,
             help="Set the initial COMMAND of new Flux instance."
@@ -616,6 +623,13 @@ class AllocCmd(MiniCmd):
 
     def main(self, args):
         jobid = self.submit(args)
+
+        # Display job id on stderr if -v
+        # N.B. we must flush sys.stderr due to the fact that it is buffered
+        # when it points to a file, and os.execvp leaves it unflushed
+        if args.verbose > 0:
+            print("jobid:", jobid, file=sys.stderr)
+            sys.stderr.flush()
 
         # Build args for flux job attach
         attach_args = ["flux-job", "attach"]

--- a/t/t2702-mini-alloc.t
+++ b/t/t2702-mini-alloc.t
@@ -44,4 +44,9 @@ test_expect_success 'flux-mini alloc runs one broker per node by default' '
 	test_debug "cat multi.out" &&
 	grep "size  *2" multi.out
 '
+test_expect_success 'flux-mini alloc -v prints jobid on stderr' '
+	$runpty -o verbose.out flux mini alloc -n1 -v flux lsattr -v &&
+	test_debug "cat verbose.out" &&
+	grep "jobid: " verbose.out
+'
 test_done


### PR DESCRIPTION
As noted in #3274, there is currently no way to get `flux mini alloc` to emit the submitted jobid, which makes either checking on a `flux mini alloc` job or scripting the `flux mini alloc` command difficult.

This PR simply adds a `-v` option to `flux mini alloc` which prints the jobid on stderr like `flux mini run`.