### PR TITLE
use LRU to purge content-cache

### DIFF
--- a/doc/man1/flux-content.rst
+++ b/doc/man1/flux-content.rst
@@ -79,11 +79,6 @@ CACHE EXPIRATION
 The parameters affecting local cache expiration may be tuned with
 flux-setattr(1):
 
-**content.purge-target-entries**
-   The cache is purged to bring the number of cache entries less than
-   or equal to this value
-   (default 1048576).
-
 **content.purge-target-size**
    The cache is purged to bring the sum of the size of cached blobs less
    than or equal to this value
@@ -93,12 +88,7 @@ flux-setattr(1):
    Only entries that have not been accessed in **old-entry** seconds
    are eligible for purge (default 10).
 
-**content.purge-large-entry**
-   Only entries with blob size greater than or equal to **large-entry** are
-   purged to reach the size target (default 256).
-
-Expiration becomes active on every heartbeat, when the cache exceeds one
-or both of the targets configured above. Dirty or invalid entries are
+Expiration becomes active on every heartbeat.  Dirty or invalid entries are
 not eligible for purge.
 
 

--- a/doc/man7/flux-broker-attributes.rst
+++ b/doc/man7/flux-broker-attributes.rst
@@ -149,17 +149,9 @@ content.flush-batch-limit
 content.hash
    The selected hash algorithm, default sha1.
 
-content.purge-large-entry
-   When the cache size footprint needs to be reduced, first consider
-   purging entries of this size or greater.
-
 content.purge-old-entry
    When the cache size footprint needs to be reduced, only consider
    purging entries that are older than this number of seconds.
-
-content.purge-target-entries
-   If possible, the cache size purged periodically so that the total
-   number of entries stays at or below this value.
 
 content.purge-target-size
    If possible, the cache size purged periodically so that the total

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -404,12 +404,8 @@ int main (int argc, char *argv[])
 
     /* Create content cache.
      */
-    if (!(ctx.cache = content_cache_create (ctx.h))) {
+    if (!(ctx.cache = content_cache_create (ctx.h, ctx.attrs))) {
         log_err ("content_cache_create");
-        goto cleanup;
-    }
-    if (content_cache_register_attrs (ctx.cache, ctx.attrs) < 0) {
-        log_err ("content cache attributes");
         goto cleanup;
     }
 

--- a/src/broker/content-cache.c
+++ b/src/broker/content-cache.c
@@ -52,7 +52,6 @@ struct msgstack {
 };
 
 struct cache_entry {
-    flux_t *h;
     void *data;
     int len;
     char *blobref;
@@ -166,10 +165,8 @@ static void cache_entry_destroy (struct cache_entry *e)
 {
     if (e) {
         int saved_errno = errno;
-        if (e->load_requests > 0)
-            flux_log (e->h, LOG_ERR, "cache entry freed with pending loads");
-        if (e->store_requests > 0)
-            flux_log (e->h, LOG_ERR, "cache entry freed wtih pending stores");
+        assert (e->load_requests == 0);
+        assert (e->store_requests == 0);
         free (e->data);
         msgstack_destroy (&e->load_requests);
         msgstack_destroy (&e->store_requests);
@@ -201,7 +198,6 @@ static struct cache_entry *cache_entry_create (flux_t *h, const char *blobref)
 
     if (!(e = calloc (1, sizeof (*e) + bloblen)))
         return NULL;
-    e->h = h;
     e->blobref = (char *)(e + 1);
     memcpy (e->blobref, blobref, bloblen);
     return e;

--- a/src/broker/content-cache.c
+++ b/src/broker/content-cache.c
@@ -975,7 +975,7 @@ static int content_cache_getattr (const char *name, const char **val, void *arg)
     return 0;
 }
 
-int content_cache_register_attrs (struct content_cache *cache, attr_t *attr)
+static int register_attrs (struct content_cache *cache, attr_t *attr)
 {
     const char *s;
 
@@ -1055,7 +1055,7 @@ void content_cache_destroy (struct content_cache *cache)
     }
 }
 
-struct content_cache *content_cache_create (flux_t *h)
+struct content_cache *content_cache_create (flux_t *h, attr_t *attrs)
 {
     struct content_cache *cache;
 
@@ -1076,6 +1076,10 @@ struct content_cache *content_cache_create (flux_t *h)
     cache->purge_large_entry = default_cache_purge_large_entry;
     strcpy (cache->hash_name, "sha1");
     cache->h = h;
+
+    if (register_attrs (cache, attrs) < 0)
+        goto error;
+
     if (flux_msg_handler_addvec (h, htab, cache, &cache->handlers) < 0)
         goto error;
     if (flux_get_rank (h, &cache->rank) < 0)

--- a/src/broker/content-cache.h
+++ b/src/broker/content-cache.h
@@ -11,10 +11,8 @@
 #ifndef HAVE_BROKER_CONTENT_CACHE_H
 #define HAVE_BROKER_CONTENT_CACHE_H 1
 
-struct content_cache *content_cache_create (flux_t *h);
+struct content_cache *content_cache_create (flux_t *h, attr_t *attr);
 void content_cache_destroy (struct content_cache *cache);
-
-int content_cache_register_attrs (struct content_cache *cache, attr_t *attr);
 
 #endif /* !HAVE_BROKER_CONTENT_CACHE_H */
 


### PR DESCRIPTION
This replaces the intensive scanning of the content-cache on every heartbeat to find candidates for purge with a simple LRU, patterned after @grondo's LRU implementation in `src/common/libutil/lru_cache.c`.  This is integrated with the internal data structures of the content cache for efficiency, and so does not use that implementation directly.

I thought I'd park this and take a more in-depth peek at its performance impact after #3591 is addressed.

There is some other quasi-related cleanup here as well.