### PR TITLE
job-manager: in mode=single, schedule higher priority jobs due to urgency change

### DIFF
--- a/src/modules/job-manager/alloc.c
+++ b/src/modules/job-manager/alloc.c
@@ -81,7 +81,7 @@ static void interface_teardown (struct alloc *alloc, char *s, int errnum)
                 job->alloc_pending = 0;
                 job->alloc_queued = 1;
                 alloc->pending_job = NULL;
-                annotations_clear (job, &cleared);
+                annotations_sched_clear (job, &cleared);
                 if (cleared) {
                     if (event_job_post_pack (ctx->event, job, "annotations",
                                              EVENT_JOURNAL_ONLY,
@@ -311,7 +311,10 @@ static void alloc_response_cb (flux_t *h, flux_msg_handler_t *mh,
         job->alloc_pending = 0;
         if (alloc->mode == SCHED_SINGLE)
             alloc->pending_job = NULL;
-        annotations_clear (job, &cleared);
+        if (job->state == FLUX_JOB_STATE_SCHED)
+            annotations_sched_clear (job, &cleared);
+        else
+            annotations_clear (job, &cleared);
         if (cleared) {
             if (event_job_post_pack (ctx->event, job, "annotations",
                                      EVENT_JOURNAL_ONLY,

--- a/src/modules/job-manager/alloc.h
+++ b/src/modules/job-manager/alloc.h
@@ -52,6 +52,9 @@ struct job *alloc_queue_next (struct alloc *alloc);
  */
 void alloc_queue_reorder (struct alloc *alloc, struct job *job);
 
+/* Recalculate pending job, e.g. after urgency change */
+int alloc_queue_recalc_pending (struct alloc *alloc);
+
 void alloc_disconnect_rpc (flux_t *h,
                            flux_msg_handler_t *mh,
                            const flux_msg_t *msg,

--- a/src/modules/job-manager/annotate.c
+++ b/src/modules/job-manager/annotate.c
@@ -46,6 +46,16 @@ void annotations_clear (struct job *job, bool *cleared)
     }
 }
 
+void annotations_sched_clear (struct job *job, bool *cleared)
+{
+    if (job->annotations) {
+        if (json_object_del (job->annotations, "sched") == 0) {
+            if (cleared)
+                (*cleared) = true;
+        }
+    }
+}
+
 /* we want to delete items set to 'null', so this is not the same
  * as json_object_update_recursive() in jansson 2.13.1
  */

--- a/src/modules/job-manager/annotate.h
+++ b/src/modules/job-manager/annotate.h
@@ -17,6 +17,7 @@
 #include "job-manager.h"
 
 void annotations_clear (struct job *job, bool *cleared);
+void annotations_sched_clear (struct job *job, bool *cleared);
 int annotations_update (flux_t *h, struct job *job, json_t *annotations);
 
 struct annotate *annotate_ctx_create (struct job_manager *ctx);

--- a/src/modules/job-manager/event.c
+++ b/src/modules/job-manager/event.c
@@ -337,6 +337,8 @@ int event_job_action (struct event *event, struct job *job)
         case FLUX_JOB_STATE_SCHED:
             if (alloc_enqueue_alloc_request (ctx->alloc, job) < 0)
                 return -1;
+            if (alloc_queue_recalc_pending (ctx->alloc) < 0)
+                return -1;
             break;
         case FLUX_JOB_STATE_RUN:
             if (start_send_request (ctx->start, job) < 0)

--- a/src/modules/job-manager/urgency.c
+++ b/src/modules/job-manager/urgency.c
@@ -119,6 +119,8 @@ void urgency_handle_request (flux_t *h,
                                  "priority", job->priority) < 0)
             goto error;
         alloc_queue_reorder (ctx->alloc, job);
+        if (alloc_queue_recalc_pending (ctx->alloc) < 0)
+            flux_log_error (h, "%s: alloc_queue_recalc_pending", __FUNCTION__);
     }
     if (flux_respond (h, msg, NULL) < 0)
         flux_log_error (h, "%s: flux_respond", __FUNCTION__);

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -107,6 +107,7 @@ TESTSCRIPTS = \
 	t2206-job-manager-bulk-state.t \
 	t2207-job-manager-wait.t \
 	t2208-queue-cmd.t \
+	t2209-job-manager-job-urgency-change.t \
 	t2210-job-manager-bugs.t \
 	t2211-job-manager-events-journal.t \
 	t2212-job-manager-jobspec.t \

--- a/t/t2209-job-manager-job-urgency-change.t
+++ b/t/t2209-job-manager-job-urgency-change.t
@@ -1,0 +1,169 @@
+#!/bin/sh
+
+test_description='Test flux job manager service urgency change to job'
+
+. `dirname $0`/job-manager/sched-helper.sh
+
+. $(dirname $0)/sharness.sh
+
+test_under_flux 4 kvs
+
+SCHED_DUMMY=${FLUX_BUILD_DIR}/t/job-manager/.libs/sched-dummy.so
+
+flux setattr log-stderr-level 1
+
+test_expect_success 'flux-job: generate jobspec for simple test job' '
+        flux jobspec srun -n1 hostname >basic.json
+'
+
+test_expect_success 'job-manager: load job-ingest, job-manager' '
+        flux module load job-manager &&
+        flux module load job-ingest &&
+        flux exec -r all -x 0 flux module load job-ingest &&
+        flux module load job-info
+'
+
+test_expect_success 'job-manager: submit 4 jobs' '
+        flux job submit --flags=debug basic.json >job1.id &&
+        flux job submit --flags=debug basic.json >job2.id &&
+        flux job submit --flags=debug basic.json >job3.id &&
+        flux job submit --flags=debug basic.json >job4.id
+'
+
+test_expect_success 'job-manager: job state SSSS (no scheduler)' '
+        jmgr_check_state $(cat job1.id) S &&
+        jmgr_check_state $(cat job2.id) S &&
+        jmgr_check_state $(cat job3.id) S &&
+        jmgr_check_state $(cat job4.id) S
+'
+
+test_expect_success HAVE_JQ 'job-manager: no annotations (SSSS)' '
+        jmgr_check_no_annotations $(cat job1.id) &&
+        jmgr_check_no_annotations $(cat job2.id) &&
+        jmgr_check_no_annotations $(cat job3.id) &&
+        jmgr_check_no_annotations $(cat job4.id)
+'
+
+test_expect_success 'job-manager: load sched-dummy --cores=2' '
+        flux module load ${SCHED_DUMMY} --cores=2
+'
+
+test_expect_success 'job-manager: job state RRSS' '
+        jmgr_check_state $(cat job1.id) R &&
+        jmgr_check_state $(cat job2.id) R &&
+        jmgr_check_state $(cat job3.id) S &&
+        jmgr_check_state $(cat job4.id) S
+'
+
+test_expect_success HAVE_JQ 'job-manager: annotate job id 3 (RRSS)' '
+        jmgr_check_no_annotations $(cat job1.id) &&
+        jmgr_check_no_annotations $(cat job2.id) &&
+        jmgr_check_annotation $(cat job3.id) "sched.reason_pending" "\"no cores available\"" &&
+        jmgr_check_no_annotations $(cat job4.id)
+'
+
+test_expect_success HAVE_JQ 'job-manager: user annotate jobs' '
+        flux job annotate $(cat job3.id) mykey foo &&
+        flux job annotate $(cat job4.id) mykey bar
+'
+
+test_expect_success HAVE_JQ 'job-manager: annotations in job id 3-4 (RRSS)' '
+        jmgr_check_no_annotations $(cat job1.id) &&
+        jmgr_check_no_annotations $(cat job2.id) &&
+        jmgr_check_annotation $(cat job3.id) "user.mykey" "\"foo\"" &&
+        jmgr_check_annotation $(cat job3.id) "sched.reason_pending" "\"no cores available\"" &&
+        jmgr_check_annotation $(cat job4.id) "user.mykey" "\"bar\""
+'
+
+test_expect_success 'job-manager: increase urgency of job 4' '
+        flux job urgency $(cat job4.id) 20
+'
+
+test_expect_success HAVE_JQ 'job-manager: annotations in job id 3-4 updated (RRSS)' '
+        jmgr_check_no_annotations $(cat job1.id) &&
+        jmgr_check_no_annotations $(cat job2.id) &&
+        jmgr_check_annotation $(cat job3.id) "user.mykey" "\"foo\"" &&
+        test_must_fail jmgr_check_annotation_exists $(cat job3.id) "sched.reason_pending" &&
+        jmgr_check_annotation $(cat job4.id) "user.mykey" "\"bar\"" &&
+        jmgr_check_annotation $(cat job4.id) "sched.reason_pending" "\"no cores available\""
+'
+
+test_expect_success 'job-manager: cancel 2' '
+        flux job cancel $(cat job2.id)
+'
+
+test_expect_success 'job-manager: job state RISR (job 4 runs instead of 3)' '
+        jmgr_check_state $(cat job1.id) R &&
+        jmgr_check_state $(cat job2.id) I &&
+        jmgr_check_state $(cat job3.id) S &&
+        jmgr_check_state $(cat job4.id) R
+'
+
+test_expect_success HAVE_JQ 'job-manager: annotations in job id 3-4 updated (RISR)' '
+        jmgr_check_no_annotations $(cat job1.id) &&
+        jmgr_check_no_annotations $(cat job2.id) &&
+        jmgr_check_annotation $(cat job3.id) "user.mykey" "\"foo\"" &&
+        jmgr_check_annotation $(cat job3.id) "sched.reason_pending" "\"no cores available\"" &&
+        jmgr_check_annotation $(cat job4.id) "user.mykey" "\"bar\"" &&
+        test_must_fail jmgr_check_annotation_exists $(cat job4.id) "sched.reason_pending"
+'
+
+test_expect_success 'job-manager: submit high urgency job' '
+        flux job submit --flags=debug --urgency=20 basic.json >job5.id
+'
+
+test_expect_success 'job-manager: job state RISRS' '
+        jmgr_check_state $(cat job1.id) R &&
+        jmgr_check_state $(cat job2.id) I &&
+        jmgr_check_state $(cat job3.id) S &&
+        jmgr_check_state $(cat job4.id) R &&
+        jmgr_check_state $(cat job5.id) S
+'
+
+test_expect_success HAVE_JQ 'job-manager: annotations in job id 3-5 updated (RISRS)' '
+        jmgr_check_no_annotations $(cat job1.id) &&
+        jmgr_check_no_annotations $(cat job2.id) &&
+        jmgr_check_annotation $(cat job3.id) "user.mykey" "\"foo\"" &&
+        test_must_fail jmgr_check_annotation_exists $(cat job3.id) "sched.reason_pending" &&
+        jmgr_check_annotation $(cat job4.id) "user.mykey" "\"bar\"" &&
+        jmgr_check_annotation $(cat job5.id) "sched.reason_pending" "\"no cores available\""
+'
+
+test_expect_success 'job-manager: cancel 1' '
+        flux job cancel $(cat job1.id)
+'
+
+test_expect_success 'job-manager: job state IISRR (job 5 runs instead of 3)' '
+        jmgr_check_state $(cat job1.id) I &&
+        jmgr_check_state $(cat job2.id) I &&
+        jmgr_check_state $(cat job3.id) S &&
+        jmgr_check_state $(cat job4.id) R &&
+        jmgr_check_state $(cat job5.id) R
+'
+
+test_expect_success HAVE_JQ 'job-manager: annotations in job id 3-5 updated (IISRR)' '
+        jmgr_check_no_annotations $(cat job1.id) &&
+        jmgr_check_no_annotations $(cat job2.id) &&
+        jmgr_check_annotation $(cat job3.id) "user.mykey" "\"foo\"" &&
+        jmgr_check_annotation $(cat job3.id) "sched.reason_pending" "\"no cores available\"" &&
+        jmgr_check_annotation $(cat job4.id) "user.mykey" "\"bar\"" &&
+        jmgr_check_no_annotations $(cat job5.id)
+'
+
+test_expect_success 'job-manager: cancel all jobs' '
+        flux job cancel $(cat job3.id) &&
+        flux job cancel $(cat job4.id) &&
+        flux job cancel $(cat job5.id)
+'
+
+test_expect_success 'job-manager: remove sched-dummy' '
+        flux module remove sched-dummy
+'
+
+test_expect_success 'job-manager: remove job-manager, job-ingest' '
+        flux module remove job-info &&
+        flux module remove job-manager &&
+        flux exec -r all flux module remove job-ingest
+'
+
+test_done

--- a/t/t2234-job-info-list-update.t
+++ b/t/t2234-job-info-list-update.t
@@ -206,13 +206,14 @@ EOT
 '
 
 test_expect_success HAVE_JQ 'change a job urgency' '
-        jobid=`head -n 1 pending.ids` &&
+        jobid=`head -n 3 pending.ids | tail -n 1` &&
         flux job urgency ${jobid} 1
 '
 
 test_expect_success HAVE_JQ 'wait for job-info to see job urgency change' '
-        jobidhead=`head -n 6 pending.ids | tail -n 5 > pending_after.ids` &&
-        jobidchange=`head -n 1 pending.ids >> pending_after.ids` &&
+        jobidhead=`head -n 2 pending.ids > pending_after.ids` &&
+        jobidhead=`head -n 6 pending.ids | tail -n 3 >> pending_after.ids` &&
+        jobidchange=`head -n 3 pending.ids | tail -n 1 >> pending_after.ids` &&
         jobidend=`tail -n2 pending.ids >> pending_after.ids` &&
         i=0 &&
         while flux job list -s pending | jq .id > list_pending_after.out && \
@@ -230,7 +231,7 @@ test_expect_success HAVE_JQ 'wait for job-info to see job urgency change' '
 test_expect_success HAVE_JQ 'flux job list pending jobs with correct urgency' '
         cat >list_urgency_after.exp <<-EOT &&
 31
-20
+31
 20
 16
 16
@@ -245,7 +246,7 @@ EOT
 test_expect_success HAVE_JQ 'flux job list pending jobs with correct priority' '
         cat >list_priority_after.exp <<-EOT &&
 31
-20
+31
 20
 16
 16


### PR DESCRIPTION
I'll just repeat what @garlick wrote in #3333 here:

> In single mode, the job-manager may have at most one alloc request outstanding with the scheduler. The first job in the alloc queue is the one that is sent. If a new job is submitted that has a higher priority than that one, or an existing job is re-prioritized so that it has a higher priority, the outstanding alloc should be canceled so that the job at the top of the alloc queue can take its place.
