### PR TITLE
Fix job shell segfault when jobspec contains JSON null

### DIFF
--- a/src/bindings/lua/jansson-lua.c
+++ b/src/bindings/lua/jansson-lua.c
@@ -61,7 +61,7 @@ int json_object_to_lua (lua_State *L, json_t *o)
             lua_pushboolean (L, 0);
             break;
         case JSON_NULL:
-            /* XXX: crap. */
+            lua_pushnil (L);
             break;
         }
         return (1);

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -223,6 +223,7 @@ dist_check_SCRIPTS = \
 	issues/t2284-initial-program-format-chars.sh \
 	issues/t2686-shell-input-race.sh \
 	issues/t3186-python-future-get-sigint.sh \
+	issues/t3415-job-shell-segfault-on-null.sh \
 	python/__init__.py \
 	python/subflux.py \
 	python/tap \

--- a/t/issues/t3415-job-shell-segfault-on-null.sh
+++ b/t/issues/t3415-job-shell-segfault-on-null.sh
@@ -1,0 +1,8 @@
+#!/bin/sh -e
+# submit a job with json-null and ensure it doesn't cause the shell
+#  to segfault
+
+# test-prereqs: HAVE_JQ
+flux job attach -vEX $(flux mini run --dry-run hostname \
+    | jq .attributes.system.shell.options.foo=null \
+    | flux job submit)

--- a/t/t4000-issues-test-driver.t
+++ b/t/t4000-issues-test-driver.t
@@ -16,7 +16,8 @@ echo "# $0: flux session size will be ${SIZE}"
 
 for testscript in ${FLUX_SOURCE_DIR}/t/issues/*; do
     testname=`basename $testscript`
-    test_expect_success  $testname "run_timeout 30 $testscript"
+    prereqs=$(sed -n 's/^.*test-prereqs: \(.*\).*$/\1/gp' $testscript)
+    test_expect_success  "$prereqs" $testname "run_timeout 30 $testscript"
 done
 
 test_done


### PR DESCRIPTION
As described in #3415, the job shell currently segfaults if there is a JSON null in the jobspec.

This occurs when the shalls packs up the jobspec to a Lua table for the shell.info table.

The fix is to not ignore `JSON_NULL` and emit a Lua `nil` instead.