### PR TITLE
libschedutil: refactor API to use struct w/ callback pointers, fix priority type, add prioritize callback, add flags

### DIFF
--- a/src/common/libschedutil/alloc.c
+++ b/src/common/libschedutil/alloc.c
@@ -20,7 +20,7 @@
 
 int schedutil_alloc_request_decode (const flux_msg_t *msg,
                                     flux_jobid_t *id,
-                                    int *priority,
+                                    unsigned int *priority,
                                     uint32_t *userid,
                                     double *t_submit)
 {

--- a/src/common/libschedutil/alloc.c
+++ b/src/common/libschedutil/alloc.c
@@ -18,24 +18,6 @@
 #include "init.h"
 #include "alloc.h"
 
-int schedutil_alloc_request_decode (const flux_msg_t *msg,
-                                    flux_jobid_t *id,
-                                    unsigned int *priority,
-                                    uint32_t *userid,
-                                    double *t_submit)
-{
-    json_int_t tmp;
-    int rc;
-    rc = flux_request_unpack (msg, NULL, "{s:I s:I s:i s:f}",
-                                         "id", id,
-                                         "priority", &tmp,
-                                         "userid", userid,
-                                         "t_submit", t_submit);
-    if (!rc && priority)
-        (*priority) = tmp;
-    return rc;
-}
-
 static int schedutil_alloc_respond (flux_t *h, const flux_msg_t *msg,
                                     int type, const char *note,
                                     json_t *annotations)

--- a/src/common/libschedutil/alloc.h
+++ b/src/common/libschedutil/alloc.h
@@ -27,15 +27,6 @@ enum {
     FLUX_SCHED_ALLOC_CANCEL   = 3,
 };
 
-/* Decode an alloc request message.
- * Return 0 on success, -1 on error with errno set.
- */
-int schedutil_alloc_request_decode (const flux_msg_t *msg,
-                                    flux_jobid_t *id,
-                                    unsigned int *priority,
-                                    uint32_t *userid,
-                                    double *t_submit);
-
 /* Respond to alloc request message - update annotation.
  * A job's annotation may be updated any number of times before alloc request
  * is finally terminated with alloc_respond_deny() or alloc_respond_success().

--- a/src/common/libschedutil/alloc.h
+++ b/src/common/libschedutil/alloc.h
@@ -32,7 +32,7 @@ enum {
  */
 int schedutil_alloc_request_decode (const flux_msg_t *msg,
                                     flux_jobid_t *id,
-                                    int *priority,
+                                    unsigned int *priority,
                                     uint32_t *userid,
                                     double *t_submit);
 

--- a/src/common/libschedutil/free.c
+++ b/src/common/libschedutil/free.c
@@ -17,12 +17,6 @@
 #include "init.h"
 #include "free.h"
 
-
-int schedutil_free_request_decode (const flux_msg_t *msg, flux_jobid_t *id)
-{
-    return flux_request_unpack (msg, NULL, "{s:I}", "id", id);
-}
-
 int schedutil_free_respond (schedutil_t *util, const flux_msg_t *msg)
 {
     flux_jobid_t id;

--- a/src/common/libschedutil/free.h
+++ b/src/common/libschedutil/free.h
@@ -19,11 +19,6 @@
 extern "C" {
 #endif
 
-/* Decode a free request.
- * Returns 0 on success, -1 on failure with errno set.
- */
-int schedutil_free_request_decode (const flux_msg_t *msg, flux_jobid_t *id);
-
 /* Respond to a free request.
  */
 int schedutil_free_respond (schedutil_t *util, const flux_msg_t *msg);

--- a/src/common/libschedutil/hello.c
+++ b/src/common/libschedutil/hello.c
@@ -18,43 +18,42 @@
 #include "init.h"
 #include "hello.h"
 
-static int schedutil_hello_job (flux_t *h,
+static int schedutil_hello_job (schedutil_t *util,
                                 flux_jobid_t id,
                                 int priority,
                                 uint32_t userid,
-                                double t_submit,
-                                schedutil_hello_cb_f *cb,
-                                void *arg)
+                                double t_submit)
 {
     char key[64];
     flux_future_t *f;
     const char *R;
 
-    if (!h) {
-        errno = EINVAL;
-        return -1;
-    }
-
     if (flux_job_kvs_key (key, sizeof (key), id, "R") < 0) {
         errno = EPROTO;
         return -1;
     }
-    if (!(f = flux_kvs_lookup (h, NULL, 0, key)))
+    if (!(f = flux_kvs_lookup (util->h, NULL, 0, key)))
         return -1;
     if (flux_kvs_lookup_get (f, &R) < 0)
         goto error;
-    if (cb (h, id, priority, userid, t_submit, R, arg) < 0)
+    if (util->ops->hello (util->h,
+                          id,
+                          priority,
+                          userid,
+                          t_submit,
+                          R,
+                          util->cb_arg) < 0)
         goto error;
     flux_future_destroy (f);
     return 0;
 error:
-    flux_log_error (h, "hello: error loading R for id=%ju",
+    flux_log_error (util->h, "hello: error loading R for id=%ju",
                     (uintmax_t)id);
     flux_future_destroy (f);
     return -1;
 }
 
-int schedutil_hello (schedutil_t *util, schedutil_hello_cb_f *cb, void *arg)
+int schedutil_hello (schedutil_t *util)
 {
     flux_future_t *f;
     json_t *jobs;
@@ -62,7 +61,7 @@ int schedutil_hello (schedutil_t *util, schedutil_hello_cb_f *cb, void *arg)
     size_t index;
     int rc = -1;
 
-    if (!util || !cb) {
+    if (!util || !util->ops->hello) {
         errno = EINVAL;
         return -1;
     }
@@ -87,13 +86,11 @@ int schedutil_hello (schedutil_t *util, schedutil_hello_cb_f *cb, void *arg)
             goto error;
         }
         priority = tmp;
-        if (schedutil_hello_job (util->h,
+        if (schedutil_hello_job (util,
                                  id,
                                  priority,
                                  userid,
-                                 t_submit,
-                                 cb,
-                                 arg) < 0)
+                                 t_submit) < 0)
             goto error;
     }
     rc = 0;

--- a/src/common/libschedutil/hello.c
+++ b/src/common/libschedutil/hello.c
@@ -60,6 +60,7 @@ int schedutil_hello (schedutil_t *util, schedutil_hello_cb_f *cb, void *arg)
     json_t *jobs;
     json_t *entry;
     size_t index;
+    int rc = -1;
 
     if (!util || !cb) {
         errno = EINVAL;
@@ -95,11 +96,10 @@ int schedutil_hello (schedutil_t *util, schedutil_hello_cb_f *cb, void *arg)
                                  arg) < 0)
             goto error;
     }
-    flux_future_destroy (f);
-    return 0;
+    rc = 0;
 error:
     flux_future_destroy (f);
-    return -1;
+    return rc;
 }
 
 /*

--- a/src/common/libschedutil/hello.c
+++ b/src/common/libschedutil/hello.c
@@ -20,7 +20,7 @@
 
 static int schedutil_hello_job (schedutil_t *util,
                                 flux_jobid_t id,
-                                int priority,
+                                unsigned int priority,
                                 uint32_t userid,
                                 double t_submit)
 {
@@ -72,7 +72,7 @@ int schedutil_hello (schedutil_t *util)
         goto error;
     json_array_foreach (jobs, index, entry) {
         flux_jobid_t id;
-        int priority;
+        unsigned int priority;
         uint32_t userid;
         double t_submit;
         json_int_t tmp;

--- a/src/common/libschedutil/hello.h
+++ b/src/common/libschedutil/hello.h
@@ -19,25 +19,12 @@
 extern "C" {
 #endif
 
-/* Callback for ingesting R + metadata for jobs that have resources
- * Return 0 on success, -1 on failure with errno set.
- * Failure of the callback aborts iteration and causes schedutil_hello()
- * to return -1 with errno passed through.
- */
-typedef int (schedutil_hello_cb_f)(flux_t *h,
-                                   flux_jobid_t id,
-                                   int priority,
-                                   uint32_t userid,
-                                   double t_submit,
-                                   const char *R,
-                                   void *arg);
-
 /* Send hello announcement to job-manager.
  * The job-manager responds with a list of jobs that have resources assigned.
- * This function looks up R for each job and passes R + metadata to 'cb'
- * with 'arg'.
+ * This function looks up R for each job and passes R + metadata to
+ * ops->hello callback.
  */
-int schedutil_hello (schedutil_t *util, schedutil_hello_cb_f *cb, void *arg);
+int schedutil_hello (schedutil_t *util);
 
 #ifdef __cplusplus
 }

