### PR TITLE
job-info / flux-jobs: Support listing nodelist 

### DIFF
--- a/doc/man1/flux-jobs.rst
+++ b/doc/man1/flux-jobs.rst
@@ -84,12 +84,12 @@ following is the format used for the default format:
 
 ::
 
-   {id.f58:>12} {username:<8.8} {name:<10.10} {status_abbrev:>2.2} {ntasks:>6} {nnodes:>6h} {runtime!F:>8h} {ranks:h}
+   {id.f58:>12} {username:<8.8} {name:<10.10} {status_abbrev:>2.2} {ntasks:>6} {nnodes:>6h} {runtime!F:>8h} {nodelist:h}
 
 The special presentation type *h* can be used to convert an empty
 string, "0s", "0.0", or "0:00:00" to a hyphen. For example, normally
-"{ranks}" would output an empty string if the job has not yet run.
-By specifying, "{ranks:h}", a hyphen would be presented instead.
+"{nodelist}" would output an empty string if the job has not yet run.
+By specifying, "{nodelist:h}", a hyphen would be presented instead.
 
 Additionally, the custom job formatter supports a set of special
 conversion flags. Conversion flags follow the format field and are

--- a/doc/man1/flux-jobs.rst
+++ b/doc/man1/flux-jobs.rst
@@ -170,6 +170,9 @@ The field names that can be specified are:
 **ranks**
    job ranks (if job ran / is running), empty string otherwise
 
+**nodelist**
+   job nodelist (if job ran / is running), empty string otherwise
+
 **state**
    job state (DEPEND, SCHED, RUN, CLEANUP, INACTIVE)
 

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -434,6 +434,7 @@ resizing
 HOSTLIST
 hostlist
 hostlists
+nodelist
 hostnames
 unfulfills
 MSGFLAG

--- a/src/bindings/python/flux/job/info.py
+++ b/src/bindings/python/flux/job/info.py
@@ -107,6 +107,7 @@ class JobInfo:
         "expiration": 0.0,
         "nnodes": "",
         "ranks": "",
+        "nodelist": "",
         "success": "",
         "result": "",
     }
@@ -332,6 +333,7 @@ class JobInfoFormat(flux.util.OutputFormat):
         "expiration": "EXPIRATION",
         "t_remaining": "T_REMAINING",
         "ranks": "RANKS",
+        "nodelist": "NODELIST",
         "success": "SUCCESS",
         "result": "RESULT",
         "result_abbrev": "RS",

--- a/src/bindings/python/flux/job/list.py
+++ b/src/bindings/python/flux/job/list.py
@@ -31,6 +31,7 @@ VALID_ATTRS = [
     "ntasks",
     "nnodes",
     "ranks",
+    "nodelist",
     "success",
     "exception_occurred",
     "exception_type",

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -1030,9 +1030,9 @@ int cmd_cancelall (optparse_t *p, int argc, char **argv)
 
 static const char *list_attrs =
     "[\"userid\",\"priority\",\"t_submit\",\"state\","          \
-    "\"name\",\"ntasks\",\"nnodes\",\"ranks\",\"expiration\",\"success\"," \
-    "\"exception_occurred\",\"exception_severity\",\"exception_type\"," \
-    "\"exception_note\",\"result\","                                    \
+    "\"name\",\"ntasks\",\"nnodes\",\"ranks\",\"nodelist\",\"expiration\"," \
+    "\"success\",\"exception_occurred\",\"exception_severity\"," \
+    "\"exception_type\",\"exception_note\",\"result\","  \
     "\"t_depend\",\"t_sched\",\"t_run\",\"t_cleanup\",\"t_inactive\"," \
     "\"annotations\"]";
 

--- a/src/cmd/flux-jobs.py
+++ b/src/cmd/flux-jobs.py
@@ -62,6 +62,7 @@ def fetch_jobs_flux(args, fields):
         "ntasks": ("ntasks",),
         "nnodes": ("nnodes",),
         "ranks": ("ranks",),
+        "nodelist": ("nodelist",),
         "success": ("success",),
         "exception.occurred": ("exception_occurred",),
         "exception.severity": ("exception_severity",),

--- a/src/cmd/flux-jobs.py
+++ b/src/cmd/flux-jobs.py
@@ -285,7 +285,7 @@ def main():
         fmt = (
             "{id.f58:>12} {username:<8.8} {name:<10.10} {status_abbrev:>2.2} "
             "{ntasks:>6} {nnodes:>6h} {runtime!F:>8h} "
-            "{ranks:h}"
+            "{nodelist:h}"
         )
     try:
         formatter = JobInfoFormat(fmt)

--- a/src/common/librlist/rlist.c
+++ b/src/common/librlist/rlist.c
@@ -912,7 +912,6 @@ struct rlist *rlist_from_json (json_t *o, json_error_t *errp)
     return (rl);
 err:
     rlist_destroy (rl);
-    json_decref (o);
     return (NULL);
 }
 

