### PR TITLE
libjob: improve method for determining instance owner

### DIFF
--- a/src/common/libflux/handle.h
+++ b/src/common/libflux/handle.h
@@ -61,7 +61,7 @@ enum {
     FLUX_POLLERR = 4,
 };
 
-/* Options for flux_setopt().
+/* Options for flux_opt_set().
  * (Connectors may define custom option names)
  */
 #define FLUX_OPT_TESTING_USERID     "flux::testing_userid"

--- a/src/common/librouter/test/usock.c
+++ b/src/common/librouter/test/usock.c
@@ -163,10 +163,19 @@ void client_invalid (void)
 {
     struct usock_retry_params retry = USOCK_RETRY_NONE;
     char *longstr;
+    struct flux_msg_cred cred;
 
     if (!(longstr = calloc (1, PATH_MAX + 1)))
         BAIL_OUT ("malloc failed");
     memset (longstr, 'a', PATH_MAX);
+
+    errno = 0;
+    ok (usock_get_cred (-1, &cred) < 0 && errno == EINVAL,
+        "usock_get_cred fd=-1 fails with EINVAL");
+
+    errno = 0;
+    ok (usock_get_cred (0, NULL) < 0 && errno == EINVAL,
+        "usock_get_cred cred=NULL fails with EINVAL");
 
     errno = 0;
     ok (usock_client_create (-1) == NULL && errno == EINVAL,

--- a/src/common/librouter/test/usock_echo.c
+++ b/src/common/librouter/test/usock_echo.c
@@ -177,6 +177,7 @@ static void test_one_echo (flux_t *h)
     flux_msg_t *rmsg;
     int fd;
     struct usock_client *client;
+    struct flux_msg_cred cred;
 
     if (!(msg = flux_request_encode ("a", NULL)))
         BAIL_OUT ("flux_request_encode failed");
@@ -189,6 +190,10 @@ static void test_one_echo (flux_t *h)
     fd = usock_client_connect (sockpath, USOCK_RETRY_DEFAULT);
     ok (fd >= 0,
         "usock_client_connect %s works", sockpath);
+    ok (usock_get_cred (fd, &cred) == 0,
+        "usock_get_cred works");
+    ok (cred.userid == getuid (),
+        "and returned cred.userid matches test uid");
     ok ((client = usock_client_create (fd)) != NULL,
         "usock_client_create works");
 

--- a/src/common/librouter/usock.c
+++ b/src/common/librouter/usock.c
@@ -385,11 +385,15 @@ void usock_server_destroy (struct usock_server *server)
     }
 }
 