--- a/src/common/libschedutil/init.c
+++ b/src/common/libschedutil/init.c
@@ -28,6 +28,7 @@ static void future_destructor (void **item)
 
 
 schedutil_t *schedutil_create (flux_t *h,
+                               int flags,
                                const struct schedutil_ops *ops,
                                void *arg)
 {
@@ -47,6 +48,7 @@ schedutil_t *schedutil_create (flux_t *h,
 
     util->h = h;
     util->ops = ops;
+    util->flags = flags;
     util->cb_arg = arg;
     if (!(util->outstanding_futures = zlistx_new ()))
         goto error;

--- a/src/common/libschedutil/init.c
+++ b/src/common/libschedutil/init.c
@@ -33,6 +33,7 @@ schedutil_t *schedutil_create (flux_t *h,
 {
     schedutil_t *util;
 
+    /* ops->prioritize is optional */
     if (!h
         || !ops
         || !ops->alloc

--- a/src/common/libschedutil/init.h
+++ b/src/common/libschedutil/init.h
@@ -28,10 +28,8 @@ typedef struct schedutil_ctx schedutil_t;
  * Return NULL on error.
  */
 schedutil_t *schedutil_create (flux_t *h,
-                               schedutil_alloc_cb_f *alloc_cb,
-                               schedutil_free_cb_f *free_cb,
-                               schedutil_cancel_cb_f *cancel_cb,
-                               void *cb_arg);
+                               const struct schedutil_ops *ops,
+                               void *arg);
 
 /* Destroy the handle for the schedutil convenience library.
  *

--- a/src/common/libschedutil/init.h
+++ b/src/common/libschedutil/init.h
@@ -21,6 +21,10 @@ extern "C" {
 
 typedef struct schedutil_ctx schedutil_t;
 
+enum schedutil_flags {
+    SCHEDUTIL_FREE_NOLOOKUP = 1, // ops->free() will be called with R=NULL
+};
+
 /* Create a handle for the schedutil convenience library.
  *
  * Used to track outstanding futures and register callbacks relevant for

--- a/src/common/libschedutil/init.h
+++ b/src/common/libschedutil/init.h
@@ -28,6 +28,7 @@ typedef struct schedutil_ctx schedutil_t;
  * Return NULL on error.
  */
 schedutil_t *schedutil_create (flux_t *h,
+                               int flags,
                                const struct schedutil_ops *ops,
                                void *arg);
 

--- a/src/common/libschedutil/ops.c
+++ b/src/common/libschedutil/ops.c
@@ -34,15 +34,10 @@ static void cancel_cb (flux_t *h, flux_msg_handler_t *mh,
                        const flux_msg_t *msg, void *arg)
 {
     schedutil_t *util = arg;
-    flux_jobid_t id;
 
     assert (util);
 
-    if (flux_request_unpack (msg, NULL, "{s:I}", "id", &id) < 0) {
-        flux_log_error (h, "sched.cancel");
-        return;
-    }
-    util->ops->cancel (h, id, util->cb_arg);
+    util->ops->cancel (h, msg, util->cb_arg);
 }
 
 static void free_continuation (flux_future_t *f, void *arg)

--- a/src/common/libschedutil/ops.c
+++ b/src/common/libschedutil/ops.c
@@ -37,7 +37,7 @@ static void alloc_cb (flux_t *h, flux_msg_handler_t *mh,
         goto error;
     if (!(jobspec = json_dumps (o, JSON_COMPACT)))
         goto nomem;
-    util->alloc_cb (h, msg, jobspec, util->cb_arg);
+    util->ops->alloc (h, msg, jobspec, util->cb_arg);
     free (jobspec);
     return;
 nomem:
@@ -60,7 +60,7 @@ static void cancel_cb (flux_t *h, flux_msg_handler_t *mh,
         flux_log_error (h, "sched.cancel");
         return;
     }
-    util->cancel_cb (h, id, util->cb_arg);
+    util->ops->cancel (h, id, util->cb_arg);
 }
 
 static void free_continuation (flux_future_t *f, void *arg)
@@ -76,7 +76,7 @@ static void free_continuation (flux_future_t *f, void *arg)
     }
     if (schedutil_remove_outstanding_future (util, f) < 0)
         flux_log_error (h, "sched.free unable to remove outstanding future");
-    util->free_cb (h, msg, R, util->cb_arg);
+    util->ops->free (h, msg, R, util->cb_arg);
     flux_future_destroy (f);
     return;
 error:

--- a/src/common/libschedutil/ops.c
+++ b/src/common/libschedutil/ops.c
@@ -24,28 +24,10 @@ static void alloc_cb (flux_t *h, flux_msg_handler_t *mh,
                       const flux_msg_t *msg, void *arg)
 {
     schedutil_t *util = arg;
-    json_t *o;
-    char *jobspec;
 
     assert (util);
 
-    if (flux_request_unpack (msg,
-                             NULL,
-                             "{s:o}",
-                             "jobspec",
-                             &o) < 0)
-        goto error;
-    if (!(jobspec = json_dumps (o, JSON_COMPACT)))
-        goto nomem;
-    util->ops->alloc (h, msg, jobspec, util->cb_arg);
-    free (jobspec);
-    return;
-nomem:
-    errno = ENOMEM;
-error:
-    flux_log_error (h, "sched.alloc");
-    if (flux_respond_error (h, msg, errno, NULL) < 0)
-        flux_log_error (h, "sched.alloc respond_error");
+    util->ops->alloc (h, msg, util->cb_arg);
 }
 
 static void cancel_cb (flux_t *h, flux_msg_handler_t *mh,

--- a/src/common/libschedutil/ops.c
+++ b/src/common/libschedutil/ops.c
@@ -73,6 +73,11 @@ static void free_cb (flux_t *h, flux_msg_handler_t *mh,
 
     assert (util);
 
+    if (util->flags & SCHEDUTIL_FREE_NOLOOKUP) {
+        util->ops->free (h, msg, NULL, util->cb_arg);
+        return;
+    }
+
     if (flux_request_unpack (msg, NULL, "{s:I}", "id", &id) < 0)
         goto error;
     if (flux_job_kvs_key (key, sizeof (key), id, "R") < 0) {

--- a/src/common/libschedutil/ops.c
+++ b/src/common/libschedutil/ops.c
@@ -102,10 +102,22 @@ error:
         flux_log_error (h, "sched.free respond_error");
 }
 
+static void prioritize_cb (flux_t *h, flux_msg_handler_t *mh,
+                           const flux_msg_t *msg, void *arg)
+{
+    schedutil_t *util = arg;
+
+    assert (util);
+
+    if (util->ops->prioritize)
+        util->ops->prioritize (h, msg, util->cb_arg);
+}
+
 static const struct flux_msg_handler_spec htab[] = {
     { FLUX_MSGTYPE_REQUEST,  "sched.alloc", alloc_cb, 0},
     { FLUX_MSGTYPE_REQUEST,  "sched.cancel", cancel_cb, 0},
     { FLUX_MSGTYPE_REQUEST,  "sched.free", free_cb, 0},
+    { FLUX_MSGTYPE_REQUEST,  "sched.prioritize", prioritize_cb, 0},
     FLUX_MSGHANDLER_TABLE_END,
 };
 

--- a/src/common/libschedutil/ops.c
+++ b/src/common/libschedutil/ops.c
@@ -27,10 +27,7 @@ static void alloc_cb (flux_t *h, flux_msg_handler_t *mh,
     json_t *o;
     char *jobspec;
 
-    if (util == NULL) {
-        errno = EINVAL;
-        goto error;
-    }
+    assert (util);
 
     if (flux_request_unpack (msg,
                              NULL,
@@ -56,6 +53,8 @@ static void cancel_cb (flux_t *h, flux_msg_handler_t *mh,
 {
     schedutil_t *util = arg;
     flux_jobid_t id;
+
+    assert (util);
 
     if (flux_request_unpack (msg, NULL, "{s:I}", "id", &id) < 0) {
         flux_log_error (h, "sched.cancel");
@@ -94,6 +93,8 @@ static void free_cb (flux_t *h, flux_msg_handler_t *mh,
     flux_jobid_t id;
     flux_future_t *f;
     char key[64];
+
+    assert (util);
 
     if (flux_request_unpack (msg, NULL, "{s:I}", "id", &id) < 0)
         goto error;

--- a/src/common/libschedutil/ops.c
+++ b/src/common/libschedutil/ops.c
@@ -24,7 +24,6 @@ static void alloc_cb (flux_t *h, flux_msg_handler_t *mh,
                       const flux_msg_t *msg, void *arg)
 {
     schedutil_t *util = arg;
-    flux_jobid_t id;
     json_t *o;
     char *jobspec;
 
@@ -35,9 +34,7 @@ static void alloc_cb (flux_t *h, flux_msg_handler_t *mh,
 
     if (flux_request_unpack (msg,
                              NULL,
-                             "{s:I s:o}",
-                             "id",
-                             &id,
+                             "{s:o}",
                              "jobspec",
                              &o) < 0)
         goto error;

--- a/src/common/libschedutil/ops.h
+++ b/src/common/libschedutil/ops.h
@@ -34,10 +34,10 @@ struct schedutil_ops {
                  void *arg);
 
     /* Callback for an alloc request.  jobspec is looked up as a
-     * convenience.  Decode msg with schedutil_alloc_request_decode().
-     * 'msg' and 'jobspec' are only valid for the duration of this
-     * call.  You should either respond to the request immediately
-     * (see alloc.h), or cache this information for later response.
+     * convenience.  'msg' and 'jobspec' are only valid for the
+     * duration of this call.  You should either respond to the
+     * request immediately (see alloc.h), or cache this information
+     * for later response.
      */
     void (*alloc)(flux_t *h,
                   const flux_msg_t *msg,
@@ -45,10 +45,9 @@ struct schedutil_ops {
                   void *arg);
 
     /* Callback for a free request.  R is looked up as a convenience.
-     * Decode msg with schedutil_free_request_decode().  'msg' and 'R'
-     * are only valid for the duration of this call.  You should
-     * either respond to the request immediately (see free.h), or
-     * cache this information for later response.
+     * 'msg' and 'R' are only valid for the duration of this call.
+     * You should either respond to the request immediately (see
+     * free.h), or cache this information for later response.
      */
     void (*free)(flux_t *h,
                  const flux_msg_t *msg,

--- a/src/common/libschedutil/ops.h
+++ b/src/common/libschedutil/ops.h
@@ -17,35 +17,42 @@
 extern "C" {
 #endif
 
-/* Callback for an alloc request.  jobspec is looked up as a convenience.
- * Decode msg with schedutil_alloc_request_decode().
- * 'msg' and 'jobspec' are only valid for hte duration of this call.
- * You should either respond to the request immediately (see alloc.h),
- * or cache this information for later response.
+/* In the following callbacks, 'msg' is a request or response message from
+ * the job manager with payload defined by RFC 27.  The message's reference
+ * count is decremented when the callback returns.
  */
-typedef void (schedutil_alloc_cb_f)(flux_t *h,
-                                    const flux_msg_t *msg,
-                                    const char *jobspec,
-                                    void *arg);
+struct schedutil_ops {
+    /* Callback for an alloc request.  jobspec is looked up as a
+     * convenience.  Decode msg with schedutil_alloc_request_decode().
+     * 'msg' and 'jobspec' are only valid for the duration of this
+     * call.  You should either respond to the request immediately
+     * (see alloc.h), or cache this information for later response.
+     */
+    void (*alloc)(flux_t *h,
+                  const flux_msg_t *msg,
+                  const char *jobspec,
+                  void *arg);
 
-/* Callback for a free request.  R is looked up as a convenience.
- * Decode msg with schedutil_free_request_decode().
- * 'msg' and 'R' are only valid for the duration of this call.
- * You should either respond to the request immediately (see free.h),
- * or cache this information for later response.
- */
-typedef void (schedutil_free_cb_f)(flux_t *h,
-                                   const flux_msg_t *msg,
-                                   const char *R,
-                                   void *arg);
+    /* Callback for a free request.  R is looked up as a convenience.
+     * Decode msg with schedutil_free_request_decode().  'msg' and 'R'
+     * are only valid for the duration of this call.  You should
+     * either respond to the request immediately (see free.h), or
+     * cache this information for later response.
+     */
+    void (*free)(flux_t *h,
+                 const flux_msg_t *msg,
+                 const char *R,
+                 void *arg);
 
-/* The job manager wants to cancel a pending alloc request.
- * The scheduler should look up the job in its queue.  If not found, do nothing.
- * If found, call schedutil_alloc_respond_cancel() and dequeue.
- */
-typedef void (schedutil_cancel_cb_f)(flux_t *h,
-                                     flux_jobid_t id,
-                                     void *arg);
+    /* The job manager wants to cancel a pending alloc request.  The
+     * scheduler should look up the job in its queue.  If not found,
+     * do nothing.  If found, call schedutil_alloc_respond_cancel()
+     * and dequeue.
+     */
+    void (*cancel)(flux_t *h,
+                   flux_jobid_t id,
+                   void *arg);
+};
 
 #ifdef __cplusplus
 }

--- a/src/common/libschedutil/ops.h
+++ b/src/common/libschedutil/ops.h
@@ -43,6 +43,12 @@ struct schedutil_ops {
      * 'msg' and 'R' are only valid for the duration of this call.
      * You should either respond to the request immediately (see
      * free.h), or cache this information for later response.
+     *
+     * If R is unneeded, it is recommended that the
+     * SCHEDUTIL_FREE_NOLOOKUP flag be set in schedutil_create().  By
+     * setting this flag, R will not be looked up, saving a KVS lookup
+     * on every invocation of this callback.  R will be set to NULL
+     * instead.
      */
     void (*free)(flux_t *h,
                  const flux_msg_t *msg,

--- a/src/common/libschedutil/ops.h
+++ b/src/common/libschedutil/ops.h
@@ -27,7 +27,7 @@ struct schedutil_ops {
      */
     int (*hello)(flux_t *h,
                  flux_jobid_t id,
-                 int priority,
+                 unsigned int priority,
                  uint32_t userid,
                  double t_submit,
                  const char *R,

--- a/src/common/libschedutil/ops.h
+++ b/src/common/libschedutil/ops.h
@@ -58,7 +58,7 @@ struct schedutil_ops {
      * and dequeue.
      */
     void (*cancel)(flux_t *h,
-                   flux_jobid_t id,
+                   const flux_msg_t *msg,
                    void *arg);
 };
 

--- a/src/common/libschedutil/ops.h
+++ b/src/common/libschedutil/ops.h
@@ -57,6 +57,14 @@ struct schedutil_ops {
     void (*cancel)(flux_t *h,
                    const flux_msg_t *msg,
                    void *arg);
+
+    /* The job manager wants to change the priority one or more jobs.
+     * This callback is not required and can be set to NULL if the
+     * caller wishes to ignore these messages.
+     */
+    void (*prioritize)(flux_t *h,
+                       const flux_msg_t *msg,
+                       void *arg);
 };
 
 #ifdef __cplusplus

--- a/src/common/libschedutil/ops.h
+++ b/src/common/libschedutil/ops.h
@@ -26,10 +26,7 @@ struct schedutil_ops {
      * Return 0 on success, -1 on failure with errno set.
      */
     int (*hello)(flux_t *h,
-                 flux_jobid_t id,
-                 unsigned int priority,
-                 uint32_t userid,
-                 double t_submit,
+                 const flux_msg_t *msg,
                  const char *R,
                  void *arg);
 

--- a/src/common/libschedutil/ops.h
+++ b/src/common/libschedutil/ops.h
@@ -22,6 +22,17 @@ extern "C" {
  * count is decremented when the callback returns.
  */
 struct schedutil_ops {
+    /* Callback for ingesting R + metadata for jobs that have resources
+     * Return 0 on success, -1 on failure with errno set.
+     */
+    int (*hello)(flux_t *h,
+                 flux_jobid_t id,
+                 int priority,
+                 uint32_t userid,
+                 double t_submit,
+                 const char *R,
+                 void *arg);
+
     /* Callback for an alloc request.  jobspec is looked up as a
      * convenience.  Decode msg with schedutil_alloc_request_decode().
      * 'msg' and 'jobspec' are only valid for the duration of this

--- a/src/common/libschedutil/ops.h
+++ b/src/common/libschedutil/ops.h
@@ -33,15 +33,13 @@ struct schedutil_ops {
                  const char *R,
                  void *arg);
 
-    /* Callback for an alloc request.  jobspec is looked up as a
-     * convenience.  'msg' and 'jobspec' are only valid for the
+    /* Callback for an alloc request.  'msg' is only valid for the
      * duration of this call.  You should either respond to the
      * request immediately (see alloc.h), or cache this information
      * for later response.
      */
     void (*alloc)(flux_t *h,
                   const flux_msg_t *msg,
-                  const char *jobspec,
                   void *arg);
 
     /* Callback for a free request.  R is looked up as a convenience.

--- a/src/common/libschedutil/schedutil_private.h
+++ b/src/common/libschedutil/schedutil_private.h
@@ -21,6 +21,7 @@ struct schedutil_ctx {
     flux_t *h;
     flux_msg_handler_t **handlers;
     const struct schedutil_ops *ops;
+    int flags;
     void *cb_arg;
     zlistx_t *outstanding_futures;
 };

--- a/src/common/libschedutil/schedutil_private.h
+++ b/src/common/libschedutil/schedutil_private.h
@@ -20,9 +20,7 @@
 struct schedutil_ctx {
     flux_t *h;
     flux_msg_handler_t **handlers;
-    schedutil_alloc_cb_f *alloc_cb;
-    schedutil_free_cb_f *free_cb;
-    schedutil_cancel_cb_f *cancel_cb;
+    const struct schedutil_ops *ops;
     void *cb_arg;
     zlistx_t *outstanding_futures;
 };

--- a/src/modules/sched-simple/libjj.c
+++ b/src/modules/sched-simple/libjj.c
@@ -145,7 +145,7 @@ err:
     errno = saved_errno;
     return rc;
 }
-                       
+
 
 /* vi: ts=4 sw=4 expandtab
  */

--- a/src/modules/sched-simple/libjj.h
+++ b/src/modules/sched-simple/libjj.h
@@ -15,6 +15,8 @@
 #include "config.h"
 #endif
 
+#include <jansson.h>
+
 #define JJ_ERROR_TEXT_LENGTH 256
 
 struct jj_counts {
@@ -32,6 +34,10 @@ struct jj_counts {
  *  Returns 0 on success and -1 on failure with errno set and jj->error[]
  *   with an error message string.
  */
+
 int libjj_get_counts (const char *spec, struct jj_counts *counts);
+
+/*  Identical to libjj_get_counts, but take json_t  */
+int libjj_get_counts_json (json_t *jobspec, struct jj_counts *counts);
 
 #endif /* !HAVE_SCHED_LIBJJ_H */

--- a/src/modules/sched-simple/sched.c
+++ b/src/modules/sched-simple/sched.c
@@ -669,6 +669,12 @@ static const struct flux_msg_handler_spec htab[] = {
     FLUX_MSGHANDLER_TABLE_END,
 };
 
+static const struct schedutil_ops ops = {
+    .alloc = alloc_cb,
+    .free = free_cb,
+    .cancel = cancel_cb,
+};
+
 int mod_main (flux_t *h, int argc, char **argv)
 {
     int rc = -1;
@@ -684,7 +690,7 @@ int mod_main (flux_t *h, int argc, char **argv)
     if (process_args (h, ss, argc, argv) < 0)
         return -1;
 
-    ss->util_ctx = schedutil_create (h, alloc_cb, free_cb, cancel_cb, ss);
+    ss->util_ctx = schedutil_create (h, &ops, ss);
     if (ss->util_ctx == NULL) {
         flux_log_error (h, "schedutil_create");
         goto done;

--- a/src/modules/sched-simple/sched.c
+++ b/src/modules/sched-simple/sched.c
@@ -101,11 +101,12 @@ jobreq_create (const flux_msg_t *msg, const char *jobspec)
 
     if (job == NULL)
         return NULL;
-    if (schedutil_alloc_request_decode (msg,
-                                        &job->id,
-                                        &job->priority,
-                                        &job->uid,
-                                        &job->t_submit) < 0)
+
+    if (flux_msg_unpack (msg, "{s:I s:i s:i s:f}",
+                         "id", &job->id,
+                         "priority", &job->priority,
+                         "userid", &job->uid,
+                         "t_submit", &job->t_submit) < 0)
         goto err;
     job->msg = flux_msg_incref (msg);
     if (libjj_get_counts (jobspec, &job->jj) < 0)

--- a/src/modules/sched-simple/sched.c
+++ b/src/modules/sched-simple/sched.c
@@ -710,7 +710,7 @@ int mod_main (flux_t *h, int argc, char **argv)
     if (process_args (h, ss, argc, argv) < 0)
         return -1;
 
-    ss->util_ctx = schedutil_create (h, &ops, ss);
+    ss->util_ctx = schedutil_create (h, 0, &ops, ss);
     if (ss->util_ctx == NULL) {
         flux_log_error (h, "schedutil_create");
         goto done;

--- a/src/modules/sched-simple/sched.c
+++ b/src/modules/sched-simple/sched.c
@@ -45,6 +45,7 @@ struct simple_sched {
 
     char *mode;             /* allocation mode */
     bool single;
+    int schedutil_flags;
     struct rlist *rlist;    /* list of resources */
     zlistx_t *queue;        /* job queue */
     schedutil_t *util_ctx;
@@ -301,6 +302,13 @@ static int try_free (flux_t *h, struct simple_sched *ss, const char *R)
 void free_cb (flux_t *h, const flux_msg_t *msg, const char *R, void *arg)
 {
     struct simple_sched *ss = arg;
+
+    if (!R) {
+        flux_log (h, LOG_ERR, "free: R is NULL");
+        if (flux_respond_error (h, msg, EINVAL, NULL) < 0)
+            flux_log_error (h, "free_cb: flux_respond_error");
+        return;
+    }
 
     if (try_free (h, ss, R) < 0) {
         if (flux_respond_error (h, msg, errno, NULL) < 0)
@@ -662,6 +670,14 @@ static char * get_alloc_mode (flux_t *h, const char *mode)
     return NULL;
 }
 
+static struct schedutil_ops ops = {
+    .hello = hello_cb,
+    .alloc = alloc_cb,
+    .free = free_cb,
+    .cancel = cancel_cb,
+    .prioritize = prioritize_cb,
+};
+
 static int process_args (flux_t *h, struct simple_sched *ss,
                          int argc, char *argv[])
 {
@@ -674,6 +690,9 @@ static int process_args (flux_t *h, struct simple_sched *ss,
         else if (strcmp ("unlimited", argv[i]) == 0) {
             ss->single = false;
         }
+        else if (strcmp ("test-free-nolookup", argv[i]) == 0) {
+            ss->schedutil_flags |= SCHEDUTIL_FREE_NOLOOKUP;
+        }
         else {
             flux_log_error (h, "Unknown module option: '%s'", argv[i]);
             return -1;
@@ -685,14 +704,6 @@ static int process_args (flux_t *h, struct simple_sched *ss,
 static const struct flux_msg_handler_spec htab[] = {
     { FLUX_MSGTYPE_REQUEST, "*.resource-status", status_cb, FLUX_ROLE_USER },
     FLUX_MSGHANDLER_TABLE_END,
-};
-
-static const struct schedutil_ops ops = {
-    .hello = hello_cb,
-    .alloc = alloc_cb,
-    .free = free_cb,
-    .cancel = cancel_cb,
-    .prioritize = prioritize_cb,
 };
 
 int mod_main (flux_t *h, int argc, char **argv)
@@ -710,7 +721,7 @@ int mod_main (flux_t *h, int argc, char **argv)
     if (process_args (h, ss, argc, argv) < 0)
         return -1;
 
-    ss->util_ctx = schedutil_create (h, 0, &ops, ss);
+    ss->util_ctx = schedutil_create (h, ss->schedutil_flags, &ops, ss);
     if (ss->util_ctx == NULL) {
         flux_log_error (h, "schedutil_create");
         goto done;

--- a/src/modules/sched-simple/sched.c
+++ b/src/modules/sched-simple/sched.c
@@ -421,10 +421,7 @@ proto_error:
 }
 
 static int hello_cb (flux_t *h,
-                     flux_jobid_t id,
-                     unsigned int priority,
-                     uint32_t userid,
-                     double t_submit,
+                     const flux_msg_t *msg,
                      const char *R,
                      void *arg)
 {
@@ -432,6 +429,19 @@ static int hello_cb (flux_t *h,
     int rc = -1;
     struct simple_sched *ss = arg;
     struct rlist *alloc;
+    flux_jobid_t id;
+    unsigned int priority;
+    uint32_t userid;
+    double t_submit;
+
+    if (flux_msg_unpack (msg, "{s:I s:i s:i s:f}",
+                         "id", &id,
+                         "priority", &priority,
+                         "userid", &userid,
+                         "t_submit", &t_submit) < 0) {
+        flux_log_error (h, "hello: invalid hello payload");
+        return -1;
+    }
 
     flux_log (h, LOG_DEBUG,
               "hello: id=%ju priority=%u userid=%u t_submit=%0.1f",

--- a/src/modules/sched-simple/sched.c
+++ b/src/modules/sched-simple/sched.c
@@ -384,8 +384,9 @@ static void cancel_cb (flux_t *h,
  * matching job found in queue, update the priority and reorder queue
  * as necessary.
  */
-void prioritize_cb (flux_t *h, flux_msg_handler_t *mh,
-                    const flux_msg_t *msg, void *arg)
+static void prioritize_cb (flux_t *h,
+                           const flux_msg_t *msg,
+                           void *arg)
 {
     struct simple_sched *ss = arg;
     json_t *jobs;
@@ -683,7 +684,6 @@ static int process_args (flux_t *h, struct simple_sched *ss,
 
 static const struct flux_msg_handler_spec htab[] = {
     { FLUX_MSGTYPE_REQUEST, "*.resource-status", status_cb, FLUX_ROLE_USER },
-    { FLUX_MSGTYPE_REQUEST, "sched.prioritize", prioritize_cb, 0},
     FLUX_MSGHANDLER_TABLE_END,
 };
 
@@ -692,6 +692,7 @@ static const struct schedutil_ops ops = {
     .alloc = alloc_cb,
     .free = free_cb,
     .cancel = cancel_cb,
+    .prioritize = prioritize_cb,
 };
 
 int mod_main (flux_t *h, int argc, char **argv)

--- a/src/modules/sched-simple/sched.c
+++ b/src/modules/sched-simple/sched.c
@@ -614,7 +614,7 @@ static int simple_sched_init (flux_t *h, struct simple_sched *ss)
 
     /*  Complete synchronous hello protocol:
      */
-    if (schedutil_hello (ss->util_ctx, hello_cb, ss) < 0) {
+    if (schedutil_hello (ss->util_ctx) < 0) {
         flux_log_error (h, "schedutil_hello");
         goto out;
     }
@@ -670,6 +670,7 @@ static const struct flux_msg_handler_spec htab[] = {
 };
 
 static const struct schedutil_ops ops = {
+    .hello = hello_cb,
     .alloc = alloc_cb,
     .free = free_cb,
     .cancel = cancel_cb,

--- a/src/modules/sched-simple/sched.c
+++ b/src/modules/sched-simple/sched.c
@@ -32,7 +32,7 @@ struct jobreq {
     void *handle;
     const flux_msg_t *msg;
     uint32_t uid;
-    int priority;
+    unsigned int priority;
     double t_submit;
     flux_jobid_t id;
     struct jj_counts jj;
@@ -414,7 +414,7 @@ proto_error:
 
 static int hello_cb (flux_t *h,
                      flux_jobid_t id,
-                     int priority,
+                     unsigned int priority,
                      uint32_t userid,
                      double t_submit,
                      const char *R,
@@ -426,7 +426,7 @@ static int hello_cb (flux_t *h,
     struct rlist *alloc;
 
     flux_log (h, LOG_DEBUG,
-              "hello: id=%ju priority=%d userid=%u t_submit=%0.1f",
+              "hello: id=%ju priority=%u userid=%u t_submit=%0.1f",
               (uintmax_t)id,
               priority,
               (unsigned int)userid,


### PR DESCRIPTION
Per #3441, any new callbacks added in the `schedutil_create()` function will break ABI.  To ensure future changes don't break ABI, set all callbacks in a struct of callback pointers, so new callbacks can be added to the end of the struct in the future.

I merely ripped two commits from @garlick's tree here:

https://github.com/garlick/flux-core/tree/schedutil_async

updating them for the current master.  I did not include any of the feature changes @garlick worked on in that tree.

Note that I did the minimum for solve #3441.  If there are other ABI breaking changes we'd like in `libschedutil` (either now or in the near future) we can discuss if this should be delayed.

