### PR TITLE
testsuite: increase resource.monitor-waitup timeout

### DIFF
--- a/t/resource/waitup.py
+++ b/t/resource/waitup.py
@@ -71,6 +71,6 @@ for rank in range(1, size):
     resource_load(rank)
 
 # Ensure waitup can now complete
-log.info("waiting 5s for waitup RPC to complete")
-future.wait_for(5)
+log.info("waiting 30s for waitup RPC to complete")
+future.wait_for(30)
 log.info("done")


### PR DESCRIPTION
Problem: A resource.monitor-waitup test was regularly failing
when running on busier systems.  It is believed the 5s timeout
in the test script was too short.

Solution: Increase the timeout from 5s to 30s.

Fixes #3329