### PR TITLE
broker: fail pending RPCs when TBON child goes down

### DIFF
--- a/src/common/librouter/Makefile.am
+++ b/src/common/librouter/Makefile.am
@@ -9,6 +9,7 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
 	-I$(top_builddir)/src/common/libflux \
+	-I$(top_srcdir)/src/common/libccan \
 	$(LIBUUID_CFLAGS)
 
 noinst_LTLIBRARIES = \
@@ -30,7 +31,11 @@ librouter_la_SOURCES = \
 	router.h \
 	router.c \
 	usock_service.h \
-	usock_service.c
+	usock_service.c \
+	msg_hash.h \
+	msg_hash.c \
+	rpc_track.h \
+	rpc_track.c
 
 TESTS = \
 	test_sendfd.t \
@@ -43,7 +48,9 @@ TESTS = \
 	test_subhash.t \
 	test_router.t \
 	test_servhash.t \
-	test_usock_service.t
+	test_usock_service.t \
+	test_msg_hash.t \
+	test_rpc_track.t
 
 check_PROGRAMS = \
         $(TESTS)
@@ -129,3 +136,13 @@ test_usock_service_t_SOURCES = test/usock_service.c
 test_usock_service_t_CPPFLAGS = $(test_cppflags)
 test_usock_service_t_LDADD = $(test_ldadd)
 test_usock_service_t_LDFLAGS = $(test_ldflags)
+
+test_msg_hash_t_SOURCES = test/msg_hash.c
+test_msg_hash_t_CPPFLAGS = $(test_cppflags)
+test_msg_hash_t_LDADD = $(test_ldadd)
+test_msg_hash_t_LDFLAGS = $(test_ldflags)
+
+test_rpc_track_t_SOURCES = test/rpc_track.c
+test_rpc_track_t_CPPFLAGS = $(test_cppflags)
+test_rpc_track_t_LDADD = $(test_ldadd)
+test_rpc_track_t_LDFLAGS = $(test_ldflags)

