### PR TITLE
python: fix use of Flux.reactor_run() from multiple threads

### DIFF
--- a/src/bindings/python/flux/core/handle.py
+++ b/src/bindings/python/flux/core/handle.py
@@ -267,6 +267,17 @@ class Flux(Wrapper):
         if reactor is None:
             reactor = self.get_reactor()
 
+        #
+        #  Only do the whole signals rigamarole below if we're in the
+        #   the main thread: libev don't take kindly to registration
+        #   of signal watcher from multiple threads.
+        #
+        if threading.current_thread() != threading.main_thread():
+            rc = self.flux_reactor_run(reactor, flags)
+            if rc < 0:
+                Flux.raise_if_exception()
+            return rc
+
         reactor_interrupted = False
 
         def reactor_interrupt(handle, *_args):

--- a/src/bindings/python/flux/core/handle.py
+++ b/src/bindings/python/flux/core/handle.py
@@ -55,6 +55,11 @@ class Flux(Wrapper):
             destructor=raw.flux_close,
         )
 
+        # Ensure reactor_depth is initialized for this thread
+        if "reactor_depth" not in self.tls.__dict__:
+            self.tls.reactor_depth = 0
+            self.tls.exception = None
+
         if handle is None:
             try:
                 self.handle = raw.flux_open(url, flags)

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -229,6 +229,7 @@ dist_check_SCRIPTS = \
 	issues/t3415-job-shell-segfault-on-null.sh \
 	issues/t3432-python-sigint.sh \
 	issues/t3429-python-future-ref.py \
+	issues/t3470-multithread-reactor-run.py \
 	python/__init__.py \
 	python/subflux.py \
 	python/tap \

--- a/t/issues/t3470-multithread-reactor-run.py
+++ b/t/issues/t3470-multithread-reactor-run.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+#
+#  Simple test for issue #3470: multiple threads calling reactor_run
+#   causes libev assertion failure.
+#
+from queue import Queue
+import sys
+import threading
+
+import flux
+
+
+def cb(f, watcher, msg, i):
+    print(f"{i}: {msg.payload_str}")
+    watcher.stop()
+
+
+def get_events(i, queue):
+    f = flux.Flux()
+    f.event_subscribe("test-event")
+    queue.put(True)
+    f.msg_watcher_create(cb, topic_glob="test-event", args=i).start()
+    f.reactor_run()
+
+
+def main():
+    nthreads = 2
+    threads = []
+    queue = Queue()
+    for i in range(0, nthreads):
+        thread = threading.Thread(
+            target=get_events,
+            args=(
+                i,
+                queue,
+            ),
+        )
+        thread.start()
+        threads.append(thread)
+
+    print(f"starting {nthreads} threads", file=sys.stderr)
+
+    # Ensure threads have subscribed to 'test-event'
+    for thread in threads:
+        queue.get()
+        print(f"got response from {thread}", file=sys.stderr)
+
+    print(f"{nthreads} threads started", file=sys.stderr)
+
+    flux.Flux().event_send("test-event", "hello")
+
+    print(f"published test-event", file=sys.stderr)
+
+    for thread in threads:
+        thread.join()
+
+    print("Done", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
As described in #3470, use of `reactor_run` in multiple Python threads currently causes a libev assertion. This is because libev only allows a signal watcher for a given signal to be handled in one reactor per process for obvious reasons. However, the `SIGINT` watcher in `Flux.reactor_run()` that attempts to ensure the reactor is interruptible is currently installed on every call.

To fix the problem, this PR only performs the special `SIGINT` handling in the main Python thread. This should be fine, because whether the main thread is or is not in the C reactor, the main thread will still handle `SIGINT` and allow the process as a whole to be interrupted.

Along the way, I also found that the `threading.local()` setup wasn't working right for multiple threads either, and this is fixed here as well.

A reproducer based on @jameshcorbett's original reproducer is added to the `t4000-issues-test-driver.t` test to ensure we don't break this again.
