### PR TITLE
testsuite: support level N inception of flux testsuite

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -45,3 +45,8 @@ check-local: all
 if ENABLE_PYLINT
 	$(top_srcdir)/scripts/pylint
 endif
+
+check-prep: all
+	cd src && $(MAKE) check
+	cd doc && $(MAKE) check
+	cd t && $(MAKE) check-prep

--- a/src/bindings/python/flux/security.py
+++ b/src/bindings/python/flux/security.py
@@ -55,7 +55,7 @@ class SecurityContext(WrapperPimpl):
 
     def sign_wrap_as(self, userid, payload, mech_type=ffi.NULL, flags=0):
         if isinstance(payload, six.text_type):
-            payload = payload.encode("utf-8")
+            payload = payload.encode("utf-8", errors="surrogateescape")
         elif not isinstance(payload, six.binary_type):
             errstr = "payload must be a text or binary type, not {}"
             raise TypeError(errstr.format(type(payload)))

--- a/src/cmd/flux-jobspec.py
+++ b/src/cmd/flux-jobspec.py
@@ -261,7 +261,7 @@ def main():
     if args.format == "yaml":
         out = yaml.dump(jobspec)
     else:
-        out = json.dumps(jobspec)
+        out = json.dumps(jobspec, ensure_ascii=False)
     print(out)
 
 

--- a/src/test/checks_run.sh
+++ b/src/test/checks_run.sh
@@ -16,6 +16,7 @@
 #  RECHECK       Run `make recheck` if `make check` fails the first time
 #  PRELOAD       Set as LD_PRELOAD for make and tests
 #  POISON        Install poison libflux and flux(1) in image
+#  INCEPTION     Run tests under a flux instance with prove(1)
 #  chain_lint    Run sharness with --chain-lint if chain_lint=t
 #
 #  And, obviously, some crucial variables that configure itself cares about:
@@ -125,6 +126,12 @@ elif test "$TEST_INSTALL" = "t"; then
     CHECKCMDS="sudo make install && \
               /usr/bin/flux keygen --force && \
               FLUX_TEST_INSTALLED_PATH=/usr/bin ${MAKE} -j $JOBS check"
+
+# Run checks under prove(1):
+elif test "$INCEPTION" = "t"; then
+	CHECKCMDS="make -j ${JOBS} check-prep && \
+	           cd t && ../src/cmd/flux start -s1 ./prove-under-flux.sh && \
+	           cd .."
 fi
 
 if test -n "$PRELOAD" ; then
@@ -175,7 +182,7 @@ fi
 if test "$DISTCHECK" != "t"; then
   checks_group "${MAKECMDS}" eval ${MAKECMDS}
 fi
-checks_group "${CHECKCMDS}" eval ${CHECKCMDS}
+checks_group "${CHECKCMDS}" eval "${CHECKCMDS}"
 RC=$?
 
 if test "$RECHECK" = "t" -a $RC -ne 0; then

--- a/src/test/docker/docker-run-checks.sh
+++ b/src/test/docker/docker-run-checks.sh
@@ -18,7 +18,7 @@ declare -r prog=${0##*/}
 die() { echo -e "$prog: $@"; exit 1; }
 
 #
-declare -r long_opts="help,quiet,interactive,image:,flux-security-version:,jobs:,no-cache,no-home,distcheck,tag:,build-directory:,install-only,no-poison,recheck"
+declare -r long_opts="help,quiet,interactive,image:,flux-security-version:,jobs:,no-cache,no-home,distcheck,tag:,build-directory:,install-only,no-poison,recheck,inception"
 declare -r short_opts="hqIdi:S:j:t:D:Pr"
 declare -r usage="
 Usage: $prog [OPTIONS] -- [CONFIGURE_ARGS...]\n\
@@ -32,6 +32,7 @@ Options:\n\
      --no-cache                Disable docker caching\n\
      --no-home                 Skip mounting the host home directory\n\
      --install-only            Skip make check, only make install\n\
+     --inception               Run tests as flux jobs\n\
  -q, --quiet                   Add --quiet to docker-build\n\
  -t, --tag=TAG                 If checks succeed, tag image as NAME\n\
  -i, --image=NAME              Use base docker image NAME (default=$IMAGE)\n\
@@ -71,6 +72,7 @@ while true; do
       --no-cache)                  NO_CACHE="--no-cache";      shift   ;;
       --no-home)                   MOUNT_HOME_ARGS="";         shift   ;;
       --install-only)              INSTALL_ONLY=t;             shift   ;;
