### PR TITLE
libflux: make flux_plugin_handler topic member const

### DIFF
--- a/src/common/libflux/plugin.c
+++ b/src/common/libflux/plugin.c
@@ -52,7 +52,7 @@ typedef const struct flux_plugin_handler *
 static void flux_plugin_handler_destroy (struct flux_plugin_handler *h)
 {
     if (h) {
-        free (h->topic);
+        free ((char *) h->topic);
         free (h);
     }
 }

--- a/src/common/libflux/plugin.h
+++ b/src/common/libflux/plugin.h
@@ -35,7 +35,7 @@ typedef int (*flux_plugin_f) (flux_plugin_t *p,
 typedef int (*flux_plugin_init_f) (flux_plugin_t *p);
 
 struct flux_plugin_handler {
-    char *topic;
+    const char *topic;
     flux_plugin_f cb;
     void *data;
 };


### PR DESCRIPTION
Problem: The topic string in `struct flux_plugin_handler` is not
const, which causes compilation errors when using static initializers
to define a table of handlers on compilers where static strings
are const (e.g. C++11).

Make the topic string const. The only reason it wasn't const was as a
convenience when destroying copied flux_plugin_handler structs. Just
cast the topic back to non-const when freeing the copy.

Fixes #3719