### PR TITLE
python: add ResourceSet class

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -15,6 +15,9 @@ ignore_missing_imports = True
 [mypy-_flux._idset]
 ignore_missing_imports = True
 
+[mypy-_flux._rlist]
+ignore_missing_imports = True
+
 [mypy-cffi]
 ignore_missing_imports = True
 

--- a/src/bindings/python/_flux/Makefile.am
+++ b/src/bindings/python/_flux/Makefile.am
@@ -29,7 +29,8 @@ PREPROC_FLAGS = \
 fluxpyso_LTLIBRARIES = \
 	_core.la \
 	_hostlist.la \
-	_idset.la
+	_idset.la \
+	_rlist.la
 
 fluxpyso_PYTHON = \
 	__init__.py
@@ -37,13 +38,15 @@ fluxpyso_PYTHON = \
 nodist_fluxbindinginclude_HEADERS = \
 	_core_preproc.h \
 	_hostlist_preproc.h \
-	_idset_preproc.h
+	_idset_preproc.h \
+	_rlist_preproc.h
 
 EXTRA_DIST = \
 	_core_build.py \
 	_security_build.py \
 	_hostlist_build.py \
 	_idset_build.py \
+	_rlist_build.py \
 	make_clean_header.py
 
 STDERR_DEVNULL = $(stderr_devnull_$(V))
@@ -94,6 +97,22 @@ _idset_preproc.h: _idset_clean.h
 	  | sed -e '/^# [0-9]*.*/d' > $@
 
 
+_rlist.c: $(srcdir)/_rlist_build.py _rlist_preproc.h
+	$(AM_V_GEN)$(PYTHON) $^ $(STDERR_DEVNULL)
+
+_rlist_clean.h: Makefile
+	$(AM_V_GEN)$(PYTHON) $(srcdir)/make_clean_header.py \
+	  --path $(top_srcdir)/src/common/librlist \
+	  --search $(top_builddir)/config \
+	  --search /usr/include \
+	  --output $@ \
+	  rlist.h
+
+_rlist_preproc.h: _rlist_clean.h
+	$(AM_V_GEN)$(CC) $(PREPROC_FLAGS) $< \
+	  | sed -e '/^# [0-9]*.*/d' > $@
+
+
 dist__core_la_SOURCES = callbacks.h
 nodist__core_la_SOURCES = _core.c
 _core_la_LIBADD = $(common_libs)
@@ -103,6 +122,12 @@ _hostlist_la_LIBADD = $(common_libs)
 
 nodist__idset_la_SOURCES = _idset.c
 _idset_la_LIBADD = $(common_libs)
+
+nodist__rlist_la_SOURCES = _rlist.c
+_rlist_la_LIBADD = \
+	$(top_builddir)/src/common/librlist/librlist.la \
+	$(HWLOC_LIBS) \
+	$(common_libs)
 
 if HAVE_FLUX_SECURITY
 

--- a/src/bindings/python/_flux/_rlist_build.py
+++ b/src/bindings/python/_flux/_rlist_build.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+from cffi import FFI
+
+from _hostlist_build import ffi as hostlist_ffi
+from _idset_build import ffi as idset_ffi
+
+ffi = FFI()
+
+ffi.include(hostlist_ffi)
+ffi.include(idset_ffi)
+
+ffi.set_source(
+    "_flux._rlist",
+    """
+#include <jansson.h>
+#include <czmq.h>
+#include "src/common/librlist/rlist.h"
+
+
+// TODO: remove this when we can use cffi 1.10
+#ifdef __GNUC__
+#pragma GCC visibility push(default)
+#endif
+            """,
+)
+
+cdefs = """
+typedef struct _zlistx_t zlistx_t;
+typedef struct _zhashx_t zhashx_t;
+typedef int... json_type;
+typedef struct json_t json_t;
+typedef struct json_error_t json_error_t;
+
+void free (void *);
+
+"""
+
+with open("_rlist_preproc.h") as h:
+    cdefs = cdefs + h.read()
+
+ffi.cdef(cdefs)
+if __name__ == "__main__":
+    ffi.emit_c_code("_rlist.c")
+    # Ensure target mtime is updated
+    Path("_rlist.c").touch()

