### PR TITLE
[WIP] job-manager: synchronize queue priority changes to job-info via priority-update event

### DIFF
--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -287,6 +287,9 @@ static struct optparse_option wait_event_opts[] =  {
     { .name = "match-context", .key = 'm', .has_arg = 1, .arginfo = "KEY=VAL",
       .usage = "match key=val in context",
     },
+    { .name = "count", .key = 'c', .has_arg = 1, .arginfo = "COUNT",
+      .usage = "number of events to wait for / match (default 1)",
+    },
     { .name = "quiet", .key = 'q', .has_arg = 0,
       .usage = "Do not output matched event",
     },
@@ -417,7 +420,7 @@ static struct optparse_subcommand subcommands[] = {
       eventlog_opts
     },
     { "wait-event",
-      "[-f text|json] [-T raw|iso|offset] [-t seconds] [-m key=val] "
+      "[-f text|json] [-T raw|iso|offset] [-t seconds] [-m key=val] [-c <num>] "
       "[-p path] [-q] [-v] id event",
       "Wait for an event ",
       cmd_wait_event,
@@ -2578,6 +2581,8 @@ struct wait_event_ctx {
     struct entry_format e;
     char *context_key;
     char *context_value;
+    int count;
+    int match_count;
 };
 
 bool wait_event_test_context (struct wait_event_ctx *ctx, json_t *context)
@@ -2630,7 +2635,9 @@ bool wait_event_test (struct wait_event_ctx *ctx, json_t *event)
             match = true;
     }
 
-    return match;
+    if (match && (++ctx->match_count) == ctx->count)
+        return true;
+    return false;
 }
 
 void wait_event_continuation (flux_future_t *f, void *arg)
@@ -2717,6 +2724,9 @@ int cmd_wait_event (optparse_t *p, int argc, char **argv)
             log_msg_exit ("must specify a context test as key=value");
         *ctx.context_value++ = '\0';
     }
+    ctx.count = optparse_get_int (p, "count", 1);
+    if (ctx.count <= 0)
+        log_msg_exit ("count must be > 0");
 
     if (!(f = flux_job_event_watch (h, ctx.id, ctx.path, 0)))
         log_err_exit ("flux_job_event_watch");

--- a/src/common/libjob/job.h
+++ b/src/common/libjob/job.h
@@ -31,6 +31,12 @@ enum job_admin_priority {
     FLUX_JOB_ADMIN_PRIORITY_MAX = 31,
 };
 
+enum job_queue_priority {
+    FLUX_JOB_QUEUE_PRIORITY_MIN = 0,
+    FLUX_JOB_QUEUE_PRIORITY_DEFAULT = FLUX_JOB_ADMIN_PRIORITY_DEFAULT,
+    FLUX_JOB_QUEUE_PRIORITY_MAX = 4294967295,
+};
+
 enum {
     FLUX_JOBID_ANY = 0xFFFFFFFFFFFFFFFF, // ~(uint64_t)0
 };

