### PR TITLE
python: fix reference counting for Python Message objects

### DIFF
--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -267,6 +267,7 @@ dist_check_SCRIPTS = \
 	issues/t3920-running-underflow.sh \
 	issues/t3960-job-exec-ehostunreach.sh \
 	issues/t3906-job-exec-exception.sh \
+	issues/t3982-python-message-ref.py \
 	python/__init__.py \
 	python/subflux.py \
 	python/tap \

--- a/t/issues/t3982-python-message-ref.py
+++ b/t/issues/t3982-python-message-ref.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+#
+#  Test for issue #3982 - Ensure python handles message refcount properly
+#
+import sys
+import flux
+from flux.constants import FLUX_MSGTYPE_REQUEST
+
+_SAVED_MESSAGES = []
+
+
+def create_cb(fh, t, msg, timer):
+    _SAVED_MESSAGES.append(msg)
+    print("server: got request, starting timer", file=sys.stderr)
+    timer.start()
+
+
+def timer_cb(fh, *args, **kwargs):
+    try:
+        msg = _SAVED_MESSAGES.pop()
+    except IndexError:
+        pass
+    else:
+        fh.respond(msg, {"success": True})
+        print("server: responded to message", file=sys.stderr)
+
+
+def rpc_cb(future):
+    if future.get()["success"]:
+        print("client: Sucesss", file=sys.stderr)
+        future.get_flux().reactor_stop()
+    else:
+        future.get_flux().reactor_stop_error()
+
+
+fh = flux.Flux()
+fh.service_register("t3982").get()
+
+timer = fh.timer_watcher_create(0.01, timer_cb)
+
+w = fh.msg_watcher_create(create_cb, FLUX_MSGTYPE_REQUEST, "t3982.test", timer)
+w.start()
+
+fh.rpc("t3982.test", {}).then(rpc_cb)
+print("client: Sent request", file=sys.stderr)
+
+fh.reactor_run()


### PR DESCRIPTION
This appears to fix the issue described in #3982.

The `Message` class was probably written before `flux_msg_incref()`, and it tried to be smart about whether or not to "destruct" the underlying `flux_msg_t` on `Message` garbage collection. This led to possible use-after-free of `flux_msg_t` if a message is stashed from a msg_handler in Python for later use.

With the availablity of `flux_msg_incref()`, the handling of `Message` objects becomes more sane. We always call `flux_msg_decref()` when a `Message` is GC'd, and call `flux_msg_incref()` always, unless the `Message` constructor itself creates the underlying `flux_msg_t`.
