### PR TITLE
kvs: optionally initialize namespace to a root reference

### DIFF
--- a/doc/man1/flux-kvs.rst
+++ b/doc/man1/flux-kvs.rst
@@ -171,11 +171,11 @@ COMMANDS
    reads version, sends version to node B. Node B waits for version, gets
    value.
 
-**getroot** [-N ns] [-s \| -o]
+**getroot** [-N ns] [-s \| -o \| -b]
    Retrieve the current KVS root, displaying it as an RFC 11 dirref object.
    Specify an alternate namespace to retrieve from via *-N*. If *-o* is
    specified, display the namespace owner. If *-s* is specified, display
-   the root sequence number.
+   the root sequence number.  If *-b* is specified, display the root blobref.
 
 **eventlog get** [-N ns] [-W] [-w] [-c count] [-u] *key*
    Display the contents of an RFC 18 KVS eventlog referred to by *key*.

--- a/doc/man1/flux-kvs.rst
+++ b/doc/man1/flux-kvs.rst
@@ -48,10 +48,12 @@ arguments are described below.
 COMMANDS
 ========
 
-**namespace create** [-o owner] *name* [*name* ...]
+**namespace create** [-o owner] [-r rootref] *name* [*name* ...]
    Create a new kvs namespace. User may specify an alternate userid of a
    user that owns the namespace via *-o*. Specifying an alternate owner
    would allow a non-instance owner to read/write to a namespace.
+   User may specify an initial root reference for the namespace via
+   *-r*.
 
 **namespace remove** *name* [*name...*]
    Remove a kvs namespace.

--- a/doc/man3/flux_kvs_namespace_create.rst
+++ b/doc/man3/flux_kvs_namespace_create.rst
@@ -19,6 +19,14 @@ SYNOPSIS
 
 ::
 
+   flux_future_t *flux_kvs_namespace_create_with (flux_t *h,
+                                                  const char *namespace,
+                                                  const char *rootref,
+                                                  uint32_t owner,
+                                                  int flags);
+
+::
+
    flux_future_t *flux_kvs_namespace_remove (flux_t *h,
                                              const char *namespace);
 
@@ -31,6 +39,11 @@ namespace, users can get/put KVS values completely independent of
 other KVS namespaces. An owner of the namespace other than the
 instance owner can be chosen by setting *owner*. Otherwise, *owner*
 can be set to FLUX_USERID_UNKNOWN.
+
+``flux_kvs_namespace_create_with()`` is identical to
+``flux_kvs_namespace_create()`` but will initialize the namespace to
+the specified *rootref*.  This may be useful in several circumstances,
+such as initializing a namespace to an earlier checkpoint.
 
 ``flux_kvs_namespace_remove()`` removes a KVS namespace.
 

--- a/src/cmd/flux-kvs.c
+++ b/src/cmd/flux-kvs.c
@@ -205,6 +205,9 @@ static struct optparse_option getroot_opts[] =  {
     { .name = "owner", .key = 'o', .has_arg = 0,
       .usage = "Show owner",
     },
+    { .name = "blobref", .key = 'b', .has_arg = 0,
+      .usage = "Show blobref",
+    },
     OPTPARSE_TABLE_END
 };
 
