### PR TITLE
flux-start: rename --scratchdir to --rundir

### DIFF
--- a/doc/man1/flux-content.rst
+++ b/doc/man1/flux-content.rst
@@ -60,8 +60,7 @@ service, and is loaded by default.
 Content database files are stored persistently on rank 0 if the
 persist-directory broker attribute is set to a directory name for
 the session. Otherwise they are stored in the directory defined
-by the scratch-directory attribute and are cleaned up when the
-instance terminates.
+by the rundir attribute and are cleaned up when the instance terminates.
 
 When one of these modules is loaded, it informs the rank 0
 cache of its availability, which triggers the cache to begin

--- a/doc/man1/flux-start.rst
+++ b/doc/man1/flux-start.rst
@@ -45,7 +45,7 @@ OPTIONS
    built with --enable-caliper. Unless CALI_LOG_VERBOSITY is already
    set in the environment, it will default to 0 for all brokers.
 
-**--scratchdir**\ =\ *DIR*
+**--rundir**\ =\ *DIR*
    (only with *--test-size*) Set the directory that will be
    used as the rundir directory for the instance. If the directory
    does not exist then it will be created during instance startup.

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -377,7 +377,6 @@ UTC
 addrole
 delrole
 strtoul
-scratchdir
 EHOSTUNREACH
 ap
 MSGID

