### PR TITLE
connectors/ssh: forward LD_LIBRARY_PATH over ssh when set

### DIFF
--- a/t/t1105-proxy.t
+++ b/t/t1105-proxy.t
@@ -68,4 +68,17 @@ test_expect_success 'flux-proxy fails with unknown URI path (ENOENT)' '
 	grep "No such file or directory" badpath.err
 '
 
+test_expect_success 'flux-proxy forwards LD_LIBRARY_PATH' '
+	cat >proxinator.sh <<-EOF &&
+	#!/bin/sh
+	echo ssh "\$@" > proxinator.log
+	EOF
+	chmod +x proxinator.sh &&
+	(export LD_LIBRARY_PATH=/foo &&
+		export FLUX_SSH=./proxinator.sh &&
+		test_must_fail flux proxy ssh://hostname/baz/local) &&
+	test_debug "cat ./proxinator.log" &&
+	grep -E "ssh.* LD_LIBRARY_PATH=[^ ]*:?/foo .*/flux relay" ./proxinator.log
+'
+
 test_done


### PR DESCRIPTION
Problem: ssh and rsh do not forward environment variables, thus
LD_LIBRARY_PATH is not guaranteed to be set on the remote node where the
flux command is run.  If the flux command is linked against libraries
that can only be found when LD_LIBRARY_PATH is set, then the flux
command will fail to run over ssh.

Solution: Grab the client-side LD_LIBRARY_PATH so that we can manually
forward it.  Then forward it by prepending it to the flux relay
command (e.g., `ssh hostname LD_LIBRARY_PATH=/foo flux relay`).

Closes #3457