### PR TITLE
add flux_get_hostbyrank() and improve caching of broker attributes

### DIFF
--- a/src/broker/attr.c
+++ b/src/broker/attr.c
@@ -324,6 +324,21 @@ const char *attr_next (attr_t *attrs)
     return e ? e->name : NULL;
 }
 
+int attr_cache_immutables (attr_t *attrs, flux_t *h)
+{
+    struct entry *e;
+
+    e = zhash_first (attrs->hash);
+    while (e) {
+        if ((e->flags & FLUX_ATTRFLAG_IMMUTABLE)) {
+            if (flux_attr_set_cacheonly (h, e->name, e->val) < 0)
+                return -1;
+        }
+        e = zhash_next (attrs->hash);
+    }
+    return 0;
+}
+
 /**
  ** Service
  **/

--- a/src/broker/attr.h
+++ b/src/broker/attr.h
@@ -80,6 +80,10 @@ int attr_add_active_uint32 (attr_t *attrs, const char *name, uint32_t *val,
 const char *attr_first (attr_t *attrs);
 const char *attr_next (attr_t *attrs);
 
+/* Cache all immutable attributes present in attrs at this point in time.
+ */
+int attr_cache_immutables (attr_t *attrs, flux_t *h);
+
 #endif /* BROKER_ATTR_H */
 
 /*

--- a/src/broker/boot_config.c
+++ b/src/broker/boot_config.c
@@ -280,7 +280,7 @@ int boot_config_attr (attr_t *attrs, json_t *hosts)
                   "hostlist",
                   s,
                   FLUX_ATTRFLAG_IMMUTABLE) < 0) {
-        log_err ("attr_add hostlist %s", s);
+        log_err ("failed to set hostlist attribute to config derived value");
         goto error;
     }
 

--- a/src/broker/boot_pmi.c
+++ b/src/broker/boot_pmi.c
@@ -401,7 +401,7 @@ done:
     if (!(s = hostlist_encode (hl)))
         goto error;
     if (attr_add (attrs, "hostlist", s, FLUX_ATTRFLAG_IMMUTABLE) < 0) {
-        log_err ("attr_add hostlist %s", s);
+        log_err ("failed to set hostlist attribute to PMI-derived value");
         free (s);
         goto error;
     }

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -429,7 +429,10 @@ int main (int argc, char *argv[])
      */
     if (ctx.verbose > 1)
         log_msg ("initializing modules");
-    modhash_initialize (ctx.modhash, ctx.h, overlay_get_uuid (ctx.overlay));
+    modhash_initialize (ctx.modhash,
+                        ctx.h,
+                        overlay_get_uuid (ctx.overlay),
+                        ctx.attrs);
 
     /* Configure broker state machine
      */

--- a/src/broker/module.h
+++ b/src/broker/module.h
@@ -28,7 +28,10 @@ typedef void (*module_status_cb_f)(module_t *p, int prev_status, void *arg);
 modhash_t *modhash_create (void);
 void modhash_destroy (modhash_t *mh);
 
-void modhash_initialize (modhash_t *mh, flux_t *h, const char *uuid);
+void modhash_initialize (modhash_t *mh,
+                         flux_t *h,
+                         const char *uuid,
+                         attr_t *attrs);
 
 /* Prepare module at 'path' for starting.
  */

--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -374,7 +374,8 @@ void overlay_log_idle_children (struct overlay *ov)
                     if (!child->idle) {
                         flux_log (ov->h,
                                   LOG_ERR,
-                                  "child %lu idle for %s",
+                        "broker on %s (rank %lu) has been unresponsive for %s",
+                                  flux_get_hostbyrank (ov->h, child->rank),
                                   (unsigned long)child->rank,
                                   fsd);
                         child->idle = true;
@@ -384,7 +385,8 @@ void overlay_log_idle_children (struct overlay *ov)
                     if (child->idle) {
                         flux_log (ov->h,
                                   LOG_ERR,
-                                  "child %lu no longer idle",
+                                  "broker on %s (rank %lu) is responsive now",
+                                  flux_get_hostbyrank (ov->h, child->rank),
                                   (unsigned long)child->rank);
                         child->idle = false;
                     }

--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -963,7 +963,10 @@ static void parent_cb (flux_reactor_t *r, flux_watcher_t *w,
                 logdrop (ov, OVERLAY_UPSTREAM, msg, "malformed keepalive");
             }
             else if (ktype == KEEPALIVE_DISCONNECT) {
-                flux_log (ov->h, LOG_ERR, "parent disconnect");
+                flux_log (ov->h, LOG_CRIT,
+                          "%s (rank %lu) sent disconnect control message",
+                          flux_get_hostbyrank (ov->h, ov->parent.rank),
+                          (unsigned long)ov->parent.rank);
                 (void)zsock_disconnect (ov->parent.zsock, "%s", ov->parent.uri);
                 ov->parent.offline = true;
                 rpc_track_purge (ov->parent.tracker, fail_parent_rpc, ov);

--- a/src/broker/test/overlay.c
+++ b/src/broker/test/overlay.c
@@ -670,6 +670,8 @@ int main (int argc, char *argv[])
         BAIL_OUT ("loopback_create failed");
     if (flux_attr_set_cacheonly (h, "rank", "0") < 0)
         BAIL_OUT ("flux_attr_set_cacheonly rank failed");
+    if (flux_attr_set_cacheonly (h, "hostlist", "test") < 0)
+        BAIL_OUT ("flux_attr_set_cacheonly hostlist failed");
     flux_log_set_redirect (h, diag_logger, NULL);
     flux_log (h, LOG_INFO, "test log message");
 

--- a/src/common/libflux/attr.h
+++ b/src/common/libflux/attr.h
@@ -61,6 +61,11 @@ int flux_get_rank (flux_t *h, uint32_t *rank);
  */
 int flux_get_size (flux_t *h, uint32_t *size);
 
+/* Look up hostname of broker rank, by consulting "hostlist" attribute.
+ * This function always returns a printable string, though it may be "(null)".
+ */
+const char *flux_get_hostbyrank (flux_t *h, uint32_t rank);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/common/libflux/test/attr.c
+++ b/src/common/libflux/test/attr.c
@@ -25,12 +25,14 @@ struct entry {
     int flags;
 };
 
+// FLUX_ATTRFLAG_IMMUTABLE = 1
 static struct entry hardwired[] = {
     { .key = "cow",     .val = "moo",   .flags = 1 },
     { .key = "duck",    .val = "quack", .flags = 1 },
     { .key = "chick",   .val = "peep",  .flags = 1  },
     { .key = "fox",     .val = "-",     .flags = 1  },
     { .key = "bear",    .val = "roar",  .flags = 1  },
+    { .key = "hostlist", .val = "foo[0-2]", .flags = 1 },
     { .key = NULL,      .val = NULL,    .flags = 1  },
 };
 
@@ -284,6 +286,23 @@ int main (int argc, char *argv[])
     errno = 0;
     ok (flux_attr_set_cacheonly (h, NULL, "bar") < 0 && errno == EINVAL,
         "flux_attr_set_cacheonly name=NULL fails with EINVAL");
+
+    /* test flux_get_hostbyrank () */
+    ok ((value = flux_get_hostbyrank (NULL, 42)) != NULL
+        && !strcmp (value, "(null)"),
+        "flux_get_hostbyrank h=NULL returns (null)");
+    ok ((value = flux_get_hostbyrank (h, FLUX_NODEID_ANY)) != NULL
+        && !strcmp (value, "any"),
+        "flux_get_hostbyrank FLUX_NODEID_ANY returns any");
+    ok ((value = flux_get_hostbyrank (h, FLUX_NODEID_UPSTREAM)) != NULL
+        && !strcmp (value, "upstream"),
+        "flux_get_hostbyrank FLUX_NODEID_UPSTREAMreturns upstream");
+    ok ((value = flux_get_hostbyrank (h, 2)) != NULL
+        && !strcmp (value, "foo2"),
+        "flux_get_hostbyrank 2 returns foo2");
+    ok ((value = flux_get_hostbyrank (h, 3)) != NULL
+        && !strcmp (value, "(null)"),
+        "flux_get_hostbyrank 3 returns (null)");
 
     test_server_stop (h);
     flux_close (h);

--- a/src/modules/job-exec/bulk-exec.c
+++ b/src/modules/job-exec/bulk-exec.c
@@ -476,11 +476,14 @@ void bulk_exec_kill_log_error (flux_future_t *f, flux_jobid_t id)
     const char *name = flux_future_first_child (f);
     while (name) {
         flux_future_t *cf = flux_future_get_child (f, name);
-        if (flux_future_get (cf, NULL) < 0)
+        if (flux_future_get (cf, NULL) < 0) {
+            uint32_t rank = flux_rpc_get_nodeid (cf);
             flux_log_error (h,
-                            "%ju: exec_kill: rank %u",
+                            "%ju: exec_kill: %s (rank %lu)",
                             (uintmax_t) id,
-                            flux_rpc_get_nodeid (cf));
+                            flux_get_hostbyrank (h, rank),
+                            (unsigned long)rank);
+        }
         name = flux_future_next_child (f);
     }
 }

--- a/src/modules/job-exec/exec.c
+++ b/src/modules/job-exec/exec.c
@@ -164,6 +164,8 @@ static void error_cb (struct bulk_exec *exec, flux_subprocess_t *p, void *arg)
     struct jobinfo *job = arg;
     flux_cmd_t *cmd = flux_subprocess_get_cmd (p);
     int errnum = flux_subprocess_fail_errno (p);
+    int rank = flux_subprocess_rank (p);
+    const char *hostname = flux_get_hostbyrank (job->h, rank);
 
     /*  cmd may be NULL here if exec implementation failed to
      *   create flux_cmd_t
@@ -179,15 +181,17 @@ static void error_cb (struct bulk_exec *exec, flux_subprocess_t *p, void *arg)
 
         jobinfo_fatal_error (job,
                              errnum,
-                             "%s on broker rank %d",
+                             "%s on broker %s (rank %d)",
                              errmsg,
-                             flux_subprocess_rank (p));
+                             hostname,
+                             rank);
     }
     else
         jobinfo_fatal_error (job,
                              flux_subprocess_fail_errno (p),
-                             "job shell exec error on rank %d",
-                             flux_subprocess_rank (p));
+                             "job shell exec error on %s (rank %d)",
+                             hostname,
+                             rank);
 }
 
 static struct bulk_exec_ops exec_ops = {

--- a/t/issues/t3906-job-exec-exception.sh
+++ b/t/issues/t3906-job-exec-exception.sh
@@ -15,4 +15,4 @@ SHELL=/bin/sh flux start -s 4 -o,-Stbon.fanout=4 --test-exit-mode=leader '\
 
 cat t3906.output
 
-grep 'lost contact with job shell on broker rank 3' t3906.output
+grep 'lost contact with job shell on broker.*rank 3' t3906.output

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -249,8 +249,8 @@ test_expect_success 'flux-start dies gracefully when run from removed dir' '
 # too slow under ASAN
 test_expect_success NO_ASAN 'test_under_flux works' '
 	echo >&2 "$(pwd)" &&
-        mkdir -p test-under-flux && (
-        cd test-under-flux &&
+	mkdir -p test-under-flux && (
+	cd test-under-flux &&
 	SHARNESS_TEST_DIRECTORY=`pwd` &&
 	export SHARNESS_TEST_SRCDIR SHARNESS_TEST_DIRECTORY FLUX_BUILD_DIR debug &&
 	run_timeout 10 "$SHARNESS_TEST_SRCDIR"/test-under-flux/test.t --verbose --debug >out 2>err
@@ -259,8 +259,8 @@ test_expect_success NO_ASAN 'test_under_flux works' '
 '
 
 test_expect_success NO_ASAN 'test_under_flux fails if loaded modules are not unloaded' '
-        mkdir -p test-under-flux && (
-        cd test-under-flux &&
+	mkdir -p test-under-flux && (
+	cd test-under-flux &&
 	SHARNESS_TEST_DIRECTORY=`pwd` &&
 	export SHARNESS_TEST_SRCDIR SHARNESS_TEST_DIRECTORY FLUX_BUILD_DIR debug &&
 	test_expect_code 1 "$SHARNESS_TEST_SRCDIR"/test-under-flux/t_modcheck.t 2>err.modcheck \
@@ -300,8 +300,8 @@ test_expect_success 'tbon.parent-endpoint cannot be read on rank 0' '
 	test_must_fail flux start ${ARGS} -s2 flux getattr tbon.parent-endpoint
 '
 test_expect_success 'tbon.parent-endpoint can be read on not rank 0' '
-       NUM=`flux start ${ARGS} -s4 flux exec -n flux getattr tbon.parent-endpoint | grep ipc | wc -l` &&
-       test $NUM -eq 3
+	NUM=`flux start ${ARGS} -s4 flux exec -n flux getattr tbon.parent-endpoint | grep ipc | wc -l` &&
+	test $NUM -eq 3
 '
 test_expect_success 'flux start (singlton) cleans up rundir' '
 	flux start ${ARGS} \
@@ -499,30 +499,30 @@ test_expect_success 'flux-help command can display manpages for api calls' '
 '
 missing_man_code()
 {
-        man notacommand >/dev/null 2>&1
-        echo $?
+	man notacommand >/dev/null 2>&1
+	echo $?
 }
 test_expect_success 'flux-help returns nonzero exit code from man(1)' '
-        test_expect_code $(missing_man_code) \
-                         eval FLUX_IGNORE_NO_DOCS=y flux help notacommand
+	test_expect_code $(missing_man_code) \
+		eval FLUX_IGNORE_NO_DOCS=y flux help notacommand
 '
 test_expect_success 'flux appends colon to missing or unset MANPATH' '
-      (unset MANPATH && flux /usr/bin/printenv | grep "MANPATH=.*:$") &&
-      MANPATH= flux /usr/bin/printenv | grep "MANPATH=.*:$"
+	(unset MANPATH && flux /usr/bin/printenv | grep "MANPATH=.*:$") &&
+	MANPATH= flux /usr/bin/printenv | grep "MANPATH=.*:$"
 '
 test_expect_success 'flux deduplicates FLUX_RC_EXTRA & FLUX_SHELL_RC_PATH' '
-    FLUX_RC_EXTRA=/foo:/bar:/foo \
-        flux /usr/bin/printenv FLUX_RC_EXTRA | grep "^/foo:/bar$" &&
-    FLUX_SHELL_RC_PATH=/foo:/bar:/foo \
-        flux /usr/bin/printenv FLUX_SHELL_RC_PATH | grep "^/foo:/bar$"
+	FLUX_RC_EXTRA=/foo:/bar:/foo \
+		flux /usr/bin/printenv FLUX_RC_EXTRA | grep "^/foo:/bar$" &&
+	FLUX_SHELL_RC_PATH=/foo:/bar:/foo \
+		flux /usr/bin/printenv FLUX_SHELL_RC_PATH | grep "^/foo:/bar$"
 '
 test_expect_success 'builtin test_size_large () works' '
-    size=$(test_size_large)  &&
-    test -n "$size" &&
-    size=$(FLUX_TEST_SIZE_MAX=2 test_size_large) &&
-    test "$size" = "2" &&
-    size=$(FLUX_TEST_SIZE_MIN=12345 FLUX_TEST_SIZE_MAX=23456 test_size_large) &&
-    test "$size" = "12345"
+	size=$(test_size_large)  &&
+	test -n "$size" &&
+	size=$(FLUX_TEST_SIZE_MAX=2 test_size_large) &&
+	test "$size" = "2" &&
+	size=$(FLUX_TEST_SIZE_MIN=12345 FLUX_TEST_SIZE_MAX=23456 test_size_large) &&
+	test "$size" = "12345"
 '
 
 waitfile=${SHARNESS_TEST_SRCDIR}/scripts/waitfile.lua
@@ -552,7 +552,7 @@ test_expect_success 'scripts/waitfile works after 1s' '
 	-- Wait 250ms and create file, at .5s write a line, at 1.1s write pattern:
 	f:timer{ timeout = 250,
 	         handler = function () tf = io.open ("waitfile.test.3", "w") end
-               }
+	       }
 	f:timer{ timeout = 500,
 	         handler = function () tf:write ("line one"); tf:flush()  end
 	       }
@@ -570,9 +570,9 @@ test_expect_success 'instance can stop cleanly with subscribers (#1025)' '
 
 # test for issue #1191
 test_expect_success 'passing NULL to flux_log functions logs to stderr (#1191)' '
-        ${FLUX_BUILD_DIR}/t/loop/logstderr > std.out 2> std.err &&
-        grep "warning: hello" std.err &&
-        grep "err: world: No such file or directory" std.err
+	${FLUX_BUILD_DIR}/t/loop/logstderr > std.out 2> std.err &&
+	grep "warning: hello" std.err &&
+	grep "err: world: No such file or directory" std.err
 '
 
 # tests for issue #3925
@@ -665,11 +665,11 @@ terminus \
 
 test_cmd_help ()
 {
-    local rc=0
-    for cmd in ${CMDS}; do
-        flux ${cmd} --help 2>&1 | grep -i usage || rc=1
-    done
-    return ${rc}
+	local rc=0
+	for cmd in ${CMDS}; do
+		flux ${cmd} --help 2>&1 | grep -i usage || rc=1
+	done
+	return ${rc}
 }
 
 KVS_SUBCMDS="\
@@ -679,17 +679,17 @@ eventlog \
 
 test_kvs_subcmd_help ()
 {
-    local rc=0
-    for subcmd in ${KVS_SUBCMDS}; do
-        flux kvs ${subcmd} --help 2>&1 | grep -i usage || rc=1
-    done
-    return ${rc}
+	local rc=0
+	for subcmd in ${KVS_SUBCMDS}; do
+		flux kvs ${subcmd} --help 2>&1 | grep -i usage || rc=1
+	done
+	return ${rc}
 }
 
 test_expect_success 'command --help works outside of flux instance' '
-        flux --help 2>&1 | grep -i usage &&
-        test_cmd_help &&
-        test_kvs_subcmd_help
+	flux --help 2>&1 | grep -i usage &&
+	test_cmd_help &&
+	test_kvs_subcmd_help
 '
 
 # Note: flux-start auto-removes rundir

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -303,6 +303,23 @@ test_expect_success 'tbon.parent-endpoint can be read on not rank 0' '
 	NUM=`flux start ${ARGS} -s4 flux exec -n flux getattr tbon.parent-endpoint | grep ipc | wc -l` &&
 	test $NUM -eq 3
 '
+
+test_expect_success 'hostlist attr is set on size 1 instance' '
+	hn=$(hostname) &&
+	cat >hostlist1.exp <<-EOT &&
+	$hn
+	EOT
+	flux start ${ARGS} flux exec flux getattr hostlist >hostlist1.out &&
+	test_cmp hostlist1.exp hostlist1.out
+'
+test_expect_success 'hostlist attr is set on all ranks of size 4 instance' '
+	flux start ${ARGS} -s4 flux exec flux getattr hostlist
+'
+test_expect_success 'setting hostlist on command line fails' '
+	test_must_fail flux start ${ARGS} -o,-Shostlist=xxx 2>hostlist.err &&
+	grep "failed to set hostlist attribute" hostlist.err
+'
+
 test_expect_success 'flux start (singlton) cleans up rundir' '
 	flux start ${ARGS} \
 		flux getattr rundir >rundir_pmi.out &&

--- a/t/t3303-system-healthcheck.t
+++ b/t/t3303-system-healthcheck.t
@@ -65,11 +65,6 @@ test_expect_success 'flux overlay status --hostnames works on PMI instance' '
 	flux start flux overlay status -vvv --hostnames
 '
 
-test_expect_success 'flux overlay status --hostnames fails on bad hostlist' '
-	test_must_fail flux start -o,-Shostlist="[-badlist" \
-		flux overlay status -vvv --hostnames
-'
-
 test_expect_success 'overlay status is full' '
 	test "$(flux overlay status)" = "full"
 '


### PR DESCRIPTION
Now that the broker `hostlist` attribute is always set, add a function for translating a broker rank to hostname, and use it to make a few log messages more useful.

This also makes a small change to the broker so that "immutable" broker attributes like `hostlist` are automatically cached in the broker flux_t handle and in all the module flux_t handles.   In other contexts, `flux_get_hostbyrank()` might make an RPC on the first call to fetch the hostlist attribute.