### PR TITLE
openmpi: ensure that shmem segments for co-located jobs don't conflict

### DIFF
--- a/src/shell/lua.d/openmpi.lua
+++ b/src/shell/lua.d/openmpi.lua
@@ -10,3 +10,27 @@
 
 shell.setenv ("OMPI_MCA_pmix", "flux")
 shell.setenv ("OMPI_MCA_schizo", "flux")
+
+-- OpenMPI needs a job-unique directory for vader shmem paths, otherwise
+-- multiple jobs per node may conflict (see flux-framework/flux-core#3649).
+
+-- Note: this plugin changes the path for files that openmpi usually shares
+-- using mmap (MAP_SHARED) from /dev/shm (tmpfs) to /tmp (maybe tmpfs).
+-- Performance may be affected if /tmp is provided by a disk-backed file system.
+
+plugin.register {
+    name = "openmpi",
+    handlers = {
+        {
+            topic = "shell.init",
+            fn = function ()
+                local tmpdir = shell.getenv ("FLUX_JOB_TMPDIR")
+                if tmpdir then
+                    shell.setenv ("OMPI_MCA_btl_vader_backing_directory", tmpdir)
+                end
+            end
+        }
+    }
+}
+
+-- vi:ts=4 sw=4 expandtab

--- a/t/t3000-mpi-basic.t
+++ b/t/t3000-mpi-basic.t
@@ -16,9 +16,9 @@ if ! test -x ${HELLO}; then
     test_done
 fi
 
-# rc1-job ensures there are 2 cores per node
+export TEST_UNDER_FLUX_CORES_PER_RANK=4
 SIZE=2
-MAX_MPI_SIZE=$(($SIZE*2))
+MAX_MPI_SIZE=$(($SIZE*$TEST_UNDER_FLUX_CORES_PER_RANK))
 test_under_flux $SIZE job
 
 hello_world() {
@@ -30,5 +30,10 @@ hello_world() {
 for size in $(seq 1 ${MAX_MPI_SIZE}); do
 	test_expect_success "mpi hello size=${size}" "hello_world ${size}"
 done
+
+# issue 3649 - try to get two size=2 jobs running concurrently on one broker
+test_expect_success 'mpi hello size=2 concurrent submit of 8 jobs' '
+	run_timeout 30 flux mini submit --cc=1-8 --watch -n2 ${HELLO}
+'
 
 test_done


### PR DESCRIPTION
Problem: shared memory segment naming for the "vader" BTL may collide
when running multiple jobs per node.

This is because the path is constructed from
  /dev/shm/vader_segment.hostname.uid.jobid.rank

and the flux pmix plugin in openmpi always sets the jobid to 0
because FLUX_JOB_ID in f58 format is converted to a 32-bit integer
using strtol().  This is a bug in the plugin, but a proper fix may
be elusive given the integer size mismatch of IDs.

Work around the plugin bug by changing
  OMPI_MCA_btl_vader_backing_directory
from default of /dev/shm to $FLUX_JOB_TMPDIR, which the shell tmpdir
plugin will have set to a job-unique directory.

Fixes #3649

This is based on top of #3661 (FLUX_JOB_TMPDIR), which should be merged first.