### PR TITLE
cmd: improve flux-mini bulksubmit --dry-run output with --cc

### DIFF
--- a/src/cmd/flux-mini.py
+++ b/src/cmd/flux-mini.py
@@ -386,7 +386,7 @@ class Xcmd:
 
             #  For better verbose and dry-run output, capture mutable
             #   args that were actually changed:
-            if val != newval:
+            if val != newval or attr == "cc":
                 self.modified[attr] = True
 
     def __getattr__(self, attr):

--- a/t/t2703-mini-bulksubmit.t
+++ b/t/t2703-mini-bulksubmit.t
@@ -302,4 +302,14 @@ test_expect_success 'flux-mini bulksubmit preserves {cc} in args' '
 	    grep ^${id}=c preserve-${id}.out
 	done
 '
+test_expect_success 'flux-mini bulksubmit --dry-run works with --cc' '
+	flux mini bulksubmit --dry-run --cc=1-2 echo {} ::: 1 2 3 \
+	  >dry-run-cc.out 2>&1 &&
+	cat <<-EOF >dry-run-cc.expected &&
+	flux-mini: submit --cc=1-2 echo 1
+	flux-mini: submit --cc=1-2 echo 2
+	flux-mini: submit --cc=1-2 echo 3
+	EOF
+	test_cmp dry-run-cc.expected dry-run-cc.out
+'
 test_done


### PR DESCRIPTION
This improves the broken `flux-mini bulksubmit --dry-run` output when the `--cc` option is used.

Instead of just dropping the option in output, this simple change includes `--cc` in the output if the option was used.

```console
$ flux mini bulksubmit --dry-run --cc=1-2 echo {} ::: 1 2 3
flux-mini: submit --cc=1-2 echo 1
flux-mini: submit --cc=1-2 echo 2
flux-mini: submit --cc=1-2 echo 3
```