### PR TITLE
avoid mvapich segfault under flux start singleton

### DIFF
--- a/src/broker/boot_pmi.c
+++ b/src/broker/boot_pmi.c
@@ -66,19 +66,23 @@ static int set_instance_level_attr (struct pmi_handle *pmi,
 /* Set broker.mapping attribute from enclosing instance PMI_process_mapping.
  */
 static int set_broker_mapping_attr (struct pmi_handle *pmi,
-                                    const char *kvsname,
+                                    struct pmi_params *pmi_params,
                                     attr_t *attrs)
 {
     char buf[1024];
     char *val = NULL;
 
-    if (broker_pmi_kvs_get (pmi,
-                            kvsname,
-                            "PMI_process_mapping",
-                            buf,
-                            sizeof (buf),
-                            -1) == PMI_SUCCESS)
-        val = buf;
+    if (pmi_params->size == 1)
+        val = "(vector,(0,1,1))";
+    else {
+        if (broker_pmi_kvs_get (pmi,
+                                pmi_params->kvsname,
+                                "PMI_process_mapping",
+                                buf,
+                                sizeof (buf),
+                                -1) == PMI_SUCCESS)
+            val = buf;
+    }
     if (attr_add (attrs, "broker.mapping", val, FLUX_ATTRFLAG_IMMUTABLE) < 0)
         return -1;
     return 0;
@@ -174,7 +178,7 @@ int boot_pmi (struct overlay *overlay, attr_t *attrs, int tbon_k)
         log_err ("set_instance_level_attr");
         goto error;
     }
-    if (set_broker_mapping_attr (pmi, pmi_params.kvsname, attrs) < 0) {
+    if (set_broker_mapping_attr (pmi, &pmi_params, attrs) < 0) {
         log_err ("error setting broker.mapping attribute");
         goto error;
     }


### PR DESCRIPTION
Here's a fix for the mvapich "invalid tag" error from `MPI_Init()` @jameshcorbett  reported in #3592.

This error occurs when flux is started by `flux start`, without `--size` or `--bootstrap=selfpmi` options, outside of a job.  When run that way, the broker uses its "singleton" PMI bootstrap mode.  The singleton mode does not find a `PMI_process_mapping` to stuff into the `broker.mapping` attribute for the shell to find later, and the pmi shell plugin thus thinks it cannot generate `PMI_process_mapping` for its jobs.  This makes mvapich sad, apparently.

Since the process mapping of a singleton is always `(vector,(0,1,1))`,  the fix is to just set the `broker.mapping` attribute to that when the instance size is 1.  See [RFC 13](https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/spec_13.html#id14) for more background.

Fix verified on quartz with the default mpi, which is where the problem was first encountered.

Note that some cases still might arise where `PMI_process_mapping` is not generated, such as when flux is launched on multiple nodes, with multiple brokers per node.  In that case, setting `-opmi.clique=pershell` should be a safe workaround for mvapich.  That can't be the default because it makes openmpi sad (#3551).



