### PR TITLE
flux-overlay status: rework options

### DIFF
--- a/src/cmd/builtin/overlay.c
+++ b/src/cmd/builtin/overlay.c
@@ -42,9 +42,6 @@ static struct optparse_option status_opts[] = {
     { .name = "timeout", .key = 't', .has_arg = 1, .arginfo = "FSD",
       .usage = "Set RPC timeout (default none)",
     },
-    { .name = "hostnames", .key = 'H', .has_arg = 0,
-      .usage = "Display hostnames instead of ranks",
-    },
     { .name = "times", .key = 'T', .has_arg = 0,
       .usage = "Show round trip RPC times",
     },
@@ -184,22 +181,17 @@ static const char *status_indent (struct status *ctx, int n)
     return buf;
 }
 
-/* Return string containing the "best" name for node.
- * If --hostnames, look up the hostname.
- * Otherwise, just make a string out of the rank.
+/* Return string containing hostname and rank.
  */
 static const char *status_getname (struct status *ctx, int rank)
 {
     static char buf[128];
-    struct hostlist *hl;
-    const char *s;
 
-    if (optparse_hasopt (ctx->opt, "hostnames")
-        && (hl = get_hostmap (ctx->h))
-        && (s = hostlist_nth (hl, rank)) != NULL)
-        snprintf (buf, sizeof (buf), "%s", s);
-    else
-        snprintf (buf, sizeof (buf), "%d", rank);
+    snprintf (buf,
+              sizeof (buf),
+              "%d %s",
+              rank,
+              flux_get_hostbyrank (ctx->h, rank));
     return buf;
 }
 

--- a/t/t3300-system-basic.t
+++ b/t/t3300-system-basic.t
@@ -33,7 +33,7 @@ test_expect_success HAVE_JQ 'broker overlay shows 2 connected children' '
 '
 
 test_expect_success 'overlay status is full' '
-	test "$(flux overlay status)" = "full"
+	test "$(flux overlay status --summary)" = "full"
 '
 
 test_expect_success 'kill broker rank=2 with SIGTERM like systemd stop' '
@@ -54,7 +54,7 @@ test_expect_success HAVE_JQ 'broker overlay shows 1 connected child' '
 '
 
 test_expect_success 'wait for overlay status to be partial' '
-	flux overlay status --wait partial --timeout 10s
+	run_timeout 10 flux overlay status --summary --wait partial
 '
 
 test_expect_success 'run broker rank=2' '
@@ -62,7 +62,7 @@ test_expect_success 'run broker rank=2' '
 '
 
 test_expect_success 'wait for overlay status to be full' '
-	flux overlay status --wait full --timeout 10s
+	run_timeout 10 flux overlay status --summary --wait full
 '
 
 test_expect_success 'flux exec over all ranks works' '
@@ -80,7 +80,7 @@ test_expect_success 'ping to rank 2 fails' '
 '
 
 test_expect_success 'wait for overlay status to be degraded' '
-	flux overlay status --wait degraded --timeout 10s
+	run_timeout 10 flux overlay status --summary --wait degraded
 '
 
 test_expect_success 'run broker rank=2' '
@@ -88,7 +88,7 @@ test_expect_success 'run broker rank=2' '
 '
 
 test_expect_success 'wait for subtree to be full' '
-	flux overlay status --wait full --timeout 10s
+	run_timeout 10 flux overlay status --summary --wait full
 '
 
 test_expect_success 'run broker rank=2 again fails' '

--- a/t/t3301-system-latestart.t
+++ b/t/t3301-system-latestart.t
@@ -31,7 +31,7 @@ test_expect_success HAVE_JQ 'startctl shows rank 1 pids as -1' '
 '
 
 test_expect_success 'overlay status is partial' '
-        test "$(flux overlay status)" = "partial"
+        test "$(flux overlay status --summary)" = "partial"
 '
 
 test_expect_success 'resource list shows one down nodes' '

--- a/t/t3303-system-healthcheck.t
+++ b/t/t3303-system-healthcheck.t
@@ -61,10 +61,6 @@ test_expect_success 'flux overlay fails on bad subcommand' '
 	test_must_fail flux overlay notcommand
 '
 
-test_expect_success 'flux overlay status --hostnames works on PMI instance' '
-	flux start flux overlay status -vvv --hostnames
-'
-
 test_expect_success 'overlay status is full' '
 	test "$(flux overlay status)" = "full"
 '
