### PR TITLE
optparse: make optional_argument apply to long options only

### DIFF
--- a/src/common/liboptparse/optparse.c
+++ b/src/common/liboptparse/optparse.c
@@ -1216,6 +1216,8 @@ static char * optstring_append (char *optstring, struct optparse_option *o)
      *   an option with no argument (has_arg = 0), 2 characters
      *   for a required argument (has_arg = 1), and 3 chars for
      *   an optional argument "o::" (has_arg = 2)
+     *  N.B.: optional argument is applied to short options only if
+     *   OPTPARSE_OPT_SHORTOPT_OPTIONAL_ARG is set on flags
      */
     len = strlen (optstring);
     n = len + o->has_arg + 1;
@@ -1224,7 +1226,7 @@ static char * optstring_append (char *optstring, struct optparse_option *o)
 
     if (o->has_arg == 1)
         colons = ":";
-    else if (o->has_arg == 2)
+    else if (o->has_arg == 2 && o->flags & OPTPARSE_OPT_SHORTOPT_OPTIONAL_ARG)
         colons = "::";
 
     sprintf (optstring+len, "%c%s", o->key, colons);

--- a/src/common/liboptparse/optparse.c
+++ b/src/common/liboptparse/optparse.c
@@ -880,7 +880,9 @@ int optparse_get_int (optparse_t *p, const char *name, int default_value)
     }
     if (n == 0)
         return default_value;
-    if (s == NULL || strlen (s) == 0)
+    if (s == NULL)
+        return n;
+    if (strlen (s) == 0)
         goto badarg;
     errno = 0;
     l = strtol (s, &endptr, 10);

