### PR TITLE
libjob: add a library for constructing V1 jobspecs

### DIFF
--- a/src/common/libjob/Makefile.am
+++ b/src/common/libjob/Makefile.am
@@ -23,11 +23,14 @@ libjob_la_SOURCES = \
 	sign_none.c \
 	sign_none.h \
 	job_hash.c \
-	job_hash.h
+	job_hash.h \
+	specutil.c \
+	specutil.h
 
 TESTS = \
 	test_job.t \
-	test_sign_none.t
+	test_sign_none.t \
+	test_specutil.t
 
 check_PROGRAMS = \
         $(TESTS)
@@ -61,3 +64,7 @@ test_job_t_LDADD = $(test_ldadd) $(LIBDL)
 test_sign_none_t_SOURCES = test/sign_none.c
 test_sign_none_t_CPPFLAGS = $(test_cppflags)
 test_sign_none_t_LDADD = $(test_ldadd) $(LIBDL)
+
+test_specutil_t_SOURCES = test/specutil.c
+test_specutil_t_CPPFLAGS = $(test_cppflags)
+test_specutil_t_LDADD = $(test_ldadd) $(LIBDL)

--- a/src/common/libjob/Makefile.am
+++ b/src/common/libjob/Makefile.am
@@ -25,12 +25,15 @@ libjob_la_SOURCES = \
 	job_hash.c \
 	job_hash.h \
 	specutil.c \
-	specutil.h
+	specutil.h \
+	jobspec1.c \
+	jobspec1.h
 
 TESTS = \
 	test_job.t \
 	test_sign_none.t \
-	test_specutil.t
+	test_specutil.t \
+	test_jobspec1.t
 
 check_PROGRAMS = \
         $(TESTS)
@@ -68,3 +71,7 @@ test_sign_none_t_LDADD = $(test_ldadd) $(LIBDL)
 test_specutil_t_SOURCES = test/specutil.c
 test_specutil_t_CPPFLAGS = $(test_cppflags)
 test_specutil_t_LDADD = $(test_ldadd) $(LIBDL)
+
+test_jobspec1_t_SOURCES = test/jobspec1.c
+test_jobspec1_t_CPPFLAGS = $(test_cppflags)
+test_jobspec1_t_LDADD = $(test_ldadd) $(LIBDL)

