### PR TITLE
ci: add ability to run tests under system instance

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -163,10 +163,12 @@ jobs:
       run: src/test/checks-annotate.sh
 
     - name: coverage report
-      if: success() && matrix.coverage
+      if: success() && matrix.coverage && matrix.image == 'bionic'
       env:
         DOCKER_REPO:
       uses: codecov/codecov-action@v1
+      with:
+        flags: ci-basic
 
     - name: docker deploy
       if: success() && matrix.docker_tag

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -108,7 +108,7 @@ jobs:
       DOCKER_USERNAME: travisflux
       DOCKER_PASSWORD: ${{ secrets.DOCKER_HUB_TRAVISFLUX_TOKEN }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    timeout-minutes: 40
+    timeout-minutes: 60
     strategy:
       matrix: ${{fromJson(needs.generate-matrix.outputs.matrix)}}
       fail-fast: false

--- a/src/cmd/flux-cron
+++ b/src/cmd/flux-cron
@@ -78,7 +78,7 @@ local function reladate (t)
         return fmt ("a minute ago")
     end
     if (diff < 90) then
-        return fmt ("%d minutes ago", diff)
+        return fmt ("%d minutes ago", math.floor (diff + 0.5))
     end
 
     -- Convert to hours:
@@ -96,10 +96,10 @@ local function reladate (t)
     -- weeks for past 10 weeks or so, reduce precision in output:
     local d = math.floor (diff)
     if (d < 70) then
-        return fmt ("%d weeks ago", (d + 3) / 7)
+        return fmt ("%d weeks ago", math.floor ((d + 3) / 7))
     end
     if (d < 365) then
-        return fmt ("%d months ago", (d + 15) / 30)
+        return fmt ("%d months ago", math.floor ((d + 15) / 30))
     end
 
     return fmt ("%.1f years ago", diff / 365)

--- a/src/shell/svc.c
+++ b/src/shell/svc.c
@@ -95,20 +95,6 @@ flux_future_t *shell_svc_vpack (struct shell_svc *svc,
     return flux_rpc_vpack (svc->shell->h, topic, rank, flags, fmt, ap);
 }
 
-flux_future_t *shell_svc_pack (struct shell_svc *svc,
-                               const char *method,
-                               int shell_rank,
-                               int flags,
-                               const char *fmt, ...)
-{
-    flux_future_t *f;
-    va_list ap;
-    va_start (ap, fmt);
-    f = shell_svc_vpack (svc, method, shell_rank, flags, fmt, ap);
-    va_end (ap);
-    return f;
-}
-
 int shell_svc_allowed (struct shell_svc *svc, const flux_msg_t *msg)
 {
     uint32_t rolemask;

--- a/src/shell/svc.h
+++ b/src/shell/svc.h
@@ -26,15 +26,6 @@ struct shell_svc *shell_svc_create (flux_shell_t *shell);
 
 /* Send an RPC to a shell 'method' by shell rank.
  */
-flux_future_t *shell_svc_pack (struct shell_svc *svc,
-                               const char *method,
-                               int shell_rank,
-                               int flags,
-                               const char *fmt, ...);
-
-
-/* Same as above, but called with a va_list instead of varargs
- */
 flux_future_t *shell_svc_vpack (struct shell_svc *svc,
                                 const char *method,
                                 int shell_rank,

--- a/src/test/checks-lib.sh
+++ b/src/test/checks-lib.sh
@@ -33,3 +33,16 @@ checks_group() {
     checks_group_end
     return $rc
 }
+
+#
+#  Usage: checks_die MESSAGE COMMANDS...
+#
+checks_die() {
+    local MSG="$1"
+    shift 1
+    printf "::error::$MSG\n"
+    if $# -gt 0; then
+        eval "$@"
+    fi
+    exit 1
+}

--- a/src/test/checks_run.sh
+++ b/src/test/checks_run.sh
@@ -176,7 +176,7 @@ sudo /sbin/runuser -u munge /usr/sbin/munged
 
 checks_group_end # Setup
 
-checks_group "autogen.sh" ./autogen.sh
+checks_group "autogen.sh" ./autogen.sh || checks_die "autogen failed"
 
 WORKDIR=$(pwd)
 if test -n "$BUILD_DIR" ; then
@@ -185,7 +185,7 @@ if test -n "$BUILD_DIR" ; then
 fi
 
 checks_group "configure ${ARGS}"  ${WORKDIR}/configure ${ARGS} \
-	|| (printf "::error::configure failed\n"; cat config.log; exit 1)
+	|| checks_die "configure failed" cat config.log
 checks_group "make clean..." make clean
 
 if test "$POISON" = "t" -a "$PROJECT" = "flux-core"; then
@@ -195,7 +195,7 @@ fi
 
 if test "$DISTCHECK" != "t"; then
   checks_group "${MAKECMDS}" "${MAKECMDS}" \
-	|| (printf "::error::${MAKECMDS} failed\n"; exit 1)
+	|| checks_die "${MAKECMDS} failed"
 fi
 checks_group "${CHECKCMDS}" "${CHECKCMDS}"
 RC=$?

--- a/src/test/checks_run.sh
+++ b/src/test/checks_run.sh
@@ -121,7 +121,8 @@ if test "$COVERAGE" = "t"; then
 	ENABLE_USER_SITE=1 \
 	COVERAGE_PROCESS_START=$(pwd)/coverage.rc \
 	${MAKE} -j $JOBS check-code-coverage && \
-	lcov -l flux*-coverage.info && \
+	(lcov -l flux*-coverage.info || :) && \
+	rm -f coverage.xml && \
 	coverage combine .coverage* && \
 	coverage html && coverage xml &&
 	chmod 444 coverage.xml &&

--- a/src/test/docker/centos8/Dockerfile
+++ b/src/test/docker/centos8/Dockerfile
@@ -69,6 +69,7 @@ RUN yum -y update \
 	aspell \
 	aspell-en \
 	glibc-langpack-en \
+	hwloc \
  && yum clean all
 
 #  Set default /usr/bin/python to python3
@@ -95,6 +96,12 @@ RUN mkdir mvapich2 \
  && make install \
  && cd .. \
  && rm -rf mvapich2
+
+# Install lcov
+RUN rpm --nodeps -i http://downloads.sourceforge.net/ltp/lcov-1.14-1.noarch.rpm
+
+# Install Python 3 coverage
+RUN pip3 install coverage
 
 ENV LANG=C.UTF-8
 RUN printf "LANG=C.UTF-8" > /etc/locale.conf

--- a/src/test/docker/docker-run-checks.sh
+++ b/src/test/docker/docker-run-checks.sh
@@ -25,7 +25,7 @@ declare -r prog=${0##*/}
 die() { echo -e "$prog: $@"; exit 1; }
 
 #
-declare -r long_opts="help,quiet,interactive,image:,flux-security-version:,jobs:,no-cache,no-home,distcheck,tag:,build-directory:,install-only,no-poison,recheck,unit-test-only,inception,platform:,workdir:"
+declare -r long_opts="help,quiet,interactive,image:,flux-security-version:,jobs:,no-cache,no-home,distcheck,tag:,build-directory:,install-only,no-poison,recheck,unit-test-only,inception,platform:,workdir:,system"
 declare -r short_opts="hqIdi:S:j:t:D:Prup:"
 declare -r usage="
 Usage: $prog [OPTIONS] -- [CONFIGURE_ARGS...]\n\
@@ -40,6 +40,7 @@ Options:\n\
      --no-home                 Skip mounting the host home directory\n\
      --install-only            Skip make check, only make install\n\
      --inception               Run tests as flux jobs\n\
+     --system                  Run under system instance\n\
  -q, --quiet                   Add --quiet to docker-build\n\
  -t, --tag=TAG                 If checks succeed, tag image as NAME\n\
  -i, --image=NAME              Use base docker image NAME (default=$IMAGE)\n\
@@ -87,6 +88,7 @@ while true; do
       --no-home)                   MOUNT_HOME_ARGS="";         shift   ;;
       --install-only)              INSTALL_ONLY=t;             shift   ;;
       --inception)                 INCEPTION=t;                shift   ;;
+      --system)                    SYSTEM=t;                   shift   ;;
       -P|--no-poison)              POISON=0;                   shift   ;;
       -t|--tag)                    TAG="$2";                   shift 2 ;;
       --)                          shift; break;                       ;;