@@ -355,7 +358,7 @@ static struct optparse_subcommand subcommands[] = {
       namespace_opt
     },
     { "getroot",
-      "[-N ns] [-s|-o]",
+      "[-N ns] [-s|-o|-b]",
       "Get KVS root treeobj",
       cmd_getroot,
       0,
@@ -1740,6 +1743,13 @@ void getroot_continuation (flux_future_t *f, void *arg)
         if (flux_kvs_getroot_get_sequence (f, &sequence) < 0)
             log_err_exit ("flux_kvs_getroot_get_sequence");
         printf ("%d\n", sequence);
+    }
+    else if (optparse_hasopt (p, "blobref")) {
+        const char *blobref;
+
+        if (flux_kvs_getroot_get_blobref (f, &blobref) < 0)
+            log_err_exit ("flux_kvs_getroot_get_blobref");
+        printf ("%s\n", blobref);
     }
     else {
         const char *treeobj;

--- a/src/cmd/flux-kvs.c
+++ b/src/cmd/flux-kvs.c
@@ -550,7 +550,7 @@ static struct optparse_option namespace_create_opts[] =  {
 
 static struct optparse_subcommand namespace_subcommands[] = {
     { "create",
-      "name [name...]",
+      "[-o owner] name [name...]",
       "Create a KVS namespace",
       cmd_namespace_create,
       0,

--- a/src/common/libkvs/kvs.c
+++ b/src/common/libkvs/kvs.c
@@ -65,6 +65,24 @@ cleanup:
     return rv;
 }
 
+flux_future_t *flux_kvs_namespace_create_with (flux_t *h, const char *ns,
+                                               const char *rootref,
+                                               uint32_t owner, int flags)
+{
+    if (!ns || !rootref || flags) {
+        errno = EINVAL;
+        return NULL;
+    }
+
+    /* N.B. owner cast to int */
+    return flux_rpc_pack (h, "kvs.namespace-create", 0, 0,
+                          "{ s:s s:s s:i s:i }",
+                          "namespace", ns,
+                          "rootref", rootref,
+                          "owner", owner,
+                          "flags", flags);
+}
+
 flux_future_t *flux_kvs_namespace_remove (flux_t *h, const char *ns)
 {
     if (!ns) {

--- a/src/common/libkvs/kvs.c
+++ b/src/common/libkvs/kvs.c
@@ -16,22 +16,53 @@
 #include <jansson.h>
 #include <flux/core.h>
 
+#include "src/common/libutil/blobref.h"
+
+#include "treeobj.h"
 #include "kvs_util_private.h"
 
 flux_future_t *flux_kvs_namespace_create (flux_t *h, const char *ns,
                                           uint32_t owner, int flags)
 {
+    flux_future_t *rv = NULL;
+    const char *hash_name;
+    json_t *rootdir = NULL;
+    char rootref[BLOBREF_MAX_STRING_SIZE];
+    void *data = NULL;
+    int len;
+
     if (!ns || flags) {
         errno = EINVAL;
         return NULL;
     }
 
+    if (!(hash_name = flux_attr_get (h, "content.hash")))
+        goto cleanup;
+
+    if (!(rootdir = treeobj_create_dir ()))
+        goto cleanup;
+
+    if (!(data = treeobj_encode (rootdir)))
+        goto cleanup;
+    len = strlen (data);
+
+    /* N.B. blobref of empty treeobj dir guaranteed to be in content store
+     * b/c that is how the primary KVS is initialized.
+     */
+    if (blobref_hash (hash_name, data, len, rootref, sizeof (rootref)) < 0)
+        goto cleanup;
+
     /* N.B. owner cast to int */
-    return flux_rpc_pack (h, "kvs.namespace-create", 0, 0,
-                          "{ s:s s:i s:i }",
-                          "namespace", ns,
-                          "owner", owner,
-                          "flags", flags);
+    rv = flux_rpc_pack (h, "kvs.namespace-create", 0, 0,
+                           "{ s:s s:s s:i s:i }",
+                           "namespace", ns,
+                           "rootref", rootref,
+                           "owner", owner,
+                           "flags", flags);
+cleanup:
+    json_decref (rootdir);
+    free (data);
+    return rv;
 }
 
 flux_future_t *flux_kvs_namespace_remove (flux_t *h, const char *ns)

--- a/src/common/libkvs/kvs.h
+++ b/src/common/libkvs/kvs.h
@@ -49,6 +49,9 @@ enum kvs_op {
  */
 flux_future_t *flux_kvs_namespace_create (flux_t *h, const char *ns,
                                           uint32_t owner, int flags);
+flux_future_t *flux_kvs_namespace_create_with (flux_t *h, const char *ns,
+                                               const char *rootref,
+                                               uint32_t owner, int flags);
 flux_future_t *flux_kvs_namespace_remove (flux_t *h, const char *ns);
 
 /* Synchronization:

--- a/src/common/libkvs/test/kvs.c
+++ b/src/common/libkvs/test/kvs.c
@@ -28,6 +28,11 @@ void errors (void)
         "flux_kvs_namespace_create fails on bad input");
 
     errno = 0;
+    ok (flux_kvs_namespace_create_with (NULL, NULL, NULL, 0, 5) == NULL
+        && errno == EINVAL,
+        "flux_kvs_namespace_create_with fails on bad input");
+
+    errno = 0;
     ok (flux_kvs_namespace_remove (NULL, NULL) == NULL && errno == EINVAL,
         "flux_kvs_namespace_remove fails on bad input");
 

--- a/t/t1000-kvs.t
+++ b/t/t1000-kvs.t
@@ -1195,6 +1195,13 @@ test_expect_success 'flux kvs getroot --owner returns instance owner' '
 	test $OWNER -eq $(id -u)
 '
 
+test_expect_success 'flux kvs getroot --blobref returns changing blobrefs' '
+	BLOBREF1=$(flux kvs getroot --blobref) &&
+	flux kvs put test.c=barf &&
+	BLOBREF2=$(flux kvs getroot --blobref) &&
+	test $BLOBREF1 != $BLOBREF2
+'
+
 test_expect_success 'flux kvs getroot works on alt namespace' '
 	flux kvs namespace create testns1 &&
 	SEQ=$(flux kvs getroot --namespace=testns1 --sequence) &&


### PR DESCRIPTION
While playing around with #3811 I realized it was impossible to initialize a namespace to a specific root reference.  So "checkpointing" was sort of impossible.

This updates the KVS namespace create RPC to allow specification of a root reference to initialize the namespace to.

Edit: Note that I did break ABI on `libkvs` to allow user to pass a `const char *rootref`.  To my knowledge, no flux-framework callers outside of `flux-core`.