### PR TITLE
flux-start: rename --size to --test-size, drop --bootstrap

### DIFF
--- a/doc/man1/flux-start.rst
+++ b/doc/man1/flux-start.rst
@@ -14,12 +14,11 @@ DESCRIPTION
 ===========
 
 flux-start(1) launches a new Flux instance. By default, flux-start
-execs a single flux-broker(1) directly. By default it will attempt to use
+execs a single flux-broker(1) directly, which will attempt to use
 PMI to fetch job information and bootstrap a flux instance.
 
 If a size is specified via *--test-size*, an instance of that size is to be
-started on the local host with flux-start as the parent. (Mostly used for
-testing purposes.)
+started on the local host with flux-start as the parent.
 
 A failure of the initial program (such as non-zero exit code)
 causes flux-start to exit with a non-zero exit code.
@@ -29,17 +28,7 @@ OPTIONS
 =======
 
 **-s, --test-size**\ =\ *N*
-   Launch an instance of size *N* on the local host. Only works with
-   *--bootstrap=selfpmi*. Automatically sets *--bootstrap=selfpmi* and prints
-   a warning to stderr if no *--bootstrap* option is specified.
-
-**-b, --bootstrap**\ =\ *METHOD*
-   Select the flux bootstrap method. Possible values of *METHOD* are:
-
-   -  pmi - Use PMI (Process Management Interface)
-
-   -  selfpmi - The flux-start process will activate its own internal PMI server,
-      and then it will launch flux-brokers that will bootstrap using said PMI server.
+   Launch an instance of size *N* on the local host.
 
 **-o, --broker-opts**\ =\ *option_string*
    Add options to the message broker daemon, separated by commas.
@@ -57,7 +46,7 @@ OPTIONS
    set in the environment, it will default to 0 for all brokers.
 
 **--scratchdir**\ =\ *DIR*
-   For selfpmi bootstrap mode, set the directory that will be
+   (only with *--test-size*) Set the directory that will be
    used as the rundir directory for the instance. If the directory
    does not exist then it will be created during instance startup.
    If a DIR is not set with this option, a unique temporary directory

--- a/doc/man1/flux-start.rst
+++ b/doc/man1/flux-start.rst
@@ -17,9 +17,9 @@ flux-start(1) launches a new Flux instance. By default, flux-start
 execs a single flux-broker(1) directly. By default it will attempt to use
 PMI to fetch job information and bootstrap a flux instance.
 
-If a size is specified via *--size*, an instance of that size is to be
-started on the local host with flux-start as the parent. (Mostly used for testing
-purposes.)
+If a size is specified via *--test-size*, an instance of that size is to be
+started on the local host with flux-start as the parent. (Mostly used for
+testing purposes.)
 
 A failure of the initial program (such as non-zero exit code)
 causes flux-start to exit with a non-zero exit code.
@@ -28,7 +28,7 @@ causes flux-start to exit with a non-zero exit code.
 OPTIONS
 =======
 
-**-s, --size**\ =\ *N*
+**-s, --test-size**\ =\ *N*
    Launch an instance of size *N* on the local host. Only works with
    *--bootstrap=selfpmi*. Automatically sets *--bootstrap=selfpmi* and prints
    a warning to stderr if no *--bootstrap* option is specified.

--- a/src/broker/doc/README.md
+++ b/src/broker/doc/README.md
@@ -9,7 +9,7 @@ a static set of config files, or using the Process Management Interface (PMI).
 ### PMI
 
 When Flux is launched by Flux, by another resource manager, or by
-`flux start [--bootstrap=selfpmi] ...`, PMI provides the broker rank and
+`flux start [--testsize=N] ...`, PMI provides the broker rank and
 size straight away, and the PMI KVS is used to share broker URIs via
 global exchange.
 

--- a/src/cmd/flux-start.c
+++ b/src/cmd/flux-start.c
@@ -82,8 +82,6 @@ static struct optparse_option opts[] = {
       .usage = "Be annoyingly informative", },
     { .name = "noexec",     .key = 'X', .has_arg = 0,
       .usage = "Don't execute (useful with -v, --verbose)", },