@@ -107,12 +109,24 @@ fi
 # distcheck incompatible with some configure args
 if test "$DISTCHECK" = "t"; then
     test "$RECHECK" = "t" && die "--recheck not allowed with --distcheck"
+    test "$SYSTEM" = "t" && die "--system not allowed with --distcheck"
     for arg in "$@"; do
         case $arg in
           --sysconfdir=*|systemdsystemunitdir=*)
             die "distcheck incompatible with configure arg $arg"
         esac
     done
+fi
+
+if test "$SYSTEM" = "t"; then
+    if test "$IMAGE" != "centos8"; then
+        echo >&2 "Setting image to centos8 for system checks build"
+    fi
+    IMAGE=centos8
+    TAG="checks-builder:centos8"
+    INSTALL_ONLY=t
+    NO_CACHE="--no-cache"
+    POISON=0
 fi
 
 CONFIGURE_ARGS="$@"
@@ -158,6 +172,7 @@ export DISTCHECK
 export RECHECK
 export UNIT_TEST_ONLY
 export BUILD_DIR
+export COVERAGE
 export chain_lint
 
 if [[ "$INSTALL_ONLY" == "t" ]]; then
@@ -246,4 +261,12 @@ if test -n "$TAG"; then
 	|| die "docker commit failed"
     docker rm tmp.$$
     echo "Tagged image $TAG"
