### PR TITLE
job-manager: allow jobtap plugins to reject jobs

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -258,7 +258,8 @@ MAN3_FILES_SECONDARY = \
 	man3/flux_jobtap_service_register.3 \
 	man3/flux_jobtap_reprioritize_all.3 \
 	man3/flux_jobtap_reprioritize_job.3 \
-	man3/flux_jobtap_priority_unavail.3
+	man3/flux_jobtap_priority_unavail.3 \
+	man3/flux_jobtap_reject_job.3
 
 MAN5_FILES = $(MAN5_FILES_PRIMARY)
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -349,6 +349,7 @@ man_pages = [
     ('man3/flux_jobtap_get_flux','flux_jobtap_reprioritize_all', 'Flux jobtap plugin interfaces', [author], 3),
     ('man3/flux_jobtap_get_flux','flux_jobtap_reprioritize_job', 'Flux jobtap plugin interfaces', [author], 3),
     ('man3/flux_jobtap_get_flux','flux_jobtap_priority_unavail', 'Flux jobtap plugin interfaces', [author], 3),
+    ('man3/flux_jobtap_get_flux','flux_jobtap_reject_job', 'Flux jobtap plugin interfaces', [author], 3),
     ('man5/flux-config-bootstrap', 'flux-config-bootstrap', 'configure Flux instance bootstrap', [author], 5),
     ('man7/flux-broker-attributes', 'flux-broker-attributes', 'overview Flux broker attributes', [author], 7),
     ('man7/flux-jobtap-plugins', 'flux-jobtap-plugins', 'overview Flux jobtap plugin API', [author], 7),

--- a/doc/man3/flux_jobtap_get_flux.rst
+++ b/doc/man3/flux_jobtap_get_flux.rst
@@ -37,6 +37,12 @@ SYNOPSIS
    int flux_jobtap_priority_unavail (flux_plugin_t *p,
                                      flux_plugin_arg_t *args);
 
+::
+
+   int flux_jobtap_reject_job (flux_plugin_t *p,
+                               flux_plugin_arg_t *args,
+                               const char *fmt, ...);
+
 
 DESCRIPTION
 ===========
@@ -71,6 +77,15 @@ called as::
 
    return flux_jobtap_priority_unavail (p, args);
 
+``flux_jobtap_reject_job()`` is a convenience function which may be used
+by a plugin from the ``job.validate`` callback to reject a job before its
+submission is fully complete. The error and optional message supplied in
+``fmt`` will be returned to the originating job submission request. This
+function returns ``-1`` so that it may be conveniently called as::
+
+  return flux_jobtap_reject_job (p, args,
+                                 "User exceeded %d jobs",
+                                 limit);
 
 RETURN VALUE
 ============
@@ -78,6 +93,9 @@ RETURN VALUE
 ``flux_jobtap_get_flux()`` returns a ``flux_t *`` handle on success. ``NULL``
 is returned with errno set to ``EINVAL`` if the supplied ``flux_plugin_t *p``
 is not a jobtap plugin handle.
+
+``flux_jobtap_reject_job()`` always returns ``-1`` so that it may be used
+to exit the ``job.validate`` callback.
 
 The remaining functions return 0 on success, -1 on failure.
 

--- a/doc/man7/flux-jobtap-plugins.rst
+++ b/doc/man7/flux-jobtap-plugins.rst
@@ -90,6 +90,18 @@ CALLBACK TOPICS
 The following callback "topic strings" are currently provided by the
 *jobtap* interface:
 
+job.validate
+  The ``job.validate`` topic allows a plugin to reject a job before
+  it is introduced to the job manager. A rejected job will result in
+  a job submission error in the submitting client, and any job data in
+  the KVS will be purged. No further callbacks will be made for rejected
+  jobs. Note: If a job is not rejected, then the ``job.new`` callback will
+  be invoked immediately after ``job.validate``. This allows limits or
+  other validation to be implemented in the ``job.validate`` callback,
+  but accounting for those limits should be confined to the ``job.new``
+  callback, since ``job.new`` may also be called during job-manager
+  restart or plugin reload.
+
 job.new
   The ``job.new`` topic is used by the job manager to notify a jobtap plugin
   about a newly introduced job. This call may be made in three different

--- a/src/modules/job-ingest/job-ingest.c
+++ b/src/modules/job-ingest/job-ingest.c
@@ -22,6 +22,7 @@
 
 #include "src/common/libutil/fluid.h"
 #include "src/common/libjob/sign_none.h"
+#include "src/common/libjob/job_hash.h"
 #include "src/common/libeventlog/eventlog.h"
 
 #include "validate.h"
@@ -115,6 +116,14 @@ struct batch {
     flux_kvs_txn_t *txn;
     zlist_t *jobs;
     json_t *joblist;
+};
+
+struct batch_response {
+    flux_future_t *f;
+    bool batch_failed;
+    int errnum;
+    const char *errmsg;
+    zhashx_t *errors;
 };
 
 static int make_key (char *buf, int bufsz, struct job *job, const char *name);
@@ -233,8 +242,86 @@ error:
     return NULL;
 }
 
