### PR TITLE
libflux: improve safety against refcounting bugs in low-level message functions

### DIFF
--- a/src/common/libflux/message.c
+++ b/src/common/libflux/message.c
@@ -370,11 +370,8 @@ int flux_msg_get_flags (const flux_msg_t *msg, uint8_t *flags)
 {
     if (msg_validate (msg) < 0)
         return -1;
-    if (!flags) {
-        errno = EINVAL;
-        return -1;
-    }
-    *flags = msg->flags;
+    if (flags)
+        *flags = msg->flags;
     return 0;
 }
 
@@ -442,11 +439,8 @@ int flux_msg_get_userid (const flux_msg_t *msg, uint32_t *userid)
 {
     if (msg_validate (msg) < 0)
         return -1;
-    if (!userid) {
-        errno = EINVAL;
-        return -1;
-    }
-    *userid = msg->userid;
+    if (userid)
+        *userid = msg->userid;
     return 0;
 }
 
@@ -462,11 +456,8 @@ int flux_msg_get_rolemask (const flux_msg_t *msg, uint32_t *rolemask)
 {
     if (msg_validate (msg) < 0)
         return -1;
-    if (!rolemask) {
-        errno = EINVAL;
-        return -1;
-    }
-    *rolemask = msg->rolemask;
+    if (rolemask)
+        *rolemask = msg->rolemask;
     return 0;
 }
 
@@ -537,15 +528,12 @@ int flux_msg_get_nodeid (const flux_msg_t *msg, uint32_t *nodeid)
 {
     if (msg_validate (msg) < 0)
         return -1;
-    if (!nodeid) {
-        errno = EINVAL;
-        return -1;
-    }
     if (msg->type != FLUX_MSGTYPE_REQUEST) {
         errno = EPROTO;
         return -1;
     }
-    *nodeid = msg->nodeid;
+    if (nodeid)
+        *nodeid = msg->nodeid;
     return 0;
 }
 
@@ -566,16 +554,13 @@ int flux_msg_get_errnum (const flux_msg_t *msg, int *errnum)
 {
     if (msg_validate (msg) < 0)
         return -1;
-    if (!errnum) {
-        errno = EINVAL;
-        return -1;
-    }
     if (msg->type != FLUX_MSGTYPE_RESPONSE
         && msg->type != FLUX_MSGTYPE_KEEPALIVE) {
         errno = EPROTO;
         return -1;
     }
-    *errnum = msg->errnum;
+    if (errnum)
+        *errnum = msg->errnum;
     return 0;
 }
 
@@ -595,15 +580,12 @@ int flux_msg_get_seq (const flux_msg_t *msg, uint32_t *seq)
 {
     if (msg_validate (msg) < 0)
         return -1;
-    if (!seq) {
-        errno = EINVAL;
-        return -1;
-    }
     if (msg->type != FLUX_MSGTYPE_EVENT) {
         errno = EPROTO;
         return -1;
     }
-    *seq = msg->sequence;
+    if (seq)
+        *seq = msg->sequence;
     return 0;
 }
 
@@ -624,16 +606,13 @@ int flux_msg_get_matchtag (const flux_msg_t *msg, uint32_t *matchtag)
 {
     if (msg_validate (msg) < 0)
         return -1;
-    if (!matchtag) {
-        errno = EINVAL;
-        return -1;
-    }
     if (msg->type != FLUX_MSGTYPE_REQUEST
         && msg->type != FLUX_MSGTYPE_RESPONSE) {
         errno = EPROTO;
         return -1;
     }
-    *matchtag = msg->matchtag;
+    if (matchtag)
+        *matchtag = msg->matchtag;
     return 0;
 }
 
@@ -653,15 +632,12 @@ int flux_msg_get_status (const flux_msg_t *msg, int *status)
 {
     if (msg_validate (msg) < 0)
         return -1;
-    if (!status) {
-        errno = EINVAL;
-        return -1;
-    }
     if (msg->type != FLUX_MSGTYPE_KEEPALIVE) {
         errno = EPROTO;
         return -1;
     }
-    *status = msg->status;
+    if (status)
+        *status = msg->status;
     return 0;
 }
 
