### PR TITLE
testsuite: add debug and workarounds for failures in github actions

### DIFF
--- a/src/common/libutil/test/ipaddr.c
+++ b/src/common/libutil/test/ipaddr.c
@@ -24,8 +24,9 @@ int main(int argc, char** argv)
 
     plan (NO_PLAN);
 
+    memset (errstr, 0, sizeof (errstr));
     ok (ipaddr_getprimary (host, sizeof (host), errstr, sizeof (errstr)) == 0,
-        "ipaddr_getprimary works");
+        "ipaddr_getprimary works: errstr=%s", errstr);
     diag ("primary: %s", host);
 
     ok (ipaddr_getall (&addrs, &addrs_len, errstr, sizeof (errstr)) == 0,

--- a/t/t3000-mpi-basic.t
+++ b/t/t3000-mpi-basic.t
@@ -32,13 +32,15 @@ run_program() {
 }
 
 test_expect_success "mpi hello singleton" '
-	run_program 5 1 1 ${FLUX_BUILD_DIR}/t/mpi/hello >single.$OPTS
+	run_program 15 1 1 ${FLUX_BUILD_DIR}/t/mpi/hello >single.out &&
+	test_debug "cat single.out"
 '
 
 test_expect_success "mpi hello all ranks" '
-	run_program 5 ${SIZE} ${SIZE} ${FLUX_BUILD_DIR}/t/mpi/hello \
-		| tee allranks.$OPTS \
-		&& grep -q "There are ${SIZE} tasks" allranks.$OPTS
+	run_program 15 ${SIZE} ${SIZE} ${FLUX_BUILD_DIR}/t/mpi/hello \
+		> allranks.out &&
+		test_debug "cat allranks.out" &&
+		grep -q "There are ${SIZE} tasks" allranks.out
 '
 
 test_done


### PR DESCRIPTION
This PR adds the suggested `errstr` output to `libutil/test_ipaddr.t` in order to diagnose the errors described in #3466.

Also, as discussed in #3463, the MPI test timeout is extended as a workaround for an issue that seems to only be reproducible in GH actions. 