### PR TITLE
update flux-security version to v0.5.0 in docker images

### DIFF
--- a/src/test/docker/docker-run-checks.sh
+++ b/src/test/docker/docker-run-checks.sh
@@ -16,7 +16,7 @@ JOBS=2
 MOUNT_HOME_ARGS="--volume=$HOME:/home/$USER -e HOME"
 
 if test "$PROJECT" = "flux-core"; then
-  FLUX_SECURITY_VERSION=0.4.0
+  FLUX_SECURITY_VERSION=0.5.0
   POISON=t
 fi
 


### PR DESCRIPTION
This PR updates the default flux-security version in docker images created by `docker-run-checks.sh` to the latest: v0.5.0. This means all published `fluxrm/flux-core` images will include the newer flux-security.