### PR TITLE
job-exec: enable manual override option for mock execution jobs

### DIFF
--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -69,7 +69,8 @@ dist_fluxcmd_SCRIPTS = \
 	flux-resource.py \
 	flux-admin.py \
 	flux-jobtap.py \
-	flux-job-validator.py
+	flux-job-validator.py \
+	flux-job-exec-override.py
 
 fluxcmd_PROGRAMS = \
 	flux-terminus \

--- a/src/cmd/flux-job-exec-override.py
+++ b/src/cmd/flux-job-exec-override.py
@@ -1,0 +1,77 @@
+#!/bin/false
+##############################################################
+# Copyright 2021 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+##############################################################
+
+import sys
+import logging
+import argparse
+
+import flux
+from flux.job import JobID
+
+LOGGER = logging.getLogger("flux-job-exec-override")
+
+
+def job_exec_start(args):
+    """Start testexec job under manual override"""
+    try:
+        flux.Flux().rpc(
+            "job-exec.override", {"event": "start", "jobid": args.jobid}
+        ).get()
+    except OSError as exc:
+        LOGGER.error("%s", exc.strerror)
+        sys.exit(1)
+
+
+def job_exec_finish(args):
+    """Finish testexec job under manual override"""
+    try:
+        flux.Flux().rpc(
+            "job-exec.override",
+            {"event": "finish", "jobid": args.jobid, "status": args.status},
+        ).get()
+    except OSError as exc:
+        LOGGER.error("%s", exc.strerror)
+        sys.exit(1)
+
+
+@flux.util.CLIMain(LOGGER)
+def main():
+    parser = argparse.ArgumentParser(prog="flux-job-exec")
+    subparsers = parser.add_subparsers(
+        title="subcommands", description="", dest="subcommand"
+    )
+    subparsers.required = True
+
+    start_parser = subparsers.add_parser(
+        "start", formatter_class=flux.util.help_formatter()
+    )
+    start_parser.add_argument("jobid", metavar="JOBID", type=JobID, help="target JOBID")
+    start_parser.set_defaults(func=job_exec_start)
+
+    finish_parser = subparsers.add_parser(
+        "finish", formatter_class=flux.util.help_formatter()
+    )
+    finish_parser.add_argument(
+        "jobid", metavar="JOBID", type=JobID, help="target JOBID"
+    )
+    finish_parser.add_argument(
+        "status", metavar="STATUS", type=int, help="finish wait status", default=0
+    )
+    finish_parser.set_defaults(func=job_exec_finish)
+
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()
+
+# vi: ts=4 sw=4 expandtab

--- a/src/modules/job-exec/job-exec.h
+++ b/src/modules/job-exec/job-exec.h
@@ -27,6 +27,8 @@ struct jobinfo;
  *
  *   - config:  (optional) called once at module load for configuraiton
  *
+ *   - unload:  (optional) called once at module unload
+ *
  *   - init:    allow selection and initialization of an exec implementation
  *              from jobspec and/or R. An implementation should return 0 to
  *              "pass" on handling this job, > 0 to denote successful
