### PR TITLE
flux-proxy: add flux-core version check

### DIFF
--- a/doc/man1/flux-proxy.rst
+++ b/doc/man1/flux-proxy.rst
@@ -9,7 +9,7 @@ flux-proxy(1)
 SYNOPSIS
 ========
 
-**flux** **proxy** URI [command [args...]]
+**flux** **proxy** [*OPTIONS*] URI [command [args...]]
 
 DESCRIPTION
 ===========
@@ -25,6 +25,13 @@ The purpose of **flux proxy** is to allow a connection to be reused,
 for example where connection establishment has high latency or
 requires authentication.
 
+
+OPTIONS
+=======
+
+**-f, --force**
+   Allow the proxy command to connect to a broker running a different
+   version of Flux with a warning message instead of a fatal error.
 
 EXAMPLES
 ========

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -639,8 +639,9 @@ static void init_attrs (attr_t *attrs, pid_t pid, struct flux_msg_cred *cred)
     init_attrs_rc_paths (attrs);
     init_attrs_shell_paths (attrs);
 
-    if (attr_add (attrs, "version", FLUX_CORE_VERSION_STRING,
-                                            FLUX_ATTRFLAG_IMMUTABLE) < 0)
+    /* Allow version to be changed by instance owner for testing
+     */
+    if (attr_add (attrs, "version", FLUX_CORE_VERSION_STRING, 0) < 0)
         log_err_exit ("attr_add version");
 
     char tmp[32];

--- a/t/t1105-proxy.t
+++ b/t/t1105-proxy.t
@@ -81,4 +81,18 @@ test_expect_success 'flux-proxy forwards LD_LIBRARY_PATH' '
 	grep -E "ssh.* LD_LIBRARY_PATH=[^ ]*:?/foo .*/flux relay" ./proxinator.log
 '
 
+test_expect_success 'set bogus broker version' '
+	flux getattr version >realversion &&
+	flux setattr version 0.0.0
+'
+test_expect_success 'flux-proxy fails with version mismatch' '
+	test_must_fail flux proxy $FLUX_URI /bin/true
+'
+test_expect_success 'flux-proxy --force works with version mismatch' '
+	flux proxy --force $FLUX_URI /bin/true
+'
+test_expect_success 'restore real broker version' '
+	flux setattr version $(cat realversion)
+'
+
 test_done


### PR DESCRIPTION
As suggested in #1816, a `flux-proxy` connection to a different Flux version can result in hard to debug problems.

This PR adds a version check.  If the version is mismatched, it is treated as a fatality unless a `--force` option is used.  Later when version interoperability is more important, we can relax the check if needed.

Note: only the major, minor, patch version _numbers_ are checked.  Any git suffix on the patch is ignored.