### PR TITLE
libflux: test: fix segfault of test_plugin.t under rpmbuild

### DIFF
--- a/src/common/libflux/Makefile.am
+++ b/src/common/libflux/Makefile.am
@@ -172,6 +172,7 @@ test_ldadd = \
 	$(top_builddir)/src/common/libtomlc99/libtomlc99.la \
 	$(top_builddir)/src/common/libev/libev.la \
 	$(top_builddir)/src/common/libczmqcontainers/libczmqcontainers.la \
+	$(top_builddir)/src/common/libccan/libccan.la \
 	$(ZMQ_LIBS) \
 	$(LIBUUID_LIBS) \
 	$(JANSSON_LIBS) \

--- a/src/common/libflux/test/plugin.c
+++ b/src/common/libflux/test/plugin.c
@@ -392,6 +392,7 @@ void test_register ()
 
 void test_load ()
 {
+    int rc;
     char *out;
     const char *result;
     flux_plugin_t *p = flux_plugin_create ();
@@ -414,8 +415,11 @@ void test_load ()
     ok (result != NULL,
         "conf = %s", result);
 
-    ok (flux_plugin_load_dso (p, "test/.libs/plugin_foo.so") == 0,
+    ok ((rc = flux_plugin_load_dso (p, "test/.libs/plugin_foo.so")) == 0,
         "flux_plugin_load worked");
+    if (rc < 0)
+        BAIL_OUT ("Failed to load test plugin: %s",
+                  flux_plugin_strerror (p));
     is (flux_plugin_get_name (p), "plugin-test",
         "loaded dso registered its own name");
 

--- a/src/test/generate-matrix.py
+++ b/src/test/generate-matrix.py
@@ -199,7 +199,7 @@ matrix.add_build(
 matrix.add_build(
     name="centos8 - py3.7",
     image="centos8",
-    env=dict(PYTHON_VERSION="3.6"),
+    env=dict(PYTHON_VERSION="3.6", LDFLAGS="-Wl,-z,relro  -Wl,-z,now"),
     docker_tag=True,
 )
 


### PR DESCRIPTION
This PR fixes a unit test failure of `src/common/libflux/test_plugin.t` under `rpmbuild` on RHEL8.

The problem was only discovered under `rpmbuild` since rpm adds `'-Wl,-z,relro -Wl,-z,now'` to `LDFLAGS`, causing a test plugin to fail to `dlopen` due to missing symbols that were ignored during normal circumstances.

Addition of `libccan.la` to `test_ldflags` fixes the underlying problem. The test was also enhanced to better report this particular failure (rather than going on to segfault). Finally, the `LDFLAGS` mentioned above are added to the `centos8` build to catch problems like this a little earlier.