### PR TITLE
testsuite: fix non-bourne shell test failure

### DIFF
--- a/t/issues/t3920-running-underflow.sh
+++ b/t/issues/t3920-running-underflow.sh
@@ -4,7 +4,7 @@
 #  does not cause underflow of the running job count.
 #
 export PLUGIN=${FLUX_BUILD_DIR}/t/job-manager/plugins/.libs/cleanup-event.so
-flux start '\
+SHELL=/bin/sh flux start '\
    flux jobtap load $PLUGIN \
 && flux queue stop \
 && jobid=$(flux mini submit hostname) \


### PR DESCRIPTION
Problem: The t3920-running-underflow test failed under non
bourne shell shells.

Solution: Set SHELL to /bin/sh in test to ensure proper
execution.

Fixes #3936