### PR TITLE
Consistently use CFLAGS / LIBS in Makefiles

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -355,13 +355,12 @@ AM_LDFLAGS = \
 AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
-	-I$(top_builddir)/src/common/libflux \
-	$(LIBUUID_CFLAGS)
+	-I$(top_builddir)/src/common/libflux
 
 LDADD = \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la \
-	$(LIBUUID_CFLAGS) $(LIBPTHREAD)
+	$(LIBPTHREAD)
 
 check_PROGRAMS = \
 	man3/topen \

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -356,12 +356,12 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
 	-I$(top_builddir)/src/common/libflux \
-	$(ZMQ_CFLAGS) $(LIBUUID_CFLAGS)
+	$(LIBUUID_CFLAGS)
 
 LDADD = \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la \
-	$(ZMQ_LIBS) $(LIBUUID_CFLAGS) $(LIBPTHREAD)
+	$(LIBUUID_CFLAGS) $(LIBPTHREAD)
 
 check_PROGRAMS = \
 	man3/topen \

--- a/src/bindings/lua/Makefile.am
+++ b/src/bindings/lua/Makefile.am
@@ -1,5 +1,4 @@
 AM_CFLAGS =	$(WARNING_CFLAGS) $(CODE_COVERAGE_CFLAGS) \
-		$(LIBUUID_CFLAGS) \
 		-Wno-parentheses -Wno-error=parentheses
 AM_LDFLAGS =	$(CODE_COVERAGE_LIBS)
 AM_CPPFLAGS =	\
@@ -44,7 +43,7 @@ luamod_ldflags = \
 luamod_libadd = \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la \
-	$(LUA_LIB) $(LIBUUID_LIBS)
+	$(LUA_LIB)
 
 flux_la_LDFLAGS = \
 	$(luamod_ldflags)

--- a/src/bindings/lua/Makefile.am
+++ b/src/bindings/lua/Makefile.am
@@ -1,5 +1,5 @@
 AM_CFLAGS =	$(WARNING_CFLAGS) $(CODE_COVERAGE_CFLAGS) \
-		$(ZMQ_CFLAGS) $(LIBUUID_CFLAGS) \
+		$(LIBUUID_CFLAGS) \
 		-Wno-parentheses -Wno-error=parentheses
 AM_LDFLAGS =	$(CODE_COVERAGE_LIBS)
 AM_CPPFLAGS =	\
@@ -44,7 +44,7 @@ luamod_ldflags = \
 luamod_libadd = \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la \
-	$(LUA_LIB) $(ZMQ_LIBS) $(LIBUUID_LIBS)
+	$(LUA_LIB) $(LIBUUID_LIBS)
 
 flux_la_LDFLAGS = \
 	$(luamod_ldflags)

--- a/src/bindings/python/_flux/Makefile.am
+++ b/src/bindings/python/_flux/Makefile.am
@@ -4,7 +4,6 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir) -I$(top_srcdir)/src/include \
 	-I$(top_srcdir)/src/common/libflux \
 	-I$(top_builddir)/src/common/libflux \
-	$(ZMQ_CFLAGS) \
 	$(LIBUUID_CFLAGS) \
 	$(PYTHON_CPPFLAGS) \
 	$(CODE_COVERAGE_CFLAGS)
@@ -20,7 +19,7 @@ common_libs = \
 	$(top_builddir)/src/common/libflux-core.la \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libdebugged/libdebugged.la \
-	$(ZMQ_LIBS) $(LIBUUID_LIBS) \
+	$(LIBUUID_LIBS) \
 	$(PYTHON_LDFLAGS)
 
 PREPROC_FLAGS = \

--- a/src/bindings/python/_flux/Makefile.am
+++ b/src/bindings/python/_flux/Makefile.am
@@ -4,7 +4,6 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir) -I$(top_srcdir)/src/include \
 	-I$(top_srcdir)/src/common/libflux \
 	-I$(top_builddir)/src/common/libflux \
-	$(LIBUUID_CFLAGS) \
 	$(PYTHON_CPPFLAGS) \
 	$(CODE_COVERAGE_CFLAGS)
 
@@ -19,7 +18,6 @@ common_libs = \
 	$(top_builddir)/src/common/libflux-core.la \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libdebugged/libdebugged.la \
-	$(LIBUUID_LIBS) \
 	$(PYTHON_LDFLAGS)
 
 PREPROC_FLAGS = \

--- a/src/broker/Makefile.am
+++ b/src/broker/Makefile.am
@@ -72,7 +72,8 @@ flux_broker_LDADD = \
 	$(ZMQ_LIBS) \
 	$(LIBUUID_LIBS) \
 	$(LIBSODIUM_LIBS) \
-	$(PMIX_LIBS)
+	$(PMIX_LIBS) \
+	$(LIBDL)
 
 flux_broker_LDFLAGS =
 

--- a/src/broker/Makefile.am
+++ b/src/broker/Makefile.am
@@ -69,6 +69,7 @@ flux_broker_LDADD = \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-optparse.la \
 	$(ZMQ_LIBS) \
+	$(LIBUUID_LIBS) \
 	$(PMIX_LIBS)
 
 flux_broker_LDFLAGS =

--- a/src/broker/Makefile.am
+++ b/src/broker/Makefile.am
@@ -12,6 +12,7 @@ AM_CPPFLAGS = \
 	$(PMIX_CFLAGS) \
 	$(ZMQ_CFLAGS) \
 	$(LIBUUID_CFLAGS) \
+	$(LIBSODIUM_CFLAGS) \
 	$(VALGRIND_CFLAGS)
 
 fluxcmd_PROGRAMS = flux-broker
@@ -70,6 +71,7 @@ flux_broker_LDADD = \
 	$(top_builddir)/src/common/libflux-optparse.la \
 	$(ZMQ_LIBS) \
 	$(LIBUUID_LIBS) \
+	$(LIBSODIUM_LIBS) \
 	$(PMIX_LIBS)
 
 flux_broker_LDFLAGS =

--- a/src/broker/Makefile.am
+++ b/src/broker/Makefile.am
@@ -68,6 +68,7 @@ flux_broker_LDADD = \
 	$(top_builddir)/src/common/libpmi/libpmi_client.la \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-optparse.la \
+	$(ZMQ_LIBS) \
 	$(PMIX_LIBS)
 
 flux_broker_LDFLAGS =
@@ -87,6 +88,7 @@ test_ldadd = \
 	$(top_builddir)/src/common/libpmi/libpmi_client.la \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libtap/libtap.la \
+	$(ZMQ_LIBS) \
 	$(PMIX_LIBS)
 
 test_ldflags = \

--- a/src/broker/Makefile.am
+++ b/src/broker/Makefile.am
@@ -13,6 +13,7 @@ AM_CPPFLAGS = \
 	$(ZMQ_CFLAGS) \
 	$(LIBUUID_CFLAGS) \
 	$(LIBSODIUM_CFLAGS) \
+	$(JANSSON_CFLAGS) \
 	$(VALGRIND_CFLAGS)
 
 fluxcmd_PROGRAMS = flux-broker
@@ -72,6 +73,7 @@ flux_broker_LDADD = \
 	$(ZMQ_LIBS) \
 	$(LIBUUID_LIBS) \
 	$(LIBSODIUM_LIBS) \
+	$(JANSSON_LIBS) \
 	$(PMIX_LIBS) \
 	$(LIBDL)
 
@@ -93,6 +95,7 @@ test_ldadd = \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libtap/libtap.la \
 	$(ZMQ_LIBS) \
+	$(JANSSON_LIBS) \
 	$(PMIX_LIBS)
 
 test_ldflags = \

--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -10,7 +10,6 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir)/src/include \
 	-I$(top_builddir)/src/common/libflux \
 	$(FLUX_SECURITY_CFLAGS) \
-	$(LIBUUID_CFLAGS) \
 	$(LIBSODIUM_CFLAGS) \
 	$(HWLOC_CFLAGS) \
 	$(PMIX_CFLAGS)
@@ -22,7 +21,6 @@ fluxcmd_ldadd = \
 	$(top_builddir)/src/common/libflux-core.la \
 	$(top_builddir)/src/common/libflux-optparse.la \
 	$(FLUX_SECURITY_LIBS) \
-	$(LIBUUID_LIBS) \
 	$(LIBPTHREAD) \
 	$(LIBDL) \
 	$(HWLOC_LIBS) \

--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -21,7 +21,6 @@ fluxcmd_ldadd = \
 	$(top_builddir)/src/common/libflux-optparse.la \
 	$(FLUX_SECURITY_LIBS) \
 	$(LIBPTHREAD) \
-	$(LIBDL) \
 	$(HWLOC_LIBS)
 
 LDADD = $(fluxcmd_ldadd)

--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -11,7 +11,8 @@ AM_CPPFLAGS = \
 	-I$(top_builddir)/src/common/libflux \
 	$(FLUX_SECURITY_CFLAGS) \
 	$(HWLOC_CFLAGS) \
-	$(PMIX_CFLAGS)
+	$(PMIX_CFLAGS) \
+	$(JANSSON_CFLAGS)
 
 fluxcmd_ldadd = \
 	$(top_builddir)/src/common/libkvs/libkvs.la \
@@ -21,7 +22,8 @@ fluxcmd_ldadd = \
 	$(top_builddir)/src/common/libflux-optparse.la \
 	$(FLUX_SECURITY_LIBS) \
 	$(LIBPTHREAD) \
-	$(HWLOC_LIBS)
+	$(HWLOC_LIBS) \
+	$(JANSSON_LIBS)
 
 LDADD = $(fluxcmd_ldadd)
 

--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -23,7 +23,6 @@ fluxcmd_ldadd = \
 	$(top_builddir)/src/common/libflux-core.la \
 	$(top_builddir)/src/common/libflux-optparse.la \
 	$(FLUX_SECURITY_LIBS) \
-	$(ZMQ_LIBS) \
 	$(LIBUUID_LIBS) \
 	$(LIBPTHREAD) \
 	$(LIBDL) \
@@ -104,8 +103,7 @@ flux_terminus_LDADD = \
 	$(top_builddir)/src/common/libterminus/libterminus.la \
 	$(top_builddir)/src/common/libidset/libidset.la \
 	$(top_builddir)/src/common/libutil/libutil.la \
-	$(fluxcmd_ldadd) \
-	$(ZMQ_LIBS)
+	$(fluxcmd_ldadd)
 
 flux_R_LDADD = \
 	$(fluxcmd_ldadd) \
@@ -114,7 +112,6 @@ flux_R_LDADD = \
 	$(top_builddir)/src/common/libhostlist/libhostlist.la \
 	$(top_builddir)/src/common/libidset/libidset.la \
 	$(top_builddir)/src/common/libutil/libutil.la \
-	$(ZMQ_LIBS) \
 	$(HWLOC_LIBS) \
 	$(JANSSON_LIBS)
 

--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -10,7 +10,6 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir)/src/include \
 	-I$(top_builddir)/src/common/libflux \
 	$(FLUX_SECURITY_CFLAGS) \
-	$(LIBSODIUM_CFLAGS) \
 	$(HWLOC_CFLAGS) \
 	$(PMIX_CFLAGS)
 
@@ -23,8 +22,7 @@ fluxcmd_ldadd = \
 	$(FLUX_SECURITY_LIBS) \
 	$(LIBPTHREAD) \
 	$(LIBDL) \
-	$(HWLOC_LIBS) \
-	$(LIBSODIUM_LIBS)
+	$(HWLOC_LIBS)
 
 LDADD = $(fluxcmd_ldadd)
 

--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -10,7 +10,6 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir)/src/include \
 	-I$(top_builddir)/src/common/libflux \
 	$(FLUX_SECURITY_CFLAGS) \
-	$(ZMQ_CFLAGS) \
 	$(LIBUUID_CFLAGS) \
 	$(LIBSODIUM_CFLAGS) \
 	$(HWLOC_CFLAGS) \
@@ -115,7 +114,13 @@ flux_R_LDADD = \
 	$(HWLOC_LIBS) \
 	$(JANSSON_LIBS)
 
+flux_keygen_CPPFLAGS = \
+	$(AM_CPPFLAGS) \
+	$(ZMQ_CFLAGS)
 
+flux_keygen_LDADD = \
+	$(fluxcmd_ldadd) \
+	$(ZMQ_LIBS)
 #
 # Automatically build list of flux(1) builtins from
 #  builtin/*.c:

