### PR TITLE
job-manager: support simple "after*" job dependencies

### DIFF
--- a/doc/man1/flux-mini.rst
+++ b/doc/man1/flux-mini.rst
@@ -133,6 +133,57 @@ emitting the job's I/O to its stdout and stderr.
 **-l, --label-io**
    Add task rank prefixes to each line of output.
 
+DEPENDENCIES
+============
+
+.. note::
+   Flux supports a simple but powerful job dependency specification in jobspec.
+   See Flux Framework RFC 26 for more detailed information about the generic
+   dependency specification.
+
+Dependencies may be specified on the ``flux mini`` command line using the
+following option
+
+**--dependency=URI**
+   Specify a dependency of the submitted job using RFC 26 dependency URI
+   format. The URI format is **SCHEME:VALUE[?key=val[&key=val...]]**.
+   The URI will be converted into RFC 26 JSON object form and appended to
+   the jobspec ``attributes.system.dependencies`` array. If the current
+   Flux instance does not support dependency scheme *SCHEME*, then the
+   submitted job will be rejected with an error message indicating this
+   fact.
+
+   The ``--dependency`` option may be specified multiple times. Each use
+   appends a new dependency object to the ``attributes.system.dependencies``
+   array.
+
+The following dependency schemes are built-in:
+
+.. note::
+   The ``after*`` dependency schemes listed below all require that the
+   target JOBID be currently active. If the target JOBID has become
+   inactive by the time the dependent job is submitted, then the submission
+   will be rejected with an error that the dependency job cannot be found.
+
+after:JOBID
+   This dependency is satisfied after JOBID starts.
+
+afterany:JOBID
+   This dependency is satisfied after JOBID enters the INACTIVE state,
+   regardless of the result
+
+afterok:JOBID
+   This dependency is satisfied after JOBID enters the INACTIVE state
+   with a successful result.
+
+afternotok:JOBID
+   This dependency is satisfied after JOBID enters the INACTIVE state
+   with an unsuccessful result.
+
+In any of the above cases, if it is determined that the dependency cannot
+be satisfied (e.g. a job fails due to an exception with afterok), then
+a fatal exception of type=dependency is raised on the current job.
+
 ENVIRONMENT
 ===========
 

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -529,3 +529,6 @@ jobtap
 unavail
 reprioritize
 reprioritization
+afterany
+afterok
+afternotok

--- a/src/cmd/flux-mini.py
+++ b/src/cmd/flux-mini.py
@@ -225,6 +225,7 @@ class Xcmd:
         "bcc": "--bcc=",
         "log": "--log=",
         "log_stderr": "--log-stderr=",
+        "dependency": "--dependency=",
     }
 
     class Xinput:

--- a/src/modules/job-manager/Makefile.am
+++ b/src/modules/job-manager/Makefile.am
@@ -60,7 +60,8 @@ libjob_manager_la_SOURCES = \
 	jobtap-internal.h \
 	jobtap.h \
 	jobtap.c \
-	plugins/priority-default.c
+	plugins/priority-default.c \
+	plugins/dependency-after.c
 
 fluxinclude_HEADERS = \
 	jobtap.h

--- a/src/modules/job-manager/jobtap.c
+++ b/src/modules/job-manager/jobtap.c
@@ -38,6 +38,7 @@
 #define FLUX_JOBTAP_PRIORITY_UNAVAIL INT64_C(-2)
 
 extern int priority_default_plugin_init (flux_plugin_t *p);
