### PR TITLE
kvs: use json object to find duplicate keys

### DIFF
--- a/src/modules/kvs-watch/kvs-watch.c
+++ b/src/modules/kvs-watch/kvs-watch.c
@@ -209,19 +209,13 @@ error:
     return NULL;
 }
 
-/* Helper for watcher_respond - is key a member of array?
- * N.B. array 'a' can be NULL
+/* Helper for watcher_respond - is key a member of object?
+ * N.B. object 'o' can be NULL
  */
-static bool array_match (json_t *a, const char *key)
+static bool key_match (json_t *o, const char *key)
 {
-    size_t index;
-    json_t *value;
-
-    json_array_foreach (a, index, value) {
-        const char *s = json_string_value (value);
-        if (s && !strcmp (s, key))
-            return true;
-    }
+    if (o && json_object_get (o, key))
+        return true;
     return false;
 }
 
@@ -666,7 +660,7 @@ static void watcher_respond (struct ns_monitor *nsm, struct watcher *w)
      */
     if (w->rootseq == -1
         || (w->flags & FLUX_KVS_WATCH_FULL)
-        || array_match (nsm->commit->keys, w->key)) {
+        || key_match (nsm->commit->keys, w->key)) {
         if (process_lookup_response (nsm, w) < 0)
             goto error_respond;
     }

--- a/src/modules/kvs/kvstxn.c
+++ b/src/modules/kvs/kvstxn.c
@@ -1262,17 +1262,6 @@ static int kvstxn_merge (kvstxn_t *dest, kvstxn_t *src)
             }
         }
     }
-    if ((len = json_array_size (src->keys))) {
-        for (i = 0; i < len; i++) {
-            json_t *key;
-            if ((key = json_array_get (src->keys, i))) {
-                if (json_array_append (dest->keys, key) < 0) {
-                    errno = ENOMEM;
-                    return -1;
-                }
-            }
-        }
-    }
 
     return 1;
 }

--- a/src/modules/kvs/kvstxn.c
+++ b/src/modules/kvs/kvstxn.c
@@ -769,42 +769,27 @@ err:
     return -1;
 }
 
-/* normalize key for setroot, and add it to keys array, if unique */
-static int normalize_and_append_unique (json_t *keys, const char *key)
+/* normalize key for setroot, and add it to keys dict, if unique */
+static int normalize_and_add_unique (json_t *keys, const char *key)
 {
     char *key_norm;
-    size_t index;
-    json_t *value;
-    bool unique = true;
+    int rc = -1;
 
     if ((key_norm = kvs_util_normalize_key (key, NULL)) == NULL)
         return -1;
-    json_array_foreach (keys, index, value) {
-        const char *s = json_string_value (value);
-        if (s && !strcmp (s, key_norm)) {
-            unique = false;
-            break;
-        }
-    }
-    if (unique) {
-        json_t *o;
-        if (!(o = json_string (key_norm)))
-            goto error;
-        if (json_array_append_new (keys, o) < 0) {
-            json_decref (o);
-            goto error;
-        }
-    }
-    free (key_norm);
-    return 0;
+    /* we don't need the value, just use a json null */
+    if (json_object_set_new (keys, key_norm, json_null ()) < 0)
+        goto error;
+    rc = 0;
 error:
     free (key_norm);
-    return -1;
+    return rc;
 }
 
