### PR TITLE
libflux: store fully decoded message in flux_msg_t

### DIFF
--- a/src/common/libflux/Makefile.am
+++ b/src/common/libflux/Makefile.am
@@ -8,6 +8,7 @@ AM_LDFLAGS = \
 AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
+	-I$(top_srcdir)/src/common/libccan \
 	-I$(top_builddir) \
 	-I$(top_builddir)/src/common/libflux \
 	$(JANSSON_CFLAGS) \

--- a/src/common/libflux/message.h
+++ b/src/common/libflux/message.h
@@ -306,15 +306,14 @@ const char *flux_msg_typestr (int type);
  * routing.
  */
 
-/* Prepare a message for routing, which consists of pushing a nil delimiter
- * frame and setting FLUX_MSGFLAG_ROUTE.  This function is a no-op if the
- * flag is already set.
+/* Prepare a message for routing by setting FLUX_MSGFLAG_ROUTE.  This
+ * function is a no-op if the flag is already set.
  * Returns 0 on success, -1 with errno set on failure.
  */
 int flux_msg_enable_route (flux_msg_t *msg);
 
-/* Strip route frames, nil delimiter, and clear FLUX_MSGFLAG_ROUTE flag.
- * This function is a no-op if the flag is already clear.
+/* Clear routes from msg and clear FLUX_MSGFLAG_ROUTE flag.  This
+ * function is a no-op if the flag is already clear.
  * Returns 0 on success, -1 with errno set on failure.
  */
 int flux_msg_clear_route (flux_msg_t *msg);
@@ -331,14 +330,14 @@ int flux_msg_push_route (flux_msg_t *msg, const char *id);
  */
 int flux_msg_pop_route (flux_msg_t *msg, char **id);
 
-/* Copy the first routing frame (closest to delimiter) contents (or NULL)
+/* Copy the first route (e.g. first pushed route) contents (or NULL)
  * to 'id'.  Caller must free 'id'.
  * For requests, this is the sender; for responses, this is the recipient.
  * Returns 0 on success, -1 with errno set (e.g. EPROTO) on failure.
  */
 int flux_msg_get_route_first (const flux_msg_t *msg, char **id);
 
