### PR TITLE
python: avoid early garbage collection of Watcher objects

### DIFF
--- a/src/bindings/python/flux/core/handle.py
+++ b/src/bindings/python/flux/core/handle.py
@@ -67,6 +67,7 @@ class Flux(Wrapper):
                 raise EnvironmentError(err.errno, "Unable to connect to Flux")
 
         self.aux_txn = None
+        self._active_watchers = set()
 
     @classmethod
     def reactor_running(cls):
@@ -222,6 +223,15 @@ class Flux(Wrapper):
         :raises TypeError: if the topic is not a str, bytes, or unicode
         """
         return self.flux_event_subscribe(encode_topic(topic))
+
+    def add_watcher(self, watcher):
+        """Add a reference to a watcher so it avoids garbage collection"""
+        self._active_watchers.add(watcher)
+        return watcher
+
+    def del_watcher(self, watcher):
+        """Remove ref to ``watcher`` so it is eligible for garbage collection"""
+        self._active_watchers.discard(watcher)
 
     def msg_watcher_create(
         self,

--- a/src/bindings/python/flux/message.py
+++ b/src/bindings/python/flux/message.py
@@ -143,7 +143,6 @@ class MessageWatcher(Watcher):
         match_tag=flux.constants.FLUX_MATCHTAG_NONE,
         args=None,
     ):
-        self.flux_handle = flux_handle
         self.callback = callback
         self.args = args
         self.wargs = ffi.new_handle(self)
@@ -162,12 +161,13 @@ class MessageWatcher(Watcher):
             {"typemask": type_mask, "matchtag": match_tag, "topic_glob": c_topic_glob},
         )
         super(MessageWatcher, self).__init__(
+            flux_handle,
             raw.flux_msg_handler_create(
-                self.flux_handle.handle,
+                flux_handle.handle,
                 match[0],
                 lib.message_handler_wrapper,
                 self.wargs,
-            )
+            ),
         )
 
     def start(self):

--- a/t/python/t0007-watchers.py
+++ b/t/python/t0007-watchers.py
@@ -121,10 +121,11 @@ class TestSignal(unittest.TestCase):
         sigw.destroy()
 
     def test_signal_watcher(self):
-        cb_called = [False]
+        cb_called = False
 
         def cb(handle, watcher, signum, args):
-            cb_called[0] = True
+            nonlocal cb_called
+            cb_called = True
             handle.reactor_stop()
 
         def raise_signal(handle, wathcer, revents, args):
@@ -141,7 +142,7 @@ class TestSignal(unittest.TestCase):
             to2.start()
             rc = self.f.reactor_run()
             self.assertTrue(rc >= 0, msg="reactor exit")
-            self.assertTrue(cb_called[0], "Signal Watcher Called")
+            self.assertTrue(cb_called, "Signal Watcher Called")
 
     def test_signal_watcher_exception(self):
         def signal_cb(handle, watcher, signum, args):

--- a/t/python/t0007-watchers.py
+++ b/t/python/t0007-watchers.py
@@ -12,6 +12,7 @@
 
 import unittest
 import os
+import gc
 import signal
 import flux
 from subflux import rerun_under_flux
@@ -205,6 +206,36 @@ class TestFdWatcher(unittest.TestCase):
                 writer.flush()
                 rc = self.f.reactor_run()
                 self.assertTrue(rc < 0)
+
+
+class TestIssue3973(unittest.TestCase):
+    @classmethod
+    def setUpClass(self):
+        self.f = flux.Flux()
+
+    def test_watcher_gc(self):
+        cb_called = 0
+
+        def cb(handle, watcher, revents, _args):
+            nonlocal cb_called
+            cb_called = cb_called + 1
+            if cb_called == 1:
+                gc.collect()
+            elif cb_called == 5:
+                handle.reactor_stop()
+
+        def cb_abort(handle, watcher, revents, _args):
+            raise RuntimeError("cb_abort should not be called")
+
+        #  Create a watcher with no local reference
+        self.f.timer_watcher_create(0.0, cb, repeat=0.05).start()
+
+        #  Timeout/abort after 5s
+        tw = self.f.timer_watcher_create(5.0, cb_abort).start()
+        self.f.reactor_run()
+
+        #  callback should have been called 5 times, not less
+        self.assertTrue(cb_called == 5)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR is an attempt at a general fix for #3973.

The problem of `Watcher` objects being subject to early GC is solved by adding them automatically to an active watchers set in the `Flux` handle from which they are created. To avoid a circular reference, the internally stored `flux_handle` in `Watcher` objects becomes a `weakref.ref()`. At `destroy()` time, a best effort is made to remove the `Watcher` from the `flux_handle` watcher set.

Unfortunately, I was getting an `AttributeError` with this approach at interpreter exit for `TimerWatcher has no attribute "get_flux"`, which is baffling, so I wrapped the call to get the `Watcher` flux handle in a `try/except` block. It probably means I've done something subtly wrong, but I couldn't find it.
