### PR TITLE
github: add a stale issues and PR bot for flux-core

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,59 @@
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+daysUntilStale: 365
+daysUntilClose: 14
+
+# Only these labels will be considered stale. Set to `[]` to disable:
+onlyLabels: []
+
+# Issues or Pull Requests with these labels will never be considered
+#  stale. Set to `[]` to disable
+#
+exemptLabels:
+  - pinned
+  - security
+  - design
+  - confirmed
+
+# Set to true to ignore issues in a project (defaults to false)
+exemptProjects: false
+
+# Set to true to ignore issues in a milestone (defaults to false)
+exemptMilestones: true
+
+# Set to true to ignore issues with an assignee (defaults to false)
+exemptAssignees: false
+
+# Label to use when marking as stale
+staleLabel: wontfix
+
+# Comment to post when marking as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  activity for 365 days. It will be closed if no further activity occurs
+  within 14 days.  Thank you for your contributions.
+
+# Comment to post when removing the stale label.
+# unmarkComment: >
+#   Your comment here.
+
+# Comment to post when closing a stale Issue or Pull Request.
+# closeComment: >
+#   Your comment here.
+
+# Limit the number of actions per hour, from 1-30. Default is 30
+limitPerRun: 2
+
+# Limit to only `issues` or `pulls`
+# only: issues
+
+# Optionally, specify configuration settings that are specific to just 'issues' or 'pulls':
+# pulls:
+#   daysUntilStale: 30
+#   markComment: >
+#     This pull request has been automatically marked as stale because it has not had
+#     recent activity. It will be closed if no further activity occurs. Thank you
+#     for your contributions.
+
+# issues:
+#   exemptLabels:
+#     - confirmed


### PR DESCRIPTION
This PR adds configuration for [probot/stale](https://probot.github.io/apps/stale/) which will start commenting on stale issues (currently configured for 84 days of inactivity) and PRs. The bot will autoclose issues and PRs if there isn't activity within 7 days of the issue being marked stale (using the `wontfix` label).

The bot is configured to only perform 2 actions (per hour I think?) so that we don't get inundated with comments. Over a couple weeks or so, the bot should help us clean up a lot of stale issues.  