### PR TITLE
flux-mini: add bulk job submission capabilities

### DIFF
--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -520,3 +520,9 @@ dec
 subkey
 waitstatus
 returncode
+bulksubmit
+basename
+bcc
+dirname
+jps
+xargs

--- a/src/bindings/python/flux/Makefile.am
+++ b/src/bindings/python/flux/Makefile.am
@@ -31,7 +31,8 @@ nobase_fluxpy_PYTHON = \
 	resource/ResourceSetImplementation.py \
 	resource/ResourceSet.py \
 	hostlist.py \
-	idset.py
+	idset.py \
+	progress.py
 
 if HAVE_FLUX_SECURITY
 nobase_fluxpy_PYTHON += security.py

--- a/src/bindings/python/flux/core/handle.py
+++ b/src/bindings/python/flux/core/handle.py
@@ -317,5 +317,15 @@ class Flux(Wrapper):
             reactor = self.get_reactor()
         self.flux_reactor_stop_error(reactor)
 
+    def reactor_incref(self, reactor=None):
+        if reactor is None:
+            reactor = self.get_reactor()
+        self.reactor_active_incref(reactor)
+
+    def reactor_decref(self, reactor=None):
+        if reactor is None:
+            reactor = self.get_reactor()
+        self.reactor_active_decref(reactor)
+
 
 # vi: ts=4 sw=4 expandtab

--- a/src/bindings/python/flux/core/watchers.py
+++ b/src/bindings/python/flux/core/watchers.py
@@ -38,9 +38,11 @@ class Watcher(object):
 
     def start(self):
         raw.flux_watcher_start(self.handle)
+        return self
 
     def stop(self):
         raw.flux_watcher_stop(self.handle)
+        return self
 
     def destroy(self):
         if self.handle is not None:

