### PR TITLE
docker: install poison flux-core libs and executables before build and test

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -532,6 +532,7 @@ AC_CONFIG_FILES( \
   t/Makefile \
   t/fluxometer/conf.lua \
   t/fluxometer/conf.lua.installed \
+  src/test/docker/poison-libflux.sh
 )
 
 AC_CONFIG_LINKS([ \

--- a/src/common/libsubprocess/Makefile.am
+++ b/src/common/libsubprocess/Makefile.am
@@ -46,10 +46,10 @@ T_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
         $(top_srcdir)/config/tap-driver.sh
 
 test_ldadd = \
+        $(top_builddir)/src/common/libtap/libtap.la \
         $(top_builddir)/src/common/libsubprocess/libsubprocess.la \
         $(top_builddir)/src/common/libflux-internal.la \
-        $(top_builddir)/src/common/libflux-core.la \
-        $(top_builddir)/src/common/libtap/libtap.la
+        $(top_builddir)/src/common/libflux-core.la
 
 test_ldflags = \
 	-no-install

--- a/src/test/docker/poison-libflux.sh.in
+++ b/src/test/docker/poison-libflux.sh.in
@@ -1,0 +1,89 @@
+#!/bin/bash
+#
+#  Build a "poison" libflux-core.so to install in system path.
+#
+#  This will hopefully ensure no flux-core internal tests try to
+#   load the system libflux-core.so
+#
+
+WORKDIR=$(mktemp -d)
+printf " Changing working directory to $WORKDIR\n"
+cd $WORKDIR || exit 1
+
+cleanup() {
+    rm -rf $WORKDIR
+    printf " Cleaning up...\n"
+}
+trap cleanup EXIT
+
+LIBDIR=@X_LIBDIR@
+BINDIR=@X_BINDIR@
+
+#  Install poison flux(1) executable in PATH
+#
+printf " Installing poison flux binary to ${BINDIR}/flux\n"
+cat >flux.sh <<EOF
+#!/bin/sh
+echo "Error: system flux executable run during test!" >&2
+EOF
+install -m 0755 flux.sh ${BINDIR}/flux
+
+
+#  Create poison dso:
+cat >poison.c <<EOF
+#include <stdio.h>
+#include <stdlib.h>
+
+void __attribute__((constructor)) poison (void)
+{
+    fprintf (stderr, "error: program loaded system %s\n", LIBNAME);
+    exit (1);
+}
+EOF
+
+CORE_VERSION=@LIBFLUX_CORE_VERSION_INFO@
+IDSET_VERSION=@LIBFLUX_IDSET_VERSION_INFO@
+HOSTLIST_VERSION=@LIBFLUX_HOSTLIST_VERSION_INFO@
+SCHEDUTIL_VERSION=@LIBFLUX_SCHEDUTIL_VERSION_INFO@
+OPTPARSE_VERSION=@LIBFLUX_OPTPARSE_VERSION_INFO@
+
+get_current() {
+    name=${1^^}_VERSION
+    echo ${!name} | cut -d: -f1
+}
+get_revision() {
+    name=${1^^}_VERSION
+    echo ${!name} | cut -d: -f2
+}
+get_age() {
+    name=${1^^}_VERSION
+    echo ${!name} | cut -d: -f3
+}
+
+printf " Installing poison flux libs in ${LIBDIR}\n"
+for lib in core idset optparse schedutil hostlist; do
+
+    #  Compile:
+    printf " BUILD    poison libflux-${lib}.so\n"
+    cc -D LIBNAME=\"libflux-${lib}\" -fPIC -shared -o libflux-${lib}.so poison.c
+
+    #  Install:
+    printf " INSTALL  poison libflux-${lib}.so to ${LIBDIR}\n"
+    install -m 0755 libflux-${lib}.so ${LIBDIR}
+
+    #  Create version links
+    #  N.B. This is very linux specific -- we may need a different way to
+    #   do this in the future.
+    #
+    current=$(get_current $lib)
+    revision=$(get_revision $lib)
+    age=$(get_age $lib)
+    major=$((current - age))
+    suffix=$major.$age.$revision
+
+    printf " LINK     ${LIBDIR}/libflux-${lib}.so.${major}\n"
+    ln -sf ${LIBDIR}/libflux-${lib}.so ${LIBDIR}/libflux-${lib}.so.${suffix}
+    ln -sf ${LIBDIR}/libflux-${lib}.so ${LIBDIR}/libflux-${lib}.so.${major}
+
+done
+

--- a/src/test/travis_run.sh
+++ b/src/test/travis_run.sh
@@ -14,6 +14,7 @@
 #  CPPCHECK      Run cppcheck if set to "t"
 #  DISTCHECK     Run `make distcheck` if set
 #  PRELOAD       Set as LD_PRELOAD for make and tests
+#  POISON        Install poison libflux and flux(1) in image
 #  chain_lint    Run sharness with --chain-lint if chain_lint=t
 #
 #  And, obviously, some crucial variables that configure itself cares about:
@@ -160,6 +161,13 @@ fi
 
 travis_fold "configure"  "/usr/src/configure ${ARGS}..." /usr/src/configure ${ARGS}
 travis_fold "make_clean" "make clean..." make clean
+
+env
+if test "$POISON" = "t"; then
+  echo "Installing poison libflux..."
+  travis_fold "poison_libflux" "Installing poison libflux..." \
+    bash src/test/docker/poison-libflux.sh
+fi
 
 if test "$DISTCHECK" != "t"; then
   echo running: ${MAKECMDS}


### PR DESCRIPTION
This PR adds a script to build and install "poison" `libflux-*.so` into the system path of docker images before `configure`, `make` and `make check`. Presumably this will help us catch cases where the system flux-core components "leak" into the testsuite.

To disable the poison libs, a new `docker-run-checks.sh` option `--no-poison` is introduced.

Also fixed one link order issue that was hitting the poison system libs during testing. 