### PR TITLE
use reactor time instead of heartbeats for internal time management

### DIFF
--- a/doc/man1/flux-content.rst
+++ b/doc/man1/flux-content.rst
@@ -90,8 +90,8 @@ flux-setattr(1):
    (default 16777216)
 
 **content.purge-old-entry**
-   Only entries that have not been accessed in **old-entry** heartbeat epochs
-   are eligible for purge (default 5).
+   Only entries that have not been accessed in **old-entry** seconds
+   are eligible for purge (default 10).
 
 **content.purge-large-entry**
    Only entries with blob size greater than or equal to **large-entry** are

--- a/doc/man1/flux-module.rst
+++ b/doc/man1/flux-module.rst
@@ -122,7 +122,7 @@ SHA1 hash) module loaded by a service.
 
 **Idle**
    Idle times are defined for flux-broker(1) modules as the number of
-   heartbeats since the module last sent a request or response message.
+   seconds since the module last sent a request or response message.
    The idle time may be defined differently for other services, or have no
    meaning.
 

--- a/doc/man7/flux-broker-attributes.rst
+++ b/doc/man7/flux-broker-attributes.rst
@@ -167,7 +167,7 @@ content.purge-large-entry
 
 content.purge-old-entry
    When the cache size footprint needs to be reduced, only consider
-   purging entries that are older than this number of heartbeats.
+   purging entries that are older than this number of seconds.
 
 content.purge-target-entries
    If possible, the cache size purged periodically so that the total

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -344,7 +344,6 @@ int main (int argc, char *argv[])
     }
     overlay_set_parent_cb (ctx.overlay, parent_cb, &ctx);
     overlay_set_child_cb (ctx.overlay, child_cb, &ctx);
-    overlay_set_idle_warning (ctx.overlay, 5);
 
     /* Arrange for the publisher to route event messages.
      * handle_event - local subscribers (ctx.h)

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -496,7 +496,6 @@ int main (int argc, char *argv[])
         log_msg ("initializing modules");
     modhash_set_rank (ctx.modhash, ctx.rank);
     modhash_set_flux (ctx.modhash, ctx.h);
-    modhash_set_heartbeat (ctx.modhash, ctx.heartbeat);
 
     /* install heartbeat (including timer on rank 0)
      */

--- a/src/broker/module.h
+++ b/src/broker/module.h
@@ -30,7 +30,6 @@ void modhash_destroy (modhash_t *mh);
 
 void modhash_set_rank (modhash_t *mh, uint32_t rank);
 void modhash_set_flux (modhash_t *mh, flux_t *h);
-void modhash_set_heartbeat (modhash_t *mh, heartbeat_t *hb);
 
 /* Prepare module at 'path' for starting.
  */

--- a/src/broker/overlay.h
+++ b/src/broker/overlay.h
@@ -33,13 +33,12 @@ void overlay_set_init_callback (struct overlay *ov,
                                 overlay_init_cb_f cb,
                                 void *arg);
 
-/* These need to be called before connect/bind.
+/* Call before connect/bind.
  */
 int overlay_init (struct overlay *ov,
                   uint32_t size,
                   uint32_t rank,
                   int tbon_k);
-void overlay_set_idle_warning (struct overlay *ov, int heartbeats);
 
 
 /* CURVE key management

--- a/src/modules/kvs/cache.c
+++ b/src/modules/kvs/cache.c
@@ -65,14 +65,11 @@ struct cache_entry *cache_entry_create (const char *ref)
         return NULL;
     }
 
-    if (!(entry = calloc (1, sizeof (*entry)))) {
-        errno = ENOMEM;
+    if (!(entry = calloc (1, sizeof (*entry))))
         return NULL;
-    }
 
     if (!(entry->blobref = strdup (ref))) {
         cache_entry_destroy (entry);
-        errno = ENOMEM;
         return NULL;
     }
 
@@ -262,6 +259,7 @@ void cache_entry_destroy (void *arg)
 {
     struct cache_entry *entry = arg;
     if (entry) {
+        int saved_errno = errno;
         free (entry->data);
         json_decref (entry->o);
         if (entry->waitlist_notdirty)
@@ -270,6 +268,7 @@ void cache_entry_destroy (void *arg)
             wait_queue_destroy (entry->waitlist_valid);
         free (entry->blobref);
         free (entry);
+        errno = saved_errno;
     }
 }
 
@@ -450,10 +449,8 @@ static void cache_entry_destroy_wrapper (void **arg)
 struct cache *cache_create (void)
 {
     struct cache *cache = calloc (1, sizeof (*cache));
-    if (!cache) {
-        errno = ENOMEM;
+    if (!cache)
         return NULL;
-    }
     if (!(cache->zhx = zhashx_new ())) {
         free (cache);
         errno = ENOMEM;

--- a/src/modules/kvs/cache.c
+++ b/src/modules/kvs/cache.c
@@ -42,7 +42,7 @@ struct cache_entry {
     void *data;             /* value raw data */
     int len;
     json_t *o;              /* value treeobj object */
-    int lastuse_epoch;      /* time of last use for cache expiry */
+    double lastuse_time;    /* time of last use for cache expiry */
     bool valid;             /* flag indicating if raw data or treeobj
                              * set, don't use data == NULL as test, as
                              * zero length data can be valid */
@@ -53,8 +53,19 @@ struct cache_entry {
 };
 
 struct cache {
+    flux_reactor_t *r;
+    double fake_time;       /* -1. for invalid */
     zhashx_t *zhx;
 };
+
+static double cache_now (struct cache *cache)
+{
+    if (cache->fake_time >= 0.)
+        return cache->fake_time;
+    if (cache->r)
+        return flux_reactor_now (cache->r);
+    return 0.;
+}
 
 struct cache_entry *cache_entry_create (const char *ref)
 {
@@ -298,12 +309,12 @@ int cache_entry_wait_valid (struct cache_entry *entry, wait_t *wait)
     return 0;
 }
 
-struct cache_entry *cache_lookup (struct cache *cache, const char *ref,
-                                  int current_epoch)
+struct cache_entry *cache_lookup (struct cache *cache, const char *ref)
 {
     struct cache_entry *entry = zhashx_lookup (cache->zhx, ref);
-    if (entry && current_epoch > entry->lastuse_epoch)
-        entry->lastuse_epoch = current_epoch;
+    double current_time = cache_now (cache);
+    if (entry && current_time > entry->lastuse_time)
+        entry->lastuse_time = current_time;
     return entry;
 }
 
@@ -339,16 +350,17 @@ int cache_count_entries (struct cache *cache)
     return zhashx_size (cache->zhx);
 }
 
-static int cache_entry_age (struct cache_entry *entry, int current_epoch)
+static int cache_entry_age (struct cache_entry *entry, struct cache *cache)
 {
+    double current_time = cache_now (cache);
     if (!entry)
         return -1;
-    if (entry->lastuse_epoch == 0)
-        entry->lastuse_epoch = current_epoch;
-    return current_epoch - entry->lastuse_epoch;
+    if (entry->lastuse_time == 0.)
+        entry->lastuse_time = current_time;
+    return current_time - entry->lastuse_time;
 }
 
-int cache_expire_entries (struct cache *cache, int current_epoch, int thresh)
+int cache_expire_entries (struct cache *cache, double thresh)
 {
     zlistx_t *keys;
     char *ref;
@@ -367,8 +379,8 @@ int cache_expire_entries (struct cache *cache, int current_epoch, int thresh)
             && !cache_entry_get_dirty (entry)
             && cache_entry_get_valid (entry)
             && !entry->refcount
-            && (thresh == 0
-                || cache_entry_age (entry, current_epoch) > thresh)) {
+            && (thresh == 0.
+                    || cache_entry_age (entry, cache) > thresh)) {
                 zhashx_delete (cache->zhx, ref);
                 count++;
         }
@@ -446,7 +458,7 @@ static void cache_entry_destroy_wrapper (void **arg)
         cache_entry_destroy (*entry);
 }
 
-struct cache *cache_create (void)
+struct cache *cache_create (flux_reactor_t *r)
 {
     struct cache *cache = calloc (1, sizeof (*cache));
     if (!cache)
@@ -456,6 +468,8 @@ struct cache *cache_create (void)
         errno = ENOMEM;
         return NULL;
     }
+    cache->r = r;
+    cache->fake_time = -1.;
     /* do not duplicate hash keys, use blobrefs stored in cache entry */
     zhashx_set_key_destructor (cache->zhx, NULL);
     zhashx_set_key_duplicator (cache->zhx, NULL);
@@ -469,6 +483,20 @@ void cache_destroy (struct cache *cache)
         zhashx_destroy (&cache->zhx);
         free (cache);
     }
+}
+
+/* for testing */
+void cache_entry_set_fake_time (struct cache_entry *entry, double time)
+{
+    if (entry)
+        entry->lastuse_time = time;
+}
+
+/* for testing */
+void cache_set_fake_time (struct cache *cache, double time)
+{
+    if (cache)
+        cache->fake_time = time;
 }
 
 /*

--- a/src/modules/kvs/cache.h
+++ b/src/modules/kvs/cache.h
@@ -110,16 +110,16 @@ int cache_entry_wait_valid (struct cache_entry *entry, wait_t *wait);
 const char *cache_entry_get_blobref (struct cache_entry *entry);
 
 /* Create/destroy the cache container and its contents.
+ * 'r' is used as a source of relative current time for cache aging.
+ * If NULL, the cache never ages.
  */
-struct cache *cache_create (void);
+struct cache *cache_create (flux_reactor_t *r);
 void cache_destroy (struct cache *cache);
 
 /* Look up a cache entry.
- * Update the entry's "last used" time to 'current_epoch',
- * taking care not to not run backwards.
+ * Update the cache entry's "last used" time.
  */
-struct cache_entry *cache_lookup (struct cache *cache,
-                                  const char *ref, int current_epoch);
+struct cache_entry *cache_lookup (struct cache *cache, const char *ref);
 
 /* Insert entry in the cache.  Reference for entry created during
  * cache_entry_create() time.  Ownership of the cache entry is
@@ -138,10 +138,11 @@ int cache_remove_entry (struct cache *cache, const char *ref);
 int cache_count_entries (struct cache *cache);
 
 /* Expire cache entries that are not dirty, not incomplete, and last
- * used more than 'thresh' epoch's ago.
+ * used more than 'max_age' seconds ago.  If max_age == 0, expire all
+ * entries that are not dirty/incomplete.
  * Returns -1 on error, expired count on success.
  */
-int cache_expire_entries (struct cache *cache, int current_epoch, int thresh);
+int cache_expire_entries (struct cache *cache, double max_age);
 
 /* Obtain statistics on the cache.
  * Returns -1 on error, 0 on success
@@ -153,6 +154,14 @@ int cache_get_stats (struct cache *cache, tstat_t *ts, int *size,
  * if they meet match criteria.
  */
 int cache_wait_destroy_msg (struct cache *cache, wait_test_msg_f cb, void *arg);
