### PR TITLE
job-manager: Fix annotation clear corner case

### DIFF
--- a/src/modules/job-manager/annotate.c
+++ b/src/modules/job-manager/annotate.c
@@ -50,6 +50,9 @@ void annotations_sched_clear (struct job *job, bool *cleared)
 {
     if (job->annotations) {
         if (json_object_del (job->annotations, "sched") == 0) {
+            /* Special case if annotations are now empty */
+            if (!json_object_size (job->annotations))
+                annotations_clear (job, NULL);
             if (cleared)
                 (*cleared) = true;
         }

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -107,7 +107,7 @@ TESTSCRIPTS = \
 	t2206-job-manager-bulk-state.t \
 	t2207-job-manager-wait.t \
 	t2208-queue-cmd.t \
-	t2209-job-manager-job-urgency-change.t \
+	t2209-job-manager-job-urgency-change-single.t \
 	t2210-job-manager-bugs.t \
 	t2211-job-manager-events-journal.t \
 	t2212-job-manager-jobspec.t \

--- a/t/t2209-job-manager-job-urgency-change-single.t
+++ b/t/t2209-job-manager-job-urgency-change-single.t
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-test_description='Test flux job manager service urgency change to job'
+test_description='Test flux job manager urgency change to job (mode=single)'
 
 . `dirname $0`/job-manager/sched-helper.sh
 


### PR DESCRIPTION
didn't want to push on #2895 too quickly for the 0.22.0 release, so I punted that issue to 0.23.0.

But figure this simple testsuite cleanup (with #3417 in mind in the future) & minor job-manager bug could be put in for 0.22.0.
