### PR TITLE
build/test: remove stale heartbeat references

### DIFF
--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -216,7 +216,6 @@ requeues
 RQ
 libev
 baz
-hb
 unsubscribe
 unsubscribes
 zeromq

--- a/src/broker/Makefile.am
+++ b/src/broker/Makefile.am
@@ -98,11 +98,6 @@ TEST_EXTENSIONS = .t
 T_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
        $(top_srcdir)/config/tap-driver.sh
 
-test_heartbeat_t_SOURCES = test/heartbeat.c
-test_heartbeat_t_CPPFLAGS = $(test_cppflags)
-test_heartbeat_t_LDADD = $(test_ldadd)
-test_heartbeat_t_LDFLAGS = $(test_ldflags)
-
 test_attr_t_SOURCES = test/attr.c
 test_attr_t_CPPFLAGS = $(test_cppflags)
 test_attr_t_LDADD = $(test_ldadd)


### PR DESCRIPTION
A couple of trivial items were missed in PR #3512. Without this fix, `./autogen.sh` complains:
```
autoreconf: running: automake --add-missing --copy --no-force
src/broker/Makefile.am:101: warning: variable 'test_heartbeat_t_SOURCES' is defined but no program or
src/broker/Makefile.am:101: library has 'test_heartbeat_t' as canonical name (possible typo)
src/broker/Makefile.am:103: warning: variable 'test_heartbeat_t_LDADD' is defined but no program or
src/broker/Makefile.am:103: library has 'test_heartbeat_t' as canonical name (possible typo)
src/broker/Makefile.am:104: warning: variable 'test_heartbeat_t_LDFLAGS' is defined but no program or
src/broker/Makefile.am:104: library has 'test_heartbeat_t' as canonical name (possible typo)
autoreconf: Leaving directory `.'
Now run ./configure.
```