### PR TITLE
WIP: add broker.hostlist attribute

### DIFF
--- a/doc/man7/flux-broker-attributes.rst
+++ b/doc/man7/flux-broker-attributes.rst
@@ -190,7 +190,7 @@ hello.hwm
 CONFIG ATTRIBUTES
 =================
 
-config.hostlist
+broker.hostlist
    The rank-ordered hosts specified in the ``bootstrap`` section of
    the Flux configuration.  Hosts are listed in RFC29 hostlist format.
 

--- a/src/broker/boot_config.c
+++ b/src/broker/boot_config.c
@@ -277,10 +277,10 @@ int boot_config_attr (attr_t *attrs, json_t *hosts)
         goto error;
 
     if (attr_add (attrs,
-                  "config.hostlist",
+                  "broker.hostlist",
                   s,
                   FLUX_ATTRFLAG_IMMUTABLE) < 0) {
-        log_err ("attr_add config.hostlist %s", s);
+        log_err ("attr_add broker.hostlist %s", s);
         goto error;
     }
 

--- a/src/broker/test/boot_config.c
+++ b/src/broker/test/boot_config.c
@@ -466,9 +466,9 @@ void test_attr (const char *dir)
     ok (rc == 0,
         "boot_config_attr works NULL hosts");
     errno = 0;
-    ok (attr_get (attrs, "config.hostlist", NULL, NULL) < 0
+    ok (attr_get (attrs, "broker.hostlist", NULL, NULL) < 0
         && errno == ENOENT,
-        "attr_get cannot find config.hostlist after NULL hosts");
+        "attr_get cannot find broker.hostlist after NULL hosts");
 
     hosts = json_array ();
     if (hosts == NULL)
@@ -476,9 +476,9 @@ void test_attr (const char *dir)
     rc = boot_config_attr (attrs, hosts);
     ok (rc == 0,
         "boot_config_attr works empty hosts");
-    ok (attr_get (attrs, "config.hostlist", NULL, NULL) < 0
+    ok (attr_get (attrs, "broker.hostlist", NULL, NULL) < 0
         && errno == ENOENT,
-        "attr_get cannot find config.hostlist after hosts");
+        "attr_get cannot find broker.hostlist after hosts");
     json_decref (hosts);
     hosts = NULL;
 
@@ -491,7 +491,7 @@ void test_attr (const char *dir)
     rc = boot_config_attr (attrs, hosts);
     ok (rc == 0,
         "boot_config_attr works on input hosts");
-    ok (attr_get (attrs, "config.hostlist", &val, &flags) == 0
+    ok (attr_get (attrs, "broker.hostlist", &val, &flags) == 0
         && !strcmp (val, "foo[0,4,1-5,14,6-9]")
         && flags == FLUX_ATTRFLAG_IMMUTABLE,
         "attr_get returns correct value and flags");

--- a/src/cmd/builtin/overlay.c
+++ b/src/cmd/builtin/overlay.c
@@ -151,13 +151,13 @@ static struct hostlist *get_hostmap_attr (flux_t *h)
     const char *s;
     struct hostlist *hl;
 
-    if (!(s = flux_attr_get (h, "config.hostlist"))) {
+    if (!(s = flux_attr_get (h, "broker.hostlist"))) {
         if (errno != ENOENT)
-            log_err_exit ("error fetching config.hostlist attribute");
+            log_err_exit ("error fetching broker.hostlist attribute");
         return NULL;
     }
     if (!(hl = hostlist_decode (s)))
-        log_err_exit ("config.hostlist value could not be decoded");
+        log_err_exit ("broker.hostlist value could not be decoded");
     return hl;
 }
 

--- a/src/common/libflux/attr.h
+++ b/src/common/libflux/attr.h
@@ -11,6 +11,12 @@
 #ifndef _FLUX_CORE_ATTR_H
 #define _FLUX_CORE_ATTR_H
 
+#include "future.h"
+
+enum {
+    FLUX_ATTR_LEADER = 1,   // getattr/setattr/rmattr on the rank 0 broker
+};
+
 /* broker attributes
  *
  * Brokers have configuration attributes.
@@ -60,6 +66,20 @@ int flux_get_rank (flux_t *h, uint32_t *rank);
  * Returns 0 on success, or -1 on failure with errno set.
  */
 int flux_get_size (flux_t *h, uint32_t *size);
+
+
+/* Asynchronous get/set/rmattr functions that return futures.
+ * These functions do not update the cache.
+ */
+flux_future_t *flux_getattr (flux_t *h, const char *name, int flags);
+int flux_getattr_value (flux_future_t *f, const char **value);
+flux_future_t *flux_setattr (flux_t *h,
+                             const char *name,
+                             const char *value,
+                             int flags);
+flux_future_t *flux_rmattr (flux_t *h,
+                            const char *name,
+                            int flags);
 
 #ifdef __cplusplus
 }