--- a/src/bindings/python/flux/progress.py
+++ b/src/bindings/python/flux/progress.py
@@ -1,0 +1,321 @@
+###############################################################
+# Copyright 2021 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+import sys
+import shutil
+import atexit
+import time
+import datetime
+
+# Bottombar heavily borrows from
+#
+#  https://github.com/evalf/bottombar/blob/master/bottombar.py
+#
+# Copyright (c) 2020 Evalf
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+
+class ElapsedTime(float):
+    """
+    An ElapsedTime object is a floating point elapsed time in seconds
+    that comes with a convenient "dt" proerty that returns a
+    datetime.timedelta object
+    """
+
+    @property
+    # pylint: disable=invalid-name
+    def dt(self):
+        return datetime.timedelta(seconds=round(self))
+
+
+class Bottombar:
+    """Maintain a status line at bottom of terminal using vt100 escape codes
+
+    The Bottombar class implements a very simple status line which stays
+    positioned at the last line of vt100 capable terminals through the
+    use of vt100 escape codes.
+
+    This class will only work propertly on vt100 compatible terminals, which
+    includes xterm, rxvt, and gnome-terminal and their derivatives on Linux,
+    as well as iTerm and Terminal on OSX, and reportedly the new Windows
+    Terminal on Windows.
+
+    Use of Bottombar requires that a ``formatter`` function be provided.
+    The ``formatter`` will be called on each update as::
+
+        formatter(bbar, width)
+
+    Where ``bbar`` is the bottombar object being formatted and ``width`` is
+    the current terminal width at the time of the update. The default
+    ``formatter`` will simply print all extra
+
+    As a convenience, the Bottombar constructor collects all extra keyword
+    arguments and presents them as attributes on the Bottombar object for
+    later access from within and outside the provided ``formatter``, e.g::
+
+        def formatter(bb, width):
+            text = f"iteration={bb.i}"
+            return text + time.ctime().rjust(width - len(text))
+
+        bb = Bottombar(formatter, i=0).start()
+        for i in range(0, 128):
+            bb.update(i=i)
+            time.sleep(.05)
+        bb.stop()
+
+    will print a statusbar with an iteration count left justified, and the
+    current time right justified.
+
+    Attributes:
+        elapsed (float): The elapsed time since ``bb.start()`` in floating
+            point seconds. As a convenience, ``bb.elapsed`` may be converted
+            to a ``datetime.timedelta`` object via the ``dt`` attribute,
+            e.g. ``bb.elapsed.dt``.
+
+    Args:
+        formatter (function): Function which returns the status string
+        kwargs: all extra keyword arguments are collected in the Bottombar
+            instance and made available as attributes for convenience
+
+    """
+
+    def __init__(self, formatter=None, **kwargs):
+        self.size = None
+        if formatter is None:
+            formatter = self._format
+        self.formatter = formatter
+        self.kwargs = kwargs
+        self._running = False
+        self._t0 = None
+
+    def __getattr__(self, attr):
+        if attr == "elapsed":
+            return ElapsedTime(time.time() - self._t0)
+        return self.kwargs[attr]
+
+    def _format(self, _bbar, _width):
+        return " ".join([f"{key}={val}" for key, val in self.kwargs.items()])
+
+    def __str__(self):
+        return self.formatter(self, self.size.columns)
+
+    def _setup_terminal(self, size=None):
+        """
+        Reset terminal scroll region and save last line for progressbar
+        """
+        if size:
+            self.size = size
+        sys.stdout.write(
+            "\0337"  # save cursor and attributes
+            "\033[r"  # reset scroll region (moves cursor)
+            "\0338"  # restore cursor and attributes
+            "\033D"  # move/scroll down
+            "\033M"  # move up
+            "\0337"  # save cursor and attributes
+            "\033[1;%dr"  # set scroll region to lines - 1
+            "\0338" % (self.size.lines - 1)  # restore cursor and attributes
+        )
+
+    def _reset_terminal(self):
+        """Reset terminal after use of progress bar
+
+        Reset terminal scroll region, print final version of progress bar.
+        Print newline.
+        """
+        sys.stdout.write(
+            "\0337"  # save cursor position
+            "\033[%d;1H"  # move cursor to bottom row, first column
+            "\033[K"  # clear entire line
+            "\033[r"  # reset scroll region
+            "\0338"  # restore cursor position
+            "%s\n" % (self.size.lines, self)  # print final bar
+        )
+        atexit.unregister(self._reset_terminal)
+
+    def redraw(self):
+        """Redraw bar without update"""
+        size = shutil.get_terminal_size()
+        if self.size != size:
+            self._setup_terminal(size)
+        sys.stdout.write(
+            "\0337"  # save cursor and attributes
+            "\033[%d;1H"  # move cursor to bottom row, first column
+            "\033[2K"  # clear entire line
+            "\033[?7l"  # disable line wrap
+            "\033[0m%s"  # clear attributes, print bar
+            "\033[?7h"  # enable line wrap
+            "\0338" % (self.size.lines, self)
+        )
+        sys.stdout.flush()
+
+    def start(self):
+        """Start drawing a Bottombar"""
+        self._running = True
+        self._t0 = time.time()
+        self.redraw()
+        atexit.register(self._reset_terminal)
+        return self
+
+    def stop(self):
+        """Reset terminal and write final bottombar state with newline"""
+        if self._running:
+            self._reset_terminal()
+            self._running = False
+
+    def update(self, **kwargs):
+        """Update keyword args and redraw a bottombar"""
+        self.kwargs.update(kwargs)
+        if self._running:
+            self.redraw()
+
+
+class ProgressBar(Bottombar):
+    """Simple progress bar that stays on last line of terminal
+
+    The ProgressBar class uses the features of Bottombar to create a
+    progress bar, plus optional other text, which stays on the last line
+    of a terminal. A vt100 compatible terminal is required.
+
+    Args:
+        total (int): The total expected number of items/units for which
+                     the progressbar is monitoring progress, default=100.
+        style (str, optional): A string progress bar style from the list
+                               "line", "bar", "dots", "steps", "vertbars".
+        before (str, optional): A string to place before the progress bar.
+        after  (str, optional): A string to place after the progress bar.
+                                default=" {percent:5.1f}%"
+        kwargs (optional): Extra keyword args are saved and passed as args
+                           when formatting the ``before`` and ``after``
+                           strings.
+
+    The ``before`` and ``after`` strings are formatted on each update to
+    the progressbar and passed all extra keyword args, plus the current
+    ``total``, ``count``, ``percent``, and ``elapsed`` time e.g.::
+
+        before_str = before.format(
+                        total=total,
+                        count=count,
+                        percent=percent,
+                        elapsed=elapsed,
+                        **kwargs
+                     )
+
+    which means that these strings are most useful when they are format
+    strings, e.g.::
+
+        ProgressBar(before="Running {total} jobs, {percent}% complete: ")
+
+    """
+
+    bar_style = {
+        "line": "─━",
+        "bar": "─█",
+        "dots": "⣀⣄⣤⣦⣶⣷⣿",
+        "steps": " ▁▂▃▄▅▆▇█",
+        "vertbars": " ▏▎▍▌▋▊▉█",
+    }
+
+    def __init__(
+        self,
+        total=100,
+        style="vertbars",
+        before="",
+        after=" {percent:5.1f}%",
+        **kwargs,
+    ):
+        super().__init__(self._formatter, **kwargs)
+        self.count = 0
+        self.total = total
+        self.before = before
+        self.after = after
+        self.style = self.bar_style[style]
+
+    def __getattr__(self, attr):
+        if attr == "total":
+            return self.total
+        if attr == "count":
+            return self.count
+        if attr == "elapsed":
+            return super().__getattr__(attr)
+        return self.kwargs[attr]
+
+    def _formatter(self, bbar, width):
+        style = self.style
+        fraction = float(self.count / self.total)
+        percent = 100 * fraction
+
+        #  Format before/after strings:
+        before = self.before.format(
+            total=self.total,
+            count=self.count,
+            elapsed=self.elapsed,
+            percent=percent,
+            **bbar.kwargs,
+        )
+        after = self.after.format(
+            total=self.total,
+            count=self.count,
+            elapsed=self.elapsed,
+            percent=percent,
+            **bbar.kwargs,
+        )
+
+        #  Calculate remaining length for progress bar:
+        length = width - len(before) - len(after) - 2
+
+        #  Calculate amount of bar fully filled and buil string
+        fill = int(length * fraction)
+        filled = style[-1] * fill
+
+        #  Now calculate partial fill and append it to filled block
+        part = int(length * len(style) * fraction) - fill * len(style)
+        if part:
+            fill += 1
+            filled += style[part]
+
+        #  Build the bar string as 'filled':
+        filled = "\u2502" + filled + style[0] * (length - fill) + "\u2502"
+        return f"{before}{filled}{after}"
+
+    def update(self, advance=1, **kwargs):
+        """Update the state of a ProgressBar
+
+        Update the state of a ProgressBar and redraw if the progress bar is
+        currently running. If ``count == total``, the progress bar will be
+        automatically stopped.
+
+        When the progress bar is stopped, the terminal will be reset and
+        the final state of the bar will be left on the last line of output.
+
+        Args:
+            advance (int, optional): Advance progress by ``advance`` amount.
+            kwargs: Update stored keyword arguments
+        """
+        self.count += advance
+        super().update(**kwargs)
+        if self.count == self.total:
+            self.stop()

