### PR TITLE
kvs: add errmsg on namespace create failure

### DIFF
--- a/src/cmd/flux-kvs.c
+++ b/src/cmd/flux-kvs.c
@@ -456,9 +456,10 @@ int cmd_namespace_create (optparse_t *p, int argc, char **argv)
     for (i = optindex; i < argc; i++) {
         const char *name = argv[i];
         int flags = 0;
-        if (!(f = flux_kvs_namespace_create (h, name, owner, flags))
-            || flux_future_get (f, NULL) < 0)
+        if (!(f = flux_kvs_namespace_create (h, name, owner, flags)))
             log_err_exit ("%s", name);
+        if (flux_future_get (f, NULL) < 0)
+            log_msg_exit ("%s: %s", name, future_strerror (f, errno));
         flux_future_destroy (f);
     }
     flux_close (h);


### PR DESCRIPTION
Per #3637, make a KVS namespace create failure a little clearer with an error msg attached to the error if a namespace is in the process of being removed.

I went back and forth on keeping the errno EEXIST vs EAGAIN, eventually settling on EAGAIN.  But it could be EEXIST instead.