### PR TITLE
system instance: add flux overlay status command

### DIFF
--- a/src/broker/doc/README.md
+++ b/src/broker/doc/README.md
@@ -2,3 +2,4 @@
 
 * [Broker Bootstrap Sequence](bootstrap.md)
 * [Broker State Machine](state_machine.md)
+* [System Instance Resiliency](resiliency.md)

--- a/src/broker/doc/resiliency.md
+++ b/src/broker/doc/resiliency.md
@@ -1,0 +1,123 @@
+## System Instance Resiliency
+
+The Flux system instance has to deal with the usual challenges faced by cluster
+system software, such as node crashes and network outages.  Although Flux's
+design attempts to meet these challenges with minimal human intervention and
+lost work, there are caveats that need to be understood by Flux developers.
+This page describes Flux's current design for resiliency.
+
+NOTE: some of this is aspirational at the time of this writing, for our L2
+resiliency planning goal to be demonstrated in early 2022.
+
+### Disordered bring-up
+
+The broker state machine ensures that a starting broker pauses until its TBON
+parent completes the rc1 script before starting its own rc1 script, so that
+upstream services are online before downstream ones start.  As a result, it
+is feasible to configure Flux to start automatically, then power on the entire
+cluster at once and let Flux sort itself out.
+
+If some nodes take longer to start up, or don't start at all, then those nodes
+and their TBON children, if any, will remain offline until they do start.
+The TBON has a fixed topology determined by configuration, and brokers do not
+adapt to route around down nodes.  In addition, Flux must be completely stopped
+to alter the topology configuration - it cannot be changed on the fly.
+
+See the Flux Administrator's Guide for a discussion on draining nodes and
+excluding nodes from scheduling via configuration.  Scheduling is somewhat
+orthogonal to this topic.
+
+### Subtree shut down
+
+Flux is stopped administratively with `systemctl stop flux`.  This is may
+be run on any broker, and will affect the broker's TBON subtree.  If run on
+the rank 0 broker, the entire Flux instance is shut down.
+
+Upon receiving SIGTERM from systemd, the broker informs its TBON children that
+it is shutting down, and waits for them to complete rc3 in leaves-to-root
+order, thus ensuring that the instance captures any state held on those
+brokers, such as KVS content.
+
+A broker that is cleanly shut down withdraws itself as a peer from its TBON
+parent.  Future RPCs to the down broker automatically receive an EHOSTUREACH
+error response.
+
+### Node crash
+
+If a node crashes without shutting down its flux broker, state held by that
+broker and its TBON subtree is lost if it was not saved to its TBON parent.
+
+The TBON parent of the lost node detects that its child has stopped sending
+messages.  The parent marks the child lost and future RPCs directed to
+(or through) the crashed node receive an EHOSTUNREACH error response.  In
+addition, RPCs are tracked at the broker overlay level, and any requests that
+were directed to (or through) the lost node that are unterminated, as
+defined by RFC 6, receive an EHOSTUNREACH error response.
+
+The TBON children of the lost node similarly detect the lack of parent
+messages.  The child marks the parent offline and future RPCs, as well as
+existing unterminated RPCs to that node receive an EHOSTUNREACH error response.
+These nodes then proceed as though they were shut down, however since they are
+cut off from upstream, any RPCs executed in rc3 to save state will fail
+immediately.  Effectively a _subtree panic_ results and data may be lost.
+
+### Node returning to Service
+
+When a lost node comes back up, or when an administratively shut down node
+is restarted with `systemctl start flux`, the freshly started broker
+attempts to join the instance via its TBON parent, just as if it were joining
+for the first time, and carrying no state from the previous incarnation.
+
+The broker peer is identified for response routing purposes by its UUID, which
+changes upon restart.  In-flight responses directed to (or through) the
+old UUID are dropped.  This is desirable behavior because matchtags from the
+previous broker incarnation(s) might become confused with matchtags from the
+current one, and the old responses are answering requests that the current
+broker didn't send.
+
+Systemd is configured to aggressively restart brokers that stop on their own,
+so TBON children of the returning broker should also be attempting to join the
+instance and may do so once the returning broker has completed the rc1 script.
+
+### Network outage
+
+Network outages that persist long enough are promoted to hard failures.
+
+Case 1:  A TBON parent marks its child lost due to a temporary network
+interruption, and the child has not yet marked the parent lost when
+communication is restored.  In this case, the parent sees messages from the
+lost UUID, and sends a kiss of death message to the child, causing a subtree
+panic at the child.  The subtree restarts and rejoins the instance.
+
+Case 2:  The TBON child marks its parent lost due to a temporary network
+interruption, and the parent has not yet marked the child lost when
+communication is restored.  Assuming the child subtree has restarted,
+the child introduces itself to the parent with a new UUID.  Before allowing
+the child to join, it marks the old UUID lost and fails unterminated RPCs
+as described above.  It then accepts the child's introduction and allows
+the subtree to join.
+
+### Diagnostics
+
+#### Subtree Health Check
+
+Each broker maintains a subtree health state that depends on the health
+state reported by its TBON children.  The states are as follows:
+
+**Name** | **Description**
+---      | ---
+Full     | online and no children partial/offline/degraded/lost
+Partial  | online, some children partial/offline; no children degraded/lost
+Degraded | online, some children degraded/lost
+Lost     | gone missing (according to parent)
+Offline  | not yet seen, or cleanly shut down (according to parent)
+
+A user may quickly assess the overall health of the overlay network by
+requesting the subtree health at rank 0.  If the state is reported as
+_partial_ or _degraded_, then the TBON may be probed further for details
+using the following algorithm:
+
+1. Request state of TBON children from target rank
+2. List TBON children in _lost_ or _offline_ state
+3. For each child in _partial_ or _degraded_ state, apply this algorithm
+on child rank