-/* Respond to all requestors (for each job) with errnum and errstr (required).
- */
+static void batch_response_destroy (struct batch_response *bresp)
+{
+    if (bresp) {
+        zhashx_destroy (&bresp->errors);
+        flux_future_destroy (bresp->f);
+        free (bresp);
+    }
+}
+
+static void *jobid_duplicator (const void *item)
+{
+    flux_jobid_t *id = calloc (1, sizeof (flux_jobid_t));
+    *id = *((flux_jobid_t *)item);
+    return id;
+}
+
+static void jobid_destructor (void **item)
+{
+    if (item) {
+        free (*item);
+        *item = NULL;
+    }
+}
+
+static struct batch_response *batch_response_create (flux_future_t *f)
+{
+    struct batch_response *bresp = NULL;
+    json_t *o = NULL;
+    json_t *entry = NULL;
+    size_t index;
+
+    if (!(bresp = calloc (1, sizeof (*bresp)))
+        || !(bresp->errors = job_hash_create ()))
+        goto error;
+    zhashx_set_key_duplicator (bresp->errors, jobid_duplicator);
+    zhashx_set_key_destructor (bresp->errors, jobid_destructor);
+    bresp->f = f;
+    flux_future_incref (f);
+
+    /*  We differentiate future fulfilled with error (entire batch failed)
+     *   and failure to unpack payload (EPROTO). This is why "future_get"
+     *   is called twice below:
+     */
+    if (flux_rpc_get (f, NULL) < 0) {
+        bresp->errnum = errno;
+        bresp->errmsg = future_strerror (f, errno);
+        bresp->batch_failed = true;
+        return bresp;
+    }
+    if (flux_rpc_get_unpack (f, "{s?o}", "errors", &o) < 0) {
+        errno = EPROTO;
+        goto error;
+    }
+    /*  Empty payload indicates the whole batch was successful
+     */
+    if (o == NULL)
+        return bresp;
+
+    /*  O/w, there were zero or more failures sent in the errors array.
+     *   Capture these in the response errors hash.
+     */
+    json_array_foreach (o, index, entry) {
+        flux_jobid_t id;
+        char *errmsg;
+        if (json_unpack (entry, "[Is]", &id, &errmsg) < 0) {
+            errno = EPROTO;
+            goto error;
+        }
+        if (zhashx_insert (bresp->errors, &id, errmsg) < 0) {
+            /* jobid duplicated? Should not happen */
+            errno = EPROTO;
+            goto error;
+        }
+    }
+    return bresp;
+error:
+    batch_response_destroy (bresp);
+    return NULL;
+}
+
 static void batch_respond_error (struct batch *batch,
                                  int errnum, const char *errstr)
 {
@@ -247,14 +334,26 @@ static void batch_respond_error (struct batch *batch,
     }
 }
 
-/* Respond to all requestors (for each job) with their id.
+/* Respond to all requestors (for each job) with their id or an error if
+ *  job submit failed
  */
-static void batch_respond_success (struct batch *batch)
+static void batch_respond (struct batch *batch, struct batch_response *br)
 {
     flux_t *h = batch->ctx->h;
+    const char *errmsg;
     struct job *job = zlist_first (batch->jobs);
+
+    if (br->batch_failed) {
+        batch_respond_error (batch, br->errnum, br->errmsg);
+        return;
+    }
+
     while (job) {
-        if (flux_respond_pack (h, job->msg, "{s:I}", "id", job->id) < 0)
+        if ((errmsg = zhashx_lookup (br->errors, &job->id))) {
+            if (flux_respond_error (h, job->msg, EINVAL, errmsg) < 0)
+                flux_log_error (h, "batch_respond: flux_respond_error");
+        }
+        else if (flux_respond_pack (h, job->msg, "{s:I}", "id", job->id) < 0)
             flux_log_error (h, "%s: flux_respond_pack", __FUNCTION__);
         job = zlist_next (batch->jobs);
     }
@@ -269,30 +368,38 @@ static void batch_cleanup_continuation (flux_future_t *f, void *arg)
     flux_future_destroy (f);
 }
 
