### PR TITLE
WIP: add flux job exec

### DIFF
--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -94,6 +94,7 @@ flux_start_LDADD = \
 
 flux_job_LDADD = \
 	$(fluxcmd_ldadd) \
+	$(top_builddir)/src/common/libjob/libjob.la \
 	$(top_builddir)/src/shell/libmpir.la \
 	$(top_builddir)/src/common/libdebugged/libdebugged.la \
 	$(top_builddir)/src/common/libterminus/libterminus.la

--- a/src/common/libflux/barrier.c
+++ b/src/common/libflux/barrier.c
@@ -80,13 +80,21 @@ flux_future_t *flux_barrier (flux_t *h, const char *name, int nprocs)
     if (!name && !(name = generate_unique_name (h)))
         return NULL;
 
-    return flux_rpc_pack (h,
-                          "barrier.enter",
-                          FLUX_NODEID_ANY,
-                          0,
-                          "{s:s s:i}",
-                           "name", name,
-                           "nprocs", nprocs);
+    if (nprocs == 1) {
+        flux_future_t *f = flux_future_create (NULL, NULL);
+        if (f)
+            flux_future_fulfill (f, NULL, NULL);
+        return f;
+    }
+    else {
+        return flux_rpc_pack (h,
+                              "barrier.enter",
+                              FLUX_NODEID_ANY,
+                              0,
+                              "{s:s s:i}",
+                               "name", name,
+                               "nprocs", nprocs);
+    }
 }
 
 /*

--- a/src/common/libflux/barrier.c
+++ b/src/common/libflux/barrier.c
@@ -12,9 +12,6 @@
 #include "config.h"
 #endif
 #include <flux/core.h>
-#include <stdbool.h>
-
-#include "src/common/libutil/xzmalloc.h"
 
 typedef struct {
     const char *id;
@@ -43,15 +40,11 @@ static libbarrier_ctx_t *getctx (flux_t *h)
             errno = EINVAL;
             goto error;
         }
-        if (!(ctx = calloc (1, sizeof (*ctx)))) {
-            errno = ENOMEM;
+        if (!(ctx = calloc (1, sizeof (*ctx))))
             goto error;
-        }
         ctx->name_len = strlen (id) + 16;
-        if (!(ctx->name = calloc (1, ctx->name_len))) {
-            errno = ENOMEM;
+        if (!(ctx->name = calloc (1, ctx->name_len)))
             goto error;
-        }
         ctx->id = id;
         if (flux_aux_set (h, "flux::barrier_client", ctx, freectx) < 0)
             goto error;

--- a/src/common/libjob/Makefile.am
+++ b/src/common/libjob/Makefile.am
@@ -23,11 +23,14 @@ libjob_la_SOURCES = \
 	sign_none.c \
 	sign_none.h \
 	job_hash.c \
-	job_hash.h
+	job_hash.h \
+	specutil.c \
+	specutil.h
 
 TESTS = \
 	test_job.t \
-	test_sign_none.t
+	test_sign_none.t \
+	test_specutil.t
 
 check_PROGRAMS = \
         $(TESTS)
@@ -61,3 +64,7 @@ test_job_t_LDADD = $(test_ldadd) $(LIBDL)
 test_sign_none_t_SOURCES = test/sign_none.c
 test_sign_none_t_CPPFLAGS = $(test_cppflags)
 test_sign_none_t_LDADD = $(test_ldadd) $(LIBDL)
+
+test_specutil_t_SOURCES = test/specutil.c
+test_specutil_t_CPPFLAGS = $(test_cppflags)
+test_specutil_t_LDADD = $(test_ldadd) $(LIBDL)

--- a/src/common/libjob/specutil.c
+++ b/src/common/libjob/specutil.c
@@ -1,0 +1,444 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <string.h>
+#include <jansson.h>
+#include <errno.h>
+
+#include "src/common/libutil/errno_safe.h"
+
+#include "specutil.h"
+
+json_t *specutil_argv_create (int argc, char **argv)
+{
+    int i;
+    json_t *a, *o;
+
+    if (!(a = json_array ()))
+        goto nomem;
+    for (i = 0; i < argc; i++) {
+        if (!(o = json_string (argv[i])) || json_array_append_new (a, o) < 0) {
+            ERRNO_SAFE_WRAP (json_decref, o);
+            goto nomem;
+        }
+    }
+    return a;
+nomem:
+    ERRNO_SAFE_WRAP (json_decref, a);
+    return NULL;
+}
+
+int specutil_env_set (json_t *o, const char *name, const char *value)
+{
+    json_t *val;
+
+    if (!(val = json_string (value)))
+        goto nomem;
+    if (json_object_set_new (o, name, val) < 0)
+        goto nomem;
+    return 0;
+nomem:
+    json_decref (val);
+    errno = ENOMEM;
+    return -1;
+}
+
+int specutil_env_unset (json_t *o, const char *name)
+{
+    (void)json_object_del (o, name);
+    return 0;
+}
+
+int specutil_env_put (json_t *o, const char *entry)
+{
+    char *cpy;
+    char *cp;
+    int rc = -1;
+
+    if (!(cpy = strdup (entry)))
+        return -1;
+    if ((cp = strchr (cpy, '=')))
+        *cp++ = '\0';
+    if (!cp || cp == cpy) {
+        errno = EINVAL;
+        goto done;
+    }
+    rc = specutil_env_set (o, cpy, cp);
+done:
+    ERRNO_SAFE_WRAP (free, cpy);
+    return rc;
+}
+
+json_t *specutil_env_create (char **env)
+{
+    int i;
+    json_t *o;
+
+    if (!(o = json_object ())) {
+        errno = ENOMEM;
+        return NULL;
+    }
+    for (i = 0; env[i] != NULL; i++) {
+        if (specutil_env_put (o, env[i]) < 0)
+            goto error;
+    }
+    return o;
+error:
+    ERRNO_SAFE_WRAP (json_decref, o);
+    return NULL;
+}
+
+/* Recursively set path=val in object 'o'.
+ * A period '.' is interpreted as a path separator.
+ * Path components are created as needed.
+ * N.B. 'path' is modified.
+ */
+static int object_set_path (json_t *o, char *path, json_t *val)
+{
+    char *cp;
+    json_t *dir;
+
+    if ((cp = strchr (path, '.'))) {
+        *cp++ = '\0';
+        if (strlen (path) == 0) {
+            errno = EINVAL;
+            return -1;
+        }
+        if (!(dir = json_object_get (o, path))) {
+            if (!(dir = json_object ()))
+                goto nomem;
+            if (json_object_set_new (o, path, dir) < 0) {
+                json_decref (dir);
+                goto nomem;
+            }
+        }
+        return object_set_path (dir, cp, val);
+    }
+
+    if (strlen (path) == 0) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (json_object_set (o, path, val) < 0)
+        goto nomem;
+    return 0;
+nomem:
+    errno = ENOMEM;
+    return -1;
+}
+
+/* Recursively delete path in object 'o'.
+ * A period '.' is interpreted as a path separator.
+ * If the target or path leading to it does not exist, return succces.
+ * N.B. 'path' is modified.
+ */
+int object_del_path (json_t *o, char *path)
+{
+    char *cp;
+    json_t *dir;
+
+    if ((cp = strchr (path, '.'))) {
+        *cp++ = '\0';
+        if (strlen (path) == 0) {
+            errno = EINVAL;
+            return -1;
+        }
+        if (!(dir = json_object_get (o, path)))
+            return 0;
+        return object_del_path (dir, cp);
+    }
+
+    if (strlen (path) == 0) {
+        errno = EINVAL;
+        return -1;
+    }
+    (void)json_object_del (o, path);
+    return 0;
+}
+
+static json_t *object_get_path (json_t *o, char *path)
+{
+    char *cp;
+    json_t *dir;
+    json_t *val;
+
+    if ((cp = strchr (path, '.'))) {
+        *cp++ = '\0';
+        if (strlen (path) == 0) {
+            errno = EINVAL;
+            return NULL;
+        }
+        if (!(dir = json_object_get (o, path))) {
+            errno = ENOENT;
+            return NULL;
+        }
+        return object_get_path (dir, cp);
+    }
+
+    if (strlen (path) == 0) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (!(val = json_object_get (o, path))) {
+        errno = ENOENT;
+        return NULL;
+    }
+    return val;
+}
+
+int specutil_attr_del (json_t *o, const char *path)
+{
+    char *cpy;
+    int rc;
+
+    if (!o || !path) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (!(cpy = strdup (path)))
+        return -1;
+    rc = object_del_path (o, cpy);
+    ERRNO_SAFE_WRAP (free, cpy);
+    return rc;
+}
+
+int specutil_attr_set (json_t *o, const char *path, json_t *val)
+{
+    char *cpy;
+    int rc;
+
+    if (!o || !path || !val) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (!(cpy = strdup (path)))
+        return -1;
+    rc = object_set_path (o, cpy, val);
+    ERRNO_SAFE_WRAP (free, cpy);
+    return rc;
+}
+
+json_t *specutil_attr_get (json_t *o, const char *path)
+{
+    char *cpy;
+    json_t *val;
+
+    if (!o || !path) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (!(cpy = strdup (path)))
+        return NULL;
+    val = object_get_path (o, cpy);
+    ERRNO_SAFE_WRAP (free, cpy);
+    return val;
+}
+
+
+static int specutil_attr_vpack (json_t *o,
+                                const char *path,
+                                const char *fmt,
+                                va_list ap)
+{
+    json_t *value;
+    int rc;
+
+    if (!fmt || !(value = json_vpack_ex (NULL, 0, fmt, ap))) {
+        errno = EINVAL;
+        return -1;
+    }
+    rc = specutil_attr_set (o, path, value);
+    ERRNO_SAFE_WRAP (json_decref, value);
+    return rc;
+}
+
+int specutil_attr_pack (json_t *o, const char *path, const char *fmt, ...)
+{
+    va_list ap;
+    int rc;
+
+    va_start (ap, fmt);
+    rc = specutil_attr_vpack (o, path, fmt, ap);
+    va_end (ap);
+    return rc;
+}
+
+static int specutil_attr_system_check (json_t *o, const char **errtxt)
+{
+    const char *key;
+    json_t *value;
+
+    json_object_foreach (o, key, value) {
+        if (!strcmp (key, "duration")) {
+            if (!json_is_number (value)) {
+                *errtxt = "attributes.system.duration must be a number";
+                return -1;
+            }
+        }
+        else if (!strcmp (key, "environment")) {
+            if (!(json_is_object (value))) {
+                *errtxt = "attributes.system.environment.must be a dictionary";
+                return -1;
+            }
+        }
+        else if (!strcmp (key, "shell")) {
+            json_t *opt;
+            if ((opt = json_object_get (value, "options"))
+                && !json_is_object (opt)) {
+                *errtxt = "attributes.shell.options must be a dictionary";
+                return -1;
+            }
+        }
+    }
+    return 0;
+}
+
+int specutil_attr_check (json_t *o, char *errbuf, int errbufsz)
+{
+    const char *key;
+    json_t *value;
+    const char *errtxt;
+
+    json_object_foreach (o, key, value) {
+        if (!strcmp (key, "user")) {
+            if (json_object_size (value) == 0) {
+                errtxt = "if present, attributes.user must contain values";
+                goto copy_error;
+            }
+        }
+        else if (!strcmp (key, "system")) {
+            if (json_object_size (value) == 0) {
+                errtxt = "if present, attributes.system must contain values";
+                goto copy_error;
+            }
+            if (specutil_attr_system_check (value, &errtxt) < 0)
+                goto copy_error;
+        }
+        else {
+            snprintf (errbuf, errbufsz, "unknown attributes section %s", key);
+            goto error;
+        }
+    }
+    return 0;
+copy_error:
+    snprintf (errbuf, errbufsz, "%s", errtxt);
+error:
+    errno = EINVAL;
+    return -1;
+}
+
+static json_t *specutil_tasks_create (json_t *argv)
+{
+    json_t *tasks;
+
+    if (!(tasks = json_pack ("[{s:O s:s s:{s:i}}]",
+                             "command", argv,
+                             "slot", "task",
+                             "count",
+                               "per_slot", 1))) {
+        errno = ENOMEM;
+        return NULL;
+    }
+    return tasks;
+}
+
+static json_t *specutil_resources_create (int ntasks,
+                                          int nodes,
+                                          int cores_per_task,
+                                          int gpus_per_task)
+{
+    json_t *slot;
+
+    if (cores_per_task < 1)
+        cores_per_task = 1;
+    if (ntasks < 1)
+        ntasks = 1;
+    if (nodes > ntasks) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (gpus_per_task > 0) {
+        if (!(slot = json_pack ("[{s:s s:i s:[{s:s s:i} {s:s s:i}] s:s}]",
+                                "type", "slot",
+                                "count", ntasks,
+                                "with",
+                                  "type", "core",
+                                  "count", cores_per_task,
+                                  "type", "gpu",
+                                  "count", gpus_per_task,
+                                "label", "task")))
+            goto nomem;
+    }
+    else {
+        if (!(slot = json_pack ("[{s:s s:i s:[{s:s s:i}] s:s}]",
+                                "type", "slot",
+                                "count", ntasks,
+                                "with",
+                                "type", "core",
+                                "count", cores_per_task,
+                                "label", "task")))
+            goto nomem;
+    }
+    if (nodes > 0) {
+        json_t *node;
+        if (!(node = json_pack ("[{s:s s:i s:o}]",
+                                "type", "node",
+                                "count", nodes,
+                                "with", slot))) {
+            json_decref (slot);
+            goto nomem;
+        }
+        return node;
+    }
+    return slot;
+nomem:
+    errno = ENOMEM;
+    return NULL;
+}
+
+json_t *specutil_jobspec_create (json_t *attributes,
+                                 json_t *argv,
+                                 int ntasks,
+                                 int nodes,
+                                 int cores_per_task,
+                                 int gpus_per_task)
+{
+    json_t *tasks = NULL;
+    json_t *resources = NULL;
+    json_t *jobspec;
+
+    if (!(tasks = specutil_tasks_create (argv)))
+        goto error;
+    if (!(resources = specutil_resources_create (ntasks,
+                                                 nodes,
+                                                 cores_per_task,
+                                                 gpus_per_task)))
+        goto error;
+    if (!(jobspec = json_pack ("{s:o s:o s:O s:i}",
+                               "resources", resources,
+                               "tasks", tasks,
+                               "attributes", attributes, // incref
+                               "version", 1))) {
+        errno = ENOMEM;
+        goto error;
+    }
+    return jobspec;
+error:
+    ERRNO_SAFE_WRAP (json_decref, resources);
+    ERRNO_SAFE_WRAP (json_decref, tasks);
+    return NULL;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libjob/specutil.h
+++ b/src/common/libjob/specutil.h
@@ -1,0 +1,43 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _JOB_SPECUTIL_H
+#define _JOB_SPECUTIL_H
+
+#include <jansson.h>
+
+json_t *specutil_jobspec_create (json_t *attributes,
+                                 json_t *argv,
+                                 int ntasks,
+                                 int nodes,
+                                 int cores_per_task,
+                                 int gpus_per_task);
+
+json_t *specutil_argv_create (int argc, char **argv);
+
+json_t *specutil_env_create (char **env);
+int specutil_env_put (json_t *env, const char *entry);
+int specutil_env_set (json_t *env, const char *name, const char *val);
+int specutil_env_unset (json_t *env, const char *name);
+
+int specutil_attr_set (json_t *attr, const char *path, json_t *val);
+int specutil_attr_pack (json_t *attr, const char *path, const char *fmt, ...);
+int specutil_attr_del (json_t *attr, const char *path);
+
+json_t *specutil_attr_get (json_t *attr, const char *path);
+
+int specutil_attr_check (json_t *attr, char *errbuf, int errbufsz);
+
+#endif /* _JOB_SPECUTIL_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */
+

--- a/src/common/libjob/specutil.h
+++ b/src/common/libjob/specutil.h
@@ -13,12 +13,18 @@
 
 #include <jansson.h>
 
+struct resource_param {
+    int ntasks;
+    int nodes;
+    int cores_per_task;
+    int gpus_per_task;
+};
+
 json_t *specutil_jobspec_create (json_t *attributes,
                                  json_t *argv,
-                                 int ntasks,
-                                 int nodes,
-                                 int cores_per_task,
-                                 int gpus_per_task);
+                                 struct resource_param *param,
+                                 char *errbuf,
+                                 int errbufsz);
 
 json_t *specutil_argv_create (int argc, char **argv);
 

