### PR TITLE
job-info, kvs-watch: support guest disconnect & credential checks

### DIFF
--- a/src/common/libflux/disconnect.h
+++ b/src/common/libflux/disconnect.h
@@ -17,10 +17,19 @@
 extern "C" {
 #endif
 
+/* Return true if disconnect request msg1 came from same sender as
+ * msg2 and has appropraite authorization */
+bool flux_disconnect_match (const flux_msg_t *msg1, const flux_msg_t *msg2);
+
 /* Remove all messages in 'l' with the same sender as 'msg'.
  * Return 0 or the number of messages removed.
  */
 int flux_msglist_disconnect (struct flux_msglist *l, const flux_msg_t *msg);
+
+/* Return true if cancel request msg1 came from same sender as msg2,
+ * has appropriate authorization, and references the matchtag in
+ * msg2 */
+bool flux_cancel_match (const flux_msg_t *msg1, const flux_msg_t *msg2);
 
 /* Respond to and remove the first message in 'l' that matches 'msg'.
  * The sender must match 'msg', and the matchtag must match the one in

--- a/src/common/libflux/message.h
+++ b/src/common/libflux/message.h
@@ -256,7 +256,7 @@ int flux_msg_set_cred (flux_msg_t *msg, struct flux_msg_cred cred);
  */
 int flux_msg_cred_authorize (struct flux_msg_cred cred, uint32_t userid);
 
-/* Convenience functions that calls
+/* Convenience function that calls
  * flux_msg_get_cred() + flux_msg_cred_authorize().
  */
 int flux_msg_authorize (const flux_msg_t *msg, uint32_t userid);

--- a/src/modules/job-info/guest_watch.c
+++ b/src/modules/job-info/guest_watch.c
@@ -838,32 +838,31 @@ error:
     return -1;
 }
 
-/* Cancel guest_watch 'gw' if it matches (sender, matchtag).
- * matchtag=FLUX_MATCHTAG_NONE matches any matchtag.
+/* Cancel guest_watch 'gw' if it matches message
  */
 static void guest_watch_cancel (struct info_ctx *ctx,
                                 struct guest_watch_ctx *gw,
                                 const flux_msg_t *msg,
-                                uint32_t matchtag)
+                                bool cancel)
 {
-    uint32_t t;
-
-    if (matchtag != FLUX_MATCHTAG_NONE
-        && (flux_msg_get_matchtag (gw->msg, &t) < 0 || matchtag != t))
-        return;
-    if (flux_msg_match_route_first (msg, gw->msg))
+    bool match;
+    if (cancel)
+        match = flux_cancel_match (msg, gw->msg);
+    else
+        match = flux_disconnect_match (msg, gw->msg);
+    if (match)
         send_cancel (gw, NULL);
 }
 
 void guest_watchers_cancel (struct info_ctx *ctx,
                             const flux_msg_t *msg,
-                            uint32_t matchtag)
+                            bool cancel)
 {
     struct guest_watch_ctx *gw;
 
     gw = zlist_first (ctx->guest_watchers);
     while (gw) {
-        guest_watch_cancel (ctx, gw, msg, matchtag);
+        guest_watch_cancel (ctx, gw, msg, cancel);
         gw = zlist_next (ctx->guest_watchers);
     }
 }

--- a/src/modules/job-info/guest_watch.c
+++ b/src/modules/job-info/guest_watch.c
@@ -843,29 +843,27 @@ error:
  */
 static void guest_watch_cancel (struct info_ctx *ctx,
                                 struct guest_watch_ctx *gw,
-                                const char *sender, uint32_t matchtag)
+                                const flux_msg_t *msg,
+                                uint32_t matchtag)
 {
     uint32_t t;
-    char *s;
 
     if (matchtag != FLUX_MATCHTAG_NONE
         && (flux_msg_get_matchtag (gw->msg, &t) < 0 || matchtag != t))
         return;
-    if (flux_msg_get_route_first (gw->msg, &s) < 0)
-        return;
-    if (!strcmp (sender, s))
+    if (flux_msg_match_route_first (msg, gw->msg))
         send_cancel (gw, NULL);
-    free (s);
 }
 
 void guest_watchers_cancel (struct info_ctx *ctx,
-                            const char *sender, uint32_t matchtag)
+                            const flux_msg_t *msg,
+                            uint32_t matchtag)
 {
     struct guest_watch_ctx *gw;
 
     gw = zlist_first (ctx->guest_watchers);
     while (gw) {
-        guest_watch_cancel (ctx, gw, sender, matchtag);
+        guest_watch_cancel (ctx, gw, msg, matchtag);
         gw = zlist_next (ctx->guest_watchers);
     }
 }

--- a/src/modules/job-info/guest_watch.h
+++ b/src/modules/job-info/guest_watch.h
@@ -21,10 +21,13 @@ int guest_watch (struct info_ctx *ctx,
                  const char *path,
                  int flags);
 
