### PR TITLE
jobtap: prototype job-manager plugin support

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -109,7 +109,8 @@ MAN3_FILES_PRIMARY = \
 	man3/flux_kvs_copy.3 \
 	man3/flux_core_version.3 \
 	man3/idset_create.3 \
-	man3/idset_encode.3
+	man3/idset_encode.3 \
+	man3/flux_jobtap_get_flux.3
 
 # These files are generated as clones of a primary page.
 # Sphinx handles this automatically if declared in the conf.py
@@ -253,7 +254,11 @@ MAN3_FILES_SECONDARY = \
 	man3/idset_first.3 \
 	man3/idset_next.3 \
 	man3/idset_count.3 \
-	man3/idset_equal.3
+	man3/idset_equal.3 \
+	man3/flux_jobtap_service_register.3 \
+	man3/flux_jobtap_reprioritize_all.3 \
+	man3/flux_jobtap_reprioritize_job.3 \
+	man3/flux_jobtap_priority_unavail.3
 
 MAN5_FILES = $(MAN5_FILES_PRIMARY)
 
@@ -263,7 +268,8 @@ MAN5_FILES_PRIMARY = \
 MAN7_FILES = $(MAN7_FILES_PRIMARY)
 
 MAN7_FILES_PRIMARY = \
-	man7/flux-broker-attributes.7
+	man7/flux-broker-attributes.7 \
+	man7/flux-jobtap-plugins.7
 
 
 RST_FILES  = \

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -344,8 +344,14 @@ man_pages = [
     ('man3/idset_encode','idset_encode', 'Convert idset to string and string to idset', [author], 3),
     ('man3/idset_encode','idset_decode', 'Convert idset to string and string to idset', [author], 3),
     ('man3/idset_encode','idset_ndecode', 'Convert idset to string and string to idset', [author], 3),
+    ('man3/flux_jobtap_get_flux','flux_jobtap_get_flux', 'Flux jobtap plugin interfaces', [author], 3),
+    ('man3/flux_jobtap_get_flux','flux_jobtap_service_register', 'Flux jobtap plugin interfaces', [author], 3),
+    ('man3/flux_jobtap_get_flux','flux_jobtap_reprioritize_all', 'Flux jobtap plugin interfaces', [author], 3),
+    ('man3/flux_jobtap_get_flux','flux_jobtap_reprioritize_job', 'Flux jobtap plugin interfaces', [author], 3),
+    ('man3/flux_jobtap_get_flux','flux_jobtap_priority_unavail', 'Flux jobtap plugin interfaces', [author], 3),
     ('man5/flux-config-bootstrap', 'flux-config-bootstrap', 'configure Flux instance bootstrap', [author], 5),
     ('man7/flux-broker-attributes', 'flux-broker-attributes', 'overview Flux broker attributes', [author], 7),
+    ('man7/flux-jobtap-plugins', 'flux-jobtap-plugins', 'overview Flux jobtap plugin API', [author], 7),
 ]
 
 # -- Options for Intersphinx -------------------------------------------------

--- a/doc/man3/flux_jobtap_get_flux.rst
+++ b/doc/man3/flux_jobtap_get_flux.rst
@@ -1,0 +1,93 @@
+=======================
+flux_jobtap_get_flux(3)
+=======================
+
+
+SYNOPSIS
+========
+
+::
+
+   #include <flux/core.h>
+   #include <flux/jobtap.h>
+
+::
+
+   flux_t *flux_jobtap_get_flux (flux_plugin_t *p);
+
+::
+
+   int flux_jobtap_service_register (flux_plugin_t *p,
+                                     const char *method,
+                                     flux_msg_handler_f cb,
+                                     void *arg);
+
+::
+
+   int flux_jobtap_reprioritize_all (flux_plugin_t *p);
+
+::
+
+   int flux_jobtap_reprioritize_job (flux_plugin_t *p,
+                                     flux_jobid_t id,
+                                     unsigned int priority);
+
+::
+
+   int flux_jobtap_priority_unavail (flux_plugin_t *p,
+                                     flux_plugin_arg_t *args);
+
+
+DESCRIPTION
+===========
+
+These interfaces are used by Flux *jobtap* plugins which are used to
+extend the job manager broker module.
+
+``flux_jobtap_get_flux()`` returns the job manager's Flux handle given
+the plugin's ``flux_plugin_t *``. This can be used by a *jobtap* plugin
+to send RPCs, schedule timer watchers, or other asynchronous work.
+
+``flux_jobtap_service_register()`` registers a service name ``method``
+under the job manager which will be handled by the provided message
+handler ``cb``.  The constructed service name will be
+``job-manager.<name>.<method>`` where ``name`` is the name of the plugin
+as returned by ``flux_plugin_get_name(3)``. As such, this call may
+fail if the *jobtap* plugin has not yet set a name for itself using
+``flux_plugin_set_name(3)``.
+
+``flux_jobtap_reprioritize_all()`` requests that the job manager begin
+reprioritization of all pending jobs, i.e. jobs in the PRIORITY and
+SCHED states. This will result on each job having a ``job.priority.get``
+callback invoked on it.
+
+``flux_jobtap_reprioritize_job()`` allows a *jobtap* plugin to asynchronously
+assign the priority of a job.
+
+``flux_jobtap_priority_unavail()`` is a convenience function which may
+be used by a plugin in the ``job.state.priority`` priority callback to
+indicate that a priority for the job is not yet available. It can be
+called as::
+
+   return flux_jobtap_priority_unavail (p, args);
+
+
+RETURN VALUE
+============
+
+``flux_jobtap_get_flux()`` returns a ``flux_t *`` handle on success. ``NULL``
+is returned with errno set to ``EINVAL`` if the supplied ``flux_plugin_t *p``
+is not a jobtap plugin handle.
+
+The remaining functions return 0 on success, -1 on failure.
+
+RESOURCES
+=========
+
+Github: http://github.com/flux-framework
+
+
+SEE ALSO
+========
+
+flux-jobtap-plugins(7)

--- a/doc/man3/index.rst
+++ b/doc/man3/index.rst
@@ -72,6 +72,7 @@ man3
    flux_zmq_watcher_create
    idset_create
    idset_encode
+   flux_jobtap_get_flux
 
 .. toctree::
    :hidden:

--- a/doc/man7/index.rst
+++ b/doc/man7/index.rst
@@ -6,3 +6,4 @@ man7
    :maxdepth: 1
 
    flux-broker-attributes
+   flux-jobtap-plugins

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -527,3 +527,8 @@ dirname
 jps
 xargs
 sep
+RPCs
+jobtap
+unavail
+reprioritize
+reprioritization

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -12,4 +12,5 @@ noinst_HEADERS = \
 	include/flux/idset.h \
 	include/flux/schedutil.h \
 	include/flux/shell.h \
-	include/flux/hostlist.h
+	include/flux/hostlist.h \
+	include/flux/jobtap.h

--- a/src/bindings/python/flux/job/Jobspec.py
+++ b/src/bindings/python/flux/job/Jobspec.py
@@ -20,7 +20,7 @@ import six
 import yaml
 
 from _flux._core import ffi
-from flux.util import parse_fsd
+from flux.util import parse_fsd, set_treedict
 
 
 def _convert_jobspec_arg_to_string(jobspec):
@@ -392,22 +392,12 @@ class Jobspec(object):
         self.setattr_shell_option("{}.{}.type".format(iotype, stream_name), "file")
         self.setattr_shell_option("{}.{}.path".format(iotype, stream_name), path)
 
-    def _set_treedict(self, in_dict, key, val):
-        """
-        _set_treedict(d, "a.b.c", 42) is like d[a][b][c] = 42
-        but levels are created on demand.
-        """
-        path = key.split(".", 1)
-        if len(path) == 2:
-            self._set_treedict(in_dict.setdefault(path[0], {}), path[1], val)
-        else:
-            in_dict[key] = val
-
     def setattr(self, key, val):
+
         """
         set job attribute
         """
