### PR TITLE
Use CCAN base64 library over libsodium base64 library

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ automake          | automake          |                   |
 libtool           | libtool           |                   |
 make              | make              |                   |
 pkgconfig         | pkg-config        |                   |
-libsodium-devel   | libsodium-dev     | >= 1.0.14         |
 zeromq4-devel     | libzmq3-dev       | >= 4.0.4          |
 czmq-devel        | libczmq-dev       | >= 3.0.1          |
 jansson-devel     | libjansson-dev    | >= 2.6            |
@@ -78,12 +77,12 @@ jq                | jq                |
 
 ##### Installing RedHat/CentOS Packages
 ```
-yum install autoconf automake libtool make pkgconfig libsodium-devel zeromq4-devel czmq-devel libuuid-devel jansson-devel lz4-devel hwloc-devel sqlite-devel lua lua-devel lua-posix python36-devel python36-cffi python36-yaml python36-jsonschema python3-sphinx aspell aspell-en valgrind-devel mpich-devel jq
+yum install autoconf automake libtool make pkgconfig zeromq4-devel czmq-devel libuuid-devel jansson-devel lz4-devel hwloc-devel sqlite-devel lua lua-devel lua-posix python36-devel python36-cffi python36-yaml python36-jsonschema python3-sphinx aspell aspell-en valgrind-devel mpich-devel jq
 ```
 
 ##### Installing Ubuntu Packages
 ```
-apt install autoconf automake libtool make pkg-config libsodium-dev libzmq3-dev libczmq-dev uuid-dev libjansson-dev liblz4-dev libhwloc-dev libsqlite3-dev lua5.1 liblua5.1-dev lua-posix python3-dev python3-cffi python3-yaml python3-jsonschema python3-sphinx aspell aspell-en valgrind libmpich-dev jq
+apt install autoconf automake libtool make pkg-config libzmq3-dev libczmq-dev uuid-dev libjansson-dev liblz4-dev libhwloc-dev libsqlite3-dev lua5.1 liblua5.1-dev lua-posix python3-dev python3-cffi python3-yaml python3-jsonschema python3-sphinx aspell aspell-en valgrind libmpich-dev jq
 ```
 
 ##### Building from Source

--- a/configure.ac
+++ b/configure.ac
@@ -327,7 +327,6 @@ X_AC_JANSSON
 PKG_CHECK_MODULES([HWLOC], [hwloc >= 1.11.1], [], [])
 PKG_CHECK_MODULES([LZ4], [liblz4], [], [])
 PKG_CHECK_MODULES([SQLITE], [sqlite3], [], [])
-PKG_CHECK_MODULES([LIBSODIUM], [libsodium >= 1.0.14], [], [])
 PKG_CHECK_MODULES([LIBUUID], [uuid], [], [])
 LX_FIND_MPI
 AM_CONDITIONAL([HAVE_MPI], [test "$have_C_mpi" = yes])

--- a/src/broker/Makefile.am
+++ b/src/broker/Makefile.am
@@ -12,7 +12,6 @@ AM_CPPFLAGS = \
 	$(PMIX_CFLAGS) \
 	$(ZMQ_CFLAGS) \
 	$(LIBUUID_CFLAGS) \
-	$(LIBSODIUM_CFLAGS) \
 	$(JANSSON_CFLAGS) \
 	$(VALGRIND_CFLAGS)
 
@@ -72,7 +71,6 @@ flux_broker_LDADD = \
 	$(top_builddir)/src/common/libflux-optparse.la \
 	$(ZMQ_LIBS) \
 	$(LIBUUID_LIBS) \
-	$(LIBSODIUM_LIBS) \
 	$(JANSSON_LIBS) \
 	$(PMIX_LIBS) \
 	$(LIBDL)

--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -52,8 +52,7 @@ libflux_internal_la_LIBADD = \
 	$(LIBPTHREAD) \
 	$(LIBDL) \
 	$(LIBRT) \
-	$(FLUX_SECURITY_LIBS) \
-	$(LIBSODIUM_LIBS)
+	$(FLUX_SECURITY_LIBS)
 libflux_internal_la_LDFLAGS = $(san_ld_zdef_flag)
 
 lib_LTLIBRARIES = libflux-core.la \