+
+/* for testing */
+void cache_entry_set_fake_time (struct cache_entry *entry, double time);
+void cache_set_fake_time (struct cache *cache, double time);
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */
 
 #endif /* !_FLUX_KVS_CACHE_H */
 

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -58,7 +58,6 @@ struct kvs_ctx {
     int faults;                 /* for kvs.stats.get, etc. */
     flux_t *h;
     uint32_t rank;
-    int epoch;              /* tracks current heartbeat epoch */
     flux_watcher_t *prep_w;
     flux_watcher_t *idle_w;
     flux_watcher_t *check_w;
@@ -1198,10 +1197,8 @@ static void heartbeat_cb (flux_t *h, flux_msg_handler_t *mh,
 {
     struct kvs_ctx *ctx = arg;
 
-    if (flux_heartbeat_decode (msg, &ctx->epoch) < 0) {
-        flux_log_error (ctx->h, "%s: flux_heartbeat_decode", __FUNCTION__);
-        return;
-    }
+    if (flux_event_decode (msg, NULL, NULL) < 0)
+        flux_log_error (h, "heartbeat");
 
     /* don't error return, fallthrough to deal with rest as necessary */
     if (kvsroot_mgr_iter_roots (ctx->krm, heartbeat_root_cb, ctx) < 0)

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -925,9 +925,7 @@ static void kvstxn_apply (kvstxn_t *kt)
     if ((errnum = kvstxn_get_aux_errnum (kt)))
         goto done;
 
-    if ((ret = kvstxn_process (kt,
-                               ctx->epoch,
-                               root->ref)) == KVSTXN_PROCESS_ERROR) {
+    if ((ret = kvstxn_process (kt, root->ref)) == KVSTXN_PROCESS_ERROR) {
         errnum = kvstxn_get_errnum (kt);
         goto done;
     }
@@ -1252,7 +1250,6 @@ static lookup_t *lookup_common (flux_t *h, flux_msg_handler_t *mh,
     wait_t *wait = NULL;
     lookup_process_t lret;
     int rc = -1;
-    int ret;
 
     /* if lookup_handle exists in msg as aux data, is a replay */
     lh = flux_msg_aux_get (msg, "lookup_handle");
@@ -1304,7 +1301,6 @@ static lookup_t *lookup_common (flux_t *h, flux_msg_handler_t *mh,
 
         if (!(lh = lookup_create (ctx->cache,
                                   ctx->krm,
-                                  ctx->epoch,
                                   ns,
                                   root_ref,
                                   root_seq,
@@ -1322,9 +1318,6 @@ static lookup_t *lookup_common (flux_t *h, flux_msg_handler_t *mh,
             errno = err;
             goto done;
         }
-
-        ret = lookup_set_current_epoch (lh, ctx->epoch);
-        assert (ret == 0);
     }
 
     lret = lookup (lh);

--- a/src/modules/kvs/kvsroot.h
+++ b/src/modules/kvs/kvsroot.h
@@ -30,7 +30,7 @@ struct kvsroot {
     kvstxn_mgr_t *ktm;
     treq_mgr_t *trm;
     zlist_t *synclist;
-    int last_update_epoch;
+    double last_update_time;
     int flags;
     bool remove;
     bool setroot_pause;

--- a/src/modules/kvs/kvssync.c
+++ b/src/modules/kvs/kvssync.c
@@ -64,10 +64,8 @@ int kvssync_add (struct kvsroot *root, flux_msg_handler_f cb, flux_t *h,
         goto error;
     }
 
-    if (!(ks = calloc (1, sizeof (*ks)))) {
-        errno = ENOMEM;
+    if (!(ks = calloc (1, sizeof (*ks))))
         goto error;
-    }
 
     ks->msg = flux_msg_incref (msg);
     ks->cb = cb;

--- a/src/modules/kvs/kvstxn.c
+++ b/src/modules/kvs/kvstxn.c
@@ -284,7 +284,7 @@ static int store_cache (kvstxn_t *kt, int current_epoch, json_t *o,
         flux_log_error (kt->ktm->h, "%s: blobref_hash", __FUNCTION__);
         goto error;
     }
-    if (!(entry = cache_lookup (kt->ktm->cache, ref, current_epoch))) {
+    if (!(entry = cache_lookup (kt->ktm->cache, ref))) {
         if (!(entry = cache_entry_create (ref))) {
             flux_log_error (kt->ktm->h, "%s: cache_entry_create", __FUNCTION__);
             goto error;
@@ -625,7 +625,7 @@ static int kvstxn_link_dirent (kvstxn_t *kt, int current_epoch,
                 goto done;
             }
 
-            if (!(entry = cache_lookup (kt->ktm->cache, ref, current_epoch))
+            if (!(entry = cache_lookup (kt->ktm->cache, ref))
                 || !cache_entry_get_valid (entry)) {
                 *missing_ref = ref;
                 goto success; /* stall */
@@ -851,9 +851,7 @@ kvstxn_process_t kvstxn_process (kvstxn_t *kt,
 
         kt->state = KVSTXN_STATE_LOAD_ROOT;
 
-        if (!(entry = cache_lookup (kt->ktm->cache,
-                                    rootdir_ref,
-                                    current_epoch))
+        if (!(entry = cache_lookup (kt->ktm->cache, rootdir_ref))
             || !cache_entry_get_valid (entry)) {
 
             if (add_missing_ref (kt, rootdir_ref) < 0) {

--- a/src/modules/kvs/kvstxn.c
+++ b/src/modules/kvs/kvstxn.c
@@ -666,7 +666,7 @@ static int kvstxn_link_dirent (kvstxn_t *kt, int current_epoch,
             }
 
             if (asprintf (&nkey, "%s.%s", target, next) < 0) {
-                saved_errno = ENOMEM;
+                saved_errno = errno;
                 goto done;
             }
             if (kvstxn_link_dirent (kt,
@@ -746,7 +746,7 @@ static int add_missing_ref (kvstxn_t *kt, const char *ref)
     char *refcpy = NULL;
 
     if (!(refcpy = strdup (ref))) {
-        errno = ENOMEM;
+        errno = errno;
         goto err;
     }
 
@@ -1106,7 +1106,7 @@ kvstxn_mgr_t *kvstxn_mgr_create (struct cache *cache,
     }
 
     if (!(ktm = calloc (1, sizeof (*ktm)))) {
-        saved_errno = ENOMEM;
+        saved_errno = errno;
         goto error;
     }
     ktm->cache = cache;

--- a/src/modules/kvs/kvstxn.h
+++ b/src/modules/kvs/kvstxn.h
@@ -95,9 +95,7 @@ json_t *kvstxn_get_keys (kvstxn_t *kt);
  * on completion, call kvstxn_get_newroot_ref() to get reference to
  * new root to be stored.
  */
-kvstxn_process_t kvstxn_process (kvstxn_t *kt,
-                                 int current_epoch,
-                                 const char *rootdir_ref);
+kvstxn_process_t kvstxn_process (kvstxn_t *kt, const char *rootdir_ref);
 
 /* on stall, iterate through all missing refs that the caller should
  * load into the cache

--- a/src/modules/kvs/lookup.c
+++ b/src/modules/kvs/lookup.c
@@ -54,7 +54,6 @@ struct lookup {
     /* inputs from user */
     struct cache *cache;
     kvsroot_mgr_t *krm;
-    int current_epoch;
 
     char *ns_name;
     char *root_ref;
@@ -512,7 +511,6 @@ error:
 
 lookup_t *lookup_create (struct cache *cache,
                          kvsroot_mgr_t *krm,
-                         int current_epoch,
                          const char *ns,
                          const char *root_ref,
                          int root_seq,
@@ -542,7 +540,6 @@ lookup_t *lookup_create (struct cache *cache,
 
     lh->cache = cache;
     lh->krm = krm;
-    lh->current_epoch = current_epoch;
 
     if (ns) {
         /* must duplicate strings, user may not keep pointer alive */
@@ -699,13 +696,6 @@ const char *lookup_missing_namespace (lookup_t *lh)
     return NULL;
 }
 
-int lookup_get_current_epoch (lookup_t *lh)
-{
-    if (lh)
-        return lh->current_epoch;
-    return -1;
-}
-
 const char *lookup_get_namespace (lookup_t *lh)
 {
     if (lh)
@@ -724,15 +714,6 @@ int lookup_get_root_seq (lookup_t *lh)
 {
     if (lh && lh->state == LOOKUP_STATE_FINISHED)
         return lh->root_seq;
-    return -1;
-}
-
-int lookup_set_current_epoch (lookup_t *lh, int epoch)
-{
-    if (lh) {
-        lh->current_epoch = epoch;
-        return 0;
-    }
     return -1;
 }
 

--- a/src/modules/kvs/lookup.c
+++ b/src/modules/kvs/lookup.c
@@ -181,16 +181,16 @@ static walk_level_t *walk_level_create (const char *root_ref,
     int saved_errno;
 
     if (!wl) {
-        saved_errno = ENOMEM;
+        saved_errno = errno;
         goto error;
     }
     if (!(wl->path_copy = strdup (path))) {
-        saved_errno = ENOMEM;
+        saved_errno = errno;
         goto error;
     }
     wl->depth = depth;
     if (!(wl->root_ref = strdup (root_ref))) {
-        saved_errno = ENOMEM;
+        saved_errno = errno;
         goto error;
     }
     if (!(wl->root_dirent = treeobj_create_dirref (root_ref))) {
@@ -243,7 +243,7 @@ static lookup_process_t symlink_check_namespace (lookup_t *lh,
     if (!root) {
         free (lh->missing_namespace);
         if (!(lh->missing_namespace = strdup (ns))) {
-            lh->errnum = ENOMEM;
+            lh->errnum = errno;
             goto done;
         }
         ret = LOOKUP_PROCESS_LOAD_MISSING_NAMESPACE;
@@ -536,7 +536,7 @@ lookup_t *lookup_create (struct cache *cache,
     }
 
     if (!(lh = calloc (1, sizeof (*lh)))) {
-        saved_errno = ENOMEM;
+        saved_errno = errno;
         goto cleanup;
     }
 
@@ -547,7 +547,7 @@ lookup_t *lookup_create (struct cache *cache,
     if (ns) {
         /* must duplicate strings, user may not keep pointer alive */
         if (!(lh->ns_name = strdup (ns))) {
-            saved_errno = ENOMEM;
+            saved_errno = errno;
             goto cleanup;
         }
     }
@@ -559,7 +559,7 @@ lookup_t *lookup_create (struct cache *cache,
 
     if (root_ref) {
         if (!(lh->root_ref = strdup (root_ref))) {
-            saved_errno = ENOMEM;
+            saved_errno = errno;
             goto cleanup;
         }
         lh->root_seq = root_seq;
@@ -940,7 +940,7 @@ lookup_process_t lookup (lookup_t *lh)
                 if (!root) {
                     free (lh->missing_namespace);
                     if (!(lh->missing_namespace = strdup (lh->ns_name))) {
-                        lh->errnum = ENOMEM;
+                        lh->errnum = errno;
                         goto error;
                     }
                     return LOOKUP_PROCESS_LOAD_MISSING_NAMESPACE;
@@ -955,7 +955,7 @@ lookup_process_t lookup (lookup_t *lh)
                  * namespace could timeout or be removed when
                  * stalling */
                 if (!(lh->root_ref = strdup (root->ref))) {
-                    lh->errnum = ENOMEM;
+                    lh->errnum = errno;
                     goto error;
                 }
                 lh->root_seq = root->seq;

--- a/src/modules/kvs/lookup.c
+++ b/src/modules/kvs/lookup.c
@@ -393,7 +393,7 @@ static lookup_process_t walk (lookup_t *lh)
                 goto error;
             }
 
-            if (!(entry = cache_lookup (lh->cache, refstr, lh->current_epoch))
+            if (!(entry = cache_lookup (lh->cache, refstr))
                 || !cache_entry_get_valid (entry)) {
                 lh->missing_ref = refstr;
                 return LOOKUP_PROCESS_LOAD_MISSING_REFS;
@@ -668,7 +668,7 @@ int lookup_iter_missing_refs (lookup_t *lh, lookup_ref_f cb, void *data)
                 if (!(ref = treeobj_get_blobref (lh->valref_missing_refs, i)))
                     return -1;
 
-                if (!(entry = cache_lookup (lh->cache, ref, lh->current_epoch))
+                if (!(entry = cache_lookup (lh->cache, ref))
                     || !cache_entry_get_valid (entry)) {
 
                     /* valref points to raw data, raw_data flag is always
@@ -773,7 +773,7 @@ static int get_single_blobref_valref_value (lookup_t *lh, bool *stall)
         lh->errnum = errno;
         return -1;
     }
-    if (!(entry = cache_lookup (lh->cache, reftmp, lh->current_epoch))
+    if (!(entry = cache_lookup (lh->cache, reftmp))
         || !cache_entry_get_valid (entry)) {
         lh->valref_missing_refs = lh->wdirent;
         (*stall) = true;
@@ -806,7 +806,7 @@ static int get_multi_blobref_valref_length (lookup_t *lh, int refcount,
             lh->errnum = errno;
             return -1;
         }
-        if (!(entry = cache_lookup (lh->cache, reftmp, lh->current_epoch))
+        if (!(entry = cache_lookup (lh->cache, reftmp))
             || !cache_entry_get_valid (entry)) {
             lh->valref_missing_refs = lh->wdirent;
             (*stall) = true;
@@ -857,7 +857,7 @@ static char *get_multi_blobref_valref_data (lookup_t *lh, int refcount,
         reftmp = treeobj_get_blobref (lh->wdirent, i);
         assert (reftmp);
 
-        entry = cache_lookup (lh->cache, reftmp, lh->current_epoch);
+        entry = cache_lookup (lh->cache, reftmp);
         assert (entry);
         assert (cache_entry_get_valid (entry));
 
@@ -982,9 +982,7 @@ lookup_process_t lookup (lookup_t *lh)
                         lh->errnum = EISDIR;
                         goto error;
                     }
-                    if (!(entry = cache_lookup (lh->cache,
-                                                lh->root_ref,
-                                                lh->current_epoch))
+                    if (!(entry = cache_lookup (lh->cache, lh->root_ref))
                         || !cache_entry_get_valid (entry)) {
                         lh->missing_ref = lh->root_ref;
                         return LOOKUP_PROCESS_LOAD_MISSING_REFS;
@@ -1082,8 +1080,7 @@ lookup_process_t lookup (lookup_t *lh)
                     lh->errnum = errno;
                     goto error;
                 }
-                if (!(entry = cache_lookup (lh->cache, reftmp,
-                                            lh->current_epoch))
+                if (!(entry = cache_lookup (lh->cache, reftmp))
                     || !cache_entry_get_valid (entry)) {
                     lh->missing_ref = reftmp;
                     return LOOKUP_PROCESS_LOAD_MISSING_REFS;

--- a/src/modules/kvs/lookup.h
+++ b/src/modules/kvs/lookup.h
@@ -40,7 +40,6 @@ typedef int (*lookup_ref_f)(lookup_t *c,
  */
 lookup_t *lookup_create (struct cache *cache,
                          kvsroot_mgr_t *krm,
-                         int current_epoch,
                          const char *ns,
                          const char *root_ref,
                          int root_seq,

--- a/src/modules/kvs/test/kvsroot.c
+++ b/src/modules/kvs/test/kvsroot.c
@@ -30,7 +30,7 @@ void basic_api_tests (void)
     struct kvsroot *tmproot;
     struct flux_msg_cred cred;
 
-    cache = cache_create ();
+    cache = cache_create (NULL);
 
     ok ((krm = kvsroot_mgr_create (NULL, &global)) != NULL,
         "kvsroot_mgr_create works");
@@ -163,7 +163,7 @@ void basic_iter_tests (void)
     struct kvsroot *root;
     int count;
 
-    cache = cache_create ();
+    cache = cache_create (NULL);
 
     ok ((krm = kvsroot_mgr_create (NULL, &global)) != NULL,
         "kvsroot_mgr_create works");
@@ -223,7 +223,7 @@ void basic_kvstxn_mgr_tests (void)
     json_t *ops = NULL;
     void *tmpaux;
 
-    cache = cache_create ();
+    cache = cache_create (NULL);
 
     ok ((krm = kvsroot_mgr_create (NULL, &global)) != NULL,
         "kvsroot_mgr_create works");

--- a/src/modules/kvs/test/kvssync.c
+++ b/src/modules/kvs/test/kvssync.c
@@ -51,7 +51,7 @@ void basic_api_tests (void)
     struct kvsroot *root;
     flux_msg_t *msg;
 
-    cache = cache_create ();
+    cache = cache_create (NULL);
 
     ok ((krm = kvsroot_mgr_create (NULL, NULL)) != NULL,
         "kvsroot_mgr_create works");
@@ -190,7 +190,7 @@ void basic_remove_tests (void)
     struct kvsroot *root;
     int i;
 
-    cache = cache_create ();
+    cache = cache_create (NULL);
 
     ok ((krm = kvsroot_mgr_create (NULL, NULL)) != NULL,
         "kvsroot_mgr_create works");

--- a/src/modules/kvs/test/kvstxn.c
+++ b/src/modules/kvs/test/kvstxn.c
@@ -39,7 +39,7 @@ static void ktest_finalize (struct cache *cache, kvsroot_mgr_t *krm)
 
 static void ktest_init (struct cache **cache, kvsroot_mgr_t **krm)
 {
-    if (!(*cache = cache_create ()))
+    if (!(*cache = cache_create (NULL)))
         BAIL_OUT ("cache_create failed");
     if (!(*krm = kvsroot_mgr_create (NULL, NULL)))
         BAIL_OUT ("kvsroot_mgr_create failed");
@@ -159,7 +159,7 @@ struct cache *create_cache_with_empty_rootdir (char *ref, int ref_len)
 
     rootdir = treeobj_create_dir ();
 
-    ok ((cache = cache_create ()) != NULL,
+    ok ((cache = cache_create (NULL)) != NULL,
         "cache_create works");
     ok (treeobj_hash ("sha1", rootdir, ref, ref_len) == 0,
         "treeobj_hash worked");

--- a/src/modules/kvs/test/kvstxn.c
+++ b/src/modules/kvs/test/kvstxn.c
@@ -657,7 +657,6 @@ void verify_value (struct cache *cache,
 
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              ns,
                              root_ref,
                              0,
@@ -715,7 +714,7 @@ void kvstxn_basic_kvstxn_process_test (void)
     ok ((kt = kvstxn_mgr_get_ready_transaction (ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns ready kvstxn");
 
-    ok (kvstxn_process (kt, 1, rootref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
+    ok (kvstxn_process (kt, rootref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
         "kvstxn_process returns KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES");
 
     ok (kvstxn_iter_dirty_cache_entries (kt, cache_count_dirty_cb, &count) == 0,
@@ -724,7 +723,7 @@ void kvstxn_basic_kvstxn_process_test (void)
     ok (count == 1,
         "correct number of cache entries were dirty");
 
-    ok (kvstxn_process (kt, 1, rootref) == KVSTXN_PROCESS_FINISHED,
+    ok (kvstxn_process (kt, rootref) == KVSTXN_PROCESS_FINISHED,
         "kvstxn_process returns KVSTXN_PROCESS_FINISHED");
 
     ok ((newroot = kvstxn_get_newroot_ref (kt)) != NULL,
@@ -774,7 +773,7 @@ void kvstxn_basic_kvstxn_process_test_normalization (void)
     ok ((kt = kvstxn_mgr_get_ready_transaction (ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns ready kvstxn");
 
-    ok (kvstxn_process (kt, 1, rootref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
+    ok (kvstxn_process (kt, rootref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
         "kvstxn_process returns KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES");
 
     ok (kvstxn_iter_dirty_cache_entries (kt, cache_count_dirty_cb, &count) == 0,
@@ -783,7 +782,7 @@ void kvstxn_basic_kvstxn_process_test_normalization (void)
     ok (count == 2,
         "correct number of cache entries were dirty");
 
-    ok (kvstxn_process (kt, 1, rootref) == KVSTXN_PROCESS_FINISHED,
+    ok (kvstxn_process (kt, rootref) == KVSTXN_PROCESS_FINISHED,
         "kvstxn_process returns KVSTXN_PROCESS_FINISHED");
 
     ok ((newroot = kvstxn_get_newroot_ref (kt)) != NULL,
@@ -839,7 +838,7 @@ void kvstxn_basic_kvstxn_process_test_multiple_transactions (void)
     ok ((kt = kvstxn_mgr_get_ready_transaction (ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns ready kvstxn");
 
-    ok (kvstxn_process (kt, 1, rootref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
+    ok (kvstxn_process (kt, rootref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
         "kvstxn_process returns KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES");
 
     ok (kvstxn_iter_dirty_cache_entries (kt, cache_count_dirty_cb, &count) == 0,
@@ -848,7 +847,7 @@ void kvstxn_basic_kvstxn_process_test_multiple_transactions (void)
     ok (count == 1,
         "correct number of cache entries were dirty");
 
-    ok (kvstxn_process (kt, 1, rootref) == KVSTXN_PROCESS_FINISHED,
+    ok (kvstxn_process (kt, rootref) == KVSTXN_PROCESS_FINISHED,
         "kvstxn_process returns KVSTXN_PROCESS_FINISHED");
 
     ok ((newroot = kvstxn_get_newroot_ref (kt)) != NULL,
@@ -864,7 +863,7 @@ void kvstxn_basic_kvstxn_process_test_multiple_transactions (void)
     ok ((kt = kvstxn_mgr_get_ready_transaction (ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns ready kvstxn");
 
-    ok (kvstxn_process (kt, 1, rootref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
+    ok (kvstxn_process (kt, rootref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
         "kvstxn_process returns KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES");
 
     count = 0;
@@ -876,7 +875,7 @@ void kvstxn_basic_kvstxn_process_test_multiple_transactions (void)
     ok (count == 2,
         "correct number of cache entries were dirty");
 
-    ok (kvstxn_process (kt, 1, rootref) == KVSTXN_PROCESS_FINISHED,
+    ok (kvstxn_process (kt, rootref) == KVSTXN_PROCESS_FINISHED,
         "kvstxn_process returns KVSTXN_PROCESS_FINISHED");
 
     ok ((newroot = kvstxn_get_newroot_ref (kt)) != NULL,
@@ -941,7 +940,7 @@ void kvstxn_basic_kvstxn_process_test_multiple_transactions_merge (void)
     ok ((kt = kvstxn_mgr_get_ready_transaction (ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns ready kvstxn");
 
-    ok (kvstxn_process (kt, 1, rootref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
+    ok (kvstxn_process (kt, rootref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
         "kvstxn_process returns KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES");
 
     ok (kvstxn_iter_dirty_cache_entries (kt, cache_count_dirty_cb, &count) == 0,
@@ -954,7 +953,7 @@ void kvstxn_basic_kvstxn_process_test_multiple_transactions_merge (void)
     ok (count == 3,
         "correct number of cache entries were dirty");
 
-    ok (kvstxn_process (kt, 1, rootref) == KVSTXN_PROCESS_FINISHED,
+    ok (kvstxn_process (kt, rootref) == KVSTXN_PROCESS_FINISHED,
         "kvstxn_process returns KVSTXN_PROCESS_FINISHED");
 
     ok ((newroot = kvstxn_get_newroot_ref (kt)) != NULL,
@@ -974,13 +973,13 @@ void kvstxn_basic_kvstxn_process_test_multiple_transactions_merge (void)
     ok ((kt = kvstxn_mgr_get_ready_transaction (ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns NULL, no more kvstxns");
 
-    ok (kvstxn_process (kt, 1, rootref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
+    ok (kvstxn_process (kt, rootref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
         "kvstxn_process returns KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES");
 
     ok (kvstxn_iter_dirty_cache_entries (kt, cache_count_dirty_cb, &count) == 0,
         "kvstxn_iter_dirty_cache_entries works for dirty cache entries");
 
-    ok (kvstxn_process (kt, 1, rootref) == KVSTXN_PROCESS_FINISHED,
+    ok (kvstxn_process (kt, rootref) == KVSTXN_PROCESS_FINISHED,
         "kvstxn_process returns KVSTXN_PROCESS_FINISHED");
 
     ok ((newroot = kvstxn_get_newroot_ref (kt)) != NULL,
@@ -1032,7 +1031,7 @@ void kvstxn_basic_kvstxn_process_test_invalid_transaction (void)
     ok ((kt = kvstxn_mgr_get_ready_transaction (ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns ready transaction");
 
-    ok (kvstxn_process (ktbad, 1, rootref) == KVSTXN_PROCESS_ERROR
+    ok (kvstxn_process (ktbad, rootref) == KVSTXN_PROCESS_ERROR
         && kvstxn_get_errnum (ktbad) == EINVAL,
         "kvstxn_process fails on bad kvstxn");
 
@@ -1072,11 +1071,11 @@ void kvstxn_basic_root_not_dir (void)
     ok ((kt = kvstxn_mgr_get_ready_transaction (ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns ready kvstxn");
 
-    ok (kvstxn_process (kt, 1, root_ref) == KVSTXN_PROCESS_ERROR,
+    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_ERROR,
         "kvstxn_process returns KVSTXN_PROCESS_ERROR");
 
     /* error is caught continuously */
-    ok (kvstxn_process (kt, 1, root_ref) == KVSTXN_PROCESS_ERROR,
+    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_ERROR,
         "kvstxn_process returns KVSTXN_PROCESS_ERROR again");
 
     ok (kvstxn_get_errnum (kt) == EINVAL,
@@ -1149,11 +1148,11 @@ void kvstxn_process_root_missing (void)
     ok ((kt = kvstxn_mgr_get_ready_transaction (ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns ready kvstxn");
 
-    ok (kvstxn_process (kt, 1, rootref) == KVSTXN_PROCESS_LOAD_MISSING_REFS,
+    ok (kvstxn_process (kt, rootref) == KVSTXN_PROCESS_LOAD_MISSING_REFS,
         "kvstxn_process returns KVSTXN_PROCESS_LOAD_MISSING_REFS");
 
     /* user forgot to call kvstxn_iter_missing_refs() test */
-    ok (kvstxn_process (kt, 1, rootref) == KVSTXN_PROCESS_LOAD_MISSING_REFS,
+    ok (kvstxn_process (kt, rootref) == KVSTXN_PROCESS_LOAD_MISSING_REFS,
         "kvstxn_process returns KVSTXN_PROCESS_LOAD_MISSING_REFS again");
 
     rd.cache = cache;
@@ -1162,17 +1161,17 @@ void kvstxn_process_root_missing (void)
     ok (kvstxn_iter_missing_refs (kt, rootref_cb, &rd) == 0,
         "kvstxn_iter_missing_refs works for dirty cache entries");
 
-    ok (kvstxn_process (kt, 1, rootref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
+    ok (kvstxn_process (kt, rootref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
         "kvstxn_process returns KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES");
 
     /* user forgot to call kvstxn_iter_dirty_cache_entries() test */
-    ok (kvstxn_process (kt, 1, rootref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
+    ok (kvstxn_process (kt, rootref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
         "kvstxn_process returns KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES again");
 
     ok (kvstxn_iter_dirty_cache_entries (kt, cache_noop_cb, NULL) == 0,
         "kvstxn_iter_dirty_cache_entries works for dirty cache entries");
 
-    ok (kvstxn_process (kt, 1, rootref) == KVSTXN_PROCESS_FINISHED,
+    ok (kvstxn_process (kt, rootref) == KVSTXN_PROCESS_FINISHED,
         "kvstxn_process returns KVSTXN_PROCESS_FINISHED");
 
     ok ((newroot = kvstxn_get_newroot_ref (kt)) != NULL,
@@ -1250,11 +1249,11 @@ void kvstxn_process_missing_ref (void)
     ok ((kt = kvstxn_mgr_get_ready_transaction (ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns ready kvstxn");
 
-    ok (kvstxn_process (kt, 1, root_ref) == KVSTXN_PROCESS_LOAD_MISSING_REFS,
+    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_LOAD_MISSING_REFS,
         "kvstxn_process returns KVSTXN_PROCESS_LOAD_MISSING_REFS");
 
     /* user forgot to call kvstxn_iter_missing_refs() test */
-    ok (kvstxn_process (kt, 1, root_ref) == KVSTXN_PROCESS_LOAD_MISSING_REFS,
+    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_LOAD_MISSING_REFS,
         "kvstxn_process returns KVSTXN_PROCESS_LOAD_MISSING_REFS again");
 
     ok (kvstxn_iter_missing_refs (kt, missingref_count_cb, &count) == 0,
@@ -1270,17 +1269,17 @@ void kvstxn_process_missing_ref (void)
 
     (void)cache_insert (cache, entry);
 
-    ok (kvstxn_process (kt, 1, root_ref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
+    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
         "kvstxn_process returns KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES");
 
     /* user forgot to call kvstxn_iter_dirty_cache_entries() test */
-    ok (kvstxn_process (kt, 1, root_ref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
+    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
         "kvstxn_process returns KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES again");
 
     ok (kvstxn_iter_dirty_cache_entries (kt, cache_noop_cb, NULL) == 0,
         "kvstxn_iter_dirty_cache_entries works for dirty cache entries");
 
-    ok (kvstxn_process (kt, 1, root_ref) == KVSTXN_PROCESS_FINISHED,
+    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_FINISHED,
         "kvstxn_process returns KVSTXN_PROCESS_FINISHED");
 
     ok ((newroot = kvstxn_get_newroot_ref (kt)) != NULL,
@@ -1392,7 +1391,7 @@ void kvstxn_process_multiple_missing_ref (void)
     ok ((kt = kvstxn_mgr_get_ready_transaction (ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns ready kvstxn");
 
-    ok (kvstxn_process (kt, 1, root_ref) == KVSTXN_PROCESS_LOAD_MISSING_REFS,
+    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_LOAD_MISSING_REFS,
         "kvstxn_process returns KVSTXN_PROCESS_LOAD_MISSING_REFS");
 
     ok (kvstxn_iter_missing_refs (kt, missingref_count_cb, &count) == 0,
@@ -1418,13 +1417,13 @@ void kvstxn_process_multiple_missing_ref (void)
 
     (void)cache_insert (cache, entry);
 
-    ok (kvstxn_process (kt, 1, root_ref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
+    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
         "kvstxn_process returns KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES");
 
     ok (kvstxn_iter_dirty_cache_entries (kt, cache_noop_cb, NULL) == 0,
         "kvstxn_iter_dirty_cache_entries works for dirty cache entries");
 
-    ok (kvstxn_process (kt, 1, root_ref) == KVSTXN_PROCESS_FINISHED,
+    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_FINISHED,
         "kvstxn_process returns KVSTXN_PROCESS_FINISHED");
 
     ok ((newroot = kvstxn_get_newroot_ref (kt)) != NULL,
@@ -1515,7 +1514,7 @@ void kvstxn_process_multiple_identical_missing_ref (void)
     ok ((kt = kvstxn_mgr_get_ready_transaction (ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns ready kvstxn");
 
-    ok (kvstxn_process (kt, 1, root_ref) == KVSTXN_PROCESS_LOAD_MISSING_REFS,
+    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_LOAD_MISSING_REFS,
         "kvstxn_process returns KVSTXN_PROCESS_LOAD_MISSING_REFS");
 
     ok (kvstxn_iter_missing_refs (kt, missingref_count_cb, &count) == 0,
@@ -1531,13 +1530,13 @@ void kvstxn_process_multiple_identical_missing_ref (void)
 
     (void)cache_insert (cache, entry);
 
-    ok (kvstxn_process (kt, 1, root_ref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
+    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
         "kvstxn_process returns KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES");
 
     ok (kvstxn_iter_dirty_cache_entries (kt, cache_noop_cb, NULL) == 0,
         "kvstxn_iter_dirty_cache_entries works for dirty cache entries");
 
-    ok (kvstxn_process (kt, 1, root_ref) == KVSTXN_PROCESS_FINISHED,
+    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_FINISHED,
         "kvstxn_process returns KVSTXN_PROCESS_FINISHED");
 
     ok ((newroot = kvstxn_get_newroot_ref (kt)) != NULL,
@@ -1624,7 +1623,7 @@ void kvstxn_process_missing_ref_removed (void)
     ok ((kt = kvstxn_mgr_get_ready_transaction (ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns ready kvstxn");
 
-    ok (kvstxn_process (kt, 1, root_ref) == KVSTXN_PROCESS_LOAD_MISSING_REFS,
+    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_LOAD_MISSING_REFS,
         "kvstxn_process returns KVSTXN_PROCESS_LOAD_MISSING_REFS");
 
     ok (kvstxn_iter_missing_refs (kt, missingref_count_cb, &count) == 0,
@@ -1640,13 +1639,13 @@ void kvstxn_process_missing_ref_removed (void)
 
     (void)cache_insert (cache, entry);
 
-    ok (kvstxn_process (kt, 1, root_ref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
+    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
         "kvstxn_process returns KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES");
 
     ok (kvstxn_iter_dirty_cache_entries (kt, cache_noop_cb, NULL) == 0,
         "kvstxn_iter_dirty_cache_entries works for dirty cache entries");
 
-    ok (kvstxn_process (kt, 1, root_ref) == KVSTXN_PROCESS_FINISHED,
+    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_FINISHED,
         "kvstxn_process returns KVSTXN_PROCESS_FINISHED");
 
     ok ((newroot = kvstxn_get_newroot_ref (kt)) != NULL,
@@ -1731,7 +1730,7 @@ void kvstxn_process_error_callbacks (void)
     ok ((kt = kvstxn_mgr_get_ready_transaction (ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns ready kvstxn");
 
-    ok (kvstxn_process (kt, 1, root_ref) == KVSTXN_PROCESS_LOAD_MISSING_REFS,
+    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_LOAD_MISSING_REFS,
         "kvstxn_process returns KVSTXN_PROCESS_LOAD_MISSING_REFS");
 
     errno = 0;
@@ -1743,7 +1742,7 @@ void kvstxn_process_error_callbacks (void)
      * kvstxn_process call */
     (void)cache_insert (cache, create_cache_entry_treeobj (dir_ref, dir));
 
-    ok (kvstxn_process (kt, 1, root_ref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
+    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
         "kvstxn_process returns KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES");
 
     errno = 0;
@@ -1831,7 +1830,7 @@ void kvstxn_process_error_callbacks_partway (void)
     ok ((kt = kvstxn_mgr_get_ready_transaction (ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns ready kvstxn");
 
-    ok (kvstxn_process (kt, 1, root_ref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
+    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
         "kvstxn_process returns KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES");
 
     errno = 0;
@@ -1881,11 +1880,11 @@ void kvstxn_process_invalid_operation (void)
     ok ((kt = kvstxn_mgr_get_ready_transaction (ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns ready kvstxn");
 
-    ok (kvstxn_process (kt, 1, root_ref) == KVSTXN_PROCESS_ERROR,
+    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_ERROR,
         "kvstxn_process returns KVSTXN_PROCESS_ERROR");
 
     /* error is caught continuously */
-    ok (kvstxn_process (kt, 1, root_ref) == KVSTXN_PROCESS_ERROR,
+    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_ERROR,
         "kvstxn_process returns KVSTXN_PROCESS_ERROR again");
 
     ok (kvstxn_get_errnum (kt) == EINVAL,
@@ -1934,7 +1933,7 @@ void kvstxn_process_malformed_operation (void)
      */
     ok ((kt = kvstxn_mgr_get_ready_transaction (ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns ready kvstxn");
-    ok (kvstxn_process (kt, 1, root_ref) == KVSTXN_PROCESS_ERROR
+    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_ERROR
         && kvstxn_get_errnum (kt) == EPROTO,
         "kvstxn_process encountered EPROTO error");
 
@@ -1975,11 +1974,11 @@ void kvstxn_process_invalid_hash (void)
     ok ((kt = kvstxn_mgr_get_ready_transaction (ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns ready kvstxn");
 
-    ok (kvstxn_process (kt, 1, root_ref) == KVSTXN_PROCESS_ERROR,
+    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_ERROR,
         "kvstxn_process returns KVSTXN_PROCESS_ERROR");
 
     /* verify kvstxn_process() does not continue processing */
-    ok (kvstxn_process (kt, 1, root_ref) == KVSTXN_PROCESS_ERROR,
+    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_ERROR,
         "kvstxn_process returns KVSTXN_PROCESS_ERROR on second call");
 
     ok (kvstxn_get_errnum (kt) == EINVAL,
@@ -2046,13 +2045,13 @@ void kvstxn_process_follow_link_no_namespace (void)
     ok ((kt = kvstxn_mgr_get_ready_transaction (ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns ready kvstxn");
 
-    ok (kvstxn_process (kt, 1, root_ref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
+    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
         "kvstxn_process returns KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES");
 
     ok (kvstxn_iter_dirty_cache_entries (kt, cache_noop_cb, NULL) == 0,
         "kvstxn_iter_dirty_cache_entries works for dirty cache entries");
 
-    ok (kvstxn_process (kt, 1, root_ref) == KVSTXN_PROCESS_FINISHED,
+    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_FINISHED,
         "kvstxn_process returns KVSTXN_PROCESS_FINISHED");
 
     ok ((newroot = kvstxn_get_newroot_ref (kt)) != NULL,
@@ -2114,13 +2113,13 @@ void kvstxn_process_follow_link_namespace (void)
     ok ((kt = kvstxn_mgr_get_ready_transaction (ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns ready kvstxn");
 
-    ok (kvstxn_process (kt, 1, root_ref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
+    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
         "kvstxn_process returns KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES");
 
     ok (kvstxn_iter_dirty_cache_entries (kt, cache_noop_cb, NULL) == 0,
         "kvstxn_iter_dirty_cache_entries works for dirty cache entries");
 
-    ok (kvstxn_process (kt, 1, root_ref) == KVSTXN_PROCESS_FINISHED,
+    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_FINISHED,
         "kvstxn_process returns KVSTXN_PROCESS_FINISHED");
 
     ok ((newroot = kvstxn_get_newroot_ref (kt)) != NULL,
@@ -2150,7 +2149,7 @@ void kvstxn_process_follow_link_namespace (void)
     ok ((kt = kvstxn_mgr_get_ready_transaction (ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns ready kvstxn");
 
-    ok (kvstxn_process (kt, 1, root_ref) == KVSTXN_PROCESS_ERROR,
+    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_ERROR,
         "kvstxn_process returns KVSTXN_PROCESS_ERROR");
 
     ok (kvstxn_get_errnum (kt) == EINVAL,
@@ -2208,13 +2207,13 @@ void kvstxn_process_dirval_test (void)
     ok ((kt = kvstxn_mgr_get_ready_transaction (ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns ready kvstxn");
 
-    ok (kvstxn_process (kt, 1, root_ref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
+    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
         "kvstxn_process returns KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES");
 
     ok (kvstxn_iter_dirty_cache_entries (kt, cache_noop_cb, NULL) == 0,
         "kvstxn_iter_dirty_cache_entries works for dirty cache entries");
 
-    ok (kvstxn_process (kt, 1, root_ref) == KVSTXN_PROCESS_FINISHED,
+    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_FINISHED,
         "kvstxn_process returns KVSTXN_PROCESS_FINISHED");
 
     ok ((newroot = kvstxn_get_newroot_ref (kt)) != NULL,
@@ -2285,13 +2284,13 @@ void kvstxn_process_delete_test (void)
     ok ((kt = kvstxn_mgr_get_ready_transaction (ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns ready kvstxn");
 
-    ok (kvstxn_process (kt, 1, root_ref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
+    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
         "kvstxn_process returns KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES");
 
     ok (kvstxn_iter_dirty_cache_entries (kt, cache_noop_cb, NULL) == 0,
         "kvstxn_iter_dirty_cache_entries works for dirty cache entries");
 
-    ok (kvstxn_process (kt, 1, root_ref) == KVSTXN_PROCESS_FINISHED,
+    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_FINISHED,
         "kvstxn_process returns KVSTXN_PROCESS_FINISHED");
 
     ok ((newroot = kvstxn_get_newroot_ref (kt)) != NULL,
@@ -2343,7 +2342,7 @@ void kvstxn_process_delete_nosubdir_test (void)
     ok ((kt = kvstxn_mgr_get_ready_transaction (ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns ready kvstxn");
 
-    ok (kvstxn_process (kt, 1, root_ref) == KVSTXN_PROCESS_FINISHED,
+    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_FINISHED,
         "kvstxn_process returns KVSTXN_PROCESS_FINISHED");
 
     ok ((newroot = kvstxn_get_newroot_ref (kt)) != NULL,
@@ -2414,7 +2413,7 @@ void kvstxn_process_delete_filevalinpath_test (void)
     ok ((kt = kvstxn_mgr_get_ready_transaction (ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns ready kvstxn");
 
-    ok (kvstxn_process (kt, 1, root_ref) == KVSTXN_PROCESS_FINISHED,
+    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_FINISHED,
         "kvstxn_process returns KVSTXN_PROCESS_FINISHED");
 
     ok ((newroot = kvstxn_get_newroot_ref (kt)) != NULL,
@@ -2485,11 +2484,11 @@ void kvstxn_process_bad_dirrefs (void)
     ok ((kt = kvstxn_mgr_get_ready_transaction (ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns ready kvstxn");
 
-    ok (kvstxn_process (kt, 1, root_ref) == KVSTXN_PROCESS_ERROR,
+    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_ERROR,
         "kvstxn_process returns KVSTXN_PROCESS_ERROR");
 
     /* error is caught continuously */
-    ok (kvstxn_process (kt, 1, root_ref) == KVSTXN_PROCESS_ERROR,
+    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_ERROR,
         "kvstxn_process returns KVSTXN_PROCESS_ERROR again");
 
     ok (kvstxn_get_errnum (kt) == ENOTRECOVERABLE,
@@ -2568,7 +2567,7 @@ void kvstxn_process_big_fileval (void)
     ok ((kt = kvstxn_mgr_get_ready_transaction (ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns ready kvstxn");
 
-    ok (kvstxn_process (kt, 1, root_ref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
+    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
         "kvstxn_process returns KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES");
 
     cache_count.treeobj_count = 0;
@@ -2583,7 +2582,7 @@ void kvstxn_process_big_fileval (void)
     ok (cache_count.total_count == 1,
         "correct number of cache entries were dirty");
 
-    ok (kvstxn_process (kt, 1, root_ref) == KVSTXN_PROCESS_FINISHED,
+    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_FINISHED,
         "kvstxn_process returns KVSTXN_PROCESS_FINISHED");
 
     ok ((newroot = kvstxn_get_newroot_ref (kt)) != NULL,
@@ -2607,7 +2606,7 @@ void kvstxn_process_big_fileval (void)
     ok ((kt = kvstxn_mgr_get_ready_transaction (ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns ready kvstxn");
 
-    ok (kvstxn_process (kt, 1, root_ref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
+    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
         "kvstxn_process returns KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES");
 
     cache_count.treeobj_count = 0;
@@ -2625,7 +2624,7 @@ void kvstxn_process_big_fileval (void)
     ok (cache_count.total_count == 2,
         "correct number of cache entries were dirty");
 
-    ok (kvstxn_process (kt, 1, root_ref) == KVSTXN_PROCESS_FINISHED,
+    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_FINISHED,
         "kvstxn_process returns KVSTXN_PROCESS_FINISHED");
 
     ok ((newroot = kvstxn_get_newroot_ref (kt)) != NULL,
@@ -2738,13 +2737,13 @@ void kvstxn_process_giant_dir (void)
     ok ((kt = kvstxn_mgr_get_ready_transaction (ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns ready kvstxn");
 
-    ok (kvstxn_process (kt, 1, root_ref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
+    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
         "kvstxn_process returns KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES");
 
     ok (kvstxn_iter_dirty_cache_entries (kt, cache_noop_cb, NULL) == 0,
         "kvstxn_iter_dirty_cache_entries works for dirty cache entries");
 
-    ok (kvstxn_process (kt, 1, root_ref) == KVSTXN_PROCESS_FINISHED,
+    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_FINISHED,
         "kvstxn_process returns KVSTXN_PROCESS_FINISHED");
 
     ok ((newroot = kvstxn_get_newroot_ref (kt)) != NULL,
@@ -2821,7 +2820,7 @@ void kvstxn_process_append (void)
     ok ((kt = kvstxn_mgr_get_ready_transaction (ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns ready kvstxn");
 
-    ok (kvstxn_process (kt, 1, root_ref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
+    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
         "kvstxn_process returns KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES");
 
     count = 0;
@@ -2833,7 +2832,7 @@ void kvstxn_process_append (void)
     ok (count == 3,
         "correct number of cache entries were dirty");
 
-    ok (kvstxn_process (kt, 1, root_ref) == KVSTXN_PROCESS_FINISHED,
+    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_FINISHED,
         "kvstxn_process returns KVSTXN_PROCESS_FINISHED");
 
     ok ((newroot = kvstxn_get_newroot_ref (kt)) != NULL,
@@ -2854,7 +2853,7 @@ void kvstxn_process_append (void)
     ok ((kt = kvstxn_mgr_get_ready_transaction (ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns ready kvstxn");
 
-    ok (kvstxn_process (kt, 1, root_ref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
+    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
         "kvstxn_process returns KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES");
 
     count = 0;
@@ -2866,7 +2865,7 @@ void kvstxn_process_append (void)
     ok (count == 2,
         "correct number of cache entries were dirty");
 
-    ok (kvstxn_process (kt, 1, root_ref) == KVSTXN_PROCESS_FINISHED,
+    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_FINISHED,
         "kvstxn_process returns KVSTXN_PROCESS_FINISHED");
 
     ok ((newroot = kvstxn_get_newroot_ref (kt)) != NULL,
@@ -2887,7 +2886,7 @@ void kvstxn_process_append (void)
     ok ((kt = kvstxn_mgr_get_ready_transaction (ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns ready kvstxn");
 
-    ok (kvstxn_process (kt, 1, root_ref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
+    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
         "kvstxn_process returns KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES");
 
     count = 0;
@@ -2898,7 +2897,7 @@ void kvstxn_process_append (void)
     ok (count == 1,
         "correct number of cache entries were dirty");
 
-    ok (kvstxn_process (kt, 1, root_ref) == KVSTXN_PROCESS_FINISHED,
+    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_FINISHED,
         "kvstxn_process returns KVSTXN_PROCESS_FINISHED");
 
     ok ((newroot = kvstxn_get_newroot_ref (kt)) != NULL,
@@ -2962,7 +2961,7 @@ void kvstxn_process_append_errors (void)
     ok ((kt = kvstxn_mgr_get_ready_transaction (ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns ready kvstxn");
 
-    ok (kvstxn_process (kt, 1, root_ref) == KVSTXN_PROCESS_ERROR,
+    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_ERROR,
         "kvstxn_process returns KVSTXN_PROCESS_ERROR");
 
     ok (kvstxn_get_errnum (kt) == EISDIR,
@@ -2979,7 +2978,7 @@ void kvstxn_process_append_errors (void)
     ok ((kt = kvstxn_mgr_get_ready_transaction (ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns ready kvstxn");
 
-    ok (kvstxn_process (kt, 1, root_ref) == KVSTXN_PROCESS_ERROR,
+    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_ERROR,
         "kvstxn_process returns KVSTXN_PROCESS_ERROR");
 
     ok (kvstxn_get_errnum (kt) == EOPNOTSUPP,
@@ -2996,7 +2995,7 @@ void kvstxn_process_append_errors (void)
     ok ((kt = kvstxn_mgr_get_ready_transaction (ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns ready kvstxn");
 
-    ok (kvstxn_process (kt, 1, root_ref) == KVSTXN_PROCESS_ERROR,
+    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_ERROR,
         "kvstxn_process returns KVSTXN_PROCESS_ERROR");
 
     ok (kvstxn_get_errnum (kt) == EOPNOTSUPP,
@@ -3084,7 +3083,7 @@ void kvstxn_process_append_no_duplicate (void)
     ok ((kt = kvstxn_mgr_get_ready_transaction (ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns ready kvstxn");
 
-    ok (kvstxn_process (kt, 1, root_ref) == KVSTXN_PROCESS_LOAD_MISSING_REFS,
+    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_LOAD_MISSING_REFS,
         "kvstxn_process returns KVSTXN_PROCESS_LOAD_MISSING_REFS");
 
     ok (kvstxn_iter_missing_refs (kt, missingref_count_cb, &count) == 0,
@@ -3100,7 +3099,7 @@ void kvstxn_process_append_no_duplicate (void)
 
     (void)cache_insert (cache, entry);
 
-    ok (kvstxn_process (kt, 1, root_ref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
+    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
         "kvstxn_process returns KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES");
 
     count = 0;
@@ -3113,7 +3112,7 @@ void kvstxn_process_append_no_duplicate (void)
     ok (count == 4,
         "correct number of cache entries were dirty");
 
-    ok (kvstxn_process (kt, 1, root_ref) == KVSTXN_PROCESS_FINISHED,
+    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_FINISHED,
         "kvstxn_process returns KVSTXN_PROCESS_FINISHED");
 
     ok ((newroot = kvstxn_get_newroot_ref (kt)) != NULL,
@@ -3178,7 +3177,7 @@ void kvstxn_process_fallback_merge (void)
     ok (kvstxn_fallback_mergeable (kt) == true,
         "kvstxn_fallback_mergeable returns true on merged transaction");
 
-    ok (kvstxn_process (kt, 1, rootref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
+    ok (kvstxn_process (kt, rootref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
         "kvstxn_process returns KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES");
 
     ok (kvstxn_iter_dirty_cache_entries (kt, cache_count_dirty_cb, &count) == 0,
@@ -3187,7 +3186,7 @@ void kvstxn_process_fallback_merge (void)
     ok (count == 1,
         "correct number of cache entries were dirty");
 
-    ok (kvstxn_process (kt, 1, rootref) == KVSTXN_PROCESS_FINISHED,
+    ok (kvstxn_process (kt, rootref) == KVSTXN_PROCESS_FINISHED,
         "kvstxn_process returns KVSTXN_PROCESS_FINISHED");
 
     ok ((newroot = kvstxn_get_newroot_ref (kt)) != NULL,
@@ -3218,7 +3217,7 @@ void kvstxn_process_fallback_merge (void)
     ok ((kt = kvstxn_mgr_get_ready_transaction (ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns ready transaction");
 
-    ok (kvstxn_process (kt, 1, rootref) == KVSTXN_PROCESS_ERROR,
+    ok (kvstxn_process (kt, rootref) == KVSTXN_PROCESS_ERROR,
         "kvstxn_process returns KVSTXN_PROCESS_ERROR");
 
     ok (kvstxn_get_errnum (kt) == EINVAL,
@@ -3241,7 +3240,7 @@ void kvstxn_process_fallback_merge (void)
     ok (kvstxn_fallback_mergeable (kt) == false,
         "kvstxn_fallback_mergeable returns false on unmerged transaction");
 
-    ok (kvstxn_process (kt, 1, rootref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
+    ok (kvstxn_process (kt, rootref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
         "kvstxn_process returns KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES");
 
     count = 0;
@@ -3251,7 +3250,7 @@ void kvstxn_process_fallback_merge (void)
     ok (count == 1,
         "correct number of cache entries were dirty");
 
-    ok (kvstxn_process (kt, 1, rootref) == KVSTXN_PROCESS_FINISHED,
+    ok (kvstxn_process (kt, rootref) == KVSTXN_PROCESS_FINISHED,
         "kvstxn_process returns KVSTXN_PROCESS_FINISHED");
 
     ok ((newroot = kvstxn_get_newroot_ref (kt)) != NULL,
@@ -3273,7 +3272,7 @@ void kvstxn_process_fallback_merge (void)
     ok (kvstxn_fallback_mergeable (kt) == false,
         "kvstxn_fallback_mergeable returns false on unmerged transaction");
 
-    ok (kvstxn_process (kt, 1, rootref) == KVSTXN_PROCESS_ERROR,
+    ok (kvstxn_process (kt, rootref) == KVSTXN_PROCESS_ERROR,
         "kvstxn_process returns KVSTXN_PROCESS_ERROR");
 
     ok (kvstxn_get_errnum (kt) == EINVAL,

--- a/src/modules/kvs/test/lookup.c
+++ b/src/modules/kvs/test/lookup.c
@@ -230,7 +230,6 @@ void basic_api (void)
 
     ok ((lh = lookup_create (cache,
                              krm,
-                             42,
                              KVS_PRIMARY_NAMESPACE,
                              "root.ref.foo",
                              0,
@@ -239,18 +238,12 @@ void basic_api (void)
                              FLUX_KVS_READLINK | FLUX_KVS_TREEOBJ,
                              NULL)) != NULL,
         "lookup_create works");
-    ok (lookup_get_current_epoch (lh) == 42,
-        "lookup_get_current_epoch works");
     ok ((tmp = lookup_get_namespace (lh)) != NULL,
         "lookup_get_namespace works");
     ok (!strcmp (tmp, KVS_PRIMARY_NAMESPACE),
         "lookup_get_namespace returns correct string");
     ok (lookup_missing_namespace (lh) == NULL,
         "lookup_missing_namespace returned NULL, no missing namespace yet");
-    ok (lookup_set_current_epoch (lh, 43) == 0,
-        "lookup_set_current_epoch works");
-    ok (lookup_get_current_epoch (lh) == 43,
-        "lookup_get_current_epoch works");
     ok (lookup_get_aux_errnum (lh) == 0,
         "lookup_get_aux_errnum returns no error");
     ok (lookup_set_aux_errnum (lh, EINVAL) == EINVAL,
@@ -275,7 +268,6 @@ void basic_api_errors (void)
 
     ok (lookup_create (NULL,
                        NULL,
-                       0,
                        NULL,
                        NULL,
                        0,
@@ -289,7 +281,6 @@ void basic_api_errors (void)
 
     ok ((lh = lookup_create (cache,
                              krm,
-                             42,
                              NULL,
                              NULL,
                              0,
@@ -303,7 +294,6 @@ void basic_api_errors (void)
 
     ok ((lh = lookup_create (cache,
                              krm,
-                             42,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -330,16 +320,12 @@ void basic_api_errors (void)
         "lookup_iter_missing_refs fails on NULL pointer");
     ok (lookup_missing_namespace (NULL) == NULL,
         "lookup_missing_namespace fails on NULL pointer");
-    ok (lookup_get_current_epoch (NULL) < 0,
-        "lookup_get_current_epoch fails on NULL pointer");
     ok (lookup_get_namespace (NULL) == NULL,
         "lookup_get_namespace fails on NULL pointer");
     ok (lookup_get_root_ref (NULL) == NULL,
         "lookup_get_root_ref fails on NULL pointer");
     ok (lookup_get_root_seq (NULL) < 0,
         "lookup_get_root_seq fails on NULL pointer");
-    ok (lookup_set_current_epoch (NULL, 42) < 0,
-        "lookup_set_current_epoch fails on NULL pointer");
     /* lookup_destroy ok on NULL pointer */
     lookup_destroy (NULL);
 
@@ -378,7 +364,6 @@ void basic_lookup (void) {
 
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -400,7 +385,6 @@ void basic_lookup (void) {
 
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              NULL,
                              root_ref,
                              18,
@@ -602,7 +586,6 @@ void lookup_root (void) {
     /* flags = 0, should error EISDIR */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -616,7 +599,6 @@ void lookup_root (void) {
     /* flags = FLUX_KVS_READDIR, should succeed */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -630,7 +612,6 @@ void lookup_root (void) {
     /* flags = FLUX_KVS_TREEOBJ, should succeed */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -646,7 +627,6 @@ void lookup_root (void) {
     /* flags = FLUX_KVS_READDIR, bad root_ref, should error EINVAL */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              NULL,
                              valref_ref,
                              0,
@@ -753,7 +733,6 @@ void lookup_basic (void) {
     /* lookup dir via dirref */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -767,7 +746,6 @@ void lookup_basic (void) {
     /* lookup value via valref */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -787,7 +765,6 @@ void lookup_basic (void) {
      */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -801,7 +778,6 @@ void lookup_basic (void) {
     /* Lookup value via valref with multiple blobrefs */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -821,7 +797,6 @@ void lookup_basic (void) {
      */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -835,7 +810,6 @@ void lookup_basic (void) {
     /* lookup value via val */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -851,7 +825,6 @@ void lookup_basic (void) {
     /* lookup dir via dir */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -865,7 +838,6 @@ void lookup_basic (void) {
     /* lookup symlink */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -881,7 +853,6 @@ void lookup_basic (void) {
     /* lookup symlinkNS */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -897,7 +868,6 @@ void lookup_basic (void) {
     /* lookup dirref treeobj */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -913,7 +883,6 @@ void lookup_basic (void) {
     /* lookup valref treeobj */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -929,7 +898,6 @@ void lookup_basic (void) {
     /* lookup val treeobj */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -945,7 +913,6 @@ void lookup_basic (void) {
     /* lookup dir treeobj */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -959,7 +926,6 @@ void lookup_basic (void) {
     /* lookup symlink treeobj */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -975,7 +941,6 @@ void lookup_basic (void) {
     /* lookup symlinkNS treeobj */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -1077,7 +1042,6 @@ void lookup_errors (void) {
      * decides what to do with entry not found */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -1092,7 +1056,6 @@ void lookup_errors (void) {
      * decides what to do with entry not found */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -1107,7 +1070,6 @@ void lookup_errors (void) {
      * decides what to do with entry not found */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -1121,7 +1083,6 @@ void lookup_errors (void) {
     /* Lookup path w/ dir in middle, should get ENOTRECOVERABLE */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -1135,7 +1096,6 @@ void lookup_errors (void) {
     /* Lookup path w/ infinite link loop, should get ELOOP */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -1149,7 +1109,6 @@ void lookup_errors (void) {
     /* Lookup path w/ infinite symlinkNS loop, should get ELOOP */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -1163,7 +1122,6 @@ void lookup_errors (void) {
     /* Lookup path w/ infinite symlink w/ & w/o namespace loop, should get ELOOP */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -1177,7 +1135,6 @@ void lookup_errors (void) {
     /* Lookup a dirref, but expecting a link, should get EINVAL. */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -1191,7 +1148,6 @@ void lookup_errors (void) {
     /* Lookup a dir, but expecting a link, should get EINVAL. */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -1205,7 +1161,6 @@ void lookup_errors (void) {
     /* Lookup a valref, but expecting a link, should get EINVAL. */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -1219,7 +1174,6 @@ void lookup_errors (void) {
     /* Lookup a val, but expecting a link, should get EINVAL. */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -1233,7 +1187,6 @@ void lookup_errors (void) {
     /* Lookup a dirref, but don't expect a dir, should get EISDIR. */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -1247,7 +1200,6 @@ void lookup_errors (void) {
     /* Lookup a dir, but don't expect a dir, should get EISDIR. */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -1261,7 +1213,6 @@ void lookup_errors (void) {
     /* Lookup a valref, but expecting a dir, should get ENOTDIR. */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -1275,7 +1226,6 @@ void lookup_errors (void) {
     /* Lookup a val, but expecting a dir, should get ENOTDIR. */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -1289,7 +1239,6 @@ void lookup_errors (void) {
     /* Lookup a symlink, but expecting a dir, should get ENOTDIR. */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -1303,7 +1252,6 @@ void lookup_errors (void) {
     /* Lookup a symlinkNS, but expecting a dir, should get ENOTDIR. */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -1317,7 +1265,6 @@ void lookup_errors (void) {
     /* Lookup a dirref that doesn't point to a dir, should get ENOTRECOVERABLE. */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -1332,7 +1279,6 @@ void lookup_errors (void) {
      * should get ENOTRECOVERABLE. */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -1346,7 +1292,6 @@ void lookup_errors (void) {
     /* Lookup with an invalid root_ref, should get EINVAL */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              valref_ref,
                              0,
@@ -1360,7 +1305,6 @@ void lookup_errors (void) {
     /* Lookup dirref with multiple blobrefs, should get ENOTRECOVERABLE */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -1375,7 +1319,6 @@ void lookup_errors (void) {
      * get ENOTRECOVERABLE */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -1393,7 +1336,6 @@ void lookup_errors (void) {
     /* Lookup with an invalid root_ref, should get EINVAL */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              NULL,
                              valref_ref,
                              0,
@@ -1448,7 +1390,6 @@ void lookup_security (void) {
 
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -1463,7 +1404,6 @@ void lookup_security (void) {
 
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -1478,7 +1418,6 @@ void lookup_security (void) {
 
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -1492,7 +1431,6 @@ void lookup_security (void) {
     /* if root_ref is set, namespace checks won't occur */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              NULL,
                              root_ref,
                              0,
@@ -1507,7 +1445,6 @@ void lookup_security (void) {
 
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              "altnamespace",
                              NULL,
                              0,
@@ -1522,7 +1459,6 @@ void lookup_security (void) {
 
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              "altnamespace",
                              NULL,
                              0,
@@ -1537,7 +1473,6 @@ void lookup_security (void) {
 
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              "altnamespace",
                              NULL,
                              0,
@@ -1552,7 +1487,6 @@ void lookup_security (void) {
 
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              "altnamespace",
                              NULL,
                              0,
@@ -1653,7 +1587,6 @@ void lookup_links (void) {
     /* lookup val, follow two links */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -1669,7 +1602,6 @@ void lookup_links (void) {
     /* lookup val, link is middle of path */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -1685,7 +1617,6 @@ void lookup_links (void) {
     /* lookup valref, link is middle of path */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -1701,7 +1632,6 @@ void lookup_links (void) {
     /* lookup dir, link is middle of path */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -1715,7 +1645,6 @@ void lookup_links (void) {
     /* lookup dirref, link is middle of path */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -1729,7 +1658,6 @@ void lookup_links (void) {
     /* lookup symlink, link is middle of path */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -1745,7 +1673,6 @@ void lookup_links (void) {
     /* lookup val, link is last part in path */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -1761,7 +1688,6 @@ void lookup_links (void) {
     /* lookup valref, link is last part in path */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -1777,7 +1703,6 @@ void lookup_links (void) {
     /* lookup dir, link is last part in path */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -1791,7 +1716,6 @@ void lookup_links (void) {
     /* lookup dirref, link is last part in path */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -1805,7 +1729,6 @@ void lookup_links (void) {
     /* lookup symlink, link is last part in path */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -1875,7 +1798,6 @@ void lookup_alt_root (void) {
     /* lookup val, alt root-ref dirref1_ref */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              NULL,
                              dirref1_ref,
                              0,
@@ -1891,7 +1813,6 @@ void lookup_alt_root (void) {
     /* lookup val, alt root-ref dirref2_ref */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              NULL,
                              dirref2_ref,
                              0,
@@ -1907,7 +1828,6 @@ void lookup_alt_root (void) {
     /* lookup val, alt root-ref dirref1_ref */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              dirref1_ref,
                              0,
@@ -1923,7 +1843,6 @@ void lookup_alt_root (void) {
     /* lookup val, alt root-ref dirref2_ref */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              dirref2_ref,
                              0,
@@ -1990,7 +1909,6 @@ void lookup_root_symlink (void) {
     /* flags = 0, should error EISDIR */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -2004,7 +1922,6 @@ void lookup_root_symlink (void) {
     /* flags = FLUX_KVS_READDIR, should succeed */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -2018,7 +1935,6 @@ void lookup_root_symlink (void) {
     /* flags = FLUX_KVS_READDIR, should succeed */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -2033,7 +1949,6 @@ void lookup_root_symlink (void) {
     /* flags = FLUX_KVS_TREEOBJ, should succeed */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -2048,7 +1963,6 @@ void lookup_root_symlink (void) {
 
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -2064,7 +1978,6 @@ void lookup_root_symlink (void) {
     /* flags = FLUX_KVS_READDIR, should succeed */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              NULL,
                              dirref_ref,
                              0,
@@ -2078,7 +1991,6 @@ void lookup_root_symlink (void) {
     /* flags = FLUX_KVS_READDIR, bad root_ref, should error EINVAL */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              NULL,
                              valref_ref,
                              0,
@@ -2145,7 +2057,6 @@ void lookup_symlinkNS (void) {
 
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              "A",
                              NULL,
                              0,
@@ -2158,7 +2069,6 @@ void lookup_symlinkNS (void) {
 
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              "A",
                              NULL,
                              0,
@@ -2171,7 +2081,6 @@ void lookup_symlinkNS (void) {
 
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              "A",
                              NULL,
                              0,
@@ -2186,7 +2095,6 @@ void lookup_symlinkNS (void) {
 
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              "A",
                              NULL,
                              0,
@@ -2201,7 +2109,6 @@ void lookup_symlinkNS (void) {
 
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              "A",
                              NULL,
                              0,
@@ -2216,7 +2123,6 @@ void lookup_symlinkNS (void) {
 
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              "A",
                              NULL,
                              0,
@@ -2231,7 +2137,6 @@ void lookup_symlinkNS (void) {
 
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              "A",
                              NULL,
                              0,
@@ -2244,7 +2149,6 @@ void lookup_symlinkNS (void) {
 
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              "A",
                              NULL,
                              0,
@@ -2318,7 +2222,6 @@ void lookup_symlinkNS_security (void) {
 
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              "A",
                              NULL,
                              0,
@@ -2333,7 +2236,6 @@ void lookup_symlinkNS_security (void) {
 
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              "A",
                              NULL,
                              0,
@@ -2348,7 +2250,6 @@ void lookup_symlinkNS_security (void) {
 
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              "A",
                              NULL,
                              0,
@@ -2363,7 +2264,6 @@ void lookup_symlinkNS_security (void) {
 
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              "A",
                              NULL,
                              0,
@@ -2420,7 +2320,6 @@ void lookup_stall_namespace (void) {
 
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -2446,7 +2345,6 @@ void lookup_stall_namespace (void) {
     /* lookup "val" should succeed cleanly */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -2463,7 +2361,6 @@ void lookup_stall_namespace (void) {
 
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              "foo",
                              NULL,
                              0,
@@ -2489,7 +2386,6 @@ void lookup_stall_namespace (void) {
     /* lookup val on namespace foo should succeed cleanly */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              "foo",
                              NULL,
                              0,
@@ -2506,7 +2402,6 @@ void lookup_stall_namespace (void) {
 
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              "roottest",
                              NULL,
                              0,
@@ -2561,7 +2456,6 @@ void lookup_stall_ref_root (void) {
     /* lookup root ".", should stall on root */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -2580,7 +2474,6 @@ void lookup_stall_ref_root (void) {
     /* lookup root ".", now fully cached, should succeed */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -2697,7 +2590,6 @@ void lookup_stall_ref (void) {
     /* lookup dirref1.val, should stall on root */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -2723,7 +2615,6 @@ void lookup_stall_ref (void) {
     /* lookup dirref1.val, now fully cached, should succeed */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -2739,7 +2630,6 @@ void lookup_stall_ref (void) {
     /* lookup symlink.val, should stall */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              NULL,
                              root_ref,
                              0,
@@ -2760,7 +2650,6 @@ void lookup_stall_ref (void) {
     /* lookup symlink.val, now fully cached, should succeed */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -2776,7 +2665,6 @@ void lookup_stall_ref (void) {
     /* lookup dirref1.valref, should stall */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -2797,7 +2685,6 @@ void lookup_stall_ref (void) {
     /* lookup dirref1.valref, now fully cached, should succeed */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -2813,7 +2700,6 @@ void lookup_stall_ref (void) {
     /* lookup dirref1.valref_multi, should stall */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -2836,7 +2722,6 @@ void lookup_stall_ref (void) {
     /* lookup dirref1.valref_multi, now fully cached, should succeed */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -2852,7 +2737,6 @@ void lookup_stall_ref (void) {
     /* lookup dirref1.valref_multi2, should stall */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -2875,7 +2759,6 @@ void lookup_stall_ref (void) {
     /* lookup dirref1.valref_multi2, now fully cached, should succeed */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -2891,7 +2774,6 @@ void lookup_stall_ref (void) {
     /* lookup dirref1.valrefmisc, should stall */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -2913,7 +2795,6 @@ void lookup_stall_ref (void) {
     /* lookup dirref1.valrefmisc_multi, should stall */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -2992,7 +2873,6 @@ void lookup_stall_namespace_removed (void) {
     /* lookup dirref.valref, should stall on root */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -3020,7 +2900,6 @@ void lookup_stall_namespace_removed (void) {
     /* lookup dirref.valref, should stall on dirref */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -3046,7 +2925,6 @@ void lookup_stall_namespace_removed (void) {
     /* lookup dirref.valref, should stall on valref */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -3080,7 +2958,6 @@ void lookup_stall_namespace_removed (void) {
     /* lookup dirref.valref, should stall on root */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -3111,7 +2988,6 @@ void lookup_stall_namespace_removed (void) {
     /* lookup dirref.valref, should stall on dirref */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -3141,7 +3017,6 @@ void lookup_stall_namespace_removed (void) {
     /* lookup dirref.valref, should stall on valref */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -3178,7 +3053,6 @@ void lookup_stall_namespace_removed (void) {
 
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              NULL,
                              root_ref,
                              0,
@@ -3219,7 +3093,6 @@ void lookup_stall_namespace_removed (void) {
 
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              NULL,
                              root_ref,
                              0,
@@ -3325,7 +3198,6 @@ void lookup_stall_ref_expire_cache_entries (void) {
     /* lookup dirref1.val, should stall on root */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,
@@ -3364,7 +3236,6 @@ void lookup_stall_ref_expire_cache_entries (void) {
 
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              NULL,
                              root_ref,
                              0,
@@ -3403,7 +3274,6 @@ void lookup_stall_ref_expire_cache_entries (void) {
     /* lookup dirref1.valref, should stall */
     ok ((lh = lookup_create (cache,
                              krm,
-                             1,
                              KVS_PRIMARY_NAMESPACE,
                              NULL,
                              0,

--- a/src/modules/kvs/test/lookup.c
+++ b/src/modules/kvs/test/lookup.c
@@ -42,7 +42,7 @@ static void ltest_finalize (struct cache *cache, kvsroot_mgr_t *krm)
 
 static void ltest_init (struct cache **cache, kvsroot_mgr_t **krm)
 {
-    if (!(*cache = cache_create ()))
+    if (!(*cache = cache_create (NULL)))
         BAIL_OUT ("cache_create failed");
     if (!(*krm = kvsroot_mgr_create (NULL, NULL)))
         BAIL_OUT ("kvsroot_mgr_create failed");
@@ -3344,7 +3344,7 @@ void lookup_stall_ref_expire_cache_entries (void) {
     ok (cache_count_entries (cache) == 1,
         "cache_count_entries returns 1");
 
-    ok (cache_expire_entries (cache, 10, 1) == 0,
+    ok (cache_expire_entries (cache, 0) == 0,
         "cache_expire_entries expires 0 entries, b/c references appropriately taken");
 
     (void)cache_insert (cache, create_cache_entry_treeobj (dirref1_ref, dirref1));
@@ -3356,7 +3356,7 @@ void lookup_stall_ref_expire_cache_entries (void) {
 
     /* clear cache */
 
-    ok (cache_expire_entries (cache, 10, 1) == 2,
+    ok (cache_expire_entries (cache, 0) == 2,
         "cache_expire_entries expires 2 entries");
 
     ok (cache_count_entries (cache) == 0,
@@ -3382,7 +3382,7 @@ void lookup_stall_ref_expire_cache_entries (void) {
     ok (cache_count_entries (cache) == 1,
         "cache_count_entries returns 1");
 
-    ok (cache_expire_entries (cache, 10, 1) == 0,
+    ok (cache_expire_entries (cache, 0) == 0,
         "cache_expire_entries expires 0 entries, b/c references appropriately taken");
 
     (void)cache_insert (cache, create_cache_entry_treeobj (dirref2_ref, dirref2));
@@ -3394,7 +3394,7 @@ void lookup_stall_ref_expire_cache_entries (void) {
 
     /* clear cache */
 
-    ok (cache_expire_entries (cache, 10, 1) == 2,
+    ok (cache_expire_entries (cache, 0) == 2,
         "cache_expire_entries expires 2 entries");
 
     ok (cache_count_entries (cache) == 0,
@@ -3425,7 +3425,7 @@ void lookup_stall_ref_expire_cache_entries (void) {
     ok (cache_count_entries (cache) == 2,
         "cache_count_entries returns 2");
 
-    ok (cache_expire_entries (cache, 10, 1) == 1,
+    ok (cache_expire_entries (cache, 0) == 1,
         "cache_expire_entries expires 1 entry, only 1 entry has reference on it");
 
     (void)cache_insert (cache, create_cache_entry_raw (valref_ref, "abcd", 4));
@@ -3437,7 +3437,7 @@ void lookup_stall_ref_expire_cache_entries (void) {
 
     /* clear cache */
 
-    ok (cache_expire_entries (cache, 10, 1) == 2,
+    ok (cache_expire_entries (cache, 0) == 2,
         "cache_expire_entries expires 2 entries");
 
     ok (cache_count_entries (cache) == 0,

--- a/src/modules/kvs/treq.c
+++ b/src/modules/kvs/treq.c
@@ -52,7 +52,7 @@ treq_mgr_t *treq_mgr_create (void)
     int saved_errno;
 
     if (!(trm = calloc (1, sizeof (*trm)))) {
-        saved_errno = ENOMEM;
+        saved_errno = errno;
         goto error;
     }
     if (!(trm->transactions = zhash_new ())) {
@@ -148,10 +148,8 @@ int treq_mgr_remove_transaction (treq_mgr_t *trm, const char *name)
     if (trm->iterating_transactions) {
         char *str = strdup (name);
 
-        if (!str) {
-            errno = ENOMEM;
+        if (!str)
             return -1;
-        }
 
         if (zlist_append (trm->removelist, str) < 0) {
             free (str);
@@ -192,8 +190,11 @@ static treq_t *treq_create_common (int nprocs, int flags)
         saved_errno = EINVAL;
         goto error;
     }
-    if (!(tr = calloc (1, sizeof (*tr)))
-        || !(tr->ops = json_array ())
+    if (!(tr = calloc (1, sizeof (*tr)))) {
+        saved_errno = errno;
+        goto error;
+    }
+    if (!(tr->ops = json_array ())
         || !(tr->requests = zlist_new ())) {
         saved_errno = ENOMEM;
         goto error;
@@ -225,7 +226,7 @@ treq_t *treq_create (const char *name, int nprocs, int flags)
     }
 
     if (!(tr->name = strdup (name))) {
-        saved_errno = ENOMEM;
+        saved_errno = errno;
         goto error;
     }
 
@@ -247,7 +248,7 @@ treq_t *treq_create_rank (uint32_t rank, unsigned int seq, int nprocs, int flags
     }
 
     if (asprintf (&(tr->name), "treq.%u.%u", rank, seq) < 0) {
-        saved_errno = ENOMEM;
+        saved_errno = errno;
         goto error;
     }
 

--- a/src/modules/kvs/waitqueue.c
+++ b/src/modules/kvs/waitqueue.c
@@ -50,10 +50,8 @@ int wait_get_usecount (wait_t *w)
 wait_t *wait_create (wait_cb_f cb, void *arg)
 {
     wait_t *w = calloc (1, sizeof (*w));
-    if (!w) {
-        errno = ENOMEM;
+    if (!w)
         return NULL;
-    }
     w->magic = WAIT_MAGIC;
     w->cb = cb;
     w->cb_arg = arg;
@@ -104,10 +102,8 @@ void *wait_msg_aux_get (wait_t *w, const char *name)
 waitqueue_t *wait_queue_create (void)
 {
     waitqueue_t *q = calloc (1, sizeof (*q));
-    if (!q) {
-        errno = ENOMEM;
+    if (!q)
         return NULL;
-    }
     if (!(q->q = zlist_new ())) {
         free (q);
         errno = ENOMEM;


### PR DESCRIPTION
This was peeled off of PR #3512.

In several places including the KVS cache, content-cache, and broker overlay network, objects are aged by counting the number of elapsed heartbeat messages.  This is prone to inaccuracy because those messages can be delayed and "bunch up" due to overlay network congestion, head of line blocking, etc..

This PR uses elapsed time, as reported by `flux_reactor_now()` to age those objects, instead of the heartbeat epoch.  The heartbeat messages only drive the periodic checks, so it's still possible to be late timing something out, but that's less likely to be a source of problems than timing something out early.  For example, early timeout of TBON peers could cause responsive nodes to be drained (once we implement #3448).  Tardiness of heartbeat callbacks will be addressed by #3512.

In addition some times that are exposed to users are now reported in seconds instead of heartbeats, which is easier to make sense of given that the heartbeat period is configurable but seconds are seconds.

Some cleanup in related code is included also.