+fi
+
+if test -n "$SYSTEM"; then
+    ${TOP}/src/test/docker/docker-run-systest.sh \
+	--image=${TAG} \
+        --jobs=${JOBS} \
+        -- src/test/checks_run.sh ${CONFIGURE_ARGS} \
+    || die "docker-run-systest.sh failed"
 fi

--- a/src/test/docker/docker-run-checks.sh
+++ b/src/test/docker/docker-run-checks.sh
@@ -173,8 +173,10 @@ if [[ "$INSTALL_ONLY" == "t" ]]; then
                 --with-flux-security \
                 --enable-caliper &&
                make clean &&
-               make -j${JOBS}" \
-    || (docker rm tmp.$$; die "docker run of 'make install' failed")
+               make -j${JOBS}"
+    RC=$?
+    docker rm tmp.$$
+    test $RC -ne 0 &&  die "docker run of 'make install' failed"
 else
     docker run --rm \
         --workdir=$WORKDIR \

--- a/src/test/docker/docker-run-systest.sh
+++ b/src/test/docker/docker-run-systest.sh
@@ -168,4 +168,24 @@ if test $RC -ne 0; then
     die "system tests failed with rc=$RC"
 fi
 
+if test -n "$CI" -a -n "$COVERAGE"; then
+    curl -Os https://uploader.codecov.io/latest/linux/codecov &&
+    chmod +x codecov &&
+    docker exec \
+      -e GCOV \
+      -e USER \
+      -e CI \
+      -e PROJECT \
+      -e HOME=/home/$USER \
+      -e GITHUB_ACTIONS \
+      -e GITHUB_HEAD_REF \
+      -e GITHUB_REF \
+      -e GITHUB_REPOSITORY \
+      -e GITHUB_RUN_ID \
+      -e GITHUB_SERVER_URL \
+      -e GITHUB_SHA \
+      -e GITHUB_WORKFLOW \
+      -w $WORKDIR flux-system-test-$$ ./codecov -F ci-system
+fi
+
 # vi: ts=4 sw=4 expandtab