--- a/src/bindings/python/flux/Makefile.am
+++ b/src/bindings/python/flux/Makefile.am
@@ -26,6 +26,9 @@ nobase_fluxpy_PYTHON = \
 	job/wait.py \
 	job/_wrapper.py \
 	resource/Rlist.py \
+	resource/__init__.py \
+	resource/ResourceSetImplementation.py \
+	resource/ResourceSet.py \
 	hostlist.py \
 	idset.py
 

--- a/src/bindings/python/flux/Makefile.am
+++ b/src/bindings/python/flux/Makefile.am
@@ -25,6 +25,7 @@ nobase_fluxpy_PYTHON = \
 	job/submit.py \
 	job/wait.py \
 	job/_wrapper.py \
+	resource/Rlist.py \
 	hostlist.py \
 	idset.py
 

--- a/src/bindings/python/flux/resource/ResourceSetImplementation.py
+++ b/src/bindings/python/flux/resource/ResourceSetImplementation.py
@@ -1,0 +1,78 @@
+###############################################################
+# Copyright 2020 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+from abc import ABC, abstractmethod
+
+
+class ResourceSetImplementation(ABC):  # pragma: no cover
+    """
+    This abstract class defines the interface that a ResourceSet
+    implementation shall provide in order to work with the ResourceSet
+    class
+    """
+
+    @abstractmethod
+    def dumps(self):
+        """Return a short-form string representation of a resource set"""
+        raise NotImplementedError
+
+    def encode(self):
+        """Return a JSON string representation of the resource set"""
+        raise NotImplementedError
+
+    @abstractmethod
+    def nodelist(self):
+        """Return the list of nodes in the resource set as a Hostlist"""
+        raise NotImplementedError
+
+    @abstractmethod
+    def ranks(self):
+        """Return the set of ranks in the resource set as an IDset"""
+        raise NotImplementedError
+
+    @abstractmethod
+    def nnodes(self):
+        """Return the number of nodes in the resource set as an IDset"""
+        raise NotImplementedError
+
+    @abstractmethod
+    def count(self, name):
+        """Return the total number of resources of type 'name'"""
+        raise NotImplementedError
+
+    @abstractmethod
+    def copy(self):
+        """Return a copy of the resource set"""
+        raise NotImplementedError
+
+    @abstractmethod
+    def union(self, rset):
+        """Return the union of two resource sets"""
+        raise NotImplementedError
+
+    @abstractmethod
+    def intersect(self, rset):
+        """Return the set intersection of two resource sets"""
+        raise NotImplementedError
+
+    @abstractmethod
+    def diff(self, rset):
+        """Return the set difference of two resource sets"""
+        raise NotImplementedError
+
+    @abstractmethod
+    def append(self, rset):
+        """Append one resource set to another"""
+        raise NotImplementedError
+
+    @abstractmethod
+    def remove_ranks(self, ranks):
+        """Remove an IDset of ranks from a resource set"""
+        raise NotImplementedError

--- a/src/bindings/python/flux/resource/Rlist.py
+++ b/src/bindings/python/flux/resource/Rlist.py
@@ -15,10 +15,12 @@ from collections import Mapping
 from _flux._rlist import ffi, lib
 from flux.wrapper import Wrapper, WrapperPimpl
 
+from flux.resource.ResourceSetImplementation import ResourceSetImplementation
 from flux.hostlist import Hostlist
 from flux.idset import IDset
 
 
+@ResourceSetImplementation.register
 class Rlist(WrapperPimpl):
     version = 1
 

--- a/src/bindings/python/flux/resource/__init__.py
+++ b/src/bindings/python/flux/resource/__init__.py
@@ -1,0 +1,12 @@
+###############################################################
+# Copyright 2020 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+from flux.resource.Rlist import Rlist
+from flux.resource.ResourceSet import ResourceSet

