### PR TITLE
libsubprocess: do not allow ref/unref in hooks

### DIFF
--- a/src/common/libsubprocess/local.c
+++ b/src/common/libsubprocess/local.c
@@ -509,12 +509,9 @@ static int local_child (flux_subprocess_t *p)
     }
 
     if (p->hooks.pre_exec) {
-        /* always a chance caller may destroy subprocess in callback */
-        flux_subprocess_ref (p);
         p->in_hook = true;
         (*p->hooks.pre_exec) (p, p->hooks.pre_exec_arg);
         p->in_hook = false;
-        flux_subprocess_unref (p);
     }
 
     if (p->flags & FLUX_SUBPROCESS_FLAGS_SETPGRP) {
@@ -622,12 +619,9 @@ static int local_fork (flux_subprocess_t *p)
         return -1;
 
     if (p->hooks.post_fork) {
-        /* always a chance caller may destroy subprocess in callback */
-        flux_subprocess_ref (p);
         p->in_hook = true;
         (*p->hooks.post_fork) (p, p->hooks.post_fork_arg);
         p->in_hook = false;
-        flux_subprocess_unref (p);
     }
 
     return (0);

--- a/src/common/libsubprocess/subprocess.c
+++ b/src/common/libsubprocess/subprocess.c
@@ -1154,13 +1154,18 @@ flux_future_t *flux_subprocess_kill (flux_subprocess_t *p, int signum)
 
 void flux_subprocess_ref (flux_subprocess_t *p)
 {
-    if (p && p->magic == SUBPROCESS_MAGIC)
+    if (p && p->magic == SUBPROCESS_MAGIC) {
+        if (p->local && p->in_hook)
+            return;
         p->refcount++;
+    }
 }
 
 void flux_subprocess_unref (flux_subprocess_t *p)
 {
     if (p && p->magic == SUBPROCESS_MAGIC) {
+        if (p->local && p->in_hook)
+            return;
         if (--p->refcount == 0)
             subprocess_free (p);
     }

--- a/src/common/libsubprocess/subprocess.h
+++ b/src/common/libsubprocess/subprocess.h
@@ -446,7 +446,8 @@ flux_future_t *flux_subprocess_kill (flux_subprocess_t *p, int signo);
 
 /*
  *  Add/remove a reference to subprocess object `p`. The subprocess object
- *   is destroyed once the last reference is removed.
+ *   is destroyed once the last reference is removed.  These calls
+ *   silently do nothing if called within a hook.
  */
 void flux_subprocess_ref (flux_subprocess_t *p);
 void flux_subprocess_unref (flux_subprocess_t *p);


### PR DESCRIPTION
Problem: In the pre_exec and post_fork hooks, the user has the potential
to destroy the subprocess, which can lead to potential segfaults later on.  We
should treat hooks as only having "read only" access to flux_subprocess_t
contents.

Solution: Do not allow the user to call flux_subprocess_ref() or
flux_subprocess_unref() while in hooks.

Fixes #2225