### PR TITLE
job-exec: log early shell/imp errors

### DIFF
--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -68,10 +68,10 @@ libflux_core_la_LIBADD = \
 	$(builddir)/libsubprocess/libsubprocess.la \
 	libflux-internal.la
 libflux_core_la_LDFLAGS = \
-        -Wl,--version-script=$(srcdir)/libflux-core.map \
+	-Wl,--version-script=$(srcdir)/libflux-core.map \
 	-version-info @LIBFLUX_CORE_VERSION_INFO@ \
-        -shared -export-dynamic --disable-static \
-        $(san_ld_zdef_flag)
+	-shared -export-dynamic --disable-static \
+	$(san_ld_zdef_flag)
 
 libflux_optparse_la_SOURCES =
 libflux_optparse_la_LIBADD = \
@@ -80,7 +80,7 @@ libflux_optparse_la_LIBADD = \
 	$(builddir)/libutil/fsd.lo \
 	$(ZMQ_LIBS) $(LIBUUID_LIBS) $(LIBPTHREAD)
 libflux_optparse_la_LDFLAGS = \
-        -Wl,--version-script=$(srcdir)/libflux-optparse.map \
+	-Wl,--version-script=$(srcdir)/libflux-optparse.map \
 	-version-info @LIBFLUX_OPTPARSE_VERSION_INFO@ \
 	-shared -export-dynamic --disable-static \
 	$(san_ld_zdef_flag)
@@ -90,7 +90,7 @@ libflux_idset_la_LIBADD = \
 	$(builddir)/libidset/libidset.la \
 	$(builddir)/libutil/veb.lo
 libflux_idset_la_LDFLAGS = \
-        -Wl,--version-script=$(srcdir)/libflux-idset.map \
+	-Wl,--version-script=$(srcdir)/libflux-idset.map \
 	-version-info @LIBFLUX_IDSET_VERSION_INFO@ \
 	-shared -export-dynamic --disable-static \
 	$(san_ld_zdef_flag)
@@ -101,7 +101,7 @@ libflux_schedutil_la_LIBADD = \
 	libflux-core.la \
 	$(JANSSON_LIBS)
 libflux_schedutil_la_LDFLAGS = \
-        -Wl,--version-script=$(srcdir)/libflux-schedutil.map \
+	-Wl,--version-script=$(srcdir)/libflux-schedutil.map \
 	-version-info @LIBFLUX_SCHEDUTIL_VERSION_INFO@ \
 	-shared -export-dynamic --disable-static \
 	$(san_ld_zdef_flag)
@@ -110,7 +110,7 @@ libflux_hostlist_la_SOURCES =
 libflux_hostlist_la_LIBADD = \
 	$(builddir)/libhostlist/libhostlist.la
 libflux_hostlist_la_LDFLAGS = \
-    -Wl,--version-script=$(srcdir)/libflux-hostlist.map \
+	-Wl,--version-script=$(srcdir)/libflux-hostlist.map \
 	-version-info @LIBFLUX_HOSTLIST_VERSION_INFO@ \
 	-shared -export-dynamic --disable-static \
 	$(san_ld_zdef_flag)
@@ -120,7 +120,7 @@ libpmi_la_LIBADD = \
 	$(builddir)/libpmi/libpmi_client.la \
 	$(builddir)/libutil/aux.lo
 libpmi_la_LDFLAGS = \
-        -Wl,--version-script=$(srcdir)/libpmi.map \
+	-Wl,--version-script=$(srcdir)/libpmi.map \
 	-version-info 0:0:0 \
 	-Wl,--defsym=flux_pmi_library=1 \
 	-shared -export-dynamic --disable-static \
@@ -131,7 +131,7 @@ libpmi2_la_LIBADD = \
 	$(builddir)/libpmi/libpmi_client.la \
 	$(builddir)/libutil/aux.lo
 libpmi2_la_LDFLAGS = \
-        -Wl,--version-script=$(srcdir)/libpmi2.map \
+	-Wl,--version-script=$(srcdir)/libpmi2.map \
 	-version-info 0:0:0 \
 	-Wl,--defsym=flux_pmi_library=1 \
 	-shared -export-dynamic --disable-static \

--- a/src/common/libeventlog/Makefile.am
+++ b/src/common/libeventlog/Makefile.am
@@ -12,13 +12,14 @@ AM_CPPFLAGS = \
 	$(ZMQ_CFLAGS)
 
 noinst_LTLIBRARIES = libeventlog.la
-fluxinclude_HEADERS = eventlog.h
-libeventlog_la_SOURCES = eventlog.c
+libeventlog_la_SOURCES = \
+	eventlog.h \
+	eventlog.c
 
 libeventlog_la_CPPFLAGS = \
 	$(AM_CPPFLAGS)
 libeventlog_la_LDFLAGS = \
-	-avoid-version -module -shared -export-dynamic \
+	-avoid-version \
 	$(AM_LDFLAGS)
 
 

