### PR TITLE
job-manager / job-exec: checkpoint and restore guest KVS namespaces

### DIFF
--- a/etc/rc1
+++ b/etc/rc1
@@ -54,7 +54,8 @@ if test $RANK -eq 0 -a "${FLUX_SCHED_MODULE}" != "none" \
     flux module load ${FLUX_SCHED_MODULE:-sched-simple}
 fi
 
-test $RANK -ne 0 || flux admin cleanup-push <<-EOT
+test $RANK -ne 0 -o "${FLUX_INSTANCE_RESTART}" = "t" \
+     || flux admin cleanup-push <<-EOT
 	flux queue stop --quiet
 	flux job cancelall --user=all --quiet -f --states RUN
 	flux queue idle --quiet

--- a/src/common/libkvs/kvs_getroot.h
+++ b/src/common/libkvs/kvs_getroot.h
@@ -21,7 +21,7 @@ flux_future_t *flux_kvs_getroot (flux_t *h, const char *ns, int flags);
 /* Decode KVS root hash response.
  *
  * treeobj - get the hash as an RFC 11 "dirref" object.
- * blobref - get the raw hash as a n RFC 10 "blobref".
+ * blobref - get the raw hash as an RFC 10 "blobref".
  * sequence - get the commit sequence number
  * owner - get the userid of the namespace owner
  */

--- a/src/modules/job-exec/Makefile.am
+++ b/src/modules/job-exec/Makefile.am
@@ -27,6 +27,8 @@ libbulk_exec_la_SOURCES = \
 job_exec_la_SOURCES = \
 	job-exec.h \
 	job-exec.c \
+	checkpoint.h \
+	checkpoint.c \
 	rset.c \
 	rset.h \
 	testexec.c \

