### PR TITLE
add flux top command

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ czmq-devel        | libczmq-dev       | >= 3.0.1          |
 jansson-devel     | libjansson-dev    | >= 2.6            |
 libuuid-devel     | uuid-dev          |                   |
 lz4-devel         | liblz4-dev        |                   |
+ncurses-devel     | libncurses-dev    |                   |
 hwloc-devel       | libhwloc-dev      | >= v1.11.1        |
 sqlite-devel      | libsqlite3-dev    | >= 3.0.0          |
 lua               | lua5.1            | >= 5.1, < 5.5     |

--- a/configure.ac
+++ b/configure.ac
@@ -332,6 +332,7 @@ PKG_CHECK_MODULES([HWLOC], [hwloc >= 1.11.1], [], [])
 PKG_CHECK_MODULES([LZ4], [liblz4], [], [])
 PKG_CHECK_MODULES([SQLITE], [sqlite3], [], [])
 PKG_CHECK_MODULES([LIBUUID], [uuid], [], [])
+PKG_CHECK_MODULES([CURSES], [ncursesw], [], [])
 LX_FIND_MPI
 AM_CONDITIONAL([HAVE_MPI], [test "$have_C_mpi" = yes])
 AX_VALGRIND_H

--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -85,7 +85,8 @@ fluxcmd_PROGRAMS = \
 	flux-job \
 	flux-queue \
 	flux-exec \
-	flux-R
+	flux-R \
+	flux-top
 
 flux_start_LDADD = \
 	$(fluxcmd_ldadd) \
@@ -122,6 +123,21 @@ flux_keygen_CPPFLAGS = \
 flux_keygen_LDADD = \
 	$(fluxcmd_ldadd) \
 	$(ZMQ_LIBS)
+
+flux_top_SOURCES = \
+	top/top.c \
+	top/top.h \
+	top/keys.c \
+	top/joblist_pane.c \
+	top/summary_pane.c \
+	top/ucache.c
+flux_top_CPPFLAGS = \
+	$(AM_CPPFLAGS) \
+	$(CURSES_CFLAGS)
+flux_top_LDADD = \
+	$(fluxcmd_ldadd) \
+	$(CURSES_LIBS)
+
 #
 # Automatically build list of flux(1) builtins from
 #  builtin/*.c:

