### PR TITLE
rlist: fix erroneous collapse of nodes with different resource children when emitting R

### DIFF
--- a/src/common/librlist/rnode.c
+++ b/src/common/librlist/rnode.c
@@ -659,8 +659,15 @@ int rnode_cmp (const struct rnode *a, const struct rnode *b)
 {
     int rv = 0;
     /*  All avail idsets must match */
-    struct rnode_child *ca = zhashx_first (a->children);
+    struct rnode_child *ca;
     struct rnode_child *cb;
+
+    /* If two nodes do not have the same number of children types,
+     *  then they are not identical. Order doesn't matter here...
+     */
+    if (zhashx_size (a->children) != zhashx_size (b->children))
+        return -1;
+    ca = zhashx_first (a->children);
     while (ca) {
         if (!(cb = zhashx_lookup (b->children, ca->name)))
             return -1;

--- a/src/common/librlist/test/rnode.c
+++ b/src/common/librlist/test/rnode.c
@@ -152,6 +152,58 @@ static void test_add_child ()
     rnode_destroy (a);
 }
 
+void test_copy ()
+{
+    struct rnode *n = NULL;
+    struct rnode *b = NULL;
+
+    if (!(n = rnode_create ("foo", 0, "0-3")))
+        BAIL_OUT ("failed to create an rnode object");
+    ok (rnode_add_child (n, "gpu", "0-1") != NULL,
+        "add two gpus to rnode");
+
+    ok ((b = rnode_copy (n)) != NULL,
+        "copy rnode");
+    ok (rnode_count_type (b, "core") == 4,
+        "rnode_count_type (gpu) == 4");
+    ok (rnode_count_type (b, "gpu") == 2,
+        "rnode_count_type (gpu) == 2");
+
+    rnode_destroy (b);
+    ok ((b = rnode_copy_avail (n)) != NULL,
+        "rnode_copy_avail");
+    ok (rnode_count_type (b, "core") == 4,
+        "rnode_count_type (gpu) == 4");
+    ok (rnode_count_type (b, "gpu") == 2,
+        "rnode_count_type (gpu) == 2");
+
+    rnode_destroy (b);
+    rnode_destroy (n);
+}
+
+void test_rnode_cmp ()
+{
+    struct rnode *a = NULL;
+    struct rnode *b = NULL;
+
+    if (!(a = rnode_create ("foo", 0, "0-3"))
+        || !(b = rnode_create ("foo", 1, "0-3")))
+        BAIL_OUT ("failed to create rnode objects");
+
+    ok (rnode_cmp (a, b) == 0,
+        "rnode_cmp returns zero for nodes with identical children");
+
+    /*  Add gpus to rnode b only */
+    ok (rnode_add_child (b, "gpu", "0-1") != NULL,
+        "add two gpus to rnode");
+
+    ok (rnode_cmp (a, b) != 0,
+        "rnode_cmp returns nonzero for nodes with differing children");
+
+    rnode_destroy (a);
+    rnode_destroy (b);
+}
+
 int main (int ac, char *av[])
 {
     struct idset *ids = NULL;
@@ -266,6 +318,7 @@ int main (int ac, char *av[])
     test_diff ();
     test_intersect ();
     test_add_child ();
+    test_copy ();
     done_testing ();
 }
 

--- a/t/t0026-flux-R.t
+++ b/t/t0026-flux-R.t
@@ -75,6 +75,14 @@ test_expect_success 'flux R append works' '
     test_debug "echo $result" &&
     test "$result" = "rank0/core[0-1] rank1/core[0-3] rank2/core[2-3]"
 '
+test_expect_success 'flux R append works when only some nodes have gpus' '
+    result=$( (flux R encode -r 0-1 -c 0-1 && \
+	       flux R encode -r 2-3 -c 0-1 -g 0-1) \
+        | flux R append | flux R decode --short) &&
+    test_debug "echo $result" &&
+    test "$result" = "rank[0-1]/core[0-1] rank[2-3]/core[0-1],gpu[0-1]"
+'
+
 test_expect_success 'flux R diff works' '
     result=$( (flux R encode -r 0-1 -c 0-1 && flux R encode -r 0-1 -c 0) \
         | flux R diff | flux R decode --short) &&


### PR DESCRIPTION
This fixes the problem described in #3813.

The problem was an embarrassing error in `rnode_cmp()`, which compares two resources nodes to determine if they have identical child resources. The function iterates each child resource type in the first node and compares idsets with the same resource type in the second node. However, if the 2nd node has extra resources, like gpus, then the node is considered equal and is collapsed into the first node and the gpus are lost.

The fix is to first compare the number of resource types and ensure they are equal before continuing on to further comparison.