### PR TITLE
flux-mini: bulksubmit: fix file input separator and add --sep option

### DIFF
--- a/doc/man1/flux-mini.rst
+++ b/doc/man1/flux-mini.rst
@@ -341,6 +341,10 @@ OTHER OPTIONS
 **--shuffle**
    *(bulksubmit)* Shuffle the list of commands before submission.
 
+**--sep=STRING**
+   *(bulksubmit)* Change the separator for file input. The default is
+   to separate files (including stdin) by newline. To separate by
+   consecutive whitespace, specify ``--sep=none``.
 
 .. _bulksubmit:
 

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -526,3 +526,4 @@ bcc
 dirname
 jps
 xargs
+sep


### PR DESCRIPTION
This fix for `flux mini bulksubmit` was split off #3464 as it seems like a simple, well contained fix.

The `flux mini bulksubmit` command splits file input on whitespace only, which is inconvenient if you want to submit a job per line in a file, and each line could contain whitespace. This is also different from the default behavior of GNU parallel, from which bulksubmit is inspired.

Change the default separator for file input to newline, and add a new `--sep=STRING` option to change the default. To get the previous behavior, use `--sep=none`, which splits on consecutive whitespace. As a side benefit, `flux mini bulksubmit` can now work with `find -print0` via `--sep='\0'`.