--- a/src/cmd/flux-mini.py
+++ b/src/cmd/flux-mini.py
@@ -366,11 +366,9 @@ class MiniCmd:
         return self.parser
 
 
-class SubmitCmd(MiniCmd):
+class SubmitBaseCmd(MiniCmd):
     """
-    SubmitCmd submits a job, displays the jobid on stdout, and returns.
-
-    Usage: flux mini submit [OPTIONS] cmd ...
+    SubmitBaseCmd is an abstract class with shared code for job submission
     """
 
     def __init__(self):
@@ -401,9 +399,6 @@ class SubmitCmd(MiniCmd):
             metavar="N",
             help="Number of GPUs to allocate per task",
         )
-        self.parser.add_argument(
-            "command", nargs=argparse.REMAINDER, help="Job command and arguments"
-        )
 
     def init_jobspec(self, args):
         if not args.command:
@@ -417,12 +412,26 @@ class SubmitCmd(MiniCmd):
             num_nodes=args.nodes,
         )
 
+
+class SubmitCmd(SubmitBaseCmd):
+    """
+    SubmitCmd submits a job, displays the jobid on stdout, and returns.
+
+    Usage: flux mini submit [OPTIONS] cmd ...
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.parser.add_argument(
+            "command", nargs=argparse.REMAINDER, help="Job command and arguments"
+        )
+
     def main(self, args):
         jobid = self.submit(args)
         print(jobid, file=sys.stdout)
 
 
-class RunCmd(SubmitCmd):
+class RunCmd(SubmitBaseCmd):
     """
     RunCmd is identical to SubmitCmd, except it attaches the the job
     after submission.  Some additional options are added to modify the
