### PR TITLE
connectors: avoid embedded synchronous RPC for subscribe/unsubscribe

### DIFF
--- a/doc/man3/flux_open.rst
+++ b/doc/man3/flux_open.rst
@@ -31,6 +31,9 @@ the value of $FLUX_URI is used, if set.
 FLUX_O_TRACE
    Dumps message trace to stderr.
 
+FLUX_O_CLONE
+   Used internally by ``flux_clone()`` (see below).
+
 FLUX_O_MATCHDEBUG
    Prints diagnostic to stderr when matchtags are leaked, for example when
    a streaming RPC is destroyed without receiving a error response as

--- a/doc/man3/flux_open.rst
+++ b/doc/man3/flux_open.rst
@@ -42,6 +42,11 @@ FLUX_O_MATCHDEBUG
 FLUX_O_NONBLOCK
    The ``flux_send()`` and ``flux_recv()`` functions should never block.
 
+FLUX_O_TEST_NOSUB
+   Make ``flux_event_subscribe()` and ``flux_event_unsubscribe()`` no-ops.
+   This may be useful in specialized situations with the ``loop://`` connector,
+   where no message handler is available to service subscription RPCs.
+
 ``flux_clone()`` creates another reference to a ``flux_t`` handle that is
 identical to the original in all respects except that it does not inherit
 a copy of the original handle's "aux" hash, or its reactor and message

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -289,9 +289,8 @@ int main (int argc, char *argv[])
     }
 
     /* Arrange for the publisher to route event messages.
-     * handle_event - local subscribers (ctx.h)
      */
-    if (!(ctx.publisher = publisher_create (ctx.h,
+    if (!(ctx.publisher = publisher_create (&ctx,
                                             (publisher_send_f)handle_event,
                                             &ctx))) {
         log_err ("error setting up event publishing service");
@@ -1388,7 +1387,7 @@ static struct internal_service services[] = {
     { "content",            NULL },
     { "attr",               NULL },
     { "heaptrace",          NULL },
-    { "event",              "[0]" },
+    { "event",              NULL },
     { "service",            NULL },
     { "overlay",            NULL },
     { "config",             NULL },

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -1351,13 +1351,13 @@ static const struct flux_msg_handler_spec htab[] = {
     },
     {
         FLUX_MSGTYPE_REQUEST,
-        "broker.sub",
+        "event.subscribe",
         broker_sub_cb,
         0
     },
     {
         FLUX_MSGTYPE_REQUEST,
-        "broker.unsub",
+        "event.unsubscribe",
         broker_unsub_cb,
         0
     },

--- a/src/broker/overlay.h
+++ b/src/broker/overlay.h
@@ -43,6 +43,12 @@ struct overlay *overlay_create (flux_t *h,
                                 void *arg);
 void overlay_destroy (struct overlay *ov);
 
+/* Start sending keepalive messages to parent and monitoring peers.
+ * This registers a sync callback, and will fail if event.subscribe
+ * doesn't have a handler yet.
+ */
+int overlay_keepalive_start (struct overlay *ov);
+
 /* Set the overlay network size and rank of this broker.
  */
 int overlay_set_geometry (struct overlay *ov, uint32_t size, uint32_t rank);

--- a/src/broker/publisher.c
+++ b/src/broker/publisher.c
@@ -87,8 +87,10 @@ static void send_event (struct publisher *pub, const flux_msg_t *msg)
         flux_log_error (pub->ctx->h, "error publishing event message");
 }
 
-void pub_cb (flux_t *h, flux_msg_handler_t *mh,
-             const flux_msg_t *msg, void *arg)
+static void publish_cb (flux_t *h,
+                        flux_msg_handler_t *mh,
+                        const flux_msg_t *msg,
+                        void *arg)
 {
     struct publisher *pub = arg;
     const char *topic;
@@ -148,7 +150,7 @@ error_restore_seq:
 }
 
 static const struct flux_msg_handler_spec htab[] = {
-    { FLUX_MSGTYPE_REQUEST, "event.pub",  pub_cb, FLUX_ROLE_USER },
+    { FLUX_MSGTYPE_REQUEST, "event.publish",  publish_cb, FLUX_ROLE_USER },
     FLUX_MSGHANDLER_TABLE_END,
 };
 

--- a/src/broker/publisher.h
+++ b/src/broker/publisher.h
@@ -11,9 +11,13 @@
 #ifndef _BROKER_PUBLISHER_H
 #define _BROKER_PUBLISHER_H
 
+#include "broker.h"
+
 typedef int (*publisher_send_f)(void *arg, const flux_msg_t *msg);
 
-struct publisher *publisher_create (flux_t *h, publisher_send_f cb, void *arg);
+struct publisher *publisher_create (struct broker *ctx,
+                                    publisher_send_f cb,
+                                    void *arg);
 void publisher_destroy (struct publisher *pub);
 
 /* Publish an encoded event message, assigning sequence number.

--- a/src/common/libflux/connector.h
+++ b/src/common/libflux/connector.h
@@ -31,9 +31,6 @@ struct flux_handle_ops {
     int         (*send)(void *impl, const flux_msg_t *msg, int flags);
     flux_msg_t* (*recv)(void *impl, int flags);
 
-    int         (*event_subscribe)(void *impl, const char *topic);
-    int         (*event_unsubscribe)(void *impl, const char *topic);
-
     void        (*impl_destroy)(void *impl);
 };
 

--- a/src/common/libflux/event.c
+++ b/src/common/libflux/event.c
@@ -211,7 +211,7 @@ static flux_future_t *wrap_event_rpc (flux_t *h,
             errno = EPROTO;
             return NULL;
         }
-        if (!(f = flux_rpc_pack (h, "event.pub", 0, 0,
+        if (!(f = flux_rpc_pack (h, "event.publish", 0, 0,
                                  "{s:s s:i s:s}", "topic", topic,
                                                   "flags", flags,
                                                   "payload", dst))) {
@@ -223,7 +223,7 @@ static flux_future_t *wrap_event_rpc (flux_t *h,
         free (dst);
     }
     else {
-        if (!(f = flux_rpc_pack (h, "event.pub", 0, 0,
+        if (!(f = flux_rpc_pack (h, "event.publish", 0, 0,
                                     "{s:s s:i}", "topic", topic,
                                                  "flags", flags))) {
             return NULL;

--- a/src/common/libflux/event.c
+++ b/src/common/libflux/event.c
@@ -22,6 +22,68 @@
 #include "rpc.h"
 #include "message.h"
 
+flux_future_t *flux_event_subscribe_ex (flux_t *h,
+                                        const char *topic,
+                                        int flags)
+{
+    if (!topic) {
+        errno = EINVAL;
+        return NULL;
+    }
+    return flux_rpc_pack (h,
+                          "event.subscribe",
+                          FLUX_NODEID_ANY,
+                          flags,
+                          "{s:s}",
+                          "topic", topic);
+}
+
+int flux_event_subscribe (flux_t *h, const char *topic)
+{
+    flux_future_t *f;
+
+    if (h && (flux_flags_get (h) & FLUX_O_TEST_NOSUB))
+        return 0;
+    if (!(f = flux_event_subscribe_ex (h, topic, 0))
+        || flux_future_get (f, NULL) < 0) {
+        flux_future_destroy (f);
+        return -1;
+    }
+    flux_future_destroy (f);
+    return 0;
+}
+
+flux_future_t *flux_event_unsubscribe_ex (flux_t *h,
+                                          const char *topic,
+                                          int flags)
+{
+    if (!topic) {
+        errno = EINVAL;
+        return NULL;
+    }
+    return flux_rpc_pack (h,
+                          "event.unsubscribe",
+                          FLUX_NODEID_ANY,
+                          flags,
+                          "{s:s}",
+                          "topic", topic);
+}
+
+int flux_event_unsubscribe (flux_t *h, const char *topic)
+{
+    flux_future_t *f;
+
+    if (h && (flux_flags_get (h) & FLUX_O_TEST_NOSUB))
+        return 0;
+    if (!(f = flux_event_unsubscribe_ex (h, topic, 0))
+        || flux_future_get (f, NULL) < 0) {
+        flux_future_destroy (f);
+        return -1;
+    }
+    flux_future_destroy (f);
+    return 0;
+}
+
 static int event_decode (const flux_msg_t *msg, const char **topic)
 {
     int type;

--- a/src/common/libflux/event.c
+++ b/src/common/libflux/event.c
@@ -211,7 +211,7 @@ static flux_future_t *wrap_event_rpc (flux_t *h,
             errno = EPROTO;
             return NULL;
         }
-        if (!(f = flux_rpc_pack (h, "event.pub", FLUX_NODEID_ANY, 0,
+        if (!(f = flux_rpc_pack (h, "event.pub", 0, 0,
                                  "{s:s s:i s:s}", "topic", topic,
                                                   "flags", flags,
                                                   "payload", dst))) {
@@ -223,7 +223,7 @@ static flux_future_t *wrap_event_rpc (flux_t *h,
         free (dst);
     }
     else {
-        if (!(f = flux_rpc_pack (h, "event.pub", FLUX_NODEID_ANY, 0,
+        if (!(f = flux_rpc_pack (h, "event.pub", 0, 0,
                                     "{s:s s:i}", "topic", topic,
                                                  "flags", flags))) {
             return NULL;

--- a/src/common/libflux/event.h
+++ b/src/common/libflux/event.h
@@ -22,6 +22,17 @@ enum event_flags {
     FLUX_EVENT_PRIVATE = 1,
 };
 
+/* Event subscribe/unsubscribe.
+ */
+int flux_event_subscribe (flux_t *h, const char *topic);
+int flux_event_unsubscribe (flux_t *h, const char *topic);
+flux_future_t *flux_event_subscribe_ex (flux_t *h,
+                                        const char *topic,
+                                        int flags);
+flux_future_t *flux_event_unsubscribe_ex (flux_t *h,
+                                          const char *topic,
+                                          int flags);
+
 /* Decode an event message with optional string payload.
  * If topic is non-NULL, assign the event topic string.
  * If s is non-NULL, assign string payload or set to NULL if none

--- a/src/common/libflux/handle.c
+++ b/src/common/libflux/handle.c
@@ -386,8 +386,6 @@ void flux_handle_destroy (flux_t *h)
                 dlclose (h->dso);
 #endif
             flux_msglist_destroy (h->queue);
-            if (h->pollfd >= 0)
-                (void)close (h->pollfd);
         }
         free (h);
         errno = saved_errno;

--- a/src/common/libflux/handle.c
+++ b/src/common/libflux/handle.c
@@ -741,32 +741,6 @@ fatal:
     return -1;
 }
 
-int flux_event_subscribe (flux_t *h, const char *topic)
-{
-    h = lookup_clone_ancestor (h);
-    if (h->ops->event_subscribe) {
-        if (h->ops->event_subscribe (h->impl, topic) < 0)
-            goto fatal;
-    }
-    return 0;
-fatal:
-    FLUX_FATAL (h);
-    return -1;
-}
-
-int flux_event_unsubscribe (flux_t *h, const char *topic)
-{
-    h = lookup_clone_ancestor (h);
-    if (h->ops->event_unsubscribe) {
-        if (h->ops->event_unsubscribe (h->impl, topic) < 0)
-            goto fatal;
-    }
-    return 0;
-fatal:
-    FLUX_FATAL (h);
-    return -1;
-}
-
 int flux_pollfd (flux_t *h)
 {
     h = lookup_clone_ancestor (h);

--- a/src/common/libflux/handle.h
+++ b/src/common/libflux/handle.h
@@ -40,10 +40,11 @@ typedef void (*flux_fatal_f)(const char *msg, void *arg);
 /* Flags for handle creation and flux_flags_set()/flux_flags_unset.
  */
 enum {
-    FLUX_O_TRACE = 1,   /* send message trace to stderr */
-    FLUX_O_CLONE = 2,   /* handle was created with flux_clone() */
-    FLUX_O_NONBLOCK = 4,/* handle should not block on send/recv */
-    FLUX_O_MATCHDEBUG = 8,/* enable matchtag debugging */
+    FLUX_O_TRACE = 1,       /* send message trace to stderr */
+    FLUX_O_CLONE = 2,       /* handle was created with flux_clone() */
+    FLUX_O_NONBLOCK = 4,    /* handle should not block on send/recv */
+    FLUX_O_MATCHDEBUG = 8,  /* enable matchtag debugging */
+    FLUX_O_TEST_NOSUB = 16, /* for testing: make (un)subscribe a no-op */
 };
 
 /* Flags for flux_requeue().
@@ -173,11 +174,6 @@ int flux_pollevents (flux_t *h);
  * Returns fd on sucess, -1 on failure with errno set.
  */
 int flux_pollfd (flux_t *h);
-
-/* Event subscribe/unsubscribe.
- */
-int flux_event_subscribe (flux_t *h, const char *topic);
-int flux_event_unsubscribe (flux_t *h, const char *topic);
 
 /* Get/clear handle message counters.
  */

--- a/src/common/libflux/test/attr.c
+++ b/src/common/libflux/test/attr.c
@@ -179,7 +179,7 @@ int main (int argc, char *argv[])
 
     test_server_environment_init ("attr-test");
 
-    if (!(h = test_server_create (test_server, NULL)))
+    if (!(h = test_server_create (0, test_server, NULL)))
         BAIL_OUT ("test_server_create failed");
 
     /* get ENOENT */

--- a/src/common/libflux/test/event.c
+++ b/src/common/libflux/test/event.c
@@ -11,9 +11,9 @@
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
-#include "message.h"
-#include "event.h"
+#include <flux/core.h>
 #include "src/common/libtap/tap.h"
+#include "src/common/libtestutil/util.h"
 
 void test_codec (void)
 {
@@ -96,11 +96,209 @@ void test_codec (void)
     flux_msg_destroy (msg);
 }
 
+void test_subscribe_badparams (void)
+{
+    flux_t *h;
+
+    if (!(h = loopback_create (0)))
+        BAIL_OUT ("loopback_create failed");
+
+    errno = 0;
+    ok (flux_event_subscribe_ex (NULL, "foo", 0) == NULL && errno == EINVAL,
+        "flux_event_subscribe_ex h=NULL fails with EINVAL");
+    errno = 0;
+    ok (flux_event_subscribe_ex (h, NULL, 0) == NULL && errno == EINVAL,
+        "flux_event_subscribe_ex topic=NULL fails with EINVAL");
+    errno = 0;
+    ok (flux_event_subscribe_ex (h, "foo", -1) == NULL && errno == EINVAL,
+        "flux_event_subscribe_ex flags=-1 fails with EINVAL");
+
+    errno = 0;
+    ok (flux_event_unsubscribe_ex (NULL, "foo", 0) == NULL && errno == EINVAL,
+        "flux_event_unsubscribe_ex h=NULL fails with EINVAL");
+    errno = 0;
+    ok (flux_event_unsubscribe_ex (h, NULL, 0) == NULL && errno == EINVAL,
+        "flux_event_unsubscribe_ex topic=NULL fails with EINVAL");
+    errno = 0;
+    ok (flux_event_unsubscribe_ex (h, "foo", -1) == NULL && errno == EINVAL,
+        "flux_event_unsubscribe_ex flags=-1 fails with EINVAL");
+
+    errno = 0;
+    ok (flux_event_subscribe (NULL, "foo") < 0 && errno == EINVAL,
+        "flux_event_subscribe h=NULL fails with EINVAL");
+    errno = 0;
+    ok (flux_event_subscribe (h, NULL) < 0 && errno == EINVAL,
+        "flux_event_subscribe topic=NULL fails with EINVAL");
+
+    errno = 0;
+    ok (flux_event_unsubscribe (NULL, "foo") < 0 && errno == EINVAL,
+        "flux_event_unsubscribe h=NULL fails with EINVAL");
+    errno = 0;
+    ok (flux_event_unsubscribe (h, NULL) < 0 && errno == EINVAL,
+        "flux_event_unsubscribe topic=NULL fails with EINVAL");
+
+    flux_close (h);
+}
+
+bool fake_failure;
+
+void subscribe_cb (flux_t *h, flux_msg_handler_t *mh,
+                   const flux_msg_t *msg, void *arg)
+{
+    const char *topic = NULL;
+
+    if (flux_request_unpack (msg, NULL, "{s:s}", "topic", &topic) < 0)
+        goto error;
+    diag ("subscribe %s", topic);
+    if (fake_failure) {
+        errno = EIO;
+        fake_failure = false;
+        goto error;
+    }
+    if (!flux_msg_is_noresponse (msg)
+        && flux_respond (h, msg, NULL) < 0)
+        diag ("error responding to subscribe request");
+    return;
+error:
+    if (!flux_msg_is_noresponse (msg)
+        && flux_respond_error (h, msg, errno, NULL) < 0)
+        diag ("error responding to subscribe request: %s", strerror (errno));
+}
+
+void unsubscribe_cb (flux_t *h, flux_msg_handler_t *mh,
+                     const flux_msg_t *msg, void *arg)
+{
+    const char *topic = NULL;
+
+    if (flux_request_unpack (msg, NULL, "{s:s}", "topic", &topic) < 0)
+        goto error;
+    diag ("unsubscribe %s", topic);
+    if (fake_failure) {
+        errno = EIO;
+        fake_failure = false;
+        goto error;
+    }
+    if (!flux_msg_is_noresponse (msg)
+        && flux_respond (h, msg, NULL) < 0)
+        diag ("error responding to unsubscribe request");
+    return;
+error:
+    if (!flux_msg_is_noresponse (msg)
+        && flux_respond_error (h, msg, errno, NULL) < 0)
+        diag ("error responding to unsubscribe request: %s", strerror (errno));
+}
+
+const struct flux_msg_handler_spec htab[] = {
+    { FLUX_MSGTYPE_REQUEST,   "event.subscribe",    subscribe_cb, 0 },
+    { FLUX_MSGTYPE_REQUEST,   "event.unsubscribe",  unsubscribe_cb, 0 },
+    FLUX_MSGHANDLER_TABLE_END,
+};
+
+int test_server (flux_t *h, void *arg)
+{
+    flux_msg_handler_t **handlers = NULL;
+    int rc = -1;
+
+    if (flux_msg_handler_addvec (h, htab, NULL, &handlers) < 0) {
+        diag ("flux_msg_handler_addvec failed");
+        return -1;
+    }
+    if (flux_reactor_run (flux_get_reactor (h), 0) < 0) {
+        diag ("flux_reactor_run failed");
+        goto done;
+    }
+    rc = 0;
+done:
+    flux_msg_handler_delvec (handlers);
+    return rc;
+}
+
+void test_subscribe_rpc (void)
+{
+    flux_t *h;
+    flux_future_t *f;
+
+    if (!(h = test_server_create (0, test_server, NULL)))
+        BAIL_OUT ("test_server_create: %s", strerror (errno));
+
+    ok (flux_event_subscribe (h, "fubar") == 0,
+        "flux_event_subscribe topic=FUBAR works");
+
+    ok (flux_event_unsubscribe (h, "fubar") == 0,
+        "flux_event_unsubscribe topic=FUBAR works");
+
+    fake_failure = true;
+    errno = 0;
+    ok (flux_event_subscribe (h, "fubar") < 0 && errno == EIO,
+        "flux_event_subscribe failure works");
+
+    fake_failure = true;
+    errno = 0;
+    ok (flux_event_unsubscribe (h, "fubar") < 0 && errno == EIO,
+        "flux_event_unsubscribe failure works");
+
+    f = flux_event_subscribe_ex (h, "fubar", FLUX_RPC_NORESPONSE);
+    ok (f != NULL,
+        "flux_event_subscribe_ex flags=FLUX_RPC_NORESPONSE works");
+    flux_future_destroy (f);
+
+    f = flux_event_unsubscribe_ex (h, "fubar", FLUX_RPC_NORESPONSE);
+    ok (f != NULL,
+        "flux_event_unsubscribe_ex flags=FLUX_RPC_NORESPONSE works");
+    flux_future_destroy (f);
+
+    f = flux_event_subscribe_ex (h, "fubar", 0);
+    ok (f && flux_future_get (f, NULL) == 0,
+        "flux_event_subscribe_ex works");
+    flux_future_destroy (f);
+
+    f = flux_event_unsubscribe_ex (h, "fubar", 0);
+    ok (f && flux_future_get (f, NULL) == 0,
+        "flux_event_unsubscribe_ex works");
+    flux_future_destroy (f);
+
+    fake_failure = true;
+    errno = 0;
+    f = flux_event_subscribe_ex (h, "fubar", 0);
+    ok (f && flux_future_get (f, NULL) < 0 && errno == EIO,
+        "flux_event_subscribe_ex failure works");
+    flux_future_destroy (f);
+
+    fake_failure = true;
+    errno = 0;
+    f = flux_event_unsubscribe_ex (h, "fubar", 0);
+    ok (f && flux_future_get (f, NULL) < 0 && errno == EIO,
+        "flux_event_unsubscribe_ex failure works");
+    flux_future_destroy (f);
+
+    if (test_server_stop (h) < 0)
+        BAIL_OUT ("error stopping test server: %s", strerror (errno));
+    flux_close (h);
+}
+
+void test_subscribe_nosub (void)
+{
+    flux_t *h;
+
+    if (!(h = loopback_create (FLUX_O_TEST_NOSUB)))
+        BAIL_OUT ("loopback_create failed");
+
+    ok (flux_event_subscribe (h, "foo") == 0,
+        "flux_event_subscribe succeeds in loopback with TEST_NOSUB flag");
+    ok (flux_event_unsubscribe (h, "foo") == 0,
+        "flux_event_unsubscribe succeeds in loopback with TEST_NOSUB flag");
+
+    flux_close (h);
+}
+
 int main (int argc, char *argv[])
 {
     plan (NO_PLAN);
 
     test_codec ();
+    test_subscribe_badparams ();
+    test_subscribe_rpc ();
+    test_subscribe_nosub ();
 
     done_testing();
     return (0);

--- a/src/common/libflux/test/event.c
+++ b/src/common/libflux/test/event.c
@@ -15,7 +15,7 @@
 #include "event.h"
 #include "src/common/libtap/tap.h"
 
-int main (int argc, char *argv[])
+void test_codec (void)
 {
     flux_msg_t *msg;
     const char *topic, *s;
@@ -25,8 +25,6 @@ int main (int argc, char *argv[])
     const void *d;
     int l;
     int i;
-
-    plan (NO_PLAN);
 
     /* no topic is an error */
     errno = 0;
@@ -96,6 +94,13 @@ int main (int argc, char *argv[])
     ok (flux_event_decode_raw (msg, NULL, &d, NULL) < 0 && errno == EINVAL,
         "flux_event_decode_raw len=NULL fails with EINVAL");
     flux_msg_destroy (msg);
+}
+
+int main (int argc, char *argv[])
+{
+    plan (NO_PLAN);
+
+    test_codec ();
 
     done_testing();
     return (0);

--- a/src/common/libflux/test/log.c
+++ b/src/common/libflux/test/log.c
@@ -25,7 +25,7 @@ int main (int argc, char *argv[])
 
     test_server_environment_init ("log-test");
 
-    if (!(h = test_server_create (NULL, NULL)))
+    if (!(h = test_server_create (0, NULL, NULL)))
         BAIL_OUT ("could not create test server");
     if (flux_attr_set_cacheonly (h, "rank", "0") < 0)
         BAIL_OUT ("flux_attr_set_cacheonly failed");

--- a/src/common/libflux/test/rpc.c
+++ b/src/common/libflux/test/rpc.c
@@ -917,14 +917,14 @@ void test_fake_server (void)
 {
     flux_t *h;
 
-    ok ((h = test_server_create (fake_server, NULL)) != NULL,
+    ok ((h = test_server_create (0, fake_server, NULL)) != NULL,
         "test_server_create (recv loop)");
     ok (test_server_stop (h) == 0,
         "test_server_stop worked");
     flux_close (h);
     diag ("completed test with server recv loop");
 
-    ok ((h = test_server_create (fake_server_reactor, NULL)) != NULL,
+    ok ((h = test_server_create (0, fake_server_reactor, NULL)) != NULL,
         "test_server_create (reactor)");
     ok ((test_server_stop (h)) == 0,
         "test_server_stop worked");
@@ -965,7 +965,7 @@ int main (int argc, char *argv[])
 
     test_fake_server ();
 
-    h = test_server_create (test_server, NULL);
+    h = test_server_create (0, test_server, NULL);
     ok (h != NULL,
         "created test server thread");
     if (!h)

--- a/src/common/libflux/test/rpc_chained.c
+++ b/src/common/libflux/test/rpc_chained.c
@@ -348,7 +348,7 @@ int main (int argc, char *argv[])
 
     test_server_environment_init ("rpc-chained-test");
 
-    h = test_server_create (test_server, NULL);
+    h = test_server_create (0, test_server, NULL);
     ok (h != NULL,
         "created test server thread");
     if (!h)

--- a/src/common/librouter/router.c
+++ b/src/common/librouter/router.c
@@ -92,7 +92,7 @@ static void router_entry_respond_byuuid (const flux_msg_t *msg,
         router_entry_respond (entry, msg, errnum);
 }
 
-/* Handle internal local.sub request.
+/* Handle internal local subscribe request.
  */
 static void local_sub_request (struct router_entry *entry, flux_msg_t *msg)
 {
@@ -108,7 +108,7 @@ error:
     router_entry_respond (entry, msg, errno);
 }
 
-/* Handle internal local.unsub request.
+/* Handle internal local unsubscribe request.
  */
 static void local_unsub_request (struct router_entry *entry, flux_msg_t *msg)
 {
@@ -172,11 +172,11 @@ void router_entry_recv (struct router_entry *entry, flux_msg_t *msg)
         return;
     switch (type) {
         case FLUX_MSGTYPE_REQUEST:
-            if (!strcmp (topic, "local.sub")) {
+            if (!strcmp (topic, "event.subscribe")) {
                 local_sub_request (entry, msg);
                 break;
             }
-            if (!strcmp (topic, "local.unsub")) {
+            if (!strcmp (topic, "event.unsubscribe")) {
                 local_unsub_request (entry, msg);
                 break;
             }

--- a/src/common/librouter/test/router.c
+++ b/src/common/librouter/test/router.c
@@ -228,7 +228,7 @@ void test_basic (flux_t *h)
                                          "{\"service\":\"testfu\"}")))
         BAIL_OUT ("flux_request_encode failed");
     router_entry_recv (entry, request); // router receives message from abcd
-    diag ("basic: sent local.sub request");
+    diag ("basic: sent service.add request");
     flux_msg_destroy (request);
     ok (flux_reactor_run (r, 0) >= 0, "basic: reactor processed one message");
 

--- a/src/common/librouter/test/router.c
+++ b/src/common/librouter/test/router.c
@@ -266,7 +266,7 @@ int main (int argc, char *argv[])
     diag ("starting test server");
     test_server_environment_init ("test_router");
 
-    if (!(h = test_server_create (0, server_cb, NULL)))
+    if (!(h = test_server_create (FLUX_O_TEST_NOSUB, server_cb, NULL)))
         BAIL_OUT ("test_server_create failed");
 
     test_basic (h);

--- a/src/common/librouter/test/router.c
+++ b/src/common/librouter/test/router.c
@@ -135,7 +135,7 @@ int basic_recv (const flux_msg_t *msg, void *arg)
 
     switch (type) {
         case FLUX_MSGTYPE_RESPONSE:
-            like (topic, "local.sub|local.unsub|service.add|service.remove|rtest.hello",
+            like (topic, "event.subscribe|event.unsubscribe|service.add|service.remove|rtest.hello",
                   "router-entry: response is %s", topic);
             break;
         case FLUX_MSGTYPE_EVENT:
@@ -192,11 +192,11 @@ void test_basic (flux_t *h)
      * - basic_recv() is called in the context of router_entry_recv()
      *   in this case so don't start the reactor.
      */
-    if (!(request = flux_request_encode ("local.sub",
+    if (!(request = flux_request_encode ("event.subscribe",
                                          "{\"topic\":\"rtest\"}")))
         BAIL_OUT ("flux_request_encode failed");
     router_entry_recv (entry, request); // router recives message from abcd
-    diag ("basic: sent local.sub request");
+    diag ("basic: sent event.subscribe request");
     flux_msg_destroy (request);
 
     /* Send an rtest.pub request from client.
@@ -212,11 +212,11 @@ void test_basic (flux_t *h)
 
     /* Now unsubscribe to rtest events.
      */
-    if (!(request = flux_request_encode ("local.unsub",
+    if (!(request = flux_request_encode ("event.unsubscribe",
                                          "{\"topic\":\"rtest\"}")))
         BAIL_OUT ("flux_request_encode failed");
     router_entry_recv (entry, request); // router recives message from abcd
-    diag ("basic: sent local.unsub request");
+    diag ("basic: sent event.unsubscribe request");
     flux_msg_destroy (request);
 
     /* Register testfu service.

--- a/src/common/librouter/test/router.c
+++ b/src/common/librouter/test/router.c
@@ -266,7 +266,7 @@ int main (int argc, char *argv[])
     diag ("starting test server");
     test_server_environment_init ("test_router");
 
-    if (!(h = test_server_create (server_cb, NULL)))
+    if (!(h = test_server_create (0, server_cb, NULL)))
         BAIL_OUT ("test_server_create failed");
 
     test_basic (h);

--- a/src/common/librouter/test/servhash.c
+++ b/src/common/librouter/test/servhash.c
@@ -248,7 +248,7 @@ int main (int argc, char *argv[])
     diag ("starting test server");
     test_server_environment_init ("test_router");
 
-    if (!(h = test_server_create (server_cb, NULL)))
+    if (!(h = test_server_create (0, server_cb, NULL)))
         BAIL_OUT ("test_server_create failed");
 
     test_basic (h);

--- a/src/common/librouter/test/usock_echo.c
+++ b/src/common/librouter/test/usock_echo.c
@@ -300,7 +300,7 @@ int main (int argc, char *argv[])
     diag ("starting test server");
     test_server_environment_init ("usock_server");
 
-    if (!(h = test_server_create (server_cb, NULL)))
+    if (!(h = test_server_create (0, server_cb, NULL)))
         BAIL_OUT ("test_server_create failed");
 
     test_early_disconnect (h);

--- a/src/common/librouter/test/usock_emfile.c
+++ b/src/common/librouter/test/usock_emfile.c
@@ -273,7 +273,7 @@ int main (int argc, char *argv[])
     diag ("starting test server");
     test_server_environment_init ("usock_server");
 
-    if (!(h = test_server_create (server_cb, &tp)))
+    if (!(h = test_server_create (0, server_cb, &tp)))
         BAIL_OUT ("test_server_create failed");
 
     wait_for_server ();

--- a/src/common/librouter/test/usock_epipe.c
+++ b/src/common/librouter/test/usock_epipe.c
@@ -226,7 +226,7 @@ int main (int argc, char *argv[])
     diag ("starting test server");
     test_server_environment_init ("usock_server");
 
-    if (!(h = test_server_create (server_cb, &tp)))
+    if (!(h = test_server_create (0, server_cb, &tp)))
         BAIL_OUT ("test_server_create failed");
 
     test_send_and_exit (h, 1);

--- a/src/common/libterminus/test/pty.c
+++ b/src/common/libterminus/test/pty.c
@@ -166,7 +166,7 @@ out:
 
 static void test_basic_protocol (void)
 {
-    flux_t *h = test_server_create (pty_server, NULL);
+    flux_t *h = test_server_create (0, pty_server, NULL);
     flux_future_t *f = NULL;
     flux_future_t *f_attach = NULL;
 
@@ -385,7 +385,7 @@ static void pty_exit_cb (struct flux_pty_client *c, void *arg)
 
 static void test_client()
 {
-    flux_t *h = test_server_create (pty_server, NULL);
+    flux_t *h = test_server_create (0, pty_server, NULL);
     flux_future_t *f = NULL;
     int rc;
     int flags = FLUX_PTY_CLIENT_ATTACH_SYNC

--- a/src/common/libterminus/test/terminus.c
+++ b/src/common/libterminus/test/terminus.c
@@ -90,7 +90,7 @@ static void test_kill_server_empty (void)
 {
     int rc;
     flux_future_t *f = NULL;
-    flux_t *h = test_server_create (terminus_server, NULL);
+    flux_t *h = test_server_create (0, terminus_server, NULL);
 
     /* kill-server
      */
@@ -121,7 +121,7 @@ static void test_protocol (void)
     int rc;
     json_t *o = NULL;
     flux_future_t *f = NULL;
-    flux_t *h = test_server_create (terminus_server, NULL);
+    flux_t *h = test_server_create (0, terminus_server, NULL);
 
     const char *service = NULL;
     const char *name = NULL;

--- a/src/common/libtestutil/util.c
+++ b/src/common/libtestutil/util.c
@@ -285,8 +285,6 @@ static const struct flux_handle_ops handle_ops = {
     .recv = test_connector_recv,
     .getopt = NULL,
     .setopt = NULL,
-    .event_subscribe = NULL,
-    .event_unsubscribe = NULL,
     .impl_destroy = test_connector_fini,
 };
 
@@ -464,8 +462,6 @@ static const struct flux_handle_ops loopback_ops = {
     .recv = loopback_connector_recv,
     .getopt = loopback_connector_getopt,
     .setopt = loopback_connector_setopt,
-    .event_subscribe = NULL,
-    .event_unsubscribe = NULL,
     .impl_destroy = loopback_connector_fini,
 };
 

--- a/src/common/libtestutil/util.c
+++ b/src/common/libtestutil/util.c
@@ -122,11 +122,10 @@ static void test_server_destroy (struct test_server *a)
     }
 }
 
-flux_t *test_server_create (test_server_f cb, void *arg)
+flux_t *test_server_create (int cflags, test_server_f cb, void *arg)
 {
     int e;
     struct test_server *a;
-    int cflags = 0; // client connector flags
     int sflags = 0; // server connector flags
 
     if (!(a = calloc (1, sizeof (*a))))

--- a/src/common/libtestutil/util.h
+++ b/src/common/libtestutil/util.h
@@ -30,7 +30,7 @@
  */
 typedef int (*test_server_f)(flux_t *h, void *arg);
 
-flux_t *test_server_create (test_server_f cb, void *arg);
+flux_t *test_server_create (int flags, test_server_f cb, void *arg);
 
 int test_server_stop (flux_t *c);
 

--- a/src/connectors/local/local.c
+++ b/src/connectors/local/local.c
@@ -96,46 +96,6 @@ static flux_msg_t *op_recv (void *impl, int flags)
     return usock_client_recv (ctx->uclient, flags);
 }
 
-static int op_event_subscribe (void *impl, const char *topic)
-{
-    struct local_connector *ctx = impl;
-    flux_future_t *f;
-
-    if (!(f = flux_rpc_pack (ctx->h,
-                             "event.subscribe",
-                             FLUX_NODEID_ANY,
-                             0,
-                             "{s:s}",
-                             "topic", topic)))
-        return -1;
-    if (flux_future_get (f, NULL) < 0) {
-        flux_future_destroy (f);
-        return -1;
-    }
-    flux_future_destroy (f);
-    return 0;
-}
-
-static int op_event_unsubscribe (void *impl, const char *topic)
-{
-    struct local_connector *ctx = impl;
-    flux_future_t *f;
-
-    if (!(f = flux_rpc_pack (ctx->h,
-                             "event.unsubscribe",
-                             FLUX_NODEID_ANY,
-                             0,
-                             "{s:s}",
-                             "topic", topic)))
-        return -1;
-    if (flux_future_get (f, NULL) < 0) {
-        flux_future_destroy (f);
-        return -1;
-    }
-    flux_future_destroy (f);
-    return 0;
-}
-
 static int op_setopt (void *impl, const char *option,
                       const void *val, size_t size)
 {
@@ -262,8 +222,6 @@ static const struct flux_handle_ops handle_ops = {
     .pollevents = op_pollevents,
     .send = op_send,
     .recv = op_recv,
-    .event_subscribe = op_event_subscribe,
-    .event_unsubscribe = op_event_unsubscribe,
     .setopt = op_setopt,
     .getopt = op_getopt,
     .impl_destroy = op_fini,

--- a/src/connectors/local/local.c
+++ b/src/connectors/local/local.c
@@ -102,7 +102,7 @@ static int op_event_subscribe (void *impl, const char *topic)
     flux_future_t *f;
 
     if (!(f = flux_rpc_pack (ctx->h,
-                             "local.sub",
+                             "event.subscribe",
                              FLUX_NODEID_ANY,
                              0,
                              "{s:s}",
@@ -122,7 +122,7 @@ static int op_event_unsubscribe (void *impl, const char *topic)
     flux_future_t *f;
 
     if (!(f = flux_rpc_pack (ctx->h,
-                             "local.unsub",
+                             "event.unsubscribe",
                              FLUX_NODEID_ANY,
                              0,
                              "{s:s}",

--- a/src/connectors/shmem/shmem.c
+++ b/src/connectors/shmem/shmem.c
@@ -102,43 +102,6 @@ done:
     return msg;
 }
 
-static int op_event_subscribe (void *impl, const char *topic)
-{
-    shmem_ctx_t *ctx = impl;
-    assert (ctx->magic == MODHANDLE_MAGIC);
-    flux_future_t *f;
-    int rc = -1;
-
-    if (!(f = flux_rpc_pack (ctx->h, "event.subscribe", FLUX_NODEID_ANY, 0,
-                             "{ s:s }", "topic", topic)))
-        goto done;
-    if (flux_future_get (f, NULL) < 0)
-        goto done;
-    rc = 0;
-done:
-    flux_future_destroy (f);
-    return rc;
-}
-
-static int op_event_unsubscribe (void *impl, const char *topic)
-{
-    shmem_ctx_t *ctx = impl;
-    assert (ctx->magic == MODHANDLE_MAGIC);
-    flux_future_t *f = NULL;
-    int rc = -1;
-
-    if (!(f = flux_rpc_pack (ctx->h, "event.unsubscribe", FLUX_NODEID_ANY, 0,
-                             "{ s:s }", "topic", topic)))
-        goto done;
-    if (flux_future_get (f, NULL) < 0)
-        goto done;
-    rc = 0;
-done:
-    flux_future_destroy (f);
-    return rc;
-}
-
-
 static void op_fini (void *impl)
 {
     shmem_ctx_t *ctx = impl;
@@ -224,8 +187,6 @@ static const struct flux_handle_ops handle_ops = {
     .recv = op_recv,
     .getopt = NULL,
     .setopt = NULL,
-    .event_subscribe = op_event_subscribe,
-    .event_unsubscribe = op_event_unsubscribe,
     .impl_destroy = op_fini,
 };
 

--- a/src/connectors/shmem/shmem.c
+++ b/src/connectors/shmem/shmem.c
@@ -109,7 +109,7 @@ static int op_event_subscribe (void *impl, const char *topic)
     flux_future_t *f;
     int rc = -1;
 
-    if (!(f = flux_rpc_pack (ctx->h, "broker.sub", FLUX_NODEID_ANY, 0,
+    if (!(f = flux_rpc_pack (ctx->h, "event.subscribe", FLUX_NODEID_ANY, 0,
                              "{ s:s }", "topic", topic)))
         goto done;
     if (flux_future_get (f, NULL) < 0)
@@ -127,7 +127,7 @@ static int op_event_unsubscribe (void *impl, const char *topic)
     flux_future_t *f = NULL;
     int rc = -1;
 
-    if (!(f = flux_rpc_pack (ctx->h, "broker.unsub", FLUX_NODEID_ANY, 0,
+    if (!(f = flux_rpc_pack (ctx->h, "event.unsubscribe", FLUX_NODEID_ANY, 0,
                              "{ s:s }", "topic", topic)))
         goto done;
     if (flux_future_get (f, NULL) < 0)

--- a/src/connectors/ssh/ssh.c
+++ b/src/connectors/ssh/ssh.c
@@ -72,7 +72,7 @@ static int op_event_subscribe (void *impl, const char *topic)
     flux_future_t *f;
     int rc = 0;
 
-    if (!(f = flux_rpc_pack (ctx->h, "local.sub", FLUX_NODEID_ANY, 0,
+    if (!(f = flux_rpc_pack (ctx->h, "event.subscribe", FLUX_NODEID_ANY, 0,
                              "{ s:s }", "topic", topic)))
         goto done;
     if (flux_future_get (f, NULL) < 0)
@@ -89,7 +89,7 @@ static int op_event_unsubscribe (void *impl, const char *topic)
     flux_future_t *f;
     int rc = 0;
 
-    if (!(f = flux_rpc_pack (ctx->h, "local.unsub", FLUX_NODEID_ANY, 0,
+    if (!(f = flux_rpc_pack (ctx->h, "event.subscribe", FLUX_NODEID_ANY, 0,
                              "{ s:s }", "topic", topic)))
         goto done;
     if (flux_future_get (f, NULL) < 0)

--- a/src/connectors/ssh/ssh.c
+++ b/src/connectors/ssh/ssh.c
@@ -66,40 +66,6 @@ static flux_msg_t *op_recv (void *impl, int flags)
     return usock_client_recv (ctx->uclient, flags);
 }
 
-static int op_event_subscribe (void *impl, const char *topic)
-{
-    struct ssh_connector *ctx = impl;
-    flux_future_t *f;
-    int rc = 0;
-
-    if (!(f = flux_rpc_pack (ctx->h, "event.subscribe", FLUX_NODEID_ANY, 0,
-                             "{ s:s }", "topic", topic)))
-        goto done;
-    if (flux_future_get (f, NULL) < 0)
-        goto done;
-    rc = 0;
-done:
-    flux_future_destroy (f);
-    return rc;
-}
-
-static int op_event_unsubscribe (void *impl, const char *topic)
-{
-    struct ssh_connector *ctx = impl;
-    flux_future_t *f;
-    int rc = 0;
-
-    if (!(f = flux_rpc_pack (ctx->h, "event.subscribe", FLUX_NODEID_ANY, 0,
-                             "{ s:s }", "topic", topic)))
-        goto done;
-    if (flux_future_get (f, NULL) < 0)
-        goto done;
-    rc = 0;
-done:
-    flux_future_destroy (f);
-    return rc;
-}
-
 static void op_fini (void *impl)
 {
     struct ssh_connector *ctx = impl;
@@ -314,8 +280,6 @@ static const struct flux_handle_ops handle_ops = {
     .pollevents = op_pollevents,
     .send = op_send,
     .recv = op_recv,
-    .event_subscribe = op_event_subscribe,
-    .event_unsubscribe = op_event_unsubscribe,
     .impl_destroy = op_fini,
 };
 

--- a/src/shell/shell.c
+++ b/src/shell/shell.c
@@ -222,7 +222,11 @@ static void shell_parse_cmdline (flux_shell_t *shell, int argc, char *argv[])
 
 static void shell_connect_flux (flux_shell_t *shell)
 {
-    if (!(shell->h = flux_open (shell->standalone ? "loop://" : NULL, 0)))
+    if (shell->standalone)
+        shell->h = flux_open ("loop://", FLUX_O_TEST_NOSUB);
+    else
+        shell->h = flux_open (NULL, 0);
+    if (!shell->h)
         shell_die_errno (1, "flux_open");
 
     /*  Set reactor for flux handle to our custom created reactor.

--- a/t/lua/t0003-events.t
+++ b/t/lua/t0003-events.t
@@ -55,36 +55,36 @@ type_ok (msg, 'table', "recv_event: got msg as a table")
 is_deeply (msg, {}, "recv_event: got empty payload as expected")
 
 
--- poke at event.pub service
+-- poke at event.publish service
 -- good request, no payload
 local request = { topic = "foo", flags = 0 }
-local response, err = f:rpc ("event.pub", request);
-is (err, nil, "event.pub: works without payload")
+local response, err = f:rpc ("event.publish", request);
+is (err, nil, "event.publish: works without payload")
 
 -- good request, with raw payload
 local request = { topic = "foo", flags = 0, payload = "aGVsbG8gd29ybGQ=" }
-local response, err = f:rpc ("event.pub", request);
-is (err, nil, "event.pub: works with payload")
+local response, err = f:rpc ("event.publish", request);
+is (err, nil, "event.publish: works with payload")
 
 -- good request, with JSON "{}\0"
 local request = { topic = "foo", flags = 0, payload = "e30A" }
-local response, err = f:rpc ("event.pub", request);
-is (err, nil, "event.pub: works with json payload")
+local response, err = f:rpc ("event.publish", request);
+is (err, nil, "event.publish: works with json payload")
 
 -- flags missing from request
 local request = { topic = "foo" }
-local response, err = f:rpc ("event.pub", request);
-is (err, "Protocol error", "event.pub: no flags, fails with EPROTO")
+local response, err = f:rpc ("event.publish", request);
+is (err, "Protocol error", "event.publish: no flags, fails with EPROTO")
 
 -- mangled base64 payload
 local request = { topic = "foo", flags = 0, payload = "aGVsbG8gd29ybGQ%" }
-local response, err = f:rpc ("event.pub", request);
-is (err, "Protocol error", "event.pub: bad base64, fails with EPROTO")
+local response, err = f:rpc ("event.publish", request);
+is (err, "Protocol error", "event.publish: bad base64, fails with EPROTO")
 
 -- good request, mangled JSON payload "{\0"
 local request = { topic = "foo", flags = 4, payload = "ewA=" }
-local response, err = f:rpc ("event.pub", request);
-is (err, "Protocol error", "event.pub: bad json payload, fails with EPROTO")
+local response, err = f:rpc ("event.publish", request);
+is (err, "Protocol error", "event.publish: bad json payload, fails with EPROTO")
 
 done_testing ()
 

--- a/t/t0004-event.t
+++ b/t/t0004-event.t
@@ -87,8 +87,9 @@ test_expect_success 'publish private event with no payload (synchronous,loopback
 	run_timeout 5 flux event pub -p -s -l foo.bar
 '
 
-test_expect_success 'event.pub request with empty payload fails with EPROTO(71)' '
-	${RPC} event.pub 71 </dev/null
+test_expect_success 'event.publish request with empty payload fails with EPROTO(71)' '
+	${RPC} event.publish 71 </dev/null
 '
+
 
 test_done


### PR DESCRIPTION
Problem: connectors have event subscribe/unsubscribe "operations" from early times when 0MQ was the primary transport, but even in the one extant 0MQ-based connector (shmem), the operations make hidden synchronous RPCs.

In addition to being unnecessary, the embedded RPCs are inflexible. If handled like other RPCs, then:
- subscriptions can be made asynchronously, where appropriate
- subscriptions can be made with FLUX_RPC_NORESPONSE, where appropriate
- In the future, RPC tracking for automatic reconnect when a broker restarts could track subscription RPCs like any other

This PR changes `flux_event_subscribe()` and `flux_event_unsubscribe()` to wrap a synchronous RPC rather than call a connector operation that might wrap a synchronous RPC or might be a no-op.  I figured it was safest to leave the semantics of these functions unchanged, rather than try to change their prototype to return a future.    Instead, two new functions `flux_event_subscribe_ex()` and `flux_event_unsubscribe_ex()` are added.  In addition to returning futures, these functions accept RPC flags.

There was a bit of special care needed to avoid deadlock in the broker, and in loopback test scenarios.  Those are documented in commit messages, and IMHO not concerning because they are not representative of our primary use cases for pub/sub.   A new handle flag FLUX_O_TEST_NOSUB was added to avoid blocking RPCs to self in a loopback test.  Not usually required - only when events are part of a test, synchronous RPCs are used, and the test doesn't install RPC handlers for `event.subscribe` and `event.unsubscribe`.