--- a/src/common/librouter/msg_hash.c
+++ b/src/common/librouter/msg_hash.c
@@ -1,0 +1,111 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/core.h>
+
+#include "src/common/libczmqcontainers/czmq_containers.h"
+
+#include "msg_hash.h"
+
+/* get message matchtag, or if there is none, return FLUX_MATCHTAG_NONE */
+static uint32_t msg_hash_matchtag_get (const flux_msg_t *msg)
+{
+    uint32_t matchtag = FLUX_MATCHTAG_NONE;
+    (void)flux_msg_get_matchtag (msg, &matchtag);
+    return matchtag;
+}
+/* get request sender uuid, or if there is none, return empty string */
+static const char *msg_hash_uuid_get (const flux_msg_t *msg)
+{
+    const char *uuid = flux_msg_route_first (msg);
+    return uuid ? uuid : "";
+}
+
+/* Use "modified Bernstein hash" as employed by zhashx internally, but input
+ * is message uuid+matchtag instead of a simple NULL-terminated string.
+ * N.B. zhashx_hash_fn signature
+ */
+static size_t msg_hash_uuid_matchtag_hasher (const void *key)
+{
+    size_t key_hash = 0;
+    const char *cp;
+    uint32_t matchtag = msg_hash_matchtag_get (key);
+    int i;
+
+    cp = msg_hash_uuid_get (key);
+    while (*cp)
+        key_hash = 33 * key_hash ^ *cp++;
+    cp = (const char *)&matchtag;
+    for (i = 0; i < sizeof (matchtag); i++)
+        key_hash = 33 * key_hash ^ *cp++;
+    return key_hash;
+}
+
+#define NUMCMP(a,b) ((a)==(b)?0:((a)<(b)?-1:1))
+
+/* Compare hash keys, consisting of message uuid+matchtag.
+ * N.B. zhashx_comparator_fn signature
+ */
+static int msg_hash_uuid_matchtag_key_cmp (const void *key1, const void *key2)
+{
+    int ret;
+
+    ret = strcmp (msg_hash_uuid_get (key1),
+                  msg_hash_uuid_get (key2));
+    if (ret == 0) {
+        ret = NUMCMP (msg_hash_matchtag_get (key1),
+                      msg_hash_matchtag_get (key2));
+    }
+    return ret;
+}
+
+/* N.B. zhashx_destructor_fn signature
+ */
+static void msg_hash_destructor (void **item)
+{
+    const flux_msg_t **msg = (const flux_msg_t **)item;
+    if (msg) {
+        flux_msg_decref (*msg);
+        *msg = NULL;
+    }
+}
+
+zhashx_t *msg_hash_create (msg_hash_type_t type)
+{
+    zhashx_t *hash;
+
+    if (!(hash = zhashx_new ())) {
+        errno = ENOMEM;
+        return NULL;
+    }
+    switch (type) {
+        case MSG_HASH_TYPE_UUID_MATCHTAG:
+            zhashx_set_key_hasher (hash, msg_hash_uuid_matchtag_hasher);
+            zhashx_set_key_comparator (hash, msg_hash_uuid_matchtag_key_cmp);
+            break;
+        default:
+            zhashx_destroy (&hash);
+            errno = EINVAL;
+            return NULL;
+    }
+    zhashx_set_key_duplicator (hash, NULL);
+    zhashx_set_key_destructor (hash, NULL);
+    zhashx_set_duplicator (hash, (zhashx_duplicator_fn *)flux_msg_incref);
+    zhashx_set_destructor (hash, msg_hash_destructor);
+
+    return hash;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/librouter/msg_hash.h
+++ b/src/common/librouter/msg_hash.h
@@ -1,0 +1,41 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _ROUTER_MSG_HASH_H
+#define _ROUTER_MSG_HASH_H
+
+#include "src/common/libczmqcontainers/czmq_containers.h"
+
+typedef enum {
+    MSG_HASH_TYPE_UUID_MATCHTAG = 1,    // Hash request/response messages based
+                                        // on sender uuid+matchtag such that
+                                        // request and its response have the
+                                        // same hash key.
+
+} msg_hash_type_t;
+
+/* Create a zhashx_t for Flux messages.  The hash key is derived from
+ * info in the message, with key hasher and key comparator methods set up
+ * as appropriate for the hash type chosen at creation.
+ *
+ * The key duplicator and destructor are disabled, since the message contains
+ * all of the key information.
+
+ * The entry duplicator and destructor are set to flux_msg_incref() and
+ * flux_msg_decref() respectively.
+ */
+zhashx_t *msg_hash_create (msg_hash_type_t hashtype);
+
+#endif /* _ROUTER_MSG_HASH_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */
+

--- a/src/common/librouter/rpc_track.c
+++ b/src/common/librouter/rpc_track.c
@@ -1,0 +1,143 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "src/common/libczmqcontainers/czmq_containers.h"
+#include "src/common/libccan/ccan/str/str.h"
+
+#include "rpc_track.h"
+#include "msg_hash.h"
+
+struct rpc_track {
+    zhashx_t *hash;
+    msg_hash_type_t type;
+};
+
+void rpc_track_destroy (struct rpc_track *rt)
+{
+    if (rt) {
+        int saved_errno = errno;
+        zhashx_destroy (&rt->hash);
+        free (rt);
+        errno = saved_errno;
+    }
+}
+
+struct rpc_track *rpc_track_create (msg_hash_type_t type)
+{
+    struct rpc_track *rt;
+
+    if (!(rt = calloc (1, sizeof (*rt))))
+        return NULL;
+    rt->type = type;
+    if (!(rt->hash = msg_hash_create (type)))
+        goto error;
+    return rt;
+error:
+    rpc_track_destroy (rt);
+    return NULL;
+}
+
+static bool response_is_error (const flux_msg_t *msg)
+{
+    int errnum;
+
+    if (flux_msg_get_errnum (msg, &errnum) < 0
+        || errnum == 0)
+        return false;
+    return true;
+}
+
+static bool request_is_disconnect (const flux_msg_t *msg)
+{
+    const char *topic;
+    const char *cp;
+
+    if (flux_msg_get_topic (msg, &topic) < 0
+        || !(cp = strstr (topic, ".disconnect"))
+        || strlen (cp) > 11)
+        return false;
+    return true;
+}
+
+static bool message_has_hashkey (const flux_msg_t *msg)
+{
+    uint32_t matchtag;
+
+    if (flux_msg_route_count (msg) < 1
+        || flux_msg_get_matchtag (msg, &matchtag) < 0
+        || matchtag == FLUX_MATCHTAG_NONE)
+        return false;
+    return true;
+}
+
+static void rpc_track_disconnect (struct rpc_track *rt, const flux_msg_t *msg)
+{
+    const char *uuid;
+    zlistx_t *values;
+    const flux_msg_t *req;
+
+    if (!(uuid = flux_msg_route_first (msg))
+        || !(values = zhashx_values (rt->hash)))
+        return;
+    req = zlistx_first (values);
+    while (req) {
+        if (streq (uuid, flux_msg_route_first (req)))
+            zhashx_delete (rt->hash, req);
+        req = zlistx_next (values);
+    }
+    zlistx_destroy (&values);
+}
+
+void rpc_track_update (struct rpc_track *rt, const flux_msg_t *msg)
+{
+    int type;
+
+    if (flux_msg_get_type (msg, &type) < 0)
+        return;
+    switch (type) {
+        case FLUX_MSGTYPE_RESPONSE:
+            if (message_has_hashkey (msg)
+                && (!flux_msg_is_streaming (msg) || response_is_error (msg)))
+                zhashx_delete (rt->hash, msg);
+            break;
+        case FLUX_MSGTYPE_REQUEST:
+            if (!flux_msg_is_noresponse (msg)
+                && message_has_hashkey (msg))
+                zhashx_insert (rt->hash, msg, (flux_msg_t *)msg);
+            else if (request_is_disconnect (msg))
+                rpc_track_disconnect (rt, msg);
+            break;
+        default:
+            break;
+    }
+}
+
+void rpc_track_purge (struct rpc_track *rt, rpc_respond_f fun, void *arg)
+{
+    const flux_msg_t *msg;
+
+    msg = zhashx_first (rt->hash);
+    while (msg) {
+        fun (msg, arg);
+        msg = zhashx_next (rt->hash);
+    }
+    zhashx_purge (rt->hash);
+}
+
+int rpc_track_count (struct rpc_track *rt)
+{
+    return zhashx_size (rt->hash);
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/src/common/librouter/rpc_track.h
+++ b/src/common/librouter/rpc_track.h
@@ -1,0 +1,44 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _ROUTER_RPC_TRACK_H
+#define _ROUTER_RPC_TRACK_H
+
+#include <flux/core.h>
+
+#include "msg_hash.h"
+
+typedef void (*rpc_respond_f)(const flux_msg_t *msg, void *arg);
+
+/* Create/destroy hash of messages.
+ * Set type=MSG_HASH_TYPE_UUID_MATCHTAG.
+ */
+struct rpc_track *rpc_track_create (msg_hash_type_t type);
+void rpc_track_destroy (struct rpc_track *rt);
+
+/* If msg is a request that requires a response, add it to the hash.
+ * If msg is a response that terminates a request in the hash (per RFC 6),
+ * remove the matching request from the hash.
+ * If msg is a disconnect request, remove all messages from the hash that
+ * were sent by the same uuid as the disconnect request.
+ */
+void rpc_track_update (struct rpc_track *rt, const flux_msg_t *msg);
+
+/* Call fun() for every hash entry, then purge all entries.
+ */
+void rpc_track_purge (struct rpc_track *rt, rpc_respond_f fun, void *arg);
+
+/* Return the number of RPCs currently being tracked.
+ */
+int rpc_track_count (struct rpc_track *rt);
+
+#endif /* _ROUTER_RPC_TRACK_H */
+
+// vi:ts=4 sw=4 expandtab

--- a/src/common/librouter/test/msg_hash.c
+++ b/src/common/librouter/test/msg_hash.c
@@ -1,0 +1,101 @@
+/************************************************************\
+ * Copyright 2014 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <uuid.h>
+#include <flux/core.h>
+
+#include "src/common/libczmqcontainers/czmq_containers.h"
+#include "src/common/librouter/msg_hash.h"
+#include "src/common/libtap/tap.h"
+
+#ifndef UUID_STR_LEN
+#define UUID_STR_LEN 37     // defined in later libuuid headers
+#endif
+
+flux_msg_t *create_request (void)
+{
+    flux_msg_t *msg;
+    uuid_t uuid;
+    char uuid_str[UUID_STR_LEN];
+
+    if (!(msg = flux_request_encode ("foo", NULL)))
+        BAIL_OUT ("flux_request_create failed");
+    flux_msg_route_enable (msg);
+    uuid_generate (uuid);
+    uuid_unparse (uuid, uuid_str);
+    if (flux_msg_route_push (msg, uuid_str) < 0)
+        BAIL_OUT ("flux_msg_route_push failed");
+    return msg;
+}
+
+void test_basic (void)
+{
+    zhashx_t *zh;
+    flux_msg_t *req1;
+    flux_msg_t *req2;
+    flux_msg_t *rep1;
+    flux_msg_t *rep2;
+
+    errno = 0;
+    ok (msg_hash_create (42) == NULL && errno == EINVAL,
+        "msg_hash_create type=42 fails with EINVAL");
+
+    if (!(zh = msg_hash_create (MSG_HASH_TYPE_UUID_MATCHTAG)))
+        BAIL_OUT ("msg_hash_create failed");
+
+    req1 = create_request ();
+    req2 = create_request ();
+    rep1 = flux_response_derive (req1, 0);
+    rep2 = flux_response_derive (req2, 0);
+    if (!rep1 || !rep2)
+        BAIL_OUT ("flux_response_derive failed");
+
+    ok (zhashx_insert (zh, req1, req1) == 0,
+        "inserted first request");
+    ok (zhashx_insert (zh, req2, req2) == 0,
+        "inserted second request");
+    ok (zhashx_size (zh) == 2,
+        "hash size=2");
+
+    zhashx_delete (zh, req1);
+    ok (zhashx_size (zh) == 1,
+        "delete first request (from response), now hash size=1");
+
+    ok (zhashx_lookup (zh, rep1) == NULL,
+        "lookup of response 1 fails");
+    ok (zhashx_lookup (zh, rep2) != NULL,
+        "lookup of response 2 works");
+
+    flux_msg_decref (req1);
+    flux_msg_decref (req2);
+    flux_msg_decref (rep1);
+    flux_msg_decref (rep2);
+
+    zhashx_destroy (&zh);
+
+}
+
+int main (int argc, char *argv[])
+{
+    plan (NO_PLAN);
+
+    test_basic ();
+
+    done_testing();
+    return (0);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */
+

--- a/src/common/librouter/test/rpc_track.c
+++ b/src/common/librouter/test/rpc_track.c
@@ -1,0 +1,294 @@
+/************************************************************\
+ * Copyright 2014 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <uuid.h>
+#include <flux/core.h>
+
+#include "src/common/librouter/rpc_track.h"
+#include "src/common/libtap/tap.h"
+
+#include "src/common/libczmqcontainers/czmq_containers.h"
+#include "src/common/librouter/msg_hash.h"
+#include "src/common/libtap/tap.h"
+
+#ifndef UUID_STR_LEN
+#define UUID_STR_LEN 37     // defined in later libuuid headers
+#endif
+
+/* Create a disconnect with same uuid as 'req'.
+ */
+flux_msg_t *create_disconnect (const flux_msg_t *req)
+{
+    const char *topic;
+    flux_msg_t *dis;
+    char buf[128];
+
+    if (!(dis = flux_msg_copy (req, false))
+        || flux_msg_get_topic (req, &topic) < 0
+        || snprintf (buf, sizeof (buf), "%s.disconnect", topic) >= sizeof (buf)
+        || flux_msg_set_topic (dis, buf) < 0
+        || flux_msg_set_noresponse (dis) < 0
+        || flux_msg_set_matchtag (dis, FLUX_MATCHTAG_NONE) < 0)
+        BAIL_OUT ("failed to create disconnect request");
+    return dis;
+}
+
+flux_msg_t *create_response (const flux_msg_t *req, int errnum)
+{
+    flux_msg_t *rep;
+
+    if (!(rep = flux_response_derive (req, errnum)))
+        BAIL_OUT ("flux_response_derive failed");
+    return rep;
+}
+
+flux_msg_t *create_request (uint32_t matchtag, int setflags)
+{
+    flux_msg_t *msg;
+    uint8_t flags;
+    uuid_t uuid;
+    char uuid_str[UUID_STR_LEN];
+
+    if (!(msg = flux_request_encode ("foo", NULL)))
+        BAIL_OUT ("flux_request_create failed");
+    if (flux_msg_set_matchtag (msg, matchtag) < 0)
+        BAIL_OUT ("flux_msg_set_matchtag failed");
+
+    if (flux_msg_get_flags (msg, &flags) < 0)
+        BAIL_OUT ("flux_msg_get_flags failed");
+        flags |= setflags;
+    if (flux_msg_set_flags (msg, flags) < 0)
+        BAIL_OUT ("flux_msg_set_flags failed");
+
+    uuid_generate (uuid);
+    uuid_unparse (uuid, uuid_str);
+    flux_msg_route_enable (msg);
+    if (flux_msg_route_push (msg, uuid_str) < 0)
+        BAIL_OUT ("flux_msg_route_push failed");
+    return msg;
+}
+
+void purge (const flux_msg_t *msg, void *arg)
+{
+    int *count = arg;
+    (*count)++;
+}
+
+void test_purge (void)
+{
+    struct rpc_track *rt;
+    int count;
+    flux_msg_t *msg[2];
+    int i;
+
+    msg[0] = create_request (1, 0);
+    msg[1] = create_request (2, FLUX_MSGFLAG_STREAMING);
+
+    if (!(rt = rpc_track_create (MSG_HASH_TYPE_UUID_MATCHTAG)))
+        BAIL_OUT ("rpc_track_create failed");
+
+    count = 0;
+    rpc_track_purge (rt, purge, &count);
+    ok (count == 0,
+        "rpc_track_purge does nothing on empty hash");
+
+    for (i = 0; i < sizeof (msg) / sizeof (msg[0]); i++)
+        rpc_track_update (rt, msg[i]);
+    ok (rpc_track_count (rt) == 2,
+        "rpc_track_update tracks 2 messages");
+
+    count = 0;
+    rpc_track_purge (rt, purge, &count);
+    ok (count == 2,
+        "rpc_track_purge called callback 2 times");
+    ok (rpc_track_count (rt) == 0,
+        "rpc_track_purge emptied hash");
+
+    rpc_track_destroy (rt);
+
+    for (i = 0; i < sizeof (msg) / sizeof (msg[0]); i++)
+        flux_msg_decref (msg[i]);
+}
+
+void test_basic (void)
+{
+    struct rpc_track *rt;
+    flux_msg_t *req[4];
+    flux_msg_t *rep[3];
+    int i;
+
+    req[0] = create_request (0, FLUX_MSGFLAG_NORESPONSE); // won't track
+    req[1] = create_request (1, 0);
+    req[2] = create_request (2, FLUX_MSGFLAG_STREAMING);
+    req[3] = flux_msg_copy (req[2], true); // same as 2 except new matchtag
+    if (!req[3])
+        BAIL_OUT ("flux_msg_copy failed");
+    if (flux_msg_set_matchtag (req[3], 3) < 0)
+        BAIL_OUT ("flux_msg_set_matchtag failed");
+
+    rep[0] = create_response (req[1], 0); // terminating (non-streaming)
+    rep[1] = create_response (req[2], 1); // terminating
+    rep[2] = create_response (req[3], 0); // not terminating (streaming)
+
+    if (!(rt = rpc_track_create (MSG_HASH_TYPE_UUID_MATCHTAG)))
+        BAIL_OUT ("rpc_track_create failed");
+
+    ok (rpc_track_count (rt) == 0,
+        "rpc_track_count returns 0 on empty hash");
+
+    for (i = 0; i < sizeof (req) / sizeof (req[0]); i++)
+        rpc_track_update (rt, req[i]);
+    ok (rpc_track_count (rt) == 3,
+        "rpc_track_update works (3 of 4 requests tracked)");
+
+    for (i = 0; i < sizeof (rep) / sizeof (rep[0]); i++)
+        rpc_track_update (rt, rep[i]);
+    ok (rpc_track_count (rt) == 1,
+        "rpc_track_update works (2 requests terminated)");
+
+    rpc_track_destroy (rt);
+
+    for (i = 0; i < sizeof (req) / sizeof (req[0]); i++)
+        flux_msg_decref (req[i]);
+    for (i = 0; i < sizeof (rep) / sizeof (rep[0]); i++)
+        flux_msg_decref (rep[i]);
+}
+
+void test_disconnect (void)
+{
+    struct rpc_track *rt;
+    flux_msg_t *req[4];
+    flux_msg_t *dis;
+    int i;
+
+    req[0] = create_request (0, FLUX_MSGFLAG_NORESPONSE); // won't track
+    req[1] = create_request (1, 0);
+    req[2] = create_request (2, FLUX_MSGFLAG_STREAMING);
+    req[3] = flux_msg_copy (req[2], true); // same as 2 except new matchtag
+    if (!req[3])
+        BAIL_OUT ("flux_msg_copy failed");
+    if (flux_msg_set_matchtag (req[3], 3) < 0)
+        BAIL_OUT ("flux_msg_set_matchtag failed");
+    dis = create_disconnect (req[2]);
+
+    if (!(rt = rpc_track_create (MSG_HASH_TYPE_UUID_MATCHTAG)))
+        BAIL_OUT ("rpc_track_create failed");
+
+    for (i = 0; i < sizeof (req) / sizeof (req[0]); i++)
+        rpc_track_update (rt, req[i]);
+    ok (rpc_track_count (rt) == 3,
+        "rpc_track_update works (3 of 4 requests tracked)");
+
+    rpc_track_update (rt, dis);
+    ok (rpc_track_count (rt) == 1, // 2 of 3 match the disconnect
+        "rpc_track_update correctly processed disconnect request");
+
+    rpc_track_destroy (rt);
+
+    for (i = 0; i < sizeof (req) / sizeof (req[0]); i++)
+        flux_msg_decref (req[i]);
+    flux_msg_decref (dis);
+}
+
+void test_badarg (void)
+{
+    struct rpc_track *rt;
+    flux_msg_t *msg;
+    uuid_t uuid;
+    char uuid_str[UUID_STR_LEN];
+
+    uuid_generate (uuid);
+    uuid_unparse (uuid, uuid_str);
+
+    errno = 0;
+    ok (rpc_track_create (42) == NULL && errno == EINVAL,
+        "rpc_track_create type=42 fails with EINVAL");
+
+    if (!(rt = rpc_track_create (MSG_HASH_TYPE_UUID_MATCHTAG)))
+        BAIL_OUT ("rpc_track_create failed");
+
+    rpc_track_update (rt, NULL);
+    ok (rpc_track_count (rt) == 0,
+        "rpc_track_update msg=NULL is a no-op");
+
+    if (!(msg = flux_request_encode ("foo", NULL))
+        || flux_msg_set_matchtag (msg, 1) < 0)
+        BAIL_OUT ("could not create test message");
+    rpc_track_update (rt, NULL);
+    ok (rpc_track_count (rt) == 0,
+        "rpc_track_update msg=(no sender) is a no-op");
+    flux_msg_decref (msg);
+
+    if (!(msg = flux_request_encode ("foo", NULL)))
+        BAIL_OUT ("could not create test message");
+    flux_msg_route_enable (msg);
+    if (flux_msg_route_push (msg, uuid_str) < 0)
+        BAIL_OUT ("could not tweak test message");
+    rpc_track_update (rt, NULL);
+    ok (rpc_track_count (rt) == 0,
+        "rpc_track_update msg=(no matchtag) is a no-op");
+    flux_msg_decref (msg);
+
+    if (!(msg = flux_event_encode ("meep", NULL)))
+        BAIL_OUT ("could not create test message");
+    rpc_track_update (rt, NULL);
+    ok (rpc_track_count (rt) == 0,
+        "rpc_track_update msg=event is a no-op");
+    flux_msg_decref (msg);
+
+    if (!(msg = flux_keepalive_encode (42, 43)))
+        BAIL_OUT ("could not create test message");
+    rpc_track_update (rt, NULL);
+    ok (rpc_track_count (rt) == 0,
+        "rpc_track_update msg=keepalive is a no-op");
+    flux_msg_decref (msg);
+
+    if (!(msg = flux_request_encode ("foo", NULL)))
+        BAIL_OUT ("could not create test message");
+    flux_msg_route_enable (msg);
+    if (flux_msg_route_push (msg, uuid_str) < 0
+        || flux_msg_set_matchtag (msg, 1) < 0)
+        BAIL_OUT ("could not tweak test message");
+    rpc_track_update (rt, msg);
+    if (rpc_track_count (rt) != 1)
+        BAIL_OUT ("could not track legit request");
+    flux_msg_decref (msg);  // reminder: hash has one entry
+
+    if (!(msg = flux_request_encode ("foo.disconnect", NULL))
+        || flux_msg_set_noresponse (msg) < 0)
+        BAIL_OUT ("could not create test disconnect");
+    rpc_track_update (rt, msg);
+    ok (rpc_track_count (rt) == 1,
+        "a disconnect without a uuid has no effect");
+    flux_msg_decref (msg);
+
+    rpc_track_destroy (rt);
+}
+
+int main (int argc, char *argv[])
+{
+    plan (NO_PLAN);
+
+    test_basic ();
+    test_purge ();
+    test_disconnect ();
+    test_badarg ();
+
+    done_testing();
+    return (0);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */
+

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -179,6 +179,7 @@ TESTSCRIPTS = \
 	t3301-system-latestart.t \
 	t3302-system-offline.t \
 	t3303-system-healthcheck.t \
+	t3304-system-rpctrack.t \
 	t4000-issues-test-driver.t \
 	lua/t0001-send-recv.t \
 	lua/t0002-rpc.t \

--- a/t/t3300-system-basic.t
+++ b/t/t3300-system-basic.t
@@ -74,10 +74,6 @@ test_expect_success 'ping to rank 2 fails' '
 	test_must_fail flux ping 2
 '
 
-test_expect_success 'dmesg shows failed send from ping' '
-	flux dmesg |grep "send failed"
-'
-
 test_expect_success 'wait for overlay status to be degraded' '
 	flux overlay status --wait degraded --timeout 10s
 '

--- a/t/t3303-system-healthcheck.t
+++ b/t/t3303-system-healthcheck.t
@@ -168,8 +168,10 @@ test_expect_success 'kill broker 14' '
 '
 
 # Ensure an EHOSTUNREACH is encountered to trigger connected state change.
-test_expect_success 'ping to rank 14 fails' '
-        test_must_fail flux ping 14
+test_expect_success 'ping to rank 14 fails with EHOSTUNREACH' '
+	echo "flux-ping: 14!broker.ping: No route to host" >ping.exp &&
+	test_must_fail flux ping 14 2>ping.err &&
+	test_cmp ping.exp ping.err
 '
 
 test_expect_success 'wait for rank 0 subtree to be degraded' '

--- a/t/t3304-system-rpctrack.t
+++ b/t/t3304-system-rpctrack.t
@@ -1,0 +1,104 @@
+#!/bin/sh
+#
+
+test_description='Test overlay RPC tracking'
+
+. `dirname $0`/sharness.sh
+
+export TEST_UNDER_FLUX_FANOUT=1
+
+test_under_flux 3 system
+
+startctl="flux python ${SHARNESS_TEST_SRCDIR}/scripts/startctl.py"
+
+# The health check with wait option is just a convenient RPC that
+# can be made to block indefinitely by requesting a state not expected
+# to be entered.
+test_expect_success NO_CHAIN_LINT 'start background RPC to rank 2' '
+	flux overlay status --wait=lost --rank=2 2>health.err &
+	echo $! >health.pid
+'
+
+# This ensures the blocking check was received on rank 2 so that
+# we don't shut down rank 2 broker before zeromq has routes the request.
+test_expect_success 'ensure background request was received on rank 2' '
+	flux overlay status --rank=2
+'
+
+test_expect_success NO_CHAIN_LINT 'broker 1 tracked child rpc count is nonzero' '
+	count=$(flux exec -r 1 flux module stats --parse=child-rpc overlay) &&
+	echo $count &&
+	test $count -gt 0
+'
+
+test_expect_success 'stop broker 2 nicely and wait for it to exit' '
+	$startctl kill 2 15 &&
+	$startctl wait 2
+'
+
+test_expect_success NO_CHAIN_LINT 'background RPC fails with EHOSTUNREACH (tracker response from rank 1)' '
+	pid=$(cat health.pid) &&
+	echo waiting for pid $pid &&
+	test_expect_code 1 wait $pid &&
+	grep "No route to host" health.err
+'
+
+test_expect_success 'new RPC to rank 2 fails with EHOSTUNREACH' '
+	test_expect_code 1 flux overlay status --rank=2 2>health2.err &&
+	grep "No route to host" health2.err
+'
+
+test_expect_success 'broker 1 tracked child rpc count is zero' '
+	count=$(flux exec -r 1 flux module stats --parse=child-rpc overlay) &&
+	echo $count &&
+	test $count -eq 0
+'
+
+test_expect_success NO_CHAIN_LINT 'start background RPC to rank 1' '
+	flux overlay status --wait=lost --rank=1 2>health3.err &
+	echo $! >health3.pid
+'
+
+test_expect_success 'ensure background request was received on rank 1' '
+	flux overlay status --rank=1
+'
+
+test_expect_success NO_CHAIN_LINT 'broker 0 tracked child rpc count is nonzero' '
+	count=$(flux module stats --parse=child-rpc overlay) &&
+	echo $count &&
+	test $count -gt 0
+'
+
+test_expect_success 'stop broker 1 hard and wait for it to exit' '
+	$startctl kill 1 9 &&
+	($startctl wait 1 || /bin/true)
+'
+
+# Ensure an EHOSTUNREACH is encountered on the socket to trigger connected
+# state change.  Note: existing traffic like heartbeat probably also serve
+# this purpose, but do it anyway to ensure repeatability.
+test_expect_success 'ping to rank 1 fails with EHOSTUNREACH' '
+	echo "flux-ping: 1!broker.ping: No route to host" >ping.exp &&
+	test_must_fail flux ping 1 2>ping.err &&
+	test_cmp ping.exp ping.err
+'
+
+test_expect_success NO_CHAIN_LINT 'background RPC fails with EHOSTUNREACH (tracker response from rank 0)' '
+	pid=$(cat health3.pid) &&
+	echo waiting for pid $pid &&
+	test_expect_code 1 wait $pid &&
+	grep "No route to host" health3.err
+'
+
+test_expect_success 'new RPC to rank 1 fails with EHOSTUNREACH' '
+	test_expect_code 1 flux overlay status --rank=1 2>health4.err &&
+	grep "No route to host" health4.err
+'
+
+test_expect_success 'broker 0 tracked child rpc count is zero' '
+	count=$(flux module stats --parse=child-rpc overlay) &&
+	echo $count &&
+	test $count -eq 0
+'
+
+test_done


### PR DESCRIPTION
This creates a generic RPC tracking class in librouter, and uses it on TBON children in the broker, as described briefly in #3800 and in more detail [here](https://github.com/flux-framework/flux-core/blob/master/src/broker/doc/resiliency.md).

Each broker tracks the state of all RPC requests passing through it to its children.  In a multi-hop RPC, each hop in that direction creates state.  If a broker goes down, only that broker's TBON parent generates the error response, which then causes the state in other brokers to be freed like it would have been had the intended destination responded.

The overhead is:
- a zhashx entry for each sent request, containnig a reference on sent `flux_msg_t`, valid while the RPC is in flight
- zhashx lookup for each received response (key=uuid+matchtag)
-  full hash walk on receipt of a disconnect request

It feels to me like this should be pretty light overhead, both in terms of memory and cpu, but I'll do some testing to see if I can quantify it.

BTW, the `rpc_track` class was written with the idea that it could be reused for:
- loss of parent (causing pending rpcs to fail fast during subtree panic)
- temporary loss of broker connection in shell

Leaving this WIP for now as I work on testing.