--- a/src/cmd/flux-start.c
+++ b/src/cmd/flux-start.c
@@ -470,17 +470,13 @@ struct client *client_create (const char *broker_path,
 
     if (flux_cmd_add_channel (cli->cmd, "PMI_FD") < 0)
         log_err_exit ("flux_cmd_add_channel");
-    if (flux_cmd_setenvf (cli->cmd, 1, "PMI_RANK", "%d", rank) < 0)
-        log_err_exit ("flux_cmd_setenvf");
-    if (flux_cmd_setenvf (cli->cmd, 1, "PMI_SIZE", "%d", ctx.test_size) < 0)
-        log_err_exit ("flux_cmd_setenvf");
-    if (flux_cmd_setenvf (cli->cmd, 1, "FLUX_START_URI",
-                          "local://%s/start", rundir) < 0)
-        log_err_exit ("flux_cmd_setenvf");
-    if (hostname) {
-        if (flux_cmd_setenvf (cli->cmd, 1, "FLUX_FAKE_HOSTNAME", "%s", hostname) < 0)
-            log_err_exit ("error setting fake hostname for rank %d", rank);
-    }
+    if (flux_cmd_setenvf (cli->cmd, 1, "PMI_RANK", "%d", rank) < 0
+        || flux_cmd_setenvf (cli->cmd, 1, "PMI_SIZE", "%d", ctx.test_size) < 0
+        || flux_cmd_setenvf (cli->cmd, 1, "FLUX_START_URI",
+                             "local://%s/start", rundir) < 0
+        || (hostname && flux_cmd_setenvf (cli->cmd, 1, "FLUX_FAKE_HOSTNAME",
+                                          "%s", hostname) < 0))
+            log_err_exit ("error setting up environment for rank %d", rank);
     return cli;
 fail:
     free (argz);

--- a/src/cmd/flux-start.c
+++ b/src/cmd/flux-start.c
@@ -441,7 +441,7 @@ struct client *client_create (const char *broker_path,
                               int rank,
                               const char *cmd_argz,
                               size_t cmd_argz_len,
-                              const char *h)
+                              const char *hostname)
 {
     struct client *cli = xzmalloc (sizeof (*cli));
     char *arg;
@@ -477,8 +477,8 @@ struct client *client_create (const char *broker_path,
     if (flux_cmd_setenvf (cli->cmd, 1, "FLUX_START_URI",
                           "local://%s/start", rundir) < 0)
         log_err_exit ("flux_cmd_setenvf");
-    if (h) {
-        if (flux_cmd_setenvf (cli->cmd, 1, "FLUX_FAKE_HOSTNAME", "%s", h) < 0)
+    if (hostname) {
+        if (flux_cmd_setenvf (cli->cmd, 1, "FLUX_FAKE_HOSTNAME", "%s", hostname) < 0)
             log_err_exit ("error setting fake hostname for rank %d", rank);
     }
     return cli;

--- a/src/cmd/flux-start.c
+++ b/src/cmd/flux-start.c
@@ -70,7 +70,7 @@ int start_session (const char *cmd_argz, size_t cmd_argz_len,
                    const char *broker_path);
 int exec_broker (const char *cmd_argz, size_t cmd_argz_len,
                  const char *broker_path);
-char *create_scratch_dir (void);
+char *create_rundir (void);
 void client_destroy (struct client *cli);
 char *find_broker (const char *searchpath);
 static void setup_profiling_env (void);
@@ -100,8 +100,8 @@ static struct optparse_option opts[] = {
       .usage = "After a broker exits, kill other brokers after DURATION", },
     { .name = "trace-pmi-server", .has_arg = 0, .arginfo = NULL,
       .usage = "Trace pmi simple server protocol exchange", },
-    { .name = "scratchdir", .key = 'D', .has_arg = 1, .arginfo = "DIR",
-      .usage = "Use DIR as scratch directory", },
+    { .name = "rundir", .key = 'D', .has_arg = 1, .arginfo = "DIR",
+      .usage = "Use DIR as broker run directory", },
     { .name = "noclique", .key = 'c', .has_arg = 0, .arginfo = NULL,
       .usage = "Don't set PMI_process_mapping in PMI KVS", },
 
@@ -177,8 +177,8 @@ int main (int argc, char *argv[])
     setup_profiling_env ();
 
     if (!optparse_hasopt (ctx.opts, "test-size")) {
-        if (optparse_hasopt (ctx.opts, "scratchdir"))
-            log_msg_exit ("--scratchdir only works with --test-size=N");
+        if (optparse_hasopt (ctx.opts, "rundir"))
+            log_msg_exit ("--rundir only works with --test-size=N");
         if (optparse_hasopt (ctx.opts, "noclique"))
             log_msg_exit ("--noclique only works with --test-size=N");
         if (optparse_hasopt (ctx.opts, "test-hosts"))
@@ -341,15 +341,15 @@ void add_args_list (char **argz, size_t *argz_len, optparse_t *opt, const char *
             log_err_exit ("argz_add");
 }
 
-char *create_scratch_dir (void)
+char *create_rundir (void)
 {
     char *tmpdir = getenv ("TMPDIR");
-    char *scratchdir = xasprintf ("%s/flux-XXXXXX", tmpdir ? tmpdir : "/tmp");
+    char *rundir = xasprintf ("%s/flux-XXXXXX", tmpdir ? tmpdir : "/tmp");
 
-    if (!mkdtemp (scratchdir))
-        log_err_exit ("mkdtemp %s", scratchdir);
-    cleanup_push_string (cleanup_directory_recursive, scratchdir);
-    return scratchdir;
+    if (!mkdtemp (rundir))
+        log_err_exit ("mkdtemp %s", rundir);
+    cleanup_push_string (cleanup_directory_recursive, rundir);
+    return rundir;
 }
 
 static int pmi_response_send (void *client, const char *buf)
@@ -437,7 +437,7 @@ error:
 }
 
 struct client *client_create (const char *broker_path,
-                              const char *scratch_dir,
+                              const char *rundir,
                               int rank,
                               const char *cmd_argz,
                               size_t cmd_argz_len,
@@ -451,7 +451,7 @@ struct client *client_create (const char *broker_path,
     cli->rank = rank;
     add_args_list (&argz, &argz_len, ctx.opts, "wrap");
     argz_add (&argz, &argz_len, broker_path);
-    char *dir_arg = xasprintf ("--setattr=rundir=%s", scratch_dir);
+    char *dir_arg = xasprintf ("--setattr=rundir=%s", rundir);
     argz_add (&argz, &argz_len, dir_arg);
     free (dir_arg);
     add_args_list (&argz, &argz_len, ctx.opts, "broker-opts");
@@ -475,7 +475,7 @@ struct client *client_create (const char *broker_path,
     if (flux_cmd_setenvf (cli->cmd, 1, "PMI_SIZE", "%d", ctx.test_size) < 0)
         log_err_exit ("flux_cmd_setenvf");
     if (flux_cmd_setenvf (cli->cmd, 1, "FLUX_START_URI",
-                          "local://%s/start", scratch_dir) < 0)
+                          "local://%s/start", rundir) < 0)
         log_err_exit ("flux_cmd_setenvf");
     if (h) {
         if (flux_cmd_setenvf (cli->cmd, 1, "FLUX_FAKE_HOSTNAME", "%s", h) < 0)
@@ -678,7 +678,7 @@ int start_session (const char *cmd_argz, size_t cmd_argz_len,
     struct client *cli;
     int rank;
     int flags = 0;
-    char *scratch_dir;
+    char *rundir;
     struct hostlist *hosts = NULL;
 
     if (isatty (STDIN_FILENO)) {
@@ -698,13 +698,12 @@ int start_session (const char *cmd_argz, size_t cmd_argz_len,
     if (!(ctx.clients = zlist_new ()))
         log_err_exit ("zlist_new");
 
-    if (optparse_hasopt (ctx.opts, "scratchdir"))
-        scratch_dir = xstrdup (optparse_get_str (ctx.opts, "scratchdir", NULL));
+    if (optparse_hasopt (ctx.opts, "rundir"))
+        rundir = xstrdup (optparse_get_str (ctx.opts, "rundir", NULL));
     else
-        scratch_dir = create_scratch_dir ();
+        rundir = create_rundir ();
 
-    start_server_initialize (scratch_dir,
-                             optparse_hasopt (ctx.opts, "verbose"));
+    start_server_initialize (rundir, optparse_hasopt (ctx.opts, "verbose"));
 
     if (optparse_hasopt (ctx.opts, "trace-pmi-server"))
         flags |= PMI_SIMPLE_SERVER_TRACE;
@@ -721,7 +720,7 @@ int start_session (const char *cmd_argz, size_t cmd_argz_len,
 
     for (rank = 0; rank < ctx.test_size; rank++) {
         if (!(cli = client_create (broker_path,
-                                   scratch_dir,
+                                   rundir,
                                    rank,
                                    cmd_argz,
                                    cmd_argz_len,
@@ -746,7 +745,7 @@ int start_session (const char *cmd_argz, size_t cmd_argz_len,
     start_server_finalize ();
 
     hostlist_destroy (hosts);
-    free (scratch_dir);
+    free (rundir);
 
     zlist_destroy (&ctx.clients);
     flux_watcher_destroy (ctx.timer);

--- a/t/python/sideflux.py
+++ b/t/python/sideflux.py
@@ -67,7 +67,7 @@ class SideFlux(object):
             "--test-size={}".format(self.size),
             "-o",
             "-Slog-forward-level=7",
-            "--scratchdir=" + self.tmpdir,
+            "--rundir=" + self.tmpdir,
             "bash",
         ]
         # print ' '.join(flux_command)

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -87,8 +87,8 @@ test_expect_success 'flux-start with size 2 has rank 1 peer' '
 test_expect_success 'flux-start -s1 works' "
 	flux start ${ARGS} -s1 /bin/true
 "
-test_expect_success 'flux-start --scratchdir without --test-size fails' "
-	test_must_fail flux start ${ARGS} --scratchdir=$(pwd) /bin/true
+test_expect_success 'flux-start --rundir without --test-size fails' "
+	test_must_fail flux start ${ARGS} --rundir=$(pwd) /bin/true
 "
 test_expect_success 'flux-start --noclique without --test-size fails' "
 	test_must_fail flux start ${ARGS} --noclique /bin/true


### PR DESCRIPTION
This was peeled off of #3661.

The main user-visible change is to rename the `--scratchdir` option to `--rundir` to more accurately reflect its purpose, which is to set the broker rundir.  Then there's a bit of cleanup.

I dropped the `flux-start` changes in #3661 but didn't want to lose this cleanup.