### PR TITLE
job-manager: add builtin begin-time dependency plugin

### DIFF
--- a/doc/man1/flux-mini.rst
+++ b/doc/man1/flux-mini.rst
@@ -105,7 +105,6 @@ following additional job parameters:
    ("s", "m", "h", or "d"). If unspecified, the job is subject to the
    system default time limit.
 
-
 STANDARD I/O
 ============
 
@@ -180,9 +179,16 @@ afternotok:JOBID
    This dependency is satisfied after JOBID enters the INACTIVE state
    with an unsuccessful result.
 
-In any of the above cases, if it is determined that the dependency cannot
-be satisfied (e.g. a job fails due to an exception with afterok), then
-a fatal exception of type=dependency is raised on the current job.
+begin-time:TIMESTAMP
+   This dependency is satisfied after TIMESTAMP, which is specified in
+   floating point seconds since the UNIX epoch. See the ``flux-mini``
+   ``--begin-time`` option below for a more user-friendly interface
+   to the ``begin-time`` dependency.
+
+In any of the above ``after*`` cases, if it is determined that the
+dependency cannot be satisfied (e.g. a job fails due to an exception
+with afterok), then a fatal exception of type=dependency is raised
+on the current job.
 
 ENVIRONMENT
 ===========
@@ -341,6 +347,16 @@ OTHER OPTIONS
    is interpreted as a string. If KEY starts with a ``^`` character, then
    VAL is interpreted as a file, which must be valid JSON, to use as the
    attribute value.
+
+**--begin-time=DATETIME**
+   Convenience option for setting a ``begin-time`` dependency for a job.
+   The job is guaranteed to start after the specified date and time.
+   If *DATETIME* begins with a ``+`` character, then the remainder is
+   considered to be an offset in Flux standard duration (RFC 23), otherwise,
+   any datetime expression accepted by the Python 
+   `parsedatetime <https://github.com/bear/parsedatetime>`_ module
+   is accepted, e.g. ``2021-06-21 8am``, ``in an hour``,
+   ``tomorrow morning``, etc.
 
 **--dry-run**
    Don't actually submit job. Just emit jobspec on stdout and exit for

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -532,3 +532,4 @@ reprioritization
 afterany
 afterok
 afternotok
+parsedatetime

--- a/src/cmd/flux-mini.py
+++ b/src/cmd/flux-mini.py
@@ -85,6 +85,21 @@ def dependency_array_create(uris):
     return dependencies
 
 