--- a/src/cmd/flux-module.c
+++ b/src/cmd/flux-module.c
@@ -13,7 +13,6 @@
 #endif
 #include <stdio.h>
 #include <getopt.h>
-#include <dlfcn.h>
 #include <flux/core.h>
 #include <flux/optparse.h>
 #include <jansson.h>

--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -83,7 +83,7 @@ libflux_optparse_la_LIBADD = \
 	$(builddir)/libczmqcontainers/libczmqcontainers.la \
 	$(builddir)/liblsd/liblsd.la \
 	$(builddir)/libutil/fsd.lo \
-	$(ZMQ_LIBS) $(LIBUUID_LIBS) $(LIBPTHREAD)
+	$(LIBUUID_LIBS) $(LIBPTHREAD)
 libflux_optparse_la_LDFLAGS = \
 	-Wl,--version-script=$(srcdir)/libflux-optparse.map \
 	-version-info @LIBFLUX_OPTPARSE_VERSION_INFO@ \

--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -83,7 +83,7 @@ libflux_optparse_la_LIBADD = \
 	$(builddir)/libczmqcontainers/libczmqcontainers.la \
 	$(builddir)/liblsd/liblsd.la \
 	$(builddir)/libutil/fsd.lo \
-	$(LIBUUID_LIBS) $(LIBPTHREAD)
+	$(LIBPTHREAD)
 libflux_optparse_la_LDFLAGS = \
 	-Wl,--version-script=$(srcdir)/libflux-optparse.map \
 	-version-info @LIBFLUX_OPTPARSE_VERSION_INFO@ \

--- a/src/common/libcontent/Makefile.am
+++ b/src/common/libcontent/Makefile.am
@@ -8,8 +8,7 @@ AM_LDFLAGS = \
 AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
-	-I$(top_builddir)/src/common/libflux \
-	$(ZMQ_CFLAGS)
+	-I$(top_builddir)/src/common/libflux
 
 noinst_LTLIBRARIES = libcontent.la
 

--- a/src/common/libeventlog/Makefile.am
+++ b/src/common/libeventlog/Makefile.am
@@ -8,8 +8,7 @@ AM_LDFLAGS = \
 AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
-	-I$(top_builddir)/src/common/libflux \
-	$(ZMQ_CFLAGS)
+	-I$(top_builddir)/src/common/libflux
 
 noinst_LTLIBRARIES = libeventlog.la
 libeventlog_la_SOURCES = \

--- a/src/common/libflux/Makefile.am
+++ b/src/common/libflux/Makefile.am
@@ -13,7 +13,6 @@ AM_CPPFLAGS = \
 	-I$(top_builddir)/src/common/libflux \
 	$(JANSSON_CFLAGS) \
 	$(ZMQ_CFLAGS) \
-	$(LIBUUID_CFLAGS) \
 	$(LIBSODIUM_CFLAGS)
 
 installed_conf_cppflags = \

--- a/src/common/libflux/Makefile.am
+++ b/src/common/libflux/Makefile.am
@@ -177,7 +177,8 @@ test_ldadd = \
 	$(LIBUUID_LIBS) \
 	$(JANSSON_LIBS) \
 	$(LIBPTHREAD) \
-	$(LIBSODIUM_LIBS)
+	$(LIBSODIUM_LIBS) \
+	$(LIBDL)
 
 test_cppflags = \
         -I$(top_srcdir)/src/common/libtap \
@@ -198,105 +199,105 @@ T_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
 
 test_message_t_SOURCES = test/message.c
 test_message_t_CPPFLAGS = $(test_cppflags)
-test_message_t_LDADD = $(test_ldadd) $(LIBDL)
+test_message_t_LDADD = $(test_ldadd)
 
 test_msglist_t_SOURCES = test/msglist.c
 test_msglist_t_CPPFLAGS = $(test_cppflags)
-test_msglist_t_LDADD = $(test_ldadd) $(LIBDL)
+test_msglist_t_LDADD = $(test_ldadd)
 
 test_event_t_SOURCES = test/event.c
 test_event_t_CPPFLAGS = $(test_cppflags)
-test_event_t_LDADD = $(test_ldadd) $(LIBDL)
+test_event_t_LDADD = $(test_ldadd)
 
 test_tagpool_t_SOURCES = test/tagpool.c
 test_tagpool_t_CPPFLAGS = $(test_cppflags)
-test_tagpool_t_LDADD = $(test_ldadd) $(LIBDL)
+test_tagpool_t_LDADD = $(test_ldadd)
 
 test_request_t_SOURCES = test/request.c
 test_request_t_CPPFLAGS = $(test_cppflags)
-test_request_t_LDADD = $(test_ldadd) $(LIBDL)
+test_request_t_LDADD = $(test_ldadd)
 
 test_response_t_SOURCES = test/response.c
 test_response_t_CPPFLAGS = $(test_cppflags)
-test_response_t_LDADD = $(test_ldadd) $(LIBDL)
+test_response_t_LDADD = $(test_ldadd)
 
 test_reactor_t_SOURCES = test/reactor.c
 test_reactor_t_CPPFLAGS = $(test_cppflags)
-test_reactor_t_LDADD = $(test_ldadd) $(LIBDL)
+test_reactor_t_LDADD = $(test_ldadd)
 
 test_future_t_SOURCES = test/future.c
 test_future_t_CPPFLAGS = $(test_cppflags)
-test_future_t_LDADD = $(test_ldadd) $(LIBDL)
+test_future_t_LDADD = $(test_ldadd)
 
 test_composite_future_t_SOURCES = test/composite_future.c
 test_composite_future_t_CPPFLAGS = $(test_cppflags)
-test_composite_future_t_LDADD = $(test_ldadd) $(LIBDL)
+test_composite_future_t_LDADD = $(test_ldadd)
 
 test_conf_t_SOURCES = test/conf.c
 test_conf_t_CPPFLAGS = $(test_cppflags)
-test_conf_t_LDADD = $(test_ldadd) $(LIBDL)
+test_conf_t_LDADD = $(test_ldadd)
 
 test_buffer_t_SOURCES = test/buffer.c
 test_buffer_t_CPPFLAGS = $(test_cppflags)
-test_buffer_t_LDADD = $(test_ldadd) $(LIBDL)
+test_buffer_t_LDADD = $(test_ldadd)
 
 test_handle_t_SOURCES = test/handle.c
 test_handle_t_CPPFLAGS = $(test_cppflags)
-test_handle_t_LDADD = $(test_ldadd) $(LIBDL)
+test_handle_t_LDADD = $(test_ldadd)
 
 test_msg_handler_t_SOURCES = test/msg_handler.c
 test_msg_handler_t_CPPFLAGS = $(test_cppflags)
-test_msg_handler_t_LDADD = $(test_ldadd) $(LIBDL)
+test_msg_handler_t_LDADD = $(test_ldadd)
 
 test_version_t_SOURCES = test/version.c
 test_version_t_CPPFLAGS = $(test_cppflags)
-test_version_t_LDADD = $(test_ldadd) $(LIBDL)
+test_version_t_LDADD = $(test_ldadd)
 
 test_rpc_t_SOURCES = test/rpc.c
 test_rpc_t_CPPFLAGS = $(test_cppflags)
-test_rpc_t_LDADD = $(test_ldadd) $(LIBDL)
+test_rpc_t_LDADD = $(test_ldadd)
 
 test_rpc_chained_t_SOURCES = test/rpc_chained.c
 test_rpc_chained_t_CPPFLAGS = $(test_cppflags)
-test_rpc_chained_t_LDADD = $(test_ldadd) $(LIBDL)
+test_rpc_chained_t_LDADD = $(test_ldadd)
 
 test_dispatch_t_SOURCES = test/dispatch.c
 test_dispatch_t_CPPFLAGS = $(test_cppflags)
-test_dispatch_t_LDADD = $(test_ldadd) $(LIBDL)
+test_dispatch_t_LDADD = $(test_ldadd)
 
 test_log_t_SOURCES = test/log.c
 test_log_t_CPPFLAGS = $(test_cppflags)
-test_log_t_LDADD = $(test_ldadd) $(LIBDL)
+test_log_t_LDADD = $(test_ldadd)
 
 test_reactor_loop_t_SOURCES = test/reactor_loop.c
 test_reactor_loop_t_CPPFLAGS = $(test_cppflags)
-test_reactor_loop_t_LDADD = $(test_ldadd) $(LIBDL)
+test_reactor_loop_t_LDADD = $(test_ldadd)
 
 test_rpc_security_t_SOURCES = test/rpc_security.c
 test_rpc_security_t_CPPFLAGS = $(test_cppflags)
-test_rpc_security_t_LDADD = $(test_ldadd) $(LIBDL)
+test_rpc_security_t_LDADD = $(test_ldadd)
 
 test_panic_t_SOURCES = test/panic.c
 test_panic_t_CPPFLAGS = $(test_cppflags)
-test_panic_t_LDADD = $(test_ldadd) $(LIBDL)
+test_panic_t_LDADD = $(test_ldadd)
 
 test_attr_t_SOURCES = test/attr.c
 test_attr_t_CPPFLAGS = $(test_cppflags)
-test_attr_t_LDADD = $(test_ldadd) $(LIBDL)
+test_attr_t_LDADD = $(test_ldadd)
 
 test_sync_t_SOURCES = test/sync.c
 test_sync_t_CPPFLAGS = $(test_cppflags)
-test_sync_t_LDADD = $(test_ldadd) $(LIBDL)
+test_sync_t_LDADD = $(test_ldadd)
 
 test_disconnect_t_SOURCES = test/disconnect.c
 test_disconnect_t_CPPFLAGS = $(test_cppflags)
-test_disconnect_t_LDADD = $(test_ldadd) $(LIBDL)
+test_disconnect_t_LDADD = $(test_ldadd)
 
 test_module_t_SOURCES = test/module.c
 test_module_t_CPPFLAGS = $(test_cppflags) \
 	-DFAKE1=\"$(abs_builddir)/test/.libs/module_fake1.so\" \
 	-DFAKE2=\"$(abs_builddir)/test/.libs/module_fake2.so\"
-test_module_t_LDADD = $(test_ldadd) $(LIBDL)
+test_module_t_LDADD = $(test_ldadd)
 
 test_module_fake1_la_SOURCES = test/module_fake1.c
 test_module_fake1_la_CPPFLAGS = $(test_cppflags)
@@ -308,14 +309,14 @@ test_module_fake2_la_LDFLAGS = $(fluxmod_ldflags) -module -rpath /nowhere
 
 test_plugin_t_SOURCES = test/plugin.c
 test_plugin_t_CPPFLAGS = $(test_cppflags)
-test_plugin_t_LDADD = $(test_ldadd) $(LIBDL)
+test_plugin_t_LDADD = $(test_ldadd)
 
 test_plugin_foo_la_SOURCES = test/plugin_foo.c
 test_plugin_foo_la_CPPFLAGS = $(test_cppflags)
 test_plugin_foo_la_LDFLAGS = -module -rpath /nowhere
-test_plugin_foo_la_LIBADD = $(test_ldadd) $(LIBDL)
+test_plugin_foo_la_LIBADD = $(test_ldadd)
 
 test_plugin_bar_la_SOURCES = test/plugin_bar.c
 test_plugin_bar_la_CPPFLAGS = $(test_cppflags)
 test_plugin_bar_la_LDFLAGS = -module -rpath /nowhere
-test_plugin_bar_la_LIBADD = $(test_ldadd) $(LIBDL)
+test_plugin_bar_la_LIBADD = $(test_ldadd)

--- a/src/common/libidset/Makefile.am
+++ b/src/common/libidset/Makefile.am
@@ -8,8 +8,7 @@ AM_LDFLAGS = \
 AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
-	-I$(top_builddir)/src/common/libflux \
-	$(ZMQ_CFLAGS)
+	-I$(top_builddir)/src/common/libflux
 
 noinst_LTLIBRARIES = libidset.la
 fluxinclude_HEADERS = idset.h
@@ -41,13 +40,11 @@ test_idset_t_CPPFLAGS = $(AM_CPPFLAGS)
 test_idset_t_LDADD = \
 	$(top_builddir)/src/common/libtap/libtap.la \
 	$(top_builddir)/src/common/libidset/libidset.la \
-	$(top_builddir)/src/common/libutil/libutil.la \
-	$(ZMQ_LIBS)
+	$(top_builddir)/src/common/libutil/libutil.la
 
 test_idsetutil_SOURCES = test/idsetutil.c
 test_idsetutil_CPPFLAGS = $(AM_CPPFLAGS)
 test_idsetutil_LDADD = \
 	$(top_builddir)/src/common/libtap/libtap.la \
 	$(top_builddir)/src/common/libidset/libidset.la \
