### PR TITLE
jobtap: support for job.dependency.* callbacks

### DIFF
--- a/doc/man7/flux-jobtap-plugins.rst
+++ b/doc/man7/flux-jobtap-plugins.rst
@@ -102,6 +102,21 @@ job.validate
   callback, since ``job.new`` may also be called during job-manager
   restart or plugin reload.
 
+job.dependency.*
+  The ``job.dependency.*`` topic allows a dependency plugin to notify the
+  job-manager that it handles a given dependency _scheme_. The job-manager
+  will scan the ``attirbutes.system.dependencies`` array, if provided, and
+  issue a ``job.dependency.SCHEME`` callback for each listed dependency.
+  If no plugin has registered for ``SCHEME``, then the job is rejected.
+  The plugin should then call ``flux_jobtap_dependency_add(3)`` to add
+  a new named dependency to the job (if necessary). Jobs with dependencies
+  will remain in the ``DEPEND`` state until all dependencies are removed
+  with a corresponding call to ``flux_jobtap_dependency_remove(3)``. See
+  ``job.state.depend`` below for more information about dependencies.
+  If there is an error in the dependency specification, the job may be
+  rejected with ``flux_jobtap_reject_job(3)`` and a negative return code 
+  from the callback.
+
 job.new
   The ``job.new`` topic is used by the job manager to notify a jobtap plugin
   about a newly introduced job. This call may be made in three different
@@ -121,7 +136,7 @@ job.state.*
   action could involve immediately transitioning to a new state)
 
 job.state.depend
-  The callback for ``FLUX_JOB_STATE_DEPEND`` is the only place from which
+  The callback for ``FLUX_JOB_STATE_DEPEND`` is the final place from which
   a plugin may add dependencies to a job. Dependencies are added via
   the ``flux_jobtap_dependency_add()`` function. This function allows a
   named dependency to be attached to a job. Jobs with dependencies will

--- a/src/modules/job-manager/job.c
+++ b/src/modules/job-manager/job.c
@@ -19,6 +19,7 @@
 #include "src/common/libczmqcontainers/czmq_containers.h"
 #include "src/common/libeventlog/eventlog.h"
 #include "src/common/libutil/grudgeset.h"
+#include "src/common/libutil/aux.h"
 
 #include "job.h"
 #include "event.h"
@@ -32,6 +33,7 @@ void job_decref (struct job *job)
         json_decref (job->jobspec_redacted);
         json_decref (job->annotations);
         grudgeset_destroy (job->dependencies);
+        aux_destroy (&job->aux);
         free (job);
         errno = saved_errno;
     }
@@ -99,6 +101,24 @@ bool job_dependency_event_valid (struct job *job,
         return false;
     }
     return true;
+}
+
+int job_aux_set (struct job *job,
+                 const char *name,
+                 void *val,
+                 flux_free_f destroy)
+{
+    return aux_set (&job->aux, name, val, destroy);
+}
+
+void *job_aux_get (struct job *job, const char *name)
+{
+    return aux_get (job->aux, name);
+}
+
+void job_aux_delete (struct job *job, const void *val)
+{
+    aux_delete (&job->aux, val);
 }
 
 /* Follow path (NULL terminated array of keys) through multiple JSON

--- a/src/modules/job-manager/job.h
+++ b/src/modules/job-manager/job.h
@@ -43,6 +43,8 @@ struct job {
 
     void *handle;           // zlistx_t handle
     int refcount;           // private to job.c
+
+    struct aux_item *aux;
 };
 
 void job_decref (struct job *job);
@@ -53,6 +55,13 @@ struct job *job_create (void);
 struct job *job_create_from_eventlog (flux_jobid_t id,
                                       const char *eventlog,
                                       const char *jobspec);
+
+int job_aux_set (struct job *job,
+                 const char *name,
+                 void *val,
+                 flux_free_f destroy);
+void *job_aux_get (struct job *job, const char *name);
+void job_aux_delete (struct job *job, const void *val);
 
 /* Helpers for maintaining czmq containers of 'struct job'.
  * The comparator sorts by (1) priority, then (2) jobid.

--- a/src/modules/job-manager/jobtap-internal.h
+++ b/src/modules/job-manager/jobtap-internal.h
@@ -48,6 +48,18 @@ int jobtap_validate (struct jobtap *jobtap,
                      struct job *job,
                      char **errp);
 
+/*  Jobtap call to iterate attributes.system.dependencies dictionary
+ *   and call job.dependency.<schema> for each entry.
+ *
+ *  If there is no plugin registered to handle a given schema then
+ *   an error is returned. A plugin which handles a given schema
+ *   may also reject the job if the dependency stanza has errors.
+ */
+int jobtap_check_dependencies (struct jobtap *jobtap,
+                               struct job *job,
+                               char **errp);
+
+
 /*  Load a new jobtap from `path`. Path may start with `builtin.` to
  *   attempt to load one of the builtin jobtap plugins.
  */

