### PR TITLE
resource: support hostnames for drain and exclude

### DIFF
--- a/src/cmd/flux-resource.py
+++ b/src/cmd/flux-resource.py
@@ -35,20 +35,20 @@ def reload(args):
 
 def drain(args):
     """
-    Send a drain request to resource module for args.idset
+    Send a drain request to resource module for args.targets
     """
     RPC(
         flux.Flux(),
         "resource.drain",
-        {"idset": args.idset, "reason": " ".join(args.reason)},
+        {"targets": args.targets, "reason": " ".join(args.reason)},
     ).get()
 
 
 def undrain(args):
     """
-    Send an "undrain" request to resource module for args.idset
+    Send an "undrain" request to resource module for args.targets
     """
-    RPC(flux.Flux(), "resource.undrain", {"idset": args.idset}).get()
+    RPC(flux.Flux(), "resource.undrain", {"targets": args.targets}).get()
 
 
 def idset_strip(idset):
@@ -331,14 +331,18 @@ def main():
     drain_parser = subparsers.add_parser(
         "drain", formatter_class=flux.util.help_formatter()
     )
-    drain_parser.add_argument("idset", help="IDSET to drain")
+    drain_parser.add_argument(
+        "targets", help="List of targets to drain (IDSET or HOSTLIST)"
+    )
     drain_parser.add_argument("reason", help="Reason", nargs=argparse.REMAINDER)
     drain_parser.set_defaults(func=drain)
 
     undrain_parser = subparsers.add_parser(
         "undrain", formatter_class=flux.util.help_formatter()
     )
