### PR TITLE
rc: load job-archive

### DIFF
--- a/etc/rc1
+++ b/etc/rc1
@@ -26,6 +26,7 @@ modload 0 cron sync=heartbeat.pulse
 modload 0 job-manager
 modload all job-info
 modload 0 job-list
+modload 0 job-archive
 
 modload all job-ingest
 modload 0 job-exec

--- a/etc/rc3
+++ b/etc/rc3
@@ -25,6 +25,7 @@ shopt -u nullglob
 modrm 0 heartbeat
 modrm 0 sched-simple
 modrm all resource
+modrm 0 job-archive
 modrm 0 job-exec
 modrm 0 job-list
 modrm all job-info

--- a/t/issues/t3503-nofiles-limit.sh
+++ b/t/issues/t3503-nofiles-limit.sh
@@ -9,8 +9,8 @@
 #   definitely cause the broker to run over the artificially lowered
 #   fd limit.
 #
-ulimit -n 110
-ulimit -Hn 110
+ulimit -n 113
+ulimit -Hn 113
 flux start \
     sh -c '
 flux mini submit --cc=1-12 hostname &&


### PR DESCRIPTION
Problem: although job-archive does nothing if not configured, it is not loaded in rc1/rc3, so a custom rc script is required if iti s needed in production.
    
Just load it in rc1/rc3 and it can be enabled with config.

(flux-accounting depends on it)
    
Fixes #3940
