### PR TITLE
python: add bindings for libflux-idset,hostlist

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
   check-asan:
     name: address-sanitizer check
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    timeout-minutes: 50
     steps:
     - uses: actions/checkout@v2
       with:

--- a/mypy.ini
+++ b/mypy.ini
@@ -9,6 +9,12 @@ ignore_missing_imports = True
 [mypy-_flux._security]
 ignore_missing_imports = True
 
+[mypy-_flux._hostlist]
+ignore_missing_imports = True
+
+[mypy-_flux._idset]
+ignore_missing_imports = True
+
 [mypy-cffi]
 ignore_missing_imports = True
 

--- a/src/bindings/python/_flux/Makefile.am
+++ b/src/bindings/python/_flux/Makefile.am
@@ -30,23 +30,28 @@ BUILT_SOURCES = \
 	_core.c \
 	_core_preproc.h \
 	_hostlist.c \
-	_hostlist_preproc.h
+	_hostlist_preproc.h \
+	_idset.c \
+	_idset_preproc.h
 
 fluxpyso_LTLIBRARIES = \
 	_core.la \
-	_hostlist.la
+	_hostlist.la \
+	_idset.la
 
 fluxpyso_PYTHON = \
 	__init__.py
 
 nodist_fluxbindinginclude_HEADERS = \
 	_core_preproc.h \
-	_hostlist_preproc.h
+	_hostlist_preproc.h \
+	_idset_preproc.h
 
 EXTRA_DIST = \
 	_core_build.py \
 	_security_build.py \
 	_hostlist_build.py \
+	_idset_build.py \
 	make_clean_header.py
 
 _core.c: $(srcdir)/_core_build.py _core_preproc.h
@@ -78,12 +83,29 @@ _hostlist_preproc.h: _hostlist_clean.h
 	$(CC) $(PREPROC_FLAGS) $< \
 	  | sed -e '/^# [0-9]*.*/d' > $@
 
+_idset.c: $(srcdir)/_idset_build.py _idset_preproc.h
+	$(PYTHON) $^
+
+_idset_clean.h: Makefile
+	$(PYTHON) $(srcdir)/make_clean_header.py \
+	  --path $(top_srcdir)/src/common/libidset \
+	  --output $@ \
+	  idset.h
+
+_idset_preproc.h: _idset_clean.h
+	$(CC) $(PREPROC_FLAGS) $< \
+	  | sed -e '/^# [0-9]*.*/d' > $@
+
+
 dist__core_la_SOURCES = callbacks.h
 nodist__core_la_SOURCES = _core.c
 _core_la_LIBADD = $(common_libs)
 
 nodist__hostlist_la_SOURCES = _hostlist.c
 _hostlist_la_LIBADD = $(common_libs)
+
+nodist__idset_la_SOURCES = _idset.c
+_idset_la_LIBADD = $(common_libs)
 
 if HAVE_FLUX_SECURITY
 

--- a/src/bindings/python/_flux/Makefile.am
+++ b/src/bindings/python/_flux/Makefile.am
@@ -1,23 +1,48 @@
 AM_CPPFLAGS = \
-	$(WARNING_CFLAGS) -Wno-missing-field-initializers \
+	$(WARNING_CFLAGS) \
+	-Wno-missing-field-initializers \
 	-I$(top_srcdir) -I$(top_srcdir)/src/include \
 	-I$(top_srcdir)/src/common/libflux \
 	-I$(top_builddir)/src/common/libflux \
-	$(ZMQ_CFLAGS) $(LIBUUID_CFLAGS) $(PYTHON_CPPFLAGS) \
+	$(ZMQ_CFLAGS) \
+	$(LIBUUID_CFLAGS) \
+	$(PYTHON_CPPFLAGS) \
 	$(CODE_COVERAGE_CFLAGS)
 
 AM_LDFLAGS = \
-	-avoid-version -module $(san_ld_zdef_flag) \
+	-avoid-version \
+	-module \
+	$(san_ld_zdef_flag) \
 	-Wl,-rpath,$(PYTHON_PREFIX)/lib \
 	$(CODE_COVERAGE_LIBS)
 
-common_libs = $(top_builddir)/src/common/libflux-core.la \
-	      $(top_builddir)/src/common/libflux-internal.la \
-	      $(top_builddir)/src/common/libdebugged/libdebugged.la \
-	      $(ZMQ_LIBS) $(LIBUUID_LIBS) \
-	      $(PYTHON_LDFLAGS)
+common_libs = \
+	$(top_builddir)/src/common/libflux-core.la \
+	$(top_builddir)/src/common/libflux-internal.la \
+	$(top_builddir)/src/common/libdebugged/libdebugged.la \
+	$(ZMQ_LIBS) $(LIBUUID_LIBS) \
+	$(PYTHON_LDFLAGS)
 
-PREPROC_FLAGS=-E  '-D__attribute__(...)='
+PREPROC_FLAGS = \
+	-E '-D__attribute__(...)='
+
+BUILT_SOURCES = \
+	_core.c \
+	_core_preproc.h
+
+fluxpyso_LTLIBRARIES = \
+	_core.la
+fluxpyso_PYTHON = \
+	__init__.py
+
+nodist_fluxbindinginclude_HEADERS = \
+	_core_preproc.h
+
+EXTRA_DIST = \
+	_core_build.py \
+	_security_build.py \
+	make_clean_header.py
+
 _core.c: $(srcdir)/_core_build.py _core_preproc.h
 	$(PYTHON) $^
 
@@ -34,21 +59,25 @@ _core_preproc.h: _core_clean.h
 	$(CC) $(PREPROC_FLAGS) _core_clean.h\
 	  | sed -e '/^# [0-9]*.*/d' > $@
 
-BUILT_SOURCES= _core.c _core_preproc.h
-fluxpyso_LTLIBRARIES = _core.la
-fluxpyso_PYTHON = __init__.py
-
-nodist_fluxbindinginclude_HEADERS = _core_preproc.h
-
 dist__core_la_SOURCES = callbacks.h
 nodist__core_la_SOURCES = _core.c
 _core_la_LIBADD = $(common_libs)
 
-EXTRA_DIST=_core_build.py make_clean_header.py
-
 if HAVE_FLUX_SECURITY
