### PR TITLE
python: avoid throwing 2nd exception on unknown errno

### DIFF
--- a/src/bindings/python/flux/core/handle.py
+++ b/src/bindings/python/flux/core/handle.py
@@ -63,9 +63,7 @@ class Flux(Wrapper):
             try:
                 self.handle = raw.flux_open(url, flags)
             except EnvironmentError as err:
-                raise EnvironmentError(
-                    err.errno, "Unable to connect to Flux: {}".format(err.strerror)
-                )
+                raise EnvironmentError(err.errno, "Unable to connect to Flux")
 
         self.aux_txn = None
 

--- a/src/bindings/python/flux/wrapper.py
+++ b/src/bindings/python/flux/wrapper.py
@@ -213,7 +213,12 @@ class FunctionWrapper(object):
             if errnum != 0:
                 raise EnvironmentError(
                     errnum,
-                    "{}: {}".format(errno.errorcode[errnum], os.strerror(errnum)),
+                    "{}: {}".format(
+                        errno.errorcode[errnum]
+                        if errnum in errno.errorcode
+                        else "Errno" + str(errnum),
+                        os.strerror(errnum),
+                    ),
                 )
 
         return result

--- a/src/modules/job-manager/alloc.c
+++ b/src/modules/job-manager/alloc.c
@@ -631,7 +631,8 @@ int alloc_queue_reprioritize (struct alloc *alloc)
 }
 
 /* called if highest priority job may have changed */
-int alloc_queue_recalc_pending (struct alloc *alloc) {
+int alloc_queue_recalc_pending (struct alloc *alloc)
+{
     struct job *head = zlistx_first (alloc->queue);
     struct job *tail = zlistx_last (alloc->pending_jobs);
     while (alloc->alloc_limit


### PR DESCRIPTION
Problem: errno values not pre-defined in the `errno.errorcode[]` dictionary cause our python API wrappers to throw a second exception within exception-throwing code.  This can actually occur since 0MQ functions called by Flux functions can set errno to 0MQ-specific values.
    
Protect against accessing an undefined dictionary entry:  when the errno value is unknown, use "ErrnoN" (N=errno) instead.

Plus some other errno related fixes are thrown in.

Edit: dropped the addition of EFLUXED generic failure code.