-	$(top_builddir)/src/common/libutil/libutil.la \
-	$(ZMQ_LIBS)
+	$(top_builddir)/src/common/libutil/libutil.la

--- a/src/common/libioencode/Makefile.am
+++ b/src/common/libioencode/Makefile.am
@@ -8,8 +8,7 @@ AM_LDFLAGS = \
 AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
-	-I$(top_builddir)/src/common/libflux \
-	$(ZMQ_CFLAGS)
+	-I$(top_builddir)/src/common/libflux
 
 noinst_LTLIBRARIES = \
 	libioencode.la

--- a/src/common/libjob/Makefile.am
+++ b/src/common/libjob/Makefile.am
@@ -56,7 +56,6 @@ test_ldadd = \
 	$(LIBPTHREAD) \
 	$(LIBRT) \
         $(FLUX_SECURITY_LIBS) \
-	$(LIBDL) \
 	$(LIBSODIUM_LIBS)
 
 test_cppflags = \
@@ -65,12 +64,12 @@ test_cppflags = \
 
 test_job_t_SOURCES = test/job.c
 test_job_t_CPPFLAGS = $(test_cppflags)
-test_job_t_LDADD = $(test_ldadd) $(LIBDL)
+test_job_t_LDADD = $(test_ldadd)
 
 test_sign_none_t_SOURCES = test/sign_none.c
 test_sign_none_t_CPPFLAGS = $(test_cppflags)
-test_sign_none_t_LDADD = $(test_ldadd) $(LIBDL)
+test_sign_none_t_LDADD = $(test_ldadd)
 
 test_jobspec1_t_SOURCES = test/jobspec1.c
 test_jobspec1_t_CPPFLAGS = $(test_cppflags)
-test_jobspec1_t_LDADD = $(test_ldadd) $(LIBDL)
+test_jobspec1_t_LDADD = $(test_ldadd)

--- a/src/common/libjob/Makefile.am
+++ b/src/common/libjob/Makefile.am
@@ -9,7 +9,6 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
 	-I$(top_builddir)/src/common/libflux \
-	$(LIBUUID_CFLAGS) \
 	$(JANSSON_CFLAGS) \
 	$(FLUX_SECURITY_CFLAGS) \
 	$(LIBSODIUM_CFLAGS)
@@ -53,7 +52,6 @@ test_ldadd = \
         $(top_builddir)/src/common/libflux/libflux.la \
         $(top_builddir)/src/common/libflux-internal.la \
         $(top_builddir)/src/common/libtap/libtap.la \
-	$(LIBUUID_LIBS) \
 	$(JANSSON_LIBS) \
 	$(LIBPTHREAD) \
 	$(LIBRT) \

--- a/src/common/libjob/Makefile.am
+++ b/src/common/libjob/Makefile.am
@@ -9,7 +9,6 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
 	-I$(top_builddir)/src/common/libflux \
-	$(ZMQ_CFLAGS) \
 	$(LIBUUID_CFLAGS) \
 	$(JANSSON_CFLAGS) \
 	$(FLUX_SECURITY_CFLAGS) \
@@ -54,7 +53,6 @@ test_ldadd = \
         $(top_builddir)/src/common/libflux/libflux.la \
         $(top_builddir)/src/common/libflux-internal.la \
         $(top_builddir)/src/common/libtap/libtap.la \
-        $(ZMQ_LIBS) \
 	$(LIBUUID_LIBS) \
 	$(JANSSON_LIBS) \
 	$(LIBPTHREAD) \

--- a/src/common/libjob/Makefile.am
+++ b/src/common/libjob/Makefile.am
@@ -54,7 +54,6 @@ test_ldadd = \
         $(top_builddir)/src/common/libtap/libtap.la \
 	$(JANSSON_LIBS) \
 	$(LIBPTHREAD) \
-	$(LIBRT) \
         $(FLUX_SECURITY_LIBS) \
 	$(LIBSODIUM_LIBS)
 

--- a/src/common/libkvs/Makefile.am
+++ b/src/common/libkvs/Makefile.am
@@ -63,8 +63,7 @@ test_ldadd = \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libtap/libtap.la \
 	$(JANSSON_LIBS) \
-	$(LIBPTHREAD) \
-	$(LIBRT)
+	$(LIBPTHREAD)
 
 test_cppflags = \
 	$(AM_CPPFLAGS) \

--- a/src/common/libkvs/Makefile.am
+++ b/src/common/libkvs/Makefile.am
@@ -9,7 +9,6 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
 	-I$(top_builddir)/src/common/libflux \
-	$(ZMQ_CFLAGS) \
 	$(LIBUUID_CFLAGS)
 
 noinst_LTLIBRARIES = libkvs.la
@@ -63,7 +62,6 @@ test_ldadd = \
 	$(top_builddir)/src/common/libflux/libflux.la \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libtap/libtap.la \
-	$(ZMQ_LIBS) \
 	$(LIBUUID_LIBS) \
 	$(JANSSON_LIBS) \
 	$(LIBPTHREAD) \

--- a/src/common/libkvs/Makefile.am
+++ b/src/common/libkvs/Makefile.am
@@ -9,6 +9,7 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
 	-I$(top_builddir)/src/common/libflux \
+	$(JANSSON_CFLAGS) \
 	$(LIBSODIUM_CFLAGS)
 
 noinst_LTLIBRARIES = libkvs.la

--- a/src/common/libkvs/Makefile.am
+++ b/src/common/libkvs/Makefile.am
@@ -8,8 +8,7 @@ AM_LDFLAGS = \
 AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
-	-I$(top_builddir)/src/common/libflux \
-	$(LIBUUID_CFLAGS)
+	-I$(top_builddir)/src/common/libflux
 
 noinst_LTLIBRARIES = libkvs.la
 
@@ -62,7 +61,6 @@ test_ldadd = \
 	$(top_builddir)/src/common/libflux/libflux.la \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libtap/libtap.la \
-	$(LIBUUID_LIBS) \
 	$(JANSSON_LIBS) \
 	$(LIBPTHREAD) \
 	$(LIBRT) \

--- a/src/common/libkvs/Makefile.am
+++ b/src/common/libkvs/Makefile.am
@@ -64,8 +64,7 @@ test_ldadd = \
 	$(top_builddir)/src/common/libtap/libtap.la \
 	$(JANSSON_LIBS) \
 	$(LIBPTHREAD) \
-	$(LIBRT) \
-	$(LIBDL)
+	$(LIBRT)
 
 test_cppflags = \
 	$(AM_CPPFLAGS) \
@@ -73,43 +72,42 @@ test_cppflags = \
 
 test_kvs_t_SOURCES = test/kvs.c
 test_kvs_t_CPPFLAGS = $(test_cppflags)
-test_kvs_t_LDADD = $(test_ldadd) $(LIBDL)
+test_kvs_t_LDADD = $(test_ldadd)
 
 test_kvs_txn_t_SOURCES = test/kvs_txn.c
 test_kvs_txn_t_CPPFLAGS = $(test_cppflags)
-test_kvs_txn_t_LDADD = $(test_ldadd) $(LIBDL)
+test_kvs_txn_t_LDADD = $(test_ldadd)
 
 test_kvs_txn_compact_t_SOURCES = test/kvs_txn_compact.c
 test_kvs_txn_compact_t_CPPFLAGS = $(test_cppflags)
-test_kvs_txn_compact_t_LDADD = $(test_ldadd) $(LIBDL)
+test_kvs_txn_compact_t_LDADD = $(test_ldadd)
 
 test_kvs_lookup_t_SOURCES = test/kvs_lookup.c
 test_kvs_lookup_t_CPPFLAGS = $(test_cppflags)
 test_kvs_lookup_t_LDADD = \
 	$(top_builddir)/src/common/libkvs/kvs_txn.o \
-	$(test_ldadd) \
-	$(LIBDL)
+	$(test_ldadd)
 
 test_kvs_dir_t_SOURCES = test/kvs_dir.c
 test_kvs_dir_t_CPPFLAGS = $(test_cppflags)
-test_kvs_dir_t_LDADD = $(test_ldadd) $(LIBDL)
+test_kvs_dir_t_LDADD = $(test_ldadd)
 
 test_kvs_commit_t_SOURCES = test/kvs_commit.c
 test_kvs_commit_t_CPPFLAGS = $(test_cppflags)
-test_kvs_commit_t_LDADD = $(test_ldadd) $(LIBDL)
+test_kvs_commit_t_LDADD = $(test_ldadd)
 
 test_kvs_getroot_t_SOURCES = test/kvs_getroot.c
 test_kvs_getroot_t_CPPFLAGS = $(test_cppflags)
-test_kvs_getroot_t_LDADD = $(test_ldadd) $(LIBDL)
+test_kvs_getroot_t_LDADD = $(test_ldadd)
 
 test_treeobj_t_SOURCES = test/treeobj.c
 test_treeobj_t_CPPFLAGS = $(test_cppflags)
-test_treeobj_t_LDADD = $(test_ldadd) $(LIBDL)
+test_treeobj_t_LDADD = $(test_ldadd)
 
 test_kvs_copy_t_SOURCES = test/kvs_copy.c
 test_kvs_copy_t_CPPFLAGS = $(test_cppflags)
-test_kvs_copy_t_LDADD = $(test_ldadd) $(LIBDL)
+test_kvs_copy_t_LDADD = $(test_ldadd)
 
 test_kvs_util_t_SOURCES = test/kvs_util.c
 test_kvs_util_t_CPPFLAGS = $(test_cppflags)
-test_kvs_util_t_LDADD = $(test_ldadd) $(LIBDL)
+test_kvs_util_t_LDADD = $(test_ldadd)

--- a/src/common/libkvs/Makefile.am
+++ b/src/common/libkvs/Makefile.am
@@ -8,7 +8,8 @@ AM_LDFLAGS = \
 AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
-	-I$(top_builddir)/src/common/libflux
+	-I$(top_builddir)/src/common/libflux \
+	$(LIBSODIUM_CFLAGS)
 
 noinst_LTLIBRARIES = libkvs.la
 

--- a/src/common/liboptparse/Makefile.am
+++ b/src/common/liboptparse/Makefile.am
@@ -8,8 +8,7 @@ AM_LDFLAGS = \
 AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
-	-I$(top_builddir)/src/common/libflux \
-	$(ZMQ_CFLAGS)
+	-I$(top_builddir)/src/common/libflux
 
 noinst_LTLIBRARIES = liboptparse.la
 fluxinclude_HEADERS = optparse.h
@@ -37,4 +36,4 @@ test_optparse_t_LDADD = \
 	$(top_builddir)/src/common/liboptparse/liboptparse.la \
 	$(top_builddir)/src/common/libczmqcontainers/libczmqcontainers.la \
 	$(top_builddir)/src/common/libutil/libutil.la \
-	$(ZMQ_LIBS) $(LIBPTHREAD)
+	$(LIBPTHREAD)

--- a/src/common/libpmi/Makefile.am
+++ b/src/common/libpmi/Makefile.am
@@ -9,7 +9,6 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
 	-I$(top_builddir)/src/common/libflux \
-	$(ZMQ_CFLAGS) \
 	$(LIBUUID_CFLAGS)
 
 noinst_LTLIBRARIES = \

--- a/src/common/libpmi/Makefile.am
+++ b/src/common/libpmi/Makefile.am
@@ -8,8 +8,7 @@ AM_LDFLAGS = \
 AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
-	-I$(top_builddir)/src/common/libflux \
-	$(LIBUUID_CFLAGS)
+	-I$(top_builddir)/src/common/libflux
 
 noinst_LTLIBRARIES = \
 	libpmi_client.la \
@@ -58,7 +57,6 @@ test_ldadd = \
 	$(top_builddir)/src/common/libev/libev.la \
 	$(top_builddir)/src/common/libczmqcontainers/libczmqcontainers.la \
 	$(ZMQ_LIBS) \
-	$(LIBUUID_LIBS) \
 	$(JANSSON_LIBS) \
 	$(LIBPTHREAD) \
 	$(LIBRT) \

--- a/src/common/librlist/Makefile.am
+++ b/src/common/librlist/Makefile.am
@@ -8,7 +8,6 @@ AM_LDFLAGS = \
 AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
-	$(ZMQ_CFLAGS) \
 	$(JANSSON_CFLAGS) \
 	$(HWLOC_CFLAGS)
 