-BUILT_SOURCES += _security.c _security_preproc.h
-fluxpyso_LTLIBRARIES += _security.la
+
+BUILT_SOURCES += \
+	_security.c\
+	_security_preproc.h
+
+fluxpyso_LTLIBRARIES += \
+	_security.la
+
+nodist_fluxbindinginclude_HEADERS +=\
+	_security_preproc.h
+
+nodist__security_la_SOURCES = \
+	_security.c
+
 _security.c: $(srcdir)/_security_build.py _security_preproc.h
 	$(PYTHON) $^
 _security_clean.h: Makefile
@@ -60,11 +89,12 @@ _security_preproc.h: _security_clean.h
 	$(CC) $(PREPROC_FLAGS) _security_clean.h \
 	  | sed -e '/^# [0-9]*.*/d' > $@
 
-EXTRA_DIST+=_security_build.py
-nodist_fluxbindinginclude_HEADERS += _security_preproc.h
-nodist__security_la_SOURCES = _security.c
-_security_la_CPPFLAGS = $(AM_CPPFLAGS) $(FLUX_SECURITY_CFLAGS)
-_security_la_LIBADD = $(common_libs) $(FLUX_SECURITY_LIBS)
+_security_la_CPPFLAGS = \
+	$(AM_CPPFLAGS) \
+	$(FLUX_SECURITY_CFLAGS)
+_security_la_LIBADD = \
+	$(common_libs) \
+	$(FLUX_SECURITY_LIBS)
 endif
 
 .PHONY: lib-copy

--- a/src/bindings/python/_flux/Makefile.am
+++ b/src/bindings/python/_flux/Makefile.am
@@ -26,14 +26,6 @@ common_libs = \
 PREPROC_FLAGS = \
 	-E '-D__attribute__(...)='
 
-BUILT_SOURCES = \
-	_core.c \
-	_core_preproc.h \
-	_hostlist.c \
-	_hostlist_preproc.h \
-	_idset.c \
-	_idset_preproc.h
-
 fluxpyso_LTLIBRARIES = \
 	_core.la \
 	_hostlist.la \
@@ -54,11 +46,15 @@ EXTRA_DIST = \
 	_idset_build.py \
 	make_clean_header.py
 
+STDERR_DEVNULL = $(stderr_devnull_$(V))
+stderr_devnull_ =  $(stderr_devnull_$(AM_DEFAULT_VERBOSITY))
+stderr_devnull_0 = >/dev/null 2>&1
+
 _core.c: $(srcdir)/_core_build.py _core_preproc.h
-	$(PYTHON) $^
+	$(AM_V_GEN)$(PYTHON) $< $(STDERR_DEVNULL)
 
 _core_clean.h: Makefile
-	$(PYTHON) $(srcdir)/make_clean_header.py \
+	$(AM_V_GEN)$(PYTHON) $(srcdir)/make_clean_header.py \
 	  --path $(top_srcdir) \
 	  --search $(top_builddir)/src/common/libflux \
 	  --additional_headers \
@@ -66,34 +62,35 @@ _core_clean.h: Makefile
 	      src/common/libdebugged/debugged.h \
 	  --output _core_clean.h \
 	  src/include/flux/core.h
+
 _core_preproc.h: _core_clean.h
-	$(CC) $(PREPROC_FLAGS) _core_clean.h\
+	$(AM_V_GEN)$(CC) $(PREPROC_FLAGS) _core_clean.h \
 	  | sed -e '/^# [0-9]*.*/d' > $@
 
 _hostlist.c: $(srcdir)/_hostlist_build.py _hostlist_preproc.h
-	$(PYTHON) $^
+	$(AM_V_GEN)$(PYTHON) $^ $(STDERR_DEVNULL)
 
 _hostlist_clean.h: Makefile
-	$(PYTHON) $(srcdir)/make_clean_header.py \
+	$(AM_V_GEN)$(PYTHON) $(srcdir)/make_clean_header.py \
 	  --path $(top_srcdir)/src/common/libhostlist \
 	  --output $@ \
 	  hostlist.h
 
 _hostlist_preproc.h: _hostlist_clean.h
-	$(CC) $(PREPROC_FLAGS) $< \
+	$(AM_V_GEN)$(CC) $(PREPROC_FLAGS) $< \
 	  | sed -e '/^# [0-9]*.*/d' > $@
 
 _idset.c: $(srcdir)/_idset_build.py _idset_preproc.h
-	$(PYTHON) $^
+	$(AM_V_GEN)$(PYTHON) $^ $(STDERR_DEVNULL)
 
 _idset_clean.h: Makefile
-	$(PYTHON) $(srcdir)/make_clean_header.py \
+	$(AM_V_GEN)$(PYTHON) $(srcdir)/make_clean_header.py \
 	  --path $(top_srcdir)/src/common/libidset \
 	  --output $@ \
 	  idset.h
 
 _idset_preproc.h: _idset_clean.h
-	$(CC) $(PREPROC_FLAGS) $< \
+	$(AM_V_GEN)$(CC) $(PREPROC_FLAGS) $< \
 	  | sed -e '/^# [0-9]*.*/d' > $@
 
 
@@ -109,10 +106,6 @@ _idset_la_LIBADD = $(common_libs)
 
 if HAVE_FLUX_SECURITY
 
-BUILT_SOURCES += \
-	_security.c\
-	_security_preproc.h
-
 fluxpyso_LTLIBRARIES += \
 	_security.la
 
@@ -123,14 +116,14 @@ nodist__security_la_SOURCES = \
 	_security.c
 
 _security.c: $(srcdir)/_security_build.py _security_preproc.h
-	$(PYTHON) $^
+	$(AM_V_GEN)$(PYTHON) $^ $(STDERR_DEVNULL)
 _security_clean.h: Makefile
-	$(PYTHON) $(srcdir)/make_clean_header.py \
+	$(AM_V_GEN)$(PYTHON) $(srcdir)/make_clean_header.py \
 	  --path $(FLUX_SECURITY_INCDIR)/flux/security \
 	  --output _security_clean.h \
-	  sign.h
+	  sign.h $(STDERR_DEVNULL)
 _security_preproc.h: _security_clean.h
