### PR TITLE
broker: add support for PMIx bootstrap

### DIFF
--- a/config/x_ac_pmix.m4
+++ b/config/x_ac_pmix.m4
@@ -1,0 +1,10 @@
+# It is fatal if --enable-pmix-bootstrap and pmix package not found.
+# (PKG_CHECK_MODULES default behavior is to fail if package not found)
+AC_DEFUN([X_AC_PMIX], [
+    AC_ARG_ENABLE([pmix-bootstrap],
+        AS_HELP_STRING([--enable-pmix-bootstrap], [Enable PMIx bootstrap]))
+    AS_IF([test "x$enable_pmix_bootstrap" = "xyes"], [
+        PKG_CHECK_MODULES([PMIX], [pmix])
+        AC_DEFINE([HAVE_LIBPMIX], [1], [Enable PMIx bootstrap])
+    ])
+])

--- a/configure.ac
+++ b/configure.ac
@@ -385,6 +385,8 @@ AS_IF([test "x$enable_content_s3" = "xyes"], [
 
 AM_CONDITIONAL([ENABLE_CONTENT_S3], [test "x$enable_content_s3" = "xyes"])
 
+X_AC_PMIX
+
 ##
 # Check for systemd
 ##

--- a/src/broker/Makefile.am
+++ b/src/broker/Makefile.am
@@ -8,6 +8,7 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
 	-I$(top_builddir)/src/common/libflux \
+	$(PMIX_CFLAGS) \
 	$(ZMQ_CFLAGS) \
 	$(LIBUUID_CFLAGS) \
 	$(VALGRIND_CFLAGS)
@@ -64,7 +65,8 @@ flux_broker_LDADD = \
 	$(builddir)/libbroker.la \
 	$(top_builddir)/src/common/libflux-core.la \
 	$(top_builddir)/src/common/libpmi/libpmi_client.la \
-	$(top_builddir)/src/common/libflux-internal.la
+	$(top_builddir)/src/common/libflux-internal.la \
+	$(PMIX_LIBS)
 
 flux_broker_LDFLAGS =
 
@@ -82,7 +84,8 @@ test_ldadd = \
 	$(top_builddir)/src/common/libflux-core.la \
 	$(top_builddir)/src/common/libpmi/libpmi_client.la \
 	$(top_builddir)/src/common/libflux-internal.la \
-	$(top_builddir)/src/common/libtap/libtap.la
+	$(top_builddir)/src/common/libtap/libtap.la \
+	$(PMIX_LIBS)
 
 test_ldflags = \
 	-no-install

--- a/src/broker/boot_pmi.c
+++ b/src/broker/boot_pmi.c
@@ -50,7 +50,8 @@ static int set_instance_level_attr (struct pmi_handle *pmi,
                                  kvsname,
                                  "flux.instance-level",
                                  val,
-                                 sizeof (val));
+                                 sizeof (val),
+                                 -1);
     if (result == PMI_SUCCESS)
         level = val;
     if (attr_add (attrs, "instance-level", level, FLUX_ATTRFLAG_IMMUTABLE) < 0)
@@ -75,7 +76,8 @@ static int set_broker_mapping_attr (struct pmi_handle *pmi,
                             kvsname,
                             "PMI_process_mapping",
                             buf,
-                            sizeof (buf)) == PMI_SUCCESS)
+                            sizeof (buf),
+                            -1) == PMI_SUCCESS)
         val = buf;
     if (attr_add (attrs, "broker.mapping", val, FLUX_ATTRFLAG_IMMUTABLE) < 0)
         return -1;
@@ -256,7 +258,7 @@ int boot_pmi (struct overlay *overlay, attr_t *attrs, int tbon_k)
             goto error;
         }
         result = broker_pmi_kvs_get (pmi, pmi_params.kvsname,
-                                     key, val, sizeof (val));
+                                     key, val, sizeof (val), rank);
         if (result != PMI_SUCCESS) {
             log_msg ("broker_pmi_kvs_get %s: %s", key, pmi_strerror (result));
             goto error;
@@ -290,7 +292,7 @@ int boot_pmi (struct overlay *overlay, attr_t *attrs, int tbon_k)
             goto error;
         }
         result = broker_pmi_kvs_get (pmi, pmi_params.kvsname,
-                                     key, val, sizeof (val));
+                                     key, val, sizeof (val), rank);
 
         if (result != PMI_SUCCESS) {
             log_msg ("broker_pmi_kvs_get %s: %s", key, pmi_strerror (result));

--- a/src/broker/pmiutil.h
+++ b/src/broker/pmiutil.h
@@ -30,7 +30,8 @@ int broker_pmi_kvs_get (struct pmi_handle *pmi,
                         const char *kvsname,
                         const char *key,
                         char *value,
-                        int len);
+                        int len,
+                        int from_rank); // -1 for undefined
 
 int broker_pmi_barrier (struct pmi_handle *pmi);
 

