### PR TITLE
jobtap: allow jobtap plugins to query posted events for jobs

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -165,7 +165,10 @@ AC_CHECK_HEADERS( \
 ##
 # Checks for typedefs, structures, and compiler characteristics
 ##
-AC_C_BIGENDIAN
+AC_C_BIGENDIAN(
+  [AC_DEFINE([HAVE_BIG_ENDIAN], [1], [big endian])],
+  [AC_DEFINE([HAVE_LITTLE_ENDIAN], [1], [little endian])]
+)
 AC_C_CONST
 AC_TYPE_SIZE_T
 AX_COMPILE_CHECK_SIZEOF(int)

--- a/src/common/libccan/Makefile.am
+++ b/src/common/libccan/Makefile.am
@@ -23,5 +23,7 @@ libccan_la_SOURCES = \
 	ccan/bitmap/bitmap.h \
 	ccan/bitmap/bitmap.c \
 	ccan/endian/endian.h \
+	ccan/compiler/compiler.h \
+	ccan/ptrint/ptrint.h \
 	ccan/build_assert/build_assert.h \
 	ccan/container_of/container_of.h

--- a/src/common/libccan/Makefile.am
+++ b/src/common/libccan/Makefile.am
@@ -20,5 +20,8 @@ libccan_la_SOURCES = \
 	ccan/list/list.h \
 	ccan/base64/base64.c \
 	ccan/base64/base64.h \
+	ccan/bitmap/bitmap.h \
+	ccan/bitmap/bitmap.c \
+	ccan/endian/endian.h \
 	ccan/build_assert/build_assert.h \
 	ccan/container_of/container_of.h

--- a/src/common/libccan/ccan/bitmap/LICENSE
+++ b/src/common/libccan/ccan/bitmap/LICENSE
@@ -1,0 +1,1 @@
+../../licenses/LGPL-2.1

--- a/src/common/libccan/ccan/bitmap/_info
+++ b/src/common/libccan/ccan/bitmap/_info
@@ -1,0 +1,32 @@
+#include "config.h"
+#include <stdio.h>
+#include <string.h>
+
+/**
+ * bitmap - bitmap handling
+ *
+ * This code handles manipulation of bitmaps, arbitrary length arrays
+ * of bits.
+ *
+ * License: LGPL (v2.1 or any later version)
+ * Author: David Gibson <david@gibson.dropbear.id.au>
+ */
+int main(int argc, char *argv[])
+{
+	/* Expect exactly one argument */
+	if (argc != 2)
+		return 1;
+
+	if (strcmp(argv[1], "depends") == 0) {
+		printf("ccan/endian\n");
+		return 0;
+	}
+
+        if (strcmp(argv[1], "testdepends") == 0) {
+                printf("ccan/array_size\n");
+		printf("ccan/foreach\n");
+                return 0;
+        }
+
+	return 1;
+}

--- a/src/common/libccan/ccan/bitmap/bitmap.c
+++ b/src/common/libccan/ccan/bitmap/bitmap.c
@@ -1,0 +1,125 @@
+/* Licensed under LGPLv2.1+ - see LICENSE file for details */
+
+#include "config.h"
+
+#include <ccan/bitmap/bitmap.h>
+
+#include <assert.h>
+
+#define BIT_ALIGN_DOWN(n)	((n) & ~(BITMAP_WORD_BITS - 1))
+#define BIT_ALIGN_UP(n)		BIT_ALIGN_DOWN((n) + BITMAP_WORD_BITS - 1)
+
+void bitmap_zero_range(bitmap *bitmap, unsigned long n, unsigned long m)
+{
+	unsigned long an = BIT_ALIGN_UP(n);
+	unsigned long am = BIT_ALIGN_DOWN(m);
+	bitmap_word headmask = BITMAP_WORD_1 >> (n % BITMAP_WORD_BITS);
+	bitmap_word tailmask = ~(BITMAP_WORD_1 >> (m % BITMAP_WORD_BITS));
+
+	assert(m >= n);
+
+	if (am < an) {
+		BITMAP_WORD(bitmap, n) &= ~bitmap_bswap(headmask & tailmask);
+		return;
+	}
+
+	if (an > n)
+		BITMAP_WORD(bitmap, n) &= ~bitmap_bswap(headmask);
+
+	if (am > an)
+		memset(&BITMAP_WORD(bitmap, an), 0,
+		       (am - an) / BITMAP_WORD_BITS * sizeof(bitmap_word));
+
+	if (m > am)
+		BITMAP_WORD(bitmap, m) &= ~bitmap_bswap(tailmask);
+}
+
+void bitmap_fill_range(bitmap *bitmap, unsigned long n, unsigned long m)
+{
+	unsigned long an = BIT_ALIGN_UP(n);
+	unsigned long am = BIT_ALIGN_DOWN(m);
+	bitmap_word headmask = BITMAP_WORD_1 >> (n % BITMAP_WORD_BITS);
+	bitmap_word tailmask = ~(BITMAP_WORD_1 >> (m % BITMAP_WORD_BITS));
+
+	assert(m >= n);
+
+	if (am < an) {
+		BITMAP_WORD(bitmap, n) |= bitmap_bswap(headmask & tailmask);
+		return;
+	}
+
+	if (an > n)
+		BITMAP_WORD(bitmap, n) |= bitmap_bswap(headmask);
+
+	if (am > an)
+		memset(&BITMAP_WORD(bitmap, an), 0xff,
+		       (am - an) / BITMAP_WORD_BITS * sizeof(bitmap_word));
+
+	if (m > am)
+		BITMAP_WORD(bitmap, m) |= bitmap_bswap(tailmask);
+}
+
+static int bitmap_clz(bitmap_word w)
+{
+#if HAVE_BUILTIN_CLZL
+	return __builtin_clzl(w);
+#else
+	int lz = 0;
+	bitmap_word mask = (bitmap_word)1 << (BITMAP_WORD_BITS - 1);
+
+	while (!(w & mask)) {
+		lz++;
+		mask >>= 1;
+	}
+
+	return lz;
+#endif
+}
+
+unsigned long bitmap_ffs(const bitmap *bitmap,
+			 unsigned long n, unsigned long m)
+{
+	unsigned long an = BIT_ALIGN_UP(n);
+	unsigned long am = BIT_ALIGN_DOWN(m);
+	bitmap_word headmask = BITMAP_WORD_1 >> (n % BITMAP_WORD_BITS);
+	bitmap_word tailmask = ~(BITMAP_WORD_1 >> (m % BITMAP_WORD_BITS));
+
+	assert(m >= n);
+
+	if (am < an) {
+		bitmap_word w = bitmap_bswap(BITMAP_WORD(bitmap, n));
+
+		w &= (headmask & tailmask);
+
+		return w ? am + bitmap_clz(w) : m;
+	}
+
+	if (an > n) {
+		bitmap_word w = bitmap_bswap(BITMAP_WORD(bitmap, n));
+
+		w &= headmask;
+
+		if (w)
+			return BIT_ALIGN_DOWN(n) + bitmap_clz(w);
+	}
+
+	while (an < am) {
+		bitmap_word w = bitmap_bswap(BITMAP_WORD(bitmap, an));
+
+		if (w)
+			return an + bitmap_clz(w);
+
+		an += BITMAP_WORD_BITS;
+	}
+
+	if (m > am) {
+		bitmap_word w = bitmap_bswap(BITMAP_WORD(bitmap, m));
+
+		w &= tailmask;
+
+		if (w)
+			return am + bitmap_clz(w);
+	}
+
+	return m;
+}

--- a/src/common/libccan/ccan/bitmap/bitmap.h
+++ b/src/common/libccan/ccan/bitmap/bitmap.h
@@ -1,0 +1,246 @@
+/* Licensed under LGPLv2+ - see LICENSE file for details */
+#ifndef CCAN_BITMAP_H_
+#define CCAN_BITMAP_H_
+
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+#include <limits.h>
+
+#include <ccan/endian/endian.h>
+
+typedef unsigned long bitmap_word;
+
+#define BITMAP_WORD_BITS	(sizeof(bitmap_word) * CHAR_BIT)
+#define BITMAP_NWORDS(_n)	\
+	(((_n) + BITMAP_WORD_BITS - 1) / BITMAP_WORD_BITS)
+
+#define BITMAP_WORD_0		(0)
+#define BITMAP_WORD_1		((bitmap_word)-1UL)
+
+/*
+ * We wrap each word in a structure for type checking.
+ */
+typedef struct bitmap {
+	bitmap_word w;
+} bitmap;
+
+#define BITMAP_DECLARE(_name, _nbits) \
+	bitmap (_name)[BITMAP_NWORDS(_nbits)]
+
+static inline size_t bitmap_sizeof(unsigned long nbits)
+{
+	return BITMAP_NWORDS(nbits) * sizeof(bitmap_word);
+}
+
+static inline bitmap_word bitmap_bswap(bitmap_word w)
+{
+	if (BITMAP_WORD_BITS == 32)
+		return (ENDIAN_CAST bitmap_word)cpu_to_be32(w);
+	else if (BITMAP_WORD_BITS == 64)
+		return (ENDIAN_CAST bitmap_word)cpu_to_be64(w);
+}
+
+#define BITMAP_WORD(_bm, _n)	((_bm)[(_n) / BITMAP_WORD_BITS].w)
+#define BITMAP_WORDBIT(_n) 	\
+	(bitmap_bswap(1UL << (BITMAP_WORD_BITS - ((_n) % BITMAP_WORD_BITS) - 1)))
+
+#define BITMAP_HEADWORDS(_nbits) \
+	((_nbits) / BITMAP_WORD_BITS)
+#define BITMAP_HEADBYTES(_nbits) \
+	(BITMAP_HEADWORDS(_nbits) * sizeof(bitmap_word))
+
+#define BITMAP_TAILWORD(_bm, _nbits) \
+	((_bm)[BITMAP_HEADWORDS(_nbits)].w)
+#define BITMAP_HASTAIL(_nbits)	(((_nbits) % BITMAP_WORD_BITS) != 0)
+#define BITMAP_TAILBITS(_nbits)	\
+	(bitmap_bswap(~(-1UL >> ((_nbits) % BITMAP_WORD_BITS))))
+#define BITMAP_TAIL(_bm, _nbits) \
+	(BITMAP_TAILWORD(_bm, _nbits) & BITMAP_TAILBITS(_nbits))
+
+static inline void bitmap_set_bit(bitmap *bitmap, unsigned long n)
+{
+	BITMAP_WORD(bitmap, n) |= BITMAP_WORDBIT(n);
+}
+
+static inline void bitmap_clear_bit(bitmap *bitmap, unsigned long n)
+{
+	BITMAP_WORD(bitmap, n) &= ~BITMAP_WORDBIT(n);
+}
+
+static inline void bitmap_change_bit(bitmap *bitmap, unsigned long n)
+{
+	BITMAP_WORD(bitmap, n) ^= BITMAP_WORDBIT(n);
+}
+
+static inline bool bitmap_test_bit(const bitmap *bitmap, unsigned long n)
+{
+	return !!(BITMAP_WORD(bitmap, n) & BITMAP_WORDBIT(n));
+}
+
+void bitmap_zero_range(bitmap *bitmap, unsigned long n, unsigned long m);
+void bitmap_fill_range(bitmap *bitmap, unsigned long n, unsigned long m);
+
+static inline void bitmap_zero(bitmap *bitmap, unsigned long nbits)
+{
+	memset(bitmap, 0, bitmap_sizeof(nbits));
+}
+
+static inline void bitmap_fill(bitmap *bitmap, unsigned long nbits)
+{
+	memset(bitmap, 0xff, bitmap_sizeof(nbits));
+}
+
+static inline void bitmap_copy(bitmap *dst, const bitmap *src,
+			       unsigned long nbits)
+{
+	memcpy(dst, src, bitmap_sizeof(nbits));
+}
+
+#define BITMAP_DEF_BINOP(_name, _op) \
+	static inline void bitmap_##_name(bitmap *dst, bitmap *src1, bitmap *src2, \
+					  unsigned long nbits)		\
+	{ \
+		unsigned long i = 0; \
+		for (i = 0; i < BITMAP_NWORDS(nbits); i++) { \
+			dst[i].w = src1[i].w _op src2[i].w; \
+		} \
+	}
+
+BITMAP_DEF_BINOP(and, &)
+BITMAP_DEF_BINOP(or, |)
+BITMAP_DEF_BINOP(xor, ^)
+BITMAP_DEF_BINOP(andnot, & ~)
+
+#undef BITMAP_DEF_BINOP
+
+static inline void bitmap_complement(bitmap *dst, const bitmap *src,
+				     unsigned long nbits)
+{
+	unsigned long i;
+
+	for (i = 0; i < BITMAP_NWORDS(nbits); i++)
+		dst[i].w = ~src[i].w;
+}
+
+static inline bool bitmap_equal(const bitmap *src1, const bitmap *src2,
+				unsigned long nbits)
+{
+	return (memcmp(src1, src2, BITMAP_HEADBYTES(nbits)) == 0)
+		&& (!BITMAP_HASTAIL(nbits)
+		    || (BITMAP_TAIL(src1, nbits) == BITMAP_TAIL(src2, nbits)));
+}
+
+static inline bool bitmap_intersects(const bitmap *src1, const bitmap *src2,
+				     unsigned long nbits)
+{
+	unsigned long i;
+
+	for (i = 0; i < BITMAP_HEADWORDS(nbits); i++) {
+		if (src1[i].w & src2[i].w)
+			return true;
+	}
+	if (BITMAP_HASTAIL(nbits) &&
+	    (BITMAP_TAIL(src1, nbits) & BITMAP_TAIL(src2, nbits)))
+		return true;
+	return false;
+}
+
+static inline bool bitmap_subset(const bitmap *src1, const bitmap *src2,
+				 unsigned long nbits)
+{
+	unsigned long i;
+
+	for (i = 0; i < BITMAP_HEADWORDS(nbits); i++) {
+		if (src1[i].w  & ~src2[i].w)
+			return false;
+	}
+	if (BITMAP_HASTAIL(nbits) &&
+	    (BITMAP_TAIL(src1, nbits) & ~BITMAP_TAIL(src2, nbits)))
+		return false;
+	return true;
+}
+
+static inline bool bitmap_full(const bitmap *bitmap, unsigned long nbits)
+{
+	unsigned long i;
+
+	for (i = 0; i < BITMAP_HEADWORDS(nbits); i++) {
+		if (bitmap[i].w != -1UL)
+			return false;
+	}
+	if (BITMAP_HASTAIL(nbits) &&
+	    (BITMAP_TAIL(bitmap, nbits) != BITMAP_TAILBITS(nbits)))
+		return false;
+
+	return true;
+}
+
+static inline bool bitmap_empty(const bitmap *bitmap, unsigned long nbits)
+{
+	unsigned long i;
+
+	for (i = 0; i < BITMAP_HEADWORDS(nbits); i++) {
+		if (bitmap[i].w != 0)
+			return false;
+	}
+	if (BITMAP_HASTAIL(nbits) && (BITMAP_TAIL(bitmap, nbits) != 0))
+		return false;
+
+	return true;
+}
+
+unsigned long bitmap_ffs(const bitmap *bitmap,
+			 unsigned long n, unsigned long m);
+
+/*
+ * Allocation functions
+ */
+static inline bitmap *bitmap_alloc(unsigned long nbits)
+{
+	return malloc(bitmap_sizeof(nbits));
+}
+
+static inline bitmap *bitmap_alloc0(unsigned long nbits)
+{
+	bitmap *bitmap;
+
+	bitmap = bitmap_alloc(nbits);
+	if (bitmap)
+		bitmap_zero(bitmap, nbits);
+	return bitmap;
+}
+
+static inline bitmap *bitmap_alloc1(unsigned long nbits)
+{
+	bitmap *bitmap;
+
+	bitmap = bitmap_alloc(nbits);
+	if (bitmap)
+		bitmap_fill(bitmap, nbits);
+	return bitmap;
+}
+
+static inline bitmap *bitmap_realloc0(bitmap *bitmap,
+				      unsigned long obits, unsigned long nbits)
+{
+	bitmap = realloc(bitmap, bitmap_sizeof(nbits));
+
+	if ((nbits > obits) && bitmap)
+		bitmap_zero_range(bitmap, obits, nbits);
+
+	return bitmap;
+}
+
+static inline bitmap *bitmap_realloc1(bitmap *bitmap,
+				      unsigned long obits, unsigned long nbits)
+{
+	bitmap = realloc(bitmap, bitmap_sizeof(nbits));
+
+	if ((nbits > obits) && bitmap)
+		bitmap_fill_range(bitmap, obits, nbits);
+
+	return bitmap;
+}
+
+#endif /* CCAN_BITMAP_H_ */