--- a/src/modules/job-exec/checkpoint.c
+++ b/src/modules/job-exec/checkpoint.c
@@ -1,0 +1,186 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* Prototype checkpoint of running jobs KVS root refs
+ *
+ * DESCRIPTION
+ *
+ * Handle checkpoint of running job's guest KVS namescapes into the
+ * primary KVS.  This will allow the namespaces to be recreated if
+ * a job manager is brought down than back up.
+ *
+ * OPERATION
+ *
+ * Get the KVS rootrefs for all running jobs and commit to
+ * "job-exec.kvs-namespaces".
+ *
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <assert.h>
+#include <unistd.h>
+#include <flux/core.h>
+
+#include "src/common/libczmqcontainers/czmq_containers.h"
+
+#include "job-exec.h"
+#include "checkpoint.h"
+
+static int lookup_nsroots (flux_t *h, zhashx_t *jobs, flux_future_t **fp)
+{
+    struct jobinfo *job = zhashx_first (jobs);
+    flux_future_t *fall = NULL;
+    flux_future_t *f = NULL;
+
+    while (job) {
+        if (job->running) {
+            if (!fall) {
+                if (!(fall = flux_future_wait_all_create ()))
+                    goto cleanup;
+                flux_future_set_flux (fall, h);
+            }
+            if (!(f = flux_kvs_getroot (h, job->ns, 0)))
+                goto cleanup;
+            if (flux_future_aux_set (f, "jobinfo", job, NULL) < 0)
+                goto cleanup;
+            if (flux_future_push (fall, job->ns, f) < 0)
+                goto cleanup;
+            f = NULL;
+        }
+        job = zhashx_next (jobs);
+    }
+
+    (*fp) = fall;
+    return 0;
+
+cleanup:
+    flux_future_destroy (f);
+    flux_future_destroy (fall);
+    return -1;
+}
+
+static json_t *get_nsroots (flux_t *h, flux_future_t *fall)
+{
+    const char *child;
+    json_t *nsdata = NULL;
+    int saved_errno;
+
+    if (!(nsdata = json_array ())) {
+        errno = ENOMEM;
+        return NULL;
+    }
+
+    child = flux_future_first_child (fall);
+    while (child) {
+        flux_future_t *f = flux_future_get_child (fall, child);
+        struct jobinfo *job;
+        const char *blobref = NULL;
+        json_t *o = NULL;
+        if (!f)
+            goto cleanup;
+        if (!(job = flux_future_aux_get (f, "jobinfo")))
+            goto cleanup;
+        if (flux_kvs_getroot_get_blobref (f, &blobref) < 0)
+            goto cleanup;
+        if (!(o = json_pack ("{s:I s:i s:s}",
+                             "id", job->id,
+                             "owner", job->userid,
+                             "kvsroot", blobref))) {
+            errno = ENOMEM;
+            goto cleanup;
+        }
+        if (json_array_append (nsdata, o) < 0) {
+            json_decref (o);
+            errno = ENOMEM;
+            goto cleanup;
+        }
+        json_decref (o);
+        child = flux_future_next_child (fall);
+    }
+
+    return nsdata;
+cleanup:
+    saved_errno = errno;
+    json_decref (nsdata);
+    errno = saved_errno;
+    return NULL;
+}
+
+static int checkpoint_commit (flux_t *h, json_t *nsdata)
+{
+    flux_future_t *f = NULL;
+    flux_kvs_txn_t *txn = NULL;
+    char *s = NULL;
+    int rv = -1;
+
+    if (!(s = json_dumps (nsdata, JSON_COMPACT))) {
+        errno = ENOMEM;
+        goto cleanup;
+    }
+
+    if (!(txn = flux_kvs_txn_create ()))
+        goto cleanup;
+
+    if (flux_kvs_txn_put (txn,
+                          0,
+                          "job-exec.kvs-namespaces",
+                          s) < 0)
+        goto cleanup;
+
+    if (!(f = flux_kvs_commit (h, NULL, 0, txn)))
+        goto cleanup;
+
+    if (flux_future_get (f, NULL) < 0)
+        goto cleanup;
+
+    rv = 0;
+cleanup:
+    flux_future_destroy (f);
+    flux_kvs_txn_destroy (txn);
+    free (s);
+    return rv;
+}
+
+void checkpoint_running (flux_t *h, zhashx_t *jobs)
+{
+    flux_future_t *lookupf = NULL;
+    json_t *nsdata = NULL;
+
+    if (!h || !jobs)
+        return;
+
+    if (lookup_nsroots (h, jobs, &lookupf) < 0) {
+        flux_log_error (h, "failed to lookup ns root refs");
+        goto cleanup;
+    }
+
+    if (!lookupf)
+        return;
+
+    if (!(nsdata = get_nsroots (h, lookupf))) {
+        flux_log_error (h, "failure getting ns root refs");
+        goto cleanup;
+    }
+
+    if (checkpoint_commit (h, nsdata) < 0) {
+        flux_log_error (h, "failure committing ns checkpoint data");
+        goto cleanup;
+    }
+
+cleanup:
+    json_decref (nsdata);
+    flux_future_destroy (lookupf);
+}
+
+/*
+ * vi: tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/job-exec/checkpoint.h
+++ b/src/modules/job-exec/checkpoint.h
@@ -11,8 +11,16 @@
 #ifndef HAVE_JOB_EXEC_CHECKPOINT_H
 #define HAVE_JOB_EXEC_CHECKPOINT_H 1
 
+#include <flux/core.h>
+
 #include "src/common/libczmqcontainers/czmq_containers.h"
 #include "job-exec.h"
+
+flux_future_t *checkpoint_get_rootrefs (flux_t *h);
+
+char *checkpoint_find_rootref (flux_future_t *f,
+                               flux_jobid_t id,
+                               uint32_t owner);
 
 void checkpoint_running (flux_t *h, zhashx_t *jobs);
 

--- a/src/modules/job-exec/checkpoint.h
+++ b/src/modules/job-exec/checkpoint.h
@@ -1,0 +1,22 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef HAVE_JOB_EXEC_CHECKPOINT_H
+#define HAVE_JOB_EXEC_CHECKPOINT_H 1
+
+#include "src/common/libczmqcontainers/czmq_containers.h"
+#include "job-exec.h"
+
+void checkpoint_running (flux_t *h, zhashx_t *jobs);
+
+#endif /* !HAVE_JOB_EXEC_CHECKPOINT_EXEC_H */
+
+/* vi: ts=4 sw=4 expandtab
+ */

--- a/src/modules/job-exec/exec.c
+++ b/src/modules/job-exec/exec.c
@@ -111,7 +111,7 @@ static const char *job_get_cwd (struct jobinfo *job)
 static void start_cb (struct bulk_exec *exec, void *arg)
 {
     struct jobinfo *job = arg;
-    jobinfo_started (job, NULL);
+    jobinfo_started (job);
     /*  This is going to be really slow. However, it should at least
      *   work for now. We wait for all imp's to start, then send input
      */

--- a/src/modules/job-exec/job-exec.c
+++ b/src/modules/job-exec/job-exec.c
@@ -319,14 +319,11 @@ static void jobinfo_complete (struct jobinfo *job, const struct idset *ranks)
     }
 }
 
