### PR TITLE
flux-mini: fix --progress counters with job exceptions

### DIFF
--- a/src/cmd/flux-mini.py
+++ b/src/cmd/flux-mini.py
@@ -770,11 +770,12 @@ class SubmitBulkCmd(SubmitBaseCmd):
                 f"{jobid}: exception: type={exception_type} note={note}",
                 file=args.stderr,
             )
+        elif event.name == "alloc" and args.watch:
+            jobinfo["state"] = "running"
         elif event.name == "start" and args.watch:
             #
             #  Watch the exec eventlog if the --watch option was provided:
             #
-            jobinfo["state"] = "running"
             job.event_watch_async(
                 self.flux_handle, jobid, eventlog="guest.exec.eventlog"
             ).then(self.exec_watch_cb, args, jobid, label)
@@ -888,7 +889,7 @@ class SubmitBulkCmd(SubmitBaseCmd):
             )
         elif event is None:
             self.progress.update(jps=self.jobs_per_sec())
-        elif event.name == "start":
+        elif event.name == "alloc":
             self.progress.update(
                 advance=0,
                 pending=self.progress.pending - 1,

--- a/src/cmd/flux-mini.py
+++ b/src/cmd/flux-mini.py
@@ -770,7 +770,7 @@ class SubmitBulkCmd(SubmitBaseCmd):
                 f"{jobid}: exception: type={exception_type} note={note}",
                 file=args.stderr,
             )
-        elif event.name == "alloc" and args.watch:
+        elif event.name == "alloc":
             jobinfo["state"] = "running"
         elif event.name == "start" and args.watch:
             #

--- a/src/modules/job-exec/job-exec.c
+++ b/src/modules/job-exec/job-exec.c
@@ -293,6 +293,10 @@ static void jobinfo_complete (struct jobinfo *job, const struct idset *ranks)
 {
     flux_t *h = job->ctx->h;
     job->running = 0;
+
+    if (job->exception_in_progress && job->wait_status == 0)
+        job->wait_status = 1<<8;
+
     if (h && job->req) {
         jobinfo_emit_event_pack_nowait (job, "complete",
                                         "{ s:i }",

--- a/t/t2703-mini-bulksubmit.t
+++ b/t/t2703-mini-bulksubmit.t
@@ -89,7 +89,7 @@ test_expect_success 'flux-mini submit --progress works without --wait' '
 test_expect_success 'flux-mini submit --progress works with --wait' '
 	$runpty flux mini submit --cc=1-10 --progress --wait hostname \
 	    >bs6.out &&
-	grep "PD:10 *R:0 *CD:0 *F:0" bs6.out &&
+	grep "PD:1 *R:0 *CD:0 *F:0" bs6.out &&
 	grep "PD:0 *R:0 *CD:10 *F:0" bs6.out &&
 	grep "100.0%" bs6.out
 '
@@ -97,7 +97,7 @@ test_expect_success 'flux-mini bulksubmit --wait/progress with failed jobs' '
         test_expect_code 1 $runpty flux mini bulksubmit \
 	    -n{} --progress --wait hostname ::: 1 2 4 1024 \
 	    >bs7.out &&
-	grep "PD:4 *R:0 *CD:0 *F:0" bs7.out &&
+	grep "PD:1 *R:0 *CD:0 *F:0" bs7.out &&
 	grep "PD:0 *R:0 *CD:3 *F:1" bs7.out &&
 	grep "100.0%" bs7.out
 '
@@ -105,7 +105,7 @@ test_expect_success 'flux-mini bulksubmit --wait/progress with failed jobs' '
         test_expect_code 2 $runpty flux mini bulksubmit \
 	    -n1 --progress --wait sh -c "exit {}" ::: 0 1 0 0 2 \
 	    >bs8.out &&
-	grep "PD:5 *R:0 *CD:0 *F:0" bs8.out &&
+	grep "PD:1 *R:0 *CD:0 *F:0" bs8.out &&
 	grep "PD:0 *R:0 *CD:3 *F:2" bs8.out &&
 	grep "100.0%" bs8.out
 '
@@ -115,7 +115,7 @@ test_expect_success 'flux-mini submit --wait/progress with job exceptions' '
 	    --setattr=system.exec.bulkexec.mock_exception={} hostname \
 	    ::: 0 init init 0 0 \
 	    >bs9.out &&
-	grep "PD:5 *R:0 *CD:0 *F:0" bs9.out &&
+	grep "PD:1 *R:0 *CD:0 *F:0" bs9.out &&
 	grep "PD:0 *R:0 *CD:3 *F:2" bs9.out &&
 	grep "100.0%" bs9.out
 '

--- a/t/t2703-mini-bulksubmit.t
+++ b/t/t2703-mini-bulksubmit.t
@@ -109,6 +109,16 @@ test_expect_success 'flux-mini bulksubmit --wait/progress with failed jobs' '
 	grep "PD:0 *R:0 *CD:3 *F:2" bs8.out &&
 	grep "100.0%" bs8.out
 '
+test_expect_success 'flux-mini submit --wait/progress with job exceptions' '
+        test_expect_code 1 $runpty flux mini bulksubmit \
+	    -n1 --progress --wait \
+	    --setattr=system.exec.bulkexec.mock_exception={} hostname \
+	    ::: 0 init init 0 0 \
+	    >bs9.out &&
+	grep "PD:5 *R:0 *CD:0 *F:0" bs9.out &&
+	grep "PD:0 *R:0 *CD:3 *F:2" bs9.out &&
+	grep "100.0%" bs9.out
+'
 test_expect_success 'flux-mini bulksubmit --wait returns highest exit code' '
 	test_expect_code 143 \
 	    flux mini bulksubmit --wait sh -c "kill -{} \$\$" ::: 0 0 15


### PR DESCRIPTION
This is a set of fixes for `flux mini submit --progress --wait` which were discovered while developing the test for #3505.

Some incorrect assumptions and bugs in the counters displayed in the progress bar caused duplicate or negative counts when jobs had exceptions during intialization.

Also included is a fix for many of the tests in `t2703-mini-bulksubmit.t` which we've seen fail recently. (Bad assumption that all jobs would get submitted before the first job ran)