### PR TITLE
python: add explicit service_(un)register method

### DIFF
--- a/src/bindings/python/flux/core/handle.py
+++ b/src/bindings/python/flux/core/handle.py
@@ -13,6 +13,7 @@ import threading
 from contextlib import contextmanager
 
 from flux.wrapper import Wrapper
+from flux.future import Future
 from flux.rpc import RPC
 from flux.message import Message
 from flux.util import encode_topic, encode_payload
@@ -323,6 +324,12 @@ class Flux(Wrapper):
         if reactor is None:
             reactor = self.get_reactor()
         self.reactor_active_decref(reactor)
+
+    def service_register(self, name):
+        return Future(self.flux_service_register(name))
+
+    def service_unregister(self, name):
+        return Future(self.flux_service_unregister(name))
 
 
 # vi: ts=4 sw=4 expandtab

--- a/src/bindings/python/flux/future.py
+++ b/src/bindings/python/flux/future.py
@@ -71,6 +71,13 @@ class Future(WrapperPimpl):
             if prefixes is None:
                 prefixes = ["flux_future_"]
 
+            # enable Future(fut_obj) to work by just re-wrapping the
+            # underlying future object and increments its reference to avoid
+            # pre-mature destruction when the original obj gets GC'd
+            if isinstance(handle, Future):
+                handle.incref()
+                handle = handle.handle
+
             super(Future.InnerWrapper, self).__init__(
                 ffi, lib, handle, match, filter_match, prefixes, destructor
             )
@@ -166,6 +173,9 @@ class Future(WrapperPimpl):
         until future is fulfilled and throws OSError on failure.
         """
         self.pimpl.flux_future_get(ffi.NULL)
+
+    def incref(self):
+        self.pimpl.flux_future_incref()
 
 
 class WaitAllFuture(Future):

--- a/t/issues/t3186-python-future-get-sigint.sh
+++ b/t/issues/t3186-python-future-get-sigint.sh
@@ -9,10 +9,9 @@ die() { log "$@"; exit 1; }
 
 cat <<EOF >get-intr.py || die "Failed to create test script"
 import flux
-from flux.future import Future
 
 f = flux.Flux()
-Future(f.service_register("$SERVICE")).get()
+f.service_register("$SERVICE").get()
 print("get-intr.py: Added service $SERVICE", flush=True)
 
 # The following should block until interrupted:

--- a/t/python/t0012-futures.py
+++ b/t/python/t0012-futures.py
@@ -218,6 +218,26 @@ class TestHandle(unittest.TestCase):
         fut = self.f.service_unregister("rpctest")
         self.assertEqual(self.f.future_get(fut, ffi.NULL), 0)
 
+    def test_08_future_from_future(self):
+        orig_fut = Future(self.f.future_create(ffi.NULL, ffi.NULL))
+        new_fut = Future(orig_fut)
+        self.assertFalse(new_fut.is_ready())
+        orig_fut.pimpl.fulfill(ffi.NULL, ffi.NULL)
+        self.assertTrue(new_fut.is_ready())
+
+        orig_fut = self.f.rpc("broker.ping", payload=self.ping_payload)
+        new_fut = Future(orig_fut)
+        del orig_fut
+        resp_payload = new_fut.get()
+        # Future's `get` returns `None`, so just test that it is fulfilled
+        self.assertTrue(new_fut.is_ready())
+
+        orig_fut = self.f.rpc("foo.bar")
+        new_fut = Future(orig_fut)
+        del orig_fut
+        with self.assertRaises(EnvironmentError):
+            resp_payload = new_fut.get()
+
 
 if __name__ == "__main__":
     if rerun_under_flux(__flux_size()):

--- a/t/python/t0012-futures.py
+++ b/t/python/t0012-futures.py
@@ -199,8 +199,7 @@ class TestHandle(unittest.TestCase):
             for x in range(msg.payload["count"]):
                 fh.respond(msg, {"seq": x})
 
-        fut = self.f.service_register("rpctest")
-        self.f.future_get(fut, ffi.NULL)
+        self.f.service_register("rpctest").get()
         watcher = self.f.msg_watcher_create(
             service_cb, flux.constants.FLUX_MSGTYPE_REQUEST, "rpctest.multi"
         )


### PR DESCRIPTION
Problem: the service (un)register functions are currently not manually
wrapped and leverage the auto-generated bindings.  The auto-generated
bindings do not automatically wrap the returned `flux_future_t` in a
python `Future` object.  Thus registering a service currently requires
the following code:

```python
future = f.service_register(name)
f.future_get(future, ffi.NULL)
```

Solution: manually wrap the service (un)register functions so that a
`Future` object is returned automatically.  This simplifies the code to:
`f.service_register(name).get()`