### PR TITLE
job-info, job-manager: rename priority event

### DIFF
--- a/src/bindings/python/flux/job/submit.py
+++ b/src/bindings/python/flux/job/submit.py
@@ -25,7 +25,7 @@ class SubmitFuture(Future):
 def submit_async(
     flux_handle,
     jobspec,
-    priority=lib.FLUX_JOB_PRIORITY_DEFAULT,
+    priority=lib.FLUX_JOB_ADMIN_PRIORITY_DEFAULT,
     waitable=False,
     debug=False,
     pre_signed=False,
@@ -92,7 +92,7 @@ def submit_get_id(future):
 def submit(
     flux_handle,
     jobspec,
-    priority=lib.FLUX_JOB_PRIORITY_DEFAULT,
+    priority=lib.FLUX_JOB_ADMIN_PRIORITY_DEFAULT,
     waitable=False,
     debug=False,
     pre_signed=False,

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -1256,7 +1256,7 @@ int cmd_submit (optparse_t *p, int argc, char **argv)
     assert (((char *)jobspec)[jobspecsz] == '\0');
     if (jobspecsz == 0)
         log_msg_exit ("required jobspec is empty");
-    priority = optparse_get_int (p, "priority", FLUX_JOB_PRIORITY_DEFAULT);
+    priority = optparse_get_int (p, "priority", FLUX_JOB_ADMIN_PRIORITY_DEFAULT);
 
 #if HAVE_FLUX_SECURITY
     if (sec) {

--- a/src/common/libjob/job.h
+++ b/src/common/libjob/job.h
@@ -25,10 +25,10 @@ enum job_submit_flags {
     FLUX_JOB_WAITABLE = 4,      // flux_job_wait() will be used on this job
 };
 
-enum job_priority {
-    FLUX_JOB_PRIORITY_MIN = 0,
-    FLUX_JOB_PRIORITY_DEFAULT = 16,
-    FLUX_JOB_PRIORITY_MAX = 31,
+enum job_admin_priority {
+    FLUX_JOB_ADMIN_PRIORITY_MIN = 0,
+    FLUX_JOB_ADMIN_PRIORITY_DEFAULT = 16,
+    FLUX_JOB_ADMIN_PRIORITY_MAX = 31,
 };
 
 enum {

--- a/src/modules/job-info/job_state.c
+++ b/src/modules/job-info/job_state.c
@@ -151,7 +151,7 @@ static void json_decref_wrapper (void **data)
  */
 static bool search_direction (struct job *job)
 {
-    if (job->priority > FLUX_JOB_PRIORITY_DEFAULT)
+    if (job->priority > FLUX_JOB_ADMIN_PRIORITY_DEFAULT)
         return true;
     else
         return false;
@@ -1287,8 +1287,8 @@ static int admin_priority_context_parse (flux_t *h,
 
     if (!context
         || json_unpack (context, "{ s:i }", "priority", &priority) < 0
-        || (priority < FLUX_JOB_PRIORITY_MIN
-            || priority > FLUX_JOB_PRIORITY_MAX)) {
+        || (priority < FLUX_JOB_ADMIN_PRIORITY_MIN
+            || priority > FLUX_JOB_ADMIN_PRIORITY_MAX)) {
         flux_log (h, LOG_ERR, "%s: priority context invalid: %ju",
                   __FUNCTION__, (uintmax_t)job->id);
         errno = EPROTO;

--- a/src/modules/job-info/job_state.c
+++ b/src/modules/job-info/job_state.c
@@ -42,9 +42,9 @@ static int submit_context_parse (flux_t *h,
 static int finish_context_parse (flux_t *h,
                                  struct job *job,
                                  json_t *context);
-static int priority_context_parse (flux_t *h,
-                                   struct job *job,
-                                   json_t *context);
+static int admin_priority_context_parse (flux_t *h,
+                                         struct job *job,
+                                         json_t *context);
 static int exception_context_parse (flux_t *h,
                                     struct job *job,
                                     json_t *context,
@@ -902,8 +902,8 @@ static struct job *eventlog_restart_parse (struct info_ctx *ctx,
         else if (!strcmp (name, "depend")) {
             update_job_state (ctx, job, FLUX_JOB_SCHED, timestamp);
         }
-        else if (!strcmp (name, "priority")) {
-            if (priority_context_parse (ctx->h, job, context) < 0)
+        else if (!strcmp (name, "admin-priority")) {
+            if (admin_priority_context_parse (ctx->h, job, context) < 0)
                 goto error;
         }
         else if (!strcmp (name, "exception")) {
@@ -1279,9 +1279,9 @@ static int journal_finish_event (struct job_state_ctx *jsctx,
                                  timestamp);
 }
 
-static int priority_context_parse (flux_t *h,
-                                   struct job *job,
-                                   json_t *context)
+static int admin_priority_context_parse (flux_t *h,
+                                         struct job *job,
+                                         json_t *context)
 {
     int priority;
 
@@ -1299,10 +1299,10 @@ static int priority_context_parse (flux_t *h,
     return 0;
 }
 
-static int journal_priority_event (struct job_state_ctx *jsctx,
-                                   flux_jobid_t id,
-                                   int eventlog_seq,
-                                   json_t *context)
+static int journal_admin_priority_event (struct job_state_ctx *jsctx,
+                                         flux_jobid_t id,
+                                         int eventlog_seq,
+                                         json_t *context)
 {
     struct job *job;
     int orig_priority;
@@ -1319,7 +1319,7 @@ static int journal_priority_event (struct job_state_ctx *jsctx,
 
     orig_priority = job->priority;
 
-    if (priority_context_parse (jsctx->h, job, context) < 0)
+    if (admin_priority_context_parse (jsctx->h, job, context) < 0)
         return -1;
 
     if (job->state & FLUX_JOB_PENDING
@@ -1492,11 +1492,11 @@ static int journal_process_event (struct job_state_ctx *jsctx, json_t *event)
                                  timestamp) < 0)
             return -1;
     }
-    else if (!strcmp (name, "priority")) {
-        if (journal_priority_event (jsctx,
-                                    id,
-                                    eventlog_seq,
-                                    context) < 0)
+    else if (!strcmp (name, "admin-priority")) {
+        if (journal_admin_priority_event (jsctx,
+                                          id,
+                                          eventlog_seq,
+                                          context) < 0)
             return -1;
     }
     else if (!strcmp (name, "exception")) {

--- a/src/modules/job-ingest/job-ingest.c
+++ b/src/modules/job-ingest/job-ingest.c
@@ -514,19 +514,19 @@ static void submit_cb (flux_t *h, flux_msg_handler_t *mh,
         goto error;
     /* Validate requested job priority.
      */
-    if (job->priority < FLUX_JOB_PRIORITY_MIN
-            || job->priority > FLUX_JOB_PRIORITY_MAX) {
+    if (job->priority < FLUX_JOB_ADMIN_PRIORITY_MIN
+            || job->priority > FLUX_JOB_ADMIN_PRIORITY_MAX) {
         snprintf (errbuf, sizeof (errbuf), "priority range is [%d:%d]",
-                  FLUX_JOB_PRIORITY_MIN, FLUX_JOB_PRIORITY_MAX);
+                  FLUX_JOB_ADMIN_PRIORITY_MIN, FLUX_JOB_ADMIN_PRIORITY_MAX);
         errmsg = errbuf;
         errno = EINVAL;
         goto error;
     }
     if (!(job->cred.rolemask & FLUX_ROLE_OWNER)
-           && job->priority > FLUX_JOB_PRIORITY_DEFAULT) {
+           && job->priority > FLUX_JOB_ADMIN_PRIORITY_DEFAULT) {
         snprintf (errbuf, sizeof (errbuf),
                   "only the instance owner can submit with priority >%d",
-                  FLUX_JOB_PRIORITY_DEFAULT);
+                  FLUX_JOB_ADMIN_PRIORITY_DEFAULT);
         errmsg = errbuf;
         errno = EINVAL;
         goto error;

--- a/src/modules/job-manager/alloc.c
+++ b/src/modules/job-manager/alloc.c
@@ -71,8 +71,7 @@ static void interface_teardown (struct alloc *alloc, char *s, int errnum)
              * so they will automatically send alloc again.
              */
             if (job->alloc_pending) {
-                bool fwd = job->priority > FLUX_JOB_PRIORITY_DEFAULT ? true
-                                                                     : false;
+                bool fwd = job->priority > FLUX_JOB_ADMIN_PRIORITY_DEFAULT;
                 bool cleared = false;
 
                 assert (job->handle == NULL);
@@ -530,7 +529,7 @@ int alloc_enqueue_alloc_request (struct alloc *alloc, struct job *job)
 {
     assert (job->state == FLUX_JOB_SCHED);
     if (!job->alloc_queued && !job->alloc_pending) {
-        bool fwd = job->priority > FLUX_JOB_PRIORITY_DEFAULT ? true : false;
+        bool fwd = job->priority > FLUX_JOB_ADMIN_PRIORITY_DEFAULT;
         assert (job->handle == NULL);
         if (!(job->handle = zlistx_insert (alloc->queue, job, fwd)))
             return -1;
@@ -573,7 +572,7 @@ struct job *alloc_queue_next (struct alloc *alloc)
 /* called from priority_handle_request() */
 void alloc_queue_reorder (struct alloc *alloc, struct job *job)
 {
-    bool fwd = job->priority > FLUX_JOB_PRIORITY_DEFAULT ? true : false;
+    bool fwd = job->priority > FLUX_JOB_ADMIN_PRIORITY_DEFAULT;
 
     zlistx_reorder (alloc->queue, job->handle, fwd);
 }

--- a/src/modules/job-manager/event.c
+++ b/src/modules/job-manager/event.c
@@ -378,8 +378,8 @@ static int event_submit_context_decode (json_t *context,
     return 0;
 }
 
-static int event_priority_context_decode (json_t *context,
-                                          int *priority)
+static int event_admin_priority_context_decode (json_t *context,
+                                                int *priority)
 {
     if (json_unpack (context, "{ s:i }", "priority", priority) < 0) {
         errno = EPROTO;
@@ -442,8 +442,8 @@ int event_job_update (struct job *job, json_t *event)
             goto inval;
         job->state = FLUX_JOB_SCHED;
     }
-    else if (!strcmp (name, "priority")) {
-        if (event_priority_context_decode (context, &job->priority) < 0)
+    else if (!strcmp (name, "admin-priority")) {
+        if (event_admin_priority_context_decode (context, &job->priority) < 0)
             goto error;
     }
     else if (!strcmp (name, "exception")) {

--- a/src/modules/job-manager/job.c
+++ b/src/modules/job-manager/job.c
@@ -49,7 +49,7 @@ struct job *job_create (void)
         return NULL;
     job->refcount = 1;
     job->userid = FLUX_USERID_UNKNOWN;
-    job->priority = FLUX_JOB_PRIORITY_DEFAULT;
+    job->priority = FLUX_JOB_ADMIN_PRIORITY_DEFAULT;
     job->state = FLUX_JOB_NEW;
     return job;
 }

--- a/src/modules/job-manager/priority.c
+++ b/src/modules/job-manager/priority.c
@@ -101,7 +101,7 @@ void priority_handle_request (flux_t *h,
      */
     orig_priority = job->priority;
     if (event_job_post_pack (ctx->event, job,
-                             "priority", 0,
+                             "admin-priority", 0,
                              "{ s:i s:i }",
                              "userid", cred.userid,
                              "priority", priority) < 0)

--- a/src/modules/job-manager/priority.c
+++ b/src/modules/job-manager/priority.c
@@ -57,7 +57,8 @@ void priority_handle_request (flux_t *h,
                                         "priority", &priority) < 0
                     || flux_msg_get_cred (msg, &cred) < 0)
         goto error;
-    if (priority < FLUX_JOB_PRIORITY_MIN || priority > FLUX_JOB_PRIORITY_MAX) {
+    if (priority < FLUX_JOB_ADMIN_PRIORITY_MIN
+        || priority > FLUX_JOB_ADMIN_PRIORITY_MAX) {
         errstr = "priority value is out of range";
         errno = EINVAL;
         goto error;
@@ -76,7 +77,8 @@ void priority_handle_request (flux_t *h,
     /* Security: guests can only reduce priority, or increase up to default.
      */
     if (!(cred.rolemask & FLUX_ROLE_OWNER)
-            && priority > MAXOF (FLUX_JOB_PRIORITY_DEFAULT, job->priority)) {
+            && priority > MAXOF (FLUX_JOB_ADMIN_PRIORITY_DEFAULT,
+                                 job->priority)) {
         errstr = "guests can only adjust priority <= default";
         errno = EPERM;
         goto error;

--- a/src/modules/job-manager/test/job.c
+++ b/src/modules/job-manager/test/job.c
@@ -27,7 +27,7 @@ void test_create (void)
     ok (job->refcount == 1,
         "job_create set refcount to 1");
     ok (job->id == 0
-        && job->priority == FLUX_JOB_PRIORITY_DEFAULT
+        && job->priority == FLUX_JOB_ADMIN_PRIORITY_DEFAULT
         && job->state == FLUX_JOB_NEW
         && job->userid == FLUX_USERID_UNKNOWN
         && job->t_submit == 0

--- a/src/modules/job-manager/test/job.c
+++ b/src/modules/job-manager/test/job.c
@@ -63,7 +63,7 @@ const char *test_input[] = {
     /* 1 */
     "{\"timestamp\":42.2,\"name\":\"submit\","
      "\"context\":{\"userid\":66,\"priority\":16,\"flags\":42}}\n"
-    "{\"timestamp\":42.3,\"name\":\"priority\","
+    "{\"timestamp\":42.3,\"name\":\"admin-priority\","
      "\"context\":{\"userid\":42,\"priority\":1}}\n",
 
     /* 2 */

--- a/src/modules/sched-simple/sched.c
+++ b/src/modules/sched-simple/sched.c
@@ -276,6 +276,7 @@ static void alloc_cb (flux_t *h, const flux_msg_t *msg,
 {
     struct simple_sched *ss = arg;
     struct jobreq *job;
+    bool search_dir;
 
     if (ss->single && zlistx_size (ss->queue) > 0) {
         flux_log (h, LOG_ERR, "alloc received before previous one handled");
@@ -298,9 +299,10 @@ static void alloc_cb (flux_t *h, const flux_msg_t *msg,
                             (uintmax_t) job->id, job->jj.nnodes,
                             job->jj.nslots, job->jj.slot_size,
                             job->jj.duration);
+    search_dir = job->priority > FLUX_JOB_ADMIN_PRIORITY_DEFAULT;
     job->handle = zlistx_insert (ss->queue,
                                  job,
-                                 job->priority > FLUX_JOB_PRIORITY_DEFAULT);
+                                 search_dir);
     flux_watcher_start (ss->prep);
     return;
 err:

--- a/t/ingest/submitbench.c
+++ b/t/ingest/submitbench.c
@@ -249,7 +249,7 @@ int cmd_submitbench (optparse_t *p, int argc, char **argv)
     ctx.max_queue_depth = optparse_get_int (p, "fanout", 256);
     ctx.totcount = optparse_get_int (p, "repeat", 1);
     ctx.jobspecsz = read_jobspec (argv[optindex++], &ctx.jobspec);
-    ctx.priority = optparse_get_int (p, "priority", FLUX_JOB_PRIORITY_DEFAULT);
+    ctx.priority = optparse_get_int (p, "priority", FLUX_JOB_ADMIN_PRIORITY_DEFAULT);
 
     const char *tmp;
     if (!(tmp = flux_attr_get (ctx.h, "security.owner")))

--- a/t/t2202-job-manager.t
+++ b/t/t2202-job-manager.t
@@ -156,9 +156,9 @@ test_expect_success 'job-manager: flux job priority sets last job priority=31' '
 
 test_expect_success 'job-manager: priority was updated in KVS' '
 	jobid=$(tail -1 <list10_ids.out) &&
-        flux job wait-event --timeout=5.0 ${jobid} priority &&
+        flux job wait-event --timeout=5.0 ${jobid} admin-priority &&
 	flux job eventlog $jobid \
-		| cut -d" " -f2- | grep ^priority >pri.out &&
+		| cut -d" " -f2- | grep ^admin-priority >pri.out &&
 	grep -q priority=31 pri.out
 '
 


### PR DESCRIPTION
Per RFC21 changes, the priority event has been renamed admin-priority.
Update in job-info, job-manager, and tests appropriately.  Update
several function names for consistency.

Fixes #3328