### PR TITLE
use zhashx_t for content-cache

### DIFF
--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -251,8 +251,6 @@ int main (int argc, char *argv[])
         oom ();
     if (!(ctx.subscriptions = zlist_new ()))
         oom ();
-    if (!(ctx.cache = content_cache_create ()))
-        oom ();
     if (!(ctx.publisher = publisher_create ()))
         oom ();
 
@@ -404,10 +402,10 @@ int main (int argc, char *argv[])
         goto cleanup;
     }
 
-    /* Registers message handlers and obtains rank.
+    /* Create content cache.
      */
-    if (content_cache_set_flux (ctx.cache, ctx.h) < 0) {
-        log_err ("content_cache_set_flux");
+    if (!(ctx.cache = content_cache_create (ctx.h))) {
+        log_err ("content_cache_create");
         goto cleanup;
     }
     if (content_cache_register_attrs (ctx.cache, ctx.attrs) < 0) {

--- a/src/broker/content-cache.h
+++ b/src/broker/content-cache.h
@@ -11,14 +11,12 @@
 #ifndef HAVE_BROKER_CONTENT_CACHE_H
 #define HAVE_BROKER_CONTENT_CACHE_H 1
 
-typedef struct content_cache content_cache_t;
+struct content_cache *content_cache_create (void);
+void content_cache_destroy (struct content_cache *cache);
 
-int content_cache_set_flux (content_cache_t *cache, flux_t *h);
+int content_cache_set_flux (struct content_cache *cache, flux_t *h);
 
-content_cache_t *content_cache_create (void);
-void content_cache_destroy (content_cache_t *cache);
-
-int content_cache_register_attrs (content_cache_t *cache, attr_t *attr);
+int content_cache_register_attrs (struct content_cache *cache, attr_t *attr);
 
 #endif /* !HAVE_BROKER_CONTENT_CACHE_H */
 

--- a/src/broker/content-cache.h
+++ b/src/broker/content-cache.h
@@ -11,10 +11,8 @@
 #ifndef HAVE_BROKER_CONTENT_CACHE_H
 #define HAVE_BROKER_CONTENT_CACHE_H 1
 
-struct content_cache *content_cache_create (void);
+struct content_cache *content_cache_create (flux_t *h);
 void content_cache_destroy (struct content_cache *cache);
-
-int content_cache_set_flux (struct content_cache *cache, flux_t *h);
 
 int content_cache_register_attrs (struct content_cache *cache, attr_t *attr);
 

--- a/src/common/libflux/msglist.c
+++ b/src/common/libflux/msglist.c
@@ -160,7 +160,7 @@ const flux_msg_t *flux_msglist_pop (struct flux_msglist *l)
 
 int flux_msglist_count (struct flux_msglist *l)
 {
-    return zlistx_size (l->zl);
+    return l ? zlistx_size (l->zl) : 0;
 }
 
 int flux_msglist_pollfd (struct flux_msglist *l)

--- a/src/common/libflux/test/msglist.c
+++ b/src/common/libflux/test/msglist.c
@@ -31,6 +31,8 @@ void check_msglist (void)
     if (!(msg2 = flux_msg_create (FLUX_MSGTYPE_REQUEST)))
         BAIL_OUT ("flux_msg_create failed");
 
+    ok (flux_msglist_count (NULL) == 0,
+        "flux_msglist_count l=NULL is 0");
     l = flux_msglist_create ();
     ok (l != NULL,
         "flux_msglist_create works");

--- a/src/common/libutil/aux.c
+++ b/src/common/libutil/aux.c
@@ -39,6 +39,8 @@ static void aux_item_destroy (struct aux_item *aux)
 }
 
 /* Create an aux item.
+ * The key (if any) is copied to the space following the item struct so the
+ * item and the key can be co-located in memory, and allocated with one malloc.
  * Return item on success, NULL on failure with errno set (ENOMEM).
  */
 static struct aux_item *aux_item_create (const char *key,


### PR DESCRIPTION
On the off chance that the content-cache's use of `zhash_t`, with its lack of growth management, has an impact on our job throughput slowdown documented in #3583, here's a quick conversion to `zhashx_t` and some other minor cleanup.

I haven't had a chance to test if this has any impact on performance - just posting it before breaking for dinner.