--- a/src/broker/runat.c
+++ b/src/broker/runat.c
@@ -65,6 +65,24 @@ static const char *env_blocklist[] = {
     "PMI_FD",
     "PMI_RANK",
     "PMI_SIZE",
+#ifdef HAVE_LIBPMIX
+    "PMIX_NAMESPACE",
+    "PMIX_VERSION",
+    "PMIX_SERVER_URI41",
+    "PMIX_RANK",
+    "PMIX_SERVER_URI21",
+    "PMIX_GDS_MODULE",
+    "PMIX_SECURITY_MODE",
+    "PMIX_HOSTNAME",
+    "PMIX_BFROP_BUFFER_TYPE",
+    "PMIX_SERVER_TMPDIR",
+    "PMIX_SYSTEM_TMPDIR",
+    "PMIX_SERVER_URI4",
+    "PMIX_MCA_psec",
+    "PMIX_SERVER_URI3",
+    "PMIX_SERVER_URI2",
+    "PMIX_SERVER_URI",
+#endif
     NULL,
 };
 

--- a/src/broker/test/pmiutil.c
+++ b/src/broker/test/pmiutil.c
@@ -66,7 +66,8 @@ int main (int argc, char **argv)
     ok (result == PMI_SUCCESS,
         "broker_pmi_barrier works");
 
-    result = broker_pmi_kvs_get (pmi, params.kvsname, "foo", val, sizeof (val));
+    result = broker_pmi_kvs_get (pmi, params.kvsname, "foo", val, sizeof (val),
+                                 -1);
     ok (result != PMI_SUCCESS,
         "broker_pmi_kvs_get fails since singleton doesn't implement kvs");
     // at least while we can get away without it!

--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -13,7 +13,8 @@ AM_CPPFLAGS = \
 	$(ZMQ_CFLAGS) \
 	$(LIBUUID_CFLAGS) \
 	$(LIBSODIUM_CFLAGS) \
-	$(HWLOC_CFLAGS)
+	$(HWLOC_CFLAGS) \
+	$(PMIX_CFLAGS)
 
 fluxcmd_ldadd = \
 	$(top_builddir)/src/common/libkvs/libkvs.la \

--- a/src/cmd/builtin/version.c
+++ b/src/cmd/builtin/version.c
@@ -8,8 +8,13 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#if HAVE_CONFIG_H
+# include <config.h>
+#endif
+#if HAVE_LIBPMIX
+# include <pmix.h>
+#endif
 #include <hwloc.h>
-#include <config.h>
 
 #include "builtin.h"
 #if HAVE_FLUX_SECURITY_VERSION_H
@@ -57,6 +62,12 @@ static int cmd_version (optparse_t *p, int ac, char *av[])
 #endif
 #if HAVE_CALIPER
     printf ("+caliper");