-	$(CC) $(PREPROC_FLAGS) _security_clean.h \
+	$(AM_V_GEN)$(CC) $(PREPROC_FLAGS) _security_clean.h \
 	  | sed -e '/^# [0-9]*.*/d' > $@
 
 _security_la_CPPFLAGS = \
@@ -143,12 +136,16 @@ endif
 
 .PHONY: lib-copy
 
+cp_verbose = $(cp_verbose_$(V))
+cp_verbose_ = $(cp_verbose_$(AM_DEFAULT_VERBOSITY))
+cp_verbose_0 = @echo "  COPY     python DSOs" ;
+
+# Copy libraries to where they can be used by python in-tree
 lib-copy-vpath: ${fluxpyso_PYTHON} ${fluxpyso_LTLIBRARIES}
-	-echo Copying libraries to where they can be used by python in-tree
-	[ "$(top_srcdir)" != "$(top_builddir)" ] && cp $(top_srcdir)/src/bindings/python/_flux/__init__.py ./; \
+	$(cp_verbose)[ "$(top_srcdir)" != "$(top_builddir)" ] && cp $(top_srcdir)/src/bindings/python/_flux/__init__.py ./; \
 	for LIB in ${fluxpyso_LTLIBRARIES:la=so} ; do \
 		test -e .libs/$$LIB && \
-		$(LN_S) .libs/$$LIB ./ || true; \
+		$(LN_S) .libs/$$LIB ./ $(STDERR_DEVNULL) || true; \
 	done
 
 all-local: lib-copy-vpath

--- a/src/bindings/python/_flux/Makefile.am
+++ b/src/bindings/python/_flux/Makefile.am
@@ -28,19 +28,25 @@ PREPROC_FLAGS = \
 
 BUILT_SOURCES = \
 	_core.c \
-	_core_preproc.h
+	_core_preproc.h \
+	_hostlist.c \
+	_hostlist_preproc.h
 
 fluxpyso_LTLIBRARIES = \
-	_core.la
+	_core.la \
+	_hostlist.la
+
 fluxpyso_PYTHON = \
 	__init__.py
 
 nodist_fluxbindinginclude_HEADERS = \
-	_core_preproc.h
+	_core_preproc.h \
+	_hostlist_preproc.h
 
 EXTRA_DIST = \
 	_core_build.py \
 	_security_build.py \
+	_hostlist_build.py \
 	make_clean_header.py
 
 _core.c: $(srcdir)/_core_build.py _core_preproc.h
@@ -59,9 +65,25 @@ _core_preproc.h: _core_clean.h
 	$(CC) $(PREPROC_FLAGS) _core_clean.h\
 	  | sed -e '/^# [0-9]*.*/d' > $@
 
+_hostlist.c: $(srcdir)/_hostlist_build.py _hostlist_preproc.h
+	$(PYTHON) $^
+
+_hostlist_clean.h: Makefile
+	$(PYTHON) $(srcdir)/make_clean_header.py \
+	  --path $(top_srcdir)/src/common/libhostlist \
+	  --output $@ \
+	  hostlist.h
+
+_hostlist_preproc.h: _hostlist_clean.h
+	$(CC) $(PREPROC_FLAGS) $< \
+	  | sed -e '/^# [0-9]*.*/d' > $@
+
 dist__core_la_SOURCES = callbacks.h
 nodist__core_la_SOURCES = _core.c
 _core_la_LIBADD = $(common_libs)
+
+nodist__hostlist_la_SOURCES = _hostlist.c
+_hostlist_la_LIBADD = $(common_libs)
 
 if HAVE_FLUX_SECURITY
 

--- a/src/bindings/python/_flux/_core_build.py
+++ b/src/bindings/python/_flux/_core_build.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from cffi import FFI
 
 ffi = FFI()
@@ -36,3 +37,5 @@ with open("_core_preproc.h") as h:
 ffi.cdef(cdefs)
 if __name__ == "__main__":
     ffi.emit_c_code("_core.c")
+    # ensure mtime of target is updated
+    Path("_core.c").touch()

--- a/src/bindings/python/_flux/_hostlist_build.py
+++ b/src/bindings/python/_flux/_hostlist_build.py
@@ -1,4 +1,5 @@
 from cffi import FFI
+from pathlib import Path
 
 ffi = FFI()
 
@@ -25,3 +26,5 @@ with open("_hostlist_preproc.h") as h:
 ffi.cdef(cdefs)
 if __name__ == "__main__":
     ffi.emit_c_code("_hostlist.c")
+    # Ensure target mtime is updated, emit_c_code() may not do it
+    Path("_hostlist.c").touch()

--- a/src/bindings/python/_flux/_hostlist_build.py
+++ b/src/bindings/python/_flux/_hostlist_build.py
@@ -1,0 +1,27 @@
+from cffi import FFI
+
+ffi = FFI()
+
+ffi.set_source(
+    "_flux._hostlist",
+    """
+#include <flux/hostlist.h>
+
+
+// TODO: remove this when we can use cffi 1.10
+#ifdef __GNUC__
+#pragma GCC visibility push(default)
+#endif
+            """,
+)
+
+cdefs = """
+    void free (void *);
+"""
+
+with open("_hostlist_preproc.h") as h:
+    cdefs = cdefs + h.read()
+
+ffi.cdef(cdefs)
+if __name__ == "__main__":
+    ffi.emit_c_code("_hostlist.c")

--- a/src/bindings/python/_flux/_idset_build.py
+++ b/src/bindings/python/_flux/_idset_build.py
@@ -1,0 +1,28 @@
+from cffi import FFI
+
+ffi = FFI()
+
+ffi.set_source(
+    "_flux._idset",
+    """
+#include <flux/idset.h>
+
+
+// TODO: remove this when we can use cffi 1.10
+#ifdef __GNUC__
+#pragma GCC visibility push(default)
+#endif
+            """,
+)
+
+cdefs = """
+static const unsigned int IDSET_INVALID_ID;
+void free (void *);
+"""
+
+with open("_idset_preproc.h") as h:
+    cdefs = cdefs + h.read()
+
+ffi.cdef(cdefs)
+if __name__ == "__main__":
+    ffi.emit_c_code("_idset.c")

--- a/src/bindings/python/_flux/_idset_build.py
+++ b/src/bindings/python/_flux/_idset_build.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from cffi import FFI
 
 ffi = FFI()
