### PR TITLE
broker: ensure subtree restart upon loss of router node

### DIFF
--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -964,12 +964,10 @@ static bool version_check (int v1, int v2, char *errbuf, int errbufsz)
 
 /* Handle overlay.hello request from downstream (child) TBON peer.
  * The peer may be rejected here if it is improperly configured.
- * If successful the peer is marked 'connected' and the state machine is
- * notified.
- *
- * N.B. use overlay sockets directly to handle this message instead of higher
- * level API to allow child->connected to gate the flow of messages from a
- * peer, and to avoid complicating the standalone overlay unit test,
+ * If successful the child's status is updated to reflect its online
+ * state and the state machine is notified.
+ * N.B. respond using overlay_sendmsg_child() to avoid the main message path
+ * during initialization.
  */
 static void hello_request_handler (struct overlay *ov, const flux_msg_t *msg)
 {
@@ -1038,7 +1036,6 @@ error:
  * If the response indicates an error, set in motion a clean broker exit by
  * printing the error message to stderr and notifying the state machine
  * that it should check overlay_parent_error() / overlay_parent_success().
- * N.B. see note in hello_request_handler() on direct use of overlay sockets.
  */
 static void hello_response_handler (struct overlay *ov, const flux_msg_t *msg)
 {

--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -819,17 +819,17 @@ static void child_cb (flux_reactor_t *r, flux_watcher_t *w,
     flux_msg_t *msg;
     int type = -1;
     const char *topic = NULL;
-    const char *sender = NULL;
+    const char *uuid = NULL;
     struct child *child;
 
     if (!(msg = zmqutil_msg_recv (ov->bind_zsock)))
         return;
     if (flux_msg_get_type (msg, &type) < 0
-        || !(sender = flux_msg_route_last (msg))) {
+        || !(uuid = flux_msg_route_last (msg))) {
         logdrop (ov, OVERLAY_DOWNSTREAM, msg, "malformed message");
         goto done;
     }
-    if (!(child = child_lookup_online (ov, sender))) {
+    if (!(child = child_lookup_online (ov, uuid))) {
         /* process hello request */
         if (type == FLUX_MSGTYPE_REQUEST
             && flux_msg_get_topic (msg, &topic) == 0

--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -467,7 +467,7 @@ bool overlay_uuid_is_child (struct overlay *ov, const char *uuid)
 
 bool overlay_uuid_is_parent (struct overlay *ov, const char *uuid)
 {
-    if (ov->rank > 0 && !strcmp (uuid, ov->parent.uuid))
+    if (ov->rank > 0 && streq (uuid, ov->parent.uuid))
         return true;
     return false;
 }
@@ -621,7 +621,7 @@ int overlay_sendmsg (struct overlay *ov,
             if (where == OVERLAY_ANY) {
                 if (ov->rank > 0
                     && (uuid = flux_msg_route_last (msg)) != NULL
-                    && !strcmp (uuid, ov->parent.uuid))
+                    && streq (uuid, ov->parent.uuid))
                     where = OVERLAY_UPSTREAM;
                 else
                     where = OVERLAY_DOWNSTREAM;

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -181,6 +181,7 @@ TESTSCRIPTS = \
 	t3303-system-healthcheck.t \
 	t3304-system-rpctrack.t \
 	t3305-system-disconnect.t \
+	t3306-system-routercrash.t \
 	t4000-issues-test-driver.t \
 	lua/t0001-send-recv.t \
 	lua/t0002-rpc.t \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -179,8 +179,8 @@ TESTSCRIPTS = \
 	t3301-system-latestart.t \
 	t3302-system-offline.t \
 	t3303-system-healthcheck.t \
-	t3304-system-rpctrack.t \
-	t3305-system-disconnect.t \
+	t3304-system-rpctrack-down.t \
+	t3305-system-rpctrack-up.t \
 	t3306-system-routercrash.t \
 	t4000-issues-test-driver.t \
 	lua/t0001-send-recv.t \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -182,6 +182,7 @@ TESTSCRIPTS = \
 	t3304-system-rpctrack-down.t \
 	t3305-system-rpctrack-up.t \
 	t3306-system-routercrash.t \
+	t3307-system-leafcrash.t \
 	t4000-issues-test-driver.t \
 	lua/t0001-send-recv.t \
 	lua/t0002-rpc.t \

--- a/t/python/t0010-job.py
+++ b/t/python/t0010-job.py
@@ -514,11 +514,13 @@ class TestJob(unittest.TestCase):
             event = future.get_event()
             if event is None:
                 return
-            if event.name == "start":
+            if event.name == "shell.start":
                 job.cancel(self.fh, jobid)
                 future.cancel()
 
-        job.event_watch_async(self.fh, ids[3]).then(cancel_on_start, ids[3])
+        job.event_watch_async(self.fh, ids[3], eventlog="guest.exec.eventlog").then(
+            cancel_on_start, ids[3]
+        )
 
         self.fh.reactor_run()
         self.assertEqual(len(result.keys()), len(ids))
@@ -580,7 +582,7 @@ class TestJob(unittest.TestCase):
                     "t_submit": 1.0,
                     "t_run": 2.0,
                     "t_cleanup": 3.0,
-                    "waitstatus": 15,
+                    "waitstatus": 36608,  # 143<<8
                     "exception_occurred": True,
                     "exception_type": "cancel",
                     "exception_note": "",

--- a/t/t3300-system-basic.t
+++ b/t/t3300-system-basic.t
@@ -102,8 +102,8 @@ test_expect_success 'wait broker rank=42 fails' '
 	test_must_fail $startctl wait 42
 '
 
-test_expect_success 'dump overlay child logs from leader broker' '
-	flux dmesg|grep broker.debug|grep "overlay child"
+test_expect_success 'dump broker logs from leader broker' '
+	flux dmesg | grep "broker\..*\[0\]"
 '
 
 test_done

--- a/t/t3300-system-basic.t
+++ b/t/t3300-system-basic.t
@@ -1,7 +1,12 @@
 #!/bin/sh
 #
 
-test_description='Test system personality'
+test_description='Test the tools used to test the system instance.
+
+Before we begin testing the system instance, verify that the
+system test personality behaves as it should, and that the
+startctl tool and flux-start support for its RPCs work as expected.
+'
 
 . `dirname $0`/sharness.sh
 

--- a/t/t3301-system-latestart.t
+++ b/t/t3301-system-latestart.t
@@ -1,7 +1,12 @@
 #!/bin/sh
 #
 
-test_description='Test system instance with late joining broker'
+test_description='Test system instance with late joining broker
+
+Start up only the leader broker and verify that the system is
+functional without a leaf node.  Then start the leaf node
+and ensure that it wires up.
+'
 
 . `dirname $0`/sharness.sh
 

--- a/t/t3302-system-offline.t
+++ b/t/t3302-system-offline.t
@@ -1,7 +1,13 @@
 #!/bin/sh
 #
 
-test_description='Test system instance with one offline router broker'
+test_description='Test job submission when upstream is down
+
+Start up only the leader broker and a leaf node, but not the
+router node between them to simulate a login node without its
+upstream router.  Try to submit a job on the leaf node and
+confirm that the user gets a reasonable error.
+'
 
 . `dirname $0`/sharness.sh
 

--- a/t/t3303-system-healthcheck.t
+++ b/t/t3303-system-healthcheck.t
@@ -1,7 +1,13 @@
 #!/bin/sh
 #
 
-test_description='Test overlay diagnostic tool'
+test_description='Verify subtree health transitions and tools
+
+Ensure that the overlay subtree health status transitions
+appropriately as brokers are taken offline or lost, and also
+put flux overlay status tool and related RPCs and subcommands
+through their paces.
+'
 
 . `dirname $0`/sharness.sh
 

--- a/t/t3304-system-rpctrack-down.t
+++ b/t/t3304-system-rpctrack-down.t
@@ -1,7 +1,12 @@
 #!/bin/sh
 #
 
-test_description='Test overlay RPC tracking'
+test_description='Test downstream RPC tracking
+
+Test that RPCs from rank 0 broker to other ranks receive
+broker-generated EHOSTUNREACH responses when the next hop in
+the RPC goes down, either nicely, or a hard crash.
+'
 
 . `dirname $0`/sharness.sh
 

--- a/t/t3305-system-disconnect.t
+++ b/t/t3305-system-disconnect.t
@@ -54,7 +54,7 @@ test_expect_success 'construct FLUX_URI for rank 13 (child of 6)' '
 '
 
 test_expect_success NO_CHAIN_LINT 'start background RPC to rank 0 via 13' '
-	FLUX_URI=$(cat uri13) flux overlay status --wait=lost 2>health.err &
+	FLUX_URI=$(cat uri13) flux overlay status --wait=lost &
 	echo $! >health.pid
 '
 test_expect_success 'ensure background request was received on rank 0' '
@@ -74,11 +74,14 @@ test_expect_success 'rank 14 exited' '
 	($startctl wait 14 || /bin/true)
 '
 
-test_expect_success NO_CHAIN_LINT 'background RPC fails with overlay disconnect (tracker response from 6)' '
+# The important thing is that the RPC fails.
+# It may fail with EHOSTUNREACH "overlay disconnect" (tracker from rank 6).
+# But this response may race with the chain of broker exits,
+# so other errors are possible such as ECONNRESET.
+test_expect_success NO_CHAIN_LINT 'background RPC fails' '
         pid=$(cat health.pid) &&
         echo waiting for pid $pid &&
-        test_expect_code 1 wait $pid &&
-        grep "overlay disconnect" health.err
+        test_expect_code 1 wait $pid
 '
 
 test_expect_success 'report health status' '

--- a/t/t3305-system-disconnect.t
+++ b/t/t3305-system-disconnect.t
@@ -68,10 +68,10 @@ test_expect_success 'rank 6 exited with rc=1' '
 	test_expect_code 1 $startctl wait 6
 '
 test_expect_success 'rank 13 exited' '
-	($startctl wait 13 || /bin/true)
+	test_might_fail $startctl wait 13
 '
 test_expect_success 'rank 14 exited' '
-	($startctl wait 14 || /bin/true)
+	test_might_fail $startctl wait 14
 '
 
 # The important thing is that the RPC fails.

--- a/t/t3305-system-rpctrack-up.t
+++ b/t/t3305-system-rpctrack-up.t
@@ -62,11 +62,11 @@ test_expect_success 'construct FLUX_URI for rank 13 (child of 6)' '
 '
 
 test_expect_success NO_CHAIN_LINT 'start background RPC to rank 0 via 13' '
-	FLUX_URI=$(cat uri13) flux overlay status --wait=lost &
+	(FLUX_URI=$(cat uri13) flux overlay status --wait=lost) &
 	echo $! >health.pid
 '
 test_expect_success 'ensure background request was received on rank 0' '
-        FLUX_URI=$(cat uri13) flux overlay status
+        (FLUX_URI=$(cat uri13) flux overlay status)
 '
 
 test_expect_success 'disconnect rank 6' '

--- a/t/t3305-system-rpctrack-up.t
+++ b/t/t3305-system-rpctrack-up.t
@@ -1,7 +1,15 @@
 #!/bin/sh
 #
 
-test_description='Test overlay parent disconnect'
+test_description='Test upstream RPC tracking and disconnect command
+
+Test that RPCs from a leaf broker to rank 0 receive broker-generated
+EHOSTUNREACH responses when a broker along the path to rank 0 is
+taken offline administratively, or if the subtree panics.
+
+Also put the flux overlay disconnect comamnd/RPC and related
+commands/RPCs through their paces.
+'
 
 . `dirname $0`/sharness.sh
 

--- a/t/t3306-system-routercrash.t
+++ b/t/t3306-system-routercrash.t
@@ -1,0 +1,67 @@
+#!/bin/sh
+#
+
+test_description='Hard fail a router node and verify child restarts
+
+When a router node crashes without a chance to notify its children
+and then starts back up, the children will reconnect and try to resume
+communications.  From the router perspective, the child uuid is
+unknown, so it forces a subtree panic in the child.  The maintains the
+invariant that when a router restarts, its children always restart too.
+This test verifies that the invariant holds when ther router crashes.
+'
+
+. `dirname $0`/sharness.sh
+
+export TEST_UNDER_FLUX_FANOUT=1
+
+test_under_flux 3 system
+
+startctl="flux python ${SHARNESS_TEST_SRCDIR}/scripts/startctl.py"
+
+test_expect_success 'tell each broker to log to stderr' '
+	flux exec flux setattr log-stderr-mode local
+'
+
+test_expect_success 'construct FLUX_URI for rank 2 (child of 1)' '
+	echo "local://$(flux getattr rundir)/local-2" >uri2 &&
+	test $(FLUX_URI=$(cat uri2) flux getattr rank) -eq 2
+'
+
+test_expect_success 'kill -9 broker 1' '
+	$startctl kill 1 9 &&
+	test_expect_code 137 $startctl wait 1
+'
+
+test_expect_success 'restart broker 1' '
+	$startctl run 1
+'
+
+test_expect_success 'ping broker 1 via broker 2' '
+	(FLUX_URI=$(cat uri2) test_must_fail flux ping --count=1 1)
+'
+
+test_expect_success 'broker 2 was disconnected' '
+	test_might_fail $startctl wait 2
+'
+
+test_expect_success 'restart broker 2' '
+	$startctl run 2
+'
+
+test_expect_success 'wait for rank 0 to report subtree status of full' '
+	run_timeout 10 flux overlay status -vvv --pretty --color --wait full
+'
+
+test_expect_success 'ping broker 2 via broker 0' '
+	flux ping --count=1 2
+'
+
+# Side effect: let rc1 on rank 2 finish loading resource module
+# before shutdown begins, or it will complain
+test_expect_success 'run a 3 node job' '
+        flux mini run -n3 -N3 /bin/true
+'
+
+
+test_done

--- a/t/t3307-system-leafcrash.t
+++ b/t/t3307-system-leafcrash.t
@@ -1,0 +1,54 @@
+#!/bin/sh
+#
+
+test_description='Hard fail a leaf node and verify transition thru lost
+
+When a leaf node crashes without a chance to notify its parent and then
+starts back up, it will try to say hello to its parent as though it were
+starting anew.  From the parent perspective, the child may be already
+online with a different uuid, so upon receipt of the hello request, it
+transitions the child subtree status through lost to fail any pending
+RPCs, then proceeds to handle the hello.  This test verifies that the
+transition through lost occurs.
+'
+
+. `dirname $0`/sharness.sh
+
+test_under_flux 2 system
+
+startctl="flux python ${SHARNESS_TEST_SRCDIR}/scripts/startctl.py"
+
+test_expect_success 'tell brokers to log to stderr' '
+	flux exec flux setattr log-stderr-mode local
+'
+
+# Degraded at parent means child was lost
+test_expect_success NO_CHAIN_LINT 'start overlay status wait in the background' '
+	flux overlay status --wait degraded &
+	echo $! >subtree.pid
+'
+
+test_expect_success 'kill -9 broker 1' '
+	$startctl kill 1 9 &&
+	test_expect_code 137 $startctl wait 1
+'
+
+test_expect_success 'restart broker 1' '
+	$startctl run 1
+'
+
+test_expect_success NO_CHAIN_LINT 'ensure child was lost' '
+	wait $(cat subtree.pid)
+'
+
+test_expect_success 'and child returned to service' '
+	flux overlay status --wait full
+'
+
+# Side effect: let rc1 on rank 1 finish loading resource module
+# before shutdown begins, or it will complain
+test_expect_success 'run a 2 node job' '
+	flux mini run -n2 -N2 /bin/true
+'
+
+test_done


### PR DESCRIPTION
This adds code to handle the case described in #3608, where a broker might be forever cut off from the flux instance if its TBON parent restarts without informing it (for example a kill -9 or a node crash).  With this change, the parent detects the child trying to communicate without first executing the hello handshake to register its uuid, and sends a KEEPALIVE_DISCONNECT message to ensure it stops.  Systemd would then be able to restart it.

Also fixed a problem with the crashed broker properly rejoining _its_ parent, discovered during testing.

There is also some minor overlay cleanup here.

This is built on top of pr #3843.  Once that is merged, this can be rebased.