### PR TITLE
Globally standardize spelling of "canceled"

### DIFF
--- a/doc/man1/flux-jobs.rst
+++ b/doc/man1/flux-jobs.rst
@@ -84,12 +84,12 @@ alias for RUN,CLEANUP; "active", an alias for "pending,running".
 
 After a job has finished and is in the INACTIVE state, it can be
 marked with one of three possible results: COMPLETED, FAILED,
-CANCELLED. Under the *result_abbrev* field name, these are
+CANCELED. Under the *result_abbrev* field name, these are
 abbreviated as CD, F, and CA respectively.
 
 The job status is a user friendly mix of both, a job is always in one
 of the following five statuses: PENDING, RUNNING, COMPLETED, FAILED,
-or CANCELLED. Under the *status_abbrev* field name, these are
+or CANCELED. Under the *status_abbrev* field name, these are
 abbreviated as P, R, CD, F, and CA respectively.
 
 
@@ -174,7 +174,7 @@ The field names that can be specified are:
    job priority
 
 **status**
-   job status (PENDING, RUNNING, COMPLETED, FAILED, or CANCELLED)
+   job status (PENDING, RUNNING, COMPLETED, FAILED, or CANCELED)
 
 **status_abbrev**
    status but in a max 2 character abbreviation
@@ -201,7 +201,7 @@ The field names that can be specified are:
    job state as a single character
 
 **result**
-   job result if job is inactive (COMPLETED, FAILED, CANCELLED), empty string otherwise
+   job result if job is inactive (COMPLETED, FAILED, CANCELED), empty string otherwise
 
 **result_abbrev**
    result but in a max 2 character abbreviation
@@ -221,7 +221,7 @@ The field names that can be specified are:
    The job return code if the job has exited, or an empty string if the
    job is still active. The return code of a job is the highest job shell
    exit code, or negative signal number if the job shell was terminated by
-   a signal. If the job was cancelled before it started, then the returncode
+   a signal. If the job was canceled before it started, then the returncode
    is set to the special value -128.
 
 **exception.occurred**
@@ -298,12 +298,12 @@ To alter which user's jobs are listed, specify the user with *--user*:
     $ flux jobs --user=flux
 
 Jobs that have finished may be filtered further by specifying if they
-have completed, failed, or were cancelled.  For example, the following
-will list the jobs that have failed or were cancelled:
+have completed, failed, or were canceled.  For example, the following
+will list the jobs that have failed or were canceled:
 
 ::
 
-    $ flux jobs --filter=failed,cancelled
+    $ flux jobs --filter=failed,canceled
 
 The *--format* option can be used to alter the output format or output
 additional information.  For example, the following would output all

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -491,8 +491,6 @@ fsd
 hms
 username
 submitter's
-CANCELLED
-cancelled
 enqueue
 nslots
 alloc

--- a/src/bindings/python/flux/job/info.py
+++ b/src/bindings/python/flux/job/info.py
@@ -218,13 +218,13 @@ class JobInfo:
         The job return code if the job has exited, or an empty string
         if the job is still active. The return code of a job is the
         highest job shell exit code, or the negative signal number if the
