### PR TITLE
libjob: add flux_job_result(3)

### DIFF
--- a/doc/man3/flux_future_and_then.rst
+++ b/doc/man3/flux_future_and_then.rst
@@ -23,6 +23,12 @@ SYNOPSIS
    void flux_future_continue_error (flux_future_t *prev, int errnum,
                                     const char *errstr);
 
+::
+
+   int flux_future_fulfill_next (flux_future_t *f,
+                                 void *result,
+                                 flux_free_f free_fn);
+
 
 DESCRIPTION
 ===========
@@ -84,6 +90,14 @@ but immediately fulfills the next future in the chain with an error and
 an optional error string. Once ``flux_future_continue_error(3)``
 completes, the future ``prev`` may safely be destroyed.
 
+``flux_future_fulfill_next(3)`` is like ``flux_future_fulfill(3)``, but
+fulfills the next future in the chain instead of the current future (which
+is presumably already fulfilled). This call is useful when a chained future
+is being used for post-processing a result from intermediate future-based
+calls, as it allows the next future to be fulfilled with a custom result,
+instead of with the value of another future as in
+``flux_future_continue(3)``.
+
 
 RETURN VALUE
 ============
@@ -94,6 +108,9 @@ future, the returned ``flux_future_t`` from each will be the same object.
 
 ``flux_future_continue()`` returns 0 on success, or -1 on error with errno
 set.
+
+``flux_future_fulfill_next()`` returns 0 on success, or -1 with errno set
+to ``EINVAL`` if the target future does not have a next future to fulfill.
 
 
 ERRORS

--- a/src/bindings/python/flux/job/__init__.py
+++ b/src/bindings/python/flux/job/__init__.py
@@ -15,7 +15,7 @@ from flux.job.kill import kill_async, kill, cancel_async, cancel
 from flux.job.submit import submit_async, submit, submit_get_id
 from flux.job.info import JobInfo, JobInfoFormat
 from flux.job.list import job_list, job_list_inactive, job_list_id, JobList
-from flux.job.wait import wait_async, wait, wait_get_status
+from flux.job.wait import wait_async, wait, wait_get_status, result_async, result
 from flux.job.event import (
     event_watch_async,
     event_watch,

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -256,6 +256,9 @@ static struct optparse_option status_opts[] = {
                " solely due to an exception (e.g. canceled jobs or"
                " jobs rejected by the scheduler) to N [default=1]"
     },
+    { .name = "json", .key = 'j', .has_arg = 0,
+      .usage = "Dump job result information gleaned from eventlog to stdout",
+    },
     OPTPARSE_TABLE_END
 };
 
@@ -2234,6 +2237,7 @@ int cmd_status (optparse_t *p, int argc, char **argv)
     int i;
     int njobs;
     int verbose = optparse_getopt (p, "verbose", NULL);
+    int json = optparse_getopt (p, "json", NULL);
     int optindex = optparse_option_index (p);
     int exception_exit_code = optparse_get_int (p, "exception-exit-code", 1);
 
@@ -2272,6 +2276,14 @@ int cmd_status (optparse_t *p, int argc, char **argv)
         int exitcode;
         int exception = 0;
         const char *exc_type = NULL;
