### PR TITLE
cron: fix race in task timeouts

### DIFF
--- a/src/modules/cron/cron.c
+++ b/src/modules/cron/cron.c
@@ -82,14 +82,6 @@ double get_timestamp (void)
     return ((double) tm.tv_sec + (tm.tv_nsec/1.0e9));
 }
 
-static void timeout_cb (flux_t *h, cron_task_t *t, void *arg)
-{
-    cron_entry_t *e = arg;
-    flux_log (h, LOG_INFO, "cron-%ju: task timeout at %.2fs. Killing",
-              e->id, e->timeout);
-    cron_task_kill (t, SIGTERM);
-}
-
 static int cron_entry_run_task (cron_entry_t *e)
 {
     flux_t *h = e->ctx->h;
@@ -126,7 +118,7 @@ int cron_entry_schedule_task (cron_entry_t *e)
     }
     cron_task_on_io (e->task, cron_entry_io_cb);
     if (e->timeout >= 0.0)
-        cron_task_set_timeout (e->task, e->timeout, timeout_cb);
+        cron_task_set_timeout (e->task, e->timeout, NULL);
 
     /*   if we've reached our (non-zero) repeat count, prematurely stop
      *     the current entry (i.e. remove it from event loop, but leave

--- a/src/modules/cron/task.c
+++ b/src/modules/cron/task.c
@@ -201,6 +201,7 @@ static void state_change_cb (flux_subprocess_t *p, flux_subprocess_state_t state
         t->running = 1;
         t->pid = flux_subprocess_pid (p);
         t->rank = flux_subprocess_rank (p);
+        cron_task_timeout_start (t);
     }
     else if (state == FLUX_SUBPROCESS_EXEC_FAILED) {
         cron_task_exec_failed (t, flux_subprocess_fail_errno (p));
@@ -356,8 +357,6 @@ int cron_task_run (cron_task_t *t,
     t->started = 1;
     clock_gettime (CLOCK_REALTIME, &t->starttime);
     cron_task_state_update (t, "Started");
-    if (t->timeout >= 0.0)
-        cron_task_timeout_start (t);
 
     t->p = p;
     rc = 0;

--- a/t/t2270-job-dependencies.t
+++ b/t/t2270-job-dependencies.t
@@ -15,6 +15,7 @@ flux setattr log-stderr-level 1
 
 PLUGINPATH=${FLUX_BUILD_DIR}/t/job-manager/plugins/.libs
 
+
 test_expect_success HAVE_JQ 'flux-mini: --dependency option works' '
 	flux mini run --dry-run \
 		--env=-* \


### PR DESCRIPTION
For whatever reason I was getting reproducible failures in  `t0015-cron.t`:  `not ok 2 - flux-cron can set timeout on tasks` (a failure I've seen intermittently, but never reproducible). It turns out this was not due to a race in the test, but a race in the cron module itself. The timeout timer was being started when the cron task was started, not when it was actually running. If the timer fired before the task was running, then the attempt to kill it will fail.

There are other problems in the cron module, but we'll not tackle those now. This PR just fixes the race by starting the timer when the task is Running instead of Starting.