### PR TITLE
content-cache: make LRU purge more effective

### DIFF
--- a/src/broker/content-cache.c
+++ b/src/broker/content-cache.c
@@ -265,7 +265,7 @@ static void cache_entry_destructor (void **item)
  * and the blobref can be co-located in memory, and allocated with one malloc.
  * Returns entry on success, NULL with errno set on failure.
  */
-static struct cache_entry *cache_entry_create (flux_t *h, const char *blobref)
+static struct cache_entry *cache_entry_create (const char *blobref)
 {
     struct cache_entry *e;
     int bloblen = strlen (blobref) + 1;
@@ -459,7 +459,7 @@ void content_load_request (flux_t *h, flux_msg_handler_t *mh,
             errno = ENOENT;
             goto error;
         }
-        if (!(e = cache_entry_create (h, blobref))
+        if (!(e = cache_entry_create (blobref))
             || cache_entry_insert (cache, e) < 0) {
             cache_entry_destroy (e);
             flux_log_error (h, "content load");
@@ -625,7 +625,7 @@ static void content_store_request (flux_t *h, flux_msg_handler_t *mh,
         goto error;
 
     if (!(e = cache_entry_lookup (cache, blobref))) {
-        if (!(e = cache_entry_create (h, blobref)))
+        if (!(e = cache_entry_create (blobref)))
             goto error;
         if (cache_entry_insert (cache, e) < 0) {
             cache_entry_destroy (e);

--- a/src/broker/content-cache.c
+++ b/src/broker/content-cache.c
@@ -635,11 +635,9 @@ static void content_store_request (flux_t *h, flux_msg_handler_t *mh,
     if (!e->valid) {
         if (cache_entry_fill (e, data, len) < 0)
             goto error;
-        if (!e->valid) {
-            e->valid = 1;
-            cache->acct_valid++;
-            cache->acct_size += len;
-        }
+        e->valid = 1;
+        cache->acct_valid++;
+        cache->acct_size += len;
         request_list_respond_raw (&e->load_requests,
                                   cache->h,
                                   e->data,

--- a/src/broker/content-cache.c
+++ b/src/broker/content-cache.c
@@ -659,15 +659,6 @@ static void content_store_request (flux_t *h, flux_msg_handler_t *mh,
                 return;
             }
         }
-    } else {
-        /* When a backing store module is unloaded, it will clear
-         * cache->backing then attempt to store all its blobs.  Any of
-         * those still in cache need to be marked dirty.
-         */
-        if (cache->rank == 0 && !cache->backing) {
-            e->dirty = 1;
-            cache->acct_dirty++;
-        }
     }
     if (flux_respond_raw (h, msg, blobref, strlen (blobref) + 1) < 0)
         flux_log_error (h, "content store: flux_respond_raw");


### PR DESCRIPTION
The "content cache" stores blobs keyed by their hash value for the KVS.   The cache is hierarchical, with a backing store at broker rank 0, and memory caches on all broker ranks.  The memory cache is "built in" to the broker, e.g. it shares the broker thread.

On the heartbeat, if the memory cache size is above a configured threshold (16MB default), then blobs are purged in LRU order until usage falls below the threshold.  The LRU scan is aborted early if an entry is reached that is younger than a configured age (10s by default).  Along the way, any entries that are dirty (not yet written upstream/to backing store) or invalid (not yet filled from upstream/backing store) are not eligible for purge and are skipped over.

While thinking about @dongahn's performance issue in #3630, I became concerned that maybe the content cache was backlogged with the LRU containing many dirty pages older than 10s.  This could cause the regular purge to take an outsize amount of time scanning the LRU, time taken away from the broker's other tasks such as routing messages.

Although this situation has not been confirmed for the above case, the fix is simple enough:  Instead of adding all cache entries to the LRU, defer adding them until they are eligible for purging.  The LRU scan will then be 100% productive - every entry visited will be purged, until thresholds are reached.  This PR first cleans up some functions for clarity, then implements that change.

For a little bit of insight into what happens in real time while a KVS workload is running, run something like
```
$ watch flux module stats content 
```
The output is a JSON object:
```json
{
 "count": 10,
 "valid": 10,
 "dirty": 0,
 "size": 1361,
 "flush-batch-count": 0
}
```
Under load the size will reach around 16M bytes, then grow under bursts of load and shrink back to 16M.  If there is an upstream/disk backlog, the valid and dirty counts will be nonzero and the size may grow larger than 16M.

As an aside, the somewhat stingy thresholds may be tuned via broker attributes:
```
content.purge-old-entry                 10
content.purge-target-size               16777216
```
