### PR TITLE
job-exec: improve errors and job exception message on broker disconnect

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -224,6 +224,8 @@ MAN3_FILES_SECONDARY = \
 	man3/flux_rpc_get.3 \
 	man3/flux_rpc_get_unpack.3 \
 	man3/flux_rpc_get_raw.3 \
+	man3/flux_rpc_get_matchtag.3 \
+	man3/flux_rpc_get_nodeid.3 \
 	man3/flux_kvs_lookupat.3 \
 	man3/flux_kvs_lookup_get.3 \
 	man3/flux_kvs_lookup_get_unpack.3 \

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -286,6 +286,8 @@ man_pages = [
     ('man3/flux_rpc', 'flux_rpc_get_unpack', 'perform a remote procedure call to a Flux service', [author], 3),
     ('man3/flux_rpc', 'flux_rpc_get_raw', 'perform a remote procedure call to a Flux service', [author], 3),
     ('man3/flux_rpc', 'flux_rpc', 'perform a remote procedure call to a Flux service', [author], 3),
+    ('man3/flux_rpc', 'flux_rpc_get_matchtag', 'perform a remote procedure call to a Flux service', [author], 3),
+    ('man3/flux_rpc', 'flux_rpc_get_nodeid', 'perform a remote procedure call to a Flux service', [author], 3),
     ('man3/flux_send', 'flux_send', 'send message using Flux Message Broker', [author], 3),
     ('man3/flux_shell_add_completion_ref', 'flux_shell_remove_completion_ref', 'Manipulate conditions for job completion.', [author], 3),
     ('man3/flux_shell_add_completion_ref', 'flux_shell_add_completion_ref', 'Manipulate conditions for job completion.', [author], 3),

--- a/doc/man3/flux_rpc.rst
+++ b/doc/man3/flux_rpc.rst
@@ -47,6 +47,14 @@ SYNOPSIS
    int flux_rpc_get_raw (flux_future_t *f,
                          const void **data, int *len);
 
+::
+
+   uint32_t flux_rpc_get_matchtag (flux_future_t *f);
+
+::
+
+   uint32_t flux_rpc_get_nodeid (flux_future_t *f);
+
 
 DESCRIPTION
 ===========
@@ -73,6 +81,10 @@ decode the RPC result. Internally, they call ``flux_future_get()``
 to access the response message stored in the future. If the response
 message has not yet been received, these functions block until it is,
 or an error occurs.
+
+``flux_rpc_get_matchtag()`` and ``flux_rpc_get_nodeid()`` are accessors
+which allow access to the RPC matchtag and target nodeid from the
+future returned from ``flux_rpc(3)``.
 
 
 REQUEST OPTIONS
@@ -178,6 +190,13 @@ object on success. On error, NULL is returned, and errno is set appropriately.
 ``flux_rpc_get()``, ``flux_rpc_get_unpack()``, and ``flux_rpc_get_raw()`` return
 zero on success. On error, -1 is returned, and errno is set appropriately.
 
+``flux_rpc_get_matchtag()`` returns the matchtag allocated to the particular
+RPC request, or ``FLUX_MATCHTAG_NONE`` if no matchtag was allocated (e.g. no
+response is expected), or the future argument does not correspond to an RPC.
+
+``flux_rpc_get_nodeid()`` returns the original ``nodeid`` target of the
+``flux_rpc()`` request, including if the RPC was targetted to
+``FLUX_NODEID_ANY`` or ``FLUX_NODEID_UPSTREAM``.
 
 ERRORS
 ======

--- a/src/common/libflux/rpc.h
+++ b/src/common/libflux/rpc.h
@@ -52,6 +52,10 @@ int flux_rpc_get_raw (flux_future_t *f, const void **data, int *len);
  */
 uint32_t flux_rpc_get_matchtag (flux_future_t *f);
 
+/* Accessor for original nodeid target of flux_rpc()
+ */
+uint32_t flux_rpc_get_nodeid (flux_future_t *f);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/common/libflux/test/rpc.c
+++ b/src/common/libflux/test/rpc.c
@@ -299,6 +299,8 @@ void test_service (flux_t *h)
     r = flux_rpc (h, "rpctest.hello", NULL, FLUX_NODEID_ANY, 0);
     ok (r != NULL,
         "flux_rpc sent request to rpctest.hello service");
+    ok (flux_rpc_get_nodeid (r) == FLUX_NODEID_ANY,
+        "flux_rpc_get_nodeid works");
     ok (flux_matchtag_avail (h) == count - 1,
         "flux_rpc allocated one matchtag");
     msg = flux_recv (h, FLUX_MATCH_RESPONSE, 0);
@@ -930,6 +932,24 @@ void test_fake_server (void)
     flux_close (h);
 }
 
