### PR TITLE
job-list: support inactive-cache-size option

### DIFF
--- a/src/modules/job-list/job-list.c
+++ b/src/modules/job-list/job-list.c
@@ -30,6 +30,10 @@ static void stats_cb (flux_t *h, flux_msg_handler_t *mh,
     int inactive = zlistx_size (ctx->jsctx->inactive);
     int idsync_lookups = zlistx_size (ctx->idsync_lookups);
     int idsync_waits = zhashx_size (ctx->idsync_waits);
+    /* N.B. the inactive count is the number of inactive jobs
+     * currently stored, which can be affected by the
+     * inactive_cache_size configuration.
+     */
     if (flux_respond_pack (h, msg, "{s:{s:i s:i s:i} s:{s:i s:i}}",
                            "jobs",
                            "pending", pending,

--- a/src/modules/job-list/job_state.h
+++ b/src/modules/job-list/job_state.h
@@ -38,6 +38,8 @@
  * The list `futures` is used to store in process futures.
  */
 
+#define INACTIVE_CACHE_SIZE_UNLIMITED -1
+
 struct job_state_ctx {
     flux_t *h;
     struct list_ctx *ctx;
@@ -58,6 +60,16 @@ struct job_state_ctx {
 
     /* stream of job events from the job-manager */
     flux_future_t *events;
+
+    /* config */
+
+    /* max inactive jobs to store / cache, < 0 indicates unlimited */
+    int inactive_cache_size;
+    zhashx_t *evicted_jobids;
+
+    /* flag indicates we are initializing via KVS, process some things
+     * differently */
+    bool init_from_kvs;
 };
 
 struct job {

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -127,6 +127,7 @@ TESTSCRIPTS = \
 	t2250-job-archive.t \
 	t2260-job-list.t \
 	t2261-job-list-update.t \
+	t2262-job-list-inactive-cache-size.t \
 	t2270-job-dependencies.t \
 	t2300-sched-simple.t \
 	t2302-sched-simple-up-down.t \

--- a/t/t2262-job-list-inactive-cache-size.t
+++ b/t/t2262-job-list-inactive-cache-size.t
@@ -1,0 +1,127 @@
+#!/bin/sh
+
+test_description='Test flux job list inactive cache size'
+
+. $(dirname $0)/sharness.sh
+
+export FLUX_CONF_DIR=$(pwd)
+test_under_flux 4 job
+
+fj_wait_event() {
+  flux job wait-event --timeout=20 "$@"
+}
+
+test_expect_success 'job-list: generate jobspec for tests' '
+        flux jobspec --format json srun -N1 hostname > hostname.json
+'
+
+test_expect_success 'job-list: unload module' '
+        flux module unload job-list
+'
+
+test_expect_success 'job-list: setup config file, cache size = 4' '
+        cat >job-list.toml <<EOF &&
+[job-list]
+inactive-cache-size = 4
+EOF
+        flux config reload
+'
+
+test_expect_success 'job-list: load module' '
+        flux module load job-list
+'
+
+test_expect_success 'job-list: submit 6 jobs' '
+        for i in $(seq 1 6); do \
+                flux job submit hostname.json >> inactiveids; \
+                fj_wait_event `tail -n 1 inactiveids` clean ; \
+        done &&
+        tac inactiveids | flux job id > inactive.ids
+'
+
+test_expect_success HAVE_JQ 'flux job list inactive jobs are truncated with cache size 4' '
+        flux job list -s inactive | jq .id > list_inactive_truncated1.out &&
+        head -n 4 inactive.ids > inactive_truncated1.ids &&
+        test_cmp list_inactive_truncated1.out inactive_truncated1.ids
+'
+
+test_expect_success 'job-list: submit 2 more jobs' '
+        for i in $(seq 1 2); do \
+                flux job submit hostname.json >> inactiveids; \
+                fj_wait_event `tail -n 1 inactiveids` clean ; \
+        done &&
+        tac inactiveids | flux job id > inactive.ids
+'
+
+test_expect_success HAVE_JQ 'flux job list inactive jobs updated and truncated with cache size 4' '
+        flux job list -s inactive | jq .id > list_inactive_truncated2.out &&
+        head -n 4 inactive.ids > inactive_truncated2.ids &&
+        test_cmp list_inactive_truncated2.out inactive_truncated2.ids
+'
+
+test_expect_success 'job-list: unload module' '
+        flux module unload job-list
+'
+
+test_expect_success 'job-list: setup config file, cache size = 5' '
+        cat >job-list.toml <<EOF &&
+[job-list]
+inactive-cache-size = 5
+EOF
+        flux config reload
+'
+
+test_expect_success 'job-list: load module' '
+        flux module load job-list
+'
+
+test_expect_success HAVE_JQ 'flux job list inactive jobs are truncated with cache size 5' '
+        flux job list -s inactive | jq .id > list_inactive_truncated3.out &&
+        head -n 5 inactive.ids > inactive_truncated3.ids &&
+        test_cmp list_inactive_truncated3.out inactive_truncated3.ids
+'
+
+test_expect_success 'job-list: unload module' '
+        flux module unload job-list
+'
+
+test_expect_success 'job-list: setup config file, cache size = 0' '
+        cat >job-list.toml <<EOF &&
+[job-list]
+inactive-cache-size = 0
+EOF
+        flux config reload
+'
+
+test_expect_success 'job-list: load module' '
+        flux module load job-list
+'
+
+test_expect_success HAVE_JQ 'flux job list no inactive jobs listed with cache size 0' '
+        flux job list -s inactive | jq .id > list_inactive_truncated4.out &&
+        touch inactive_truncated4.ids &&
+        test_cmp list_inactive_truncated4.out inactive_truncated4.ids
+'
+
+test_expect_success 'job-list: unload module' '
+        flux module unload job-list
+'
+
+test_expect_success 'job-list: setup config file, cache size = -1 (unlimited)' '
+        cat >job-list.toml <<EOF &&
+[job-list]
+inactive-cache-size = -1
+EOF
+        flux config reload
+'
+
+test_expect_success 'job-list: load module' '
+        flux module load job-list
+'
+
+test_expect_success HAVE_JQ 'flux job list all inactive jobs with cache size = -1' '
+        flux job list -s inactive | jq .id > list_inactive.out &&
+        test_cmp list_inactive.out inactive.ids
+'
+
+test_done


### PR DESCRIPTION
Per issue #3607, support an option to limit the number of inactive jobs cached by the `job-list` module.

Primary benefit: improve performance over time as the `job-list` module would use up a large amount of memory.

Consequence: job listing tools will no longer see inactive jobs "evicted" by the `job-list` module.  Because of this, the default inactive cache size is set to `-1`, which is "unlimited" cache size and the same as current behavior.  This is to maintain backwards compatibility until a more long term solution involving the `job-archive` can be designed and developed.  The option is there for any power users that may be seeing throughput limitations.

Medium term benefit: #3610 is the long term solution and a "cache size" config will be needed anyway.  So implement this easy-ish solution for the medium term.

Performance example:

w/o the option turned on

```
Running throughput.py 4096 jobs per iteration, 25 iterations
throughput:     26.0 job/s (script:  25.9 job/s)
throughput:     24.4 job/s (script:  24.4 job/s)
throughput:     23.7 job/s (script:  23.7 job/s)
throughput:     23.2 job/s (script:  23.2 job/s)
throughput:     22.9 job/s (script:  22.9 job/s)
throughput:     22.4 job/s (script:  22.3 job/s)
throughput:     21.9 job/s (script:  21.8 job/s)
throughput:     21.6 job/s (script:  21.5 job/s)
throughput:     21.4 job/s (script:  21.3 job/s)
throughput:     20.7 job/s (script:  20.6 job/s)
throughput:     20.6 job/s (script:  20.6 job/s)
throughput:     20.2 job/s (script:  20.1 job/s)
throughput:     19.5 job/s (script:  19.4 job/s)
throughput:     18.8 job/s (script:  18.8 job/s)
throughput:     18.7 job/s (script:  18.6 job/s)
throughput:     18.5 job/s (script:  18.4 job/s)
throughput:     18.4 job/s (script:  18.4 job/s)
throughput:     18.0 job/s (script:  18.0 job/s)
throughput:     17.6 job/s (script:  17.6 job/s)
throughput:     17.2 job/s (script:  17.2 job/s)
throughput:     17.0 job/s (script:  17.0 job/s)
throughput:     16.7 job/s (script:  16.7 job/s)
throughput:     16.3 job/s (script:  16.3 job/s)
throughput:     15.8 job/s (script:  15.8 job/s)
throughput:     15.8 job/s (script:  15.8 job/s)
```

w/ the option turned on with the following config


```
[job-list]
inactive-cache-size = 2048
```

```
Running throughput.py 4096 jobs per iteration, 25 iterations
throughput:     26.3 job/s (script:  26.2 job/s)
throughput:     24.9 job/s (script:  24.8 job/s)
throughput:     24.4 job/s (script:  24.4 job/s)
throughput:     24.0 job/s (script:  23.9 job/s)
throughput:     23.8 job/s (script:  23.7 job/s)
throughput:     23.7 job/s (script:  23.7 job/s)
throughput:     23.7 job/s (script:  23.7 job/s)
throughput:     23.9 job/s (script:  23.9 job/s)
throughput:     23.6 job/s (script:  23.5 job/s)
throughput:     23.5 job/s (script:  23.5 job/s)
throughput:     23.7 job/s (script:  23.6 job/s)
throughput:     23.6 job/s (script:  23.6 job/s)
throughput:     23.5 job/s (script:  23.5 job/s)
throughput:     23.4 job/s (script:  23.3 job/s)
throughput:     23.4 job/s (script:  23.3 job/s)
throughput:     23.3 job/s (script:  23.3 job/s)
throughput:     23.2 job/s (script:  23.2 job/s)
throughput:     23.3 job/s (script:  23.3 job/s)
throughput:     23.3 job/s (script:  23.3 job/s)
throughput:     23.2 job/s (script:  23.2 job/s)
throughput:     23.2 job/s (script:  23.1 job/s)
throughput:     23.2 job/s (script:  23.1 job/s)
throughput:     23.2 job/s (script:  23.1 job/s)
throughput:     23.0 job/s (script:  22.9 job/s)
throughput:     23.0 job/s (script:  23.0 job/s)
```
