### PR TITLE
libflux: msg_handler: capture duplicate non-glob request handlers in a stack

### DIFF
--- a/src/cmd/flux-jobtap.py
+++ b/src/cmd/flux-jobtap.py
@@ -33,7 +33,7 @@ def jobtap_load(args):
         )
     except FileNotFoundError:
         LOGGER.error(
-            "%s not found, no plugin is currently loaded",
+            "%s not found",
             args.plugin,
         )
         sys.exit(1)

--- a/src/common/libflux/msg_handler.c
+++ b/src/common/libflux/msg_handler.c
@@ -218,8 +218,8 @@ static void call_handler (flux_msg_handler_t *mh, const flux_msg_t *msg)
         return;
     if (!(rolemask & mh->rolemask)) {
         if (flux_msg_cmp (msg, FLUX_MATCH_REQUEST)
-                        && flux_msg_get_matchtag (msg, &matchtag) == 0
-                        && matchtag != FLUX_MATCHTAG_NONE) {
+            && flux_msg_get_matchtag (msg, &matchtag) == 0
+            && matchtag != FLUX_MATCHTAG_NONE) {
             const char *errmsg;
             if (mh->rolemask == 0 || mh->rolemask == FLUX_ROLE_OWNER)
                 errmsg = "Request requires owner credentals";
@@ -250,11 +250,11 @@ static bool dispatch_message (struct dispatch *d,
     if (type == FLUX_MSGTYPE_RESPONSE) {
         uint32_t matchtag;
         if (flux_msg_get_route_count (msg) == 0
-                && flux_msg_get_matchtag (msg, &matchtag) == 0
-                && matchtag != FLUX_MATCHTAG_NONE
-                && (mh = zhashx_lookup (d->handlers_rpc, &matchtag))
-                && mh->running
-                && flux_msg_cmp (msg, mh->match)) {
+            && flux_msg_get_matchtag (msg, &matchtag) == 0
+            && matchtag != FLUX_MATCHTAG_NONE
+            && (mh = zhashx_lookup (d->handlers_rpc, &matchtag))
+            && mh->running
+            && flux_msg_cmp (msg, mh->match)) {
             call_handler (mh, msg);
             match = true;
         }
@@ -263,8 +263,8 @@ static bool dispatch_message (struct dispatch *d,
     else if (type == FLUX_MSGTYPE_REQUEST) {
         const char *topic;
         if (flux_msg_get_topic (msg, &topic) == 0
-                && (mh = zhashx_lookup (d->handlers_method, topic))
-                && mh->running) {
+            && (mh = zhashx_lookup (d->handlers_method, topic))
+            && mh->running) {
             call_handler (mh, msg);
             match = true;
         }
@@ -487,11 +487,11 @@ void flux_msg_handler_destroy (flux_msg_handler_t *mh)
         int saved_errno = errno;
         assert (mh->magic == HANDLER_MAGIC);
         if (mh->match.typemask == FLUX_MSGTYPE_RESPONSE
-                            && mh->match.matchtag != FLUX_MATCHTAG_NONE) {
+            && mh->match.matchtag != FLUX_MATCHTAG_NONE) {
             zhashx_delete (mh->d->handlers_rpc, &mh->match.matchtag);
         }
         else if (mh->match.typemask == FLUX_MSGTYPE_REQUEST
-                            && !isa_multmatch (mh->match.topic_glob)) {
+                 && !isa_multmatch (mh->match.topic_glob)) {
             zhashx_delete (mh->d->handlers_method, mh->match.topic_glob);
         }
         else {
@@ -532,7 +532,7 @@ flux_msg_handler_t *flux_msg_handler_create (flux_t *h,
      * indicates a matchtag reuse problem!
      */
     if (mh->match.typemask == FLUX_MSGTYPE_RESPONSE
-                            && mh->match.matchtag != FLUX_MATCHTAG_NONE) {
+        && mh->match.matchtag != FLUX_MATCHTAG_NONE) {
         if (zhashx_insert (d->handlers_rpc, &mh->match.matchtag, mh) < 0) {
             errno = EEXIST;
             goto error;
@@ -543,7 +543,7 @@ flux_msg_handler_t *flux_msg_handler_create (flux_t *h,
      * This allows builtin module methods to be overridden.
      */
     else if (mh->match.typemask == FLUX_MSGTYPE_REQUEST
-                            && !isa_multmatch (mh->match.topic_glob)) {
+             && !isa_multmatch (mh->match.topic_glob)) {
         zhashx_update (d->handlers_method, mh->match.topic_glob, mh);
     }
     /* Request (glob), response (FLUX_MATCHTAG_NONE), events:

--- a/src/modules/job-manager/jobtap.c
+++ b/src/modules/job-manager/jobtap.c
@@ -485,7 +485,6 @@ static void jobtap_handle_load_req (struct job_manager *ctx,
     /*  Make plugin aware of all active jobs via job.new callback
      */
     jobs = zhashx_values (ctx->active_jobs);
-    zlistx_set_destructor (jobs, NULL);
     job = zlistx_first (jobs);
     while (job) {
         (void) jobtap_call (ctx->jobtap, job, "job.new", NULL);

--- a/src/modules/job-manager/jobtap.c
+++ b/src/modules/job-manager/jobtap.c
@@ -410,22 +410,13 @@ int jobtap_load (struct jobtap *jobtap,
         }
     }
 
-    /*  Always unload current plugin before loading next plugin.
-     *  This works around an issue in message dispatch when re-loading
-     *   the same plugin which registers a service endpoint, or
-     *   a different plugin which results in the same service topic
-     *   string. This results in the old plugin's message handler
-     *   being removed from the dispatch hash when the new plugin
-     *   registers its handler, then the *new* plugin's message handler
-     *   is removed from the hash when the old plugin is destroyed.
-     */
-    flux_plugin_destroy (jobtap->plugin);
-    jobtap->plugin = NULL;
-
     /*  Special "none" value leaves no plugin loaded
      */
-    if (strcmp (path, "none") == 0)
+    if (strcmp (path, "none") == 0) {
+        flux_plugin_destroy (jobtap->plugin);
+        jobtap->plugin = NULL;
         return 0;
+    }
 
     if (!(p = flux_plugin_create ())
         || flux_plugin_aux_set (p, "flux::jobtap", jobtap, NULL) < 0)
@@ -453,6 +444,7 @@ int jobtap_load (struct jobtap *jobtap,
         goto error;
     }
 done:
+    flux_plugin_destroy (jobtap->plugin);
     jobtap->plugin = p;
     return 0;
 error:

--- a/t/t2212-job-manager-plugins.t
+++ b/t/t2212-job-manager-plugins.t
@@ -23,8 +23,7 @@ test_expect_success 'job-manager: attempt to load invalid plugin fails' '
 	test_must_fail flux jobtap load builtin.foo &&
 	flux jobtap list >list2.out &&
 	test_debug "cat list2.out" &&
-	grep "none" list2.out &&
-	flux jobtap load builtin.priority.default
+	grep "default" list2.out
 '
 test_expect_success 'job-manager: load with invalid conf fails' '
 	cat <<-EOF >badconf.py &&

--- a/t/t2212-job-manager-plugins.t
+++ b/t/t2212-job-manager-plugins.t
@@ -37,7 +37,8 @@ test_expect_success 'job-manager: load with invalid conf fails' '
 test_expect_success 'job-manager: default plugin sets priority to urgency' '
 	jobid=$(flux mini submit --urgency=8 hostname) &&
 	flux job wait-event -v $jobid priority &&
-	test $(flux jobs -no {priority} $jobid) = 8
+	test $(flux jobs -no {priority} $jobid) = 8 &&
+	flux job wait-event -v $jobid clean
 '
 test_expect_success 'job-manager: default plugin works with sched.prioritize' '
 	ncores=$(flux resource list -s free -no {ncores}) &&
@@ -133,6 +134,7 @@ test_expect_success 'job-manager: test with random priority plugin' '
 	flux jobs -c4 -no {name}:{priority} | sort > pri-after.out &&
 	test_must_fail test_cmp pri-before.out pri-after.out &&
 	flux job cancel $sleepjob &&
+	flux job wait-event -vt 30 $sleepjob clean &&
 	flux job wait --all -v
 '
 test_expect_success 'job-manager: run args test plugin' '


### PR DESCRIPTION
As described in #3476, there is a problem when a duplicate non-glob msg handler is added to the dispatcher. The duplicate handler replaces the current handler in the internal "method handlers" hash, and then when either the old or new handler is destroyed, the hash entry is purged leaving an active but non-function msg handler.

This PR changes the single msg_handler entry in the `dispatch->handlers_method` hash into a stack of handlers. Handlers are pushed onto this stack as they are added, and the only the top handler is currently "active" (even if it is not currently started). The internal list is only created when a second matching request handler is added to a  handle.

Since the underlying issue is fixed, the workaround in the jobtap code is removed. Now when the load of a plugin fails, the previously loaded plugin can stay resident, instead of leaving no plugin active.

Along the way, a couple other issues in the jobtap code were discovered and fixed:

 * a race condition in the `t2212-job-manager-plugins.t` test
 * a memory leak when loading a jobtap plugin when jobs are active

I can move the extraneous fixes into a separate PR if that is desired.