### PR TITLE
job-manager: send updated priorities to schedulers

### DIFF
--- a/src/common/libschedutil/init.c
+++ b/src/common/libschedutil/init.c
@@ -39,7 +39,7 @@ schedutil_t *schedutil_create (flux_t *h,
         errno = EINVAL;
         return NULL;
     }
-    if (!(util = calloc(1, sizeof(*util))))
+    if (!(util = calloc (1, sizeof (*util))))
         return NULL;
 
     util->h = h;

--- a/src/common/libschedutil/init.h
+++ b/src/common/libschedutil/init.h
@@ -21,7 +21,7 @@ extern "C" {
 
 typedef struct schedutil_ctx schedutil_t;
 
-/* Create a handle for the schedutil conveinence library.
+/* Create a handle for the schedutil convenience library.
  *
  * Used to track outstanding futures and register callbacks relevant for
  * schedulers and simulators.
@@ -33,7 +33,7 @@ schedutil_t *schedutil_create (flux_t *h,
                                schedutil_cancel_cb_f *cancel_cb,
                                void *cb_arg);
 
-/* Destory the handle for the schedutil conveinence library.
+/* Destroy the handle for the schedutil convenience library.
  *
  * Will automatically respond ENOSYS to any outstanding messages (e.g., free,
  * alloc).

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -114,6 +114,7 @@ TESTSCRIPTS = \
 	t2220-job-archive.t \
 	t2213-job-manager-hold-single.t \
 	t2214-job-manager-hold-unlimited.t \
+	t2215-job-manager-priority-order-unlimited.t \
 	t2230-job-info-list.t \
 	t2231-job-info-lookup.t \
 	t2232-job-info-eventlog-watch.t \

--- a/t/job-manager/sched-dummy.c
+++ b/t/job-manager/sched-dummy.c
@@ -54,6 +54,7 @@ struct sched_ctx {
     const char *mode;
     flux_watcher_t *prep;
     zlistx_t *jobs;
+    flux_msg_handler_t **handlers;
 };
 
 static void job_destroy (void *data)
@@ -88,6 +89,19 @@ static int job_cmp (const void *x, const void *y)
     if ((rc = (-1)*NUMCMP (j1->priority, j2->priority)) == 0)
         rc = NUMCMP (j1->id, j2->id);
     return rc;
+}
+
+static struct job *
+job_find (struct sched_ctx *sc, flux_jobid_t id)
+{
+    struct job *job;
+    job = zlistx_first (sc->jobs);
+    while (job) {
+        if (job->id == id)
+            return job;
+        job = zlistx_next (sc->jobs);
+    }
+    return NULL;
 }
 
 /* Create job struct from sched.alloc request.
@@ -223,6 +237,41 @@ void try_alloc (struct sched_ctx *sc)
     return;
 }
 
+void prioritize_cb (flux_t *h, flux_msg_handler_t *mh,
+                    const flux_msg_t *msg, void *arg)
+{
+    struct sched_ctx *sc = arg;
+    json_t *jobs;
+    size_t index;
+    json_t *arr;
+
+    if (flux_request_unpack (msg, NULL, "{s:o}", "jobs", &jobs) < 0)
+        goto proto_error;
+
+    json_array_foreach (jobs, index, arr) {
+        flux_jobid_t id;
+        int64_t priority;
+        struct job *job;
+
+        if (json_unpack (arr, "[I,I]", &id, &priority) < 0)
+            goto proto_error;
+
+        if ((job = job_find (sc, id))) {
+            job->priority = priority;
+            zlistx_reorder (sc->jobs, job->handle, true);
+            break;
+        }
+    }
+
+    /* called to regenerate annotations */
+    try_alloc (sc);
+    return;
+
+proto_error:
+    flux_log (h, LOG_ERR, "malformed sched.reprioritize request");
+    return;
+}
+
 void cancel_cb (flux_t *h, flux_jobid_t id, void *arg)
 {
     struct sched_ctx *sc = arg;
@@ -234,15 +283,11 @@ void cancel_cb (flux_t *h, flux_jobid_t id, void *arg)
     if (!strcmp (sc->mode, "single") && job->id != id)
         return;
 
-    while (job) {
-        if (job->id == id) {
-            if (schedutil_alloc_respond_cancel (sc->schedutil_ctx,
-                                                job->msg) < 0)
-                flux_log_error (h, "%s: alloc_respond_cancel", __FUNCTION__);
-            zlistx_delete (sc->jobs, job->handle);
-            break;
-        }
-        job = zlistx_next (sc->jobs);
+    if ((job = job_find (sc, id))) {
+        if (schedutil_alloc_respond_cancel (sc->schedutil_ctx,
+                                            job->msg) < 0)
+            flux_log_error (h, "%s: alloc_respond_cancel", __FUNCTION__);
+        zlistx_delete (sc->jobs, job->handle);
     }
 
     /* called to regenerate annotations */
@@ -353,6 +398,11 @@ error:
     return NULL;
 }
 
+static const struct flux_msg_handler_spec htab[] = {
+    { FLUX_MSGTYPE_REQUEST, "sched.prioritize", prioritize_cb, 0},
+    FLUX_MSGHANDLER_TABLE_END,
+};
+
 void sched_destroy (struct sched_ctx *sc)
 {
     if (sc) {
@@ -370,6 +420,7 @@ void sched_destroy (struct sched_ctx *sc)
             job = zlistx_next (sc->jobs);
         }
         zlistx_destroy (&sc->jobs);
+        flux_msg_handler_delvec (sc->handlers);
         free (sc);
         errno = saved_errno;
     }
@@ -408,6 +459,13 @@ struct sched_ctx *sched_create (flux_t *h, int argc, char **argv)
     }
     zlistx_set_comparator (sc->jobs, job_cmp);
     zlistx_set_destructor (sc->jobs, job_destructor);
