### PR TITLE
broker/overlay: misc cleanup

### DIFF
--- a/doc/man3/tsync.c
+++ b/doc/man3/tsync.c
@@ -25,7 +25,7 @@ int main (int argc, char **argv)
         log_err_exit ("error registering continuation");
 
     if (flux_reactor_run (flux_get_reactor (h), 0) < 0)
-        log_err_exit ("reactor returned wtih error");
+        log_err_exit ("reactor returned with error");
 
     flux_future_destroy (f);
 

--- a/src/broker/groups.c
+++ b/src/broker/groups.c
@@ -458,12 +458,16 @@ static void join_request_cb (flux_t *h,
     if (groups_join (g, name) < 0)
         goto error;
     group->join_request = flux_msg_incref (msg);
-    if (flux_respond (h, msg, NULL) < 0)
-        flux_log_error (h, "error responding to groups.leave request");
+    if (flux_respond (h, msg, NULL) < 0) {
+        if (errno != ENOSYS)
+            flux_log_error (h, "error responding to groups.leave request");
+    }
     return;
 error:
-    if (flux_respond_error (h, msg, errno, errmsg) < 0)
-        flux_log_error (h, "error responding to groups.leave request");
+    if (flux_respond_error (h, msg, errno, errmsg) < 0) {
+        if (errno != ENOSYS)
+            flux_log_error (h, "error responding to groups.leave request");
+    }
 }
 
 /* A client wishes to LEAVE a group.

--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -80,7 +80,7 @@ static const char *subtree_status_names[] = {
 };
 
 struct child {
-    int lastseen;
+    double lastseen;
     uint32_t rank;
     char uuid[UUID_STR_LEN];
     enum subtree_status status;
@@ -362,7 +362,7 @@ void overlay_log_idle_children (struct overlay *ov)
     struct child *child;
     double now = flux_reactor_now (ov->reactor);
     char fsd[64];
-    int idle;
+    double idle;
 
     if (idle_max > 0) {
         foreach_overlay_child (ov, child) {

--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -164,7 +164,7 @@ static void hello_request_handler (struct overlay *ov, const flux_msg_t *msg);
 static int overlay_keepalive_parent (struct overlay *ov,
                                      enum keepalive_type ktype,
                                      int arg);
-static int overlay_health_respond (struct overlay *ov, const flux_msg_t *msg);
+static void overlay_health_respond_all (struct overlay *ov);
 static json_t *get_subtree_topo (struct overlay *ov, int rank);
 
 /* Convenience iterator for ov->children
@@ -179,17 +179,6 @@ static const char *subtree_status_str (enum subtree_status status)
     if (status > SUBTREE_STATUS_MAXIMUM)
         return "unknown";
     return subtree_status_names[status];
-}
-
-static enum subtree_status subtree_status_num (const char *name)
-{
-    int i;
-
-    for (i = 0; i <= SUBTREE_STATUS_MAXIMUM; i++) {
-        if (streq (subtree_status_names[i], name))
-            return i;
-    }
-    return SUBTREE_STATUS_UNKNOWN;
 }
 
 static bool subtree_is_online (enum subtree_status status)
@@ -233,29 +222,10 @@ static void subtree_status_update (struct overlay *ov)
         }
     }
     if (ov->status != status) {
-        const flux_msg_t *msg;
-        const char *wait;
-
         ov->status = status;
         monotime (&ov->status_timestamp);
         overlay_keepalive_parent (ov, KEEPALIVE_STATUS, ov->status);
-
-        /* Process waiting health requests, in case this broker
-         * transitioned into the state that is being waited for
-         */
-        msg = flux_msglist_first (ov->health_requests);
-        while (msg) {
-            if (flux_request_unpack (msg, NULL, "{s:s}", "wait", &wait) == 0
-                && subtree_status_num (wait) == ov->status) {
-                if (overlay_health_respond (ov, msg) < 0) {
-                    if (flux_respond_error (ov->h, msg, errno, NULL) < 0)
-                        flux_log_error (ov->h,
-                                        "error responding to overlay.health");
-                }
-                flux_msglist_delete (ov->health_requests);
-            }
-            msg = flux_msglist_next (ov->health_requests);
-        }
+        overlay_health_respond_all (ov);
     }
 }
 
@@ -747,6 +717,7 @@ static void overlay_child_status_update (struct overlay *ov,
 
         subtree_status_update (ov);
         overlay_monitor_notify (ov);
+        overlay_health_respond_all (ov);
     }
 }
 
@@ -1441,37 +1412,36 @@ nomem:
     return -1;
 }
 
