### PR TITLE
Sync priority changes from job-manager to job-info

### DIFF
--- a/src/common/libjob/job.h
+++ b/src/common/libjob/job.h
@@ -31,6 +31,11 @@ enum job_urgency {
     FLUX_JOB_URGENCY_MAX = 31,
 };
 
+enum job_queue_priority {
+    FLUX_JOB_PRIORITY_MIN = 0,
+    FLUX_JOB_PRIORITY_MAX = 4294967295,
+};
+
 enum {
     FLUX_JOBID_ANY = 0xFFFFFFFFFFFFFFFF, // ~(uint64_t)0
 };

--- a/src/modules/job-info/job_state.c
+++ b/src/modules/job-info/job_state.c
@@ -1687,6 +1687,12 @@ static int journal_process_event (struct job_state_ctx *jsctx, json_t *event)
             return -1;
     }
     else if (!strcmp (name, "flux-restart")) {
+        /* Presently, job-info depends on job-manager.events-journal
+         * service.  So if job-manager reloads, job-info must be
+         * reloaded, making the probability of reaching this
+         * `flux-restart` path very low.  Code added for completeness
+         * and in case dependency removed in the future.
+         */
         if (journal_revert_job (jsctx,
                                 id,
                                 eventlog_seq,

--- a/src/modules/job-info/job_state.h
+++ b/src/modules/job-info/job_state.h
@@ -68,6 +68,7 @@ struct job {
     flux_jobid_t id;
     uint32_t userid;
     int urgency;
+    unsigned int priority;
     double t_submit;
     int flags;
     flux_job_state_t state;

--- a/src/modules/job-manager/alloc.c
+++ b/src/modules/job-manager/alloc.c
@@ -71,7 +71,7 @@ static void interface_teardown (struct alloc *alloc, char *s, int errnum)
              * so they will automatically send alloc again.
              */
             if (job->alloc_pending) {
-                bool fwd = job->urgency > FLUX_JOB_URGENCY_DEFAULT;
+                bool fwd = job->priority > (FLUX_JOB_PRIORITY_MAX / 2);
                 bool cleared = false;
 
                 assert (job->handle == NULL);
@@ -344,7 +344,7 @@ int alloc_request (struct alloc *alloc, struct job *job)
         return -1;
     if (flux_msg_pack (msg, "{s:I s:i s:i s:f s:O}",
                             "id", job->id,
-                            "priority", job->urgency,
+                            "priority", job->priority,
                             "userid", job->userid,
                             "t_submit", job->t_submit,
                             "jobspec", job->jobspec_redacted) < 0)
@@ -382,7 +382,7 @@ static void hello_cb (flux_t *h, flux_msg_handler_t *mh,
         if (job->has_resources) {
             if (!(entry = json_pack ("{s:I s:i s:i s:f}",
                                      "id", job->id,
-                                     "priority", job->urgency,
+                                     "priority", job->priority,
                                      "userid", job->userid,
                                      "t_submit", job->t_submit)))
                 goto nomem;
@@ -530,7 +530,7 @@ int alloc_enqueue_alloc_request (struct alloc *alloc, struct job *job)
 {
     assert (job->state == FLUX_JOB_STATE_SCHED);
     if (!job->alloc_queued && !job->alloc_pending) {
-        bool fwd = job->urgency > FLUX_JOB_URGENCY_DEFAULT;
+        bool fwd = job->priority > (FLUX_JOB_PRIORITY_MAX / 2);
         assert (job->handle == NULL);
         if (!(job->handle = zlistx_insert (alloc->queue, job, fwd)))
             return -1;
@@ -575,7 +575,7 @@ struct job *alloc_queue_next (struct alloc *alloc)
 /* called from urgency_handle_request() */
 void alloc_queue_reorder (struct alloc *alloc, struct job *job)
 {
-    bool fwd = job->urgency > FLUX_JOB_URGENCY_DEFAULT;
+    bool fwd = job->priority > (FLUX_JOB_PRIORITY_MAX / 2);
 
     zlistx_reorder (alloc->queue, job->handle, fwd);
 }

--- a/src/modules/job-manager/event.c
+++ b/src/modules/job-manager/event.c
@@ -396,11 +396,11 @@ static int event_submit_context_decode (json_t *context,
 }
 
 static int event_priority_context_decode (json_t *context,
-                                          int *priority)
+                                          unsigned int *priority)
 {
     /* N.B. eventually this will be the priority, but is the
      * same of the urgency at the moment */
-    if (json_unpack (context, "{ s:i }", "priority", priority) < 0) {
+    if (json_unpack (context, "{ s:i }", "priority", (int *)priority) < 0) {
         errno = EPROTO;
         return -1;
     }
@@ -475,7 +475,7 @@ int event_job_update (struct job *job, json_t *event)
     else if (!strcmp (name, "priority")) {
         if (job->state != FLUX_JOB_STATE_PRIORITY)
             goto inval;
-        if (event_priority_context_decode (context, &job->urgency) < 0)
+        if (event_priority_context_decode (context, &job->priority) < 0)
             goto error;
         job->state = FLUX_JOB_STATE_SCHED;
     }

--- a/src/modules/job-manager/event.c
+++ b/src/modules/job-manager/event.c
@@ -473,7 +473,8 @@ int event_job_update (struct job *job, json_t *event)
         job->state = FLUX_JOB_STATE_PRIORITY;
     }
     else if (!strcmp (name, "priority")) {
-        if (job->state != FLUX_JOB_STATE_PRIORITY)
+        if (job->state != FLUX_JOB_STATE_PRIORITY
+            && job->state != FLUX_JOB_STATE_SCHED)
             goto inval;
         if (event_priority_context_decode (context, &job->priority) < 0)
             goto error;

--- a/src/modules/job-manager/job.c
+++ b/src/modules/job-manager/job.c
@@ -129,7 +129,7 @@ void *job_duplicator (const void *item)
     return job_incref ((struct job *)item);
 }
 
-/* Compare jobs, ordering by (1) urgency, (2) job id.
+/* Compare jobs, ordering by (1) priority, (2) job id.
  * N.B. zlistx_comparator_fn signature
  */
 int job_comparator (const void *a1, const void *a2)
@@ -138,7 +138,7 @@ int job_comparator (const void *a1, const void *a2)
     const struct job *j2 = a2;
     int rc;
 
-    if ((rc = (-1)*NUMCMP (j1->urgency, j2->urgency)) == 0)
+    if ((rc = (-1)*NUMCMP (j1->priority, j2->priority)) == 0)
         rc = NUMCMP (j1->id, j2->id);
     return rc;
 }

--- a/src/modules/job-manager/job.h
+++ b/src/modules/job-manager/job.h
@@ -20,6 +20,7 @@ struct job {
     flux_jobid_t id;
     uint32_t userid;
     int urgency;
+    unsigned int priority;
     double t_submit;
     int flags;
     json_t *jobspec_redacted;

--- a/src/modules/job-manager/test/job.c
+++ b/src/modules/job-manager/test/job.c
@@ -164,7 +164,9 @@ void test_create_from_eventlog (void)
         "job_create_from_eventlog log=(submit+depend+priority) set id from param");
     ok (job->userid == 66,
         "job_create_from_eventlog log=(submit+depend+priority) set userid from submit");
-    ok (job->urgency == 1,
+    ok (job->urgency == 16,
+        "job_create_from_eventlog log=(submit+depend+priority) set urgency from submit");
+    ok (job->priority == 1,
         "job_create_from_eventlog log=(submit+depend+priority) set priority from priority");
     ok (job->t_submit == 42.2,
         "job_create_from_eventlog log=(submit+depend+priority) set t_submit from submit");

--- a/src/modules/job-manager/urgency.c
+++ b/src/modules/job-manager/urgency.c
@@ -112,6 +112,12 @@ void urgency_handle_request (flux_t *h,
      * new urgency, but for now priority is set to urgency */
     if (urgency != orig_urgency) {
         job->priority = urgency;
+        if (event_job_post_pack (ctx->event, job,
+                                 "priority",
+                                 0,
+                                 "{ s:i }",
+                                 "priority", job->priority) < 0)
+            goto error;
         alloc_queue_reorder (ctx->alloc, job);
     }
     if (flux_respond (h, msg, NULL) < 0)

--- a/src/modules/job-manager/urgency.c
+++ b/src/modules/job-manager/urgency.c
@@ -108,8 +108,12 @@ void urgency_handle_request (flux_t *h,
                              "userid", cred.userid,
                              "urgency", urgency) < 0)
         goto error;
-    if (urgency != orig_urgency)
+    /* N.B. once priority plugin work developed, should recall with
+     * new urgency, but for now priority is set to urgency */
+    if (urgency != orig_urgency) {
+        job->priority = urgency;
         alloc_queue_reorder (ctx->alloc, job);
+    }
     if (flux_respond (h, msg, NULL) < 0)
         flux_log_error (h, "%s: flux_respond", __FUNCTION__);
     return;

--- a/t/t2202-job-manager.t
+++ b/t/t2202-job-manager.t
@@ -107,17 +107,17 @@ test_expect_success 'job-manager: queue contains 3 jobs' '
 	test $(wc -l <list3.out) -eq 3
 '
 
-test_expect_success 'job-manager: queue is sorted in urgency order' '
-	cat >list3_urgency.exp <<-EOT &&
+test_expect_success 'job-manager: queue is sorted in priority order' '
+	cat >list3_priority.exp <<-EOT &&
 	31
 	16
 	0
 	EOT
-	cut -f4 <list3.out >list3_urgency.out &&
-	test_cmp list3_urgency.exp list3_urgency.out
+	cut -f4 <list3.out >list3_priority.out &&
+	test_cmp list3_priority.exp list3_priority.out
 '
 
-test_expect_success 'job-manager: list-jobs --count shows highest urgency jobs' '
+test_expect_success 'job-manager: list-jobs --count shows highest priority jobs' '
 	cat >list3_lim2.exp <<-EOT &&
 	31
 	16

--- a/t/t2230-job-info-list.t
+++ b/t/t2230-job-info-list.t
@@ -50,10 +50,10 @@ wait_jobid_state() {
 # - the second loop of job submissions are intended to eat up all resources
 # - the last job submissions are intended to get a create a set of
 #   pending jobs, because jobs from the second loop have taken all resources
-#   - we desire pending jobs sorted in urgency order, so we need to
+#   - we desire pending jobs sorted in priority order, so we need to
 #   create the sorted list for comparison later.
 # - job ids are stored in files in the order we expect them to be listed
-#   - pending jobs - by urgency (highest first), job id (smaller first)
+#   - pending jobs - by priority (highest first), job id (smaller first)
 #   - running jobs - by start time (most recent first)
 #   - inactive jobs - by completion time (most recent first)
 #
@@ -253,7 +253,7 @@ test_expect_success HAVE_JQ 'flux job list only completed jobs' '
 # state since we happen to know all these jobs are in the "sched"
 # state given checks above
 
-test_expect_success HAVE_JQ 'flux job list pending jobs in urgency order' '
+test_expect_success HAVE_JQ 'flux job list pending jobs in priority order' '
         flux job list -s pending | jq .id > list_pending1.out &&
         flux job list -s depend,priority,sched | jq .id > list_pending2.out &&
         flux job list -s sched | jq .id > list_pending3.out &&

--- a/t/t2234-job-info-list-update.t
+++ b/t/t2234-job-info-list-update.t
@@ -47,10 +47,10 @@ wait_jobid_state() {
 # - the second loop of job submissions are intended to eat up all resources
 # - the last job submissions are intended to get a create a set of
 #   pending jobs, because jobs from the second loop have taken all resources
-#   - we desire pending jobs sorted in urgency order, so we need to
+#   - we desire pending jobs sorted in priority order, so we need to
 #   create the sorted list for comparison later.
 # - job ids are stored in files in the order we expect them to be listed
-#   - pending jobs - by urgency (highest first), job id (smaller first)
+#   - pending jobs - by priority (highest first), job id (smaller first)
 #   - running jobs - by start time (most recent first)
 #   - inactive jobs - by completion time (most recent first)
 #
@@ -170,7 +170,7 @@ test_expect_success HAVE_JQ 'flux job list inactive jobs in completed order' '
 # state since we happen to know all these jobs are in the "sched"
 # state given checks above
 
-test_expect_success HAVE_JQ 'flux job list pending jobs in urgency order' '
+test_expect_success HAVE_JQ 'flux job list pending jobs in priority order' '
         flux job list -s pending | jq .id > list_pending.out &&
         test_cmp list_pending.out pending.ids
 '

--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -19,7 +19,7 @@ JSONSCHEMA_VALIDATOR=${FLUX_SOURCE_DIR}/src/modules/job-ingest/validators/valida
 # - the last job submissions are intended to get a create a set of
 #   pending jobs, because jobs from the second loop have taken all resources
 # - job ids are stored in files in the order we expect them to be listed
-#   - pending jobs - by urgency (highest first), job id (smaller first)
+#   - pending jobs - by priority (highest first), job id (smaller first)
 #   - running jobs - by start time (most recent first)
 #   - inactive jobs - by completion time (most recent first)
 #


### PR DESCRIPTION
per #3345.

Nothing too remarkable with this change, except the first commit, where I had a logic error with the `flux-restart` state revert-ing.