### PR TITLE
ci: use long path for builddir in test build

### DIFF
--- a/src/test/checks_run.sh
+++ b/src/test/checks_run.sh
@@ -176,12 +176,13 @@ checks_group_end # Setup
 
 checks_group "autogen.sh" ./autogen.sh
 
+WORKDIR=$(pwd)
 if test -n "$BUILD_DIR" ; then
   mkdir -p "$BUILD_DIR"
   cd "$BUILD_DIR"
 fi
 
-checks_group "configure ${ARGS}"  /usr/src/configure ${ARGS} \
+checks_group "configure ${ARGS}"  ${WORKDIR}/configure ${ARGS} \
 	|| (printf "::error::configure failed\n"; cat config.log; exit 1)
 checks_group "make clean..." make clean
 

--- a/src/test/generate-matrix.py
+++ b/src/test/generate-matrix.py
@@ -166,6 +166,7 @@ matrix.add_build(
         TEST_CHECK_PREREQS="t",
     ),
     args="--with-flux-security",
+    command_args="--workdir=/usr/src/" + "workdir/" * 15,
 )
 
 # Ubuntu: coverage


### PR DESCRIPTION
This PR adds a `--workdir` option to `docker-run-checks.sh` to create a builddir other than `/usr/src`.

It turns out some testsuite (and perhaps other) bugs only appear in lengthy builddirs, so add a really long workdir to the bionic builder to find these issues before they are merged.

This PR will fail ci until #3736 is fixed.