### PR TITLE
add flag to bypass jobspec validation

### DIFF
--- a/src/bindings/python/flux/job/submit.py
+++ b/src/bindings/python/flux/job/submit.py
@@ -29,6 +29,7 @@ def submit_async(
     waitable=False,
     debug=False,
     pre_signed=False,
+    novalidate=False,
 ):
     """Ask Flux to run a job, without waiting for a response
 
@@ -53,6 +54,10 @@ def submit_async(
     :param pre_signed: jobspec argument is already signed
         (default is False)
     :type pre_signed: bool
+    :param novalidate: jobspec does not need to be validated.
+        (default is False) novalidate=True is restricted to the
+        instance owner.
+    :type novalidate: bool
     :returns: a Flux Future object for obtaining the assigned jobid
     :rtype: Future
     """
@@ -64,6 +69,8 @@ def submit_async(
         flags |= constants.FLUX_JOB_DEBUG
     if pre_signed:
         flags |= constants.FLUX_JOB_PRE_SIGNED
+    if novalidate:
+        flags |= constants.FLUX_JOB_NOVALIDATE
     future_handle = RAW.submit(flux_handle, jobspec, urgency, flags)
     return SubmitFuture(future_handle)
 

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -1264,6 +1264,8 @@ int cmd_submit (optparse_t *p, int argc, char **argv)
                 flags |= FLUX_JOB_WAITABLE;
             else if (!strcmp (name, "signed"))
                 flags |= FLUX_JOB_PRE_SIGNED;
+            else if (!strcmp (name, "novalidate"))
+                flags |= FLUX_JOB_NOVALIDATE;
             else
                 log_msg_exit ("unknown flag: %s", name);
         }

--- a/src/cmd/flux-mini.py
+++ b/src/cmd/flux-mini.py
@@ -535,7 +535,7 @@ class MiniCmd:
             "--flags",
             action="append",
             help="Set comma separated list of job submission flags. Possible "
-            + "flags:  debug, waitable",
+            + "flags:  debug, waitable, novalidate",
             metavar="FLAGS",
         )
         parser.add_argument(
@@ -639,6 +639,7 @@ class MiniCmd:
 
         arg_debug = False
         arg_waitable = False
+        arg_novalidate = False
         if args.flags is not None:
             for tmp in args.flags:
                 for flag in tmp.split(","):
@@ -646,6 +647,8 @@ class MiniCmd:
                         arg_debug = True
                     elif flag == "waitable":
                         arg_waitable = True
+                    elif flag == "novalidate":
+                        arg_novalidate = True
                     else:
                         raise ValueError("--flags: Unknown flag " + flag)
 
@@ -667,6 +670,7 @@ class MiniCmd:
             urgency=urgency,
             waitable=arg_waitable,
             debug=arg_debug,
+            novalidate=arg_novalidate,
         )
 
     def submit(self, args, jobspec=None):

--- a/src/common/libjob/job.h
+++ b/src/common/libjob/job.h
@@ -23,6 +23,7 @@ enum job_submit_flags {
     FLUX_JOB_PRE_SIGNED = 1,    // 'jobspec' is already signed
     FLUX_JOB_DEBUG = 2,
     FLUX_JOB_WAITABLE = 4,      // flux_job_wait() will be used on this job
+    FLUX_JOB_NOVALIDATE = 8,    // don't validate jobspec (instance owner only)
 };
 
 enum job_urgency {

--- a/t/t2100-job-ingest.t
+++ b/t/t2100-job-ingest.t
@@ -115,6 +115,11 @@ test_expect_success 'job-ingest: guest cannot submit urgency=17' '
 		flux job submit --urgency=17 basic.json"
 '
 
+test_expect_success 'job-ingest: guest cannot submit --flags=novalidate' '
+        test_must_fail bash -c "FLUX_HANDLE_ROLEMASK=0x2 \
+                flux job submit --flags=novalidate basic.json"
+'
+
 test_expect_success NO_ASAN 'job-ingest: submit job 100 times' '
 	${SUBMITBENCH} -r 100 use_case_2.6.json
 '

--- a/t/t2100-job-ingest.t
+++ b/t/t2100-job-ingest.t
@@ -111,7 +111,8 @@ test_expect_success 'job-ingest: urgency range is enforced' '
 '
 
 test_expect_success 'job-ingest: guest cannot submit urgency=17' '
-	! FLUX_HANDLE_ROLEMASK=0x2 flux job submit --urgency=17 basic.json
+	test_must_fail bash -c "FLUX_HANDLE_ROLEMASK=0x2 \
+		flux job submit --urgency=17 basic.json"
 '
 
 test_expect_success NO_ASAN 'job-ingest: submit job 100 times' '
@@ -123,13 +124,14 @@ test_expect_success NO_ASAN 'job-ingest: submit job 100 times, reuse signature' 
 '
 
 test_expect_success HAVE_FLUX_SECURITY 'job-ingest: submit user != signed user fails' '
-	! FLUX_HANDLE_USERID=9999 flux job submit basic.json 2>baduser.out &&
+	test_must_fail bash -c "FLUX_HANDLE_USERID=9999 \
+		flux job submit basic.json" 2>baduser.out &&
 	grep -q "signer=$(id -u) != requestor=9999" baduser.out
 '
 
 test_expect_success HAVE_FLUX_SECURITY 'job-ingest: non-owner mech=none fails' '
-	! FLUX_HANDLE_ROLEMASK=0x2 flux job submit \
-		--sign-type=none basic.json 2>badrole.out &&
+	test_must_fail bash -c "FLUX_HANDLE_ROLEMASK=0x2 flux job submit \
+		--sign-type=none basic.json" 2>badrole.out &&
 	grep -q "only instance owner" badrole.out
 '
 

--- a/t/t2700-mini-cmd.t
+++ b/t/t2700-mini-cmd.t
@@ -77,6 +77,13 @@ test_expect_success 'flux mini submit --flags debug,waitable works' '
 	jobid=$(flux mini submit --flags debug,waitable hostname) &&
 	flux job eventlog $jobid | grep submit | grep flags=6
 '
+test_expect_success 'flux mini submit --flags=novalidate works' '
+	jobid=$(flux mini submit --flags novalidate /bin/true) &&
+	flux job eventlog $jobid | grep submit | grep flags=8
+'
+test_expect_success 'flux mini submit with bad flags fails' '
+	test_must_fail flux mini submit --flags notaflag /bin/true
+'
 test_expect_success 'flux mini run -v produces jobid on stderr' '
 	flux mini run -v hostname 2>v.err &&
 	grep jobid: v.err


### PR DESCRIPTION
This adds a FLUX_JOB_NOVALIDATE flag that can be passed by the instance owner to the `job-ingest` module to bypass jobspec validation on a per-job basis, as opposed to reloading the `job-ingest` module with the `disable-validator` module option and disabling the validator for all jobs.

I originally added this as part of the `flux job exec` work to improve turnaround time for short lived jobs.  I broke it out for separate consideration here, since it's not really all _that_ helpful for the case it was written for, as the cost of validation is low once the python co-process is up and running.

Can we imagine this being useful for other things?  I'm fine if we prefer to dump it.