### PR TITLE
WIP: add pmix shell plugin

### DIFF
--- a/config/x_ac_pmix.m4
+++ b/config/x_ac_pmix.m4
@@ -3,9 +3,18 @@
 AC_DEFUN([X_AC_PMIX], [
     AC_ARG_ENABLE([pmix-bootstrap],
         AS_HELP_STRING([--enable-pmix-bootstrap], [Enable flux broker to bootstrap with pmix, if offered by foreign resource manager]))
+    AC_ARG_ENABLE([pmix-shell-plugin],
+        AS_HELP_STRING([--enable-pmix-shell-plugin], [Enable flux shell to offer pmix service to select openmpi jobs]))
     AS_IF([test "x$enable_pmix_bootstrap" = "xyes"], [
         AC_DEFINE([BROKER_PMIX], [1], [Enable flux broker pmix bootstrap])
+    ])
+    AS_IF([test "x$enable_pmix_shell_plugin" = "xyes"], [
+        AC_DEFINE([SHELL_PMIX], [1], [Enable flux shell pmix plugin])
+    ])
+
+    AS_IF([test "x$enable_pmix_bootstrap" = "xyes" -o "x$enable_pmix_shell_plugin" = "xyes"], [
         PKG_CHECK_MODULES([PMIX], [pmix])
     ])
     AM_CONDITIONAL([BROKER_PMIX], [test "x$enable_pmix_bootstrap" = "xyes"])
+    AM_CONDITIONAL([SHELL_PMIX], [test "x$enable_pmix_shell_plugin" = "xyes"])
 ])

--- a/config/x_ac_pmix.m4
+++ b/config/x_ac_pmix.m4
@@ -1,10 +1,11 @@
-# It is fatal if --enable-pmix-bootstrap and pmix package not found.
+# It is fatal if --enable-pmix-* and pmix package not found.
 # (PKG_CHECK_MODULES default behavior is to fail if package not found)
 AC_DEFUN([X_AC_PMIX], [
     AC_ARG_ENABLE([pmix-bootstrap],
-        AS_HELP_STRING([--enable-pmix-bootstrap], [Enable PMIx bootstrap]))
+        AS_HELP_STRING([--enable-pmix-bootstrap], [Enable flux broker to bootstrap with pmix, if offered by foreign resource manager]))
     AS_IF([test "x$enable_pmix_bootstrap" = "xyes"], [
+        AC_DEFINE([BROKER_PMIX], [1], [Enable flux broker pmix bootstrap])
         PKG_CHECK_MODULES([PMIX], [pmix])
-        AC_DEFINE([HAVE_LIBPMIX], [1], [Enable PMIx bootstrap])
     ])
+    AM_CONDITIONAL([BROKER_PMIX], [test "x$enable_pmix_bootstrap" = "xyes"])
 ])

--- a/src/broker/Makefile.am
+++ b/src/broker/Makefile.am
@@ -73,8 +73,11 @@ flux_broker_LDADD = \
 	$(ZMQ_LIBS) \
 	$(LIBUUID_LIBS) \
 	$(JANSSON_LIBS) \
-	$(PMIX_LIBS) \
 	$(LIBDL)
+
+if BROKER_PMIX
+flux_broker_LDADD += $(PMIX_LIBS)
+endif
 
 flux_broker_LDFLAGS =
 
@@ -95,8 +98,11 @@ test_ldadd = \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libtap/libtap.la \
 	$(ZMQ_LIBS) \
-	$(JANSSON_LIBS) \
-	$(PMIX_LIBS)
+	$(JANSSON_LIBS)
+
+if BROKER_PMIX
+test_ldadd += $(PMIX_LIBS)
+endif
 
 test_ldflags = \
 	-no-install

