### PR TITLE
libflux: plugin: make FLUX_PLUGIN_ARG_UPDATE the default for set/pack

### DIFF
--- a/doc/man7/flux-jobtap-plugins.rst
+++ b/doc/man7/flux-jobtap-plugins.rst
@@ -70,7 +70,7 @@ entry      o    posted eventlog entry, including context
 ========== ==== ==========================================
 
 Return arguments can be packed using the ``FLUX_PLUGIN_ARG_OUT`` and
-optionally ``FLUX_PLUGIN_ARG_UPDATE`` flags. For example to return
+optionally ``FLUX_PLUGIN_ARG_REPLACE`` flags. For example to return
 a priority::
 
    rc = flux_plugin_arg_pack (args, FLUX_PLUGIN_ARG_OUT,
@@ -80,7 +80,7 @@ a priority::
 While a job is pending, *jobtap* plugin callbacks may also add job
 annotations by returning a value for the ``annotations`` key::
 
-   flux_plugin_arg_pack (args, FLUX_PLUGIN_ARG_OUT|FLUX_PLUGIN_ARG_UPDATE,
+   flux_plugin_arg_pack (args, FLUX_PLUGIN_ARG_OUT,
                          "{s:{s:s}}",
                          "annotations", "test", value);
 

--- a/src/common/libflux/plugin.c
+++ b/src/common/libflux/plugin.c
@@ -461,7 +461,7 @@ static int arg_set (flux_plugin_arg_t *args, int flags, json_t *o)
 {
     json_t **dstp;
     dstp = arg_get (args, flags);
-    if (flags & FLUX_PLUGIN_ARG_UPDATE && *dstp != NULL) {
+    if (!(flags & FLUX_PLUGIN_ARG_REPLACE) && *dstp != NULL) {
         /*  On update, the object 'o' is spiritually inherited by
          *   args, so decref this object after attempting the update.
          */

--- a/src/common/libflux/plugin.h
+++ b/src/common/libflux/plugin.h
@@ -138,7 +138,7 @@ const char *flux_plugin_arg_strerror (flux_plugin_arg_t *args);
 enum {
     FLUX_PLUGIN_ARG_IN =  0,    /* Operate on input args    */
     FLUX_PLUGIN_ARG_OUT = 1,    /* Operate on output args   */
-    FLUX_PLUGIN_ARG_UPDATE = 2  /* Update args for set/pack */
+    FLUX_PLUGIN_ARG_REPLACE = 2 /* Replace args for set/pack */
 };
 
 /*  Get/set arguments in plugin arg object using JSON encoded strings

--- a/src/common/libflux/test/plugin.c
+++ b/src/common/libflux/test/plugin.c
@@ -193,9 +193,9 @@ void test_plugin_args ()
         "flux_plugin_arg_unpack returned valid value for arg");
 
     ok (flux_plugin_arg_set (args,
-                             FLUX_PLUGIN_ARG_IN | FLUX_PLUGIN_ARG_UPDATE,
+                             FLUX_PLUGIN_ARG_IN,
                              "{\"b\":7}") == 0,
-        "flux_plugin_arg_set with FLUX_PLUGIN_ARG_UPDATE works");
+        "flux_plugin_arg_set can update existing args");
     ok (flux_plugin_arg_unpack (args, FLUX_PLUGIN_ARG_IN,
                                 "{s:i}", "b", &arg) == 0,
         "flux_plugin_arg_unpack worked");
@@ -208,14 +208,14 @@ void test_plugin_args ()
         "flux_plugin_arg_unpack returned valid value for old arg");
 
 
-    /* Test update with unset args */
+    /* Test replace with unset args */
     flux_plugin_arg_t *new = flux_plugin_arg_create ();
     if (!new)
         BAIL_OUT ("flux_plugin_arg_create failed");
     ok (flux_plugin_arg_set (args,
-                             FLUX_PLUGIN_ARG_IN | FLUX_PLUGIN_ARG_UPDATE,
+                             FLUX_PLUGIN_ARG_IN|FLUX_PLUGIN_ARG_REPLACE,
                             "{\"count\": 29}") == 0,
-        "flux_plugin_arg_set with ARG_UPDATE works for empty args");
+        "flux_plugin_arg_set with ARG_REPLACE works for empty args");
     flux_plugin_arg_destroy (new);
 
     ok (flux_plugin_arg_unpack (args, FLUX_PLUGIN_ARG_IN,

--- a/src/modules/job-manager/jobtap.c
+++ b/src/modules/job-manager/jobtap.c
@@ -170,7 +170,7 @@ static flux_plugin_arg_t *jobtap_args_vcreate (struct jobtap *jobtap,
 
     if (fmt
         && flux_plugin_arg_vpack (args,
-                                  FLUX_PLUGIN_ARG_IN|FLUX_PLUGIN_ARG_UPDATE,
+                                  FLUX_PLUGIN_ARG_IN,
                                   fmt, ap) < 0)
         goto error;
     return args;
@@ -604,7 +604,7 @@ static int jobtap_check_dependency (struct jobtap *jobtap,
     }
 
     if (flux_plugin_arg_pack (args,
-                              FLUX_PLUGIN_ARG_IN|FLUX_PLUGIN_ARG_UPDATE,
+                              FLUX_PLUGIN_ARG_IN,
                               "{s:O}",
                               "dependency", entry) < 0
         || flux_plugin_arg_set (args, FLUX_PLUGIN_ARG_OUT, "{}") < 0) {
@@ -1241,7 +1241,7 @@ int flux_jobtap_priority_unavail (flux_plugin_t *p, flux_plugin_arg_t *args)
     /* Still todo: check valid state, etc.
      */
     return flux_plugin_arg_pack (args,
-                                 FLUX_PLUGIN_ARG_OUT|FLUX_PLUGIN_ARG_UPDATE,
+                                 FLUX_PLUGIN_ARG_OUT,
                                  "{s:I}",
                                  "priority", FLUX_JOBTAP_PRIORITY_UNAVAIL);
 }
@@ -1272,7 +1272,7 @@ int flux_jobtap_reject_job (flux_plugin_t *p,
         errmsg[len - 2] = '+';
     }
     if (flux_plugin_arg_pack (args,
-                              FLUX_PLUGIN_ARG_OUT|FLUX_PLUGIN_ARG_UPDATE,
+                              FLUX_PLUGIN_ARG_OUT,
                               "{s:s}",
                               "errmsg", errmsg) < 0) {
         flux_t *h = flux_jobtap_get_flux (p);

--- a/src/shell/log.c
+++ b/src/shell/log.c
@@ -78,7 +78,7 @@ static flux_plugin_arg_t *log_msg_args (int level,
                                         const char *msg)
 {
     int rc = -1;
-    int flags = FLUX_PLUGIN_ARG_IN | FLUX_PLUGIN_ARG_UPDATE;
+    int flags = FLUX_PLUGIN_ARG_IN;
     flux_plugin_arg_t *args = flux_plugin_arg_create ();
 
     if (!args)

--- a/src/shell/test/plugstack.c
+++ b/src/shell/test/plugstack.c
@@ -44,7 +44,7 @@ static int next_level (flux_plugin_t *p, const char *s,
 {
     struct plugstack *st = arg;
     return flux_plugin_arg_pack (args,
-                                 FLUX_PLUGIN_ARG_OUT|FLUX_PLUGIN_ARG_UPDATE,
+                                 FLUX_PLUGIN_ARG_OUT,
                                  "{s:s}",
                                  "next_name", plugstack_current_name (st));
 }

--- a/t/job-manager/plugins/test.c
+++ b/t/job-manager/plugins/test.c
@@ -67,7 +67,7 @@ static int cb (flux_plugin_t *p,
         }
         if (strcmp (test_mode, "priority type error") == 0) {
             flux_plugin_arg_pack (args,
-                                  FLUX_PLUGIN_ARG_OUT|FLUX_PLUGIN_ARG_UPDATE,
+                                  FLUX_PLUGIN_ARG_OUT,
                                   "{s:s}",
                                   "priority", "foo");
         }
@@ -79,7 +79,7 @@ static int cb (flux_plugin_t *p,
             return -1;
         if (strcmp (test_mode, "sched: update priority") == 0) {
             flux_plugin_arg_pack (args,
-                                  FLUX_PLUGIN_ARG_OUT|FLUX_PLUGIN_ARG_UPDATE,
+                                  FLUX_PLUGIN_ARG_OUT,
                                   "{s:i}",
                                   "priority", 42);
         }
@@ -94,7 +94,7 @@ static int cb (flux_plugin_t *p,
             return flux_jobtap_priority_unavail (p, args);
         if (strcmp (test_mode, "priority.get: bad arg") == 0) {
             flux_plugin_arg_pack (args,
-                                  FLUX_PLUGIN_ARG_OUT|FLUX_PLUGIN_ARG_UPDATE,
+                                  FLUX_PLUGIN_ARG_OUT,
                                   "{s:s}",
                                   "priority", "foo");
         }


### PR DESCRIPTION
Fixes #3683

This was pretty straightforward, but @SteVwonder and @cmoussa1 should sign off since I think they are developing plugins external to flux-core.

This PR removes `FLUX_PLUGIN_ARG_UPDATE` and makes its behavior the default. The new flag `FLUX_PLUGIN_ARG_REPLACE` can be used to get the old default behavior. Therefore existing out-of-tree plugins may get compile-time errors if they use `FLUX_PLUGIN_ARG_UPDATE`