### PR TITLE
fix PMI_process_mapping when Flux is launched with multiple brokers per node

### DIFF
--- a/doc/man7/flux-broker-attributes.rst
+++ b/doc/man7/flux-broker-attributes.rst
@@ -64,11 +64,6 @@ tbon.maxlevel
 
 tbon.endpoint
    The endpoint for the tree based overlay network to communicate over.
-   Format specifier "%h" can be used to specify the IP address of the
-   host and is useful when configuring an IP endpoint. Format specifier
-   "%B" can be used to specify the value of the attribute broker.rundir.
-   It is useful when configuring an IPC endpoint. Defaults to
-   "tcp://%h:\*".
 
 
 SOCKET ATTRIBUTES

--- a/src/broker/boot_config.c
+++ b/src/broker/boot_config.c
@@ -446,15 +446,6 @@ int boot_config (flux_t *h, struct overlay *overlay, attr_t *attrs, int tbon_k)
     uint32_t size;
     json_t *hosts = NULL;
 
-    /* Throw an error if 'tbon.endpoint' attribute is already set.
-     * flux-start sets this, and it's not compatible with the
-     * config boot method as it would be overwritten below.
-     */
-    if (attr_get (attrs, "tbon.endpoint", NULL, NULL) == 0) {
-        log_msg ("attr tbon.endpoint may not be set with [bootstrap] config");
-        return -1;
-    }
-
     /* Ingest the [bootstrap] stanza.
      */
     if (boot_config_parse (flux_get_conf (h), &conf, &hosts) < 0)

