### PR TITLE
python: add concurrent.futures executor

### DIFF
--- a/src/bindings/python/flux/Makefile.am
+++ b/src/bindings/python/flux/Makefile.am
@@ -26,6 +26,7 @@ nobase_fluxpy_PYTHON = \
 	job/wait.py \
 	job/stats.py \
 	job/_wrapper.py \
+	job/executor.py \
 	resource/Rlist.py \
 	resource/__init__.py \
 	resource/ResourceSetImplementation.py \

--- a/src/bindings/python/flux/job/__init__.py
+++ b/src/bindings/python/flux/job/__init__.py
@@ -23,5 +23,10 @@ from flux.job.event import (
     JobEventWatchFuture,
     EventLogEvent,
     JobException,
+    MAIN_EVENTS,
+)
+from flux.job.executor import (
+    FluxExecutor,
+    FluxExecutorFuture,
 )
 from flux.core.inner import ffi

--- a/src/bindings/python/flux/job/event.py
+++ b/src/bindings/python/flux/job/event.py
@@ -15,6 +15,27 @@ from flux.job._wrapper import _RAW as RAW
 from _flux._core import ffi
 
 
+# Names of events that may appear in the main eventlog (i.e. ``eventlog="eventlog"``)
+# See Flux RFC 21 for documentation on each event.
+MAIN_EVENTS = frozenset(
+    {
+        "submit",
+        "depend",
+        "priority",
+        "flux-restart",
+        "urgency",
+        "alloc",
+        "free",
+        "start",
+        "release",
+        "finish",
+        "clean",
+        "debug",
+        "exception",
+    }
+)
+
+
 class EventLogEvent:
     """
     wrapper class for a single KVS EventLog entry
@@ -149,10 +170,21 @@ def event_watch(flux_handle, jobid, eventlog="eventlog"):
 
 
 class JobException(Exception):
+    """Represents an 'exception' event occurring to a job.
+
+    Instances expose a few public attributes.
+
+    :var timestamp: the timestamp of the 'exception' event.
+    :var type: A string identifying the type of job exception.
+    :var note: Brief human-readable explanation of the exception.
+    :var severity: the severity of the exception. Exceptions with a severity
+        of 0 are fatal to the job; any other severity is non-fatal.
+    """
+
     def __init__(self, event):
         self.timestamp = event.timestamp
         self.type = event.context["type"]
-        self.note = event.context["note"]
+        self.note = event.context.get("note", "no explanation given")
         self.severity = event.context["severity"]
         super().__init__(self)
 

--- a/src/bindings/python/flux/job/executor.py
+++ b/src/bindings/python/flux/job/executor.py
@@ -1,0 +1,475 @@
+###############################################################
+# Copyright 2020 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+"""
+This module defines the ``FluxExecutor`` and ``FluxExecutorFuture`` classes.
+"""
+
+import threading
+import logging
+import itertools
+import collections
+import concurrent.futures
+import weakref
+import time
+import os
+
+import flux
+from flux.job.submit import submit_async, submit_get_id
+from flux.job.event import event_watch_async, JobException, MAIN_EVENTS
+
+
+class _FluxExecutorThread(threading.Thread):
+    """Thread that submits jobs to Flux and waits for event updates.
+
+    Completes FluxExecutorFutures as events indicate that they finish.
+
+    :param exit_event: ``threading.Event`` indicating when the associated
+        Executor has shut down.
+    :param jobspecs_to_submit: a queue filled with jobspecs by the Executor
+    :param poll_interval: the interval (in seconds) to check for new jobs.
+    """
+
+    # pylint: disable=too-many-arguments
+    def __init__(
+        self,
+        exit_event,
+        jobspecs_to_submit,
+        poll_interval,
+        handle_args,
+        handle_kwargs,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.__exit_event = exit_event
+        self.__jobspecs_to_submit = jobspecs_to_submit
+        self.__remaining_flux_futures = 0  # number of unfulfilled futures
+        self.__poll_interval = poll_interval
+        self.__flux_handle = flux.Flux(*handle_args, **handle_kwargs)
+
+    def run(self):
+        """Loop indefinitely, submitting jobspecs and fetching jobids."""
+        self.__flux_handle.timer_watcher_create(
+            self.__poll_interval, self.__submit_new_jobs, repeat=self.__poll_interval
+        ).start()
+        while self.__work_remains():
+            self.__submit_new_jobs(reactor_run=False)
+            if self.__flux_handle.reactor_run() < 0:
+                msg = "reactor start failed"
+                self.__flux_handle.fatal_error(msg)
+                raise RuntimeError(msg)
+
+    def __work_remains(self):
+        """Return True if and only if there is still work to be done.
+
+        Equivalently, return False if it is safe to exit.
+        """
+        return (
+            not self.__exit_event.is_set()
+            or self.__jobspecs_to_submit
+            or self.__remaining_flux_futures > 0
+        )
+
+    def __submit_new_jobs(self, *_, reactor_run=True):
+        """Pull jobspecs from the queue and submit them.
+
+        Invoked on a timer, and passed several arguments, none
+        of which are used---hence the "*_"
+        """
+        if not self.__work_remains() and reactor_run:
+            self.__flux_handle.reactor_stop()
+        if self.__remaining_flux_futures == 0 and not self.__jobspecs_to_submit:
+            time.sleep(self.__poll_interval)
+        while self.__jobspecs_to_submit:
+            try:
+                jobspec, user_future = self.__jobspecs_to_submit.popleft()
+            except IndexError:
+                continue
+            if user_future.set_running_or_notify_cancel():
+                try:
+                    submit_async(self.__flux_handle, jobspec).then(
+                        self.__submission_callback, user_future
+                    )
+                except OSError as os_error:
+                    user_future.set_exception(os_error)
+                else:
+                    self.__remaining_flux_futures += 1
+
+    def __submission_callback(self, submission_future, user_future):
+        """Callback invoked when a jobid is ready for a submitted jobspec."""
+        jobid = submit_get_id(submission_future)
+        user_future._set_jobid(jobid)  # pylint: disable=protected-access
+        event_watch_async(self.__flux_handle, jobid).then(
+            self.__event_update, user_future
+        )
+
+    def __event_update(self, event_future, user_future):
+        """Callback invoked when a job has an event update."""
+        event = event_future.get_event()
+        if event is not None:
+            if event.name in user_future.EVENTS:
+                user_future._set_event(event)  # pylint: disable=protected-access
+            # check if the event tells us that the job is done
+            if not user_future.done():
+                if event.name == "finish":
+                    exit_status = event.context["status"]
+                    if os.WIFEXITED(exit_status):
+                        user_future.set_result(os.WEXITSTATUS(exit_status))
+                    elif os.WIFSIGNALED(exit_status):
+                        user_future.set_result(-os.WTERMSIG(exit_status))
+                    else:
+                        user_future.set_exception(ValueError(exit_status))
+                elif event.name == "exception" and event.context["severity"] == 0:
+                    user_future.set_exception(JobException(event))
+        else:  # no more events
+            self.__remaining_flux_futures -= 1
+
+
+class FluxExecutorFuture(concurrent.futures.Future):
+    """A ``concurrent.futures.Future`` subclass that represents a single Flux job.
+
+    In addition to all of the ``concurrent.futures.Future`` functionality,
+    ``FluxExecutorFuture`` instances offer:
+
+    * The ``jobid`` and ``add_jobid_callback`` methods for retrieving the
+      Flux jobid of the underlying job.
+    * The ``add_event_callback`` method to invoke callbacks when particular
+      job-state events occur.
+
+    Valid events are contained in the ``EVENTS`` class attribute.
+    """
+
+    #: A set containing the names of valid events.
+    EVENTS = MAIN_EVENTS
+
+    def __init__(self, owning_thread_id, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Thread.ident of thread tasked with completing this future
+        self.__owning_thread_id = owning_thread_id
+        self.__jobid_condition = threading.Condition()
+        self.__jobid = None
+        self.__jobid_callbacks = []
+        self.__event_lock = threading.RLock()
+        self.__events_occurred = {state: collections.deque() for state in self.EVENTS}
+        self.__event_callbacks = {state: collections.deque() for state in self.EVENTS}
+
+    def _set_jobid(self, jobid):
+        """Sets the Flux jobid associated with the future.
+
+        Should only be used by Executor implementations and unit tests.
+        """
+        if self.__jobid is not None:
+            raise RuntimeError("invalid state")  # should be InvalidStateError in 3.8+
+        with self.__jobid_condition:
+            self.__jobid = jobid
+            self.__jobid_condition.notify_all()
+        for callback in self.__jobid_callbacks:
+            self._invoke_flux_callback(callback)
+
+    def add_done_callback(self, *args, **kwargs):  # pylint: disable=arguments-differ
+        """Attaches a callable that will be called when the future finishes.
+
+        :param fn: A callable that will be called with this future as its only
+            argument when the future completes or is cancelled. The callable
+            will always be called by a thread in the same process in which
+            it was added. If the future has already completed or been
+            cancelled then the callable will be called immediately. These
+            callables are called in the order that they were added.
+        :return: ``self``
+        """
+        super().add_done_callback(*args, **kwargs)
+        return self
+
+    def jobid(self, timeout=None):
+        """Return the jobid of the Flux job that the future represents.
+
+        :param timeout: The number of seconds to wait for the jobid.
+            If None, then there is no limit on the wait time.
+
+        :return: a positive integer jobid, or ``-1`` if the future was cancelled.
+
+        :raises concurrent.futures.TimeoutError: If the jobid is not available
+            before the given timeout.
+        """
+        if self.__jobid is not None:
+            return self.__jobid
+        with self.__jobid_condition:
+            self.__jobid_condition.wait(timeout)
+            if self.__jobid is not None:
+                return self.__jobid
+            raise concurrent.futures.TimeoutError()
+
+    def add_jobid_callback(self, callback):
+        """Attaches a callable that will be called when the jobid is ready.
+
+        Added callables are called in the order that they were added and may be called
+        in another thread.  If the callable raises an ``Exception`` subclass, it will
+        be logged and ignored.  If the callable raises a ``BaseException`` subclass,
+        the behavior is undefined.
+
+        :param callback: a callable taking the future as its only argument.
+        :return: ``self``
+        """
+        with self.__jobid_condition:
+            if self.__jobid is None:
+                self.__jobid_callbacks.append(callback)
+                return self
+        self._invoke_flux_callback(callback)
+        return self
+
+    def _invoke_flux_callback(self, callback, *args):
+        try:
+            callback(self, *args)
+        except Exception:  # pylint: disable=broad-except
+            logging.getLogger(__name__).exception(
+                "exception calling callback for %r", self
+            )
+
+    def exception(self, *args, **kwargs):  # pylint: disable=arguments-differ
+        """If this method is invoked from a jobid callback by an executor thread,
+        it will result in deadlock, since the current thread will wait
+        for work that the same thread is meant to do.
+
+        Head off this possibility by checking the current thread.
+        """
+        if not self.done() and threading.get_ident() == self.__owning_thread_id:
+            raise RuntimeError("Cannot wait for future from inside callback")
+        return super().exception(*args, **kwargs)
+
+    exception.__doc__ = concurrent.futures.Future.exception.__doc__
+
+    def result(self, *args, **kwargs):  # pylint: disable=arguments-differ
+        """If this method is invoked from a jobid callback by an executor thread,
+        it will result in deadlock, since the current thread will wait
+        for work that the same thread is meant to do.
+
+        Head off this possibility by checking the current thread.
+        """
+        if not self.done() and threading.get_ident() == self.__owning_thread_id:
+            raise RuntimeError("Cannot wait for future from inside callback")
+        return super().result(*args, **kwargs)
+
+    result.__doc__ = concurrent.futures.Future.result.__doc__
+
+    def cancel(self, *args, **kwargs):  # pylint: disable=arguments-differ
+        """If a thread is waiting for the future's jobid, and another
+        thread cancels the future, the waiting thread would never wake up
+        because the jobid would never be set.
+
+        When cancelling, set the jobid to something invalid.
+        """
+        cancelled = super().cancel(*args, **kwargs)
+        if cancelled:
+            self._set_jobid(-1)
+        return cancelled
+
+    cancel.__doc__ = concurrent.futures.Future.cancel.__doc__
+
+    def add_event_callback(self, event, callback):
+        """Add a callback to be invoked when an event occurs.
+
+        The callback will be invoked, with the future as the first argument and the
+        ``flux.job.EventLogEvent`` as the second, whenever the event occurs. If the
+        event occurs multiple times, the callback will be invoked with each different
+        `EventLogEvent` instance. If the event never occurs, the callback
+        will never be invoked.
+
+        Added callables are called in the order that they were added and may be called
+        in another thread.  If the callable raises an ``Exception`` subclass, it will
+        be logged and ignored.  If the callable raises a ``BaseException`` subclass,
+        the behavior is undefined.
+
+        If the event has already occurred, the callback will be called immediately.
+
+        :param event: the name of the event to add the callback to.
+        :param callback: a callable taking the future and the event as arguments.
+        :return: ``self``
+        """
+        if event not in self.EVENTS:
+            raise ValueError(event)
+        with self.__event_lock:
+            self.__event_callbacks[event].append(callback)
+            for log_entry in self.__events_occurred[event]:
+                self._invoke_flux_callback(callback, log_entry)
+        return self
+
+    def _set_event(self, log_entry):
+        """Set an event on the future.
+
+        For use by Executor implementations and unit tests.
+
+        :param log_entry: an ``EventLogEvent``.
+        """
+        event_name = log_entry.name
+        if event_name not in self.EVENTS:
+            raise ValueError(event_name)
+        with self.__event_lock:
+            self.__events_occurred[event_name].append(log_entry)
+            # make a shallow copy of callbacks --- in case a user callback
+            # tries to add another callback for the same event
+            for callback in list(self.__event_callbacks[event_name]):
+                self._invoke_flux_callback(callback, log_entry)
+
+
+class FluxExecutor:
+    """Provides a method to submit jobs to Flux asynchronously.
+
+    Forks threads to complete futures and fetch event updates in the background.
+
+    Inspired by the ``concurrent.futures.Executor`` class, with the following
+    interface differences:
+
+        - the ``submit`` method takes a ``flux.job.Jobspec`` instead of a
+          callable and its arguments, and returns a ``FluxExecutorFuture``
+          representing that job.
+        - the ``map`` method is not supported, given that the executor consumes
+          Jobspecs rather than callables.
+
+    Otherwise, the FluxExecutor is faithful to its inspiration. In addition
+    to methods and behavior defined by ``concurrent.futures``, FluxExecutor
+    provides its futures with event updates and the jobid of the underlying job.
+
+    Returned futures have their jobid set as soon as it is available, which is
+    always before the future completes.
+
+    Futures may receive event updates even after they complete. The names
+    of valid events are contained in the ``EVENTS`` class attribute.
+
+    The result of a future is the highest process exit status of the underlying job
+    (in which case the result is an integer greater than or equal to 0),
+    or ``-signum`` where ``signum`` is the number
+    of the signal that caused the process to terminate
+    (in which case the result is an integer less than 0).
+
+    A future is marked as "running" (and can no longer be canceled using the
+    ``.cancel()`` method) once the associated jobspec
+    has been submitted to Flux. The underlying Flux job may still be
+    canceled, however, using the ``flux.job.cancel`` and
+    ``flux.job.kill`` functions, in which case a ``JobException`` will be set.
+
+    If the jobspec is invalid, an ``OSError`` is set.
+
+    :param threads: the number of worker threads to fork.
+    :param thread_name_prefix: used to control the names of ``threading.Thread``
+        objects created by the executor, for easier debugging.
+    :param poll_interval: the interval (in seconds) in which to break out of the
+        flux event loop to check for new job submissions.
+    :param handle_args: positional arguments to the ``flux.Flux`` instances used by
+        the executor.
+    :param handle_kwargs: keyword arguments to the ``flux.Flux`` instances used by
+        the executor.
+    """
+
+    # Used to assign unique thread names when thread_name_prefix is not supplied.
+    _counter = itertools.count().__next__
+    #: A set containing valid event names for attaching to futures.
+    EVENTS = MAIN_EVENTS
+
+    # pylint: disable=too-many-arguments,dangerous-default-value
+    def __init__(
+        self,
+        threads=1,
+        thread_name_prefix="",
+        poll_interval=0.1,
+        handle_args=(),
+        handle_kwargs={},
+    ):
+        if threads < 0:
+            raise ValueError("the number of threads must be > 0")
+        # split jobs equally among threads; give them each their own queue
+        self._submission_queues = [collections.deque() for i in range(threads)]
+        self._next_thread = 0  # the next thread to give a job to
+        self._shutdown_lock = threading.Lock()
+        self._shutdown_event = threading.Event()
+        thread_name_prefix = (
+            thread_name_prefix or f"{type(self).__name__}-{self._counter()}"
+        )
+        self._executor_threads = [
+            _FluxExecutorThread(
+                self._shutdown_event,
+                deque,
+                poll_interval,
+                handle_args,
+                handle_kwargs,
+                name=(f"{thread_name_prefix}-{i}"),
+                daemon=True,
+            )
+            for i, deque in enumerate(self._submission_queues)
+        ]
+        for thread in self._executor_threads:
+            thread.start()
+        # register a finalizer to ensure worker threads are notified to shut down
+        self._finalizer = weakref.finalize(
+            self, self._shutdown_threads, self._shutdown_event, self._executor_threads
+        )
+
+    def shutdown(self, wait=True, *, cancel_futures=False):
+        """Clean-up the resources associated with the Executor.
+
+        It is safe to call this method several times. Otherwise, no other
+        methods can be called after this one.
+
+        :param wait: If ``True``, then this method will not return until all running
+            futures have finished executing and the resources used by the
+            executor have been reclaimed.
+        :param cancel_futures: If ``True``, this method will cancel all pending
+            futures that the executor has not started running. Any futures that
+            are completed or running won't be cancelled, regardless of the value
+            of ``cancel_futures``.
+        """
+        with self._shutdown_lock:
+            self._shutdown_event.set()
+        if cancel_futures:
+            # Drain all work items from the queues, and then cancel their
+            # associated futures.
+            for deque in self._submission_queues:
+                while deque:
+                    try:
+                        _, user_future = deque.popleft()
+                    except IndexError:
+                        pass
+                    else:
+                        user_future.cancel()
+                        user_future.set_running_or_notify_cancelled()
+        if wait:
+            for thread in self._executor_threads:
+                thread.join()
+
+    def submit(self, jobspec):
+        """Submit a jobspec to Flux and return a ``FluxExecutorFuture``.
+
+        :raises RuntimeError: if ``shutdown`` has been called.
+        """
+        with self._shutdown_lock:
+            if self._shutdown_event.is_set():
+                raise RuntimeError("cannot schedule new futures after shutdown")
+            future_owner_id = self._executor_threads[self._next_thread].ident
+            fut = FluxExecutorFuture(future_owner_id)
+            self._submission_queues[self._next_thread].append((jobspec, fut))
+            self._next_thread = (self._next_thread + 1) % len(self._submission_queues)
+            return fut
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.shutdown(wait=True)
+        return False
+
+    @staticmethod
+    def _shutdown_threads(event, threads):
+        """Set the threading.Event and join all threads.
+
+        Not a method so as not to prevent garbage collection
+        (see `weakref.finalize` docs).
+        """
+        event.set()
+        for thread in threads:
+            thread.join()

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -186,6 +186,7 @@ TESTSCRIPTS = \
 	python/t0020-hostlist.py \
 	python/t0021-idset.py \
 	python/t0022-resource-set.py \
+	python/t0023-executor.py \
 	python/t1000-service-add-remove.py
 
 if HAVE_FLUX_SECURITY

--- a/t/python/t0023-executor.py
+++ b/t/python/t0023-executor.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python3
+
+###############################################################
+# Copyright 2020 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+import unittest
+import collections
+import threading
+import os
+import itertools
+import concurrent.futures as cf
+
+from flux.job import JobspecV1, EventLogEvent, JobException
+from flux.job.executor import (
+    FluxExecutor,
+    FluxExecutorFuture,
+    _FluxExecutorThread,
+)
+
+
+def __flux_size():
+    return 1
+
+
+class ShamJobEventWatchFuture:
+    """A wrapper around a LogEvent to act like a JobEventWatchFuture."""
+
+    def __init__(self, log_event):
+        self.log_event = log_event
+
+    def get_event(self):
+        return self.log_event
+
+
+class TestFluxExecutor(unittest.TestCase):
+    """Tests for FluxExecutor."""
+
+    def test_as_completed(self):
+        with FluxExecutor() as executor:
+            jobspec = JobspecV1.from_command(["true"])
+            futures = [executor.submit(jobspec) for _ in range(3)]
+            for fut in cf.as_completed(futures):
+                self.assertEqual(fut.result(timeout=0), 0)
+                self.assertIsNone(fut.exception())
+
+    def test_failed_submit(self):
+        with FluxExecutor(thread_name_prefix="foobar") as executor:
+            jobspec = JobspecV1.from_command(["false"])
+            future = executor.submit(jobspec).add_jobid_callback(
+                lambda future: event.set()
+            )
+            event = threading.Event()
+            jobid = future.jobid()
+            self.assertGreater(jobid, 0)
+            self.assertTrue(event.is_set())
+            self.assertEqual(future.result(), 1)
+            self.assertIsNone(future.exception())
+
+    def test_cancel(self):
+        with FluxExecutor() as executor:
+            jobspec = JobspecV1.from_command(["false"])
+            for _ in range(3):
+                future = executor.submit(jobspec)
+                if future.cancel():
+                    self.assertFalse(future.running())
+                    self.assertTrue(future.cancelled())
+                    self.assertEqual(future.jobid(), -1)
+                    with self.assertRaises(cf.CancelledError):
+                        future.exception()
+                else:
+                    self.assertEqual(future.result(), 1)
+                    self.assertIsNone(future.exception())
+
+    def test_bad_jobspec(self):
+        with FluxExecutor() as executor:
+            future = executor.submit(None)  # not a valid jobspec
+        with self.assertRaises(OSError):
+            # future should be fulfilled after shutdown
+            future.result(timeout=0)
+        self.assertIsInstance(future.exception(), OSError)
+
+    def test_submit_after_shutdown(self):
+        executor = FluxExecutor()
+        executor.shutdown(wait=True)
+        with self.assertRaises(RuntimeError):
+            executor.submit(JobspecV1.from_command(["true"]))
+        with self.assertRaises(RuntimeError):
+            executor.submit(None)
+
+    def test_wait(self):
+        with FluxExecutor(threads=3) as executor:
+            jobspec = JobspecV1.from_command(["false"])
+            futures = [executor.submit(jobspec) for _ in range(3)]
+            done, not_done = cf.wait(futures, return_when=cf.FIRST_COMPLETED)
+            self._check_done(done)
+            done, not_done = cf.wait(futures, return_when=cf.FIRST_EXCEPTION)
+            self._check_done(done)
+            done, not_done = cf.wait(futures)
+            self._check_done(done)
+            self.assertEqual(len(not_done), 0)
+
+    def _check_done(self, done_futures):
+        self.assertGreater(len(done_futures), 0)
+        for fut in done_futures:
+            self.assertEqual(fut.result(timeout=0), 1)
+
+    def test_executor_event_callbacks(self):
+        with FluxExecutor() as executor:
+            expected_events = set(["start", "finish", "depend", "priority", "free"])
+            future = executor.submit(JobspecV1.from_command(["false"]))
+            for event in executor.EVENTS:
+                future.add_event_callback(
+                    event, lambda fut, event: expected_events.discard(event.name)
+                )
+        self.assertFalse(expected_events)  # no more expected events
+
+    def test_exception_event(self):
+        with FluxExecutor() as executor:
+            flag = threading.Event()
+            future = executor.submit(JobspecV1.from_command(["/not/a/real/app"]))
+            future.add_event_callback("exception", lambda fut, event: flag.set())
+            self.assertIsInstance(future.exception(), JobException)
+            self.assertTrue(flag.is_set())
+
+
+class TestFluxExecutorThread(unittest.TestCase):
+    """Simple synchronous tests for _FluxExecutorThread."""
+
+    def test_exit_condition(self):
+        deq = collections.deque()
+        event = threading.Event()
+        thread = _FluxExecutorThread(event, deq, 0.1, (), {})
+        self.assertTrue(thread._FluxExecutorThread__work_remains())
+        event.set()
+        self.assertFalse(thread._FluxExecutorThread__work_remains())
+        deq.append(None)
+        self.assertTrue(thread._FluxExecutorThread__work_remains())
+
+    def test_bad_jobspecs(self):
+        deq = collections.deque()
+        event = threading.Event()
+        thread = _FluxExecutorThread(event, deq, 0.01, (), {})
+        futures = [FluxExecutorFuture(threading.get_ident()) for _ in range(5)]
+        deq.extend((None, f) for f in futures)
+        event.set()
+        thread.run()
+        self.assertFalse(deq)
+        self.assertEqual(0, thread._FluxExecutorThread__remaining_flux_futures)
+        for fut in futures:
+            self.assertIsInstance(fut.exception(), OSError)
+
+    def test_cancel(self):
+        deq = collections.deque()
+        event = threading.Event()
+        jobspec = JobspecV1.from_command(["false"])
+        thread = _FluxExecutorThread(event, deq, 0.01, (), {})
+        futures = [FluxExecutorFuture(threading.get_ident()) for _ in range(5)]
+        for fut in futures:
+            deq.append((jobspec, fut))
+            fut.cancel()
+        event.set()
+        thread.run()
+        for fut in futures:
+            with self.assertRaises(cf.CancelledError):
+                fut.result()
+            self.assertEqual(fut.jobid(), -1)
+
+    def test_exception_completion(self):
+        jobspec = JobspecV1.from_command(["false"])
+        thread = _FluxExecutorThread(
+            threading.Event(), collections.deque(), 0.01, (), {}
+        )
+        fut = FluxExecutorFuture(threading.get_ident())
+        self.assertFalse(fut.done())
+        fut._set_event(EventLogEvent({"name": "start", "timestamp": 0}))
+        self.assertFalse(fut.done())
+        thread._FluxExecutorThread__event_update(
+            ShamJobEventWatchFuture(
+                EventLogEvent(
+                    {
+                        "name": "exception",
+                        "timestamp": 0,
+                        "context": {"severity": 1, "type": "foobar"},
+                    }
+                )
+            ),
+            fut,
+        )
+        self.assertFalse(fut.done())
+        thread._FluxExecutorThread__event_update(
+            ShamJobEventWatchFuture(
+                EventLogEvent(
+                    {
+                        "name": "exception",
+                        "timestamp": 0,
+                        "context": {"severity": 0, "type": "foobar"},
+                    }
+                )
+            ),
+            fut,
+        )
+        self.assertTrue(fut.done())
+        self.assertIsInstance(fut.exception(), JobException)
+
+    def test_finish_completion(self):
+        thread = _FluxExecutorThread(
+            threading.Event(), collections.deque(), 0.01, (), {}
+        )
+        for exit_status in (0, 1, 15, 120, 255):
+            flag = threading.Event()
+            fut = FluxExecutorFuture(threading.get_ident()).add_done_callback(
+                lambda fut: flag.set()
+            )
+            thread._FluxExecutorThread__event_update(
+                ShamJobEventWatchFuture(
+                    EventLogEvent(
+                        {
+                            "name": "finish",
+                            "timestamp": 0,
+                            "context": {"status": exit_status},
+                        }
+                    )
+                ),
+                fut,
+            )
+            self.assertTrue(fut.done())
+            self.assertTrue(flag.is_set())
+            if os.WIFEXITED(exit_status):
+                self.assertEqual(fut.result(), os.WEXITSTATUS(exit_status))
+            elif os.WIFSIGNALED(exit_status):
+                self.assertEqual(fut.result(), -os.WTERMSIG(exit_status))
+
+
+class TestFluxExecutorFuture(unittest.TestCase):
+    """Tests for FluxExecutorFuture."""
+
+    def test_set_jobid(self):
+        for jobid in (21, 594240):
+            fut = FluxExecutorFuture(threading.get_ident())
+            with self.assertRaises(cf.TimeoutError):
+                fut.jobid(timeout=0)
+            fut._set_jobid(jobid)
+            self.assertEqual(jobid, fut.jobid(timeout=0))
+            with self.assertRaises(RuntimeError):
+                fut._set_jobid(jobid)
+
+    def test_jobid_callback(self):
+        fut = FluxExecutorFuture(threading.get_ident())
+        flag = threading.Event()
+        fut.add_jobid_callback(lambda f: flag.set())
+        self.assertFalse(flag.is_set())
+        fut._set_jobid(5)
+        self.assertTrue(flag.is_set())
+        # now check that adding callbacks fires them immediately
+        flag.clear()
+        fut.add_jobid_callback(lambda f: flag.set())
+        self.assertTrue(flag.is_set())
+
+    def test_event_callback(self):
+        fut = FluxExecutorFuture(threading.get_ident())
+        flag = threading.Event()
+        for state in ("clean", "start", "alloc"):
+            flag.clear()
+            fut.add_event_callback(
+                state, lambda f, log: (flag.set(), self.assertEqual(log.name, state))
+            )
+            log_event = EventLogEvent({"name": state, "timestamp": 0})
+            fut._set_event(log_event)
+            self.assertTrue(flag.is_set())
+            # now check that adding callbacks fires them immediately
+            flag.clear()
+            fut.add_event_callback(
+                state, lambda f, log: (flag.set(), self.assertEqual(log.name, state))
+            )
+            self.assertTrue(flag.is_set())
+
+    def test_bad_event(self):
+        fut = FluxExecutorFuture(threading.get_ident())
+        event = "not an event"
+        log_event = EventLogEvent({"name": event, "timestamp": 0})
+        with self.assertRaises(ValueError):
+            fut._set_event(log_event)
+        with self.assertRaises(ValueError):
+            fut.add_event_callback(event, None)
+
+    def test_callback_deadlock(self):
+        flag = threading.Event()
+        # try waiting for the future from the callback
+        fut = FluxExecutorFuture(threading.get_ident()).add_jobid_callback(
+            lambda fut: (fut.result(), flag.set())
+        )
+        fut._set_jobid(5)
+        # check that flag wasn't set---because the callback raised
+        self.assertFalse(flag.is_set())
+        # try the same with an event callback
+        log_event = EventLogEvent({"name": "debug", "timestamp": 0})
+        fut.add_event_callback(
+            log_event.name, lambda fut, event: (fut.result(), flag.set())
+        )
+        fut._set_event(log_event)
+        self.assertFalse(flag.is_set())
+        # now complete the future and try again
+        fut.set_result(21)
+        fut.add_jobid_callback(lambda fut: (fut.result(), flag.set()))
+        self.assertTrue(flag.is_set())
+        flag.clear()
+        fut.add_event_callback(
+            log_event.name, lambda fut, event: (fut.result(), flag.set())
+        )
+        self.assertTrue(flag.is_set())
+
+    def test_multiple_events(self):
+        fut = FluxExecutorFuture(threading.get_ident())
+        counter = itertools.count()
+        fut.add_event_callback("urgency", lambda fut, event: next(counter))
+        total_iterations = 5
+        for _ in range(5):
+            fut._set_event(EventLogEvent({"name": "urgency", "timestamp": 0}))
+        self.assertEqual(next(counter), total_iterations)
+        new_counter = itertools.count()
+        fut.add_event_callback("urgency", lambda fut, event: next(new_counter))
+        self.assertEqual(next(new_counter), total_iterations)
+        fut._set_event(EventLogEvent({"name": "urgency", "timestamp": 0}))
+        # invoking the callback increments the counter, as does checking the counter
+        self.assertEqual(next(counter), total_iterations + 2)
+        self.assertEqual(next(new_counter), total_iterations + 2)
+
+    def test_adding_callbacks_from_callbacks(self):
+        fut = FluxExecutorFuture(threading.get_ident())
+        flag = threading.Event()
+        nested_callback = lambda fut, event: flag.set()
+        fut.add_event_callback(
+            "start", lambda fut, event: fut.add_event_callback("start", nested_callback)
+        )
+        fut._set_event(EventLogEvent({"name": "start", "timestamp": 0}))
+        self.assertTrue(flag.is_set())
+
+
+if __name__ == "__main__":
+    from subflux import rerun_under_flux
+
+    if rerun_under_flux(size=__flux_size(), personality="job"):
+        from pycotap import TAPTestRunner
+
+        unittest.main(testRunner=TAPTestRunner())
+
+# vi: ts=4 sw=4 expandtab


### PR DESCRIPTION
Both Themis and Parsl use Flux in basically the same way. Both have a stream of jobs, and want to stream jobs through Flux. The stream of jobs may be produced dynamically (i.e. as a job runs it produces N new jobs) or the stream may be fixed and static but simply so large that it doesn't make sense to submit all the jobs all at once. For that reason, a mechanism to submit and monitor jobs in bulk (as discussed in #3454 and #2653) isn't quite the right solution, although I think it would be really useful in other circumstances. 

What I think would be really useful to Themis and Parsl, and perhaps to Radical Pilot as well (I'll ask Andre for feedback later), is a [concurrent.futures.Executor](https://docs.python.org/3/library/concurrent.futures.html) type of thing, which is what this PR provides.

The only new object provided is the `flux.job.FluxExecutor`, which has only two methods, `submit(jobspec)` and `shutdown()` (`map` is not supported). The `submit()` method is exactly like in `concurrent.futures` except that it takes a jobspec rather than a callable, but it returns a `concurrent.futures.Future` just like normal. `shutdown` is quite different, but it could be brought in line with `concurrent.futures` if that was useful.

Here's what I think are the advantages of this approach, aside from covering the use-case I described in the first paragraph:

1. The interface will be familiar to Python users, and it's well-documented. I don't think the fact that the executor consumes jobspecs instead of callables really changes the basic usage.
2. It gives Flux access to the `concurrent.futures.as_completed` and `concurrent.futures.wait` functions (and whatever other functions work on `concurrent.futures.Future` objects) for free.
3. I think the `FluxExecutor` should be pretty fast. The `submit` method does almost no work, so looping over it is an effective bulk-submission mechanism. Jobs are submitted in a separate thread, and waited on in yet another thread (so instantiating a `FluxExecutor` will fork two new threads).