-/* Create array of keys (strings) from array of operations ({ "key":s ... })
- * The keys array is for inclusion in the kvs.setroot event, so we can
- * notify watchers of keys that their key may have changed.
+/* Create dict of keys (strings) from array of operations ({ "key":s ... })
+ * The keys are for inclusion in the kvs.setroot event, so we can
+ * notify watchers of keys that their key may have changed.  The value in
+ * the dict is unneeded, so we set it to a json null.
  */
 static json_t *keys_from_ops (json_t *ops)
 {
@@ -812,13 +797,13 @@ static json_t *keys_from_ops (json_t *ops)
     size_t index;
     json_t *op;
 
-    if (!(keys = json_array ()))
+    if (!(keys = json_object ()))
         return NULL;
     json_array_foreach (ops, index, op) {
         const char *key;
         if (json_unpack (op, "{s:s}", "key", &key) < 0)
             goto error;
-        if (normalize_and_append_unique (keys, key) < 0)
+        if (normalize_and_add_unique (keys, key) < 0)
             goto error;
     }
     return keys;

--- a/src/modules/kvs/test/kvstxn.c
+++ b/src/modules/kvs/test/kvstxn.c
@@ -322,36 +322,26 @@ bool is_op_key (json_t *ops, const char *key)
  */
 bool keys_match_ops (json_t *ops, json_t *keys)
 {
-    size_t index;
-    json_t *key;
-    const char *k;
-
-    json_array_foreach (keys, index, key) {
-        k = json_string_value (key);
-        if (k == NULL || !is_op_key (ops, k))
+    const char *key;
+    json_t *value;
+    json_object_foreach (keys, key, value) {
+        if (!is_op_key (ops, key))
             return false;
     }
     return true;
 }
 
 
-/* Return true if 'key' is a member of 'keys' array
+/* Return true if 'key' is a member of 'keys' dict
  */
 bool is_key (json_t *keys, const char *key)
 {
-    size_t index;
-    json_t *o;
-    const char *k;
-
-    json_array_foreach (keys, index, o) {
-        if ((k = json_string_value (o))
-                    && !strcmp (key, k))
-            return true;
-    }
+    if (json_object_get (keys, key))
+        return true;
     return false;
 }
 
-/* Return true if all ops have a key array entry
+/* Return true if all ops have a key dict entry
  */
 bool ops_match_keys (json_t *keys, json_t *ops)
 {


### PR DESCRIPTION
As discussed in #3615, there is some bottlenecking at larger scales in the KVS `normalize_and_append_unique()` function.  In the function, a json array is regularly searched to determine if any keys are duplicates of each other.  This is is an O(N^2) search with a not so friendly `strcmp()` in the middle.

As an experiment I modified the "array search" to use a json object as a "hash lookup".  Effectively replacing a `json_array_foreach` & `strcmp` with a single call to `json_object_get()`.

The results using the nsbench benchmark.

Before

```
  0.17s: Benchmark on 256 namespaces complete: 1468.3 namespace/s
  0.35s: Benchmark on 512 namespaces complete: 1469.0 namespace/s
  0.70s: Benchmark on 1024 namespaces complete: 1461.4 namespace/s
  1.35s: Benchmark on 2048 namespaces complete: 1519.2 namespace/s
  2.68s: Benchmark on 4096 namespaces complete: 1527.9 namespace/s
  5.31s: Benchmark on 8192 namespaces complete: 1543.5 namespace/s
 11.13s: Benchmark on 16384 namespaces complete: 1471.8 namespace/s
 22.50s: Benchmark on 32768 namespaces complete: 1456.6 namespace/s
 47.77s: Benchmark on 65536 namespaces complete: 1371.8 namespace/s
115.77s: Benchmark on 131072 namespaces complete: 1132.2 namespace/s
364.97s: Benchmark on 262144 namespaces complete: 718.3 namespace/s
```

After

```
  0.19s: Benchmark on 256 namespaces complete: 1379.0 namespace/s
  0.37s: Benchmark on 512 namespaces complete: 1401.2 namespace/s
  0.71s: Benchmark on 1024 namespaces complete: 1437.1 namespace/s
  1.34s: Benchmark on 2048 namespaces complete: 1526.3 namespace/s
  2.80s: Benchmark on 4096 namespaces complete: 1464.3 namespace/s
  5.48s: Benchmark on 8192 namespaces complete: 1495.9 namespace/s
 11.19s: Benchmark on 16384 namespaces complete: 1464.7 namespace/s
 22.80s: Benchmark on 32768 namespaces complete: 1436.9 namespace/s
 45.33s: Benchmark on 65536 namespaces complete: 1445.8 namespace/s
 93.02s: Benchmark on 131072 namespaces complete: 1409.1 namespace/s
184.98s: Benchmark on 262144 namespaces complete: 1417.2 namespace/s
```

At the lower end, minor incremental slowdown (i assume some extra allocations and such), but at the higher end, wow! Note the relatively good scaling, with namespace rate staying relatively constant.

Using test script from #3630

`>for i in 256 512 1024 2048 4096 8192 16384 32768; do src/cmd/flux start ./test3633.sh -m unlimited -n $i; done | grep Script`

Before

```
Script runtime:          1.489s
Script runtime:          2.689s
Script runtime:          5.637s
Script runtime:         11.162s
Script runtime:         22.577s
Script runtime:         48.433s
Script runtime:        114.042s
Script runtime:        255.004s
```

After

```
Script runtime:          1.536s
Script runtime:          2.713s
Script runtime:          5.567s
Script runtime:         11.225s
Script runtime:         22.400s
Script runtime:         45.295s
Script runtime:        102.272s
Script runtime:        218.626s
```

Again at the higher ends, it's a nice chunk better.  

I originally did this experiment thinking to replace the setroot event's array with an object.  So that the extra allocations wouldn't occur and an array search wouldn't occur on setroot listeners.

However, I'd feel remiss to change the RPC to set an object over an array, where the object values are completely useless.  And we don't technically have a bottleneck in the array search on setroot listeners.  This one location is the only bottleneck i know of.

So I'm thinking this experiment may be a decent enough win for the time being.

Although using a `json_object()` as a cheapo hash is sort of, well silly.  Especially since we don't need the value of the keys we set.  Unfortunately, I think it's probably better than a `zhash`.    We don't seem to have a `set` data structure laying around in `flux-core`.  I looked at @grondo's `grudgeset` but that uses a `json_object` internally already.

Will peruse the interwebs to see if we can find a better one.  But wanted to post this for now if anyone can think of a `set` data structure out there we can use that would be good.