+
+    /* N.B. schedutil_create() registers the "sched" service  name */
+    if (flux_msg_handler_addvec (h, htab, sc, &sc->handlers) < 0) {
+        flux_log_error (h, "flux_msg_handler_addvec");
+        goto error;
+    }
+
     return sc;
 error:
     sched_destroy (sc);

--- a/t/t2210-job-manager-bugs.t
+++ b/t/t2210-job-manager-bugs.t
@@ -37,30 +37,6 @@ test_expect_success 'issue2664: cancel job 1 and drain (cleanup)' '
 '
 
 #
-# Issue 3051 job-manager: segfault on urgency change with pending alloc
-#
-
-test_expect_success 'issue3051: submit full system job' '
-	ncores=$(flux resource list -s up -no {ncores}) &&
-	flux mini submit -n ${ncores} sleep 3600 >issue3051.job1
-'
-test_expect_success 'issue3051: submit one more job and wait for alloc' '
-	flux mini submit --flags=debug /bin/true >issue3051.job2 &&
-	flux job wait-event -t 5 $(cat issue3051.job2) debug.alloc-request
-'
-test_expect_success 'issue3051: cannot change urgency of job with pending alloc' '
-	test_must_fail flux job urgency $(cat issue3051.job2) 1 2>issue3051.err
-'
-test_expect_success 'issue3051: human message is reasonable' '
-	grep alloc issue3051.err
-'
-test_expect_success 'issue3051: clean up' '
-	flux job cancel $(cat issue3051.job2) &&
-	flux job cancel $(cat issue3051.job1) &&
-	flux queue drain
-'
-
-#
 # Issue 3218 job-manager: segfault when changing urgency of running job
 #
 

