### PR TITLE
flux-python: fix use of virtualenv python

### DIFF
--- a/src/cmd/builtin/python.c
+++ b/src/cmd/builtin/python.c
@@ -16,6 +16,13 @@
 
 static int cmd_python (optparse_t *p, int ac, char *av[])
 {
+    /*
+     *  Ensure av[0] matches the full path of the interpreter we're executing.
+     *  Other than just being good practice, this ensures that sys.executable
+     *  is correct (since python uses sys.argv[0] for sys.executable) and so
+     *  that symlink'd binaries in virtualenvs are respected.
+     */
+    av[0] = PYTHON_INTERPRETER;
     execv (PYTHON_INTERPRETER, av); /* no return if sucessful */
     log_err_exit ("execvp (%s)", PYTHON_INTERPRETER);
     return (0);

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -59,6 +59,13 @@ test_expect_success 'flux-python command runs a python that finds flux' '
 	flux python -c "import flux"
 '
 
+test_expect_success 'flux-python command runs the configured python' '
+	define_line=$(grep "^#define PYTHON_INTERPRETER" ${FLUX_BUILD_DIR}/config/config.h) &&
+	expected=$(echo ${define_line} | sed -E '\''s~.*define PYTHON_INTERPRETER "(.*)"~\1~'\'') &&
+	actual=$(flux python -c "import sys; print(sys.executable)") &&
+	test "${expected}" = "${actual}"
+'
+
 # Minimal is sufficient for these tests, but test_under_flux unavailable
 # clear the RC paths
 ARGS="-o,-Sbroker.rc1_path=,-Sbroker.rc3_path="


### PR DESCRIPTION
Problem: when a virtualenv is created, it symlinks the system python
into the virtualenv directory.  The full path to this symlink is then
compiled into the `flux-python` subcommand as the first argument to
`execve`, but the first value in the argument list (`execve`'s second
arg), is just `python`.  This leads to an "escape" of the virtualenv
and a return to the system python environment:

```
PATH=/usr/bin/:$PATH strace -e process -f flux python -c 'import sys; print(sys.executable)'
execve("/usr/bin/flux", ["flux", "python", "-c", "import sys; print(sys.executable"...], 0x7fffd6b27020 /* 18 vars */) = 0
arch_prctl(ARCH_SET_FS, 0x7f849efccb00) = 0
execve("/ve_exaworks/bin/python3", ["python", "-c", "import sys; print(sys.executable"...], 0x20e73f0 /* 26 vars */) = 0
arch_prctl(ARCH_SET_FS, 0x7f7545579740) = 0
/usr/bin/python
exit_group(0)                           = ?
+++ exited with 0 +++
```

Solution: set the first value in the argument list to the full python
interpreter path.  This results in the argv of the python process being
the full interpreter path as opposed to just `python`, ensuring that the
virtualenv environment is maintained:

```
PATH=/usr/bin/:$PATH flux python -c 'import sys; print(sys.executable)'
/ve_exaworks/bin/python
```