### PR TITLE
systemd: configure weak dependency on munge

### DIFF
--- a/etc/flux.service.in
+++ b/etc/flux.service.in
@@ -1,5 +1,6 @@
 [Unit]
 Description=Flux message broker
+Wants=munge.service
 
 [Service]
 TimeoutStopSec=90


### PR DESCRIPTION
Problem: the flux system instance by default uses munge to
sign/verify job requests, but declares no dependency in its
systemd unit file.

Add a 'Wants: munge-service' to the flux systemd unit file.
This ensures that the munged service is automatically started
if available, but does not prevent flux from starting if not.

See also:
https://www.freedesktop.org/software/systemd/man/systemd.unit.html#Wants=

Fixes #3571