### PR TITLE
broker: set hostlist attribute when Flux is boostrapped from PMI

### DIFF
--- a/doc/man7/flux-broker-attributes.rst
+++ b/doc/man7/flux-broker-attributes.rst
@@ -39,6 +39,9 @@ content.backing-path
    If file exists, its content is imported into the instance.
    If it doesn't exist, it is created.
 
+hostlist
+   An RFC29 hostlist in broker rank order.
+
 
 TOPOLOGY ATTRIBUTES
 ===================
@@ -185,14 +188,6 @@ hello.hwm
    The reduction high water mark for the broker wireup protocol,
    normally calculated based on the topology.
    Set to 0 to disable the high water mark.
-
-
-CONFIG ATTRIBUTES
-=================
-
-config.hostlist
-   The rank-ordered hosts specified in the ``bootstrap`` section of
-   the Flux configuration.  Hosts are listed in RFC29 hostlist format.
 
 
 RESOURCES

--- a/src/broker/boot_config.c
+++ b/src/broker/boot_config.c
@@ -277,10 +277,10 @@ int boot_config_attr (attr_t *attrs, json_t *hosts)
         goto error;
 
     if (attr_add (attrs,
-                  "config.hostlist",
+                  "hostlist",
                   s,
                   FLUX_ATTRFLAG_IMMUTABLE) < 0) {
-        log_err ("attr_add config.hostlist %s", s);
+        log_err ("attr_add hostlist %s", s);
         goto error;
     }
 

--- a/src/broker/test/boot_config.c
+++ b/src/broker/test/boot_config.c
@@ -466,9 +466,9 @@ void test_attr (const char *dir)
     ok (rc == 0,
         "boot_config_attr works NULL hosts");
     errno = 0;
-    ok (attr_get (attrs, "config.hostlist", NULL, NULL) < 0
+    ok (attr_get (attrs, "hostlist", NULL, NULL) < 0
         && errno == ENOENT,
-        "attr_get cannot find config.hostlist after NULL hosts");
+        "attr_get cannot find hostlist after NULL hosts");
 
     hosts = json_array ();
     if (hosts == NULL)
@@ -476,9 +476,9 @@ void test_attr (const char *dir)
     rc = boot_config_attr (attrs, hosts);
     ok (rc == 0,
         "boot_config_attr works empty hosts");
-    ok (attr_get (attrs, "config.hostlist", NULL, NULL) < 0
+    ok (attr_get (attrs, "hostlist", NULL, NULL) < 0
         && errno == ENOENT,
-        "attr_get cannot find config.hostlist after hosts");
+        "attr_get cannot find hostlist after hosts");
     json_decref (hosts);
     hosts = NULL;
 
@@ -491,7 +491,7 @@ void test_attr (const char *dir)
     rc = boot_config_attr (attrs, hosts);
     ok (rc == 0,
         "boot_config_attr works on input hosts");
-    ok (attr_get (attrs, "config.hostlist", &val, &flags) == 0
+    ok (attr_get (attrs, "hostlist", &val, &flags) == 0
         && !strcmp (val, "foo[0,4,1-5,14,6-9]")
         && flags == FLUX_ATTRFLAG_IMMUTABLE,
         "attr_get returns correct value and flags");

--- a/src/cmd/builtin/overlay.c
+++ b/src/cmd/builtin/overlay.c
@@ -151,13 +151,13 @@ static struct hostlist *get_hostmap_attr (flux_t *h)
     const char *s;
     struct hostlist *hl;
 
-    if (!(s = flux_attr_get (h, "config.hostlist"))) {
+    if (!(s = flux_attr_get (h, "hostlist"))) {
         if (errno != ENOENT)
-            log_err_exit ("error fetching config.hostlist attribute");
+            log_err_exit ("error fetching hostlist attribute");
         return NULL;
     }
     if (!(hl = hostlist_decode (s)))
-        log_err_exit ("config.hostlist value could not be decoded");
+        log_err_exit ("hostlist value could not be decoded");
     return hl;
 }
 

--- a/t/t0013-config-file.t
+++ b/t/t0013-config-file.t
@@ -108,7 +108,7 @@ test_expect_success 'create initial program for testing' '
 	cat <<-EOT >attrdump.sh &&
 	#!/bin/sh
 	flux getattr size
-	flux getattr config.hostlist
+	flux getattr hostlist
 	EOT
 	chmod +x attrdump.sh
 '

--- a/t/t3300-system-basic.t
+++ b/t/t3300-system-basic.t
@@ -18,9 +18,9 @@ overlay_connected_children() {
 	flux python -c "import flux; print(flux.Flux().rpc(\"overlay.stats.get\",nodeid=0).get_str())" | jq -r '.["child-connected"]'
 }
 
-test_expect_success 'broker config.hostlist has fake hostlist' '
+test_expect_success 'broker hostlist has fake hostlist' '
 	echo "fake[0-2]" >hostlist.exp &&
-	flux getattr config.hostlist >hostlist.out &&
+	flux getattr hostlist >hostlist.out &&
 	test_cmp hostlist.exp hostlist.out
 '
 

--- a/t/t3303-system-healthcheck.t
+++ b/t/t3303-system-healthcheck.t
@@ -73,7 +73,7 @@ test_expect_success 'flux overlay status --hostnames fails on PMI instance witho
 '
 
 test_expect_success 'flux overlay status --hostnames fails on bad hostlist' '
-	test_must_fail flux start -o,-Sconfig.hostlist="[-badlist" \
+	test_must_fail flux start -o,-Shostlist="[-badlist" \
 		flux overlay status -vvv --hostnames
 '
 

--- a/t/t3303-system-healthcheck.t
+++ b/t/t3303-system-healthcheck.t
@@ -65,13 +65,6 @@ test_expect_success 'flux overlay status --hostnames works on PMI instance' '
 	flux start flux overlay status -vvv --hostnames
 '
 
-test_expect_success 'flux overlay status --hostnames fails on PMI instance without R' '
-	test_must_fail flux start \
-		"flux kvs get --waitcreate resource.R && \
-		flux kvs unlink resource.R && \
-		flux overlay status -vvv --hostnames"
-'
-
 test_expect_success 'flux overlay status --hostnames fails on bad hostlist' '
 	test_must_fail flux start -o,-Shostlist="[-badlist" \
 		flux overlay status -vvv --hostnames


### PR DESCRIPTION
Problem: a single-user flux instance boostrapped from flux or a foreign launcher does not have a hostlist, which would be useful for logging as suggested in #3961.

This renames  the `config.hostlist` broker attribute to `hostlist` and removes an assumption in the resource module that a configured _R_ must be re-ranked if the attribute is present (really it should only be re-ranked if the `[bootstrap]` config table exists).

Then the `hostlist` attribute is set during PMI bootstrap by adding the hostname to each node's business card and reading all the business cards on each rank.

In this attempt, the hostlist is guaranteed to be set after the broker exists bootstrap, regardless of the bootstrap method, which makes it useful for logging during wire-up.

This is a revamp of PR #3963.

Labeled WIP pending performance testing.