-        self._set_treedict(self.jobspec, "attributes." + key, val)
+        set_treedict(self.jobspec, "attributes." + key, val)
 
     def setattr_shell_option(self, key, val):
         """

--- a/src/bindings/python/flux/job/info.py
+++ b/src/bindings/python/flux/job/info.py
@@ -106,6 +106,7 @@ class JobInfo:
         "t_inactive": 0.0,
         "expiration": 0.0,
         "nnodes": "",
+        "priority": "",
         "ranks": "",
         "nodelist": "",
         "success": "",

--- a/src/broker/module.c
+++ b/src/broker/module.c
@@ -617,7 +617,7 @@ module_t *module_add (modhash_t *mh, const char *path)
     int rc;
 
     dlerror ();
-    if (!(dso = dlopen (path, RTLD_NOW | RTLD_LOCAL | FLUX_DEEPBIND))) {
+    if (!(dso = dlopen (path, RTLD_NOW | RTLD_GLOBAL | FLUX_DEEPBIND))) {
         log_msg ("%s", dlerror ());
         errno = ENOENT;
         return NULL;

--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -69,7 +69,8 @@ dist_fluxcmd_SCRIPTS = \
 	flux-mini.py \
 	flux-jobs.py \
 	flux-resource.py \
-	flux-admin.py
+	flux-admin.py \
+	flux-jobtap.py
 
 fluxcmd_PROGRAMS = \
 	flux-terminus \

--- a/src/cmd/flux-jobtap.py
+++ b/src/cmd/flux-jobtap.py
@@ -1,0 +1,98 @@
+#!/bin/false
+##############################################################
+# Copyright 2021 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+##############################################################
+
+import os
+import sys
+import logging
+import argparse
+
+import flux
+from flux.util import TreedictAction
+
+
+def jobtap_load(args):
+    """Load a jobtap plugin into the job manager"""
+    if args.plugin == "none" or args.plugin.startswith("builtin."):
+        path = args.plugin
+    else:
+        path = os.path.abspath(args.plugin)
+
+    try:
+        resp = (
+            flux.Flux()
+            .rpc("job-manager.jobtap", {"load": path, "conf": args.conf})
+            .get()
+        )
+    except FileNotFoundError:
+        LOGGER.error(
+            "%s not found, no plugin is currently loaded",
+            args.plugin,
+        )
+        sys.exit(1)
+    if not args.quiet:
+        print("Loaded:")
+        for name in resp["plugins"]:
+            print(name)
+        print("Previously loaded:")
+    for name in resp["previous"]:
+        print(name)
+
+
+def jobtap_list(_args):
+    """List currently loaded jobtap plugin"""
+    resp = flux.Flux().rpc("job-manager.jobtap", {"query_only": True}).get()
+    for name in resp["plugins"]:
+        print(name)
+
+
+LOGGER = logging.getLogger("flux-jobtap")
+
+
+@flux.util.CLIMain(LOGGER)
+def main():
+    parser = argparse.ArgumentParser(prog="flux-jobtap")
+    subparsers = parser.add_subparsers(
+        title="subcommands", description="", dest="subcommand"
+    )
+    subparsers.required = True
+
+    load_parser = subparsers.add_parser(
+        "load", formatter_class=flux.util.help_formatter()
+    )
+    load_parser.add_argument(
+        "-q",
+        "--quiet",
+        action="count",
+        default=0,
+        help="Only print previously loaded plugin after success",
+    )
+    load_parser.add_argument("plugin", help="Plugin path or builtin name")
+    load_parser.add_argument(
+        "conf",
+        help="List of key=value config keys to set as plugin configuration",
+        action=TreedictAction,
+        nargs=argparse.REMAINDER,
+    )
+    load_parser.set_defaults(func=jobtap_load)
+
+    list_parser = subparsers.add_parser(
+        "list", formatter_class=flux.util.help_formatter()
+    )
+    list_parser.set_defaults(func=jobtap_list)
+
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()
+
+# vi: ts=4 sw=4 expandtab

--- a/src/common/libflux/Makefile.am
+++ b/src/common/libflux/Makefile.am
@@ -179,7 +179,8 @@ test_cppflags = \
 check_LTLIBRARIES = \
 	test/module_fake1.la \
 	test/module_fake2.la \
-	test/plugin_foo.la
+	test/plugin_foo.la \
+	test/plugin_bar.la
 
 
 check_PROGRAMS = $(TESTS)
@@ -294,3 +295,8 @@ test_plugin_foo_la_SOURCES = test/plugin_foo.c
 test_plugin_foo_la_CPPFLAGS = $(test_cppflags)
 test_plugin_foo_la_LDFLAGS = -module -rpath /nowhere
 test_plugin_foo_la_LIBADD = $(test_ldadd) $(LIBDL)
+
+test_plugin_bar_la_SOURCES = test/plugin_bar.c
+test_plugin_bar_la_CPPFLAGS = $(test_cppflags)
+test_plugin_bar_la_LDFLAGS = -module -rpath /nowhere
+test_plugin_bar_la_LIBADD = $(test_ldadd) $(LIBDL)

--- a/src/common/libflux/plugin.c
+++ b/src/common/libflux/plugin.c
@@ -543,11 +543,12 @@ int flux_plugin_call (flux_plugin_t *p, const char *string,
     plugin_error_clear (p);
     if (!p || !string)
         return plugin_seterror (p, EINVAL, NULL);
-    h = match_handler (p, string);
-    if (!h)
+    if (!(h = match_handler (p, string)))
         return 0;
     assert (h->cb);
-    return (*h->cb) (p, string, args, h->data);
+    if ((*h->cb) (p, string, args, h->data) < 0)
+        return -1;
+    return 1;
 }
 
 

--- a/src/common/libflux/plugin.h
+++ b/src/common/libflux/plugin.h
@@ -17,6 +17,13 @@
 extern "C" {
 #endif
 
+enum {
+    FLUX_PLUGIN_RTLD_LAZY =      1,  /* Lazy function binding                */
+    FLUX_PLUGIN_RTLD_NOW =       2,  /* Immediate function binding           */
+    FLUX_PLUGIN_RTLD_GLOBAL =    4,  /* Load with RTLD_GLOBAL                */
+    FLUX_PLUGIN_RTLD_DEEPBIND =  8,  /* Load with RTLD_DEEPBIND if available */
+};
+
 typedef struct flux_plugin flux_plugin_t;
 typedef struct flux_plugin_arg flux_plugin_arg_t;
 
@@ -37,6 +44,11 @@ struct flux_plugin_handler {
  */
 flux_plugin_t * flux_plugin_create (void);
 void flux_plugin_destroy (flux_plugin_t *p);
+
+/*  Get and set plugin flags. Flags currently only apply to load_dso()
+ */
+int flux_plugin_get_flags (flux_plugin_t *p);
+int flux_plugin_set_flags (flux_plugin_t *p, int flags);
 
 /*  Returns the last error from a plugin. Only valid if
  *   the last call returned an error.

--- a/src/common/libflux/plugin.h
+++ b/src/common/libflux/plugin.h
@@ -161,6 +161,10 @@ int flux_plugin_arg_vunpack (flux_plugin_arg_t *args, int flags,
 
 /*  Call first plugin callback matching 'name', passing optional plugin
  *   arguments in 'args'.
+ *
+ *  Returns 0 if no callback was found for `name`, -1 if callback was
+ *   called with return value < 0, and 1 if callback was called with
+ *   return value >= 0.
  */
 int flux_plugin_call (flux_plugin_t *p, const char *name,
                       flux_plugin_arg_t *args);

--- a/src/common/libflux/test/plugin.c
+++ b/src/common/libflux/test/plugin.c
@@ -314,7 +314,7 @@ void test_basic ()
     b = 4;
     ok (flux_plugin_arg_pack (args, 0, "{s:i s:i}", "a", a, "b", b) == 0,
         "flux_plugin_arg_pack works");
-    ok (flux_plugin_call (p, "op.add", args) == 0,
+    ok (flux_plugin_call (p, "op.add", args) >= 0,
         "flux_plugin_call op.add works");
 
     ok (flux_plugin_arg_unpack (args, FLUX_PLUGIN_ARG_OUT,
@@ -326,7 +326,7 @@ void test_basic ()
     a = 2;
     ok (flux_plugin_arg_pack (args, 0, "{s:i s:i}", "a", a, "b", b) == 0,
         "flux_plugin_arg_pack works");
-    ok (flux_plugin_call (p, "op.multiply", args) == 0,
+    ok (flux_plugin_call (p, "op.multiply", args) >= 0,
         "callback with topic op.multiply worked");
     ok (flux_plugin_arg_unpack (args, FLUX_PLUGIN_ARG_OUT,
                                 "{s:i}", "a", &a) == 0,
@@ -361,7 +361,7 @@ void test_register ()
 
     ok (flux_plugin_register (p, "test_register", tab) == 0,
         "flux_plugin_register 2 handlers works");
-    ok (flux_plugin_call (p, "foo.test", args) == 0,
+    ok (flux_plugin_call (p, "foo.test", args) >= 0,
         "flux_plugin_call foo.test worked");
     ok (flux_plugin_arg_unpack (args, FLUX_PLUGIN_ARG_OUT,
                                 "{s:s s:s}",
@@ -373,7 +373,7 @@ void test_register ()
     is (data, foodata,
         "flux_plugin_call passed correct void *data to foo()");
 
-    ok (flux_plugin_call (p, "fallthru", args) == 0,
+    ok (flux_plugin_call (p, "fallthru", args) >= 0,
         "flux_plugin_call fallthru worked");
     ok (flux_plugin_arg_unpack (args, FLUX_PLUGIN_ARG_OUT,
                                 "{s:s s:s}",
@@ -420,7 +420,7 @@ void test_load ()
     flux_plugin_arg_t *args = flux_plugin_arg_create ();
     if (!args)
         BAIL_OUT ("flux_plugin_arg_create failed");
-    ok (flux_plugin_call (p, "test.foo", args) == 0,
+    ok (flux_plugin_call (p, "test.foo", args) >= 0,
         "flux_plugin_call (test.foo) success");
     ok (flux_plugin_arg_unpack (args,
                                 FLUX_PLUGIN_ARG_OUT,
@@ -435,7 +435,7 @@ void test_load ()
         "flux_plugin_arg_out works");
     diag ("out = %s", out);
     free (out);
-    ok (flux_plugin_call (p, "test.bar", args) == 0,
+    ok (flux_plugin_call (p, "test.bar", args) >= 0,
         "flux_plugin_call (test.bar) success");
     ok (flux_plugin_arg_unpack (args, FLUX_PLUGIN_ARG_OUT,
                                 "{s:s}", "result", &result) == 0,

--- a/src/common/libflux/test/plugin_bar.c
+++ b/src/common/libflux/test/plugin_bar.c
@@ -1,0 +1,23 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#include <flux/core.h>
+
+/*  Invalid global symbol to force dlopen failure
+ */
+extern int my_invalid_sym (void);
+
+int flux_plugin_init (flux_plugin_t *p)
+{
+    return my_invalid_sym ();
+}
+
+/* vi: ts=4 sw=4 expandtab
+ */

--- a/src/include/flux/jobtap.h
+++ b/src/include/flux/jobtap.h
@@ -1,0 +1,14 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* Allow in-tree programs to #include <flux/jobtap.h> like out-of-tree would.
+ */
+
+#include "src/modules/job-manager/jobtap.h"

--- a/src/modules/job-manager/Makefile.am
+++ b/src/modules/job-manager/Makefile.am
@@ -58,6 +58,9 @@ libjob_manager_la_SOURCES = \
 	jobtap.h \
 	jobtap.c
 
+fluxinclude_HEADERS = \
+	jobtap.h
+
 job_manager_la_LDFLAGS = $(fluxmod_ldflags) -module
 job_manager_la_LIBADD = \
 	libjob-manager.la \

--- a/src/modules/job-manager/Makefile.am
+++ b/src/modules/job-manager/Makefile.am
@@ -63,7 +63,11 @@ libjob_manager_la_SOURCES = \
 fluxinclude_HEADERS = \
 	jobtap.h
 
-job_manager_la_LDFLAGS = $(fluxmod_ldflags) -module
+job_manager_la_LDFLAGS = \
+	$(fluxlib_ldflags) \
+	-export-symbols-regex \
+	'^(flux_jobtap.*|mod_name|mod_service|mod_main)$$' \
+	-module
 job_manager_la_LIBADD = \
 	libjob-manager.la \
 	$(fluxmod_libadd) \

--- a/src/modules/job-manager/Makefile.am
+++ b/src/modules/job-manager/Makefile.am
@@ -11,11 +11,17 @@ AM_CPPFLAGS = \
 	-I$(top_builddir)/src/common/libflux \
 	$(ZMQ_CFLAGS) $(JANSSON_CFLAGS)
 
-fluxmod_LTLIBRARIES = job-manager.la
+fluxmod_LTLIBRARIES = \
+	job-manager.la
+
+noinst_LTLIBRARIES = \
+	libjob-manager.la
 
 job_manager_la_SOURCES = \
 	job-manager.c \
-	job-manager.h \
+	job-manager.h
+
+libjob_manager_la_SOURCES = \
 	job.c \
 	job.h \
 	submit.c \
@@ -48,12 +54,14 @@ job_manager_la_SOURCES = \
 	getattr.c
 
 job_manager_la_LDFLAGS = $(fluxmod_ldflags) -module
-job_manager_la_LIBADD = $(fluxmod_libadd) \
-		    $(top_builddir)/src/common/libjob/libjob.la \
-		    $(top_builddir)/src/common/libflux-internal.la \
-		    $(top_builddir)/src/common/libflux-core.la \
-		    $(top_builddir)/src/common/libflux-optparse.la \
-		    $(ZMQ_LIBS)
+job_manager_la_LIBADD = \
+	libjob-manager.la \
+	$(fluxmod_libadd) \
+	$(top_builddir)/src/common/libjob/libjob.la \
+	$(top_builddir)/src/common/libflux-internal.la \
+	$(top_builddir)/src/common/libflux-core.la \
+	$(top_builddir)/src/common/libflux-optparse.la \
+	$(ZMQ_LIBS)
 
 TESTS = \
 	test_job.t \
@@ -65,15 +73,7 @@ TESTS = \
 	test_annotate.t
 
 test_ldadd = \
-        $(top_builddir)/src/modules/job-manager/event.o \
-        $(top_builddir)/src/modules/job-manager/job.o \
-        $(top_builddir)/src/modules/job-manager/alloc.o \
-        $(top_builddir)/src/modules/job-manager/start.o \
-        $(top_builddir)/src/modules/job-manager/drain.o \
-        $(top_builddir)/src/modules/job-manager/submit.o \
-        $(top_builddir)/src/modules/job-manager/wait.o \
-        $(top_builddir)/src/modules/job-manager/annotate.o \
-        $(top_builddir)/src/modules/job-manager/journal.o \
+	libjob-manager.la \
 	$(top_builddir)/src/common/libtap/libtap.la \
 	$(top_builddir)/src/common/libjob/libjob.la \
 	$(top_builddir)/src/common/libflux-internal.la \

--- a/src/modules/job-manager/Makefile.am
+++ b/src/modules/job-manager/Makefile.am
@@ -53,7 +53,10 @@ libjob_manager_la_SOURCES = \
 	getattr.h \
 	getattr.c \
 	prioritize.h \
-	prioritize.c
+	prioritize.c \
+	jobtap-internal.h \
+	jobtap.h \
+	jobtap.c
 
 job_manager_la_LDFLAGS = $(fluxmod_ldflags) -module
 job_manager_la_LIBADD = \

--- a/src/modules/job-manager/Makefile.am
+++ b/src/modules/job-manager/Makefile.am
@@ -56,7 +56,9 @@ libjob_manager_la_SOURCES = \
 	prioritize.c \
 	jobtap-internal.h \
 	jobtap.h \
-	jobtap.c
+	jobtap.c \
+	plugins/default.c \
+	plugins/hold.c
 
 fluxinclude_HEADERS = \
 	jobtap.h

--- a/src/modules/job-manager/Makefile.am
+++ b/src/modules/job-manager/Makefile.am
@@ -51,7 +51,9 @@ libjob_manager_la_SOURCES = \
 	journal.h \
 	journal.c \
 	getattr.h \
-	getattr.c
+	getattr.c \
+	prioritize.h \
+	prioritize.c
 
 job_manager_la_LDFLAGS = $(fluxmod_ldflags) -module
 job_manager_la_LIBADD = \

--- a/src/modules/job-manager/alloc.c
+++ b/src/modules/job-manager/alloc.c
@@ -201,7 +201,6 @@ static void alloc_response_cb (flux_t *h, flux_msg_handler_t *mh,
     json_t *annotations = NULL;
     struct job *job;
     bool cleared = false;
-    json_t *tmp = NULL;
 
     if (flux_response_decode (msg, NULL, NULL) < 0)
         goto teardown; // ENOSYS here if scheduler not loaded/shutting down
@@ -237,25 +236,8 @@ static void alloc_response_cb (flux_t *h, flux_msg_handler_t *mh,
             errno = EEXIST;
             goto teardown;
         }
-        if (annotations_update (h, job, annotations) < 0)
+        if (annotations_update_and_publish (ctx, job, annotations) < 0)
             flux_log_error (h, "annotations_update: id=%ju", (uintmax_t)id);
-        if (annotations) {
-            if (job->annotations) {
-                /* deep copy necessary for journal history, as
-                 * job->annotations can be modified in future */
-                if (!(tmp = json_deep_copy (job->annotations)))
-                    goto nomem;
-            }
-            if (event_job_post_pack (ctx->event,
-                                     job,
-                                     "annotations",
-                                     EVENT_JOURNAL_ONLY,
-                                     "{s:O?}",
-                                     "annotations", tmp) < 0)
-                flux_log_error (ctx->h,
-                                "%s: event_job_post_pack: id=%ju",
-                                __FUNCTION__, (uintmax_t)id);
-        }
         if (job->annotations) {
             if (event_job_post_pack (ctx->event, job, "alloc", 0,
                                      "{ s:O }",
@@ -272,23 +254,8 @@ static void alloc_response_cb (flux_t *h, flux_msg_handler_t *mh,
             errno = EPROTO;
             goto teardown;
         }
-        if (annotations_update (h, job, annotations) < 0)
+        if (annotations_update_and_publish (ctx, job, annotations) < 0)
             flux_log_error (h, "annotations_update: id=%ju", (uintmax_t)id);
-        if (job->annotations) {
-            /* deep copy necessary for journal history, as
-             * job->annotations can be modified in future */
-            if (!(tmp = json_deep_copy (job->annotations)))
-                goto nomem;
-        }
-        if (event_job_post_pack (ctx->event,
-                                 job,
-                                 "annotations",
-                                 EVENT_JOURNAL_ONLY,
-                                 "{s:O?}",
-                                 "annotations", tmp) < 0)
-            flux_log_error (ctx->h,
-                            "%s: event_job_post_pack: id=%ju",
-                            __FUNCTION__, (uintmax_t)id);
         break;
     case FLUX_SCHED_ALLOC_DENY: // error
         alloc->alloc_pending_count--;
@@ -341,12 +308,8 @@ static void alloc_response_cb (flux_t *h, flux_msg_handler_t *mh,
         errno = EINVAL;
         goto teardown;
     }
-    json_decref (tmp);
     return;
-nomem:
-    errno = ENOMEM;
 teardown:
-    json_decref (tmp);
     interface_teardown (alloc, "alloc response error", errno);
 }
 

--- a/src/modules/job-manager/alloc.h
+++ b/src/modules/job-manager/alloc.h
@@ -52,6 +52,11 @@ struct job *alloc_queue_next (struct alloc *alloc);
  */
 void alloc_queue_reorder (struct alloc *alloc, struct job *job);
 
+/* Re-sort alloc queue.
+ * Recalculate pending jobs if necessary
+ */
+int alloc_queue_reprioritize (struct alloc *alloc);
+
 /* Recalculate pending job, e.g. after urgency change */
 int alloc_queue_recalc_pending (struct alloc *alloc);
 

--- a/src/modules/job-manager/annotate.c
+++ b/src/modules/job-manager/annotate.c
@@ -106,6 +106,10 @@ int update_annotation_recursive (struct job *job, json_t *orig, json_t *new)
 
 int annotations_update (flux_t *h, struct job *job, json_t *annotations)
 {
+    if (!json_is_object (annotations)) {
+        errno = EINVAL;
+        return -1;
+    }
     if (annotations) {
         if (!job->annotations) {
             if (!(job->annotations = json_object ())) {

--- a/src/modules/job-manager/annotate.h
+++ b/src/modules/job-manager/annotate.h
@@ -26,6 +26,10 @@ void annotate_ctx_destroy (struct annotate *annotate);
 /* exposed for unit testing only */
 int update_annotation_recursive (struct job *job, json_t *orig, json_t *new);
 
+int annotations_update_and_publish (struct job_manager *ctx,
+                                    struct job *job,
+                                    json_t *annotations);
+
 #endif /* ! _FLUX_JOB_MANAGER_ANNOTATE_H */
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab

--- a/src/modules/job-manager/job-manager.h
+++ b/src/modules/job-manager/job-manager.h
@@ -27,6 +27,7 @@ struct job_manager {
     struct kill *kill;
     struct annotate *annotate;
     struct journal *journal;
+    struct jobtap *jobtap;
 };
 
 #endif /* !_FLUX_JOB_MANAGER_H */

--- a/src/modules/job-manager/job.c
+++ b/src/modules/job-manager/job.c
@@ -51,6 +51,7 @@ struct job *job_create (void)
     job->refcount = 1;
     job->userid = FLUX_USERID_UNKNOWN;
     job->urgency = FLUX_JOB_URGENCY_DEFAULT;
+    job->priority = -1;
     job->state = FLUX_JOB_STATE_NEW;
     return job;
 }

--- a/src/modules/job-manager/job.h
+++ b/src/modules/job-manager/job.h
@@ -51,7 +51,7 @@ struct job *job_create_from_eventlog (flux_jobid_t id,
                                       const char *jobspec);
 
 /* Helpers for maintaining czmq containers of 'struct job'.
- * The comparator sorts by (1) urgency, then (2) jobid.
+ * The comparator sorts by (1) priority, then (2) jobid.
  */
 void job_destructor (void **item);
 void *job_duplicator (const void *item);

--- a/src/modules/job-manager/jobtap-internal.h
+++ b/src/modules/job-manager/jobtap-internal.h
@@ -1,0 +1,62 @@
+/************************************************************\
+ * Copyright 2020 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _FLUX_JOB_MANAGER_JOBTAP_H
+#define _FLUX_JOB_MANAGER_JOBTAP_H
+
+#include "job.h"
+#include "job-manager.h"
+
+typedef struct jobtap_error {
+    char text [128];
+} jobtap_error_t;
+
+struct jobtap * jobtap_create (struct job_manager *ctx);
+
+void jobtap_destroy (struct jobtap *jobtap);
+
+/*  Call the jobtap plugin with topic string `topic`.
+ *   `fmt` is jansson-style pack arguments to add the plugin args
+ */
+int jobtap_call (struct jobtap *jobtap,
+                 struct job *job,
+                 const char *topic,
+                 const char *fmt,
+                 ...);
+
+/*  Jobtap call specific for getting a new priority from the jobtap
+ *   plugin if available. The priority will be returned in `pprio` if
+ *   it was set.
+ */
+int jobtap_get_priority (struct jobtap *jobtap,
+                         struct job *job,
+                         int64_t *pprio);
+
+/*  Load a new jobtap from `path`. Path may start with `builtin.` to
+ *   attempt to load one of the builtin jobtap plugins.
+ */
+int jobtap_load (struct jobtap *jobtap,
+                 const char *path,
+                 jobtap_error_t *errp);
+
+/*  Job manager RPC handler for loading new jobtap plugins.
+ */
+void jobtap_handler (flux_t *h,
+                     flux_msg_handler_t *mh,
+                     const flux_msg_t *msg,
+                     void *arg);
+
+
+#endif /* _FLUX_JOB_MANAGER_JOBTAP_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */
+

--- a/src/modules/job-manager/jobtap-internal.h
+++ b/src/modules/job-manager/jobtap-internal.h
@@ -44,6 +44,7 @@ int jobtap_get_priority (struct jobtap *jobtap,
  */
 int jobtap_load (struct jobtap *jobtap,
                  const char *path,
+                 json_t *conf,
                  jobtap_error_t *errp);
 
 /*  Job manager RPC handler for loading new jobtap plugins.

--- a/src/modules/job-manager/jobtap.c
+++ b/src/modules/job-manager/jobtap.c
@@ -491,6 +491,16 @@ int flux_jobtap_service_register (flux_plugin_t *p,
     return 0;
 }
 
+int flux_jobtap_reprioritize_all (flux_plugin_t *p)
+{
+    struct jobtap *jobtap = flux_plugin_aux_get (p, "flux::jobtap");
+    if (!jobtap) {
+        errno = EINVAL;
+        return -1;
+    }
+    return reprioritize_all (jobtap->ctx);
+}
+
 int flux_jobtap_reprioritize_job (flux_plugin_t *p,
                                   flux_jobid_t id,
                                   unsigned int priority)

--- a/src/modules/job-manager/jobtap.c
+++ b/src/modules/job-manager/jobtap.c
@@ -1,0 +1,524 @@
+/************************************************************\
+ * Copyright 2020 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* jobtap.c - a job manager plugin interface
+ *
+ *  Maintains a list of one or more job manager plugins which
+ *   "tap" into job state transitions and/or events.
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <errno.h>
+#include <unistd.h>
+#include <stdarg.h>
+
+#include <flux/core.h>
+
+#include "annotate.h"
+#include "prioritize.h"
+#include "jobtap.h"
+#include "jobtap-internal.h"
+
+#define FLUX_JOBTAP_PRIORITY_UNAVAIL INT64_C(-2)
+
+struct jobtap {
+    struct job_manager *ctx;
+    flux_plugin_t *plugin;
+    char last_error [128];
+};
+
+struct jobtap *jobtap_create (struct job_manager *ctx)
+{
+    struct jobtap *jobtap = calloc (1, sizeof (*jobtap));
+    if (!jobtap)
+        return NULL;
+    jobtap->ctx = ctx;
+    return jobtap;
+}
+
+void jobtap_destroy (struct jobtap *jobtap)
+{
+    if (jobtap) {
+        jobtap->ctx = NULL;
+        flux_plugin_destroy (jobtap->plugin);
+        free (jobtap);
+    }
+}
+
+static const char *jobtap_plugin_name (flux_plugin_t *p)
+{
+    const char *name;
+    if (!p)
+        return "none";
+    if ((name = flux_plugin_get_name (p)))
+        return name;
+    return "unknown";
+}
+
+static flux_plugin_arg_t *jobtap_args_vcreate (struct jobtap *jobtap,
+                                               struct job *job,
+                                               const char *fmt,
+                                               va_list ap)
+{
+    flux_plugin_arg_t *args = flux_plugin_arg_create ();
+    if (!args)
+        return NULL;
+
+    if (flux_plugin_arg_pack (args,
+                              FLUX_PLUGIN_ARG_IN,
+                              "{s:O s:I s:i s:i s:i s:I s:f}",
+                              "jobspec", job->jobspec_redacted,
+                              "id", job->id,
+                              "userid", job->userid,
+                              "urgency", job->urgency,
+                              "state", job->state,
+                              "priority", job->priority,
+                              "t_submit", job->t_submit) < 0)
+        goto error;
+
+    if (fmt
+        && flux_plugin_arg_vpack (args,
+                                  FLUX_PLUGIN_ARG_IN|FLUX_PLUGIN_ARG_UPDATE,
+                                  fmt, ap) < 0)
+        goto error;
+
+    /*
+     *  Always start with empty OUT args. This allows unpack of OUT
+     *   args to work without error, even if plugin does not set any
+     *   OUT args.
+     */
+    if (flux_plugin_arg_set (args, FLUX_PLUGIN_ARG_OUT, "{}") < 0)
+        goto error;
+
+    return args;
+error:
+    flux_plugin_arg_destroy (args);
+    return NULL;
+}
+
+int jobtap_get_priority (struct jobtap *jobtap,
+                         struct job *job,
+                         int64_t *pprio)
+{
+    int rc = -1;
+    flux_plugin_arg_t *args;
+    va_list ap;
+    int64_t priority = -1;
+
+    if (!jobtap || !job || !pprio) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (!jobtap->plugin) {
+        *pprio = job->urgency;
+        return 0;
+    }
+    /*  N.B.: passing uninitialized ap to args_vcreate, but it should be
+     *   ok, since fmt == NULL, ap will not be used.
+     */
+    if (!(args = jobtap_args_vcreate (jobtap, job, NULL, ap)))
+        return -1;
+    rc = flux_plugin_call (jobtap->plugin, "job.priority.get", args);
+    if (rc == 1) {
+        /*
+         *  A priority.get callback was run. Try to unpack a new priority
+         */
+        if (flux_plugin_arg_unpack (args, FLUX_PLUGIN_ARG_OUT,
+                                    "{s?I}",
+                                    "priority", &priority) < 0) {
+            flux_log (jobtap->ctx->h, LOG_ERR,
+                      "jobtap: %s: job.priority.get: arg_unpack: %s",
+                      jobtap_plugin_name (jobtap->plugin),
+                      flux_plugin_arg_strerror (args));
+            rc = -1;
+        }
+        if (priority == -1) {
+           /*
+            *  A plugin callback was called but didn't provide a
+            *   priority. This could be due to a loaded plugin that is
+            *   not a priority plugin. Therefore take the default action
+            *   and set priority to job->urgency.
+            */
+            priority = job->urgency;
+        }
+        else if (priority == FLUX_JOBTAP_PRIORITY_UNAVAIL) {
+            /*
+             *  Plugin cannot determine priority at this time. Set
+             *   priority to the current job->priority so that a priority
+             *   event is not generated.
+             */
+            priority = job->priority;
+            /*
+             *  A plugin cannot return an "unavailable" priority from the
+             *   priority.get callback for jobs in SCHED state. Log an error
+             *   in this case and make no change to priority.
+             */
+            if (job->state == FLUX_JOB_STATE_SCHED)
+                flux_log (jobtap->ctx->h, LOG_ERR,
+                          "jobtap: %s: %ju: BUG: plugin didn't return priority",
+                          jobtap_plugin_name (jobtap->plugin),
+                          (uintmax_t) job->id);
+        }
+        /*
+         *   O/w, plugin provided a new priority.
+         */
+    }
+    else if (rc == 0) {
+        /*
+         *  No priority.get callback was run. Enable default behavior
+         *   (priority == urgency)
+         */
+        priority = job->urgency;
+    }
+    else {
+        /*
+         *  priority.get callback was run and failed. Log the error
+         *   and return the current priority.
+         */
+        flux_log (jobtap->ctx->h, LOG_ERR,
+                  "jobtap: %s: job.priority.get: callback failed",
+                  jobtap_plugin_name (jobtap->plugin));
+        priority = job->priority;
+    }
+
+    flux_plugin_arg_destroy (args);
+    *pprio = priority;
+    return rc;
+}
+
+int jobtap_call (struct jobtap *jobtap,
+                 struct job *job,
+                 const char *topic,
+                 const char *fmt,
+                 ...)
+{
+    int rc = -1;
+    json_t *note = NULL;
+    flux_plugin_arg_t *args;
+    int64_t priority = -1;
+    va_list ap;
+
+    if (!jobtap->plugin) {
+        /*
+         * Default with no plugin: ensure we advance past PRIORITY state
+         */
+        if (job->state == FLUX_JOB_STATE_PRIORITY
+           && reprioritize_job (jobtap->ctx, job, job->urgency) < 0)
+            flux_log (jobtap->ctx->h, LOG_ERR,
+                      "reprioritize_job: id=%ju: failed",
+                      (uintmax_t) job->id);
+        return 0;
+    }
+
+    va_start (ap, fmt);
+    if (!(args = jobtap_args_vcreate (jobtap, job, fmt, ap))) {
+        flux_log (jobtap->ctx->h, LOG_ERR,
+                  "jobtap: %s: %s: %ju: failed to create plugin args",
+                  jobtap_plugin_name (jobtap->plugin),
+                  topic,
+                  (uintmax_t) job->id);
+    }
+    va_end (ap);
+
+    if (!args)
+        return -1;
+
+    rc = flux_plugin_call (jobtap->plugin, topic, args);
+    if (rc < 0) {
+        flux_log (jobtap->ctx->h, LOG_ERR,
+                  "jobtap: %s: %s: callback returned error",
+                  jobtap_plugin_name (jobtap->plugin),
+                  topic);
+    }
+    if (flux_plugin_arg_unpack (args, FLUX_PLUGIN_ARG_OUT,
+                                "{s?I s?o}",
+                                "priority", &priority,
+                                "annotations", &note) < 0) {
+        flux_log (jobtap->ctx->h, LOG_ERR,
+                  "jobtap: %s: %s: arg_unpack: %s",
+                  jobtap_plugin_name (jobtap->plugin),
+                  topic,
+                  flux_plugin_arg_strerror (args));
+        rc = -1;
+    }
+    if (note != NULL) {
+        /*
+         *  Allow plugins to update annotations. (A failure here will be
+         *   logged but not considered a fatal error)
+         *
+         *  In job.new callback annotations are not published because an
+         *   annotation event published to the journal before the first
+         *   job state event may confuse consumers (i.e. job-info).
+         */
+        int rc;
+        if (strcmp (topic, "job.new") == 0)
+            rc = annotations_update (jobtap->ctx->h, job, note);
+        else
+            rc = annotations_update_and_publish (jobtap->ctx, job, note);
+        if (rc < 0)
+            flux_log_error (jobtap->ctx->h,
+                            "jobtap: %s: %s: %ju: annotations_update",
+                            jobtap_plugin_name (jobtap->plugin),
+                            topic,
+                            (uintmax_t) job->id);
+    }
+    if (priority >= FLUX_JOB_PRIORITY_MIN) {
+        /*
+         *  Reprioritize job if plugin returned a priority.
+         *   Note: reprioritize_job() is a no-op if job is not in
+         *         PRIORITY or SCHED state)
+         */
+        if (reprioritize_job (jobtap->ctx, job, priority) < 0) {
+            flux_log_error (jobtap->ctx->h,
+                            "jobtap: %s: reprioritize_job",
+                            jobtap_plugin_name (jobtap->plugin));
+        }
+    }
+    else if (job->state == FLUX_JOB_STATE_PRIORITY && priority == -1) {
+        /*
+         *  Plugin didn't return a priority value (not even
+         *   FLUX_JOBTAP_PRIORITY_UNAVAIL). Take default action
+         *   to prevent job from being stuck in PRIORITY state when
+         *   a non-priority plugin is loaded.
+         */
+        if (reprioritize_job (jobtap->ctx, job, job->urgency) < 0) {
+            flux_log_error (jobtap->ctx->h,
+                            "jobtap: setting priority to urgency failed");
+        }
+    }
+    /*  else: FLUX_JOBTAP_PRIORITY_UNAVAIL, job cannot yet be assigned a
+     *   priority. This is a fall-through condiition. A job in PRIORITY
+     *   state will stay there until the plugin actively calls
+     *   flux_jobtap_reprioritize_job()
+     */
+    flux_plugin_arg_destroy (args);
+    return rc;
+}
+
+int jobtap_load (struct jobtap *jobtap,
+                 const char *path,
+                 jobtap_error_t *errp)
+{
+    flux_plugin_t *p = NULL;
+
+    if (errp)
+        memset (errp->text, 0, sizeof (errp->text));
+
+    /*  Always unload current plugin before loading next plugin.
+     *  This works around an issue in message dispatch when re-loading
+     *   the same plugin which registers a service endpoint, or
+     *   a different plugin which results in the same service topic
+     *   string. This results in the old plugin's message handler
+     *   being removed from the dispatch hash when the new plugin
+     *   registers its handler, then the *new* plugin's message handler
+     *   is removed from the hash when the old plugin is destroyed.
+     */
+    flux_plugin_destroy (jobtap->plugin);
+    jobtap->plugin = NULL;
+
+    /*  Special "none" value leaves no plugin loaded
+     */
+    if (strcmp (path, "none") == 0)
+        return 0;
+
+    if (!(p = flux_plugin_create ())
+        || flux_plugin_aux_set (p, "flux::jobtap", jobtap, NULL) < 0)
+        goto error;
+    flux_plugin_set_flags (p, FLUX_PLUGIN_RTLD_NOW);
+    if (flux_plugin_load_dso (p, path) < 0)
+        goto error;
+    /*
+     *  A jobtap plugin must set a name, error out if not:
+     */
+    if (strcmp (flux_plugin_get_name (p), path) == 0) {
+        snprintf (errp->text, sizeof (errp->text), "%s",
+                  "Plugin did not set name in flux_plugin_init");
+        goto error;
+    }
+    jobtap->plugin = p;
+    return 0;
+error:
+    if (errp && errp->text[0] == '\0')
+        strncpy (errp->text, flux_plugin_strerror (p), sizeof (errp->text));
+    flux_plugin_destroy (p);
+    return -1;
+}
+
+static void jobtap_handle_load_req (struct job_manager *ctx,
+                                    const flux_msg_t *msg,
+                                    const char *path)
+{
+    char *prev = NULL;
+    jobtap_error_t error;
+    const char *errstr = NULL;
+
+    if (!(prev = strdup (jobtap_plugin_name (ctx->jobtap->plugin))))
+        goto error;
+    if (jobtap_load (ctx->jobtap, path, &error) < 0) {
+        errstr = error.text;
+        goto error;
+    }
+    if (flux_respond_pack (ctx->h,
+                           msg,
+                           "{s:[s] s:[s]}",
+                           "plugins",
+                           jobtap_plugin_name (ctx->jobtap->plugin),
+                           "previous",
+                           prev ? prev : "none") < 0)
+        flux_log_error (ctx->h, "jobtap_handle_load_req: flux_respond");
+    free (prev);
+    return;
+error:
+    free (prev);
+    if (flux_respond_error (ctx->h, msg, errno, errstr) < 0)
+        flux_log_error (ctx->h, "jobtap_handler: flux_respond_error");
+}
+
+static void jobtap_handle_list_req (flux_t *h,
+                                    struct jobtap *jobtap,
+                                    const flux_msg_t *msg)
+{
+    if (flux_respond_pack (h, msg,
+                           "{ s:[s] }",
+                           "plugins",
+                           jobtap_plugin_name (jobtap->plugin)) < 0)
+        flux_log_error (h, "jobtap_handle_list: flux_respond");
+}
+
+void jobtap_handler (flux_t *h,
+                     flux_msg_handler_t *mh,
+                     const flux_msg_t *msg,
+                     void *arg)
+{
+    struct job_manager *ctx = arg;
+    const char *path = NULL;
+    int query_only = 0;
+
+    if (flux_request_unpack (msg,
+                             NULL,
+                             "{s?s s?b}",
+                             "load", &path,
+                             "query_only", &query_only) < 0) {
+        if (flux_respond_error (h, msg, EPROTO, NULL) < 0)
+            flux_log_error (h, "jobtap_handler: flux_respond_error");
+        return;
+    }
+    if (query_only)
+        jobtap_handle_list_req (h, ctx->jobtap, msg);
+    else
+        jobtap_handle_load_req (ctx, msg, path);
+}
+
+flux_t *flux_jobtap_get_flux (flux_plugin_t *p)
+{
+    struct jobtap *jobtap = NULL;
+
+    if (p == NULL
+        || !(jobtap = flux_plugin_aux_get (p, "flux::jobtap"))
+        || !jobtap->ctx) {
+        errno = EINVAL;
+        return NULL;
+    }
+    return jobtap->ctx->h;
+}
+
+static int build_jobtap_topic (flux_plugin_t *p,
+                               const char *method,
+                               char *buf,
+                               int len)
+{
+    const char *name = jobtap_plugin_name (p);
+
+    /*  Plugin name must be set before calling service_register:
+     *  (by default, path loaded plugins have their name set to the path.
+     *   detect that here with strchr())
+     */
+    if (name == NULL || strchr (name, '/')) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (snprintf (buf,
+                  len,
+                  "job-manager.%s%s%s",
+                  name,
+                  method ? "." : "",
+                  method ? method : "") >= len) {
+        errno = EINVAL;
+        return -1;
+    }
+    return 0;
+}
+
+int flux_jobtap_service_register (flux_plugin_t *p,
+                                  const char *method,
+                                  flux_msg_handler_f cb,
+                                  void *arg)
+{
+    struct flux_match match = FLUX_MATCH_REQUEST;
+    flux_msg_handler_t *mh;
+    char topic[1024];
+    flux_t *h;
+
+    if (!(h = flux_jobtap_get_flux (p))
+        || build_jobtap_topic (p, method, topic, sizeof (topic)) < 0)
+        return -1;
+
+    match.topic_glob = topic;
+    if (!(mh = flux_msg_handler_create (h, match, cb, arg)))
+        return -1;
+
+    if (flux_plugin_aux_set (p,
+                             NULL,
+                             mh,
+                             (flux_free_f) flux_msg_handler_destroy) < 0) {
+        flux_msg_handler_destroy (mh);
+        return -1;
+    }
+    flux_msg_handler_start (mh);
+    flux_log (h, LOG_DEBUG, "jobtap plugin %s registered method %s",
+              jobtap_plugin_name (p),
+              topic);
+    return 0;
+}
+
+int flux_jobtap_reprioritize_job (flux_plugin_t *p,
+                                  flux_jobid_t id,
+                                  unsigned int priority)
+{
+    struct jobtap *jobtap = flux_plugin_aux_get (p, "flux::jobtap");
+    if (!jobtap) {
+        errno = EINVAL;
+        return -1;
+    }
+    return reprioritize_id (jobtap->ctx, id, priority);
+}
+
+int flux_jobtap_priority_unavail (flux_plugin_t *p, flux_plugin_arg_t *args)
+{
+    struct jobtap *jobtap = flux_plugin_aux_get (p, "flux::jobtap");
+    if (!jobtap) {
+        errno = EINVAL;
+        return -1;
+    }
+    /* Still todo: check valid state, etc.
+     */
+    return flux_plugin_arg_pack (args,
+                                 FLUX_PLUGIN_ARG_OUT|FLUX_PLUGIN_ARG_UPDATE,
+                                 "{s:I}",
+                                 "priority", FLUX_JOBTAP_PRIORITY_UNAVAIL);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */
+

--- a/src/modules/job-manager/jobtap.h
+++ b/src/modules/job-manager/jobtap.h
@@ -1,0 +1,55 @@
+/************************************************************\
+ * Copyright 2020 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* Flux job-manager "jobtap" plugin interface
+ */
+
+#ifndef FLUX_JOBTAP_H
+#define FLUX_JOBTAP_H
+
+#include <flux/core.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*  Get a copy of the flux_t handle which may then be used to
+ *   set timer, periodic, prep/check/idle watchers, etc.
+ */
+flux_t * flux_jobtap_get_flux (flux_plugin_t *p);
+
+/*  Register a service handler for `method` within the job-manager.
+ *   The service will be 'job-manager.<name>.<method>'
+ */
+int flux_jobtap_service_register (flux_plugin_t *p,
+                                  const char *method,
+                                  flux_msg_handler_f cb,
+                                  void *arg);
+
+/*  Set the priority of job `id` to `priority`. This does nothing
+ *   if the priority isn't changed from the current value or if the
+ *   job is not in the PRIORITY or SCHED states. O/w, a priority event
+ *   is generated, job->priority is updated, and the job may move from
+ *   PRIORITY->SCHED state.
+ */
+int flux_jobtap_reprioritize_job (flux_plugin_t *p,
+                                  flux_jobid_t id,
+                                  unsigned int priority);
+
+/*  Convenience function to return unavailable priority in PRIORITY state
+ */
+int flux_jobtap_priority_unavail (flux_plugin_t *p,
+                                  flux_plugin_arg_t *args);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* !FLUX_JOBTAP_H */

--- a/src/modules/job-manager/jobtap.h
+++ b/src/modules/job-manager/jobtap.h
@@ -33,6 +33,12 @@ int flux_jobtap_service_register (flux_plugin_t *p,
                                   flux_msg_handler_f cb,
                                   void *arg);
 
+/*  Start a loop to re-prioritize all jobs. The plugin "priority.get"
+ *   callback will be called for each job currently in SCHED or
+ *   PRIORITY states.
+ */
+int flux_jobtap_reprioritize_all (flux_plugin_t *p);
+
 /*  Set the priority of job `id` to `priority`. This does nothing
  *   if the priority isn't changed from the current value or if the
  *   job is not in the PRIORITY or SCHED states. O/w, a priority event

--- a/src/modules/job-manager/plugins/default.c
+++ b/src/modules/job-manager/plugins/default.c
@@ -1,0 +1,67 @@
+/************************************************************\
+ * Copyright 2020 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* builtins/priority.c - builtin basic job priority plugin
+ *
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/core.h>
+#include <flux/jobtap.h>
+
+/*  The current implementation of priority.get just copies
+ *   the urgency to the priority.
+ */
+static int priority_cb (flux_plugin_t *p,
+                        const char *topic,
+                        flux_plugin_arg_t *args,
+                        void *data)
+{
+    int urgency = -1;
+    flux_t *h = flux_jobtap_get_flux (p);
+    if (flux_plugin_arg_unpack (args, FLUX_PLUGIN_ARG_IN,
+                                "{s:i}",
+                                "urgency", &urgency) < 0) {
+        flux_log (h, LOG_ERR,
+                 "flux_plugin_arg_unpack: %s",
+                 flux_plugin_arg_strerror (args));
+        return -1;
+    }
+    if (flux_plugin_arg_pack (args, FLUX_PLUGIN_ARG_OUT,
+                             "{s:i}",
+                             "priority", urgency) < 0) {
+        flux_log (h, LOG_ERR,
+                 "flux_plugin_arg_pack: %s",
+                 flux_plugin_arg_strerror (args));
+        return -1;
+    }
+    return 0;
+}
+
+int default_priority_plugin_init (flux_plugin_t *p)
+{
+    if (flux_plugin_add_handler (p,
+                                 "job.state.priority",
+                                 priority_cb,
+                                 NULL) < 0
+        || flux_plugin_add_handler (p,
+                                    "job.priority.get",
+                                    priority_cb,
+                                    NULL) < 0) {
+        return -1;
+    }
+    return 0;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/job-manager/plugins/hold.c
+++ b/src/modules/job-manager/plugins/hold.c
@@ -1,0 +1,37 @@
+/************************************************************\
+ * Copyright 2020 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* builtins/hold.c - builtin plugin that holds all submitted jobs
+ *
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <jansson.h>
+#include <flux/core.h>
+#include <flux/jobtap.h>
+
+/* Always set priority=0 so all jobs are submitted in held state
+ */
+static int hold_cb (flux_plugin_t *p,
+                    const char *topic,
+                    flux_plugin_arg_t *args,
+                    void *arg)
+{
+    flux_plugin_arg_pack (args, FLUX_PLUGIN_ARG_OUT, "{s:I}", "priority", 0LL);
+    return 0;
+}
+
+
+int hold_priority_plugin_init (flux_plugin_t *p)
+{
+    return flux_plugin_add_handler (p, "job.state.priority", hold_cb, NULL);
+}

--- a/src/modules/job-manager/prioritize.c
+++ b/src/modules/job-manager/prioritize.c
@@ -1,0 +1,160 @@
+/************************************************************\
+ * Copyright 2020 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* prioritize - job priority related functions
+ *
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/core.h>
+
+#include "job.h"
+#include "event.h"
+#include "alloc.h"
+#include "job-manager.h"
+#include "prioritize.h"
+
+static int sched_prioritize (flux_t *h, json_t *priorities)
+{
+    flux_future_t *f;
+    if (json_array_size (priorities) == 0) {
+        json_decref (priorities);
+        return 0;
+    }
+    if (!(f = flux_rpc_pack (h,
+                             "sched.prioritize",
+                             FLUX_NODEID_ANY,
+                             FLUX_RPC_NORESPONSE,
+                             "{s:o}",
+                             "jobs", priorities)))
+        return -1;
+    flux_future_destroy (f);
+    return 0;
+}
+
+static int sched_prioritize_one (struct job_manager *ctx, struct job *job)
+{
+    json_t * priorities = json_pack ("[[II]]", job->id, job->priority);
+    if (!priorities) {
+        flux_log (ctx->h, LOG_ERR, "sched_prioritize: json_pack failed");
+        return -1;
+    }
+    if (sched_prioritize (ctx->h, priorities) < 0) {
+        flux_log_error (ctx->h, "rpc: sched.priority: id=%ju", job->id);
+        json_decref (priorities);
+        return -1;
+    }
+    return 0;
+}
+
+static int reprioritize_one (struct job_manager *ctx,
+                             struct job *job,
+                             int64_t priority,
+                             bool oneshot)
+{
+    int flags = 0;
+
+    /*  Urgency values that specify "hold" and "expedite" override
+     *   requested priority:
+     */
+    if (job->urgency == FLUX_JOB_URGENCY_HOLD)
+        priority = FLUX_JOB_PRIORITY_MIN;
+    else if (job->urgency == FLUX_JOB_URGENCY_EXPEDITE)
+        priority = FLUX_JOB_PRIORITY_MAX;
+
+    /*  If priority did not change, then do not post a priority
+     *   event, reorder queues, etc. (a change of priority to the
+     *   current value is not an "event")
+     */
+    if (priority == job->priority)
+        return 0;
+
+    /*  Priority event is only posted to job eventlog in
+     *   PRIORITY state, or transition of priority away from
+     *   MIN (held) or MAX (expedited).
+     */
+    /*  XXX: Disable for now, tests assume all priority updates
+     *       go to KVS eventlog
+    if (!(job->flags & FLUX_JOB_DEBUG)
+        && job->state != FLUX_JOB_STATE_PRIORITY
+        && job->priority != FLUX_JOB_PRIORITY_MIN
+        && job->priority != FLUX_JOB_PRIORITY_MAX)
+        flags = EVENT_JOURNAL_ONLY;
+     */
+
+    /*  Post 'priority' event.
+     *
+     *  This call will result in job->priority being set, and,
+     *   if the job is in the PRIORITY state, will transition to
+     *   the SCHED state, invoke plugin callbacks, etc.
+     */
+    if (event_job_post_pack (ctx->event, job,
+                             "priority",
+                             flags,
+                             "{s:I}",
+                             "priority", priority) < 0)
+        return -1;
+
+    /*  Update alloc queues, cancel outstanding alloc requests for
+     *   newly "held" jobs, and if in "oneshot" mode, notify scheduler
+     *   of priority change
+     */
+    if (job->alloc_queued && oneshot) {
+        alloc_queue_reorder (ctx->alloc, job);
+        if (alloc_queue_recalc_pending (ctx->alloc) < 0)
+            return -1;
+    }
+    else if (job->alloc_pending) {
+        if (job->priority == FLUX_JOB_PRIORITY_MIN) {
+            if (alloc_cancel_alloc_request (ctx->alloc, job) < 0)
+                return -1;
+        }
+        else if (oneshot) {
+            if (sched_prioritize_one (ctx, job) < 0)
+                return -1;
+        }
+    }
+    return 0;
+}
+
+int reprioritize_job (struct job_manager *ctx,
+                      struct job *job,
+                      int64_t priority)
+{
+    if (!job) {
+        errno = EINVAL;
+        return -1;
+    }
+    /*  For convenience, do not return an error if a job is not in
+     *   a "prioritizable" state (PRIORITY || SCHED). Just do nothing.
+     */
+    if (job->state != FLUX_JOB_STATE_PRIORITY
+        && job->state != FLUX_JOB_STATE_SCHED)
+        return 0;
+    return reprioritize_one (ctx, job, priority, true);
+}
+
+int reprioritize_id (struct job_manager *ctx,
+                     flux_jobid_t id,
+                     int64_t priority)
+{
+    struct job *job = zhashx_lookup (ctx->active_jobs, &id);
+    if (!job) {
+        errno = ENOENT;
+        return -1;
+    }
+    return reprioritize_job (ctx, job, priority);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/job-manager/prioritize.c
+++ b/src/modules/job-manager/prioritize.c
@@ -172,7 +172,7 @@ int reprioritize_all (struct job_manager *ctx)
     for (job = zhashx_first (ctx->active_jobs); job;
          job = zhashx_next (ctx->active_jobs)) {
         /*
-         *  Only proess jobs between PRIORITY and SCHED states:
+         *  Only process jobs between PRIORITY and SCHED states:
          */
         if (job->state != FLUX_JOB_STATE_PRIORITY
             && job->state != FLUX_JOB_STATE_SCHED)

--- a/src/modules/job-manager/prioritize.h
+++ b/src/modules/job-manager/prioritize.h
@@ -14,6 +14,13 @@
 #include <flux/core.h>
 #include "job-manager.h"
 
+/*  Request that all jobs be reprioritized. This involves calling the
+ *   job.priority.get plugin callback for all jobs, and sending the
+ *   sched.prioritize RPC to update the scheduler with any job
+ *   priorities which have changed.
+ */
+int reprioritize_all (struct job_manager *ctx);
+
 /*  Request reprioritization of a single job
  */
 int reprioritize_job (struct job_manager *ctx,

--- a/src/modules/job-manager/prioritize.h
+++ b/src/modules/job-manager/prioritize.h
@@ -1,0 +1,31 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _FLUX_JOB_MANAGER_PRIORITIZE_H
+#define _FLUX_JOB_MANAGER_PRIORITIZE_H
+
+#include <flux/core.h>
+#include "job-manager.h"
+
+/*  Request reprioritization of a single job
+ */
+int reprioritize_job (struct job_manager *ctx,
+                      struct job *job,
+                      int64_t priority);
+
+int reprioritize_id (struct job_manager *ctx,
+                     flux_jobid_t id,
+                     int64_t priority);
+
+#endif /* ! _FLUX_JOB_MANAGER_PRIORITIZE_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/job-manager/restart.c
+++ b/src/modules/job-manager/restart.c
@@ -24,6 +24,7 @@
 #include "restart.h"
 #include "event.h"
 #include "wait.h"
+#include "jobtap-internal.h"
 
 /* restart_map callback should return -1 on error to stop map with error,
  * or 0 on success.  'job' is only valid for the duration of the callback.
@@ -220,6 +221,21 @@ int restart_from_kvs (struct job_manager *ctx)
      */
     job = zhashx_first (ctx->active_jobs);
     while (job) {
+        /*
+         *  On restart, call 'job.new' plugin callbacks since this is
+         *   the first time this instance of the job-manager has seen
+         *   this job. Be sure to call this before posting any other
+         *   events below, since job.new should always be the first
+         *   callback for a job.
+         *
+         *  Jobs in SCHED state may also immediately transition back to
+         *   PRIORITY, potentially generating two other plugin callbacks
+         *   after this one. (job.priority, job.sched...)
+         */
+        if (jobtap_call (ctx->jobtap, job, "job.new", NULL) < 0)
+            flux_log_error (ctx->h, "jobtap_call (id=%ju, new)",
+                                (uintmax_t) job->id);
+
         if (job->state == FLUX_JOB_STATE_SCHED) {
             /*
              * This is confusing. In order to update priority on transition

--- a/src/modules/job-manager/restart.c
+++ b/src/modules/job-manager/restart.c
@@ -221,6 +221,14 @@ int restart_from_kvs (struct job_manager *ctx)
     job = zhashx_first (ctx->active_jobs);
     while (job) {
         if (job->state == FLUX_JOB_STATE_SCHED) {
+            /*
+             * This is confusing. In order to update priority on transition
+             *  back to PRIORITY state, the priority must be reset to "-1",
+             *  even though the last priority value was reconstructed from
+             *  the eventlog. This is becuase the transitioning "priority"
+             *  event is only posted when the priority changes.
+             */
+            job->priority = -1;
             if (event_job_post_pack (ctx->event,
                                      job,
                                      "flux-restart",

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -115,6 +115,7 @@ TESTSCRIPTS = \
 	t2213-job-manager-hold-single.t \
 	t2214-job-manager-hold-unlimited.t \
 	t2215-job-manager-priority-order-unlimited.t \
+	t2216-job-manager-plugins.t \
 	t2230-job-info-list.t \
 	t2231-job-info-lookup.t \
 	t2232-job-info-eventlog-watch.t \
@@ -324,7 +325,11 @@ check_LTLIBRARIES = \
 	shell/plugins/getopt.la \
 	shell/plugins/setopt.la \
 	shell/plugins/log.la \
-	shell/plugins/test-event.la
+	shell/plugins/test-event.la \
+	job-manager/plugins/priority-wait.la \
+	job-manager/plugins/args.la \
+	job-manager/plugins/test.la \
+	job-manager/plugins/random.la
 
 check-prep:
 	$(MAKE) $(check_PROGRAMS) $(check_LTLIBRARIES)
@@ -623,6 +628,45 @@ shell_plugins_test_event_la_CPPFLAGS = $(test_cppflags)
 shell_plugins_test_event_la_LDFLAGS = -module -rpath /nowhere
 shell_plugins_test_event_la_LIBADD = \
 	$(top_builddir)/src/common/libflux-core.la
+
+job_manager_plugins_priority_wait_la_SOURCES = \
+	job-manager/plugins/priority-wait.c
+job_manager_plugins_priority_wait_la_CPPFLAGS = \
+	$(test_cppflags)
+job_manager_plugins_priority_wait_la_LDFLAGS = \
+	-module -rpath /nowhere
+job_manager_plugins_priority_wait_la_LIBADD = \
+	$(top_builddir)/src/common/libflux-core.la
+
+job_manager_plugins_args_la_SOURCES = \
+	job-manager/plugins/args.c
+job_manager_plugins_args_la_CPPFLAGS = \
+	$(test_cppflags)
+job_manager_plugins_args_la_LDFLAGS = \
+	-module -rpath /nowhere
+job_manager_plugins_args_la_LIBADD = \
+	$(top_builddir)/src/common/libflux-core.la
+
+job_manager_plugins_test_la_SOURCES = \
+	job-manager/plugins/test.c
+job_manager_plugins_test_la_CPPFLAGS = \
+	$(test_cppflags)
+job_manager_plugins_test_la_LDFLAGS = \
+	-module -rpath /nowhere
+job_manager_plugins_test_la_LIBADD = \
+	$(top_builddir)/src/common/libflux-core.la
+
+job_manager_plugins_random_la_SOURCES = \
+	job-manager/plugins/random.c
+job_manager_plugins_random_la_CPPFLAGS = \
+	$(test_cppflags)
+job_manager_plugins_random_la_LDFLAGS = \
+	-module -rpath /nowhere
+job_manager_plugins_random_la_LIBADD = \
+	$(top_builddir)/src/common/libflux-core.la
+
+
+
 
 hwloc_hwloc_convert_SOURCES = hwloc/hwloc-convert.c
 hwloc_hwloc_convert_CPPFLAGS = $(HWLOC_CFLAGS) $(test_cppflags)

--- a/t/job-manager/plugins/args.c
+++ b/t/job-manager/plugins/args.c
@@ -1,0 +1,84 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* args.c - test job-manager jobtap plugin callback for expected args
+ */
+
+#include <jansson.h>
+
+#include <flux/core.h>
+#include <flux/jobtap.h>
+
+static int cb (flux_plugin_t *p,
+               const char *topic,
+               flux_plugin_arg_t *args,
+               void *arg)
+{
+    json_t *resources = NULL;
+    json_t *entry = NULL;
+    flux_jobid_t id = FLUX_JOBID_ANY;
+    uint32_t userid = (uint32_t) -1;
+    int urgency = -1;
+    unsigned int priority = 1234;
+    flux_job_state_t state = 4096;
+    flux_job_state_t prev_state = 4096;
+    double t_submit = 0.0;
+    flux_t *h = flux_jobtap_get_flux (p);
+
+    if (flux_plugin_arg_unpack (args, FLUX_PLUGIN_ARG_IN,
+                                "{s:{s:o} s?o s:I s:i s:i s:i s:i s?i s:f}",
+                                "jobspec", "resources", &resources,
+                                 "entry", &entry,
+                                "id", &id,
+                                "userid", &userid,
+                                "urgency", &urgency,
+                                "priority", &priority,
+                                "state", &state,
+                                "prev_state", &prev_state,
+                                "t_submit", &t_submit) < 0) {
+        flux_log (h,
+                  LOG_ERR,
+                  "flux_plugin_arg_unpack: %s",
+                  flux_plugin_arg_strerror (args));
+        return -1;
+    }
+
+    if (strncmp (topic, "job.state.", 10) == 0) {
+        if (entry == NULL
+            || state == 4096
+            || prev_state == 4096) {
+            flux_log (h,
+                      LOG_ERR,
+                      "%s: entry=%p state=%d prev_state=%d",
+                       topic, entry, state, prev_state);
+            return -1;
+        }
+    }
+    if (resources == NULL
+        || id == FLUX_JOBID_ANY
+        || userid == (uint32_t) -1
+        || urgency == -1
+        || priority == 1234
+        || t_submit == 0.0) {
+        flux_log (h,
+                  LOG_ERR,
+                  "%s: res=%p id=%ju uid=%d  urg=%d, pri=%d, t_submit=%f",
+                  topic, resources, id, userid, urgency, priority, t_submit);
+        return -1;
+    }
+    flux_log (h, LOG_INFO, "args-check: %s: OK", topic);
+    return 0;
+}
+
+int flux_plugin_init (flux_plugin_t *p)
+{
+    flux_plugin_set_name (p, "args");
+    return flux_plugin_add_handler (p, "job.*", cb, NULL);
+}

--- a/t/job-manager/plugins/priority-wait.c
+++ b/t/job-manager/plugins/priority-wait.c
@@ -1,0 +1,69 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* priority-wait.c - keep jobs in priority state and wait for
+ *  an RPC to assign priority.
+ */
+
+#include <flux/core.h>
+#include <flux/jobtap.h>
+
+
+static void release_cb (flux_t *h,
+                        flux_msg_handler_t *mh,
+                        const flux_msg_t *msg,
+                        void *arg)
+{
+    flux_jobid_t id;
+    int64_t priority = -1;
+    flux_plugin_t *p = arg;
+
+    if (flux_request_unpack (msg, NULL,
+                             "{s:I s:I}",
+                             "id", &id,
+                             "priority", &priority) < 0) {
+        flux_log_error (h, "failed to unpack priority-wait.release msg");
+        goto error;
+    }
+    if (priority < FLUX_JOB_PRIORITY_MIN
+        || priority > FLUX_JOB_PRIORITY_MAX) {
+        errno = EINVAL;
+        goto error;
+    }
+    if (flux_jobtap_reprioritize_job (p, id, (unsigned int) priority) < 0)
+        goto error;
+    if (flux_respond (h, msg, NULL) < 0)
+        flux_log_error (h, "flux_respond");
+    return;
+error:
+    flux_respond_error (h, msg, errno, flux_msg_last_error (msg));
+}
+
+static int priority_cb (flux_plugin_t *p,
+                        const char *topic,
+                        flux_plugin_arg_t *args,
+                        void *arg)
+{
+    return flux_jobtap_priority_unavail (p, args);
+}
+
+static const struct flux_plugin_handler tab[] = {
+    { "job.state.priority", priority_cb, NULL },
+    { "job.priority.get", priority_cb, NULL },
+    { 0 },
+};
+
+int flux_plugin_init (flux_plugin_t *p)
+{
+    if (flux_plugin_register (p, "priority-wait", tab) < 0
+        || flux_jobtap_service_register (p, "release", release_cb, p) < 0)
+        return -1;
+    return 0;
+}

--- a/t/job-manager/plugins/random.c
+++ b/t/job-manager/plugins/random.c
@@ -1,0 +1,88 @@
+/************************************************************\
+ * Copyright 2020 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* builtins/random.c - test plugin that randomizes priority every
+ *  second.
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdlib.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <flux/core.h>
+#include <flux/jobtap.h>
+
+static int priority_cb (flux_plugin_t *p,
+                        const char *topic,
+                        flux_plugin_arg_t *args,
+                        void *data)
+{
+    int64_t priority = lrand48 ();
+    if (flux_plugin_arg_pack (args, FLUX_PLUGIN_ARG_OUT,
+                              "{s:I}",
+                              "priority", priority) < 0) {
+        flux_t *h = flux_jobtap_get_flux (p);
+        flux_log (h, LOG_ERR,
+                 "flux_plugin_arg_pack: %s",
+                 flux_plugin_arg_strerror (args));
+        return -1;
+    }
+    return 0;
+}
+
+static void reprioritize (flux_reactor_t *r,
+                          flux_watcher_t *w,
+                          int revents,
+                          void *arg)
+{
+    flux_jobtap_reprioritize_all (arg);
+}
+
+int flux_plugin_init (flux_plugin_t *p)
+{
+    flux_reactor_t *r;
+    flux_watcher_t *tw;
+    flux_t *h = flux_jobtap_get_flux (p);
+
+    if (flux_plugin_set_name (p, "random") < 0)
+        return -1;
+
+    if (!h
+        || !(r = flux_get_reactor (h))
+        || !(tw = flux_timer_watcher_create (r, 1., 1., reprioritize, p)))
+        return -1;
+
+    srand48 (getpid());
+    flux_watcher_start (tw);
+
+    /* Auto-destroy timer watcher on plugin exit:
+     */
+    flux_plugin_aux_set (p, NULL, tw, (flux_free_f) flux_watcher_destroy);
+
+    if (flux_plugin_add_handler (p,
+                                 "job.state.priority",
+                                 priority_cb,
+                                 NULL) < 0
+        || flux_plugin_add_handler (p,
+                                    "job.priority.get",
+                                    priority_cb,
+                                    NULL) < 0) {
+        return -1;
+    }
+    return 0;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/t/job-manager/plugins/test.c
+++ b/t/job-manager/plugins/test.c
@@ -1,0 +1,120 @@
+#include <stdio.h>
+#include <jansson.h>
+
+#include <flux/core.h>
+#include <flux/jobtap.h>
+
+static int cb (flux_plugin_t *p,
+               const char *topic,
+               flux_plugin_arg_t *args,
+               void *arg)
+{
+    const char *test_mode;
+    flux_t *h = flux_jobtap_get_flux (p);
+
+    /*  Get test-mode argument from jobspec
+     */
+    if (flux_plugin_arg_unpack (args, FLUX_PLUGIN_ARG_IN,
+                                "{s:{s:{s:{s:{s:s}}}}}",
+                                "jobspec",
+                                 "attributes",
+                                  "system",
+                                   "jobtap",
+                                    "test-mode", &test_mode) < 0) {
+        flux_log (h, LOG_ERR,
+                  "test: flux_plugin_arg_unpack: %s",
+                  flux_plugin_arg_strerror (args));
+        return -1;
+    }
+
+    /*  Update annotations with the test mode:
+     */
+    if (flux_plugin_arg_pack (args,
+                              FLUX_PLUGIN_ARG_OUT,
+                              "{s:{s:s}}",
+                              "annotations",
+                              "test", test_mode) < 0)
+        flux_log (h, LOG_ERR,
+                  "arg_pack: %s",
+                  flux_plugin_arg_strerror (args));
+
+    if (strcmp (topic, "job.state.priority") == 0) {
+        if (strcmp (test_mode, "priority unset") == 0)
+            return 0;
+        if (strcmp (test_mode, "callback error") == 0)
+            return -1;
+        if (strcmp (test_mode, "annotations error") == 0) {
+            if (flux_plugin_arg_pack (args,
+                                      FLUX_PLUGIN_ARG_OUT,
+                                      "{s:s}",
+                                      "annotations", "test") < 0)
+                flux_log (h, LOG_ERR,
+                          "arg_pack: %s",
+                          flux_plugin_arg_strerror (args));
+            return 0;
+        }
+        if (strcmp (test_mode, "priority type error") == 0) {
+            flux_plugin_arg_pack (args,
+                                  FLUX_PLUGIN_ARG_OUT|FLUX_PLUGIN_ARG_UPDATE,
+                                  "{s:s}",
+                                  "priority", "foo");
+        }
+    }
+    else if (strcmp (topic, "job.state.sched") == 0) {
+        if (strcmp (test_mode, "sched: priority unavail") == 0)
+            return flux_jobtap_priority_unavail (p, args);
+        if (strcmp (test_mode, "sched: callback error") == 0)
+            return -1;
+        if (strcmp (test_mode, "sched: update priority") == 0) {
+            flux_plugin_arg_pack (args,
+                                  FLUX_PLUGIN_ARG_OUT|FLUX_PLUGIN_ARG_UPDATE,
+                                  "{s:i}",
+                                  "priority", 42);
+        }
+    }
+    else if (strcmp (topic, "job.priority.get") == 0) {
+        if (strcmp (test_mode, "priority.get: fail") == 0)
+            return -1;
+        if (strcmp (test_mode, "priority.get: unavail") == 0)
+            return flux_jobtap_priority_unavail (p, args);
+        if (strcmp (test_mode, "priority.get: bad arg") == 0) {
+            flux_plugin_arg_pack (args,
+                                  FLUX_PLUGIN_ARG_OUT|FLUX_PLUGIN_ARG_UPDATE,
+                                  "{s:s}",
+                                  "priority", "foo");
+        }
+    }
+    return 0;
+}
+
+static void reprioritize_cb (flux_t *h, flux_msg_handler_t *mh,
+                             const flux_msg_t *msg,
+                             void *arg)
+{
+    flux_plugin_t *p = arg;
+    flux_log (h, LOG_INFO, "jobtap.test: reprioritizing all jobs");
+    if (flux_jobtap_reprioritize_all (p) < 0)
+        flux_log_error (h, "reprioritize");
+    flux_log (h, LOG_INFO, "jobtap.test: reprioritizing all jobs complete");
+    if (flux_respond (h, msg, "{}") < 0)
+        flux_log_error (h, "flux_respond");
+}
+
+int flux_plugin_init (flux_plugin_t *p)
+{
+    flux_t *h = flux_jobtap_get_flux (p);
+    flux_plugin_set_name (p, "test");
+
+    /*  Print config if we got one */
+    flux_log (h, LOG_INFO, "jobtap.test: conf=%s", flux_plugin_get_conf (p));
+
+    /*  Allow reprioritization of all jobs via an RPC:
+     */
+    if (flux_jobtap_service_register (p,
+                                      "reprioritize",
+                                      reprioritize_cb, p) < 0) {
+        flux_log_error (h, "jobtap_service_register");
+        return -1;
+    }
+    return flux_plugin_add_handler (p, "job.*", cb, NULL);
+}

--- a/t/t2216-job-manager-plugins.t
+++ b/t/t2216-job-manager-plugins.t
@@ -1,0 +1,212 @@
+#!/bin/sh
+
+test_description='Test job manager jobtap plugin interface'
+
+. `dirname $0`/job-manager/sched-helper.sh
+
+. $(dirname $0)/sharness.sh
+
+test_under_flux 4 job
+
+flux setattr log-stderr-level 1
+
+id_byname() {
+	flux jobs -ano {name}:{id} | grep ^$1: | head -1 | cut -d: -f2
+}
+
+test_expect_success 'job-manager: builtin module loaded by default' '
+	flux jobtap list > list.out &&
+	test_debug "cat list.out" &&
+	grep "builtin.priority.default" list.out
+'
+test_expect_success 'job-manager: attempt to load invalid plugin fails' '
+	test_must_fail flux jobtap load builtin.foo &&
+	flux jobtap list >list2.out &&
+	test_debug "cat list2.out" &&
+	grep "none" list2.out &&
+	flux jobtap load builtin.priority.default
+'
+test_expect_success 'job-manager: load with invalid conf fails' '
+	cat <<-EOF >badconf.py &&
+	import flux
+	h = flux.Flux()
+	print(h.rpc("job-manager.jobtap", {"load": "none", "conf": 1}).get())
+	EOF
+	test_must_fail flux python badconf.py
+'
+test_expect_success 'job-manager: default plugin sets priority to urgency' '
+	jobid=$(flux mini submit --urgency=8 hostname) &&
+	flux job wait-event -v $jobid priority &&
+	test $(flux jobs -no {priority} $jobid) = 8
+'
+test_expect_success 'job-manager: default plugin works with sched.prioritize' '
+	ncores=$(flux resource list -s free -no {ncores}) &&
+	allcores=$(flux mini submit -n ${ncores} sleep 1000) &&
+	flux mini submit --cc=1-2 --flags=debug hostname >prio.jobids &&
+	job1=$(cat prio.jobids | head -1) &&
+	job3=$(cat prio.jobids | tail -1) &&
+	flux job wait-event -v $job1 debug.alloc-request &&
+	test_debug "echo updating urgency of top queued job" &&
+	flux job urgency $job1 17 &&
+	flux job wait-event -v $job1 priority &&
+	test_debug "echo updating urgency of last queued job" &&
+	flux job urgency $job3 18 &&
+	flux job wait-event -v $job3 debug.alloc-request &&
+	test_debug "echo cleanup" &&
+	flux job cancelall -f &&
+	flux queue drain
+'
+test_expect_success 'job-manager: no plugin acts the same as default' '
+	flux jobtap load none &&
+	flux queue stop &&
+	jobid=$(flux mini submit --urgency=22 hostname) &&
+	flux job wait-event -v $jobid priority &&
+	test $(flux jobs -no {priority} $jobid) = 22 &&
+	flux job urgency $jobid 7 &&
+	flux job wait-event --count=2 -v $jobid priority &&
+	test $(flux jobs -no {priority} $jobid) = 7 &&
+	flux queue start &&
+	flux job wait-event $jobid clean
+'
+test_expect_success HAVE_JQ 'job-manager: builtin hold plugin holds jobs' '
+	flux jobtap load builtin.priority.hold &&
+	flux mini bulksubmit --job-name=cc-{0} hostname ::: $(seq 1 4) \
+	    >hold.jobids &&
+	flux job wait-event -v $(cat hold.jobids | tail -1) priority &&
+	for id in $(cat hold.jobids); do
+	    test_debug "echo waiting for job ${id} priority event" &&
+	    flux job wait-event -f json ${id} priority | \
+	        jq -e ".context.priority == 0"
+	done
+'
+test_expect_success 'job-manager: job is released when urgency set' '
+	jobid=$(id_byname cc-1) &&
+	test_debug "echo jobid=${jobid}" &&
+	state=$(flux jobs -no {state} $jobid) &&
+	test_debug "echo state is ${state}" &&
+	test "$state" = "SCHED" &&
+	flux job urgency $jobid 1 &&
+	flux job wait-event -v -t 5 $jobid clean
+'
+test_expect_success 'job-manager: cancel of held job works' '
+	jobid=$(id_byname cc-2) &&
+	flux job cancel $jobid &&
+	flux job wait-event -v -t 5 $jobid clean
+'
+test_expect_success 'job-manager: add administrative hold to one job' '
+	jobid=$(id_byname cc-3) &&
+	flux job urgency $jobid 0 &&
+	state=$(flux jobs -no {state} $jobid) &&
+	test_debug "echo state is ${state}" &&
+	test "$state" = "SCHED"
+'
+test_expect_success 'job-manager: held jobs get a priority on plugin load' '
+	flux jobtap load builtin.priority.default &&
+	jobid=$(id_byname cc-4) &&
+	flux job wait-event -v -t 5 $jobid clean
+'
+test_expect_success 'job-manager: but adminstratively held job is still held' '
+	jobid=$(id_byname cc-3) &&
+	state=$(flux jobs -no {state} $jobid) &&
+	priority=$(flux jobs -no {priority} $jobid) &&
+	urgency=$(flux jobs -no {urgency} $jobid) &&
+	test_debug "echo state=${state} pri=${priority} urgency=${urgency}" &&
+	test "$state" = "SCHED" &&
+	test $priority = 0 &&
+	test $urgency  = 0
+'
+test_expect_success 'job-manager: release final held job' '
+	jobid=$(id_byname cc-3) &&
+	flux job urgency $jobid 1 &&
+	flux job wait-event -v $jobid clean
+'
+PLUGINPATH=${FLUX_BUILD_DIR}/t/job-manager/plugins/.libs
+test_expect_success 'job-manager: test with random priority plugin' '
+	flux module reload sched-simple unlimited &&
+	ncores=$(flux resource list -s free -no {ncores}) &&
+	sleepjob=$(flux mini submit -n ${ncores} sleep 3000) &&
+	flux jobtap load ${PLUGINPATH}/random.so &&
+	flux mini bulksubmit --flags waitable --job-name=random-{} hostname \
+	    ::: $(seq 1 4) &&
+	flux jobs -c4 -no {name}:{priority} | sort > pri-before.out &&
+	sleep 1 &&
+	flux jobs -c4 -no {name}:{priority} | sort > pri-after.out &&
+	test_must_fail test_cmp pri-before.out pri-after.out &&
+	flux job cancel $sleepjob &&
+	flux job wait --all -v
+'
+test_expect_success 'job-manager: run args test plugin' '
+	flux jobtap load ${PLUGINPATH}/args.so &&
+	flux mini run hostname &&
+	flux dmesg | grep args-check > args-check.log &&
+	test_debug "cat args-check.log" &&
+	test $(grep -c OK args-check.log) = 7
+'
+test_expect_success 'job-manager: load test jobtap plugin' '
+	flux jobtap load ${PLUGINPATH}/test.so foo.test=1 &&
+	flux dmesg | grep "conf={\"foo\":{\"test\":1}}"
+'
+test_expect_success 'job-manager: run all test plugin test modes' '
+	cat <<-EOF | sort >test-modes.txt &&
+	priority unset
+	callback error
+	priority type error
+	sched: priority unavail
+	sched: update priority
+	annotations error
+	EOF
+	COUNT=$(cat test-modes.txt | wc -l) &&
+	run_timeout 20 \
+	  flux mini bulksubmit -q --watch \
+	    --setattr=system.jobtap.test-mode={} \
+	    hostname :::: test-modes.txt >test-plugin.out &&
+	test_debug "cat test-plugin.out" &&
+	test $COUNT = $(cat test-plugin.out | wc -l) &&
+	flux jobs -ac $COUNT -no {annotations.test} | \
+	    sort >test-annotations.out &&
+	test_cmp test-modes.txt test-annotations.out
+'
+test_expect_success 'job-manager: run test plugin modes for priority.get' '
+	cat <<-EOF | sort >test-modes.priority.get &&
+	priority.get: fail
+	priority.get: unavail
+	priority.get: bad arg
+	EOF
+	cat <<-EOT >reprioritize.py &&
+	import flux
+	flux.Flux().rpc("job-manager.test.reprioritize", {}).get()
+	EOT
+	COUNT=$(cat test-modes.priority.get|wc -l) &&
+	flux queue stop &&
+	flux mini bulksubmit \
+	    --flags waitable --setattr=system.jobtap.test-mode={} hostname \
+	    :::: test-modes.priority.get > priority.get.jobids &&
+	flux python ./reprioritize.py &&
+	flux queue start &&
+	test_debug "flux dmesg | grep jobtap\.test" &&
+	run_timeout 20 flux job wait -v --all
+'
+test_expect_success 'job-manager: plugin can keep job in PRIORITY state' '
+	flux jobtap load ${PLUGINPATH}/priority-wait.so &&
+	jobid=$(flux mini submit hostname) &&
+	flux job wait-event -vt 5 $jobid depend &&
+	test $(flux jobs -no {state} $jobid) = "PRIORITY"
+'
+test_expect_success 'job-manager: job exits PRIORITY when priority is set' '
+	jobid=$(flux jobs -nc 1 -o {id}) &&
+	cat <<-EOF >pri-set.py &&
+	import flux
+	from flux.job import JobID
+	import sys
+
+	jobid = flux.job.JobID(sys.argv[1])
+	priority = int(sys.argv[2])
+	topic = "job-manager.priority-wait.release"
+	print(flux.Flux().rpc(topic, {"id": jobid, "priority": priority}).get())
+	EOF
+	flux python pri-set.py $jobid 42000 &&
+	flux job wait-event -vt 5 $jobid clean &&
+	flux jobs -no {priority} $jobid &&
+	test $(flux jobs -no {priority} $jobid) = 42000
+'
+test_done


### PR DESCRIPTION
This is an early prototype of a job manager plugin implementation which could support priority plugins.

There is still a lot of work to do here, including some commit refactoring and implementation of plugin configuration, but I'm posting the work in progress to get feedback on the *interface* itself, in case this is headed in the wrong direction.

#### Abstract

A plugin system for job manager is introduced which uses the standard Flux plugin `flux_plugin_t`. Plugins can register for callbacks to get notified about new jobs (on submission or job manager restart) or any other state transitions, along with a special `priority.set` callback which indicates the job manager is offering to let the plugin calculate a job priority.

Job information is passed to the plugins via the `flux_plugin_arg_t` arguments, reducing the actual exported plugin interface to a minimum.

A plugin can return a special value from the PRIORITY state callback which indicates a priority cannot be calculated immediately. Jobs will stay in the PRIORITY state until the plugin explicitly sets a priority.

An interface to request reprioritization of all jobs is introduced. This causes the `priority.set` callback to be called for all jobs in the PRIORITY and SCHED state.

Plugins have access to the job manager Flux handle and a method to create an RPC endpoint under `job-manager.`, which should allow advanced priority plugins to accomplish asynchronous work to keep internal state up-to-date.

#### Description

This PR introduces a new job manager plugin interface which allows plugins to tap into all job state transitions, as well as optionally provide a priority when the job manager needs to calculate one. Job manager plugins are called "jobtap" plugins to avoid long names in interfaces (like `flux_job_manager_plugin_*`).

The prototype is built using the Flux `flux_plugin_t` standard plugin interface, so a conforming plugin need only define the single entrypoint symbol:
```c 
    int flux_plugin_init (flux_plugin_t *p);
```
from which a plugin can register callbacks based on a topic string glob (this should be familiar to users of job shell plugins), e.g.
```c
     flux_plugin_add_handler (p, "*", cb, NULL);
```
would register callback `cb()` for all possible plugin callback topics.

The possible set of callback topics currently include:

 - `job.new`: the job manager is seeing a job for the first time. This correspoonds to jobs either submitted or being reloaded from from the KVS. In the `job.new` callback, the job state must be explicitly checked (though it is definitely not state NEW, since the job manager does not handle jobs in this state).
 - `job.<state>`: on transition to job state `state`. Note, this will not include all job states. Due to architecture of the job manager the first state plugins will see after `job.new` is `job.priority`.
 - `priority.set`: when the job manager wants to recalculate priority of a job.

Instead of using a scheme where an opaque `job_manager_job_t` type is exposed with accessors for data about the job for which callbacks apply, this prototype instead packs all possible job information into the `flux_plugin_arg_t` passed to the plugin, which allows the plugin to unpack only the necessary data, while also allowing for future flexibility. That is the args are packed as:
```c
         flux_plugin_arg_pack (args,
                              FLUX_PLUGIN_ARG_IN,
                              "{s:O s:I s:i s:i s:i s:I s:f}",
                              "jobspec", job->jobspec_redacted,
                              "id", job->id,
                              "userid", job->userid,
                              "urgency", job->urgency,
                              "state", job->state,
                              "priority", job->priority,
                              "t_submit", job->t_submit);
```
The `jobtap_call()` interface (internal to the job manager) also allows arbitrary other arguments to be passed to the plugin (currently the event that caused the state transition is passed, though I'm not sure there's a use case for it).

One benefit of this approach is that a plugin can unpack just the resources section of the jobspec, e.g.
```c
    flux_plugin_arg_unpack (args, FLUX_PLUGIN_ARG_IN,
                            "{s:{s:o}",
                            "jobspec", "resources", &resources);
```
Plugins may also _modify_ the jobspec as well, which could be useful in some advanced use cases I've seen mentioned recently.

The two most important callback topics for a job priority plugin will be the `job.priority` and `priority.set` callbacks. A priority plugin must provide a priority immediately on both of these callbacks. The priority is returned via the `FLUX_PLUGIN_ARG_OUT` args, e.g.:
```C
        flux_plugin_arg_pack (args, FLUX_PLUGIN_ARG_OUT,
                          "{s:i}",
                          "priority", pri);
```
If in the `job.priority` callback (i.e. entry to the PRIORITY state), the plugin cannot provide a priority immediately, then the special value `FLUX_JOBTAP_PRIORITY_UNAVAIL` should be returned. This will cause the job to stay in the PRIORITY state until the plugin asynchronously provides a priority via the function `flux_jobtap_reprioritize_job()`. A convenience function is provided for this case:
```c
        int flux_jobtap_priority_unavail (flux_plugin_t *p,
                                          flux_plugin_arg_t *args);
```
Presumably, if the priority is currently unavailable, the plugin will fire off some asynchronous work to fetch missing information, and will request reprioritization of the job in the callback for that async operation.

If a plugin job.priority callback does not return a priority, or note that priority is unavailable, then jobtap will provide a default priority to avoid jobs hanging in the PRIORITY state when a non-priority jobtap plugin is loaded.

The jobtap interface includes an installed header file `<flux/jobtap.h>` which provides some interfaces for the plugin into the job manager.  These include access to the job manager's flux_t handle for setting up timer or periodic watchers, or sending RPCs, an interface for registering plugin-specific services, and interfaces for reprioritizing and single job or requesting re-prioritization of all jobs in a loop (the plugin's `priority.set` callback will be called for each prioritized job).

Instead of defining a `flux_jobtap_t` opaque type, `jobtap.h` functions simply take a `flux_plugin_t` directly. This is as a convenience to plugin developers, as it saves a call to something like `flux_plugin_get_jobtap()` (this is done instead inside each method)

Plugins other than the default may be loaded via the job-manager.jobtap RPC. A few builtin plugins are provided for testing, including
    
 - `builtin.default` - sets priority to the current urgency (this plugin is not strictly necessary anymore and may be dropped for efficiency)
 - `builtin.age` - An experimental plugin where urgency and time since submission both contribute to priority (this one also would probably be removed before merging the PR).
 - `builtin.hold` - all jobs get an initial priority of 0 and are thus held until a non-zero urgency is set.
 - `builtin.random` - jobs are assigned a random priority. The plugin additionally calls a reprioritization loop once per second. (use for torture test)
    
The python script below can be used currently to load a non-default plugin, in case anyone wants to play with these other plugins:
    
```python
#!/usr/bin/env python3
import flux
import sys
print(flux.Flux().rpc("job-manager.jobtap", {"load": sys.argv[1]}).get())
```
    
After a new plugin is loaded, a job reprioritization loop is run, which will cause the plugin to get a priority.set callback for each job in SCHED or PRIORITY state.

#### Example

This plugin registers for all plugin topics and emits debugging info on stderr.

In the PRIORITY state it returns `flux_jobtap_priority_unavail()` and starts a timer, setting an actual priority after 1s to demonstate jobs hanging in the PRIORITY state.

```c
#include <stdio.h>
#include <jansson.h>

#include <flux/core.h>
#include <flux/jobtap.h>

struct timer_arg {
    flux_jobid_t id;
    int urgency;
    flux_plugin_t *p;
};

struct timer_arg *timer_arg_create (flux_plugin_t *p,
                                    flux_jobid_t id,
                                    int urgency)
{
    struct timer_arg *ta = calloc (1, sizeof (*ta));
    if (!ta)
        return NULL;
    ta->id = id;
    ta->p = p;
    ta->urgency = urgency;
    return ta;
}

void timer_arg_destroy (struct timer_arg *ta)
{
    free (ta);
}

static void timer_cb (flux_reactor_t *r,
                      flux_watcher_t *w,
                      int revents,
                      void *arg)
{
    struct timer_arg *ta = arg;
    flux_jobtap_reprioritize_job (ta->p, ta->id, ta->urgency);
    timer_arg_destroy (ta);
    flux_watcher_destroy (w);
}

static int cb (flux_plugin_t *p,
               const char *topic,
               flux_plugin_arg_t *args,
               void *arg)
{
    json_t *resources;
    flux_jobid_t id;
    uint32_t userid;
    int urgency;
    unsigned int priority;
    flux_job_state_t state;
    double t_submit;
    char *s;

    flux_plugin_arg_unpack (args, FLUX_PLUGIN_ARG_IN,
                            "{s:{s:o} s:I s:i s:i s:i s:i s:f}",
                            "jobspec", "resources", &resources,
                            "id", &id,
                            "userid", &userid,
                            "urgency", &urgency,
                            "priority", &priority,
                            "state", &state,
                            "t_submit", &t_submit);

    s = json_dumps (resources, JSON_COMPACT);
    fprintf (stderr, "%s: id=%ju uid=%u urg=%d pri=%u state=%d t_submit=%.5f\n",
             topic, id, userid, urgency, priority, state, t_submit);
    fprintf (stderr, "resources: %s\n", s);
    free (s);

    if (strcmp (topic, "job.priority") == 0) {
        flux_t *h = flux_jobtap_get_flux (p);
        struct timer_arg *ta = timer_arg_create (p, id, urgency);
        flux_watcher_t *w = flux_timer_watcher_create (flux_get_reactor (h),
                                                       1., 0.,
                                                       timer_cb,
                                                       ta);
        flux_watcher_start (w);
        return flux_jobtap_priority_unavail (p, args);
    }
    return 0;
}

int flux_plugin_init (flux_plugin_t *p)
{
    return flux_plugin_add_handler (p, "*", cb, NULL);
}

```

This plugin currently must be compiled via:
```console
$ gcc -I. -Isrc/include -fPIC -shared -o test.so test.c
```

At the top of the Flux build tree, but once `jobtap.h` is installed, the extra `-I. -Isrc/include` will not be necessary.


#### Benchmark

There might be some question if the addition of `jobtap_call()` to every state transition will impact maximum job throughput.

I used the following throughput tests to ensure that the impact of this PR would not be severe. The `throughput.py` test exercises the maximum rate of jobs through the job manager by submitting jobs the `exec.test` key set, which only simulates job execution (no job shell is actually launched)

These two runs compare the default plugin which will behave the same as loading no plugin:
```console
grondo@asp:~/git/flux-core.git$ src/cmd/flux start -s4 sh -c 'flux module reload sched-simple unlimited; ./throughput.py -n 1024' 2>&1 | tee output
number of jobs: 1024
script runtime: 7.846 s
job runtime:    7.661 s
throughput:     133.7 job/s (script: 130.5 job/s)

grondo@asp:~/git/flux-core.git$ src/cmd/flux start -s4 sh -c 'flux module reload sched-simple unlimited; ./jobtap.py none; ./throughput.py -n 1024' 2>&1 | tee output
{'previous': 'default', 'current': 'none'}
number of jobs: 1024
script runtime: 7.948 s
job runtime:    7.731 s
throughput:     132.5 job/s (script: 128.8 job/s)
```

It can be seen that the impact of calling a basic jobtap plugin is negligible.

Finally, the `builtin.random` plugin is a torture test for this interface, since it will reassign priorities randomly every second:

```console
$ src/cmd/flux start -s4 sh -c 'flux module reload sched-simple unlimited; ./jobtap.py builtin.random; ./throughput.py -n 1024' 2>&1 | tee output
{'previous': 'default', 'current': 'random'}
number of jobs: 1024
script runtime: 14.293s
job runtime:    14.107s
throughput:     72.6 job/s (script:  71.6 job/s)
```

This plugin seems to have a significant impact, so care will have to be taken when periodically requesting the reprioritization of all jobs.