### PR TITLE
job-manager: handle scheduler disconnect

### DIFF
--- a/src/modules/job-manager/alloc.h
+++ b/src/modules/job-manager/alloc.h
@@ -52,6 +52,11 @@ struct job *alloc_queue_next (struct alloc *alloc);
  */
 void alloc_queue_reorder (struct alloc *alloc, struct job *job);
 
+void alloc_disconnect_rpc (flux_t *h,
+                           flux_msg_handler_t *mh,
+                           const flux_msg_t *msg,
+                           void *arg);
+
 #endif /* ! _FLUX_JOB_MANAGER_ALLOC_H */
 
 /*

--- a/src/modules/job-manager/job-manager.c
+++ b/src/modules/job-manager/job-manager.c
@@ -58,6 +58,9 @@ void disconnect_rpc (flux_t *h,
                      const flux_msg_t *msg,
                      void *arg)
 {
+    /* disconnects occur once per client, there is no way to know
+     * which services a client used, so we must check all services for
+     * cleanup */
     wait_disconnect_rpc (h, mh, msg, arg);
     journal_listeners_disconnect_rpc (h, mh, msg, arg);
 }

--- a/src/modules/job-manager/job-manager.c
+++ b/src/modules/job-manager/job-manager.c
@@ -61,6 +61,7 @@ void disconnect_rpc (flux_t *h,
     /* disconnects occur once per client, there is no way to know
      * which services a client used, so we must check all services for
      * cleanup */
+    alloc_disconnect_rpc (h, mh, msg, arg);
     wait_disconnect_rpc (h, mh, msg, arg);
     journal_listeners_disconnect_rpc (h, mh, msg, arg);
 }


### PR DESCRIPTION
If the scheduler disconnects, it is not handled by the disconnect
callback.  Teardown the scheduler if the scheduler has gone down.

Fixes #3030