### PR TITLE
enhance testsuite reliability on RHEL8/TOSS4

### DIFF
--- a/t/t2601-job-shell-standalone.t
+++ b/t/t2601-job-shell-standalone.t
@@ -5,7 +5,7 @@ test_description='Test flux-shell in --standalone mode'
 . `dirname $0`/sharness.sh
 
 #  Run flux-shell under flux command to get correct paths
-FLUX_SHELL="run_timeout 30 flux ${FLUX_BUILD_DIR}/src/shell/flux-shell"
+FLUX_SHELL="run_timeout 60 flux ${FLUX_BUILD_DIR}/src/shell/flux-shell"
 
 PMI_INFO=${FLUX_BUILD_DIR}/src/common/libpmi/test_pmi_info
 KVSTEST=${FLUX_BUILD_DIR}/src/common/libpmi/test_kvstest

--- a/t/t2611-debug-emulate.t
+++ b/t/t2611-debug-emulate.t
@@ -13,6 +13,8 @@ stop_tasks_test()     {
 
 test_under_flux 2
 
+TIMEOUT=10
+
 parse_jobid() {
         outfile=$1 &&
         jobid=$(cat ${outfile} | grep ^jobid: | awk '{ print $2 }') &&
@@ -30,79 +32,79 @@ test_expect_success 'debugger: launching under debugger via flux-mini works' '
         flux mini run -v --debug-emulate -N 2 -n 2 sleep 0 2> jobid.out &&
         jobid=$(parse_jobid jobid.out) &&
         echo ${jobid} > jobid &&
-        flux job wait-event -vt 2.5 ${jobid} finish
+        flux job wait-event -vt ${TIMEOUT} ${jobid} finish
 '
 
 test_expect_success 'debugger: submitting under debugger via flux-mini works' '
         jobid=$(flux mini submit -N 2 -n 2 -o stop-tasks-in-exec hostname) &&
-        flux job wait-event -vt 2.5  ${jobid} start &&
+        flux job wait-event -vt ${TIMEOUT}  ${jobid} start &&
         flux job attach --debug-emulate ${jobid} &&
-        flux job wait-event -vt 2.5  ${jobid} finish
+        flux job wait-event -vt ${TIMEOUT}  ${jobid} finish
 '
 
 test_expect_success HAVE_JQ 'debugger: submitting under debugger via flux-job works' '
         flux jobspec srun -N2 -n 2 hostname | stop_tasks_test > stop_tasks.json &&
         jobid=$(flux job submit stop_tasks.json) &&
-        flux job wait-event -vt 2.5  ${jobid} start &&
+        flux job wait-event -vt ${TIMEOUT}  ${jobid} start &&
         flux job attach --debug-emulate ${jobid} &&
-        flux job wait-event -vt 2.5  ${jobid} finish
+        flux job wait-event -vt ${TIMEOUT}  ${jobid} finish
 '
 
 test_expect_success 'debugger: SIGCONT can unlock a job in stop-tasks-in-exec' '
         jobid=$(flux mini submit -N 2 -n 2 -o stop-tasks-in-exec hostname) &&
-        flux job wait-event -vt 2.5  ${jobid} start &&
+        flux job wait-event -vt ${TIMEOUT}  ${jobid} start &&
         flux job kill --signal=SIGCONT ${jobid} &&
-        flux job wait-event -vt 2.5  ${jobid} finish
+        flux job wait-event -vt ${TIMEOUT}  ${jobid} finish
 '
 
 test_expect_success 'debugger: attaching to a running job works' '
         jobid=$(flux jobspec srun -n 1 ${stall} done 10 | flux job submit) &&
-        flux job wait-event -vt 2.5 ${jobid} start &&
-        ${waitfile} -v -t 2.5 done &&
+        flux job wait-event -vt ${TIMEOUT} ${jobid} start &&
+        ${waitfile} -v -t ${TIMEOUT} done &&
         flux job attach -v --debug-emulate ${jobid} &&
-        flux job wait-event -vt 2.5 ${jobid} finish
+        flux job wait-event -vt ${TIMEOUT} ${jobid} finish
 '
 
 test_expect_success 'debugger: attaching to a finished job must fail' '
         jobid=$(flux jobspec srun -n 2 hostname | flux job submit) &&
-        flux job wait-event -vt 2.5 ${jobid} finish &&
+        flux job wait-event -vt ${TIMEOUT} ${jobid} finish &&
         test_must_fail flux job attach --debug-emulate ${jobid}
 '
 
 test_expect_success 'debug-emulate: attaching to a failed job must fail' '
         jobid=$(flux jobspec srun -n 2 ./bad_cmd | flux job submit) &&
-        flux job wait-event -vt 2.5 ${jobid} finish &&
+        flux job wait-event -vt ${TIMEOUT} ${jobid} finish &&
         test_must_fail flux job attach --debug-emulate ${jobid}
 '
 
 test_expect_success 'debugger: totalview_jobid is set for attach mode' '
         jobid=$(flux jobspec srun -n 1 ${stall} done2 10 | flux job submit) &&
         jobid=$(flux job id ${jobid}) &&
-        flux job wait-event -vt 2.5 ${jobid} start &&
-        ${waitfile} -v -t 2.5 done2 &&
+        flux job wait-event -vt ${TIMEOUT} ${jobid} start &&
+        ${waitfile} -v -t ${TIMEOUT} done2 &&
         flux job attach -vv --debug-emulate ${jobid} 2> jobid.out2 &&
-        flux job wait-event -vt 2.5 ${jobid} finish &&
+        flux job wait-event -vt ${TIMEOUT} ${jobid} finish &&
         tv_jobid=$(parse_totalview_jobid jobid.out2) &&
         test ${tv_jobid} = "${jobid}"
 '
 
 flux_job_attach() {
         flux job attach -vv --debug ${1} 2> ${2} &
-        ${waitfile} -v -t 2.5 --pattern="totalview_jobid" ${2}
+        ${waitfile} -v -t ${TIMEOUT} --pattern="totalview_jobid" ${2}
 }
 
 # flux job attach --debug JOBID must not continue target processes
 test_expect_success 'debugger: job attach --debug must not continue target' '
         jobid=$(flux jobspec srun -n 1 ${stall} done3 100 | flux job submit) &&
         jobid=$(flux job id ${jobid}) &&
-        flux job wait-event -vt 2.5 ${jobid} start &&
-        ${waitfile} -v -t 2.5 done3 &&
+        flux job wait-event -vt ${TIMEOUT} ${jobid} start &&
+        ${waitfile} -v -t ${TIMEOUT} done3 &&
         flux_job_attach ${jobid} jobid.out3 &&
         tv_jobid=$(parse_totalview_jobid jobid.out3) &&
         test ${tv_jobid} = "${jobid}" &&
-        test_must_fail flux job wait-event -vt 2.5 ${jobid} finish &&
+        test_must_fail flux job wait-event -vt ${TIMEOUT} ${jobid} finish &&
         flux job cancel ${jobid} &&
-        flux job wait-event -vt 2.5 ${jobid} finish
+        flux job wait-event -vt ${TIMEOUT} ${jobid} finish
 '
 
 test_done

--- a/t/t4000-issues-test-driver.t
+++ b/t/t4000-issues-test-driver.t
@@ -17,7 +17,7 @@ echo "# $0: flux session size will be ${SIZE}"
 for testscript in ${FLUX_SOURCE_DIR}/t/issues/*; do
     testname=`basename $testscript`
     prereqs=$(sed -n 's/^.*test-prereqs: \(.*\).*$/\1/gp' $testscript)
-    test_expect_success  "$prereqs" $testname "run_timeout 30 $testscript"
+    test_expect_success  "$prereqs" $testname "run_timeout 120 $testscript"
 done
 
 test_done

--- a/t/valgrind/valgrind.supp
+++ b/t/valgrind/valgrind.supp
@@ -77,3 +77,14 @@
    fun:_dl_open
    ...
 }
+{
+   <issue_3522>
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   obj:/usr/lib64/libhwloc.so.15.4.0
+   obj:/usr/lib64/libhwloc.so.15.4.0
+   obj:/usr/lib64/libhwloc.so.15.4.0
+   fun:hwloc_topology_load
+   ...
+}


### PR DESCRIPTION
This PR extends some testsuite timeouts and adds the known libhwloc leak discovered by @chu11 to valgrind suppressions in order to make the testsuite reliably pass on TOSS4 systems. The timeout increases are required because there is some uncharacterized performance degradation affecting Flux on these systems.

On this branch `make -j 16 check` reliably passes on fluke, where without it that command fails every time.

Fixes #3522