### PR TITLE
Globally drop unnecessary 0MQ includes

### DIFF
--- a/src/bindings/lua/zmsg-lua.h
+++ b/src/bindings/lua/zmsg-lua.h
@@ -12,7 +12,6 @@
 #define HAVE_ZMSG_LUA_H
 
 #include <lua.h>
-#include <zmq.h>
 #include <jansson.h>
 
 #include "flux/core.h"

--- a/src/cmd/builtin/proxy.c
+++ b/src/cmd/builtin/proxy.c
@@ -26,7 +26,6 @@
 #include <stdbool.h>
 #include <argz.h>
 #include <glob.h>
-#include <czmq.h>
 #include <inttypes.h>
 
 #include "src/common/libutil/cleanup.h"

--- a/src/common/libflux/ev_flux.c
+++ b/src/common/libflux/ev_flux.c
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
-#include <zmq.h>
+#include <stddef.h>
 #include <stdbool.h>
 
 #include "handle.h"

--- a/src/modules/job-manager/plugins/dependency-after.c
+++ b/src/modules/job-manager/plugins/dependency-after.c
@@ -16,11 +16,11 @@
 #include "config.h"
 #endif
 #include <jansson.h>
-#include <czmq.h>
 #include <flux/core.h>
 #include <flux/jobtap.h>
 
 #include "src/common/libutil/iterators.h"
+#include "src/common/libczmqcontainers/czmq_containers.h"
 
 /* Types of "after*" dependencies:
  */


### PR DESCRIPTION
Problem: czmq.h and/or zmq.h was included in a number of locations
that was unnecessary.

Solution: Remove the unnecessary includes.  In some cases, replace with
include of czmq_containers.h or other appropriate headers that czmq/zmq
happened to include.

Fixes #3624