-    { .name = "bootstrap",  .key = 'b', .has_arg = 1, .arginfo = "METHOD",
-      .usage = "Set flux instance's network bootstrap method", },
     { .name = "test-size",       .key = 's', .has_arg = 1, .arginfo = "N",
       .usage = "Start a test instance by launching N brokers locally", },
     { .name = "broker-opts",.key = 'o', .has_arg = 1, .arginfo = "OPTS",
@@ -116,36 +114,6 @@ static struct optparse_option opts[] = {
     OPTPARSE_TABLE_END,
 };
 
-enum {
-    BOOTSTRAP_PMI,
-    BOOTSTRAP_SELFPMI
-};
-
-static struct {
-    char *string;
-    int num;
-} bootstrap_options[] = {
-    {"pmi", BOOTSTRAP_PMI},
-    {"selfpmi", BOOTSTRAP_SELFPMI},
-    {NULL, -1}
-};
-
-/* Turn the bootstrap option string into an integer value */
-static int parse_bootstrap_option (optparse_t *opts)
-{
-    const char *bootstrap;
-    int i;
-
-    bootstrap = optparse_get_str (opts, "bootstrap", "pmi");
-    for (i = 0; ; i++) {
-        if (bootstrap_options[i].string == NULL)
-            break;
-        if (!strcmp(bootstrap_options[i].string, bootstrap))
-            return bootstrap_options[i].num;
-    }
-    log_msg_exit("Unknown bootstrap method \"%s\"", bootstrap);
-}
-
 /* Various things will go wrong with module loading, process execution, etc.
  *  when current directory can't be found. Exit early with error to avoid
  *  chaotic stream of error messages later in startup.
@@ -165,7 +133,6 @@ int main (int argc, char *argv[])
     const char *searchpath;
     int optindex;
     char *broker_path;
-    int bootstrap;
 
     log_init ("flux-start");
 
@@ -192,15 +159,7 @@ int main (int argc, char *argv[])
     if (!(broker_path = find_broker (searchpath)))
         log_msg_exit ("Could not locate broker in %s", searchpath);
 
-    bootstrap = parse_bootstrap_option (ctx.opts);
     if (optparse_hasopt (ctx.opts, "test-size")) {
-        if (bootstrap != BOOTSTRAP_SELFPMI) {
-            if (!optparse_hasopt (ctx.opts, "bootstrap")) {
-                bootstrap = BOOTSTRAP_SELFPMI;
-            } else {
-                log_errn_exit(EINVAL, "--test-size can only be used with --bootstrap=selfpmi");
-            }
-        }
         ctx.test_size = optparse_get_int (ctx.opts, "test-size", -1);
         if (ctx.test_size <= 0)
             log_msg_exit ("--test-size argument must be > 0");
@@ -208,21 +167,15 @@ int main (int argc, char *argv[])
 
     setup_profiling_env ();
 
-    switch (bootstrap) {
-    case BOOTSTRAP_PMI:
+    if (!optparse_hasopt (ctx.opts, "test-size")) {
         if (optparse_hasopt (ctx.opts, "scratchdir"))
-            log_msg_exit ("--scratchdir only works with --bootstrap=selfpmi");
+            log_msg_exit ("--scratchdir only works with --test-size=N");
         if (optparse_hasopt (ctx.opts, "noclique"))
-            log_msg_exit ("--noclique only works with --bootstrap=selfpmi");
+            log_msg_exit ("--noclique only works with --test-size=N");
         status = exec_broker (command, len, broker_path);
-        break;
-    case BOOTSTRAP_SELFPMI:
-        if (!optparse_hasopt (ctx.opts, "test-size"))
-            log_msg_exit ("--test-size must be specified for --bootstrap=selfpmi");
+    }
+    else {
         status = start_session (command, len, broker_path);
-        break;
-    default:
-        assert(0); /* should never happen */
     }
 
     optparse_destroy (ctx.opts);

--- a/t/README.md
+++ b/t/README.md
@@ -187,7 +187,7 @@ following extra functions:
 	size <size>. If size is not given a default of 1 is used.
 	This function essentially invokes
 	
-	  exec flux start --size=N /path/to/test/script args...
+	  exec flux start --test-size=N /path/to/test/script args...
 
   run_timeout S COMMAND... :
 	Runs COMMAND with timeout of S seconds. run_timeout will

