### PR TITLE
libkvs: compact only if ops len > 1

### DIFF
--- a/src/common/libkvs/kvs_txn_compact.c
+++ b/src/common/libkvs/kvs_txn_compact.c
@@ -210,7 +210,7 @@ int txn_compact (flux_kvs_txn_t *txn)
     }
 
     len = json_array_size (txn->ops);
-    if (!len)
+    if (len < 2)
         return 0;
 
     if (!(ops_new = json_array ())) {


### PR DESCRIPTION
I noticed this will doing some looking at issue #1804 awhile back.  Forgot that I had this sitting on a branch.  It's just a simple / dumb fix.

```
Problem: The txn_compact() function would attempt to compact
transactions if there are > 0 operations.  But it is impossible to
compact just 1 operation, you need atleast 2 operations to conceivably
compact.

Solution: Check for > 1 instead of > 0 operations.
```