-/* Remove KVS job entries previously committed for all jobs in batch.
+/* Remove KVS job entries previously committed for all failed jobs in batch.
  */
-static int batch_cleanup (struct batch *batch)
+static int batch_cleanup (struct batch *batch, struct batch_response *br)
 {
     flux_t *h = batch->ctx->h;
     flux_kvs_txn_t *txn;
     struct job *job;
     flux_future_t *f = NULL;
     char key[64];
+    int count = 0;
 
     if (!(txn = flux_kvs_txn_create ()))
         return -1;
     job = zlist_first (batch->jobs);
     while (job) {
-        if (make_key (key, sizeof (key), job, NULL) < 0)
-            goto error;
-        if (flux_kvs_txn_unlink (txn, 0, key) < 0)
-            goto error;
+        if (br == NULL
+            || br->batch_failed
+            || zhashx_lookup (br->errors, &job->id)) {
+            if (make_key (key, sizeof (key), job, NULL) < 0)
+                goto error;
+            if (flux_kvs_txn_unlink (txn, 0, key) < 0)
+                goto error;
+            count++;
+        }
         job = zlist_next (batch->jobs);
     }
-    if (!(f = flux_kvs_commit (h, NULL, 0, txn)))
-        goto error;
-    if (flux_future_then (f, -1., batch_cleanup_continuation, NULL) < 0)
-        goto error;
+    if (count > 0) {
+        if (!(f = flux_kvs_commit (h, NULL, 0, txn)))
+            goto error;
+        if (flux_future_then (f, -1., batch_cleanup_continuation, NULL) < 0)
+            goto error;
+    }
     flux_kvs_txn_destroy (txn);
     return 0;
 error:
@@ -307,17 +414,23 @@ error:
 static void batch_announce_continuation (flux_future_t *f, void *arg)
 {
     struct batch *batch = arg;
+    struct batch_response *bresp;
     flux_t *h = batch->ctx->h;
 
-    if (flux_future_get (f, NULL) < 0) {
-        batch_respond_error (batch, errno, future_strerror (f, errno));
-        if (batch_cleanup (batch) < 0)
-            flux_log_error (h, "%s: KVS cleanup failure", __FUNCTION__);
-    }
+    if (!(bresp = batch_response_create (f)))
+        batch_respond_error (batch,
+                             errno,
+                             "Failed to process batch response");
     else
-        batch_respond_success (batch);
+        batch_respond (batch, bresp);
+
+    /*  Clean up any state in KVS for failed jobs
+     */
+    if (batch_cleanup (batch, bresp) < 0)
+        flux_log_error (h, "%s: KVS cleanup failure", __FUNCTION__);
 
     batch_destroy (batch);
+    batch_response_destroy (bresp);
     flux_future_destroy (f);
 }
 
@@ -338,7 +451,7 @@ static void batch_announce (struct batch *batch)
 error:
     flux_log_error (h, "%s: error sending RPC", __FUNCTION__);
     batch_respond_error (batch, errno, "error sending job-manager.submit RPC");
-    if (batch_cleanup (batch) < 0)
+    if (batch_cleanup (batch, NULL) < 0)
         flux_log_error (h, "%s: KVS cleanup failure", __FUNCTION__);
     batch_destroy (batch);
     flux_future_destroy (f);
@@ -383,7 +496,7 @@ static void batch_flush (flux_reactor_t *r, flux_watcher_t *w,
     if (flux_future_then (f, -1., batch_flush_continuation, batch) < 0) {
         batch_respond_error (batch, errno, "flux_future_then (kvs) failed");
         flux_future_destroy (f);
-        if (batch_cleanup (batch) < 0)
+        if (batch_cleanup (batch, NULL) < 0)
             flux_log_error (ctx->h, "%s: KVS cleanup failure", __FUNCTION__);
         goto error;
     }

--- a/src/modules/job-manager/jobtap-internal.h
+++ b/src/modules/job-manager/jobtap-internal.h
@@ -39,6 +39,15 @@ int jobtap_get_priority (struct jobtap *jobtap,
                          struct job *job,
                          int64_t *pprio);
 
+
+/*  Jobtap call specific to validating a job during submission. If the
+ *   plugin returns failure from this callback the job will be rejected
+ *   with an optional error message passed back in `errp`.
+ */
+int jobtap_validate (struct jobtap *jobtap,
+                     struct job *job,
+                     char **errp);
+
 /*  Load a new jobtap from `path`. Path may start with `builtin.` to
  *   attempt to load one of the builtin jobtap plugins.
  */

--- a/src/modules/job-manager/jobtap.c
+++ b/src/modules/job-manager/jobtap.c
@@ -654,6 +654,42 @@ int flux_jobtap_priority_unavail (flux_plugin_t *p, flux_plugin_arg_t *args)
                                  "priority", FLUX_JOBTAP_PRIORITY_UNAVAIL);
 }
 