-void jobinfo_started (struct jobinfo *job, const char *fmt, ...)
+void jobinfo_started (struct jobinfo *job)
 {
     flux_t *h = job->ctx->h;
     if (h && job->req) {
-        va_list ap;
-        va_start (ap, fmt);
         job->running = 1;
-        va_end (ap);
         if (jobinfo_respond (h, job, "start") < 0)
             flux_log_error (h, "jobinfo_started: flux_respond");
     }

--- a/src/modules/job-exec/job-exec.c
+++ b/src/modules/job-exec/job-exec.c
@@ -26,7 +26,7 @@
  *
  * JOB INIT:
  *
- * On reciept of a start request, the exec service enters initialization
+ * On receipt of a start request, the exec service enters initialization
  * phase of the job, where the jobspec and R are fetched from the KVS,
  * and the guest namespace is created and linked from the primary
  * namespace. A guest.exec.eventlog is created with an initial "init"

--- a/src/modules/job-exec/job-exec.c
+++ b/src/modules/job-exec/job-exec.c
@@ -743,6 +743,7 @@ static void jobinfo_start_continue (flux_future_t *f, void *arg)
     }
     job->has_namespace = 1;
 
+
     /*  If an exception was received during startup, no need to continue
      *   with startup
      */

--- a/src/modules/job-exec/job-exec.c
+++ b/src/modules/job-exec/job-exec.c
@@ -290,7 +290,7 @@ static int jobinfo_send_release (struct jobinfo *job,
 }
 
 static int jobinfo_respond (flux_t *h, struct jobinfo *job,
-                            const char *event, int status)
+                            const char *event)
 {
     return flux_respond_pack (h, job->req, "{s:I s:s s:{}}",
                                            "id", job->id,
@@ -327,7 +327,7 @@ void jobinfo_started (struct jobinfo *job, const char *fmt, ...)
         va_start (ap, fmt);
         job->running = 1;
         va_end (ap);
-        if (jobinfo_respond (h, job, "start", 0) < 0)
+        if (jobinfo_respond (h, job, "start") < 0)
             flux_log_error (h, "jobinfo_started: flux_respond");
     }
 }

