### PR TITLE
testsuite: handle hwloc issues and improve config file bootstrap test

### DIFF
--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -92,6 +92,15 @@ test_expect_success 'flux-start --scratchdir without --test-size fails' "
 test_expect_success 'flux-start --noclique without --test-size fails' "
 	test_must_fail flux start ${ARGS} --noclique /bin/true
 "
+test_expect_success 'flux-start --test-hosts without --test-size fails' "
+	test_must_fail flux start ${ARGS} --test-hosts=foo /bin/true
+"
+test_expect_success 'flux-start --test-hosts with insufficient hosts fails' "
+	test_must_fail flux start ${ARGS} -s2 --test-hosts=foo /bin/true
+"
+test_expect_success 'flux-start --test-hosts with garbled hosts fails' "
+	test_must_fail flux start ${ARGS} -s2 --test-hosts=foo] /bin/true
+"
 test_expect_success 'flux-start in exec mode passes through errors from command' "
 	test_must_fail flux start ${ARGS} /bin/false
 "

--- a/t/t2310-resource-module.t
+++ b/t/t2310-resource-module.t
@@ -141,16 +141,20 @@ test_expect_success HAVE_JQ 'hwloc XML from both sources match' '
 	done
 '
 
-test_expect_success 'reloading XML results in same R as before' '
-	flux kvs get resource.R >R.orig &&
+normalize_json() {
+	jq -cS .
+}
+
+test_expect_success HAVE_JQ 'reloading XML results in same R as before' '
+	flux kvs get resource.R | normalize_json >R.orig &&
 	flux resource reload -x hwloc &&
-	flux kvs get resource.R >R.new &&
+	flux kvs get resource.R | normalize_json >R.new &&
 	test_cmp R.orig R.new
 '
 
-test_expect_success 'reload original R just to do it and verify' '
+test_expect_success HAVE_JQ 'reload original R just to do it and verify' '
 	flux resource reload R.orig &&
-	flux kvs get resource.R >R.new2 &&
+	flux kvs get resource.R | normalize_json >R.new2 &&
 	test_cmp R.orig R.new2
 '
 

--- a/t/t2310-resource-module.t
+++ b/t/t2310-resource-module.t
@@ -117,17 +117,21 @@ test_expect_success 'flux resource reload fails on empty XML directory' '
 	test_must_fail flux resource reload -x $(pwd)/empty
 '
 
+sanitize_hwloc_xml() {
+    sed 's/pci_link_speed=".*"//g' $1
+}
+
 test_expect_success HAVE_JQ 'extract hwloc XML from JSON object' '
 	mkdir -p hwloc &&
 	for i in $(seq 0 $(($SIZE-1))); do \
-		jq -r .xml[$i] hwloc.json >hwloc/$i.xml; \
+		jq -r .xml[$i] hwloc.json | sanitize_hwloc_xml >hwloc/$i.xml; \
 	done
 '
 
 test_expect_success HAVE_JQ 'get hwloc XML direct from ranks' '
 	mkdir -p hwloc_direct &&
 	for i in $(seq 0 $(($SIZE-1))); do \
-		get_topo $i >hwloc_direct/$i.xml || return 1; \
+		get_topo $i | sanitize_hwloc_xml >hwloc_direct/$i.xml || return 1; \
 	done
 '
 

--- a/t/t3200-instance-restart.t
+++ b/t/t3200-instance-restart.t
@@ -12,19 +12,23 @@ if test -n "$S3_ACCESS_KEY_ID"; then
     export FLUX_CONF_DIR=$(pwd)
 fi
 
+lastword () {
+	awk '{ print $NF }'
+}
+
 test_expect_success 'run a job in persistent instance' '
 	flux start -o,--setattr=content.backing-path=$(pwd)/content.sqlite \
-	           flux mini run -v /bin/true 2>&1 | sed -n "s/jobid: //p" >id1.out
+	           flux mini run -v /bin/true 2>&1 | lastword >id1.out
 '
 
 test_expect_success 'restart instance and run another job' '
 	flux start -o,--setattr=content.backing-path=$(pwd)/content.sqlite \
-	           flux mini run -v /bin/true 2>&1 | sed -n "s/jobid: //p" >>id2.out
+	           flux mini run -v /bin/true 2>&1 | lastword >>id2.out
 '
 
 test_expect_success 'restart instance and run another job' '
 	flux start -o,--setattr=content.backing-path=$(pwd)/content.sqlite \
-	           flux mini run -v /bin/true 2>&1 | sed -n "s/jobid: //p" >>id3.out
+	           flux mini run -v /bin/true 2>&1 | lastword >>id3.out
 '
 
 test_expect_success 'restart instance and list inactive jobs' '
@@ -48,7 +52,7 @@ test_expect_success 'run a job in persistent instance (content-files)' '
 	flux start \
 	    -o,-Scontent.backing-module=content-files \
 	    -o,-Scontent.backing-path=$(pwd)/content.files \
-	    flux mini run -v /bin/true 2>&1 | sed -n "s/jobid: //p" >files_id1.out
+	    flux mini run -v /bin/true 2>&1 | lastword >files_id1.out
 '
 test_expect_success 'restart instance and list inactive jobs' '
 	flux start \
@@ -83,7 +87,7 @@ test_expect_success S3 'create content-s3.toml from env' '
 test_expect_success S3 'run a job in persistent instance (content-s3)' '
 	flux start \
 	    -o,-Scontent.backing-module=content-s3 \
-	    flux mini run -v /bin/true 2>&1 | sed -n "s/jobid: //p" >files_id2.out
+	    flux mini run -v /bin/true 2>&1 | lastword >files_id2.out
 '
 test_expect_success S3 'restart instance and list inactive jobs' '
 	flux start \

--- a/t/valgrind/valgrind.supp
+++ b/t/valgrind/valgrind.supp
@@ -88,3 +88,40 @@
    fun:hwloc_topology_load
    ...
 }
+{
+   <issue_3640>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:calloc
+   obj:/usr/lib/x86_64-linux-gnu/libnvidia-opencl.so.460.73.01
+   ...
+   fun:clGetPlatformIDs
+   obj:/usr/lib/x86_64-linux-gnu/hwloc/hwloc_opencl.so
+   obj:/usr/lib/x86_64-linux-gnu/libhwloc.so.15.1.0
+   fun:hwloc_topology_load
+   ...
+}
+{
+   <issue_3640>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   obj:/usr/lib/x86_64-linux-gnu/libnvidia-opencl.so.460.73.01
+   ...
+   fun:clGetPlatformIDs
+   obj:/usr/lib/x86_64-linux-gnu/hwloc/hwloc_opencl.so
+   obj:/usr/lib/x86_64-linux-gnu/libhwloc.so.15.1.0
+   fun:hwloc_topology_load
+   ...
+}
+{
+   <issue_3640>
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   fun:XNVCTRLQueryTargetStringAttribute
+   obj:/usr/lib/x86_64-linux-gnu/hwloc/hwloc_gl.so
+   obj:/usr/lib/x86_64-linux-gnu/libhwloc.so.15.1.0
+   fun:hwloc_topology_load
+   ...
+}


### PR DESCRIPTION
This fixes/works around some test issues that popped up over the weekend when I started using a freshly installed Ubuntu 20.04 LTS system with an nvidia GPU.

Continuing in the "test enhancements" vein, this adds a new `flux start --test-hosts=HOSTLIST` option to enable a config file bootstrapped flux instance to be started in test.  That cleaned up some fragile "manual start" scripting in `t0013-config-file.t` .  It also prepares for  future tests that will restart brokers (since PMI bootstrap is not restartable).