### PR TITLE
python: fix circular reference in check_future_error decorator

### DIFF
--- a/src/bindings/python/flux/util.py
+++ b/src/bindings/python/flux/util.py
@@ -40,7 +40,6 @@ def check_future_error(func):
         try:
             return func(calling_obj, *args, **kwargs)
         except EnvironmentError as error:
-            exception_tuple = sys.exc_info()
             try:
                 future = (
                     calling_obj.handle
@@ -49,10 +48,10 @@ def check_future_error(func):
                 )
                 errmsg = raw.flux_future_error_string(future)
             except EnvironmentError:
-                six.reraise(*exception_tuple)
+                raise error from None
             if errmsg is None:
-                six.reraise(*exception_tuple)
-            raise EnvironmentError(error.errno, errmsg.decode("utf-8"))
+                raise error from None
+            raise EnvironmentError(error.errno, errmsg.decode("utf-8")) from None
 
     return func_wrapper
 

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -225,6 +225,7 @@ dist_check_SCRIPTS = \
 	issues/t3186-python-future-get-sigint.sh \
 	issues/t3415-job-shell-segfault-on-null.sh \
 	issues/t3432-python-sigint.sh \
+	issues/t3429-python-future-ref.py \
 	python/__init__.py \
 	python/subflux.py \
 	python/tap \

--- a/t/issues/t3429-python-future-ref.py
+++ b/t/issues/t3429-python-future-ref.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+#
+#  Test for issue #3429 - circular future reference occurs when
+#   an exception occurs in a Future continuation_callback. Then
+#   the future is not garbage collected and Python hangs in the
+#   Flux reactor
+#
+import flux
+
+
+def ping_cb(rpc):
+    print(rpc.get_str())
+
+
+h = flux.Flux()
+print("asynchronous: ping kvs.foo")
+h.rpc("kvs.foo", {}).then(ping_cb)
+try:
+    rc = h.reactor_run()
+except OSError as exc:
+    print(f"Got exception: {exc}")
+
+print("Done")


### PR DESCRIPTION
Fix the issue described in #3429. The check_future_error decorator uses `sys.exc_info()` which can cause  a circular reference that is sometimes not cleaned up before re-entering the C reactor. This can result in a "hang" if the reactor is supposed to exit because the consumed future was the last "active" watcher on the reactor.

