### PR TITLE
python: miscellaneous fixes to docstrings and argument names in bindings

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -44,7 +44,10 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 master_doc = 'index'
 source_suffix = '.rst'
 
-extensions = ['sphinx.ext.napoleon']
+extensions = [
+    'sphinx.ext.intersphinx',
+    'sphinx.ext.napoleon'
+]
 
 # Disable "smartquotes" to avoid things such as turning long-options
 #  "--" into en-dash in html output, which won't make much sense for
@@ -344,3 +347,16 @@ man_pages = [
     ('man5/flux-config-bootstrap', 'flux-config-bootstrap', 'configure Flux instance bootstrap', [author], 5),
     ('man7/flux-broker-attributes', 'flux-broker-attributes', 'overview Flux broker attributes', [author], 7),
 ]
+
+# -- Options for Intersphinx -------------------------------------------------
+
+intersphinx_mapping = {
+    "rfc": (
+        "https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/",
+        None,
+    ),
+    "workflow-examples": (
+        "https://flux-framework.readthedocs.io/projects/flux-workflow-examples/en/latest/",
+        None,
+    ),
+}

--- a/src/bindings/python/flux/job/Jobspec.py
+++ b/src/bindings/python/flux/job/Jobspec.py
@@ -41,7 +41,7 @@ def _convert_jobspec_arg_to_string(jobspec):
         raise EnvironmentError(errno.EINVAL, "jobspec must not be None/NULL")
     elif not isinstance(jobspec, six.binary_type):
         raise TypeError(
-            "jobpsec must be a Jobspec or string (either binary or unicode)"
+            "jobspec must be a Jobspec or string (either binary or unicode)"
         )
     return jobspec
 

--- a/src/bindings/python/flux/job/event.py
+++ b/src/bindings/python/flux/job/event.py
@@ -105,6 +105,11 @@ def event_watch_async(flux_handle, jobid, eventlog="eventlog"):
     Returns a JobEventWatchFuture. Call .get_event() from the then
     callback to get the currently returned event from the Future object.
 
+    .. seealso::
+
+       :doc:`rfc:spec_21`
+          Documentation for the events in the main eventlog
+
     :param flux_handle: handle for Flux broker from flux.Flux()
     :type flux_handle: Flux
     :param jobid: the job ID on which to watch events
@@ -125,6 +130,11 @@ def event_watch(flux_handle, jobid, eventlog="eventlog"):
     Example:
         >>> for event in job.event_watch(flux_handle, jobid):
         ...     # do something with event
+
+    .. seealso::
+
+       :doc:`rfc:spec_21`
+          Documentation for the events in the main eventlog
 
     :param flux_handle: handle for Flux broker from flux.Flux()
     :type flux_handle: Flux
