### PR TITLE
Fix a couple build and test issues found on ppc64le with clang 6.0+

### DIFF
--- a/src/common/libccan/ccan/base64/base64.c
+++ b/src/common/libccan/ccan/base64/base64.c
@@ -31,7 +31,7 @@ static int8_t sixbit_from_b64(const base64_maps_t *maps,
 	int8_t ret;
 
 	ret = maps->decode_map[(unsigned char)b64letter];
-	if (ret == (char)0xff) {
+	if (ret == (int8_t)0xff) {
 		errno = EDOM;
 		return -1;
 	}
@@ -41,7 +41,7 @@ static int8_t sixbit_from_b64(const base64_maps_t *maps,
 
 bool base64_char_in_alphabet(const base64_maps_t *maps, const char b64char)
 {
-	return (maps->decode_map[(const unsigned char)b64char] != (char)0xff);
+	return (maps->decode_map[(const unsigned char)b64char] != (int8_t)0xff);
 }
 
 void base64_init_maps(base64_maps_t *dest, const char src[64])

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -61,7 +61,8 @@ test_expect_success 'flux-python command runs a python that finds flux' '
 
 test_expect_success 'flux-python command runs the configured python' '
 	define_line=$(grep "^#define PYTHON_INTERPRETER" ${FLUX_BUILD_DIR}/config/config.h) &&
-	expected=$(echo ${define_line} | sed -E '\''s~.*define PYTHON_INTERPRETER "(.*)"~\1~'\'') &&
+	pypath=$(echo ${define_line} | sed -E '\''s~.*define PYTHON_INTERPRETER "(.*)"~\1~'\'') &&
+	expected=$(${pypath} -c "import sys; print(sys.executable)") &&
 	actual=$(flux python -c "import sys; print(sys.executable)") &&
 	test "${expected}" = "${actual}"
 '


### PR DESCRIPTION
This PR fixes a couple issues that popped up when building on a ppc64le TOSS system with clang 11.0.x.

The first issue is a build problem discussed in #3874.

The second issue isn't ppc64le/clang specific, but fixes a test error when the Python interpreter used by `flux python` is a symlink.