### PR TITLE
libjob: repair interoperability with flux-security

### DIFF
--- a/src/common/libjob/sign_none.c
+++ b/src/common/libjob/sign_none.c
@@ -51,7 +51,7 @@ int header_decode (const char *src, int srclen, uint32_t *useridp)
             val_version = val;
         else if (!strcmp (key, "userid"))
             val_userid = val;
-        else if (!strcmp (key, "mech"))
+        else if (!strcmp (key, "mechanism"))
             val_mech = val;
         else
             goto error_inval;
@@ -84,7 +84,7 @@ static char *header_encode (uint32_t userid)
     int dstlen;
     int i;
 
-    srclen = snprintf (src, sizeof (src), "version:i1:userid:i%lu:mech:snone:",
+    srclen = snprintf (src, sizeof (src), "version:i1:userid:i%lu:mechanism:snone:",
                        (unsigned long)userid);
     assert (srclen < sizeof (src));
     for (i = 0; i < srclen; i++) {

--- a/src/common/libjob/test/sign_none.c
+++ b/src/common/libjob/test/sign_none.c
@@ -73,11 +73,11 @@ char *wrap (const char *header, int headerlen, void *payload, int payloadlen)
  */
 void decode_good (void)
 {
-    const char good1_header[] = "version\0i1\0userid\0i1000\0mech\0snone";
+    const char good1_header[] = "version\0i1\0userid\0i1000\0mechanism\0snone";
     char *good1 = wrap (good1_header, sizeof (good1_header), "foo", 4);
-    const char good2_header[] = "userid\0i1000\0mech\0snone\0version\0i1";
+    const char good2_header[] = "userid\0i1000\0mechanism\0snone\0version\0i1";
     char *good2 = wrap (good2_header, sizeof (good2_header), NULL, 0);
-    const char good3_header[] = "mech\0snone\0version\0i1\0userid\0i0";
+    const char good3_header[] = "mechanism\0snone\0version\0i1\0userid\0i0";
     char *good3 = wrap (good3_header, sizeof (good3_header), "", 1);
 
     uint32_t userid;
@@ -121,37 +121,37 @@ void decode_good (void)
 void decode_bad_header (void)
 {
     /* version 2 */
-    const char bad1_header[] = "version\0i2\0userid\0i1000\0mech\0snone";
+    const char bad1_header[] = "version\0i2\0userid\0i1000\0mechanism\0snone";
     char *bad1 = wrap (bad1_header, sizeof (bad1_header), NULL, 0);
     /* string version */
-    const char bad2_header[] = "version\0s1\0userid\0i1000\0mech\0snone";
+    const char bad2_header[] = "version\0s1\0userid\0i1000\0mechanism\0snone";
     char *bad2 = wrap (bad2_header, sizeof (bad2_header), NULL, 0);
     /* missing version */
-    const char bad3_header[] = "userid\0i1000\0mech\0snone";
+    const char bad3_header[] = "userid\0i1000\0mechanism\0snone";
     char *bad3 = wrap (bad3_header, sizeof (bad3_header), NULL, 0);
     /* extra foo field */
-    const char bad4_header[] = "foo\0i0\0version\0i1\0userid\0i1000\0mech\0snone";
+    const char bad4_header[] = "foo\0i0\0version\0i1\0userid\0i1000\0mechanism\0snone";
     char *bad4 = wrap (bad4_header, sizeof (bad4_header), NULL, 0);
     /* negative userid */
-    const char bad5_header[] = "version\0i1\0userid\0i-1\0mech\0snone";
+    const char bad5_header[] = "version\0i1\0userid\0i-1\0mechanism\0snone";
     char *bad5 = wrap (bad5_header, sizeof (bad5_header), NULL, 0);
     /* wrong type userid */
-    const char bad6_header[] = "version\0i1\0userid\0s42\0mech\0snone";
+    const char bad6_header[] = "version\0i1\0userid\0s42\0mechanism\0snone";
     char *bad6 = wrap (bad6_header, sizeof (bad6_header), NULL, 0);
     /* missing userid */
-    const char bad7_header[] = "version\0i1\0mech\0snone";
+    const char bad7_header[] = "version\0i1\0mechanism\0snone";
     char *bad7 = wrap (bad7_header, sizeof (bad7_header), NULL, 0);
     /* wrong mech */
-    const char bad8_header[] = "version\0i1\0userid\0i1000\0mech\0smunge";
+    const char bad8_header[] = "version\0i1\0userid\0i1000\0mechanism\0smunge";
     char *bad8 = wrap (bad8_header, sizeof (bad8_header), NULL, 0);
     /* wrong type mech */
-    const char bad9_header[] = "version\0i1\0userid\0i1000\0mech\0inone";
+    const char bad9_header[] = "version\0i1\0userid\0i1000\0mechanism\0inone";
     char *bad9 = wrap (bad9_header, sizeof (bad9_header), NULL, 0);
     /* missing mech */
     const char bad10_header[] = "version\0i1\0userid\0i1000";
     char *bad10 = wrap (bad10_header, sizeof (bad10_header), NULL, 0);
     /* extra separator */
-    const char bad11_header[] = "\0version\0i1\0userid\0i1000\0mech\0snone";
+    const char bad11_header[] = "\0version\0i1\0userid\0i1000\0mechanism\0snone";
     char *bad11 = wrap (bad11_header, sizeof (bad11_header), NULL, 0);
 
     uint32_t userid;
@@ -229,17 +229,18 @@ void decode_bad_header (void)
 
 void decode_bad_other (void)
 {
-    const char *good = "dmVyc2lvbgBpMQB1c2VyaWQAaTEwMDAAbWVjaABzbm9uZQA=.Zm9vAA==.none";
+    const char *good = "dmVyc2lvbgBpMQB1c2VyaWQAaTEwMDAAbWVjaGFuaXNtAHNub25lAA==.Zm9vAA==.none";
     /* wrong suffix */
-    const char *bad1  = "dmVyc2lvbgBpMQB1c2VyaWQAaTEwMDAAbWVjaABzbm9uZQA=.Zm9vAA==.wrong";
+    const char *bad1  = "dmVyc2lvbgBpMQB1c2VyaWQAaTEwMDAAbWVjaGFuaXNtAHNub25lAA==.Zm9vAA==.wrong";
+
     /* missing field */
-    const char *bad2  = "dmVyc2lvbgBpMQB1c2VyaWQAaTEwMDAAbWVjaABzbm9uZQA=.none";
+    const char *bad2  = "dmVyc2lvbgBpMQB1c2VyaWQAaTEwMDAAbWVjaGFuaXNtAHNub25lAA==.none";
     /* two missing fields */
     const char *bad3  = "none";
     /* invalid base64 payload (% character) */
-    const char *bad4  = "dmVyc2lvbgBpMQB1c2VyaWQAaTEwMDAAbWVjaABzbm9uZQA=.%m9vAA==.none";
+    const char *bad4  = "dmVyc2lvbgBpMQB1c2VyaWQAaTEwMDAAbWVjaGFuaXNtAHNub25lAA==.%m9vAA==.none";
     /* invalid base64 header (% character) */
-    const char *bad5  = "%mVyc2lvbgBpMQB1c2VyaWQAaTEwMDAAbWVjaABzbm9uZQA=.Zm9vAA==.none";
+    const char *bad5 = "%mVyc2lvbgBpMQB1c2VyaWQAaTEwMDAAbWVjaGFuaXNtAHNub25lAA==.Zm9vAA==.none";
 
     uint32_t userid;
     void *payload;
@@ -296,7 +297,7 @@ void badarg (void)
 
     /* unwrap */
 
-    const char good1_header[] = "version\0i1\0userid\0i1000\0mech\0snone";
+    const char good1_header[] = "version\0i1\0userid\0i1000\0mechanism\0snone";
     char *good1 = wrap (good1_header, sizeof (good1_header), "foo", 4);
 
     errno = 0;

--- a/src/common/libjob/test/sign_none.c
+++ b/src/common/libjob/test/sign_none.c
@@ -40,6 +40,7 @@ void simple (void)
     ok (rc == 0 && userid == 1000
         && payloadsz == 4 && memcmp (payload, "foo", 4) == 0,
         "sign_none_unwrap works");
+    free (payload);
 
     free (s);
 }
@@ -92,6 +93,7 @@ void decode_good (void)
     ok (rc == 0 && userid == 1000
         && payloadsz == 4 && memcmp (payload, "foo", 4) == 0,
         "dummy encode 1 decodes as expected");
+    free (payload);
 
     userid = 0;
     payload = NULL;
@@ -100,6 +102,7 @@ void decode_good (void)
     rc = sign_none_unwrap (good2, &payload, &payloadsz, &userid);
     ok (rc == 0 && userid == 1000 && payloadsz == 0,
         "dummy encode 2 decodes as expected");
+    free (payload);
 
     userid = 1;
     payload = NULL;
@@ -108,6 +111,7 @@ void decode_good (void)
     rc = sign_none_unwrap (good3, &payload, &payloadsz, &userid);
     ok (rc == 0 && userid == 0 && payloadsz == 1 && *(char *)payload == '\0',
         "dummy encode 3 decodes as expected");
+    free (payload);
 
     free (good1);
     free (good2);


### PR DESCRIPTION
flux-core signs jobs with an internal "none" signer when configured without flux-security.  As noted in #3354, it seems the format of the envelopes now differ between flux-security and flux-core.  This PR fixes the issue and adds tests to ensure that sign/verify works both ways.