--- a/src/common/libeventlog/Makefile.am
+++ b/src/common/libeventlog/Makefile.am
@@ -14,14 +14,15 @@ AM_CPPFLAGS = \
 noinst_LTLIBRARIES = libeventlog.la
 libeventlog_la_SOURCES = \
 	eventlog.h \
-	eventlog.c
+	eventlog.c \
+	eventlogger.h \
+	eventlogger.c
 
 libeventlog_la_CPPFLAGS = \
 	$(AM_CPPFLAGS)
 libeventlog_la_LDFLAGS = \
 	-avoid-version \
 	$(AM_LDFLAGS)
-
 
 TESTS = test_eventlog.t
 

--- a/src/common/libeventlog/eventlogger.c
+++ b/src/common/libeventlog/eventlogger.c
@@ -89,7 +89,7 @@ static void eventlog_batch_error (struct eventlog_batch *batch, int errnum)
         return;
     entry = zlist_first (batch->entries);
     while (entry) {
-        (*ev->ops.err) (ev, errnum, entry);
+        (*ev->ops.err) (ev, ev->arg, errnum, entry);
         entry = zlist_next (batch->entries);
     }
 }

--- a/src/common/libeventlog/eventlogger.c
+++ b/src/common/libeventlog/eventlogger.c
@@ -263,6 +263,37 @@ out:
     return rc;
 }
 
