### PR TITLE
[WIP] python/job: add new Job class and unittests for the new class

### DIFF
--- a/src/bindings/python/flux/job/__init__.py
+++ b/src/bindings/python/flux/job/__init__.py
@@ -25,3 +25,4 @@ from flux.job.event import (
     JobException,
 )
 from flux.core.inner import ffi
+from flux.job.workflow import Job

--- a/src/bindings/python/flux/job/workflow.py
+++ b/src/bindings/python/flux/job/workflow.py
@@ -1,0 +1,122 @@
+###############################################################
+# Copyright 2020 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+import json
+from abc import ABC, abstractmethod
+
+import flux.job
+from flux.job.Jobspec import _convert_jobspec_arg_to_string
+from flux.job import JobID
+
+class JobABC(ABC):
+    @abstractmethod
+    def submit(self):
+        pass
+
+    @abstractmethod
+    def wait(self):
+        pass
+
+    @abstractmethod
+    def cancel(self):
+        pass
+
+    @abstractmethod
+    def kill(self):
+        pass
+
+
+class Job(JobABC):
+    def __init__(self, flux_handle, jobspec):
+        self._fh = flux_handle
+        self._jobspec_str = _convert_jobspec_arg_to_string(jobspec)
+        self._jobspec = None
+        self._jobid = None
+        self._submitted = False
+        self._waitable = False
+        self._submit_future = None
+
+    def submit_async(self, **kwargs):
+        if self._submitted:
+            raise RuntimeError("Cannot submit job twice")
+        self._waitable = kwargs.get('waitable', False)
+        # TODO: if we supported `and_then` on futures, we could register a
+        # callback and grab the jobid after fulfillment while still returning a
+        # future to the user and not keeping a reference to the future ourselves
+        self._submit_future = flux.job.submit_async(self.handle, self.jobspec_str, **kwargs)
+        self._submitted = True
+        return self._submit_future
+
+    def submit(self, **kwargs):
+        if self._submitted:
+            raise RuntimeError("Cannot submit job twice")
+        self._waitable = kwargs.get('waitable', False)
+        jobid = flux.job.submit(self.handle, self.jobspec_str, **kwargs)
+        self._submitted = True
+        self._jobid = JobID(jobid)
+        return jobid
+
+    @property
+    def handle(self):
+        return self._fh
+
+    @property
+    def waitable(self):
+        return self._waitable
+
+    @property
+    def jobspec(self):
+        if self._jobspec is None:
+            self._jobspec = json.loads(self._jobspec_str)
+        return self._jobspec
+
+    @property
+    def jobspec_str(self):
+        return self._jobspec_str
+
+    @property
+    def jobid(self):
+        # TODO: should getting jobid of unsubmitted job be an exception?
+        if self._jobid is None and self._submit_future is not None:
+            self._jobid = JobID(self._submit_future.get_id())
+            self._submit_future = None
+        return self._jobid
+
+    def wait(self):
+        if not self._submitted:
+            raise RuntimeError("Cannot wait on an unsubmitted job")
+        if not self._waitable:
+            raise RuntimeError("Cannot wait on job not marked waitable at submit time")
+        return flux.job.wait(self.handle, self.jobid)
+
+    def cancel_async(self, reason=None):
+        if not self._submitted:
+            raise RuntimeError("Cannot cancel an unsubmitted job")
+        return flux.job.cancel_async(self.handle, self.jobid, reason=reason)
+
+    def cancel(self, reason=None):
+        if not self._submitted:
+            raise RuntimeError("Cannot cancel an unsubmitted job")
+        return flux.job.cancel(self.handle, self.jobid, reason=reason)
+
+    def kill_async(self, signum=None):
+        if not self._submitted:
+            raise RuntimeError("Cannot kill an unsubmitted job")
+        return flux.job.kill_async(self.handle, self.jobid, signum=signum)
+
+    def kill(self, signum=None):
+        if not self._submitted:
+            raise RuntimeError("Cannot kill an unsubmitted job")
+        return flux.job.kill(self.handle, self.jobid, signum=signum)
+
+    def event_wait(self, name, **kwargs):
+        if not self._submitted:
+            raise RuntimeError("Cannot wait on events for an unsubmitted job")
+        return flux.job.event_wait(self.handle, self.jobid, name, **kwargs)

