### PR TITLE
libutil: avoid zmq_strerror()

### DIFF
--- a/src/common/libutil/log.c
+++ b/src/common/libutil/log.c
@@ -22,7 +22,6 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <signal.h>
-#include <zmq.h>
 
 #include "log.h"
 
@@ -48,16 +47,7 @@ _verr (int errnum, const char *fmt, va_list ap)
 {
     char *msg = NULL;
     char buf[128];
-    const char *s;
-
-    /* zeromq-4.2.1 reports EHOSTUNREACH as "Host unreachable",
-     * but "No route to host" is canonical on Linux and we have some
-     * tests that depend on it, so remap here.
-     */
-    if (errnum == EHOSTUNREACH)
-        s = "No route to host";
-    else
-        s = zmq_strerror (errnum);
+    const char *s = strerror (errnum);
 
     if (!prog)
         log_init (NULL);


### PR DESCRIPTION
Problem: libutil's log library calls zmq_strerror(), which creates
a libflux-core.so dependency on libzmq.so, but 0MQ only defines a
handful of error numbers.

Call strerror() instead.  If strerror() encounters an unknown
error code, it is printed numerically.

Fixes #3620