### PR TITLE
Add a 32 bit build to github ci checks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -135,6 +135,10 @@ jobs:
       run: |
         docker run -d -p 9000:9000 minio/minio server /data; \
 
+    - name: docker buildx
+      uses: docker/setup-buildx-action@v1
+      if: matrix.needs_buildx
+
     - name: docker-run-checks
       env: ${{matrix.env}}
       run: ${{matrix.command}}

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -8,6 +8,7 @@ pull_request_rules:
       - status-success="python lint"
       - status-success="mypy"
       - status-success="bionic"
+      - status-success="bionic - 32 bit"
       - status-success="bionic - gcc-8,content-s3,distcheck"
       - status-success="bionic - py3.7,clang-6.0"
       - status-success="bionic - test-install"

--- a/src/test/generate-matrix.py
+++ b/src/test/generate-matrix.py
@@ -73,12 +73,18 @@ class BuildMatrix:
         test_s3=False,
         coverage=False,
         recheck=True,
+        platform=None,
         command_args="",
     ):
         """Add a build to the matrix.include array"""
 
         # Extra environment to add to this command:
         env = env or {}
+
+        needs_buildx = False
+        if platform:
+            command_args += f"--platform={platform}"
+            needs_buildx = True
 
         # The command to run:
         command = f"{docker_run_checks} -j{jobs} --image={image} {command_args}"
@@ -114,6 +120,7 @@ class BuildMatrix:
                 "coverage": coverage,
                 "test_s3": test_s3,
                 "docker_tag": docker_tag,
+                "needs_buildx": needs_buildx,
                 "create_release": create_release,
             }
         )
@@ -129,6 +136,12 @@ matrix = BuildMatrix()
 
 # Ubuntu: no args
 matrix.add_build(name="bionic")
+
+# Ubuntu: 32b
+matrix.add_build(
+    name="bionic - 32 bit",
+    platform="linux/386",
+)
 
 # Ubuntu: gcc-8, content-s3, distcheck
 matrix.add_build(


### PR DESCRIPTION
This PR adds another builder to the flux-core GitHub ci workflow that compiles and run tests in a 32 bit environment.

A new `linux/386` image has been pushed up to `fluxrm/testenv:bionic` (bionic is one of the few older distros that support a 32 bit docker base image), and `docker-run-checks.sh` has a new `--platform` option which (if docker supports it), can be used to run under this architecture.

This cross-platform docker support requires the experimental [Docker buildx](https://docs.docker.com/buildx/working-with-buildx/) frontend, which is automatically pulled into the builder if necessary. With buildx, if qemu and binfmt_misc are present, then the docker image may run under qemu, allowing foreign architecture docker containers to run on x86, (e.g. ppc64le arm64, etc). However, this is disabled for the 32 bit build here because I found it ran way to slow. Therefore, the new build is a 32 bit userspace on an x86_64 host. However, this should be sufficient to find many of 32 bit bugs we recently fixed.