### PR TITLE
job-manager: add prolog/epilog support for jobtap plugins

### DIFF
--- a/src/modules/job-exec/job-exec.c
+++ b/src/modules/job-exec/job-exec.c
@@ -440,7 +440,7 @@ void jobinfo_log_output (struct jobinfo *job,
                                  "rank", buf,
                                  "data", data, len) < 0)
         flux_log_error (job->h,
-                        "evenlog_append failed: %ju: message=%s",
+                        "eventlog_append failed: %ju: message=%s",
                         (uintmax_t) job->id,
                         data);
 }

--- a/src/modules/job-manager/job.h
+++ b/src/modules/job-manager/job.h
@@ -41,6 +41,8 @@ struct job {
     uint8_t has_resources:1;
     uint8_t start_pending:1;// start request sent to job-exec
 
+    uint8_t perilog_active; // if nonzero, prolog/epilog active
+
     json_t *annotations;
 
     struct grudgeset *dependencies;

--- a/src/modules/job-manager/jobtap.c
+++ b/src/modules/job-manager/jobtap.c
@@ -1898,6 +1898,124 @@ int flux_jobtap_job_event_posted (flux_plugin_t *p,
     return 0;
 }
 
+static int jobtap_emit_perilog_event (struct jobtap *jobtap,
+                                      struct job *job,
+                                      bool prolog,
+                                      bool start,
+                                      const char *description,
+                                      int status)
+{
+    int flags = 0;
+    const char *event = prolog ? start ? "prolog-start" : "prolog-finish" :
+                                 start ? "epilog-start" : "epilog-finish";
+
+    if (!description) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    /*  prolog events cannot be emitted after a start request is pending.
+     *
+     *  epilog events cannot be emitted outside of CLEANUP state
+     *   and must be emitted before free request is pending.
+     */
+    if ((prolog && job->start_pending)
+        || (prolog && job->state == FLUX_JOB_STATE_CLEANUP)
+        || (!prolog && job->state != FLUX_JOB_STATE_CLEANUP)
+        || (!prolog && job->free_pending)) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (start)
+        return event_job_post_pack (jobtap->ctx->event,
+                                    job,
+                                    event,
+                                    flags,
+                                    "{s:s}",
+                                    "description", description);
+    else
+        return event_job_post_pack (jobtap->ctx->event,
+                                    job,
+                                    event,
+                                    flags,
+                                    "{s:s s:i}",
+                                    "description", description,
+                                    "status", status);
+}
+
+int flux_jobtap_prolog_start (flux_plugin_t *p, const char *description)
+{
+    struct job * job;
+    struct jobtap *jobtap;
+
+    if (!p
+        || !(jobtap = flux_plugin_aux_get (p, "flux::jobtap"))
+        || !(job = current_job (jobtap))) {
+        errno = EINVAL;
+        return -1;
+    }
+    return jobtap_emit_perilog_event (jobtap, job, true, true, description, 0);
+}
+
+int flux_jobtap_prolog_finish (flux_plugin_t *p,
+                               flux_jobid_t id,
+                               const char *description,
+                               int status)
+{
+    struct job * job;
+    struct jobtap *jobtap;
+
+    if (!p || !(jobtap = flux_plugin_aux_get (p, "flux::jobtap"))) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (!(job = jobtap_lookup_jobid (p, id)))
+        return -1;
+    return jobtap_emit_perilog_event (jobtap,
+                                      job,
+                                      true,
+                                      false,
+                                      description,
+                                      status);
+}
+
+int flux_jobtap_epilog_start (flux_plugin_t *p, const char *description)
+{
+    struct job * job;
+    struct jobtap *jobtap;
+
+    if (!p
+        || !(jobtap = flux_plugin_aux_get (p, "flux::jobtap"))
+        || !(job = current_job (jobtap))) {
+        errno = EINVAL;
+        return -1;
+    }
+    return jobtap_emit_perilog_event (jobtap, job, false, true, description, 0);
+}
+
+int flux_jobtap_epilog_finish (flux_plugin_t *p,
+                               flux_jobid_t id,
+                               const char *description,
+                               int status)
+{
+    struct job * job;
+    struct jobtap *jobtap;
+
+    if (!p || !(jobtap = flux_plugin_aux_get (p, "flux::jobtap"))) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (!(job = jobtap_lookup_jobid (p, id)))
+        return -1;
+    return jobtap_emit_perilog_event (jobtap,
+                                      job,
+                                      false,
+                                      false,
+                                      description,
+                                      status);
+}
+
+
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab
  */

--- a/src/modules/job-manager/jobtap.h
+++ b/src/modules/job-manager/jobtap.h
@@ -194,6 +194,38 @@ int flux_jobtap_job_subscribe (flux_plugin_t *p, flux_jobid_t id);
  */
 void flux_jobtap_job_unsubscribe (flux_plugin_t *p, flux_jobid_t id);
 
+
+/*  Post an event to the current job eventlog indicating that a prolog
+ *   action has started. This will block the start request to the
+ *   execution system until `flux_jobtap_prolog_finish()` is called.
+ */
+int flux_jobtap_prolog_start (flux_plugin_t *p, const char *description);
+
+/*  Post an event to the eventlog for job id indicating that a prolog
+ *   action has finished. The description should match the description
+ *   of an outstanding prolog start event. `status` is informational
+ *   and should be 0 to indicate success, non-zero for failure.
+ */
+int flux_jobtap_prolog_finish (flux_plugin_t *p,
+                               flux_jobid_t id,
+                               const char *description,
+                               int status);
+
+/*  Post an event to the current job eventlog indicating that an epilog
+ *   action has started. This will block the free request to the
+ *   scheduler until `flux_jobtap_epilog_finish()` is called.
+ */
+int flux_jobtap_epilog_start (flux_plugin_t *p, const char *description);
+
+/*  Post an event to the eventlog for job id indicating that an epilog
+ *   action has finished. The description should match the description
+ *   of an outstanding epilog start event. `status` is informational
+ *   and should be 0 to indicate success, non-zero for failure.
+ */
+int flux_jobtap_epilog_finish (flux_plugin_t *p,
+                               flux_jobid_t id,
+                               const char *description,
+                               int status);
 #ifdef __cplusplus
 }
 #endif