@@ -26,3 +27,5 @@ with open("_idset_preproc.h") as h:
 ffi.cdef(cdefs)
 if __name__ == "__main__":
     ffi.emit_c_code("_idset.c")
+    # Ensure target mtime is updated
+    Path("_idset.c").touch()

--- a/src/bindings/python/_flux/_security_build.py
+++ b/src/bindings/python/_flux/_security_build.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from cffi import FFI
 
 ffi = FFI()
@@ -30,3 +31,5 @@ with open("_security_preproc.h") as h:
 ffi.cdef(cdefs)
 if __name__ == "__main__":
     ffi.emit_c_code("_security.c")
+    # ensure target mtime is updated
+    Path("_security.c").touch()

--- a/src/bindings/python/flux/Makefile.am
+++ b/src/bindings/python/flux/Makefile.am
@@ -24,7 +24,8 @@ nobase_fluxpy_PYTHON = \
 	job/info.py \
 	job/submit.py \
 	job/wait.py \
-	job/_wrapper.py
+	job/_wrapper.py \
+	hostlist.py
 
 if HAVE_FLUX_SECURITY
 nobase_fluxpy_PYTHON += security.py

--- a/src/bindings/python/flux/Makefile.am
+++ b/src/bindings/python/flux/Makefile.am
@@ -25,7 +25,8 @@ nobase_fluxpy_PYTHON = \
 	job/submit.py \
 	job/wait.py \
 	job/_wrapper.py \
-	hostlist.py
+	hostlist.py \
+	idset.py
 
 if HAVE_FLUX_SECURITY
 nobase_fluxpy_PYTHON += security.py

--- a/src/bindings/python/flux/hostlist.py
+++ b/src/bindings/python/flux/hostlist.py
@@ -1,0 +1,208 @@
+###############################################################
+# Copyright 2020 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+import numbers
+import collections
+from _flux._hostlist import ffi, lib
+from flux.wrapper import Wrapper, WrapperPimpl
+
+
+class HostlistIterator:
+    def __init__(self, hostlist):
+        self._hostlist = hostlist
+        self._index = 0
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self._index < len(self._hostlist):
+            result = self._hostlist[self._index]
+            self._index += 1
+            return result
+        raise StopIteration
+
+
+class Hostlist(WrapperPimpl):
+    """A Flux hostlist object
+
+    The Hostlist class wraps libflux-hostlist to implement a list
+    of hosts which can be converted to and from the RFC 29 hostlist
+    encoding.
+    """
+
+    class InnerWrapper(Wrapper):
+        def __init__(
+            self,
+            handle=None,
+        ):
+            super().__init__(
+                ffi,
+                lib,
+                handle=handle,
+                match=ffi.typeof("struct hostlist *"),
+                prefixes=["hostlist_"],
+                destructor=lib.hostlist_destroy,
+            )
+
+    def __init__(self, arg="", handle=None):
+        """
+        Create a new Hostlist object from RFC 29 Hostlist string or an
+        Iterable containing a set of RFC 29 Hostlist strings:
+
+        :param arg: A string or Iterable containing one or more hosts
+                    encoded in RFC 29 hostlist format
+
+        E.g.
+
+        >>> hl = Hostlist()
+        >>> hl = Hostlist("host")
+        >>> hl = Hostlist("host[0-10]")
+        >>> hl = Hostlist([ "foo1", "foo2" ])
+
+        """
+        #  If no `struct hostlist *` handle passed in, then create
+        #   a new handle from string argument
+        if handle is None:
+            if isinstance(arg, str):
+                handle = lib.hostlist_decode(arg.encode("utf-8"))
+                if handle == ffi.NULL:
+                    raise ValueError(f"Invalid hostlist: '{arg}'")
+            elif isinstance(arg, collections.Iterable):
+                handle = lib.hostlist_create()
+                for hosts in arg:
+                    if not isinstance(hosts, str):
+                        typestr = type(hosts)
+                        raise TypeError(
+                            f"Hostlist(): expected string or Iterable, got {typestr}"
+                        )
+                    result = lib.hostlist_append(handle, hosts.encode("utf-8"))
+                    if result < 0:
+                        raise ValueError(f"Invalid hostlist: '{hosts}'")
+            else:
+                typestr = type(arg)
+                raise TypeError(
+                    f"Hostlist(): expected string or Iterable, got {typestr}"
+                )
+        super().__init__()
+        self.pimpl = self.InnerWrapper(handle)
+
+    def __str__(self):
+        return self.encode()
+
+    def __repr__(self):
+        return f"Hostlist('{self}')"
+
+    def __len__(self):
+        return self.pimpl.count()
+
+    def __getitem__(self, index):
+        """Index and slice a hostlist
+
+        Works like normal Python list indexing, including slices:
+
+        >>> hl = Hostlist("foo[0-9]")
+        >>> hl[0]
+        'foo0'
+        >>> hl[9]
+        'foo9'
+        >>> hl[-1]
+        'foo9'
+        >>> hl[8:]
+        ['foo8', 'foo9']
+        >>> hl[1:3]
+        ['foo1', 'foo2']
+
+        """
+        if isinstance(index, numbers.Integral):
+            if index < 0:
+                index = len(self) + index
+            if 0 <= index < len(self):
+                # N.B. wrapper class already calls ffi.string() on result:
+                return self.pimpl.nth(index).decode("utf-8")
+            raise IndexError("Hostlist index out of range")
+
+        if isinstance(index, slice):
+            return [self[n] for n in range(len(self))[index]]
+
+        raise TypeError("Hostlist index must be integer or slice")
+
+    def __iter__(self):
+        """Return a Hostlist iterator"""
+        return HostlistIterator(self)
+
+    def __contains__(self, name):
+        """Test if a hostname is in a Hostlist"""
+        try:
+            self.pimpl.find(name)
+        except FileNotFoundError:
+            return False
+        return True
+
+    def encode(self):
+        """Encode a Hostlist to an RFC 29 hostlist string"""
+        #
+        #  N.B. Do not use automatic wrapper call here to avoid leaking
+        #   `char *` result. Instead explicitly call free() after copying
+        #   the returned string to Python
+        #
+        val = lib.hostlist_encode(self.handle)
+        result = ffi.string(val)
+        lib.free(val)
+        return result.decode("utf-8")
+
+    def count(self):
+        """Return the number of hosts in Hostlist"""
+        return self.pimpl.count()
+
+    def append(self, *args):
+        """Append one or more arguments to a Hostlist
+
+        Args may be either a Hostlist or any valid argument to Hostlist()
+        """
+        count = 0
+        for arg in args:
+            if not isinstance(arg, Hostlist):
+                arg = Hostlist(arg)
+            count += self.pimpl.append_list(arg)
+        return count
+
+    def delete(self, hosts):
+        """Delete host or hosts from Hostlist
+
+        param: hosts: A Hostlist or string in RFC 29 hostlist encoding
+        """
+        return self.pimpl.delete(str(hosts))
+
+    def sort(self):
+        """Sort a Hostlist"""
+        self.pimpl.sort()
+        return self
+
+    def uniq(self):
+        """Sort and remove duplicate hostnames from Hostlist"""
+        self.pimpl.uniq()
+        return self
+
+    def expand(self):
+        """Convert a Hostlist to a Python list"""
+        return self[:]
+
+    def copy(self):
+        """Copy a Hostlist object"""
+        return Hostlist(handle=self.pimpl.copy())
+
+
+def decode(arg):
+    """
+    Decode a string or iterable of strings in RFC 29 hostlist format
+    to a Hostlist object
+    """
+    return Hostlist(arg)