--- a/src/broker/runat.c
+++ b/src/broker/runat.c
@@ -65,7 +65,7 @@ static const char *env_blocklist[] = {
     "PMI_FD",
     "PMI_RANK",
     "PMI_SIZE",
-#ifdef HAVE_LIBPMIX
+#ifdef BROKER_PMIX
     "PMIX_NAMESPACE",
     "PMIX_VERSION",
     "PMIX_SERVER_URI41",

--- a/src/cmd/builtin/version.c
+++ b/src/cmd/builtin/version.c
@@ -11,7 +11,7 @@
 #if HAVE_CONFIG_H
 # include <config.h>
 #endif
-#if HAVE_LIBPMIX
+#ifdef BROKER_PMIX
 # include <pmix.h>
 #endif
 #include <hwloc.h>
@@ -64,8 +64,8 @@ static int cmd_version (optparse_t *p, int ac, char *av[])
 #if HAVE_CALIPER
     printf ("+caliper");
 #endif
-#if HAVE_LIBPMIX
-    printf ("+pmix-bootstrap==%ld.%ld.%ld",
+#ifdef BROKER_PMIX
+    printf ("+pmix==%ld.%ld.%ld",
             PMIX_VERSION_MAJOR,
             PMIX_VERSION_MINOR,
             PMIX_VERSION_RELEASE);

--- a/src/cmd/builtin/version.c
+++ b/src/cmd/builtin/version.c
@@ -11,7 +11,7 @@
 #if HAVE_CONFIG_H
 # include <config.h>
 #endif
-#ifdef BROKER_PMIX
+#if defined (BROKER_PMIX) || defined (SHELL_PMIX)
 # include <pmix.h>
 #endif
 #include <hwloc.h>
@@ -64,7 +64,7 @@ static int cmd_version (optparse_t *p, int ac, char *av[])
 #if HAVE_CALIPER
     printf ("+caliper");
 #endif
-#ifdef BROKER_PMIX
+#if defined (BROKER_PMIX) || defined (SHELL_PMIX)
     printf ("+pmix==%ld.%ld.%ld",
             PMIX_VERSION_MAJOR,
             PMIX_VERSION_MINOR,

--- a/src/shell/Makefile.am
+++ b/src/shell/Makefile.am
@@ -163,7 +163,7 @@ TESTS = \
 
 if SHELL_PMIX
 TESTS += \
-	plugins/pmix/test/codec.t
+	plugins/pmix/test_codec.t
 endif
 
 
@@ -182,6 +182,12 @@ test_cppflags = \
 
 
 check_PROGRAMS = $(TESTS)
+
+if SHELL_PMIX
+check_PROGRAMS += \
+	plugins/pmix/test_barrier \
+	plugins/pmix/test_bizcard
+endif
 
 check_LTLIBRARIES = \
 	test/a/plugin.la \
@@ -267,6 +273,29 @@ plugins_pmix_test_codec_t_LDADD = \
 	$(test_ldadd)
 plugins_pmix_test_codec_t_LDFLAGS = \
 	$(test_ldflags)
+
+plugins_pmix_test_barrier_SOURCES = \
+	plugins/pmix/test/barrier.c
+plugins_pmix_test_barrier_CPPFLAGS = \
+	$(PMIX_CFLAGS) \
+	$(test_cppflags)
+plugins_pmix_test_barrier_LDADD = \
+	$(PMIX_LIBS) \
+	$(test_ldadd)
+plugins_pmix_test_barrier_LDFLAGS = \
+	$(test_ldflags)
+
+plugins_pmix_test_bizcard_SOURCES = \
+	plugins/pmix/test/bizcard.c
+plugins_pmix_test_bizcard_CPPFLAGS = \
+	$(PMIX_CFLAGS) \
+	$(test_cppflags)
+plugins_pmix_test_bizcard_LDADD = \
+	$(PMIX_LIBS) \
+	$(test_ldadd)
+plugins_pmix_test_bizcard_LDFLAGS = \
+	$(test_ldflags)
+
 
 .PHONY: link-shell-plugins clean-shell-plugins
 

--- a/src/shell/Makefile.am
+++ b/src/shell/Makefile.am
@@ -110,6 +110,46 @@ flux_shell_LDFLAGS = \
 	-export-dynamic \
 	-Wl,--version-script=$(srcdir)/flux-shell.map
 
+if SHELL_PMIX
+shell_plugin_LTLIBRARIES = \
+	plugins/pmix/pmix.la
+endif
+
+plugins_pmix_pmix_la_SOURCES = \
+	plugins/pmix/pmix.c \
+	plugins/pmix/server.h \
+	plugins/pmix/server.c \
+	plugins/pmix/codec.h \
+	plugins/pmix/codec.c \
+	plugins/pmix/synchro.h \
+	plugins/pmix/synchro.c \
+	plugins/pmix/infovec.h \
+	plugins/pmix/infovec.c \
+	plugins/pmix/map.h \
+	plugins/pmix/map.c \
+	plugins/pmix/dmodex.h \
+	plugins/pmix/dmodex.c \
+	plugins/pmix/socketpair.h \
+	plugins/pmix/socketpair.c \
+	pmi/pmi_exchange.c \
+	pmi/pmi_exchange.h
+plugins_pmix_pmix_la_CPPFLAGS = \
+	$(AM_CPPFLAGS) \
+	$(PMIX_CFLAGS) \
+	$(ZMQ_CFLAGS)
+plugins_pmix_pmix_la_LIBADD = \
+	$(builddir)/libshell.la \
+	$(top_builddir)/src/common/libflux-internal.la \
+	$(top_builddir)/src/common/libzmqutil/libzmqutil.la \
+	$(top_builddir)/src/common/librlist/librlist.la \
+	$(PMIX_LIBS) \
+	$(ZMQ_LIBS)
+plugins_pmix_pmix_la_LDFLAGS = \
+	$(AM_LDFLAGS) \
+	$(fluxplugin_ldflags) \
+	-module
+
+
 EXTRA_DIST = \
 	flux-shell.map
 

--- a/src/shell/Makefile.am
+++ b/src/shell/Makefile.am
@@ -161,6 +161,12 @@ TESTS = \
 	mpir/test_nodelist.t \
 	mpir/test_proctable.t
 
+if SHELL_PMIX
+TESTS += \
+	plugins/pmix/test/codec.t
+endif
+
+
 test_ldadd = \
 	$(top_builddir)/src/common/libflux-core.la \
 	$(top_builddir)/src/common/libpmi/libpmi_server.la \
@@ -250,6 +256,17 @@ test_mustache_t_LDADD = \
 test_mustache_t_LDFLAGS = \
 	$(test_ldflags)
 
+plugins_pmix_test_codec_t_SOURCES = \
+	plugins/pmix/codec.c \
+	plugins/pmix/test/codec.c
+plugins_pmix_test_codec_t_CPPFLAGS = \
+	$(PMIX_CFLAGS) \
+	$(test_cppflags)
+plugins_pmix_test_codec_t_LDADD = \
+	$(JANSSON_LIBS) \
+	$(test_ldadd)
+plugins_pmix_test_codec_t_LDFLAGS = \
+	$(test_ldflags)
 
 .PHONY: link-shell-plugins clean-shell-plugins
 

--- a/src/shell/lua.d/openmpi.lua
+++ b/src/shell/lua.d/openmpi.lua
@@ -8,8 +8,16 @@
 -- SPDX-License-Identifier: LGPL-3.0
 -------------------------------------------------------------
 
-shell.setenv ("OMPI_MCA_pmix", "flux")
-shell.setenv ("OMPI_MCA_schizo", "flux")
+local mpi, version = shell.getopt_with_version ("mpi")
+
+if mpi == "openmpi" and version == "5" then
+    shell.setenv ("OMPI_MCA_pmix", "^flux")
+    shell.setenv ("OMPI_MCA_schizo", "^flux")
+    plugin.load ("pmix/pmix.so")
+else
+    shell.setenv ("OMPI_MCA_pmix", "flux")
+    shell.setenv ("OMPI_MCA_schizo", "flux")
+end
 
 -- OpenMPI needs a job-unique directory for vader shmem paths, otherwise
 -- multiple jobs per node may conflict (see flux-framework/flux-core#3649).

--- a/src/shell/plugins/pmix/codec.c
+++ b/src/shell/plugins/pmix/codec.c
@@ -1,0 +1,411 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* codec.c - encode/decode functions betwen pmix data structures and json */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <sys/types.h>
+#include <jansson.h>
+#include <pmix_server.h>
+
+#include "src/common/libutil/log.h"
+#include "src/common/libccan/ccan/base64/base64.h"
+
+#include "codec.h"
+
+json_t *pp_pointer_encode (void *ptr)
+{
+    return json_integer ((uintptr_t)ptr);
+}
+
+int pp_pointer_decode (json_t *o, void **ptr)
+{
+    if (!json_is_integer (o))
+        return -1;
+    *ptr = (void *)json_integer_value (o);
+    return 0;
+}
+
+json_t *pp_data_encode (const void *data, size_t length)
+{
+    int xlength = base64_encoded_length (length) + 1; // +1 for \0 term
+    char *xdata;
+    json_t *o = NULL;
+
+    if (!(xdata = malloc (xlength))
+        || base64_encode (xdata, xlength, data, length) < 0
+        || !(o = json_string (xdata))) {
+        free (xdata);
+        return NULL;
+    }
+    free (xdata);
+    return o;
+}
+
+ssize_t pp_data_decode_bufsize (json_t *o)
+{
+    if (!json_is_string (o))
+        return -1;
+
+    int xlength = json_string_length (o);
+    size_t length = base64_decoded_length (xlength);
+
+    return length;
+}
+
+ssize_t pp_data_decode_tobuf (json_t *o, void *data, size_t length)
+{
+    if (!json_is_string (o))
+        return -1;
+
+    int xlength = json_string_length (o);
+    const void *xdata = json_string_value (o);
+
+    return base64_decode (data, length, xdata, xlength);
+}
+
+int pp_data_decode (json_t *o, void **datap, size_t *lengthp)
+{
+    ssize_t bufsize;
+    ssize_t length;
+    void *data;
+
+    if ((bufsize = pp_data_decode_bufsize (o)) < 0)
+        return -1;
+    if (!(data = malloc (bufsize))
+        || (length = pp_data_decode_tobuf (o, data, bufsize)) < 0) {
+        free (data);
+        return -1;
+    }
+    *datap = data;
+    *lengthp = length;
+    return 0;
+}
+
+json_t *pp_proc_encode (const pmix_proc_t *proc)
+{
+    return json_pack ("{s:s s:i}",
+                      "nspace", proc->nspace,
+                      "rank", proc->rank);
+}
+
+int pp_proc_decode (json_t *o, pmix_proc_t *proc)
+{
+    const char *nspace;
+    int rank;
+
+    if (json_unpack (o,
+                     "{s:s s:i}",
+                     "nspace", &nspace,
+                     "rank", &rank) < 0)
+        return -1;
+    proc->rank = rank;
+    strncpy (proc->nspace, nspace, PMIX_MAX_NSLEN);
+    proc->nspace[PMIX_MAX_NSLEN] = '\0';
+    return 0;
+}
+
+json_t *pp_proc_array_encode (const pmix_proc_t *procs, size_t nprocs)
+{
+    json_t *o;
+    json_t *entry;
+    int i;
+
+    if (!(o = json_array ()))
+        return NULL;
+    for (i = 0; i < nprocs; i++) {
+        if (!(entry = pp_proc_encode (&procs[i]))
+            || json_array_append_new (o, entry) < 0) {
+            json_decref (entry);
+            json_decref (o);
+            return NULL;
+        }
+    }
+    return o;
+}
+
+int pp_proc_array_decode (json_t *o, pmix_proc_t **procsp, size_t *nprocsp)
+{
+    pmix_proc_t *procs;
+    size_t nprocs = json_array_size (o);
+    size_t index;
+    json_t *value;
+
+    if (!json_is_array (o)
+        || !(procs = calloc (nprocs, sizeof (procs[0]))))
+        return -1;
+    json_array_foreach (o, index, value) {
+        if (pp_proc_decode (value, &procs[index]) < 0) {
+            free (procs);
+            return -1;
+        }
+    }
+    *procsp = procs;
+    *nprocsp = nprocs;
+    return 0;
+}
+
+json_t *pp_value_encode (const pmix_value_t *value)
+{
+    json_t *o = NULL;
+    json_t *data = NULL;
+
+    switch (value->type) {
+        case PMIX_BOOL:
+            data = value->data.flag ? json_true () : json_false ();
+            break;
+        case PMIX_BYTE:
+            data = json_integer (value->data.byte);
+            break;
+        case PMIX_STRING:
+            data = json_string (value->data.string);
+            break;
+        case PMIX_SIZE:
+            data = json_integer (value->data.size);
+            break;
+        case PMIX_PID:
+            data = json_integer (value->data.pid);
+            break;
+        case PMIX_INT:
+            data = json_integer (value->data.integer);
+            break;
+        case PMIX_INT8:
+            data = json_integer (value->data.int8);
+            break;
+        case PMIX_INT16:
+            data = json_integer (value->data.int16);
+            break;
+        case PMIX_INT32:
+            data = json_integer (value->data.int32);
+            break;
+        case PMIX_INT64:
+            data = json_integer (value->data.int64);
+            break;
+        case PMIX_UINT:
+            data = json_integer (value->data.uint);
+            break;
+        case PMIX_UINT8:
+            data = json_integer (value->data.uint8);
+            break;
+        case PMIX_UINT16:
+            data = json_integer (value->data.uint16);
+            break;
+        case PMIX_UINT32:
+            data = json_integer (value->data.uint32);
+            break;
+        case PMIX_UINT64:
+            data = json_integer (value->data.uint64);
+            break;
+        case PMIX_FLOAT:
+            data = json_real (value->data.fval);
+            break;
+        case PMIX_DOUBLE:
+            data = json_real (value->data.dval);
+            break;
+        case PMIX_TIMEVAL: // struct timeval
+            data = json_pack ("{s:I s:I}",
+                              "sec", (intmax_t)value->data.tv.tv_sec,
+                              "usec", (intmax_t)value->data.tv.tv_usec);
+            break;
+        case PMIX_TIME: // time_t
+            data = json_integer (value->data.time);
+            break;
+        case PMIX_STATUS: // pmix_status_t
+            data = json_integer (value->data.status);
+            break;
+        case PMIX_PROC: // pmix_proc_t *
+            data = pp_proc_encode (value->data.proc);
+            break;
+        default:
+            log_msg ("pmix: unsupported value encoding %d", value->type);
+            break;
+    }
+    if (data) {
+        o = json_pack ("{s:i s:O}",
+                       "type", value->type,
+                       "data", data);
+        json_decref (data);
+    }
+    return o;
+}
+
+void pp_value_release (pmix_value_t *value)
+{
+    switch (value->type) {
+        case PMIX_PROC:
+            free (value->data.proc);
+            break;
+        case PMIX_STRING:
+            free (value->data.string);
+            break;
+    }
+}
+
+/* N.B. for some types, memory is allocated and assigned to value->data
+ * that must be freed with pp_value_release().
+ */
+int pp_value_decode (json_t *o, pmix_value_t *value)
+{
+    int type;
+    json_t *data;
+
+    if (json_unpack (o,
+                     "{s:i s:o}",
+                     "type", &type,
+                     "data", &data) < 0)
+        return -1;
+    switch (type) {
+        case PMIX_BOOL:
+            value->data.flag = json_is_false (data) ? 0 : 1;
+            break;
+        case PMIX_BYTE:
+            value->data.byte = json_integer_value (data);
+            break;
+        case PMIX_STRING: {
+            char *cpy;
+            if (!(cpy = strdup (json_string_value (data))))
+                return -1;
+            value->data.string = cpy;
+            break;
+        }
+        case PMIX_SIZE:
+            value->data.size = json_integer_value (data);
+            break;
+        case PMIX_PID:
+            value->data.pid = json_integer_value (data);
+            break;
+        case PMIX_INT:
+            value->data.integer = json_integer_value (data);
+            break;
+        case PMIX_INT8:
+            value->data.int8 = json_integer_value (data);
+            break;
+        case PMIX_INT16:
+            value->data.int16 = json_integer_value (data);
+            break;
+        case PMIX_INT32:
+            value->data.int32 = json_integer_value (data);
+            break;
+        case PMIX_INT64:
+            value->data.int64 = json_integer_value (data);
+            break;
+        case PMIX_UINT:
+            value->data.uint = json_integer_value (data);
+            break;
+        case PMIX_UINT8:
+            value->data.uint8 = json_integer_value (data);
+            break;
+        case PMIX_UINT16:
+            value->data.uint16 = json_integer_value (data);
+            break;
+        case PMIX_UINT32:
+            value->data.uint32 = json_integer_value (data);
+            break;
+        case PMIX_UINT64:
+            value->data.uint64 = json_integer_value (data);
+            break;
+        case PMIX_FLOAT:
+            value->data.fval = json_real_value (data);
+            break;
+        case PMIX_DOUBLE:
+            value->data.dval = json_real_value (data);
+            break;
+        case PMIX_TIMEVAL: {
+            json_int_t sec, usec;
+            if (json_unpack (data, "{s:I s:I}", &sec, &usec) < 0)
+                return -1;
+            value->data.tv.tv_sec = sec;
+            value->data.tv.tv_usec = usec;
+            break;
+        }
+        case PMIX_TIME: // time_t
+            value->data.time = json_integer_value (data);
+            break;
+        case PMIX_STATUS: // pmix_status_t
+            value->data.status = json_integer_value (data);
+            break;
+        case PMIX_PROC: {
+            pmix_proc_t *proc;
+            if (!(proc = calloc (1, sizeof (*proc)))
+                || pp_proc_decode (data, proc) < 0) {
+                free (proc);
+                return -1;
+            }
+            value->data.proc = proc;
+            break;
+        }
+        default:
+            return -1;
+    }
+    value->type = type;
+    return 0;
+}
+
+json_t *pp_info_encode (const pmix_info_t *info)
+{
+    json_t *o;
+    json_t *value;
+
+    if (!(value = pp_value_encode (&info->value)))
+        return NULL;
+    o = json_pack ("{s:s s:i s:O}",
+                   "key", info->key,
+                   "flags", info->flags,
+                   "value", value);
+    json_decref (value);
+    return o;
+}
+
+void pp_info_release (pmix_info_t *info)
+{
+    pp_value_release (&info->value);
+}
+
+int pp_info_decode (json_t *o, pmix_info_t *info)
+{
+    const char *key;
+    int flags;
+    json_t *xvalue;
+
+    if (json_unpack (o,
+                     "{s:s s:i s:o}",
+                     "key", &key,
+                     "flags", &flags,
+                     "value", &xvalue) < 0)
+        return -1;
+    if (pp_value_decode (xvalue, &info->value) < 0) // allocs mem
+        return -1;
+    strncpy (info->key, key, PMIX_MAX_KEYLEN);
+    info->key[PMIX_MAX_KEYLEN] = '\0';
+    return 0;
+}
+
+json_t *pp_info_array_encode (const pmix_info_t *info, size_t ninfo)
+{
+    json_t *o;
+    json_t *entry;
+    int i;
+
+    if (!(o = json_array ()))
+        return NULL;
+    for (i = 0; i < ninfo; i++) {
+        if (!(entry = pp_info_encode (&info[i]))
+            || json_array_append_new (o, entry) < 0) {
+            json_decref (entry);
+            json_decref (o);
+            return NULL;
+        }
+    }
+    return o;
+}
+
+// vi:tabstop=4 shiftwidth=4 expandtab

--- a/src/shell/plugins/pmix/codec.h
+++ b/src/shell/plugins/pmix/codec.h
@@ -1,0 +1,45 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#include <jansson.h>
+#include <pmix_server.h>
+
+#ifndef _PMIX_PP_CODEC_H
+#define _PMIX_PP_CODEC_H
+
+json_t *pp_pointer_encode (void *ptr);
+int pp_pointer_decode (json_t *o, void **ptr);
+
+json_t *pp_data_encode (const void *data, size_t length);
+int pp_data_decode (json_t *o, void **data, size_t *length);
+
+ssize_t pp_data_decode_bufsize (json_t *o);
+ssize_t pp_data_decode_tobuf (json_t *o, void *data, size_t buflen);
+
+json_t *pp_value_encode (const pmix_value_t *value);
+int pp_value_decode (json_t *o, pmix_value_t *value); // allocs internal mem
+void pp_value_release (pmix_value_t *value); // release internal mem from decode
+
+json_t *pp_info_encode (const pmix_info_t *info);
+int pp_info_decode (json_t *o, pmix_info_t *info); // allocs internal mem
+void pp_info_release (pmix_info_t *info); // release internal mem from decode
+
+json_t *pp_proc_encode (const pmix_proc_t *proc);
+int pp_proc_decode (json_t *o, pmix_proc_t *proc);
+
+json_t *pp_proc_array_encode (const pmix_proc_t *procs, size_t nprocs);
+int pp_proc_array_decode (json_t *o, pmix_proc_t **procs, size_t *nprocs);
+
+// decode info array with infovec_create_from_json()
+json_t *pp_info_array_encode (const pmix_info_t *info, size_t ninfo);
+
+#endif
+
+// vi:tabstop=4 shiftwidth=4 expandtab

--- a/src/shell/plugins/pmix/dmodex.c
+++ b/src/shell/plugins/pmix/dmodex.c
@@ -1,0 +1,211 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* dmodex.c - call PMIx_server_dmodex_request() remotely
+ *
+ * Implement a shell service method "pmix-dmodex" that calls
+ * the above function and returns the results.
+ * The service is registered with pp_dmodex_service_register().
+ *
+ * The "client" end is wrapped in a function that returns a future,
+ * with accessors for the returned data and the status.
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/core.h>
+#include <flux/shell.h>
+#include <pmix_server.h>
+
+#include "src/common/libutil/errno_safe.h"
+
+#include "internal.h"
+#include "task.h"
+
+#include "codec.h"
+#include "dmodex.h"
+
+/**
+ ** Server
+ **/
+
+struct dmodex {
+    flux_t *h;
+    const flux_msg_t *msg;
+};
+
+static void dmodex_destroy (struct dmodex *dm)
+{
+    if (dm) {
+        int saved_errno = errno;
+        flux_msg_decref (dm->msg);
+        free (dm);
+        errno = saved_errno;
+    }
+}
+
+static struct dmodex *dmodex_create (flux_t *h, const flux_msg_t *msg)
+{
+    struct dmodex *dm;
+    if (!(dm = calloc (1, sizeof (*dm))))
+        return NULL;
+    dm->h = h;
+    dm->msg = flux_msg_incref (msg);
+    return dm;
+}
+
+// N.B. pmix_dmodex_response_fn_t signature
+static void dmodex_response_cb (pmix_status_t status,
+                                char *data,
+                                size_t ndata,
+                                void *cbdata)
+{
+    struct dmodex *dm = cbdata;
+    json_t *xdata;
+
+    if (!(xdata = pp_data_encode (data, ndata))) {
+        errno = ENOMEM;
+        goto error;
+    }
+    if (flux_respond_pack (dm->h,
+                           dm->msg,
+                           "{s:i s:O}",
+                           "status", status,
+                           "data", xdata) < 0)
+        shell_warn ("error responding to pmix-dmodex request");
+    json_decref (xdata);
+    dmodex_destroy (dm);
+    return;
+error:
+    if (flux_respond_error (dm->h, dm->msg, errno, NULL) < 0)
+        shell_warn ("error responding to pmix-dmodex request");
+    dmodex_destroy (dm);
+}
+
+static void dmodex_request_cb (flux_t *h,
+                               flux_msg_handler_t *mh,
+                               const flux_msg_t *msg,
+                               void *arg)
+{
+    struct psrv *psrv = arg;
+    json_t *xproc;
+    pmix_proc_t proc;
+    struct dmodex *dm = NULL;
+    int rc;
+
+    if (flux_request_unpack (msg, NULL, "{s:o}", "proc", &xproc) < 0)
+        goto error;
+    if (pp_proc_decode (xproc, &proc) < 0) {
+        errno = EPROTO;
+        goto error;
+    }
+    if (!(dm = dmodex_create (h, msg)))
+        goto error;
+    rc = pp_server_dmodex_request (psrv, &proc, dmodex_response_cb, dm);
+    if (rc != PMIX_SUCCESS) {
+        json_t *xdata;
+        if (!(xdata = pp_data_encode ("", 0)))
+            goto error;
+        if (flux_respond_pack (dm->h,
+                               dm->msg,
+                               "{s:i s:O}",
+                               "status", rc,
+                               "data", xdata) < 0)
+            shell_warn ("error responding to pmix-dmodex request");
+        json_decref (xdata);
+        dmodex_destroy (dm);
+    }
+    return;
+error:
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
+        goto error;
+    dmodex_destroy (dm);
+}
+
+int pp_dmodex_service_register (flux_shell_t *shell, struct psrv *psrv)
+{
+    return flux_shell_service_register (shell,
+                                        "pmix-dmodex",
+                                        dmodex_request_cb,
+                                        psrv);
+}
+
+/**
+ ** Client
+ **/
+
+/* what shell rank hosts proc->rank? */
+static int lookup_shell_rank (flux_shell_t *shell, const pmix_proc_t *proc)
+{
+    int shell_rank;
+
+    for (shell_rank = 0; shell_rank < shell->info->shell_size; shell_rank++) {
+        struct rcalc_rankinfo ri;
+        if (rcalc_get_nth (shell->info->rcalc, shell_rank, &ri) < 0)
+            goto error;
+        if (proc->rank >= ri.global_basis
+            && proc->rank < ri.global_basis + ri.ntasks)
+            return shell_rank;
+    }
+error:
+    errno = ENOENT;
+    return -1;
+}
+
+flux_future_t *pp_dmodex (flux_shell_t *shell, const pmix_proc_t *proc)
+{
+    flux_future_t *f;
+    int shell_rank;
+    json_t *xproc;
+
+    if ((shell_rank = lookup_shell_rank (shell, proc)) < 0)
+        return NULL;
+    if (!(xproc = pp_proc_encode (proc))) {
+        errno = ENOMEM;
+        return NULL;
+    }
+    shell_trace ("pmix-dmodex rpc shell_rank %d proc %d",
+                 shell_rank, proc->rank);
+    f = flux_shell_rpc_pack (shell,
+                             "pmix-dmodex",
+                              shell_rank,
+                              0,
+                              "{s:O}",
+                              "proc", xproc);
+    ERRNO_SAFE_WRAP (json_decref, xproc);
+    return f;
+}
+
+int pp_dmodex_get_status (flux_future_t *f, pmix_status_t *status)
+{
+    if (flux_rpc_get_unpack (f, "{s:i}", "status", status) < 0)
+        return -1;
+    return 0;
+
+}
+int pp_dmodex_get_data (flux_future_t *f, void **datap, int *sizep)
+{
+    json_t *xdata;
+    void *data;
+    size_t size;
+
+    if (flux_rpc_get_unpack (f, "{s:o}", "data", &xdata) < 0)
+        return -1;
+    if (pp_data_decode (xdata, &data, &size) < 0) {
+        errno = EPROTO;
+        return -1;
+    }
+    *datap = data;
+    *sizep = size;
+    return 0;
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/src/shell/plugins/pmix/dmodex.h
+++ b/src/shell/plugins/pmix/dmodex.h
@@ -1,0 +1,30 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _PMIX_PP_DIRECT_H
+#define _PMIX_PP_DIRECT_H
+
+#include <flux/core.h>
+#include <flux/shell.h>
+#include <pmix_server.h>
+
+#include "server.h"
+
+flux_future_t *pp_dmodex (flux_shell_t *shell, const pmix_proc_t *proc);
+
+int pp_dmodex_get_status (flux_future_t *f, pmix_status_t *status);
+// caller must free data
+int pp_dmodex_get_data (flux_future_t *f, void **data, int *size);
+
+int pp_dmodex_service_register (flux_shell_t *shell, struct psrv *psrv);
+
+#endif
+
+// vi:ts=4 sw=4 expandtab

--- a/src/shell/plugins/pmix/infovec.c
+++ b/src/shell/plugins/pmix/infovec.c
@@ -93,6 +93,32 @@ int pp_infovec_set_u32 (struct infovec *iv, const char *key, uint32_t value)
     return 0;
 }
 
+int pp_infovec_set_bool (struct infovec *iv, const char *key, bool value)
+{
+    pmix_info_t *info;
+
+    if (!(info = alloc_slot (iv)))
+        return -1;
+    strncpy (info->key, key, PMIX_MAX_KEYLEN);
+    info->value.type = PMIX_BOOL;
+    info->value.data.flag = value;
+    return 0;
+}
+
+int pp_infovec_set_rank (struct infovec *iv,
+                         const char *key,
+                         pmix_rank_t value)
+{
+    pmix_info_t *info;
+
+    if (!(info = alloc_slot (iv)))
+        return -1;
+    strncpy (info->key, key, PMIX_MAX_KEYLEN);
+    info->value.type = PMIX_PROC_RANK;
+    info->value.data.rank = value;
+    return 0;
+}
+
 struct infovec *pp_infovec_create (void)
 {
     struct infovec *iv;

--- a/src/shell/plugins/pmix/infovec.c
+++ b/src/shell/plugins/pmix/infovec.c
@@ -1,0 +1,125 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* infovec.c - helper class for working with pmix_info_t arrays
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <errno.h>
+#include <jansson.h>
+#include <pmix_server.h>
+
+#include "infovec.h"
+#include "codec.h"
+
+#define INFOVEC_CHUNK 8
+
+struct infovec {
+    int length;
+    int count;
+    pmix_info_t *info;
+};
+
+int pp_infovec_count (struct infovec *iv)
+{
+    return iv->count;
+}
+
+pmix_info_t *pp_infovec_info (struct infovec *iv)
+{
+    return iv->info;
+}
+
+void pp_infovec_destroy (struct infovec *iv)
+{
+    if (iv) {
+        int saved_errno = errno;
+        for (int i = 0; i < iv->count; i++)
+            pp_info_release (&iv->info[i]);
+        free (iv);
+        errno = saved_errno;
+    }
+}
+
+static pmix_info_t *alloc_slot (struct infovec *iv)
+{
+    if (iv->count == iv->length) {
+        int new_length = iv->length + INFOVEC_CHUNK;
+        size_t new_size = sizeof (iv->info[0]) * new_length;
+        pmix_info_t *new_info;
+
+        if (!(new_info = realloc (iv->info, new_size)))
+            return NULL;
+        iv->info = new_info;
+        iv->length = new_length;
+    }
+    return &iv->info[iv->count++];
+}
+
+int pp_infovec_set_str (struct infovec *iv, const char *key, const char *val)
+{
+    char *cpy;
+    pmix_info_t *info;
+
+    if (!(cpy = strdup (val))
+        || !(info = alloc_slot (iv))) {
+        free (cpy);
+        return -1;
+    }
+    strncpy (info->key, key, PMIX_MAX_KEYLEN);
+    info->value.type = PMIX_STRING;
+    info->value.data.string = cpy;
+    return 0;
+}
+
+int pp_infovec_set_u32 (struct infovec *iv, const char *key, uint32_t value)
+{
+    pmix_info_t *info;
+
+    if (!(info = alloc_slot (iv)))
+        return -1;
+    strncpy (info->key, key, PMIX_MAX_KEYLEN);
+    info->value.type = PMIX_UINT32;
+    info->value.data.uint32 = value;
+    return 0;
+}
+
+struct infovec *pp_infovec_create (void)
+{
+    struct infovec *iv;
+    if (!(iv = calloc (1, sizeof (*iv))))
+        return NULL;
+    return iv;
+}
+
+struct infovec *pp_infovec_create_from_json (json_t *o)
+{
+    size_t index;
+    json_t *value;
+    struct infovec *iv;
+    pmix_info_t *info;
+
+    if ( !json_is_array (o)
+        || !(iv = pp_infovec_create ()))
+        return NULL;
+    json_array_foreach (o, index, value) {
+        if (!(info = alloc_slot (iv))
+            || pp_info_decode (value, info) < 0)
+            goto error;
+    }
+    return iv;
+error:
+    pp_infovec_destroy (iv);
+    return NULL;
+}
+
+// vi:tabstop=4 shiftwidth=4 expandtab

--- a/src/shell/plugins/pmix/infovec.h
+++ b/src/shell/plugins/pmix/infovec.h
@@ -11,7 +11,7 @@
 #ifndef _PMIX_PP_CODEC
 #define _PMIX_PP_CODEC
 
-#include <pmix_server.h>
+#include <pmix.h>
 #include <jansson.h>
 
 struct infovec *pp_infovec_create (void);
@@ -20,6 +20,8 @@ void pp_infovec_destroy (struct infovec *iv);
 
 int pp_infovec_set_u32 (struct infovec *iv, const char *key, uint32_t val);
 int pp_infovec_set_str (struct infovec *iv, const char *key, const char *str);
+int pp_infovec_set_bool (struct infovec *iv, const char *key, bool val);
+int pp_infovec_set_rank (struct infovec *iv, const char *key, pmix_rank_t val);
 
 int pp_infovec_count (struct infovec *iv);
 pmix_info_t *pp_infovec_info (struct infovec *iv);

--- a/src/shell/plugins/pmix/infovec.h
+++ b/src/shell/plugins/pmix/infovec.h
@@ -1,0 +1,29 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _PMIX_PP_CODEC
+#define _PMIX_PP_CODEC
+
+#include <pmix_server.h>
+#include <jansson.h>
+
+struct infovec *pp_infovec_create (void);
+struct infovec *pp_infovec_create_from_json (json_t *o);
+void pp_infovec_destroy (struct infovec *iv);
+
+int pp_infovec_set_u32 (struct infovec *iv, const char *key, uint32_t val);
+int pp_infovec_set_str (struct infovec *iv, const char *key, const char *str);
+
+int pp_infovec_count (struct infovec *iv);
+pmix_info_t *pp_infovec_info (struct infovec *iv);
+
+#endif
+
+// vi:ts=4 sw=4 expandtab

--- a/src/shell/plugins/pmix/map.c
+++ b/src/shell/plugins/pmix/map.c
@@ -1,0 +1,117 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* map.c - generate map strings required to be set in pmix server nspace
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <argz.h>
+#include <jansson.h>
+#include <pmix_server.h>
+
+#include "src/common/libhostlist/hostlist.h"
+#include "src/common/librlist/rlist.h"
+
+#include "rcalc.h"
+
+/* Create a comma-separated list of hosts from 'hl' for input to
+ * PMIx_generate_regex().  IOW, like hostlist_encode() w/o range compression.
+ */
+static char *csv_from_hostlist (struct hostlist *hl)
+{
+    char *argz = NULL;
+    size_t argz_len = 0;
+    const char *host;
+
+    host = hostlist_first (hl);
+    while (host) {
+        if (argz_add (&argz, &argz_len, host) != 0) {
+            free (argz);
+            return NULL;
+        }
+        host = hostlist_next (hl);
+    }
+    argz_stringify (argz, argz_len, ',');
+    return argz;
+}
+
+char *pp_map_node_create (json_t *R)
+{
+    struct rlist *rl = NULL;
+    struct hostlist *hl = NULL;
+    char *csv = NULL;
+    char *value;
+
+    if (!(rl = rlist_from_json (R, NULL))
+        || !(hl = rlist_nodelist (rl))
+        || !(csv = csv_from_hostlist (hl))
+        || PMIx_generate_regex (csv, &value) != PMIX_SUCCESS)
+        value = NULL;
+
+    free (csv);
+    rlist_destroy (rl);
+    hostlist_destroy (hl);
+    return value;
+}
+
+/* Create a comma-separated list of ranks for tasks running on
+ * the node described by 'ri'.
+ */
+static char *rankset_create (struct rcalc_rankinfo *ri)
+{
+    struct idset *ids;
+    char *value;
+
+    if (!(ids = idset_create (0, IDSET_FLAG_AUTOGROW))
+        || idset_range_set (ids,
+                            ri->global_basis,
+                            ri->global_basis + ri->ntasks - 1) < 0
+        || !(value = idset_encode (ids, 0)))
+        value = NULL;
+    idset_destroy (ids);
+    return value;
+}
+
+char *pp_map_proc_create (int nnodes, rcalc_t *rcalc)
+{
+    char *argz = NULL;
+    size_t argz_len = 0;
+    char *value;
+
+    for (int i = 0; i < nnodes; i++) {
+        struct rcalc_rankinfo ri;
+        char *rankset = NULL;
+
+        if (rcalc_get_nth (rcalc, i, &ri) < 0
+            || !(rankset = rankset_create (&ri))
+            || argz_add (&argz, &argz_len, rankset) != 0) {
+            free (rankset);
+            free (argz);
+            return NULL;
+        }
+    }
+    argz_stringify (argz, argz_len, ';');
+    if (PMIx_generate_ppn (argz, &value) != PMIX_SUCCESS)
+        value = NULL;
+    free (argz);
+    return value;
+}
+
+char *pp_map_local_peers (int shell_rank, rcalc_t *rcalc)
+{
+    struct rcalc_rankinfo ri;
+    if (rcalc_get_nth (rcalc, shell_rank, &ri) < 0)
+        return NULL;
+    return rankset_create (&ri);
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/src/shell/plugins/pmix/map.h
+++ b/src/shell/plugins/pmix/map.h
@@ -1,0 +1,22 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _PMIX_PP_MAP_H
+#define _PMIX_PP_MAP_H
+
+#include <jansson.h>
+
+char *pp_map_node_create (json_t *R);
+char *pp_map_proc_create (int nnodes, rcalc_t *rcalc);
+char *pp_map_local_peers (int shell_rank, rcalc_t *rcalc);
+
+#endif
+
+// vi:ts=4 sw=4 expandtab

--- a/src/shell/plugins/pmix/pmix.c
+++ b/src/shell/plugins/pmix/pmix.c
@@ -1,0 +1,651 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* pmix.c - main pmix shell plugin
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <sys/types.h>
+#include <pthread.h>
+#include <flux/core.h>
+#include <pmix_server.h>
+#include <pmix.h>
+
+#include "internal.h"
+#include "task.h"
+
+#include "src/shell/pmi/pmi_exchange.h"
+
+#include "server.h"
+#include "synchro.h"
+#include "infovec.h"
+#include "map.h"
+#include "dmodex.h"
+#include "codec.h"
+
+#define PP_NSPACE_NAME  "flux"
+
+struct client {
+    pmix_proc_t proc;
+};
+
+struct pp {
+    flux_shell_t *shell;
+    struct psrv *psrv;
+    zlist_t *clients;
+    struct pmi_exchange *pmi_exchange;
+};
+
+/* This has to be global, since pmix_server_module_t callbacks don't have a way
+ * to pass in a user-supplied pointer.
+ */
+
+static struct pp *global_plugin_ctx;
+
+static int client_connected_cb (const pmix_proc_t *proc,
+                                void *server_object,
+                                pmix_op_cbfunc_t cbfunc,
+                                void *cbdata)
+{
+    //struct client *cli = server_object;
+
+    if (cbfunc)
+        cbfunc (PMIX_SUCCESS, cbdata);
+    return 0;
+}
+
+static int client_finalized_cb (const pmix_proc_t *proc,
+                                void *server_object,
+                                pmix_op_cbfunc_t cbfunc,
+                                void *cbdata)
+{
+    //struct client *cli = server_object;
+
+    if (cbfunc)
+        cbfunc (PMIX_SUCCESS, cbdata);
+    return 0;
+}
+
+static int abort_cb (const pmix_proc_t *proc,
+                     void *server_object,
+                     int status,
+                     const char msg[],
+                     pmix_proc_t procs[],
+                     size_t nprocs,
+                     pmix_op_cbfunc_t cbfunc,
+                     void *cbdata)
+{
+    struct client *cli = server_object;
+
+    shell_die (1, "pmix: rank %d called abort: %s", cli->proc.rank, msg);
+
+    if (cbfunc)
+        cbfunc (PMIX_SUCCESS, cbdata);
+    return 0;
+}
+
+/* Context used to pass upcall's callback pointers to rpc continuation,
+ * so it can make the upcall's callback after receiving a response.
+ * This is used by both fence_nb and direct_modex upcalls, since they have
+ * the same callback signature.
+ */
+struct modex_ctx {
+    pmix_modex_cbfunc_t cbfunc;
+    void *cbdata;
+};
+
+void modex_ctx_destroy (struct modex_ctx *ctx)
+{
+    if (ctx) {
+        int saved_errno = errno;
+        free (ctx);
+        errno = saved_errno;
+    }
+}
+
+static struct modex_ctx *modex_ctx_create (pmix_modex_cbfunc_t cbfunc,
+                                           void *cbdata)
+{
+    struct modex_ctx *ctx;
+
+    if (!(ctx = calloc (1, sizeof (*ctx))))
+        return NULL;
+    ctx->cbfunc = cbfunc;
+    ctx->cbdata = cbdata;
+    return ctx;
+}
+
+static json_t *dict_create (int shell_rank, void *data, size_t size)
+{
+    char key[16];
+    json_t *xdata;
+    json_t *dict = NULL;
+
+    snprintf (key, sizeof (key), "%d", shell_rank);
+    if ((xdata = pp_data_encode (data, size))) {
+        dict = json_pack ("{s:O}", key, xdata);
+        json_decref (xdata);
+    }
+    return dict;
+}
+
+static int dict_concat (json_t *dict, void **datap, size_t *sizep)
+{
+    const char *key;
+    json_t *value;
+    uint8_t *data;
+    ssize_t bufsize = 0;
+    ssize_t size = 0;
+
+    json_object_foreach (dict, key, value) {
+        ssize_t chunk;
+        if ((chunk = pp_data_decode_bufsize (value)) < 0)
+            return -1;
+        bufsize += chunk;
+    }
+    if (!(data = malloc (bufsize)))
+        return -1;
+
+    json_object_foreach (dict, key, value) {
+        ssize_t chunk;
+        chunk = pp_data_decode_tobuf (value, data + size, bufsize - size);
+        if (chunk < 0)
+            goto error;
+        size += chunk;
+    }
+    *datap = data;
+    *sizep = size;
+    return 0;
+error:
+    free (data);
+    return -1;
+}
+
+static void exchange_cb (struct pmi_exchange *pex, void *arg)
+{
+    struct modex_ctx *ctx = arg;
+
+    if (pmi_exchange_has_error (pex)) {
+        shell_warn ("pmix: exchange failed");
+        goto error;
+    }
+    if (ctx->cbfunc) {
+        void *data = NULL;
+        size_t ndata;
+        if (dict_concat (pmi_exchange_get_dict (pex), &data, &ndata) < 0) {
+            shell_warn ("pmix: error processing exchanged dict");
+            goto error;
+        }
+        ctx->cbfunc (PMIX_SUCCESS, data, ndata, ctx->cbdata, free, data);
+    }
+    return;
+error:
+    if (ctx->cbfunc)
+        ctx->cbfunc (PMIX_ERROR, NULL, 0, ctx->cbdata, NULL, NULL);
+}
+
+static int fence_nb_cb (const pmix_proc_t procs[],
+                        size_t nprocs,
+                        const pmix_info_t info[],
+                        size_t ninfo,
+                        char *data,
+                        size_t ndata,
+                        pmix_modex_cbfunc_t cbfunc,
+                        void *cbdata)
+{
+    struct pp *pp = global_plugin_ctx;
+    struct modex_ctx *ctx = NULL;
+    json_t *dict = NULL;
+    int rc = PMIX_ERROR;
+    int i;
+
+    /* Implementation requires full proc participation.
+     */
+    if (nprocs > 1 || procs[0].rank != PMIX_RANK_WILDCARD) {
+        shell_warn ("pmix: fence over proc subset is not supported by flux");
+        rc = PMIX_ERR_NOT_SUPPORTED;
+        goto error;
+    }
+
+    /* Process any info options from the server upcall.
+     */
+    for (i = 0; i < ninfo; i++) {
+        if (!strcmp (info[i].key, "pmix.collect")) {
+            if (info[i].value.type != PMIX_BOOL
+                || !info[i].value.data.flag)
+                goto error;
+        }
+        else {
+            int required = (info[i].flags & PMIX_INFO_REQD);
+            shell_warn ("pmix: unknown %s fence_nb info key: %s",
+                        required ? "required" : "optional",
+                        info[i].key);
+            if (required)
+                goto error;
+        }
+    }
+
+    if (!(dict = dict_create (pp->shell->info->shell_rank, data, ndata))
+        || !(ctx = modex_ctx_create (cbfunc, cbdata))
+        || pmi_exchange (pp->pmi_exchange, dict, exchange_cb, ctx) < 0) {
+        modex_ctx_destroy (ctx);
+        shell_warn ("pmix: error initiating exchange");
+        goto error;
+    }
+    json_decref (dict);
+    return 0;
+error:
+    if (cbfunc)
+        cbfunc (rc, NULL, 0, cbdata, NULL, NULL);
+    json_decref (dict);
+    return 0; // N.B. func return value is ignored - use cbfunc only
+}
+
+/* Finalize a direct modex upcall using info obtained from
+ * pmix-dmodex RPC to another shell.
+ */
+static void direct_modex_continuation (flux_future_t *f, void *arg)
+{
+    struct modex_ctx *ctx = flux_future_aux_get (f, "modex_ctx");
+    void *data;
+    int ndata;
+    int status;
+
+    if (pp_dmodex_get_status (f, &status) < 0) {
+        if (errno == ETIMEDOUT)
+            status = PMIX_ERR_TIMEOUT;
+        else
+            status = PMIX_ERROR;
+        goto error;
+    }
+    if (status != PMIX_SUCCESS)
+        goto error;
+    if (ctx->cbfunc) {
+        /* pp_dmodex_get_data() allocates data, then server releases it with
+         * free() b/c we tell it to with the last two cbfunc args
+         */
+        if (pp_dmodex_get_data (f, &data, &ndata) < 0) {
+            status = PMIX_ERROR;
+            goto error;
+        }
+        ctx->cbfunc (PMIX_SUCCESS, data, ndata, ctx->cbdata, free, data);
+    }
+    flux_future_destroy (f);
+    return;
+error:
+    if (ctx->cbfunc)
+        ctx->cbfunc (status, NULL, 0, ctx->cbdata, NULL, NULL);
+    flux_future_destroy (f);
+}
+
+/* This is the direct_modex upcall from the server.
+ * It makes the pmix-dmodex rpc, then continues executing
+ * in direct_modex_continuation() when response is received.
+ */
+static int direct_modex_cb (const pmix_proc_t *proc,
+                            const pmix_info_t info[],
+                            size_t ninfo,
+                            pmix_modex_cbfunc_t cbfunc,
+                            void *cbdata)
+{
+    struct pp *pp = global_plugin_ctx;
+    struct modex_ctx *ctx = NULL;
+    flux_future_t *f = NULL;
+    double timeout = -1; // seconds, -1 to disable
+    int rc = PMIX_ERROR;
+    int i;
+
+    /* Process any info options from the server upcall.
+     */
+    for (i = 0; i < ninfo; i++) {
+        /* Optional timeout (seconds, 0=infinite)
+         * The future will be fulfilled with ETIMEDOUT if the timer
+         * expires before a response is received.
+         */
+        if (!strcmp (info[i].key, "pmix.timeout")) {
+            if (info[i].value.type != PMIX_INT)
+                goto error;
+            if (timeout > 0)
+                timeout = info[i].value.data.integer;
+        }
+        /* FIXME: This opt is flagged as required, and advises us to wait for
+         * a particular key to be posted by a client before responding to the
+         * direct modex request upcall, but there doesn't seem to be an
+         * interface to ask the pmix server to wait for a particular key,
+         * for example, by passing this info into PMIx_server_dmodex_request(),
+         * and the modex data is opaque from our perspective, so how do we know?
+         * Probably missing something.  N.B. added in pmix spec v4.0 (dec 2020)
+         */
+        else if (!strcmp (info[i].key, "pmix.req.key")) {
+            if (info[i].value.type != PMIX_STRING)
+                goto error;
+            int required = (info[i].flags & PMIX_INFO_REQD);
+            shell_debug ("pmix: ignoring %s dmodex %s=%s argument",
+                        required ? "required" : "optional",
+                        info[i].key,
+                        info[i].value.data.string);
+        }
+        else {
+            int required = (info[i].flags & PMIX_INFO_REQD);
+            shell_warn ("pmix: unknown %s dmodex %s argument",
+                        required ? "required" : "optional",
+                        info[i].key);
+            if (required)
+                goto error;
+        }
+    }
+
+    if (!(f = pp_dmodex (pp->shell, proc))
+        || !(ctx = modex_ctx_create (cbfunc, cbdata))
+        || flux_future_then (f, timeout, direct_modex_continuation, pp) < 0
+        || flux_future_aux_set (f,
+                                "modex_ctx",
+                                ctx,
+                                (flux_free_f)modex_ctx_destroy) < 0) {
+        shell_warn ("pmix: error initiating pmix-modex RPC");
+        modex_ctx_destroy (ctx);
+        flux_future_destroy (f);
+        goto error;
+    }
+    return 0;
+error:
+    if (cbfunc)
+        cbfunc (rc, NULL, 0, cbdata, NULL, NULL);
+    return 0; // N.B. func return value is ignored - use cbfunc only
+}
+
+static void error_cb (size_t evhdlr_registration_id,
+                      pmix_status_t status,
+                      const pmix_proc_t *source,
+                      pmix_info_t info[],
+                      size_t ninfo,
+                      pmix_info_t results[],
+                      size_t nresults,
+                      pmix_event_notification_cbfunc_fn_t cbfunc,
+                      void *cbdata)
+{
+    shell_warn ("pmix: rank %d error: %s",
+                source->rank, PMIx_Error_string (status));
+}
+
+static pmix_server_module_t callbacks = {
+    .client_connected = client_connected_cb,
+    .client_finalized = client_finalized_cb,
+    .abort = abort_cb,
+    .fence_nb = fence_nb_cb,
+    .direct_modex = direct_modex_cb,
+};
+
+static void client_destroy (struct client *cli)
+{
+    if (cli) {
+        int saved_errno = errno;
+        free (cli);
+        errno = saved_errno;
+    }
+}
+
+static struct client *client_create (int rank)
+{
+    struct client *cli;
+
+    if (!(cli = calloc (1, sizeof (*cli))))
+        return NULL;
+
+    cli->proc.rank = rank;
+    strncpy (cli->proc.nspace, PP_NSPACE_NAME, PMIX_MAX_NSLEN);
+
+    return cli;
+}
+
+static void pp_destroy (struct pp *pp)
+{
+    if (pp) {
+        int saved_errno = errno;
+        if (pp->clients) {
+            struct client *cli;
+            while ((cli = zlist_pop (pp->clients)))
+                client_destroy (cli);
+            zlist_destroy (&pp->clients);
+        }
+        pp_server_destroy (pp->psrv);
+        pmi_exchange_destroy (pp->pmi_exchange);
+        global_plugin_ctx = NULL;
+        free (pp);
+        errno = saved_errno;
+    }
+}
+
+/* Register nspace.
+ * N.B. this must complete synchronously, before tasks are started.
+ */
+static int register_nspace (flux_shell_t *shell)
+{
+    struct infovec *iv = NULL;
+    int job_size = shell->info->total_ntasks;
+    int local_size = shell->info->rankinfo.ntasks;
+    char *local_peers = NULL;
+    char *proc_map = NULL;
+    char *node_map = NULL;
+    char jobid[32];
+    struct synchro sync;
+    int rc;
+    int ret = -1;
+
+    if (!(local_peers = pp_map_local_peers (shell->info->shell_rank,
+                                            shell->info->rcalc))
+        || !(proc_map = pp_map_proc_create (shell->info->shell_size,
+                                            shell->info->rcalc))
+        || !(node_map = pp_map_node_create (shell->info->R))
+        || flux_job_id_encode (shell->jobid, "f58", jobid, sizeof (jobid)) < 0) {
+        shell_warn ("pmix: error preparing nspace maps");
+        goto done;
+    }
+
+    if (shell->info->shell_rank == 0) {
+        shell_debug ("job_size %d", job_size);
+        shell_debug ("proc_map %s", proc_map);
+        shell_debug ("node_map %s", node_map);
+    }
+    shell_debug ("local_size %d", local_size);
+    shell_debug ("local_peers %s", local_peers);
+
+    if (!(iv = pp_infovec_create ())
+        || pp_infovec_set_u32 (iv, PMIX_UNIV_SIZE, job_size) < 0
+        || pp_infovec_set_str (iv, PMIX_JOBID, jobid) < 0
+        || pp_infovec_set_u32 (iv, PMIX_JOB_SIZE, job_size) < 0
+        || pp_infovec_set_u32 (iv, PMIX_MAX_PROCS, job_size) < 0
+        || pp_infovec_set_str (iv, PMIX_PROC_MAP, proc_map) < 0
+        || pp_infovec_set_str (iv, PMIX_NODE_MAP, node_map) < 0
+        || pp_infovec_set_u32 (iv, PMIX_LOCAL_SIZE, local_size) < 0
+        || pp_infovec_set_str (iv, PMIX_LOCAL_PEERS, local_peers) < 0) {
+        shell_warn ("pmix: error setting info vector");
+        goto done;
+    }
+
+    /* If rc is PMIX_SUCCESS, wait for callback to get final rc value.
+     * If rc is anything else, function is done and callback won't be called.
+     * There are two success values.
+     */
+    pp_synchro_init (&sync);
+    rc = PMIx_server_register_nspace (PP_NSPACE_NAME,
+                                      local_size,
+                                      pp_infovec_info (iv),
+                                      pp_infovec_count (iv),
+                                      pp_synchro_signal,
+                                      &sync);
+    if (rc == PMIX_SUCCESS)
+        rc = pp_synchro_wait (&sync);
+    if (rc != PMIX_SUCCESS && rc != PMIX_OPERATION_SUCCEEDED) {
+        shell_warn ("pmix: PMIx_server_register_nspace: %s",
+                    PMIx_Error_string (rc));
+        goto done;
+    }
+    ret = 0;
+done:
+    free (node_map);
+    free (proc_map);
+    free (local_peers);
+    pp_infovec_destroy (iv);
+    return ret;
+}
+
+static int initialize_pmix_server (struct pp *pp)
+{
+    const char *tmpdir;
+
+    if (!(tmpdir = flux_shell_getenv (pp->shell, "FLUX_JOB_TMPDIR"))) {
+        shell_warn ("pmix: FLUX_JOB_TMPDIR is not set");
+        return -1;
+    }
+    if (!(pp->psrv = pp_server_create (flux_get_reactor (pp->shell->h),
+                                       tmpdir,
+                                       &callbacks,
+                                       error_cb,
+                                       pp)))
+        return -1;
+    return 0;
+}
+
+static struct pp *pp_create (flux_shell_t *shell)
+{
+    struct pp *pp;
+
+    if (!(pp = calloc (1, sizeof (*pp))))
+        return NULL;
+    pp->shell = shell;
+    if (!(pp->clients = zlist_new ()))
+        goto error;
+    if (initialize_pmix_server (pp) < 0) {
+        shell_warn ("pmix: could not initialize pmix server");
+        goto error;
+    }
+    if (pp_dmodex_service_register (shell, pp->psrv) < 0) {
+        shell_warn ("pmix: failed to register dmodex service");
+        goto error;
+    }
+    if (register_nspace (shell) < 0) {
+        shell_warn ("pmix: failed to register nspace");
+        goto error;
+    }
+    if (!(pp->pmi_exchange = pmi_exchange_create (shell, 0))) {
+        shell_warn ("pmix: failed to create exchange context");
+        goto error;
+    }
+    global_plugin_ctx = pp;
+    return pp;
+error:
+    pp_destroy (pp);
+    return NULL;
+}
+
+static int pp_init (flux_plugin_t *p,
+                    const char *topic,
+                    flux_plugin_arg_t *arg,
+                    void *data)
+{
+    flux_shell_t *shell = flux_plugin_get_shell (p);
+    struct pp *pp;
+    if (!shell || !(pp = pp_create (shell)))
+        return -1;
+    if (flux_plugin_aux_set (p, "pp", pp, (flux_free_f) pp_destroy) < 0) {
+        pp_destroy (pp);
+        return -1;
+    }
+    return 0;
+}
+
+static int pp_task_init (flux_plugin_t *p,
+                         const char *topic,
+                         flux_plugin_arg_t *args,
+                         void *arg)
+{
+    flux_shell_t *shell;
+    struct pp *pp;
+    flux_shell_task_t *task;
+    flux_cmd_t *cmd;
+    char **env = NULL;
+    int rank;
+    struct client *cli;
+    int rc;
+
+    if (!(shell = flux_plugin_get_shell (p))
+        || !(pp = flux_plugin_aux_get (p, "pp"))
+        || !(task = flux_shell_current_task (shell))
+        || !(cmd = flux_shell_task_cmd (task))
+        || flux_shell_task_info_unpack (task, "{s:i}", "rank", &rank) < 0)
+        return -1;
+
+    if (!(cli = client_create (rank))
+        || zlist_append (pp->clients, cli) < 0) {
+        client_destroy (cli);
+        return -1;
+    }
+
+    /* Set pmix related environment variables.
+     */
+    if ((rc = PMIx_server_setup_fork (&cli->proc, &env)) != PMIX_SUCCESS) {
+        shell_warn ("pmix: PMIx_server_setup_fork: %s",
+                    PMIx_Error_string (rc));
+        return -1;
+    }
+    if (env) {
+        int i;
+        for (i = 0; env[i] != NULL; i++) {
+            char *name = env[i];
+            char *value = strchr (name, '=');
+            if (value)
+                *value++ = '\0';
+            if (flux_cmd_setenvf (cmd, 1, name, "%s", value) < 0) {
+                shell_warn ("pmix: setenv %s failed", name);
+                return -1;
+            }
+        }
+        free (env);
+    }
+
+    /* Register the client with the server.
+     * If rc is PMIX_SUCCESS, wait for callback to get final rc value.
+     * If rc is anything else, function is done and callback won't be called.
+     * There are two success values.
+     */
+    struct synchro sync;
+    pp_synchro_init (&sync);
+    rc = PMIx_server_register_client (&cli->proc,
+                                      getuid (),
+                                      getgid (),
+                                      cli, // handle passed back to us
+                                      pp_synchro_signal,
+                                      &sync);
+    if (rc == PMIX_SUCCESS)
+        rc = pp_synchro_wait (&sync);
+    if (rc != PMIX_SUCCESS && rc != PMIX_OPERATION_SUCCEEDED) {
+        shell_warn ("pmix: PMIx_server_register_client: %s",
+                    PMIx_Error_string (rc));
+        return -1;
+    }
+    return 0;
+}
+
+int flux_plugin_init (flux_plugin_t *p)
+{
+    if (flux_plugin_set_name (p, "pmix") < 0
+        || flux_plugin_add_handler (p, "shell.init", pp_init, NULL) < 0
+        || flux_plugin_add_handler (p, "task.init", pp_task_init, NULL) < 0) {
+        return -1;
+    }
+    return 0;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/shell/plugins/pmix/pmix.c
+++ b/src/shell/plugins/pmix/pmix.c
@@ -354,7 +354,11 @@ static int direct_modex_cb (const pmix_proc_t *proc,
                 goto error;
         }
     }
-
+    if (proc->rank >= pp->shell->info->total_ntasks
+        || strcmp (proc->nspace, PP_NSPACE_NAME) != 0) {
+        rc = PMIX_ERR_PROC_ENTRY_NOT_FOUND;
+        goto error;
+    }
     if (!(f = pp_dmodex (pp->shell, proc))
         || !(ctx = modex_ctx_create (cbfunc, cbdata))
         || flux_future_then (f, timeout, direct_modex_continuation, pp) < 0

--- a/src/shell/plugins/pmix/server.c
+++ b/src/shell/plugins/pmix/server.c
@@ -1,0 +1,818 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* server.c - pmix server thread ops
+ *
+ * pmix server callbacks are invoked in server thread context.  Use a 0MQ
+ * inproc (shared memory) socket to send callback parameters to the shell
+ * thread where an identical callback is invoked.  The shell end plays
+ * nicely with the flux reactor and can be oblivious to MT-safety issues
+ * contained in this source module.
+ *
+ * Each callback has a matched send and receive function.  Support for
+ * individual callbacks are being added as needed, as they are a little bit
+ * laborious to write.
+ *
+ * To add another callback:
+ * - implement send function and add entry to send_callbacks[] for
+ *   pmix_server_module_t callbacks, or wrapper function for other functions
+ * - implement recv function and add entry to recv_callbacks[]
+ *
+ * Other notes:
+ * - it is safe to call pmix completion callbacks and API functions
+ *   from the shell thread.  In fact, completion function pointers are
+ *   tranferred as json integers over the socket and invoked from the shell.
+ *
+ * - it is *not* safe to call shell functions from the server thread,
+ *   e.g. don't call shell_warn() from send functions below!
+ *
+ * - the 0MQ socket pair is created and destroyed in the shell thread,
+ *   but while the server thread is running, the server socket end may *only*
+ *   be used from the server thread.  0MQ sockets are generally not MT-safe.
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <assert.h>
+#include <stdarg.h>
+#include <jansson.h>
+#include <flux/core.h>
+#include <pmix.h>
+#include <pmix_server.h>
+#include <czmq.h>
+#include <zmq.h>
+
+#include "src/common/libutil/log.h"
+#include "src/common/libzmqutil/reactor.h"
+#include "src/common/libzmqutil/msg_zsock.h"
+
+#include "internal.h"
+#include "task.h"
+
+#include "server.h"
+#include "infovec.h"
+#include "codec.h"
+#include "socketpair.h"
+
+typedef void (*recv_cb_f)(struct psrv *psrv, const flux_msg_t *msg);
+// an entry in the recv_callbacks[] table
+struct recv_cb {
+    const char *name;
+    recv_cb_f fun;
+};
+
+struct psrv {
+    struct socketpair *sp;
+    flux_watcher_t *w;
+    pmix_server_module_t *callbacks;
+    pmix_notification_fn_t error_cb;
+    void *callback_arg;
+};
+
+/* This has to be global, since pmix_server_module_t callbacks don't have a way
+ * to pass in a user-supplied pointer.
+ */
+static struct psrv *global_server_ctx;
+
+/**
+ ** client_connected callback
+ **/
+
+static void recv_client_connected (struct psrv *psrv, const flux_msg_t *msg)
+{
+    json_t *xproc;
+    json_t *xserver_object;
+    json_t *xcbfunc;
+    json_t *xcbdata;
+    pmix_proc_t proc;
+    void *server_object;
+    pmix_op_cbfunc_t cbfunc;
+    void *cbdata;
+    int rc;
+
+    if (flux_msg_unpack (msg,
+                         "{s:o s:o s:o s:o}",
+                         "proc", &xproc,
+                         "server_object", &xserver_object,
+                         "cbfunc", &xcbfunc,
+                         "cbdata", &xcbdata) < 0) {
+        shell_warn ("error unpacking client_connected message");
+        return;
+    }
+    if (pp_proc_decode (xproc, &proc) < 0
+        || pp_pointer_decode (xserver_object, &server_object) < 0
+        || pp_pointer_decode (xcbfunc, (void **)&cbfunc) < 0
+        || pp_pointer_decode (xcbdata, &cbdata) < 0) {
+        shell_warn ("error decoding client_connected message");
+        rc = PMIX_ERROR;
+    }
+    else if (!psrv->callbacks->client_connected)
+        rc = PMIX_ERR_NOT_IMPLEMENTED;
+    else {
+        rc = psrv->callbacks->client_connected (&proc,
+                                                server_object,
+                                                cbfunc,
+                                                cbdata);
+    }
+    if (rc != PMIX_SUCCESS) {
+        if (cbfunc)
+            cbfunc (rc, cbdata);
+    }
+}
+
+static int send_client_connected (const pmix_proc_t *proc,
+                                  void *server_object,
+                                  pmix_op_cbfunc_t cbfunc,
+                                  void *cbdata)
+{
+    struct psrv *psrv = global_server_ctx;
+    json_t *xproc;
+    json_t *xserver_object = NULL;
+    json_t *xcbfunc = NULL;
+    json_t *xcbdata = NULL;
+    int rc = PMIX_SUCCESS;
+
+    if (!(xproc = pp_proc_encode (proc))
+        || !(xserver_object = pp_pointer_encode (server_object))
+        || !(xcbfunc = pp_pointer_encode (cbfunc))
+        || !(xcbdata = pp_pointer_encode (cbdata))
+        || pp_socketpair_send_pack (psrv->sp,
+                                    "client_connected",
+                                    "{s:O s:O s:O s:O}",
+                                    "proc", xproc,
+                                    "server_object", xserver_object,
+                                    "cbfunc", xcbfunc,
+                                    "cbdata", xcbdata))
+        rc = PMIX_ERROR;
+    json_decref (xproc);
+    json_decref (xserver_object);
+    json_decref (xcbfunc);
+    json_decref (xcbdata);
+    return rc;
+}
+
+/**
+ ** client_finalized callback
+ **/
+
+static void recv_client_finalized (struct psrv *psrv, const flux_msg_t *msg)
+{
+    json_t *xproc;
+    json_t *xserver_object;
+    json_t *xcbfunc;
+    json_t *xcbdata;
+    void *server_object;
+    pmix_op_cbfunc_t cbfunc;
+    void *cbdata;
+    pmix_proc_t proc;
+    int rc;
+
+    if (flux_msg_unpack (msg,
+                         "{s:o s:o s:o s:o}",
+                         "proc", &xproc,
+                         "server_object", &xserver_object,
+                         "cbfunc", &xcbfunc,
+                         "cbdata", &xcbdata) < 0) {
+        shell_warn ("error unpacking client_finalized notification");
+        return;
+    }
+    if (pp_proc_decode (xproc, &proc) < 0
+        || pp_pointer_decode (xserver_object, &server_object) < 0
+        || pp_pointer_decode (xcbfunc, (void **)&cbfunc) < 0
+        || pp_pointer_decode (xcbdata, &cbdata) < 0) {
+        shell_warn ("error decoding client_finalized notification");
+        rc = PMIX_ERROR;
+    }
+    else if (!psrv->callbacks->client_finalized)
+        rc = PMIX_ERR_NOT_IMPLEMENTED;
+    else {
+        rc = psrv->callbacks->client_finalized (&proc,
+                                                server_object,
+                                                cbfunc,
+                                                cbdata);
+    }
+    if (rc != PMIX_SUCCESS) {
+        if (cbfunc)
+            cbfunc (rc, cbdata);
+    }
+}
+
+static int send_client_finalized (const pmix_proc_t *proc,
+                                  void *server_object,
+                                  pmix_op_cbfunc_t cbfunc,
+                                  void *cbdata)
+{
+    struct psrv *psrv = global_server_ctx;
+    json_t *xproc = NULL;
+    json_t *xserver_object = NULL;
+    json_t *xcbfunc = NULL;
+    json_t *xcbdata = NULL;
+    int rc = PMIX_SUCCESS;
+
+    if (!(xproc = pp_proc_encode (proc))
+        || !(xserver_object = pp_pointer_encode (server_object))
+        || !(xcbfunc = pp_pointer_encode (cbfunc))
+        || !(xcbdata = pp_pointer_encode (cbdata))
+        || pp_socketpair_send_pack (psrv->sp,
+                                    "client_finalized",
+                                    "{s:O s:O s:O s:O}",
+                                    "proc", xproc,
+                                    "server_object", xserver_object,
+                                    "cbfunc", xcbfunc,
+                                    "cbdata", xcbdata))
+        rc = PMIX_ERROR;
+    json_decref (xproc);
+    json_decref (xserver_object);
+    json_decref (xcbfunc);
+    json_decref (xcbdata);
+    return rc;
+}
+
+/**
+ ** abort callback
+ **/
+
+static void recv_abort (struct psrv *psrv, const flux_msg_t *msg)
+{
+    json_t *xproc;
+    json_t *xserver_object;
+    json_t *xprocs;
+    json_t *xcbfunc;
+    json_t *xcbdata;
+    pmix_proc_t proc;
+    void *server_object;
+    pmix_proc_t *procs = NULL;
+    size_t nprocs;
+    int status;
+    const char *message;
+    pmix_op_cbfunc_t cbfunc;
+    void *cbdata;
+    int rc;
+
+    if (flux_msg_unpack (msg,
+                         "{s:o s:o s:i s:s s:o s:o s:o}",
+                         "proc", &xproc,
+                         "server_object", &xserver_object,
+                         "status", &status,
+                         "msg", &message,
+                         "procs", &xprocs,
+                         "cbfunc", &xcbfunc,
+                         "cbdata", &xcbdata) < 0) {
+        shell_warn ("error unpacking abort notification");
+        return;
+    }
+    if (pp_proc_decode (xproc, &proc) < 0
+        || pp_pointer_decode (xserver_object, &server_object) < 0
+        || pp_proc_array_decode (xprocs, &procs, &nprocs) < 0
+        || pp_pointer_decode (xcbfunc, (void **)&cbfunc) < 0
+        || pp_pointer_decode (xcbdata, &cbdata) < 0) {
+        shell_warn ("error decoding abort notification");
+        rc = PMIX_ERROR;
+    }
+    else if (!psrv->callbacks->abort)
+        rc = PMIX_ERR_NOT_IMPLEMENTED;
+    else {
+        rc = psrv->callbacks->abort (&proc,
+                                     server_object,
+                                     status,
+                                     message,
+                                     procs,
+                                     nprocs,
+                                     cbfunc,
+                                     cbdata);
+    }
+    if (rc != PMIX_SUCCESS) {
+        if (cbfunc)
+            cbfunc (rc, cbdata);
+    }
+    free (procs);
+}
+
+static int send_abort (const pmix_proc_t *proc,
+                       void *server_object,
+                       int status,
+                       const char msg[],
+                       pmix_proc_t procs[],
+                       size_t nprocs,
+                       pmix_op_cbfunc_t cbfunc,
+                       void *cbdata)
+{
+    struct psrv *psrv = global_server_ctx;
+    json_t *xproc = NULL;
+    json_t *xserver_object = NULL;
+    json_t *xprocs = NULL;
+    json_t *xcbfunc = NULL;
+    json_t *xcbdata = NULL;
+    int rc = PMIX_SUCCESS;
+
+    if (!(xproc = pp_proc_encode (proc))
+        || !(xserver_object = pp_pointer_encode (server_object))
+        || !(xprocs = pp_proc_array_encode (procs, nprocs))
+        || !(xcbfunc = pp_pointer_encode (cbfunc))
+        || !(cbdata = pp_pointer_encode (cbdata))
+        || pp_socketpair_send_pack (psrv->sp,
+                                    "abort",
+                                    "{s:O s:O s:i s:s s:O s:O s:O}",
+                                    "proc", xproc,
+                                    "server_object", xserver_object,
+                                    "status", status,
+                                    "msg", msg,
+                                    "procs", xprocs,
+                                    "cbfunc", xcbfunc,
+                                    "cbdata", xcbdata) < 0)
+        rc = PMIX_ERROR;
+    json_decref (xproc);
+    json_decref (xserver_object);
+    json_decref (xprocs);
+    json_decref (xcbfunc);
+    json_decref (xcbdata);
+    return rc;
+}
+
+/**
+ ** fence_nb callback
+ **/
+
+static void recv_fence_nb (struct psrv *psrv, const flux_msg_t *msg)
+{
+    json_t *xprocs;
+    json_t *xinfo;
+    json_t *xdata;
+    json_t *xcbfunc;
+    json_t *xcbdata;
+    pmix_proc_t *procs = NULL;
+    size_t nprocs;
+    struct infovec *iv = NULL;;
+    void *data = NULL;
+    size_t ndata;
+    pmix_modex_cbfunc_t cbfunc;
+    void *cbdata;
+    int rc;
+
+    if (flux_msg_unpack (msg,
+                         "{s:o s:o s:o s:o s:o}",
+                         "procs", &xprocs,
+                         "info", &xinfo,
+                         "data", &xdata,
+                         "cbfunc", &xcbfunc,
+                         "cbdata", &xcbdata) < 0) {
+        shell_warn ("error unpacking fence_nb notification");
+        return;
+    }
+    if (pp_proc_array_decode (xprocs, &procs, &nprocs) < 0
+        || !(iv = pp_infovec_create_from_json (xinfo))
+        || pp_data_decode (xdata, &data, &ndata) < 0
+        || pp_pointer_decode (xcbfunc, (void **)&cbfunc) < 0
+        || pp_pointer_decode (xcbdata, &cbdata) < 0) {
+        shell_warn ("error decoding fence_nb notification");
+        rc = PMIX_ERROR;
+    }
+    else if (!psrv->callbacks->fence_nb) {
+        rc = PMIX_ERR_NOT_IMPLEMENTED;
+    }
+    else {
+        rc = psrv->callbacks->fence_nb (procs,
+                                        nprocs,
+                                        pp_infovec_info (iv),
+                                        pp_infovec_count (iv),
+                                        data,
+                                        ndata,
+                                        cbfunc,
+                                        cbdata);
+    }
+    if (rc != PMIX_SUCCESS) {
+        if (cbfunc)
+            cbfunc (rc, NULL, 0, cbdata, NULL, NULL);
+    }
+    pp_infovec_destroy (iv);
+    free (procs);
+    free (data);
+}
+
+static int send_fence_nb (const pmix_proc_t procs[],
+                          size_t nprocs,
+                          const pmix_info_t info[],
+                          size_t ninfo,
+                          char *data,
+                          size_t ndata,
+                          pmix_modex_cbfunc_t cbfunc,
+                          void *cbdata)
+{
+    struct psrv *psrv = global_server_ctx;
+    json_t *xprocs = NULL;
+    json_t *xinfo = NULL;
+    json_t *xdata = NULL;
+    json_t *xcbfunc = NULL;
+    json_t *xcbdata = NULL;
+    int rc = PMIX_SUCCESS;
+
+    if (!(xprocs = pp_proc_array_encode (procs, nprocs))
+        || !(xinfo = pp_info_array_encode (info, ninfo))
+        || !(xdata = pp_data_encode (data, ndata))
+        || !(xcbfunc = pp_pointer_encode (cbfunc))
+        || !(xcbdata = pp_pointer_encode (cbdata))
+        || pp_socketpair_send_pack (psrv->sp,
+                                    "fence_nb",
+                                    "{s:O s:O s:O s:O s:O}",
+                                    "procs", xprocs,
+                                    "info", xinfo,
+                                    "data", xdata,
+                                    "cbfunc", xcbfunc,
+                                    "cbdata", xcbdata) < 0) {
+        rc = PMIX_ERROR;
+    }
+    json_decref (xprocs);
+    json_decref (xinfo);
+    json_decref (xdata);
+    json_decref (xcbfunc);
+    json_decref (xcbdata);
+    return rc;
+}
+
+/**
+ ** direct_modex callback
+ **/
+
+static void recv_direct_modex (struct psrv *psrv, const flux_msg_t *msg)
+{
+    json_t *xproc;
+    json_t *xinfo;
+    json_t *xcbfunc;
+    json_t *xcbdata;
+    pmix_proc_t proc;
+    pmix_modex_cbfunc_t cbfunc;
+    void *cbdata;
+    struct infovec *iv = NULL;
+    int rc;
+
+    if (flux_msg_unpack (msg,
+                         "{s:o s:o s:o s:o}",
+                         "proc", &xproc,
+                         "info", &xinfo,
+                         "cbfunc", &xcbfunc,
+                         "cbdata", &xcbdata) < 0) {
+        shell_warn ("error unpacking direct_modex notification");
+        return;
+    }
+    else if (pp_proc_decode (xproc, &proc) < 0
+        || !(iv = pp_infovec_create_from_json (xinfo))
+        || pp_pointer_decode (xcbfunc, (void **)&cbfunc) < 0
+        || pp_pointer_decode (xcbdata, &cbdata) < 0) {
+        shell_warn ("error decoding direct_modex notification");
+        rc = PMIX_ERROR;
+    }
+    else if (!psrv->callbacks->direct_modex)
+        rc = PMIX_ERR_NOT_IMPLEMENTED;
+    else {
+        rc = psrv->callbacks->direct_modex (&proc,
+                                            pp_infovec_info (iv),
+                                            pp_infovec_count (iv),
+                                            cbfunc,
+                                            cbdata);
+    }
+    if (rc != PMIX_SUCCESS) {
+        if (cbfunc)
+            cbfunc (rc, NULL, 0, cbdata, NULL, NULL);
+    }
+    pp_infovec_destroy (iv);
+}
+
+static int send_direct_modex (const pmix_proc_t *proc,
+                              const pmix_info_t info[],
+                              size_t ninfo,
+                              pmix_modex_cbfunc_t cbfunc,
+                              void *cbdata)
+{
+    struct psrv *psrv = global_server_ctx;
+    json_t *xproc  = NULL;
+    json_t *xinfo = NULL;
+    json_t *xcbfunc = NULL;
+    json_t *xcbdata = NULL;
+    int rc = PMIX_SUCCESS;
+
+    if (!(xproc = pp_proc_encode (proc))
+        || !(xinfo = pp_info_array_encode (info, ninfo))
+        || !(xcbfunc = pp_pointer_encode (cbfunc))
+        || !(xcbdata = pp_pointer_encode (cbdata))
+        || pp_socketpair_send_pack (psrv->sp,
+                                    "direct_modex",
+                                    "{s:O s:O s:O s:O}",
+                                    "proc", xproc,
+                                    "info", xinfo,
+                                    "cbfunc", xcbfunc,
+                                    "cbdata", xcbdata) < 0)
+        rc = PMIX_ERROR;
+    json_decref (xproc);
+    json_decref (xinfo);
+    json_decref (xcbfunc);
+    json_decref (xcbdata);
+    return rc;
+}
+
+/**
+ ** error callback
+ **/
+
+static void recv_error (struct psrv *psrv, const flux_msg_t *msg)
+{
+    int id;
+    int status;
+    json_t *xsource;
+    json_t *xinfo;
+    json_t *xresults;
+    json_t *xcbfunc;
+    json_t *xcbdata;
+    pmix_proc_t source;
+    struct infovec *iv = NULL;
+    struct infovec *rv = NULL;
+    pmix_event_notification_cbfunc_fn_t cbfunc;
+    void *cbdata;
+
+    if (flux_msg_unpack (msg,
+                         "{s:o s:i}",
+                         "id", &id,
+                         "status", &status,
+                         "source", &xsource,
+                         "info", &xinfo,
+                         "results", &xresults,
+                         "cbfunc", &xcbfunc,
+                         "cbdata", &xcbdata) < 0) {
+        shell_warn ("error unpacking error notification");
+        goto done;
+    }
+    if (pp_proc_decode (xsource, &source) < 0
+        || !(iv = pp_infovec_create_from_json (xinfo))
+        || !(rv = pp_infovec_create_from_json (xresults))
+        || pp_pointer_decode (xcbfunc, (void **)&cbfunc) < 0
+        || pp_pointer_decode (xcbdata, &cbdata) < 0) {
+        shell_warn ("error decoding error notification");
+        goto done;
+    }
+    if (psrv->error_cb) {
+        psrv->error_cb (id,
+                        status,
+                        &source,
+                        pp_infovec_info (iv),
+                        pp_infovec_count (iv),
+                        pp_infovec_info (rv),
+                        pp_infovec_count (rv),
+                        cbfunc,
+                        cbdata);
+    }
+done:
+    pp_infovec_destroy (iv);
+}
+
+static void send_error_cb (size_t evhdlr_registration_id,
+                           pmix_status_t status,
+                           const pmix_proc_t *source,
+                           pmix_info_t info[],
+                           size_t ninfo,
+                           pmix_info_t results[],
+                           size_t nresults,
+                           pmix_event_notification_cbfunc_fn_t cbfunc,
+                           void *cbdata)
+{
+    struct psrv *psrv = global_server_ctx;
+    json_t *xsource = NULL;
+    json_t *xinfo = NULL;
+    json_t *xresults = NULL;
+    json_t *xcbfunc = NULL;
+    json_t *xcbdata = NULL;
+
+    if (!(xsource = pp_proc_encode (source))
+        || !(xinfo = pp_info_array_encode (info, ninfo))
+        || !(xresults = pp_info_array_encode (results, nresults))
+        || !(xcbfunc = pp_pointer_encode (cbfunc))
+        || !(xcbdata = pp_pointer_encode (cbdata))
+        || pp_socketpair_send_pack (psrv->sp,
+                                    "error",
+                                    "{s:i s:i s:O s:O s:O s:O s:O}",
+                                    "id", evhdlr_registration_id,
+                                    "status", status,
+                                    "source", xsource,
+                                    "info", xinfo,
+                                    "results", xresults,
+                                    "cbfunc", xcbfunc,
+                                    "cbdata", xcbdata) < 0)
+        log_msg ("pmix: error message dropped");
+    json_decref (xsource);
+    json_decref (xinfo);
+    json_decref (xresults);
+    json_decref (xcbfunc);
+    json_decref (xcbdata);
+}
+
+/**
+ ** dmodex_response_cb
+ ** callback for PMIx_server_dmodex_request()
+ **/
+
+struct dmodex_response {
+    pmix_dmodex_response_fn_t cbfunc;
+    void *cbdata;
+    struct psrv *psrv;
+};
+
+static void recv_dmodex_response_cb (struct psrv *psrv, const flux_msg_t *msg)
+{
+    int status;
+    json_t *xdata;
+    json_t *xcbfunc;
+    json_t *xcbdata;
+    void *data = NULL;
+    size_t ndata;
+    pmix_dmodex_response_fn_t cbfunc;
+    void *cbdata;
+
+    if (flux_msg_unpack (msg,
+                         "{s:i s:o s:o s:o}",
+                         "status", &status,
+                         "data", &xdata,
+                         "cbfunc", &xcbfunc,
+                         "cbdata", &xcbdata) < 0) {
+        shell_warn ("error unpacking dmodex_response_cb message");
+        return;
+    }
+    if (pp_data_decode (xdata, &data, &ndata) < 0
+        || pp_pointer_decode (xcbfunc, (void **)&cbfunc) < 0
+        || pp_pointer_decode (xcbdata, &cbdata) < 0) {
+        shell_warn ("error decoding dmodex_response_cb message");
+        goto done;
+    }
+    if (cbfunc)
+        cbfunc (status, data, ndata, cbdata);
+done:
+    free (data);
+}
+
+static void send_dmodex_response_cb (pmix_status_t status,
+                                     char *data,
+                                     size_t size,
+                                     void *cbdata)
+{
+    struct dmodex_response *ctx = cbdata;
+    json_t *xdata = NULL;
+    json_t *xcbfunc = NULL;
+    json_t *xcbdata = NULL;
+
+    if (!(xdata = pp_data_encode (data, size))
+        || !(xcbfunc = pp_pointer_encode (ctx->cbfunc))
+        || !(xcbdata = pp_pointer_encode (ctx->cbdata))
+        || pp_socketpair_send_pack (ctx->psrv->sp,
+                                    "dmodex_response_cb",
+                                    "{s:i s:O s:O s:O}",
+                                    "status", status,
+                                    "data", xdata,
+                                    "cbfunc", xcbfunc,
+                                    "cbdata", xcbdata))
+    json_decref (xdata);
+    json_decref (xcbfunc);
+    json_decref (xcbdata);
+    free (ctx);
+}
+
+pmix_status_t pp_server_dmodex_request (struct psrv *psrv,
+                                        const pmix_proc_t *proc,
+                                        pmix_dmodex_response_fn_t cbfunc,
+                                        void *cbdata)
+{
+    struct dmodex_response *ctx;
+    int rc;
+
+    if (!(ctx = calloc (1, sizeof (*ctx))))
+        return PMIX_ERR_NOMEM;
+    ctx->cbfunc = cbfunc;
+    ctx->cbdata = cbdata;
+    ctx->psrv = psrv;
+    rc = PMIx_server_dmodex_request (proc, send_dmodex_response_cb, ctx);
+    if (rc != PMIX_SUCCESS)
+        free (ctx);
+    return rc;
+}
+
+struct recv_cb recv_callbacks[] = {
+    { "client_connected", recv_client_connected },
+    { "client_finalized", recv_client_finalized },
+    { "client_abort", recv_abort },
+    { "fence_nb", recv_fence_nb },
+    { "direct_modex", recv_direct_modex },
+    { "error", recv_error},
+    { "dmodex_response_cb", recv_dmodex_response_cb },
+    { NULL, NULL },
+};
+
+static pmix_server_module_t send_callbacks = {
+    .client_connected = send_client_connected,
+    .client_finalized = send_client_finalized,
+    .abort = send_abort,
+    .fence_nb = send_fence_nb,
+    .direct_modex = send_direct_modex,
+};
+
+/* A message is received reactively on the shell end of the socket.
+ * Dispatch to matched callback from recv_callbacks[] table.
+ */
+static void recv_cb (const flux_msg_t *msg, void *arg)
+{
+    struct psrv *psrv = arg;
+    const char *topic;
+    const char *payload;
+    struct recv_cb *cb;
+
+    if (flux_event_decode (msg, &topic, &payload) < 0) {
+        shell_warn ("pmix: message decode error - dropped");
+        goto done;
+    }
+    shell_trace ("pmix: callback %s: %s", topic, payload ? payload : "");
+    for (cb = &recv_callbacks[0]; cb->name != NULL; cb++) {
+        if (streq (topic, cb->name))
+            break;
+    }
+    if (cb->fun)
+        cb->fun (psrv, msg);
+    else
+        shell_warn ("pmix: unhandled callback: %s", topic);
+done:
+    flux_msg_decref (msg);
+}
+
+void pp_server_destroy (struct psrv *psrv)
+{
+    if (psrv) {
+        int saved_errno = errno;
+        int rc;
+
+        PMIx_Deregister_event_handler (0, NULL, NULL);
+        if ((rc = PMIx_server_finalize ()) != PMIX_SUCCESS)
+            shell_warn ("PMIx_server_finalize: %s", PMIx_Error_string (rc));
+        pp_socketpair_destroy (psrv->sp);
+        global_server_ctx = NULL;
+        free (psrv);
+        errno = saved_errno;
+    }
+}
+
+struct psrv *pp_server_create (flux_reactor_t *r,
+                               const char *tmpdir,
+                               pmix_server_module_t *callbacks,
+                               pmix_notification_fn_t error_cb,
+                               void *callback_arg)
+{
+    struct psrv *psrv;
+    struct infovec *iv = NULL;
+    int rc;
+
+    if (!(psrv = calloc (1, sizeof (*psrv))))
+        return NULL;
+    psrv->callbacks = callbacks;
+    psrv->error_cb = error_cb;
+    psrv->callback_arg = callback_arg;
+
+    /* Set up 0MQ push - pull socket pair.
+     */
+    if (!(psrv->sp = pp_socketpair_create (r))
+        || pp_socketpair_recv_register (psrv->sp, recv_cb, psrv) < 0)
+        goto error;
+
+    /* Prepare info array to pass to PMIX_server_init
+     */
+    if (!(iv = pp_infovec_create ()))
+        goto error;
+    if (pp_infovec_set_str (iv, PMIX_SERVER_TMPDIR, tmpdir) < 0)
+        goto error;
+
+    /* Start server thread
+     */
+    rc = PMIx_server_init (&send_callbacks,
+                           pp_infovec_info (iv),
+                           pp_infovec_count (iv));
+    if (rc != PMIX_SUCCESS) {
+        shell_warn ("PMIx_server_init: %s", PMIx_Error_string (rc));
+        goto error;
+    }
+
+    /* Register error callback
+     * Note that the call to Deregister in pp_server_destroy() assumes event
+     * handler id=0 since this is the first one registered.
+     */
+    PMIx_Register_event_handler (NULL, 0, NULL, 0, send_error_cb, NULL, NULL);
+
+    global_server_ctx = psrv;
+    pp_infovec_destroy (iv);
+    return psrv;
+error:
+    pp_infovec_destroy (iv);
+    pp_server_destroy (psrv);
+    return NULL;
+}
+
+// vi:tabstop=4 shiftwidth=4 expandtab

--- a/src/shell/plugins/pmix/server.c
+++ b/src/shell/plugins/pmix/server.c
@@ -762,13 +762,12 @@ void pp_server_destroy (struct psrv *psrv)
 }
 
 struct psrv *pp_server_create (flux_reactor_t *r,
-                               const char *tmpdir,
+                               struct infovec *iv,
                                pmix_server_module_t *callbacks,
                                pmix_notification_fn_t error_cb,
                                void *callback_arg)
 {
     struct psrv *psrv;
-    struct infovec *iv = NULL;
     int rc;
 
     if (!(psrv = calloc (1, sizeof (*psrv))))
@@ -781,13 +780,6 @@ struct psrv *pp_server_create (flux_reactor_t *r,
      */
     if (!(psrv->sp = pp_socketpair_create (r))
         || pp_socketpair_recv_register (psrv->sp, recv_cb, psrv) < 0)
-        goto error;
-
-    /* Prepare info array to pass to PMIX_server_init
-     */
-    if (!(iv = pp_infovec_create ()))
-        goto error;
-    if (pp_infovec_set_str (iv, PMIX_SERVER_TMPDIR, tmpdir) < 0)
         goto error;
 
     /* Start server thread
@@ -807,10 +799,8 @@ struct psrv *pp_server_create (flux_reactor_t *r,
     PMIx_Register_event_handler (NULL, 0, NULL, 0, send_error_cb, NULL, NULL);
 
     global_server_ctx = psrv;
-    pp_infovec_destroy (iv);
     return psrv;
 error:
-    pp_infovec_destroy (iv);
     pp_server_destroy (psrv);
     return NULL;
 }

--- a/src/shell/plugins/pmix/server.h
+++ b/src/shell/plugins/pmix/server.h
@@ -11,8 +11,12 @@
 #ifndef _PMIX_PP_SERVER_H
 #define _PMIX_PP_SERVER_H
 
+#include <flux/core.h>
+#include <pmix_server.h>
+#include "infovec.h"
+
 struct psrv *pp_server_create (flux_reactor_t *r,
-                               const char *tmpdir,
+                               struct infovec *iv,
                                pmix_server_module_t *callbacks,
                                pmix_notification_fn_t error_cb,
                                void *arg);

--- a/src/shell/plugins/pmix/server.h
+++ b/src/shell/plugins/pmix/server.h
@@ -1,0 +1,29 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _PMIX_PP_SERVER_H
+#define _PMIX_PP_SERVER_H
+
+struct psrv *pp_server_create (flux_reactor_t *r,
+                               const char *tmpdir,
+                               pmix_server_module_t *callbacks,
+                               pmix_notification_fn_t error_cb,
+                               void *arg);
+
+void pp_server_destroy (struct psrv *psrv);
+
+pmix_status_t pp_server_dmodex_request (struct psrv *psrv,
+                                        const pmix_proc_t *proc,
+                                        pmix_dmodex_response_fn_t cbfunc,
+                                        void *cbdata);
+
+#endif
+
+// vi:ts=4 sw=4 expandtab

--- a/src/shell/plugins/pmix/socketpair.c
+++ b/src/shell/plugins/pmix/socketpair.c
@@ -1,0 +1,129 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* socketpair.c - shared memory channel from pmix server to shell plugin
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <zmq.h>
+
+#include "src/common/libzmqutil/reactor.h"
+#include "src/common/libzmqutil/msg_zsock.h"
+
+#include "socketpair.h"
+
+#define SOCKETPAIR_ENDPOINT   "inproc://pmix-socketpair"
+
+struct socketpair {
+    void *zctx;
+    void *sock[2];
+    socketpair_recv_f fun;
+    void *arg;
+    flux_watcher_t *w;
+};
+
+static void recv_cb (flux_reactor_t *r,
+                     flux_watcher_t *w,
+                     int revents,
+                     void *arg)
+{
+    struct socketpair *sp = arg;
+    flux_msg_t *msg;
+
+    if ((revents & FLUX_POLLIN)
+        && (msg = zmqutil_msg_recv (sp->sock[1]))) {
+        if (sp->fun)
+            sp->fun (msg, sp->arg);
+        flux_msg_decref (msg);
+    }
+}
+
+int pp_socketpair_recv_register (struct socketpair *sp,
+                                 socketpair_recv_f fun,
+                                 void *arg)
+{
+    sp->fun = fun;
+    sp->arg = arg;
+    flux_watcher_start (sp->w);
+    return 0;
+}
+
+int pp_socketpair_send_pack (struct socketpair *sp,
+                             const char *name,
+                             const char *fmt, ...)
+{
+    flux_msg_t *msg = NULL;
+    va_list ap;
+    int rc = 0;
+
+    va_start (ap, fmt);
+    if (!(msg = flux_msg_create (FLUX_MSGTYPE_EVENT))
+        || flux_msg_set_topic (msg, name) < 0
+        || flux_msg_vpack (msg, fmt, ap) < 0
+        || zmqutil_msg_send (sp->sock[0], msg) < 0) {
+        rc = -1;
+    }
+    va_end (ap);
+    flux_msg_decref (msg);
+
+    return rc;
+}
+
+void pp_socketpair_destroy (struct socketpair *sp)
+{
+    if (sp) {
+        int saved_errno = errno;
+        flux_watcher_destroy (sp->w);
+
+        zmq_disconnect (sp->sock[0], SOCKETPAIR_ENDPOINT);
+        zmq_close (sp->sock[0]);
+
+        zmq_unbind (sp->sock[1], SOCKETPAIR_ENDPOINT);
+        zmq_close (sp->sock[1]);
+
+        zmq_ctx_term (sp->zctx);
+        errno = saved_errno;
+    }
+}
+
+struct socketpair *pp_socketpair_create (flux_reactor_t *r)
+{
+    struct socketpair *sp;
+
+    if (!(sp = calloc (1, sizeof (*sp))))
+        return NULL;
+    if (!(sp->zctx = zmq_ctx_new ()))
+        goto error;
+
+    if (!(sp->sock[1] = zmq_socket (sp->zctx, ZMQ_PULL)))
+        goto error;
+    if (zmq_bind (sp->sock[1], SOCKETPAIR_ENDPOINT) < 0)
+        goto error;
+    if (!(sp->w = zmqutil_watcher_create (r,
+                                          sp->sock[1],
+                                          FLUX_POLLIN,
+                                          recv_cb,
+                                          sp)))
+        goto error;
+
+    if (!(sp->sock[0] = zmq_socket (sp->zctx, ZMQ_PUSH)))
+        goto error;
+    if (zmq_connect (sp->sock[0], SOCKETPAIR_ENDPOINT) < 0)
+        goto error;
+
+    return sp;
+error:
+    pp_socketpair_destroy (sp);
+    return NULL;
+}
+
+// vi:tabstop=4 shiftwidth=4 expandtab

--- a/src/shell/plugins/pmix/socketpair.h
+++ b/src/shell/plugins/pmix/socketpair.h
@@ -1,0 +1,42 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _PMIX_SOCKETPAIR_H
+#define _PMIX_SOCKETPAIR_H
+
+#include <stdarg.h>
+#include <flux/core.h>
+#include <czmq.h>
+#include <zmq.h>
+
+/* Create and destroy socketpair from the shell thread.
+ */
+struct socketpair *pp_socketpair_create (flux_reactor_t *r);
+void pp_socketpair_destroy (struct socketpair *sp);
+
+/* Register receive callback that will be called in the shell thread
+ * for each message sent by the server.
+ */
+typedef void (*socketpair_recv_f)(const flux_msg_t *msg, void *arg);
+
+int pp_socketpair_recv_register (struct socketpair *sp,
+                                 socketpair_recv_f fun,
+                                 void *arg);
+
+/* Send function must be called from the server thread ONLY.
+ */
+int pp_socketpair_send_pack (struct socketpair *sp,
+                             const char *name,
+                             const char *fmt, ...);
+
+
+#endif
+
+// vi:tabstop=4 shiftwidth=4 expandtab

--- a/src/shell/plugins/pmix/synchro.c
+++ b/src/shell/plugins/pmix/synchro.c
@@ -1,0 +1,67 @@
+/************************************************************\
+ * Copyright 2016 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* synchro.c - synchronize with simple PMIx server functions
+ *
+ * Some PMIx server function calls are asynchronous, with completion
+ * status returned to a pmix_op_cbfunc_t callback made in PMIx server
+ * thread context.  The 'synchro' mini-class provides a way for these
+ * functions to be called *synchronously* without going through the
+ * server socket in server.c.
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <pthread.h>
+#include <pmix_server.h>
+
+#include "synchro.h"
+
+void pp_synchro_init (struct synchro *x)
+{
+    pthread_mutex_init (&x->lock, NULL);
+    pthread_cond_init (&x->cond, NULL);
+    x->valid = 0;
+}
+
+void pp_synchro_clear (struct synchro *x)
+{
+    pthread_mutex_lock (&x->lock);
+    x->valid = 0;
+    pthread_mutex_unlock (&x->lock);
+}
+
+/* pmix_op_cbfunc_t function signature */
+void pp_synchro_signal (pmix_status_t status, void *cbdata)
+{
+    struct synchro *x = cbdata;
+
+    pthread_mutex_lock (&x->lock);
+    x->status = status;
+    x->valid = 1;
+    pthread_cond_signal (&x->cond);
+    pthread_mutex_unlock (&x->lock);
+}
+
+pmix_status_t pp_synchro_wait (struct synchro *x)
+{
+    pmix_status_t rc = PMIX_ERROR;
+
+    pthread_mutex_lock (&x->lock);
+    while (!x->valid)
+        pthread_cond_wait (&x->cond, &x->lock);
+    rc = x->status;
+    pthread_mutex_unlock (&x->lock);
+
+    return rc;
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/src/shell/plugins/pmix/synchro.h
+++ b/src/shell/plugins/pmix/synchro.h
@@ -1,0 +1,34 @@
+/************************************************************\
+ * Copyright 2016 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#include <pthread.h>
+#include <pmix_server.h>
+
+#ifndef _PMIX_PP_SYNCHRO_H
+#define _PMIX_PP_SYNCHRO_H
+
+struct synchro {
+    pthread_mutex_t lock;
+    pthread_cond_t cond;
+    volatile pmix_status_t status;
+    volatile int valid;
+};
+
+void pp_synchro_init (struct synchro *x);
+void pp_synchro_clear (struct synchro *x);
+
+pmix_status_t pp_synchro_wait (struct synchro *x);
+
+// pmix_op_cbfunc_t function signature
+void pp_synchro_signal (pmix_status_t status, void *cbdata);
+
+#endif
+
+// vi:ts=4 sw=4 expandtab

--- a/src/shell/plugins/pmix/test/barrier.c
+++ b/src/shell/plugins/pmix/test/barrier.c
@@ -1,0 +1,69 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+ \************************************************************/
+
+/* barrier.c - time a PMIx_Fence() with no data
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <pmix.h>
+#include <stdio.h>
+
+#include "src/common/libutil/log.h"
+#include "src/common/libutil/monotime.h"
+
+int main (int argc, char **argv)
+{
+    pmix_proc_t self;
+    int rc;
+
+    /* Initialize
+     * Use the rank as a prefix for any log messages (once known).
+     */
+    char name[512];
+    if ((rc = PMIx_Init (&self, NULL, 0)) != PMIX_SUCCESS)
+        log_msg_exit ("PMIx_Init: %s", PMIx_Error_string (rc));
+    snprintf (name, sizeof (name), "%s.%d", self.nspace, self.rank);
+    log_init (name);
+    if (self.rank == 0)
+        log_msg ("completed PMIx_Init.");
+
+    /* Get the size and print it so we know the test wired up.
+     */
+    pmix_proc_t proc;
+    pmix_value_t *valp;
+    strncpy (proc.nspace, self.nspace, PMIX_MAX_NSLEN);
+    proc.nspace[PMIX_MAX_NSLEN] = '\0';
+    proc.rank = PMIX_RANK_WILDCARD;
+    if ((rc = PMIx_Get (&proc, PMIX_JOB_SIZE, NULL, 0, &valp)) != PMIX_SUCCESS)
+        log_msg_exit ("PMIx_Get %s: %s", PMIX_JOB_SIZE, PMIx_Error_string (rc));
+    if (self.rank == 0)
+        log_msg ("there are %d tasks",
+                 valp->type == PMIX_UINT32 ? valp->data.uint32 : -1);
+    PMIX_VALUE_RELEASE (valp);
+
+    /* Time the fence
+     */
+    struct timespec t;
+    monotime (&t);
+    if ((rc = PMIx_Fence (NULL, 0, NULL, 0)))
+        log_msg_exit ("PMIx_Fence: %s", PMIx_Error_string (rc));
+    if (self.rank == 0)
+        log_msg ("completed barrier in %0.3fs.", monotime_since (t) / 1000);
+
+    if ((rc = PMIx_Finalize (NULL, 0)))
+        log_msg_exit ("PMIx_Finalize: %s", PMIx_Error_string (rc));
+    if (self.rank == 0)
+        log_msg ("completed PMIx_Finalize.");
+    return 0;
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/src/shell/plugins/pmix/test/bizcard.c
+++ b/src/shell/plugins/pmix/test/bizcard.c
@@ -1,0 +1,186 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+ \************************************************************/
+
+/* bizcard.c - procs exchange "business cards" (spec v5.0 sec B.1) */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <pmix.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdint.h>
+
+#include "src/common/libutil/log.h"
+#include "src/common/libutil/monotime.h"
+
+int main (int argc, char **argv)
+{
+    char name[512];
+    char buf[2048];
+    pmix_proc_t self;
+    pmix_proc_t proc;
+    pmix_value_t val;
+    pmix_value_t *valp;
+    pmix_info_t info;
+    struct timespec t;
+    int rc;
+    int size;
+    char hostname[128];
+    int lrank;
+    int srank;
+
+    /* Initialize and set log prefix to nspace.rank
+     */
+    if ((rc = PMIx_Init (&self, NULL, 0)) != PMIX_SUCCESS)
+        log_msg_exit ("PMIx_Init: %s", PMIx_Error_string (rc));
+    snprintf (name, sizeof (name), "%s.%d", self.nspace, self.rank);
+    log_init (name);
+    if (self.rank == 0)
+        log_msg ("completed PMIx_Init.");
+
+    /* Get the size
+     */
+    strncpy (proc.nspace, self.nspace, PMIX_MAX_NSLEN);
+    proc.nspace[PMIX_MAX_NSLEN] = '\0';
+    proc.rank = PMIX_RANK_WILDCARD;
+    if ((rc = PMIx_Get (&proc,
+                        PMIX_JOB_SIZE,
+                        NULL,
+                        0,
+                        &valp)) != PMIX_SUCCESS) {
+        log_msg_exit ("PMIx_Get %s: %s",
+                      PMIX_JOB_SIZE,
+                      PMIx_Error_string (rc));
+    }
+    if (valp->type != PMIX_UINT32)
+        log_msg_exit ("PMIx_Get %s: return unexpected type", PMIX_JOB_SIZE);
+    size = valp->data.uint32;
+    if (self.rank == 0)
+        log_msg ("there are %d tasks", size);
+    PMIX_VALUE_RELEASE (valp);
+
+    /* Get the hostname
+     */
+    if ((rc = PMIx_Get (&self, PMIX_HOSTNAME, NULL, 0, &valp)) != PMIX_SUCCESS)
+        log_msg_exit ("PMIx_Get %s: %s", PMIX_HOSTNAME, PMIx_Error_string (rc));
+    if (valp->type != PMIX_STRING)
+        log_msg_exit ("PMIx_Get %s: return unexpected type", PMIX_HOSTNAME);
+    snprintf (hostname, sizeof (hostname), "%s", valp->data.string);
+    PMIX_VALUE_RELEASE (valp);
+
+    /* Get the local rank
+     */
+    if ((rc = PMIx_Get (&self,
+                        PMIX_LOCAL_RANK,
+                        NULL,
+                        0,
+                        &valp)) != PMIX_SUCCESS)
+        log_msg_exit ("PMIx_Get %s: %s",
+                      PMIX_LOCAL_RANK,
+                      PMIx_Error_string (rc));
+    if (valp->type != PMIX_UINT16)
+        log_msg_exit ("PMIx_Get %s: return unexpected type", PMIX_LOCAL_RANK);
+    lrank = valp->data.uint16;
+    PMIX_VALUE_RELEASE (valp);
+
+    /* Get the server rank
+     */
+    if ((rc = PMIx_Get (&self,
+                        PMIX_SERVER_RANK,
+                        NULL,
+                        0,
+                        &valp)) != PMIX_SUCCESS)
+        log_msg_exit ("PMIx_Get %s: %s",
+                      PMIX_SERVER_RANK,
+                      PMIx_Error_string (rc));
+    if (valp->type != PMIX_PROC_RANK)
+        log_msg_exit ("PMIx_Get %s: return unexpected type", PMIX_SERVER_RANK);
+    srank = valp->data.rank;
+    PMIX_VALUE_RELEASE (valp);
+
+
+    /* Store the business card for our nspace, rank.
+     */
+    snprintf (buf,
+              sizeof (buf),
+              "+-------------------------------\n"
+              "| Hello, my name is %s.%d\n"
+              "|   I live on %s\n"
+              "|   My local rank is %d\n"
+              "|   My server rank is %d\n"
+              "+-------------------------------\n",
+              self.nspace, self.rank,
+              hostname,
+              lrank,
+              srank);
+    val.type = PMIX_STRING;
+    val.data.string = buf;
+    if ((rc = PMIx_Put (PMIX_GLOBAL, "card", &val)) != PMIX_SUCCESS)
+        log_msg_exit ("PMIx_Put %s: %s", "card", PMIx_Error_string (rc));
+    if ((rc = PMIx_Commit ()) != PMIX_SUCCESS)
+        log_msg_exit ("PMIx_Commit: %s", PMIx_Error_string (rc));
+
+    /* Fence
+     */
+    strncpy (info.key, PMIX_COLLECT_DATA, PMIX_MAX_KEYLEN);
+    info.key[PMIX_MAX_KEYLEN] = '\0';
+    info.value.type = PMIX_BOOL;
+    info.value.data.flag = true;
+
+    monotime (&t);
+    if ((rc = PMIx_Fence (NULL, 0, &info, 1)) != PMIX_SUCCESS)
+        log_msg_exit ("PMIx_Fence: %s", PMIx_Error_string (rc));
+    if (self.rank == 0)
+        log_msg ("PMIx_Fence completed in %0.3fs", monotime_since (t) / 1000);
+
+    /* Fetch specified card(s) and print.
+     */
+    if (self.rank == 0 && argc > 1) {
+        for (int optindex = 1; optindex < argc; optindex++) {
+            pmix_proc_t proc;
+            pmix_value_t *valp;
+
+            strncpy (proc.nspace, self.nspace, PMIX_MAX_NSLEN);
+            proc.nspace[PMIX_MAX_NSLEN] = '\0';
+            errno = 0;
+            proc.rank = strtoul (argv[optindex], NULL, 10);
+            if (errno != 0)
+                log_err_exit ("Error parsing argument '%s'", argv[optindex]);
+
+            if ((rc = PMIx_Get (&proc,
+                                "card",
+                                NULL,
+                                0,
+                                &valp)) != PMIX_SUCCESS) {
+                log_msg_exit ("PMIx_Get rank %d card: %s",
+                              proc.rank,
+                              PMIx_Error_string (rc));
+            }
+            if (valp->type != PMIX_STRING) {
+                log_msg_exit ("PMIx_Get rank %d card: returned wrong type",
+                              proc.rank);
+            }
+            fprintf (stderr, "%s", valp->data.string);
+            PMIX_VALUE_RELEASE (valp);
+        }
+    }
+
+    /* Finalize
+     */
+    if ((rc = PMIx_Finalize (NULL, 0)) != PMIX_SUCCESS)
+        log_msg_exit ("PMIx_Finalize: %s", PMIx_Error_string (rc));
+    if (self.rank == 0)
+        log_msg ("completed PMIx_Finalize");
+
+    return 0;
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/src/shell/plugins/pmix/test/codec.c
+++ b/src/shell/plugins/pmix/test/codec.c
@@ -1,0 +1,71 @@
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <jansson.h>
+#include <pmix_server.h>
+
+#include "src/common/libtap/tap.h"
+
+#include "plugins/pmix/codec.h"
+
+void check_data (void)
+{
+    json_t *o;
+    char in_buf[64];
+    int in_len;
+    void *out_buf;
+    size_t out_len;
+
+    snprintf (in_buf, sizeof (in_buf), "foobar");
+    in_len = strlen (in_buf) + 1;
+    out_buf = NULL;
+    out_len = -1;
+    ok ((o = pp_data_encode (in_buf, in_len)) != NULL,
+        "pp_data_encode %d bytes works", in_len);
+    ok (pp_data_decode (o, &out_buf, &out_len) == 0,
+        "pp_data_decode works");
+    diag ("out_len = %d", out_len);
+    ok (out_len == in_len
+        && out_buf != NULL
+        && memcmp (in_buf, out_buf, out_len) == 0,
+        "pp_data_decode returned the correct value");
+    free (out_buf);
+}
+
+void check_pointer (void)
+{
+    json_t *o;
+    void *ptr_in;
+    void *ptr_out;
+
+    ptr_in = (void *)~0LL;
+    ptr_out = (void *)0xdeadbeef;
+    ok ((o = pp_pointer_encode (ptr_in)) != NULL,
+        "pp_pointer_encode ~0LL works");
+    ok (pp_pointer_decode (o, &ptr_out) == 0,
+        "pp_pointer_decode works");
+    ok (ptr_in == ptr_out,
+        "pp_pointer_decode returned the correct value");
+
+    ptr_in = 0;
+    ptr_out = (void *)0xdeadbeef;
+    ok ((o = pp_pointer_encode (ptr_in)) != NULL,
+        "pp_pointer_encode 0 works");
+    ok (pp_pointer_decode (o, &ptr_out) == 0,
+        "pp_pointer_decode works");
+    ok (ptr_in == ptr_out,
+        "pp_pointer_decode returned the correct value");
+}
+
+int main (int argc, char **argv)
+{
+    plan (NO_PLAN);
+
+    check_pointer ();
+    check_data ();
+
+    done_testing ();
+    return 0;
+}
+
+// vi:ts=4 sw=4 expandtab


### PR DESCRIPTION
OK, this is an experiment, and more WIP than most WIPs.  It adds a pmix plugin to the shell so that possibly we'll be better at launching openmpi someday (like in version 5 when they drop all other ways to launch it).

To replicate my environment, install openpmix 3.2.3 somewhere like `/usr/local` and configure flux with `--enable-pmix-bootstrap`.  Note that `libpmix2-3.1.5-1` packaged wtih Ubuntu 20.04 doesn't work.  I don't know whose fault it is, mine or theirs.  Avoid that version for now.  A `src/shell/plugins/pmix.so` module will be built that the shell currently loads automatically.   Automatic loading is not the desired endpoint with this for a variety of reasons, not least that it brings in libzmq and its dependencies, undoing all the work that @chu11 did to avoid the FIPS self-test penalty on TOSS 4.

Because our `openmpi.lua` plugin subverts openmpi's use of pmix, there is a temporary commit here that just comments that stuff out.  We'll need a long term solution for that.

The main innovation in this attempt is a mechanism to synchronize pmix callbacks/upcalls, which are made in the context of the pmix server thread, with the reactor in the shell thread. The real callbacks/upcalls are wrapped so that they create a message and send it over a shared memory zeromq socket.  The message is received by a reactor watcher for the other end of the socket, and the callback is reconstructed with the original signature.  This shenanigans is all neatly contained in `pmix/server.c` so for the most part, those functions still work as described in the pmix spec.

There are two pmix upcalls implemented, which I assumed were fundamental.  One is the "direct modex" callback in which we let the pmix server thread on one shell asks the pmix server thread on another shell for a particular rank's posted KVS keys.  This is implemented as a shell RPC. I'm not sure I totally got it right as I'm ignoring the `pmix.req.key=value` option that the server passes telling us to synchronize with the remote server to wait for specific KVS keys to be posted before asking for the keys in bulk.  But I don't know how that's supposed to work so for now, I just fetch the keys and hope they are there.

The other callback of interest is "fence_nb" which is the combo barrier/exchange operation as in  "normal" pmi.  I just mapped it to the tree-based exchange code in the pmi builtin plugin, which is not a great match in terms of its data handling, but gets the job done with a little extra base64 encoding.

I am able to run  an openmpi hello world across two shells with this.

Much more to do for this to be reasonable, but wanted to park it here in case it stimulated some discussion.

Here's a two task run  of hello world with some tracing enabled so we can see what openmpi + openpmi are doing:
```
$ flux mini run -n2 -N2 -overbose=2 ../../t/mpi/hello
0.030s: flux-shell[1]: DEBUG: 1: tasks [1] on cores 0
0.030s: flux-shell[1]: DEBUG: Loading /home/garlick/proj/flux-core/src/shell/initrc.lua
0.040s: flux-shell[1]: DEBUG: pmix: local_size 1
0.040s: flux-shell[1]: DEBUG: pmix: local_peers 1
0.061s: flux-shell[1]: TRACE: shell barrier complete
0.061s: flux-shell[1]: TRACE: exited barrier with rc = 0
0.065s: flux-shell[1]: TRACE: shell barrier complete
0.065s: flux-shell[1]: TRACE: exited barrier with rc = 0
0.027s: flux-shell[0]: DEBUG: 0: task_count=2 slot_count=2 cores_per_slot=1 slots_per_node=1
0.027s: flux-shell[0]: DEBUG: 0: tasks [0] on cores 0
0.027s: flux-shell[0]: DEBUG: Loading /home/garlick/proj/flux-core/src/shell/initrc.lua
0.031s: flux-shell[0]: DEBUG: output: batch timeout = 0.500s
0.060s: flux-shell[0]: DEBUG: pmix: job_size 2
0.060s: flux-shell[0]: DEBUG: pmix: proc_map 0;1
0.060s: flux-shell[0]: DEBUG: pmix: node_map pmix[system76-pc,system76-pc]
0.060s: flux-shell[0]: DEBUG: pmix: local_size 1
0.060s: flux-shell[0]: DEBUG: pmix: local_peers 0
0.061s: flux-shell[0]: TRACE: shell barrier complete
0.061s: flux-shell[0]: TRACE: exited barrier with rc = 0
0.065s: flux-shell[0]: TRACE: shell barrier complete
0.065s: flux-shell[0]: TRACE: exited barrier with rc = 0
0.078s: flux-shell[1]: TRACE: pmix: callback client_connected: {"proc":{"nspace":"flux","rank":1},"server_object":94501530846800,"cbfunc":0,"cbdata":0}
0.102s: flux-shell[0]: TRACE: pmix: callback client_connected: {"proc":{"nspace":"flux","rank":0},"server_object":94918678995712,"cbfunc":0,"cbdata":0}
0.103s: flux-shell[1]: TRACE: pmix: callback fence_nb: {"procs":[{"nspace":"flux","rank":-2}],"info":[{"key":"pmix.collect","flags":0,"value":{"type":1,"data":true}}],"data":"AAAAAQAPAAAAAAAAAGsAAAABAQAAAAEADwAAAAAAAABYAAAAAQAAAAEAAAABAAAADGJ0bC50Y3AuNC4wAAAbAA8AAAAAAAAAMAoAAg0AAAAAAAAAAAAAAAAEAAIAAAAAAKwRAAEAAAAAAAAAAAAAAAAEAAQAAAAAAA==","cbfunc":140412633177552,"cbdata":140412480209344}
0.151s: flux-shell[0]: TRACE: pmix: callback fence_nb: {"procs":[{"nspace":"flux","rank":-2}],"info":[{"key":"pmix.collect","flags":0,"value":{"type":1,"data":true}}],"data":"AAAAAQAPAAAAAAAAAJAAAAABAQAAAAEADwAAAAAAAAB9AAAAAQAAAAAAAAABAAAADGJ0bC50Y3AuNC4wAAAbAA8AAAAAAAAAMAoAAg0AAAAAAAAAAAAAAAAEAQIAAAAAAKwRAAEAAAAAAAAAAAAAAAAEAQQAAAAAAAAAAAEAAAANcG1sLmJhc2UuMi4wAAAbAA8AAAAAAAAABG9iMQA=","cbfunc":140062825557456,"cbdata":140062641701408}
0.151s: flux-shell[0]: TRACE: pmix: callback fence_nb: {"procs":[{"nspace":"flux","rank":-2}],"info":[],"data":"","cbfunc":140062825557456,"cbdata":140062641701408}
0.152s: flux-shell[0]: TRACE: pmix: callback dmodex_response_cb: {"status":0,"data":"AAAAAQAAAAxidGwudGNwLjQuMAAAGwAPAAAAAAAAADAKAAINAAAAAAAAAAAAAAAABAECAAAAAACsEQABAAAAAAAAAAAAAAAABAEEAAAAAAAAAAABAAAADXBtbC5iYXNlLjIuMAAAGwAPAAAAAAAAAARvYjEA","cbfunc":140062826328368,"cbdata":94918679066464}
0.154s: flux-shell[0]: TRACE: pmix: callback fence_nb: {"procs":[{"nspace":"flux","rank":-2}],"info":[],"data":"","cbfunc":140062825557456,"cbdata":140062641701408}
0.151s: flux-shell[1]: TRACE: pmix: callback direct_modex: {"proc":{"nspace":"flux","rank":0},"info":[{"key":"pmix.req.key","flags":0,"value":{"type":3,"data":"pml.base.2.0"}}],"cbfunc":140412633349504,"cbdata":140412480218224}
0.151s: flux-shell[1]: DEBUG: pmix: ignoring required dmodex pmix.req.key=pml.base.2.0 argument
0.152s: flux-shell[1]: TRACE: pmix-dmodex rpc shell_rank 0 proc 0
0.152s: flux-shell[1]: TRACE: pmix: callback fence_nb: {"procs":[{"nspace":"flux","rank":-2}],"info":[],"data":"","cbfunc":140412633177552,"cbdata":140412480209344}
0.154s: flux-shell[1]: TRACE: pmix: callback fence_nb: {"procs":[{"nspace":"flux","rank":-2}],"info":[],"data":"","cbfunc":140412633177552,"cbdata":140412480209344}
ƒXt6RLXR: completed MPI_Init in 0.079s.  There are 2 tasks
ƒXt6RLXR: completed first barrier in 0.002s
ƒXt6RLXR: completed MPI_Finalize in 0.046s
0.198s: flux-shell[0]: TRACE: pmix: callback client_finalized: {"proc":{"nspace":"flux","rank":0},"server_object":94918678995712,"cbfunc":140062825559312,"cbdata":140062641698544}
0.201s: flux-shell[0]: TRACE: 0: C: pmi EOF
0.201s: flux-shell[0]: DEBUG: task 0 complete status=0
0.198s: flux-shell[1]: TRACE: pmix: callback client_finalized: {"proc":{"nspace":"flux","rank":1},"server_object":94501530846800,"cbfunc":140412633179408,"cbdata":140412480212992}
0.201s: flux-shell[1]: TRACE: 1: C: pmi EOF
0.201s: flux-shell[1]: DEBUG: task 1 complete status=0
0.209s: flux-shell[0]: DEBUG: exit 0
0.210s: flux-shell[1]: DEBUG: exit 0
```

