### PR TITLE
kvs: remove client disconnect bottleneck

### DIFF
--- a/src/modules/kvs/test/waitqueue.c
+++ b/src/modules/kvs/test/waitqueue.c
@@ -169,8 +169,16 @@ int main (int argc, char *argv[])
         "wait_create works");
     ok ((q = wait_queue_create ()) != NULL,
         "wait_queue_create works");
+    ok (wait_queue_length (q) == 0,
+        "wait_queue_length 0 on new queue");
+    ok (wait_queue_msgs_count (q) == 0,
+        "wait_queue_msgs_count 0 on new queue");
     ok (wait_addqueue (q, w) == 0,
         "wait_addqueue works");
+    ok (wait_queue_length (q) == 1,
+        "wait_queue_length 1 after addqueue");
+    ok (wait_queue_msgs_count (q) == 0,
+        "wait_queue_msgs_count 0 after addqueue w/o msg");
     ok (wait_get_usecount (w) == 1,
         "wait_get_usecount 1 after wait_addqueue");
     ok (count == 0,
@@ -191,6 +199,8 @@ int main (int argc, char *argv[])
         "wait_queue_create works");
     ok (wait_queue_length (q) == 0 && wait_queue_length (q2) == 0,
         "wait_queue_length 0 on new queue");
