### PR TITLE
testsuite: fix intermittent test, speed up others

### DIFF
--- a/t/issues/t3470-multithread-reactor-run.py
+++ b/t/issues/t3470-multithread-reactor-run.py
@@ -19,8 +19,10 @@ def get_events(i, queue):
     f = flux.Flux()
     f.event_subscribe("test-event")
     queue.put(True)
-    f.msg_watcher_create(cb, topic_glob="test-event", args=i).start()
+    w = f.msg_watcher_create(cb, topic_glob="test-event", args=i)
+    w.start()
     f.reactor_run()
+    w.destroy()
 
 
 def main():

--- a/t/t0004-event.t
+++ b/t/t0004-event.t
@@ -6,15 +6,23 @@ test_description='Test event propagation'
 . `dirname $0`/sharness.sh
 SIZE=4
 LASTRANK=$(($SIZE-1))
-test_under_flux ${SIZE} kvs
+test_under_flux ${SIZE} minimal
 
 RPC=${FLUX_BUILD_DIR}/t/request/rpc
+
+test_expect_success 'load heartbeat module with fast rate' '
+        flux module load heartbeat period=0.1s
+'
 
 test_expect_success 'heartbeat is received on all ranks' '
 	run_timeout 5 \
           flux exec -n flux event sub --count=1 heartbeat.pulse >output_event_sub &&
 	hb_count=`grep "^heartbeat.pulse" output_event_sub | wc -l` &&
         test $hb_count -eq $SIZE
+'
+
+test_expect_success 'unload heartbeat module' '
+	flux module remove heartbeat
 '
 
 test_expect_success 'events from rank 0 received correctly on rank 0' '


### PR DESCRIPTION
Here are a couple of minor test improvements.   One commit fixes a test that occasionally fails for me (#3723) and the other speeds up two tests by loading the heartbeat module with a very fast heartrate, and not loading unnecessary modules.