--- a/src/common/libccan/ccan/bitmap/test/run-alloc.c
+++ b/src/common/libccan/ccan/bitmap/test/run-alloc.c
@@ -1,0 +1,101 @@
+#include <ccan/bitmap/bitmap.h>
+#include <ccan/tap/tap.h>
+#include <ccan/array_size/array_size.h>
+#include <ccan/foreach/foreach.h>
+
+#include <ccan/bitmap/bitmap.c>
+
+int bitmap_sizes[] = {
+	1, 2, 3, 4, 5, 6, 7, 8,
+	16, 17, 24, 32, 33,
+	64, 65, 127, 128, 129,
+	1023, 1024, 1025,
+};
+#define NSIZES ARRAY_SIZE(bitmap_sizes)
+#define NTESTS_BASE 4
+#define NTESTS_REALLOC 10
+
+static void test_basic_alloc(int nbits)
+{
+	bitmap *bitmap;
+
+	bitmap = bitmap_alloc0(nbits);
+	ok1(bitmap != NULL);
+	ok1(bitmap_empty(bitmap, nbits));
+
+	free(bitmap);
+
+	bitmap = bitmap_alloc1(nbits);
+	ok1(bitmap != NULL);
+	ok1(bitmap_full(bitmap, nbits));
+
+	free(bitmap);
+}
+
+static void test_realloc(int obits, int nbits)
+{
+	bitmap *bitmap;
+	int i;
+	bool wrong;
+
+	bitmap = bitmap_alloc0(obits);
+	ok1(bitmap != NULL);
+	ok1(bitmap_empty(bitmap, obits));
+
+	bitmap = bitmap_realloc1(bitmap, obits, nbits);
+	ok1(bitmap != NULL);
+	if (obits < nbits)
+		ok1(bitmap_empty(bitmap, obits));
+	else
+		ok1(bitmap_empty(bitmap, nbits));
+
+	wrong = false;
+	for (i = obits; i < nbits; i++)
+		wrong = wrong || !bitmap_test_bit(bitmap, i);
+	ok1(!wrong);
+
+	free(bitmap);
+
+	bitmap = bitmap_alloc1(obits);
+	ok1(bitmap != NULL);
+	ok1(bitmap_full(bitmap, obits));
+
+	bitmap = bitmap_realloc0(bitmap, obits, nbits);
+	ok1(bitmap != NULL);
+	if (obits < nbits)
+		ok1(bitmap_full(bitmap, obits));
+	else
+		ok1(bitmap_full(bitmap, nbits));
+
+	wrong = false;
+	for (i = obits; i < nbits; i++)
+		wrong = wrong || bitmap_test_bit(bitmap, i);
+	ok1(!wrong);
+
+	free(bitmap);
+}
+
+int main(void)
+{
+	int i, j;
+
+	/* This is how many tests you plan to run */
+	plan_tests(NSIZES * NTESTS_BASE + NSIZES * NSIZES * NTESTS_REALLOC);
+
+	for (i = 0; i < NSIZES; i++) {
+		diag("Testing %d-bit bitmap", bitmap_sizes[i]);
+		test_basic_alloc(bitmap_sizes[i]);
+	}
+
+	for (i = 0; i < NSIZES; i++) {
+		for (j = 0; j < NSIZES; j++) {
+			diag("Testing %d-bit => %d-bit bitmap",
+			     bitmap_sizes[i], bitmap_sizes[j]);
+
+			test_realloc(bitmap_sizes[i], bitmap_sizes[j]);
+		}
+	}
+
+	/* This exits depending on whether all tests passed */
+	return exit_status();
+}