--- a/src/modules/job-info/job_state.c
+++ b/src/modules/job-info/job_state.c
@@ -1350,7 +1350,7 @@ static int admin_priority_context_parse (flux_t *h,
         || json_unpack (context, "{ s:i }", "priority", &priority) < 0
         || (priority < FLUX_JOB_ADMIN_PRIORITY_MIN
             || priority > FLUX_JOB_ADMIN_PRIORITY_MAX)) {
-        flux_log (h, LOG_ERR, "%s: priority context invalid: %ju",
+        flux_log (h, LOG_ERR, "%s: admin-priority context invalid: %ju",
                   __FUNCTION__, (uintmax_t)job->id);
         errno = EPROTO;
         return -1;

--- a/src/modules/job-info/job_state.h
+++ b/src/modules/job-info/job_state.h
@@ -67,7 +67,8 @@ struct job {
 
     flux_jobid_t id;
     uint32_t userid;
-    int priority;
+    int admin_priority;
+    int queue_priority;
     double t_submit;
     int flags;
     flux_job_state_t state;

--- a/src/modules/job-info/job_util.c
+++ b/src/modules/job-info/job_util.c
@@ -71,7 +71,7 @@ json_t *job_to_json (struct job *job, json_t *attrs, job_info_error_t *errp)
             val = json_integer (job->userid);
         }
         else if (!strcmp (attr, "priority")) {
-            val = json_integer (job->priority);
+            val = json_integer (job->admin_priority);
         }
         else if (!strcmp (attr, "t_submit")
                  || !strcmp (attr, "t_depend")) {

--- a/src/modules/job-manager/alloc.c
+++ b/src/modules/job-manager/alloc.c
@@ -71,7 +71,7 @@ static void interface_teardown (struct alloc *alloc, char *s, int errnum)
              * so they will automatically send alloc again.
              */
             if (job->alloc_pending) {
-                bool fwd = job->priority > FLUX_JOB_ADMIN_PRIORITY_DEFAULT;
+                bool fwd = job->queue_priority > FLUX_JOB_QUEUE_PRIORITY_DEFAULT;
                 bool cleared = false;
 
                 assert (job->handle == NULL);
@@ -344,7 +344,7 @@ int alloc_request (struct alloc *alloc, struct job *job)
         return -1;
     if (flux_msg_pack (msg, "{s:I s:i s:i s:f}",
                             "id", job->id,
-                            "priority", job->priority,
+                            "priority", job->queue_priority,
                             "userid", job->userid,
                             "t_submit", job->t_submit) < 0)
         goto error;
@@ -381,7 +381,7 @@ static void hello_cb (flux_t *h, flux_msg_handler_t *mh,
         if (job->has_resources) {
             if (!(entry = json_pack ("{s:I s:i s:i s:f}",
                                      "id", job->id,
-                                     "priority", job->priority,
+                                     "priority", job->queue_priority,
                                      "userid", job->userid,
                                      "t_submit", job->t_submit)))
                 goto nomem;
@@ -529,7 +529,7 @@ int alloc_enqueue_alloc_request (struct alloc *alloc, struct job *job)
 {
     assert (job->state == FLUX_JOB_STATE_SCHED);
     if (!job->alloc_queued && !job->alloc_pending) {
-        bool fwd = job->priority > FLUX_JOB_ADMIN_PRIORITY_DEFAULT;
+        bool fwd = job->queue_priority > FLUX_JOB_QUEUE_PRIORITY_DEFAULT;
         assert (job->handle == NULL);
         if (!(job->handle = zlistx_insert (alloc->queue, job, fwd)))
             return -1;
@@ -572,7 +572,7 @@ struct job *alloc_queue_next (struct alloc *alloc)
 /* called from priority_handle_request() */
 void alloc_queue_reorder (struct alloc *alloc, struct job *job)
 {
-    bool fwd = job->priority > FLUX_JOB_ADMIN_PRIORITY_DEFAULT;
+    bool fwd = job->queue_priority > FLUX_JOB_QUEUE_PRIORITY_DEFAULT;
 
     zlistx_reorder (alloc->queue, job->handle, fwd);
 }

--- a/src/modules/job-manager/event.c
+++ b/src/modules/job-manager/event.c
@@ -416,6 +416,17 @@ static int event_admin_priority_context_decode (json_t *context,
     return 0;
 }
 
+static int event_priority_update_context_decode (json_t *context,
+                                                 int *priority)
+{
+    if (json_unpack (context, "{ s:i }", "priority", priority) < 0) {
+        errno = EPROTO;
+        return -1;
+    }
+
+    return 0;
+}
+
 static int event_exception_context_decode (json_t *context,
                                            int *severity)
 {
@@ -479,6 +490,11 @@ int event_job_update (struct job *job, json_t *event)
     else if (!strcmp (name, "admin-priority")) {
         if (event_admin_priority_context_decode (context,
                                                  &job->admin_priority) < 0)
+            goto error;
+    }
+    else if (!strcmp (name, "priority-update")) {
+        if (event_priority_update_context_decode (context,
+                                                  &job->queue_priority) < 0)
             goto error;
     }
     else if (!strcmp (name, "exception")) {

--- a/src/modules/job-manager/event.c
+++ b/src/modules/job-manager/event.c
@@ -320,7 +320,8 @@ int event_job_action (struct event *event, struct job *job)
         case FLUX_JOB_STATE_PRIORITY:
             /* N.B. Priority will be set via a priority plugin call in
              * the future. For the time being, we pass the
-             * administrative priority set via submit.
+             * administrative priority set via submit or
+             * administrative change.
              */
             if (event_job_post_pack (event,
                                      job,
@@ -531,6 +532,15 @@ int event_job_update (struct job *job, json_t *event)
         if (job->state != FLUX_JOB_STATE_CLEANUP)
             goto inval;
         job->state = FLUX_JOB_STATE_INACTIVE;
+    }
+    else if (!strcmp (name, "flux-restart")) {
+        /* The flux-restart event is currently only posted to jobs in
+         * SCHED state since that is the only state transition defined
+         * for the event in RFC21.  In the future, other transitions
+         * may be defined.
+         */
+        if (job->state == FLUX_JOB_STATE_SCHED)
+            job->state = FLUX_JOB_STATE_PRIORITY;
     }
     return 0;
 inval:

--- a/src/modules/job-manager/event.c
+++ b/src/modules/job-manager/event.c
@@ -328,7 +328,7 @@ int event_job_action (struct event *event, struct job *job)
                                      "priority",
                                      0,
                                      "{ s:i }",
-                                     "priority", job->priority) < 0)
+                                     "priority", job->admin_priority) < 0)
                 return -1;
             break;
         case FLUX_JOB_STATE_SCHED:
@@ -458,7 +458,7 @@ int event_job_update (struct job *job, json_t *event)
             goto inval;
         job->t_submit = timestamp;
         if (event_submit_context_decode (context,
-                                         &job->priority,
+                                         &job->admin_priority,
                                          &job->userid,
                                          &job->flags) < 0)
             goto error;
@@ -472,12 +472,13 @@ int event_job_update (struct job *job, json_t *event)
     else if (!strcmp (name, "priority")) {
         if (job->state != FLUX_JOB_STATE_PRIORITY)
             goto inval;
-        if (event_priority_context_decode (context, &job->priority) < 0)
+        if (event_priority_context_decode (context, &job->queue_priority) < 0)
             goto error;
         job->state = FLUX_JOB_STATE_SCHED;
     }
     else if (!strcmp (name, "admin-priority")) {
-        if (event_admin_priority_context_decode (context, &job->priority) < 0)
+        if (event_admin_priority_context_decode (context,
+                                                 &job->admin_priority) < 0)
             goto error;
     }
     else if (!strcmp (name, "exception")) {

--- a/src/modules/job-manager/job.c
+++ b/src/modules/job-manager/job.c
@@ -49,7 +49,8 @@ struct job *job_create (void)
         return NULL;
     job->refcount = 1;
     job->userid = FLUX_USERID_UNKNOWN;
-    job->priority = FLUX_JOB_ADMIN_PRIORITY_DEFAULT;
+    job->admin_priority = FLUX_JOB_ADMIN_PRIORITY_DEFAULT;
+    job->queue_priority = FLUX_JOB_QUEUE_PRIORITY_DEFAULT;
     job->state = FLUX_JOB_STATE_NEW;
     return job;
 }
@@ -117,7 +118,7 @@ int job_comparator (const void *a1, const void *a2)
     const struct job *j2 = a2;
     int rc;
 
-    if ((rc = (-1)*NUMCMP (j1->priority, j2->priority)) == 0)
+    if ((rc = (-1)*NUMCMP (j1->queue_priority, j2->queue_priority)) == 0)
         rc = NUMCMP (j1->id, j2->id);
     return rc;
 }

--- a/src/modules/job-manager/job.h
+++ b/src/modules/job-manager/job.h
@@ -19,7 +19,8 @@
 struct job {
     flux_jobid_t id;
     uint32_t userid;
-    int priority;
+    int admin_priority;
+    int queue_priority;
     double t_submit;
     int flags;
     int eventlog_seq;           // eventlog count / sequence number

--- a/src/modules/job-manager/list.c
+++ b/src/modules/job-manager/list.c
@@ -45,7 +45,7 @@ int list_append_job (json_t *jobs, struct job *job)
                          "userid",
                          job->userid,
                          "priority",
-                         job->priority,
+                         job->admin_priority,
                          "t_submit",
                          job->t_submit,
                          "state",

--- a/src/modules/job-manager/priority.c
+++ b/src/modules/job-manager/priority.c
@@ -113,6 +113,12 @@ void priority_handle_request (flux_t *h,
      * admin_priority */
     if (admin_priority != orig_admin_priority) {
         job->queue_priority = admin_priority;
+        if (event_job_post_pack (ctx->event, job,
+                                 "priority-update",
+                                 0,
+                                 "{ s:i }",
+                                 "priority", job->queue_priority) < 0)
+            goto error;
         alloc_queue_reorder (ctx->alloc, job);
     }
     if (flux_respond (h, msg, NULL) < 0)

--- a/src/modules/job-manager/submit.c
+++ b/src/modules/job-manager/submit.c
@@ -45,7 +45,7 @@ int submit_add_one_job (zhashx_t *active_jobs, zlist_t *newjobs, json_t *o)
         return -1;
     if (json_unpack (o, "{s:I s:i s:i s:f s:i}",
                         "id", &job->id,
-                        "priority", &job->priority,
+                        "priority", &job->admin_priority,
                         "userid", &job->userid,
                         "t_submit", &job->t_submit,
                         "flags", &job->flags) < 0) {
@@ -126,7 +126,7 @@ static int submit_post_event (struct job_manager *ctx, struct job *job)
                                  "submit",
                                  "{ s:i s:i s:i }",
                                  "userid", job->userid,
-                                 "priority", job->priority,
+                                 "priority", job->admin_priority,
                                  "flags", job->flags);
     if (!entry)
         goto error;

--- a/src/modules/job-manager/test/job.c
+++ b/src/modules/job-manager/test/job.c
@@ -27,7 +27,8 @@ void test_create (void)
     ok (job->refcount == 1,
         "job_create set refcount to 1");
     ok (job->id == 0
-        && job->priority == FLUX_JOB_ADMIN_PRIORITY_DEFAULT
+        && job->admin_priority == FLUX_JOB_ADMIN_PRIORITY_DEFAULT
+        && job->queue_priority == FLUX_JOB_QUEUE_PRIORITY_DEFAULT
         && job->state == FLUX_JOB_STATE_NEW
         && job->userid == FLUX_USERID_UNKNOWN
         && job->t_submit == 0
@@ -128,8 +129,10 @@ void test_create_from_eventlog (void)
         "job_create_from_eventlog log=(submit) set userid from submit");
     ok (job->flags == 42,
         "job_create_from_eventlog log=(submit) set flags from submit");
-    ok (job->priority == 16,
-        "job_create_from_eventlog log=(submit) set priority from submit");
+    ok (job->admin_priority == 16,
+        "job_create_from_eventlog log=(submit) set admin priority from submit");
+    ok (job->queue_priority == FLUX_JOB_QUEUE_PRIORITY_DEFAULT,
+        "job_create_from_eventlog log=(submit) queue priority is default");
     ok (job->t_submit == 42.2,
         "job_create_from_eventlog log=(submit) set t_submit from submit");
     ok (job->state == FLUX_JOB_STATE_DEPEND,
@@ -144,8 +147,11 @@ void test_create_from_eventlog (void)
         "job_create_from_eventlog log=(submit+admin-pri) set id from param");
     ok (job->userid == 66,
         "job_create_from_eventlog log=(submit+admin-pri) set userid from submit");
-    ok (job->priority == 1,
-        "job_create_from_eventlog log=(submit+admin-pri) set priority from priority");
+    ok (job->admin_priority == 1,
+        "job_create_from_eventlog log=(submit+admin-pri) set "
+        "admin priority from admin-priority");
+    ok (job->queue_priority == FLUX_JOB_QUEUE_PRIORITY_DEFAULT,
+        "job_create_from_eventlog log=(submit+admin-pri) queue priority is default");
     ok (job->t_submit == 42.2,
         "job_create_from_eventlog log=(submit+admin-pri) set t_submit from submit");
     ok (!job->alloc_pending
@@ -164,8 +170,12 @@ void test_create_from_eventlog (void)
         "job_create_from_eventlog log=(submit+depend+priority) set id from param");
     ok (job->userid == 66,
         "job_create_from_eventlog log=(submit+depend+priority) set userid from submit");
-    ok (job->priority == 1,
-        "job_create_from_eventlog log=(submit+depend+priority) set priority from priority");
+    ok (job->admin_priority == 16,
+        "job_create_from_eventlog log=(submit+depend+priority) set "
+        "admin priority from submit");
+    ok (job->queue_priority == 1,
+        "job_create_from_eventlog log=(submit+depend+priority) set "
+        "queue priority from priority");
     ok (job->t_submit == 42.2,
         "job_create_from_eventlog log=(submit+depend+priority) set t_submit from submit");
     ok (!job->alloc_pending
@@ -182,8 +192,8 @@ void test_create_from_eventlog (void)
         BAIL_OUT ("job_create_from_eventlog log=(submit+ex0) failed");
     ok (job->userid == 66,
         "job_create_from_eventlog log=(submit+ex0) set userid from submit");
-    ok (job->priority == 16,
-        "job_create_from_eventlog log=(submit+ex0) set priority from submit");
+    ok (job->admin_priority == 16,
+        "job_create_from_eventlog log=(submit+ex0) set admin priority from submit");
     ok (job->t_submit == 42.2,
         "job_create_from_eventlog log=(submit+ex0) set t_submit from submit");
     ok (!job->alloc_pending

--- a/src/modules/job-manager/test/job.c
+++ b/src/modules/job-manager/test/job.c
@@ -66,26 +66,26 @@ const char *test_input[] = {
     "{\"timestamp\":42.3,\"name\":\"admin-priority\","
      "\"context\":{\"userid\":42,\"priority\":1}}\n",
 
-    /* 3 */
+    /* 2 */
     "{\"timestamp\":42.2,\"name\":\"submit\","
      "\"context\":{\"userid\":66,\"priority\":16,\"flags\":42}}\n"
     "{\"timestamp\":42.3,\"name\":\"depend\"}\n"
     "{\"timestamp\":42.4,\"name\":\"priority\","
      "\"context\":{\"priority\":1}}\n",
 
-    /* 4 */
+    /* 3 */
     "{\"timestamp\":42.2,\"name\":\"submit\","
      "\"context\":{\"userid\":66,\"priority\":16,\"flags\":42}}\n"
     "{\"timestamp\":42.3,\"name\":\"exception\","
      "\"context\":{\"type\":\"cancel\",\"severity\":0,\"userid\":42}}\n",
 
-    /* 5 */
+    /* 4 */
     "{\"timestamp\":42.2,\"name\":\"submit\","
      "\"context\":{\"userid\":66,\"priority\":16,\"flags\":42}}\n"
     "{\"timestamp\":42.3,\"name\":\"exception\","
      "\"context\":{\"type\":\"meep\",\"severity\":1,\"userid\":42}}\n",
 
-    /* 6 */
+    /* 5 */
     "{\"timestamp\":42.2,\"name\":\"submit\","
      "\"context\":{\"userid\":66,\"priority\":16,\"flags\":42}}\n"
     "{\"timestamp\":42.3,\"name\":\"depend\"}\n"
@@ -93,10 +93,10 @@ const char *test_input[] = {
      "\"context\":{\"priority\":100}}\n"
     "{\"timestamp\":42.5,\"name\":\"alloc\"}\n",
 
-    /* 7 */
+    /* 6 */
     "{\"timestamp\":42.3,\"name\":\"alloc\"}\n",
 
-    /* 8 */
+    /* 7 */
     "{\"timestamp\":42.2,\"name\":\"submit\","
      "\"context\":{\"userid\":66,\"priority\":16,\"flags\":42}}\n"
     "{\"timestamp\":42.3,\"name\":\"depend\"}\n"

--- a/src/modules/job-manager/test/submit.c
+++ b/src/modules/job-manager/test/submit.c
@@ -43,7 +43,7 @@ void single_job_check (zhashx_t *active_jobs)
         "hash contains one job");
     ok ((job = zlist_head (newjobs)) != NULL,
         "newjobs contains one job");
-    ok (job->id == 1 && job->priority == 10 && job->userid == 42
+    ok (job->id == 1 && job->admin_priority == 10 && job->userid == 42
         && job->t_submit == 1.0 && job->flags == 0,
         "struct job was properly decoded");
 

--- a/t/t2202-job-manager.t
+++ b/t/t2202-job-manager.t
@@ -185,6 +185,21 @@ test_expect_success 'job-manager: queue was successfully reconstructed' '
 	test_cmp list10_reordered.out list_reload.out
 '
 
+check_eventlog_restart_events() {
+	for jobid in $(cut -f1 <list_reload.out); do
+		if ! flux job wait-event -t 20 -c 1 ${jobid} flux-restart \
+		   || ! flux job wait-event -t 20 -c 2 ${jobid} priority
+		then
+			return 1
+		fi
+	done
+	return 0
+}
+
+test_expect_success 'job-manager: eventlog indicates restart & priority event' '
+	check_eventlog_restart_events
+'
+
 test_expect_success HAVE_JQ 'job-manager: max_jobid has not changed' '
 	${RPC} job-manager.getinfo | jq .max_jobid >max2.out &&
 	test_cmp max2.exp max2.out

--- a/t/t2230-job-info-list.t
+++ b/t/t2230-job-info-list.t
@@ -1004,6 +1004,30 @@ test_expect_success HAVE_JQ 'list-inactive request with invalid input fails with
 	test_cmp ${name}.expected ${name}.out
 '
 
+#
+# stress test
+#
+
+wait_jobs_finish() {
+        local i=0
+        while ([ "$(flux job list | wc -l)" != "0" ]) \
+              && [ $i -lt 1000 ]
+        do
+                sleep 0.1
+                i=$((i + 1))
+        done
+        if [ "$i" -eq "1000" ]
+        then
+            return 1
+        fi
+        return 0
+}
+
+test_expect_success LONGTEST 'stress job-info.list-id' '
+        flux python ${FLUX_SOURCE_DIR}/t/job-info/list-id.py 500 &&
+        wait_jobs_finish
+'
+
 # invalid job data tests
 #
 # to avoid potential racyness, wait up to 5 seconds for job to appear
@@ -1015,6 +1039,10 @@ test_expect_success HAVE_JQ 'list-inactive request with invalid input fails with
 # is invalid in these tests and how job-info parses the invalid data.
 # Different parsing errors could have some fields initialized but
 # others not.
+#
+# note that these tests should be done last, as the introduction of
+# invalid job data into the KVS could affect tests above.
+#
 
 # Following tests use invalid jobspecs, must load a more permissive validator
 
@@ -1133,27 +1161,4 @@ test_expect_success HAVE_JQ 'flux job list works on racy annotations' '
         cat list_racy_annotation.out | $jq -e ".annotations"
 '
 
-#
-# stress test
-#
-
-wait_jobs_finish() {
-        local i=0
-        while ([ "$(flux job list | wc -l)" != "0" ]) \
-              && [ $i -lt 1000 ]
-        do
-                sleep 0.1
-                i=$((i + 1))
-        done
-        if [ "$i" -eq "1000" ]
-        then
-            return 1
-        fi
-        return 0
-}
-
-test_expect_success LONGTEST 'stress job-info.list-id' '
-        flux python ${FLUX_SOURCE_DIR}/t/job-info/list-id.py 500 &&
-        wait_jobs_finish
-'
 test_done

--- a/t/t2232-job-info-eventlog-watch.t
+++ b/t/t2232-job-info-eventlog-watch.t
@@ -256,6 +256,46 @@ test_expect_success 'flux job wait-event -p times out on no event (live job)' '
         flux job cancel $jobid
 '
 
+test_expect_success NO_CHAIN_LINT 'flux job wait-event --count=0 errors' '
+        test_must_fail fj_wait_event --count=0 1234 foobar 2> count.err &&
+        grep "count must be" count.err
+'
+
+test_expect_success NO_CHAIN_LINT 'flux job wait-event --count=1 works' '
+        jobid=$(submit_job) &&
+        fj_wait_event --count=1 ${jobid} clean
+'
+
+test_expect_success NO_CHAIN_LINT 'flux job wait-event --count=2 works' '
+        jobid=$(submit_job_wait) &&
+        kvsdir=$(flux job id --to=kvs $jobid) &&
+	flux kvs eventlog append ${kvsdir}.eventlog foobar &&
+        test_must_fail flux job wait-event --timeout=0.2 --count=2 ${jobid} foobar &&
+	flux kvs eventlog append ${kvsdir}.eventlog foobar &&
+        fj_wait_event --count=2 ${jobid} foobar &&
+        flux job cancel $jobid
+'
+
+test_expect_success NO_CHAIN_LINT 'flux job wait-event --count=2 and context match works' '
+        jobid=$(submit_job_wait) &&
+        kvsdir=$(flux job id --to=kvs $jobid) &&
+	flux kvs eventlog append ${kvsdir}.eventlog foobar "{\"foo\":\"bar\"}" &&
+        test_must_fail flux job wait-event --timeout=0.2 --count=2 --match-context="foo=\"bar\"" ${jobid} foobar &&
+	flux kvs eventlog append ${kvsdir}.eventlog foobar "{\"foo\":\"bar\"}" &&
+        fj_wait_event --count=2 --match-context="foo=\"bar\"" ${jobid} foobar &&
+        flux job cancel $jobid
+'
+
+test_expect_success NO_CHAIN_LINT 'flux job wait-event --count=2 and invalid context match fails' '
+        jobid=$(submit_job_wait) &&
+        kvsdir=$(flux job id --to=kvs $jobid) &&
+	flux kvs eventlog append ${kvsdir}.eventlog foobar "{\"foo\":\"bar\"}" &&
+        test_must_fail flux job wait-event --timeout=0.2 --count=2 --match-context="foo=\"dar\"" ${jobid} foobar &&
+	flux kvs eventlog append ${kvsdir}.eventlog foobar "{\"foo\":\"bar\"}" &&
+        test_must_fail flux job wait-event --timeout=0.2 --count=2 --match-context="foo=\"dar\"" ${jobid} foobar &&
+        flux job cancel $jobid
+'
+
 # In order to test watching a guest event log that does not yet exist,
 # we will start a job that will take up all resources.  Then start
 # another job, which we will watch and know it hasn't started running

--- a/t/t2234-job-info-list-update.t
+++ b/t/t2234-job-info-list-update.t
@@ -153,7 +153,7 @@ test_expect_success 'submit jobs for job list testing' '
         wait_states
 '
 
-# Note: "running" = "run" & "cleanup", we also test just "run" state
+# Note: "running" = "run" | "cleanup", we also test just "run" state
 # since we happen to know all these jobs are in the "run" state given
 # checks above
 
@@ -167,7 +167,7 @@ test_expect_success HAVE_JQ 'flux job list inactive jobs in completed order' '
         test_cmp list_inactive.out inactive.ids
 '
 
-# Note: "pending" = "depend" & "sched", we also test just "sched"
+# Note: "pending" = "depend" | "sched", we also test just "sched"
 # state since we happen to know all these jobs are in the "sched"
 # state given checks above
 

--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -944,6 +944,13 @@ test_expect_success 'cleanup job listing jobs ' '
         done
 '
 
+#
+# invalid job data tests
+#
+# note that these tests should be done last, as the introduction of
+# invalid job data into the KVS could affect tests above.
+#
+
 # Following tests use invalid jobspecs, must load a more permissive validator
 
 ingest_module ()


### PR DESCRIPTION
Per discussion in #3342.  Build on top of PR #3371 

- First add appropritae FLUX_JOB_QUEUE_PRIORITY_MIN/MAX/DEFAULT enums.  I just picked the default to be the same as the ADMIN_PRIORITY_DEFAULT, since admin priority == queue priority at the moment.

- Second, a bunch of cleanup in job-manager / job-info, to differentiate between admin/queue priority in events and storing admin vs queue priority in job data structures.  This actually breaks some tests, which are solved by ...

- Three, introduce `priority-update` event to advertise new queue priority (RFC21 update for this coming as well).