### PR TITLE
broker: improve IP address heuristic in PMI bootstrap

### DIFF
--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -298,6 +298,7 @@ int main (int argc, char *argv[])
     zsys_set_linger (5);
     zsys_set_rcvhwm (0);
     zsys_set_sndhwm (0);
+    zsys_set_ipv6 (1);
 
     /* Set up the flux reactor.
      */

--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -605,10 +605,8 @@ int overlay_bind (struct overlay *ov, const char *uri)
     zcert_apply (ov->cert, ov->child->zsock);
     zsock_set_curve_server (ov->child->zsock, 1);
 
-    if (zsock_bind (ov->child->zsock, "%s", ov->child->uri) < 0) {
-        log_err ("could not bind to %s", ov->child->uri);
+    if (zsock_bind (ov->child->zsock, "%s", ov->child->uri) < 0)
         return -1;
-    }
     if (strchr (ov->child->uri, '*')) { /* capture dynamically assigned port */
         char *newuri = zsock_last_endpoint (ov->child->zsock);
         if (!newuri)

--- a/src/common/libutil/ipaddr.c
+++ b/src/common/libutil/ipaddr.c
@@ -20,7 +20,6 @@
 #include <stdarg.h>
 #include <string.h>
 #include <stdio.h>
-#include <argz.h>
 
 #include "log.h"
 #include "ipaddr.h"
@@ -55,51 +54,6 @@ int ipaddr_getprimary (char *buf, int len, char *errstr, int errstrsz)
     }
     freeaddrinfo (res);
     return 0;
-}
-
-int ipaddr_getall (char **addrs, size_t *addrssz, char *errstr, int errstrsz)
-{
-    struct ifaddrs *ifaddr = NULL;
-    struct ifaddrs *ifa;
-    int family;
-    int e;
-    char host[NI_MAXHOST];
-    int rc = -1;
-
-    if (getifaddrs (&ifaddr) < 0) {
-        if (errstr)
-            snprintf (errstr, errstrsz, "getifaddrs: %s", strerror (errno));
-        return -1;
-    }
-    /* Ref: getifaddrs(3) example */
-    for (ifa = ifaddr; ifa != NULL; ifa = ifa->ifa_next) {
-        if (ifa->ifa_addr == NULL)
-            continue;
-        family = ifa->ifa_addr->sa_family;
-        if (family != AF_INET && family != AF_INET6)
-            continue;
-        e = getnameinfo (ifa->ifa_addr,
-                         family == AF_INET ? sizeof (struct sockaddr_in)
-                                           : sizeof (struct sockaddr_in6),
-                         host, NI_MAXHOST,
-                         NULL, 0, NI_NUMERICHOST);
-        if (e != 0) {
-            if (errstr)
-                snprintf (errstr, errstrsz, "getnameinfo: %s",
-                          gai_strerror (e));
-            goto done;
-        }
-        if ((e = argz_add (addrs, addrssz, host)) != 0) {
-            if (errstr)
-                snprintf (errstr, errstrsz, "argz_add: %s", strerror (errno));
-            goto done;
-        }
-    }
-    rc = 0;
-done:
-    if (ifaddr)
-        freeifaddrs (ifaddr);
-    return rc;
 }
 
 /*

--- a/src/common/libutil/ipaddr.c
+++ b/src/common/libutil/ipaddr.c
@@ -24,6 +24,18 @@
 #include "log.h"
 #include "ipaddr.h"
 
+static __attribute__ ((format (printf, 3, 4)))
+void esprintf (char *buf, int len, const char *fmt, ...)
+{
+    if (buf) {
+        va_list ap;
+
+        va_start (ap, fmt);
+        vsnprintf (buf, len, fmt, ap);
+        va_end (ap);
+    }
+}
+
 int ipaddr_getprimary (char *buf, int len, char *errstr, int errstrsz)
 {
     char hostname[HOST_NAME_MAX + 1];
@@ -31,8 +43,7 @@ int ipaddr_getprimary (char *buf, int len, char *errstr, int errstrsz)
     int e;
 
     if (gethostname (hostname, sizeof (hostname)) < 0) {
-        if (errstr)
-            snprintf (errstr, errstrsz, "gethostname: %s", strerror (errno));
+        esprintf (errstr, errstrsz, "gethostname: %s", strerror (errno));
         return -1;
     }
     memset (&hints, 0, sizeof (hints));
@@ -40,15 +51,13 @@ int ipaddr_getprimary (char *buf, int len, char *errstr, int errstrsz)
     hints.ai_socktype = SOCK_STREAM;
 
     if ((e = getaddrinfo (hostname, NULL, &hints, &res)) || res == NULL) {
-        if (errstr)
-            snprintf (errstr, errstrsz, "getaddrinfo %s: %s",
-                      hostname, gai_strerror (e));
+        esprintf (errstr, errstrsz, "getaddrinfo %s: %s",
+                  hostname, gai_strerror (e));
         return -1;
     }
     if ((e = getnameinfo (res->ai_addr, res->ai_addrlen, buf, len,
                           NULL, 0, NI_NUMERICHOST))) {
-        if (errstr)
-            snprintf (errstr, errstrsz, "getnameinfo: %s", gai_strerror (e));
+        esprintf (errstr, errstrsz, "getnameinfo: %s", gai_strerror (e));
         freeaddrinfo (res);
         return -1;
     }

--- a/src/common/libutil/ipaddr.h
+++ b/src/common/libutil/ipaddr.h
@@ -11,10 +11,26 @@
 #ifndef _UTIL_GETIP_H
 #define _UTIL_GETIP_H
 
-#include <sys/types.h>
+#include <sys/socket.h> // for AF_INET, AF_INET6
 
-/* Get ip address associated with primary hostname.
- * Return it as a string in buf (up to len bytes, always null terminated)
+/* Guess at a usable network address for the local node using one
+ * of these methods:
+ * 1. Find the interface associated with the default route, then
+ *    look up address of that interface.
+ * 2. Look up address associated with the hostname
+ *
+ * Main use case: determine bind address for a PMI-bootstrapped flux broker.
+ *
+ * Some environment variables alter the default behavior:
+ *
+ * FLUX_IPADDR_IPV6
+ *   if set, IPv6 addresses are preferred, with fallback to IPv4
+ *   if unset, IPv4 addresses are preferred, wtih fallback to IPv6
+ * FLUX_IPADDR_HOSTNAME
+ *   if set, only method 2 is tried above
+ *   if unset, first method 1 is tried, then if that fails, method 2 is tried
+ *
+ * Return address as a string in buf (up to len bytes, always null terminated)
  * Return 0 on success, -1 on error with error message written to errstr
  * if non-NULL.
  */

