### PR TITLE
job-manager: add redacted jobspec to exec.start request

### DIFF
--- a/src/modules/job-manager/start.c
+++ b/src/modules/job-manager/start.c
@@ -273,9 +273,10 @@ int start_send_request (struct start *start, struct job *job)
     if (!job->start_pending && start->topic != NULL) {
         if (!(msg = flux_request_encode (start->topic, NULL)))
             return -1;
-        if (flux_msg_pack (msg, "{s:I s:i}",
+        if (flux_msg_pack (msg, "{s:I s:i s:O}",
                                 "id", job->id,
-                                "userid", job->userid) < 0)
+                                "userid", job->userid,
+                                "jobspec", job->jobspec_redacted) < 0)
             goto error;
         if (flux_send (ctx->h, msg, 0) < 0)
             goto error;


### PR DESCRIPTION
As with `sched.alloc`, the job manager can now forward the cached jobspec in `exec.start`, so that the job-exec module doesn't have to fetch the full jobspec from the KVS for each job.