### PR TITLE
Expand available job statistics and add flux-jobs --stats,--stats-only options

### DIFF
--- a/doc/man1/flux-jobs.rst
+++ b/doc/man1/flux-jobs.rst
@@ -53,6 +53,24 @@ OPTIONS
    Control output coloring. WHEN can be *never*, *always*, or *auto*.
    Defaults to *auto*.
 
+**--stats**
+   Output a summary of global job statistics before the header.
+   May be useful in conjunction with utilities like ``watch(1)``, e.g.::
+
+      $ watch -n 2 flux jobs --stats -f running -c 25
+
+   will display a summary of global statistics along with the top 25
+   running jobs, updated every 2 seconds.
+
+**--stats-only**
+   Output a summary of global job statistics and exit.
+   ``flux jobs`` will exit with non-zero exit status with ``--stats-only``
+   if there are no active jobs. This allows the following loop to work::
+
+       $ while flux jobs --stats-only; do sleep 2; done
+
+   All other options are ignored when ``--stats-only`` is used. 
+
 
 JOB STATUS
 ==========

--- a/src/bindings/python/flux/Makefile.am
+++ b/src/bindings/python/flux/Makefile.am
@@ -24,6 +24,7 @@ nobase_fluxpy_PYTHON = \
 	job/info.py \
 	job/submit.py \
 	job/wait.py \
+	job/stats.py \
 	job/_wrapper.py \
 	resource/Rlist.py \
 	resource/__init__.py \

--- a/src/bindings/python/flux/job/stats.py
+++ b/src/bindings/python/flux/job/stats.py
@@ -1,0 +1,94 @@
+###############################################################
+# Copyright 2020 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+from flux.rpc import RPC
+
+
+class JobStats:
+    """Container for job statistics as returned by job-info.job-stats
+
+
+    Attributes:
+        depend: Count of jobs current in DEPEND state
+        priority: Count of jobs in PRIORITY state
+        sched: Count of jobs in SCHED state
+        run: Count of jobs in RUN state
+        cleanup: Count of jobs in CLEANUP state
+        inactive: Count of INACTIVE jobs
+        active: Total number of active jobs (all states but INACTIVE)
+        failed: Total number of jobs that did not exit with zero status
+        successful: Total number of jobs completed with zero exit code
+        cancelled: Total number of jobs that were cancelled
+        timeout: Total number of jobs that timed out
+        pending: Sum of "depend", "priority", and "sched"
+        running: Sum of "run" and "cleanup"
+
+    """
+
+    def __init__(self, handle):
+        """Initialize a JobStats object with Flux handle ``handle``"""
+        self.handle = handle
+        self.callback = None
+        self.cb_kwargs = {}
+        for attr in [
+            "depend",
+            "sched",
+            "run",
+            "cleanup",
+            "inactive",
+            "failed",
+            "cancelled",
+            "timeout",
+            "pending",
+            "running",
+            "successful",
+            "active",
+        ]:
+            setattr(self, attr, -1)
+
+    def _update_cb(self, rpc):
+        resp = rpc.get()
+        for state, count in resp["job_states"].items():
+            setattr(self, state, count)
+        for state in ["failed", "timeout", "cancelled"]:
+            setattr(self, state, resp[state])
+
+        #  Compute some stats for convenience:
+        #  pylint: disable=attribute-defined-outside-init
+        self.pending = self.depend + self.priority + self.sched
+        self.running = self.run + self.cleanup
+        self.successful = self.inactive - self.failed
+        self.active = self.total - self.inactive
+
+        if self.callback:
+            self.callback(self, **self.cb_kwargs)
+
+    def _query(self):
+        return RPC(self.handle, "job-info.job-stats", {})
+
+    def update(self, callback=None, **kwargs):
+        """Asynchronously fetch job statistics and update this object.
+
+        Requires that the reactor for this handle be running in order to
+        process the result.
+
+        Args:
+            callback: Optional: a callback to call when asynchronous
+             update is complete.
+            kwargs: Optional: extra keyword arguments to pass to callback()
+        """
+        self.callback = callback
+        self.cb_kwargs = kwargs
+        self._query().then(self._update_cb)
+
+    def update_sync(self):
+        """Synchronously update job statistics"""
+        self._update_cb(self._query())
+        return self