+
+        if (json) {
+            const char *s = NULL;
+            if (flux_job_result_get (futures[i], &s) < 0)
+                log_err_exit ("flux_job_result_get");
+            printf ("%s\n", s);
+        }
+
         if (flux_job_result_get_unpack (futures[i],
                                         "{s:b s?s s?i}",
                                         "exception_occurred", &exception,

--- a/src/common/libflux/composite_future.c
+++ b/src/common/libflux/composite_future.c
@@ -522,6 +522,20 @@ void flux_future_continue_error (flux_future_t *prev, int errnum,
     }
 }
 
+int flux_future_fulfill_next (flux_future_t *f,
+                              void *result,
+                              flux_free_f free_fn)
+{
+    struct chained_future *cf = chained_future_get (f);
+    if (cf == NULL || !cf->next) {
+        errno = EINVAL;
+        return -1;
+    }
+    cf->continued = true;
+    flux_future_fulfill (cf->next, result, free_fn);
+    return 0;
+}
+
 flux_future_t *flux_future_and_then (flux_future_t *prev,
                                      flux_continuation_f next_cb, void *arg)
 {

--- a/src/common/libflux/future.h
+++ b/src/common/libflux/future.h
@@ -125,6 +125,12 @@ int flux_future_continue (flux_future_t *prev, flux_future_t *f);
 void flux_future_continue_error (flux_future_t *prev, int errnum,
                                  const char *errstr);
 
+/*  Fulfill the next future in the chain immediately with a result.
+ */
+int flux_future_fulfill_next (flux_future_t *prev,
+                              void *result,
+                              flux_free_f free_fn);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/common/libjob/job.c
+++ b/src/common/libjob/job.c
@@ -23,6 +23,7 @@
 #include "job.h"
 #include "sign_none.h"
 #include "src/common/libutil/fluid.h"
+#include "src/common/libeventlog/eventlog.h"
 
 #if HAVE_FLUX_SECURITY
 /* If a textual error message is available in flux-security,
@@ -656,6 +657,220 @@ int flux_job_id_encode (flux_jobid_t id,
         return -1;
     }
     return fluid_encode (buf, bufsz, id, t);
+}
+
+static flux_job_result_t job_result_calc (json_t *res)
+{
+    double t_run = -1.;
+    int status = -1;
+    bool exception = false;
+    const char *exception_type = NULL;
+    json_error_t error;
+
+    if (json_unpack_ex (res, &error, 0,
+                        "{s?f s:b s?i s?s}",
+                        "t_run", &t_run,
+                        "exception_occurred", &exception,
+                        "waitstatus", &status,
+                        "exception_type", &exception_type) < 0)
+        return FLUX_JOB_RESULT_FAILED;
+
+    if (t_run > 0. && status == 0)
+        return FLUX_JOB_RESULT_COMPLETED;
+    if (exception) {
+        if (exception_type != NULL) {
+            if (strcmp (exception_type, "cancel") == 0)
+                return FLUX_JOB_RESULT_CANCELED;
+            if (strcmp (exception_type, "timeout") == 0)
+                return FLUX_JOB_RESULT_TIMEOUT;
+        }
+    }
+    return FLUX_JOB_RESULT_FAILED;
+}
+
+static void result_eventlog_error_cb (flux_future_t *f, void *arg)
+{
+    json_t *res = arg;
+    json_t *o = NULL;
+    char *s = NULL;
+
+    if (flux_future_get (f, NULL) < 0 && errno != ENODATA) {
+        flux_future_continue_error (f, errno, NULL);
+        goto out;
+    }
+    flux_job_result_t result = job_result_calc (res);
+    if (!(o = json_integer (result))
+        || json_object_set_new (res, "result", o) < 0
+        || !(s = json_dumps (res, JSON_COMPACT))) {
+        flux_future_continue_error (f, errno, NULL);
+        goto out;
+    }
+    flux_future_fulfill_next (f, s, free);
+out:
+    flux_future_destroy (f);
+}
+
+
+static int result_exception_severity (json_t *res)
+{
+    json_t *sev = json_object_get (res, "exception_severity");
+    if (sev) {
+        return json_integer_value (sev);
+    }
+    return -1;
+}
+
+static int job_result_handle_exception (json_t *res,
+                                        json_t *context)
+{
+    json_t *type;
+    json_t *severity;
+    json_t *note = NULL;
+    json_t *exception = json_object_get (res, "exception_occurred");
+
+    if (!exception)
+        return -1;
+
+    if (json_unpack (context,
+                     "{s:o s:o s?:o}",
+                     "type", &type,
+                     "severity", &severity,
+                     "note", &note) < 0)
+        return -1;
+
+    if (json_is_true (exception)) {
+        /* Only overwrite previous exception if the latest
+         *  is of greater severity.
+         */
+        int sev = json_integer_value (severity);
+        int prev_sev = result_exception_severity (res);
+        if (prev_sev > 0 && prev_sev < sev)
+            return 0;
+    }
+    if (json_object_set (res, "exception_occurred", json_true ()) < 0
+        || json_object_set (res, "exception_type", type) < 0
+        || json_object_set (res, "exception_note", note) < 0
+        || json_object_set (res, "exception_severity", severity) < 0)
+            return -1;
+    return 0;
+}
+
+static void result_eventlog_cb (flux_future_t *f, void *arg)
+{
+    json_t *res = arg;
+    const char *entry = NULL;
+    const char *name = NULL;
+    json_t *o = NULL;
+    json_t *context = NULL;
+    json_t *timestamp = NULL;
+
+    if (flux_job_event_watch_get (f, &entry) < 0) {
+        /* This should never happen, since this is an "and_then" callback
+         */
+        goto error;
+    }
+    if (!(o = eventlog_entry_decode (entry))
+        || !(timestamp = json_object_get (o, "timestamp"))
+        || eventlog_entry_parse (o, NULL, &name, &context) < 0)
+        goto error;
+
+    if (!strcmp (name, "submit")) {
+        if (json_object_set (res, "t_submit", timestamp) < 0)
+            goto error;
+    }
+    else if (!strcmp (name, "alloc")) {
+        if (json_object_set (res, "t_run", timestamp) < 0)
+            goto error;
+    }
+    else if (!strcmp (name, "finish")) {
+        json_t *wstatus = NULL;
+        if (json_object_set (res, "t_cleanup", timestamp) < 0
+            || !(wstatus = json_object_get (context, "status"))
+            || json_object_set (res, "waitstatus", wstatus) < 0)
+            goto error;
+    }
+    else if (!strcmp (name, "exception"))
+        job_result_handle_exception (res, context);
+
+    json_decref (o);
+
+    /*  Ensure "next" future is not auto-continued by chained future
+     *   implementation. This is non-obvious, but if this call is not
+     *   made then our next future would be prematurely fulfilled.
+     */
+    flux_future_continue (f, NULL);
+    flux_future_reset (f);
+    return;
+error:
+    flux_future_continue_error (f, errno, NULL);
+    flux_future_destroy (f);
+}
+
+int flux_job_result_get_unpack (flux_future_t *f, const char *fmt, ...)
+{
+    json_t *res;
+    json_error_t error;
+    int rc;
+    va_list ap;
+
+    if (f == NULL
+        || !(res = flux_future_aux_get (f, "flux::result"))) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (flux_future_get (f, NULL) < 0)
+        return -1;
+
+    va_start (ap, fmt);
+    rc = json_vunpack_ex (res, &error, 0, fmt, ap);
+    va_end (ap);
+    if (rc < 0)
+        errno = EINVAL;
+    return rc;
+}
+
+int flux_job_result_get (flux_future_t *f,
+                         const char **json_str)
+{
+    return flux_future_get (f, (const void **) json_str);
+}
+
+json_t *job_result_alloc (flux_jobid_t id)
+{
+    return json_pack ("{s:I s:b}",
+                      "id", id,
+                      "exception_occurred", false);
+}
+
+flux_future_t *flux_job_result (flux_t *h, flux_jobid_t id, int flags)
+{
+    json_t *res = NULL;
+    flux_future_t *f = NULL;
+    flux_future_t *event_f = NULL;
+    int saved_errno;
+
+    if (!(res = job_result_alloc (id))
+        || !(event_f = flux_job_event_watch (h, id, "eventlog", 0))
+        || !(f = flux_future_and_then (event_f, result_eventlog_cb, res))
+        || !(f = flux_future_or_then (event_f,
+                                      result_eventlog_error_cb,
+                                      res))
+        || flux_future_aux_set (f,
+                                "flux::result",
+                                res,
+                                (flux_free_f) json_decref) < 0)
+        goto error;
+
+    return f;
+error:
+    saved_errno = errno;
+    json_decref (res);
+    if (event_f) {
+        flux_job_event_watch_cancel (event_f);
+        flux_future_destroy (f);
+    }
+    errno = saved_errno;
+    return NULL;
 }
 
 /*

--- a/src/common/libjob/job.h
+++ b/src/common/libjob/job.h
@@ -212,6 +212,35 @@ flux_future_t *flux_job_event_watch (flux_t *h, flux_jobid_t id,
 int flux_job_event_watch_get (flux_future_t *f, const char **event);
 int flux_job_event_watch_cancel (flux_future_t *f);
 
+/*  Wait for job to reach its terminal state and fetch the job result
+ *   along with other ancillary information from the job eventlog.
+ */
+flux_future_t *flux_job_result (flux_t *h, flux_jobid_t id, int flags);
+
+/*  Get the job result "payload" as a JSON string
+ */
+int flux_job_result_get (flux_future_t *f,
+                         const char **json_str);
+
+/*  Decode and unpack the result payload from future `f`.
+ *  The result object contains the following information:
+ *
+ *   {
+ *     "id":i,                 jobid
+ *     "result:i,              flux_job_result_t
+ *     "t_submit":f,           timestamp of job submit event
+ *     "t_run":f,              timestamp of job alloc event
+ *     "t_cleanup":f,          timestamp of job finish event
+ *     "waitstatus"?i,         wait status (if job started)
+ *     "exception_occurred":b, true if job exception occurred
+ *     "exception_severity"?i, exception severity (if exception)
+ *     "exception_type"?s,     exception type (if exception)
+ *     "exception_note"?s      exception note (if exception)
+ *   }
+ *
+ */
+int flux_job_result_get_unpack (flux_future_t *f, const char *fmt, ...);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This is an offshoot of an idea proposed by @jameshcorbett in #3575.

The code for `flux job status` is abstracted into a new API function: `flux_job_wait_status(3)`. This function returns a future that is fulfilled when the job eventlog reaches the end condition, and the future result contains some convenient information for getting a processed exit code, detecting if the job started or hit an exception, etc.

`flux job status` is then switched to this new interface.

Not too happy about the name of the function nor the requirement for a new structure added to the interface, but this is just an early demonstration for now.

A next step would be to develop a Python binding using this interface that meets @jameshcorbett's use case.

Fixes #3575