### PR TITLE
testsuite: add valgrind suppression for opencl

### DIFF
--- a/t/valgrind/valgrind.supp
+++ b/t/valgrind/valgrind.supp
@@ -112,3 +112,14 @@
    fun:hwloc_topology_load
    ...
 }
+{
+   <issue_3793>
+   Memcheck:Addr1
+   obj:*/libnvidia-opencl.so.*
+   ...
+   fun:clGetPlatformIDs
+   obj:*/hwloc_opencl.so
+   obj:*/libhwloc.so.*
+   fun:hwloc_topology_load
+   ...
+}


### PR DESCRIPTION
Problem: valgrind test reports a new invalid read error
on system with OpenCL installed.

Add a valgrind suppression.

Fixes #3793