### PR TITLE
broker: improve logging of 0MQ socket events

### DIFF
--- a/src/broker/test/overlay.c
+++ b/src/broker/test/overlay.c
@@ -407,10 +407,12 @@ void trio (flux_t *h)
     ok (flux_msg_get_topic (rmsg, &topic) == 0 && !strcmp (topic, "eeeb"),
         "%s: received message has expected topic", ctx[1]->name);
 
-
+    /* Cover some error code in overlay_bind() where the ZAP handler
+     * fails to initialize because its endpoint is already bound.
+     */
     errno = 0;
-    ok (overlay_bind (ctx[1]->ov, "ipc://@foo") < 0 && errno == EINVAL,
-        "%s: second overlay_bind in proc fails with EINVAL", ctx[0]->name);
+    ok (overlay_bind (ctx[1]->ov, "ipc://@foo") < 0 && errno == EADDRINUSE,
+        "%s: second overlay_bind in proc fails with EADDRINUSE", ctx[0]->name);
 
     /* Various tests of rank 2 without proper authorization.
      * First a baseline - resend 1->0 and make sure timed recv works.

--- a/src/cmd/builtin/version.c
+++ b/src/cmd/builtin/version.c
@@ -15,6 +15,7 @@
 # include <pmix.h>
 #endif
 #include <hwloc.h>
+#include <zmq.h>
 
 #include "builtin.h"
 #if HAVE_FLUX_SECURITY_VERSION_H
@@ -74,6 +75,10 @@ static int cmd_version (optparse_t *p, int ac, char *av[])
             HWLOC_API_VERSION >>  8 & 0x000000ff,
             HWLOC_API_VERSION       & 0x000000ff
             );
+    printf ("+zmq==%d.%d.%d",
+            ZMQ_VERSION_MAJOR,
+            ZMQ_VERSION_MINOR,
+            ZMQ_VERSION_PATCH);
     printf ("\n");
     return (0);
 }

--- a/src/common/libzmqutil/Makefile.am
+++ b/src/common/libzmqutil/Makefile.am
@@ -10,6 +10,7 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir)/src/include \
 	-I$(top_srcdir)/src/common/libccan \
 	-I$(top_builddir)/src/common/libflux \
+	$(LIBUUID_CFLAGS) \
 	$(ZMQ_CFLAGS)
 
 noinst_LTLIBRARIES = \
@@ -23,12 +24,15 @@ libzmqutil_la_SOURCES = \
 	ev_zmq.h \
 	ev_zmq.c \
 	zap.h \
-	zap.c
+	zap.c \
+	monitor.h \
+	monitor.c
 
 TESTS = test_msg_zsock.t \
 	test_reactor.t \
 	test_ev.t \
-	test_zap.t
+	test_zap.t \
+	test_monitor.t
 
 check_PROGRAMS = \
 	$(TESTS)
@@ -42,6 +46,7 @@ test_ldadd = \
 	$(top_builddir)/src/common/libflux-core.la \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libtap/libtap.la \
+	$(LIBUUID_LIBS) \
 	$(ZMQ_LIBS)
 
 test_cppflags = \
@@ -70,3 +75,8 @@ test_zap_t_SOURCES = test/zap.c
 test_zap_t_CPPFLAGS = $(test_cppflags)
 test_zap_t_LDADD = $(test_ldadd)
 test_zap_t_LDFLAGS = $(test_ldflags)
+
+test_monitor_t_SOURCES = test/monitor.c
+test_monitor_t_CPPFLAGS = $(test_cppflags)
+test_monitor_t_LDADD = $(test_ldadd)
+test_monitor_t_LDFLAGS = $(test_ldflags)

--- a/src/common/libzmqutil/monitor.c
+++ b/src/common/libzmqutil/monitor.c
@@ -1,0 +1,317 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <czmq.h>
+#include <zmq.h>
+#include <uuid.h>
+
+#include "reactor.h"
+#include "monitor.h"
+
+#ifndef UUID_STR_LEN
+#define UUID_STR_LEN 37     // defined in later libuuid headers
+#endif
+
+#if (ZMQ_VERSION > ZMQ_MAKE_VERSION (4, 1, 4))
+/* N.B. 4.1.4 has a bad bug
+ */
+struct zmqutil_monitor {
+    zsock_t *sock;
+    char endpoint[UUID_STR_LEN + 64];
+    flux_watcher_t *w;
+    zmqutil_monitor_f fun;
+    void *arg;
+    bool stopped;
+};
+
+static struct {
+    uint16_t event;
+    enum {
+        VAL_NONE,
+        VAL_ERRNO,
+        VAL_PROTO,
+        VAL_ZAPNUM,
+    } valtype;
+    const char *desc;
+} nametab[] = {
+    { ZMQ_EVENT_CONNECTED, VAL_NONE,"connected" },
+    { ZMQ_EVENT_CONNECT_DELAYED, VAL_NONE, "connect delayed" },
+    { ZMQ_EVENT_CONNECT_RETRIED, VAL_NONE, "connect retried" },
+    { ZMQ_EVENT_LISTENING, VAL_NONE, "listening" },
+    { ZMQ_EVENT_BIND_FAILED, VAL_ERRNO, "bind failed" },
+    { ZMQ_EVENT_ACCEPTED, VAL_NONE, "accepted" },
+    { ZMQ_EVENT_ACCEPT_FAILED, VAL_ERRNO, "accept failed" },
+    { ZMQ_EVENT_CLOSED, VAL_NONE, "closed" },
+    { ZMQ_EVENT_CLOSE_FAILED, VAL_ERRNO, "close failed" },
+    { ZMQ_EVENT_DISCONNECTED, VAL_NONE, "disconnected" },
+    { ZMQ_EVENT_MONITOR_STOPPED, VAL_NONE, "monitor stopped" },
+#ifdef ZMQ_EVENT_HANDSHAKE_FAILED_NO_DETAIL
+    { ZMQ_EVENT_HANDSHAKE_FAILED_NO_DETAIL, VAL_ERRNO, "handshake failed" },
+#endif
+#ifdef ZMQ_EVENT_HANDSHAKE_SUCCEEDED
+    { ZMQ_EVENT_HANDSHAKE_SUCCEEDED, VAL_NONE, "handshake succeeded" },
+#endif
+#ifdef ZMQ_EVENT_HANDSHAKE_FAILED_PROTOCOL
+    { ZMQ_EVENT_HANDSHAKE_FAILED_PROTOCOL, VAL_PROTO,
+      "handshake failed protocol" },
+#endif
+#ifdef ZMQ_EVENT_HANDSHAKE_FAILED_AUTH
+    { ZMQ_EVENT_HANDSHAKE_FAILED_AUTH, VAL_ZAPNUM,
+      "handshake failed auth" },
+#endif
+};
+
+static struct {
+    uint32_t value;
+    const char *desc;
+} prototab[] = {
+#ifdef ZMQ_EVENT_HANDSHAKE_FAILED_PROTOCOL
+    { ZMQ_PROTOCOL_ERROR_ZMTP_UNSPECIFIED, "ZMTP unspecified" },
+    { ZMQ_PROTOCOL_ERROR_ZMTP_UNEXPECTED_COMMAND, "ZMTP unexpected command" },
+    { ZMQ_PROTOCOL_ERROR_ZMTP_INVALID_SEQUENCE, "ZMTP invalid sequence" },
+    { ZMQ_PROTOCOL_ERROR_ZMTP_KEY_EXCHANGE, "ZMTP key exchange" },
+    { ZMQ_PROTOCOL_ERROR_ZMTP_MALFORMED_COMMAND_UNSPECIFIED,
+      "ZMTP malformed command unspecified" },
+    { ZMQ_PROTOCOL_ERROR_ZMTP_MALFORMED_COMMAND_MESSAGE,
+      "ZMTP malformed command message" },
+    { ZMQ_PROTOCOL_ERROR_ZMTP_MALFORMED_COMMAND_HELLO,
+      "ZMTP malformed command hello" },
+    { ZMQ_PROTOCOL_ERROR_ZMTP_MALFORMED_COMMAND_INITIATE,
+      "ZMTP malformed command initiate" },
+    { ZMQ_PROTOCOL_ERROR_ZMTP_MALFORMED_COMMAND_ERROR,
+      "ZMTP malformed command error" },
+    { ZMQ_PROTOCOL_ERROR_ZMTP_MALFORMED_COMMAND_READY,
+      "ZMTP malformed command ready" },
+    { ZMQ_PROTOCOL_ERROR_ZMTP_MALFORMED_COMMAND_WELCOME,
+      "ZMTP malformed command welcome" },
+    { ZMQ_PROTOCOL_ERROR_ZMTP_INVALID_METADATA, "ZMTP invalid metadata" },
+    { ZMQ_PROTOCOL_ERROR_ZMTP_CRYPTOGRAPHIC, "ZMTP cryptographic" },
+    { ZMQ_PROTOCOL_ERROR_ZMTP_MECHANISM_MISMATCH, "ZMTP mechanism mismatch" },
+    { ZMQ_PROTOCOL_ERROR_ZAP_UNSPECIFIED, "ZAP unspecified" },
+    { ZMQ_PROTOCOL_ERROR_ZAP_MALFORMED_REPLY, "ZAP malformed reply" },
+    { ZMQ_PROTOCOL_ERROR_ZAP_BAD_REQUEST_ID, "ZAP bad request id" },
+    { ZMQ_PROTOCOL_ERROR_ZAP_BAD_VERSION, "ZAP bad version" },
+    { ZMQ_PROTOCOL_ERROR_ZAP_INVALID_STATUS_CODE, "ZAP invalid status code" },
+    { ZMQ_PROTOCOL_ERROR_ZAP_INVALID_METADATA, "ZAP invalid metadata" },
+#endif
+};
+
+static const char *eventstr (struct monitor_event *mevent)
+{
+    int i;
+    for (i = 0; i < sizeof (nametab) / sizeof (nametab[0]); i++) {
+        if (mevent->event == nametab[i].event)
+            return nametab[i].desc;
+    }
+    return "unknown socket event";
+}
+
+static const char *valuestr (struct monitor_event *mevent)
+{
+    int i;
+    int valtype = VAL_NONE;
+    static char buf[128];
+
+    /* look up valtype for event */
+    for (i = 0; i < sizeof (nametab) / sizeof (nametab[0]); i++) {
+        if (mevent->event == nametab[i].event)
+            valtype = nametab[i].valtype;
+    }
+    /* decode value depending on valtype */
+    if (valtype == VAL_ERRNO)
+        return strerror (mevent->value);
+    if (valtype == VAL_ZAPNUM) {
+        snprintf (buf, sizeof (buf), "ZAP status code %d", mevent->value);
+        return buf;
+    }
+    if (valtype == VAL_PROTO) {
+        for (i = 0; i < sizeof (prototab) / sizeof (prototab[0]); i++) {
+            if (mevent->value == prototab[i].value)
+                return prototab[i].desc;
+        }
+        snprintf (buf, sizeof (buf), "unknown protocol error %d", mevent->value);
+        return buf;
+    }
+    return "";
+}
+
+bool zmqutil_monitor_iserror (struct monitor_event *mevent)
+{
+    if (mevent) {
+        switch (mevent->event) {
+            case ZMQ_EVENT_BIND_FAILED:
+            case ZMQ_EVENT_ACCEPT_FAILED:
+            case ZMQ_EVENT_CLOSE_FAILED:
+#ifdef ZMQ_EVENT_HANDSHAKE_FAILED_NO_DETAIL
+            case ZMQ_EVENT_HANDSHAKE_FAILED_NO_DETAIL:
+#endif
+#ifdef ZMQ_EVENT_HANDSHAKE_FAILED_PROTOCOL
+            case ZMQ_EVENT_HANDSHAKE_FAILED_PROTOCOL:
+#endif
+#ifdef ZMQ_EVENT_HANDSHAKE_FAILED_AUTH
+            case ZMQ_EVENT_HANDSHAKE_FAILED_AUTH:
+#endif
+                return true;
+        }
+    }
+    return false;
+}
+
+int zmqutil_monitor_get (struct zmqutil_monitor *mon,
+                         struct monitor_event *mevent)
+{
+    zframe_t *zf;
+
+    if (!mon || !mevent) {
+        errno = EINVAL;
+        return -1;
+    }
+    /* receive event+value frame */
+    if (!(zf = zframe_recv (mon->sock)) || zframe_size (zf) != 6)
+        return -1;
+    mevent->event = *(uint16_t *)zframe_data (zf);
+    mevent->value = *(uint32_t *)(zframe_data (zf) + 2);
+    zframe_destroy (&zf);
+
+    /* receive endpoint frame */
+    if (!(zf = zframe_recv (mon->sock)))
+        return -1;
+    snprintf (mevent->endpoint,
+              sizeof (mevent->endpoint),
+              "%.*s",
+              (int)zframe_size (zf), zframe_data (zf));
+    zframe_destroy (&zf);
+
+    /* note end of monitor stream for zmqutil_monitor_destroy() */
+    if (mevent->event == ZMQ_EVENT_MONITOR_STOPPED)
+        mon->stopped = true;
+
+    /* decode event, value */
+    mevent->event_str = eventstr (mevent);
+    mevent->value_str = valuestr (mevent);
+    return 0;
+}
+
+static void monitor_callback (flux_reactor_t *r,
+                              flux_watcher_t *w,
+                              int revents,
+                              void *arg)
+{
+    struct zmqutil_monitor *mon = arg;
+
+    if (mon->fun)
+        mon->fun (mon, mon->arg);
+}
+
+/* Read messages from the monitor socket until the final MONITOR_STOPPED
+ * message is read.  This presumes that the socket being monitored is
+ * closed before zmqutil_monitor_destroy() is called.  If the monitor socket
+ * is destroyed before consuming this event, it may cause the 0MQ I/O thread
+ * to block when the PAIR socket it is writing to enters the mute state.
+ */
+static void monitor_purge (struct zmqutil_monitor *mon)
+{
+    struct monitor_event event;
+
+    while (!mon->stopped) {
+        if (zmqutil_monitor_get (mon, &event) < 0)
+            break;
+    }
+}
+
+void zmqutil_monitor_destroy (struct zmqutil_monitor *mon)
+{
+    if (mon) {
+        int saved_errno = errno;
+        flux_watcher_destroy (mon->w);
+        if (mon->sock) {
+            monitor_purge (mon);
+            zsock_disconnect (mon->sock, "%s", mon->endpoint);
+            zsock_destroy (&mon->sock);
+        }
+        free (mon);
+        errno = saved_errno;
+    }
+}
+
+struct zmqutil_monitor *zmqutil_monitor_create (zsock_t *sock,
+                                                flux_reactor_t *r,
+                                                zmqutil_monitor_f fun,
+                                                void *arg)
+{
+    struct zmqutil_monitor *mon;
+    uuid_t uuid;
+    char uuid_str[UUID_STR_LEN];
+
+    if (!sock || !r) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (!(mon = calloc (1, sizeof (*mon))))
+        return NULL;
+    mon->fun = fun;
+    mon->arg = arg;
+
+    /* Generate a unique inproc endpoint for monitoring this socket.
+     */
+    uuid_generate (uuid);
+    uuid_unparse (uuid, uuid_str);
+    snprintf (mon->endpoint, sizeof (mon->endpoint), "inproc://%s", uuid_str);
+
+    /* Arrange for local callback to run on each monitor event.
+     * It will call the user's callback.
+     */
+    if (zmq_socket_monitor (zsock_resolve (sock),
+                            mon->endpoint,
+                            ZMQ_EVENT_ALL) < 0
+        || !(mon->sock = zsock_new (ZMQ_PAIR))
+        || zsock_connect (mon->sock, "%s", mon->endpoint) < 0
+        || !(mon->w = zmqutil_watcher_create (r,
+                                              mon->sock,
+                                              FLUX_POLLIN,
+                                              monitor_callback,
+                                              mon)))
+        goto error;
+    zsock_set_linger (mon->sock, 0);
+    zsock_set_unbounded (mon->sock);
+    flux_watcher_start (mon->w);
+    return mon;
+error:
+    zmqutil_monitor_destroy (mon);
+    return NULL;
+}
+#else
+/* Monitoring is disabled due to libzmq being too old.
+ */
+struct zmqutil_monitor *zmqutil_monitor_create (zsock_t *sock,
+                                                flux_reactor_t *r,
+                                                zmqutil_monitor_f fun,
+                                                void *arg)
+{
+    return NULL;
+}
+void zmqutil_monitor_destroy (struct zmqutil_monitor *mon)
+{
+}
+int zmqutil_monitor_get (struct zmqutil_monitor *mon,
+                         struct monitor_event *mevent)
+{
+    return -1;
+}
+bool zmqutil_monitor_iserror (struct monitor_event *mevent)
+{
+    return false;
+}
+#endif
+
+// vi:ts=4 sw=4 expandtab