@@ -26,7 +25,6 @@ librlist_la_SOURCES = \
 test_ldadd = \
 	$(top_builddir)/src/common/libtap/libtap.la \
 	$(top_builddir)/src/common/libflux-internal.la \
-	$(ZMQ_LIBS) \
 	$(LIBPTHREAD) \
 	$(JANSSON_LIBS) \
 	$(HWLOC_LIBS)

--- a/src/common/librouter/Makefile.am
+++ b/src/common/librouter/Makefile.am
@@ -9,7 +9,6 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
 	-I$(top_builddir)/src/common/libflux \
-	$(ZMQ_CFLAGS) \
 	$(LIBUUID_CFLAGS)
 
 noinst_LTLIBRARIES = \

--- a/src/common/libschedutil/Makefile.am
+++ b/src/common/libschedutil/Makefile.am
@@ -8,8 +8,7 @@ AM_LDFLAGS = \
 AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
-	-I$(top_builddir)/src/common/libflux \
-	$(ZMQ_CFLAGS)
+	-I$(top_builddir)/src/common/libflux
 
 noinst_LTLIBRARIES = \
 	libschedutil.la
@@ -35,6 +34,3 @@ libschedutil_la_SOURCES = \
 	alloc.c \
 	free.h \
 	free.c
-
-libschedutil_la_LIBADD = \
-	$(ZMQ_LIBS)

--- a/src/common/libsubprocess/Makefile.am
+++ b/src/common/libsubprocess/Makefile.am
@@ -8,8 +8,7 @@ AM_LDFLAGS = \
 AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
-	-I$(top_builddir)/src/common/libflux \
-	$(ZMQ_CFLAGS)
+	-I$(top_builddir)/src/common/libflux
 
 noinst_LTLIBRARIES = \
 	libsubprocess.la

--- a/src/common/libterminus/Makefile.am
+++ b/src/common/libterminus/Makefile.am
@@ -9,7 +9,6 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
 	-I$(top_builddir)/src/common/libflux \
-	$(LIBUUID_CFLAGS) \
 	$(JANSSON_CFLAGS) \
 	$(FLUX_SECURITY_CFLAGS) \
 	$(LIBSODIUM_CFLAGS)

--- a/src/common/libterminus/Makefile.am
+++ b/src/common/libterminus/Makefile.am
@@ -9,7 +9,6 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
 	-I$(top_builddir)/src/common/libflux \
-	$(ZMQ_CFLAGS) \
 	$(LIBUUID_CFLAGS) \
 	$(JANSSON_CFLAGS) \
 	$(FLUX_SECURITY_CFLAGS) \

--- a/src/common/libterminus/Makefile.am
+++ b/src/common/libterminus/Makefile.am
@@ -10,8 +10,7 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir)/src/include \
 	-I$(top_builddir)/src/common/libflux \
 	$(JANSSON_CFLAGS) \
-	$(FLUX_SECURITY_CFLAGS) \
-	$(LIBSODIUM_CFLAGS)
+	$(FLUX_SECURITY_CFLAGS)
 
 noinst_LTLIBRARIES = libterminus.la
 

--- a/src/common/libutil/Makefile.am
+++ b/src/common/libutil/Makefile.am
@@ -191,16 +191,16 @@ test_lru_cache_t_CPPFLAGS = $(test_cppflags)
 test_lru_cache_t_LDADD = $(test_ldadd)
 
 test_blobref_t_SOURCES = test/blobref.c
-test_blobref_t_CPPFLAGS = $(test_cppflags) $(JANSSON_CFLAGS)
-test_blobref_t_LDADD = $(test_ldadd) $(JANSSON_LIBS)
+test_blobref_t_CPPFLAGS = $(test_cppflags)
+test_blobref_t_LDADD = $(test_ldadd)
 
 test_unlink_t_SOURCES = test/unlink.c
-test_unlink_t_CPPFLAGS = $(test_cppflags) $(JANSSON_CFLAGS)
-test_unlink_t_LDADD = $(test_ldadd) $(JANSSON_LIBS)
+test_unlink_t_CPPFLAGS = $(test_cppflags)
+test_unlink_t_LDADD = $(test_ldadd)
 
 test_cleanup_t_SOURCES = test/cleanup.c
-test_cleanup_t_CPPFLAGS = $(test_cppflags) $(JANSSON_CFLAGS)
-test_cleanup_t_LDADD = $(test_ldadd) $(JANSSON_LIBS)
+test_cleanup_t_CPPFLAGS = $(test_cppflags)
+test_cleanup_t_LDADD = $(test_ldadd)
 
 test_dirwalk_t_SOURCES = test/dirwalk.c
 test_dirwalk_t_CPPFLAGS = $(test_cppflags)

--- a/src/common/libutil/Makefile.am
+++ b/src/common/libutil/Makefile.am
@@ -2,7 +2,6 @@ AM_CFLAGS = \
 	$(WARNING_CFLAGS) \
 	$(CODE_COVERAGE_CFLAGS) \
 	$(ZMQ_CFLAGS) \
-	$(LIBUUID_CFLAGS) \
 	-Wno-strict-aliasing -Wno-error=strict-aliasing \
 	-Wno-parentheses -Wno-error=parentheses
 
@@ -132,7 +131,6 @@ test_ldadd = \
 	$(top_builddir)/src/common/libczmqcontainers/libczmqcontainers.la \
 	$(top_builddir)/src/common/libccan/libccan.la \
 	$(ZMQ_LIBS) \
-	$(LIBUUID_LIBS) \
 	$(LIBPTHREAD) \
 	$(LIBRT) \
 	$(JANSSON_LIBS)

--- a/src/connectors/local/Makefile.am
+++ b/src/connectors/local/Makefile.am
@@ -9,7 +9,6 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
 	-I$(top_builddir)/src/common/libflux \
-	$(ZMQ_CFLAGS) \
 	$(LIBUUID_CFLAGS)
 
 fluxconnector_LTLIBRARIES = local.la
@@ -23,5 +22,4 @@ local_la_LDFLAGS = -module $(san_ld_zdef_flag) \
 local_la_LIBADD = \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la \
-	$(ZMQ_LIBS) \
 	$(LIBUUID_LIBS)

--- a/src/connectors/local/Makefile.am
+++ b/src/connectors/local/Makefile.am
@@ -8,8 +8,7 @@ AM_LDFLAGS = \
 AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
-	-I$(top_builddir)/src/common/libflux \
-	$(LIBUUID_CFLAGS)
+	-I$(top_builddir)/src/common/libflux
 
 fluxconnector_LTLIBRARIES = local.la
 
@@ -21,5 +20,4 @@ local_la_LDFLAGS = -module $(san_ld_zdef_flag) \
 
 local_la_LIBADD = \
 	$(top_builddir)/src/common/libflux-internal.la \
-	$(top_builddir)/src/common/libflux-core.la \
-	$(LIBUUID_LIBS)
+	$(top_builddir)/src/common/libflux-core.la

--- a/src/connectors/loop/Makefile.am
+++ b/src/connectors/loop/Makefile.am
@@ -8,8 +8,7 @@ AM_LDFLAGS = \
 AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
-	-I$(top_builddir)/src/common/libflux \
-	$(LIBUUID_CFLAGS)
+	-I$(top_builddir)/src/common/libflux
 
 fluxconnector_LTLIBRARIES = loop.la
 
@@ -21,5 +20,4 @@ loop_la_LDFLAGS = -module $(san_ld_zdef_flag) \
 
 loop_la_LIBADD = \
 	$(top_builddir)/src/common/libflux-internal.la \
-	$(top_builddir)/src/common/libflux-core.la \
-	$(LIBUUID_LIBS)
+	$(top_builddir)/src/common/libflux-core.la

--- a/src/connectors/loop/Makefile.am
+++ b/src/connectors/loop/Makefile.am
@@ -9,7 +9,6 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
 	-I$(top_builddir)/src/common/libflux \
-	$(ZMQ_CFLAGS) \
 	$(LIBUUID_CFLAGS)
 
 fluxconnector_LTLIBRARIES = loop.la
@@ -23,5 +22,4 @@ loop_la_LDFLAGS = -module $(san_ld_zdef_flag) \
 loop_la_LIBADD = \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la \
-	$(ZMQ_LIBS) \
 	$(LIBUUID_LIBS)

--- a/src/connectors/shmem/Makefile.am
+++ b/src/connectors/shmem/Makefile.am
@@ -9,8 +9,7 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
 	-I$(top_builddir)/src/common/libflux \
-	$(ZMQ_CFLAGS) \
-	$(LIBUUID_CFLAGS)
+	$(ZMQ_CFLAGS)
 
 fluxconnector_LTLIBRARIES = shmem.la
 
@@ -23,5 +22,5 @@ shmem_la_LDFLAGS = -module $(san_ld_zdef_flag) \
 shmem_la_LIBADD = \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la \
-	$(ZMQ_LIBS) \
-	$(LIBUUID_LIBS)
+	$(ZMQ_LIBS)
+

--- a/src/connectors/ssh/Makefile.am
+++ b/src/connectors/ssh/Makefile.am
@@ -8,8 +8,7 @@ AM_LDFLAGS = \
 AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
-	-I$(top_builddir)/src/common/libflux \
-	$(LIBUUID_CFLAGS)
+	-I$(top_builddir)/src/common/libflux
 
 fluxconnector_LTLIBRARIES = ssh.la
 
@@ -21,5 +20,4 @@ ssh_la_LDFLAGS = -module $(san_ld_zdef_flag) \
 
 ssh_la_LIBADD = \
 	$(top_builddir)/src/common/libflux-internal.la \
-	$(top_builddir)/src/common/libflux-core.la \
-	$(LIBUUID_LIBS)
+	$(top_builddir)/src/common/libflux-core.la

--- a/src/connectors/ssh/Makefile.am
+++ b/src/connectors/ssh/Makefile.am
@@ -9,7 +9,6 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
 	-I$(top_builddir)/src/common/libflux \
-	$(ZMQ_CFLAGS) \
 	$(LIBUUID_CFLAGS)
 
 fluxconnector_LTLIBRARIES = ssh.la
@@ -23,5 +22,4 @@ ssh_la_LDFLAGS = -module $(san_ld_zdef_flag) \
 ssh_la_LIBADD = \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la \
-	$(ZMQ_LIBS) \
 	$(LIBUUID_LIBS)

--- a/src/modules/barrier/Makefile.am
+++ b/src/modules/barrier/Makefile.am
@@ -8,13 +8,11 @@ AM_LDFLAGS = \
 AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
-	-I$(top_builddir)/src/common/libflux \
-	$(ZMQ_CFLAGS)
+	-I$(top_builddir)/src/common/libflux
 
 fluxmod_LTLIBRARIES = barrier.la
 
 barrier_la_SOURCES = barrier.c
 barrier_la_LDFLAGS = $(fluxmod_ldflags) -module
 barrier_la_LIBADD = $(top_builddir)/src/common/libflux-internal.la \
-		    $(top_builddir)/src/common/libflux-core.la \
-		    $(ZMQ_LIBS)
+		    $(top_builddir)/src/common/libflux-core.la

--- a/src/modules/barrier/Makefile.am
+++ b/src/modules/barrier/Makefile.am
@@ -15,7 +15,6 @@ fluxmod_LTLIBRARIES = barrier.la
 
 barrier_la_SOURCES = barrier.c
 barrier_la_LDFLAGS = $(fluxmod_ldflags) -module
-barrier_la_LIBADD = $(fluxmod_libadd) \
-		    $(top_builddir)/src/common/libflux-internal.la \
+barrier_la_LIBADD = $(top_builddir)/src/common/libflux-internal.la \
 		    $(top_builddir)/src/common/libflux-core.la \
 		    $(ZMQ_LIBS)

--- a/src/modules/connector-local/Makefile.am
+++ b/src/modules/connector-local/Makefile.am
@@ -8,13 +8,11 @@ AM_LDFLAGS = \
 AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
-	-I$(top_builddir)/src/common/libflux \
-	$(ZMQ_CFLAGS)
+	-I$(top_builddir)/src/common/libflux
 
 fluxmod_LTLIBRARIES = connector-local.la
 
 connector_local_la_SOURCES = local.c
 connector_local_la_LDFLAGS = $(fluxmod_ldflags) -module
 connector_local_la_LIBADD = $(top_builddir)/src/common/libflux-internal.la \