--- a/src/common/libutil/ipaddr.h
+++ b/src/common/libutil/ipaddr.h
@@ -20,15 +20,6 @@
  */
 int ipaddr_getprimary (char *buf, int len, char *errstr, int errstrsz);
 
-
-/* Get a list of all stringified ip addresses associated with interfaces on
- * the local host.  The result is appended to 'addrs', 'addrsz', an argz list
- * that must be initialized as described in argz_add(3).  Both AF_INET
- * and AF_INET6 address families are included in the list.  Return 0 on
- * success, -1 on error with error message written to errstr if non-NULL.
- */
-int ipaddr_getall (char **addrs, size_t *addrssz, char *errstr, int errstrsz);
-
 #endif /* !_UTIL_GETIP_H */
 
 /*

--- a/src/common/libutil/test/ipaddr.c
+++ b/src/common/libutil/test/ipaddr.c
@@ -9,27 +9,58 @@
 \************************************************************/
 
 #include <sys/param.h>
-#include <argz.h>
 
 #include "src/common/libtap/tap.h"
 #include "src/common/libutil/ipaddr.h"
 
+
+static void setopt (const char *name, int val)
+{
+    if (val) {
+        if (setenv (name, "1", 1) < 0)
+            BAIL_OUT ("setenv %s", name);
+    }
+    else {
+        if (unsetenv (name) < 0)
+            BAIL_OUT ("unsetenv %s", name);
+    }
+}
+
 int main(int argc, char** argv)
 {
     char host[MAXHOSTNAMELEN + 1];
-    char errstr[200];
+    char err[200];
     int n;
 
     plan (NO_PLAN);
 
-    memset (errstr, 0, sizeof (errstr));
-    n = ipaddr_getprimary (host, sizeof (host), errstr, sizeof (errstr));
+    setopt ("FLUX_IPADDR_HOSTNAME", 0);
+    setopt ("FLUX_IPADDR_V6", 0);
+    n = ipaddr_getprimary (host, sizeof (host), err, sizeof (err));
     ok (n == 0,
-        "ipaddr_getprimary works");
-    if (n == 0)
-        diag ("primary: %s", host);
-    else
-        diag ("Error: %s", errstr);
+        "ipaddr_getprimary (hostname=0 v6=0) works");
+    diag ("%s", n == 0 ? host : err);
+
+    setopt ("FLUX_IPADDR_HOSTNAME", 0);
+    setopt ("FLUX_IPADDR_V6", 1);
+    n = ipaddr_getprimary (host, sizeof (host), err, sizeof (err));
+    ok (n == 0,
+        "ipaddr_getprimary (hostname=0 v6=1) works");
+    diag ("%s", n == 0 ? host : err);
+
+    setopt ("FLUX_IPADDR_HOSTNAME", 1);
+    setopt ("FLUX_IPADDR_V6", 0);
+    n = ipaddr_getprimary (host, sizeof (host), err, sizeof (err));
+    ok (n == 0,
+        "ipaddr_getprimary (hostname=1 v6=0) works");
+    diag ("%s", n == 0 ? host : err);
+
+    setopt ("FLUX_IPADDR_HOSTNAME", 1);
+    setopt ("FLUX_IPADDR_V6", 1);
+    n = ipaddr_getprimary (host, sizeof (host), err, sizeof (err));
+    ok (n == 0,
+        "ipaddr_getprimary (hostname=1 v6=1)");
+    diag ("%s", n == 0 ? host : err);
 
     done_testing();
 }

