### PR TITLE
testsuite: update hwloc-calc usage

### DIFF
--- a/t/lua/t1001-timeouts.t
+++ b/t/lua/t1001-timeouts.t
@@ -26,7 +26,7 @@ local to, err = f:timer {
 }
 type_ok (to, 'userdata', "created timeout handler")
 is (err, nil, "error from timer create is nil")
-is (to.timeout, 250, 'timeout is 500ms')
+is (to.timeout, 250, 'timeout is 250ms')
 type_ok (to.id, 'number', 'new timeout id is '..to.id)
 
 local r = f:reactor()

--- a/t/t2604-job-shell-affinity.t
+++ b/t/t2604-job-shell-affinity.t
@@ -16,7 +16,7 @@ CPUS_ALLOWED_COUNT="$(pwd)/cpus-allowed-count.sh"
 
 cat >${CPUS_ALLOWED_COUNT} << EOF
 #!/bin/sh
-hwloc-bind --get | hwloc-calc --number-of core
+hwloc-bind --get | hwloc-calc --number-of core | tail -n 1
 EOF
 chmod +x ${CPUS_ALLOWED_COUNT}
 


### PR DESCRIPTION
Update usage of `hwloc-calc`, as additional output in newer versions is messing up some scripting.

Also fix up a typo I found.