### PR TITLE
shell: avoid dropping stderr after a PMI abort

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -135,6 +135,7 @@ MAN3_FILES_SECONDARY = \
 	man3/flux_shell_setopt_pack.3 \
 	man3/flux_shell_err.3 \
 	man3/flux_shell_fatal.3 \
+	man3/flux_shell_raise.3 \
 	man3/flux_shell_log_setlevel.3 \
 	man3/flux_shell_task_info_unpack.3 \
 	man3/flux_shell_task_cmd.3 \

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -315,6 +315,7 @@ man_pages = [
     ('man3/flux_shell_killall', 'flux_shell_killall', 'Send the specified signal to all processes in the shell', [author], 3),
     ('man3/flux_shell_log', 'flux_shell_err', 'Log shell plugin messages to registered shell loggers', [author], 3),
     ('man3/flux_shell_log', 'flux_shell_fatal', 'Log shell plugin messages to registered shell loggers', [author], 3),
+    ('man3/flux_shell_log', 'flux_shell_raise', 'Log shell plugin messages to registered shell loggers', [author], 3),
     ('man3/flux_shell_log', 'flux_shell_log_setlevel', 'Log shell plugin messages to registered shell loggers', [author], 3),
     ('man3/flux_shell_log', 'flux_shell_log', 'Log shell plugin messages to registered shell loggers', [author], 3),
     ('man3/flux_shell_plugstack_call', 'flux_shell_plugstack_call', 'Calls the function referenced by topic.', [author], 3),

--- a/doc/man3/flux_shell_log.rst
+++ b/doc/man3/flux_shell_log.rst
@@ -38,7 +38,12 @@ SYNOPSIS
                           int exit_code,
                           const char *fmt,
                           ...)
+::
 