+#endif
+#if HAVE_LIBPMIX
+    printf ("+pmix-bootstrap==%ld.%ld.%ld",
+            PMIX_VERSION_MAJOR,
+            PMIX_VERSION_MINOR,
+            PMIX_VERSION_RELEASE);
 #endif
     printf ("+hwloc==%d.%d.%d",
             HWLOC_API_VERSION >> 16 & 0x000000ff,

--- a/src/test/docker/bionic/Dockerfile
+++ b/src/test/docker/bionic/Dockerfile
@@ -16,6 +16,8 @@ RUN apt-get update \
         wget \
         man \
         git \
+        flex \
+        ssh \
         sudo \
         vim \
         luarocks \
@@ -82,6 +84,7 @@ RUN apt-get update \
         libhwloc-dev \
         libmpich-dev \
         libs3-dev \
+        libevent-dev \
  && rm -rf /var/lib/apt/lists/*
 
 # Testing utils and libs
@@ -112,5 +115,25 @@ RUN mkdir caliper \
  && make install \
  && cd ../.. \
  && rm -rf caliper
+
+# Install openpmix, prrte
+RUN mkdir prrte \
+ && cd prrte \
+ && git clone https://github.com/openpmix/openpmix.git \
+ && git clone https://github.com/openpmix/prrte.git \
+ && ls -l \
+ && set -x \
+ && cd openpmix \
+ && git checkout fefaed568f33bf86f28afb6e45237f1ec5e4de93 \
+ && ./autogen.pl \
+ && ./configure --prefix=/usr --disable-static && make -j 4 install \
+ && ldconfig \
+ && cd .. \
+ && cd prrte \
+ && git checkout 477894f4720d822b15cab56eee7665107832921c \
+ && ./autogen.pl \
+ && ./configure --prefix=/usr && make -j 4 install \
+ && cd ../.. \
+ && rm -rf prrte
 
 ENV LANG=C.UTF-8

--- a/src/test/generate-matrix.py
+++ b/src/test/generate-matrix.py
@@ -151,7 +151,7 @@ matrix.add_build(
         CXX="g++8",
         DISTCHECK="t",
     ),
-    args="--with-flux-security --enable-caliper",
+    args="--with-flux-security --enable-caliper --enable-pmix-bootstrap",
     test_s3=True,
 )
 
@@ -169,7 +169,7 @@ matrix.add_build(
 )
 
 # Ubuntu: coverage
-matrix.add_build(name="coverage", coverage=True, jobs=2)
+matrix.add_build(name="coverage", coverage=True, jobs=2, args="--enable-pmix-bootstrap")
 
 # Ubuntu: TEST_INSTALL
 matrix.add_build(

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -98,6 +98,7 @@ TESTSCRIPTS = \
 	t2006-hwloc-versions.t \
 	t2007-caliper.t \
 	t2008-althash.t \
+	t2009-pmix-bootstrap.t \
 	t2010-kvs-snapshot-restore.t \
 	t2100-job-ingest.t \
 	t2110-job-ingest-validator.t \

--- a/t/t2009-pmix-bootstrap.t
+++ b/t/t2009-pmix-bootstrap.t
@@ -1,0 +1,56 @@
+#!/bin/sh
+#
+
+test_description='Test that Flux can be lauched by PMIx-enabled launcher'
+
+# Append --logfile option if FLUX_TESTS_LOGFILE is set in environment:
+test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
+. `dirname $0`/sharness.sh
+
+ARGS="-o,-Sbroker.rc1_path=,-Sbroker.rc3_path="
+
+# prterun (any version) works
+find_prterun() {
+	local path
+
+	path=$(which prterun) 2>/dev/null || return 1
+	version=$($path -V | head -1 | awk '{print $NF;}')
+	echo "found $path version $version" >&2
+	echo $path
+}
+
+# Use convenient sort(1) option to determine if semantic version $1 >= $2
+version_gte() {
+	test "$( (echo $1; echo $2) | sort --version-sort | tail -1)" = $1
+}
+
+# mpirun.openmpi >= 4.0.3 works
+find_mpirun() {
+	local path
+	local version
+
+	path=$(which mpirun.openmpi 2>/dev/null) || return 1
+	version=$($path -V | head -1 | awk '{print $NF;}')
+	version_gte $version 4.0.3 || return 1
+	echo "found $path version $version" >&2
+	echo $path
+}
+
+if ! flux version | grep -q +pmix-bootstrap; then
+	skip_all='skipping: not configured wtih --enable-pmix-bootstrap'
+	test_done
+fi
+
+if ! prterun=$(find_prterun) && ! prterun=$(find_mpirun); then
+	skip_all='skipping: could not find pmix-enabled launcher'
+	test_done
+fi
+
+test_expect_success 'prterun can launch Flux' '
+	echo 4 >size.exp &&
+	FLUX_PMI_DEBUG=1 $prterun --map-by :OVERSUBSCRIBE --n 4 \
+		flux start ${ARGS} flux getattr size >size.out &&
+	test_cmp size.exp size.out
+'
+
+test_done


### PR DESCRIPTION
PMIx support for bootstrapping flux is added by running
configure --with-pmix[=PATH]
When specified, PATH must contain the pmix.h header file.

PMIx is used at bootstrap by running
flux start --bootstrap=pmix

Limitations:
  - configure does *not* check PATH contains the pmix.h header file
  - libpmix.so currently has to be in the LD_LIBRARY_PATH