### PR TITLE
shell: add library of Lua convenience functions for use in plugins 

### DIFF
--- a/src/shell/Makefile.am
+++ b/src/shell/Makefile.am
@@ -22,6 +22,7 @@ dist_shellrc_SCRIPTS = \
 	initrc.lua
 
 dist_shelllua_SCRIPTS = \
+	lua.d/00-lib.lua \
 	lua.d/mvapich.lua \
 	lua.d/intel_mpi.lua \
 	lua.d/openmpi.lua \

--- a/src/shell/lua.d/00-lib.lua
+++ b/src/shell/lua.d/00-lib.lua
@@ -1,0 +1,70 @@
+-------------------------------------------------------------
+-- Copyright 2021 Lawrence Livermore National Security, LLC
+-- (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+--
+-- This file is part of the Flux resource manager framework.
+-- For details, see https://github.com/flux-framework.
+--
+-- SPDX-License-Identifier: LGPL-3.0
+-------------------------------------------------------------
+
+--  Useful functions shared by all subsequently loaded
+--   shell Lua plugins
+
+--- Get a top level option from the shell.options table which includes
+---  an optional "@version" specification.
+--
+--  @param name The name of the option to get
+--
+--  Returns val, version
+--   `val` will be nil if shell option was not set
+--   `version` will be nil if no version specified.
+--
+function shell.getopt_with_version (name)
+    if not name then return nil end
+    local opt = shell.options[name]
+    if opt then
+        return opt:match("^[^@]+"), opt:match("@(.+)$")
+    end
+    return nil
+end
+
+--- Prepend `path` to colon-separated path environment variable `env_var`
+--
+--  @param env_var The environment variable to which to prepend
+--  @param path    The path to prepend
+--
+function shell.prepend_path (env_var, path)
+    local val = shell.getenv (env_var)
+
+    -- If path is already in env_var, do nothing. We stick ":" on both
+    -- ends of the existing value so we can easily match exact paths
+    -- instead of possibly matching substrings of paths when trying
+    -- to match "zero or more" colons.
+    --
+    if val and ((":"..val..":"):match (":"..path..":")) then return end
+
+    if val == nil then
+       suffix = ''
+    else
+       suffix = ':'..val
+    end
+    shell.setenv (env_var, path..suffix)
+end
+
+--- Strip all environment variables from job environment that match one
+--   or more pattern arguments.
+--
+function shell.env_strip (...)
+    local env = shell.getenv ()
+    for k,v in pairs (env) do
+        for _,pattern in pairs ({...}) do
+            if k:match(pattern) then
+                shell.unsetenv (k)
+            end
+        end
+    end
+end
+
+-- vi: ts=4 sw=4 expandtab
+-- 

--- a/src/shell/lua.d/spectrum.lua
+++ b/src/shell/lua.d/spectrum.lua
@@ -10,45 +10,15 @@
 
 -- Set environment specific to spectrum_mpi (derived from openmpi)
 --
-if shell.options.mpi ~= "spectrum" then return end
+
+local mpi, version = shell.getopt_with_version ("mpi")
+
+if mpi ~= "spectrum" then return end
 
 local posix = require 'posix'
 
-function prepend_path (env_var, path)
-    local val = shell.getenv (env_var)
-
-    -- If path is already in env_var, do nothing. We stick ":" on both
-    -- ends of the existing value so we can easily match exact paths
-    -- instead of possibly matching substrings of paths when trying
-    -- to match "zero or more" colons.
-    --
-    if val and ((":"..val..":"):match (":"..path..":")) then return end
-
-    if val == nil then
-       suffix = ''
-    else
-       suffix = ':'..val
-    end
-    shell.setenv (env_var, path..suffix)
-end
-
-local function strip_env_by_prefix (env, prefix)
-    --
-    -- Have to call env:get() to translate env object to Lua table
-    --  in order to use pairs() to iterate environment keys:
-    --
-    for k,v in pairs (env) do
-        if k:match("^"..prefix) then
-            shell.unsetenv (k)
-        end
-    end
-end
-
-local env = shell.getenv()
-
 -- Clear all existing PMIX_ and OMPI_ values before setting our own
-strip_env_by_prefix (env, "PMIX_")
-strip_env_by_prefix (env, "OMPI_")
+shell.env_strip ("^PMIX_", "^OMPI_")
 
 -- Assumes the installation paths of Spectrum MPI on LLNL's Sierra
 shell.setenv ('OMPI_MCA_osc', "pt2pt")
@@ -57,8 +27,10 @@ shell.setenv ('OMPI_MCA_btl', "self")
 shell.setenv ('OMPI_MCA_coll_hcoll_enable', '0')
 
 -- Help find libcollectives.so
-prepend_path ('LD_LIBRARY_PATH', '/opt/ibm/spectrum_mpi/lib/pami_port')
-prepend_path ('LD_PRELOAD', '/opt/ibm/spectrum_mpi/lib/libpami_cudahook.so')
+shell.prepend_path ('LD_LIBRARY_PATH',
+                    '/opt/ibm/spectrum_mpi/lib/pami_port')
+shell.prepend_path ('LD_PRELOAD',
+                    '/opt/ibm/spectrum_mpi/lib/libpami_cudahook.so')
 
 plugin.register {
     name = "spectrum",
@@ -76,7 +48,6 @@ plugin.register {
         }
     }
 }
