### PR TITLE
kvs: fix assert due to busy KVS

### DIFF
--- a/src/modules/kvs/cache.h
+++ b/src/modules/kvs/cache.h
@@ -127,8 +127,9 @@ struct cache_entry *cache_lookup (struct cache *cache, const char *ref);
  */
 int cache_insert (struct cache *cache, struct cache_entry *entry);
 
-/* Remove a cache_entry from the cache.  Will not be removed if dirty
- * or there are any waiters of any sort.
+/* Remove a cache_entry from the cache.  Will not be removed if dirty,
+ * if there are any waiters of any sort, or if there are any references
+ * taken on the entry (i.e. with cache_entry_incref()).
  * Returns 1 on removed, 0 if not
  */
 int cache_remove_entry (struct cache *cache, const char *ref);

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -1073,8 +1073,8 @@ static int kvstxn_check_root_cb (struct kvsroot *root, void *arg)
 
     if ((kt = kvstxn_mgr_get_ready_transaction (root->ktm))) {
         if (cbd->ctx->transaction_merge) {
-            /* if merge fails, set errnum in txn_t, let
-             * txn_apply() handle error handling.
+            /* if merge fails, set errnum in kvstxn_t, let
+             * kvstxn_apply() handle error handling.
              */
             if (kvstxn_mgr_merge_ready_transactions (root->ktm) < 0)
                 kvstxn_set_aux_errnum (kt, errno);


### PR DESCRIPTION
Per discussion in #3549, this fixes an assert due to a missing cache entry that expires when the KVS is heavily loaded.

There is some discussion in #3549 about some additional cleanup, but in the interest of getting this into the 0.25.0 milestone, I decided to work on the cleanup after this specific fix.  I'll send (future) cleanups in a separate PR.

Side note: the core patch has been cleaned up compared to what I put in the 0.19.0 side branch.

https://github.com/chu11/flux-core/tree/issue3549_v0190_kvs_assert
