### PR TITLE
resource: improve topo-reduce error handling

### DIFF
--- a/src/broker/groups.c
+++ b/src/broker/groups.c
@@ -522,8 +522,12 @@ static int get_respond_one (struct groups *g,
 
     if (!(s = idset_encode (group->members, IDSET_FLAG_RANGE)))
         return -1;
-    if (flux_respond_pack (g->ctx->h, msg, "{s:s}", "members", s) < 0)
-        flux_log_error (g->ctx->h, "error responding to groups.get request");
+    if (flux_respond_pack (g->ctx->h, msg, "{s:s}", "members", s) < 0) {
+        if (errno != ENOSYS) {
+            flux_log_error (g->ctx->h,
+                            "error responding to groups.get request");
+        }
+    }
     free (s);
     return 0;
 }
@@ -579,8 +583,10 @@ static void get_request_cb (flux_t *h,
     }
     return;
 error:
-    if (flux_respond_error (h, msg, errno, errmsg) < 0)
-        flux_log_error (h, "error responding to groups.get request");
+    if (flux_respond_error (h, msg, errno, errmsg) < 0) {
+        if (errno != ENOSYS)
+            flux_log_error (h, "error responding to groups.get request");
+    }
 }
 
 /* A client has disconnected.  Find any groups with a cached JOIN request

--- a/t/t2310-resource-module.t
+++ b/t/t2310-resource-module.t
@@ -34,6 +34,9 @@ get_topo() {
 res_reload() {
 	flux python -c "import flux; print(flux.Flux().rpc(\"resource.reload\",nodeid=$1).get())"
 }
+bad_reduce() {
+	flux python -c "import flux; print(flux.Flux().rpc(\"resource.topo-reduce\",nodeid=$1))"
+}
 
 test_expect_success 'load resource module with bad option fails' '
 	test_must_fail flux module load resource badoption
@@ -53,6 +56,9 @@ test_expect_success 'reload module on rank 2 to trigger dup topo-reduce' '
 test_expect_success 'load resource module on ranks 1,3' '
 	flux exec -r1 flux module load resource &&
 	flux exec -r3 flux module load resource
+'
+test_expect_success 'send bad topo-reduce request to rank 0' '
+	bad_reduce 0
 '
 
 test_expect_success HAVE_JQ 'resource.eventlog exists' '

--- a/t/valgrind/workload.d/job-info
+++ b/t/valgrind/workload.d/job-info
@@ -4,7 +4,7 @@ set -x
 
 # Test info fetch
 
-id=$(flux mini submit -t 1 -n 1 /bin/true)
+id=$(flux mini submit -n 1 /bin/true)
 flux job attach ${id}
 
 flux job info ${id} eventlog jobspec R >/dev/null


### PR DESCRIPTION
This addresses a fatal resource module error discovered by @grondo in #3946.  The error handling code in the `resource.topo-reduce` request handler was not quite correct with respect to handling (expected) duplicate requests.

Also, an earlier commit 66d55f32dfa7e7c132a9b57dfa2056d20415e1e4 was supposed to suppress ENOSYS errors from the `groups.get` RPC, but it handled  `groups.leave` only.  Fix that too.