### PR TITLE
shell: require FLUX_SHELL_PLUGIN_NAME in plugins to fix logging component discovery

### DIFF
--- a/doc/man3/flux_shell_log.rst
+++ b/doc/man3/flux_shell_log.rst
@@ -13,7 +13,8 @@ SYNOPSIS
 
 ::
 
-   void flux_shell_log (int level,
+   void flux_shell_log (const char *component,
+                        int level,
                         const char *file,
                         int line,
                         const char *fmt,
@@ -21,7 +22,8 @@ SYNOPSIS
 
 ::
 
-   int flux_shell_err (const char *file,
+   int flux_shell_err (const char *component,
+                       const char *file,
                        int line,
                        int errnum,
                        const char *fmt,
@@ -29,7 +31,8 @@ SYNOPSIS
 
 ::
 
-   void flux_shell_fatal (const char *file,
+   void flux_shell_fatal (const char *component,
+                          const char *file,
                           int line,
                           int errnum,
                           int exit_code,
@@ -45,9 +48,15 @@ SYNOPSIS
 DESCRIPTION
 ===========
 
-``flux_shell_log()`` logs a message at ``level`` to all loggers registered
-to receive messages at that severity or greater. See ``flux_log`` for a
-list of supported levels. The following macros handle common levels.
+``flux_shell_log()`` logs a message at for shell component or plugin
+``component`` at ``level`` to all loggers registered to receive messages
+at that severity or greater. See ``flux_log`` for a list of supported levels.
+
+
+The following macros handle common levels. For external shell plugins,
+the required macro ``FLUX_SHELL_PLUGIN_NAME`` is automatically substituted
+for the ``component`` in all macros.
+
 
 ::
 

--- a/src/shell/affinity.c
+++ b/src/shell/affinity.c
@@ -10,6 +10,8 @@
 
 /* builtin cpu-affinity processing
  */
+#define FLUX_SHELL_PLUGIN_NAME "cpu-affinity"
+
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -314,7 +316,7 @@ static int affinity_init (flux_plugin_t *p,
 }
 
 struct shell_builtin builtin_affinity = {
-    .name = "affinity",
+    .name = FLUX_SHELL_PLUGIN_NAME,
     .init = affinity_init,
 };
 

--- a/src/shell/batch.c
+++ b/src/shell/batch.c
@@ -10,6 +10,8 @@
 
 /* batch script handler
  */
+#define FLUX_SHELL_PLUGIN_NAME "batch"
+
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -216,7 +218,7 @@ static int batch_init (flux_plugin_t *p,
 }
 
 struct shell_builtin builtin_batch = {
-    .name = "batch",
+    .name = FLUX_SHELL_PLUGIN_NAME,
     .init = batch_init,
 };
 

--- a/src/shell/builtins.c
+++ b/src/shell/builtins.c
@@ -9,6 +9,7 @@
 \************************************************************/
 
 /* job shell builtin plugin loader */
+#define FLUX_SHELL_PLUGIN_NAME NULL
 
 #if HAVE_CONFIG_H
 #include "config.h"

--- a/src/shell/doom.c
+++ b/src/shell/doom.c
@@ -24,6 +24,7 @@
  *   Raise the fatal exception immediately if the first task fails,
  *   e.g. calls exit with a nonzero value or is terminated by signal.
  */
+#define FLUX_SHELL_PLUGIN_NAME "doom"
 
 #if HAVE_CONFIG_H
 #include "config.h"
@@ -288,7 +289,7 @@ static int doom_init (flux_plugin_t *p,
 }
 
 struct shell_builtin builtin_doom = {
-    .name = "doom",
+    .name = FLUX_SHELL_PLUGIN_NAME,
     .init = doom_init,
     .task_exit = doom_task_exit,
 };

--- a/src/shell/events.c
+++ b/src/shell/events.c
@@ -11,6 +11,7 @@
 /*  Shell exec.eventlog event emitter
  *  Allows context for shell events to be added from multiple sources.
  */
+#define FLUX_SHELL_PLUGIN_NAME NULL
 
 #if HAVE_CONFIG_H
 #include "config.h"

--- a/src/shell/evlog.c
+++ b/src/shell/evlog.c
@@ -28,6 +28,7 @@
  *   plugins to be set independently of the main shell log
  *   facility level.
  */
+#define FLUX_SHELL_PLUGIN_NAME "evlog"
 
 #if HAVE_CONFIG_H
 #include "config.h"
@@ -213,7 +214,7 @@ err:
 }
 
 struct shell_builtin builtin_log_eventlog = {
-    .name = "evlog",
+    .name = FLUX_SHELL_PLUGIN_NAME,
     .connect = log_eventlog_start,
 };
 

--- a/src/shell/gpubind.c
+++ b/src/shell/gpubind.c
@@ -13,6 +13,7 @@
  * Builtin GPU binding for flux-shell. Spread CUDA_VISIBLE_DEVICES
  *  across tasks depending on number in slot.
  */
+#define FLUX_SHELL_PLUGIN_NAME "gpu-affinity"
 
 #if HAVE_CONFIG_H
 #include "config.h"
@@ -151,7 +152,7 @@ static int gpubind_init (flux_plugin_t *p,
 }
 
 struct shell_builtin builtin_gpubind = {
-    .name = "gpu-affinity",
+    .name = FLUX_SHELL_PLUGIN_NAME,
     .init = gpubind_init
 };
 

--- a/src/shell/info.c
+++ b/src/shell/info.c
@@ -9,6 +9,7 @@
 \************************************************************/
 
 /* job shell info */
+#define FLUX_SHELL_PLUGIN_NAME NULL
 
 #if HAVE_CONFIG_H
 #include "config.h"

--- a/src/shell/input.c
+++ b/src/shell/input.c
@@ -14,6 +14,7 @@
  * stdin from front-end command or file is read for redirected
  * standard input.
  */
+#define FLUX_SHELL_PLUGIN_NAME "input"
 
 #if HAVE_CONFIG_H
 #include "config.h"
@@ -598,7 +599,7 @@ static int shell_input_task_exit (flux_plugin_t *p,
 }
 
 struct shell_builtin builtin_input = {
-    .name = "input",
+    .name = FLUX_SHELL_PLUGIN_NAME,
     .init = shell_input_init,
     .task_init = shell_input_task_init,
     .task_exit = shell_input_task_exit

--- a/src/shell/kill.c
+++ b/src/shell/kill.c
@@ -12,6 +12,7 @@
  *
  * Handle 'shell-<id>.kill' events by forwarding signal to local tasks
  */
+#define FLUX_SHELL_PLUGIN_NAME "kill_event_handler"
 
 #if HAVE_CONFIG_H
 #include "config.h"
@@ -49,7 +50,7 @@ static int kill_event_init (flux_plugin_t *p,
 }
 
 struct shell_builtin builtin_kill = {
-    .name = "kill_event_handler",
+    .name = FLUX_SHELL_PLUGIN_NAME,
     .init = kill_event_init,
 };
 

--- a/src/shell/log.c
+++ b/src/shell/log.c
@@ -20,6 +20,8 @@
  * in the shell at runtime.
  *
  */
+#define FLUX_SHELL_PLUGIN_NAME NULL
+
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif

--- a/src/shell/mpir/mpir.c
+++ b/src/shell/mpir/mpir.c
@@ -11,10 +11,12 @@
 /* MPIR_proctable service for job shell
  *
  */
+#define FLUX_SHELL_PLUGIN_NAME "mpir"
 
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
+
 #include <unistd.h>
 #include <stdio.h>
 #include <string.h>
@@ -386,7 +388,7 @@ static int mpir_service_init (flux_plugin_t *p,
 }
 
 struct shell_builtin builtin_mpir = {
-    .name = "mpir",
+    .name = FLUX_SHELL_PLUGIN_NAME,
     .init = mpir_service_init,
 };
 

--- a/src/shell/mpir/ptrace.c
+++ b/src/shell/mpir/ptrace.c
@@ -18,6 +18,8 @@
  *   3. Add "sync=true" to the emitted `shell.start` event
  *       to indicate all tasks are now stopped in exec().
  */
+#define FLUX_SHELL_PLUGIN_NAME "ptrace"
+
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -140,7 +142,7 @@ static int ptrace_init (flux_plugin_t *p,
 }
 
 struct shell_builtin builtin_ptrace = {
-    .name =      "ptrace",
+    .name =      FLUX_SHELL_PLUGIN_NAME,
     .init =      ptrace_init,
 };
 

--- a/src/shell/output.c
+++ b/src/shell/output.c
@@ -39,6 +39,7 @@
  * - The number of in-flight write requests on each shell is limited to
  *   shell_output_hwm, to avoid matchtag exhaustion, etc. for chatty tasks.
  */
+#define FLUX_SHELL_PLUGIN_NAME "output"
 
 #if HAVE_CONFIG_H
 #include "config.h"
@@ -1151,7 +1152,7 @@ static int shell_output_init (flux_plugin_t *p,
 }
 
 struct shell_builtin builtin_output = {
-    .name = "output",
+    .name = FLUX_SHELL_PLUGIN_NAME,
     .init = shell_output_init,
     .task_init = shell_output_task_init
 };

--- a/src/shell/plugstack.c
+++ b/src/shell/plugstack.c
@@ -7,6 +7,7 @@
  *
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
+#define FLUX_SHELL_PLUGIN_NAME NULL
 
 #if HAVE_CONFIG_H
 #  include "config.h"

--- a/src/shell/plugstack.h
+++ b/src/shell/plugstack.h
@@ -61,10 +61,6 @@ int plugstack_call (struct plugstack *st,
                     const char *name,
                     flux_plugin_arg_t *args);
 
-/*  Return currently active plugin name, or NULL if not in plugstack
- */
-const char * plugstack_current_name (struct plugstack *st);
-
 #endif /* !_SHELL_PLUGSTACK_H */
 
 /* vi: ts=4 sw=4 expandtab

--- a/src/shell/pmi/pmi.c
+++ b/src/shell/pmi/pmi.c
@@ -50,6 +50,7 @@
  * - Teardown of the subprocess channel is deferred until task completion,
  *   although client closes its end after PMI_Finalize().
  */
+#define FLUX_SHELL_PLUGIN_NAME "pmi"
 
 #if HAVE_CONFIG_H
 #include "config.h"
@@ -673,7 +674,7 @@ static int shell_pmi_task_init (flux_plugin_t *p,
 }
 
 struct shell_builtin builtin_pmi = {
-    .name = "pmi",
+    .name = FLUX_SHELL_PLUGIN_NAME,
     .init = shell_pmi_init,
     .task_init = shell_pmi_task_init,
 };

--- a/src/shell/pmi/pmi_exchange.c
+++ b/src/shell/pmi/pmi_exchange.c
@@ -27,6 +27,7 @@
  * Nodes that are peers in the ersatz tree may actually be multiple hops
  * apart on the Flux tree based overlay network at the broker level.
  */
+#define FLUX_SHELL_PLUGIN_NAME "pmi"
 
 #if HAVE_CONFIG_H
 #include "config.h"

--- a/src/shell/pty.c
+++ b/src/shell/pty.c
@@ -8,6 +8,8 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#define FLUX_SHELL_PLUGIN_NAME "pty"
+
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -188,7 +190,7 @@ static int pty_task_exit (flux_plugin_t *p,
 }
 
 struct shell_builtin builtin_pty = {
-    .name = "pty",
+    .name = FLUX_SHELL_PLUGIN_NAME,
     .init = pty_init,
     .task_exec = pty_task_exec,
     .task_exit = pty_task_exit,

--- a/src/shell/rc.c
+++ b/src/shell/rc.c
@@ -7,6 +7,7 @@
  *
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
+#define FLUX_SHELL_PLUGIN_NAME NULL
 
 /* Load and run shell rc script
  *
@@ -547,7 +548,7 @@ static int call_shell_log (int level, lua_State *L)
     const char *s = lua_tostring (L, 1);
 
     get_lua_sourceinfo (L, &ar, &file, &line);
-    flux_shell_log (level, file, line, "%s", s);
+    flux_shell_log (NULL, level, file, line, "%s", s);
     return 0;
 }
 
@@ -582,7 +583,7 @@ static int l_shell_die (lua_State *L)
     const char *s = lua_tostring (L, 1);
 
     get_lua_sourceinfo (L, &ar, &file, &line);
-    flux_shell_fatal (file, line, 0, 1, "%s", s);
+    flux_shell_fatal (NULL, file, line, 0, 1, "%s", s);
     return 0;
 }
 

--- a/src/shell/shell.c
+++ b/src/shell/shell.c
@@ -9,6 +9,7 @@
 \************************************************************/
 
 /* job shell mainline */
+#define FLUX_SHELL_PLUGIN_NAME NULL
 
 #if HAVE_CONFIG_H
 #include "config.h"

--- a/src/shell/shell.h
+++ b/src/shell/shell.h
@@ -299,32 +299,47 @@ enum {
     FLUX_SHELL_TRACE  = 7,  /* LOG_DEBUG   */
 };
 
+#ifndef FLUX_SHELL_PLUGIN_NAME
+# error "FLUX_SHELL_PLUGIN_NAME must be defined"
+#endif
+
 #define shell_trace(...) \
-    flux_shell_log (FLUX_SHELL_TRACE, __FILE__, __LINE__, __VA_ARGS__)
+    flux_shell_log (FLUX_SHELL_PLUGIN_NAME, \
+                    FLUX_SHELL_TRACE, __FILE__, __LINE__, __VA_ARGS__)
 
 #define shell_debug(...) \
-    flux_shell_log (FLUX_SHELL_DEBUG, __FILE__, __LINE__, __VA_ARGS__)
+    flux_shell_log (FLUX_SHELL_PLUGIN_NAME, \
+                    FLUX_SHELL_DEBUG, __FILE__, __LINE__, __VA_ARGS__)
 
 #define shell_log(...) \
-    flux_shell_log (FLUX_SHELL_NOTICE, __FILE__, __LINE__, __VA_ARGS__)
+    flux_shell_log (FLUX_SHELL_PLUGIN_NAME, \
+                    FLUX_SHELL_NOTICE, __FILE__, __LINE__, __VA_ARGS__)
 
 #define shell_warn(...) \
-    flux_shell_log (FLUX_SHELL_WARN, __FILE__, __LINE__, __VA_ARGS__)
+    flux_shell_log (FLUX_SHELL_PLUGIN_NAME, \
+                    FLUX_SHELL_WARN, __FILE__, __LINE__, __VA_ARGS__)
 
 #define shell_log_error(...) \
-    flux_shell_log (FLUX_SHELL_ERROR, __FILE__, __LINE__, __VA_ARGS__)
+    flux_shell_log (FLUX_SHELL_PLUGIN_NAME, \
+                    FLUX_SHELL_ERROR, __FILE__, __LINE__, __VA_ARGS__)
 
 #define shell_log_errn(errn, ...) \
-    flux_shell_err (__FILE__, __LINE__, errn, __VA_ARGS__)
+    flux_shell_err (FLUX_SHELL_PLUGIN_NAME, \
+                    __FILE__, __LINE__, errn, __VA_ARGS__)
 
 #define shell_log_errno(...) \
-    flux_shell_err (__FILE__, __LINE__, errno, __VA_ARGS__)
+    flux_shell_err (FLUX_SHELL_PLUGIN_NAME, \
+                    __FILE__, __LINE__, errno, __VA_ARGS__)
 
 #define shell_die(code,...) \
-    flux_shell_fatal (__FILE__, __LINE__, 0, code, __VA_ARGS__)
+    flux_shell_fatal (FLUX_SHELL_PLUGIN_NAME, \
+                      __FILE__, __LINE__, \
+                      0, code, __VA_ARGS__)
 
 #define shell_die_errno(code,...) \
-    flux_shell_fatal (__FILE__, __LINE__, errno, code, __VA_ARGS__)
+    flux_shell_fatal (FLUX_SHELL_PLUGIN_NAME, \
+                      __FILE__, __LINE__, \
+                      errno, code, __VA_ARGS__)
 
 #define shell_set_verbose(n) \
     flux_shell_log_setlevel(FLUX_SHELL_NOTICE+n, NULL)
@@ -334,11 +349,12 @@ enum {
 
 /*  Log a message at level to all registered loggers at level or above
  */
-void flux_shell_log (int level,
+void flux_shell_log (const char *component,
+                     int level,
                      const char *file,
                      int line,
                      const char *fmt, ...)
-                     __attribute__ ((format (printf, 4, 5)));
+                     __attribute__ ((format (printf, 5, 6)));
 
 /*  Log a message at FLUX_SHELL_ERROR level, additionally appending the
  *   result of strerror (errnum) for convenience.
@@ -346,22 +362,24 @@ void flux_shell_log (int level,
  *  Returns -1 with errno = errnum, so that the function can be used as
  *   return flux_shell_err (...);
  */
-int flux_shell_err (const char *file,
+int flux_shell_err (const char *component,
+                    const char *file,
                     int line,
                     int errnum,
                     const char *fmt, ...)
-                    __attribute__ ((format (printf, 4, 5)));
+                    __attribute__ ((format (printf, 5, 6)));
 
 /*  Log a message at FLUX_SHELL_FATAL level and schedule termination of
  *   the job shell. May generate an exception if tasks are already
  *   running. Exits with exit_code.
  */
-void flux_shell_fatal (const char *file,
-                      int line,
-                      int errnum,
-                      int exit_code,
-                      const char *fmt, ...)
-                      __attribute__ ((format (printf, 5, 6)));
+void flux_shell_fatal (const char *component,
+                       const char *file,
+                       int line,
+                       int errnum,
+                       int exit_code,
+                       const char *fmt, ...)
+                       __attribute__ ((format (printf, 6, 7)));
 
 /*  Set default severity of logging destination 'dest' to level.
  *   If dest == NULL then set the internal log dispatch level --

--- a/src/shell/signals.c
+++ b/src/shell/signals.c
@@ -17,6 +17,7 @@
  * SIGTERM - forward
  *
  */
+#define FLUX_SHELL_PLUGIN_NAME "signals"
 
 #if HAVE_CONFIG_H
 #include "config.h"
@@ -65,7 +66,7 @@ static int signals_init (flux_plugin_t *p,
 }
 
 struct shell_builtin builtin_signals = {
-    .name = "sighandler",
+    .name = FLUX_SHELL_PLUGIN_NAME,
     .init = signals_init,
 };
 

--- a/src/shell/svc.c
+++ b/src/shell/svc.c
@@ -25,6 +25,7 @@
  * - Services should not be used until after the shells exit the init barrier,
  *   to ensure service registration has completed.
  */
+#define FLUX_SHELL_PLUGIN_NAME NULL
 
 #if HAVE_CONFIG_H
 #include "config.h"

--- a/src/shell/task.c
+++ b/src/shell/task.c
@@ -32,6 +32,7 @@
  * Each running task adds reactor handlers that are removed on
  * completion.
  */
+#define FLUX_SHELL_PLUGIN_NAME NULL
 
 #if HAVE_CONFIG_H
 #include "config.h"

--- a/src/shell/tmpdir.c
+++ b/src/shell/tmpdir.c
@@ -8,6 +8,8 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#define FLUX_SHELL_PLUGIN_NAME "tmpdir"
+
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -110,7 +112,7 @@ static int tmpdir_init (flux_plugin_t *p,
 }
 
 struct shell_builtin builtin_tmpdir = {
-    .name = "tmpdir",
+    .name = FLUX_SHELL_PLUGIN_NAME,
     .init = tmpdir_init,
 };
 

--- a/t/shell/plugins/conftest.c
+++ b/t/shell/plugins/conftest.c
@@ -7,6 +7,7 @@
  *
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
+#define FLUX_SHELL_PLUGIN_NAME "conftest"
 
 #if HAVE_CONFIG_H
 #include "config.h"

--- a/t/shell/plugins/dummy.c
+++ b/t/shell/plugins/dummy.c
@@ -7,6 +7,7 @@
  *
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
+#define FLUX_SHELL_PLUGIN_NAME "dummy"
 
 #if HAVE_CONFIG_H
 #include "config.h"

--- a/t/shell/plugins/getopt.c
+++ b/t/shell/plugins/getopt.c
@@ -7,6 +7,7 @@
  *
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
+#define FLUX_SHELL_PLUGIN_NAME "getopt"
 
 #if HAVE_CONFIG_H
 #include "config.h"

--- a/t/shell/plugins/invalid-args.c
+++ b/t/shell/plugins/invalid-args.c
@@ -7,6 +7,7 @@
  *
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
+#define FLUX_SHELL_PLUGIN_NAME "invalid-args"
 
 #if HAVE_CONFIG_H
 #include "config.h"

--- a/t/shell/plugins/jobspec-info.c
+++ b/t/shell/plugins/jobspec-info.c
@@ -7,6 +7,7 @@
  *
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
+#define FLUX_SHELL_PLUGIN_NAME "jobspec-info"
 
 #if HAVE_CONFIG_H
 #include "config.h"

--- a/t/shell/plugins/log.c
+++ b/t/shell/plugins/log.c
@@ -7,6 +7,7 @@
  *
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
+#define FLUX_SHELL_PLUGIN_NAME "log"
 
 #if HAVE_CONFIG_H
 #include "config.h"
@@ -85,7 +86,7 @@ static void destructor (void *arg)
 int flux_plugin_init (flux_plugin_t *p)
 {
     plan (NO_PLAN);
-    flux_plugin_set_name (p, "log");
+    flux_plugin_set_name (p, FLUX_SHELL_PLUGIN_NAME);
 
     /*  Set a dummy aux item to force our destructor to be called */
     flux_plugin_aux_set (p, NULL, p, destructor);

--- a/t/shell/plugins/setopt.c
+++ b/t/shell/plugins/setopt.c
@@ -7,6 +7,7 @@
  *
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
+#define FLUX_SHELL_PLUGIN_NAME "setopt"
 
 #if HAVE_CONFIG_H
 #include "config.h"

--- a/t/shell/plugins/test-event.c
+++ b/t/shell/plugins/test-event.c
@@ -7,6 +7,7 @@
  *
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
+#define FLUX_SHELL_PLUGIN_NAME "event-test"
 
 #if HAVE_CONFIG_H
 #include "config.h"
@@ -47,7 +48,7 @@ static int check_event_context (flux_plugin_t *p,
 
 int flux_plugin_init (flux_plugin_t *p)
 {
-    flux_plugin_set_name (p, "event-test");
+    flux_plugin_set_name (p, FLUX_SHELL_PLUGIN_NAME);
     return flux_plugin_add_handler (p,
                                     "shell.init",
                                     check_event_context,


### PR DESCRIPTION
The current mechanism for discovery of shell plugin name in the logging facility only works for plugin code which is directly invoked as a result of a `plugstack_call()`. Shell plugins that log from reactor-based callbacks, therefore, do not currently have a "component" name set on their log messages, which makes output confusing and will thwart future efforts to filter log messages on component name.

Drop the "current stack" of plugins and `plugstack_get_current()` functionality which provided the current plugin and instead add a `const char *component` argument to all logging functions. To avoid changing all logging call sites, set the component to a new _required_ define `FLUX_SHELL_PLUGIN_NAME` in all the convenience macros `shell_log()` `shell_debug()` etc.

To ensure out-of-tree plugins define `FLUX_SHELL_PLUGIN_NAME`, error out in `shell.h` if this preprocessor macro is not defined.

Unfortunately this breaks the shell plugin ABI and API. We could have defined new alternate shell logging functions, but since we're still early in the game, I decided to keep things simple and just tolerate the breakage this time.

I will submit PRs to all current out-of-tree shell plugins - currently in flux-sched, flux-coral2, and mpibind. (I think flux-pmix will already be handled)

Meanwhile, someone ensure I'm not going off the deep end here and stop me if so.