### PR TITLE
rc: fix local connector retries

### DIFF
--- a/etc/rc1
+++ b/etc/rc1
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 # Allow connector-local more time to start listening on socket
-FLUX_LOCAL_CONNECTOR_RETRY_COUNT=40 RANK=$(flux getattr rank)
+RANK=$(FLUX_LOCAL_CONNECTOR_RETRY_COUNT=30 flux getattr rank)
 
 if ! content_backing=$(flux getattr content.backing-module 2>/dev/null); then
     content_backing=content-sqlite


### PR DESCRIPTION
Problem: FLUX_LOCAL_CONNECTOR_RETRY_COUNT has no effect in rc1

This is a shell programming error.  The construct
  VAR=value FOO=$(cmd)
has no effect on cmd, since VAR is not exported.  Restructure as
  FOO=$(VAR=value cmd)

Revert the retry increase in 8bafb4fd310446ab665faeb223fb7b61a2c75d96
since that change had no effect, and this bug is the real problem.