--- a/src/test/docker/docker-run-systest.sh
+++ b/src/test/docker/docker-run-systest.sh
@@ -1,0 +1,171 @@
+#!/bin/bash
+#
+#  Build fluxorama image with builddir mounted as /usr/src for testing.
+#
+
+PROJECT=flux-core
+WORKDIR=/usr/src
+MOUNT_HOME_ARGS="--volume=$HOME:/home/$USER -e HOME"
+JOBS=2
+IMAGE="fluxrm/flux-core:centos8"
+
+declare -r prog=${0##*/}
+die() { echo -e "$prog: $@"; exit 1; }
+
+declare -r long_opts="help,no-home,no-cache,rebuild,jobs:,image:"
+declare -r short_opts="hrj:i:"
+declare -r usage="
+Usage: $prog [OPTIONS]\n\
+Build fluxorama system test docker image for CI builds\n\
+\n\
+Options:\n\
+ -h, --help                    Display this message\n\
+ -j, --jobs=N                  Value for make -j (default=$JOBS)\n\
+ -i, --image=NAME              Base image (default=$IMAGE)\n\
+     --rebuild                 Rebuild base fluxorama image from source\n\
+     --no-home                 Skip mounting the host home directory\n\
+     --no-cache                Run docker build with --no-cache option\n\
+"
+
+# check if running in OSX
+if [[ "$(uname)" == "Darwin" ]]; then
+    # BSD getopt
+    GETOPTS=`/usr/bin/getopt $short_opts -- $*`
+else
+    # GNU getopt
+    GETOPTS=`/usr/bin/getopt -u -o $short_opts -l $long_opts -n $prog -- $@`
+    if [[ $? != 0 ]]; then
+        die "$usage"
+    fi
+    eval set -- "$GETOPTS"
+fi
+
+while true; do
+    case "$1" in
+      -h|--help)     echo -ne "$usage";          exit 0  ;;
+      -j|--jobs)     JOBS="$2";                  shift 2 ;;
+      -i|--image)    IMAGE="$2";                 shift 2 ;;
+      --rebuild)     REBUILD_BASE_IMAGE=t;       shift   ;;
+      --no-home)     MOUNT_HOME_ARGS="";         shift   ;;
+      --no-cache)    NOCACHE="--no-cache";       shift   ;;
+      --)            shift; break;                       ;;
+      *)             die "Invalid option '$1'\n$usage"   ;;
+    esac
+done
+
+if test $# -eq 0; then
+    set "bash"
+fi
+
+TOP=$(git rev-parse --show-toplevel 2>&1) \
+    || die "not inside $PROJECT git repository!"
+which docker >/dev/null \
+    || die "unable to find docker binary!"
+
+. ${TOP}/src/test/checks-lib.sh
+
+if test "$REBUILD_BASE_IMAGE" = "t"; then
+    checks_group "Rebuilding fluxrm/flux-core:centos8 from source" \
+      $TOP/src/test/docker/docker-run-checks.sh \
+        -j $JOBS \
+        -i centos8 \
+        -t $IMAGE \
+        --install-only
+fi
+
+checks_group "Building system image for user $USER $(id -u) group=$(id -g)" \
+  docker build \
+    ${NOCACHE} \
+    --build-arg IMAGE=$IMAGE \
+    --build-arg USER=$USER \
+    --build-arg UID=$(id -u) \
+    --build-arg GID=$(id -g) \
+    -t fluxorama:systest \
+    --target=systest \
+    ${TOP}/src/test/docker/fluxorama \
+    || die "docker build failed"
+
+NAME=flux-system-test-$$
+checks_group "Launching system instance container $NAME" \
+  docker run -d --rm \
+    --hostname=fluxorama \
+    --workdir=$WORKDIR \
+    $MOUNT_HOME_ARGS \
+    --volume=$TOP:$WORKDIR \
+    --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro \
+    --tmpfs=/run \
+    --cap-add SYS_PTRACE \
+    --name=flux-system-test-$$ \
+    --network=host \
+    fluxorama:systest \
+    || die "docker run of fluxorama test container failed"
+
+until docker exec -u $USER:$GID \
+    flux-system-test-$$ flux mini run hostname 2>/dev/null; do
+    echo "Waiting for flux-system-test-$$ to be ready"
+    sleep 1
+done
+
+#  Start user@uid.service service for unit tests:
+#
+checks_group "Starting user service user@$(id -u).service" \
+  docker exec flux-system-test-$$ \
+    systemctl start user@$(id -u).service \
+    || die "docker start user@$(id -u).service failed"
+
+if test -t 0; then
+    INTERACTIVE="-ti"
+fi
+
+checks_group "Executing tests under system instance container" \
+  docker exec \
+    "${INTERACTIVE}" \
+    -u $USER:$GID \
+    ${CC+-e CC=$CC} \
+    ${CXX+-e CXX=$CXX} \
+    ${LDFLAGS+-e LDFLAGS=$LDFLAGS} \
+    ${CFLAGS+-e CFLAGS=$CFLAGS} \
+    ${CPPFLAGS+-e CPPFLAGS=$CPPFLAGS} \
+    -e PS1 \
+    -e GCOV \
+    -e CCACHE_CPP2 \
+    -e CCACHE_READONLY \
+    -e COVERAGE \
+    -e TEST_INSTALL \
+    -e CPPCHECK \
+    -e DISTCHECK \
+    -e RECHECK \
+    -e UNIT_TEST_ONLY \
+    -e chain_lint \
+    -e JOBS \
+    -e USER \
+    -e PROJECT \
+    -e CI \
+    -e TAP_DRIVER_QUIET \
+    -e TEST_CHECK_PREREQS \
+    -e FLUX_TEST_TIMEOUT \
+    -e FLUX_TEST_SIZE_MAX \
+    -e PYTHON_VERSION \
+    -e PRELOAD \
+    -e POISON \
+    -e INCEPTION \
+    -e ASAN_OPTIONS \
+    -e BUILD_DIR \
+    -e S3_ACCESS_KEY_ID \
+    -e S3_SECRET_ACCESS_KEY \
+    -e S3_HOSTNAME \
+    -e S3_BUCKET \
+    -e HOME=/home/$USER \
+    -e XDG_RUNTIME_DIR=/run/user/$(id -u) \
+    -e DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/$(id -u)/bus \
+    -w $WORKDIR \
+    flux-system-test-$$ "$@"
+RC=$?
+
+docker exec -ti flux-system-test-$$ shutdown -r now
+
+if test $RC -ne 0; then
+    die "system tests failed with rc=$RC"
+fi
+
+# vi: ts=4 sw=4 expandtab

--- a/src/test/docker/docker-run-systest.sh
+++ b/src/test/docker/docker-run-systest.sh
@@ -145,6 +145,7 @@ checks_group "Executing tests under system instance container" \
     -e TEST_CHECK_PREREQS \
     -e FLUX_TEST_TIMEOUT \
     -e FLUX_TEST_SIZE_MAX \
+    -e FLUX_ENABLE_SYSTEM_TESTS=t \
     -e PYTHON_VERSION \
     -e PRELOAD \
     -e POISON \

--- a/src/test/docker/fluxorama/Dockerfile
+++ b/src/test/docker/fluxorama/Dockerfile
@@ -80,6 +80,9 @@ COPY job-exec.toml /etc/flux/system/conf.d/exec.toml
 COPY access.toml /etc/flux/system/conf.d/access.toml
 
 RUN chmod 4755 /usr/libexec/flux/flux-imp \
+ && chmod 0644 /etc/flux/imp/conf.d/imp.toml \
+ && chmod 0644 /etc/flux/system/conf.d/exec.toml \
+ && chmod 0644 /etc/flux/system/conf.d/access.toml \
  && systemctl enable flux.service \
  && systemctl enable munge.service \
  && systemctl enable ttyd.service

