### PR TITLE
libflux: Add missing C++ header guards

### DIFF
--- a/src/common/libeventlog/eventlog.h
+++ b/src/common/libeventlog/eventlog.h
@@ -13,6 +13,10 @@
 
 #include <jansson.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* convenience function to extract timestamp, name, and optional
  * context from an event entry */
 int eventlog_entry_parse (json_t *entry,
@@ -47,6 +51,10 @@ json_t *eventlog_entry_vpack (double timestamp,
                               va_list ap);
 
 char *eventlog_entry_encode (json_t *entry);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* !_EVENTLOG_H */
 

--- a/src/common/libflux/buffer.h
+++ b/src/common/libflux/buffer.h
@@ -13,6 +13,10 @@
 
 #include <stdbool.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct flux_buffer flux_buffer_t;
 
 /* Create buffer.
@@ -126,5 +130,9 @@ int flux_buffer_read_to_fd (flux_buffer_t *fb, int fd, int len);
 int flux_buffer_write_from_fd (flux_buffer_t *fb, int fd, int len);
 
 /* FUTURE: append, prepend, printf, add_flux_buffer, etc. */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* !_FLUX_BUFFER_H */

--- a/src/common/libhostlist/hostlist.h
+++ b/src/common/libhostlist/hostlist.h
@@ -13,6 +13,10 @@
 #ifndef FLUX_HOSTLIST_H
 #define FLUX_HOSTLIST_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct hostlist *hostlist_create (void);
 
 void hostlist_destroy (struct hostlist *hl);
@@ -134,5 +138,9 @@ const char * hostlist_current (struct hostlist *hl);
  *  or -1 on error.
  */
 int hostlist_remove_current (struct hostlist *hl);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* !_HOSTLIST_H */

--- a/src/common/libidset/idset.h
+++ b/src/common/libidset/idset.h
@@ -19,6 +19,10 @@
 #include <sys/param.h>
 #include <stdbool.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 enum idset_flags {
     IDSET_FLAG_AUTOGROW = 1, // allow idset size to automatically grow
     IDSET_FLAG_BRACKETS = 2, // encode non-singleton idset with brackets
@@ -118,6 +122,9 @@ typedef int (*idset_format_map_f)(const char *s, bool *stop, void *arg);
 
 int idset_format_map (const char *s, idset_format_map_f fun, void *arg);
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* !FLUX_IDSET_H */
 

--- a/src/common/libkvs/kvs_txn.h
+++ b/src/common/libkvs/kvs_txn.h
@@ -11,11 +11,11 @@
 #ifndef _FLUX_CORE_KVS_TXN_H
 #define _FLUX_CORE_KVS_TXN_H
 
+#include <stdarg.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <stdarg.h>
 
 typedef struct flux_kvs_txn flux_kvs_txn_t;
 

--- a/src/common/libpmi/pmi.h
+++ b/src/common/libpmi/pmi.h
@@ -13,6 +13,10 @@
 #ifndef FLUX_PMI_H_INCLUDED
 #define FLUX_PMI_H_INCLUDED
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define PMI_SUCCESS                  0
 #define PMI_FAIL                    -1
 #define PMI_ERR_INIT                 1
@@ -93,6 +97,10 @@ int PMI_Args_to_keyval (int *argcp, char *((*argvp)[]),
                         PMI_keyval_t **keyvalp, int *size);
 int PMI_Free_keyvals (PMI_keyval_t keyvalp[], int size);
 int PMI_Get_options (char *str, int *length);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* !FLUX_PMI_H_INCLUDED */
 

--- a/src/common/libpmi/pmi2.h
+++ b/src/common/libpmi/pmi2.h
@@ -11,6 +11,10 @@
 #ifndef FLUX_PMI2_H_INCLUDED
 #define FLUX_PMI2_H_INCLUDED
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define PMI2_SUCCESS                0
 #define PMI2_FAIL                   -1
 #define PMI2_ERR_INIT               1
@@ -97,7 +101,9 @@ int PMI2_Nameserv_lookup (const char service_name[],
 int PMI2_Nameserv_unpublish (const char service_name[],
                              const struct MPID_Info *info_ptr);
 
-
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* !FLUX_PMI2_H_INCLUDED */
 

--- a/src/common/libschedutil/alloc.h
+++ b/src/common/libschedutil/alloc.h
@@ -16,6 +16,10 @@
 
 #include "init.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 enum {
     FLUX_SCHED_ALLOC_SUCCESS  = 0,
     FLUX_SCHED_ALLOC_ANNOTATE = 1,
@@ -61,6 +65,10 @@ int schedutil_alloc_respond_success_pack (schedutil_t *util,
  * N.B. 'msg' is the alloc request, not the cancel request.
  */
 int schedutil_alloc_respond_cancel (schedutil_t *util, const flux_msg_t *msg);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* !_FLUX_SCHEDUTIL_ALLOC_H */
 

--- a/src/common/libschedutil/free.h
+++ b/src/common/libschedutil/free.h
@@ -15,6 +15,10 @@
 
 #include "init.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Decode a free request.
  * Returns 0 on success, -1 on failure with errno set.
  */
@@ -23,6 +27,10 @@ int schedutil_free_request_decode (const flux_msg_t *msg, flux_jobid_t *id);
 /* Respond to a free request.
  */
 int schedutil_free_respond (schedutil_t *util, const flux_msg_t *msg);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* !_FLUX_SCHEDUTIL_FREE_H */
 

--- a/src/common/libschedutil/hello.h
+++ b/src/common/libschedutil/hello.h
@@ -15,6 +15,10 @@
 
 #include "init.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Callback for ingesting R + metadata for jobs that have resources
  * Return 0 on success, -1 on failure with errno set.
  * Failure of the callback aborts iteration and causes schedutil_hello()
@@ -34,6 +38,10 @@ typedef int (schedutil_hello_cb_f)(flux_t *h,
  * with 'arg'.
  */
 int schedutil_hello (schedutil_t *util, schedutil_hello_cb_f *cb, void *arg);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* !_FLUX_SCHEDUTIL_HELLO_H */
 

--- a/src/common/libschedutil/init.h
+++ b/src/common/libschedutil/init.h
@@ -15,6 +15,10 @@
 
 #include "ops.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct schedutil_ctx schedutil_t;
 
 /* Create a handle for the schedutil conveinence library.
@@ -35,5 +39,9 @@ schedutil_t *schedutil_create (flux_t *h,
  * alloc).
  */
 void schedutil_destroy (schedutil_t* ctx);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* !_FLUX_SCHEDUTIL_INIT_H */

--- a/src/common/libschedutil/ops.h
+++ b/src/common/libschedutil/ops.h
@@ -13,6 +13,10 @@
 
 #include <flux/core.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Callback for an alloc request.  jobspec is looked up as a convenience.
  * Decode msg with schedutil_alloc_request_decode().
  * 'msg' and 'jobspec' are only valid for hte duration of this call.
@@ -42,6 +46,10 @@ typedef void (schedutil_free_cb_f)(flux_t *h,
 typedef void (schedutil_cancel_cb_f)(flux_t *h,
                                      flux_jobid_t id,
                                      void *arg);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* !_FLUX_SCHEDUTIL_OPS_H */
 

--- a/src/common/libschedutil/ready.h
+++ b/src/common/libschedutil/ready.h
@@ -15,12 +15,20 @@
 
 #include "init.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Send ready request to job-manager, selecting interface 'mode'
  * ("single", "unlimited", ...).  'queue_depth', if non-NULL,
  * is set to the number of jobs in SCHED state that have not yet requested
  * resources.  Returns 0 on success, -1 on failure with errno set.
  */
 int schedutil_ready (schedutil_t *util, const char *mode, int *queue_depth);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* !_FLUX_SCHEDUTIL_READY_H */
 

--- a/src/common/libsubprocess/subprocess.h
+++ b/src/common/libsubprocess/subprocess.h
@@ -15,6 +15,10 @@
 
 #include <flux/core.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  *  flux_cmd_t: An object that defines a command to be run, either
  *   remotely or as a child of the current process. Includes cmdline
@@ -502,5 +506,9 @@ int flux_subprocess_aux_set (flux_subprocess_t *p,
  *   no such context exists, then NULL is returned.
  */
 void *flux_subprocess_aux_get (flux_subprocess_t *p, const char *name);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* !_FLUX_CORE_SUBPROCESS_H */

--- a/src/common/schedutil.h
+++ b/src/common/schedutil.h
@@ -11,20 +11,12 @@
 #ifndef _FLUX_SCHEDUTIL_H
 #define _FLUX_SCHEDUTIL_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include "schedutil/init.h"
 #include "schedutil/hello.h"
 #include "schedutil/ready.h"
 #include "schedutil/alloc.h"
 #include "schedutil/free.h"
 #include "schedutil/ops.h"
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif /* !_FLUX_SCHEDUTIL_H */
 


### PR DESCRIPTION
Add missing C++ header guards in all installed header files.

Fixes #3267