### PR TITLE
broker: drop broker.rundir and select ipc vs tcp using broker.mapping

### DIFF
--- a/doc/man7/flux-broker-attributes.rst
+++ b/doc/man7/flux-broker-attributes.rst
@@ -23,18 +23,11 @@ size
    The number of broker ranks in the flux instance
 
 rundir
-   A global, shared temporary directory available for scratch storage
-   within the session. By default, a temporary directory is created
-   for each broker rank, but if rundir is set on the command line, this
-   directory may be shared by all broker ranks (typically only within
-   a node). If rundir does not exist, it is created and subsequently
-   removed during session exit. An existing rundir is not removed at exit.
-
-broker.rundir
-   A temporary directory available for per-rank scratch storage within
-   the session. By default broker.rundir is set to "${rundir}/${rank}",
-   which guarantees a unique directory per rank. It is not advisable
-   to override this attribute on the command line. Use rundir instead.
+   A temporary directory available for scratch storage within the session.
+   By default, a temporary directory is created for each broker rank, but
+   if rundir is set on the command line, this directory may be shared by
+   all broker ranks running on the same node.  If rundir is created by the
+   broker, it is removed during session exit.
 
 content.backing-path
    The path to the content backing store file(s). If this is set on the

--- a/src/broker/boot_config.c
+++ b/src/broker/boot_config.c
@@ -479,7 +479,7 @@ int boot_config (flux_t *h, struct overlay *overlay, attr_t *attrs, int tbon_k)
     /* Tell overlay network this broker's rank, size, and branching factor.
      * If a curve certificate was provided, load it.
      */
-    if (overlay_init (overlay, size, rank, tbon_k) < 0)
+    if (overlay_set_geometry (overlay, size, rank, tbon_k) < 0)
         goto error;
     if (conf.curve_cert) {
         if (overlay_cert_load (overlay, conf.curve_cert) < 0)

--- a/src/broker/boot_pmi.c
+++ b/src/broker/boot_pmi.c
@@ -178,7 +178,10 @@ int boot_pmi (struct overlay *overlay, attr_t *attrs, int tbon_k)
         log_err ("error setting broker.mapping attribute");
         goto error;
     }
-    if (overlay_init (overlay, pmi_params.size, pmi_params.rank, tbon_k) < 0)
+    if (overlay_set_geometry (overlay,
+                              pmi_params.size,
+                              pmi_params.rank,
+                              tbon_k) < 0)
         goto error;
 
     /* A size=1 instance has no peers, so skip the PMI exchange.

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -769,7 +769,7 @@ cleanup:
  */
 static int create_rundir (attr_t *attrs)
 {
-    const char *run_dir;
+    const char *run_dir = NULL;
     char *dir = NULL;
     bool do_cleanup = true;
     struct stat sb;
@@ -829,10 +829,10 @@ static int create_rundir (attr_t *attrs)
         log_err ("error setting rundir broker attribute flags");
         goto done;
     }
-    if (do_cleanup)
-        cleanup_push_string (cleanup_directory_recursive, run_dir);
     rc = 0;
 done:
+    if (do_cleanup && run_dir != NULL)
+        cleanup_push_string (cleanup_directory_recursive, run_dir);
     free (dir);
     return rc;
 }

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -771,7 +771,6 @@ static int create_rundir (attr_t *attrs)
 {
     const char *run_dir;
     char *dir = NULL;
-    char *uri = NULL;
     bool do_cleanup = true;
     struct stat sb;
     int rc = -1;
@@ -835,7 +834,6 @@ static int create_rundir (attr_t *attrs)
     rc = 0;
 done:
     free (dir);
-    free (uri);
     return rc;
 }
 

--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -86,9 +86,6 @@ struct overlay {
 
     overlay_recv_f recv_cb;
     void *recv_arg;
-
-    overlay_init_f init_cb;
-    void *init_arg;
 };
 
 static void overlay_mcast_child (struct overlay *ov, const flux_msg_t *msg);
