### PR TITLE
broker: ignore missing ldconfig when searching for libpmi.so

### DIFF
--- a/src/broker/liblist.c
+++ b/src/broker/liblist.c
@@ -76,8 +76,10 @@ static void trim_end (char *s, int ch)
 static int liblist_append_from_ldconfig (zlist_t *libs, const char *libname)
 {
     FILE *f;
-    const char *cmd = "ldconfig -p | sed -e 's/([^(]*)[\t ]*//'" \
-                      "            | awk -F\" => \" '{print $1 \":\" $2};'";
+    const char *cmd = "ldconfig=$(command -v ldconfig)" \
+                      " && $ldconfig -p" \
+                      "  | sed -e 's/([^(]*)[\t ]*//'" \
+                      "  | awk -F\" => \" '{print $1 \":\" $2};'";
     char line[1024];
     int rc = -1;
 


### PR DESCRIPTION
Problem: Some installations of flux-core do not have ldconfig(1)
present in PATH, and this results in a senseless warning

  sh: ldconfig: command not found

Adjust the shell command used with popen(3) to first check for ldconfig
in PATH before trying to run it, thus silently ignoring the missing
command.