--- a/src/common/libutil/test/ipaddr.c
+++ b/src/common/libutil/test/ipaddr.c
@@ -18,23 +18,18 @@ int main(int argc, char** argv)
 {
     char host[MAXHOSTNAMELEN + 1];
     char errstr[200];
-    char *addrs = NULL;
-    size_t addrs_len = 0;
-    const char *entry = NULL;
+    int n;
 
     plan (NO_PLAN);
 
     memset (errstr, 0, sizeof (errstr));
-    ok (ipaddr_getprimary (host, sizeof (host), errstr, sizeof (errstr)) == 0,
-        "ipaddr_getprimary works: errstr=%s", errstr);
-    diag ("primary: %s", host);
-
-    ok (ipaddr_getall (&addrs, &addrs_len, errstr, sizeof (errstr)) == 0,
-        "ipaddrs_getall works");
-    while ((entry = argz_next (addrs, addrs_len, entry)))
-        diag ("%s", entry);
-
-    free (addrs);
+    n = ipaddr_getprimary (host, sizeof (host), errstr, sizeof (errstr));
+    ok (n == 0,
+        "ipaddr_getprimary works");
+    if (n == 0)
+        diag ("primary: %s", host);
+    else
+        diag ("Error: %s", errstr);
 
     done_testing();
 }


### PR DESCRIPTION
When the broker bootstraps with PMI, it calls an internal function `ipaddr_getprimary()` that guesses the IP address it sould bind to for downstream TBON peers.  `ipaddr_getprimary()` currently returns the first IP address assigned to the hostname.  On systems like Ubuntu that assign the hostname a local-only address in `/etc/hosts`, a Flux system instance spanning multiple nodes creates batch jobs that cannot wire up.  In addition, IPv6 addresses could be returned, but zeromq is not configured to allow them to work.

This PR changes the heuristic in `ipaddr_getprimary()` to first look up the interface associated with the default route, and use its address if available.  If there is no default route, then fall back to the hostname method.

Zeromq handling of IPv6 addresses is enabled, and an argument for expressing an address family preference is added, defaulting to IPv4 in the PMI bootstrap.  If the `FLUX_IPADDR_V6` environment variable is set, set the preference to IPv6.  If an address in the preferred address family is unavailable, fall back to the other address family.