### PR TITLE
job-manager: support job hold and expedite

### DIFF
--- a/src/common/libjob/job.h
+++ b/src/common/libjob/job.h
@@ -27,8 +27,10 @@ enum job_submit_flags {
 
 enum job_urgency {
     FLUX_JOB_URGENCY_MIN = 0,
+    FLUX_JOB_URGENCY_HOLD = FLUX_JOB_URGENCY_MIN,
     FLUX_JOB_URGENCY_DEFAULT = 16,
     FLUX_JOB_URGENCY_MAX = 31,
+    FLUX_JOB_URGENCY_EXPEDITE = FLUX_JOB_URGENCY_MAX,
 };
 
 enum job_queue_priority {

--- a/src/common/libschedutil/alloc.c
+++ b/src/common/libschedutil/alloc.c
@@ -24,11 +24,16 @@ int schedutil_alloc_request_decode (const flux_msg_t *msg,
                                     uint32_t *userid,
                                     double *t_submit)
 {
-    return flux_request_unpack (msg, NULL, "{s:I s:i s:i s:f}",
-                                           "id", id,
-                                           "priority", priority,
-                                           "userid", userid,
-                                           "t_submit", t_submit);
+    json_int_t tmp;
+    int rc;
+    rc = flux_request_unpack (msg, NULL, "{s:I s:I s:i s:f}",
+                                         "id", id,
+                                         "priority", &tmp,
+                                         "userid", userid,
+                                         "t_submit", t_submit);
+    if (!rc && priority)
+        (*priority) = tmp;
+    return rc;
 }
 
 static int schedutil_alloc_respond (flux_t *h, const flux_msg_t *msg,

--- a/src/common/libschedutil/hello.c
+++ b/src/common/libschedutil/hello.c
@@ -75,15 +75,17 @@ int schedutil_hello (schedutil_t *util, schedutil_hello_cb_f *cb, void *arg)
         int priority;
         uint32_t userid;
         double t_submit;
+        json_int_t tmp;
 
-        if (json_unpack (entry, "{s:I s:i s:i s:f}",
+        if (json_unpack (entry, "{s:I s:I s:i s:f}",
                                 "id", &id,
-                                "priority", &priority,
+                                "priority", &tmp,
                                 "userid", &userid,
                                 "t_submit", &t_submit) < 0) {
             errno = EPROTO;
             goto error;
         }
+        priority = tmp;
         if (schedutil_hello_job (util->h,
                                  id,
                                  priority,

--- a/src/modules/job-info/job_state.c
+++ b/src/modules/job-info/job_state.c
@@ -1319,17 +1319,15 @@ static int priority_context_parse (flux_t *h,
                                    struct job *job,
                                    json_t *context)
 {
-    unsigned int priority;
-
     if (!context
-        || json_unpack (context, "{ s:i }", "priority", &priority) < 0) {
+        || json_unpack (context,
+                        "{ s:I }",
+                        "priority", (json_int_t *)&job->priority) < 0) {
         flux_log (h, LOG_ERR, "%s: priority context invalid: %ju",
                   __FUNCTION__, (uintmax_t)job->id);
         errno = EPROTO;
         return -1;
     }
-
-    job->priority = priority;
     return 0;
 }
 
@@ -1340,7 +1338,7 @@ static int journal_priority_event (struct job_state_ctx *jsctx,
                                    json_t *context)
 {
     struct job *job;
-    unsigned int orig_priority;
+    int64_t orig_priority;
 
     if (!(job = zhashx_lookup (jsctx->index, &id))) {
         flux_log_error (jsctx->h, "%s: job %ju not in hash",

--- a/src/modules/job-info/job_state.h
+++ b/src/modules/job-info/job_state.h
@@ -64,7 +64,7 @@ struct job {
     flux_jobid_t id;
     uint32_t userid;
     int urgency;
-    unsigned int priority;
+    int64_t priority;
     double t_submit;
     int flags;
     flux_job_state_t state;

--- a/src/modules/job-manager/alloc.c
+++ b/src/modules/job-manager/alloc.c
@@ -63,7 +63,7 @@ static void requeue_pending (struct alloc *alloc, struct job *job)
     assert (job->alloc_pending);
     assert (job->handle == NULL);
     if (!(job->handle = zlistx_insert (alloc->queue, job, fwd)))
-        flux_log_error (ctx->h, "%s: queue_insert", __FUNCTION__);
+        flux_log (ctx->h, LOG_ERR, "failed to enqueue job for scheduling");
     job->alloc_pending = 0;
     job->alloc_queued = 1;
     alloc->pending_job = NULL;

--- a/src/modules/job-manager/alloc.c
+++ b/src/modules/job-manager/alloc.c
@@ -359,9 +359,9 @@ int alloc_request (struct alloc *alloc, struct job *job)
 
     if (!(msg = flux_request_encode ("sched.alloc", NULL)))
         return -1;
-    if (flux_msg_pack (msg, "{s:I s:i s:i s:f s:O}",
+    if (flux_msg_pack (msg, "{s:I s:I s:i s:f s:O}",
                             "id", job->id,
-                            "priority", job->priority,
+                            "priority", (json_int_t)job->priority,
                             "userid", job->userid,
                             "t_submit", job->t_submit,
                             "jobspec", job->jobspec_redacted) < 0)
@@ -397,7 +397,7 @@ static void hello_cb (flux_t *h, flux_msg_handler_t *mh,
     job = zhashx_first (ctx->active_jobs);
     while (job) {
         if (job->has_resources) {
-            if (!(entry = json_pack ("{s:I s:i s:i s:f}",
+            if (!(entry = json_pack ("{s:I s:I s:i s:f}",
                                      "id", job->id,
                                      "priority", job->priority,
                                      "userid", job->userid,

--- a/src/modules/job-manager/event.c
+++ b/src/modules/job-manager/event.c
@@ -309,6 +309,7 @@ nomem:
 int event_job_action (struct event *event, struct job *job)
 {
     struct job_manager *ctx = event->ctx;
+    unsigned int priority;
 
     switch (job->state) {
         case FLUX_JOB_STATE_NEW:
@@ -326,12 +327,16 @@ int event_job_action (struct event *event, struct job *job)
              * SCHED state, dequeue the job first.
              */
             alloc_dequeue_alloc_request (ctx->alloc, job);
+            if (job->urgency == FLUX_JOB_URGENCY_HOLD)
+                priority = FLUX_JOB_PRIORITY_MIN;
+            else
+                priority = job->urgency;
             if (event_job_post_pack (event,
                                      job,
                                      "priority",
                                      0,
                                      "{ s:i }",
-                                     "priority", job->urgency) < 0)
+                                     "priority", priority) < 0)
                 return -1;
             break;
         case FLUX_JOB_STATE_SCHED:

--- a/src/modules/job-manager/event.c
+++ b/src/modules/job-manager/event.c
@@ -329,6 +329,8 @@ int event_job_action (struct event *event, struct job *job)
             alloc_dequeue_alloc_request (ctx->alloc, job);
             if (job->urgency == FLUX_JOB_URGENCY_HOLD)
                 priority = FLUX_JOB_PRIORITY_MIN;
+            else if (job->urgency == FLUX_JOB_URGENCY_EXPEDITE)
+                priority = FLUX_JOB_PRIORITY_MAX;
             else
                 priority = job->urgency;
             /* We pack priority with I instead of i to avoid issue of

--- a/src/modules/job-manager/job.h
+++ b/src/modules/job-manager/job.h
@@ -20,7 +20,7 @@ struct job {
     flux_jobid_t id;
     uint32_t userid;
     int urgency;
-    unsigned int priority;
+    int64_t priority;
     double t_submit;
     int flags;
     json_t *jobspec_redacted;

--- a/src/modules/job-manager/list.c
+++ b/src/modules/job-manager/list.c
@@ -39,7 +39,9 @@ int list_append_job (json_t *jobs, struct job *job)
 {
     json_t *o;
 
-    if (!(o = json_pack ("{s:I s:i s:i s:i s:f s:i}",
+    /* We pack priority with I instead of i to avoid issue of
+     * signed vs unsigned int */
+    if (!(o = json_pack ("{s:I s:i s:i s:I s:f s:i}",
                          "id",
                          job->id,
                          "userid",

--- a/src/modules/job-manager/urgency.c
+++ b/src/modules/job-manager/urgency.c
@@ -111,7 +111,10 @@ void urgency_handle_request (flux_t *h,
     /* N.B. once priority plugin work developed, should recall with
      * new urgency, but for now priority is set to urgency */
     if (urgency != orig_urgency) {
-        job->priority = urgency;
+        if (urgency == FLUX_JOB_URGENCY_HOLD)
+            job->priority = FLUX_JOB_PRIORITY_MIN;
+        else
+            job->priority = urgency;
         if (event_job_post_pack (ctx->event, job,
                                  "priority",
                                  0,

--- a/src/modules/job-manager/urgency.c
+++ b/src/modules/job-manager/urgency.c
@@ -113,6 +113,8 @@ void urgency_handle_request (flux_t *h,
     if (urgency != orig_urgency) {
         if (urgency == FLUX_JOB_URGENCY_HOLD)
             job->priority = FLUX_JOB_PRIORITY_MIN;
+        else if (urgency == FLUX_JOB_URGENCY_EXPEDITE)
+            job->priority = FLUX_JOB_PRIORITY_MAX;
         else
             job->priority = urgency;
         /* We pack priority with I instead of i to avoid issue of

--- a/src/modules/job-manager/urgency.c
+++ b/src/modules/job-manager/urgency.c
@@ -20,7 +20,7 @@
  * - new urgency
  *
  * Output:
- * - n/a
+ * - old urgency
  *
  * Caveats:
  * - Need to handle case where job has already made request for resources.
@@ -137,8 +137,10 @@ void urgency_handle_request (flux_t *h,
                 goto error;
         }
     }
-    if (flux_respond (h, msg, NULL) < 0)
-        flux_log_error (h, "%s: flux_respond", __FUNCTION__);
+    if (flux_respond_pack (h, msg, "{s:i}", "old_urgency", orig_urgency) < 0) {
+        flux_log_error (h, "%s: flux_respond_pack", __FUNCTION__);
+        goto error;
+    }
     return;
 error:
     if (flux_respond_error (h, msg, errno, errstr) < 0)

--- a/src/modules/job-manager/urgency.c
+++ b/src/modules/job-manager/urgency.c
@@ -115,10 +115,12 @@ void urgency_handle_request (flux_t *h,
             job->priority = FLUX_JOB_PRIORITY_MIN;
         else
             job->priority = urgency;
+        /* We pack priority with I instead of i to avoid issue of
+         * signed vs unsigned int */
         if (event_job_post_pack (ctx->event, job,
                                  "priority",
                                  0,
-                                 "{ s:i }",
+                                 "{ s:I }",
                                  "priority", job->priority) < 0)
             goto error;
         alloc_queue_reorder (ctx->alloc, job);

--- a/src/modules/job-manager/urgency.c
+++ b/src/modules/job-manager/urgency.c
@@ -120,7 +120,7 @@ void urgency_handle_request (flux_t *h,
             goto error;
         alloc_queue_reorder (ctx->alloc, job);
         if (alloc_queue_recalc_pending (ctx->alloc) < 0)
-            flux_log_error (h, "%s: alloc_queue_recalc_pending", __FUNCTION__);
+            goto error;
     }
     if (flux_respond (h, msg, NULL) < 0)
         flux_log_error (h, "%s: flux_respond", __FUNCTION__);

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -113,6 +113,7 @@ TESTSCRIPTS = \
 	t2212-job-manager-jobspec.t \
 	t2220-job-archive.t \
 	t2213-job-manager-hold-single.t \
+	t2214-job-manager-hold-unlimited.t \
 	t2230-job-info-list.t \
 	t2231-job-info-lookup.t \
 	t2232-job-info-eventlog-watch.t \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -112,6 +112,7 @@ TESTSCRIPTS = \
 	t2211-job-manager-events-journal.t \
 	t2212-job-manager-jobspec.t \
 	t2220-job-archive.t \
+	t2213-job-manager-hold-single.t \
 	t2230-job-info-list.t \
 	t2231-job-info-lookup.t \
 	t2232-job-info-eventlog-watch.t \

--- a/t/job-manager/sched-dummy.c
+++ b/t/job-manager/sched-dummy.c
@@ -221,6 +221,9 @@ void cancel_cb (flux_t *h, flux_jobid_t id, void *arg)
         }
         job = zlist_next (sc->jobs);
     }
+
+    /* called to regenerate annotations */
+    try_alloc (sc);
 }
 
 void free_cb (flux_t *h, const flux_msg_t *msg, const char *R, void *arg)

--- a/t/t2202-job-manager.t
+++ b/t/t2202-job-manager.t
@@ -256,6 +256,15 @@ test_expect_success HAVE_JQ 'job-manager: flux job urgency special args work' '
 	flux job cancel ${jobid}
 '
 
+test_expect_success 'job-manager: flux job urgency -v work' '
+	jobid=$(flux job submit basic.json | flux job id) &&
+	flux job urgency -v ${jobid} 10 2>&1 | grep "16" &&
+	flux job urgency -v ${jobid} hold 2>&1 | grep "10" &&
+	flux job urgency -v ${jobid} expedite 2>&1 | grep "held" &&
+	flux job urgency -v ${jobid} 10 2>&1 | grep "expedited" &&
+	flux job cancel ${jobid}
+'
+
 test_expect_success 'job-manager: guest can reduce urgency from default' '
 	jobid=$(flux job submit  basic.json) &&
 	FLUX_HANDLE_ROLEMASK=0x2 flux job urgency ${jobid} 5 &&

--- a/t/t2202-job-manager.t
+++ b/t/t2202-job-manager.t
@@ -116,7 +116,7 @@ test_expect_success 'job-manager: queue contains 3 jobs' '
 
 test_expect_success HAVE_JQ 'job-manager: queue is sorted in priority order' '
 	cat >list3_priority.exp <<-EOT &&
-	31
+	4294967295
 	16
 	0
 	EOT
@@ -126,7 +126,7 @@ test_expect_success HAVE_JQ 'job-manager: queue is sorted in priority order' '
 
 test_expect_success HAVE_JQ 'job-manager: list-jobs --count shows highest priority jobs' '
 	cat >list3_lim2.exp <<-EOT &&
-	31
+	4294967295
 	16
 	EOT
 	${LIST_JOBS} -c 2 | $jq .priority >list3_lim2.out &&

--- a/t/t2202-job-manager.t
+++ b/t/t2202-job-manager.t
@@ -239,6 +239,23 @@ test_expect_success 'job-manager: flux job urgency fails on invalid urgency' '
 	flux job cancel ${jobid}
 '
 
+test_expect_success HAVE_JQ 'job-manager: flux job urgency special args work' '
+	jobid=$(flux job submit basic.json | flux job id) &&
+	flux job urgency ${jobid} hold &&
+	${LIST_JOBS} > list_hold.out &&
+	test $(cat list_hold.out | grep ${jobid} | $jq .urgency) -eq 0 &&
+	test $(cat list_hold.out | grep ${jobid} | $jq .priority) -eq 0 &&
+	flux job urgency ${jobid} expedite &&
+	${LIST_JOBS} > list_expedite.out &&
+	test $(cat list_expedite.out | grep ${jobid} | $jq .urgency) -eq 31 &&
+	test $(cat list_expedite.out | grep ${jobid} | $jq .priority) -eq 4294967295 &&
+	flux job urgency ${jobid} default &&
+	${LIST_JOBS} > list_default.out &&
+	test $(cat list_default.out | grep ${jobid} | $jq .urgency) -eq 16 &&
+	test $(cat list_default.out | grep ${jobid} | $jq .priority) -eq 16 &&
+	flux job cancel ${jobid}
+'
+
 test_expect_success 'job-manager: guest can reduce urgency from default' '
 	jobid=$(flux job submit  basic.json) &&
 	FLUX_HANDLE_ROLEMASK=0x2 flux job urgency ${jobid} 5 &&

--- a/t/t2202-job-manager.t
+++ b/t/t2202-job-manager.t
@@ -133,6 +133,12 @@ test_expect_success HAVE_JQ 'job-manager: list-jobs --count shows highest priori
 	test_cmp list3_lim2.exp list3_lim2.out
 '
 
+test_expect_success HAVE_JQ 'job-manager: priority listed as priority=4294967295 in KVS' '
+	jobid=$(head -n 1 list3.out | $jq .id) &&
+        flux job wait-event --timeout=5.0 ${jobid} priority &&
+	flux job eventlog $jobid | grep priority=4294967295
+'
+
 test_expect_success HAVE_JQ 'job-manager: cancel jobs' '
 	for jobid in $($jq .id <list3.out); do \
 		flux job cancel ${jobid}; \
@@ -167,6 +173,12 @@ test_expect_success 'job-manager: urgency was updated in KVS' '
 	flux job eventlog $jobid \
 		| cut -d" " -f2- | grep ^urgency >urgency.out &&
 	grep -q urgency=31 urgency.out
+'
+
+test_expect_success 'job-manager: priority was updated in KVS' '
+	jobid=$(tail -1 <list10_ids.out) &&
+        flux job wait-event --timeout=5.0 -c 2 ${jobid} priority &&
+	flux job eventlog $jobid | grep ^priority | tail -n 1 | priority=4294967295
 '
 
 test_expect_success HAVE_JQ 'job-manager: that job is now the first job' '

--- a/t/t2210-job-manager-bugs.t
+++ b/t/t2210-job-manager-bugs.t
@@ -49,7 +49,7 @@ test_expect_success 'issue3051: submit one more job and wait for alloc' '
 	flux job wait-event -t 5 $(cat issue3051.job2) debug.alloc-request
 '
 test_expect_success 'issue3051: cannot change urgency of job with pending alloc' '
-	test_must_fail flux job urgency $(cat issue3051.job2) 0 2>issue3051.err
+	test_must_fail flux job urgency $(cat issue3051.job2) 1 2>issue3051.err
 '
 test_expect_success 'issue3051: human message is reasonable' '
 	grep alloc issue3051.err

--- a/t/t2213-job-manager-hold-single.t
+++ b/t/t2213-job-manager-hold-single.t
@@ -1,0 +1,173 @@
+#!/bin/sh
+
+test_description='Test flux job manager job hold (single mode)'
+
+. `dirname $0`/job-manager/sched-helper.sh
+
+. $(dirname $0)/sharness.sh
+
+test_under_flux 4 kvs
+
+SCHED_DUMMY=${FLUX_BUILD_DIR}/t/job-manager/.libs/sched-dummy.so
+
+flux setattr log-stderr-level 1
+
+test_expect_success 'flux-job: generate jobspec for simple test job' '
+        flux jobspec srun -n1 hostname >basic.json
+'
+
+test_expect_success 'job-manager: load job-ingest, job-manager' '
+        flux module load job-manager &&
+        flux module load job-ingest &&
+        flux exec -r all -x 0 flux module load job-ingest &&
+        flux module load job-info
+'
+
+test_expect_success 'job-manager: submit 5 jobs (job 2 held)' '
+        flux job submit --flags=debug basic.json >job1.id &&
+        flux job submit --flags=debug --urgency=0 basic.json >job2.id &&
+        flux job submit --flags=debug basic.json >job3.id &&
+        flux job submit --flags=debug basic.json >job4.id &&
+        flux job submit --flags=debug basic.json >job5.id
+'
+
+test_expect_success HAVE_JQ 'job-manager: job state SSSS (no scheduler)' '
+        jmgr_check_state $(cat job1.id) S &&
+        jmgr_check_state $(cat job2.id) S &&
+        jmgr_check_state $(cat job3.id) S &&
+        jmgr_check_state $(cat job4.id) S &&
+        jmgr_check_state $(cat job5.id) S
+'
+
+test_expect_success HAVE_JQ 'job-manager: no annotations (SSSSS)' '
+        jmgr_check_no_annotations $(cat job1.id) &&
+        jmgr_check_no_annotations $(cat job2.id) &&
+        jmgr_check_no_annotations $(cat job3.id) &&
+        jmgr_check_no_annotations $(cat job4.id) &&
+        jmgr_check_no_annotations $(cat job5.id)
+'
+
+test_expect_success 'job-manager: load sched-dummy --cores=1' '
+        flux module load ${SCHED_DUMMY} --cores=1
+'
+
+test_expect_success HAVE_JQ 'job-manager: job state RSSS' '
+        jmgr_check_state $(cat job1.id) R &&
+        jmgr_check_state $(cat job2.id) S &&
+        jmgr_check_state $(cat job3.id) S &&
+        jmgr_check_state $(cat job4.id) S &&
+        jmgr_check_state $(cat job5.id) S
+'
+
+test_expect_success HAVE_JQ 'job-manager: annotations job 3 pending, job 2 held (RSSS)' '
+        jmgr_check_no_annotations $(cat job1.id) &&
+        jmgr_check_no_annotations $(cat job2.id) &&
+        jmgr_check_annotation $(cat job3.id) "sched.reason_pending" "\"no cores available\"" &&
+        jmgr_check_no_annotations $(cat job4.id) &&
+        jmgr_check_no_annotations $(cat job5.id)
+'
+
+test_expect_success 'job-manager: job 4 hold' '
+        flux job urgency $(cat job4.id) 0
+'
+
+test_expect_success 'job-manager: cancel job 1' '
+        flux job cancel $(cat job1.id)
+'
+
+test_expect_success HAVE_JQ 'job-manager: job state ISRSS (job 3 run, job 2 held)' '
+        jmgr_check_state $(cat job1.id) I &&
+        jmgr_check_state $(cat job2.id) S &&
+        jmgr_check_state $(cat job3.id) R &&
+        jmgr_check_state $(cat job4.id) S &&
+        jmgr_check_state $(cat job5.id) S
+'
+
+test_expect_success HAVE_JQ 'job-manager: annotations job 5 pending (job 2/4 held)' '
+        jmgr_check_no_annotations $(cat job1.id) &&
+        jmgr_check_no_annotations $(cat job2.id) &&
+        jmgr_check_no_annotations $(cat job3.id) &&
+        jmgr_check_no_annotations $(cat job4.id) &&
+        jmgr_check_annotation $(cat job5.id) "sched.reason_pending" "\"no cores available\""
+'
+
+test_expect_success 'job-manager: job 4 release (higher urgency)' '
+        flux job urgency $(cat job4.id) 20
+'
+
+test_expect_success HAVE_JQ 'job-manager: annotations job 4 pending' '
+        jmgr_check_no_annotations $(cat job1.id) &&
+        jmgr_check_no_annotations $(cat job2.id) &&
+        jmgr_check_no_annotations $(cat job3.id) &&
+        jmgr_check_annotation $(cat job4.id) "sched.reason_pending" "\"no cores available\"" &&
+        jmgr_check_no_annotations $(cat job5.id)
+'
+
+test_expect_success 'job-manager: cancel job 3' '
+        flux job cancel $(cat job3.id)
+'
+
+test_expect_success HAVE_JQ 'job-manager: job state ISIRS (job 4 run, job 2 held)' '
+        jmgr_check_state $(cat job1.id) I &&
+        jmgr_check_state $(cat job2.id) S &&
+        jmgr_check_state $(cat job3.id) I &&
+        jmgr_check_state $(cat job4.id) R &&
+        jmgr_check_state $(cat job5.id) S
+'
+
+test_expect_success HAVE_JQ 'job-manager: annotations job 5 pending (job 2 held)' '
+        jmgr_check_no_annotations $(cat job1.id) &&
+        jmgr_check_no_annotations $(cat job2.id) &&
+        jmgr_check_no_annotations $(cat job3.id) &&
+        jmgr_check_no_annotations $(cat job4.id) &&
+        jmgr_check_annotation $(cat job5.id) "sched.reason_pending" "\"no cores available\""
+'
+
+test_expect_success 'job-manager: cancel job 4' '
+        flux job cancel $(cat job4.id)
+'
+
+test_expect_success HAVE_JQ 'job-manager: job state ISIIR (job 5 run, job 2 held)' '
+        jmgr_check_state $(cat job1.id) I &&
+        jmgr_check_state $(cat job2.id) S &&
+        jmgr_check_state $(cat job3.id) I &&
+        jmgr_check_state $(cat job4.id) I &&
+        jmgr_check_state $(cat job5.id) R
+'
+
+test_expect_success HAVE_JQ 'job-manager: annotations no job pending (job 2 held)' '
+        jmgr_check_no_annotations $(cat job1.id) &&
+        jmgr_check_no_annotations $(cat job2.id) &&
+        jmgr_check_no_annotations $(cat job3.id) &&
+        jmgr_check_no_annotations $(cat job4.id) &&
+        jmgr_check_no_annotations $(cat job5.id)
+'
+
+test_expect_success 'job-manager: job 2 release' '
+        flux job urgency $(cat job2.id) 16
+'
+
+test_expect_success HAVE_JQ 'job-manager: annotations job 2 pending' '
+        jmgr_check_no_annotations $(cat job1.id) &&
+        jmgr_check_annotation $(cat job2.id) "sched.reason_pending" "\"no cores available\"" &&
+        jmgr_check_no_annotations $(cat job3.id) &&
+        jmgr_check_no_annotations $(cat job4.id) &&
+        jmgr_check_no_annotations $(cat job5.id)
+'
+
+test_expect_success 'job-manager: cancel remaining jobs' '
+        flux job cancel $(cat job2.id) &&
+        flux job cancel $(cat job5.id)
+'
+
+test_expect_success 'job-manager: remove sched-dummy' '
+        flux module remove sched-dummy
+'
+
+test_expect_success 'job-manager: remove job-manager, job-ingest' '
+        flux module remove job-info &&
+        flux module remove job-manager &&
+        flux exec -r all flux module remove job-ingest
+'
+
+test_done

--- a/t/t2214-job-manager-hold-unlimited.t
+++ b/t/t2214-job-manager-hold-unlimited.t
@@ -1,0 +1,190 @@
+#!/bin/sh
+
+test_description='Test flux job manager job hold (unlimited mode)'
+
+. `dirname $0`/job-manager/sched-helper.sh
+
+. $(dirname $0)/sharness.sh
+
+test_under_flux 4 kvs
+
+SCHED_DUMMY=${FLUX_BUILD_DIR}/t/job-manager/.libs/sched-dummy.so
+
+flux setattr log-stderr-level 1
+
+test_expect_success 'flux-job: generate jobspec for simple test job' '
+        flux jobspec srun -n1 hostname >basic.json
+'
+
+test_expect_success 'job-manager: load job-ingest, job-manager' '
+        flux module load job-manager &&
+        flux module load job-ingest &&
+        flux exec -r all -x 0 flux module load job-ingest &&
+        flux exec -r all flux module load job-info
+'
+
+test_expect_success 'job-manager: submit 5 jobs (job 4 held)' '
+        flux job submit --flags=debug basic.json >job1.id &&
+        flux job submit --flags=debug basic.json >job2.id &&
+        flux job submit --flags=debug basic.json >job3.id &&
+        flux job submit --flags=debug --urgency=0 basic.json >job4.id &&
+        flux job submit --flags=debug basic.json >job5.id
+'
+
+test_expect_success HAVE_JQ 'job-manager: job state SSSSS (no scheduler)' '
+        jmgr_check_state $(cat job1.id) S &&
+        jmgr_check_state $(cat job2.id) S &&
+        jmgr_check_state $(cat job3.id) S &&
+        jmgr_check_state $(cat job4.id) S &&
+        jmgr_check_state $(cat job5.id) S
+'
+
+test_expect_success HAVE_JQ 'job-manager: no annotations (SSSSS)' '
+        jmgr_check_no_annotations $(cat job1.id) &&
+        jmgr_check_no_annotations $(cat job2.id) &&
+        jmgr_check_no_annotations $(cat job3.id) &&
+        jmgr_check_no_annotations $(cat job4.id) &&
+        jmgr_check_no_annotations $(cat job5.id)
+'
+
+test_expect_success 'job-manager: load sched-dummy --cores=2' '
+        flux module load ${SCHED_DUMMY} --cores=2 --mode=unlimited
+'
+
+test_expect_success HAVE_JQ 'job-manager: job state RRSSS' '
+        jmgr_check_state $(cat job1.id) R &&
+        jmgr_check_state $(cat job2.id) R &&
+        jmgr_check_state $(cat job3.id) S &&
+        jmgr_check_state $(cat job4.id) S &&
+        jmgr_check_state $(cat job5.id) S
+'
+
+test_expect_success HAVE_JQ 'job-manager: job annotations correct (RRSSS)' '
+        jmgr_check_annotation $(cat job1.id) "sched.resource_summary" "\"1core\"" &&
+        jmgr_check_annotation $(cat job2.id) "sched.resource_summary" "\"1core\"" &&
+        jmgr_check_annotation $(cat job3.id) "sched.reason_pending" "\"no cores\"" &&
+        jmgr_check_annotation $(cat job3.id) "sched.jobs_ahead" "0" &&
+        jmgr_check_no_annotations $(cat job4.id) &&
+        jmgr_check_annotation $(cat job5.id) "sched.reason_pending" "\"no cores\"" &&
+        jmgr_check_annotation $(cat job5.id) "sched.jobs_ahead" "1"
+'
+
+test_expect_success 'job-manager: put hold on job 3' '
+        flux job urgency $(cat job3.id) hold
+'
+
+test_expect_success HAVE_JQ 'job-manager: job state RRSSS' '
+        jmgr_check_state $(cat job1.id) R &&
+        jmgr_check_state $(cat job2.id) R &&
+        jmgr_check_state $(cat job3.id) S &&
+        jmgr_check_state $(cat job4.id) S &&
+        jmgr_check_state $(cat job5.id) S
+'
+
+test_expect_success HAVE_JQ 'job-manager: job annotations updated (RRSSS)' '
+        jmgr_check_annotation $(cat job1.id) "sched.resource_summary" "\"1core\"" &&
+        jmgr_check_annotation $(cat job2.id) "sched.resource_summary" "\"1core\"" &&
+        jmgr_check_no_annotations $(cat job3.id) &&
+        jmgr_check_no_annotations $(cat job4.id) &&
+        jmgr_check_annotation $(cat job5.id) "sched.reason_pending" "\"no cores\"" &&
+        jmgr_check_annotation $(cat job5.id) "sched.jobs_ahead" "0"
+'
+
+test_expect_success 'job-manager: cancel job 1 & 2' '
+        flux job cancel $(cat job1.id) &&
+        flux job cancel $(cat job2.id)
+'
+
+test_expect_success HAVE_JQ 'job-manager: job state IISSR' '
+        jmgr_check_state $(cat job1.id) I &&
+        jmgr_check_state $(cat job2.id) I &&
+        jmgr_check_state $(cat job3.id) S &&
+        jmgr_check_state $(cat job4.id) S &&
+        jmgr_check_state $(cat job5.id) R
+'
+
+test_expect_success HAVE_JQ 'job-manager: job annotations updated (IISSR)' '
+        jmgr_check_no_annotations $(cat job1.id) &&
+        jmgr_check_no_annotations $(cat job2.id) &&
+        jmgr_check_no_annotations $(cat job3.id) &&
+        jmgr_check_no_annotations $(cat job4.id) &&
+        jmgr_check_annotation $(cat job5.id) "sched.resource_summary" "\"1core\""
+'
+
+test_expect_success 'job-manager: remove hold on job 3' '
+        flux job urgency $(cat job3.id) 16
+'
+
+test_expect_success HAVE_JQ 'job-manager: job state IISSR' '
+        jmgr_check_state $(cat job1.id) I &&
+        jmgr_check_state $(cat job2.id) I &&
+        jmgr_check_state $(cat job3.id) R &&
+        jmgr_check_state $(cat job4.id) S &&
+        jmgr_check_state $(cat job5.id) R
+'
+
+test_expect_success HAVE_JQ 'job-manager: job annotations updated (IIRSR)' '
+        jmgr_check_no_annotations $(cat job1.id) &&
+        jmgr_check_no_annotations $(cat job2.id) &&
+        jmgr_check_annotation $(cat job3.id) "sched.resource_summary" "\"1core\"" &&
+        jmgr_check_no_annotations $(cat job4.id) &&
+        jmgr_check_annotation $(cat job5.id) "sched.resource_summary" "\"1core\""
+'
+
+test_expect_success 'job-manager: remove hold on job 4' '
+        flux job urgency $(cat job4.id) 16
+'
+
+test_expect_success HAVE_JQ 'job-manager: job state IIRSR' '
+        jmgr_check_state $(cat job1.id) I &&
+        jmgr_check_state $(cat job2.id) I &&
+        jmgr_check_state $(cat job3.id) R &&
+        jmgr_check_state $(cat job4.id) S &&
+        jmgr_check_state $(cat job5.id) R
+'
+
+test_expect_success HAVE_JQ 'job-manager: job annotations updated (IIRSR)' '
+        jmgr_check_no_annotations $(cat job1.id) &&
+        jmgr_check_no_annotations $(cat job2.id) &&
+        jmgr_check_annotation $(cat job3.id) "sched.resource_summary" "\"1core\"" &&
+        jmgr_check_annotation $(cat job4.id) "sched.reason_pending" "\"no cores\"" &&
+        jmgr_check_annotation $(cat job4.id) "sched.jobs_ahead" "0" &&
+        jmgr_check_annotation $(cat job5.id) "sched.resource_summary" "\"1core\""
+'
+
+test_expect_success 'job-manager: cancel job 3' '
+        flux job cancel $(cat job3.id)
+'
+
+test_expect_success HAVE_JQ 'job-manager: job state IIIRR' '
+        jmgr_check_state $(cat job1.id) I &&
+        jmgr_check_state $(cat job2.id) I &&
+        jmgr_check_state $(cat job3.id) I &&
+        jmgr_check_state $(cat job4.id) R &&
+        jmgr_check_state $(cat job5.id) R
+'
+
+test_expect_success HAVE_JQ 'job-manager: job annotations updated (IISRR)' '
+        jmgr_check_no_annotations $(cat job1.id) &&
+        jmgr_check_no_annotations $(cat job2.id) &&
+        jmgr_check_no_annotations $(cat job3.id) &&
+        jmgr_check_annotation $(cat job4.id) "sched.resource_summary" "\"1core\"" &&
+        jmgr_check_annotation $(cat job5.id) "sched.resource_summary" "\"1core\""
+'
+
+test_expect_success 'job-manager: cancel all jobs' '
+        flux job cancel $(cat job4.id) &&
+        flux job cancel $(cat job5.id)
+'
+
+test_expect_success 'job-manager: remove sched-dummy' '
+        flux module remove sched-dummy
+'
+
+test_expect_success 'job-manager: remove job-info, job-manager, job-ingest' '
+        flux exec -r all flux module remove job-info &&
+        flux module remove job-manager &&
+        flux exec -r all flux module remove job-ingest
+'
+
+test_done

--- a/t/t2230-job-info-list.t
+++ b/t/t2230-job-info-list.t
@@ -290,8 +290,8 @@ EOT
 
 test_expect_success HAVE_JQ 'flux job list pending jobs with correct priority' '
         cat >list_priority.exp <<-EOT &&
-31
-31
+4294967295
+4294967295
 20
 20
 16

--- a/t/t2234-job-info-list-update.t
+++ b/t/t2234-job-info-list-update.t
@@ -192,8 +192,8 @@ EOT
 
 test_expect_success HAVE_JQ 'flux job list pending jobs with correct priority' '
         cat >list_priority.exp <<-EOT &&
-31
-31
+4294967295
+4294967295
 20
 20
 16
@@ -245,8 +245,8 @@ EOT
 
 test_expect_success HAVE_JQ 'flux job list pending jobs with correct priority' '
         cat >list_priority_after.exp <<-EOT &&
-31
-31
+4294967295
+4294967295
 20
 16
 16

--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -371,7 +371,7 @@ test_expect_success 'flux-jobs --format={userid},{username} works' '
 
 test_expect_success 'flux-jobs --format={urgency},{priority} works' '
 	flux jobs --suppress-header -a --format="{urgency},{priority}" > urgency_priority.out &&
-	echo 31,31 > urgency_priority.exp &&
+	echo 31,4294967295 > urgency_priority.exp &&
 	echo 25,25 >> urgency_priority.exp &&
 	echo 20,20 >> urgency_priority.exp &&
 	echo 15,15 >> urgency_priority.exp &&


### PR DESCRIPTION
Per #2895 and #3324, support the idea of a job hold and job expedite.  A hold is urgency=0, in which a job will not be sent to the scheduler (note that #3334 still exists, so if the job has already been sent to the scheduler in unlimited mode, no way to change it yet).  Expedite is urgency=31, which automatically leads to the job priority being set to the max (2^32-1).

Supporting this in `flux job urgency`, the special args of `hold`, `expedite`, and `default` are now supported, making it easier for a
user to set a hold/expediate/default job priority on a job without knowing what values those map too.

Per discussion in #2895 it would be nice to inform a caller what the prior urgency was after changing it.  So I modified the `job-manager.urgency` RPC to return the old urgency to the caller.

I support a new `libjob` function `flux_job_set_urgency_get_prior_urgency()` to parse the RPC response.
I'm not a fan of this function name, and had trouble coming up with a good name.  Suggestions welcome.  Could just shorten to `flux_job_set_urgency_get()`, which is what I also considered.  Or need to shorten `flux_job_set_urgency()` to flux_job_urgency()` too.

I then support a `--verbose` option in `flux job urgency` to output a message to stderr on what the prior urgency was.  I had trouble with the option name here too.  Could have been `--output-prior` or something like that (in which I could perhaps output to stdout instead of stderr), but just settled on verbose in case we add more output in the future.  Suggestions welcome as well.
