### PR TITLE
cron: load crontabs from directory if cron.directory attribute is set

### DIFF
--- a/etc/Makefile.am
+++ b/etc/Makefile.am
@@ -7,7 +7,8 @@ dist_fluxrc_SCRIPTS = \
         rc3
 
 dist_fluxrc1_SCRIPTS = \
-        rc1.d/01-enclosing-instance
+        rc1.d/01-enclosing-instance \
+        rc1.d/02-cron
 
 fluxhelpdir = $(datadir)/flux/help.d
 fluxhelp_DATA = flux/help.d/core.json

--- a/etc/flux.service.in
+++ b/etc/flux.service.in
@@ -7,6 +7,7 @@ TimeoutStopSec=90
 KillMode=mixed
 ExecStart=@X_BINDIR@/flux broker \
   --config-path=@X_SYSCONFDIR@/flux/system/conf.d \
+  -Scron.directory=@X_SYSCONFDIR@/flux/system/cron.d \
   -Stbon.fanout=256 \
   -Srundir=@X_RUNSTATEDIR@/flux \
   -Slocal-uri=local://@X_RUNSTATEDIR@/flux/local \

--- a/etc/rc1.d/02-cron
+++ b/etc/rc1.d/02-cron
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Load crontabs from directory if cron.directory attribute is set
+
+if test $(flux getattr rank) -eq 0 \
+	&& cron_dir=$(flux getattr cron.directory 2>/dev/null) \
+	&& test -d "$cron_dir"; then
+	shopt -s nullglob
+	for file in $cron_dir/*; do
+		if test -f $file; then
+			if ! flux cron tab <$file; then
+				echo "could not load crontab: $file" >&2
+				exit 1
+			fi
+		fi
+	done
+	shopt -u nullglob
+fi

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -176,6 +176,7 @@ TESTSCRIPTS = \
 	t3001-mpi-personalities.t \
 	t3002-pmi.t \
 	t3003-mpi-abort.t \
+	t3201-crontabs.t \
 	t3300-system-basic.t \
 	t3301-system-latestart.t \
 	t3302-system-offline.t \

--- a/t/t3201-crontabs.t
+++ b/t/t3201-crontabs.t
@@ -1,0 +1,40 @@
+#!/bin/sh
+#
+
+test_description='Test rc1 loading of crontab files'
+
+# Append --logfile option if FLUX_TESTS_LOGFILE is set in environment:
+test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
+. `dirname $0`/sharness.sh
+
+test_expect_success 'empty cron.directory works' '
+	mkdir cron.d &&
+	flux start -o,-Scron.directory=cron.d /bin/true
+'
+test_expect_success 'non-existent cron.directory works' '
+	flux start -o,-Scron.directory=noexist /bin/true
+'
+test_expect_success 'cron.directory with subdirectory works' '
+	rm -rf cron.d &&
+	mkdir -p cron.d/subdir &&
+	flux start -o,-Scron.directory=cron.d /bin/true
+'
+test_expect_success 'cron.directory with non-crontab file fails' '
+	rm -rf cron.d &&
+	mkdir cron.d &&
+	echo zzz >cron.d/badtab &&
+	test_must_fail flux start -o,-Scron.directory=cron.d \
+		/bin/true 2>bad.err &&
+	grep "could not load crontab" bad.err
+'
+test_expect_success 'cron.directory with good crontab files works' '
+	rm -rf cron.d &&
+	mkdir cron.d &&
+	echo "10 * * * * /bin/true" >cron.d/goodtab &&
+	echo "20 * * * * hostname" >cron.d/goodtab2 &&
+	flux start -o,-Scron.directory=cron.d flux cron list >list.out &&
+	grep /bin/true list.out &&
+	grep hostname list.out
+'
+
+test_done


### PR DESCRIPTION
cron: load crontabs from directory
    
Problem: sys admins need a way to set up cron jobs for the system instance only, that persist across an instance reboot.
    
Set a `cron.directory`  attribute in the systemd unit file.
    
In rc1, on rank 0 only, if the cron.directory attribute is set, iterate over files in the directory, loading each into the cron service with `flux cron tab <$file`.