--- a/src/modules/job-manager/submit.c
+++ b/src/modules/job-manager/submit.c
@@ -195,7 +195,8 @@ static int submit_validate_jobs (struct job_manager *ctx,
         char *errmsg = NULL;
         json_t *entry = NULL;
 
-        if (jobtap_validate (ctx->jobtap, job, &errmsg) < 0) {
+        if (jobtap_validate (ctx->jobtap, job, &errmsg) < 0
+            || jobtap_check_dependencies (ctx->jobtap, job, &errmsg) < 0) {
             /*
              *  This job is rejected: append error to error payload and
              *   delete the job from newjobs list

--- a/t/job-manager/plugins/dependency-test.c
+++ b/t/job-manager/plugins/dependency-test.c
@@ -59,7 +59,7 @@ static int depend_cb (flux_plugin_t *p,
                                 "jobspec",
                                 "attributes",
                                 "system",
-                                "dependencies", &deps) < 0)
+                                "dependency-test", &deps) < 0)
         return -1;
     if (deps && json_is_array (deps)) {
         size_t index;

--- a/t/job-manager/plugins/dependency-test.c
+++ b/t/job-manager/plugins/dependency-test.c
@@ -49,35 +49,38 @@ static int depend_cb (flux_plugin_t *p,
                       void *arg)
 {
     flux_jobid_t id;
-    json_t *deps = NULL;
-    flux_t *h = flux_jobtap_get_flux (p);
+    const char *name = NULL;
+    int remove = 0;
 
     if (flux_plugin_arg_unpack (args,
                                 FLUX_PLUGIN_ARG_IN,
-                                "{s:I s:{s:{s:{s?o}}}}",
+                                "{s:I s:{s:s s?i}}",
                                 "id", &id,
-                                "jobspec",
-                                "attributes",
-                                "system",
-                                "dependency-test", &deps) < 0)
-        return -1;
-    if (deps && json_is_array (deps)) {
-        size_t index;
-        json_t *val;
-        json_array_foreach (deps, index, val) {
-            const char *s = json_string_value (val);
-            if (flux_jobtap_dependency_add (p, id, s) < 0) {
-                flux_log_error (h, "jobtap_dependency_add (%s)", s);
-                return -1;
-            }
-        }
-        return 0;
+                                "dependency",
+                                "value", &name,
+                                "remove", &remove) < 0) {
+        return flux_jobtap_reject_job (p, args,
+                                       "failed to unpack dependency args: %s",
+                                       flux_plugin_arg_strerror (args));
     }
-    return flux_jobtap_dependency_add (p, id, "dependency-test");
+
+    if (flux_jobtap_dependency_add (p, id, name) < 0) {
+        flux_log_error (flux_jobtap_get_flux (p),
+                        "flux_jobtap_dependency_add (%s)",
+                        name);
+        return -1;
+    }
+    if (remove && flux_jobtap_dependency_remove (p, id, name) < 0) {
+        flux_log_error (flux_jobtap_get_flux (p),
+                        "flux_jobtap_dependency_remove (%s)",
+                        name);
+        return -1;
+    }
+    return 0;
 }
 
 static const struct flux_plugin_handler tab[] = {
-    { "job.state.depend", depend_cb, NULL },
+    { "job.dependency.test", depend_cb, NULL },
     { 0 },
 };
 

--- a/t/t2212-job-manager-plugins.t
+++ b/t/t2212-job-manager-plugins.t
@@ -255,14 +255,14 @@ test_expect_success 'job-manager: plugin can manage depedencies' '
 	EOF
 	flux module reload job-ingest &&
 	flux jobtap load ${PLUGINPATH}/dependency-test.so &&
-	jobid=$(flux mini submit hostname) &&
+	jobid=$(flux mini submit --dependency=test:dependency-test hostname) &&
 	flux job wait-event -vt 15 ${jobid} dependency-add &&
 	test $(flux jobs -no {state} ${jobid}) = DEPEND &&
 	flux python dep-remove.py ${jobid} &&
 	flux job wait-event -vt 15 ${jobid} clean
 '
 test_expect_success 'job-manager: job.state.depend is called on plugin load' '
-	jobid=$(flux mini submit hostname) &&
+	jobid=$(flux mini submit --dependency=test:dependency-test hostname) &&
 	flux job wait-event -vt 15 ${jobid} dependency-add &&
 	flux jobtap load ${PLUGINPATH}/dependency-test.so &&
 	test $(flux jobs -no {state} ${jobid}) = DEPEND &&

--- a/t/t2270-job-dependencies.t
+++ b/t/t2270-job-dependencies.t
@@ -10,6 +10,41 @@ flux setattr log-stderr-level 1
 
 PLUGINPATH=${FLUX_BUILD_DIR}/t/job-manager/plugins/.libs
 
+test_expect_success HAVE_JQ 'flux-mini: --dependency option works' '
+	flux mini run --dry-run \
+		--env=-* \
+		--dependency=foo:1234 \
+		--dependency=foo:f1?val=bar \
+		--dependency="foo:f1?val=a&val=b" true | \
+		jq '.attributes.system.dependencies' > deps.json &&
+	test_debug "cat deps.json" &&
+	jq -e ".[0].scheme == \"foo\"" < deps.json &&
+	jq -e ".[0].value == 1234" < deps.json &&
+	jq -e ".[1].scheme == \"foo\"" < deps.json &&
+	jq -e ".[1].value == \"f1\""   < deps.json &&
+	jq -e ".[1].val == \"bar\""    < deps.json &&
+	jq -e ".[2].val[0] == \"a\""   < deps.json &&
+	jq -e ".[2].val[1] == \"b\""   < deps.json
+'
+test_expect_success 'submitted job with unknown dependency scheme is rejected' '
+	test_must_fail flux mini submit --dependency=invalid:value hostname
+'
+test_expect_success 'job with too long dependency scheme is rejected' '
+	test_must_fail flux mini submit \
+		--dependency=$(python -c "print \"x\"*156"):value hostname
+'
+test_expect_success 'submitted job with invalid dependencies is rejected' '
+	test_must_fail flux mini submit \
+		--setattr=system.dependencies={} \
+		hostname > not-an-array.out 2>&1 &&
+	test_debug "cat not-an-array.out" &&
+	grep -q "must be an array" not-an-array.out &&
+	test_must_fail flux mini submit \
+		--setattr=system.dependencies="[{\"foo\":1}]" \
+		hostname > empty-object.out 2>&1 &&
+	test_debug "cat empty-object.out" &&
+	grep -q "missing" empty-object.out
+'
 test_expect_success 'create dep-remove.py' '
 	cat <<-EOF >dep-remove.py
 	import flux
@@ -26,18 +61,25 @@ test_expect_success 'job-manager: load dependency-test plugin' '
 	flux jobtap load ${PLUGINPATH}/dependency-test.so
 '
 test_expect_success 'job-manager: dependency-test plugin is working' '
-	jobid=$(flux mini submit hostname) &&
-	flux job wait-event -t 15 -m description=dependency-test \
+	jobid=$(flux mini submit --dependency=test:deptest true) &&
+	flux job wait-event -t 15 -m description=deptest \
 		${jobid} dependency-add &&
 	test $(flux jobs -no {state} ${jobid}) = DEPEND &&
-	flux python dep-remove.py ${jobid} dependency-test &&
-	flux job wait-event -t 15 -m description=dependency-test \
+	flux python dep-remove.py ${jobid} deptest &&
+	flux job wait-event -t 15 -m description=deptest \
 		${jobid} dependency-remove &&
 	flux job wait-event -vt 15 ${jobid} clean
 '
+test_expect_success 'plugin rejects job with malformed dependency spec' '
+	test_must_fail flux mini submit \
+		--dependency=test:failure?remove=bad \
+		hostname >baddeps.out 2>&1 &&
+	test_debug "cat baddeps.out" &&
+	grep "failed to unpack dependency" baddeps.out
+'
 test_expect_success 'job dependencies are available in listing tools' '
 	jobid=$(flux mini submit \
-		--setattr=system.dependency-test="[\"foo\"]" \
+		--dependency=test:foo \
 		hostname) &&
 	flux job wait-event -t 15 -m description=foo ${jobid} dependency-add &&
 	flux jobs -o {id}:{dependencies} &&
@@ -49,7 +91,8 @@ test_expect_success 'job dependencies are available in listing tools' '
 '
 test_expect_success 'multiple job dependencies works' '
 	jobid=$(flux mini submit \
-		--setattr=system.dependency-test="[\"foo\",\"bar\"]" \
+		--dependency=test:foo \
+		--dependency=test:bar \
 		hostname) &&
 	flux job wait-event -t 15 -m description=bar ${jobid} dependency-add &&
 	flux jobs -o {id}:{dependencies} &&
@@ -62,7 +105,8 @@ test_expect_success 'multiple job dependencies works' '
 '
 test_expect_success 'multiple dependency-add with same description is ignored' '
 	jobid=$(flux mini submit \
-		--setattr=system.dependency-test="[\"bar\",\"bar\"]" \
+		--dependency=test:bar \
+		--dependency=test:bar \
 		hostname) &&
 	flux job wait-event -t 15 -m description=bar ${jobid} dependency-add &&
 	flux job eventlog ${jobid} &&
@@ -71,10 +115,17 @@ test_expect_success 'multiple dependency-add with same description is ignored' '
 	flux python dep-remove.py ${jobid} bar &&
 	flux job wait-event -vt 15 ${jobid} clean
 '
-
+test_expect_success 'dependency can be removed in job.dependency callback' '
+	id=$(flux mini submit \
+		--dependency=test:bar?remove=1 \
+		hostname) &&
+	flux job wait-event -t 15 -m description=bar ${id} dependency-add &&
+	flux job wait-event -t 15 -m description=bar ${id} dependency-remove &&
+	flux job wait-event -vt 15 ${id} clean
+'
 test_expect_success 'invalid dependency-remove is ignored' '
 	jobid=$(flux mini submit \
-		--setattr=system.dependency-test="[\"bar\"]" \
+		--dependency=test:bar \
 		hostname) &&
 	flux job wait-event -t 15 -m description=bar ${jobid} dependency-add &&
 	test_must_fail flux python dep-remove.py ${jobid} foo  &&
@@ -87,7 +138,8 @@ test_expect_success 'invalid dependency-remove is ignored' '
 '
 test_expect_success 'dependencies are re-established after restart' '
 	jobid=$(flux mini submit \
-		--setattr=system.dependency-test="[\"foo\",\"bar\"]" \
+		--dependency=test:foo \
+		--dependency=test:bar \
 		hostname) &&
 	flux job wait-event -t 15 -m description=bar ${jobid} dependency-add &&
 	flux jobs -o {id}:{dependencies} &&

--- a/t/t2270-job-dependencies.t
+++ b/t/t2270-job-dependencies.t
@@ -37,7 +37,7 @@ test_expect_success 'job-manager: dependency-test plugin is working' '
 '
 test_expect_success 'job dependencies are available in listing tools' '
 	jobid=$(flux mini submit \
-		--setattr=system.dependencies="[\"foo\"]" \
+		--setattr=system.dependency-test="[\"foo\"]" \
 		hostname) &&
 	flux job wait-event -t 15 -m description=foo ${jobid} dependency-add &&
 	flux jobs -o {id}:{dependencies} &&
@@ -49,7 +49,7 @@ test_expect_success 'job dependencies are available in listing tools' '
 '
 test_expect_success 'multiple job dependencies works' '
 	jobid=$(flux mini submit \
-		--setattr=system.dependencies="[\"foo\",\"bar\"]" \
+		--setattr=system.dependency-test="[\"foo\",\"bar\"]" \
 		hostname) &&
 	flux job wait-event -t 15 -m description=bar ${jobid} dependency-add &&
 	flux jobs -o {id}:{dependencies} &&
@@ -62,7 +62,7 @@ test_expect_success 'multiple job dependencies works' '
 '
 test_expect_success 'multiple dependency-add with same description is ignored' '
 	jobid=$(flux mini submit \
-		--setattr=system.dependencies="[\"bar\",\"bar\"]" \
+		--setattr=system.dependency-test="[\"bar\",\"bar\"]" \
 		hostname) &&
 	flux job wait-event -t 15 -m description=bar ${jobid} dependency-add &&
 	flux job eventlog ${jobid} &&
@@ -74,7 +74,7 @@ test_expect_success 'multiple dependency-add with same description is ignored' '
 
 test_expect_success 'invalid dependency-remove is ignored' '
 	jobid=$(flux mini submit \
-		--setattr=system.dependencies="[\"bar\"]" \
+		--setattr=system.dependency-test="[\"bar\"]" \
 		hostname) &&
 	flux job wait-event -t 15 -m description=bar ${jobid} dependency-add &&
 	test_must_fail flux python dep-remove.py ${jobid} foo  &&
@@ -87,7 +87,7 @@ test_expect_success 'invalid dependency-remove is ignored' '
 '
 test_expect_success 'dependencies are re-established after restart' '
 	jobid=$(flux mini submit \
-		--setattr=system.dependencies="[\"foo\",\"bar\"]" \
+		--setattr=system.dependency-test="[\"foo\",\"bar\"]" \
 		hostname) &&
 	flux job wait-event -t 15 -m description=bar ${jobid} dependency-add &&
 	flux jobs -o {id}:{dependencies} &&


### PR DESCRIPTION
This PR adds support for the `job.dependency.<scheme>` jobtap callback topic as proposed in #3651.

These callbacks are issued just after the `job.validate` callback so that jobs with invalid dependency spec or an unsupported dependency `scheme` can be rejected before they are fully submitted.

This first required queueing dependency-add/remove events in the `struct job *` structure, for later posting in the DEPEND state (since events can't be posted to a job that is not yet active). (Pulled in @garlick's commit to add aux list to `struct job` for this purpose)

For simplicity, redundant add/remove events are queued and then ignored when they are later posted to the eventlog. This could be "fixed" if anyone feels that was a poor design choice.

Finally, a `flux mini` `--dependency` option is added. This option takes the URI specification from [RFC 26](https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/spec_26.html), except that the required keys are relaxed so that only `scheme` and `value` are required, e.g.
```
ƒ(s=1,d=0,builddir) grondo@asp:~/git/f.git$ flux mini submit --dry-run --dependency=string:foo --dependency=string:bar?type=in hostname | jq .attributes.system.dependencies
[
  {
    "scheme": "string",
    "value": "foo"
  },
  {
    "scheme": "string",
    "value": "bar",
    "type": "in"
  }
]
```