--- a/t/fluxometer.lua
+++ b/t/fluxometer.lua
@@ -71,7 +71,7 @@ function fluxTest:start_session (t)
     local extra_args = t.args or {}
     local cmd = { self.flux_path, "start",
                   unpack (self.start_args),
-                  string.format ("--size=%d", size) }
+                  string.format ("--test-size=%d", size) }
 
     if t.args then
         for _,v in pairs (t.args) do

--- a/t/python/sideflux.py
+++ b/t/python/sideflux.py
@@ -64,7 +64,6 @@ class SideFlux(object):
         flux_command = [
             flux_exe,
             "start",
-            "--bootstrap=selfpmi",
             "--test-size={}".format(self.size),
             "-o",
             "-Slog-forward-level=7",

--- a/t/python/sideflux.py
+++ b/t/python/sideflux.py
@@ -65,7 +65,7 @@ class SideFlux(object):
             flux_exe,
             "start",
             "--bootstrap=selfpmi",
-            "--size={}".format(self.size),
+            "--test-size={}".format(self.size),
             "-o",
             "-Slog-forward-level=7",
             "--scratchdir=" + self.tmpdir,

--- a/t/python/subflux.py
+++ b/t/python/subflux.py
@@ -45,7 +45,7 @@ def rerun_under_flux(size=1, personality="full"):
     # ported from sharness.d/flux-sharness.sh
     child_env["FLUX_BUILD_DIR"] = builddir
     child_env["FLUX_SOURCE_DIR"] = srcdir
-    command = [flux_exe, "start", "--bootstrap=selfpmi", "--size", str(size)]
+    command = [flux_exe, "start", "--bootstrap=selfpmi", "--test-size", str(size)]
     if personality != "full":
         for rc_num in [1, 3]:
             attr = "broker.rc{}_path".format(rc_num)

--- a/t/python/subflux.py
+++ b/t/python/subflux.py
@@ -45,7 +45,7 @@ def rerun_under_flux(size=1, personality="full"):
     # ported from sharness.d/flux-sharness.sh
     child_env["FLUX_BUILD_DIR"] = builddir
     child_env["FLUX_SOURCE_DIR"] = srcdir
-    command = [flux_exe, "start", "--bootstrap=selfpmi", "--test-size", str(size)]
+    command = [flux_exe, "start", "--test-size", str(size)]
     if personality != "full":
         for rc_num in [1, 3]:
             attr = "broker.rc{}_path".format(rc_num)

--- a/t/sharness.d/flux-sharness.sh
+++ b/t/sharness.d/flux-sharness.sh
@@ -123,7 +123,7 @@ test_under_flux() {
     logopts="-o -Slog-filename=${log_file},-Slog-forward-level=7"
     TEST_UNDER_FLUX_ACTIVE=t \
     TERM=${ORIGINAL_TERM} \
-      exec flux start --bootstrap=selfpmi --size=${size} \
+      exec flux start --bootstrap=selfpmi --test-size=${size} \
                       ${RC1_PATH+-o -Sbroker.rc1_path=${RC1_PATH}} \
                       ${RC3_PATH+-o -Sbroker.rc3_path=${RC3_PATH}} \
                       ${logopts} \

--- a/t/sharness.d/flux-sharness.sh
+++ b/t/sharness.d/flux-sharness.sh
@@ -123,7 +123,7 @@ test_under_flux() {
     logopts="-o -Slog-filename=${log_file},-Slog-forward-level=7"
     TEST_UNDER_FLUX_ACTIVE=t \
     TERM=${ORIGINAL_TERM} \
-      exec flux start --bootstrap=selfpmi --test-size=${size} \
+      exec flux start --test-size=${size} \
                       ${RC1_PATH+-o -Sbroker.rc1_path=${RC1_PATH}} \
                       ${RC3_PATH+-o -Sbroker.rc3_path=${RC3_PATH}} \
                       ${logopts} \

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -83,20 +83,14 @@ test_expect_success 'flux-start with size 2 has rank 1 peer' '
 		flux module stats --parse=child-count overlay >child2.out &&
 	test_cmp child2.exp child2.out
 '
-test_expect_success 'flux-start -s1 --bootstrap=selfpmi works' "
-	flux start ${ARGS} -s1 --bootstrap=selfpmi /bin/true
+test_expect_success 'flux-start -s1 works' "
+	flux start ${ARGS} -s1 /bin/true
 "
-test_expect_success 'flux-start --bootstrap=selfpmi fails (no size specified)' "
-	test_must_fail flux start ${ARGS} --bootstrap=selfpmi /bin/true
+test_expect_success 'flux-start --scratchdir without --test-size fails' "
+	test_must_fail flux start ${ARGS} --scratchdir=$(pwd) /bin/true
 "
-test_expect_success 'flux-start -s1 --boostrap=pmi fails' "
-	test_must_fail flux start ${ARGS} -s1 --bootstrap=pmi /bin/true
-"
-test_expect_success 'flux-start --scratchdir --boostrap=pmi fails' "
-	test_must_fail flux start ${ARGS} --scratchdir=$(pwd) --bootstrap=pmi /bin/true
-"
-test_expect_success 'flux-start --noclique --boostrap=pmi fails' "
-	test_must_fail flux start ${ARGS} --noclique --bootstrap=pmi /bin/true
+test_expect_success 'flux-start --noclique without --test-size fails' "
+	test_must_fail flux start ${ARGS} --noclique /bin/true
 "
 test_expect_success 'flux-start in exec mode passes through errors from command' "
 	test_must_fail flux start ${ARGS} /bin/false
@@ -194,21 +188,21 @@ test_expect_success 'tbon.parent-endpoint can be read on not rank 0' '
        NUM=`flux start ${ARGS} -s4 flux exec -n flux getattr tbon.parent-endpoint | grep ipc | wc -l` &&
        test $NUM -eq 3
 '
-test_expect_success 'flux start --bootstrap=pmi (singlton) cleans up rundir' '
-	flux start ${ARGS} --bootstrap=pmi \
+test_expect_success 'flux start (singlton) cleans up rundir' '
+	flux start ${ARGS} \
 		flux getattr rundir >rundir_pmi.out &&
 	RUNDIR=$(cat rundir_pmi.out) &&
 	test_must_fail test -d $RUNDIR
 '
-test_expect_success 'flux start --bootstrap=selfpmi -s1 cleans up rundirs' '
-	flux start ${ARGS} --bootstrap=selfpmi -s1 \
+test_expect_success 'flux start -s1 cleans up rundirs' '
+	flux start ${ARGS} -s1 \
 		flux getattr rundir >rundir_selfpmi1.out &&
 	RUNDIR=$(cat rundir_selfpmi1.out) &&
 	test -n "$RUNDIR" &&
 	test_must_fail test -d $RUNDIR
 '
-test_expect_success 'flux start --bootstrap=selfpmi -s2 cleans up rundirs' '
-	flux start ${ARGS} --bootstrap=selfpmi -s2 \
+test_expect_success 'flux start -s2 cleans up rundirs' '
+	flux start ${ARGS} -s2 \
 		flux getattr rundir >rundir_selfpmi2.out &&
 	RUNDIR=$(cat rundir_selfpmi2.out) &&
 	test -n "$RUNDIR" &&
@@ -408,7 +402,7 @@ test_expect_success 'scripts/waitfile works after 1s' '
 '
 # test for issue #1025
 test_expect_success 'instance can stop cleanly with subscribers (#1025)' '
-	flux start ${ARGS} -s2 --bootstrap=selfpmi bash -c "nohup flux event sub heartbeat.pulse &"
+	flux start ${ARGS} -s2 bash -c "nohup flux event sub heartbeat.pulse &"
 '
 
 # test for issue #1191
@@ -439,7 +433,7 @@ test_expect_success 'create panic script' '
 
 test_expect_success 'flux-start: panic rank 1 of a size=2 instance' '
 	! flux start ${ARGS} \
-		--killer-timeout=0.2 --bootstrap=selfpmi -s2 \
+		--killer-timeout=0.2 -s2 \
 		bash -c "flux getattr rundir; flux exec -r 1 ./panic.sh; sleep 5" >panic.out 2>panic.err
 '
 test_expect_success 'flux-start: panic message reached stderr' '

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -66,31 +66,31 @@ test_expect_success 'flux-start in exec mode works' "
 	flux start ${ARGS} flux getattr size | grep -x 1
 "
 test_expect_success 'flux-start in subprocess/pmi mode works (size 1)' "
-	flux start ${ARGS} --size=1 flux getattr size | grep -x 1
+	flux start ${ARGS} -s1 flux getattr size | grep -x 1
 "
 test_expect_success 'flux-start in subprocess/pmi mode works (size 2)' "
-	flux start ${ARGS} --size=2 flux getattr size | grep -x 2
+	flux start ${ARGS} -s2 flux getattr size | grep -x 2
 "
 test_expect_success 'flux-start with size 1 has no peers' '
 	echo 0 >nochild.exp &&
-	flux start ${ARGS} --size=1 \
+	flux start ${ARGS} -s1 \
 		flux module stats --parse=child-count overlay >nochild.out &&
 	test_cmp nochild.exp nochild.out
 '
 test_expect_success 'flux-start with size 2 has rank 1 peer' '
 	echo 1 >child2.exp &&
-	flux start ${ARGS} --size=2 \
+	flux start ${ARGS} -s2 \
 		flux module stats --parse=child-count overlay >child2.out &&
 	test_cmp child2.exp child2.out
 '
-test_expect_success 'flux-start --size=1 --bootstrap=selfpmi works' "
-	flux start ${ARGS} --size=1 --bootstrap=selfpmi /bin/true
+test_expect_success 'flux-start -s1 --bootstrap=selfpmi works' "
+	flux start ${ARGS} -s1 --bootstrap=selfpmi /bin/true
 "
 test_expect_success 'flux-start --bootstrap=selfpmi fails (no size specified)' "
 	test_must_fail flux start ${ARGS} --bootstrap=selfpmi /bin/true
 "
-test_expect_success 'flux-start --size=1 --boostrap=pmi fails' "
-	test_must_fail flux start ${ARGS} --size=1 --bootstrap=pmi /bin/true
+test_expect_success 'flux-start -s1 --boostrap=pmi fails' "
+	test_must_fail flux start ${ARGS} -s1 --bootstrap=pmi /bin/true
 "
 test_expect_success 'flux-start --scratchdir --boostrap=pmi fails' "
 	test_must_fail flux start ${ARGS} --scratchdir=$(pwd) --bootstrap=pmi /bin/true
@@ -102,19 +102,19 @@ test_expect_success 'flux-start in exec mode passes through errors from command'
 	test_must_fail flux start ${ARGS} /bin/false
 "
 test_expect_success 'flux-start in subprocess/pmi mode passes through errors from command' "
-	test_must_fail flux start ${ARGS} --size=1 /bin/false
+	test_must_fail flux start ${ARGS} -s1 /bin/false
 "
 test_expect_success 'flux-start in exec mode passes exit code due to signal' "
 	test_expect_code 130 flux start ${ARGS} 'kill -INT \$\$'
 "
 test_expect_success 'flux-start in subprocess/pmi mode passes exit code due to signal' "
-	test_expect_code 130 flux start ${ARGS} --size=1 'kill -INT \$\$'
+	test_expect_code 130 flux start ${ARGS} -s1 'kill -INT \$\$'
 "
 test_expect_success 'flux-start in exec mode works as initial program' "
-	flux start ${ARGS} --size=2 flux start ${ARGS} flux getattr size | grep -x 1
+	flux start ${ARGS} -s2 flux start ${ARGS} flux getattr size | grep -x 1
 "
 test_expect_success 'flux-start in subprocess/pmi mode works as initial program' "
-	flux start ${ARGS} --size=2 flux start ${ARGS} --size=1 flux getattr size | grep -x 1
+	flux start ${ARGS} -s2 flux start ${ARGS} -s1 flux getattr size | grep -x 1
 "
 
 test_expect_success 'flux-start --wrap option works' '
@@ -128,8 +128,8 @@ test_expect_success 'flux-start --wrap option works' '
 	EOF
 	test_cmp wrap.expected wrap.output
 '
-test_expect_success 'flux-start --wrap option works with --size' '
-	flux start ${ARGS} --size=2 -vX --wrap=test-wrap > wrap2.output 2>&1 &&
+test_expect_success 'flux-start --wrap option works with --test-size' '
+	flux start ${ARGS} -s2 -vX --wrap=test-wrap > wrap2.output 2>&1 &&
 	test_debug "cat wrap2.output" &&
 	test "$(grep -c test-wrap wrap2.output)" = "2"
 '
@@ -191,7 +191,7 @@ test_expect_success 'tbon.parent-endpoint cannot be read on rank 0' '
 	test_must_fail flux start ${ARGS} -s2 flux getattr tbon.parent-endpoint
 '
 test_expect_success 'tbon.parent-endpoint can be read on not rank 0' '
-       NUM=`flux start ${ARGS} --size 4 flux exec -n flux getattr tbon.parent-endpoint | grep ipc | wc -l` &&
+       NUM=`flux start ${ARGS} -s4 flux exec -n flux getattr tbon.parent-endpoint | grep ipc | wc -l` &&
        test $NUM -eq 3
 '
 test_expect_success 'flux start --bootstrap=pmi (singlton) cleans up rundir' '
@@ -200,15 +200,15 @@ test_expect_success 'flux start --bootstrap=pmi (singlton) cleans up rundir' '
 	RUNDIR=$(cat rundir_pmi.out) &&
 	test_must_fail test -d $RUNDIR
 '
-test_expect_success 'flux start --bootstrap=selfpmi --size=1 cleans up rundirs' '
-	flux start ${ARGS} --bootstrap=selfpmi --size=1 \
+test_expect_success 'flux start --bootstrap=selfpmi -s1 cleans up rundirs' '
+	flux start ${ARGS} --bootstrap=selfpmi -s1 \
 		flux getattr rundir >rundir_selfpmi1.out &&
 	RUNDIR=$(cat rundir_selfpmi1.out) &&
 	test -n "$RUNDIR" &&
 	test_must_fail test -d $RUNDIR
 '
-test_expect_success 'flux start --bootstrap=selfpmi --size=2 cleans up rundirs' '
-	flux start ${ARGS} --bootstrap=selfpmi --size=2 \
+test_expect_success 'flux start --bootstrap=selfpmi -s2 cleans up rundirs' '
+	flux start ${ARGS} --bootstrap=selfpmi -s2 \
 		flux getattr rundir >rundir_selfpmi2.out &&
 	RUNDIR=$(cat rundir_selfpmi2.out) &&
 	test -n "$RUNDIR" &&
@@ -439,7 +439,7 @@ test_expect_success 'create panic script' '
 
 test_expect_success 'flux-start: panic rank 1 of a size=2 instance' '
 	! flux start ${ARGS} \
-		--killer-timeout=0.2 --bootstrap=selfpmi --size=2 \
+		--killer-timeout=0.2 --bootstrap=selfpmi -s2 \
 		bash -c "flux getattr rundir; flux exec -r 1 ./panic.sh; sleep 5" >panic.out 2>panic.err
 '
 test_expect_success 'flux-start: panic message reached stderr' '

--- a/t/t1001-kvs-internals.t
+++ b/t/t1001-kvs-internals.t
@@ -293,7 +293,7 @@ test_expect_success 'kvs: invalid dirref write wont hang' '
 test_expect_success NO_ASAN "kvs: failure to store blob that exceeds max size does not hang" '
         dd if=/dev/zero count=$((1048576/4096+1)) bs=4096 \
                         skip=$((1048576/4096)) >toobig 2>/dev/null &&
-        test_must_fail flux start --size=4 -o,--setattr=content.blob-size-limit=1048576 \
+        test_must_fail flux start -s4 -o,--setattr=content.blob-size-limit=1048576 \
                        flux kvs put -r $DIR.bad_toobig=- <toobig
 '
 


### PR DESCRIPTION
As suggested in #3599, this renames some confusing `flux start` options.

The `--size=N` option is renamed to `--test-size=N` (retaining `-s` short option).
The `--bootstrap={pmi|selfpmi}` option is dropped.  The `--test-size` option now implies "selfpmi".

There will need to be a small sharness patch applies to `flux-sched` after this is merged.
