### PR TITLE
broker: log slow nodes during startup

### DIFF
--- a/etc/flux.service.in
+++ b/etc/flux.service.in
@@ -15,7 +15,8 @@ ExecStart=@X_BINDIR@/flux broker \
   -Slog-stderr-mode=local \
   -Scontent.backing-path=@X_LOCALSTATEDIR@/lib/flux/content.sqlite \
   -Sbroker.rc2_none \
-  -Sbroker.quorum=0
+  -Sbroker.quorum=0 \
+  -Sbroker.quorum-timeout=none
 ExecReload=@X_BINDIR@/flux config reload
 Restart=on-success
 RestartSec=5s

--- a/src/broker/state_machine.c
+++ b/src/broker/state_machine.c
@@ -218,7 +218,7 @@ static void action_quorum (struct state_machine *s)
                              0,
                              "{s:s}",
                              "name", "broker.online"))
-        || flux_future_then (f, -1, action_quorum_continuation, s)) {
+        || flux_future_then (f, -1, action_quorum_continuation, s) < 0) {
         flux_future_destroy (f);
         state_machine_post (s, "quorum-fail");
         return;


### PR DESCRIPTION
This is an attempt to improve logging somewhat when faced with the problem described in #3959, where flux gets stuck starting up because of a bad node, and doesn't provide any clues as to which node is the bad one.  A timer is added to the state machine which is started on rank 0 upon entering QUORUM state, and fires every 60s, logging the brokers that haven't checked in yet, until rank 0 exits the QUORUM state.  Here's an example with the timeout cranked down to 1s:
```
$ flux start -s8 -o,-Sbroker.quorum-timeout=1s
2021-11-28T00:09:52.631500Z broker.err[0]: quorum delayed: waiting for system76-pc (rank 7)
2021-11-28T00:09:52.680774Z broker.err[0]: quorum reached
ƒ(s=8,d=0,builddir) $
```

Unfortunately, if the bad node is a router on the overlay network, any of its children will likely be logged as well, so it may still be ambiguous which node is the root cause.  Still, probably better than nothing.