### PR TITLE
README: update LLNL-CODE

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,4 +186,4 @@ installed, you may build libpmix as a separate package to get them installed.
 
 SPDX-License-Identifier: LGPL-3.0
 
-LLNL-CODE-76440
+LLNL-CODE-764420


### PR DESCRIPTION
Problem: README lists original LLNL release ID, but the ID was updated when when Flux was relicensed as LGPL-3.0.

Update to the new release ID.

Thanks to @slabasan fpr catching that!