### PR TITLE
fix github actions on tag push

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -9,7 +9,7 @@ jobs:
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
-    - run: git fetch --tags
+    - run: git fetch --tags || true
     - name: docker-run-checks with ASan
       timeout-minutes: 40
       env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,7 +68,7 @@ jobs:
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
-    - run: git fetch --tags
+    - run: git fetch --tags || true
     - run: >
         src/test/docker/docker-run-checks.sh --install-only
         --tag=fluxrm/flux-core:bionic

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -178,3 +178,4 @@ jobs:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
         asset_path: ${{ steps.prep_release.outputs.tarball }}
         asset_name: ${{ steps.prep_release.outputs.tarball }}
+        asset_content_type: "application/gzip"


### PR DESCRIPTION
This PR fixes a couple GitHub action failures that were only seen when pushing a tag.

Since the actions are edited, this PR might need someone to push the merge button manually. (assuming actions pass)