+      --inception)                 INCEPTION=t;                shift   ;;
       -P|--no-poison)              POISON=0;                   shift   ;;
       -t|--tag)                    TAG="$2";                   shift 2 ;;
       --)                          shift; break;                       ;;
@@ -118,6 +120,7 @@ fi
 echo "mounting $TOP as /usr/src"
 
 export POISON
+export INCEPTION
 export JOBS
 export DISTCHECK
 export RECHECK
@@ -167,6 +170,7 @@ else
         -e PYTHON_VERSION \
         -e PRELOAD \
         -e POISON \
+        -e INCEPTION \
         -e ASAN_OPTIONS \
         -e BUILD_DIR \
         -e S3_ACCESS_KEY_ID \

--- a/src/test/generate-matrix.py
+++ b/src/test/generate-matrix.py
@@ -73,6 +73,7 @@ class BuildMatrix:
         test_s3=False,
         coverage=False,
         recheck=True,
+        command_args="",
     ):
         """Add a build to the matrix.include array"""
 
@@ -80,7 +81,7 @@ class BuildMatrix:
         env = env or {}
 
         # The command to run:
-        command = f"{docker_run_checks} -j{jobs} --image={image}"
+        command = f"{docker_run_checks} -j{jobs} --image={image} {command_args}"
 
         # Add --recheck option if requested
         if recheck and "DISTCHECK" not in env:
@@ -187,6 +188,13 @@ matrix.add_build(
     image="centos8",
     env=dict(PYTHON_VERSION="3.6"),
     docker_tag=True,
+)
+
+# inception
+matrix.add_build(
+    name="inception",
+    image="bionic",
+    command_args="--inception",
 )
 
 print(matrix)

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -317,6 +317,9 @@ check_LTLIBRARIES = \
 	shell/plugins/log.la \
 	shell/plugins/test-event.la
 
+check-prep:
+	$(MAKE) $(check_PROGRAMS) $(check_LTLIBRARIES)
+
 dist_check_DATA = \
 	hwloc-data/sierra2/0.xml \
 	hwloc-data/sierra2/1.xml \

--- a/t/job-archive/query.py
+++ b/t/job-archive/query.py
@@ -48,9 +48,13 @@ if __name__ == "__main__":
 
     rows = cursor.fetchall()
 
+    #  make print below safe to handle utf-8
+    utf8out = open(1, "w", encoding="utf-8", closefd=False)
+
     for row in rows:
         for key in row.keys():
-            print(key + " = " + str(row[key]))
+            val = row[key]
+            print(f"{key} = {val}", file=utf8out)
 
     con.close()
     sys.exit(0)

--- a/t/jobspec/summarize-minimal-jobspec.py
+++ b/t/jobspec/summarize-minimal-jobspec.py
@@ -11,7 +11,8 @@ import yaml
 
 def load_jobspec(stream, prefix=""):
     try:
-        jobspec = yaml.safe_load(stream)
+        data = stream.read().encode("utf-8")
+        jobspec = yaml.safe_load(data)
         return jobspec
     except (yaml.YAMLError) as e:
         print("{}{}".format(prefix, e.problem))
@@ -56,7 +57,7 @@ def main():
 
     if args.jobspec:
         try:
-            with open(args.jobspec, "r") as fd:
+            with open(args.jobspec, "r", encoding="utf-8") as fd:
                 jobspec = yaml.safe_load(fd)
         except (OSError, IOError) as e:
             print("{}{}".format(args.jobspec, e.strerror))

--- a/t/jobspec/validate.py
+++ b/t/jobspec/validate.py
@@ -11,7 +11,8 @@ import jsonschema
 def validate_input(jobspec_stream, schema, label=""):
     errors = 0
     try:
-        data = yaml.safe_load(jobspec_stream)
+        raw = jobspec_stream.read().encode("utf-8", errors="surrogateescape")
+        data = yaml.safe_load(raw)
         jsonschema.validate(data, schema)
     except (yaml.YAMLError) as e:
         print("{}: {}".format(label, e.problem))
