### PR TITLE
affinity: use comma separated list format for CUDA_VISIBLE_DEVICES

### DIFF
--- a/src/shell/gpubind.c
+++ b/src/shell/gpubind.c
@@ -143,7 +143,7 @@ static int gpubind_init (flux_plugin_t *p,
             return shell_log_errno ("gpubind: flux_plugin_add_handler");
     }
     else {
-        char *ids = idset_encode (gpus, IDSET_FLAG_RANGE);
+        char *ids = idset_encode (gpus, 0);
         flux_shell_setenvf (shell, 1, "CUDA_VISIBLE_DEVICES", "%s", ids);
         free (ids);
     }

--- a/t/t2604-job-shell-affinity.t
+++ b/t/t2604-job-shell-affinity.t
@@ -87,8 +87,8 @@ test_expect_success 'flux-shell: gpu-affinity works by default' '
 	flux mini run -N1 -n2 --dry-run \
 		printenv CUDA_VISIBLE_DEVICES > j.${name} &&
 	cat >${name}.expected <<-EOF  &&
-	0: 0-3
-	1: 0-3
+	0: 0,1,2,3
+	1: 0,1,2,3
 	EOF
 	${FLUX_SHELL} -s -v -r 0 -j j.${name} -R R.gpu 0 &&
 	${FLUX_SHELL} -s -v -r 0 -j j.${name} -R R.gpu 0 | sort -k1,1n \
@@ -100,8 +100,8 @@ test_expect_success 'flux-shell: gpu-affinity=on' '
 	flux mini run -N1 -n2 --dry-run -o gpu-affinity=on \
 		printenv CUDA_VISIBLE_DEVICES > j.${name} &&
 	cat >${name}.expected <<-EOF  &&
-	0: 0-3
-	1: 0-3
+	0: 0,1,2,3
+	1: 0,1,2,3
 	EOF
 	${FLUX_SHELL} -s -v -r 0 -j j.${name} -R R.gpu 0 | sort -k1,1n \
 		> ${name}.out 2>${name}.err &&


### PR DESCRIPTION
Problem: GPU bind uses IDSET for the CUDA_VISIBLE_DEVICES environment
variable. However, hwloc doesn't support this format and this
precludes a nested flux instance from correctly auto-detecting its
allocated GPUs.

Use comma separated list format for this env variable.
Adjust the two test cases that assume the IDSET format.