-			    $(top_builddir)/src/common/libflux-core.la \
-			    $(ZMQ_LIBS)
+			    $(top_builddir)/src/common/libflux-core.la

--- a/src/modules/content-files/Makefile.am
+++ b/src/modules/content-files/Makefile.am
@@ -8,8 +8,7 @@ AM_LDFLAGS = \
 AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
-	-I$(top_builddir)/src/common/libflux \
-	$(ZMQ_CFLAGS)
+	-I$(top_builddir)/src/common/libflux
 
 fluxmod_LTLIBRARIES = content-files.la
 
@@ -22,8 +21,7 @@ content_files_la_LDFLAGS = $(fluxmod_ldflags) -module
 content_files_la_LIBADD = \
 		$(top_builddir)/src/common/libcontent/libcontent.la \
 		$(top_builddir)/src/common/libflux-internal.la \
-		$(top_builddir)/src/common/libflux-core.la \
-		$(ZMQ_LIBS)
+		$(top_builddir)/src/common/libflux-core.la
 
 TESTS = test_filedb.t
 
@@ -31,7 +29,7 @@ test_ldadd = \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la \
 	$(top_builddir)/src/common/libtap/libtap.la \
-	$(ZMQ_LIBS) $(LIBPTHREAD)
+	$(LIBPTHREAD)
 
 test_ldflags = \
 	-no-install

--- a/src/modules/content-s3/Makefile.am
+++ b/src/modules/content-s3/Makefile.am
@@ -8,8 +8,7 @@ AM_LDFLAGS = \
 AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
-	-I$(top_builddir)/src/common/libflux \
-	$(ZMQ_CFLAGS)
+	-I$(top_builddir)/src/common/libflux
 
 fluxmod_LTLIBRARIES = content-s3.la
 
@@ -23,13 +22,13 @@ content_s3_la_LIBADD = \
 		$(top_builddir)/src/common/libcontent/libcontent.la \
 		$(top_builddir)/src/common/libflux-internal.la \
 		$(top_builddir)/src/common/libflux-core.la \
-		$(ZMQ_LIBS) $(LIBS3)
+		$(LIBS3)
 
 test_ldadd = \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la \
 	$(top_builddir)/src/common/libtap/libtap.la \
-	$(ZMQ_LIBS) $(LIBPTHREAD) $(LIBS3)
+	$(LIBPTHREAD) $(LIBS3)
 
 test_ldflags = \
 	-no-install

--- a/src/modules/content-sqlite/Makefile.am
+++ b/src/modules/content-sqlite/Makefile.am
@@ -9,7 +9,7 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
 	-I$(top_builddir)/src/common/libflux \
-	$(ZMQ_CFLAGS) $(SQLITE_CFLAGS) \
+	$(SQLITE_CFLAGS) \
 	$(LZ4_CFLAGS)
 
 fluxmod_LTLIBRARIES = content-sqlite.la
@@ -22,4 +22,4 @@ content_sqlite_la_LIBADD = \
 		$(top_builddir)/src/common/libcontent/libcontent.la \
 		$(top_builddir)/src/common/libflux-internal.la \
 		$(top_builddir)/src/common/libflux-core.la \
-		$(ZMQ_LIBS) $(SQLITE_LIBS) $(LZ4_LIBS)
+		$(SQLITE_LIBS) $(LZ4_LIBS)

--- a/src/modules/cron/Makefile.am
+++ b/src/modules/cron/Makefile.am
@@ -3,7 +3,8 @@ AM_CFLAGS = \
 	$(CODE_COVERAGE_CFLAGS)
 
 AM_LDFLAGS = \
-	$(CODE_COVERAGE_LIBS)
+	$(CODE_COVERAGE_LIBS) \
+	$(JANSSON_CFLAGS)
 
 AM_CPPFLAGS = \
 	-I$(top_srcdir) \
@@ -25,4 +26,5 @@ cron_la_SOURCES = \
 
 cron_la_LDFLAGS = $(fluxmod_ldflags) -module
 cron_la_LIBADD = $(top_builddir)/src/common/libflux-internal.la \
-		 $(top_builddir)/src/common/libflux-core.la
+		 $(top_builddir)/src/common/libflux-core.la \
+		 $(JANSSON_LIBS)

--- a/src/modules/cron/Makefile.am
+++ b/src/modules/cron/Makefile.am
@@ -8,8 +8,7 @@ AM_LDFLAGS = \
 AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
-	-I$(top_builddir)/src/common/libflux \
-	$(ZMQ_CFLAGS)
+	-I$(top_builddir)/src/common/libflux
 
 fluxmod_LTLIBRARIES = cron.la
 
@@ -26,5 +25,4 @@ cron_la_SOURCES = \
 
 cron_la_LDFLAGS = $(fluxmod_ldflags) -module
 cron_la_LIBADD = $(top_builddir)/src/common/libflux-internal.la \
-		 $(top_builddir)/src/common/libflux-core.la \
-		 $(ZMQ_LIBS)
+		 $(top_builddir)/src/common/libflux-core.la

--- a/src/modules/heartbeat/Makefile.am
+++ b/src/modules/heartbeat/Makefile.am
@@ -9,7 +9,6 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
 	-I$(top_builddir)/src/common/libflux \
-	$(ZMQ_CFLAGS) \
 	$(HWLOC_CFLAGS)
 
 fluxmod_LTLIBRARIES = heartbeat.la
@@ -20,5 +19,4 @@ heartbeat_la_SOURCES = \
 heartbeat_la_LDFLAGS = $(fluxmod_ldflags) -module
 heartbeat_la_LIBADD = \
 	$(top_builddir)/src/common/libflux-internal.la \
-	$(top_builddir)/src/common/libflux-core.la \
-	$(ZMQ_LIBS)
+	$(top_builddir)/src/common/libflux-core.la

--- a/src/modules/heartbeat/Makefile.am
+++ b/src/modules/heartbeat/Makefile.am
@@ -19,7 +19,6 @@ heartbeat_la_SOURCES = \
 
 heartbeat_la_LDFLAGS = $(fluxmod_ldflags) -module
 heartbeat_la_LIBADD = \
-	$(fluxmod_libadd) \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la \
 	$(ZMQ_LIBS)

--- a/src/modules/heartbeat/Makefile.am
+++ b/src/modules/heartbeat/Makefile.am
@@ -8,8 +8,7 @@ AM_LDFLAGS = \
 AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
-	-I$(top_builddir)/src/common/libflux \
-	$(HWLOC_CFLAGS)
+	-I$(top_builddir)/src/common/libflux
 
 fluxmod_LTLIBRARIES = heartbeat.la
 

--- a/src/modules/job-archive/Makefile.am
+++ b/src/modules/job-archive/Makefile.am
@@ -18,7 +18,7 @@ job_archive_la_SOURCES = \
 	job-archive.c
 
 job_archive_la_LDFLAGS = $(fluxmod_ldflags) -module
-job_archive_la_LIBADD = $(fluxmod_libadd) \
+job_archive_la_LIBADD = \
 	$(top_builddir)/src/common/libjob/libjob.la \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la \

--- a/src/modules/job-archive/Makefile.am
+++ b/src/modules/job-archive/Makefile.am
@@ -10,7 +10,7 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir)/src/include \
 	-I$(top_builddir)/src/common/libflux \
 	$(ZMQ_CFLAGS) $(SQLITE_CFLAGS) \
-	$(FLUX_SECURITY_CFLAGS) $(YAMLCPP_CFLAGS)
+	$(FLUX_SECURITY_CFLAGS)
 
 fluxmod_LTLIBRARIES = job-archive.la
 

--- a/src/modules/job-archive/Makefile.am
+++ b/src/modules/job-archive/Makefile.am
@@ -9,7 +9,7 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
 	-I$(top_builddir)/src/common/libflux \
-	$(ZMQ_CFLAGS) $(SQLITE_CFLAGS) \
+	$(SQLITE_CFLAGS) \
 	$(FLUX_SECURITY_CFLAGS)
 
 fluxmod_LTLIBRARIES = job-archive.la
@@ -23,4 +23,4 @@ job_archive_la_LIBADD = \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la \
 	$(top_builddir)/src/common/libflux-optparse.la \
-	$(SQLITE_LIBS) $(ZMQ_LIBS)
+	$(SQLITE_LIBS)

--- a/src/modules/job-archive/Makefile.am
+++ b/src/modules/job-archive/Makefile.am
@@ -3,7 +3,8 @@ AM_CFLAGS = \
 	$(CODE_COVERAGE_CFLAGS)
 
 AM_LDFLAGS = \
-	$(CODE_COVERAGE_LIBS)
+	$(CODE_COVERAGE_LIBS) \
+	$(JANSSON_CFLAGS)
 
 AM_CPPFLAGS = \
 	-I$(top_srcdir) \
@@ -23,4 +24,5 @@ job_archive_la_LIBADD = \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la \
 	$(top_builddir)/src/common/libflux-optparse.la \
+	$(JANSSON_LIBS) \
 	$(SQLITE_LIBS)

--- a/src/modules/job-exec/Makefile.am
+++ b/src/modules/job-exec/Makefile.am
@@ -40,6 +40,7 @@ job_exec_la_LIBADD = \
 	$(top_builddir)/src/common/libjob/libjob.la \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la \
+	$(JANSSON_LIBS) \
 	libbulk-exec.la
 
 bulk_exec_SOURCES = \

--- a/src/modules/job-exec/Makefile.am
+++ b/src/modules/job-exec/Makefile.am
@@ -9,7 +9,7 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
 	-I$(top_builddir)/src/common/libflux \
-	$(ZMQ_CFLAGS) $(JANSSON_CFLAGS)
+	$(JANSSON_CFLAGS)
 
 fluxmod_LTLIBRARIES = \
 	job-exec.la
@@ -40,8 +40,7 @@ job_exec_la_LIBADD = \
 	$(top_builddir)/src/common/libjob/libjob.la \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la \
-	libbulk-exec.la \
-	$(ZMQ_LIBS)
+	libbulk-exec.la
 
 bulk_exec_SOURCES = \
 	test/bulk-exec.c
@@ -52,14 +51,13 @@ bulk_exec_LDADD = \
 	$(top_builddir)/src/common/libflux-core.la \
 	$(top_builddir)/src/common/libflux-idset.la \
 	$(top_builddir)/src/common/libflux-optparse.la \
-	$(top_builddir)/src/common/libutil/libutil.la \
-	$(ZMQ_LIBS)
+	$(top_builddir)/src/common/libutil/libutil.la
 
 test_ldadd = \
 	$(top_builddir)/src/common/libtap/libtap.la \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la \
-	$(ZMQ_LIBS) $(LIBPTHREAD) $(JANSSON_LIBS)
+	$(LIBPTHREAD) $(JANSSON_LIBS)
 
 test_ldflags = \
 	-no-install

--- a/src/modules/job-exec/Makefile.am
+++ b/src/modules/job-exec/Makefile.am
@@ -37,7 +37,6 @@ job_exec_la_LDFLAGS = \
 	-module
 
 job_exec_la_LIBADD = \
-	$(fluxmod_libadd) \
 	$(top_builddir)/src/common/libjob/libjob.la \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la \

--- a/src/modules/job-info/Makefile.am
+++ b/src/modules/job-info/Makefile.am
@@ -9,7 +9,7 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
 	-I$(top_builddir)/src/common/libflux \
-	$(ZMQ_CFLAGS) $(FLUX_SECURITY_CFLAGS) $(YAMLCPP_CFLAGS)
+	$(ZMQ_CFLAGS) $(FLUX_SECURITY_CFLAGS)
 
 fluxmod_LTLIBRARIES = job-info.la
 

--- a/src/modules/job-info/Makefile.am
+++ b/src/modules/job-info/Makefile.am
@@ -3,7 +3,8 @@ AM_CFLAGS = \
 	$(CODE_COVERAGE_CFLAGS)
 
 AM_LDFLAGS = \
-	$(CODE_COVERAGE_LIBS)
+	$(CODE_COVERAGE_LIBS) \
+	$(JANSSON_CFLAGS)
 
 AM_CPPFLAGS = \
 	-I$(top_srcdir) \
@@ -32,4 +33,5 @@ job_info_la_LIBADD = \
 	$(top_builddir)/src/common/libflux-core.la \
 	$(top_builddir)/src/common/libflux-optparse.la \
 	$(top_builddir)/src/common/librlist/librlist.la \
+	$(JANSSON_LIBS) \
 	$(HWLOC_LIBS)