@@ -91,11 +87,11 @@ test_expect_success HAVE_JQ 'wait for rank 1 to lose connection with rank 3' '
 '
 
 test_expect_success 'flux overlay status -vv and gaudy options works' '
-	flux overlay status -vv --pretty --times --hostnames --ghost
+	flux overlay status -vv --pretty --times --ghost
 '
 
 test_expect_success 'flux overlay status -v shows rank 3 offline' '
-	echo "3: offline" >health_v.exp &&
+	echo "3 fake3: offline" >health_v.exp &&
 	flux overlay status -v >health_v.out &&
 	test_cmp health_v.exp health_v.out
 '
@@ -114,9 +110,9 @@ test_expect_success 'flux overlay status -vvv --ghost --color' '
 
 test_expect_success 'flux overlay status -vv: 0,1:partial, 3:offline' '
 	cat >health_vv.exp <<-EOT &&
-	0: partial
-	1: partial
-	3: offline
+	0 fake0: partial
+	1 fake1: partial
+	3 fake3: offline
 	EOT
 	flux overlay status -vv >health_vv.out &&
 	test_cmp health_vv.exp health_vv.out
@@ -124,11 +120,11 @@ test_expect_success 'flux overlay status -vv: 0,1:partial, 3:offline' '
 
 test_expect_success 'flux overlay status -vvg: 0-1:partial, 3,7-8:offline' '
 	cat >health_vvg.exp <<-EOT &&
-	0: partial
-	1: partial
-	3: offline
-	7: offline
-	8: offline
+	0 fake0: partial
+	1 fake1: partial
+	3 fake3: offline
+	7 fake7: offline
+	8 fake8: offline
 	EOT
 	flux overlay status -vvg >health_vvg.out &&
 	test_cmp health_vvg.exp health_vvg.out
@@ -136,21 +132,21 @@ test_expect_success 'flux overlay status -vvg: 0-1:partial, 3,7-8:offline' '
 
 test_expect_success 'flux overlay status -vvvg: 0,1:partial, 3,7-8:offline, rest:full' '
 	cat >health_vvvg.exp <<-EOT &&
-	0: partial
-	1: partial
-	3: offline
-	7: offline
-	8: offline
-	4: full
-	9: full
-	10: full
-	2: full
-	5: full
-	11: full
-	12: full
-	6: full
-	13: full
-	14: full
+	0 fake0: partial
+	1 fake1: partial
+	3 fake3: offline
+	7 fake7: offline
+	8 fake8: offline
+	4 fake4: full
+	9 fake9: full
+	10 fake10: full
+	2 fake2: full
+	5 fake5: full
+	11 fake11: full
+	12 fake12: full
+	6 fake6: full
+	13 fake13: full
+	14 fake14: full
 	EOT
 	flux overlay status -vvvg >health_vvvg.out &&
 	test_cmp health_vvvg.exp health_vvvg.out

--- a/t/t3303-system-healthcheck.t
+++ b/t/t3303-system-healthcheck.t
@@ -54,7 +54,7 @@ test_expect_success 'overlay.topology RPC with bad rank fails' '
 '
 
 test_expect_success 'flux overlay status fails on bad rank' '
-	test_must_fail flux overlay status --rank 99
+	test_must_fail flux overlay status --summary --rank 99
 '
 
 test_expect_success 'flux overlay fails on bad subcommand' '
@@ -62,13 +62,7 @@ test_expect_success 'flux overlay fails on bad subcommand' '
 '
 
 test_expect_success 'overlay status is full' '
-	test "$(flux overlay status)" = "full"
-'
-
-test_expect_success 'flux overlay status -v prints full' '
-	echo full >health.exp &&
-	flux overlay status -v >health.out &&
-	test_cmp health.exp health.out
+	test "$(flux overlay status --summary)" = "full"
 '
 
 test_expect_success 'stop broker 3 with children 7,8' '
@@ -76,7 +70,7 @@ test_expect_success 'stop broker 3 with children 7,8' '
 '
 
 test_expect_success 'wait for rank 0 overlay status to be partial' '
-	flux overlay status --rank 0 --wait=partial --timeout=10s
+	run_timeout 10 flux overlay status --rank 0 --summary --wait=partial
 '
 
 # Just because rank 0 is partial doesn't mean rank 3 is offline yet
