### PR TITLE
broker: fail pending RPCs when TBON parent goes down

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -322,6 +322,7 @@ AM_CONDITIONAL([ENABLE_PYLINT], [test "x$PYLINT" = "xpylint"])
 AX_PROG_LUA([5.1],[5.5])
 AX_LUA_HEADERS
 AX_LUA_LIBS
+# N.B oldest in CI are bionic=libzmq-4.2.5, centos7=zeromq-4.1.4
 PKG_CHECK_MODULES([ZMQ], [libczmq >= 3.0.0 libzmq >= 4.0.4])
 X_AC_JANSSON
 PKG_CHECK_MODULES([HWLOC], [hwloc >= 1.11.1], [], [])

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -234,9 +234,6 @@ int main (int argc, char *argv[])
     zsys_set_logstream (stderr);
     zsys_set_logident ("flux-broker");
     zsys_handler_set (NULL);
-    zsys_set_linger (5);
-    zsys_set_rcvhwm (0);
-    zsys_set_sndhwm (0);
 
     /* Set up the flux reactor with support for child watchers.
      * Associate an internal flux_t handle with the reactor.

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -225,7 +225,19 @@ int main (int argc, char *argv[])
         || sigaction (SIGTERM, NULL, &old_sigact_term) < 0)
         log_err_exit ("error setting signal mask");
 
-    /* Initailize zeromq context
+    /* Initialize libczmq zsys class.
+     *
+     * zsys_init() creates a global 0MQ context and starts the 0MQ I/O thread.
+     * The context is implicitly shared by users of the zsock class within
+     * the broker, including shmem connector, overlay.c, and module.c.
+     * libczmq tracks 0MQ sockets created with zsock, and any left open are
+     * closed by an atexit() handler to prevent zmq_ctx_term() from hanging.
+     *
+     * If something goes wrong, such as unclosed sockets in the atexit handler,
+     * czmq sends messages to its log class, which we redirect to stderr here.
+     *
+     * Disable czmq's internal signal handlers for SIGINT and SIGTERM, since
+     * the broker will install its own.
      */
     if (!zsys_init ()) {
         log_err ("zsys_init");

--- a/src/broker/module.c
+++ b/src/broker/module.c
@@ -610,6 +610,8 @@ module_t *module_add (modhash_t *mh, const char *path)
         log_err ("zsock_new_pair");
         goto cleanup;
     }
+    zsock_set_unbounded (p->sock);
+    zsock_set_linger (p->sock, 5);
     if (zsock_bind (p->sock, "inproc://%s", module_get_uuid (p)) < 0) {
         log_err ("zsock_bind inproc://%s", module_get_uuid (p));
         goto cleanup;

--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -1211,33 +1211,15 @@ int overlay_bind (struct overlay *ov, const char *uri)
     return 0;
 }
 
-/* A callback of type attr_get_f to allow retrieving some information
- * from an struct overlay through attr_get().
+/* Call after overlay bootstrap (bind/connect),
+ * to get concretized 0MQ endpoints.
  */
