### PR TITLE
Python: asyncio support

### DIFF
--- a/src/bindings/python/flux/Makefile.am
+++ b/src/bindings/python/flux/Makefile.am
@@ -38,7 +38,9 @@ nobase_fluxpy_PYTHON = \
 	resource/ResourceSet.py \
 	hostlist.py \
 	idset.py \
-	progress.py
+	progress.py \
+	asyncio/__init__.py \
+	asyncio/job.py
 
 if HAVE_FLUX_SECURITY
 nobase_fluxpy_PYTHON += security.py

--- a/src/bindings/python/flux/asyncio/__init__.py
+++ b/src/bindings/python/flux/asyncio/__init__.py
@@ -1,0 +1,71 @@
+"""Integration of Flux's event loop model with Python's own asyncio event loop.
+
+Basic usage: start an asyncio event loop (e.g. with `asyncio.run()`), call
+`start_flux_loop(flux.Flux())`, and then invoke the coroutines provided
+by this package.
+"""
+
+import asyncio
+
+import flux.constants
+
+
+def start_flux_loop(handle):
+    """Start the Flux-asyncio event loop.
+
+    This function must be called before any Flux coroutines and
+    with an active asyncio event loop.
+
+    :param handle: a `flux.Flux` instance. This handle will be used
+        for all Flux coroutines in the current loop.
+    :raises RuntimeError: if the Flux-asyncio event loop is active
+        (i.e. this function has already been called)
+    """
+    if hasattr(asyncio.get_event_loop(), "_flux_handle"):
+        raise RuntimeError("`start_flux_loop` already called")
+    loop = asyncio.get_event_loop()
+    file_desc = handle.pollfd()
+    # pylint: disable=protected-access
+    loop._flux_handle = handle
+    loop._flux_pollfd = file_desc
+    loop.add_reader(file_desc, _run_flux_reactor)
+
+
+def stop_flux_loop():
+    """Stop the Flux-asyncio event loop."""
+    loop = asyncio.get_event_loop()
+    try:
+        # pylint: disable=protected-access
+        loop.remove_reader(loop._flux_pollfd)
+        del loop._flux_handle
+        del loop._flux_pollfd
+    except AttributeError:
+        raise RuntimeError("`start_flux_loop` not called")
+
+
+def _get_loop_flux_handle():
+    try:
+        # pylint: disable=protected-access
+        return asyncio.get_event_loop()._flux_handle
+    except AttributeError:
+        raise RuntimeError("`start_flux_loop` not called")
+
+
+def _flux_fatal(handle, msg):
+    handle.fatal_error(msg)
+    raise RuntimeError(msg)
+
+
+def _run_flux_reactor():
+    """Run the Flux reactor and schedule another reactor run."""
+    # pylint: disable=no-member
+    handle = _get_loop_flux_handle()
+    events = handle.pollevents()
+    if events & flux.constants.FLUX_POLLERR:
+        _flux_fatal(handle, "Flux pollevents returned POLLERR")
+    if events & flux.constants.FLUX_POLLIN:
+        returncode = 1  # just set it to something > 0
+        while returncode > 0:
+            returncode = handle.reactor_run(flags=flux.constants.FLUX_REACTOR_NOWAIT)
+        if returncode < 0:
+            _flux_fatal(handle, "Reactor run failed")