--- a/src/shell/evlog.c
+++ b/src/shell/evlog.c
@@ -175,7 +175,7 @@ static int evlog_shell_exit (flux_plugin_t *p,
     return 0;
 }
 
-/*  Start the evenlog-based logger during shell.connect, just after the
+/*  Start the eventlog-based logger during shell.connect, just after the
  *   shell has obtained a flux_t handle. This allows more early log
  *   messages to make it into the eventlog, but some data (such as
  *   the current shell_rank) is not available at this time.

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -377,6 +377,7 @@ check_LTLIBRARIES = \
 	job-manager/plugins/dependency-test.la \
 	job-manager/plugins/subscribe.la \
 	job-manager/plugins/cleanup-event.la \
+	job-manager/plugins/perilog-test.la \
 	stats/stats-basic.la \
 	stats/stats-immediate.la
 
@@ -787,6 +788,15 @@ job_manager_plugins_cleanup_event_la_CPPFLAGS = \
 job_manager_plugins_cleanup_event_la_LDFLAGS = \
 	$(fluxplugin_ldflags) -module -rpath /nowhere
 job_manager_plugins_cleanup_event_la_LIBADD = \
+	$(top_builddir)/src/common/libflux-core.la
+
+job_manager_plugins_perilog_test_la_SOURCES = \
+	job-manager/plugins/perilog-test.c
+job_manager_plugins_perilog_test_la_CPPFLAGS = \
+	$(test_cppflags)
+job_manager_plugins_perilog_test_la_LDFLAGS = \
+	$(fluxplugin_ldflags) -module -rpath /nowhere
+job_manager_plugins_perilog_test_la_LIBADD = \
 	$(top_builddir)/src/common/libflux-core.la
 
 hwloc_hwloc_convert_SOURCES = hwloc/hwloc-convert.c

--- a/t/job-manager/plugins/jobtap_api.c
+++ b/t/job-manager/plugins/jobtap_api.c
@@ -13,6 +13,180 @@
 #include <flux/core.h>
 #include <flux/jobtap.h>
 
+static int test_prolog_start_finish (flux_plugin_t *p,
+                                     const char *topic,
+                                     flux_plugin_arg_t *args)
+{
+    errno = 0;
+    if (flux_jobtap_prolog_start (NULL, NULL) == 0
+        || errno != EINVAL)
+        flux_jobtap_raise_exception (p, FLUX_JOBTAP_CURRENT_JOB,
+                                     "test", 0,
+                                     "%s: %s: errno=%d != %d",
+                                     topic,
+                                     "flux_jobtap_prolog_start (NULL NULL)",
+                                     errno,
+                                     EINVAL);
+    errno = 0;
+    if (flux_jobtap_prolog_start (p, NULL) == 0
+        || errno != EINVAL)
+        flux_jobtap_raise_exception (p, FLUX_JOBTAP_CURRENT_JOB,
+                                     "test", 0,
+                                     "%s: %s: errno=%d != %d",
+                                     topic,
+                                     "flux_jobtap_prolog_start (p, NULL)",
+                                     errno,
+                                     EINVAL);
+
+    errno = 0;
+    if (strcmp (topic, "job.state.cleanup") == 0) {
+        if (flux_jobtap_prolog_start (p, "test") == 0
+            || errno != EINVAL)
+            flux_jobtap_raise_exception (p, FLUX_JOBTAP_CURRENT_JOB,
+                                         "test", 0,
+                                         "%s: %s: errno=%d != %d",
+                                         topic,
+                                         "flux_jobtap_prolog_start ",
+                                         "after start request should fail",
+                                         errno,
+                                         EINVAL);
+
+
+    }
+    errno = 0;
+    if (flux_jobtap_prolog_finish (NULL, FLUX_JOBTAP_CURRENT_JOB, NULL, 0) == 0
+        || errno != EINVAL)
+        flux_jobtap_raise_exception (p, FLUX_JOBTAP_CURRENT_JOB,
+                                     "test", 0,
+                                     "%s: %s: errno=%d != %d",
+                                     topic,
+                                     "flux_jobtap_prolog_finish (NULL, ...)",
+                                     errno,
+                                     EINVAL);
+    errno = 0;
+    if (flux_jobtap_prolog_finish (p, FLUX_JOBTAP_CURRENT_JOB, NULL, 0) == 0
+        || errno != EINVAL)
+        flux_jobtap_raise_exception (p, FLUX_JOBTAP_CURRENT_JOB,
+                                     "test", 0,
+                                     "%s: %s: errno=%d != %d",
+                                     topic,
+                                     "flux_jobtap_prolog_finish (p, NULL...)",
+                                     errno,
+                                     EINVAL);
+    errno = 0;
+    if (flux_jobtap_prolog_finish (NULL, FLUX_JOBTAP_CURRENT_JOB, NULL, 0) == 0
+        || errno != EINVAL)
+        flux_jobtap_raise_exception (p, FLUX_JOBTAP_CURRENT_JOB,
+                                     "test", 0,
+                                     "%s: %s: errno=%d != %d",
+                                     topic,
+                                     "flux_jobtap_prolog_finish (p, 1)",
+                                     errno,
+                                     EINVAL);
+    errno = 0;
+    if (flux_jobtap_prolog_finish (p, 1, "test", 0) == 0
+        || errno != ENOENT)
+        flux_jobtap_raise_exception (p, FLUX_JOBTAP_CURRENT_JOB,
+                                     "test", 0,
+                                     "%s: %s (%s): errno=%d != %d",
+                                     topic,
+                                     "flux_jobtap_prolog_finish",
+                                     "p, 1, \"test\", 0",
+                                     errno,
+                                     EINVAL);
+
+
+    return 0;
+}
+
+
+static int test_epilog_start_finish (flux_plugin_t *p,
+                                     const char *topic,
+                                     flux_plugin_arg_t *args)
+{
+    errno = 0;
+    if (flux_jobtap_epilog_start (NULL, NULL) == 0
+        || errno != EINVAL)
+        flux_jobtap_raise_exception (p, FLUX_JOBTAP_CURRENT_JOB,
+                                     "test", 0,
+                                     "%s: %s: errno=%d != %d",
+                                     topic,
+                                     "flux_jobtap_epilog_start (NULL NULL)",
+                                     errno,
+                                     EINVAL);
+    errno = 0;
+    if (flux_jobtap_epilog_start (p, NULL) == 0
+        || errno != EINVAL)
+        flux_jobtap_raise_exception (p, FLUX_JOBTAP_CURRENT_JOB,
+                                     "test", 0,
+                                     "%s: %s: errno=%d != %d",
+                                     topic,
+                                     "flux_jobtap_epilog_start (p, NULL)",
+                                     errno,
+                                     EINVAL);
+
+    errno = 0;
+    if (strcmp (topic, "job.state.run") == 0) {
+        if (flux_jobtap_epilog_start (p, "test") == 0
+            || errno != EINVAL)
+            flux_jobtap_raise_exception (p, FLUX_JOBTAP_CURRENT_JOB,
+                                         "test", 0,
+                                         "%s: %s: errno=%d != %d",
+                                         topic,
+                                         "flux_jobtap_epilog_start ",
+                                         "after start request should fail",
+                                         errno,
+                                         EINVAL);
+
+
+    }
+    errno = 0;
+    if (flux_jobtap_epilog_finish (NULL, FLUX_JOBTAP_CURRENT_JOB, NULL, 0) == 0
+        || errno != EINVAL)
+        flux_jobtap_raise_exception (p, FLUX_JOBTAP_CURRENT_JOB,
+                                     "test", 0,
+                                     "%s: %s: errno=%d != %d",
+                                     topic,
+                                     "flux_jobtap_epilog_finish (NULL, ...)",
+                                     errno,
+                                     EINVAL);
+    errno = 0;
+    if (flux_jobtap_epilog_finish (p, FLUX_JOBTAP_CURRENT_JOB, NULL, 0) == 0
+        || errno != EINVAL)
+        flux_jobtap_raise_exception (p, FLUX_JOBTAP_CURRENT_JOB,
+                                     "test", 0,
+                                     "%s: %s: errno=%d != %d",
+                                     topic,
+                                     "flux_jobtap_epilog_finish (p, NULL...)",
+                                     errno,
+                                     EINVAL);
+    errno = 0;
+    if (flux_jobtap_epilog_finish (NULL, FLUX_JOBTAP_CURRENT_JOB, NULL, 0) == 0
+        || errno != EINVAL)
+        flux_jobtap_raise_exception (p, FLUX_JOBTAP_CURRENT_JOB,
+                                     "test", 0,
+                                     "%s: %s: errno=%d != %d",
+                                     topic,
+                                     "flux_jobtap_epilog_finish (p, 1)",
+                                     errno,
+                                     EINVAL);
+    errno = 0;
+    if (flux_jobtap_epilog_finish (p, 1, "test", 0) == 0
+        || errno != ENOENT)
+        flux_jobtap_raise_exception (p, FLUX_JOBTAP_CURRENT_JOB,
+                                     "test", 0,
+                                     "%s: %s (%s): errno=%d != %d",
+                                     topic,
+                                     "flux_jobtap_epilog_finish",
+                                     "p, 1, \"test\", 0",
+                                     errno,
+                                     EINVAL);
+
+
+    return 0;
+}
+
+
 static int test_event_post_pack (flux_plugin_t *p,
                                  const char *topic,
                                  flux_plugin_arg_t *args)
@@ -332,6 +506,8 @@ static int cleanup_cb (flux_plugin_t *p,
                        void *arg)
 {
     test_event_post_pack (p, topic, args);
+    test_prolog_start_finish (p, topic, args);
+    test_epilog_start_finish (p, topic, args);
     return test_job_result (p, topic, args);
 }
 
@@ -357,6 +533,8 @@ static int run_cb (flux_plugin_t *p,
                                            EINVAL,
                                            errno);
     test_event_post_pack (p, topic, args);
+    test_prolog_start_finish (p, topic, args);
+    test_epilog_start_finish (p, topic, args);
     return 0;
 }
 

--- a/t/job-manager/plugins/perilog-test.c
+++ b/t/job-manager/plugins/perilog-test.c
@@ -1,0 +1,142 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* perilog-test.c - basic tests for job manager prolog/epilog
+ */
+
+#include <errno.h>
+#include <string.h>
+#include <jansson.h>
+
+#include <flux/core.h>
+#include <flux/jobtap.h>
+
+struct perilog_data {
+    flux_plugin_t *p;
+    flux_jobid_t id;
+    char *name;
+    bool prolog;
+    int status;
+};
+
+static struct perilog_data *
+perilog_data_create (flux_plugin_t *p,
+                     flux_jobid_t id,
+                     bool prolog,
+                     const char *name,
+                     int status)
+{
+    struct perilog_data *d = malloc (sizeof (*d));
+    if (!d)
+        return NULL;
+    if (!(d->name = strdup (name))) {
+        free (d);
+        return NULL;
+    }
+    d->p = p;
+    d->id = id;
+    d->prolog = prolog;
+    d->status = status;
+    return d;
+}
+
+static void perilog_data_destroy (struct perilog_data *d)
+{
+    if (d) {
+        free (d->name);
+        free (d);
+    }
+}
+
+static void timer_cb (flux_reactor_t *r,
+                      flux_watcher_t *w,
+                      int revents, void *arg)
+{
+    struct perilog_data *d = arg;
+    if (d->prolog) {
+        if (flux_jobtap_prolog_finish (d->p, d->id, d->name, d->status) < 0)
+            flux_jobtap_raise_exception (d->p, FLUX_JOBTAP_CURRENT_JOB,
+                                        "test", 0,
+                                        "flux_jobtap_prolog_finish: %s",
+                                        strerror (errno));
+    }
+    else {
+        if (flux_jobtap_epilog_finish (d->p, d->id, d->name, d->status) < 0)
+            flux_jobtap_raise_exception (d->p, FLUX_JOBTAP_CURRENT_JOB,
+                                        "test", 0,
+                                        "flux_jobtap_epilog_finish: %s",
+                                        strerror (errno));
+    }
+    flux_watcher_destroy (w);
+    perilog_data_destroy (d);
+}
+
+static int cb (flux_plugin_t *p,
+               const char *topic,
+               flux_plugin_arg_t *args,
+               void *arg)
+{
+    flux_t *h = flux_jobtap_get_flux (p);
+    flux_watcher_t *tw;
+    flux_jobid_t id;
+    struct perilog_data *d;
+    int rc;
+    int prolog = strcmp (topic, "job.state.run") == 0;
+
+    if (flux_plugin_arg_unpack (args,
+                                FLUX_PLUGIN_ARG_IN,
+                                "{s:I}",
+                                "id", &id) < 0) {
+        flux_log_error (h, "flux_plugin_arg_unpack");
+        return -1;
+    }
+
+    if (!(d = perilog_data_create (p, id, prolog, "test", 0))) {
+        flux_log_error (h, "perilog_data_create");
+        return -1;
+    }
+
+    tw = flux_timer_watcher_create (flux_get_reactor (h),
+                                    0.1,
+                                    0.0,
+                                    timer_cb,
+                                    d);
+    if (tw == NULL) {
+        flux_log_error (h, "timer_watcher_create");
+        return -1;
+    }
+
+    flux_watcher_start (tw);
+    if (prolog)
+        rc = flux_jobtap_prolog_start (p, "test");
+    else
+        rc = flux_jobtap_epilog_start (p, "test");
+    if (rc < 0) {
+        flux_jobtap_raise_exception (p, FLUX_JOBTAP_CURRENT_JOB,
+                                     "test", 0,
+                                     "flux_jobtap_%s_start failed: %s",
+                                     prolog ? "prolog" : "epilog",
+                                     strerror (errno));
+    }
+    return 0;
+}
+
+static const struct flux_plugin_handler tab[] = {
+    { "job.state.run",     cb, NULL },
+    { "job.state.cleanup", cb, NULL },
+    { 0 },
+};
+
+int flux_plugin_init (flux_plugin_t *p)
+{
+    if (flux_plugin_register (p, "perilog-test", tab) < 0)
+        return -1;
+    return 0;
+}