+int flux_jobtap_reject_job (flux_plugin_t *p,
+                            flux_plugin_arg_t *args,
+                            const char *fmt,
+                            ...)
+{
+    char errmsg [1024];
+    int len = sizeof (errmsg);
+    int n;
+
+    if (fmt) {
+        va_list ap;
+        va_start (ap, fmt);
+        n = vsnprintf (errmsg, sizeof (errmsg), fmt, ap);
+        va_end (ap);
+    }
+    else {
+        n = snprintf (errmsg,
+                      sizeof (errmsg),
+                      "rejected by job-manager plugin '%s'",
+                      jobtap_plugin_name (p));
+    }
+    if (n >= len) {
+        errmsg[len - 1] = '\0';
+        errmsg[len - 2] = '+';
+    }
+    if (flux_plugin_arg_pack (args,
+                              FLUX_PLUGIN_ARG_OUT|FLUX_PLUGIN_ARG_UPDATE,
+                              "{s:s}",
+                              "errmsg", errmsg) < 0) {
+        flux_t *h = flux_jobtap_get_flux (p);
+        if (h)
+            flux_log_error (h, "flux_jobtap_reject_job: failed to pack error");
+    }
+    return -1;
+}
+
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab
  */

--- a/src/modules/job-manager/jobtap.h
+++ b/src/modules/job-manager/jobtap.h
@@ -54,6 +54,18 @@ int flux_jobtap_reprioritize_job (flux_plugin_t *p,
 int flux_jobtap_priority_unavail (flux_plugin_t *p,
                                   flux_plugin_arg_t *args);
 
+
+/*  Convenience function to be used in job.validate callback to reject a
+ *   job with error message formatted by the fmt string.
+ *   returns -1 to allow an idiom like:
+ *
+ *   return flux_jobtap_reject_job (p, args, "failed validation");
+ */
+int flux_jobtap_reject_job (flux_plugin_t *p,
+                            flux_plugin_arg_t *args,
+                            const char *fmt, ...)
+                            __attribute__ ((format (printf, 3, 4)));
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/modules/job-manager/submit.c
+++ b/src/modules/job-manager/submit.c
@@ -211,7 +211,7 @@ static void submit_cb (flux_t *h, flux_msg_handler_t *mh,
         flux_log_error (h, "%s: error enqueuing batch", __FUNCTION__);
         goto error;
     }
-    if (flux_respond (h, msg, NULL) < 0)
+    if (flux_respond (h, msg, "{}") < 0)
         flux_log_error (h, "%s: flux_respond", __FUNCTION__);
 
     /* Submitting user is being responded to with jobid's.

--- a/src/modules/job-manager/submit.h
+++ b/src/modules/job-manager/submit.h
@@ -23,9 +23,9 @@ struct submit *submit_ctx_create (struct job_manager *ctx);
 void submit_ctx_destroy (struct submit *submit);
 
 /* exposed for unit testing only */
-int submit_add_one_job (zhashx_t *active_jobs, zlist_t *newjobs, json_t *o);
-void submit_add_jobs_cleanup (zhashx_t *active_jobs, zlist_t *newjobs);
-zlist_t *submit_add_jobs (zhashx_t *active_jobs, json_t *jobs);
+void submit_add_jobs_cleanup (zhashx_t *active_jobs, zlistx_t *newjobs);
+zlistx_t *submit_jobs_to_list (json_t *jobs);
+int submit_hash_jobs (zhashx_t *active_jobs, zlistx_t *newjobs);
 
 #endif /* ! _FLUX_JOB_MANAGER_SUBMIT_H */
 

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -333,7 +333,8 @@ check_LTLIBRARIES = \
 	job-manager/plugins/priority-invert.la \
 	job-manager/plugins/args.la \
 	job-manager/plugins/test.la \
-	job-manager/plugins/random.la
+	job-manager/plugins/random.la \
+	job-manager/plugins/validate.la
 
 check-prep:
 	$(MAKE) $(check_PROGRAMS) $(check_LTLIBRARIES)
@@ -676,6 +677,16 @@ job_manager_plugins_random_la_CPPFLAGS = \
 job_manager_plugins_random_la_LDFLAGS = \
 	-module -rpath /nowhere
 job_manager_plugins_random_la_LIBADD = \
+	$(top_builddir)/src/common/libflux-core.la
+
+
+job_manager_plugins_validate_la_SOURCES = \
+	job-manager/plugins/validate.c
+job_manager_plugins_validate_la_CPPFLAGS = \
+	$(test_cppflags)
+job_manager_plugins_validate_la_LDFLAGS = \
+	-module -rpath /nowhere
+job_manager_plugins_validate_la_LIBADD = \
 	$(top_builddir)/src/common/libflux-core.la
 
 

--- a/t/ingest/job-manager-dummy.c
+++ b/t/ingest/job-manager-dummy.c
@@ -33,7 +33,7 @@ static void commit_continuation (flux_future_t *f, void *arg)
             flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
     }
     else {
-        if (flux_respond (h, msg, NULL) < 0)
+        if (flux_respond (h, msg, "{}") < 0)
             flux_log_error (h, "%s: flux_respond", __FUNCTION__);
     }
     flux_msg_destroy (msg);

