### PR TITLE
add bootstrap.ipv6_enable = true config option

### DIFF
--- a/doc/man5/flux-config-bootstrap.rst
+++ b/doc/man5/flux-config-bootstrap.rst
@@ -29,6 +29,11 @@ expected to bootstrap from an identical config file.
 KEYWORDS
 ========
 
+enable_ipv6
+   (optional) Boolean value for enabling IPv6.  By default only IPv4 is
+   enabled.  Note that setting this to true prevents binding to a named
+   interface that only supports IPv4.
+
 curve_cert
    (optional) Path to a CURVE certificate generated with flux-keygen(1).
    The certificate should be identical on all broker ranks.

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -534,3 +534,5 @@ afternotok
 parsedatetime
 cancelall
 raiseall
+IPv4
+IPv6

--- a/src/broker/boot_config.c
+++ b/src/broker/boot_config.c
@@ -510,10 +510,8 @@ int boot_config (flux_t *h, struct overlay *overlay, attr_t *attrs)
                                        bind_uri,
                                        sizeof (bind_uri)) < 0)
             goto error;
-        if (overlay_bind (overlay, bind_uri) < 0) {
-            log_err ("overlay_bind");
+        if (overlay_bind (overlay, bind_uri) < 0)
             goto error;
-        }
         if (overlay_authorize (overlay,
                                overlay_cert_name (overlay),
                                overlay_cert_pubkey (overlay)) < 0) {

--- a/src/broker/boot_config.h
+++ b/src/broker/boot_config.h
@@ -32,6 +32,7 @@ struct boot_conf {
     char default_bind[MAX_URI + 1];
     char default_connect[MAX_URI + 1];
     json_t *hosts;
+    int enable_ipv6;
 };
 
 int boot_config_geturibyrank (json_t *hosts,

--- a/src/broker/boot_pmi.c
+++ b/src/broker/boot_pmi.c
@@ -193,6 +193,10 @@ int boot_pmi (struct overlay *overlay, attr_t *attrs)
     if (pmi_params.size == 1)
         goto done;
 
+    /* Enable ipv6 for maximum flexibility in address selection.
+     */
+    overlay_set_ipv6 (overlay, 1);
+
     /* If there are to be downstream peers, then bind to socket and extract
      * the concretized URI for sharing with other ranks.
      * N.B. there are no downstream peers if the 0th child of this rank

--- a/src/broker/boot_pmi.c
+++ b/src/broker/boot_pmi.c
@@ -210,10 +210,8 @@ int boot_pmi (struct overlay *overlay, attr_t *attrs)
 
         if (format_bind_uri (buf, sizeof (buf), attrs, pmi_params.rank) < 0)
             goto error;
-        if (overlay_bind (overlay, buf) < 0) {
-            log_err ("error binding to %s", buf);
+        if (overlay_bind (overlay, buf) < 0)
             goto error;
-        }
         uri = overlay_get_bind_uri (overlay);
     }
     else {

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -237,7 +237,6 @@ int main (int argc, char *argv[])
     zsys_set_linger (5);
     zsys_set_rcvhwm (0);
     zsys_set_sndhwm (0);
-    zsys_set_ipv6 (1);
 
     /* Set up the flux reactor with support for child watchers.
      * Associate an internal flux_t handle with the reactor.

--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -104,6 +104,7 @@ struct overlay {
     zcertstore_t *certstore;
     zsock_t *zap;
     flux_watcher_t *zap_w;
+    int enable_ipv6;
 
     flux_t *h;
     attr_t *attrs;
@@ -356,6 +357,11 @@ int overlay_get_child_peer_count (struct overlay *ov)
             count++;
     }
     return count;
+}
+
+void overlay_set_ipv6 (struct overlay *ov, int enable)
+{
+    ov->enable_ipv6 = enable;
 }
 
 void overlay_log_idle_children (struct overlay *ov)
@@ -1081,6 +1087,7 @@ int overlay_connect (struct overlay *ov)
         }
         if (!(ov->parent.zsock = zsock_new_dealer (NULL)))
             goto nomem;
+        zsock_set_ipv6 (ov->parent.zsock, ov->enable_ipv6);
         zsock_set_zap_domain (ov->parent.zsock, FLUX_ZAP_DOMAIN);
         zcert_apply (ov->cert, ov->parent.zsock);
         zsock_set_curve_serverkey (ov->parent.zsock, ov->parent.pubkey);
@@ -1114,6 +1121,7 @@ int overlay_bind (struct overlay *ov, const char *uri)
     if (!(ov->bind_zsock = zsock_new_router (NULL)))
         return -1;
     zsock_set_router_mandatory (ov->bind_zsock, 1);
+    zsock_set_ipv6 (ov->bind_zsock, ov->enable_ipv6);
 
     zsock_set_zap_domain (ov->bind_zsock, FLUX_ZAP_DOMAIN);
     zcert_apply (ov->cert, ov->bind_zsock);

--- a/src/broker/overlay.h
+++ b/src/broker/overlay.h
@@ -79,6 +79,7 @@ void overlay_set_version (struct overlay *ov, int version); // test only
 const char *overlay_get_uuid (struct overlay *ov);
 bool overlay_uuid_is_parent (struct overlay *ov, const char *uuid);
 bool overlay_uuid_is_child (struct overlay *ov, const char *uuid);
+void overlay_set_ipv6 (struct overlay *ov, int enable);
 
 /* Broker should call overlay_bind() if there are children.  This may happen
  * before any peers are authorized as long as they are authorized before they

--- a/src/broker/test/boot_config.c
+++ b/src/broker/test/boot_config.c
@@ -529,6 +529,31 @@ void test_curve_cert (const char *dir)
     flux_conf_decref (cf);
 }
 
+void test_ipv6 (const char *dir)
+{
+    char path[PATH_MAX + 1];
+    json_t *hosts;
+    flux_conf_t *cf;
+    struct boot_conf conf;
+    const char *input = \
+"[bootstrap]\n" \
+"enable_ipv6 = true\n";
+
+    create_test_file (dir, "boot", path, sizeof (path), input);
+    if (!(cf = flux_conf_parse (dir, NULL)))
+        BAIL_OUT ("flux_conf_parse failed");
+
+    ok (boot_config_parse (cf, &conf, &hosts) == 0 && hosts == NULL,
+        "boot_config_parse works with enable_ipv6");
+    ok (conf.enable_ipv6 != 0,
+        "and enable_ipv6 has expected value");
+
+    if (unlink (path) < 0)
+        BAIL_OUT ("could not cleanup test file %s", path);
+
+    flux_conf_decref (cf);
+}
+
 int main (int argc, char **argv)
 {
     char dir[PATH_MAX + 1];
@@ -551,6 +576,7 @@ int main (int argc, char **argv)
     test_toml_mixed_array (dir);
     test_attr (dir);
     test_curve_cert (dir);
+    test_ipv6 (dir);
 
     if (rmdir (dir) < 0)
         BAIL_OUT ("could not cleanup test dir %s", dir);


### PR DESCRIPTION
Problem: as noted in #3824, the current default of enabling ipv6 for all zeromq sockets prevents the flux system instance from binding to an interface that only has ipv4 addresses.  We just hit this on fluke, and in fact this bug is a blocker for getting the system instance updated on fluke.

This PR disables ipv6 for config bootstrap only, and adds a config setting for overriding the default, should that be necessary:
  ```toml  
 [bootstrap]
 enable_ipv6 = true
``` 
    
Fixes #3824