--- a/src/modules/resource/inventory.c
+++ b/src/modules/resource/inventory.c
@@ -25,7 +25,7 @@
  * Case 1 (method=configuration)
  * -----------------------------
  * TOML config specifies [resource] path, pointing to R.  R is parsed
- * and is "re-ranked" if the 'config.hostlist' broker attribute defines a
+ * and is "re-ranked" if the 'broker.hostlist' broker attribute defines a
  * different mapping of ranks to hostnames.  (This attribute derives from the
  * [bootstrap] config, which we assume is the definitive mapping).
  *
@@ -336,7 +336,7 @@ static int convert_R_conf (flux_t *h, json_t *conf_R, json_t **Rp)
         errno = EINVAL;
         return -1;
     }
-    if ((hosts = flux_attr_get (h, "config.hostlist"))) {
+    if ((hosts = flux_attr_get (h, "broker.hostlist"))) {
         if (rlist_rerank (rl, hosts) < 0) { // sets errno
             flux_log (h, LOG_ERR, "error reranking R");
             goto error;

--- a/t/t0013-config-file.t
+++ b/t/t0013-config-file.t
@@ -108,7 +108,7 @@ test_expect_success 'create initial program for testing' '
 	cat <<-EOT >attrdump.sh &&
 	#!/bin/sh
 	flux getattr size
-	flux getattr config.hostlist
+	flux getattr broker.hostlist
 	EOT
 	chmod +x attrdump.sh
 '

--- a/t/t3300-system-basic.t
+++ b/t/t3300-system-basic.t
@@ -18,9 +18,9 @@ overlay_connected_children() {
 	flux python -c "import flux; print(flux.Flux().rpc(\"overlay.stats.get\",nodeid=0).get_str())" | jq -r '.["child-connected"]'
 }
 
-test_expect_success 'broker config.hostlist has fake hostlist' '
+test_expect_success 'broker broker.hostlist has fake hostlist' '
 	echo "fake[0-2]" >hostlist.exp &&
-	flux getattr config.hostlist >hostlist.out &&
+	flux getattr broker.hostlist >hostlist.out &&
 	test_cmp hostlist.exp hostlist.out
 '
 

--- a/t/t3303-system-healthcheck.t
+++ b/t/t3303-system-healthcheck.t
@@ -73,7 +73,7 @@ test_expect_success 'flux overlay status --hostnames fails on PMI instance witho
 '
 
 test_expect_success 'flux overlay status --hostnames fails on bad hostlist' '
-	test_must_fail flux start -o,-Sconfig.hostlist="[-badlist" \
+	test_must_fail flux start -o,-Sbroker.hostlist="[-badlist" \
 		flux overlay status -vvv --hostnames
 '
 

--- a/t/t3303-system-healthcheck.t
+++ b/t/t3303-system-healthcheck.t
@@ -65,18 +65,6 @@ test_expect_success 'flux overlay status --hostnames works on PMI instance' '
 	flux start flux overlay status -vvv --hostnames
 '
 
-test_expect_success 'flux overlay status --hostnames fails on PMI instance without R' '
-	test_must_fail flux start \
-		"flux kvs get --waitcreate resource.R && \
-		flux kvs unlink resource.R && \
-		flux overlay status -vvv --hostnames"
-'
-
-test_expect_success 'flux overlay status --hostnames fails on bad hostlist' '
-	test_must_fail flux start -o,-Sbroker.hostlist="[-badlist" \
-		flux overlay status -vvv --hostnames
-'
-
 test_expect_success 'overlay status is full' '
 	test "$(flux overlay status)" = "full"
 '


### PR DESCRIPTION
Following up on #3961, this renames the `config.hostlist` attribute to `broker.hostlist`, and has the resource module set it from _R_ if it is not already set by the broker config bootstrap.  Then `flux overlay` is converted to always use this instead of falling back to reading _R_ from the KVS.

We didn't have future-based libflux API calls for manipulating broker attributes so I refactored that code a little to add them.  I included a `flags` parameter which lets you optionally direct the operation to rank 0, which is helpful here because `broker.host` is only set on rank 0 when the resource module sets it.

This still feels a little half baked and some tests are needed so adding the WIP prefix.