### PR TITLE
broker: refactor overlay network send/receive interfaces

### DIFF
--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -87,10 +87,10 @@ struct overlay {
 
     struct endpoint *child;     /* ROUTER - requests from children */
 
-    overlay_monitor_cb_f child_monitor_cb;
+    overlay_monitor_f child_monitor_cb;
     void *child_monitor_arg;
 
-    overlay_init_cb_f init_cb;
+    overlay_init_f init_cb;
     void *init_arg;
 };
 
@@ -138,7 +138,7 @@ error:
 }
 
 void overlay_set_init_callback (struct overlay *ov,
-                                overlay_init_cb_f cb,
+                                overlay_init_f cb,
                                 void *arg)
 {
     ov->init_cb = cb;
@@ -834,7 +834,7 @@ int overlay_register_attrs (struct overlay *overlay, attr_t *attrs)
 }
 
 void overlay_set_monitor_cb (struct overlay *ov,
-                             overlay_monitor_cb_f cb,
+                             overlay_monitor_f cb,
                              void *arg)
 {
     ov->child_monitor_cb = cb;

--- a/src/broker/overlay.h
+++ b/src/broker/overlay.h
@@ -13,18 +13,21 @@
 
 #include "attr.h"
 
-enum {
-    KEEPALIVE_STATUS_NORMAL = 0,
-    KEEPALIVE_STATUS_DISCONNECT = 1,
-};
+typedef enum {
+    OVERLAY_ANY = 0,
+    OVERLAY_UPSTREAM,
+    OVERLAY_DOWNSTREAM,
+} overlay_where_t;
 
 struct overlay;
 
-typedef void (*overlay_sock_cb_f)(struct overlay *ov, void *arg);
 typedef int (*overlay_init_cb_f)(struct overlay *ov, void *arg);
 typedef void (*overlay_monitor_cb_f)(struct overlay *ov, void *arg);
+typedef void (*overlay_recv_f)(const flux_msg_t *msg,
+                               overlay_where_t from,
+                               void *arg);
 
-struct overlay *overlay_create (flux_t *h);
+struct overlay *overlay_create (flux_t *h, overlay_recv_f cb, void *arg);
 void overlay_destroy (struct overlay *ov);
 
 /* Set a callback triggered during overlay_init()
@@ -62,30 +65,19 @@ int overlay_get_child_peer_count (struct overlay *ov);
 int overlay_set_parent_uri (struct overlay *ov, const char *uri);
 int overlay_set_parent_pubkey (struct overlay *ov, const char *pubkey);
 const char *overlay_get_parent_uri (struct overlay *ov);
-void overlay_set_parent_cb (struct overlay *ov,
-                            overlay_sock_cb_f cb,
-                            void *arg);
 int overlay_sendmsg_parent (struct overlay *ov, const flux_msg_t *msg);
-flux_msg_t *overlay_recvmsg_parent (struct overlay *ov);
 
 /* The child is where other ranks connect to send requests.
  * This is the ROUTER side of parent sockets described above.
  */
 int overlay_bind (struct overlay *ov, const char *uri);
 const char *overlay_get_bind_uri (struct overlay *ov);
-void overlay_set_child_cb (struct overlay *ov, overlay_sock_cb_f cb, void *arg);
 int overlay_sendmsg_child (struct overlay *ov, const flux_msg_t *msg);
-flux_msg_t *overlay_recvmsg_child (struct overlay *ov);
 
 /* We can "multicast" events to all child peers using mcast_child().
  * It walks the 'children' hash, finding peers and routeing them a copy of msg.
  */
 void overlay_mcast_child (struct overlay *ov, const flux_msg_t *msg);
-
-/* Call when message is received from child 'uuid'.
- * If message was a keepalive, update 'status', otherwise set to zero.
- */
-void overlay_keepalive_child (struct overlay *ov, const char *uuid, int status);
 
 /* Register callback that will be called each time a child connects/disconnects.
  * Use overlay_get_child_peer_count() to access the actual count.

--- a/src/broker/overlay.h
+++ b/src/broker/overlay.h
@@ -43,6 +43,11 @@ int overlay_init (struct overlay *ov,
                   uint32_t rank,
                   int tbon_k);
 
+/* Send a message on the overlay network.
+ */
+int overlay_sendmsg (struct overlay *ov,
+                     const flux_msg_t *msg,
+                     overlay_where_t where);
 
 /* CURVE key management
  * If downstream peers, call overlay_authorize() with public key of each peer.
@@ -65,19 +70,12 @@ int overlay_get_child_peer_count (struct overlay *ov);
 int overlay_set_parent_uri (struct overlay *ov, const char *uri);
 int overlay_set_parent_pubkey (struct overlay *ov, const char *pubkey);
 const char *overlay_get_parent_uri (struct overlay *ov);
-int overlay_sendmsg_parent (struct overlay *ov, const flux_msg_t *msg);
 
 /* The child is where other ranks connect to send requests.
  * This is the ROUTER side of parent sockets described above.
  */
 int overlay_bind (struct overlay *ov, const char *uri);
 const char *overlay_get_bind_uri (struct overlay *ov);
-int overlay_sendmsg_child (struct overlay *ov, const flux_msg_t *msg);
-
-/* We can "multicast" events to all child peers using mcast_child().
- * It walks the 'children' hash, finding peers and routeing them a copy of msg.
- */
-void overlay_mcast_child (struct overlay *ov, const flux_msg_t *msg);
 
 /* Register callback that will be called each time a child connects/disconnects.
  * Use overlay_get_child_peer_count() to access the actual count.

--- a/src/broker/overlay.h
+++ b/src/broker/overlay.h
@@ -21,8 +21,8 @@ typedef enum {
 
 struct overlay;
 
-typedef int (*overlay_init_cb_f)(struct overlay *ov, void *arg);
-typedef void (*overlay_monitor_cb_f)(struct overlay *ov, void *arg);
+typedef int (*overlay_init_f)(struct overlay *ov, void *arg);
+typedef void (*overlay_monitor_f)(struct overlay *ov, void *arg);
 typedef void (*overlay_recv_f)(const flux_msg_t *msg,
                                overlay_where_t from,
                                void *arg);
@@ -33,7 +33,7 @@ void overlay_destroy (struct overlay *ov);
 /* Set a callback triggered during overlay_init()
  */
 void overlay_set_init_callback (struct overlay *ov,
-                                overlay_init_cb_f cb,
+                                overlay_init_f cb,
                                 void *arg);
 
 /* Call before connect/bind.
@@ -81,7 +81,7 @@ const char *overlay_get_bind_uri (struct overlay *ov);
  * Use overlay_get_child_peer_count() to access the actual count.
  */
 void overlay_set_monitor_cb (struct overlay *ov,
-                             overlay_monitor_cb_f cb,
+                             overlay_monitor_f cb,
                              void *arg);
 
 /* Establish communication with parent.


### PR DESCRIPTION
This PR moves some code for manipulating message routes and zeromq sockets into overlay.c, to reduce the complexity of broker.c a little.  Two overlay receive callbacks become one, and three overlay send functions become one.  It's just cleanup.  There should be no functional changes here.

The overlay unit test is bolstered with some new tests, although I imagine this area of code is pretty well covered by sharness tests anyway.