### PR TITLE
libflux: add flux_plugin_aux_delete()

### DIFF
--- a/src/common/libflux/plugin.c
+++ b/src/common/libflux/plugin.c
@@ -217,6 +217,11 @@ void *flux_plugin_aux_get (flux_plugin_t *p, const char *key)
     return aux_get (p->aux, key);
 }
 
+void flux_plugin_aux_delete (flux_plugin_t *p, const void *val)
+{
+    return aux_delete (&p->aux, val);
+}
+
 const char *flux_plugin_strerror (flux_plugin_t *p)
 {
     return p->last_error;

--- a/src/common/libflux/plugin.h
+++ b/src/common/libflux/plugin.h
@@ -109,6 +109,9 @@ int flux_plugin_aux_set (flux_plugin_t *p,
  */
 void * flux_plugin_aux_get (flux_plugin_t *p, const char *key);
 
+/*  Delete auxiliary data by value.
+ */
+void flux_plugin_aux_delete (flux_plugin_t *p, const void *val);
 
 /*  Set optional JSON string as load-time config for plugin 'p'.
  */

--- a/src/common/libflux/plugin.h
+++ b/src/common/libflux/plugin.h
@@ -91,7 +91,7 @@ int flux_plugin_register (flux_plugin_t *p,
                           const char *name,
                           const struct flux_plugin_handler t[]);
 
-/*  Associate auxillary data with the plugin handle 'p'. If free_fn is
+/*  Associate auxiliary data with the plugin handle 'p'. If free_fn is
  *   set then this function will be called on the data at plugin
  *   destruction.
  *
@@ -105,7 +105,7 @@ int flux_plugin_aux_set (flux_plugin_t *p,
                          void *val,
                          flux_free_f free_fn);
 
-/*  Get current auxillary data under `key`.
+/*  Get current auxiliary data under `key`.
  */
 void * flux_plugin_aux_get (flux_plugin_t *p, const char *key);
 

--- a/src/common/libflux/test/plugin.c
+++ b/src/common/libflux/test/plugin.c
@@ -111,6 +111,8 @@ void test_invalid_args ()
         "flux_plugin_aux_get (p, NULL) returns EINVAL");
     ok (flux_plugin_aux_get (p, "foo") == NULL && errno == ENOENT,
         "flux_plugin_aux_get (p, 'foo') returns ENOENT");
+    lives_ok ({flux_plugin_aux_delete (p, NULL);},
+        "flux_plugin_aux_delete (p, NULL) doesn't crash");
 
     ok (flux_plugin_add_handler (NULL, "foo.*", foo, NULL) < 0 && errno == EINVAL,
         "flux_plugin_add_handler (NULL, ...) returns EINVAL");

--- a/src/common/libutil/aux.c
+++ b/src/common/libutil/aux.c
@@ -146,6 +146,22 @@ int aux_set (struct aux_item **head,
     return 0;
 }
 
+void aux_delete (struct aux_item **head, const void *val)
+{
+    struct aux_item *item;
+
+    if (head && val) {
+        while ((item = *head)) {
+            if (item->val == val) {
+                *head = item->next;
+                aux_item_destroy (item);
+                break;
+            }
+            head = &item->next;
+        }
+    }
+}
+
 /* Destroy aux list 'head', calling destructors on items that have them.
  */
 void aux_destroy (struct aux_item **head)

--- a/src/common/libutil/aux.h
+++ b/src/common/libutil/aux.h
@@ -36,6 +36,8 @@ struct aux_item;
 int aux_set (struct aux_item **aux, const char *key,
              void *val, aux_free_f free_fn);
 
+void aux_delete (struct aux_item **aux, const void *val);
+
 void *aux_get (struct aux_item *aux, const char *key);
 
 void aux_destroy (struct aux_item **aux);

--- a/src/common/libutil/test/aux.c
+++ b/src/common/libutil/test/aux.c
@@ -176,6 +176,38 @@ void simple_test (void)
         "aux_destroy aux=NULL doesn't crash");
 }
 
+void test_delete (void)
+{
+    struct aux_item *aux = NULL;
+    int items[8];
+    int i;
+
+    for (i = 0; i < 8; i++)
+        if (aux_set (&aux, NULL, &items[i], myfree) < 0)
+            BAIL_OUT ("aux_set failed on item %d", i);
+
+    myfree_count = 0;
+    aux_delete (NULL, "foo");
+    ok (myfree_count == 0,
+        "aux_delete aux=NULL does nothing");
+
+    myfree_count = 0;
+    aux_delete (&aux, NULL);
+    ok (myfree_count == 0,
+        "aux_delete val=NULL does nothing");
+
+    myfree_count = 0;
+    aux_delete (&aux, &i);
+    ok (myfree_count == 0,
+        "aux_delete val=unknown does nothing");
+
+    myfree_count = 0;
+    for (i = 0; i < 8; i++)
+        aux_delete (&aux, &items[i]);
+    ok (myfree_count == 8,
+        "aux_delete works with valid pointer");
+}
+
 int main (int argc, char *argv[])
 {
     plan (NO_PLAN);
@@ -183,6 +215,7 @@ int main (int argc, char *argv[])
     simple_test ();
     aux_destroy_no_get_self ();
     aux_destroy_set_ok ();
+    test_delete ();
 
     done_testing ();
 


### PR DESCRIPTION
Per discussion in #3561, make `aux_delete()` available in the aux base that lets an anonymous item be removed by value.  Its destructor is called, if defined.

Add corresponding method to the `flux_plugin` class.