-
 
 -- vi: ts=4 sw=4 expandtab
 

--- a/t/t3001-mpi-personalities.t
+++ b/t/t3001-mpi-personalities.t
@@ -60,6 +60,18 @@ test_expect_success NO_ASAN "spectrum mpi only enabled with option" '
   grep /opt/ibm/spectrum spectrum.out
 '
 
+test_expect_success NO_ASAN "spectrum mpi also enabled with spectrum@version" '
+  LD_PRELOAD_saved=${LD_PRELOAD} &&
+  unset LD_PRELOAD &&
+  test_when_finished "export LD_PRELOAD=${LD_PRELOAD_saved}" &&
+  flux mini run -n${SIZE} -N${SIZE} \
+    -o mpi=spectrum@10.4 --dry-run printenv LD_PRELOAD > j.spectrum &&
+  test_expect_code 1 run_program 15 ${SIZE} ${SIZE} printenv LD_PRELOAD &&
+  jobid=$(flux job submit j.spectrum) &&
+  flux job attach ${jobid} > spectrum.out &&
+  grep /opt/ibm/spectrum spectrum.out
+'
+
 test_expect_success 'spectrum mpi sets OMPI_COMM_WORLD_RANK' '
   flux mini run -n${SIZE} -N${SIZE} \
     -o mpi=spectrum --dry-run printenv OMPI_COMM_WORLD_RANK > j.spectrum &&

--- a/t/t3001-mpi-personalities.t
+++ b/t/t3001-mpi-personalities.t
@@ -48,21 +48,21 @@ test_expect_success "intel mpi only rewrites when necessary" '
    test "$(wc -l intel-mpi.unset | cut -f 1 -d " ")" = "0"
 '
 
-test_expect_success NO_ASAN,HAVE_JQ "spectrum mpi only enabled with option" '
+test_expect_success NO_ASAN "spectrum mpi only enabled with option" '
   LD_PRELOAD_saved=${LD_PRELOAD} &&
   unset LD_PRELOAD &&
   test_when_finished "export LD_PRELOAD=${LD_PRELOAD_saved}" &&
-  flux jobspec srun -n${SIZE} -N${SIZE} printenv LD_PRELOAD \
-    | jq ".attributes.system.shell.options.mpi = \"spectrum\"" > j.spectrum &&
+  flux mini run -n${SIZE} -N${SIZE} \
+    -o mpi=spectrum --dry-run printenv LD_PRELOAD > j.spectrum &&
   test_expect_code 1 run_program 15 ${SIZE} ${SIZE} printenv LD_PRELOAD &&
   jobid=$(flux job submit j.spectrum) &&
   flux job attach ${jobid} > spectrum.out &&
   grep /opt/ibm/spectrum spectrum.out
 '
 
-test_expect_success HAVE_JQ 'spectrum mpi sets OMPI_COMM_WORLD_RANK' '
-  flux jobspec srun -n${SIZE} -N${SIZE} printenv OMPI_COMM_WORLD_RANK \
-    | jq ".attributes.system.shell.options.mpi = \"spectrum\"" > j.spectrum &&
+test_expect_success 'spectrum mpi sets OMPI_COMM_WORLD_RANK' '
+  flux mini run -n${SIZE} -N${SIZE} \
+    -o mpi=spectrum --dry-run printenv OMPI_COMM_WORLD_RANK > j.spectrum &&
   jobid=$(flux job submit j.spectrum) &&
   flux job attach ${jobid} | sort -n > spectrum.rank.out &&
   test_debug "cat spectrum.rank.out" &&


### PR DESCRIPTION
As described in #3855, it would be helpful if there was a way to abstract commonly useful functionality for the MPI personality plugins in the shell (and other Lua-plugins). This PR creates and installs a `00-lib.lua` "plugin", and collects some new and existing common functions that will be available in all other shell Lua plugins (assuming that `00-lib.lua` is sourced before other lua.d files)

A new `shell.getopt_with_version (name)` function is introduced, which automatically splits a top-level shell option `name` into a `value` and `version` parts, separated by `@` (assuming that is the separator of choice).
E.g. if `-o mpi=spectrum@10.4` then
```lua
    local mpi, version = shell.getopt_with_version ("mpi")
```
would return `"spectrum", "10.4"`. The `spectrum.lua` plugin could then take version-dependent action by checking if `version` is set (not `nil`). 

Some of the other functions in `spectrum.lua` were preemptively moved to `00-lib.lua`, even though there are not yet other users.