--- a/src/bindings/python/flux/asyncio/job.py
+++ b/src/bindings/python/flux/asyncio/job.py
@@ -1,0 +1,106 @@
+"""Flux-asyncio integration for ``flux.job`` functions."""
+
+import asyncio
+
+import flux.job
+from flux.asyncio import _get_loop_flux_handle
+
+
+async def _asyncio_flux_wrapper(flux_func, getter, args, kwargs):
+    """Convert a flux async function into a coroutine.
+
+    :param flux_func: the function to wrap. Should return a Flux future
+    :param getter: the function to get the result of the Flux future. If None,
+        use future.get()
+    :param args: args for flux_func
+    :param kwargs: kwargs for flux_func
+    """
+    handle = _get_loop_flux_handle()
+    asyncio_fut = asyncio.get_event_loop().create_future()
+    if getter is None:
+        callback = lambda flux_fut: asyncio_fut.set_result(flux_fut.get())
+    else:
+        callback = lambda flux_fut: asyncio_fut.set_result(getter(flux_fut))
+    flux_func(handle, *args, **kwargs).then(callback)
+    return await asyncio_fut
+
+
+async def submit(*args, **kwargs):
+    """Submit a new job and return the job ID.
+
+    Has the same signature as ``flux.job.submit``, minus the first argument.
+
+    :raises RuntimeError: if the Flux-asyncio event loop is not active.
+    """
+    return await _asyncio_flux_wrapper(
+        flux.job.submit_async, flux.job.submit_get_id, args, kwargs
+    )
+
+
+async def cancel(*args, **kwargs):
+    """Cancel a running or pending job.
+
+    Has the same signature as ``flux.job.cancel``, minus the first argument.
+
+    :raises RuntimeError: if the Flux-asyncio event loop is not active.
+    """
+    return await _asyncio_flux_wrapper(flux.job.cancel_async, None, args, kwargs)
+
+
+async def kill(*args, **kwargs):
+    """Send a signal to a running job.
+
+    Has the same signature as ``flux.job.kill``, minus the first argument.
+
+    :raises RuntimeError: if the Flux-asyncio event loop is not active.
+    """
+    return await _asyncio_flux_wrapper(flux.job.kill_async, None, args, kwargs)
+
+
+async def wait(*args, **kwargs):
+    """Wait for a job to complete and return a ``flux.job.JobWaitResult``.
+
+    A lighter-weight function than ``result``, this function requires that
+    the specified job be waitable (``flux.job.submit(..., waitable=True)``).
+
+    Has the same signature as ``flux.job.wait``, minus the first argument.
+
+    :raises RuntimeError: if the Flux-asyncio event loop is not active.
+    """
+    return await _asyncio_flux_wrapper(
+        flux.job.wait_async, flux.job.wait_get_status, args, kwargs
+    )
+
+
+async def result(*args, **kwargs):
+    """Wait for a job to complete and return a ``flux.job.JobInfo``.
+
+    A more heavyweight function than ``wait``, this function does not require that
+    the specified job be waitable (``flux.job.submit(..., waitable=some_boolean)``).
+
+    Has the same signature as ``flux.job.result``, minus the first argument.
+
+    :raises RuntimeError: if the Flux-asyncio event loop is not active.
+    """
+    return await _asyncio_flux_wrapper(
+        flux.job.result_async, flux.job.JobResultFuture.get_info, args, kwargs
+    )
+
+
+async def event_watch(*args, **kwargs):
+    """Asynchronous generator that yields `flux.job.EventLogEvent` instances.
+
+    Accepts the same arguments as ``flux.job.event_watch``, minus the first argument.
+
+    :raises RuntimeError: if the Flux-asyncio event loop is not active.
+    """
+    handle = _get_loop_flux_handle()
+    queue = asyncio.Queue()
+    flux.job.event_watch_async(handle, *args, **kwargs).then(
+        lambda flux_fut: queue.put_nowait(flux_fut.get_event())
+    )
+    while True:
+        event = await queue.get()
+        if event is None:
+            return
+        yield event

--- a/src/bindings/python/flux/job/__init__.py
+++ b/src/bindings/python/flux/job/__init__.py
@@ -15,7 +15,14 @@ from flux.job.kill import kill_async, kill, cancel_async, cancel
 from flux.job.submit import submit_async, submit, submit_get_id
 from flux.job.info import JobInfo, JobInfoFormat
 from flux.job.list import job_list, job_list_inactive, job_list_id, JobList