--- a/src/cmd/top/joblist_pane.c
+++ b/src/cmd/top/joblist_pane.c
@@ -1,0 +1,168 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <sys/types.h>
+#include <unistd.h>
+#include <time.h>
+#include <jansson.h>
+
+#include "src/common/libutil/fsd.h"
+
+#include "top.h"
+
+static const struct dimension win_dim = { 0, 5, 80, 60 };
+
+struct joblist_pane {
+    struct top *top;
+    WINDOW *win;
+    json_t *jobs;
+    struct ucache *ucache;
+};
+
+void joblist_pane_draw (struct joblist_pane *joblist)
+{
+    double now = flux_reactor_now (flux_get_reactor (joblist->top->h));
+    size_t index;
+    json_t *job;
+    int name_width = getmaxx (joblist->win) - (12 + 8 + 2 + 6 + 6 + 7 + 6);
+
+    werase (joblist->win);
+    wattron (joblist->win, A_REVERSE);
+    mvwprintw (joblist->win,
+               0,
+               0,
+               "%12s %8s %2s %6s %6s %7s %-*s",
+               "JOBID", "USER", "ST", "NTASKS", "NNODES", "RUNTIME",
+               name_width, "NAME");
+    wattroff (joblist->win, A_REVERSE);
+    if (joblist->jobs == NULL)
+        return;
+    json_array_foreach (joblist->jobs, index, job) {
+        char idstr[16];
+        char run[16];
+        flux_jobid_t id;
+        int userid;
+        const char *username;
+        const char *name;
+        int state;
+        int ntasks;
+        int nnodes;
+        double t_run;
+
+        if (json_unpack (job,
+                         "{s:I s:i s:i s:s s:i s:i s:f}",
+                         "id", &id,
+                         "userid", &userid,
+                         "state", &state,
+                         "name", &name,
+                         "nnodes", &nnodes,
+                         "ntasks", &ntasks,
+                         "t_run", &t_run) < 0)
+            fatal (errno, "error decoding a job record from job-list RPC");
+        if (flux_job_id_encode (id, "f58", idstr, sizeof (idstr)) < 0)
+            fatal (errno, "error encoding jobid as F58");
+        if (fsd_format_duration_ex (run, sizeof (run), now - t_run, 2) < 0)
+            fatal (errno, "error formating expiration time as FSD");
+        if (!(username = ucache_lookup (joblist->ucache, userid)))
+            fatal (errno, "error looking up userid %d in ucache", (int)userid);
+        mvwprintw (joblist->win,
+                   1 + index,
+                   0,
+                   "%13.13s %8.8s %2.2s %6d %6d %7.7s %-*.*s",
+                   idstr,
+                   username,
+                   flux_job_statetostr (state, true),
+                   ntasks,
+                   nnodes,
+                   run,
+                   name_width,
+                   name_width,
+                   name);
+    }
+}
+
+static void joblist_continuation (flux_future_t *f, void *arg)
+{
+    struct joblist_pane *joblist = arg;
+    json_t *jobs;
+
+    if (flux_rpc_get_unpack (f, "{s:o}", "jobs", &jobs) < 0)
+        fatal (errno, "error decoding job-list.list RPC response");
+    json_decref (joblist->jobs);
+    joblist->jobs = json_incref (jobs);
+    joblist_pane_draw (joblist);
+    flux_future_destroy (f);
+}
+
+void joblist_pane_query (struct joblist_pane *joblist)
+{
+    flux_future_t *f;
+
+    if (!(f = flux_rpc_pack (joblist->top->h,
+                             "job-list.list",
+                             0,
+                             0,
+                             "{s:i s:i s:i s:i s:[s,s,s,s,s,s]}",
+                             "max_entries", win_dim.y_length - 1,
+                             "userid", FLUX_USERID_UNKNOWN,
+                             "states", FLUX_JOB_STATE_RUNNING,
+                             "results", 0,
+                             "attrs",
+                               "userid",
+                               "state",
+                               "name",
+                               "nnodes",
+                               "ntasks",
+                               "t_run"))
+        || flux_future_then (f, -1, joblist_continuation, joblist) < 0)
+        fatal (errno, "error sending job-list.list RPC request");
+}
+
+void joblist_pane_refresh (struct joblist_pane *joblist)
+{
+    wnoutrefresh (joblist->win);
+}
+
+struct joblist_pane *joblist_pane_create (struct top *top)
+{
+    struct joblist_pane *joblist;
+
+    if (!(joblist = calloc (1, sizeof (*joblist))))
+        fatal (errno, "could not allocate joblist context");
+    if (!(joblist->ucache = ucache_create ()))
+        fatal (errno, "could not create ucache");
+    joblist->top = top;
+    if (!(joblist->win = newwin (win_dim.y_length,
+                                 win_dim.x_length,
+                                 win_dim.y_begin,
+                                 win_dim.x_begin)))
+        fatal (0, "error creating joblist curses window");
+    joblist_pane_query (joblist);
+    joblist_pane_draw (joblist);
+    joblist_pane_refresh (joblist);
+    return joblist;
+}
+
+void joblist_pane_destroy (struct joblist_pane *joblist)
+{
+    if (joblist) {
+        int saved_errno = errno;
+        delwin (joblist->win);
+        ucache_destroy (joblist->ucache);
+        json_decref (joblist->jobs);
+        free (joblist);
+        errno = saved_errno;
+    }
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/src/cmd/top/keys.c
+++ b/src/cmd/top/keys.c
@@ -1,0 +1,78 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <sys/types.h>
+#include <unistd.h>
+#include <time.h>
+
+#include "top.h"
+
+struct keys {
+    struct top *top;
+    flux_watcher_t *w;
+};
+
+static void keys_cb (flux_reactor_t *r,
+                     flux_watcher_t *w,
+                     int revents,
+                     void *arg)
+{
+    struct keys *keys = arg;
+    int c;
+
+    switch ((c = getch ())) {
+        case 'q':
+            flux_reactor_stop (r);
+            break;
+        case '':
+            clear ();
+            summary_pane_draw (keys->top->summary_pane);
+            joblist_pane_draw (keys->top->joblist_pane);
+            break;
+    }
+}
+
+struct keys *keys_create (struct top *top)
+{
+    struct keys *keys;
+
+    if (!(keys = calloc (1, sizeof (*keys))))
+        fatal (errno, "error creating context for key handling");
+    if (!(keys->w = flux_fd_watcher_create (flux_get_reactor (top->h),
+                                            STDIN_FILENO,
+                                            FLUX_POLLIN,
+                                            keys_cb,
+                                            keys)))
+        fatal (errno, "error creating fd watcher for stdin");
+    keys->top = top;
+
+    cbreak ();
+    noecho ();
+    intrflush (stdscr, FALSE);
+    keypad (stdscr, TRUE);
+
+    flux_watcher_start (keys->w);
+    return keys;
+}
+
+void keys_destroy (struct keys *keys)
+{
+    if (keys) {
+        int saved_errno = errno;
+        flux_watcher_destroy (keys->w);
+        free (keys);
+        errno = saved_errno;
+    }
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/src/cmd/top/summary_pane.c
+++ b/src/cmd/top/summary_pane.c
@@ -1,0 +1,412 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <sys/types.h>
+#include <unistd.h>
+#include <time.h>
+#include <jansson.h>
+
+#include "src/common/libutil/fsd.h"
+#include "src/common/librlist/rlist.h"
+
+#include "top.h"
+
+static const struct dimension win_dim = { 0, 0, 80, 5 };
+static const struct dimension level_dim = { 0, 0, 2, 1 };
+static const struct dimension jobid_dim = { 36, 0, 16, 1 };
+static const struct dimension timeleft_dim = { 70, 0, 10, 1 };
+static const struct dimension resource_dim = { 4, 1, 36, 3 };
+static const struct dimension heart_dim = { 77, 3, 1, 1 };
+static const struct dimension stats_dim = { 60, 1, 15, 3 };
+
+static const double heartblink_duration = 0.5;
+
+struct resource_count {
+    int total;
+    int down;
+    int used;
+};
+
+struct stats {
+    int depend;
+    int priority;
+    int sched;
+    int run;
+    int cleanup;
+    int inactive;
+    int total;
+};
+
+struct summary_pane {
+    struct top *top;
+    WINDOW *win;
+    unsigned long instance_level;
+    flux_jobid_t jobid;
+    double expiration;
+    struct stats stats;
+    struct resource_count node;
+    struct resource_count core;
+    struct resource_count gpu;
+    flux_watcher_t *heartblink;
+    bool heart_visible;
+};
+
+static void draw_timeleft (struct summary_pane *sum)
+{
+    double now = flux_reactor_now (flux_get_reactor (sum->top->h));
+    double timeleft = sum->expiration - now;
+    char buf[32] = "";
+
+    if (timeleft > 0)
+        fsd_format_duration_ex (buf, sizeof (buf), timeleft, 2);
+
+    mvwprintw (sum->win,
+               timeleft_dim.y_begin,
+               timeleft_dim.x_begin,
+               "%*s%s",
+               timeleft_dim.x_length - 2,
+               buf,
+               timeleft > 0 ? "⌚" : "∞");
+}
+
+static void draw_level (struct summary_pane *sum)
+{
+    const char *sup[] = { "", "²", "³", "⁴", "⁵", "⁶", "⁷", "⁸", "⁹", "⁺" };
+    int size = sizeof (sup) / sizeof (sup[0]);
+    unsigned long level = sum->instance_level;
+
+    wattron (sum->win, COLOR_PAIR (TOP_COLOR_YELLOW));
+    mvwprintw (sum->win,
+               level_dim.y_begin,
+               level_dim.x_begin,
+               "%s%s",
+               "ƒ",
+               sup[level < size ? level : size - 1]);
+    wattroff (sum->win, COLOR_PAIR (TOP_COLOR_YELLOW));
+}
+
+static void draw_jobid (struct summary_pane *sum)
+{
+    if (sum->jobid != FLUX_JOBID_ANY) {
+        char buf[jobid_dim.x_length + 1];
+        flux_job_id_encode (sum->jobid, "f58", buf, sizeof (buf));
+        wattron (sum->win, A_BOLD);
+        mvwprintw (sum->win, jobid_dim.y_begin, jobid_dim.x_begin, "%s", buf);
+        wattroff (sum->win, A_BOLD);
+    }
+}
+
+static void draw_stats (struct summary_pane *sum)
+{
+    mvwprintw (sum->win,
+               stats_dim.y_begin,
+               stats_dim.x_begin,
+               "%*d pending",
+               stats_dim.x_length - 10,
+               sum->stats.depend + sum->stats.priority + sum->stats.sched);
+    mvwprintw (sum->win,
+               stats_dim.y_begin + 1,
+               stats_dim.x_begin,
+               "%*d running",
+               stats_dim.x_length - 10,
+               sum->stats.run + sum->stats.cleanup);
+    mvwprintw (sum->win,
+               stats_dim.y_begin + 2,
+               stats_dim.x_begin,
+               "%*d inactive",
+               stats_dim.x_length - 10,
+               sum->stats.inactive);
+}
+
+/* Create a little graph like this that fits in bufsz:
+ *     name [||||||||||        |||32/128]
+ * "used" grows from the left in yellow; "down" grows from the right in red.
+ * Fraction is used/total.
+ */
+static void draw_bargraph (WINDOW *win, int y, int x, int x_length,
+                           const char *name, struct resource_count res)
+{
+    char prefix[16];
+    char suffix[16];
+
+    if (x_length > 80)
+        x_length = 80;
+    if (res.used > res.total)
+        res.used = res.total;
+
+    snprintf (prefix, sizeof (prefix), "%5s [", name);
+    snprintf (suffix, sizeof (suffix), "%d/%d]", res.used, res.total);
+
+    int slots = x_length - strlen (prefix) - strlen (suffix) - 1;
+    mvwprintw (win,
+               y,
+               x,
+               "%s%*s%s",
+               prefix,
+               slots, "",
+               suffix);
+    /* Graph used */
+    wattron (win, COLOR_PAIR (TOP_COLOR_YELLOW));
+    for (int i = 0; i < ((double)res.used / res.total) * slots; i++)
+        mvwaddch (win, y, x + strlen (prefix) + i, '|');
+    wattroff (win, COLOR_PAIR (TOP_COLOR_YELLOW));
+
+    /* Graph down */
+    wattron (win, COLOR_PAIR (TOP_COLOR_RED));
+    for (int i = slots - 1;
+         i >= slots - ((double)res.down / res.total) * slots; i--) {
+        mvwaddch (win, y, x + strlen (prefix) + i, '|');
+    }
+    wattroff (win, COLOR_PAIR (TOP_COLOR_RED));
+}
+
+static void draw_resource (struct summary_pane *sum)
+{
+    draw_bargraph (sum->win,
+                   resource_dim.y_begin,
+                   resource_dim.x_begin,
+                   resource_dim.x_length,
+                   "nodes",
+                   sum->node);
+    draw_bargraph (sum->win,
+                   resource_dim.y_begin + 1,
+                   resource_dim.x_begin,
+                   resource_dim.x_length,
+                   "cores",
+                   sum->core);
+    draw_bargraph (sum->win,
+                   resource_dim.y_begin + 2,
+                   resource_dim.x_begin,
+                   resource_dim.x_length,
+                   "gpus",
+                   sum->gpu);
+}
+
+static void draw_heartbeat (struct summary_pane *sum)
+{
+    mvwprintw (sum->win,
+               heart_dim.y_begin,
+               heart_dim.x_begin,
+               "%s",
+               sum->heart_visible ? "♡" : " ");
+}
+
+/* Fetch expiration time (abs time relative to UNIX epoch) from resource.R.
+ * If unavailable (e.g. we are a guest in the system instance), return 0.
+ */
+static double get_expiration (flux_t *h)
+{
+    flux_future_t *f;
+    double val = 0;
+
+    if (!(f = flux_kvs_lookup (h, NULL, 0, "resource.R"))
+        || flux_kvs_lookup_get_unpack (f,
+                                       "{s:{s:f}}",
+                                       "execution",
+                                       "expiration", &val) < 0) {
+        if (errno == EPERM)
+            goto done;
+        fatal (errno, "error fetching or decoding resource.R");
+    }
+done:
+    flux_future_destroy (f);
+    return val;
+}
+
+static int get_instance_level (flux_t *h)
+{
+    const char *s;
+    unsigned long level;
+
+    if (!(s = flux_attr_get (h, "instance-level")))
+        fatal (errno, "error fetching instance-level broker attribute");
+    errno = 0;
+    level = strtoul (s, NULL, 10);
+    if (errno != 0)
+        fatal (errno, "error parsing instance level");
+    return level;
+}
+
+static flux_jobid_t get_jobid (flux_t *h)
+{
+    const char *s;
+    flux_jobid_t jobid;
+
+    if (!(s = flux_attr_get (h, "jobid")))
+        return FLUX_JOBID_ANY;
+    if (flux_job_id_parse (s, &jobid) < 0)
+        fatal (errno, "error parsing value of jobid attribute: %s", s);
+    return jobid;
+}
+
+static int resource_count (json_t *o,
+                           const char *name,
+                           int *nnodes,
+                           int *ncores,
+                           int *ngpus)
+{
+    json_t *R;
+    struct rlist *rl;
+
+    if (!(R = json_object_get (o, name)))
+        return -1;
+    if (json_is_null (R)) { // N.B. fluxion sets objects to json null if empty
+        *nnodes = *ncores = *ngpus = 0;
+        return 0;
+    }
+    if (!(rl = rlist_from_json (R, NULL)))
+        return -1;
+    *nnodes = rlist_nnodes (rl);
+    *ncores = rlist_count (rl, "core");
+    *ngpus = rlist_count (rl, "gpu");
+    rlist_destroy (rl);
+    return 0;
+}
+
+static void resource_continuation (flux_future_t *f, void *arg)
+{
+    struct summary_pane *sum = arg;
+    json_t *o;
+
+    if (flux_rpc_get_unpack (f, "o", &o) < 0)
+        fatal (errno, "sched.resource-status RPC failed");
+    if (resource_count (o,
+                        "all",
+                        &sum->node.total,
+                        &sum->core.total,
+                        &sum->gpu.total) < 0
+        || resource_count (o,
+                           "allocated",
+                           &sum->node.used,
+                           &sum->core.used,
+                           &sum->gpu.used) < 0
+        || resource_count (o,
+                           "down",
+                           &sum->node.down,
+                           &sum->core.down,
+                           &sum->gpu.down) < 0)
+        fatal (0, "error decoding sched.resource-status RPC response");
+    flux_future_destroy (f);
+    draw_resource (sum);
+}
+
+static void stats_continuation (flux_future_t *f, void *arg)
+{
+    struct summary_pane *sum = arg;
+
+    if (flux_rpc_get_unpack (f,
+                             "{s:{s:i s:i s:i s:i s:i s:i s:i}}",
+                             "job_states",
+                               "depend", &sum->stats.depend,
+                               "priority", &sum->stats.priority,
+                               "sched", &sum->stats.sched,
+                               "run", &sum->stats.run,
+                               "cleanup", &sum->stats.cleanup,
+                               "inactive", &sum->stats.inactive,
+                               "total", &sum->stats.total))
+        fatal (errno, "error decoding job-list.job-stats RPC response");
+    flux_future_destroy (f);
+    draw_stats (sum);
+}
+
+static void heartblink_cb (flux_reactor_t *r,
+                           flux_watcher_t *w,
+                           int revents,
+                           void *arg)
+{
+    struct summary_pane *sum = arg;
+
+    sum->heart_visible = false;
+    draw_heartbeat (sum);
+}
+
+void summary_pane_heartbeat (struct summary_pane *sum)
+{
+    sum->heart_visible = true;
+    flux_timer_watcher_reset (sum->heartblink, heartblink_duration, 0.);
+    flux_watcher_start (sum->heartblink);
+}
+
+void summary_pane_query (struct summary_pane *sum)
+{
+    flux_future_t *f;
+    flux_future_t *fstats;
+
+    if (!(f = flux_rpc (sum->top->h, "sched.resource-status", NULL, 0, 0))
+        || flux_future_then (f, -1, resource_continuation, sum) < 0) {
+        flux_future_destroy (f);
+    }
+    if (!(fstats = flux_rpc (sum->top->h, "job-list.job-stats", "{}", 0, 0))
+        || flux_future_then (fstats, -1, stats_continuation, sum) < 0) {
+        flux_future_destroy (fstats);
+    }
+}
+
+void summary_pane_draw (struct summary_pane *sum)
+{
+    werase (sum->win);
+    draw_level (sum);
+    draw_jobid (sum);
+    draw_timeleft (sum);
+    draw_resource (sum);
+    draw_stats (sum);
+    draw_heartbeat (sum);
+}
+
+void summary_pane_refresh (struct summary_pane *sum)
+{
+    wnoutrefresh (sum->win);
+}
+
+struct summary_pane *summary_pane_create (struct top *top)
+{
+    struct summary_pane *sum;
+    flux_reactor_t *r = flux_get_reactor (top->h);
+
+    if (!(sum = calloc (1, sizeof (*sum))))
+        fatal (errno, "error creating context for summary pane");
+    if (!(sum->heartblink = flux_timer_watcher_create (r,
+                                                       heartblink_duration,
+                                                       0.,
+                                                       heartblink_cb,
+                                                       sum)))
+        fatal (errno, "error creating timer for heartbeat blink");
+    if (!(sum->win = newwin (win_dim.y_length,
+                             win_dim.x_length,
+                             win_dim.y_begin,
+                             win_dim.x_begin)))
+        fatal (0, "error creating curses window for summary pane");
+    sum->top = top;
+
+    sum->expiration = get_expiration (top->h);
+    sum->instance_level = get_instance_level (top->h);
+    sum->jobid = get_jobid (top->h);
+
+    summary_pane_query (sum);
+    summary_pane_draw (sum);
+    summary_pane_refresh (sum);
+    return sum;
+}
+
+void summary_pane_destroy (struct summary_pane *sum)
+{
+    if (sum) {
+        int saved_errno = errno;
+        flux_watcher_destroy (sum->heartblink);
+        delwin (sum->win);
+        free (sum);
+        errno = saved_errno;
+    }
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/src/cmd/top/top.c
+++ b/src/cmd/top/top.c
@@ -1,0 +1,275 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdlib.h>
+#include <unistd.h>
+#include <locale.h>
+
+#include "top.h"
+
+static const double job_activity_rate_limit = 2;
+
+void fatal (int errnum, const char *fmt, ...)
+{
+    va_list ap;
+    char buf[128];
+
+    va_start (ap, fmt);
+    vsnprintf (buf, sizeof (buf), fmt, ap);
+    va_end (ap);
+
+    endwin ();
+    fprintf (stderr,
+             "flux-top: %s%s%s\n",
+             buf,
+             errnum == 0 ? "" : ": ",
+             errnum == 0 ? "" : strerror (errnum));
+    exit (1);
+}
+
+/* When connection is lost to Flux, this function is called before
+ * errors propagate to higher level functions (like RPCs), so it
+ * is an opportunity to consolidate error handling for that case.
+ * N.B. ssh:// connections do not always propagate fatal errors as expected.
+ * N.B. the msg argument would appear to be mostly useless for our purposes.
+ */
+static void flux_fatal (const char *msg, void *arg)
+{
+    fatal (0, "lost connection to Flux");
+}
+
+static void heartbeat_cb (flux_t *h,
+                          flux_msg_handler_t *mh,
+                          const flux_msg_t *msg,
+                          void *arg)
+{
+    struct top *top = arg;
+    summary_pane_heartbeat (top->summary_pane);
+    summary_pane_draw (top->summary_pane);
+    joblist_pane_draw (top->joblist_pane);
+}
+
+static void jobtimer_cb (flux_reactor_t *r,
+                         flux_watcher_t *w,
+                         int revents,
+                         void *arg)
+{
+    struct top *top = arg;
+
+    summary_pane_query (top->summary_pane);
+    joblist_pane_query (top->joblist_pane);
+    top->jobtimer_running = false;
+}
+
+/* After some job state activity, and after a rate-limited delay,
+ * trigger queries for info in the two panes.
+ */
+static void job_state_cb (flux_t *h,
+                          flux_msg_handler_t *mh,
+                          const flux_msg_t *msg,
+                          void *arg)
+{
+    struct top *top = arg;
+
+    if (!top->jobtimer_running) {
+        flux_timer_watcher_reset (top->jobtimer, job_activity_rate_limit, 0.);
+        flux_watcher_start (top->jobtimer);
+        top->jobtimer_running = true;
+    }
+}
+
+void refresh_cb (flux_reactor_t *r,
+                 flux_watcher_t *w,
+                 int revents,
+                 void *arg)
+{
+    struct top *top = arg;
+
+    summary_pane_refresh (top->summary_pane);
+    joblist_pane_refresh (top->joblist_pane);
+    doupdate ();
+}
+
+static int job_get_state (flux_t *h, flux_jobid_t id, int *statep)
+{
+    flux_future_t *f;
+    int state;
+
+    if (!(f = flux_rpc_pack (h,
+                             "job-list.list-id",
+                             0,
+                             0,
+                             "{s:I s:[s]}",
+                             "id", id,
+                             "attrs",
+                               "state"))
+        || flux_rpc_get_unpack (f, "{s:{s:i}}", "job", "state", &state) < 0) {
+        flux_future_destroy (f);
+        return -1;
+    }
+    flux_future_destroy (f);
+    *statep = state;
+    return 0;
+}
+
+/* Get handle to Flux instance to be monitored.
+ * If id = FLUX_JOBID_ANY, merely call flux_open().
+ * Otherwise, fetch remote-uri from job and open that.
+ */
+static flux_t *open_flux_instance (flux_jobid_t id)
+{
+    flux_t *h;
+    flux_future_t *f = NULL;
+    const char *uri_key = "guest.flux.remote_uri";
+    const char *uri;
+    flux_t *job_h = NULL;
+    int state;
+
+    if (!(h = flux_open (NULL, 0)))
+        fatal (errno, "error connecting to Flux");
+    if (id == FLUX_JOBID_ANY)
+        return h;
+    if (job_get_state (h, id, &state) < 0)
+        fatal (0, "unknown jobid");
+    if (!(state & FLUX_JOB_STATE_RUNNING))
+        fatal (0, "job is not running");
+    if (!(f = flux_rpc_pack (h,
+                             "job-info.lookup",
+                             0,
+                             0,
+                             "{s:I s:[s] s:i}",
+                             "id", id,
+                             "keys", uri_key,
+                             "flags", 0))
+        || flux_rpc_get_unpack (f, "{s:s}", uri_key, &uri) < 0) {
+        if (errno == ENOENT)
+            fatal (0, "error reading job remote-uri - not a Flux instance?");
+        fatal (errno, "error reading job remote-uri");
+    }
+    if (!(job_h = flux_open (uri, 0)))
+        fatal (errno, "error connecting to job");
+    flux_future_destroy (f);
+    flux_close (h);
+    return job_h;
+}
+
+/* Initialize 'stdscr' and register colors.
+ * N.B. this program does not use stdscr, but it does use getch(), which
+ * implicitly refreshes stdscr.  Therefore, make sure that stdscr is synced
+ * with its internal buffer by calling refresh() below to prevent unwanted
+ * screen updates on the first keypress.
+ */
+static void initialize_curses (void)
+{
+    initscr ();
+    curs_set (0); // make cursor disappear
+
+    use_default_colors ();
+    start_color ();
+    init_pair (TOP_COLOR_YELLOW, COLOR_YELLOW, -1);
+    init_pair (TOP_COLOR_RED, COLOR_RED, -1);
+
+    clear ();
+    refresh ();
+}
+
+static const struct flux_msg_handler_spec htab[] = {
+    { FLUX_MSGTYPE_EVENT, "job-state", job_state_cb, 0 },
+    { FLUX_MSGTYPE_EVENT, "heartbeat.pulse", heartbeat_cb, 0 },
+    FLUX_MSGHANDLER_TABLE_END,
+};
+
+static struct optparse_option cmdopts[] = {
+    { .name = "test-exit", .has_arg = 0, .flags = OPTPARSE_OPT_HIDDEN,
+      .usage = "Exit after screen initialization, for testing",
+    },
+    OPTPARSE_TABLE_END,
+};
+
+static const char *usage_msg = "[OPTIONS] [JOBID]";
+
+int main (int argc, char *argv[])
+{
+    int optindex;
+    struct top top;
+    int reactor_flags = 0;
+
+    memset (&top, 0, sizeof (top));
+    top.id = FLUX_JOBID_ANY;
+
+    setlocale (LC_ALL, "");
+
+    if (!(top.opts = optparse_create ("flux-top"))
+        || optparse_add_option_table (top.opts, cmdopts) != OPTPARSE_SUCCESS
+        || optparse_set (top.opts,
+                         OPTPARSE_USAGE,
+                         usage_msg) != OPTPARSE_SUCCESS)
+        fatal (0, "error setting up option parsing");
+
+    if ((optindex = optparse_parse_args (top.opts, argc, argv)) < 0)
+        exit (1);
+    if (optindex < argc) {
+        const char *s = argv[optindex++];
+        if (flux_job_id_parse (s, &top.id) < 0)
+            fatal (errno, "failed to parse JOBID argument");
+    }
+    if (optindex != argc) {
+        optparse_print_usage (top.opts);
+        exit (1);
+    }
+    top.h = open_flux_instance (top.id);
+    flux_fatal_set (top.h, flux_fatal, &top);
+    if (!(top.refresh = flux_prepare_watcher_create (flux_get_reactor (top.h),
+                                                     refresh_cb,
+                                                     &top))
+        || !(top.jobtimer = flux_timer_watcher_create (flux_get_reactor (top.h),
+                                                       0.,
+                                                       0.,
+                                                       jobtimer_cb,
+                                                       &top)))
+        fatal (errno, "could not create timers");
+    flux_watcher_start (top.refresh);
+
+    if (flux_msg_handler_addvec (top.h, htab, &top, &top.handlers) < 0)
+        fatal (errno, "error registering message handlers");
+    if (flux_event_subscribe (top.h, "job-state") < 0
+        || flux_event_subscribe (top.h, "heartbeat.pulse") < 0)
+        fatal (errno, "error subscribing to events");
+
+    if (!isatty (STDIN_FILENO))
+        fatal (0, "stdin is not a terminal");
+    initialize_curses ();
+    top.keys = keys_create (&top);
+    top.summary_pane = summary_pane_create (&top);
+    top.joblist_pane = joblist_pane_create (&top);
+
+    if (optparse_hasopt (top.opts, "test-exit"))
+        reactor_flags |= FLUX_REACTOR_ONCE;
+    if (flux_reactor_run (flux_get_reactor (top.h), reactor_flags) < 0)
+        fatal (errno, "reactor loop unexpectedly terminated");
+
+    flux_watcher_destroy (top.refresh);
+    flux_watcher_destroy (top.jobtimer);
+    flux_msg_handler_delvec (top.handlers);
+    joblist_pane_destroy (top.joblist_pane);
+    summary_pane_destroy (top.summary_pane);
+    keys_destroy (top.keys);
+    endwin ();
+    flux_close (top.h);
+    optparse_destroy (top.opts);
+    return 0;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/cmd/top/top.h
+++ b/src/cmd/top/top.h
@@ -1,0 +1,71 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#include <sys/types.h>
+#include <curses.h>
+#include <stdarg.h>
+#include <flux/core.h>
+#include <flux/optparse.h>
+
+// set printf format attribute on this curses function for our convenience
+int mvwprintw(WINDOW *win, int y, int x, const char *fmt, ...)
+    __attribute__ ((format (printf, 4, 5)));
+
+enum {
+    TOP_COLOR_YELLOW = 1,
+    TOP_COLOR_RED = 2,
+};
+
+struct top {
+    flux_t *h;
+    flux_jobid_t id;
+    uint32_t userid;
+    uint32_t size;
+    struct summary_pane *summary_pane;
+    struct joblist_pane *joblist_pane;
+    struct keys *keys;
+    flux_watcher_t *refresh;
+    flux_watcher_t *jobtimer;
+    bool jobtimer_running;
+    flux_msg_handler_t **handlers;
+    optparse_t *opts;
+};
+
+struct dimension {
+    int x_begin;
+    int y_begin;
+    int x_length;
+    int y_length;
+};
+
+struct summary_pane *summary_pane_create (struct top *top);
+void summary_pane_destroy (struct summary_pane *sum);
+void summary_pane_draw (struct summary_pane *sum);
+void summary_pane_refresh (struct summary_pane *sum);
+void summary_pane_query (struct summary_pane *sum);
+void summary_pane_heartbeat (struct summary_pane *sum);
+
+struct joblist_pane *joblist_pane_create (struct top *top);
+void joblist_pane_destroy (struct joblist_pane *sum);
+void joblist_pane_draw (struct joblist_pane *sum);
+void joblist_pane_refresh (struct joblist_pane *sum);
+void joblist_pane_query (struct joblist_pane *sum);
+
+struct keys *keys_create (struct top *top);
+void keys_destroy (struct keys *keys);
+
+struct ucache *ucache_create (void);
+void ucache_destroy (struct ucache *ucache);
+const char *ucache_lookup (struct ucache *ucache, uid_t userid);
+
+void fatal (int errnum, const char *fmt, ...)
+    __attribute__ ((format (printf, 2, 3)));
+
+// vi:ts=4 sw=4 expandtab

--- a/src/cmd/top/ucache.c
+++ b/src/cmd/top/ucache.c
@@ -1,0 +1,91 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* ucache.c - simple username cache
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <sys/types.h>
+#include <stdlib.h>
+#include <pwd.h>
+#include <stdio.h>
+
+#include "top.h"
+
+struct ucache_entry {
+    uid_t id;
+    char name[9];
+};
+
+struct ucache {
+    struct ucache_entry *users;
+    size_t len;
+};
+
+/* Add a new entry to the end of the cache.
+ * If memory allocation fails, return NULL with errno set.
+ */
+static const char *ucache_add (struct ucache *ucache,
+                               uid_t userid,
+                               const char *name)
+{
+    struct ucache_entry *new_users;
+    struct ucache_entry *entry;
+
+    if (!(new_users = realloc (ucache->users,
+                               sizeof (ucache->users[0]) * (ucache->len + 1))))
+        return NULL;
+    ucache->users = new_users;
+    entry = &ucache->users[ucache->len++];
+
+    entry->id = userid;
+    snprintf (entry->name, sizeof (entry->name), "%s", name);
+    return entry->name;
+}
+
+/* Find userid in cache and return username.
+ * If not found, look up in password file, add to cache, and return username.
+ * If memory allocation or user lookup fails, return NULL with errno set.
+ */
+const char *ucache_lookup (struct ucache *ucache, uid_t userid)
+{
+    struct passwd *pwd;
+
+    for (int i = 0; i < ucache->len; i++) {
+        if (ucache->users[i].id == userid)
+            return ucache->users[i].name;
+    }
+    if (!(pwd = getpwuid (userid)))
+        return NULL;
+    return ucache_add (ucache, userid, pwd->pw_name);
+}
+
+void ucache_destroy (struct ucache *ucache)
+{
+    if (ucache) {
+        int saved_errno = errno;
+        free (ucache->users);
+        free (ucache);
+        errno = saved_errno;
+    }
+}
+
+struct ucache *ucache_create (void)
+{
+    struct ucache *ucache;
+
+    if (!(ucache = calloc (1, sizeof (*ucache))))
+        return NULL;
+    return ucache;
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/src/common/libutil/fsd.c
+++ b/src/common/libutil/fsd.c
@@ -87,20 +87,30 @@ int fsd_parse_duration (const char *s, double *dp)
     return 0;
 }
 
-int fsd_format_duration (char *buf, size_t len, double duration)
+int fsd_format_duration_ex (char *buf,
+                            size_t len,
+                            double duration,
+                            int precision)
 {
     if (buf == NULL || len <= 0 || is_invalid_duration(duration)) {
         errno = EINVAL;
         return -1;
     }
     if (duration < 60.)
-        return snprintf (buf, len, "%gs", duration);
+        return snprintf (buf, len, "%.*gs", precision, duration);
     else if (duration < 60. * 60.)
-        return snprintf (buf, len, "%gm", duration / 60.);
+        return snprintf (buf, len, "%.*gm", precision, duration / 60.);
     else if (duration < 60. * 60. * 24.)
-        return snprintf (buf, len, "%gh", duration / (60. * 60.));
-    else
-        return snprintf (buf, len, "%gd", duration / (60. * 60. * 24.));
+        return snprintf (buf, len, "%.*gh", precision, duration / (60. * 60.));
+    else {
+        return snprintf (buf, len, "%.*gd", precision,
+                         duration / (60. * 60. * 24.));
+    }
+}
+
+int fsd_format_duration (char *buf, size_t len, double duration)
+{
+    return fsd_format_duration_ex (buf, len, duration, 6);
 }
 
 /*

--- a/src/common/libutil/fsd.h
+++ b/src/common/libutil/fsd.h
@@ -23,6 +23,10 @@ int fsd_parse_duration (const char *s, double *dp);
  */
 int fsd_format_duration (char *buf, size_t len, double duration);
 
+/*  Same as above, but precision may be specified.
+ */
+int fsd_format_duration_ex (char *buf, size_t len, double duration, int prec);
+
 #endif /* !_UTIL_FSD_H */
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab

--- a/src/common/libutil/test/fsd.c
+++ b/src/common/libutil/test/fsd.c
@@ -125,6 +125,10 @@ int main(int argc, char** argv)
         "fsd_format_duration (86400.) works");
     is (buf, "1.2d", "returns expected string = %s", buf);
 
+    ok (fsd_format_duration_ex (buf, sizeof (buf), 62.0, 1),
+        "fsd_format_duration_ex (62., 1) works");
+    is (buf, "1m", "returns expected string = %s", buf);
+
     done_testing();
 }
 

--- a/src/common/libutil/test/fsd.c
+++ b/src/common/libutil/test/fsd.c
@@ -69,7 +69,7 @@ int main(int argc, char** argv)
     ok (fsd_parse_duration ("0.5m", &d) == 0,
         "fsd_parse_duration (0.5m) returns success");
     ok (d == 30., "got d == %g", d);
-    
+
     ok (fsd_parse_duration ("0.5h", &d) == 0,
         "fsd_parse_duration (0.5h) returns success");
     ok (d == .5 * 60. * 60., "got d == %g", d);
@@ -92,7 +92,7 @@ int main(int argc, char** argv)
 
     ok (fsd_format_duration (NULL, 1024, 1000.) < 0 && errno == EINVAL,
         "fsd_format_duration with buf == NULL returns EINVAL");
-    
+
     ok (fsd_format_duration (buf, sizeof (buf), .001),
         "fsd_format_duration (.001) works");
     is (buf, "0.001s", "returns expected string = %s", buf);

--- a/src/test/docker/bionic/Dockerfile
+++ b/src/test/docker/bionic/Dockerfile
@@ -77,6 +77,7 @@ RUN apt-get update \
         libczmq-dev \
         libjansson-dev \
         libmunge-dev \
+        libncursesw5-dev \
         liblua5.2-dev \
         liblz4-dev \
         libsqlite3-dev \

--- a/src/test/docker/centos7/Dockerfile
+++ b/src/test/docker/centos7/Dockerfile
@@ -24,6 +24,7 @@ RUN yum -y update \
       make \
       munge \
       munge-devel \
+      ncurses-devel \
       coreutils \
       ccache \
       cppcheck \

--- a/src/test/docker/centos8/Dockerfile
+++ b/src/test/docker/centos8/Dockerfile
@@ -51,6 +51,7 @@ RUN yum -y update \
 	czmq-devel \
 	jansson-devel \
 	munge-devel \
+	ncurses-devel \
 	lz4-devel \
 	sqlite-devel \
 	libuuid-devel \

--- a/src/test/docker/checks/Dockerfile
+++ b/src/test/docker/checks/Dockerfile
@@ -54,9 +54,9 @@ RUN case $BASE_IMAGE in \
 #  existing packages)
 #
 RUN case $BASE_IMAGE in \
-     bionic*) ;; \
-     focal*) ;; \
-     centos*|fedora*) ;; \
+     bionic*) apt update && apt install libncursesw5-dev ;; \
+     focal*) apt update && apt install libncurses-dev ;; \
+     centos*|fedora*) yum -y install ncurses-devel ;; \
      *) (>&2 echo "Unknown BASE_IMAGE") ;; \
     esac
 

