### PR TITLE
mergify: replace strict merge with queue+rebase

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,5 +1,5 @@
-pull_request_rules:
-  - name: rebase and merge when passing all checks
+queue_rules:
+  - name: default
     conditions:
       - base=master
       - status-success="validate commits"
@@ -25,11 +25,22 @@ pull_request_rules:
       - "#approved-reviews-by>0"
       - "#changes-requested-reviews-by=0"
       - -title~=^\[*[Ww][Ii][Pp]
+
+pull_request_rules:
+  - name: rebase and merge when passing all checks
+    conditions:
+      - base=master
+      - label="merge-when-passing"
+      - label!="work-in-progress"
+      - -title~=^\[*[Ww][Ii][Pp]
+      - "approved-reviews-by=@flux-framework/core"
+      - "#approved-reviews-by>0"
+      - "#changes-requested-reviews-by=0"
     actions:
-      merge:
-        method: merge
-        strict: smart
-        strict_method: rebase
+      queue:
+        name: default
+        method: rebase
+        update_method: rebase
   - name: remove outdated approved reviews
     conditions:
       - author!=@core


### PR DESCRIPTION
Problem: Mergify.io has deprecated the strict merge mode action:

 https://blog.mergify.io/strict-mode-deprecation/

Replace the strict mode configuration with a default queue with a
rebase action which should be equivalent.

I think the way the `queue` action works is that once the conditions in the `pull_request_rules` are met, then the PR is moved into the `default` queue which then tests then merges with the specified action (`rebase`). The `queue` ensures that the first PR entering the queue is the first to be merged.

Since we're using the `rebase` action, hopefully this will be no different than the previous mergify operation.