--- a/src/modules/job-info/Makefile.am
+++ b/src/modules/job-info/Makefile.am
@@ -26,7 +26,7 @@ job_info_la_SOURCES = \
 	guest_watch.c
 
 job_info_la_LDFLAGS = $(fluxmod_ldflags) -module
-job_info_la_LIBADD = $(fluxmod_libadd) \
+job_info_la_LIBADD = \
 	$(top_builddir)/src/common/libjob/libjob.la \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la \

--- a/src/modules/job-info/Makefile.am
+++ b/src/modules/job-info/Makefile.am
@@ -9,7 +9,7 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
 	-I$(top_builddir)/src/common/libflux \
-	$(ZMQ_CFLAGS) $(FLUX_SECURITY_CFLAGS)
+	$(FLUX_SECURITY_CFLAGS)
 
 fluxmod_LTLIBRARIES = job-info.la
 
@@ -32,5 +32,4 @@ job_info_la_LIBADD = \
 	$(top_builddir)/src/common/libflux-core.la \
 	$(top_builddir)/src/common/libflux-optparse.la \
 	$(top_builddir)/src/common/librlist/librlist.la \
-	$(ZMQ_LIBS) \
 	$(HWLOC_LIBS)

--- a/src/modules/job-ingest/Makefile.am
+++ b/src/modules/job-ingest/Makefile.am
@@ -9,7 +9,7 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
 	-I$(top_builddir)/src/common/libflux \
-	$(ZMQ_CFLAGS) $(FLUX_SECURITY_CFLAGS) \
+	$(FLUX_SECURITY_CFLAGS) \
 	$(JANSSON_CFLAGS)
 
 fluxmod_LTLIBRARIES = job-ingest.la
@@ -28,8 +28,7 @@ job_ingest_la_LIBADD = \
 		    $(top_builddir)/src/common/libflux-internal.la \
 		    $(top_builddir)/src/common/libflux-core.la \
 		    $(top_builddir)/src/common/libflux-optparse.la \
-		    $(FLUX_SECURITY_LIBS) \
-		    $(ZMQ_LIBS)
+		    $(FLUX_SECURITY_LIBS)
 
 fluxschemadir = $(datadir)/flux/schema/jobspec/
 dist_fluxschema_DATA = \

--- a/src/modules/job-ingest/Makefile.am
+++ b/src/modules/job-ingest/Makefile.am
@@ -9,7 +9,7 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
 	-I$(top_builddir)/src/common/libflux \
-	$(ZMQ_CFLAGS) $(FLUX_SECURITY_CFLAGS) $(YAMLCPP_CFLAGS) \
+	$(ZMQ_CFLAGS) $(FLUX_SECURITY_CFLAGS) \
 	$(JANSSON_CFLAGS)
 
 fluxmod_LTLIBRARIES = job-ingest.la

--- a/src/modules/job-ingest/Makefile.am
+++ b/src/modules/job-ingest/Makefile.am
@@ -28,6 +28,7 @@ job_ingest_la_LIBADD = \
 		    $(top_builddir)/src/common/libflux-internal.la \
 		    $(top_builddir)/src/common/libflux-core.la \
 		    $(top_builddir)/src/common/libflux-optparse.la \
+		    $(JANSSON_LIBS) \
 		    $(FLUX_SECURITY_LIBS)
 
 fluxschemadir = $(datadir)/flux/schema/jobspec/

--- a/src/modules/job-ingest/Makefile.am
+++ b/src/modules/job-ingest/Makefile.am
@@ -23,7 +23,7 @@ job_ingest_la_SOURCES = \
 	types.h
 
 job_ingest_la_LDFLAGS = $(fluxmod_ldflags) -module
-job_ingest_la_LIBADD = $(fluxmod_libadd) \
+job_ingest_la_LIBADD = \
 		    $(top_builddir)/src/common/libjob/libjob.la \
 		    $(top_builddir)/src/common/libflux-internal.la \
 		    $(top_builddir)/src/common/libflux-core.la \

--- a/src/modules/job-list/Makefile.am
+++ b/src/modules/job-list/Makefile.am
@@ -28,7 +28,7 @@ job_list_la_SOURCES = \
 	stats.c
 
 job_list_la_LDFLAGS = $(fluxmod_ldflags) -module
-job_list_la_LIBADD = $(fluxmod_libadd) \
+job_list_la_LIBADD = \
 	$(top_builddir)/src/common/libjob/libjob.la \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la \

--- a/src/modules/job-list/Makefile.am
+++ b/src/modules/job-list/Makefile.am
@@ -9,7 +9,8 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
 	-I$(top_builddir)/src/common/libflux \
-	$(FLUX_SECURITY_CFLAGS)
+	$(FLUX_SECURITY_CFLAGS) \
+	$(JANSSON_CFLAGS)
 
 fluxmod_LTLIBRARIES = job-list.la
 
@@ -34,4 +35,5 @@ job_list_la_LIBADD = \
 	$(top_builddir)/src/common/libflux-core.la \
 	$(top_builddir)/src/common/libflux-optparse.la \
 	$(top_builddir)/src/common/librlist/librlist.la \
+	$(JANSSON_LIBS) \
 	$(HWLOC_LIBS)

--- a/src/modules/job-list/Makefile.am
+++ b/src/modules/job-list/Makefile.am
@@ -9,7 +9,7 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
 	-I$(top_builddir)/src/common/libflux \
-	$(ZMQ_CFLAGS) $(FLUX_SECURITY_CFLAGS)
+	$(FLUX_SECURITY_CFLAGS)
 
 fluxmod_LTLIBRARIES = job-list.la
 
@@ -34,5 +34,4 @@ job_list_la_LIBADD = \
 	$(top_builddir)/src/common/libflux-core.la \
 	$(top_builddir)/src/common/libflux-optparse.la \
 	$(top_builddir)/src/common/librlist/librlist.la \
-	$(ZMQ_LIBS) \
 	$(HWLOC_LIBS)

--- a/src/modules/job-list/Makefile.am
+++ b/src/modules/job-list/Makefile.am
@@ -9,7 +9,7 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
 	-I$(top_builddir)/src/common/libflux \
-	$(ZMQ_CFLAGS) $(FLUX_SECURITY_CFLAGS) $(YAMLCPP_CFLAGS)
+	$(ZMQ_CFLAGS) $(FLUX_SECURITY_CFLAGS)
 
 fluxmod_LTLIBRARIES = job-list.la
 

--- a/src/modules/job-manager/Makefile.am
+++ b/src/modules/job-manager/Makefile.am
@@ -79,7 +79,8 @@ job_manager_la_LIBADD = \
 	$(top_builddir)/src/common/libjob/libjob.la \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la \
-	$(top_builddir)/src/common/libflux-optparse.la
+	$(top_builddir)/src/common/libflux-optparse.la \
+	$(JANSSON_LIBS)
 
 plugins_priority_hold_la_SOURCES = \
 	plugins/priority-hold.c

--- a/src/modules/job-manager/Makefile.am
+++ b/src/modules/job-manager/Makefile.am
@@ -76,7 +76,6 @@ job_manager_la_LDFLAGS = \
 	-module
 job_manager_la_LIBADD = \
 	libjob-manager.la \
-	$(fluxmod_libadd) \
 	$(top_builddir)/src/common/libjob/libjob.la \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la \

--- a/src/modules/job-manager/Makefile.am
+++ b/src/modules/job-manager/Makefile.am
@@ -9,7 +9,7 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
 	-I$(top_builddir)/src/common/libflux \
-	$(ZMQ_CFLAGS) $(JANSSON_CFLAGS)
+	$(JANSSON_CFLAGS)
 
 fluxmod_LTLIBRARIES = \
 	job-manager.la
@@ -79,8 +79,7 @@ job_manager_la_LIBADD = \
 	$(top_builddir)/src/common/libjob/libjob.la \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la \
-	$(top_builddir)/src/common/libflux-optparse.la \
-	$(ZMQ_LIBS)
+	$(top_builddir)/src/common/libflux-optparse.la
 
 plugins_priority_hold_la_SOURCES = \
 	plugins/priority-hold.c
@@ -112,7 +111,7 @@ test_ldadd = \
 	$(top_builddir)/src/common/libjob/libjob.la \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la \
-	$(ZMQ_LIBS) $(LIBPTHREAD) $(JANSSON_LIBS)
+	$(LIBPTHREAD) $(JANSSON_LIBS)
 
 test_cppflags = \
 	$(AM_CPPFLAGS)

--- a/src/modules/kvs-watch/Makefile.am
+++ b/src/modules/kvs-watch/Makefile.am
@@ -18,7 +18,7 @@ kvs_watch_la_SOURCES = \
 
 
 kvs_watch_la_LDFLAGS = $(fluxmod_ldflags) -module
-kvs_watch_la_LIBADD = $(fluxmod_libadd) \
+kvs_watch_la_LIBADD = \
 	$(top_builddir)/src/common/libkvs/libkvs.la \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la \

--- a/src/modules/kvs-watch/Makefile.am
+++ b/src/modules/kvs-watch/Makefile.am
@@ -9,7 +9,7 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
 	-I$(top_builddir)/src/common/libflux \
-	$(ZMQ_CFLAGS) $(FLUX_SECURITY_CFLAGS)
+	$(FLUX_SECURITY_CFLAGS)
 
 fluxmod_LTLIBRARIES = kvs-watch.la
 
@@ -22,5 +22,4 @@ kvs_watch_la_LIBADD = \
 	$(top_builddir)/src/common/libkvs/libkvs.la \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la \
-	$(top_builddir)/src/common/libflux-optparse.la \
-	$(ZMQ_LIBS)
+	$(top_builddir)/src/common/libflux-optparse.la

--- a/src/modules/kvs-watch/Makefile.am
+++ b/src/modules/kvs-watch/Makefile.am
@@ -9,7 +9,7 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
 	-I$(top_builddir)/src/common/libflux \
-	$(ZMQ_CFLAGS) $(FLUX_SECURITY_CFLAGS) $(YAMLCPP_CFLAGS)
+	$(ZMQ_CFLAGS) $(FLUX_SECURITY_CFLAGS)
 
 fluxmod_LTLIBRARIES = kvs-watch.la
 

--- a/src/modules/kvs-watch/Makefile.am
+++ b/src/modules/kvs-watch/Makefile.am
@@ -9,7 +9,8 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
 	-I$(top_builddir)/src/common/libflux \
-	$(FLUX_SECURITY_CFLAGS)
+	$(FLUX_SECURITY_CFLAGS) \
+	$(JANSSON_CFLAGS)
 
 fluxmod_LTLIBRARIES = kvs-watch.la
 
@@ -22,4 +23,5 @@ kvs_watch_la_LIBADD = \
 	$(top_builddir)/src/common/libkvs/libkvs.la \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la \
-	$(top_builddir)/src/common/libflux-optparse.la
+	$(top_builddir)/src/common/libflux-optparse.la \
+	$(JANSSON_LIBS)

--- a/src/modules/kvs/Makefile.am
+++ b/src/modules/kvs/Makefile.am
@@ -10,7 +10,8 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir)/src/include \
 	-I$(top_srcdir)/src/common/libccan \
 	-I$(top_builddir)/src/common/libflux \
-	$(LIBSODIUM_CFLAGS)
+	$(LIBSODIUM_CFLAGS) \
+	$(JANSSON_CFLAGS)
 
 fluxmod_LTLIBRARIES = kvs.la
 
@@ -35,6 +36,7 @@ kvs_la_LDFLAGS = $(fluxmod_ldflags) -module
 kvs_la_LIBADD = $(top_builddir)/src/common/libkvs/libkvs.la \
 		$(top_builddir)/src/common/libflux-internal.la \
 		$(top_builddir)/src/common/libflux-core.la \
+		$(JANSSON_LIBS) \
 		$(LIBSODIUM_LIBS)
 
 TESTS = \
@@ -51,6 +53,7 @@ test_ldadd = \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la \
 	$(top_builddir)/src/common/libtap/libtap.la \
+	$(JANSSON_LIBS) \
         $(LIBPTHREAD)
 
 test_ldflags = \
@@ -58,7 +61,8 @@ test_ldflags = \
 
 test_cppflags = \
         $(AM_CPPFLAGS) \
-        -I$(top_srcdir)/src/common/libtap
+        -I$(top_srcdir)/src/common/libtap \
+	$(JANSSON_CFLAGS)
 
 check_PROGRAMS = $(TESTS)
 

