### PR TITLE
libpmi/server: don't allow PMI2 to connect

### DIFF
--- a/src/common/libpmi/simple_server.c
+++ b/src/common/libpmi/simple_server.c
@@ -231,7 +231,7 @@ int pmi_simple_server_request (struct pmi_simple_server *pmi,
             goto proto;
         if (keyval_parse_uint (buf, "pmi_subversion", &pmi_subversion) < 0)
             goto proto;
-        if (pmi_version < 1 || (pmi_version == 1 && pmi_subversion < 1))
+        if (pmi_version != 1 || (pmi_version == 1 && pmi_subversion < 1))
             snprintf (resp, sizeof (resp), "cmd=response_to_init rc=-1\n");
         else
             snprintf (resp, sizeof (resp), "cmd=response_to_init rc=0 "


### PR DESCRIPTION
Problem: since slurm installs its libpmi2.so in the main libdir, it's
easy for applications to pick it up unintentionally in an rpath.
When Flux tries to launch the app, PMI tracing shows:

  TRACE: 0: C: cmd=init pmi_version=2 pmi_subversion=0
  TRACE: 0: S: cmd=response_to_init rc=0 pmi_version=1 pmi_subversion=1

followed by application hang.

Send back a failure code if the major version is not 1 to turn
the hang into a hard failure.

Add unit test coverage.

Fixes #3909