### PR TITLE
job-manager: small fixes for the alloc-bypass plugin

### DIFF
--- a/src/modules/job-manager/plugins/alloc-bypass.c
+++ b/src/modules/job-manager/plugins/alloc-bypass.c
@@ -88,6 +88,7 @@ static int alloc_start (flux_plugin_t *p,
                         flux_jobid_t id,
                         const char *R)
 {
+    int saved_errno;
     flux_future_t *f = NULL;
     flux_jobid_t *idptr = NULL;
 
@@ -102,8 +103,10 @@ static int alloc_start (flux_plugin_t *p,
     *idptr = id;
     return 0;
 error:
+    saved_errno = errno;
     flux_future_destroy (f);
     free (idptr);
+    errno = saved_errno;
     return -1;
 }
 
@@ -227,11 +230,12 @@ static int validate_cb (flux_plugin_t *p,
                                     "alloc-bypass::R",
                                     s,
                                     free) < 0) {
+        int saved_errno = errno;
         free (s);
         return flux_jobtap_reject_job (p,
                                        args,
                                        "failed to capture alloc-bypass R: %s",
-                                       strerror (errno));
+                                       strerror (saved_errno));
     }
     return 0;
 }

--- a/src/modules/job-manager/plugins/alloc-bypass.c
+++ b/src/modules/job-manager/plugins/alloc-bypass.c
@@ -142,11 +142,13 @@ static int sched_cb (flux_plugin_t *p,
 
     if (flux_jobtap_job_set_flag (p,
                                   FLUX_JOBTAP_CURRENT_JOB,
-                                  "alloc-bypass") < 0)
-        return flux_jobtap_raise_exception (p, FLUX_JOBTAP_CURRENT_JOB,
-                                            "alloc", 0,
-                                            "Failed to set alloc-bypass: %s",
-                                            strerror (errno));
+                                  "alloc-bypass") < 0) {
+        flux_jobtap_raise_exception (p, FLUX_JOBTAP_CURRENT_JOB,
+                                     "alloc", 0,
+                                     "Failed to set alloc-bypass: %s",
+                                     strerror (errno));
+        return -1;
+    }
     return 0;
 }
 

--- a/src/modules/job-manager/plugins/alloc-bypass.c
+++ b/src/modules/job-manager/plugins/alloc-bypass.c
@@ -40,12 +40,14 @@ static void alloc_continuation (flux_future_t *f, void *arg)
                                      *idptr,
                                      "alloc",
                                      "{s:b}",
-                                     "bypass", true) < 0)
+                                     "bypass", true) < 0) {
         flux_jobtap_raise_exception (p,
                                      *idptr,
                                      "alloc", 0,
                                      "failed to post alloc event: %s",
                                      strerror (errno));
+        goto done;
+    }
 
     /*  Set "needs-free" so that alloc-bypass knows that a "free"
      *   event needs to be emitted for this node.


### PR DESCRIPTION
Some small mistakes were found in the `alloc-bypass` plugin during a review of flux-framework/flux-k8s#14.

Since early on it may be common practice to start from one of the existing jobtap plugins by copying an example, we should fix the issues discovered so they aren't copied again. This work was done quickly so an extra set of eyes will be valued.

Additionally during that review it was discovered that the Python tests have no coverage of `flux_respond_error()` (which would also be a good example usage for someone to copy), so that is tacked on here even though it is not relevant.