### PR TITLE
libkvs: save aux data in future instead of handle

### DIFF
--- a/doc/man3/flux_aux_set.rst
+++ b/doc/man3/flux_aux_set.rst
@@ -38,7 +38,9 @@ but no new value is stored. If *name* is NULL,
 
 ``flux_aux_get()`` retrieves application-specific data
 by *name*. If the data was stored anonymously, it
-cannot be retrieved.
+cannot be retrieved.  Note that ``flux_aux_get()`` does not scale to a
+large number of items, and flux module handles may persist for a long
+time.
 
 Names beginning with "flux::" are reserved for internal use.
 

--- a/src/common/libflux/handle.h
+++ b/src/common/libflux/handle.h
@@ -115,6 +115,9 @@ bool flux_fatality (flux_t *h);
  * handle by name.  The destructor, if non-NULL, will be called
  * to destroy this state when the handle is destroyed.
  * Key names used internally by flux-core are prefixed with "flux::".
+ *
+ * N.B. flux_aux_get does not scale to a large number of items, and
+ * broker module handles may persist for a long time.
  */
 void *flux_aux_get (flux_t *h, const char *name);
 int flux_aux_set (flux_t *h, const char *name, void *aux, flux_free_f destroy);

--- a/src/common/libflux/test/msg_handler.c
+++ b/src/common/libflux/test/msg_handler.c
@@ -42,7 +42,7 @@ void test_msg_handler_create (flux_t *h)
      */
     mh = flux_msg_handler_create (h, FLUX_MATCH_ANY, dummy_msg_handler, NULL);
     ok (mh != NULL,
-        "able to creat fake message handler");
+        "able to create fake message handler");
     flux_msg_handler_destroy (mh);
 
     /* invalid arguments

--- a/src/common/libkvs/kvs_copy.c
+++ b/src/common/libkvs/kvs_copy.c
@@ -174,7 +174,10 @@ flux_future_t *flux_kvs_copy (flux_t *h,
                                      dstkey,
                                      commit_flags)))
         goto error;
-    if (flux_aux_set (h, NULL, ctx, (flux_free_f)copy_context_destroy) < 0) {
+    if (flux_future_aux_set (f1,
+                             NULL,
+                             ctx,
+                             (flux_free_f)copy_context_destroy) < 0) {
         copy_context_destroy (ctx);
         goto error;
     }
@@ -209,7 +212,10 @@ flux_future_t *flux_kvs_move (flux_t *h,
                                      dstkey,
                                      commit_flags)))
         goto error;
-    if (flux_aux_set (h, NULL, ctx, (flux_free_f)copy_context_destroy) < 0) {
+    if (flux_future_aux_set (f1,
+                             NULL,
+                             ctx,
+                             (flux_free_f)copy_context_destroy) < 0) {
         copy_context_destroy (ctx);
         goto error;
     }


### PR DESCRIPTION
Per discussion in #3583.

Problem: In `flux_kvs_copy()` and `flux_kvs_move()` some auxiliary data was stored in the flux handle, with a destructor set for when the handle is destroyed.  However, the flux handle is a long lived object, typically staying alive for the length of a flux instance.  Therefore, the memory is basically never freed during the existence of the instance.

This continual memory allocation led to a very large auxiliary list in the underlying implementation and poor performance for long running instances with many jobs.

Solution: Move the auxiliary data from the flux handle to the futures used within `flux_kvs_copy()` and `flux_kvs_move()`.  These futures are short lived, therefore auxiliary memory will be cleaned up more regularly.

Also add some extra documentation to remind users of this issue when using `flux_aux_set()`.

Some performance tests to show how this is helping.

Using simulated execution.

before

```
Running throughput.py 4096 jobs per iteration, 20 iterations
throughput:     100.3 job/s (script:  99.4 job/s)
throughput:     94.7 job/s (script:  93.9 job/s)
throughput:     91.1 job/s (script:  90.3 job/s)
throughput:     90.5 job/s (script:  89.7 job/s)
throughput:     85.4 job/s (script:  84.7 job/s)
throughput:     76.2 job/s (script:  75.6 job/s)
throughput:     66.3 job/s (script:  65.9 job/s)
throughput:     59.4 job/s (script:  59.0 job/s)
throughput:     53.9 job/s (script:  53.6 job/s)
throughput:     49.5 job/s (script:  49.1 job/s)
throughput:     44.4 job/s (script:  44.2 job/s)
throughput:     42.6 job/s (script:  42.4 job/s)
throughput:     38.7 job/s (script:  38.5 job/s)
throughput:     37.2 job/s (script:  37.1 job/s)
throughput:     34.7 job/s (script:  34.6 job/s)
throughput:     33.0 job/s (script:  32.9 job/s)
throughput:     31.3 job/s (script:  31.2 job/s)
throughput:     30.3 job/s (script:  30.2 job/s)
throughput:     29.7 job/s (script:  29.6 job/s)
throughput:     28.0 job/s (script:  27.9 job/s)
```

after

```
Running throughput.py 4096 jobs per iteration, 20 iterations
throughput:     97.8 job/s (script:  96.9 job/s)
throughput:     95.4 job/s (script:  94.5 job/s)
throughput:     90.3 job/s (script:  89.5 job/s)
throughput:     89.4 job/s (script:  88.6 job/s)
throughput:     88.9 job/s (script:  88.0 job/s)
throughput:     87.6 job/s (script:  86.9 job/s)
throughput:     85.8 job/s (script:  85.1 job/s)
throughput:     83.6 job/s (script:  82.9 job/s)
throughput:     85.0 job/s (script:  84.3 job/s)
throughput:     83.0 job/s (script:  82.3 job/s)
throughput:     81.2 job/s (script:  80.5 job/s)
throughput:     79.8 job/s (script:  79.2 job/s)
throughput:     82.3 job/s (script:  81.6 job/s)
throughput:     76.2 job/s (script:  75.6 job/s)
throughput:     80.8 job/s (script:  80.1 job/s)
throughput:     81.1 job/s (script:  80.5 job/s)
throughput:     80.2 job/s (script:  79.4 job/s)
throughput:     75.7 job/s (script:  75.1 job/s)
throughput:     77.3 job/s (script:  76.4 job/s)
throughput:     76.0 job/s (script:  75.4 job/s)
```

Obviously a huge difference maker.

However, there are other fixes to go as there is still some performance degradation.

When running a real job (i.e. job shell is launched) instead of using simulated execution.

before

```
Running throughput.py 4096 jobs per iteration, 20 iterations
throughput:     25.0 job/s (script:  24.9 job/s)
throughput:     22.8 job/s (script:  22.8 job/s)
throughput:     21.2 job/s (script:  21.2 job/s)
throughput:     20.2 job/s (script:  20.2 job/s)
throughput:     19.1 job/s (script:  19.1 job/s)
throughput:     18.8 job/s (script:  18.8 job/s)
throughput:     17.6 job/s (script:  17.6 job/s)
throughput:     16.7 job/s (script:  16.6 job/s)
throughput:     15.0 job/s (script:  15.0 job/s)
throughput:     14.6 job/s (script:  14.5 job/s)
throughput:     13.2 job/s (script:  13.2 job/s)
throughput:     13.1 job/s (script:  13.1 job/s)
throughput:     12.8 job/s (script:  12.8 job/s)
throughput:     12.4 job/s (script:  12.4 job/s)
throughput:     12.1 job/s (script:  12.1 job/s)
throughput:     11.6 job/s (script:  11.6 job/s)
throughput:     11.4 job/s (script:  11.4 job/s)
throughput:     10.8 job/s (script:  10.8 job/s)
throughput:     10.7 job/s (script:  10.7 job/s)
throughput:     10.5 job/s (script:  10.5 job/s)
```

after
```
Running throughput.py 4096 jobs per iteration, 20 iterations
throughput:     25.1 job/s (script:  25.0 job/s)
throughput:     23.1 job/s (script:  23.0 job/s)
throughput:     21.9 job/s (script:  21.9 job/s)
throughput:     21.2 job/s (script:  21.1 job/s)
throughput:     20.2 job/s (script:  20.2 job/s)
throughput:     18.4 job/s (script:  18.4 job/s)
throughput:     17.6 job/s (script:  17.6 job/s)
throughput:     17.3 job/s (script:  17.3 job/s)
throughput:     16.7 job/s (script:  16.7 job/s)
throughput:     15.7 job/s (script:  15.7 job/s)
throughput:     14.6 job/s (script:  14.6 job/s)
throughput:     13.7 job/s (script:  13.7 job/s)
throughput:     14.0 job/s (script:  13.9 job/s)
throughput:     13.9 job/s (script:  13.8 job/s)
throughput:     13.7 job/s (script:  13.7 job/s)
throughput:     13.5 job/s (script:  13.4 job/s)
throughput:     13.0 job/s (script:  13.0 job/s)
throughput:     13.0 job/s (script:  12.9 job/s)
throughput:     12.4 job/s (script:  12.4 job/s)
throughput:     12.2 job/s (script:  12.2 job/s)
```

There's a more severe drop here.  So this is perhaps just the first of several bottleneck fixes.