--- a/t/job-manager/plugins/test.c
+++ b/t/job-manager/plugins/test.c
@@ -27,6 +27,16 @@ static int cb (flux_plugin_t *p,
         return -1;
     }
 
+    if (strcmp (topic, "job.validate") == 0) {
+        if (strcmp (test_mode, "validate failure") == 0)
+            return flux_jobtap_reject_job (p, args, "rejected for testing");
+        if (strcmp (test_mode, "validate failure nullmsg") == 0)
+            return flux_jobtap_reject_job (p, args, NULL);
+        if (strcmp (test_mode, "validate failure nomsg") == 0)
+            return -1;
+        return 0;
+    }
+
     /*  Update annotations with the test mode:
      */
     if (flux_plugin_arg_pack (args,

--- a/t/job-manager/plugins/validate.c
+++ b/t/job-manager/plugins/validate.c
@@ -1,0 +1,44 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* Test plugin which limits job to 4 per user */
+
+#include <stdio.h>
+
+#include <flux/core.h>
+#include <flux/jobtap.h>
+
+static int reject_id = 4;
+
+static int validate (flux_plugin_t *p,
+                     const char *topic,
+                     flux_plugin_arg_t *args,
+                     void *arg)
+{
+    int i;
+    /* Failure to unpack not an error, just let jobs without
+     *  validate-test-id through
+     */
+    if (flux_plugin_arg_unpack (args, FLUX_PLUGIN_ARG_IN,
+                                "{s:{s:{s:{s:{s:i}}}}}",
+                                "jobspec",
+                                 "attributes", "system", "jobtap",
+                                  "validate-test-id", &i) < 0)
+        return 0;
+    if (i == reject_id)
+        return flux_jobtap_reject_job (p, args, "Job had reject_id == %d", i);
+    return 0;
+}
+
+int flux_plugin_init (flux_plugin_t *p)
+{
+    flux_plugin_set_name (p, "test-validate");
+    return flux_plugin_add_handler (p, "job.validate", validate, NULL);
+}

--- a/t/t2200-job-ingest.t
+++ b/t/t2200-job-ingest.t
@@ -215,6 +215,17 @@ test_expect_success 'job-ingest: validator unexpected exit is handled' '
 	grep "unexpectedly exited" badvalidator.out
 '
 
+test_expect_success 'job-ingest: reload dummy job-manager in fail mode' '
+	ingest_module reload batch-count=4 &&
+	flux module remove job-manager &&
+	flux module load \
+	    ${FLUX_BUILD_DIR}/t/ingest/.libs/job-manager-dummy.so force_fail
+'
+
+test_expect_success 'job-ingest: handle total batch failure in job-ingest' '
+	test_must_fail flux mini submit --cc=1-4 hostname
+'
+
 test_expect_success 'job-ingest: remove modules' '
 	flux module remove job-manager &&
 	flux exec -r all flux module remove job-ingest

--- a/t/t2216-job-manager-plugins.t
+++ b/t/t2216-job-manager-plugins.t
@@ -140,7 +140,7 @@ test_expect_success 'job-manager: run args test plugin' '
 	flux mini run hostname &&
 	flux dmesg | grep args-check > args-check.log &&
 	test_debug "cat args-check.log" &&
-	test $(grep -c OK args-check.log) = 7
+	test $(grep -c OK args-check.log) = 8
 '
 test_expect_success 'job-manager: load test jobtap plugin' '
 	flux jobtap load ${PLUGINPATH}/test.so foo.test=1 &&

--- a/t/t2216-job-manager-plugins.t
+++ b/t/t2216-job-manager-plugins.t
@@ -186,6 +186,26 @@ test_expect_success 'job-manager: run test plugin modes for priority.get' '
 	test_debug "flux dmesg | grep jobtap\.test" &&
 	run_timeout 20 flux job wait -v --all
 '
+test_expect_success 'job-manager: run test plugin modes for job.validate' '
+	test_expect_code 1 \
+	    flux mini submit\
+	        --setattr=system.jobtap.test-mode="validate failure" \
+	        hostname >validate-failure.out 2>&1 &&
+	test_debug "cat validate-failure.out" &&
+	grep "rejected for testing" validate-failure.out &&
+	test_expect_code 1 \
+	    flux mini submit\
+	        --setattr=system.jobtap.test-mode="validate failure nullmsg" \
+	        hostname >validate-failure2.out 2>&1 &&
+	test_debug "cat validate-failure2.out" &&
+	grep "rejected by job-manager plugin" validate-failure2.out &&
+	test_expect_code 1 \
+	    flux mini submit\
+	        --setattr=system.jobtap.test-mode="validate failure nomsg" \
+	        hostname >validate-failure3.out 2>&1 &&
+	test_debug "cat validate-failure3.out" &&
+	grep "rejected by job-manager plugin" validate-failure3.out
+'
 test_expect_success 'job-manager: plugin can keep job in PRIORITY state' '
 	flux jobtap load ${PLUGINPATH}/priority-wait.so &&
 	jobid=$(flux mini submit hostname) &&
@@ -208,5 +228,16 @@ test_expect_success 'job-manager: job exits PRIORITY when priority is set' '
 	flux job wait-event -vt 5 $jobid clean &&
 	flux jobs -no {priority} $jobid &&
 	test $(flux jobs -no {priority} $jobid) = 42000
+'
+test_expect_success 'job-manager: plugin can reject some jobs in a batch' '
+	flux module reload job-ingest batch-count=6 &&
+	flux jobtap load ${PLUGINPATH}/validate.so &&
+	test_expect_code 1 \
+	    flux mini bulksubmit --watch \
+	        --setattr=system.jobtap.validate-test-id={} \
+	        echo foo ::: 1 1 1 4 4 1 >validate-plugin.out 2>&1 &&
+	test_debug "cat validate-plugin.out" &&
+	grep "Job had reject_id" validate-plugin.out &&
+	test 4 -eq $(grep -c foo validate-plugin.out)
 '
 test_done


### PR DESCRIPTION
This PR changes the `job-manager.submit` protocol that job-ingest uses to submit batches of submitted jobs to the job manager. As described in #3472, job-ingest currently sends jobs in batches to the job manager in an all-or-nothing  approach, either the whole batch succeeds or it fails.

This PR extends that protocol to allow the job-manager to fail individual jobs. The response to `job-manager.submit` now may contain an optional `errors` key which is a list of `[jobid, errmsg]` tuples, each of which indicates that the given `jobid` failed. This allows one or more of a batch of jobs to be failed, each with a different error message.

Finally, a new jobtap hook `job.validate` is added which is called before a job is added to the job manager active jobs hash. A plugin can reject a job from this hook by returning `< 0`, with an optional `errmg` pushed onto the `FLUX_PLUGIN_ARG_OUT`. A convenience function, `flux_jobtap_reject_job ()` is added to allow a plugin to both push an error message onto the OUT args and return `-1` from the `job.validate` callback.

I tested this and it doesn't seem to horribly affect the ingest rate.