@@ -106,14 +103,6 @@ static void overlay_monitor_notify (struct overlay *ov)
 {
     if (ov->child_monitor_cb)
         ov->child_monitor_cb (ov, ov->child_monitor_arg);
-}
-
-void overlay_set_init_callback (struct overlay *ov,
-                                overlay_init_f cb,
-                                void *arg)
-{
-    ov->init_cb = cb;
-    ov->init_arg = arg;
 }
 
 /* Allocate children array based on static tree topology, and return size.
@@ -159,8 +148,6 @@ int overlay_init (struct overlay *ov,
         uint32_t parent_rank = kary_parentof (tbon_k, rank);
         snprintf (ov->parent_uuid, sizeof (ov->uuid), "%"PRIu32, parent_rank);
     }
-    if (ov->init_cb)
-        return (*ov->init_cb) (ov, ov->init_arg);
 
     return 0;
 }

--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -130,10 +130,10 @@ static int alloc_children (uint32_t rank,
     return count;
 }
 
-int overlay_init (struct overlay *ov,
-                  uint32_t size,
-                  uint32_t rank,
-                  int tbon_k)
+int overlay_set_geometry (struct overlay *ov,
+                          uint32_t size,
+                          uint32_t rank,
+                          int tbon_k)
 {
     ov->size = size;
     ov->rank = rank;

--- a/src/broker/overlay.h
+++ b/src/broker/overlay.h
@@ -31,10 +31,10 @@ void overlay_destroy (struct overlay *ov);
 
 /* Call before connect/bind.
  */
-int overlay_init (struct overlay *ov,
-                  uint32_t size,
-                  uint32_t rank,
-                  int tbon_k);
+int overlay_set_geometry (struct overlay *ov,
+                          uint32_t size,
+                          uint32_t rank,
+                          int tbon_k);
 
 /* Send a message on the overlay network.
  */

