### PR TITLE
github: explicitly checkout tag if creating a release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -119,6 +119,10 @@ jobs:
        ref: ${{ github.event.pull_request.head.sha }}
        fetch-depth: 0
 
+    - name: checkout tag
+      if: ${{ matrix.create_release }}
+      run: git checkout ${{ matrix.tag }}
+
     - name: coverage setup
       env: ${{matrix.env}}
       if: matrix.coverage


### PR DESCRIPTION
Problem: When a tag is pushed, GitHub Actions does not appear to
properly checkout the tag such that `git describe` returns a SHA
suffix version instead of the version being tagged.

When creating a release, add a step after git clone that explicitly
checks out the tag ref to hopefully work around this problem.