--- a/src/test/docker/fedora33/Dockerfile
+++ b/src/test/docker/fedora33/Dockerfile
@@ -48,6 +48,7 @@ RUN yum -y update \
 	czmq-devel \
 	jansson-devel \
 	munge-devel \
+	ncurses-devel \
 	lz4-devel \
 	sqlite-devel \
 	libuuid-devel \

--- a/src/test/docker/fedora34/Dockerfile
+++ b/src/test/docker/fedora34/Dockerfile
@@ -48,6 +48,7 @@ RUN yum -y update \
 	czmq-devel \
 	jansson-devel \
 	munge-devel \
+	ncurses-devel \
 	lz4-devel \
 	sqlite-devel \
 	libuuid-devel \

--- a/src/test/docker/focal/Dockerfile
+++ b/src/test/docker/focal/Dockerfile
@@ -79,6 +79,7 @@ RUN apt-get update \
         libczmq-dev \
         libjansson-dev \
         libmunge-dev \
+        libncurses-dev \
         liblua5.2-dev \
         lua-posix-dev \
         liblz4-dev \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -172,6 +172,7 @@ TESTSCRIPTS = \
 	t2702-mini-alloc.t \
 	t2703-mini-bulksubmit.t \
 	t2800-jobs-cmd.t \
+	t2801-top-cmd.t \
 	t2900-job-timelimits.t \
 	t3000-mpi-basic.t \
 	t3001-mpi-personalities.t \

