### PR TITLE
flux-mini: add --log and --log-stderr options

### DIFF
--- a/doc/man1/flux-mini.rst
+++ b/doc/man1/flux-mini.rst
@@ -312,11 +312,27 @@ OTHER OPTIONS
    *(submit,bulksubmit)* Replicate the job for each ``id`` in ``IDSET``.
    ``FLUX_JOB_CC=id`` will be set in the environment of each submitted job
    to allow the job to alter its execution based on the submission index.
-   (e.g. for reading from a different input file).
+   (e.g. for reading from a different input file). When using ``--cc``,
+   the substitution string ``{cc}`` may be used in options and commands
+   and will be replaced by the current ``id``.
 
 **--bcc=IDSET**
    *(submit,bulksubmit)* Identical to ``--cc``, but do not set
    ``FLUX_JOB_CC`` in each job. All jobs will be identical copies.
+   As with ``--cc``, ``{cc}`` in option arguments and commands will be
+   replaced with the current ``id``.
+
+**--log=FILE**
+   *(submit,bulksubmit)* Log ``flux-mini`` output and stderr to ``FILE``
+   instead of the terminal. If a replacement (e.g. ``{}`` or ``{cc}``)
+   appears in ``FILE``, then one or more output files may be opened.
+   For example, to save all submitted jobids into separate files, use::
+
+      flux mini submit --cc=1-4 --log=job{cc}.id hostname
+
+**--log-stderr=FILE**
+   *(submit,bulksubmit)* Separate stderr into ``FILE`` instead of sending
+   it to the terminal or a ``FILE`` specified by ``--log``.
 
 **--wait**
    *(submit,bulksubmit)* Wait on completion of all jobs before exiting.
