### PR TITLE
Fix various memleaks discovered by ASAN

### DIFF
--- a/src/broker/test/boot_config.c
+++ b/src/broker/test/boot_config.c
@@ -501,6 +501,7 @@ void test_attr (const char *dir)
     if (unlink (path) < 0)
         BAIL_OUT ("could not cleanup test file %s", path);
     flux_conf_decref (cf);
+    attr_destroy (attrs);
 }
 
 void test_curve_cert (const char *dir)
@@ -525,6 +526,7 @@ void test_curve_cert (const char *dir)
     if (unlink (path) < 0)
         BAIL_OUT ("could not cleanup test file %s", path);
 
+    flux_conf_decref (cf);
 }
 
 int main (int argc, char **argv)

--- a/src/common/libflux/test/module.c
+++ b/src/common/libflux/test/module.c
@@ -42,6 +42,7 @@ void test_modname (void)
     name = flux_modname (FAKE1, NULL, NULL);
     ok (name != NULL && !strcmp (name, "fake1"),
         "flux_modname path=module_fake1 works");
+    free (name);
 
     errno = 0;
     errmsg_count = 0;
@@ -123,13 +124,14 @@ void test_modfind_fini (void)
 
 void test_modfind (void)
 {
-    const char *path;
+    char *path;
 
     test_modfind_init ();
 
     path = flux_modfind (searchpath, "fake1", errmsg_cb, NULL);
     ok (path != NULL && !strcmp (path, link1),
         "flux_modfind modname=fake1 returns correct path");
+    free (path);
 
     errno = 0;
     errmsg_count = 0;

--- a/src/common/libflux/test/rpc.c
+++ b/src/common/libflux/test/rpc.c
@@ -274,6 +274,8 @@ void test_corner_case (flux_t *h)
     ok (flux_rpc_pack (h, "topic", 0, 0xFF, "{ s:s }", "foo", "bar") == NULL
         && errno == EINVAL,
         "flux_rpc_pack fails with EINVAL on invalid flags");
+
+    flux_msg_destroy (msg);
 }
 
 void test_service (flux_t *h)
@@ -791,14 +793,16 @@ void test_rpc_message (flux_t *h)
  */
 static int fake_server (flux_t *h, void *arg)
 {
-    flux_msg_t *msg;
+    flux_msg_t *msg = NULL;
 
     while ((msg = flux_recv (h, FLUX_MATCH_ANY, 0)) != NULL) {
         const char *topic = "unknown";
         (void)flux_msg_get_topic (msg, &topic);
         if (!strcmp (topic, "shutdown"))
             break;
+        flux_msg_destroy (msg);
     }
+    flux_msg_destroy (msg);
     return 0;
 }
 

--- a/src/common/libhostlist/test/hostrange.c
+++ b/src/common/libhostlist/test/hostrange.c
@@ -217,6 +217,8 @@ void test_cmp ()
             "hostrange_cmp (%s, %s) = %d, expected %d",
              s1, s2, result, t->result);
         t++;
+        free (s1);
+        free (s2);
     }
 }
 

--- a/src/common/libioencode/test/ioencode.c
+++ b/src/common/libioencode/test/ioencode.c
@@ -75,6 +75,7 @@ void basic (void)
         && eof == true,
         "iodecode returned correct info");
     free (data);
+    json_decref (o);
 }
 
 int main (int argc, char *argv[])

--- a/src/common/libjob/job.c
+++ b/src/common/libjob/job.c
@@ -230,6 +230,7 @@ flux_future_t *flux_job_list (flux_t *h,
     if (!h || max_entries < 0 || !json_str
            || !(o = json_loads (json_str, 0, NULL))
            || states & ~valid_states) {
+        json_decref (o);
         errno = EINVAL;
         return NULL;
     }

--- a/src/common/libkvs/test/kvs_dir.c
+++ b/src/common/libkvs/test/kvs_dir.c
@@ -39,6 +39,7 @@ void test_empty (void)
     json_t *o;
     char *s;
     const char *key;
+    char *keyat;
 
     lives_ok ({flux_kvsdir_destroy (NULL);},
         "flux_kvsdir_destroy with NULL paramter doesn't crash");
@@ -76,6 +77,7 @@ void test_empty (void)
         BAIL_OUT ("json_dumps failed on new treeobj");
     dir = flux_kvsdir_create (NULL, NULL, "foo", s);
     free (s);
+    json_decref (o);
 
     ok (dir != NULL,
         "flux_kvsdir_create with empty directory works");
@@ -91,9 +93,10 @@ void test_empty (void)
     key = flux_kvsdir_key (dir);
     ok (key != NULL && !strcmp (key, "foo"),
         "flux_kvsdir_key returns the key we put in");
-    key = flux_kvsdir_key_at (dir, "a.b.c");
-    ok (key != NULL && !strcmp (key, "foo.a.b.c"),
+    keyat = flux_kvsdir_key_at (dir, "a.b.c");
+    ok (keyat != NULL && !strcmp (keyat, "foo.a.b.c"),
         "flux_kvsdir_key_at a.b.c returns foo.a.b.c");
+    free (keyat);
     ok (flux_kvsdir_handle (dir) == NULL,
         "flux_kvsdir_handle returns NULL since that's what we put in");
     ok (flux_kvsdir_rootref (dir) == NULL,
@@ -239,6 +242,8 @@ void test_full (void)
         "flux_kvsdir_get_size on copy still returns 4 after orig freed");
 
     flux_kvsdir_destroy (cpy);
+
+    json_decref (o);
 }
 
 int main (int argc, char *argv[])

--- a/src/common/libkvs/test/kvs_txn_compact.c
+++ b/src/common/libkvs/test/kvs_txn_compact.c
@@ -42,8 +42,9 @@ int check_null_value (json_t *dirent)
 
 int check_raw_value (json_t *dirent, const char *expected, int expected_len)
 {
-    char *data;
+    char *data = NULL;
     int len;
+    int rc = -1;
 
     if (treeobj_decode_val (dirent, (void **)&data, &len) < 0) {
         diag ("%s: initial base64 decode failed", __FUNCTION__);
@@ -51,8 +52,9 @@ int check_raw_value (json_t *dirent, const char *expected, int expected_len)
     }
     if (len == expected_len
         && memcmp (data, expected, len) == 0)
-        return 0;
-    return -1;
+        rc = 0;
+    free (data);
+    return rc;
 }
 
 int main (int argc, char *argv[])
@@ -355,6 +357,8 @@ int main (int argc, char *argv[])
         && flags == FLUX_KVS_APPEND
         && check_null_value (dirent) == 0,
         "1: consolidated foo = A");
