### PR TITLE
flux-shell: add minor optimizations for single node jobs

### DIFF
--- a/src/common/libflux/barrier.c
+++ b/src/common/libflux/barrier.c
@@ -80,13 +80,21 @@ flux_future_t *flux_barrier (flux_t *h, const char *name, int nprocs)
     if (!name && !(name = generate_unique_name (h)))
         return NULL;
 
-    return flux_rpc_pack (h,
-                          "barrier.enter",
-                          FLUX_NODEID_ANY,
-                          0,
-                          "{s:s s:i}",
-                           "name", name,
-                           "nprocs", nprocs);
+    if (nprocs == 1) {
+        flux_future_t *f = flux_future_create (NULL, NULL);
+        if (f)
+            flux_future_fulfill (f, NULL, NULL);
+        return f;
+    }
+    else {
+        return flux_rpc_pack (h,
+                              "barrier.enter",
+                              FLUX_NODEID_ANY,
+                              0,
+                              "{s:s s:i}",
+                               "name", name,
+                               "nprocs", nprocs);
+    }
 }
 
 /*

--- a/src/common/libflux/barrier.c
+++ b/src/common/libflux/barrier.c
@@ -12,9 +12,6 @@
 #include "config.h"
 #endif
 #include <flux/core.h>
-#include <stdbool.h>
-
-#include "src/common/libutil/xzmalloc.h"
 
 typedef struct {
     const char *id;
@@ -43,15 +40,11 @@ static libbarrier_ctx_t *getctx (flux_t *h)
             errno = EINVAL;
             goto error;
         }
-        if (!(ctx = calloc (1, sizeof (*ctx)))) {
-            errno = ENOMEM;
+        if (!(ctx = calloc (1, sizeof (*ctx))))
             goto error;
-        }
         ctx->name_len = strlen (id) + 16;
-        if (!(ctx->name = calloc (1, ctx->name_len))) {
-            errno = ENOMEM;
+        if (!(ctx->name = calloc (1, ctx->name_len)))
             goto error;
-        }
         ctx->id = id;
         if (flux_aux_set (h, "flux::barrier_client", ctx, freectx) < 0)
             goto error;

--- a/src/shell/output.c
+++ b/src/shell/output.c
@@ -27,7 +27,7 @@
  *   task sends an EOF for both stdout and stderr.
  * - completion reference also taken for each KVS commit, to ensure
  *   commits complete before shell exits
- * - all shells (even the leader) send I/O to the service with RPC
+ * - follower shells send I/O to the service with RPC
  * - Any errors getting I/O to the leader are logged by RPC completion
  *   callbacks.
  * - Any outstanding RPCs at shell_output_destroy() are synchronously waited for
@@ -396,21 +396,13 @@ static int shell_output_file (struct shell_output *out)
     return 0;
 }
 
-/* Convert 'iodecode' object to an valid RFC 24 data event.
- * N.B. the iodecode object is a valid "context" for the event.
- */
-static void shell_output_write_cb (flux_t *h,
-                                   flux_msg_handler_t *mh,
-                                   const flux_msg_t *msg,
-                                   void *arg)
+static int shell_output_write_leader (struct shell_output *out,
+                                      json_t *o,
+                                      flux_msg_handler_t *mh) // may be NULL
 {
-    struct shell_output *out = arg;
     bool eof = false;
-    json_t *o;
     json_t *entry;
 
-    if (flux_request_unpack (msg, NULL, "o", &o) < 0)
-        goto error;
     if (iodecode (o, NULL, NULL, NULL, NULL, &eof) < 0)
         goto error;
     if (!(entry = eventlog_entry_pack (0., "data", "O", o))) // increfs 'o'
@@ -455,6 +447,26 @@ static void shell_output_write_cb (flux_t *h,
             }
         }
     }
+    return 0;
+error:
+    return -1;
+}
+
+/* Convert 'iodecode' object to an valid RFC 24 data event.
+ * N.B. the iodecode object is a valid "context" for the event.
+ */
+static void shell_output_write_cb (flux_t *h,
+                                   flux_msg_handler_t *mh,
+                                   const flux_msg_t *msg,
+                                   void *arg)
+{
+    struct shell_output *out = arg;
+    json_t *o;
+
+    if (flux_request_unpack (msg, NULL, "o", &o) < 0)
+        goto error;
+    if (shell_output_write_leader (out, o, mh) < 0)
+        goto error;
     if (flux_respond (out->shell->h, msg, NULL) < 0)
         shell_log_errno ("flux_respond");
     return;
@@ -493,16 +505,22 @@ static int shell_output_write (struct shell_output *out,
         return -1;
     }
 
-    if (!(f = flux_shell_rpc_pack (out->shell, "write", 0, 0, "O", o)))
-        goto error;
-    if (flux_future_then (f, -1, shell_output_write_completion, out) < 0)
-        goto error;
-    if (zlist_append (out->pending_writes, f) < 0)
-        shell_log_error ("zlist_append failed");
+    if (out->shell->info->shell_rank == 0) {
+        if (shell_output_write_leader (out, o, NULL) < 0)
+            shell_log_errno ("shell_output_write_leader");
+    }
+    else {
+        if (!(f = flux_shell_rpc_pack (out->shell, "write", 0, 0, "O", o)))
+            goto error;
+        if (flux_future_then (f, -1, shell_output_write_completion, out) < 0)
+            goto error;
+        if (zlist_append (out->pending_writes, f) < 0)
+            shell_log_error ("zlist_append failed");
+        if (zlist_size (out->pending_writes) >= shell_output_hwm)
+            shell_output_control (out, true);
+    }
     json_decref (o);
 
-    if (zlist_size (out->pending_writes) >= shell_output_hwm)
-        shell_output_control (out, true);
     return 0;
 
 error:
@@ -524,7 +542,7 @@ void shell_output_destroy (struct shell_output *out)
         if (out->pending_writes) {
             flux_future_t *f;
 
-            while ((f = zlist_pop (out->pending_writes))) { // leader+follower
+            while ((f = zlist_pop (out->pending_writes))) { // follower only
                 if (flux_future_get (f, NULL) < 0)
                     shell_log_errno ("shell_output_write");
                 flux_future_destroy (f);


### PR DESCRIPTION
Here are a couple of optimizations peeled off of the withdrawn PR #3567 (`flux job exec`).  My comment about these from that PR was:

> One is to turn a barrier with nprocs=1 into a no-op (avoiding an RPC). This affects all barriers, but in particular I was thinking of the one in the shell, to make the case of a single node job with one shell a little faster.
>
> The other is to shunt task output in the rank 0 (leader) shell directly to buffers rather than have rank 0 send an RPC to itself just for a slight code readability benefit. Thus, a one node job would not use any RPCs to collect output from the tasks, though nothing changes after that point (e.g. shell still commits output to KVS).
>
> The 100x serial /bin/true test didn't seem to be affected, and neither did 100x serial t/shell/lptest processes, which produce a chunk of output. So that was a bit disappointing. However, I can't imagine these changes hurt, so I went ahead and pushed them up here.

I just ran `throughput.py -x /bin/true` and didn't detect any obvious advantage there either, but these still seem like worthy changes that I hate to lose.  Maybe they will have an impact when we run down other performance bottlenecks.