--- a/t/t2215-job-manager-priority-order-unlimited.t
+++ b/t/t2215-job-manager-priority-order-unlimited.t
@@ -1,0 +1,114 @@
+#!/bin/sh
+
+test_description='Test flux job manager dummy scheduler priority ordering (unlimited)'
+
+. `dirname $0`/job-manager/sched-helper.sh
+
+. $(dirname $0)/sharness.sh
+
+test_under_flux 4 kvs
+
+SCHED_DUMMY=${FLUX_BUILD_DIR}/t/job-manager/.libs/sched-dummy.so
+
+flux setattr log-stderr-level 1
+
+test_expect_success 'flux-job: generate jobspec for simple test job' '
+        flux jobspec srun -n1 hostname >basic.json
+'
+
+test_expect_success 'job-manager: load job-ingest, job-manager' '
+        flux module load job-manager &&
+        flux module load job-ingest &&
+        flux exec -r all -x 0 flux module load job-ingest &&
+        flux exec -r all flux module load job-info
+'
+
+test_expect_success 'job-manager: submit 5 jobs (differing urgencies)' '
+        flux job submit --flags=debug --urgency=12 basic.json >job1.id &&
+        flux job submit --flags=debug --urgency=10 basic.json >job2.id &&
+        flux job submit --flags=debug --urgency=14 basic.json >job3.id &&
+        flux job submit --flags=debug --urgency=16 basic.json >job4.id &&
+        flux job submit --flags=debug --urgency=18 basic.json >job5.id
+'
+
+test_expect_success HAVE_JQ 'job-manager: job state SSSSS (no scheduler)' '
+        jmgr_check_state $(cat job1.id) S &&
+        jmgr_check_state $(cat job2.id) S &&
+        jmgr_check_state $(cat job3.id) S &&
+        jmgr_check_state $(cat job4.id) S &&
+        jmgr_check_state $(cat job5.id) S
+'
+
+test_expect_success HAVE_JQ 'job-manager: no annotations (SSSSS)' '
+        jmgr_check_no_annotations $(cat job1.id) &&
+        jmgr_check_no_annotations $(cat job2.id) &&
+        jmgr_check_no_annotations $(cat job3.id) &&
+        jmgr_check_no_annotations $(cat job4.id) &&
+        jmgr_check_no_annotations $(cat job5.id)
+'
+
+test_expect_success 'job-manager: load sched-dummy --cores=2' '
+        flux module load ${SCHED_DUMMY} --cores=2 --mode=unlimited
+'
+
+test_expect_success HAVE_JQ 'job-manager: job state SSSRR' '
+        jmgr_check_state $(cat job1.id) S &&
+        jmgr_check_state $(cat job2.id) S &&
+        jmgr_check_state $(cat job3.id) S &&
+        jmgr_check_state $(cat job4.id) R &&
+        jmgr_check_state $(cat job5.id) R
+'
+
+test_expect_success HAVE_JQ 'job-manager: annotate jobs (RRSSS)' '
+        jmgr_check_annotation $(cat job1.id) "sched.reason_pending" "\"no cores\"" &&
+        jmgr_check_annotation $(cat job1.id) "sched.jobs_ahead" "1" &&
+        jmgr_check_annotation $(cat job2.id) "sched.reason_pending" "\"no cores\"" &&
+        jmgr_check_annotation $(cat job2.id) "sched.jobs_ahead" "2" &&
+        jmgr_check_annotation $(cat job3.id) "sched.reason_pending" "\"no cores\"" &&
+        jmgr_check_annotation $(cat job3.id) "sched.jobs_ahead" "0" &&
+        jmgr_check_annotation $(cat job4.id) "sched.resource_summary" "\"1core\"" &&
+        jmgr_check_annotation $(cat job5.id) "sched.resource_summary" "\"1core\""
+'
+
+test_expect_success 'job-manager: cancel 5' '
+        flux job cancel $(cat job5.id)
+'
+
+test_expect_success HAVE_JQ 'job-manager: job state SSRRI' '
+        jmgr_check_state $(cat job1.id) S &&
+        jmgr_check_state $(cat job2.id) S &&
+        jmgr_check_state $(cat job3.id) R &&
+        jmgr_check_state $(cat job4.id) R &&
+        jmgr_check_state $(cat job5.id) I
+'
+
+test_expect_success HAVE_JQ 'job-manager: annotate jobs (SSRRI)' '
+        jmgr_check_annotation $(cat job1.id) "sched.reason_pending" "\"no cores\"" &&
+        jmgr_check_annotation $(cat job1.id) "sched.jobs_ahead" "0" &&
+        jmgr_check_annotation $(cat job2.id) "sched.reason_pending" "\"no cores\"" &&
+        jmgr_check_annotation $(cat job2.id) "sched.jobs_ahead" "1" &&
+        jmgr_check_annotation $(cat job3.id) "sched.resource_summary" "\"1core\"" &&
+        test_must_fail jmgr_check_annotation_exists $(cat job4.id) "sched.reason_pending" &&
+        test_must_fail jmgr_check_annotation_exists $(cat job4.id) "sched.jobs_ahead" &&
+        jmgr_check_annotation $(cat job4.id) "sched.resource_summary" "\"1core\"" &&
+        jmgr_check_no_annotations $(cat job5.id)
+'
+
+# cancel non-running jobs first, to ensure they are not accidentally run when
+# running jobs free resources.
+test_expect_success 'job-manager: cancel all jobs' '
+        flux job cancelall --states=SCHED -f &&
+        flux job cancelall -f
+'
+
+test_expect_success 'job-manager: remove sched-dummy' '
+        flux module remove sched-dummy
+'
+
+test_expect_success 'job-manager: remove job-info, job-manager, job-ingest' '
+        flux exec -r all flux module remove job-info &&
+        flux module remove job-manager &&
+        flux exec -r all flux module remove job-ingest
+'
+
+test_done

--- a/t/t2300-sched-simple.t
+++ b/t/t2300-sched-simple.t
@@ -192,20 +192,20 @@ test_expect_success 'sched-simple: reload in unlimited mode' '
     $dmesg_grep -t 10 "scheduler: ready unlimited"
 '
 test_expect_success 'sched-simple: submit 3 more jobs' '
-	flux job submit basic.json >job11.id &&
-	flux job submit basic.json >job12.id &&
-	flux job submit basic.json >job13.id &&
-	flux job wait-event --timeout=5.0 $(cat job13.id) alloc
+	flux job submit basic.json >job14.id &&
+	flux job submit basic.json >job15.id &&
+	flux job submit basic.json >job16.id &&
+	flux job wait-event --timeout=5.0 $(cat job16.id) alloc
 '
 test_expect_success 'sched-simple: check allocations for running jobs' '
