### PR TITLE
test: fix test for installing poison libflux

### DIFF
--- a/src/test/checks_run.sh
+++ b/src/test/checks_run.sh
@@ -177,7 +177,7 @@ checks_group "configure ${ARGS}"  /usr/src/configure ${ARGS} \
 	|| (printf "::error::configure failed\n"; cat config.log; exit 1)
 checks_group "make clean..." make clean
 
-if test "$POISON" = "t" -a test "$PROJECT" = "flux-core"; then
+if test "$POISON" = "t" -a "$PROJECT" = "flux-core"; then
   checks_group "Installing poison libflux..." \
     bash src/test/docker/poison-libflux.sh
 fi


### PR DESCRIPTION
Problem: the existing `test` errors out with `too many arguments`. The
issue is that an extra call to `test` snuck into the conditional.

Solution: remove the extra call to `test` and rely on the `-a` logical
and for the conditional check.

Closes #3460