### PR TITLE
testsuite: fix core idsets in resource module tests

### DIFF
--- a/t/t2310-resource-module.t
+++ b/t/t2310-resource-module.t
@@ -179,7 +179,7 @@ test_expect_success 'one rank was was drained' '
 # Since jq is used in the first bit, HAVE_JQ is required in other bits too
 test_expect_success HAVE_JQ 'change expected cores in resource.R' "
 	flux kvs get resource.R &&
-	jq '.execution.R_lite[0].children.core = \"0-48\"' R.orig >R.Mcore &&
+	jq '.execution.R_lite[0].children.core = \"0-1048\"' R.orig >R.Mcore &&
 	flux resource reload R.Mcore
 "
 test_expect_success HAVE_JQ 'reload resource module' '

--- a/t/t2315-resource-system.t
+++ b/t/t2315-resource-system.t
@@ -5,7 +5,7 @@ test_description='Test resource module with system instance config'
 . `dirname $0`/sharness.sh
 
 test_expect_success 'create test R with unlikely core count' '
-	flux R encode -r0-1 -c0-36 >R.test
+	flux R encode -r0-1 -c0-1048 >R.test
 '
 
 test_expect_success 'create config file pointing to test R' '


### PR DESCRIPTION
As described in #3312, fix the core idsets in a couple resource module tests.

This is required to run `make check` on systems with >37 cores. (e.g. ppc64le builder in buildfarm)