--- a/t/python/t0023-workflow.py
+++ b/t/python/t0023-workflow.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+###############################################################
+# Copyright 2020 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+import json
+import unittest
+import subflux
+
+import flux
+from flux.job.workflow import Job
+from flux.job.Jobspec import JobspecV1
+from flux.job import JobID
+
+class TestJob(unittest.TestCase):
+    @classmethod
+    def setUpClass(self):
+        self.fh = flux.Flux()
+
+    def test_init_jobspec_obj(self):
+        job = Job(self.fh, JobspecV1.from_command(["hostname"]))
+        self.assertEqual(job.jobspec['tasks'][0]['command'], ["hostname"])
+
+    def test_init_jobspec_str(self):
+        job = Job(self.fh, JobspecV1.from_command(["hostname"]).dumps())
+        self.assertEqual(job.jobspec['tasks'][0]['command'], ["hostname"])
+
+    def test_init_failures(self):
+        with self.assertRaises(TypeError) as error:
+            Job(self.fh, 0)
+
+    def test_submit(self):
+        job = Job(self.fh, JobspecV1.from_command(["hostname"]))
+        jobid = job.submit()
+        self.assertGreater(jobid, 0)
+
+    def test_submit_failures(self):
+        job = Job(self.fh, JobspecV1.from_command(["hostname"]))
+        jobid = job.submit()
+        self.assertGreater(jobid, 0)
+        with self.assertRaises(RuntimeError) as error:
+            jobid = job.submit()
+
+    def test_wait(self):
+        job = Job(self.fh, JobspecV1.from_command(["hostname"]))
+        jobid = job.submit(waitable=True)
+        (jobid_wait, success, error) = job.wait()
+        self.assertEqual(jobid, jobid_wait)
+        self.assertTrue(success)
+
+    def test_wait_failure(self):
+        job = Job(self.fh, JobspecV1.from_command(["hostname"]))
+        with self.assertRaises(RuntimeError) as error:
+            job.wait() # haven't submitted yet
+        jobid = job.submit()
+        with self.assertRaises(RuntimeError) as error:
+            job.wait() # not submitted with waitable=True
+
+    def test_event_wait(self):
+        job = Job(self.fh, JobspecV1.from_command(["hostname"]))
+        job.submit()
+        job.event_wait("depend")
+        job.event_wait("alloc")
+        job.event_wait("start")
+        job.event_wait("finish")
+        job.event_wait("free")
+
+    def test_cancel(self):
+        job = Job(self.fh, JobspecV1.from_command(["sleep", "1000"]))
+        job.submit()
+        job.cancel()
+
+    def test_cancel_failure(self):
+        job = Job(self.fh, JobspecV1.from_command(["sleep", "1000"]))
+        with self.assertRaises(RuntimeError) as error:
+            job.cancel()
+
+    def test_kill(self):
+        job = Job(self.fh, JobspecV1.from_command(["sleep", "1000"]))
+        job.submit(waitable=True)
+
+        #  Wait for shell to fully start to avoid delay in signal
+        job.event_wait("start")
+        job.event_wait(
+            name="shell.start", eventlog="guest.exec.eventlog"
+        )
+        job.kill(signum=9)
+
+        (jobid_wait, success, error) = job.wait()
+        self.assertEqual(job.jobid, jobid_wait)
+        self.assertFalse(success)
+
+    def test_kill_failure(self):
+        job = Job(self.fh, JobspecV1.from_command(["sleep", "1000"]))
+        with self.assertRaises(RuntimeError) as error:
+            job.kill()
+
+def __flux_size():
+    return 1
+
+if __name__ == "__main__":
+    from subflux import rerun_under_flux
+
+    if rerun_under_flux(size=__flux_size()):
+        from pycotap import TAPTestRunner
+
+        unittest.main(testRunner=TAPTestRunner())


### PR DESCRIPTION
Just a little PR that I was poking around with on my flight.  Figured I would put it up for some feedback if this is useful.  Right now, it just flips the API "inside out" so that you can do:
```python
from flux.job.workflow import Job

myjob = Job(flux_handle, JobspecV1.from_command(["hostname"]))
myjob.submit(args)
myjob.event_wait("alloc")
myjob.cancel()
```
as opposed to:
```python
import flux.job as job

jobid = job.submit(flux_handle, JobspecV1.from_command(["hostname"]))
job.event_wait(flux_handle, jobid, "alloc")
job.cancel(flux_handle, jobid)
```

I think this in and of itself is a minor benefit (maybe even a negative by creating multiple ways to do the same thing).  The bigger benefit I think would come from the next level of abstraction discussed in #2653: an Ensemble, JobPool, and/or Workflow class that allows easy handling of groups of jobs and nested instances.