### PR TITLE
support job prolog/epilog commands

### DIFF
--- a/doc/man1/flux-exec.rst
+++ b/doc/man1/flux-exec.rst
@@ -62,6 +62,9 @@ OPTIONS
 **-v, --verbose**
    Run with more verbosity.
 
+**-q, --quiet**
+   Suppress extraneous output (e.g. per-rank error exit status).
+
 
 NODESET FORMAT
 ==============

--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -71,7 +71,8 @@ dist_fluxcmd_SCRIPTS = \
 	flux-admin.py \
 	flux-jobtap.py \
 	flux-job-validator.py \
-	flux-job-exec-override.py
+	flux-job-exec-override.py \
+	flux-perilog-run.py
 
 fluxcmd_PROGRAMS = \
 	flux-terminus \

--- a/src/cmd/flux-exec.c
+++ b/src/cmd/flux-exec.c
@@ -41,6 +41,8 @@ static struct optparse_option cmdopts[] = {
       .usage = "Redirect stdin from /dev/null" },
     { .name = "verbose", .key = 'v', .has_arg = 0,
       .usage = "Run with more verbosity." },
+    { .name = "quiet", .key = 'q', .has_arg = 0,
+      .usage = "Suppress extraneous output." },
     OPTPARSE_TABLE_END
 };
 
@@ -456,7 +458,7 @@ int main (int argc, char *argv[])
                  monotime_since (t0), exited, exit_code);
 
     /* output message on any tasks that exited non-zero */
