### PR TITLE
testsuite: add tests for late joining broker

### DIFF
--- a/doc/man1/flux-start.rst
+++ b/doc/man1/flux-start.rst
@@ -74,6 +74,12 @@ OPTIONS
    is triggered upon exit of any broker, and the flux-start exit code is the
    highest exit code of all brokers.  Default: ``any``.
 
+**--test-start-mode**\ =\ *MODE*
+   Set the start mode.  If set to ``all``, all brokers are started immediately.
+   If set to ``leader``, only the leader is started.  Hint: in ``leader`` mode,
+   use ``--setattr=broker.quorum=0`` to let the initial program start before
+   the other brokers are online.  Default: ``all``.
+
 **--test-rundir**\ =\ *PATH*
    Set the directory to be used as the broker rundir.  By default, a directory
    is created in /tmp for the duration of the test and destroyed afterwards.

--- a/src/common/libsubprocess/remote.c
+++ b/src/common/libsubprocess/remote.c
@@ -711,7 +711,8 @@ static void remote_continuation_cb (flux_future_t *f, void *arg)
     if (flux_rpc_get_unpack (f, "{ s:s s:i }",
                              "type", &type,
                              "rank", &rank) < 0) {
-        flux_log_error (p->h, "%s: flux_rpc_get_unpack", __FUNCTION__);
+        if (errno != EHOSTUNREACH) // broker is down, don't log
+            flux_log_error (p->h, "%s: flux_rpc_get_unpack", __FUNCTION__);
         goto error;
     }
 

