### PR TITLE
libflux: deactivate RPC message handlers after final response

### DIFF
--- a/src/common/libsubprocess/remote.c
+++ b/src/common/libsubprocess/remote.c
@@ -756,7 +756,7 @@ int remote_exec (flux_subprocess_t *p)
      * internally in this code.  But output callbacks are optional, we
      * don't care if user doesn't want it.
      */
-    if (!(f = flux_rpc_pack (p->h, "broker.rexec", p->rank, 0,
+    if (!(f = flux_rpc_pack (p->h, "broker.rexec", p->rank, FLUX_RPC_STREAMING,
                              "{s:s s:i s:i s:i}",
                              "cmd", cmd_str,
                              "on_channel_out", p->ops.on_channel_out ? 1 : 0,

--- a/t/python/t0012-futures.py
+++ b/t/python/t0012-futures.py
@@ -207,9 +207,11 @@ class TestHandle(unittest.TestCase):
         watcher.start()
 
         arg = {"count": 0, "target": 3}
-        self.f.rpc("rpctest.multi", {"count": arg["target"]}).then(
-            continuation_cb, arg=arg
-        )
+        self.f.rpc(
+            "rpctest.multi",
+            {"count": arg["target"]},
+            flags=flux.constants.FLUX_RPC_STREAMING,
+        ).then(continuation_cb, arg=arg)
         ret = self.f.reactor_run()
         self.assertEqual(arg["count"], arg["target"])
 


### PR DESCRIPTION
This PR fixes the issue described in #3852, a problem first described in flux-framework/FluxRM.jl#17.

In general, the problem is that RPCs do not drop their active references on an event loop until the future is _destroyed_, instead of dropping them when future is _fulfilled_. This means an RPC future can't be used outside of an event loop since `flux_reactor_run(3)` will not return until all RPC futures are destroyed.

This PR just stops the internal RPC msg_handler once the final expected response is received. In the case of a normal RPC, this is when the future is first fulfilled, but for streaming RPCs this is at the first error.

A couple spots were missing the FLUX_RPC_STREAMING flag (as evidenced by hangs). These were fixed here.

The libsubprocess protocol still doesn't send an error response as the terminating message in the protocol. However, I think this is OK for now since, internally, the multi-response future is destroyed whenever the "final" response is received.