### PR TITLE
testsuite: avoid long ipc:// paths in system test personality

### DIFF
--- a/doc/man1/flux-start.rst
+++ b/doc/man1/flux-start.rst
@@ -81,9 +81,13 @@ OPTIONS
    the other brokers are online.  Default: ``all``.
 
 **--test-rundir**\ =\ *PATH*
-   Set the directory to be used as the broker rundir.  By default, a directory
-   is created in /tmp for the duration of the test and destroyed afterwards.
-   If specified beforehand with this option, the directory is not destroyed.
+   Set the directory to be used as the broker rundir instead of creating a
+   temporary one.  The directory must exist, and is not cleaned up unless
+   ``--test-rundir-cleanup`` is also specified.
+
+**--test-rundir-cleanup**
+   Recursively remove the directory specified with ``--test-rundir`` upon
+   completion of flux-start.
 
 **--test-pmi-clique**\ =\ *MODE*
    Set the pmi clique mode, which determines how ``PMI_process_mapping`` is set

--- a/src/broker/boot_config.c
+++ b/src/broker/boot_config.c
@@ -31,7 +31,7 @@
 #include "boot_config.h"
 
 
-/* Copy 'fmt' into 'buf', substuting the following tokens:
+/* Copy 'fmt' into 'buf', substituting the following tokens:
  * - %h  host
  * - %p  port
  * Returns 0 on success, or -1 on overflow.

--- a/src/cmd/flux-start.c
+++ b/src/cmd/flux-start.c
@@ -212,18 +212,16 @@ int main (int argc, char *argv[])
     setup_profiling_env ();
 
     if (!optparse_hasopt (ctx.opts, "test-size")) {
-        if (optparse_hasopt (ctx.opts, "test-rundir"))
-            log_msg_exit ("--rundir only works with --test-size=N");
-        if (optparse_hasopt (ctx.opts, "test-pmi-clique"))
-            log_msg_exit ("--test-pmi-clique only works with --test-size=N");
-        if (optparse_hasopt (ctx.opts, "test-hosts"))
-            log_msg_exit ("--test-hosts only works with --test-size=N");
-        if (optparse_hasopt (ctx.opts, "test-exit-timeout"))
-            log_msg_exit ("--test-exit-timeout only works with --test-size=N");
-        if (optparse_hasopt (ctx.opts, "test-exit-mode"))
-            log_msg_exit ("--test-exit-mode only works with --test-size=N");
-        if (optparse_hasopt (ctx.opts, "test-start-mode"))
-            log_msg_exit ("--test-start-mode only works with --test-size=N");
+        int i;
+        for (i = 0; i < sizeof (opts) / sizeof (opts[0]); i++) {
+            if (opts[i].name
+                && !strncmp (opts[i].name, "test-", 5)
+                && optparse_hasopt (ctx.opts, opts[i].name))
+                log_msg_exit ("%s only works with --test-size", opts[0].name);
+        }
+    }
+
+    if (!optparse_hasopt (ctx.opts, "test-size")) {
         if (exec_broker (command, len, broker_path) < 0)
             log_err_exit ("error execing broker");
     }

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -151,6 +151,9 @@ test_expect_success 'flux-start --test-start-mode=all is accepted' "
 test_expect_success 'flux-start --test-start-mode=badmode fails' "
 	test_must_fail flux start ${ARGS} -s1 --test-start-mode=badmode /bin/true
 "
+test_expect_success 'flux-start --test-rundir-cleanup without --test-size fails' "
+	test_must_fail flux start ${ARGS} --test-rundir-cleanup /bin/true
+"
 test_expect_success 'flux-start --verbose=2 enables PMI tracing' "
 	flux start ${ARGS} \
 		--test-size=1 --verbose=2 \
@@ -316,6 +319,16 @@ test_expect_success 'flux start --test-rundir works' '
 	echo $RUNDIR >rundir_test.exp &&
 	test_cmp rundir_test.exp rundir_test.out &&
 	rmdir $RUNDIR
+'
+test_expect_success 'flux start --test-rundir --test-rundir-cleanup works' '
+	RUNDIR=$(mktemp -d) &&
+	flux start ${ARGS} --test-size=1 \
+		--test-rundir=$RUNDIR \
+		--test-rundir-cleanup \
+		flux getattr rundir >rundir_test.out &&
+	echo $RUNDIR >rundir_test.exp &&
+	test_cmp rundir_test.exp rundir_test.out &&
+	test_must_fail test -d $RUNDIR
 '
 test_expect_success 'flux start --test-rundir with missing directory fails' '
 	test_must_fail flux start ${ARGS} --test-size=1 \


### PR DESCRIPTION
This is a fix for the problem @dongahn encountered when building flux-core in a long directory, reported in #3736.

The fix is to use a directory in /tmp for the broker "rundir" in the system test personality, and put the sockets there instead of using the test trash directory, which is relative to the build tree.  To get the directory cleaned up properly, I added a new option to `flux-start`.  That seemed a bit easier than getting sharness to do it (at least, I was having a hard time getting that to work).  This approach is fine IMHO.