### PR TITLE
testsuite: improve in-tree MPI testing

### DIFF
--- a/src/common/libpmi/simple_client.c
+++ b/src/common/libpmi/simple_client.c
@@ -367,7 +367,7 @@ int pmi_simple_client_abort (struct pmi_simple_client *pmi,
     if (exit_code < 0)
         return PMI_ERR_INVALID_ARG;
     if (dprintf (pmi->fd,
-                 "cmd=abort exit_code=%d%s%s\n",
+                 "cmd=abort exitcode=%d%s%s\n",
                  exit_code,
                  msg ? " error_msg=" : "",
                  msg ? msg : "") < 0)

--- a/src/shell/pmi/pmi.c
+++ b/src/shell/pmi/pmi.c
@@ -355,7 +355,8 @@ static void pmi_fd_cb (flux_shell_task_t *task,
     rc = pmi_simple_server_request (pmi->server, line, task, task->rank);
     if (rc < 0) {
         shell_trace ("%d: S: pmi request error", task->rank);
-        return;
+        shell_die (1, "PMI-1 wire protocol error");
+
     }
     if (rc == 1) {
         shell_trace ("%d: S: pmi finalized", task->rank);

--- a/src/test/docker/focal/Dockerfile
+++ b/src/test/docker/focal/Dockerfile
@@ -35,7 +35,6 @@ RUN apt-get update \
         ccache \
         lua5.2 \
         lua-posix \
-        mpich \
         valgrind \
         jq \
  && rm -rf /var/lib/apt/lists/*
@@ -86,7 +85,7 @@ RUN apt-get update \
         libsqlite3-dev \
         uuid-dev \
         libhwloc-dev \
-        libmpich-dev \
+        libopenmpi-dev \
         libs3-dev \
  && rm -rf /var/lib/apt/lists/*
 

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -318,7 +318,14 @@ check_PROGRAMS = \
 
 if HAVE_MPI
 check_PROGRAMS += \
-	mpi/hello
+	mpi/hello \
+	mpi/mpich_basic/self \
+	mpi/mpich_basic/simple \
+	mpi/mpich_basic/sendrecv \
+	mpi/mpich_basic/srtest \
+	mpi/mpich_basic/netpipe \
+	mpi/mpich_basic/patterns \
+	mpi/mpich_basic/adapt
 endif
 
 check_LTLIBRARIES = \
@@ -392,6 +399,34 @@ loop_issue2711_LDADD = \
 mpi_hello_SOURCES = mpi/hello.c
 mpi_hello_CPPFLAGS = $(MPI_CFLAGS) $(test_cppflags)
 mpi_hello_LDADD = $(MPI_CLDFLAGS) $(test_ldadd)
+
+mpi_mpich_basic_adapt_SOURCES = mpi/mpich_basic/adapt.c mpi/mpich_basic/GetOpt.c mpi/mpich_basic/GetOpt.h
+mpi_mpich_basic_adapt_CPPFLAGS = $(MPI_CFLAGS) $(test_cppflags)
+mpi_mpich_basic_adapt_LDADD = $(MPI_CLDFLAGS) $(test_ldadd)
+
+mpi_mpich_basic_netpipe_SOURCES = mpi/mpich_basic/netmpi.c mpi/mpich_basic/GetOpt.c mpi/mpich_basic/GetOpt.h
+mpi_mpich_basic_netpipe_CPPFLAGS = $(MPI_CFLAGS) $(test_cppflags)
+mpi_mpich_basic_netpipe_LDADD = $(MPI_CLDFLAGS) $(test_ldadd)
+
+mpi_mpich_basic_patterns_SOURCES = mpi/mpich_basic/patterns.c
+mpi_mpich_basic_patterns_CPPFLAGS = $(MPI_CFLAGS) $(test_cppflags)
+mpi_mpich_basic_patterns_LDADD = $(MPI_CLDFLAGS) $(test_ldadd)
+
+mpi_mpich_basic_srtest_SOURCES = mpi/mpich_basic/srtest.c
+mpi_mpich_basic_srtest_CPPFLAGS = $(MPI_CFLAGS) $(test_cppflags)
+mpi_mpich_basic_srtest_LDADD = $(MPI_CLDFLAGS) $(test_ldadd)
+
+mpi_mpich_basic_self_SOURCES = mpi/mpich_basic/self.c
+mpi_mpich_basic_self_CPPFLAGS = $(MPI_CFLAGS) $(test_cppflags)
+mpi_mpich_basic_self_LDADD = $(MPI_CLDFLAGS) $(test_ldadd)
+
+mpi_mpich_basic_sendrecv_SOURCES = mpi/mpich_basic/sendrecv.c
+mpi_mpich_basic_sendrecv_CPPFLAGS = $(MPI_CFLAGS) $(test_cppflags)
+mpi_mpich_basic_sendrecv_LDADD = $(MPI_CLDFLAGS) $(test_ldadd)
+
+mpi_mpich_basic_simple_SOURCES = mpi/mpich_basic/simple.c
+mpi_mpich_basic_simple_CPPFLAGS = $(MPI_CFLAGS) $(test_cppflags)
+mpi_mpich_basic_simple_LDADD = $(MPI_CLDFLAGS) $(test_ldadd)
 
 kvs_torture_SOURCES = kvs/torture.c
 kvs_torture_CPPFLAGS = $(test_cppflags)

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -390,8 +390,8 @@ loop_issue2711_LDADD = \
 	$(test_ldadd) $(LIBDL)
 
 mpi_hello_SOURCES = mpi/hello.c
-mpi_hello_CPPFLAGS = $(MPI_CFLAGS)
-mpi_hello_LDADD = $(MPI_CLDFLAGS) $(LIBRT)
+mpi_hello_CPPFLAGS = $(MPI_CFLAGS) $(test_cppflags)
+mpi_hello_LDADD = $(MPI_CLDFLAGS) $(test_ldadd)
 
 kvs_torture_SOURCES = kvs/torture.c
 kvs_torture_CPPFLAGS = $(test_cppflags)

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -168,6 +168,7 @@ TESTSCRIPTS = \
 	t3000-mpi-basic.t \
 	t3001-mpi-personalities.t \
 	t3002-pmi.t \
+	t3003-mpi-abort.t \
 	t4000-issues-test-driver.t \
 	lua/t0001-send-recv.t \
 	lua/t0002-rpc.t \
@@ -319,6 +320,8 @@ check_PROGRAMS = \
 if HAVE_MPI
 check_PROGRAMS += \
 	mpi/hello \
+	mpi/abort \
+	mpi/version \
 	mpi/mpich_basic/self \
 	mpi/mpich_basic/simple \
 	mpi/mpich_basic/sendrecv \
@@ -399,6 +402,14 @@ loop_issue2711_LDADD = \
 mpi_hello_SOURCES = mpi/hello.c
 mpi_hello_CPPFLAGS = $(MPI_CFLAGS) $(test_cppflags)
 mpi_hello_LDADD = $(MPI_CLDFLAGS) $(test_ldadd)
+
+mpi_abort_SOURCES = mpi/abort.c
+mpi_abort_CPPFLAGS = $(MPI_CFLAGS) $(test_cppflags)
+mpi_abort_LDADD = $(MPI_CLDFLAGS) $(test_ldadd)
+
+mpi_version_SOURCES = mpi/version.c
+mpi_version_CPPFLAGS = $(MPI_CFLAGS) $(test_cppflags)
+mpi_version_LDADD = $(MPI_CLDFLAGS) $(test_ldadd)
 
 mpi_mpich_basic_adapt_SOURCES = mpi/mpich_basic/adapt.c mpi/mpich_basic/GetOpt.c mpi/mpich_basic/GetOpt.h
 mpi_mpich_basic_adapt_CPPFLAGS = $(MPI_CFLAGS) $(test_cppflags)

--- a/t/mpi/abort.c
+++ b/t/mpi/abort.c
@@ -1,0 +1,39 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdlib.h>
+#include <mpi.h>
+
+int main (int argc, char *argv[])
+{
+    int id, ntasks;
+    int abort_rank = -1;
+
+    if (argc == 2)
+        abort_rank = strtol (argv[1], NULL, 10);
+
+    MPI_Init (&argc, &argv);
+    MPI_Comm_rank (MPI_COMM_WORLD, &id);
+    MPI_Comm_size (MPI_COMM_WORLD, &ntasks);
+
+    if (id == abort_rank)
+        MPI_Abort (MPI_COMM_WORLD, 42);
+    MPI_Barrier (MPI_COMM_WORLD);
+
+    MPI_Finalize ();
+
+    return 0;
+}
+
+// vi: ts=4 sw=4 expandtab
+

--- a/t/mpi/hello.c
+++ b/t/mpi/hello.c
@@ -23,13 +23,19 @@ int main (int argc, char *argv[])
 {
     int id, ntasks;
     struct timespec t;
+    const char *label;
+
+    if (!(label = getenv ("FLUX_JOB_CC")))
+        if (!(label = getenv ("FLUX_JOB_ID")))
+            label = "0";
 
     monotime (&t);
     MPI_Init (&argc, &argv);
     MPI_Comm_rank (MPI_COMM_WORLD, &id);
     MPI_Comm_size (MPI_COMM_WORLD, &ntasks);
     if (id == 0) {
-        printf ("0: completed MPI_Init in %0.3fs.  There are %d tasks\n",
+        printf ("%s: completed MPI_Init in %0.3fs.  There are %d tasks\n",
+                label,
                 monotime_since (t) / 1000, ntasks);
         fflush (stdout);
     }
@@ -37,7 +43,8 @@ int main (int argc, char *argv[])
     monotime (&t);
     MPI_Barrier (MPI_COMM_WORLD);
     if (id == 0) {
-        printf ("0: completed first barrier in %0.3fs\n",
+        printf ("%s: completed first barrier in %0.3fs\n",
+                label,
                 monotime_since (t) / 1000);
         fflush (stdout);
     }
@@ -45,7 +52,8 @@ int main (int argc, char *argv[])
     monotime (&t);
     MPI_Finalize ();
     if (id == 0) {
-        printf ("0: completed MPI_Finalize in %0.3fs\n",
+        printf ("%s: completed MPI_Finalize in %0.3fs\n",
+                label,
                 monotime_since (t) / 1000);
         fflush (stdout);
     }

--- a/t/mpi/hello.c
+++ b/t/mpi/hello.c
@@ -8,65 +8,45 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
 #include <mpi.h>
 #include <stdio.h>
 #include <unistd.h>
 #include <stdlib.h>
 #include <time.h>
 
-static struct timespec diff (struct timespec start, struct timespec end)
-{
-    struct timespec temp;
-    if ((end.tv_nsec-start.tv_nsec)<0) {
-        temp.tv_sec = end.tv_sec-start.tv_sec-1;
-        temp.tv_nsec = 1000000000+end.tv_nsec-start.tv_nsec;
-    } else {
-        temp.tv_sec = end.tv_sec-start.tv_sec;
-        temp.tv_nsec = end.tv_nsec-start.tv_nsec;
-    }
-    return temp;
-}
-
-static double time_since (struct timespec t0)
-{
-    struct timespec ts, d;
-    clock_gettime (CLOCK_MONOTONIC, &ts);
-
-    d = diff (t0, ts);
-
-    return ((double) d.tv_sec * 1000 + (double) d.tv_nsec / 1000000);
-}
+#include "src/common/libutil/monotime.h"
 
 int main (int argc, char *argv[])
 {
     int id, ntasks;
     struct timespec t;
 
-    clock_gettime (CLOCK_MONOTONIC, &t);
+    monotime (&t);
     MPI_Init (&argc, &argv);
     MPI_Comm_rank (MPI_COMM_WORLD, &id);
     MPI_Comm_size (MPI_COMM_WORLD, &ntasks);
-
     if (id == 0) {
         printf ("0: completed MPI_Init in %0.3fs.  There are %d tasks\n",
-                time_since (t)/1000, ntasks);
+                monotime_since (t) / 1000, ntasks);
         fflush (stdout);
     }
-	if (id == 0)
-		clock_gettime (CLOCK_MONOTONIC, &t);
+
+    monotime (&t);
     MPI_Barrier (MPI_COMM_WORLD);
     if (id == 0) {
         printf ("0: completed first barrier in %0.3fs\n",
-                time_since (t) / 1000);
+                monotime_since (t) / 1000);
         fflush (stdout);
     }
 
-    if (id == 0)
-        clock_gettime (CLOCK_MONOTONIC, &t);
+    monotime (&t);
     MPI_Finalize ();
     if (id == 0) {
         printf ("0: completed MPI_Finalize in %0.3fs\n",
-                time_since (t) / 1000);
+                monotime_since (t) / 1000);
         fflush (stdout);
     }
     return 0;

--- a/t/mpi/hello.c
+++ b/t/mpi/hello.c
@@ -40,35 +40,38 @@ static double time_since (struct timespec t0)
 int
 main(int argc, char *argv[])
 {
-        int id, ntasks;
-	struct timespec t;
+    int id, ntasks;
+    struct timespec t;
 
-	clock_gettime (CLOCK_MONOTONIC, &t);
-        MPI_Init(&argc, &argv);
-        MPI_Comm_rank(MPI_COMM_WORLD, &id);
-        MPI_Comm_size(MPI_COMM_WORLD, &ntasks);
-        if (id == 0) {
-                printf("0: completed MPI_Init in %0.3fs.  There are %d tasks\n",
-		   time_since (t)/1000, ntasks);
-                fflush(stdout);
-        }
+    clock_gettime (CLOCK_MONOTONIC, &t);
+    MPI_Init(&argc, &argv);
+    MPI_Comm_rank(MPI_COMM_WORLD, &id);
+    MPI_Comm_size(MPI_COMM_WORLD, &ntasks);
 
+    if (id == 0) {
+        printf("0: completed MPI_Init in %0.3fs.  There are %d tasks\n",
+               time_since (t)/1000, ntasks);
+        fflush(stdout);
+    }
 	if (id == 0)
 		clock_gettime (CLOCK_MONOTONIC, &t);
-        MPI_Barrier(MPI_COMM_WORLD);
-        if (id == 0) {
-                printf("0: completed first barrier in %0.3fs\n",
-				time_since (t) / 1000);
-                fflush(stdout);
-        }
+    MPI_Barrier(MPI_COMM_WORLD);
+    if (id == 0) {
+        printf("0: completed first barrier in %0.3fs\n",
+               time_since (t) / 1000);
+        fflush(stdout);
+    }
 
-	if (id == 0)
-		clock_gettime (CLOCK_MONOTONIC, &t);
-        MPI_Finalize();
-        if (id == 0) {
-                printf("0: completed MPI_Finalize in %0.3fs\n",
-				time_since (t) / 1000);
-                fflush(stdout);
-        }
-        return 0;
+    if (id == 0)
+        clock_gettime (CLOCK_MONOTONIC, &t);
+    MPI_Finalize();
+    if (id == 0) {
+        printf("0: completed MPI_Finalize in %0.3fs\n",
+               time_since (t) / 1000);
+        fflush(stdout);
+    }
+    return 0;
 }
+
+// vi: ts=4 sw=4 expandtab
+

--- a/t/mpi/hello.c
+++ b/t/mpi/hello.c
@@ -37,38 +37,37 @@ static double time_since (struct timespec t0)
     return ((double) d.tv_sec * 1000 + (double) d.tv_nsec / 1000000);
 }
 
-int
-main(int argc, char *argv[])
+int main (int argc, char *argv[])
 {
     int id, ntasks;
     struct timespec t;
 
     clock_gettime (CLOCK_MONOTONIC, &t);
-    MPI_Init(&argc, &argv);
-    MPI_Comm_rank(MPI_COMM_WORLD, &id);
-    MPI_Comm_size(MPI_COMM_WORLD, &ntasks);
+    MPI_Init (&argc, &argv);
+    MPI_Comm_rank (MPI_COMM_WORLD, &id);
+    MPI_Comm_size (MPI_COMM_WORLD, &ntasks);
 
     if (id == 0) {
-        printf("0: completed MPI_Init in %0.3fs.  There are %d tasks\n",
-               time_since (t)/1000, ntasks);
-        fflush(stdout);
+        printf ("0: completed MPI_Init in %0.3fs.  There are %d tasks\n",
+                time_since (t)/1000, ntasks);
+        fflush (stdout);
     }
 	if (id == 0)
 		clock_gettime (CLOCK_MONOTONIC, &t);
-    MPI_Barrier(MPI_COMM_WORLD);
+    MPI_Barrier (MPI_COMM_WORLD);
     if (id == 0) {
-        printf("0: completed first barrier in %0.3fs\n",
-               time_since (t) / 1000);
-        fflush(stdout);
+        printf ("0: completed first barrier in %0.3fs\n",
+                time_since (t) / 1000);
+        fflush (stdout);
     }
 
     if (id == 0)
         clock_gettime (CLOCK_MONOTONIC, &t);
-    MPI_Finalize();
+    MPI_Finalize ();
     if (id == 0) {
-        printf("0: completed MPI_Finalize in %0.3fs\n",
-               time_since (t) / 1000);
-        fflush(stdout);
+        printf ("0: completed MPI_Finalize in %0.3fs\n",
+                time_since (t) / 1000);
+        fflush (stdout);
     }
     return 0;
 }

--- a/t/mpi/mpich_basic/GetOpt.c
+++ b/t/mpi/mpich_basic/GetOpt.c
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "GetOpt.h"
+#include <stdio.h>
+
+bool GetOpt(int *argc, LPTSTR ** argv, CLPTSTR flag)
+{
+    int i, j;
+    if (flag == NULL)
+        return false;
+
+    for (i = 0; i < *argc; i++) {
+        if (_tcsicmp((*argv)[i], flag) == 0) {
+            for (j = i; j < *argc; j++) {
+                (*argv)[j] = (*argv)[j + 1];
+            }
+            *argc -= 1;
+            return true;
+        }
+    }
+    return false;
+}
+
+bool GetOptInt(int *argc, LPTSTR ** argv, CLPTSTR flag, int *n)
+{
+    int i, j;
+    if (flag == NULL)
+        return false;
+
+    for (i = 0; i < *argc; i++) {
+        if (_tcsicmp((*argv)[i], flag) == 0) {
+            if (i + 1 == *argc)
+                return false;
+            *n = _ttoi((*argv)[i + 1]);
+            for (j = i; j < *argc - 1; j++) {
+                (*argv)[j] = (*argv)[j + 2];
+            }
+            *argc -= 2;
+            return true;
+        }
+    }
+    return false;
+}
+
+bool GetOptLong(int *argc, LPTSTR ** argv, CLPTSTR flag, long *n)
+{
+    int i;
+    if (GetOptInt(argc, argv, flag, &i)) {
+        *n = (long) i;
+        return true;
+    }
+    return false;
+}
+
+bool GetOptDouble(int *argc, LPTSTR ** argv, CLPTSTR flag, double *d)
+{
+    int i, j;
+
+    if (flag == NULL)
+        return false;
+
+    for (i = 0; i < *argc; i++) {
+        if (_tcsicmp((*argv)[i], flag) == 0) {
+            if (i + 1 == *argc)
+                return false;
+            *d = _tcstod((*argv)[i + 1], NULL);
+            for (j = i; j < *argc - 1; j++) {
+                (*argv)[j] = (*argv)[j + 2];
+            }
+            *argc -= 2;
+            return true;
+        }
+    }
+    return false;
+}
+
+bool GetOptString(int *argc, LPTSTR ** argv, CLPTSTR flag, char *str)
+{
+    int i, j;
+
+    if (flag == NULL)
+        return false;
+
+    for (i = 0; i < *argc; i++) {
+        if (_tcsicmp((*argv)[i], flag) == 0) {
+            if (i + 1 == *argc)
+                return false;
+            strcpy(str, (*argv)[i + 1]);
+            for (j = i; j < *argc - 1; j++) {
+                (*argv)[j] = (*argv)[j + 2];
+            }
+            *argc -= 2;
+            return true;
+        }
+    }
+    return false;
+}

--- a/t/mpi/mpich_basic/GetOpt.h
+++ b/t/mpi/mpich_basic/GetOpt.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#ifndef GETOPT_H_INCLUDED
+#define GETOPT_H_INCLUDED
+
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+#define CLPTSTR const char *
+#define LPTSTR char *
+#define LPCTSTR char *
+#define _tcsicmp strcmp
+#define _ttoi atoi
+#define _tcstod(a,b) atof(a)
+#define stricmp strcmp
+#define bool int
+#define true 1
+#define false 0
+
+bool GetOpt(int *argc, char ***argv, const char *flag);
+bool GetOptInt(int *argc, char ***argv, const char *flag, int *n);
+bool GetOptLong(int *argc, char ***argv, const char *flag, long *n);
+bool GetOptDouble(int *argc, char ***argv, const char *flag, double *d);
+bool GetOptString(int *argc, char ***argv, const char *flag, char *str);
+
+#endif /* GETOPT_H_INCLUDED */

--- a/t/mpi/mpich_basic/adapt.c
+++ b/t/mpi/mpich_basic/adapt.c
@@ -1,0 +1,1476 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#ifdef HAVE_WINDOWS_H
+#include <winsock2.h>
+#include <windows.h>
+#endif
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "mpi.h"
+#include "GetOpt.h"
+
+#ifndef BOOL
+typedef int BOOL;
+#endif
+#ifndef TRUE
+#define TRUE 1
+#endif
+#ifndef FALSE
+#define FALSE 0
+#endif
+
+#define MIN(x, y)	(((x) < (y))?(x):(y))
+#define MAX(x, y)	(((x) > (y))?(x):(y))
+
+#ifdef HAVE_WINDOWS_H
+#define POINTER_TO_INT(a)   ((int)(0xffffffff & (__int64) (a)))
+#else
+#define POINTER_TO_INT(a)   ((MPI_Aint)(a))
+#endif
+
+#define CREATE_DIFFERENCE_CURVES
+#undef CREATE_SINGLE_CURVE
+
+#define MAX_NUM_O12_TRIALS 18
+#define TRIALS          7
+#define PERT            3
+#define LONGTIME        1e99
+#define CHARSIZE        8
+#define RUNTM		0.1
+#define MAXINT          2147483647
+#define MAX_LAT_TIME    2
+#define LEFT_PROCESS    0
+#define MIDDLE_PROCESS  1
+#define RIGHT_PROCESS   2
+#define MSG_TAG_01      9901
+#define MSG_TAG_12      9912
+#define MSG_TAG_012     9012
+
+int g_left_rank = -1;
+int g_middle_rank = -1;
+int g_right_rank = -1;
+int g_proc_loc = -1;
+int g_NSAMP = 250;
+double g_STOPTM = 0.1;
+int g_latency012_reps = 1000;
+int g_nIproc = 0;
+int g_nNproc = 0;
+
+typedef struct ArgStruct {
+    char *sbuff;                /* Send buffer      */
+    char *rbuff;                /* Recv buffer      */
+    int bufflen;                /* Length of buffer */
+    int nbor, nbor2;            /* neighbor */
+    int iproc;                  /* rank */
+    int tr;                     /* transmitter/receiver flag */
+    int latency_reps;           /* reps needed to time latency */
+} ArgStruct;
+
+typedef struct Data {
+    double t;
+    double bps;
+    int bits;
+    int repeat;
+} Data;
+
+int Setup(int middle_rank, ArgStruct * p01, ArgStruct * p12, ArgStruct * p012);
+void Sync(ArgStruct * p);
+void Sync012(ArgStruct * p);
+void SendTime(ArgStruct * p, double *t);
+void RecvTime(ArgStruct * p, double *t);
+void SendReps(ArgStruct * p, int *rpt);
+void RecvReps(ArgStruct * p, int *rpt);
+double TestLatency(ArgStruct * p);
+double TestLatency012(ArgStruct * p);
+void PrintOptions(void);
+int DetermineLatencyReps(ArgStruct * p);
+int DetermineLatencyReps012(ArgStruct * p);
+
+void PrintOptions()
+{
+    printf("\n");
+    printf("Usage: adapt flags\n");
+    printf(" flags:\n");
+    printf("       -reps #iterations\n");
+    printf("       -time stop_time\n");
+    printf("       -start initial_msg_size\n");
+    printf("       -end final_msg_size\n");
+    printf("       -out outputfile\n");
+    printf("       -nocache\n");
+    printf("       -pert\n");
+    printf("       -noprint\n");
+    printf("       -middle rank_0_1_or_2\n");
+    printf("Requires exactly three processes\n");
+    printf("\n");
+}
+
+int main(int argc, char *argv[])
+{
+    FILE *out = 0;              /* Output data file                     */
+    char s[255];                /* Generic string                       */
+    char *memtmp;
+    char *memtmp1;
+    MPI_Status status;
+
+    int ii, i, j, k, n, nq,     /* Loop indices                         */
+     bufoffset = 0,             /* Align buffer to this                 */
+        bufalign = 16 * 1024,   /* Boundary to align buffer to          */
+        nrepeat01, nrepeat12,   /* Number of time to do the transmission */
+        nrepeat012, len,        /* Number of bytes to be transmitted    */
+        inc = 1,        /* Increment value                      */
+        pert,   /* Perturbation value                   */
+        ipert,  /* index of the perturbation loop       */
+        start = 0,      /* Starting value for signature curve   */
+        end = MAXINT,   /* Ending value for signature curve     */
+        printopt = 1,   /* Debug print statements flag          */
+        middle_rank = 0,        /* rank 0, 1 or 2 where 2-0-1 or 0-1-2 or 1-2-0 */
+        tint;
+
+    ArgStruct args01, args12, args012;  /* Argumentsfor all the calls   */
+
+    double t, t0, t1,           /* Time variables                       */
+     tlast01, tlast12, tlast012,        /* Time for the last transmission    */
+     latency01, latency12,      /* Network message latency              */
+     latency012, tdouble;       /* Network message latency to go from 0 -> 1 -> 2 */
+#ifdef CREATE_DIFFERENCE_CURVES
+    int itrial, ntrials;
+    double *dtrials;
+#endif
+
+    Data *bwdata01, *bwdata12, *bwdata012;      /* Bandwidth curve data       */
+
+    BOOL bNoCache = FALSE;
+    BOOL bSavePert = FALSE;
+    BOOL bUseMegaBytes = FALSE;
+
+    MPI_Init(&argc, &argv);
+
+    MPI_Comm_size(MPI_COMM_WORLD, &g_nNproc);
+    MPI_Comm_rank(MPI_COMM_WORLD, &g_nIproc);
+
+    if (g_nNproc != 3) {
+        if (g_nIproc == 0)
+            PrintOptions();
+        MPI_Finalize();
+        exit(0);
+    }
+
+    GetOptDouble(&argc, &argv, "-time", &g_STOPTM);
+    GetOptInt(&argc, &argv, "-reps", &g_NSAMP);
+    GetOptInt(&argc, &argv, "-start", &start);
+    GetOptInt(&argc, &argv, "-end", &end);
+    bNoCache = GetOpt(&argc, &argv, "-nocache");
+    bUseMegaBytes = GetOpt(&argc, &argv, "-mb");
+    if (GetOpt(&argc, &argv, "-noprint"))
+        printopt = 0;
+    bSavePert = GetOpt(&argc, &argv, "-pert");
+    GetOptInt(&argc, &argv, "-middle", &middle_rank);
+    if (middle_rank < 0 || middle_rank > 2)
+        middle_rank = 0;
+
+    bwdata01 = malloc((g_NSAMP + 1) * sizeof(Data));
+    bwdata12 = malloc((g_NSAMP + 1) * sizeof(Data));
+    bwdata012 = malloc((g_NSAMP + 1) * sizeof(Data));
+
+    if (g_nIproc == 0)
+        strcpy(s, "adapt.out");
+    GetOptString(&argc, &argv, "-out", s);
+
+    if (start > end) {
+        fprintf(stdout, "Start MUST be LESS than end\n");
+        exit(420132);
+    }
+
+    Setup(middle_rank, &args01, &args12, &args012);
+
+    if (g_nIproc == 0) {
+        if ((out = fopen(s, "w")) == NULL) {
+            fprintf(stdout, "Can't open %s for output\n", s);
+            exit(1);
+        }
+    }
+
+    /* Calculate latency */
+    switch (g_proc_loc) {
+        case LEFT_PROCESS:
+            latency01 = TestLatency(&args01);
+            /*printf("[0] latency01 = %0.9f\n", latency01);fflush(stdout); */
+            RecvTime(&args01, &latency12);
+            /*printf("[0] latency12 = %0.9f\n", latency12);fflush(stdout); */
+            break;
+        case MIDDLE_PROCESS:
+            latency01 = TestLatency(&args01);
+            /*printf("[1] latency01 = %0.9f\n", latency01);fflush(stdout); */
+            SendTime(&args12, &latency01);
+            latency12 = TestLatency(&args12);
+            /*printf("[1] latency12 = %0.9f\n", latency12);fflush(stdout); */
+            SendTime(&args01, &latency12);
+            break;
+        case RIGHT_PROCESS:
+            RecvTime(&args12, &latency01);
+            /*printf("[2] latency01 = %0.9f\n", latency01);fflush(stdout); */
+            latency12 = TestLatency(&args12);
+            /*printf("[2] latency12 = %0.9f\n", latency12);fflush(stdout); */
+            break;
+    }
+
+    latency012 = TestLatency012(&args012);
+
+    if ((g_nIproc == 0) && printopt) {
+        printf("Latency%d%d_ : %0.9f\n", g_left_rank, g_middle_rank, latency01);
+        printf("Latency_%d%d : %0.9f\n", g_middle_rank, g_right_rank, latency12);
+        printf("Latency%d%d%d : %0.9f\n", g_left_rank, g_middle_rank, g_right_rank, latency012);
+        fflush(stdout);
+        printf("Now starting main loop\n");
+        fflush(stdout);
+    }
+    tlast01 = latency01;
+    tlast12 = latency12;
+    tlast012 = latency012;
+    inc = (start > 1) ? start / 2 : inc;
+    args01.bufflen = start;
+    args12.bufflen = start;
+    args012.bufflen = start;
+
+#ifdef CREATE_DIFFERENCE_CURVES
+    /* print the header line of the output file */
+    if (g_nIproc == 0) {
+        fprintf(out, "bytes\tMbits/s\ttime\tMbits/s\ttime");
+        for (ii = 1, itrial = 0; itrial < MAX_NUM_O12_TRIALS; ii <<= 1, itrial++)
+            fprintf(out, "\t%d", ii);
+        fprintf(out, "\n");
+        fflush(out);
+    }
+    ntrials = MAX_NUM_O12_TRIALS;
+    dtrials = malloc(sizeof(double) * ntrials);
+#endif
+
+    /* Main loop of benchmark */
+    for (nq = n = 0, len = start;
+         n < g_NSAMP && tlast012 < g_STOPTM && len <= end; len = len + inc, nq++) {
+        if (nq > 2)
+            inc = (nq % 2) ? inc + inc : inc;
+
+        /* clear the old values */
+        for (itrial = 0; itrial < ntrials; itrial++) {
+            dtrials[itrial] = LONGTIME;
+        }
+
+        /* This is a perturbation loop to test nearby values */
+        for (ipert = 0, pert = (inc > PERT + 1) ? -PERT : 0;
+             pert <= PERT; ipert++, n++, pert += (inc > PERT + 1) ? PERT : PERT + 1) {
+
+
+            /*****************************************************/
+            /*         Run a trial between rank 0 and 1          */
+            /*****************************************************/
+
+            MPI_Barrier(MPI_COMM_WORLD);
+
+
+            if (g_proc_loc == RIGHT_PROCESS)
+                goto skip_01_trial;
+
+            /* Calculate howmany times to repeat the experiment. */
+            if (args01.tr) {
+                if (args01.bufflen == 0)
+                    nrepeat01 = args01.latency_reps;
+                else
+                    nrepeat01 = (int) (MAX((RUNTM / ((double) args01.bufflen /
+                                                     (args01.bufflen - inc + 1.0) * tlast01)),
+                                           TRIALS));
+                SendReps(&args01, &nrepeat01);
+            } else {
+                RecvReps(&args01, &nrepeat01);
+            }
+
+            /* Allocate the buffer */
+            args01.bufflen = len + pert;
+            /* printf("allocating %d bytes\n", args01.bufflen * nrepeat01 + bufalign); */
+            if (bNoCache) {
+                if ((args01.sbuff =
+                     (char *) malloc(args01.bufflen * nrepeat01 + bufalign)) == (char *) NULL) {
+                    fprintf(stdout, "Couldn't allocate memory\n");
+                    fflush(stdout);
+                    break;
+                }
+            } else {
+                if ((args01.sbuff = (char *) malloc(args01.bufflen + bufalign)) == (char *) NULL) {
+                    fprintf(stdout, "Couldn't allocate memory\n");
+                    fflush(stdout);
+                    break;
+                }
+            }
+            /* if ((args01.rbuff = (char *)malloc(args01.bufflen * nrepeat01 + bufalign)) == (char *)NULL) */
+            if ((args01.rbuff = (char *) malloc(args01.bufflen + bufalign)) == (char *) NULL) {
+                fprintf(stdout, "Couldn't allocate memory\n");
+                fflush(stdout);
+                break;
+            }
+
+            /* save the original pointers in case alignment moves them */
+            memtmp = args01.sbuff;
+            memtmp1 = args01.rbuff;
+
+            /* Possibly align the data buffer */
+            if (!bNoCache) {
+                if (bufalign != 0) {
+                    args01.sbuff +=
+                        (bufalign - (POINTER_TO_INT(args01.sbuff) % bufalign) +
+                         bufoffset) % bufalign;
+                    /* args01.rbuff += (bufalign - ((MPI_Aint)args01.rbuff % bufalign) + bufoffset) % bufalign; */
+                }
+            }
+            args01.rbuff +=
+                (bufalign - (POINTER_TO_INT(args01.rbuff) % bufalign) + bufoffset) % bufalign;
+
+            if (args01.tr && printopt) {
+                fprintf(stdout, "%3d: %9d bytes %4d times --> ", n, args01.bufflen, nrepeat01);
+                fflush(stdout);
+            }
+
+            /* Finally, we get to transmit or receive and time */
+            if (args01.tr) {
+                bwdata01[n].t = LONGTIME;
+                t1 = 0;
+                for (i = 0; i < TRIALS; i++) {
+                    if (bNoCache) {
+                        if (bufalign != 0) {
+                            args01.sbuff =
+                                memtmp +
+                                ((bufalign - (POINTER_TO_INT(args01.sbuff) % bufalign) +
+                                  bufoffset) % bufalign);
+                            /* args01.rbuff = memtmp1 + ((bufalign - ((MPI_Aint)args01.rbuff % bufalign) + bufoffset) % bufalign); */
+                        } else {
+                            args01.sbuff = memtmp;
+                            /* args01.rbuff = memtmp1; */
+                        }
+                    }
+
+                    Sync(&args01);
+                    t0 = MPI_Wtime();
+                    for (j = 0; j < nrepeat01; j++) {
+                        MPI_Send(args01.sbuff, args01.bufflen, MPI_BYTE, args01.nbor, MSG_TAG_01,
+                                 MPI_COMM_WORLD);
+                        MPI_Recv(args01.rbuff, args01.bufflen, MPI_BYTE, args01.nbor, MSG_TAG_01,
+                                 MPI_COMM_WORLD, &status);
+                        if (bNoCache) {
+                            args01.sbuff += args01.bufflen;
+                            /* args01.rbuff += args01.bufflen; */
+                        }
+                    }
+                    t = (MPI_Wtime() - t0) / (2 * nrepeat01);
+
+                    t1 += t;
+                    bwdata01[n].t = MIN(bwdata01[n].t, t);
+                }
+                SendTime(&args01, &bwdata01[n].t);
+            } else {
+                bwdata01[n].t = LONGTIME;
+                t1 = 0;
+                for (i = 0; i < TRIALS; i++) {
+                    if (bNoCache) {
+                        if (bufalign != 0) {
+                            args01.sbuff =
+                                memtmp +
+                                ((bufalign - (POINTER_TO_INT(args01.sbuff) % bufalign) +
+                                  bufoffset) % bufalign);
+                            /* args01.rbuff = memtmp1 + ((bufalign - ((MPI_Aint)args01.rbuff % bufalign) + bufoffset) % bufalign); */
+                        } else {
+                            args01.sbuff = memtmp;
+                            /* args01.rbuff = memtmp1; */
+                        }
+                    }
+
+                    Sync(&args01);
+                    t0 = MPI_Wtime();
+                    for (j = 0; j < nrepeat01; j++) {
+                        MPI_Recv(args01.rbuff, args01.bufflen, MPI_BYTE, args01.nbor, MSG_TAG_01,
+                                 MPI_COMM_WORLD, &status);
+                        MPI_Send(args01.sbuff, args01.bufflen, MPI_BYTE, args01.nbor, MSG_TAG_01,
+                                 MPI_COMM_WORLD);
+                        if (bNoCache) {
+                            args01.sbuff += args01.bufflen;
+                            /* args01.rbuff += args01.bufflen; */
+                        }
+                    }
+                    t = (MPI_Wtime() - t0) / (2 * nrepeat01);
+                }
+                RecvTime(&args01, &bwdata01[n].t);
+            }
+            tlast01 = bwdata01[n].t;
+            bwdata01[n].bits = args01.bufflen * CHARSIZE;
+            bwdata01[n].bps = bwdata01[n].bits / (bwdata01[n].t * 1024 * 1024);
+            bwdata01[n].repeat = nrepeat01;
+
+            if (args01.tr) {
+                if (bSavePert) {
+                    if (args01.iproc == 0) {
+                        if (bUseMegaBytes)
+                            fprintf(out, "%d\t%f\t%0.9f\t", bwdata01[n].bits / 8,
+                                    bwdata01[n].bps / 8, bwdata01[n].t);
+                        else
+                            fprintf(out, "%d\t%f\t%0.9f\t", bwdata01[n].bits / 8, bwdata01[n].bps,
+                                    bwdata01[n].t);
+                        fflush(out);
+                    } else {
+                        MPI_Send(&bwdata01[n].bits, 1, MPI_INT, 0, 1, MPI_COMM_WORLD);
+                        MPI_Send(&bwdata01[n].bps, 1, MPI_DOUBLE, 0, 1, MPI_COMM_WORLD);
+                        MPI_Send(&bwdata01[n].t, 1, MPI_DOUBLE, 0, 1, MPI_COMM_WORLD);
+                    }
+                }
+            }
+
+            free(memtmp);
+            free(memtmp1);
+
+            if (args01.tr && printopt) {
+                if (bUseMegaBytes)
+                    printf(" %6.2f MBps in %0.9f sec\n", bwdata01[n].bps / 8, tlast01);
+                else
+                    printf(" %6.2f Mbps in %0.9f sec\n", bwdata01[n].bps, tlast01);
+                fflush(stdout);
+            }
+
+          skip_01_trial:
+            if (g_proc_loc == RIGHT_PROCESS && g_nIproc == 0 && bSavePert) {
+                MPI_Recv(&tint, 1, MPI_INT, g_left_rank, 1, MPI_COMM_WORLD, &status);
+                fprintf(out, "%d\t", tint / 8);
+                MPI_Recv(&tdouble, 1, MPI_DOUBLE, g_left_rank, 1, MPI_COMM_WORLD, &status);
+                if (bUseMegaBytes)
+                    tdouble = tdouble / 8.0;
+                fprintf(out, "%f\t", tdouble);
+                MPI_Recv(&tdouble, 1, MPI_DOUBLE, g_left_rank, 1, MPI_COMM_WORLD, &status);
+                fprintf(out, "%0.9f\t", tdouble);
+                fflush(out);
+            }
+
+
+            /*****************************************************/
+            /*         Run a trial between rank 1 and 2          */
+            /*****************************************************/
+
+            MPI_Barrier(MPI_COMM_WORLD);
+
+
+            if (g_proc_loc == LEFT_PROCESS)
+                goto skip_12_trial;
+
+            /* Calculate howmany times to repeat the experiment. */
+            if (args12.tr) {
+                if (args12.bufflen == 0)
+                    nrepeat12 = args12.latency_reps;
+                else
+                    nrepeat12 = (int) (MAX((RUNTM / ((double) args12.bufflen /
+                                                     (args12.bufflen - inc + 1.0) * tlast12)),
+                                           TRIALS));
+                SendReps(&args12, &nrepeat12);
+            } else {
+                RecvReps(&args12, &nrepeat12);
+            }
+
+            /* Allocate the buffer */
+            args12.bufflen = len + pert;
+            /* printf("allocating %d bytes\n", args12.bufflen * nrepeat12 + bufalign); */
+            if (bNoCache) {
+                if ((args12.sbuff =
+                     (char *) malloc(args12.bufflen * nrepeat12 + bufalign)) == (char *) NULL) {
+                    fprintf(stdout, "Couldn't allocate memory\n");
+                    fflush(stdout);
+                    break;
+                }
+            } else {
+                if ((args12.sbuff = (char *) malloc(args12.bufflen + bufalign)) == (char *) NULL) {
+                    fprintf(stdout, "Couldn't allocate memory\n");
+                    fflush(stdout);
+                    break;
+                }
+            }
+            /* if ((args12.rbuff = (char *)malloc(args12.bufflen * nrepeat12 + bufalign)) == (char *)NULL) */
+            if ((args12.rbuff = (char *) malloc(args12.bufflen + bufalign)) == (char *) NULL) {
+                fprintf(stdout, "Couldn't allocate memory\n");
+                fflush(stdout);
+                break;
+            }
+
+            /* save the original pointers in case alignment moves them */
+            memtmp = args12.sbuff;
+            memtmp1 = args12.rbuff;
+
+            /* Possibly align the data buffer */
+            if (!bNoCache) {
+                if (bufalign != 0) {
+                    args12.sbuff +=
+                        (bufalign - (POINTER_TO_INT(args12.sbuff) % bufalign) +
+                         bufoffset) % bufalign;
+                    /* args12.rbuff += (bufalign - ((MPI_Aint)args12.rbuff % bufalign) + bufoffset) % bufalign; */
+                }
+            }
+            args12.rbuff +=
+                (bufalign - (POINTER_TO_INT(args12.rbuff) % bufalign) + bufoffset) % bufalign;
+
+            if (args12.tr && printopt) {
+                printf("%3d: %9d bytes %4d times --> ", n, args12.bufflen, nrepeat12);
+                fflush(stdout);
+            }
+
+            /* Finally, we get to transmit or receive and time */
+            if (args12.tr) {
+                bwdata12[n].t = LONGTIME;
+                t1 = 0;
+                for (i = 0; i < TRIALS; i++) {
+                    if (bNoCache) {
+                        if (bufalign != 0) {
+                            args12.sbuff =
+                                memtmp +
+                                ((bufalign - (POINTER_TO_INT(args12.sbuff) % bufalign) +
+                                  bufoffset) % bufalign);
+                            /* args12.rbuff = memtmp1 + ((bufalign - ((MPI_Aint)args12.rbuff % bufalign) + bufoffset) % bufalign); */
+                        } else {
+                            args12.sbuff = memtmp;
+                            /* args12.rbuff = memtmp1; */
+                        }
+                    }
+
+                    Sync(&args12);
+                    t0 = MPI_Wtime();
+                    for (j = 0; j < nrepeat12; j++) {
+                        MPI_Send(args12.sbuff, args12.bufflen, MPI_BYTE, args12.nbor, MSG_TAG_12,
+                                 MPI_COMM_WORLD);
+                        MPI_Recv(args12.rbuff, args12.bufflen, MPI_BYTE, args12.nbor, MSG_TAG_12,
+                                 MPI_COMM_WORLD, &status);
+                        if (bNoCache) {
+                            args12.sbuff += args12.bufflen;
+                            /* args12.rbuff += args12.bufflen; */
+                        }
+                    }
+                    t = (MPI_Wtime() - t0) / (2 * nrepeat12);
+
+                    t1 += t;
+                    bwdata12[n].t = MIN(bwdata12[n].t, t);
+                }
+                SendTime(&args12, &bwdata12[n].t);
+            } else {
+                bwdata12[n].t = LONGTIME;
+                t1 = 0;
+                for (i = 0; i < TRIALS; i++) {
+                    if (bNoCache) {
+                        if (bufalign != 0) {
+                            args12.sbuff =
+                                memtmp +
+                                ((bufalign - (POINTER_TO_INT(args12.sbuff) % bufalign) +
+                                  bufoffset) % bufalign);
+                            /* args12.rbuff = memtmp1 + ((bufalign - ((MPI_Aint)args12.rbuff % bufalign) + bufoffset) % bufalign); */
+                        } else {
+                            args12.sbuff = memtmp;
+                            /* args12.rbuff = memtmp1; */
+                        }
+                    }
+
+                    Sync(&args12);
+                    t0 = MPI_Wtime();
+                    for (j = 0; j < nrepeat12; j++) {
+                        MPI_Recv(args12.rbuff, args12.bufflen, MPI_BYTE, args12.nbor, MSG_TAG_12,
+                                 MPI_COMM_WORLD, &status);
+                        MPI_Send(args12.sbuff, args12.bufflen, MPI_BYTE, args12.nbor, MSG_TAG_12,
+                                 MPI_COMM_WORLD);
+                        if (bNoCache) {
+                            args12.sbuff += args12.bufflen;
+                            /* args12.rbuff += args12.bufflen; */
+                        }
+                    }
+                    t = (MPI_Wtime() - t0) / (2 * nrepeat12);
+                }
+                RecvTime(&args12, &bwdata12[n].t);
+            }
+            tlast12 = bwdata12[n].t;
+            bwdata12[n].bits = args12.bufflen * CHARSIZE;
+            bwdata12[n].bps = bwdata12[n].bits / (bwdata12[n].t * 1024 * 1024);
+            bwdata12[n].repeat = nrepeat12;
+
+            if (args12.tr) {
+                if (bSavePert) {
+                    if (g_nIproc == 0) {
+                        if (bUseMegaBytes)
+                            fprintf(out, "%f\t%0.9f\t", bwdata12[n].bps / 8, bwdata12[n].t);
+                        else
+                            fprintf(out, "%f\t%0.9f\t", bwdata12[n].bps, bwdata12[n].t);
+                        fflush(out);
+                    } else {
+                        MPI_Send(&bwdata12[n].bps, 1, MPI_DOUBLE, 0, 1, MPI_COMM_WORLD);
+                        MPI_Send(&bwdata12[n].t, 1, MPI_DOUBLE, 0, 1, MPI_COMM_WORLD);
+                    }
+                }
+            }
+
+            free(memtmp);
+            free(memtmp1);
+
+            if (args12.tr && printopt) {
+                if (bUseMegaBytes)
+                    printf(" %6.2f MBps in %0.9f sec\n", bwdata12[n].bps / 8, tlast12);
+                else
+                    printf(" %6.2f Mbps in %0.9f sec\n", bwdata12[n].bps, tlast12);
+                fflush(stdout);
+            }
+
+          skip_12_trial:
+            if (g_proc_loc == LEFT_PROCESS && g_nIproc == 0 && bSavePert) {
+                MPI_Recv(&tdouble, 1, MPI_DOUBLE, g_middle_rank, 1, MPI_COMM_WORLD, &status);
+                if (bUseMegaBytes)
+                    tdouble = tdouble / 8.0;
+                fprintf(out, "%f\t", tdouble);
+                MPI_Recv(&tdouble, 1, MPI_DOUBLE, g_middle_rank, 1, MPI_COMM_WORLD, &status);
+                fprintf(out, "%0.9f\t", tdouble);
+                fflush(out);
+            }
+#ifdef CREATE_DIFFERENCE_CURVES
+            /*****************************************************/
+            /*         Run a trial between rank 0, 1 and 2       */
+            /*****************************************************/
+
+            MPI_Barrier(MPI_COMM_WORLD);
+
+
+            /* Calculate howmany times to repeat the experiment. */
+            if (g_nIproc == 0) {
+                if (args012.bufflen == 0)
+                    nrepeat012 = g_latency012_reps;
+                else
+                    nrepeat012 = (int) (MAX((RUNTM / ((double) args012.bufflen /
+                                                      (args012.bufflen - inc + 1.0) * tlast012)),
+                                            TRIALS));
+                MPI_Bcast(&nrepeat012, 1, MPI_INT, 0, MPI_COMM_WORLD);
+            } else {
+                MPI_Bcast(&nrepeat012, 1, MPI_INT, 0, MPI_COMM_WORLD);
+            }
+
+            /* Allocate the buffer */
+            args012.bufflen = len + pert;
+            /* printf("allocating %d bytes\n", args12.bufflen * nrepeat012 + bufalign); */
+            if (bNoCache) {
+                if ((args012.sbuff =
+                     (char *) malloc(args012.bufflen * nrepeat012 + bufalign)) == (char *) NULL) {
+                    fprintf(stdout, "Couldn't allocate memory\n");
+                    fflush(stdout);
+                    break;
+                }
+            } else {
+                if ((args012.sbuff = (char *) malloc(args012.bufflen + bufalign)) == (char *) NULL) {
+                    fprintf(stdout, "Couldn't allocate memory\n");
+                    fflush(stdout);
+                    break;
+                }
+            }
+            /* if ((args012.rbuff = (char *)malloc(args012.bufflen * nrepeat012 + bufalign)) == (char *)NULL) */
+            if ((args012.rbuff = (char *) malloc(args012.bufflen + bufalign)) == (char *) NULL) {
+                fprintf(stdout, "Couldn't allocate memory\n");
+                fflush(stdout);
+                break;
+            }
+
+            /* save the original pointers in case alignment moves them */
+            memtmp = args012.sbuff;
+            memtmp1 = args012.rbuff;
+
+            /* Possibly align the data buffer */
+            if (!bNoCache) {
+                if (bufalign != 0) {
+                    args012.sbuff +=
+                        (bufalign - (POINTER_TO_INT(args012.sbuff) % bufalign) +
+                         bufoffset) % bufalign;
+                    /* args12.rbuff += (bufalign - ((MPI_Aint)args12.rbuff % bufalign) + bufoffset) % bufalign; */
+                }
+            }
+            args012.rbuff +=
+                (bufalign - (POINTER_TO_INT(args012.rbuff) % bufalign) + bufoffset) % bufalign;
+
+            if (g_nIproc == 0 && printopt) {
+                printf("%3d: %9d bytes %4d times --> ", n, args012.bufflen, nrepeat012);
+                fflush(stdout);
+            }
+
+            for (itrial = 0, ii = 1; ii <= nrepeat012 && itrial < ntrials; ii <<= 1, itrial++) {
+                /* Finally, we get to transmit or receive and time */
+                switch (g_proc_loc) {
+                    case LEFT_PROCESS:
+                        bwdata012[n].t = LONGTIME;
+                        t1 = 0;
+                        for (i = 0; i < TRIALS; i++) {
+                            if (bNoCache) {
+                                if (bufalign != 0) {
+                                    args012.sbuff =
+                                        memtmp +
+                                        ((bufalign - (POINTER_TO_INT(args012.sbuff) % bufalign) +
+                                          bufoffset) % bufalign);
+                                    /* args012.rbuff = memtmp1 + ((bufalign - ((MPI_Aint)args012.rbuff % bufalign) + bufoffset) % bufalign); */
+                                } else {
+                                    args012.sbuff = memtmp;
+                                    /* args012.rbuff = memtmp1; */
+                                }
+                            }
+
+                            Sync012(&args012);
+                            t0 = MPI_Wtime();
+                            for (j = 0; j < nrepeat012; j++) {
+                                MPI_Send(args012.sbuff, args012.bufflen, MPI_BYTE, args012.nbor,
+                                         MSG_TAG_012, MPI_COMM_WORLD);
+                                MPI_Recv(args012.rbuff, args012.bufflen, MPI_BYTE, args012.nbor,
+                                         MSG_TAG_012, MPI_COMM_WORLD, &status);
+                                if (bNoCache) {
+                                    args012.sbuff += args012.bufflen;
+                                    /* args012.rbuff += args012.bufflen; */
+                                }
+                            }
+                            t = (MPI_Wtime() - t0) / (2 * nrepeat012);
+
+                            t1 += t;
+                            bwdata012[n].t = MIN(bwdata012[n].t, t);
+                        }
+                        MPI_Bcast(&bwdata012[n].t, 1, MPI_DOUBLE, g_left_rank, MPI_COMM_WORLD);
+                        break;
+                    case MIDDLE_PROCESS:
+                        bwdata012[n].t = LONGTIME;
+                        t1 = 0;
+                        for (i = 0; i < TRIALS; i++) {
+                            if (bNoCache) {
+                                if (bufalign != 0) {
+                                    args012.sbuff =
+                                        memtmp +
+                                        ((bufalign - (POINTER_TO_INT(args012.sbuff) % bufalign) +
+                                          bufoffset) % bufalign);
+                                    /* args012.rbuff = memtmp1 + ((bufalign - ((MPI_Aint)args012.rbuff % bufalign) + bufoffset) % bufalign); */
+                                } else {
+                                    args012.sbuff = memtmp;
+                                    /* args012.rbuff = memtmp1; */
+                                }
+                            }
+
+                            Sync012(&args012);
+                            t0 = MPI_Wtime();
+
+                        /******* use the ii variable here !!! ******/
+
+                            for (j = 0; j <= nrepeat012 - ii; j += ii) {
+                                for (k = 0; k < ii; k++) {
+                                    MPI_Send(args012.sbuff, args012.bufflen, MPI_BYTE,
+                                             args012.nbor2, MSG_TAG_012, MPI_COMM_WORLD);
+                                    MPI_Recv(args012.rbuff, args012.bufflen, MPI_BYTE,
+                                             args012.nbor2, MSG_TAG_012, MPI_COMM_WORLD, &status);
+                                }
+                                /* do the left process second because it does the timing and needs to include time to send to the right process. */
+                                for (k = 0; k < ii; k++) {
+                                    MPI_Recv(args012.rbuff, args012.bufflen, MPI_BYTE, args012.nbor,
+                                             MSG_TAG_012, MPI_COMM_WORLD, &status);
+                                    MPI_Send(args012.sbuff, args012.bufflen, MPI_BYTE, args012.nbor,
+                                             MSG_TAG_012, MPI_COMM_WORLD);
+                                }
+                                if (bNoCache) {
+                                    args012.sbuff += args012.bufflen;
+                                    /* args012.rbuff += args012.bufflen; */
+                                }
+                            }
+                            j = nrepeat012 % ii;
+                            for (k = 0; k < j; k++) {
+                                MPI_Send(args012.sbuff, args012.bufflen, MPI_BYTE, args012.nbor2,
+                                         MSG_TAG_012, MPI_COMM_WORLD);
+                                MPI_Recv(args012.rbuff, args012.bufflen, MPI_BYTE, args012.nbor2,
+                                         MSG_TAG_012, MPI_COMM_WORLD, &status);
+                            }
+                            /* do the left process second because it does the timing and needs to include time to send to the right process. */
+                            for (k = 0; k < j; k++) {
+                                MPI_Recv(args012.rbuff, args012.bufflen, MPI_BYTE, args012.nbor,
+                                         MSG_TAG_012, MPI_COMM_WORLD, &status);
+                                MPI_Send(args012.sbuff, args012.bufflen, MPI_BYTE, args012.nbor,
+                                         MSG_TAG_012, MPI_COMM_WORLD);
+                            }
+                            t = (MPI_Wtime() - t0) / (2 * nrepeat012);
+                        }
+                        MPI_Bcast(&bwdata012[n].t, 1, MPI_DOUBLE, g_left_rank, MPI_COMM_WORLD);
+                        break;
+                    case RIGHT_PROCESS:
+                        bwdata012[n].t = LONGTIME;
+                        t1 = 0;
+                        for (i = 0; i < TRIALS; i++) {
+                            if (bNoCache) {
+                                if (bufalign != 0) {
+                                    args012.sbuff =
+                                        memtmp +
+                                        ((bufalign - (POINTER_TO_INT(args012.sbuff) % bufalign) +
+                                          bufoffset) % bufalign);
+                                    /* args012.rbuff = memtmp1 + ((bufalign - ((MPI_Aint)args012.rbuff % bufalign) + bufoffset) % bufalign); */
+                                } else {
+                                    args012.sbuff = memtmp;
+                                    /* args012.rbuff = memtmp1; */
+                                }
+                            }
+
+                            Sync012(&args012);
+                            t0 = MPI_Wtime();
+                            for (j = 0; j < nrepeat012; j++) {
+                                MPI_Recv(args012.rbuff, args012.bufflen, MPI_BYTE, args012.nbor,
+                                         MSG_TAG_012, MPI_COMM_WORLD, &status);
+                                MPI_Send(args012.sbuff, args012.bufflen, MPI_BYTE, args012.nbor,
+                                         MSG_TAG_012, MPI_COMM_WORLD);
+                                if (bNoCache) {
+                                    args012.sbuff += args012.bufflen;
+                                    /* args012.rbuff += args012.bufflen; */
+                                }
+                            }
+                            t = (MPI_Wtime() - t0) / (2 * nrepeat012);
+                        }
+                        MPI_Bcast(&bwdata012[n].t, 1, MPI_DOUBLE, g_left_rank, MPI_COMM_WORLD);
+                        break;
+                }
+                tlast012 = bwdata012[n].t;
+                bwdata012[n].bits = args012.bufflen * CHARSIZE;
+                bwdata012[n].bps = bwdata012[n].bits / (bwdata012[n].t * 1024 * 1024);
+                bwdata012[n].repeat = nrepeat012;
+                if (itrial < ntrials) {
+                    dtrials[itrial] = MIN(dtrials[itrial], bwdata012[n].t);
+                }
+
+                if (g_nIproc == 0) {
+                    if (bSavePert) {
+                        fprintf(out, "\t%0.9f", bwdata012[n].t);
+                        fflush(out);
+                    }
+                    if (printopt) {
+                        printf(" %0.9f", tlast012);
+                        fflush(stdout);
+                    }
+                }
+            }
+            if (g_nIproc == 0) {
+                if (bSavePert) {
+                    fprintf(out, "\n");
+                    fflush(out);
+                }
+                if (printopt) {
+                    printf("\n");
+                    fflush(stdout);
+                }
+            }
+
+            free(memtmp);
+            free(memtmp1);
+#endif
+
+#ifdef CREATE_SINGLE_CURVE
+            /*****************************************************/
+            /*         Run a trial between rank 0, 1 and 2       */
+            /*****************************************************/
+
+            MPI_Barrier(MPI_COMM_WORLD);
+
+
+            /* Calculate howmany times to repeat the experiment. */
+            if (g_nIproc == 0) {
+                if (args012.bufflen == 0)
+                    nrepeat012 = g_latency012_reps;
+                else
+                    nrepeat012 = (int) (MAX((RUNTM / ((double) args012.bufflen /
+                                                      (args012.bufflen - inc + 1.0) * tlast012)),
+                                            TRIALS));
+                MPI_Bcast(&nrepeat012, 1, MPI_INT, 0, MPI_COMM_WORLD);
+            } else {
+                MPI_Bcast(&nrepeat012, 1, MPI_INT, 0, MPI_COMM_WORLD);
+            }
+
+            /* Allocate the buffer */
+            args012.bufflen = len + pert;
+            /* printf("allocating %d bytes\n", args12.bufflen * nrepeat012 + bufalign); */
+            if (bNoCache) {
+                if ((args012.sbuff =
+                     (char *) malloc(args012.bufflen * nrepeat012 + bufalign)) == (char *) NULL) {
+                    fprintf(stdout, "Couldn't allocate memory\n");
+                    fflush(stdout);
+                    break;
+                }
+            } else {
+                if ((args012.sbuff = (char *) malloc(args012.bufflen + bufalign)) == (char *) NULL) {
+                    fprintf(stdout, "Couldn't allocate memory\n");
+                    fflush(stdout);
+                    break;
+                }
+            }
+            /* if ((args012.rbuff = (char *)malloc(args012.bufflen * nrepeat012 + bufalign)) == (char *)NULL) */
+            if ((args012.rbuff = (char *) malloc(args012.bufflen + bufalign)) == (char *) NULL) {
+                fprintf(stdout, "Couldn't allocate memory\n");
+                fflush(stdout);
+                break;
+            }
+
+            /* save the original pointers in case alignment moves them */
+            memtmp = args012.sbuff;
+            memtmp1 = args012.rbuff;
+
+            /* Possibly align the data buffer */
+            if (!bNoCache) {
+                if (bufalign != 0) {
+                    args012.sbuff +=
+                        (bufalign - (POINTER_TO_INT(args012.sbuff) % bufalign) +
+                         bufoffset) % bufalign;
+                    /* args12.rbuff += (bufalign - ((MPI_Aint)args12.rbuff % bufalign) + bufoffset) % bufalign; */
+                }
+            }
+            args012.rbuff +=
+                (bufalign - (POINTER_TO_INT(args012.rbuff) % bufalign) + bufoffset) % bufalign;
+
+            if (g_nIproc == 0 && printopt) {
+                printf("%3d: %9d bytes %4d times --> ", n, args012.bufflen, nrepeat012);
+                fflush(stdout);
+            }
+
+            /* Finally, we get to transmit or receive and time */
+            switch (g_proc_loc) {
+                case LEFT_PROCESS:
+                    bwdata012[n].t = LONGTIME;
+                    t1 = 0;
+                    for (i = 0; i < TRIALS; i++) {
+                        if (bNoCache) {
+                            if (bufalign != 0) {
+                                args012.sbuff =
+                                    memtmp +
+                                    ((bufalign - (POINTER_TO_INT(args012.sbuff) % bufalign) +
+                                      bufoffset) % bufalign);
+                                /* args012.rbuff = memtmp1 + ((bufalign - ((MPI_Aint)args012.rbuff % bufalign) + bufoffset) % bufalign); */
+                            } else {
+                                args012.sbuff = memtmp;
+                                /* args012.rbuff = memtmp1; */
+                            }
+                        }
+
+                        Sync012(&args012);
+                        t0 = MPI_Wtime();
+                        for (j = 0; j < nrepeat012; j++) {
+                            MPI_Send(args012.sbuff, args012.bufflen, MPI_BYTE, args012.nbor,
+                                     MSG_TAG_012, MPI_COMM_WORLD);
+                            MPI_Recv(args012.rbuff, args012.bufflen, MPI_BYTE, args012.nbor,
+                                     MSG_TAG_012, MPI_COMM_WORLD, &status);
+                            if (bNoCache) {
+                                args012.sbuff += args012.bufflen;
+                                /* args012.rbuff += args012.bufflen; */
+                            }
+                        }
+                        t = (MPI_Wtime() - t0) / (2 * nrepeat012);
+
+                        t1 += t;
+                        bwdata012[n].t = MIN(bwdata012[n].t, t);
+                    }
+                    MPI_Bcast(&bwdata012[n].t, 1, MPI_DOUBLE, g_left_rank, MPI_COMM_WORLD);
+                    break;
+                case MIDDLE_PROCESS:
+                    bwdata012[n].t = LONGTIME;
+                    t1 = 0;
+                    for (i = 0; i < TRIALS; i++) {
+                        if (bNoCache) {
+                            if (bufalign != 0) {
+                                args012.sbuff =
+                                    memtmp +
+                                    ((bufalign - (POINTER_TO_INT(args012.sbuff) % bufalign) +
+                                      bufoffset) % bufalign);
+                                /* args012.rbuff = memtmp1 + ((bufalign - ((MPI_Aint)args012.rbuff % bufalign) + bufoffset) % bufalign); */
+                            } else {
+                                args012.sbuff = memtmp;
+                                /* args012.rbuff = memtmp1; */
+                            }
+                        }
+
+                        Sync012(&args012);
+                        t0 = MPI_Wtime();
+                        for (j = 0; j < nrepeat012; j++) {
+                            MPI_Recv(args012.rbuff, args012.bufflen, MPI_BYTE, args012.nbor,
+                                     MSG_TAG_012, MPI_COMM_WORLD, &status);
+                            MPI_Send(args012.sbuff, args012.bufflen, MPI_BYTE, args012.nbor2,
+                                     MSG_TAG_012, MPI_COMM_WORLD);
+                            MPI_Recv(args012.rbuff, args012.bufflen, MPI_BYTE, args012.nbor2,
+                                     MSG_TAG_012, MPI_COMM_WORLD, &status);
+                            MPI_Send(args012.sbuff, args012.bufflen, MPI_BYTE, args012.nbor,
+                                     MSG_TAG_012, MPI_COMM_WORLD);
+                            if (bNoCache) {
+                                args012.sbuff += args012.bufflen;
+                                /* args012.rbuff += args012.bufflen; */
+                            }
+                        }
+                        t = (MPI_Wtime() - t0) / (2 * nrepeat012);
+                    }
+                    MPI_Bcast(&bwdata012[n].t, 1, MPI_DOUBLE, g_left_rank, MPI_COMM_WORLD);
+                    break;
+                case RIGHT_PROCESS:
+                    bwdata012[n].t = LONGTIME;
+                    t1 = 0;
+                    for (i = 0; i < TRIALS; i++) {
+                        if (bNoCache) {
+                            if (bufalign != 0) {
+                                args012.sbuff =
+                                    memtmp +
+                                    ((bufalign - (POINTER_TO_INT(args012.sbuff) % bufalign) +
+                                      bufoffset) % bufalign);
+                                /* args012.rbuff = memtmp1 + ((bufalign - ((MPI_Aint)args012.rbuff % bufalign) + bufoffset) % bufalign); */
+                            } else {
+                                args012.sbuff = memtmp;
+                                /* args012.rbuff = memtmp1; */
+                            }
+                        }
+
+                        Sync012(&args012);
+                        t0 = MPI_Wtime();
+                        for (j = 0; j < nrepeat012; j++) {
+                            MPI_Recv(args012.rbuff, args012.bufflen, MPI_BYTE, args012.nbor,
+                                     MSG_TAG_012, MPI_COMM_WORLD, &status);
+                            MPI_Send(args012.sbuff, args012.bufflen, MPI_BYTE, args012.nbor,
+                                     MSG_TAG_012, MPI_COMM_WORLD);
+                            if (bNoCache) {
+                                args012.sbuff += args012.bufflen;
+                                /* args012.rbuff += args012.bufflen; */
+                            }
+                        }
+                        t = (MPI_Wtime() - t0) / (2 * nrepeat012);
+                    }
+                    MPI_Bcast(&bwdata012[n].t, 1, MPI_DOUBLE, g_left_rank, MPI_COMM_WORLD);
+                    break;
+            }
+            tlast012 = bwdata012[n].t;
+            bwdata012[n].bits = args012.bufflen * CHARSIZE;
+            bwdata012[n].bps = bwdata012[n].bits / (bwdata012[n].t * 1024 * 1024);
+            bwdata012[n].repeat = nrepeat012;
+
+            if (g_nIproc == 0) {
+                if (bSavePert) {
+                    if (bUseMegaBytes)
+                        fprintf(out, "%f\t%0.9f\n", bwdata012[n].bps / 8, bwdata012[n].t);
+                    else
+                        fprintf(out, "%f\t%0.9f\n", bwdata012[n].bps, bwdata012[n].t);
+                    fflush(out);
+                }
+            }
+
+            free(memtmp);
+            free(memtmp1);
+
+            if (g_nIproc == 0 && printopt) {
+                if (bUseMegaBytes)
+                    printf(" %6.2f MBps in %0.9f sec\n", bwdata012[n].bps / 8, tlast012);
+                else
+                    printf(" %6.2f Mbps in %0.9f sec\n", bwdata012[n].bps, tlast012);
+                fflush(stdout);
+            }
+#endif
+
+        }       /* End of perturbation loop */
+
+        if (!bSavePert) {       /* && g_nIproc == 0) */
+            /* if we didn't save all of the perturbation loops, find the max and save it */
+            int index01 = 1, index12 = 1;
+            double dmax01 = bwdata01[n - 1].bps;
+            double dmax12 = bwdata12[n - 1].bps;
+#ifdef CREATE_SINGLE_CURVE
+            int index012 = 1;
+            double dmax012 = bwdata012[n - 1].bps;
+#endif
+            for (; ipert > 1; ipert--) {
+                if (bwdata01[n - ipert].bps > dmax01) {
+                    index01 = ipert;
+                    dmax01 = bwdata01[n - ipert].bps;
+                }
+                if (bwdata12[n - ipert].bps > dmax12) {
+                    index12 = ipert;
+                    dmax12 = bwdata12[n - ipert].bps;
+                }
+#ifdef CREATE_SINGLE_CURVE
+                if (bwdata012[n - ipert].bps > dmax012) {
+                    index012 = ipert;
+                    dmax012 = bwdata012[n - ipert].bps;
+                }
+#endif
+            }
+            /* get the left stuff out */
+            MPI_Bcast(&index01, 1, MPI_INT, g_left_rank, MPI_COMM_WORLD);
+            MPI_Bcast(&bwdata01[n - index01].bits, 1, MPI_INT, g_left_rank, MPI_COMM_WORLD);
+            MPI_Bcast(&bwdata01[n - index01].bps, 1, MPI_DOUBLE, g_left_rank, MPI_COMM_WORLD);
+            MPI_Bcast(&bwdata01[n - index01].t, 1, MPI_DOUBLE, g_left_rank, MPI_COMM_WORLD);
+            /* get the right stuff out */
+            MPI_Bcast(&index12, 1, MPI_INT, g_middle_rank, MPI_COMM_WORLD);
+            MPI_Bcast(&bwdata12[n - index12].bps, 1, MPI_DOUBLE, g_middle_rank, MPI_COMM_WORLD);
+            MPI_Bcast(&bwdata12[n - index12].t, 1, MPI_DOUBLE, g_middle_rank, MPI_COMM_WORLD);
+            if (g_nIproc == 0) {
+                if (bUseMegaBytes) {
+                    fprintf(out, "%d\t%f\t%0.9f\t", bwdata01[n - index01].bits / 8,
+                            bwdata01[n - index01].bps / 8, bwdata01[n - index01].t);
+                    fprintf(out, "%f\t%0.9f\t", bwdata12[n - index12].bps / 8,
+                            bwdata12[n - index12].t);
+#ifdef CREATE_SINGLE_CURVE
+                    fprintf(out, "%f\t%0.9f\n", bwdata012[n - index012].bps / 8,
+                            bwdata012[n - index012].t);
+#endif
+                } else {
+                    fprintf(out, "%d\t%f\t%0.9f\t", bwdata01[n - index01].bits / 8,
+                            bwdata01[n - index01].bps, bwdata01[n - index01].t);
+                    fprintf(out, "%f\t%0.9f\t", bwdata12[n - index12].bps, bwdata12[n - index12].t);
+#ifdef CREATE_SINGLE_CURVE
+                    fprintf(out, "%f\t%0.9f\n", bwdata012[n - index012].bps,
+                            bwdata012[n - index012].t);
+#endif
+                }
+#ifdef CREATE_DIFFERENCE_CURVES
+                for (itrial = 0; itrial < ntrials && dtrials[itrial] != LONGTIME; itrial++) {
+                    fprintf(out, "%0.9f\t", dtrials[itrial]);
+                }
+                fprintf(out, "\n");
+#endif
+                fflush(out);
+            }
+        }
+    }   /* End of main loop  */
+
+    if (g_nIproc == 0)
+        fclose(out);
+    /* THE_END:          */
+    MPI_Finalize();
+    free(bwdata01);
+    free(bwdata12);
+    free(bwdata012);
+    return 0;
+}
+
+int Setup(int middle_rank, ArgStruct * p01, ArgStruct * p12, ArgStruct * p012)
+{
+    char s[255];
+    int len = 255;
+
+    p01->iproc = p12->iproc = p012->iproc = g_nIproc;
+
+    MPI_Get_processor_name(s, &len);
+    /*gethostname(s, len); */
+    printf("%d: %s\n", p01->iproc, s);
+    fflush(stdout);
+
+    switch (middle_rank) {
+        case 0:
+            switch (g_nIproc) {
+                case 0:
+                    g_proc_loc = MIDDLE_PROCESS;
+                    p01->nbor = 2;
+                    p01->tr = FALSE;
+                    p12->nbor = 1;
+                    p12->tr = TRUE;
+                    p012->nbor = 2;
+                    p012->nbor2 = 1;
+                    break;
+                case 1:
+                    g_proc_loc = RIGHT_PROCESS;
+                    p01->nbor = -1;
+                    p01->tr = FALSE;
+                    p12->nbor = 0;
+                    p12->tr = FALSE;
+                    p012->nbor = 0;
+                    p012->nbor2 = -1;
+                    break;
+                case 2:
+                    g_proc_loc = LEFT_PROCESS;
+                    p01->nbor = 0;
+                    p01->tr = TRUE;
+                    p12->nbor = -1;
+                    p12->tr = FALSE;
+                    p012->nbor = 0;
+                    p012->nbor2 = -1;
+                    break;
+            }
+            g_left_rank = 2;
+            g_middle_rank = 0;
+            g_right_rank = 1;
+            break;
+        case 1:
+            switch (g_nIproc) {
+                case 0:
+                    g_proc_loc = LEFT_PROCESS;
+                    p01->nbor = 1;
+                    p01->tr = TRUE;
+                    p12->nbor = -1;
+                    p12->tr = FALSE;
+                    p012->nbor = 1;
+                    p012->nbor2 = -1;
+                    break;
+                case 1:
+                    g_proc_loc = MIDDLE_PROCESS;
+                    p01->nbor = 0;
+                    p01->tr = FALSE;
+                    p12->nbor = 2;
+                    p12->tr = TRUE;
+                    p012->nbor = 0;
+                    p012->nbor2 = 2;
+                    break;
+                case 2:
+                    g_proc_loc = RIGHT_PROCESS;
+                    p01->nbor = -1;
+                    p01->tr = FALSE;
+                    p12->nbor = 1;
+                    p12->tr = FALSE;
+                    p012->nbor = 1;
+                    p012->nbor2 = -1;
+                    break;
+            }
+            g_left_rank = 0;
+            g_middle_rank = 1;
+            g_right_rank = 2;
+            break;
+        case 2:
+            switch (g_nIproc) {
+                case 0:
+                    g_proc_loc = RIGHT_PROCESS;
+                    p01->nbor = -1;
+                    p01->tr = FALSE;
+                    p12->nbor = 2;
+                    p12->tr = FALSE;
+                    p012->nbor = 2;
+                    p012->nbor2 = -1;
+                    break;
+                case 1:
+                    g_proc_loc = LEFT_PROCESS;
+                    p01->nbor = 2;
+                    p01->tr = TRUE;
+                    p12->nbor = -1;
+                    p12->tr = FALSE;
+                    p012->nbor = 2;
+                    p012->nbor2 = -1;
+                    break;
+                case 2:
+                    g_proc_loc = MIDDLE_PROCESS;
+                    p01->nbor = 1;
+                    p01->tr = FALSE;
+                    p12->nbor = 0;
+                    p12->tr = TRUE;
+                    p012->nbor = 1;
+                    p012->nbor2 = 0;
+                    break;
+            }
+            g_left_rank = 1;
+            g_middle_rank = 2;
+            g_right_rank = 0;
+            break;
+    }
+
+    return 1;
+}
+
+void Sync(ArgStruct * p)
+{
+    MPI_Status status;
+    if (p->tr) {
+        MPI_Send(NULL, 0, MPI_BYTE, p->nbor, 1, MPI_COMM_WORLD);
+        MPI_Recv(NULL, 0, MPI_BYTE, p->nbor, 1, MPI_COMM_WORLD, &status);
+        MPI_Send(NULL, 0, MPI_BYTE, p->nbor, 1, MPI_COMM_WORLD);
+    } else {
+        MPI_Recv(NULL, 0, MPI_BYTE, p->nbor, 1, MPI_COMM_WORLD, &status);
+        MPI_Send(NULL, 0, MPI_BYTE, p->nbor, 1, MPI_COMM_WORLD);
+        MPI_Recv(NULL, 0, MPI_BYTE, p->nbor, 1, MPI_COMM_WORLD, &status);
+    }
+}
+
+void Sync012(ArgStruct * p)
+{
+    MPI_Status status;
+    switch (g_proc_loc) {
+        case LEFT_PROCESS:
+            MPI_Send(NULL, 0, MPI_BYTE, p->nbor, 1, MPI_COMM_WORLD);
+            MPI_Recv(NULL, 0, MPI_BYTE, p->nbor, 1, MPI_COMM_WORLD, &status);
+            MPI_Send(NULL, 0, MPI_BYTE, p->nbor, 1, MPI_COMM_WORLD);
+            break;
+        case MIDDLE_PROCESS:
+            MPI_Recv(NULL, 0, MPI_BYTE, p->nbor, 1, MPI_COMM_WORLD, &status);
+            MPI_Send(NULL, 0, MPI_BYTE, p->nbor2, 1, MPI_COMM_WORLD);
+            MPI_Recv(NULL, 0, MPI_BYTE, p->nbor2, 1, MPI_COMM_WORLD, &status);
+            MPI_Send(NULL, 0, MPI_BYTE, p->nbor, 1, MPI_COMM_WORLD);
+            MPI_Recv(NULL, 0, MPI_BYTE, p->nbor, 1, MPI_COMM_WORLD, &status);
+            MPI_Send(NULL, 0, MPI_BYTE, p->nbor2, 1, MPI_COMM_WORLD);
+            break;
+        case RIGHT_PROCESS:
+            MPI_Recv(NULL, 0, MPI_BYTE, p->nbor, 1, MPI_COMM_WORLD, &status);
+            MPI_Send(NULL, 0, MPI_BYTE, p->nbor, 1, MPI_COMM_WORLD);
+            MPI_Recv(NULL, 0, MPI_BYTE, p->nbor, 1, MPI_COMM_WORLD, &status);
+            break;
+    }
+}
+
+int DetermineLatencyReps(ArgStruct * p)
+{
+    MPI_Status status;
+    double t0, duration = 0;
+    int reps = 1, prev_reps = 0;
+    int i;
+
+    /* prime the send/receive pipes */
+    Sync(p);
+    Sync(p);
+    Sync(p);
+
+    /* test how long it takes to send n messages
+     * where n = 1, 2, 4, 8, 16, 32, ...
+     */
+    t0 = MPI_Wtime();
+    t0 = MPI_Wtime();
+    t0 = MPI_Wtime();
+    while ((duration < RUNTM) || (duration < MAX_LAT_TIME && reps < 1000)) {
+        t0 = MPI_Wtime();
+        for (i = 0; i < reps - prev_reps; i++) {
+            Sync(p);
+        }
+        duration += MPI_Wtime() - t0;
+        prev_reps = reps;
+        reps = reps * 2;
+
+        /* use duration from the root only */
+        if (p->tr)
+            MPI_Send(&duration, 1, MPI_DOUBLE, p->nbor, 2, MPI_COMM_WORLD);
+        else
+            MPI_Recv(&duration, 1, MPI_DOUBLE, p->nbor, 2, MPI_COMM_WORLD, &status);
+    }
+
+    return reps;
+}
+
+int DetermineLatencyReps012(ArgStruct * p)
+{
+    double t0, duration = 0;
+    int reps = 1, prev_reps = 0;
+    int i;
+
+    /* prime the send/receive pipes */
+    Sync012(p);
+    Sync012(p);
+    Sync012(p);
+
+    /* test how long it takes to send n messages
+     * where n = 1, 2, 4, 8, 16, 32, ...
+     */
+    t0 = MPI_Wtime();
+    t0 = MPI_Wtime();
+    t0 = MPI_Wtime();
+    while ((duration < RUNTM) || (duration < MAX_LAT_TIME && reps < 1000)) {
+        t0 = MPI_Wtime();
+        for (i = 0; i < reps - prev_reps; i++) {
+            Sync012(p);
+        }
+        duration += MPI_Wtime() - t0;
+        prev_reps = reps;
+        reps = reps * 2;
+
+        /* use duration from the root only */
+        MPI_Bcast(&duration, 1, MPI_DOUBLE, g_left_rank, MPI_COMM_WORLD);
+    }
+
+    return reps;
+}
+
+double TestLatency(ArgStruct * p)
+{
+    double latency, t0, min_latency = LONGTIME;
+    int i, j;
+    MPI_Status status;
+    char str[100];
+
+    /* calculate the latency between rank 0 and rank 1 */
+    p->latency_reps = DetermineLatencyReps(p);
+    if (/*p->latency_reps < 1024 && */ p->tr) {
+        if (g_proc_loc == LEFT_PROCESS) {
+            sprintf(str, "%d <-> %d      ", p->iproc, p->nbor);
+        } else {
+            sprintf(str, "      %d <-> %d", p->iproc, p->nbor);
+        }
+        /*printf("To determine %s latency, using %d reps\n", p->iproc == 0 ? "0 -> 1     " : "     1 -> 2", p->latency_reps); */
+        printf("To determine %s latency, using %d reps.\n", str, p->latency_reps);
+        fflush(stdout);
+    }
+
+    for (j = 0; j < TRIALS; j++) {
+        Sync(p);
+        t0 = MPI_Wtime();
+        t0 = MPI_Wtime();
+        t0 = MPI_Wtime();
+        t0 = MPI_Wtime();
+        for (i = 0; i < p->latency_reps; i++) {
+            if (p->tr) {
+                MPI_Send(NULL, 0, MPI_BYTE, p->nbor, 1, MPI_COMM_WORLD);
+                MPI_Recv(NULL, 0, MPI_BYTE, p->nbor, 1, MPI_COMM_WORLD, &status);
+            } else {
+                MPI_Recv(NULL, 0, MPI_BYTE, p->nbor, 1, MPI_COMM_WORLD, &status);
+                MPI_Send(NULL, 0, MPI_BYTE, p->nbor, 1, MPI_COMM_WORLD);
+            }
+        }
+        latency = (MPI_Wtime() - t0) / (2 * p->latency_reps);
+        min_latency = MIN(min_latency, latency);
+    }
+
+    return min_latency;
+}
+
+double TestLatency012(ArgStruct * p)
+{
+    double latency, t0, min_latency = LONGTIME;
+    int i, j;
+    MPI_Status status;
+
+    g_latency012_reps = DetermineLatencyReps012(p);
+    if (g_proc_loc == MIDDLE_PROCESS) {
+        printf("To determine %d <-- %d --> %d latency, using %d reps\n", p->nbor, p->iproc,
+               p->nbor2, g_latency012_reps);
+        fflush(stdout);
+    }
+
+    for (j = 0; j < TRIALS; j++) {
+        Sync012(p);
+        t0 = MPI_Wtime();
+        t0 = MPI_Wtime();
+        t0 = MPI_Wtime();
+        t0 = MPI_Wtime();
+        for (i = 0; i < g_latency012_reps; i++) {
+            switch (g_proc_loc) {
+                case LEFT_PROCESS:
+                    MPI_Send(NULL, 0, MPI_BYTE, p->nbor, 1, MPI_COMM_WORLD);
+                    MPI_Recv(NULL, 0, MPI_BYTE, p->nbor, 1, MPI_COMM_WORLD, &status);
+                    break;
+                case MIDDLE_PROCESS:
+                    MPI_Recv(NULL, 0, MPI_BYTE, p->nbor, 1, MPI_COMM_WORLD, &status);
+                    MPI_Send(NULL, 0, MPI_BYTE, p->nbor2, 1, MPI_COMM_WORLD);
+                    MPI_Recv(NULL, 0, MPI_BYTE, p->nbor2, 1, MPI_COMM_WORLD, &status);
+                    MPI_Send(NULL, 0, MPI_BYTE, p->nbor, 1, MPI_COMM_WORLD);
+                    break;
+                case RIGHT_PROCESS:
+                    MPI_Recv(NULL, 0, MPI_BYTE, p->nbor, 1, MPI_COMM_WORLD, &status);
+                    MPI_Send(NULL, 0, MPI_BYTE, p->nbor, 1, MPI_COMM_WORLD);
+                    break;
+            }
+        }
+        latency = (MPI_Wtime() - t0) / (2 * g_latency012_reps);
+        min_latency = MIN(min_latency, latency);
+    }
+
+    return min_latency;
+}
+
+void SendTime(ArgStruct * p, double *t)
+{
+    MPI_Send(t, 1, MPI_DOUBLE, p->nbor, 2, MPI_COMM_WORLD);
+}
+
+void RecvTime(ArgStruct * p, double *t)
+{
+    MPI_Status status;
+    MPI_Recv(t, 1, MPI_DOUBLE, p->nbor, 2, MPI_COMM_WORLD, &status);
+}
+
+void SendReps(ArgStruct * p, int *rpt)
+{
+    MPI_Send(rpt, 1, MPI_INT, p->nbor, 2, MPI_COMM_WORLD);
+}
+
+void RecvReps(ArgStruct * p, int *rpt)
+{
+    MPI_Status status;
+    MPI_Recv(rpt, 1, MPI_INT, p->nbor, 2, MPI_COMM_WORLD, &status);
+}

--- a/t/mpi/mpich_basic/netmpi.c
+++ b/t/mpi/mpich_basic/netmpi.c
@@ -1,0 +1,667 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#ifdef HAVE_WINDOWS_H
+#include <winsock2.h>
+#include <windows.h>
+#endif
+#include <stdio.h>
+#include <stdlib.h>
+#include "mpi.h"
+#include "GetOpt.h"
+#include <string.h>
+
+#ifndef BOOL
+typedef int BOOL;
+#endif
+#ifndef TRUE
+#define TRUE 1
+#endif
+#ifndef FALSE
+#define FALSE 0
+#endif
+
+#define  TRIALS 	3
+#define  REPEAT 	1000
+int g_NSAMP = 250;
+#define  PERT		3
+/*#define  LATENCYREPS	1000*/
+int g_LATENCYREPS = 1000;
+#define  LONGTIME	1e99
+#define  CHARSIZE	8
+#define  PATIENCE	50
+#define  RUNTM		0.25
+double g_STOPTM = 0.1;
+#define  MAXINT 	2147483647
+
+#define ABS(x)		(((x) < 0)?(-(x)):(x))
+#define MIN(x, y)	(((x) < (y))?(x):(y))
+#define MAX(x, y)	(((x) > (y))?(x):(y))
+
+int g_nIproc = 0, g_nNproc = 0;
+
+typedef struct protocolstruct ProtocolStruct;
+struct protocolstruct {
+    int nbor, iproc;
+};
+
+typedef struct argstruct ArgStruct;
+struct argstruct {
+    /* This is the common information that is needed for all tests      */
+    char *host;                 /* Name of receiving host                       */
+    char *buff;                 /* Transmitted buffer                           */
+    char *buff1;                /* Transmitted buffer                           */
+    size_t bufflen;             /* Length of transmitted buffer                 */
+    int tr,                     /* Transmit flag                                */
+     nbuff;                     /* Number of buffers to transmit                */
+
+    /* Now we work with a union of information for protocol dependent stuff */
+    ProtocolStruct prot;        /* Structure holding necessary info for TCP */
+};
+
+typedef struct data Data;
+struct data {
+    double t;
+    double bps;
+    double variance;
+    int bits;
+    int repeat;
+};
+
+double When(void);
+int Setup(ArgStruct * p);
+void Sync(ArgStruct * p);
+void SendData(ArgStruct * p);
+void RecvData(ArgStruct * p);
+void SendRecvData(ArgStruct * p);
+void SendTime(ArgStruct * p, double *t, int *rpt);
+void RecvTime(ArgStruct * p, double *t, int *rpt);
+int Establish(ArgStruct * p);
+int CleanUp(ArgStruct * p);
+double TestLatency(ArgStruct * p);
+double TestSyncTime(ArgStruct * p);
+void PrintOptions(void);
+int DetermineLatencyReps(ArgStruct * p);
+
+void PrintOptions()
+{
+    printf("\n");
+    printf("Usage: netpipe flags\n");
+    printf(" flags:\n");
+    printf("       -reps #iterations\n");
+    printf("       -time stop_time\n");
+    printf("       -start initial_msg_size\n");
+    printf("       -end final_msg_size\n");
+    printf("       -out outputfile\n");
+    printf("       -nocache\n");
+    printf("       -headtohead\n");
+    printf("       -pert\n");
+    printf("       -noprint\n");
+    printf("       -onebuffer largest_buffer_size\n");
+    printf("Requires exactly two processes\n");
+    printf("\n");
+}
+
+int main(int argc, char *argv[])
+{
+    FILE *out = 0;              /* Output data file                     */
+    char s[255];                /* Generic string                       */
+    char *memtmp;
+    char *memtmp1;
+
+    int i, j, n, nq,            /* Loop indices                         */
+     bufoffset = 0,             /* Align buffer to this                 */
+        bufalign = 16 * 1024,   /* Boundary to align buffer to          */
+        nrepeat,        /* Number of time to do the transmission */
+        nzero = 0, inc = 1,     /* Increment value                      */
+        detailflag = 0, /* Set to examine the signature curve detail */
+        pert,   /* Perturbation value                   */
+        ipert,  /* index of the perturbation loop       */
+        start = 0,      /* Starting value for signature curve   */
+        end = MAXINT,   /* Ending value for signature curve     */
+        streamopt = 0,  /* Streaming mode flag                  */
+        printopt = 1;   /* Debug print statements flag          */
+    int one_buffer = 0;
+    int onebuffersize = 100 * 1024 * 1024;
+    int quit = 0;
+    size_t len;                 /* Number of bytes to be transmitted    */
+
+    ArgStruct args;             /* Argumentsfor all the calls           */
+
+    double t, t0, t1, t2,       /* Time variables                       */
+     tlast,                     /* Time for the last transmission       */
+     tzero = 0, latency,        /* Network message latency              */
+        synctime;       /* Network synchronization time         */
+
+    Data *bwdata;               /* Bandwidth curve data                 */
+
+    BOOL bNoCache = FALSE;
+    BOOL bHeadToHead = FALSE;
+    BOOL bSavePert = FALSE;
+    BOOL bUseMegaBytes = FALSE;
+
+    MPI_Init(&argc, &argv);
+
+    MPI_Comm_size(MPI_COMM_WORLD, &g_nNproc);
+    MPI_Comm_rank(MPI_COMM_WORLD, &g_nIproc);
+
+    if (g_nNproc != 2) {
+        if (g_nIproc == 0)
+            PrintOptions();
+        MPI_Finalize();
+        exit(0);
+    }
+
+    GetOptDouble(&argc, &argv, "-time", &g_STOPTM);
+    GetOptInt(&argc, &argv, "-reps", &g_NSAMP);
+    GetOptInt(&argc, &argv, "-start", &start);
+    GetOptInt(&argc, &argv, "-end", &end);
+    one_buffer = GetOptInt(&argc, &argv, "-onebuffer", &onebuffersize);
+    if (one_buffer) {
+        if (onebuffersize < 1) {
+            one_buffer = 0;
+        } else {
+            onebuffersize += bufalign;
+        }
+    }
+    bNoCache = GetOpt(&argc, &argv, "-nocache");
+    bHeadToHead = GetOpt(&argc, &argv, "-headtohead");
+    bUseMegaBytes = GetOpt(&argc, &argv, "-mb");
+    if (GetOpt(&argc, &argv, "-noprint"))
+        printopt = 0;
+    bSavePert = GetOpt(&argc, &argv, "-pert");
+
+    bwdata = malloc((g_NSAMP + 1) * sizeof(Data));
+
+    if (g_nIproc == 0)
+        strcpy(s, "Netpipe.out");
+    GetOptString(&argc, &argv, "-out", s);
+
+    if (start > end) {
+        fprintf(stdout, "Start MUST be LESS than end\n");
+        exit(420132);
+    }
+
+    args.nbuff = TRIALS;
+
+    Setup(&args);
+    Establish(&args);
+
+    if (args.tr) {
+        if ((out = fopen(s, "w")) == NULL) {
+            fprintf(stdout, "Can't open %s for output\n", s);
+            exit(1);
+        }
+    }
+
+    latency = TestLatency(&args);
+    synctime = TestSyncTime(&args);
+
+
+    if (args.tr) {
+        SendTime(&args, &latency, &nzero);
+    } else {
+        RecvTime(&args, &latency, &nzero);
+    }
+    if (args.tr && printopt) {
+        printf("Latency: %0.9f\n", latency);
+        fflush(stdout);
+        printf("Sync Time: %0.9f\n", synctime);
+        fflush(stdout);
+        printf("Now starting main loop\n");
+        fflush(stdout);
+    }
+    tlast = latency;
+    inc = (start > 1 && !detailflag) ? start / 2 : inc;
+    args.bufflen = start;
+
+    if (one_buffer) {
+        args.buff = (char *) malloc(onebuffersize);
+        args.buff1 = (char *) malloc(onebuffersize);
+    }
+
+    /* Main loop of benchmark */
+    for (nq = n = 0, len = start;
+         n < g_NSAMP && tlast < g_STOPTM && len <= end && !quit; len = len + inc, nq++) {
+        if (nq > 2 && !detailflag)
+            inc = ((nq % 2)) ? inc + inc : inc;
+
+        /* This is a perturbation loop to test nearby values */
+        for (ipert = 0, pert = (!detailflag && inc > PERT + 1) ? -PERT : 0;
+             pert <= PERT && !quit;
+             ipert++, n++, pert += (!detailflag && inc > PERT + 1) ? PERT : PERT + 1) {
+
+            /* Calculate howmany times to repeat the experiment. */
+            if (args.tr) {
+                if (args.bufflen == 0)
+                    nrepeat = g_LATENCYREPS;
+                else
+                    nrepeat = (int) (MAX((RUNTM / ((double) args.bufflen /
+                                                   (args.bufflen - inc + 1.0) * tlast)), TRIALS));
+                SendTime(&args, &tzero, &nrepeat);
+            } else {
+                nrepeat = 1;    /* Just needs to be greater than zero */
+                RecvTime(&args, &tzero, &nrepeat);
+            }
+
+            /* Allocate the buffer */
+            args.bufflen = len + pert;
+            if (one_buffer) {
+                if (bNoCache) {
+                    if (args.bufflen * nrepeat + bufalign > onebuffersize) {
+                        fprintf(stdout, "Exceeded user specified buffer size\n");
+                        fflush(stdout);
+                        quit = 1;
+                        break;
+                    }
+                } else {
+                    if (args.bufflen + bufalign > onebuffersize) {
+                        fprintf(stdout, "Exceeded user specified buffer size\n");
+                        fflush(stdout);
+                        quit = 1;
+                        break;
+                    }
+                }
+            } else {
+                /* printf("allocating %d bytes\n",
+                 * args.bufflen * nrepeat + bufalign); */
+                if (bNoCache) {
+                    if ((args.buff =
+                         (char *) malloc(args.bufflen * nrepeat + bufalign)) == (char *) NULL) {
+                        fprintf(stdout, "Couldn't allocate memory\n");
+                        fflush(stdout);
+                        break;
+                    }
+                } else {
+                    if ((args.buff = (char *) malloc(args.bufflen + bufalign)) == (char *) NULL) {
+                        fprintf(stdout, "Couldn't allocate memory\n");
+                        fflush(stdout);
+                        break;
+                    }
+                }
+                /* if ((args.buff1 = (char *)malloc(args.bufflen * nrepeat + bufalign)) == (char *)NULL) */
+                if ((args.buff1 = (char *) malloc(args.bufflen + bufalign)) == (char *) NULL) {
+                    fprintf(stdout, "Couldn't allocate memory\n");
+                    fflush(stdout);
+                    break;
+                }
+            }
+            /* Possibly align the data buffer */
+            memtmp = args.buff;
+            memtmp1 = args.buff1;
+
+            if (!bNoCache) {
+                if (bufalign != 0) {
+                    args.buff +=
+                        (bufalign - ((MPI_Aint) args.buff % bufalign) + bufoffset) % bufalign;
+                    /* args.buff1 += (bufalign - ((MPI_Aint)args.buff1 % bufalign) + bufoffset) % bufalign; */
+                }
+            }
+            args.buff1 += (bufalign - ((MPI_Aint) args.buff1 % bufalign) + bufoffset) % bufalign;
+
+            if (args.tr && printopt) {
+                fprintf(stdout, "%3d: %9zu bytes %4d times --> ", n, args.bufflen, nrepeat);
+                fflush(stdout);
+            }
+
+            /* Finally, we get to transmit or receive and time */
+            if (args.tr) {
+                bwdata[n].t = LONGTIME;
+                t2 = t1 = 0;
+                for (i = 0; i < TRIALS; i++) {
+                    if (bNoCache) {
+                        if (bufalign != 0) {
+                            args.buff =
+                                memtmp +
+                                ((bufalign - ((MPI_Aint) args.buff % bufalign) +
+                                  bufoffset) % bufalign);
+                            /* args.buff1 = memtmp1 + ((bufalign - ((MPI_Aint)args.buff1 % bufalign) + bufoffset) % bufalign); */
+                        } else {
+                            args.buff = memtmp;
+                            /* args.buff1 = memtmp1; */
+                        }
+                    }
+
+                    Sync(&args);
+                    t0 = When();
+                    for (j = 0; j < nrepeat; j++) {
+                        if (bHeadToHead)
+                            SendRecvData(&args);
+                        else {
+                            SendData(&args);
+                            if (!streamopt) {
+                                RecvData(&args);
+                            }
+                        }
+                        if (bNoCache) {
+                            args.buff += args.bufflen;
+                            /* args.buff1 += args.bufflen; */
+                        }
+                    }
+                    t = (When() - t0) / ((1 + !streamopt) * nrepeat);
+
+                    if (!streamopt) {
+                        t2 += t * t;
+                        t1 += t;
+                        bwdata[n].t = MIN(bwdata[n].t, t);
+                    }
+                }
+                if (!streamopt)
+                    SendTime(&args, &bwdata[n].t, &nzero);
+                else
+                    RecvTime(&args, &bwdata[n].t, &nzero);
+
+                if (!streamopt)
+                    bwdata[n].variance = t2 / TRIALS - t1 / TRIALS * t1 / TRIALS;
+
+            } else {
+                bwdata[n].t = LONGTIME;
+                t2 = t1 = 0;
+                for (i = 0; i < TRIALS; i++) {
+                    if (bNoCache) {
+                        if (bufalign != 0) {
+                            args.buff =
+                                memtmp +
+                                ((bufalign - ((MPI_Aint) args.buff % bufalign) +
+                                  bufoffset) % bufalign);
+                            /* args.buff1 = memtmp1 + ((bufalign - ((MPI_Aint)args.buff1 % bufalign) + bufoffset) % bufalign); */
+                        } else {
+                            args.buff = memtmp;
+                            /* args.buff1 = memtmp1; */
+                        }
+                    }
+
+                    Sync(&args);
+                    t0 = When();
+                    for (j = 0; j < nrepeat; j++) {
+                        if (bHeadToHead)
+                            SendRecvData(&args);
+                        else {
+                            RecvData(&args);
+                            if (!streamopt)
+                                SendData(&args);
+                        }
+                        if (bNoCache) {
+                            args.buff += args.bufflen;
+                            /* args.buff1 += args.bufflen; */
+                        }
+                    }
+                    t = (When() - t0) / ((1 + !streamopt) * nrepeat);
+
+                    if (streamopt) {
+                        t2 += t * t;
+                        t1 += t;
+                        bwdata[n].t = MIN(bwdata[n].t, t);
+                    }
+                }
+                if (streamopt)
+                    SendTime(&args, &bwdata[n].t, &nzero);
+                else
+                    RecvTime(&args, &bwdata[n].t, &nzero);
+
+                if (streamopt)
+                    bwdata[n].variance = t2 / TRIALS - t1 / TRIALS * t1 / TRIALS;
+            }
+            tlast = bwdata[n].t;
+            bwdata[n].bits = args.bufflen * CHARSIZE;
+            bwdata[n].bps = bwdata[n].bits / (bwdata[n].t * 1024 * 1024);
+            bwdata[n].repeat = nrepeat;
+
+            if (args.tr) {
+                if (bSavePert) {
+                    /* fprintf(out,"%f\t%f\t%d\t%d\t%f\n", bwdata[n].t, bwdata[n].bps,
+                     * bwdata[n].bits, bwdata[n].bits / 8, bwdata[n].variance); */
+                    if (bUseMegaBytes)
+                        fprintf(out, "%d\t%f\t%0.9f\n", bwdata[n].bits / 8, bwdata[n].bps / 8,
+                                bwdata[n].t);
+                    else
+                        fprintf(out, "%d\t%f\t%0.9f\n", bwdata[n].bits / 8, bwdata[n].bps,
+                                bwdata[n].t);
+                    fflush(out);
+                }
+            }
+            if (!one_buffer) {
+                free(memtmp);
+                free(memtmp1);
+            }
+            if (args.tr && printopt) {
+                if (bUseMegaBytes)
+                    fprintf(stdout, " %6.2f MBps in %0.9f sec\n", bwdata[n].bps / 8, tlast);
+                else
+                    fprintf(stdout, " %6.2f Mbps in %0.9f sec\n", bwdata[n].bps, tlast);
+                fflush(stdout);
+            }
+        }       /* End of perturbation loop */
+        if (!bSavePert && args.tr) {
+            /* if we didn't save all of the perturbation loops, find the max and save it */
+            int index = 1;
+            double dmax = bwdata[n - 1].bps;
+            for (; ipert > 1; ipert--) {
+                if (bwdata[n - ipert].bps > dmax) {
+                    index = ipert;
+                    dmax = bwdata[n - ipert].bps;
+                }
+            }
+            if (bUseMegaBytes)
+                fprintf(out, "%d\t%f\t%0.9f\n", bwdata[n - index].bits / 8,
+                        bwdata[n - index].bps / 8, bwdata[n - index].t);
+            else
+                fprintf(out, "%d\t%f\t%0.9f\n", bwdata[n - index].bits / 8, bwdata[n - index].bps,
+                        bwdata[n - index].t);
+            fflush(out);
+        }
+    }   /* End of main loop  */
+
+    if (args.tr)
+        fclose(out);
+    /* THE_END:          */
+    CleanUp(&args);
+    free(bwdata);
+    return 0;
+}
+
+
+/* Return the current time in seconds, using a double precision number. 	 */
+double When()
+{
+    return MPI_Wtime();
+}
+
+int Setup(ArgStruct * p)
+{
+    int nproc;
+    char s[255];
+    int len = 255;
+
+    MPI_Comm_rank(MPI_COMM_WORLD, &p->prot.iproc);
+    MPI_Comm_size(MPI_COMM_WORLD, &nproc);
+
+    MPI_Get_processor_name(s, &len);
+    /*gethostname(s, len); */
+    printf("%d: %s\n", p->prot.iproc, s);
+    fflush(stdout);
+
+    if (p->prot.iproc == 0)
+        p->prot.nbor = 1;
+    else
+        p->prot.nbor = 0;
+
+    if (nproc < 2) {
+        printf("Need two processes\n");
+        printf("nproc: %i\n", nproc);
+        exit(-2);
+    }
+
+    if (p->prot.iproc == 0)
+        p->tr = 1;
+    else
+        p->tr = 0;
+    return 1;
+}
+
+void Sync(ArgStruct * p)
+{
+    char ch;
+    MPI_Status status;
+    if (p->tr) {
+        MPI_Send(&ch, 0, MPI_BYTE, p->prot.nbor, 1, MPI_COMM_WORLD);
+        MPI_Recv(&ch, 0, MPI_BYTE, p->prot.nbor, 1, MPI_COMM_WORLD, &status);
+        MPI_Send(&ch, 0, MPI_BYTE, p->prot.nbor, 1, MPI_COMM_WORLD);
+    } else {
+        MPI_Recv(&ch, 0, MPI_BYTE, p->prot.nbor, 1, MPI_COMM_WORLD, &status);
+        MPI_Send(&ch, 0, MPI_BYTE, p->prot.nbor, 1, MPI_COMM_WORLD);
+        MPI_Recv(&ch, 0, MPI_BYTE, p->prot.nbor, 1, MPI_COMM_WORLD, &status);
+    }
+}
+
+int DetermineLatencyReps(ArgStruct * p)
+{
+    MPI_Status status;
+    double t0, duration = 0;
+    int reps = 1, prev_reps = 0;
+    int i;
+
+    /* prime the send/receive pipes */
+    Sync(p);
+    Sync(p);
+    Sync(p);
+
+    /* test how long it takes to send n messages
+     * where n = 1, 2, 4, 8, 16, 32, ...
+     */
+    t0 = When();
+    t0 = When();
+    t0 = When();
+    while ((duration < 1) || (duration < 3 && reps < 1000)) {
+        t0 = When();
+        for (i = 0; i < reps - prev_reps; i++) {
+            Sync(p);
+        }
+        duration += When() - t0;
+        prev_reps = reps;
+        reps = reps * 2;
+
+        /* use duration from the root only */
+        if (p->prot.iproc == 0)
+            MPI_Send(&duration, 1, MPI_DOUBLE, p->prot.nbor, 2, MPI_COMM_WORLD);
+        else
+            MPI_Recv(&duration, 1, MPI_DOUBLE, p->prot.nbor, 2, MPI_COMM_WORLD, &status);
+    }
+
+    return reps;
+}
+
+double TestLatency(ArgStruct * p)
+{
+    double latency, t0;
+    int i;
+
+    g_LATENCYREPS = DetermineLatencyReps(p);
+    if (g_LATENCYREPS < 1024 && p->prot.iproc == 0) {
+        printf("Using %d reps to determine latency\n", g_LATENCYREPS);
+        fflush(stdout);
+    }
+
+    p->bufflen = 0;
+    p->buff = NULL;     /*(char *)malloc(p->bufflen); */
+    p->buff1 = NULL;    /*(char *)malloc(p->bufflen); */
+    Sync(p);
+    t0 = When();
+    t0 = When();
+    t0 = When();
+    t0 = When();
+    for (i = 0; i < g_LATENCYREPS; i++) {
+        if (p->tr) {
+            SendData(p);
+            RecvData(p);
+        } else {
+            RecvData(p);
+            SendData(p);
+        }
+    }
+    latency = (When() - t0) / (2 * g_LATENCYREPS);
+    /*
+     * free(p->buff);
+     * free(p->buff1);
+     */
+
+    return latency;
+}
+
+double TestSyncTime(ArgStruct * p)
+{
+    double synctime, t0;
+    int i;
+
+    t0 = When();
+    t0 = When();
+    t0 = When();
+    t0 = When();
+    t0 = When();
+    t0 = When();
+    for (i = 0; i < g_LATENCYREPS; i++)
+        Sync(p);
+    synctime = (When() - t0) / g_LATENCYREPS;
+
+    return synctime;
+}
+
+void SendRecvData(ArgStruct * p)
+{
+    MPI_Status status;
+
+    /*MPI_Sendrecv(p->buff, p->bufflen, MPI_BYTE, p->prot.nbor, 1, p->buff1, p->bufflen, MPI_BYTE, p->prot.nbor, 1, MPI_COMM_WORLD, &status); */
+
+    MPI_Request request;
+    MPI_Irecv(p->buff1, p->bufflen, MPI_BYTE, p->prot.nbor, 1, MPI_COMM_WORLD, &request);
+    MPI_Send(p->buff, p->bufflen, MPI_BYTE, p->prot.nbor, 1, MPI_COMM_WORLD);
+    MPI_Wait(&request, &status);
+
+    /*
+     * MPI_Send(p->buff, p->bufflen, MPI_BYTE, p->prot.nbor, 1, MPI_COMM_WORLD);
+     * MPI_Recv(p->buff1, p->bufflen, MPI_BYTE, p->prot.nbor, 1, MPI_COMM_WORLD, &status);
+     */
+}
+
+void SendData(ArgStruct * p)
+{
+    MPI_Send(p->buff, p->bufflen, MPI_BYTE, p->prot.nbor, 1, MPI_COMM_WORLD);
+}
+
+void RecvData(ArgStruct * p)
+{
+    MPI_Status status;
+    MPI_Recv(p->buff1, p->bufflen, MPI_BYTE, p->prot.nbor, 1, MPI_COMM_WORLD, &status);
+}
+
+
+void SendTime(ArgStruct * p, double *t, int *rpt)
+{
+    if (*rpt > 0)
+        MPI_Send(rpt, 1, MPI_INT, p->prot.nbor, 2, MPI_COMM_WORLD);
+    else
+        MPI_Send(t, 1, MPI_DOUBLE, p->prot.nbor, 2, MPI_COMM_WORLD);
+}
+
+void RecvTime(ArgStruct * p, double *t, int *rpt)
+{
+    MPI_Status status;
+    if (*rpt > 0)
+        MPI_Recv(rpt, 1, MPI_INT, p->prot.nbor, 2, MPI_COMM_WORLD, &status);
+    else
+        MPI_Recv(t, 1, MPI_DOUBLE, p->prot.nbor, 2, MPI_COMM_WORLD, &status);
+}
+
+int Establish(ArgStruct * p)
+{
+    return 1;
+}
+
+int CleanUp(ArgStruct * p)
+{
+    /*MPI_Barrier(MPI_COMM_WORLD); */
+    MPI_Finalize();
+    return 1;
+}

--- a/t/mpi/mpich_basic/patterns.c
+++ b/t/mpi/mpich_basic/patterns.c
@@ -1,0 +1,382 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpi.h"
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#ifndef TRUE
+#define TRUE 1
+#endif
+#ifndef FALSE
+#define FALSE 0
+#endif
+
+#define DEFAULT_RNDV_SIZE 24*1024
+/* Prototypes */
+int SendRecvTest(int, int);
+int IsendIrecvTest(int);
+int IsenIrecvTest2(int, int);
+int OutOfOrderTest(int, int);
+int ForceUnexpectedTest(int, int);
+int RndvTest(int, int, int);
+
+int SendRecvTest(int rank, int n)
+{
+    int tag = 1;
+    MPI_Status status;
+    char buffer[100];
+    int i;
+
+    if (rank == 0) {
+        strcpy(buffer, "Hello process one.");
+        for (i = 0; i < n; i++)
+            MPI_Send(buffer, 100, MPI_BYTE, 1, tag, MPI_COMM_WORLD);
+    } else if (rank == 1) {
+        for (i = 0; i < n; i++)
+            MPI_Recv(buffer, 100, MPI_BYTE, 0, tag, MPI_COMM_WORLD, &status);
+        /*printf("Rank 1: received message '%s'\n", buffer);fflush(stdout); */
+    }
+
+    return TRUE;
+}
+
+int IsendIrecvTest(int rank)
+{
+    int tag = 1;
+    MPI_Status status;
+    MPI_Request request;
+    char buffer[100];
+
+    if (rank == 0) {
+        strcpy(buffer, "Hello process one.");
+        MPI_Isend(buffer, 100, MPI_BYTE, 1, tag, MPI_COMM_WORLD, &request);
+        MPI_Wait(&request, &status);
+    } else if (rank == 1) {
+        MPI_Irecv(buffer, 100, MPI_BYTE, 0, tag, MPI_COMM_WORLD, &request);
+        MPI_Wait(&request, &status);
+        /*printf("Rank 1: received message '%s'\n", buffer);fflush(stdout); */
+    }
+
+    return TRUE;
+}
+
+int IsendIrecvTest2(int rank, int buf_size);
+int IsendIrecvTest2(int rank, int buf_size)
+{
+    int tag1 = 1;
+    int tag2 = 2;
+    MPI_Status status;
+    MPI_Request request1, request2;
+    char *buffer;
+
+    buffer = (char *) malloc(buf_size);
+    if (buffer == NULL)
+        return FALSE;
+    if (rank == 0) {
+        strcpy(buffer, "Hello process one.");
+        MPI_Isend(buffer, buf_size, MPI_BYTE, 1, tag1, MPI_COMM_WORLD, &request1);
+        MPI_Isend(buffer, buf_size, MPI_BYTE, 1, tag2, MPI_COMM_WORLD, &request2);
+        MPI_Wait(&request1, &status);
+        MPI_Wait(&request2, &status);
+    } else if (rank == 1) {
+        MPI_Irecv(buffer, buf_size, MPI_BYTE, 0, tag1, MPI_COMM_WORLD, &request1);
+        MPI_Irecv(buffer, buf_size, MPI_BYTE, 0, tag2, MPI_COMM_WORLD, &request2);
+        MPI_Wait(&request1, &status);
+        MPI_Wait(&request2, &status);
+        /*printf("Rank 1: received message '%s'\n", buffer);fflush(stdout); */
+    }
+
+    free(buffer);
+    return TRUE;
+}
+
+int OutOfOrderTest(int rank, int buf_size)
+{
+    int tag1 = 1;
+    int tag2 = 2;
+    MPI_Status status;
+    MPI_Request request1, request2;
+    char *buffer;
+
+    buffer = (char *) malloc(buf_size);
+    if (buffer == NULL)
+        return FALSE;
+    if (rank == 0) {
+        strcpy(buffer, "Hello process one.");
+        MPI_Isend(buffer, buf_size, MPI_BYTE, 1, tag1, MPI_COMM_WORLD, &request1);
+        MPI_Isend(buffer, buf_size, MPI_BYTE, 1, tag2, MPI_COMM_WORLD, &request2);
+        MPI_Wait(&request1, &status);
+        MPI_Wait(&request2, &status);
+    } else if (rank == 1) {
+        MPI_Irecv(buffer, buf_size, MPI_BYTE, 0, tag2, MPI_COMM_WORLD, &request1);
+        MPI_Irecv(buffer, buf_size, MPI_BYTE, 0, tag1, MPI_COMM_WORLD, &request2);
+        MPI_Wait(&request2, &status);
+        MPI_Wait(&request1, &status);
+        /*printf("Rank 1: received message '%s'\n", buffer);fflush(stdout); */
+    }
+
+    free(buffer);
+    return TRUE;
+}
+
+int ForceUnexpectedTest(int rank, int buf_size)
+{
+    int tag1 = 1;
+    int tag2 = 2;
+    MPI_Status status;
+    MPI_Request request1, request2;
+    char *buffer;
+
+    buffer = (char *) malloc(buf_size);
+    if (buffer == NULL)
+        return FALSE;
+
+    if (rank == 0) {
+        strcpy(buffer, "Hello process one.");
+        MPI_Isend(buffer, buf_size, MPI_BYTE, 1, tag1, MPI_COMM_WORLD, &request1);
+        MPI_Isend(buffer, buf_size, MPI_BYTE, 1, tag2, MPI_COMM_WORLD, &request2);
+        MPI_Wait(&request1, &status);
+        MPI_Wait(&request2, &status);
+        MPI_Recv(buffer, buf_size, MPI_BYTE, 1, tag1, MPI_COMM_WORLD, &status);
+    } else if (rank == 1) {
+        MPI_Irecv(buffer, buf_size, MPI_BYTE, 0, tag2, MPI_COMM_WORLD, &request2);
+        MPI_Wait(&request2, &status);
+        MPI_Irecv(buffer, buf_size, MPI_BYTE, 0, tag1, MPI_COMM_WORLD, &request1);
+        MPI_Wait(&request1, &status);
+        /*printf("Rank 1: received message '%s'\n", buffer);fflush(stdout); */
+        MPI_Send(buffer, buf_size, MPI_BYTE, 0, tag1, MPI_COMM_WORLD);
+    }
+
+    free(buffer);
+
+    return TRUE;
+}
+
+int RndvTest(int rank, int size, int reps)
+{
+    int tag = 1;
+    MPI_Status status;
+    char *buffer;
+    int i;
+
+    buffer = (char *) malloc(size);
+    if (buffer == NULL) {
+        printf("malloc failed to allocate %d bytes.\n", size);
+        exit(0);
+    }
+    if (rank == 0) {
+        for (i = 0; i < reps; i++) {
+            if (reps == 1) {
+                printf("0: sending to process 1\n");
+                fflush(stdout);
+            }
+            MPI_Send(buffer, size, MPI_BYTE, 1, tag, MPI_COMM_WORLD);
+            if (reps == 1) {
+                printf("0: receiving from process 1\n");
+                fflush(stdout);
+            }
+            MPI_Recv(buffer, size, MPI_BYTE, 1, tag, MPI_COMM_WORLD, &status);
+            if (reps == 1) {
+                printf("0: done\n");
+                fflush(stdout);
+            }
+        }
+    } else if (rank == 1) {
+        for (i = 0; i < reps; i++) {
+            if (reps == 1) {
+                printf("1: receiving from process 0\n");
+                fflush(stdout);
+            }
+            MPI_Recv(buffer, size, MPI_BYTE, 0, tag, MPI_COMM_WORLD, &status);
+            if (reps == 1) {
+                printf("1: sending to process 0\n");
+                fflush(stdout);
+            }
+            MPI_Send(buffer, size, MPI_BYTE, 0, tag, MPI_COMM_WORLD);
+            if (reps == 1) {
+                printf("1: done\n");
+                fflush(stdout);
+            }
+        }
+    }
+    free(buffer);
+
+    return TRUE;
+}
+
+int main(int argc, char *argv[])
+{
+    int result;
+    int size, rank;
+    int bDoAll = FALSE;
+    int reps;
+    int rndv_size = DEFAULT_RNDV_SIZE;
+
+    MPI_Init(&argc, &argv);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+    if (size < 2) {
+        printf("Two processes needed.\n");
+        printf("options:\n");
+        printf(" sr [reps] ............... send/recv\n");
+        printf(" isr ..................... isend/irecv\n");
+        printf(" iisr .................... isend,isend/irecv,irecv wait\n");
+        printf(" oo ...................... out of order isend/irecv\n");
+        printf(" unex .................... force unexpected msg\n");
+        printf(" rndv [size] ............. rndv\n");
+        printf(" rndv_reps [reps] [size] . rndv\n");
+        printf(" rndv_iisr [size] ........ rndv iisr\n");
+        printf(" rndv_oo [size] .......... rndv oo\n");
+        printf(" rndv_unex [size] ........ rndv unex\n");
+        printf("default rndv size = %d bytes\n", DEFAULT_RNDV_SIZE);
+        MPI_Finalize();
+        return 0;
+    }
+
+    if (rank > 1) {
+        printf("Rank %d, I am not participating.\n", rank);
+        fflush(stdout);
+    } else {
+        if (argc < 2)
+            bDoAll = TRUE;
+
+        if (bDoAll || (strcmp(argv[1], "sr") == 0)) {
+            reps = 1;
+            if (argc > 2) {
+                reps = atoi(argv[2]);
+                if (reps < 1)
+                    reps = 1;
+            }
+            if (rank == 0) {
+                printf("Send/recv test: %d reps\n", reps);
+                fflush(stdout);
+            }
+            result = SendRecvTest(rank, reps);
+            printf(result ? "%d:SUCCESS - sr\n" : "%d:FAILURE - sr\n", rank);
+            fflush(stdout);
+        }
+
+        if (bDoAll || (strcmp(argv[1], "isr") == 0)) {
+            if (rank == 0) {
+                printf("Isend/irecv wait test\n");
+                fflush(stdout);
+            }
+            result = IsendIrecvTest(rank);
+            printf(result ? "%d:SUCCESS - isr\n" : "%d:FAILURE - isr\n", rank);
+            fflush(stdout);
+        }
+
+        if (bDoAll || (strcmp(argv[1], "iisr") == 0)) {
+            if (rank == 0) {
+                printf("Isend,isend/irecv,irecv wait wait test\n");
+                fflush(stdout);
+            }
+            result = IsendIrecvTest2(rank, 100);
+            printf(result ? "%d:SUCCESS - iisr\n" : "%d:FAILURE - iisr\n", rank);
+            fflush(stdout);
+        }
+
+        if (bDoAll || (strcmp(argv[1], "oo") == 0)) {
+            if (rank == 0) {
+                printf("Out of order isend/irecv test\n");
+                fflush(stdout);
+            }
+            result = OutOfOrderTest(rank, 100);
+            printf(result ? "%d:SUCCESS - oo\n" : "%d:FAILURE - oo\n", rank);
+            fflush(stdout);
+        }
+
+        if (bDoAll || (strcmp(argv[1], "unex") == 0)) {
+            if (rank == 0) {
+                printf("Force unexpected message test\n");
+                fflush(stdout);
+            }
+            result = ForceUnexpectedTest(rank, 100);
+            printf(result ? "%d:SUCCESS - unex\n" : "%d:FAILURE - unex\n", rank);
+            fflush(stdout);
+        }
+
+        if (bDoAll || (strcmp(argv[1], "rndv") == 0)) {
+            if (argc > 2) {
+                rndv_size = atoi(argv[2]);
+                if (rndv_size < 1024)
+                    rndv_size = 1024;
+            }
+            if (rank == 0) {
+                printf("Rndv test\n");
+                fflush(stdout);
+            }
+            result = RndvTest(rank, rndv_size, 1);
+            printf(result ? "%d:SUCCESS - rndv\n" : "%d:FAILURE - rndv\n", rank);
+            fflush(stdout);
+        }
+
+        if (bDoAll || (strcmp(argv[1], "rndv_reps") == 0)) {
+            reps = 100;
+            if (argc > 2) {
+                reps = atoi(argv[2]);
+                if (reps < 1)
+                    reps = 1;
+            }
+            if (argc > 3) {
+                rndv_size = atoi(argv[3]);
+            }
+            if (rank == 0) {
+                printf("Rndv test: %d reps of size %d\n", reps, rndv_size);
+                fflush(stdout);
+            }
+            result = RndvTest(rank, rndv_size, reps);
+            printf(result ? "%d:SUCCESS - rndv_reps\n" : "%d:FAILURE - rndv_reps\n", rank);
+            fflush(stdout);
+        }
+
+        if (bDoAll || (strcmp(argv[1], "rndv_iisr") == 0)) {
+            if (rank == 0) {
+                printf("Rndv isend,isend/irecv,irecv wait wait test\n");
+                fflush(stdout);
+            }
+            if (argc > 2) {
+                rndv_size = atoi(argv[2]);
+            }
+            result = IsendIrecvTest2(rank, rndv_size);
+            printf(result ? "%d:SUCCESS - rndv_iisr\n" : "%d:FAILURE - rndv_iisr\n", rank);
+            fflush(stdout);
+        }
+
+        if (bDoAll || (strcmp(argv[1], "rndv_oo") == 0)) {
+            if (rank == 0) {
+                printf("Rndv out of order isend/irecv test\n");
+                fflush(stdout);
+            }
+            if (argc > 2) {
+                rndv_size = atoi(argv[2]);
+            }
+            result = OutOfOrderTest(rank, rndv_size);
+            printf(result ? "%d:SUCCESS - rndv_oo\n" : "%d:FAILURE - rndv_oo\n", rank);
+            fflush(stdout);
+        }
+
+        if (bDoAll || (strcmp(argv[1], "rndv_unex") == 0)) {
+            if (argc > 2) {
+                rndv_size = atoi(argv[2]);
+                if (rndv_size < 1024)
+                    rndv_size = 1024;
+            }
+            if (rank == 0) {
+                printf("Force unexpected rndv message test\n");
+                fflush(stdout);
+            }
+            result = ForceUnexpectedTest(rank, rndv_size);
+            printf(result ? "%d:SUCCESS - rndv_unex\n" : "%d:FAILURE - rndv_unex\n", rank);
+            fflush(stdout);
+        }
+    }
+
+    MPI_Finalize();
+    return 0;
+}

--- a/t/mpi/mpich_basic/self.c
+++ b/t/mpi/mpich_basic/self.c
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpi.h"
+
+int main(int argc, char *argv[])
+{
+    int i, j;
+    MPI_Status status;
+
+    MPI_Init(&argc, &argv);
+
+    MPI_Sendrecv(&i, 1, MPI_INT, 0, 100, &j, 1, MPI_INT, 0, 100, MPI_COMM_WORLD, &status);
+
+    MPI_Finalize();
+    return (0);
+}

--- a/t/mpi/mpich_basic/sendrecv.c
+++ b/t/mpi/mpich_basic/sendrecv.c
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpi.h"
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#define LARGE_SIZE  100*1024
+#define RNDV_SIZE   256*1024
+
+int main(int argc, char *argv[])
+{
+    int size, rank;
+    char buffer[100] = "garbage";
+    char big_buffer[RNDV_SIZE] = "big garbage";
+    MPI_Status status;
+    int tag = 1;
+    int reps = 1;
+    int i;
+
+    printf("Simple Send/Recv test.\n");
+    fflush(stdout);
+
+    MPI_Init(&argc, &argv);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+    if (size < 2) {
+        printf("Two processes needed.\n");
+        MPI_Finalize();
+        return 0;
+    }
+
+    if (argc > 1) {
+        reps = atoi(argv[1]);
+        if (reps < 1)
+            reps = 1;
+    }
+
+    if (rank == 0) {
+        printf("Rank 0: sending 100 bytes messages to process 1.\n");
+        fflush(stdout);
+        strcpy(buffer, "Hello process one.");
+        for (i = 0; i < reps; i++) {
+            MPI_Send(buffer, 100, MPI_BYTE, 1, tag, MPI_COMM_WORLD);
+            MPI_Recv(buffer, 100, MPI_BYTE, 1, tag, MPI_COMM_WORLD, &status);
+        }
+        strcpy(big_buffer, "Hello again process one.");
+        printf("Rank 0: sending %dk bytes messages to process 1.\n", LARGE_SIZE / 1024);
+        fflush(stdout);
+        for (i = 0; i < reps; i++) {
+            MPI_Send(big_buffer, LARGE_SIZE, MPI_BYTE, 1, tag, MPI_COMM_WORLD);
+            MPI_Recv(big_buffer, LARGE_SIZE, MPI_BYTE, 1, tag, MPI_COMM_WORLD, &status);
+        }
+        strcpy(big_buffer, "Hello yet again process one.");
+        printf("Rank 0: sending %dk bytes messages to process 1.\n", RNDV_SIZE / 1024);
+        fflush(stdout);
+        for (i = 0; i < reps; i++) {
+            MPI_Send(big_buffer, RNDV_SIZE, MPI_BYTE, 1, tag, MPI_COMM_WORLD);
+            MPI_Recv(big_buffer, RNDV_SIZE, MPI_BYTE, 1, tag, MPI_COMM_WORLD, &status);
+        }
+    } else if (rank == 1) {
+        printf("Rank 1: receiving messages from process 0.\n");
+        fflush(stdout);
+        for (i = 0; i < reps; i++) {
+            MPI_Recv(buffer, 100, MPI_BYTE, 0, tag, MPI_COMM_WORLD, &status);
+            MPI_Send(buffer, 100, MPI_BYTE, 0, tag, MPI_COMM_WORLD);
+        }
+        printf("Rank 1: received message '%s'\n", buffer);
+        fflush(stdout);
+        for (i = 0; i < reps; i++) {
+            MPI_Recv(big_buffer, LARGE_SIZE, MPI_BYTE, 0, tag, MPI_COMM_WORLD, &status);
+            MPI_Send(big_buffer, LARGE_SIZE, MPI_BYTE, 0, tag, MPI_COMM_WORLD);
+        }
+        printf("Rank 1: received message '%s'\n", big_buffer);
+        fflush(stdout);
+        for (i = 0; i < reps; i++) {
+            MPI_Recv(big_buffer, RNDV_SIZE, MPI_BYTE, 0, tag, MPI_COMM_WORLD, &status);
+            MPI_Send(big_buffer, RNDV_SIZE, MPI_BYTE, 0, tag, MPI_COMM_WORLD);
+        }
+        printf("Rank 1: received message '%s'\n", big_buffer);
+        fflush(stdout);
+    } else {
+        printf("Rank %d, I am not participating.\n", rank);
+        fflush(stdout);
+    }
+
+    MPI_Finalize();
+    return 0;
+}

--- a/t/mpi/mpich_basic/simple.c
+++ b/t/mpi/mpich_basic/simple.c
@@ -1,0 +1,14 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpi.h"
+
+int main(int argc, char *argv[])
+{
+    MPI_Init(&argc, &argv);
+    MPI_Finalize();
+
+    return 0;
+}

--- a/t/mpi/mpich_basic/srtest.c
+++ b/t/mpi/mpich_basic/srtest.c
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpi.h"
+#include <stdio.h>
+#include <string.h>
+
+#define BUFLEN 512
+
+int main(int argc, char *argv[])
+{
+    int myid, numprocs, next, namelen;
+    char buffer[BUFLEN], processor_name[MPI_MAX_PROCESSOR_NAME];
+    MPI_Status status;
+
+    MPI_Init(&argc, &argv);
+    MPI_Comm_size(MPI_COMM_WORLD, &numprocs);
+    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+    MPI_Get_processor_name(processor_name, &namelen);
+    fprintf(stderr, "Process %d of %d is alive on %s\n", myid, numprocs, processor_name);
+
+    strcpy(buffer, "hello there");
+    if (myid == numprocs - 1)
+        next = 0;
+    else
+        next = myid + 1;
+
+    if (myid == 0) {
+        printf("%d sending '%s' \n", myid, buffer);
+        MPI_Send(buffer, (int) strlen(buffer) + 1, MPI_CHAR, next, 99, MPI_COMM_WORLD);
+        printf("%d receiving \n", myid);
+        MPI_Recv(buffer, BUFLEN, MPI_CHAR, MPI_ANY_SOURCE, 99, MPI_COMM_WORLD, &status);
+        printf("%d received '%s' \n", myid, buffer);
+        /* mpdprintf(001,"%d receiving \n",myid); */
+    } else {
+        printf("%d receiving  \n", myid);
+        MPI_Recv(buffer, BUFLEN, MPI_CHAR, MPI_ANY_SOURCE, 99, MPI_COMM_WORLD, &status);
+        printf("%d received '%s' \n", myid, buffer);
+        /* mpdprintf(001,"%d receiving \n",myid); */
+        MPI_Send(buffer, (int) strlen(buffer) + 1, MPI_CHAR, next, 99, MPI_COMM_WORLD);
+        printf("%d sent '%s' \n", myid, buffer);
+    }
+    MPI_Barrier(MPI_COMM_WORLD);
+    MPI_Finalize();
+    return (0);
+}

--- a/t/mpi/version.c
+++ b/t/mpi/version.c
@@ -1,0 +1,37 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <mpi.h>
+#include <stdio.h>
+
+int main (int argc, char *argv[])
+{
+    char version[MPI_MAX_LIBRARY_VERSION_STRING];
+    int len;
+    int exit_rc = -1;
+
+    MPI_Init (&argc, &argv);
+    MPI_Get_library_version (version, &len);
+    if (len < 0) {
+        fprintf (stderr, "MPI_Get_library_version failed\n");
+        goto done;
+    }
+    printf ("%s\n", version);
+    exit_rc = 0;
+done:
+    MPI_Finalize ();
+    return exit_rc;
+}
+
+// vi: ts=4 sw=4 expandtab
+

--- a/t/t3000-mpi-basic.t
+++ b/t/t3000-mpi-basic.t
@@ -21,19 +21,21 @@ SIZE=2
 MAX_MPI_SIZE=$(($SIZE*$TEST_UNDER_FLUX_CORES_PER_RANK))
 test_under_flux $SIZE job
 
-hello_world() {
-	run_timeout 30 flux mini run -n$1 ${HELLO} >hello-$1.out &&
-	grep -q "are $1 tasks" hello-$1.out &&
-	test_debug "cat hello-$1.out"
-}
+OPTS="-ocpu-affinity=off -overbose=1"
 
-for size in $(seq 1 ${MAX_MPI_SIZE}); do
-	test_expect_success "mpi hello size=${size}" "hello_world ${size}"
-done
+test_expect_success 'mpi hello various sizes' '
+	run_timeout 30 flux mini submit --cc=1-$MAX_MPI_SIZE $OPTS \
+		--watch -n{cc} ${HELLO} >hello.out &&
+	for i in $(seq 1 $MAX_MPI_SIZE); do \
+		grep "There are $i tasks" hello.out; \
+	done
+'
 
 # issue 3649 - try to get two size=2 jobs running concurrently on one broker
 test_expect_success 'mpi hello size=2 concurrent submit of 8 jobs' '
-	run_timeout 30 flux mini submit --cc=1-8 --watch -n2 ${HELLO}
+	run_timeout 30 flux mini submit --cc=1-8 $OPTS \
+		--watch -n2 ${HELLO} >hello2.out &&
+	test $(grep "There are 2 tasks" hello2.out | wc -l) -eq 8
 '
 
 test_done

--- a/t/t3000-mpi-basic.t
+++ b/t/t3000-mpi-basic.t
@@ -38,4 +38,39 @@ test_expect_success 'mpi hello size=2 concurrent submit of 8 jobs' '
 	test $(grep "There are 2 tasks" hello2.out | wc -l) -eq 8
 '
 
+# Run some basic tests pulled from MPICH as a sanity check
+test_expect_success 'ANL self works' '
+	run_timeout 30 flux mini run $OPTS \
+		${FLUX_BUILD_DIR}/t/mpi/mpich_basic/self
+'
+test_expect_success 'ANL simple works' '
+	run_timeout 30 flux mini run -n 2 $OPTS \
+		${FLUX_BUILD_DIR}/t/mpi/mpich_basic/simple
+'
+test_expect_success 'ANL sendrecv works on 1 node' '
+	run_timeout 30 flux mini run -n 2 -N1 $OPTS \
+		${FLUX_BUILD_DIR}/t/mpi/mpich_basic/sendrecv
+'
+test_expect_success 'ANL sendrecv works on 2 nodes' '
+	run_timeout 30 flux mini run -n 2 -N2 $OPTS \
+		${FLUX_BUILD_DIR}/t/mpi/mpich_basic/sendrecv
+'
+test_expect_success LONGTEST 'ANL netpipe works' '
+	flux mini run -n 2 $OPTS \
+		${FLUX_BUILD_DIR}/t/mpi/mpich_basic/netpipe
+'
+test_expect_success 'ANL patterns works 1 node' '
+	run_timeout 30 flux mini run -n 2 -N1 $OPTS \
+		${FLUX_BUILD_DIR}/t/mpi/mpich_basic/patterns
+'
+test_expect_success 'ANL patterns works 2 nodes' '
+	run_timeout 30 flux mini run -n 2 -N2 $OPTS \
+		${FLUX_BUILD_DIR}/t/mpi/mpich_basic/patterns
+'
+test_expect_success LONGTEST 'ANL adapt works' '
+	flux mini run -n 3 $OPTS \
+		${FLUX_BUILD_DIR}/t/mpi/mpich_basic/adapt
+'
+
+
 test_done

--- a/t/t3003-mpi-abort.t
+++ b/t/t3003-mpi-abort.t
@@ -1,0 +1,74 @@
+#!/bin/sh
+#
+
+test_description='Test that MPI_Abort works'
+
+
+. `dirname $0`/sharness.sh
+
+if test -z "$FLUX_TEST_MPI"; then
+    skip_all='skipping MPI tests, FLUX_TEST_MPI not set'
+    test_done
+fi
+
+if ! test -x ${FLUX_BUILD_DIR}/t/mpi/abort; then
+    skip_all='skipping MPI tests, MPI not available/configured'
+    test_done
+fi
+
+# Use convenient sort(1) option to determine if semantic version $1 >= $2
+version_gte() {
+    test "$( (echo $1; echo $2) | sort --version-sort | tail -1)" = $1
+}
+
+#
+# mpich < 3.2.0 simply exits on MPI_Abort() instead of sending the PMI-1
+# abort message.  Don't test this for now because of missing early exit
+# detection in Flux (flux-framework/flux-core#2238)
+#
+mpich_min=3.2.0
+mpich_ver=$(${FLUX_BUILD_DIR}/t/mpi/version | awk '/MPICH Version:/ {print $3}')
+if test -n $mpich_ver && ! version_gte $mpich_ver $mpich_min; then
+    skip_all="skipping MPI abort test on MPICH $mpich_ver (< $mpich_min)"
+    test_done
+fi
+
+export TEST_UNDER_FLUX_CORES_PER_RANK=4
+SIZE=2
+MAX_MPI_SIZE=$(($SIZE*$TEST_UNDER_FLUX_CORES_PER_RANK))
+test_under_flux $SIZE job
+
+OPTS="-ocpu-affinity=off"
+
+diag() {
+	echo "test failed: cat $1"
+	cat $1
+	return 1
+}
+
+# These tests use ! for expected failure rather than 'test_expect_code'
+# because (I think) we may alternately get the exit code passed to MPI_Abort(),
+# or an exit code that indicates tasks were signaled.  If we can ensure that
+# the exit code is deterministic, that should be fixed.
+
+# get a PMI server trace in the CI output in case we need it to debug!
+test_expect_success 'MPI_Abort size=1 with PMI server tracing enabled' '
+	${FLUX_BUILD_DIR}/t/mpi/version | head -1 &&
+	! run_timeout 60 flux mini run $OPTS -overbose=2 \
+		${FLUX_BUILD_DIR}/t/mpi/abort 0
+'
+
+test_expect_success "MPI_Abort on size=${MAX_MPI_SIZE}, first rank triggers exception" '
+	! run_timeout 60 flux mini run -n${MAX_MPI_SIZE} $OPTS \
+		${FLUX_BUILD_DIR}/t/mpi/abort 0 2>abort0.err &&
+	(grep "exception.*MPI_Abort" abort0.err || diag abort0.err)
+'
+
+test_expect_success "MPI_Abort on size=${MAX_MPI_SIZE}, last rank triggers exception" '
+	! run_timeout 60 flux mini run -n${MAX_MPI_SIZE} $OPTS \
+		${FLUX_BUILD_DIR}/t/mpi/abort $(($MAX_MPI_SIZE-1)) \
+		2>abort1.err &&
+	(grep "exception.*MPI_Abort" abort1.err || diag abort1.err)
+'
+
+test_done


### PR DESCRIPTION
Our in-tree MPI testing is pretty minimal, basically just covering `MPI_Init()`, `MPI_Barrier()`, and `MPI_Finalize()`. This PR cleans up what we have, then adds `MPI_Abort()` coverage, and some basic comms tests pulled in from the MPICH source tree.
