### PR TITLE
testsuite: fix invalid tests, cleanup list-jobs, remove hardcoded states/results

### DIFF
--- a/src/modules/job-manager/list.c
+++ b/src/modules/job-manager/list.c
@@ -39,13 +39,15 @@ int list_append_job (json_t *jobs, struct job *job)
 {
     json_t *o;
 
-    if (!(o = json_pack ("{s:I s:i s:i s:f s:i}",
+    if (!(o = json_pack ("{s:I s:i s:i s:i s:f s:i}",
                          "id",
                          job->id,
                          "userid",
                          job->userid,
                          "urgency",
                          job->urgency,
+                         "priority",
+                         job->priority,
                          "t_submit",
                          job->t_submit,
                          "state",

--- a/src/modules/job-manager/test/list.c
+++ b/src/modules/job-manager/test/list.c
@@ -46,8 +46,8 @@ int main (int argc, char *argv[])
         "array[0] id=1");
     if (id != 1)
         diag ("id=%d", (int)id);
-    ok (json_object_size (el) == 5,
-        "array[1] size=5");
+    ok (json_object_size (el) == 6,
+        "array[1] size=6");
 
     json_decref (jobs);
     job_decref (job);

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -248,6 +248,7 @@ dist_check_SCRIPTS = \
 	job-manager/submit-sliding-window.py \
 	job-manager/wait-interrupted.py \
 	job-manager/sched-helper.sh \
+	job-manager/job-conv.py \
 	job-attach/outputsleep.sh \
 	job-exec/dummy.sh \
 	job-exec/imp.sh \

--- a/t/job-manager/job-conv.py
+++ b/t/job-manager/job-conv.py
@@ -1,0 +1,115 @@
+##############################################################
+# Copyright 2020 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+##############################################################
+
+import sys
+import argparse
+
+from flux.core.inner import ffi, raw
+
+
+def statetostr(args):
+    if not args.states:
+        args.states = [line.strip() for line in sys.stdin]
+
+    for state in args.states:
+        print(raw.flux_job_statetostr(int(state), args.single).decode("utf-8"))
+
+
+def strtostate(args):
+    state = ffi.new("flux_job_state_t [1]")
+    if not args.strings:
+        args.strings = [line.strip() for line in sys.stdin]
+
+    for s in args.strings:
+        try:
+            raw.flux_job_strtostate(s, state)
+        except Exception:
+            print(f"invalid string {s}")
+            sys.exit(1)
+        print(int(state[0]))
+
+
+def resulttostr(args):
+    if not args.results:
+        args.results = [line.strip() for line in sys.stdin]
+
+    for result in args.results:
+        print(raw.flux_job_resulttostr(int(result), args.abbrev).decode("utf-8"))
+
+
+def strtoresult(args):
+    result = ffi.new("flux_job_result_t [1]")
+    if not args.strings:
+        args.strings = [line.strip() for line in sys.stdin]
+
+    for s in args.strings:
+        try:
+            raw.flux_job_strtoresult(s, result)
+        except Exception:
+            print(f"invalid string {s}")
+            sys.exit(1)
+        print(int(result[0]))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(prog="job-conv")
+    subparsers = parser.add_subparsers(
+        title="subcommands", description="", dest="subcommand"
+    )
+    subparsers.required = True
+
+    statetostr_parser = subparsers.add_parser("statetostr")
+    statetostr_parser.add_argument(
+        "-s",
+        "--single",
+        action="store_true",
+        help="Output single string abbreviation",
+    )
+    statetostr_parser.add_argument(
+        "states",
+        nargs="*",
+        help="List of states to convert",
+    )
+    statetostr_parser.set_defaults(func=statetostr)
+
+    strtostate_parser = subparsers.add_parser("strtostate")
+    strtostate_parser.add_argument(
+        "strings",
+        nargs="*",
+        help="List of strings to convert",
+    )
+    strtostate_parser.set_defaults(func=strtostate)
+
+    resulttostr_parser = subparsers.add_parser("resulttostr")
+    resulttostr_parser.add_argument(
+        "-a",
+        "--abbrev",
+        action="store_true",
+        help="Output abbreviated result string",
+    )
+    resulttostr_parser.add_argument(
+        "results",
+        nargs="*",
+        help="List of results to convert",
+    )
+    resulttostr_parser.set_defaults(func=resulttostr)
+
+    strtoresult_parser = subparsers.add_parser("strtoresult")
+    strtoresult_parser.add_argument(
+        "strings",
+        nargs="*",
+        help="List of strings to convert",
+    )
+    strtoresult_parser.set_defaults(func=strtoresult)
+
+    args = parser.parse_args()
+    args.func(args)
+
+# vi: ts=4 sw=4 expandtab

--- a/t/job-manager/list-jobs.c
+++ b/t/job-manager/list-jobs.c
@@ -90,6 +90,7 @@ int main (int argc, char *argv[])
     json_array_foreach (jobs, index, value) {
         flux_jobid_t id;
         int urgency;
+        unsigned int priority;
         uint32_t userid;
         double t_submit;
         char timestr[80];
@@ -97,9 +98,10 @@ int main (int argc, char *argv[])
         json_t *annotations = NULL;
         char *annotations_str = NULL;
 
-        if (json_unpack (value, "{s:I s:i s:i s:f s:i s?:o}",
+        if (json_unpack (value, "{s:I s:i s:i s:i s:f s:i s?:o}",
                                 "id", &id,
                                 "urgency", &urgency,
+                                "priority", &priority,
                                 "userid", &userid,
                                 "t_submit", &t_submit,
                                 "state", &state,
@@ -109,11 +111,12 @@ int main (int argc, char *argv[])
             log_err_exit ("time conversion error");
         if (annotations)
             annotations_str = json_dumps (annotations, 0);
-        printf ("%ju\t%s\t%lu\t%d\t%s%s%s\n",
+        printf ("%ju\t%s\t%lu\t%d\t%u\t%s%s%s\n",
                 (uintmax_t)id,
                 flux_job_statetostr (state, true),
                 (unsigned long)userid,
                 urgency,
+                priority,
                 timestr,
                 annotations_str ? "\t" : "",
                 annotations_str ? annotations_str : "");

--- a/t/job-manager/sched-helper.sh
+++ b/t/job-manager/sched-helper.sh
@@ -43,7 +43,7 @@ jmgr_check_state() {
 _jmgr_get_annotation() {
         local id=$(flux job id $1)
         local key=$2
-        local note="$(${JMGR_JOB_LIST} | grep ${id} | cut -f 6- | jq ."${key}")"
+        local note="$(${JMGR_JOB_LIST} | grep ${id} | cut -f 7- | jq ."${key}")"
         echo $note
 }
 
@@ -77,7 +77,7 @@ jmgr_check_annotation() {
 jmgr_check_annotation_exists() {
         local id=$(flux job id $1)
         local key=$2
-        ${JMGR_JOB_LIST} | grep ${id} | cut -f 6- | jq -e ."${key}" > /dev/null
+        ${JMGR_JOB_LIST} | grep ${id} | cut -f 7- | jq -e ."${key}" > /dev/null
 }
 
 # verify that job contains no annotations through job manager
@@ -85,7 +85,7 @@ jmgr_check_annotation_exists() {
 # arg1 - jobid
 jmgr_check_no_annotations() {
         local id=$(flux job id $1)
-        test -z "$(${JMGR_JOB_LIST} | grep ${id} | cut -f 6-)" && return 0
+        test -z "$(${JMGR_JOB_LIST} | grep ${id} | cut -f 7-)" && return 0
         return 1
 }
 

--- a/t/job-manager/sched-helper.sh
+++ b/t/job-manager/sched-helper.sh
@@ -4,13 +4,14 @@
 # job-manager sched helper functions
 
 JMGR_JOB_LIST=${FLUX_BUILD_DIR}/t/job-manager/list-jobs
+JOB_CONV="flux python ${FLUX_SOURCE_DIR}/t/job-manager/job-conv.py"
 
 # internal function to get job state via job manager
 #
 # if job is not found by list-jobs, but the clean event exists
 # in the job's eventlog, return state as inactive
 #
-# use flux-jobs --from-stdin to convert state numeric value to string
+# use job-conf tool to convert state numeric value to string
 # value.
 #
 # arg1 - jobid
@@ -18,7 +19,8 @@ _jmgr_get_state() {
         local id=$(flux job id $1)
         local state=$(${JMGR_JOB_LIST} \
                       | grep ${id} \
-                      | flux jobs -n --from-stdin -o "{state_single}")
+                      | jq .state \
+                      | ${JOB_CONV} statetostr -s)
         test -z "$state" \
                 && flux job wait-event --timeout=5 ${id} clean >/dev/null \
                 && state=I

--- a/t/t2202-job-manager.t
+++ b/t/t2202-job-manager.t
@@ -64,6 +64,12 @@ test_expect_success 'job-manager: queue list job with correct urgency' '
 	test_cmp list1_urgency.exp list1_urgency.out
 '
 
+test_expect_success 'job-manager: queue list job with correct priority' '
+	echo 16 >list1_priority.exp &&
+	cut -f5 <list1.out >list1_priority.out &&
+	test_cmp list1_priority.exp list1_priority.out
+'
+
 test_expect_success 'job-manager: raise non-fatal exception on job' '
 	jobid=$(cat list1_jobid.out) &&
 	flux job raise --severity=1 --type=testing ${jobid} Mumble grumble &&
@@ -113,7 +119,7 @@ test_expect_success 'job-manager: queue is sorted in priority order' '
 	16
 	0
 	EOT
-	cut -f4 <list3.out >list3_priority.out &&
+	cut -f5 <list3.out >list3_priority.out &&
 	test_cmp list3_priority.exp list3_priority.out
 '
 
@@ -122,7 +128,7 @@ test_expect_success 'job-manager: list-jobs --count shows highest priority jobs'
 	31
 	16
 	EOT
-	${LIST_JOBS} -c 2 | cut -f4 >list3_lim2.out &&
+	${LIST_JOBS} -c 2 | cut -f5 >list3_lim2.out &&
 	test_cmp list3_lim2.exp list3_lim2.out
 '
 

--- a/t/t2202-job-manager.t
+++ b/t/t2202-job-manager.t
@@ -41,32 +41,32 @@ test_expect_success 'job-manager: queue contains 1 job' '
 	test $(wc -l <list1.out) -eq 1
 '
 
-test_expect_success 'job-manager: queue lists job with correct jobid' '
-	cut -f1 <list1.out >list1_jobid.out &&
+test_expect_success HAVE_JQ 'job-manager: queue lists job with correct jobid' '
+	$jq .id <list1.out >list1_jobid.out &&
 	test_cmp submit1.out list1_jobid.out
 '
 
-test_expect_success 'job-manager: queue lists job with state=N' '
-	echo "S" >list1_state.exp &&
-	cut -f2 <list1.out >list1_state.out &&
+test_expect_success HAVE_JQ 'job-manager: queue lists job with state=N' '
+	echo "8" >list1_state.exp &&
+	$jq .state <list1.out >list1_state.out &&
 	test_cmp list1_state.exp list1_state.out
 '
 
-test_expect_success 'job-manager: queue lists job with correct userid' '
+test_expect_success HAVE_JQ 'job-manager: queue lists job with correct userid' '
 	id -u >list1_userid.exp &&
-	cut -f3 <list1.out >list1_userid.out &&
+	$jq .userid <list1.out >list1_userid.out &&
 	test_cmp list1_userid.exp list1_userid.out
 '
 
-test_expect_success 'job-manager: queue list job with correct urgency' '
+test_expect_success HAVE_JQ 'job-manager: queue list job with correct urgency' '
 	echo 16 >list1_urgency.exp &&
-	cut -f4 <list1.out >list1_urgency.out &&
+	$jq .urgency <list1.out >list1_urgency.out &&
 	test_cmp list1_urgency.exp list1_urgency.out
 '
 
-test_expect_success 'job-manager: queue list job with correct priority' '
+test_expect_success HAVE_JQ 'job-manager: queue list job with correct priority' '
 	echo 16 >list1_priority.exp &&
-	cut -f5 <list1.out >list1_priority.out &&
+	$jq .priority <list1.out >list1_priority.out &&
 	test_cmp list1_priority.exp list1_priority.out
 '
 
@@ -113,27 +113,27 @@ test_expect_success 'job-manager: queue contains 3 jobs' '
 	test $(wc -l <list3.out) -eq 3
 '
 
-test_expect_success 'job-manager: queue is sorted in priority order' '
+test_expect_success HAVE_JQ 'job-manager: queue is sorted in priority order' '
 	cat >list3_priority.exp <<-EOT &&
 	31
 	16
 	0
 	EOT
-	cut -f5 <list3.out >list3_priority.out &&
+	$jq .priority <list3.out >list3_priority.out &&
 	test_cmp list3_priority.exp list3_priority.out
 '
 
-test_expect_success 'job-manager: list-jobs --count shows highest priority jobs' '
+test_expect_success HAVE_JQ 'job-manager: list-jobs --count shows highest priority jobs' '
 	cat >list3_lim2.exp <<-EOT &&
 	31
 	16
 	EOT
-	${LIST_JOBS} -c 2 | cut -f5 >list3_lim2.out &&
+	${LIST_JOBS} -c 2 | $jq .priority >list3_lim2.out &&
 	test_cmp list3_lim2.exp list3_lim2.out
 '
 
-test_expect_success 'job-manager: cancel jobs' '
-	for jobid in $(cut -f1 <list3.out); do \
+test_expect_success HAVE_JQ 'job-manager: cancel jobs' '
+	for jobid in $($jq .id <list3.out); do \
 		flux job cancel ${jobid}; \
 	done
 '
@@ -149,9 +149,9 @@ test_expect_success 'job-manager: submit 10 jobs of equal urgency' '
 	done
 '
 
-test_expect_success 'job-manager: jobs are listed in submit order' '
+test_expect_success HAVE_JQ 'job-manager: jobs are listed in submit order' '
 	${LIST_JOBS} >list10.out &&
-	cut -f1 <list10.out >list10_ids.out &&
+	$jq .id <list10.out >list10_ids.out &&
 	test_cmp submit10.out list10_ids.out
 '
 
@@ -168,9 +168,9 @@ test_expect_success 'job-manager: urgency was updated in KVS' '
 	grep -q urgency=31 urgency.out
 '
 
-test_expect_success 'job-manager: that job is now the first job' '
+test_expect_success HAVE_JQ 'job-manager: that job is now the first job' '
 	${LIST_JOBS} >list10_reordered.out &&
-	firstid=$(cut -f1 <list10_reordered.out | head -1) &&
+	firstid=$($jq .id <list10_reordered.out | head -1) &&
 	lastid=$(tail -1 <list10_ids.out) &&
 	test "${lastid}" -eq "${firstid}"
 '
@@ -192,7 +192,7 @@ test_expect_success 'job-manager: queue was successfully reconstructed' '
 '
 
 check_eventlog_restart_events() {
-	for jobid in $(cut -f1 <list_reload.out); do
+	for jobid in $($jq .id <list_reload.out); do
 		if ! flux job wait-event -t 20 -c 1 ${jobid} flux-restart \
 		   || ! flux job wait-event -t 20 -c 2 ${jobid} priority
 		then
@@ -202,7 +202,7 @@ check_eventlog_restart_events() {
 	return 0
 }
 
-test_expect_success 'job-manager: eventlog indicates restart & priority event' '
+test_expect_success HAVE_JQ 'job-manager: eventlog indicates restart & priority event' '
 	check_eventlog_restart_events
 '
 
@@ -211,8 +211,8 @@ test_expect_success HAVE_JQ 'job-manager: max_jobid has not changed' '
 	test_cmp max2.exp max2.out
 '
 
-test_expect_success 'job-manager: cancel jobs' '
-	for jobid in $(cut -f1 <list_reload.out); do \
+test_expect_success HAVE_JQ 'job-manager: cancel jobs' '
+	for jobid in $($jq .id <list_reload.out); do \
 		flux job cancel ${jobid}; \
 	done &&
 	test $(${LIST_JOBS} | wc -l) -eq 0
@@ -308,8 +308,8 @@ test_expect_success 'job-manager: there is still one job in the queue' '
 	test $(wc -l <list.out) -eq 1
 '
 
-test_expect_success 'job-manager: drain unblocks when last job is canceled' '
-	jobid=$(cut -f1 <list.out) &&
+test_expect_success HAVE_JQ 'job-manager: drain unblocks when last job is canceled' '
+	jobid=$($jq .id <list.out) &&
 	run_timeout 5 ${DRAIN_CANCEL} ${jobid}
 '
 

--- a/t/t2202-job-manager.t
+++ b/t/t2202-job-manager.t
@@ -11,6 +11,7 @@ flux setattr log-stderr-level 1
 DRAIN_CANCEL="flux python ${FLUX_SOURCE_DIR}/t/job-manager/drain-cancel.py"
 RPC=${FLUX_BUILD_DIR}/t/request/rpc
 LIST_JOBS=${FLUX_BUILD_DIR}/t/job-manager/list-jobs
+JOB_CONV="flux python ${FLUX_SOURCE_DIR}/t/job-manager/job-conv.py"
 
 test_expect_success 'job-manager: generate jobspec for simple test job' '
         flux jobspec srun -n1 hostname >basic.json
@@ -47,8 +48,8 @@ test_expect_success HAVE_JQ 'job-manager: queue lists job with correct jobid' '
 '
 
 test_expect_success HAVE_JQ 'job-manager: queue lists job with state=N' '
-	echo "8" >list1_state.exp &&
-	$jq .state <list1.out >list1_state.out &&
+	echo "SCHED" >list1_state.exp &&
+	$jq .state <list1.out | ${JOB_CONV} statetostr >list1_state.out &&
 	test_cmp list1_state.exp list1_state.out
 '
 

--- a/t/t2203-job-manager-dummysched-single.t
+++ b/t/t2203-job-manager-dummysched-single.t
@@ -31,7 +31,7 @@ test_expect_success 'job-manager: submit 5 jobs' '
         flux job submit --flags=debug basic.json >job5.id
 '
 
-test_expect_success 'job-manager: job state SSSSS (no scheduler)' '
+test_expect_success HAVE_JQ 'job-manager: job state SSSSS (no scheduler)' '
         jmgr_check_state $(cat job1.id) S &&
         jmgr_check_state $(cat job2.id) S &&
         jmgr_check_state $(cat job3.id) S &&
@@ -51,7 +51,7 @@ test_expect_success 'job-manager: load sched-dummy --cores=2' '
         flux module load ${SCHED_DUMMY} --cores=2
 '
 
-test_expect_success 'job-manager: job state RRSSS' '
+test_expect_success HAVE_JQ 'job-manager: job state RRSSS' '
         jmgr_check_state $(cat job1.id) R &&
         jmgr_check_state $(cat job2.id) R &&
         jmgr_check_state $(cat job3.id) S &&
@@ -91,7 +91,7 @@ test_expect_success 'job-manager: cancel 2' '
         flux job cancel $(cat job2.id)
 '
 
-test_expect_success 'job-manager: job state RIRSS' '
+test_expect_success HAVE_JQ 'job-manager: job state RIRSS' '
         jmgr_check_state $(cat job1.id) R &&
         jmgr_check_state $(cat job2.id) I &&
         jmgr_check_state $(cat job3.id) R &&
@@ -152,7 +152,7 @@ test_expect_success 'job-manager: hello handshake userid is expected' '
         grep userid=$(id -u) hello.dmesg
 '
 
-test_expect_success 'job-manager: job state RIRRR' '
+test_expect_success HAVE_JQ 'job-manager: job state RIRRR' '
         jmgr_check_state $(cat job1.id) R &&
         jmgr_check_state $(cat job2.id) I &&
         jmgr_check_state $(cat job3.id) R &&
@@ -188,7 +188,7 @@ test_expect_success 'job-manager: cancel 1' '
         flux job cancel $(cat job1.id)
 '
 
-test_expect_success 'job-manager: job state IIRRR' '
+test_expect_success HAVE_JQ 'job-manager: job state IIRRR' '
         jmgr_check_state $(cat job1.id) I &&
         jmgr_check_state $(cat job2.id) I &&
         jmgr_check_state $(cat job3.id) R &&
@@ -202,7 +202,7 @@ test_expect_success 'job-manager: cancel all jobs' '
         flux job cancel $(cat job5.id)
 '
 
-test_expect_success 'job-manager: job state IIIII' '
+test_expect_success HAVE_JQ 'job-manager: job state IIIII' '
         jmgr_check_state $(cat job1.id) I &&
         jmgr_check_state $(cat job2.id) I &&
         jmgr_check_state $(cat job3.id) I &&

--- a/t/t2204-job-manager-dummysched-unlimited.t
+++ b/t/t2204-job-manager-dummysched-unlimited.t
@@ -31,7 +31,7 @@ test_expect_success 'job-manager: submit 5 jobs' '
         flux job submit --flags=debug basic.json >job5.id
 '
 
-test_expect_success 'job-manager: job state SSSSS (no scheduler)' '
+test_expect_success HAVE_JQ 'job-manager: job state SSSSS (no scheduler)' '
         jmgr_check_state $(cat job1.id) S &&
         jmgr_check_state $(cat job2.id) S &&
         jmgr_check_state $(cat job3.id) S &&
@@ -51,7 +51,7 @@ test_expect_success 'job-manager: load sched-dummy --cores=2' '
         flux module load ${SCHED_DUMMY} --cores=2 --mode=unlimited
 '
 
-test_expect_success 'job-manager: job state RRSSS' '
+test_expect_success HAVE_JQ 'job-manager: job state RRSSS' '
         jmgr_check_state $(cat job1.id) R &&
         jmgr_check_state $(cat job2.id) R &&
         jmgr_check_state $(cat job3.id) S &&
@@ -96,7 +96,7 @@ test_expect_success 'job-manager: cancel 2' '
         flux job cancel $(cat job2.id)
 '
 
-test_expect_success 'job-manager: job state RIRSS' '
+test_expect_success HAVE_JQ 'job-manager: job state RIRSS' '
         jmgr_check_state $(cat job1.id) R &&
         jmgr_check_state $(cat job2.id) I &&
         jmgr_check_state $(cat job3.id) R &&
@@ -148,7 +148,7 @@ test_expect_success 'job-manager: cancel 5' '
         flux job cancel $(cat job5.id)
 '
 
-test_expect_success 'job-manager: job state RIRSI' '
+test_expect_success HAVE_JQ 'job-manager: job state RIRSI' '
         jmgr_check_state $(cat job1.id) R &&
         jmgr_check_state $(cat job2.id) I &&
         jmgr_check_state $(cat job3.id) R &&
@@ -200,7 +200,7 @@ test_expect_success 'job-manager: cancel all jobs' '
         flux job cancelall -f
 '
 
-test_expect_success 'job-manager: job state IIIII' '
+test_expect_success HAVE_JQ 'job-manager: job state IIIII' '
         jmgr_check_state $(cat job1.id) I &&
         jmgr_check_state $(cat job2.id) I &&
         jmgr_check_state $(cat job3.id) I &&

--- a/t/t2205-job-manager-annotate.t
+++ b/t/t2205-job-manager-annotate.t
@@ -31,7 +31,7 @@ test_expect_success 'job-manager: submit 5 jobs' '
         flux job submit --flags=debug basic.json >job5.id
 '
 
-test_expect_success 'job-manager: job state SSSSS (no scheduler)' '
+test_expect_success HAVE_JQ 'job-manager: job state SSSSS (no scheduler)' '
         jmgr_check_state $(cat job1.id) S &&
         jmgr_check_state $(cat job2.id) S &&
         jmgr_check_state $(cat job3.id) S &&
@@ -95,7 +95,7 @@ test_expect_success 'job-manager: load sched-dummy --cores=2' '
         flux module load ${SCHED_DUMMY} --cores=2 --mode=unlimited
 '
 
-test_expect_success 'job-manager: job state RRSSS' '
+test_expect_success HAVE_JQ 'job-manager: job state RRSSS' '
         jmgr_check_state $(cat job1.id) R &&
         jmgr_check_state $(cat job2.id) R &&
         jmgr_check_state $(cat job3.id) S &&
@@ -205,7 +205,7 @@ test_expect_success 'job-manager: cancel 2' '
         flux job cancel $(cat job2.id)
 '
 
-test_expect_success 'job-manager: job state RIRSS' '
+test_expect_success HAVE_JQ 'job-manager: job state RIRSS' '
         jmgr_check_state $(cat job1.id) R &&
         jmgr_check_state $(cat job2.id) I &&
         jmgr_check_state $(cat job3.id) R &&
@@ -271,7 +271,7 @@ test_expect_success 'job-manager: cancel all jobs' '
         flux job cancelall -f
 '
 
-test_expect_success 'job-manager: job state IIIII' '
+test_expect_success HAVE_JQ 'job-manager: job state IIIII' '
         jmgr_check_state $(cat job1.id) I &&
         jmgr_check_state $(cat job2.id) I &&
         jmgr_check_state $(cat job3.id) I &&

--- a/t/t2207-job-manager-wait.t
+++ b/t/t2207-job-manager-wait.t
@@ -35,13 +35,13 @@ test_expect_success "wait works on inactive,waitable job" '
 	flux job wait ${JOBID}
 '
 
-test_expect_success "waitable inactive jobs are listed as zombies" '
+test_expect_success HAVE_JQ "waitable inactive jobs are listed as zombies" '
 	JOBID=$(flux mini submit --flags waitable /bin/true) &&
 	echo ${JOBID} >id1.out &&
 	flux job wait-event ${JOBID} clean &&
 	${list_jobs} >list1.out &&
 	test $(wc -l <list1.out) -eq 1 &&
-	test "$(cut -f2 <list1.out)" = "I"
+	test "$($jq .state <list1.out)" = "64"
 '
 
 test_expect_success "zombies go away after they are waited for" '

--- a/t/t2207-job-manager-wait.t
+++ b/t/t2207-job-manager-wait.t
@@ -11,6 +11,7 @@ SUBMIT_WAIT="flux python ${FLUX_SOURCE_DIR}/t/job-manager/submit-wait.py"
 SUBMIT_WAITANY="flux python ${FLUX_SOURCE_DIR}/t/job-manager/submit-waitany.py"
 SUBMIT_SW="flux python ${FLUX_SOURCE_DIR}/t/job-manager/submit-sliding-window.py"
 SUBMIT_INTER="flux python ${FLUX_SOURCE_DIR}/t/job-manager/wait-interrupted.py"
+JOB_CONV="flux python ${FLUX_SOURCE_DIR}/t/job-manager/job-conv.py"
 
 flux setattr log-stderr-level 1
 
@@ -41,7 +42,7 @@ test_expect_success HAVE_JQ "waitable inactive jobs are listed as zombies" '
 	flux job wait-event ${JOBID} clean &&
 	${list_jobs} >list1.out &&
 	test $(wc -l <list1.out) -eq 1 &&
-	test "$($jq .state <list1.out)" = "64"
+	test "$($jq .state <list1.out | ${JOB_CONV} statetostr)" = "INACTIVE"
 '
 
 test_expect_success "zombies go away after they are waited for" '

--- a/t/t2209-job-manager-job-urgency-change-single.t
+++ b/t/t2209-job-manager-job-urgency-change-single.t
@@ -30,7 +30,7 @@ test_expect_success 'job-manager: submit 4 jobs' '
         flux job submit --flags=debug basic.json >job4.id
 '
 
-test_expect_success 'job-manager: job state SSSS (no scheduler)' '
+test_expect_success HAVE_JQ 'job-manager: job state SSSS (no scheduler)' '
         jmgr_check_state $(cat job1.id) S &&
         jmgr_check_state $(cat job2.id) S &&
         jmgr_check_state $(cat job3.id) S &&
@@ -48,7 +48,7 @@ test_expect_success 'job-manager: load sched-dummy --cores=2' '
         flux module load ${SCHED_DUMMY} --cores=2
 '
 
-test_expect_success 'job-manager: job state RRSS' '
+test_expect_success HAVE_JQ 'job-manager: job state RRSS' '
         jmgr_check_state $(cat job1.id) R &&
         jmgr_check_state $(cat job2.id) R &&
         jmgr_check_state $(cat job3.id) S &&
@@ -92,7 +92,7 @@ test_expect_success 'job-manager: cancel 2' '
         flux job cancel $(cat job2.id)
 '
 
-test_expect_success 'job-manager: job state RISR (job 4 runs instead of 3)' '
+test_expect_success HAVE_JQ 'job-manager: job state RISR (job 4 runs instead of 3)' '
         jmgr_check_state $(cat job1.id) R &&
         jmgr_check_state $(cat job2.id) I &&
         jmgr_check_state $(cat job3.id) S &&
@@ -112,7 +112,7 @@ test_expect_success 'job-manager: submit high urgency job' '
         flux job submit --flags=debug --urgency=20 basic.json >job5.id
 '
 
-test_expect_success 'job-manager: job state RISRS' '
+test_expect_success HAVE_JQ 'job-manager: job state RISRS' '
         jmgr_check_state $(cat job1.id) R &&
         jmgr_check_state $(cat job2.id) I &&
         jmgr_check_state $(cat job3.id) S &&
@@ -133,7 +133,7 @@ test_expect_success 'job-manager: cancel 1' '
         flux job cancel $(cat job1.id)
 '
 
-test_expect_success 'job-manager: job state IISRR (job 5 runs instead of 3)' '
+test_expect_success HAVE_JQ 'job-manager: job state IISRR (job 5 runs instead of 3)' '
         jmgr_check_state $(cat job1.id) I &&
         jmgr_check_state $(cat job2.id) I &&
         jmgr_check_state $(cat job3.id) S &&

--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -70,11 +70,11 @@ export FLUX_PYCLI_LOGLEVEL=10
 
 listjobs() {
 	${FLUX_BUILD_DIR}/t/job-manager/list-jobs \
-	    | awk '{print $1}' \
+	    | $jq .id \
 	    | flux job id --to=f58
 }
 
-test_expect_success 'submit jobs for job list testing' '
+test_expect_success HAVE_JQ 'submit jobs for job list testing' '
 	#  Create `hostname` and `sleep 600` jobspec
 	#
 	flux mini submit --dry-run hostname >hostname.json &&

--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -115,7 +115,7 @@ test_expect_success 'submit jobs for job list testing' '
 	#  Submit a set of jobs with non-default urgencies
 	#  N.B. Use `flux job submit` for efficiency
 	#
-	for u in 30 25 20 15 10 5; do
+	for u in 31 25 20 15 10 5; do
 		flux job submit --urgency=$u sleep600.json >> sched.ids
 	done &&
 	listjobs > active.ids &&
@@ -371,7 +371,7 @@ test_expect_success 'flux-jobs --format={userid},{username} works' '
 
 test_expect_success 'flux-jobs --format={urgency},{priority} works' '
 	flux jobs --suppress-header -a --format="{urgency},{priority}" > urgency_priority.out &&
-	echo 30,30 > urgency_priority.exp &&
+	echo 31,31 > urgency_priority.exp &&
 	echo 25,25 >> urgency_priority.exp &&
 	echo 20,20 >> urgency_priority.exp &&
 	echo 15,15 >> urgency_priority.exp &&


### PR DESCRIPTION
Per discussion in #3433 and peeling off from #3428.

- fixed up several tests that were incorrectly testing urgency instead of priority, necessitating adding `priority` to the `list-jobs` output

- have the `t/job-manager/list-jobs` tool output full json output instead of its specific formatting.  

- by doing the above, remove `awk` and `cut` to retrieve fields to  `jq`, so now tests should be a little bit more clear on what they are testing and are more robust if the `list-jobs` RPC returns more fields in the future.

for example:

```
-test_expect_success 'job-manager: queue is sorted in priority order' '
+test_expect_success HAVE_JQ 'job-manager: queue is sorted in priority order' '
        cat >list3_priority.exp <<-EOT &&
        31
        16
        0
        EOT
-       cut -f5 <list3.out >list3_priority.out &&
+       $jq .priority <list3.out >list3_priority.out &&
        test_cmp list3_priority.exp list3_priority.out
 '
```

- added the subcommands `statetostr`, `strtostate`, `resulttostr`, `strtoresult` to `flux job`.  They call the functions in `libjob` you expect.  There was a discussion in #3433 about re-writing `list-jobs` in python and outputting a specific format that would make `list-jobs` tests better instead of writing these commands.  However, it ended up there were non-list-jobs tests that needed these commands, so I just went with this approach.

- update the testsuite to remove many of the hard coded state and result values used in the tests, to hopefully make tests more clear and more robust for the future if additional states/results are added.

for example, one test that I think is far more clear

```
 test_expect_success HAVE_JQ 'flux job list only failed jobs' '
         id=$(id -u) &&
-        $jq -j -c -n  "{max_entries:1000, userid:${id}, states:64, results:2, attrs:[]}" \
+        state=`flux job strtostate INACTIVE` &&
+        result=`flux job strtoresult FAILED` &&
+        $jq -j -c -n  "{max_entries:1000, userid:${id}, states:${state}, results:${result}, attrs:[]}" \
           | $RPC job-info.list | $jq .jobs | $jq -c '.[]' | $jq .id > list_result_failed.out &&
         test_cmp failed.ids list_result_failed.out
 '
```

Admittedly, the "win" on these changes isn't as large as I had imagined it to be.  But I think its still a win.  And with some of the changes upcoming in #3428 and the future it'd be good to get rid of as many of the `cut -fN` laying around where you have little idea what fields are being grabbed.