+class BeginTimeAction(argparse.Action):
+    """Convenience class to handle --begin-time file option
+
+    Append --begin-time options to the "dependency" list in namespace
+    """
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        uri = "begin-time:" + str(util.parse_datetime(values).timestamp())
+        items = getattr(namespace, "dependency", [])
+        if items is None:
+            items = []
+        items.append(uri)
+        setattr(namespace, "dependency", items)
+
+
 def filter_dict(env, pattern, reverseMatch=True):
     """
     Filter out all keys that match "pattern" from dict 'env'
@@ -450,6 +465,12 @@ class MiniCmd:
             action="append",
             help="Set an RFC 26 dependency URI for this job",
             metavar="URI",
+        )
+        parser.add_argument(
+            "--begin-time",
+            action=BeginTimeAction,
+            metavar="TIME",
+            help="Set minimum begin time for job",
         )
         parser.add_argument(
             "--env",

--- a/src/modules/job-manager/Makefile.am
+++ b/src/modules/job-manager/Makefile.am
@@ -61,7 +61,8 @@ libjob_manager_la_SOURCES = \
 	jobtap.h \
 	jobtap.c \
 	plugins/priority-default.c \
-	plugins/dependency-after.c
+	plugins/dependency-after.c \
+	plugins/begin-time.c
 
 fluxinclude_HEADERS = \
 	jobtap.h

--- a/src/modules/job-manager/jobtap.c
+++ b/src/modules/job-manager/jobtap.c
@@ -39,6 +39,7 @@
 
 extern int priority_default_plugin_init (flux_plugin_t *p);
 extern int after_plugin_init (flux_plugin_t *p);
+extern int begin_time_plugin_init (flux_plugin_t *p);
 
 struct jobtap_builtin {
     const char *name;
@@ -48,6 +49,7 @@ struct jobtap_builtin {
 static struct jobtap_builtin jobtap_builtins [] = {
     { ".priority-default", priority_default_plugin_init },
     { ".dependency-after", after_plugin_init },
+    { ".begin-time", &begin_time_plugin_init },
     { 0 },
 };
 

--- a/src/modules/job-manager/plugins/begin-time.c
+++ b/src/modules/job-manager/plugins/begin-time.c
@@ -1,0 +1,183 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/*  begin-time: Builtin job-manager begin-time dependency plugin */
+
+#include <time.h>
+#include <math.h>
+#include <jansson.h>
+
+#include <flux/core.h>
+#include <flux/jobtap.h>
+
+struct begin_time_arg {
+    flux_plugin_t *p;
+    flux_watcher_t *w;
+    flux_jobid_t id;
+    double begin_time;
+    char desc [128];
+};
+
+static void begin_time_arg_destroy (struct begin_time_arg *b)
+{
+    if (b) {
+        flux_watcher_destroy (b->w);
+        free (b);
+    }
+}
+
+static struct begin_time_arg * begin_time_arg_create (flux_plugin_t *p,
+                                                      flux_jobid_t id,
+                                                      double begin_time)
+{
+    struct begin_time_arg *b = NULL;
+    int len = sizeof (b->desc);
+
+    if (!(b = calloc (1, sizeof (*b)))
+        || snprintf (b->desc, len, "begin-time=%.3f", begin_time) >= len)
+        goto err;
+    b->p = p;
+    b->id = id;
+    b->begin_time = begin_time;
+    return b;
+err:
+    begin_time_arg_destroy (b);
+    return NULL;
+}
+
+static void begin_time_cb (flux_reactor_t *r,
+                           flux_watcher_t *w,
+                           int revents,
+                           void *arg)
+{
+    struct begin_time_arg *b = arg;
+    flux_t *h = flux_jobtap_get_flux (b->p);
+    if (flux_jobtap_dependency_remove (b->p, b->id, b->desc) < 0)
+        flux_log_error (h, "begin-time: flux_jobtap_dependency_remove");
+    if (flux_jobtap_job_aux_delete (b->p, b->id, b) < 0)
+        flux_log_error (h, "begin-time: flux_jobtap_job_aux_delete");
+}
+
+
+static int add_begin_time (flux_plugin_t *p,
+                           flux_t *h,
+                           flux_reactor_t *r,
+                           flux_jobid_t id,
+                           double begin_time)
+{
+    struct begin_time_arg *arg = NULL;
+
+    if (!(arg = begin_time_arg_create (p, id, begin_time))) {
+        flux_log (h, LOG_ERR, "failed to create begin-time args");
+        goto error;
+    }
+
+    if (!(arg->w = flux_periodic_watcher_create (r,
+                                                 begin_time,
+                                                 0.,
+                                                 NULL,
+                                                 begin_time_cb,
+                                                 arg))) {
+        flux_log_error (h, "flux_periodic_watcher_create");
+        goto error;
+    }
+    flux_watcher_start (arg->w);
+
+    if (flux_jobtap_dependency_add (p, id, arg->desc) < 0) {
+        flux_log_error (h, "%ju: flux_jobtap_dependency_add", (uintmax_t) id);
+        goto error;
+    }
+
+    /*  In case job is destroyed before begin_time, tie destruction
+     *   of this watcher to the current job.
+     */
+    if (flux_jobtap_job_aux_set (p,
+                                 FLUX_JOBTAP_CURRENT_JOB,
+                                 "flux::begin-time",
+                                 arg,
+                                 (flux_free_f) begin_time_arg_destroy) < 0) {
+        flux_log_error (h, "flux_jobtap_job_aux_set");
+        goto error;
+    }
+    return 0;
+error:
+    begin_time_arg_destroy (arg);
+    return -1;
+}
+
+/*  Parse string 's' to a floating-point timestamp,
+ *   ensuring validity of the result.
+ */
+static int parse_timestamp (const char *s, double *dp)
+{
+    double d;
+    char *p;
+    if (s == NULL) {
+        errno = EINVAL;
+        return -1;
+    }
+    d = strtod (s, &p);
+
+    /*  Ensure d is a valid timestamp
+     */
+    if (d < 0. || isnan(d) || isinf(d) || *p != '\0') {
+        errno = EINVAL;
+        return -1;
+    }
+    *dp = d;
+    return 0;
+}
+
+/*  Handle job.dependnecy.begin-time requests
+ */
+static int depend_cb (flux_plugin_t *p,
+                      const char *topic,
+                      flux_plugin_arg_t *args,
+                      void *arg)
+{
+    flux_jobid_t id;
+    const char *s;
+    double begin_time = 0.;
+    flux_reactor_t *r;
+    flux_t *h = flux_jobtap_get_flux (p);
+
+    if (!h || !(r = flux_get_reactor (h)))
+        return -1;
+
+    if (flux_plugin_arg_unpack (args,
+                                FLUX_PLUGIN_ARG_IN,
+                                "{s:I s:{s:s}}",
+                                "id", &id,
+                                "dependency",
+                                "value", &s) < 0)
+        return flux_jobtap_reject_job (p,
+                                       args,
+                                       "error processing begin-time: %s",
+                                       flux_plugin_arg_strerror (args));
+    if (parse_timestamp (s, &begin_time) < 0)
+        return flux_jobtap_reject_job (p,
+                                       args,
+                                       "Invalid begin-time=%s",
+                                       s);
+
+    if (add_begin_time (p, h, r, id, begin_time) < 0)
+        return flux_jobtap_reject_job (p,
+                                       args,
+                                       "Unable to initialize begin-time");
+    return 0;
+}
+
+int begin_time_plugin_init (flux_plugin_t *p)
+{
+    return flux_plugin_add_handler (p,
+                                    "job.dependency.begin-time",
+                                    depend_cb,
+                                    NULL);
+}

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -129,6 +129,7 @@ TESTSCRIPTS = \
 	t2261-job-list-update.t \
 	t2270-job-dependencies.t \
 	t2271-job-dependency-after.t \
+	t2272-job-begin-time.t \
 	t2300-sched-simple.t \
 	t2302-sched-simple-up-down.t \
 	t2310-resource-module.t \

--- a/t/t2272-job-begin-time.t
+++ b/t/t2272-job-begin-time.t
@@ -1,0 +1,50 @@
+#!/bin/sh
+
+test_description='Test job begin-time dependencies'
+
+. $(dirname $0)/sharness.sh
+
+test_under_flux 1 job
+
+flux setattr log-stderr-level 1
+
+test_expect_success 'begin-time: submit a job with begin-time +1h' '
+	DELAYED=$(flux mini submit --begin-time=+1h hostname) &&
+	flux job wait-event -vt 15 $DELAYED dependency-add
+'
+test_expect_success 'begin-time: flux mini --begin-time=invalid fails' '
+	test_expect_code 1 flux mini submit --begin-time=foo hostname &&
+	test_expect_code 1 flux mini submit --begin-time=+a hostname
+'
+test_expect_success 'begin-time: rejects invalid timestamp' '
+	test_expect_code 1 flux mini submit \
+		--dependency=begin-time:-1.0 \
+		hostname
+'
+test_expect_success HAVE_JQ 'begin-time rejects missing timestamp' '
+	flux mini run --dry-run hostname | \
+	  jq ".attributes.system.dependencies[0].scheme = \"begin-time\"" \
+	  > invalid.json &&
+	test_expect_code 1 flux job submit invalid.json
+'
+test_expect_success HAVE_JQ '--begin-time sets dependency in jobspec' '
+	flux mini run --dry-run --begin-time=+1h hostname | \
+	    jq -e ".attributes.system.dependencies[0].scheme == \"begin-time\""
+'
+test_expect_success 'begin-time: elapsed begin-time releases job immediately' '
+	jobid=$(flux mini submit --begin-time=now hostname) &&
+	flux job wait-event -vt 15 $jobid dependency-remove &&
+	flux job wait-event -vt 15 $jobid clean
+'
+test_expect_success 'begin-time: job with begin-time works' '
+	flux mini run -vvv --begin=time=+1s hostname
+'
+test_expect_success 'begin-time: job with begin-time=+1h is still in depend' '
+	flux jobs &&
+	test $(flux jobs -no {state} $DELAYED) = "DEPEND"
+'
+test_expect_success 'begin-time: job with begin-time can be safely canceled' '
+	flux job cancel $DELAYED &&
+	flux job wait-event -vt 15 $DELAYED clean
+'
+test_done


### PR DESCRIPTION
This small WIP PR adds a minimum begin-time (or start-after time) via a new `begin-time` dependency scheme.
For this scheme, the `value` is interpreted as floating-point seconds since epoch after which the dependency shall be removed. The plugin uses the convenient flux "periodic" watcher, which watches system time instead of relative time, so it should "just work". If the time for which the dependency is set has already lapsed then the dependency is satisfied immediately.

The next step is to add a `flux-mini` option equivalent to Slurm's `--begin` option, (perhaps named `--begin-time` or `--start-after` to be more explicit), with support for parsing a slew of user friendly datetimes and datetime offsets, e.g.

 * `--begin-time=+FSD`
 * `--begin-time=Tuesday`
 * `--begin-time=2021-06-15`

etc. There are some promising python packages in this area (e.g. [dateutil](https://dateutil.readthedocs.io/en/stable/), [dateparser](https://dateparser.readthedocs.io/en/latest/)) but each has its drawbacks and I'd hate to add a new dependency to support just one option.

For now maybe the best approach would be to support a series of `strptime` formats, and additionally if the argument starts with `+` it would be considered `now+FSD`.

To try out the support presently, you can still use `--dependency=begin-time:TIME`, e.g.:
```
$ flux mini run -vvv --dependency=begin-time:$(($(date +%s)+2)) hostname
jobid: ƒ28x5DMfv7
0.000s: job.submit {"userid":1000,"urgency":16,"flags":0}
0.014s: job.dependency-add {"description":"begin-time=1623194817.000"}
1.188s: job.dependency-remove {"description":"begin-time=1623194817.000"}
1.188s: job.depend
1.188s: job.priority {"priority":16}
1.190s: job.alloc {"annotations":{"sched":{"resource_summary":"rank0/core0"}}}
1.250s: job.start
```