### PR TITLE
allow default shell rc path to be extended via FLUX_SHELL_RC_PATH

### DIFF
--- a/src/shell/initrc.lua
+++ b/src/shell/initrc.lua
@@ -3,7 +3,11 @@
 plugin.load { file = "*.so", conf = {} }
 
 -- Source all rc files under shell.rcpath/lua.d/*.lua of shell rcpath:
-source (shell.rcpath .. "/lua.d/*.lua")
+local rcpath = shell.rcpath.."/lua.d" ..
+               ":" .. (shell.getenv("FLUX_SHELL_RC_PATH") or "")
+for path in rcpath:gmatch ("[^:]+") do
+    source (path .. "/*.lua")
+end
 
 -- If userrc is set in shell options, then load the user supplied initrc here:
 if shell.options.userrc then source (shell.options.userrc) end

--- a/t/t2603-job-shell-initrc.t
+++ b/t/t2603-job-shell-initrc.t
@@ -42,6 +42,15 @@ test_expect_success 'flux-shell: initrc: plugin.searchpath set via broker attr' 
 	flux setattr conf.shell_pluginpath "${old_pluginpath}"
 	
 '
+test_expect_success 'flux-shell: default initrc obeys FLUX_SHELL_RC_PATH' '
+	mkdir test-dir.d &&
+	cat >test-dir.d/test.lua <<-EOF &&
+	shell.log ("plugin loaded from test-dir.d")
+	EOF
+	FLUX_SHELL_RC_PATH=$(pwd)/test-dir.d \
+	  flux mini run hostname >rcpath.log 2>&1 &&
+	grep "plugin loaded from test-dir.d" rcpath.log
+'
 test_expect_success 'flux-shell: initrc: generate 1-task jobspec and matching R' '
 	flux jobspec srun -N1 -n1 echo Hi >j1 &&
 	cat >R1 <<-EOT


### PR DESCRIPTION
This is an attempt at a simple solution for #3866.

The default `initrc.lua` for the job shell loads all `*.lua` rc scripts from `${rcpath}/lua.d/*`, where `rcpath` is the directory in which `initrc.lua` was found. On a normal system, the default shell initialization can be influenced by dropping another Lua rc script in this directory. (This is how the mpi 'personality' plugins work).

However, in systems like spack, where every package has its own root, add-on packages like mpibind can't just drop a new file into the shell `rcpath`, since that path is in the flux-core package's root. This PR adds support for a new environment variable `FLUX_SHELL_RC_PATH` which, when set in a job's environment, will extend the search path for `*.lua` files to automatically load at runtime.

Therefore, in spack, packages can append a path to a directory where they keep a Lua rc file which can then load plugins, further change environment, etc.

For example, the mpibind spack package, which wants to always load the `mpibind.so` shell plugin, can install a one-liner `mpibind.lua` like:
```Lua
plugin.load ("/full/path/to/mpibind.so")
```
and in the environment manipulation for the spack package, extend the environment to append the directory in which this Lua file is installed to `FLUX_SHELL_RC_PATH`.

On a non-spack system, the `mpibind.lua` file can just be installed directly into the default rcpath, e.g. `/etc/flux/shell/lua.d`.