### PR TITLE
jobtap: fixes and api enhancements to support dependency plugins

### DIFF
--- a/src/cmd/flux-mini.py
+++ b/src/cmd/flux-mini.py
@@ -65,7 +65,7 @@ class Dependency:
     def entry(self):
         entry = {
             "scheme": self.scheme,
-            "value": self._try_number(self.path),
+            "value": self.path,
         }
         if self.uri.query:
             for key, val in parse_qs(self.uri.query).items():

--- a/src/modules/job-manager/event.c
+++ b/src/modules/job-manager/event.c
@@ -489,8 +489,7 @@ static const char *state_topic (struct job *job)
 }
 
 /* This function implements state transitions per RFC 21.
- * If FLUX_JOB_WAITABLE flag is set, then on a fatal exception or
- * cleanup event, capture the event in job->end_event for flux_job_wait().
+ * On a fatal exception or cleanup event, capture the event in job->end_event.
  */
 int event_job_update (struct job *job, json_t *event)
 {
@@ -543,7 +542,7 @@ int event_job_update (struct job *job, json_t *event)
         if (event_exception_context_decode (context, &severity) < 0)
             goto error;
         if (severity == 0) {
-            if ((job->flags & FLUX_JOB_WAITABLE) && !job->end_event)
+            if (!job->end_event)
                 job->end_event = json_incref (event);
 
             job->state = FLUX_JOB_STATE_CLEANUP;
@@ -567,7 +566,7 @@ int event_job_update (struct job *job, json_t *event)
             && job->state != FLUX_JOB_STATE_CLEANUP)
             goto inval;
         if (job->state == FLUX_JOB_STATE_RUN) {
-            if ((job->flags & FLUX_JOB_WAITABLE) && !job->end_event)
+            if (!job->end_event)
                 job->end_event = json_incref (event);
 
             job->state = FLUX_JOB_STATE_CLEANUP;

--- a/src/modules/job-manager/jobtap.c
+++ b/src/modules/job-manager/jobtap.c
@@ -1643,6 +1643,22 @@ int flux_jobtap_raise_exception (flux_plugin_t *p,
     return rc;
 }
 
+flux_plugin_arg_t * flux_jobtap_job_lookup (flux_plugin_t *p,
+                                            flux_jobid_t id)
+{
+    struct jobtap *jobtap;
+    struct job *job;
+    if (!p || !(jobtap = flux_plugin_aux_get (p, "flux::jobtap"))) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (!(job = jobtap_lookup_jobid (p, id))) {
+        errno = ENOENT;
+        return NULL;
+    }
+    return jobtap_args_create (jobtap, job);
+}
+
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab
  */

--- a/src/modules/job-manager/jobtap.h
+++ b/src/modules/job-manager/jobtap.h
@@ -152,6 +152,11 @@ int flux_jobtap_raise_exception (flux_plugin_t *p,
  */
 flux_plugin_arg_t * flux_jobtap_job_lookup (flux_plugin_t *p,
                                             flux_jobid_t id);
+
+
+int flux_jobtap_get_job_result (flux_plugin_t *p,
+                                flux_jobid_t id,
+                                flux_job_result_t *resultp);
 #ifdef __cplusplus
 }
 #endif

--- a/src/modules/job-manager/jobtap.h
+++ b/src/modules/job-manager/jobtap.h
@@ -140,6 +140,18 @@ int flux_jobtap_raise_exception (flux_plugin_t *p,
                                  int severity,
                                  const char *fmt,
                                  ...);
+
+/*  Return a flux_plugin_arg_t object for any active job.
+ *
+ *  The result can then be unpacked with flux_plugin_arg_unpack(3) to get
+ *   active job information such as userid, state, etc.
+ *
+ *  If `id` is not an active job then NULL is returned with ENOENT set.
+ *
+ *  Caller must free with flux_plugin_arg_destroy(3).
+ */
+flux_plugin_arg_t * flux_jobtap_job_lookup (flux_plugin_t *p,
+                                            flux_jobid_t id);
 #ifdef __cplusplus
 }
 #endif

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -351,6 +351,7 @@ check_LTLIBRARIES = \
 	job-manager/plugins/args.la \
 	job-manager/plugins/test.la \
 	job-manager/plugins/job_aux.la \
+	job-manager/plugins/jobtap_api.la \
 	job-manager/plugins/random.la \
 	job-manager/plugins/validate.la \
 	job-manager/plugins/dependency-test.la
@@ -739,6 +740,15 @@ job_manager_plugins_job_aux_la_CPPFLAGS = \
 job_manager_plugins_job_aux_la_LDFLAGS = \
 	$(fluxplugin_ldflags) -module -rpath /nowhere
 job_manager_plugins_job_aux_la_LIBADD = \
+	$(top_builddir)/src/common/libflux-core.la
+
+job_manager_plugins_jobtap_api_la_SOURCES = \
+	job-manager/plugins/jobtap_api.c
+job_manager_plugins_jobtap_api_la_CPPFLAGS = \
+	$(test_cppflags)
+job_manager_plugins_jobtap_api_la_LDFLAGS = \
+	$(fluxplugin_ldflags) -module -rpath /nowhere
+job_manager_plugins_jobtap_api_la_LIBADD = \
 	$(top_builddir)/src/common/libflux-core.la
 
 job_manager_plugins_random_la_SOURCES = \

--- a/t/job-manager/plugins/jobtap_api.c
+++ b/t/job-manager/plugins/jobtap_api.c
@@ -1,0 +1,244 @@
+/************************************************************\
+ * Copyright 2020 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#include <string.h>
+#include <errno.h>
+#include <flux/core.h>
+#include <flux/jobtap.h>
+
+static int test_job_lookup (flux_plugin_t *p,
+                            const char *topic,
+                            flux_plugin_arg_t *args)
+{
+    flux_jobid_t id;
+    flux_jobid_t lookupid = FLUX_JOBID_ANY;
+    flux_plugin_arg_t *oarg;
+
+    if (flux_plugin_arg_unpack (args,
+                                FLUX_PLUGIN_ARG_IN,
+                                "{s:I s:{s:{s:{s?I}}}}",
+                                "id", &id,
+                                "jobspec",
+                                  "attributes",
+                                    "system",
+                                      "lookup-id", &lookupid) < 0)
+        return flux_jobtap_raise_exception (p, FLUX_JOBTAP_CURRENT_JOB,
+                                            "test", 0,
+                                            "%s: failed to unpack lookupid: %s",
+                                            topic,
+                                            flux_plugin_arg_strerror (args));
+
+    errno = 0;
+    oarg = flux_jobtap_job_lookup (NULL, FLUX_JOBID_ANY);
+    if (oarg != NULL || errno != EINVAL)
+        return flux_jobtap_raise_exception (p, FLUX_JOBTAP_CURRENT_JOB,
+                                           "test", 0,
+                                           "%s: %s: expected errno=%d got %d",
+                                           topic,
+                                           "flux_jobtap_job_lookup",
+                                           EINVAL,
+                                           errno);
+
+    errno = 0;
+    oarg = flux_jobtap_job_lookup (p, 1234);
+    if (oarg != NULL || errno != ENOENT)
+        return flux_jobtap_raise_exception (p, FLUX_JOBTAP_CURRENT_JOB,
+                                           "test", 0,
+                                           "%s: %s: expected errno=%d got %d",
+                                           topic,
+                                           "flux_jobtap_job_lookup",
+                                           ENOENT,
+                                           errno);
+
+    /*  lookup current job works */
+    oarg = flux_jobtap_job_lookup (p, FLUX_JOBTAP_CURRENT_JOB);
+    if (oarg == NULL)
+        return flux_jobtap_raise_exception (p, FLUX_JOBTAP_CURRENT_JOB,
+                                           "test", 0,
+                                           "%s: %s: on current job failed: %s",
+                                           topic,
+                                           "flux_jobtap_job_lookup",
+                                           strerror (errno));
+    flux_plugin_arg_destroy (oarg);
+
+    /*  Skip final test if lookupid not set in jobspec */
+    if (lookupid == FLUX_JOBID_ANY)
+        return 0;
+
+    /*  lookup other job works */
+    oarg = flux_jobtap_job_lookup (p, lookupid);
+    if (oarg == NULL)
+        return flux_jobtap_raise_exception (p, FLUX_JOBTAP_CURRENT_JOB,
+                                           "test", 0,
+                                           "%s: %s: on %ju failed: %s",
+                                           topic,
+                                           "flux_jobtap_job_lookup",
+                                           (uintmax_t) lookupid,
+                                           strerror (errno));
+    return 0;
+}
+
+static int test_job_result (flux_plugin_t *p,
+                            const char *topic,
+                            flux_plugin_arg_t *args)
+{
+    int rc;
+    flux_jobid_t id;
+    flux_job_result_t result;
+    flux_job_result_t expected_result = FLUX_JOB_RESULT_COMPLETED;
+    const char *s = NULL;
+
+    if (flux_plugin_arg_unpack (args,
+                                FLUX_PLUGIN_ARG_IN,
+                                "{s:I s:{s:{s:{s?s}}}}",
+                                "id", &id,
+                                "jobspec",
+                                  "attributes",
+                                    "system",
+                                      "expected-result", &s) < 0)
+        return flux_jobtap_raise_exception (p, FLUX_JOBTAP_CURRENT_JOB,
+                                            "test", 0,
+                                            "%s: failed to unpack result: %s",
+                                            topic,
+                                            flux_plugin_arg_strerror (args));
+
+    if (s != NULL && flux_job_strtoresult (s, &expected_result) < 0)
+        return flux_jobtap_raise_exception (p, FLUX_JOBTAP_CURRENT_JOB,
+                                            "test", 0,
+                                            "%s: flux_job_strtoresult: %s",
+                                            topic,
+                                            strerror (errno));
+
+    /*  Test flux_jobtap_get_job_result(3) ENOENT */
+    errno = 0;
+    rc = flux_jobtap_get_job_result (p, 1234, &result);
+    if (rc == 0 || errno != ENOENT)
+        return flux_jobtap_raise_exception (p, FLUX_JOBTAP_CURRENT_JOB,
+                                           "test", 0,
+                                           "%s: %s: expected errno=%d got %d",
+                                           topic,
+                                           "flux_jobtap_get_job_result",
+                                           ENOENT,
+                                           errno);
+
+    /*  Test flux_jobtap_get_job_result(3) EINVAL */
+    errno = 0;
+    rc = flux_jobtap_get_job_result (NULL, 1234, &result);
+    if (rc == 0 || errno != EINVAL)
+        return flux_jobtap_raise_exception (p, FLUX_JOBTAP_CURRENT_JOB,
+                                           "test", 0,
+                                           "%s: %s: expected errno=%d got %d",
+                                           topic,
+                                           "flux_jobtap_get_job_result",
+                                           EINVAL,
+                                           errno);
+
+
+    rc = flux_jobtap_get_job_result (p,
+                                     FLUX_JOBTAP_CURRENT_JOB,
+                                     &result);
+    if (rc < 0 || expected_result != result)
+        return flux_jobtap_raise_exception (p, FLUX_JOBTAP_CURRENT_JOB,
+                                           "test", 0,
+                                           "%s: %s: expected errno=%d got %d",
+                                           topic,
+                                           "flux_jobtap_get_job_result",
+                                           ENOENT,
+                                           errno);
+
+    return 0;
+}
+
+static int inactive_cb (flux_plugin_t *p,
+                        const char *topic,
+                        flux_plugin_arg_t *args,
+                        void *arg)
+{
+    return test_job_result (p, topic, args);
+}
+
+static int cleanup_cb (flux_plugin_t *p,
+                       const char *topic,
+                       flux_plugin_arg_t *args,
+                       void *arg)
+{
+    return test_job_result (p, topic, args);
+}
+
+static int run_cb (flux_plugin_t *p,
+                   const char *topic,
+                   flux_plugin_arg_t *args,
+                   void *arg)
+{
+    int rc;
+    flux_job_result_t result;
+
+    /*  Test flux_jobtap_get_job_result(3) returns EINVAL here */
+    errno = 0;
+    rc = flux_jobtap_get_job_result (p, FLUX_JOBTAP_CURRENT_JOB, &result);
+    if (rc == 0 || errno != EINVAL)
+        return flux_jobtap_raise_exception (p, FLUX_JOBTAP_CURRENT_JOB,
+                                           "test", 0,
+                                           "%s: %s: expected errno=%d got %d",
+                                           topic,
+                                           "flux_jobtap_get_job_result",
+                                           EINVAL,
+                                           errno);
+    return 0;
+}
+
+static int sched_cb (flux_plugin_t *p,
+                     const char *topic,
+                     flux_plugin_arg_t *args,
+                     void *arg)
+{
+    return 0;
+}
+
+static int priority_cb (flux_plugin_t *p,
+                        const char *topic,
+                        flux_plugin_arg_t *args,
+                        void *arg)
+{
+    return 0;
+}
+
+static int depend_cb (flux_plugin_t *p,
+                      const char *topic,
+                      flux_plugin_arg_t *args,
+                      void *arg)
+{
+    return test_job_lookup (p, topic, args);
+}
+
+
+static int validate_cb (flux_plugin_t *p,
+                        const char *topic,
+                        flux_plugin_arg_t *args,
+                        void *arg)
+{
+    return test_job_lookup (p, topic, args);
+}
+
+static const struct flux_plugin_handler tab[] = {
+    { "job.validate",       validate_cb, NULL },
+    { "job.state.priority", priority_cb, NULL },
+    { "job.state.depend",   depend_cb,   NULL },
+    { "job.state.sched",    sched_cb,    NULL },
+    { "job.state.run",      run_cb,      NULL },
+    { "job.state.cleanup",  cleanup_cb,  NULL },
+    { "job.state.inactive", inactive_cb, NULL },
+    { 0 }
+};
+
+int flux_plugin_init (flux_plugin_t *p)
+{
+    return flux_plugin_register (p, "api-test", tab);
+}