@@ -156,6 +166,11 @@ def event_wait(flux_handle, jobid, name, eventlog="eventlog", raiseJobException=
     Wait synchronously for an eventlog entry named "name" and
     return the entry to caller, raises OSError with ENODATA if
     event never occurred
+
+    .. seealso::
+
+       :doc:`rfc:spec_21`
+          Documentation for the events in the main eventlog
 
     :param flux_handle: handle for Flux broker from flux.Flux()
     :type flux_handle: Flux

--- a/src/bindings/python/flux/job/event.py
+++ b/src/bindings/python/flux/job/event.py
@@ -100,8 +100,7 @@ class JobEventWatchFuture(Future):
 def event_watch_async(flux_handle, jobid, eventlog="eventlog"):
     """Asynchronously get eventlog updates for a job
 
-    Asynchronously watch the events of a job eventlog, optionally only
-    returning events that match a glob pattern.
+    Asynchronously watch the events of a job eventlog.
 
     Returns a JobEventWatchFuture. Call .get_event() from the then
     callback to get the currently returned event from the Future object.
@@ -109,7 +108,6 @@ def event_watch_async(flux_handle, jobid, eventlog="eventlog"):
     :param flux_handle: handle for Flux broker from flux.Flux()
     :type flux_handle: Flux
     :param jobid: the job ID on which to watch events
-    :param name: The event name or glob pattern for which to wait (default: \\*)
     :param eventlog: eventlog path in job kvs directory (default: eventlog)
     :returns: a JobEventWatchFuture object
     :rtype: JobEventWatchFuture
@@ -131,7 +129,6 @@ def event_watch(flux_handle, jobid, eventlog="eventlog"):
     :param flux_handle: handle for Flux broker from flux.Flux()
     :type flux_handle: Flux
     :param jobid: the job ID on which to watch events
-    :param name: The event name or glob pattern for which to wait (default: \\*)
     :param eventlog: eventlog path in job kvs directory (default: eventlog)
     """
     watcher = event_watch_async(flux_handle, jobid, eventlog)

--- a/src/bindings/python/flux/job/kill.py
+++ b/src/bindings/python/flux/job/kill.py
@@ -55,7 +55,7 @@ def cancel_async(flux_handle, jobid, reason=None):
     return Future(RAW.cancel(flux_handle, int(jobid), reason))
 
 
-def cancel(flux_handle, jobid, signum=None):
+def cancel(flux_handle, jobid, reason=None):
     """Cancel a pending or or running job
 
     :param flux_handle: handle for Flux broker from flux.Flux()
@@ -63,4 +63,4 @@ def cancel(flux_handle, jobid, signum=None):
     :param jobid: the job ID of the job to cancel
 
     """
-    return cancel_async(flux_handle, jobid, signum).get()
+    return cancel_async(flux_handle, jobid, reason).get()

--- a/src/bindings/python/flux/job/kill.py
+++ b/src/bindings/python/flux/job/kill.py
@@ -43,12 +43,13 @@ def kill(flux_handle, jobid, signum=None):
 def cancel_async(flux_handle, jobid, reason=None):
     """Cancel a pending or or running job asynchronously
 
-    :param flux_handle: handle for Flux broker from flux.Flux()
-    :type flux_handle: Flux
-    :param jobid: the job ID of the job to cancel
-    :returns: a Future
-    :rtype: Future
+    Arguments:
+        flux_handle: handle for Flux broker from flux.Flux()
+        jobid: the job ID of the job to cancel
+        reason: the textual reason associated with the cancelation
 
+    Returns:
+        Future: a future fulfilled when the cancelation completes
     """
     if not reason:
         reason = ffi.NULL
@@ -58,9 +59,9 @@ def cancel_async(flux_handle, jobid, reason=None):
 def cancel(flux_handle, jobid, reason=None):
     """Cancel a pending or or running job
 
-    :param flux_handle: handle for Flux broker from flux.Flux()
-    :type flux_handle: Flux
-    :param jobid: the job ID of the job to cancel
-
+    Arguments:
+        flux_handle: handle for Flux broker from flux.Flux()
+        jobid: the job ID of the job to cancel
+        reason: the textual reason associated with the cancelation
     """
     return cancel_async(flux_handle, jobid, reason).get()

--- a/src/bindings/python/flux/job/kill.py
+++ b/src/bindings/python/flux/job/kill.py
@@ -8,13 +8,18 @@
 # SPDX-License-Identifier: LGPL-3.0
 ###############################################################
 import signal
+from typing import Union, Optional
 
 from flux.future import Future
 from flux.job._wrapper import _RAW as RAW
+from flux.core.handle import Flux  # for typing
+from flux.job.JobID import JobID  # for typing
 from _flux._core import ffi
 
 
-def kill_async(flux_handle, jobid, signum=None):
+def kill_async(
+    flux_handle: Flux, jobid: Union[JobID, int], signum: Optional[int] = None
+):
     """Send a signal to a running job asynchronously
 
     :param flux_handle: handle for Flux broker from flux.Flux()
@@ -29,7 +34,7 @@ def kill_async(flux_handle, jobid, signum=None):
     return Future(RAW.kill(flux_handle, int(jobid), signum))
 
 
-def kill(flux_handle, jobid, signum=None):
+def kill(flux_handle: Flux, jobid: Union[JobID, int], signum: Optional[int] = None):
     """Send a signal to a running job.
 
     :param flux_handle: handle for Flux broker from flux.Flux()
@@ -40,7 +45,9 @@ def kill(flux_handle, jobid, signum=None):
     return kill_async(flux_handle, jobid, signum).get()
 
 
-def cancel_async(flux_handle, jobid, reason=None):
+def cancel_async(
+    flux_handle: Flux, jobid: Union[JobID, int], reason: Optional[str] = None
+):
     """Cancel a pending or or running job asynchronously
 
     Arguments:
@@ -56,7 +63,7 @@ def cancel_async(flux_handle, jobid, reason=None):
     return Future(RAW.cancel(flux_handle, int(jobid), reason))
 
 
-def cancel(flux_handle, jobid, reason=None):
+def cancel(flux_handle: Flux, jobid: Union[JobID, int], reason: Optional[str] = None):
     """Cancel a pending or or running job
 
     Arguments:


### PR DESCRIPTION
A couple of minor things that I noticed while I playing around with the python bindings.

The largest change is pulling in intersphinx and then referencing RFC21 in the `event_watch`/`event_wait` docstrings.