-from flux.job.wait import wait_async, wait, wait_get_status, result_async, result
+from flux.job.wait import (
+    wait_async,
+    wait,
+    wait_get_status,
+    result_async,
+    result,
+    JobResultFuture,
+)
 from flux.job.event import (
     event_watch_async,
     event_watch,

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -191,6 +191,7 @@ TESTSCRIPTS = \
 	python/t0021-idset.py \
 	python/t0022-resource-set.py \
 	python/t0023-executor.py \
+	python/t0024-asyncio.py \
 	python/t1000-service-add-remove.py
 
 if HAVE_FLUX_SECURITY

--- a/t/python/t0010-job.py
+++ b/t/python/t0010-job.py
@@ -233,6 +233,7 @@ class TestJob(unittest.TestCase):
         self.assertEqual(len(events), 9)
         self.assertEqual(events[0], "submit")
         self.assertEqual(events[-1], "clean")
+        self.assertLess(set(events), job.MAIN_EVENTS)
 
     def test_20_002_job_event_watch_no_autoreset(self):
         jobid = job.submit(self.fh, JobspecV1.from_command(["sleep", "0"]))
@@ -279,6 +280,7 @@ class TestJob(unittest.TestCase):
             self.assertTrue(hasattr(event, "context"))
             self.assertIs(type(event.timestamp), float)
             self.assertIs(type(event.name), str)
+            self.assertIn(event.name, job.MAIN_EVENTS)
             self.assertIs(type(event.context), dict)
             events.append(event.name)
         self.assertEqual(len(events), 9)

--- a/t/python/t0024-asyncio.py
+++ b/t/python/t0024-asyncio.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+
+"""Tests for the flux.asyncio package."""
+
+###############################################################
+# Copyright 2014 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+import os
+import unittest
+import asyncio
+
+import flux.job
+import flux.constants
+import flux.asyncio.job
+
+
+def __flux_size():
+    return 1
+
+
+def test_coroutine(coro):
+    asyncio.get_event_loop().run_until_complete(_wrap_coroutine(coro))
+
+
+async def _wrap_coroutine(coro):
+    flux.asyncio.start_flux_loop(flux.Flux())
+    try:
+        result = await coro
+    finally:
+        flux.asyncio.stop_flux_loop()
+    return result
+
+
+class TestFluxAsyncio(unittest.TestCase):
+    """Tests for the flux.asyncio package."""
+
+    def test_submit_success(self):
+        test_coroutine(self._test_submit_success())
+
+    async def _test_submit_success(self):
+        jobspec = flux.job.JobspecV1.from_command(["true"])
+        jobid = await flux.asyncio.job.submit(jobspec, waitable=True)
+        self.assertGreater(jobid, 0)
+        exit_status = await flux.asyncio.job.wait(jobid)
+        self.assertTrue(exit_status.success)
+        self.assertEqual(exit_status.jobid, jobid)
+
+    def test_submit_failure(self):
+        test_coroutine(self._test_submit_failure())
+
+    async def _test_submit_failure(self):
+        jobspec = flux.job.JobspecV1.from_command(["false"])
+        jobid = await flux.asyncio.job.submit(jobspec)
+        self.assertGreater(jobid, 0)
+        job_info = await flux.asyncio.job.result(jobid)
+        self.assertEqual(job_info.id, jobid)
+        self.assertEqual(job_info.returncode, 1)
+        self.assertGreater(job_info.t_run, 0)
+
+    def test_submit_cancel(self):
+        test_coroutine(self._test_submit_cancel())
+
+    async def _test_submit_cancel(self):
+        jobspec = flux.job.JobspecV1.from_command(["sleep", "2"])
+        jobid = await flux.asyncio.job.submit(jobspec, waitable=True)
+        self.assertGreater(jobid, 0)
+        await flux.asyncio.job.cancel(jobid)
+        exit_status = await flux.asyncio.job.wait(jobid)
+        self.assertFalse(exit_status.success)
+        self.assertEqual(exit_status.jobid, jobid)
+
+    def test_submit_events(self):
+        test_coroutine(self._test_submit_events())
+
+    async def _test_submit_events(self):
+        jobspec = flux.job.JobspecV1.from_command(["true"])
+        jobid = await flux.asyncio.job.submit(jobspec)
+        self.assertGreater(jobid, 0)
+        async for event in flux.asyncio.job.event_watch(jobid):
+            self.assertIsInstance(event, flux.job.EventLogEvent)
+            if event.name == "finish":
+                self.assertTrue(os.WIFEXITED(event.context["status"]))
+                self.assertEqual(0, os.WEXITSTATUS(event.context["status"]))
+            if event.name == "exception":
+                raise ValueError(event)
+
+
+if __name__ == "__main__":
+    from subflux import rerun_under_flux
+
+    if rerun_under_flux(size=__flux_size(), personality="job"):
+        from pycotap import TAPTestRunner
+
+        unittest.main(testRunner=TAPTestRunner())


### PR DESCRIPTION
This is a draft I just wanted to get some feedback on before I continue working on it too much more. Right now what it adds is fairly minimal: [asyncio](https://docs.python.org/3/library/asyncio.html) support for a few of the ``flux.job`` functions. It's hard to explain what you don't understand very well, so I won't even try to explain asyncio. But basically what it gets Flux users is that they can make their asynchronous code look and feel a little more synchronous without losing performance. Callbacks on Flux futures are replaced with `async/await` syntax.

The good side is that the additional asyncio code is really minimal, at least so far. The bad side is that there would be three ways to submit and manage jobs: the native callback-based event loop, `FluxExecutor`, and then the new `async/await` asyncio stuff.

Here's what the classic [bulksubmit](https://github.com/flux-framework/flux-workflow-examples/tree/master/async-bulk-job-submit) example looks like with the new interface:

```python

import asyncio
import argparse
import time

import flux
import flux.job
import flux.asyncio.job


async def submit_wait(jobspec):
    jobid = await flux.asyncio.job.submit(jobspec, waitable=True)
    return await flux.asyncio.job.wait(jobid)


async def submit_jobs(jobspec, count):
    flux.asyncio.start_flux_loop(flux.Flux())
    results = await asyncio.gather(*(submit_wait(jobspec) for _ in range(count)))
    for job_status in results:
        if not job_status.success:
            raise ValueError()


def main():
    parser = argparse.ArgumentParser(
        description="Submit a command repeatedly using FluxExecutor"
    )
    parser.add_argument(
        "-n",
        "--njobs",
        type=int,
        metavar="N",
        help="Set the total number of jobs to run",
        default=100,
    )
    parser.add_argument("command", nargs=argparse.REMAINDER)
    args = parser.parse_args()
    if not args.command:
        args.command = ["true"]
    jobspec = flux.job.JobspecV1.from_command(args.command)
    t0 = time.perf_counter()
    asyncio.run(submit_jobs(jobspec, args.njobs), debug=True)
    dt = time.perf_counter() - t0
    print(f"Ran {args.njobs} jobs in {dt:.1f}s. {args.njobs / dt:.1f} job/s")


if __name__ == '__main__':
    main()
```

It seems to be pretty speedy, actually: 

```
bash-4.2$ flux-core/src/cmd/flux start python flux-workflow-examples/async-bulk-job-submit/bulksubmit_executor.py -n100
bulksubmit_executor: submitted 100 jobs in 3.74s. 26.72job/s
bulksubmit_executor: First job finished in about 4.226s
|██████████████████████████████████████████████████████████| 100.0% (13.3 job/s)
bulksubmit_executor: Ran 100 jobs in 7.7s. 13.0 job/s
bash-4.2$ flux-core/src/cmd/flux start python flux_asyncio_test.py -n100
Ran 100 jobs in 4.3s. 23.3 job/s
```

If you like it, I would be happy to expand the covered functions beyond `submit`, `wait`, `cancel`, `kill`, and `event_watch`.

Oh yeah, the usage is that once you start your asyncio event loop and before invoking any Flux awaitables, you call `flux.asyncio.start_flux_loop(flux.Flux())`. After that you're good to go.

Thanks to @dongahn  and @SteVwonder for helping me with this during the hackathon a month or so ago.