### PR TITLE
docs: add explicit link to man pages section

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -3,20 +3,21 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Welcome to flux-core's documentation!
-=====================================
+Documentation for flux-core
+===========================
 
 .. toctree::
    :maxdepth: 2
    :caption: Contents:
 
 
-Man Pages
-=========
+.. _man-pages:
+
+flux-core Manual Pages
+======================
 
 .. toctree::
    :maxdepth: 2
-   :caption: Manual pages
 
    man1/index
    man3/index


### PR DESCRIPTION
Problem: when referencing the flux-core docs via intersphinx, it uses
the top section title of `index.rst` "Welcome to flux-core's
documentation".  For the meta flux-docs RTD project, we want a link that
says "Flux-core Man Pages".

Solution: Rename the subsection to "Flux-core Man Pages" and give it an
explicit link so that we can reference it with intersphinx from flux-docs.

Related to https://github.com/flux-framework/flux-docs/issues/67