@@ -46,6 +48,7 @@ struct jobinfo;
 struct exec_implementation {
     const char *name;
     int  (*config)  (flux_t *h, int argc, char **argv);
+    void (*unload)  (void);
     int  (*init)    (struct jobinfo *job);
     void (*exit)    (struct jobinfo *job);
     int  (*start)   (struct jobinfo *job);

--- a/t/t2400-job-exec-test.t
+++ b/t/t2400-job-exec-test.t
@@ -14,14 +14,11 @@ RPC=${FLUX_BUILD_DIR}/t/request/rpc
 
 job_kvsdir()    { flux job id --to=kvs $1; }
 exec_eventlog() { flux kvs get -r $(job_kvsdir $1).guest.exec.eventlog; }
-exec_test()     { ${jq} '.attributes.system.exec.test = {}'; }
-exec_testattr() {
-	${jq} --arg key "$1" --arg value $2 \
-	      '.attributes.system.exec.test[$key] = $value'
-}
 
 test_expect_success 'job-exec: generate jobspec for simple test job' '
-        flux jobspec srun -n1 hostname | exec_test > basic.json
+	flux mini run \
+	    --setattr=system.exec.test.run_duration=0.0001s \
+	    --dry-run hostname > basic.json
 '
 test_expect_success 'job-exec: basic job runs in simulated mode' '
 	jobid=$(flux job submit basic.json) &&
@@ -46,8 +43,8 @@ test_expect_success 'job-exec: exec.eventlog exists with expected states' '
 	tail -1 eventlog.1.out | grep "done"
 '
 test_expect_success 'job-exec: canceling job during execution works' '
-	jobid=$(flux jobspec srun -t 1 hostname | \
-		 exec_test | flux job submit) &&
+	jobid=$(flux mini submit \
+                --setattr=system.exec.test.run_duration=10s hostname) &&
 	flux job wait-event -vt 2.5 ${jobid} start &&
 	flux job cancel ${jobid} &&
 	flux job wait-event -t 2.5 ${jobid} exception &&
@@ -57,9 +54,8 @@ test_expect_success 'job-exec: canceling job during execution works' '
 	exec_eventlog $jobid | grep "complete" | grep "\"status\":15"
 '
 test_expect_success 'job-exec: mock exception during initialization' '
-	flux jobspec srun hostname | \
-	  exec_testattr mock_exception init > ex1.json &&
-	jobid=$(flux job submit ex1.json) &&
+	jobid=$(flux mini submit \
+	         --setattr=system.exec.test.mock_exception=init true) &&
 	flux job wait-event -t 2.5 ${jobid} exception > exception.1.out &&
 	test_debug "flux job eventlog ${jobid}" &&
 	grep "type=\"exec\"" exception.1.out &&
@@ -69,9 +65,8 @@ test_expect_success 'job-exec: mock exception during initialization' '
 	test_must_fail grep "finish" eventlog.${jobid}.out
 '
 test_expect_success 'job-exec: mock exception during run' '
-	flux jobspec srun hostname | \
-	  exec_testattr mock_exception run > ex2.json &&
-	jobid=$(flux job submit ex2.json) &&
+	jobid=$(flux mini submit \
+	         --setattr=system.exec.test.mock_exception=run true) &&
 	flux job wait-event -t 2.5 ${jobid} exception > exception.2.out &&
 	grep "type=\"exec\"" exception.2.out &&
 	grep "mock run exception generated" exception.2.out &&


### PR DESCRIPTION
Testing of future work that uses internal job events of the `RUN` state for synchronization may require better control of how the `start` and `finish` events are emitted for test jobs. 

This PR extends the job-exec module's `testexec` implementation to add an `override` option. When this option is enabled via `attributes.system.exec.test.override=1` in jobspec, the module does not immediately issue the `start` response to the job manager, but instead waits for a manual request from the job owner via a new `job-exec.override` service. If the job does not have a `duration` or `attributes.system.exec.test.run_duration` set (or they are `0.`) then the job will continue to "run" until a manual `finish` event is requested, or a job exception raised.

A new plumbing command `flux job-exec-override` is provided to ease the use of this new interface.

This will allow, for instance, a test that ensures a dependency waiting on the `start` event is not released after the `alloc` event (and thus `RUN` state), and instead waits explicitly for the `start` event.

Also, it occurs to me that, though not ideal, this interface could be used as a stopgap solution for #2924 (exec system bypass). E.g. a driver script could request resources with an `exec.test.override` jobspec, wait for the alloc event, execute work outside of the Flux exec system and manually issue a `start` event when the work has started, then when the work is complete, manually issue a `finish` event with the correct status, effectively bypassing the normal execution system.

This could also be useful for launching k8s containers using Flux alloc-bypass jobs. The container can be associated with an alloc-bypass, job-exec override job so that the container takes no resources from the instance. The `start` and `finish` events can be manually issued when the container is started and stopped, and other Flux jobs can set `after` and `afterany` dependencies on these container jobs. (Once #3865 goes in)