-    undrain_parser.add_argument("idset", help="IDSET to resume")
+    undrain_parser.add_argument(
+        "targets", help="List of targets to resume (IDSET or HOSTLIST)"
+    )
     undrain_parser.set_defaults(func=undrain)
 
     list_parser = subparsers.add_parser(

--- a/src/common/librlist/rlist.h
+++ b/src/common/librlist/rlist.h
@@ -143,6 +143,23 @@ struct hostlist * rlist_nodelist (const struct rlist *rl);
  */
 struct idset * rlist_ranks (const struct rlist *rl);
 
+
+/*  Return an idset of ranks corresponding to 'hosts' (a string encoded
+ *   in RFC29 hostlist format)
+ *
+ *  Multiple ranks may be returned per host in 'hosts' if ranks
+ *   share hostnames (e.g. multiple broker ranks per node)
+ *
+ *  Order of 'hosts' is ignored since the return type is an idset.
+ *
+ *  Returns success only if all hosts have one or more ranks in rlist.
+ *
+ *  Returns NULL on failure with error text in err if err is non-NULL.
+ */
+struct idset * rlist_hosts_to_ranks (const struct rlist *rl,
+                                     const char *hosts,
+                                     rlist_error_t *err);
+
 /*
  *  Serialize a resource list into v1 "R" format. This encodes only the
  *   "available" ids in each resource node into execution.R_lite

--- a/src/modules/resource/drain.c
+++ b/src/modules/resource/drain.c
@@ -116,7 +116,7 @@ static void drain_cb (flux_t *h,
     if (flux_request_unpack (msg,
                              NULL,
                              "{s:s s?:s}",
-                             "idset",
+                             "targets",
                              &s,
                              "reason",
                              &reason) < 0)
@@ -193,7 +193,7 @@ static void undrain_cb (flux_t *h,
     if (flux_request_unpack (msg,
                              NULL,
                              "{s:s}",
-                             "idset",
+                             "targets",
                              &s) < 0)
         goto error;
     if (!(idset = drain_idset_decode (drain, s, errbuf, sizeof (errbuf)))) {

--- a/src/modules/resource/inventory.h
+++ b/src/modules/resource/inventory.h
@@ -40,6 +40,18 @@ int inventory_put (struct inventory *inv, json_t *R, const char *method);
 
 int inventory_put_xml (struct inventory *inv, json_t *xml);
 
+/* Return a set of ranks for a string of "targets". The 'targets' argument
+ * may be an RFC22 encoded idset or RFC29 hostlist. If an idset, the
+ * decoded idset is returned, if a hostlist, then the set of ranks
+ * corresponding to the hostnames in 'targets' is returned.
+ *
+ * On error, a textual error string will be returned in errbuf
+ */
+struct idset *inventory_targets_to_ranks (struct inventory *inv,
+                                          const char *targets,
+                                          char *errbuf,
+                                          int errsize);
+
 #endif /* !_FLUX_RESOURCE_INVENTORY_H */
 
 

--- a/src/modules/resource/resource.c
+++ b/src/modules/resource/resource.c
@@ -34,8 +34,8 @@
 
 /* Parse [resource] table.
  *
- * exclude = "idset"
- *   Exclude specified broker rank(s) from scheduling
+ * exclude = "targets"
+ *   Exclude specified broker rank(s) or hosts from scheduling
  *
  * path = "/path"
  *   Set path to resource object

--- a/src/modules/resource/topo.c
+++ b/src/modules/resource/topo.c
@@ -71,7 +71,7 @@ static int drain_self (struct topo *topo, const char *reason)
                                  0,
                                  0,
                                  "{s:s s:s}",
-                                 "idset",
+                                 "targets",
                                  rankstr,
                                  "reason",
                                  reason)))

--- a/t/t2310-resource-module.t
+++ b/t/t2310-resource-module.t
@@ -27,13 +27,13 @@ load_resource () {
 }
 
 get_hwloc () {
-        flux python -c "import flux; print(flux.Flux().rpc(\"resource.get-xml\",nodeid=$1).get_str())"
+	flux python -c "import flux; print(flux.Flux().rpc(\"resource.get-xml\",nodeid=$1).get_str())"
 }
 get_topo() {
-        flux python -c "import flux; print(flux.Flux().rpc(\"resource.topo-get\",nodeid=$1).get_str())"
+	flux python -c "import flux; print(flux.Flux().rpc(\"resource.topo-get\",nodeid=$1).get_str())"
 }
 res_reload() {
-        flux python -c "import flux; print(flux.Flux().rpc(\"resource.reload\",nodeid=$1).get())"
+	flux python -c "import flux; print(flux.Flux().rpc(\"resource.reload\",nodeid=$1).get())"
 }
 
 test_expect_success 'load resource module with bad option fails' '

--- a/t/t2311-resource-drain.t
+++ b/t/t2311-resource-drain.t
@@ -10,10 +10,10 @@ test_under_flux $SIZE
 # Usage: waitup N
 #   where N is a count of online ranks
 waitup () {
-        run_timeout 5 flux python -c "import flux; print(flux.Flux().rpc(\"resource.monitor-waitup\",{\"up\":$1}).get())"
+	run_timeout 5 flux python -c "import flux; print(flux.Flux().rpc(\"resource.monitor-waitup\",{\"up\":$1}).get())"
 }
 waitdown () {
-        waitup $(($SIZE-$1))
+	waitup $(($SIZE-$1))
 }
 
 has_resource_event () {
@@ -77,18 +77,18 @@ test_expect_success 'resource.eventlog has one undrain event' '
 '
 
 test_expect_success 'undrain fails if rank not drained' '
-        test_must_fail flux resource undrain 1 2>undrain_not.err &&
-        grep "rank 1 not drained" undrain_not.err
+	test_must_fail flux resource undrain 1 2>undrain_not.err &&
+	grep "rank 1 not drained" undrain_not.err
 '
 
 test_expect_success 'drain fails if idset is empty' '
-        test_must_fail flux resource drain "" 2>drain_empty.err &&
-        grep "idset is empty" drain_empty.err
+	test_must_fail flux resource drain "" 2>drain_empty.err &&
+	grep "idset is empty" drain_empty.err
 '
 
 test_expect_success 'drain fails if idset is out of range' '
-        test_must_fail flux resource drain "0-$SIZE" 2>drain_range.err &&
-        grep "idset is out of range" drain_range.err
+	test_must_fail flux resource drain "0-$SIZE" 2>drain_range.err &&
+	grep "idset is out of range" drain_range.err
 '
 
 test_done

--- a/t/t2311-resource-drain.t
+++ b/t/t2311-resource-drain.t
@@ -91,4 +91,14 @@ test_expect_success 'drain fails if idset is out of range' '
 	grep "idset is out of range" drain_range.err
 '
 
+# Note: in test, drain `hostname` will drain all ranks since all ranks
+#  are running on the same host
+#
+test_expect_success 'un/drain works with hostnames' '
+	flux resource drain $(hostname) &&
+	test $(flux resource list -n -s down -o {nnodes}) -eq $SIZE &&
+	flux resource undrain $(hostname) &&
+	test $(flux resource list -n -s down -o {nnodes}) -eq 0
+'
+
 test_done

--- a/t/t2311-resource-drain.t
+++ b/t/t2311-resource-drain.t
@@ -81,11 +81,6 @@ test_expect_success 'undrain fails if rank not drained' '
         grep "rank 1 not drained" undrain_not.err
 '
 
-test_expect_success 'drain fails if idset is malformed' '
-        test_must_fail flux resource drain xxzz 2>drain_badset.err &&
-        grep "failed to decode idset" drain_badset.err
-'
-
 test_expect_success 'drain fails if idset is empty' '
         test_must_fail flux resource drain "" 2>drain_empty.err &&
         grep "idset is empty" drain_empty.err

--- a/t/t2312-resource-exclude.t
+++ b/t/t2312-resource-exclude.t
@@ -14,18 +14,18 @@ test_under_flux $SIZE
 # Usage: waitup N
 #   where N is a count of online ranks
 waitup () {
-        run_timeout 5 flux python -c "import flux; print(flux.Flux().rpc(\"resource.monitor-waitup\",{\"up\":$1}).get())"
+    run_timeout 5 flux python -c "import flux; print(flux.Flux().rpc(\"resource.monitor-waitup\",{\"up\":$1}).get())"
 }
 waitdown () {
-        waitup $(($SIZE-$1))
+    waitup $(($SIZE-$1))
 }
 
 has_resource_event () {
-        flux kvs eventlog get resource.eventlog | awk '{ print $2 }' | grep $1
+    flux kvs eventlog get resource.eventlog | awk '{ print $2 }' | grep $1
 }
 
 test_expect_success 'wait for monitor to declare all nodes are up' '
-        waitdown 0
+    waitdown 0
 '
 test_expect_success 'reconfigure with rank 0 exclusion' '
 	cat >resource.toml <<-EOT &&

--- a/t/t2312-resource-exclude.t
+++ b/t/t2312-resource-exclude.t
@@ -67,6 +67,16 @@ test_expect_success 'reconfig with out of range exclude idset fails' '
 	test_must_fail flux config reload
 '
 
+test_expect_success 'reconfig with hostnames in exclude set works' '
+	cat >resource.toml <<-EOT &&
+	[resource]
+	exclude = "$(hostname)"
+	EOT
+	flux config reload &&
+	test_debug "flux dmesg | grep resource" &&
+	test $(flux resource list -n -s down -o {nnodes}) -eq ${SIZE}
+'
+
 test_expect_success 'reconfig with no exclude idset' '
 	cat >resource.toml <<-EOT &&
 	[resource]

--- a/t/t2313-resource-acquire.t
+++ b/t/t2313-resource-acquire.t
@@ -24,14 +24,14 @@ acquire_stream() {
 # Usage: waitup N
 #   where N is a count of online ranks
 waitup () {
-        run_timeout 5 flux python -c "import flux; print(flux.Flux().rpc(\"resource.monitor-waitup\",{\"up\":$1}).get())"
+	run_timeout 5 flux python -c "import flux; print(flux.Flux().rpc(\"resource.monitor-waitup\",{\"up\":$1}).get())"
 }
 waitdown () {
-        waitup $(($SIZE-$1))
+	waitup $(($SIZE-$1))
 }
 
 test_expect_success 'wait for monitor to declare all ranks are up' '
-        waitdown 0
+	waitdown 0
 '
 
 test_expect_success HAVE_JQ 'unload scheduler' '


### PR DESCRIPTION
This PR adds simple support for specification of hostlists in addition to idsets in both `flux resource drain/undrain` and the `resource.exclude` configuration keyword. It is a WIP in case the approach here is not acceptable.

The approach here is to change the "idset" in the drain protocol and exclude value to a more generic "targets" list, which can be either an idset or a RFC29 hostlist. When a "targets" string is decoded to a set of ranks, the resource module will first attempt to use `idset_decode()`, and if that fails, it will try to decode "targets" as a hostlist and turn that into a set of ranks using a new function in librlist `rlist_hosts_to_ranks()`. The code proceeds as before once the "targets" are converted to a `struct idset`.

The same was done to the resource.exclude keyword since it was trivial, and resources can now be excluded in the config by hostname.

Note that when running `flux start -s N`, all ranks have the same hostname, and `flux resource drain HOST` drains all ranks with hostname HOST, so draining by idset is still quite useful.

The resource.eventlog drain and exclude events still use strictly idsets.

```
$ flux resource list -s up -no {nnodes}
4
$ flux resource drain asp
$ flux resource list -s up -no {nnodes}
0
```