### PR TITLE
job-info: support LRU cache mapping job id -> owner

### DIFF
--- a/src/modules/job-info/Makefile.am
+++ b/src/modules/job-info/Makefile.am
@@ -14,8 +14,8 @@ AM_CPPFLAGS = \
 fluxmod_LTLIBRARIES = job-info.la
 
 job_info_la_SOURCES = \
+	job-info.h \
 	job-info.c \
-	info.h \
 	allow.h \
 	allow.c \
 	lookup.h \

--- a/src/modules/job-info/allow.c
+++ b/src/modules/job-info/allow.c
@@ -16,7 +16,7 @@
 #include <jansson.h>
 #include <flux/core.h>
 
-#include "info.h"
+#include "job-info.h"
 #include "allow.h"
 
 #include "src/common/libeventlog/eventlog.h"

--- a/src/modules/job-info/allow.c
+++ b/src/modules/job-info/allow.c
@@ -62,11 +62,31 @@ error:
     return rv;
 }
 
+static void store_lru (struct info_ctx *ctx, flux_jobid_t id, uint32_t userid)
+{
+    char key[64];
+    uint32_t *userid_ptr = NULL;
+
+    snprintf (key, 64, "%ju", (uintmax_t)id);
+
+    if (!(userid_ptr = calloc (1, sizeof (userid))))
+        return;
+    (*userid_ptr) = userid;
+
+    if (lru_cache_put (ctx->owner_lru, key, userid_ptr) < 0) {
+        if (errno != EEXIST)
+            flux_log_error (ctx->h, "%s: lru_cache_put", __FUNCTION__);
+        free (userid_ptr);
+        return;
+    }
+    return;
+}
+
 /* Optimization:
  * Avoid calling eventlog_get_userid() if message cred has OWNER role.
  */
 int eventlog_allow (struct info_ctx *ctx, const flux_msg_t *msg,
-                    const char *s)
+                    flux_jobid_t id, const char *s)
 {
     struct flux_msg_cred cred;
 
@@ -76,8 +96,26 @@ int eventlog_allow (struct info_ctx *ctx, const flux_msg_t *msg,
         uint32_t userid;
         if (eventlog_get_userid (ctx, s, &userid) < 0)
             return -1;
+        store_lru (ctx, id, userid);
         if (flux_msg_cred_authorize (cred, userid) < 0)
             return -1;
+    }
+    return 0;
+}
+
+int eventlog_allow_lru (struct info_ctx *ctx,
+                        const flux_msg_t *msg,
+                        flux_jobid_t id)
+{
+    char key[64];
+    uint32_t *userid_ptr;
+
+    snprintf (key, 64, "%ju", (uintmax_t)id);
+
+    if ((userid_ptr = lru_cache_get (ctx->owner_lru, key))) {
+        if (flux_msg_authorize (msg, (*userid_ptr)) < 0)
+            return -1;
+        return 1;
     }
     return 0;
 }

--- a/src/modules/job-info/allow.h
+++ b/src/modules/job-info/allow.h
@@ -17,10 +17,21 @@
 
 /* Determine if user who sent request 'msg' is allowed to
  * access job eventlog 's'.  Assume first event is the "submit"
- * event which records the job owner.
+ * event which records the job owner.  Will cache recently looked
+ * up job owners in an LRU cache.
  */
 int eventlog_allow (struct info_ctx *ctx, const flux_msg_t *msg,
-                    const char *s);
+                    flux_jobid_t id, const char *s);
+
+/* Determine if user who sent request 'msg' is allowed to access job
+ * eventlog via LRU cache.  Returns 1 if access allowed, 0 if
+ * indeterminate, -1 on error (including EPERM if access not allowed).
+ * If 0 returned, typically that means the eventlog needs to be looked
+ * up and then eventlog_allow() has to be called.
+ */
+int eventlog_allow_lru (struct info_ctx *ctx,
+                        const flux_msg_t *msg,
+                        flux_jobid_t id);
 
 #endif /* ! _FLUX_JOB_INFO_ALLOW_H */
 

--- a/src/modules/job-info/allow.h
+++ b/src/modules/job-info/allow.h
@@ -13,7 +13,7 @@
 
 #include <flux/core.h>
 
-#include "info.h"
+#include "job-info.h"
 
 /* Determine if user who sent request 'msg' is allowed to
  * access job eventlog 's'.  Assume first event is the "submit"

--- a/src/modules/job-info/guest_watch.c
+++ b/src/modules/job-info/guest_watch.c
@@ -369,6 +369,12 @@ static void get_main_eventlog_continuation (flux_future_t *f, void *arg)
         goto done;
     }
 
+    /* N.B. Check for whether requester should be allowed to read this
+     * eventlog could be done here (eventlog_allow ()), however since
+     * it will be done in the primary watch code anyways, we let the
+     * check fallthrough to be done there.
+     */
+
     if (check_guest_namespace_status (gw, s) < 0)
         goto error;
 

--- a/src/modules/job-info/guest_watch.c
+++ b/src/modules/job-info/guest_watch.c
@@ -22,7 +22,7 @@
 #include "src/common/libjob/job.h"
 #include "src/common/libeventlog/eventlog.h"
 
