### PR TITLE
WIP: add flux job exec and job manager fastpath

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -29,6 +29,7 @@ MAN1_FILES_PRIMARY = \
 	man1/flux-cron.1 \
 	man1/flux-event.1 \
 	man1/flux-mini.1 \
+	man1/flux-job.1 \
 	man1/flux-version.1 \
 	man1/flux-jobs.1 \
 	man1/flux-shell.1 \

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -131,6 +131,7 @@ man_pages = [
     ('man1/flux-kvs', 'flux-kvs', 'Flux key-value store utility', [author], 1),
     ('man1/flux-logger', 'flux-logger', 'create a Flux log entry', [author], 1),
     ('man1/flux-mini', 'flux-mini', 'Minimal Job Submission Tool', [author], 1),
+    ('man1/flux-job', 'flux-job', 'Job Housekeeping Tool', [author], 1),
     ('man1/flux-module', 'flux-module', 'manage Flux extension modules', [author], 1),
     ('man1/flux-ping', 'flux-ping', 'measure round-trip latency to Flux services', [author], 1),
     ('man1/flux-proxy', 'flux-proxy', 'create proxy environment for Flux instance', [author], 1),

--- a/doc/man1/flux-job.rst
+++ b/doc/man1/flux-job.rst
@@ -1,0 +1,151 @@
+.. flux-help-include: true
+
+===========
+flux-job(1)
+===========
+
+
+SYNOPSIS
+========
+
+**flux** **job** **cancel** *id* [*message...*]
+
+**flux** **job** **cancelall** [*OPTIONS*] [*message...*]
+
+**flux** **job** **kill** [*--signal=SIG*] *id*
+
+**flux** **job** **killall** [*OPTIONS*]
+
+**flux** **job** **raise** [*OPTIONS*] *id* [*message...*]
+
+**flux** **job** **raiseall** [*OPTIONS*] *type* [*message...*]
+
+**flux** **job** **exec** [*OPTIONS*] [*--ntasks=N*] *COMMAND...*
+
+
+DESCRIPTION
+===========
+
+flux-job(1) performs various job related housekeeping functions.
+
+CANCEL
+======
+
+A single job may be canceled with ``flux job cancel``.
+
+Jobs may be canceled in bulk with ``flux job cancelall``.  Target jobs are
+selected with:
+
+**-u, --user=USER**
+   Set target user.  The instance owner may specify *all* for all users.
+
+**-S, --states=STATES**
+   Set target job states (default: ACTIVE).
+
+**-f, --force**
+   Confirm the command
+
+**-q, --quiet**
+   Suppress output if no jobs match
+
+SIGNAL
+======
+
+Running jobs may be signaled with ``flux job kill``.
+
+**-s, --signal=SIG**
+   Send signal SIG (default: SIGTERM).
+
+Running jobs may be signaled in bulk with ``flux job killall``.  In addition
+to the option above, target jobs are selected with:
+
+**-u, --user=USER**
+   Set target user.  The instance owner may specify *all* for all users.
+
+**-f, --force**
+   Confirm the command.
+
+EXCEPTION
+=========
+
+An exception may raised on a single job with ``flux job raise``.
+
+**-s, --severity=N**
+   Set exception severity.  The severity may range from 0=fatal to
+   7=least severe (default: 0).
+
+**-t, --type=TYPE**
+   Set exception type (default: cancel).
+
+Exceptions may be raised in bulk with ``flux job raiseall``.  In addition to
+the severity option above, target jobs are selected with:
+
+**-u, --user=USER**
+   Set target user.  The instance owner may specify *all* for all users.
+
+**-S, --states=STATES**
+   Set target job states (default: ACTIVE)
+
+**-f, --force**
+   Confirm the command.
+
+FAST EXEC
+=========
+
+``flux job exec`` is like ``flux mini run``, but faster for short jobs.
+The reduction in overhead comes with the following limitations:
+
+* It is only available to the Flux instance owner.
+
+* There are no options to set urgency, job attributes, dependencies,
+  begin-time, or submission flags.
+
+* There is no way to manipulate the environment on the command line.
+
+* Standard input is always redirected from /dev/null.
+
+* Standard output is always sent to the ``flux job exec`` standard output,
+  via the KVS.
+
+The options are as follows:
+
+**-n, --ntasks=N**
+   Set the number of tasks to launch (default 1).
+
+**-c, --cores-per-task=N**
+   Set the number of cores to assign to each task (default 1).
+
+**-g, --gpus-per-task=N**
+   Set the number of GPU devices to assign to each task (default none).
+
+**-N, --nodes=N**
+   Set the number of nodes to assign to the job. Tasks will be distributed
+   evenly across the allocated nodes. It is an error to request more nodes
+   than there are tasks. If unspecified, the number of nodes will be chosen
+   by the scheduler.
+
+**-t, --time-limit=FSD**
+   Set a time limit for the job in Flux standard duration (RFC 23).
+   FSD is a floating point number with a single character units suffix
+   ("s", "m", "h", or "d"). If unspecified, the job is subject to the
+   system default time limit.
+
+**-l, --label-io**
+   Add task rank prefixes to each line of output.
+
+**-o, --setopt=KEY[=VAL]**
+   Set shell option. Keys may include periods to denote hierarchy.
+   VAL is optional and may be valid JSON (bare values, objects, or arrays),
+   otherwise VAL is interpreted as a string. If VAL is not set, then the
+   default value is 1. See SHELL OPTIONS below.
+
+
+RESOURCES
+=========
+
+Github: http://github.com/flux-framework
+
+SEE ALSO
+========
+
+flux-mini(1)

--- a/doc/man1/index.rst
+++ b/doc/man1/index.rst
@@ -14,6 +14,7 @@ man1
    flux-exec
    flux-getattr
    flux-hwloc
+   flux-job
    flux-jobs
    flux-jobtap
    flux-keygen

--- a/doc/man3/index.rst
+++ b/doc/man3/index.rst
@@ -67,6 +67,7 @@ man3
    flux_shell_task_subprocess
    flux_signal_watcher_create
    flux_stat_watcher_create
+   flux_sync_create
    flux_timer_watcher_create
    flux_watcher_start
    flux_zmq_watcher_create

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -533,3 +533,5 @@ afterany
 afterok
 afternotok
 parsedatetime
+cancelall
+raiseall

--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -95,6 +95,8 @@ flux_start_LDADD = \
 
 flux_job_LDADD = \
 	$(fluxcmd_ldadd) \
+	$(top_builddir)/src/common/libjob/libjob.la \
+	$(top_builddir)/src/common/libutil/libutil.la \
 	$(top_builddir)/src/shell/libmpir.la \
 	$(top_builddir)/src/common/libczmqcontainers/libczmqcontainers.la \
 	$(top_builddir)/src/common/libdebugged/libdebugged.la \

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -150,7 +150,7 @@ static struct optparse_option cancelall_opts[] =  {
     { .name = "force", .key = 'f', .has_arg = 0,
       .usage = "Confirm the command",
     },
-    { .name = "quiet", .key = 'f', .has_arg = 0,
+    { .name = "quiet", .key = 'q', .has_arg = 0,
       .usage = "Suppress output if no jobs match",
     },
     OPTPARSE_TABLE_END

--- a/src/modules/job-ingest/job-ingest.c
+++ b/src/modules/job-ingest/job-ingest.c
@@ -1003,10 +1003,11 @@ int mod_main (flux_t *h, int argc, char **argv)
             goto done;
         }
         flux_future_destroy (f);
-        /* fluid_init() will fail on rank > 16K.
+        /* fluid_init() only works on first 16K ranks (0-16383).
+         * Reserve the highest numbered rank for job manager fastpath.
          * Just skip loading the job module on those ranks.
          */
-        if (fluid_init (&ctx.gen, rank, timestamp) < 0) {
+        if (rank >= 16383 || fluid_init (&ctx.gen, rank, timestamp) < 0) {
             flux_log (h, LOG_ERR, "fluid_init failed");
             errno = EINVAL;
         }

--- a/src/modules/job-manager/Makefile.am
+++ b/src/modules/job-manager/Makefile.am
@@ -58,6 +58,8 @@ libjob_manager_la_SOURCES = \
 	getattr.c \
 	prioritize.h \
 	prioritize.c \
+	runjob.h \
+	runjob.c \
 	jobtap-internal.h \
 	jobtap.h \
 	jobtap.c \

--- a/src/modules/job-manager/event.c
+++ b/src/modules/job-manager/event.c
@@ -693,7 +693,12 @@ int event_job_post_vpack (struct event *event,
     flux_job_state_t old_state = job->state;
     int eventlog_seq = (flags & EVENT_JOURNAL_ONLY) ? -1 : job->eventlog_seq;
 
-    if (job->state == FLUX_JOB_STATE_NEW) {
+    /* Events posted for jobs in the NEW state will be sent the journal
+     * _before_ the "submit" event for the job, which violates the invariant
+     * the "submit" event is the first job event.  Exception: allow the
+     * "submit" event itself to be posted by runjob.c.
+     */
+    if (job->state == FLUX_JOB_STATE_NEW && strcmp (name, "submit") != 0) {
         errno = EAGAIN;
         return -1;
     }

--- a/src/modules/job-manager/job-manager.h
+++ b/src/modules/job-manager/job-manager.h
@@ -29,6 +29,7 @@ struct job_manager {
     struct kill *kill;
     struct annotate *annotate;
     struct journal *journal;
+    struct runjob *runjob;
     struct jobtap *jobtap;
 };
 

--- a/src/modules/job-manager/runjob.c
+++ b/src/modules/job-manager/runjob.c
@@ -1,0 +1,190 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* runjob.c - fastpath for running a job in one RPC
+ *
+ * The RPC returns when the job is inactive and includes the wait status.
+ *
+ * Access is restricted to instance owner only.
+ * Job ID is issued here, instead of in job-ingest.
+ * Jobspec validation is bypassed.
+ * Jobspec is not signed, nor is signed jobspec stored to KVS.
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <czmq.h>
+#include <assert.h>
+#include <jansson.h>
+#include <flux/core.h>
+
+#include "src/common/libutil/fluid.h"
+#include "src/common/libutil/jpath.h"
+#include "src/common/libutil/errno_safe.h"
+
+#include "job.h"
+#include "wait.h"
+#include "event.h"
+#include "runjob.h"
+
+struct runjob {
+    struct job_manager *ctx;
+    struct fluid_generator fluid_gen;
+};
+
+static void jobspec_continuation (flux_future_t *f, void *arg)
+{
+    struct runjob *runjob = arg;
+    flux_t *h = flux_future_get_flux (f);
+    struct job *job = flux_future_aux_get (f, "job");
+    const char *errstr = NULL;
+
+    if (flux_rpc_get (f, NULL) < 0) {
+        errstr = "eventlog commit failed";
+        goto error;
+    }
+    if (event_job_post_pack (runjob->ctx->event,
+                             job,
+                             "submit",
+                             0,
+                             "{s:i s:i s:i}",
+                             "userid", job->userid,
+                             "urgency", job->urgency,
+                             "flags", job->flags) < 0) {
+        errstr = "error posting submit event";
+        goto error;
+    }
+    wait_notify_active (runjob->ctx->wait, job);
+    job_aux_delete (job, f);
+    return;
+error:
+    if (flux_respond_error (h, job->waiter, errno, errstr) < 0)
+        flux_log_error (h, "error responding to runjob");
+    zhashx_delete (runjob->ctx->active_jobs, &job->id);
+}
+
+static flux_future_t *commit_jobspec (flux_t *h, struct job *job)
+{
+    char key[64];
+    flux_future_t *f = NULL;
+    flux_kvs_txn_t *txn;
+
+    if (flux_job_kvs_key (key, sizeof (key), job->id, "jobspec") < 0)
+        return NULL;
+    if (!(txn = flux_kvs_txn_create ()))
+        return NULL;
+    if (flux_kvs_txn_pack (txn, 0, key, "O", job->jobspec_redacted) < 0)
+        goto error;
+    if (!(f = flux_kvs_commit (h, NULL, 0, txn)))
+        goto error;
+    flux_kvs_txn_destroy (txn);
+    return f;
+error:
+    flux_future_destroy (f);
+    flux_kvs_txn_destroy (txn);
+    return NULL;
+}
+
+void runjob_handler (flux_t *h,
+                     flux_msg_handler_t *mh,
+                     const flux_msg_t *msg,
+                     void *arg)
+{
+    struct job_manager *ctx = arg;
+    struct runjob *runjob = ctx->runjob;
+    json_t *jobspec;
+    const char *errstr = NULL;
+    struct job *job = NULL;
+    flux_future_t *f;
+
+    if (flux_request_unpack (msg,
+                             NULL,
+                             "{s:o}",
+                             "jobspec", &jobspec) < 0) {
+        errstr = "malformed runjob request";
+        goto error;
+    }
+    if (!(job = job_create ()))
+        goto error;
+    /* The runjob request will be handled as if it were a 'wait' request
+     * for this job.  Code in wait.c responds to the request once the job
+     * becomes inactive.
+     */
+    job->flags = FLUX_JOB_WAITABLE;
+    job->waiter = flux_msg_incref (msg);
+
+    if (flux_msg_get_userid (msg, &job->userid) < 0)
+        goto error;
+    if (fluid_generate (&runjob->fluid_gen, &job->id) < 0) {
+        errstr = "error generating job id";
+        errno = EINVAL;
+        goto error;
+    }
+    /* The redacted jobspec is not actually redacted until it (in full)
+     * becomes part of the KVS transaction below.
+     */
+    job->jobspec_redacted = json_incref (jobspec);
+    /* Start KVS commit of jobspec.
+     * If the commit is successful, its continuation posts the submit event
+     * which kicks the job state machine.
+     * N.B. future 'f' destruction is tied to 'job', not the other way around
+     */
+    if (!(f = commit_jobspec (h, job))
+        || flux_future_aux_set (f, "job", job, NULL) < 0
+        || flux_future_then (f, -1, jobspec_continuation, runjob) < 0
+        || job_aux_set (job, NULL, f, (flux_free_f)flux_future_destroy) < 0) {
+        flux_future_destroy (f);
+        errstr = "error committing jobspec to KVS";
+        goto error;
+    }
+    if (jpath_del (job->jobspec_redacted, "attributes.system.environment") < 0)
+        goto error;
+
+    zhashx_update (ctx->active_jobs, &job->id, job); // increfs job
+    job_decref (job);
+    return;
+error:
+    if (flux_respond_error (h, msg, errno, errstr) < 0)
+        flux_log_error (h, "error responding to runjob");
+    job_decref (job);
+}
+
+void runjob_ctx_destroy (struct runjob *runjob)
+{
+    if (runjob) {
+        int saved_errno = errno;
+        free (runjob);
+        errno = saved_errno;
+    }
+}
+
+struct runjob *runjob_ctx_create (struct job_manager *ctx)
+{
+    struct runjob *runjob;
+
+    if (!(runjob = calloc (1, sizeof (*runjob))))
+        return NULL;
+    runjob->ctx = ctx;
+    if (fluid_init (&runjob->fluid_gen,
+                    16383, // reserved by job-ingest
+                    fluid_get_timestamp (ctx->max_jobid)) < 0) {
+        flux_log (ctx->h, LOG_ERR, "fluid_init failed");
+        goto error;
+    }
+    return runjob;
+error:
+    runjob_ctx_destroy (runjob);
+    return NULL;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/job-manager/runjob.h
+++ b/src/modules/job-manager/runjob.h
@@ -1,0 +1,26 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef FLUX_JOB_MANAGER_RUNJOB_H
+#define FLUX_JOB_MANAGER_RUNJOB_H
+
+#include <flux/core.h>
+#include "job-manager.h"
+
+void runjob_handler (flux_t *h,
+                     flux_msg_handler_t *mh,
+                     const flux_msg_t *msg,
+                     void *arg);
+
+struct runjob *runjob_ctx_create (struct job_manager *ctx);
+void runjob_ctx_destroy (struct runjob *runjob);
+
+
+#endif /* !FLUX_JOB_MANAGER_RUNJOB_H */

--- a/t/t2201-job-cmd.t
+++ b/t/t2201-job-cmd.t
@@ -592,4 +592,59 @@ test_expect_success 'flux job: killall -f kills one job' '
 	run_timeout 60 flux queue drain
 '
 
+test_expect_success 'flux job exec with no command fails' '
+	test_must_fail flux job exec
+'
+test_expect_success 'flux job exec too many nodes fails' '
+	test_must_fail flux job exec -N2 -n1 /bin/true
+'
+test_expect_success 'flux job exec with bad URI fails' '
+	test_must_fail bash -c "FLUX_URI=/baduri flux job exec /bin/true"
+'
+test_expect_success 'rpc to job-manager.runjob with no payload fails' '
+        test_must_fail flux python -c \
+	  "import flux; print(flux.Flux().rpc(\"job-manager.runjob\",0).get())"
+'
+test_expect_success 'flux job exec with malformed shell option fails' '
+	test_must_fail flux job exec -oa..b=42 /bin/true
+'
+
+test_expect_success 'flux job exec works' '
+	flux job exec /bin/true
+'
+test_expect_success 'flux job exec --label-io works' '
+	flux job exec --label-io echo hi >exec1.out &&
+	grep "0: hi" exec1.out
+'
+test_expect_success 'flux job exec --ntasks=2 works' '
+	flux job exec --ntasks=2 --label-io echo hi >exec2.out &&
+	grep "1: hi" exec2.out
+'
+# sched-simple does not support GPU resources
+test_expect_success 'flux job exec --gpus-per-task=1 fails because scheduler' '
+	test_must_fail flux job exec --gpus-per-task=1 /bin/true 2>exec3.err &&
+	grep "resource type" exec3.err
+'
+test_expect_success 'flux job exec --cores-per-task=2 works' '
+	flux job exec --cores-per-task=2 /bin/true
+'
+test_expect_success 'flux job exec --nnodes=1 works' '
+	flux job exec --nnodes=1 -n2 /bin/true
+'
+test_expect_success 'flux job exec --time-limit=30s works' '
+	flux job exec --time-limit=30s /bin/true
+'
+test_expect_success HAVE_JQ 'flux job exec --setopt=foo works' '
+	id=$(flux job exec --setopt=foo printenv FLUX_JOB_ID) &&
+	flux job info $id jobspec >foo.jobspec &&
+	value=$(jq -e .attributes.system.shell.options.foo foo.jobspec) &&
+	test "$value" = "1"
+'
+test_expect_success HAVE_JQ 'flux job exec --setopt=a.b=bar works' '
+	id=$(flux job exec --setopt=a.b=bar printenv FLUX_JOB_ID) &&
+	flux job info $id jobspec >ab.jobspec &&
+	value=$(jq -e -r .attributes.system.shell.options.a.b ab.jobspec) &&
+	test "$value" = "bar"
+'
+
 test_done

--- a/t/valgrind/workload.d/job-exec
+++ b/t/valgrind/workload.d/job-exec
@@ -1,0 +1,5 @@
+#!/bin/bash -e
+
+set -x
+
+flux job exec /bin/true


### PR DESCRIPTION
Zombie alert - #3567 is not quite dead!

This is a rebased version of the original `flux job exec` hack.  The C jobspec support in the original was since improved and merged.  There is less and less code needed to make this work, so I thought I might as well bring it forth again.

It's still pretty fast, e.g.
```
$ time flux job exec hostname
system76-pc

real	0m0.075s
user	0m0.025s
sys	0m0.003s

$ time flux mini run hostname
system76-pc

real	0m0.245s
user	0m0.071s
sys	0m0.020s

# one more time after validator started:

$ time flux mini run hostname
system76-pc

real	0m0.146s
user	0m0.072s
sys	0m0.020s
```

I didn't try to change the user interface - I'm sure that could be improved.