-    if (zhashx_size (exitsets) > 0) {
+    if (!optparse_hasopt (opts, "quiet") && zhashx_size (exitsets) > 0) {
         struct id_set *idset = zhashx_first (exitsets);
         while (idset) {
             const char *key = zhashx_cursor (exitsets);

--- a/src/cmd/flux-perilog-run.py
+++ b/src/cmd/flux-perilog-run.py
@@ -1,0 +1,228 @@
+##############################################################
+# Copyright 2021 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+##############################################################
+
+import os
+import sys
+import subprocess
+import argparse
+import logging
+import signal
+from pathlib import Path
+
+import flux
+from flux.resource import ResourceSet
+from flux.idset import IDset
+from flux.job import JobID
+
+
+def fetch_job_ranks(handle, jobid):
+    """Fetch job ranks from KVS for jobid"""
+    try:
+        return IDset(ResourceSet(flux.kvs.get(handle, f"{jobid.kvs}.R")).ranks)
+    except FileNotFoundError:
+        LOGGER.error("R not found in kvs for job %s, unable to continue", jobid)
+        return None
+
+
+def drain(handle, ids, reason):
+    """Drain ranks in idset `ids` with reason """
+
+    handle.rpc(
+        "resource.drain",
+        {"targets": str(ids), "reason": reason},
+        nodeid=0,
+    )
+
+
+def unblock_signals():
+    """Unblock signals in children"""
+    signal.pthread_sigmask(signal.SIG_UNBLOCK, {signal.SIGTERM, signal.SIGINT})
+
+
+def process_create(cmd):
+    # pylint: disable=subprocess-popen-preexec-fn
+    return subprocess.Popen(cmd, preexec_fn=unblock_signals)
+
+
+def run_per_rank(name, jobid, args):
+    """Run args.exec_per_rank on every rank of jobid
+
+    If command fails on any rank then drain that rank
+    """
+
+    returncode = 0
+
+    if args.exec_per_rank is None:
+        return 0
+
+    per_rank_cmd = args.exec_per_rank.split(",")
+
+    processes = {}
+    fail_ids = IDset()
+
+    handle = flux.Flux()
+
+    ranks = fetch_job_ranks(handle, jobid)
+    if ranks is None:
+        return 1
+
+    if args.verbose:
+        LOGGER.info(
+            "%s: %s: executing %s on ranks %s", jobid, name, per_rank_cmd, ranks
+        )
+
+    for rank in ranks:
+        cmd = ["flux", "exec", "-qn", f"-r{rank}"] + per_rank_cmd
+        processes[rank] = process_create(cmd)
+
+    for rank in ranks:
+        rc = processes[rank].wait()
+        if rc != 0:
+            fail_ids.set(rank)
+            if rc > returncode:
+                returncode = rc
+
+    if len(fail_ids) > 0:
+        LOGGER.info("%s: %s failed %s, draining", jobid, fail_ids, name)
+        drain(handle, fail_ids, f"{name} failed for jobid {jobid}")
+
+    if args.verbose:
+        ranks.subtract(fail_ids)
+        if len(ranks) > 0:
+            LOGGER.info("%s: %s: completed successfully on %s", jobid, name, ranks)
+
+    return returncode
+
+
+def run_scripts(name, jobid, args):
+    """Run a directory of scripts in parallel"""
+
+    returncode = 0
+    jobid = JobID(os.environ["FLUX_JOB_ID"])
+
+    if args.exec_directory is None:
+        args.exec_directory = f"/etc/flux/system/{name}.d"
+    path = Path(args.exec_directory)
+    if not path.is_dir():
+        return 0
+
+    scripts = [x for x in path.iterdir() if os.access(x, os.X_OK)]
+
+    if args.verbose:
+        LOGGER.info(
+            "%s: %s: running %d scripts from %s",
+            jobid,
+            name,
+            len(scripts),
+            args.exec_directory,
+        )
+    processes = {cmd: process_create([cmd]) for cmd in scripts}
+
+    for cmd in scripts:
+        rc = processes[cmd].wait()
+        if rc != 0:
+            if rc > returncode:
+                returncode = rc
+            LOGGER.error("%s: %s failed with rc=%d", jobid, cmd, rc)
+        elif args.verbose:
+            LOGGER.info("%s: %s completed successfully", jobid, cmd)
+
+    return returncode
+
+
+def run(name, jobid, args):
+    returncode = run_scripts(name, jobid, args)
+    if returncode != 0:
+        sys.exit(returncode)
+
+    if args.exec_per_rank:
+        returncode = run_per_rank(name, jobid, args)
+        if returncode != 0:
+            sys.exit(returncode)
+
+
+def run_prolog(jobid, args):
+    run("prolog", jobid, args)
+
+
+def run_epilog(jobid, args):
+    run("epilog", jobid, args)
+
+
+LOGGER = logging.getLogger("flux-perilog-run")
+
+
+def main():
+
+    signal.pthread_sigmask(signal.SIG_BLOCK, {signal.SIGTERM, signal.SIGINT})
+
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(
+        title="subcommands", description="", dest="subcommand"
+    )
+    subparsers.required = True
+
+    prolog_parser = subparsers.add_parser(
+        "prolog", formatter_class=flux.util.help_formatter()
+    )
+    prolog_parser.add_argument(
+        "-v", "--verbose", help="Log script events", action="store_true"
+    )
+    prolog_parser.add_argument(
+        "-e",
+        "--exec-per-rank",
+        metavar="CMD[,ARGS...]",
+        help="Use flux-exec(1) to run CMD and optional ARGS on each target "
+        + "rank of jobid set in FLUX_JOB_ID environment variable",
+    )
+    prolog_parser.add_argument(
+        "-d",
+        "--exec-directory",
+        metavar="DIRECTORY",
+        help="Run all executables in DIRECTORY (default=/etc/flux/system/prolog.d)",
+    )
+    prolog_parser.set_defaults(func=run_prolog)
+
+    epilog_parser = subparsers.add_parser(
+        "epilog", formatter_class=flux.util.help_formatter()
+    )
+    epilog_parser.add_argument(
+        "-v", "--verbose", help="Log script events", action="store_true"
+    )
+    epilog_parser.add_argument(
+        "-e",
+        "--exec-per-rank",
+        metavar="CMD[,ARGS...]",
+        help="Use flux-exec(1) to run CMD and optional ARGS on each target "
+        + "rank of jobid set in FLUX_JOB_ID environment variable",
+    )
+    epilog_parser.add_argument(
+        "-d",
+        "--exec-directory",
+        metavar="DIRECTORY",
+        help="Run all executables in DIRECTORY (default=/etc/flux/system/epilog.d)",
+    )
+    epilog_parser.set_defaults(func=run_epilog)
+
+    args = parser.parse_args()
+    try:
+        jobid = JobID(os.environ["FLUX_JOB_ID"])
+    except KeyError:
+        LOGGER.error("FLUX_JOB_ID not found in environment")
+        sys.exit(1)
+
+    if args.verbose:
+        logging.basicConfig(level=logging.DEBUG)
+
+    args.func(jobid, args)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/modules/job-manager/Makefile.am
+++ b/src/modules/job-manager/Makefile.am
@@ -20,7 +20,8 @@ noinst_LTLIBRARIES = \
 
 jobtap_plugin_LTLIBRARIES = \
 	plugins/priority-hold.la \
-	plugins/alloc-bypass.la
+	plugins/alloc-bypass.la \
+	plugins/perilog.la
 
 job_manager_la_SOURCES = \
 	job-manager.c \
@@ -97,6 +98,17 @@ plugins_alloc_bypass_la_LIBADD = \
 plugins_alloc_bypass_la_LDFLAGS = \
 	$(fluxplugin_ldflags) \
 	-module
+
+plugins_perilog_la_SOURCES = \
+	plugins/perilog.c
+plugins_perilog_la_LIBADD = \
+	$(top_builddir)/src/common/libflux-internal.la \
+	$(top_builddir)/src/common/librlist/librlist.la \
+	$(top_builddir)/src/common/libjob/libjob.la
+plugins_perilog_la_LDFLAGS = \
+	$(fluxplugin_ldflags) \
+	-module
+
 
 TESTS = \
 	test_job.t \

--- a/src/modules/job-manager/jobtap.c
+++ b/src/modules/job-manager/jobtap.c
@@ -1920,7 +1920,7 @@ static int jobtap_emit_perilog_event (struct jobtap *jobtap,
      *   and must be emitted before free request is pending.
      */
     if ((prolog && job->start_pending)
-        || (prolog && job->state == FLUX_JOB_STATE_CLEANUP)
+        || ((prolog && start) && job->state == FLUX_JOB_STATE_CLEANUP)
         || (!prolog && job->state != FLUX_JOB_STATE_CLEANUP)
         || (!prolog && job->free_pending)) {
         errno = EINVAL;

--- a/src/modules/job-manager/plugins/perilog.c
+++ b/src/modules/job-manager/plugins/perilog.c
@@ -1,0 +1,509 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/*  perilog.c : execute a job manager prolog/epilog for jobs
+ *
+ *  Run prolog and/or epilog commands on rank 0 before jobs
+ *   have been allocated or freed resources.
+ *
+ *  Notes:
+ *
+ *  - The job manager prolog is started at the RUN state.
+ *
+ *  - If a job gets a fatal exception while the prolog is
+ *    running, the prolog is terminated with SIGTERM, followed
+ *    by SIGKILL
+ *
+ *  - The epilog is started as a result of a "finish" event,
+ *    and therefore the job manager epilog is only run if
+ *    job shells are actually started.
+ *
+ *  - Requires that a prolog and/or epilog command be configured
+ *    in the [job-manager.prolog] and [job-manager.epilog]
+ *    tables, e.g.
+ *
+ *     [job-manager.prolog]
+ *     command = [ "command", "arg1", "arg2" ]
+ *
+ *  - The queue should be idle before unloading/reloading this
+ *     plugin. Otherwise jobs may become stuck because a prolog
+ *     or epilog in progress will result in a missing -finish
+ *     event in the job's eventlog.
+ */
+
+#include <limits.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#define EXIT_CODE(x) __W_EXITCODE(x,0)
+
+#include <jansson.h>
+#include <flux/core.h>
+#include <flux/jobtap.h>
+
+#include "src/common/libjob/job_hash.h"
+#include "src/common/libczmqcontainers/czmq_containers.h"
+
+extern char **environ;
+
+/*  Global prolog/epilog configuration
+ */
+static struct perilog_conf {
+    double prolog_kill_timeout;/*  Time between SIGTERM/SIGKILL for prolog  */
+    flux_cmd_t *prolog_cmd;    /*  Configured prolog command                */
+    flux_cmd_t *epilog_cmd;    /*  Configured epilog command                */
+    zhashx_t *processes;       /*  List of outstanding perilog_proc objects */
+} perilog_config;
+
+
+/*  Data for a prolog/epilog process
+ */
+struct perilog_proc {
+    flux_plugin_t *p;
+    flux_jobid_t id;
+    bool prolog;
+    flux_subprocess_t *sp;
+    flux_future_t *kill_f;
+};
+
+static struct perilog_proc * perilog_proc_create (flux_plugin_t *p,
+                                                  flux_jobid_t id,
+                                                  bool prolog,
+                                                  flux_subprocess_t *sp)
+{
+    struct perilog_proc *proc = calloc (1, sizeof (*proc));
+    if (proc == NULL)
+        return NULL;
+    proc->p = p;
+    proc->id = id;
+    proc->prolog = prolog;
+    proc->sp = sp;
+    if (zhashx_insert (perilog_config.processes, &proc->id, proc) < 0) {
+        free (proc);
+        return NULL;
+    }
+    return proc;
+}
+
+static void perilog_proc_destroy (struct perilog_proc *proc)
+{
+    if (proc) {
+        flux_subprocess_destroy (proc->sp);
+        flux_future_destroy (proc->kill_f);
+        free (proc);
+    }
+}
+
+/*  zhashx_destructor_fn prototype
+ */
+static void perilog_proc_destructor (void **item)
+{
+    if (item) {
+        struct perilog_proc *proc = *item;
+        perilog_proc_destroy (proc);
+        *item = NULL;
+    }
+}
+
+/*  delete process from global hash - calls perilog_proc_destructor()
+ */
+static void perilog_proc_delete (struct perilog_proc *proc)
+{
+    if (proc) {
+        zhashx_delete (perilog_config.processes, &proc->id);
+    }
+}
+
+static void emit_finish_event (struct perilog_proc *proc, int status)
+{
+    if (proc->prolog) {
+        /*
+         *  If prolog failed, raise job exception before prolog-finish
+         *   event is emitted to ensure job isn't halfway started before
+         *   the exception is raised:
+         */
+        if (status != 0
+            && flux_jobtap_raise_exception (proc->p,
+                                            proc->id,
+                                            "prolog",
+                                            0,
+                                            "prolog failed with status=%d",
+                                            status) < 0)
+                flux_log_error (flux_jobtap_get_flux (proc->p),
+                                "prolog-finish: flux_jobtap_raise_exception");
+
+        if (flux_jobtap_prolog_finish (proc->p,
+                                       proc->id,
+                                       "job-manager.prolog",
+                                       status) < 0)
+            flux_log_error (flux_jobtap_get_flux (proc->p),
+                            "flux_jobtap_prolog_finish: id=%ju status=%d",
+                            proc->id,
+                            status);
+    }
+    else {
+        /*
+         *  Epilog complete: unsubscribe this plugin from the
+         *   finished job and post an epilog-finish event.
+         *
+         *  No job exception is raised since the job is already exiting,
+         *   and it is expected that the actual epilog script will
+         *   drain nodes or take other action on failure if necessary.
+         */
+        flux_jobtap_job_unsubscribe (proc->p, proc->id);
+        if (flux_jobtap_epilog_finish (proc->p,
+                                       proc->id,
+                                       "job-manager.epilog",
+                                       status) < 0)
+            flux_log_error (flux_jobtap_get_flux (proc->p),
+                            "flux_jobtap_epilog_finish");
+    }
+}
+
+static void completion_cb (flux_subprocess_t *sp)
+{
+    struct perilog_proc *proc = flux_subprocess_aux_get (sp, "perilog_proc");
+    if (proc) {
+        emit_finish_event (proc, flux_subprocess_status (sp));
+        perilog_proc_delete (proc);
+    }
+}
+
+static void state_cb (flux_subprocess_t *sp, flux_subprocess_state_t state)
+{
+    struct perilog_proc *proc;
+
+    if ((state == FLUX_SUBPROCESS_FAILED
+        || state == FLUX_SUBPROCESS_EXEC_FAILED)
+        && (proc = flux_subprocess_aux_get (sp, "perilog_proc"))) {
+
+        /*  If subprocess failed or execution failed, then we still
+         *   must be sure to emit a finish event.
+         */
+        int errnum = flux_subprocess_fail_errno (sp);
+        int code = EXIT_CODE(1);
+
+        if (errnum == EPERM || errnum == EACCES)
+            code = EXIT_CODE(126);
+        else if (errnum == ENOENT)
+            code = EXIT_CODE(127);
+        else if (errnum == EHOSTUNREACH)
+            code = EXIT_CODE(68);
+
+        flux_log (flux_jobtap_get_flux (proc->p),
+                  LOG_ERR,
+                  "%s %s: code=%d",
+                  proc->prolog ? "prolog": "epilog",
+                  flux_subprocess_state_string (flux_subprocess_state (sp)),
+                  code);
+
+        emit_finish_event (proc, code);
+        perilog_proc_delete (proc);
+    }
+}
+
+static void io_cb (flux_subprocess_t *sp, const char *stream)
+{
+    struct perilog_proc *proc = flux_subprocess_aux_get (sp, "perilog_proc");
+    flux_t *h = flux_jobtap_get_flux (proc->p);
+    const char *s;
+    int len;
+
+    if (!(s = flux_subprocess_getline (sp, stream, &len))) {
+        flux_log_error (h, "%ju: %s: %s: flux_subprocess_getline",
+                        (uintmax_t) proc->id,
+                        proc->prolog ? "prolog": "epilog",
+                        stream);
+        return;
+    }
+    if (len) {
+        int level = LOG_INFO;
+        if (strcmp (stream, "stderr") == 0)
+            level = LOG_ERR;
+        flux_log (h,
+                  level,
+                  "%ju: %s: %s: %s",
+                  (uintmax_t) proc->id,
+                  proc->prolog ? "prolog" : "epilog",
+                  stream,
+                  s);
+    }
+}
+
+static int run_command (flux_plugin_t *p,
+                        flux_plugin_arg_t *args,
+                        int prolog,
+                        flux_cmd_t *cmd)
+{
+    flux_t *h = flux_jobtap_get_flux (p);
+    struct perilog_proc *proc;
+    flux_jobid_t id;
+    uint32_t userid;
+    flux_subprocess_t *sp = NULL;
+    flux_subprocess_ops_t ops = {
+        .on_completion = completion_cb,
+        .on_state_change = state_cb,
+        .on_stdout = io_cb,
+        .on_stderr = io_cb
+    };
+    char path[PATH_MAX + 1];
+    char jobid[128];
+
+    if (flux_plugin_arg_unpack (args,
+                                FLUX_PLUGIN_ARG_IN,
+                                "{s:I s:i}",
+                                "id", &id,
+                                "userid", &userid) < 0) {
+        flux_log_error (h, "flux_plugin_arg_unpack");
+        return -1;
+    }
+
+    if (flux_job_id_encode (id, "f58", jobid, sizeof (jobid)) < 0) {
+        flux_log_error (h, "flux_job_id_encode");
+        return -1;
+    }
+
+    if (flux_cmd_setcwd (cmd, getcwd (path, sizeof (path))) < 0
+        || flux_cmd_setenvf (cmd, 1, "FLUX_JOB_ID", "%s", jobid) < 0
+        || flux_cmd_setenvf (cmd, 1, "FLUX_JOB_USERID", "%u", userid) < 0) {
+        flux_log_error (h, "%s: flux_cmd_create", prolog ? "prolog" : "epilog");
+        return -1;
+    }
+
+    if (!(sp = flux_rexec (h, 0, 0, cmd, &ops))) {
+        flux_log_error (h, "%s: flux_rexec", prolog ? "prolog" : "epilog");
+        return -1;
+    }
+
+    if (!(proc = perilog_proc_create (p, id, prolog, sp))) {
+        flux_log_error (h, "%s: proc_create", prolog ? "prolog" : "epilog");
+        flux_subprocess_destroy (sp);
+        return -1;
+    }
+
+    if (flux_subprocess_aux_set (sp, "perilog_proc", proc, NULL) < 0) {
+        flux_log_error (h, "%s: flux_subprocess_aux_set",
+                        prolog ? "prolog" : "epilog");
+        return -1;
+    }
+
+    if (flux_jobtap_job_aux_set (p,
+                                 FLUX_JOBTAP_CURRENT_JOB,
+                                 "perilog_proc",
+                                 proc,
+                                 NULL) < 0) {
+        flux_log_error (h, "%s: flux_jobtap_job_aux_set",
+                        prolog ? "prolog" : "epilog");
+        return -1;
+    }
+
+    if (prolog) {
+        if (flux_jobtap_job_subscribe (p, FLUX_JOBTAP_CURRENT_JOB) < 0)
+            flux_log_error (h, "prolog: flux_jobtap_job_subscribe");
+    }
+
+    return 0;
+}
+
+static int run_cb (flux_plugin_t *p,
+                   const char *topic,
+                   flux_plugin_arg_t *args,
+                   void *arg)
+{
+    if (perilog_config.prolog_cmd == NULL)
+        return 0;
+
+    if (run_command (p, args, 1, perilog_config.prolog_cmd) < 0) {
+        flux_jobtap_raise_exception (p,
+                                     FLUX_JOBTAP_CURRENT_JOB,
+                                     "prolog",
+                                     0,
+                                     "failed to start job prolog");
+        return -1;
+    }
+    return flux_jobtap_prolog_start (p, "job-manager.prolog");
+}
+
+static int job_finish_cb (flux_plugin_t *p,
+                          const char *topic,
+                          flux_plugin_arg_t *args,
+                          void *arg)
+{
+    if (perilog_config.epilog_cmd == NULL)
+        return 0;
+
+    if (run_command (p, args, 0, perilog_config.epilog_cmd) < 0) {
+        flux_jobtap_raise_exception (p,
+                                     FLUX_JOBTAP_CURRENT_JOB,
+                                     "epilog",
+                                     0,
+                                     "failed to start job epilog");
+        return -1;
+    }
+    return flux_jobtap_epilog_start (p, "job-manager.epilog");
+}
+
+static void prolog_kill_cb (flux_future_t *f, void *arg)
+{
+    struct perilog_proc *proc = arg;
+    flux_t *h = flux_future_get_flux (f);
+
+    if (flux_future_get (f, NULL) < 0) {
+        if (errno == ETIMEDOUT) {
+            flux_future_t *fkill;
+            if (!(fkill = flux_subprocess_kill (proc->sp, SIGKILL)))
+                flux_log_error (h,
+                                "failed to send SIGKILL to prolog for %ju",
+                                (uintmax_t) proc->id);
+            /* Do not wait for error response */
+            flux_future_destroy (fkill);
+            return;
+        }
+        flux_log_error (h, "prolog_kill");
+    }
+    /*
+     *  N.B.: We use flux_future_reset() on fulfilled future so that the
+     *  next fulfillment will be the timeout set by the original call to
+     *  flux_future_then() below. If the process is destroyed before the
+     *  timer expires, then the future will also be destroyed so the
+     *  timeout above won't occur.
+     */
+    flux_future_reset (f);
+}
+
+
+static int prolog_kill (struct perilog_proc *proc)
+{
+    flux_t *h = flux_jobtap_get_flux (proc->p);
+
+    if (!(proc->kill_f = flux_subprocess_kill (proc->sp, SIGTERM)))
+        return -1;
+
+    if (flux_future_then (proc->kill_f,
+                          perilog_config.prolog_kill_timeout,
+                          prolog_kill_cb, proc) < 0) {
+        flux_log_error (h, "prolog_kill: flux_future_then");
+        flux_future_destroy (proc->kill_f);
+        proc->kill_f = NULL;
+        return -1;
+    }
+
+    return 0;
+}
+
+static int exception_cb (flux_plugin_t *p,
+                         const char *topic,
+                         flux_plugin_arg_t *args,
+                         void *arg)
+{
+    /*  On exception, kill any prolog running for this job:
+     *   Follow up with SIGKILL after 10s.
+     */
+    struct perilog_proc *proc;
+    if ((proc = flux_jobtap_job_aux_get (p,
+                                        FLUX_JOBTAP_CURRENT_JOB,
+                                        "perilog_proc"))
+        && flux_subprocess_state (proc->sp) == FLUX_SUBPROCESS_RUNNING)
+        return prolog_kill (proc);
+    return 0;
+}
+
+static flux_cmd_t *cmd_from_json (json_t *o)
+{
+    size_t index;
+    json_t *value;
+    flux_cmd_t *cmd;
+
+    if (!json_is_array (o))
+        return NULL;
+
+    if (!(cmd = flux_cmd_create (0, NULL, environ)))
+        return NULL;
+
+    json_array_foreach (o, index, value) {
+        const char *arg = json_string_value (value);
+        if (!value
+            || flux_cmd_argv_append (cmd, arg) < 0)
+            goto fail;
+    }
+    return cmd;
+fail:
+    flux_cmd_destroy (cmd);
+    return NULL;
+}
+
+/*  Parse [job-manager.prolog] and [job-manager.epilog] config
+ */
+static int conf_init (flux_t *h, struct perilog_conf *conf)
+{
+    flux_conf_error_t error;
+    json_t *prolog = NULL;
+    json_t *epilog = NULL;
+
+    memset (conf, 0, sizeof (*conf));
+    conf->prolog_kill_timeout = 5.;
+    if (!(conf->processes = job_hash_create ()))
+        return -1;
+    zhashx_set_destructor (conf->processes,
+                           perilog_proc_destructor);
+
+    if (flux_conf_unpack (flux_get_conf (h),
+                          &error,
+                          "{s?:{s?:{s?o s?F !} s?:{s?o !}}}",
+                          "job-manager",
+                          "prolog",
+                            "command", &prolog,
+                            "kill-timeout", &conf->prolog_kill_timeout,
+                          "epilog",
+                            "command", &epilog) < 0) {
+        flux_log (h, LOG_ERR,
+                  "prolog/epilog configuration error: %s",
+                  error.errbuf);
+        return -1;
+    }
+    if (prolog &&
+        !(conf->prolog_cmd = cmd_from_json (prolog))) {
+        flux_log (h, LOG_ERR, "[job-manager.prolog] command malformed!");
+        return -1;
+    }
+    if (epilog &&
+        !(conf->epilog_cmd = cmd_from_json (epilog))) {
+        flux_log (h, LOG_ERR, "[job-manager.epilog] command malformed!");
+        return -1;
+    }
+    return 0;
+}
+
+static void free_config (struct perilog_conf *conf)
+{
+    flux_cmd_destroy (conf->prolog_cmd);
+    flux_cmd_destroy (conf->epilog_cmd);
+    zhashx_destroy (&conf->processes);
+}
+
+static const struct flux_plugin_handler tab[] = {
+    { "job.state.run",       run_cb,       NULL },
+    { "job.event.finish",    job_finish_cb,NULL },
+    { "job.event.exception", exception_cb, NULL },
+    { 0 }
+};
+
+int flux_plugin_init (flux_plugin_t *p)
+{
+    if (conf_init (flux_jobtap_get_flux (p), &perilog_config) < 0
+        || flux_plugin_aux_set (p,
+                                NULL,
+                                &perilog_config,
+                                (flux_free_f) free_config) < 0) {
+        free_config (&perilog_config);
+        return -1;
+    }
+    return flux_plugin_register (p, "perilog", tab);
+}

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -134,6 +134,7 @@ TESTSCRIPTS = \
 	t2271-job-dependency-after.t \
 	t2272-job-begin-time.t \
 	t2273-job-alloc-bypass.t \
+	t2274-manager-perilog.t \
 	t2300-sched-simple.t \
 	t2302-sched-simple-up-down.t \
 	t2310-resource-module.t \

--- a/t/sharness.d/flux-sharness.sh
+++ b/t/sharness.d/flux-sharness.sh
@@ -137,7 +137,7 @@ remove_trashdir_wrapper() {
 #
 #  Reinvoke a test file under a flux instance
 #
-#  Usage: test_under_flux <size> [personality]
+#  Usage: test_under_flux <size> [personality] [flux-start-options]
 #
 #  where personality is one of:
 #
@@ -180,6 +180,13 @@ remove_trashdir_wrapper() {
 test_under_flux() {
     size=${1:-1}
     personality=${2:-full}
+
+    #  Note: args > 2 are passed along as extra arguments
+    #   to flux-start below using "$@", so shift up to the
+    #   the first two arguments away:
+    #
+    test $# -eq 1 && shift || shift 2
+
     log_file="$TEST_NAME.broker.log"
     if test -n "$TEST_UNDER_FLUX_ACTIVE" ; then
         if test "$TEST_UNDER_FLUX_PERSONALITY" = "system"; then
@@ -254,6 +261,7 @@ test_under_flux() {
                       ${sysopts} \
                       ${logopts} \
                       ${valgrind} \
+                      "$@" \
                      "sh $0 ${flags}"
 }
 

--- a/t/t2274-manager-perilog.t
+++ b/t/t2274-manager-perilog.t
@@ -1,0 +1,190 @@
+#!/bin/sh
+
+test_description='Test prolog/epilog jobtap functionality'
+
+. $(dirname $0)/sharness.sh
+
+mkdir config
+cat <<EOF >config/perilog.toml
+[job-manager.prolog]
+command = [
+  "flux", "perilog-run", "prolog", "-d", "$(pwd)/prolog.d"
+]
+[job-manager.epilog]
+command = [
+  "flux", "perilog-run", "epilog", "-d", "$(pwd)/epilog.d"
+]
+EOF
+
+test_under_flux 4 full -o,--config-path=$(pwd)/config
+
+flux setattr log-stderr-level 1
+
+# In case the testsuite is running as a Flux job
+unset FLUX_JOB_ID
+
+drained_ranks() { flux resource status -no {ranks} -s drain; }
+
+no_drained_ranks() { test "$(drained_ranks)" = ""; }
+
+undrain_all() {
+	ranks="$(drained_ranks)"
+	if test -n "$ranks"; then
+	    flux resource undrain $ranks
+	fi
+}
+
+test_expect_success 'perilog: setup rundirs' '
+	mkdir prolog.d epilog.d &&
+	for f in prolog epilog prolog.2 epilog.2; do
+		cat <<-EOF >${f%.*}.d/${f}.sh
+		#!/bin/sh
+		echo in ${f}
+		EOF
+	done &&
+	chmod +x prolog.d/*.sh epilog.d/*.sh
+'
+test_expect_success 'perilog: perilog-run fails without FLUX_JOB_ID' '
+	test_expect_code 1 flux perilog-run prolog
+'
+test_expect_success 'perilog: perilog-run script works' '
+	FLUX_JOB_ID=f1 flux perilog-run prolog -v -d prolog.d > prolog.output &&
+	FLUX_JOB_ID=f1 flux perilog-run epilog -v -d epilog.d > epilog.output &&
+	grep "in prolog" prolog.output &&
+	grep "in epilog" epilog.output &&
+	grep "in prolog.2" prolog.output &&
+	grep "in epilog.2" epilog.output
+'
+test_expect_success 'perilog: perilog-run fails if any local script fails' '
+	printf "#!/bin/sh\nexit 12" >prolog.d/fail.sh &&
+	chmod +x prolog.d/fail.sh &&
+	( export FLUX_JOB_ID=f1 &&
+	  test_expect_code 12 \
+	    flux perilog-run prolog -v -d prolog.d 
+	) &&
+	rm -f prolog.d/fail.sh
+'
+test_expect_success 'perilog: perilog-run --exec-per-rank works' '
+	jobid=$(flux mini submit -n4 -N4 true) &&
+	flux job wait-event $jobid alloc &&
+	FLUX_JOB_ID=${jobid} \
+	  flux perilog-run prolog -veflux,getattr,rank \
+	  >prolog-e.out &&
+	$(no_drained_ranks) &&
+	test_debug "cat prolog-e.out" &&
+	sort prolog-e.out > prolog-e.sorted &&
+	seq 0 3 > prolog-e.expected &&
+	test_cmp prolog-e.expected prolog-e.sorted
+'
+test_expect_success 'perilog: failed ranks are drained with --exec-per-rank' '
+	printf "#!/bin/sh\n! test \$(flux getattr rank) -eq \"\$1\"" \
+	  >fail-on.sh &&
+	chmod +x fail-on.sh &&
+	(export FLUX_JOB_ID=${jobid}  &&
+	 test_expect_code 1 flux perilog-run prolog -ve./fail-on.sh,1
+	) &&
+	test "$(drained_ranks)" = "1" &&
+	undrain_all
+'
+test_expect_success 'perilog: load perilog.so plugin' '
+	flux jobtap load perilog.so
+'
+test_expect_success 'perilog: configured prolog/epilog works for jobs' '
+	undrain_all &&
+	jobid=$(flux mini submit --job-name=works hostname) &&
+	flux job attach -vE $jobid > submit1.log 2>&1 &&
+	test_debug "cat submit1.log" &&
+	grep prolog-start submit1.log &&
+	grep prolog-finish submit1.log &&
+	grep epilog-start submit1.log &&
+	grep epilog-finish submit1.log
+'
+test_expect_success 'perilog: job can be canceled while prolog is running' '
+	printf "#!/bin/sh\nsleep 60" > prolog.d/sleep.sh &&
+	chmod +x prolog.d/sleep.sh &&
+	test_when_finished "rm -f prolog.d/sleep.sh" &&
+	jobid=$(flux mini submit --job-name=cancel hostname) &&
+	flux job wait-event -t 15 $jobid prolog-start &&
+	flux job cancel $jobid &&
+	flux job wait-event -t 15 $jobid prolog-finish &&
+	flux job wait-event -t 15 $jobid exception &&
+	test_must_fail flux job attach -vE $jobid
+'
+test_expect_success HAVE_JQ 'perilog: prolog failure raises job exception' '
+	printf "#!/bin/sh\n/bin/false" > prolog.d/fail.sh &&
+	chmod +x prolog.d/fail.sh &&
+	test_when_finished "rm -f prolog.d/fail.sh" &&
+	jobid=$(flux mini submit --job-name=prolog-failure hostname) &&
+	flux job wait-event -t 15 $jobid prolog-start &&
+	flux job wait-event -m type=prolog -t 15 $jobid exception &&
+	flux job eventlog -f json $jobid | jq -r -S .name \
+	  > fail.events &&
+	test_must_fail grep ^start$ fail.events
+'
+test_expect_success 'perilog: prolog/epilog output is logged' '
+	printf "#!/bin/sh\necho this is the prolog" > prolog.d/log.sh &&
+	chmod +x prolog.d/log.sh &&
+	test_when_finished "rm -f prolog.d/log.sh" &&
+	jobid=$(flux mini submit --job-name=output-test hostname) &&
+	flux job wait-event -t 15 $jobid prolog-finish &&
+	flux dmesg | grep "prolog: stdout: this is the prolog" &&
+	flux job wait-event -vt 15 $jobid clean
+'
+test_expect_success 'perilog: fails if configuration is not valid' '
+	flux jobtap remove perilog.so &&
+	cat <<-EOF >config/perilog.toml &&
+	[job-manager.prolog]
+	command = "flux perilog-run prolog"
+	EOF
+	flux config reload &&
+	test_must_fail flux jobtap load perilog.so &&
+	cat <<-EOF2 >config/perilog.toml &&
+	[job-manager.epilog]
+	command = "flux perilog-run epilog"
+	EOF2
+	flux config reload &&
+	test_must_fail flux jobtap load perilog.so &&
+	cat <<-EOF3 >config/perilog.toml &&
+	[job-manager.epilog]
+	extra = 1
+	command = [ "flux",  "perilog-run",  "epilog" ]
+	EOF3
+	flux config reload &&
+	test_must_fail flux jobtap load perilog.so
+'
+test_expect_success 'perilog: fails if command not found' '
+	cat <<-EOF >config/perilog.toml &&
+	[job-manager.prolog]
+	command = [ "/noexist" ]
+	EOF
+	flux config reload &&
+	flux jobtap load perilog.so &&
+	jobid=$(flux mini submit --job-name=prolog-failure hostname) &&
+	test_must_fail flux job attach -vEX $jobid
+'
+test_expect_success 'perilog: prolog is killed even if it ignores SIGTERM' '
+	cat <<-EOF >trap-sigterm.sh &&
+	#!/bin/sh
+	trap "echo trap-sigterm got SIGTERM" 15
+	flux kvs put trap-ready=1
+	sleep 60 &
+	pid=\$!
+	wait \$pid
+	sleep 60
+	EOF
+	chmod +x trap-sigterm.sh &&
+	cat <<-EOT >config/perilog.toml &&
+	[job-manager.prolog]
+	kill-timeout = 0.5
+	command = [ "$(pwd)/trap-sigterm.sh" ]
+	EOT
+	flux config reload &&
+	flux jobtap load --remove=*.so perilog.so &&
+	jobid=$(flux mini submit --job-name=prolog-sigkill hostname) &&
+	flux job wait-event -t 15 $jobid prolog-start &&
+	flux job cancel $jobid &&
+	flux job wait-event -t 15 -m status=9 $jobid prolog-finish &&
+	test_must_fail flux job attach -vEX $jobid
+'
+
+test_done


### PR DESCRIPTION
This PR is a WIP implementation of a jobtap plugin and a new command which together support running traditional job prolog/epilogs when the plugin is loaded and configured.

Tests still need to be added, but before that I wanted to ensure the general approach is acceptable.

This PR adds a new `perilog.so` plugin (for lack of a better name) which, when loaded and configured, supports running a configurable command on rank 0 as prolog and/or epilog actions. 

The PR also adds a new helper script `flux-perilog-run.py` which when configured as the prolog or epilog command, supports running a set of scripts from a directory (default `/etc/flux/system/prolog.d` and `/etc/flux/system/epilog.d/`) and optionally executing a command across all ranks of the starting/completing job. This last feature is meant as a stopgap until we have true per-rank prolog/epilog supported by the execution system.

The `perilog.so` plugin reads configuration from the `[job-manager.prolog]` and `[job-manager.epilog]` tables, which currently support a `command` key only, e.g. to run the per-rank prolog/epilog for every job the following configuration would work:

```toml
[job-manager.prolog]
command = [ "flux", "perilog-run", "prolog", "-e/usr/libexec/flux/flux-imp,run,prolog" ]
[job-manager.epilog]
command = [ "flux", "perilog-run", "epilog", "-e/usr/libexec/flux/flux-imp,run,epilog" ]
```

Random notes:
- When running with `-e, --exec-per-rank=CMD[,ARGS...]`, the `flux perilog-run` script will automatically drain any ranks on which the prolog/epilog fails with a corresponding reason.
- If a prolog fails, a job exception is raised before the `prolog-finish` event so that the job is not started
- The job epilog is triggered by a `finish` event, not entry to the CLEANUP state. This means the epilog is only run if a job was started (Hm, I'm rethinking this one now)
- The `flux perilog-run` command will probably go away after the job-exec system incorporates its own prolog/epilog support


