### PR TITLE
libflux: add time stamp to message trace

### DIFF
--- a/src/common/libflux/message.c
+++ b/src/common/libflux/message.c
@@ -1582,7 +1582,7 @@ static void nodeid2str (uint32_t nodeid, char *buf, int buflen)
     assert (n < buflen);
 }
 
-void flux_msg_fprint (FILE *f, const flux_msg_t *msg)
+void flux_msg_fprint_ts (FILE *f, const flux_msg_t *msg, double timestamp)
 {
     int hops;
     const char *prefix;
@@ -1597,6 +1597,10 @@ void flux_msg_fprint (FILE *f, const flux_msg_t *msg)
         return;
     }
     prefix = msgtype_shortstr (msg->type);
+    /* Timestamp
+     */
+    if (timestamp >= 0.)
+        fprintf (f, "%s %.5f\n", prefix, timestamp);
     /* Topic (keepalive has none)
      */
     if (msg->topic)
@@ -1676,6 +1680,11 @@ void flux_msg_fprint (FILE *f, const flux_msg_t *msg)
         else
             fprintf (f, "malformed payload\n");
     }
+}
+
+void flux_msg_fprint (FILE *f, const flux_msg_t *msg)
+{
+    flux_msg_fprint_ts (f, msg, -1);
 }
 
 static zmsg_t *msg_to_zmsg (const flux_msg_t *msg)

--- a/src/common/libflux/message.h
+++ b/src/common/libflux/message.h
@@ -294,6 +294,7 @@ bool flux_msg_cmp (const flux_msg_t *msg, struct flux_match match);
 /* Print a Flux message on specified output stream.
  */
 void flux_msg_fprint (FILE *f, const flux_msg_t *msg);
+void flux_msg_fprint_ts (FILE *f, const flux_msg_t *msg, double timestamp);
 
 /* Convert a numeric FLUX_MSGTYPE value to string,
  * or "unknown" if unrecognized.

--- a/src/common/libflux/test/message.c
+++ b/src/common/libflux/test/message.c
@@ -1107,8 +1107,8 @@ void check_print (void)
 
     ok ((msg = flux_msg_create (FLUX_MSGTYPE_KEEPALIVE)) != NULL,
         "created test message");
-    lives_ok ({flux_msg_fprint (f, msg);},
-        "flux_msg_fprint doesn't segfault on keepalive");
+    lives_ok ({flux_msg_fprint_ts (f, msg, 0.);},
+        "flux_msg_fprint_ts doesn't segfault on keepalive");
     flux_msg_destroy (msg);
 
     ok ((msg = flux_msg_create (FLUX_MSGTYPE_EVENT)) != NULL,

--- a/t/t0002-request.t
+++ b/t/t0002-request.t
@@ -34,6 +34,11 @@ test_expect_success 'request: load req module on rank 1' '
 test_expect_success 'request: simple rpc with no payload' '
 	${FLUX_BUILD_DIR}/t/request/treq null
 '
+test_expect_success 'request: simple rpc with no payload (traced)' '
+	FLUX_HANDLE_TRACE=1 \
+		${FLUX_BUILD_DIR}/t/request/treq null 2>trace.out &&
+	grep ">" trace.out
+'
 
 test_expect_success 'request: simple rpc to rank 0' '
 	${FLUX_BUILD_DIR}/t/request/treq --rank 0 null


### PR DESCRIPTION
Problem: message traces obtained by setting `FLUX_HANDLE_TRACE=1` do not contain timestamps, thus are not as helpful as they could be for performance investigations.

This adds timestamps that look like this (they are in seconds):
```
$ FLUX_HANDLE_TRACE=1 flux getattr size
--------------------------------------
> 0.00000
> attr.get
> flags=topic,payload,route userid=unknown rolemask=none nodeid=any matchtag=1
> {"name":"size"}
--------------------------------------
< 0.00024
< attr.get
< flags=topic,payload,route userid=5588 rolemask=owner errnum=0 matchtag=1
< {"value":"1","flags":1}
1
```
So this RPC took 240 microseconds.