### PR TITLE
NEWS.md: Fix typo for v0.29.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-flux-core version 0.28.0 - 2021-09-03
+flux-core version 0.29.0 - 2021-09-03
 -------------------------------------
 
 This release of Flux includes a new fault mechanism which ensures that


### PR DESCRIPTION
I just noticed that the release notes for flux-core v0.29.0 reference v0.28.0. Sorry!

This PR fixes that blunder.