@@ -30,7 +31,7 @@ def validate_input(jobspec_stream, schema, label=""):
 def validate_inputfile(infile, schema):
     errors = 0
     try:
-        with open(infile) as fd:
+        with open(infile, encoding="utf-8", errors="surrogateescape") as fd:
             errors += validate_input(fd, schema, label=infile)
     except (OSError, IOError) as e:
         print("{}: {}".format(infile, e.strerror))

--- a/t/prove-under-flux.sh
+++ b/t/prove-under-flux.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+prove --merge --timer -j 128 --exec="flux mini run -n1" ./t*.t ./python/t*.py

--- a/t/python/sideflux.py
+++ b/t/python/sideflux.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 ###############################################################
 # Copyright 2014 Lawrence Livermore National Security, LLC
 # (c.f. AUTHORS, NOTICE.LLNS, COPYING)

--- a/t/python/subflux.py
+++ b/t/python/subflux.py
@@ -27,6 +27,8 @@ builddir = os.path.abspath(
 )
 flux_exe = os.path.join(builddir, "src", "cmd", "flux")
 
+sys.path.append(script_dir + "/tap")
+
 
 def is_exe(fpath):
     return os.path.isfile(fpath) and os.access(fpath, os.X_OK)

--- a/t/python/subflux.py
+++ b/t/python/subflux.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 ###############################################################
 # Copyright 2014 Lawrence Livermore National Security, LLC

--- a/t/python/t0001-handle.py
+++ b/t/python/t0001-handle.py
@@ -10,14 +10,12 @@
 # SPDX-License-Identifier: LGPL-3.0
 ###############################################################
 
-from __future__ import print_function
-
 import unittest
 import syslog
 import six
 
 import flux
-from subflux import rerun_under_flux
+from subflux import rerun_under_flux, script_dir
 
 
 def __flux_size():

--- a/t/python/t0001-handle.py
+++ b/t/python/t0001-handle.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 ###############################################################
 # Copyright 2014 Lawrence Livermore National Security, LLC

--- a/t/python/t0002-wrapper.py
+++ b/t/python/t0002-wrapper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 ###############################################################
 # Copyright 2014 Lawrence Livermore National Security, LLC

--- a/t/python/t0003-barrier.py
+++ b/t/python/t0003-barrier.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 ###############################################################
 # Copyright 2014 Lawrence Livermore National Security, LLC

--- a/t/python/t0004-event.py
+++ b/t/python/t0004-event.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 ###############################################################
 # Copyright 2014 Lawrence Livermore National Security, LLC

--- a/t/python/t0005-kvs.py
+++ b/t/python/t0005-kvs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 ###############################################################
 # Copyright 2014 Lawrence Livermore National Security, LLC

--- a/t/python/t0006-request.py
+++ b/t/python/t0006-request.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 ###############################################################
 # Copyright 2014 Lawrence Livermore National Security, LLC

--- a/t/python/t0007-watchers.py
+++ b/t/python/t0007-watchers.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 ###############################################################
 # Copyright 2014 Lawrence Livermore National Security, LLC

--- a/t/python/t0009-security.py
+++ b/t/python/t0009-security.py
@@ -11,10 +11,15 @@
 ###############################################################
 
 import os
+import sys
 import unittest
 from tempfile import NamedTemporaryFile
 
-from flux.security import SecurityContext
+try:
+    from flux.security import SecurityContext
+except:
+    print("1..0 # skip flux.security module not available")
+    sys.exit(0)
 
 
 def __flux_size():

--- a/t/python/t0009-security.py
+++ b/t/python/t0009-security.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 ###############################################################
 # Copyright 2014 Lawrence Livermore National Security, LLC

--- a/t/python/t0010-job.py
+++ b/t/python/t0010-job.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 ###############################################################
 # Copyright 2014 Lawrence Livermore National Security, LLC

--- a/t/python/t0012-futures.py
+++ b/t/python/t0012-futures.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 ###############################################################
 # Copyright 2019 Lawrence Livermore National Security, LLC

--- a/t/python/t0020-hostlist.py
+++ b/t/python/t0020-hostlist.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ###############################################################
 # Copyright 2020 Lawrence Livermore National Security, LLC
 # (c.f. AUTHORS, NOTICE.LLNS, COPYING)

