### PR TITLE
resource: fail get-xml request on quorum subset

### DIFF
--- a/t/t3301-system-latestart.t
+++ b/t/t3301-system-latestart.t
@@ -17,6 +17,10 @@ test_under_flux 2 system
 
 startctl="flux python ${SHARNESS_TEST_SRCDIR}/scripts/startctl.py"
 
+get_hwloc () {
+        flux python -c "import flux; print(flux.Flux().rpc(\"resource.get-xml\",nodeid=$1).get_str())"
+}
+
 test_expect_success 'broker.quorum was set to 0 by system test personality' '
 	echo 0 >quorum.exp &&
 	flux getattr broker.quorum >quorum.out &&
@@ -53,6 +57,12 @@ test_expect_success 'single node job can run with only rank 0 up' '
 
 test_expect_success 'two node job is accepted although it cannot run yet' '
 	flux mini submit -N2 -n2 echo Hello >jobid
+'
+
+# bug 3884
+test_expect_success 'resource.get-xml RPC fails with reasonable error' '
+	test_must_fail get_hwloc 0 2>get_hwloc.err &&
+	grep "may block forever" get_hwloc.err
 '
 
 test_expect_success 'start rank 1' '


### PR DESCRIPTION
Problem: if R is missing augmented graph information, fluxion
might block forever on resource.get-xml request for resource
discovery results.

Resource discovery is the natural fallback if resources not
not configured.  But fluxion cannot tell the difference between
R that lacks configured JGF augmentation because it was misconfigured,
and R allocated by a scheduler that doesn't support it.

If discovered hwloc results are not immediately available at the time
of the request, fail the request if the broker.quorum attribute is
less than the full instance, as this indicates that the instance
should begin operation with some ranks offline, and R should contain
all needed information.

Tack a test onto t3301-system-latestart.t

Fixes #3884.