### PR TITLE
shell: ensure TMPDIR exists for all jobs

### DIFF
--- a/src/shell/Makefile.am
+++ b/src/shell/Makefile.am
@@ -24,7 +24,8 @@ dist_shelllua_SCRIPTS = \
 	lua.d/mvapich.lua \
 	lua.d/intel_mpi.lua \
 	lua.d/openmpi.lua \
-	lua.d/spectrum.lua
+	lua.d/spectrum.lua \
+	lua.d/tmpdir.lua
 
 noinst_LTLIBRARIES = \
 	libshell.la \

--- a/src/shell/lua.d/tmpdir.lua
+++ b/src/shell/lua.d/tmpdir.lua
@@ -1,0 +1,21 @@
+-------------------------------------------------------------
+-- Copyright 2020 Lawrence Livermore National Security, LLC
+-- (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+--
+-- This file is part of the Flux resource manager framework.
+-- For details, see https://github.com/flux-framework.
+--
+-- SPDX-License-Identifier: LGPL-3.0
+-------------------------------------------------------------
+--
+-- Ensure TMPDIR exists if it is set in job environment
+--
+local tmpdir = shell.getenv ("TMPDIR")
+if tmpdir then
+    local rc, exit, signal = os.execute ("umask 077; mkdir -p "..tmpdir)
+    if not rc then
+        shell.log_error ("Failed to create TMPDIR="..tmpdir)
+    end
+end
+
+

--- a/t/t2602-job-shell.t
+++ b/t/t2602-job-shell.t
@@ -271,5 +271,9 @@ test_expect_success 'job-shell: cover invalid buffer type' '
 	flux job attach $id 2> stderr-invalid-buffering.out &&
 	grep "invalid buffer type" stderr-invalid-buffering.out
 '
+test_expect_success 'job-shell: creates missing TMPDIR by default' '
+    TMPDIR=$(pwd)/mytmpdir flux mini run true &&
+    test -d mytmpdir
+'
 
 test_done


### PR DESCRIPTION
Add a default Lua plugin that ensures TMPDIR exists for all jobs.

Any error from `mkdir` will be logged, but the actual output of the command will go to the exec system and `flux dmesg` output. This will be fixed in a future PR which sends output from job shell to a special exec system per-job logfile. (TBD)