--- a/src/common/libjob/job.h
+++ b/src/common/libjob/job.h
@@ -50,6 +50,8 @@ typedef enum {
     FLUX_JOB_STATE_INACTIVE               = 64,   // captive end state
 } flux_job_state_t;
 
+#define FLUX_JOB_NR_STATES 7
+
 /* Virtual states, for convenience.
  */
 enum {

--- a/src/modules/job-info/Makefile.am
+++ b/src/modules/job-info/Makefile.am
@@ -31,7 +31,9 @@ job_info_la_SOURCES = \
 	job_util.h \
 	job_util.c \
 	idsync.h \
-	idsync.c
+	idsync.c \
+	stats.h \
+	stats.c
 
 job_info_la_LDFLAGS = $(fluxmod_ldflags) -module
 job_info_la_LIBADD = $(fluxmod_libadd) \

--- a/src/modules/job-info/job_state.h
+++ b/src/modules/job-info/job_state.h
@@ -15,6 +15,7 @@
 #include <jansson.h>
 
 #include "info.h"
+#include "stats.h"
 
 /* To handle the common case of user queries on job state, we will
  * store jobs in three different lists.
@@ -45,13 +46,8 @@ struct job_state_ctx {
     zlistx_t *processing;
     zlistx_t *futures;
 
-    /* count current jobs in what states */
-    int depend_count;
-    int priority_count;
-    int sched_count;
-    int run_count;
-    int cleanup_count;
-    int inactive_count;
+    /*  Job statistics: */
+    struct job_stats stats;
 
     /* debug/testing - if paused store job events journal on list for
      * processing later */

--- a/src/modules/job-info/stats.c
+++ b/src/modules/job-info/stats.c
@@ -1,0 +1,115 @@
+/************************************************************\
+ * Copyright 2020 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <flux/core.h>
+
+#include "job_state.h"
+#include "stats.h"
+
+/*  Return the index into stats->state_count[] array for the
+ *   job state 'state'
+ */
+static inline int state_index (flux_job_state_t state)
+{
+    int i = 0;
+    while (!(state & (1<<i)))
+        i++;
+    assert (i < FLUX_JOB_NR_STATES);
+    return i;
+}
+
+/*  Return a lowercase state name for the state at 'index' the
+ *   stats->state_count[] array.
+ */
+static const char *state_index_name (int index)
+{
+    static char name[64];
+    char *p;
+
+    memset (name, 0, sizeof (name));
+    strncpy (name,
+            flux_job_statetostr ((1<<index), false),
+            sizeof (name) - 1);
+
+    for (p = name; *p != '\0'; ++p)
+        *p = tolower(*p);
+    return name;
+}
+
+void job_stats_update (struct job_stats *stats,
+                       struct job *job,
+                       flux_job_state_t newstate)
+{
+    stats->state_count[state_index(newstate)]++;
+
+    /*  Stats for NEW are not tracked */
+    if (job->state != FLUX_JOB_STATE_NEW)
+        stats->state_count[state_index(job->state)]--;
+
+    if (newstate == FLUX_JOB_STATE_INACTIVE && !job->success) {
+        stats->failed++;
+        if (job->exception_occurred) {
+            if (strcmp (job->exception_type, "cancel") == 0)
+                stats->cancelled++;
+            else if (strcmp (job->exception_type, "timeout") == 0)
+                stats->timeout++;
+        }
+    }
+}
+
+static int json_add_counter (json_t *o,
+                             const char *key,
+                             unsigned int n)
+{
+    json_t *val = json_integer (n);
+    if (!val || json_object_set_new (o, key, val) < 0) {
+        json_decref (val);
+        return -1;
+    }
+    return 0;
+}
+
+static json_t *job_states_encode (struct job_stats *stats)
+{
+    unsigned int total = 0;
+    json_t *o = json_object ();
+    if (!o)
+        return NULL;
+    for (int i = 1; i < FLUX_JOB_NR_STATES; i++) {
+        if (json_add_counter (o,
+                              state_index_name (i),
+                              stats->state_count[i]) < 0)
+            goto error;
+        total += stats->state_count[i];
+    }
+    if (json_add_counter (o, "total", total) < 0)
+        goto error;
+    return o;
+error:
+    json_decref (o);
+    return NULL;
+}
+
+json_t * job_stats_encode (struct job_stats *stats)
+{
+    json_t *states = job_states_encode (stats);
+    if (states == NULL)
+        return NULL;
+
+    return json_pack ("{ s:o s:i s:i s:i }",
+                      "job_states", states,
+                      "failed", stats->failed,
+                      "cancelled", stats->cancelled,
+                      "timeout", stats->timeout);
+}

--- a/src/modules/job-info/stats.h
+++ b/src/modules/job-info/stats.h
@@ -1,0 +1,34 @@
+/************************************************************\
+ * Copyright 2020 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _FLUX_JOB_INFO_JOB_STATS_H
+#define _FLUX_JOB_INFO_JOB_STATS_H
+
+#include <flux/core.h> /* FLUX_JOB_NR_STATES */
+
+struct job_stats {
+    unsigned int state_count[FLUX_JOB_NR_STATES];
+    unsigned int total;
+    unsigned int failed;
+    unsigned int timeout;
+    unsigned int cancelled;
+};
+
+/* Forward declaration of struct job to avoid circular header file
+ *  dependemncy.
+ */
+struct job;
+void job_stats_update (struct job_stats *stats,
+                       struct job *job,
+                       flux_job_state_t newstate);
+
+json_t * job_stats_encode (struct job_stats *stats);
+
+#endif /* ! _FLUX_JOB_INFO_JOB_STATS_H */

--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -971,6 +971,28 @@ for d in ${ISSUES_DIR}/*; do
 done
 
 
+# job stats
+test_expect_success 'flux-jobs --stats works' '
+	flux jobs --stats -a >stats.output &&
+	test_debug "cat stats.output" &&
+	fail=$(state_count failed cancelled) &&
+	run=$(state_count run) &&
+	inactive=$(state_count inactive) &&
+	active=$(state_count active) &&
+	comp=$((inactive - fail)) &&
+	pend=$((active - run)) &&
+	cat <<-EOF >stats.expected &&
+	${run} running, ${comp} completed, ${fail} failed, ${pend} pending
+	EOF
+	head -1 stats.output > stats.actual &&
+	test_cmp stats.expected stats.actual
+'
+
+test_expect_success 'flux-jobs --stats-only works' '
+	flux jobs --stats-only > stats-only.output &&
+	test_cmp stats.expected stats-only.output
+'
+
 test_expect_success 'cleanup job listing jobs ' '
         for jobid in `cat active.ids`; do \
             flux job cancel $jobid; \


### PR DESCRIPTION
This PR adds a few more meta-statistics to the `job-info.job-stats` RPC, adds a python `JobStats` class for fetching these statistics (and computing other convenient stats), and uses `JobStats` in newly introduced `flux jobs --stats,--stats-only` options.

This is just meant as the minimum solution for #3386, and to get the enhanced `job-info.job-stats` RPC into mainline for possible use in other work. Therefore, nothing too elaborate was done in `flux jobs` so it would be easy to change or undo in the future if we go another route.

One thing that might be controversial in this PR: I made `flux jobs --stats-only` exit with non-zero status by default when there are no more active jobs. This makes a possibly common use case really straightforward:

```
 # submit a bunch of work
 $ while flux jobs --stats-only; do sleep 1; done
```