### PR TITLE
testsuite: generalize valgrind suppressions

### DIFF
--- a/t/valgrind/valgrind.supp
+++ b/t/valgrind/valgrind.supp
@@ -92,20 +92,7 @@
    <issue_3640>
    Memcheck:Leak
    match-leak-kinds: possible
-   fun:calloc
-   obj:*/libnvidia-opencl.so.*
-   ...
-   fun:clGetPlatformIDs
-   obj:*/hwloc_opencl.so
-   obj:*/libhwloc.so.*
-   fun:hwloc_topology_load
-   ...
-}
-{
-   <issue_3640>
-   Memcheck:Leak
-   match-leak-kinds: possible
-   fun:malloc
+   fun:*alloc
    obj:*/libnvidia-opencl.so.*
    ...
    fun:clGetPlatformIDs

--- a/t/valgrind/valgrind.supp
+++ b/t/valgrind/valgrind.supp
@@ -93,11 +93,11 @@
    Memcheck:Leak
    match-leak-kinds: possible
    fun:calloc
-   obj:/usr/lib/x86_64-linux-gnu/libnvidia-opencl.so.460.73.01
+   obj:*/libnvidia-opencl.so.*
    ...
    fun:clGetPlatformIDs
-   obj:/usr/lib/x86_64-linux-gnu/hwloc/hwloc_opencl.so
-   obj:/usr/lib/x86_64-linux-gnu/libhwloc.so.15.1.0
+   obj:*/hwloc_opencl.so
+   obj:*/libhwloc.so.*
    fun:hwloc_topology_load
    ...
 }
@@ -106,11 +106,11 @@
    Memcheck:Leak
    match-leak-kinds: possible
    fun:malloc
-   obj:/usr/lib/x86_64-linux-gnu/libnvidia-opencl.so.460.73.01
+   obj:*/libnvidia-opencl.so.*
    ...
    fun:clGetPlatformIDs
-   obj:/usr/lib/x86_64-linux-gnu/hwloc/hwloc_opencl.so
-   obj:/usr/lib/x86_64-linux-gnu/libhwloc.so.15.1.0
+   obj:*/hwloc_opencl.so
+   obj:*/libhwloc.so.*
    fun:hwloc_topology_load
    ...
 }
@@ -120,8 +120,8 @@
    match-leak-kinds: definite
    fun:malloc
    fun:XNVCTRLQueryTargetStringAttribute
-   obj:/usr/lib/x86_64-linux-gnu/hwloc/hwloc_gl.so
-   obj:/usr/lib/x86_64-linux-gnu/libhwloc.so.15.1.0
+   obj:*/hwloc_gl.so
+   obj:*/libhwloc.so.*
    fun:hwloc_topology_load
    ...
 }


### PR DESCRIPTION
I found the valgrind suppressions added for #3640 no longer worked after a system update.

This PR generalizes library versions and paths using wildcards, and consolidates two suppressions that were identical except for one line.

Sorry, should have done better on the first attempt.