--- a/src/bindings/python/flux/idset.py
+++ b/src/bindings/python/flux/idset.py
@@ -1,0 +1,279 @@
+###############################################################
+# Copyright 2020 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+import numbers
+import collections
+from _flux._idset import ffi, lib
+from flux.wrapper import Wrapper, WrapperPimpl
+
+IDSET_INVALID_ID = lib.IDSET_INVALID_ID
+IDSET_FLAG_RANGE = lib.IDSET_FLAG_RANGE
+IDSET_FLAG_BRACKETS = lib.IDSET_FLAG_BRACKETS
+
+
+class IDsetIterator:
+    def __init__(self, idset):
+        self._idset = idset
+        self._next = idset.pimpl.first()
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        result = self._next
+        self._next = self._idset.pimpl.next(result)
+        if result == IDSET_INVALID_ID:
+            raise StopIteration
+        return result
+
+
+class IDset(WrapperPimpl):
+    """A Flux idset object
+
+    The IDset class wraps libflux-idset, and encapsulates a set of
+    unordered non-negative integers. See idset_create(3).
+
+    A Python IDset object may be created from a valid RFC22 idset string,
+    e.g. "0", "0-3", "0,5,7", or any Python iterable type as long as the
+    iterable contains only non-negative integers. For example:
+
+    >>> ids = IDset("0-3")
+    >>> ids2 = IDset([0, 1, 2, 3])
+    >>> ids3 = IDset({0, 1, 2, 3})
+
+    """
+
+    class InnerWrapper(Wrapper):
+        def __init__(
+            self,
+            arg="",
+            handle=None,
+        ):
+            if handle is None:
+                handle = lib.idset_decode(arg.encode("utf-8"))
+                if handle == ffi.NULL:
+                    raise ValueError(f"IDset(): Invalid argument: {arg}")
+            super().__init__(
+                ffi,
+                lib,
+                match=ffi.typeof("struct idset *"),
+                prefixes=["idset_", "IDSET_"],
+                destructor=lib.idset_destroy,
+                handle=handle,
+            )
+
+    def __init__(self, arg="", flags=IDSET_FLAG_RANGE, handle=None):
+        super().__init__()
+        if isinstance(arg, collections.Iterable) and not isinstance(arg, str):
+            self.pimpl = self.InnerWrapper()
+            self.add(arg)
+        else:
+            self.pimpl = self.InnerWrapper(arg=arg, handle=handle)
+        self.default_flags = flags
+
+    def __str__(self):
+        return self.encode()
+
+    def __repr__(self):
+        # Always encode repr with ranges
+        ids = self.encode(flags=IDSET_FLAG_RANGE)
+        return f"IDset('{ids}')"
+
+    def __len__(self):
+        return self.pimpl.count()
+
+    def __iter__(self):
+        return IDsetIterator(self)
+
+    def __contains__(self, i):
+        return self.test(i)
+
+    def __getitem__(self, i):
+        return self.test(i)
+
+    def __setitem__(self, i, value):
+        if value in (0, 1):
+            value = bool(value)
+        if not isinstance(value, bool):
+            typestr = type(value)
+            raise TypeError(f"IDset setitem must be bool or 0,1 not {typestr}")
+        if value:
+            self.set(i)
+        else:
+            self.clear(i)
+
+    def __eq__(self, idset):
+        return self.equal(idset)
+
+    def equal(self, idset):
+        if not isinstance(idset, IDset):
+            raise TypeError
+        return self.pimpl.equal(idset)
+
+    def set_flags(self, flags):
+        """Set default flags for IDset encoding:
+        valid flags are IDSET_FLAG_RANGE and IDSET_FLAG_BRACKETS
+        """
+        self.default_flags = flags
+
+    @staticmethod
+    def _check_index(i, name):
+        if not isinstance(i, numbers.Integral):
+            typestr = type(i)
+            raise TypeError(f"IDset.{name} supports integers, not {typestr}")
+        if i < 0:
+            raise ValueError(f"negative index passed to IDset.{name}")
+
+    def test(self, i):
+        """Test if an id is set in an IDset
+        :param: i: the id to test
+        """
+        self._check_index(i, "test")
+        return self.pimpl.test(i)
+
+    def set(self, start, end=None):
+        """Set an id or range of ids in an IDset
+        :param: start: The first id to set
+        :param: end: (optional) The last id in a range to set
+
+        Returns a copy of self so that this will work:
+        >>> print(IDset().set(0,3))
+
+        """
+        self._check_index(start, "set")
+        if end is None:
+            self.pimpl.set(start)
+        else:
+            self._check_index(end, "set")
+            if end < start:
+                raise ValueError(f"can't set range with {start} > {end}")
+            self.pimpl.range_set(start, end)
+        return self
+
+    def clear(self, start, end=None):
+        """Clear an id or range of ids in an IDset
+        :param: start: The first id to clear
+        :param: end: (optional) The last id in a range to clear
+
+        Returns a copy of self so that this will work:
+        >>> print(IDset("0-9").clear(0,3))
+
+        """
+        self._check_index(start, "clear")
+        if end is None:
+            self.pimpl.clear(start)
+        else:
+            self._check_index(end, "clear")
+            if end < start:
+                raise ValueError(f"can't set range with {start} > {end}")
+            self.pimpl.range_clear(start, end)
+        return self
+
+    def expand(self):
+        """Expand an IDset into a list of integers"""
+        return list(self)
+
+    def count(self):
+        """Return the number of integers in an IDset"""
+        return self.pimpl.count()
+
+    def copy(self):
+        return IDset(handle=self.pimpl.copy())
+
+    def encode(self, flags=None):
+        """Encode an IDset to a string.
+        :param: flags: (optional) flags to influence encoding
+        """
+        if flags is None:
+            flags = self.default_flags
+        #
+        #  N.B. Do not use automatic wrapper call here to avoid leaking
+        #  `char *` result. Instead, explicitly call free() after copying
+        #  the returned string to Python
+        #
+        val = lib.idset_encode(self.handle, flags)
+        result = ffi.string(val)
+        lib.free(val)
+        return result.decode("utf-8")
+
+    def first(self):
+        """Return the first id set in an IDset"""
+        return self.pimpl.first()
+
+    def next(self, i):
+        """Return the next id set in an IDset after value i"""
+        self._check_index(i, "next")
+        return self.pimpl.next(i)
+
+    def last(self):
+        """Return the greatest id set in an IDset"""
+        return self.pimpl.last()
+
+    @staticmethod
+    def arg_to_set(arg, method):
+        if isinstance(arg, str):
+            try:
+                arg = IDset(arg)
+            except:
+                raise ValueError(f"IDset.{method}(): string isn't a valid idset")
+        elif not isinstance(arg, collections.Iterable):
+            typestr = type(arg)
+            method = f"IDset.{method}()"
+            raise TypeError(
+                f"{method}: expected an idset string or iterable, got {typestr}"
+            )
+        return set(arg)
+
+    def add(self, arg):
+        """Add all ids or values in arg to IDset
+        :param: arg: IDset, string, or iterable of integers to add
+        """
+        for i in self.arg_to_set(arg, "add"):
+            self.set(i)
+        return self
+
+    def subtract(self, arg):
+        """subtract all ids or values in arg from IDset
+        :param: arg: IDset, string, or iterable of integers to subtract
+        """
+        for i in self.arg_to_set(arg, "subtract"):
+            self.clear(i)
+        return self
+
+    def union(self, *args):
+        """Return the union of the current IDset and all args
+
+        All args will be converted to IDsets if possible, i.e. any IDset,
+        valid idset string, or iterable composed of integers will work.
+        """
+        result = set(self)
+        for idset in args:
+            if not isinstance(idset, IDset):
+                idset = IDset(idset)
+            result = result | set(idset)
+        return IDset(result)
+
+    def intersect(self, *args):
+        """Return the set intersection of the target IDset and all args
+
+        All args will be converted to IDsets if possible, i.e. any IDset,
+        valid idset string, or iterable composed of integers will work.
+        """
+        result = set(self)
+        for idset in args:
+            if not isinstance(idset, IDset):
+                idset = IDset(idset)
+            result = result & set(idset)
+        return IDset(result)
+
+
+def decode(string):
+    """Decode an idset string and return IDset object"""
+    return IDset(string)

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -174,6 +174,7 @@ TESTSCRIPTS = \
 	python/t0012-futures.py \
 	python/t0013-job-list-inactive.py \
 	python/t0020-hostlist.py \
