### PR TITLE
add stats api for internal metric collection

### DIFF
--- a/src/broker/content-cache.c
+++ b/src/broker/content-cache.c
@@ -920,6 +920,25 @@ void content_cache_destroy (struct content_cache *cache)
     }
 }
 
+static void timer_cb (flux_reactor_t *r, 
+                      flux_watcher_t *w, 
+                      int revents, 
+                      void *arg)
+{
+    struct content_cache *cache = arg;
+
+    flux_stats_gauge (cache->h, "flux.content-cache.count",
+        (int) zhashx_size (cache->entries), false);
+    flux_stats_gauge (cache->h, "flux.content-cache.valid",
+        cache->acct_valid, false);
+    flux_stats_gauge (cache->h, "flux.content-cache.dirty",
+        cache->acct_dirty, false);
+    flux_stats_gauge (cache->h, "flux.content-cache.size",
+        cache->acct_size, false);
+    flux_stats_gauge (cache->h, "flux.content-cache.flush-batch-count",
+        cache->flush_batch_count, false);
+}
+
 struct content_cache *content_cache_create (flux_t *h, attr_t *attrs)
 {
     struct content_cache *cache;

--- a/src/common/libflux/Makefile.am
+++ b/src/common/libflux/Makefile.am
@@ -81,7 +81,8 @@ fluxcoreinclude_HEADERS = \
 	service.h \
 	plugin.h \
 	sync.h \
-	disconnect.h
+	disconnect.h \
+	stats.h
 
 nodist_fluxcoreinclude_HEADERS = \
 	version.h
@@ -126,7 +127,10 @@ libflux_la_SOURCES = \
 	version.c \
 	plugin.c \
 	sync.c \
-	disconnect.c
+	disconnect.c \
+	stats.c \
+	fripp.h \
+	fripp.c
 
 libflux_la_CPPFLAGS = \
 	$(installed_conf_cppflags) \

--- a/src/common/libflux/flux.h
+++ b/src/common/libflux/flux.h
@@ -37,6 +37,7 @@
 #include "plugin.h"
 #include "sync.h"
 #include "disconnect.h"
+#include "stats.h"
 
 #endif /* !_FLUX_CORE_FLUX_H */
 

--- a/src/common/libflux/fripp.c
+++ b/src/common/libflux/fripp.c
@@ -1,0 +1,468 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <stdbool.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <syslog.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "attr.h"
+#include "flog.h"
+#include "fripp.h"
+#include "reactor.h"
+
+#include "src/common/libczmqcontainers/czmq_containers.h"
+#include "src/common/libutil/iterators.h"
+
+#define FRIPP_MAX_PACKET_LEN 1440
+#define INTERNAL_BUFFSIZE 128
+#define DEFAULT_AGG_PERIOD 1.0
+
+typedef enum {
+    BRUBECK_COUNTER,
+    BRUBECK_GAUGE,
+    BRUBECK_TIMER
+} metric_type;
+
+union val {
+    ssize_t l;
+    double d;
+};
+
+struct metric {
+    union val cur;
+    union val prev;
+    bool inc;
+    metric_type type;
+};
+
+struct fripp_ctx {
+    struct sockaddr_in si_server;
+    int sock;
+    int buf_len;
+    int tail;
+    char *buf;
+    char prefix[INTERNAL_BUFFSIZE];
+
+    zhashx_t *metrics;
+    zlist_t *done;
+    flux_watcher_t *w;
+    double period;
+};
+
+bool fripp_enabled (struct fripp_ctx *ctx, const char *metric)
+{
+    if (ctx && metric)
+        return zhashx_lookup (ctx->metrics, metric) != NULL;
+
+    return getenv ("FLUX_FRIPP_STATSD") != NULL;
+}
+
+void fripp_set_prefix (struct fripp_ctx *ctx, const char *prefix)
+{
+    strncpy (ctx->prefix, prefix, INTERNAL_BUFFSIZE - 1);
+}
+
+static int split_packet (char *packet, int len)
+{
+    for (int i = len - 1; i >= 0; --i) {
+        if (packet[i] == '\n' || packet[i] == '\0') {
+            packet[i] = '\0';
+            return i;
+        }
+    }
+
+    return -1;
+}
+
+static int fripp_send_metrics (struct fripp_ctx *ctx)
+{
+    int len, sock_len = sizeof (ctx->si_server);
+    bool split;
+    char *packet = ctx->buf;
+
+    do {
+        split = false;
+        len = strlen (packet);
+
+        if (len > FRIPP_MAX_PACKET_LEN)
+            split = true;
+        if ((len = split_packet (packet, len > FRIPP_MAX_PACKET_LEN ?
+                FRIPP_MAX_PACKET_LEN : len)) == -1)
+            return -1;
+        (void) sendto (ctx->sock, packet, len, 0,
+                    (void *) &ctx->si_server, sock_len);
+    } while (split && (packet = &packet[len + 1]));
+
+    return 0;
+}
+
+int fripp_packet_appendf (struct fripp_ctx *ctx, const char *fmt, ...)
+{
+    va_list ap, cpy;
+    va_start (ap, fmt);
+    va_copy (cpy, ap);
+
+    char buf[INTERNAL_BUFFSIZE];
+    int len, rc = 0;
+
+    if ((len = vsnprintf (buf, INTERNAL_BUFFSIZE, fmt, ap))
+            >= INTERNAL_BUFFSIZE) {
+        rc = -1;
+        goto done;
+    }
+
+    ctx->tail += len;
+
+    if (ctx->tail >= ctx->buf_len) {
+        char *tmp;
+        if (!(tmp = realloc(ctx->buf, (ctx->tail + 1) * sizeof (char)))) {
+            rc = -1;
+            goto done;
+        }
+
+        ctx->buf_len = ctx->tail + 1;
+        ctx->buf = tmp;
+    }
+
+    strcat (ctx->buf, buf);
+
+done:
+    va_end (ap);
+    va_end (cpy);
+
+    return rc;
+}
+
+int fripp_sendf (struct fripp_ctx *ctx, const char *fmt, ...)
+{
+    va_list ap, cpy;
+    va_start (ap, fmt);
+    va_copy (cpy, ap);
+
+    int len, rc = 0;
+
+    if ((len = vsnprintf (ctx->buf, ctx->buf_len, fmt, ap))
+         >= ctx->buf_len) {
+
+        char *tmp;
+        if (!(tmp = realloc (ctx->buf, (len + 1) * sizeof (char)))) {
+            rc = -1;
+            goto done;
+        }
+
+        ctx->buf = tmp;
+        ctx->buf_len = len + 1;
+        (void) vsnprintf (ctx->buf, ctx->buf_len, fmt, cpy);
+    }
+
+    rc = fripp_send_metrics (ctx);
+
+done:
+    va_end (ap);
+    va_end (cpy);
+
+    return rc;
+}
+
+int fripp_count (struct fripp_ctx *ctx,
+                 const char *name,
+                 ssize_t count)
+{
+    if (ctx->period == 0)
+        return fripp_sendf (ctx, "%s.%s:%zd|C\n", ctx->prefix, name, count);
+
+    struct metric *m;
+
+    if (!(m = zhashx_lookup (ctx->metrics, name))) {
+        if (!(m = malloc (sizeof (*m))))
+            return -1;
+
+        zhashx_insert (ctx->metrics, name, (void *) m);
+        m->prev.l = -1;
+    }
+
+    m->type = BRUBECK_COUNTER;
+    m->inc = false;
+    m->cur.l = count;
+
+    flux_watcher_start (ctx->w);
+
+    return 0;
+}
+
+int fripp_gauge (struct fripp_ctx *ctx,
+                 const char *name,
+                 ssize_t value,
+                 bool inc)
+{
+    if (ctx->period == 0)
+        return fripp_sendf (ctx, inc && value > 0 ?
+                            "%s.%s:+%zd|g\n" : "%s.%s:%zd|g\n",
+                            ctx->prefix, name, value);
+
+    struct metric *m;
+
+    if (!(m = zhashx_lookup (ctx->metrics, name))) {
+        if (!(m = calloc (1, sizeof (*m))))
+            return -1;
+
+        zhashx_insert (ctx->metrics, name, (void *) m);
+        m->prev.l = -1;
+    }
+
+    m->type = BRUBECK_GAUGE;
+    m->inc = inc;
+    m->cur.l = inc ? m->cur.l + value : value;
+
+    flux_watcher_start (ctx->w);
+
+    return 0;
+}
+
+int fripp_timing (struct fripp_ctx *ctx,
+                  const char *name,
+                  double ms)
+{
+    if (ctx->period == 0)
+        return fripp_sendf (ctx, "%s.%s:%lf|ms\n", ctx->prefix, name, ms);
+
+    struct metric *m;
+
+    if (!(m = zhashx_lookup (ctx->metrics, name))) {
+        if (!(m = malloc (sizeof (*m))))
+            return -1;
+
+        zhashx_insert (ctx->metrics, name, (void *) m);
+        m->prev.d = -1.0;
+    }
+
+    m->type = BRUBECK_TIMER;
+    m->inc = false;
+    m->cur.d = ms;
+
+    flux_watcher_start (ctx->w);
+
+    return 0;
+}
+
+static void metric_destroy (void **item)
+{
+    if (item) {
+        free (*item);
+        *item = NULL;
+    }
+}
+
+static void timer_cb (flux_reactor_t *r,
+                      flux_watcher_t *w,
+                      int revents,
+                      void *arg)
+{
+    struct fripp_ctx *ctx = arg;
+    const char *name;
+    struct metric *m;
+
+    int rc = 0;
+
+    if (!ctx->buf[0] && zhashx_size (ctx->metrics) == 0) {
+        flux_watcher_stop (ctx->w);
+        return;
+    }
+
+    FOREACH_ZHASHX (ctx->metrics, name, m) {
+        if ((m->type == BRUBECK_COUNTER || m->type == BRUBECK_GAUGE)
+                && m->cur.l == m->prev.l) {
+            zlist_append (ctx->done, (void *) name);
+            continue;
+        }
+        if (m->type == BRUBECK_TIMER && m->cur.d == m->prev.d) {
+            zlist_append (ctx->done, (void *) name);
+            continue;
+        }
+
+        m->prev.l = m->cur.l;
+
+        switch (m->type) {
+            case BRUBECK_COUNTER:
+                rc = fripp_packet_appendf (ctx,
+                                           "%s.%s:%zd|C\n",
+                                           ctx->prefix,
+                                           name,
+                                           m->cur.l);
+                break;
+            case BRUBECK_GAUGE:
+                rc = fripp_packet_appendf (ctx,
+                                           "%s.%s:%zd|g\n",
+                                           ctx->prefix,
+                                           name,
+                                           m->cur.l);
+                break;
+            case BRUBECK_TIMER:
+                rc = fripp_packet_appendf (ctx,
+                                           "%s.%s:%lf|ms\n",
+                                           ctx->prefix,
+                                           name,
+                                           m->cur.d);
+                break;
+            default:
+                break;
+        }
+
+        if (rc)
+            continue;
+    }
+
+    fripp_send_metrics (ctx);
+
+    char *s;
+    while ((s = zlist_pop (ctx->done)))
+        zhashx_delete (ctx->metrics, s);
+
+    memset (ctx->buf, 0, ctx->buf_len);
+
+    ctx->tail = 0;
+}
+
+void fripp_set_agg_period (struct fripp_ctx *ctx, double period)
+{
+    if (period <= 0) {
+        flux_watcher_stop (ctx->w);
+        ctx->period = 0;
+        return;
+    }
+
+    ctx->period = period;
+    double after = flux_watcher_next_wakeup (ctx->w) - (double) time (NULL);
+
+    flux_timer_watcher_reset (ctx->w, after, ctx->period);
+}
+
+void fripp_ctx_destroy (void *arg)
+{
+    struct fripp_ctx *ctx = arg;
+
+    if (ctx->w) {
+        flux_watcher_stop (ctx->w);
+        flux_watcher_destroy (ctx->w);
+    }
+    if (ctx->metrics) {
+        zhashx_purge (ctx->metrics);
+        zhashx_destroy (&ctx->metrics);
+    }
+    if (ctx->done) {
+        zlist_destroy (&ctx->done);
+    }
+    close (ctx->sock);
+    free (ctx->buf);
+    free (ctx);
+}
+
+struct fripp_ctx *fripp_ctx_create (flux_t *h)
+{
+    struct fripp_ctx *ctx;
+    char *uri, *port_s = NULL, *host = NULL;
+
+    if (!(ctx = calloc (1, sizeof (*ctx)))) {
+        flux_log_error (h, "fripp_ctx_create");
+        goto error;
+    }
+    if (!(uri = getenv ("FLUX_FRIPP_STATSD"))) {
+        flux_log_error (h, "FLUX_FRIPP_STATSD env var not set");
+        goto error;
+    }
+    if (!(port_s = strrchr (uri, ':'))) {
+        flux_log_error (h, "FLUX_FRIPP_STATSD env var no port");
+        goto error;
+    }
+    if (!(host = calloc (1, port_s - uri + 1))) {
+        flux_log_error (h, "fripp_ctx_create");
+        goto error;
+    }
+
+    strncpy (host, uri, port_s - uri);
+    uint16_t port = (uint16_t) atoi (++port_s);
+
+    memset (&ctx->si_server, 0, sizeof (ctx->si_server));
+    ctx->si_server.sin_family = AF_INET;
+    ctx->si_server.sin_port = htons (port);
+
+    if (!inet_aton (host, &ctx->si_server.sin_addr)) {
+        flux_log_error (h, "error creating server address");
+        free (host);
+        goto error;
+    }
+
+    free (host);
+
+    if ((ctx->sock = socket(AF_INET, SOCK_DGRAM, 0)) == -1) {
+        flux_log_error (h, "error opening socket");
+        goto error;
+    }
+    if (!(ctx->buf = calloc (1, INTERNAL_BUFFSIZE))) {
+        flux_log_error (h, "calloc");
+        close (ctx->sock);
+        goto error;
+    }
+
+    ctx->buf_len = INTERNAL_BUFFSIZE;
+    ctx->tail = 0;
+
+    uint32_t rank;
+    char buf[16];
+    flux_get_rank (h, &rank);
+    sprintf (buf, "flux.%d", rank);
+    fripp_set_prefix (ctx, buf);
+
+    if (!(ctx->metrics = zhashx_new ())) {
+        fripp_ctx_destroy (ctx);
+        return NULL;
+    }
+
+    zhashx_set_destructor (ctx->metrics, metric_destroy);
+
+
+    if (!(ctx->done = zlist_new ())) {
+        fripp_ctx_destroy (ctx);
+        return NULL;
+    }
+    if (!(ctx->w = flux_timer_watcher_create (
+              flux_get_reactor(h),
+              DEFAULT_AGG_PERIOD,
+              DEFAULT_AGG_PERIOD,
+              timer_cb,
+              ctx))) {
+        fripp_ctx_destroy (ctx);
+        return NULL;
+    }
+
+
+    ctx->period = DEFAULT_AGG_PERIOD;
+    flux_watcher_start (ctx->w);
+
+    return ctx;
+
+error:
+    if (ctx)
+        free (ctx);
+    return NULL;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libflux/fripp.h
+++ b/src/common/libflux/fripp.h
@@ -1,0 +1,72 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _FLUX_CORE_FRIPP_H
+#define _FLUX_CORE_FRIPP_H
+
+#include <stdarg.h>
+
+#include "handle.h"
+
+struct fripp_ctx;
+
+struct fripp_ctx *fripp_ctx_create (flux_t *h);
+void fripp_ctx_destroy (void *arg);
+
+/* Format and append a packet to the internal queue to be sent on the
+ * next flush.
+ */
+int fripp_packet_appendf (struct fripp_ctx *ctx, const char *fmt, ...)
+        __attribute__ ((format (printf, 2, 3)));
+
+/* Format and send a single packet immediately.
+ */
+int fripp_sendf (struct fripp_ctx *ctx, const char *fmt, ...)
+        __attribute__ ((format (printf, 2, 3)));
+
+/* Update (or create) and store 'count' for 'name' to be sent on the
+ * next flush.
+ */
+int fripp_count (struct fripp_ctx *ctx, const char *name, ssize_t count);
+
+/* Update (or create) and store 'value' for 'name' to be sent on the
+ * next flush. The'inc' indicates wether or not 'value' is some delta on
+ * the previous value. If 'inc' is set and 'name' was not previously stored,
+ * then the value is stored directly.
+ */
+int fripp_gauge (struct fripp_ctx *ctx, const char *name, ssize_t value, bool inc);
+
+/* Update (or create) and store 'ms' for 'name' to be sent on the
+ * next flush.
+ */
+int fripp_timing (struct fripp_ctx *ctx, const char *name, double ms);
+
+/* Update the internal aggregation period over which metrics accumulate
+ * before being set. A 'period' of '0' indicates the metrics should be
+ * sent immediately.
+ */
+void fripp_set_agg_period (struct fripp_ctx *ctx, double period);
+
+/* Check whether fripp collection is enabled. If 'metric' is non-NULL
+ *check if it is currently being tracked.
+ */
+bool fripp_enabled (struct fripp_ctx *ctx, const char *metric);
+
+/* Set the prefix to be preprended to all metrics sent from the handle.
+ * The prefix has a max limit of 127 characters. The default prefix is
+ * flux.{{rank}}.
+ */
+void fripp_set_prefix (struct fripp_ctx *ctx, const char *prefix);
+
+#endif
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libflux/stats.c
+++ b/src/common/libflux/stats.c
@@ -1,0 +1,113 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdio.h>
+
+#include "fripp.h"
+#include "stats.h"
+
+#define FRIPP_AUX_TAG "flux::fripp"
+
+static struct fripp_ctx *get_fripp_ctx (flux_t *h)
+{
+    if (!fripp_enabled (NULL, NULL))
+        return NULL;
+
+    struct fripp_ctx *ctx;
+    if (!(ctx = flux_aux_get (h, FRIPP_AUX_TAG))) {
+        if (!(ctx = fripp_ctx_create (h)))
+            return NULL;
+        if (flux_aux_set (h, FRIPP_AUX_TAG, ctx, fripp_ctx_destroy) == -1) {
+            fripp_ctx_destroy (ctx);
+            return NULL;
+        }
+    }
+
+    return ctx;
+}
+
+void flux_stats_count (flux_t *h, const char *name, ssize_t count)
+{
+    struct fripp_ctx *ctx;
+    if (!(ctx = get_fripp_ctx (h)))
+        return;
+
+    fripp_count (ctx, name, count);
+}
+
+void flux_stats_gauge_set (flux_t *h, const char *name, ssize_t value)
+{
+    struct fripp_ctx *ctx;
+    if (!(ctx = get_fripp_ctx (h)))
+        return;
+
+    fripp_gauge (ctx, name, value, false);
+}
+
+void flux_stats_gauge_inc (flux_t *h, const char *name, ssize_t inc)
+{
+    struct fripp_ctx *ctx;
+    if (!(ctx = get_fripp_ctx (h)))
+        return;
+
+    fripp_gauge (ctx, name, inc, true);
+}
+
+void flux_stats_timing (flux_t *h, const char *name, double ms)
+{
+    struct fripp_ctx *ctx;
+    if (!(ctx = get_fripp_ctx (h)))
+        return;
+
+    fripp_timing (ctx, name, ms);
+}
+
+
+void flux_stats_set_period (flux_t *h, double period)
+{
+    struct fripp_ctx *ctx;
+    if (!(ctx = get_fripp_ctx (h)))
+        return;
+
+    fripp_set_agg_period (ctx, period);
+}
+
+void flux_stats_set_prefix (flux_t *h, const char *fmt, ...)
+{
+    struct fripp_ctx *ctx;
+    if (!(ctx = get_fripp_ctx (h)))
+        return;
+
+    va_list ap;
+    va_start (ap, fmt);
+
+    char prefix[128];
+    if (vsnprintf (prefix, sizeof (prefix), fmt, ap) >= 128)
+        goto done;
+
+    fripp_set_prefix (ctx, prefix);
+
+done:
+    va_end (ap);
+}
+
+bool flux_stats_enabled (flux_t *h, const char *metric)
+{
+    return fripp_enabled (get_fripp_ctx (h), metric);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libflux/stats.h
+++ b/src/common/libflux/stats.h
@@ -1,0 +1,82 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _FLUX_CORE_STATS_H
+#define _FLUX_CORE_STATS_H
+
+#include "handle.h"
+
+/* Metric types:
+ * Counter - An integer value that will, on the backend (brubeck) send the
+ *           count and reset to 0 at each flush. It calculates the change
+ *           from the value sent at the previous flush.
+ *           An example of where to use a counter is the builtin msgcounters
+ *           that are part of each flux_t handle. The counts will continually
+ *           increase and brubeck will handle calculating the count sent in
+ *           the interval.
+ * Gauge   - An integer that takes an arbitrary value and maintains its
+ *           value until it is set again. Gauges can also take incremental
+ *           values in the form of a + or - in front of the value which
+ *           increments the previously stored value.
+ *           An example of where to use a gauge is to track the current
+ *           size of the broker's content-cache. At each point, the cache's
+ *           sizes are independent of each other.
+ * Timing  - A double value which represents the time taken for a given
+ *           task in ms.
+ *           An example of where to use a timer is timing the length of
+ *           asynchronous loads in the broker's content-cache. The cache
+ *           entry can keep track of when the load was started and then
+ *           calculate and send the time taken once the entry is loaded.
+ */
+
+/* Update (or create) and store 'count' for 'name' to be sent on the
+ * next flush.
+ */
+void flux_stats_count (flux_t *h, const char *name, ssize_t count);
+
+/* Update (or create) and store 'value' for 'name' to be sent on the
+ * next flush.
+ */
+void flux_stats_gauge_set (flux_t *h, const char *name, ssize_t value);
+
+/* Update (or create) and increment 'value' for 'name' to be sent on the
+ * next flush. If'name' was not previously stored, then the value is stored
+ * directly (i.e. assumed 0 previous value).
+ */
+void flux_stats_gauge_inc (flux_t *h, const char *name, ssize_t inc);
+
+
+/* Update (or create) and store 'ms' for 'name' to be sent on the
+ * next flush.
+ */
+void flux_stats_timing (flux_t *h, const char *name, double ms);
+
+/* Update the internal aggregation period over which metrics accumulate
+ * before being set. A 'period' of '0' indicates the metrics should be
+ * sent immediately. The default aggregation period is 1s.
+ */
+void flux_stats_set_period (flux_t *h, double period);
+
+/* Set the prefix to be preprended to all metrics sent from the handle.
+ * The prefix has a max limit of 127 characters. The default prefix is
+ * flux.{{rank}}.
+ */
+void flux_stats_set_prefix (flux_t *h, const char *fmt, ...);
+
+/* Check whether stats collection is enabled on the flux handle.
+ * If 'metric' is non-NULL check if it is currently being tracked.
+ */
+bool flux_stats_enabled (flux_t *h, const char *metric);
+
+#endif
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -94,6 +94,7 @@ TESTSCRIPTS = \
 	t1106-ssh-connector.t \
 	t1107-heartbeat.t \
 	t1108-local-opt.t \
+	t1200-stats-basic.t \
 	t2004-hydra.t \
 	t2005-hwloc-basic.t \
 	t2006-hwloc-versions.t \
@@ -265,6 +266,7 @@ dist_check_SCRIPTS = \
 	scripts/sign-as.py \
 	scripts/runpty.py \
 	scripts/dmesg-grep.py \
+	scripts/stats-listen.py \
 	valgrind/valgrind-workload.sh \
 	valgrind/workload.d/job \
 	kvs/kvs-helper.sh \
@@ -366,7 +368,9 @@ check_LTLIBRARIES = \
 	job-manager/plugins/jobtap_api.la \
 	job-manager/plugins/random.la \
 	job-manager/plugins/validate.la \
-	job-manager/plugins/dependency-test.la
+	job-manager/plugins/dependency-test.la \
+	stats/stats-basic.la \
+	stats/stats-immediate.la
 
 check-prep:
 	$(MAKE) $(check_PROGRAMS) $(check_LTLIBRARIES)
@@ -768,3 +772,19 @@ util_jobspec1_validate_LDADD = $(test_ldadd)
 util_handle_SOURCES = util/handle.c
 util_handle_CPPFLAGS = $(test_cppflags)
 util_handle_LDADD = $(test_ldadd)
+
+stats_stats_basic_la_SOURCES = stats/stats-basic.c
+stats_stats_basic_la_CPPFLAGS = $(test_cppflags)
+stats_stats_basic_la_LDFLAGS = \
+	$(fluxplugin_ldflags) -module -rpath /nowhere
+stats_stats_basic_la_LIBADD = \
+	$(top_builddir)/src/common/libflux-internal.la \
+	$(top_builddir)/src/common/libflux-core.la
+
+stats_stats_immediate_la_SOURCES = stats/stats-immediate.c
+stats_stats_immediate_la_CPPFLAGS = $(test_cppflags)
+stats_stats_immediate_la_LDFLAGS = \
+	$(fluxplugin_ldflags) -module -rpath /nowhere
+stats_stats_immediate_la_LIBADD = \
+	$(top_builddir)/src/common/libflux-internal.la \
+	$(top_builddir)/src/common/libflux-core.la

--- a/t/scripts/stats-listen.py
+++ b/t/scripts/stats-listen.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+###############################################################
+# Copyright 2021 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+import argparse
+import re
+import socket
+import subprocess
+import os
+
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    "-n",
+    "--no-set-host",
+    help="don't set the FLUX_FRIPP_STATSD environment variable",
+    action="store_true",
+)
+parser.add_argument(
+    "-s",
+    "--search-for",
+    metavar="METRIC",
+    help="search for a specific metric tag",
+)
+parser.add_argument(
+    "-V", "--validate", help="validate packet form", action="store_true"
+)
+parser.add_argument(
+    "-w",
+    "--wait-for",
+    metavar="N",
+    help="wait for N packets to be recieved",
+    type=int,
+    default=1,
+)
+parser.add_argument("cmd", nargs=argparse.REMAINDER)
+args = parser.parse_args()
+
+s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+s.bind(("127.0.0.1", 0))
+
+if not args.no_set_host:
+    os.environ["FLUX_FRIPP_STATSD"] = f"0.0.0.0:{s.getsockname()[1]}"
+
+f = subprocess.Popen(args.cmd, env=dict(os.environ))
+f.wait()
+
+p = []
+
+if args.search_for is not None:
+    while True:
+        m = s.recvfrom(1024)[0]
+        if args.search_for in m.decode("utf-8"):
+            p.append(m)
+            break
+
+else:
+    for i in range(args.wait_for):
+        p.append(s.recvfrom(1024)[0])
+
+    if len(p) < args.wait_for:
+        s.close()
+        exit(-1)
+
+if args.validate:
+    metrics = str.splitlines("".join([_.decode("utf-8") for _ in p]))
+    ex = re.compile("^\w+:[\+\-]*\d+\|ms|[gC]$")
+
+    for m in metrics:
+        if not ex.search(m):
+            s.close()
+            exit(-1)
+
+print(p)
+s.close()

--- a/t/stats/stats-basic.c
+++ b/t/stats/stats-basic.c
@@ -1,0 +1,75 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#include <flux/core.h>
+#include <flux/jobtap.h>
+#include <time.h>
+
+#include "src/common/libutil/monotime.h"
+
+struct cb_data {
+    ssize_t cleanup;
+    ssize_t inactive;
+    struct timespec ts;
+};
+
+static int state_cb (flux_plugin_t *p,
+                     const char *topic,
+                     flux_plugin_arg_t *args,
+                     void *arg)
+{
+    struct cb_data *data = arg;
+    flux_job_state_t state;
+    flux_job_state_t prev_state = 4096;
+    flux_t *h = flux_jobtap_get_flux (p);
+
+    if (flux_plugin_arg_unpack (args, FLUX_PLUGIN_ARG_IN,
+                               "{s:i s?i}",
+                               "state", &state,
+                               "prev_state", &prev_state) < 0) {
+        flux_log (h,
+                 LOG_ERR,
+                 "flux_plugin_arg_unpack: %s",
+                 flux_plugin_arg_strerror(args));
+        return -1;
+    }
+
+    switch (state) {
+        case FLUX_JOB_STATE_CLEANUP:
+            flux_stats_count (h, "cleanup.count", ++data->cleanup);
+            monotime (&data->ts);
+            break;
+        case FLUX_JOB_STATE_INACTIVE:
+            flux_stats_timing (h, "cleanup.timing", monotime_since (data->ts));
+            flux_stats_count (h, "inactive.count", ++data->inactive);
+            break;
+        default:
+            break;
+    }
+
+    return 0;
+}
+
+int flux_plugin_init (flux_plugin_t *p)
+{
+    struct cb_data *data;
+    flux_t *h;
+    if (!(h = flux_jobtap_get_flux (p)))
+        return -1;
+    if (!(data = calloc (1, sizeof (*data))))
+        return -1;
+    if (flux_plugin_aux_set (p, "data", data, free) < 0)
+        return -1;
+
+    flux_stats_set_prefix (h, "flux.job.state");
+    flux_stats_set_period (h, 1.0);
+
+    return flux_plugin_add_handler (p, "job.state.*", state_cb, data);
+}

--- a/t/stats/stats-immediate.c
+++ b/t/stats/stats-immediate.c
@@ -1,0 +1,83 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#include <flux/core.h>
+#include <flux/jobtap.h>
+#include <time.h>
+
+#include "src/common/libutil/monotime.h"
+
+struct cb_data {
+    ssize_t inactive;
+    struct timespec ts;
+};
+
+static int state_cb (flux_plugin_t *p,
+                     const char *topic,
+                     flux_plugin_arg_t *args,
+                     void *arg)
+{
+    struct cb_data *data = arg;
+    flux_job_state_t state;
+    flux_job_state_t prev_state = 4096;
+    flux_t *h = flux_jobtap_get_flux (p);
+
+
+    if (flux_plugin_arg_unpack (args, FLUX_PLUGIN_ARG_IN,
+                               "{s:i s?i}",
+                               "state", &state,
+                               "prev_state", &prev_state) < 0) {
+        flux_log (h,
+                 LOG_ERR,
+                 "flux_plugin_arg_unpack: %s",
+                 flux_plugin_arg_strerror(args));
+        return -1;
+    }
+
+    flux_stats_gauge_inc (h, flux_job_statetostr (state, false), 1);
+    flux_stats_gauge_inc (h, flux_job_statetostr (prev_state, false), -1);
+
+    switch (state) {
+        case FLUX_JOB_STATE_CLEANUP:
+            monotime (&data->ts);
+            break;
+        case FLUX_JOB_STATE_INACTIVE:
+            flux_stats_timing (h, "cleanup.timing", monotime_since (data->ts));
+            flux_stats_count (h, "inactive.count", ++data->inactive);
+            break;
+        default:
+            break;
+    }
+
+    return 0;
+}
+
+int flux_plugin_init (flux_plugin_t *p)
+{
+    struct cb_data *data;
+    flux_t *h;
+    if (!(h = flux_jobtap_get_flux (p)))
+        return -1;
+    if (!(data = calloc (1, sizeof (*data))))
+        return -1;
+    if (flux_plugin_aux_set (p, "data", data, free) < 0)
+        return -1;
+
+    flux_stats_set_prefix (h, "flux.job.state.immediate");
+    flux_stats_set_period (h, 0.0);
+
+    // try setting a prefix with a length longer than the limit (127)
+    // and expect it to remain as "flux.job.stats.immediate"
+    flux_stats_set_prefix (h, "aQmi173rvgumStDdMZdwtJtpLLVJOUXol2aDndev/XsH/gM\
+wlPz/vMZhajJWGctwJZa1uFoAoINjwITPvezGoQDb/9DD3vkPcknN+f/u3vSc0tg/+3aFTONhUIomK\
+B4qiSKSotbtZl3Ewe2Oh+wI+nuG3/ebqIXSoEXjIFOB7vvGA==");
+
+    return flux_plugin_add_handler (p, "job.state.*", state_cb, data);
+}

--- a/t/t1200-stats-basic.t
+++ b/t/t1200-stats-basic.t
@@ -1,0 +1,46 @@
+#!/bin/sh
+#
+
+test_description='Test stats collection and sending'
+
+. `dirname $0`/sharness.sh
+
+udp=$SHARNESS_TEST_SRCDIR/scripts/stats-listen.py
+timeout=$SHARNESS_TEST_SRCDIR/scripts/run_timeout.py
+plugin_i=${FLUX_BUILD_DIR}/t/stats/.libs/stats-immediate.so
+plugin_b=${FLUX_BUILD_DIR}/t/stats/.libs/stats-basic.so
+
+test_expect_success 'prefix set' '
+	$timeout 20 flux python $udp -s flux.job.state.immediate flux start \
+	"flux jobtap load $plugin_i && flux mini run hostname"
+'
+
+test_expect_success 'multiple packets received' '
+	$timeout 20 flux python $udp -w 3 flux start \
+	"flux jobtap load $plugin_i && flux mini run hostname"
+'
+
+test_expect_success 'validate packets immediate' '
+	$timeout 20 flux python $udp -V flux start \
+	"flux jobtap load $plugin_i && flux mini run hostname"
+'
+
+test_expect_success 'timing packets received immediate' '
+	$timeout 20 flux python $udp -s timing flux start \
+	"flux jobtap load $plugin_i && flux mini run hostname"
+'
+
+test_expect_success 'timing packets received basic' '
+	$timeout 20 flux python $udp -s timing flux start \
+	"flux jobtap load $plugin_b && flux mini run hostname && sleep 1"
+'
+
+test_expect_success 'valid content-cache packets received' '
+	$timeout 20 flux python $udp -s content-cache -V flux start sleep 1
+'
+
+test_expect_success 'nothing received with no endpoint' '
+	unset FLUX_FRIPP_STATSD && test_expect_code 137 $timeout 5 flux python $udp -n flux start
+'
+
+test_done


### PR DESCRIPTION
This adds a simple metric collection & sender api to `libflux` as suggested in issue #3517. The public api in `src/common/libflux/stats.h` defines the functions for storing metrics and changing the internal flush interval (which is `1s` by default). There are three types of supported metrics: `counters`, `gauges`, and `timers`. `Counters` send integers values which are aggregated in Brubeck over its flush interval. `Gauges` take an arbitrary integer value and maintain that value until next set, like a snapshot at a certain point. `Timers` take an amount of time in miliseconds. 

Right now there are no CI tests (something I need some suggestions on), but to test locally first set up Brubeck and Graphite which I have some instructions on setting up in my [https://github.com/flux-framework/fripp/blob/main/journals/week1.md](journal). Next, the stats will try getting the address to send to by reading the `FLUX_FRIPP_STATSD={IP}:{PORT}` environment variable. If you use the default config file from brubeck it should be set to `0.0.0.0:8126`. This branch has the stats running in the `content-cache`, but another use case is to use the [https://github.com/flux-framework/fripp/blob/main/code/jobtap-plugins/state-counts.c](state-counts plugin) which can be built like:

```bash
$ gcc -shared -I$HOME/flux-core -I$HOME/flux-core/src/include -fPIC \
    -o state-counts.so ../fripp.h ../fripp.c state-counts.c
```

and assuming that the plugin is in `../fripp/code/jobtap-plugins/`, it can be loaded into a running instance like this:

```bash
$ flux jobtap load $(pwd)/../fripp/code/jobtap-plugins/state-counts.so
```