-#include "info.h"
+#include "job-info.h"
 #include "watch.h"
 
 /* This code (entrypoint guest_watch()) handles all

--- a/src/modules/job-info/guest_watch.h
+++ b/src/modules/job-info/guest_watch.h
@@ -13,7 +13,7 @@
 
 #include <flux/core.h>
 
-#include "info.h"
+#include "job-info.h"
 
 int guest_watch (struct info_ctx *ctx,
                  const flux_msg_t *msg,

--- a/src/modules/job-info/job-info.c
+++ b/src/modules/job-info/job-info.c
@@ -94,6 +94,7 @@ static void info_ctx_destroy (struct info_ctx *ctx)
     if (ctx) {
         int saved_errno = errno;
         flux_msg_handler_delvec (ctx->handlers);
+        lru_cache_destroy (ctx->owner_lru);
         /* freefn set on lookup entries will destroy list entries */
         if (ctx->lookups)
             zlist_destroy (&ctx->lookups);
@@ -118,6 +119,9 @@ static struct info_ctx *info_ctx_create (flux_t *h)
     ctx->h = h;
     if (flux_msg_handler_addvec (h, htab, ctx, &ctx->handlers) < 0)
         goto error;
+    if (!(ctx->owner_lru = lru_cache_create (OWNER_LRU_MAXSIZE)))
+        goto error;
+    lru_cache_set_free_f (ctx->owner_lru, (lru_cache_free_f)free);
     if (!(ctx->lookups = zlist_new ()))
         goto error;
     if (!(ctx->watchers = zlist_new ()))

--- a/src/modules/job-info/job-info.c
+++ b/src/modules/job-info/job-info.c
@@ -14,7 +14,7 @@
 #include <czmq.h>
 #include <flux/core.h>
 
-#include "info.h"
+#include "job-info.h"
 #include "allow.h"
 #include "lookup.h"
 #include "watch.h"

--- a/src/modules/job-info/job-info.h
+++ b/src/modules/job-info/job-info.h
@@ -14,9 +14,14 @@
 #include <flux/core.h>
 #include <czmq.h>
 
+#include "src/common/libutil/lru_cache.h"
+
+#define OWNER_LRU_MAXSIZE 1000
+
 struct info_ctx {
     flux_t *h;
     flux_msg_handler_t **handlers;
+    lru_cache_t *owner_lru; /* jobid -> owner LRU */
     zlist_t *lookups;
     zlist_t *watchers;
     zlist_t *guest_watchers;

--- a/src/modules/job-info/job-info.h
+++ b/src/modules/job-info/job-info.h
@@ -8,8 +8,8 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
-#ifndef _FLUX_JOB_INFO_INFO_H
-#define _FLUX_JOB_INFO_INFO_H
+#ifndef _FLUX_JOB_INFO_H
+#define _FLUX_JOB_INFO_H
 
 #include <flux/core.h>
 #include <czmq.h>
@@ -22,7 +22,7 @@ struct info_ctx {
     zlist_t *guest_watchers;
 };
 
-#endif /* _FLUX_JOB_INFO_INFO_H */
+#endif /* _FLUX_JOB_INFO_H */
 
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab

--- a/src/modules/job-info/lookup.c
+++ b/src/modules/job-info/lookup.c
@@ -173,7 +173,7 @@ static void info_lookup_continuation (flux_future_t *fall, void *arg)
             goto error;
         }
 
-        if (eventlog_allow (ctx, l->msg, s) < 0)
+        if (eventlog_allow (ctx, l->msg, l->id, s) < 0)
             goto error;
         l->allow = true;
     }
@@ -246,6 +246,17 @@ static int check_keys_for_eventlog (struct lookup_ctx *l)
 {
     size_t index;
     json_t *key;
+    int ret;
+
+    if ((ret = eventlog_allow_lru (l->ctx,
+                                   l->msg,
+                                   l->id)) < 0)
+        return -1;
+
+    if (ret) {
+        l->allow = true;
+        return 0;
+    }
 
     json_array_foreach(l->keys, index, key) {
         const char *keystr;

--- a/src/modules/job-info/lookup.c
+++ b/src/modules/job-info/lookup.c
@@ -17,7 +17,7 @@
 #include <jansson.h>
 #include <flux/core.h>
 
-#include "info.h"
+#include "job-info.h"
 #include "lookup.h"
 #include "allow.h"
 

--- a/src/modules/job-info/lookup.h
+++ b/src/modules/job-info/lookup.h
@@ -13,8 +13,6 @@
 
 #include <flux/core.h>
 
-#include "info.h"
-
 void lookup_cb (flux_t *h, flux_msg_handler_t *mh,
                 const flux_msg_t *msg, void *arg);
 

--- a/src/modules/job-info/watch.c
+++ b/src/modules/job-info/watch.c
@@ -21,7 +21,7 @@
 #include "src/common/libjob/job.h"
 #include "src/common/libeventlog/eventlog.h"
 
-#include "info.h"
+#include "job-info.h"
 #include "watch.h"
 #include "guest_watch.h"
 #include "allow.h"


### PR DESCRIPTION
per discussion in #3521 

consideration: should I drop the commit for the "always-lookup-job-owner" option?  It's very specific to testing this LRU support, and isn't something I even bothered to add a test into sharness for.  It really can't be used for anything else.  I'm leaning towards removing that commit, but thought I'd leave in for the time being.