+int eventlogger_append_vpack (struct eventlogger *ev,
+                              int flags,
+                              const char *path,
+                              const char *name,
+                              const char *fmt,
+                              va_list ap)
+{
+    int rc;
+    json_t *entry = NULL;
+
+    if (!(entry = eventlog_entry_vpack (0., name, fmt, ap)))
+        return -1;
+    rc = eventlogger_append_entry (ev, flags, path, entry);
+    json_decref (entry);
+    return rc;
+}
+
+int eventlogger_append_pack (struct eventlogger *ev,
+                             int flags,
+                             const char *path,
+                             const char *name,
+                             const char *fmt, ...)
+{
+    int rc = -1;
+    va_list ap;
+    va_start (ap, fmt);
+    rc = eventlogger_append_vpack (ev, flags, path, name, fmt, ap);
+    va_end (ap);
+    return rc;
+}
+
 int eventlogger_flush (struct eventlogger *ev)
 {
     int rc = -1;

--- a/src/common/libeventlog/eventlogger.c
+++ b/src/common/libeventlog/eventlogger.c
@@ -15,7 +15,7 @@
 #include <czmq.h>
 #include <flux/core.h>
 
-#include "src/common/libeventlog/eventlog.h"
+#include "eventlog.h"
 #include "eventlogger.h"
 
 struct eventlog_batch {

--- a/src/common/libeventlog/eventlogger.h
+++ b/src/common/libeventlog/eventlogger.h
@@ -8,8 +8,8 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
-#ifndef FLUX_SHELL_EVENTLOGGER_H
-#define FLUX_SHELL_EVENTLOGGER_H
+#ifndef HAVE_FLUX_EVENTLOGGER_H
+#define HAVE_FLUX_EVENTLOGGER_H
 
 #include <flux/core.h>
 #include <jansson.h>
@@ -66,4 +66,4 @@ int eventlogger_flush (struct eventlogger *ev);
 }
 #endif
 
-#endif /* !FLUX_SHELL_EVENTLOGGER_H */
+#endif /* !HAVE_FLUX_EVENTLOGGER_H */

--- a/src/common/libeventlog/eventlogger.h
+++ b/src/common/libeventlog/eventlogger.h
@@ -11,6 +11,7 @@
 #ifndef HAVE_FLUX_EVENTLOGGER_H
 #define HAVE_FLUX_EVENTLOGGER_H
 
+#include <stdarg.h>
 #include <flux/core.h>
 #include <jansson.h>
 
@@ -58,6 +59,19 @@ int eventlogger_append_entry (struct eventlogger *ev,
                               int flags,
                               const char *path,
                               json_t *entry);
+
+int eventlogger_append_vpack (struct eventlogger *ev,
+                              int flags,
+                              const char *path,
+                              const char *name,
+                              const char *fmt,
+                              va_list ap);
+
+int eventlogger_append_pack (struct eventlogger *ev,
+                             int flags,
+                             const char *path,
+                             const char *name,
+                             const char *fmt, ...);
 
 int eventlogger_set_commit_timeout (struct eventlogger *ev, double timeout);
 

--- a/src/common/libeventlog/eventlogger.h
+++ b/src/common/libeventlog/eventlogger.h
@@ -22,6 +22,7 @@ struct eventlogger;
 
 typedef void (*eventlogger_state_f) (struct eventlogger *ev, void *arg);
 typedef void (*eventlogger_err_f) (struct eventlogger *ev,
+                                   void *arg,
                                    int err,
                                    json_t *entry);
 

--- a/src/common/libeventlog/eventlogger.h
+++ b/src/common/libeventlog/eventlogger.h
@@ -77,6 +77,8 @@ int eventlogger_set_commit_timeout (struct eventlogger *ev, double timeout);
 
 int eventlogger_flush (struct eventlogger *ev);
 
+flux_future_t *eventlogger_commit (struct eventlogger *ev);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/common/libeventlog/eventlogger.h
+++ b/src/common/libeventlog/eventlogger.h
@@ -47,6 +47,10 @@ struct eventlogger *eventlogger_create (flux_t *h,
                                         struct eventlogger_ops *ops,
                                         void *arg);
 
+/*  Set eventlogger namespace
+ */
+int eventlogger_setns (struct eventlogger *ev, const char *ns);
+
 void eventlogger_destroy (struct eventlogger *ev);
 
 int eventlogger_append (struct eventlogger *ev,

--- a/src/modules/job-exec/exec.c
+++ b/src/modules/job-exec/exec.c
@@ -146,10 +146,17 @@ static void complete_cb (struct bulk_exec *exec, void *arg)
 static void output_cb (struct bulk_exec *exec, flux_subprocess_t *p,
                        const char *stream,
                        const char *data,
-                       int data_len,
+                       int len,
                        void *arg)
 {
     struct jobinfo *job = arg;
+    const char *cmd = flux_cmd_arg (flux_subprocess_get_cmd (p), 0);
+    jobinfo_log_output (job,
+                        flux_subprocess_rank (p),
+                        basename (cmd),
+                        stream,
+                        data,
+                        len);
     flux_log (job->h, LOG_INFO, "%ju: %d: %s: %s",
                       (uintmax_t) job->id,
                       flux_subprocess_rank (p),

--- a/src/modules/job-exec/exec.c
+++ b/src/modules/job-exec/exec.c
@@ -327,13 +327,6 @@ static int exec_cancel (struct jobinfo *job)
     return bulk_exec_cancel (exec);
 }
 
-static int exec_cleanup (struct jobinfo *job, const struct idset *idset)
-{
-    /* No epilog supported */
-    jobinfo_cleanup_complete (job, idset, 0);
-    return 0;
-}
-
 static void exec_exit (struct jobinfo *job)
 {
     struct bulk_exec *exec = job->data;
@@ -399,7 +392,6 @@ struct exec_implementation bulkexec = {
     .start =    exec_start,
     .kill =     exec_kill,
     .cancel =   exec_cancel,
-    .cleanup =  exec_cleanup
 };
 
 /* vi: ts=4 sw=4 expandtab

--- a/src/modules/job-exec/exec.c
+++ b/src/modules/job-exec/exec.c
@@ -157,10 +157,6 @@ static void output_cb (struct bulk_exec *exec, flux_subprocess_t *p,
                         stream,
                         data,
                         len);
-    flux_log (job->h, LOG_INFO, "%ju: %d: %s: %s",
-                      (uintmax_t) job->id,
-                      flux_subprocess_rank (p),
-                      stream, data);
 }
 
 static void error_cb (struct bulk_exec *exec, flux_subprocess_t *p, void *arg)

--- a/src/modules/job-exec/job-exec.c
+++ b/src/modules/job-exec/job-exec.c
@@ -377,7 +377,6 @@ static void jobinfo_fatal_verror (struct jobinfo *job, int errnum,
         msg [msglen-2] = '+';
         msg [msglen-1] = '\0';
     }
-    jobinfo_emit_event_pack_nowait (job, "exception", "{ s:s }", "note", msg);
     /* If exception_in_progress set, then no need to respond with another
      *  exception back to job manager. O/w, DO respond to job-manager
      *  and set exception-in-progress.

--- a/src/modules/job-exec/job-exec.h
+++ b/src/modules/job-exec/job-exec.h
@@ -114,6 +114,15 @@ void jobinfo_tasks_complete (struct jobinfo *job,
 void jobinfo_fatal_error (struct jobinfo *job, int errnum,
                           const char *fmt, ...);
 
+/* Append a log output message to exec.eventlog for job
+ */
+void jobinfo_log_output (struct jobinfo *job,
+                         int rank,
+                         const char *component,
+                         const char *stream,
+                         const char *data,
+                         int len);
+
 #endif /* !HAVE_JOB_EXEC_EXEC_H */
 
 /* vi: ts=4 sw=4 expandtab

--- a/src/modules/job-exec/job-exec.h
+++ b/src/modules/job-exec/job-exec.h
@@ -76,6 +76,8 @@ struct jobinfo {
 
     int                   wait_status;
 
+    struct eventlogger *  ev;           /* event batcher */
+
     double                kill_timeout; /* grace time between sigterm,kill */
     flux_watcher_t       *kill_timer;
     flux_watcher_t       *expiration_timer;

--- a/src/modules/job-exec/job-exec.h
+++ b/src/modules/job-exec/job-exec.h
@@ -42,7 +42,6 @@ struct jobinfo;
  *
  *   - cancel:  cancel any pending work (i.e. shells yet to be executed)
  *
- *   - cleanup: Initiate any cleanup (epilog) on ranks.
  */
 struct exec_implementation {
     const char *name;
@@ -52,7 +51,6 @@ struct exec_implementation {
     int  (*start)   (struct jobinfo *job);
     int  (*kill)    (struct jobinfo *job, int signum);
     int  (*cancel)  (struct jobinfo *job);
-    int  (*cleanup) (struct jobinfo *job, const struct idset *ranks);
 };
 
 /*  Exec job information */
@@ -109,15 +107,7 @@ void jobinfo_tasks_complete (struct jobinfo *job,
                              const struct idset *ranks,
                              int wait_status);
 
-/* Notify job-exec that ranks in idset `ranks` have finished epilog,
- *  and resources can be released
- */
-void jobinfo_cleanup_complete (struct jobinfo *job,
-                               const struct idset *ranks,
-                               int rc);
-
-
-/* Notify job-exec of fatal error. Triggers kill/cleanup.
+/* Notify job-exec of fatal error. Triggers kill/finalize.
  */
 void jobinfo_fatal_error (struct jobinfo *job, int errnum,
                           const char *fmt, ...);

--- a/src/modules/job-exec/testexec.c
+++ b/src/modules/job-exec/testexec.c
@@ -25,7 +25,6 @@
  *
  * {
  *   "run_duration":s,      - alternate/override attributes.system.duration
- *   "cleanup_duration":s   - enable a fake job epilog and set its duration
  *   "wait_status":i        - report this value as status in the "finish" resp
  *   "mock_exception":s     - mock an exception during this phase of job
  *                             execution (currently "init" and "run")
@@ -43,7 +42,6 @@
 struct testconf {
     bool                  enabled;          /* test execution enabled       */
     double                run_duration;     /* duration of fake job in sec  */
-    double                cleanup_duration; /* if > 0., duration of epilog  */
     int                   wait_status;      /* reported status for "finish" */
     const char *          mock_exception;   /* fake excetion at this site   */
 };
@@ -82,14 +80,12 @@ static double jobspec_duration (flux_t *h, json_t *jobspec)
 
 static int init_testconf (flux_t *h, struct testconf *conf, json_t *jobspec)
 {
-    const char *tclean = NULL;
     const char *trun = NULL;
     json_t *test = NULL;
     json_error_t err;
 
     /* get/set defaults */
     conf->run_duration = jobspec_duration (h, jobspec);
-    conf->cleanup_duration = -1.;
     conf->wait_status = 0;
     conf->mock_exception = NULL;
     conf->enabled = false;
@@ -101,9 +97,8 @@ static int init_testconf (flux_t *h, struct testconf *conf, json_t *jobspec)
         return 0;
     conf->enabled = true;
     if (json_unpack_ex (test, &err, 0,
-                        "{s?s s?s s?i s?s}",
+                        "{s?s s?i s?s}",
                         "run_duration", &trun,
-                        "cleanup_duration", &tclean,
                         "wait_status", &conf->wait_status,
                         "mock_exception", &conf->mock_exception) < 0) {
         flux_log (h, LOG_ERR, "init_testconf: %s", err.text);
@@ -111,8 +106,6 @@ static int init_testconf (flux_t *h, struct testconf *conf, json_t *jobspec)
     }
     if (trun && fsd_parse_duration (trun, &conf->run_duration) < 0)
         flux_log (h, LOG_ERR, "Unable to parse run duration: %s", trun);
-    if (tclean && fsd_parse_duration (tclean, &conf->cleanup_duration) < 0)
-        flux_log (h, LOG_ERR, "Unable to parse cleanup duration: %s", tclean);
     return 0;
 }
 
@@ -124,7 +117,7 @@ static bool testconf_mock_exception (struct testconf *conf, const char *where)
     return (s && strcmp (s, where) == 0);
 }
 
-/* Timer callback, post the "finish" event and start "cleanup" tasks.
+/* Timer callback, post the "finish" event and notify tasks are complete
  */
 static void timer_cb (flux_reactor_t *r,
                       flux_watcher_t *w,
@@ -169,64 +162,6 @@ static int start_timer (flux_t *h, struct testexec *te, struct jobinfo *job)
     else
         return -1;
     return 0;
-}
-
-
-static void cleanup_timer_cb (flux_reactor_t *r, flux_watcher_t *w,
-                             int revents, void *arg)
-{
-    flux_future_fulfill ((flux_future_t *) arg, NULL, NULL);
-    flux_watcher_destroy (w);
-}
-
-static flux_future_t * fake_cleanup (struct jobinfo *job)
-{
-    struct testexec *te = job->data;
-    flux_t *h = job->h;
-    flux_reactor_t *r = flux_get_reactor (h);
-    flux_future_t *f = NULL;
-    flux_watcher_t *timer = NULL;
-    double t = te->conf.cleanup_duration;
-
-    if (!(f = flux_future_create (NULL, NULL)))
-        return NULL;
-    flux_future_set_flux (f, h);
-
-    /* If no cleanup, immediately fulfill future */
-    if (t <= 0.) {
-        flux_future_fulfill (f, NULL, NULL);
-        return f;
-    }
-
-    /*  O/w, start timer to simulate cleanup */
-    if (!(timer = flux_timer_watcher_create (r, t, 0.,
-                                             cleanup_timer_cb, f))) {
-        flux_log_error (h, "flux_timer_watcher_create");
-        flux_future_fulfill_error (f, errno, "flux_timer_watcher_create");
-    }
-    flux_watcher_start (timer);
-    return f;
-}
-
-static void fake_cleanup_cb (flux_future_t *f, void *arg)
-{
-    struct jobinfo *job = arg;
-    struct idset *idset = flux_future_aux_get (f, "idset");
-    /*  XXX: ranks idset not fully supported and may be NULL */
-    jobinfo_cleanup_complete (job, idset, 0);
-    flux_future_destroy (f);
-}
-
-static int fake_cleanup_start (struct jobinfo *job, const struct idset *ranks)
-{
-    struct idset *idset = ranks ? idset_copy (ranks) : NULL;
-    flux_future_t *f = fake_cleanup (job);
-    if (!f || flux_future_then (f, -1., fake_cleanup_cb, job) < 0) {
-        flux_future_destroy (f);
-        return -1;
-    }
-    flux_future_aux_set (f, "idset", idset, (flux_free_f) idset_destroy);
-    return (0);
 }
 
 static int testexec_init (struct jobinfo *job)
@@ -285,11 +220,6 @@ static int testexec_kill (struct jobinfo *job, int signum)
     return 0;
 }
 
-static int testexec_cleanup (struct jobinfo *job, const struct idset *idset)
-{
-    return fake_cleanup_start (job, idset);
-}
-
 static void testexec_exit (struct jobinfo *job)
 {
     struct testexec *te = job->data;
@@ -303,7 +233,6 @@ struct exec_implementation testexec = {
     .exit =     testexec_exit,
     .start =    testexec_start,
     .kill =     testexec_kill,
-    .cleanup =  testexec_cleanup
 };
 
 /* vi: ts=4 sw=4 expandtab

--- a/src/shell/Makefile.am
+++ b/src/shell/Makefile.am
@@ -36,8 +36,6 @@ libshell_la_SOURCES = \
 	plugstack.h \
 	jobspec.c \
 	jobspec.h \
-	eventlogger.c \
-	eventlogger.h \
 	rcalc.c \
 	rcalc.h
 

--- a/src/shell/events.c
+++ b/src/shell/events.c
@@ -21,7 +21,7 @@
 
 #include <flux/shell.h>
 
-#include "eventlogger.h"
+#include "src/common/libeventlog/eventlogger.h"
 
 struct shell_eventlogger {
     flux_shell_t *shell;

--- a/src/shell/evlog.c
+++ b/src/shell/evlog.c
@@ -37,10 +37,11 @@
 #include <flux/core.h>
 #include <flux/shell.h>
 
+#include "src/common/libeventlog/eventlogger.h"
+
 #include "info.h"
 #include "internal.h"
 #include "builtins.h"
-#include "eventlogger.h"
 
 struct evlog {
     int sync_mode;

--- a/src/shell/evlog.c
+++ b/src/shell/evlog.c
@@ -95,7 +95,10 @@ static void evlog_unref (struct eventlogger *ev, void *arg)
     flux_shell_remove_completion_ref (evlog->shell, "eventlogger.txn");
 }
 
-static void evlog_error (struct eventlogger *ev, int errnum, json_t *entry)
+static void evlog_error (struct eventlogger *ev,
+                         void *arg,
+                         int errnum,
+                         json_t *entry)
 {
     const char *msg;
     if (json_unpack (entry, "{s:{s:s}}",

--- a/src/shell/output.c
+++ b/src/shell/output.c
@@ -50,13 +50,13 @@
 
 #include "src/common/libidset/idset.h"
 #include "src/common/libeventlog/eventlog.h"
+#include "src/common/libeventlog/eventlogger.h"
 #include "src/common/libioencode/ioencode.h"
 
 #include "task.h"
 #include "svc.h"
 #include "internal.h"
 #include "builtins.h"
-#include "eventlogger.h"
 #include "log.h"
 #include "mustache.h"
 

--- a/src/test/checks-annotate.sh
+++ b/src/test/checks-annotate.sh
@@ -4,7 +4,6 @@
 #
 #  Uses GH Workflow commands for GH Actions
 #
-
 error() {
     printf "::error::$@\n"
 }
@@ -16,7 +15,7 @@ catfile() {
     fi
 }
 catfile_error() {
-    error "Found $1\n"
+    error "Found $1"
     catfile $1
 }
 annotate_test_log() {
@@ -78,6 +77,8 @@ rm $logfile
 #  Find and emit all *.asan.* files from test:
 #
 export -f catfile_error
+export -f catfile
+export -f error
 find . -name *.asan.* | xargs -i bash -c 'catfile_error {}'
 
 
@@ -88,7 +89,7 @@ ls -1 t/*.t | sort >/tmp/expected
 ls -1 t/*.trs | sed 's/rs$//' | sort >/tmp/actual
 comm -23 /tmp/expected /tmp/actual > missing
 if test -s missing; then
-    error "Detected $(wc -l missing) missing tests:\n"
+    error "Detected $(wc -l missing) missing tests:"
     for f in $(cat missing); do
         printf "$f\n"
         file=${f//.t}

--- a/t/t2400-job-exec-test.t
+++ b/t/t2400-job-exec-test.t
@@ -79,15 +79,6 @@ test_expect_success 'job-exec: mock exception during run' '
 	flux job eventlog ${jobid} > eventlog.${jobid}.out &&
 	grep "finish status=15" eventlog.${jobid}.out
 '
-test_expect_success 'job-exec: simulate epilog/cleanup tasks' '
-	flux jobspec srun hostname | \
-	  exec_testattr cleanup_duration 0.01s > cleanup.json &&
-	jobid=$(flux job submit cleanup.json) &&
-	flux job wait-event -vt 2.5 ${jobid} clean &&
-	exec_eventlog $jobid > exec.eventlog.$jobid &&
-	grep "cleanup\.start" exec.eventlog.$jobid &&
-	grep "cleanup\.finish" exec.eventlog.$jobid
-'
 test_expect_success 'job-exec: R with invalid expiration raises exception' '
 	flux module unload job-exec &&
 	jobid=$(flux job submit basic.json) &&
@@ -96,22 +87,6 @@ test_expect_success 'job-exec: R with invalid expiration raises exception' '
 	flux kvs put ${key}=${R} &&
 	flux module load job-exec &&
 	flux job wait-event -v $jobid exception
-'
-#
-# XXX: Trying to generate an exception during cleanup is racy, however,
-#  there is not currently another way to do this until we have a *real*
-#  epilog script which could be triggered by events. If this test becomes
-#  a problem, we can disable it until that time.
-#
-test_expect_success FLAKY_TESTS 'job-exec: exception during cleanup' '
-	flux jobspec srun hostname | \
-	  exec_testattr cleanup_duration 1s > cleanup-long.json &&
-	jobid=$(flux job submit cleanup-long.json) &&
-	flux job wait-event -vt 2.5 ${jobid} finish &&
-	flux job cancel ${jobid} &&
-	flux job wait-event -t 10 ${jobid} clean &&
-	exec_eventlog $jobid > exec.eventlog.$jobid &&
-	grep "cleanup\.finish" exec.eventlog.$jobid
 '
 test_expect_success 'start request with empty payload fails with EPROTO(71)' '
 	${RPC} job-exec.start 71 </dev/null

--- a/t/t2400-job-exec-test.t
+++ b/t/t2400-job-exec-test.t
@@ -91,4 +91,12 @@ test_expect_success 'job-exec: R with invalid expiration raises exception' '
 test_expect_success 'start request with empty payload fails with EPROTO(71)' '
 	${RPC} job-exec.start 71 </dev/null
 '
+test_expect_success 'job-exec: invalid testexec conf generates exception' '
+	jobid=$(flux mini submit \
+	    --setattr=system.exec.test.run_duration=0.01 hostname) &&
+	flux job wait-event -t 5 ${jobid} exception > except.invalid.out &&
+	grep "type=\"exec\"" except.invalid.out &&
+	flux job wait-event -qt 5 ${jobid} clean &&
+	flux job eventlog ${jobid}
+'
 test_done

--- a/t/t2404-job-exec-multiuser.t
+++ b/t/t2404-job-exec-multiuser.t
@@ -47,7 +47,7 @@ test_expect_success HAVE_JQ 'job-exec: job as guest tries to run IMP' '
 	flux job attach ${id} &&
 	flux job list-ids ${id} > ${id}.json &&
 	jq -e ".userid == 42" < ${id}.json &&
-	flux dmesg | grep "test-imp: Running.*$(flux job id ${id})"
+	flux job attach ${id} 2>&1 | grep "test-imp: Running.*$(flux job id ${id})"
 '
 test_expect_success HAVE_JQ 'job-exec: large jobspec does not get truncated' '
 	( FAKE_USERID=42 &&


### PR DESCRIPTION
This PR updates job-exec to log early shell/IMP standard output to a new `log` event type in the `guest.exec.eventlog`, instead of just logging with `flux_log()`.

This makes early shell and IMP errors available for display to the user instead of lost in the `flux dmesg` logs. (i.e. the dreaded 
 ```
flux-job: task(s) exited with exit code 1
flux-job: No job output found
 ```
error)

As an example, I commonly run the shell under valgrind with a wrapper script, and now we no longer need to process `flux dmesg` output to get the output from `valgrind`:

```
ƒ(s=4,d=0,builddir) grondo@asp:~/git/f.git$ cat shell.sh 
#!/bin/sh
libtool e valgrind --leak-check=full /home/grondo/git/f.git/src/shell/flux-shell "$@"
ƒ(s=4,d=0,builddir) grondo@asp:~/git/f.git$ flux module reload job-exec job-shell=$(pwd)/shell.sh
ƒ(s=4,d=0,builddir) grondo@asp:~/git/f.git$ flux mini run hostname
0.211s: shell.sh[0]: stderr: ==23948== Memcheck, a memory error detector
0.211s: shell.sh[0]: stderr: ==23948== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
0.211s: shell.sh[0]: stderr: ==23948== Using Valgrind-3.13.0 and LibVEX; rerun with -h for copyright info
0.211s: shell.sh[0]: stderr: ==23948== Command: /home/grondo/git/f.git/src/shell/.libs/flux-shell 277496780029952
0.211s: shell.sh[0]: stderr: ==23948== 
1.927s: shell.sh[0]: stderr: ==23948== Conditional jump or move depends on uninitialised value(s)
1.928s: shell.sh[0]: stderr: ==23948==    at 0x62F6507: __wmemchr_avx2 (memchr-avx2.S:254)
1.928s: shell.sh[0]: stderr: ==23948==    by 0x6251638: internal_fnwmatch (fnmatch_loop.c:168)
1.928s: shell.sh[0]: stderr: ==23948==    by 0x6254AA7: fnmatch@@GLIBC_2.2.5 (fnmatch.c:434)
1.928s: shell.sh[0]: stderr: ==23948==    by 0x624E3A9: glob_in_dir (glob.c:1354)
1.928s: shell.sh[0]: stderr: ==23948==    by 0x624F5E8: glob@@GLIBC_2.27 (glob.c:1097)
1.928s: shell.sh[0]: stderr: ==23948==    by 0x120BEC: plugstack_glob (plugstack.c:252)
1.928s: shell.sh[0]: stderr: ==23948==    by 0x1211BE: plugstack_load (plugstack.c:348)
1.928s: shell.sh[0]: stderr: ==23948==    by 0x1148A9: plugin_load (rc.c:303)
1.928s: shell.sh[0]: stderr: ==23948==    by 0x1148A9: l_plugin_load (rc.c:314)
1.928s: shell.sh[0]: stderr: ==23948==    by 0x5965984: ??? (in /usr/lib/x86_64-linux-gnu/liblua5.2.so.0.0.0)
1.928s: shell.sh[0]: stderr: ==23948==    by 0x5971544: ??? (in /usr/lib/x86_64-linux-gnu/liblua5.2.so.0.0.0)
1.928s: shell.sh[0]: stderr: ==23948==    by 0x5965CAD: ??? (in /usr/lib/x86_64-linux-gnu/liblua5.2.so.0.0.0)
1.928s: shell.sh[0]: stderr: ==23948==    by 0x59652DE: ??? (in /usr/lib/x86_64-linux-gnu/liblua5.2.so.0.0.0)
1.928s: shell.sh[0]: stderr: ==23948== 
1.935s: shell.sh[0]: stderr: ==23948== Conditional jump or move depends on uninitialised value(s)
1.935s: shell.sh[0]: stderr: ==23948==    at 0x62F6517: __wmemchr_avx2 (memchr-avx2.S:264)
1.935s: shell.sh[0]: stderr: ==23948==    by 0x6251638: internal_fnwmatch (fnmatch_loop.c:168)
1.935s: shell.sh[0]: stderr: ==23948==    by 0x6254AA7: fnmatch@@GLIBC_2.2.5 (fnmatch.c:434)
1.935s: shell.sh[0]: stderr: ==23948==    by 0x624E3A9: glob_in_dir (glob.c:1354)
1.935s: shell.sh[0]: stderr: ==23948==    by 0x624F5E8: glob@@GLIBC_2.27 (glob.c:1097)
1.935s: shell.sh[0]: stderr: ==23948==    by 0x114992: l_source_rcfiles (rc.c:356)
1.935s: shell.sh[0]: stderr: ==23948==    by 0x5965984: ??? (in /usr/lib/x86_64-linux-gnu/liblua5.2.so.0.0.0)
1.935s: shell.sh[0]: stderr: ==23948==    by 0x5971544: ??? (in /usr/lib/x86_64-linux-gnu/liblua5.2.so.0.0.0)
1.935s: shell.sh[0]: stderr: ==23948==    by 0x5965CAD: ??? (in /usr/lib/x86_64-linux-gnu/liblua5.2.so.0.0.0)
1.935s: shell.sh[0]: stderr: ==23948==    by 0x59652DE: ??? (in /usr/lib/x86_64-linux-gnu/liblua5.2.so.0.0.0)
1.935s: shell.sh[0]: stderr: ==23948==    by 0x5965F10: ??? (in /usr/lib/x86_64-linux-gnu/liblua5.2.so.0.0.0)
1.935s: shell.sh[0]: stderr: ==23948==    by 0x5961DB0: lua_pcallk (in /usr/lib/x86_64-linux-gnu/liblua5.2.so.0.0.0)
1.935s: shell.sh[0]: stderr: ==23948== 
2.490s: shell.sh[0]: stderr: hwloc x86 backend cannot work under Valgrind, disabling.
2.659s: shell.sh[0]: stderr: ==23972== Warning: invalid file descriptor 1048564 in syscall close()
2.659s: shell.sh[0]: stderr: ==23972== Warning: invalid file descriptor 1048565 in syscall close()
2.659s: shell.sh[0]: stderr: ==23972== Warning: invalid file descriptor 1048566 in syscall close()
2.659s: shell.sh[0]: stderr: ==23972== Warning: invalid file descriptor 1048567 in syscall close()
2.659s: shell.sh[0]: stderr: ==23972==    Use --log-fd=<number> to select an alternative log fd.
2.659s: shell.sh[0]: stderr: ==23972== Warning: invalid file descriptor 1048568 in syscall close()
2.659s: shell.sh[0]: stderr: ==23972== Warning: invalid file descriptor 1048569 in syscall close()
asp
2.846s: shell.sh[0]: stderr: ==23948== Warning: invalid file descriptor -1 in syscall close()
2.916s: shell.sh[0]: stderr: ==23948== 
2.916s: shell.sh[0]: stderr: ==23948== HEAP SUMMARY:
2.917s: shell.sh[0]: stderr: ==23948==     in use at exit: 120 bytes in 2 blocks
2.917s: shell.sh[0]: stderr: ==23948==   total heap usage: 8,032 allocs, 8,030 frees, 15,330,325 bytes allocated
2.917s: shell.sh[0]: stderr: ==23948== 
2.920s: shell.sh[0]: stderr: ==23948== 88 bytes in 1 blocks are definitely lost in loss record 2 of 2
2.920s: shell.sh[0]: stderr: ==23948==    at 0x4C31B0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
2.920s: shell.sh[0]: stderr: ==23948==    by 0x74F34A8: lt__malloc (in /usr/lib/x86_64-linux-gnu/libltdl.so.7.3.1)
2.920s: shell.sh[0]: stderr: ==23948==    by 0x74F34DD: lt__zalloc (in /usr/lib/x86_64-linux-gnu/libltdl.so.7.3.1)
2.920s: shell.sh[0]: stderr: ==23948==    by 0x74F5779: ??? (in /usr/lib/x86_64-linux-gnu/libltdl.so.7.3.1)
2.920s: shell.sh[0]: stderr: ==23948==    by 0x74F6120: lt_dlopenadvise (in /usr/lib/x86_64-linux-gnu/libltdl.so.7.3.1)
2.921s: shell.sh[0]: stderr: ==23948==    by 0x983CE85: ???
2.921s: shell.sh[0]: stderr: ==23948==    by 0x5B9CAE0: ??? (in /usr/lib/x86_64-linux-gnu/libhwloc.so.5.7.6)
2.921s: shell.sh[0]: stderr: ==23948==    by 0x5B95E86: hwloc_topology_init (in /usr/lib/x86_64-linux-gnu/libhwloc.so.5.7.6)
2.921s: shell.sh[0]: stderr: ==23948==    by 0x11D69B: shell_affinity_topology_init (affinity.c:161)
2.921s: shell.sh[0]: stderr: ==23948==    by 0x11D69B: shell_affinity_create (affinity.c:179)
2.921s: shell.sh[0]: stderr: ==23948==    by 0x11D69B: affinity_init (affinity.c:278)
2.921s: shell.sh[0]: stderr: ==23948==    by 0x121011: plugstack_call (plugstack.c:180)
2.921s: shell.sh[0]: stderr: ==23948==    by 0x110EFA: shell_init (shell.c:1020)
2.921s: shell.sh[0]: stderr: ==23948==    by 0x110EFA: main (shell.c:1164)
2.921s: shell.sh[0]: stderr: ==23948== 
2.921s: shell.sh[0]: stderr: ==23948== LEAK SUMMARY:
2.921s: shell.sh[0]: stderr: ==23948==    definitely lost: 88 bytes in 1 blocks
2.921s: shell.sh[0]: stderr: ==23948==    indirectly lost: 0 bytes in 0 blocks
2.921s: shell.sh[0]: stderr: ==23948==      possibly lost: 0 bytes in 0 blocks
2.921s: shell.sh[0]: stderr: ==23948==    still reachable: 32 bytes in 1 blocks
2.921s: shell.sh[0]: stderr: ==23948==         suppressed: 0 bytes in 0 blocks
2.921s: shell.sh[0]: stderr: ==23948== Reachable blocks (those to which a pointer was found) are not shown.
2.921s: shell.sh[0]: stderr: ==23948== To see them, rerun with: --leak-check=full --show-leak-kinds=all
2.921s: shell.sh[0]: stderr: ==23948== 
2.921s: shell.sh[0]: stderr: ==23948== For counts of detected and suppressed errors, rerun with: -v
2.921s: shell.sh[0]: stderr: ==23948== Use --track-origins=yes to see where uninitialised values come from
2.921s: shell.sh[0]: stderr: ==23948== ERROR SUMMARY: 7 errors from 3 contexts (suppressed: 0 from 0)
```

Fixes #3185