--- a/src/common/liboptparse/optparse.h
+++ b/src/common/liboptparse/optparse.h
@@ -130,6 +130,12 @@ struct optparse_subcommand {
  */
 #define OPTPARSE_OPT_HIDDEN       0x2
 
+/*
+ *  Apply optional argument to short options as well as long. The default
+ *   is that optional arguments only apply to longopts.
+ */
+#define OPTPARSE_OPT_SHORTOPT_OPTIONAL_ARG 0x4
+
 /******************************************************************************
  *  Subcommand FLAGS:
  *****************************************************************************/

--- a/src/common/liboptparse/optparse.h
+++ b/src/common/liboptparse/optparse.h
@@ -358,8 +358,10 @@ bool optparse_hasopt (optparse_t *p, const char *name);
 
 /*
  *   Return the option argument as an integer if 'name' was used,
- *    'default_value' if not.  If the option is unknown, or the argument
- *    could not be converted to an integer, call the fatal error function.
+ *    'default_value' if not.  If the option does not take an argument,
+ *    then returns the number of times the option was used.
+ *    If the option is unknown, or the argument could not be converted to
+ *    an integer, call the fatal error function.
  */
 int optparse_get_int (optparse_t *p, const char *name, int default_value);
 

--- a/src/common/liboptparse/test/optparse.c
+++ b/src/common/liboptparse/test/optparse.c
@@ -400,20 +400,22 @@ void test_convenience_accessors (void)
      */
     dies_ok ({optparse_get_int (p, "no-exist", 0); },
             "get_int exits on unknown arg");
-    dies_ok ({optparse_get_int (p, "foo", 0); },
-            "get_int exits on option with no argument");
     dies_ok ({optparse_get_int (p, "baz", 0); },
             "get_int exits on option with wrong type argument (string)");
     dies_ok ({optparse_get_int (p, "dub", 0); },
             "get_int exits on option with wrong type argument (float)");
     lives_ok ({optparse_get_int (p, "bar", 0); },
             "get_int lives on known arg");
+    lives_ok ({optparse_get_int (p, "foo", 0); },
+            "get_int lives on option with no argument");
     ok (optparse_get_int (p, "bar", 42) == 42,
             "get_int returns default argument when arg not present");
     ok (optparse_get_int (p, "mnf", 42) == 7,
             "get_int returns arg when present");
     ok (optparse_get_int (p, "neg", 42) == -4,
             "get_int returns negative arg when present");
+    ok (optparse_get_int (p, "foo", 42) == 1,
+            "get_int returns option count with no arg");
 
     /* get_double
      */
@@ -1271,9 +1273,9 @@ static void test_optparse_get ()
 int main (int argc, char *argv[])
 {
 
-    plan (286);
+    plan (287);
 
-    test_convenience_accessors (); /* 35 tests */
+    test_convenience_accessors (); /* 36 tests */
     test_usage_output (); /* 46 tests */
     test_option_cb ();  /* 16 tests */
     test_errors (); /* 9 tests */

--- a/src/common/liboptparse/test/optparse.c
+++ b/src/common/liboptparse/test/optparse.c
@@ -1270,10 +1270,82 @@ static void test_optparse_get ()
     optparse_destroy (p);
 }
 
+static void test_optional_args ()
+{
+    char *av1[] = { "test-optional-args", "-xx", "-y2", NULL };
+    int ac1 =  sizeof (av1) / sizeof (av1[0]) - 1;
+
+    char *av2[] = { "test-optional-args", "--testx=2", "--testy=2", NULL };
+    int ac2 =  sizeof (av2) / sizeof (av2[0]) - 1;
+
+    char *av3[] = { "test-optional-args", "--testx", "--testy", NULL };
+    int ac3 =  sizeof (av3) / sizeof (av3[0]) - 1;
+
+    struct optparse_option opts [] = {
+        { .name = "testx",
+          .key  = 'x',
+          .has_arg = 2,
+          .arginfo = "N",
+          .usage = "optional arg on longopt only",
+          .flags = 0,
+        },
+        { .name = "testy",
+          .key  = 'y',
+          .has_arg = 2,
+          .arginfo = "N",
+          .usage = "optional arg on short and longopts",
+          .flags = OPTPARSE_OPT_SHORTOPT_OPTIONAL_ARG,
+        },
+        OPTPARSE_TABLE_END,
+    };
+    optparse_err_t e;
+    optparse_t *p = optparse_create ("test-optional-args");
+    if (!p)
+        BAIL_OUT ("optparse_create");
+
+    e = optparse_add_option_table (p, opts);
+    if (e != OPTPARSE_SUCCESS)
+        BAIL_OUT ("optparse_add_option_table");
+    ok (optparse_parse_args (p, ac1, av1) == ac1,
+        "optparse_parse_args");
+    ok (optparse_get_int (p, "testx", -1) == 2,
+        "shortopt with optional_arg: -xx works by default");
+    ok (optparse_get_int (p, "testy", -1) == 2,
+        "shortopt with optional_arg supported: -y2 works");
+    optparse_destroy (p);
+
+    p = optparse_create ("test-optional-args");
+    if (!p)
+        BAIL_OUT ("optparse_create");
+    e = optparse_add_option_table (p, opts);
+    if (e != OPTPARSE_SUCCESS)
+        BAIL_OUT ("optparse_add_option_table");
+    ok (optparse_parse_args (p, ac2, av2) == ac2,
+        "optparse_parse_args");
+    ok (optparse_get_int (p, "testx", -1) == 2,
+        "shortopt with optional_arg: --testx=2 works by default");
+    ok (optparse_get_int (p, "testy", -1) == 2,
+        "shortopt with optional_arg supported: ---testy=2 also works");
+    optparse_destroy (p);
+
+    p = optparse_create ("test-optional-args");
+    if (!p)
+        BAIL_OUT ("optparse_create");
+    e = optparse_add_option_table (p, opts);
+    if (e != OPTPARSE_SUCCESS)
+        BAIL_OUT ("optparse_add_option_table");
+    ok (optparse_parse_args (p, ac3, av3) == ac3,
+        "optparse_parse_args");
+    ok (optparse_get_int (p, "testx", -1) == 1,
+        "shortopt with optional_arg: --testx sets result to 1");
+    ok (optparse_get_int (p, "testy", -1) == 1,
+        "shortopt with optional_arg supported: ---testy also sets result to 1");
+    optparse_destroy (p);
+}
+
 int main (int argc, char *argv[])
 {
-
-    plan (287);
+    plan (296);
 
     test_convenience_accessors (); /* 36 tests */
     test_usage_output (); /* 46 tests */
@@ -1290,6 +1362,7 @@ int main (int argc, char *argv[])
     test_add_option_table_failure (); /* 4 tests */
     test_reg_subcommands (); /* 1 test */
     test_optparse_get (); /* 13 tests */
+    test_optional_args (); /* 9 tests */
 
     done_testing ();
     return (0);


### PR DESCRIPTION
As discussed in #3700, it is a bummer that `.has_arg = 2` (optional_argument) doesn't work well for `--verbose`. Then you can't use the idiom of `-vvv` for verbosity level 3.  But if you don't allow an argument, users that want to use long options have to use `--verbose --verbose --verbose`.

It is rare that optional arguments are useful with short options, so this PR makes optional args apply to long options only by default. The result is that `-vvv` works as does `--verbose=3`. A flag is added to restore the old behavior.

As part of this work it seemed useful to have `optparse_get_int()` return the number of times an option was used on the command line instead of a fatal error if it is called on an option with no argument, so that change was made here as well.