### PR TITLE
allow jobs to bypass scheduler with alloc-bypass jobtap plugin

### DIFF
--- a/src/modules/job-manager/Makefile.am
+++ b/src/modules/job-manager/Makefile.am
@@ -18,7 +18,8 @@ noinst_LTLIBRARIES = \
 	libjob-manager.la
 
 jobtap_plugin_LTLIBRARIES = \
-	plugins/priority-hold.la
+	plugins/priority-hold.la \
+	plugins/alloc-bypass.la
 
 job_manager_la_SOURCES = \
 	job-manager.c \
@@ -88,6 +89,14 @@ plugins_priority_hold_la_LDFLAGS = \
 	$(fluxplugin_ldflags) \
 	-module
 
+plugins_alloc_bypass_la_SOURCES = \
+	plugins/alloc-bypass.c
+plugins_alloc_bypass_la_LIBADD = \
+	$(top_builddir)/src/common/libflux-internal.la \
+	$(top_builddir)/src/common/librlist/librlist.la
+plugins_alloc_bypass_la_LDFLAGS = \
+	$(fluxplugin_ldflags) \
+	-module
 
 TESTS = \
 	test_job.t \

--- a/src/modules/job-manager/alloc.c
+++ b/src/modules/job-manager/alloc.c
@@ -538,7 +538,8 @@ int alloc_send_free_request (struct alloc *alloc, struct job *job)
 int alloc_enqueue_alloc_request (struct alloc *alloc, struct job *job)
 {
     assert (job->state == FLUX_JOB_STATE_SCHED);
-    if (!job->alloc_queued
+    if (!job->alloc_bypass
+        && !job->alloc_queued
         && !job->alloc_pending
         && job->priority != FLUX_JOB_PRIORITY_MIN) {
         bool fwd = job->priority > (FLUX_JOB_PRIORITY_MAX / 2);

--- a/src/modules/job-manager/event.c
+++ b/src/modules/job-manager/event.c
@@ -690,6 +690,10 @@ int event_job_post_vpack (struct event *event,
     flux_job_state_t old_state = job->state;
     int eventlog_seq = (flags & EVENT_JOURNAL_ONLY) ? -1 : job->eventlog_seq;
 
+    if (job->state == FLUX_JOB_STATE_NEW) {
+        errno = EAGAIN;
+        return -1;
+    }
     if (get_timestamp_now (&timestamp) < 0)
         goto error;
     if (!(entry = eventlog_entry_vpack (timestamp, name, context_fmt, ap)))

--- a/src/modules/job-manager/event.c
+++ b/src/modules/job-manager/event.c
@@ -352,11 +352,14 @@ int event_job_action (struct event *event, struct job *job)
              * response with final=true.  Thus once the flag is clear,
              * it is safe to release all resources to the scheduler.
              */
-            if (job->has_resources && !job->start_pending
-                                   && !job->free_pending) {
+            if (job->has_resources
+                && !job->alloc_bypass
+                && !job->start_pending
+                && !job->free_pending) {
                 if (alloc_send_free_request (ctx->alloc, job) < 0)
                     return -1;
             }
+
             /* Post cleanup event when cleanup is complete.
              */
             if (!job->alloc_queued && !job->alloc_pending

--- a/src/modules/job-manager/event.h
+++ b/src/modules/job-manager/event.h
@@ -56,6 +56,13 @@ int event_job_post_pack (struct event *event,
                          const char *context_fmt,
                          ...);
 
+int event_job_post_vpack (struct event *event,
+                          struct job *job,
+                          const char *name,
+                          int flags,
+                          const char *context_fmt,
+                          va_list ap);
+
 void event_ctx_destroy (struct event *event);
 struct event *event_ctx_create (struct job_manager *ctx);
 

--- a/src/modules/job-manager/job.c
+++ b/src/modules/job-manager/job.c
@@ -104,6 +104,37 @@ bool job_dependency_event_valid (struct job *job,
     return true;
 }
 
+static int job_flag_set_internal (struct job *job,
+                                  const char *flag,
+                                  bool dry_run)
+{
+   if (strcmp (flag, "alloc-bypass") == 0) {
+        if (!dry_run)
+            job->alloc_bypass = 1;
+    }
+    else if (strcmp (flag, "debug") == 0) {
+        if (!dry_run)
+            job->flags |= FLUX_JOB_DEBUG;
+    }
+    else {
+        errno = EINVAL;
+        return -1;
+    }
+    return 0;
+}
+
+int job_flag_set (struct job *job, const char *flag)
+{
+    return job_flag_set_internal (job, flag, false);
+}
+
+bool job_flag_valid (struct job *job, const char *flag)
+{
+    if (job_flag_set_internal (job, flag, true) < 0)
+        return false;
+    return true;
+}
+
 int job_aux_set (struct job *job,
                  const char *name,
                  void *val,

--- a/src/modules/job-manager/job.h
+++ b/src/modules/job-manager/job.h
@@ -33,6 +33,7 @@ struct job {
 
     uint8_t alloc_queued:1; // queued for alloc, but alloc request not sent
     uint8_t alloc_pending:1;// alloc request sent to sched
+    uint8_t alloc_bypass:1; // alloc bypass enabled
     uint8_t free_pending:1; // free request sent to sched
     uint8_t has_resources:1;
     uint8_t start_pending:1;// start request sent to job-exec

--- a/src/modules/job-manager/job.h
+++ b/src/modules/job-manager/job.h
@@ -87,6 +87,15 @@ bool job_dependency_event_valid (struct job *job,
                                  const char *event,
                                  const char *description);
 
+
+/*  Set a limited set of flags by name on job
+ */
+int job_flag_set (struct job *job, const char *flag);
+
+/*  Test if flag name 'flag' is a valid job flag
+ */
+bool job_flag_valid (struct job *job, const char *flag);
+
 #endif /* _FLUX_JOB_MANAGER_JOB_H */
 
 /*

--- a/src/modules/job-manager/jobtap.c
+++ b/src/modules/job-manager/jobtap.c
@@ -1634,6 +1634,31 @@ int flux_jobtap_job_aux_delete (flux_plugin_t *p,
     return 0;
 }
 
+int flux_jobtap_job_set_flag (flux_plugin_t *p,
+                              flux_jobid_t id,
+                              const char *flag)
+{
+    struct jobtap *jobtap;
+    struct job *job;
+    if (!p || !flag || !(jobtap = flux_plugin_aux_get (p, "flux::jobtap"))) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (!(job = jobtap_lookup_jobid (p, id))) {
+        errno = ENOENT;
+        return -1;
+    }
+    if (!job_flag_valid (job, flag))
+        return -1;
+    return event_job_post_pack (jobtap->ctx->event,
+                                job,
+                                "set-flags",
+                                0,
+                                "{s:[s]}",
+                                "flags",
+                                flag);
+}
+
 static int jobtap_job_vraise (struct jobtap *jobtap,
                               struct job *job,
                               const char *type,

--- a/src/modules/job-manager/jobtap.c
+++ b/src/modules/job-manager/jobtap.c
@@ -1757,6 +1757,30 @@ int flux_jobtap_get_job_result (flux_plugin_t *p,
     return 0;
 }
 
+int flux_jobtap_event_post_pack (flux_plugin_t *p,
+                                 flux_jobid_t id,
+                                 const char *name,
+                                 const char *fmt,
+                                 ...)
+{
+    int rc;
+    va_list ap;
+    struct jobtap *jobtap;
+    struct job *job;
+
+    if (!p || !name
+        || !(jobtap = flux_plugin_aux_get (p, "flux::jobtap"))) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (!(job = jobtap_lookup_jobid (p, id)))
+        return -1;
+    va_start (ap, fmt);
+    rc = event_job_post_vpack (jobtap->ctx->event, job, name, 0, fmt, ap);
+    va_end (ap);
+    return rc;
+}
+
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab
  */

--- a/src/modules/job-manager/jobtap.c
+++ b/src/modules/job-manager/jobtap.c
@@ -1058,8 +1058,7 @@ static int plugin_try_load (struct jobtap *jobtap,
 
     if (flux_plugin_load_dso (p, fullpath) < 0)
         return errprintf (errp,
-                          "%s: %s",
-                          fullpath,
+                          "%s",
                           flux_plugin_strerror (p));
     if (!(name = strdup (basename (fullpath)))
         || flux_plugin_aux_set (p, "jobtap::basename", name, free) < 0) {

--- a/src/modules/job-manager/jobtap.h
+++ b/src/modules/job-manager/jobtap.h
@@ -141,6 +141,18 @@ int flux_jobtap_raise_exception (flux_plugin_t *p,
                                  const char *fmt,
                                  ...);
 
+/*  Post event 'name' to job `id` with optional context defined by
+ *   args `fmt, ...`.
+ *
+ *  If `id` is FLUX_JOBTAP_CURRENT_JOB then the event will be posted to
+ *   the current job.
+ */
+int flux_jobtap_event_post_pack (flux_plugin_t *p,
+                                 flux_jobid_t id,
+                                 const char *name,
+                                 const char *fmt,
+                                 ...);
+
 /*  Return a flux_plugin_arg_t object for any active job.
  *
  *  The result can then be unpacked with flux_plugin_arg_unpack(3) to get

--- a/src/modules/job-manager/jobtap.h
+++ b/src/modules/job-manager/jobtap.h
@@ -56,7 +56,6 @@ int flux_jobtap_reprioritize_job (flux_plugin_t *p,
 int flux_jobtap_priority_unavail (flux_plugin_t *p,
                                   flux_plugin_arg_t *args);
 
-
 /*  Convenience function to be used in job.validate callback to reject a
  *   job with error message formatted by the fmt string.
  *   returns -1 to allow an idiom like:
@@ -132,6 +131,13 @@ int flux_jobtap_job_aux_delete (flux_plugin_t *p,
                                 flux_jobid_t id,
                                 void *val);
 
+/*  Set a named flag on job `id`.
+ */
+int flux_jobtap_job_set_flag (flux_plugin_t *p,
+                              flux_jobid_t id,
+                              const char *flag);
+
+
 /*  Raise an exception for job 'id' or current job if FLUX_JOBTAP_CURRENT_JOB
  */
 int flux_jobtap_raise_exception (flux_plugin_t *p,
@@ -169,6 +175,8 @@ flux_plugin_arg_t * flux_jobtap_job_lookup (flux_plugin_t *p,
 int flux_jobtap_get_job_result (flux_plugin_t *p,
                                 flux_jobid_t id,
                                 flux_job_result_t *resultp);
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/modules/job-manager/plugins/alloc-bypass.c
+++ b/src/modules/job-manager/plugins/alloc-bypass.c
@@ -1,0 +1,229 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* alloc-bypass.c - If attributes.system.R exists in jobspec, then
+ *  bypass scheduler alloc protocol and use R directly (for instance
+ *  owner use only)
+ */
+
+
+#include <unistd.h>
+#include <sys/types.h>
+
+#include <jansson.h>
+#include <flux/core.h>
+#include <flux/jobtap.h>
+
+#include "src/common/librlist/rlist.h"
+
+static void alloc_continuation (flux_future_t *f, void *arg)
+{
+    flux_plugin_t *p = arg;
+    flux_jobid_t *idptr = flux_future_aux_get (f, "jobid");
+
+    if (flux_future_get (f, NULL) < 0) {
+        flux_jobtap_raise_exception (p,
+                                     *idptr,
+                                     "alloc", 0,
+                                     "failed to commit R to kvs: %s",
+                                      strerror (errno));
+        goto done;
+    }
+    if (flux_jobtap_event_post_pack (p,
+                                     *idptr,
+                                     "alloc",
+                                     "{s:b}",
+                                     "bypass", true) < 0)
+        flux_jobtap_raise_exception (p,
+                                     *idptr,
+                                     "alloc", 0,
+                                     "failed to post alloc event: %s",
+                                     strerror (errno));
+
+    /*  Set "needs-free" so that alloc-bypass knows that a "free"
+     *   event needs to be emitted for this node.
+     */
+    if (flux_jobtap_job_aux_set (p, *idptr, "alloc-bypass::free", p, NULL) < 0)
+        flux_log_error (flux_jobtap_get_flux (p),
+                        "id=%ju: Failed to set alloc-bypass::free",
+                        *idptr);
+
+done:
+    flux_future_destroy (f);
+}
+
+static int alloc_start (flux_plugin_t *p,
+                        flux_jobid_t id,
+                        const char *R)
+{
+    flux_t *h;
+    char key[64];
+    flux_future_t *f = NULL;
+    flux_kvs_txn_t *txn = NULL;
+    flux_jobid_t *idptr = NULL;
+
+    if (!(h = flux_jobtap_get_flux (p))
+        || flux_job_kvs_key (key, sizeof (key), id, "R") < 0
+        || !(txn = flux_kvs_txn_create ())
+        || flux_kvs_txn_put (txn, 0, key, R) < 0
+        || !(f = flux_kvs_commit (h, NULL, 0, txn))
+        || flux_future_then (f, -1, alloc_continuation, p)
+        || !(idptr = calloc (1, sizeof (*idptr)))
+        || flux_future_aux_set (f, "jobid", idptr, free) < 0) {
+        flux_kvs_txn_destroy (txn);
+        flux_future_destroy (f);
+        free (idptr);
+        return -1;
+    }
+    *idptr = id;
+    flux_kvs_txn_destroy (txn);
+    return 0;
+}
+
+
+static int sched_cb (flux_plugin_t *p,
+                     const char *topic,
+                     flux_plugin_arg_t *args,
+                     void *arg)
+{
+    const char *R = NULL;
+    flux_jobid_t id;
+
+    /*  If alloc-bypass::R set on this job then commit R to KVS
+     *   and set alloc-bypass flag
+     */
+    if (!(R = flux_jobtap_job_aux_get (p,
+                                       FLUX_JOBTAP_CURRENT_JOB,
+                                       "alloc-bypass::R")))
+        return 0;
+
+
+    if (flux_plugin_arg_unpack (args,
+                                FLUX_PLUGIN_ARG_IN,
+                                "{s:I}",
+                                "id", &id) < 0) {
+        flux_jobtap_raise_exception (p, FLUX_JOBTAP_CURRENT_JOB,
+                                     "alloc", 0,
+                                     "alloc-bypass: %s: unpack: %s",
+                                     topic,
+                                     flux_plugin_arg_strerror (args));
+        return -1;
+    }
+
+    if (alloc_start (p, id, R) < 0)
+        flux_jobtap_raise_exception (p, id, "alloc", 0,
+                                     "failed to commit R to kvs");
+
+    if (flux_jobtap_job_set_flag (p,
+                                  FLUX_JOBTAP_CURRENT_JOB,
+                                  "alloc-bypass") < 0)
+        return flux_jobtap_raise_exception (p, FLUX_JOBTAP_CURRENT_JOB,
+                                            "alloc", 0,
+                                            "Failed to set alloc-bypass: %s",
+                                            strerror (errno));
+    return 0;
+}
+
+static int cleanup_cb (flux_plugin_t *p,
+                       const char *topic,
+                       flux_plugin_arg_t *args,
+                       void *arg)
+{
+    /*  If alloc-bypass::free is set on this job, then this plugin
+     *   sent an "alloc" event, so a "free" event needs to be sent now.
+     */
+    if (flux_jobtap_job_aux_get (p,
+                                 FLUX_JOBTAP_CURRENT_JOB,
+                                 "alloc-bypass::free")) {
+        if (flux_jobtap_event_post_pack (p,
+                                         FLUX_JOBTAP_CURRENT_JOB,
+                                         "free",
+                                         NULL) < 0)
+             flux_log_error (flux_jobtap_get_flux (p),
+                             "alloc-bypass: failed to post free event");
+    }
+    return 0;
+}
+
+static int validate_cb (flux_plugin_t *p,
+                        const char *topic,
+                        flux_plugin_arg_t *args,
+                        void *arg)
+{
+    json_t *R = NULL;
+    char *s;
+    struct rlist *rl;
+    json_error_t error;
+    uint32_t userid = (uint32_t) -1;
+
+    if (flux_plugin_arg_unpack (args,
+                                FLUX_PLUGIN_ARG_IN,
+                                "{s:i s:{s:{s:{s?{s?o}}}}}",
+                                "userid", &userid,
+                                "jobspec",
+                                 "attributes",
+                                  "system",
+                                   "alloc-bypass",
+                                    "R", &R) < 0) {
+        return flux_jobtap_reject_job (p,
+                                       args,
+                                       "invalid system.alloc-bypass.R: %s",
+                                       flux_plugin_arg_strerror (args));
+    }
+
+    /*  Nothing to do if no R provided
+     */
+    if (R == NULL)
+        return 0;
+
+    if (userid != getuid ())
+        return flux_jobtap_reject_job (p,
+                                       args,
+                                       "Guest user cannot use alloc bypass");
+
+    /*  Sanity check R for validity
+     */
+    if (!(rl = rlist_from_json (R, &error)))
+        return flux_jobtap_reject_job (p,
+                                       args,
+                                       "alloc-bypass: invalid R: %s",
+                                       error.text);
+    rlist_destroy (rl);
+
+    /*  Store R string in job structure to avoid re-fetching from plugin args
+     *   in job.state.sched callback.
+     */
+    if (!(s = json_dumps (R, 0))
+        || flux_jobtap_job_aux_set (p,
+                                    FLUX_JOBTAP_CURRENT_JOB,
+                                    "alloc-bypass::R",
+                                    s,
+                                    free) < 0) {
+        free (s);
+        return flux_jobtap_reject_job (p,
+                                       args,
+                                       "failed to capture alloc-bypass R: %s",
+                                       strerror (errno));
+    }
+    return 0;
+}
+
+static const struct flux_plugin_handler tab[] = {
+    { "job.state.sched",   sched_cb,    NULL },
+    { "job.state.cleanup", cleanup_cb,  NULL },
+    { "job.validate",      validate_cb, NULL },
+    { 0 }
+};
+
+
+int flux_plugin_init (flux_plugin_t *p)
+{
+    return flux_plugin_register (p, "alloc-bypass", tab);
+}

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -131,6 +131,7 @@ TESTSCRIPTS = \
 	t2270-job-dependencies.t \
 	t2271-job-dependency-after.t \
 	t2272-job-begin-time.t \
+	t2273-job-alloc-bypass.t \
 	t2300-sched-simple.t \
 	t2302-sched-simple-up-down.t \
 	t2310-resource-module.t \

--- a/t/job-manager/plugins/jobtap_api.c
+++ b/t/job-manager/plugins/jobtap_api.c
@@ -243,6 +243,7 @@ static int test_job_lookup (flux_plugin_t *p,
                                            "flux_jobtap_job_lookup",
                                            (uintmax_t) lookupid,
                                            strerror (errno));
+    flux_plugin_arg_destroy (oarg);
     return 0;
 }
 

--- a/t/job-manager/plugins/jobtap_api.c
+++ b/t/job-manager/plugins/jobtap_api.c
@@ -13,6 +13,91 @@
 #include <flux/core.h>
 #include <flux/jobtap.h>
 
+static int test_event_post_pack (flux_plugin_t *p,
+                                 const char *topic,
+                                 flux_plugin_arg_t *args)
+{
+    const char *event = NULL;
+
+    errno = 0;
+    if (flux_jobtap_event_post_pack (NULL, 0, NULL, NULL) == 0
+        || errno != EINVAL)
+        flux_jobtap_raise_exception (p, FLUX_JOBTAP_CURRENT_JOB,
+                                     "test", 0,
+                                     "%s: %s (%s): errno=%d != %d",
+                                     topic,
+                                     "flux_jobtap_event_post_pack",
+                                     " (NULL, ...)",
+                                     errno,
+                                     EINVAL);
+    errno = 0;
+    if (flux_jobtap_event_post_pack (p, 0, "foo", NULL) == 0
+        || errno != ENOENT)
+        flux_jobtap_raise_exception (p, FLUX_JOBTAP_CURRENT_JOB,
+                                     "test", 0,
+                                     "%s: %s (%s): errno=%d != %d",
+                                     topic,
+                                     "flux_jobtap_event_post_pack",
+                                     " (NULL, ...)",
+                                     errno,
+                                     ENOENT);
+
+    if (strcmp (topic, "job.validate") == 0
+        || strcmp (topic, "job.new") == 0) {
+        /* Events may not be emitted before DEPEND state */
+        if (flux_jobtap_event_post_pack (p,
+                                         FLUX_JOBTAP_CURRENT_JOB,
+                                         "foo",
+                                         NULL) == 0
+            || errno != EAGAIN)
+            flux_jobtap_raise_exception (p, FLUX_JOBTAP_CURRENT_JOB,
+                                         "test", 0,
+                                         "%s: %s (%s): errno=%d != %d",
+                                         topic,
+                                         "flux_jobtap_event_post_pack",
+                                         " (topic=%S)",
+                                         errno,
+                                         EINVAL);
+        return 0;
+    }
+
+    const char *state;
+    if (strncmp (topic, "job.state.", 10) == 0)
+        state = topic+10;
+    else
+        state = topic+4;
+    if (flux_plugin_arg_unpack (args, FLUX_PLUGIN_ARG_IN,
+                                "{s:{s:{s:{s?{s?s}}}}}",
+                                "jobspec",
+                                 "attributes",
+                                  "system",
+                                   state,
+                                    "post-event", &event) < 0)
+        return flux_jobtap_raise_exception (p,
+                                            FLUX_JOBTAP_CURRENT_JOB,
+                                            "test", 0,
+                                            "%s: %s: unpack_args: %s",
+                                            topic,
+                                            "test_event_post",
+                                            flux_plugin_arg_strerror (args));
+    if (event != NULL) {
+        if (flux_jobtap_event_post_pack (p,
+                                         FLUX_JOBTAP_CURRENT_JOB,
+                                         event,
+                                         "{s:s}",
+                                         "test_context", "yes") < 0)
+            flux_jobtap_raise_exception (p, FLUX_JOBTAP_CURRENT_JOB,
+                                         "test", 0,
+                                         "%s: %s (event=%s): %s",
+                                         topic,
+                                         "flux_jobtap_event_post_pack",
+                                         event,
+                                         strerror (errno));
+    }
+
+    return 0;
+}
+
 static void set_flag_expect_error (const char *topic,
                                    flux_plugin_t *p,
                                    flux_jobid_t id,
@@ -245,6 +330,7 @@ static int cleanup_cb (flux_plugin_t *p,
                        flux_plugin_arg_t *args,
                        void *arg)
 {
+    test_event_post_pack (p, topic, args);
     return test_job_result (p, topic, args);
 }
 
@@ -269,6 +355,7 @@ static int run_cb (flux_plugin_t *p,
                                            "flux_jobtap_get_job_result",
                                            EINVAL,
                                            errno);
+    test_event_post_pack (p, topic, args);
     return 0;
 }
 
@@ -278,6 +365,7 @@ static int sched_cb (flux_plugin_t *p,
                      void *arg)
 {
     test_job_flags (p, topic, args);
+    test_event_post_pack (p, topic, args);
     return 0;
 }
 
@@ -287,6 +375,7 @@ static int priority_cb (flux_plugin_t *p,
                         void *arg)
 {
     test_job_flags (p, topic, args);
+    test_event_post_pack (p, topic, args);
     return 0;
 }
 
@@ -296,6 +385,7 @@ static int depend_cb (flux_plugin_t *p,
                       void *arg)
 {
     test_job_flags (p, topic, args);
+    test_event_post_pack (p, topic, args);
     return test_job_lookup (p, topic, args);
 }
 
@@ -305,6 +395,7 @@ static int validate_cb (flux_plugin_t *p,
                         flux_plugin_arg_t *args,
                         void *arg)
 {
+    test_event_post_pack (p, topic, args);
     return test_job_lookup (p, topic, args);
 }
 
@@ -313,6 +404,7 @@ static int new_cb (flux_plugin_t *p,
                    flux_plugin_arg_t *args,
                    void *arg)
 {
+    test_event_post_pack (p, topic, args);
     return test_job_flags (p, topic, args);
 }
 

--- a/t/job-manager/plugins/jobtap_api.c
+++ b/t/job-manager/plugins/jobtap_api.c
@@ -308,11 +308,11 @@ static int test_job_result (flux_plugin_t *p,
     if (rc < 0 || expected_result != result)
         return flux_jobtap_raise_exception (p, FLUX_JOBTAP_CURRENT_JOB,
                                            "test", 0,
-                                           "%s: %s: expected errno=%d got %d",
+                                           "%s: %s: expected result=%d got %d",
                                            topic,
                                            "flux_jobtap_get_job_result",
-                                           ENOENT,
-                                           errno);
+                                           expected_result,
+                                           result);
 
     return 0;
 }

--- a/t/t2212-job-manager-plugins.t
+++ b/t/t2212-job-manager-plugins.t
@@ -216,6 +216,12 @@ test_expect_success 'job-manager: load jobtap_api test plugin' '
 	flux job cancel $id &&
 	test_must_fail flux job wait-event -vm type=test $id exception
 '
+test_expect_success 'job-manager: test that job flags can be set' '
+	id=$(flux mini submit \
+	       --setattr=system.depend.set_flag=debug hostname) &&
+	flux job wait-event -vt 20 $id debug.free-request &&
+	flux job wait-event -vt 20 $id clean
+'
 test_expect_success 'job-manager: load test jobtap plugin' '
 	flux jobtap load --remove=all ${PLUGINPATH}/test.so foo.test=1 &&
 	flux dmesg | grep "conf={\"foo\":{\"test\":1}}"

--- a/t/t2212-job-manager-plugins.t
+++ b/t/t2212-job-manager-plugins.t
@@ -222,6 +222,14 @@ test_expect_success 'job-manager: test that job flags can be set' '
 	flux job wait-event -vt 20 $id debug.free-request &&
 	flux job wait-event -vt 20 $id clean
 '
+test_expect_success 'job-manager: jobtap plugin can emit events' '
+	for state in validate new depend priority run cleanup; do
+	    id=$(flux mini submit \
+	          --setattr system.${state}.post-event=testevent hostname) &&
+	    flux job wait-event -vt 20 $id testevent &&
+	    flux job wait-event -t 20 $id clean
+	done
+'
 test_expect_success 'job-manager: load test jobtap plugin' '
 	flux jobtap load --remove=all ${PLUGINPATH}/test.so foo.test=1 &&
 	flux dmesg | grep "conf={\"foo\":{\"test\":1}}"

--- a/t/t2273-job-alloc-bypass.t
+++ b/t/t2273-job-alloc-bypass.t
@@ -1,0 +1,77 @@
+#!/bin/sh
+
+test_description='Test alloc-bypass job manager plugin'
+
+. $(dirname $0)/sharness.sh
+
+test_under_flux 2 job
+
+flux version | grep -q libflux-security && test_set_prereq FLUX_SECURITY
+
+flux setattr log-stderr-level 1
+
+submit_as_alternate_user()
+{
+        FAKE_USERID=42
+        test_debug "echo running flux mini run $@ as userid $FAKE_USERID"
+        flux mini run --dry-run "$@" | \
+	  flux python ${SHARNESS_TEST_SRCDIR}/scripts/sign-as.py $FAKE_USERID \
+            >job.signed
+        FLUX_HANDLE_USERID=$FAKE_USERID \
+          flux job submit --flags=signed job.signed
+}
+
+test_expect_success 'alloc-bypass: start a job using all resources' '
+	SLEEPID=$(flux mini submit \
+	            -n $(flux resource list -s up -no {ncores}) \
+	            sleep inf)
+'
+test_expect_success 'alloc-bypass: load alloc-bypass plugin' '
+	flux jobtap load alloc-bypass.so
+'
+test_expect_success 'alloc-bypass: works' '
+	flux resource list &&
+	run_timeout 15 \
+	    flux mini run \
+	        --setattr=system.alloc-bypass.R="$(flux kvs get resource.R)" \
+	        -o per-resource.type=node hostname
+'
+test_expect_success 'alloc-bypass: works with per-resource.type=core' '
+	flux mini run \
+	    --setattr=system.alloc-bypass.R="$(flux kvs get resource.R)" \
+	    -o per-resource.type=core hostname
+'
+test_expect_success 'alloc-bypass: works with jobid' '
+	flux mini run \
+	    --setattr=system.alloc-bypass.R="$(flux job info $SLEEPID R)" \
+	    -o per-resource.type=node flux getattr rank
+'
+test_expect_success FLUX_SECURITY 'alloc-bypass: guest user not allowed' '
+	test_must_fail submit_as_alternate_user \
+	  --setattr=system.alloc-bypass.R="$(flux kvs get resource.R)" \
+          hostname
+'
+test_expect_success 'alloc-bypass; invalid alloc-bypass.R type fails' '
+	test_must_fail flux mini run \
+	    --setattr=system.alloc-bypass.R=1 \
+	    -o per-resource.type=node hostname
+'
+test_expect_success 'alloc-bypass: invalid alloc-bypass.R object fails' '
+	test_must_fail flux mini run \
+	    --setattr=system.alloc-bypass.R="{\"version\": 1}" \
+	    -o per-resource.type=node hostname
+'
+test_expect_success 'alloc-bypass: handles exception before alloc event' '
+	jobid=$(flux mini submit \
+	        --setattr=system.alloc-bypass.R="$(flux kvs get resource.R)" \
+		--dependency=afterok:$SLEEPID \
+		-o per-resource.type=node hostname) &&
+	flux job wait-event -vt 15 $jobid dependency-add &&
+	flux job cancel $jobid &&
+	test_must_fail flux job attach -vEX $jobid
+'
+test_expect_success 'alloc-bypass: kill sleep job' '
+	flux job cancelall -f &&
+	flux job wait-event $SLEEPID clean
+'
+test_done


### PR DESCRIPTION
This is a proof-of-concept implementation of the idea discussed in #3737. This will probably need a bit more work before it could be a merge candidate, but I thought it might be useful to push here for now in order to continue the discussion around a concrete implementation.

The current approach is pretty straightforward:

 * Add a new `alloc_bypass` flag to the job manager's `struct job`. If this flag is set then alloc/free requests are not sent to the loaded scheduler
 * Allow a jobtap plugin to return an `R` in the `job.state.sched` callback, which, if the job was submitted by the instance owner, enables "alloc bypass" mode, writes the `R` to the appropriate KVS path, and finally generates an `alloc` event directly
 * Add an `alloc-bypass.so` loadable jobtap plugin which returns an `R` in `job.state.sched` if one is set in `attributes.system.R`
 * Add a new convenience `--with-R` option to `flux-mini.py` which writes its argument to `attributes.system.R` and also sets the `per-resource.type` shell option to `node` (running one process per node by default)

Actually, while working on this, I wondered if instead of returning an `R` directly in the plugin "out" arguments, a plugin should be allowed to simply set the alloc_bypass flag on a job. This would allow the plugin requesting alloc bypass to asynchronously commit `R` itself to the KVS and generate the `alloc` event when ready. We'd have to add some helper functions to the interface, but this seems a bit more powerful than the current approach, since it allows for cases where `R` is not immediately available.

In kind, the generation of the `free` event should be left to the plugin as well. Currently the `free` event is simply posted immediately upon entry to the CLEANUP state if `job->alloc_bypass` is set.

In fact, I wonder if that kind of interface would be useful for the simulator?

Open to any other ideas of course, just thought it might be useful to have a somewhat working implementation. Examples:

```console
$ flux resource list
     STATE NNODES   NCORES    NGPUS NODELIST
      free      4        8        0 asp,asp,asp,asp
 allocated      4        8        0 asp,asp,asp,asp
      down      0        0        0 
# load required jobtap plugin:
$ flux jobtap load alloc-bypass.so

# run across arbitrary resources using `flux R encode`
$ flux mini run --with-R="$(flux R encode -r 2-3 -c 3)" --label-io sh -c 'echo rank is $(flux getattr rank); taskset -c -p $$'
1: rank is 3
0: rank is 2
1: pid 28180's current affinity list: 3
0: pid 28181's current affinity list: 3

# Run across job resources using `flux job info` and `flux R decode`
$ flux jobs
       JOBID USER     NAME       ST NTASKS NNODES  RUNTIME NODELIST
    ƒAufacbR grondo   sleep       R      4      2   6.479m asp,asp
    ƒASKFs4T grondo   sleep       R      4      2   6.497m asp,asp
$ flux mini run --with-R="$((flux job info ƒASKFs4T R && flux job info ƒAufacbR R) | flux R decode)"  --label-io sh -c 'echo rank is $(flux getattr rank); taskset -c -p $$'
1: rank is 1
3: rank is 3
2: rank is 2
1: pid 30856's current affinity list: 0,1
0: rank is 0
0: pid 30855's current affinity list: 0,1
2: pid 30853's current affinity list: 0,1
3: pid 30854's current affinity list: 0,1

# Run multiple tasks per core instead of 1 per node:
$ flux mini run --with-R="$(flux R encode -r 2 -c 0)" -o per-resource.type=core -o per-resource.count=4 --label-io sh -c 'echo rank is $(flux getattr rank); taskset -c -p $$'
0: rank is 2
1: rank is 2
0: pid 32098's current affinity list: 0
1: pid 32099's current affinity list: 0
2: rank is 2
3: rank is 2
2: pid 32101's current affinity list: 0
3: pid 32105's current affinity list: 0

```