--- a/src/common/libjob/test/specutil.c
+++ b/src/common/libjob/test/specutil.c
@@ -1,0 +1,313 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <jansson.h>
+#include <stdbool.h>
+#include <string.h>
+#include <errno.h>
+
+#include "src/common/libtap/tap.h"
+#include "src/common/libjob/specutil.h"
+
+bool object_is_string (json_t *object, const char *name, const char *val)
+{
+    json_t *o;
+    const char *s;
+    if (!(o = json_object_get (object, name)))
+        return false;
+    if (!json_is_string (o))
+        return false;
+    if (!(s = json_string_value (o)))
+        return false;
+    if (strcmp (val, s) != 0)
+        return false;
+    return true;
+}
+
+bool entry_is_string (json_t *array, int index, const char *val)
+{
+    json_t *o;
+    const char *s;
+    if (!(o = json_array_get (array, index)))
+        return false;
+    if (!json_is_string (o))
+        return false;
+    if (!(s = json_string_value (o)))
+        return false;
+    if (strcmp (val, s) != 0)
+        return false;
+    return true;
+}
+
+void check_env (void)
+{
+    json_t *env;
+
+    if (!(env = specutil_env_create (environ)))
+        BAIL_OUT ("specutil_env_create failed");
+    ok (json_object_size (env) > 0,
+        "specutil_env_create() works");
+
+    ok (specutil_env_set (env, "TEST_FOO", "42") == 0
+        && object_is_string (env, "TEST_FOO", "42"),
+        "specutil_env_set TEST_FOO=42 works");
+
+    ok (specutil_env_set (env, "TEST_FOO", "43") == 0
+        && object_is_string (env, "TEST_FOO", "43"),
+        "specutil_env_set TEST_FOO=43 works");
+
+    ok (specutil_env_put (env, "TEST_FOO=44") == 0
+        && object_is_string (env, "TEST_FOO", "44"),
+        "specutil_env_put TEST_FOO=44 works");
+
+    ok (specutil_env_unset (env, "TEST_FOO") == 0
+        && !json_object_get (env, "TEST_FOO"),
+        "specutil_env_del TEST_FOO works");
+
+    json_decref (env);
+}
+
+void check_argv (void)
+{
+    char *argv[] = { "this", "is", "a", "test" };
+    int argc = sizeof (argv) / sizeof (argv[0]);
+    json_t *av;
+    int i;
+    int errors = 0;
+
+    if (!(av = specutil_argv_create (argc, argv)))
+        BAIL_OUT ("specutil_argv_create failed");
+    ok (json_array_size (av) == argc,
+        "specutil_argv_create works");
+    for (i = 0; i < argc; i++) {
+        if (!entry_is_string (av, i, argv[i]))
+            errors++;
+    }
+    ok (errors == 0,
+        "specutil_argv_create set correct array values");
+
+    json_decref (av);
+}
+
+void check_attr (void)
+{
+    json_t *attr;
+    json_t *val;
+
+    if (!(attr = json_object ()))
+        BAIL_OUT ("json_object failed");
+    ok (specutil_attr_pack (attr, "foo", "s", "bar") == 0
+        && object_is_string (attr, "foo", "bar"),
+        "specutil_attr_pack foo=bar works");
+    ok (specutil_attr_pack (attr, "foo", "s", "baz") == 0
+        && object_is_string (attr, "foo", "baz"),
+        "specutil_attr_pack foo=baz works");
+    ok (specutil_attr_pack (attr, "a.b", "f", 0.1) == 0
+        && (val = json_object_get (attr, "a"))
+        && json_is_object (val),
+        "specutil_attr_pack a.b=(0.1) created object named a");
+    ok ((val = specutil_attr_get (attr, "a.b"))
+        && json_is_real (val)
+        && json_real_value (val) == 0.1,
+        "specutil_attr_get a.b returns expected value");
+    ok (specutil_attr_del (attr, "a.b") == 0,
+        "specutil_attr_del a.b works");
+    errno = 0;
+    ok (specutil_attr_get (attr, "a.b") == NULL && errno == ENOENT,
+        "specutil_attr_get a.b fails with ENOENT");
+    ok ((val = json_object_get (attr, "a"))
+        && json_is_object (val),
+        "but 'a' is still there");
+    ok (specutil_attr_del (attr, "a") == 0
+        && !json_object_get (attr, "a"),
+        "specutil_attr_del a works");
+    ok (specutil_attr_del (attr, "noexist") == 0,
+        "specutil_attr_del noexist returns success");
+    ok (specutil_attr_del (attr, "noexist.a") == 0,
+        "specutil_attr_del noexist.a returns success");
+
+
+    errno = 0;
+    ok (specutil_attr_pack (attr, ".", "s", "a") < 0 && errno == EINVAL,
+        "specutil_attr_pack path=. fails with EINVAL");
+    errno = 0;
+    ok (specutil_attr_pack (attr, ".a", "s", "a") < 0 && errno == EINVAL,
+        "specutil_attr_pack path=.a fails with EINVAL");
+    errno = 0;
+    ok (specutil_attr_pack (attr, "a.", "s", "a") < 0 && errno == EINVAL,
+        "specutil_attr_pack path=a. fails with EINVAL");
+    errno = 0;
+    ok (specutil_attr_pack (attr, "a..b", "s", "a") < 0 && errno == EINVAL,
+        "specutil_attr_pack path=a..b fails with EINVAL");
+    errno = 0;
+    ok (specutil_attr_pack (NULL, "a", "s", "a") < 0 && errno == EINVAL,
+        "specutil_attr_pack attr=NULL fails with EINVAL");
+    errno = 0;
+    ok (specutil_attr_pack (attr, NULL, "s", "a") < 0 && errno == EINVAL,
+        "specutil_attr_pack path=NULL fails with EINVAL");
+    errno = 0;
+    ok (specutil_attr_pack (attr, "a", NULL, "a") < 0 && errno == EINVAL,
+        "specutil_attr_pack fmt=a fails with EINVAL");
+
+    errno = 0;
+    ok (specutil_attr_get (NULL, "a") == NULL && errno == EINVAL,
+        "specutil_attr_get attr=NULL fails with EINVAL");
+    errno = 0;
+    ok (specutil_attr_get (attr, NULL) == NULL && errno == EINVAL,
+        "specutil_attr_get path=NULL fails with EINVAL");
+
+    errno = 0;
+    ok (specutil_attr_set (NULL, "a", json_null ()) < 0 && errno == EINVAL,
+        "specutil_attr_set attr=NULL fails with EINVAL");
+    errno = 0;
+    ok (specutil_attr_set (attr, NULL, json_null ()) < 0 && errno == EINVAL,
+        "specutil_attr_set path=NULL fails with EINVAL");
+    errno = 0;
+    ok (specutil_attr_set (attr, "a", NULL) < 0 && errno == EINVAL,
+        "specutil_attr_set value=NULL fails with EINVAL");
+
+    json_decref (attr);
+}
+
+void check_jobspec (void)
+{
+    char *argv[] = { "this", "is", "a", "test" };
+    int argc = sizeof (argv) / sizeof (argv[0]);
+    json_t *attr;
+    json_t *av;
+    json_t *spec;
+    json_t *val;
+
+    if (!(attr = json_object ()))
+        BAIL_OUT ("json_object failed");
+    if (!(av = specutil_argv_create (argc, argv)))
+        BAIL_OUT ("specutil_argv_create failed");
+
+    ok ((spec = specutil_jobspec_create (attr, av, 0, 0, 0, 0)) != NULL,
+        "specutil_jobspec_create works");
+    ok (json_object_get (spec, "resources") != NULL,
+        "jobspec has resources section");
+    ok (json_object_get (spec, "tasks") != NULL,
+        "jobspec has tasks section");
+    ok (json_object_get (spec, "attributes") != NULL,
+        "jobspec has attributes section");
+    ok ((val = json_object_get (spec, "version")) != NULL
+        && json_is_integer (val)
+        && json_integer_value (val) == 1,
+        "jobspec has version 1");
+
+    json_decref (attr);
+    json_decref (av);
+    json_decref (spec);
+}
+
+void check_attr_check (void)
+{
+    json_t *attr;
+    char errbuf[128];
+
+    if (!(attr = json_object ()))
+        BAIL_OUT ("json_object failed");
+    ok (specutil_attr_check (attr, errbuf, sizeof (errbuf)) == 0,
+        "specutil_attr_check attr={} OK");
+
+    if (specutil_attr_pack (attr, "a.b", "s", "foo") < 0)
+        BAIL_OUT ("could not set a.b");
+    errno = 0;
+    *errbuf = '\0';
+    ok (specutil_attr_check (attr, errbuf, sizeof (errbuf)) < 0
+        && errno == EINVAL
+        && strlen (errbuf) > 0,
+        "specutil_attr_check failed with EINVAL, errbuf");
+    diag ("errbuf=%s", errbuf);
+    json_object_del (attr, "a");
+
+    if (specutil_attr_pack (attr, "system", "{}") < 0)
+        BAIL_OUT ("could not set system={}");
+    errno = 0;
+    *errbuf = '\0';
+    ok (specutil_attr_check (attr, errbuf, sizeof (errbuf)) < 0
+        && errno == EINVAL
+        && strlen (errbuf) > 0,
+        "specutil_attr_check attr= failed with EINVAL, errbuf");
+    diag ("errbuf=%s", errbuf);
+
+    if (specutil_attr_pack (attr, "system.duration", "f", 0.1) < 0)
+        BAIL_OUT ("could not set system.duration=0.1");
+    ok (specutil_attr_check (attr, errbuf, sizeof (errbuf)) == 0,
+        "specutil_attr_check system.duration=0.1 OK");
+
+    if (specutil_attr_pack (attr, "system.duration", "s", "x") < 0)
+        BAIL_OUT ("could not set system.duration=x");
+    errno = 0;
+    *errbuf = '\0';
+    ok (specutil_attr_check (attr, errbuf, sizeof (errbuf)) < 0
+        && errno == EINVAL
+        && strlen (errbuf) > 0,
+        "specutil_attr_check system.duration=x failed with EINVAL, errbuf");
+    diag ("errbuf=%s", errbuf);
+
+    if (specutil_attr_del (attr, "system") < 0)
+        BAIL_OUT ("could not remove system attribute dict");
+    if (specutil_attr_pack (attr, "system.environment", "{}") < 0)
+        BAIL_OUT ("could not set system.environment={}");
+    ok (specutil_attr_check (attr, errbuf, sizeof (errbuf)) == 0,
+        "specutil_attr_check system.environment={} OK");
+
+    if (specutil_attr_pack (attr, "system.environment", "s", "x") < 0)
+        BAIL_OUT ("could not set system.environment=x");
+    errno = 0;
+    *errbuf = '\0';
+    ok (specutil_attr_check (attr, errbuf, sizeof (errbuf)) < 0
+        && errno == EINVAL
+        && strlen (errbuf) > 0,
+        "specutil_attr_check system.environment=x failed with EINVAL, errbuf");
+    diag ("errbuf=%s", errbuf);
+
+    if (specutil_attr_del (attr, "system") < 0)
+        BAIL_OUT ("could not remove system attribute dict");
+    if (specutil_attr_pack (attr, "system.shell.options", "{}") < 0)
+        BAIL_OUT ("could not set system.shell.options={}");
+    ok (specutil_attr_check (attr, errbuf, sizeof (errbuf)) == 0,
+        "specutil_attr_check system.shell.options={} OK");
+
+    if (specutil_attr_pack (attr, "system.shell.options", "s", "x") < 0)
+        BAIL_OUT ("could not set system.shell.options=x");
+    errno = 0;
+    *errbuf = '\0';
+    ok (specutil_attr_check (attr, errbuf, sizeof (errbuf)) < 0
+        && errno == EINVAL
+        && strlen (errbuf) > 0,
+        "specutil_attr_check system.shell.options=x failed with EINVAL, errbuf");
+    diag ("errbuf=%s", errbuf);
+
+    json_decref (attr);
+}
+
+int main (int argc, char *argv[])
+{
+    plan (NO_PLAN);
+
+    check_env ();
+    check_argv ();
+    check_attr ();
+    check_jobspec ();
+    check_attr_check ();
+
+    done_testing ();
+    return 0;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libjob/test/specutil.c
+++ b/src/common/libjob/test/specutil.c
@@ -187,13 +187,16 @@ void check_jobspec (void)
     json_t *av;
     json_t *spec;
     json_t *val;
+    struct resource_param p = { 0, 0, 0, 0 };
+    char errbuf[128];
 
     if (!(attr = json_object ()))
         BAIL_OUT ("json_object failed");
     if (!(av = specutil_argv_create (argc, argv)))
         BAIL_OUT ("specutil_argv_create failed");
 
-    ok ((spec = specutil_jobspec_create (attr, av, 0, 0, 0, 0)) != NULL,
+    ok ((spec = specutil_jobspec_create (attr, av, &p,
+                                         errbuf, sizeof (errbuf))) != NULL,
         "specutil_jobspec_create works");
     ok (json_object_get (spec, "resources") != NULL,
         "jobspec has resources section");

--- a/src/modules/job-ingest/job-ingest.c
+++ b/src/modules/job-ingest/job-ingest.c
@@ -1023,10 +1023,11 @@ int mod_main (flux_t *h, int argc, char **argv)
             goto done;
         }
         flux_future_destroy (f);
-        /* fluid_init() will fail on rank > 16K.
+        /* fluid_init() only works on first 16K ranks (0-16383).
+         * Reserve the highest numbered rank for job manager fastpath.
          * Just skip loading the job module on those ranks.
          */
-        if (fluid_init (&ctx.gen, rank, timestamp) < 0) {
+        if (rank >= 16383 || fluid_init (&ctx.gen, rank, timestamp) < 0) {
             flux_log (h, LOG_ERR, "fluid_init failed");
             errno = EINVAL;
         }

--- a/src/modules/job-manager/Makefile.am
+++ b/src/modules/job-manager/Makefile.am
@@ -54,6 +54,8 @@ libjob_manager_la_SOURCES = \
 	getattr.c \
 	prioritize.h \
 	prioritize.c \
+	runjob.h \
+	runjob.c \
 	jobtap-internal.h \
 	jobtap.h \
 	jobtap.c \

--- a/src/modules/job-manager/event.c
+++ b/src/modules/job-manager/event.c
@@ -463,8 +463,8 @@ static const char *state_topic (struct job *job)
 }
 
 /* This function implements state transitions per RFC 21.
- * If FLUX_JOB_WAITABLE flag is set, then on a fatal exception or
- * cleanup event, capture the event in job->end_event for flux_job_wait().
+ * On a fatal exception or cleanup event, capture the event in job struct
+ * for flux_job_wait().
  */
 int event_job_update (struct job *job, json_t *event)
 {
@@ -511,9 +511,7 @@ int event_job_update (struct job *job, json_t *event)
         if (event_exception_context_decode (context, &severity) < 0)
             goto error;
         if (severity == 0) {
-            if ((job->flags & FLUX_JOB_WAITABLE) && !job->end_event)
-                job->end_event = json_incref (event);
-
+            wait_set_end_event (job, event);
             job->state = FLUX_JOB_STATE_CLEANUP;
         }
     }
@@ -535,9 +533,7 @@ int event_job_update (struct job *job, json_t *event)
             && job->state != FLUX_JOB_STATE_CLEANUP)
             goto inval;
         if (job->state == FLUX_JOB_STATE_RUN) {
-            if ((job->flags & FLUX_JOB_WAITABLE) && !job->end_event)
-                job->end_event = json_incref (event);
-
+            wait_set_end_event (job, event);
             job->state = FLUX_JOB_STATE_CLEANUP;
         }
     }

