### PR TITLE
broker: fix intermittent hang during instance tear-down on Centos7/TOSS3

### DIFF
--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -370,6 +370,7 @@ int main (int argc, char *argv[])
     }
     overlay_set_parent_cb (ctx.overlay, parent_cb, &ctx);
     overlay_set_child_cb (ctx.overlay, child_cb, &ctx);
+    overlay_set_idle_warning (ctx.overlay, 5);
 
     /* Arrange for the publisher to route event messages.
      * handle_event - local subscribers (ctx.h)

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -1557,8 +1557,7 @@ static int handle_event (broker_ctx_t *ctx, const flux_msg_t *msg)
 
     /* Forward to this rank's children.
      */
-    if (overlay_mcast_child (ctx->overlay, msg) < 0)
-        flux_log_error (ctx->h, "%s: overlay_mcast_child", __FUNCTION__);
+    overlay_mcast_child (ctx->overlay, msg);
 
     /* Internal services may install message handlers for events.
      */

--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -273,7 +273,7 @@ int overlay_sendmsg_child (struct overlay *ov, const flux_msg_t *msg)
         errno = EINVAL;
         goto done;
     }
-    rc = flux_msg_sendzsock (ov->child->zs, msg);
+    rc = flux_msg_sendzsock_ex (ov->child->zs, msg, true);
 done:
     return rc;
 }