--- a/src/common/libccan/ccan/bitmap/test/run-ffs.c
+++ b/src/common/libccan/ccan/bitmap/test/run-ffs.c
@@ -1,0 +1,74 @@
+#include <ccan/bitmap/bitmap.h>
+#include <ccan/tap/tap.h>
+#include <ccan/array_size/array_size.h>
+#include <ccan/foreach/foreach.h>
+
+#include <ccan/bitmap/bitmap.c>
+
+int bitmap_sizes[] = {
+	1, 2, 3, 4, 5, 6, 7, 8,
+	16, 17, 24, 32, 33,
+	64, 65, 127, 128, 129,
+	1023, 1024, 1025,
+};
+#define NSIZES ARRAY_SIZE(bitmap_sizes)
+
+#define ok_eq(a, b) \
+	ok((a) == (b), "%s [%u] == %s [%u]", \
+	   #a, (unsigned)(a), #b, (unsigned)(b))
+
+static void test_size(int nbits)
+{
+	BITMAP_DECLARE(bitmap, nbits);
+	int i;
+
+	bitmap_zero(bitmap, nbits);
+	ok_eq(bitmap_ffs(bitmap, 0, nbits), nbits);
+
+	for (i = 0; i < nbits; i++) {
+		bitmap_zero(bitmap, nbits);
+		bitmap_set_bit(bitmap, i);
+
+		ok_eq(bitmap_ffs(bitmap, 0, nbits), i);
+		ok_eq(bitmap_ffs(bitmap, i, nbits), i);
+		ok_eq(bitmap_ffs(bitmap, i + 1, nbits), nbits);
+
+		bitmap_zero(bitmap, nbits);
+		bitmap_fill_range(bitmap, i, nbits);
+
+		ok_eq(bitmap_ffs(bitmap, 0, nbits), i);
+		ok_eq(bitmap_ffs(bitmap, i, nbits), i);
+		ok_eq(bitmap_ffs(bitmap, i + 1, nbits), (i + 1));
+		ok_eq(bitmap_ffs(bitmap, nbits - 1, nbits), (nbits - 1));
+
+		if (i > 0) {
+			ok_eq(bitmap_ffs(bitmap, 0, i), i);
+			ok_eq(bitmap_ffs(bitmap, 0, i - 1), (i - 1));
+		}
+
+		if (i > 0) {
+			bitmap_zero(bitmap, nbits);
+			bitmap_fill_range(bitmap, 0, i);
+
+			ok_eq(bitmap_ffs(bitmap, 0, nbits), 0);
+			ok_eq(bitmap_ffs(bitmap, i - 1, nbits), (i - 1));
+			ok_eq(bitmap_ffs(bitmap, i, nbits), nbits);
+		}
+	}
+}
+
+int main(void)
+{
+	int i;
+
+	/* Too complicated to work out the exact number */
+	plan_no_plan();
+
+	for (i = 0; i < NSIZES; i++) {
+		diag("Testing %d-bit bitmap", bitmap_sizes[i]);
+		test_size(bitmap_sizes[i]);
+	}
+
+	/* This exits depending on whether all tests passed */
+	return exit_status();
+}

--- a/src/common/libccan/ccan/bitmap/test/run-ranges.c
+++ b/src/common/libccan/ccan/bitmap/test/run-ranges.c
@@ -1,0 +1,77 @@
+#include <ccan/bitmap/bitmap.h>
+#include <ccan/tap/tap.h>
+#include <ccan/array_size/array_size.h>
+#include <ccan/foreach/foreach.h>
+
+#include <ccan/bitmap/bitmap.c>
+
+int bitmap_sizes[] = {
+	1, 2, 3, 4, 5, 6, 7, 8,
+	16, 24, 32, 64, 256,
+	/*
+	 * Don't put too big sizes in here, or it will take forever to
+	 * run under valgrind (the test is O(n^3)).
+	 */
+};
+#define NSIZES ARRAY_SIZE(bitmap_sizes)
+#define NTESTS 2
+
+static void test_size(int nbits)
+{
+	BITMAP_DECLARE(bitmap, nbits);
+	uint32_t marker = 0xdeadbeef;
+	int i, j, k;
+	bool wrong;
+
+	for (i = 0; i < nbits; i++) {
+		for (j = i; j <= nbits; j++) {
+			bitmap_zero(bitmap, nbits);
+			bitmap_fill_range(bitmap, i, j);
+
+			wrong = false;
+			for (k = 0; k < nbits; k++) {
+				bool inrange = (k >= i) && (k < j);
+				wrong = wrong || (bitmap_test_bit(bitmap, k) != inrange);
+			}
+			ok1(!wrong);
+		}
+	}
+
+	for (i = 0; i < nbits; i++) {
+		for (j = i; j <= nbits; j++) {
+			bitmap_fill(bitmap, nbits);
+			bitmap_zero_range(bitmap, i, j);
+
+			wrong = false;
+			for (k = 0; k < nbits; k++) {
+				bool inrange = (k >= i) && (k < j);
+				wrong = wrong || (bitmap_test_bit(bitmap, k) == inrange);
+			}
+			ok1(!wrong);
+		}
+	}
+
+	ok1(marker == 0xdeadbeef);
+}
+
+int main(void)
+{
+	int totaltests = 0;
+	int i;
+
+	for (i = 0; i < NSIZES; i++) {
+		int size = bitmap_sizes[i];
+
+		/* Summing the arithmetic series gives: */
+		totaltests += size*(size + 3) + 1;
+	}
+	plan_tests(totaltests);
+
+	for (i = 0; i < NSIZES; i++) {
+		diag("Testing %d-bit bitmap", bitmap_sizes[i]);
+		test_size(bitmap_sizes[i]);
+	}
+
+	/* This exits depending on whether all tests passed */
+	return exit_status();
+}

--- a/src/common/libccan/ccan/bitmap/test/run.c
+++ b/src/common/libccan/ccan/bitmap/test/run.c
@@ -1,0 +1,118 @@
+#include <ccan/bitmap/bitmap.h>
+#include <ccan/tap/tap.h>
+#include <ccan/array_size/array_size.h>
+#include <ccan/foreach/foreach.h>
+
+#include <ccan/bitmap/bitmap.c>
+
+int bitmap_sizes[] = {
+	1, 2, 3, 4, 5, 6, 7, 8,
+	16, 17, 24, 32, 33,
+	64, 65, 127, 128, 129,
+	1023, 1024, 1025,
+};
+#define NSIZES ARRAY_SIZE(bitmap_sizes)
+#define NTESTS 9
+
+static void test_sizes(int nbits, bool dynalloc)
+{
+	BITMAP_DECLARE(sbitmap, nbits);
+	uint32_t marker;
+	bitmap *bitmap;
+	int i, j;
+	bool wrong;
+
+	if (dynalloc) {
+		bitmap = bitmap_alloc(nbits);
+		ok1(bitmap != NULL);
+	} else {
+		bitmap = sbitmap;
+		marker = 0xdeadbeef;
+	}
+
+	bitmap_zero(bitmap, nbits);
+	wrong = false;
+	for (i = 0; i < nbits; i++) {
+		wrong = wrong || bitmap_test_bit(bitmap, i);
+	}
+	ok1(!wrong);
+
+	bitmap_fill(bitmap, nbits);
+	wrong = false;
+	for (i = 0; i < nbits; i++) {
+		wrong = wrong || !bitmap_test_bit(bitmap, i);
+	}
+	ok1(!wrong);
+
+	wrong = false;
+	for (i = 0; i < nbits; i++) {
+		bitmap_zero(bitmap, nbits);
+		bitmap_set_bit(bitmap, i);
+		for (j = 0; j < nbits; j++) {
+			bool val = (i == j);
+
+			wrong = wrong || (bitmap_test_bit(bitmap, j) != val);
+		}
+	}
+	ok1(!wrong);
+
+	wrong = false;
+	for (i = 0; i < nbits; i++) {
+		bitmap_fill(bitmap, nbits);
+		bitmap_clear_bit(bitmap, i);
+		for (j = 0; j < nbits; j++) {
+			bool val = !(i == j);
+
+			wrong = wrong || (bitmap_test_bit(bitmap, j) != val);
+		}
+	}
+	ok1(!wrong);
+
+	bitmap_zero(bitmap, nbits);
+	ok1(bitmap_empty(bitmap, nbits));
+
+	wrong = false;
+	for (i = 0; i < nbits; i++) {
+		bitmap_zero(bitmap, nbits);
+		bitmap_set_bit(bitmap, i);
+		wrong = wrong || bitmap_empty(bitmap, nbits);
+	}
+	ok1(!wrong);
+
+	bitmap_fill(bitmap, nbits);
+	ok1(bitmap_full(bitmap, nbits));
+
+	wrong = false;
+	for (i = 0; i < nbits; i++) {
+		bitmap_fill(bitmap, nbits);
+		bitmap_clear_bit(bitmap, i);
+		wrong = wrong || bitmap_full(bitmap, nbits);
+	}
+	ok1(!wrong);
+	
+	if (dynalloc) {
+		free(bitmap);
+	} else {
+		ok1(marker == 0xdeadbeef);
+	}
+}
+
+int main(void)
+{
+	int i;
+	bool dynalloc;
+
+	/* This is how many tests you plan to run */
+	plan_tests(NSIZES * NTESTS * 2);
+
+	for (i = 0; i < NSIZES; i++) {
+		foreach_int(dynalloc, false, true) {
+			diag("Testing %d-bit bitmap (%s allocation)",
+			     bitmap_sizes[i], dynalloc ? "dynamic" : "static");
+			test_sizes(bitmap_sizes[i], dynalloc);
+		}
+	}
+
+	/* This exits depending on whether all tests passed */
+	return exit_status();
+}

--- a/src/common/libccan/ccan/compiler/LICENSE
+++ b/src/common/libccan/ccan/compiler/LICENSE
@@ -1,0 +1,1 @@
+../../licenses/CC0

--- a/src/common/libccan/ccan/compiler/_info
+++ b/src/common/libccan/ccan/compiler/_info
@@ -1,0 +1,64 @@
+#include "config.h"
+#include <string.h>
+#include <stdio.h>
+
+/**
+ * compiler - macros for common compiler extensions
+ *
+ * Abstracts away some compiler hints.  Currently these include:
+ * - COLD
+ *	For functions not called in fast paths (aka. cold functions)
+ * - PRINTF_FMT
+ *	For functions which take printf-style parameters.
+ * - CONST_FUNCTION
+ *	For functions which return the same value for same parameters.
+ * - NEEDED
+ *	For functions and variables which must be emitted even if unused.
+ * - UNNEEDED
+ *	For functions and variables which need not be emitted if unused.
+ * - UNUSED
+ *	For parameters which are not used.
+ * - IS_COMPILE_CONSTANT()
+ *	For using different tradeoffs for compiletime vs runtime evaluation.
+ *
+ * License: CC0 (Public domain)
+ * Author: Rusty Russell <rusty@rustcorp.com.au>
+ *
+ * Example:
+ *	#include <ccan/compiler/compiler.h>
+ *	#include <stdio.h>
+ *	#include <stdarg.h>
+ *
+ *	// Example of a (slow-path) logging function.
+ *	static int log_threshold = 2;
+ *	static void COLD PRINTF_FMT(2,3)
+ *		logger(int level, const char *fmt, ...)
+ *	{
+ *		va_list ap;
+ *		va_start(ap, fmt);
+ *		if (level >= log_threshold)
+ *			vfprintf(stderr, fmt, ap);
+ *		va_end(ap);
+ *	}
+ *
+ *	int main(int argc, char *argv[] UNNEEDED)
+ *	{
+ *		if (argc != 1) {
+ *			logger(3, "Don't want %i arguments!\n", argc-1);
+ *			return 1;
+ *		}
+ *		return 0;
+ *	}
+ */
+int main(int argc, char *argv[])
+{
+	/* Expect exactly one argument */
+	if (argc != 2)
+		return 1;
+
+	if (strcmp(argv[1], "depends") == 0) {
+		return 0;
+	}
+
+	return 1;
+}

--- a/src/common/libccan/ccan/compiler/compiler.h
+++ b/src/common/libccan/ccan/compiler/compiler.h
@@ -1,0 +1,317 @@
+/* CC0 (Public domain) - see LICENSE file for details */
+#ifndef CCAN_COMPILER_H
+#define CCAN_COMPILER_H
+#include "config.h"
+
+#ifndef COLD
+#if HAVE_ATTRIBUTE_COLD
+/**
+ * COLD - a function is unlikely to be called.
+ *
+ * Used to mark an unlikely code path and optimize appropriately.
+ * It is usually used on logging or error routines.
+ *
+ * Example:
+ * static void COLD moan(const char *reason)
+ * {
+ *	fprintf(stderr, "Error: %s (%s)\n", reason, strerror(errno));
+ * }
+ */
+#define COLD __attribute__((__cold__))
+#else
+#define COLD
+#endif
+#endif
+
+#ifndef NORETURN
+#if HAVE_ATTRIBUTE_NORETURN
+/**
+ * NORETURN - a function does not return
+ *
+ * Used to mark a function which exits; useful for suppressing warnings.
+ *
+ * Example:
+ * static void NORETURN fail(const char *reason)
+ * {
+ *	fprintf(stderr, "Error: %s (%s)\n", reason, strerror(errno));
+ *	exit(1);
+ * }
+ */
+#define NORETURN __attribute__((__noreturn__))
+#else
+#define NORETURN
+#endif
+#endif
+
+#ifndef PRINTF_FMT
+#if HAVE_ATTRIBUTE_PRINTF
+/**
+ * PRINTF_FMT - a function takes printf-style arguments
+ * @nfmt: the 1-based number of the function's format argument.
+ * @narg: the 1-based number of the function's first variable argument.
+ *
+ * This allows the compiler to check your parameters as it does for printf().
+ *
+ * Example:
+ * void PRINTF_FMT(2,3) my_printf(const char *prefix, const char *fmt, ...);
+ */
+#define PRINTF_FMT(nfmt, narg) \
+	__attribute__((format(__printf__, nfmt, narg)))
+#else
+#define PRINTF_FMT(nfmt, narg)
+#endif
+#endif
+
+#ifndef CONST_FUNCTION
+#if HAVE_ATTRIBUTE_CONST
+/**
+ * CONST_FUNCTION - a function's return depends only on its argument
+ *
+ * This allows the compiler to assume that the function will return the exact
+ * same value for the exact same arguments.  This implies that the function
+ * must not use global variables, or dereference pointer arguments.
+ */
+#define CONST_FUNCTION __attribute__((__const__))
+#else
+#define CONST_FUNCTION
+#endif
+
+#ifndef PURE_FUNCTION
+#if HAVE_ATTRIBUTE_PURE
+/**
+ * PURE_FUNCTION - a function is pure
+ *
+ * A pure function is one that has no side effects other than it's return value
+ * and uses no inputs other than it's arguments and global variables.
+ */
+#define PURE_FUNCTION __attribute__((__pure__))
+#else
+#define PURE_FUNCTION
+#endif
+#endif
+#endif
+
+#if HAVE_ATTRIBUTE_UNUSED
+#ifndef UNNEEDED
+/**
+ * UNNEEDED - a variable/function may not be needed
+ *
+ * This suppresses warnings about unused variables or functions, but tells
+ * the compiler that if it is unused it need not emit it into the source code.
+ *
+ * Example:
+ * // With some preprocessor options, this is unnecessary.
+ * static UNNEEDED int counter;
+ *
+ * // With some preprocessor options, this is unnecessary.
+ * static UNNEEDED void add_to_counter(int add)
+ * {
+ *	counter += add;
+ * }
+ */
+#define UNNEEDED __attribute__((__unused__))
+#endif
+
+#ifndef NEEDED
+#if HAVE_ATTRIBUTE_USED
+/**
+ * NEEDED - a variable/function is needed
+ *
+ * This suppresses warnings about unused variables or functions, but tells
+ * the compiler that it must exist even if it (seems) unused.
+ *
+ * Example:
+ *	// Even if this is unused, these are vital for debugging.
+ *	static NEEDED int counter;
+ *	static NEEDED void dump_counter(void)
+ *	{
+ *		printf("Counter is %i\n", counter);
+ *	}
+ */
+#define NEEDED __attribute__((__used__))
+#else
+/* Before used, unused functions and vars were always emitted. */
+#define NEEDED __attribute__((__unused__))
+#endif
+#endif
+
+#ifndef UNUSED
+/**
+ * UNUSED - a parameter is unused
+ *
+ * Some compilers (eg. gcc with -W or -Wunused) warn about unused
+ * function parameters.  This suppresses such warnings and indicates
+ * to the reader that it's deliberate.
+ *
+ * Example:
+ *	// This is used as a callback, so needs to have this prototype.
+ *	static int some_callback(void *unused UNUSED)
+ *	{
+ *		return 0;
+ *	}
+ */
+#define UNUSED __attribute__((__unused__))
+#endif
+#else
+#ifndef UNNEEDED
+#define UNNEEDED
+#endif
+#ifndef NEEDED
+#define NEEDED
+#endif
+#ifndef UNUSED
+#define UNUSED
+#endif
+#endif
+
+#ifndef IS_COMPILE_CONSTANT
+#if HAVE_BUILTIN_CONSTANT_P
+/**
+ * IS_COMPILE_CONSTANT - does the compiler know the value of this expression?
+ * @expr: the expression to evaluate
+ *
+ * When an expression manipulation is complicated, it is usually better to
+ * implement it in a function.  However, if the expression being manipulated is
+ * known at compile time, it is better to have the compiler see the entire
+ * expression so it can simply substitute the result.
+ *
+ * This can be done using the IS_COMPILE_CONSTANT() macro.
+ *
+ * Example:
+ *	enum greek { ALPHA, BETA, GAMMA, DELTA, EPSILON };
+ *
+ *	// Out-of-line version.
+ *	const char *greek_name(enum greek greek);
+ *
+ *	// Inline version.
+ *	static inline const char *_greek_name(enum greek greek)
+ *	{
+ *		switch (greek) {
+ *		case ALPHA: return "alpha";
+ *		case BETA: return "beta";
+ *		case GAMMA: return "gamma";
+ *		case DELTA: return "delta";
+ *		case EPSILON: return "epsilon";
+ *		default: return "**INVALID**";
+ *		}
+ *	}
+ *
+ *	// Use inline if compiler knows answer.  Otherwise call function
+ *	// to avoid copies of the same code everywhere.
+ *	#define greek_name(g)						\
+ *		 (IS_COMPILE_CONSTANT(greek) ? _greek_name(g) : greek_name(g))
+ */
+#define IS_COMPILE_CONSTANT(expr) __builtin_constant_p(expr)
+#else
+/* If we don't know, assume it's not. */
+#define IS_COMPILE_CONSTANT(expr) 0
+#endif
+#endif
+
+#ifndef WARN_UNUSED_RESULT
+#if HAVE_WARN_UNUSED_RESULT
+/**
+ * WARN_UNUSED_RESULT - warn if a function return value is unused.
+ *
+ * Used to mark a function where it is extremely unlikely that the caller
+ * can ignore the result, eg realloc().
+ *
+ * Example:
+ * // buf param may be freed by this; need return value!
+ * static char *WARN_UNUSED_RESULT enlarge(char *buf, unsigned *size)
+ * {
+ *	return realloc(buf, (*size) *= 2);
+ * }
+ */
+#define WARN_UNUSED_RESULT __attribute__((__warn_unused_result__))
+#else
+#define WARN_UNUSED_RESULT
+#endif
+#endif
+
+
+#if HAVE_ATTRIBUTE_DEPRECATED
+/**
+ * WARN_DEPRECATED - warn that a function/type/variable is deprecated when used.
+ *
+ * Used to mark a function, type or variable should not be used.
+ *
+ * Example:
+ * WARN_DEPRECATED char *oldfunc(char *buf);
+ */
+#define WARN_DEPRECATED __attribute__((__deprecated__))
+#else
+#define WARN_DEPRECATED
+#endif
+
+
+#if HAVE_ATTRIBUTE_NONNULL
+/**
+ * NO_NULL_ARGS - specify that no arguments to this function can be NULL.
+ *
+ * The compiler will warn if any pointer args are NULL.
+ *
+ * Example:
+ * NO_NULL_ARGS char *my_copy(char *buf);
+ */
+#define NO_NULL_ARGS __attribute__((__nonnull__))
+
+/**
+ * NON_NULL_ARGS - specify that some arguments to this function can't be NULL.
+ * @...: 1-based argument numbers for which args can't be NULL.
+ *
+ * The compiler will warn if any of the specified pointer args are NULL.
+ *
+ * Example:
+ * char *my_copy2(char *buf, char *maybenull) NON_NULL_ARGS(1);
+ */
+#define NON_NULL_ARGS(...) __attribute__((__nonnull__(__VA_ARGS__)))
+#else
+#define NO_NULL_ARGS
+#define NON_NULL_ARGS(...)
+#endif
+
+#if HAVE_ATTRIBUTE_RETURNS_NONNULL
+/**
+ * RETURNS_NONNULL - specify that this function cannot return NULL.
+ *
+ * Mainly an optimization opportunity, but can also suppress warnings.
+ *
+ * Example:
+ * RETURNS_NONNULL char *my_copy(char *buf);
+ */
+#define RETURNS_NONNULL __attribute__((__returns_nonnull__))
+#else
+#define RETURNS_NONNULL
+#endif
+
+#if HAVE_ATTRIBUTE_SENTINEL
+/**
+ * LAST_ARG_NULL - specify the last argument of a variadic function must be NULL.
+ *
+ * The compiler will warn if the last argument isn't NULL.
+ *
+ * Example:
+ * char *join_string(char *buf, ...) LAST_ARG_NULL;
+ */
+#define LAST_ARG_NULL __attribute__((__sentinel__))
+#else
+#define LAST_ARG_NULL
+#endif
+
+#if HAVE_BUILTIN_CPU_SUPPORTS
+/**
+ * cpu_supports - test if current CPU supports the named feature.
+ *
+ * This takes a literal string, and currently only works on glibc platforms.
+ *
+ * Example:
+ * if (cpu_supports("mmx"))
+ *	printf("MMX support engaged!\n");
+ */
+#define cpu_supports(x) __builtin_cpu_supports(x)
+#else
+#define cpu_supports(x) 0
+#endif /* HAVE_BUILTIN_CPU_SUPPORTS */
+
+#endif /* CCAN_COMPILER_H */

--- a/src/common/libccan/ccan/compiler/test/compile_fail-printf.c
+++ b/src/common/libccan/ccan/compiler/test/compile_fail-printf.c
@@ -1,0 +1,24 @@
+#include <ccan/compiler/compiler.h>
+
+static void PRINTF_FMT(2,3) my_printf(int x, const char *fmt, ...)
+{
+	(void)x;
+	(void)fmt;
+}
+
+int main(void)
+{
+	unsigned int i = 0;
+
+	my_printf(1, "Not a pointer "
+#ifdef FAIL
+		  "%p",
+#if !HAVE_ATTRIBUTE_PRINTF
+#error "Unfortunately we don't fail if !HAVE_ATTRIBUTE_PRINTF."
+#endif
+#else
+		  "%i",
+#endif
+		  i);
+	return 0;
+}

--- a/src/common/libccan/ccan/compiler/test/run-is_compile_constant.c
+++ b/src/common/libccan/ccan/compiler/test/run-is_compile_constant.c
@@ -1,0 +1,17 @@
+#include <ccan/compiler/compiler.h>
+#include <ccan/tap/tap.h>
+
+int main(int argc, char *argv[])
+{
+	(void)argc;
+	(void)argv;
+	plan_tests(2);
+
+	ok1(!IS_COMPILE_CONSTANT(argc));
+#if HAVE_BUILTIN_CONSTANT_P
+	ok1(IS_COMPILE_CONSTANT(7));
+#else
+	pass("If !HAVE_BUILTIN_CONSTANT_P, IS_COMPILE_CONSTANT always false");
+#endif
+	return exit_status();
+}

--- a/src/common/libccan/ccan/endian/LICENSE
+++ b/src/common/libccan/ccan/endian/LICENSE
@@ -1,0 +1,1 @@
+../../licenses/CC0

--- a/src/common/libccan/ccan/endian/_info
+++ b/src/common/libccan/ccan/endian/_info
@@ -1,0 +1,55 @@
+#include "config.h"
+#include <stdio.h>
+#include <string.h>
+
+/**
+ * endian - endian conversion macros for simple types
+ *
+ * Portable protocols (such as on-disk formats, or network protocols)
+ * are often defined to be a particular endian: little-endian (least
+ * significant bytes first) or big-endian (most significant bytes
+ * first).
+ *
+ * Similarly, some CPUs lay out values in memory in little-endian
+ * order (most commonly, Intel's 8086 and derivatives), or big-endian
+ * order (almost everyone else).
+ *
+ * This module provides conversion routines, inspired by the linux kernel.
+ * It also provides leint32_t, beint32_t etc typedefs, which are annotated for
+ * the sparse checker.
+ *
+ * Example:
+ *	#include <stdio.h>
+ *	#include <err.h>
+ *	#include <ccan/endian/endian.h>
+ *
+ *	// 
+ *	int main(int argc, char *argv[])
+ *	{
+ *		uint32_t value;
+ *
+ *		if (argc != 2)
+ *			errx(1, "Usage: %s <value>", argv[0]);
+ *
+ *		value = atoi(argv[1]);
+ *		printf("native:        %08x\n", value);
+ *		printf("little-endian: %08x\n", cpu_to_le32(value));
+ *		printf("big-endian:    %08x\n", cpu_to_be32(value));
+ *		printf("byte-reversed: %08x\n", bswap_32(value));
+ *		exit(0);
+ *	}
+ *
+ * License: License: CC0 (Public domain)
+ * Author: Rusty Russell <rusty@rustcorp.com.au>
+ */
+int main(int argc, char *argv[])
+{
+	if (argc != 2)
+		return 1;
+
+	if (strcmp(argv[1], "depends") == 0)
+		/* Nothing */
+		return 0;
+
+	return 1;
+}

--- a/src/common/libccan/ccan/endian/endian.h
+++ b/src/common/libccan/ccan/endian/endian.h
@@ -1,0 +1,363 @@
+/* CC0 (Public domain) - see LICENSE file for details */
+#ifndef CCAN_ENDIAN_H
+#define CCAN_ENDIAN_H
+#include <stdint.h>
+#include "config.h"
+
+/**
+ * BSWAP_16 - reverse bytes in a constant uint16_t value.
+ * @val: constant value whose bytes to swap.
+ *
+ * Designed to be usable in constant-requiring initializers.
+ *
+ * Example:
+ *	struct mystruct {
+ *		char buf[BSWAP_16(0x1234)];
+ *	};
+ */
+#define BSWAP_16(val)				\
+	((((uint16_t)(val) & 0x00ff) << 8)	\
+	 | (((uint16_t)(val) & 0xff00) >> 8))
+
+/**
+ * BSWAP_32 - reverse bytes in a constant uint32_t value.
+ * @val: constant value whose bytes to swap.
+ *
+ * Designed to be usable in constant-requiring initializers.
+ *
+ * Example:
+ *	struct mystruct {
+ *		char buf[BSWAP_32(0xff000000)];
+ *	};
+ */
+#define BSWAP_32(val)					\
+	((((uint32_t)(val) & 0x000000ff) << 24)		\
+	 | (((uint32_t)(val) & 0x0000ff00) << 8)		\
+	 | (((uint32_t)(val) & 0x00ff0000) >> 8)		\
+	 | (((uint32_t)(val) & 0xff000000) >> 24))
+
+/**
+ * BSWAP_64 - reverse bytes in a constant uint64_t value.
+ * @val: constantvalue whose bytes to swap.
+ *
+ * Designed to be usable in constant-requiring initializers.
+ *
+ * Example:
+ *	struct mystruct {
+ *		char buf[BSWAP_64(0xff00000000000000ULL)];
+ *	};
+ */
+#define BSWAP_64(val)						\
+	((((uint64_t)(val) & 0x00000000000000ffULL) << 56)	\
+	 | (((uint64_t)(val) & 0x000000000000ff00ULL) << 40)	\
+	 | (((uint64_t)(val) & 0x0000000000ff0000ULL) << 24)	\
+	 | (((uint64_t)(val) & 0x00000000ff000000ULL) << 8)	\
+	 | (((uint64_t)(val) & 0x000000ff00000000ULL) >> 8)	\
+	 | (((uint64_t)(val) & 0x0000ff0000000000ULL) >> 24)	\
+	 | (((uint64_t)(val) & 0x00ff000000000000ULL) >> 40)	\
+	 | (((uint64_t)(val) & 0xff00000000000000ULL) >> 56))
+
+#if HAVE_BYTESWAP_H
+#include <byteswap.h>
+#else
+/**
+ * bswap_16 - reverse bytes in a uint16_t value.
+ * @val: value whose bytes to swap.
+ *
+ * Example:
+ *	// Output contains "1024 is 4 as two bytes reversed"
+ *	printf("1024 is %u as two bytes reversed\n", bswap_16(1024));
+ */
+static inline uint16_t bswap_16(uint16_t val)
+{
+	return BSWAP_16(val);
+}
+
+/**
+ * bswap_32 - reverse bytes in a uint32_t value.
+ * @val: value whose bytes to swap.
+ *
+ * Example:
+ *	// Output contains "1024 is 262144 as four bytes reversed"
+ *	printf("1024 is %u as four bytes reversed\n", bswap_32(1024));
+ */
+static inline uint32_t bswap_32(uint32_t val)
+{
+	return BSWAP_32(val);
+}
+#endif /* !HAVE_BYTESWAP_H */
+
+#if !HAVE_BSWAP_64
+/**
+ * bswap_64 - reverse bytes in a uint64_t value.
+ * @val: value whose bytes to swap.
+ *
+ * Example:
+ *	// Output contains "1024 is 1125899906842624 as eight bytes reversed"
+ *	printf("1024 is %llu as eight bytes reversed\n",
+ *		(unsigned long long)bswap_64(1024));
+ */
+static inline uint64_t bswap_64(uint64_t val)
+{
+	return BSWAP_64(val);
+}
+#endif
+
+/* Needed for Glibc like endiness check */
+#define	__LITTLE_ENDIAN	1234
+#define	__BIG_ENDIAN	4321
+
+/* Sanity check the defines.  We don't handle weird endianness. */
+#if !HAVE_LITTLE_ENDIAN && !HAVE_BIG_ENDIAN
+#error "Unknown endian"
+#elif HAVE_LITTLE_ENDIAN && HAVE_BIG_ENDIAN
+#error "Can't compile for both big and little endian."
+#elif HAVE_LITTLE_ENDIAN
+#ifndef __BYTE_ORDER
+#define __BYTE_ORDER	__LITTLE_ENDIAN
+#elif __BYTE_ORDER != __LITTLE_ENDIAN
+#error "__BYTE_ORDER already defined, but not equal to __LITTLE_ENDIAN"
+#endif
+#elif HAVE_BIG_ENDIAN
+#ifndef __BYTE_ORDER
+#define __BYTE_ORDER	__BIG_ENDIAN
+#elif __BYTE_ORDER != __BIG_ENDIAN
+#error "__BYTE_ORDER already defined, but not equal to __BIG_ENDIAN"
+#endif
+#endif
+
+
+#ifdef __CHECKER__
+/* sparse needs forcing to remove bitwise attribute from ccan/short_types */
+#define ENDIAN_CAST __attribute__((force))
+#define ENDIAN_TYPE __attribute__((bitwise))
+#else
+#define ENDIAN_CAST
+#define ENDIAN_TYPE
+#endif
+
+typedef uint64_t ENDIAN_TYPE leint64_t;
+typedef uint64_t ENDIAN_TYPE beint64_t;
+typedef uint32_t ENDIAN_TYPE leint32_t;
+typedef uint32_t ENDIAN_TYPE beint32_t;
+typedef uint16_t ENDIAN_TYPE leint16_t;
+typedef uint16_t ENDIAN_TYPE beint16_t;
+
+#if HAVE_LITTLE_ENDIAN
+/**
+ * CPU_TO_LE64 - convert a constant uint64_t value to little-endian
+ * @native: constant to convert
+ */
+#define CPU_TO_LE64(native) ((ENDIAN_CAST leint64_t)(native))
+
+/**
+ * CPU_TO_LE32 - convert a constant uint32_t value to little-endian
+ * @native: constant to convert
+ */
+#define CPU_TO_LE32(native) ((ENDIAN_CAST leint32_t)(native))
+
+/**
+ * CPU_TO_LE16 - convert a constant uint16_t value to little-endian
+ * @native: constant to convert
+ */
+#define CPU_TO_LE16(native) ((ENDIAN_CAST leint16_t)(native))
+
+/**
+ * LE64_TO_CPU - convert a little-endian uint64_t constant
+ * @le_val: little-endian constant to convert
+ */
+#define LE64_TO_CPU(le_val) ((ENDIAN_CAST uint64_t)(le_val))
+
+/**
+ * LE32_TO_CPU - convert a little-endian uint32_t constant
+ * @le_val: little-endian constant to convert
+ */
+#define LE32_TO_CPU(le_val) ((ENDIAN_CAST uint32_t)(le_val))
+
+/**
+ * LE16_TO_CPU - convert a little-endian uint16_t constant
+ * @le_val: little-endian constant to convert
+ */
+#define LE16_TO_CPU(le_val) ((ENDIAN_CAST uint16_t)(le_val))
+
+#else /* ... HAVE_BIG_ENDIAN */
+#define CPU_TO_LE64(native) ((ENDIAN_CAST leint64_t)BSWAP_64(native))
+#define CPU_TO_LE32(native) ((ENDIAN_CAST leint32_t)BSWAP_32(native))
+#define CPU_TO_LE16(native) ((ENDIAN_CAST leint16_t)BSWAP_16(native))
+#define LE64_TO_CPU(le_val) BSWAP_64((ENDIAN_CAST uint64_t)le_val)
+#define LE32_TO_CPU(le_val) BSWAP_32((ENDIAN_CAST uint32_t)le_val)
+#define LE16_TO_CPU(le_val) BSWAP_16((ENDIAN_CAST uint16_t)le_val)
+#endif /* HAVE_BIG_ENDIAN */
+
+#if HAVE_BIG_ENDIAN
+/**
+ * CPU_TO_BE64 - convert a constant uint64_t value to big-endian
+ * @native: constant to convert
+ */
+#define CPU_TO_BE64(native) ((ENDIAN_CAST beint64_t)(native))
+
+/**
+ * CPU_TO_BE32 - convert a constant uint32_t value to big-endian
+ * @native: constant to convert
+ */
+#define CPU_TO_BE32(native) ((ENDIAN_CAST beint32_t)(native))
+
+/**
+ * CPU_TO_BE16 - convert a constant uint16_t value to big-endian
+ * @native: constant to convert
+ */
+#define CPU_TO_BE16(native) ((ENDIAN_CAST beint16_t)(native))
+
+/**
+ * BE64_TO_CPU - convert a big-endian uint64_t constant
+ * @le_val: big-endian constant to convert
+ */
+#define BE64_TO_CPU(le_val) ((ENDIAN_CAST uint64_t)(le_val))
+
+/**
+ * BE32_TO_CPU - convert a big-endian uint32_t constant
+ * @le_val: big-endian constant to convert
+ */
+#define BE32_TO_CPU(le_val) ((ENDIAN_CAST uint32_t)(le_val))
+
+/**
+ * BE16_TO_CPU - convert a big-endian uint16_t constant
+ * @le_val: big-endian constant to convert
+ */
+#define BE16_TO_CPU(le_val) ((ENDIAN_CAST uint16_t)(le_val))
+
+#else /* ... HAVE_LITTLE_ENDIAN */
+#define CPU_TO_BE64(native) ((ENDIAN_CAST beint64_t)BSWAP_64(native))
+#define CPU_TO_BE32(native) ((ENDIAN_CAST beint32_t)BSWAP_32(native))
+#define CPU_TO_BE16(native) ((ENDIAN_CAST beint16_t)BSWAP_16(native))
+#define BE64_TO_CPU(le_val) BSWAP_64((ENDIAN_CAST uint64_t)le_val)
+#define BE32_TO_CPU(le_val) BSWAP_32((ENDIAN_CAST uint32_t)le_val)
+#define BE16_TO_CPU(le_val) BSWAP_16((ENDIAN_CAST uint16_t)le_val)
+#endif /* HAVE_LITTE_ENDIAN */
+
+
+/**
+ * cpu_to_le64 - convert a uint64_t value to little-endian
+ * @native: value to convert
+ */
+static inline leint64_t cpu_to_le64(uint64_t native)
+{
+	return CPU_TO_LE64(native);
+}
+
+/**
+ * cpu_to_le32 - convert a uint32_t value to little-endian
+ * @native: value to convert
+ */
+static inline leint32_t cpu_to_le32(uint32_t native)
+{
+	return CPU_TO_LE32(native);
+}
+
+/**
+ * cpu_to_le16 - convert a uint16_t value to little-endian
+ * @native: value to convert
+ */
+static inline leint16_t cpu_to_le16(uint16_t native)
+{
+	return CPU_TO_LE16(native);
+}
+
+/**
+ * le64_to_cpu - convert a little-endian uint64_t value
+ * @le_val: little-endian value to convert
+ */
+static inline uint64_t le64_to_cpu(leint64_t le_val)
+{
+	return LE64_TO_CPU(le_val);
+}
+
+/**
+ * le32_to_cpu - convert a little-endian uint32_t value
+ * @le_val: little-endian value to convert
+ */
+static inline uint32_t le32_to_cpu(leint32_t le_val)
+{
+	return LE32_TO_CPU(le_val);
+}
+
+/**
+ * le16_to_cpu - convert a little-endian uint16_t value
+ * @le_val: little-endian value to convert
+ */
+static inline uint16_t le16_to_cpu(leint16_t le_val)
+{
+	return LE16_TO_CPU(le_val);
+}
+
+/**
+ * cpu_to_be64 - convert a uint64_t value to big endian.
+ * @native: value to convert
+ */
+static inline beint64_t cpu_to_be64(uint64_t native)
+{
+	return CPU_TO_BE64(native);
+}
+
+/**
+ * cpu_to_be32 - convert a uint32_t value to big endian.
+ * @native: value to convert
+ */
+static inline beint32_t cpu_to_be32(uint32_t native)
+{
+	return CPU_TO_BE32(native);
+}
+
+/**
+ * cpu_to_be16 - convert a uint16_t value to big endian.
+ * @native: value to convert
+ */
+static inline beint16_t cpu_to_be16(uint16_t native)
+{
+	return CPU_TO_BE16(native);
+}
+
+/**
+ * be64_to_cpu - convert a big-endian uint64_t value
+ * @be_val: big-endian value to convert
+ */
+static inline uint64_t be64_to_cpu(beint64_t be_val)
+{
+	return BE64_TO_CPU(be_val);
+}
+
+/**
+ * be32_to_cpu - convert a big-endian uint32_t value
+ * @be_val: big-endian value to convert
+ */
+static inline uint32_t be32_to_cpu(beint32_t be_val)
+{
+	return BE32_TO_CPU(be_val);
+}
+
+/**
+ * be16_to_cpu - convert a big-endian uint16_t value
+ * @be_val: big-endian value to convert
+ */
+static inline uint16_t be16_to_cpu(beint16_t be_val)
+{
+	return BE16_TO_CPU(be_val);
+}
+
+/* Whichever they include first, they get these definitions. */
+#ifdef CCAN_SHORT_TYPES_H
+/**
+ * be64/be32/be16 - 64/32/16 bit big-endian representation.
+ */
+typedef beint64_t be64;
+typedef beint32_t be32;
+typedef beint16_t be16;
+
+/**
+ * le64/le32/le16 - 64/32/16 bit little-endian representation.
+ */
+typedef leint64_t le64;
+typedef leint32_t le32;
+typedef leint16_t le16;
+#endif
+#endif /* CCAN_ENDIAN_H */

--- a/src/common/libccan/ccan/endian/test/compile_ok-constant.c
+++ b/src/common/libccan/ccan/endian/test/compile_ok-constant.c
@@ -1,0 +1,12 @@
+#include <ccan/endian/endian.h>
+
+struct foo {
+	char one[BSWAP_16(0xFF00)];
+	char two[BSWAP_32(0xFF000000)];
+	char three[BSWAP_64(0xFF00000000000000ULL)];
+};
+
+int main(void)
+{
+	return 0;
+}

--- a/src/common/libccan/ccan/endian/test/run.c
+++ b/src/common/libccan/ccan/endian/test/run.c
@@ -1,0 +1,106 @@
+#include <ccan/endian/endian.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <ccan/tap/tap.h>
+
+int main(void)
+{
+	union {
+		uint64_t u64;
+		unsigned char u64_bytes[8];
+	} u64;
+	union {
+		uint32_t u32;
+		unsigned char u32_bytes[4];
+	} u32;
+	union {
+		uint16_t u16;
+		unsigned char u16_bytes[2];
+	} u16;
+
+	plan_tests(48);
+
+	/* Straight swap tests. */
+	u64.u64_bytes[0] = 0x00;
+	u64.u64_bytes[1] = 0x11;
+	u64.u64_bytes[2] = 0x22;
+	u64.u64_bytes[3] = 0x33;
+	u64.u64_bytes[4] = 0x44;
+	u64.u64_bytes[5] = 0x55;
+	u64.u64_bytes[6] = 0x66;
+	u64.u64_bytes[7] = 0x77;
+	u64.u64 = bswap_64(u64.u64);
+	ok1(u64.u64_bytes[7] == 0x00);
+	ok1(u64.u64_bytes[6] == 0x11);
+	ok1(u64.u64_bytes[5] == 0x22);
+	ok1(u64.u64_bytes[4] == 0x33);
+	ok1(u64.u64_bytes[3] == 0x44);
+	ok1(u64.u64_bytes[2] == 0x55);
+	ok1(u64.u64_bytes[1] == 0x66);
+	ok1(u64.u64_bytes[0] == 0x77);
+
+	u32.u32_bytes[0] = 0x00;
+	u32.u32_bytes[1] = 0x11;
+	u32.u32_bytes[2] = 0x22;
+	u32.u32_bytes[3] = 0x33;
+	u32.u32 = bswap_32(u32.u32);
+	ok1(u32.u32_bytes[3] == 0x00);
+	ok1(u32.u32_bytes[2] == 0x11);
+	ok1(u32.u32_bytes[1] == 0x22);
+	ok1(u32.u32_bytes[0] == 0x33);
+
+	u16.u16_bytes[0] = 0x00;
+	u16.u16_bytes[1] = 0x11;
+	u16.u16 = bswap_16(u16.u16);
+	ok1(u16.u16_bytes[1] == 0x00);
+	ok1(u16.u16_bytes[0] == 0x11);
+
+	/* Endian tests. */
+	u64.u64 = cpu_to_le64(0x0011223344556677ULL);
+	ok1(u64.u64_bytes[0] == 0x77);
+	ok1(u64.u64_bytes[1] == 0x66);
+	ok1(u64.u64_bytes[2] == 0x55);
+	ok1(u64.u64_bytes[3] == 0x44);
+	ok1(u64.u64_bytes[4] == 0x33);
+	ok1(u64.u64_bytes[5] == 0x22);
+	ok1(u64.u64_bytes[6] == 0x11);
+	ok1(u64.u64_bytes[7] == 0x00);
+	ok1(le64_to_cpu(u64.u64) == 0x0011223344556677ULL);
+
+	u64.u64 = cpu_to_be64(0x0011223344556677ULL);
+	ok1(u64.u64_bytes[7] == 0x77);
+	ok1(u64.u64_bytes[6] == 0x66);
+	ok1(u64.u64_bytes[5] == 0x55);
+	ok1(u64.u64_bytes[4] == 0x44);
+	ok1(u64.u64_bytes[3] == 0x33);
+	ok1(u64.u64_bytes[2] == 0x22);
+	ok1(u64.u64_bytes[1] == 0x11);
+	ok1(u64.u64_bytes[0] == 0x00);
+	ok1(be64_to_cpu(u64.u64) == 0x0011223344556677ULL);
+
+	u32.u32 = cpu_to_le32(0x00112233);
+	ok1(u32.u32_bytes[0] == 0x33);
+	ok1(u32.u32_bytes[1] == 0x22);
+	ok1(u32.u32_bytes[2] == 0x11);
+	ok1(u32.u32_bytes[3] == 0x00);
+	ok1(le32_to_cpu(u32.u32) == 0x00112233);
+
+	u32.u32 = cpu_to_be32(0x00112233);
+	ok1(u32.u32_bytes[3] == 0x33);
+	ok1(u32.u32_bytes[2] == 0x22);
+	ok1(u32.u32_bytes[1] == 0x11);
+	ok1(u32.u32_bytes[0] == 0x00);
+	ok1(be32_to_cpu(u32.u32) == 0x00112233);
+
+	u16.u16 = cpu_to_le16(0x0011);
+	ok1(u16.u16_bytes[0] == 0x11);
+	ok1(u16.u16_bytes[1] == 0x00);
+	ok1(le16_to_cpu(u16.u16) == 0x0011);
+
+	u16.u16 = cpu_to_be16(0x0011);
+	ok1(u16.u16_bytes[1] == 0x11);
+	ok1(u16.u16_bytes[0] == 0x00);
+	ok1(be16_to_cpu(u16.u16) == 0x0011);
+
+	exit(exit_status());
+}

--- a/src/common/libccan/ccan/ptrint/LICENSE
+++ b/src/common/libccan/ccan/ptrint/LICENSE
@@ -1,0 +1,1 @@
+../../licenses/CC0

--- a/src/common/libccan/ccan/ptrint/_info
+++ b/src/common/libccan/ccan/ptrint/_info
@@ -1,0 +1,60 @@
+#include "config.h"
+#include <stdio.h>
+#include <string.h>
+
+/**
+ * ptrint - Encoding integers in pointer values
+ *
+ * Library (standard or ccan) functions which take user supplied
+ * callbacks usually have the callback supplied with a void * context
+ * pointer.  For simple cases, it's sometimes sufficient to pass a
+ * simple integer cast into a void *, rather than having to allocate a
+ * context structure.  This module provides some helper macros to do
+ * this relatively safely and portably.
+ *
+ * The key characteristics of these functions are:
+ *	ptr2int(int2ptr(val)) == val
+ * and
+ *      !int2ptr(val) == !val
+ * (i.e. the transformation preserves truth value).
+ *
+ * Example:
+ *	#include <ccan/ptrint/ptrint.h>
+ *
+ *	static void callback(void *opaque)
+ *	{
+ *		int val = ptr2int(opaque);
+ *		printf("Value is %d\n", val);
+ *	}
+ *
+ *	void (*cb)(void *opaque) = callback;
+ *
+ *	int main(void)
+ *	{
+ *		int val = 17;
+ *
+ *		(*cb)(int2ptr(val));
+ *		exit(0);
+ *	}
+ *
+ * License: CC0 (Public domain)
+ * Author: David Gibson <david@gibson.dropbear.id.au>
+ */
+int main(int argc, char *argv[])
+{
+	/* Expect exactly one argument */
+	if (argc != 2)
+		return 1;
+
+	if (strcmp(argv[1], "depends") == 0) {
+		printf("ccan/build_assert\n");
+		printf("ccan/compiler\n");
+		return 0;
+	}
+	if (strcmp(argv[1], "testdepends") == 0) {
+		printf("ccan/array_size\n");
+		return 0;
+	}
+
+	return 1;
+}

--- a/src/common/libccan/ccan/ptrint/ptrint.h
+++ b/src/common/libccan/ccan/ptrint/ptrint.h
@@ -1,0 +1,35 @@
+/* CC0 (Public domain) - see LICENSE file for details */
+#ifndef CCAN_PTRINT_H
+#define CCAN_PTRINT_H
+
+#include "config.h"
+
+#include <stddef.h>
+
+#include <ccan/build_assert/build_assert.h>
+#include <ccan/compiler/compiler.h>
+
+/*
+ * This is a deliberately incomplete type, because it should never be
+ * dereferenced - instead it marks pointer values which are actually
+ * encoding integers
+ */
+typedef struct ptrint ptrint_t;
+
+CONST_FUNCTION static inline ptrdiff_t ptr2int(const ptrint_t *p)
+{
+	/*
+	 * ptrdiff_t is the right size by definition, but to avoid
+	 * surprises we want a warning if the user can't fit at least
+	 * a regular int in there
+	 */
+	BUILD_ASSERT(sizeof(int) <= sizeof(ptrdiff_t));
+	return (const char *)p - (const char *)NULL;
+}
+
+CONST_FUNCTION static inline ptrint_t *int2ptr(ptrdiff_t i)
+{
+	return (ptrint_t *)((char *)NULL + i);
+}
+
+#endif /* CCAN_PTRINT_H */

--- a/src/common/libccan/ccan/ptrint/test/run.c
+++ b/src/common/libccan/ccan/ptrint/test/run.c
@@ -1,0 +1,29 @@
+#include <limits.h>
+
+#include <ccan/array_size/array_size.h>
+
+#include <ccan/ptrint/ptrint.h>
+#include <ccan/tap/tap.h>
+
+static ptrdiff_t testvals[] = {
+	-INT_MAX, -1, 0, 1, 2, 17, INT_MAX,
+};
+
+int main(void)
+{
+	int i;
+
+	/* This is how many tests you plan to run */
+	plan_tests(2 * ARRAY_SIZE(testvals));
+
+	for (i = 0; i < ARRAY_SIZE(testvals); i++) {
+		ptrdiff_t val = testvals[i];
+		void *ptr = int2ptr(val);
+
+		ok1(ptr2int(ptr) == val);
+		ok1(!val == !ptr);
+	}
+
+	/* This exits depending on whether all tests passed */
+	return exit_status();
+}

--- a/src/common/libccan/licenses/LGPL-2.1
+++ b/src/common/libccan/licenses/LGPL-2.1
@@ -1,0 +1,510 @@
+
+                  GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 2.1, February 1999
+
+ Copyright (C) 1991, 1999 Free Software Foundation, Inc.
+	51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+[This is the first released version of the Lesser GPL.  It also counts
+ as the successor of the GNU Library Public License, version 2, hence
+ the version number 2.1.]
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+Licenses are intended to guarantee your freedom to share and change
+free software--to make sure the software is free for all its users.
+
+  This license, the Lesser General Public License, applies to some
+specially designated software packages--typically libraries--of the
+Free Software Foundation and other authors who decide to use it.  You
+can use it too, but we suggest you first think carefully about whether
+this license or the ordinary General Public License is the better
+strategy to use in any particular case, based on the explanations
+below.
+
+  When we speak of free software, we are referring to freedom of use,
+not price.  Our General Public Licenses are designed to make sure that
+you have the freedom to distribute copies of free software (and charge
+for this service if you wish); that you receive source code or can get
+it if you want it; that you can change the software and use pieces of
+it in new free programs; and that you are informed that you can do
+these things.
+
+  To protect your rights, we need to make restrictions that forbid
+distributors to deny you these rights or to ask you to surrender these
+rights.  These restrictions translate to certain responsibilities for
+you if you distribute copies of the library or if you modify it.
+
+  For example, if you distribute copies of the library, whether gratis
+or for a fee, you must give the recipients all the rights that we gave
+you.  You must make sure that they, too, receive or can get the source
+code.  If you link other code with the library, you must provide
+complete object files to the recipients, so that they can relink them
+with the library after making changes to the library and recompiling
+it.  And you must show them these terms so they know their rights.
+
+  We protect your rights with a two-step method: (1) we copyright the
+library, and (2) we offer you this license, which gives you legal
+permission to copy, distribute and/or modify the library.
+
+  To protect each distributor, we want to make it very clear that
+there is no warranty for the free library.  Also, if the library is
+modified by someone else and passed on, the recipients should know
+that what they have is not the original version, so that the original
+author's reputation will not be affected by problems that might be
+introduced by others.
+
+  Finally, software patents pose a constant threat to the existence of
+any free program.  We wish to make sure that a company cannot
+effectively restrict the users of a free program by obtaining a
+restrictive license from a patent holder.  Therefore, we insist that
+any patent license obtained for a version of the library must be
+consistent with the full freedom of use specified in this license.
+
+  Most GNU software, including some libraries, is covered by the
+ordinary GNU General Public License.  This license, the GNU Lesser
+General Public License, applies to certain designated libraries, and
+is quite different from the ordinary General Public License.  We use
+this license for certain libraries in order to permit linking those
+libraries into non-free programs.
+
+  When a program is linked with a library, whether statically or using
+a shared library, the combination of the two is legally speaking a
+combined work, a derivative of the original library.  The ordinary
+General Public License therefore permits such linking only if the
+entire combination fits its criteria of freedom.  The Lesser General
+Public License permits more lax criteria for linking other code with
+the library.
+
+  We call this license the "Lesser" General Public License because it
+does Less to protect the user's freedom than the ordinary General
+Public License.  It also provides other free software developers Less
+of an advantage over competing non-free programs.  These disadvantages
+are the reason we use the ordinary General Public License for many
+libraries.  However, the Lesser license provides advantages in certain
+special circumstances.
+
+  For example, on rare occasions, there may be a special need to
+encourage the widest possible use of a certain library, so that it
+becomes a de-facto standard.  To achieve this, non-free programs must
+be allowed to use the library.  A more frequent case is that a free
+library does the same job as widely used non-free libraries.  In this
+case, there is little to gain by limiting the free library to free
+software only, so we use the Lesser General Public License.
+
+  In other cases, permission to use a particular library in non-free
+programs enables a greater number of people to use a large body of
+free software.  For example, permission to use the GNU C Library in
+non-free programs enables many more people to use the whole GNU
+operating system, as well as its variant, the GNU/Linux operating
+system.
+
+  Although the Lesser General Public License is Less protective of the
+users' freedom, it does ensure that the user of a program that is
+linked with the Library has the freedom and the wherewithal to run
+that program using a modified version of the Library.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.  Pay close attention to the difference between a
+"work based on the library" and a "work that uses the library".  The
+former contains code derived from the library, whereas the latter must
+be combined with the library in order to run.
+
+                  GNU LESSER GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License Agreement applies to any software library or other
+program which contains a notice placed by the copyright holder or
+other authorized party saying it may be distributed under the terms of
+this Lesser General Public License (also called "this License").
+Each licensee is addressed as "you".
+
+  A "library" means a collection of software functions and/or data
+prepared so as to be conveniently linked with application programs
+(which use some of those functions and data) to form executables.
+
+  The "Library", below, refers to any such software library or work
+which has been distributed under these terms.  A "work based on the
+Library" means either the Library or any derivative work under
+copyright law: that is to say, a work containing the Library or a
+portion of it, either verbatim or with modifications and/or translated
+straightforwardly into another language.  (Hereinafter, translation is
+included without limitation in the term "modification".)
+
+  "Source code" for a work means the preferred form of the work for
+making modifications to it.  For a library, complete source code means
+all the source code for all modules it contains, plus any associated
+interface definition files, plus the scripts used to control
+compilation and installation of the library.
+
+  Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running a program using the Library is not restricted, and output from
+such a program is covered only if its contents constitute a work based
+on the Library (independent of the use of the Library in a tool for
+writing it).  Whether that is true depends on what the Library does
+and what the program that uses the Library does.
+
+  1. You may copy and distribute verbatim copies of the Library's
+complete source code as you receive it, in any medium, provided that
+you conspicuously and appropriately publish on each copy an
+appropriate copyright notice and disclaimer of warranty; keep intact
+all the notices that refer to this License and to the absence of any
+warranty; and distribute a copy of this License along with the
+Library.
+
+  You may charge a fee for the physical act of transferring a copy,
+and you may at your option offer warranty protection in exchange for a
+fee.
+
+  2. You may modify your copy or copies of the Library or any portion
+of it, thus forming a work based on the Library, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) The modified work must itself be a software library.
+
+    b) You must cause the files modified to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    c) You must cause the whole of the work to be licensed at no
+    charge to all third parties under the terms of this License.
+
+    d) If a facility in the modified Library refers to a function or a
+    table of data to be supplied by an application program that uses
+    the facility, other than as an argument passed when the facility
+    is invoked, then you must make a good faith effort to ensure that,
+    in the event an application does not supply such function or
+    table, the facility still operates, and performs whatever part of
+    its purpose remains meaningful.
+
+    (For example, a function in a library to compute square roots has
+    a purpose that is entirely well-defined independent of the
+    application.  Therefore, Subsection 2d requires that any
+    application-supplied function or table used by this function must
+    be optional: if the application does not supply it, the square
+    root function must still compute square roots.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Library,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Library, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote
+it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Library.
+
+In addition, mere aggregation of another work not based on the Library
+with the Library (or with a work based on the Library) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may opt to apply the terms of the ordinary GNU General Public
+License instead of this License to a given copy of the Library.  To do
+this, you must alter all the notices that refer to this License, so
+that they refer to the ordinary GNU General Public License, version 2,
+instead of to this License.  (If a newer version than version 2 of the
+ordinary GNU General Public License has appeared, then you can specify
+that version instead if you wish.)  Do not make any other change in
+these notices.
+
+  Once this change is made in a given copy, it is irreversible for
+that copy, so the ordinary GNU General Public License applies to all
+subsequent copies and derivative works made from that copy.
+
+  This option is useful when you wish to copy part of the code of
+the Library into a program that is not a library.
+
+  4. You may copy and distribute the Library (or a portion or
+derivative of it, under Section 2) in object code or executable form
+under the terms of Sections 1 and 2 above provided that you accompany
+it with the complete corresponding machine-readable source code, which
+must be distributed under the terms of Sections 1 and 2 above on a
+medium customarily used for software interchange.
+
+  If distribution of object code is made by offering access to copy
+from a designated place, then offering equivalent access to copy the
+source code from the same place satisfies the requirement to
+distribute the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  5. A program that contains no derivative of any portion of the
+Library, but is designed to work with the Library by being compiled or
+linked with it, is called a "work that uses the Library".  Such a
+work, in isolation, is not a derivative work of the Library, and
+therefore falls outside the scope of this License.
+
+  However, linking a "work that uses the Library" with the Library
+creates an executable that is a derivative of the Library (because it
+contains portions of the Library), rather than a "work that uses the
+library".  The executable is therefore covered by this License.
+Section 6 states terms for distribution of such executables.
+
+  When a "work that uses the Library" uses material from a header file
+that is part of the Library, the object code for the work may be a
+derivative work of the Library even though the source code is not.
+Whether this is true is especially significant if the work can be
+linked without the Library, or if the work is itself a library.  The
+threshold for this to be true is not precisely defined by law.
+
+  If such an object file uses only numerical parameters, data
+structure layouts and accessors, and small macros and small inline
+functions (ten lines or less in length), then the use of the object
+file is unrestricted, regardless of whether it is legally a derivative
+work.  (Executables containing this object code plus portions of the
+Library will still fall under Section 6.)
+
+  Otherwise, if the work is a derivative of the Library, you may
+distribute the object code for the work under the terms of Section 6.
+Any executables containing that work also fall under Section 6,
+whether or not they are linked directly with the Library itself.
+
+  6. As an exception to the Sections above, you may also combine or
+link a "work that uses the Library" with the Library to produce a
+work containing portions of the Library, and distribute that work
+under terms of your choice, provided that the terms permit
+modification of the work for the customer's own use and reverse
+engineering for debugging such modifications.
+
+  You must give prominent notice with each copy of the work that the
+Library is used in it and that the Library and its use are covered by
+this License.  You must supply a copy of this License.  If the work
+during execution displays copyright notices, you must include the
+copyright notice for the Library among them, as well as a reference
+directing the user to the copy of this License.  Also, you must do one
+of these things:
+
+    a) Accompany the work with the complete corresponding
+    machine-readable source code for the Library including whatever
+    changes were used in the work (which must be distributed under
+    Sections 1 and 2 above); and, if the work is an executable linked
+    with the Library, with the complete machine-readable "work that
+    uses the Library", as object code and/or source code, so that the
+    user can modify the Library and then relink to produce a modified
+    executable containing the modified Library.  (It is understood
+    that the user who changes the contents of definitions files in the
+    Library will not necessarily be able to recompile the application
+    to use the modified definitions.)
+
+    b) Use a suitable shared library mechanism for linking with the
+    Library.  A suitable mechanism is one that (1) uses at run time a
+    copy of the library already present on the user's computer system,
+    rather than copying library functions into the executable, and (2)
+    will operate properly with a modified version of the library, if
+    the user installs one, as long as the modified version is
+    interface-compatible with the version that the work was made with.
+
+    c) Accompany the work with a written offer, valid for at least
+    three years, to give the same user the materials specified in
+    Subsection 6a, above, for a charge no more than the cost of
+    performing this distribution.
+
+    d) If distribution of the work is made by offering access to copy
+    from a designated place, offer equivalent access to copy the above
+    specified materials from the same place.
+
+    e) Verify that the user has already received a copy of these
+    materials or that you have already sent this user a copy.
+
+  For an executable, the required form of the "work that uses the
+Library" must include any data and utility programs needed for
+reproducing the executable from it.  However, as a special exception,
+the materials to be distributed need not include anything that is
+normally distributed (in either source or binary form) with the major
+components (compiler, kernel, and so on) of the operating system on
+which the executable runs, unless that component itself accompanies
+the executable.
+
+  It may happen that this requirement contradicts the license
+restrictions of other proprietary libraries that do not normally
+accompany the operating system.  Such a contradiction means you cannot
+use both them and the Library together in an executable that you
+distribute.
+
+  7. You may place library facilities that are a work based on the
+Library side-by-side in a single library together with other library
+facilities not covered by this License, and distribute such a combined
+library, provided that the separate distribution of the work based on
+the Library and of the other library facilities is otherwise
+permitted, and provided that you do these two things:
+
+    a) Accompany the combined library with a copy of the same work
+    based on the Library, uncombined with any other library
+    facilities.  This must be distributed under the terms of the
+    Sections above.
+
+    b) Give prominent notice with the combined library of the fact
+    that part of it is a work based on the Library, and explaining
+    where to find the accompanying uncombined form of the same work.
+
+  8. You may not copy, modify, sublicense, link with, or distribute
+the Library except as expressly provided under this License.  Any
+attempt otherwise to copy, modify, sublicense, link with, or
+distribute the Library is void, and will automatically terminate your
+rights under this License.  However, parties who have received copies,
+or rights, from you under this License will not have their licenses
+terminated so long as such parties remain in full compliance.
+
+  9. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Library or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Library (or any work based on the
+Library), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Library or works based on it.
+
+  10. Each time you redistribute the Library (or any work based on the
+Library), the recipient automatically receives a license from the
+original licensor to copy, distribute, link with or modify the Library
+subject to these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties with
+this License.
+
+  11. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Library at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Library by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Library.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply, and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  12. If the distribution and/or use of the Library is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Library under this License
+may add an explicit geographical distribution limitation excluding those
+countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  13. The Free Software Foundation may publish revised and/or new
+versions of the Lesser General Public License from time to time.
+Such new versions will be similar in spirit to the present version,
+but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Library
+specifies a version number of this License which applies to it and
+"any later version", you have the option of following the terms and
+conditions either of that version or of any later version published by
+the Free Software Foundation.  If the Library does not specify a
+license version number, you may choose any version ever published by
+the Free Software Foundation.
+
+  14. If you wish to incorporate parts of the Library into other free
+programs whose distribution conditions are incompatible with these,
+write to the author to ask for permission.  For software which is
+copyrighted by the Free Software Foundation, write to the Free
+Software Foundation; we sometimes make exceptions for this.  Our
+decision will be guided by the two goals of preserving the free status
+of all derivatives of our free software and of promoting the sharing
+and reuse of software generally.
+
+                            NO WARRANTY
+
+  15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO
+WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW.
+EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR
+OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY
+KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE
+LIBRARY IS WITH YOU.  SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME
+THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
+WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY
+AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU
+FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR
+CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE
+LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING
+RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
+FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF
+SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+           How to Apply These Terms to Your New Libraries
+
+  If you develop a new library, and you want it to be of the greatest
+possible use to the public, we recommend making it free software that
+everyone can redistribute and change.  You can do so by permitting
+redistribution under these terms (or, alternatively, under the terms
+of the ordinary General Public License).
+
+  To apply these terms, attach the following notices to the library.
+It is safest to attach them to the start of each source file to most
+effectively convey the exclusion of warranty; and each file should
+have at least the "copyright" line and a pointer to where the full
+notice is found.
+
+
+    <one line to give the library's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+Also add information on how to contact you by electronic and paper mail.
+
+You should also get your employer (if you work as a programmer) or
+your school, if any, to sign a "copyright disclaimer" for the library,
+if necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the
+  library `Frob' (a library for tweaking knobs) written by James
+  Random Hacker.
+
+  <signature of Ty Coon>, 1 April 1990
+  Ty Coon, President of Vice
+
+That's all there is to it!
+
+

--- a/src/modules/job-manager/Makefile.am
+++ b/src/modules/job-manager/Makefile.am
@@ -9,6 +9,7 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
 	-I$(top_builddir)/src/common/libflux \
+	-I$(top_srcdir)/src/common/libccan \
 	$(JANSSON_CFLAGS)
 
 fluxmod_LTLIBRARIES = \

--- a/src/modules/job-manager/event.c
+++ b/src/modules/job-manager/event.c
@@ -696,6 +696,17 @@ static int event_jobtap_call (struct event *event,
     return 0;
 }
 
+static int event_job_cache (struct event *event,
+                            struct job *job,
+                            const char *name)
+{
+    int id;
+    /*  Get a unique event id for event 'name' and stash it with the job */
+    if ((id = event_index (event, name)) < 0)
+        return -1;
+    return job_event_id_set (job, id);
+}
+
 int event_job_post_entry (struct event *event,
                           struct job *job,
                           const char *name,
@@ -717,6 +728,8 @@ int event_job_post_entry (struct event *event,
     if (event_job_update (job, entry) < 0) // modifies job->state
         return -1;
     job->eventlog_seq++;
+    if (event_job_cache (event, job, name) < 0)
+        return -1;
     if (!(flags & EVENT_NO_COMMIT)
         && event_batch_commit_event (event, job, entry) < 0)
         return -1;

--- a/src/modules/job-manager/event.h
+++ b/src/modules/job-manager/event.h
@@ -78,6 +78,10 @@ void event_listeners_disconnect_rpc (flux_t *h,
                                      const flux_msg_t *msg,
                                      void *arg);
 
+
+/*  Return globally unique index for event name */
+int event_index (struct event *event, const char *name);
+
 #endif /* _FLUX_JOB_MANAGER_EVENT_H */
 
 /*

--- a/src/modules/job-manager/job.h
+++ b/src/modules/job-manager/job.h
@@ -18,6 +18,7 @@
 #include "src/common/libjob/job.h"
 #include "src/common/libutil/grudgeset.h"
 #include "src/common/libflux/plugin.h"
+#include "ccan/bitmap/bitmap.h"
 
 struct job {
     flux_jobid_t id;
@@ -45,6 +46,8 @@ struct job {
     struct grudgeset *dependencies;
 
     zlistx_t *subscribers;  // list of plugins subscribed to all job events
+
+    struct bitmap *events;  // set of events by id posted to this job
 
     void *handle;           // zlistx_t handle
     int refcount;           // private to job.c
@@ -106,6 +109,12 @@ bool job_flag_valid (struct job *job, const char *flag);
 int job_events_subscribe (struct job *job, flux_plugin_t *p);
 
 void job_events_unsubscribe (struct job *job, flux_plugin_t *p);
+
+/*  Add and test for events posted to jobs by a global event id.
+ *  (Event names are translated to id by the event class)
+ */
+int job_event_id_set (struct job *job, int id);
+int job_event_id_test (struct job *job, int id);
 
 #endif /* _FLUX_JOB_MANAGER_JOB_H */
 

--- a/src/modules/job-manager/jobtap.c
+++ b/src/modules/job-manager/jobtap.c
@@ -1868,6 +1868,28 @@ void flux_jobtap_job_unsubscribe (flux_plugin_t *p, flux_jobid_t id)
         job_events_unsubscribe (job, p);
 }
 
+int flux_jobtap_job_event_posted (flux_plugin_t *p,
+                                  flux_jobid_t id,
+                                  const char *name)
+{
+    int index;
+    struct job * job;
+    struct jobtap *jobtap;
+
+    if (!p
+        || !name
+        || !(jobtap = flux_plugin_aux_get (p, "flux::jobtap"))) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (!(job = jobtap_lookup_jobid (p, id))
+        || (index = event_index (jobtap->ctx->event, name)) < 0)
+        return -1;
+    if (job_event_id_test (job, index))
+        return 1;
+    return 0;
+}
+
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab
  */

--- a/src/modules/job-manager/jobtap.h
+++ b/src/modules/job-manager/jobtap.h
@@ -176,6 +176,11 @@ int flux_jobtap_get_job_result (flux_plugin_t *p,
                                 flux_jobid_t id,
                                 flux_job_result_t *resultp);
 
+/*  Return 1 if event 'name' has been posted to job 'id', 0 if not.
+ */
+int flux_jobtap_job_event_posted (flux_plugin_t *p,
+                                  flux_jobid_t id,
+                                  const char *name);
 
 /*
  *  This function subscribes plugin 'p' to extra callbacks for job 'id'

--- a/src/modules/job-manager/test/job.c
+++ b/src/modules/job-manager/test/job.c
@@ -288,6 +288,45 @@ static void test_subscribe (void)
     pass ("destroy 2nd plugin after all jobs");
 }
 
+static void test_event_id_cache (void)
+{
+    struct job *job = job_create ();
+    ok (job_event_id_set (job, 1024) < 0 && errno == ENOSPC,
+        "job_event_id_set 1024 returns ENOSPC");
+    ok (job_event_id_set (job, -1) < 0 && errno == EINVAL,
+        "job_event_id_set -1 returns EINVAL");
+
+    ok (job_event_id_test (job, 1024) < 0 && errno == EINVAL,
+        "job_event_id_test 1024 returns EINVAL");
+    ok (job_event_id_test (job, -1) < 0 && errno == EINVAL,
+        "job_event_id_test -1 returns EINVAL");
+
+    ok (job_event_id_test (job, 0) == 0,
+        "job_event_id_test 0 returns 0");
+    ok (job_event_id_test (job, 63) == 0,
+        "job_event_id_test 63 returns 0");
+
+    ok (job_event_id_set (job, 0) == 0,
+        "job_event_id_set works");
+    ok (job_event_id_test (job, 0) == 1,
+        "job_event_id_test 0 now returns 1");
+    ok (job_event_id_set (job, 3) == 0,
+        "job_event_id_set works");
+    ok (job_event_id_test (job, 3) == 1,
+        "job_event_id_test 3 now returns 1");
+    ok (job_event_id_set (job, 63) == 0,
+        "job_event_id_set works");
+    ok (job_event_id_test (job, 63) == 1,
+        "job_event_id_test 63 now returns 1");
+
+    ok (job_event_id_set (job, 3) == 0,
+        "job_event_id_set of the same event works");
+    ok (job_event_id_test (job, 3) == 1,
+        "job_event_id_test of multiple set event works");
+
+    job_decref (job);
+}
+
 int main (int argc, char *argv[])
 {
     plan (NO_PLAN);
@@ -295,6 +334,7 @@ int main (int argc, char *argv[])
     test_create ();
     test_create_from_eventlog ();
     test_subscribe ();
+    test_event_id_cache ();
 
     done_testing ();
 }

--- a/t/job-manager/plugins/subscribe.c
+++ b/t/job-manager/plugins/subscribe.c
@@ -11,8 +11,24 @@ static int cb (flux_plugin_t *p,
 {
     flux_t *h = flux_jobtap_get_flux (p);
 
-    if (strcmp (topic, "job.event.start") == 0)
+    if (strcmp (topic, "job.event.start") == 0) {
+        /*  Test flux_jobtap_job_event_posted(), then unsusbscribe()
+         */
+        if (flux_jobtap_job_event_posted (NULL, 0, NULL) != -1
+            || flux_jobtap_job_event_posted (p, 0, NULL) != -1)
+            flux_jobtap_raise_exception (p, FLUX_JOBTAP_CURRENT_JOB,
+                                         "subscribe-test",
+                                         0,
+                                         "event_count() invalid args failed");
+        if (flux_jobtap_job_event_posted (p,
+                                         FLUX_JOBTAP_CURRENT_JOB,
+                                         "start") != 1)
+            flux_jobtap_raise_exception (p, FLUX_JOBTAP_CURRENT_JOB,
+                                         "subscribe-test",
+                                         0,
+                                         "event_count 'start' didn't return 1");
         flux_jobtap_job_unsubscribe (p, FLUX_JOBTAP_CURRENT_JOB);
+    }
     else if (strcmp (topic, "job.event.finish") == 0) {
         flux_jobtap_raise_exception (p, FLUX_JOBTAP_CURRENT_JOB,
                                      "subscribe-test",


### PR DESCRIPTION
This PR adds a new interface `flux_jobtap_job_event_count()` to jobtap.

This allows plugins to determine which and how many of a named event have been posted to a job. This allows, for instance, more fine-grained determination of a job's current "state" (beyond `flux_job_state_t`), e.g. has a job in `RUN` state seen a `start` event or `release` event or `exception`. This is also provides a much easier method by which a plugin can determine a job's place in the state diagram that checking the current state (if the job has seen a `start` event, then we know it is in the RUN state or later, instead of having to check whether current state is `CLEANUP` or `INACTIVE` or `RUN`)

Unfortunately, this requires a hash added to each job struct. However, in real-world testing this didn't seem to have much impact to job throughput, though there will be a runtime memory usage penalty. Since effort has been made to keep the size of the `struct job` small, I wonder if this approach will be acceptable.

This interface will be used by future changes to the `after:JOBID` dependencies to trigger the release of the dependent job on the `start` event instead of transition to the `RUN` state.

This PR is built on top of #3861 (mainly to avoid conflicts)