@@ -994,10 +970,6 @@ int flux_msg_get_payload (const flux_msg_t *msg, const void **buf, int *size)
 {
     if (msg_validate (msg) < 0)
         return -1;
-    if (!buf && !size) {
-        errno = EINVAL;
-        return -1;
-    }
     if (!(msg->flags & FLUX_MSGFLAG_PAYLOAD)) {
         errno = EPROTO;
         return -1;
@@ -1028,28 +1000,24 @@ int flux_msg_set_string (flux_msg_t *msg, const char *s)
 int flux_msg_get_string (const flux_msg_t *msg, const char **s)
 {
     const char *buf;
+    const char *result;
     int size;
-    int rc = -1;
 
     if (msg_validate (msg) < 0)
         return -1;
-    if (!s) {
-        errno = EINVAL;
-        return -1;
-    }
     if (flux_msg_get_payload (msg, (const void **)&buf, &size) < 0) {
         errno = 0;
-        *s = NULL;
+        result = NULL;
     } else {
         if (!buf || size == 0 || buf[size - 1] != '\0') {
             errno = EPROTO;
-            goto done;
+            return -1;
         }
-        *s = buf;
+        result = buf;
     }
-    rc = 0;
-done:
-    return rc;
+    if (s)
+        *s = result;
+    return 0;
 }
 
 /* N.B. const attribute of msg argument is defeated internally to

--- a/src/common/libflux/message.c
+++ b/src/common/libflux/message.c
@@ -1443,15 +1443,20 @@ void flux_match_free (struct flux_match m)
     ERRNO_SAFE_WRAP (free, (char *)m.topic_glob);
 }
 
-int flux_match_asprintf (struct flux_match *m, const char *topic_glob_fmt, ...)
+int flux_match_asprintf (struct flux_match *m, const char *fmt, ...)
 {
-    va_list args;
-    va_start (args, topic_glob_fmt);
+    va_list ap;
     char *topic = NULL;
-    int res = vasprintf (&topic, topic_glob_fmt, args);
-    va_end (args);
+    int res;
+
+    va_start (ap, fmt);
+    res = vasprintf (&topic, fmt, ap);
+    va_end (ap);
+    if (res < 0)
+        return -1;
+
     m->topic_glob = topic;
-    return res;
+    return 0;
 }
 
 bool flux_msg_route_match_first (const flux_msg_t *msg1, const flux_msg_t *msg2)

--- a/src/common/libflux/message.c
+++ b/src/common/libflux/message.c
@@ -47,6 +47,15 @@
 #include "message_route.h"
 #include "message_proto.h"
 
+static int msg_validate (const flux_msg_t *msg)
+{
+    if (!msg || msg->refcount <= 0) {
+        errno = EINVAL;
+        return -1;
+    }
+    return 0;
+}
+
 static void msg_setup_type (flux_msg_t *msg)
 {
     switch (msg->type) {
@@ -96,9 +105,10 @@ flux_msg_t *flux_msg_create (int type)
 
 void flux_msg_destroy (flux_msg_t *msg)
 {
-    if (msg && --msg->refcount == 0) {
+    if (msg && msg->refcount > 0 && --msg->refcount == 0) {
         int saved_errno = errno;
-        flux_msg_route_clear (msg);
+        if ((msg->flags & FLUX_MSGFLAG_ROUTE))
+            msg_route_clear (msg);
         free (msg->topic);
         free (msg->payload);
         json_decref (msg->json);
@@ -124,10 +134,8 @@ const flux_msg_t *flux_msg_incref (const flux_msg_t *const_msg)
 {
     flux_msg_t *msg = (flux_msg_t *)const_msg;
 
-    if (!msg) {
-        errno = EINVAL;
+    if (msg_validate (msg) < 0)
         return NULL;
-    }
     msg->refcount++;
     return msg;
 }
@@ -140,19 +148,15 @@ int flux_msg_aux_set (const flux_msg_t *const_msg, const char *name,
                       void *aux, flux_free_f destroy)
 {
     flux_msg_t *msg = (flux_msg_t *)const_msg;
-    if (!msg) {
-        errno = EINVAL;
+    if (msg_validate (msg) < 0)
         return -1;
-    }
     return aux_set (&msg->aux, name, aux, destroy);
 }
 
 void *flux_msg_aux_get (const flux_msg_t *msg, const char *name)
 {
-    if (!msg) {
-        errno = EINVAL;
+    if (msg_validate (msg) < 0)
         return NULL;
-    }
     return aux_get (msg->aux, name);
 }
 
@@ -169,10 +173,8 @@ ssize_t flux_msg_encode_size (const flux_msg_t *msg)
 {
     ssize_t size = 0;
 
-    if (!msg) {
-        errno = EINVAL;
+    if (msg_validate (msg) < 0)
         return -1;
-    }
 
     encode_count (&size, PROTO_SIZE);
     if (msg->flags & FLUX_MSGFLAG_PAYLOAD)
@@ -223,10 +225,8 @@ int flux_msg_encode (const flux_msg_t *msg, void *buf, size_t size)
     ssize_t total = 0;
     ssize_t n;
 
-    if (!msg) {
-        errno = EINVAL;
+    if (msg_validate (msg) < 0)
         return -1;
-    }
     /* msg never completed initial setup */
     if (msg->type == FLUX_MSGTYPE_ANY) {
         errno = EPROTO;
@@ -324,10 +324,8 @@ error:
 
 int flux_msg_set_type (flux_msg_t *msg, int type)
 {
-    if (!msg) {
-        errno = EINVAL;
+    if (msg_validate (msg) < 0)
         return -1;
-    }
     if (type != FLUX_MSGTYPE_REQUEST
         && type != FLUX_MSGTYPE_RESPONSE
         && type != FLUX_MSGTYPE_EVENT
@@ -342,10 +340,8 @@ int flux_msg_set_type (flux_msg_t *msg, int type)
 
 int flux_msg_get_type (const flux_msg_t *msg, int *type)
 {
-    if (!msg) {
-        errno = EINVAL;
+    if (msg_validate (msg) < 0)
         return -1;
-    }
     (*type) = msg->type;
     return 0;
 }
@@ -357,8 +353,9 @@ int flux_msg_set_flags (flux_msg_t *msg, uint8_t flags)
                               | FLUX_MSGFLAG_PRIVATE | FLUX_MSGFLAG_STREAMING
                               | FLUX_MSGFLAG_NORESPONSE;
 
-    if (!msg
-        || (flags & ~valid_flags)
+    if (msg_validate (msg) < 0)
+        return -1;
+    if ((flags & ~valid_flags)
         || ((flags & FLUX_MSGFLAG_STREAMING)
             && (flags & FLUX_MSGFLAG_NORESPONSE))) {
         errno = EINVAL;
@@ -370,7 +367,9 @@ int flux_msg_set_flags (flux_msg_t *msg, uint8_t flags)
 
 int flux_msg_get_flags (const flux_msg_t *msg, uint8_t *flags)
 {
-    if (!msg || !flags) {
+    if (msg_validate (msg) < 0)
+        return -1;
+    if (!flags) {
         errno = EINVAL;
         return -1;
     }
@@ -380,10 +379,8 @@ int flux_msg_get_flags (const flux_msg_t *msg, uint8_t *flags)
 
 int flux_msg_set_private (flux_msg_t *msg)
 {
-    if (!msg) {
-        errno = EINVAL;
+    if (msg_validate (msg) < 0)
         return -1;
-    }
     if (flux_msg_set_flags (msg, msg->flags | FLUX_MSGFLAG_PRIVATE) < 0)
         return -1;
     return 0;
@@ -391,7 +388,7 @@ int flux_msg_set_private (flux_msg_t *msg)
 
 bool flux_msg_is_private (const flux_msg_t *msg)
 {
-    if (!msg)
+    if (msg_validate (msg) < 0)
         return true;
     return (msg->flags & FLUX_MSGFLAG_PRIVATE) ? true : false;
 }
@@ -399,10 +396,8 @@ bool flux_msg_is_private (const flux_msg_t *msg)
 int flux_msg_set_streaming (flux_msg_t *msg)
 {
     uint8_t flags;
-    if (!msg) {
-        errno = EINVAL;
+    if (msg_validate (msg) < 0)
         return -1;
-    }
     flags = msg->flags & ~FLUX_MSGFLAG_NORESPONSE;
     if (flux_msg_set_flags (msg, flags | FLUX_MSGFLAG_STREAMING) < 0)
         return -1;
@@ -411,7 +406,7 @@ int flux_msg_set_streaming (flux_msg_t *msg)
 
 bool flux_msg_is_streaming (const flux_msg_t *msg)
 {
-    if (!msg)
+    if (msg_validate (msg) < 0)
         return true;
     return (msg->flags & FLUX_MSGFLAG_STREAMING) ? true : false;
 }
@@ -419,10 +414,8 @@ bool flux_msg_is_streaming (const flux_msg_t *msg)
 int flux_msg_set_noresponse (flux_msg_t *msg)
 {
     uint8_t flags = 0;
-    if (!msg) {
-        errno = EINVAL;
+    if (msg_validate (msg) < 0)
         return -1;
-    }
     flags = msg->flags & ~FLUX_MSGFLAG_STREAMING;
     if (flux_msg_set_flags (msg, flags | FLUX_MSGFLAG_NORESPONSE) < 0)
         return -1;
@@ -431,24 +424,24 @@ int flux_msg_set_noresponse (flux_msg_t *msg)
 
 bool flux_msg_is_noresponse (const flux_msg_t *msg)
 {
-    if (!msg)
+    if (msg_validate (msg) < 0)
         return true;
     return (msg->flags & FLUX_MSGFLAG_NORESPONSE) ? true : false;
 }
 
 int flux_msg_set_userid (flux_msg_t *msg, uint32_t userid)
 {
-    if (!msg) {
-        errno = EINVAL;
+    if (msg_validate (msg) < 0)
         return -1;
-    }
     msg->userid = userid;
     return 0;
 }
 
 int flux_msg_get_userid (const flux_msg_t *msg, uint32_t *userid)
 {
-    if (!msg || !userid) {
+    if (msg_validate (msg) < 0)
+        return -1;
+    if (!userid) {
         errno = EINVAL;
         return -1;
     }
@@ -458,17 +451,17 @@ int flux_msg_get_userid (const flux_msg_t *msg, uint32_t *userid)
 
 int flux_msg_set_rolemask (flux_msg_t *msg, uint32_t rolemask)
 {
-    if (!msg) {
-        errno = EINVAL;
+    if (msg_validate (msg) < 0)
         return -1;
-    }
     msg->rolemask = rolemask;
     return 0;
 }
 
 int flux_msg_get_rolemask (const flux_msg_t *msg, uint32_t *rolemask)
 {
-    if (!msg || !rolemask) {
+    if (msg_validate (msg) < 0)
+        return -1;
+    if (!rolemask) {
         errno = EINVAL;
         return -1;
     }
@@ -478,7 +471,9 @@ int flux_msg_get_rolemask (const flux_msg_t *msg, uint32_t *rolemask)
 
 int flux_msg_get_cred (const flux_msg_t *msg, struct flux_msg_cred *cred)
 {
-    if (!msg || !cred) {
+    if (msg_validate (msg) < 0)
+        return -1;
+    if (!cred) {
         errno = EINVAL;
         return -1;
     }
@@ -491,10 +486,8 @@ int flux_msg_get_cred (const flux_msg_t *msg, struct flux_msg_cred *cred)
 
 int flux_msg_set_cred (flux_msg_t *msg, struct flux_msg_cred cred)
 {
-    if (!msg) {
-        errno = EINVAL;
+    if (msg_validate (msg) < 0)
         return -1;
-    }
     if (flux_msg_set_rolemask (msg, cred.rolemask) < 0)
         return -1;
     if (flux_msg_set_userid (msg, cred.userid) < 0)
@@ -526,8 +519,8 @@ int flux_msg_authorize (const flux_msg_t *msg, uint32_t userid)
 
 int flux_msg_set_nodeid (flux_msg_t *msg, uint32_t nodeid)
 {
-    if (!msg)
-        goto error;
+    if (msg_validate (msg) < 0)
+        return -1;
     if (nodeid == FLUX_NODEID_UPSTREAM) /* should have been resolved earlier */
         goto error;
     if (msg->type != FLUX_MSGTYPE_REQUEST)
@@ -541,7 +534,9 @@ error:
 
 int flux_msg_get_nodeid (const flux_msg_t *msg, uint32_t *nodeidp)
 {
-    if (!msg || !nodeidp) {
+    if (msg_validate (msg) < 0)
+        return -1;
+    if (!nodeidp) {
         errno = EINVAL;
         return -1;
     }
@@ -555,9 +550,10 @@ int flux_msg_get_nodeid (const flux_msg_t *msg, uint32_t *nodeidp)
 
 int flux_msg_set_errnum (flux_msg_t *msg, int e)
 {
-    if (!msg
-        || (msg->type != FLUX_MSGTYPE_RESPONSE
-            && msg->type != FLUX_MSGTYPE_KEEPALIVE)) {
+    if (msg_validate (msg) < 0)
+        return -1;
+    if (msg->type != FLUX_MSGTYPE_RESPONSE
+        && msg->type != FLUX_MSGTYPE_KEEPALIVE) {
         errno = EINVAL;
         return -1;
     }
@@ -567,7 +563,9 @@ int flux_msg_set_errnum (flux_msg_t *msg, int e)
 
 int flux_msg_get_errnum (const flux_msg_t *msg, int *e)
 {
-    if (!msg || !e) {
+    if (msg_validate (msg) < 0)
+        return -1;
+    if (!e) {
         errno = EINVAL;
         return -1;
     }
@@ -582,7 +580,9 @@ int flux_msg_get_errnum (const flux_msg_t *msg, int *e)
 
 int flux_msg_set_seq (flux_msg_t *msg, uint32_t seq)
 {
-    if (!msg || msg->type != FLUX_MSGTYPE_EVENT) {
+    if (msg_validate (msg) < 0)
+        return -1;
+    if (msg->type != FLUX_MSGTYPE_EVENT) {
         errno = EINVAL;
         return -1;
     }
@@ -592,7 +592,9 @@ int flux_msg_set_seq (flux_msg_t *msg, uint32_t seq)
 
 int flux_msg_get_seq (const flux_msg_t *msg, uint32_t *seq)
 {
-    if (!msg || !seq) {
+    if (msg_validate (msg) < 0)
+        return -1;
+    if (!seq) {
         errno = EINVAL;
         return -1;
     }
@@ -606,9 +608,10 @@ int flux_msg_get_seq (const flux_msg_t *msg, uint32_t *seq)
 
 int flux_msg_set_matchtag (flux_msg_t *msg, uint32_t t)
 {
-    if (!msg
-        || (msg->type != FLUX_MSGTYPE_REQUEST
-            && msg->type != FLUX_MSGTYPE_RESPONSE)) {
+    if (msg_validate (msg) < 0)
+        return -1;
+    if (msg->type != FLUX_MSGTYPE_REQUEST
+        && msg->type != FLUX_MSGTYPE_RESPONSE) {
         errno = EINVAL;
         return -1;
     }
@@ -618,7 +621,9 @@ int flux_msg_set_matchtag (flux_msg_t *msg, uint32_t t)
 
 int flux_msg_get_matchtag (const flux_msg_t *msg, uint32_t *t)
 {
-    if (!msg || !t) {
+    if (msg_validate (msg) < 0)
+        return -1;
+    if (!t) {
         errno = EINVAL;
         return -1;
     }
@@ -633,7 +638,9 @@ int flux_msg_get_matchtag (const flux_msg_t *msg, uint32_t *t)
 
 int flux_msg_set_status (flux_msg_t *msg, int s)
 {
-    if (!msg || msg->type != FLUX_MSGTYPE_KEEPALIVE) {
+    if (msg_validate (msg) < 0)
+        return -1;
+    if (msg->type != FLUX_MSGTYPE_KEEPALIVE) {
         errno = EINVAL;
         return -1;
     }
@@ -643,7 +650,9 @@ int flux_msg_set_status (flux_msg_t *msg, int s)
 
 int flux_msg_get_status (const flux_msg_t *msg, int *s)
 {
-    if (!msg || !s) {
+    if (msg_validate (msg) < 0)
+        return -1;
+    if (!s) {
         errno = EINVAL;
         return -1;
     }
@@ -714,14 +723,14 @@ bool flux_msg_cmp (const flux_msg_t *msg, struct flux_match match)
 
 void flux_msg_route_enable (flux_msg_t *msg)
 {
-    if (!msg || (msg->flags & FLUX_MSGFLAG_ROUTE))
+    if (msg_validate (msg) < 0 || (msg->flags & FLUX_MSGFLAG_ROUTE))
         return;
     (void) flux_msg_set_flags (msg, msg->flags | FLUX_MSGFLAG_ROUTE);
 }
 
 void flux_msg_route_disable (flux_msg_t *msg)
 {
-    if (!msg || (!(msg->flags & FLUX_MSGFLAG_ROUTE)))
+    if (msg_validate (msg) < 0 || (!(msg->flags & FLUX_MSGFLAG_ROUTE)))
         return;
     flux_msg_route_clear (msg);
     (void) flux_msg_set_flags (msg, msg->flags & ~(uint8_t)FLUX_MSGFLAG_ROUTE);
@@ -729,14 +738,16 @@ void flux_msg_route_disable (flux_msg_t *msg)
 
 void flux_msg_route_clear (flux_msg_t *msg)
 {
-    if (!msg || (!(msg->flags & FLUX_MSGFLAG_ROUTE)))
+    if (msg_validate (msg) < 0 || (!(msg->flags & FLUX_MSGFLAG_ROUTE)))
         return;
     msg_route_clear (msg);
 }
 
 int flux_msg_route_push (flux_msg_t *msg, const char *id)
 {
-    if (!msg || !id) {
+    if (msg_validate (msg) < 0)
+        return -1;
+    if (!id) {
         errno = EINVAL;
         return -1;
     }
@@ -749,10 +760,8 @@ int flux_msg_route_push (flux_msg_t *msg, const char *id)
 
 int flux_msg_route_delete_last (flux_msg_t *msg)
 {
-    if (!msg) {
-        errno = EINVAL;
+    if (msg_validate (msg) < 0)
         return -1;
-    }
     if (!(msg->flags & FLUX_MSGFLAG_ROUTE)) {
         errno = EPROTO;
         return -1;
@@ -765,7 +774,7 @@ const char *flux_msg_route_last (const flux_msg_t *msg)
 {
     struct route_id *r;
 
-    if (!msg || !(msg->flags & FLUX_MSGFLAG_ROUTE))
+    if (msg_validate (msg) < 0 || !(msg->flags & FLUX_MSGFLAG_ROUTE))
         return NULL;
     if ((r = list_top (&msg->routes, struct route_id, route_id_node)))
         return r->id;
@@ -777,7 +786,7 @@ const char *flux_msg_route_first (const flux_msg_t *msg)
 {
     struct route_id *r;
 
-    if (!msg || !(msg->flags & FLUX_MSGFLAG_ROUTE))
+    if (msg_validate (msg) < 0 || !(msg->flags & FLUX_MSGFLAG_ROUTE))
         return NULL;
     if ((r = list_tail (&msg->routes, struct route_id, route_id_node)))
         return r->id;
@@ -786,10 +795,8 @@ const char *flux_msg_route_first (const flux_msg_t *msg)
 
 int flux_msg_route_count (const flux_msg_t *msg)
 {
-    if (!msg) {
-        errno = EINVAL;
+    if (msg_validate (msg) < 0)
         return -1;
-    }
     if (!(msg->flags & FLUX_MSGFLAG_ROUTE)) {
         errno = EPROTO;
         return -1;
@@ -820,10 +827,8 @@ char *flux_msg_route_string (const flux_msg_t *msg)
     int hops, len;
     char *buf, *cp;
 
-    if (!msg) {
-        errno = EINVAL;
+    if (msg_validate (msg) < 0)
         return NULL;
-    }
     if (!(msg->flags & FLUX_MSGFLAG_ROUTE)) {
         errno = EPROTO;
         return NULL;
@@ -857,10 +862,8 @@ int flux_msg_set_payload (flux_msg_t *msg, const void *buf, int size)
 {
     uint8_t flags = 0;
 
-    if (!msg) {
-        errno = EINVAL;
+    if (msg_validate (msg) < 0)
         return -1;
-    }
     json_decref (msg->json);            /* invalidate cached json object */
     msg->json = NULL;
     flags = msg->flags;
@@ -911,7 +914,7 @@ int flux_msg_set_payload (flux_msg_t *msg, const void *buf, int size)
 
 static inline void msg_lasterr_reset (flux_msg_t *msg)
 {
-    if (msg) {
+    if (msg_validate (msg) == 0) {
         free (msg->lasterr);
         msg->lasterr = NULL;
     }
@@ -941,7 +944,9 @@ int flux_msg_vpack (flux_msg_t *msg, const char *fmt, va_list ap)
 
     msg_lasterr_reset (msg);
 
-    if (!msg || !fmt || *fmt == '\0')
+    if (msg_validate (msg) < 0)
+        return -1;
+    if (!fmt || *fmt == '\0')
         goto error_inval;
 
     if (!(json = json_vpack_ex (&err, 0, fmt, ap))) {
@@ -986,7 +991,9 @@ int flux_msg_pack (flux_msg_t *msg, const char *fmt, ...)
 
 int flux_msg_get_payload (const flux_msg_t *msg, const void **buf, int *size)
 {
-    if (!msg || (!buf && !size)) {
+    if (msg_validate (msg) < 0)
+        return -1;
+    if (!buf && !size) {
         errno = EINVAL;
         return -1;
     }
@@ -1003,7 +1010,7 @@ int flux_msg_get_payload (const flux_msg_t *msg, const void **buf, int *size)
 
 bool flux_msg_has_payload (const flux_msg_t *msg)
 {
-    if (!msg)
+    if (msg_validate (msg) < 0)
         return false;
     return ((msg->flags & FLUX_MSGFLAG_PAYLOAD));
 }
@@ -1023,9 +1030,11 @@ int flux_msg_get_string (const flux_msg_t *msg, const char **s)
     int size;
     int rc = -1;
 
+    if (msg_validate (msg) < 0)
+        return -1;
     if (!s) {
         errno = EINVAL;
-        goto done;
+        return -1;
     }
     if (flux_msg_get_payload (msg, (const void **)&buf, &size) < 0) {
         errno = 0;
@@ -1054,7 +1063,9 @@ int flux_msg_vunpack (const flux_msg_t *cmsg, const char *fmt, va_list ap)
 
     msg_lasterr_reset (msg);
 
-    if (!msg || !fmt || *fmt == '\0') {
+    if (msg_validate (msg) < 0)
+        return -1;
+    if (!fmt || *fmt == '\0') {
         errno = EINVAL;
         return -1;
     }
@@ -1102,6 +1113,8 @@ const char *flux_msg_last_error (const flux_msg_t *msg)
 {
     if (!msg)
         return "msg object is NULL";
+    if (msg->refcount <= 0)
+        return "msg object is unreferenced";
     if (msg->lasterr == NULL)
         return "";
     return msg->lasterr;
@@ -1111,10 +1124,8 @@ int flux_msg_set_topic (flux_msg_t *msg, const char *topic)
 {
     uint8_t flags = 0;
 
-    if (!msg) {
-        errno = EINVAL;
+    if (msg_validate (msg) < 0)
         return -1;
-    }
     flags = msg->flags;
     if ((flags & FLUX_MSGFLAG_TOPIC) && topic) {        /* case 1: repl topic */
         free (msg->topic);
@@ -1138,7 +1149,9 @@ int flux_msg_set_topic (flux_msg_t *msg, const char *topic)
 
 int flux_msg_get_topic (const flux_msg_t *msg, const char **topic)
 {
-    if (!msg || !topic) {
+    if (msg_validate (msg) < 0)
+        return -1;
+    if (!topic) {
         errno = EINVAL;
         return -1;
     }
@@ -1154,10 +1167,8 @@ flux_msg_t *flux_msg_copy (const flux_msg_t *msg, bool payload)
 {
     flux_msg_t *cpy = NULL;
 
-    if (!msg) {
-        errno = EINVAL;
+    if (msg_validate (msg) < 0)
         return NULL;
-    }
 
     if (!(cpy = flux_msg_create (FLUX_MSGTYPE_ANY)))
         return NULL;
@@ -1324,6 +1335,10 @@ void flux_msg_fprint_ts (FILE *f, const flux_msg_t *msg, double timestamp)
         fprintf (f, "NULL");
         return;
     }
+    if (msg->refcount <= 0) {
+        fprintf (f, "unref");
+        return;
+    }
     prefix = type2prefix (msg->type);
     /* Timestamp
      */
@@ -1418,10 +1433,8 @@ void flux_msg_fprint (FILE *f, const flux_msg_t *msg)
 int flux_msg_frames (const flux_msg_t *msg)
 {
     int n = 1; /* 1 for proto frame */
-    if (!msg) {
-        errno = EINVAL;
+    if (msg_validate (msg) < 0)
         return -1;
-    }
     if (msg->flags & FLUX_MSGFLAG_PAYLOAD)
         n++;
     if (msg->flags & FLUX_MSGFLAG_TOPIC)

--- a/src/common/libflux/message.c
+++ b/src/common/libflux/message.c
@@ -350,29 +350,31 @@ int flux_msg_get_type (const flux_msg_t *msg, int *type)
     return 0;
 }
 
-int flux_msg_set_flags (flux_msg_t *msg, uint8_t fl)
+int flux_msg_set_flags (flux_msg_t *msg, uint8_t flags)
 {
     const uint8_t valid_flags = FLUX_MSGFLAG_TOPIC | FLUX_MSGFLAG_PAYLOAD
                               | FLUX_MSGFLAG_ROUTE | FLUX_MSGFLAG_UPSTREAM
                               | FLUX_MSGFLAG_PRIVATE | FLUX_MSGFLAG_STREAMING
                               | FLUX_MSGFLAG_NORESPONSE;
 
-    if (!msg || fl & ~valid_flags || ((fl & FLUX_MSGFLAG_STREAMING)
-                                   && (fl & FLUX_MSGFLAG_NORESPONSE)) != 0) {
+    if (!msg
+        || (flags & ~valid_flags)
+        || ((flags & FLUX_MSGFLAG_STREAMING)
+            && (flags & FLUX_MSGFLAG_NORESPONSE))) {
         errno = EINVAL;
         return -1;
     }
-    msg->flags = fl;
+    msg->flags = flags;
     return 0;
 }
 
-int flux_msg_get_flags (const flux_msg_t *msg, uint8_t *fl)
+int flux_msg_get_flags (const flux_msg_t *msg, uint8_t *flags)
 {
-    if (!msg || !fl) {
+    if (!msg || !flags) {
         errno = EINVAL;
         return -1;
     }
-    (*fl) = msg->flags;
+    *flags = msg->flags;
     return 0;
 }
 

--- a/src/common/libflux/message.c
+++ b/src/common/libflux/message.c
@@ -533,11 +533,11 @@ error:
     return -1;
 }
 
-int flux_msg_get_nodeid (const flux_msg_t *msg, uint32_t *nodeidp)
+int flux_msg_get_nodeid (const flux_msg_t *msg, uint32_t *nodeid)
 {
     if (msg_validate (msg) < 0)
         return -1;
-    if (!nodeidp) {
+    if (!nodeid) {
         errno = EINVAL;
         return -1;
     }
@@ -545,11 +545,11 @@ int flux_msg_get_nodeid (const flux_msg_t *msg, uint32_t *nodeidp)
         errno = EPROTO;
         return -1;
     }
-    *nodeidp = msg->nodeid;
+    *nodeid = msg->nodeid;
     return 0;
 }
 
-int flux_msg_set_errnum (flux_msg_t *msg, int e)
+int flux_msg_set_errnum (flux_msg_t *msg, int errnum)
 {
     if (msg_validate (msg) < 0)
         return -1;
@@ -558,15 +558,15 @@ int flux_msg_set_errnum (flux_msg_t *msg, int e)
         errno = EINVAL;
         return -1;
     }
-    msg->errnum = e;
+    msg->errnum = errnum;
     return 0;
 }
 
-int flux_msg_get_errnum (const flux_msg_t *msg, int *e)
+int flux_msg_get_errnum (const flux_msg_t *msg, int *errnum)
 {
     if (msg_validate (msg) < 0)
         return -1;
-    if (!e) {
+    if (!errnum) {
         errno = EINVAL;
         return -1;
     }
@@ -575,7 +575,7 @@ int flux_msg_get_errnum (const flux_msg_t *msg, int *e)
         errno = EPROTO;
         return -1;
     }
-    *e = msg->errnum;
+    *errnum = msg->errnum;
     return 0;
 }
 
@@ -607,7 +607,7 @@ int flux_msg_get_seq (const flux_msg_t *msg, uint32_t *seq)
     return 0;
 }
 
-int flux_msg_set_matchtag (flux_msg_t *msg, uint32_t t)
+int flux_msg_set_matchtag (flux_msg_t *msg, uint32_t matchtag)
 {
     if (msg_validate (msg) < 0)
         return -1;
@@ -616,15 +616,15 @@ int flux_msg_set_matchtag (flux_msg_t *msg, uint32_t t)
         errno = EINVAL;
         return -1;
     }
-    msg->matchtag = t;
+    msg->matchtag = matchtag;
     return 0;
 }
 
-int flux_msg_get_matchtag (const flux_msg_t *msg, uint32_t *t)
+int flux_msg_get_matchtag (const flux_msg_t *msg, uint32_t *matchtag)
 {
     if (msg_validate (msg) < 0)
         return -1;
-    if (!t) {
+    if (!matchtag) {
         errno = EINVAL;
         return -1;
     }
@@ -633,11 +633,11 @@ int flux_msg_get_matchtag (const flux_msg_t *msg, uint32_t *t)
         errno = EPROTO;
         return -1;
     }
-    *t = msg->matchtag;
+    *matchtag = msg->matchtag;
     return 0;
 }
 
-int flux_msg_set_status (flux_msg_t *msg, int s)
+int flux_msg_set_status (flux_msg_t *msg, int status)
 {
     if (msg_validate (msg) < 0)
         return -1;
@@ -645,15 +645,15 @@ int flux_msg_set_status (flux_msg_t *msg, int s)
         errno = EINVAL;
         return -1;
     }
-    msg->status = s;
+    msg->status = status;
     return 0;
 }
 
-int flux_msg_get_status (const flux_msg_t *msg, int *s)
+int flux_msg_get_status (const flux_msg_t *msg, int *status)
 {
     if (msg_validate (msg) < 0)
         return -1;
-    if (!s) {
+    if (!status) {
         errno = EINVAL;
         return -1;
     }
@@ -661,7 +661,7 @@ int flux_msg_get_status (const flux_msg_t *msg, int *s)
         errno = EPROTO;
         return -1;
     }
-    *s = msg->status;
+    *status = msg->status;
     return 0;
 }
 

--- a/src/common/libflux/message.c
+++ b/src/common/libflux/message.c
@@ -342,7 +342,8 @@ int flux_msg_get_type (const flux_msg_t *msg, int *type)
 {
     if (msg_validate (msg) < 0)
         return -1;
-    (*type) = msg->type;
+    if (type)
+        *type = msg->type;
     return 0;
 }
 

--- a/src/common/libflux/message.c
+++ b/src/common/libflux/message.c
@@ -446,7 +446,7 @@ int flux_msg_get_userid (const flux_msg_t *msg, uint32_t *userid)
         errno = EINVAL;
         return -1;
     }
-    (*userid) = msg->userid;
+    *userid = msg->userid;
     return 0;
 }
 
@@ -466,7 +466,7 @@ int flux_msg_get_rolemask (const flux_msg_t *msg, uint32_t *rolemask)
         errno = EINVAL;
         return -1;
     }
-    (*rolemask) = msg->rolemask;
+    *rolemask = msg->rolemask;
     return 0;
 }
 
@@ -603,7 +603,7 @@ int flux_msg_get_seq (const flux_msg_t *msg, uint32_t *seq)
         errno = EPROTO;
         return -1;
     }
-    (*seq) = msg->sequence;
+    *seq = msg->sequence;
     return 0;
 }
 
@@ -633,7 +633,7 @@ int flux_msg_get_matchtag (const flux_msg_t *msg, uint32_t *t)
         errno = EPROTO;
         return -1;
     }
-    (*t) = msg->matchtag;
+    *t = msg->matchtag;
     return 0;
 }
 
@@ -661,7 +661,7 @@ int flux_msg_get_status (const flux_msg_t *msg, int *s)
         errno = EPROTO;
         return -1;
     }
-    (*s) = msg->status;
+    *s = msg->status;
     return 0;
 }
 

--- a/src/common/libflux/test/message.c
+++ b/src/common/libflux/test/message.c
@@ -92,6 +92,8 @@ void check_cornercase (void)
     errno = 0;
     ok (flux_msg_get_type (NULL, &type) < 0 && errno == EINVAL,
         "flux_msg_get_type fails with EINVAL on msg = NULL");
+    lives_ok ({flux_msg_get_type (msg, NULL);},
+        "flux_msg_get_type doesn't segfault with NULL type arg");
 
     errno = 0;
     ok (flux_msg_set_private (NULL) < 0 && errno == EINVAL,

--- a/src/common/libflux/test/message.c
+++ b/src/common/libflux/test/message.c
@@ -127,9 +127,8 @@ void check_cornercase (void)
     errno = 0;
     ok (flux_msg_get_payload (NULL, NULL, NULL) < 0 && errno == EINVAL,
         "flux_msg_get_payload msg=NULL fails with EINVAL");
-    errno = 0;
-    ok (flux_msg_get_payload (msg, NULL, NULL) < 0 && errno == EINVAL,
-       "flux_msg_get_payload fails with EINVAL on in-and-out params = NULL");
+    lives_ok ({flux_msg_get_payload (msg, NULL, NULL);},
+       "flux_msg_get_payload does not segfault on in-and-out params = NULL");
     errno = 0;
     ok (flux_msg_get_payload (msg, &payload, &payload_size) < 0
         && errno == EPROTO,
@@ -140,9 +139,8 @@ void check_cornercase (void)
     errno = 0;
     ok (flux_msg_get_flags (NULL, &flags) < 0 && errno == EINVAL,
         "flux_msg_get_flags msg=NULL fails with EINVAL");
-    errno = 0;
-    ok (flux_msg_get_flags (msg, NULL) < 0 && errno == EINVAL,
-        "flux_msg_get_flags flags=NULL fails with EINVAL");
+    lives_ok ({flux_msg_get_flags (msg, NULL);},
+        "flux_msg_get_flags flags=NULL does not segfault");
     errno = 0;
     ok (flux_msg_set_flags (NULL, 0) < 0 && errno == EINVAL,
         "flux_msg_set_flags msg=NULL fails with EINVAL");
@@ -180,18 +178,16 @@ void check_cornercase (void)
     errno = 0;
     ok (flux_msg_get_userid (NULL, &cred.userid) < 0 && errno == EINVAL,
         "flux_msg_get_userid msg=NULL fails with EINVAL");
-    errno = 0;
-    ok (flux_msg_get_userid (msg, NULL) < 0 && errno == EINVAL,
-        "flux_msg_get_userid userid=NULL fails with EINVAL");
+    lives_ok ({flux_msg_get_userid (msg, NULL);},
+        "flux_msg_get_userid userid=NULL does not segfault");
     errno = 0;
     ok (flux_msg_set_userid (NULL, cred.userid) < 0 && errno == EINVAL,
         "flux_msg_set_userid msg=NULL fails with EINVAL");
     errno = 0;
     ok (flux_msg_get_rolemask (NULL, &cred.rolemask) < 0 && errno == EINVAL,
         "flux_msg_get_rolemask msg=NULL fails with EINVAL");
-    errno = 0;
-    ok (flux_msg_get_rolemask (msg, NULL) < 0 && errno == EINVAL,
-        "flux_msg_get_rolemask rolemask=NULL fails with EINVAL");
+    lives_ok ({flux_msg_get_rolemask (msg, NULL);},
+        "flux_msg_get_rolemask rolemask=NULL does not segfault");
     errno = 0;
     ok (flux_msg_set_rolemask (NULL, cred.rolemask) < 0 && errno == EINVAL,
         "flux_msg_set_rolemask msg=NULL fails with EINVAL");
@@ -215,9 +211,8 @@ void check_cornercase (void)
     errno = 0;
     ok (flux_msg_get_errnum (NULL, &errnum) < 0 && errno == EINVAL,
         "flux_msg_get_errnum fails with EINVAL on msg = NULL");
-    errno = 0;
-    ok (flux_msg_get_errnum (msg, NULL) < 0 && errno == EINVAL,
-        "flux_msg_get_errnum fails with EINVAL on in-and-out param = NULL");
+    lives_ok ({flux_msg_get_errnum (msg, NULL);},
+        "flux_msg_get_errnum errnum = NULL does not segfault");
     errno = 0;
     ok (flux_msg_get_errnum (req, &errnum) < 0 && errno == EPROTO,
         "flux_msg_get_errnum fails with EPROTO on msg != response type");
@@ -227,9 +222,8 @@ void check_cornercase (void)
     errno = 0;
     ok (flux_msg_get_seq (NULL, &seq) < 0 && errno == EINVAL,
         "flux_msg_get_seq fails with EINVAL on msg = NULL");
-    errno = 0;
-    ok (flux_msg_get_seq (msg, NULL) < 0 && errno == EINVAL,
-        "flux_msg_get_seq fails with EINVAL on in-and-out param = NULL");
+    lives_ok ({flux_msg_get_seq (msg, NULL);},
+        "flux_msg_get_seq seq = NULL does not segfault");
     errno = 0;
     ok (flux_msg_get_seq (req, &seq) < 0 && errno == EPROTO,
         "flux_msg_get_seq fails with EPROTO on msg != event type");
@@ -239,9 +233,8 @@ void check_cornercase (void)
     errno = 0;
     ok (flux_msg_get_status (NULL, &status) < 0 && errno == EINVAL,
         "flux_msg_get_status fails with EINVAL on msg = NULL");
-    errno = 0;
-    ok (flux_msg_get_status (msg, NULL) < 0 && errno == EINVAL,
-        "flux_msg_get_status fails with EINVAL on in-and-out param = NULL");
+    lives_ok ({flux_msg_get_status (msg, NULL);},
+        "flux_msg_get_status status = NULL does not segfault");
     errno = 0;
     ok (flux_msg_get_status (req, &status) < 0 && errno == EPROTO,
         "flux_msg_get_status fails with EPROTO on msg != keepalive type");
@@ -251,9 +244,8 @@ void check_cornercase (void)
     errno = 0;
     ok (flux_msg_get_matchtag (NULL, &tag) < 0 && errno == EINVAL,
         "flux_msg_get_matchtag fails with EINVAL on msg = NULL");
-    errno = 0;
-    ok (flux_msg_get_matchtag (msg, NULL) < 0 && errno == EINVAL,
-        "flux_msg_get_matchtag fails with EINVAL on in-and-out param = NULL");
+    lives_ok ({flux_msg_get_matchtag (msg, NULL);},
+        "flux_msg_get_matchtag matchtag = NULL does not segfault");
     errno = 0;
     ok (flux_msg_get_matchtag (evt, &tag) < 0 && errno == EPROTO,
         "flux_msg_get_matchtag fails with EPROTO on msg != req/rsp type");


### PR DESCRIPTION
This PR extends the NULL safety check in many `flux_msg_*()` functions to include checking that the message reference count is nonzero.  I verified that the reproducer for #3982 no longer sends a misdirected response to the broker groups service (it just hangs now).  Hopefully these checks will make message refcounting bugs more straigtforward to track down.

There's also a bit of gratuitous cleanup in here (couldn't resist).