--- a/src/common/libzmqutil/monitor.h
+++ b/src/common/libzmqutil/monitor.h
@@ -1,0 +1,48 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#include <flux/core.h>
+#include <czmq.h>
+#include <zmq.h>
+
+struct monitor_event {
+    uint16_t event;
+    uint32_t value;
+    char endpoint[256];
+    const char *event_str;
+    const char *value_str;
+};
+
+struct zmqutil_monitor;
+
+typedef void (*zmqutil_monitor_f)(struct zmqutil_monitor *mon, void *arg);
+
+/* Arrange for 'fun' to be called each time there is an event on 'sock'.
+ * Create must be called before connect/bind, and destroy must be called
+ * after close/destroy.
+ * N.B. this will fail if an old/buggy version of libzmq is used.
+ */
+struct zmqutil_monitor *zmqutil_monitor_create (zsock_t *sock,
+                                                flux_reactor_t *r,
+                                                zmqutil_monitor_f fun,
+                                                void *arg);
+void zmqutil_monitor_destroy (struct zmqutil_monitor *mon);
+
+/* Receive an event from the monitor socket.
+ * This should be called once each time the the monitor callback is invoked.
+ */
+int zmqutil_monitor_get (struct zmqutil_monitor *mon,
+                         struct monitor_event *mevent);
+
+/* Returns true if the socket event likely should be logged at error severity.
+ */
+bool zmqutil_monitor_iserror (struct monitor_event *mevent);
+
+// vi:ts=4 sw=4 expandtab

