### PR TITLE
flux-mini: avoid substitution without --cc/bcc, allow --setattr value to be read from file

### DIFF
--- a/doc/man1/flux-mini.rst
+++ b/doc/man1/flux-mini.rst
@@ -287,7 +287,9 @@ OTHER OPTIONS
 **--setattr=KEY=VAL**
    Set jobspec attribute. Keys may include periods to denote hierarchy.
    VAL may be valid JSON (bare values, objects, or arrays), otherwise VAL
-   is interpreted as a string.
+   is interpreted as a string. If KEY starts with a ``^`` character, then
+   VAL is interpreted as a file, which must be valid JSON, to use as the
+   attribute value.
 
 **--dry-run**
    Don't actually submit job. Just emit jobspec on stdout and exit for

--- a/src/cmd/flux-mini.py
+++ b/src/cmd/flux-mini.py
@@ -964,8 +964,8 @@ class SubmitBulkCmd(SubmitBaseCmd):
             self.progress_start(args, len(cclist))
 
         for i in cclist:
-            #  substitute any {cc} in args and create jobspec:
-            xargs = Xcmd(args, cc=i)
+            #  substitute any {cc} in args (only if --cc or --bcc):
+            xargs = Xcmd(args, cc=i) if i else args
             jobspec = self.jobspec_create(xargs)
 
             if args.cc or args.bcc:

--- a/src/cmd/flux-mini.py
+++ b/src/cmd/flux-mini.py
@@ -271,7 +271,7 @@ class Xcmd:
         for arg in args.command:
             try:
                 result = arg.format(*inputs, **kwargs).split("::list::")
-            except IndexError:
+            except (IndexError, KeyError):
                 LOGGER.error("Invalid replacement string in command: '%s'", arg)
                 sys.exit(1)
             if result:
@@ -295,9 +295,17 @@ class Xcmd:
                     newval = [x.format(*inputs, **kwargs) for x in val]
                 else:
                     newval = val
-            except IndexError:
+            except IndexError as exc:
                 LOGGER.error(
-                    "Invalid replacement string in %s: '%s'",
+                    "Invalid replacement index in %s%s'",
+                    self.mutable_args[attr],
+                    val,
+                )
+                sys.exit(1)
+            except KeyError as exc:
+                LOGGER.error(
+                    "Replacement key %s not found in '%s%s'",
+                    exc,
                     self.mutable_args[attr],
                     val,
                 )

--- a/t/t2700-mini-cmd.t
+++ b/t/t2700-mini-cmd.t
@@ -252,4 +252,11 @@ test_expect_success 'flux-mini submit --cc works' '
 	EOF
 	test_cmp cc.output.expected cc.output.sorted
 '
+test_expect_success HAVE_JQ 'flux-mini submit does not substitute {} without --cc' '
+	flux mini submit \
+		--env=-* \
+		--setattr=system.test={} \
+		--dry-run true > nocc.json &&
+	jq -e ".attributes.system.test == {}" < nocc.json
+'
 test_done

--- a/t/t2700-mini-cmd.t
+++ b/t/t2700-mini-cmd.t
@@ -129,6 +129,23 @@ test_expect_success HAVE_JQ 'flux mini submit --setattr works' '
 	test $(jq ".attributes.user.foo2" attr.out) = "\"yyy\"" &&
 	test $(jq ".attributes.system.bar" attr.out) = "42"
 '
+test_expect_success HAVE_JQ 'flux mini submit --setattr=^ATTR=VAL works' '
+	cat | jq -S . >attr.json <<-EOF &&
+	[
+	  { "foo":"value",
+	    "bar": 42
+	  },
+	  { "foo":"value2",
+	    "bar": null
+	  }
+	]
+	EOF
+	flux mini submit --dry-run \
+		--setattr ^user.foo=attr.json \
+		hostname | \
+	    jq -S .attributes.user.foo > attrout.json &&
+	test_cmp attr.json attrout.json
+'
 test_expect_success 'flux mini submit --setattr fails without value' '
 	test_expect_code 1 \
 		flux mini submit --dry-run \
