### PR TITLE
man: Add note about shell quoting/escaping

### DIFF
--- a/doc/man1/flux-jobs.rst
+++ b/doc/man1/flux-jobs.rst
@@ -144,6 +144,10 @@ substitutions for *annotations.sched* and *annotations.user*.  For
 example, a reason pending status can be retrieved via
 "{sched.reason_pending}".
 
+As a reminder to the reader, some shells may interpret special
+characters in Python's string format syntax.  The format may need to
+be quoted or escaped to work under certain shells.
+
 The field names that can be specified are:
 
 **id**


### PR DESCRIPTION
Add note to flux-jobs(1) that some shells may interpret the special
characters in Python's string format syntax.  Inform users that they may
need to quote or escape characters depending on the shell.

(This is per an offline discussion in slack, pretty minor, perhaps language could be tweaked.)