--- a/src/modules/kvs/Makefile.am
+++ b/src/modules/kvs/Makefile.am
@@ -9,8 +9,7 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
 	-I$(top_srcdir)/src/common/libccan \
-	-I$(top_builddir)/src/common/libflux \
-	$(ZMQ_CFLAGS)
+	-I$(top_builddir)/src/common/libflux
 
 fluxmod_LTLIBRARIES = kvs.la
 
@@ -34,8 +33,7 @@ kvs_la_SOURCES = \
 kvs_la_LDFLAGS = $(fluxmod_ldflags) -module
 kvs_la_LIBADD = $(top_builddir)/src/common/libkvs/libkvs.la \
 		$(top_builddir)/src/common/libflux-internal.la \
-		$(top_builddir)/src/common/libflux-core.la \
-		$(ZMQ_LIBS)
+		$(top_builddir)/src/common/libflux-core.la
 
 TESTS = \
 	test_waitqueue.t \
@@ -51,7 +49,7 @@ test_ldadd = \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la \
 	$(top_builddir)/src/common/libtap/libtap.la \
-        $(ZMQ_LIBS) $(LIBPTHREAD)
+        $(LIBPTHREAD)
 
 test_ldflags = \
 	-no-install

--- a/src/modules/kvs/Makefile.am
+++ b/src/modules/kvs/Makefile.am
@@ -9,7 +9,8 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
 	-I$(top_srcdir)/src/common/libccan \
-	-I$(top_builddir)/src/common/libflux
+	-I$(top_builddir)/src/common/libflux \
+	$(LIBSODIUM_CFLAGS)
 
 fluxmod_LTLIBRARIES = kvs.la
 
@@ -33,7 +34,8 @@ kvs_la_SOURCES = \
 kvs_la_LDFLAGS = $(fluxmod_ldflags) -module
 kvs_la_LIBADD = $(top_builddir)/src/common/libkvs/libkvs.la \
 		$(top_builddir)/src/common/libflux-internal.la \
-		$(top_builddir)/src/common/libflux-core.la
+		$(top_builddir)/src/common/libflux-core.la \
+		$(LIBSODIUM_LIBS)
 
 TESTS = \
 	test_waitqueue.t \

--- a/src/modules/resource/Makefile.am
+++ b/src/modules/resource/Makefile.am
@@ -9,6 +9,7 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
 	-I$(top_builddir)/src/common/libflux \
+	$(JANSSON_CFLAGS) \
 	$(HWLOC_CFLAGS)
 
 fluxmod_LTLIBRARIES = resource.la
@@ -38,6 +39,7 @@ resource_la_LIBADD = \
 	$(top_builddir)/src/common/librlist/librlist.la \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la \
+	$(JANSSON_LIBS) \
 	$(HWLOC_LIBS)
 
 TESTS = test_rutil.t
@@ -48,13 +50,15 @@ test_ldadd = \
         $(top_builddir)/src/common/libflux-core.la \
         $(top_builddir)/src/common/libtap/libtap.la \
 	$(HWLOC_LIBS) \
+	$(JANSSON_LIBS) \
 	$(LIBPTHREAD)
 
 test_ldflags = \
         -no-install
 
 test_cppflags = \
-        $(AM_CPPFLAGS)
+        $(AM_CPPFLAGS) \
+	$(JANSSON_CFLAGS)
 
 check_PROGRAMS = $(TESTS)
 

--- a/src/modules/resource/Makefile.am
+++ b/src/modules/resource/Makefile.am
@@ -9,7 +9,6 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
 	-I$(top_builddir)/src/common/libflux \
-	$(ZMQ_CFLAGS) \
 	$(HWLOC_CFLAGS)
 
 fluxmod_LTLIBRARIES = resource.la
@@ -39,7 +38,6 @@ resource_la_LIBADD = \
 	$(top_builddir)/src/common/librlist/librlist.la \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la \
-	$(ZMQ_LIBS) \
 	$(HWLOC_LIBS)
 
 TESTS = test_rutil.t
@@ -49,7 +47,6 @@ test_ldadd = \
         $(top_builddir)/src/common/libflux-internal.la \
         $(top_builddir)/src/common/libflux-core.la \
         $(top_builddir)/src/common/libtap/libtap.la \
-        $(ZMQ_LIBS) \
 	$(HWLOC_LIBS) \
 	$(LIBPTHREAD)
 

--- a/src/modules/resource/Makefile.am
+++ b/src/modules/resource/Makefile.am
@@ -36,7 +36,6 @@ resource_la_SOURCES = \
 
 resource_la_LDFLAGS = $(fluxmod_ldflags) -module
 resource_la_LIBADD = \
-	$(fluxmod_libadd) \
 	$(top_builddir)/src/common/librlist/librlist.la \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la \

--- a/src/modules/sched-simple/Makefile.am
+++ b/src/modules/sched-simple/Makefile.am
@@ -9,7 +9,7 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
 	-I$(top_builddir)/src/common/libflux \
-	$(ZMQ_CFLAGS) $(JANSSON_CFLAGS)
+	$(JANSSON_CFLAGS)
 
 fluxmod_LTLIBRARIES = \
 	sched-simple.la
@@ -35,5 +35,4 @@ sched_simple_la_LIBADD = \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la \
 	$(top_builddir)/src/common/libflux-optparse.la \
-	$(ZMQ_LIBS) \
 	$(HWLOC_LIBS)

--- a/src/modules/sched-simple/Makefile.am
+++ b/src/modules/sched-simple/Makefile.am
@@ -29,7 +29,6 @@ sched_simple_la_LDFLAGS = \
 	-module
 
 sched_simple_la_LIBADD = \
-	$(fluxmod_libadd) \
 	libjj.la \
 	$(top_builddir)/src/common/librlist/librlist.la \
 	$(top_builddir)/src/common/libschedutil/libschedutil.la \

--- a/src/modules/sched-simple/Makefile.am
+++ b/src/modules/sched-simple/Makefile.am
@@ -35,4 +35,5 @@ sched_simple_la_LIBADD = \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la \
 	$(top_builddir)/src/common/libflux-optparse.la \
+	$(JANSSON_LIBS) \
 	$(HWLOC_LIBS)

--- a/src/shell/Makefile.am
+++ b/src/shell/Makefile.am
@@ -8,7 +8,7 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
 	-I$(top_builddir)/src/common/libflux \
-	$(ZMQ_CFLAGS) $(VALGRIND_CFLAGS) \
+	$(VALGRIND_CFLAGS) \
 	$(LUA_INCLUDE) \
 	$(HWLOC_CFLAGS)
 

--- a/src/shell/Makefile.am
+++ b/src/shell/Makefile.am
@@ -10,7 +10,8 @@ AM_CPPFLAGS = \
 	-I$(top_builddir)/src/common/libflux \
 	$(VALGRIND_CFLAGS) \
 	$(LUA_INCLUDE) \
-	$(HWLOC_CFLAGS)
+	$(HWLOC_CFLAGS) \
+	$(JANSSON_CFLAGS)
 
 shellrcdir = \
 	$(fluxrcdir)/shell
@@ -101,7 +102,8 @@ flux_shell_LDADD = \
 	$(top_builddir)/src/common/libterminus/libterminus.la \
 	$(top_builddir)/src/common/libutil/libutil.la \
 	$(LUA_LIB) \
-	$(HWLOC_LIBS)
+	$(HWLOC_LIBS) \
+	$(JANSSON_LIBS)
 
 flux_shell_LDFLAGS = \
 	-export-dynamic \

--- a/src/test/Makefile.am
+++ b/src/test/Makefile.am
@@ -1,16 +1,3 @@
-AM_CFLAGS = \
-	$(WARNING_CFLAGS) \
-	$(CODE_COVERAGE_CFLAGS)
-
-AM_LDFLAGS = \
-	$(CODE_COVERAGE_LIBS)
-
-AM_CPPFLAGS = \
-	-I$(top_srcdir) \
-	-I$(top_srcdir)/src/include \
-	-I$(top_builddir)/src/common/libflux \
-	$(ZMQ_CFLAGS)
-
 noinst_SCRIPTS = \
 	relnotes.sh \
 	backtrace-all.sh \
@@ -20,9 +7,5 @@ noinst_SCRIPTS = \
 	cppcheck.sh \
 	docker-deploy.sh \
 	generate-matrix.py
-
-LDADD = $(top_builddir)/src/common/libflux-internal.la \
-	$(top_builddir)/src/common/libflux-core.la \
-	$(ZMQ_LIBS) $(LIBPTHREAD) $(LIBDL)
 
 EXTRA_DIST = $(noinst_SCRIPTS)

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -395,22 +395,19 @@ test_cppflags = \
 
 shmem_backtoback_t_SOURCES = shmem/backtoback.c
 shmem_backtoback_t_CPPFLAGS = $(test_cppflags)
-shmem_backtoback_t_LDADD = $(test_ldadd) $(LIBDL)
+shmem_backtoback_t_LDADD = $(test_ldadd)
 
 loop_logstderr_SOURCES = loop/logstderr.c
 loop_logstderr_CPPFLAGS = $(test_cppflags)
-loop_logstderr_LDADD = \
-	$(test_ldadd) $(LIBDL)
+loop_logstderr_LDADD = $(test_ldadd)
 
 loop_issue2337_SOURCES = loop/issue2337.c
 loop_issue2337_CPPFLAGS = $(test_cppflags)
-loop_issue2337_LDADD = \
-	$(test_ldadd) $(LIBDL)
+loop_issue2337_LDADD = $(test_ldadd)
 
 loop_issue2711_SOURCES = loop/issue2711.c
 loop_issue2711_CPPFLAGS = $(test_cppflags)
-loop_issue2711_LDADD = \
-	$(test_ldadd) $(LIBDL)
+loop_issue2711_LDADD = $(test_ldadd)
 
 mpi_hello_SOURCES = mpi/hello.c
 mpi_hello_CPPFLAGS = $(MPI_CFLAGS) $(test_cppflags)
@@ -454,204 +451,167 @@ mpi_mpich_basic_simple_LDADD = $(MPI_CLDFLAGS) $(test_ldadd)
 
 kvs_torture_SOURCES = kvs/torture.c
 kvs_torture_CPPFLAGS = $(test_cppflags)
-kvs_torture_LDADD = \
-	$(test_ldadd) $(LIBDL)
+kvs_torture_LDADD = $(test_ldadd)
 
 kvs_dtree_SOURCES = kvs/dtree.c
 kvs_dtree_CPPFLAGS = $(test_cppflags)
-kvs_dtree_LDADD = \
-	$(test_ldadd) $(LIBDL)
+kvs_dtree_LDADD = $(test_ldadd)
 
 kvs_blobref_SOURCES = kvs/blobref.c
 kvs_blobref_CPPFLAGS = $(test_cppflags)
-kvs_blobref_LDADD = \
-	$(test_ldadd) $(LIBDL)
+kvs_blobref_LDADD = $(test_ldadd)
 
 kvs_commit_SOURCES = kvs/commit.c
 kvs_commit_CPPFLAGS = $(test_cppflags)
-kvs_commit_LDADD = \
-	$(test_ldadd) $(LIBDL)
+kvs_commit_LDADD = $(test_ldadd)
 
 kvs_fence_api_SOURCES = kvs/fence_api.c
 kvs_fence_api_CPPFLAGS = $(test_cppflags)
-kvs_fence_api_LDADD = \
-	$(test_ldadd) $(LIBDL)
+kvs_fence_api_LDADD = $(test_ldadd)
 
 kvs_transactionmerge_SOURCES = kvs/transactionmerge.c
 kvs_transactionmerge_CPPFLAGS = $(test_cppflags)
-kvs_transactionmerge_LDADD = \
-	$(test_ldadd) $(LIBDL)
+kvs_transactionmerge_LDADD = $(test_ldadd)
 
 kvs_fence_namespace_remove_SOURCES = kvs/fence_namespace_remove.c
 kvs_fence_namespace_remove_CPPFLAGS = $(test_cppflags)
-kvs_fence_namespace_remove_LDADD = \
-	$(test_ldadd) $(LIBDL)
+kvs_fence_namespace_remove_LDADD = $(test_ldadd)
 
 kvs_fence_invalid_SOURCES = kvs/fence_invalid.c
 kvs_fence_invalid_CPPFLAGS = $(test_cppflags)
-kvs_fence_invalid_LDADD = \
-	$(test_ldadd) $(LIBDL)
+kvs_fence_invalid_LDADD = $(test_ldadd)
 
 kvs_lookup_invalid_SOURCES = kvs/lookup_invalid.c
 kvs_lookup_invalid_CPPFLAGS = $(test_cppflags)