--- a/t/python/t0020-hostlist.py
+++ b/t/python/t0020-hostlist.py
@@ -10,6 +10,7 @@
 ###############################################################
 
 import unittest
+import subflux
 from pycotap import TAPTestRunner
 import flux.hostlist as hostlist
 

--- a/t/python/t0021-idset.py
+++ b/t/python/t0021-idset.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ###############################################################
 # Copyright 2020 Lawrence Livermore National Security, LLC
 # (c.f. AUTHORS, NOTICE.LLNS, COPYING)

--- a/t/python/t0021-idset.py
+++ b/t/python/t0021-idset.py
@@ -10,6 +10,7 @@
 ###############################################################
 
 import unittest
+import subflux
 from pycotap import TAPTestRunner
 import flux.idset as idset
 

--- a/t/python/t0022-resource-set.py
+++ b/t/python/t0022-resource-set.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ###############################################################
 # Copyright 2020 Lawrence Livermore National Security, LLC
 # (c.f. AUTHORS, NOTICE.LLNS, COPYING)

--- a/t/python/t0022-resource-set.py
+++ b/t/python/t0022-resource-set.py
@@ -11,6 +11,7 @@
 
 import json
 import unittest
+import subflux
 from pycotap import TAPTestRunner
 from flux.resource import ResourceSet, Rlist
 from flux.idset import IDset

--- a/t/python/t1000-service-add-remove.py
+++ b/t/python/t1000-service-add-remove.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 ###############################################################
 # Copyright 2014 Lawrence Livermore National Security, LLC

--- a/t/t0021-flux-jobspec.t
+++ b/t/t0021-flux-jobspec.t
@@ -178,7 +178,7 @@ test_expect_success HAVE_JQ 'current working directory encoded in jobspec' '
 '
 
 test_expect_success HAVE_JQ 'current environment encoded in jobspec' '
-    flux python -c "import os,json; print (json.dumps(dict(os.environ)))" | \
+    flux python -c "import os,json; print (json.dumps(dict(os.environ), ensure_ascii=False))" | \
         jq -S . >environ.expected &&
     flux jobspec srun hostname | \
         jq -S -e ".attributes.system.environment" > environ.output &&
@@ -218,7 +218,7 @@ test_expect_success HAVE_JQ 'jobspec srun --export=VAR,VAR2,... works' '
 
 test_expect_success HAVE_JQ 'jobspec srun --export=ALL,VAR=val works' '
     FLOOP=boop \
-      flux python -c "import os,json; print (json.dumps(dict(os.environ)))" | \
+      flux python -c "import os,json; print (json.dumps(dict(os.environ), ensure_ascii=False))" | \
         jq -S . >floop.expected &&
     flux jobspec srun --export=ALL,FLOOP=boop hostname | \
         jq -S ".attributes.system.environment" > floop.output &&

--- a/t/t2604-job-shell-affinity.t
+++ b/t/t2604-job-shell-affinity.t
@@ -120,9 +120,11 @@ test_expect_success 'flux-shell: gpu-affinity=per-task' '
 	test_cmp ${name}.expected ${name}.out
 '
 test_expect_success 'flux-shell: gpu-affinity=off' '
-	name=gpu-off &&
-	flux mini run -N1 -n2 --dry-run -o gpu-affinity=off \
-		printenv CUDA_VISIBLE_DEVICES > j.${name} &&
+	name=gpu-off && (
+	  unset CUDA_VISIBLE_DEVICES &&
+	  flux mini run -N1 -n2 --dry-run -o gpu-affinity=off \
+		printenv CUDA_VISIBLE_DEVICES > j.${name}
+	) &&
 	cat >${name}.expected <<-EOF  &&
 	EOF
 	test_expect_code 1  ${FLUX_SHELL} -s -v -r 0 -j j.${name} -R R.gpu 0 \

--- a/t/t2606-job-shell-output-redirection.t
+++ b/t/t2606-job-shell-output-redirection.t
@@ -301,6 +301,7 @@ test_expect_success 'job-shell: job attach exits cleanly if no kvs output (2-tas
         grep stderr:baz err26 &&
         ! test -s out26.attach &&
         sed -i -e "/stdin EOF could not be sent/d" err26.attach &&
