### PR TITLE
docker: fix and update ci dockerfiles

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -14,7 +14,7 @@ queue_rules:
       - status-success="bionic - test-install"
       - status-success="focal - py3.8"
       - status-success="centos7"
-      - status-success="centos8 - py3.7"
+      - status-success="centos8"
       - status-success="fedora33 - gcc-10,py3.9"
       - status-success="fedora34 - gcc-11.2,py3.9"
       - status-success="coverage"

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ lua-posix         | lua-posix         |                   |
 python36-devel    | python3-dev       | >= 3.6            |
 python36-cffi     | python3-cffi      | >= 1.1            |
 python36-yaml     | python3-yaml      | >= 3.10.0         |
-python36-jsonschema | python3-jsonschema | >= 2.3.0       |
+python36-jsonschema | python3-jsonschema | >= 2.3.0, < 4.0 |
 phthon3-sphinx    | python3-sphinx    |                   | *1*
 
 *Note 1 - only needed if optional man pages are to be created.

--- a/src/test/docker/README.md
+++ b/src/test/docker/README.md
@@ -48,13 +48,27 @@ pushed to DockerHub at `fluxrm/testenv:bionic` and
 script still runs against the new `testenv` images, e.g.:
 
 ```
-$ for i in bionic focal centos7 centos8 fedora33 fedora34; do
+$ for i in focal centos7 centos8 fedora33 fedora34; do
     make clean &&
     docker build --no-cache -t fluxrm/testenv:$i src/test/docker/$i &&
     src/test/docker/docker-run-checks.sh -j 4 --image=$i &&
     docker push fluxrm/testenv:$i
   done
 ```
+
+#### Bionic multiarch images
+
+Building the bionic images for linux/amd64 and linux/386 requires the
+Docker buildx extensions, see
+
+ https://www.docker.com/blog/multi-arch-build-and-images-the-simple-way/
+
+and run
+```
+$  docker buildx build --push --platform=linux/386,linux/amd64 --tag fluxrm/testenv:bionic src/test/docker/bionic
+```
+
+to build and push images to docker hub.
 
 #### Local Testing
 

--- a/src/test/docker/bionic/Dockerfile
+++ b/src/test/docker/bionic/Dockerfile
@@ -54,16 +54,18 @@ RUN apt-get update \
 # mapped into the container and contains the same libraries
 RUN apt-get update \
  && apt-get -qq install -y --no-install-recommends \
+	libffi-dev \
         python3-dev \
         python3.7-dev \
         python3.8-dev \
         python3-pip \
         python3-setuptools \
         python3-wheel \
- && rm -rf /var/lib/apt/lists/* \
- && for PY in python3.6 python3.7 python3.8 ; do \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN for PY in python3.6 python3.7 python3.8 ; do \
         sudo $PY -m pip install --upgrade --ignore-installed \
-            coverage cffi six pyyaml jsonschema \
+            coverage cffi six pyyaml "jsonschema>=2.6,<4.0" \
             sphinx sphinx-rtd-theme sphinxcontrib-spelling; \
     done ; \
     apt-get -qq purge -y python3-pip \

--- a/src/test/docker/checks/Dockerfile
+++ b/src/test/docker/checks/Dockerfile
@@ -54,9 +54,9 @@ RUN case $BASE_IMAGE in \
 #  existing packages)
 #
 RUN case $BASE_IMAGE in \
-     bionic*) apt update && apt install libncursesw5-dev ;; \
-     focal*) apt update && apt install libncurses-dev ;; \
-     centos*|fedora*) yum -y install ncurses-devel ;; \
+     bionic*) ;; \
+     focal*) ;; \
+     centos*|fedora*) ;; \
      *) (>&2 echo "Unknown BASE_IMAGE") ;; \
     esac
 

--- a/src/test/generate-matrix.py
+++ b/src/test/generate-matrix.py
@@ -203,7 +203,7 @@ matrix.add_build(
 
 # Centos8
 matrix.add_build(
-    name="centos8 - py3.7",
+    name="centos8",
     image="centos8",
     env=dict(PYTHON_VERSION="3.6", LDFLAGS="-Wl,-z,relro  -Wl,-z,now"),
     docker_tag=True,

--- a/t/t2700-mini-cmd.t
+++ b/t/t2700-mini-cmd.t
@@ -98,23 +98,23 @@ test_expect_success 'flux mini run -vvv produces exec events on stderr' '
 '
 test_expect_success HAVE_JQ 'flux mini submit --time-limit=5d works' '
 	flux mini submit --dry-run --time-limit=5d hostname >t5d.out &&
-	test $(jq ".attributes.system.duration" t5d.out) = "432000"
+	jq -r ".attributes.system.duration == 432000"
 '
 test_expect_success HAVE_JQ 'flux mini submit --time-limit=4h works' '
 	flux mini submit --dry-run --time-limit=4h hostname >t4h.out &&
-	test $(jq ".attributes.system.duration" t4h.out) = "14400"
+	jq -r ".attributes.system.duration == 14400"
 '
 test_expect_success HAVE_JQ 'flux mini submit --time-limit=1m works' '
 	flux mini submit --dry-run --time-limit=5m hostname >t5m.out &&
-	test $(jq ".attributes.system.duration" t5m.out) = "300"
+	jq -r ".attributes.system.duration == 300"
 '
 test_expect_success HAVE_JQ 'flux mini submit -t5s works' '
 	flux mini submit --dry-run -t5s hostname >t5s.out &&
-	test $(jq ".attributes.system.duration" t5s.out) = "5"
+	jq -r ".attributes.system.duration == 300"
 '
 test_expect_success HAVE_JQ 'flux mini submit -t5 works' '
 	flux mini submit --dry-run -t5 hostname >t5.out &&
-	test $(jq ".attributes.system.duration" t5.out) = "5"
+	jq -r ".attributes.system.duration == 300"
 '
 test_expect_success 'flux mini submit --time-limit=00:30 fails' '
 	test_must_fail flux mini submit --time-limit=00:30 hostname 2>st.err &&


### PR DESCRIPTION
During rebuild of docker images for #3989 wonderful `pip` in the bionic image pulled in latest `jsonschema`, which broke the build since `configure` can't detect the version for that module after 4.0 since they removed the `__version__` attribute on the module. Additionally, the newest cffi module no longer built with python3.7 because it now appears to require `libffi-dev`.

Additionally, I noticed that `src/test/docker/README.md` hadn't been updated with instructions for how to build the multiarch `bionic` image, which requires `docker buildx`.

This PR includes the fix for #3989. It seems like that commit can also fit in this PR to speed up the merge of these fixes.