+	python/t0021-idset.py \
 	python/t1000-service-add-remove.py
 
 if HAVE_FLUX_SECURITY

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -173,6 +173,7 @@ TESTSCRIPTS = \
 	python/t0010-job.py \
 	python/t0012-futures.py \
 	python/t0013-job-list-inactive.py \
+	python/t0020-hostlist.py \
 	python/t1000-service-add-remove.py
 
 if HAVE_FLUX_SECURITY

--- a/t/python/t0020-hostlist.py
+++ b/t/python/t0020-hostlist.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python
+###############################################################
+# Copyright 2020 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+import unittest
+from pycotap import TAPTestRunner
+import flux.hostlist as hostlist
+
+
+class TestHostlistMethods(unittest.TestCase):
+    def test_basic_decode(self):
+        # simple string works
+        hl = hostlist.decode("host")
+        self.assertEqual(hl.count(), 1)
+
+        # iterables works
+        hl = hostlist.decode(["foo1", "foo2"])
+        self.assertEqual(str(hl), "foo[1-2]")
+
+        # set works, but must sort to get guaranteed order
+        hl = hostlist.decode({"foo1", "foo2"}).sort()
+        self.assertEqual(str(hl), "foo[1-2]")
+
+        with self.assertRaises(TypeError):
+            hl = hostlist.decode(["foo1", 42])
+
+    def test_invalid_decode(self):
+        test_invalid = [
+            "[]",
+            "foo[]",
+            "foo[",
+            "foo[1,3",
+            "foo[[1,3]",
+            "foo]",
+            "foo[x-y]",
+            "foo[0-1,2--5]",
+        ]
+        for string in test_invalid:
+            with self.assertRaises(ValueError):
+                hostlist.decode(string)
+
+        # TypeError tests
+        with self.assertRaises(TypeError):
+            hostlist.decode(42)
+        with self.assertRaises(TypeError):
+            hostlist.decode(1.0)
+        with self.assertRaises(TypeError):
+            hostlist.decode(["foo", 42])
+        with self.assertRaises(TypeError):
+            hostlist.decode()
+
+    def test_str(self):
+        tests = [
+            {"input": "", "output": ""},
+            {"input": "foo0", "output": "foo0"},
+            {"input": "foo0,foo1", "output": "foo[0-1]"},
+            {"input": "foo0,bar1", "output": "foo0,bar1"},
+            {"input": "foo[0-10]", "output": "foo[0-10]"},
+        ]
+        for test in tests:
+            hl = hostlist.decode(test["input"])
+            expected = test["output"]
+            self.assertEqual(str(hl), expected)
+            self.assertEqual(repr(hl), f"Hostlist('{expected}')")
+
+    def test_count(self):
+        tests = [
+            {"input": "", "result": 0},
+            {"input": "foo0", "result": 1},
+            {"input": "foo0,foo1", "result": 2},
+            {"input": "foo0,bar1", "result": 2},
+            {"input": "foo[0-10]", "result": 11},
+        ]
+        for test in tests:
+            hl = hostlist.decode(test["input"])
+            self.assertEqual(len(hl), test["result"])
+            self.assertEqual(hl.count(), test["result"])
+
+    def test_index(self):
+        hl = hostlist.decode("foo[0-9]")
+        self.assertEqual(hl[0], "foo0")
+        self.assertEqual(hl[1], "foo1")
+        self.assertEqual(hl[9], "foo9")
+        self.assertEqual(hl[-1], "foo9")
+        self.assertEqual(hl[-2], "foo8")
+        self.assertListEqual(hl[1:3], ["foo1", "foo2"])
+
+    def test_index_exceptions(self):
+        hl = hostlist.decode("foo[0-9]")
+        self.assertRaises(TypeError, lambda x: x["a"], hl)
+        self.assertRaises(IndexError, lambda x: x[10], hl)
+
+    def test_contains(self):
+        hl = hostlist.decode("foo[0-9]")
+        self.assertIn("foo0", hl)
+        self.assertIn("foo5", hl)
+        self.assertNotIn("foo10", hl)
+        self.assertNotIn("foo", hl)
+
+    def test_iterator(self):
+        hl = hostlist.decode("foo[0-3]")
+        self.assertListEqual([host for host in hl], hl.expand())
+        hl = hostlist.decode("")
+        self.assertListEqual([host for host in hl], [])
+
+    def test_append(self):
+        hl = hostlist.decode("")
+        self.assertEqual(hl.append("foo[0-3]"), 4)
+        self.assertEqual(str(hl), "foo[0-3]")
+        self.assertEqual(hl.append("foo[7-9]"), 3)
+        self.assertEqual(str(hl), "foo[0-3,7-9]")
+        nl = hostlist.decode("foo1,bar")
+        self.assertEqual(hl.append(nl), 2)
+        self.assertEqual(str(hl), "foo[0-3,7-9,1],bar")
+        hl.append(["bar0", "bar1"])
+        self.assertEqual(str(hl), "foo[0-3,7-9,1],bar,bar[0-1]")
+
+        with self.assertRaises(TypeError):
+            hl.append(42)
+        with self.assertRaises(TypeError):
+            hl.append(["bar2", 42])
+
+    def test_delete(self):
+        hl = hostlist.decode("foo[0-10]")
+        self.assertEqual(hl.delete("foo5"), 1)
+        self.assertEqual(hl.delete("foo1,foo3"), 2)
+        self.assertEqual(str(hl), "foo[0,2,4,6-10]")
+
+        self.assertEqual(hl.delete(hostlist.decode("foo[6-7]")), 2)
+        self.assertEqual(str(hl), "foo[0,2,4,8-10]")
+
+    def test_sort(self):
+        hl = hostlist.decode("foo[7,6,5,4,3,2,1]").sort()
+        self.assertEqual(str(hl), "foo[1-7]")
+
+    def test_uniq(self):
+        hl = hostlist.decode("foo[1-7,1-7,1-7]").uniq()
+        self.assertEqual(str(hl), "foo[1-7]")
+
+    def test_copy(self):
+        hl = hostlist.decode("foo[0-3]")
+        cp = hl.copy()
+        hl.delete("foo[0-3]")
+        self.assertEqual(str(cp), "foo[0-3]")
+
+
+if __name__ == "__main__":
+    unittest.main(testRunner=TAPTestRunner())
+
+
+# vi: ts=4 sw=4 expandtab

