### PR TITLE
broker: send offline responses while broker is initializing

### DIFF
--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -1540,13 +1540,13 @@ static void module_cb (module_t *p, void *arg)
             }
             /* Requests sent by the module on behalf of _its_ peers, e.g.
              * connector-local module with connected clients, will have a
-             * route count greater than one here.  If this broker is not yet
+             * route count greater than one here.  If this broker is not
              * "online" (entered INIT state), politely rebuff these requests.
              * Possible scenario for this message: user submitting a job on
              * a login node before cluster reboot is complete.
              */
             else if (count > 1 && !ctx->online) {
-                const char *errmsg = "Upstream Flux broker is not yet online."
+                const char *errmsg = "Upstream Flux broker is offline."
                                      " Try again later.";
 
                 if (flux_respond_error (ctx->h, msg, EAGAIN, errmsg) < 0)

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -1518,6 +1518,7 @@ static void module_cb (module_t *p, void *arg)
     flux_msg_t *msg = module_recvmsg (p);
     int type;
     int ka_errnum, ka_status;
+    int count;
 
     if (!msg)
         goto done;
@@ -1528,13 +1529,31 @@ static void module_cb (module_t *p, void *arg)
             (void)broker_response_sendmsg (ctx, msg);
             break;
         case FLUX_MSGTYPE_REQUEST:
-            broker_request_sendmsg (ctx, msg);
-            if (flux_msg_get_route_count (msg) == 1
-                && module_disconnect_arm (p, msg, disconnect_send_cb, ctx) < 0) {
-                    flux_log_error (ctx->h,
-                                    "%s: module_disconnect_arm",
-                                    module_get_name (p));
+            count = flux_msg_get_route_count (msg);
+            /* Requests originated by the broker module will have a route
+             * count of 1.  Ensure that, when the module is unloaded, a
+             * disconnect message is sent to all services used by broker module.
+             */
+            if (count == 1) {
+                if (module_disconnect_arm (p, msg, disconnect_send_cb, ctx) < 0)
+                    flux_log_error (ctx->h, "error arming module disconnect");
             }
+            /* Requests sent by the module on behalf of _its_ peers, e.g.
+             * connector-local module with connected clients, will have a
+             * route count greater than one here.  If this broker is not yet
+             * "online" (entered INIT state), politely rebuff these requests.
+             * Possible scenario for this message: user submitting a job on
+             * a login node before cluster reboot is complete.
+             */
+            else if (count > 1 && !ctx->online) {
+                const char *errmsg = "Upstream Flux broker is not yet online."
+                                     " Try again later.";
+
+                if (flux_respond_error (ctx->h, msg, EAGAIN, errmsg) < 0)
+                    flux_log_error (ctx->h, "send offline response message");
+                break;
+            }
+            broker_request_sendmsg (ctx, msg);
             break;
         case FLUX_MSGTYPE_EVENT:
             if (broker_event_sendmsg (ctx, msg) < 0) {

--- a/src/broker/broker.h
+++ b/src/broker/broker.h
@@ -19,6 +19,8 @@ struct broker {
     uint32_t rank;
     uint32_t size;
 
+    bool online;
+
     struct broker_attr *attrs;
     struct flux_msg_cred cred;  /* instance owner */
 

--- a/src/broker/state_machine.c
+++ b/src/broker/state_machine.c
@@ -167,6 +167,7 @@ static broker_state_t state_next (broker_state_t current, const char *event)
 
 static void action_init (struct state_machine *s)
 {
+    s->ctx->online = true;
     if (runat_is_defined (s->ctx->runat, "rc1")) {
         if (runat_start (s->ctx->runat, "rc1", runat_completion_cb, s) < 0) {
             flux_log_error (s->ctx->h, "runat_start rc1");

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -173,6 +173,7 @@ TESTSCRIPTS = \
 	t3003-mpi-abort.t \
 	t3300-system-basic.t \
 	t3301-system-latestart.t \
+	t3302-system-offline.t \
 	t4000-issues-test-driver.t \
 	lua/t0001-send-recv.t \
 	lua/t0002-rpc.t \

--- a/t/sharness.d/flux-sharness.sh
+++ b/t/sharness.d/flux-sharness.sh
@@ -95,6 +95,7 @@ make_bootstrap_config() {
     echo "--test-exit-timeout=${TEST_UNDER_FLUX_EXIT_TIMEOUT:-0}"
     echo "-o,-Sbroker.quorum=${TEST_UNDER_FLUX_QUORUM:-$full}"
     echo "--test-start-mode=${TEST_UNDER_FLUX_START_MODE:-all}"
+    echo "-o,--k-ary=${TEST_UNDER_FLUX_FANOUT:-$size}"
 }
 
 #
@@ -148,6 +149,8 @@ remove_trashdir_wrapper() {
 #        Set the broker.quorum attribute (default: 0-<highest_rank>)
 #    - TEST_UNDER_FLUX_START_MODE
 #        Set the flux-start start mode (default: all)
+#    - TEST_UNDER_FLUX_FANOUT
+#        Set the TBON fanout (default: size (flat))
 #
 test_under_flux() {
     size=${1:-1}

--- a/t/t3302-system-offline.t
+++ b/t/t3302-system-offline.t
@@ -1,0 +1,31 @@
+#!/bin/sh
+#
+
+test_description='Test system instance with one offline router broker'
+
+. `dirname $0`/sharness.sh
+
+export TEST_UNDER_FLUX_FANOUT=1
+export TEST_UNDER_FLUX_QUORUM=0
+export TEST_UNDER_FLUX_START_MODE=leader
+
+test_under_flux 3 system
+
+startctl="flux python ${SHARNESS_TEST_SRCDIR}/scripts/startctl.py"
+
+test_expect_success 'start rank 2 before TBON parent is up' '
+	$startctl run 2
+'
+
+test_expect_success HAVE_JQ 'startctl shows rank 1 pid as -1' '
+        test $($startctl status | jq -r ".procs[1].pid") = "-1"
+'
+
+test_expect_success 'flux mini run on rank 2 fails with offline error' '
+	test_must_fail bash -c \
+		"FLUX_URI=$(echo $FLUX_URI | sed s/local-0/local-2/) \
+			flux mini run hostname" 2>online.err &&
+	grep "broker is offline" online.err
+'
+
+test_done


### PR DESCRIPTION
Problem: if a user submits a job on a login node, but the broker upstream of that node is not yet online, the request may hang leaving the user wondering what's going on.

Send an EAGAIN response to user requests (route count >= 2) received before the broker enters INIT state
```
$ flux mini run hostname
flux-mini: ERROR: [Errno 11] Upstream Flux broker is not yet online. Try again later.
```
A sharness test is added that re-creates this situation.

This is based on top of #3709 (this PR is just the last 3 commits).