+extern int after_plugin_init (flux_plugin_t *p);
 
 struct jobtap_builtin {
     const char *name;
@@ -46,6 +47,7 @@ struct jobtap_builtin {
 
 static struct jobtap_builtin jobtap_builtins [] = {
     { ".priority-default", priority_default_plugin_init },
+    { ".dependency-after", after_plugin_init },
     { 0 },
 };
 

--- a/src/modules/job-manager/jobtap.c
+++ b/src/modules/job-manager/jobtap.c
@@ -1735,8 +1735,10 @@ int flux_jobtap_get_job_result (flux_plugin_t *p,
                         "context",
                         "status", &waitstatus,
                         "type", &exception_type,
-                        "severity", &exception_severity) < 0)
+                        "severity", &exception_severity) < 0) {
+        errno = EINVAL;
         return -1;
+    }
     if (strcmp (name, "finish") == 0 && waitstatus == 0)
         result = FLUX_JOB_RESULT_COMPLETED;
     else if (strcmp (name, "exception") == 0) {

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -128,6 +128,7 @@ TESTSCRIPTS = \
 	t2260-job-list.t \
 	t2261-job-list-update.t \
 	t2270-job-dependencies.t \
+	t2271-job-dependency-after.t \
 	t2300-sched-simple.t \
 	t2302-sched-simple-up-down.t \
 	t2310-resource-module.t \

--- a/t/t2271-job-dependency-after.t
+++ b/t/t2271-job-dependency-after.t
@@ -1,0 +1,173 @@
+#!/bin/sh
+
+test_description='Test job dependency after* support'
+
+. $(dirname $0)/sharness.sh
+
+flux version | grep -q libflux-security && test_set_prereq FLUX_SECURITY
+
+test_under_flux 1 job
+
+flux setattr log-stderr-level 1
+
+submit_as_alternate_user()
+{
+	FAKE_USERID=42
+	test_debug "echo running flux mini run $@ as userid $FAKE_USERID"
+	flux mini run --dry-run "$@" | \
+		flux python ${SHARNESS_TEST_SRCDIR}/scripts/sign-as.py $FAKE_USERID \
+		>job.signed
+	FLUX_HANDLE_USERID=$FAKE_USERID \
+		flux job submit --flags=signed job.signed
+}
+
+test_expect_success 'dependency=after:invalid rejects invalid target jobids' '
+	test_expect_code 1 flux mini bulksubmit \
+		--dependency={} \
+		--log-stderr={}.err \
+		hostname ::: \
+		after:-1 \
+		after:bar \
+		after:1234 \
+		after:${jobid} &&
+	grep "\"-1\" is not a valid jobid" after:-1.err &&
+	grep "\"bar\" is not a valid jobid" after:bar.err &&
+	grep "job not found" after:1234.err
+'
+test_expect_success FLUX_SECURITY 'dependency=after will not work on another user job' '
+	jobid=$(flux mini submit sleep 300) &&
+	test_debug "echo submitted job $jobid" &&
+	test_expect_code 1 submit_as_alternate_user \
+		--dependency=afterany:$jobid hostname \
+		>baduser.log 2>&1 &&
+	test_debug "cat baduser.log" &&
+	grep "Permission denied" baduser.log &&
+	flux job cancel $jobid
+'
+test_expect_success HAVE_JQ 'dependency=after rejects invalid dependency' '
+	flux mini run --dry-run hostname | \
+	  jq ".attributes.system.dependencies[0] = \
+		{\"scheme\":\"after\", \"value\": 1}" >job.json &&
+	test_expect_code 1 flux job submit job.json
+'
+test_expect_success 'dependency=after works' '
+	jobid=$(flux mini submit --urgency=hold hostname) &&
+	depid=$(flux mini submit --dependency=after:$jobid hostname) &&
+	flux job wait-event -vt 15 $depid dependency-add &&
+	test_debug "echo checking that job ${depid} is in DEPEND state" &&
+	test "$(flux jobs -no {state} $depid)" = "DEPEND" &&
+	flux job urgency $jobid default &&
+	flux job wait-event -vt 15 $depid clean 
+'
+test_expect_success 'dependency=after works when antecedent is running' '
+	jobid=$(flux mini submit sleep 300) &&
+	flux job wait-event -vt 15 $jobid start &&
+	depip=$(flux mini submit --dependency=after:$jobid hostname) &&
+	flux job wait-event -vt 15 $depid clean &&
+	flux job cancel $jobid
+'
+test_expect_success 'dependency=after generates exception for failed job' '
+	jobid=$(flux mini submit --urgency=hold hostname) &&
+	depid=$(flux mini submit --dependency=after:$jobid hostname) &&
+	flux job wait-event -vt 15 $depid dependency-add &&
+	test_debug "echo checking that job ${depid} is in DEPEND state" &&
+	test "$(flux jobs -no {state} $depid)" = "DEPEND" &&
+	flux job cancel $jobid &&
+	flux job wait-event -m type=dependency -vt 15 $depid exception 
+'
+test_expect_success 'dependency=afterany works' '
+	flux mini bulksubmit \
+		--urgency=hold \
+		--job-name={} \
+		--log=jobids.afterany {} 300 \
+		::: true false sleep &&
+	job1=$(sed "1q;d" jobids.afterany) &&
+	job2=$(sed "2q;d" jobids.afterany) &&
+	job3=$(sed "3q;d" jobids.afterany) &&
+	jobid=$(flux mini submit \
+		--dependency=afterany:$job1 \
+		--dependency=afterany:$job2 \
+		--dependency=afterany:$job3 \
+		hostname) &&
+	for id in $(cat jobids.afterany);
+		do flux job urgency $id default;
+	done &&
+	flux jobs &&
+	flux job wait-event -vt 15 \
+		-m description=after-finish=$job2 \
+		$jobid dependency-remove &&
+	flux jobs &&
+	flux job cancel $job3 &&
+	flux job wait-event -vt 15 $jobid clean
+'
+test_expect_success 'dependency=afterok works' '
+	flux mini bulksubmit \
+		--urgency=hold \
+		--job-name={} \
+		--log=jobids.afterok {} 300 \
+		::: true false sleep &&
+	job1=$(sed "1q;d" jobids.afterok) &&
+	job2=$(sed "2q;d" jobids.afterok) &&
+	job3=$(sed "3q;d" jobids.afterok) &&
+	ok1=$(flux mini submit \
+		--dependency=afterok:$job1 \
+		hostname) &&
+	ok2=$(flux mini submit \
+		--dependency=afterok:$job2 \
+		hostname) &&
+	ok3=$(flux mini submit \
+		--dependency=afterok:$job3 \
+		hostname) &&
+	for id in $(cat jobids.afterok);
+		do flux job urgency $id default;
+	done &&
+	flux job wait-event -vt 15 $job3 start &&
+	flux job cancel $job3 &&
+	flux job wait-event -vt 15 \
+		-m description=after-success=$job1 \
+		$ok1 dependency-remove &&
+	flux job wait-event -vt 15 \
+		-m type=dependency $ok2 exception &&
+	flux job wait-event -vt 15 \
+		-m type=dependency $ok2 exception
+'
+test_expect_success 'dependency=afternotok works' '
+	flux mini bulksubmit \
+		--urgency=hold \
+		--job-name={} \
+		--log=jobids.afternotok {} 300 \
+		::: true false sleep &&
+	job1=$(sed "1q;d" jobids.afternotok) &&
+	job2=$(sed "2q;d" jobids.afternotok) &&
+	job3=$(sed "3q;d" jobids.afternotok) &&
+	ok1=$(flux mini submit \
+		--dependency=afternotok:$job1 \
+		hostname) &&
+	ok2=$(flux mini submit \
+		--dependency=afternotok:$job2 \
+		hostname) &&
+	ok3=$(flux mini submit \
+		--dependency=afternotok:$job3 \
+		hostname) &&
+	for id in $(cat jobids.afternotok);
+		do flux job urgency $id default;
+	done &&
+	flux job wait-event -vt 15 $job3 start &&
+	flux job cancel $job3 &&
+	flux job wait-event -vt 15 \
+		-m description=after-failure=$job2 \
+		$ok2 dependency-remove &&
+	flux job wait-event -vt 15 \
+		-m description=after-failure=$job3 \
+		$ok3 dependency-remove &&
+	flux job wait-event -vt 15 \
+		-m type=dependency $ok1 exception
+'
+test_expect_success 'jobs with dependencies can be safely canceled' '
+	jobid=$(flux mini submit --urgency=hold hostname) &&
+	depid=$(flux mini submit --dependency=after:$jobid hostname) &&
+	flux job cancel $depid &&
+	flux job urgency $jobid default &&
+	flux job wait-event -vt 15 $jobid clean
+'
+test_done


### PR DESCRIPTION
This is  WIP PR which adds support for simple `after{,any,ok,notok}` dependency schemes.

The implementation roughly mimics that of Slurm's `--dependency=after*:JOBID` feature. I'm not sure Slurm's interface is the greatest, but it didn't seem like a good idea to arbitrarily change it, at least at first.

This is posted as WIP before it is fully complete (mostly need testing) to ensure that the approach and design of the feature are on the right track (before spending a bunch of time testing). Especially @SteVwonder and @ryanday36 may want to give their approval of the interface.

One difference between this and Slurm's `--dependency=after*` feature is that, in the current implementation, jobs for which a dependency could never be satisfied, e.g. `afterok` is used and the requisite job fails, have a fatal exception raised. In Slurm these jobs stay in the queue until they are canceled or updated. (since we can't update jobs yet, there seemed no reason to keep the job queued)