+        sed -i -e "/affinity/d" err26.attach &&
         ! test -s err26.attach
 '
 


### PR DESCRIPTION
Problem: Many Flux tests in the testsuite fail when run as Flux jobs.

Most of the issues were utf-8 encoding problems in various Python libraries and scripts. This is triggered in a Flux job because `FLUX_JOB_ID` in the environment is encoded with F58 by default, but sharness resets `LANG=C` for all tests. When various python bits try to encode/decode the environment in jobspec, etc, then encoding exceptions are thrown.

This PR fixes a bunch of spots that were experiencing these exceptions by adding `errors="surrogateescape"` where necessary (though in one spot, stdin had to be reopened and forced to utf-8).

There were other little fixes along the way, including a small kludge to allow python tests in `t/python/t*.py` to be run by hand, which then allowed these scripts to be run as a Flux job, i.e. this now works:
```
$ flux mini run -n1 python/t0001-handle.py 
TAP version 13
ok 1 __main__.TestHandle.test_anonymous_handle_rpc_ping
ok 2 __main__.TestHandle.test_attr_get
ok 3 __main__.TestHandle.test_create_handle
ok 4 __main__.TestHandle.test_get_rank
ok 5 __main__.TestHandle.test_log
ok 6 __main__.TestHandle.test_rpc_null_payload
ok 7 __main__.TestHandle.test_rpc_ping
ok 8 __main__.TestHandle.test_rpc_ping_unicode
ok 9 __main__.TestHandle.test_rpc_with
1..9
```

With that all in place, and to avoid breaking running the testsuite as jobs in the future, an "inception" builder is introduced that runs all tests under `./t` under `flux-mini run` using `prove(1)`. See new script `t/prove-under-flux.sh`, which also can be used outside of the inception builder to run all tests in parallel in a large flux instance:

