### PR TITLE
job-manager: minor cleanup and improvements for event handling

### DIFF
--- a/src/modules/job-manager/event.c
+++ b/src/modules/job-manager/event.c
@@ -631,16 +631,6 @@ error:
     return -1;
 }
 
-static int get_timestamp_now (double *timestamp)
-{
-    struct timespec ts;
-    if (clock_gettime (CLOCK_REALTIME, &ts) < 0)
-        return -1;
-    *timestamp = (1E-9 * ts.tv_nsec) + ts.tv_sec;
-    return 0;
-}
-
-
 /*  Call jobtap plugin for event if necessary.
  *  Currently jobtap plugins are called only on state transitions or
  *   update of job urgency via "urgency" event.
@@ -748,15 +738,12 @@ int event_job_post_vpack (struct event *event,
     json_t *entry = NULL;
     int saved_errno;
     int rc;
-    double timestamp;
 
     if (job->state == FLUX_JOB_STATE_NEW) {
         errno = EAGAIN;
         return -1;
     }
-    if (get_timestamp_now (&timestamp) < 0)
-        return -1;
-    if (!(entry = eventlog_entry_vpack (timestamp, name, context_fmt, ap)))
+    if (!(entry = eventlog_entry_vpack (0., name, context_fmt, ap)))
         return -1;
     rc = event_job_post_entry (event, job, name, flags, entry);
 

--- a/src/modules/job-manager/event.c
+++ b/src/modules/job-manager/event.c
@@ -701,7 +701,8 @@ int event_job_post_entry (struct event *event,
     if (event_job_update (job, entry) < 0) // modifies job->state
         return -1;
     job->eventlog_seq++;
-    if (event_batch_commit_event (event, job, entry) < 0)
+    if (!(flags & EVENT_NO_COMMIT)
+        && event_batch_commit_event (event, job, entry) < 0)
         return -1;
     if (job->state != old_state) {
         double timestamp;

--- a/src/modules/job-manager/event.c
+++ b/src/modules/job-manager/event.c
@@ -584,7 +584,8 @@ int event_job_update (struct job *job, json_t *event)
             job->state = FLUX_JOB_STATE_RUN;
     }
     else if (!strcmp (name, "free")) {
-        if (job->state != FLUX_JOB_STATE_CLEANUP)
+        if (job->state != FLUX_JOB_STATE_CLEANUP
+            || !job->has_resources)
             goto inval;
         job->has_resources = 0;
     }

--- a/src/modules/job-manager/event.h
+++ b/src/modules/job-manager/event.h
@@ -63,6 +63,12 @@ int event_job_post_vpack (struct event *event,
                           const char *context_fmt,
                           va_list ap);
 
+int event_job_post_entry (struct event *event,
+                          struct job *job,
+                          const char *name,
+                          int flags,
+                          json_t *entry);
+
 void event_ctx_destroy (struct event *event);
 struct event *event_ctx_create (struct job_manager *ctx);
 

--- a/src/modules/job-manager/event.h
+++ b/src/modules/job-manager/event.h
@@ -20,6 +20,7 @@
 
 enum job_manager_event_flags {
     EVENT_JOURNAL_ONLY = 1,
+    EVENT_NO_COMMIT =    2,  // Do not commit event to eventlog
 };
 
 /* Take any action for 'job' currently needed based on its internal state.

--- a/src/modules/job-manager/job.h
+++ b/src/modules/job-manager/job.h
@@ -31,6 +31,7 @@ struct job {
     json_t *end_event;      // event that caused transition to CLEANUP state
     const flux_msg_t *waiter; // flux_job_wait() request
 
+    uint8_t depend_posted:1;// depend event already posted
     uint8_t alloc_queued:1; // queued for alloc, but alloc request not sent
     uint8_t alloc_pending:1;// alloc request sent to sched
     uint8_t alloc_bypass:1; // alloc bypass enabled


### PR DESCRIPTION
This PR was mainly prep work for a prototype solution for #3746, however, it may be considered good cleanup and minor improvements. Notably, this PR:

 - ensures spurious "free" event (e.g. as posted by a jobtap plugin) is caught as an error
 - adds a flag to ensure a "depend" event can't be posted more than once
 - refactors `event_job_post*` functions so that `submit_post_event()` can use this shared code
 - removes need for one-off timestamp capture in `event_job_post_pack()`