### PR TITLE
github: fix missing docker tag in matrix builds

### DIFF
--- a/src/test/generate-matrix.py
+++ b/src/test/generate-matrix.py
@@ -45,9 +45,9 @@ class BuildMatrix:
                 tag += f"-{self.tag}"
             env["DOCKER_TAG"] = tag
             command += f" --tag={tag}"
-            return True
+            return True, command
 
-        return False
+        return False, command
 
     def env_add_s3(self, args, env):
         """Add necessary environment and args to test content-s3 module"""
@@ -88,7 +88,7 @@ class BuildMatrix:
 
         if docker_tag:
             #  Only export docker_tag if this is main branch or a tag:
-            docker_tag = self.create_docker_tag(image, env, command)
+            docker_tag, command = self.create_docker_tag(image, env, command)
 
         if test_s3:
             args = self.env_add_s3(args, env)


### PR DESCRIPTION
Problem: A missing --tag=NAME argument to docker-run-checks.sh
caused the push of new docker images on main branch and tags to
fail.

Ensure the --tag argument is supplied when branch is "master" or
we are building a tag, and docker_tag=True.