```
ƒ(s=32,d=0,builddir) grondo@fluke25:~/git/flux-core.git/t$ ./prove-under-flux.sh
[16:17:59] ./t0024-content-s3.t ............................... skipped: skipping content-s3 test since S3_HOSTNAME not set
[16:17:59] ./t0016-cron-faketime.t ............................ skipped: libfaketime not found. Skipping all tests
[16:18:00] ./t2004-hydra.t .................................... skipped: skipping hydra-launching-flux tests, mpiexec.hydra unavailable
[16:18:00] ./t2007-caliper.t .................................. skipped: skipping Caliper tests, Flux not built with Caliper support
[16:18:01] ./t1103-apidisconnect.t ............................ ok     1438 ms
[16:18:01] ./t0010-generic-utils.t ............................ ok     2083 ms
[16:18:01] ./t2006-hwloc-versions.t ........................... ok     2196 ms
[16:18:01] ./t2350-resource-list.t ............................ ok     2265 ms
[16:18:02] ./t0013-config-file.t .............................. ok     2479 ms
[16:18:02] ./t0008-attr.t ..................................... ok     2510 ms
[16:18:02] ./t0004-event.t .................................... ok     2512 ms
[16:18:02] ./t0009-dmesg.t .................................... ok     2512 ms
[16:18:02] ./t2206-job-manager-bulk-state.t ................... ok     2561 ms
[16:18:02] ./t1105-proxy.t .................................... ok     2587 ms
[16:18:02] ./t0014-runlevel.t ................................. ok     2616 ms
[16:18:02] ./t3000-mpi-basic.t ................................ skipped: skipping MPI tests, FLUX_TEST_MPI not set
[16:18:02] ./t1101-barrier-basic.t ............................ ok     2707 ms
[16:18:02] ./t2005-hwloc-basic.t .............................. ok     2742 ms
[16:18:02] ./t0002-request.t .................................. ok     2754 ms
[16:18:02] ./t0007-ping.t ..................................... ok     2754 ms
[16:18:02] ./t1102-cmddriver.t ................................ ok     2758 ms
[16:18:02] ./t2008-althash.t .................................. ok     2761 ms
[16:18:02] ./t1008-kvs-eventlog.t ............................. ok     2768 ms
[16:18:02] ./t0000-sharness.t ................................. ok     2779 ms
[16:18:02] ./t0012-content-sqlite.t ........................... ok     2777 ms
[16:18:02] ./t1106-ssh-connector.t ............................ ok     2772 ms
[16:18:02] ./t0011-content-cache.t ............................ ok     2781 ms
[16:18:02] ./t0018-content-files.t ............................ ok     2782 ms
[16:18:02] ./t0005-rexec.t .................................... ok     2798 ms
[16:18:02] ./t2010-kvs-snapshot-restore.t ..................... ok     2790 ms
[16:18:02] ./t2210-job-manager-bugs.t ......................... ok     2798 ms
[16:18:02] ./t2401-job-exec-hello.t ........................... ok     2746 ms
[16:18:02] ./t0005-exec.t ..................................... ok     2826 ms
[16:18:02] ./t0025-broker-state-machine.t ..................... ok     2823 ms
[16:18:02] ./t2212-job-manager-jobspec.t ...................... ok     2817 ms
[16:18:02] ./t0015-cron.t ..................................... ok     2830 ms
[16:18:02] ./t0026-flux-R.t ................................... ok     2829 ms
[16:18:02] ./t0022-jj-reader.t ................................ ok     2846 ms
[16:18:02] ./t2400-job-exec-test.t ............................ ok     2775 ms
[16:18:02] ./t0003-module.t ................................... ok     2858 ms
[16:18:02] ./t0020-terminus.t ................................. ok     2854 ms
[16:18:02] ./t2351-resource-status-input.t .................... ok     2783 ms
[16:18:02] ./t0021-flux-jobspec.t ............................. ok     2858 ms
[16:18:02] ./t2313-resource-acquire.t ......................... ok     1664 ms
[16:18:02] ./t1009-kvs-copy.t ................................. ok     2867 ms
[16:18:02] ./t2312-resource-exclude.t ......................... ok     1676 ms
[16:18:02] ./t0001-basic.t .................................... ok     2881 ms
[16:18:02] ./t1005-kvs-security.t ............................. ok     2880 ms
[16:18:02] ./python/t0020-hostlist.py ......................... ok       84 ms
[16:18:02] ./python/t0021-idset.py ............................ ok       78 ms
[16:18:02] ./t1004-kvs-namespace.t ............................ ok     2895 ms
[16:18:02] ./t2600-job-shell-rcalc.t .......................... ok     2825 ms
[16:18:02] ./t0019-jobspec-schema.t ........................... ok     2903 ms
[16:18:02] ./t0017-security.t ................................. ok     2905 ms
[16:18:02] ./t2208-queue-cmd.t ................................ ok     2899 ms
[16:18:02] ./python/t0022-resource-set.py ..................... ok       26 ms
[16:18:02] ./t2202-job-manager.t .............................. ok     2904 ms
[16:18:02] ./t2201-job-cmd.t .................................. ok     2912 ms
[16:18:02] ./t2501-job-status.t ............................... ok     3013 ms
[16:18:02] ./t2605-job-shell-output-redirection-standalone.t .. ok     3006 ms
[16:18:02] ./t2609-job-shell-events.t ......................... ok     2454 ms
[16:18:03] ./t2404-job-exec-multiuser.t ....................... ok     3347 ms
[16:18:03] ./python/t0002-wrapper.py .......................... ok       91 ms
[16:18:04] ./t2302-sched-simple-up-down.t ..................... ok     4419 ms
[16:18:04] ./python/t0009-security.py ......................... ok       83 ms
[16:18:04] ./t2234-job-info-list-update.t ..................... ok     4488 ms
[16:18:04] ./t2613-job-shell-batch.t .......................... ok     2936 ms
[16:18:04] ./python/t0001-handle.py ........................... ok      293 ms
[16:18:04] ./t2231-job-info-lookup.t .......................... ok     5039 ms
[16:18:04] ./python/t0004-event.py ............................ ok      311 ms
[16:18:04] ./t2203-job-manager-dummysched-single.t ............ ok     5324 ms
[16:18:05] ./python/t0005-kvs.py .............................. ok      394 ms
[16:18:05] ./python/t0006-request.py .......................... ok      296 ms
[16:18:05] ./t2311-resource-drain.t ........................... ok     4827 ms
[16:18:05] ./t2220-job-archive.t .............................. ok     5532 ms
[16:18:05] ./t2900-job-timelimits.t ........................... ok     2120 ms
[16:18:05] ./python/t0007-watchers.py ......................... ok      528 ms
[16:18:05] ./python/t1000-service-add-remove.py ............... ok      370 ms
[16:18:05] ./python/t0012-futures.py .......................... ok      408 ms
[16:18:05] ./t2300-sched-simple.t ............................. ok     6185 ms
[16:18:05] ./t2608-job-shell-log.t ............................ ok     4959 ms
[16:18:06] ./python/t0010-job.py .............................. ok     3120 ms
[16:18:06] ./t2314-resource-monitor.t ......................... ok     6076 ms
[16:18:06] ./t1001-kvs-internals.t ............................ ok     7325 ms
[16:18:07] ./t2610-job-shell-mpir.t ........................... ok     6249 ms
[16:18:07] ./t2211-job-manager-events-journal.t ............... ok     7843 ms
[16:18:07] ./t2603-job-shell-initrc.t ......................... ok     5028 ms
[16:18:07] ./t2604-job-shell-affinity.t ....................... ok     5542 ms
[16:18:07] ./python/t0013-job-list-inactive.py ................ ok     4279 ms
[16:18:07] ./t1000-kvs.t ...................................... ok     8204 ms
[16:18:08] ./t2601-job-shell-standalone.t ..................... ok     8288 ms
[16:18:08] ./t1007-kvs-lookup-watch.t ......................... ok     8782 ms
[16:18:08] ./t2402-job-exec-dummy.t ........................... ok     8919 ms
[16:18:08] ./python/t0003-barrier.py .......................... ok     1611 ms
[16:18:08] ./t2611-debug-emulate.t ............................ ok     5998 ms
[16:18:09] ./t2207-job-manager-wait.t ......................... ok     9435 ms
[16:18:09] ./t2403-job-exec-conf.t ............................ ok     9397 ms
[16:18:09] ./t2204-job-manager-dummysched-unlimited.t ......... ok     9483 ms
[16:18:09] ./t3001-mpi-personalities.t ........................ ok     3977 ms
[16:18:09] ./t2233-job-info-security.t ........................ ok    10057 ms
[16:18:10] ./t2500-job-attach.t ............................... ok     8652 ms
[16:18:10] ./t2315-resource-system.t .......................... ok    11051 ms
[16:18:10] ./t3002-pmi.t ...................................... ok     5161 ms
[16:18:10] ./t2607-job-shell-input.t .......................... ok    10505 ms
[16:18:10] ./t2606-job-shell-output-redirection.t ............. ok    10507 ms
[16:18:11] ./t2310-resource-module.t .......................... ok    11731 ms
[16:18:12] ./t3100-flux-in-flux.t ............................. ok     7333 ms
[16:18:12] ./t2700-mini-cmd.t ................................. ok     8582 ms
[16:18:13] ./t2232-job-info-eventlog-watch.t .................. ok    13348 ms
[16:18:14] ./t3200-instance-restart.t ......................... ok    10039 ms
[16:18:14] ./t2702-mini-alloc.t ............................... ok    12490 ms
[16:18:14] ./t2200-job-ingest.t ............................... ok    14435 ms
[16:18:16] ./t2612-job-shell-pty.t ............................ ok    15074 ms
[16:18:16] ./t2205-job-manager-annotate.t ..................... ok    16427 ms
[16:18:16] ./t2602-job-shell.t ................................ ok    16624 ms
[16:18:18] ./t4000-issues-test-driver.t ....................... ok    13450 ms
[16:18:19] ./t2701-mini-batch.t ............................... ok    17788 ms
[16:18:25] ./t2230-job-info-list.t ............................ ok    26099 ms
[16:18:28] ./t1003-kvs-stress.t ............................... ok    28704 ms
[16:18:32] ./t2800-jobs-cmd.t ................................. ok    29962 ms
[16:18:32] ./t5000-valgrind.t ................................. ok       18 ms
[16:18:32]
All tests successful.
Files=121, Tests=2773, 47 wallclock secs ( 0.67 usr  0.06 sys + 13.44 cusr  3.41 csys = 17.58 CPU)
Result: PASS
```