--- a/src/cmd/flux-start.c
+++ b/src/cmd/flux-start.c
@@ -486,7 +486,6 @@ struct client *client_create (const char *broker_path, const char *scratch_dir,
     argz_add (&argz, &argz_len, broker_path);
     char *dir_arg = xasprintf ("--setattr=rundir=%s", scratch_dir);
     argz_add (&argz, &argz_len, dir_arg);
-    argz_add (&argz, &argz_len, "--setattr=tbon.endpoint=ipc://%B/req");
     free (dir_arg);
     add_args_list (&argz, &argz_len, ctx.opts, "broker-opts");
     if (rank == 0 && cmd_argz)

--- a/src/shell/lua.d/openmpi.lua
+++ b/src/shell/lua.d/openmpi.lua
@@ -8,8 +8,5 @@
 -- SPDX-License-Identifier: LGPL-3.0
 -------------------------------------------------------------
 
-local f = require 'flux'.new ()
-local rundir  = f:getattr ('broker.rundir')
-shell.setenv ("OMPI_MCA_orte_tmpdir_base", rundir)
 shell.setenv ("OMPI_MCA_pmix", "flux")
 shell.setenv ("OMPI_MCA_schizo", "flux")

--- a/src/shell/lua.d/spectrum.lua
+++ b/src/shell/lua.d/spectrum.lua
@@ -44,18 +44,11 @@ local function strip_env_by_prefix (env, prefix)
     end
 end
 
-local f = require 'flux'.new()
-local rundir = f:getattr ('broker.rundir')
-
 local env = shell.getenv()
 
 -- Clear all existing PMIX_ and OMPI_ values before setting our own
 strip_env_by_prefix (env, "PMIX_")
 strip_env_by_prefix (env, "OMPI_")
-
--- Avoid shared memory segment name collisions
--- when flux instance runs >1 broker per node.
-shell.setenv ('OMPI_MCA_orte_tmpdir_base', rundir)
 
 -- Assumes the installation paths of Spectrum MPI on LLNL's Sierra
 shell.setenv ('OMPI_MCA_osc', "pt2pt")

--- a/src/shell/pmi/pmi.c
+++ b/src/shell/pmi/pmi.c
@@ -363,38 +363,63 @@ static void pmi_fd_cb (flux_shell_task_t *task,
 }
 
 /* Generate 'PMI_process_mapping' key (see RFC 13) for MPI clique computation.
- *
- * Create an array of pmi_map_block structures, sized for worst case mapping
- * (no compression possible).  Walk through the rcalc info for each shell rank.
- * If shell's mapping looks identical to previous one, increment block->nodes;
- * otherwise consume another array slot.  Finally, encode to string, put it
- * in the local KVS hash, and free array.
  */
-static int init_clique (struct shell_pmi *pmi)
+static int init_clique (struct shell_pmi *pmi, const char *opt)
 {
-    struct pmi_map_block *blocks;
+    struct pmi_map_block *blocks = NULL;
     int nblocks;
     int i;
     char val[SIMPLE_KVS_VAL_MAX];
 
-    if (!(blocks = calloc (pmi->shell->info->shell_size, sizeof (*blocks))))
-        return -1;
-    nblocks = 0;
+     /* pmi.clique=pershell (default): one clique per shell.
+      * Create an array of pmi_map_block structures, sized for worst case
+      * mapping (no compression possible).  Walk through the rcalc info for
+      * each shell rank.  If shell's mapping looks identical to previous one,
+      * increment block->nodes; otherwise consume another array slot.
+      */
+    if (!strcmp (opt, "pershell")) {
+        if (!(blocks = calloc (pmi->shell->info->shell_size, sizeof (*blocks))))
+            return -1;
+        nblocks = 0;
 
-    for (i = 0; i < pmi->shell->info->shell_size; i++) {
-        struct rcalc_rankinfo ri;
+        for (i = 0; i < pmi->shell->info->shell_size; i++) {
+            struct rcalc_rankinfo ri;
 
-        if (rcalc_get_nth (pmi->shell->info->rcalc, i, &ri) < 0)
-            goto error;
-        if (nblocks == 0 || blocks[nblocks - 1].procs != ri.ntasks) {
-            blocks[nblocks].nodeid = i;
-            blocks[nblocks].procs = ri.ntasks;
-            blocks[nblocks].nodes = 1;
-            nblocks++;
+            if (rcalc_get_nth (pmi->shell->info->rcalc, i, &ri) < 0)
+                goto error;
+            if (nblocks == 0 || blocks[nblocks - 1].procs != ri.ntasks) {
+                blocks[nblocks].nodeid = i;
+                blocks[nblocks].procs = ri.ntasks;
+                blocks[nblocks].nodes = 1;
+                nblocks++;
+            }
+            else
+                blocks[nblocks - 1].nodes++;
         }
-        else
-            blocks[nblocks - 1].nodes++;
     }
+    /* pmi.clique=single: all procs are on the same node.
+     */
+    else if (!strcmp (opt, "single")) {
+        if (!(blocks = calloc (1, sizeof (*blocks))))
+            return -1;
+        nblocks = 1;
+        blocks[0].nodeid = 0;
+        blocks[0].procs = pmi->shell->info->total_ntasks;
+        blocks[0].nodes = 1;
+    }
+    /* pmi.clique=none: disable PMI_process_mapping generation.
+     */
+    else if (!strcmp (opt, "none")) {
+        goto out;
+    }
+    else {
+        shell_log_error ("pmi.clique=%s is invalid", opt);
+        goto error;
+    }
+
+    /* Encode to string, and store to local KVS hash.
+     */
+
     /* If value exceeds SIMPLE_KVS_VAL_MAX, skip setting the key
      * without generating an error.  The client side will not treat
      * a missing key as an error.  It should be unusual though so log it.
@@ -462,15 +487,20 @@ static struct pmi_simple_ops shell_pmi_ops = {
     .abort          = shell_pmi_abort,
 };
 
-static int parse_args (flux_shell_t *shell, int *exchange_k, const char **kvs)
+static int parse_args (flux_shell_t *shell,
+                       int *exchange_k,
+                       const char **kvs,
+                       const char **clique)
 {
     if (flux_shell_getopt_unpack (shell,
                                   "pmi",
-                                  "{s?s s?{s?i}}",
+                                  "{s?s s?{s?i} s?s}",
                                   "kvs",
                                   kvs,
                                   "exchange",
-                                    "k", exchange_k) < 0)
+                                    "k", exchange_k,
+                                  "clique",
+                                  clique) < 0)
         return -1;
     return 0;
 }
@@ -483,12 +513,13 @@ static struct shell_pmi *pmi_create (flux_shell_t *shell)
     char kvsname[32];
     const char *kvs = "exchange";
     int exchange_k = 0; // 0=use default tree fanout
+    const char *clique = "pershell";
 
     if (!(pmi = calloc (1, sizeof (*pmi))))
         return NULL;
     pmi->shell = shell;
 
-    if (parse_args (shell, &exchange_k, &kvs) < 0)
+    if (parse_args (shell, &exchange_k, &kvs, &clique) < 0)
         goto error;
     if (!strcmp (kvs, "native")) {
         shell_pmi_ops.kvs_put = native_kvs_put;
@@ -534,7 +565,7 @@ static struct shell_pmi *pmi_create (flux_shell_t *shell)
         errno = ENOMEM;
         goto error;
     }
-    if (init_clique (pmi) < 0)
+    if (init_clique (pmi, clique) < 0)
         goto error;
     if (!shell->standalone) {
         if (set_flux_instance_level (pmi) < 0)

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -90,6 +90,12 @@ test_expect_success 'flux-start --bootstrap=selfpmi fails (no size specified)' "
 test_expect_success 'flux-start --size=1 --boostrap=pmi fails' "
 	test_must_fail flux start ${ARGS} --size=1 --bootstrap=pmi /bin/true
 "
+test_expect_success 'flux-start --scratchdir --boostrap=pmi fails' "
+	test_must_fail flux start ${ARGS} --scratchdir=$(pwd) --bootstrap=pmi /bin/true
+"
+test_expect_success 'flux-start --noclique --boostrap=pmi fails' "
+	test_must_fail flux start ${ARGS} --noclique --bootstrap=pmi /bin/true
+"
 test_expect_success 'flux-start in exec mode passes through errors from command' "
 	test_must_fail flux start ${ARGS} /bin/false
 "

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -171,23 +171,19 @@ test_expect_success 'tbon.endpoint can be read' '
 	ATTR_VAL=`flux start ${ARGS} -s2 flux getattr tbon.endpoint` &&
 	echo $ATTR_VAL | grep "://"
 '
-test_expect_success 'tbon.endpoint can be set and %h works' '
-	flux start ${ARGS} -s2 -o,--setattr=tbon.endpoint=tcp://%h:* \
-		flux getattr tbon.endpoint >pct_h.out &&
-	grep "^tcp" pct_h.out &&
-	test_must_fail grep "%h" pct_h.out
+test_expect_success 'tbon.endpoint uses ipc:// in standalone instance' '
+	flux start ${ARGS} -s2 \
+		flux getattr tbon.endpoint >endpoint.out &&
+	grep "^ipc://" endpoint.out
 '
-test_expect_success 'tbon.endpoint with %B works' '
-	flux start ${ARGS} -s2 -o,--setattr=tbon.endpoint=ipc://%B/req \
-		flux getattr tbon.endpoint >pct_B.out &&
-	grep "^ipc" pct_B.out &&
-	test_must_fail grep "%B" pct_B.out
+test_expect_success 'tbon.endpoint uses tcp:// if process mapping unavailable' '
+	flux start ${ARGS} -s2 --noclique \
+		flux getattr tbon.endpoint >endpoint2.out &&
+	grep "^tcp" endpoint2.out
 '
-# N.B. rank 1 has to be killed in this test after rank 0 fails gracefully
-# so test_must_fail won't work here
-test_expect_success 'tbon.endpoint fails on bad endpoint' '
-	! flux start ${ARGS} -s2 --killer-timeout=0.2 \
-		-o,--setattr=tbon.endpoint=foo://bar /bin/true
+test_expect_success 'tbon.endpoint cannot be set' '
+	test_must_fail flux start ${ARGS} -s2 \
+		-o,--setattr=tbon.endpoint=ipc:///tmp/customflux /bin/true
 '
 test_expect_success 'tbon.parent-endpoint cannot be read on rank 0' '
 	test_must_fail flux start ${ARGS} -s2 flux getattr tbon.parent-endpoint

--- a/t/t2601-job-shell-standalone.t
+++ b/t/t2601-job-shell-standalone.t
@@ -135,7 +135,8 @@ test_expect_success 'flux-shell: shell PMI works' '
 		>pmi_info.out 2>pmi_info.err
 '
 test_expect_success 'flux-shell: shell PMI exports clique info' '
-	flux jobspec srun -N1 -n8 ${PMI_INFO} -c >j8pmi_clique &&
+	flux mini run -opmi.clique=pershell --dry-run -N1 -n8 \
+		${PMI_INFO} -c >j8pmi_clique &&
 	${FLUX_SHELL} -v -s -r 0 -j j8pmi_clique -R R8 51 \
 		>pmi_clique.out 2>pmi_clique.err &&
 	COUNT=$(grep "clique=0,1,2,3,4,5,6,7" pmi_clique.out | wc -l) &&

--- a/t/t2602-job-shell.t
+++ b/t/t2602-job-shell.t
@@ -69,8 +69,8 @@ test_expect_success 'pmi-shell: bad pmi.clique option fails' '
 '
 
 test_expect_success 'pmi-shell: PMI cliques are correct for 1 ppn' '
-        id=$(flux jobspec srun -N4 -n4 ${PMI_INFO} -c | flux job submit) &&
-	flux job attach $id >pmi_clique1.raw &&
+	flux mini run -opmi.clique=pershell -N4 -n4 \
+		${PMI_INFO} -c >pmi_clique1.raw &&
 	sort -snk1 <pmi_clique1.raw >pmi_clique1.out &&
 	sort >pmi_clique1.exp <<-EOT &&
 	0: clique=0
@@ -81,8 +81,8 @@ test_expect_success 'pmi-shell: PMI cliques are correct for 1 ppn' '
 	test_cmp pmi_clique1.exp pmi_clique1.out
 '
 test_expect_success 'pmi-shell: PMI cliques are correct for 2 ppn' '
-        id=$(flux jobspec srun -N2 -n4 ${PMI_INFO} -c | flux job submit) &&
-	flux job attach $id >pmi_clique2.raw &&
+	flux mini run -opmi.clique=pershell \
+		-N2 -n4 ${PMI_INFO} -c >pmi_clique2.raw &&
 	sort -snk1 <pmi_clique2.raw >pmi_clique2.out &&
 	sort >pmi_clique2.exp <<-EOT &&
 	0: clique=0,1
@@ -93,8 +93,8 @@ test_expect_success 'pmi-shell: PMI cliques are correct for 2 ppn' '
 	test_cmp pmi_clique2.exp pmi_clique2.out
 '
 test_expect_success 'pmi-shell: PMI cliques are correct for irregular ppn' '
-        id=$(flux jobspec srun -N4 -n5 ${PMI_INFO} -c | flux job submit) &&
-	flux job attach $id >pmi_cliquex.raw &&
+	flux mini run -opmi.clique=pershell -N4 -n5 \
+		${PMI_INFO} -c >pmi_cliquex.raw &&
 	sort -snk1 <pmi_cliquex.raw >pmi_cliquex.out &&
 	sort >pmi_cliquex.exp <<-EOT &&
 	0: clique=0,1

--- a/t/t2602-job-shell.t
+++ b/t/t2602-job-shell.t
@@ -62,6 +62,12 @@ test_expect_success 'job-shell: PMI works' '
 	flux job attach $id >pmi_info.out 2>pmi_info.err &&
 	grep size=4 pmi_info.out
 '
+test_expect_success 'pmi-shell: bad pmi.clique option fails' '
+	test_must_fail flux mini run -opmi.clique=badopt \
+		/bin/true 2>badopt.err &&
+	grep "pmi.clique=badopt is invalid" badopt.err
+'
+
 test_expect_success 'pmi-shell: PMI cliques are correct for 1 ppn' '
         id=$(flux jobspec srun -N4 -n4 ${PMI_INFO} -c | flux job submit) &&
 	flux job attach $id >pmi_clique1.raw &&

--- a/t/t3002-pmi.t
+++ b/t/t3002-pmi.t
@@ -16,7 +16,8 @@ test_expect_success 'pmi_info works' '
 '
 
 test_expect_success 'pmi_info --clique shows each node with own clique' '
-	flux mini run -n${SIZE} -N${SIZE} ${pmi_info} --clique >clique.out &&
+	flux mini run -opmi.clique=pershell -n${SIZE} -N${SIZE} \
+		${pmi_info} --clique >clique.out &&
 	count=$(cut -f2 -d: clique.out | sort | uniq | wc -l) &&
 	test $count -eq ${SIZE}
 '


### PR DESCRIPTION
As noted in #3551, the current strategy of setting `OMPI_MCA_orte_tmpdir_base` for OpenMPI to the broker run directory probably won't work for a multi-user instance, when the instance owner != the job owner.  It also covers up an actual problem, which is an inaccuracy in our `PMI_process_mapping` generation.

The inaccuracy is that each shell is considered a separate "clique", but when multiple brokers are launched per node, those cliques are really on the same node, which breaks assumptions in OpenMPI and causes segfaults.

So get `PMI_process_mapping` when the broker bootstraps and store that in an attribute.  Then in the shell, fetch the broker's mapping and determine whether it is safe to treat each shell as a clique, or whether the job's mapping should be for one big clique (standalone `flux start` case) or not be set at all.

TODO: tests