@@ -425,10 +441,18 @@ These include:
  - ``{./%}`` returns the basename of the input string with any
    extension removed.
  - ``{.//}`` returns the dirname of the input string
- - ``{seq}`` returns the input sequence number (0 origin).
+ - ``{seq}`` returns the input sequence number (0 origin)
+ - ``{seq1}`` returns the input sequence number (1 origin)
+ - ``{cc}`` returns the current ``id`` from use of ``--cc`` or ``--bcc``.
+   Note that replacement of ``{cc}`` is done in a second pass, since the
+   ``--cc`` option argument may itself be replaced in the first substitution
+   pass. If ``--cc/bcc`` were not used, then ``{cc}`` is replaced with an
+   empty string. This is the only substitution supported with
+   ``flux-mini submit``.
 
-Note that besides ``{seq}``, these attributes can also take the input
-index, e.g. ``{0.%}`` or ``{1.//}``, when multiple inputs are used.
+Note that besides ``{seq}``, ``{seq1}``, and ``{cc}`` these attributes
+can also take the input index, e.g. ``{0.%}`` or ``{1.//}``, when multiple
+inputs are used.
 
 Additional attributes may be defined with the ``--define`` option, e.g.::
 

--- a/src/cmd/flux-mini.py
+++ b/src/cmd/flux-mini.py
@@ -242,13 +242,16 @@ class Xcmd:
             return [restore(x) for x in val]
         return val
 
-    def __init__(self, args, inputs, **kwargs):
+    def __init__(self, args, inputs=None, **kwargs):
         """Initialize and Xcmd (eXtensible Command) object
 
         Given BulkSubmit `args` and `inputs`, substitute all inputs
         in command and applicable options using string.format().
 
         """
+        if inputs is None:
+            inputs = []
+
         #  Save reference to original args:
         self._orig_args = args
 

--- a/src/cmd/flux-mini.py
+++ b/src/cmd/flux-mini.py
@@ -1158,7 +1158,10 @@ class BulkSubmitCmd(SubmitBulkCmd):
         #  For each set of generated input lists, append a command
         #   to run. Keep a sequence counter so that {seq} can be used
         #   in the format expansion.
-        return [Xcmd(args, inp, seq=i, cc="{cc}") for i, inp in enumerate(inputs)]
+        return [
+            Xcmd(args, inp, seq=i, seq1=i + 1, cc="{cc}")
+            for i, inp in enumerate(inputs)
+        ]
 
     def main(self, args):
         if not args.command:

--- a/src/cmd/flux-mini.py
+++ b/src/cmd/flux-mini.py
@@ -1158,7 +1158,7 @@ class BulkSubmitCmd(SubmitBulkCmd):
         #  For each set of generated input lists, append a command
         #   to run. Keep a sequence counter so that {seq} can be used
         #   in the format expansion.
-        return [Xcmd(args, inp, seq=i) for i, inp in enumerate(inputs)]
+        return [Xcmd(args, inp, seq=i, cc="{cc}") for i, inp in enumerate(inputs)]
 
     def main(self, args):
         if not args.command:

--- a/t/t2203-job-manager-single.t
+++ b/t/t2203-job-manager-single.t
@@ -24,10 +24,8 @@ test_expect_success 'job-manager: load sched-simple w/ 1 rank, 2 cores/rank' '
 '
 
 test_expect_success 'job-manager: submit 5 jobs' '
-        flux mini submit --cc="1-5" --flags=debug -n1 \
-           hostname > jobids.out &&
-        split --numeric-suffixes=1 --additional-suffix=.id -l 1 -a 1 \
-           jobids.out job
+        flux mini submit --log=job{cc}.id --cc="1-5" --flags=debug -n1 \
+           hostname
 '
 
 test_expect_success HAVE_JQ 'job-manager: job state RRSSS' '

--- a/t/t2204-job-manager-limited.t
+++ b/t/t2204-job-manager-limited.t
@@ -13,10 +13,8 @@ test_under_flux 1 job
 flux setattr log-stderr-level 1
 
 test_expect_success 'job-manager: submit 5 jobs' '
-        flux mini submit --cc="1-5" --flags=debug -n1 \
-           hostname > jobids.out &&
-        split --numeric-suffixes=1 --additional-suffix=.id -l 1 -a 1 \
-           jobids.out job
+        flux mini submit --log=job{cc}.id --cc="1-5" --flags=debug -n1 \
+           hostname
 '
 
 test_expect_success HAVE_JQ 'job-manager: job state RRSSS' '

--- a/t/t2205-job-manager-unlimited.t
+++ b/t/t2205-job-manager-unlimited.t
@@ -13,10 +13,8 @@ test_under_flux 1 job
 flux setattr log-stderr-level 1
 
 test_expect_success 'job-manager: submit 5 jobs' '
-        flux mini submit --cc="1-5" --flags=debug -n1 \
-           hostname > jobids.out &&
-        split --numeric-suffixes=1 --additional-suffix=.id -l 1 -a 1 \
-           jobids.out job
+        flux mini submit --log=job{cc}.id --cc="1-5" --flags=debug -n1 \
+           hostname
 '
 
 test_expect_success HAVE_JQ 'job-manager: job state RRSSS' '

--- a/t/t2206-job-manager-annotate.t
+++ b/t/t2206-job-manager-annotate.t
@@ -15,10 +15,8 @@ test_expect_success 'job-manager: initially run without scheduler' '
         flux module unload sched-simple
 '
 test_expect_success 'job-manager: submit 5 jobs' '
-        flux mini submit --cc="1-5" --flags=debug -n1 \
-           hostname > jobids.out &&
-        split --numeric-suffixes=1 --additional-suffix=.id -l 1 -a 1 \
-           jobids.out job
+        flux mini submit --log=job{cc}.id --cc="1-5" --flags=debug -n1 \
+           hostname
 '
 
 test_expect_success HAVE_JQ 'job-manager: no annotations (SSSSS)' '

--- a/t/t2213-job-manager-hold-single.t
+++ b/t/t2213-job-manager-hold-single.t
@@ -15,10 +15,8 @@ flux setattr log-stderr-level 1
 
 # N.B. resources = 1 rank, 1 core/rank
 test_expect_success 'job-manager: submit 5 jobs (job 2 held)' '
-        flux mini bulksubmit --urgency="{}" --flags=debug -n1 \
-           hostname ::: default hold default default default > jobids.out &&
-        split --numeric-suffixes=1 --additional-suffix=.id -l 1 -a 1 \
-           jobids.out job
+        flux mini bulksubmit --log=job{seq1}.id --urgency={} --flags=debug -n1 \
+           hostname ::: default hold default default default
 '
 
 test_expect_success HAVE_JQ 'job-manager: job state RSSSS' '

--- a/t/t2214-job-manager-hold-limited.t
+++ b/t/t2214-job-manager-hold-limited.t
@@ -14,10 +14,8 @@ flux setattr log-stderr-level 1
 
 # N.B. resources = 1 rank, 2 cores/rank
 test_expect_success 'job-manager: submit 5 jobs (job 3,4,5 held)' '
-        flux mini bulksubmit --urgency="{}" --flags=debug -n1 \
-           hostname ::: default default hold hold hold > jobids.out &&
-        split --numeric-suffixes=1 --additional-suffix=.id -l 1 -a 1 \
-           jobids.out job
+        flux mini bulksubmit --log=job{seq1}.id --urgency={} --flags=debug -n1 \
+           hostname ::: default default hold hold hold
 '
 
 test_expect_success HAVE_JQ 'job-manager: job state RRSSS' '

--- a/t/t2215-job-manager-hold-unlimited.t
+++ b/t/t2215-job-manager-hold-unlimited.t
@@ -14,10 +14,8 @@ flux setattr log-stderr-level 1
 
 # N.B. resources = 1 rank, 2 cores/rank
 test_expect_success 'job-manager: submit 5 jobs (job 4 held)' '
-        flux mini bulksubmit --urgency="{}" --flags=debug -n1 \
-           hostname ::: default default default hold default > jobids.out &&
-        split --numeric-suffixes=1 --additional-suffix=.id -l 1 -a 1 \
-           jobids.out job
+        flux mini bulksubmit --log=job{seq1}.id --urgency={} --flags=debug -n1 \
+           hostname ::: default default default hold default
 '
 
 test_expect_success HAVE_JQ 'job-manager: job state RRSSS' '

--- a/t/t2216-job-manager-priority-order-single.t
+++ b/t/t2216-job-manager-priority-order-single.t
@@ -14,10 +14,8 @@ flux setattr log-stderr-level 1
 
 # N.B. resources = 1 rank, 2 cores/rank
 test_expect_success 'job-manager: submit 4 jobs' '
-        flux mini submit --cc="1-4" --flags=debug -n1 \
-           hostname > jobids.out &&
-        split --numeric-suffixes=1 --additional-suffix=.id -l 1 -a 1 \
-           jobids.out job
+        flux mini submit --log=job{cc}.id --cc="1-4" --flags=debug -n1 \
+           hostname
 '
 
 test_expect_success HAVE_JQ 'job-manager: job state RRSS' '

--- a/t/t2217-job-manager-priority-order-limited.t
+++ b/t/t2217-job-manager-priority-order-limited.t
@@ -16,10 +16,8 @@ flux setattr log-stderr-level 1
 # flux queue stop/start to ensure no scheduling until after all jobs submitted
 test_expect_success 'job-manager: submit 5 jobs (differing urgencies)' '
         flux queue stop &&
-        flux mini bulksubmit --urgency="{}" --flags=debug -n1 \
-           hostname ::: $(seq 10 2 18) > jobids.out &&
-        split --numeric-suffixes=1 --additional-suffix=.id -l 1 -a 1 \
-           jobids.out job &&
+        flux mini bulksubmit --log=job{seq1}.id --urgency={} --flags=debug -n1 \
+           hostname ::: $(seq 10 2 18) &&
         flux queue start
 '
 

--- a/t/t2218-job-manager-priority-order-unlimited.t
+++ b/t/t2218-job-manager-priority-order-unlimited.t
@@ -16,10 +16,8 @@ flux setattr log-stderr-level 1
 # flux queue stop/start to ensure no scheduling until after all jobs submitted
 test_expect_success 'job-manager: submit 5 jobs (differing urgencies)' '
         flux queue stop &&
-        flux mini bulksubmit --urgency="{}" --flags=debug -n1 \
+        flux mini bulksubmit --log=job{seq1}.id --urgency={} --flags=debug -n1 \
            hostname ::: 12 10 14 16 18 > jobids.out &&
-        split --numeric-suffixes=1 --additional-suffix=.id -l 1 -a 1 \
-           jobids.out job &&
         flux queue start
 '
 


### PR DESCRIPTION
This PR adds support for `--log=FILE` and `--log-stderr=FILE` options in `flux-mini submit` and `bulksubmit`. These options allow  the `flux-mini` output to be sent to files instead of the terminal. If `FILE` contains substitution strings, then a single `flux-mini` invocation may save output to multiple files.

As a side-effect, `{cc}` may now be used as a substitution in both `submit` and `bulksubmit`. With `bulksubmit`, the substitution of `{cc}` is done in a second pass, since any argument to `--cc` may be substituted in the first pass.

The use case being addressed here is to save jobids from bulksubmit and submit with `--cc` to separate files. This can be accomplished as:
```
  $ flux mini submit --cc=1-4 --log=job{cc}.id hostname
```

which will save the jobids to `job1.id` `job2.id` etc.

When not using `--cc` e.g. with `bulksubmit`, then `{}` or `{seq}` (or a newly added 1-origin `{seq1}`) should be used to generate unique filenames per job:

```
 $ flux mini bulksubmit --log=job{seq}.out --watch ./{} ::: t*.t
```

In this case since `--watch` is used, the output from all the jobs will also be saved in each output file.

Along the way a couple issues were fixed, most notably `bulksubmit` was substituting mustache template `{{id}}` in `--output` and `--error` to `{id}`, and the tests using `split(1)` were replaced with the `--log` option.
