### PR TITLE
fix 32-bit portability issues

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -172,6 +172,7 @@ AX_COMPILE_CHECK_SIZEOF(int)
 AX_COMPILE_CHECK_SIZEOF(long)
 AX_COMPILE_CHECK_SIZEOF(long long)
 AX_COMPILE_CHECK_SIZEOF(uintptr_t, [#include <stdint.h>])
+AX_COMPILE_CHECK_SIZEOF(ptrdiff_t, [#include <stddef.h>])
 AX_COMPILE_CHECK_SIZEOF(size_t, [#include <stdint.h>])
 
 ##

--- a/src/bindings/lua/flux-lua.c
+++ b/src/bindings/lua/flux-lua.c
@@ -747,7 +747,7 @@ static int l_msghandler_remove (lua_State *L)
 
 static int l_msghandler_add (lua_State *L)
 {
-    struct flux_match match;
+    struct flux_match match = FLUX_MATCH_ANY;
     struct l_flux_ref *mh = NULL;
     flux_msg_handler_t *fmh = NULL;
     flux_t *f = lua_get_flux (L, 1);

--- a/src/bindings/lua/jansson-lua.c
+++ b/src/bindings/lua/jansson-lua.c
@@ -34,11 +34,11 @@ int lua_is_json_null (lua_State *L, int index)
 
 int json_object_to_lua (lua_State *L, json_t *o)
 {
-        if (o == NULL) {
-            lua_pushnil (L);
-            return (1);
-        }
-        switch (json_typeof (o)) {
+    if (o == NULL) {
+        lua_pushnil (L);
+        return (1);
+    }
+    switch (json_typeof (o)) {
         case JSON_OBJECT:
             json_object_to_lua_table (L, o);
             break;
@@ -63,8 +63,8 @@ int json_object_to_lua (lua_State *L, json_t *o)
         case JSON_NULL:
             lua_pushnil (L);
             break;
-        }
-        return (1);
+    }
+    return (1);
 }
 
 int json_object_string_to_lua (lua_State *L, const char *json_str)

--- a/src/bindings/lua/jansson-lua.c
+++ b/src/bindings/lua/jansson-lua.c
@@ -11,6 +11,7 @@
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
+#include <stdint.h>
 #include <math.h>
 #include <errno.h>
 #include <lua.h>
@@ -34,6 +35,7 @@ int lua_is_json_null (lua_State *L, int index)
 
 int json_object_to_lua (lua_State *L, json_t *o)
 {
+    uint64_t val;
     if (o == NULL) {
         lua_pushnil (L);
         return (1);
@@ -49,7 +51,12 @@ int json_object_to_lua (lua_State *L, json_t *o)
             lua_pushstring (L, json_string_value (o));
             break;
         case JSON_INTEGER:
-            lua_pushinteger (L, json_integer_value (o));
+            val = json_integer_value (o);
+#if LUA_VERSION_NUM < 530 && SIZEOF_PTRDIFF_T == 4
+            lua_pushnumber (L, (double) val);
+#else
+            lua_pushinteger (L, (lua_Integer) val);
+#endif
             break;
         case JSON_REAL:
             lua_pushnumber (L, json_real_value (o));
@@ -132,8 +139,13 @@ int lua_value_to_json (lua_State *L, int i, json_t **valp)
 
     switch (lua_type (L, index)) {
         case LUA_TNUMBER:
-            if (lua_is_integer (L, index))
+            if (lua_is_integer (L, index)) {
+#if LUA_VERSION_NUM < 530 && SIZEOF_PTRDIFF_T == 4
+                o = json_integer ((json_int_t) lua_tonumber (L, index));
+#else
                 o = json_integer (lua_tointeger (L, index));
+#endif
+            }
             else
                 o = json_real (lua_tonumber (L, index));
             break;

--- a/src/bindings/python/_flux/_core_build.py
+++ b/src/bindings/python/_flux/_core_build.py
@@ -28,6 +28,7 @@ typedef int... pid_t;
 typedef ... va_list;
 void * unpack_long(ptrdiff_t num);
 void free(void *ptr);
+#define FLUX_JOBID_ANY 0xFFFFFFFFFFFFFFFF
 
     """
 

--- a/src/cmd/flux-R.c
+++ b/src/cmd/flux-R.c
@@ -563,10 +563,10 @@ int cmd_rerank (optparse_t *p, int argc, char **argv)
         if (errno == ENOENT)
             log_msg_exit ("failed to find one or more provided hosts in R");
         else if (errno == EOVERFLOW)
-            log_msg_exit ("Too many hosts specified (expected %ld)",
+            log_msg_exit ("Too many hosts specified (expected %zu)",
                           rlist_nnodes (rl));
         else if (errno == ENOSPC)
-            log_msg_exit ("Too few hosts specified (expected %ld)",
+            log_msg_exit ("Too few hosts specified (expected %zu)",
                           rlist_nnodes (rl));
         else
             log_err_exit ("rlist_rerank");

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -2822,7 +2822,7 @@ void info_output (flux_future_t *f, const char *suffix, flux_jobid_t id)
     if (flux_rpc_get_unpack (f, "{s:s}", suffix, &s) < 0) {
         if (errno == ENOENT) {
             flux_future_destroy (f);
-            log_msg_exit ("job %lu id or key not found", id);
+            log_msg_exit ("job %ju id or key not found", (uintmax_t)id);
         }
         else
             log_err_exit ("flux_rpc_get_unpack");

--- a/src/cmd/flux-terminus.c
+++ b/src/cmd/flux-terminus.c
@@ -675,7 +675,7 @@ int cmd_list (optparse_t *p, int argc, char **argv)
             rank,
             datestr);
     if ((n = json_array_size (l)))
-        printf ("%ld current session%s:\n", n, n > 1 ? "s" : "");
+        printf ("%zu current session%s:\n", n, n > 1 ? "s" : "");
     else
         printf ("no sessions\n");
     for (int i = 0; i < json_array_size (l); i++)

--- a/src/common/libjob/job.h
+++ b/src/common/libjob/job.h
@@ -38,9 +38,8 @@ enum job_queue_priority {
     FLUX_JOB_PRIORITY_MAX = 4294967295,
 };
 
-enum {
-    FLUX_JOBID_ANY = 0xFFFFFFFFFFFFFFFF, // ~(uint64_t)0
-};
+// N.B. value is duplicated in python bindings
+#define FLUX_JOBID_ANY 0xFFFFFFFFFFFFFFFF // ~(uint64_t)0
 
 typedef enum {
     FLUX_JOB_STATE_NEW                    = 1,

--- a/src/modules/job-exec/bulk-exec.c
+++ b/src/modules/job-exec/bulk-exec.c
@@ -254,7 +254,7 @@ static void subprocess_destroy_finish (flux_future_t *f, void *arg)
     if (flux_future_get (f, NULL) < 0) {
         flux_t *h = flux_subprocess_aux_get (p, "flux_t");
         flux_log_error (h, "subprocess_kill: %ju: %s",
-                        (uintmax_t) flux_subprocess_pid,
+                        (uintmax_t) flux_subprocess_pid (p),
                         flux_strerror (errno));
     }
     flux_subprocess_destroy (p);

--- a/src/modules/job-exec/job-exec.c
+++ b/src/modules/job-exec/job-exec.c
@@ -998,7 +998,7 @@ static void exception_cb (flux_t *h, flux_msg_handler_t *mh,
          *   doesn't dump a duplicate exception into the eventlog.
          */
         job->exception_in_progress = 1;
-        flux_log (h, LOG_DEBUG, "exec aborted: id=%ld", id);
+        flux_log (h, LOG_DEBUG, "exec aborted: id=%ju", (uintmax_t)id);
         jobinfo_fatal_error (job, 0, "aborted due to exception type=%s", type);
     }
 }

--- a/src/modules/job-manager/prioritize.c
+++ b/src/modules/job-manager/prioritize.c
@@ -236,7 +236,7 @@ int reprioritize_all (struct job_manager *ctx)
     /*  Update scheduler with any changed priorities */
     if (sched_prioritize (ctx->h, priorities) < 0) {
         flux_log_error (ctx->h,
-                        "reprioritize: sched.priority: failed for %ld jobs",
+                        "reprioritize: sched.priority: failed for %zu jobs",
                         json_array_size (priorities));
         goto error;
     }

--- a/src/modules/job-manager/test/submit.c
+++ b/src/modules/job-manager/test/submit.c
@@ -29,7 +29,7 @@ void single_job_check (zhashx_t *active_jobs)
 
     /* good job */
     if (!(job1 = json_pack ("[{s:I s:i s:i s:f s:i s:{}}]",
-                            "id", 1,
+                            "id", 1LL,
                             "urgency", 10,
                             "userid", 42,
                             "t_submit", 1.0,
@@ -92,13 +92,13 @@ void multi_job_check (zhashx_t *active_jobs)
         "hash is initially empty");
     if (!(jobs = json_pack ("[{s:I s:i s:i s:f s:i s:{}},"
                              "{s:I s:i s:i s:f s:i s:{}}]",
-                            "id", 1,
+                            "id", 1LL,
                             "urgency", 10,
                             "userid", 42,
                             "t_submit", 1.0,
                             "flags", 0,
                             "jobspec",
-                            "id", 2,
+                            "id", 2LL,
                             "urgency", 11,
                             "userid", 43,
                             "t_submit", 1.1,

--- a/src/shell/batch.c
+++ b/src/shell/batch.c
@@ -86,7 +86,7 @@ batch_info_create (flux_shell_t *shell, json_t *batch)
             shell_log_error ("mkstemp");
             goto error;
         }
-        shell_debug ("Copying batch script size=%ld for job to %s",
+        shell_debug ("Copying batch script size=%zu for job to %s",
                      len,
                      b->script);
         if (write_all (fd, data, len) < 0) {

--- a/src/shell/mpir/ptrace.c
+++ b/src/shell/mpir/ptrace.c
@@ -46,7 +46,7 @@ static int ptrace_traceme (flux_plugin_t *p,
 
 int current_task_pid (flux_shell_t *shell)
 {
-    long pid = -1;
+    json_int_t pid = -1;
     if (flux_shell_task_info_unpack (flux_shell_current_task (shell),
                                      "{s:I}",
                                      "pid", &pid) < 0)

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -301,6 +301,7 @@ check_PROGRAMS = \
 	rexec/rexec_count_stdout \
 	rexec/rexec_getline \
 	job-manager/list-jobs \
+	job-manager/print-constants \
 	job-manager/events_journal_stream \
 	ingest/submitbench \
 	sched-simple/jj-reader \
@@ -574,6 +575,11 @@ ingest_submitbench_LDADD = \
 job_manager_list_jobs_SOURCES = job-manager/list-jobs.c
 job_manager_list_jobs_CPPFLAGS = $(test_cppflags)
 job_manager_list_jobs_LDADD = \
+	$(test_ldadd) $(LIBDL)
+
+job_manager_print_constants_SOURCES = job-manager/print-constants.c
+job_manager_print_constants_CPPFLAGS = $(test_cppflags)
+job_manager_print_constants_LDADD = \
 	$(test_ldadd) $(LIBDL)
 
 job_manager_events_journal_stream_SOURCES = job-manager/events_journal_stream.c

--- a/t/ingest/job-manager-dummy.c
+++ b/t/ingest/job-manager-dummy.c
@@ -146,7 +146,7 @@ void getinfo_cb (flux_t *h,
                  const flux_msg_t *msg,
                  void *arg)
 {
-    flux_jobid_t id = (1000UL * 1000) << 24; // fluid with 1000s timestamp
+    flux_jobid_t id = (1000ULL * 1000) << 24; // fluid with 1000s timestamp
     if (flux_request_decode (msg, NULL, NULL) < 0)
         goto error;
     if (flux_respond_pack (h,

--- a/t/job-manager/print-constants.c
+++ b/t/job-manager/print-constants.c
@@ -1,0 +1,35 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdio.h>
+#include <flux/core.h>
+
+int main (int argc, char *argv[])
+{
+    if (argc != 2) {
+        fprintf (stderr, "Usage: print-constants NAME\n");
+        return 1;
+    }
+    if (!strcmp (argv[1], "FLUX_JOBID_ANY")) {
+        printf ("%llx\n", (long long unsigned)FLUX_JOBID_ANY);
+    }
+    else {
+        fprintf (stderr, "unknown name\n");
+        return 1;
+    }
+    return 0;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/t/t2208-job-manager-wait.t
+++ b/t/t2208-job-manager-wait.t
@@ -12,12 +12,23 @@ SUBMIT_WAITANY="flux python ${FLUX_SOURCE_DIR}/t/job-manager/submit-waitany.py"
 SUBMIT_SW="flux python ${FLUX_SOURCE_DIR}/t/job-manager/submit-sliding-window.py"
 SUBMIT_INTER="flux python ${FLUX_SOURCE_DIR}/t/job-manager/wait-interrupted.py"
 JOB_CONV="flux python ${FLUX_SOURCE_DIR}/t/job-manager/job-conv.py"
+PRINT_CONSTANTS="${FLUX_BUILD_DIR}/t/job-manager/print-constants"
 
 flux setattr log-stderr-level 1
 
 test_job_count() {
     test $(${list_jobs} | wc -l) -eq $1
 }
+
+print_jobid_any_py() {
+	flux python -c 'import flux.constants; print(f"{flux.constants.FLUX_JOBID_ANY:x}")'
+}
+
+test_expect_success "python FLUX_JOBID_ANY matches job.h" '
+	py_id=$(print_jobid_any_py) &&
+	c_id=$($PRINT_CONSTANTS FLUX_JOBID_ANY) &&
+	test $py_id = $c_id
+'
 
 test_expect_success "wait works on waitable job run with flux-mini" '
 	JOBID=$(flux mini submit --flags waitable /bin/true) &&


### PR DESCRIPTION
This fixes some minor things that prevent compilation on a 32-bit system.

Still need to run down the following in the python bindings.  Dinner time so thought I'd post a checkpoint in case anyone has a hint on this one
```
make[1]: Entering directory '/home/garlick/proj/flux-core/src/bindings/python/_flux'
/usr/bin/python3 _core_build.py 
generating _core.c
Traceback (most recent call last):
  File "_core_build.py", line 39, in <module>
    ffi.emit_c_code("_core.c")
  File "/usr/lib/python3/dist-packages/cffi/api.py", line 692, in emit_c_code
    c_file=filename, call_c_compiler=False, **kwds)
  File "/usr/lib/python3/dist-packages/cffi/recompiler.py", line 1509, in recompile
    verbose=compiler_verbose)
  File "/usr/lib/python3/dist-packages/cffi/recompiler.py", line 1414, in make_c_source
    verbose)
  File "/usr/lib/python3/dist-packages/cffi/recompiler.py", line 1389, in _make_c_or_py_source
    recompiler.collect_step_tables()
  File "/usr/lib/python3/dist-packages/cffi/recompiler.py", line 239, in collect_step_tables
    self._generate("ctx")
  File "/usr/lib/python3/dist-packages/cffi/recompiler.py", line 224, in _generate
    method(tp, realname)
  File "/usr/lib/python3/dist-packages/cffi/recompiler.py", line 1031, in _generate_cpy_anonymous_ctx
    self._enum_ctx(tp, name)
  File "/usr/lib/python3/dist-packages/cffi/recompiler.py", line 1114, in _enum_ctx
    basetp = tp.build_baseinttype(self.ffi, [])
  File "/usr/lib/python3/dist-packages/cffi/model.py", line 555, in build_baseinttype
    "or 'unsigned long'" % self._get_c_name())
cffi.CDefError: anonymous $enum_$19: enum $19 values don't all fit into either 'long' or 'unsigned long'
make[1]: *** [Makefile:1014: _core.c] Error 1
```