+    ok (wait_queue_msgs_count (q) == 0 && wait_queue_msgs_count (q2) == 0,
+        "wait_queue_msgs_count 0 on new queue");
 
     /* Create wait_t for msg
      * Add to two queues, run queues, wait_t called once
@@ -203,7 +213,6 @@ int main (int argc, char *argv[])
     ok (w != NULL,
         "wait_create_msg_handler with non-NULL msg works");
     flux_msg_destroy (msg);
-
     ok (wait_get_usecount (w) == 0,
         "wait_usecount 0 initially");
     ok (wait_addqueue (q, w) == 0,
@@ -216,11 +225,15 @@ int main (int argc, char *argv[])
         "wait_usecount 2 after adding to second queue");
     ok (wait_queue_length (q) == 1 && wait_queue_length (q2) == 1,
         "wait_queue_length of each queue is 1");
+    ok (wait_queue_msgs_count (q) == 1 && wait_queue_msgs_count (q2) == 1,
+        "wait_queue_msgs_count of each queue is 1");
 
     ok (wait_runqueue (q) == 0,
         "wait_runqueue success");
     ok (wait_queue_length (q) == 0 && wait_queue_length (q2) == 1,
         "wait_runqueue dequeued wait_t from first queue");
+    ok (wait_queue_msgs_count (q) == 0 && wait_queue_msgs_count (q2) == 1,
+        "wait_runqueue dequeued wait_t from first queue, msgs count valid");
     ok (wait_get_usecount (w) == 1,
         "wait_usecount 1 after one run");
     ok (count == 0,
@@ -230,6 +243,8 @@ int main (int argc, char *argv[])
         "wait_runqueue success");
     ok (wait_queue_length (q) == 0 && wait_queue_length (q2) == 0,
         "wait_runqueue dequeued wait_t from second queue");
+    ok (wait_queue_msgs_count (q) == 0 && wait_queue_msgs_count (q2) == 0,
+        "wait_runqueue dequeued wait_t from second queue, msgs count valid");
     ok (count == 1,
         "wait_t callback has run");
 
@@ -259,6 +274,8 @@ int main (int argc, char *argv[])
         "wait_destroy_msg found 3 matches");
     ok (wait_queue_length (q) == 17,
         "wait_queue_length 17 after 3 deletions");
+    ok (wait_queue_msgs_count (q) == 17,
+        "wait_queue_msgs_count 17 after 3 deletions");
     ok (count == 0,
         "wait_t callback has not run");
 
@@ -266,6 +283,8 @@ int main (int argc, char *argv[])
         "wait_destroy_msg found 17 matches");
     ok (wait_queue_length (q) == 0,
         "wait_queue_length 0 after 17 deletions");
+    ok (wait_queue_msgs_count (q) == 0,
+        "wait_queue_msgs_count 0 after 17 deletions");
     ok (count == 0,
         "wait_t callback has not run");
 

--- a/src/modules/kvs/waitqueue.h
+++ b/src/modules/kvs/waitqueue.h
@@ -46,6 +46,11 @@ int wait_get_usecount (wait_t *wait);
 waitqueue_t *wait_queue_create (void);
 void wait_queue_destroy (waitqueue_t *q);
 int wait_queue_length (waitqueue_t *q);
+/* Special counter indicating queue entries with msgs created with
+ * wait_create_msg_handler().  Useful if user wishes to avoid excess
+ * iteration calls on wait_destroy_msg().
+ */
+int wait_queue_msgs_count (waitqueue_t *q);
 
 /* Add a wait_t to a queue.
  * Returns -1 on error, 0 on success


### PR DESCRIPTION
Per discussion in #3615, there is a small bottleneck in the KVS's disconnect path.  Using @grondo's throughput benchmark.

`>perf record -g --call-graph=dwarf -F 1000 src/cmd/flux start ./throughput_issue3615.sh 1024 1`

```
      - 9.16% flux_reactor_run
         - ev_run
            - 8.85% ev_invoke_pending
               - 5.57% handle_cb
                  - 4.40% dispatch_message (inlined)
                     - 4.38% call_handler
                        - 3.13% disconnect_request_cb
                           - 3.11% cache_wait_destroy_msg
                              - 2.08% wait_destroy_msg
                                   1.71% fzlist_first
                                0.63% fzhashx_next
```

At ~3% of samplings, `disconnect_request_cb()`'s impact is not huge but not nothing.  It regularly showed up amongst many profiling benchmarks.  Here is the core of `cache_wait_destroy_msg()`.

```
    FOREACH_ZHASHX (cache->zhx, key, entry) {
        if (entry->waitlist_valid) {
            if ((n = wait_destroy_msg (entry->waitlist_valid, cb, arg)) < 0)
                goto done;
            count += n;
        }
        if (entry->waitlist_notdirty) {
            if ((n = wait_destroy_msg (entry->waitlist_notdirty, cb, arg)) < 0)
                goto done;
            count += n;
        }
    }
```

It can be slow for two reasons.

1) it does a `FOREACH_ZHASHX` iterating through all hash buckets.  As some prior investigations showed (such as #3591), the number of hash buckets may be significantly more than the number of entries in the hash/cache.

2) not every `waitlist` being passed to `wait_destroy_msg()` has entries.  Thus the high percentage of samplings to `zlist_first()` as it grabs the first entry in the list to only see it's NULL afterwards.

This PR puts all waitlists that are non-empty onto a list.  We then iterate over just the cache entries that have waitlist messages we need to examine.

After doing this change, the profiling:

```
   - mod_main
      - 7.80% flux_reactor_run
         - ev_run
            - 7.34% ev_invoke_pending
               - 2.81% handle_cb
                  - 1.50% dispatch_message (inlined)
                     - 1.46% call_handler
                          0.50% lookup_plus_request_cb
```

Less time in the KVS module and no more hits in `disconnect_request_cb()`.

Since this was only hitting ~3 percent of profiling before, it could be hard to know if there's an obvious performance gain and if the annoyance of maintaining these lists is worth it.

Running the throughput benchmark ten times.

Before

```
Running throughput.py 1024 jobs per iteration, 10 iterations
throughput:     31.6 job/s (script:  31.2 job/s)
throughput:     30.1 job/s (script:  29.8 job/s)
throughput:     29.2 job/s (script:  29.0 job/s)
throughput:     28.9 job/s (script:  28.6 job/s)
throughput:     28.4 job/s (script:  28.2 job/s)
throughput:     29.0 job/s (script:  28.7 job/s)
throughput:     29.3 job/s (script:  29.0 job/s)
throughput:     28.1 job/s (script:  27.8 job/s)
throughput:     27.8 job/s (script:  27.6 job/s)
throughput:     29.1 job/s (script:  28.8 job/s)
```

After

```
Running throughput.py 1024 jobs per iteration, 10 iterations
throughput:     34.4 job/s (script:  34.0 job/s)
throughput:     32.3 job/s (script:  32.0 job/s)
throughput:     32.5 job/s (script:  32.2 job/s)
throughput:     31.9 job/s (script:  31.5 job/s)
throughput:     31.7 job/s (script:  31.4 job/s)
throughput:     31.8 job/s (script:  31.5 job/s)
throughput:     30.8 job/s (script:  30.5 job/s)
throughput:     30.8 job/s (script:  30.5 job/s)
throughput:     31.7 job/s (script:  31.4 job/s)
throughput:     31.1 job/s (script:  30.8 job/s)
```

There does seem to be a slight win here.

Using nsbench benchmark

Before

```
  0.22s: Benchmark on 256 namespaces complete: 1161.8 namespace/s
  0.46s: Benchmark on 512 namespaces complete: 1123.0 namespace/s
  0.90s: Benchmark on 1024 namespaces complete: 1136.6 namespace/s
  1.75s: Benchmark on 2048 namespaces complete: 1168.7 namespace/s
  3.38s: Benchmark on 4096 namespaces complete: 1212.6 namespace/s
  7.04s: Benchmark on 8192 namespaces complete: 1164.0 namespace/s
 13.79s: Benchmark on 16384 namespaces complete: 1188.0 namespace/s
 28.28s: Benchmark on 32768 namespaces complete: 1158.6 namespace/s
 55.84s: Benchmark on 65536 namespaces complete: 1173.6 namespace/s
109.77s: Benchmark on 131072 namespaces complete: 1194.0 namespace/s
221.78s: Benchmark on 262144 namespaces complete: 1182.0 namespace/s
```

After

```
  0.21s: Benchmark on 256 namespaces complete: 1212.4 namespace/s
  0.43s: Benchmark on 512 namespaces complete: 1191.2 namespace/s
  0.90s: Benchmark on 1024 namespaces complete: 1143.8 namespace/s
  1.80s: Benchmark on 2048 namespaces complete: 1135.9 namespace/s
  3.47s: Benchmark on 4096 namespaces complete: 1179.5 namespace/s
  6.87s: Benchmark on 8192 namespaces complete: 1192.7 namespace/s
 13.44s: Benchmark on 16384 namespaces complete: 1219.4 namespace/s
 28.62s: Benchmark on 32768 namespaces complete: 1145.0 namespace/s
 54.44s: Benchmark on 65536 namespaces complete: 1203.8 namespace/s
105.44s: Benchmark on 131072 namespaces complete: 1243.1 namespace/s
221.08s: Benchmark on 262144 namespaces complete: 1185.8 namespace/s
```

No discernible win here.

But overall, I think a plus given positive results from the throughput test.
