### PR TITLE
job-list: support RPC to purge cache

### DIFF
--- a/src/bindings/python/flux/job/list.py
+++ b/src/bindings/python/flux/job/list.py
@@ -124,6 +124,8 @@ class JobListIdsFuture(WaitAllFuture):
             except EnvironmentError as err:
                 if err.errno == errno.ENOENT:
                     msg = f"JobID {child.jobid.orig} unknown"
+                elif err.errno == errno.EFAULT:
+                    msg = f"JobID {child.jobid.orig} purged"
                 else:
                     msg = f"rpc: {err.strerror}"
                 self.errors.append(msg)

--- a/src/modules/job-list/Makefile.am
+++ b/src/modules/job-list/Makefile.am
@@ -20,6 +20,8 @@ job_list_la_SOURCES = \
 	job_state.c \
 	list.h \
 	list.c \
+	purge.h \
+	purge.c \
 	job_util.h \
 	job_util.c \
 	idsync.h \

--- a/src/modules/job-list/job_state.h
+++ b/src/modules/job-list/job_state.h
@@ -58,6 +58,8 @@ struct job_state_ctx {
 
     /* stream of job events from the job-manager */
     flux_future_t *events;
+
+    zhashx_t *purged_jobids;
 };
 
 struct job {

--- a/src/modules/job-list/list.c
+++ b/src/modules/job-list/list.c
@@ -471,6 +471,13 @@ json_t *get_job_by_id (struct list_ctx *ctx,
     struct job *job;
 
     if (!(job = zhashx_lookup (ctx->jsctx->index, &id))) {
+        /* if id was purged, for time being return EFAULT.  Picking
+         * an errno to just make it obvious this is a unique corner
+         * case. */
+        if (zhashx_lookup (ctx->jsctx->purged_jobids, &id)) {
+            errno = EFAULT;
+            return NULL;
+        }
         if (stall) {
             if (check_id_valid (ctx, msg, id, attrs) < 0) {
                 flux_log_error (ctx->h, "%s: check_id_valid", __FUNCTION__);

--- a/src/modules/job-list/purge.c
+++ b/src/modules/job-list/purge.c
@@ -1,0 +1,100 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* purge.c - purge jobs */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <jansson.h>
+#include <flux/core.h>
+#include <assert.h>
+
+#include "src/common/libutil/errno_safe.h"
+#include "src/common/libczmqcontainers/czmq_containers.h"
+
+#include "purge.h"
+#include "stats.h"
+
+static int remove_one_inactive_job (struct job_state_ctx *jsctx)
+{
+    struct job *job = NULL;
+    flux_jobid_t id;
+    flux_jobid_t *idptr = NULL;
+
+    zlistx_last (jsctx->inactive);
+    job = zlistx_detach_cur (jsctx->inactive);
+    assert (job != NULL);
+    job_stats_remove_inactive (&jsctx->stats, job);
+    id = job->id;
+    zhashx_delete (jsctx->index, &job->id);
+
+    if (!(idptr = malloc (sizeof (flux_jobid_t)))) {
+        flux_log_error (jsctx->h, "%s: malloc", __FUNCTION__);
+        goto enomem;
+    }
+    (*idptr) = id;
+
+    /* we don't care about the contents stored in the purged_jobs
+     * hash, just store ptr to this id.  The destructor set on
+     * purged_jobids will free this memory. */
+    if (zhashx_insert (jsctx->purged_jobids, idptr, idptr) < 0) {
+        flux_log_error (jsctx->h, "%s: zhashx_insert", __FUNCTION__);
+        free (idptr);
+        goto enomem;
+    }
+    return 0;
+
+enomem:
+    errno = ENOMEM;
+    return -1;
+}
+
+void purge_cb (flux_t *h, flux_msg_handler_t *mh,
+               const flux_msg_t *msg, void *arg)
+{
+    struct list_ctx *ctx = arg;
+    int count = 0;
+
+    if (flux_request_unpack (msg, NULL, "{s?:i}", "count", &count) < 0) {
+        errno = EPROTO;
+        goto error;
+    }
+    if (count < 0) {
+        errno = EPROTO;
+        goto error;
+    }
+
+    /* count=0 means remove all */
+    if (!count
+        || zlistx_size (ctx->jsctx->inactive) < count)
+        count = zlistx_size (ctx->jsctx->inactive);
+
+    while (count) {
+        if (remove_one_inactive_job (ctx->jsctx) < 0)
+            goto error;
+        count--;
+    }
+
+    if (flux_respond (h, msg, NULL) < 0) {
+        flux_log_error (h, "%s: flux_respond", __FUNCTION__);
+        goto error;
+    }
+
+    return;
+
+error:
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/job-list/purge.h
+++ b/src/modules/job-list/purge.h
@@ -1,0 +1,25 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _FLUX_JOB_LIST_PURGE_H
+#define _FLUX_JOB_LIST_PURGE_H
+
+#include <flux/core.h>
+
+#include "job-list.h"
+
+void purge_cb (flux_t *h, flux_msg_handler_t *mh,
+               const flux_msg_t *msg, void *arg);
+
+#endif /* ! _FLUX_JOB_LIST_PURGE_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/job-list/stats.c
+++ b/src/modules/job-list/stats.c
@@ -69,6 +69,22 @@ void job_stats_update (struct job_stats *stats,
     }
 }
 
+void job_stats_remove_inactive (struct job_stats *stats,
+                                struct job *job)
+{
+    assert (job->state == FLUX_JOB_STATE_INACTIVE);
+    stats->state_count[state_index(job->state)]--;
+    if (!job->success) {
+        stats->failed--;
+        if (job->exception_occurred) {
+            if (strcmp (job->exception_type, "cancel") == 0)
+                stats->canceled--;
+            else if (strcmp (job->exception_type, "timeout") == 0)
+                stats->timeout--;
+        }
+    }
+}
+
 static int json_add_counter (json_t *o,
                              const char *key,
                              unsigned int n)

--- a/src/modules/job-list/stats.h
+++ b/src/modules/job-list/stats.h
@@ -28,6 +28,9 @@ void job_stats_update (struct job_stats *stats,
                        struct job *job,
                        flux_job_state_t newstate);
 
+void job_stats_remove_inactive (struct job_stats *stats,
+                                struct job *job);
+
 json_t * job_stats_encode (struct job_stats *stats);
 
 #endif /* ! _FLUX_JOB_LIST_JOB_STATS_H */

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -279,6 +279,7 @@ dist_check_SCRIPTS = \
 	job-list/list-id.py \
 	job-list/list-rpc.py \
 	job-list/jobspec-permissive.jsonschema \
+	job-list/job-list-helper.sh \
 	ingest/bad-validate.py \
 	job-archive/query.py
 

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -127,6 +127,7 @@ TESTSCRIPTS = \
 	t2250-job-archive.t \
 	t2260-job-list.t \
 	t2261-job-list-update.t \
+	t2262-job-list-purge.t \
 	t2270-job-dependencies.t \
 	t2271-job-dependency-after.t \
 	t2272-job-begin-time.t \

--- a/t/job-list/job-list-helper.sh
+++ b/t/job-list/job-list-helper.sh
@@ -1,0 +1,91 @@
+#!/bin/sh
+#
+
+# job-list test helper functions
+
+# fj_wait_event
+#
+# flux job wait event w/ a timeout, to ensure tests can't hang
+fj_wait_event() {
+    flux job wait-event --timeout=20 "$@"
+}
+
+# state_ids
+# - arg1 - state
+#
+# Return the expected jobids list in a given state/filter:
+#   "all", "pending", "running", "inactive", "active",
+#   "completed", "canceled", "failed"
+#
+# Note that while the above states are the "expected" states,
+# technically any string to a ${filename}.ids can be passed to this
+# function.
+#
+state_ids() {
+    for f in "$@"; do
+        cat ${f}.ids
+    done
+}
+
+# state_count
+# - arg1 - state
+#
+# Return the expected count of jobs in a given state (See above for
+# common list)
+#
+# Note that while the above states are the "expected" states,
+# technically any string to a ${filename}.ids can be passed to this
+# function.
+#
+state_count() {
+    state_ids "$@" | wc -l
+}
+
+# wait_jobid_state
+# - arg1 - jobid
+# - arg2 - job state
+#
+# Wait until a jobid reaches a specific state
+wait_jobid_state() {
+        local jobid=$(flux job id $1)
+        local state=$2
+        local i=0
+        while ! flux job list --states=${state} | grep $jobid > /dev/null \
+               && [ $i -lt 50 ]
+        do
+                sleep 0.1
+                i=$((i + 1))
+        done
+        if [ "$i" -eq "50" ]
+        then
+            return 1
+        fi
+        return 0
+}
+
+# wait_states
+#
+# the job-list module has eventual consistency with the jobs stored in
+# the job-manager's queue.  To ensure no raciness in tests, we spin
+# until all of the pending jobs have reached SCHED state, running jobs
+# have reached RUN state, and inactive jobs have reached INACTIVE
+# state.
+wait_states() {
+        pending=$(state_count pending)
+        running=$(state_count running)
+        inactive=$(state_count inactive)
+        local i=0
+        while ( [ "$(flux job list --states=sched | wc -l)" != "$pending" ] \
+                || [ "$(flux job list --states=run | wc -l)" != "$running" ] \
+                || [ "$(flux job list --states=inactive | wc -l)" != "$inactive" ]) \
+               && [ $i -lt 50 ]
+        do
+                sleep 0.1
+                i=$((i + 1))
+        done
+        if [ "$i" -eq "50" ]
+        then
+            return 1
+        fi
+        return 0
+}

--- a/t/t2260-job-list.t
+++ b/t/t2260-job-list.t
@@ -2,6 +2,8 @@
 
 test_description='Test flux job list services'
 
+. $(dirname $0)/job-list/job-list-helper.sh
+
 . $(dirname $0)/sharness.sh
 
 test_under_flux 4 job
@@ -14,27 +16,6 @@ JOB_CONV="flux python ${FLUX_SOURCE_DIR}/t/job-manager/job-conv.py"
 if test "$TEST_LONG" = "t"; then
     test_set_prereq LONGTEST
 fi
-
-fj_wait_event() {
-  flux job wait-event --timeout=20 "$@"
-}
-
-wait_jobid_state() {
-        local jobid=$(flux job id $1)
-        local state=$2
-        local i=0
-        while ! flux job list --states=${state} | grep $jobid > /dev/null \
-               && [ $i -lt 50 ]
-        do
-                sleep 0.1
-                i=$((i + 1))
-        done
-        if [ "$i" -eq "50" ]
-        then
-            return 1
-        fi
-        return 0
-}
 
 #
 # job list tests
@@ -59,48 +40,6 @@ wait_jobid_state() {
 #
 # TODO
 # - alternate userid job listing
-
-# Return the expected jobids list in a given state:
-#   "all", "pending", "running", "inactive", "active",
-#   "completed", "canceled", "failed"
-#
-state_ids() {
-    for f in "$@"; do
-        cat ${f}.ids
-    done
-}
-
-# Return the expected count of jobs in a given state (See above for list)
-#
-state_count() {
-    state_ids "$@" | wc -l
-}
-
-# the job-list module has eventual consistency with the jobs stored in
-# the job-manager's queue.  To ensure no raciness in tests, we spin
-# until all of the pending jobs have reached SCHED state, running jobs
-# have reached RUN state, and inactive jobs have reached INACTIVE
-# state.
-
-wait_states() {
-        pending=$(state_count pending)
-        running=$(state_count running)
-        inactive=$(state_count inactive)
-        local i=0
-        while ( [ "$(flux job list --states=sched | wc -l)" != "$pending" ] \
-                || [ "$(flux job list --states=run | wc -l)" != "$running" ] \
-                || [ "$(flux job list --states=inactive | wc -l)" != "$inactive" ]) \
-               && [ $i -lt 50 ]
-        do
-                sleep 0.1
-                i=$((i + 1))
-        done
-        if [ "$i" -eq "50" ]
-        then
-            return 1
-        fi
-        return 0
-}
 
 test_expect_success 'submit jobs for job list testing' '
         #  Create `hostname` and `sleep` jobspec

--- a/t/t2261-job-list-update.t
+++ b/t/t2261-job-list-update.t
@@ -2,6 +2,8 @@
 
 test_description='Test flux job list services w/ changing job data'
 
+. $(dirname $0)/job-list/job-list-helper.sh
+
 . $(dirname $0)/sharness.sh
 
 test_under_flux 4 job
@@ -11,27 +13,6 @@ RPC=${FLUX_BUILD_DIR}/t/request/rpc
 if test "$TEST_LONG" = "t"; then
     test_set_prereq LONGTEST
 fi
-
-fj_wait_event() {
-  flux job wait-event --timeout=20 "$@"
-}
-
-wait_jobid_state() {
-        local jobid=$(flux job id $1)
-        local state=$2
-        local i=0
-        while ! flux job list --states=${state} | grep $jobid > /dev/null \
-               && [ $i -lt 50 ]
-        do
-                sleep 0.1
-                i=$((i + 1))
-        done
-        if [ "$i" -eq "50" ]
-        then
-            return 1
-        fi
-        return 0
-}
 
 #
 # job list tests
@@ -56,48 +37,6 @@ wait_jobid_state() {
 #
 # TODO
 # - alternate userid job listing
-
-# Return the expected jobids list in a given state:
-#   "all", "pending", "running", "inactive", "active",
-#   "completed", "canceled", "failed"
-#
-state_ids() {
-    for f in "$@"; do
-        cat ${f}.ids
-    done
-}
-
-# Return the expected count of jobs in a given state (See above for list)
-#
-state_count() {
-    state_ids "$@" | wc -l
-}
-
-# the job-list module has eventual consistency with the jobs stored in
-# the job-manager's queue.  To ensure no raciness in tests, we spin
-# until all of the pending jobs have reached SCHED state, running jobs
-# have reached RUN state, and inactive jobs have reached INACTIVE
-# state.
-
-wait_states() {
-        pending=$(state_count pending)
-        running=$(state_count running)
-        inactive=$(state_count inactive)
-        local i=0
-        while ( [ "$(flux job list --states=sched | wc -l)" != "$pending" ] \
-                || [ "$(flux job list --states=run | wc -l)" != "$running" ] \
-                || [ "$(flux job list --states=inactive | wc -l)" != "$inactive" ]) \
-               && [ $i -lt 50 ]
-        do
-                sleep 0.1
-                i=$((i + 1))
-        done
-        if [ "$i" -eq "50" ]
-        then
-            return 1
-        fi
-        return 0
-}
 
 test_expect_success 'submit jobs for job list testing' '
         #  Create `hostname` and `sleep` jobspec

--- a/t/t2262-job-list-purge.t
+++ b/t/t2262-job-list-purge.t
@@ -1,0 +1,179 @@
+#!/bin/sh
+
+test_description='Test flux job list purge inactive'
+
+. $(dirname $0)/job-list/job-list-helper.sh
+
+. $(dirname $0)/sharness.sh
+
+export FLUX_CONF_DIR=$(pwd)
+test_under_flux 4 job
+
+RPC=${FLUX_BUILD_DIR}/t/request/rpc
+
+get_completed_count() {
+    count=`flux jobs --stats-only 2>&1 | awk '{print \$3}'`
+    echo ${count}
+}
+
+get_failed_count() {
+    count=`flux jobs --stats-only 2>&1 | awk '{print \$5}'`
+    echo ${count}
+}
+
+# submit a whole bunch of jobs for job list testing
+#
+# - the first loop of job submissions are intended to have some jobs run
+#   quickly and complete
+# - the second loop of job submissions are intended to eat up all resources
+# - job ids are stored in files in the order we expect them to be listed
+#   - pending jobs - by priority (highest first), job id (smaller first)
+#   - running jobs - by start time (most recent first)
+#   - inactive jobs - by completion time (most recent first)
+#
+# TODO
+# - alternate userid job listing
+
+test_expect_success 'submit jobs for testing' '
+        #  Create `hostname` and `sleep` jobspec
+        #  N.B. Used w/ `flux job submit` for serial job submission
+        #  for efficiency (vs serial `flux mini submit`.
+        #
+        flux mini submit --dry-run hostname >hostname.json &&
+        flux mini submit --dry-run --time-limit=5m sleep 600 > sleeplong.json &&
+        #
+        # submit jobs that will complete
+        #
+        for i in $(seq 0 3); do
+                flux job submit hostname.json >> inactiveids
+                fj_wait_event `tail -n 1 inactiveids` clean
+        done &&
+        #
+        #  Currently all inactive ids are "completed"
+        #
+        tac inactiveids | flux job id > completed.ids &&
+        #
+        #  Run jobs that will fail, copy its JOBID to both inactive and
+        #   failed lists.
+        #
+        ! jobid=`flux mini submit --wait nosuchcommand` &&
+        echo $jobid >> inactiveids &&
+        flux job id $jobid >> failedids &&
+        jobid=`flux mini submit --time-limit=0.25 sleep 30` &&
+        fj_wait_event $jobid clean &&
+        echo $jobid >> inactiveids &&
+        flux job id $jobid >> failedids &&
+        #
+        #  Submit 8 sleep jobs to fill up resources
+        #
+        for i in $(seq 0 7); do
+                flux job submit sleeplong.json >> runningids
+                fj_wait_event $jobid alloc
+        done &&
+        tac runningids | flux job id > running.ids &&
+        #
+        #  Submit a job and cancel it, copy its JOBID to both inactive
+        #    and failed lists
+        #
+        jobid=`flux mini submit --job-name=canceledjob sleep 30` &&
+        flux job wait-event $jobid depend &&
+        flux job cancel $jobid &&
+        flux job wait-event $jobid clean &&
+        flux job id $jobid >> inactiveids &&
+        flux job id $jobid >> failedids &&
+        tac inactiveids | flux job id > inactive.ids &&
+        tac failedids | flux job id > failed.ids &&
+        # no pending jobs, create empty file of pending job ids
+        touch pending.ids &&
+        #
+        #  Synchronize all expected states
+        #
+        wait_states
+'
+
+test_expect_success HAVE_JQ 'flux job list all inactive jobs' '
+        flux job list -s inactive | jq .id > list_inactive1.out &&
+        test_cmp list_inactive1.out inactive.ids
+'
+
+test_expect_success HAVE_JQ 'flux job list-ids lists all jobs' '
+        ids=`cat inactive.ids | xargs` &&
+        flux job list-ids ${ids} | jq .id > list_inactive2.out &&
+        test_cmp list_inactive2.out inactive.ids
+'
+
+test_expect_success HAVE_JQ 'job-list stats has correct counts' '
+        count=`flux module stats --parse "jobs.inactive" job-list` &&
+        test ${count} -eq $(state_count inactive) &&
+        count=`get_completed_count` &&
+        test ${count} -eq $(state_count completed) &&
+        count=`get_failed_count` &&
+        test ${count} -eq $(state_count failed)
+'
+
+test_expect_success HAVE_JQ 'flux job list-purge 2 jobs' '
+        flux job list-purge --count=2
+'
+
+test_expect_success HAVE_JQ 'remove ids from files that should have been purged' '
+        count=$(state_count completed) &&
+        count=$((count - 2)) &&
+        head -n ${count} completed.ids > completed-purge2.ids &&
+        count=$(state_count inactive) &&
+        count=$((count - 2)) &&
+        head -n ${count} inactive.ids > inactive-purge2.ids
+'
+
+test_expect_success HAVE_JQ 'flux job list inactive jobs updated' '
+        flux job list -s inactive | jq .id > list_inactive3.out &&
+        test_cmp list_inactive3.out inactive-purge2.ids
+'
+
+test_expect_success HAVE_JQ 'flux job list-ids still works' '
+        ids=`cat inactive-purge2.ids | xargs` &&
+        flux job list-ids ${ids} | jq .id > list_inactive4.out &&
+        test_cmp list_inactive4.out inactive-purge2.ids
+'
+
+test_expect_success HAVE_JQ 'flux job list-ids fails on purged job ids' '
+        id1=`tail -n 1 inactive.ids` &&
+        test_must_fail flux job list-ids ${id1} &&
+        id2=`tail -n 2 inactive.ids | head -n 1` &&
+        test_must_fail flux job list-ids ${id2}
+'
+
+test_expect_success HAVE_JQ 'job-list stats has updated counts' '
+        count=`flux module stats --parse "jobs.inactive" job-list` &&
+        test ${count} -eq $(state_count inactive-purge2) &&
+        count=`get_completed_count` &&
+        test ${count} -eq $(state_count completed-purge2) &&
+        count=`get_failed_count` &&
+        test ${count} -eq $(state_count failed)
+'
+
+test_expect_success HAVE_JQ 'flux job list-purge all jobs' '
+        flux job list-purge
+'
+
+test_expect_success HAVE_JQ 'flux job list inactive jobs lists 0 jobs' '
+        count=`flux job list -s inactive | wc -l` &&
+        test $count -eq 0
+'
+
+test_expect_success HAVE_JQ 'job-list stats indicates 0 inactive jobs' '
+        count=`flux module stats --parse "jobs.inactive" job-list` &&
+        test ${count} -eq 0 &&
+        count=`get_completed_count` &&
+        test ${count} -eq 0 &&
+        count=`get_failed_count` &&
+        test ${count} -eq 0
+'
+
+#
+# Bad requests
+#
+test_expect_success 'job-list.purge with invalid count fails with EPROTO(71)' '
+     $jq -j -c -n  "{count:-1}" | ${RPC} job-list.purge 71
+'
+
+test_done


### PR DESCRIPTION
Per comment by @grondo on #3611, here is an alternative take on a solution for #3607.

Instead of supporting a configurable cache size, instead support an RPC to purge the cache of some number (or all) cached inactive jobs.

This helps in two ways.  1) Reduce/eliminate cached data, which can help w/ performance.  2) "reset" the job-list output.  This can be useful for testing purposes or just general use when you wish for really old inactive jobs to no longer be listed.

Throughput tests should similar results to what was in #3611, so won't post them.  Basically regularly calling `flux job list-purge-inactive` ensures job throughput doesn't decrease that much over time.