### PR TITLE
job-list: cleanup & testsuite modernization & consistency updates

### DIFF
--- a/src/modules/job-list/job_state.c
+++ b/src/modules/job-list/job_state.c
@@ -308,7 +308,7 @@ static void list_id_respond (struct list_ctx *ctx,
                              struct idsync_data *isd,
                              struct job *job)
 {
-    job_info_error_t err;
+    job_list_error_t err;
     json_t *o;
 
     if (!(o = job_to_json (job, isd->attrs, &err)))

--- a/src/modules/job-list/job_state.c
+++ b/src/modules/job-list/job_state.c
@@ -1209,6 +1209,20 @@ static int job_transition_state (struct job_state_ctx *jsctx,
     return 0;
 }
 
+#define lookup_job(jsctx,id) _lookup_job(jsctx,id,__FUNCTION__)
+static struct job *_lookup_job (struct job_state_ctx *jsctx,
+                                flux_jobid_t id,
+                                const char *prefix)
+{
+    struct job *job;
+    if (!(job = zhashx_lookup (jsctx->index, &id))) {
+        flux_log_error (jsctx->h, "%s: job %ju not in hash",
+                        prefix, (uintmax_t)id);
+        return NULL;
+    }
+    return job;
+}
+
 static int journal_advance_job (struct job_state_ctx *jsctx,
                                 flux_jobid_t id,
                                 flux_job_state_t newstate,
@@ -1217,12 +1231,9 @@ static int journal_advance_job (struct job_state_ctx *jsctx,
 {
     struct job *job;
 
-    if (!(job = zhashx_lookup (jsctx->index, &id))) {
-        flux_log_error (jsctx->h, "%s: job %ju not in hash",
-                        __FUNCTION__, (uintmax_t)id);
-        /* do not return error, we consider it a non-fatal error */
+    /* job not found is not-fatal, do not return error */
+    if (!(job = lookup_job (jsctx, id)))
         return 0;
-    }
 
     if (job_update_eventlog_seq (jsctx, job, eventlog_seq) == 1)
         return 0;
@@ -1237,12 +1248,9 @@ static int journal_revert_job (struct job_state_ctx *jsctx,
 {
     struct job *job;
 
-    if (!(job = zhashx_lookup (jsctx->index, &id))) {
-        flux_log_error (jsctx->h, "%s: job %ju not in hash",
-                        __FUNCTION__, (uintmax_t)id);
-        /* do not return error, we consider it a non-fatal error */
+    /* job not found is not-fatal, do not return error */
+    if (!(job = lookup_job (jsctx, id)))
         return 0;
-    }
 
     /* The flux-restart event is currently only posted to jobs in
      * SCHED state since that is the only state transition defined
@@ -1351,12 +1359,9 @@ static int journal_priority_event (struct job_state_ctx *jsctx,
     struct job *job;
     int64_t orig_priority;
 
-    if (!(job = zhashx_lookup (jsctx->index, &id))) {
-        flux_log_error (jsctx->h, "%s: job %ju not in hash",
-                        __FUNCTION__, (uintmax_t)id);
-        /* do not return error, we consider it a non-fatal error */
+    /* job not found is not-fatal, do not return error */
+    if (!(job = lookup_job (jsctx, id)))
         return 0;
-    }
 
     if (job_update_eventlog_seq (jsctx, job, eventlog_seq) == 1)
         return 0;
@@ -1412,12 +1417,9 @@ static int journal_finish_event (struct job_state_ctx *jsctx,
 {
     struct job *job;
 
-    if (!(job = zhashx_lookup (jsctx->index, &id))) {
-        flux_log_error (jsctx->h, "%s: job %ju not in hash",
-                        __FUNCTION__, (uintmax_t)id);
-        /* do not return error, we consider it a non-fatal error */
+    /* job not found is not-fatal, do not return error */
+    if (!(job = lookup_job (jsctx, id)))
         return 0;
-    }
 
     if (job_update_eventlog_seq (jsctx, job, eventlog_seq) == 1)
         return 0;
@@ -1460,12 +1462,9 @@ static int journal_urgency_event (struct job_state_ctx *jsctx,
 {
     struct job *job;
 
-    if (!(job = zhashx_lookup (jsctx->index, &id))) {
-        flux_log_error (jsctx->h, "%s: job %ju not in hash",
-                        __FUNCTION__, (uintmax_t)id);
-        /* do not return error, we consider it a non-fatal error */
+    /* job not found is not-fatal, do not return error */
+    if (!(job = lookup_job (jsctx, id)))
         return 0;
-    }
 
     if (job_update_eventlog_seq (jsctx, job, eventlog_seq) == 1)
         return 0;
@@ -1583,12 +1582,9 @@ static int journal_exception_event (struct job_state_ctx *jsctx,
     struct job *job;
     int severity;
 
-    if (!(job = zhashx_lookup (jsctx->index, &id))) {
-        flux_log_error (jsctx->h, "%s: job %ju not in hash",
-                        __FUNCTION__, (uintmax_t)id);
-        /* do not return error, we consider it a non-fatal error */
+    /* job not found is not-fatal, do not return error */
+    if (!(job = lookup_job (jsctx, id)))
         return 0;
-    }
 
     if (job_update_eventlog_seq (jsctx, job, eventlog_seq) == 1)
         return 0;
@@ -1623,12 +1619,9 @@ static int journal_annotations_event (struct job_state_ctx *jsctx,
         return -1;
     }
 
-    if (!(job = zhashx_lookup (jsctx->index, &id))) {
-        flux_log_error (jsctx->h, "%s: job %ju not in hash",
-                        __FUNCTION__, (uintmax_t)id);
-        /* do not return error, we consider it a non-fatal error */
+    /* job not found is not-fatal, do not return error */
+    if (!(job = lookup_job (jsctx, id)))
         return 0;
-    }
 
     json_decref (job->annotations);
     if (json_is_null (annotations))
@@ -1646,12 +1639,9 @@ static int journal_dependency_event (struct job_state_ctx *jsctx,
 {
     struct job *job;
 
-    if (!(job = zhashx_lookup (jsctx->index, &id))) {
-        flux_log_error (jsctx->h, "%s: job %ju not in hash",
-                        __FUNCTION__, (uintmax_t)id);
-        /* do not return error, we consider it a non-fatal error */
+    /* job not found is not-fatal, do not return error */
+    if (!(job = lookup_job (jsctx, id)))
         return 0;
-    }
 
     return dependency_context_parse (jsctx->h, job, cmd, context);
 }
@@ -1764,12 +1754,9 @@ static int journal_process_event (struct job_state_ctx *jsctx, json_t *event)
     }
     else {
         struct job *job;
-        if (!(job = zhashx_lookup (jsctx->index, &id))) {
-            flux_log_error (jsctx->h, "%s: job %ju not in hash",
-                            __FUNCTION__, (uintmax_t)id);
-            /* do not return error, we consider it a non-fatal error */
+        /* job not found is not-fatal, do not return error */
+        if (!(job = lookup_job (jsctx, id)))
             return 0;
-        }
         (void) job_update_eventlog_seq (jsctx, job, eventlog_seq);
     }
 

--- a/src/modules/job-list/job_util.c
+++ b/src/modules/job-list/job_util.c
@@ -22,7 +22,7 @@
 #include "job_util.h"
 #include "job_state.h"
 
-void seterror (job_info_error_t *errp, const char *fmt, ...)
+void seterror (job_list_error_t *errp, const char *fmt, ...)
 {
     if (errp) {
         va_list ap;
@@ -42,7 +42,7 @@ void seterror (job_info_error_t *errp, const char *fmt, ...)
  * EPROTO - malformed attrs array
  * ENOMEM - out of memory
  */
-json_t *job_to_json (struct job *job, json_t *attrs, job_info_error_t *errp)
+json_t *job_to_json (struct job *job, json_t *attrs, job_list_error_t *errp)
 {
     size_t index;
     json_t *value;

--- a/src/modules/job-list/job_util.h
+++ b/src/modules/job-list/job_util.h
@@ -17,12 +17,12 @@
 
 typedef struct {
     char text[160];
-} job_info_error_t;
+} job_list_error_t;
 
 void __attribute__((format (printf, 2, 3)))
-seterror (job_info_error_t *errp, const char *fmt, ...);
+seterror (job_list_error_t *errp, const char *fmt, ...);
 
-json_t *job_to_json (struct job *job, json_t *attrs, job_info_error_t *errp);
+json_t *job_to_json (struct job *job, json_t *attrs, job_list_error_t *errp);
 
 #endif /* ! _FLUX_JOB_LIST_JOB_UTIL_H */
 

--- a/src/modules/job-list/list.c
+++ b/src/modules/job-list/list.c
@@ -25,7 +25,7 @@
 #include "job_state.h"
 
 json_t *get_job_by_id (struct list_ctx *ctx,
-                       job_info_error_t *errp,
+                       job_list_error_t *errp,
                        const flux_msg_t *msg,
                        flux_jobid_t id,
                        json_t *attrs,
@@ -51,7 +51,7 @@ bool job_filter (struct job *job, uint32_t userid, int states, int results)
  * ENOMEM - out of memory
  */
 int get_jobs_from_list (json_t *jobs,
-                        job_info_error_t *errp,
+                        job_list_error_t *errp,
                         zlistx_t *list,
                         int max_entries,
                         json_t *attrs,
@@ -89,7 +89,7 @@ int get_jobs_from_list (json_t *jobs,
  * ENOMEM - out of memory
  */
 json_t *get_jobs (struct list_ctx *ctx,
-                  job_info_error_t *errp,
+                  job_list_error_t *errp,
                   int max_entries,
                   json_t *attrs,
                   uint32_t userid,
@@ -161,7 +161,7 @@ void list_cb (flux_t *h, flux_msg_handler_t *mh,
               const flux_msg_t *msg, void *arg)
 {
     struct list_ctx *ctx = arg;
-    job_info_error_t err;
+    job_list_error_t err;
     json_t *jobs = NULL;
     json_t *attrs;
     int max_entries;
@@ -229,7 +229,7 @@ error:
  * ENOMEM - out of memory
  */
 json_t *get_inactive_jobs (struct list_ctx *ctx,
-                           job_info_error_t *errp,
+                           job_list_error_t *errp,
                            int max_entries,
                            double since,
                            json_t *attrs,
@@ -275,7 +275,7 @@ void list_inactive_cb (flux_t *h, flux_msg_handler_t *mh,
                        const flux_msg_t *msg, void *arg)
 {
     struct list_ctx *ctx = arg;
-    job_info_error_t err = {{0}};
+    job_list_error_t err = {{0}};
     json_t *jobs = NULL;
     int max_entries;
     double since;
@@ -462,7 +462,7 @@ error:
  * ENOMEM - out of memory
  */
 json_t *get_job_by_id (struct list_ctx *ctx,
-                       job_info_error_t *errp,
+                       job_list_error_t *errp,
                        const flux_msg_t *msg,
                        flux_jobid_t id,
                        json_t *attrs,
@@ -505,7 +505,7 @@ void list_id_cb (flux_t *h, flux_msg_handler_t *mh,
                   const flux_msg_t *msg, void *arg)
 {
     struct list_ctx *ctx = arg;
-    job_info_error_t err = {{0}};
+    job_list_error_t err = {{0}};
     json_t *job = NULL;
     flux_jobid_t id;
     json_t *attrs;

--- a/src/modules/job-list/stats.h
+++ b/src/modules/job-list/stats.h
@@ -15,7 +15,6 @@
 
 struct job_stats {
     unsigned int state_count[FLUX_JOB_NR_STATES];
-    unsigned int total;
     unsigned int failed;
     unsigned int timeout;
     unsigned int canceled;

--- a/t/t2261-job-list-update.t
+++ b/t/t2261-job-list-update.t
@@ -101,15 +101,17 @@ wait_states() {
 
 test_expect_success 'submit jobs for job list testing' '
         #  Create `hostname` and `sleep` jobspec
+        #  N.B. Used w/ `flux job submit` for serial job submission
+        #  for efficiency (vs serial `flux mini submit`.
         #
-        flux jobspec --format json srun -N1 hostname > hostname.json &&
-        flux jobspec --format json srun -N1 sleep 300 > sleeplong.json &&
+        flux mini submit --dry-run hostname >hostname.json &&
+        flux mini submit --dry-run --time-limit=5m sleep 600 > sleeplong.json &&
         #
         # submit jobs that will complete
         #
-        for i in $(seq 0 3); do \
-                flux job submit hostname.json >> inactiveids; \
-                fj_wait_event `tail -n 1 inactiveids` clean ; \
+        for i in $(seq 0 3); do
+                flux job submit hostname.json >> inactiveids
+                fj_wait_event `tail -n 1 inactiveids` clean
         done &&
         #
         #  Currently all inactive ids are "completed"


### PR DESCRIPTION
Peeled this off of #3688 since there's a medium big cleanup commit per @grondo comments in #3688.  I'll just let my commit message do the talking:

```
    testsuite: modernize job list tests
    
    Modernize job list tests in t2260-job-list.t, t2261-job-list-update.t,
    and t2800-jobs-cmd.t by replacing `flux job submit` with `flux mini submit`
    as much as possible.  This leads to the removal of generated jobspecs
    in most cases.
    
    As a consequence, the `--wait` option can be used instead of using
    `flux job wait-event` to wait for a job to complete.
    
    In addition make code consistent between these test files.  This includes
    using the "fj_wait_event()" function and just generally using the
    same test style throughout all three files.  In some cases, slightly
    faster code using jobspecs was eliminated in favor of just running
    "flux mini submit" in series.
```

The "running things in series" part to just make the tests more obvious and simple is probably the one part that may be disliked in review.   I figured using `--cc` and sorting job ids is just confusing.  In `t2800-job-ids` there was already a sorting of job ids that was IMO confusing.  So went with the slower / simpler option.