--- a/src/modules/resource/resource.c
+++ b/src/modules/resource/resource.c
@@ -71,9 +71,20 @@ static int parse_config (struct resource_ctx *ctx,
         return -1;
     }
     if (path) {
+        FILE *f;
         json_error_t e;
 
-        if (!(o = json_load_file (path, 0, &e))) {
+        if (!(f = fopen (path, "r"))) {
+            (void)snprintf (errbuf,
+                            errbufsize,
+                            "%s: %s",
+                            path,
+                            strerror (errno));
+            return -1;
+        }
+        o = json_loadf (f, 0, &e);
+        fclose (f);
+        if (!o) {
             (void)snprintf (errbuf,
                             errbufsize,
                             "%s: %s on line %d",

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -172,6 +172,7 @@ TESTSCRIPTS = \
 	t3002-pmi.t \
 	t3003-mpi-abort.t \
 	t3300-system-basic.t \
+	t3301-system-latestart.t \
 	t4000-issues-test-driver.t \
 	lua/t0001-send-recv.t \
 	lua/t0002-rpc.t \

--- a/t/sharness.d/flux-sharness.sh
+++ b/t/sharness.d/flux-sharness.sh
@@ -84,10 +84,17 @@ make_bootstrap_config() {
 	        { host = "$fakehosts" },
 	    ]
 	EOT
+    flux R encode --hosts=$fakehosts -r$full >$workdir/R
+    cat >$workdir/conf.d/resource.toml <<-EOT2
+	[resource]
+	    path = "$workdir/R"
+	    noverify = true
+	EOT2
     echo "--test-hosts=$fakehosts -o,-c$workdir/conf.d"
     echo "--test-exit-mode=${TEST_UNDER_FLUX_EXIT_MODE:-leader}"
     echo "--test-exit-timeout=${TEST_UNDER_FLUX_EXIT_TIMEOUT:-0}"
     echo "-o,-Sbroker.quorum=${TEST_UNDER_FLUX_QUORUM:-$full}"
+    echo "--test-start-mode=${TEST_UNDER_FLUX_START_MODE:-all}"
 }
 
 #
@@ -139,6 +146,8 @@ remove_trashdir_wrapper() {
 #        Set the flux-start exit timeout (default: 0)
 #    - TEST_UNDER_FLUX_QUORUM
 #        Set the broker.quorum attribute (default: 0-<highest_rank>)
+#    - TEST_UNDER_FLUX_START_MODE
+#        Set the flux-start start mode (default: all)
 #
 test_under_flux() {
     size=${1:-1}

--- a/t/sharness.d/flux-sharness.sh
+++ b/t/sharness.d/flux-sharness.sh
@@ -155,7 +155,7 @@ test_under_flux() {
     log_file="$TEST_NAME.broker.log"
     if test -n "$TEST_UNDER_FLUX_ACTIVE" ; then
         if test "$TEST_UNDER_FLUX_PERSONALITY" = "system"; then
-            cleanup remove_trashdir_wrapper
+            test "$debug" = "t" || cleanup remove_trashdir_wrapper
         fi
         test "$debug" = "t" || cleanup rm "${SHARNESS_TEST_DIRECTORY:-..}/$log_file"
         flux_module_list > module-list.initial

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -133,7 +133,16 @@ test_expect_success 'flux-start --test-exit-mode=leader is accepted' "
 	flux start ${ARGS} -s1 --test-exit-mode=leader /bin/true
 "
 test_expect_success 'flux-start --test-exit-mode=badmode fails' "
-	test_must_fail flux start ${ARGS} --test-exit-mode=badmode /bin/true
+	test_must_fail flux start ${ARGS} -s1 --test-exit-mode=badmode /bin/true
+"
+test_expect_success 'flux-start --test-start-mode without --test-size fails' "
+	test_must_fail flux start ${ARGS} --test-start-mode=all /bin/true
+"
+test_expect_success 'flux-start --test-start-mode=all is accepted' "
+	flux start ${ARGS} -s1 --test-start-mode=all /bin/true
+"
+test_expect_success 'flux-start --test-start-mode=badmode fails' "
+	test_must_fail flux start ${ARGS} -s1 --test-start-mode=badmode /bin/true
 "
 test_expect_success 'flux-start --verbose=2 enables PMI tracing' "
 	flux start ${ARGS} \

--- a/t/t2310-resource-module.t
+++ b/t/t2310-resource-module.t
@@ -220,4 +220,16 @@ test_expect_success 'unload resource module' '
 	flux exec -r all flux module remove resource
 '
 
+test_expect_success 'reconfig with bad R path' '
+	cat >resource.toml <<-EOT &&
+	[resource]
+	path = "/noexist"
+	EOT
+	flux config reload
+'
+
+test_expect_success 'load resource module fails due to bad R' '
+	test_must_fail flux module load resource
+'
+
 test_done

--- a/t/t3301-system-latestart.t
+++ b/t/t3301-system-latestart.t
@@ -1,0 +1,63 @@
+#!/bin/sh
+#
+
+test_description='Test system instance with late joining broker'
+
+. `dirname $0`/sharness.sh
+
+export TEST_UNDER_FLUX_QUORUM=0
+export TEST_UNDER_FLUX_START_MODE=leader
+
+test_under_flux 2 system
+
+startctl="flux python ${SHARNESS_TEST_SRCDIR}/scripts/startctl.py"
+
+test_expect_success 'broker.quorum was set to 0 by system test personality' '
+	echo 0 >quorum.exp &&
+	flux getattr broker.quorum >quorum.out &&
+	test_cmp quorum.exp quorum.out
+'
+test_expect_success HAVE_JQ 'startctl shows rank 1 pids as -1' '
+	test $($startctl status | jq -r ".procs[1].pid") = "-1"
+'
+
+test_expect_success 'resource list shows one down nodes' '
+	echo 1 >down.exp &&
+	flux resource list -n -s down -o {nnodes} >down.out &&
+	test_cmp down.exp down.out
+'
+
+test_expect_success 'resource status shows no drained nodes' '
+	echo 0 >drain.exp &&
+	flux resource status -s drain -no {nnodes} >drain.out &&
+	test_cmp drain.exp drain.out
+'
+
+test_expect_success 'flux exec -r 1 fails with EHOSTUNREACH' '
+	test_must_fail run_timeout 30 flux exec -r 1 /bin/true 2>unreach.err &&
+	grep "No route to host" unreach.err
+'
+
+test_expect_success 'single node job can run with only rank 0 up' '
+	run_timeout 30 flux mini run -n1 /bin/true
+'
+
+test_expect_success 'two node job is accepted although it cannot run yet' '
+	flux mini submit -N2 -n2 echo Hello >jobid
+'
+
+test_expect_success 'start rank 1' '
+	$startctl run 1
+'
+
+test_expect_success HAVE_JQ 'startctl shows rank 1 pid not -1' '
+	test $($startctl status | jq -r ".procs[1].pid") != "-1"
+'
+
+# Side effect: this test blocks until the rank 1 broker has a chance to
+# wire up and start services
+test_expect_success 'two node job can now run' '
+	run_timeout 30 flux job attach $(cat jobid)
+'
+
+test_done


### PR DESCRIPTION
This PR adds a `flux start --test-start-mode` option that can start the instance with only the leader broker running.  The `system` sharness test personality is modified so that this can be configured from a test script.  Finally, a test script is added that checks a few basics with a late joining broker such as:
* `flux exec` to down broker doesn't hang
* down broker is not drained
* down broker is still part of the resource set used to evaluate jobspec satisfiability
* once the broker is brought up, jobs run that were stuck before

A few minor nits were fixed while working on the test.