-/* Cancel all lookups that match (msg credentials, matchtag). */
+/* Cancel all lookups that match msg.
+ * match credentials & matchtag if cancel true
+ * match credentials if cancel false
+ */
 void guest_watchers_cancel (struct info_ctx *ctx,
                             const flux_msg_t *msg,
-                            uint32_t matchtag);
+                            bool cancel);
 
 void guest_watch_cleanup (struct info_ctx *ctx);
 

--- a/src/modules/job-info/guest_watch.h
+++ b/src/modules/job-info/guest_watch.h
@@ -21,9 +21,10 @@ int guest_watch (struct info_ctx *ctx,
                  const char *path,
                  int flags);
 
-/* Cancel all lookups that match (sender, matchtag). */
+/* Cancel all lookups that match (msg credentials, matchtag). */
 void guest_watchers_cancel (struct info_ctx *ctx,
-                            const char *sender, uint32_t matchtag);
+                            const flux_msg_t *msg,
+                            uint32_t matchtag);
 
 void guest_watch_cleanup (struct info_ctx *ctx);
 

--- a/src/modules/job-info/job-info.c
+++ b/src/modules/job-info/job-info.c
@@ -69,7 +69,7 @@ static const struct flux_msg_handler_spec htab[] = {
     { .typemask     = FLUX_MSGTYPE_REQUEST,
       .topic_glob   = "job-info.disconnect",
       .cb           = disconnect_cb,
-      .rolemask     = 0
+      .rolemask     = FLUX_ROLE_USER
     },
     { .typemask     = FLUX_MSGTYPE_REQUEST,
       .topic_glob   = "job-info.stats.get",

--- a/src/modules/job-info/job-info.c
+++ b/src/modules/job-info/job-info.c
@@ -25,15 +25,8 @@ static void disconnect_cb (flux_t *h, flux_msg_handler_t *mh,
                            const flux_msg_t *msg, void *arg)
 {
     struct info_ctx *ctx = arg;
-    char *sender;
-
-    if (flux_msg_get_route_first (msg, &sender) < 0) {
-        flux_log_error (h, "%s: flux_msg_get_route_first", __FUNCTION__);
-        return;
-    }
-    watchers_cancel (ctx, sender, FLUX_MATCHTAG_NONE);
-    guest_watchers_cancel (ctx, sender, FLUX_MATCHTAG_NONE);
-    free (sender);
+    watchers_cancel (ctx, msg, FLUX_MATCHTAG_NONE);
+    guest_watchers_cancel (ctx, msg, FLUX_MATCHTAG_NONE);
 }
 
 static void stats_cb (flux_t *h, flux_msg_handler_t *mh,

--- a/src/modules/job-info/job-info.c
+++ b/src/modules/job-info/job-info.c
@@ -27,10 +27,6 @@ static void disconnect_cb (flux_t *h, flux_msg_handler_t *mh,
     struct info_ctx *ctx = arg;
     char *sender;
 
-    if (flux_request_decode (msg, NULL, NULL) < 0) {
-        flux_log_error (h, "%s: flux_request_decode", __FUNCTION__);
-        return;
-    }
     if (flux_msg_get_route_first (msg, &sender) < 0) {
         flux_log_error (h, "%s: flux_msg_get_route_first", __FUNCTION__);
         return;

--- a/src/modules/job-info/job-info.c
+++ b/src/modules/job-info/job-info.c
@@ -25,8 +25,8 @@ static void disconnect_cb (flux_t *h, flux_msg_handler_t *mh,
                            const flux_msg_t *msg, void *arg)
 {
     struct info_ctx *ctx = arg;
-    watchers_cancel (ctx, msg, FLUX_MATCHTAG_NONE);
-    guest_watchers_cancel (ctx, msg, FLUX_MATCHTAG_NONE);
+    watchers_cancel (ctx, msg, false);
+    guest_watchers_cancel (ctx, msg, false);
 }
 
 static void stats_cb (flux_t *h, flux_msg_handler_t *mh,

--- a/src/modules/job-info/watch.h
+++ b/src/modules/job-info/watch.h
@@ -19,9 +19,10 @@ void watch_cb (flux_t *h, flux_msg_handler_t *mh,
 void watch_cancel_cb (flux_t *h, flux_msg_handler_t *mh,
                       const flux_msg_t *msg, void *arg);
 
-/* Cancel all lookups that match (sender, matchtag). */
+/* Cancel all lookups that match (msg credentials, matchtag). */
 void watchers_cancel (struct info_ctx *ctx,
-                      const char *sender, uint32_t matchtag);
+                      const flux_msg_t *msg,
+                      uint32_t matchtag);
 
 void watch_cleanup (struct info_ctx *ctx);
 

--- a/src/modules/job-info/watch.h
+++ b/src/modules/job-info/watch.h
@@ -19,10 +19,13 @@ void watch_cb (flux_t *h, flux_msg_handler_t *mh,
 void watch_cancel_cb (flux_t *h, flux_msg_handler_t *mh,
                       const flux_msg_t *msg, void *arg);
 
-/* Cancel all lookups that match (msg credentials, matchtag). */
+/* Cancel all lookups that match msg.
+ * match credentials & matchtag if cancel true
+ * match credentials if cancel false
+ */
 void watchers_cancel (struct info_ctx *ctx,
                       const flux_msg_t *msg,
-                      uint32_t matchtag);
+                      bool cancel);
 
 void watch_cleanup (struct info_ctx *ctx);
 

--- a/src/modules/kvs-watch/kvs-watch.c
+++ b/src/modules/kvs-watch/kvs-watch.c
@@ -1031,10 +1031,6 @@ static void disconnect_cb (flux_t *h, flux_msg_handler_t *mh,
     struct watch_ctx *ctx = arg;
     char *sender;
 
-    if (flux_request_decode (msg, NULL, NULL) < 0) {
-        flux_log_error (h, "%s: flux_request_decode", __FUNCTION__);
-        return;
-    }
     if (flux_msg_get_route_first (msg, &sender) < 0) {
         flux_log_error (h, "%s: flux_msg_get_route_first", __FUNCTION__);
         return;

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -2073,8 +2073,6 @@ static void disconnect_request_cb (flux_t *h, flux_msg_handler_t *mh,
     struct kvs_cb_data cbd;
     char *sender = NULL;
 
-    if (flux_request_decode (msg, NULL, NULL) < 0)
-        return;
     if (flux_msg_get_route_first (msg, &sender) < 0)
         return;
     cbd.ctx = ctx;

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -76,7 +76,7 @@ struct kvs_cb_data {
     wait_t *wait;
     int errnum;
     bool ready;
-    char *sender;
+    const flux_msg_t *msg;
 };
 
 static void transaction_prep_cb (flux_reactor_t *r, flux_watcher_t *w,
@@ -2043,15 +2043,8 @@ static void setroot_event_cb (flux_t *h, flux_msg_handler_t *mh,
 
 static bool disconnect_cmp (const flux_msg_t *msg, void *arg)
 {
-    char *sender = arg;
-    char *s = NULL;
-    bool match = false;
-
-    if (flux_msg_get_route_first (msg, &s) == 0 && !strcmp (s, sender))
-        match = true;
-    if (s)
-        free (s);
-    return match;
+    flux_msg_t *msgreq = arg;
+    return flux_msg_match_route_first (msgreq, msg);
 }
 
 static int disconnect_request_root_cb (struct kvsroot *root, void *arg)
@@ -2060,7 +2053,7 @@ static int disconnect_request_root_cb (struct kvsroot *root, void *arg)
 
     /* Log error, but don't return -1, can continue to iterate
      * remaining roots */
-    if (kvssync_remove_msg (root, disconnect_cmp, cbd->sender) < 0)
+    if (kvssync_remove_msg (root, disconnect_cmp, (void *)cbd->msg) < 0)
         flux_log_error (cbd->ctx->h, "%s: kvssync_remove_msg", __FUNCTION__);
 
     return 0;
@@ -2071,18 +2064,14 @@ static void disconnect_request_cb (flux_t *h, flux_msg_handler_t *mh,
 {
     struct kvs_ctx *ctx = arg;
     struct kvs_cb_data cbd;
-    char *sender = NULL;
 
-    if (flux_msg_get_route_first (msg, &sender) < 0)
-        return;
     cbd.ctx = ctx;
-    cbd.sender = sender;
+    cbd.msg = msg;
     if (kvsroot_mgr_iter_roots (ctx->krm, disconnect_request_root_cb, &cbd) < 0)
         flux_log_error (h, "%s: kvsroot_mgr_iter_roots", __FUNCTION__);
 
-    if (cache_wait_destroy_msg (ctx->cache, disconnect_cmp, sender) < 0)
+    if (cache_wait_destroy_msg (ctx->cache, disconnect_cmp, (void *)msg) < 0)
         flux_log_error (h, "%s: wait_destroy_msg", __FUNCTION__);
-    free (sender);
 }
 
 static int stats_get_root_cb (struct kvsroot *root, void *arg)


### PR DESCRIPTION
Since the fixes for #3526, #3528, #3529 are similar and all related, I've put them all in this PR, although we could split them out.

1) Add a new function `flux_msg_match_cred()` to handle the common case check of ensuring a message came from an instance owner or the userid of the sender matches another message's userid.

2) Clean up some cancel/disconnect code that manually matched message senders and instead use `flux_msg_match_route_first()`

3) Add a call to `flux_msg_match_cred()` to also check for a guest user credentials.

I didn't add any tests as I'm confident that existing tests already cover this (since its cancel paths) or we've generally never covered (disconnect).
