### PR TITLE
libflux: update flux msg route functions

### DIFF
--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -1081,7 +1081,7 @@ static void broker_disconnect_cb (flux_t *h, flux_msg_handler_t *mh,
 {
     const char *sender;
 
-    if ((sender = flux_msg_get_route_first (msg)))
+    if ((sender = flux_msg_route_first (msg)))
         exec_terminate_subprocesses_by_uuid (h, sender);
     /* no response */
 }
@@ -1095,7 +1095,7 @@ static void broker_sub_cb (flux_t *h, flux_msg_handler_t *mh,
 
     if (flux_request_unpack (msg, NULL, "{ s:s }", "topic", &topic) < 0)
         goto error;
-    if (!(uuid = flux_msg_get_route_first (msg))) {
+    if (!(uuid = flux_msg_route_first (msg))) {
         errno = EPROTO;
         goto error;
     }
@@ -1122,7 +1122,7 @@ static void broker_unsub_cb (flux_t *h, flux_msg_handler_t *mh,
 
     if (flux_request_unpack (msg, NULL, "{ s:s }", "topic", &topic) < 0)
         goto error;
-    if (!(uuid = flux_msg_get_route_first (msg))) {
+    if (!(uuid = flux_msg_route_first (msg))) {
         errno = EPROTO;
         goto error;
     }
@@ -1182,7 +1182,7 @@ static void service_add_cb (flux_t *h, flux_msg_handler_t *w,
         goto error;
     if (service_allow (cred, name) < 0)
         goto error;
-    if (!(sender = flux_msg_get_route_first (msg))) {
+    if (!(sender = flux_msg_route_first (msg))) {
         errno = EPROTO;
         goto error;
     }
@@ -1214,7 +1214,7 @@ static void service_remove_cb (flux_t *h, flux_msg_handler_t *w,
         goto error;
     if (service_allow (cred, name) < 0)
         goto error;
-    if (!(sender = flux_msg_get_route_first (msg))) {
+    if (!(sender = flux_msg_route_first (msg))) {
         errno = EPROTO;
         goto error;
     }
@@ -1468,7 +1468,7 @@ static void module_cb (module_t *p, void *arg)
             (void)broker_response_sendmsg (ctx, msg);
             break;
         case FLUX_MSGTYPE_REQUEST:
-            count = flux_msg_get_route_count (msg);
+            count = flux_msg_route_count (msg);
             /* Requests originated by the broker module will have a route
              * count of 1.  Ensure that, when the module is unloaded, a
              * disconnect message is sent to all services used by broker module.
@@ -1693,7 +1693,7 @@ static int broker_response_sendmsg (broker_ctx_t *ctx, const flux_msg_t *msg)
     int rc;
     const char *uuid;
 
-    if (!(uuid = flux_msg_get_route_last (msg)))
+    if (!(uuid = flux_msg_route_last (msg)))
         rc = flux_requeue (ctx->h, msg, FLUX_RQ_TAIL);
     else if (overlay_uuid_is_parent (ctx->overlay, uuid))
         rc = overlay_sendmsg (ctx->overlay, msg, OVERLAY_UPSTREAM);

--- a/src/broker/log.c
+++ b/src/broker/log.c
@@ -598,7 +598,7 @@ static int cmp_sender (const flux_msg_t *msg, const char *uuid)
 {
     const char *sender;
 
-    if (!(sender = flux_msg_get_route_first (msg)))
+    if (!(sender = flux_msg_route_first (msg)))
         return 0;
     if (!sender || strcmp (sender, uuid) != 0)
         return 0;
@@ -614,7 +614,7 @@ static void disconnect_request_cb (flux_t *h, flux_msg_handler_t *mh,
     zlist_t *tmp = NULL;
 
     assert (logbuf->magic == LOGBUF_MAGIC);
-    if (!(sender = flux_msg_get_route_first (msg)))
+    if (!(sender = flux_msg_route_first (msg)))
         goto done;
     msgp = zlist_first (logbuf->followers);
     while (msgp) {

--- a/src/broker/log.c
+++ b/src/broker/log.c
@@ -596,29 +596,25 @@ error:
 
 static int cmp_sender (const flux_msg_t *msg, const char *uuid)
 {
-    char *sender = NULL;
-    int rc = 0;
+    const char *sender;
 
-    if (flux_msg_get_route_first (msg, &sender) < 0)
-        goto done;
+    if (!(sender = flux_msg_get_route_first (msg)))
+        return 0;
     if (!sender || strcmp (sender, uuid) != 0)
-        goto done;
-    rc = 1;
-done:
-    free (sender);
-    return rc;
+        return 0;
+    return 1;
 }
 
 static void disconnect_request_cb (flux_t *h, flux_msg_handler_t *mh,
                                    const flux_msg_t *msg, void *arg)
 {
     logbuf_t *logbuf = arg;
-    char *sender = NULL;
+    const char *sender;
     const flux_msg_t *msgp;
     zlist_t *tmp = NULL;
 
     assert (logbuf->magic == LOGBUF_MAGIC);
-    if (flux_msg_get_route_first (msg, &sender) < 0 || !sender)
+    if (!(sender = flux_msg_get_route_first (msg)))
         goto done;
     msgp = zlist_first (logbuf->followers);
     while (msgp) {
@@ -635,7 +631,6 @@ static void disconnect_request_cb (flux_t *h, flux_msg_handler_t *mh,
             zlist_remove (logbuf->followers, (flux_msg_t *)msgp);
     }
 done:
-    free (sender);
     zlist_destroy (&tmp);
     /* no response */
 }

--- a/src/broker/module.c
+++ b/src/broker/module.c
@@ -340,26 +340,20 @@ done:
 
 int module_response_sendmsg (modhash_t *mh, const flux_msg_t *msg)
 {
-    char *uuid = NULL;
-    int rc = -1;
+    const char *uuid;
     module_t *p;
 
     if (!msg)
         return 0;
-    if (flux_msg_get_route_last (msg, &uuid) < 0)
-        goto done;
-    if (!uuid) {
+    if (!(uuid = flux_msg_get_route_last (msg))) {
         errno = EPROTO;
-        goto done;
+        return -1;
     }
     if (!(p = zhash_lookup (mh->zh_byuuid, uuid))) {
         errno = ENOSYS;
-        goto done;
+        return -1;
     }
-    rc = module_sendmsg (p, msg);
-done:
-    free (uuid);
-    return rc;
+    return module_sendmsg (p, msg);
 }
 
 int module_disconnect_arm (module_t *p,

--- a/src/broker/module.c
+++ b/src/broker/module.c
@@ -259,12 +259,12 @@ flux_msg_t *module_recvmsg (module_t *p)
         goto error;
     switch (type) {
         case FLUX_MSGTYPE_RESPONSE:
-            if (flux_msg_delete_route_last (msg) < 0)
+            if (flux_msg_route_delete_last (msg) < 0)
                 goto error;
             break;
         case FLUX_MSGTYPE_REQUEST:
         case FLUX_MSGTYPE_EVENT:
-            if (flux_msg_push_route (msg, p->uuid_str) < 0)
+            if (flux_msg_route_push (msg, p->uuid_str) < 0)
                 goto error;
             break;
         default:
@@ -312,7 +312,7 @@ int module_sendmsg (module_t *p, const flux_msg_t *msg)
         case FLUX_MSGTYPE_REQUEST: { /* simulate DEALER socket */
             if (!(cpy = flux_msg_copy (msg, true)))
                 goto done;
-            if (flux_msg_push_route (cpy, p->modhash->uuid_str) < 0)
+            if (flux_msg_route_push (cpy, p->modhash->uuid_str) < 0)
                 goto done;
             if (flux_msg_sendzsock (p->sock, cpy) < 0)
                 goto done;
@@ -321,7 +321,7 @@ int module_sendmsg (module_t *p, const flux_msg_t *msg)
         case FLUX_MSGTYPE_RESPONSE: { /* simulate ROUTER socket */
             if (!(cpy = flux_msg_copy (msg, true)))
                 goto done;
-            if (flux_msg_delete_route_last (cpy) < 0)
+            if (flux_msg_route_delete_last (cpy) < 0)
                 goto done;
             if (flux_msg_sendzsock (p->sock, cpy) < 0)
                 goto done;
@@ -345,7 +345,7 @@ int module_response_sendmsg (modhash_t *mh, const flux_msg_t *msg)
 
     if (!msg)
         return 0;
-    if (!(uuid = flux_msg_get_route_last (msg))) {
+    if (!(uuid = flux_msg_route_last (msg))) {
         errno = EPROTO;
         return -1;
     }

--- a/src/broker/module.c
+++ b/src/broker/module.c
@@ -259,7 +259,7 @@ flux_msg_t *module_recvmsg (module_t *p)
         goto error;
     switch (type) {
         case FLUX_MSGTYPE_RESPONSE:
-            if (flux_msg_pop_route (msg, NULL) < 0)
+            if (flux_msg_delete_route_last (msg) < 0)
                 goto error;
             break;
         case FLUX_MSGTYPE_REQUEST:
@@ -321,7 +321,7 @@ int module_sendmsg (module_t *p, const flux_msg_t *msg)
         case FLUX_MSGTYPE_RESPONSE: { /* simulate ROUTER socket */
             if (!(cpy = flux_msg_copy (msg, true)))
                 goto done;
-            if (flux_msg_pop_route (cpy, NULL) < 0)
+            if (flux_msg_delete_route_last (cpy) < 0)
                 goto done;
             if (flux_msg_sendzsock (p->sock, cpy) < 0)
                 goto done;

--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -359,8 +359,7 @@ static int overlay_keepalive_parent (struct overlay *ov, int status)
     if (ov->parent.zsock) {
         if (!(msg = flux_keepalive_encode (0, status)))
             return -1;
-        if (flux_msg_enable_route (msg) < 0)
-            goto error;
+        flux_msg_enable_route (msg);
         if (overlay_sendmsg_parent (ov, msg) < 0)
             goto error;
         flux_msg_destroy (msg);
@@ -454,8 +453,7 @@ int overlay_sendmsg (struct overlay *ov,
                 if (!(flags & FLUX_MSGFLAG_ROUTE)) {
                     if (!(cpy = flux_msg_copy (msg, true)))
                         goto error;
-                    if (flux_msg_enable_route (cpy) < 0)
-                        goto error;
+                    flux_msg_enable_route (cpy);
                     msg = cpy;
                 }
                 if (overlay_sendmsg_parent (ov, msg) < 0)
@@ -513,8 +511,7 @@ static int overlay_mcast_child_one (struct overlay *ov,
 
     if (!(cpy = flux_msg_copy (msg, true)))
         return -1;
-    if (flux_msg_enable_route (cpy) < 0)
-        goto done;
+    flux_msg_enable_route (cpy);
     if (flux_msg_push_route (cpy, child->uuid) < 0)
         goto done;
     if (overlay_sendmsg_child (ov, cpy) < 0)
@@ -642,11 +639,8 @@ static void parent_cb (flux_reactor_t *r, flux_watcher_t *w,
         hello_response_handler (ov, msg);
         goto handled;
     }
-    if (type == FLUX_MSGTYPE_EVENT) {
-        if (flux_msg_clear_route (msg) < 0) {
-            goto drop;
-        }
-    }
+    if (type == FLUX_MSGTYPE_EVENT)
+        flux_msg_clear_route (msg);
     ov->recv_cb (msg, OVERLAY_UPSTREAM, ov->recv_arg);
 handled:
     flux_msg_destroy (msg);

--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -640,7 +640,7 @@ static void parent_cb (flux_reactor_t *r, flux_watcher_t *w,
         goto handled;
     }
     if (type == FLUX_MSGTYPE_EVENT)
-        flux_msg_clear_route (msg);
+        flux_msg_disable_route (msg);
     ov->recv_cb (msg, OVERLAY_UPSTREAM, ov->recv_arg);
 handled:
     flux_msg_destroy (msg);

--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -600,8 +600,8 @@ static void child_cb (flux_reactor_t *r, flux_watcher_t *w,
              * were a request, but the effect we want for responses is to have
              * a route popped off at each router hop.
              */
-            (void)flux_msg_pop_route (msg, NULL); // child id from ROUTER
-            (void)flux_msg_pop_route (msg, NULL); // my id
+            (void)flux_msg_delete_route_last (msg); // child id from ROUTER
+            (void)flux_msg_delete_route_last (msg); // my id
             break;
         case FLUX_MSGTYPE_EVENT:
             break;

--- a/src/broker/ping.c
+++ b/src/broker/ping.c
@@ -76,7 +76,7 @@ static void ping_request_cb (flux_t *h, flux_msg_handler_t *mh,
      * That identity is passed in to ping_initialize() as the uuid.
      * Tack it onto the route string.
      */
-    if (!(route_str = flux_msg_get_route_string (msg)))
+    if (!(route_str = flux_msg_route_string (msg)))
         goto error;
     new_size = strlen (route_str) + strlen (p->uuid) + 2;
     if (!(new_str = realloc (route_str, new_size)))
@@ -120,7 +120,7 @@ int ping_initialize (flux_t *h, const char *service, const char *uuid)
         goto error;
     /* The uuid is tacked onto the route string constructed for
      * ping responses.  Truncate the uuid to 8 chars to match policy
-     * of flux_msg_get_route_string().
+     * of flux_msg_route_string().
      */
     if (!(p->uuid = strdup (uuid)))
         goto error;

--- a/src/broker/publisher.c
+++ b/src/broker/publisher.c
@@ -131,8 +131,7 @@ int publisher_send (struct publisher *pub, const flux_msg_t *msg)
 
     if (!(cpy = flux_msg_copy (msg, true)))
         return -1;
-    if (flux_msg_clear_route (cpy) < 0)
-        goto error;
+    flux_msg_clear_route (cpy);
     if (flux_msg_set_seq (cpy, ++pub->seq) < 0)
         goto error_restore_seq;
     send_event (pub, cpy);
@@ -140,7 +139,6 @@ int publisher_send (struct publisher *pub, const flux_msg_t *msg)
     return 0;
 error_restore_seq:
     pub->seq--;
-error:
     flux_msg_destroy (cpy);
     return -1;
 }

--- a/src/broker/publisher.c
+++ b/src/broker/publisher.c
@@ -131,7 +131,7 @@ int publisher_send (struct publisher *pub, const flux_msg_t *msg)
 
     if (!(cpy = flux_msg_copy (msg, true)))
         return -1;
-    flux_msg_clear_route (cpy);
+    flux_msg_disable_route (cpy);
     if (flux_msg_set_seq (cpy, ++pub->seq) < 0)
         goto error_restore_seq;
     send_event (pub, cpy);

--- a/src/broker/publisher.c
+++ b/src/broker/publisher.c
@@ -131,7 +131,7 @@ int publisher_send (struct publisher *pub, const flux_msg_t *msg)
 
     if (!(cpy = flux_msg_copy (msg, true)))
         return -1;
-    flux_msg_disable_route (cpy);
+    flux_msg_route_disable (cpy);
     if (flux_msg_set_seq (cpy, ++pub->seq) < 0)
         goto error_restore_seq;
     send_event (pub, cpy);

--- a/src/broker/test/overlay.c
+++ b/src/broker/test/overlay.c
@@ -309,7 +309,7 @@ void trio (flux_t *h)
         "%s: request was received by overlay", ctx[0]->name);
     ok (flux_msg_get_topic (rmsg, &topic) == 0 && !strcmp (topic, "meep"),
         "%s: received message has expected topic", ctx[0]->name);
-    ok ((sender = flux_msg_get_route_first (rmsg)) != NULL
+    ok ((sender = flux_msg_route_first (rmsg)) != NULL
         && !strcmp (sender, ctx[1]->uuid),
         "%s: received message sender is rank 1", ctx[0]->name);
 
@@ -330,7 +330,7 @@ void trio (flux_t *h)
         "%s: request was received by overlay", ctx[1]->name);
     ok (flux_msg_get_topic (rmsg, &topic) == 0 && !strcmp (topic, "errr"),
         "%s: request has expected topic", ctx[1]->name);
-    ok ((sender = flux_msg_get_route_first (rmsg)) != NULL
+    ok ((sender = flux_msg_route_first (rmsg)) != NULL
         && !strcmp (sender, ctx[0]->uuid),
         "%s: request sender is rank 0", ctx[1]->name);
 
@@ -338,8 +338,8 @@ void trio (flux_t *h)
      */
     if (!(msg = flux_response_encode ("m000", NULL)))
         BAIL_OUT ("flux_response_encode failed");
-    if (flux_msg_push_route (msg, ctx[0]->uuid) < 0)
-        BAIL_OUT ("flux_msg_push_route failed");
+    if (flux_msg_route_push (msg, ctx[0]->uuid) < 0)
+        BAIL_OUT ("flux_msg_route_push failed");
     ok (overlay_sendmsg (ctx[1]->ov, msg, OVERLAY_ANY) == 0,
         "%s: overlay_sendmsg response where=ANY works", ctx[1]->name);
     flux_msg_decref (msg);
@@ -349,7 +349,7 @@ void trio (flux_t *h)
         "%s: response was received by overlay", ctx[0]->name);
     ok (flux_msg_get_topic (rmsg, &topic) == 0 && !strcmp (topic, "m000"),
         "%s: received message has expected topic", ctx[0]->name);
-    ok (flux_msg_get_route_count (rmsg) == 0,
+    ok (flux_msg_route_count (rmsg) == 0,
         "%s: received message has no routes", ctx[0]->name);
 
     /* Event 1->0
@@ -371,8 +371,8 @@ void trio (flux_t *h)
      */
     if (!(msg = flux_response_encode ("moop", NULL)))
         BAIL_OUT ("flux_response_encode failed");
-    if (flux_msg_push_route (msg, ctx[1]->uuid) < 0)
-        BAIL_OUT ("flux_msg_push_route failed");
+    if (flux_msg_route_push (msg, ctx[1]->uuid) < 0)
+        BAIL_OUT ("flux_msg_route_push failed");
     ok (overlay_sendmsg (ctx[0]->ov, msg, OVERLAY_ANY) == 0,
         "%s: overlay_sendmsg response where=ANY works", ctx[0]->name);
     flux_msg_decref (msg);
@@ -382,7 +382,7 @@ void trio (flux_t *h)
         "%s: response was received by overlay", ctx[1]->name);
     ok (flux_msg_get_topic (rmsg, &topic) == 0 && !strcmp (topic, "moop"),
         "%s: response has expected topic", ctx[1]->name);
-    ok (flux_msg_get_route_count (rmsg) == 0,
+    ok (flux_msg_route_count (rmsg) == 0,
         "%s: response has no routes", ctx[1]->name);
 
     /* Event 0->1

--- a/src/broker/test/overlay.c
+++ b/src/broker/test/overlay.c
@@ -256,7 +256,7 @@ void trio (flux_t *h)
     zsock_t *zsock_none;
     zsock_t *zsock_curve;
     zcert_t *cert;
-    char *sender;
+    const char *sender;
 
     ctx[0] = ctx_create (h, "trio", size, 0, recv_cb);
 
@@ -309,11 +309,9 @@ void trio (flux_t *h)
         "%s: request was received by overlay", ctx[0]->name);
     ok (flux_msg_get_topic (rmsg, &topic) == 0 && !strcmp (topic, "meep"),
         "%s: received message has expected topic", ctx[0]->name);
-    sender = NULL;
-    ok (flux_msg_get_route_first (rmsg, &sender) == 0
-        && sender != NULL && !strcmp (sender, ctx[1]->uuid),
+    ok ((sender = flux_msg_get_route_first (rmsg)) != NULL
+        && !strcmp (sender, ctx[1]->uuid),
         "%s: received message sender is rank 1", ctx[0]->name);
-    free (sender);
 
     /* Send request 0->1
      * Side effect: during recvmsg_timeout(), reactor allows hello response
@@ -332,11 +330,9 @@ void trio (flux_t *h)
         "%s: request was received by overlay", ctx[1]->name);
     ok (flux_msg_get_topic (rmsg, &topic) == 0 && !strcmp (topic, "errr"),
         "%s: request has expected topic", ctx[1]->name);
-    sender = NULL;
-    ok (flux_msg_get_route_first (rmsg, &sender) == 0
-        && sender != NULL && !strcmp (sender, ctx[0]->uuid),
+    ok ((sender = flux_msg_get_route_first (rmsg)) != NULL
+        && !strcmp (sender, ctx[0]->uuid),
         "%s: request sender is rank 0", ctx[1]->name);
-    free (sender);
 
     /* Response 1->0
      */

--- a/src/cmd/flux-start.c
+++ b/src/cmd/flux-start.c
@@ -860,14 +860,12 @@ void disconnect_cb (flux_t *h,
                     const flux_msg_t *msg,
                     void *arg)
 {
-    char *uuid = NULL;
+    const char *uuid;
 
-    if (flux_msg_get_route_first (msg, &uuid) < 0)
-        goto done;
+    if (!(uuid = flux_msg_get_route_first (msg)))
+        return;
     if (ctx.verbose >= 1)
         log_msg ("disconnect from %.5s", uuid);
-done:
-    free (uuid);
 }
 
 const struct flux_msg_handler_spec htab[] = {

--- a/src/cmd/flux-start.c
+++ b/src/cmd/flux-start.c
@@ -862,7 +862,7 @@ void disconnect_cb (flux_t *h,
 {
     const char *uuid;
 
-    if (!(uuid = flux_msg_get_route_first (msg)))
+    if (!(uuid = flux_msg_route_first (msg)))
         return;
     if (ctx.verbose >= 1)
         log_msg ("disconnect from %.5s", uuid);

--- a/src/common/libflux/disconnect.c
+++ b/src/common/libflux/disconnect.c
@@ -21,7 +21,7 @@ bool flux_disconnect_match (const flux_msg_t *msg1, const flux_msg_t *msg2)
     struct flux_msg_cred cred;
     uint32_t userid;
 
-    if (!flux_msg_match_route_first (msg1, msg2))
+    if (!flux_msg_route_match_first (msg1, msg2))
         return false;
 
     if (flux_msg_get_cred (msg1, &cred) < 0)

--- a/src/common/libflux/event.c
+++ b/src/common/libflux/event.c
@@ -135,7 +135,7 @@ static flux_msg_t *flux_event_create (const char *topic)
         goto error;
     if (flux_msg_set_topic (msg, topic) < 0)
         goto error;
-    flux_msg_enable_route (msg);
+    flux_msg_route_enable (msg);
     return msg;
 error:
     flux_msg_destroy (msg);

--- a/src/common/libflux/event.c
+++ b/src/common/libflux/event.c
@@ -135,8 +135,7 @@ static flux_msg_t *flux_event_create (const char *topic)
         goto error;
     if (flux_msg_set_topic (msg, topic) < 0)
         goto error;
-    if (flux_msg_enable_route (msg) < 0)
-        goto error;
+    flux_msg_enable_route (msg);
     return msg;
 error:
     flux_msg_destroy (msg);

--- a/src/common/libflux/handle.c
+++ b/src/common/libflux/handle.c
@@ -703,7 +703,7 @@ flux_msg_t *flux_recv (flux_t *h, struct flux_match match, int flags)
     cali_begin_string (h->prof.msg_match_glob,
                        match.topic_glob ? match.topic_glob : "NONE");
     const char *sender;
-    sender = flux_msg_get_route_first (msg);
+    sender = flux_msg_route_first (msg);
     if (sender)
         cali_begin_string (h->prof.msg_sender, sender);
     profiling_msg_snapshot (h, msg, flags, "recv");

--- a/src/common/libflux/handle.c
+++ b/src/common/libflux/handle.c
@@ -702,8 +702,8 @@ flux_msg_t *flux_recv (flux_t *h, struct flux_match match, int flags)
     cali_begin_int (h->prof.msg_match_tag, match.matchtag);
     cali_begin_string (h->prof.msg_match_glob,
                        match.topic_glob ? match.topic_glob : "NONE");
-    char *sender = NULL;
-    flux_msg_get_route_first (msg, &sender);
+    const char *sender;
+    sender = flux_msg_get_route_first (msg);
     if (sender)
         cali_begin_string (h->prof.msg_sender, sender);
     profiling_msg_snapshot (h, msg, flags, "recv");
@@ -712,8 +712,6 @@ flux_msg_t *flux_recv (flux_t *h, struct flux_match match, int flags)
     cali_end (h->prof.msg_match_type);
     cali_end (h->prof.msg_match_tag);
     cali_end (h->prof.msg_match_glob);
-
-    free (sender);
 #endif
     return msg;
 fatal:

--- a/src/common/libflux/message.c
+++ b/src/common/libflux/message.c
@@ -929,6 +929,14 @@ void flux_msg_enable_route (flux_msg_t *msg)
     (void) flux_msg_set_flags (msg, msg->flags | FLUX_MSGFLAG_ROUTE);
 }
 
+void flux_msg_disable_route (flux_msg_t *msg)
+{
+    if (!msg || (!(msg->flags & FLUX_MSGFLAG_ROUTE)))
+        return;
+    flux_msg_clear_route (msg);
+    (void) flux_msg_set_flags (msg, msg->flags & ~(uint8_t)FLUX_MSGFLAG_ROUTE);
+}
+
 void flux_msg_clear_route (flux_msg_t *msg)
 {
     struct route_id *r;
@@ -938,7 +946,6 @@ void flux_msg_clear_route (flux_msg_t *msg)
         route_id_destroy (r);
     list_head_init (&msg->routes);
     msg->routes_len = 0;
-    (void) flux_msg_set_flags (msg, msg->flags & ~(uint8_t)FLUX_MSGFLAG_ROUTE);
 }
 
 int flux_msg_push_route (flux_msg_t *msg, const char *id)

--- a/src/common/libflux/message.c
+++ b/src/common/libflux/message.c
@@ -199,7 +199,7 @@ void flux_msg_destroy (flux_msg_t *msg)
 {
     if (msg && --msg->refcount == 0) {
         int saved_errno = errno;
-        (void) flux_msg_clear_route (msg);
+        flux_msg_clear_route (msg);
         free (msg->topic);
         free (msg->payload);
         json_decref (msg->json);
@@ -922,31 +922,23 @@ bool flux_msg_cmp (const flux_msg_t *msg, struct flux_match match)
     return true;
 }
 
-int flux_msg_enable_route (flux_msg_t *msg)
+void flux_msg_enable_route (flux_msg_t *msg)
 {
-    if (!msg) {
-        errno = EINVAL;
-        return -1;
-    }
-    if ((msg->flags & FLUX_MSGFLAG_ROUTE))
-        return 0;
-    return flux_msg_set_flags (msg, msg->flags | FLUX_MSGFLAG_ROUTE);
+    if (!msg || (msg->flags & FLUX_MSGFLAG_ROUTE))
+        return;
+    (void) flux_msg_set_flags (msg, msg->flags | FLUX_MSGFLAG_ROUTE);
 }
 
-int flux_msg_clear_route (flux_msg_t *msg)
+void flux_msg_clear_route (flux_msg_t *msg)
 {
     struct route_id *r;
-    if (!msg) {
-        errno = EINVAL;
-        return -1;
-    }
-    if (!(msg->flags & FLUX_MSGFLAG_ROUTE))
-        return 0;
+    if (!msg || (!(msg->flags & FLUX_MSGFLAG_ROUTE)))
+        return;
     while ((r = list_pop (&msg->routes, struct route_id, route_id_node)))
         route_id_destroy (r);
     list_head_init (&msg->routes);
     msg->routes_len = 0;
-    return flux_msg_set_flags (msg, msg->flags & ~(uint8_t)FLUX_MSGFLAG_ROUTE);
+    (void) flux_msg_set_flags (msg, msg->flags & ~(uint8_t)FLUX_MSGFLAG_ROUTE);
 }
 
 int flux_msg_push_route (flux_msg_t *msg, const char *id)

--- a/src/common/libflux/message.c
+++ b/src/common/libflux/message.c
@@ -1002,6 +1002,24 @@ error:
     return rv;
 }
 
+int flux_msg_delete_route_last (flux_msg_t *msg)
+{
+    struct route_id *r;
+    if (!msg) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (!(msg->flags & FLUX_MSGFLAG_ROUTE)) {
+        errno = EPROTO;
+        return -1;
+    }
+    if ((r = list_pop (&msg->routes, struct route_id, route_id_node))) {
+        route_id_destroy (r);
+        msg->routes_len--;
+    }
+    return 0;
+}
+
 /* replaces flux_msg_nexthop */
 const char *flux_msg_get_route_last (const flux_msg_t *msg)
 {

--- a/src/common/libflux/message.c
+++ b/src/common/libflux/message.c
@@ -967,41 +967,6 @@ int flux_msg_push_route (flux_msg_t *msg, const char *id)
     return 0;
 }
 
-int flux_msg_pop_route (flux_msg_t *msg, char **id)
-{
-    struct route_id *r;
-    int rv = -1;
-
-    /* do not check 'id' for NULL, a "pop" is acceptable w/o returning
-     * data to the user.  Caller may wish to only "pop" and not look
-     * at the data.
-     */
-    if (!msg) {
-        errno = EINVAL;
-        return -1;
-    }
-    if (!(msg->flags & FLUX_MSGFLAG_ROUTE)) {
-        errno = EPROTO;
-        return -1;
-    }
-    if (list_empty (&msg->routes)) {
-        if (id)
-            (*id) = NULL;
-        return 0;
-    }
-    r = list_pop (&msg->routes, struct route_id, route_id_node);
-    assert (r);
-    if (id) {
-        if (!((*id) = strdup (r->id)))
-            goto error;
-    }
-    rv = 0;
-error:
-    route_id_destroy (r);
-    msg->routes_len--;
-    return rv;
-}
-
 int flux_msg_delete_route_last (flux_msg_t *msg)
 {
     struct route_id *r;

--- a/src/common/libflux/message.h
+++ b/src/common/libflux/message.h
@@ -310,63 +310,63 @@ const char *flux_msg_typestr (int type);
 /* Enable routes on a message by setting FLUX_MSGFLAG_ROUTE.  This
  * function is a no-op if the flag is already set.
  */
-void flux_msg_enable_route (flux_msg_t *msg);
+void flux_msg_route_enable (flux_msg_t *msg);
 
 /* Disable routes on a message by clearing the FLUX_MSGFLAG_ROUTE
  * flag.  In addition, clear all presently stored routes.  This
  * function is a no-op if the flag is already set.
  */
-void flux_msg_disable_route (flux_msg_t *msg);
+void flux_msg_route_disable (flux_msg_t *msg);
 
 /* Clear all routes stored in a message.  This function is a no-op if
  * routes are not enabled.
  */
-void flux_msg_clear_route (flux_msg_t *msg);
+void flux_msg_route_clear (flux_msg_t *msg);
 
 /* Push a route frame onto the message (mimic what dealer socket does).
  * 'id' is copied internally.
  * Returns 0 on success, -1 with errno set (e.g. EINVAL) on failure.
  */
-int flux_msg_push_route (flux_msg_t *msg, const char *id);
+int flux_msg_route_push (flux_msg_t *msg, const char *id);
 
 /* Delete last route frame off the message.  Effectively performs the
- * "opposite" of flux_msg_push_route().
+ * "opposite" of flux_msg_route_push().
  *
  * Returns 0 on success, -1 with errno set (e.g. EPROTO) on failure.
  */
-int flux_msg_delete_route_last (flux_msg_t *msg);
+int flux_msg_route_delete_last (flux_msg_t *msg);
 
 /* Return the first route (e.g. first pushed route) or NULL if there
  * are no routes.
  * For requests, this is the sender; for responses, this is the recipient.
  * Returns route id on success, NULL for no route or error.
  */
-const char *flux_msg_get_route_first (const flux_msg_t *msg);
+const char *flux_msg_route_first (const flux_msg_t *msg);
 
 /* Return the last route (e.g. most recent pushed route) or NULL if there
  * are no routes.
  * For requests, this is the last hop; for responses: this is the next hop.
  * Returns route id on success, NULL for no route or error.
  */
-const char *flux_msg_get_route_last (const flux_msg_t *msg);
+const char *flux_msg_route_last (const flux_msg_t *msg);
 
 /* Return the number of route frames in the message.
  * It is an EPROTO error if there is no route stack.
  * Returns 0 on success, -1 with errno set (e.g. EPROTO) on failure.
  */
-int flux_msg_get_route_count (const flux_msg_t *msg);
+int flux_msg_route_count (const flux_msg_t *msg);
 
 /* Return a string representing the route stack in message.
  * Return NULL if routes are not enabled; empty string if
  * the route stack contains no route frames).
  * Caller must free the returned string.
  */
-char *flux_msg_get_route_string (const flux_msg_t *msg);
+char *flux_msg_route_string (const flux_msg_t *msg);
 
 /* Return true if messages have the same first routing frame.
  * (For requests, the sender)
  */
-bool flux_msg_match_route_first (const flux_msg_t *msg1,
+bool flux_msg_route_match_first (const flux_msg_t *msg1,
                                  const flux_msg_t *msg2);
 
 #ifdef __cplusplus

--- a/src/common/libflux/message.h
+++ b/src/common/libflux/message.h
@@ -331,6 +331,13 @@ int flux_msg_push_route (flux_msg_t *msg, const char *id);
  */
 int flux_msg_pop_route (flux_msg_t *msg, char **id);
 
+/* Delete last route frame off the message.  Similar to
+ * flux_msg_pop_route(), but avoids the extra memory allocation/free.
+ *
+ * Returns 0 on success, -1 with errno set (e.g. EPROTO) on failure.
+ */
+int flux_msg_delete_route_last (flux_msg_t *msg);
+
 /* Return the first route (e.g. first pushed route) or NULL if there
  * are no routes.
  * For requests, this is the sender; for responses, this is the recipient.

--- a/src/common/libflux/message.h
+++ b/src/common/libflux/message.h
@@ -325,14 +325,8 @@ int flux_msg_clear_route (flux_msg_t *msg);
  */
 int flux_msg_push_route (flux_msg_t *msg, const char *id);
 
-/* Pop a route frame off the message and return identity (or NULL) in 'id'.
- * Caller must free 'id'.
- * Returns 0 on success, -1 with errno set (e.g. EPROTO) on failure.
- */
-int flux_msg_pop_route (flux_msg_t *msg, char **id);
-
-/* Delete last route frame off the message.  Similar to
- * flux_msg_pop_route(), but avoids the extra memory allocation/free.
+/* Delete last route frame off the message.  Effectively performs the
+ * "opposite" of flux_msg_push_route().
  *
  * Returns 0 on success, -1 with errno set (e.g. EPROTO) on failure.
  */

--- a/src/common/libflux/message.h
+++ b/src/common/libflux/message.h
@@ -307,13 +307,19 @@ const char *flux_msg_typestr (int type);
  * routing.
  */
 
-/* Prepare a message for routing by setting FLUX_MSGFLAG_ROUTE.  This
+/* Enable routes on a message by setting FLUX_MSGFLAG_ROUTE.  This
  * function is a no-op if the flag is already set.
  */
 void flux_msg_enable_route (flux_msg_t *msg);
 
-/* Clear routes from msg and clear FLUX_MSGFLAG_ROUTE flag.  This
- * function is a no-op if the flag is already clear.
+/* Disable routes on a message by clearing the FLUX_MSGFLAG_ROUTE
+ * flag.  In addition, clear all presently stored routes.  This
+ * function is a no-op if the flag is already set.
+ */
+void flux_msg_disable_route (flux_msg_t *msg);
+
+/* Clear all routes stored in a message.  This function is a no-op if
+ * routes are not enabled.
  */
 void flux_msg_clear_route (flux_msg_t *msg);
 

--- a/src/common/libflux/message.h
+++ b/src/common/libflux/message.h
@@ -309,15 +309,13 @@ const char *flux_msg_typestr (int type);
 
 /* Prepare a message for routing by setting FLUX_MSGFLAG_ROUTE.  This
  * function is a no-op if the flag is already set.
- * Returns 0 on success, -1 with errno set on failure.
  */
-int flux_msg_enable_route (flux_msg_t *msg);
+void flux_msg_enable_route (flux_msg_t *msg);
 
 /* Clear routes from msg and clear FLUX_MSGFLAG_ROUTE flag.  This
  * function is a no-op if the flag is already clear.
- * Returns 0 on success, -1 with errno set on failure.
  */
-int flux_msg_clear_route (flux_msg_t *msg);
+void flux_msg_clear_route (flux_msg_t *msg);
 
 /* Push a route frame onto the message (mimic what dealer socket does).
  * 'id' is copied internally.

--- a/src/common/libflux/message.h
+++ b/src/common/libflux/message.h
@@ -331,19 +331,19 @@ int flux_msg_push_route (flux_msg_t *msg, const char *id);
  */
 int flux_msg_pop_route (flux_msg_t *msg, char **id);
 
-/* Copy the first route (e.g. first pushed route) contents (or NULL)
- * to 'id'.  Caller must free 'id'.
+/* Return the first route (e.g. first pushed route) or NULL if there
+ * are no routes.
  * For requests, this is the sender; for responses, this is the recipient.
- * Returns 0 on success, -1 with errno set (e.g. EPROTO) on failure.
+ * Returns route id on success, NULL for no route or error.
  */
-int flux_msg_get_route_first (const flux_msg_t *msg, char **id);
+const char *flux_msg_get_route_first (const flux_msg_t *msg);
 
-/* Copy the last route (e.g. most recent pushed route) contents (or NULL)
- * to 'id'.  Caller must free 'id'.
+/* Return the last route (e.g. most recent pushed route) or NULL if there
+ * are no routes.
  * For requests, this is the last hop; for responses: this is the next hop.
- * Returns 0 on success, -1 with errno set (e.g. EPROTO) on failure.
+ * Returns route id on success, NULL for no route or error.
  */
-int flux_msg_get_route_last (const flux_msg_t *msg, char **id);
+const char *flux_msg_get_route_last (const flux_msg_t *msg);
 
 /* Return the number of route frames in the message.
  * It is an EPROTO error if there is no route stack.

--- a/src/common/libflux/msg_handler.c
+++ b/src/common/libflux/msg_handler.c
@@ -361,7 +361,7 @@ static bool dispatch_message (struct dispatch *d,
     /* rpc response w/matchtag */
     if (type == FLUX_MSGTYPE_RESPONSE) {
         uint32_t matchtag;
-        if (flux_msg_get_route_count (msg) == 0
+        if (flux_msg_route_count (msg) == 0
             && flux_msg_get_matchtag (msg, &matchtag) == 0
             && matchtag != FLUX_MATCHTAG_NONE
             && (mh = zhashx_lookup (d->handlers_rpc, &matchtag))
@@ -409,7 +409,7 @@ static void handle_late_response (struct dispatch *d, const flux_msg_t *msg)
 
     if (flux_msg_get_matchtag (msg, &matchtag) < 0)
         return;
-    if (flux_msg_get_route_count (msg) != 0)
+    if (flux_msg_route_count (msg) != 0)
         return; // foreign matchtag domain (or error getting count)
     if (matchtag == FLUX_MATCHTAG_NONE)
         return; // no matchtag was allocated

--- a/src/common/libflux/request.c
+++ b/src/common/libflux/request.c
@@ -133,7 +133,7 @@ static flux_msg_t *request_encode (const char *topic)
         goto error;
     if (flux_msg_set_topic (msg, topic) < 0)
         goto error;
-    flux_msg_enable_route (msg);
+    flux_msg_route_enable (msg);
     return msg;
 error:
     flux_msg_destroy (msg);

--- a/src/common/libflux/request.c
+++ b/src/common/libflux/request.c
@@ -133,8 +133,7 @@ static flux_msg_t *request_encode (const char *topic)
         goto error;
     if (flux_msg_set_topic (msg, topic) < 0)
         goto error;
-    if (flux_msg_enable_route (msg) < 0)
-        goto error;
+    flux_msg_enable_route (msg);
     return msg;
 error:
     flux_msg_destroy (msg);

--- a/src/common/libflux/response.c
+++ b/src/common/libflux/response.c
@@ -139,7 +139,7 @@ static flux_msg_t *response_encode (const char *topic, int errnum)
         goto error;
     if (flux_msg_set_topic (msg, topic) < 0)
         goto error;
-    flux_msg_enable_route (msg);
+    flux_msg_route_enable (msg);
     if (flux_msg_set_errnum (msg, errnum) < 0)
         goto error;
     return msg;

--- a/src/common/libflux/response.c
+++ b/src/common/libflux/response.c
@@ -139,8 +139,7 @@ static flux_msg_t *response_encode (const char *topic, int errnum)
         goto error;
     if (flux_msg_set_topic (msg, topic) < 0)
         goto error;
-    if (flux_msg_enable_route (msg) < 0)
-        goto error;
+    flux_msg_enable_route (msg);
     if (flux_msg_set_errnum (msg, errnum) < 0)
         goto error;
     return msg;

--- a/src/common/libflux/test/disconnect.c
+++ b/src/common/libflux/test/disconnect.c
@@ -29,7 +29,7 @@ flux_msg_t *create_request (int sender,
     if (!(msg = flux_request_encode ("foo", NULL)))
         return NULL;
     snprintf (id, sizeof (id), "%d", sender);
-    if (flux_msg_push_route (msg, id) < 0)
+    if (flux_msg_route_push (msg, id) < 0)
         return NULL;
     if (flux_msg_set_rolemask (msg, rolemask) < 0)
         return NULL;
@@ -51,7 +51,7 @@ flux_msg_t *create_cancel (int sender,
     if (!(msg = flux_request_encode ("foo", NULL)))
         return NULL;
     snprintf (id, sizeof (id), "%d", sender);
-    if (flux_msg_push_route (msg, id) < 0)
+    if (flux_msg_route_push (msg, id) < 0)
         return NULL;
     if (flux_msg_set_rolemask (msg, rolemask) < 0)
         return NULL;

--- a/src/common/libflux/test/dispatch.c
+++ b/src/common/libflux/test/dispatch.c
@@ -114,8 +114,8 @@ void test_fastpath (flux_t *h)
     ok (cb_called == 1,
         "message handler was called after being started");
 
-    ok (flux_msg_enable_route (msg) == 0
-        && flux_msg_push_route (msg, "myuuid") == 0,
+    flux_msg_enable_route (msg);
+    ok (flux_msg_push_route (msg, "myuuid") == 0,
         "added route to message");
     ok (flux_send (h, msg, 0) == 0,
         "sent response message on loop connector");
@@ -351,8 +351,9 @@ void test_response_with_routes (flux_t *h)
         "foo.bar RPC response created");
     if (flux_msg_set_matchtag (msg, mtag) < 0)
         BAIL_OUT ("flux_msg_set_matchtag failed");
-    if (flux_msg_enable_route (msg) < 0 || flux_msg_push_route (msg, "9") < 0)
-        BAIL_OUT ("flux_msg_enable/push_route failed");
+    flux_msg_enable_route (msg);
+    if (flux_msg_push_route (msg, "9") < 0)
+        BAIL_OUT ("flux_msg_push_route failed");
 
     /* register RPC response handler */
     match.matchtag = mtag;

--- a/src/common/libflux/test/dispatch.c
+++ b/src/common/libflux/test/dispatch.c
@@ -114,8 +114,8 @@ void test_fastpath (flux_t *h)
     ok (cb_called == 1,
         "message handler was called after being started");
 
-    flux_msg_enable_route (msg);
-    ok (flux_msg_push_route (msg, "myuuid") == 0,
+    flux_msg_route_enable (msg);
+    ok (flux_msg_route_push (msg, "myuuid") == 0,
         "added route to message");
     ok (flux_send (h, msg, 0) == 0,
         "sent response message on loop connector");
@@ -351,9 +351,9 @@ void test_response_with_routes (flux_t *h)
         "foo.bar RPC response created");
     if (flux_msg_set_matchtag (msg, mtag) < 0)
         BAIL_OUT ("flux_msg_set_matchtag failed");
-    flux_msg_enable_route (msg);
-    if (flux_msg_push_route (msg, "9") < 0)
-        BAIL_OUT ("flux_msg_push_route failed");
+    flux_msg_route_enable (msg);
+    if (flux_msg_route_push (msg, "9") < 0)
+        BAIL_OUT ("flux_msg_route_push failed");
 
     /* register RPC response handler */
     match.matchtag = mtag;

--- a/src/common/libflux/test/message.c
+++ b/src/common/libflux/test/message.c
@@ -33,7 +33,6 @@ void check_cornercase (void)
     int type, errnum, status;
     uint32_t tag;
     uint8_t flags;
-    char *route;
     const char *topic;
     const void *payload;
     int payload_size;
@@ -272,28 +271,14 @@ void check_cornercase (void)
     errno = 0;
     ok (flux_msg_pop_route (msg, NULL) == -1 && errno == EPROTO,
         "flux_msg_pop_route returns -1 errno EPROTO on msg w/o routes enabled");
-    errno = 0;
-    ok (flux_msg_get_route_first (NULL, &route) == -1 && errno == EINVAL,
-        "flux_msg_get_route_first returns -1 errno EINVAL on msg = NULL");
-    errno = 0;
-    ok (flux_msg_get_route_first (msg, NULL) == -1 && errno == EINVAL,
-        "flux_msg_get_route_first returns -1 errno EINVAL on in-and-out "
-        "param = NULL");
-    errno = 0;
-    ok (flux_msg_get_route_first (msg, &route) == -1 && errno == EPROTO,
-        "flux_msg_get_route_first returns -1 errno EPROTO on msg "
-        "w/o routes enabled");
-    errno = 0;
-    ok (flux_msg_get_route_last (NULL, &route) == -1 && errno == EINVAL,
-        "flux_msg_get_route_last returns -1 errno EINVAL on msg = NULL");
-    errno = 0;
-    ok (flux_msg_get_route_last (msg, NULL) == -1 && errno == EINVAL,
-        "flux_msg_get_route_last returns -1 errno EINVAL on in-and-out "
-        "param = NULL");
-    errno = 0;
-    ok (flux_msg_get_route_last (msg, &route) == -1 && errno == EPROTO,
-        "flux_msg_get_route_last returns -1 errno EPROTO on msg "
-        "w/o routes enabled");
+    ok (flux_msg_get_route_first (NULL) == NULL,
+        "flux_msg_get_route_first returns NULL on msg = NULL");
+    ok (flux_msg_get_route_first (msg) == NULL,
+        "flux_msg_get_route_first returns NULL on msg w/o routes enabled");
+    ok (flux_msg_get_route_last (NULL) == NULL,
+        "flux_msg_get_route_last returns NULL on msg = NULL");
+    ok (flux_msg_get_route_last (msg) == NULL,
+        "flux_msg_get_route_last returns NULL on msg w/o routes enabled");
     errno = 0;
     ok ((flux_msg_get_route_count (NULL) == -1 && errno == EINVAL),
         "flux_msg_get_route_count returns -1 errno EINVAL on msg = NULL");
@@ -319,6 +304,7 @@ void check_cornercase (void)
 void check_routes (void)
 {
     flux_msg_t *msg;
+    const char *route;
     char *s;
 
     ok ((msg = flux_msg_create (FLUX_MSGTYPE_REQUEST)) != NULL
@@ -334,26 +320,24 @@ void check_routes (void)
     ok (flux_msg_pop_route (msg, &s) == 0 && s == NULL,
         "flux_msg_pop_route works and sets id to NULL on msg w/o routes");
 
-    ok (flux_msg_get_route_first (msg, &s) == 0 && s == NULL,
-        "flux_msg_get_route_first returns 0, id=NULL on msg w/o routes");
-    ok (flux_msg_get_route_last (msg, &s) == 0 && s == NULL,
-        "flux_msg_get_route_last returns 0, id=NULL on msg w/o routes");
+    ok ((route = flux_msg_get_route_first (msg)) == NULL,
+        "flux_msg_get_route_first returns NULL on msg w/o routes");
+    ok ((route = flux_msg_get_route_last (msg)) == NULL,
+        "flux_msg_get_route_last returns NULL on msg w/o routes");
     ok (flux_msg_push_route (msg, "sender") == 0 && flux_msg_frames (msg) == 3,
         "flux_msg_push_route works and adds a frame");
     ok ((flux_msg_get_route_count (msg) == 1),
         "flux_msg_get_route_count returns 1 on msg w/ id1");
 
-    ok (flux_msg_get_route_first (msg, &s) == 0 && s != NULL,
+    ok ((route = flux_msg_get_route_first (msg)) != NULL,
         "flux_msg_get_route_first works");
-    like (s, "sender",
+    like (route, "sender",
         "flux_msg_get_route_first returns id on msg w/ id1");
-    free (s);
 
-    ok (flux_msg_get_route_last (msg, &s) == 0 && s != NULL,
+    ok ((route = flux_msg_get_route_last (msg)) != NULL,
         "flux_msg_get_route_last works");
-    like (s, "sender",
+    like (route, "sender",
         "flux_msg_get_route_last returns id on msg w/ id1");
-    free (s);
 
     ok ((s = flux_msg_get_route_string (msg)) != NULL,
         "flux_msg_get_route_string works");
@@ -366,17 +350,15 @@ void check_routes (void)
     ok ((flux_msg_get_route_count (msg) == 2),
         "flux_msg_get_route_count returns 2 on msg w/ id1+id2");
 
-    ok (flux_msg_get_route_first (msg, &s) == 0 && s != NULL,
+    ok ((route = flux_msg_get_route_first (msg)) != NULL,
         "flux_msg_get_route_first works");
-    like (s, "sender",
+    like (route, "sender",
         "flux_msg_get_route_first returns id1 on msg w/ id1+id2");
-    free (s);
 
-    ok (flux_msg_get_route_last (msg, &s) == 0 && s != NULL,
+    ok ((route = flux_msg_get_route_last (msg)) != NULL,
         "flux_msg_get_route_last works");
-    like (s, "router",
+    like (route, "router",
         "flux_msg_get_route_last returns id2 on message with id1+id2");
-    free (s);
 
     ok ((s = flux_msg_get_route_string (msg)) != NULL,
         "flux_msg_get_route_string works");

--- a/src/common/libflux/test/message.c
+++ b/src/common/libflux/test/message.c
@@ -250,57 +250,57 @@ void check_cornercase (void)
     ok (flux_msg_get_matchtag (evt, &tag) < 0 && errno == EPROTO,
         "flux_msg_get_matchtag fails with EPROTO on msg != req/rsp type");
 
-    lives_ok ({flux_msg_enable_route (NULL);},
-        "flux_msg_enable_route msg=NULL doesnt crash");
-    lives_ok ({flux_msg_disable_route (NULL);},
-        "flux_msg_disable_route msg=NULL doesnt crash");
-    lives_ok ({flux_msg_clear_route (NULL);},
-        "flux_msg_clear_route msg=NULL doesnt crash");
+    lives_ok ({flux_msg_route_enable (NULL);},
+        "flux_msg_route_enable msg=NULL doesnt crash");
+    lives_ok ({flux_msg_route_disable (NULL);},
+        "flux_msg_route_disable msg=NULL doesnt crash");
+    lives_ok ({flux_msg_route_clear (NULL);},
+        "flux_msg_route_clear msg=NULL doesnt crash");
 
     errno = 0;
-    ok (flux_msg_push_route (NULL, "foo") == -1 && errno == EINVAL,
-        "flux_msg_push_route returns -1 errno EINVAL on msg = NULL");
+    ok (flux_msg_route_push (NULL, "foo") == -1 && errno == EINVAL,
+        "flux_msg_route_push returns -1 errno EINVAL on msg = NULL");
     errno = 0;
-    ok (flux_msg_push_route (msg, NULL) == -1 && errno == EINVAL,
-        "flux_msg_push_route returns -1 errno EINVAL on id = NULL");
+    ok (flux_msg_route_push (msg, NULL) == -1 && errno == EINVAL,
+        "flux_msg_route_push returns -1 errno EINVAL on id = NULL");
     errno = 0;
-    ok (flux_msg_push_route (msg, "foo") == -1 && errno == EPROTO,
-        "flux_msg_push_route returns -1 errno EPROTO on msg w/o routes enabled");
+    ok (flux_msg_route_push (msg, "foo") == -1 && errno == EPROTO,
+        "flux_msg_route_push returns -1 errno EPROTO on msg w/o routes enabled");
     errno = 0;
-    ok (flux_msg_delete_route_last (NULL) == -1 && errno == EINVAL,
-        "flux_msg_delete_route_last returns -1 errno EINVAL on id = NULL");
+    ok (flux_msg_route_delete_last (NULL) == -1 && errno == EINVAL,
+        "flux_msg_route_delete_last returns -1 errno EINVAL on id = NULL");
     errno = 0;
-    ok (flux_msg_delete_route_last (msg) == -1 && errno == EPROTO,
-        "flux_msg_delete_route_last returns -1 errno EPROTO on msg "
+    ok (flux_msg_route_delete_last (msg) == -1 && errno == EPROTO,
+        "flux_msg_route_delete_last returns -1 errno EPROTO on msg "
         "w/o routes enabled");
-    ok (flux_msg_get_route_first (NULL) == NULL,
-        "flux_msg_get_route_first returns NULL on msg = NULL");
-    ok (flux_msg_get_route_first (msg) == NULL,
-        "flux_msg_get_route_first returns NULL on msg w/o routes enabled");
-    ok (flux_msg_get_route_last (NULL) == NULL,
-        "flux_msg_get_route_last returns NULL on msg = NULL");
-    ok (flux_msg_get_route_last (msg) == NULL,
-        "flux_msg_get_route_last returns NULL on msg w/o routes enabled");
+    ok (flux_msg_route_first (NULL) == NULL,
+        "flux_msg_route_first returns NULL on msg = NULL");
+    ok (flux_msg_route_first (msg) == NULL,
+        "flux_msg_route_first returns NULL on msg w/o routes enabled");
+    ok (flux_msg_route_last (NULL) == NULL,
+        "flux_msg_route_last returns NULL on msg = NULL");
+    ok (flux_msg_route_last (msg) == NULL,
+        "flux_msg_route_last returns NULL on msg w/o routes enabled");
     errno = 0;
-    ok ((flux_msg_get_route_count (NULL) == -1 && errno == EINVAL),
-        "flux_msg_get_route_count returns -1 errno EINVAL on msg = NULL");
+    ok ((flux_msg_route_count (NULL) == -1 && errno == EINVAL),
+        "flux_msg_route_count returns -1 errno EINVAL on msg = NULL");
     errno = 0;
-    ok ((flux_msg_get_route_count (msg) == -1 && errno == EPROTO),
-        "flux_msg_get_route_count returns -1 errno EPROTO on msg "
+    ok ((flux_msg_route_count (msg) == -1 && errno == EPROTO),
+        "flux_msg_route_count returns -1 errno EPROTO on msg "
         "w/o routes enabled");
     errno = 0;
-    ok ((flux_msg_get_route_string (NULL) == NULL && errno == EINVAL),
-        "flux_msg_get_route_string returns NULL errno EINVAL on msg = NULL");
+    ok ((flux_msg_route_string (NULL) == NULL && errno == EINVAL),
+        "flux_msg_route_string returns NULL errno EINVAL on msg = NULL");
     errno = 0;
-    ok ((flux_msg_get_route_string (msg) == NULL && errno == EPROTO),
-        "flux_msg_get_route_string returns NULL errno EPROTO on msg "
+    ok ((flux_msg_route_string (msg) == NULL && errno == EPROTO),
+        "flux_msg_route_string returns NULL errno EPROTO on msg "
         "w/o routes enabled");
 
     flux_msg_destroy (msg);
 }
 
-/* flux_msg_get_route_first, flux_msg_get_route_last,
- *   flux_msg_get_route_count on message with variable number of
+/* flux_msg_route_first, flux_msg_route_last,
+ *   flux_msg_route_count on message with variable number of
  *   routing frames
  */
 void check_routes (void)
@@ -313,86 +313,86 @@ void check_routes (void)
         && flux_msg_frames (msg) == 1,
         "flux_msg_create works and creates msg with 1 frame");
 
-    flux_msg_clear_route (msg);
+    flux_msg_route_clear (msg);
     ok (flux_msg_frames (msg) == 1,
-        "flux_msg_clear_route works, is no-op on msg w/o routes enabled");
-    flux_msg_disable_route (msg);
+        "flux_msg_route_clear works, is no-op on msg w/o routes enabled");
+    flux_msg_route_disable (msg);
     ok (flux_msg_frames (msg) == 1,
-        "flux_msg_disable_route works, is no-op on msg w/o routes enabled");
-    flux_msg_enable_route (msg);
+        "flux_msg_route_disable works, is no-op on msg w/o routes enabled");
+    flux_msg_route_enable (msg);
     ok (flux_msg_frames (msg) == 2,
-        "flux_msg_enable_route works, adds one frame on msg w/ routes enabled");
-    ok ((flux_msg_get_route_count (msg) == 0),
-        "flux_msg_get_route_count returns 0 on msg w/o routes");
+        "flux_msg_route_enable works, adds one frame on msg w/ routes enabled");
+    ok ((flux_msg_route_count (msg) == 0),
+        "flux_msg_route_count returns 0 on msg w/o routes");
 
-    ok ((route = flux_msg_get_route_first (msg)) == NULL,
-        "flux_msg_get_route_first returns NULL on msg w/o routes");
-    ok ((route = flux_msg_get_route_last (msg)) == NULL,
-        "flux_msg_get_route_last returns NULL on msg w/o routes");
-    ok (flux_msg_push_route (msg, "sender") == 0 && flux_msg_frames (msg) == 3,
-        "flux_msg_push_route works and adds a frame");
-    ok ((flux_msg_get_route_count (msg) == 1),
-        "flux_msg_get_route_count returns 1 on msg w/ id1");
+    ok ((route = flux_msg_route_first (msg)) == NULL,
+        "flux_msg_route_first returns NULL on msg w/o routes");
+    ok ((route = flux_msg_route_last (msg)) == NULL,
+        "flux_msg_route_last returns NULL on msg w/o routes");
+    ok (flux_msg_route_push (msg, "sender") == 0 && flux_msg_frames (msg) == 3,
+        "flux_msg_route_push works and adds a frame");
+    ok ((flux_msg_route_count (msg) == 1),
+        "flux_msg_route_count returns 1 on msg w/ id1");
 
-    ok ((route = flux_msg_get_route_first (msg)) != NULL,
-        "flux_msg_get_route_first works");
+    ok ((route = flux_msg_route_first (msg)) != NULL,
+        "flux_msg_route_first works");
     like (route, "sender",
-        "flux_msg_get_route_first returns id on msg w/ id1");
+        "flux_msg_route_first returns id on msg w/ id1");
 
-    ok ((route = flux_msg_get_route_last (msg)) != NULL,
-        "flux_msg_get_route_last works");
+    ok ((route = flux_msg_route_last (msg)) != NULL,
+        "flux_msg_route_last works");
     like (route, "sender",
-        "flux_msg_get_route_last returns id on msg w/ id1");
+        "flux_msg_route_last returns id on msg w/ id1");
 
-    ok ((s = flux_msg_get_route_string (msg)) != NULL,
-        "flux_msg_get_route_string works");
+    ok ((s = flux_msg_route_string (msg)) != NULL,
+        "flux_msg_route_string works");
     like (s, "sender",
-        "flux_msg_get_route_string returns correct string on msg w/ id1");
+        "flux_msg_route_string returns correct string on msg w/ id1");
     free (s);
 
-    ok (flux_msg_push_route (msg, "router") == 0 && flux_msg_frames (msg) == 4,
-        "flux_msg_push_route works and adds a frame");
-    ok ((flux_msg_get_route_count (msg) == 2),
-        "flux_msg_get_route_count returns 2 on msg w/ id1+id2");
+    ok (flux_msg_route_push (msg, "router") == 0 && flux_msg_frames (msg) == 4,
+        "flux_msg_route_push works and adds a frame");
+    ok ((flux_msg_route_count (msg) == 2),
+        "flux_msg_route_count returns 2 on msg w/ id1+id2");
 
-    ok ((route = flux_msg_get_route_first (msg)) != NULL,
-        "flux_msg_get_route_first works");
+    ok ((route = flux_msg_route_first (msg)) != NULL,
+        "flux_msg_route_first works");
     like (route, "sender",
-        "flux_msg_get_route_first returns id1 on msg w/ id1+id2");
+        "flux_msg_route_first returns id1 on msg w/ id1+id2");
 
-    ok ((route = flux_msg_get_route_last (msg)) != NULL,
-        "flux_msg_get_route_last works");
+    ok ((route = flux_msg_route_last (msg)) != NULL,
+        "flux_msg_route_last works");
     like (route, "router",
-        "flux_msg_get_route_last returns id2 on message with id1+id2");
+        "flux_msg_route_last returns id2 on message with id1+id2");
 
-    ok ((s = flux_msg_get_route_string (msg)) != NULL,
-        "flux_msg_get_route_string works");
+    ok ((s = flux_msg_route_string (msg)) != NULL,
+        "flux_msg_route_string works");
     like (s, "sender!router",
-        "flux_msg_get_route_string returns correct string on msg w/ id1+id2");
+        "flux_msg_route_string returns correct string on msg w/ id1+id2");
     free (s);
 
-    ok (flux_msg_delete_route_last (msg) == 0 && flux_msg_frames (msg) == 3,
-        "flux_msg_delete_route_last works and removed a frame");
-    ok (flux_msg_get_route_count (msg) == 1,
-        "flux_msg_get_route_count returns 1 on message w/ id1");
+    ok (flux_msg_route_delete_last (msg) == 0 && flux_msg_frames (msg) == 3,
+        "flux_msg_route_delete_last works and removed a frame");
+    ok (flux_msg_route_count (msg) == 1,
+        "flux_msg_route_count returns 1 on message w/ id1");
 
-    flux_msg_clear_route (msg);
-    ok (flux_msg_get_route_count (msg) == 0,
-        "flux_msg_clear_route clear routing frames");
+    flux_msg_route_clear (msg);
+    ok (flux_msg_route_count (msg) == 0,
+        "flux_msg_route_clear clear routing frames");
     ok (flux_msg_frames (msg) == 2,
-        "flux_msg_clear_route did not disable routing frames");
+        "flux_msg_route_clear did not disable routing frames");
 
-    ok (flux_msg_push_route (msg, "foobar") == 0 && flux_msg_frames (msg) == 3,
-        "flux_msg_push_route works and adds a frame after flux_msg_clear_route()");
-    ok ((flux_msg_get_route_count (msg) == 1),
-        "flux_msg_get_route_count returns 1 on msg w/ id1");
+    ok (flux_msg_route_push (msg, "foobar") == 0 && flux_msg_frames (msg) == 3,
+        "flux_msg_route_push works and adds a frame after flux_msg_route_clear()");
+    ok ((flux_msg_route_count (msg) == 1),
+        "flux_msg_route_count returns 1 on msg w/ id1");
 
-    flux_msg_disable_route (msg);
+    flux_msg_route_disable (msg);
     ok (flux_msg_frames (msg) == 1,
-        "flux_msg_disable_route clear routing frames");
+        "flux_msg_route_disable clear routing frames");
 
-    ok (flux_msg_push_route (msg, "boobar") < 0 && errno == EPROTO,
-        "flux_msg_push_route fails with EPROTO after flux_msg_disable_route()");
+    ok (flux_msg_route_push (msg, "boobar") < 0 && errno == EPROTO,
+        "flux_msg_route_push fails with EPROTO after flux_msg_route_disable()");
 
     flux_msg_destroy (msg);
 }
@@ -413,9 +413,9 @@ void check_topic (void)
     like (s, "blorg",
        "and we got back the topic string we set");
 
-    flux_msg_enable_route (msg);
-    ok (flux_msg_push_route (msg, "id1") == 0,
-        "flux_msg_push_route works");
+    flux_msg_route_enable (msg);
+    ok (flux_msg_route_push (msg, "id1") == 0,
+        "flux_msg_route_push works");
     ok (flux_msg_get_topic (msg, &s) == 0,
        "flux_msg_get_topic still works, with routes");
     like (s, "blorg",
@@ -641,11 +641,11 @@ void check_payload (void)
     ok (flux_msg_set_topic (msg, NULL) == 0 && flux_msg_frames (msg) == 2,
        "flux_msg_set_topic NULL works");
 
-    flux_msg_enable_route (msg);
+    flux_msg_route_enable (msg);
     ok (flux_msg_frames (msg) == 3,
-        "flux_msg_enable_route works");
-    ok (flux_msg_push_route (msg, "id1") == 0 && flux_msg_frames (msg) == 4,
-        "flux_msg_push_route works");
+        "flux_msg_route_enable works");
+    ok (flux_msg_route_push (msg, "id1") == 0 && flux_msg_frames (msg) == 4,
+        "flux_msg_route_push works");
 
     len = 0; buf = NULL; errno = 0;
     ok (flux_msg_get_payload (msg, &buf, &len) == 0
@@ -1048,17 +1048,17 @@ void check_copy (void)
     type = -1;
     ok (flux_msg_get_type (cpy, &type) == 0 && type == FLUX_MSGTYPE_KEEPALIVE
              && !flux_msg_has_payload (cpy)
-             && flux_msg_get_route_count (cpy) < 0
+             && flux_msg_route_count (cpy) < 0
              && flux_msg_get_topic (cpy, &topic) < 0,
         "copy is keepalive: no routes, topic, or payload");
     flux_msg_destroy (cpy);
 
     ok ((msg = flux_msg_create (FLUX_MSGTYPE_REQUEST)) != NULL,
         "created request");
-    flux_msg_enable_route (msg);
-    ok (flux_msg_push_route (msg, "first") == 0,
+    flux_msg_route_enable (msg);
+    ok (flux_msg_route_push (msg, "first") == 0,
         "added route 1");
-    ok (flux_msg_push_route (msg, "second") == 0,
+    ok (flux_msg_route_push (msg, "second") == 0,
         "added route 2");
     ok (flux_msg_set_topic (msg, "foo") == 0,
         "set topic string");
@@ -1071,23 +1071,23 @@ void check_copy (void)
              && flux_msg_has_payload (cpy)
              && flux_msg_get_payload (cpy, &cpybuf, &cpylen) == 0
              && cpylen == sizeof (buf) && memcmp (cpybuf, buf, cpylen) == 0
-             && flux_msg_get_route_count (cpy) == 2
+             && flux_msg_route_count (cpy) == 2
              && flux_msg_get_topic (cpy, &topic) == 0 && !strcmp (topic,"foo"),
         "copy is request: w/routes, topic, and payload");
 
-    ok ((s = flux_msg_get_route_last (cpy)) != NULL,
-        "flux_msg_get_route_last gets route from copy");
+    ok ((s = flux_msg_route_last (cpy)) != NULL,
+        "flux_msg_route_last gets route from copy");
     like (s, "second",
-          "flux_msg_get_route_last returns correct second route");
-    ok (flux_msg_delete_route_last (cpy) == 0,
-        "flux_msg_delete_route_last removes second route");
+          "flux_msg_route_last returns correct second route");
+    ok (flux_msg_route_delete_last (cpy) == 0,
+        "flux_msg_route_delete_last removes second route");
 
-    ok ((s = flux_msg_get_route_last (cpy)) != NULL,
-        "flux_msg_get_route_last pops route from copy");
+    ok ((s = flux_msg_route_last (cpy)) != NULL,
+        "flux_msg_route_last pops route from copy");
     like (s, "first",
-          "flux_msg_get_route_last returns correct first route");
-    ok (flux_msg_delete_route_last (cpy) == 0,
-        "flux_msg_delete_route_last removes first route");
+          "flux_msg_route_last returns correct first route");
+    ok (flux_msg_route_delete_last (cpy) == 0,
+        "flux_msg_route_delete_last removes first route");
 
     flux_msg_destroy (cpy);
 
@@ -1096,7 +1096,7 @@ void check_copy (void)
     type = -1;
     ok (flux_msg_get_type (cpy, &type) == 0 && type == FLUX_MSGTYPE_REQUEST
              && !flux_msg_has_payload (cpy)
-             && flux_msg_get_route_count (cpy) == 2
+             && flux_msg_route_count (cpy) == 2
              && flux_msg_get_topic (cpy, &topic) == 0 && !strcmp (topic,"foo"),
         "copy is request: w/routes, topic, and no payload");
     flux_msg_destroy (cpy);
@@ -1131,8 +1131,8 @@ void check_print (void)
         "created test message");
     ok (flux_msg_set_topic (msg, "foo.bar") == 0,
         "set topic string");
-    flux_msg_enable_route (msg);
-    ok (flux_msg_push_route (msg, "id1") == 0,
+    flux_msg_route_enable (msg);
+    ok (flux_msg_route_push (msg, "id1") == 0,
         "added one route");
     ok (flux_msg_set_payload (msg, buf, strlen (buf)) == 0,
         "added payload");
@@ -1184,7 +1184,7 @@ void check_print (void)
 
     ok ((msg = flux_msg_create (FLUX_MSGTYPE_RESPONSE)) != NULL,
         "created test message");
-    flux_msg_enable_route (msg);
+    flux_msg_route_enable (msg);
     lives_ok ({flux_msg_fprint (f, msg);},
         "flux_msg_fprint doesn't segfault on response with empty route stack");
     flux_msg_destroy (msg);
@@ -1250,10 +1250,10 @@ void check_flags (void)
         && (flags & FLUX_MSGFLAG_PAYLOAD),
         "flux_msg_set_payload sets FLUX_MSGFLAG_PAYLOAD");
 
-    flux_msg_enable_route (msg);
+    flux_msg_route_enable (msg);
     ok (flux_msg_get_flags (msg, &flags) == 0
         && (flags & FLUX_MSGFLAG_ROUTE),
-        "flux_msg_enable_route sets FLUX_MSGFLAG_ROUTE");
+        "flux_msg_route_enable sets FLUX_MSGFLAG_ROUTE");
 
     flux_msg_destroy (msg);
 }

--- a/src/common/libflux/test/message.c
+++ b/src/common/libflux/test/message.c
@@ -250,12 +250,11 @@ void check_cornercase (void)
     ok (flux_msg_get_matchtag (evt, &tag) < 0 && errno == EPROTO,
         "flux_msg_get_matchtag fails with EPROTO on msg != req/rsp type");
 
-    errno = 0;
-    ok (flux_msg_enable_route (NULL) == -1 && errno == EINVAL,
-        "flux_msg_enable_route returns -1 errno EINVAL on msg = NULL");
-    errno = 0;
-    ok (flux_msg_clear_route (NULL) == -1 && errno == EINVAL,
-        "flux_msg_clear_route returns -1 errno EINVAL on msg = NULL");
+    lives_ok ({flux_msg_enable_route (NULL);},
+        "flux_msg_enable_route msg=NULL doesnt crash");
+    lives_ok ({flux_msg_clear_route (NULL);},
+        "flux_msg_clear_route msg=NULL doesnt crash");
+
     errno = 0;
     ok (flux_msg_push_route (NULL, "foo") == -1 && errno == EINVAL,
         "flux_msg_push_route returns -1 errno EINVAL on msg = NULL");
@@ -312,9 +311,11 @@ void check_routes (void)
         && flux_msg_frames (msg) == 1,
         "flux_msg_create works and creates msg with 1 frame");
 
-    ok (flux_msg_clear_route (msg) == 0 && flux_msg_frames (msg) == 1,
+    flux_msg_clear_route (msg);
+    ok (flux_msg_frames (msg) == 1,
         "flux_msg_clear_route works, is no-op on msg w/o routes enabled");
-    ok (flux_msg_enable_route (msg) == 0 && flux_msg_frames (msg) == 2,
+    flux_msg_enable_route (msg);
+    ok (flux_msg_frames (msg) == 2,
         "flux_msg_enable_route works, adds one frame on msg w/ routes enabled");
     ok ((flux_msg_get_route_count (msg) == 0),
         "flux_msg_get_route_count returns 0 on msg w/o routes");
@@ -370,7 +371,8 @@ void check_routes (void)
     ok (flux_msg_get_route_count (msg) == 1,
         "flux_msg_get_route_count returns 1 on message w/ id1");
 
-    ok (flux_msg_clear_route (msg) == 0 && flux_msg_frames (msg) == 1,
+    flux_msg_clear_route (msg);
+    ok (flux_msg_frames (msg) == 1,
         "flux_msg_clear_route clear routing frames");
     flux_msg_destroy (msg);
 }
@@ -391,8 +393,7 @@ void check_topic (void)
     like (s, "blorg",
        "and we got back the topic string we set");
 
-    ok (flux_msg_enable_route (msg) == 0,
-        "flux_msg_enable_route works");
+    flux_msg_enable_route (msg);
     ok (flux_msg_push_route (msg, "id1") == 0,
         "flux_msg_push_route works");
     ok (flux_msg_get_topic (msg, &s) == 0,
@@ -620,7 +621,8 @@ void check_payload (void)
     ok (flux_msg_set_topic (msg, NULL) == 0 && flux_msg_frames (msg) == 2,
        "flux_msg_set_topic NULL works");
 
-    ok (flux_msg_enable_route (msg) == 0 && flux_msg_frames (msg) == 3,
+    flux_msg_enable_route (msg);
+    ok (flux_msg_frames (msg) == 3,
         "flux_msg_enable_route works");
     ok (flux_msg_push_route (msg, "id1") == 0 && flux_msg_frames (msg) == 4,
         "flux_msg_push_route works");
@@ -1033,8 +1035,7 @@ void check_copy (void)
 
     ok ((msg = flux_msg_create (FLUX_MSGTYPE_REQUEST)) != NULL,
         "created request");
-    ok (flux_msg_enable_route (msg) == 0,
-        "enable routes");
+    flux_msg_enable_route (msg);
     ok (flux_msg_push_route (msg, "first") == 0,
         "added route 1");
     ok (flux_msg_push_route (msg, "second") == 0,
@@ -1110,8 +1111,7 @@ void check_print (void)
         "created test message");
     ok (flux_msg_set_topic (msg, "foo.bar") == 0,
         "set topic string");
-    ok (flux_msg_enable_route (msg) == 0,
-        "enabled routing");
+    flux_msg_enable_route (msg);
     ok (flux_msg_push_route (msg, "id1") == 0,
         "added one route");
     ok (flux_msg_set_payload (msg, buf, strlen (buf)) == 0,
@@ -1164,8 +1164,7 @@ void check_print (void)
 
     ok ((msg = flux_msg_create (FLUX_MSGTYPE_RESPONSE)) != NULL,
         "created test message");
-    ok (flux_msg_enable_route (msg) == 0,
-        "enabled routing");
+    flux_msg_enable_route (msg);
     lives_ok ({flux_msg_fprint (f, msg);},
         "flux_msg_fprint doesn't segfault on response with empty route stack");
     flux_msg_destroy (msg);
@@ -1231,8 +1230,8 @@ void check_flags (void)
         && (flags & FLUX_MSGFLAG_PAYLOAD),
         "flux_msg_set_payload sets FLUX_MSGFLAG_PAYLOAD");
 
-    ok (flux_msg_enable_route (msg) == 0
-        && flux_msg_get_flags (msg, &flags) == 0
+    flux_msg_enable_route (msg);
+    ok (flux_msg_get_flags (msg, &flags) == 0
         && (flags & FLUX_MSGFLAG_ROUTE),
         "flux_msg_enable_route sets FLUX_MSGFLAG_ROUTE");
 

--- a/src/common/libflux/test/message.c
+++ b/src/common/libflux/test/message.c
@@ -271,6 +271,13 @@ void check_cornercase (void)
     errno = 0;
     ok (flux_msg_pop_route (msg, NULL) == -1 && errno == EPROTO,
         "flux_msg_pop_route returns -1 errno EPROTO on msg w/o routes enabled");
+    errno = 0;
+    ok (flux_msg_delete_route_last (NULL) == -1 && errno == EINVAL,
+        "flux_msg_delete_route_last returns -1 errno EINVAL on id = NULL");
+    errno = 0;
+    ok (flux_msg_delete_route_last (msg) == -1 && errno == EPROTO,
+        "flux_msg_delete_route_last returns -1 errno EPROTO on msg "
+        "w/o routes enabled");
     ok (flux_msg_get_route_first (NULL) == NULL,
         "flux_msg_get_route_first returns NULL on msg = NULL");
     ok (flux_msg_get_route_first (msg) == NULL,
@@ -372,6 +379,18 @@ void check_routes (void)
     like (s, "router",
         "flux_msg_pop_route returns id2 on message with id1+id2");
     free (s);
+    ok (flux_msg_get_route_count (msg) == 1,
+        "flux_msg_get_route_count returns 1 on message w/ id1");
+
+    ok (flux_msg_push_route (msg, "router2") == 0 && flux_msg_frames (msg) == 4,
+        "flux_msg_push_route works and adds a frame");
+    ok ((flux_msg_get_route_count (msg) == 2),
+        "flux_msg_get_route_count returns 2 on msg w/ id1+id2");
+
+    ok (flux_msg_delete_route_last (msg) == 0 && flux_msg_frames (msg) == 3,
+        "flux_msg_delete_route_last works and removed a frame");
+    ok (flux_msg_get_route_count (msg) == 1,
+        "flux_msg_get_route_count returns 1 on message w/ id1");
 
     ok (flux_msg_clear_route (msg) == 0 && flux_msg_frames (msg) == 1,
         "flux_msg_clear_route clear routing frames");

--- a/src/common/libflux/test/rpc.c
+++ b/src/common/libflux/test/rpc.c
@@ -316,7 +316,7 @@ void test_service (flux_t *h)
         && (cred.rolemask & FLUX_ROLE_OWNER),
         "response has cred.userid=UID, cred.rolemask including OWNER");
     errno = 0;
-    rc = flux_msg_get_route_count (msg);
+    rc = flux_msg_route_count (msg);
     ok ((rc == -1 && errno == EINVAL) || (rc == 0),
         "response has no residual route stack");
     flux_future_destroy (r);

--- a/src/common/librouter/router.c
+++ b/src/common/librouter/router.c
@@ -188,8 +188,7 @@ void router_entry_recv (struct router_entry *entry, flux_msg_t *msg)
                 service_remove_request (entry, msg);
                 break;
             }
-            if (flux_msg_enable_route (msg) < 0)
-                return;
+            flux_msg_enable_route (msg);
             if (flux_msg_push_route (msg, entry->uuid) < 0)
                 return;
             if (disconnect_arm (entry->dcon, msg) < 0)

--- a/src/common/librouter/router.c
+++ b/src/common/librouter/router.c
@@ -188,8 +188,8 @@ void router_entry_recv (struct router_entry *entry, flux_msg_t *msg)
                 service_remove_request (entry, msg);
                 break;
             }
-            flux_msg_enable_route (msg);
-            if (flux_msg_push_route (msg, entry->uuid) < 0)
+            flux_msg_route_enable (msg);
+            if (flux_msg_route_push (msg, entry->uuid) < 0)
                 return;
             if (disconnect_arm (entry->dcon, msg) < 0)
                 return;
@@ -378,7 +378,7 @@ static void response_cb (flux_t *h,
 
     if (!(cpy = flux_msg_copy (msg, true)))
         goto error;
-    if (!(uuid = flux_msg_get_route_last (cpy))) { // may set uuid=NULL no routes
+    if (!(uuid = flux_msg_route_last (cpy))) { // may set uuid=NULL no routes
         errno = EINVAL;
         goto error;
     }
@@ -386,7 +386,7 @@ static void response_cb (flux_t *h,
         errno = EHOSTUNREACH;
         goto error;
     }
-    if (flux_msg_delete_route_last (cpy) < 0)
+    if (flux_msg_route_delete_last (cpy) < 0)
         goto error;
     if (entry->send (cpy, entry->arg) < 0) {
         flux_log_error (h, "router: response > client=%.5s", entry->uuid);

--- a/src/common/librouter/servhash.c
+++ b/src/common/librouter/servhash.c
@@ -68,7 +68,6 @@ static flux_msg_t *request_copy_clear_routes (const flux_msg_t *msg)
     if (!(cpy = flux_msg_copy (msg, true)))
         return NULL;
     flux_msg_clear_route (cpy);
-    flux_msg_enable_route (cpy);
     return cpy;
 }
 

--- a/src/common/librouter/servhash.c
+++ b/src/common/librouter/servhash.c
@@ -67,10 +67,8 @@ static flux_msg_t *request_copy_clear_routes (const flux_msg_t *msg)
     flux_msg_t *cpy;
     if (!(cpy = flux_msg_copy (msg, true)))
         return NULL;
-    if (flux_msg_clear_route (cpy) < 0 || flux_msg_enable_route (cpy) < 0) {
-        flux_msg_destroy (cpy);
-        return NULL;
-    }
+    flux_msg_clear_route (cpy);
+    flux_msg_enable_route (cpy);
     return cpy;
 }
 

--- a/src/common/librouter/servhash.c
+++ b/src/common/librouter/servhash.c
@@ -67,7 +67,7 @@ static flux_msg_t *request_copy_clear_routes (const flux_msg_t *msg)
     flux_msg_t *cpy;
     if (!(cpy = flux_msg_copy (msg, true)))
         return NULL;
-    flux_msg_clear_route (cpy);
+    flux_msg_route_clear (cpy);
     return cpy;
 }
 

--- a/src/common/librouter/test/usock_service.c
+++ b/src/common/librouter/test/usock_service.c
@@ -64,7 +64,7 @@ void disconnect_cb (flux_t *h,
                     void *arg)
 {
     const char *uuid;
-    if ((uuid = flux_msg_get_route_first (msg)))
+    if ((uuid = flux_msg_route_first (msg)))
         diag ("disconnect from %.5s", uuid);
     flux_reactor_stop (flux_get_reactor (h));
 }

--- a/src/common/librouter/test/usock_service.c
+++ b/src/common/librouter/test/usock_service.c
@@ -63,10 +63,9 @@ void disconnect_cb (flux_t *h,
                     const flux_msg_t *msg,
                     void *arg)
 {
-    char *uuid = NULL;
-    if (flux_msg_get_route_first (msg, &uuid) == 0)
+    const char *uuid;
+    if ((uuid = flux_msg_get_route_first (msg)))
         diag ("disconnect from %.5s", uuid);
-    free (uuid);
     flux_reactor_stop (flux_get_reactor (h));
 }
 

--- a/src/common/librouter/usock_service.c
+++ b/src/common/librouter/usock_service.c
@@ -49,15 +49,15 @@ static void notify_disconnect (struct service *ss, const char *uuid)
 {
     flux_msg_t *msg;
 
-    /* flux_msg_enable_route() returns void.  To avoid creating an
+    /* flux_msg_route_enable() returns void.  To avoid creating an
      * extra branch, call with C trick to avoid breaking up single if
      * statement into multiple.
      */
     if (!(msg = flux_request_encode ("disconnect", NULL))
         || flux_msg_set_noresponse (msg) < 0
-        || (flux_msg_enable_route (msg), false)
+        || (flux_msg_route_enable (msg), false)
         || flux_msg_set_cred (msg, ss->cred) < 0
-        || flux_msg_push_route (msg, uuid) < 0
+        || flux_msg_route_push (msg, uuid) < 0
         || flux_requeue (ss->h, msg, FLUX_RQ_TAIL) < 0) {
         if (ss->verbose)
             log_msg ("error notifying server of %.5s disconnect", uuid);
@@ -91,15 +91,15 @@ static void service_recv (struct usock_conn *uconn, flux_msg_t *msg, void *arg)
     struct service *ss = arg;
     int type = 0;
 
-    /* flux_msg_enable_route() returns void.  To avoid creating an
+    /* flux_msg_route_enable() returns void.  To avoid creating an
      * extra branch, call with C trick to avoid breaking up single if
      * statement into multiple.
      */
     if (flux_msg_get_type (msg, &type) < 0
         || type != FLUX_MSGTYPE_REQUEST
-        || (flux_msg_enable_route (msg), false)
+        || (flux_msg_route_enable (msg), false)
         || flux_msg_set_cred (msg, ss->cred) < 0
-        || flux_msg_push_route (msg, uuid) < 0
+        || flux_msg_route_push (msg, uuid) < 0
         || flux_requeue (ss->h, msg, FLUX_RQ_TAIL) < 0)
         goto drop;
     return;
@@ -151,7 +151,7 @@ static int service_handle_send (void *impl, const flux_msg_t *msg, int flags)
     }
     if (!(cpy = flux_msg_copy (msg, true)))
         return -1;
-    if (!(uuid = flux_msg_get_route_last (cpy))) {
+    if (!(uuid = flux_msg_route_last (cpy))) {
         errno = EPROTO;
         goto error;
     }
@@ -161,7 +161,7 @@ static int service_handle_send (void *impl, const flux_msg_t *msg, int flags)
         errno = ENOENT;
         goto error;
     }
-    if (flux_msg_delete_route_last (cpy) < 0)
+    if (flux_msg_route_delete_last (cpy) < 0)
         goto error;
     if (usock_conn_send (uconn, cpy) < 0)
         goto error;

--- a/src/common/librouter/usock_service.c
+++ b/src/common/librouter/usock_service.c
@@ -49,9 +49,13 @@ static void notify_disconnect (struct service *ss, const char *uuid)
 {
     flux_msg_t *msg;
 
+    /* flux_msg_enable_route() returns void.  To avoid creating an
+     * extra branch, call with C trick to avoid breaking up single if
+     * statement into multiple.
+     */
     if (!(msg = flux_request_encode ("disconnect", NULL))
         || flux_msg_set_noresponse (msg) < 0
-        || flux_msg_enable_route (msg) < 0
+        || (flux_msg_enable_route (msg), false)
         || flux_msg_set_cred (msg, ss->cred) < 0
         || flux_msg_push_route (msg, uuid) < 0
         || flux_requeue (ss->h, msg, FLUX_RQ_TAIL) < 0) {
@@ -87,9 +91,13 @@ static void service_recv (struct usock_conn *uconn, flux_msg_t *msg, void *arg)
     struct service *ss = arg;
     int type = 0;
 
+    /* flux_msg_enable_route() returns void.  To avoid creating an
+     * extra branch, call with C trick to avoid breaking up single if
+     * statement into multiple.
+     */
     if (flux_msg_get_type (msg, &type) < 0
         || type != FLUX_MSGTYPE_REQUEST
-        || flux_msg_enable_route (msg) < 0
+        || (flux_msg_enable_route (msg), false)
         || flux_msg_set_cred (msg, ss->cred) < 0
         || flux_msg_push_route (msg, uuid) < 0
         || flux_requeue (ss->h, msg, FLUX_RQ_TAIL) < 0)

--- a/src/common/libsubprocess/server.c
+++ b/src/common/libsubprocess/server.c
@@ -530,7 +530,7 @@ const char *subprocess_sender (flux_subprocess_t *p)
     struct rexec *rex = flux_subprocess_aux_get (p, auxkey);
     const char *sender;
 
-    if (!rex || !(sender = flux_msg_get_route_first (rex->msg)))
+    if (!rex || !(sender = flux_msg_route_first (rex->msg)))
         return NULL;
 
     return sender;

--- a/src/common/libsubprocess/server.c
+++ b/src/common/libsubprocess/server.c
@@ -525,12 +525,12 @@ error:
         flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
 }
 
-char *subprocess_sender (flux_subprocess_t *p)
+const char *subprocess_sender (flux_subprocess_t *p)
 {
     struct rexec *rex = flux_subprocess_aux_get (p, auxkey);
-    char *sender;
+    const char *sender;
 
-    if (!rex || flux_msg_get_route_first (rex->msg, &sender) < 0)
+    if (!rex || !(sender = flux_msg_get_route_first (rex->msg)))
         return NULL;
 
     return sender;
@@ -540,7 +540,7 @@ static json_t *process_info (flux_subprocess_t *p)
 {
     flux_cmd_t *cmd;
     char *cmd_str = NULL;
-    char *sender = NULL;
+    const char *sender;
     json_t *info = NULL;
 
     if (!(cmd = flux_subprocess_get_cmd (p)))
@@ -563,7 +563,6 @@ static json_t *process_info (flux_subprocess_t *p)
     }
 
 cleanup:
-    free (sender);
     free (cmd_str);
     return info;
 }
@@ -682,15 +681,13 @@ int server_terminate_subprocesses (flux_subprocess_server_t *s)
 
 static void terminate_uuid (flux_subprocess_t *p, const char *id)
 {
-    char *sender;
+    const char *sender;
 
     if (!(sender = subprocess_sender (p)))
         return;
 
     if (!strcmp (id, sender))
         server_signal_subprocess (p, SIGKILL);
-
-    free (sender);
 }
 
 int server_terminate_by_uuid (flux_subprocess_server_t *s,

--- a/src/common/libterminus/pty.c
+++ b/src/common/libterminus/pty.c
@@ -102,7 +102,7 @@ static struct pty_client *pty_client_create (const flux_msg_t *msg)
 
     if (!(c = calloc (1, sizeof (*c))))
         return NULL;
-    if (!(uuid = flux_msg_get_route_first (msg))) {
+    if (!(uuid = flux_msg_route_first (msg))) {
         errno = EPROTO;
         goto error;
     }
@@ -133,7 +133,7 @@ static struct pty_client *pty_client_find_sender (struct flux_pty *pty,
     struct pty_client *c = NULL;
     const char *uuid;
 
-    if (!(uuid = flux_msg_get_route_first (msg))) {
+    if (!(uuid = flux_msg_route_first (msg))) {
         llog_error (pty, "flux_msg_get_route_first: uuid is NULL!");
         return NULL;
     }

--- a/src/common/libterminus/pty.c
+++ b/src/common/libterminus/pty.c
@@ -97,15 +97,18 @@ static void pty_client_destroy (struct pty_client *c)
 
 static struct pty_client *pty_client_create (const flux_msg_t *msg)
 {
-    char *uuid = NULL;
+    const char *uuid;
     struct pty_client *c = NULL;
 
     if (!(c = calloc (1, sizeof (*c))))
         return NULL;
-    if (flux_msg_get_route_first (msg, &uuid) < 0)
+    if (!(uuid = flux_msg_get_route_first (msg))) {
+        errno = EPROTO;
         goto error;
+    }
     c->req = flux_msg_incref (msg);
-    c->uuid = uuid;
+    if (!(c->uuid = strdup (uuid)))
+        goto error;
     return c;
 error:
     pty_client_destroy (c);
@@ -128,18 +131,13 @@ static struct pty_client *pty_client_find_sender (struct flux_pty *pty,
                                                   const flux_msg_t *msg)
 {
     struct pty_client *c = NULL;
-    char *uuid = NULL;
+    const char *uuid;
 
-    if (flux_msg_get_route_first (msg, &uuid) < 0) {
-        llog_error (pty, "flux_msg_get_route_first: %s", strerror (errno));
-        return NULL;
-    }
-    if (uuid == NULL) {
+    if (!(uuid = flux_msg_get_route_first (msg))) {
         llog_error (pty, "flux_msg_get_route_first: uuid is NULL!");
         return NULL;
     }
     c = pty_client_find (pty, uuid);
-    free (uuid);
 
     return c;
 }

--- a/src/common/libterminus/terminus.c
+++ b/src/common/libterminus/terminus.c
@@ -758,7 +758,7 @@ static void disconnect_cb (flux_t *h,
     struct terminus_session *s;
     const char *sender;
 
-    if (!(sender = flux_msg_get_route_first (msg))) {
+    if (!(sender = flux_msg_route_first (msg))) {
         llog_error (ts, "flux_msg_get_route_first: uuid is NULL!");
         return;
     }

--- a/src/common/libterminus/terminus.c
+++ b/src/common/libterminus/terminus.c
@@ -756,19 +756,17 @@ static void disconnect_cb (flux_t *h,
 {
     struct flux_terminus_server *ts = arg;
     struct terminus_session *s;
-    char *sender = NULL;
+    const char *sender;
 
-    if (flux_msg_get_route_first (msg, &sender) < 0) {
-        llog_error (ts, "flux_msg_get_route_first: %s", strerror (errno));
-        goto out;
+    if (!(sender = flux_msg_get_route_first (msg))) {
+        llog_error (ts, "flux_msg_get_route_first: uuid is NULL!");
+        return;
     }
     s = zlist_first (ts->sessions);
     while (s) {
         flux_pty_disconnect_client (s->pty, sender);
         s = zlist_next (ts->sessions);
     }
-out:
-    free (sender);
 }
 
 static const struct flux_msg_handler_spec handler_tab[] = {

--- a/src/common/libtestutil/util.c
+++ b/src/common/libtestutil/util.c
@@ -237,7 +237,7 @@ static int test_connector_send (void *impl, const flux_msg_t *msg, int flags)
                 goto error;
             break;
         case FLUX_MSGTYPE_RESPONSE:
-            if (flux_msg_pop_route (cpy, NULL) < 0)
+            if (flux_msg_delete_route_last (cpy) < 0)
                 goto error;
             break;
     }

--- a/src/common/libtestutil/util.c
+++ b/src/common/libtestutil/util.c
@@ -231,12 +231,12 @@ static int test_connector_send (void *impl, const flux_msg_t *msg, int flags)
         goto error;
     switch (type) {
         case FLUX_MSGTYPE_REQUEST:
-            flux_msg_enable_route (cpy);
-            if (flux_msg_push_route (cpy, "test") < 0)
+            flux_msg_route_enable (cpy);
+            if (flux_msg_route_push (cpy, "test") < 0)
                 goto error;
             break;
         case FLUX_MSGTYPE_RESPONSE:
-            if (flux_msg_delete_route_last (cpy) < 0)
+            if (flux_msg_route_delete_last (cpy) < 0)
                 goto error;
             break;
     }

--- a/src/common/libtestutil/util.c
+++ b/src/common/libtestutil/util.c
@@ -231,8 +231,7 @@ static int test_connector_send (void *impl, const flux_msg_t *msg, int flags)
         goto error;
     switch (type) {
         case FLUX_MSGTYPE_REQUEST:
-            if (flux_msg_enable_route (cpy) < 0)
-                goto error;
+            flux_msg_enable_route (cpy);
             if (flux_msg_push_route (cpy, "test") < 0)
                 goto error;
             break;

--- a/src/modules/barrier/barrier.c
+++ b/src/modules/barrier/barrier.c
@@ -329,7 +329,7 @@ static void enter_request_cb (flux_t *h, flux_msg_handler_t *mh,
                              "name", &name,
                              "nprocs", &nprocs) < 0)
         goto error;
-    if (!(sender = flux_msg_get_route_first (msg))) {
+    if (!(sender = flux_msg_route_first (msg))) {
         errno = EPROTO;
         goto error;
     }
@@ -367,7 +367,7 @@ static void disconnect_request_cb (flux_t *h, flux_msg_handler_t *mh,
 
     if (flux_msg_get_cred (msg, &cred) < 0)
         goto error;
-    if (!(sender = flux_msg_get_route_first (msg))) {
+    if (!(sender = flux_msg_route_first (msg))) {
         errno = EPROTO;
         goto error;
     }

--- a/src/modules/barrier/barrier.c
+++ b/src/modules/barrier/barrier.c
@@ -158,7 +158,7 @@ error:
 }
 
 static int barrier_add_client (struct barrier *b,
-                               char *sender,
+                               const char *sender,
                                const flux_msg_t *msg)
 {
     if (zhash_insert (b->clients, sender, (void *)flux_msg_incref (msg)) < 0) {
@@ -318,7 +318,7 @@ static void enter_request_cb (flux_t *h, flux_msg_handler_t *mh,
 {
     struct barrier_ctx *ctx = arg;
     struct barrier *b;
-    char *sender = NULL;
+    const char *sender;
     const char *name;
     int nprocs;
     uint32_t owner;
@@ -329,8 +329,10 @@ static void enter_request_cb (flux_t *h, flux_msg_handler_t *mh,
                              "name", &name,
                              "nprocs", &nprocs) < 0)
         goto error;
-    if (flux_msg_get_route_first (msg, &sender) < 0)
+    if (!(sender = flux_msg_get_route_first (msg))) {
+        errno = EPROTO;
         goto error;
+    }
     if (flux_msg_get_userid (msg, &owner) < 0)
         goto error;
     if (!(b = barrier_lookup_create (ctx, name, nprocs, owner)))
@@ -346,11 +348,9 @@ static void enter_request_cb (flux_t *h, flux_msg_handler_t *mh,
     }
     if (barrier_update (b, 1) < 0)
         goto error;
-    free (sender);
     return;
 error:
     flux_respond_error (ctx->h, msg, errno, NULL);
-    free (sender);
 }
 
 /* Upon client disconnect, abort any pending barriers it was
@@ -360,15 +360,17 @@ static void disconnect_request_cb (flux_t *h, flux_msg_handler_t *mh,
                                    const flux_msg_t *msg, void *arg)
 {
     struct barrier_ctx *ctx = arg;
-    char *sender = NULL;
+    const char *sender;
     const char *key;
     struct barrier *b;
     struct flux_msg_cred cred;
 
     if (flux_msg_get_cred (msg, &cred) < 0)
         goto error;
-    if (flux_msg_get_route_first (msg, &sender) < 0)
+    if (!(sender = flux_msg_get_route_first (msg))) {
+        errno = EPROTO;
         goto error;
+    }
     FOREACH_ZHASH (ctx->barriers, key, b) {
         if (zhash_lookup (b->clients, sender)) {
             if (flux_msg_cred_authorize (cred, b->owner) < 0) {
@@ -382,11 +384,9 @@ static void disconnect_request_cb (flux_t *h, flux_msg_handler_t *mh,
                 flux_log_error (h, "exit_event_send");
         }
     }
-    free (sender);
     return;
 error:
     flux_log_error (h, "barrier.disconnect");
-    free (sender);
 }
 
 static int exit_event_send (flux_t *h,

--- a/src/modules/job-manager/alloc.c
+++ b/src/modules/job-manager/alloc.c
@@ -420,7 +420,7 @@ static void ready_cb (flux_t *h, flux_msg_handler_t *mh,
         errno = EPROTO;
         goto error;
     }
-    if (!(sender = flux_msg_get_route_first (msg))) {
+    if (!(sender = flux_msg_route_first (msg))) {
         flux_log (h, LOG_ERR, "%s: flux_msg_get_route_first: sender is NULL",
                   __FUNCTION__);
         goto error;
@@ -774,7 +774,7 @@ void alloc_disconnect_rpc (flux_t *h,
 
     if (alloc->sched_sender) {
         const char *sender;
-        if ((sender = flux_msg_get_route_first (msg))
+        if ((sender = flux_msg_route_first (msg))
             && !strcmp (sender, alloc->sched_sender))
             interface_teardown (ctx->alloc, "disconnect", 0);
     }

--- a/src/modules/job-manager/wait.c
+++ b/src/modules/job-manager/wait.c
@@ -307,7 +307,7 @@ void wait_disconnect_rpc (flux_t *h,
     job = zhashx_first (ctx->active_jobs);
     while (job && wait->waiters > 0) {
         if (job->waiter) {
-            if (flux_msg_match_route_first (job->waiter, msg)) {
+            if (flux_msg_route_match_first (job->waiter, msg)) {
                 flux_msg_decref (job->waiter);
                 job->waiter = NULL;
                 wait->waiters--;

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -2061,7 +2061,7 @@ static void setroot_event_cb (flux_t *h, flux_msg_handler_t *mh,
 static bool disconnect_cmp (const flux_msg_t *msg, void *arg)
 {
     flux_msg_t *msgreq = arg;
-    return flux_msg_match_route_first (msgreq, msg);
+    return flux_msg_route_match_first (msgreq, msg);
 }
 
 static int disconnect_request_root_cb (struct kvsroot *root, void *arg)

--- a/src/modules/kvs/test/kvssync.c
+++ b/src/modules/kvs/test/kvssync.c
@@ -213,7 +213,8 @@ void basic_remove_tests (void)
         snprintf (s, sizeof (s), "%d", i);
         if (!(msg = flux_msg_create (FLUX_MSGTYPE_REQUEST)))
             break;
-        if (flux_msg_enable_route (msg) < 0 || flux_msg_push_route (msg, s) < 0)
+        flux_msg_enable_route (msg);
+        if (flux_msg_push_route (msg, s) < 0)
             break;
         ok (!kvssync_add (root, cb, NULL, NULL, msg, NULL, i),
             "kvssync_add w/ seq = %d works", i);

--- a/src/modules/kvs/test/kvssync.c
+++ b/src/modules/kvs/test/kvssync.c
@@ -165,17 +165,15 @@ void basic_api_tests (void)
 
 bool msgcmp (const flux_msg_t *msg, void *arg)
 {
-    char *id = NULL;
+    const char *id;
     bool match = false;
-    if (flux_msg_get_route_first (msg, &id) == 0
+    if ((id = flux_msg_get_route_first (msg))
         && (!strcmp (id, "1")
             || !strcmp (id, "2")
             || !strcmp (id, "3")
             || !strcmp (id, "4")
             || !strcmp (id, "5")))
         match = true;
-    if (id)
-        free (id);
     return match;
 }
 

--- a/src/modules/kvs/test/kvssync.c
+++ b/src/modules/kvs/test/kvssync.c
@@ -167,7 +167,7 @@ bool msgcmp (const flux_msg_t *msg, void *arg)
 {
     const char *id;
     bool match = false;
-    if ((id = flux_msg_get_route_first (msg))
+    if ((id = flux_msg_route_first (msg))
         && (!strcmp (id, "1")
             || !strcmp (id, "2")
             || !strcmp (id, "3")
@@ -213,8 +213,8 @@ void basic_remove_tests (void)
         snprintf (s, sizeof (s), "%d", i);
         if (!(msg = flux_msg_create (FLUX_MSGTYPE_REQUEST)))
             break;
-        flux_msg_enable_route (msg);
-        if (flux_msg_push_route (msg, s) < 0)
+        flux_msg_route_enable (msg);
+        if (flux_msg_route_push (msg, s) < 0)
             break;
         ok (!kvssync_add (root, cb, NULL, NULL, msg, NULL, i),
             "kvssync_add w/ seq = %d works", i);

--- a/src/modules/kvs/test/waitqueue.c
+++ b/src/modules/kvs/test/waitqueue.c
@@ -43,13 +43,11 @@ void msghand (flux_t *h, flux_msg_handler_t *mh,
 
 bool msgcmp (const flux_msg_t *msg, void *arg)
 {
-    char *id = NULL;
+    const char *id;
     bool match = false;
-    if (flux_msg_get_route_first (msg, &id) == 0
+    if ((id = flux_msg_get_route_first (msg))
         && (!strcmp (id, "19") || !strcmp (id, "18") || !strcmp (id, "17")))
         match = true;
-    if (id)
-        free (id);
     return match;
 }
 

--- a/src/modules/kvs/test/waitqueue.c
+++ b/src/modules/kvs/test/waitqueue.c
@@ -45,7 +45,7 @@ bool msgcmp (const flux_msg_t *msg, void *arg)
 {
     const char *id;
     bool match = false;
-    if ((id = flux_msg_get_route_first (msg))
+    if ((id = flux_msg_route_first (msg))
         && (!strcmp (id, "19") || !strcmp (id, "18") || !strcmp (id, "17")))
         match = true;
     return match;
@@ -255,8 +255,8 @@ int main (int argc, char *argv[])
         snprintf (s, sizeof (s), "%d", i);
         if (!(msg = flux_msg_create (FLUX_MSGTYPE_REQUEST)))
             break;
-        flux_msg_enable_route (msg);
-        if (flux_msg_push_route (msg, s) < 0)
+        flux_msg_route_enable (msg);
+        if (flux_msg_route_push (msg, s) < 0)
             break;
         if (!(w = wait_create_msg_handler (NULL, NULL, msg, &count, msghand)))
             break;

--- a/src/modules/kvs/test/waitqueue.c
+++ b/src/modules/kvs/test/waitqueue.c
@@ -255,7 +255,8 @@ int main (int argc, char *argv[])
         snprintf (s, sizeof (s), "%d", i);
         if (!(msg = flux_msg_create (FLUX_MSGTYPE_REQUEST)))
             break;
-        if (flux_msg_enable_route (msg) < 0 || flux_msg_push_route (msg, s) < 0)
+        flux_msg_enable_route (msg);
+        if (flux_msg_push_route (msg, s) < 0)
             break;
         if (!(w = wait_create_msg_handler (NULL, NULL, msg, &count, msghand)))
             break;


### PR DESCRIPTION
I'll just post what is in the primary commit message here:

```
Problem: The functions flux_msg_get_route_first() and
flux_msg_get_route_last() return route IDs via an allocated string
that must be freed by the user.  This API made sense previously
when route IDs were stored internally in a zframe.  However, now
that the route IDs are stored in decoded data structures, we could
return the route IDs directly.

Solution: Return internally stored route IDs via a const char *
instead of an allocated string.  Adjust all callers accordingly.
use 'const char *' instead of 'char *' in several places where
more appropriate.
```

If you're wondering why don't I put this change in one of the other libflux refactoring PRs, its b/c `flux-sched` needs updating too, so figure a separate PR would be best.

I had some further design thoughts too which I'll post in #3617.