### PR TITLE
job-manager: enable job dependency management

### DIFF
--- a/doc/man1/flux-jobs.rst
+++ b/doc/man1/flux-jobs.rst
@@ -173,6 +173,9 @@ The field names that can be specified are:
 **priority**
    job priority
 
+**dependencies**
+   list of any currently outstanding job dependencies
+
 **status**
    job status (PENDING, RUNNING, COMPLETED, FAILED, or CANCELED)
 

--- a/doc/man7/flux-jobtap-plugins.rst
+++ b/doc/man7/flux-jobtap-plugins.rst
@@ -9,8 +9,8 @@ DESCRIPTION
 The *jobtap* interface supports loading of builtin and external
 plugins into the job manager broker module. These plugins can be used
 to assign job priorities using algorithms other than the default,
-aid in debugging of the flow of job states, or generically extend
-the functionality of the job manager.
+assign job dependencies, aid in debugging of the flow of job states,
+or generically extend the functionality of the job manager.
 
 NOTE:
    Currently only a single jobtap plugin may be loaded into the job manager
@@ -119,6 +119,18 @@ job.state.*
   The callback is made after the state has been published to the job's
   eventlog, but before any action has been taken on that state (since the
   action could involve immediately transitioning to a new state)
+
+job.state.depend
+  The callback for ``FLUX_JOB_STATE_DEPEND`` is the only place from which
+  a plugin may add dependencies to a job. Dependencies are added via
+  the ``flux_jobtap_dependency_add()`` function. This function allows a
+  named dependency to be attached to a job. Jobs with dependencies will
+  remain in the ``DEPEND`` state until all dependencies are removed with
+  a corresponding call the ``flux_jobtap_dependency_remove()``. A dependency
+  may only be used once. A second call to ``flux_jobtap_dependency_add()``
+  with the same dependency description will return ``EEXIST``, even if
+  the dependency was subsequently removed. (This allows idempotent operation
+  of plugin-managed dependencies for job-manager or plugin restart).
 
 job.state.priority
   The callback for ``FLUX_JOB_STATE_PRIORITY`` is special, in that a plugin

--- a/src/bindings/python/flux/job/info.py
+++ b/src/bindings/python/flux/job/info.py
@@ -90,6 +90,13 @@ class AnnotationsInfo:
             return AnnotationsInfo({})
 
 