-static int overlay_attr_get_cb (const char *name, const char **val, void *arg)
-{
-    struct overlay *overlay = arg;
-    int rc = -1;
-
-    if (!strcmp (name, "tbon.parent-endpoint"))
-        *val = overlay_get_parent_uri (overlay);
-    else {
-        errno = ENOENT;
-        goto done;
-    }
-    rc = 0;
-done:
-    return rc;
-}
-
 int overlay_register_attrs (struct overlay *overlay)
 {
-    if (attr_add_active (overlay->attrs,
-                         "tbon.parent-endpoint",
-                         FLUX_ATTRFLAG_READONLY,
-                         overlay_attr_get_cb,
-                         NULL,
-                         overlay) < 0)
+    if (attr_add (overlay->attrs,
+                  "tbon.parent-endpoint",
+                  overlay->parent.uri,
+                  FLUX_ATTRFLAG_IMMUTABLE) < 0)
         return -1;
     if (attr_add_uint32 (overlay->attrs,
                          "rank",

--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -351,8 +351,8 @@ const char *overlay_get_uuid (struct overlay *ov)
 
 bool overlay_parent_error (struct overlay *ov)
 {
-    return (ov->parent.hello_responded
-            && ov->parent.hello_error);
+    return ((ov->parent.hello_responded && ov->parent.hello_error)
+            || ov->parent.offline);
 }
 
 bool overlay_parent_success (struct overlay *ov)
@@ -926,6 +926,7 @@ static void parent_cb (flux_reactor_t *r, flux_watcher_t *w,
                 (void)zsock_disconnect (ov->parent.zsock, "%s", ov->parent.uri);
                 ov->parent.offline = true;
                 rpc_track_purge (ov->parent.tracker, fail_parent_rpc, ov);
+                overlay_monitor_notify (ov);
             }
             else
                 logdrop (ov, OVERLAY_UPSTREAM, msg, "unknown keepalive type");

--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -941,6 +941,8 @@ static int overlay_zap_init (struct overlay *ov)
 {
     if (!(ov->zap = zsock_new (ZMQ_REP)))
         return -1;
+    zsock_set_unbounded (ov->zap);
+    zsock_set_linger (ov->zap, 5);
     if (zsock_bind (ov->zap, ZAP_ENDPOINT) < 0) {
         errno = EINVAL;
         log_err ("could not bind to %s", ZAP_ENDPOINT);
@@ -1114,6 +1116,8 @@ int overlay_connect (struct overlay *ov)
         }
         if (!(ov->parent.zsock = zsock_new_dealer (NULL)))
             goto nomem;
+        zsock_set_unbounded (ov->parent.zsock);
+        zsock_set_linger (ov->parent.zsock, 5);
         zsock_set_ipv6 (ov->parent.zsock, ov->enable_ipv6);
         zsock_set_zap_domain (ov->parent.zsock, FLUX_ZAP_DOMAIN);
         zcert_apply (ov->cert, ov->parent.zsock);
@@ -1152,6 +1156,8 @@ int overlay_bind (struct overlay *ov, const char *uri)
         log_err ("error creating zmq ROUTER socket");
         return -1;
     }
+    zsock_set_unbounded (ov->bind_zsock);
+    zsock_set_linger (ov->bind_zsock, 5);
     zsock_set_router_mandatory (ov->bind_zsock, 1);
     zsock_set_ipv6 (ov->bind_zsock, ov->enable_ipv6);
 

--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -1570,6 +1570,7 @@ static void overlay_disconnect_subtree_cb (flux_t *h,
         errstr = "failed to send KEEPALIVE_DISCONNECT message";
         goto error;
     }
+    overlay_child_status_update (ov, child, SUBTREE_STATUS_LOST);
     if (flux_respond (h, msg, NULL) < 0)
         flux_log_error (h, "error responding to overlay.disconnect-subtree");
     return;

--- a/src/broker/state_machine.c
+++ b/src/broker/state_machine.c
@@ -736,8 +736,10 @@ static void monitor_update (flux_t *h,
     msg = flux_msglist_first (requests);
     while (msg) {
         if (flux_respond_pack (h, msg, "{s:i}", "state", state) < 0) {
-            if (errno != EHOSTUNREACH && errno != ENOSYS)
-                flux_log_error (h, "error responding to monitor request");
+            if (errno != EHOSTUNREACH && errno != ENOSYS) {
+                flux_log_error (h,
+                        "error responding to state-machine.monitor request");
+            }
         }
         msg = flux_msglist_next (requests);
     }
@@ -752,16 +754,20 @@ static void monitor_cb (flux_t *h,
 
     if (flux_request_decode (msg, NULL, NULL) < 0)
         goto error;
-    if (flux_respond_pack (h, msg, "{s:i}", "state", s->state) < 0)
-        flux_log_error (h, "error responding to monitor request");
+    if (flux_respond_pack (h, msg, "{s:i}", "state", s->state) < 0) {
+        flux_log_error (h,
+                        "error responding to state-machine.monitor request");
+    }
     if (flux_msg_is_streaming (msg)) {
         if (flux_msglist_append (s->monitor.requests, msg) < 0)
             goto error;
     }
     return;
 error:
-    if (flux_respond_error (h, msg, errno, NULL) < 0)
-        flux_log_error (h, "error responding to monitor request");
+    if (flux_respond_error (h, msg, errno, NULL) < 0) {
+        flux_log_error (h,
+                        "error responding to state-machine.monitor request");
+    }
 }
 
 static void monitor_continuation (flux_future_t *f, void *arg)
@@ -771,7 +777,7 @@ static void monitor_continuation (flux_future_t *f, void *arg)
     int state;
 
     if (flux_rpc_get_unpack (f, "{s:i}", "state", &state) < 0) {
-        flux_log_error (h, "monitor");
+        flux_log_error (h, "state-machine.monitor");
         s->monitor.parent_error = 1;
         return;
     }

--- a/src/broker/state_machine.c
+++ b/src/broker/state_machine.c
@@ -819,6 +819,12 @@ static void overlay_monitor_cb (struct overlay *overlay, void *arg)
                 state_machine_post (s, "parent-fail");
             }
             break;
+        case STATE_RUN:
+            if (overlay_parent_error (overlay)) {
+                s->ctx->exit_rc = 1;
+                state_machine_post (s, "rc2-abort");
+            }
+            break;
         /* In SHUTDOWN state, post exit event if children have disconnected.
          * If there are no children on entry to SHUTDOWN state (e.g. leaf
          * node) the exit event is posted immediately in action_shutdown().

--- a/src/cmd/builtin/overlay.c
+++ b/src/cmd/builtin/overlay.c
@@ -18,8 +18,14 @@
 #include "src/common/libutil/monotime.h"
 #include "src/common/libutil/fsd.h"
 #include "src/common/libhostlist/hostlist.h"
+#include "src/common/librlist/rlist.h"
 
 #include "builtin.h"
+
+/* Wait a short time for resource.R to appear in the KVS
+ * if we need it to map hostnames to ranks.
+ */
+static const double resource_timeout = 2.0;
 
 static const char *ansi_default = "\033[39m";
 static const char *ansi_red = "\033[31m";
@@ -72,7 +78,6 @@ struct status {
     flux_t *h;
     int verbose;
     double timeout;
-    struct hostlist *hl;
     optparse_t *opt;
     struct timespec start;
     const char *wait;
@@ -85,10 +90,58 @@ struct status_node {
     bool ghost;
 };
 
+static struct hostlist *overlay_hostmap;
+
 typedef bool (*map_f)(struct status *ctx,
                       struct status_node *node,
                       bool parent,
                       int level);
+
+/* Fetch hostmap from the KVS.
+ * Use the WAITCREATE flag in case the resource inventory is being
+ * dynamically discovered, but do it under a relatively short timeout.
+ */
+static struct hostlist *get_hostmap_R (flux_t *h)
+{
+    flux_future_t *f;
+    const char *R;
+    struct rlist *rl;
+    struct hostlist *hl;
+
+    if (!(f = flux_kvs_lookup (h, NULL, FLUX_KVS_WAITCREATE, "resource.R"))
+        || flux_future_wait_for (f, resource_timeout) < 0
+        || flux_kvs_lookup_get (f, &R) < 0
+        || !(rl = rlist_from_R (R))
+        || !(hl = rlist_nodelist (rl)))
+        log_err_exit ("error fetching resource.R from KVS");
+    rlist_destroy (rl);
+    flux_future_destroy (f);
+    return hl;
+}
+
+static struct hostlist *get_hostmap_attr (flux_t *h)
+{
+    const char *s;
+    struct hostlist *hl;
+
+    if (!(s = flux_attr_get (h, "config.hostlist"))) {
+        if (errno != ENOENT)
+            log_err_exit ("error fetching config.hostlist attribute");
+        return NULL;
+    }
+    if (!(hl = hostlist_decode (s)))
+        log_err_exit ("config.hostlist value could not be decoded");
+    return hl;
+}
+
+static struct hostlist *get_hostmap (flux_t *h)
+{
+    if (!overlay_hostmap) {
+        if (!(overlay_hostmap = get_hostmap_attr (h)))
+            overlay_hostmap = get_hostmap_R (h);
+    }
+    return overlay_hostmap;
+}
 
 static const char *status_duration (struct status *ctx, double since)
 {
@@ -148,9 +201,12 @@ static const char *status_indent (struct status *ctx, int n)
 static const char *status_getname (struct status *ctx, int rank)
 {
     static char buf[128];
+    struct hostlist *hl;
     const char *s;
 
-    if (ctx->hl && (s = hostlist_nth (ctx->hl, rank)) != NULL)
+    if (optparse_hasopt (ctx->opt, "hostnames")
+        && (hl = get_hostmap (ctx->h))
+        && (s = hostlist_nth (hl, rank)) != NULL)
         snprintf (buf, sizeof (buf), "%s", s);
     else
         snprintf (buf, sizeof (buf), "%d", rank);
@@ -416,17 +472,8 @@ static int subcmd_status (optparse_t *p, int ac, char *av[])
     ctx.h = builtin_get_flux_handle (p);
     ctx.verbose = optparse_get_int (p, "verbose", 0);
     ctx.timeout = optparse_get_duration (p, "timeout", -1.0);
-    ctx.hl = NULL;
     ctx.opt = p;
     ctx.wait = optparse_get_str (p, "wait", NULL);
-
-    if (optparse_hasopt (p, "hostnames")) {
-        const char *s = flux_attr_get (ctx.h, "config.hostlist");
-        if (!s)
-            log_err_exit ("config.hostlist attribute is not set");
-        if (!(ctx.hl = hostlist_decode (s)))
-            log_err_exit ("config.hostlist value could not be decoded");
-    }
 
     if (ctx.verbose <= 0)
         fun = show_top;
@@ -439,7 +486,45 @@ static int subcmd_status (optparse_t *p, int ac, char *av[])
 
     status_healthwalk (&ctx, rank, 0, fun);
 
-    hostlist_destroy (ctx.hl);
+    return 0;
+}
+
+static int subcmd_gethostbyrank (optparse_t *p, int ac, char *av[])
+{
+    int optindex = optparse_option_index (p);
+    flux_t *h = builtin_get_flux_handle (p);
+    struct hostlist *hostmap = get_hostmap (h);
+    struct hostlist *hosts;
+    struct idset *ranks;
+    unsigned int rank;
+    char *s;
+
+    if (optindex != ac - 1)
+        log_msg_exit ("IDSET is required");
+    if (!(ranks = idset_decode (av[optindex++])))
+        log_err_exit ("IDSET could not be decoded");
+
+    if (!(hosts = hostlist_create ()))
+        log_err_exit ("failed to create hostlist");
+
+    rank = idset_first (ranks);
+    while (rank != IDSET_INVALID_ID) {
+        const char *host;
+        if (!(host = hostlist_nth (hostmap, rank)))
+            log_msg_exit ("rank %u is not found in host map", rank);
+        if (hostlist_append (hosts, host) < 0)
+            log_err_exit ("error appending to hostlist");
+        rank = idset_next (ranks, rank);
+    }
+    if (!(s = hostlist_encode (hosts)))
+        log_err_exit ("error encoding hostlist");
+
+    printf ("%s\n", s);
+
+    free (s);
+    hostlist_destroy (hosts);
+    idset_destroy (ranks);
+
     return 0;
 }
 
@@ -449,6 +534,9 @@ int cmd_overlay (optparse_t *p, int argc, char *argv[])
 
     if (optparse_run_subcommand (p, argc, argv) != OPTPARSE_SUCCESS)
         exit (1);
+
+    hostlist_destroy (overlay_hostmap);
+
     return (0);
 }
 
@@ -459,6 +547,13 @@ static struct optparse_subcommand overlay_subcmds[] = {
       subcmd_status,
       0,
       status_opts,
+    },
+    { "gethostbyrank",
+      "[OPTIONS] IDSET",
+      "lookup hostname(s) for rank(s), if available",
+      subcmd_gethostbyrank,
+      0,
+      NULL,
     },
     OPTPARSE_SUBCMD_END
 };

--- a/src/common/libflux/tagpool.c
+++ b/src/common/libflux/tagpool.c
@@ -56,19 +56,19 @@ static void pool_set (Veb veb, uint32_t from, uint32_t to, uint8_t value)
 
 struct tagpool *tagpool_create (void)
 {
-    struct tagpool *t = calloc (1, sizeof (*t));
-    if (!t)
-        goto nomem;
+    struct tagpool *t;
+
+    if (!(t = calloc (1, sizeof (*t))))
+        return NULL;
     t->magic = TAGPOOL_MAGIC;
     t->veb = vebnew (TAGPOOL_START, 1);
-    if (!t->veb.D)
-        goto nomem;
+    if (!t->veb.D) // vebnew() calls malloc which sets errno on failure
+        goto error;
     vebdel (t->veb, FLUX_MATCHTAG_NONE); /* allocate reserved value */
     t->avail = TAGPOOL_COUNT - 1;
     return t;
-nomem:
+error:
     tagpool_destroy (t);
-    errno = ENOMEM;
     return NULL;
 }
 

--- a/src/common/librouter/rpc_track.c
+++ b/src/common/librouter/rpc_track.c
@@ -70,12 +70,16 @@ static bool request_is_disconnect (const flux_msg_t *msg)
     return true;
 }
 
-static bool message_has_hashkey (const flux_msg_t *msg)
+/* Avoid putting messages in the hash that have ambiguous hash keys;
+ * specifically, avoid RFC 27 sched alloc RPCs, which are regular RPCs
+ * that don't use the matchtag field (setting it to FLUX_MATCHTAG_NONE),
+ * instead using payload elements to match requests and responses.
+ */
+static bool message_is_hashable (const flux_msg_t *msg)
 {
     uint32_t matchtag;
 
-    if (flux_msg_route_count (msg) < 1
-        || flux_msg_get_matchtag (msg, &matchtag) < 0
+    if (flux_msg_get_matchtag (msg, &matchtag) < 0
         || matchtag == FLUX_MATCHTAG_NONE)
         return false;
     return true;
@@ -92,7 +96,8 @@ static void rpc_track_disconnect (struct rpc_track *rt, const flux_msg_t *msg)
         return;
     req = zlistx_first (values);
     while (req) {
-        if (streq (uuid, flux_msg_route_first (req)))
+        const char *uuid2 = flux_msg_route_first (req);
+        if (uuid2 && streq (uuid, uuid2))
             zhashx_delete (rt->hash, req);
         req = zlistx_next (values);
     }
@@ -107,13 +112,13 @@ void rpc_track_update (struct rpc_track *rt, const flux_msg_t *msg)
         return;
     switch (type) {
         case FLUX_MSGTYPE_RESPONSE:
-            if (message_has_hashkey (msg)
+            if (message_is_hashable (msg)
                 && (!flux_msg_is_streaming (msg) || response_is_error (msg)))
                 zhashx_delete (rt->hash, msg);
             break;
         case FLUX_MSGTYPE_REQUEST:
             if (!flux_msg_is_noresponse (msg)
-                && message_has_hashkey (msg))
+                && message_is_hashable (msg))
                 zhashx_insert (rt->hash, msg, (flux_msg_t *)msg);
             else if (request_is_disconnect (msg))
                 rpc_track_disconnect (rt, msg);

--- a/src/common/librouter/rpc_track.c
+++ b/src/common/librouter/rpc_track.c
@@ -108,7 +108,7 @@ void rpc_track_update (struct rpc_track *rt, const flux_msg_t *msg)
 {
     int type;
 
-    if (flux_msg_get_type (msg, &type) < 0)
+    if (!rt || !msg || flux_msg_get_type (msg, &type) < 0)
         return;
     switch (type) {
         case FLUX_MSGTYPE_RESPONSE:
@@ -132,17 +132,20 @@ void rpc_track_purge (struct rpc_track *rt, rpc_respond_f fun, void *arg)
 {
     const flux_msg_t *msg;
 
-    msg = zhashx_first (rt->hash);
-    while (msg) {
-        fun (msg, arg);
-        msg = zhashx_next (rt->hash);
+    if (rt) {
+        msg = zhashx_first (rt->hash);
+        while (msg) {
+            if (fun)
+                fun (msg, arg);
+            msg = zhashx_next (rt->hash);
+        }
+        zhashx_purge (rt->hash);
     }
-    zhashx_purge (rt->hash);
 }
 
 int rpc_track_count (struct rpc_track *rt)
 {
-    return zhashx_size (rt->hash);
+    return rt ? zhashx_size (rt->hash) : 0;
 }
 
 // vi:ts=4 sw=4 expandtab

--- a/src/common/librouter/test/rpc_track.c
+++ b/src/common/librouter/test/rpc_track.c
@@ -315,6 +315,37 @@ void test_hashable (void)
     rpc_track_destroy (rt);
 }
 
+void test_nilarg (void)
+{
+    struct rpc_track *rt;
+    flux_msg_t *msg;
+
+    if (!(rt = rpc_track_create (MSG_HASH_TYPE_UUID_MATCHTAG)))
+        BAIL_OUT ("rpc_track_create failed");
+    msg = create_request (1, 0, true);
+    rpc_track_update (rt, msg);
+
+    ok (rpc_track_count (NULL) == 0,
+        "rpc_track_count rt=NULL returns 0");
+
+    lives_ok ({rpc_track_update (NULL, msg);},
+              "rpc_track_update rt=NULL doesn't crash");
+    lives_ok ({rpc_track_update (rt, NULL);},
+              "rpc_track_update msg=NULL doesn't crash");
+
+    lives_ok ({rpc_track_purge (NULL, purge, NULL);},
+              "rpc_track_purge rt=NULL doesn't crash");
+
+    lives_ok ({rpc_track_purge (rt, NULL, NULL);},
+              "rpc_track_purge func=NULL doesn't crash");
+    lives_ok ({rpc_track_destroy (NULL);},
+              "rpc_track_destroy rt=NULL doesn't crash");
+
+
+    flux_msg_decref (msg);
+    rpc_track_destroy (rt);
+}
+
 int main (int argc, char *argv[])
 {
     plan (NO_PLAN);
@@ -324,6 +355,7 @@ int main (int argc, char *argv[])
     test_disconnect ();
     test_badarg ();
     test_hashable ();
+    test_nilarg ();
 
     done_testing();
     return (0);

--- a/src/connectors/shmem/shmem.c
+++ b/src/connectors/shmem/shmem.c
@@ -188,6 +188,7 @@ flux_t *connector_init (const char *path, int flags)
     if (!(ctx->sock = zsock_new_pair (NULL)))
         goto error;
     zsock_set_unbounded (ctx->sock);
+    zsock_set_linger (ctx->sock, 5);
     if (bind_socket) {
         if (zsock_bind (ctx->sock, "inproc://%s", ctx->uuid) < 0)
             goto error;

--- a/src/connectors/shmem/shmem.c
+++ b/src/connectors/shmem/shmem.c
@@ -8,6 +8,14 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+/* Note:
+ * This connector creates a 0MQ inproc socket that communicates with another
+ * inproc socket in the same process (normally the flux broker).  Pairs of
+ * inproc sockets must share a common 0MQ context.  This connector uses the
+ * libczmq zsock class, which hides creation/sharing of the 0MQ context;
+ * therefore, the other inproc socket should be created with zsock also.
+ */
+
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -180,6 +180,7 @@ TESTSCRIPTS = \
 	t3302-system-offline.t \
 	t3303-system-healthcheck.t \
 	t3304-system-rpctrack.t \
+	t3305-system-disconnect.t \
 	t4000-issues-test-driver.t \
 	lua/t0001-send-recv.t \
 	lua/t0002-rpc.t \

--- a/t/t3303-system-healthcheck.t
+++ b/t/t3303-system-healthcheck.t
@@ -61,15 +61,20 @@ test_expect_success 'flux overlay fails on bad subcommand' '
 	test_must_fail flux overlay notcommand
 '
 
-test_expect_success 'flux overlay status --hostnames fails on PMI instance' '
-	test_must_fail flux start -o,-Sbroker.rc1_path=,-Sbroker.rc3_path= \
-		flux overlay status --hostnames
+test_expect_success 'flux overlay status --hostnames works on PMI instance' '
+	flux start flux overlay status -vvv --hostnames
+'
+
+test_expect_success 'flux overlay status --hostnames fails on PMI instance without R' '
+	test_must_fail flux start \
+		"flux kvs get --waitcreate resource.R && \
+		flux kvs unlink resource.R && \
+		flux overlay status -vvv --hostnames"
 '
 
 test_expect_success 'flux overlay status --hostnames fails on bad hostlist' '
-	test_must_fail flux start -o,-Sbroker.rc1_path=,-Sbroker.rc3_path= \
-		-o,-Sconfig.hostlist="[-badlist" \
-		flux overlay status --hostnames
+	test_must_fail flux start -o,-Sconfig.hostlist="[-badlist" \
+		flux overlay status -vvv --hostnames
 '
 
 test_expect_success 'overlay status is full' '
@@ -194,6 +199,30 @@ test_expect_success 'flux overlay status -vvgpc' '
 '
 test_expect_success 'flux overlay status -vvvgpc' '
 	flux overlay status -vvv --ghost --pretty --color
+'
+
+test_expect_success 'flux overlay gethostbyrank with no rank fails' '
+	test_must_fail flux overlay gethostbyrank
+'
+
+test_expect_success 'flux overlay gethostbyrank 0 works' '
+	echo fake0 >host.0.exp &&
+	flux overlay gethostbyrank 0 >host.0.out &&
+	test_cmp host.0.exp host.0.out
+'
+
+test_expect_success 'flux overlay gethostbyrank 0-14 works' '
+	echo "fake[0-14]" >host.0-14.exp &&
+	flux overlay gethostbyrank 0-14 >host.0-14.out &&
+	test_cmp host.0-14.exp host.0-14.out
+'
+
+test_expect_success 'flux overlay gethostbyrank fails on invalid idset' '
+	test_must_fail flux overlay gethostbyrank -- -1
+'
+
+test_expect_success 'flux overlay gethostbyrank fails on out of range rank' '
+	test_must_fail flux overlay gethostbyrank 100
 '
 
 test_done

--- a/t/t3305-system-disconnect.t
+++ b/t/t3305-system-disconnect.t
@@ -1,0 +1,24 @@
+#!/bin/sh
+#
+
+test_description='Test overlay parent disconnect'
+
+. `dirname $0`/sharness.sh
+
+export TEST_UNDER_FLUX_FANOUT=2
+
+test_under_flux 15 system
+
+startctl="flux python ${SHARNESS_TEST_SRCDIR}/scripts/startctl.py"
+
+test_expect_success 'flux overlay parentof fails with missing RANK' '
+	test_must_fail flux overlay parentof
+'
+test_expect_success 'flux overlay parentof fails with rank out of range' '
+	test_must_fail flux overlay parentof 42
+'
+test_expect_success 'flux overlay parentof fails with rank 0' '
+	test_must_fail flux overlay parentof 0
+'
+
+test_done

--- a/t/t3305-system-disconnect.t
+++ b/t/t3305-system-disconnect.t
@@ -11,6 +11,9 @@ test_under_flux 15 system
 
 startctl="flux python ${SHARNESS_TEST_SRCDIR}/scripts/startctl.py"
 
+test_expect_success 'tell each broker to log to stderr' '
+	flux exec flux setattr log-stderr-mode local
+'
 test_expect_success 'flux overlay parentof fails with missing RANK' '
 	test_must_fail flux overlay parentof
 '
@@ -19,6 +22,76 @@ test_expect_success 'flux overlay parentof fails with rank out of range' '
 '
 test_expect_success 'flux overlay parentof fails with rank 0' '
 	test_must_fail flux overlay parentof 0
+'
+test_expect_success 'flux overlay parentof relects k=2 topology' '
+	test $(flux overlay parentof 1) -eq 0 &&
+	test $(flux overlay parentof 2) -eq 0 &&
+	test $(flux overlay parentof 3) -eq 1 &&
+	test $(flux overlay parentof 4) -eq 1 &&
+	test $(flux overlay parentof 5) -eq 2 &&
+	test $(flux overlay parentof 6) -eq 2 &&
+	test $(flux overlay parentof 7) -eq 3 &&
+	test $(flux overlay parentof 8) -eq 3 &&
+	test $(flux overlay parentof 9) -eq 4 &&
+	test $(flux overlay parentof 10) -eq 4 &&
+	test $(flux overlay parentof 11) -eq 5 &&
+	test $(flux overlay parentof 12) -eq 5 &&
+	test $(flux overlay parentof 13) -eq 6 &&
+	test $(flux overlay parentof 14) -eq 6
+'
+
+test_expect_success 'flux overlay disconnect fails with missing rank' '
+	test_must_fail flux overlay disconnect
+'
+
+test_expect_success 'flux overlay disconnect fails on incorrect parent' '
+	test_must_fail flux overlay disconnect --parent 0 14
+'
+
+test_expect_success 'construct FLUX_URI for rank 13 (child of 6)' '
+	echo "local://$(flux getattr rundir)/local-13" >uri13 &&
+	test $(FLUX_URI=$(cat uri13) flux getattr rank) -eq 13
+'
+
+test_expect_success NO_CHAIN_LINT 'start background RPC to rank 0 via 13' '
+	FLUX_URI=$(cat uri13) flux overlay status --wait=lost 2>health.err &
+	echo $! >health.pid
+'
+test_expect_success 'ensure background request was received on rank 0' '
+        FLUX_URI=$(cat uri13) flux overlay status
+'
+
+test_expect_success 'disconnect rank 6' '
+	flux overlay disconnect 6
+'
+test_expect_success 'rank 6 exited with rc=1' '
+	test_expect_code 1 $startctl wait 6
+'
+test_expect_success 'rank 13 exited' '
+	($startctl wait 13 || /bin/true)
+'
+test_expect_success 'rank 14 exited' '
+	($startctl wait 14 || /bin/true)
+'
+
+test_expect_success NO_CHAIN_LINT 'background RPC fails with overlay disconnect (tracker response from 6)' '
+        pid=$(cat health.pid) &&
+        echo waiting for pid $pid &&
+        test_expect_code 1 wait $pid &&
+        grep "overlay disconnect" health.err
+'
+
+test_expect_success 'report health status' '
+	flux overlay status -vvv --pretty --ghost --color
+'
+test_expect_success 'health status for rank 6 is lost' '
+	echo "6: lost" >status.exp &&
+	flux overlay status -v >status.out &&
+	test_cmp status.exp status.out
+'
+
+test_expect_success 'attempt to disconnect rank 6 again fails' '
+	test_must_fail flux overlay disconnect 6
 '
 
 test_done


### PR DESCRIPTION
This implements broker RPC tracking in the upstream direction, analogous to the downstream tracking added in #3822.  The `rpc_track` class added in that PR was reused. 

With this component completed, we now have the machinery in place to avoid RPC hangs resulting from lost broker connections.  The next piece is to activate the machinery when we detect an uncommunicative broker or other unrecoverable broker failure mode.

A `flux overlay disconnect RANK` command was added that allows a sys admin to force disconnect a broker,  as proposed in #3805.   Tests for this PR are built upon this tool.

Code was added as part of `flux overlay disconnect` to determine the parent of the target rank by querying the topology from rank 0 and searching it.  To make this easier to test, a subcommand was added that exposes the topology lookup directly.  Maybe it'll be useful in other contexts:
```
$ flux overlay parentof 4
1
```
Also, while doing a bit of refactoring in the command, I updated `flux overlay status` to map ranks to hostnames using `resource.R` if `config.hostlist` is unavailable, as suggested by @grondo.  That mapping is exposed directly for testing in another subcommand:
```
$ flux overlay gethostbyrank 4
system76-pc
```
I've left this as a WIP just so I have a chance to cogitate on it a bit over the weekend, and decide if I've missed anything.
