### PR TITLE
doc: mock import for `yaml` dependency

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -86,7 +86,7 @@ def setup(app):
 # `_flux` will not exist, causing import errors.  Mock the imports to prevent
 # these errors.
 
-autodoc_mock_imports = ["_flux", "flux.constants"]
+autodoc_mock_imports = ["_flux", "flux.constants", "yaml"]
 
 napoleon_google_docstring = True
 


### PR DESCRIPTION
Problem: sphinx fails to auto-generate API documentation for the
`flux.job.*` submodules due to an error when importing `yaml`.

Mock the import of `yaml` using Sphinx's built-in mocking capabilities,
re-enabling the autogeneration of all the python APIs

Closes #3424