Part of the reason this dependency plugin was implemented was to ensure that the jobtap interface had enough support for something like this. Indeed, several bugs and required features were found, fixed and added here, including:

 * Addition of `flux_jobtap_job_lookup()` to lookup any currently active job in the job-manager. The result is returned as a `flux_plugin_arg_t *` to reduce any code duplication, however that choice could be controversial...
 *  Addition of `flux_jobtap_get_job_result()` to return the `flux_job_result_t` of a job in the `job.state.{CLEANUP,INACTIVE}` callback contexts. Providing this function required that the job-manager store the `end_event` for jobs whether they are waitable or not. Since the event adds only a small amount of extra memory to non-waitable jobs, and only in the final two job states, this will probably have zero impact. However @garlick should probably comment.
 *  Replace `jobtap->current_job` with a stack of "current jobs" to make the jobtap interface reentrant. This fixes a bug when jobtap callbacks end up calling callbacks of other jobs (e.g. when releasing a dependency which causes a state transition)
 * Ensure that all cached dependency-remove events are emitted _after_ all dependency-add events, otherwise a job can be prematurely released from the DEPEND state.

Finally, some examples:

Job runs after another job successfully completes:
```
$ flux mini run -vvv --dependency=afterok:$(flux mini submit sleep 2) hostname
jobid: ƒBpaaPscj
0.000s: job.submit {"userid":1000,"urgency":16,"flags":0}
0.013s: job.dependency-add {"description":"after-success=ƒBpUKAuaF"}
1.844s: job.dependency-remove {"description":"after-success=ƒBpUKAuaF"}
1.844s: job.depend
1.844s: job.priority {"priority":16}
1.845s: job.alloc {"annotations":{"sched":{"resource_summary":"rank0/core0"}}}
1.850s: job.start
[snip]
```

