### PR TITLE
python: fix ctrl-c handling and re-throw unhandled exceptions in reactor_run()

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -35,5 +35,8 @@ follow_imports = silent
 [mypy-flux.job.list]
 ignore_errors = True
 
+[mypy-flux.core.handle]
+ignore_errors = True
+
 [mypy-python.t1000-service-add-remove]
 ignore_errors = True

--- a/src/bindings/python/flux/core/handle.py
+++ b/src/bindings/python/flux/core/handle.py
@@ -21,6 +21,8 @@ from flux.core.inner import raw
 from flux.message import MessageWatcher
 from flux.core.watchers import TimerWatcher
 from flux.core.watchers import SignalWatcher
+from flux.core.watchers import FDWatcher
+from flux.constants import FLUX_POLLIN, FLUX_POLLOUT, FLUX_POLLERR
 from _flux._core import ffi, lib
 
 
@@ -233,6 +235,11 @@ class Flux(Wrapper):
 
     def signal_watcher_create(self, signum, callback, args=None):
         return SignalWatcher(self, signum, callback, args)
+
+    def fd_watcher_create(self, fd_int, callback, events=None, args=None):
+        if events is None:
+            events = FLUX_POLLIN | FLUX_POLLOUT | FLUX_POLLERR
+        return FDWatcher(self, fd_int, events, callback, args=args)
 
     def barrier(self, name, nprocs):
         self.flux_barrier(name, nprocs)

--- a/src/bindings/python/flux/core/handle.py
+++ b/src/bindings/python/flux/core/handle.py
@@ -24,6 +24,7 @@ from flux.core.watchers import SignalWatcher
 from _flux._core import ffi, lib
 
 