--- a/t/t2212-job-manager-plugins.t
+++ b/t/t2212-job-manager-plugins.t
@@ -380,4 +380,16 @@ test_expect_success 'job-manager: job.state.depend is called on plugin load' '
 	flux python dep-remove.py ${jobid} &&
 	flux job wait-event -vt 15 ${jobid} clean
 '
+test_expect_success 'job-manager: job prolog/epilog events work' '
+	flux jobtap load --remove=all ${PLUGINPATH}/perilog-test.so &&
+	jobid=$(flux mini submit hostname) &&
+	flux job attach -vE $jobid 2>&1 | tee perilog-test.out &&
+	n_prolog=$(grep -n job.prolog-finish perilog-test.out | cut -d: -f1) &&
+	n_start=$(grep -n job.start perilog-test.out | cut -d: -f1) &&
+	n_epilog=$(grep -n job.epilog-finish perilog-test.out | cut -d: -f1) &&
+	n_free=$(grep -n job.free perilog-test.out | cut -d: -f1) &&
+	test_debug "echo Checking that prolog-finish=$n_prolog event occurs before start=$n_start event" &&
+	test_debug "echo Checking that epilog-finish=$n_epilog event occurs before free=$n_free event" &&
+	test $n_prolog -lt $n_start -a $n_epilog -lt $n_free
+'
 test_done


### PR DESCRIPTION
This PR adds support for `prolog-*` and `epilog-*` events for jobs and the corresponding jobtap interface functions `flux_jobtap_prolog_start()`, `flux_jobtap_prolog_finish()`, `flux_jobtap_epilog_start()` and `flux_jobtap_epilog_finish()`.

If a plugin needs to perform some asynchronous actions after a job has been allocated resources, but before the `start` request is sent to the execution system, then it can use the `prolog` events, and if a plugin needs to perform similar actions after all job shells have finished, but before resources are returned to the scheduler, then it can use the `epilog` events.

@jameshcorbett, I think you had a use case for the `prolog-start`, `prolog-finish` events. If so, can you give this PR a quick review to ensure it meets your requirements?