### PR TITLE
shell: add taskids idset to flux_shell_get_rank_info(3)

### DIFF
--- a/doc/man3/flux_shell_get_info.rst
+++ b/doc/man3/flux_shell_get_info.rst
@@ -60,7 +60,14 @@ string with the following layout:
 
    "broker_rank":i,
    "ntasks":i
+   "taskids":s
    "resources": { "cores":s, ... }
+
+where ``broker_rank`` is the broker rank on which the target shell rank
+of the query is running, ``ntasks`` is the number of tasks running under
+that shell rank, ``taskids`` is a list of task id assignments for those
+tasks (an RFC 22 idset string), and ``resources`` is a dictionary of
+resource name to resource ids assigned to the shell rank.
 
 ``flux_shell_info_unpack()`` and ``flux_shell_rank_info_unpack()``
 accomplished the same thing with Jansson-style formatting arguments.

--- a/src/shell/shell.h
+++ b/src/shell/shell.h
@@ -118,6 +118,7 @@ int flux_shell_info_unpack (flux_shell_t *shell,
  *  {
  *   "broker_rank":i,
  *   "ntasks":i
+ *   "taskids": s // task id list for this rank in RFC 22 idset form.
  *   "resources": { "cores":s, ... }
  *  }
  */

--- a/t/shell/initrc/tests/0001-shell-info.lua
+++ b/t/shell/initrc/tests/0001-shell-info.lua
@@ -57,6 +57,9 @@ type_ok (rankinfo.resources, "table",
     "rankinfo.resources is a table")
 is (rankinfo.resources.cores, "0,1",
     "rankinfo.resources.cores is expected value")
+type_ok (rankinfo.taskids, "string",
+    "rankinfo.taskids is a string")
+diag ("  rankinfo.taskids is "..rankinfo.taskids)
 
 error_like ("i = task.info", "access task",
     "trying to access task causes error")


### PR DESCRIPTION
As described in #3820, a couple shell plugins have needed to gather the list of taskids assigned to shell ranks in a job. Currently, plugins can assume "block" allocation of task ids and recreate the mapping themselves, but not only is this cumbersome, it will be wrong if the shell ever chooses a different mapping for task ids across shell ranks.

This PR adds a new member of the `flux_shell_get_rank_info(3)` payload - a `taskids` entry which is an RFC 22 idset string of task ids the shell has assigned to the target shell rank.