--- a/src/test/docker/fluxorama/Dockerfile
+++ b/src/test/docker/fluxorama/Dockerfile
@@ -1,4 +1,5 @@
-FROM fluxrm/flux-core:centos8 AS systest
+ARG IMAGE=fluxrm/flux-core:centos8
+FROM $IMAGE AS systest
 
 # Default container user.
 # "fluxuser" should match fluxrm/flux-core image
@@ -65,10 +66,10 @@ WORKDIR /home/$USER
 EXPOSE 7681
 CMD [ "init" ]
 
+FROM systest AS fluxorama
+
 RUN dnf install -y psmisc tmux \
  && dnf clean all
-
-FROM systest AS fluxorama
 
 #
 #  Install ttyd

--- a/src/test/docker/fluxorama/Dockerfile
+++ b/src/test/docker/fluxorama/Dockerfile
@@ -1,14 +1,10 @@
-
-FROM fluxrm/flux-core:centos8
+FROM fluxrm/flux-core:centos8 AS systest
 
 # Default container user.
 # "fluxuser" should match fluxrm/flux-core image
 ARG USER=fluxuser
 ARG UID=2100
 ARG GID=2100
-
-# UID for system "flux" user. Runs Flux instance
-ARG FLUXUID=1000
 
 ENV container docker
 