@@ -291,7 +291,7 @@ static int overlay_mcast_child_one (void *zsock,
         goto done;
     if (flux_msg_push_route (cpy, uuid) < 0)
         goto done;
-    if (flux_msg_sendzsock (zsock, cpy) < 0) {
+    if (flux_msg_sendzsock_ex (zsock, cpy, true) < 0) {
         if (errno != EHOSTUNREACH) // a child has disconnected - not an error
             goto done;
     }

--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -653,7 +653,7 @@ void overlay_destroy (struct overlay *ov)
 }
 
 static const struct flux_msg_handler_spec htab[] = {
-    { FLUX_MSGTYPE_EVENT,  "heartbeat", heartbeat_cb, 0 },
+    { FLUX_MSGTYPE_EVENT,  "hb", heartbeat_cb, 0 },
     { FLUX_MSGTYPE_REQUEST,  "overlay.lspeer", lspeer_cb, 0 },
     FLUX_MSGHANDLER_TABLE_END,
 };

--- a/src/broker/overlay.h
+++ b/src/broker/overlay.h
@@ -64,7 +64,7 @@ int overlay_sendmsg_child (struct overlay *ov, const flux_msg_t *msg);
 /* We can "multicast" events to all child peers using mcast_child().
  * It walks the 'children' hash, finding peers and routeing them a copy of msg.
  */
-int overlay_mcast_child (struct overlay *ov, const flux_msg_t *msg);
+void overlay_mcast_child (struct overlay *ov, const flux_msg_t *msg);
 
 /* Call when message is received from child 'uuid'.
  */

--- a/src/broker/overlay.h
+++ b/src/broker/overlay.h
@@ -14,6 +14,11 @@
 #include "attr.h"
 #include "src/common/libutil/zsecurity.h"
 
+enum {
+    KEEPALIVE_STATUS_NORMAL = 0,
+    KEEPALIVE_STATUS_DISCONNECT = 1,
+};
+
 struct overlay;
 
 typedef void (*overlay_sock_cb_f)(struct overlay *ov, void *sock, void *arg);
@@ -67,8 +72,9 @@ int overlay_sendmsg_child (struct overlay *ov, const flux_msg_t *msg);
 void overlay_mcast_child (struct overlay *ov, const flux_msg_t *msg);
 
 /* Call when message is received from child 'uuid'.
+ * If message was a keepalive, update 'status', otherwise set to zero.
  */
-void overlay_checkin_child (struct overlay *ov, const char *uuid);
+void overlay_keepalive_child (struct overlay *ov, const char *uuid, int status);
 
 /* Register callback that will be called each time a child connects/disconnects.
  * Use overlay_get_child_peer_count() to access the actual count.

--- a/src/common/libflux/message.c
+++ b/src/common/libflux/message.c
@@ -1576,7 +1576,7 @@ void flux_msg_fprint (FILE *f, const flux_msg_t *msg)
     zframe_fprint (proto, prefix, f);
 }
 
-int flux_msg_sendzsock (void *sock, const flux_msg_t *msg)
+int flux_msg_sendzsock_ex (void *sock, const flux_msg_t *msg, bool nonblock)
 {
     int rc = -1;
 
@@ -1590,6 +1590,9 @@ int flux_msg_sendzsock (void *sock, const flux_msg_t *msg)
     zframe_t *zf = zmsg_first (msg->zmsg);
     size_t count = 0;
 
+    if (nonblock)
+        flags |= ZFRAME_DONTWAIT;
+
     while (zf) {
         if (++count == zmsg_size (msg->zmsg))
             flags &= ~ZFRAME_MORE;
@@ -1600,6 +1603,11 @@ int flux_msg_sendzsock (void *sock, const flux_msg_t *msg)
     rc = 0;
 done:
     return rc;
+}
+
+int flux_msg_sendzsock (void *sock, const flux_msg_t *msg)
+{
+    return flux_msg_sendzsock_ex (sock, msg, false);
 }
 
 flux_msg_t *flux_msg_recvzsock (void *sock)

--- a/src/common/libflux/message.h
+++ b/src/common/libflux/message.h
@@ -130,6 +130,7 @@ flux_msg_t *flux_msg_decode (const void *buf, size_t size);
  * Returns 0 on success, -1 on failure with errno set.
  */
 int flux_msg_sendzsock (void *dest, const flux_msg_t *msg);
+int flux_msg_sendzsock_ex (void *dest, const flux_msg_t *msg, bool nonblock);
 
 /* Receive a message from zeromq socket.
  * Returns message on success, NULL on failure with errno set.

--- a/src/modules/resource/monitor.c
+++ b/src/modules/resource/monitor.c
@@ -143,7 +143,7 @@ static int batch_timeout_leader (struct monitor *monitor)
     if (idset_count (b->down) > 0) {
         if (!(offline = idset_encode (b->down, IDSET_FLAG_RANGE)))
             goto done;
-        flux_log (h, LOG_DEBUG, "monitor-batch: down %s", online);
+        flux_log (h, LOG_DEBUG, "monitor-batch: down %s", offline);
         if (rutil_idset_sub (monitor->up, b->down) < 0)
             goto done;
     }


### PR DESCRIPTION
This PR addresses the problem noted in #3235, where an instance can become stuck during teardown.  I think it also has been happening in the centos7 builder and is responsible for spurious CI failures.  (I was usually able to reproduce in the Centos 7 docker image by running back to back `flux start -s32 /bin/true` after 7-10 iterations).

The problem seems to be with zeromq 4.1.4, which is the version we are stuck with on Centos 7/TOSS 3.  The ROUTER socket, which communicates with downstream TBON children, is not supposed to be able to block, but on that release it occasionally does when a peer is in the process of disconnecting.  This PR works around it by sending to that socket (only) in a non-blocking mode and logging any errors.  This enables the broker to avoid getting stuck.  Logs like this will occasionally pop up in the logs during shutdown now on centos7:
```
2020-12-04T21:48:03.155039Z broker.err[11]: mcast error to child rank 23: Resource temporarily unavailable
```
We could consider reducing the log severity if we're only seeing these innocuous errors at shutdown, but I wanted to make them stand out for a while to be sure we aren't seeing them at other times.

This PR also changes the way that disconnects are detected from the "monitor socket" method, to a combination of a special disconnect keep-alive message, and EHOSTUNREACH detection on send.  The monitor socket in zeromq 4.1.4 has a disturbing bug where the zeromq end of it is used from multiple threads, potentially corrupting memory.  Although it turned out not to be the solution to the hangs, I felt that the new method is superior anyway, since it can pinpoint which rank is disconnecting, whereas the monitor socket could only maintain a count.

Finally, to enable better debugging, keep-alive monitoring/logging was re-eneabled.  If a broker stops communicating for 5 heartbeats, it will be logged at LOG_CRIT level each heartbeat, like it was a while back.  I found it helpful while debugging the above, particularly now that brokers that have disconnected can be excluded from the "idle" logging (only brokers that connected, but possibly deadlocked are logged now).

I'm marking as a WIP for now b/c this probably needs a workout on fluke before we consider merging it.  I'm not sure what testing to add for CI but maybe something will come to me.