--- a/t/t2270-job-dependencies.t
+++ b/t/t2270-job-dependencies.t
@@ -19,17 +19,19 @@ test_expect_success HAVE_JQ 'flux-mini: --dependency option works' '
 	flux mini run --dry-run \
 		--env=-* \
 		--dependency=foo:1234 \
+		--dependency=foo:3.1415 \
 		--dependency=foo:f1?val=bar \
 		--dependency="foo:f1?val=a&val=b" true | \
 		jq '.attributes.system.dependencies' > deps.json &&
 	test_debug "cat deps.json" &&
 	jq -e ".[0].scheme == \"foo\"" < deps.json &&
-	jq -e ".[0].value == 1234" < deps.json &&
-	jq -e ".[1].scheme == \"foo\"" < deps.json &&
-	jq -e ".[1].value == \"f1\""   < deps.json &&
-	jq -e ".[1].val == \"bar\""    < deps.json &&
-	jq -e ".[2].val[0] == \"a\""   < deps.json &&
-	jq -e ".[2].val[1] == \"b\""   < deps.json
+	jq -e ".[0].value == \"1234\"" < deps.json &&
+	jq -e ".[1].value == \"3.1415\"" < deps.json &&
+	jq -e ".[2].scheme == \"foo\"" < deps.json &&
+	jq -e ".[2].value == \"f1\""   < deps.json &&
+	jq -e ".[2].val == \"bar\""    < deps.json &&
+	jq -e ".[3].val[0] == \"a\""   < deps.json &&
+	jq -e ".[3].val[1] == \"b\""   < deps.json
 '
 test_expect_success 'submitted job with unknown dependency scheme is rejected' '
 	test_must_fail flux mini submit --dependency=invalid:value hostname


### PR DESCRIPTION
This PR is pulled from #3696, it felt better to split these more generic jobtap fixes and enhancements from the addition of the `dependency-after` jobtap plugin itself.

This PR includes the following:
  * change `--dependency=scheme:value` in `flux-mini` to always encode `value` as a string per RFC 26
  * fix reentrancy of jobtap->current_job
  * capture job->end_event for all jobs, not just waitable
  * add `flux_jobtap_get_job_result()`
  * add `flux_jobtap_lookup_job()`
 
Along with corresponding testsuite updates.