### PR TITLE
job-info: consolidate watch RPC targets

### DIFF
--- a/src/common/libjob/job.c
+++ b/src/common/libjob/job.c
@@ -448,17 +448,11 @@ flux_future_t *flux_job_event_watch (flux_t *h, flux_jobid_t id,
     flux_future_t *f;
     const char *topic = "job-info.eventlog-watch";
     int rpc_flags = FLUX_RPC_STREAMING;
-    bool guest = false;
 
     /* No flags supported yet */
     if (!h || !path || flags) {
         errno = EINVAL;
         return NULL;
-    }
-    if (path && !strncmp (path, "guest.", 6)) {
-        topic = "job-info.guest-eventlog-watch";
-        path += 6;
-        guest = true;
     }
     if (!(f = flux_rpc_pack (h, topic, FLUX_NODEID_ANY, rpc_flags,
                              "{s:I s:s s:i}",
@@ -466,13 +460,6 @@ flux_future_t *flux_job_event_watch (flux_t *h, flux_jobid_t id,
                              "path", path,
                              "flags", flags)))
         return NULL;
-    if (guest) {
-        /* value not relevant, set to anything */
-        if (flux_future_aux_set (f, "guest", "", NULL) < 0) {
-            flux_future_destroy (f);
-            return NULL;
-        }
-    }
     return f;
 }
 
@@ -496,8 +483,6 @@ int flux_job_event_watch_cancel (flux_future_t *f)
         errno = EINVAL;
         return -1;
     }
-    if (flux_future_aux_get (f, "guest") != NULL)
-        topic = "job-info.guest-eventlog-watch-cancel";
     if (!(f2 = flux_rpc_pack (flux_future_get_flux (f),
                               topic,
                               FLUX_NODEID_ANY,

--- a/src/modules/job-info/guest_watch.h
+++ b/src/modules/job-info/guest_watch.h
@@ -13,11 +13,13 @@
 
 #include <flux/core.h>
 
-void guest_watch_cb (flux_t *h, flux_msg_handler_t *mh,
-                     const flux_msg_t *msg, void *arg);
+#include "info.h"
 
-void guest_watch_cancel_cb (flux_t *h, flux_msg_handler_t *mh,
-                            const flux_msg_t *msg, void *arg);
+int guest_watch (struct info_ctx *ctx,
+                 const flux_msg_t *msg,
+                 flux_jobid_t id,
+                 const char *path,
+                 int flags);
 
 /* Cancel all lookups that match (sender, matchtag). */
 void guest_watchers_cancel (struct info_ctx *ctx,

--- a/src/modules/job-info/job-info.c
+++ b/src/modules/job-info/job-info.c
@@ -77,16 +77,6 @@ static const struct flux_msg_handler_spec htab[] = {
       .rolemask     = FLUX_ROLE_USER
     },
     { .typemask     = FLUX_MSGTYPE_REQUEST,
-      .topic_glob   = "job-info.guest-eventlog-watch",
-      .cb           = guest_watch_cb,
-      .rolemask     = FLUX_ROLE_USER
-    },
-    { .typemask     = FLUX_MSGTYPE_REQUEST,
-      .topic_glob   = "job-info.guest-eventlog-watch-cancel",
-      .cb           = guest_watch_cancel_cb,
-      .rolemask     = FLUX_ROLE_USER
-    },
-    { .typemask     = FLUX_MSGTYPE_REQUEST,
       .topic_glob   = "job-info.disconnect",
       .cb           = disconnect_cb,
       .rolemask     = 0

--- a/t/t2231-job-info-eventlog-watch.t
+++ b/t/t2231-job-info-eventlog-watch.t
@@ -358,8 +358,5 @@ test_expect_success 'job-info stats works' '
 test_expect_success 'eventlog-watch request with empty payload fails with EPROTO(71)' '
 	${RPC} job-info.eventlog-watch 71 </dev/null
 '
-test_expect_success 'guest-eventlog-watch request with empty payload fails with EPROTO(71)' '
-	${RPC} job-info.guest-eventlog-watch 71 </dev/null
-'
 
 test_done


### PR DESCRIPTION
Problem: Two RPC targets handle watching of job eventlogs, the "job-info.eventlog-watch" target and the "job-info.guest-eventlog-watch" target (in addition to the "cancel" equivalents).  This can be confusing to anyone who wish to call these targets directly, as the path of the job eventlog will determine which should be called.

Solution: Consolidate these two targets into the single "job-info.eventlog-watch" target.  Internally, `job-info` will determine if the standard 'watch' or special 'guest watch' code path should be used.

Update `libjob` accordingly.

Remove now non-applicable tests.

Fixes #2330