--- a/src/broker/overlay.h
+++ b/src/broker/overlay.h
@@ -21,7 +21,6 @@ typedef enum {
 
 struct overlay;
 
-typedef int (*overlay_init_f)(struct overlay *ov, void *arg);
 typedef void (*overlay_monitor_f)(struct overlay *ov, void *arg);
 typedef void (*overlay_recv_f)(const flux_msg_t *msg,
                                overlay_where_t from,
@@ -29,12 +28,6 @@ typedef void (*overlay_recv_f)(const flux_msg_t *msg,
 
 struct overlay *overlay_create (flux_t *h, overlay_recv_f cb, void *arg);
 void overlay_destroy (struct overlay *ov);
-
-/* Set a callback triggered during overlay_init()
- */
-void overlay_set_init_callback (struct overlay *ov,
-                                overlay_init_f cb,
-                                void *arg);
 
 /* Call before connect/bind.
  */

--- a/src/broker/test/overlay.c
+++ b/src/broker/test/overlay.c
@@ -335,7 +335,7 @@ void trio (flux_t *h)
     ok (flux_msg_get_topic (rmsg, &topic) == 0 && !strcmp (topic, "m000"),
         "%s: received message has expected topic", ctx[0]->name);
     ok (flux_msg_get_route_count (rmsg) == 0,
-        "%s: received message has no routes");
+        "%s: received message has no routes", ctx[0]->name);
 
     /* Event
      */
@@ -392,7 +392,7 @@ void trio (flux_t *h)
     ok (flux_msg_get_topic (rmsg, &topic) == 0 && !strcmp (topic, "moop"),
         "%s: response has expected topic", ctx[1]->name);
     ok (flux_msg_get_route_count (rmsg) == 0,
-        "%s: response has no routes");
+        "%s: response has no routes", ctx[1]->name);
 
     /* Event
      */

--- a/src/broker/test/overlay.c
+++ b/src/broker/test/overlay.c
@@ -103,8 +103,8 @@ void single (flux_t *h)
     struct context *ctx = ctx_create (h, "single", 1, 0, NULL);
     flux_msg_t *msg;
 
-    ok (overlay_init (ctx->ov, 1, 0, 2) == 0,
-        "%s: overlay_init size=1 rank=0 tbon_k=2 works", ctx->name);
+    ok (overlay_set_geometry (ctx->ov, 1, 0, 2) == 0,
+        "%s: overlay_set_geometry size=1 rank=0 tbon_k=2 works", ctx->name);
 
     ok (overlay_get_size (ctx->ov) == 1,
         "%s: overlay_get_size returns 1", ctx->name);
@@ -254,8 +254,8 @@ void trio (flux_t *h)
 
     ctx[0] = ctx_create (h, "trio", size, 0, recv_cb);
 
-    ok (overlay_init (ctx[0]->ov, size, 0, k_ary) == 0,
-        "%s: overlay_init works", ctx[0]->name);
+    ok (overlay_set_geometry (ctx[0]->ov, size, 0, k_ary) == 0,
+        "%s: overlay_set_geometry works", ctx[0]->name);
 
     ok ((server_pubkey = overlay_cert_pubkey (ctx[0]->ov)) != NULL,
         "%s: overlay_cert_pubkey works", ctx[0]->name);
@@ -266,7 +266,7 @@ void trio (flux_t *h)
 
     ctx[1] = ctx_create (h, "trio", size, 1, recv_cb);
 
-    ok (overlay_init (ctx[1]->ov, size, 1, k_ary) == 0,
+    ok (overlay_set_geometry (ctx[1]->ov, size, 1, k_ary) == 0,
         "%s: overlay_init works", ctx[1]->name);
 
     ok ((client_pubkey = overlay_cert_pubkey (ctx[1]->ov)) != NULL,

--- a/src/broker/test/overlay.c
+++ b/src/broker/test/overlay.c
@@ -98,28 +98,13 @@ struct context *ctx_create (flux_t *h, const char *name, int size, int rank,
     return ctx;
 }
 
-int single_init_cb (struct overlay *ov, void *arg)
-{
-    struct context *ctx = arg;
-    // get rundir attr
-    // create rank subidr
-    // set broker.rundir attr
-    // set local-uri attr to local://${broker.rundir}/local
-    flux_log (ctx->h, LOG_INFO, "single_init_cb called");
-    return 0;
-}
-
-
 void single (flux_t *h)
 {
     struct context *ctx = ctx_create (h, "single", 1, 0, NULL);
     flux_msg_t *msg;
 
-    overlay_set_init_callback (ctx->ov, single_init_cb, ctx);
     ok (overlay_init (ctx->ov, 1, 0, 2) == 0,
         "%s: overlay_init size=1 rank=0 tbon_k=2 works", ctx->name);
-    ok (match_list (logs, "single_init_cb called") == 1,
-        "%s: overlay_init triggered init callback", ctx->name);
 
     ok (overlay_get_size (ctx->ov) == 1,
         "%s: overlay_get_size returns 1", ctx->name);

--- a/src/cmd/flux-start.c
+++ b/src/cmd/flux-start.c
@@ -380,8 +380,7 @@ void add_args_list (char **argz, size_t *argz_len, optparse_t *opt, const char *
 char *create_scratch_dir (void)
 {
     char *tmpdir = getenv ("TMPDIR");
-    char *scratchdir = xasprintf ("%s/flux-%d-XXXXXX",
-                                  tmpdir ? tmpdir : "/tmp", (int)getpid());
+    char *scratchdir = xasprintf ("%s/flux-XXXXXX", tmpdir ? tmpdir : "/tmp");
 
     if (!mkdtemp (scratchdir))
         log_err_exit ("mkdtemp %s", scratchdir);

--- a/src/modules/connector-local/local.c
+++ b/src/modules/connector-local/local.c
@@ -304,6 +304,7 @@ int mod_main (flux_t *h, int argc, char **argv)
     }
     if (!(tmpdir = strstr (local_uri, "local://"))) {
         flux_log (h, LOG_ERR, "malformed local-uri");
+        errno = EINVAL;
         goto done;
     }
     sockpath = tmpdir + 8;


### PR DESCRIPTION
This is based on top of #3553.

With `PMI_process_mapping` available in the broker, use it rather than an explicit broker command line option from `flux start` to determine when `ipc://` can be used in place of `tcp://` for the overlay network.

In addition, perform the following cleanup that falls out from these changes:
* Don't allow `tbon.endpoint` to be set on the command line.  We don't need this anymore now that we can bootstrap from config files, and `flux-start` doesn't need to set it tell the broker to use `ipc://`
* Eliminate `broker.rundir`, the ranked subdirectory of `rundir`.  Instead append the rank to `ipc://` paths when used, and to the local URI, in case `rundir` happens to be shared by multiple brokers (e.g. standalone `flux start`).
* Eliminate the callback triggered by calling `overlay_init()`.  This used to create `broker.rundir` from within the PMI bootstrap code, after the rank was known, so that the `ipc://` paths could use it later on in the PMI bootstrap code.