### PR TITLE
kvs: improve performance of transaction prep/check

### DIFF
--- a/src/modules/kvs/Makefile.am
+++ b/src/modules/kvs/Makefile.am
@@ -8,6 +8,7 @@ AM_LDFLAGS = \
 AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
+	-I$(top_srcdir)/src/common/libccan \
 	-I$(top_builddir)/src/common/libflux \
 	$(ZMQ_CFLAGS)
 

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -1005,7 +1005,6 @@ done:
      * N.B. treq_t remains in the treq_mgr_t hash until event is received.
      */
     kvstxn_mgr_remove_transaction (root->ktm, kt, fallback);
-    return;
 
 stall:
     return;

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -1044,11 +1044,11 @@ static void transaction_prep_cb (flux_reactor_t *r, flux_watcher_t *w,
 
 static int kvstxn_check_root_cb (struct kvsroot *root, void *arg)
 {
-    struct kvs_cb_data *cbd = arg;
+    struct kvs_ctx *ctx = arg;
     kvstxn_t *kt;
 
     if ((kt = kvstxn_mgr_get_ready_transaction (root->ktm))) {
-        if (cbd->ctx->transaction_merge) {
+        if (ctx->transaction_merge) {
             /* if merge fails, set errnum in kvstxn_t, let
              * kvstxn_apply() handle error handling.
              */
@@ -1076,11 +1076,10 @@ static void transaction_check_cb (flux_reactor_t *r, flux_watcher_t *w,
                                   int revents, void *arg)
 {
     struct kvs_ctx *ctx = arg;
-    struct kvs_cb_data cbd = { .ctx = ctx, .ready = false };
 
     flux_watcher_stop (ctx->idle_w);
 
-    if (kvsroot_mgr_iter_roots (ctx->krm, kvstxn_check_root_cb, &cbd) < 0) {
+    if (kvsroot_mgr_iter_roots (ctx->krm, kvstxn_check_root_cb, ctx) < 0) {
         flux_log_error (ctx->h, "%s: kvsroot_mgr_iter_roots", __FUNCTION__);
         return;
     }

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -2386,8 +2386,8 @@ static void start_root_remove (struct kvs_ctx *ctx, const char *ns)
          */
 
         if (treq_mgr_iter_transactions (root->trm,
-                                          root_remove_process_transactions,
-                                          &cbd) < 0)
+                                        root_remove_process_transactions,
+                                        &cbd) < 0)
             flux_log_error (ctx->h, "%s: treq_mgr_iter_transactions",
                             __FUNCTION__);
     }

--- a/src/modules/kvs/kvsroot.c
+++ b/src/modules/kvs/kvsroot.c
@@ -158,6 +158,7 @@ struct kvsroot *kvsroot_mgr_create_root (kvsroot_mgr_t *krm,
         goto error;
     }
 
+    list_node_init (&root->work_queue_node);
     return root;
 
  error:

--- a/src/modules/kvs/kvsroot.h
+++ b/src/modules/kvs/kvsroot.h
@@ -19,6 +19,7 @@
 #include "treq.h"
 #include "waitqueue.h"
 #include "src/common/libutil/blobref.h"
+#include "src/common/libccan/ccan/list/list.h"
 
 typedef struct kvsroot_mgr kvsroot_mgr_t;
 
@@ -35,6 +36,7 @@ struct kvsroot {
     bool remove;
     bool setroot_pause;
     zlist_t *setroot_queue;
+    struct list_node work_queue_node;
 };
 
 /* return -1 on error, 0 on success, 1 on success & to stop iterating */

--- a/src/modules/kvs/kvstxn.h
+++ b/src/modules/kvs/kvstxn.h
@@ -124,7 +124,7 @@ void kvstxn_cleanup_dirty_cache_entry (kvstxn_t *kt, struct cache_entry *entry);
  */
 
 /* flux_t is optional, if NULL logging will go to stderr */
-kvstxn_mgr_t *kvstxn_mgr_create (struct cache *ktache,
+kvstxn_mgr_t *kvstxn_mgr_create (struct cache *cache,
                                  const char *ns,
                                  const char *hash_name,
                                  flux_t *h,


### PR DESCRIPTION
Per discussion in #3633.

I went back and forth on implementation eventually settling on a `zlist` "work_queue".  I dislike the fact I have a "on_work_queue" flag placed in the `struct kvsroot` structure.  It sort of breaks abstraction of that struct.  I could ...

1) just search the list instead of maintaining a flag, but that's a lot of iteration and we don't want to do that.

2) use a `zhash_t` instead, but a `zhash` foreach iterates through all hash buckets, and we're trying to limit iteration

3) use a `zhash_t` along w/ a `zlist_t`, using the `zhash_t` just for "is it on the list" management.  Seems like a lot of effort for just the flag.

Using @grondo's namespace benchmark.

Before

```
  0.19s: Benchmark on 256 namespaces complete: 1382.4 namespace/s
  0.35s: Benchmark on 512 namespaces complete: 1481.6 namespace/s
  0.87s: Benchmark on 1024 namespaces complete: 1179.5 namespace/s
  2.64s: Benchmark on 2048 namespaces complete: 776.0 namespace/s
 12.99s: Benchmark on 4096 namespaces complete: 315.3 namespace/s
 48.11s: Benchmark on 8192 namespaces complete: 170.3 namespace/s
174.14s: Benchmark on 16384 namespaces complete: 94.1 namespace/s
540.87s: Benchmark on 32768 namespaces complete: 60.6 namespace/s
```

After

```
  0.18s: Benchmark on 256 namespaces complete: 1458.1 namespace/s
  0.35s: Benchmark on 512 namespaces complete: 1464.3 namespace/s
  0.72s: Benchmark on 1024 namespaces complete: 1416.8 namespace/s
  1.41s: Benchmark on 2048 namespaces complete: 1450.0 namespace/s
  2.82s: Benchmark on 4096 namespaces complete: 1451.9 namespace/s
  5.61s: Benchmark on 8192 namespaces complete: 1459.7 namespace/s
 11.30s: Benchmark on 16384 namespaces complete: 1449.4 namespace/s
 22.47s: Benchmark on 32768 namespaces complete: 1458.0 namespace/s
```

