### PR TITLE
flux resource: allow drain, undrain, and status to work on any rank

### DIFF
--- a/src/cmd/flux-resource.py
+++ b/src/cmd/flux-resource.py
@@ -274,7 +274,7 @@ def status(args):
     if args.from_stdin:
         resp = sys.stdin.read()
     else:
-        resp = RPC(flux.Flux(), "resource.status").get()
+        resp = RPC(flux.Flux(), "resource.status", nodeid=0).get()
 
     rstat = ResourceStatus.from_status_response(resp, fmt)
 

--- a/src/cmd/flux-resource.py
+++ b/src/cmd/flux-resource.py
@@ -48,6 +48,7 @@ def drain(args):
         flux.Flux(),
         "resource.drain",
         {"targets": args.targets, "reason": " ".join(args.reason)},
+        nodeid=0,
     ).get()
 
 
@@ -55,7 +56,7 @@ def undrain(args):
     """
     Send an "undrain" request to resource module for args.targets
     """
-    RPC(flux.Flux(), "resource.undrain", {"targets": args.targets}).get()
+    RPC(flux.Flux(), "resource.undrain", {"targets": args.targets}, nodeid=0).get()
 
 
 class StatusLine:

--- a/t/t2310-resource-module.t
+++ b/t/t2310-resource-module.t
@@ -195,6 +195,19 @@ test_expect_success 'resource.get-xml blocks until all ranks are up' '
 	flux python ${SHARNESS_TEST_SRCDIR}/resource/get-xml-test.py
 '
 
+test_expect_success 'flux resource status works on rank > 0' '
+	flux exec -r 1 flux resource status
+'
+
+status_onrank() {
+	flux python -c "import flux; print(flux.Flux().rpc(\"resource.status\",nodeid=$1).get())"
+}
+
+test_expect_success 'resource.status RPC fails on rank > 0' '
+	test_must_fail status_onrank 1 2>status.err &&
+	grep "only works on rank 0" status.err
+'
+
 test_expect_success 'unload resource module' '
 	flux exec -r all flux module remove resource
 '

--- a/t/t2310-resource-module.t
+++ b/t/t2310-resource-module.t
@@ -113,8 +113,8 @@ test_expect_success 'flux resource reload fails on nonexistent XML directory' '
 '
 
 test_expect_success 'flux resource reload fails on empty XML directory' '
-    mkdir empty &&
-    test_must_fail flux resource reload -x $(pwd)/empty
+	mkdir empty &&
+	test_must_fail flux resource reload -x $(pwd)/empty
 '
 
 test_expect_success HAVE_JQ 'extract hwloc XML from JSON object' '
@@ -192,7 +192,7 @@ test_expect_success HAVE_JQ 'all ranks were drained' '
 '
 
 test_expect_success 'resource.get-xml blocks until all ranks are up' '
-    flux python ${SHARNESS_TEST_SRCDIR}/resource/get-xml-test.py
+	flux python ${SHARNESS_TEST_SRCDIR}/resource/get-xml-test.py
 '
 
 test_expect_success 'unload resource module' '


### PR DESCRIPTION
This ties up a couple of loose ends in the `flux resource` command.  `status`, `drain`, and `undrain` didn't work, and were not being tested on, ranks other than zero.