+
+    flux_kvs_txn_destroy (txn);
 
     /* Test 8: single append is a no-op */
 

--- a/src/common/librouter/test/router.c
+++ b/src/common/librouter/test/router.c
@@ -251,6 +251,7 @@ void test_basic (flux_t *h)
         BAIL_OUT ("flux_request_encode failed");
     router_entry_recv (entry, request); // router recives message from abcd
     ok (flux_reactor_run (r, 0) >= 0, "basic: reactor processed one message");
+    flux_msg_destroy (request);
 
     router_entry_delete (entry);
     router_destroy (rtr);

--- a/src/common/librouter/test/usock.c
+++ b/src/common/librouter/test/usock.c
@@ -152,6 +152,7 @@ void conn_invalid (void)
     ok (usock_conn_create (r, 0, -1) == NULL && errno == EINVAL,
         "usock_conn_create outfd=-1 fails with EINVAL");
 
+    flux_msg_destroy (msg);
     usock_conn_destroy (conn);
     (void)close (fd[0]);
     (void)close (fd[1]);

--- a/src/common/libsubprocess/test/cmd.c
+++ b/src/common/libsubprocess/test/cmd.c
@@ -188,6 +188,8 @@ void test_find_opts (void)
 
     ok (flux_cmd_find_opts (cmd, substrings4) == 0,
         "flux_cmd_find_opts doesn't find substrings");
+
+    flux_cmd_destroy (cmd);
 }
 
 void test_stringify (void)

--- a/src/modules/content-files/test/filedb.c
+++ b/src/modules/content-files/test/filedb.c
@@ -98,6 +98,7 @@ void test_simple (const char *dbpath)
         "filedb_get key1 works");
     ok (data && size == sizeof (val2) && memcmp (data, val2, size) == 0,
         "and returned the updated data");
+    free (data);
 }
 
 int main (int argc, char *argv[])

--- a/src/modules/job-manager/test/annotate.c
+++ b/src/modules/job-manager/test/annotate.c
@@ -83,6 +83,7 @@ void basic (void)
 
     json_decref (new);
     json_decref (cmp);
+    json_decref (orig);
 }
 
 void recursive (void)
@@ -103,6 +104,9 @@ void recursive (void)
     ok (!rc && json_equal (orig, cmp) > 0,
         "update_annotation_recursive recursively does nothing on "
         "empty dictionary");
+
+    json_decref (new);
+    json_decref (cmp);
 
     new = json_pack ("{s:{s:s}}", "obj", "str", "foo");
     cmp = json_pack ("{s:{s:s}}", "obj", "str", "foo");
@@ -178,6 +182,7 @@ void recursive (void)
 
     json_decref (new);
     json_decref (cmp);
+    json_decref (orig);
 }
 
 void overwrite (void)
@@ -236,6 +241,7 @@ void overwrite (void)
 
     json_decref (new);
     json_decref (cmp);
+    json_decref (orig);
 }
 
 int main (int argc, char *argv[])

--- a/src/modules/kvs/test/lookup.c
+++ b/src/modules/kvs/test/lookup.c
@@ -405,6 +405,7 @@ void basic_lookup (void) {
     lookup_destroy (lh);
 
     ltest_finalize (cache, krm);
+    json_decref (root);
 }
 
 void check_common (lookup_t *lh,


### PR DESCRIPTION
So due to a ASAN failure in #3548, I tried to run ASAN on TOSS4 and hit all of these other ASAN discovered memleaks when trying to debug my PR's issue (i.e. `make check` was constantly failing all over the place, never getting to the unit test failure I hit in CI).

I thought these were new ASAN discoveries in TOSS4 over TOSS3, but @grondo reminded me that we turn off leak detection in the CI b/c there are too many and many can't be fixed.   But by this point I had already gone down the path of fixing a bunch of these leaks.

I saw no reason to waste these fixes, so here they are and some extras as I continued the exercise.  I did find one actual memleak in `libjob`, so the exercise wasn't a complete waste of time.