### PR TITLE
broker: fail gracefully when rundir or local-uri exceed AF_UNIX path limits

### DIFF
--- a/doc/man7/flux-broker-attributes.rst
+++ b/doc/man7/flux-broker-attributes.rst
@@ -23,11 +23,14 @@ size
    The number of broker ranks in the flux instance
 
 rundir
-   A temporary directory available for scratch storage within the session.
-   By default, a temporary directory is created for each broker rank, but
-   if rundir is set on the command line, this directory may be shared by
-   all broker ranks running on the same node.  If rundir is created by the
-   broker, it is removed during session exit.
+   A temporary directory where UNIX domain sockets and the default
+   content.backing-path are located (see below).  By default, each broker
+   rank creates a unique rundir in $TMPDIR and removes it on exit.  If
+   rundir is set on the command line, beware exceeding the UNIX domain socket
+   path limit described in unix(7), as low as 92 bytes on some systems.
+   If rundir is set to a pre-existing directory, the directory is not removed
+   on exit;  if the broker has to create the directory, it is removed.
+   In most cases this attribute should not be set by users.
 
 content.backing-path
    The path to the content backing store file(s). If this is set on the

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -722,13 +722,6 @@ static int checkdir (const char *name, const char *path)
 
 
 /*  Handle global rundir attribute.
- *
- *  If not set, create a temporary directory and use it as the rundir.
- *  If set, attempt to create it if it doesn't exist. In either case,
- *  validate directory persmissions and set the rundir attribute
- *  immutable. If the rundir is created by this function it will be
- *  scheduled for later cleanup at broker exit. Pre-existing directories
- *  are left intact.
  */
 static int create_rundir (attr_t *attrs)
 {

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -769,6 +769,19 @@ static int create_rundir (attr_t *attrs)
     if (checkdir ("rundir", run_dir) < 0)
         goto done;
 
+    /*  Ensure that AF_UNIX sockets can be created in rundir - see #3925.
+     */
+    struct sockaddr_un sa;
+    size_t path_limit = sizeof (sa.sun_path) - sizeof ("/local-9999");
+    size_t path_length = strlen (run_dir);
+    if (path_length > path_limit) {
+        log_msg ("rundir length of %zu bytes exceeds max %zu"
+                 " to allow for AF_UNIX socket creation.",
+                 path_length,
+                 path_limit);
+        goto done;
+    }
+
     /*  rundir is now fixed, so make the attribute immutable, and
      *   schedule the dir for cleanup at exit if we created it here.
      */
@@ -819,6 +832,18 @@ static int init_local_uri_attr (struct overlay *ov, attr_t *attrs)
         }
         if (checkdir ("local-uri directory", dirname (path)) < 0)
             return -1;
+
+        /* see #3925 */
+        struct sockaddr_un sa;
+        size_t path_limit = sizeof (sa.sun_path) - 1;
+        size_t path_length = strlen (uri + 8);
+        if (path_length > path_limit) {
+            log_msg ("local-uri length of %zu bytes exceeds max %zu"
+                     " AF_UNIX socket path length",
+                     path_length,
+                     path_limit);
+            return -1;
+        }
     }
     return 0;
 }

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -569,6 +569,25 @@ test_expect_success 'passing NULL to flux_log functions logs to stderr (#1191)' 
         grep "err: world: No such file or directory" std.err
 '
 
+# tests for issue #3925
+test_expect_success 'setting rundir to a long directory fails (#3925)' '
+	longdir=rundir-01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789 &&
+	mkdir -p $longdir &&
+	test_must_fail flux start ${ARGS} \
+		-o,-Srundir=$longdir \
+		/bin/true 2>longrun.err &&
+	grep "exceeds max" longrun.err
+'
+
+test_expect_success 'setting local-uri to a long path fails (#3925)' '
+	longdir=rundir-01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789 &&
+	mkdir -p $longdir &&
+	test_must_fail flux start ${ARGS} \
+		-o,-Slocal-uri=local://$longdir/local-0 \
+		/bin/true 2>longuri.err &&
+	grep "exceeds max" longuri.err
+'
+
 reactorcat=${SHARNESS_TEST_DIRECTORY}/reactor/reactorcat
 test_expect_success 'reactor: reactorcat example program works' '
 	dd if=/dev/urandom bs=1024 count=4 >reactorcat.in &&

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -362,8 +362,9 @@ test_expect_success 'rundir override works' '
 	test -d $RUNDIR &&
 	rm -rf $RUNDIR
 '
-test_expect_success 'rundir override creates nonexistent dirs' '
-	RUNDIR="$(pwd)/rundir" &&
+test_expect_success 'rundir override creates nonexistent dirs and cleans up' '
+	RUNDIR=`mktemp -d` &&
+	rmdir $RUNDIR &&
 	flux start ${ARGS} -o,--setattr=rundir=$RUNDIR sh -c "test -d $RUNDIR" &&
 	test_expect_code 1 test -d $RUNDIR
 '
@@ -396,7 +397,12 @@ test_expect_success 'broker broker.pid attribute is readable' '
 	test "$BROKERPID" -eq "$BROKERPID"
 '
 test_expect_success 'local-uri override works' '
-	flux start ${ARGS} -o,-Slocal-uri=local://$(pwd)/meep printenv FLUX_URI
+	newsock=local:///tmp/meep &&
+	echo $newsock >uri.exp &&
+	flux start ${ARGS} \
+		-o,-Slocal-uri=$newsock \
+		printenv FLUX_URI >uri.out &&
+	test_cmp uri.exp uri.out
 '
 test_expect_success 'broker fails gracefully when local-uri is malformed' '
 	test_must_fail flux start ${ARGS} -o,-Slocal-uri=baduri \


### PR DESCRIPTION
Problem: if `local-uri` or TBON unix domain sockets exceed the max allowed path length, the instance fails with obscure errors.  This may occur if
- TMPDIR is set to a long path name
- rundir is set on the command line with -Srundir=path
- local-uri is set on the command line with -Slocal-uri=uri

Add some checks to catch this early and print reasonable errors.  Also update flux-broker-attributes(7) to discourage the use of `rundir` and warn about the AF_UNIX path limit, which is quite small and may surprise some.