### PR TITLE
python: fix version requirement in jobspec validator plugin

### DIFF
--- a/src/bindings/python/flux/job/validator/plugins/jobspec.py
+++ b/src/bindings/python/flux/job/validator/plugins/jobspec.py
@@ -26,21 +26,25 @@ class Validator(ValidatorPlugin):
         parser.add_argument(
             "--require-version",
             metavar="V",
-            type=int,
             default=1,
-            help="Require jobspec version V",
+            help="Require jobspec version V (or any)",
         )
 
     def configure(self, args):
-        self.require_version = args.require_version
-        if args.require_version < 1:
-            raise ValueError(
-                f"Required jobspec version too low: {args.require_version} is < 1"
-            )
-        elif args.require_version > 1:
-            raise ValueError(
-                f"Required jobspec version too high: {args.require_version} is > 1"
-            )
+        try:
+            self.require_version = int(args.require_version)
+            if self.require_version < 1:
+                raise ValueError(
+                    f"Required jobspec version too low: {args.require_version} is < 1"
+                )
+            elif self.require_version > 1:
+                raise ValueError(
+                    f"Required jobspec version too high: {args.require_version} is > 1"
+                )
+        except ValueError:
+            if args.require_version != "any":
+                raise ValueError(f"Invalid argument to --require-version")
+            self.require_version = None
 
     def validate(self, args):
-        validate_jobspec(json.dumps(args.jobspec))
+        validate_jobspec(json.dumps(args.jobspec), self.require_version)

--- a/src/cmd/flux-job-validator.py
+++ b/src/cmd/flux-job-validator.py
@@ -86,6 +86,8 @@ def main():
         LOGGER.critical(exc)
         sys.exit(1)
 
+    exitcode = 0
+
     # Ensure stdin is line buffered, with proper encoding
     for line in os.fdopen(
         sys.stdin.fileno(), "r", buffering=1, encoding="utf-8", errors="surrogateescape"
@@ -100,9 +102,15 @@ def main():
                     "urgency": 16,
                 }
             )
+            #  In --jobspec-only mode, exit with nonzero exit code
+            #   if validation failed:
+            if result.errnum != 0:
+                exitcode = 1
         else:
             result = validator.validate(line)
         print(result, flush=True)
+
+    sys.exit(exitcode)
 
 
 if __name__ == "__main__":

--- a/t/t2100-job-ingest.t
+++ b/t/t2100-job-ingest.t
@@ -55,8 +55,10 @@ test_expect_success 'job-ingest: job-ingest fails with bad option' '
 	test_must_fail flux module load job-ingest badopt=xyz
 '
 
-test_expect_success 'job-ingest: load job-ingest' '
-	ingest_module load validator-plugins=jobspec
+test_expect_success 'job-ingest: load job-ingest: require-version=any' '
+	ingest_module load \
+		validator-plugins=jobspec \
+		validator-args=--require-version=any
 '
 
 test_expect_success HAVE_JQ 'job-ingest: dummy job-manager has expected max_jobid' '

--- a/t/t2110-job-ingest-validator.t
+++ b/t/t2110-job-ingest-validator.t
@@ -85,19 +85,19 @@ test_expect_success HAVE_JQ 'flux job-validator --feasibility-service works ' '
 			--feasibility-service=kvs.ping \
 		| jq -e ".errnum == 0"
 '
-test_expect_success 'job-ingest: valid jobspecs accepted' '
+test_expect_success 'job-ingest: v1 jobspecs accepted by default' '
+	test_valid ${JOBSPEC}/valid_v1/*
+'
+test_expect_success 'job-ingest: test jobspec validator with any version' '
+	ingest_module reload \
+		validator-plugins=jobspec \
+		validator-args="--require-version=any"
+'
+test_expect_success 'job-ingest: all valid jobspecs accepted' '
 	test_valid ${JOBSPEC}/valid/*
 '
 test_expect_success 'job-ingest: invalid jobs rejected' '
 	test_invalid ${JOBSPEC}/invalid/*
-'
-test_expect_success 'job-ingest: test jobspec validator with version 1' '
-	ingest_module reload \
-		validator-plugins=jobspec \
-		validator-args="--require-version,1"
-'
-test_expect_success 'job-ingest: v1 jobspecs accepted with v1 requirement' '
-	test_valid ${JOBSPEC}/valid_v1/*
 '
 test_expect_success 'job-ingest: test python jsonschema validator' '
 	ingest_module reload \

--- a/t/t2110-job-ingest-validator.t
+++ b/t/t2110-job-ingest-validator.t
@@ -63,6 +63,11 @@ test_expect_success 'flux job-validator --require-version rejects invalid arg' '
 		test_expect_code 1 \
 		flux job-validator --jobspec-only --require-version=0
 '
+test_expect_success HAVE_JQ 'flux job-validator rejects non-V1 jobspec' '
+	flux mini run --dry-run hostname | jq -c ".version = 2" | \
+		test_expect_code 1 \
+		flux job-validator --jobspec-only --require-version=1
+'
 test_expect_success 'flux job-validator --schema rejects invalid arg' '
 	flux mini run --dry-run hostname | \
 		test_expect_code 1 \

--- a/t/t2110-job-ingest-validator.t
+++ b/t/t2110-job-ingest-validator.t
@@ -56,15 +56,15 @@ test_expect_success 'flux job-validator errors on invalid plugin' '
 	test_expect_code 1 flux job-validator --plugin=/tmp </dev/null
 '
 test_expect_success 'flux job-validator --require-version rejects invalid arg' '
-	flux mini run hostname | \
+	flux mini run --dry-run hostname | \
 		test_expect_code 1 \
 		flux job-validator --jobspec-only --require-version=99 &&
-	flux mini run hostname | \
+	flux mini run --dry-run hostname | \
 		test_expect_code 1 \
 		flux job-validator --jobspec-only --require-version=0
 '
 test_expect_success 'flux job-validator --schema rejects invalid arg' '
-	flux mini run hostname | \
+	flux mini run --dry-run hostname | \
 		test_expect_code 1 \
 		flux job-validator --jobspec-only \
 			--plugins=schema \


### PR DESCRIPTION
This PR addresses issue #3772 -- the `jobspec` `flux job-validator` plugin was supposed to be validating V1 jobspec only by default (and with `--require-version=1`), but unfortunately was completely ignoring this option.

This PR fixes the bug in the plugin, and also adds support for `--require-version=any` for disabling the jobspec version check (which is currently the default)

Some tests needed to updated now that V1 is the default requirement.