### PR TITLE
Support flux-restart event to prepare for fair share priority plugin

### DIFF
--- a/src/modules/job-manager/alloc.c
+++ b/src/modules/job-manager/alloc.c
@@ -539,7 +539,9 @@ int alloc_enqueue_alloc_request (struct alloc *alloc, struct job *job)
     return 0;
 }
 
-/* called from event_job_action() FLUX_JOB_STATE_CLEANUP */
+/* called from event_job_action() FLUX_JOB_STATE_CLEANUP
+ * or transition from FLUX_JOB_STATE_SCHED back to FLUX_JOB_STATE_PRIORITY.
+ */
 void alloc_dequeue_alloc_request (struct alloc *alloc, struct job *job)
 {
     if (job->alloc_queued) {

--- a/src/modules/job-manager/event.c
+++ b/src/modules/job-manager/event.c
@@ -320,8 +320,13 @@ int event_job_action (struct event *event, struct job *job)
         case FLUX_JOB_STATE_PRIORITY:
             /* N.B. Priority will be set via a priority plugin call in
              * the future. For the time being, we pass the
-             * administrative priority set via submit.
+             * administrative priority set via submit or
+             * administrative change.
+             *
+             * In the event we have re-entered this state from the
+             * SCHED state, dequeue the job first.
              */
+            alloc_dequeue_alloc_request (ctx->alloc, job);
             if (event_job_post_pack (event,
                                      job,
                                      "priority",
@@ -531,6 +536,15 @@ int event_job_update (struct job *job, json_t *event)
         if (job->state != FLUX_JOB_STATE_CLEANUP)
             goto inval;
         job->state = FLUX_JOB_STATE_INACTIVE;
+    }
+    else if (!strcmp (name, "flux-restart")) {
+        /* The flux-restart event is currently only posted to jobs in
+         * SCHED state since that is the only state transition defined
+         * for the event in RFC21.  In the future, other transitions
+         * may be defined.
+         */
+        if (job->state == FLUX_JOB_STATE_SCHED)
+            job->state = FLUX_JOB_STATE_PRIORITY;
     }
     return 0;
 inval:

--- a/t/t2202-job-manager.t
+++ b/t/t2202-job-manager.t
@@ -185,6 +185,21 @@ test_expect_success 'job-manager: queue was successfully reconstructed' '
 	test_cmp list10_reordered.out list_reload.out
 '
 
+check_eventlog_restart_events() {
+	for jobid in $(cut -f1 <list_reload.out); do
+		if ! flux job wait-event -t 20 -c 1 ${jobid} flux-restart \
+		   || ! flux job wait-event -t 20 -c 2 ${jobid} priority
+		then
+			return 1
+		fi
+	done
+	return 0
+}
+
+test_expect_success 'job-manager: eventlog indicates restart & priority event' '
+	check_eventlog_restart_events
+'
+
 test_expect_success HAVE_JQ 'job-manager: max_jobid has not changed' '
 	${RPC} job-manager.getinfo | jq .max_jobid >max2.out &&
 	test_cmp max2.exp max2.out

--- a/t/t2230-job-info-list.t
+++ b/t/t2230-job-info-list.t
@@ -831,6 +831,46 @@ test_expect_success HAVE_JQ 'verify nnodes/ranks/nodelist preserved across resta
 '
 
 #
+# job-info can handle flux-restart events
+#
+# TODO: presently job-info depends on job-manager journal, so it is
+# not possible to test the reload of the job-manager that doesn't also
+# reload job-info.
+#
+
+wait_jobid() {
+        local jobid="$1"
+        local i=0
+        while ! flux job list --states=sched | grep $jobid > /dev/null \
+               && [ $i -lt 50 ]
+        do
+                sleep 0.1
+                i=$((i + 1))
+        done
+        if [ "$i" -eq "50" ]
+        then
+            return 1
+        fi
+        return 0
+}
+
+# to ensure jobs are still in PENDING state, stop queue before
+# reloading job-info & job-manager.  reload job-exec & sched-simple
+# after wait_jobid, b/c we do not want the job to be accidentally
+# executed.
+test_expect_success 'job-info parses flux-restart events' '
+        flux queue stop &&
+        jobid=`flux job submit hostname.json | flux job id` &&
+        fj_wait_event $jobid priority &&
+        flux module unload job-info &&
+        flux module reload job-manager &&
+        flux module load job-info &&
+        wait_jobid $jobid &&
+        flux module reload job-exec &&
+        flux module reload sched-simple
+'
+
+#
 # job list special cases
 #
 

--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -961,6 +961,13 @@ test_expect_success 'cleanup job listing jobs ' '
         done
 '
 
+#
+# invalid job data tests
+#
+# note that these tests should be done last, as the introduction of
+# invalid job data into the KVS could affect tests above.
+#
+
 # Following tests use invalid jobspecs, must load a more permissive validator
 
 ingest_module ()


### PR DESCRIPTION
Support the flux-restart event, generating it in job-manager, parsing it in restarts in job-manager, and handling it in job-info.

For testing purposes, I also add support of a `--count` option in `flux job wait-event`.

Per #3345 (which is really a split off from #3327)