@@ -86,70 +80,60 @@ test_expect_success HAVE_JQ 'wait for rank 1 to lose connection with rank 3' '
 	wait_connected 1 1 10 0.2
 '
 
-test_expect_success 'flux overlay status -vv and gaudy options works' '
-	flux overlay status -vv --pretty --times --ghost
+test_expect_success 'flux overlay status -vv works' '
+	flux overlay status -vv
 '
 
-test_expect_success 'flux overlay status -v shows rank 3 offline' '
-	echo "3 fake3: offline" >health_v.exp &&
-	flux overlay status -v >health_v.out &&
-	test_cmp health_v.exp health_v.out
+test_expect_success 'flux overlay status shows rank 3 offline' '
+	echo "3 fake3: offline" >health.exp &&
+	flux overlay status --no-pretty --no-color | grep fake3 >health.out &&
+	test_cmp health.exp health.out
 '
 
-test_expect_success 'flux overlay status -v --ghost --color' '
-	flux overlay status -v --ghost --color
+test_expect_success 'flux overlay status --summary' '
+	flux overlay status --summary
 '
 
-test_expect_success 'flux overlay status -vv --ghost --color' '
-	flux overlay status -vv --ghost --color
+test_expect_success 'flux overlay status --down' '
+	flux overlay status --down
 '
 
-test_expect_success 'flux overlay status -vvv --ghost --color' '
-	flux overlay status -vvv --ghost --color
+test_expect_success 'flux overlay status -vv' '
+	flux overlay status -vv
 '
 
-test_expect_success 'flux overlay status -vv: 0,1:partial, 3:offline' '
-	cat >health_vv.exp <<-EOT &&
-	0 fake0: partial
-	1 fake1: partial
-	3 fake3: offline
-	EOT
-	flux overlay status -vv >health_vv.out &&
-	test_cmp health_vv.exp health_vv.out
+test_expect_success 'flux overlay status: 0,1:partial, 3:offline' '
+	flux overlay status --no-color --no-pretty  >health2.out &&
+	grep "0 fake0: partial" health2.out &&
+	grep "1 fake1: partial" health2.out &&
+	grep "3 fake3: offline" health2.out
 '
 
-test_expect_success 'flux overlay status -vvg: 0-1:partial, 3,7-8:offline' '
-	cat >health_vvg.exp <<-EOT &&
-	0 fake0: partial
-	1 fake1: partial
-	3 fake3: offline
-	7 fake7: offline
-	8 fake8: offline
-	EOT
-	flux overlay status -vvg >health_vvg.out &&
-	test_cmp health_vvg.exp health_vvg.out
+test_expect_success 'flux overlay status: 0-1:partial, 3,7-8:offline' '
+	flux overlay status --no-color --no-pretty >health3.out &&
+	grep "0 fake0: partial" health3.out &&
+	grep "1 fake1: partial" health3.out &&
+	grep "3 fake3: offline" health3.out &&
+	grep "7 fake7: offline" health3.out &&
+	grep "8 fake8: offline" health3.out
 '
 
-test_expect_success 'flux overlay status -vvvg: 0,1:partial, 3,7-8:offline, rest:full' '
-	cat >health_vvvg.exp <<-EOT &&
-	0 fake0: partial
-	1 fake1: partial
-	3 fake3: offline
-	7 fake7: offline
-	8 fake8: offline
-	4 fake4: full
-	9 fake9: full
-	10 fake10: full
-	2 fake2: full
-	5 fake5: full
-	11 fake11: full
-	12 fake12: full
-	6 fake6: full
-	13 fake13: full
-	14 fake14: full
-	EOT
-	flux overlay status -vvvg >health_vvvg.out &&
-	test_cmp health_vvvg.exp health_vvvg.out
+test_expect_success 'flux overlay status: 0,1:partial, 3,7-8:offline, rest:full' '
+	flux overlay status --no-color --no-pretty >health4.out &&
+	grep "0 fake0: partial" health4.out &&
+	grep "1 fake1: partial" health4.out &&
+	grep "3 fake3: offline" health4.out &&
+	grep "7 fake7: offline" health4.out &&
+	grep "8 fake8: offline" health4.out &&
+	grep "4 fake4: full" health4.out &&
+	grep "9 fake9: full" health4.out &&
+	grep "10 fake10: full" health4.out &&
+	grep "2 fake2: full" health4.out &&
+	grep "5 fake5: full" health4.out &&
+	grep "11 fake11: full" health4.out &&
+	grep "6 fake6: full" health4.out &&
+	grep "13 fake13: full" health4.out &&
+	grep "14 fake14: full" health4.out
 '
 
 test_expect_success 'kill broker 14' '