@@ -136,6 +153,29 @@ test_expect_success 'flux mini submit --setattr fails without value' '
 		hostname >attr_fail.out 2>&1 &&
 	test_debug "cat attr_fail.out" &&
 	grep "Missing value for attr foo" attr_fail.out
+'
+test_expect_success HAVE_JQ 'flux mini submit --setattr=^ detects bad JSON' '
+	cat <<-EOF > bad.json &&
+	[ { "foo":"value",
+	    "bar": 42
+	  },
+	  { foo":"value2",
+	    "bar": null
+	  }
+	]
+	EOF
+	test_expect_code 1 \
+	    flux mini submit --dry-run \
+	      --setattr ^user.foo=bad.json \
+	      hostname > attrbadjson.out 2>&1 &&
+	test_debug "cat attrbadjson.out" &&
+	grep "ERROR: --setattr: bad.json:" attrbadjson.out &&
+	test_expect_code 1 \
+	    flux mini submit --dry-run \
+	      --setattr ^user.foo=nosuchfile.json \
+	      hostname > attrbadfile.out 2>&1 &&
+	test_debug "cat attrbadfile.out" &&
+	grep "ERROR:.*nosuchfile" attrbadfile.out
 '
 test_expect_success HAVE_JQ 'flux mini submit --setopt works' '
 	flux mini submit --dry-run \

--- a/t/t2703-mini-bulksubmit.t
+++ b/t/t2703-mini-bulksubmit.t
@@ -253,8 +253,8 @@ test_expect_success 'flux-mini bulksubmit reports invalid replacement strings' '
 	test_expect_code 1 flux mini bulksubmit -n {1} {} ::: 0 1 2 \
 	    >bad2.out 2>&1 &&
 	test_debug "cat bad2.out" &&
-	grep "Invalid replacement string in command" bad.out &&
-	grep "Invalid replacement string in -n" bad2.out
+	grep "Invalid replacement .* in command" bad.out &&
+	grep "Invalid replacement .* in -n" bad2.out
 '
 test_expect_success 'flux-mini bulksubmit: preserves mustache templates' '
 	flux mini bulksubmit --dry-run --output=flux-{}.{{id}}.out \

--- a/t/t2703-mini-bulksubmit.t
+++ b/t/t2703-mini-bulksubmit.t
@@ -253,8 +253,12 @@ test_expect_success 'flux-mini bulksubmit reports invalid replacement strings' '
 	test_expect_code 1 flux mini bulksubmit -n {1} {} ::: 0 1 2 \
 	    >bad2.out 2>&1 &&
 	test_debug "cat bad2.out" &&
+	test_expect_code 1 flux mini bulksubmit -n {f} true ::: 0 1 2 \
+	    >bad3.out 2>&1 &&
+	test_debug "cat bad3.out" &&
 	grep "Invalid replacement .* in command" bad.out &&
-	grep "Invalid replacement .* in -n" bad2.out
+	grep "Invalid replacement .* in -n" bad2.out &&
+	grep "Replacement key '\''f'\'' not found" bad3.out
 '
 test_expect_success 'flux-mini bulksubmit: preserves mustache templates' '
 	flux mini bulksubmit --dry-run --output=flux-{}.{{id}}.out \


### PR DESCRIPTION
This small PR fixes a couple of annoyances when working with `flux-mini --setattr`.

 1. Currently, substitution of `{cc}` is attempted with `flux mini submit` even if `--cc` or `--bcc` wasn't used. This means that even the simplest objects cannot be specified as values with `flux mini submit --setattr=`. Avoid doing the "input" substitution in `flux mini submit` when no `--cc` or `--bcc` argument was used, since it isn't necessary anyway.
 2. More moderately complex jobspec attributes get really unwieldy to specify with `--setattr`, since the quoting gets painful quite quickly. Also, they can't be specified at all with `bulksubmit` due to 1. above. Add an option to read the attribute value from a JSON file when the attribute key starts with `^`. (I realized after the fact that another solution may be to have a separate option `--setattr-file` or something . Let me know if that is preferrable)