--- a/src/common/libflux/Makefile.am
+++ b/src/common/libflux/Makefile.am
@@ -12,8 +12,7 @@ AM_CPPFLAGS = \
 	-I$(top_builddir) \
 	-I$(top_builddir)/src/common/libflux \
 	$(JANSSON_CFLAGS) \
-	$(ZMQ_CFLAGS) \
-	$(LIBSODIUM_CFLAGS)
+	$(ZMQ_CFLAGS)
 
 installed_conf_cppflags = \
 	-DINSTALLED_MODULE_PATH=\"$(fluxmoddir)\" \
@@ -177,7 +176,6 @@ test_ldadd = \
 	$(LIBUUID_LIBS) \
 	$(JANSSON_LIBS) \
 	$(LIBPTHREAD) \
-	$(LIBSODIUM_LIBS) \
 	$(LIBDL)
 
 test_cppflags = \

--- a/src/common/libioencode/ioencode.c
+++ b/src/common/libioencode/ioencode.c
@@ -35,7 +35,7 @@ static json_t *data_encode_base64 (const char *stream,
     char *dest = NULL;
     size_t destlen = base64_encoded_length (len) + 1; /* +1 for NUL */
 
-    if ((dest = calloc (1, destlen))
+    if ((dest = malloc (destlen))
         && (n = base64_encode (dest, destlen, data, len)) >= 0) {
             o = json_pack ("{s:s s:s s:s s:s#}",
                            "stream", stream,
@@ -102,7 +102,7 @@ static int decode_data_base64 (char *src,
 {
     ssize_t rc;
     size_t size = base64_decoded_length (srclen);
-    if (!(*datap = calloc (1, size)))
+    if (!(*datap = malloc (size)))
         return -1;
     if ((rc = base64_decode (*datap, size, src, srclen)) < 0)
         return -1;

--- a/src/common/libjob/Makefile.am
+++ b/src/common/libjob/Makefile.am
@@ -10,8 +10,7 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir)/src/include \
 	-I$(top_builddir)/src/common/libflux \
 	$(JANSSON_CFLAGS) \
-	$(FLUX_SECURITY_CFLAGS) \
-	$(LIBSODIUM_CFLAGS)
+	$(FLUX_SECURITY_CFLAGS)
 
 noinst_LTLIBRARIES = libjob.la
 fluxcoreinclude_HEADERS = \
@@ -54,8 +53,7 @@ test_ldadd = \
 	$(top_builddir)/src/common/libtap/libtap.la \
 	$(JANSSON_LIBS) \
 	$(LIBPTHREAD) \
-	$(FLUX_SECURITY_LIBS) \
-	$(LIBSODIUM_LIBS)
+	$(FLUX_SECURITY_LIBS)
 
 test_cppflags = \
 	$(AM_CPPFLAGS) \

--- a/src/common/libjob/Makefile.am
+++ b/src/common/libjob/Makefile.am
@@ -41,25 +41,25 @@ TESTS = \
 	test_jobspec1.t
 
 check_PROGRAMS = \
-        $(TESTS)
+	$(TESTS)
 
 TEST_EXTENSIONS = .t
 T_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
-        $(top_srcdir)/config/tap-driver.sh
+	$(top_srcdir)/config/tap-driver.sh
 
 test_ldadd = \
-        $(top_builddir)/src/common/libjob/libjob.la \
-        $(top_builddir)/src/common/libflux/libflux.la \
-        $(top_builddir)/src/common/libflux-internal.la \
-        $(top_builddir)/src/common/libtap/libtap.la \
+	$(top_builddir)/src/common/libjob/libjob.la \
+	$(top_builddir)/src/common/libflux/libflux.la \
+	$(top_builddir)/src/common/libflux-internal.la \
+	$(top_builddir)/src/common/libtap/libtap.la \
 	$(JANSSON_LIBS) \
 	$(LIBPTHREAD) \
-        $(FLUX_SECURITY_LIBS) \
+	$(FLUX_SECURITY_LIBS) \
 	$(LIBSODIUM_LIBS)
 
 test_cppflags = \
-        $(AM_CPPFLAGS) \
-        -I$(top_srcdir)/src/common/libtap
+	$(AM_CPPFLAGS) \
+	-I$(top_srcdir)/src/common/libtap
 
 test_job_t_SOURCES = test/job.c
 test_job_t_CPPFLAGS = $(test_cppflags)

--- a/src/common/libkvs/Makefile.am
+++ b/src/common/libkvs/Makefile.am
@@ -9,8 +9,7 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
 	-I$(top_builddir)/src/common/libflux \
-	$(JANSSON_CFLAGS) \
-	$(LIBSODIUM_CFLAGS)
+	$(JANSSON_CFLAGS)
 
 noinst_LTLIBRARIES = libkvs.la
 

--- a/src/common/libkvs/treeobj.c
+++ b/src/common/libkvs/treeobj.c
@@ -512,10 +512,8 @@ json_t *treeobj_create_val (const void *data, int len)
     json_t *obj = NULL;
 
     xlen = sodium_base64_encoded_len (len, sodium_base64_VARIANT_ORIGINAL);
-    if (!(xdata = malloc (xlen))) {
-        errno = ENOMEM;
+    if (!(xdata = malloc (xlen)))
         goto done;
-    }
     sodium_bin2base64 (xdata, xlen, (const unsigned char *)data, len,
                               sodium_base64_VARIANT_ORIGINAL);
 

--- a/src/common/libkvs/treeobj.c
+++ b/src/common/libkvs/treeobj.c
@@ -16,11 +16,13 @@
 #include <errno.h>
 #include <string.h>
 #include <assert.h>
-#include <sodium.h>
+#include <stdbool.h>
+#include <jansson.h>
+
+#include "src/common/libccan/ccan/base64/base64.h"
+#include "src/common/libutil/blobref.h"
 
 #include "treeobj.h"
-#include "src/common/libutil/macros.h"
-#include "src/common/libutil/blobref.h"
 
 static const int treeobj_version = 1;
 
@@ -214,7 +216,8 @@ int treeobj_decode_val (const json_t *obj, void **dp, int *lp)
 {
     const char *type, *xdatastr;
     const json_t *xdata;
-    size_t len, xlen;
+    size_t databuflen, xlen;
+    ssize_t datalen;
     char *data;
 
     if (treeobj_peek (obj, &type, &xdata) < 0
@@ -224,14 +227,12 @@ int treeobj_decode_val (const json_t *obj, void **dp, int *lp)
     }
     xdatastr = json_string_value (xdata);
     xlen = strlen (xdatastr);
-    len = BASE64_DECODE_SIZE (xlen) + 1; // includes space for a trailing \0
+    databuflen = base64_decoded_length (xlen) + 1; // +1  for a trailing \0
 
-    if (len > 1) {
-        if (!(data = calloc (1, len)))
+    if (databuflen > 1) {
+        if (!(data = malloc (databuflen)))
             return -1;
-        if (sodium_base642bin ((unsigned char *)data, len, xdatastr, xlen,
-                               NULL, &len, NULL,
-                               sodium_base64_VARIANT_ORIGINAL) < 0) {
+        if ((datalen = base64_decode (data, databuflen, xdatastr, xlen)) < 0) {
             free (data);
             errno = EINVAL;
             return -1;
@@ -239,10 +240,10 @@ int treeobj_decode_val (const json_t *obj, void **dp, int *lp)
     }
     else {
         data = NULL;
-        len = 0;
+        datalen = 0;
     }
     if (lp)
-        *lp = len;
+        *lp = datalen;
     if (dp)
         *dp = data;
     else
@@ -511,12 +512,11 @@ json_t *treeobj_create_val (const void *data, int len)
     char *xdata;
     json_t *obj = NULL;
 
-    xlen = sodium_base64_encoded_len (len, sodium_base64_VARIANT_ORIGINAL);
+    xlen = base64_encoded_length (len) + 1; /* +1 for NUL */
     if (!(xdata = malloc (xlen)))
         goto done;
-    sodium_bin2base64 (xdata, xlen, (const unsigned char *)data, len,
-                              sodium_base64_VARIANT_ORIGINAL);
-
+    if (base64_encode (xdata, xlen, (char *)data, len) < 0)
+        goto done;
     if (!(obj = json_pack ("{s:i s:s s:s}", "ver", treeobj_version,
                                             "type", "val",
                                             "data", xdata))) {

--- a/src/common/libsubprocess/remote.c
+++ b/src/common/libsubprocess/remote.c
@@ -18,8 +18,6 @@
 #include <errno.h>
 #include <assert.h>
 
-#include <sodium.h>
-
 #include <flux/core.h>
 
 #include "src/common/libczmqcontainers/czmq_containers.h"

--- a/src/common/libsubprocess/server.c
+++ b/src/common/libsubprocess/server.c
@@ -18,8 +18,6 @@
 #include <errno.h>
 #include <assert.h>
 
-#include <sodium.h>
-
 #include <flux/core.h>
 
 #include "src/common/libczmqcontainers/czmq_containers.h"

--- a/src/common/libutil/macros.h
+++ b/src/common/libutil/macros.h
@@ -15,13 +15,4 @@
 #define STRINGIFY(X) REAL_STRINGIFY (X)
 #define SIZEOF_FIELD(type, field) sizeof (((type *)0)->field)
 
-/* Maximum size of buffer needed to decode a base64 string of length 'x',
- * where 4 characters are decoded into 3 bytes.  Add 3 bytes to ensure a
- * partial 4-byte chunk will be accounted for during integer division.
- * This size is safe for use with all (4) libsodium base64 variants.
- * N.B. unlike @dun's base64 implementation from the munge project,
- * this size does not include room for a \0 string terminator.
- */
-#define BASE64_DECODE_SIZE(x) ((((x) + 3) / 4) * 3)
-
 #endif

--- a/src/modules/job-archive/job-archive.c
+++ b/src/modules/job-archive/job-archive.c
@@ -21,7 +21,6 @@
 #include <unistd.h>
 #include <stdbool.h>
 #include <flux/core.h>
-#include <sodium.h>
 #include <jansson.h>
 #include <sqlite3.h>
 

--- a/src/modules/kvs/Makefile.am
+++ b/src/modules/kvs/Makefile.am
@@ -10,7 +10,6 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir)/src/include \
 	-I$(top_srcdir)/src/common/libccan \
 	-I$(top_builddir)/src/common/libflux \
-	$(LIBSODIUM_CFLAGS) \
 	$(JANSSON_CFLAGS)
 
 fluxmod_LTLIBRARIES = kvs.la
@@ -36,8 +35,7 @@ kvs_la_LDFLAGS = $(fluxmod_ldflags) -module
 kvs_la_LIBADD = $(top_builddir)/src/common/libkvs/libkvs.la \
 		$(top_builddir)/src/common/libflux-internal.la \
 		$(top_builddir)/src/common/libflux-core.la \
-		$(JANSSON_LIBS) \
-		$(LIBSODIUM_LIBS)
+		$(JANSSON_LIBS)
 
 TESTS = \
 	test_waitqueue.t \

--- a/t/lua/t0003-events.t
+++ b/t/lua/t0003-events.t
@@ -77,7 +77,7 @@ local response, err = f:rpc ("event.pub", request);
 is (err, "Protocol error", "event.pub: no flags, fails with EPROTO")
 
 -- mangled base64 payload
-local request = { topic = "foo", flags = 0, payload = "aGVsbG8gd29ybGQ" }
+local request = { topic = "foo", flags = 0, payload = "aGVsbG8gd29ybGQ%" }
 local response, err = f:rpc ("event.pub", request);
 is (err, "Protocol error", "event.pub: bad base64, fails with EPROTO")
 


### PR DESCRIPTION
Per #3787 and some other discussions, replace base64 use in flux-core with the ccan library over the libsodium library.

As a result, we can eliminate the linking of libsodium throughout flux-core.

Note, that I left `libsodium` in the DockerFiles for the time being, as its still needed for `flux-security`.  I think this is the right thing to do?
