### PR TITLE
python: fix bug in FluxExecutor.attach method

### DIFF
--- a/src/bindings/python/flux/job/executor.py
+++ b/src/bindings/python/flux/job/executor.py
@@ -163,6 +163,7 @@ class _FluxExecutorThread(threading.Thread):
 
     def __event_update(self, event_future, user_future):
         """Callback invoked when a job has an event update."""
+        event = None
         try:
             event = event_future.get_event()
         except FileNotFoundError:  # job ID was not accepted


### PR DESCRIPTION
Problem: when a nonexistent jobid is passed to FluxExecutor.attach(), the executor should catch a `FileNotFoundException` and error out the future. However, along that line of control flow a variable is undefined (`UnboundLocalError`), causing the executor to crash. Fix: a single-line change to define the variable. Add tests to catch the problem.

For an example of the bug see https://github.com/flux-framework/flux-core/pull/3835#issuecomment-904735399