-kvs_lookup_invalid_LDADD = \
-	$(test_ldadd) $(LIBDL)
+kvs_lookup_invalid_LDADD = $(test_ldadd)
 
 kvs_commit_order_SOURCES = kvs/commit_order.c
 kvs_commit_order_CPPFLAGS = $(test_cppflags)
-kvs_commit_order_LDADD = \
-	$(test_ldadd) $(LIBDL)
+kvs_commit_order_LDADD = $(test_ldadd)
 
 kvs_watch_disconnect_SOURCES = kvs/watch_disconnect.c
 kvs_watch_disconnect_CPPFLAGS = $(test_cppflags)
-kvs_watch_disconnect_LDADD = \
-	$(test_ldadd) $(LIBDL)
+kvs_watch_disconnect_LDADD = $(test_ldadd)
 
 kvs_issue1760_SOURCES = kvs/issue1760.c
 kvs_issue1760_CPPFLAGS = $(test_cppflags)
-kvs_issue1760_LDADD = \
-	$(test_ldadd) $(LIBDL)
+kvs_issue1760_LDADD = $(test_ldadd)
 
 kvs_issue1876_SOURCES = kvs/issue1876.c
 kvs_issue1876_CPPFLAGS = $(test_cppflags)
-kvs_issue1876_LDADD = \
-	$(test_ldadd) $(LIBDL)
+kvs_issue1876_LDADD = $(test_ldadd)
 
 kvs_waitcreate_cancel_SOURCES = kvs/waitcreate_cancel.c
 kvs_waitcreate_cancel_CPPFLAGS = $(test_cppflags)
-kvs_waitcreate_cancel_LDADD = \
-	$(test_ldadd) $(LIBDL)
+kvs_waitcreate_cancel_LDADD = $(test_ldadd)
 
 kvs_setrootevents_SOURCES = kvs/setrootevents.c
 kvs_setrootevents_CPPFLAGS = $(test_cppflags)
-kvs_setrootevents_LDADD = \
-	$(test_ldadd) $(LIBDL)
+kvs_setrootevents_LDADD = $(test_ldadd)
 
 kvs_checkpoint_SOURCES = kvs/checkpoint.c
 kvs_checkpoint_CPPFLAGS = $(test_cppflags)
-kvs_checkpoint_LDADD = \
-	$(test_ldadd) $(LIBDL)
+kvs_checkpoint_LDADD = $(test_ldadd)
 
 request_treq_SOURCES = request/treq.c
 request_treq_CPPFLAGS = $(test_cppflags)
-request_treq_LDADD = \
-	$(test_ldadd) $(LIBDL)
+request_treq_LDADD = $(test_ldadd)
 
 request_rpc_SOURCES = request/rpc.c
 request_rpc_CPPFLAGS = $(test_cppflags)
-request_rpc_LDADD = \
-	$(test_ldadd) $(LIBDL)
+request_rpc_LDADD = $(test_ldadd)
 
 request_rpc_stream_SOURCES = request/rpc_stream.c
 request_rpc_stream_CPPFLAGS = $(test_cppflags)
-request_rpc_stream_LDADD = \
-	$(test_ldadd) $(LIBDL)
+request_rpc_stream_LDADD = $(test_ldadd)
 
 module_parent_la_SOURCES = module/parent.c
 module_parent_la_CPPFLAGS = $(test_cppflags)
 module_parent_la_LDFLAGS = $(fluxmod_ldflags) -module -rpath /nowher
-module_parent_la_LIBADD = \
-	$(test_ldadd) $(LIBDL)
+module_parent_la_LIBADD = $(test_ldadd) $(LIBDL)
 
 module_child_la_SOURCES = module/child.c
 module_child_la_CPPFLAGS = $(test_cppflags)
 module_child_la_LDFLAGS = $(fluxmod_ldflags) -module -rpath /nowher
-module_child_la_LIBADD = \
-	$(test_ldadd) $(LIBDL)
+module_child_la_LIBADD = $(test_ldadd)
 
 module_running_la_SOURCES = module/running.c
 module_running_la_CPPFLAGS = $(test_cppflags)
 module_running_la_LDFLAGS = $(fluxmod_ldflags) -module -rpath /nowher
-module_running_la_LIBADD = \
-	$(test_ldadd) $(LIBDL)
+module_running_la_LIBADD = $(test_ldadd)
 
 barrier_tbarrier_SOURCES = barrier/tbarrier.c
 barrier_tbarrier_CPPFLAGS = $(test_cppflags)
-barrier_tbarrier_LDADD = \
-	$(test_ldadd) $(LIBDL)
+barrier_tbarrier_LDADD = $(test_ldadd)
 
 request_req_la_SOURCES = request/req.c
 request_req_la_CPPFLAGS = $(test_cppflags)
 request_req_la_LDFLAGS = $(fluxmod_ldflags) -module -rpath /nowher
-request_req_la_LIBADD = \
-	$(test_ldadd) $(LIBDL)
+request_req_la_LIBADD = $(test_ldadd)
 
 shell_rcalc_SOURCES = shell/rcalc.c
 shell_rcalc_CPPFLAGS = $(test_cppflags)
-shell_rcalc_LDADD = \
-	$(top_builddir)/src/shell/libshell.la \
-	$(test_ldadd) $(LIBDL)
+shell_rcalc_LDADD = $(top_builddir)/src/shell/libshell.la \
+	$(test_ldadd)
 
 shell_lptest_SOURCES = shell/lptest.c
 shell_lptest_CPPFLAGS = $(test_cppflags)
-shell_lptest_LDADD = \
-	$(test_ldadd) $(LIBDL)
+shell_lptest_LDADD = $(test_ldadd)
 
 shell_mpir_SOURCES = shell/mpir.c
 shell_mpir_CPPFLAGS = $(test_cppflags)
 shell_mpir_LDADD = \
 	$(top_builddir)/src/shell/libmpir.la \
-	$(test_ldadd) $(LIBDL)
+	$(test_ldadd)
 
 debug_stall_SOURCES = debug/stall.c
 debug_stall_CPPFLAGS = $(test_cppflags)
 
 reactor_reactorcat_SOURCES = reactor/reactorcat.c
 reactor_reactorcat_CPPFLAGS = $(test_cppflags)
-reactor_reactorcat_LDADD = \
-	 $(test_ldadd) $(LIBDL)
+reactor_reactorcat_LDADD = $(test_ldadd)
 
 rexec_rexec_SOURCES = rexec/rexec.c
 rexec_rexec_CPPFLAGS = $(test_cppflags)
-rexec_rexec_LDADD = \
-	$(test_ldadd) $(LIBDL)
+rexec_rexec_LDADD = $(test_ldadd)
 
 rexec_rexec_ps_SOURCES = rexec/rexec_ps.c
 rexec_rexec_ps_CPPFLAGS = $(test_cppflags)
-rexec_rexec_ps_LDADD = \
-	$(test_ldadd) $(LIBDL)
+rexec_rexec_ps_LDADD = $(test_ldadd)
 
 rexec_rexec_count_stdout_SOURCES = rexec/rexec_count_stdout.c
 rexec_rexec_count_stdout_CPPFLAGS = $(test_cppflags)
-rexec_rexec_count_stdout_LDADD = \
-	$(test_ldadd) $(LIBDL)
+rexec_rexec_count_stdout_LDADD = $(test_ldadd)
 
 rexec_rexec_getline_SOURCES = rexec/rexec_getline.c
 rexec_rexec_getline_CPPFLAGS = $(test_cppflags)
-rexec_rexec_getline_LDADD = \
-	$(test_ldadd) $(LIBDL)
+rexec_rexec_getline_LDADD = $(test_ldadd)
 
 ingest_job_manager_dummy_la_SOURCES = ingest/job-manager-dummy.c
 ingest_job_manager_dummy_la_CPPFLAGS = $(test_cppflags)
 ingest_job_manager_dummy_la_LDFLAGS = $(fluxmod_ldflags) -module -rpath /nowhere
-ingest_job_manager_dummy_la_LIBADD = \
-	$(test_ldadd) $(LIBDL)
+ingest_job_manager_dummy_la_LIBADD = $(test_ldadd)
 
 ingest_submitbench_SOURCES = ingest/submitbench.c
 ingest_submitbench_CPPFLAGS = $(test_cppflags)
-ingest_submitbench_LDADD = \
-	$(test_ldadd) $(LIBDL)
+ingest_submitbench_LDADD = $(test_ldadd)
 
 job_manager_list_jobs_SOURCES = job-manager/list-jobs.c
 job_manager_list_jobs_CPPFLAGS = $(test_cppflags)
-job_manager_list_jobs_LDADD = \
-	$(test_ldadd) $(LIBDL)
+job_manager_list_jobs_LDADD = $(test_ldadd)
 
 job_manager_print_constants_SOURCES = job-manager/print-constants.c
 job_manager_print_constants_CPPFLAGS = $(test_cppflags)
-job_manager_print_constants_LDADD = \
-	$(test_ldadd) $(LIBDL)
+job_manager_print_constants_LDADD = $(test_ldadd)
 
 job_manager_events_journal_stream_SOURCES = job-manager/events_journal_stream.c
 job_manager_events_journal_stream_CPPFLAGS = $(test_cppflags)
-job_manager_events_journal_stream_LDADD = \
-	$(test_ldadd) $(LIBDL)
+job_manager_events_journal_stream_LDADD = $(test_ldadd)
 
 disconnect_watcher_la_SOURCES = disconnect/watcher.c
 disconnect_watcher_la_CPPFLAGS = $(test_cppflags)
 disconnect_watcher_la_LDFLAGS = $(fluxmod_ldflags) -module -rpath /nowhere
-disconnect_watcher_la_LIBADD = \
-	$(test_ldadd) $(LIBDL)
+disconnect_watcher_la_LIBADD = $(test_ldadd)
 
 sched_simple_jj_reader_SOURCES = sched-simple/jj-reader.c
 sched_simple_jj_reader_CPPFLAGS = $(test_cppflags)
@@ -802,10 +762,8 @@ hwloc_hwloc_version_LDADD = $(HWLOC_LIBS) \
 
 util_jobspec1_validate_SOURCES = util/jobspec1-validate.c
 util_jobspec1_validate_CPPFLAGS = $(test_cppflags)
-util_jobspec1_validate_LDADD = \
-	$(test_ldadd) $(LIBDL)
+util_jobspec1_validate_LDADD = $(test_ldadd)
 
 util_handle_SOURCES = util/handle.c
 util_handle_CPPFLAGS = $(test_cppflags)
-util_handle_LDADD = \
-	$(test_ldadd) $(LIBDL)
+util_handle_LDADD = $(test_ldadd)

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -8,8 +8,7 @@ AM_LDFLAGS = \
 AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
-	-I$(top_builddir)/src/common/libflux \
-	$(ZMQ_CFLAGS)
+	-I$(top_builddir)/src/common/libflux
 
 #  Always set LUA_PATH such that builddir/?.lua is first so that the
 #   build version of fluxometer.lua is found.
@@ -388,7 +387,7 @@ test_ldadd = \
 	$(top_builddir)/src/common/libtap/libtap.la \
 	$(top_builddir)/src/common/libflux-optparse.la \
 	$(top_builddir)/src/common/libflux-core.la \
-	$(ZMQ_LIBS) $(LIBPTHREAD)
+	$(LIBPTHREAD)
 
 test_cppflags = \
 	-I$(top_srcdir)/src/common/libtap \


### PR DESCRIPTION
Per #3776, I found that ZMQ_CFLAGS and ZMQ_LIBS were used excessively throughout the Makefiles.  Libraries /modules that have no need to link to zmq (e.g. `liboptparse`) were linked to it.  Some of these were likely old additions that were no longer needed after refactoring with `libczmqcontainers`.   Others were likely lazy cut & paste issues.   As I went through, realized that many ZMQ_LIBS additions were unnecessary b/c other libs (e.g. `libflux-internal`) already links to it.  So cleaned those up too.

Along the way, noticed more unnecessary inclusions and just decided to go nuts, cleaning up LIBUUID, LIBSODIUM, HWLOC_CFLAGS, LIBDL, LIBRT, and JANSSON macros as well.  Some cases were stupid, where variables like `test_ldadd` included `FOO_LIBS`, and every test binary that used `test_ldadd` also linked to `FOO_LIBS`.

I may have missed some, but minimally its much more cleaned up.