-/* Copy the last routing frame (farthest from delimiter) contents (or NULL)
+/* Copy the last route (e.g. most recent pushed route) contents (or NULL)
  * to 'id'.  Caller must free 'id'.
  * For requests, this is the last hop; for responses: this is the next hop.
  * Returns 0 on success, -1 with errno set (e.g. EPROTO) on failure.

--- a/src/common/libflux/test/message.c
+++ b/src/common/libflux/test/message.c
@@ -315,61 +315,61 @@ void check_routes (void)
         "flux_msg_create works and creates msg with 1 frame");
 
     ok (flux_msg_clear_route (msg) == 0 && flux_msg_frames (msg) == 1,
-        "flux_msg_clear_route works, is no-op on msg w/o delim");
+        "flux_msg_clear_route works, is no-op on msg w/o routes enabled");
     ok (flux_msg_enable_route (msg) == 0 && flux_msg_frames (msg) == 2,
-        "flux_msg_enable_route works, adds one frame on msg w/o delim");
+        "flux_msg_enable_route works, adds one frame on msg w/ routes enabled");
     ok ((flux_msg_get_route_count (msg) == 0),
-        "flux_msg_get_route_count returns 0 on msg w/delim");
+        "flux_msg_get_route_count returns 0 on msg w/o routes");
     ok (flux_msg_pop_route (msg, &s) == 0 && s == NULL,
         "flux_msg_pop_route works and sets id to NULL on msg w/o routes");
 
     ok (flux_msg_get_route_first (msg, &s) == 0 && s == NULL,
-        "flux_msg_get_route_first returns 0, id=NULL on msg w/delim");
+        "flux_msg_get_route_first returns 0, id=NULL on msg w/o routes");
     ok (flux_msg_get_route_last (msg, &s) == 0 && s == NULL,
-        "flux_msg_get_route_last returns 0, id=NULL on msg w/delim");
+        "flux_msg_get_route_last returns 0, id=NULL on msg w/o routes");
     ok (flux_msg_push_route (msg, "sender") == 0 && flux_msg_frames (msg) == 3,
         "flux_msg_push_route works and adds a frame");
     ok ((flux_msg_get_route_count (msg) == 1),
-        "flux_msg_get_route_count returns 1 on msg w/delim+id");
+        "flux_msg_get_route_count returns 1 on msg w/ id1");
 
     ok (flux_msg_get_route_first (msg, &s) == 0 && s != NULL,
         "flux_msg_get_route_first works");
     like (s, "sender",
-        "flux_msg_get_route_first returns id on msg w/delim+id");
+        "flux_msg_get_route_first returns id on msg w/ id1");
     free (s);
 
     ok (flux_msg_get_route_last (msg, &s) == 0 && s != NULL,
         "flux_msg_get_route_last works");
     like (s, "sender",
-        "flux_msg_get_route_last returns id on msg w/delim+id");
+        "flux_msg_get_route_last returns id on msg w/ id1");
     free (s);
 
     ok (flux_msg_push_route (msg, "router") == 0 && flux_msg_frames (msg) == 4,
         "flux_msg_push_route works and adds a frame");
     ok ((flux_msg_get_route_count (msg) == 2),
-        "flux_msg_get_route_count returns 2 on msg w/delim+id1+id2");
+        "flux_msg_get_route_count returns 2 on msg w/ id1+id2");
 
     ok (flux_msg_get_route_first (msg, &s) == 0 && s != NULL,
         "flux_msg_get_route_first works");
     like (s, "sender",
-        "flux_msg_get_route_first returns id1 on msg w/delim+id1+id2");
+        "flux_msg_get_route_first returns id1 on msg w/ id1+id2");
     free (s);
 
     ok (flux_msg_get_route_last (msg, &s) == 0 && s != NULL,
         "flux_msg_get_route_last works");
     like (s, "router",
-        "flux_msg_get_route_last returns id2 on message with delim+id1+id2");
+        "flux_msg_get_route_last returns id2 on message with id1+id2");
     free (s);
 
     s = NULL;
     ok (flux_msg_pop_route (msg, &s) == 0 && s != NULL,
         "flux_msg_pop_route works on msg w/routes");
     like (s, "router",
-        "flux_msg_pop_route returns id2 on message with delim+id1+id2");
+        "flux_msg_pop_route returns id2 on message with id1+id2");
     free (s);
 
     ok (flux_msg_clear_route (msg) == 0 && flux_msg_frames (msg) == 1,
-        "flux_msg_clear_route strips routing frames and delim");
+        "flux_msg_clear_route clear routing frames");
     flux_msg_destroy (msg);
 }
 

--- a/src/common/libflux/test/message.c
+++ b/src/common/libflux/test/message.c
@@ -22,11 +22,12 @@
 void check_cornercase (void)
 {
     flux_msg_t *msg;
+    flux_msg_t *req, *rsp, *evt;
     struct flux_msg_cred cred;
-    uint32_t seq;
+    uint32_t seq, nodeid;
     uint8_t encodebuf[64];
     size_t encodesize = 64;
-    int errnum, status;
+    int type, errnum, status;
     uint32_t tag;
     uint8_t flags;
     char *route;
@@ -34,7 +35,17 @@ void check_cornercase (void)
     const void *payload;
     int payload_size;
 
+    errno = 0;
+    ok (flux_msg_create (0xFFFF) == NULL && errno == EINVAL,
+        "flux_msg_create fails with EINVAL on invalid type");
+
     if (!(msg = flux_msg_create (FLUX_MSGTYPE_REQUEST)))
+        BAIL_OUT ("flux_msg_create failed");
+    if (!(req = flux_msg_create (FLUX_MSGTYPE_REQUEST)))
+        BAIL_OUT ("flux_msg_create failed");
+    if (!(rsp = flux_msg_create (FLUX_MSGTYPE_RESPONSE)))
+        BAIL_OUT ("flux_msg_create failed");
+    if (!(evt = flux_msg_create (FLUX_MSGTYPE_EVENT)))
         BAIL_OUT ("flux_msg_create failed");
 
     lives_ok ({flux_msg_destroy (NULL);},
@@ -46,6 +57,10 @@ void check_cornercase (void)
     errno = 0;
     ok (flux_msg_aux_get (NULL, "foo") == NULL && errno == EINVAL,
         "flux_msg_aux_get msg=NULL fails with EINVAL");
+
+    errno = 0;
+    ok (flux_msg_copy (NULL, true) == NULL && errno == EINVAL,
+        "flux_msg_copy msg=NULL fails with EINVAL");
 
     errno = 0;
     ok (flux_msg_incref (NULL) == NULL && errno == EINVAL,
@@ -64,6 +79,13 @@ void check_cornercase (void)
         "flux_msg_frames returns -1 errno EINVAL on msg = NULL");
 
     errno = 0;
+    ok (flux_msg_set_type (NULL, 0) < 0 && errno == EINVAL,
+        "flux_msg_set_type fails with EINVAL on msg = NULL");
+    errno = 0;
+    ok (flux_msg_get_type (NULL, &type) < 0 && errno == EINVAL,
+        "flux_msg_get_type fails with EINVAL on msg = NULL");
+
+    errno = 0;
     ok (flux_msg_set_private (NULL) < 0 && errno == EINVAL,
         "flux_msg_set_private msg=NULL fails with EINVAL");
     ok (flux_msg_is_private (NULL) == true,
@@ -80,14 +102,21 @@ void check_cornercase (void)
         "flux_msg_is_noresponse msg=NULL returns true");
 
     errno = 0;
-    ok (flux_msg_set_payload (NULL, NULL, 0) < 0 && errno == EINVAL,
-        "flux_msg_set_payload msg=NULL fails with EINVAL");
+    ok (flux_msg_set_topic (NULL, "foobar") < 0 && errno == EINVAL,
+       "flux_msg_set_topic fails with EINVAL on msg = NULL");
     errno = 0;
     ok (flux_msg_get_topic (msg, NULL) < 0 && errno == EINVAL,
        "flux_msg_get_topic fails with EINVAL on in-and-out param = NULL");
     errno = 0;
     ok (flux_msg_get_topic (msg, &topic) < 0 && errno == EPROTO,
        "flux_msg_get_topic fails with EPROTO on msg w/o topic");
+
+    errno = 0;
+    ok (flux_msg_set_payload (NULL, NULL, 0) < 0 && errno == EINVAL,
+        "flux_msg_set_payload msg=NULL fails with EINVAL");
+    errno = 0;
+    ok (flux_msg_get_payload (NULL, NULL, NULL) < 0 && errno == EINVAL,
+        "flux_msg_get_payload msg=NULL fails with EINVAL");
     errno = 0;
     ok (flux_msg_get_payload (msg, NULL, NULL) < 0 && errno == EINVAL,
        "flux_msg_get_payload fails with EINVAL on in-and-out params = NULL");
@@ -95,6 +124,8 @@ void check_cornercase (void)
     ok (flux_msg_get_payload (msg, &payload, &payload_size) < 0
         && errno == EPROTO,
        "flux_msg_get_payload fails with EPROTO on msg w/o payload");
+    ok (flux_msg_has_payload (NULL) == false,
+        "flux_msg_has_payload returns false on msg = NULL");
 
     errno = 0;
     ok (flux_msg_get_flags (NULL, &flags) < 0 && errno == EINVAL,
@@ -118,9 +149,24 @@ void check_cornercase (void)
     ok (flux_msg_pack (NULL, "{s:i}", "foo", 42) < 0 && errno == EINVAL,
        "flux_msg_pack msg=NULL fails with EINVAL");
     errno = 0;
+    ok (flux_msg_pack (msg, NULL) < 0 && errno == EINVAL,
+        "flux_msg_pack fails with EINVAL with NULL format");
+    errno = 0;
+    ok (flux_msg_unpack (NULL, "{s:i}", "type", &type) < 0 && errno == EINVAL,
+       "flux_msg_unpack msg=NULL fails with EINVAL");
+    errno = 0;
     ok (flux_msg_unpack (msg, NULL) < 0 && errno == EINVAL,
         "flux_msg_unpack fails with EINVAL with NULL format");
 
+    errno = 0;
+    ok (flux_msg_set_nodeid (NULL, 0) < 0 && errno == EINVAL,
+                "flux_msg_set_nodeid fails with EINVAL on msg = NULL");
+    errno = 0;
+    ok (flux_msg_get_nodeid (NULL, &nodeid) < 0 && errno == EINVAL,
+        "flux_msg_get_nodeid fails with EINVAL on msg = NULL");
+    errno = 0;
+    ok (flux_msg_get_nodeid (rsp, &nodeid) < 0 && errno == EPROTO,
+        "flux_msg_get_nodeid fails with PROTO on msg != request type");
     errno = 0;
     ok (flux_msg_get_userid (NULL, &cred.userid) < 0 && errno == EINVAL,
         "flux_msg_get_userid msg=NULL fails with EINVAL");
@@ -163,6 +209,9 @@ void check_cornercase (void)
     ok (flux_msg_get_errnum (msg, NULL) < 0 && errno == EINVAL,
         "flux_msg_get_errnum fails with EINVAL on in-and-out param = NULL");
     errno = 0;
+    ok (flux_msg_get_errnum (req, &errnum) < 0 && errno == EPROTO,
+        "flux_msg_get_errnum fails with EPROTO on msg != response type");
+    errno = 0;
     ok (flux_msg_set_seq (NULL, 0) < 0 && errno == EINVAL,
         "flux_msg_set_seq fails with EINVAL on msg = NULL");
     errno = 0;
@@ -171,6 +220,9 @@ void check_cornercase (void)
     errno = 0;
     ok (flux_msg_get_seq (msg, NULL) < 0 && errno == EINVAL,
         "flux_msg_get_seq fails with EINVAL on in-and-out param = NULL");
+    errno = 0;
+    ok (flux_msg_get_seq (req, &seq) < 0 && errno == EPROTO,
+        "flux_msg_get_seq fails with EPROTO on msg != event type");
     errno = 0;
     ok (flux_msg_set_status (NULL, 0) < 0 && errno == EINVAL,
         "flux_msg_set_status fails with EINVAL on msg = NULL");
@@ -181,6 +233,9 @@ void check_cornercase (void)
     ok (flux_msg_get_status (msg, NULL) < 0 && errno == EINVAL,
         "flux_msg_get_status fails with EINVAL on in-and-out param = NULL");
     errno = 0;
+    ok (flux_msg_get_status (req, &status) < 0 && errno == EPROTO,
+        "flux_msg_get_status fails with EPROTO on msg != keepalive type");
+    errno = 0;
     ok (flux_msg_set_matchtag (NULL, 42) < 0 && errno == EINVAL,
         "flux_msg_set_matchtag fails with EINVAL on msg = NULL");
     errno = 0;
@@ -189,10 +244,31 @@ void check_cornercase (void)
     errno = 0;
     ok (flux_msg_get_matchtag (msg, NULL) < 0 && errno == EINVAL,
         "flux_msg_get_matchtag fails with EINVAL on in-and-out param = NULL");
+    errno = 0;
+    ok (flux_msg_get_matchtag (evt, &tag) < 0 && errno == EPROTO,
+        "flux_msg_get_matchtag fails with EPROTO on msg != req/rsp type");
 
+    errno = 0;
+    ok (flux_msg_enable_route (NULL) == -1 && errno == EINVAL,
+        "flux_msg_enable_route returns -1 errno EINVAL on msg = NULL");
+    errno = 0;
+    ok (flux_msg_clear_route (NULL) == -1 && errno == EINVAL,
+        "flux_msg_clear_route returns -1 errno EINVAL on msg = NULL");
+    errno = 0;
+    ok (flux_msg_push_route (NULL, "foo") == -1 && errno == EINVAL,
+        "flux_msg_push_route returns -1 errno EINVAL on msg = NULL");
     errno = 0;
     ok (flux_msg_push_route (msg, NULL) == -1 && errno == EINVAL,
         "flux_msg_push_route returns -1 errno EINVAL on id = NULL");
+    errno = 0;
+    ok (flux_msg_push_route (msg, "foo") == -1 && errno == EPROTO,
+        "flux_msg_push_route returns -1 errno EPROTO on msg w/o routes enabled");
+    errno = 0;
+    ok (flux_msg_pop_route (NULL, NULL) == -1 && errno == EINVAL,
+        "flux_msg_pop_route returns -1 errno EINVAL on id = NULL");
+    errno = 0;
+    ok (flux_msg_pop_route (msg, NULL) == -1 && errno == EPROTO,
+        "flux_msg_pop_route returns -1 errno EPROTO on msg w/o routes enabled");
     errno = 0;
     ok (flux_msg_get_route_first (NULL, &route) == -1 && errno == EINVAL,
         "flux_msg_get_route_first returns -1 errno EINVAL on msg = NULL");
@@ -201,9 +277,27 @@ void check_cornercase (void)
         "flux_msg_get_route_first returns -1 errno EINVAL on in-and-out "
         "param = NULL");
     errno = 0;
+    ok (flux_msg_get_route_first (msg, &route) == -1 && errno == EPROTO,
+        "flux_msg_get_route_first returns -1 errno EPROTO on msg "
+        "w/o routes enabled");
+    errno = 0;
+    ok (flux_msg_get_route_last (NULL, &route) == -1 && errno == EINVAL,
+        "flux_msg_get_route_last returns -1 errno EINVAL on msg = NULL");
+    errno = 0;
     ok (flux_msg_get_route_last (msg, NULL) == -1 && errno == EINVAL,
         "flux_msg_get_route_last returns -1 errno EINVAL on in-and-out "
         "param = NULL");
+    errno = 0;
+    ok (flux_msg_get_route_last (msg, &route) == -1 && errno == EPROTO,
+        "flux_msg_get_route_last returns -1 errno EPROTO on msg "
+        "w/o routes enabled");
+    errno = 0;
+    ok ((flux_msg_get_route_count (NULL) == -1 && errno == EINVAL),
+        "flux_msg_get_route_count returns -1 errno EINVAL on msg = NULL");
+    errno = 0;
+    ok ((flux_msg_get_route_count (msg) == -1 && errno == EPROTO),
+        "flux_msg_get_route_count returns -1 errno EPROTO on msg "
+        "w/o routes enabled");
 
     flux_msg_destroy (msg);
 }
@@ -219,18 +313,6 @@ void check_routes (void)
     ok ((msg = flux_msg_create (FLUX_MSGTYPE_REQUEST)) != NULL
         && flux_msg_frames (msg) == 1,
         "flux_msg_create works and creates msg with 1 frame");
-    errno = 0;
-    ok (flux_msg_get_route_count (msg) < 0 && errno == EPROTO,
-        "flux_msg_get_route_count returns -1 errno EPROTO on msg w/o delim");
-    errno = 0;
-    ok ((flux_msg_get_route_first (msg, &s) == -1 && errno == EPROTO),
-        "flux_msg_get_route_first returns -1 errno EPROTO on msg w/o delim");
-    errno = 0;
-    ok ((flux_msg_get_route_last (msg, &s) == -1 && errno == EPROTO),
-        "flux_msg_get_route_last returns -1 errno EPROTO on msg w/o delim");
-    errno = 0;
-    ok ((flux_msg_pop_route (msg, &s) == -1 && errno == EPROTO),
-        "flux_msg_pop_route returns -1 errno EPROTO on msg w/o delim");
 
     ok (flux_msg_clear_route (msg) == 0 && flux_msg_frames (msg) == 1,
         "flux_msg_clear_route works, is no-op on msg w/o delim");
@@ -798,6 +880,7 @@ void check_cmp (void)
 void check_encode (void)
 {
     flux_msg_t *msg, *msg2;
+    uint8_t smallbuf[1];
     void *buf;
     size_t size;
     const char *topic;
@@ -807,6 +890,9 @@ void check_encode (void)
         "flux_msg_create works");
     ok (flux_msg_set_topic (msg, "foo.bar") == 0,
         "flux_msg_set_topic works");
+    errno = 0;
+    ok (flux_msg_encode (msg, smallbuf, 1) < 0 && errno == EINVAL,
+        "flux_msg_encode fails on EINVAL with buffer too small");
     size = flux_msg_encode_size (msg);
     ok (size > 0,
         "flux_msg_encode_size works");


### PR DESCRIPTION
Per discussion in #3617, this is part 1 to remove the `libczmq` dependency on `libflux-core`.  In this code we rework the `flux_msg_t` internals to store data in its own native data structure rather than using `zmsg_t`.

Just wanted to get some initial thoughts.

Should we consider this a mergable PR?  Or would we want to complete more of #3617 in one PR?  It is a lot of code changes.

The only places that `zmsg_t` and `zframe_t` remain are in `flux_msg_encode_size()`, `flux_msg_encode()`, `flux_msg_decode()`, `flux_msg_sendzsock()`, and `flux_msg_recvzsock()`.  We have some `msg_to_zmsg()` and `zmsg_to_msg()` internal functions to handle the transition for the time being.  These functions will eventually be migrated out of `libflux-core`.  To `librouter`?  Or a helper lib?  This is perhaps still TBD.

Note that both `ccan` and `czmq` define a `streq()` macro ... ugh.  So decided to change the macro in `ccan` for the time being.  We can (hopefully) revert this commit at a later time when things are no longer coupled.

Should the format of `flux_msg_fprint()` change?  With the removal of internal `zmsg_t` storage, we are no longer dependent on formatting output like `zframe_fprint()`.  We can output whatever we like.  This can be a follow on PR of course.