+static void overlay_health_respond_all (struct overlay *ov)
+{
+    const flux_msg_t *msg;
+
+    msg = flux_msglist_first (ov->health_requests);
+    while (msg) {
+        if (overlay_health_respond (ov, msg) < 0)
+            flux_log_error (ov->h, "error responding to overlay.health");
+        msg = flux_msglist_next (ov->health_requests);
+    }
+}
+
 static void overlay_health_cb (flux_t *h,
                                flux_msg_handler_t *mh,
                                const flux_msg_t *msg,
                                void *arg)
 {
     struct overlay *ov = arg;
-    const char *wait = NULL; // optional wait for state before responding
-    char errbuf[128];
-    const char *errstr = NULL;
 
-    if (flux_request_unpack (msg, NULL, "{s?s}", "wait", &wait) < 0)
+    if (flux_request_decode (msg, NULL, NULL) < 0)
         goto error;
-    if (wait) {
-        int state = subtree_status_num (wait);
-
-        if (state == SUBTREE_STATUS_UNKNOWN) {
-            snprintf (errbuf, sizeof (errbuf), "unknown state: '%s'", wait);
-            errstr = errbuf;
-            errno = EPROTO;
+    if (flux_msg_is_streaming (msg)) {
+        if (flux_msglist_append (ov->health_requests, msg) < 0)
             goto error;
-        }
-        if (state != ov->status) {
-            flux_msglist_append (ov->health_requests, msg);
-            return;
-        }
     }
     if (overlay_health_respond (ov, msg) < 0)
         goto error;
     return;
 error:
-    if (flux_respond_error (h, msg, errno, errstr) < 0)
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
         flux_log_error (h, "error responding to overlay.health");
 }
 

--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -366,7 +366,7 @@ void overlay_log_idle_children (struct overlay *ov)
 
     if (idle_max > 0) {
         foreach_overlay_child (ov, child) {
-            if (subtree_is_online (child->status)) {
+            if (subtree_is_online (child->status) && child->lastseen > 0) {
                 idle = now - child->lastseen;
 
                 if (idle >= idle_max) {

--- a/src/common/libutil/ipaddr.h
+++ b/src/common/libutil/ipaddr.h
@@ -25,7 +25,7 @@
  *
  * FLUX_IPADDR_IPV6
  *   if set, IPv6 addresses are preferred, with fallback to IPv4
- *   if unset, IPv4 addresses are preferred, wtih fallback to IPv6
+ *   if unset, IPv4 addresses are preferred, with fallback to IPv6
  * FLUX_IPADDR_HOSTNAME
  *   if set, only method 2 is tried above
  *   if unset, first method 1 is tried, then if that fails, method 2 is tried

--- a/t/t2009-pmix-bootstrap.t
+++ b/t/t2009-pmix-bootstrap.t
@@ -37,7 +37,7 @@ find_mpirun() {
 }
 
 if ! flux version | grep -q +pmix-bootstrap; then
-	skip_all='skipping: not configured wtih --enable-pmix-bootstrap'
+	skip_all='skipping: not configured with --enable-pmix-bootstrap'
 	test_done
 fi
 

--- a/t/t3303-system-healthcheck.t
+++ b/t/t3303-system-healthcheck.t
@@ -39,9 +39,6 @@ wait_connected() {
 	return 1
 }
 
-bad_health_request() {
-        flux python -c "import flux; print(flux.Flux().rpc(\"overlay.health\",nodeid=0).get_str())"
-}
 bad_topo_request() {
         flux python -c "import flux; print(flux.Flux().rpc(\"overlay.topology\",nodeid=0).get_str())"
 }
@@ -49,9 +46,6 @@ bad_topo_request_rank99() {
         flux python -c "import flux; print(flux.Flux().rpc(\"overlay.topology\",{\"rank\":99},nodeid=0).get_str())"
 }
 
-test_expect_success 'overlay.health RPC with no payload fails' '
-	test_must_fail bad_health_request
-'
 test_expect_success 'overlay.topology RPC with no payload fails' '
 	test_must_fail bad_topo_request
 '


### PR DESCRIPTION
Suppress a couple of concerning but actually benign error messages @grondo noticed when he was testing flux on a node that was running out of memory.

Plus some other minor quasi-related stuff I had queued up, the most substantial of which is changing an RPC that is used by `flux overlay status` to be more useful for other things TBD.  (This commit came from an earlier monitoring branch so the use case is not there anymore, but I think this is probably a better way to structure the RPC before expanding it to include idle time).