### PR TITLE
testsuite: replace loop in t2300-sched-simple.t with dmesg-grep.py helper

### DIFF
--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -230,6 +230,7 @@ dist_check_SCRIPTS = \
 	scripts/tssh \
 	scripts/sign-as.py \
 	scripts/runpty.py \
+	scripts/dmesg-grep.py \
 	valgrind/valgrind-workload.sh \
 	valgrind/workload.d/job \
 	kvs/kvs-helper.sh \

--- a/t/scripts/dmesg-grep.py
+++ b/t/scripts/dmesg-grep.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+###############################################################
+# Copyright 2019 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+#
+#  Follow Flux dmesg output until a line matches a pattern
+#
+import sys
+import argparse
+import re
+
+import flux
+from flux.core.watchers import TimerWatcher
+from flux.constants import FLUX_RPC_STREAMING
+
+
+parser = argparse.ArgumentParser(
+    description="watch the flux dmesg log for a given pattern"
+)
+parser.add_argument(
+    "-t",
+    "--timeout",
+    help="Timeout with error after some number of seconds",
+    metavar="SEC",
+    type=float,
+    default=1.0,
+)
+parser.add_argument(
+    "-v",
+    "--verbose",
+    help="Emit each line of dmesg output, not just first matching",
+    action="count",
+    default=0,
+)
+parser.add_argument("pattern")
+args = parser.parse_args()
+
+
+def timer_cb(h, watcher, revents, _arg):
+    print("Timeout!", file=sys.stderr)
+    h.reactor_stop_error()
+
+
+def dmesg_cb(rpc, pattern, verbose=False):
+    buf = rpc.get_str()
+    match = pattern.search(buf)
+    if match:
+        print(buf)
+        rpc.flux_handle.reactor_stop()
+    elif verbose:
+        print(buf)
+    rpc.reset()
+
+
+pattern = re.compile(args.pattern)
+
+h = flux.Flux()
+
+rpc = h.rpc("log.dmesg", {"follow": True}, flags=FLUX_RPC_STREAMING)
+rpc.then(dmesg_cb, pattern, verbose=args.verbose)
+
+TimerWatcher(h, args.timeout, timer_cb).start()
+if h.reactor_run() < 0:
+    sys.exit(1)

--- a/t/t2300-sched-simple.t
+++ b/t/t2300-sched-simple.t
@@ -18,6 +18,7 @@ flux R encode -r0-1 -c0-1 >R.test
 
 SCHEMA=${FLUX_SOURCE_DIR}/src/modules/job-ingest/schemas/jobspec.jsonschema
 JSONSCHEMA_VALIDATOR=${FLUX_SOURCE_DIR}/src/modules/job-ingest/validators/validate-schema.py
+dmesg_grep=${SHARNESS_TEST_SRCDIR}/scripts/dmesg-grep.py
 
 kvs_job_dir() {
 	flux job id --to=kvs $1
@@ -186,19 +187,9 @@ test_expect_success 'sched-simple: there are no outstanding sched requests' '
 	grep "0 alloc requests pending to scheduler" queue_status.out &&
 	grep "0 free requests pending to scheduler" queue_status.out
 '
-# flux dmesg can be racy as flux module load of sched-simple can return
-# before sched-simple is initialized, so we'll loop up to 10 times
-# if needed
 test_expect_success 'sched-simple: reload in unlimited mode' '
 	flux module load sched-simple unlimited &&
-	i=0 &&
-	while !	flux dmesg | grep "scheduler: ready unlimited" && \
-	      [ $i -lt 10 ]
-	do
-	    sleep 1
-	    i=$((i + 1))
-	done &&
-	test "$i" -lt "10"
+    $dmesg_grep -t 10 "scheduler: ready unlimited"
 '
 test_expect_success 'sched-simple: submit 3 more jobs' '
 	flux job submit basic.json >job11.id &&


### PR DESCRIPTION
This PR requires #3366 

Add a testsuite utility that follows `log.dmesg` output searching for a pattern. If a line matches the script exits with success, o/w it waits until a timeout elapses and exits with an error.

This is meant to be used in place of `flux dmesg | grep PATTERN` when that construct may be racy due to log message generation from asynchronous events, or if the log message is not generated on rank 0.

Replace the one known racy test which currently loops over `flux dmesg | grep` with the new script.