-static int get_socket_peercred (int fd, struct flux_msg_cred *cred)
+int usock_get_cred (int fd, struct flux_msg_cred *cred)
 {
     struct ucred ucred;
     socklen_t crlen;
 
+    if (fd < 0 || !cred) {
+        errno = EINVAL;
+        return -1;
+    }
     crlen = sizeof (ucred);
     if (getsockopt (fd,
                     SOL_SOCKET,
@@ -459,7 +463,7 @@ static struct usock_conn *server_accept (struct usock_server *server,
     if ((cfd = accept4 (server->fd, NULL, NULL, SOCK_CLOEXEC)) < 0)
         return NULL;
     if (!(conn = usock_conn_create (r, cfd, cfd))
-                        || get_socket_peercred (cfd, &conn->cred) < 0) {
+                        || usock_get_cred (cfd, &conn->cred) < 0) {
         ERRNO_SAFE_WRAP (close, cfd);
         return NULL;
     }

--- a/src/common/librouter/usock.h
+++ b/src/common/librouter/usock.h
@@ -47,6 +47,8 @@ typedef void (*usock_conn_recv_f)(struct usock_conn *conn,
                                   flux_msg_t *msg,
                                   void *arg);
 
+int usock_get_cred (int fd, struct flux_msg_cred *cred);
+
 /* Server
  */
 

--- a/src/common/libtestutil/util.h
+++ b/src/common/libtestutil/util.h
@@ -38,7 +38,7 @@ void test_server_environment_init (const char *test_name);
 
 
 /* Create a loopback connector for testing.
- * The net effect is much the same as flux_open("local://") except
+ * The net effect is much the same as flux_open("loop://") except
  * the implementation is self contained here.  Close with flux_close().
  *
  * Like loop://, this support test manipulation of credentials:

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -94,6 +94,7 @@ TESTSCRIPTS = \
 	t1105-proxy.t \
 	t1106-ssh-connector.t \
 	t1107-heartbeat.t \
+	t1108-local-opt.t \
 	t2004-hydra.t \
 	t2005-hwloc-basic.t \
 	t2006-hwloc-versions.t \
@@ -325,7 +326,8 @@ check_PROGRAMS = \
 	debug/stall \
 	hwloc/hwloc-convert \
 	hwloc/hwloc-version \
-	util/jobspec1-validate
+	util/jobspec1-validate \
+	util/handle
 
 if HAVE_MPI
 check_PROGRAMS += \
@@ -801,4 +803,9 @@ hwloc_hwloc_version_LDADD = $(HWLOC_LIBS) \
 util_jobspec1_validate_SOURCES = util/jobspec1-validate.c
 util_jobspec1_validate_CPPFLAGS = $(test_cppflags)
 util_jobspec1_validate_LDADD = \
+	$(test_ldadd) $(LIBDL)
+
+util_handle_SOURCES = util/handle.c
+util_handle_CPPFLAGS = $(test_cppflags)
+util_handle_LDADD = \
 	$(test_ldadd) $(LIBDL)

--- a/t/t1108-local-opt.t
+++ b/t/t1108-local-opt.t
@@ -1,0 +1,23 @@
+#!/bin/sh
+#
+
+test_description='Test local connector opt'
+
+. `dirname $0`/sharness.sh
+SIZE=1
+test_under_flux ${SIZE} minimal
+
+HANDLE_UTIL=${FLUX_BUILD_DIR}/t/util/handle
+
+test_expect_success 'getopt flux::owner works' '
+	ID=$($HANDLE_UTIL getopt u32 flux::owner) &&
+	test $ID -eq $(id -u)
+'
+test_expect_success 'getopt unknown key fails' '
+	test_must_fail $HANDLE_UTIL badkey
+'
+test_expect_success 'getopt wrong size' '
+	test_must_fail $HANDLE_UTIL getopt u8 flux::owner
+'
+
+test_done

--- a/t/util/handle.c
+++ b/t/util/handle.c
@@ -1,0 +1,66 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* handle.c - test util for flux_t handle */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdio.h>
+#include <flux/core.h>
+
+#include "src/common/libutil/log.h"
+
+void usage (void)
+{
+    fprintf (stderr, "Usage: handle getopt u8|u32 name\n");
+    exit (1);
+}
+
+void getopt (flux_t *h, const char *type, const char *name)
+{
+    if (!strcmp (type, "u8")) {
+        uint8_t val;
+        if (flux_opt_get (h, name, &val, sizeof (val)) < 0)
+            log_err_exit ("%s", name);
+        printf ("%u\n", (unsigned int)val);
+    }
+    else if (!strcmp (type, "u32")) {
+        uint32_t val;
+        if (flux_opt_get (h, name, &val, sizeof (val)) < 0)
+            log_err_exit ("%s", name);
+        printf ("%u\n", (unsigned int)val);
+    }
+    else
+        usage ();
+}
+
+int main (int argc, char *argv[])
+{
+    flux_t *h;
+
+    if (argc != 4)
+        usage();
+
+    if (!(h = flux_open (NULL, 0)))
+        log_err_exit ("flux_open");
+
+    if (!strcmp (argv[1], "getopt"))
+        getopt (h, argv[2], argv[3]);
+    else
+        usage ();
+
+    flux_close (h);
+
+    return (0);
+}
+
+// vi:ts=4 sw=4 expandtab


### PR DESCRIPTION
This is proposed solution for #3760, in which the `t3302-system-offline.t` test fails when flux is built `--with-flux-security` and the munge daemon is not running.  Use of the `security.owner` broker attribute is replaced with a connector method based on SO_PEERCRED.    The existing `flux_opt_get()` interface is leveraged.

I tested this using @grondo's method from the issue to reproduce the failure and it works.

As a bonus, the first job submitted no longer has to make the extra synchronous RPC to the broker.