--- a/src/cmd/flux-R.c
+++ b/src/cmd/flux-R.c
@@ -270,13 +270,7 @@ static struct hostlist *hostlist_from_option (optparse_t *p,
 
 static void rlist_puts (struct rlist *rl)
 {
-    json_t *o;
-    char *R;
-    if (!(o = rlist_to_R (rl)))
-        log_err_exit ("rlist_to_R");
-    if (!(R = json_dumps (o, 0)))
-        log_err_exit ("json_dumps");
-    json_decref (o);
+    char *R = rlist_encode (rl);
     puts (R);
     free (R);
 }

--- a/src/cmd/flux-resource.py
+++ b/src/cmd/flux-resource.py
@@ -11,12 +11,11 @@
 import sys
 import logging
 import argparse
-import re
 import os.path
-from itertools import count, groupby
 import json
 
 import flux
+from flux.resource import ResourceSet
 from flux.rpc import RPC
 from flux.memoized_property import memoized_property
 
@@ -51,192 +50,6 @@ def undrain(args):
     RPC(flux.Flux(), "resource.undrain", {"targets": args.targets}).get()
 
 
-def idset_strip(idset):
-    return idset.strip("[").rstrip("]")
-
-
-def idset_range(idset):
-    start, end = map(int, idset.split("-"))
-    return range(start, end + 1)
-
-
-def idset_expand(idset):
-    result = []
-    if not idset:
-        return result
-    for i in idset_strip(idset).split(","):
-        if "-" not in i:
-            result.append(int(i))
-        else:
-            result.extend(idset_range(i))
-    return result
-
-
-def idset_toset(idset):
-    result = set()
-    if not idset:
-        return result
-    for i in idset_strip(idset).split(","):
-        if "-" not in i:
-            result.add(int(i))
-        else:
-            for j in idset_range(i):
-                result.add(j)
-    return result
-
-
-def bracket(setstr):
-    """
-    Add brackets to idset if not already present and idset is not single number
-    """
-    if not setstr or setstr[0] == "[" or re.match(r"^[^,-]+$", setstr):
-        return setstr
-    return f"[{setstr}]"
-
-
-def idset_encode(idlist):
-    """
-    Encode list of integers in idlist into an idset string
-    """
-    ranges = []
-    # Collect consecutive integers:
-    # See: https://stackoverflow.com/questions/3429510
-    for x in (list(x) for _, x in groupby(idlist, lambda x, c=count(): next(c) - x)):
-        current = f"{x[0]}"
-        if len(x) > 1:
-            current += f"-{x[-1]}"
-        ranges.append(current)
-    return bracket(",".join(ranges))
-
-
-class Rv1:
-    """
-    Simple class encapsulating a Flux Rv1 resource set
-    """
-
-    def __init__(self, rset=None, state=None):
-        # pylint: disable=invalid-name
-        self.R_lite = []
-        if rset is not None:
-            self.R_lite = rset["execution"]["R_lite"]
-        if state:
-            self._state = state
-
-    def __str__(self):
-        """
-        Return short-form string for an Rv1 resource set (cores only)
-        """
-        items = []
-        # Group ranks with same core idsets for more compact output
-        for _, x in groupby(self.R_lite, lambda x: x["children"]["core"]):
-            group = list(x)
-            ranks = set()
-            cores = bracket(group[0]["children"]["core"])
-            for i in (idset_expand(entry["rank"]) for entry in group):
-                ranks.update(i)
-            if cores:
-                items.append("rank{}/core{}".format(idset_encode(ranks), cores))
-        return " ".join(items)
-
-    @classmethod
-    def from_setlist(cls, setlist):
-        """
-        Build an Rv1 dictionary from a list-of-sets style resource set,
-        then use this to construct an Rv1 object
-        """
-        rlite = []
-        for rank, children in setlist.items():
-            entry = {"rank": str(rank), "children": {}}
-            for child, idset in children.items():
-                entry["children"][child] = idset_encode(idset)
-            rlite.append(entry)
-
-        return Rv1({"execution": {"R_lite": rlite}})
-
-    def setlist(self):
-        """
-        Return a "setlist" representation of a resource set.
-        This is a dictionary of ranks, with each entry pointing
-        to a dictionary of Python sets, one for each child resource type.
-        e.g.
-        R = { "0": { "core": { 0, 1, 2, 3 }, "gpu": { 0 } }
-        """
-        result = {}
-        for entry in self.R_lite:
-            for rank in idset_expand(entry["rank"]):
-                result[rank] = {}
-                for child, idset in entry["children"].items():
-                    result[rank][child] = idset_toset(idset)
-        return result
-
-    def subtract(self, res):
-        """
-        Subtract one Rv1 resource set from another and return the result
-        """
-        set1 = self.setlist()
-        set2 = res.setlist()
-        for rank, children in set2.items():
-            for child in children:
-                if rank in set1 and child in set1[rank]:
-                    set1[rank][child] -= set2[rank][child]
-                    if not set1[rank][child]:
-                        del set1[rank][child]
-                    if not set1[rank]:
-                        del set1[rank]
-        return Rv1.from_setlist(set1)
-
-    def __sub__(self, res):
-        return self.subtract(res)
-
-    def _count_resource(self, name):
-        """
-        Return total number of child resources of name "name"
-        """
-        total = 0
-        for entry in self.R_lite:
-            ranks = len(idset_expand(entry["rank"]))
-            try:
-                nitems = len(idset_expand(entry["children"][name]))
-                total += ranks * nitems
-            except KeyError:
-                pass
-        return total
-
-    @property
-    def state(self):
-        return self._state
-
-    @state.setter
-    def state(self, value):
-        self._state = value
-
-    @memoized_property
-    def rlist(self):
-        return str(self)
-
-    @memoized_property
-    def ranks(self):
-        ranks = []
-        for entry in self.R_lite:
-            ranks.extend(idset_expand(entry["rank"]))
-        return idset_encode(ranks)
-
-    @memoized_property
-    def nnodes(self):
-        nnodes = 0
-        for entry in self.R_lite:
-            nnodes += len(idset_expand(entry["rank"]))
-        return nnodes
-
-    @memoized_property
-    def ncores(self):
-        return self._count_resource("core")
-
-    @memoized_property
-    def ngpus(self):
-        return self._count_resource("gpu")
-
-
 class SchedResourceList:
     """
     Encapsulate response from sched.resource-status query.
@@ -252,7 +65,9 @@ class SchedResourceList:
 
     def __init__(self, resp):
         for state in ["all", "down", "allocated"]:
-            setattr(self, f"_{state}", Rv1(resp.get(state), state=state))
+            rset = ResourceSet(resp.get(state))
+            rset.state = state
+            setattr(self, f"_{state}", rset)
 
     def __getattr__(self, attr):
         if attr.startswith("_"):

--- a/src/cmd/flux-resource.py
+++ b/src/cmd/flux-resource.py
@@ -103,6 +103,7 @@ def list_handler(args):
         "ncores": "NCORES",
         "ngpus": "NGPUS",
         "ranks": "RANKS",
+        "nodelist": "NODELIST",
         "rlist": "LIST",
     }
 
@@ -112,9 +113,10 @@ def list_handler(args):
             LOGGER.error("Invalid resource state %s specified", state)
             sys.exit(1)
 
-    fmt = "{state:>10} {nnodes:>6} {ncores:>8} {ngpus:>8}"
     if args.verbose:
-        fmt += " {rlist}"
+        fmt = "{state:>10} {nnodes:>6} {ncores:>8} {ngpus:>8} {rlist}"
+    else:
+        fmt = "{state:>10} {nnodes:>6} {ncores:>8} {ngpus:>8} {nodelist}"
     if args.format:
         fmt = args.format
 

--- a/src/common/librlist/rlist.c
+++ b/src/common/librlist/rlist.c
@@ -1304,6 +1304,19 @@ fail:
     return NULL;
 }
 
+char *rlist_encode (struct rlist *rl)
+{
+    json_t *o;
+    char *R;
+    if (!rl)
+        return NULL;
+    if (!(o = rlist_to_R (rl)))
+        return NULL;
+    R = json_dumps (o, 0);
+    json_decref (o);
+    return R;
+}
+
 static int by_rank (const void *item1, const void *item2)
 {
     const struct rnode *x = item1;

--- a/src/common/librlist/rlist.c
+++ b/src/common/librlist/rlist.c
@@ -922,9 +922,6 @@ struct rlist *rlist_from_R (const char *s)
     json_t *o = json_loads (s, 0, &err);
     if (o)
         rl = rlist_from_json (o, &err);
-    if (!rl)
-        fprintf (stderr, "line %d: col %d: pos %d: err=%s\n",
-                err.line, err.column, err.position, err.text);
     json_decref (o);
     return rl;
 }

--- a/src/common/librlist/rlist.h
+++ b/src/common/librlist/rlist.h
@@ -164,6 +164,13 @@ struct idset * rlist_hosts_to_ranks (const struct rlist *rl,
  */
 json_t * rlist_to_R (struct rlist *rl);
 
+
+/*
+ *  Encode resource list into v1 "R" string format.
+ *  Identical to `R = rlist_to_R (rl); return json_dumps (R, 0);`.
+ */
+char *rlist_encode (struct rlist *rl);
+
 /*
  *  Dump short form description of rlist `rl` as a single line string.
  *    Caller must free returned string.

--- a/src/common/librlist/rlist.h
+++ b/src/common/librlist/rlist.h
@@ -126,8 +126,6 @@ struct rlist *rlist_union (const struct rlist *rla, const struct rlist *rlb);
 struct rlist *rlist_intersect (const struct rlist *rla,
                               const struct rlist *rlb);
 
-struct rlist *rlist_get_rank (const struct rlist *rl, int rank);
-
 /*  Return number of resource nodes in resource list `rl`
  */
 size_t rlist_nnodes (const struct rlist *rl);

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -175,6 +175,7 @@ TESTSCRIPTS = \
 	python/t0013-job-list-inactive.py \
 	python/t0020-hostlist.py \
 	python/t0021-idset.py \
+	python/t0022-resource-set.py \
 	python/t1000-service-add-remove.py
 
 if HAVE_FLUX_SECURITY

--- a/t/python/t0022-resource-set.py
+++ b/t/python/t0022-resource-set.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python
+###############################################################
+# Copyright 2020 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+import json
+import unittest
+from pycotap import TAPTestRunner
+from flux.resource import ResourceSet, Rlist
+from flux.idset import IDset
+from flux.hostlist import Hostlist
+
+
+class TestRSet(unittest.TestCase):
+    R_input = """
+    {
+      "version": 1,
+      "execution": {
+        "R_lite": [
+          {
+            "rank": "0-3",
+            "children": {
+                "core": "0-3",
+                "gpu": "0"
+             }
+          }
+        ],
+        "starttime": 0,
+        "expiration": 0,
+        "nodelist": [
+          "fluke[0-3]"
+        ]
+      }
+    }
+    """
+
+    def test_init_string(self):
+        #  init by string
+        rset = ResourceSet(self.R_input)
+        self.assertEqual(str(rset), "rank[0-3]/core[0-3],gpu0")
+        self.assertEqual(rset.ncores, 16)
+        self.assertEqual(rset.ngpus, 4)
+
+    def test_init_dict(self):
+        #  init by dict
+        rdict = json.loads(self.R_input)
+        rset = ResourceSet(rdict)
+        self.assertEqual(str(rset), "rank[0-3]/core[0-3],gpu0")
+        self.assertEqual(rset.ncores, 16)
+        self.assertEqual(rset.ngpus, 4)
+        self.assertEqual(rset.nnodes, 4)
+
+    def test_init_implementation(self):
+        #  init by resource set implementation
+        rlist = Rlist().add_rank(0, cores="0-1").add_child(0, "gpu", "0")
+        rset = ResourceSet(rlist)
+        self.assertEqual(str(rset), "rank0/core[0-1],gpu0")
+        self.assertEqual(rset.ncores, 2)
+        self.assertEqual(rset.ngpus, 1)
+        self.assertEqual(rset.nnodes, 1)
+
+    def test_init_empty(self):
+        rset = ResourceSet()
+        self.assertEqual(str(rset), "")
+        self.assertEqual(rset.nnodes, 0)
+        self.assertEqual(rset.ncores, 0)
+        self.assertEqual(rset.ngpus, 0)
+
+    def test_init_assertions(self):
+        #  test invalid implementation
+        with self.assertRaises(TypeError):
+            ResourceSet((1, 2))
+
+        #  test invalid resource set string:
+        with self.assertRaises(ValueError):
+            ResourceSet("")
+
+        #  test invalid version
+        with self.assertRaises(ValueError):
+            ResourceSet({"version": 199})
+
+        #  test string with invalid version
+        with self.assertRaises(ValueError):
+            arg = json.dumps({"version": 199})
+            ResourceSet(arg)
+
+        #  test dict without 'version' string
+        with self.assertRaises(KeyError):
+            ResourceSet({})
+
+        #  test invalid JSON string
+        with self.assertRaises(json.decoder.JSONDecodeError):
+            ResourceSet("{")
+
+    def test_op(self):
+        set1 = ResourceSet(self.R_input)
+        set2 = set1.copy().remove_ranks("2-3")
+
+        # difference
+        result = set1 - set2
+        self.assertIsInstance(result, ResourceSet)
+        self.assertEqual(str(result), "rank[2-3]/core[0-3],gpu0")
+
+        set3 = result
+        # union
+        result = set3 | set1
+        self.assertIsInstance(result, ResourceSet)
+        self.assertEqual(str(result), "rank[0-3]/core[0-3],gpu0")
+
+        # intersection
+        result = set1 & set2
+        self.assertIsInstance(result, ResourceSet)
+        self.assertEqual(str(result), "rank[0-1]/core[0-3],gpu0")
+
+    def test_encode(self):
+        rset = ResourceSet(self.R_input)
+        rstring = rset.encode()
+        rset2 = ResourceSet(rstring)
+        self.assertEqual(str(rset), str(rset2))
+
+    def test_append(self):
+        rset = ResourceSet(self.R_input)
+        rset2 = ResourceSet(Rlist().add_rank(4, cores="0-3").add_child(4, "gpu", "0"))
+        rset.append(rset2)
+        self.assertEqual(str(rset), "rank[0-4]/core[0-3],gpu0")
+
+    def test_nodelist(self):
+        rset = ResourceSet(self.R_input)
+        self.assertIsInstance(rset.nodelist, Hostlist)
+        self.assertEqual(rset.nodelist.count(), 4)
+        self.assertEqual(str(rset.nodelist), "fluke[0-3]")
+
+    def test_ranks(self):
+        rset = ResourceSet(self.R_input)
+        self.assertIsInstance(rset.ranks, IDset)
+        self.assertEqual(rset.ranks.count(), 4)
+        self.assertEqual(str(rset.ranks), "0-3")
+
+    def test_state(self):
+        rset = ResourceSet(self.R_input)
+        self.assertIsNone(rset.state)
+        rset.state = "up"
+        self.assertEqual(rset.state, "up")
+
+
+if __name__ == "__main__":
+    unittest.main(testRunner=TAPTestRunner())
+
+
+# vi: ts=4 sw=4 expandtab

--- a/t/t2350-resource-list.t
+++ b/t/t2350-resource-list.t
@@ -6,13 +6,19 @@ test_description='flux-resource list tests'
 test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
 . $(dirname $0)/sharness.sh
 
+# Use a static format to avoid breaking output if default flux-resource list
+#  format ever changes
+FORMAT="{state:>10} {nnodes:>6} {ncores:>8} {ngpus:>8}"
+
 for input in ${SHARNESS_TEST_SRCDIR}/resource-status/*.json; do
     name=$(basename ${input%%.json})
     test_expect_success "flux-resource list input check: $name" '
         base=${input%%.json} &&
         expected=${base}.expected &&
         name=$(basename $base) &&
-        flux resource list --from-stdin < $input > $name.output 2>&1 &&
+        flux resource list -o "$FORMAT" \
+            --from-stdin < $input > $name.output 2>&1 &&
+        test_debug "cat $name.output" &&
         test_cmp $expected $name.output
     '
 done


### PR DESCRIPTION
This PR adds a python `ResourceSet` class -- a generic interface for parsing and using _R_.

In this first cut, `ResourceSet` is built from an underlying _implementation_, which for _R_ version 1 is a new binding for the C `librlist` API.

Each implementation must be a member of a `ResourceSetImplementation` abstract base class, which provides the minimum interface necessary for the generic `ResourceSet` class to implement its API.

I kept the API fairly simple for now. The hope is that when we have an Rv2 implementation, it can be plugged in as the version 2 implementation of `ResourceSet`, and zero users of `ResourceSet` will need to be updated. 

Finally, the hand-coded `Rv1` and `IDset` implementations in `flux-resource.py` are dropped and the script is updated to use `ResourceSet` for working with R objects.