### PR TITLE
Python/FluxExecutor bug fixes

### DIFF
--- a/t/python/t0023-executor.py
+++ b/t/python/t0023-executor.py
@@ -83,6 +83,9 @@ class TestFluxExecutor(unittest.TestCase):
     def test_bad_jobspec(self):
         with FluxExecutor() as executor:
             future = executor.submit(None)  # not a valid jobspec
+        with self.assertRaisesRegex(RuntimeError, r"job could not be submitted.*"):
+            # trying to fetch jobid should raise an error
+            future.jobid()
         with self.assertRaises(OSError):
             # future should be fulfilled after shutdown
             future.result(timeout=0)


### PR DESCRIPTION
Two bug fixes for FluxExecutor:

First, in the event that a FluxExecutor thread crashes, the executor becomes completely unusable and your Python program will hang. That's fine as long as threads just don't crash, but I found that they do crash when the executor is connected to a remote Flux instance which has gone away. The first commit makes the threads a little more robust. When a thread raises an exception, all outstanding futures have that exception set on them. That is, ``fut.result()`` might return something like ``RuntimeError("can't connect to remote Flux instance at ...")``. Moreover, all future calls to ``submit()`` will raise a ``RuntimeError`` (this aspect is not necessary and I'm not sure it's even desirable---feedback welcome).

Second, when a job cannot be submitted (e.g. because of an invalid jobspec) the jobid will never be set. But then calls to ``fut.jobid()`` hang. Fix that by detecting when a job could not be submitted and raise a ``RuntimeError`` when accessing the jobid.