### PR TITLE
ci: minor coverage testing fixes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -161,7 +161,9 @@ jobs:
 
     - name: coverage report
       if: success() && matrix.coverage
-      run: DOCKER_REPO= bash <(curl -s https://codecov.io/bash)
+      env:
+        DOCKER_REPO:
+      uses: codecov/codecov-action@v1
 
     - name: docker deploy
       if: success() && matrix.docker_tag

--- a/src/test/generate-matrix.py
+++ b/src/test/generate-matrix.py
@@ -169,7 +169,12 @@ matrix.add_build(
 )
 
 # Ubuntu: coverage
-matrix.add_build(name="coverage", coverage=True, jobs=2, args="--enable-pmix-bootstrap")
+matrix.add_build(
+    name="coverage",
+    coverage=True,
+    jobs=2,
+    args="--with-flux-security --enable-pmix-bootstrap",
+)
 
 # Ubuntu: TEST_INSTALL
 matrix.add_build(


### PR DESCRIPTION
This PR includes a couple minor fixes for coverage testing in GH actions

 * ensure `--with-flux-security` is used in the coverage builder
 * switch to the official codecov github action instead of manual run of the bash uploader

Since this modifies GitHub workflow yaml, it will likely need to be manually merged.