Job exception raised if dependency can't be satisfied
```
$ flux mini run -vvv --dependency=afternotok:$(flux mini submit sleep 2) hostname
jobid: ƒC9C3kwd9
0.000s: job.submit {"userid":1000,"urgency":16,"flags":0}
0.013s: job.dependency-add {"description":"after-failure=ƒC961ss7m"}
1.853s: job.exception type=dependency severity=0 dependency after-failure=ƒC961ss7m can never be satisfied
1.853s: job.clean
```

job with multiple dependencies
```
$ flux mini run -vvv --dependency=after:$(flux mini submit sleep 1) --dependency=afterany:$(flux mini submit sleep 3) --dependency=afterok:$(flux mini submit sleep 1) --dependency=afternotok:$(flux mini submit -t 5s sleep 10) hostname
jobid: ƒCPtQi2mm
0.000s: job.submit {"userid":1000,"urgency":16,"flags":0}
0.013s: job.dependency-add {"description":"after-start=ƒCPTe82hd"}
0.013s: job.dependency-add {"description":"after-finish=ƒCPZg17D1"}
0.013s: job.dependency-add {"description":"after-success=ƒCPfkrAH5"}
0.013s: job.dependency-add {"description":"after-failure=ƒCPn6X6Ab"}
0.013s: job.dependency-remove {"description":"after-start=ƒCPTe82hd"}
0.585s: job.dependency-remove {"description":"after-success=ƒCPfkrAH5"}
2.349s: job.dependency-remove {"description":"after-finish=ƒCPZg17D1"}
4.779s: job.dependency-remove {"description":"after-failure=ƒCPn6X6Ab"}
4.779s: job.depend
4.779s: job.priority {"priority":16}
4.784s: job.alloc {"annotations":{"sched":{"resource_summary":"rank0/core0"}}}
4.789s: job.start
[snip]
```