### PR TITLE
cmd: support high-level URIs and JOBID arguments in flux-top and flux-proxy

### DIFF
--- a/doc/man1/flux-proxy.rst
+++ b/doc/man1/flux-proxy.rst
@@ -9,17 +9,22 @@ flux-proxy(1)
 SYNOPSIS
 ========
 
-**flux** **proxy** [*OPTIONS*] URI [command [args...]]
+**flux** **proxy** [*OPTIONS*] TARGET [command [args...]]
 
 DESCRIPTION
 ===========
 
-**flux proxy** connects to the Flux instance identified by *URI*,
+**flux proxy** connects to the Flux instance identified by *TARGET*,
 then spawns a shell with FLUX_URI pointing to a local:// socket
 managed by the proxy program. As long as the shell is running,
 the proxy program routes messages between the instance and the
 local:// socket. Once the shell terminates, the proxy program
 terminates and removes the socket.
+
+The *TARGET* argument is a URI which can be resolved by ``flux uri``,
+including a Flux jobid, a fully-resolved native ``ssh`` or ``local``
+URI, or a resolvable URI with a scheme supported by a ``flux uri``
+plugin.  See :man1:`flux-uri` for details.
 
 The purpose of **flux proxy** is to allow a connection to be reused,
 for example where connection establishment has high latency or
@@ -49,6 +54,32 @@ Connect to the same job remotely on host foo.com:
 ::
 
    $ flux proxy ssh://foo.com/tmp/flux-123456-abcdef/0/local
+
+Connect to a Flux instance running as job ƒQBfmbm in the current instance:
+
+::
+
+   $ flux proxy ƒQBfmbm
+
+or
+
+::
+
+   $ flux proxy jobid:ƒQBfmbm
+
+
+Connect to a Flux instance running as job ƒQ8ho35 in ƒQBfmbm
+
+::
+
+  $ flux proxy jobid:ƒQBfmbm/ƒQ8ho35
+
+
+Connect to a Flux instance started in Slurm job 1234
+
+::
+
+  $ flux proxy slurm:1234
 
 
 RESOURCES

--- a/doc/man1/flux-uri.rst
+++ b/doc/man1/flux-uri.rst
@@ -11,7 +11,7 @@ SYNOPSIS
 DESCRIPTION
 ===========
 
-Connections to Flux are established via a Uniform Resource Indicator
+Connections to Flux are established via a Uniform Resource Identifier
 (URI) which is passed to the :man3:`flux_open` API call. These *native*
 URIs indicate the "connector" which will be used to establish the
 connection, and are typically either *local*, with a  ``local`` URI

--- a/doc/man1/flux-uri.rst
+++ b/doc/man1/flux-uri.rst
@@ -79,7 +79,8 @@ jobid:ID[/ID...]
    ``scheme:`` is provided in *TARGET* passed to ``flux uri``, so the
    ``jobid:`` prefix is optional. A hierarchy of Flux jobids is supported,
    so ``f1234/f3456`` will resolve the URI for job ``f3456`` running in
-   job ``f1234`` in the current instance.
+   job ``f1234`` in the current instance. This scheme will raise an error
+   if the target job is not running.
 
 pid:PID
   This scheme attempts to read the ``FLUX_URI`` value from the process id

--- a/src/bindings/python/flux/uri/resolvers/jobid.py
+++ b/src/bindings/python/flux/uri/resolvers/jobid.py
@@ -40,11 +40,12 @@ class URIResolver(URIResolverPlugin):
 
         #  Fetch the jobinfo object for this job
         try:
-            uri = (
-                job_list_id(flux_handle, jobid, attrs=["annotations"])
-                .get_jobinfo()
-                .user.uri
-            )
+            job = job_list_id(
+                flux_handle, jobid, attrs=["state", "annotations"]
+            ).get_jobinfo()
+            if job.state != "RUN":
+                raise ValueError(f"jobid {arg} is not running")
+            uri = job.user.uri
         except FileNotFoundError as exc:
             raise ValueError(f"jobid {arg} not found") from exc
 

--- a/src/common/libutil/Makefile.am
+++ b/src/common/libutil/Makefile.am
@@ -88,7 +88,9 @@ libutil_la_SOURCES = \
 	digest.c \
 	digest.h \
 	jpath.c \
-	jpath.h
+	jpath.h \
+	uri.c \
+	uri.h
 
 EXTRA_DIST = veb_mach.c
 

--- a/src/common/libutil/uri.c
+++ b/src/common/libutil/uri.c
@@ -1,0 +1,64 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdlib.h>
+#include <string.h>
+
+#include "src/common/libyuarel/yuarel.h"
+#include "popen2.h"
+#include "read_all.h"
+#include "log.h"
+
+static void nullify_newline (char *str)
+{
+    int n;
+    if (str && (n = strlen (str)) > 0) {
+        if (str[n-1] == '\n')
+            str[n-1] = '\0';
+    }
+}
+
+char *uri_resolve (const char *uri)
+{
+    struct popen2_child *child = NULL;
+    struct yuarel yuri;
+    char *result = NULL;
+    char *argv[] = { "flux", "uri", (char *) uri, NULL };
+
+    char *cpy = strdup (uri);
+    if (!cpy)
+        return NULL;
+    if (yuarel_parse (&yuri, cpy) == 0) {
+        if (strcmp (yuri.scheme, "ssh") == 0
+            || strcmp (yuri.scheme, "local") == 0) {
+            free (cpy);
+            return strdup (uri);
+        }
+    }
+    free (cpy);
+
+    if (!(child = popen2 ("flux", argv))
+        || (read_all (popen2_get_fd (child), (void **)&result) < 0))
+        goto out;
+    nullify_newline (result);
+out:
+    if (pclose2 (child) < 0) {
+        /* flux-uri returned error */
+        free (result);
+        result = NULL;
+    }
+    return result;
+}
+
+
+// vi:ts=4 sw=4 expandtab

