### PR TITLE
testsuite: modify jobid capture logic

### DIFF
--- a/t/t3200-instance-restart.t
+++ b/t/t3200-instance-restart.t
@@ -12,23 +12,19 @@ if test -n "$S3_ACCESS_KEY_ID"; then
     export FLUX_CONF_DIR=$(pwd)
 fi
 
-lastword () {
-	awk '{ print $NF }'
-}
-
 test_expect_success 'run a job in persistent instance' '
 	flux start -o,--setattr=content.backing-path=$(pwd)/content.sqlite \
-	           flux mini run -v /bin/true 2>&1 | lastword >id1.out
+	           flux mini submit /bin/true >id1.out
 '
 
 test_expect_success 'restart instance and run another job' '
 	flux start -o,--setattr=content.backing-path=$(pwd)/content.sqlite \
-	           flux mini run -v /bin/true 2>&1 | lastword >>id2.out
+	           flux mini submit /bin/true >id2.out
 '
 
 test_expect_success 'restart instance and run another job' '
 	flux start -o,--setattr=content.backing-path=$(pwd)/content.sqlite \
-	           flux mini run -v /bin/true 2>&1 | lastword >>id3.out
+	           flux mini submit /bin/true >id3.out
 '
 
 test_expect_success 'restart instance and list inactive jobs' '
@@ -52,7 +48,7 @@ test_expect_success 'run a job in persistent instance (content-files)' '
 	flux start \
 	    -o,-Scontent.backing-module=content-files \
 	    -o,-Scontent.backing-path=$(pwd)/content.files \
-	    flux mini run -v /bin/true 2>&1 | lastword >files_id1.out
+	    flux mini submit /bin/true >files_id1.out
 '
 test_expect_success 'restart instance and list inactive jobs' '
 	flux start \
@@ -87,7 +83,7 @@ test_expect_success S3 'create content-s3.toml from env' '
 test_expect_success S3 'run a job in persistent instance (content-s3)' '
 	flux start \
 	    -o,-Scontent.backing-module=content-s3 \
-	    flux mini run -v /bin/true 2>&1 | lastword >files_id2.out
+	    flux mini submit /bin/true >files_id2.out
 '
 test_expect_success S3 'restart instance and list inactive jobs' '
 	flux start \


### PR DESCRIPTION
Problem: In previous commit

    commit bb9e4faac34df8b6ae31c9c0b2430841226b4678
    Author: Jim Garlick <garlick.jim@gmail.com>
    Date:   Tue May 11 18:41:06 2021 -0700

        testsuite: make jobid capture ignore stderr gunk

the jobid is assumed to be the last output. However, in some environments
there may be extraneous output before and after the jobid is output.  Leading
to test failures in those environments.

Solution: Go back to the jobid parsing logic from

    commit 77ef3e822ae24a71b352573db3f64ae078488e22
    Author: Jim Garlick <garlick.jim@gmail.com>
    Date:   Fri Mar 13 09:35:56 2020 -0700

        testsuite: cover jobid order across restart

but add an additional "grep" call to limit jobid parsing
to only lines with the "jobid:" prefix.

This should also deal with the issues fixed by:
    
    commit 9b4f457edb59be67d39eb8e0042962d527e2a7cb
    Author: Mark A. Grondona <mark.grondona@gmail.com>
    Date:   Thu Jul 30 23:07:00 2020 +0000
    
        t3200-instance-restart.t: enhance test reliability