--- a/src/modules/job-exec/job-exec.h
+++ b/src/modules/job-exec/job-exec.h
@@ -61,6 +61,7 @@ struct jobinfo {
     flux_t *              h;
     flux_jobid_t          id;
     char                  ns [64];   /* namespace string */
+    char                * rootref;   /* ns rootref if restart */
     const flux_msg_t *    req;       /* initial request */
     uint32_t              userid;    /* requesting userid */
     int                   flags;     /* job flags */

--- a/src/modules/job-exec/job-exec.h
+++ b/src/modules/job-exec/job-exec.h
@@ -77,6 +77,7 @@ struct jobinfo {
     uint8_t               running:1;     /* all shells are running */
     uint8_t               finalizing:1;  /* in process of cleanup */
 
+    int                   reattach;      /* job-manager reattach attempt */
     int                   wait_status;
 
     struct eventlogger *  ev;           /* event batcher */
@@ -104,6 +105,9 @@ int jobinfo_emit_event_pack_nowait (struct jobinfo *job,
 
 /* Emit  start event */
 void jobinfo_started (struct jobinfo *job);
+
+/* Emit  reattached event */
+void jobinfo_reattached (struct jobinfo *job);
 
 /* Notify job-exec that ranks in idset `ranks` have completed
  *  with the given wait status

--- a/src/modules/job-exec/job-exec.h
+++ b/src/modules/job-exec/job-exec.h
@@ -102,8 +102,8 @@ int jobinfo_emit_event_pack_nowait (struct jobinfo *job,
                                      const char *name,
                                      const char *fmt, ...);
 
-/* Emit  start event with optional note in jansson pack format */
-void jobinfo_started (struct jobinfo *job, const char *fmt, ...);
+/* Emit  start event */
+void jobinfo_started (struct jobinfo *job);
 
 /* Notify job-exec that ranks in idset `ranks` have completed
  *  with the given wait status

--- a/src/modules/job-exec/testexec.c
+++ b/src/modules/job-exec/testexec.c
@@ -171,7 +171,6 @@ static int start_timer (flux_t *h, struct testexec *te)
     if (t < 0.)
         t = 1.e-5;
     if (t >= 0.) {
-        char timebuf[256];
         if (t > 0.) {
             te->timer = flux_timer_watcher_create (r, t, 0., timer_cb, te);
             if (!te->timer) {
@@ -179,10 +178,8 @@ static int start_timer (flux_t *h, struct testexec *te)
                 return -1;
             }
             flux_watcher_start (te->timer);
-            snprintf (timebuf, sizeof (timebuf), "%.6fs", t);
-        } else
-            strncpy (timebuf, "inf", sizeof (timebuf));
-        jobinfo_started (te->job, "{ s:s }", "timer", timebuf);
+        }
+        jobinfo_started (te->job);
     }
     else
         return -1;

--- a/src/modules/job-manager/job.h
+++ b/src/modules/job-manager/job.h
@@ -40,6 +40,7 @@ struct job {
     uint8_t free_pending:1; // free request sent to sched
     uint8_t has_resources:1;
     uint8_t start_pending:1;// start request sent to job-exec
+    uint8_t reattach:1;
 
     uint8_t perilog_active; // if nonzero, prolog/epilog active
 

--- a/src/modules/job-manager/restart.c
+++ b/src/modules/job-manager/restart.c
@@ -269,6 +269,16 @@ int restart_from_kvs (struct job_manager *ctx)
         else if ((job->state & FLUX_JOB_STATE_RUNNING) != 0) {
             ctx->running_jobs++;
             job->reattach = 1;
+            if ((job->flags & FLUX_JOB_DEBUG)) {
+                if (event_job_post_pack (ctx->event,
+                                         job,
+                                         "debug.exec-reattach-start",
+                                         0,
+                                         "{s:I}",
+                                         "id", (uintmax_t)job->id) < 0)
+                    flux_log_error (ctx->h, "%s: event_job_post_pack id=%ju",
+                                    __FUNCTION__, (uintmax_t)job->id);
+            }
         }
         job = zhashx_next (ctx->active_jobs);
     }

--- a/src/modules/job-manager/restart.c
+++ b/src/modules/job-manager/restart.c
@@ -266,8 +266,10 @@ int restart_from_kvs (struct job_manager *ctx)
                                 __FUNCTION__, (uintmax_t)job->id);
             }
         }
-        else if ((job->state & FLUX_JOB_STATE_RUNNING) != 0)
+        else if ((job->state & FLUX_JOB_STATE_RUNNING) != 0) {
             ctx->running_jobs++;
+            job->reattach = 1;
+        }
         job = zhashx_next (ctx->active_jobs);
     }
     flux_log (ctx->h, LOG_INFO, "restart: %d running jobs", ctx->running_jobs);

--- a/src/modules/job-manager/start.c
+++ b/src/modules/job-manager/start.c
@@ -211,7 +211,14 @@ static void start_response_cb (flux_t *h, flux_msg_handler_t *mh,
         }
     }
     else if (!strcmp (type, "reattached")) {
-        /* nothing to do yet */
+        if ((job->flags & FLUX_JOB_DEBUG)) {
+            if (event_job_post_pack (ctx->event,
+                                     job,
+                                     "debug.exec-reattach-finish",
+                                     0,
+                                     NULL) < 0)
+                goto error_post;
+        }
     }
     else if (!strcmp (type, "release")) {
         const char *idset;

--- a/src/modules/job-manager/start.c
+++ b/src/modules/job-manager/start.c
@@ -210,6 +210,9 @@ static void start_response_cb (flux_t *h, flux_msg_handler_t *mh,
                 goto error_post;
         }
     }
+    else if (!strcmp (type, "reattached")) {
+        /* nothing to do yet */
+    }
     else if (!strcmp (type, "release")) {
         const char *idset;
         int final;

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -47,7 +47,8 @@ clean-local:
 LONGTESTSCRIPTS = \
 	t5000-valgrind.t \
 	t3100-flux-in-flux.t \
-	t3200-instance-restart.t
+	t3200-instance-restart.t \
+	t3202-instance-restart-testexec.t
 
 # This list is included in both TESTS and dist_check_SCRIPTS.
 TESTSCRIPTS = \

--- a/t/t3202-instance-restart-testexec.t
+++ b/t/t3202-instance-restart-testexec.t
@@ -1,0 +1,57 @@
+#!/bin/sh
+
+test_description='Test instance restart and still running jobs with testexec'
+
+# Append --logfile option if FLUX_TESTS_LOGFILE is set in environment:
+test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
+. `dirname $0`/sharness.sh
+
+export FLUX_INSTANCE_RESTART=t
+
+test_expect_success 'run a testexec job in persistent instance (long run)' '
+	flux start -o,--setattr=content.backing-path=$(pwd)/content.sqlite \
+	     flux mini submit \
+	       --flags=debug \
+	       --setattr=system.exec.test.run_duration=100s \
+	       hostname >id1.out
+'
+
+test_expect_success 'restart instance, reattach to running job, cancel it (long run)' '
+	flux start -o,--setattr=content.backing-path=$(pwd)/content.sqlite \
+	     sh -c "flux job eventlog $(cat id1.out) > eventlog_long1.out; \
+		    flux jobs -n > jobs_long1.out; \
+		    flux job cancel $(cat id1.out)" &&
+	grep "reattach-start" eventlog_long1.out &&
+	grep "reattach-finish" eventlog_long1.out &&
+	grep $(cat id1.out) jobs_long1.out
+'
+
+test_expect_success 'restart instance, job completed (long run)' '
+	flux start -o,--setattr=content.backing-path=$(pwd)/content.sqlite \
+	     sh -c "flux job eventlog $(cat id1.out) > eventlog_long2.out; \
+		    flux jobs -n > jobs_long2.out" &&
+	grep "finish" eventlog_long2.out | grep status &&
+	test_must_fail grep $(cat id1.out) jobs_long2.out
+'
+
+# reattach_finish will indicate to testexcec that the job finished
+# right after reattach, emulating a job that finished before the
+# instance restarted
+test_expect_success 'run a testexec job in persistent instance (exit run)' '
+	flux start -o,--setattr=content.backing-path=$(pwd)/content.sqlite \
+	     flux mini submit \
+	       --flags=debug \
+	       --setattr=system.exec.test.reattach_finish=1 \
+	       --setattr=system.exec.test.run_duration=100s \
+	     hostname >id2.out
+'
+
+test_expect_success 'restart instance, reattach to running job, its finished (exit run)' '
+	flux start -o,--setattr=content.backing-path=$(pwd)/content.sqlite \
+	     sh -c "flux job eventlog $(cat id2.out) > eventlog_exit1.out" &&
+	grep "reattach-start" eventlog_exit1.out &&
+	grep "reattach-finish" eventlog_exit1.out &&
+	grep "finish" eventlog_exit1.out | grep status
+'
+
+test_done


### PR DESCRIPTION
Thought I'd throw up this WIP if there are any high level thoughts / comments.  This is an prototype set of changes for checkpointing KVS namespaces when a broker goes down and "re-attaching" to an already running job.  What this PR does is:

A) upon unloading the job-exec module, checkpoint the rootref of the KVS namespaces of still running jobs
B) upon re-load, if the job is believed to still be running, send `job-exec` a "re-attach" flag from `job-manager`
C) upon re-load, have `job-exec` re-build KVS namespace with checkpointed rootref
D) upon "re-attach", `testexec` will simulate remaining runtime of the job based on the starttime of the job (i.e. perhaps `testexec` thinks the job has run 90 seconds out of 100 seconds, simulate a run for just 10 more seconds)

