### PR TITLE
libflux: restart continuation timeout in flux_future_reset()

### DIFF
--- a/doc/man3/flux_future_get.rst
+++ b/doc/man3/flux_future_get.rst
@@ -88,10 +88,9 @@ out immediately if the future has not already been fulfilled.
 
 ``flux_future_reset()`` unfulfills a future, invalidating any result stored
 in the container, and preparing it to be fulfilled once again. If a
-continuation was registered, it remains in effect for the next fulfillment,
-however any timeout will have been cleared by the current fulfillment
-and must be re-established by following the ``flux_future_reset()`` with
-another ``flux_future_then()``, if desired.
+continuation was registered, it remains in effect for the next fulfillment.
+If a timeout was specified when the continuation was registered, it is
+restarted.
 
 ``flux_future_destroy()`` destroys a future, including any result contained
 within.

--- a/src/common/libflux/future.c
+++ b/src/common/libflux/future.c
@@ -180,28 +180,19 @@ static int then_context_set_timeout (struct then_context *then,
 {
     if (then) {
         then->timeout = timeout;
-        if (timeout < 0.)       // disable
+        if (timeout < 0.)
             flux_watcher_stop (then->timer);
         else {
-            if (!then->timer) { // set
-                then->timer = flux_timer_watcher_create (then->r, timeout, 0.,
+            if (!then->timer) {
+                then->timer = flux_timer_watcher_create (then->r, 0., timeout,
                                                          then_timer_cb, arg);
                 if (!then->timer)
                     return -1;
             }
-            else {              // reset
-                flux_timer_watcher_reset (then->timer, timeout, 0.);
-            }
-            flux_watcher_start (then->timer);
+            flux_timer_watcher_again (then->timer);
         }
     }
     return 0;
-}
-
-static void then_context_clear_timer (struct then_context *then)
-{
-    if (then)
-        flux_watcher_stop (then->timer);
 }
 
 static void init_result (struct future_result *fs)
@@ -339,7 +330,6 @@ void flux_future_decref (flux_future_t *f)
 static void post_fulfill (flux_future_t *f)
 {
     now_context_clear_timer (f->now);
-    then_context_clear_timer (f->then);
     if (f->now)
         flux_reactor_stop (f->now->r);
     if (f->then)

--- a/src/common/libflux/future.c
+++ b/src/common/libflux/future.c
@@ -90,11 +90,10 @@ static void now_context_destroy (struct now_context *now)
 
 static struct now_context *now_context_create (void)
 {
-    struct now_context *now = calloc (1, sizeof (*now));
-    if (!now) {
-        errno = ENOMEM;
-        goto error;
-    }
+    struct now_context *now;
+
+    if (!(now = calloc (1, sizeof (*now))))
+        return NULL;
     if (!(now->r = flux_reactor_create (0)))
         goto error;
     return now;
@@ -148,11 +147,10 @@ static void then_context_destroy (struct then_context *then)
 
 static struct then_context *then_context_create (flux_reactor_t *r, void *arg)
 {
-    struct then_context *then = calloc (1, sizeof (*then));
-    if (!then) {
-        errno = ENOMEM;
-        goto error;
-    }
+    struct then_context *then;
+
+    if (!(then = calloc (1, sizeof (*then))))
+        return NULL;
     then->r = r;
     if (!(then->check = flux_check_watcher_create (r, check_cb, arg)))
         goto error;
@@ -313,20 +311,16 @@ void flux_future_destroy (flux_future_t *f)
  */
 flux_future_t *flux_future_create (flux_future_init_f cb, void *arg)
 {
-    flux_future_t *f = calloc (1, sizeof (*f));
-    if (!f) {
-        errno = ENOMEM;
-        goto error;
-    }
+    flux_future_t *f;
+
+    if (!(f = calloc (1, sizeof (*f))))
+        return NULL;
     f->init = cb;
     f->init_arg = arg;
     f->queue = NULL;
     f->embed = NULL;
     f->refcount = 1;
     return f;
-error:
-    flux_future_destroy (f);
-    return NULL;
 }
 
 void flux_future_incref (flux_future_t *f)

--- a/src/common/libflux/future.c
+++ b/src/common/libflux/future.c
@@ -534,7 +534,6 @@ int flux_future_get (flux_future_t *f, const void **result)
 /* Set up continuation to run once future is fulfilled.
  * Lazily set up the "then" reactor context.
  * If timer expires, fulfill the future with ETIMEDOUT error.
- * This function can only be called once.
  */
 int flux_future_then (flux_future_t *f, double timeout,
                       flux_continuation_f cb, void *arg)

--- a/src/common/libflux/reactor.c
+++ b/src/common/libflux/reactor.c
@@ -687,6 +687,14 @@ void flux_timer_watcher_reset (flux_watcher_t *w, double after, double repeat)
     ev_timer_set (tw, after, repeat);
 }
 
+void flux_timer_watcher_again (flux_watcher_t *w)
+{
+    assert (flux_watcher_get_ops (w) == &timer_watcher);
+    ev_timer *tw = w->data;
+    struct ev_loop *loop = w->r->loop;
+    ev_timer_again (loop, tw);
+}
+
 /* Periodic
  */
 struct f_periodic {

--- a/src/common/libflux/reactor.h
+++ b/src/common/libflux/reactor.h
@@ -147,6 +147,8 @@ flux_watcher_t *flux_timer_watcher_create (flux_reactor_t *r,
 
 void flux_timer_watcher_reset (flux_watcher_t *w, double after, double repeat);
 
+void flux_timer_watcher_again (flux_watcher_t *w);
+
 /* periodic
  */
 


### PR DESCRIPTION
This was peeled off of PR #3512.  It changes `flux_future_reset()` to restart any timeout that was specified in the call to `flux_future_then()`.   This change has no effect when the future is used non-reactively.

In addition, a more efficient mechanism of managing the recurring reactor timeout is used, as documented in the libev manual.  This method required `ev_timer_again()` to be used, so it is exposed in our API as `flux_timer_watcher_again()`.

There's a bit of cleanup in the surrounding code here as well.