--- a/src/modules/job-info/Makefile.am
+++ b/src/modules/job-info/Makefile.am
@@ -39,4 +39,6 @@ job_info_la_LIBADD = $(fluxmod_libadd) \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la \
 	$(top_builddir)/src/common/libflux-optparse.la \
-	$(ZMQ_LIBS)
+	$(top_builddir)/src/common/librlist/librlist.la \
+	$(ZMQ_LIBS) \
+	$(HWLOC_LIBS)

--- a/src/modules/job-info/job_state.c
+++ b/src/modules/job-info/job_state.c
@@ -21,6 +21,7 @@
 #include "src/common/libutil/fluid.h"
 #include "src/common/libutil/fsd.h"
 #include "src/common/libjob/job_hash.h"
+#include "src/common/librlist/rlist.h"
 #include "src/common/libidset/idset.h"
 
 #include "job_state.h"
@@ -598,73 +599,15 @@ static flux_future_t *state_depend_lookup (struct job_state_ctx *jsctx,
     return NULL;
 }
 
-static int idset_add_set (struct idset *set, struct idset *new)
-{
-    unsigned int i = idset_first (new);
-    while (i != IDSET_INVALID_ID) {
-        if (idset_test (set, i)) {
-            errno = EEXIST;
-            return -1;
-        }
-        if (idset_set (set, i) < 0)
-            return -1;
-        i = idset_next (new, i);
-    }
-    return 0;
-}
-
-static int idset_set_string (struct idset *idset, const char *ids)
-{
-    int rc;
-    struct idset *new = idset_decode (ids);
-    if (!new)
-        return -1;
-    rc = idset_add_set (idset, new);
-    idset_destroy (new);
-    return rc;
-}
-
-static int parse_rlite (struct info_ctx *ctx,
-                        struct job *job,
-                        const json_t *R_lite)
-{
-    struct idset *idset = NULL;
-    size_t index;
-    json_t *value;
-    int saved_errno, rc = -1;
-    int flags = IDSET_FLAG_BRACKETS | IDSET_FLAG_RANGE;
-
-    if (!(idset = idset_create (0, IDSET_FLAG_AUTOGROW)))
-        return -1;
-    json_array_foreach (R_lite, index, value) {
-        const char *ranks = NULL;
-        if ((json_unpack_ex (value, NULL, 0, "{s:s}", "rank", &ranks) < 0)
-            || (idset_set_string (idset, ranks) < 0))
-            goto nonfatal_err;
-    }
-
-    job->nnodes = idset_count (idset);
-    if (!(job->ranks = idset_encode (idset, flags)))
-        goto nonfatal_err;
-
-    /* nonfatal error - invalid rlite, but we'll continue on.  job
-     * listing will get initialized data */
-nonfatal_err:
-    rc = 0;
-    saved_errno = errno;
-    idset_destroy (idset);
-    errno = saved_errno;
-    return rc;
-}
-
 static int R_lookup_parse (struct info_ctx *ctx,
                            struct job *job,
                            const char *s)
 {
+    struct rlist *rl = NULL;
+    struct idset *idset = NULL;
     json_error_t error;
-    json_t *R_lite = NULL;
-    int version;
-    int rc = -1;
+    int flags = IDSET_FLAG_BRACKETS | IDSET_FLAG_RANGE;
+    int saved_errno, rc = -1;
 
     if (!(job->R = json_loads (s, 0, &error))) {
         flux_log (ctx->h, LOG_ERR,
@@ -673,35 +616,28 @@ static int R_lookup_parse (struct info_ctx *ctx,
         goto nonfatal_error;
     }
 
-    if (json_unpack_ex (job->R, &error, 0,
-                        "{s:i s:{s?F s:o}}",
-                        "version", &version,
-                        "execution",
-                        "expiration", &job->expiration,
-                        "R_lite", &R_lite) < 0) {
-        flux_log (ctx->h, LOG_ERR,
-                  "%s: job %ju invalid R: %s",
-                  __FUNCTION__, (uintmax_t)job->id, error.text);
+    if (!(rl = rlist_from_json (job->R, &error))) {
+        flux_log_error (ctx->h, "rlist_from_json: %s", error.text);
         goto nonfatal_error;
-    }
-    if (version != 1) {
-        flux_log (ctx->h, LOG_ERR,
-                  "%s: job %ju invalid R version: %d",
-                  __FUNCTION__, (uintmax_t)job->id, version);
-        goto nonfatal_error;
-    }
-    if (parse_rlite (ctx, job, R_lite) < 0) {
-        flux_log (ctx->h, LOG_ERR,
-                  "%s: job %ju parse_rlite: %s",
-                  __FUNCTION__, (uintmax_t)job->id, strerror (errno));
-        goto error;
     }
 
-    /* nonfatal error - invalid rlite, but we'll continue on.  job
-     * listing will get initialized data */
+    job->expiration = rl->expiration;
+
+    if (!(idset = rlist_ranks (rl)))
+        goto nonfatal_error;
+
+    job->nnodes = idset_count (idset);
+    if (!(job->ranks = idset_encode (idset, flags)))
+        goto nonfatal_error;
+
+    /* nonfatal error - invalid R, but we'll continue on.  job listing
+     * will get initialized data */
 nonfatal_error:
     rc = 0;
-error:
+    saved_errno = errno;
+    idset_destroy (idset);
+    rlist_destroy (rl);
+    errno = saved_errno;
     return rc;
 }
 

--- a/src/modules/job-info/job_state.h
+++ b/src/modules/job-info/job_state.h
@@ -74,6 +74,7 @@ struct job {
     int ntasks;
     int nnodes;
     char *ranks;
+    char *nodelist;
     double expiration;
     bool success;
     bool exception_occurred;

--- a/src/modules/job-info/job_util.c
+++ b/src/modules/job-info/job_util.c
@@ -126,6 +126,15 @@ json_t *job_to_json (struct job *job, json_t *attrs, job_info_error_t *errp)
             else
                 val = json_string ("");
         }
+        else if (!strcmp (attr, "nodelist")) {
+            if (!(job->states_mask & FLUX_JOB_RUN))
+                continue;
+            /* potentially NULL if R invalid */
+            if (job->nodelist)
+                val = json_string (job->nodelist);
+            else
+                val = json_string ("");
+        }
         else if (!strcmp (attr, "expiration")) {
             if (!(job->states_mask & FLUX_JOB_RUN))
                 continue;

--- a/src/modules/job-info/list.c
+++ b/src/modules/job-info/list.c
@@ -568,9 +568,10 @@ void list_attrs_cb (flux_t *h, flux_msg_handler_t *mh,
     const char *attrs[] = { "userid", "priority", "t_submit", "t_depend",
                             "t_sched", "t_run", "t_cleanup", "t_inactive",
                             "state", "name", "ntasks", "nnodes", "ranks",
-                            "success", "exception_occurred", "exception_type",
-                            "exception_severity", "exception_note", "result",
-                            "expiration", "annotations", NULL };
+                            "nodelist", "success", "exception_occurred",
+                            "exception_type", "exception_severity",
+                            "exception_note", "result", "expiration",
+                            "annotations", NULL };
     json_t *a = NULL;
     int i;
 

--- a/src/modules/sched-simple/Makefile.am
+++ b/src/modules/sched-simple/Makefile.am
@@ -37,4 +37,4 @@ sched_simple_la_LIBADD = \
 	$(top_builddir)/src/common/libflux-core.la \
 	$(top_builddir)/src/common/libflux-optparse.la \
 	$(ZMQ_LIBS) \
-    $(HWLOC_LIBS)
+	$(HWLOC_LIBS)


### PR DESCRIPTION
Per #3313 and #3323, convert `job-info` to use `librlist`, then add `nodelist` as a listable attribute in `job-info`.  Added fix for #3322 in here as well.

Most of the changes in this PR aren't earth shattering, pretty basic.  But two things to note for possible discussion:

- I changed the default output of `flux-jobs` to list `NODELIST` instead of `RANKS`, b/c I figure that's what most users probably want by default.  I doubt this change is controversial.  Unless someone thinks we should list both `RANKS` and `NODELIST`?

- I think the `NNODES` attribute is a bit ambiguous now w/ `NODELIST` output available.  We could have a situation where multiple brokers exist on a node, so the number of ranks might be > 1, but the number of nodes is a different number.  Here's a simple example:

```
>flux jobs -A
       JOBID USER     NAME       ST NTASKS NNODES  RUNTIME NODELIST
    ƒ9E6hswD achu     hostname   CD      4      2   0.099s catalyst[159,159]
    ƒ7fzjXZh achu     hostname   CD      4      4   0.136s catalyst[159,159,159,159]
```

I was about change `NNODES` to be `NRANKS`, then implement a new field `NNODES` that is the actual number of nodes the job ran on.  But I noticed that `nnodes` is used in `librlist` and it has meaning there as.

Perhaps `NNODES` is fine it doesn't have to be changed.  Maybe all that needs to be done is `NNODES` needs to be clarified in the documentation to be "resource nodes", not "physical nodes"?

Or perhaps `NNODES` needs to be changed globally?
