### PR TITLE
python: validate dependencies in Jobspec constructor

### DIFF
--- a/src/bindings/python/flux/job/Jobspec.py
+++ b/src/bindings/python/flux/job/Jobspec.py
@@ -58,6 +58,14 @@ def _validate_keys(expected, given, keys_optional=False, allow_additional=False)
             raise ValueError("Extraneous key ({})".format(extraneous_key))
 
 
+def _validate_dependency(dep):
+    _validate_keys(["scheme", "value"], dep.keys(), allow_additional=True)
+    if not isinstance(dep["scheme"], str):
+        raise TypeError("dependency scheme must be a string")
+    if not isinstance(dep["value"], str):
+        raise TypeError("dependency value must be a string")
+
+
 def validate_jobspec(jobspec, require_version=None):
     """
     Validates the jobspec by attempting to construct a Jobspec object.  If no
@@ -146,6 +154,9 @@ class Jobspec(object):
 
         if attributes is not None:
             self._validate_attributes(attributes)
+
+            if "system" in attributes:
+                self._validate_system_attributes(attributes["system"])
 
     @classmethod
     def from_yaml_stream(cls, yaml_stream):
@@ -244,6 +255,14 @@ class Jobspec(object):
     @staticmethod
     def _validate_attributes(attributes):
         _validate_keys(["system", "user"], attributes.keys(), keys_optional=True)
+
+    @staticmethod
+    def _validate_system_attributes(system):
+        if "dependencies" in system:
+            if not isinstance(system["dependencies"], abc.Sequence):
+                raise TypeError("attributes.system.dependencies must be a list")
+            for dependency in system["dependencies"]:
+                _validate_dependency(dependency)
 
     @staticmethod
     def _create_resource(res_type, count, with_child=None):

--- a/src/modules/job-ingest/schemas/jobspec.jsonschema
+++ b/src/modules/job-ingest/schemas/jobspec.jsonschema
@@ -134,10 +134,10 @@
             "properties": {
               "environment": { "type" : "object"}
             },
-	        "additionalProperties": { "type": "string" }
+            "additionalProperties": { "type": "string" }
           }
         },
-	"additionalProperties": false
+        "additionalProperties": false
       }
     }
   }

--- a/src/modules/job-ingest/schemas/jobspec.jsonschema
+++ b/src/modules/job-ingest/schemas/jobspec.jsonschema
@@ -99,7 +99,18 @@
           "properties": {
             "duration": { "type": "number", "minimum": 0 },
             "cwd": { "type": "string" },
-            "environment": { "type": "object" }
+            "environment": { "type": "object" },
+            "dependencies": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": ["scheme", "value"],
+                "properties": {
+                  "scheme": { "type": "string" },
+                  "value": { "type": "string" }
+                }
+              }
+            }
           }
         },
         "user": {

--- a/src/modules/job-ingest/schemas/jobspec_v1.jsonschema
+++ b/src/modules/job-ingest/schemas/jobspec_v1.jsonschema
@@ -125,7 +125,7 @@
             }
           }
         },
-	    "additionalProperties": false
+        "additionalProperties": false
       }
     }
   }

--- a/src/modules/job-ingest/schemas/jobspec_v1.jsonschema
+++ b/src/modules/job-ingest/schemas/jobspec_v1.jsonschema
@@ -93,7 +93,18 @@
           "properties": {
             "duration": { "type": "number", "minimum": 0 },
             "cwd": { "type": "string" },
-            "environment": { "type": "object" }
+            "environment": { "type": "object" },
+            "dependencies": {
+               "type": "array",
+               "items": {
+                 "type": "object",
+                 "required": ["scheme", "value"],
+                 "properties": {
+                   "scheme": { "type": "string" },
+                   "value": { "type": "string" }
+                 }
+               }
+            }
           }
         },
         "user": {

--- a/t/jobspec/invalid/dependencies_not_array.yaml
+++ b/t/jobspec/invalid/dependencies_not_array.yaml
@@ -1,0 +1,17 @@
+version: 999
+resources:
+  - type: slot
+    count: 1
+    label: foo
+    with:
+      - type: node
+        count: 1
+tasks:
+  - command: [ "app" ]
+    slot: foo
+    count:
+      per_slot: 1
+attributes:
+  system:
+    dependencies:
+      scheme: foo

--- a/t/jobspec/invalid/dependency_invalid.yaml
+++ b/t/jobspec/invalid/dependency_invalid.yaml
@@ -1,0 +1,18 @@
+version: 999
+resources:
+  - type: slot
+    count: 1
+    label: foo
+    with:
+      - type: node
+        count: 1
+tasks:
+  - command: [ "app" ]
+    slot: foo
+    count:
+      per_slot: 1
+attributes:
+  system:
+    dependencies:
+      - scheme: foo
+        value: 1

--- a/t/jobspec/validate.py
+++ b/t/jobspec/validate.py
@@ -50,8 +50,10 @@ try:
     schema = json.load(open(args.schema))
 except (OSError, IOError) as e:
     sys.exit("{}: {}".format(args.schema, e.strerror))
-except:
-    sys.exit("{}: unknown error".format(args.schema))
+except json.decoder.JSONDecodeError as e:
+    sys.exit("{}: JSONDecodeError: {}".format(args.schema, e))
+except Exception as e:
+    sys.exit("{}: unknown error: {}: {}".format(args.schema, type(e), e))
 
 # Validate each file on command line
 errors = 0

--- a/t/t2270-job-dependencies.t
+++ b/t/t2270-job-dependencies.t
@@ -40,6 +40,9 @@ test_expect_success 'job with too long dependency scheme is rejected' '
 	test_must_fail flux mini submit \
 		--dependency=$(python -c "print \"x\"*156"):value hostname
 '
+test_expect_success 'reload ingest with disabled validator' '
+	flux module reload -f job-ingest disable-validator
+'
 test_expect_success 'submitted job with invalid dependencies is rejected' '
 	test_must_fail flux mini submit \
 		--setattr=system.dependencies={} \
@@ -51,6 +54,9 @@ test_expect_success 'submitted job with invalid dependencies is rejected' '
 		hostname > empty-object.out 2>&1 &&
 	test_debug "cat empty-object.out" &&
 	grep -q "missing" empty-object.out
+'
+test_expect_success 'reload ingest with default validator' '
+	flux module reload -f job-ingest
 '
 test_expect_success 'create dep-remove.py' '
 	cat <<-EOF >dep-remove.py

--- a/t/t2271-job-dependency-after.t
+++ b/t/t2271-job-dependency-after.t
@@ -44,11 +44,17 @@ test_expect_success FLUX_SECURITY 'dependency=after will not work on another use
 	grep "Permission denied" baduser.log &&
 	flux job cancel $jobid
 '
+test_expect_success 'disable ingest validator' '
+	flux module reload -f job-ingest disable-validator
+'
 test_expect_success HAVE_JQ 'dependency=after rejects invalid dependency' '
 	flux mini run --dry-run hostname | \
 	  jq ".attributes.system.dependencies[0] = \
 		{\"scheme\":\"after\", \"value\": 1}" >job.json &&
 	test_expect_code 1 flux job submit job.json
+'
+test_expect_success 'reenable ingest validator' '
+	flux module reload -f job-ingest
 '
 test_expect_success 'dependency=after works' '
 	jobid=$(flux mini submit --urgency=hold hostname) &&


### PR DESCRIPTION
This PR adds missing functionality to the `Jobspec` class to validate that the `dependencies` system attribute, if it exists, conforms to RFC 14 and RFC 26.