@@ -31,38 +27,17 @@ RUN (cd /lib/systemd/system/sysinit.target.wants/; \
     rm -f /lib/systemd/system/basic.target.wants/*;\
     rm -f /lib/systemd/system/anaconda.target.wants/*;
 
-
-RUN dnf install -y psmisc tmux \
- && dnf clean all
-
-#
-#  Install ttyd
-RUN wget https://github.com/tsl0922/ttyd/releases/download/1.6.0/ttyd_linux.x86_64
-RUN mv ttyd_linux.x86_64 /usr/bin/ttyd && chmod 755 /usr/bin/ttyd
+RUN id $USER \
+ || ( groupadd -g $UID $USER \
+   && useradd -g $USER -u $UID -d /home/$USER -m $USER \
+   && printf "$USER ALL= NOPASSWD: ALL\\n" >> /etc/sudoers \
+   && usermod -G wheel $USER \
+ )
 
 #
-#  Register ttyd service
-RUN user=fluxuser && uid=$(id -u $user) && gid=$(id -g fluxuser) \
- && printf "#!/bin/sh\n"       >/bin/ttyd.sh \
- && printf "rm -f /var/run/nologin\n" >>/bin/ttyd.sh \
- && printf "/usr/bin/ttyd -o -p 7681 /bin/login $user\n" >>/bin/ttyd.sh \
- && printf "systemctl halt --no-block\n" >>/bin/ttyd.sh \
- && chmod 755 /bin/ttyd.sh \
- && printf "[Unit]\n" >/etc/systemd/system/ttyd.service \
- && printf "Description=ttyd service\n\n" >>/etc/systemd/system/ttyd.service \
- && printf "[Service]\n" >>/etc/systemd/system/ttyd.service \
- && printf "Type=simple\n" >>/etc/systemd/system/ttyd.service \
- && printf "ExecStart=/bin/ttyd.sh\n" >>/etc/systemd/system/ttyd.service \
- && printf "User=root\nGroup=root\n" >>/etc/systemd/system/ttyd.service \
- && printf "[Install]\nWantedBy=multi-user.target\n" >>/etc/systemd/system/ttyd.service
-
+# Add flux user and group
 #
-# Add flux user
-#
-RUN groupadd -g $FLUXUID flux \
- && useradd -g flux -u $FLUXUID -d /home/flux -m flux
-
-# N.B.: "fluxuser" already exists in fluxrm/flux-core image
+RUN useradd --user-group --system -d /home/flux -m flux
 
 #
 #  Add users besides fluxuser for mult-user testing
@@ -84,12 +59,35 @@ RUN chmod 4755 /usr/libexec/flux/flux-imp \
  && chmod 0644 /etc/flux/system/conf.d/exec.toml \
  && chmod 0644 /etc/flux/system/conf.d/access.toml \
  && systemctl enable flux.service \
- && systemctl enable munge.service \
- && systemctl enable ttyd.service
-
-COPY f.txt /etc/motd
-COPY entrypoint.sh /usr/local/sbin
+ && systemctl enable munge.service
 
 WORKDIR /home/$USER
 EXPOSE 7681
 CMD [ "init" ]
+
+RUN dnf install -y psmisc tmux \
+ && dnf clean all
+
+FROM systest AS fluxorama
+
+#
+#  Install ttyd
+RUN wget https://github.com/tsl0922/ttyd/releases/download/1.6.0/ttyd_linux.x86_64
+RUN mv ttyd_linux.x86_64 /usr/bin/ttyd && chmod 755 /usr/bin/ttyd
+
+#
+#  Register ttyd service
+RUN user=$USER && uid=$(id -u $user) && gid=$(id -g $user) \
+ && printf "#!/bin/sh\n"       >/bin/ttyd.sh \
+ && printf "rm -f /var/run/nologin\n" >>/bin/ttyd.sh \
+ && printf "/usr/bin/ttyd -o -p 7681 /bin/login $user\n" >>/bin/ttyd.sh \
+ && printf "systemctl halt --no-block\n" >>/bin/ttyd.sh \
+ && chmod 755 /bin/ttyd.sh \
+ && printf "[Unit]\n" >/etc/systemd/system/ttyd.service \
+ && printf "Description=ttyd service\n\n" >>/etc/systemd/system/ttyd.service \
+ && printf "[Service]\n" >>/etc/systemd/system/ttyd.service \
+ && printf "Type=simple\n" >>/etc/systemd/system/ttyd.service \
+ && printf "ExecStart=/bin/ttyd.sh\n" >>/etc/systemd/system/ttyd.service \
+ && printf "User=root\nGroup=root\n" >>/etc/systemd/system/ttyd.service \
+ && printf "[Install]\nWantedBy=multi-user.target\n" >>/etc/systemd/system/ttyd.service \
+ && systemctl enable ttyd.service

--- a/src/test/docker/fluxorama/entrypoint.sh
+++ b/src/test/docker/fluxorama/entrypoint.sh
@@ -1,11 +1,14 @@
 #!/bin/sh
-#  Set default password for fluxuser
-if test -z "$FLUXUSER_PASSWORD"; then
-   printf >&2 "ERROR: No password set for fluxuser\n"
-   printf >&2 "Please set via the FLUXUSER_PASSWORD environment variable\n"
-   printf >&2 "e.g. FLUXUSER_PASSWORD=xxzzy docker run -e FLUXUSER_PASSWORD ..\n"
+if systemctl is-enabled ttyd; then
+  #  Set default password for fluxuser
+  if test -z "$FLUXUSER_PASSWORD"; then
+     printf >&2 "ERROR: No password set for fluxuser\n"
+     printf >&2 "Please set via the FLUXUSER_PASSWORD environment variable\n"
+     printf >&2 \
+         "e.g. FLUXUSER_PASSWORD=xxzzyy docker run -e FLUXUSER_PASSWORD ..\n"
    exit 1
+  fi
+  printf >&2 "Setting requested password for fluxuser..\n"
+  echo fluxuser:${FLUXUSER_PASSWORD} | chpasswd
 fi
-printf >&2 "Setting requested password for fluxuser..\n"
-echo fluxuser:${FLUXUSER_PASSWORD} | chpasswd
 exec "$@"

--- a/src/test/generate-matrix.py
+++ b/src/test/generate-matrix.py
@@ -209,6 +209,16 @@ matrix.add_build(
     docker_tag=True,
 )
 
+# Centos8, system, coverage
+matrix.add_build(
+    name="centos8 - system,coverage",
+    image="centos8",
+    coverage=True,
+    jobs=2,
+    command_args="--system",
+    args="--with-flux-security --enable-caliper",
+)
+
 # Fedora 33
 matrix.add_build(
     name="fedora33 - gcc-10,py3.9",

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -45,6 +45,7 @@ clean-local:
 #   in TESTS so that `make check` runs them first, hopefully resulting
 #   in a reduced makespan overall.
 LONGTESTSCRIPTS = \
+	t9000-system.t \
 	t5000-valgrind.t \
 	t3100-flux-in-flux.t \
 	t3200-instance-restart.t \
@@ -252,6 +253,7 @@ EXTRA_DIST= \
 
 dist_check_SCRIPTS = \
 	$(TESTSCRIPTS) \
+	system/0001-basic.t \
 	issues/t0441-kvs-put-get.sh \
 	issues/t0505-msg-handler-reg.lua \
 	issues/t0821-kvs-segfault.sh \

--- a/t/scripts/run_timeout.py
+++ b/t/scripts/run_timeout.py
@@ -71,6 +71,7 @@ def do_timeout():
         r = p.wait(timeout=args.timeout)
     except s.TimeoutExpired:
         # send signal to timeout process
+        print(f"{args.cmd} timed out after {args.timeout}s", file=sys.stderr)
         p.send_signal(args.signal)
         if args.kill_after > 0:
             try:

--- a/t/system/0001-basic.t
+++ b/t/system/0001-basic.t
@@ -1,0 +1,13 @@
+#
+#  Basic system instance sanity checks
+#
+test_expect_success 'system instance runs job as current uid' '
+	jobid=$(flux mini submit id -u) &&
+	result=$(flux job attach $jobid) &&
+	test_debug "echo Job ran with userid $result" &&
+	test $result -eq $(id -u) &&
+	test $(flux getattr security.owner) -ne $result
+'
+test_expect_success 'flux jobs lists job with correct userid' '
+	test $(flux jobs -no {userid} $jobid) -eq $(id -u)
+'

--- a/t/t0016-cron-faketime.t
+++ b/t/t0016-cron-faketime.t
@@ -8,9 +8,11 @@ if ! test_have_prereq NO_ASAN; then
     test_done
 fi
 
-# allow libfaketime to be found on ubuntu
+# allow libfaketime to be found on ubuntu, centos
 if test -d /usr/lib/x86_64-linux-gnu/faketime ; then
   export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu/faketime"
+elif test -d /usr/lib64/faketime ; then
+  export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/lib64/faketime"
 fi
 
 #  Check for libfaketimeMT using known epoch with /bin/date:
@@ -37,6 +39,10 @@ cron_entry_check() {
     test -n $key || return 1
     test -n "$expected" || return 1
     local result="$(flux cron dump --key=${key} ${id})" || return 1
+    if test "$key" = "typedata.next_wakeup"; then
+        # convert result to an integer:
+        result=$(printf "%.0f" $result)
+    fi
     echo "cron-${id}: ${key}=${result}, wanted ${expected}" >&2
     test "${result}" = "${expected}"
 }

--- a/t/t1200-stats-basic.t
+++ b/t/t1200-stats-basic.t
@@ -3,6 +3,8 @@
 
 test_description='Test stats collection and sending'
 
+# Append --logfile option if FLUX_TESTS_LOGFILE is set in environment:
+test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile --debug
 . `dirname $0`/sharness.sh
 
 udp=$SHARNESS_TEST_SRCDIR/scripts/stats-listen.py

--- a/t/t1200-stats-basic.t
+++ b/t/t1200-stats-basic.t
@@ -8,41 +8,43 @@ test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile --debug
 . `dirname $0`/sharness.sh
 
 udp=$SHARNESS_TEST_SRCDIR/scripts/stats-listen.py
-timeout=$SHARNESS_TEST_SRCDIR/scripts/run_timeout.py
+timeout="$SHARNESS_TEST_SRCDIR/scripts/run_timeout.py 60"
+timeout5="$SHARNESS_TEST_SRCDIR/scripts/run_timeout.py 5"
 plugin_i=${FLUX_BUILD_DIR}/t/stats/.libs/stats-immediate.so
 plugin_b=${FLUX_BUILD_DIR}/t/stats/.libs/stats-basic.so
 
 test_expect_success 'prefix set' '
-	$timeout 20 flux python $udp -s flux.job.state.immediate flux start \
+	$timeout flux python $udp -s flux.job.state.immediate flux start \
 	"flux jobtap load $plugin_i && flux mini run hostname"
 '
 
 test_expect_success 'multiple packets received' '
-	$timeout 20 flux python $udp -w 3 flux start \
+	$timeout flux python $udp -w 3 flux start \
 	"flux jobtap load $plugin_i && flux mini run hostname"
 '
 
 test_expect_success 'validate packets immediate' '
-	$timeout 20 flux python $udp -V flux start \
+	$timeout flux python $udp -V flux start \
 	"flux jobtap load $plugin_i && flux mini run hostname"
 '
 
 test_expect_success 'timing packets received immediate' '
-	$timeout 20 flux python $udp -s timing flux start \
+	$timeout flux python $udp -s timing flux start \
 	"flux jobtap load $plugin_i && flux mini run hostname"
 '
 
 test_expect_success 'timing packets received basic' '
-	$timeout 20 flux python $udp -s timing flux start \
+	$timeout flux python $udp -s timing flux start \
 	"flux jobtap load $plugin_b && flux mini run hostname && sleep 1"
 '
 
 test_expect_success 'valid content-cache packets received' '
-	$timeout 20 flux python $udp -s content-cache -V flux start sleep 1
+	$timeout flux python $udp -s content-cache -V flux start sleep 1
 '
 
 test_expect_success 'nothing received with no endpoint' '
-	unset FLUX_FRIPP_STATSD && test_expect_code 137 $timeout 5 flux python $udp -n flux start
+	unset FLUX_FRIPP_STATSD &&
+	test_expect_code 137 $timeout5 flux python $udp -n flux start
 '
 
 test_expect_success 'FLUX_FRIPP_STATSD with colectomy' '

--- a/t/t9000-system.t
+++ b/t/t9000-system.t
@@ -1,0 +1,64 @@
+#!/bin/sh
+#
+
+test_description='Run tests against a system instance of Flux'
+
+if test -n "$FLUX_ENABLE_SYSTEM_TESTS" || test -n "$debug"; then
+	FLUX_TEST_INSTALLED_PATH=${FLUX_TEST_INSTALLED_PATH:-/usr/bin}
+fi
+. `dirname $0`/sharness.sh
+
+#  Do not run system tests by default unless FLUX_ENABLE_SYSTEM_TESTS
+#   is set in environment (e.g. by CI), or the test run run with -d, --debug
+#
+if test -z "$FLUX_ENABLE_SYSTEM_TESTS" && test "$debug" = ""; then
+	skip_all='skipping system tests since FLUX_ENABLE_SYSTEM_TESTS not set'
+	test_done
+fi
+
+owner=$(flux getattr security.owner 2>/dev/null)
+if test -n "$owner" -a "$owner" != "$(id -u)"; then
+	test_set_prereq SYSTEM
+fi
+if ! test_have_prereq SYSTEM; then
+	skip_all='skipping system instance tests, no system instance found'
+	test_done
+fi
+
+if test -z "$T9000_SYSTEM_GLOB"; then
+	T9000_SYSTEM_GLOB="*"
+fi
+
+#
+#  Wrap test_expect_success so we can prepend a custom test-label,
+#   then shadow function with an alias. Note that the alias is
+#   _not_ called in expect_success_wrap() because POSIX says:
+#
+#   "To prevent infinite loops in recursive aliasing, if the shell is
+#    not currently processing an alias of the same name, the word shall
+#    be replaced by the value of the alias; otherwise, it shall not be
+#    replaced."
+#
+#   Sec 2.3.1
+#   https://pubs.opengroup.org/onlinepubs/007904975/utilities/xcu_chap02.html
+#
+expect_success_wrap() {
+	if test $# -eq 3; then
+		test_expect_success "$TEST_LABEL: $1" "$2" "$3"
+	else
+		test_expect_success "$TEST_LABEL: $1" "$2"
+	fi
+}
+alias test_expect_success='expect_success_wrap'
+
+#
+#  All system instance tests are defined in t/system/*
+#  We run them serially to avoid conficted requests for resources
+#   to the enclosing system instance, which in CI may be limited.
+#
+for testscript in ${FLUX_SOURCE_DIR}/t/system/${T9000_SYSTEM_GLOB}; do
+	TEST_LABEL="$(basename $testscript)"
+	source $testscript
+done
+
+test_done


### PR DESCRIPTION
This PR adds a tweak to the fluxorama docker image along with a simple script to make iterative development and test easier within this systemd based docker container.

Currently, the script only launches an interactive shell within the container after launching it. In the future, though, the script could be extended to run a suite of multi-user specific tests.

I'm posting this a little early since @chu11 may find the script useful in his current work.

The script first optionally rebuilds the `fluxrm/flux-core:centos8` image from the current build directory (only if `--rebuild` option is used). It then builds the `systest` stage of the `fluxorama` image (an image without ttyd enabled) and starts the container in the background. An interactive shell is started in the container as the current user (just like `docker-run-checks.sh -I`). Once the shell exits, the running container is stopped with `docker exec shutdown -r now`)

example:
```console
grondo@asp:~/git/f.git$ ./src/test/docker/docker-run-systest.sh 
Building system image for user grondo 1000 group=1000
Sending build context to Docker daemon  30.21kB
Step 1/20 : FROM fluxrm/flux-core:centos8 AS systest
[snip]...

Successfully built 1f9a4a0f1e07
Successfully tagged fluxorama:systest

af1147e6f79cb51450b23ff62006eb36d30630fe551584063eaa379900a4110a
 grondo@fluxorama:/usr/src$ flux resource list
     STATE NNODES   NCORES    NGPUS NODELIST
      free      1        4        0 fluxorama
 allocated      0        0        0 
      down      0        0        0 
 grondo@fluxorama:/usr/src$ sudo systemctl status flux
● flux.service - Flux message broker
   Loaded: loaded (/etc/systemd/system/flux.service; enabled; vendor preset: di>
   Active: active (running) since Sat 2021-08-28 02:47:49 UTC; 2min 27s ago
  Process: 36 ExecStartPre=/bin/chmod 0700 /var/lib/flux (code=exited, status=0>
  Process: 35 ExecStartPre=/bin/chown flux:flux /var/lib/flux (code=exited, sta>
  Process: 27 ExecStartPre=/bin/mkdir -p /var/lib/flux (code=exited, status=0/S>
 Main PID: 37 (flux-broker-0)
    Tasks: 17 (limit: 26213)
   Memory: 7.6M
   CGroup: /system.slice/snap.docker.dockerd.service/system.slice/flux.service
           └─37 broker --config-path=/etc/flux/system/conf.d -Stbon.fanout=256 >

Aug 28 02:47:49 fluxorama flux[37]: job-manager.info[0]: restart: 0 jobs
Aug 28 02:47:49 fluxorama flux[37]: job-manager.info[0]: restart: 0 running jobs
Aug 28 02:47:49 fluxorama flux[37]: job-manager.info[0]: restart: no checkpoint>
Aug 28 02:47:49 fluxorama flux[37]: broker.info[0]: rc1.0: running /etc/flux/rc>
Aug 28 02:47:49 fluxorama flux[37]: sched-simple.info[0]: resource update: {"re>
Aug 28 02:47:49 fluxorama flux[37]: broker.info[0]: rc1.0: /bin/bash -c /etc/fl>
Aug 28 02:47:49 fluxorama flux[37]: broker.info[0]: rc1-success: init->quorum 0>
Aug 28 02:47:49 fluxorama flux[37]: broker.info[0]: quorum-full: quorum->run 4.>
Aug 28 02:47:49 fluxorama flux[37]: broker.info[0]: rc2-none: ignored in run
Aug 28 02:50:15 fluxorama systemd[1]: flux.service: Failed to reset devices.lis>

```