### PR TITLE
allow jobtap plugins to subscribe to job events

### DIFF
--- a/doc/man7/flux-jobtap-plugins.rst
+++ b/doc/man7/flux-jobtap-plugins.rst
@@ -161,6 +161,14 @@ job.state.*
   eventlog, but before any action has been taken on that state (since the
   action could involve immediately transitioning to a new state)
 
+job.event.*
+  The ``job.event.*`` callbacks are only made for plugins that have explicitly
+  subscribed to a job with ``flux_jobtap_job_subscribe()``. In this case,
+  all job events result in this callback being invoked on all subscribed
+  plugins. This may be useful for plugins to get notification of events
+  that do not necessarily result in a state transition, e.g. the ``start``
+  event or a non-fatal ``exception``.
+
 job.state.depend
   The callback for ``FLUX_JOB_STATE_DEPEND`` is the final place from which
   a plugin may add dependencies to a job. Dependencies are added via

--- a/src/modules/job-manager/event.c
+++ b/src/modules/job-manager/event.c
@@ -650,6 +650,20 @@ static int event_jobtap_call (struct event *event,
                               json_t *entry,
                               flux_job_state_t old_state)
 {
+
+    /*  Notify any subscribers of all events, separately from
+     *   special cases for state change and urgency events below.
+     */
+    if (jobtap_notify_subscribers (event->ctx->jobtap,
+                                   job,
+                                   name,
+                                   "{s:O}",
+                                   "entry", entry) < 0)
+            flux_log (event->ctx->h, LOG_ERR,
+                      "jobtap: event.%s callback failed for job %ju",
+                      name,
+                      (uintmax_t) job->id);
+
     if (job->state != old_state) {
         /*
          *  Call plugin callback on state change

--- a/src/modules/job-manager/job.h
+++ b/src/modules/job-manager/job.h
@@ -17,6 +17,7 @@
 #include "src/common/libczmqcontainers/czmq_containers.h"
 #include "src/common/libjob/job.h"
 #include "src/common/libutil/grudgeset.h"
+#include "src/common/libflux/plugin.h"
 
 struct job {
     flux_jobid_t id;
@@ -42,6 +43,8 @@ struct job {
     json_t *annotations;
 
     struct grudgeset *dependencies;
+
+    zlistx_t *subscribers;  // list of plugins subscribed to all job events
 
     void *handle;           // zlistx_t handle
     int refcount;           // private to job.c
@@ -97,6 +100,12 @@ int job_flag_set (struct job *job, const char *flag);
 /*  Test if flag name 'flag' is a valid job flag
  */
 bool job_flag_valid (struct job *job, const char *flag);
+
+/*  Allow a flux_plugin_t to subscribe to all job events
+ */
+int job_events_subscribe (struct job *job, flux_plugin_t *p);
+
+void job_events_unsubscribe (struct job *job, flux_plugin_t *p);
 
 #endif /* _FLUX_JOB_MANAGER_JOB_H */
 

--- a/src/modules/job-manager/jobtap-internal.h
+++ b/src/modules/job-manager/jobtap-internal.h
@@ -78,6 +78,12 @@ void jobtap_handler (flux_t *h,
                      void *arg);
 
 
+int jobtap_notify_subscribers (struct jobtap *jobtap,
+                               struct job *job,
+                               const char *event_name,
+                               const char *fmt,
+                               ...);
+
 #endif /* _FLUX_JOB_MANAGER_JOBTAP_H */
 
 /*

--- a/src/modules/job-manager/jobtap.h
+++ b/src/modules/job-manager/jobtap.h
@@ -177,6 +177,18 @@ int flux_jobtap_get_job_result (flux_plugin_t *p,
                                 flux_job_result_t *resultp);
 
 
+/*
+ *  This function subscribes plugin 'p' to extra callbacks for job 'id'
+ *   such as job.event.<name> for each job event. The plugin must have a
+ *   handler registered that matches one or more of these callbacks.
+ */
+int flux_jobtap_job_subscribe (flux_plugin_t *p, flux_jobid_t id);
+
+
+/*  Unsubscribe plugin 'p' from extra callbacks for job 'id'
+ */
+void flux_jobtap_job_unsubscribe (flux_plugin_t *p, flux_jobid_t id);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/modules/job-manager/restart.c
+++ b/src/modules/job-manager/restart.c
@@ -14,8 +14,6 @@
 #include "config.h"
 #endif
 #include <stdlib.h>
-#include <argz.h>
-#include <envz.h>
 #include <flux/core.h>
 
 #include "src/common/libutil/fluid.h"

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -374,6 +374,7 @@ check_LTLIBRARIES = \
 	job-manager/plugins/random.la \
 	job-manager/plugins/validate.la \
 	job-manager/plugins/dependency-test.la \
+	job-manager/plugins/subscribe.la \
 	stats/stats-basic.la \
 	stats/stats-immediate.la
 
@@ -711,6 +712,15 @@ job_manager_plugins_args_la_CPPFLAGS = \
 job_manager_plugins_args_la_LDFLAGS = \
 	$(fluxplugin_ldflags) -module -rpath /nowhere
 job_manager_plugins_args_la_LIBADD = \
+	$(top_builddir)/src/common/libflux-core.la
+
+job_manager_plugins_subscribe_la_SOURCES = \
+	job-manager/plugins/subscribe.c
+job_manager_plugins_subscribe_la_CPPFLAGS = \
+	$(test_cppflags)
+job_manager_plugins_subscribe_la_LDFLAGS = \
+	$(fluxplugin_ldflags) -module -rpath /nowhere
+job_manager_plugins_subscribe_la_LIBADD = \
 	$(top_builddir)/src/common/libflux-core.la
 
 job_manager_plugins_test_la_SOURCES = \

--- a/t/job-manager/plugins/args.c
+++ b/t/job-manager/plugins/args.c
@@ -50,6 +50,16 @@ static int cb (flux_plugin_t *p,
         return -1;
     }
 
+    if (strcmp (topic, "job.new") == 0) {
+        /*  Subscribe to events so we get all job.event.* callbacks */
+        if (flux_jobtap_job_subscribe (p, FLUX_JOBTAP_CURRENT_JOB) < 0) {
+            flux_log (h,
+                      LOG_ERR,
+                      "%s: jobtap_job_subscribe: %s",
+                       topic,
+                       strerror (errno));
+        }
+    }
     if (strncmp (topic, "job.state.", 10) == 0) {
         if (entry == NULL
             || state == 4096

--- a/t/job-manager/plugins/subscribe.c
+++ b/t/job-manager/plugins/subscribe.c
@@ -1,0 +1,66 @@
+#include <stdio.h>
+#include <jansson.h>
+
+#include <flux/core.h>
+#include <flux/jobtap.h>
+
+static int cb (flux_plugin_t *p,
+               const char *topic,
+               flux_plugin_arg_t *args,
+               void *arg)
+{
+    flux_t *h = flux_jobtap_get_flux (p);
+
+    if (strcmp (topic, "job.event.start") == 0)
+        flux_jobtap_job_unsubscribe (p, FLUX_JOBTAP_CURRENT_JOB);
+    else if (strcmp (topic, "job.event.finish") == 0) {
+        flux_jobtap_raise_exception (p, FLUX_JOBTAP_CURRENT_JOB,
+                                     "subscribe-test",
+                                     0,
+                                     "unexpectedly got finish event",
+                                     strerror (errno));
+        return -1;
+    }
+
+    flux_log (h, LOG_INFO, "subscribe-check: %s: OK", topic);
+    if (strcmp (topic, "job.event.start") == 0) {
+        // Test for nonzero exit from job.event.* callback:
+        return -1;
+    }
+    else
+        return 0;
+}
+
+static int new_cb (flux_plugin_t *p,
+                   const char *topic,
+                   flux_plugin_arg_t *args,
+                   void *arg)
+{
+    /*  Test invalid arguments */
+    flux_jobtap_job_unsubscribe (NULL, 0);
+    flux_jobtap_job_unsubscribe (p, 0);
+    if (flux_jobtap_job_subscribe (NULL, 0) != -1
+        || flux_jobtap_job_subscribe (p, 0) != -1)
+        return flux_jobtap_reject_job (p, args,
+                                       "subscribe-test: "
+                                       "invalid args check failed");
+    if (flux_jobtap_job_subscribe (p, FLUX_JOBTAP_CURRENT_JOB) < 0)
+        return flux_jobtap_reject_job (p, args,
+                                       "subscribe-test: "
+                                       "flux_jobtap_job_subscribe: %s",
+                                       strerror (errno));
+    return 0;
+}
+
+int flux_plugin_init (flux_plugin_t *p)
+{
+    flux_t *h = flux_jobtap_get_flux (p);
+    flux_plugin_set_name (p, "subscribe-test");
+
+    if (flux_plugin_add_handler (p, "job.event.*", cb, NULL) < 0
+        || flux_plugin_add_handler (p, "job.validate", new_cb, NULL) < 0) {
+        flux_log_error (h, "flux_plugin_add_handler");
+        return -1;
+    }
+    return 0;
+}

--- a/t/t2212-job-manager-plugins.t
+++ b/t/t2212-job-manager-plugins.t
@@ -190,6 +190,13 @@ test_expect_success 'job-manager: run args test plugin' '
 	test_debug "cat args-check.log" &&
 	test $(grep -c OK args-check.log) = 17
 '
+test_expect_success 'job-manager: run subscribe test plugin' '
+	flux jobtap load --remove=all ${PLUGINPATH}/subscribe.so &&
+	flux mini run hostname &&
+	flux dmesg | grep subscribe-check > subscribe-check.log &&
+	test_debug "cat subscribe-check.log" &&
+	test $(grep -c OK subscribe-check.log) = 5
+'
 test_expect_success 'job-manager: run job_aux test plugin' '
 	flux jobtap load --remove=all ${PLUGINPATH}/job_aux.so &&
 	flux mini run hostname

--- a/t/t2212-job-manager-plugins.t
+++ b/t/t2212-job-manager-plugins.t
@@ -188,7 +188,7 @@ test_expect_success 'job-manager: run args test plugin' '
 	flux mini run hostname &&
 	flux dmesg | grep args-check > args-check.log &&
 	test_debug "cat args-check.log" &&
-	test $(grep -c OK args-check.log) = 8
+	test $(grep -c OK args-check.log) = 17
 '
 test_expect_success 'job-manager: run job_aux test plugin' '
 	flux jobtap load --remove=all ${PLUGINPATH}/job_aux.so &&


### PR DESCRIPTION
This work was done in anticipation of future requirements for some jobtap plugins to get callbacks on job events and not just job state transitions (and priority/urgency events). This could probably be implemented by separately watching the job eventlog, but this has high development cost and is wasteful, since all events go through the job manager anyway.

Issuing a callback for all loaded plugins on every job event would probably be high cost, therefore this approach requires plugins that want these extra  callbacks to "subscribe" to events for the job. This means that in the common case, this change should add no overhead, and only plugins which are interested in all job events will have `job.event.*` callbacks called.

Unfortunately the resulting code was a little more complicated than I had hoped. Since a plugin subscribed to jobs could be unloaded before the jobs are inactive, and jobs can go inactive before a plugin is unloaded, each plugin has to keep a list of its subscriptions in addition to the job's list of subscribed plugins. Then on destruction, each entity has to be removed from the alternate list.

Finally, to make good use of the new functionality, the dependency-after plugin uses a job subscription for `after` dependencies to release jobs after the `start` event, instead of after the transition to the `RUN` state (technically after the `alloc` event)

(Thinking of release notes, perhaps this last change should be moved to a separate PR)

This is still WIP because a more comprehensive test plugin should be added that exercises the new functionality.