@@ -164,7 +148,7 @@ test_expect_success 'ping to rank 14 fails with EHOSTUNREACH' '
 '
 
 test_expect_success 'wait for rank 0 subtree to be degraded' '
-	flux overlay status --wait=degraded --timeout=10s
+	run_timeout 10 flux overlay status --summary --wait=degraded
 '
 
 test_expect_success 'wait for unknown status fails' '
@@ -172,17 +156,14 @@ test_expect_success 'wait for unknown status fails' '
 '
 
 test_expect_success 'wait timeout works' '
-	test_must_fail flux overlay status --wait=full --timeout=0.1s
+	test_must_fail flux overlay status --wait=full --summary --timeout=0.1s
 '
 
-test_expect_success 'flux overlay status -vg --since' '
-	flux overlay status -vg --since
+test_expect_success 'flux overlay status -vv' '
+	flux overlay status -vv
 '
-test_expect_success 'flux overlay status -vvgpc' '
-	flux overlay status -vvgpc
-'
-test_expect_success 'flux overlay status -vvvgpc' '
-	flux overlay status -vvv --ghost --pretty --color
+test_expect_success 'flux overlay status -v' '
+	flux overlay status -v
 '
 
 test_expect_success 'flux overlay gethostbyrank with no rank fails' '

--- a/t/t3305-system-rpctrack-up.t
+++ b/t/t3305-system-rpctrack-up.t
@@ -96,7 +96,7 @@ test_expect_success 'report health status' '
 	flux overlay status -vvv --pretty --ghost --color
 '
 test_expect_success 'health status for rank 6 is lost' '
-	echo "6: lost" >status.exp &&
+	echo "6 fake6: lost" >status.exp &&
 	flux overlay status -v >status.out &&
 	test_cmp status.exp status.out
 '

--- a/t/t3305-system-rpctrack-up.t
+++ b/t/t3305-system-rpctrack-up.t
@@ -93,11 +93,12 @@ test_expect_success NO_CHAIN_LINT 'background RPC fails' '
 '
 
 test_expect_success 'report health status' '
-	flux overlay status -vvv --pretty --ghost --color
+	flux overlay status
 '
 test_expect_success 'health status for rank 6 is lost' '
 	echo "6 fake6: lost" >status.exp &&
-	flux overlay status -v >status.out &&
+	flux overlay status --down --no-color --no-pretty \
+		| grep fake6 >status.out &&
 	test_cmp status.exp status.out
 '
 

--- a/t/t3306-system-routercrash.t
+++ b/t/t3306-system-routercrash.t
@@ -106,7 +106,7 @@ test_expect_success 'resource status shows 0 offline nodes' '
 '
 
 test_expect_success 'wait for rank 0 to report subtree status of full' '
-	run_timeout 10 flux overlay status -vvv --pretty --color --wait full
+	run_timeout 10 flux overlay status --wait full
 '
 
 test_expect_success 'ping broker 2 via broker 0' '


### PR DESCRIPTION
Problem:  flux -overlay requires a bunch of options to get the most useful output.

The inadequacy of the current default output was brought home to me in our discussion with the AHA moles team.  I suggested the command, and Jeff ran it on the call and said "it just prints full".   If you're running the tool you probably want the detail.  If you don't want the detail, then you can learn the options to dial it down.

So, rework the options so that one doesn't have to specify `-vvv --ghost --pretty --color` to get the "best" output.  Now the default includes all the brokers with full gaudiness, which can be dialed down with `--no-pretty --no-color` if desired.  Add two options `--summary` (the former default - terse one word summary of subtree status), and `--down`, which only shows down/offline brokers and their TBON parents.

Repurpose `-v` to show time in current state and `-vv` to add RPC round trip time instead of the `--since` and `--times` options.

Finally, add hostnames to the output unconditionally.

Example of default output for a `--test-size=16` instance with rank 3 disconnected:

![Screenshot from 2021-11-19 11-58-53](https://user-images.githubusercontent.com/169947/142684236-5f3f4caa-4424-4d09-9b58-33e10a39ce65.png)
