### PR TITLE
add overlay network version/config check

### DIFF
--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -51,6 +51,7 @@ struct parent {
     char *pubkey;
     uint32_t rank;
     char rank_str[16];
+    bool error;
 };
 
 /* Wake up periodically (between 'sync_min' and 'sync_max' seconds) and:
@@ -170,6 +171,11 @@ uint32_t overlay_get_rank (struct overlay *ov)
 uint32_t overlay_get_size (struct overlay *ov)
 {
     return ov->size;
+}
+
+bool overlay_parent_error (struct overlay *ov)
+{
+    return ov->parent.error;
 }
 
 int overlay_get_child_peer_count (struct overlay *ov)

--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -37,7 +37,7 @@ enum {
 
 struct child {
     int lastseen;
-    unsigned long rank;
+    uint32_t rank;
     char rank_str[16];
     bool connected;
     bool idle;
@@ -128,7 +128,7 @@ static int alloc_children (uint32_t rank,
         for (i = 0; i < count; i++) {
             ch[i].rank = kary_childof (k, size, rank, i);
             snprintf (ch[i].rank_str, sizeof (ch[i].rank_str),"%lu",
-                      ch[i].rank);
+                      (unsigned long)ch[i].rank);
         }
     }
     *chp = ch;
@@ -148,12 +148,12 @@ int overlay_set_geometry (struct overlay *ov,
                                            tbon_k,
                                            &ov->children)) < 0)
         return -1;
-    snprintf (ov->rank_str, sizeof (ov->rank_str), "%"PRIu32, rank);
+    snprintf (ov->rank_str, sizeof (ov->rank_str), "%lu", (unsigned long)rank);
     if (rank > 0) {
         snprintf (ov->parent.rank_str,
                   sizeof (ov->parent.rank_str),
-                  "%"PRIu32,
-                  kary_parentof (tbon_k, rank));
+                  "%lu",
+                  (unsigned long)kary_parentof (tbon_k, rank));
     }
 
     return 0;
@@ -199,7 +199,7 @@ void overlay_log_idle_children (struct overlay *ov)
                         flux_log (ov->h,
                                   LOG_ERR,
                                   "child %lu idle for %s",
-                                  child->rank,
+                                  (unsigned long)child->rank,
                                   fsd);
                         child->idle = true;
                     }
@@ -209,7 +209,7 @@ void overlay_log_idle_children (struct overlay *ov)
                         flux_log (ov->h,
                                   LOG_ERR,
                                   "child %lu no longer idle",
-                                  child->rank);
+                                  (unsigned long)child->rank);
                         child->idle = false;
                     }
                 }
@@ -320,7 +320,7 @@ int overlay_sendmsg (struct overlay *ov,
                             goto error;
                         if (flux_msg_push_route (cpy, ov->rank_str) < 0)
                             goto error;
-                        snprintf (rte, sizeof (rte), "%"PRIu32, route);
+                        snprintf (rte, sizeof (rte), "%lu", (unsigned long)route);
                         if (flux_msg_push_route (cpy, rte) < 0)
                             goto error;
                         msg = cpy;
@@ -456,7 +456,7 @@ static void overlay_mcast_child (struct overlay *ov, const flux_msg_t *msg)
                 else
                     flux_log_error (ov->h,
                                     "mcast error to child rank %lu",
-                                    child->rank);
+                                    (unsigned long)child->rank);
             }
         }
     }

--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -49,6 +49,7 @@ struct parent {
     flux_watcher_t *w;
     int lastsent;
     char *pubkey;
+    uint32_t rank;
     char rank_str[16];
 };
 
@@ -150,10 +151,11 @@ int overlay_set_geometry (struct overlay *ov,
         return -1;
     snprintf (ov->rank_str, sizeof (ov->rank_str), "%lu", (unsigned long)rank);
     if (rank > 0) {
+        ov->parent.rank = kary_parentof (tbon_k, rank);
         snprintf (ov->parent.rank_str,
                   sizeof (ov->parent.rank_str),
                   "%lu",
-                  (unsigned long)kary_parentof (tbon_k, rank));
+                  (unsigned long)ov->parent.rank);
     }
 
     return 0;

--- a/src/broker/overlay.h
+++ b/src/broker/overlay.h
@@ -71,6 +71,7 @@ int overlay_get_child_peer_count (struct overlay *ov);
 const char *overlay_get_bind_uri (struct overlay *ov);
 const char *overlay_get_parent_uri (struct overlay *ov);
 int overlay_set_parent_uri (struct overlay *ov, const char *uri);
+bool overlay_parent_error (struct overlay *ov);
 
 /* Broker should call overlay_bind() if there are children.  This may happen
  * before any peers are authorized as long as they are authorized before they
@@ -83,9 +84,9 @@ int overlay_bind (struct overlay *ov, const char *uri);
  */
 int overlay_connect (struct overlay *ov);
 