--- a/t/t2801-top-cmd.t
+++ b/t/t2801-top-cmd.t
@@ -1,0 +1,80 @@
+#!/bin/sh
+
+test_description='Test flux top command'
+
+. $(dirname $0)/sharness.sh
+
+test_under_flux 4
+
+runpty="${SHARNESS_TEST_SRCDIR}/scripts/runpty.py"
+waitfile="${SHARNESS_TEST_SRCDIR}/scripts/waitfile.lua"
+testssh="${SHARNESS_TEST_SRCDIR}/scripts/tssh"
+
+test_expect_success 'flux-top -h prints custom usage' '
+	flux top -h 2>usage &&
+	grep "Usage:.*JOBID" usage
+'
+test_expect_success 'flux-top fails on unknown option' '
+	test_must_fail flux top --notopt 2>notopt.err &&
+	grep "unrecognized option" notopt.err
+'
+test_expect_success 'flux-top fails if FLUX_URI is set wrong' '
+	(FLUX_URI=noturi test_must_fail flux top) 2>baduri.err &&
+	grep "connecting to Flux" baduri.err
+'
+test_expect_success 'flux-top fails if job argument is not a job ID' '
+	test_must_fail flux top notjob 2>badjobid.err &&
+	grep "failed to parse JOBID" badjobid.err
+'
+test_expect_success 'flux-top fails if job argument is unknown' '
+	test_must_fail flux top 12345 2>unkjobid.err &&
+	grep "unknown job" unkjobid.err
+'
+test_expect_success 'run a test job to completion' '
+	flux mini submit --wait -n1 /bin/true >jobid
+'
+test_expect_success 'flux-top fails if job is not running' '
+	test_must_fail flux top $(cat jobid) 2>notrun.err &&
+	grep "job is not running" notrun.err
+'
+test_expect_success 'flux-top fails if stdin is not a tty' '
+	test_must_fail flux top --test-exit </dev/null 2>notty.err &&
+	grep "stdin is not a terminal" notty.err
+'
+test_expect_success 'flux-top --test-exit works with a pty' '
+	$runpty flux top --test-exit >/dev/null
+'
+test_expect_success 'submit batch script and wait for it to start' '
+	cat >batch.sh <<-EOT &&
+	#!/bin/sh
+	touch job2-has-started
+	sleep inf
+	EOT
+	chmod +x batch.sh &&
+	flux mini batch -t30m -n1 batch.sh >jobid2 &&
+	$waitfile job2-has-started
+'
+test_expect_success 'flux-top JOBID works' '
+	FLUX_SSH=$testssh $runpty --format=asciicast -o topjob.log \
+		flux top --test-exit $(cat jobid2)
+'
+test_expect_success 'submit non-batch job and wait for it to start' '
+	flux mini submit -n1 \
+		bash -c "touch job3-has-started && sleep inf" >jobid3 &&
+	$waitfile job3-has-started
+'
+test_expect_success 'flux-top JOBID fails when JOBID is not a flux instance' '
+	FLUX_SSH=$testssh test_must_fail \
+		$runpty --format=asciicast -o notflux.log \
+		flux top --test-exit $(cat jobid3) &&
+	grep "not a Flux instance" notflux.log
+'
+test_expect_success NO_CHAIN_LINT 'flux-top quits on q keypress' '
+	$runpty --quit-char=q --format=asciicast -o keys.log flux top &
+	pid=$! &&
+	sleep 1 &&
+	kill -USR1 $pid &&
+	wait $pid
+'
+
+test_done


