### PR TITLE
testsuite: make valgrind test opt-in

### DIFF
--- a/src/test/checks_run.sh
+++ b/src/test/checks_run.sh
@@ -164,6 +164,8 @@ export FLUX_TEST_MPI=t
 export FLUX_TESTS_LOGFILE=t
 export DISTCHECK_CONFIGURE_FLAGS="${ARGS}"
 
+# Force enable valgrind test
+export FLUX_ENABLE_VALGRIND_TEST=t
 
 if test "$CPPCHECK" = "t"; then
     sh -x src/test/cppcheck.sh

--- a/t/t5000-valgrind.t
+++ b/t/t5000-valgrind.t
@@ -6,6 +6,13 @@ test_description='Run broker under valgrind with a small workload'
 test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
 . `dirname $0`/sharness.sh
 
+#  Do not run valgrind test by default unless FLUX_ENABLE_VALGRIND_TEST
+#   is set in environment (e.g. by CI), or the test run run with -d, --debug
+#
+if test -z "$FLUX_ENABLE_VALGRIND_TEST" && test "$debug" = ""; then
+    skip_all='skipping valgrind tests since FLUX_ENABLE_VALGRIND_TEST not set'
+    test_done
+fi
 if ! which valgrind >/dev/null; then
     skip_all='skipping valgrind tests since no valgrind executable found'
     test_done


### PR DESCRIPTION
The `t5000-valgrind.t` test is prone to spurious failures on new systems and distros due to false positives in system libraries, etc. This can cause confusion when new users run `make check`.

Disable `t5000-valgrind.t` by default, unless it is run with the `-d, --debug` flag (this allows it to be run by hand as `./t5000-valgrind.t -d`), or if `FLUX_ENABLE_VALGRIND_TEST` is set in the environment. The environment variable is then set in `checks_run.sh` so that the valgrind test is always run under `docker-run-checks.sh` and therefore the CI.