This currently works with tests like this:

```
flux mini submit --setattr=system.exec.test.run_duration=100s hostname

<wait a little>

# remove all job modules and KVS
flux module remove job-exec; flux module remove sched-simple; flux module remove job-list; flux module remove job-info; flux module remove job-manager; flux module remove job-ingest; flux module remove kvs

<wait a little>

# re-add KVS and all job modules
sleep 5; flux module load kvs; flux module load job-manager; flux module load job-info; flux module load job-list; flux module load job-ingest; flux module load job-exec; flux module load sched-simple
```

the eventlogs for the above test look like this (we would need RFC changes to document any new events we put in here).  Some of the guest event log stuff is just for debugging / info.

```
>flux job eventlog f5xBPt79
1636493577.871553 submit userid=8556 urgency=16 flags=0
1636493577.885256 depend
1636493577.885322 priority priority=16
1636493577.887893 alloc annotations={"sched":{"resource_summary":"rank0/core0"}}
1636493577.890752 start
1636493590.477205 flux-reattach
1636493590.757046 reattach
1636493607.762088 finish status=0
1636493607.766412 release ranks="all" final=true
1636493607.767615 free
1636493607.767666 clean

>flux job eventlog -p guest.exec.eventlog f5xBPt79
1636493577.888897 init
1636493577.890580 starting
1636493577.890601 timer timerrun=30.0
1636493590.755381 reattach
1636493590.756492 re-starting
1636493590.756854 note timeleft=17
1636493590.756869 timer timerrun=17.0
1636493607.761802 timercb
1636493607.761841 complete status=0
1636493607.761891 done


```

need to cleanup code, try and make some code non-synchronous, need to make tests, but I think this is a first good step