--- a/t/python/t0021-idset.py
+++ b/t/python/t0021-idset.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python
+###############################################################
+# Copyright 2020 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+import unittest
+from pycotap import TAPTestRunner
+import flux.idset as idset
+
+
+class TestIDsetMethods(unittest.TestCase):
+    def test_str(self):
+        tests = [
+            {"input": "", "flags": None, "output": ""},
+            {"input": "0", "flags": None, "output": "0"},
+            {"input": "0,1", "flags": None, "output": "0-1"},
+            {"input": "0-10", "flags": None, "output": "0-10"},
+            {
+                "input": "0-10",
+                "flags": idset.IDSET_FLAG_RANGE | idset.IDSET_FLAG_BRACKETS,
+                "output": "[0-10]",
+            },
+            {
+                "input": "0-3",
+                "flags": idset.IDSET_FLAG_BRACKETS,
+                "output": "[0,1,2,3]",
+            },
+            {"input": "0-3", "flags": 0, "output": "0,1,2,3"},
+        ]
+        for test in tests:
+            ids = idset.decode(test["input"])
+            if test["flags"] is not None:
+                ids.set_flags(test["flags"])
+            self.assertEqual(str(ids), test["output"])
+            expected = str(idset.decode(test["output"]))
+            self.assertEqual(repr(ids), f"IDset('{expected}')")
+
+    def test_count(self):
+        tests = [
+            {"input": "", "result": 0},
+            {"input": "0", "result": 1},
+            {"input": "0,1", "result": 2},
+            {"input": "0-10", "result": 11},
+            {"input": "0,5,9", "result": 3},
+        ]
+        i = 0
+        for test in tests:
+            with self.subTest(i=i):
+                ids = idset.decode(test["input"])
+                self.assertEqual(len(ids), test["result"])
+                self.assertEqual(ids.count(), test["result"])
+
+    def test_index(self):
+        ids = idset.decode("0-9")
+        self.assertTrue(ids[0])
+        self.assertTrue(ids[5])
+        self.assertFalse(ids[10])
+        ids[10] = True
+        ids[21] = 1
+        ids[5] = False
+        self.assertTrue(ids[10])
+        self.assertTrue(ids[21])
+        self.assertFalse(ids[5])
+        self.assertEqual(str(ids), "0-4,6-10,21")
+
+    def test_index_exceptions(self):
+        ids = idset.decode("0-9")
+        self.assertRaises(TypeError, lambda x: x["a"], ids)
+        self.assertRaises(ValueError, lambda x: x[-1], ids)
+        with self.assertRaises(TypeError):
+            ids[0] = 7
+        with self.assertRaises(TypeError):
+            ids[0] = "hello"
+
+    def test_contains(self):
+        ids = idset.decode("0-9")
+        self.assertIn(0, ids)
+        self.assertIn(5, ids)
+        self.assertNotIn(10, ids)
+        self.assertNotIn(1024, ids)
+
+    def test_contains_exceptions(self):
+        ids = idset.decode("0-9")
+        with self.assertRaises(ValueError):
+            -1 in ids
+        with self.assertRaises(TypeError):
+            "foo" in ids
+
+    def test_iterator(self):
+        ids = idset.decode("0-3,7")
+        self.assertListEqual([i for i in ids], [0, 1, 2, 3, 7])
+        ids = idset.decode("3")
+        self.assertListEqual([i for i in ids], [3])
+        ids = idset.decode("")
+        self.assertListEqual([i for i in ids], [])
+
+    def test_expand(self):
+        self.assertListEqual(idset.decode("0-3").expand(), [0, 1, 2, 3])
+        self.assertListEqual(idset.decode("").expand(), [])
+
+    def test_set_and_clear(self):
+        ids = idset.IDset()
+        ids.set(3)
+        self.assertTrue(ids[3])
+        self.assertEqual(str(ids), "3")
+        ids.clear(3)
+        self.assertFalse(ids[3])
+        self.assertEqual(str(ids), "")
+
+        ids.set(3, 7)
+        self.assertEqual(str(ids), "3-7")
+
+        ids.clear(4, 5)
+        self.assertEqual(str(ids), "3,6-7")
+
+    def test_set_and_clear_exceptions(self):
+        ids = idset.IDset()
+        self.assertRaises(ValueError, lambda x: x.set(-1), ids)
+        self.assertRaises(ValueError, lambda x: x.set(1, -1), ids)
+        self.assertRaises(TypeError, lambda x: x.set("a"), ids)
+        self.assertRaises(ValueError, lambda x: x.set(5, 1), ids)
+
+        self.assertRaises(ValueError, lambda x: x.clear(-1), ids)
+        self.assertRaises(ValueError, lambda x: x.clear(1, -1), ids)
+        self.assertRaises(TypeError, lambda x: x.clear("a"), ids)
+        self.assertRaises(ValueError, lambda x: x.clear(5, 1), ids)
+
+    def test_copy(self):
+        ids = idset.decode("0-9")
+        cp = ids.copy()
+        cp.clear(1, 9)
+        self.assertEqual(str(cp), "0")
+
+    def test_equal(self):
+        ids1 = idset.IDset()
+        ids2 = idset.IDset()
+        self.assertEqual(ids1, ids2)
+        self.assertTrue(ids1.equal(ids2))
+        ids1.set(0, 9)
+        ids2.set(0, 9)
+        self.assertEqual(ids1, ids2)
+        self.assertTrue(ids2.equal(ids1))
+        ids1.clear(0)
+        self.assertNotEqual(ids1, ids2)
+        self.assertFalse(ids1.equal(ids2))
+        with self.assertRaises(TypeError):
+            ids1 == "foo"
+        with self.assertRaises(TypeError):
+            ids1.equal("foo")
+
+    def test_first_last_next(self):
+        ids = idset.decode("0-9")
+        self.assertEqual(ids.first(), 0)
+        self.assertEqual(ids.last(), 9)
+        self.assertEqual(ids.next(5), 6)
+        self.assertEqual(ids.next(9), idset.IDSET_INVALID_ID)
+        self.assertRaises(ValueError, lambda x: x.next(-1), ids)
+        self.assertRaises(TypeError, lambda x: x.next("a"), ids)
+
+    def test_add_subtract(self):
+        ids = idset.decode("0-9")
+        self.assertEqual(str(ids.add("10-11")), "0-11")
+        self.assertEqual(str(ids.add([20, 21])), "0-11,20-21")
+        self.assertEqual(str(ids.add(idset.decode(""))), "0-11,20-21")
+
+        self.assertEqual(str(ids.subtract([])), "0-11,20-21")
+        self.assertEqual(str(ids.subtract("11-20")), "0-10,21")
+        self.assertEqual(str(ids.subtract(idset.decode("0-10"))), "21")
+        self.assertEqual(str(ids.subtract([21])), "")
+        with self.assertRaises(ValueError):
+            ids.subtract("foo")
+        with self.assertRaises(TypeError):
+            ids.subtract(42)
+        with self.assertRaises(ValueError):
+            ids.add("foo")
+        with self.assertRaises(TypeError):
+            ids.add(42)
+
+    def test_intersect(self):
+        tests = [
+            {"idset": "0-10", "args": ["0-5", "0-3"], "result": "0-3"},
+            {"idset": "0-1", "args": ["3-4"], "result": ""},
+            {"idset": "0-1024", "args": ["500-600"], "result": "500-600"},
+        ]
+        for test in tests:
+            ids = idset.decode(test["idset"])
+            # first, works with encoded idsets
+            result = ids.intersect(*test["args"])
+            self.assertEqual(str(result), test["result"])
+
+            # also try with decoded IDset objects
+            result = ids.intersect(*map(idset.decode, test["args"]))
+            self.assertEqual(str(result), test["result"])
+
+    def test_union(self):
+        tests = [
+            {"idset": "0-10", "args": ["5-15", "0-3"], "result": "0-15"},
+            {"idset": "0-1", "args": ["3-4"], "result": "0-1,3-4"},
+        ]
+        for test in tests:
+            ids = idset.decode(test["idset"])
+            result = ids.union(*test["args"])
+            self.assertEqual(str(result), test["result"])
+
+
+if __name__ == "__main__":
+    unittest.main(testRunner=TAPTestRunner())
+
+
+# vi: ts=4 sw=4 expandtab


### PR DESCRIPTION
This PR is pretty straightforward. It adds basic `IDset` and `Hostlist` Python classes which wrap libflux-idset.so and libflux-hostlist.so.

I was also going to make automated bindings for librlist to make an Rv1 class, however I decided to stop here and make the Rv1 class a separate PR.