-/* This hook is used by the state machine to detect when a downstream
- * peer connects or disconnects.  The callback may access the current count
- * of connected peers using overlay_get_child_peer_count().
+/* 'cb' is called each time the number of connected TBON children changes,
+ * or when a TBON parent error occurs.  Use overlay_get_child_peer_count()
+ * or overlay_parent_error() from the callback.
  */
 void overlay_set_monitor_cb (struct overlay *ov,
                              overlay_monitor_f cb,

--- a/src/broker/overlay.h
+++ b/src/broker/overlay.h
@@ -66,12 +66,15 @@ int overlay_set_parent_pubkey (struct overlay *ov, const char *pubkey);
 /* Misc. accessors
  */
 uint32_t overlay_get_rank (struct overlay *ov);
+void overlay_set_rank (struct overlay *ov, uint32_t rank); // test only
 uint32_t overlay_get_size (struct overlay *ov);
 int overlay_get_child_peer_count (struct overlay *ov);
 const char *overlay_get_bind_uri (struct overlay *ov);
 const char *overlay_get_parent_uri (struct overlay *ov);
 int overlay_set_parent_uri (struct overlay *ov, const char *uri);
 bool overlay_parent_error (struct overlay *ov);
+bool overlay_parent_success (struct overlay *ov);
+void overlay_set_version (struct overlay *ov, int version); // test only
 
 /* Broker should call overlay_bind() if there are children.  This may happen
  * before any peers are authorized as long as they are authorized before they
@@ -84,9 +87,9 @@ int overlay_bind (struct overlay *ov, const char *uri);
  */
 int overlay_connect (struct overlay *ov);
 
-/* 'cb' is called each time the number of connected TBON children changes,
- * or when a TBON parent error occurs.  Use overlay_get_child_peer_count()
- * or overlay_parent_error() from the callback.
+/* 'cb' is called each time the number of connected TBON peers changes,
+ * or when a TBON parent error occurs.  Use overlay_get_child_peer_count(),
+ * overlay_parent_error(), or overlay_parent_connected() from the callback.
  */
 void overlay_set_monitor_cb (struct overlay *ov,
                              overlay_monitor_f cb,

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -72,14 +72,16 @@ test_expect_success 'flux-start in subprocess/pmi mode works (size 2)' "
 	flux start ${ARGS} --size=2 flux getattr size | grep -x 2
 "
 test_expect_success 'flux-start with size 1 has no peers' '
+	echo 0 >nochild.exp &&
 	flux start ${ARGS} --size=1 \
-		flux python -c "import flux; print(flux.Flux().rpc(\"overlay.lspeer\").get())" >idle.out &&
-	test_must_fail grep idle idle.out
+		flux module stats --parse=child-count overlay >nochild.out &&
+	test_cmp nochild.exp nochild.out
 '
 test_expect_success 'flux-start with size 2 has rank 1 peer' '
+	echo 1 >child2.exp &&
 	flux start ${ARGS} --size=2 \
-		flux python -c "import flux; print(flux.Flux().rpc(\"overlay.lspeer\").get())" >idle2.out &&
-	grep idle idle2.out
+		flux module stats --parse=child-count overlay >child2.out &&
+	test_cmp child2.exp child2.out
 '
 test_expect_success 'flux-start --size=1 --bootstrap=selfpmi works' "
 	flux start ${ARGS} --size=1 --bootstrap=selfpmi /bin/true


### PR DESCRIPTION
This adds a handshake, when a broker connects to its TBON parent, to verify that they are running compatible versions of flux-core (exact match required for now), and checking that the connecting rank is really a peer.

This solves two potential real world system instance cases
1) Out of sync bootstrap config file resulting in improper TBON wire-up
2) A flux package upgrade that misses some nodes

If either of these error conditions is detected, the (child) broker emits a human readable error to stderr and exits with a nonzero exit code.  In the system instance case, the error would be captured in the systemd journal, and systemd would not automatically restart the failing broker.  In the non system-instance case, the enclosing instance (or `flux-start`) would capture stderr and, depending on how it is configured, possibly terminate the other brokers stuck in JOIN or QUORUM state.

The handshake should not really contribute that much to instance startup latency.  The state machine already sends an RPC to the parent broker and this one is overlapped for the most part.

This PR also lays groundwork for detecting when a broker has restarted without cleanly disconnecting, although that specific case is not handled here.