--- a/src/common/libutil/uri.h
+++ b/src/common/libutil/uri.h
@@ -1,0 +1,33 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _UTIL_URI_H
+#define _UTIL_URI_H
+
+/*  Resolve a target or "high-level" URI with the flux-uri(1) command,
+ *   returning the result. If the URI is already a native Flux URI (e.g.
+ *   `local://` or `ssh://`), then `flux uri` is *not* called and instead
+ *   the target is returned unmodified to avoid the extra overhead of
+ *   running a subprocess.
+ *
+ *  On failure, NULL is returned. Stderr is not redirected or consumed,
+ *   so the expectation is that the underlying `flux uri` error will
+ *   already be copied to the callers tty.
+ *
+ *  Caller must free the returned string on success.
+ *
+ *  Note: this function uses popen2() to execute flux-uri as a subprocess,
+ *   so care should be taken in when and how this function is called.
+ */
+char *uri_resolve (const char *target);
+
+#endif /* !_UTIL_URI_H */
+
+// vi:ts=4 sw=4 expandtab

--- a/t/t1105-proxy.t
+++ b/t/t1105-proxy.t
@@ -59,10 +59,6 @@ test_expect_success 'flux-proxy cannot shadow a broker service (EEXIST)' "
 	  $RPC service.add 17 <service4.add.in
 "
 
-test_expect_success 'flux-proxy fails with unknown URI scheme (ENOENT)' '
-	test_must_fail flux proxy badscheme:// 2>badscheme.err &&
-	grep "No such file or directory" badscheme.err
-'
 test_expect_success 'flux-proxy fails with unknown URI path (ENOENT)' '
 	test_must_fail flux proxy local:///noexist  2>badpath.err &&
 	grep "No such file or directory" badpath.err

--- a/t/t2802-uri-cmd.t
+++ b/t/t2802-uri-cmd.t
@@ -56,6 +56,12 @@ test_expect_success NO_CHAIN_LINT 'flux-uri pid scheme fails for non-flux pid' '
 	test_expect_code 1 flux uri pid:$pid &&
 	kill $pid
 '
+test_expect_success 'flux uri fails for completed job' '
+	complete_id=$(flux mini submit --wait flux start /bin/true) &&
+	test_expect_code 1 flux uri ${complete_id} 2>jobid-notrunning.log &&
+	test_debug "cat jobid-notrunning.log" &&
+	grep "not running" jobid-notrunning.log
+'
 test_expect_success 'start a small hierarchy of Flux instances' '
 	cat <<-EOF >batch.sh &&
 	#!/bin/sh


### PR DESCRIPTION
This PR adds a C function `flux_uri_resolve()` to libutil which calls out to `flux-uri(1)` to resolve a high-level URI "target" to a native Flux URI.

Then, support for high-level URIs is added to both `flux top` and `flux proxy` by calling `flux_uri_resolve()` to resolve the command argument, if provided.

This allows these commands to connect to jobs using any resolvable URI argument supported by `flux-uri(1)`, including plain jobids, nested jobids, e.g.:

```
ƒ(s=1,d=0,builddir) grondo@asp:~/git/flux-core.git$ flux jobs
       JOBID USER     NAME       ST NTASKS NNODES  RUNTIME NODELIST
   ƒQ6Nz6NkP grondo   flux        R      4      1   43.22s asp
ƒ(s=1,d=0,builddir) grondo@asp:~/git/flux-core.git$ flux proxy ƒQ6Nz6NkP?local flux jobs
       JOBID USER     NAME       ST NTASKS NNODES  RUNTIME NODELIST
     ƒs3pknC grondo   flux        R      1      1   50.43s asp
     ƒs3pknB grondo   flux        R      1      1   50.43s asp
     ƒs2LmVq grondo   flux        R      1      1   50.43s asp
ƒ(s=1,d=0,builddir) grondo@asp:~/git/flux-core.git$ flux proxy ƒQ6Nz6NkP/ƒs3pknC?local flux jobs -c 4
       JOBID USER     NAME       ST NTASKS NNODES  RUNTIME NODELIST
     ƒxpsxUD grondo   sleep      PD      1      -        - -
     ƒxpsxUE grondo   sleep      PD      1      -        - -
     ƒxrMwkT grondo   sleep      PD      1      -        - -
     ƒyG5kFy grondo   sleep      PD      1      -        - -
```

(Here I used `?local` because I don't have passwordless `ssh` set up)