### PR TITLE
WIP: make flux job wait return highest shell exit code

### DIFF
--- a/src/common/libjob/job.h
+++ b/src/common/libjob/job.h
@@ -123,6 +123,7 @@ int flux_job_wait_get_status (flux_future_t *f,
                               bool *success,
                               const char **errstr);
 int flux_job_wait_get_id (flux_future_t *f, flux_jobid_t *id);
+int flux_job_wait_get_exit_code (flux_future_t *f, int *exit_rc);
 
 /* Request a list of jobs.
  * If 'max_entries' > 0, fetch at most that many jobs.

--- a/src/common/libjob/wait.c
+++ b/src/common/libjob/wait.c
@@ -11,9 +11,83 @@
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <jansson.h>
 #include <flux/core.h>
 
 #include "job.h"
+
+#include "src/common/libeventlog/eventlog.h"
+#include "src/common/libutil/errno_safe.h"
+
+struct wait_result {
+    bool success;
+    char errbuf[128];
+};
+
+static int decode_job_result (json_t *event, struct wait_result *result)
+{
+    const char *name;
+    json_t *context;
+
+    if (eventlog_entry_parse (event, NULL, &name, &context) < 0)
+        return -1;
+
+    /* Exception - set errbuf=description, set success=false
+     */
+    if (!strcmp (name, "exception")) {
+        const char *type;
+        const char *note = NULL;
+
+        if (json_unpack (context,
+                         "{s:s s?:s}",
+                         "type",
+                         &type,
+                         "note",
+                         &note) < 0)
+            return -1;
+        (void)snprintf (result->errbuf,
+                        sizeof (result->errbuf),
+                        "Fatal exception type=%s %s",
+                        type,
+                        note ? note : "");
+        result->success = false;
+    }
+    /* Shells exited - set errbuf=decoded status byte,
+     * set success=true if all shells exited with 0, otherwise false.
+     */
+    else if (!strcmp (name, "finish")) {
+        int status;
+
+        if (json_unpack (context, "{s:i}", "status", &status) < 0)
+            return -1;
+        if (WIFSIGNALED (status)) {
+            (void)snprintf (result->errbuf,
+                            sizeof (result->errbuf),
+                            "task(s) %s",
+                            strsignal (WTERMSIG (status)));
+            result->success = false;
+        }
+        else if (WIFEXITED (status)) {
+            (void)snprintf (result->errbuf,
+                            sizeof (result->errbuf),
+                            "task(s) exited with exit code %d",
+                            WEXITSTATUS (status));
+            result->success = WEXITSTATUS (status) == 0 ? true : false;
+        }
+        else {
+            (void)snprintf (result->errbuf,
+                            sizeof (result->errbuf),
+                            "unexpected wait(2) status %d",
+                            status);
+            result->success = false;
+        }
+    }
+    else
+        return -1;
+    return 0;
+}
 
 flux_future_t *flux_job_wait (flux_t *h, flux_jobid_t id)
 {
@@ -34,24 +108,37 @@ int flux_job_wait_get_status (flux_future_t *f,
                               bool *successp,
                               const char **errstrp)
 {
-    int success;
-    const char *errstr;
+    const char *auxkey = "flux::wait_result";
+    struct wait_result *result;
 
     if (!f) {
         errno = EINVAL;
         return -1;
     }
-    if (flux_rpc_get_unpack (f,
-                             "{s:b s:s}",
-                             "success",
-                             &success,
-                             "errstr",
-                             &errstr) < 0)
-        return -1;
+    if (!(result = flux_future_aux_get (f, auxkey))) {
+        json_t *event;
+
+        if (flux_rpc_get_unpack (f,
+                                 "{s:o}",
+                                 "event",
+                                 &event) < 0)
+            return -1;
+        if (!(result = calloc (1, sizeof (*result))))
+            return -1;
+        if (decode_job_result (event, result) < 0) {
+            free (result);
+            errno = EPROTO;
+            return -1;
+        }
+        if (flux_future_aux_set (f, auxkey, result, free) < 0) {
+            ERRNO_SAFE_WRAP (free, result);
+            return -1;
+        }
+    }
     if (successp)
-        *successp = success ? true : false;
+        *successp = result->success;
     if (errstrp)
-        *errstrp = errstr;
+        *errstrp = result->errbuf;
     return 0;
 }
 

--- a/src/modules/job-manager/event.c
+++ b/src/modules/job-manager/event.c
@@ -591,6 +591,7 @@ int event_job_update (struct job *job, json_t *event)
         job->has_resources = 1;
         if (job->state == FLUX_JOB_STATE_SCHED)
             job->state = FLUX_JOB_STATE_RUN;
+        job->t_alloc = timestamp;
     }
     else if (!strcmp (name, "free")) {
         if (job->state != FLUX_JOB_STATE_CLEANUP
@@ -608,6 +609,7 @@ int event_job_update (struct job *job, json_t *event)
 
             job->state = FLUX_JOB_STATE_CLEANUP;
         }
+        job->t_finish = timestamp;
     }
     else if (!strcmp (name, "release")) {
         int final;

--- a/src/modules/job-manager/job.h
+++ b/src/modules/job-manager/job.h
@@ -24,6 +24,8 @@ struct job {
     int urgency;
     int64_t priority;
     double t_submit;
+    double t_alloc;         // SCHED->RUN transtion
+    double t_finish;        // RUN->CLEANUP transition
     int flags;
     json_t *jobspec_redacted;
     int eventlog_seq;           // eventlog count / sequence number

--- a/src/modules/job-manager/wait.c
+++ b/src/modules/job-manager/wait.c
@@ -13,9 +13,7 @@
  * Handle flux_job_wait (id) requests.
  *
  * The call blocks until the job transitions to INACTIVE, then
- * a summary of the job result is returned:
- * - a boolean success
- * - a textual error string
+ * a summary of the job result is returned.
  *
  * The event that transitions a waitable job to the CLEANUP state is
  * captured in job->end_event.  RFC 21 dictates it must be a finish event
@@ -82,11 +80,12 @@ static void wait_respond (struct waitjob *wait,
         goto error;
     if (flux_respond_pack (h,
                            msg,
-                           "{s:I s:O}",
-                           "id",
-                           job->id,
-                           "event",
-                           job->end_event) < 0)
+                           "{s:I s:f s:f s:f s:O}",
+                           "id", job->id,
+                           "t_submit", job->t_submit,
+                           "t_alloc", job->t_alloc,
+                           "t_finish", job->t_finish,
+                           "event", job->end_event) < 0)
         flux_log_error (h, "wait_respond id=%ju", (uintmax_t)job->id);
     return;
 error:

--- a/t/t2208-job-manager-wait.t
+++ b/t/t2208-job-manager-wait.t
@@ -113,19 +113,19 @@ test_expect_success "wait FLUX_JOBID_ANY fails with no waitable jobs" '
 test_expect_success "wait works when job terminated by exception" '
 	JOBID=$(flux mini submit --flags waitable sleep 120) &&
 	flux job raise --severity=0 ${JOBID} my-exception-message &&
-	! flux job wait ${JOBID} 2>exception.out &&
+	test_must_fail flux job wait ${JOBID} 2>exception.out &&
 	grep my-exception-message exception.out
 '
 
 test_expect_success "wait works when job tasks exit 1" '
 	JOBID=$(flux mini submit --flags waitable /bin/false) &&
-	! flux job wait ${JOBID} 2>false.out &&
+	test_must_fail flux job wait ${JOBID} 2>false.out &&
 	grep exit false.out
 '
 
 test_expect_success "wait works when job tasks exit 1" '
 	JOBID=$(flux mini submit --flags waitable /bin/false) &&
-	! flux job wait ${JOBID} 2>false.out &&
+	test_must_fail flux job wait ${JOBID} 2>false.out &&
 	grep exit false.out
 '
 


### PR DESCRIPTION
Peeled off of  #3741 (or rather a work in progress based on that).

This updates the job manager `wait` RPC to return the terminating event rather than the interpreted (success, error string) tuple.  Existing API interfaces are unchanged -  the interpretation moves from the job manager to libjob.  A new function, `flux_job_wait_get_exit_code()` interprets the terminating event into a reasonable proxy exit code for the job.

Then this gets used in the `flux job wait` command, which now returns the highest exit code of the tasks, which I think came up as a deficiency when this fast exec stuff was originally discussed.  The `flux_job_wait()` interface will be used by `flux job exec` if that goes in, but that's a different PR.