+   void flux_shell_raise (const char *type,
+                          int severity,
+                          const char *fmt,
+                          ...)
 ::
 
    int flux_shell_log_setlevel (int level,
@@ -106,6 +111,10 @@ note that the choices of ``errnum`` are either 0 or ``errno``.
 ::
 
    #define shell_die_errno(code,...) \
+
+``flux_shell_raise()`` explicitly raises an exception for the current
+job of the given ``type`` and ``severity``. Exceptions of severity 0
+will result in termination of the job by the execution system.
 
 ``flux_shell_log_setlevel()`` sets default severity of logging
 destination ``dest`` to ``level``. If ``dest`` is NULL then the internal

--- a/src/shell/pmi/pmi.c
+++ b/src/shell/pmi/pmi.c
@@ -86,11 +86,14 @@ static void shell_pmi_abort (void *arg,
                              int exit_code,
                              const char *msg)
 {
-    /* Generate job exception (exit_code ignored for now) */
-    shell_die (exit_code,
-               "MPI_Abort%s%s",
-               msg ? ": " : "",
-               msg ? msg : "");
+    /*  Attempt to raise job exception and return to the shell's reactor.
+     *   This allows the shell to continue to process events and stdio
+     *   until the exec system terminates the job due to the exception.
+     */
+    flux_shell_raise ("exec", 0,
+                      "MPI_Abort%s%s",
+                      msg ? ": " : "",
+                      msg ? msg : "");
 }
 
 static int put_dict (json_t *dict, const char *key, const char *val)

--- a/src/shell/shell.h
+++ b/src/shell/shell.h
@@ -381,6 +381,8 @@ void flux_shell_fatal (const char *component,
                        const char *fmt, ...)
                        __attribute__ ((format (printf, 6, 7)));
 
+void flux_shell_raise (const char *type, int severity, const char *fmt, ...);
+
 /*  Set default severity of logging destination 'dest' to level.
  *   If dest == NULL then set the internal log dispatch level --
  *   (i.e. no messages above severity level will be logged to any

--- a/t/mpi/abort.c
+++ b/t/mpi/abort.c
@@ -12,6 +12,7 @@
 #include "config.h"
 #endif
 #include <stdlib.h>
+#include <stdio.h>
 #include <mpi.h>
 
 int main (int argc, char *argv[])
@@ -26,8 +27,12 @@ int main (int argc, char *argv[])
     MPI_Comm_rank (MPI_COMM_WORLD, &id);
     MPI_Comm_size (MPI_COMM_WORLD, &ntasks);
 
-    if (id == abort_rank)
+    printf ("Hello World from rank %d\n", id);
+
+    if (id == abort_rank) {
+        fprintf (stderr, "Rank %d is going to MPI_Abort now\n", id);
         MPI_Abort (MPI_COMM_WORLD, 42);
+    }
     MPI_Barrier (MPI_COMM_WORLD);
 
     MPI_Finalize ();

--- a/t/t3003-mpi-abort.t
+++ b/t/t3003-mpi-abort.t
@@ -38,7 +38,7 @@ SIZE=2
 MAX_MPI_SIZE=$(($SIZE*$TEST_UNDER_FLUX_CORES_PER_RANK))
 test_under_flux $SIZE job
 
-OPTS="-ocpu-affinity=off -oexit-on-error"
+OPTS="-ocpu-affinity=off"
 
 diag() {
 	echo "test failed: cat $1"

--- a/t/t3003-mpi-abort.t
+++ b/t/t3003-mpi-abort.t
@@ -64,14 +64,18 @@ test_expect_success 'MPI_Abort size=1 with PMI server tracing enabled' '
 test_expect_success "MPI_Abort on size=${MAX_MPI_SIZE}, first rank triggers exception" '
 	! run_timeout 60 flux mini run -n${MAX_MPI_SIZE} $OPTS \
 		${FLUX_BUILD_DIR}/t/mpi/abort 0 2>abort0.err &&
-	(grep exception abort0.err || diag abort0.err)
+	(grep exception abort0.err || diag abort0.err) &&
+	test_debug "cat abort0.err" &&
+	grep "Rank 0 is going to MPI_Abort now" abort0.err
 '
 
 test_expect_success "MPI_Abort on size=${MAX_MPI_SIZE}, last rank triggers exception" '
+	rank=$(($MAX_MPI_SIZE-1)) &&
 	! run_timeout 60 flux mini run -n${MAX_MPI_SIZE} $OPTS \
-		${FLUX_BUILD_DIR}/t/mpi/abort $(($MAX_MPI_SIZE-1)) \
+		${FLUX_BUILD_DIR}/t/mpi/abort $rank \
 		2>abort1.err &&
-	(grep exception abort1.err || diag abort1.err)
+	(grep exception abort1.err || diag abort1.err) &&
+	grep "Rank $rank is going to MPI_Abort now" abort1.err
 '
 
 test_done


### PR DESCRIPTION
The `shell_die ()` call currently used in the job shell's PMI abort handler causes the shell to exit immediately without any ability to process pending events or I/O in the reactor. This results in the loss of stdout/err which might occur around the time of the abort.

This PR introduces a new shell API call: `flux_shell_raise(3)` which allows a shell plugin to easily raise a job exception, and replaces the `shell_die()` call with `flux_shell_raise(3)` in the PMI plugin's abort handler. This allows the shell to reenter the reactor after the exception is raised. The exec system will then terminate the job due to the exception.

A similar test to the reproducer from #3894 is also added to the testsuite.

This changes the overall wait or finish status for the job, since there is currently no way to propagate the MPI_Abort requested exit code down through the exec system at this time. A separate issue will be created to track that.

The new `flux_shell_raise(3)` function does a synchronous get to ensure the exception was successfully created before moving on, because this is what `shell_die(3)` did. If this is a problem in other contexts, maybe the function should get a flag to run in synchronous mode, or fire-and-forget mode (as @garlick was currently doing in the pmix implementation)

Finally, the shell `doom` plugin has a similar issue (calls `shell_die()` from the `exit-on-error` handler), so there is a potential for output loss there as well. I decided not to address that here, and wait for a solution to the global exit code problem, since that plugin also expects to be able to set the exit code for the shell.