### PR TITLE
ci: add fedora33 docker image for testing

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -14,15 +14,13 @@ jobs:
     - name: docker-run-checks with ASan
       timeout-minutes: 40
       env:
-        CC: gcc-8
-        CXX: g++-8
-        PRELOAD: /usr/lib/gcc/x86_64-linux-gnu/8/libasan.so
-        ASAN_OPTIONS: detect_leaks=0,start_deactivated=true
+        PRELOAD: /usr/lib64/libasan.so.6
+        ASAN_OPTIONS: detect_leaks=0,start_deactivated=true,replace_str=true
         FLUX_TEST_TIMEOUT: 300
         TAP_DRIVER_QUIET: t
       run: >
         src/test/docker/docker-run-checks.sh \
-          --image=bionic --unit-test-only -j2 \
+          --image=fedora33 --unit-test-only -j2 \
           -- --with-flux-security --enable-sanitizer=address
 
     - name: after failure

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -14,6 +14,7 @@ pull_request_rules:
       - status-success="focal - py3.8"
       - status-success="centos7"
       - status-success="centos8 - py3.7"
+      - status-success="fedora33 - gcc-10,py3.9"
       - status-success="coverage"
       - status-success="address-sanitizer check"
       - label="merge-when-passing"

--- a/src/cmd/flux-cron
+++ b/src/cmd/flux-cron
@@ -69,7 +69,7 @@ local function reladate (t)
     end
 
     if (diff < 90) then
-        return fmt ("%d seconds ago", diff)
+        return fmt ("%d seconds ago", math.floor(diff + 0.5))
     end
 
     -- Convert to minutes:

--- a/src/test/docker/README.md
+++ b/src/test/docker/README.md
@@ -48,12 +48,12 @@ pushed to DockerHub at `fluxrm/testenv:bionic` and
 script still runs against the new `testenv` images, e.g.:
 
 ```
-$ for i in bionic centos7 focal centos8; do
+$ for i in bionic focal centos7 centos8 fedora33; do
     make clean &&
     docker build --no-cache -t fluxrm/testenv:$i src/test/docker/$i &&
     src/test/docker/docker-run-checks.sh -j 4 --image=$i &&
     docker push fluxrm/testenv:$i
-   done
+  done
 ```
 
 #### Local Testing

--- a/src/test/docker/checks/Dockerfile
+++ b/src/test/docker/checks/Dockerfile
@@ -43,7 +43,7 @@ RUN set -x && groupadd fluxuser \
 RUN case $BASE_IMAGE in \
      bionic*) adduser $USER sudo && adduser fluxuser sudo ;; \
      focal*)  adduser $USER sudo && adduser fluxuser sudo ;; \
-     centos*) usermod -G wheel $USER && usermod -G wheel fluxuser ;; \
+     centos*|fedora*) usermod -G wheel $USER && usermod -G wheel fluxuser ;; \
      *) (>&2 echo "Unknown BASE_IMAGE") ;; \
     esac
 
@@ -56,7 +56,7 @@ RUN case $BASE_IMAGE in \
 RUN case $BASE_IMAGE in \
      bionic*) ;; \
      focal*) ;; \
-     centos*) ;; \
+     centos*|fedora*) ;; \
      *) (>&2 echo "Unknown BASE_IMAGE") ;; \
     esac
 

--- a/src/test/docker/fedora33/Dockerfile
+++ b/src/test/docker/fedora33/Dockerfile
@@ -1,0 +1,88 @@
+FROM fedora:33
+
+LABEL maintainer="Mark Grondona <mgrondona@llnl.gov>"
+
+#  Enable PowerTools for development packages
+RUN yum -y update \
+ && yum -y update \
+#  Utilities
+ && yum -y install \
+	wget \
+	man-db \
+	less \
+	git \
+	sudo \
+	munge \
+	ccache \
+	lua \
+	mpich \
+	valgrind \
+	jq \
+	which \
+	file \
+	vim \
+	patch \
+	diffutils \
+	hostname \
+#  Compilers, autotools
+	pkgconfig \
+	libtool \
+	autoconf \
+	automake \
+	gcc \
+	gcc-c++ \
+	libasan \
+	make \
+	cmake \
+#  Python
+	python36 \
+	python3-devel \
+	python3-cffi \
+	python3-six \
+	python3-yaml \
+	python3-jsonschema \
+	python3-sphinx \
+#  Development dependencies
+	libsodium-devel \
+	zeromq-devel \
+	czmq-devel \
+	jansson-devel \
+	munge-devel \
+	lz4-devel \
+	sqlite-devel \
+	libuuid-devel \
+	hwloc-devel \
+	mpich-devel \
+	lua-devel \
+	valgrind-devel \
+	libs3-devel \
+#  Other deps
+	perl-Time-HiRes \
+	lua-posix \
+	libfaketime \
+	cppcheck \
+	enchant \
+	aspell \
+	aspell-en \
+	glibc-langpack-en \
+ && yum clean all
+
+#  Add /usr/bin/mpicc link so MPI tests are built
+RUN alternatives --install /usr/bin/mpicc mpicc /usr/lib64/mpich/bin/mpicc 100
+
+# Install caliper by hand for now:
+RUN mkdir caliper \
+ && cd caliper \
+ && wget -O - https://github.com/LLNL/Caliper/archive/v1.7.0.tar.gz | tar xvz --strip-components 1 \
+ && mkdir build \
+ && cd build \
+ && cmake .. -DCMAKE_INSTALL_PREFIX=/usr \
+ && make -j 4 \
+ && make install \
+ && cd ../.. \
+ && rm -rf caliper
+
+ENV LANG=C.UTF-8
+RUN printf "LANG=C.UTF-8" > /etc/locale.conf
+
+COPY config.site /usr/share/config.site

--- a/src/test/docker/fedora33/config.site
+++ b/src/test/docker/fedora33/config.site
@@ -1,0 +1,6 @@
+# Force libdir to /usr/lib64 if prefix=/usr on this platform
+if test "$prefix" = "/usr" ; then
+    test $sysconfdir = "${prefix}/etc" && sysconfdir=/etc
+    libdir=/usr/lib64
+fi
+:

--- a/src/test/generate-matrix.py
+++ b/src/test/generate-matrix.py
@@ -190,6 +190,13 @@ matrix.add_build(
     docker_tag=True,
 )
 
+# Fedora 33
+matrix.add_build(
+    name="fedora33 - gcc-10,py3.9",
+    image="fedora33",
+    docker_tag=True,
+)
+
 # inception
 matrix.add_build(
     name="inception",


### PR DESCRIPTION
This PR adds a docker image for fedora33 and adds it to our CI matrix. This gets us tests using GCC 10.x.

The asan build is also updated to use fedora33 to get the newer sanitizers in gcc-10.