--- a/src/modules/job-manager/job-manager.c
+++ b/src/modules/job-manager/job-manager.c
@@ -30,6 +30,7 @@
 #include "annotate.h"
 #include "journal.h"
 #include "getattr.h"
+#include "runjob.h"
 #include "jobtap-internal.h"
 
 #include "job-manager.h"
@@ -111,6 +112,12 @@ static const struct flux_msg_handler_spec htab[] = {
         "job-manager.getinfo",
         getinfo_handle_request,
         FLUX_ROLE_USER
+    },
+    {
+        FLUX_MSGTYPE_REQUEST,
+        "job-manager.runjob",
+        runjob_handler,
+        FLUX_ROLE_OWNER,
     },
     {
         FLUX_MSGTYPE_REQUEST,
@@ -201,6 +208,10 @@ int mod_main (flux_t *h, int argc, char **argv)
         flux_log_error (h, "restart_from_kvs");
         goto done;
     }
+    if (!(ctx.runjob = runjob_ctx_create (&ctx))) {            // uses max_jobid
+        flux_log_error (h, "error creating runjob interface"); //   from restart
+        goto done;
+    }
     if (flux_reactor_run (r, 0) < 0) {
         flux_log_error (h, "flux_reactor_run");
         goto done;
@@ -222,6 +233,7 @@ done:
     alloc_ctx_destroy (ctx.alloc);
     submit_ctx_destroy (ctx.submit);
     event_ctx_destroy (ctx.event);
+    runjob_ctx_destroy (ctx.runjob);
     jobtap_destroy (ctx.jobtap);
     zhashx_destroy (&ctx.active_jobs);
     return rc;

--- a/src/modules/job-manager/job-manager.h
+++ b/src/modules/job-manager/job-manager.h
@@ -27,6 +27,7 @@ struct job_manager {
     struct kill *kill;
     struct annotate *annotate;
     struct journal *journal;
+    struct runjob *runjob;
     struct jobtap *jobtap;
 };
 

--- a/src/modules/job-manager/job.c
+++ b/src/modules/job-manager/job.c
@@ -26,7 +26,6 @@ void job_decref (struct job *job)
 {
     if (job && --job->refcount == 0) {
         int saved_errno = errno;
-        json_decref (job->end_event);
         json_decref (job->jobspec_redacted);
         json_decref (job->annotations);
         aux_destroy (&job->aux);

--- a/src/modules/job-manager/job.c
+++ b/src/modules/job-manager/job.c
@@ -27,7 +27,6 @@ void job_decref (struct job *job)
     if (job && --job->refcount == 0) {
         int saved_errno = errno;
         json_decref (job->end_event);
-        flux_msg_decref (job->waiter);
         json_decref (job->jobspec_redacted);
         json_decref (job->annotations);
         aux_destroy (&job->aux);

--- a/src/modules/job-manager/job.c
+++ b/src/modules/job-manager/job.c
@@ -20,6 +20,7 @@
 #include "event.h"
 
 #include "src/common/libeventlog/eventlog.h"
+#include "src/common/libutil/aux.h"
 
 void job_decref (struct job *job)
 {
@@ -29,6 +30,7 @@ void job_decref (struct job *job)
         flux_msg_decref (job->waiter);
         json_decref (job->jobspec_redacted);
         json_decref (job->annotations);
+        aux_destroy (&job->aux);
         free (job);
         errno = saved_errno;
     }
@@ -54,6 +56,24 @@ struct job *job_create (void)
     job->priority = -1;
     job->state = FLUX_JOB_STATE_NEW;
     return job;
+}
+
+int job_aux_set (struct job *job,
+                 const char *name,
+                 void *val,
+                 flux_free_f destroy)
+{
+    return aux_set (&job->aux, name, val, destroy);
+}
+
+void *job_aux_get (struct job *job, const char *name)
+{
+    return aux_get (job->aux, name);
+}
+
+void job_aux_delete (struct job *job, const void *val)
+{
+    aux_delete (&job->aux, val);
 }
 
 /* Follow path (NULL terminated array of keys) through multiple JSON

--- a/src/modules/job-manager/job.h
+++ b/src/modules/job-manager/job.h
@@ -27,7 +27,6 @@ struct job {
     int eventlog_seq;           // eventlog count / sequence number
     flux_job_state_t state;
     json_t *end_event;      // event that caused transition to CLEANUP state
-    const flux_msg_t *waiter; // flux_job_wait() request
 
     uint8_t alloc_queued:1; // queued for alloc, but alloc request not sent
     uint8_t alloc_pending:1;// alloc request sent to sched

--- a/src/modules/job-manager/job.h
+++ b/src/modules/job-manager/job.h
@@ -26,7 +26,6 @@ struct job {
     json_t *jobspec_redacted;
     int eventlog_seq;           // eventlog count / sequence number
     flux_job_state_t state;
-    json_t *end_event;      // event that caused transition to CLEANUP state
 
     uint8_t alloc_queued:1; // queued for alloc, but alloc request not sent
     uint8_t alloc_pending:1;// alloc request sent to sched

--- a/src/modules/job-manager/job.h
+++ b/src/modules/job-manager/job.h
@@ -39,6 +39,8 @@ struct job {
 
     void *handle;           // zlistx_t handle
     int refcount;           // private to job.c
+
+    struct aux_item *aux;
 };
 
 void job_decref (struct job *job);
@@ -49,6 +51,13 @@ struct job *job_create (void);
 struct job *job_create_from_eventlog (flux_jobid_t id,
                                       const char *eventlog,
                                       const char *jobspec);
+
+int job_aux_set (struct job *job,
+                 const char *name,
+                 void *val,
+                 flux_free_f destroy);
+void *job_aux_get (struct job *job, const char *name);
+void job_aux_delete (struct job *job, const void *val);
 
 /* Helpers for maintaining czmq containers of 'struct job'.
  * The comparator sorts by (1) priority, then (2) jobid.

--- a/src/modules/job-manager/runjob.c
+++ b/src/modules/job-manager/runjob.c
@@ -1,0 +1,205 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* runjob.c - fastpath for running a job in one RPC
+ *
+ * The RPC returns when the job is inactive and includes the wait status.
+ *
+ * Access is restricted to instance owner only.
+ * Job ID is issued and jobspec is constructed here, instead of in job-ingest.
+ * Jobspec validators are bypassed.
+ * Jobspec is not signed, nor is signed jobspec stored to KVS.
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <czmq.h>
+#include <assert.h>
+#include <jansson.h>
+#include <flux/core.h>
+
+#include "src/common/libjob/specutil.h"
+#include "src/common/libutil/fluid.h"
+#include "src/common/libutil/errno_safe.h"
+
+#include "job.h"
+#include "wait.h"
+#include "event.h"
+#include "runjob.h"
+
+struct runjob {
+    struct job_manager *ctx;
+    struct fluid_generator fluid_gen;
+};
+
+static void jobspec_continuation (flux_future_t *f, void *arg)
+{
+    struct runjob *runjob = arg;
+    flux_t *h = flux_future_get_flux (f);
+    struct job *job = flux_future_aux_get (f, "job");
+    const char *errstr = NULL;
+
+    if (flux_rpc_get (f, NULL) < 0) {
+        errstr = "eventlog commit failed";
+        goto error;
+    }
+    if (event_job_post_pack (runjob->ctx->event,
+                             job,
+                             "submit",
+                             0,
+                             "{s:i s:i s:i}",
+                             "userid", job->userid,
+                             "urgency", job->urgency,
+                             "flags", job->flags) < 0) {
+        errstr = "error posting submit event";
+        goto error;
+    }
+    wait_notify_active (runjob->ctx->wait, job);
+    job_aux_delete (job, f);
+    return;
+error:
+    if (flux_respond_error (h, wait_get_waiter (job), errno, errstr) < 0)
+        flux_log_error (h, "error responding to runjob");
+    zhashx_delete (runjob->ctx->active_jobs, &job->id);
+}
+
+static flux_future_t *commit_jobspec (flux_t *h, struct job *job)
+{
+    char key[64];
+    flux_future_t *f = NULL;
+    flux_kvs_txn_t *txn;
+
+    if (flux_job_kvs_key (key, sizeof (key), job->id, "jobspec") < 0)
+        return NULL;
+    if (!(txn = flux_kvs_txn_create ()))
+        return NULL;
+    if (flux_kvs_txn_pack (txn, 0, key, "O", job->jobspec_redacted) < 0)
+        goto error;
+    if (!(f = flux_kvs_commit (h, NULL, 0, txn)))
+        goto error;
+    flux_kvs_txn_destroy (txn);
+    return f;
+error:
+    flux_future_destroy (f);
+    flux_kvs_txn_destroy (txn);
+    return NULL;
+}
+
+void runjob_handler (flux_t *h,
+                     flux_msg_handler_t *mh,
+                     const flux_msg_t *msg,
+                     void *arg)
+{
+    struct job_manager *ctx = arg;
+    struct runjob *runjob = ctx->runjob;
+    json_t *command;
+    json_t *attributes;
+    int ntasks;
+    char errbuf[128];
+    const char *errstr = NULL;
+    struct job *job = NULL;
+    const char *envkey = "attributes.system.environment";
+    flux_future_t *f;
+
+    if (flux_request_unpack (msg,
+                             NULL,
+                             "{s:o s:o s:i}",
+                             "command", &command,
+                             "attributes", &attributes,
+                             "ntasks", &ntasks) < 0) {
+        errstr = "malformed runjob request";
+        goto error;
+    }
+    if (specutil_attr_check (attributes, errbuf, sizeof (errbuf)) < 0) {
+        errstr = errbuf;
+        goto error;
+    }
+    if (!(job = job_create ()))
+        goto error;
+    /* The runjob request will be handled as if it were a 'wait' request
+     * for this job.  Code in wait.c responds to the request once the job
+     * becomes inactive.
+     */
+    job->flags = FLUX_JOB_WAITABLE;
+    if (wait_set_waiter (runjob->ctx->wait, job, msg) < 0)
+        goto error;
+    if (flux_msg_get_userid (msg, &job->userid) < 0)
+        goto error;
+    if (fluid_generate (&runjob->fluid_gen, &job->id) < 0) {
+        errstr = "error generating job id";
+        errno = EINVAL;
+        goto error;
+    }
+    /* The redacted jobspec is not actually redacted until it (in full)
+     * becomes part of the KVS transaction below.
+     */
+    if (!(job->jobspec_redacted  = specutil_jobspec_create (attributes,
+                                                            command,
+                                                            ntasks,
+                                                            0,
+                                                            1,
+                                                            0))) {
+        errstr = "error building jobspec";
+        goto error;
+    }
+    /* Start KVS commit of jobspec.
+     * If the commit is successful, its continuation posts the submit event
+     * which kicks the job state machine.
+     * N.B. future 'f' destruction is tied to 'job', not the other way around
+     */
+    if (!(f = commit_jobspec (h, job))
+        || flux_future_aux_set (f, "job", job, NULL) < 0
+        || flux_future_then (f, -1, jobspec_continuation, runjob) < 0
+        || job_aux_set (job, NULL, f, (flux_free_f)flux_future_destroy) < 0) {
+        flux_future_destroy (f);
+        errstr = "error committing jobspec to KVS";
+        goto error;
+    }
+    specutil_attr_del (job->jobspec_redacted, envkey); // redact environment
+    zhashx_update (ctx->active_jobs, &job->id, job);
+    return;
+error:
+    if (flux_respond_error (h, msg, errno, errstr) < 0)
+        flux_log_error (h, "error resopnding to runjob");
+    job_decref (job);
+}
+
+void runjob_ctx_destroy (struct runjob *runjob)
+{
+    if (runjob) {
+        int saved_errno = errno;
+        free (runjob);
+        errno = saved_errno;
+    }
+}
+
+struct runjob *runjob_ctx_create (struct job_manager *ctx)
+{
+    struct runjob *runjob;
+
+    if (!(runjob = calloc (1, sizeof (*runjob))))
+        return NULL;
+    runjob->ctx = ctx;
+    if (fluid_init (&runjob->fluid_gen,
+                    16383, // reserved by job-ingest
+                    fluid_get_timestamp (ctx->max_jobid)) < 0) {
+        flux_log (ctx->h, LOG_ERR, "fluid_init failed");
+        goto error;
+    }
+    return runjob;
+error:
+    runjob_ctx_destroy (runjob);
+    return NULL;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/job-manager/runjob.h
+++ b/src/modules/job-manager/runjob.h
@@ -1,0 +1,26 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef FLUX_JOB_MANAGER_RUNJOB_H
+#define FLUX_JOB_MANAGER_RUNJOB_H
+
+#include <flux/core.h>
+#include "job-manager.h"
+
+void runjob_handler (flux_t *h,
+                     flux_msg_handler_t *mh,
+                     const flux_msg_t *msg,
+                     void *arg);
+
+struct runjob *runjob_ctx_create (struct job_manager *ctx);
+void runjob_ctx_destroy (struct runjob *runjob);
+
+
+#endif /* !FLUX_JOB_MANAGER_RUNJOB_H */

--- a/src/modules/job-manager/wait.c
+++ b/src/modules/job-manager/wait.c
@@ -137,6 +137,34 @@ static int decode_job_result (struct job *job,
     return 0;
 }
 
+int wait_set_waiter (struct waitjob *wait,
+                     struct job *job,
+                     const flux_msg_t *msg)
+{
+    if (job_aux_set (job,
+                     "wait::request",
+                     (void *)flux_msg_incref (msg),
+                     (flux_free_f)flux_msg_decref) < 0) {
+        flux_msg_decref (msg);
+        return -1;
+    }
+    wait->waiters++;
+    return 0;
+}
+
+const flux_msg_t *wait_get_waiter (struct job *job)
+{
+    return job_aux_get (job, "wait::request");
+}
+
+void wait_clear_waiter (struct waitjob *wait, struct job *job)
+{
+    if (job_aux_get (job, "wait::request")) {
+        job_aux_set (job, "wait::request", NULL, NULL);
+        wait->waiters--;
+    }
+}
+
 /* Respond to wait request 'msg' with completion info from 'job'.
  */
 static void wait_respond (struct waitjob *wait,
@@ -181,11 +209,9 @@ void wait_notify_inactive (struct waitjob *wait, struct job *job)
 
     assert ((job->flags & FLUX_JOB_WAITABLE));
 
-    if (job->waiter) {
-        wait_respond (wait, job->waiter, job);
-        flux_msg_decref (job->waiter);
-        job->waiter = NULL;
-        wait->waiters--;
+    if ((req = wait_get_waiter (job))) {
+        wait_respond (wait, req, job);
+        wait_clear_waiter (wait, job);
     }
     else if ((req = flux_msglist_first (wait->requests))) {
         wait_respond (wait, req, job);
@@ -246,7 +272,7 @@ static void wait_rpc (flux_t *h,
         /* If job is still active, enqueue the request.
          */
         else if ((job = zhashx_lookup (ctx->active_jobs, &id))) {
-            if (job->waiter) {
+            if (wait_get_waiter (job)) {
                 errstr = "job id already has a waiter";
                 goto error_nojob;
             }
@@ -254,8 +280,10 @@ static void wait_rpc (flux_t *h,
                 errstr = "job was not submitted with FLUX_JOB_WAITABLE";
                 goto error_nojob;
             }
-            job->waiter = flux_msg_incref (msg);
-            wait->waiters++;
+            if (wait_set_waiter (wait, job, msg) < 0) {
+                errstr = "error establishing wait context";
+                goto error;
+            }
             return;
         }
         /* Invalid jobid, not waitable, or already waited on.
@@ -305,12 +333,10 @@ void wait_disconnect_rpc (flux_t *h,
 
     job = zhashx_first (ctx->active_jobs);
     while (job && wait->waiters > 0) {
-        if (job->waiter) {
-            if (flux_msg_match_route_first (job->waiter, msg)) {
-                flux_msg_decref (job->waiter);
-                job->waiter = NULL;
-                wait->waiters--;
-            }
+        const flux_msg_t *req;
+        if ((req = wait_get_waiter (job))) {
+            if (flux_msg_match_route_first (msg, req))
+                wait_clear_waiter (wait, job);
         }
         job = zhashx_next (ctx->active_jobs);
     }
@@ -349,11 +375,11 @@ void wait_ctx_destroy (struct waitjob *wait)
          */
         job = zhashx_first (wait->ctx->active_jobs);
         while (job && wait->waiters > 0) {
-            if (job->waiter) {
-                respond_unloading (h, job->waiter);
-                flux_msg_decref (job->waiter);
-                job->waiter = NULL;
-                wait->waiters--;
+            const flux_msg_t *msg;
+
+            if ((msg = wait_get_waiter (job))) {
+                respond_unloading (h, msg);
+                wait_clear_waiter (wait, job);
             }
             job = zhashx_next (wait->ctx->active_jobs);
         }

--- a/src/modules/job-manager/wait.h
+++ b/src/modules/job-manager/wait.h
@@ -27,6 +27,15 @@ void wait_disconnect_rpc (flux_t *h,
                           const flux_msg_t *msg,
                           void *arg);
 
+/* 'msg' will receive a response once job becomes inactive.
+ * Takes a ref on 'msg' while waiting.
+ */
+int wait_set_waiter (struct waitjob *wait,
+                     struct job *job,
+                     const flux_msg_t *msg);
+void wait_clear_waiter (struct waitjob *wait, struct job *job);
+const flux_msg_t *wait_get_waiter (struct job *job);
+
 struct job *wait_zombie_first (struct waitjob *wait);
 struct job *wait_zombie_next (struct waitjob *wait);
 

--- a/src/modules/job-manager/wait.h
+++ b/src/modules/job-manager/wait.h
@@ -36,6 +36,11 @@ int wait_set_waiter (struct waitjob *wait,
 void wait_clear_waiter (struct waitjob *wait, struct job *job);
 const flux_msg_t *wait_get_waiter (struct job *job);
 
+/* Store terminating event for waiter to decode.
+ * Do nothing if job is not waitable, or event has already been stored.
+ */
+int wait_set_end_event (struct job *job, json_t *event);
+
 struct job *wait_zombie_first (struct waitjob *wait);
 struct job *wait_zombie_next (struct waitjob *wait);
 

--- a/t/t2201-job-cmd.t
+++ b/t/t2201-job-cmd.t
@@ -591,5 +591,16 @@ test_expect_success 'flux job: killall -f kills one job' '
         flux job killall -f &&
 	run_timeout 60 flux queue drain
 '
+test_expect_success 'flux job exec works' '
+	flux job exec /bin/true
+'
+test_expect_success 'flux job exec --label-io works' '
+	flux job exec --label-io echo hi >exec1.out &&
+	grep "0: hi" exec1.out
+'
+test_expect_success 'flux job exec --ntasks=2 works' '
+	flux job exec --ntasks=2 --label-io echo hi >exec2.out &&
+	grep "1: hi" exec2.out
+'
 
 test_done


### PR DESCRIPTION
As discussed in #3556, this PR adds an experimental run command with less overhead, and fewer features, than `flux mini run`:
```
Usage: flux-job exec [OPTIONS]
Run job with one task per core to completion
  -h, --help             Display this message.
  -n, --ntasks=COUNT     Run N tasks (default 1)
  -l, --label-io         Label output by rank
```
It is available only to the instance owner, and has very limited options as shown above.  A specialized service in the job-manager accepts the job submission and commits jobspec to the KVS.  Once the KVS commit completes, it posts the `submit` event and the state machine takes it from there.   To obtain the result, the FLUX_JOB_WAITABLE flag is set, and the original request effectively gets a wait response once the job becomes inactive.  That allowed the service to be implemented with a fairly small amount of code.

Other limitations include
- no shell options
- no submit options
- no duration or other options
- resources expressed only in cores
- task to resource mapping is one task per core
- output is not produced while the job runs; it is emitted all at once at the end
- signals are not forwarded (e.g. aborting before job is done does not abort job)
- no environment options

There are probably more I'm not thinking of.

Anyway, I thought I would post this half formed thing as a demo, for @jedbrown to poke at and see if it helps his use case.