### PR TITLE
Include signal.h for test/bulk-exec.c

### DIFF
--- a/src/modules/job-exec/test/bulk-exec.c
+++ b/src/modules/job-exec/test/bulk-exec.c
@@ -15,6 +15,7 @@
 #define _GNU_SOURCE 1
 #include <unistd.h>
 #include <assert.h>
+#include <signal.h>
 
 #include <flux/core.h>
 #include <flux/idset.h>


### PR DESCRIPTION
Otherwise during compilation with BinaryBuilder:

```
cc -std=gnu99 -DHAVE_CONFIG_H -I. -I../../../config  -I../../.. -I../../../src/include -I../../../src/common/libflux -I/workspace/destdir/include -DCZMQ_BUILD_DRAFT_API=1 -DZMQ_BUILD_DRAFT_API=1  -I/workspace/destdir/include   -Wall -Werror -Wno-strict-aliasing -Wno-error=deprecated-declarations -Werror=missing-field-initializers  -Wl,-rpath-link,/opt/x86_64-linux-gnu/x86_64-linux-gnu/lib64 -MT test/bulk-exec.o -MD -MP -MF $depbase.Tpo -c -o test/bulk-exec.o test/bulk-exec.c &&\
mv -f $depbase.Tpo $depbase.Po
test/bulk-exec.c: In function ‘main’:
test/bulk-exec.c:251:53: error: ‘SIGINT’ undeclared (first use in this function)
                                                     SIGINT,
                                                     ^
test/bulk-exec.c:251:53: note: each undeclared identifier is reported only once for each function it appears in
```