--- a/src/common/libzmqutil/test/monitor.c
+++ b/src/common/libzmqutil/test/monitor.c
@@ -1,0 +1,50 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <flux/core.h>
+#include "monitor.h"
+
+#include "src/common/libtap/tap.h"
+
+void test_badargs (void)
+{
+    /* Note: these are stubbed for older libzmq (e.g. centos 7),
+     * so checking for errno == EINVAL is not going to happen there.
+     */
+    ok (zmqutil_monitor_create (NULL, NULL, NULL, NULL) == NULL,
+        "zmqutil_monitor_create sock=NULL fails");
+
+    lives_ok({zmqutil_monitor_destroy (NULL);},
+        "zmqutil_monitor_destroy sock=NULL doesn't crash");
+
+    ok (zmqutil_monitor_get (NULL, NULL) < 0,
+        "zmqutil_monitor_get mon=NULL fails");
+
+    lives_ok({zmqutil_monitor_iserror (NULL);},
+        "zmqutil_monitor_iserror mevent=NULL doesn't crash");
+
+}
+
+int main (int argc, char *argv[])
+{
+    plan (NO_PLAN);
+
+    test_badargs ();
+
+    done_testing ();
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libzmqutil/zap.c
+++ b/src/common/libzmqutil/zap.c
@@ -211,10 +211,8 @@ struct zmqutil_zap *zmqutil_zap_create (flux_reactor_t *r)
         goto error;
     if (!(zap->sock = zsock_new (ZMQ_REP)))
         goto error;
-    if (zsock_bind (zap->sock, ZAP_ENDPOINT) < 0) {
-        errno = EINVAL;
+    if (zsock_bind (zap->sock, ZAP_ENDPOINT) < 0)
         goto error;
-    }
     if (!(zap->w = zmqutil_watcher_create (r,
                                            zap->sock,
                                            FLUX_POLLIN,


### PR DESCRIPTION
0MQ does things like connect and authentication in its I/O thread without exposing it in its API, which is convenient, though sometimes when not working, you wish you knew what was going on in there. 

0MQ does offer [zmq_socket_monitor(3)](http://api.zeromq.org/master:zmq-socket-monitor) which we've employed in the past for counting peers, but it has a bad bug in the version of libzmq that is still packaged on centos7, and has a few other caveats that you have to be very careful with, such as the ability to deadlock the 0MQ I/O thread if the monitor socket is not properly managed.  So we stopped using it.

This PR brings back socket monitoring for the broker overlay network, but only for logging purposes, and only for modern 0MQ versions.  The sorts of messages that might appear can be seen by running the overlay unit test, e.g.
```
# debug: child sockevent ipc://@trio-0 disconnected
# debug: child sockevent ipc://@trio-0 accepted
# err: child sockevent ipc://@trio-0 handshake failed protocol: ZMTP mechanism mismatch
# err: child sockevent ipc://@trio-0 handshake failed auth: ZAP status code 400
```
This is not super useful on its own, but it might provide useful context around other overlay messages in the logs when things are not working right.

The monitoring API in 0MQ is evolving, so I wrapped it up in a `libzmqutil_monitor` class so we can avoid exposing those details in `broker/overlay.c`.