### PR DESCRIPTION
This adds a first cut at a `flux top` command.  Usage is `flux top [jobid]`.

There is quite a bit of explanation in the commit that adds the command so I won't duplicate that here.  Instead here are a couple of screen shots.  The first example is of monitoring a batch job running the throughput test:
```
ƒ(s=8,d=0,builddir) $ cat foo.sh
#!/bin/bash
/home/garlick/proj/flux-core/src/test/throughput.py -x -n 10000
ƒ(s=8,d=0,builddir) $ flux mini batch -n16 -t 10m foo.sh
ƒ3BBeCNddq
ƒ(s=8,d=0,builddir) $ flux top ƒ3BBeCNddq
```
The two turtles on the left indicate that this job has an instance depth of 1 (hierarchy of 2).  The hourglass on the right shows the time left in the instance, because it was submitted with a time limit.
![Screenshot from 2021-11-24 10-14-29](https://user-images.githubusercontent.com/169947/143301855-13267037-05da-484d-880c-49f30440ad67.png)

The second example shows fluke, with some nodes down graphed in red.  There is no expiration time in the system instance, so there is an infinity symbol in the upper right.  Its not shown in these screenshots, but a little heartbeat indicator flashes for each system heartbeat event message, letting you know the instance and `flux top`'s connection to it are functioning.

![Screenshot from 2021-11-24 11-29-42](https://user-images.githubusercontent.com/169947/143301963-88ce494a-9fa2-4d47-afd6-d72dcc0ee9fe.png)