+class InfoList(list):
+    """Extend list with string representation appropriate for JobInfo format"""
+
+    def __str__(self):
+        return ",".join(self)
+
+
 class JobInfo:
     """
     JobInfo class: encapsulate job-list.list response in an object
@@ -141,6 +148,9 @@ class JobInfo:
         combined_dict["annotations"] = AnnotationsInfo(aDict)
         combined_dict["sched"] = combined_dict["annotations"].sched
         combined_dict["user"] = combined_dict["annotations"].user
+
+        deps = combined_dict.get("dependencies", [])
+        combined_dict["dependencies"] = InfoList(deps)
 
         #  Set all keys as self._{key} to be found by getattr and
         #   memoized_property decorator:
@@ -375,6 +385,7 @@ class JobInfoFormat(flux.util.OutputFormat):
         "exception.type": "EXCEPTION-TYPE",
         "exception.note": "EXCEPTION-NOTE",
         "annotations": "ANNOTATIONS",
+        "dependencies": "DEPENDENCIES",
         # The following are special pre-defined cases per RFC27
         "annotations.sched.t_estimate": "T_ESTIMATE",
         "annotations.sched.reason_pending": "REASON",

--- a/src/bindings/python/flux/job/list.py
+++ b/src/bindings/python/flux/job/list.py
@@ -41,6 +41,7 @@ VALID_ATTRS = [
     "result",
     "expiration",
     "annotations",
+    "dependencies",
 ]
 
 

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -1061,7 +1061,7 @@ static const char *list_attrs =
     "\"success\",\"exception_occurred\",\"exception_severity\"," \
     "\"exception_type\",\"exception_note\",\"result\",\"waitstatus\","  \
     "\"t_depend\",\"t_run\",\"t_cleanup\"," \
-    "\"t_inactive\"," "\"annotations\"]";
+    "\"t_inactive\",\"annotations\",\"dependencies\"]";
 
 int cmd_list (optparse_t *p, int argc, char **argv)
 {

--- a/src/cmd/flux-jobs.py
+++ b/src/cmd/flux-jobs.py
@@ -85,6 +85,7 @@ def fetch_jobs_flux(args, fields):
         "expiration": ("expiration", "state", "result"),
         "t_remaining": ("expiration", "state", "result"),
         "annotations": ("annotations",),
+        "dependencies": ("dependencies",),
         # Special cases, pointers to sub-dicts in annotations
         "sched": ("annotations",),
         "user": ("annotations",),

--- a/src/common/libutil/Makefile.am
+++ b/src/common/libutil/Makefile.am
@@ -85,7 +85,9 @@ libutil_la_SOURCES = \
 	errno_safe.h \
 	intree.c \
 	intree.h \
-	llog.h
+	llog.h \
+	grudgeset.c \
+	grudgeset.h
 
 EXTRA_DIST = veb_mach.c
 
@@ -111,7 +113,8 @@ TESTS = test_ev.t \
 	test_fdutils.t \
 	test_fsd.t \
 	test_intree.t \
-	test_fdwalk.t
+	test_fdwalk.t \
+	test_grudgeset.t
 
 
 test_ldadd = \
@@ -232,3 +235,7 @@ test_intree_t_LDADD = $(test_ldadd)
 test_fdwalk_t_SOURCES = test/fdwalk.c
 test_fdwalk_t_CPPFLAGS = $(test_cppflags)
 test_fdwalk_t_LDADD = $(test_ldadd)
+
+test_grudgeset_t_SOURCES = test/grudgeset.c
+test_grudgeset_t_CPPFLAGS = $(test_cppflags)
+test_grudgeset_t_LDADD = $(test_ldadd)

--- a/src/common/libutil/grudgeset.c
+++ b/src/common/libutil/grudgeset.c
@@ -1,0 +1,133 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <string.h>
+#include <errno.h>
+
+#include <jansson.h>
+
+struct grudgeset {
+    json_t *set;
+    json_t *grudges;
+};
+
+void grudgeset_destroy (struct grudgeset *gset)
+{
+    if (gset) {
+        int saved_errno = errno;
+        json_decref (gset->set);
+        json_decref (gset->grudges);
+        free (gset);
+        errno = saved_errno;
+    }
+}
+
+static struct grudgeset *grudgeset_create (void)
+{
+    struct grudgeset *gset = calloc (1, sizeof (*gset));
+    if (!gset
+        || !(gset->set = json_array ())
+        || !(gset->grudges = json_object ()))
+        goto error;
+    return gset;
+error:
+    grudgeset_destroy (gset);
+    return NULL;
+}
+
+int grudgeset_used (struct grudgeset *gset, const char *val)
+{
+    if (!gset || !val)
+        return 0;
+    return (json_object_get (gset->grudges, val) != NULL);
+}
+
+static int json_array_find (json_t *array, const char *val)
+{
+    size_t index;
+    json_t *entry;
+    json_array_foreach (array, index, entry) {
+        const char *s = json_string_value (entry);
+        if (val && strcmp (val, s) == 0) {
+            return (int) index;
+        }
+    }
+    return -1;
+}
+
+int grudgeset_contains (struct grudgeset *gset, const char *val)
+{
+    if (!gset
+        || !val
+        || json_array_find (gset->set, val) < 0)
+        return 0;
+    return 1;
+}
+
+int grudgeset_add (struct grudgeset **gsetp, const char *val)
+{
+    json_t *o = NULL;
+
+    if (!gsetp || !val) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (!*gsetp) {
+        if (!(*gsetp = grudgeset_create ()))
+            return -1;
+    }
+    if (grudgeset_used (*gsetp, val)) {
+        errno = EEXIST;
+        return -1;
+    }
+    if (!(o = json_string (val))
+        || json_array_append_new ((*gsetp)->set, o) < 0) {
+        json_decref (o);
+        errno = ENOMEM;
+        return -1;
+    }
+    /* val is guaranteed not to exist in set->grudges */
+    (void) json_object_set_new ((*gsetp)->grudges, val, json_null ());
+    return 0;
+}
+
+int grudgeset_remove (struct grudgeset *gset, const char *val)
+{
+    int index;
+    if (val == NULL) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (gset && (index = json_array_find (gset->set, val)) >= 0)
+        return json_array_remove (gset->set, index);
+    errno = ENOENT;
+    return -1;
+}
+
+json_t *grudgeset_tojson (struct grudgeset *gset)
+{
+    if (gset)
+        return gset->set;
+    return NULL;
+}
+
+int grudgeset_size (struct grudgeset *gset)
+{
+    if (gset == NULL)
+        return 0;
+    return json_array_size (gset->set);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libutil/grudgeset.h
+++ b/src/common/libutil/grudgeset.h
@@ -1,0 +1,56 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _UTIL_GRUDGESET_H
+#define _UTIL_GRUDGESET_H
+
+/*  "grudge" set implementation. A set which only allows values to
+ *   be inserted once, even if they are subsequently removed.
+ */
+
+struct grudgeset;
+
+/* Add the string 'val' to set `*gsetp`. If *gsetp is NULL
+ * a new grudge set will be created with a single entry.
+ *
+ *  If a value was previously added to the set, then the append
+ *   will fail with -1 and errno set to EEXIST.
+ */
+int grudgeset_add (struct grudgeset **gsetp, const char *val);
+
+/*  Remove matching entry 'val' from gset. It is assumed there are
+ *   no duplicates.
+ */
+int grudgeset_remove (struct grudgeset *gset, const char *val);
+
+/*  Return number of elements in grudgeset
+ *  If gset is NULL then the size is 0.
+ */
+int grudgeset_size (struct grudgeset *gset);
+
+/*  Return 1 if val has been used in grudgeset, 0 otherwise
+ */
+int grudgeset_used (struct grudgeset *gset, const char *val);
+
+/*  Return 1 if set currently contains val, 0 otherwise
+ */
+int grudgeset_contains (struct grudgeset *gset, const char *val);
+
+/*  Return the current set in grudgeset 'gset'
+ *  The returned object is a JSON array.
+ *  Note: this should not be modified by caller, but is returned
+ *   non-const so it can be json_incref'd for nocopy use in message
+ *   payloads, etc.
+ */
+json_t *grudgeset_tojson (struct grudgeset *gset);
+
+void grudgeset_destroy (struct grudgeset *gset);
+
+#endif /* !_UTIL_GRUDGE_SET_H */

--- a/src/common/libutil/test/grudgeset.c
+++ b/src/common/libutil/test/grudgeset.c
@@ -1,0 +1,97 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#include <string.h>
+#include <errno.h>
+#include <jansson.h>
+
+#include "src/common/libtap/tap.h"
+#include "src/common/libutil/grudgeset.h"
+
+int main (int argc, char *argv[])
+{
+    struct grudgeset *gs = NULL;
+
+    plan (NO_PLAN);
+
+    ok (grudgeset_add (NULL, NULL) < 0 && errno == EINVAL,
+        "grudgeset_add (NULL, NULL) returns EINVAL");
+    ok (grudgeset_add (&gs, NULL) < 0 && errno == EINVAL,
+        "grudgeset_add (&o, NULL) returns EINVAL");
+    ok (grudgeset_remove (NULL, NULL) < 0 && errno == EINVAL,
+        "grudgeset_remove (NULL, NULL) returns EINVAL");
+
+    ok (grudgeset_remove (NULL, "foo") < 0 && errno == ENOENT,
+        "grudgeset_remove(NULL, \"foo\") returns ENOENT");
+    ok (grudgeset_size (NULL) == 0,
+        "grudgeset_size (NULL) == 0");
+
+    ok (grudgeset_used (NULL, "foo") == 0,
+        "grudgeset_used (NULL, \"foo\") returns 0");
+    ok (grudgeset_contains (NULL, NULL) == 0,
+        "grudgeset_contains (NULL, NULL) returns 0");
+    ok (grudgeset_contains (NULL, "foo") == 0,
+        "grudgeset_contains (NULL, \"foo\") returns 0");
+    ok (grudgeset_tojson (NULL) == NULL,
+        "grudgeset_tojson (NULL) returns NULL");
+
+    ok (grudgeset_add (&gs, "foo") == 0,
+        "grudgeset_add works with NULL object");
+    ok (gs != NULL,
+        "grudgeset is now non-NULL");
+    ok (grudgeset_size (gs) == 1,
+        "set is of size 1");
+    ok (grudgeset_contains (gs, "foo") == 1,
+        "grudgeset_contains (foo) works");
+
+    ok (grudgeset_add (&gs, "foo") < 0 && errno == EEXIST,
+        "grudgeset_add of existing value returns EEXIST");
+
+    ok (grudgeset_add (&gs, "baz") == 0,
+        "grudgeset_add of a second value works");
+    ok (grudgeset_size (gs) == 2,
+        "grudgeset is of size 2");
+    ok (grudgeset_contains (gs, "baz") == 1,
+        "grudgeset_contains (baz) works");
+
+    ok (grudgeset_tojson (gs) != NULL,
+        "grudgeset_tojson() is non-NULL");
+
+    ok (grudgeset_remove (gs, "xxyyzz") < 0 && errno == ENOENT,
+        "grudgeset_remove of nonexistent entry returns ENOENT");
+
+    ok (grudgeset_remove (gs, "foo") == 0,
+        "grudgeset_remove of first item in set works");
+    ok (grudgeset_size (gs) == 1,
+        "set is of size 1");
+    ok (grudgeset_contains (gs, "foo") == 0,
+        "grudgeset no longer contains foo");
+    ok (grudgeset_used (gs, "foo") == 1,
+        "but grudgeset has marked foo as \"used\"");
+
+    ok (grudgeset_add (&gs, "foo") < 0 && errno == EEXIST,
+        "grudgeset_add of removed value still fails");
+
+    ok (grudgeset_remove (gs, "baz") == 0,
+        "grudgeset_remove of second element works");
+    ok (grudgeset_size (gs) == 0,
+        "grudgeset_size is now 0");
+    ok (grudgeset_used (gs, "baz"),
+        "grudgeset_used (baz) == 1");
+
+    grudgeset_destroy (gs);
+
+    done_testing ();
+    return 0;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/job-list/job_state.h
+++ b/src/modules/job-list/job_state.h
@@ -16,6 +16,7 @@
 
 #include "job-list.h"
 #include "stats.h"
+#include "src/common/libutil/grudgeset.h"
 
 /* To handle the common case of user queries on job state, we will
  * store jobs in three different lists.
@@ -83,6 +84,7 @@ struct job {
     const char *exception_note;
     flux_job_result_t result;
     json_t *annotations;
+    struct grudgeset *dependencies;
     int eventlog_seq;           /* last event seq read */
 
     /* cache of job information */

--- a/src/modules/job-list/job_util.c
+++ b/src/modules/job-list/job_util.c
@@ -183,6 +183,11 @@ json_t *job_to_json (struct job *job, json_t *attrs, job_info_error_t *errp)
                 continue;
             val = json_incref (job->annotations);
         }
+        else if (!strcmp (attr, "dependencies")) {
+            if (!job->dependencies)
+                continue;
+            val = json_incref (grudgeset_tojson (job->dependencies));
+        }
         else {
             seterror (errp, "%s is not a valid attribute", attr);
             errno = EINVAL;

--- a/src/modules/job-list/list.c
+++ b/src/modules/job-list/list.c
@@ -571,7 +571,8 @@ void list_attrs_cb (flux_t *h, flux_msg_handler_t *mh,
                             "ranks", "nodelist", "success", "exception_occurred",
                             "exception_type", "exception_severity",
                             "exception_note", "result", "expiration",
-                            "annotations", "waitstatus", NULL };
+                            "annotations", "waitstatus", "dependencies",
+                            NULL };
     json_t *a = NULL;
     int i;
 

--- a/src/modules/job-manager/jobtap.c
+++ b/src/modules/job-manager/jobtap.c
@@ -487,6 +487,14 @@ static void jobtap_handle_load_req (struct job_manager *ctx,
     job = zlistx_first (jobs);
     while (job) {
         (void) jobtap_call (ctx->jobtap, job, "job.new", NULL);
+
+        /*  If job is in DEPEND state then there may be pending dependencies.
+         *  Notify plugin of the DEPEND state assuming it needs to create
+         *   some state in order to resolve the dependency.
+         */
+        if (job->state == FLUX_JOB_STATE_DEPEND)
+            (void) jobtap_call (ctx->jobtap, job, "job.state.depend", NULL);
+
         job = zlistx_next (jobs);
     }
     zlistx_destroy (&jobs);

--- a/src/modules/job-manager/jobtap.c
+++ b/src/modules/job-manager/jobtap.c
@@ -26,6 +26,7 @@
 
 #include "annotate.h"
 #include "prioritize.h"
+#include "event.h"
 #include "jobtap.h"
 #include "jobtap-internal.h"
 
@@ -688,6 +689,58 @@ int flux_jobtap_reject_job (flux_plugin_t *p,
             flux_log_error (h, "flux_jobtap_reject_job: failed to pack error");
     }
     return -1;
+}
+
+static struct job *lookup_job (struct job_manager *ctx, flux_jobid_t id)
+{
+    struct job *job = zhashx_lookup (ctx->active_jobs, &id);
+    if (!job)
+        errno = ENOENT;
+    return job;
+}
+
+
+static int emit_dependency_event (flux_plugin_t *p,
+                                  flux_jobid_t id,
+                                  const char *event,
+                                  const char *description)
+{
+    int flags = 0;
+    struct job *job;
+
+    struct jobtap *jobtap = flux_plugin_aux_get (p, "flux::jobtap");
+    if (!jobtap) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (!(job = lookup_job (jobtap->ctx, id)))
+        return -1;
+    if (job->state != FLUX_JOB_STATE_DEPEND) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (!job_dependency_event_valid (job, event, description))
+       return -1;
+    return event_job_post_pack (jobtap->ctx->event,
+                                job,
+                                event,
+                                flags,
+                                "{s:s}",
+                                "description", description);
+}
+
+int flux_jobtap_dependency_add (flux_plugin_t *p,
+                                flux_jobid_t id,
+                                const char *description)
+{
+    return emit_dependency_event (p, id, "dependency-add", description);
+}
+
+int flux_jobtap_dependency_remove (flux_plugin_t *p,
+                                   flux_jobid_t id,
+                                   const char *description)
+{
+    return emit_dependency_event (p, id, "dependency-remove", description);
 }
 
 /*

--- a/src/modules/job-manager/jobtap.c
+++ b/src/modules/job-manager/jobtap.c
@@ -471,6 +471,7 @@ static void jobtap_handle_load_req (struct job_manager *ctx,
     jobtap_error_t error;
     const char *errstr = NULL;
     struct job *job = NULL;
+    zlistx_t *jobs;
 
     if (!(prev = strdup (jobtap_plugin_name (ctx->jobtap->plugin))))
         goto error;
@@ -481,11 +482,14 @@ static void jobtap_handle_load_req (struct job_manager *ctx,
 
     /*  Make plugin aware of all active jobs via job.new callback
      */
-    job = zhashx_first (ctx->active_jobs);
+    jobs = zhashx_values (ctx->active_jobs);
+    zlistx_set_destructor (jobs, NULL);
+    job = zlistx_first (jobs);
     while (job) {
         (void) jobtap_call (ctx->jobtap, job, "job.new", NULL);
-        job = zhashx_next (ctx->active_jobs);
+        job = zlistx_next (jobs);
     }
+    zlistx_destroy (&jobs);
 
     /* Now schedule reprioritize of all jobs
      */

--- a/src/modules/job-manager/jobtap.h
+++ b/src/modules/job-manager/jobtap.h
@@ -66,6 +66,38 @@ int flux_jobtap_reject_job (flux_plugin_t *p,
                             const char *fmt, ...)
                             __attribute__ ((format (printf, 3, 4)));
 
+
+/*  Add a job dependency to a job with the given description. The dependency
+ *   will keep the job in the DEPEND state until it is removed later via the
+ *   flux_jobtap_dependency_remove() function.
+ *
+ *  This function is only valid from the job.state.depend callback.
+ *
+ *  A job dependency may only be added to a job once.
+ *
+ *  Returns 0 on success, or -1 on error with errno set:
+ *   - ENOENT: job 'id' not found
+ *   - EEXIST: dependency 'description' has already been used
+ *   - EINVAL: invalid argument
+ *
+ */
+int flux_jobtap_dependency_add (flux_plugin_t *p,
+                                flux_jobid_t id,
+                                const char *description);
+
+/*  Remove a currently active job dependency with the given description.
+ *   Once all outstanding job dependencies have been removed, then the job
+ *   will proceed out of the DEPEND state.
+ *
+ *  Returns 0 on success, -1 on failure with errno set:
+ *   ENOENT: job 'id' not found or 'description' is not a current dependency
+ *   EINVAL: invalid argument
+ *
+ */
+int flux_jobtap_dependency_remove (flux_plugin_t *p,
+                                   flux_jobid_t id,
+                                   const char *description);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/modules/job-manager/list.c
+++ b/src/modules/job-manager/list.c
@@ -64,6 +64,14 @@ int list_append_job (json_t *jobs, struct job *job)
             return -1;
         }
     }
+    if (job->dependencies) {
+        json_t *deps = grudgeset_tojson (job->dependencies);
+        if (json_object_set (o, "dependencies", deps) < 0) {
+            json_decref (o);
+            errno = ENOMEM;
+            return -1;
+        }
+    }
     if (json_array_append_new (jobs, o) < 0) {
         json_decref (o);
         errno = ENOMEM;

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -339,7 +339,8 @@ check_LTLIBRARIES = \
 	job-manager/plugins/args.la \
 	job-manager/plugins/test.la \
 	job-manager/plugins/random.la \
-	job-manager/plugins/validate.la
+	job-manager/plugins/validate.la \
+	job-manager/plugins/dependency-test.la
 
 check-prep:
 	$(MAKE) $(check_PROGRAMS) $(check_LTLIBRARIES)
@@ -699,8 +700,14 @@ job_manager_plugins_validate_la_LDFLAGS = \
 job_manager_plugins_validate_la_LIBADD = \
 	$(top_builddir)/src/common/libflux-core.la
 
-
-
+job_manager_plugins_dependency_test_la_SOURCES = \
+	job-manager/plugins/dependency-test.c
+job_manager_plugins_dependency_test_la_CPPFLAGS = \
+	$(test_cppflags)
+job_manager_plugins_dependency_test_la_LDFLAGS = \
+	-module -rpath /nowhere
+job_manager_plugins_dependency_test_la_LIBADD = \
+	$(top_builddir)/src/common/libflux-core.la
 
 hwloc_hwloc_convert_SOURCES = hwloc/hwloc-convert.c
 hwloc_hwloc_convert_CPPFLAGS = $(HWLOC_CFLAGS) $(test_cppflags)

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -127,6 +127,7 @@ TESTSCRIPTS = \
 	t2250-job-archive.t \
 	t2260-job-list.t \
 	t2261-job-list-update.t \
+	t2270-job-dependencies.t \
 	t2300-sched-simple.t \
 	t2302-sched-simple-up-down.t \
 	t2310-resource-module.t \

--- a/t/job-manager/plugins/dependency-test.c
+++ b/t/job-manager/plugins/dependency-test.c
@@ -1,0 +1,90 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* dependency-test.c - keep jobs in depend state and wait for
+ *  an RPC to release
+ */
+
+#include <jansson.h>
+
+#include <flux/core.h>
+#include <flux/jobtap.h>
+
+
+static void remove_cb (flux_t *h,
+                       flux_msg_handler_t *mh,
+                       const flux_msg_t *msg,
+                       void *arg)
+{
+    flux_jobid_t id;
+    const char *description = NULL;
+    flux_plugin_t *p = arg;
+
+    if (flux_request_unpack (msg, NULL,
+                             "{s:I s:s}",
+                             "id", &id,
+                             "description", &description) < 0) {
+        flux_log_error (h, "failed to unpack dependency-test.remove msg");
+        goto error;
+    }
+    if (flux_jobtap_dependency_remove (p, id, description) < 0)
+        goto error;
+    if (flux_respond (h, msg, NULL) < 0)
+        flux_log_error (h, "flux_respond");
+    return;
+error:
+    flux_respond_error (h, msg, errno, flux_msg_last_error (msg));
+}
+
+static int depend_cb (flux_plugin_t *p,
+                      const char *topic,
+                      flux_plugin_arg_t *args,
+                      void *arg)
+{
+    flux_jobid_t id;
+    json_t *deps = NULL;
+    flux_t *h = flux_jobtap_get_flux (p);
+
+    if (flux_plugin_arg_unpack (args,
+                                FLUX_PLUGIN_ARG_IN,
+                                "{s:I s:{s:{s:{s?o}}}}",
+                                "id", &id,
+                                "jobspec",
+                                "attributes",
+                                "system",
+                                "dependencies", &deps) < 0)
+        return -1;
+    if (deps && json_is_array (deps)) {
+        size_t index;
+        json_t *val;
+        json_array_foreach (deps, index, val) {
+            const char *s = json_string_value (val);
+            if (flux_jobtap_dependency_add (p, id, s) < 0) {
+                flux_log_error (h, "jobtap_dependency_add (%s)", s);
+                return -1;
+            }
+        }
+        return 0;
+    }
+    return flux_jobtap_dependency_add (p, id, "dependency-test");
+}
+
+static const struct flux_plugin_handler tab[] = {
+    { "job.state.depend", depend_cb, NULL },
+    { 0 },
+};
+
+int flux_plugin_init (flux_plugin_t *p)
+{
+    if (flux_plugin_register (p, "dependency-test", tab) < 0
+        || flux_jobtap_service_register (p, "remove", remove_cb, p) < 0)
+        return -1;
+    return 0;
+}

--- a/t/job-manager/plugins/test.c
+++ b/t/job-manager/plugins/test.c
@@ -9,13 +9,15 @@ static int cb (flux_plugin_t *p,
                flux_plugin_arg_t *args,
                void *arg)
 {
+    flux_jobid_t id;
     const char *test_mode;
     flux_t *h = flux_jobtap_get_flux (p);
 
     /*  Get test-mode argument from jobspec
      */
     if (flux_plugin_arg_unpack (args, FLUX_PLUGIN_ARG_IN,
-                                "{s:{s:{s:{s:{s:s}}}}}",
+                                "{s:I s:{s:{s:{s:{s:s}}}}}",
+                                "id", &id,
                                 "jobspec",
                                  "attributes",
                                   "system",
@@ -80,6 +82,9 @@ static int cb (flux_plugin_t *p,
                                   FLUX_PLUGIN_ARG_OUT|FLUX_PLUGIN_ARG_UPDATE,
                                   "{s:i}",
                                   "priority", 42);
+        }
+        if (strcmp (test_mode, "sched: dependency-add") == 0) {
+            return flux_jobtap_dependency_add (p, id, "foo");
         }
     }
     else if (strcmp (topic, "job.priority.get") == 0) {

--- a/t/t2270-job-dependencies.t
+++ b/t/t2270-job-dependencies.t
@@ -1,0 +1,109 @@
+#!/bin/sh
+
+test_description='Test job dependencies'
+
+. $(dirname $0)/sharness.sh
+
+test_under_flux 4 job
+
+flux setattr log-stderr-level 1
+
+PLUGINPATH=${FLUX_BUILD_DIR}/t/job-manager/plugins/.libs
+
+test_expect_success 'create dep-remove.py' '
+	cat <<-EOF >dep-remove.py
+	import flux
+	from flux.job import JobID
+	import sys
+
+	jobid = flux.job.JobID(sys.argv[1])
+	name = sys.argv[2]
+	topic = "job-manager.dependency-test.remove"
+	print(flux.Flux().rpc(topic, {"id": jobid, "description": name}).get())
+	EOF
+'
+test_expect_success 'job-manager: load dependency-test plugin' '
+	flux jobtap load ${PLUGINPATH}/dependency-test.so
+'
+test_expect_success 'job-manager: dependency-test plugin is working' '
+	jobid=$(flux mini submit hostname) &&
+	flux job wait-event -t 15 -m description=dependency-test \
+		${jobid} dependency-add &&
+	test $(flux jobs -no {state} ${jobid}) = DEPEND &&
+	flux python dep-remove.py ${jobid} dependency-test &&
+	flux job wait-event -t 15 -m description=dependency-test \
+		${jobid} dependency-remove &&
+	flux job wait-event -vt 15 ${jobid} clean
+'
+test_expect_success 'job dependencies are available in listing tools' '
+	jobid=$(flux mini submit \
+		--setattr=system.dependencies="[\"foo\"]" \
+		hostname) &&
+	flux job wait-event -t 15 -m description=foo ${jobid} dependency-add &&
+	flux jobs -o {id}:{dependencies} &&
+	test "$(flux jobs -no {dependencies} ${jobid})" = "foo" &&
+	flux job list | grep "dependencies.*foo" &&
+	${FLUX_BUILD_DIR}/t/job-manager/list-jobs | grep "dependencies.*foo" &&
+	flux python dep-remove.py ${jobid} foo &&
+	flux job wait-event -vt 15 ${jobid} clean
+'
+test_expect_success 'multiple job dependencies works' '
+	jobid=$(flux mini submit \
+		--setattr=system.dependencies="[\"foo\",\"bar\"]" \
+		hostname) &&
+	flux job wait-event -t 15 -m description=bar ${jobid} dependency-add &&
+	flux jobs -o {id}:{dependencies} &&
+	test "$(flux jobs -no {dependencies} ${jobid})" = "foo,bar" &&
+	flux python dep-remove.py ${jobid} bar &&
+	flux jobs -o {id}:{dependencies} &&
+	test "$(flux jobs -no {dependencies} ${jobid})" = "foo" &&
+	flux python dep-remove.py ${jobid} foo &&
+	flux job wait-event -vt 15 ${jobid} clean
+'
+test_expect_success 'multiple dependency-add with same description is ignored' '
+	jobid=$(flux mini submit \
+		--setattr=system.dependencies="[\"bar\",\"bar\"]" \
+		hostname) &&
+	flux job wait-event -t 15 -m description=bar ${jobid} dependency-add &&
+	flux job eventlog ${jobid} &&
+	flux jobs -o {id}:{dependencies} ${jobid} &&
+	test "$(flux jobs -no {dependencies} ${jobid})" = "bar" &&
+	flux python dep-remove.py ${jobid} bar &&
+	flux job wait-event -vt 15 ${jobid} clean
+'
+
+test_expect_success 'invalid dependency-remove is ignored' '
+	jobid=$(flux mini submit \
+		--setattr=system.dependencies="[\"bar\"]" \
+		hostname) &&
+	flux job wait-event -t 15 -m description=bar ${jobid} dependency-add &&
+	test_must_fail flux python dep-remove.py ${jobid} foo  &&
+	flux job eventlog ${jobid} &&
+	flux jobs -o {id}:{dependencies} ${jobid} &&
+	test "$(flux jobs -no {dependencies} ${jobid})" = "bar" &&
+	flux python dep-remove.py ${jobid} bar &&
+	flux job wait-event -vt 15 ${jobid} clean &&
+	test "$(flux jobs -no {dependencies:h} ${jobid})" = "-"
+'
+test_expect_success 'dependencies are re-established after restart' '
+	jobid=$(flux mini submit \
+		--setattr=system.dependencies="[\"foo\",\"bar\"]" \
+		hostname) &&
+	flux job wait-event -t 15 -m description=bar ${jobid} dependency-add &&
+	flux jobs -o {id}:{dependencies} &&
+	flux python dep-remove.py ${jobid} bar &&
+	flux jobs -o {id}:{dependencies} &&
+	flux module remove job-list &&
+	flux module reload job-manager &&
+	flux jobtap load ${PLUGINPATH}/dependency-test.so &&
+	flux module load job-list &&
+	flux module reload -f sched-simple &&
+	flux module reload -f job-exec &&
+	flux job eventlog ${jobid} &&
+	flux jobs -o {id}:{dependencies} &&
+	test "$(flux jobs -no {dependencies} ${jobid})" = "foo" &&
+	flux python dep-remove.py ${jobid} foo &&
+	flux jobs -o {id}:{dependencies} &&
+	flux job wait-event -vt 15 ${jobid} clean
+'
+test_done


### PR DESCRIPTION
This is WIP that adds support for `dependency-add`/`dependency-remove` events in the job manager, with hooks for jobtap plugins to generate these events.

This is not too useful yet since only one jobtap plugin can be loaded simultaneously. However it can be used to develop proof-of-concept job dependency plugins, which could then be used once jobtap supports a suite of plugins.

Still todo here is to add discovery of dependencies to `job-list` so outstanding dependencies can be listed, and doc updates.


Example: The following is a plugin that sets a delay if a job has `attributes.system.delay-start` set:

```c
#include <stdio.h>
#include <jansson.h>
#include <czmq.h>

#include <flux/core.h>
#include <flux/jobtap.h>

static flux_future_t *flux_future_timer (flux_reactor_t *r,
                                  double timeout,
                                  flux_continuation_f cb,
                                  void *arg)
{
    flux_future_t *f = flux_future_create (NULL, NULL);
    flux_future_set_reactor (f, r);
    if (flux_future_then (f, timeout, cb, arg) < 0) {
        flux_future_destroy (f);
        return NULL;
    }
    return f;
}

static int cache_future (flux_plugin_t *p, flux_future_t *f)
{
    char key [24];
    (void) sprintf (key, "%p", f);
    return flux_plugin_aux_set (p, key, f, (flux_free_f) flux_future_destroy);
}

static void free_future (flux_plugin_t *p, flux_future_t *f)
{
    char key [24];
    (void) sprintf (key, "%p", f);
    flux_plugin_aux_set (p, key, NULL, NULL);
}

static void timer_cb (flux_future_t *f, void *arg)
{
    flux_plugin_t *p = arg;
    flux_jobid_t *idptr = flux_future_aux_get (f, "jobid");
    if (!p || !idptr)
        return;
    flux_jobtap_dependency_remove (p, *idptr, "delay-start");
    free_future (p, f);
}

static int depend_cb (flux_plugin_t *p,
               const char *topic,
               flux_plugin_arg_t *args,
               void *arg)
{
    flux_jobid_t *idptr = NULL;
    flux_reactor_t *r;
    flux_future_t *f = NULL;
    double delay = 0.;
    flux_t *h = flux_jobtap_get_flux (p);

    if (!(idptr = calloc (1, sizeof (*idptr))))
        return -1;

    flux_plugin_arg_unpack (args,
                            FLUX_PLUGIN_ARG_IN,
                            "{s:I s:{s:{s:{s?F}}}}",
                            "id", idptr,
                            "jobspec",
                            "attributes",
                            "system",
                            "delay-start",
                            &delay);

    if (delay) {
        flux_jobtap_dependency_add (p, *idptr, "delay-start");
        if (!h
            || !(r = flux_get_reactor (h))
            || !(f = flux_future_timer (r, delay, timer_cb, p))
            || cache_future (p, f) < 0
            || flux_future_aux_set (f, "jobid", idptr, free) < 0) {
            fprintf (stderr, "failed to set delay dependency on job\n");
            flux_future_destroy (f);
            free (idptr);
            flux_jobtap_dependency_remove (p, *idptr, "delay-start");
            return -1;
        }
    }
    return 0;
}

int flux_plugin_init (flux_plugin_t *p)
{
    flux_plugin_set_name (p, "delay-start");
    return flux_plugin_add_handler (p, "job.state.depend", depend_cb, NULL);
}
```

When loaded, jobs with that attribute are delayed in the DEPEND state:

```
ƒ(s=1,d=0,builddir) grondo@asp:~/git/f.git$ flux jobtap load test.so
Loaded:
delay-start
Previously loaded:
builtin.priority.default
ƒ(s=1,d=0,builddir) grondo@asp:~/git/f.git$ flux mini run -vvv --setattr=system.delay-start=3 hostname
jobid: ƒP8ewA5u
0.000s: job.submit {"userid":1000,"urgency":16,"flags":0}
0.013s: job.dependency-add {"name":"delay-start"}
3.016s: job.dependency-remove {"name":"delay-start"}
3.016s: job.depend
3.016s: job.priority {"priority":16}
3.018s: job.alloc {"annotations":{"sched":{"resource_summary":"rank0/core0"}}}
3.055s: job.start
3.019s: exec.init
3.020s: exec.starting
3.085s: exec.shell.init {"leader-rank":0,"size":1,"service":"1000-shell-842535010304"}
3.130s: exec.shell.start {"task-count":1}
asp
3.162s: exec.complete {"status":0}
3.162s: exec.done
3.162s: job.finish {"status":0}
3.165s: job.release {"ranks":"all","final":true}
3.166s: job.free
3.166s: job.clean
```

Fixes issue #3557