### PR TITLE
small fixes: resource memory leak, improve error messages, check size of int

### DIFF
--- a/config/x_ac_jansson.m4
+++ b/config/x_ac_jansson.m4
@@ -13,6 +13,12 @@ AC_DEFUN([X_AC_JANSSON], [
         AC_MSG_ERROR([json_int_t must be 64 bits for flux to be built])
     ])
 
+    AX_COMPILE_CHECK_SIZEOF(int)
+
+    AS_VAR_IF([ac_cv_sizeof_int],[2],[
+        AC_MSG_ERROR([flux cannot be built on a system with 16 bit ints])
+    ])
+
     LIBS="$ac_save_LIBS"
     CFLAGS="$ac_save_CFLAGS"
   ]

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -1692,7 +1692,7 @@ static void valid_or_exit_for_debug (struct attach_ctx *ctx)
         && state != FLUX_JOB_STATE_PRIORITY
         && state != FLUX_JOB_STATE_SCHED
         && state != FLUX_JOB_STATE_RUN) {
-        log_msg_exit ("cannot debug job that isn't running");
+        log_msg_exit ("cannot debug job that has finished running");
     }
 
     return;

--- a/src/modules/resource/inventory.c
+++ b/src/modules/resource/inventory.c
@@ -694,6 +694,8 @@ static void resource_reload (flux_t *h,
     if (inv->R) {
         json_decref (inv->R);
         inv->R = NULL;
+        free (inv->method);
+        inv->method = NULL;
     }
     if (inventory_put (inv, resobj, "reload") < 0)
         goto error;


### PR DESCRIPTION
This PR two minor bugs:
- resource module memory leak on `flux module reload` (my bad!)
- rewords a misleading `flux job` error message when debugging

Also, refuse to build on Super Nintendo.  I'm sure there will be disappointment.