@@ -439,6 +448,9 @@ class RunCmd(SubmitCmd):
             action="count",
             default=0,
             help="Increase verbosity on stderr (multiple use OK)",
+        )
+        self.parser.add_argument(
+            "command", nargs=argparse.REMAINDER, help="Job command and arguments"
         )
 
     def main(self, args):

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -154,6 +154,7 @@ TESTSCRIPTS = \
 	t2700-mini-cmd.t \
 	t2701-mini-batch.t \
 	t2702-mini-alloc.t \
+	t2703-mini-bulksubmit.t \
 	t2800-jobs-cmd.t \
 	t2900-job-timelimits.t \
 	t3000-mpi-basic.t \

--- a/t/t2700-mini-cmd.t
+++ b/t/t2700-mini-cmd.t
@@ -228,4 +228,20 @@ test_expect_success HAVE_JQ 'flux-mini --env-file works' '
 	       {\"FOO\":\"bar\", \"BAR\":\"bar/baz\"}" envfile.out
     done
 '
+test_expect_success 'flux-mini submit --cc works' '
+	flux mini submit --cc=0-3 sh -c "echo \$FLUX_JOB_CC" >cc.jobids &&
+	test_debug "cat cc.jobids" &&
+	test $(wc -l < cc.jobids) -eq 4 &&
+	for job in $(cat cc.jobids); do
+		flux job attach $job
+	done > cc.output &&
+	sort cc.output > cc.output.sorted &&
+	cat <<-EOF >cc.output.expected &&
+	0
+	1
+	2
+	3
+	EOF
+	test_cmp cc.output.expected cc.output.sorted
+'
 test_done

--- a/t/t2703-mini-bulksubmit.t
+++ b/t/t2703-mini-bulksubmit.t
@@ -1,0 +1,236 @@
+#!/bin/sh
+
+test_description='flux-mini bulksubmit specific tests'
+
+. $(dirname $0)/sharness.sh
+
+
+# Start an instance with 16 cores across 4 ranks
+export TEST_UNDER_FLUX_CORES_PER_RANK=4
+test_under_flux 4 job
+
+flux setattr log-stderr-level 1
+
+runpty="${SHARNESS_TEST_SRCDIR}/scripts/runpty.py -f asciicast --line-buffer"
+
+test_expect_success 'flux-mini bulksubmit submits each arg as a job' '
+	echo 1 2 3 | flux mini bulksubmit echo {} >bs.ids &&
+	test $(wc -l < bs.ids) -eq 3 &&
+	for job in $(cat bs.ids); do
+	    flux job attach $job
+	done | sort >bs.output &&
+	cat <<-EOF >bs.expected &&
+	1
+	2
+	3
+	EOF
+	test_cmp bs.expected bs.output
+'
+test_expect_success 'flux-mini bulksubmit uses default command of {}' '
+	flux mini bulksubmit --dry-run ::: foo bar baz >default-cmd.out &&
+	cat <<-EOF >default-cmd.expected &&
+	flux-mini: submit foo
+	flux-mini: submit bar
+	flux-mini: submit baz
+	EOF
+	test_cmp default-cmd.expected default-cmd.out
+'
+test_expect_success 'flux-mini bulksubmit --cc works' '
+	echo 1 2 3 | flux mini bulksubmit --cc=0-1 echo {} >bs2.ids &&
+	test $(wc -l < bs2.ids) -eq 6 &&
+	for job in $(cat bs2.ids); do
+	    flux job attach $job
+	done | sort >bs2.output &&
+	cat <<-EOF >bs2.expected &&
+	1
+	1
+	2
+	2
+	3
+	3
+	EOF
+	test_cmp bs2.expected bs2.output
+'
+test_expect_success 'flux-mini bulksubmit --bcc works' '
+	echo 1 2 3 | \
+	    flux mini bulksubmit --quiet --watch --bcc=0-1 \
+	        sh -c "echo {}\$FLUX_JOB_CC" >bcc.out &&
+	sort bcc.out > bcc.out.sorted &&
+	cat <<-EOF >bcc.expected &&
+	1
+	1
+	2
+	2
+	3
+	3
+	EOF
+	test_cmp bcc.expected bcc.out.sorted
+'
+test_expect_success 'flux-mini bulksubmit --watch works' '
+	flux mini bulksubmit --watch echo {} ::: foo bar baz >bs3.out &&
+	test_debug "cat bs3.out" &&
+	grep ^foo bs3.out &&
+	grep ^bar bs3.out &&
+	grep ^baz bs3.out
+'
+test_expect_success 'flux-mini bulksubmit reports exceptions with --watch' '
+	test_expect_code 1 \
+	    flux mini bulksubmit --watch -n {} hostname ::: 1 2 4 1024 \
+	    >b4.out 2>&1 &&
+	test_debug "cat b4.out" &&
+	grep "unsatisfiable request" b4.out
+'
+test_expect_success 'flux-mini submit --progress works without --wait' '
+	$runpty flux mini submit --cc=1-10 --progress hostname >bs5.out &&
+	test_debug "cat bs5.out" &&
+	grep "10 jobs" bs5.out &&
+	grep "100.0%" bs5.out
+'
+test_expect_success 'flux-mini submit --progress works with --wait' '
+	$runpty flux mini submit --cc=1-10 --progress --wait hostname \
+	    >bs6.out &&
+	grep "PD:10 *R:0 *CD:0 *F:0" bs6.out &&
+	grep "PD:0 *R:0 *CD:10 *F:0" bs6.out &&
+	grep "100.0%" bs6.out
+'
+test_expect_success 'flux-mini bulksubmit --wait/progress with failed jobs' '
+        test_expect_code 1 $runpty flux mini bulksubmit \
+	    -n{} --progress --wait hostname ::: 1 2 4 1024 \
+	    >bs7.out &&
+	grep "PD:4 *R:0 *CD:0 *F:0" bs7.out &&
+	grep "PD:0 *R:0 *CD:3 *F:1" bs7.out &&
+	grep "100.0%" bs7.out
+'
+test_expect_success 'flux-mini bulksubmit --wait/progress with failed jobs' '
+        test_expect_code 2 $runpty flux mini bulksubmit \
+	    -n1 --progress --wait sh -c "exit {}" ::: 0 1 0 0 2 \
+	    >bs8.out &&
+	grep "PD:5 *R:0 *CD:0 *F:0" bs8.out &&
+	grep "PD:0 *R:0 *CD:3 *F:2" bs8.out &&
+	grep "100.0%" bs8.out
+'
+test_expect_success 'flux-mini bulksubmit --wait returns highest exit code' '
+	test_expect_code 143 \
+	    flux mini bulksubmit --wait sh -c "kill -{} \$\$" ::: 0 0 15
+'
+test_expect_success 'flux-mini bulksubmit replacement format strings work' '
+	echo /a/b/c/d.txt /a/b/c/d c.txt | \
+	    flux mini bulksubmit --dry-run {seq} {} {.%} {./} {.//} {./%} \
+	    >repl.out &&
+	cat <<-EOF >repl.expected &&
+	flux-mini: submit 0 /a/b/c/d.txt /a/b/c/d d.txt /a/b/c d
+	flux-mini: submit 1 /a/b/c/d /a/b/c/d d /a/b/c d
+	flux-mini: submit 2 c.txt c c.txt  c
+	EOF
+	test_debug "cat repl.out" &&
+	test_cmp repl.expected repl.out
+'
+test_expect_success 'flux-mini bulksubmit can use replacement string in opts' '
+	flux mini bulksubmit --dry-run -n {} -N {} -c {} -g {} hostname \
+	    ::: 1 2 3 4 >repl2.out &&
+	test_debug "cat -v repl2.out" &&
+	cat <<-EOF >repl2.expected &&
+	flux-mini: submit -n1 -N1 -c1 -g1 hostname
+	flux-mini: submit -n2 -N2 -c2 -g2 hostname
+	flux-mini: submit -n3 -N3 -c3 -g3 hostname
+	flux-mini: submit -n4 -N4 -c4 -g4 hostname
+	EOF
+	test_cmp repl2.expected repl2.out
+'
+test_expect_success 'flux-mini bulksubmit combines all inputs by default' '
+	flux mini bulksubmit --dry-run sleep {0}.{1} \
+	    ::: 0 1 2 3 4 ::: 0 5 9 >repl3.out &&
+	test_debug "cat repl3.out" &&
+	cat <<-EOF >repl3.expected &&
+	flux-mini: submit sleep 0.0
+	flux-mini: submit sleep 0.5
+	flux-mini: submit sleep 0.9
+	flux-mini: submit sleep 1.0
+	flux-mini: submit sleep 1.5
+	flux-mini: submit sleep 1.9
+	flux-mini: submit sleep 2.0
+	flux-mini: submit sleep 2.5
+	flux-mini: submit sleep 2.9
+	flux-mini: submit sleep 3.0
+	flux-mini: submit sleep 3.5
+	flux-mini: submit sleep 3.9
+	flux-mini: submit sleep 4.0
+	flux-mini: submit sleep 4.5
+	flux-mini: submit sleep 4.9
+	EOF
+	test_cmp repl3.expected repl3.out
+'
+test_expect_success 'flux-mini bulksubmit links inputs with :::+' '
+	flux mini bulksubmit --dry-run {0}:{1} \
+	    ::: 0 1 2 3 4 4 :::+ a b c >linked.out &&
+	test_debug "cat linked.out" &&
+	cat <<-EOF >linked.expected &&
+	flux-mini: submit 0:a
+	flux-mini: submit 1:b
+	flux-mini: submit 2:c
+	flux-mini: submit 3:a
+	flux-mini: submit 4:b
+	flux-mini: submit 4:c
+	EOF
+	test_cmp linked.expected linked.out
+'
+test_expect_success 'flux-mini bulksubmit reads from files with ::::' '
+	seq 1 3 >input &&
+	flux mini bulksubmit --dry-run :::: input >fileinput.out &&
+	cat <<-EOF >fileinput.expected &&
+	flux-mini: submit 1
+	flux-mini: submit 2
+	flux-mini: submit 3
+	EOF
+	test_cmp fileinput.expected fileinput.out
+'
+test_expect_success 'flux-mini bulksubmit can substitute in list options' "
+	flux mini bulksubmit --dry-run --env=-* --env=SEQ={seq} ::: a b c \
+	    >envsub.out &&
+	test_debug "cat envsub.out" &&
+	cat <<-EOF >envsub.expected
+	flux-mini: submit --env=['-*', 'SEQ=0'] a
+	flux-mini: submit --env=['-*', 'SEQ=1'] b
+	flux-mini: submit --env=['-*', 'SEQ=2'] c
+	EOF
+	test_cmp envsub.expected envsub.out
+"
+test_expect_success 'flux-mini bulksubmit --define works' '
+ 	flux mini bulksubmit --dry-run \
+	    --define=p2="2**int(x)" \
+	    --job-name={} -n {.p2} hostname ::: $(seq 1 8) \
+	    >define.out &&
+	test_debug "cat define.out" &&
+	cat <<-EOF >define.expected &&
+	flux-mini: submit -n2 --job-name=1 hostname
+	flux-mini: submit -n4 --job-name=2 hostname
+	flux-mini: submit -n8 --job-name=3 hostname
+	flux-mini: submit -n16 --job-name=4 hostname
+	flux-mini: submit -n32 --job-name=5 hostname
+	flux-mini: submit -n64 --job-name=6 hostname
+	flux-mini: submit -n128 --job-name=7 hostname
+	flux-mini: submit -n256 --job-name=8 hostname
+	EOF
+	test_cmp define.expected define.out
+'
+test_expect_success 'flux-mini bulksubmit --shuffle works' '
+	flux mini bulksubmit --dry-run --shuffle \
+	    {seq}:{} ::: $(seq 1 8) >shuffle.out &&
+	test_debug "cat shuffle.out" &&
+	sort shuffle.out > shuffle.sorted &&
+	test_must_fail test_cmp shuffle.sorted shuffle.out >/dev/null
+'
+test_expect_success 'flux-mini bulksubmit --progress is ignored for no tty' '
+	flux mini submit --progress --wait --cc=0-1 sleep 0 >notty.out 2>&1 &&
+	grep "Ignoring --progress option" notty.out
+'
+test_expect_success 'flux-mini bulksubmit reports invalid replacement strings' '
+	test_expect_code 1 flux mini bulksubmit {1} ::: 0 1 2 >bad.out 2>&1 &&
+	test_debug "cat bad.out" &&
+	test_expect_code 1 flux mini bulksubmit -n {1} {} ::: 0 1 2 \
+	    >bad2.out 2>&1 &&
+	test_debug "cat bad2.out" &&
+	grep "Invalid replacement string in command" bad.out &&
+	grep "Invalid replacement string in -n" bad2.out
+'
+test_done


### PR DESCRIPTION
In the context of testing and exercising Flux interfaces, I've found it handy to have a tool that can submit a bunch of jobs rapidly, but our standard tools are definitely lacking in this department. I have a `bulksubmit.py` script which works, but it requires a directory full of jobspec files, which is not convenient.

As an experiment I made a small change to `flux-mini.py` to allow asynchronous submission of jobspec, and using that interface, added an option that allows bulk submission of the same job  rapidly. I'm putting up this experimental PR to get feedback before I move on to any testing.

This PR enhances the job submission used in `flux-mini.py` to use `submit_async()`, which opens the door to submitting multiple jobs per invocation (without performing them back to back).

Then, a new `--cc=IDSET` option is introduced to `flux job submit` which submits a copy of the requested job for each `id` in `IDSET`. The only difference is that the environment variable `FLUX_JOB_CC=id` is set for jobs submitted in this way, which allows each job to determine its index of submission if necessary (e.g. to operate on a different input file). This is similar, though not quite as efficient as, the [job array](https://slurm.schedmd.com/job_array.html) feature in Slurm.

e.g.

```
$ flux mini submit --cc=1-10 sh -c 'echo $FLUX_JOB_CC'
ƒLgfPweP1
ƒLgfPweP2
ƒLgfPweP3
ƒLgfPweP4
ƒLgfRRdfM
ƒLgfRRdfN
ƒLgfRRdfP
ƒLgfRRdfQ
ƒLgfRRdfR
ƒLgfRRdfS
$ flux job attach ƒLgfRRdfM
5
```

After this, it was trivial to add a `flux mini bulksubmit` command which, instead of taking a COMMAND and ARGS as positional parameters, treats each positional argument as separate command, and creates a job with the same submission arguments for each, e.g.:

```
$ flux mini bulksubmit hostname hostname hostname
ƒKfWcDdUb
ƒKfWdhckw
ƒKfWdhckx
```

or perhaps more useful

```
$ flux mini bulksubmit ./python/t*.py
ƒL1TnX4BH
ƒL1TnX4BJ
ƒL1TnX4BK
ƒL1Tp13Td
ƒL1Tp13Te
ƒL1Tp13Tf
ƒL1Tp13Tg
ƒL1Tp13Th
ƒL1TqV2jy
ƒL1TqV2jz
ƒL1TqV2k1
ƒL1TqV2k2
ƒL1Try22K
ƒL1Try22L
ƒL1Try22M
```

`flux mini bulksubmit` also supports the `--cc` option, in which case every command is CC'd for each ID in IDSET. This allows us, for instance, to submit a mix of sleep jobs very quickly:

```
$ time flux mini bulksubmit --cc=1-100 'sleep 0' 'sleep 1' 'sleep 3' | wc -l
300

real	0m2.219s
user	0m1.847s
sys	0m0.062s
```

Everything here is kind of open for discussion. The `--cc` option was at first `--repeat`, then `--replicate`, but I like how short `--cc` is, and how the exported variable is also short, since it might be used in scripts.

Also, the addition of a different `FLUX_JOB_CC` to each jobspec unfortunately means every jobspec is different. Maybe eventually we can figure out a way to have these kinds of jobs "share" a jobspec, in the meantime we could leave that out, or have it opt-in only.