### PR TITLE
testsuite: fix several tests on slower systems

### DIFF
--- a/t/sharness.d/flux-sharness.sh
+++ b/t/sharness.d/flux-sharness.sh
@@ -34,6 +34,29 @@ test_size_large() {
 
 
 #
+#  Like test_must_fail(), but additionally allow process to be
+#   terminated by SIGKILL or SIGTERM
+#
+test_must_fail_or_be_terminated() {
+    "$@"
+    exit_code=$?
+    # Allow death by SIGTERM or SIGKILL
+    if test $exit_code = 143 -o $exit_code = 137; then
+        return 0
+    elif test $exit_code = 0; then
+        echo >&2 "test_must_fail: command succeeded: $*"
+        return 1
+    elif test $exit_code -gt 129 -a $exit_code -le 192; then
+        echo >&2 "test_must_fail: died by non-SIGTERM signal: $*"
+        return 1
+    elif test $exit_code = 127; then
+        echo >&2 "test_must_fail: command not found: $*"
+        return 1
+    fi
+    return 0
+}
+
+#
 #  Tests using test_under_flux() and which load their own modules should
 #   ensure those modules are unloaded at the end of the test for proper
 #   cleanup and test coverage (also as a general principle, module unload

--- a/t/t0005-exec.t
+++ b/t/t0005-exec.t
@@ -172,13 +172,14 @@ test_expect_success 'I/O -- long lines' '
 	test_cmp output expected
 '
 
-
+waitfile=$SHARNESS_TEST_SRCDIR/scripts/waitfile.lua
 test_expect_success 'signal forwarding works' '
 	cat >test_signal.sh <<-EOF &&
 	#!/bin/bash
 	sig=\${1-INT}
-	flux exec -n sleep 100 </dev/null &
-	sleep 1 &&
+	stdbuf --output=L \
+	    flux exec -n sh -c "echo hi; sleep 100" >sleepready.out 2>&1 &
+	$waitfile -t 20 -p ^hi -c ${SIZE} sleepready.out &&
 	kill -\$sig %1 &&
 	wait %1
 	exit \$?

--- a/t/t2608-job-shell-log.t
+++ b/t/t2608-job-shell-log.t
@@ -156,29 +156,6 @@ test_expect_success 'job-exec: set kill-timeout to low value for testing' '
 	flux module reload job-exec kill-timeout=0.25
 '
 
-#  Fatal error tests below must exit with failure, but exit due to
-#  SIGTERM should also be allowed. Therefore adapt sharness `test_must_fail`
-#  to allow exit 1 or 143 for succcess.
-#
-test_must_fail_or_be_terminated() {
-    "$@"
-    exit_code=$?
-    # Allow death by SIGTERM or SIGKILL
-    if test $exit_code = 143 -o $exit_code = 137; then
-        return 0
-    elif test $exit_code = 0; then
-        echo >&2 "test_must_fail: command succeeded: $*"
-        return 1
-    elif test $exit_code -gt 129 -a $exit_code -le 192; then
-        echo >&2 "test_must_fail: died by non-SIGTERM signal: $*"
-        return 1
-    elif test $exit_code = 127; then
-        echo >&2 "test_must_fail: command not found: $*"
-        return 1
-    fi
-    return 0
-}
-
 dump_job_output_eventlog() {
     flux job eventlog -p guest.output $(sed -n 's/^jobid: //p' fatal-$1.out)
 }

--- a/t/t2608-job-shell-log.t
+++ b/t/t2608-job-shell-log.t
@@ -163,8 +163,8 @@ test_expect_success 'job-exec: set kill-timeout to low value for testing' '
 test_must_fail_or_be_terminated() {
     "$@"
     exit_code=$?
-    # Allow death by SIGTERM
-    if test $exit_code = 143; then
+    # Allow death by SIGTERM or SIGKILL
+    if test $exit_code = 143 -o $exit_code = 137; then
         return 0
     elif test $exit_code = 0; then
         echo >&2 "test_must_fail: command succeeded: $*"


### PR DESCRIPTION
I was getting several reproducible testsuite failures with a build directory configured with `--enable-code-coverage` while running `make -j 16 check` on a system with 4 cores.

This PR fixes all of the frequently failing tests in this environment.