### PR TITLE
systemd: fix typo in flux.service unit file

### DIFF
--- a/etc/flux.service.in
+++ b/etc/flux.service.in
@@ -19,7 +19,7 @@ ExecStart=/bin/bash -c '\
   -Scontent.backing-path=@X_LOCALSTATEDIR@/lib/flux/content.sqlite \
   -Sbroker.rc2_none \
   -Sbroker.quorum=0 \
-  -Sbroker.quorum-timeout=none
+  -Sbroker.quorum-timeout=none \
 '
 ExecReload=@X_BINDIR@/flux config reload
 Restart=on-success


### PR DESCRIPTION
Problem: A rebase error left a line in etc/flux.service.in without
a necessary continuation character, causing systemd to fail to start
flux.

Add the missing line continuation character to etc/flux.service.in.

Fixes #3995