### PR TITLE
mpi: add -ompi=openmpi@5 support

### DIFF
--- a/src/shell/lua.d/openmpi.lua
+++ b/src/shell/lua.d/openmpi.lua
@@ -8,8 +8,15 @@
 -- SPDX-License-Identifier: LGPL-3.0
 -------------------------------------------------------------
 
-shell.setenv ("OMPI_MCA_pmix", "flux")
-shell.setenv ("OMPI_MCA_schizo", "flux")
+local mpi, version = shell.getopt_with_version ("mpi")
+
+if mpi == "openmpi" and version and tonumber (version) >= 5 then
+    shell.setenv ("OMPI_MCA_pmix", "^flux")
+    shell.setenv ("OMPI_MCA_schizo", "^flux")
+else
+    shell.setenv ("OMPI_MCA_pmix", "flux")
+    shell.setenv ("OMPI_MCA_schizo", "flux")
+end
 
 -- OpenMPI needs a job-unique directory for vader shmem paths, otherwise
 -- multiple jobs per node may conflict (see flux-framework/flux-core#3649).

--- a/t/t3001-mpi-personalities.t
+++ b/t/t3001-mpi-personalities.t
@@ -82,4 +82,17 @@ test_expect_success 'spectrum mpi sets OMPI_COMM_WORLD_RANK' '
   test_cmp spectrum.rank.expected spectrum.rank.out
 '
 
+# openmpi loads by default currently, so -ompi=openmpi is not actually needed
+test_expect_success 'openmpi sets OMPI_MCA_pmix=flux OMPI_MCA_schizo=flux' '
+  flux mini run -ompi=openmpi printenv >env.out &&
+  grep OMPI_MCA_pmix=flux env.out &&
+  grep OMPI_MCA_schizo=flux env.out
+'
+
+test_expect_success 'openmpi@5 eschews flux plugins' '
+  flux mini run -ompi=openmpi@5 printenv >env5.out &&
+  grep OMPI_MCA_pmix=^flux env5.out &&
+  grep OMPI_MCA_schizo=^flux env5.out
+'
+
 test_done


### PR DESCRIPTION
Problem: upstream openmpi nixed our flux plugins in the v5 series, as mentioned in #3586, but our `openmpi.lua` plugin sets the environment to require those plugins, unconditionally.  This prevents flux from bootstrapping openmpi-v5, even with a pmix shell plugin.

Use the new mpi personality version support to change the logic if `-ompi=openmpi@5` is supplied by the user.  Otherwise, behavior does not change.