### PR TITLE
libflux: flux_modfind: ignore DSOs with no mod_name symbol

### DIFF
--- a/src/common/libflux/module.c
+++ b/src/common/libflux/module.c
@@ -49,14 +49,7 @@ char *flux_modname (const char *path, flux_moderr_f *cb, void *arg)
         return NULL;
     }
     dlerror ();
-    if (!(np = dlsym (dso, "mod_name"))) {
-        char *errmsg;
-        if (cb && (errmsg = dlerror ()))
-            cb (errmsg, arg);
-        errno = EINVAL;
-        goto error;
-    }
-    if (!*np) {
+    if (!(np = dlsym (dso, "mod_name")) || !*np) {
         errno = EINVAL;
         goto error;
     }

--- a/src/common/libflux/test/module.c
+++ b/src/common/libflux/test/module.c
@@ -47,8 +47,8 @@ void test_modname (void)
     errno = 0;
     errmsg_count = 0;
     name = flux_modname (FAKE2, errmsg_cb, NULL);
-    ok (name == NULL && errno == EINVAL && errmsg_count == 1,
-        "flux_modname path=module_fake2 fails with EINVAL and extended error");
+    ok (name == NULL && errno == EINVAL,
+        "flux_modname path=module_fake2 fails with EINVAL");
 
     errmsg_count = 0;
     name = flux_modname (FAKE2, NULL, NULL);
@@ -136,8 +136,8 @@ void test_modfind (void)
     errno = 0;
     errmsg_count = 0;
     path = flux_modfind (searchpath, "fake2", errmsg_cb, NULL);
-    ok (path == NULL && errno == ENOENT && errmsg_count == 1,
-        "flux_modfind modname=fake2 fails with ENOENT and extended error");
+    ok (path == NULL && errno == ENOENT,
+        "flux_modfind modname=fake2 fails with ENOENT");
 
     errno = 0;
     path = flux_modfind (searchpath, NULL, NULL, NULL);


### PR DESCRIPTION
Problem: flux_modname(3) returns a dlerror() based error message
in any provided error callback when dlsym ("mod_name") fails, but
this extra error is probably unecessary in most, if not all,
situations. It also generates a lot of noise when flux_modfind(3)
recurses through directories with a lot of non-module .so files.

Simplify flux_modname(3) to return EINVAL when a "mod_name" symbol
is not found in the DSO. This will quiet unnecessary errors from
flux_modfind() and `flux module load` etc, effectively ignoring
DSOs without a `mod_name` symbol.