### PR TITLE
shell: fix dropped stdout from shell plugins in task.exec callback

### DIFF
--- a/src/shell/shell.c
+++ b/src/shell/shell.c
@@ -1032,6 +1032,12 @@ static void shell_task_exec (flux_shell_task_t *task, void *arg)
 {
     flux_shell_t *shell = arg;
     shell->current_task->in_pre_exec = true;
+
+    /*  Set stdout to unbuffered so that any output from task.exec plugins
+     *   is not lost at exec(2).
+     */
+    (void) setvbuf (stdout, NULL, _IONBF, 0);
+
     if (plugstack_call (shell->plugstack, "task.exec", NULL) < 0)
         shell_log_errno ("task.exec plugin(s) failed");
 #if CODE_COVERAGE_ENABLED

--- a/t/t2608-job-shell-log.t
+++ b/t/t2608-job-shell-log.t
@@ -244,7 +244,7 @@ test_expect_success 'flux-shell: fatal error in task.fork works' '
 
 '
 test_expect_success 'flux-shell: fatal error in task.exec works' '
-	site=task.fork &&
+	site=task.exec &&
 	test_when_finished "test_debug \"dump_job_output_eventlog $site\"" &&
 	test_must_fail_or_be_terminated \
 		flux mini run -v -n2 -N2 \

--- a/t/t2608-job-shell-log.t
+++ b/t/t2608-job-shell-log.t
@@ -259,4 +259,24 @@ test_expect_success 'flux-shell: fatal error in task.exec works' '
 		fatal-${site}.out &&
 	dump_job_output_eventlog $site | grep log-fatal-error
 '
+test_expect_success 'flux-shell: stdout/err from task.exec works' '
+	cat <<-EOF >task.exec.print.lua &&
+	plugin.register {
+	  name = "stdout-test",
+	    handlers = {
+	    {
+	      topic = "task.exec",
+	      fn = function ()
+	        io.stderr:write("this is stderr\n")
+	        io.stdout:write("this is stdout\n")
+	      end
+	    }
+	  }
+	}
+	EOF
+	flux mini run -o initrc=task.exec.print.lua hostname \
+	  >print.out 2>print.err &&
+	grep "^this is stderr" print.err &&
+	grep "^this is stdout" print.out
+'
 test_done


### PR DESCRIPTION
As described in #3444, if a shell plugin tries to write data to stdout, some or all of that output may be dropped since stdout is buffered, and the buffer is lost at `exec(2)`.

This PR simply sets `stdout` to unbuffered during `task.exec` to avoid the problem and the confusion it might cause.