### PR TITLE
github: fix the fix for ci builds on master

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -122,13 +122,14 @@ jobs:
     - name: fetch annotated tag
       if: >
         (matrix.create_release || matrix.docker_tag) &&
-        env.GITHUB_BRANCH != 'master'
+        github.ref != 'refs/heads/master'
       run: |
         # Ensure git-describe works on a tag.
         #  (checkout@v2 action may have left current tag as
         #   lightweight instead of annotated. See
         #   https://github.com/actions/checkout/issues/290)
         #
+        echo github.ref == ${{ github.ref }} ;
         git fetch -f origin ${{ github.ref }}:${{ github.ref }} ;
         echo git describe now reports $(git describe --always)
 


### PR DESCRIPTION
Problem: The fix for builds on master didn't work, since GITHUB_BRANCH
was not set in the _environment_ of the annotated tags step (it was set
as an output).

Fall back to using github.ref, and skip the annotated tags checkout
when `github.ref == 'refs/heads/master'`.

Add a line of debugging in case this step starts to fail again in the
future.

This time I actually tested by pushing to the main branch of my own repo.