+static void test_rpc_get_nodeid (flux_t *h)
+{
+    flux_future_t *f;
+
+    errno = 0;
+    f = flux_rpc (h, "rpctest.hello", NULL, 0, 0);
+    ok (f != NULL,
+        "flux_rpc sent request to rpctest.hello service");
+    ok (flux_rpc_get_nodeid (f) == 0,
+        "flux_rpc_get_nodeid works");
+    ok (flux_future_get (f, NULL) == 0,
+        "flux_future_get works");
+    ok (flux_rpc_get_nodeid (f) == 0,
+        "flux_rpc_get_nodeid still works after future_get()");
+
+    flux_future_destroy (f);
+}
+
 static void fatal_err (const char *message, void *arg)
 {
     BAIL_OUT ("fatal error: %s", message);
@@ -969,6 +989,8 @@ int main (int argc, char *argv[])
 
     test_rpc_active_count (h);
     test_multi_rpc_active_count (h);
+
+    test_rpc_get_nodeid (h);
 
     ok (test_server_stop (h) == 0,
         "stopped test server thread");

--- a/src/common/libsubprocess/remote.c
+++ b/src/common/libsubprocess/remote.c
@@ -541,7 +541,10 @@ static int remote_state (flux_subprocess_t *p, flux_future_t *f,
     int status = 0;
 
     if (flux_rpc_get_unpack (f, "{ s:i }", "state", &state) < 0) {
-        flux_log_error (p->h, "%s: flux_rpc_get_unpack", __FUNCTION__);
+        flux_log_error (p->h,
+                        "%s: flux_rpc_get_unpack: rank %u",
+                        __FUNCTION__,
+                        flux_rpc_get_nodeid (f));
         return -1;
     }
 
@@ -648,7 +651,10 @@ static void remote_exec_cb (flux_future_t *f, void *arg)
     if (flux_rpc_get_unpack (f, "{ s:s s:i }",
                              "type", &type,
                              "rank", &rank) < 0) {
-        flux_log_error (p->h, "%s: flux_rpc_get_unpack", __FUNCTION__);
+        flux_log_error (p->h,
+                        "%s: flux_rpc_get_unpack: rank %u",
+                        __FUNCTION__,
+                        flux_rpc_get_nodeid (f));
         goto error;
     }
 
@@ -689,7 +695,10 @@ error:
     if (p->state == FLUX_SUBPROCESS_RUNNING) {
         flux_future_t *fkill;
         if (!(fkill = remote_kill (p, SIGKILL)))
-            flux_log_error (p->h, "%s: remote_kill", __FUNCTION__);
+            flux_log_error (p->h,
+                            "%s: remote_kill: rank %u",
+                            __FUNCTION__,
+                            flux_rpc_get_nodeid (fkill));
         else
             flux_future_destroy (fkill);
     }
@@ -710,7 +719,10 @@ static void remote_continuation_cb (flux_future_t *f, void *arg)
                              "type", &type,
                              "rank", &rank) < 0) {
         if (errno != EHOSTUNREACH) // broker is down, don't log
-            flux_log_error (p->h, "%s: flux_rpc_get_unpack", __FUNCTION__);
+            flux_log_error (p->h,
+                            "%s: flux_rpc_get_unpack: rank %u",
+                            __FUNCTION__,
+                            flux_rpc_get_nodeid (f));
         goto error;
     }
 

--- a/src/modules/job-exec/bulk-exec.h
+++ b/src/modules/job-exec/bulk-exec.h
@@ -66,6 +66,10 @@ int bulk_exec_start (flux_t *h, struct bulk_exec *exec);
 
 flux_future_t * bulk_exec_kill (struct bulk_exec *exec, int signal);
 
+/*  Log per-rank kill errors for a failed bulk_exec_kill() RPC.
+ */
+void bulk_exec_kill_log_error (flux_future_t *f, flux_jobid_t id);
+
 flux_future_t *bulk_exec_imp_kill (struct bulk_exec *exec,
                                    const char *imp_path,
                                    int signal);

--- a/src/modules/job-exec/exec.c
+++ b/src/modules/job-exec/exec.c
@@ -303,7 +303,7 @@ static void exec_kill_cb (flux_future_t *f, void *arg)
 {
     struct jobinfo *job = arg;
     if (flux_future_get (f, NULL) < 0 && errno != ENOENT)
-        flux_log_error (job->h, "%ju: exec_kill", (uintmax_t) job->id);
+        bulk_exec_kill_log_error (f, job->id);
     jobinfo_decref (job);
     flux_future_destroy (f);
 }

--- a/src/modules/job-exec/job-exec.c
+++ b/src/modules/job-exec/job-exec.c
@@ -248,6 +248,12 @@ static int jobid_exception (flux_t *h, flux_jobid_t id,
                                         strerror (errnum));
     else
         snprintf (note, sizeof (note), "%s", text ? text : "");
