### PR TITLE
testsuite: add mvapich2 to centos8 CI image

### DIFF
--- a/src/test/docker/centos8/Dockerfile
+++ b/src/test/docker/centos8/Dockerfile
@@ -5,7 +5,7 @@ LABEL maintainer="Mark Grondona <mgrondona@llnl.gov>"
 #  Enable PowerTools for development packages
 RUN yum -y update \
  && dnf -y install 'dnf-command(config-manager)' \
- && yum config-manager --set-enabled PowerTools \
+ && yum config-manager --set-enabled powertools \
  && yum -y update \
 #  Enable EPEL
  && yum -y install epel-release \

--- a/src/test/docker/centos8/Dockerfile
+++ b/src/test/docker/centos8/Dockerfile
@@ -19,7 +19,6 @@ RUN yum -y update \
 	munge \
 	ccache \
 	lua \
-	mpich \
 	valgrind \
 	jq \
 	which \
@@ -36,6 +35,8 @@ RUN yum -y update \
 	gcc-c++ \
 	make \
 	cmake \
+	bison \
+	flex \
 #  Python
 	python36 \
 	python3-devel \
@@ -54,7 +55,6 @@ RUN yum -y update \
 	sqlite-devel \
 	libuuid-devel \
 	hwloc-devel \
-	mpich-devel \
 	lua-devel \
 	valgrind-devel \
 	libs3-devel \
@@ -72,9 +72,6 @@ RUN yum -y update \
 #  Set default /usr/bin/python to python3
 RUN alternatives --set python /usr/bin/python3
 
-#  Add /usr/bin/mpicc link so MPI tests are built
-RUN alternatives --install /usr/bin/mpicc mpicc /usr/lib64/mpich/bin/mpicc 100
-
 # Install caliper by hand for now:
 RUN mkdir caliper \
  && cd caliper \
@@ -86,6 +83,16 @@ RUN mkdir caliper \
  && make install \
  && cd ../.. \
  && rm -rf caliper
+
+# Install mvapich2
+RUN mkdir mvapich2 \
+ && cd mvapich2 \
+ && wget -O - http://mvapich.cse.ohio-state.edu/download/mvapich/mv2/mvapich2-2.3.6.tar.gz | tar xvz --strip-components 1 \
+ && ./configure --with-device=ch3:sock --disable-fortran --prefix=/usr \
+ && make -j4 \
+ && make install \
+ && cd .. \
+ && rm -rf mvapich2
 
 ENV LANG=C.UTF-8
 RUN printf "LANG=C.UTF-8" > /etc/locale.conf

--- a/t/t3003-mpi-abort.t
+++ b/t/t3003-mpi-abort.t
@@ -32,6 +32,14 @@ if test -n $mpich_ver && ! version_gte $mpich_ver $mpich_min; then
     skip_all="skipping MPI abort test on MPICH $mpich_ver (< $mpich_min)"
     test_done
 fi
+#
+# mvapich2 2.3.6 also exits on MPI_Abort()
+# As there is no public git history for mvapich at this time, skip all versions.
+#
+if ${FLUX_BUILD_DIR}/t/mpi/version | grep -q MVAPICH2; then
+    skip_all="skipping MPI abort test on MVAPICH2"
+    test_done
+fi
 
 export TEST_UNDER_FLUX_CORES_PER_RANK=4
 SIZE=2


### PR DESCRIPTION
This builds the latest mvapich2 in the centos8 image for CI.  With this in, we'll be doing basic MPI testing on mpich, openmpi, and mvapich.