### PR TITLE
github: increase ci timeout to 40 minutes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -108,7 +108,7 @@ jobs:
       DOCKER_USERNAME: travisflux
       DOCKER_PASSWORD: ${{ secrets.DOCKER_HUB_TRAVISFLUX_TOKEN }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    timeout-minutes: 30
+    timeout-minutes: 40
     strategy:
       matrix: ${{fromJson(needs.generate-matrix.outputs.matrix)}}
       fail-fast: false


### PR DESCRIPTION
Problem: Over time, the addition of tests to the testsuite has
increased the minimum runtime of the GitHub workflow builds. The
coverage build is especially impacted, presumably due to extra IO
induced by gcov output, and is now often timing out.

Increase the build timeout to 40 minutes to avoid spurious CI timeouts
in the coverage builder.

This will need to be merged manually since it touches the workflow
config under `.github`.