--- a/src/common/libjob/jobspec1.c
+++ b/src/common/libjob/jobspec1.c
@@ -1,0 +1,261 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <errno.h>
+#include <jansson.h>
+#include <string.h>
+
+#include "specutil.h"
+#include "src/common/libutil/errno_safe.h"
+
+#include "jobspec1.h"
+
+struct flux_jobspec1 {
+    json_t *obj;
+};
+
+int flux_jobspec1_attr_unpack (flux_jobspec1_t *jobspec,
+                               const char *path,
+                               const char *fmt,
+                               ...)
+{
+    va_list ap;
+    json_t *root;
+    int rc;
+
+    if (!jobspec || !path || !fmt) {
+        errno = EINVAL;
+        return -1;
+    }
+    va_start (ap, fmt);
+    if (!(root =
+              specutil_attr_get (json_object_get (jobspec->obj, "attributes"), path))) {
+        return -1;
+    }
+    rc = json_vunpack_ex (root, NULL, 0, fmt, ap);
+    va_end (ap);
+    return rc;
+}
+
+int flux_jobspec1_attr_del (flux_jobspec1_t *jobspec, const char *path)
+{
+    if (!jobspec) {  // 'path' checked by specutil_attr_del
+        errno = EINVAL;
+        return -1;
+    }
+    return specutil_attr_del (json_object_get (jobspec->obj, "attributes"), path);
+}
+
+int flux_jobspec1_attr_pack (flux_jobspec1_t *jobspec,
+                             const char *path,
+                             const char *fmt,
+                             ...)
+{
+    va_list ap;
+    int rc;
+
+    if (!jobspec || !path || !fmt) {
+        errno = EINVAL;
+        return -1;
+    }
+    va_start (ap, fmt);
+    rc = specutil_attr_vpack (json_object_get (jobspec->obj, "attributes"),
+                              path,
+                              fmt,
+                              ap);
+
+    va_end (ap);
+    return rc;
+}
+
+int flux_jobspec1_attr_check (flux_jobspec1_t *jobspec, char *errbuf, int errbufsz)
+{
+    if (!jobspec || !errbuf || errbufsz < 0) {
+        errno = EINVAL;
+        return -1;
+    }
+    return specutil_attr_check (json_object_get (jobspec->obj, "attributes"),
+                                errbuf,
+                                errbufsz);
+}
+
+int flux_jobspec1_unsetenv (flux_jobspec1_t *jobspec, const char *name)
+{
+    json_t *environment;
+
+    if (!jobspec || !name) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (!(environment =
+              specutil_attr_get (jobspec->obj, "attributes.system.environment"))) {
+        return -1;
+    }
+    return specutil_env_unset (environment, name);
+}
+
+int flux_jobspec1_setenv (flux_jobspec1_t *jobspec,
+                           const char *name,
+                           const char *value,
+                           int overwrite)
+{
+    json_t *environment;
+
+    if (!jobspec || !name || !value) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (!(environment =
+              specutil_attr_get (jobspec->obj, "attributes.system.environment"))) {
+        return -1;
+    }
+    return specutil_env_set (environment, name, value, overwrite);
+}
+
+/* 'stdio_name' should be one of: 'output.stdout', 'output.stderr', or 'input.stdin'. */
+static int flux_jobspec1_set_stdio (flux_jobspec1_t *jobspec,
+                                    const char *stdio_name,
+                                    const char *path)
+{
+    char key[256];
+
+    if (!jobspec || !path || (strcmp (stdio_name, "input.stdin")
+        && strcmp (stdio_name, "output.stdout")
+        && strcmp (stdio_name, "output.stderr"))) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (snprintf (key, sizeof (key), "system.shell.options.%s", stdio_name)
+        >= sizeof (key)) {
+        errno = EOVERFLOW;
+        return -1;
+    }
+    return flux_jobspec1_attr_pack (jobspec,
+                                    key,
+                                    "{s:s s:s}",
+                                    "type",
+                                    "file",
+                                    "path",
+                                    path);
+}
+
+int flux_jobspec1_set_stdin (flux_jobspec1_t *jobspec, const char *path)
+{
+    return flux_jobspec1_set_stdio (jobspec, "input.stdin", path);
+}
+
+int flux_jobspec1_set_stdout (flux_jobspec1_t *jobspec, const char *path)
+{
+    return flux_jobspec1_set_stdio (jobspec, "output.stdout", path);
+}
+
+int flux_jobspec1_set_stderr (flux_jobspec1_t *jobspec, const char *path)
+{
+    return flux_jobspec1_set_stdio (jobspec, "output.stderr", path);
+}
+
+int flux_jobspec1_set_cwd (flux_jobspec1_t *jobspec, const char *cwd)
+{
+    if (!cwd) {  // 'jobspec' checked by 'attr_pack'
+        errno = EINVAL;
+        return -1;
+    }
+    return flux_jobspec1_attr_pack (jobspec, "system.cwd", "s", cwd);
+}
+
+char *flux_jobspec1_encode (flux_jobspec1_t *jobspec, size_t flags)
+{
+    char *returnval;
+
+    if (!jobspec) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (!(returnval = json_dumps (jobspec->obj, flags))) {
+        errno = ENOMEM;
+        return NULL;
+    }
+    return returnval;
+}
+
+flux_jobspec1_t *flux_jobspec1_from_command (int argc,
+                                             char **argv,
+                                             char **env,
+                                             int ntasks,
+                                             int cores_per_task,
+                                             int gpus_per_task,
+                                             int nnodes,
+                                             double duration)
+{
+    json_t *obj;
+    json_t *resources = NULL;
+    json_t *tasks = NULL;
+    json_t *env_obj = NULL;
+    flux_jobspec1_t *jobspec;
+
+    // resource arguments are checked by 'resources_create'
+    if (argc < 0 || !argv || duration < 0.0) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (!(tasks = specutil_tasks_create (argc, argv))) {
+        return NULL;
+    }
+    if (!(resources = specutil_resources_create (ntasks,
+                                                 cores_per_task,
+                                                 gpus_per_task,
+                                                 nnodes))) {
+        goto error;
+    }
+    if (!(env_obj = specutil_env_create (env))){
+        goto error;
+    }
+    if (!(obj = json_pack ("{s:o, s:o, s:{s:{s:f, s:o}}, s:i}",
+                           "resources", resources,
+                           "tasks", tasks,
+                           "attributes",
+                           "system",
+                           "duration", duration,
+                           "environment", env_obj,
+                           "version", 1))) {
+        errno = ENOMEM;
+        goto error;
+    }
+    if (!(jobspec = malloc (sizeof (flux_jobspec1_t)))) {
+        ERRNO_SAFE_WRAP (json_decref, obj);
+        return NULL;
+    }
+    jobspec->obj = obj;
+    return jobspec;
+
+error:
+    ERRNO_SAFE_WRAP (json_decref, tasks);
+    ERRNO_SAFE_WRAP (json_decref, resources);
+    ERRNO_SAFE_WRAP (json_decref, env_obj);
+    return NULL;
+}
+
+void flux_jobspec1_destroy (flux_jobspec1_t *jobspec)
+{
+    int saved_errno = errno;
+
+    if (jobspec) {
+        json_decref (jobspec->obj);
+        free (jobspec);
+        errno = saved_errno;
+    }
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libjob/jobspec1.h
+++ b/src/common/libjob/jobspec1.h
@@ -1,0 +1,129 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _FLUX_CORE_JOBSPEC1_H
+#define _FLUX_CORE_JOBSPEC1_H
+
+typedef struct flux_jobspec1 flux_jobspec1_t;
+
+/* Remove the value in the jobspec's 'attributes' section at the given path,
+ * where "." is treated as a path separator. Return 0 on success, -1 on error.
+ * It is not an error if 'path' does not exist.
+ */
+int flux_jobspec1_attr_del (flux_jobspec1_t *jobspec, const char *path);
+
+/* Set the value in the jobspec's 'attributes' section at the given path,
+ * where "." is treated as a path separator.
+ * 'fmt' should be a jansson pack-style string corresponding to the
+ * remaining arguments.
+ * Return 0 on success, -1 on error.
+ */
+int flux_jobspec1_attr_pack (flux_jobspec1_t *jobspec,
+                             const char *path,
+                             const char *fmt,
+                             ...);
+
+/* Unpack the values in the jobspec's 'attributes' section at the given path,
+ * where "." is treated as a path separator.
+ * 'fmt' should be a jansson unpack-style string corresponding to the
+ * remaining args.
+ * Return 0 on success, -1 on error.
+ */
+int flux_jobspec1_attr_unpack (flux_jobspec1_t *jobspec,
+                               const char *path,
+                               const char *fmt,
+                               ...);
+
+/* Check the validity of the 'attributes' section of a jobspec, writing an error
+ * message to 'errbuf'.
+ * Return 0 on success, -1 on error with an error message written.
+ * This function succeeding does not guarantee that the jobspec is valid.
+ */
+int flux_jobspec1_attr_check (flux_jobspec1_t *jobspec, char *errbuf, int errbufsz);
+
+/* Remove an entry in a Jobspec's environment.
+ * This function succeeds regardless of the presence of the variable.
+ * However, it will fail if the environment object does not exist.
+ * Return 0 on success, nonzero on error.
+ */
+int flux_jobspec1_unsetenv (flux_jobspec1_t *jobspec, const char *name);
+
+/* Add the variable 'name' to the environment
+ * with the value 'value', if name does not already exist.  If 'name'
+ * does exist in the environment, then its value is changed to 'value'
+ * if 'overwrite' is nonzero; if 'overwrite' is zero, then the value of
+ *'name' is not changed (and this function returns a success status).
+ * Return 0 on success, nonzero with errno set on error.
+ */
+int flux_jobspec1_setenv (flux_jobspec1_t *jobspec,
+                           const char *name,
+                           const char *value,
+                           int overwrite);
+
+/* Direct the stdin of a jobspec to a path given by
+ * 'stdin'. Return 0 on success, -1 on error.
+ */
+int flux_jobspec1_set_stdin (flux_jobspec1_t *jobspec, const char *path);
+
+/* Direct the stdout of a jobspec to a path given by
+ * 'stdout'. Return 0 on success, -1 on error.
+ */
+int flux_jobspec1_set_stdout (flux_jobspec1_t *jobspec, const char *path);
+
+/* Direct the stderr of a jobspec to a path given by
+ * 'stderr'. Return 0 on success, -1 on error.
+ */
+int flux_jobspec1_set_stderr (flux_jobspec1_t *jobspec, const char *path);
+
+/* Set the working directory of a jobspec.
+ * Return 0 on success, -1 on error.
+ */
+int flux_jobspec1_set_cwd (flux_jobspec1_t *jobspec, const char *cwd);
+
+/* Encode a jobspec to a string, e.g. for usage with ``flux_job_submit()``.
+ * 'flags' should be 0.
+ * Return NULL with errno set on error.
+ * The return value must be released with ``free()``.
+ */
+char *flux_jobspec1_encode (flux_jobspec1_t *jobspec, size_t flags);
+
+/* Create and return a minimum viable V1 Jobspec.
+ * The jobspec will have stdin, stdout, stderr all directed to the KVS,
+ * and the environment will be empty.
+ * The jobspec must be released with 'flux_jobspec1_free'.
+ * 'argc' and 'argv' should collectively define the command and its
+ * arguments.
+ * 'env' should be an 'environ(7)'-style array, where NULL indicates an
+ * empty environment.
+ * 'tasks' should be the number of tasks to launch
+ * 'cores_per_task' should be the number of cores per task to allocate
+ * 'gpus_per_task' should be the number of gpus per task to allocate
+ * 'nodes' should be the number of nodes to spread the allocated cores
+ * and gpus across. If 0, the scheduler will determine how to distribute
+ * the resources.
+ * Return NULL on error with errno set.
+ */
+flux_jobspec1_t *flux_jobspec1_from_command (int argc,
+                                             char **argv,
+                                             char **env,
+                                             int ntasks,
+                                             int cores_per_task,
+                                             int gpus_per_task,
+                                             int nnodes,
+                                             double duration);
+
+/* Free a jobspec. */
+void flux_jobspec1_destroy (flux_jobspec1_t *jobspec);
+
+#endif /* _FLUX_CORE_JOBSPEC1_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libjob/specutil.c
+++ b/src/common/libjob/specutil.c
@@ -1,0 +1,445 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <string.h>
+#include <jansson.h>
+#include <errno.h>
+
+#include "src/common/libutil/errno_safe.h"
+
+#include "specutil.h"
+
+json_t *specutil_argv_create (int argc, char **argv)
+{
+    int i;
+    json_t *a, *o;
+
+    if (!(a = json_array ()))
+        goto nomem;
+    for (i = 0; i < argc; i++) {
+        if (!(o = json_string (argv[i])) || json_array_append_new (a, o) < 0) {
+            ERRNO_SAFE_WRAP (json_decref, o);
+            goto nomem;
+        }
+    }
+    return a;
+nomem:
+    ERRNO_SAFE_WRAP (json_decref, a);
+    return NULL;
+}
+
+int specutil_env_set (json_t *o, const char *name, const char *value)
+{
+    json_t *val;
+
+    if (!(val = json_string (value)))
+        goto nomem;
+    if (json_object_set_new (o, name, val) < 0)
+        goto nomem;
+    return 0;
+nomem:
+    json_decref (val);
+    errno = ENOMEM;
+    return -1;
+}
+
+int specutil_env_unset (json_t *o, const char *name)
+{
+    (void)json_object_del (o, name);
+    return 0;
+}
+
+int specutil_env_put (json_t *o, const char *entry)
+{
+    char *cpy;
+    char *cp;
+    int rc = -1;
+
+    if (!(cpy = strdup (entry)))
+        return -1;
+    if ((cp = strchr (cpy, '=')))
+        *cp++ = '\0';
+    if (!cp || cp == cpy) {
+        errno = EINVAL;
+        goto done;
+    }
+    rc = specutil_env_set (o, cpy, cp);
+done:
+    ERRNO_SAFE_WRAP (free, cpy);
+    return rc;
+}
+
+json_t *specutil_env_create (char **env)
+{
+    int i;
+    json_t *o;
+
+    if (!(o = json_object ())) {
+        errno = ENOMEM;
+        return NULL;
+    }
+    for (i = 0; env[i] != NULL; i++) {
+        if (specutil_env_put (o, env[i]) < 0)
+            goto error;
+    }
+    return o;
+error:
+    ERRNO_SAFE_WRAP (json_decref, o);
+    return NULL;
+}
+
+/* Recursively set path=val in object 'o'.
+ * A period '.' is interpreted as a path separator.
+ * Path components are created as needed.
+ * N.B. 'path' is modified.
+ */
+static int object_set_path (json_t *o, char *path, json_t *val)
+{
+    char *cp;
+    json_t *dir;
+
+    if ((cp = strchr (path, '.'))) {
+        *cp++ = '\0';
+        if (strlen (path) == 0) {
+            errno = EINVAL;
+            return -1;
+        }
+        if (!(dir = json_object_get (o, path))) {
+            if (!(dir = json_object ()))
+                goto nomem;
+            if (json_object_set_new (o, path, dir) < 0) {
+                json_decref (dir);
+                goto nomem;
+            }
+        }
+        return object_set_path (dir, cp, val);
+    }
+
+    if (strlen (path) == 0) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (json_object_set (o, path, val) < 0)
+        goto nomem;
+    return 0;
+nomem:
+    errno = ENOMEM;
+    return -1;
+}
+
+/* Recursively delete path in object 'o'.
+ * A period '.' is interpreted as a path separator.
+ * If the target or path leading to it does not exist, return succces.
+ * N.B. 'path' is modified.
+ */
+int object_del_path (json_t *o, char *path)
+{
+    char *cp;
+    json_t *dir;
+
+    if ((cp = strchr (path, '.'))) {
+        *cp++ = '\0';
+        if (strlen (path) == 0) {
+            errno = EINVAL;
+            return -1;
+        }
+        if (!(dir = json_object_get (o, path)))
+            return 0;
+        return object_del_path (dir, cp);
+    }
+
+    if (strlen (path) == 0) {
+        errno = EINVAL;
+        return -1;
+    }
+    (void)json_object_del (o, path);
+    return 0;
+}
+
+static json_t *object_get_path (json_t *o, char *path)
+{
+    char *cp;
+    json_t *dir;
+    json_t *val;
+
+    if ((cp = strchr (path, '.'))) {
+        *cp++ = '\0';
+        if (strlen (path) == 0) {
+            errno = EINVAL;
+            return NULL;
+        }
+        if (!(dir = json_object_get (o, path))) {
+            errno = ENOENT;
+            return NULL;
+        }
+        return object_get_path (dir, cp);
+    }
+
+    if (strlen (path) == 0) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (!(val = json_object_get (o, path))) {
+        errno = ENOENT;
+        return NULL;
+    }
+    return val;
+}
+
+int specutil_attr_del (json_t *o, const char *path)
+{
+    char *cpy;
+    int rc;
+
+    if (!o || !path) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (!(cpy = strdup (path)))
+        return -1;
+    rc = object_del_path (o, cpy);
+    ERRNO_SAFE_WRAP (free, cpy);
+    return rc;
+}
+
+int specutil_attr_set (json_t *o, const char *path, json_t *val)
+{
+    char *cpy;
+    int rc;
+
+    if (!o || !path || !val) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (!(cpy = strdup (path)))
+        return -1;
+    rc = object_set_path (o, cpy, val);
+    ERRNO_SAFE_WRAP (free, cpy);
+    return rc;
+}
+
+json_t *specutil_attr_get (json_t *o, const char *path)
+{
+    char *cpy;
+    json_t *val;
+
+    if (!o || !path) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (!(cpy = strdup (path)))
+        return NULL;
+    val = object_get_path (o, cpy);
+    ERRNO_SAFE_WRAP (free, cpy);
+    return val;
+}
+
+
+static int specutil_attr_vpack (json_t *o,
+                                const char *path,
+                                const char *fmt,
+                                va_list ap)
+{
+    json_t *value;
+    int rc;
+
+    if (!fmt || !(value = json_vpack_ex (NULL, 0, fmt, ap))) {
+        errno = EINVAL;
+        return -1;
+    }
+    rc = specutil_attr_set (o, path, value);
+    ERRNO_SAFE_WRAP (json_decref, value);
+    return rc;
+}
+
+int specutil_attr_pack (json_t *o, const char *path, const char *fmt, ...)
+{
+    va_list ap;
+    int rc;
+
+    va_start (ap, fmt);
+    rc = specutil_attr_vpack (o, path, fmt, ap);
+    va_end (ap);
+    return rc;
+}
+
+static int specutil_attr_system_check (json_t *o, const char **errtxt)
+{
+    const char *key;
+    json_t *value;
+
+    json_object_foreach (o, key, value) {
+        if (!strcmp (key, "duration")) {
+            if (!json_is_number (value)) {
+                *errtxt = "attributes.system.duration must be a number";
+                return -1;
+            }
+        }
+        else if (!strcmp (key, "environment")) {
+            if (!(json_is_object (value))) {
+                *errtxt = "attributes.system.environment.must be a dictionary";
+                return -1;
+            }
+        }
+        else if (!strcmp (key, "shell")) {
+            json_t *opt;
+            if ((opt = json_object_get (value, "options"))
+                && !json_is_object (opt)) {
+                *errtxt = "attributes.shell.options must be a dictionary";
+                return -1;
+            }
+        }
+    }
+    return 0;
+}
+
+int specutil_attr_check (json_t *o, char *errbuf, int errbufsz)
+{
+    const char *key;
+    json_t *value;
+    const char *errtxt;
+
+    json_object_foreach (o, key, value) {
+        if (!strcmp (key, "user")) {
+            if (json_object_size (value) == 0) {
+                errtxt = "if present, attributes.user must contain values";
+                goto copy_error;
+            }
+        }
+        else if (!strcmp (key, "system")) {
+            if (json_object_size (value) == 0) {
+                errtxt = "if present, attributes.system must contain values";
+                goto copy_error;
+            }
+            if (specutil_attr_system_check (value, &errtxt) < 0)
+                goto copy_error;
+        }
+        else {
+            snprintf (errbuf, errbufsz, "unknown attributes section %s", key);
+            goto error;
+        }
+    }
+    return 0;
+copy_error:
+    snprintf (errbuf, errbufsz, "%s", errtxt);
+error:
+    errno = EINVAL;
+    return -1;
+}
+
+static json_t *specutil_tasks_create (json_t *argv)
+{
+    json_t *tasks;
+
+    if (!(tasks = json_pack ("[{s:O s:s s:{s:i}}]",
+                             "command", argv,
+                             "slot", "task",
+                             "count",
+                               "per_slot", 1))) {
+        errno = ENOMEM;
+        return NULL;
+    }
+    return tasks;
+}
+
+static json_t *specutil_resources_create (struct resource_param *param)
+{
+    json_t *slot;
+    struct resource_param p = *param;
+
+    if (p.cores_per_task < 1)
+        p.cores_per_task = 1;
+    if (p.ntasks < 1)
+        p.ntasks = 1;
+    if (p.nodes > p.ntasks) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (p.gpus_per_task > 0) {
+        if (!(slot = json_pack ("[{s:s s:i s:[{s:s s:i} {s:s s:i}] s:s}]",
+                                "type", "slot",
+                                "count", p.ntasks,
+                                "with",
+                                  "type", "core",
+                                  "count", p.cores_per_task,
+                                  "type", "gpu",
+                                  "count", p.gpus_per_task,
+                                "label", "task")))
+            goto nomem;
+    }
+    else {
+        if (!(slot = json_pack ("[{s:s s:i s:[{s:s s:i}] s:s}]",
+                                "type", "slot",
+                                "count", p.ntasks,
+                                "with",
+                                "type", "core",
+                                "count", p.cores_per_task,
+                                "label", "task")))
+            goto nomem;
+    }
+    if (p.nodes > 0) {
+        json_t *node;
+        if (!(node = json_pack ("[{s:s s:i s:o}]",
+                                "type", "node",
+                                "count", p.nodes,
+                                "with", slot))) {
+            json_decref (slot);
+            goto nomem;
+        }
+        return node;
+    }
+    return slot;
+nomem:
+    errno = ENOMEM;
+    return NULL;
+}
+
+json_t *specutil_jobspec_create (json_t *attributes,
+                                 json_t *argv,
+                                 struct resource_param *param,
+                                 char *errbuf,
+                                 int errbufsz)
+{
+    json_t *tasks = NULL;
+    json_t *resources = NULL;
+    json_t *jobspec;
+
+    if (specutil_attr_check (attributes, errbuf, errbufsz) < 0)
+        goto error;
+    if (!(tasks = specutil_tasks_create (argv))) {
+        snprintf (errbuf, errbufsz, "Error creating tasks object");
+        goto error;
+    }
+    if (!(resources = specutil_resources_create (param))) {
+        snprintf (errbuf, errbufsz, "Error creating resources object");
+        goto error;
+    }
+    if (!(jobspec = json_pack ("{s:o s:o s:O s:i}",
+                               "resources", resources,
+                               "tasks", tasks,
+                               "attributes", attributes, // incref
+                               "version", 1))) {
+        errno = ENOMEM;
+        snprintf (errbuf, errbufsz, "Error creating jobspec object");
+        goto error;
+    }
+    return jobspec;
+error:
+    ERRNO_SAFE_WRAP (json_decref, resources);
+    ERRNO_SAFE_WRAP (json_decref, tasks);
+    return NULL;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libjob/specutil.h
+++ b/src/common/libjob/specutil.h
@@ -1,0 +1,49 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _JOB_SPECUTIL_H
+#define _JOB_SPECUTIL_H
+
+#include <jansson.h>
+
+struct resource_param {
+    int ntasks;
+    int nodes;
+    int cores_per_task;
+    int gpus_per_task;
+};
+
+json_t *specutil_jobspec_create (json_t *attributes,
+                                 json_t *argv,
+                                 struct resource_param *param,
+                                 char *errbuf,
+                                 int errbufsz);
+
+json_t *specutil_argv_create (int argc, char **argv);
+
+json_t *specutil_env_create (char **env);
+int specutil_env_put (json_t *env, const char *entry);
+int specutil_env_set (json_t *env, const char *name, const char *val);
+int specutil_env_unset (json_t *env, const char *name);
+
+int specutil_attr_set (json_t *attr, const char *path, json_t *val);
+int specutil_attr_pack (json_t *attr, const char *path, const char *fmt, ...);
+int specutil_attr_del (json_t *attr, const char *path);
+
+json_t *specutil_attr_get (json_t *attr, const char *path);
+
+int specutil_attr_check (json_t *attr, char *errbuf, int errbufsz);
+
+#endif /* _JOB_SPECUTIL_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */
+

--- a/src/common/libjob/specutil.h
+++ b/src/common/libjob/specutil.h
@@ -13,37 +13,31 @@
 
 #include <jansson.h>
 
-struct resource_param {
-    int ntasks;
-    int nodes;
-    int cores_per_task;
-    int gpus_per_task;
-};
-
-json_t *specutil_jobspec_create (json_t *attributes,
-                                 json_t *argv,
-                                 struct resource_param *param,
-                                 char *errbuf,
-                                 int errbufsz);
-
 json_t *specutil_argv_create (int argc, char **argv);
 
 json_t *specutil_env_create (char **env);
 int specutil_env_put (json_t *env, const char *entry);
-int specutil_env_set (json_t *env, const char *name, const char *val);
+int specutil_env_set (json_t *env, const char *name, const char *val, int overwrite);
 int specutil_env_unset (json_t *env, const char *name);
 
 int specutil_attr_set (json_t *attr, const char *path, json_t *val);
 int specutil_attr_pack (json_t *attr, const char *path, const char *fmt, ...);
+int specutil_attr_vpack (json_t *o, const char *path, const char *fmt, va_list ap);
 int specutil_attr_del (json_t *attr, const char *path);
 
 json_t *specutil_attr_get (json_t *attr, const char *path);
 
 int specutil_attr_check (json_t *attr, char *errbuf, int errbufsz);
 
+json_t *specutil_tasks_create (int argc, char **argv);
+
+json_t *specutil_resources_create (int ntasks,
+                                   int cores_per_task,
+                                   int gpus_per_task,
+                                   int nnodes);
+
 #endif /* _JOB_SPECUTIL_H */
 
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab
  */
-

--- a/src/common/libjob/test/jobspec1.c
+++ b/src/common/libjob/test/jobspec1.c
@@ -1,0 +1,416 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <errno.h>
+#include <jansson.h>
+#include <stdbool.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "src/common/libjob/jobspec1.h"
+#include "src/common/libtap/tap.h"
+
+extern char **environ;
+
+int free_wrapper (void *ptr)
+{
+    free (ptr);
+    return 1;
+}
+
+int decref_wrapper (json_t *ptr)
+{
+    json_decref (ptr);
+    return 1;
+}
+
+void check_stdio_cwd (void)
+{
+    char *argv[] = {"this", "is", "a", "test"};
+    int argc = sizeof (argv) / sizeof (argv[0]);
+    flux_jobspec1_t *jobspec;
+    char *path;
+
+    if (!(jobspec = flux_jobspec1_from_command (argc, argv, NULL, 1, 1, 1, 0, 0.0))) {
+        BAIL_OUT ("flux_jobspec1_from_command failed");
+    }
+    ok (flux_jobspec1_set_cwd (NULL, "/foo/bar/baz") < 0 && errno == EINVAL,
+        "flux_jobspec1_set_cwd catches NULL jobspec");
+    errno = 0;
+    ok (flux_jobspec1_set_cwd (jobspec, NULL) < 0 && errno == EINVAL,
+        "flux_jobspec1_set_cwd catches NULL cwd");
+    errno = 0;
+    ok (flux_jobspec1_set_cwd (jobspec, "/foo/bar/baz") == 0
+            && (flux_jobspec1_attr_unpack (jobspec, "system.cwd", "s", &path) == 0)
+
+            && (strcmp ("/foo/bar/baz", path) == 0),
+        "flux_jobspec1_set_cwd works");
+    ok (flux_jobspec1_set_stdin (NULL, "/foo/bar/baz") < 0 && errno == EINVAL,
+        "flux_jobspec1_set_stdin catches NULL jobspec");
+    errno = 0;
+    ok (flux_jobspec1_set_stdin (jobspec, NULL) < 0 && errno == EINVAL,
+        "flux_jobspec1_set_stdin catches NULL path");
+    errno = 0;
+    ok (flux_jobspec1_set_stdin (jobspec, "/foo/bar/stdin.txt") == 0
+            && (flux_jobspec1_attr_unpack (jobspec,
+                                           "system.shell.options.input.stdin.path",
+                                           "s",
+                                           &path)
+                == 0)
+
+            && (strcmp ("/foo/bar/stdin.txt", path) == 0),
+        "flux_jobspec1_set_stdin sets right path");
+    ok ((flux_jobspec1_attr_unpack (jobspec,
+                                    "system.shell.options.input.stdin.type",
+                                    "s",
+                                    &path)
+         == 0)
+            && (strcmp ("file", path) == 0),
+        "flux_jobspec1_set_stdin sets right type");
+    ok (flux_jobspec1_set_stdout (NULL, "/foo/bar/baz") < 0 && errno == EINVAL,
+        "flux_jobspec1_set_stdout catches NULL jobspec");
+    errno = 0;
+    ok (flux_jobspec1_set_stdout (jobspec, NULL) < 0 && errno == EINVAL,
+        "flux_jobspec1_set_stdout catches NULL path");
+    errno = 0;
+    ok (flux_jobspec1_set_stdout (jobspec, "/foo/bar/stdout.txt") == 0
+            && (flux_jobspec1_attr_unpack (jobspec,
+                                           "system.shell.options.output.stdout.path",
+                                           "s",
+                                           &path)
+                == 0)
+
+            && (strcmp ("/foo/bar/stdout.txt", path) == 0),
+        "flux_jobspec1_set_stdout sets right path");
+    ok ((flux_jobspec1_attr_unpack (jobspec,
+                                    "system.shell.options.output.stdout.type",
+                                    "s",
+                                    &path)
+         == 0)
+            && (strcmp ("file", path) == 0),
+        "flux_jobspec1_set_stdout sets right type");
+    ok (flux_jobspec1_set_stderr (NULL, "/foo/bar/baz") < 0 && errno == EINVAL,
+        "flux_jobspec1_set_stderr catches NULL jobspec");
+    errno = 0;
+    ok (flux_jobspec1_set_stderr (jobspec, NULL) < 0 && errno == EINVAL,
+        "flux_jobspec1_set_stderr catches NULL path");
+    errno = 0;
+    ok (flux_jobspec1_set_stderr (jobspec, "/foo/bar/stderr.txt") == 0
+            && (flux_jobspec1_attr_unpack (jobspec,
+                                           "system.shell.options.output.stderr.path",
+                                           "s",
+                                           &path)
+                == 0)
+
+            && (strcmp ("/foo/bar/stderr.txt", path) == 0),
+        "flux_jobspec1_set_stderr sets right path");
+    ok ((flux_jobspec1_attr_unpack (jobspec,
+                                    "system.shell.options.output.stderr.type",
+                                    "s",
+                                    &path)
+         == 0)
+            && (strcmp ("file", path) == 0),
+        "flux_jobspec1_set_stderr sets right type");
+    flux_jobspec1_destroy (jobspec);
+}
+
+void check_env (void)
+{
+    char *argv[] = {"this", "is", "a", "test"};
+    int argc = sizeof (argv) / sizeof (argv[0]);
+    flux_jobspec1_t *jobspec;
+    char *val;
+
+    if (!(jobspec =
+              flux_jobspec1_from_command (argc, argv, environ, 1, 1, 1, 0, 0.0))) {
+        BAIL_OUT ("flux_jobspec1_from_command failed with environ");
+    }
+    ok (flux_jobspec1_setenv (NULL, "FOO", "BAR", 1) < 0 && errno == EINVAL,
+        "flux_jobspec1_setenv catches NULL jobspec");
+    errno = 0;
+    ok (flux_jobspec1_setenv (jobspec, NULL, "BAR", 1) < 0 && errno == EINVAL,
+        "flux_jobspec1_setenv catches NULL variable name");
+    errno = 0;
+    ok (flux_jobspec1_setenv (jobspec, "FOO", NULL, 1) < 0 && errno == EINVAL,
+        "flux_jobspec1_setenv catches NULL variable value");
+    errno = 0;
+    ok (flux_jobspec1_unsetenv (NULL, "FOO") < 0 && errno == EINVAL,
+        "flux_jobspec1_unsetenv catches NULL jobspec");
+    errno = 0;
+    ok (flux_jobspec1_unsetenv (jobspec, NULL) < 0 && errno == EINVAL,
+        "flux_jobspec1_unsetenv catches NULL variable");
+    errno = 0;
+    ok (flux_jobspec1_setenv (jobspec, "FOO1", "BAR1", 1) == 0
+            && (flux_jobspec1_attr_unpack (jobspec,
+                                           "system.environment.FOO1",
+                                           "s",
+                                           &val)
+                == 0)
+            && (strcmp ("BAR1", val) == 0),
+        "jobspec_setenv FOO1=BAR1 works");
+    ok (flux_jobspec1_setenv (jobspec, "FOO1", "BAZ1", 1) == 0
+            && (flux_jobspec1_attr_unpack (jobspec,
+                                           "system.environment.FOO1",
+                                           "s",
+                                           &val)
+                == 0)
+            && (strcmp ("BAZ1", val) == 0),
+        "jobspec_setenv FOO1=BAZ1 works (overwrite=1)");
+    ok (flux_jobspec1_setenv (jobspec, "FOO1", "BAZ2", 0) == 0
+            && (flux_jobspec1_attr_unpack (jobspec,
+                                           "system.environment.FOO1",
+                                           "s",
+                                           &val)
+                == 0)
+            && (strcmp ("BAZ1", val) == 0),
+        "jobspec_setenv FOO1=BAZ2 works (overwrite=0)");
+    ok (flux_jobspec1_unsetenv (jobspec, "FOO1") == 0
+            && (flux_jobspec1_attr_unpack (jobspec,
+                                           "system.environment.FOO1",
+                                           "s",
+                                           &val)
+                < 0),
+        "unset FOO1 works");
+    ok (flux_jobspec1_setenv (jobspec, "FOO2", "BAR2", 1) == 0
+            && (flux_jobspec1_attr_unpack (jobspec,
+                                           "system.environment.FOO2",
+                                           "s",
+                                           &val)
+                == 0)
+            && (strcmp ("BAR2", val) == 0),
+        "jobspec_setenv FOO2=BAR2 works");
+
+    // test functions when environment object is deleted
+    ok (flux_jobspec1_attr_del (jobspec, "system.environment") == 0,
+        "deleting environment works");
+    ok (flux_jobspec1_setenv (jobspec, "FOO1", "BAR1", 1) < 0
+            && (flux_jobspec1_attr_unpack (jobspec,
+                                           "system.environment.FOO1",
+                                           "s",
+                                           &val)
+                < 0),
+        "can't set FOO1=BAR1 after deleting environment object");
+    ok (flux_jobspec1_unsetenv (jobspec, "FOO") < 0,
+        "flux_jobspec1_unsetenv fails after deleting environment");
+    flux_jobspec1_destroy (jobspec);
+}
+
+void check_attr (void)
+{
+    char *argv[] = {"this", "is", "a", "test"};
+    int argc = sizeof (argv) / sizeof (argv[0]);
+    flux_jobspec1_t *jobspec;
+    json_t *json_ptr;
+    int int_val;
+    char *char_ptr;
+
+    if (!(jobspec = flux_jobspec1_from_command (argc, argv, NULL, 1, 1, 1, 0, 0.0))) {
+        BAIL_OUT ("flux_jobspec1_from_command failed");
+    }
+    ok (flux_jobspec1_attr_pack (NULL, "foo.bar", "i", 5) < 0 && errno == EINVAL,
+        "flux_jobspec1_attr_pack catches NULL jobspec");
+    errno = 0;
+    ok (flux_jobspec1_attr_pack (jobspec, NULL, "i", 5) < 0 && errno == EINVAL,
+        "flux_jobspec1_attr_pack catches NULL path");
+    errno = 0;
+    ok (flux_jobspec1_attr_pack (jobspec, "foo.bar", NULL, 5) < 0 && errno == EINVAL,
+        "flux_jobspec1_attr_pack catches NULL format string");
+    errno = 0;
+    ok (flux_jobspec1_attr_unpack (NULL, "foo.bar", "i", 5) < 0 && errno == EINVAL,
+        "flux_jobspec1_attr_unpack catches NULL jobspec");
+    errno = 0;
+    ok (flux_jobspec1_attr_unpack (jobspec, NULL, "i", 5) < 0 && errno == EINVAL,
+        "flux_jobspec1_attr_unpack catches NULL path");
+    errno = 0;
+    ok (flux_jobspec1_attr_unpack (jobspec, "foo.bar", NULL, 5) < 0 && errno == EINVAL,
+        "flux_jobspec1_attr_unpack catches NULL format string");
+    errno = 0;
+    ok (flux_jobspec1_attr_del (jobspec, NULL) < 0 && errno == EINVAL,
+        "flux_jobspec1_attr_del catches NULL path");
+    errno = 0;
+    ok (flux_jobspec1_attr_del (NULL, "foo.bar") < 0 && errno == EINVAL,
+        "flux_jobspec1_attr_del catches NULL jobspec");
+    errno = 0;
+
+    ok (flux_jobspec1_attr_pack (jobspec, "foo.bar", "s", "baz") == 0
+            && (flux_jobspec1_attr_unpack (jobspec, "foo.bar", "s", &char_ptr) == 0)
+            && strcmp ("baz", char_ptr) == 0,
+        "flux_jobspec1_attr_pack works on strings");
+    ok (flux_jobspec1_attr_pack (jobspec, "foo.bar", "i", 19) == 0
+            && (flux_jobspec1_attr_unpack (jobspec, "foo.bar", "i", &int_val) == 0)
+            && 19 == int_val,
+        "flux_jobspec1_attr_pack works on integers");
+    ok (flux_jobspec1_attr_pack (jobspec, "foo", "{s:s}", "bar", "baz") == 0
+            && (flux_jobspec1_attr_unpack (jobspec, "foo", "{s:s}", "bar", &char_ptr)
+                == 0)
+            && strcmp ("baz", char_ptr) == 0,
+        "flux_jobspec1_attr_pack works on objects");
+    ok (flux_jobspec1_attr_del (jobspec, "foo.bar.baz") == 0
+            && (flux_jobspec1_attr_unpack (jobspec, "foo.bar.baz", "o", &json_ptr) < 0),
+        "flux_jobspec1_attr_del works");
+    ok (flux_jobspec1_attr_del (jobspec, "foo") == 0
+            && (flux_jobspec1_attr_unpack (jobspec, "foo", "o", &json_ptr) < 0),
+        "flux_jobspec1_attr_del works");
+    flux_jobspec1_destroy (jobspec);
+}
+
+void check_jobspec (void)
+{
+    char *argv[] = {"this", "is", "a", "test"};
+    int argc = sizeof (argv) / sizeof (argv[0]);
+    flux_jobspec1_t *jobspec;
+    char errbuf[50];
+    char *str;
+    json_t *val;
+    double passed_duration = 5.0;
+    double duration;
+
+    if (!(jobspec = flux_jobspec1_from_command (argc,
+                                                argv,
+                                                NULL,
+                                                1,
+                                                1,
+                                                1,
+                                                0,
+                                                passed_duration))) {
+        BAIL_OUT ("flux_jobspec1_from_command failed");
+    }
+    ok (flux_jobspec1_attr_check (NULL, errbuf, 5) < 0 && errno == EINVAL,
+        "flux_jobspec1_attr_check catches NULL jobspec");
+    errno = 0;
+    ok (flux_jobspec1_attr_check (jobspec, NULL, 5) < 0 && errno == EINVAL,
+        "flux_jobspec1_attr_check catches NULL errbuf");
+    errno = 0;
+    ok (flux_jobspec1_attr_check (jobspec, errbuf, -1) < 0 && errno == EINVAL,
+        "flux_jobspec1_attr_check catches invalid errbuf size");
+    errno = 0;
+
+    ok (flux_jobspec1_attr_check (jobspec, errbuf, sizeof (errbuf)) == 0,
+        "flux_jobspec1_attr_check passed");
+    ok (flux_jobspec1_attr_unpack (jobspec, "system", "o", &val) == 0,
+        "jobspec has system attribute");
+    ok (flux_jobspec1_attr_unpack (jobspec, "system.duration", "f", &duration) == 0
+            && (duration - passed_duration < 0.001),
+        "jobspec has system.duration attribute set to correct value");
+    ok (flux_jobspec1_attr_unpack (jobspec, "system.environment", "o", &val) == 0
+            && json_is_object (val) && json_object_size (val) == 0,
+        "jobspec has system.environment object of size 0");
+    ok (flux_jobspec1_attr_unpack (jobspec, "foo.bar", "s", &str) < 0,
+        "jobspec has no foo.bar attribute");
+    flux_jobspec1_destroy (jobspec);
+    passed_duration = 0.0;
+    if (!(jobspec = flux_jobspec1_from_command (argc,
+                                                argv,
+                                                NULL,
+                                                1,
+                                                1,
+                                                1,
+                                                0,
+                                                passed_duration))) {
+        BAIL_OUT ("flux_jobspec1_from_command failed");
+    }
+    ok ((flux_jobspec1_attr_unpack (jobspec, "system.duration", "f", &duration) == 0)
+            && (duration == passed_duration),
+        "jobspec has system.duration attribute set to correct value");
+    flux_jobspec1_destroy (jobspec);
+    ok (flux_jobspec1_from_command (argc, argv, NULL, 1, 1, 1, 5, 0) == NULL,
+        "flux_jobspec1_from_command failed when nnodes > ntasks");
+    if (!(jobspec = flux_jobspec1_from_command (argc, argv, NULL, 5, 1, 1, 3, 0.0))) {
+        BAIL_OUT ("flux_jobspec1_from_command failed when nnodes < ntasks");
+    }
+    ok (flux_jobspec1_attr_check (jobspec, errbuf, sizeof (errbuf)) == 0,
+        "flux_jobspec1_attr_check passed when nnodes < ntasks");
+    ok (flux_jobspec1_attr_pack (jobspec, "system.duration", "s", "not a number") == 0
+            && flux_jobspec1_attr_unpack (jobspec, "system.duration", "f", &duration)
+                   < 0,
+        "deleting system.duration works");
+    ok (flux_jobspec1_attr_check (jobspec, errbuf, sizeof (errbuf)) < 0,
+        "flux_jobspec1_attr_check failed after changing system.duration to a string");
+    flux_jobspec1_destroy (jobspec);
+    if (!(jobspec = flux_jobspec1_from_command (argc, argv, NULL, 5, 1, 1, 5, 0.0))) {
+        BAIL_OUT ("flux_jobspec1_from_command failed when nnodes == ntasks");
+    }
+    ok (flux_jobspec1_attr_check (jobspec, errbuf, sizeof (errbuf)) == 0,
+        "flux_jobspec1_attr_check passed when nnodes == ntasks");
+    ok (flux_jobspec1_attr_pack (jobspec, "foo", "f", 19.5) == 0
+            && flux_jobspec1_attr_check (jobspec, errbuf, sizeof (errbuf)) < 0,
+        "attr_check failed after adding spurious attribute");
+    flux_jobspec1_destroy (jobspec);
+}
+
+void check_encoding (void)
+{
+    char *argv[] = {"this", "is", "a", "test"};
+    int argc = sizeof (argv) / sizeof (argv[0]);
+    flux_jobspec1_t *jobspec;
+    char *encoded;
+    json_t *dup = NULL;
+    json_error_t err;
+
+    if (!(jobspec = flux_jobspec1_from_command (argc, argv, NULL, 5, 3, 2, 0, 0.0))
+        || !(encoded = flux_jobspec1_encode (jobspec, 0))) {
+        BAIL_OUT ("flux_jobspec1_from_command or subsequent encoding failed");
+    };
+    ok ((dup = json_loads (encoded, 0, &err)) && free_wrapper (encoded)
+            && decref_wrapper (dup),
+        "decoding works");
+
+    errno = EINVAL;
+    flux_jobspec1_destroy (jobspec);
+    ok (errno == EINVAL, "flux_jobspec1_destroy preserves errno");
+    errno = 0;
+
+    ok (flux_jobspec1_encode (NULL, 0) == NULL && errno == EINVAL,
+        "flux_jobspec1_encode catches NULL jobspec");
+    errno = 0;
+}
+
+void check_bad_args (void)
+{
+    char *argv[] = {"this", "is", "a", "test"};
+    int argc = sizeof (argv) / sizeof (argv[0]);
+
+    ok (flux_jobspec1_from_command (-1, argv, NULL, 1, 1, 1, 0, 5.0) == NULL
+            && errno == EINVAL,
+        "flux_jobspec1_from_command catches bad argc");
+    errno = 0;
+    ok (flux_jobspec1_from_command (argc, NULL, NULL, 1, 1, 1, 0, 5.0) == NULL
+            && errno == EINVAL,
+        "flux_jobspec1_from_command catches bad argv");
+    errno = 0;
+    ok (flux_jobspec1_from_command (argc, argv, NULL, 1, 1, 1, 0, -1.5) == NULL
+            && errno == EINVAL,
+        "flux_jobspec1_from_command catches bad duration");
+    errno = 0;
+
+    flux_jobspec1_destroy (NULL);
+}
+
+int main (int argc, char *argv[])
+{
+    plan (NO_PLAN);
+
+    check_stdio_cwd ();
+    check_env ();
+    check_jobspec ();
+    check_attr ();
+    check_encoding ();
+    check_bad_args ();
+
+    done_testing ();
+    return 0;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libjob/test/specutil.c
+++ b/src/common/libjob/test/specutil.c
@@ -1,0 +1,316 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <jansson.h>
+#include <stdbool.h>
+#include <string.h>
+#include <errno.h>
+
+#include "src/common/libtap/tap.h"
+#include "src/common/libjob/specutil.h"
+
+bool object_is_string (json_t *object, const char *name, const char *val)
+{
+    json_t *o;
+    const char *s;
+    if (!(o = json_object_get (object, name)))
+        return false;
+    if (!json_is_string (o))
+        return false;
+    if (!(s = json_string_value (o)))
+        return false;
+    if (strcmp (val, s) != 0)
+        return false;
+    return true;
+}
+
+bool entry_is_string (json_t *array, int index, const char *val)
+{
+    json_t *o;
+    const char *s;
+    if (!(o = json_array_get (array, index)))
+        return false;
+    if (!json_is_string (o))
+        return false;
+    if (!(s = json_string_value (o)))
+        return false;
+    if (strcmp (val, s) != 0)
+        return false;
+    return true;
+}
+
+void check_env (void)
+{
+    json_t *env;
+
+    if (!(env = specutil_env_create (environ)))
+        BAIL_OUT ("specutil_env_create failed");
+    ok (json_object_size (env) > 0,
+        "specutil_env_create() works");
+
+    ok (specutil_env_set (env, "TEST_FOO", "42") == 0
+        && object_is_string (env, "TEST_FOO", "42"),
+        "specutil_env_set TEST_FOO=42 works");
+
+    ok (specutil_env_set (env, "TEST_FOO", "43") == 0
+        && object_is_string (env, "TEST_FOO", "43"),
+        "specutil_env_set TEST_FOO=43 works");
+
+    ok (specutil_env_put (env, "TEST_FOO=44") == 0
+        && object_is_string (env, "TEST_FOO", "44"),
+        "specutil_env_put TEST_FOO=44 works");
+
+    ok (specutil_env_unset (env, "TEST_FOO") == 0
+        && !json_object_get (env, "TEST_FOO"),
+        "specutil_env_del TEST_FOO works");
+
+    json_decref (env);
+}
+
+void check_argv (void)
+{
+    char *argv[] = { "this", "is", "a", "test" };
+    int argc = sizeof (argv) / sizeof (argv[0]);
+    json_t *av;
+    int i;
+    int errors = 0;
+
+    if (!(av = specutil_argv_create (argc, argv)))
+        BAIL_OUT ("specutil_argv_create failed");
+    ok (json_array_size (av) == argc,
+        "specutil_argv_create works");
+    for (i = 0; i < argc; i++) {
+        if (!entry_is_string (av, i, argv[i]))
+            errors++;
+    }
+    ok (errors == 0,
+        "specutil_argv_create set correct array values");
+
+    json_decref (av);
+}
+
+void check_attr (void)
+{
+    json_t *attr;
+    json_t *val;
+
+    if (!(attr = json_object ()))
+        BAIL_OUT ("json_object failed");
+    ok (specutil_attr_pack (attr, "foo", "s", "bar") == 0
+        && object_is_string (attr, "foo", "bar"),
+        "specutil_attr_pack foo=bar works");
+    ok (specutil_attr_pack (attr, "foo", "s", "baz") == 0
+        && object_is_string (attr, "foo", "baz"),
+        "specutil_attr_pack foo=baz works");
+    ok (specutil_attr_pack (attr, "a.b", "f", 0.1) == 0
+        && (val = json_object_get (attr, "a"))
+        && json_is_object (val),
+        "specutil_attr_pack a.b=(0.1) created object named a");
+    ok ((val = specutil_attr_get (attr, "a.b"))
+        && json_is_real (val)
+        && json_real_value (val) == 0.1,
+        "specutil_attr_get a.b returns expected value");
+    ok (specutil_attr_del (attr, "a.b") == 0,
+        "specutil_attr_del a.b works");
+    errno = 0;
+    ok (specutil_attr_get (attr, "a.b") == NULL && errno == ENOENT,
+        "specutil_attr_get a.b fails with ENOENT");
+    ok ((val = json_object_get (attr, "a"))
+        && json_is_object (val),
+        "but 'a' is still there");
+    ok (specutil_attr_del (attr, "a") == 0
+        && !json_object_get (attr, "a"),
+        "specutil_attr_del a works");
+    ok (specutil_attr_del (attr, "noexist") == 0,
+        "specutil_attr_del noexist returns success");
+    ok (specutil_attr_del (attr, "noexist.a") == 0,
+        "specutil_attr_del noexist.a returns success");
+
+
+    errno = 0;
+    ok (specutil_attr_pack (attr, ".", "s", "a") < 0 && errno == EINVAL,
+        "specutil_attr_pack path=. fails with EINVAL");
+    errno = 0;
+    ok (specutil_attr_pack (attr, ".a", "s", "a") < 0 && errno == EINVAL,
+        "specutil_attr_pack path=.a fails with EINVAL");
+    errno = 0;
+    ok (specutil_attr_pack (attr, "a.", "s", "a") < 0 && errno == EINVAL,
+        "specutil_attr_pack path=a. fails with EINVAL");
+    errno = 0;
+    ok (specutil_attr_pack (attr, "a..b", "s", "a") < 0 && errno == EINVAL,
+        "specutil_attr_pack path=a..b fails with EINVAL");
+    errno = 0;
+    ok (specutil_attr_pack (NULL, "a", "s", "a") < 0 && errno == EINVAL,
+        "specutil_attr_pack attr=NULL fails with EINVAL");
+    errno = 0;
+    ok (specutil_attr_pack (attr, NULL, "s", "a") < 0 && errno == EINVAL,
+        "specutil_attr_pack path=NULL fails with EINVAL");
+    errno = 0;
+    ok (specutil_attr_pack (attr, "a", NULL, "a") < 0 && errno == EINVAL,
+        "specutil_attr_pack fmt=a fails with EINVAL");
+
+    errno = 0;
+    ok (specutil_attr_get (NULL, "a") == NULL && errno == EINVAL,
+        "specutil_attr_get attr=NULL fails with EINVAL");
+    errno = 0;
+    ok (specutil_attr_get (attr, NULL) == NULL && errno == EINVAL,
+        "specutil_attr_get path=NULL fails with EINVAL");
+
+    errno = 0;
+    ok (specutil_attr_set (NULL, "a", json_null ()) < 0 && errno == EINVAL,
+        "specutil_attr_set attr=NULL fails with EINVAL");
+    errno = 0;
+    ok (specutil_attr_set (attr, NULL, json_null ()) < 0 && errno == EINVAL,
+        "specutil_attr_set path=NULL fails with EINVAL");
+    errno = 0;
+    ok (specutil_attr_set (attr, "a", NULL) < 0 && errno == EINVAL,
+        "specutil_attr_set value=NULL fails with EINVAL");
+
+    json_decref (attr);
+}
+
+void check_jobspec (void)
+{
+    char *argv[] = { "this", "is", "a", "test" };
+    int argc = sizeof (argv) / sizeof (argv[0]);
+    json_t *attr;
+    json_t *av;
+    json_t *spec;
+    json_t *val;
+    struct resource_param p = { 0, 0, 0, 0 };
+    char errbuf[128];
+
+    if (!(attr = json_object ()))
+        BAIL_OUT ("json_object failed");
+    if (!(av = specutil_argv_create (argc, argv)))
+        BAIL_OUT ("specutil_argv_create failed");
+
+    ok ((spec = specutil_jobspec_create (attr, av, &p,
+                                         errbuf, sizeof (errbuf))) != NULL,
+        "specutil_jobspec_create works");
+    ok (json_object_get (spec, "resources") != NULL,
+        "jobspec has resources section");
+    ok (json_object_get (spec, "tasks") != NULL,
+        "jobspec has tasks section");
+    ok (json_object_get (spec, "attributes") != NULL,
+        "jobspec has attributes section");
+    ok ((val = json_object_get (spec, "version")) != NULL
+        && json_is_integer (val)
+        && json_integer_value (val) == 1,
+        "jobspec has version 1");
+
+    json_decref (attr);
+    json_decref (av);
+    json_decref (spec);
+}
+
+void check_attr_check (void)
+{
+    json_t *attr;
+    char errbuf[128];
+
+    if (!(attr = json_object ()))
+        BAIL_OUT ("json_object failed");
+    ok (specutil_attr_check (attr, errbuf, sizeof (errbuf)) == 0,
+        "specutil_attr_check attr={} OK");
+
+    if (specutil_attr_pack (attr, "a.b", "s", "foo") < 0)
+        BAIL_OUT ("could not set a.b");
+    errno = 0;
+    *errbuf = '\0';
+    ok (specutil_attr_check (attr, errbuf, sizeof (errbuf)) < 0
+        && errno == EINVAL
+        && strlen (errbuf) > 0,
+        "specutil_attr_check failed with EINVAL, errbuf");
+    diag ("errbuf=%s", errbuf);
+    json_object_del (attr, "a");
+
+    if (specutil_attr_pack (attr, "system", "{}") < 0)
+        BAIL_OUT ("could not set system={}");
+    errno = 0;
+    *errbuf = '\0';
+    ok (specutil_attr_check (attr, errbuf, sizeof (errbuf)) < 0
+        && errno == EINVAL
+        && strlen (errbuf) > 0,
+        "specutil_attr_check attr= failed with EINVAL, errbuf");
+    diag ("errbuf=%s", errbuf);
+
+    if (specutil_attr_pack (attr, "system.duration", "f", 0.1) < 0)
+        BAIL_OUT ("could not set system.duration=0.1");
+    ok (specutil_attr_check (attr, errbuf, sizeof (errbuf)) == 0,
+        "specutil_attr_check system.duration=0.1 OK");
+
+    if (specutil_attr_pack (attr, "system.duration", "s", "x") < 0)
+        BAIL_OUT ("could not set system.duration=x");
+    errno = 0;
+    *errbuf = '\0';
+    ok (specutil_attr_check (attr, errbuf, sizeof (errbuf)) < 0
+        && errno == EINVAL
+        && strlen (errbuf) > 0,
+        "specutil_attr_check system.duration=x failed with EINVAL, errbuf");
+    diag ("errbuf=%s", errbuf);
+
+    if (specutil_attr_del (attr, "system") < 0)
+        BAIL_OUT ("could not remove system attribute dict");
+    if (specutil_attr_pack (attr, "system.environment", "{}") < 0)
+        BAIL_OUT ("could not set system.environment={}");
+    ok (specutil_attr_check (attr, errbuf, sizeof (errbuf)) == 0,
+        "specutil_attr_check system.environment={} OK");
+
+    if (specutil_attr_pack (attr, "system.environment", "s", "x") < 0)
+        BAIL_OUT ("could not set system.environment=x");
+    errno = 0;
+    *errbuf = '\0';
+    ok (specutil_attr_check (attr, errbuf, sizeof (errbuf)) < 0
+        && errno == EINVAL
+        && strlen (errbuf) > 0,
+        "specutil_attr_check system.environment=x failed with EINVAL, errbuf");
+    diag ("errbuf=%s", errbuf);
+
+    if (specutil_attr_del (attr, "system") < 0)
+        BAIL_OUT ("could not remove system attribute dict");
+    if (specutil_attr_pack (attr, "system.shell.options", "{}") < 0)
+        BAIL_OUT ("could not set system.shell.options={}");
+    ok (specutil_attr_check (attr, errbuf, sizeof (errbuf)) == 0,
+        "specutil_attr_check system.shell.options={} OK");
+
+    if (specutil_attr_pack (attr, "system.shell.options", "s", "x") < 0)
+        BAIL_OUT ("could not set system.shell.options=x");
+    errno = 0;
+    *errbuf = '\0';
+    ok (specutil_attr_check (attr, errbuf, sizeof (errbuf)) < 0
+        && errno == EINVAL
+        && strlen (errbuf) > 0,
+        "specutil_attr_check system.shell.options=x failed with EINVAL, errbuf");
+    diag ("errbuf=%s", errbuf);
+
+    json_decref (attr);
+}
+
+int main (int argc, char *argv[])
+{
+    plan (NO_PLAN);
+
+    check_env ();
+    check_argv ();
+    check_attr ();
+    check_jobspec ();
+    check_attr_check ();
+
+    done_testing ();
+    return 0;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */


### PR DESCRIPTION
This PR proposes an interface for constructing V1 jobspecs in C to satisfy some of @ardangelo 's needs for CTI support, specifically job launch (#3290). The interface provides helper functions for a subset of ``flux mini submit`` options, including:

- Setting the CWD
- Redirecting stdio to files
- Setting duration
- Setting environment variables
- Setting tasks, cores_per_task, gpus_per_task, and nodes

The other ``mini run`` options are not supported, at least not with helper functions. However, it's possible to set arbitrary attributes on the jobspec. For instance, to launch a job with a startup barrier like @ardangelo requested:

```C
json_t *trueval = json_true();
json_t *jobspec = flux_specutil_jobspecV1_from_command (...);
flux_specutil_jobspecV1_attr_set (jobspec, "attributes.system.shell.options.stop-tasks-in-exec", trueval);
```

I don't have much experience with C coding so I figured I would get the interface right before getting too bogged down in the implementation. The jobspec is represented as a json_t, because I wasn't sure whether it would be better to have a single-member flux_jobspecV1_t struct, or something like that. Most of the code I do have comes from #3567 .

Tagging @dongahn.