--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -1253,7 +1253,8 @@ static int overlay_health_respond (struct overlay *ov, const flux_msg_t *msg)
     duration = monotime_since (ov->status_timestamp) / 1000.0;
     if (flux_respond_pack (ov->h,
                            msg,
-                           "{s:s s:f s:O}",
+                           "{s:i s:s s:f s:O}",
+                           "rank", ov->rank,
                            "status", subtree_status_str (ov->status),
                            "duration", duration,
                            "children", array) < 0)

--- a/src/broker/overlay.h
+++ b/src/broker/overlay.h
@@ -50,7 +50,7 @@ int overlay_sendmsg (struct overlay *ov,
  * with the public key of each downstream peer to authorize it to connect,
  * and overlay_set_parent_pubkey() with the public key of the parent
  * before calling overlay_connect().
- * NOTE: if bootstrapping with PMI, unique public keys generated for
+ * NOTE: if bootstrapping with PMI, unique public keys are generated for
  * each broker and shared via PMI exchange.  If boostrapping with config
  * files, each broker loads an (assumed) identical key-pair from a file.
  * Only the public key may be shared over the network, never the private key.

--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -9,6 +9,7 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
 	-I$(top_builddir)/src/common/libflux \
+	-I$(top_srcdir)/src/common/libccan \
 	$(FLUX_SECURITY_CFLAGS) \
 	$(HWLOC_CFLAGS) \
 	$(PMIX_CFLAGS) \
@@ -50,6 +51,7 @@ flux_SOURCES = \
 	builtin/hwloc.c \
 	builtin/heaptrace.c \
 	builtin/proxy.c \
+	builtin/overlay.c \
 	builtin/relay.c \
 	builtin/python.c
 nodist_flux_SOURCES = \

--- a/src/cmd/builtin/overlay.c
+++ b/src/cmd/builtin/overlay.c
@@ -1,0 +1,488 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+# include <config.h>
+#endif
+#include <jansson.h>
+#include <flux/core.h>
+
+#include "src/common/libccan/ccan/str/str.h"
+#include "src/common/libutil/monotime.h"
+#include "src/common/libutil/fsd.h"
+#include "src/common/libhostlist/hostlist.h"
+
+#include "builtin.h"
+
+static const char *ansi_default = "\033[39m";
+static const char *ansi_red = "\033[31m";
+static const char *ansi_yellow = "\033[33m";
+//static const char *ansi_green = "\033[32m";
+static const char *ansi_dark_gray = "\033[90m";
+
+static const char *vt100_mode_line = "\033(0";
+static const char *vt100_mode_normal = "\033(B";
+
+static struct optparse_option status_opts[] = {
+    { .name = "rank", .key = 'r', .has_arg = 1, .arginfo = "NODEID",
+      .usage = "Check health of subtree rooted at NODEID (default 0)",
+    },
+    { .name = "verbose", .key = 'v', .has_arg = 2, .arginfo = "[LEVEL]",
+      .usage = "Increase reporting detail"
+               " (1=lost/offline nodes, 2=degraded/partial trees, 3=full)",
+    },
+    { .name = "timeout", .key = 't', .has_arg = 1, .arginfo = "FSD",
+      .usage = "Set RPC timeout (default none)",
+    },
+    { .name = "hostnames", .key = 'H', .has_arg = 0,
+      .usage = "Display hostnames instead of ranks",
+    },
+    { .name = "times", .key = 'T', .has_arg = 0,
+      .usage = "Show round trip RPC times",
+    },
+    { .name = "pretty", .key = 'p', .has_arg = 0,
+      .usage = "Indent entries and use line drawing characters"
+               " to show overlay tree structure",
+    },
+    { .name = "ghost", .key = 'g', .has_arg = 0,
+      .usage = "Fill in presumed state of nodes that are"
+               " inaccessible behind offline/lost overlay parents",
+    },
+    { .name = "color", .key = 'c', .has_arg = 0,
+      .usage = "Use color to highlight offline/lost nodes",
+    },
+    { .name = "since", .key = 's', .has_arg = 0,
+      .usage = "Show time since current state was entered",
+    },
+    { .name = "wait", .key = 'w', .has_arg = 1, .arginfo = "STATE",
+      .usage = "Wait until subtree enters STATE before reporting"
+               " (full, partial, offline, degraded, lost)",
+    },
+    OPTPARSE_TABLE_END
+};
+
+struct status {
+    flux_t *h;
+    int verbose;
+    double timeout;
+    struct hostlist *hl;
+    optparse_t *opt;
+    struct timespec start;
+    const char *wait;
+};
+
+struct status_node {
+    int rank;
+    const char *status;
+    double duration;
+    bool ghost;
+};
+
+typedef bool (*map_f)(struct status *ctx,
+                      struct status_node *node,
+                      bool parent,
+                      int level);
+
+static const char *status_duration (struct status *ctx, double since)
+{
+    char dbuf[128];
+    static char buf[256];
+
+    if (!optparse_hasopt (ctx->opt, "since")
+        || since <= 0.
+        || fsd_format_duration (dbuf, sizeof (dbuf), since) < 0)
+        return "";
+    snprintf (buf, sizeof (buf), " for %s", dbuf);
+    return buf;
+}
+
+static const char *status_colorize (struct status *ctx,
+                                    const char *status,
+                                    bool ghost)
+{
+    static char buf[128];
+
+    if (optparse_hasopt (ctx->opt, "color")) {
+        if (streq (status, "lost") && !ghost) {
+            snprintf (buf, sizeof (buf), "%s%s%s",
+                      ansi_red, status, ansi_default);
+            status = buf;
+        }
+        else if (streq (status, "offline") && !ghost) {
+            snprintf (buf, sizeof (buf), "%s%s%s",
+                      ansi_yellow, status, ansi_default);
+            status = buf;
+        }
+        else if (ghost) {
+            snprintf (buf, sizeof (buf), "%s%s%s",
+                      ansi_dark_gray, status, ansi_default);
+            status = buf;
+        }
+    }
+    return status;
+}
+
+static const char *status_indent (struct status *ctx, int n)
+{
+    static char buf[1024];
+    if (!optparse_hasopt (ctx->opt, "pretty") || n == 0)
+        return "";
+    snprintf (buf, sizeof (buf), "%*s%s%s%s", n - 1, "",
+              vt100_mode_line,
+              "m", // '|_'
+              vt100_mode_normal);
+    return buf;
+}
+
+/* Return string containing the "best" name for node.
+ * If --hostnames, look up the hostname.
+ * Otherwise, just make a string out of the rank.
+ */
+static const char *status_getname (struct status *ctx, int rank)
+{
+    static char buf[128];
+    const char *s;
+
+    if (ctx->hl && (s = hostlist_nth (ctx->hl, rank)) != NULL)
+        snprintf (buf, sizeof (buf), "%s", s);
+    else
+        snprintf (buf, sizeof (buf), "%d", rank);
+    return buf;
+}
+
+/* If --times, return string containing parenthesised elapsed
+ * time since last RPC was started, with leading space.
+ * Otherwise, return the empty string
+ */
+static const char *status_rpctime (struct status *ctx)
+{
+    static char buf[64];
+    if (!optparse_hasopt (ctx->opt, "times"))
+        return "";
+    snprintf (buf, sizeof (buf), " (%.3f ms)", monotime_since (ctx->start));
+    return buf;
+}
+
+static void status_print (struct status *ctx,
+                          struct status_node *node,
+                          bool parent,
+                          int level)
+{
+    printf ("%s%s: %s%s%s\n",
+            status_indent (ctx, level),
+            status_getname (ctx, node->rank),
+            status_colorize (ctx, node->status, node->ghost),
+            status_duration (ctx, node->duration),
+            parent ? status_rpctime (ctx) : "");
+}
+
+static void status_print_noname (struct status *ctx,
+                                 struct status_node *node,
+                                 bool parent,
+                                 int level)
+{
+    printf ("%s%s%s%s\n",
+            status_indent (ctx, level),
+            status_colorize (ctx, node->status, node->ghost),
+            status_duration (ctx, node->duration),
+            parent ? status_rpctime (ctx) : "");
+}
+
+/* Look up topology of 'child_rank' within the subtree topology rooted
+ * at 'parent_rank'. Caller must json_decref() the result.
+ * Returns NULL if --ghost option was not provided, or the lookup fails.
+ */
+static json_t *topo_lookup (struct status *ctx,
+                            int parent_rank,
+                            int child_rank)
+{
+    flux_future_t *f;
+    json_t *topo;
+
+    if (!optparse_hasopt (ctx->opt, "ghost"))
+        return NULL;
+    if (!(f = flux_rpc_pack (ctx->h,
+                             "overlay.topology",
+                             parent_rank,
+                             0,
+                             "{s:i}",
+                             "rank", child_rank))
+        || flux_future_wait_for (f, ctx->timeout) < 0
+        || flux_rpc_get_unpack (f, "o", &topo) < 0) {
+        flux_future_destroy (f);
+        return NULL;
+    }
+    json_incref (topo);
+    flux_future_destroy (f);
+    return topo;
+}
+
+/* Walk a "ghost" subtree from the fixed topology.  Each node is assumed to
+ * have the same 'status' as the offline/lost parent at the subtree root.
+ * This augments healthwalk() to fill in nodes that would otherwise be missing
+ * because they don't have a direct parent that is online for probing.
+ * N.B. the starting point, the rank at the root of topo, is assumed to
+ * have already been mapped/iterated over.
+ */
+static void status_ghostwalk (struct status *ctx,
+                              json_t *topo,
+                              int level,
+                              const char *status,
+                              map_f fun)
+{
+    json_t *children;
+    size_t index;
+    json_t *entry;
+    struct status_node node = {
+        .status = status,
+        .duration = -1., // invalid - don't print
+        .ghost = true,
+    };
+
+    if (json_unpack (topo, "{s:o}", "children", &children) < 0)
+        return;
+    json_array_foreach (children, index, entry) {
+        if (json_unpack (entry, "{s:i}", "rank", &node.rank) < 0)
+            return;
+        if (fun (ctx, &node, false, level + 1))
+            status_ghostwalk (ctx, entry, level + 1, status, fun);
+    }
+}
+
+static flux_future_t *health_rpc (struct status *ctx, int rank)
+{
+    flux_future_t *f;
+
+    if (ctx->wait) {
+        f = flux_rpc_pack (ctx->h,
+                           "overlay.health",
+                           rank,
+                           0,
+                           "{s:s}",
+                           "wait", ctx->wait);
+        ctx->wait = NULL; // only wait on --rank, not subsequent probing
+    }
+    else {
+        f = flux_rpc_pack (ctx->h,
+                           "overlay.health",
+                           rank,
+                           0,
+                           "{}");
+    }
+    return f;
+}
+
+/* Execute fun() for each online broker in subtree rooted at 'rank'.
+ * If fun() returns true, follow tree to the broker's children.
+ * If false, don't go down that path.
+ */
+static int status_healthwalk (struct status *ctx,
+                              int rank,
+                              int level,
+                              map_f fun)
+{
+    struct status_node node = { .ghost = false };
+    flux_future_t *f;
+    json_t *children;
+    int rc = 0;
+
+    monotime (&ctx->start);
+
+    if (!(f = health_rpc (ctx, rank))
+        || flux_future_wait_for (f, ctx->timeout) < 0
+        || flux_rpc_get_unpack (f,
+                                "{s:i s:s s:f s:o}",
+                                "rank", &node.rank,
+                                "status", &node.status,
+                                "duration", &node.duration,
+                                "children", &children) < 0) {
+        /* RPC failed.
+         * An error at level 0 should be fatal, e.g. unknown wait argument,
+         * bad rank, timeout.  An error at level > 0 should return -1 so
+         * ghostwalk() can be tried (parent hasn't noticed child crash?)
+         * and sibling subtrees can be probed.
+         */
+        if (level == 0)
+            log_msg_exit ("%s", future_strerror (f, errno));
+        printf ("%s%s: %s%s\n",
+                status_indent (ctx, level),
+                status_getname (ctx, rank),
+                future_strerror (f, errno),
+                status_rpctime (ctx));
+        rc = -1;
+        goto done;
+    }
+    if (fun (ctx, &node, true, level)) {
+        if (children) {
+            size_t index;
+            json_t *entry;
+            struct status_node child = { .ghost = false };
+            json_t *topo;
+
+            json_array_foreach (children, index, entry) {
+                if (json_unpack (entry,
+                                 "{s:i s:s s:f}",
+                                 "rank", &child.rank,
+                                 "status", &child.status,
+                                 "duration", &child.duration) < 0)
+                    log_msg_exit ("error parsing child array entry");
+                if (fun (ctx, &child, false, level + 1)) {
+                    if (streq (child.status, "offline")
+                        || streq (child.status, "lost")
+                        || status_healthwalk (ctx, child.rank,
+                                              level + 1, fun) < 0) {
+                        topo = topo_lookup (ctx, node.rank, child.rank);
+                        status_ghostwalk (ctx, topo, level + 1, child.status, fun);
+                    }
+                }
+            }
+        }
+    }
+done:
+    flux_future_destroy (f);
+    return rc;
+}
+
+/* map fun - print the first entry without adornment and stop the walk.
+ */
+static bool show_top (struct status *ctx,
+                      struct status_node *node,
+                      bool parent,
+                      int level)
+{
+    status_print_noname (ctx, node, parent, level);
+    return false;
+}
+
+/* map fun - only follow degraded/partial, only print lost/offline (leaves).
+ */
+static bool show_badleaves (struct status *ctx,
+                            struct status_node *node,
+                            bool parent,
+                            int level)
+{
+    if (level == 0 && streq (node->status, "full"))
+        status_print_noname (ctx, node, parent, level);
+    else if (streq (node->status, "lost") || streq (node->status, "offline"))
+        status_print (ctx, node, parent, level);
+    if (streq (node->status, "full"))
+        return false;
+    return true;
+}
+
+/* map fun - only follow degraded/partial, but print all non-full nodes.
+ */
+static bool show_badtrees (struct status *ctx,
+                           struct status_node *node,
+                           bool parent,
+                           int level)
+{
+    if (parent
+        || streq (node->status, "lost")
+        || streq (node->status, "offline"))
+        status_print (ctx, node, parent, level);
+    if (streq (node->status, "full"))
+        return false;
+    return true;
+}
+
+/* map fun - follow all live brokers and print everything
+ */
+static bool show_all (struct status *ctx,
+                      struct status_node *node,
+                      bool parent,
+                      int level)
+{
+    if (parent
+        || streq (node->status, "lost")
+        || streq (node->status, "offline"))
+        status_print (ctx, node, parent, level);
+    return true;
+}
+
+static int subcmd_status (optparse_t *p, int ac, char *av[])
+{
+    int rank = optparse_get_int (p, "rank", 0);
+    struct status ctx;
+    map_f fun;
+
+    ctx.h = builtin_get_flux_handle (p);
+    ctx.verbose = optparse_get_int (p, "verbose", 0);
+    ctx.timeout = optparse_get_duration (p, "timeout", -1.0);
+    ctx.hl = NULL;
+    ctx.opt = p;
+    ctx.wait = optparse_get_str (p, "wait", NULL);
+
+    if (optparse_hasopt (p, "hostnames")) {
+        const char *s = flux_attr_get (ctx.h, "config.hostlist");
+        if (!s)
+            log_err_exit ("config.hostlist attribute is not set");
+        if (!(ctx.hl = hostlist_decode (s)))
+            log_err_exit ("config.hostlist value could not be decoded");
+    }
+
+    if (ctx.verbose <= 0)
+        fun = show_top;
+    else if (ctx.verbose == 1)
+        fun = show_badleaves;
+    else if (ctx.verbose == 2)
+        fun = show_badtrees;
+    else
+        fun = show_all;
+
+    status_healthwalk (&ctx, rank, 0, fun);
+
+    hostlist_destroy (ctx.hl);
+    return 0;
+}
+
+int cmd_overlay (optparse_t *p, int argc, char *argv[])
+{
+    log_init ("flux-overlay");
+
+    if (optparse_run_subcommand (p, argc, argv) != OPTPARSE_SUCCESS)
+        exit (1);
+    return (0);
+}
+
+static struct optparse_subcommand overlay_subcmds[] = {
+    { "status",
+      "[OPTIONS]",
+      "Display overlay subtree health status",
+      subcmd_status,
+      0,
+      status_opts,
+    },
+    OPTPARSE_SUBCMD_END
+};
+
+
+int subcommand_overlay_register (optparse_t *p)
+{
+    optparse_err_t e;
+
+    e = optparse_reg_subcommand (p,
+        "overlay",
+        cmd_overlay,
+        NULL,
+        "Manage overlay network",
+        0,
+        NULL);
+    if (e != OPTPARSE_SUCCESS)
+        return -1;
+
+    e = optparse_reg_subcommands (optparse_get_subcommand (p, "overlay"),
+                                  overlay_subcmds);
+    return (e == OPTPARSE_SUCCESS ? 0 : -1);
+}
+
+/*
+ * vi: ts=4 sw=4 expandtab
+ */

--- a/src/common/libhostlist/hostlist.h
+++ b/src/common/libhostlist/hostlist.h
@@ -54,8 +54,6 @@ int hostlist_append_list (struct hostlist *hl1, struct hostlist *hl2);
 /*  Return the nth host in hostlist 'hl' or NULL on failure.
  *
  *  Moves the hostlist cursor to the returned host on success.
- *
- *  Note: call must free returned memory
  */
 const char * hostlist_nth (struct hostlist * hl, int n);
 

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -177,6 +177,7 @@ TESTSCRIPTS = \
 	t3300-system-basic.t \
 	t3301-system-latestart.t \
 	t3302-system-offline.t \
+	t3303-system-healthcheck.t \
 	t4000-issues-test-driver.t \
 	lua/t0001-send-recv.t \
 	lua/t0002-rpc.t \

--- a/t/t3301-system-latestart.t
+++ b/t/t3301-system-latestart.t
@@ -21,6 +21,10 @@ test_expect_success HAVE_JQ 'startctl shows rank 1 pids as -1' '
 	test $($startctl status | jq -r ".procs[1].pid") = "-1"
 '
 
+test_expect_success 'overlay status is partial' '
+        test "$(flux overlay status)" = "partial"
+'
+
 test_expect_success 'resource list shows one down nodes' '
 	echo 1 >down.exp &&
 	flux resource list -n -s down -o {nnodes} >down.out &&
@@ -52,6 +56,10 @@ test_expect_success 'start rank 1' '
 
 test_expect_success HAVE_JQ 'startctl shows rank 1 pid not -1' '
 	test $($startctl status | jq -r ".procs[1].pid") != "-1"
+'
+
+test_expect_success 'wait for overlay status to be full' '
+        flux overlay status --wait full --timeout 10s
 '
 
 # Side effect: this test blocks until the rank 1 broker has a chance to

--- a/t/t3303-system-healthcheck.t
+++ b/t/t3303-system-healthcheck.t
@@ -1,0 +1,197 @@
+#!/bin/sh
+#
+
+test_description='Test overlay diagnostic tool'
+
+. `dirname $0`/sharness.sh
+
+export TEST_UNDER_FLUX_FANOUT=2
+
+test_under_flux 15 system
+
+startctl="flux python ${SHARNESS_TEST_SRCDIR}/scripts/startctl.py"
+
+overlay_connected_children() {
+	rank=$1
+        flux python -c "import flux; print(flux.Flux().rpc(\"overlay.stats.get\",nodeid=${rank}).get_str())" | jq -r '.["child-connected"]'
+}
+
+# Usage: wait_connected rank count tries delay
+wait_connected() {
+	local rank=$1
+	local count=$2
+	local tries=$3
+	local delay=$4
+
+	while test $tries -gt 0; do
+		local n=$(overlay_connected_children $rank)
+		echo $n children
+		test $n -eq $count && return 0
+		sleep $delay
+		tries=$(($tries-1))
+	done
+	return 1
+}
+
+bad_health_request() {
+        flux python -c "import flux; print(flux.Flux().rpc(\"overlay.health\",nodeid=0).get_str())"
+}
+bad_topo_request() {
+        flux python -c "import flux; print(flux.Flux().rpc(\"overlay.topology\",nodeid=0).get_str())"
+}
+bad_topo_request_rank99() {
+        flux python -c "import flux; print(flux.Flux().rpc(\"overlay.topology\",{\"rank\":99},nodeid=0).get_str())"
+}
+
+test_expect_success 'overlay.health RPC with no payload fails' '
+	test_must_fail bad_health_request
+'
+test_expect_success 'overlay.topology RPC with no payload fails' '
+	test_must_fail bad_topo_request
+'
+test_expect_success 'overlay.topology RPC with bad rank fails' '
+	test_must_fail bad_topo_request_rank99
+'
+
+test_expect_success 'flux overlay status fails on bad rank' '
+	test_must_fail flux overlay status --rank 99
+'
+
+test_expect_success 'flux overlay fails on bad subcommand' '
+	test_must_fail flux overlay notcommand
+'
+
+test_expect_success 'flux overlay status --hostnames fails on PMI instance' '
+	test_must_fail flux start -o,-Sbroker.rc1_path=,-Sbroker.rc3_path= \
+		flux overlay status --hostnames
+'
+
+test_expect_success 'flux overlay status --hostnames fails on bad hostlist' '
+	test_must_fail flux start -o,-Sbroker.rc1_path=,-Sbroker.rc3_path= \
+		-o,-Sconfig.hostlist="[-badlist" \
+		flux overlay status --hostnames
+'
+
+test_expect_success 'overlay status is full' '
+	test "$(flux overlay status)" = "full"
+'
+
+test_expect_success 'flux overlay status -v prints full' '
+	echo full >health.exp &&
+	flux overlay status -v >health.out &&
+	test_cmp health.exp health.out
+'
+
+test_expect_success 'stop broker 3 with children 7,8' '
+	$startctl kill 3 15
+'
+
+test_expect_success 'wait for rank 0 overlay status to be partial' '
+	flux overlay status --rank 0 --wait=partial --timeout=10s
+'
+
+# Just because rank 0 is partial doesn't mean rank 3 is offline yet
+# (shutdown starts at the leaves, and rank 3 will turn partial as
+# soon as one of its children goes offline)
+test_expect_success HAVE_JQ 'wait for rank 1 to lose connection with rank 3' '
+	wait_connected 1 1 10 0.2
+'
+
+test_expect_success 'flux overlay status -vv and gaudy options works' '
+	flux overlay status -vv --pretty --times --hostnames --ghost
+'
+
+test_expect_success 'flux overlay status -v shows rank 3 offline' '
+	echo "3: offline" >health_v.exp &&
+	flux overlay status -v >health_v.out &&
+	test_cmp health_v.exp health_v.out
+'
+
+test_expect_success 'flux overlay status -v --ghost --color' '
+	flux overlay status -v --ghost --color
+'
+
+test_expect_success 'flux overlay status -vv --ghost --color' '
+	flux overlay status -vv --ghost --color
+'
+
+test_expect_success 'flux overlay status -vvv --ghost --color' '
+	flux overlay status -vvv --ghost --color
+'
+
+test_expect_success 'flux overlay status -vv: 0,1:partial, 3:offline' '
+	cat >health_vv.exp <<-EOT &&
+	0: partial
+	1: partial
+	3: offline
+	EOT
+	flux overlay status -vv >health_vv.out &&
+	test_cmp health_vv.exp health_vv.out
+'
+
+test_expect_success 'flux overlay status -vvg: 0-1:partial, 3,7-8:offline' '
+	cat >health_vvg.exp <<-EOT &&
+	0: partial
+	1: partial
+	3: offline
+	7: offline
+	8: offline
+	EOT
+	flux overlay status -vvg >health_vvg.out &&
+	test_cmp health_vvg.exp health_vvg.out
+'
+
+test_expect_success 'flux overlay status -vvvg: 0,1:partial, 3,7-8:offline, rest:full' '
+	cat >health_vvvg.exp <<-EOT &&
+	0: partial
+	1: partial
+	3: offline
+	7: offline
+	8: offline
+	4: full
+	9: full
+	10: full
+	2: full
+	5: full
+	11: full
+	12: full
+	6: full
+	13: full
+	14: full
+	EOT
+	flux overlay status -vvvg >health_vvvg.out &&
+	test_cmp health_vvvg.exp health_vvvg.out
+'
+
+test_expect_success 'kill broker 14' '
+	$startctl kill 14 9
+'
+
+# Ensure an EHOSTUNREACH is encountered to trigger connected state change.
+test_expect_success 'ping to rank 14 fails' '
+        test_must_fail flux ping 14
+'
+
+test_expect_success 'wait for rank 0 subtree to be degraded' '
+	flux overlay status --wait=degraded --timeout=10s
+'
+
+test_expect_success 'wait for unknown status fails' '
+	test_must_fail flux overlay status --wait=foo
+'
+
+test_expect_success 'wait timeout works' '
+	test_must_fail flux overlay status --wait=full --timeout=0.1s
+'
+
+test_expect_success 'flux overlay status -vg --since' '
+	flux overlay status -vg --since
+'
+test_expect_success 'flux overlay status -vvgpc' '
+	flux overlay status -vvgpc
+'
+test_expect_success 'flux overlay status -vvvgpc' '
+	flux overlay status -vvv --ghost --pretty --color
+'
+
+test_done


### PR DESCRIPTION
This PR adds a prototype `flux healthcheck` tool, and modifies the broker overlay code to track "subtree health".  The design is documented in a markdown document added in this PR so I won't go into detail here.

The tool is then exercised by the "t33xx-system-*.t" sharness scripts.

This is what it looks like on a healthy system:

```
ƒ(s=16,d=0,builddir) $ flux healthcheck
full
ƒ(s=16,d=0,builddir) $ flux healthcheck -vvv --times --pretty
0: full  (0.275 ms)
└1: full  (0.415 ms)
 └3: full  (0.517 ms)
  └7: full  (0.590 ms)
   └15: full  (0.691 ms)
  └8: full  (0.594 ms)
 └4: full  (0.447 ms)
  └9: full  (0.633 ms)
  └10: full  (0.569 ms)
└2: full  (0.331 ms)
 └5: full  (0.519 ms)
  └11: full  (0.570 ms)
  └12: full  (0.564 ms)
 └6: full  (0.498 ms)
  └13: full  (0.548 ms)
  └14: full  (0.515 ms)
ƒ(s=16,d=0,builddir) $ flux healthcheck --rank 6 -vvv --times --pretty
6: full  (0.731 ms)
└13: full  (0.585 ms)
└14: full  (0.533 ms)

```

Unhealthy examples:
```
$ flux healthcheck
degraded
$ flux healthcheck -v
2: lost
$ flux healthcheck -vv --pretty --times --hostnames
fake0: degraded (0.102 ms)
└fake2: lost
```