### PR TITLE
NEWS.md: prep for 0.23.0 tag

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,43 @@
+flux-core version 0.23.0 - 2021-01-25
+-------------------------------------
+
+This release adds a job priority plugin framework, enabling the
+flux-accounting project to set job priorities with a fair share
+algorithm.
+
+The scheduler protocol (RFC 27) and libschedutil convenience API
+have changed, therefore users of flux-sched must upgrade to 0.15.0.
+
+### New features
+
+ * jobtap: prototype job-manager plugin support (#3464)
+ * flux-mini: add bulk job submission capabilities (#3426, #3478)
+ * job-manager: send updated priorities to schedulers (#3442)
+ * job-manager: support job hold and expedite (#3428)
+
+### Fixes
+
+ * connectors/ssh: forward `LD_LIBRARY_PATH` over ssh when set (#3458)
+ * python: fix use of `Flux.reactor_run()` from multiple threads (#3471)
+ * python: misc. fixes to docstrings and argument names in bindings (#3451)
+ * python: fix circular reference in `check_future_error` decorator (#3437)
+ * python: fix ctrl-c, re-throw unhandled exceptions in `reactor_run()` (#3435)
+ * shell: fix dropped stdout from shell plugins in task.exec callback (#3446)
+
+### Cleanup/Testing
+
+ * ci: limit asan build to unit tests only (#3479)
+ * libschedutil: API improvements and priority integration (#3447)
+ * configure: add switch to allow flux to be built without python (#3459)
+ * testsuite: remove sched-dummy, migrate testing to sched-simple (#3462)
+ * testsuite: add debug, workarounds for failures in github actions (#3467)
+ * test: fix test for installing poison libflux (#3461)
+ * cleanup: update outdated terminology (#3456)
+ * Globally standardize spelling of "canceled" (#3443)
+ * ci: better script portability and other small updates (#3438)
+ * testsuite: fix invalid tests, cleanup list-jobs, avoid hard-coding (#3436)
+ * fix github actions on tag push (#3430)
+
 flux-core version 0.22.0 - 2020-12-16
 -------------------------------------
 


### PR DESCRIPTION
We should be tagging 0.23.0 by monday 1/25 to make the TOSS 3 packaging deadline on Tues 1/26.   I updated the 0.23.0 milestone to reflect this and created a 0.24.0 one to push some things onto.

@chu11 I pushed the `mode=limited`  work you are doing over to 0.24.0 per our earlier discussion, but I'm open to pulling it back in if it can make it.  It sounds like you're now rebased on top of the jobtap PR so maybe?

Here's release notes for stuff merged so far.  As usual feel free to push directly to this PR.