### PR TITLE
mergify: set queue method to merge, not rebase

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -39,7 +39,7 @@ pull_request_rules:
     actions:
       queue:
         name: default
-        method: rebase
+        method: merge
         update_method: rebase
   - name: remove outdated approved reviews
     conditions:


### PR DESCRIPTION
Problem: The current mergify config specifies that PRs are merged
using a rebase method and not merge. This would result in the PR branch
being rebased onto the main branch instead of creating a merge commit,
which we use to generate release notes. Luckily, flux-core branch
protection rules prevent the rebase from being completed by mergify.

Change the queue action for PRs to be merge, with an update_method of
rebase, which should be similar to the previous 'strict' mode flux-core
was using earlier.