### PR TITLE
ci: better script portability and other small updates

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -1,4 +1,5 @@
 on: [ push, pull_request ]
+name: asan
 jobs:
   check-asan:
     name: address-sanitizer check

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,5 @@
 on: [ pull_request, push ]
+name: ci
 jobs:
   check-pr:
     name: validate commits

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,7 @@ jobs:
   check-pr:
     name: validate commits
     runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
     steps:
     - uses: actions/checkout@v2
       with:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![github ci](https://github.com/flux-framework/flux-core/workflows/.github/workflows/main.yml/badge.svg)](https://github.com/flux-framework/flux-core/actions?query=workflow%3A.github%2Fworkflows%2Fmain.yml)
+[![ci](https://github.com/flux-framework/flux-core/workflows/ci/badge.svg)](https://github.com/flux-framework/flux-core/actions?query=workflow%3A.github%2Fworkflows%2Fmain.yml)
 [![codecov](https://codecov.io/gh/flux-framework/flux-core/branch/master/graph/badge.svg)](https://codecov.io/gh/flux-framework/flux-core)
 
 _NOTE: The interfaces of flux-core are being actively developed

--- a/src/test/checks_run.sh
+++ b/src/test/checks_run.sh
@@ -173,7 +173,8 @@ if test -n "$BUILD_DIR" ; then
   cd "$BUILD_DIR"
 fi
 
-checks_group "configure ${ARGS}"  /usr/src/configure ${ARGS}
+checks_group "configure ${ARGS}"  /usr/src/configure ${ARGS} \
+	|| (printf "::error::configure failed\n"; cat config.log; exit 1)
 checks_group "make clean..." make clean
 
 if test "$POISON" = "t" -a test "$PROJECT" = "flux-core"; then
@@ -182,7 +183,8 @@ if test "$POISON" = "t" -a test "$PROJECT" = "flux-core"; then
 fi
 
 if test "$DISTCHECK" != "t"; then
-  checks_group "${MAKECMDS}" eval ${MAKECMDS}
+  checks_group "${MAKECMDS}" eval ${MAKECMDS} \
+	|| (printf "::error::${MAKECMDS} failed\n"; exit 1)
 fi
 checks_group "${CHECKCMDS}" eval "${CHECKCMDS}"
 RC=$?
@@ -192,7 +194,7 @@ if test "$RECHECK" = "t" -a $RC -ne 0; then
   # `make recheck` is not recursive, only perform it if at least some tests
   #   under ./t were run (and presumably failed)
   #
-  if test -s t/t0001-basic.trs; then
+  if test -s t/t0000-sharness.trs; then
     cd t
     printf "::warning::make check failed, trying recheck in ./t\n"
     checks_group "make recheck" ${MAKE} -j ${JOBS} recheck


### PR DESCRIPTION
This PR was the result of updating flux-sched to Github Actions.

The docker-run-checks.sh script got a slight rewrite, allowing it to be copied to flux-sched with only trivial modifications. This will allow us to move improvements to the script between the projects more easily (and perhaps allow the script to be used in other flux-framework projects in the future)

The pr-validator action is now skipped except for pull requests (it doesn't make sense to run it otherwise)

And finally, the two workflows are given names `ci` and `asan` for easier reference (otherwise github refers to them  by full path in the repo)