+# pylint: disable=too-many-public-methods
 class Flux(Wrapper):
     """
     The general Flux handle class, create one of these to connect to the

--- a/src/bindings/python/flux/core/watchers.py
+++ b/src/bindings/python/flux/core/watchers.py
@@ -52,7 +52,12 @@ class Watcher(object):
 def timeout_handler_wrapper(unused1, unused2, revents, opaque_handle):
     del unused1, unused2  # unused arguments
     watcher = ffi.from_handle(opaque_handle)
-    watcher.callback(watcher.flux_handle, watcher, revents, watcher.args)
+    try:
+        watcher.callback(watcher.flux_handle, watcher, revents, watcher.args)
+    # pylint: disable=broad-except
+    except Exception as exc:
+        type(watcher.flux_handle).set_exception(exc)
+        watcher.flux_handle.reactor_stop_error()
 
 
 class TimerWatcher(Watcher):
@@ -79,8 +84,13 @@ class TimerWatcher(Watcher):
 def fd_handler_wrapper(unused1, unused2, revents, opaque_handle):
     del unused1, unused2  # unused arguments
     watcher = ffi.from_handle(opaque_handle)
-    fd_int = raw.fd_watcher_get_fd(watcher.handle)
-    watcher.callback(watcher.flux_handle, watcher, fd_int, revents, watcher.args)
+    try:
+        fd_int = raw.fd_watcher_get_fd(watcher.handle)
+        watcher.callback(watcher.flux_handle, watcher, fd_int, revents, watcher.args)
+    # pylint: disable=broad-except
+    except Exception as exc:
+        type(watcher.flux_handle).set_exception(exc)
+        watcher.flux_handle.reactor_stop_error()
 
 
 class FDWatcher(Watcher):
@@ -106,8 +116,13 @@ class FDWatcher(Watcher):
 @ffi.def_extern()
 def signal_handler_wrapper(_unused1, _unused2, _unused3, opaque_handle):
     watcher = ffi.from_handle(opaque_handle)
-    signal_int = raw.signal_watcher_get_signum(watcher.handle)
-    watcher.callback(watcher.flux_handle, watcher, signal_int, watcher.args)
+    try:
+        signal_int = raw.signal_watcher_get_signum(watcher.handle)
+        watcher.callback(watcher.flux_handle, watcher, signal_int, watcher.args)
+    # pylint: disable=broad-except
+    except Exception as exc:
+        type(watcher.flux_handle).set_exception(exc)
+        watcher.flux_handle.reactor_stop_error()
 
 
 class SignalWatcher(Watcher):

--- a/src/bindings/python/flux/message.py
+++ b/src/bindings/python/flux/message.py
@@ -122,12 +122,17 @@ class Message(WrapperPimpl):
 def message_handler_wrapper(unused1, unused2, msg_handle, opaque_handle):
     del unused1, unused2  # unused arguments
     watcher = ffi.from_handle(opaque_handle)
-    watcher.callback(
-        watcher.flux_handle,
-        watcher,
-        Message(handle=msg_handle, destruct=False),
-        watcher.args,
-    )
+    try:
+        watcher.callback(
+            watcher.flux_handle,
+            watcher,
+            Message(handle=msg_handle, destruct=False),
+            watcher.args,
+        )
+    # pylint: disable=broad-except
+    except Exception as exc:
+        type(watcher.flux_handle).set_exception(exc)
+        watcher.flux_handle.reactor_stop_error()
 
 
 class MessageWatcher(Watcher):

--- a/src/bindings/python/flux/rpc.py
+++ b/src/bindings/python/flux/rpc.py
@@ -74,7 +74,6 @@ class RPC(Future):
             return None
         return ffi.string(payload_str[0]).decode("utf-8")
 
-    @interruptible
     def get(self):
         resp_str = self.get_str()
         if resp_str is None:

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -224,6 +224,7 @@ dist_check_SCRIPTS = \
 	issues/t2686-shell-input-race.sh \
 	issues/t3186-python-future-get-sigint.sh \
 	issues/t3415-job-shell-segfault-on-null.sh \
+	issues/t3432-python-sigint.sh \
 	python/__init__.py \
 	python/subflux.py \
 	python/tap \

--- a/t/issues/t3432-python-sigint.sh
+++ b/t/issues/t3432-python-sigint.sh
@@ -1,0 +1,65 @@
+#!/bin/sh
+# reactor_run() is uninterruptible if callback makes synchronous RPC
+
+waitfile=${SHARNESS_TEST_SRCDIR}/scripts/waitfile.lua
+
+log() { echo "t3432: $@" >&2; }
+die() { log "$@"; cat t3423.log >&2; exit 1; }
+
+cat <<EOF >reactor-intr.py || die "Failed to create test script"
+import sys
+import flux
+from flux.core.watchers import TimerWatcher
+
+def timeout_cb(handle, watcher, revents, _args):
+    raise OSError("Timed out!")
+
+def startup_cb(handle, watcher, revents, _args):
+    print("sending ping request")
+    h.rpc("kvs.ping", {}).then(ping_cb, do_sync=True)
+
+def ping_cb(rpc, do_sync=False):
+    print("ping_cb")
+    print(rpc.get_str())
+    if do_sync:
+       print("synchronous ping in ping_cb:")
+       print(rpc.get_flux().rpc("kvs.ping", {}).get_str())
+       print("ready.")
+       sys.stdout.flush()
+
+do_sync = len(sys.argv) > 1 and sys.argv[1] == "sync" 
+
+h = flux.Flux()
+
+print("starting timer watchers")
+tw1 = TimerWatcher(h, 0.01, startup_cb)
+tw2 = TimerWatcher(h, 20., timeout_cb)
+
+print("starting reactor_run")
+try:
+    tw1.start()
+    tw2.start()
+    h.reactor_run()
+except KeyboardInterrupt as exc:
+    print("Got KeyboardInterrupt. Exiting...")
+    pass
+EOF
+
+log "Created test script reactor-intr.py"
+
+flux python reactor-intr.py sync >t3432.log 2>&1 &
+pid=$!
+
+log "Started PID=$pid"
+
+$waitfile --timeout=10 --pattern="^ready" t3432.log || die "waitfile failed"
+
+log "Sending SIGINT to $pid"
+kill -INT $pid || die "Failed to kill PID $pid"
+
+log "Waiting for $pid to exit"
+wait $pid
+STATUS=$?
+
+test $STATUS -eq 0 || die "process exited with $STATUS expected 0"
+log "Python script exited with status $STATUS"

--- a/t/python/t0007-watchers.py
+++ b/t/python/t0007-watchers.py
@@ -73,7 +73,7 @@ class TestTimer(unittest.TestCase):
     def test_msg_watcher_unicode(self):
         with self.f.msg_watcher_create(
             lambda handle, x, y, z: handle.fatal_error("cb should not run"),
-            topic_glob=u"foo.*",
+            topic_glob="foo.*",
         ) as mw:
             self.assertIsNotNone(mw)
 

--- a/t/python/t0012-futures.py
+++ b/t/python/t0012-futures.py
@@ -82,6 +82,14 @@ class TestHandle(unittest.TestCase):
         self.assertGreaterEqual(ret, 0, msg="Reactor exited with {}".format(ret))
         self.assertTrue(cb_ran[0], msg="Callback did not run successfully")
 
+    def test_03_future_then_exception(self):
+        def then_cb(future):
+            raise RuntimeError("this is a test")
+
+        self.f.rpc("cmb.ping", self.ping_payload).then(then_cb)
+        with self.assertRaises(RuntimeError) as cm:
+            rc = self.f.reactor_run()
+
     def test_03_future_then_varargs(self):
         cb_ran = [False]
 

--- a/t/python/t0012-futures.py
+++ b/t/python/t0012-futures.py
@@ -92,7 +92,7 @@ class TestHandle(unittest.TestCase):
                 self.assertEqual(two, "two")
                 self.assertEqual(three, "three")
             finally:
-                future.get_handle().reactor_stop()
+                future.get_flux().reactor_stop()
 
         self.f.rpc("cmb.ping").then(then_cb, "one", "two", "three")
         gc.collect(2)
@@ -105,7 +105,7 @@ class TestHandle(unittest.TestCase):
 
         def then_cb(future):
             cb_ran[0] = True
-            future.get_handle().reactor_stop()
+            future.get_flux().reactor_stop()
 
         self.f.rpc("cmb.ping").then(then_cb)
         gc.collect(2)
@@ -121,7 +121,7 @@ class TestHandle(unittest.TestCase):
             try:
                 self.assertIsNone(args)
             finally:
-                future.get_handle().reactor_stop()
+                future.get_flux().reactor_stop()
 
         self.f.rpc("cmb.ping").then(then_cb)
         gc.collect(2)
@@ -140,7 +140,7 @@ class TestHandle(unittest.TestCase):
                 # val3 gets default value
                 self.assertEqual(val3, "default")
             finally:
-                future.get_handle().reactor_stop()
+                future.get_flux().reactor_stop()
 
         self.f.rpc("cmb.ping").then(then_cb, val2=True, val1=True)
         gc.collect(2)
@@ -152,8 +152,8 @@ class TestHandle(unittest.TestCase):
         """Register two 'then' cbs and ensure it throws an exception"""
         with self.assertRaises(EnvironmentError) as cm:
             rpc = self.f.rpc(b"cmb.ping")
-            rpc.then(lambda x, y: None)
-            rpc.then(lambda x, y: None)
+            rpc.then(lambda x: None)
+            rpc.then(lambda x: None)
         self.assertEqual(cm.exception.errno, errno.EEXIST)
 
     def test_05_future_error_string(self):


### PR DESCRIPTION
This PR fixes the signal handling problems described in #3432.

As described in that issue, a new global, per-thread state variable is introduced to determine if the current thread is executing under the Flux reactor, and disables the `@interrupt` decorator if so. This fixes many instances where Ctrl-C bafflingly could not interrupt a python program which had called into the reactor.

Additionally, `@interruptible` was mistakenly placed on `RPC.get()` which calls `RPC.get_str()` which was already using the `@interruptible` decorator, so that likely caused some issues as well.

I've also fixed the handling of exceptions in Future and Watcher callbacks in this PR. If an uncaught exception is detected from one of these callbacks, it is saved in global state and the reactor is terminated with an error. The reactor_run() method then re-throws the exception, which makes it so that these errors do not go undetected.

In fact there were some errors in the testsuite which were masked by this problem. (including calling a method that didn't exist!). Those are fixed here.

A next step here might be to throw `OSError` when `handle.reactor_run()` returns `-1`. This might be more pythonic, and would allow running the reactor to always be placed in a `try/except` block.