### PR TITLE
module: reduce keepalive message traffic

### DIFF
--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -1703,14 +1703,13 @@ static void module_status_cb (module_t *p, int prev_status, void *arg)
     int status = module_get_status (p);
     const char *name = module_get_name (p);
 
-    /* Transition from INIT 
-     * If module started normally, i.e. INIT->SLEEPING/RUNNING, then
+    /* Transition from INIT
+     * If module started normally, i.e. INIT->RUNNING, then
      * respond to insmod requests now. O/w, delay responses until
      * EXITED, when any errnum is available.
      */
-    if (prev_status == FLUX_MODSTATE_INIT &&
-        (status == FLUX_MODSTATE_RUNNING ||
-         status == FLUX_MODSTATE_SLEEPING)) {
+    if (prev_status == FLUX_MODSTATE_INIT
+        && status == FLUX_MODSTATE_RUNNING) {
         if (module_insmod_respond (ctx->h, p) < 0)
             flux_log_error (ctx->h, "flux_respond to insmod %s", name);
     }

--- a/src/broker/modservice.c
+++ b/src/broker/modservice.c
@@ -158,7 +158,7 @@ static void prepare_cb (flux_reactor_t *r, flux_watcher_t *w,
                         int revents, void *arg)
 {
     modservice_ctx_t *ctx = arg;
-    flux_msg_t *msg = flux_keepalive_encode (0, FLUX_MODSTATE_SLEEPING);
+    flux_msg_t *msg = flux_keepalive_encode (0, FLUX_MODSTATE_RUNNING);
     if (!msg || flux_send (ctx->h, msg, 0) < 0)
         flux_log_error (ctx->h, "error sending keepalive");
     flux_msg_destroy (msg);

--- a/src/broker/modservice.c
+++ b/src/broker/modservice.c
@@ -40,7 +40,6 @@ typedef struct {
     module_t *p;
     zlist_t *handlers;
     flux_watcher_t *w_prepare;
-    flux_watcher_t *w_check;
 } modservice_ctx_t;
 
 static void freectx (void *arg)
@@ -51,7 +50,6 @@ static void freectx (void *arg)
         flux_msg_handler_destroy (mh);
     zlist_destroy (&ctx->handlers);
     flux_watcher_destroy (ctx->w_prepare);
-    flux_watcher_destroy (ctx->w_check);
     free (ctx);
 }
 
@@ -158,22 +156,19 @@ static void prepare_cb (flux_reactor_t *r, flux_watcher_t *w,
                         int revents, void *arg)
 {
     modservice_ctx_t *ctx = arg;
-    flux_msg_t *msg = flux_keepalive_encode (0, FLUX_MODSTATE_RUNNING);
-    if (!msg || flux_send (ctx->h, msg, 0) < 0)
-        flux_log_error (ctx->h, "error sending keepalive");
-    flux_msg_destroy (msg);
-}
 
-/* Reactor loop just unblocked.
- */
-static void check_cb (flux_reactor_t *r, flux_watcher_t *w,
-                      int revents, void *arg)
-{
-    modservice_ctx_t *ctx = arg;
+    /*  Notify broker that this module has finished initialization
+     */
     flux_msg_t *msg = flux_keepalive_encode (0, FLUX_MODSTATE_RUNNING);
     if (!msg || flux_send (ctx->h, msg, 0) < 0)
         flux_log_error (ctx->h, "error sending keepalive");
     flux_msg_destroy (msg);
+
+    /*  Then, disable te prepare watcher. We no longer send keepalive
+     *   messages on every entry/exit of the reactor.
+     */
+    flux_watcher_destroy (ctx->w_prepare);
+    ctx->w_prepare = NULL;
 }
 
 static int register_event (modservice_ctx_t *ctx, const char *name,
@@ -281,12 +276,7 @@ int modservice_register (flux_t *h, module_t *p)
         log_err ("flux_prepare_watcher_create");
         return -1;
     }
-    if (!(ctx->w_check = flux_check_watcher_create (r, check_cb, ctx))) {
-        log_err ("flux_check_watcher_create");
-        return -1;
-    }
     flux_watcher_start (ctx->w_prepare);
-    flux_watcher_start (ctx->w_check);
     return 0;
 }
 

--- a/src/broker/module.c
+++ b/src/broker/module.c
@@ -541,7 +541,6 @@ void module_set_status_cb (module_t *p, module_status_cb_f cb, void *arg)
 void module_set_status (module_t *p, int new_status)
 {
     assert (p->magic == MODULE_MAGIC);
-    assert (p->status != new_status);
     assert (new_status != FLUX_MODSTATE_INIT);  /* illegal state transition */
     assert (p->status != FLUX_MODSTATE_EXITED); /* illegal state transition */
     int prev_status = p->status;

--- a/src/cmd/flux-module.c
+++ b/src/cmd/flux-module.c
@@ -442,8 +442,6 @@ char lsmod_state_char (int state)
     switch (state) {
     case FLUX_MODSTATE_INIT:
         return 'I';
-    case FLUX_MODSTATE_SLEEPING:
-        return 'S';
     case FLUX_MODSTATE_RUNNING:
         return 'R';
     case FLUX_MODSTATE_FINALIZING:

--- a/src/common/libflux/module.h
+++ b/src/common/libflux/module.h
@@ -28,10 +28,9 @@ extern "C" {
  */
 enum {
     FLUX_MODSTATE_INIT           = 0,
-    FLUX_MODSTATE_SLEEPING       = 1,
-    FLUX_MODSTATE_RUNNING        = 2,
-    FLUX_MODSTATE_FINALIZING     = 3,
-    FLUX_MODSTATE_EXITED         = 4,
+    FLUX_MODSTATE_RUNNING        = 1,
+    FLUX_MODSTATE_FINALIZING     = 2,
+    FLUX_MODSTATE_EXITED         = 3,
 };
 
 /* Mandatory symbols for modules


### PR DESCRIPTION
This PR removes the prep/check based module keepalive messages completely. Now those messages are only sent to the broker in order to transition modules out of INIT state to RUNNING (which now only means the module is not initializing) and finalizing/exited.

Since there is no longer a case for FLUX_MODSTATE_SLEEPING, that module is removed (already updated RFC 5).

