### PR TITLE
flux-start: add embedded server

### DIFF
--- a/src/common/libflux/event.h
+++ b/src/common/libflux/event.h
@@ -37,7 +37,7 @@ int flux_event_decode (const flux_msg_t *msg, const char **topic,
 int flux_event_unpack (const flux_msg_t *msg, const char **topic,
                        const char *fmt, ...);
 
-/* Encode an event message with optinal string payload.
+/* Encode an event message with optional string payload.
  * If s is non-NULL, it is copied to the message payload.
  * Returns message or NULL on failure with errno set.
  */
@@ -77,7 +77,7 @@ flux_future_t *flux_event_publish_pack (flux_t *h,
                                         const char *topic, int flags,
                                         const char *fmt, ...);
 
-/* Publish an event with optinal raw paylaod.
+/* Publish an event with optional raw payload.
  */
 flux_future_t *flux_event_publish_raw (flux_t *h,
                                        const char *topic, int flags,

--- a/src/common/libflux/message.h
+++ b/src/common/libflux/message.h
@@ -191,7 +191,7 @@ int flux_msg_set_flags (flux_msg_t *msg, uint8_t flags);
 /* Get/set string payload.
  * flux_msg_set_string() accepts a NULL 's' (no payload).
  * flux_msg_get_string() will set 's' to NULL if there is no payload
- * N.B. the raw paylaod includes C string \0 terminator.
+ * N.B. the raw payload includes C string \0 terminator.
  */
 int flux_msg_set_string (flux_msg_t *msg, const char *);
 int flux_msg_get_string (const flux_msg_t *msg, const char **s);

--- a/src/common/libflux/message.h
+++ b/src/common/libflux/message.h
@@ -59,12 +59,14 @@ struct flux_match {
 };
 
 struct flux_match flux_match_init (int typemask,
-                                                   uint32_t matchtag,
-                                                   const char *topic_glob);
+                                   uint32_t matchtag,
+                                   const char *topic_glob);
 
 void flux_match_free (struct flux_match m);
 
-int flux_match_asprintf (struct flux_match *m, const char *topic_glob_fmt, ...);
+int flux_match_asprintf (struct flux_match *m,
+                         const char *topic_glob_fmt,
+                         ...);
 
 #define FLUX_MATCH_ANY flux_match_init( \
     FLUX_MSGTYPE_ANY, \
@@ -334,14 +336,14 @@ int flux_msg_pop_route (flux_msg_t *msg, char **id);
  * For requests, this is the sender; for responses, this is the recipient.
  * Returns 0 on success, -1 with errno set (e.g. EPROTO) on failure.
  */
-int flux_msg_get_route_first (const flux_msg_t *msg, char **id); /* closest to delim */
+int flux_msg_get_route_first (const flux_msg_t *msg, char **id);
 
 /* Copy the last routing frame (farthest from delimiter) contents (or NULL)
  * to 'id'.  Caller must free 'id'.
  * For requests, this is the last hop; for responses: this is the next hop.
  * Returns 0 on success, -1 with errno set (e.g. EPROTO) on failure.
  */
-int flux_msg_get_route_last (const flux_msg_t *msg, char **id); /* farthest from delim */
+int flux_msg_get_route_last (const flux_msg_t *msg, char **id);
 
 /* Return the number of route frames in the message.
  * It is an EPROTO error if there is no route stack.

--- a/src/common/librouter/Makefile.am
+++ b/src/common/librouter/Makefile.am
@@ -29,7 +29,9 @@ librouter_la_SOURCES = \
 	servhash.h \
 	servhash.c \
 	router.h \
-	router.c
+	router.c \
+	usock_service.h \
+	usock_service.c
 
 TESTS = \
 	test_sendfd.t \
@@ -41,7 +43,8 @@ TESTS = \
 	test_usock_emfile.t \
 	test_subhash.t \
 	test_router.t \
-	test_servhash.t
+	test_servhash.t \
+	test_usock_service.t
 
 check_PROGRAMS = \
         $(TESTS)
@@ -120,3 +123,8 @@ test_servhash_t_SOURCES = test/servhash.c
 test_servhash_t_CPPFLAGS = $(test_cppflags)
 test_servhash_t_LDADD = $(test_ldadd)
 test_servhash_t_LDFLAGS = $(test_ldflags)
+
+test_usock_service_t_SOURCES = test/usock_service.c
+test_usock_service_t_CPPFLAGS = $(test_cppflags)
+test_usock_service_t_LDADD = $(test_ldadd)
+test_usock_service_t_LDFLAGS = $(test_ldflags)

--- a/src/common/librouter/test/usock_service.c
+++ b/src/common/librouter/test/usock_service.c
@@ -1,0 +1,152 @@
+/************************************************************  \
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <limits.h>
+#include <pthread.h>
+#include <flux/core.h>
+
+#include "src/common/libtap/tap.h"
+#include "src/common/libutil/unlink_recursive.h"
+#include "src/common/librouter/usock_service.h"
+
+struct server_context {
+    char sockpath[1024];
+    pthread_t t;
+    flux_t *h;
+    flux_reactor_t *r;
+    flux_msg_handler_t **handlers;
+};
+
+void tmpdir_destroy (const char *path)
+{
+    diag ("rm -r %s", path);
+    if (unlink_recursive (path) < 0)
+        BAIL_OUT ("unlink_recursive failed");
+}
+
+void tmpdir_create (char *buf, int size)
+{
+    const char *tmpdir = getenv ("TMPDIR");
+
+    if (snprintf (buf,
+                  size,
+                  "%s/usock.XXXXXXX",
+                  tmpdir ? tmpdir : "/tmp") >= size)
+        BAIL_OUT ("tmpdir_create buffer overflow");
+    if (!mkdtemp (buf))
+        BAIL_OUT ("mkdtemp %s: %s", buf, strerror (errno));
+    diag ("mkdir %s", buf);
+}
+
+void hello_cb (flux_t *h,
+               flux_msg_handler_t *mh,
+               const flux_msg_t *msg,
+               void *arg)
+{
+    diag ("hello");
+    if (flux_respond (h, msg, NULL) < 0)
+        BAIL_OUT ("flux_respond failed");
+}
+
+void disconnect_cb (flux_t *h,
+                    flux_msg_handler_t *mh,
+                    const flux_msg_t *msg,
+                    void *arg)
+{
+    char *uuid = NULL;
+    if (flux_msg_get_route_first (msg, &uuid) == 0)
+        diag ("disconnect from %.5s", uuid);
+    free (uuid);
+    flux_reactor_stop (flux_get_reactor (h));
+}
+
+void *server_thread (void *arg)
+{
+    struct server_context *ctx = arg;
+
+    flux_reactor_run (ctx->r, 0);
+    return NULL;
+}
+
+const struct flux_msg_handler_spec htab[] = {
+    { FLUX_MSGTYPE_REQUEST, "hello", hello_cb, 0 },
+    { FLUX_MSGTYPE_REQUEST, "disconnect", disconnect_cb, 0 },
+    FLUX_MSGHANDLER_TABLE_END,
+};
+
+void server_create (struct server_context *ctx, const char *tmpdir)
+{
+    if (!(ctx->r = flux_reactor_create (0)))
+        BAIL_OUT ("flux_reactor_create failed");
+    snprintf (ctx->sockpath, sizeof (ctx->sockpath), "%s/sock", tmpdir);
+    ctx->h = usock_service_create (ctx->r, ctx->sockpath, true);
+    ok (ctx->h != NULL,
+        "usock_service_create listening on %s", ctx->sockpath);
+    ok (flux_msg_handler_addvec (ctx->h, htab, &ctx, &ctx->handlers) == 0,
+        "successfully registered msg handlers");
+    ok (pthread_create (&ctx->t, NULL, server_thread, ctx) == 0,
+        "started server thread");
+}
+
+void server_destroy (struct server_context *ctx)
+{
+    ok (pthread_join (ctx->t, NULL) == 0,
+        "joined with server thread");
+    flux_msg_handler_delvec (ctx->handlers);
+    flux_close (ctx->h);
+    flux_reactor_destroy (ctx->r);
+}
+
+void simple_check (const char *tmpdir)
+{
+    char uri[2048];
+    struct server_context ctx;
+    flux_t *h;
+    flux_future_t *f;
+
+    memset (&ctx, 0, sizeof (ctx));
+    server_create (&ctx, tmpdir);
+
+    snprintf (uri, sizeof (uri), "local://%s", ctx.sockpath);
+    h = flux_open (uri, 0);
+    ok (h != NULL,
+        "client connected to server");
+
+    if (!(f = flux_rpc (h, "hello", NULL, 0, 0)))
+        BAIL_OUT ("error sending hello RPC");
+    ok (flux_rpc_get (f, NULL) == 0,
+        "got response to HELLO rpc");
+    flux_future_destroy (f);
+
+    flux_close (h); // triggers disconnect
+
+    server_destroy (&ctx);
+}
+
+int main (int argc, char *argv[])
+{
+    char tmpdir[PATH_MAX + 1];
+
+    plan (NO_PLAN);
+    tmpdir_create (tmpdir, sizeof (tmpdir));
+
+    simple_check (tmpdir);
+
+    tmpdir_destroy (tmpdir);
+    done_testing ();
+    return 0;
+}
+
+/*
+ * vi: ts=4 sw=4 expandtab
+ */

--- a/src/common/librouter/usock_service.c
+++ b/src/common/librouter/usock_service.c
@@ -1,0 +1,226 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <unistd.h>
+#include <sys/types.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <flux/core.h>
+
+#include "src/common/libczmqcontainers/czmq_containers.h"
+#include "src/common/libutil/log.h"
+#include "src/common/libutil/errno_safe.h"
+#include "usock.h"
+
+#include "usock_service.h"
+
+static void service_destroy (void *impl);
+
+static const struct flux_handle_ops service_handle_ops;
+
+struct service {
+    bool verbose;
+    struct usock_server *usock_srv;
+    struct flux_msg_cred cred;
+    zhashx_t *connections; // uconn by uuid
+    flux_t *h;
+};
+
+/* zhashx_destructor_fn signature */
+static void connection_destructor (void **item)
+{
+    if (item) {
+        usock_conn_destroy (*item);
+        *item = NULL;
+    }
+}
+
+static void notify_disconnect (struct service *ss, const char *uuid)
+{
+    flux_msg_t *msg;
+
+    if (!(msg = flux_request_encode ("disconnect", NULL))
+        || flux_msg_set_noresponse (msg) < 0
+        || flux_msg_enable_route (msg) < 0
+        || flux_msg_set_cred (msg, ss->cred) < 0
+        || flux_msg_push_route (msg, uuid) < 0
+        || flux_requeue (ss->h, msg, FLUX_RQ_TAIL) < 0) {
+        if (ss->verbose)
+            log_msg ("error notifying server of %.5s disconnect", uuid);
+    }
+    flux_msg_decref (msg);
+}
+
+/* usock_conn_error_f signature */
+static void service_error (struct usock_conn *uconn, int errnum, void *arg)
+{
+    struct service *ss = arg;
+    const char *uuid = usock_conn_get_uuid (uconn);
+
+    if (ss->verbose) {
+        if (errnum != EPIPE && errnum != EPROTO && errnum != ECONNRESET) {
+            const struct flux_msg_cred *cred = usock_conn_get_cred (uconn);
+            log_errn (errnum, "client=%.5s userid=%u",
+                     uuid,
+                     (unsigned int)cred->userid);
+        }
+        log_msg ("bye %.5s", uuid);
+    }
+    notify_disconnect (ss, uuid); // notify server of disconnect
+    zhashx_delete (ss->connections, uuid);
+}
+
+/* usock_conn_recv_f signature */
+static void service_recv (struct usock_conn *uconn, flux_msg_t *msg, void *arg)
+{
+    const char *uuid = usock_conn_get_uuid (uconn);
+    struct service *ss = arg;
+    int type = 0;
+
+    if (flux_msg_get_type (msg, &type) < 0
+        || type != FLUX_MSGTYPE_REQUEST
+        || flux_msg_enable_route (msg) < 0
+        || flux_msg_set_cred (msg, ss->cred) < 0
+        || flux_msg_push_route (msg, uuid) < 0
+        || flux_requeue (ss->h, msg, FLUX_RQ_TAIL) < 0)
+        goto drop;
+    return;
+drop:
+    if (ss->verbose)
+        log_msg ("drop %s from %.5s", flux_msg_typestr (type), uuid);
+}
+
+/* usock_acceptor_f signature */
+static void service_acceptor (struct usock_conn *uconn, void *arg)
+{
+    struct service *ss = arg;
+    const struct flux_msg_cred *cred = usock_conn_get_cred (uconn);
+    const char *uuid = usock_conn_get_uuid (uconn);
+
+    if (cred->userid != ss->cred.userid) {
+        errno = EPERM;
+        goto error;
+    }
+    if (zhashx_insert (ss->connections, uuid, uconn) < 0) {
+        errno = EEXIST;
+        goto error;
+    }
+    if (ss->verbose)
+        log_msg ("hi %.5s", uuid);
+    usock_conn_set_error_cb (uconn, service_error, ss);
+    usock_conn_set_recv_cb (uconn, service_recv, ss);
+    usock_conn_accept (uconn, cred);
+    return;
+error:
+    usock_conn_reject (uconn, errno);
+    usock_conn_destroy (uconn);
+}
+
+/* flux_handle_ops send signature */
+static int service_handle_send (void *impl, const flux_msg_t *msg, int flags)
+{
+    struct service *ss = impl;
+    int type = 0;
+    flux_msg_t *cpy = NULL;
+    char *uuid = NULL;
+    struct usock_conn *uconn;
+
+    if (flux_msg_get_type (msg, &type) < 0)
+        return -1;
+    if (type != FLUX_MSGTYPE_RESPONSE) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (!(cpy = flux_msg_copy (msg, true)))
+        return -1;
+    if (flux_msg_pop_route (cpy, &uuid) < 0)
+        goto error;
+    if (flux_msg_set_cred (cpy, ss->cred) < 0)
+        goto error;
+    if (!(uconn = zhashx_lookup (ss->connections, uuid))) {
+        errno = ENOENT;
+        goto error;
+    }
+    if (usock_conn_send (uconn, cpy) < 0)
+        goto error;
+    flux_msg_decref (cpy);
+    free (uuid);
+    return 0;
+error:
+    flux_msg_decref (cpy);
+    ERRNO_SAFE_WRAP (free, uuid);
+    return -1;
+}
+
+static struct service *service_create  (flux_reactor_t *r,
+                                        const char *sockpath,
+                                        bool verbose)
+{
+    struct service *ss;
+
+    if (!(ss = calloc (1, sizeof (*ss))))
+        return NULL;
+    ss->verbose = verbose;
+    if (!(ss->usock_srv = usock_server_create (r, sockpath, 0777)))
+        goto error;
+    usock_server_set_acceptor (ss->usock_srv, service_acceptor, ss);
+    if (!(ss->connections = zhashx_new ()))
+        goto error;
+    zhashx_set_key_duplicator (ss->connections, NULL);
+    zhashx_set_key_destructor (ss->connections, NULL);
+    zhashx_set_destructor (ss->connections, connection_destructor);
+    ss->cred.userid = getuid ();
+    ss->cred.rolemask = FLUX_ROLE_OWNER;
+    return ss;
+error:
+    service_destroy (ss);
+    return NULL;
+}
+
+/* flux_handle_ops impl_destroy signature */
+static void service_destroy (void *impl)
+{
+    struct service *ss = impl;
+    if (ss) {
+        int saved_errno = errno;
+        zhashx_destroy (&ss->connections);
+        usock_server_destroy (ss->usock_srv);
+        free (ss);
+        errno = saved_errno;
+    }
+}
+
+flux_t *usock_service_create (flux_reactor_t *r,
+                              const char *rundir,
+                              bool verbose)
+{
+    struct service *ss;
+
+    if (!(ss = service_create (r, rundir, verbose)))
+        return NULL;
+    if (!(ss->h = flux_handle_create (ss, &service_handle_ops, 0))
+            || flux_set_reactor (ss->h, r) < 0) {
+        service_destroy (ss);
+        return NULL;
+    }
+    return ss->h;
+}
+
+static const struct flux_handle_ops service_handle_ops = {
+    .send = service_handle_send,
+    .impl_destroy = service_destroy,
+};
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/librouter/usock_service.h
+++ b/src/common/librouter/usock_service.h
@@ -1,0 +1,41 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _ROUTER_USOCK_SERVICE_H
+#define _ROUTER_USOCK_SERVICE_H
+
+/* Create a flux_t handle representing a usock socket on 'sockpath'.
+ * This can be used to embed a faux flux service in a program.
+ * The server end can register message handlers as usual.
+ * The client end can flux_open() local://${sockpath} and make RPCs.
+ *
+ * Limitations:
+ * - connections from "guests" (uid != server uid) are rejected
+ * - event messages may not be published or subscribed to
+ * - clients may not register services
+ * - rank addressing is ignored
+ * - server flux_t handle requires async reactor operation
+ *   (one cannot call flux_recv() in a loop and expect it to make progress)
+ *
+ * When a client disconnects, a request is automatically sent to the server
+ * from the client's uuid.  This is similar to RFC 6 disconnects, except
+ * the topic string is always "disconnect", not "<service>.disconnect".
+ *
+ * The handle must be closed with flux_close().
+ */
+flux_t *usock_service_create (flux_reactor_t *r,
+                              const char *sockpath,
+                              bool verbose);
+
+#endif // _ROUTER_USOCK_SERVICE_H
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -221,6 +221,7 @@ EXTRA_DIST= \
 	shell/initrc/tests \
 	flux-jobs/tests \
 	scripts/run_timeout.py \
+	scripts/startctl.py \
 	jobspec \
 	flux-resource \
 	resource/get-xml-test.py \

--- a/t/scripts/startctl.py
+++ b/t/scripts/startctl.py
@@ -1,0 +1,32 @@
+###############################################################
+# Copyright 2021 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+# startctl - tell flux-start to do things
+#
+# Usage: flux start -s1 flux python startctl.py
+
+import os
+import flux
+
+
+def status(h):
+    print(h.rpc("start.status").get_str())
+
+
+def main():
+    h = flux.Flux(os.environ.get("FLUX_START_URI"))
+    status(h)
+
+
+if __name__ == "__main__":
+    main()
+
+
+# vi: ts=4 sw=4 expandtab


### PR DESCRIPTION
This adds a convenience function for setting up an embedded server that listens on a `local://` socket and routes messages between connected clients and a server side `flux_t` handle.  It's a bit of an abomination if you think about it too hard, but it does let arbitrary programs offer "services" in the usual way by registering message handlers, and clients to connect to it and use RPCs the way they would do with flux, so pretty convenient.

Maybe this will come in handy if the shell needs to offer a standalone service to applications, especially if that application is flux?

A server is then embedded in `flux-start` for the purpose of enabling system tests that restart brokers.  In this PR, the only service method just lists broker pids.  I thought maybe getting this much in with tests was maybe a good place to cut this PR and start the next one?