### PR TITLE
ci: limit asan build to unit tests only

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -22,7 +22,7 @@ jobs:
         TAP_DRIVER_QUIET: t
       run: >
         src/test/docker/docker-run-checks.sh \
-          --image=bionic --recheck -j2 \
+          --image=bionic --unit-test-only -j2 \
           -- --with-flux-security --enable-sanitizer=address
 
     - name: after failure

--- a/src/test/checks_run.sh
+++ b/src/test/checks_run.sh
@@ -15,6 +15,7 @@
 #  CPPCHECK      Run cppcheck if set to "t"
 #  DISTCHECK     Run `make distcheck` if set
 #  RECHECK       Run `make recheck` if `make check` fails the first time
+#  UNIT_TEST_ONLY Only run `make check` under ./src
 #  PRELOAD       Set as LD_PRELOAD for make and tests
 #  POISON        Install poison libflux and flux(1) in image
 #  INCEPTION     Run tests under a flux instance with prove(1)
@@ -140,6 +141,10 @@ if test -n "$PRELOAD" ; then
   CHECKCMDS="/usr/bin/env 'LD_PRELOAD=$PRELOAD' ${CHECKCMDS}"
 fi
 
+if test -n "$UNIT_TEST_ONLY"; then
+  CHECKCMDS="(cd src && $CHECKCMDS)"
+fi
+
 # CI has limited resources, even though number of processors might
 #  might appear to be large. Limit session size for testing to 5 to avoid
 #  spurious timeouts.
@@ -183,10 +188,10 @@ if test "$POISON" = "t" -a "$PROJECT" = "flux-core"; then
 fi
 
 if test "$DISTCHECK" != "t"; then
-  checks_group "${MAKECMDS}" eval ${MAKECMDS} \
+  checks_group "${MAKECMDS}" "${MAKECMDS}" \
 	|| (printf "::error::${MAKECMDS} failed\n"; exit 1)
 fi
-checks_group "${CHECKCMDS}" eval "${CHECKCMDS}"
+checks_group "${CHECKCMDS}" "${CHECKCMDS}"
 RC=$?
 
 if test "$RECHECK" = "t" -a $RC -ne 0; then

--- a/src/test/docker/docker-run-checks.sh
+++ b/src/test/docker/docker-run-checks.sh
@@ -24,8 +24,8 @@ declare -r prog=${0##*/}
 die() { echo -e "$prog: $@"; exit 1; }
 
 #
-declare -r long_opts="help,quiet,interactive,image:,flux-security-version:,jobs:,no-cache,no-home,distcheck,tag:,build-directory:,install-only,no-poison,recheck,inception"
-declare -r short_opts="hqIdi:S:j:t:D:Pr"
+declare -r long_opts="help,quiet,interactive,image:,flux-security-version:,jobs:,no-cache,no-home,distcheck,tag:,build-directory:,install-only,no-poison,recheck,unit-test-only,inception"
+declare -r short_opts="hqIdi:S:j:t:D:Pru"
 declare -r usage="
 Usage: $prog [OPTIONS] -- [CONFIGURE_ARGS...]\n\
 Build docker image for CI builds, then run tests inside the new\n\
@@ -46,6 +46,7 @@ Options:\n\
  -j, --jobs=N                  Value for make -j (default=$JOBS)\n
  -d, --distcheck               Run 'make distcheck' instead of 'make check'\n\
  -r, --recheck                 Run 'make recheck' after failure\n\
+ -u, --unit-test-only          Only run unit tests\n\
  -P, --no-poison               Do not install poison libflux and flux(1)\n\
  -D, --build-directory=DIRNAME Name of a subdir to build in, will be made\n\
  -I, --interactive             Instead of running ci build, run docker\n\
@@ -74,6 +75,7 @@ while true; do
       -I|--interactive)            INTERACTIVE="/bin/bash";    shift   ;;
       -d|--distcheck)              DISTCHECK=t;                shift   ;;
       -r|--recheck)                RECHECK=t;                  shift   ;;
+      -u|--unit-test-only)         UNIT_TEST_ONLY=t;           shift   ;;
       -D|--build-directory)        BUILD_DIR="$2";             shift 2 ;;
       --no-cache)                  NO_CACHE="--no-cache";      shift   ;;
       --no-home)                   MOUNT_HOME_ARGS="";         shift   ;;
@@ -141,6 +143,7 @@ export INCEPTION
 export JOBS
 export DISTCHECK
 export RECHECK
+export UNIT_TEST_ONLY
 export BUILD_DIR
 export chain_lint
 
@@ -176,6 +179,7 @@ else
         -e CPPCHECK \
         -e DISTCHECK \
         -e RECHECK \
+        -e UNIT_TEST_ONLY \
         -e chain_lint \
         -e JOBS \
         -e USER \


### PR DESCRIPTION
For some reason the address sanitizer build has been hanging lately and timing out on almost every run. I was going to blame something in #3464, but then it is happening in #3478 as well, so I don't think it is related to any of the pending PRs.

Pending investigation of the hangs, this PR adds a new docker-run-checks option `--unit-test-only` which limits `make check` to run under `src/` only (only unit tests), and then uses that option on the asan build. This should remove the chance for hangs from the address sanitizer build, while still provided some benefit.

Since this PR touches the github workflow config, it will need to be manually merged.