### PR TITLE
add FluxURIResolver Python class and flux-uri command for job URI discovery

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -33,7 +33,8 @@ MAN1_FILES_PRIMARY = \
 	man1/flux-version.1 \
 	man1/flux-jobs.1 \
 	man1/flux-shell.1 \
-	man1/flux-jobtap.1
+	man1/flux-jobtap.1 \
+	man1/flux-uri.1
 
 # These files are generated as clones of a primary page.
 # Sphinx handles this automatically if declared in the conf.py

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -321,6 +321,7 @@ stderr_devnull_0 = >/dev/null 2>&1
 
 $(MAN_FILES): conf.py $(RST_FILES)
 	$(sphinx_man) \
+	PYTHONPATH=$(PYTHONPATH):$(abs_srcdir) \
 	SPHINX_BUILDDIR=$(abs_builddir) $(PYTHON) \
 		-m sphinx $(sphinx_verbose_flags) -b man $(srcdir) ./man \
 		$(STDERR_DEVNULL)
@@ -333,12 +334,14 @@ $(MAN_FILES): conf.py $(RST_FILES)
 .PHONY: html
 html: conf.py $(RST_FILES)
 	$(sphinx_html) \
+	PYTHONPATH=$(PYTHONPATH):$(abs_srcdir) \
 	SPHINX_BUILDDIR=$(abs_builddir) $(PYTHON) \
 		-m sphinx $(sphinx_verbose_flags) -b html $(srcdir) ./html \
 		$(STDERR_DEVNULL)
 
 EXTRA_DIST = \
 	conf.py \
+	domainrefs.py \
 	index.rst \
 	$(RST_FILES) \
 	man1/NODESET.rst \

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -46,8 +46,28 @@ source_suffix = '.rst'
 
 extensions = [
     'sphinx.ext.intersphinx',
-    'sphinx.ext.napoleon'
+    'sphinx.ext.napoleon',
+    'domainrefs'
 ]
