### PR TITLE
remove unnecessary flux_future_then calls

### DIFF
--- a/t/kvs/transactionmerge.c
+++ b/t/kvs/transactionmerge.c
@@ -84,10 +84,6 @@ static void watch_count_cb (flux_future_t *f, void *arg)
 
     flux_future_reset (f);
 
-    /* re-call to set timeout */
-    if (flux_future_then (f, WATCH_TIMEOUT, watch_count_cb, arg) < 0)
-        log_err_exit ("flux_future_then");
-
     if (changecount == threadcount) {
         if (flux_kvs_lookup_cancel (f) < 0)
             log_err_exit ("flux_kvs_lookup_cancel");


### PR DESCRIPTION
Problem: Sometimes flux_future_then() is called after
flux_future_reset() to reset the continuation timeout.
These calls are no longer necessary due to update of
flux_future_reset() in PR 3518 / commit
dca95688b24459b1e67492d7d4302abfdfb10476

Solution: Remove unnecessary flux_future_then() calls.  Cleanup
code accordingly.