### PR TITLE
ci: add fedora 34 build and fix compiler errors from gcc 11.2

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -20,7 +20,7 @@ jobs:
         TAP_DRIVER_QUIET: t
       run: >
         src/test/docker/docker-run-checks.sh \
-          --image=fedora33 --unit-test-only -j2 \
+          --image=fedora34 --unit-test-only -j2 \
           -- --with-flux-security --enable-sanitizer=address
 
     - name: after failure

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -16,6 +16,7 @@ pull_request_rules:
       - status-success="centos7"
       - status-success="centos8 - py3.7"
       - status-success="fedora33 - gcc-10,py3.9"
+      - status-success="fedora34 - gcc-11.2,py3.9"
       - status-success="coverage"
       - status-success="address-sanitizer check"
       - label="merge-when-passing"

--- a/src/common/libccan/ccan/base64/base64.c
+++ b/src/common/libccan/ccan/base64/base64.c
@@ -118,7 +118,7 @@ size_t base64_decoded_length(size_t srclen)
 	return ((srclen+3)/4*3);
 }
 
-int base64_decode_quartet_using_maps(const base64_maps_t *maps, char dest[3],
+ssize_t base64_decode_quartet_using_maps(const base64_maps_t *maps, char dest[3],
 				     const char src[4])
 {
 	signed char a;
@@ -143,7 +143,7 @@ int base64_decode_quartet_using_maps(const base64_maps_t *maps, char dest[3],
 }
 
 
-int base64_decode_tail_using_maps(const base64_maps_t *maps, char dest[3],
+ssize_t base64_decode_tail_using_maps(const base64_maps_t *maps, char dest[3],
 				  const char * src, const size_t srclen)
 {
 	char longsrc[4];
@@ -178,7 +178,7 @@ ssize_t base64_decode_using_maps(const base64_maps_t *maps,
 {
 	ssize_t dest_offset = 0;
 	ssize_t i;
-	size_t more;
+	ssize_t more;
 
 	if (destlen < base64_decoded_length(srclen)) {
 		errno = EOVERFLOW;

--- a/src/common/libccan/ccan/base64/base64.h
+++ b/src/common/libccan/ccan/base64/base64.h
@@ -103,8 +103,8 @@ ssize_t base64_decode_using_maps(const base64_maps_t *maps,
  * @return Number of decoded bytes set in dest. -1 on error (and errno set)
  * @note sets errno = EDOM if src contains invalid characters
  */
-int base64_decode_quartet_using_maps(const base64_maps_t *maps,
-				     char dest[3], const char src[4]);
+ssize_t base64_decode_quartet_using_maps(const base64_maps_t *maps,
+				         char dest[3], const char src[4]);
 
 /**
  * base64_decode_tail_using_maps - decode the final bytes of a base64 string using a specific alphabet
@@ -116,8 +116,8 @@ int base64_decode_quartet_using_maps(const base64_maps_t *maps,
  * @note sets errno = EDOM if src contains invalid characters
  * @note sets errno = EINVAL if src is an invalid base64 tail
  */
-int base64_decode_tail_using_maps(const base64_maps_t *maps, char *dest,
-				  const char *src, size_t srclen);
+ssize_t base64_decode_tail_using_maps(const base64_maps_t *maps, char dest[3],
+				      const char *src, size_t srclen);
 
 
 /* the rfc4648 functions: */
@@ -212,7 +212,7 @@ ssize_t base64_decode(char *dest, size_t destlen,
  * @note sets errno = EDOM if src contains invalid characters
  */
 static inline
-int base64_decode_quartet(char dest[3], const char src[4])
+ssize_t base64_decode_quartet(char dest[3], const char src[4])
 {
 	return base64_decode_quartet_using_maps(&base64_maps_rfc4648,
 						dest, src);

--- a/src/common/librouter/test/rpc_track.c
+++ b/src/common/librouter/test/rpc_track.c
@@ -66,7 +66,7 @@ flux_msg_t *create_request (uint32_t matchtag, int setflags, bool add_uuid)
 
     if (flux_msg_get_flags (msg, &flags) < 0)
         BAIL_OUT ("flux_msg_get_flags failed");
-        flags |= setflags;
+    flags |= setflags;
     if (flux_msg_set_flags (msg, flags) < 0)
         BAIL_OUT ("flux_msg_set_flags failed");
 

--- a/src/test/docker/README.md
+++ b/src/test/docker/README.md
@@ -48,7 +48,7 @@ pushed to DockerHub at `fluxrm/testenv:bionic` and
 script still runs against the new `testenv` images, e.g.:
 
 ```
-$ for i in bionic focal centos7 centos8 fedora33; do
+$ for i in bionic focal centos7 centos8 fedora33 fedora34; do
     make clean &&
     docker build --no-cache -t fluxrm/testenv:$i src/test/docker/$i &&
     src/test/docker/docker-run-checks.sh -j 4 --image=$i &&

--- a/src/test/docker/fedora34/Dockerfile
+++ b/src/test/docker/fedora34/Dockerfile
@@ -1,0 +1,88 @@
+FROM fedora:34
+
+LABEL maintainer="Mark Grondona <mgrondona@llnl.gov>"
+
+#  Enable PowerTools for development packages
+RUN yum -y update \
+ && yum -y update \
+#  Utilities
+ && yum -y install \
+	wget \
+	man-db \
+	less \
+	git \
+	sudo \
+	munge \
+	ccache \
+	lua \
+	mpich \
+	valgrind \
+	jq \
+	which \
+	file \
+	vim \
+	patch \
+	diffutils \
+	hostname \
+#  Compilers, autotools
+	pkgconfig \
+	libtool \
+	autoconf \
+	automake \
+	gcc \
+	gcc-c++ \
+	libasan \
+	make \
+	cmake \
+#  Python
+	python36 \
+	python3-devel \
+	python3-cffi \
+	python3-six \
+	python3-yaml \
+	python3-jsonschema \
+	python3-sphinx \
+#  Development dependencies
+	libsodium-devel \
+	zeromq-devel \
+	czmq-devel \
+	jansson-devel \
+	munge-devel \
+	lz4-devel \
+	sqlite-devel \
+	libuuid-devel \
+	hwloc-devel \
+	mpich-devel \
+	lua-devel \
+	valgrind-devel \
+	libs3-devel \
+#  Other deps
+	perl-Time-HiRes \
+	lua-posix \
+	libfaketime \
+	cppcheck \
+	enchant \
+	aspell \
+	aspell-en \
+	glibc-langpack-en \
+ && yum clean all
+
+#  Add /usr/bin/mpicc link so MPI tests are built
+RUN alternatives --install /usr/bin/mpicc mpicc /usr/lib64/mpich/bin/mpicc 100
+
+# Install caliper by hand for now:
+RUN mkdir caliper \
+ && cd caliper \
+ && wget -O - https://github.com/LLNL/Caliper/archive/v1.7.0.tar.gz | tar xvz --strip-components 1 \
+ && mkdir build \
+ && cd build \
+ && cmake .. -DCMAKE_INSTALL_PREFIX=/usr \
+ && make -j 4 \
+ && make install \
+ && cd ../.. \
+ && rm -rf caliper
+
+ENV LANG=C.UTF-8
+RUN printf "LANG=C.UTF-8" > /etc/locale.conf
+
+COPY config.site /usr/share/config.site

--- a/src/test/docker/fedora34/config.site
+++ b/src/test/docker/fedora34/config.site
@@ -1,0 +1,6 @@
+# Force libdir to /usr/lib64 if prefix=/usr on this platform
+if test "$prefix" = "/usr" ; then
+    test $sysconfdir = "${prefix}/etc" && sysconfdir=/etc
+    libdir=/usr/lib64
+fi
+:

--- a/src/test/generate-matrix.py
+++ b/src/test/generate-matrix.py
@@ -216,6 +216,14 @@ matrix.add_build(
     docker_tag=True,
 )
 
+# Fedora 34
+matrix.add_build(
+    name="fedora34 - gcc-11.2,py3.9",
+    image="fedora34",
+    docker_tag=True,
+)
+
+
 # inception
 matrix.add_build(
     name="inception",

--- a/t/mpi/mpich_basic/netmpi.c
+++ b/t/mpi/mpich_basic/netmpi.c
@@ -503,7 +503,7 @@ int Setup(ArgStruct * p)
 
 void Sync(ArgStruct * p)
 {
-    char ch;
+    char ch = 0;
     MPI_Status status;
     if (p->tr) {
         MPI_Send(&ch, 0, MPI_BYTE, p->prot.nbor, 1, MPI_COMM_WORLD);


### PR DESCRIPTION
This PR adds Fedora Core 34 to our CI. The compiler in this version, gcc 11.2, found some new errors, so those are fixed.

The address sanitizer build is also switched to fedora 34 on the assumption that the newer GCC will have better sanitizers.

Eventually we'll switch away from fedora 33, but for now the fedora33 ci build needs to stay since dependent projects (e.g. flux-sched) still need the fedora33 docker image produced as a result of the ci build.