+
+domainrefs = {
+    'man1': {
+        'text': "%s(1)",
+        'url': "../man1/%s.html"
+    },
+    'man3': {
+        'text': "%s(3)",
+        'url': "../man3/%s.html"
+    },
+    'man5': {
+        'text': "%s(5)",
+        'url': "../man5/%s.html"
+    },
+    'man7': {
+        'text': "%s(7)",
+        'url': "../man7/%s.html"
+    }
+}
 
 # Disable "smartquotes" to avoid things such as turning long-options
 #  "--" into en-dash in html output, which won't make much sense for

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -147,6 +147,7 @@ man_pages = [
     ('man1/flux-hwloc', 'flux-hwloc', 'Control/query resource-hwloc service', [author], 1),
     ('man1/flux-jobs', 'flux-jobs', 'list jobs submitted to Flux', [author], 1),
     ('man1/flux-jobtap', 'flux-jobtap', 'List, remove, and load job-manager plugins', [author], 1),
+    ('man1/flux-uri', 'flux-uri', 'resolve Flux URIs', [author], 1),
     ('man1/flux-keygen', 'flux-keygen', 'generate keys for Flux security', [author], 1),
     ('man1/flux-kvs', 'flux-kvs', 'Flux key-value store utility', [author], 1),
     ('man1/flux-logger', 'flux-logger', 'create a Flux log entry', [author], 1),

--- a/doc/domainrefs.py
+++ b/doc/domainrefs.py
@@ -1,0 +1,72 @@
+"""
+Originally from:
+
+  https://github.com/mitogen-hq/mitogen/blob/master/docs/domainrefs.py
+
+Copyright 2021, the Mitogen authors
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+"""
+import functools
+import re
+
+import docutils.nodes
+import docutils.utils
+
+
+CUSTOM_RE = re.compile('(.*) <(.*)>')
+
+
+def role(config, role, rawtext, text, lineno, inliner, options={}, content=[]):
+    template = 'https://docs.ansible.com/ansible/latest/modules/%s_module.html'
+
+    match = CUSTOM_RE.match(text)
+    if match:  # "custom text <real link>"
+        title = match.group(1)
+        text = match.group(2)
+    elif text.startswith('~'):  # brief
+        text = text[1:]
+        title = config.get('brief', '%s') % (
+            docutils.utils.unescape(text),
+        )
+    else:
+        title = config.get('text', '%s') % (
+            docutils.utils.unescape(text),
+        )
+
+    node = docutils.nodes.reference(
+        rawsource=rawtext,
+        text=title,
+        refuri=config['url'] % (text,),
+        **options
+    )
+
+    return [node], []
+
+
+def setup(app):
+    for name, info in app.config._raw_config['domainrefs'].items():
+        app.add_role(name, functools.partial(role, info))

--- a/doc/man1/flux-uri.rst
+++ b/doc/man1/flux-uri.rst
@@ -1,0 +1,147 @@
+===========
+flux-uri(1)
+===========
+
+
+SYNOPSIS
+========
+
+**flux** *uri* [OPTIONS] *TARGET*
+
+DESCRIPTION
+===========
+
+Connections to Flux are established via a Uniform Resource Indicator
+(URI) which is passed to the :man3:`flux_open` API call. These *native*
+URIs indicate the "connector" which will be used to establish the
+connection, and are typically either *local*, with a  ``local`` URI
+scheme, or *remote*, with a ``ssh`` URI scheme. These URIs are considered
+fully-resolved, native Flux URIs.
+
+Processes running within a Flux instance will have the ``FLUX_URI``
+environment variable set to a native URI which :man3:`flux_open` will
+use by default, with fallback to a compiled-in native URI for the system
+instance of Flux. Therefore, there is usually no need to specify a URI when
+connecting to the enclosing instance. However, connecting to a *different*
+Flux instance will require discovery of the fully-resolved URI for that
+instance.
+
+**flux uri** attempts to resolve its *TARGET* argument to a native local
+or remote URI. The *TARGET* is itself a URI which specifies the method
+to use in URI resolution via the scheme part, with the path and query
+parts passed to a plugin which implements the resolution method.
+
+As a convenience, if *TARGET* is specified with no scheme, then the scheme
+is assumed to be ``jobid``.  This allows ``flux uri`` to be used to look
+up the URI for a Flux instance running as a job in the current enclosing
+instance with:
+
+::
+
+   $ flux uri JOBID
+
+Depending on the *TARGET* URI scheme and corresponding plugin, specific
+query arguments int *TARGET* may be supported. However, as a convenience,
+all *TARGET* URIs support the special query arguments ``local`` or
+``remote`` to force the resulting URI into a local (``local://``) or remote
+(``ssh://``) form. For example:
+
+::
+
+   $ flux uri JOBID?local
+
+would return the ``local://`` URI for *JOBID* (if the URI can be resolved).
+
+A list of supported URI schemes will be listed at the bottom of
+``flux uri --help`` message. For a description of the URI resolver schemes
+included with Flux, see the URI SCHEMES and EXAMPLES sections below.
+
+OPTIONS
+=======
+
+**-remote**
+   Return the *remote* (``ssh://``)  equivalent of the resolved URI.
+
+**--local**
+   Return the *local* (``local://``) equivalent of the resulved URI.
+   Warning: the resulting URI may be invalid for the current system
+   if the network host specified by an ``ssh`` URI is not the current
+   host.
+
+URI SCHEMES
+===========
+
+The following URI schemes are included by default:
+
+jobid:ID[/ID...]
+   This scheme attempts to get the URI for a Flux instance running as a
+   job in the current enclosing instance. This is the assumed scheme if no
+   ``scheme:`` is provided in *TARGET* passed to ``flux uri``, so the
+   ``jobid:`` prefix is optional. A hierarchy of Flux jobids is supported,
+   so ``f1234/f3456`` will resolve the URI for job ``f3456`` running in
+   job ``f1234`` in the current instance.
+
+pid:PID
+  This scheme attempts to read the ``FLUX_URI`` value from the process id
+  *PID* using ``/proc/PID/environ``. If *PID* refers to a ``flux-broker``,
+  then the scheme reads ``FLUX_URI`` from the broker's initial program or
+  another child process since ``FLUX_URI`` in the broker's environment
+  would refer to *its* parent (or may not be set at all in the case of a
+  test instance started with ``flux start --test-size=N``).
+
+slurm:JOBID
+  This scheme makes a best-effort to resolve the URI of a Flux instance
+  launched under Slurm. It invokes ``srun`` to run ``scontrol listpids``
+  on the first node of the job, and then uses the ``pid`` resolver until
+  it finds a valid ``FLUX_URI``.
+
+
+EXAMPLES
+========
+
+To get the URI of a job in the current instance in its ``local://`` form:
+
+::
+
+   $ flux uri --local ƒN8Pz2xVu
+   local:///tmp/flux-zbVtVg/jobtmp-0-ƒN8Pz2xVu/flux-59uf5w/local-0
+
+or
+
+::
+
+   $ flux uri ƒN8Pz2xVu?local
+   local:///tmp/flux-zbVtVg/jobtmp-0-ƒN8Pz2xVu/flux-59uf5w/local-0
+
+
+Get the URI of a nested job:
+
+::
+
+   $ flux uri ƒqxxTiZBM/ƒr2XFWP?local
+   local:///tmp/flux-zbVtVg/jobtmp-0-ƒqxxTiZBM/flux-EPgSwk/local-0
+
+.. note::
+   With  the ``jobid`` resolver, ``?local`` only needs to be placed on
+   the last component of the jobid "path" or hierarchy. This will resolve
+   each URI in turn as a local URI.
+
+Get the URI of a local flux-broker
+
+::
+
+   $ flux uri pid:$(pidof -s flux-broker)
+   local:///tmp/flux-sLuBkZ/local-0
+
+Get the URI for a Flux instance running as a Slurm job:
+
+::
+
+   $ flux uri slurm:7843494
+   ssh://cluster42/var/tmp/user/flux-MpnytT/local-0
+
+
+RESOURCES
+=========
+
+Github: http://github.com/flux-framework

--- a/doc/man1/index.rst
+++ b/doc/man1/index.rst
@@ -26,5 +26,6 @@ man1
    flux-proxy
    flux-start
    flux-shell
+   flux-uri
    flux-version
    flux

--- a/src/bindings/python/flux/Makefile.am
+++ b/src/bindings/python/flux/Makefile.am
@@ -44,6 +44,7 @@ nobase_fluxpy_PYTHON = \
 	uri/__init__.py \
 	uri/resolvers/jobid.py \
 	uri/resolvers/pid.py \
+	uri/resolvers/slurm.py \
 	utils/parsedatetime/__init__.py \
 	utils/parsedatetime/parsedatetime.py \
 	utils/parsedatetime/warns.py \

--- a/src/bindings/python/flux/Makefile.am
+++ b/src/bindings/python/flux/Makefile.am
@@ -9,6 +9,7 @@ nobase_fluxpy_PYTHON = \
 	future.py \
 	memoized_property.py \
 	debugged.py \
+	importer.py \
 	core/__init__.py \
 	core/watchers.py \
 	core/inner.py \

--- a/src/bindings/python/flux/Makefile.am
+++ b/src/bindings/python/flux/Makefile.am
@@ -42,6 +42,7 @@ nobase_fluxpy_PYTHON = \
 	progress.py \
 	uri/uri.py \
 	uri/__init__.py \
+	uri/resolvers/jobid.py \
 	utils/parsedatetime/__init__.py \
 	utils/parsedatetime/parsedatetime.py \
 	utils/parsedatetime/warns.py \

--- a/src/bindings/python/flux/Makefile.am
+++ b/src/bindings/python/flux/Makefile.am
@@ -43,6 +43,7 @@ nobase_fluxpy_PYTHON = \
 	uri/uri.py \
 	uri/__init__.py \
 	uri/resolvers/jobid.py \
+	uri/resolvers/pid.py \
 	utils/parsedatetime/__init__.py \
 	utils/parsedatetime/parsedatetime.py \
 	utils/parsedatetime/warns.py \

--- a/src/bindings/python/flux/Makefile.am
+++ b/src/bindings/python/flux/Makefile.am
@@ -40,6 +40,8 @@ nobase_fluxpy_PYTHON = \
 	hostlist.py \
 	idset.py \
 	progress.py \
+	uri/uri.py \
+	uri/__init__.py \
 	utils/parsedatetime/__init__.py \
 	utils/parsedatetime/parsedatetime.py \
 	utils/parsedatetime/warns.py \

--- a/src/bindings/python/flux/importer.py
+++ b/src/bindings/python/flux/importer.py
@@ -1,0 +1,56 @@
+###############################################################
+# Copyright 2021 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+import sys
+import os
+import pkgutil
+import importlib
+
+
+def import_plugins_pkg(ns_pkg):
+    """Import all modules found in the namespace package ``ns_pkg``"""
+    return {
+        name: importlib.import_module(f"{ns_pkg.__name__}.{name}")
+        for finder, name, ispkg in pkgutil.iter_modules(ns_pkg.__path__)
+    }
+
+
+def import_plugins(pkg_name, pluginpath=None):
+    """Load plugins from a namespace package and optional additional paths
+
+    A plugin in pluginpath with the same name as an existing plugin will
+    take precedence
+    """
+    if pluginpath is not None:
+        sys.path[1:1] = pluginpath
+
+    try:
+        #  Load 'pkg_name' as a namespace plugin
+        pkg = importlib.import_module(pkg_name)
+        plugins = import_plugins_pkg(pkg)
+    except ModuleNotFoundError:
+        return []
+
+    if pluginpath is not None:
+        #  Undo any added pluginpath elements.
+        for path in pluginpath:
+            sys.path.remove(path)
+
+    return plugins
+
+
+def import_path(file_path):
+    """Import a module directly from file_path"""
+
+    module_name = os.path.basename(file_path).rstrip(".py")
+    spec = importlib.util.spec_from_file_location(module_name, file_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module

--- a/src/bindings/python/flux/job/validator/validator.py
+++ b/src/bindings/python/flux/job/validator/validator.py
@@ -8,16 +8,13 @@
 # SPDX-License-Identifier: LGPL-3.0
 ###############################################################
 
-import os
-import sys
 import json
-import importlib
-import pkgutil
 import argparse
 import threading
 import concurrent.futures
 from abc import ABC, abstractmethod
 import flux
+from flux.importer import import_plugins, import_path
 
 
 class ValidatorResult:
@@ -123,43 +120,6 @@ class ValidatorPlugin(ABC):  # pragma: no cover
             None or (errnum, errmsg) tuple.
         """
         raise NotImplementedError
-
-
-def import_plugins_pkg(ns_pkg):
-    """Import all modules found in the namespace package ``ns_pkg``"""
-    return {
-        name: importlib.import_module(f"{ns_pkg.__name__}.{name}")
-        for finder, name, ispkg in pkgutil.iter_modules(ns_pkg.__path__)
-    }
-
-
-def import_plugins(pkg_name, pluginpath=None):
-    """Load plugins from a namespace package and optional additional paths
-
-    A plugin in pluginpath with the same name as an existing plugin will
-    take precedence
-    """
-    if pluginpath is not None:
-        sys.path[1:1] = pluginpath
-
-    #  Load 'pkg_name' as a namespace plugin
-    pkg = importlib.import_module(pkg_name)
-    plugins = import_plugins_pkg(pkg)
-
-    if pluginpath is not None:
-        #  Undo any added pluginpath elements.
-        for path in pluginpath:
-            sys.path.remove(path)
-
-    return plugins
-
-
-def import_path(file_path):
-    module_name = os.path.basename(file_path).rstrip(".py")
-    spec = importlib.util.spec_from_file_location(module_name, file_path)
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
 
 
 # pylint: disable=too-many-instance-attributes

--- a/src/bindings/python/flux/uri/__init__.py
+++ b/src/bindings/python/flux/uri/__init__.py
@@ -1,0 +1,11 @@
+###############################################################
+# Copyright 2021 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+from flux.uri.uri import URI, JobURI, URIResolverURI, FluxURIResolver, URIResolverPlugin

--- a/src/bindings/python/flux/uri/resolvers/jobid.py
+++ b/src/bindings/python/flux/uri/resolvers/jobid.py
@@ -1,0 +1,70 @@
+###############################################################
+# Copyright 2021 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+from pathlib import PurePath
+
+import flux
+from flux.job import JobID, job_list_id
+from flux.uri import URIResolverPlugin, URIResolverURI, JobURI
+
+
+def filter_slash(iterable):
+    return list(filter(lambda x: "/" not in x, iterable))
+
+
+class URIResolver(URIResolverPlugin):
+    """A URI resolver that attempts to fetch the remote_uri for a job"""
+
+    def describe(self):
+        return "Get URI for a given Flux JOBID"
+
+    def _do_resolve(self, uri, flux_handle, force_local=False):
+        #
+        #  Convert a possible hiearchy of jobids to a list, dropping any
+        #   extraneous '/' (e.g. //id0/id1 -> [ "id0", "id1" ]
+        jobids = filter_slash(PurePath(uri.path).parts)
+
+        #  Pop the first jobid off the list, this id should be local:
+        arg = jobids.pop(0)
+        try:
+            jobid = JobID(arg)
+        except OSError as exc:
+            raise ValueError(f"{arg} is not a valid jobid")
+
+        #  Fetch the jobinfo object for this job
+        try:
+            uri = (
+                job_list_id(flux_handle, jobid, attrs=["annotations"])
+                .get_jobinfo()
+                .user.uri
+            )
+        except FileNotFoundError as exc:
+            raise ValueError(f"jobid {arg} not found") from exc
+
+        if str(uri) == "":
+            raise ValueError(f"URI not found for job {arg}")
+
+        #  If there are more jobids in the hierarchy to resolve, resolve
+        #   them recursively
+        if jobids:
+            arg = "/".join(jobids)
+            resolver_uri = URIResolverURI(f"jobid:{arg}")
+            if force_local:
+                uri = JobURI(uri).local
+            return self._do_resolve(
+                resolver_uri, flux.Flux(uri), force_local=force_local
+            )
+        return uri
+
+    def resolve(self, uri):
+        force_local = False
+        if "local" in uri.query_dict:
+            force_local = True
+        return self._do_resolve(uri, flux.Flux(), force_local=force_local)

--- a/src/bindings/python/flux/uri/resolvers/pid.py
+++ b/src/bindings/python/flux/uri/resolvers/pid.py
@@ -1,0 +1,55 @@
+###############################################################
+# Copyright 2021 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+import os
+import re
+from pathlib import PurePath
+
+from flux.uri import URIResolverPlugin
+
+
+def _get_broker_child(pid):
+    """Return the pid of the first child found, for use with flux-broker"""
+    for taskid in os.listdir(f"/proc/{pid}/task"):
+        try:
+            with open(f"/proc/{pid}/task/{taskid}/children") as cfile:
+                cpid = cfile.read().split(" ")[0]
+                if cpid:
+                    return cpid
+        except FileNotFoundError:
+            pass
+    raise ValueError(f"PID {pid} is a flux-broker and no child can be found")
+
+
+class URIResolver(URIResolverPlugin):
+    """A URIResolver that can fetch a FLUX_URI value from a local PID"""
+
+    def describe(self):
+        return "Get FLUX_URI for a given local PID"
+
+    def resolve(self, uri):
+        """
+        Resolve a PID to a URI by grabbing the FLUX_URI environment variable
+        from the process environment, or if the process is a flux-broker,
+        then from the first child.
+        """
+        pid = PurePath(uri.path).parts[0]
+        command = ""
+        with open(f"/proc/{pid}/status") as sfile:
+            command = sfile.read().split("\t")[1]
+        if re.search("flux-broker", command):
+            pid = _get_broker_child(pid)
+        with open(f"/proc/{pid}/environ", encoding="utf-8") as envfile:
+            for line in envfile.read().split("\0"):
+                if "=" in line:
+                    result = line.split("=")
+                    if result[0] == "FLUX_URI":
+                        return result[1]
+        raise ValueError(f"PID {pid} doesn't seem to have a FLUX_URI")

--- a/src/bindings/python/flux/uri/resolvers/slurm.py
+++ b/src/bindings/python/flux/uri/resolvers/slurm.py
@@ -1,0 +1,107 @@
+###############################################################
+# Copyright 2021 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+import os
+import errno
+import subprocess
+from pathlib import PurePath
+
+from flux.uri import URIResolverPlugin, FluxURIResolver
+
+
+def slurm_job_pids(jobid):
+    """Read pids for Slurm jobid using scontrol listpids"""
+
+    pids = []
+    sp = subprocess.run(
+        ["scontrol", "listpids", jobid], stdout=subprocess.PIPE, stderr=subprocess.PIPE
+    )
+    if sp.returncode != 0:
+        raise OSError(errno.ENOENT)
+    for line in sp.stdout.decode("utf-8").split("\n"):
+        #  Output fields are "PID,JOBID,STEPID,LOCALID,GLOBALID"
+        #
+        #  The "main" flux-broker should have been directly launched
+        #   from slurmstepd, so its LOCALID should be 0. Thus, only
+        #   process pids with LOCALID 0 so we don't accidentally get
+        #   the FLUX_URI for a subinstance of the main Flux instance
+        #   (avoids the need to query the instance-level attribute)
+        fields = line.split()
+        try:
+            if int(fields[3]) != 0:
+                continue
+            pid = int(fields[0])
+            if pid != os.getpid():
+                pids.append(pid)
+        except (ValueError, IndexError):
+            pass
+    return pids
+
+
+def slurm_resolve_remote(jobid):
+    """
+    Attempt to resolve a Flux job URI for Slurm jobid by running
+
+      srun --overlap --jobid flux uri slurm:jobid
+
+    on the first node of the Slurm job
+    """
+
+    #  Clear FLUX_URI in srun environment so we don't confuse
+    #   ourselves and return the current FLUX_URI from flux-uri's
+    #   environment
+    env = os.environ.copy()
+    if "FLUX_URI" in env:
+        del env["FLUX_URI"]
+    sp = subprocess.run(
+        [
+            "srun",
+            "--overlap",
+            f"--jobid={jobid}",
+            "-n1",
+            "-N1",
+            "flux",
+            "uri",
+            f"slurm:{jobid}",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=env,
+    )
+    if sp.returncode != 0:
+        raise ValueError(f"Unable to resolve Flux URI for Slurm job {jobid}")
+    return sp.stdout.decode("utf-8").rstrip()
+
+
+class URIResolver(URIResolverPlugin):
+    """A URIResolver that can fetch a FLUX_URI from a Slurm job"""
+
+    def describe(self):
+        return "Get URI for a Flux instance launched under Slurm"
+
+    def resolve(self, uri):
+        jobid = PurePath(uri.path).parts[0]
+
+        #  Get list of local Slurm job pids from scontrol.
+        #  If that fails, then the job might be running remotely, so
+        #   try using srun to run `flux uri slurm:JOBID` on the first
+        #   node of the Slurm job.
+        try:
+            pids = slurm_job_pids(jobid)
+        except OSError:
+            return slurm_resolve_remote(jobid)
+
+        resolver = FluxURIResolver()
+        for pid in pids:
+            try:
+                return resolver.resolve(f"pid:{pid}").remote
+            except (ValueError, OSError):
+                pass
+        raise ValueError(f"PID {pid} doesn't seem to have a FLUX_URI")

--- a/src/bindings/python/flux/uri/uri.py
+++ b/src/bindings/python/flux/uri/uri.py
@@ -1,0 +1,199 @@
+###############################################################
+# Copyright 2021 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+import platform
+import re
+from abc import ABC, abstractmethod
+
+from urllib.parse import urlparse, parse_qs
+
+from flux.importer import import_plugins
+
+
+class URI:
+    """Simple URI class
+
+    Parse URI strings with urllib.parse.urlparse, but with mutable properties
+
+    Attributes:
+      uri: copy of original uri argument
+      scheme: addressing scheme
+      netloc: network location part
+      path: path part
+      params: parameters if present
+      query:  query component
+      query_dict: query component as dictionary
+      fragment: fragment identifier
+    """
+
+    def __init__(self, uri):
+
+        self.uri = uri
+        self.query_dict = {}
+        uri = urlparse(self.uri)
+
+        for name, value in uri._asdict().items():
+            setattr(self, name, value)
+
+        if self.query:
+            self.query_dict = parse_qs(self.query, keep_blank_values=True)
+
+
+class JobURI(URI):
+    """A Flux job/instance URI
+
+    A URI specific to a Flux instance. Same attributes as flux.uri.URI,
+    with additional attributes to convert to a ``remote`` or ``local``
+    URI.
+
+    Attributes:
+      remote: If local URI, returns a remote URI substituting current hostname.
+              If a remote URI, returns the URI.
+      local: If a remote URI, convert to a local URI. Otherwise return the URI.
+    """
+
+    def __init__(self, uri):
+        super().__init__(uri)
+        if self.scheme == "":
+            raise ValueError(f"JobURI '{uri}' does not have a valid scheme")
+        self.path = re.sub("/+", "/", self.path)
+        self.remote_uri = None
+        self.local_uri = None
+
+    @property
+    def remote(self):
+        if not self.remote_uri:
+            if self.scheme == "ssh":
+                self.remote_uri = self.uri
+            elif self.scheme == "local":
+                hostname = platform.uname()[1]
+                self.remote_uri = f"ssh://{hostname}{self.path}"
+            else:
+                raise ValueError(
+                    f"Cannot convert JobURI with scheme {self.scheme} to remote"
+                )
+        return self.remote_uri
+
+    @property
+    def local(self):
+        if not self.local_uri:
+            if self.scheme == "local":
+                self.local_uri = self.uri
+            elif self.scheme == "ssh":
+                self.local_uri = f"local://{self.path}"
+            else:
+                raise ValueError(
+                    f"Cannot convert JobURI with scheme {self.scheme} to local"
+                )
+
+        return self.local_uri
+
+    def __str__(self):
+        return self.uri
+
+
+class URIResolverURI(URI):
+    """A URI which resolves to a JobURI
+
+    A URI used with ``FluxURIResolver.resolve``.
+    Includes a workaround for ``urllib.parse.urlparse`` problems parsing
+    path componenets with only digits.
+    """
+
+    def __init__(self, uri):
+        #  Replace : with :FXX to allow path to be digits only
+        super().__init__(uri.replace(":", ":FXX", 1))
+        self.path = self.path.replace("FXX", "", 1)
+
+
+class URIResolverPlugin(ABC):  # pragma: no cover
+    """Abstract type for a plugin used to resolve Flux URIs"""
+
+    def __init__(self, *args):
+        """Initialize a URI resolver plugin"""
+
+    @abstractmethod
+    def describe(self):
+        """Return a short description of the support URI scheme"""
+        return NotImplementedError
+
+    @abstractmethod
+    def resolve(self, uri):
+        """Resolve a get-uri URI into a FluxJobURI"""
+        return NotImplementedError
+
+
+class FluxURIResolver:
+    """A plugin-based Flux job URI resolver class
+
+    A FluxURIResolver loads plugins which implement different _schemes_
+    for resolution simple URIs to Flux job URIs. Plugins or "resolvers"
+    are loaded from the ``flux.uri.resolvers`` namespace.
+    """
+
+    def __init__(self, pluginpath=None):
+        if pluginpath is None:
+            pluginpath = []
+        self.plugin_namespace = "flux.uri.resolvers"
+        self.resolvers = {}
+
+        plugins = import_plugins(self.plugin_namespace, pluginpath)
+        if plugins:
+            for scheme, plugin in plugins.items():
+                self.resolvers[scheme] = plugin.URIResolver()
+
+    def resolve(self, uri):
+        """Resolve ``uri`` to a Flux job URI using dynamically loaded plugins
+
+        The _scheme_ of the provided target URI determines which plugin
+        is used to satisfy the query.
+
+        If no _scheme_ is provided, then a default scheme of ``jobid``
+        is assumed.
+
+        URI "query" parameters may be supported by the underlying resolver
+        plugin, but the ``remote`` and ``local`` query strings are always
+        supported and will result in forced conversion of the returned
+        job URI to a remote or local form, respectively.
+
+        Raises NotImplementedError if no plugin for _scheme_ can be found.
+
+        Raises ValueError if ``uri`` cannot otherwise be converted to a
+        job uri by the plugin for _scheme_.
+
+        """
+        scheme = URIResolverURI(uri).scheme
+        if str(scheme) == "":
+            scheme = "jobid"
+            uri = f"jobid:{uri}"
+        if scheme in ["ssh", "local"]:
+            return JobURI(uri)
+        if scheme not in self.resolvers:
+            raise NotImplementedError(f"No plugin for URI scheme {scheme}")
+
+        resolver_uri = URIResolverURI(uri)
+
+        query = resolver_uri.query_dict
+        if "local" in query and "remote" in query:
+            raise ValueError("Only one of 'local' or 'remote' is allowed")
+
+        result = JobURI(self.resolvers[scheme].resolve(resolver_uri))
+
+        #  Special case for 'local' or 'remote' query paramters:
+        if "local" in query:
+            result = JobURI(result.local)
+        elif "remote" in query:
+            result = JobURI(result.remote)
+        return result
+
+    def plugins(self):
+        """Get a dict of loaded URI resolver plugins by {name: description}"""
+
+        return {name: x.describe() for name, x in self.resolvers.items()}

--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -71,7 +71,8 @@ dist_fluxcmd_SCRIPTS = \
 	flux-jobtap.py \
 	flux-job-validator.py \
 	flux-job-exec-override.py \
-	flux-perilog-run.py
+	flux-perilog-run.py \
+	flux-uri.py
 
 fluxcmd_PROGRAMS = \
 	flux-terminus \

--- a/src/cmd/flux-uri.py
+++ b/src/cmd/flux-uri.py
@@ -1,0 +1,67 @@
+##############################################################
+# Copyright 2021 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+##############################################################
+
+import sys
+import logging
+import argparse
+
+import flux
+from flux.uri import FluxURIResolver
+
+LOGGER = logging.getLogger("flux-uri")
+
+
+@flux.util.CLIMain(LOGGER)
+def main():
+
+    sys.stdout = open(
+        sys.stdout.fileno(), "w", encoding="utf8", errors="surrogateescape"
+    )
+
+    resolver = FluxURIResolver()
+    plugins = [f"  {x}\t\t{y}" for x, y in resolver.plugins().items()]
+    plugin_list = "Supported resolver schemes:\n" + "\n".join(plugins)
+
+    parser = argparse.ArgumentParser(
+        prog="flux-uri",
+        description="Resolve TARGET to a Flux URI",
+        epilog=plugin_list,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--remote",
+        action="store_true",
+        help="convert a local URI to remote",
+    )
+    parser.add_argument(
+        "--local",
+        action="store_true",
+        help="convert a remote URI to local",
+    )
+    parser.add_argument(
+        "uri",
+        metavar="TARGET",
+        help="A Flux jobid or URI in scheme:argument form (e.g. jobid:f1234)",
+    )
+
+    args = parser.parse_args()
+    uri = resolver.resolve(args.uri)
+    if args.remote:
+        print(uri.remote)
+    elif args.local:
+        print(uri.local)
+    else:
+        print(uri)
+
+
+if __name__ == "__main__":
+    main()
+
+# vi: ts=4 sw=4 expandtab

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -174,6 +174,7 @@ TESTSCRIPTS = \
 	t2703-mini-bulksubmit.t \
 	t2800-jobs-cmd.t \
 	t2801-top-cmd.t \
+	t2802-uri-cmd.t \
 	t2900-job-timelimits.t \
 	t3000-mpi-basic.t \
 	t3001-mpi-personalities.t \
@@ -212,6 +213,7 @@ TESTSCRIPTS = \
 	python/t0022-resource-set.py \
 	python/t0023-executor.py \
 	python/t0024-util.py \
+	python/t0025-uri.py \
 	python/t1000-service-add-remove.py
 
 if HAVE_FLUX_SECURITY

--- a/t/python/t0025-uri.py
+++ b/t/python/t0025-uri.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+
+###############################################################
+# Copyright 2021 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+import unittest
+import platform
+import subflux  # To set up PYTHONPATH
+from pycotap import TAPTestRunner
+from flux.uri import JobURI, FluxURIResolver
+
+
+class TestJobURI(unittest.TestCase):
+    def test_parse_remote(self):
+        uri = JobURI("ssh://foo.com/tmp/foo?tag=bar&x=y")
+        self.assertEqual(uri.uri, "ssh://foo.com/tmp/foo?tag=bar&x=y")
+        self.assertEqual(uri.remote, "ssh://foo.com/tmp/foo?tag=bar&x=y")
+        self.assertEqual(uri.local, "local:///tmp/foo")
+        self.assertEqual(uri.scheme, "ssh")
+        self.assertEqual(uri.netloc, "foo.com")
+        self.assertEqual(uri.path, "/tmp/foo")
+        self.assertEqual(uri.query, "tag=bar&x=y")
+        self.assertEqual(uri.fragment, "")
+        self.assertEqual(uri.params, "")
+
+    def test_parse_local(self):
+        hostname = platform.uname()[1]
+        uri = JobURI("local:///tmp/foo")
+        self.assertEqual(uri.uri, "local:///tmp/foo")
+        self.assertEqual(str(uri), "local:///tmp/foo")
+        self.assertEqual(uri.remote, f"ssh://{hostname}/tmp/foo")
+        self.assertEqual(uri.local, "local:///tmp/foo")
+        self.assertEqual(uri.scheme, "local")
+        self.assertEqual(uri.netloc, "")
+        self.assertEqual(uri.path, "/tmp/foo")
+        self.assertEqual(uri.query, "")
+        self.assertEqual(uri.fragment, "")
+        self.assertEqual(uri.params, "")
+
+    def test_parse_errors(self):
+        with self.assertRaises(ValueError) as error:
+            JobURI("foo:///tmp/bar").remote
+        with self.assertRaises(ValueError) as error:
+            JobURI("foo:///tmp/bar").local
+        with self.assertRaises(ValueError) as error:
+            JobURI("")
+
+
+if __name__ == "__main__":
+    unittest.main(testRunner=TAPTestRunner())

--- a/t/t2802-uri-cmd.t
+++ b/t/t2802-uri-cmd.t
@@ -1,0 +1,135 @@
+#!/bin/sh
+
+test_description='Test flux uri command'
+
+. $(dirname $0)/sharness.sh
+
+test_under_flux 1
+
+testssh="${SHARNESS_TEST_SRCDIR}/scripts/tssh"
+
+test_expect_success 'flux-uri -h prints list of resolvers' '
+	flux uri --help >help.out >help.out 2>&1 &&
+	test_debug "cat help.out" &&
+	grep "Supported resolver schemes" help.out
+'
+test_expect_success 'flux-uri rejects invalid URI' '
+	test_expect_code 1 flux uri bar &&
+	test_expect_code 1 flux uri bar:foo
+'
+test_expect_success 'flux-uri passes through ssh and local URIs unchanged' '
+	ssh_uri="ssh://bongo@foo.com:123/tmp/flux-xyzzy/local-0" &&
+	local_uri="local:///tmp/flux-xyzzy/local-0" &&
+	result=$(flux uri $ssh_uri) &&
+	test_debug "echo flux uri $ssh_uri returns $result" &&
+	test "$result" = "$ssh_uri" &&
+	result=$(flux uri $local_uri) &&
+	test_debug "echo flux uri $local_uri returns $result" &&
+	test "$result" = "$local_uri" &&
+	result=$(flux uri --local $ssh_uri) &&
+	test_debug "echo flux uri --local $ssh_uri returns $result" &&
+	test "$result" = "$local_uri" &&
+	result=$(flux uri --remote $local_uri) &&
+	test_debug "echo flux uri --remote $local_uri returns $result" &&
+	test "$result" = "ssh://$(hostname -s)/tmp/flux-xyzzy/local-0"
+'
+test_expect_success 'flux-uri pid resolver works' '
+	test "$(flux uri pid:$$)" =  "$FLUX_URI"
+'
+test_expect_success 'flux-uri pid resolver works with ?local' '
+	test "$(flux uri pid:$$?local)" =  "$FLUX_URI"
+'
+test_expect_success 'flux-uri pid resolver works with ?remote' '
+	test "$(flux uri pid:$$?remote)" =  "$(flux uri --remote $FLUX_URI)"
+'
+test_expect_success 'flux-uri pid resolver works on flux-broker' '
+	test "$(flux uri pid:$(flux getattr broker.pid))" =  "$FLUX_URI"
+'
+test_expect_success 'flux-uri pid resolver fails for nonexistent pid' '
+	test_expect_code 1 flux uri pid:123456
+'
+test_expect_success 'flux-uri pid resolver fails with ?local&remote' '
+	test_expect_code 1 flux uri "pid:$$?local&remote"
+'
+test_expect_success NO_CHAIN_LINT 'flux-uri pid scheme fails for non-flux pid' '
+	pid=$(bash -c "unset FLUX_URI;sleep 30 >/dev/null 2>&1 & echo \$!") &&
+	test_expect_code 1 flux uri pid:$pid &&
+	kill $pid
+'
+test_expect_success 'start a small hierarchy of Flux instances' '
+	cat <<-EOF >batch.sh &&
+	#!/bin/sh
+	jobid=\$(flux mini submit -n1 flux start flux mini run sleep 300) &&
+	flux --parent job memo \$(flux getattr jobid) jobid=\$jobid &&
+	flux job attach \$jobid
+	EOF
+	chmod +x batch.sh &&
+	jobid=$(flux mini batch -n1 batch.sh) &&
+	flux job wait-event -T offset -vt 15 -c 2 $jobid memo
+'
+test_expect_success 'flux uri resolves jobid argument' '
+	flux proxy $(flux uri --local $jobid) flux getattr jobid >jobid1.out &&
+	test "$(cat jobid1.out)" = "$jobid"
+'
+test_expect_success 'flux uri resolves hierarchical jobid argument'  '
+	jobid2=$(flux jobs -no {user.jobid} $jobid) &&
+	test_debug "echo attempting to resolve jobid:${jobid}/${jobid2}" &&
+	uri=$(FLUX_SSH=$testssh flux uri --local jobid:${jobid}/${jobid2}) &&
+	test_debug "echo jobid:${jobid}/${jobid2} is ${uri}" &&
+	uri=$(FLUX_SSH=$testssh flux uri --local ${jobid}/${jobid2}) &&
+	test_debug "echo ${jobid}/${jobid2} is ${uri}"
+'
+test_expect_success 'flux uri resolves hierarchical jobids with ?local' '
+	test_debug "echo attempting to resolve jobid:${jobid}/${jobid2}" &&
+	uri=$(flux uri jobid:${jobid}/${jobid2}?local) &&
+	test_debug "echo jobid:${jobid}/${jobid2}?local is ${uri}" &&
+	uri=$(flux uri ${jobid}/${jobid2}?local) &&
+	test_debug "echo ${jobid}/${jobid2}?local is ${uri}"
+
+'
+test_expect_success 'flux uri jobid returns error for non-instance job' '
+	id=$(flux mini submit sleep 600) &&
+	test_expect_code 1 flux uri $id
+'
+test_expect_success 'flux uri jobid scheme returns error for invalid jobid' '
+	test_expect_code 1 flux uri jobid:boop
+'
+test_expect_success 'flux uri jobid scheme returns error for unkown jobid' '
+	test_expect_code 1 flux uri jobid:f1
+'
+test_expect_success 'setup fake srun and scontrol cmds for mock slurm testing' '
+	#  slurm resolver runs `srun flux uri slurm:jobid`
+	#  mock the execution of that command here by just returning a uri
+	cat <<-EOF >srun &&
+	#!/bin/sh
+	test -n "\$SRUN_FAIL" && exit 1
+	exec flux uri pid:$$
+	EOF
+	chmod +x srun &&
+	#  slurm resolver attempts to list pids from `scontrol listpids`
+	#  return a single listpids line with our pid for mocking
+	#  set
+	cat <<-EOF >scontrol &&
+	#!/bin/sh
+	test -n "\$REMOTE" && exit 1
+	echo "PID      JOBID    STEPID   LOCALID GLOBALID"
+	echo "1         1234      1234         0        0"
+	echo "$$        1234      1234         0        0"
+	EOF
+	chmod +x scontrol
+'
+test_expect_success 'flux-uri mock testing of slurm resolver works' '
+	result=$(PATH=$(pwd):$PATH flux uri --local slurm:1234) &&
+	test_debug "echo slurm:1234 got $result" &&
+	test "$result" = "$FLUX_URI" &&
+	result=$(PATH=$(pwd):$PATH REMOTE=t flux uri --local slurm:1234) &&
+	test_debug "echo slurm:1234 with REMOTE=t got $result" &&
+	test "$result" = "$FLUX_URI" &&
+	( export PATH=$(pwd):$PATH REMOTE=t SRUN_FAIL=t &&
+	  test_expect_code 1 flux uri slurm:1234 )
+'
+test_expect_success 'cleanup jobs' '
+	flux job cancelall -f &&
+	flux queue drain
+'
+test_done


### PR DESCRIPTION
This PR introduces a `FluxURIResolver` Python class which can resolve target URIs to Flux job URIs. Support for resolving URIs in different contexts is provided by resolver "plugins" which are loaded based on the target URI _scheme_, though if no _scheme_ is provided, then a scheme of `jobid` is assumed.

A new `flux-uri(1)` utility is provided to access this Python class from the commandline.

The PR includes three resolver plugins:

 * `jobid`: resolve job URIs for a Flux jobid in the current instance. This resolver works recursively if a "path" of jobids is provided, e.g. `jobid:f1234/f3456` will attempt to resolve the URI for jobid `f3456` running as  child job of `f1234`. Since `jobid` is the default URI resolver scheme, `f1234/f3456` would also work. e.g.
   ```console
   $ flux uri ƒR3S77XQb
   ssh://quartz18/var/tmp/grondo/flux-jJ8CaZ/local-0
   ```
 * `pid:` resolve a URI for a local process id. This plugin attempts to read the `FLUX_URI` value from `/proc/PID/environ`. As a convenience, if the process appears to be a `flux-broker`, then the `FLUX_URI` of one of its children is used. This allows determination of the URI for a running flux-broker by providing its PID (useful in implementation of other resolvers)
   ```console
   $ flux uri pid:$(pidof flux-broker)
   local:///tmp/flux-TBU7RM/local-0
   ```
 * `slurm:` an experimental resolver for Flux instances run as Slurm jobs. The `slurm` plugin works by using `srun` to run `scontrol listpids` on the first node of a Slurm job. For each PID that is also a direct child of slurmstepd (i.e. localid == 0) the `pid` resolver is used to resolve the FLUX_URI locally.
   ```console
   $ squeue -u grondo
             JOBID PARTITION     NAME     USER ST       TIME  NODES NODELIST(REASON)
           7843494    pdebug interact   grondo  R      55:36      2 quartz[18-19
   $ flux uri slurm:7843494
   ssh://quartz18/var/tmp/grondo/flux-MpnytT/local-0
   ```

URI resolver plugins are loaded from the `flux.uri.resolvers` namespace, so it is trivial to add third party or override existing resolvers on systems where needed. E.g. I assume someone could provide an `lsf` plugin at some point.

The next step is to extend `flux proxy` to call out to `flux uri` if its argument is not already a `local://` or `ssh://` URI. I actually have this working, but figured that would be better for a separate PR, release notes wise.

Here's a preview:
```console
$ src/cmd/flux proxy slurm:7843731 flux resource list
     STATE NNODES   NCORES    NGPUS NODELIST
      free      4       72        0 quartz[1,1-2,2]
 allocated      0        0        0 
      down      0        0        0 

```