### PR TITLE
testsuite: sanitize environment and fix hang in t2607-job-shell-input.t

### DIFF
--- a/t/sharness.d/flux-sharness.sh
+++ b/t/sharness.d/flux-sharness.sh
@@ -375,4 +375,9 @@ fi
 for var in $(env | grep ^PMI); do unset ${var%%=*}; done
 for var in $(env | grep ^SLURM); do unset ${var%%=*}; done
 
+# Sanitize Flux environment variables that should not be inherited by
+#  tests
+unset FLUX_SHELL_RC_PATH
+unset FLUX_RC_EXTRA
+
 # vi: ts=4 sw=4 expandtab


### PR DESCRIPTION
Just a couple small testsuite fixes in one PR.

This PR unsets `FLUX_RC_EXTRA` and `FLUX_SHELL_RC_PATH` for all sharness tests since these variables from the environment could interfere with test reproducibility.

Also improve a couple flaky tests in `t2607-job-shell-input.t`. The main improvement is more efficient submission of duplicate jobs and addition of a timeout, which _should_ turn the hangs we sometimes see in CI into hard failures (at which point we could investigate further)