+
+    flux_log (h,
+              LOG_INFO,
+              "job-exception: id=%ju: %s",
+              (uintmax_t) id,
+              note);
     return flux_respond_pack (h, msg, "{s:I s:s s:{s:i s:s s:s}}",
                                       "id", id,
                                       "type", "exception",

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -263,6 +263,7 @@ dist_check_SCRIPTS = \
 	issues/t3775-binary-io.sh \
 	issues/t3920-running-underflow.sh \
 	issues/t3960-job-exec-ehostunreach.sh \
+	issues/t3906-job-exec-exception.sh \
 	python/__init__.py \
 	python/subflux.py \
 	python/tap \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -262,6 +262,7 @@ dist_check_SCRIPTS = \
 	issues/t3503-nofiles-limit.sh \
 	issues/t3775-binary-io.sh \
 	issues/t3920-running-underflow.sh \
+	issues/t3960-job-exec-ehostunreach.sh \
 	python/__init__.py \
 	python/subflux.py \
 	python/tap \

--- a/t/issues/t3906-job-exec-exception.sh
+++ b/t/issues/t3906-job-exec-exception.sh
@@ -1,0 +1,18 @@
+#!/bin/sh -e
+#
+#  Ensure a job exception is raised when broker rank disconnects
+#
+#  1. Submit job and ensure it has started
+#  2. Kill a leaf broker
+#  3. Ensure job exception is raised and includes appropriate error note
+#
+export startctl="flux python ${SHARNESS_TEST_SRCDIR}/scripts/startctl.py"
+SHELL=/bin/sh flux start -s 4 -o,-Stbon.fanout=4 --test-exit-mode=leader '\
+   id=$(flux mini submit -n4 -N4 sleep inf) \
+&& flux job wait-event $id start \
+&& $startctl kill 3 9 \
+&& flux job wait-event $id exception >t3906.output 2>&1'
+
+cat t3906.output
+
+grep 'lost contact with job shell on broker rank 3' t3906.output

--- a/t/issues/t3960-job-exec-ehostunreach.sh
+++ b/t/issues/t3960-job-exec-ehostunreach.sh
@@ -1,0 +1,27 @@
+#!/bin/sh -e
+#
+#  Trigger an EHOSTUNREACH error when attempting to kill a job.
+#
+#  1. Submit job and ensure it has started
+#  2. Send SIGSTOP to a leaf broker
+#  3. Cancel job and wait for exception to appear in job eventlog
+#  4. The subprocess kill RPC should now be sent to the stopped broker
+#  5. Kill the stopped broker with SIGKILL
+#  6. Wait for job clean event and dump logs
+#  7. Ensure killed rank appears in logs for exec_kill message
+#
+#
+export startctl="flux python ${SHARNESS_TEST_SRCDIR}/scripts/startctl.py"
+SHELL=/bin/sh flux start -s 4 -o,-Stbon.fanout=4 --test-exit-mode=leader '\
+   id=$(flux mini submit -n4 -N4 sleep inf) \
+&& flux job wait-event $id start \
+&& $startctl kill 3 19 \
+&& flux job cancel $id \
+&& flux job wait-event $id exception \
+&& $startctl kill 3 9 \
+&& flux job attach -vE $id \
+;  flux dmesg >t3960.output 2>&1'
+
+cat t3960.output
+
+grep 'exec_kill.*rank 3' t3960.output

--- a/t/t4000-issues-test-driver.t
+++ b/t/t4000-issues-test-driver.t
@@ -14,7 +14,11 @@ SIZE=4
 test_under_flux ${SIZE}
 echo "# $0: flux session size will be ${SIZE}"
 
-for testscript in ${FLUX_SOURCE_DIR}/t/issues/*; do
+if test -z "$T4000_ISSUES_GLOB"; then
+    T4000_ISSUES_GLOB="*"
+fi
+
+for testscript in ${FLUX_SOURCE_DIR}/t/issues/${T4000_ISSUES_GLOB}; do
     testname=`basename $testscript`
     prereqs=$(sed -n 's/^.*test-prereqs: \(.*\).*$/\1/gp' $testscript)
     test_expect_success  "$prereqs" $testname "run_timeout 120 $testscript"


### PR DESCRIPTION
As discussed in #3960, the remote execution and kill errors from the job-exec module do not include any rank information, which is unhelpful in diagnosing problems from logs alone.

This PR adds a `flux_rpc_get_nodeid(3)` API call to make it convenient to print the target rank in rpc errors, and uses this to add rank information to many remote subprocess and job-exec error messages.

I didn't go as far as caching the entire request for every RPC, since I didn't have a use case for anything other than the `nodeid` at this time, and was worried about the extra memory required when many, many RPCs are in flight in a client or module. For now, a `nodeid` field is added to the `struct flux_rpc` which simply caches the `nodeid` argument to `flux_rpc(3)`, making it conveniently available during error handling on the `flux_future_get(3)` or `flux_rpc_get(3)` side.


 