### PR TITLE
docker: add --build-arg to docker-run-checks, systemd-devel to centos8

### DIFF
--- a/src/test/docker/centos8/Dockerfile
+++ b/src/test/docker/centos8/Dockerfile
@@ -58,6 +58,7 @@ RUN yum -y update \
 	lua-devel \
 	valgrind-devel \
 	libs3-devel \
+	systemd-devel \
 #  Other deps
 	perl-Time-HiRes \
 	lua-posix \

--- a/src/test/docker/docker-run-checks.sh
+++ b/src/test/docker/docker-run-checks.sh
@@ -81,6 +81,7 @@ while true; do
       -r|--recheck)                RECHECK=t;                  shift   ;;
       -u|--unit-test-only)         UNIT_TEST_ONLY=t;           shift   ;;
       -D|--build-directory)        BUILD_DIR="$2";             shift 2 ;;
+      --build-arg)                 BUILD_ARG=" --build-arg $2" shift 2 ;;
       --workdir)                   WORKDIR="$2";               shift 2 ;;
       --no-cache)                  NO_CACHE="--no-cache";      shift   ;;
       --no-home)                   MOUNT_HOME_ARGS="";         shift   ;;
@@ -139,6 +140,7 @@ checks_group "Building image $IMAGE for user $USER $(id -u) group=$(id -g)" \
     --build-arg UID=$(id -u) \
     --build-arg GID=$(id -g) \
     --build-arg FLUX_SECURITY_VERSION=$FLUX_SECURITY_VERSION \
+    ${BUILD_ARG:- } \
     -t ${BUILD_IMAGE} \
     ${DOCKERFILE} \
     || die "docker build failed"


### PR DESCRIPTION
A couple of small docker/test updates here.

In flux-pmix we needed a `--build-arg` option to `docker-run-checks.sh`, so pull that back up here.

For systemd-based job shell execution @chu11 needs `systemd-devel` in the centos8 image, so add that.

I've already pushed the new `fluxrm/testenv:centos8` image to docker hub.