-        job shell was terminated by a signal. For jobs that were cancelled
+        job shell was terminated by a signal. For jobs that were canceled
         before the RUN state, the return code will be set to -128.
         """
         status = self.waitstatus
         code = ""
         if not isinstance(status, int):
-            if self.result_id == flux.constants.FLUX_JOB_RESULT_CANCELLED:
+            if self.result_id == flux.constants.FLUX_JOB_RESULT_CANCELED:
                 code = -128
         elif os.WIFSIGNALED(status):
             code = -os.WTERMSIG(status)

--- a/src/bindings/python/flux/job/list.py
+++ b/src/bindings/python/flux/job/list.py
@@ -169,7 +169,7 @@ class JobList:
     RESULTS = {
         "completed": flux.constants.FLUX_JOB_RESULT_COMPLETED,
         "failed": flux.constants.FLUX_JOB_RESULT_FAILED,
-        "cancelled": flux.constants.FLUX_JOB_RESULT_CANCELLED,
+        "canceled": flux.constants.FLUX_JOB_RESULT_CANCELED,
         "timeout": flux.constants.FLUX_JOB_RESULT_TIMEOUT,
     }
 

--- a/src/bindings/python/flux/job/stats.py
+++ b/src/bindings/python/flux/job/stats.py
@@ -25,7 +25,7 @@ class JobStats:
         active: Total number of active jobs (all states but INACTIVE)
         failed: Total number of jobs that did not exit with zero status
         successful: Total number of jobs completed with zero exit code
-        cancelled: Total number of jobs that were cancelled
+        canceled: Total number of jobs that were canceled
         timeout: Total number of jobs that timed out
         pending: Sum of "depend", "priority", and "sched"
         running: Sum of "run" and "cleanup"
@@ -44,7 +44,7 @@ class JobStats:
             "cleanup",
             "inactive",
             "failed",
-            "cancelled",
+            "canceled",
             "timeout",
             "pending",
             "running",
@@ -57,7 +57,7 @@ class JobStats:
         resp = rpc.get()
         for state, count in resp["job_states"].items():
             setattr(self, state, count)
-        for state in ["failed", "timeout", "cancelled"]:
+        for state in ["failed", "timeout", "canceled"]:
             setattr(self, state, resp[state])
 
         #  Compute some stats for convenience:

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -1000,7 +1000,7 @@ int cmd_cancelall (optparse_t *p, int argc, char **argv)
     if (optparse_hasopt (p, "states")) {
         state_mask = parse_arg_states (p, "states");
         if ((state_mask & FLUX_JOB_STATE_INACTIVE))
-            log_msg_exit ("Inactive jobs cannot be cancelled");
+            log_msg_exit ("Inactive jobs cannot be canceled");
     }
     else
         state_mask = FLUX_JOB_STATE_ACTIVE;

--- a/src/cmd/flux-jobs.py
+++ b/src/cmd/flux-jobs.py
@@ -269,7 +269,7 @@ def color_setup(args, job):
                 sys.stdout.write("\033[01;32m")
             elif job.result == "FAILED":
                 sys.stdout.write("\033[01;31m")
-            elif job.result == "CANCELLED":
+            elif job.result == "CANCELED":
                 sys.stdout.write("\033[37m")
             elif job.result == "TIMEOUT":
                 sys.stdout.write("\033[01;31m")

--- a/src/cmd/flux-kvs.c
+++ b/src/cmd/flux-kvs.c
@@ -1871,7 +1871,7 @@ void eventlog_get_continuation (flux_future_t *f, void *arg)
     json_t *value;
     bool limit_reached = false;
 
-    /* Handle cancelled lookup (FLUX_KVS_WATCH flag only).
+    /* Handle canceled lookup (FLUX_KVS_WATCH flag only).
      * Destroy the future and return (reactor will then terminate).
      * Errors other than ENODATA are handled by the flux_kvs_lookup_get().
      */

--- a/src/common/libjob/job.c
+++ b/src/common/libjob/job.c
@@ -564,8 +564,8 @@ const char *flux_job_resulttostr (flux_job_result_t result, bool abbrev)
             return abbrev ? "CD" : "COMPLETED";
         case FLUX_JOB_RESULT_FAILED:
             return abbrev ? "F" : "FAILED";
-        case FLUX_JOB_RESULT_CANCELLED:
-            return abbrev ? "CA" : "CANCELLED";
+        case FLUX_JOB_RESULT_CANCELED:
+            return abbrev ? "CA" : "CANCELED";
         case FLUX_JOB_RESULT_TIMEOUT:
             return abbrev ? "TO" : "TIMEOUT";
     }
@@ -580,8 +580,8 @@ int flux_job_strtoresult (const char *s, flux_job_result_t *result)
         *result = FLUX_JOB_RESULT_COMPLETED;
     else if (!strcasecmp (s, "F") || !strcasecmp (s, "FAILED"))
         *result = FLUX_JOB_RESULT_FAILED;
-    else if (!strcasecmp (s, "CA") || !strcasecmp (s, "CANCELLED"))
-        *result = FLUX_JOB_RESULT_CANCELLED;
+    else if (!strcasecmp (s, "CA") || !strcasecmp (s, "CANCELED"))
+        *result = FLUX_JOB_RESULT_CANCELED;
     else if (!strcasecmp (s, "TO") || !strcasecmp (s, "TIMEOUT"))
         *result = FLUX_JOB_RESULT_TIMEOUT;
     else

--- a/src/common/libjob/job.h
+++ b/src/common/libjob/job.h
@@ -68,7 +68,7 @@ enum {
 typedef enum {
     FLUX_JOB_RESULT_COMPLETED = 1,
     FLUX_JOB_RESULT_FAILED = 2,
-    FLUX_JOB_RESULT_CANCELLED = 4,
+    FLUX_JOB_RESULT_CANCELED = 4,
     FLUX_JOB_RESULT_TIMEOUT = 8,
 } flux_job_result_t;
 

--- a/src/common/libjob/test/job.c
+++ b/src/common/libjob/test/job.c
@@ -275,7 +275,7 @@ struct rr {
 struct rr rrtab[] = {
     { FLUX_JOB_RESULT_COMPLETED, "CD", "COMPLETED" },
     { FLUX_JOB_RESULT_FAILED,    "F",  "FAILED" },
-    { FLUX_JOB_RESULT_CANCELLED, "CA", "CANCELLED" },
+    { FLUX_JOB_RESULT_CANCELED,  "CA", "CANCELED" },
     { FLUX_JOB_RESULT_TIMEOUT,   "TO", "TIMEOUT" },
     { -1, NULL, NULL },
 };

--- a/src/modules/job-info/job_state.c
+++ b/src/modules/job-info/job_state.c
@@ -735,7 +735,7 @@ static void eventlog_inactive_complete (struct info_ctx *ctx,
         job->result = FLUX_JOB_RESULT_COMPLETED;
     else if (job->exception_occurred) {
         if (!strcmp (job->exception_type, "cancel"))
-            job->result = FLUX_JOB_RESULT_CANCELLED;
+            job->result = FLUX_JOB_RESULT_CANCELED;
         else if (!strcmp (job->exception_type, "timeout"))
             job->result = FLUX_JOB_RESULT_TIMEOUT;
     }

--- a/src/modules/job-info/list.c
+++ b/src/modules/job-info/list.c
@@ -199,7 +199,7 @@ void list_cb (flux_t *h, flux_msg_handler_t *mh,
     if (!results)
         results = (FLUX_JOB_RESULT_COMPLETED
                    | FLUX_JOB_RESULT_FAILED
-                   | FLUX_JOB_RESULT_CANCELLED
+                   | FLUX_JOB_RESULT_CANCELED
                    | FLUX_JOB_RESULT_TIMEOUT);
 
     if (!(jobs = get_jobs (ctx, &err, max_entries,

--- a/src/modules/job-info/stats.c
+++ b/src/modules/job-info/stats.c
@@ -61,7 +61,7 @@ void job_stats_update (struct job_stats *stats,
         stats->failed++;
         if (job->exception_occurred) {
             if (strcmp (job->exception_type, "cancel") == 0)
-                stats->cancelled++;
+                stats->canceled++;
             else if (strcmp (job->exception_type, "timeout") == 0)
                 stats->timeout++;
         }
@@ -110,6 +110,6 @@ json_t * job_stats_encode (struct job_stats *stats)
     return json_pack ("{ s:o s:i s:i s:i }",
                       "job_states", states,
                       "failed", stats->failed,
-                      "cancelled", stats->cancelled,
+                      "canceled", stats->canceled,
                       "timeout", stats->timeout);
 }

--- a/src/modules/job-info/stats.h
+++ b/src/modules/job-info/stats.h
@@ -18,7 +18,7 @@ struct job_stats {
     unsigned int total;
     unsigned int failed;
     unsigned int timeout;
-    unsigned int cancelled;
+    unsigned int canceled;
 };
 
 /* Forward declaration of struct job to avoid circular header file

--- a/src/modules/kvs-watch/kvs-watch.c
+++ b/src/modules/kvs-watch/kvs-watch.c
@@ -26,7 +26,7 @@ struct watcher {
     const flux_msg_t *request;  // request message
     struct flux_msg_cred cred;  // request cred
     int rootseq;                // last root sequence number sent
-    bool cancelled;             // true if watcher has been cancelled
+    bool canceled;              // true if watcher has been canceled
     bool mute;                  // true if response should be suppressed
     bool responded;             // true if watcher has responded atleast once
     bool initial_rpc_sent;      // flag is initial watch rpc sent
@@ -615,7 +615,7 @@ static void watcher_respond (struct ns_monitor *nsm, struct watcher *w)
      */
     if (w->finished)
         goto finished;
-    if (w->cancelled) {
+    if (w->canceled) {
         errno = ENODATA;
         goto error_respond;
     }
@@ -719,7 +719,7 @@ static void watcher_cancel (struct ns_monitor *nsm, struct watcher *w,
     if (flux_msg_get_route_first (w->request, &s) < 0)
         return;
     if (!strcmp (sender, s)) {
-        w->cancelled = true;
+        w->canceled = true;
         w->mute = mute;
         watcher_respond (nsm, w);
     }
@@ -883,7 +883,7 @@ static void namespace_getroot_continuation (flux_future_t *f, void *arg)
     uint32_t owner;
     struct commit *commit;
 
-    /* small racy chance watcher cancelled before getroot completes */
+    /* small racy chance watcher canceled before getroot completes */
     if (zlist_size (nsm->watchers) == 0) {
         zhash_delete (nsm->ctx->namespaces, nsm->ns_name);
         return;
@@ -998,7 +998,7 @@ error:
 /* kvs-watch.cancel request
  * The user called flux_kvs_lookup_cancel() which expects no response.
  * The enclosed matchtag and the cancel sender are used to find the
- * watcher that is to be cancelled.  The watcher will receive an ENODATA
+ * watcher that is to be canceled.  The watcher will receive an ENODATA
  * response message.
  */
 static void cancel_cb (flux_t *h, flux_msg_handler_t *mh,
@@ -1022,7 +1022,7 @@ static void cancel_cb (flux_t *h, flux_msg_handler_t *mh,
 
 /* kvs-watch.disconnect request
  * This is sent automatically upon local connector disconnect.
- * The disconnect sender is used to find any watchers to be cancelled.
+ * The disconnect sender is used to find any watchers to be canceled.
  */
 static void disconnect_cb (flux_t *h, flux_msg_handler_t *mh,
                            const flux_msg_t *msg, void *arg)

--- a/t/t2205-job-manager-annotate.t
+++ b/t/t2205-job-manager-annotate.t
@@ -300,7 +300,7 @@ test_expect_success HAVE_JQ 'job-manager: no annotations in job-info (IIIII)' '
 '
 
 # compared to above, note that job ids that ran retain annotations
-# note that user annotation on job4 is removed, as job was cancelled
+# note that user annotation on job4 is removed, as job was canceled
 test_expect_success HAVE_JQ 'job-manager: no annotations in job-info (IIIII)' '
         fjobs_check_annotation $(cat job1.id) "annotations.user.mykey" "bozo" &&
         fjobs_check_annotation $(cat job1.id) "annotations.sched.resource_summary" "1core" &&

--- a/t/t2230-job-info-list.t
+++ b/t/t2230-job-info-list.t
@@ -63,7 +63,7 @@ wait_jobid_state() {
 
 # Return the expected jobids list in a given state:
 #   "all", "pending", "running", "inactive", "active",
-#   "completed", "cancelled", "failed"
+#   "completed", "canceled", "failed"
 #
 state_ids() {
     for f in "$@"; do
@@ -158,12 +158,12 @@ test_expect_success 'submit jobs for job list testing' '
         #
         #  Submit a job and cancel it
         #
-        jobid=`flux mini submit cancelledjob` &&
+        jobid=`flux mini submit canceledjob` &&
         flux job wait-event $jobid depend &&
         flux job cancel $jobid &&
         flux job wait-event $jobid clean &&
         flux job id $jobid >> inactiveids &&
-        flux job id $jobid > cancelled.ids &&
+        flux job id $jobid > canceled.ids &&
         tac inactiveids | flux job id > inactive.ids &&
         cat active.ids > all.ids &&
         cat inactive.ids >> all.ids &&
@@ -218,7 +218,7 @@ test_expect_success HAVE_JQ 'flux job list inactive jobs with correct state' '
 
 test_expect_success HAVE_JQ 'flux job list inactive jobs results are correct' '
         flux job list -s inactive | jq .result | ${JOB_CONV} resulttostr > list_result_I.out &&
-        echo "CANCELLED" >> list_result_I.exp &&
+        echo "CANCELED" >> list_result_I.exp &&
         echo "FAILED" >> list_result_I.exp &&
         for count in `seq 1 4`; do \
             echo "COMPLETED" >> list_result_I.exp; \
@@ -229,13 +229,13 @@ test_expect_success HAVE_JQ 'flux job list inactive jobs results are correct' '
 # Hard code results values for these tests, as we did not add a results
 # option to flux_job_list() or the flux-job command.
 
-test_expect_success HAVE_JQ 'flux job list only cancelled jobs' '
+test_expect_success HAVE_JQ 'flux job list only canceled jobs' '
         id=$(id -u) &&
         state=`${JOB_CONV} strtostate INACTIVE` &&
-        result=`${JOB_CONV} strtoresult CANCELLED` &&
+        result=`${JOB_CONV} strtoresult CANCELED` &&
         $jq -j -c -n  "{max_entries:1000, userid:${id}, states:${state}, results:${result}, attrs:[]}" \
-          | $RPC job-info.list | $jq .jobs | $jq -c '.[]' | $jq .id > list_result_cancelled.out &&
-        test_cmp cancelled.ids list_result_cancelled.out
+          | $RPC job-info.list | $jq .jobs | $jq -c '.[]' | $jq .id > list_result_canceled.out &&
+        test_cmp canceled.ids list_result_canceled.out
 '
 
 test_expect_success HAVE_JQ 'flux job list only failed jobs' '

--- a/t/t2234-job-info-list-update.t
+++ b/t/t2234-job-info-list-update.t
@@ -59,7 +59,7 @@ wait_jobid_state() {
 
 # Return the expected jobids list in a given state:
 #   "all", "pending", "running", "inactive", "active",
-#   "completed", "cancelled", "failed"
+#   "completed", "canceled", "failed"
 #
 state_ids() {
     for f in "$@"; do


### PR DESCRIPTION
Problem: The spelling of "canceled" is inconsistently
used in flux.  Sometimes the British spelling "cancelled" is
used and othertimes the American spelling "canceled" is used.

Solution: Change all spellings of "cancelled" to "canceled".

Fixes #3439