-	list_R $(cat job11.id job12.id job13.id ) \
-		 > single-allocs.out &&
-	cat <<-EOF >first-fit-allocs.expected &&
+	list_R $(cat job14.id job15.id job16.id ) \
+		 > unlimited-allocs.out &&
+	cat <<-EOF >unlimited-allocs.expected &&
 	annotations={"sched":{"resource_summary":"rank0/core0"}}
 	annotations={"sched":{"resource_summary":"rank0/core1"}}
 	annotations={"sched":{"resource_summary":"rank1/core0"}}
 	EOF
-	test_cmp first-fit-allocs.expected first-fit-allocs.out
+	test_cmp unlimited-allocs.expected unlimited-allocs.out
 '
 test_expect_success 'sched-simple: remove sched-simple and cancel jobs' '
 	flux module remove sched-simple &&

--- a/t/t2300-sched-simple.t
+++ b/t/t2300-sched-simple.t
@@ -132,7 +132,7 @@ test_expect_success 'sched-simple: check allocations for running jobs' '
 	EOF
 	test_cmp best-fit-allocs.expected best-fit-allocs.out
 '
-test_expect_success 'sched-simple: cancel pending job' '
+test_expect_success 'sched-simple: cancel pending & running job' '
 	id=$(cat job10.id) &&
 	flux job cancel $id &&
 	flux job wait-event --timeout=5.0 $id exception &&

--- a/t/t2300-sched-simple.t
+++ b/t/t2300-sched-simple.t
@@ -191,11 +191,14 @@ test_expect_success 'sched-simple: reload in unlimited mode' '
 	flux module load sched-simple unlimited &&
 	$dmesg_grep -t 10 "scheduler: ready unlimited"
 '
-test_expect_success 'sched-simple: submit 3 more jobs' '
+test_expect_success 'sched-simple: submit 5 more jobs' '
 	flux job submit basic.json >job14.id &&
 	flux job submit basic.json >job15.id &&
 	flux job submit basic.json >job16.id &&
-	flux job wait-event --timeout=5.0 $(cat job16.id) alloc
+	flux job submit basic.json >job17.id &&
+	flux job submit basic.json >job18.id &&
+	flux job wait-event --timeout=5.0 $(cat job16.id) alloc &&
+	flux job wait-event --timeout=5.0 $(cat job18.id) submit
 '
 test_expect_success 'sched-simple: check allocations for running jobs' '
 	list_R $(cat job14.id job15.id job16.id ) \
@@ -206,6 +209,23 @@ test_expect_success 'sched-simple: check allocations for running jobs' '
 	annotations={"sched":{"resource_summary":"rank1/core0"}}
 	EOF
 	test_cmp unlimited-allocs.expected unlimited-allocs.out
+'
+test_expect_success 'sched-simple: update urgency of job' '
+	flux job urgency $(cat job18.id) 20
+'
+test_expect_success 'sched-simple: cancel running job' '
+	flux job cancel $(cat job14.id) &&
+	flux job wait-event --timeout=5.0 $(cat job14.id) free
+'
+test_expect_success 'sched-simple: ensure more urgent job run' '
+	list_R $(cat job18.id job15.id job16.id) \
+		 > unlimited-allocs2.out &&
+	cat <<-EOF >unlimited-allocs2.expected &&
+	annotations={"sched":{"resource_summary":"rank0/core0"}}
+	annotations={"sched":{"resource_summary":"rank0/core1"}}
+	annotations={"sched":{"resource_summary":"rank1/core0"}}
+	EOF
+	test_cmp unlimited-allocs2.expected unlimited-allocs2.out
 '
 test_expect_success 'sched-simple: remove sched-simple and cancel jobs' '
 	flux module remove sched-simple &&

--- a/t/t2300-sched-simple.t
+++ b/t/t2300-sched-simple.t
@@ -189,7 +189,7 @@ test_expect_success 'sched-simple: there are no outstanding sched requests' '
 '
 test_expect_success 'sched-simple: reload in unlimited mode' '
 	flux module load sched-simple unlimited &&
-    $dmesg_grep -t 10 "scheduler: ready unlimited"
+	$dmesg_grep -t 10 "scheduler: ready unlimited"
 '
 test_expect_success 'sched-simple: submit 3 more jobs' '
 	flux job submit basic.json >job14.id &&


### PR DESCRIPTION
Built on top of #3428.

Per #3334 and RFC27 updates, support updates of job priorities for jobs that have been sent to the scheduler (are "pending" in the job-manager) via the `sched.prioritize` RPC.

Per discussion in #3441, in order to not break ABI for the time being, `sched.prioritize` is supported in the `sched-simple` and
`sched-dummy` (testsuite) schedulers by "manually" setting up the callback and parsing messages rather than through the `libschedutil` interface.  Once `libschedutil` is refactored per #3441, we can update to use those interfaces instead.

