### PR TITLE
shell: add exit-on-error option

### DIFF
--- a/doc/man1/flux-shell.rst
+++ b/doc/man1/flux-shell.rst
@@ -258,6 +258,10 @@ options are supported by the builtin plugins of ``flux-shell``:
   Flux Standard Duration form.  A value of ``none`` disables generation of
   the exception.
 
+**exit-on-error**
+  If the first task to exit was signaled or exited with a nonzero status,
+  raise a fatal exception on the job immediately.
+
 SHELL INITRC
 ============
 

--- a/t/mpi/version.c
+++ b/t/mpi/version.c
@@ -20,7 +20,6 @@ int main (int argc, char *argv[])
     int len;
     int exit_rc = -1;
 
-    MPI_Init (&argc, &argv);
     MPI_Get_library_version (version, &len);
     if (len < 0) {
         fprintf (stderr, "MPI_Get_library_version failed\n");
@@ -29,7 +28,6 @@ int main (int argc, char *argv[])
     printf ("%s\n", version);
     exit_rc = 0;
 done:
-    MPI_Finalize ();
     return exit_rc;
 }
 

--- a/t/t2614-job-shell-doom.t
+++ b/t/t2614-job-shell-doom.t
@@ -29,8 +29,18 @@ test_expect_success 'flux-shell: run script with 2 tasks and 1s timeout' '
 
 test_expect_success 'flux-shell: run script with 2 nodes and 1s timeout' '
 	test_must_fail run_timeout 30 flux mini run \
-		-n2 -N2 -o exit-timeout=1s ./testscript.sh 2>tmout.err &&
-	grep "exception.*timeout" tmout.err
+		-n2 -N2 -o exit-timeout=1s ./testscript.sh 2>tmout2.err &&
+	grep "exception.*timeout" tmout2.err
+'
+
+test_expect_success 'flux-shell: run script with 2 tasks and exit-on-error' '
+	test_must_fail run_timeout 30 flux mini run \
+		-n2 -o exit-on-error ./testscript.sh
+'
+
+test_expect_success 'flux-shell: run script with 2 nodes and exit-on-error' '
+	test_must_fail run_timeout 30 flux mini run \
+		-n2 -N2 -o exit-on-error ./testscript.sh
 '
 
 test_expect_success 'flux-shell: exit-timeout=aaa is rejected' '

--- a/t/t3000-mpi-basic.t
+++ b/t/t3000-mpi-basic.t
@@ -23,6 +23,10 @@ test_under_flux $SIZE job
 
 OPTS="-ocpu-affinity=off -overbose=1"
 
+test_expect_success 'show MPI version under test' '
+	${FLUX_BUILD_DIR}/t/mpi/version
+'
+
 test_expect_success 'mpi hello various sizes' '
 	run_timeout 30 flux mini submit --cc=1-$MAX_MPI_SIZE $OPTS \
 		--watch -n{cc} ${HELLO} >hello.out &&

--- a/t/t3003-mpi-abort.t
+++ b/t/t3003-mpi-abort.t
@@ -46,6 +46,10 @@ diag() {
 	return 1
 }
 
+test_expect_success 'show MPI version under test' '
+        ${FLUX_BUILD_DIR}/t/mpi/version
+'
+
 # These tests use ! for expected failure rather than 'test_expect_code'
 # because the job exit code is not deterministic.  'test_must_fail' cannot be
 # used either because 128 + SIGNUM is not accepted as "failure".


### PR DESCRIPTION
This PR adds a shell option `exit-on-error` (to the `doom` plugin), which implements the behavior suggested in #3691.

It also allows the MPI abort tests to work on all the MPIs we are testing in CI, so that test is changed to eliminate the skip logic and set this new shell option.