### PR TITLE
Python: fix "no such file or directory" job exception resulting from bad jobspec

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ lua-devel         | liblua5.1-dev     | >= 5.1, < 5.5     |
 lua-posix         | lua-posix         |                   | *1*
 python36-devel    | python3-dev       | >= 3.6            |
 python36-cffi     | python3-cffi      | >= 1.1            |
-python36-six      | python3-six       | >= 1.9            |
 python36-yaml     | python3-yaml      | >= 3.10.0         |
 python36-jsonschema | python3-jsonschema | >= 2.3.0       |
 phthon3-sphinx    | python3-sphinx    |                   | *2*

--- a/config/tap-driver.py
+++ b/config/tap-driver.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-from __future__ import print_function
 
 import sys
 import os

--- a/configure.ac
+++ b/configure.ac
@@ -250,11 +250,6 @@ AM_COND_IF([WITH_PYTHON], [
                  ,
                  [AC_MSG_ERROR([could not find python module cffi, version 1.1+ required])]
                  )
-  AM_CHECK_PYMOD(six,
-                 [StrictVersion(six.__version__) >= StrictVersion('1.9.0')],
-                 ,
-                 [AC_MSG_ERROR([could not find python module six, version 1.9.0+ required])]
-                 )
   AM_CHECK_PYMOD(yaml,
                  [StrictVersion(yaml.__version__) >= StrictVersion ('3.10.0')],
                  ,

--- a/src/bindings/python/_flux/make_clean_header.py
+++ b/src/bindings/python/_flux/make_clean_header.py
@@ -8,7 +8,6 @@
 # SPDX-License-Identifier: LGPL-3.0
 ###############################################################
 
-from __future__ import print_function
 import os
 import re
 

--- a/src/bindings/python/flux/core/handle.py
+++ b/src/bindings/python/flux/core/handle.py
@@ -11,7 +11,6 @@
 import signal
 import threading
 from contextlib import contextmanager
-import six
 
 from flux.wrapper import Wrapper
 from flux.rpc import RPC
@@ -148,7 +147,7 @@ class Flux(Wrapper):
         :param fstring: A string to log, C-style formatting is *not* supported
         """
         # Short-circuited because variadics can't be wrapped cleanly
-        if isinstance(fstring, six.text_type):
+        if isinstance(fstring, str):
             fstring = fstring.encode("utf-8")
         lib.flux_log(self.handle, level, fstring)
 

--- a/src/bindings/python/flux/job/Jobspec.py
+++ b/src/bindings/python/flux/job/Jobspec.py
@@ -347,7 +347,7 @@ class Jobspec(object):
 
     @stdin.setter
     def stdin(self, path):
-        """Redirect stdin to a file given by `path`"""
+        """Redirect stdin to a file given by `path`, a string or pathlib object."""
         self._set_io_path("input", "stdin", path)
 
     @property
@@ -356,7 +356,7 @@ class Jobspec(object):
 
     @stdout.setter
     def stdout(self, path):
-        """Redirect stdout to a file given by `path`"""
+        """Redirect stdout to a file given by `path`, a string or pathlib object."""
         self._set_io_path("output", "stdout", path)
 
     @property
@@ -365,7 +365,7 @@ class Jobspec(object):
 
     @stderr.setter
     def stderr(self, path):
-        """Redirect stderr to a file given by `path`"""
+        """Redirect stderr to a file given by `path`, a string or pathlib object."""
         self._set_io_path("output", "stderr", path)
 
     def _get_io_path(self, iotype, stream_name):
@@ -388,6 +388,13 @@ class Jobspec(object):
         :param stream_name: the name of the io stream
         :param path: the path to redirect the stream
         """
+        if isinstance(path, os.PathLike):
+            path = os.fspath(path)
+        if not isinstance(path, str):
+            raise TypeError(
+                "The path must be a string or pathlib object, "
+                f"got {type(path).__name__}"
+            )
         self.setattr_shell_option("{}.{}.type".format(iotype, stream_name), "file")
         self.setattr_shell_option("{}.{}.path".format(iotype, stream_name), path)
 

--- a/src/bindings/python/flux/job/Jobspec.py
+++ b/src/bindings/python/flux/job/Jobspec.py
@@ -16,7 +16,6 @@ import collections
 import collections.abc as abc
 import numbers
 
-import six
 import yaml
 
 from _flux._core import ffi
@@ -34,12 +33,12 @@ def _convert_jobspec_arg_to_string(jobspec):
     """
     if isinstance(jobspec, Jobspec):
         jobspec = jobspec.dumps()
-    elif isinstance(jobspec, six.text_type):
+    elif isinstance(jobspec, str):
         jobspec = jobspec.encode("utf-8", errors="surrogateescape")
     elif jobspec is None or jobspec == ffi.NULL:
         # catch this here rather than in C for a better error message
         raise EnvironmentError(errno.EINVAL, "jobspec must not be None/NULL")
-    elif not isinstance(jobspec, six.binary_type):
+    elif not isinstance(jobspec, bytes):
         raise TypeError(
             "jobspec must be a Jobspec or string (either binary or unicode)"
         )
@@ -168,7 +167,7 @@ class Jobspec(object):
         for key in ["min", "max", "operand"]:
             if key not in range_dict:
                 continue
-            if not isinstance(range_dict[key], six.integer_types):
+            if not isinstance(range_dict[key], int):
                 raise TypeError("{} must be an int".format(key))
             if range_dict[key] < 1:
                 raise ValueError("{} must be > 0".format(key))
@@ -187,7 +186,7 @@ class Jobspec(object):
         # validate the 'type' key
         if "type" not in res:
             raise ValueError("type is a required key for resources")
-        if not isinstance(res["type"], six.string_types):
+        if not isinstance(res["type"], str):
             raise TypeError("type must be a string")
 
         # validate the 'count' key
@@ -196,14 +195,14 @@ class Jobspec(object):
         count = res["count"]
         if isinstance(count, abc.Mapping):
             cls._validate_complex_range(count)
-        elif not isinstance(count, six.integer_types):
+        elif not isinstance(count, int):
             raise TypeError("count must be an int or mapping")
         elif count < 1:
             raise ValueError("count must be > 0")
 
         # validate the string keys
         for key in ["id", "unit", "label"]:
-            if key in res and not isinstance(res[key], six.string_types):
+            if key in res and not isinstance(res[key], str):
                 raise TypeError("{} must be a string".format(key))
 
         # validate the 'exclusive' key
@@ -225,7 +224,7 @@ class Jobspec(object):
         if not isinstance(task["count"], abc.Mapping):
             raise TypeError("count must be a mapping")
 
-        if not isinstance(task["slot"], six.string_types):
+        if not isinstance(task["slot"], str):
             raise TypeError("slot must be a string")
 
         if "attributes" in task and not isinstance(task["attributes"], abc.Mapping):
@@ -237,9 +236,9 @@ class Jobspec(object):
         if not (
             (  # sequence of strings - N.B. also true for just a plain string
                 isinstance(command, abc.Sequence)
-                and all(isinstance(x, six.string_types) for x in command)
+                and all(isinstance(x, str) for x in command)
             )
-        ) or isinstance(command, six.string_types):
+        ) or isinstance(command, str):
             raise TypeError("command must be a list of strings")
 
     @staticmethod
@@ -250,7 +249,7 @@ class Jobspec(object):
     def _create_resource(res_type, count, with_child=None):
         if with_child is not None and not isinstance(with_child, abc.Sequence):
             raise TypeError("child resource must None or a sequence")
-        if with_child is not None and isinstance(with_child, six.string_types):
+        if with_child is not None and isinstance(with_child, str):
             raise TypeError("child resource must not be a string")
         if not count > 0:
             raise ValueError("resource count must be > 0")
@@ -283,7 +282,7 @@ class Jobspec(object):
         - a python datetime.timedelta
         A duration of zero is interpreted as "not set".
         """
-        if isinstance(duration, six.string_types):
+        if isinstance(duration, str):
             time = parse_fsd(duration)
         elif isinstance(duration, datetime.timedelta):
             time = duration.total_seconds()
@@ -314,9 +313,9 @@ class Jobspec(object):
         - a pathlib object (if py 3.6+)
         - a string
         """
-        if six.PY3 and isinstance(cwd, os.PathLike):
+        if isinstance(cwd, os.PathLike):
             cwd = os.fspath(cwd)
-        if not isinstance(cwd, six.string_types):
+        if not isinstance(cwd, str):
             raise ValueError("cwd must be a string")
         self.setattr("system.cwd", cwd)
 

--- a/src/bindings/python/flux/kvs.py
+++ b/src/bindings/python/flux/kvs.py
@@ -8,8 +8,6 @@
 # SPDX-License-Identifier: LGPL-3.0
 ###############################################################
 
-from __future__ import print_function
-
 import json
 import errno
 

--- a/src/bindings/python/flux/message.py
+++ b/src/bindings/python/flux/message.py
@@ -11,8 +11,6 @@
 import errno
 import json
 
-import six
-
 from flux.wrapper import Wrapper, WrapperPimpl
 from flux.core.inner import ffi, lib, raw
 from flux.core.watchers import Watcher
@@ -152,9 +150,9 @@ class MessageWatcher(Watcher):
 
         if topic_glob is None or topic_glob == ffi.NULL:
             topic_glob = ffi.NULL
-        elif isinstance(topic_glob, six.text_type):
+        elif isinstance(topic_glob, str):
             topic_glob = topic_glob.encode("UTF-8")
-        elif not isinstance(topic_glob, six.binary_type):
+        elif not isinstance(topic_glob, bytes):
             errmsg = "Topic must be a string, not {}".format(type(topic_glob))
             raise TypeError(errno.EINVAL, errmsg)
         c_topic_glob = ffi.new("char[]", topic_glob)

--- a/src/bindings/python/flux/security.py
+++ b/src/bindings/python/flux/security.py
@@ -8,8 +8,6 @@
 # SPDX-License-Identifier: LGPL-3.0
 ###############################################################
 
-import six
-
 from _flux._security import ffi, lib
 from flux.wrapper import Wrapper, WrapperPimpl, FunctionWrapper
 
@@ -54,23 +52,23 @@ class SecurityContext(WrapperPimpl):
         self.pimpl.configure(config_pattern)
 
     def sign_wrap_as(self, userid, payload, mech_type=ffi.NULL, flags=0):
-        if isinstance(payload, six.text_type):
+        if isinstance(payload, str):
             payload = payload.encode("utf-8", errors="surrogateescape")
-        elif not isinstance(payload, six.binary_type):
+        elif not isinstance(payload, bytes):
             errstr = "payload must be a text or binary type, not {}"
             raise TypeError(errstr.format(type(payload)))
         return self.pimpl.wrap_as(userid, payload, len(payload), mech_type, flags)
 
     def sign_wrap(self, payload, mech_type=ffi.NULL, flags=0):
-        if isinstance(payload, six.text_type):
+        if isinstance(payload, str):
             payload = payload.encode("utf-8")
-        elif not isinstance(payload, six.binary_type):
+        elif not isinstance(payload, bytes):
             errstr = "payload must be a text or binary type, not {}"
             raise TypeError(errstr.format(type(payload)))
         return self.pimpl.wrap(payload, len(payload), mech_type, flags)
 
     def sign_unwrap(self, signed_payload, flags=0):
-        if not isinstance(signed_payload, six.binary_type):
+        if not isinstance(signed_payload, bytes):
             errstr = "signed_payload must be a binary type, not {}"
             raise TypeError(errstr.format(type(signed_payload)))
 

--- a/src/bindings/python/flux/util.py
+++ b/src/bindings/python/flux/util.py
@@ -22,8 +22,6 @@ import threading
 from datetime import timedelta
 from string import Formatter
 
-import six
-
 from flux.core.inner import ffi, raw
 
 __all__ = [
@@ -86,9 +84,9 @@ def interruptible(func):
 def encode_payload(payload):
     if payload is None or payload == ffi.NULL:
         payload = ffi.NULL
-    elif isinstance(payload, six.text_type):
+    elif isinstance(payload, str):
         payload = payload.encode("UTF-8")
-    elif not isinstance(payload, six.binary_type):
+    elif not isinstance(payload, bytes):
         payload = json.dumps(payload, ensure_ascii=False).encode("UTF-8")
     return payload
 
@@ -97,9 +95,9 @@ def encode_topic(topic):
     # Convert topic to utf-8 binary string
     if topic is None or topic == ffi.NULL:
         raise EnvironmentError(errno.EINVAL, "Topic must not be None/NULL")
-    if isinstance(topic, six.text_type):
+    if isinstance(topic, str):
         topic = topic.encode("UTF-8")
-    elif not isinstance(topic, six.binary_type):
+    elif not isinstance(topic, bytes):
         errmsg = "Topic must be a string, not {}".format(type(topic))
         raise TypeError(errno.EINVAL, errmsg)
     return topic

--- a/src/bindings/python/flux/wrapper.py
+++ b/src/bindings/python/flux/wrapper.py
@@ -20,8 +20,6 @@ import inspect
 from types import MethodType
 from typing import Dict, Any
 
-import six
-
 
 class MissingFunctionError(Exception):
     def __init__(self, name, c_name, name_list, arguments):
@@ -189,18 +187,15 @@ class FunctionWrapper(object):
             elif isinstance(args[i], WrapperBase):
                 # Unpack wrapper objects
                 args[i] = args[i].handle
-            elif isinstance(args[i], six.text_type):
+            elif isinstance(args[i], str):
                 args[i] = args[i].encode("utf-8", errors="surrogateescape")
 
         try:
             result = self.fun(*args)
         except TypeError as err:
-            six.raise_from(
-                InvalidArguments(
-                    self.name, self.ffi.getctype(self.function_type), args_in
-                ),
-                err,
-            )
+            raise InvalidArguments(
+                self.name, self.ffi.getctype(self.function_type), args_in
+            ) from err
 
         if result == calling_object.ffi.NULL:
             result = None

--- a/src/cmd/flux-jobspec.py
+++ b/src/cmd/flux-jobspec.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import re
 import os
 import sys

--- a/src/modules/job-ingest/validators/validate-jobspec.py
+++ b/src/modules/job-ingest/validators/validate-jobspec.py
@@ -8,8 +8,6 @@
 #  SPDX-License-Identifier: LGPL-3.0
 ##############################################################
 
-from __future__ import print_function
-
 import sys
 import json
 import argparse

--- a/src/modules/job-ingest/validators/validate-schema.py
+++ b/src/modules/job-ingest/validators/validate-schema.py
@@ -8,8 +8,6 @@
 #  SPDX-License-Identifier: LGPL-3.0
 ##############################################################
 
-from __future__ import print_function
-
 import sys
 import argparse
 import json

--- a/t/jobspec/summarize-minimal-jobspec.py
+++ b/t/jobspec/summarize-minimal-jobspec.py
@@ -1,7 +1,5 @@
 # Usage: flux python summarize-minimal-jobspec.py -j jobspec >summary.txt
 
-from __future__ import print_function
-
 import sys
 import json
 import argparse

--- a/t/python/sideflux.py
+++ b/t/python/sideflux.py
@@ -9,7 +9,6 @@
 # SPDX-License-Identifier: LGPL-3.0
 ###############################################################
 
-from __future__ import print_function
 import io
 import re
 import os
@@ -23,7 +22,7 @@ import pprint
 import shutil
 import tempfile
 import time
-from six.moves import queue as Queue
+import queue
 import pycotap
 
 # pprint.pprint(os.environ)
@@ -200,7 +199,7 @@ class SimpleAsyncRunner(object):
         if not self.done:
             try:
                 self.res = self.q.get(True, timeout)
-            except Queue.Empty:
+            except queue.Empty:
                 raise AsyncTimeout("The result is not ready, has a test run too long?")
             self.done = True
         return self.res

--- a/t/python/subflux.py
+++ b/t/python/subflux.py
@@ -10,8 +10,6 @@
 # SPDX-License-Identifier: LGPL-3.0
 ###############################################################
 
-from __future__ import print_function
-
 import os
 import sys
 import subprocess

--- a/t/python/t0001-handle.py
+++ b/t/python/t0001-handle.py
@@ -12,7 +12,6 @@
 
 import unittest
 import syslog
-import six
 
 import flux
 from subflux import rerun_under_flux, script_dir
@@ -43,7 +42,7 @@ class TestHandle(unittest.TestCase):
         r = self.f.rpc(b"broker.ping", {"seq": 1, "pad": "stuff"}).get()
         self.assertEqual(r["seq"], 1)
         self.assertEqual(r["pad"], u"stuff")
-        self.assertTrue(isinstance(r["pad"], six.text_type))
+        self.assertTrue(isinstance(r["pad"], str))
 
     def test_anonymous_handle_rpc_ping(self):
         """Send a ping using an anonymous/unnamed flux handle"""
@@ -59,7 +58,7 @@ class TestHandle(unittest.TestCase):
         ).get()
         self.assertEqual(r[u"\xa3"], u"value")
         self.assertEqual(r["key"], u"\u32db \u263a \u32e1")
-        self.assertTrue(isinstance(r["key"], six.text_type))
+        self.assertTrue(isinstance(r["key"], str))
 
     def test_rpc_with(self):
         """Sending a ping"""
@@ -82,7 +81,7 @@ class TestHandle(unittest.TestCase):
 
     def test_attr_get(self):
         local_uri = self.f.attr_get("local-uri")
-        self.assertTrue(isinstance(local_uri, six.text_type))
+        self.assertTrue(isinstance(local_uri, str))
         self.assertEqual(local_uri[:6], "local:")
 
         attr_rank = int(self.f.attr_get("rank"))

--- a/t/python/t0002-wrapper.py
+++ b/t/python/t0002-wrapper.py
@@ -12,7 +12,6 @@
 
 import unittest
 
-import six
 import flux
 from flux.core.inner import ffi, raw
 import flux.wrapper
@@ -45,8 +44,8 @@ class TestWrapper(unittest.TestCase):
         future = f.rpc("broker.ping", payload)
         resp = future.get()
         future.pimpl.handle = None
-        with six.assertRaisesRegex(
-            self, ValueError, r"Attempting to call a cached, bound method.*NULL handle"
+        with self.assertRaisesRegex(
+            ValueError, r"Attempting to call a cached, bound method.*NULL handle"
         ):
             resp = future.get()
 
@@ -54,7 +53,7 @@ class TestWrapper(unittest.TestCase):
         flux.core.inner.raw.flux_log(flux.Flux("loop://"), 0, "stuff")
 
     def test_masked_function(self):
-        with six.assertRaisesRegex(self, AttributeError, r".*masks function.*"):
+        with self.assertRaisesRegex(AttributeError, r".*masks function.*"):
             flux.Flux("loop://").rpc("topic").pimpl.flux_request_encode("request", 15)
 
     def test_set_pimpl_handle(self):
@@ -67,7 +66,7 @@ class TestWrapper(unittest.TestCase):
     def test_set_pimpl_handle_invalid(self):
         f = flux.Flux("loop://")
         r = f.rpc("topic")
-        with six.assertRaisesRegex(self, TypeError, r".*expected a.*"):
+        with self.assertRaisesRegex(TypeError, r".*expected a.*"):
             r.handle = f.rpc("other topic")
 
     def test_read_basic_value(self):
@@ -78,8 +77,7 @@ class TestWrapper(unittest.TestCase):
         infinite recursion as documented in
         https://github.com/flux-framework/flux-core/issues/2485
         """
-        with six.assertRaisesRegex(
-            self,
+        with self.assertRaisesRegex(
             TypeError,
             (
                 r"(.*takes at least.*arguments.*)"

--- a/t/python/t0003-barrier.py
+++ b/t/python/t0003-barrier.py
@@ -10,11 +10,8 @@
 # SPDX-License-Identifier: LGPL-3.0
 ###############################################################
 
-from __future__ import print_function
 import unittest
 import multiprocessing as mp
-
-from six.moves import range as range
 
 import flux
 from subflux import rerun_under_flux

--- a/t/python/t0004-event.py
+++ b/t/python/t0004-event.py
@@ -10,9 +10,7 @@
 # SPDX-License-Identifier: LGPL-3.0
 ###############################################################
 
-from __future__ import print_function
 import unittest
-import six
 
 import flux
 from subflux import rerun_under_flux
@@ -36,7 +34,7 @@ class TestEvent(unittest.TestCase):
         """Unsubscribe from an event"""
         self.assertGreaterEqual(self.f.event_subscribe("testevent.2"), 0)
         self.assertGreaterEqual(self.f.event_unsubscribe("testevent.2"), 0)
-        with self.assertRaisesRegexp(EnvironmentError, "No such file"):
+        with self.assertRaisesRegex(EnvironmentError, "No such file"):
             self.f.event_unsubscribe("nonexistent.event")
 
     def test_full_event(self):
@@ -48,7 +46,7 @@ class TestEvent(unittest.TestCase):
             evt = self.f.event_recv()
             self.assertIsNotNone(evt)
 
-            if isinstance(event_name, six.binary_type):
+            if isinstance(event_name, bytes):
                 self.assertEqual(evt.topic, event_name.decode("utf-8"))
             else:
                 self.assertEqual(evt.topic, event_name)

--- a/t/python/t0005-kvs.py
+++ b/t/python/t0005-kvs.py
@@ -10,9 +10,7 @@
 # SPDX-License-Identifier: LGPL-3.0
 ###############################################################
 
-from __future__ import print_function
 import unittest
-import six
 
 import flux
 import flux.kvs
@@ -39,7 +37,7 @@ class TestKVS(unittest.TestCase):
         kd.commit()
         nv = kd[key]
         self.assertEqual(value, nv)
-        self.assertFalse(isinstance(nv, six.binary_type))
+        self.assertFalse(isinstance(nv, bytes))
         return kd
 
     def test_set_int(self):
@@ -123,7 +121,7 @@ class TestKVS(unittest.TestCase):
             )
 
     def test_read_non_existent_basedir(self):
-        with self.assertRaisesRegexp(EnvironmentError, "No such file"):
+        with self.assertRaisesRegex(EnvironmentError, "No such file"):
             print(
                 flux.kvs.KVSDir(
                     self.f, "crazykeythatclearlydoesntexistandneverwillinanyuniverse"

--- a/t/python/t0009-security.py
+++ b/t/python/t0009-security.py
@@ -50,7 +50,7 @@ allowed-types = [ "none" ]
         self.assertEqual(wrapping_user, os.getuid())
 
     def test_01_security_error(self):
-        with self.assertRaisesRegexp(EnvironmentError, "sign-unwrap:.*"):
+        with self.assertRaisesRegex(EnvironmentError, "sign-unwrap:.*"):
             unwrapped_payload, wrapping_user = self.context.sign_unwrap(b"foo")
 
 

--- a/t/python/t0010-job.py
+++ b/t/python/t0010-job.py
@@ -346,6 +346,8 @@ class TestJob(unittest.TestCase):
             for path in ("foo.txt", "bar.md", "foo.json"):
                 setattr(jobspec, stream, path)
                 self.assertEqual(getattr(jobspec, stream), path)
+            with self.assertRaises(TypeError):
+                setattr(jobspec, stream, None)
 
     def test_22_from_batch_command(self):
         """Test that `from_batch_command` produces a valid jobspec"""

--- a/t/python/t0010-job.py
+++ b/t/python/t0010-job.py
@@ -18,10 +18,10 @@ import unittest
 import datetime
 import signal
 import locale
+import pathlib
 from glob import glob
 
 import yaml
-import six
 
 import flux
 import flux.kvs
@@ -140,10 +140,6 @@ class TestJob(unittest.TestCase):
                 jobspec.duration = duration
 
     def test_11_cwd_pathlib(self):
-        if six.PY2:
-            return
-        import pathlib
-
         jobspec_path = pathlib.PosixPath(self.jobspec_dir) / "valid" / "basic_v1.yaml"
         jobspec = Jobspec.from_yaml_file(jobspec_path)
         cwd = pathlib.PosixPath("/tmp")

--- a/t/python/t0012-futures.py
+++ b/t/python/t0012-futures.py
@@ -10,13 +10,10 @@
 # SPDX-License-Identifier: LGPL-3.0
 ###############################################################
 
-from __future__ import print_function
-
 import gc
 import errno
 import unittest
 
-import six.moves
 import flux
 import flux.constants
 from flux.core.inner import ffi
@@ -199,7 +196,7 @@ class TestHandle(unittest.TestCase):
             future.reset()
 
         def service_cb(fh, t, msg, arg):
-            for x in six.moves.range(msg.payload["count"]):
+            for x in range(msg.payload["count"]):
                 fh.respond(msg, {"seq": x})
 
         fut = self.f.service_register("rpctest")

--- a/t/python/t0013-job-list-inactive.py
+++ b/t/python/t0013-job-list-inactive.py
@@ -20,7 +20,6 @@ import time
 from glob import glob
 
 import yaml
-import six
 
 import flux
 from flux import job


### PR DESCRIPTION
Two pretty trivial changes. The first commit fixes a problem I introduced in #3019. When you set a jobspec's stdout/err property to ``None``, the job will hit an exception:

```
JobWaitResult(jobid=22162702336, success=False, errstr=b'Fatal exception type=exec shell_init: No such file or directory')
```

The error message actually confused me for a little while, and it's such an easy fix, that I think it's worth it.

(Edit: it's especially confusing because the properties default to ``None``, which works fine, but if you explicitly set them to ``None`` the job will fail.)

The second commit removes references to the ``six`` module. I noticed them while I was working on the first commit and so I just went ahead and replaced the ``six`` aliases with their Python 3 names.

I would be happy to squash these two commits down to one if you want, just let me know.