### PR TITLE
doc: audit / cleanup SEE ALSO and RESOURCES, add cross references

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -6,6 +6,7 @@ extraction:
         - python3-six
         - python3-yaml
         - python3-jsonschema
+        - python3-docutils
 
 path_classifiers:
   vendor:

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -349,7 +349,8 @@ EXTRA_DIST = \
 	$(RST_FILES) \
 	man1/NODESET.rst \
 	man3/JSON_PACK.rst \
-	man3/JSON_UNPACK.rst
+	man3/JSON_UNPACK.rst \
+	man7/flux-undocumented.rst
 
 CLEANFILES = \
 	$(MAN_FILES)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -66,7 +66,23 @@ domainrefs = {
     'man7': {
         'text': "%s(7)",
         'url': "../man7/%s.html"
-    }
+    },
+    'linux:man1': {
+        'text': '%s(1)',
+        'url': 'http://man7.org/linux/man-pages/man1/%s.1.html',
+    },
+    'linux:man2': {
+        'text': '%s(2)',
+        'url': 'http://man7.org/linux/man-pages/man2/%s.2.html',
+    },
+    'linux:man3': {
+        'text': '%s(3)',
+        'url': 'http://man7.org/linux/man-pages/man3/%s.3.html',
+    },
+    'linux:man7': {
+        'text': '%s(7)',
+        'url': 'http://man7.org/linux/man-pages/man7/%s.7.html',
+    },
 }
 
 # Disable "smartquotes" to avoid things such as turning long-options

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -22,6 +22,7 @@
 #
 import os
 import sys
+import docutils.nodes
 
 # -- Project information -----------------------------------------------------
 
@@ -51,22 +52,6 @@ extensions = [
 ]
 
 domainrefs = {
-    'man1': {
-        'text': "%s(1)",
-        'url': "../man1/%s.html"
-    },
-    'man3': {
-        'text': "%s(3)",
-        'url': "../man3/%s.html"
-    },
-    'man5': {
-        'text': "%s(5)",
-        'url': "../man5/%s.html"
-    },
-    'man7': {
-        'text': "%s(7)",
-        'url': "../man7/%s.html"
-    },
     'linux:man1': {
         'text': '%s(1)',
         'url': 'http://man7.org/linux/man-pages/man1/%s.1.html',
@@ -117,9 +102,30 @@ def run_apidoc(_):
     exclusions = [os.path.join(py_bindings_dir, 'setup.py'),]
     main(['-e', '-f', '-M', '-o', output_path, py_bindings_dir] + exclusions)
 
+def man_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
+    section = int(name[-1])
+    page = None
+    for man in man_pages:
+        if man[1] == text and man[4] == section:
+            page = man[0]
+            break
+    if page == None:
+        page = "man7/flux-undocumented"
+        section = 7
+
+    node = docutils.nodes.reference(
+        rawsource=rawtext,
+        text=f"{text}({section})",
+        refuri=f"../{page}.html",
+        **options,
+    )
+    return [node], []
+
 # launch setup
 def setup(app):
     app.connect('builder-inited', run_apidoc)
+    for section in [ 1, 3, 5, 7 ]:
+        app.add_role(f"man{section}", man_role)
 
 # ReadTheDocs runs sphinx without first building Flux, so the cffi modules in
 # `_flux` will not exist, causing import errors.  Mock the imports to prevent

--- a/doc/man1/flux-broker.rst
+++ b/doc/man1/flux-broker.rst
@@ -51,7 +51,7 @@ OPTIONS
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org
 
 
 SEE ALSO

--- a/doc/man1/flux-broker.rst
+++ b/doc/man1/flux-broker.rst
@@ -57,4 +57,4 @@ Github: http://github.com/flux-framework
 SEE ALSO
 ========
 
-flux-broker-attributes(7)
+:man7:`flux-broker-attributes`

--- a/doc/man1/flux-content.rst
+++ b/doc/man1/flux-content.rst
@@ -135,8 +135,4 @@ RESOURCES
 
 Github: http://github.com/flux-framework
 
-
-SEE ALSO
-========
-
 `RFC 10: Content Storage Service <https://github.com/flux-framework/rfc/blob/master/spec_10.rst>`__

--- a/doc/man1/flux-content.rst
+++ b/doc/man1/flux-content.rst
@@ -135,4 +135,4 @@ RESOURCES
 
 Flux: http://flux-framework.org
 
-`RFC 10: Content Storage Service <https://github.com/flux-framework/rfc/blob/master/spec_10.rst>`__
+RFC 10: Content Storage Service: https://github.com/flux-framework/rfc/blob/master/spec_10.rst

--- a/doc/man1/flux-content.rst
+++ b/doc/man1/flux-content.rst
@@ -139,4 +139,4 @@ Github: http://github.com/flux-framework
 SEE ALSO
 ========
 
-`RFC 10: Content Store <https://github.com/flux-framework/rfc/blob/master/spec_10.rst>`__
+`RFC 10: Content Storage Service <https://github.com/flux-framework/rfc/blob/master/spec_10.rst>`__

--- a/doc/man1/flux-content.rst
+++ b/doc/man1/flux-content.rst
@@ -133,6 +133,6 @@ traveling further up the tree.
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org
 
 `RFC 10: Content Storage Service <https://github.com/flux-framework/rfc/blob/master/spec_10.rst>`__

--- a/doc/man1/flux-content.rst
+++ b/doc/man1/flux-content.rst
@@ -94,7 +94,7 @@ not eligible for purge.
 CACHE ACCOUNTING
 ================
 
-Some accounting info for the local cache can be viewed with flux-getattr(1):
+Some accounting info for the local cache can be viewed with :man1:`flux-getattr`:
 
 **content.acct-entries**
    The total number of cache entries.

--- a/doc/man1/flux-cron.rst
+++ b/doc/man1/flux-cron.rst
@@ -257,7 +257,7 @@ for *flux cron sync* for more information.
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org
 
 
 SEE ALSO

--- a/doc/man1/flux-cron.rst
+++ b/doc/man1/flux-cron.rst
@@ -263,4 +263,4 @@ Github: http://github.com/flux-framework
 SEE ALSO
 ========
 
-flux-exec(1), flux-dmesg(1)
+:man1:`flux-exec`, :man1:`flux-dmesg`

--- a/doc/man1/flux-cron.rst
+++ b/doc/man1/flux-cron.rst
@@ -19,7 +19,7 @@ triggers such as a time interval or Flux events. The service is
 implemented as a Flux extension module which, when loaded, manages
 a set of cron entries and uses the built-in *broker.exec* service to run
 a command associated with the entry each time the defined trigger is
-reached. As with *flux-exec(1)*, these tasks run as direct children
+reached. As with :man1:`flux-exec`, these tasks run as direct children
 of the flux-broker and run outside of the control of any loaded
 job scheduling service.
 
@@ -233,7 +233,7 @@ scheduler control, described in more detail in the *flux-exec(1)* man
 page.
 
 Standard output and error from tasks executed by the cron service are
-logged and may be viewed with *flux-dmesg(1)*. If a cron task exits
+logged and may be viewed with :man1:`flux-dmesg`. If a cron task exits
 with non-zero status, or fails to launch under the *broker.exec* service,
 a message is logged and the failure is added to the failure stats.
 On task failure, the cron job is stopped if *stop-on-failure* is set, and

--- a/doc/man1/flux-dmesg.rst
+++ b/doc/man1/flux-dmesg.rst
@@ -51,4 +51,4 @@ Github: http://github.com/flux-framework
 SEE ALSO
 ========
 
-flux-setattr(1), flux-broker-attributes(7)
+:man1:`flux-setattr`, :man7:`flux-broker-attributes`

--- a/doc/man1/flux-dmesg.rst
+++ b/doc/man1/flux-dmesg.rst
@@ -45,7 +45,7 @@ To dump the ring buffer on all ranks
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org
 
 
 SEE ALSO

--- a/doc/man1/flux-env.rst
+++ b/doc/man1/flux-env.rst
@@ -16,7 +16,7 @@ DESCRIPTION
 
 flux-env(1) dumps a list of all environment variables as set by flux if run
 without a command, when run with a command the environment is set and the
-command is run as it would be by the env(1) utility.
+command is run as it would be by the :linux:man1:`env` utility.
 
 
 RESOURCES

--- a/doc/man1/flux-env.rst
+++ b/doc/man1/flux-env.rst
@@ -16,7 +16,7 @@ DESCRIPTION
 
 flux-env(1) dumps a list of all environment variables as set by flux if run
 without a command, when run with a command the environment is set and the
-command is run as it would be by the ENV(1) utility.
+command is run as it would be by the env(1) utility.
 
 
 RESOURCES

--- a/doc/man1/flux-env.rst
+++ b/doc/man1/flux-env.rst
@@ -22,4 +22,4 @@ command is run as it would be by the env(1) utility.
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org

--- a/doc/man1/flux-event.rst
+++ b/doc/man1/flux-event.rst
@@ -51,4 +51,4 @@ COMMANDS
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org

--- a/doc/man1/flux-exec.rst
+++ b/doc/man1/flux-exec.rst
@@ -75,4 +75,4 @@ NODESET FORMAT
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org

--- a/doc/man1/flux-getattr.rst
+++ b/doc/man1/flux-getattr.rst
@@ -36,7 +36,7 @@ flux-lsattr(1) lists attribute names, optionally with their values.
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org
 
 
 SEE ALSO

--- a/doc/man1/flux-getattr.rst
+++ b/doc/man1/flux-getattr.rst
@@ -42,4 +42,4 @@ Github: http://github.com/flux-framework
 SEE ALSO
 ========
 
-flux_attr_get(3), flux-broker-attributes(7)
+:man3:`flux_attr_get`, :man7:`flux-broker-attributes`

--- a/doc/man1/flux-hwloc.rst
+++ b/doc/man1/flux-hwloc.rst
@@ -17,7 +17,7 @@ SYNOPSIS
 DESCRIPTION
 ===========
 
-The **flux-hwloc** utility queries hwloc(7) topology information for
+The **flux-hwloc** utility queries :linux:man7:`hwloc` topology information for
 an instance by gathering XML from the core resource module.
 
 COMMANDS
@@ -53,8 +53,8 @@ EXAMPLES
 ========
 
 When using HWLOC < 2.0 only, the output of ``flux hwloc topology``
-may be piped to other hwloc(7) commands such as ``lstopo(1)`` or
-``hwloc-info(1)``, e.g.
+may be piped to other :linux:man7:`hwloc` commands such as
+:linux:man1:`lstopo` or :linux:man1:`hwloc-info`, e.g.
 
 ::
 

--- a/doc/man1/flux-hwloc.rst
+++ b/doc/man1/flux-hwloc.rst
@@ -92,4 +92,4 @@ hwloc: https://www.open-mpi.org/projects/hwloc/
 SEE ALSO
 ========
 
-lstopo(1)
+:linux:man1:`lstopo`

--- a/doc/man1/flux-hwloc.rst
+++ b/doc/man1/flux-hwloc.rst
@@ -86,8 +86,10 @@ RESOURCES
 
 Github: http://github.com/flux-framework
 
+hwloc: https://www.open-mpi.org/projects/hwloc/
+
 
 SEE ALSO
 ========
 
-lstopo(1), hwloc: https://www.open-mpi.org/projects/hwloc/
+lstopo(1)

--- a/doc/man1/flux-hwloc.rst
+++ b/doc/man1/flux-hwloc.rst
@@ -84,7 +84,7 @@ may be piped to other hwloc(7) commands such as ``lstopo(1)`` or
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org
 
 hwloc: https://www.open-mpi.org/projects/hwloc/
 

--- a/doc/man1/flux-job.rst
+++ b/doc/man1/flux-job.rst
@@ -93,5 +93,5 @@ type (positional argument) and accepts the following options:
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org
 

--- a/doc/man1/flux-jobs.rst
+++ b/doc/man1/flux-jobs.rst
@@ -54,7 +54,8 @@ OPTIONS
 
 **--stats**
    Output a summary of global job statistics before the header.
-   May be useful in conjunction with utilities like ``watch(1)``, e.g.::
+   May be useful in conjunction with utilities like
+   :linux:man1:`watch`, e.g.::
 
       $ watch -n 2 flux jobs --stats -f running -c 25
 
@@ -216,7 +217,7 @@ The field names that can be specified are:
    True of False if job completed successfully, empty string otherwise
 
 **waitstatus**
-   The raw status of the job as returned by ``waitpid(2)`` if the job
+   The raw status of the job as returned by :linux:man2:`waitpid` if the job
    exited, otherwise an empty string. Note: *waitstatus* is the maximum
    wait status returned by all job shells in a job, which may not necessarily
    indicate the highest *task* wait status. (The job shell exits with the

--- a/doc/man1/flux-jobs.rst
+++ b/doc/man1/flux-jobs.rst
@@ -332,4 +332,4 @@ user can learn why a job failed.
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org

--- a/doc/man1/flux-jobtap.rst
+++ b/doc/man1/flux-jobtap.rst
@@ -24,15 +24,17 @@ COMMANDS
 
 **load** [*-r*, *--remove=NAME*] PLUGIN [KEY=VAL, KEY=VAL...]
   Load a new plugin into the job-manager, optionally removing plugin NAME
-  first. With *--remove* NAME may be a glob(7) pattern match. Optional
-  KEY=VAL occurring after PLUGIN will set config KEY to VAL for PLUGIN.
+  first. With *--remove* NAME may be a :linux:man7:`glob` pattern
+  match. Optional KEY=VAL occurring after PLUGIN will set config KEY
+  to VAL for PLUGIN.
 
 **remove** NAME
-  Remove plugin NAME. NAME may be a glob(7) pattern in which case all
-  matching, non-builtin plugins are removed. The special value `all` may
-  be used to remove all loaded jobtap plugins. Builtin plugins (those
-  starting with a leading ``.``) must be removed explicitly or by
-  preceding *NAME* with ``.``, e.g. ``.*``.
+  Remove plugin NAME. NAME may be a :linux:man7:`glob` pattern in
+  which case all matching, non-builtin plugins are removed. The
+  special value `all` may be used to remove all loaded jobtap
+  plugins. Builtin plugins (those starting with a leading ``.``) must
+  be removed explicitly or by preceding *NAME* with ``.``,
+  e.g. ``.*``.
 
 RESOURCES
 =========

--- a/doc/man1/flux-jobtap.rst
+++ b/doc/man1/flux-jobtap.rst
@@ -37,7 +37,7 @@ COMMANDS
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org
 
 SEE ALSO
 ========

--- a/doc/man1/flux-jobtap.rst
+++ b/doc/man1/flux-jobtap.rst
@@ -42,4 +42,4 @@ Github: http://github.com/flux-framework
 SEE ALSO
 ========
 
-flux-jobtap-plugins(7)
+:man7:`flux-jobtap-plugins`

--- a/doc/man1/flux-keygen.rst
+++ b/doc/man1/flux-keygen.rst
@@ -41,6 +41,4 @@ CurveZMQ: http://curvezmq.org/page:read-the-docs
 
 ZMTP/3.0: http://rfc.zeromq.org/spec:23
 
-Using ZeroMQ Security:
-http://hintjens.com/blog:48 and
-http://hintjens.com/blog:49
+Using ZeroMQ Security: http://hintjens.com/blog:48, http://hintjens.com/blog:49

--- a/doc/man1/flux-keygen.rst
+++ b/doc/man1/flux-keygen.rst
@@ -35,10 +35,6 @@ RESOURCES
 
 Github: http://github.com/flux-framework
 
-
-SEE ALSO
-========
-
 ZAP: http://rfc.zeromq.org/spec:27
 
 CurveZMQ: http://curvezmq.org/page:read-the-docs

--- a/doc/man1/flux-keygen.rst
+++ b/doc/man1/flux-keygen.rst
@@ -33,7 +33,7 @@ public keys are exchanged with PMI.
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org
 
 ZAP: http://rfc.zeromq.org/spec:27
 

--- a/doc/man1/flux-kvs.rst
+++ b/doc/man1/flux-kvs.rst
@@ -213,4 +213,4 @@ COMMANDS
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org

--- a/doc/man1/flux-kvs.rst
+++ b/doc/man1/flux-kvs.rst
@@ -96,11 +96,11 @@ COMMANDS
 **ls** [-N ns] [-R] [-d] [-F] [-w COLS] [-1] [*key* ...]
    Display directory referred to by *key*, or "." (root) if unspecified.
    Specify an alternate namespace to display via *-N*. Remaining options are
-   roughly equivalent to a subset of ls(1) options. *-R* lists directory
-   recursively. *-d* displays directory not its contents. *-F*
-   classifies files with one character suffix (. is directory, @ is
-   symlink). *-w COLS* sets the terminal width in characters. *-1*
-   causes output to be displayed in one column.
+   roughly equivalent to a subset of :linux:man1:`ls` options. *-R*
+   lists directory recursively. *-d* displays directory not its
+   contents. *-F* classifies files with one character suffix (. is
+   directory, @ is symlink). *-w COLS* sets the terminal width in
+   characters. *-1* causes output to be displayed in one column.
 
 **dir** [-N ns] [-R] [-d] [-w COLS] [-a treeobj] [*key*]
    Display all keys and their values under the directory *key*. Specify

--- a/doc/man1/flux-logger.rst
+++ b/doc/man1/flux-logger.rst
@@ -48,4 +48,4 @@ Github: http://github.com/flux-framework
 SEE ALSO
 ========
 
-flux-dmesg(1), flux_log(3), syslog(3)
+:man1:`flux-dmesg`, :man3:`flux_log`, syslog(3)

--- a/doc/man1/flux-logger.rst
+++ b/doc/man1/flux-logger.rst
@@ -16,7 +16,7 @@ DESCRIPTION
 flux-logger(1) appends Flux log entries to the local Flux
 broker's circular buffer.
 
-Log entries are associated with a syslog(3) style severity.
+Log entries are associated with a :linux:man3:`syslog` style severity.
 Valid severity names are *emerg*, *alert*, *crit*, *err*,
 *warning*, *notice*, *info*, *debug*.
 

--- a/doc/man1/flux-logger.rst
+++ b/doc/man1/flux-logger.rst
@@ -42,7 +42,7 @@ OPTIONS
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org
 
 
 SEE ALSO

--- a/doc/man1/flux-logger.rst
+++ b/doc/man1/flux-logger.rst
@@ -48,4 +48,4 @@ Flux: http://flux-framework.org
 SEE ALSO
 ========
 
-:man1:`flux-dmesg`, :man3:`flux_log`, syslog(3)
+:man1:`flux-dmesg`, :man3:`flux_log`, :linux:man3:`syslog`

--- a/doc/man1/flux-mini.rst
+++ b/doc/man1/flux-mini.rst
@@ -206,9 +206,9 @@ with the job.
 **--env-remove=PATTERN**
    Remove all environment variables matching *PATTERN* from the current
    generated environment. If *PATTERN* starts with a ``/`` character,
-   then it is considered a regex(7), otherwise *PATTERN* is treated
-   as a shell glob(7). This option is equivalent to ``--env=-PATTERN``
-   and may be used multiple times.
+   then it is considered a :linux:man7:`regex`, otherwise *PATTERN* is
+   treated as a shell :linux:man7:`glob`. This option is equivalent to
+   ``--env=-PATTERN`` and may be used multiple times.
 
 **--env-file=FILE**
    Read a set of environment *RULES* from a *FILE*. This option is
@@ -223,8 +223,9 @@ rules are
 
  * If a rule begins with ``-``, then the rest of the rule is a pattern
    which removes matching environment variables. If the pattern starts
-   with ``/``, it is a regex(7), optionally ending with ``/``, otherwise
-   the pattern is considered a shell glob(7) expression.
+   with ``/``, it is a :linux:man7:`regex`, optionally ending with
+   ``/``, otherwise the pattern is considered a shell
+   :linux:man7:`glob` expression.
 
    Examples:
       ``-*`` or ``-/.*/`` filter all environment variables creating an

--- a/doc/man1/flux-mini.rst
+++ b/doc/man1/flux-mini.rst
@@ -573,4 +573,4 @@ overridden in some cases:
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org

--- a/doc/man1/flux-module.rst
+++ b/doc/man1/flux-module.rst
@@ -15,7 +15,7 @@ DESCRIPTION
 ===========
 
 flux-module(1) manages dynamically loadable Flux modules.
-It can load/remove/list modules for the flux-broker(1), and for other
+It can load/remove/list modules for the :man1:`flux-broker`, and for other
 Flux services that support dynamic module extensions.
 
 
@@ -46,7 +46,7 @@ COMMANDS
    not loaded during removal unless the ``-f, --force`` option is specified.
 
 **list** [*service*]
-   List modules loaded by *service*, or by flux-broker(1) if *service* is unspecified.
+   List modules loaded by *service*, or by :man1:`flux-broker` if *service* is unspecified.
 
 **stats** [*OPTIONS*] [*name*]
    Request statistics from module *name*. A JSON object containing a set of
@@ -74,7 +74,7 @@ STATS OPTIONS
 
 **-R, --rusage**
    Return a JSON object representing an *rusage* structure
-   returned by getrusage(2).
+   returned by :linux:man2:`getrusage`.
 
 **-c, --clear**
    Send a request message to clear statistics in the target module.
@@ -121,7 +121,7 @@ SHA1 hash) module loaded by a service.
    the module .so file.
 
 **Idle**
-   Idle times are defined for flux-broker(1) modules as the number of
+   Idle times are defined for :man1:`flux-broker` modules as the number of
    seconds since the module last sent a request or response message.
    The idle time may be defined differently for other services, or have no
    meaning.
@@ -136,7 +136,7 @@ All Flux modules define the following global symbols:
    A null-terminated string defining the module name.
    Module names are words delimited by periods, with the service that
    will load the module indicated by the words that prefix the final one.
-   If there is no prefix, the module is loaded by flux-broker(1).
+   If there is no prefix, the module is loaded by :man1:`flux-broker`.
 
 **int mod_main (void \*context, int argc, char \**argv);**
    An entry function.

--- a/doc/man1/flux-module.rst
+++ b/doc/man1/flux-module.rst
@@ -151,4 +151,4 @@ Flux: http://flux-framework.org
 SEE ALSO
 ========
 
-syslog(3)
+:linux:man3:`syslog`

--- a/doc/man1/flux-module.rst
+++ b/doc/man1/flux-module.rst
@@ -145,7 +145,7 @@ All Flux modules define the following global symbols:
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org
 
 
 SEE ALSO

--- a/doc/man1/flux-ping.rst
+++ b/doc/man1/flux-ping.rst
@@ -89,4 +89,4 @@ round-trip latency is a bit over half a millisecond. The route hops are:
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org

--- a/doc/man1/flux-proxy.rst
+++ b/doc/man1/flux-proxy.rst
@@ -85,4 +85,4 @@ Connect to a Flux instance started in Slurm job 1234
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org

--- a/doc/man1/flux-shell.rst
+++ b/doc/man1/flux-shell.rst
@@ -465,4 +465,5 @@ Github: http://github.com/flux-framework
 
 SEE ALSO
 ========
-flux-mini(1)
+
+:man1:`flux-mini`

--- a/doc/man1/flux-shell.rst
+++ b/doc/man1/flux-shell.rst
@@ -460,7 +460,7 @@ generated if they are accessed from any other context.
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org
 
 
 SEE ALSO

--- a/doc/man1/flux-shell.rst
+++ b/doc/man1/flux-shell.rst
@@ -91,7 +91,7 @@ execution of the job:
  * create all local tasks. For each task, the following procedure is used
 
    - call ``task.init`` plugin callback
-   - launch task, call ``task.exec`` plugin callback just before ``execve(2)``
+   - launch task, call ``task.exec`` plugin callback just before :linux:man2:`execve`
    - call ``task.fork`` plugin callback
 
  * once all tasks have started, call ``shell.start`` plugin callback
@@ -124,7 +124,7 @@ which calls to ``flux_plugin_add_handler(3)`` should be used to register
 functions which will be invoked at defined points during shell execution.
 These callbacks are defined by "topic strings" to which plugins can
 "subscribe" by calling ``flux_plugin_add_handler(3)`` and/or
-``flux_plugin_register(3)`` with topic ``glob(7)`` strings.
+``flux_plugin_register(3)`` with topic :linux:man7:`glob` strings.
 
 .. note::
    ``flux_plugin_init(3)`` is not called for builtin shell plugins. If
@@ -153,7 +153,7 @@ By default, flux-shell supports the following plugin callback topics:
 
 **task.exec**
   Called for each task after the task has been forked just before
-  ``execve(2)`` is called. This callback is made from within the
+  :linux:man2:`execve` is called. This callback is made from within the
   task process.
 
 **task.fork**
@@ -337,7 +337,7 @@ supported. Job shell specific functions and tables are described below:
   Return the job environment (not the job shell environment). This is
   the environment which will be inherited by the job tasks. If called
   with no arguments, then the entire environment is copied to a table
-  and returned. Otherwise, acts as ``flux_shell_getenv(3)`` and returns
+  and returned. Otherwise, acts as :man3:`flux_shell_getenv` and returns
   the value for the environment variable name, or ``nil`` if not set.
 
 **shell.setenv(var, val, [overwrite])**
@@ -364,7 +364,7 @@ supported. Job shell specific functions and tables are described below:
 
 **shell.info**
   Returns a Lua table of shell information obtained via
-  ``flux_shell_get_info(3)``. This table includes
+  :man3:`flux_shell_get_info`. This table includes
 
   **jobid**
     The current jobid.
@@ -392,7 +392,7 @@ supported. Job shell specific functions and tables are described below:
 
 **shell.get_rankinfo(shell_rank)**
   Query rank-specific shell info as in the function call
-  ``flux_shell_get_rank_info(3)``.  If ``shell_rank`` is not provided
+  :man3:`flux_shell_get_rank_info`.  If ``shell_rank`` is not provided
   then the current rank is used.  Returns a table of rank-specific
   information including:
 
@@ -418,7 +418,7 @@ generated if they are accessed from any other context.
 
 **task.info**
   Returns a Lua table of task specific information for the "current"
-  task (see ``flux_shell_task_get_info(3)``). Included members of
+  task (see :man3:`flux_shell_task_get_info`). Included members of
   the ``task.info`` table include:
 
   **localid**
@@ -430,8 +430,8 @@ generated if they are accessed from any other context.
   **pid**
     The process id of the current task (if task has been started)
   **wait_status**
-    (Only in ``task.exit``) The status returned by ``waitpid(2)`` for
-    this task.
+    (Only in ``task.exit``) The status returned by
+    :linux:man2:`waitpid` for this task.
   **exitcode**
     (Only in ``task.exit``) The exit code if ``WIFEXTED()`` is true.
   **signaled**

--- a/doc/man1/flux-start.rst
+++ b/doc/man1/flux-start.rst
@@ -14,7 +14,7 @@ DESCRIPTION
 ===========
 
 flux-start(1) launches a new Flux instance. By default, flux-start
-execs a single flux-broker(1) directly, which will attempt to use
+execs a single :man1:`flux-broker` directly, which will attempt to use
 PMI to fetch job information and bootstrap a flux instance.
 
 If a size is specified via *--test-size*, an instance of that size is to be

--- a/doc/man1/flux-start.rst
+++ b/doc/man1/flux-start.rst
@@ -126,7 +126,7 @@ shell as the initial program:
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org
 
 
 SEE ALSO

--- a/doc/man1/flux-start.rst
+++ b/doc/man1/flux-start.rst
@@ -132,4 +132,4 @@ Github: http://github.com/flux-framework
 SEE ALSO
 ========
 
-flux-broker(1)
+:man1:`flux-broker`

--- a/doc/man1/flux-uri.rst
+++ b/doc/man1/flux-uri.rst
@@ -145,4 +145,4 @@ Get the URI for a Flux instance running as a Slurm job:
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org

--- a/doc/man1/flux-version.rst
+++ b/doc/man1/flux-version.rst
@@ -25,4 +25,4 @@ of the currently linked libflux-security is included.
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org

--- a/doc/man1/flux.rst
+++ b/doc/man1/flux.rst
@@ -97,4 +97,4 @@ setenv PYTHONPATH
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org

--- a/doc/man1/flux.rst
+++ b/doc/man1/flux.rst
@@ -37,7 +37,7 @@ OPTIONS
    Display command environment, and the path search for *CMD*.
 
 **-V, --version**
-   Convenience option to run flux-version(1).
+   Convenience option to run :man1:`flux-version`.
 
 
 SUB-COMMAND ENVIRONMENT

--- a/doc/man1/flux.rst
+++ b/doc/man1/flux.rst
@@ -98,3 +98,4 @@ RESOURCES
 =========
 
 Flux: http://flux-framework.org
+

--- a/doc/man3/JSON_PACK.rst
+++ b/doc/man3/JSON_PACK.rst
@@ -77,4 +77,4 @@ Whitespace, **:** (colon) and **,** (comma) are ignored.
 
 These descriptions came from the Jansson 2.10 manual.
 
-See also: Jansson API: Building Values <http://jansson.readthedocs.io/en/2.10/apiref.html#building-values>`__
+See also: Jansson API: Building Values: http://jansson.readthedocs.io/en/2.10/apiref.html#building-values

--- a/doc/man3/JSON_UNPACK.rst
+++ b/doc/man3/JSON_UNPACK.rst
@@ -71,4 +71,4 @@ Whitespace, **:** (colon) and **,** (comma) are ignored.
 
 These descriptions came from the Jansson 2.10 manual.
 
-See also: `Jansson API: Parsing and Validating Values <http://jansson.readthedocs.io/en/2.10/apiref.html#parsing-and-validating-values>`__
+See also: Jansson API: Parsing and Validating Values: http://jansson.readthedocs.io/en/2.10/apiref.html#parsing-and-validating-values

--- a/doc/man3/flux_attr_get.rst
+++ b/doc/man3/flux_attr_get.rst
@@ -71,5 +71,5 @@ Github: http://github.com/flux-framework
 SEE ALSO
 ========
 
-flux-getattr(1), flux-broker-attributes(7),
+:man1:`flux-getattr`, :man7:`flux-broker-attributes`,
 `RFC 3: Flux Message Protocol <https://github.com/flux-framework/rfc/blob/master/spec_3.rst>`__

--- a/doc/man3/flux_attr_get.rst
+++ b/doc/man3/flux_attr_get.rst
@@ -65,7 +65,7 @@ EPERM
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org
 
 `RFC 3: Flux Message Protocol <https://github.com/flux-framework/rfc/blob/master/spec_3.rst>`__
 

--- a/doc/man3/flux_attr_get.rst
+++ b/doc/man3/flux_attr_get.rst
@@ -71,5 +71,5 @@ Github: http://github.com/flux-framework
 SEE ALSO
 ========
 
-flux-lsattr(1), flux-getattr(1), flux-setattr(1), flux-broker-attributes(7),
+flux-getattr(1), flux-broker-attributes(7),
 `RFC 3: CMB1 - Flux Comms Message Broker Protocol <https://github.com/flux-framework/rfc/blob/master/spec_3.rst>`__

--- a/doc/man3/flux_attr_get.rst
+++ b/doc/man3/flux_attr_get.rst
@@ -72,4 +72,4 @@ SEE ALSO
 ========
 
 flux-getattr(1), flux-broker-attributes(7),
-`RFC 3: CMB1 - Flux Comms Message Broker Protocol <https://github.com/flux-framework/rfc/blob/master/spec_3.rst>`__
+`RFC 3: Flux Message Protocol <https://github.com/flux-framework/rfc/blob/master/spec_3.rst>`__

--- a/doc/man3/flux_attr_get.rst
+++ b/doc/man3/flux_attr_get.rst
@@ -67,9 +67,10 @@ RESOURCES
 
 Github: http://github.com/flux-framework
 
+`RFC 3: Flux Message Protocol <https://github.com/flux-framework/rfc/blob/master/spec_3.rst>`__
+
 
 SEE ALSO
 ========
 
 :man1:`flux-getattr`, :man7:`flux-broker-attributes`,
-`RFC 3: Flux Message Protocol <https://github.com/flux-framework/rfc/blob/master/spec_3.rst>`__

--- a/doc/man3/flux_attr_get.rst
+++ b/doc/man3/flux_attr_get.rst
@@ -67,7 +67,7 @@ RESOURCES
 
 Flux: http://flux-framework.org
 
-`RFC 3: Flux Message Protocol <https://github.com/flux-framework/rfc/blob/master/spec_3.rst>`__
+RFC 3: Flux Message Protocol: https://github.com/flux-framework/rfc/blob/master/spec_3.rst
 
 
 SEE ALSO

--- a/doc/man3/flux_aux_set.rst
+++ b/doc/man3/flux_aux_set.rst
@@ -69,7 +69,7 @@ ENOENT
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org
 
 
 SEE ALSO

--- a/doc/man3/flux_aux_set.rst
+++ b/doc/man3/flux_aux_set.rst
@@ -75,4 +75,4 @@ Github: http://github.com/flux-framework
 SEE ALSO
 ========
 
-flux_open(3)
+:man3:`flux_open`

--- a/doc/man3/flux_child_watcher_create.rst
+++ b/doc/man3/flux_child_watcher_create.rst
@@ -75,7 +75,7 @@ RESOURCES
 
 Flux: http://flux-framework.org
 
-`libev home page <http://software.schmorp.de/pkg/libev.html>`__
+libev: http://software.schmorp.de/pkg/libev.html
 
 
 SEE ALSO

--- a/doc/man3/flux_child_watcher_create.rst
+++ b/doc/man3/flux_child_watcher_create.rst
@@ -44,7 +44,7 @@ The callback *revents* argument should be ignored.
 The process id that had a transition may be obtained by calling
 ``flux_child_watcher_get_rpid()``.
 
-The status value returned by waitpid(2) may be obtained by calling
+The status value returned by :linux:man2:`waitpid` may be obtained by calling
 ``flux_child_watcher_get_rstatus()``.
 
 Only a Flux reactor created with the FLUX_REACTOR_SIGCHLD flag can

--- a/doc/man3/flux_child_watcher_create.rst
+++ b/doc/man3/flux_child_watcher_create.rst
@@ -75,10 +75,10 @@ RESOURCES
 
 Github: http://github.com/flux-framework
 
+`libev home page <http://software.schmorp.de/pkg/libev.html>`__
+
 
 SEE ALSO
 ========
 
 :man3:`flux_watcher_start`, :man3:`flux_reactor_run`
-
-`libev home page <http://software.schmorp.de/pkg/libev.html>`__

--- a/doc/man3/flux_child_watcher_create.rst
+++ b/doc/man3/flux_child_watcher_create.rst
@@ -73,7 +73,7 @@ EINVAL
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org
 
 `libev home page <http://software.schmorp.de/pkg/libev.html>`__
 

--- a/doc/man3/flux_child_watcher_create.rst
+++ b/doc/man3/flux_child_watcher_create.rst
@@ -79,6 +79,6 @@ Github: http://github.com/flux-framework
 SEE ALSO
 ========
 
-flux_watcher_start(3), flux_reactor_run(3)
+:man3:`flux_watcher_start`, :man3:`flux_reactor_run`
 
 `libev home page <http://software.schmorp.de/pkg/libev.html>`__

--- a/doc/man3/flux_content_load.rst
+++ b/doc/man3/flux_content_load.rst
@@ -123,7 +123,7 @@ EHOSTUNREACH
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org
 
 `RFC 10: Content Storage Service <https://github.com/flux-framework/rfc/blob/master/spec_10.rst>`__
 

--- a/doc/man3/flux_content_load.rst
+++ b/doc/man3/flux_content_load.rst
@@ -129,6 +129,6 @@ Github: http://github.com/flux-framework
 SEE ALSO
 ========
 
-flux_rpc(3), flux_future_get(3)
+:man3:`flux_rpc`, :man3:`flux_future_get`
 
 `RFC 10: Content Storage Service <https://github.com/flux-framework/rfc/blob/master/spec_10.rst>`__

--- a/doc/man3/flux_content_load.rst
+++ b/doc/man3/flux_content_load.rst
@@ -64,7 +64,7 @@ retrieve the stored blob. The blobref string is valid until
 ``flux_future_destroy()`` is called.
 
 These functions may be used asynchronously.
-See ``flux_future_then(3)`` for details.
+See :man3:`flux_future_then` for details.
 
 
 FLAGS
@@ -109,7 +109,7 @@ EPROTO
 
 EFBIG
    A blob larger than the configured maximum blob size
-   could not be stored. See flux-broker-attributes(7).
+   could not be stored. See :man7:`flux-broker-attributes`.
 
 ENOSYS
    The CONTENT_FLAG_CACHE_BYPASS flag was set in a request, but no

--- a/doc/man3/flux_content_load.rst
+++ b/doc/man3/flux_content_load.rst
@@ -125,7 +125,7 @@ RESOURCES
 
 Flux: http://flux-framework.org
 
-`RFC 10: Content Storage Service <https://github.com/flux-framework/rfc/blob/master/spec_10.rst>`__
+RFC 10: Content Storage Service: https://github.com/flux-framework/rfc/blob/master/spec_10.rst
 
 
 SEE ALSO

--- a/doc/man3/flux_content_load.rst
+++ b/doc/man3/flux_content_load.rst
@@ -125,10 +125,10 @@ RESOURCES
 
 Github: http://github.com/flux-framework
 
+`RFC 10: Content Storage Service <https://github.com/flux-framework/rfc/blob/master/spec_10.rst>`__
+
 
 SEE ALSO
 ========
 
 :man3:`flux_rpc`, :man3:`flux_future_get`
-
-`RFC 10: Content Storage Service <https://github.com/flux-framework/rfc/blob/master/spec_10.rst>`__

--- a/doc/man3/flux_core_version.rst
+++ b/doc/man3/flux_core_version.rst
@@ -80,4 +80,4 @@ RESOURCES
 
 Flux: http://flux-framework.org
 
-semver.org[Semantic Versioning 2.0.0]
+Semantic Versioning 2.0.0: http://semver.org

--- a/doc/man3/flux_core_version.rst
+++ b/doc/man3/flux_core_version.rst
@@ -45,7 +45,7 @@ FLUX_CORE_VERSION_HEX
 
 FLUX_CORE_VERSION_STRING
    (string) the three versions above separated by periods, with optional
-   ``git-describe(1)`` suffix preceded by a hyphen, if the version is a
+   :linux:man1:`git-describe` suffix preceded by a hyphen, if the version is a
    development snapshot.
 
 Note that major version zero (0.y.z) is for initial development.

--- a/doc/man3/flux_core_version.rst
+++ b/doc/man3/flux_core_version.rst
@@ -80,8 +80,4 @@ RESOURCES
 
 Github: http://github.com/flux-framework
 
-
-SEE ALSO
-========
-
 semver.org[Semantic Versioning 2.0.0]

--- a/doc/man3/flux_core_version.rst
+++ b/doc/man3/flux_core_version.rst
@@ -78,6 +78,6 @@ These functions cannot fail.
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org
 
 semver.org[Semantic Versioning 2.0.0]

--- a/doc/man3/flux_event_decode.rst
+++ b/doc/man3/flux_event_decode.rst
@@ -119,4 +119,4 @@ Github: http://github.com/flux-framework
 SEE ALSO
 ========
 
-flux_event_subscribe(3)
+:man3:`flux_event_subscribe`

--- a/doc/man3/flux_event_decode.rst
+++ b/doc/man3/flux_event_decode.rst
@@ -113,7 +113,7 @@ EPROTO
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org
 
 
 SEE ALSO

--- a/doc/man3/flux_event_publish.rst
+++ b/doc/man3/flux_event_publish.rst
@@ -106,7 +106,7 @@ EPROTO
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org
 
 
 SEE ALSO

--- a/doc/man3/flux_event_publish.rst
+++ b/doc/man3/flux_event_publish.rst
@@ -66,8 +66,8 @@ the future will trigger recovery of lost events, so these confirmations
 do indicate that Flux's best effort at event propagation is under way.
 
 If this level of confirmation is not required, one may encode
-an event message directly using ``flux_event_encode(3)`` and related
-functions and send it directly with ``flux_send(3)``.
+an event message directly using :man3:`flux_event_encode` and related
+functions and send it directly with :man3:`flux_send`.
 
 
 FLAGS

--- a/doc/man3/flux_event_publish.rst
+++ b/doc/man3/flux_event_publish.rst
@@ -112,4 +112,4 @@ Github: http://github.com/flux-framework
 SEE ALSO
 ========
 
-flux_event_decode(3), flux_event_subscribe(3)
+:man3:`flux_event_decode`, :man3:`flux_event_subscribe`

--- a/doc/man3/flux_event_subscribe.rst
+++ b/doc/man3/flux_event_subscribe.rst
@@ -22,7 +22,7 @@ one or more words separated by periods, interpreted as a hierarchical
 name space.
 
 ``flux_event_subscribe()`` requests that event messages matching *topic*
-be delivered via ``flux_recv(3)``. A match consists of a string comparison
+be delivered via :man3:`flux_recv`. A match consists of a string comparison
 of the event topic and the subscription topic, up to the length of the
 subscription topic. Thus "foo." matches events with topics "foo.bar"
 and "foo.baz", and "" matches all events. This matching algorithm
@@ -37,7 +37,7 @@ will not result in multiple deliveries of a given message. Each
 duplicate subscription requires a separate unsubscribe.
 
 It is not necessary to remove subscriptions with ``flux_event_unsubscribe()``
-prior to calling ``flux_close(3)``.
+prior to calling :man3:`flux_close`.
 
 
 RETURN VALUE

--- a/doc/man3/flux_event_subscribe.rst
+++ b/doc/man3/flux_event_subscribe.rst
@@ -69,4 +69,4 @@ displays one, then quits.
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org

--- a/doc/man3/flux_fatal_set.rst
+++ b/doc/man3/flux_fatal_set.rst
@@ -46,7 +46,7 @@ which translates to a fatal error function called with *msg* set to
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org
 
 
 SEE ALSO

--- a/doc/man3/flux_fatal_set.rst
+++ b/doc/man3/flux_fatal_set.rst
@@ -52,4 +52,4 @@ Github: http://github.com/flux-framework
 SEE ALSO
 ========
 
-flux_open(3)
+:man3:`flux_open`

--- a/doc/man3/flux_fd_watcher_create.rst
+++ b/doc/man3/flux_fd_watcher_create.rst
@@ -84,4 +84,4 @@ Github: http://github.com/flux-framework
 SEE ALSO
 ========
 
-flux_watcher_start(3), flux_reactor_run(3).
+:man3:`flux_watcher_start`, :man3:`flux_reactor_run`

--- a/doc/man3/flux_fd_watcher_create.rst
+++ b/doc/man3/flux_fd_watcher_create.rst
@@ -78,7 +78,7 @@ ENOMEM
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org
 
 
 SEE ALSO

--- a/doc/man3/flux_flags_set.rst
+++ b/doc/man3/flux_flags_set.rst
@@ -45,7 +45,7 @@ These functions never fail.
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org
 
 
 SEE ALSO

--- a/doc/man3/flux_flags_set.rst
+++ b/doc/man3/flux_flags_set.rst
@@ -27,7 +27,7 @@ handle flags will be a logical and of the old flags and the inverse of the new.
 ``flux_flags_get()`` can be used to retrieve the current open flags from
 handle *h*.
 
-The valid flags are described in ``flux_open(3)``.
+The valid flags are described in :man3:`flux_open`.
 
 
 RETURN VALUE

--- a/doc/man3/flux_flags_set.rst
+++ b/doc/man3/flux_flags_set.rst
@@ -51,4 +51,4 @@ Github: http://github.com/flux-framework
 SEE ALSO
 ========
 
-flux_open(3)
+:man3:`flux_open`

--- a/doc/man3/flux_future_and_then.rst
+++ b/doc/man3/flux_future_and_then.rst
@@ -129,7 +129,7 @@ ENOENT
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org
 
 
 SEE ALSO

--- a/doc/man3/flux_future_and_then.rst
+++ b/doc/man3/flux_future_and_then.rst
@@ -33,12 +33,12 @@ SYNOPSIS
 DESCRIPTION
 ===========
 
-See ``flux_future_get(3)`` for general functions that operate on futures,
-and ``flux_future_create(3)`` for a description of the ``flux_future_t``
+See :man3:`flux_future_get` for general functions that operate on futures,
+and :man3:`flux_future_create` for a description of the ``flux_future_t``
 base type. This page covers functions for the sequential composition of
 futures, i.e. chains of dependent futures.
 
-``flux_future_and_then(3)`` is similar to ``flux_future_then(3)``, but
+``flux_future_and_then(3)`` is similar to :man3:`flux_future_then`, but
 returns a future that may later be "continued" from the continuation
 callback ``cb``. The provided continuation callback ``cb`` is only
 executed when the future argument ``f`` is fulfilled successfully. On

--- a/doc/man3/flux_future_and_then.rst
+++ b/doc/man3/flux_future_and_then.rst
@@ -135,4 +135,4 @@ Github: http://github.com/flux-framework
 SEE ALSO
 ========
 
-flux_future_get(3), flux_future_create(3)
+:man3:`flux_future_get`, :man3:`flux_future_create`

--- a/doc/man3/flux_future_create.rst
+++ b/doc/man3/flux_future_create.rst
@@ -246,7 +246,7 @@ EEXIST
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org
 
 
 SEE ALSO

--- a/doc/man3/flux_future_create.rst
+++ b/doc/man3/flux_future_create.rst
@@ -252,4 +252,4 @@ Github: http://github.com/flux-framework
 SEE ALSO
 ========
 
-flux_future_get(3), flux_clone(3)
+:man3:`flux_future_get`, :man3:`flux_clone`

--- a/doc/man3/flux_future_create.rst
+++ b/doc/man3/flux_future_create.rst
@@ -67,7 +67,7 @@ SYNOPSIS
 DESCRIPTION
 ===========
 
-See ``flux_future_get(3)`` for general functions that operate on futures.
+See :man3:`flux_future_get` for general functions that operate on futures.
 This page covers functions primarily used when building classes that
 return futures.
 

--- a/doc/man3/flux_future_get.rst
+++ b/doc/man3/flux_future_get.rst
@@ -145,4 +145,4 @@ Python3 concurrent.futures: https://docs.python.org/3/library/concurrent.futures
 SEE ALSO
 ========
 
-flux_future_create (3)
+:man3:`flux_future_create`

--- a/doc/man3/flux_future_get.rst
+++ b/doc/man3/flux_future_get.rst
@@ -133,7 +133,7 @@ ETIMEDOUT
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org
 
 C++ std::future: `<http://en.cppreference.com/w/cpp/thread/future>`_
 

--- a/doc/man3/flux_future_get.rst
+++ b/doc/man3/flux_future_get.rst
@@ -135,7 +135,7 @@ RESOURCES
 
 Flux: http://flux-framework.org
 
-C++ std::future: `<http://en.cppreference.com/w/cpp/thread/future>`_
+C++ std::future: http://en.cppreference.com/w/cpp/thread/future
 
 Java ``util.concurrent.Future``: https://docs.oracle.com/javase/7/docs/api/java/util/concurrent/Future.html
 

--- a/doc/man3/flux_future_get.rst
+++ b/doc/man3/flux_future_get.rst
@@ -58,7 +58,7 @@ implementation of any particular one.
 Generally other Flux classes return futures, and may provide class-specific
 access function for results. The functions described in this page can be
 used to access, synchronize, and destroy futures returned from any such class.
-Authors of classes that return futures are referred to ``flux_future_create(3)``.
+Authors of classes that return futures are referred to :man3:`flux_future_create`.
 
 
 DESCRIPTION

--- a/doc/man3/flux_future_wait_all_create.rst
+++ b/doc/man3/flux_future_wait_all_create.rst
@@ -119,4 +119,4 @@ Github: http://github.com/flux-framework
 SEE ALSO
 ========
 
-flux_future_get(3), flux_future_create(3)
+:man3:`flux_future_get`, :man3:`flux_future_create`

--- a/doc/man3/flux_future_wait_all_create.rst
+++ b/doc/man3/flux_future_wait_all_create.rst
@@ -113,7 +113,7 @@ ENOENT
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org
 
 
 SEE ALSO

--- a/doc/man3/flux_future_wait_all_create.rst
+++ b/doc/man3/flux_future_wait_all_create.rst
@@ -29,8 +29,8 @@ SYNOPSIS
 DESCRIPTION
 ===========
 
-See ``flux_future_get(3)`` for general functions that operate on futures,
-and ``flux_future_create(3)`` for a description of the ``flux_future_t``
+See :man3:`flux_future_get` for general functions that operate on futures,
+and :man3:`flux_future_create` for a description of the ``flux_future_t``
 base type. This page covers functions used for composing futures into
 composite types using containers that allow waiting on all or any of a
 set of child futures.

--- a/doc/man3/flux_get_rank.rst
+++ b/doc/man3/flux_get_rank.rst
@@ -50,4 +50,4 @@ RESOURCES
 
 Flux: http://flux-framework.org
 
-`RFC 3: Flux Message Protocol <https://github.com/flux-framework/rfc/blob/master/spec_3.rst>`__
+RFC 3: Flux Message Protocol: https://github.com/flux-framework/rfc/blob/master/spec_3.rst

--- a/doc/man3/flux_get_rank.rst
+++ b/doc/man3/flux_get_rank.rst
@@ -48,6 +48,6 @@ Example:
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org
 
 `RFC 3: Flux Message Protocol <https://github.com/flux-framework/rfc/blob/master/spec_3.rst>`__

--- a/doc/man3/flux_get_rank.rst
+++ b/doc/man3/flux_get_rank.rst
@@ -50,8 +50,4 @@ RESOURCES
 
 Github: http://github.com/flux-framework
 
-
-SEE ALSO
-========
-
 `RFC 3: Flux Message Protocol <https://github.com/flux-framework/rfc/blob/master/spec_3.rst>`__

--- a/doc/man3/flux_get_rank.rst
+++ b/doc/man3/flux_get_rank.rst
@@ -54,4 +54,4 @@ Github: http://github.com/flux-framework
 SEE ALSO
 ========
 
-`RFC 3: CMB1 - Flux Comms Message Broker Protocol <https://github.com/flux-framework/rfc/blob/master/spec_3.rst>`__
+`RFC 3: Flux Message Protocol <https://github.com/flux-framework/rfc/blob/master/spec_3.rst>`__

--- a/doc/man3/flux_get_reactor.rst
+++ b/doc/man3/flux_get_reactor.rst
@@ -27,8 +27,8 @@ of the owner to destroy it after the handle is destroyed.
 handle *h*. A flux_reactor_t object may be obtained from another handle,
 for example when events from multiple handles are to be managed using
 a common flux_reactor_t, or one may be created directly with
-``flux_reactor_create(3)``. ``flux_set_reactor()`` should be called
-immediately after ``flux_open(3)`` to avoid conflict with other API calls
+:man3:`flux_reactor_create`. ``flux_set_reactor()`` should be called
+immediately after :man3:`flux_open` to avoid conflict with other API calls
 which may internally call ``flux_get_reactor()``.
 
 

--- a/doc/man3/flux_get_reactor.rst
+++ b/doc/man3/flux_get_reactor.rst
@@ -61,4 +61,4 @@ Github: http://github.com/flux-framework
 SEE ALSO
 ========
 
-flux_reactor_create(3), flux_reactor_destroy(3)
+:man3:`flux_future_create`, :man3:`flux_reactor_destroy`

--- a/doc/man3/flux_get_reactor.rst
+++ b/doc/man3/flux_get_reactor.rst
@@ -55,7 +55,7 @@ EEXIST
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org
 
 
 SEE ALSO

--- a/doc/man3/flux_handle_watcher_create.rst
+++ b/doc/man3/flux_handle_watcher_create.rst
@@ -84,4 +84,5 @@ Github: http://github.com/flux-framework
 SEE ALSO
 ========
 
-flux_watcher_start(3), flux_reactor_run(3), flux_recv(3), flux_send(3).
+:man3:`flux_watcher_start`, :man3:`flux_reactor_run`,
+:man3:`flux_recv`, :man3:`flux_send`

--- a/doc/man3/flux_handle_watcher_create.rst
+++ b/doc/man3/flux_handle_watcher_create.rst
@@ -78,7 +78,7 @@ ENOMEM
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org
 
 
 SEE ALSO

--- a/doc/man3/flux_idle_watcher_create.rst
+++ b/doc/man3/flux_idle_watcher_create.rst
@@ -77,10 +77,10 @@ RESOURCES
 
 Github: http://github.com/flux-framework
 
+`libev home page <http://software.schmorp.de/pkg/libev.html>`__
+
 
 SEE ALSO
 ========
 
 :man3:`flux_watcher_start`, :man3:`flux_reactor_run`
-
-`libev home page <http://software.schmorp.de/pkg/libev.html>`__

--- a/doc/man3/flux_idle_watcher_create.rst
+++ b/doc/man3/flux_idle_watcher_create.rst
@@ -75,7 +75,7 @@ ENOMEM
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org
 
 `libev home page <http://software.schmorp.de/pkg/libev.html>`__
 

--- a/doc/man3/flux_idle_watcher_create.rst
+++ b/doc/man3/flux_idle_watcher_create.rst
@@ -77,7 +77,7 @@ RESOURCES
 
 Flux: http://flux-framework.org
 
-`libev home page <http://software.schmorp.de/pkg/libev.html>`__
+libev: http://software.schmorp.de/pkg/libev.html
 
 
 SEE ALSO

--- a/doc/man3/flux_idle_watcher_create.rst
+++ b/doc/man3/flux_idle_watcher_create.rst
@@ -81,6 +81,6 @@ Github: http://github.com/flux-framework
 SEE ALSO
 ========
 
-flux_watcher_start(3), flux_reactor_run(3)
+:man3:`flux_watcher_start`, :man3:`flux_reactor_run`
 
 `libev home page <http://software.schmorp.de/pkg/libev.html>`__

--- a/doc/man3/flux_jobtap_get_flux.rst
+++ b/doc/man3/flux_jobtap_get_flux.rst
@@ -102,7 +102,7 @@ The remaining functions return 0 on success, -1 on failure.
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org
 
 
 SEE ALSO

--- a/doc/man3/flux_jobtap_get_flux.rst
+++ b/doc/man3/flux_jobtap_get_flux.rst
@@ -108,4 +108,4 @@ Github: http://github.com/flux-framework
 SEE ALSO
 ========
 
-flux-jobtap-plugins(7)
+:man7:`flux-jobtap-plugins`

--- a/doc/man3/flux_kvs_commit.rst
+++ b/doc/man3/flux_kvs_commit.rst
@@ -135,4 +135,4 @@ Github: http://github.com/flux-framework
 SEE ALSO
 ========
 
-flux_future_get(3), flux_kvs_txn_create(3)
+:man3:`flux_future_get`, :man3:`flux_kvs_txn_create`

--- a/doc/man3/flux_kvs_commit.rst
+++ b/doc/man3/flux_kvs_commit.rst
@@ -42,8 +42,8 @@ DESCRIPTION
 
 ``flux_kvs_commit()`` sends a request via handle *h* to the KVS service
 to commit a transaction *txn*. *txn* is created with
-``flux_kvs_txn_create(3)`` and after commit completion, is destroyed
-with ``flux_kvs_txn_destroy()``. A ``flux_future_t`` object is returned,
+:man3:`flux_kvs_txn_create` and after commit completion, is destroyed
+with :man3:`flux_kvs_txn_destroy`. A ``flux_future_t`` object is returned,
 which acts as handle for synchronization and container for the
 response. The *txn* will operate in the namespace specified by *ns*.
 If *ns* is NULL, ``flux_kvs_commit()`` will operate on the default
@@ -58,12 +58,12 @@ service for the named operation, the transactions are combined and committed
 together as one transaction. *name* must be unique across the Flux session
 and should not be reused, even after the fence is complete.
 
-``flux_future_then(3)`` may be used to register a reactor callback
+:man3:`flux_future_then` may be used to register a reactor callback
 (continuation) to be called once the response to the commit/fence
-request has been received. ``flux_future_wait_for(3)`` may be used to
+request has been received. :man3:`flux_future_wait_for` may be used to
 block until the response has been received. Both accept an optional timeout.
 
-``flux_future_get()``, ``flux_kvs_commit_get_treeobj()``, or
+:man3:`flux_future_get`, ``flux_kvs_commit_get_treeobj()``, or
 ``flux_kvs_commit_get_sequence()`` can decode the response. A return of
 0 indicates success and the entire transaction was committed. A
 return of -1 indicates failure, none of the transaction was committed.

--- a/doc/man3/flux_kvs_commit.rst
+++ b/doc/man3/flux_kvs_commit.rst
@@ -129,7 +129,7 @@ EOVERFLOW
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org
 
 
 SEE ALSO

--- a/doc/man3/flux_kvs_copy.rst
+++ b/doc/man3/flux_kvs_copy.rst
@@ -32,7 +32,7 @@ DESCRIPTION
 to look up the directory entry of *srckey*. Upon receipt of the response,
 it then sends another request to commit a duplicate at *dstkey*.
 *commit_flags* are passed through to the commit operation.
-See the FLAGS section of flux_kvs_commit(3).
+See the FLAGS section of :man3:`flux_kvs_commit`.
 
 The net effect is that all content below *srckey* is copied to *dstkey*.
 Due to the hash tree organization of the KVS name space, only the
@@ -45,7 +45,7 @@ the commit within ``flux_kvs_copy()``, and to the commit which performs
 the unlink.
 
 ``flux_kvs_copy()`` and ``flux_kvs_move()`` are capable of working across
-namespaces. See ``flux_kvs_commit(3)`` for info on how to select a
+namespaces. See :man3:`flux_kvs_commit` for info on how to select a
 namespace other than the default.
 
 

--- a/doc/man3/flux_kvs_copy.rst
+++ b/doc/man3/flux_kvs_copy.rst
@@ -99,4 +99,4 @@ Github: http://github.com/flux-framework
 SEE ALSO
 ========
 
-flux_future_get(3), flux_kvs_commit(3)
+:man3:`flux_future_get`, :man3:`flux_kvs_commit`

--- a/doc/man3/flux_kvs_copy.rst
+++ b/doc/man3/flux_kvs_copy.rst
@@ -93,7 +93,7 @@ ENOTSUP
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org
 
 
 SEE ALSO

--- a/doc/man3/flux_kvs_getroot.rst
+++ b/doc/man3/flux_kvs_getroot.rst
@@ -48,10 +48,10 @@ for the response. *flags* is currently unused and should be set to 0.
 Upon future fulfillment, these functions can decode the result:
 
 ``flux_kvs_getroot_get_treeobj()`` obtains the root hash in the form
-of an RFC 11 *dirref* treeobj, suitable to be passed to ``flux_kvs_lookupat(3)``.
+of an RFC 11 *dirref* treeobj, suitable to be passed to :man3:`flux_kvs_lookupat`.
 
 ``flux_kvs_getroot_get_blobref()`` obtains the RFC 10 blobref, suitable to
-be passed to ``flux_content_load(3)``.
+be passed to :man3:`flux_content_load`.
 
 ``flux_kvs_getroot_get_sequence()`` retrieves the monotonic sequence number
 for the root.

--- a/doc/man3/flux_kvs_getroot.rst
+++ b/doc/man3/flux_kvs_getroot.rst
@@ -110,4 +110,4 @@ Github: http://github.com/flux-framework
 SEE ALSO
 ========
 
-flux_kvs_lookup (3), flux_future_get (3), flux_content_load (3).
+:man3:`flux_kvs_lookup`, :man3:`flux_future_get`, :man3:`flux_content_load`

--- a/doc/man3/flux_kvs_getroot.rst
+++ b/doc/man3/flux_kvs_getroot.rst
@@ -104,7 +104,7 @@ ENODATA
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org
 
 
 SEE ALSO

--- a/doc/man3/flux_kvs_lookup.rst
+++ b/doc/man3/flux_kvs_lookup.rst
@@ -243,6 +243,6 @@ Github: http://github.com/flux-framework
 SEE ALSO
 ========
 
-flux_rpc(3), flux_future_then(3)
+:man3:`flux_rpc`, :man3:`flux_future_then`
 
 `RFC 11: Key Value Store Tree Object Format v1 <https://github.com/flux-framework/rfc/blob/master/spec_11.rst>`__

--- a/doc/man3/flux_kvs_lookup.rst
+++ b/doc/man3/flux_kvs_lookup.rst
@@ -237,7 +237,7 @@ EPERM
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org
 
 `RFC 11: Key Value Store Tree Object Format v1 <https://github.com/flux-framework/rfc/blob/master/spec_11.rst>`__
 

--- a/doc/man3/flux_kvs_lookup.rst
+++ b/doc/man3/flux_kvs_lookup.rst
@@ -239,10 +239,10 @@ RESOURCES
 
 Github: http://github.com/flux-framework
 
+`RFC 11: Key Value Store Tree Object Format v1 <https://github.com/flux-framework/rfc/blob/master/spec_11.rst>`__
+
 
 SEE ALSO
 ========
 
 :man3:`flux_rpc`, :man3:`flux_future_then`
-
-`RFC 11: Key Value Store Tree Object Format v1 <https://github.com/flux-framework/rfc/blob/master/spec_11.rst>`__

--- a/doc/man3/flux_kvs_lookup.rst
+++ b/doc/man3/flux_kvs_lookup.rst
@@ -239,7 +239,7 @@ RESOURCES
 
 Flux: http://flux-framework.org
 
-`RFC 11: Key Value Store Tree Object Format v1 <https://github.com/flux-framework/rfc/blob/master/spec_11.rst>`__
+RFC 11: Key Value Store Tree Object Format v1: https://github.com/flux-framework/rfc/blob/master/spec_11.rst
 
 
 SEE ALSO

--- a/doc/man3/flux_kvs_lookup.rst
+++ b/doc/man3/flux_kvs_lookup.rst
@@ -116,7 +116,7 @@ lookup.
 requested with FLUX_KVS_WATCH or a waiting lookup response with
 FLUX_KVS_WAITCREATE. See FLAGS below for additional information.
 
-These functions may be used asynchronously. See ``flux_future_then(3)`` for
+These functions may be used asynchronously. See :man3:`flux_future_then` for
 details.
 
 

--- a/doc/man3/flux_kvs_namespace_create.rst
+++ b/doc/man3/flux_kvs_namespace_create.rst
@@ -87,7 +87,7 @@ ENOTSUP
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org
 
 
 SEE ALSO

--- a/doc/man3/flux_kvs_namespace_create.rst
+++ b/doc/man3/flux_kvs_namespace_create.rst
@@ -93,4 +93,4 @@ Github: http://github.com/flux-framework
 SEE ALSO
 ========
 
-flux_kvs_lookup(3), flux_kvs_commit(3)
+:man3:`flux_kvs_lookup`, :man3:`flux_kvs_commit`

--- a/doc/man3/flux_kvs_txn_create.rst
+++ b/doc/man3/flux_kvs_txn_create.rst
@@ -67,7 +67,7 @@ The Flux Key Value Store is a general purpose distributed storage
 service used by Flux services.
 
 ``flux_kvs_txn_create()`` creates a KVS transaction object that may be
-passed to ``flux_kvs_commit(3)`` or ``flux_kvs_fence(3)``. The transaction
+passed to :man3:`flux_kvs_commit` or :man3:`flux_kvs_fence`. The transaction
 consists of a list of operations that are applied to the KVS together,
 in order. The entire transaction either succeeds or fails. After commit
 or fence, the object must be destroyed with ``flux_kvs_txn_destroy()``.

--- a/doc/man3/flux_kvs_txn_create.rst
+++ b/doc/man3/flux_kvs_txn_create.rst
@@ -141,7 +141,7 @@ RESOURCES
 
 Flux: http://flux-framework.org
 
-`RFC 11: Key Value Store Tree Object Format v1 <https://github.com/flux-framework/rfc/blob/master/spec_11.rst>`__
+RFC 11: Key Value Store Tree Object Format v1: https://github.com/flux-framework/rfc/blob/master/spec_11.rst
 
 
 SEE ALSO

--- a/doc/man3/flux_kvs_txn_create.rst
+++ b/doc/man3/flux_kvs_txn_create.rst
@@ -139,7 +139,7 @@ ENOMEM
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org
 
 `RFC 11: Key Value Store Tree Object Format v1 <https://github.com/flux-framework/rfc/blob/master/spec_11.rst>`__
 

--- a/doc/man3/flux_kvs_txn_create.rst
+++ b/doc/man3/flux_kvs_txn_create.rst
@@ -145,6 +145,6 @@ Github: http://github.com/flux-framework
 SEE ALSO
 ========
 
-flux_kvs_commit(3)
+:man3:`flux_kvs_commit`
 
 `RFC 11: Key Value Store Tree Object Format v1 <https://github.com/flux-framework/rfc/blob/master/spec_11.rst>`__

--- a/doc/man3/flux_kvs_txn_create.rst
+++ b/doc/man3/flux_kvs_txn_create.rst
@@ -141,10 +141,10 @@ RESOURCES
 
 Github: http://github.com/flux-framework
 
+`RFC 11: Key Value Store Tree Object Format v1 <https://github.com/flux-framework/rfc/blob/master/spec_11.rst>`__
+
 
 SEE ALSO
 ========
 
 :man3:`flux_kvs_commit`
-
-`RFC 11: Key Value Store Tree Object Format v1 <https://github.com/flux-framework/rfc/blob/master/spec_11.rst>`__

--- a/doc/man3/flux_log.rst
+++ b/doc/man3/flux_log.rst
@@ -124,7 +124,7 @@ ENOMEM
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org
 
 `RFC 5424 The Syslog Protocol <https://tools.ietf.org/html/rfc5424>`__
 

--- a/doc/man3/flux_log.rst
+++ b/doc/man3/flux_log.rst
@@ -24,7 +24,7 @@ DESCRIPTION
 are sent to the Flux message broker on *h* for handling if it is
 specified. If *h* is NULL, the log message is output to stderr.
 
-The *level* parameter should be set to one of the syslog(3) severity
+The *level* parameter should be set to one of the :linux:man3:`syslog` severity
 levels, which are, in order of decreasing importance:
 
 *LOG_EMERG*
@@ -52,7 +52,7 @@ levels, which are, in order of decreasing importance:
    debug-level message
 
 When *h* is specified, log messages are are added to the broker's
-circular buffer which can be accessed with flux-dmesg(1). From there,
+circular buffer which can be accessed with :man1:`flux-dmesg`. From there,
 a message's disposition is up to the broker's log configuration.
 
 ``flux_log_set_procid()`` may be used to override the default procid,

--- a/doc/man3/flux_log.rst
+++ b/doc/man3/flux_log.rst
@@ -126,7 +126,7 @@ RESOURCES
 
 Flux: http://flux-framework.org
 
-`RFC 5424 The Syslog Protocol <https://tools.ietf.org/html/rfc5424>`__
+RFC 5424 The Syslog Protocol: https://tools.ietf.org/html/rfc5424
 
 
 SEE ALSO

--- a/doc/man3/flux_log.rst
+++ b/doc/man3/flux_log.rst
@@ -126,9 +126,10 @@ RESOURCES
 
 Github: http://github.com/flux-framework
 
+`RFC 5424 The Syslog Protocol <https://tools.ietf.org/html/rfc5424>`__
+
 
 SEE ALSO
 ========
 
 :man1:`flux-dmesg`, :man1:`flux-logger`,
-`RFC 5424 The Syslog Protocol <https://tools.ietf.org/html/rfc5424>`__

--- a/doc/man3/flux_log.rst
+++ b/doc/man3/flux_log.rst
@@ -130,5 +130,5 @@ Github: http://github.com/flux-framework
 SEE ALSO
 ========
 
-flux-dmesg(1), flux-logger(1),
+:man1:`flux-dmesg`, :man1:`flux-logger`,
 `RFC 5424 The Syslog Protocol <https://tools.ietf.org/html/rfc5424>`__

--- a/doc/man3/flux_msg_cmp.rst
+++ b/doc/man3/flux_msg_cmp.rst
@@ -47,7 +47,7 @@ RETURN VALUE
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org
 
 
 SEE ALSO

--- a/doc/man3/flux_msg_cmp.rst
+++ b/doc/man3/flux_msg_cmp.rst
@@ -53,4 +53,4 @@ Flux: http://flux-framework.org
 SEE ALSO
 ========
 
-fnmatch(3)
+:linux:man3:`fnmatch`

--- a/doc/man3/flux_msg_encode.rst
+++ b/doc/man3/flux_msg_encode.rst
@@ -18,7 +18,7 @@ DESCRIPTION
 
 ``flux_msg_encode()`` converts *msg* to a serialized representation,
 allocated internally and assigned to *buf*, number of bytes to *size*.
-The caller must release *buf* with free(3).
+The caller must release *buf* with :linux:man3:`free`.
 
 ``flux_msg_decode()`` performs the inverse, creating *msg* from *buf* and *size*.
 The caller must destroy *msg* with flux_msg_destroy().

--- a/doc/man3/flux_msg_encode.rst
+++ b/doc/man3/flux_msg_encode.rst
@@ -47,4 +47,4 @@ ENOMEM
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org

--- a/doc/man3/flux_msg_handler_addvec.rst
+++ b/doc/man3/flux_msg_handler_addvec.rst
@@ -69,7 +69,7 @@ ENOMEM
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org
 
 
 SEE ALSO

--- a/doc/man3/flux_msg_handler_addvec.rst
+++ b/doc/man3/flux_msg_handler_addvec.rst
@@ -43,8 +43,8 @@ The last entry in the array is set to NULL.
 returned from ``flux_msg_handler_addvec()``.
 
 These functions are convenience functions which call
-``flux_msg_handler_create(3)``, ``flux_msg_handler_start(3)``; and
-``flux_msg_handler_stop(3)``, ``flux_msg_handler_destroy(3)`` on each element
+:man3:`flux_msg_handler_create`, :man3:`flux_msg_handler_start`; and
+:man3:`flux_msg_handler_stop`, :man3:`flux_msg_handler_destroy` on each element
 of the array, respectively.
 
 If ``flux_msg_handler_addvec()`` encounters an error creating a message

--- a/doc/man3/flux_msg_handler_addvec.rst
+++ b/doc/man3/flux_msg_handler_addvec.rst
@@ -75,4 +75,4 @@ Github: http://github.com/flux-framework
 SEE ALSO
 ========
 
-flux_msg_handler_create(3)
+:man3:`flux_msg_handler_create`

--- a/doc/man3/flux_msg_handler_create.rst
+++ b/doc/man3/flux_msg_handler_create.rst
@@ -42,7 +42,7 @@ DESCRIPTION
 ===========
 
 ``flux_msg_handler_create()`` registers *callback* to be invoked when
-a message meeting *match* criteria, as described in ``flux_msg_cmp(3)``,
+a message meeting *match* criteria, as described in :man3:`flux_msg_cmp`,
 is received on Flux broker handle *h*.
 
 The message handler must be started with ``flux_msg_handler_start()`` in
@@ -51,7 +51,7 @@ the message handler to stop receiving messages. Starting and stopping
 are idempotent operations.
 
 The handle *h* is monitored for FLUX_POLLIN events on the flux_reactor_t
-associated with the handle as described in ``flux_set_reactor(3)``.
+associated with the handle as described in :man3:`flux_set_reactor`.
 This internal "handle watcher" is started when the first message handler
 is started, and stopped when the last message handler is stopped.
 
@@ -85,7 +85,7 @@ CAVEATS
 =======
 
 Although it is possible to register a message handler in a given `flux_t`
-handle for any topic string, ``flux-broker(1)`` does not automatically route
+handle for any topic string, :man1:`flux-broker` does not automatically route
 matching requests or events to the handle.
 
 Requests are only routed if the handle has registered a matching service
@@ -93,7 +93,7 @@ with ``flux_service_register(3)``, or for broker modules only, the service
 matches the module name.
 
 Events are only routed if the topic matches a subscription registered
-with ``flux_event_subscribe(3)``.
+with :man3:`flux_event_subscribe`.
 
 
 RETURN VALUE

--- a/doc/man3/flux_msg_handler_create.rst
+++ b/doc/man3/flux_msg_handler_create.rst
@@ -119,4 +119,4 @@ Github: http://github.com/flux-framework
 SEE ALSO
 ========
 
-flux_get_reactor(3), flux_reactor_run(3), flux_msg_cmp(3)
+:man3:`flux_get_reactor`, :man3:`flux_reactor_run`, :man3:`flux_msg_cmp`

--- a/doc/man3/flux_msg_handler_create.rst
+++ b/doc/man3/flux_msg_handler_create.rst
@@ -113,7 +113,7 @@ ENOMEM
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org
 
 
 SEE ALSO

--- a/doc/man3/flux_open.rst
+++ b/doc/man3/flux_open.rst
@@ -87,4 +87,4 @@ and path, requests the broker rank, and finally closes the broker handle.
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org

--- a/doc/man3/flux_periodic_watcher_create.rst
+++ b/doc/man3/flux_periodic_watcher_create.rst
@@ -81,10 +81,10 @@ RESOURCES
 
 Github: http://github.com/flux-framework
 
+`libev home page <http://software.schmorp.de/pkg/libev.html>`__
+
 
 SEE ALSO
 ========
 
 :man3:`flux_watcher_start`, :man3:`flux_reactor_run`, :man3:`flux_timer_watcher_create`
-
-`libev home page <http://software.schmorp.de/pkg/libev.html>`__

--- a/doc/man3/flux_periodic_watcher_create.rst
+++ b/doc/man3/flux_periodic_watcher_create.rst
@@ -81,7 +81,7 @@ RESOURCES
 
 Flux: http://flux-framework.org
 
-`libev home page <http://software.schmorp.de/pkg/libev.html>`__
+libev: http://software.schmorp.de/pkg/libev.html
 
 
 SEE ALSO

--- a/doc/man3/flux_periodic_watcher_create.rst
+++ b/doc/man3/flux_periodic_watcher_create.rst
@@ -85,6 +85,6 @@ Github: http://github.com/flux-framework
 SEE ALSO
 ========
 
-flux_watcher_start(3), flux_reactor_run(3), flux_timer_watcher_create(3)
+:man3:`flux_watcher_start`, :man3:`flux_reactor_run`, :man3:`flux_timer_watcher_create`
 
 `libev home page <http://software.schmorp.de/pkg/libev.html>`__

--- a/doc/man3/flux_periodic_watcher_create.rst
+++ b/doc/man3/flux_periodic_watcher_create.rst
@@ -79,7 +79,7 @@ ENOMEM
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org
 
 `libev home page <http://software.schmorp.de/pkg/libev.html>`__
 

--- a/doc/man3/flux_pollevents.rst
+++ b/doc/man3/flux_pollevents.rst
@@ -187,8 +187,9 @@ RESOURCES
 
 Flux: http://flux-framework.org
 
-http://pod.tst.eu/http://cvs.schmorp.de/libev/ev.pod
+libev API: http://pod.tst.eu/http://cvs.schmorp.de/libev/ev.pod
 
-http://api.zeromq.org/4-0:zmq-getsockopt
+zmq_getsockopt(3): http://api.zeromq.org/4-0:zmq-getsockopt
 
+Embedding ZeroMQ in the libev event looop:
 http://funcptr.net/2013/04/20/embedding-zeromq-in-the-libev-event-loop

--- a/doc/man3/flux_pollevents.rst
+++ b/doc/man3/flux_pollevents.rst
@@ -64,12 +64,13 @@ to integrate flux handles into the Flux reactor, which is based on libev.
 Refer to the libev documentation for background on how libev works.
 
 There are a total of four different types of libev watcher in the
-composite watcher. libev "prepare" and "check" callbacks are executed just
-before and just after libev blocks internally in the poll(2) system call.
-Here they are used to test ``flux_pollevents()``, make user callbacks,
-and enable/disable no-op "io" and "idle" watchers. The io watcher
-watches for EV_READ on ``flux_pollfd()`` file descriptor. The idle watcher,
-if enabled, is always ready and thus causes the event loop to spin.
+composite watcher. libev "prepare" and "check" callbacks are executed
+just before and just after libev blocks internally in the
+:linux:man2:`poll` system call.  Here they are used to test
+``flux_pollevents()``, make user callbacks, and enable/disable no-op
+"io" and "idle" watchers. The io watcher watches for EV_READ on
+``flux_pollfd()`` file descriptor. The idle watcher, if enabled, is
+always ready and thus causes the event loop to spin.
 
 When ``flux_pollevents()`` has poll flags asserted, the idle watcher is enabled.
 When ``flux_pollevents()`` has no poll flags asserted, the idle watcher is

--- a/doc/man3/flux_pollevents.rst
+++ b/doc/man3/flux_pollevents.rst
@@ -187,10 +187,6 @@ RESOURCES
 
 Github: http://github.com/flux-framework
 
-
-SEE ALSO
-========
-
 http://pod.tst.eu/http://cvs.schmorp.de/libev/ev.pod
 
 http://api.zeromq.org/4-0:zmq-getsockopt

--- a/doc/man3/flux_pollevents.rst
+++ b/doc/man3/flux_pollevents.rst
@@ -185,7 +185,7 @@ handle events pending.
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org
 
 http://pod.tst.eu/http://cvs.schmorp.de/libev/ev.pod
 

--- a/doc/man3/flux_reactor_create.rst
+++ b/doc/man3/flux_reactor_create.rst
@@ -34,15 +34,15 @@ There is currently only one possible flag for reactor creation:
 
 FLUX_REACTOR_SIGCHLD
    The reactor will internally register a SIGCHLD handler and be capable
-   of handling flux child watchers (see flux_child_watcher_create(3)).
+   of handling flux child watchers (see :man3:`flux_child_watcher_create`).
 
 For each event source and type that is to be monitored, a flux_watcher_t
 object is created using a type-specific create function, and started
-with flux_watcher_start(3).
+with :man3:`flux_watcher_start`.
 
 For each event source and type that is to be monitored, a flux_watcher_t
 object is created and associated with a specific reactor using a type-specific
-create function, and started with flux_watcher_start(3). To receive events,
+create function, and started with :man3:`flux_watcher_start`. To receive events,
 control must be transferred to the reactor event loop by calling
 ``flux_reactor_run()``.
 
@@ -71,7 +71,7 @@ is met:
 If ``flux_reactor_stop_error()`` is called, this will cause
 ``flux_reactor_run()`` to return -1 indicating that an error has occurred.
 The caller should ensure that a valid error code has been assigned to
-errno(3) before calling this function.
+:linux:man3:`errno` before calling this function.
 
 ``flux_reactor_destroy()`` releases an internal reference taken at
 ``flux_reactor_create()`` time. Freeing of the underlying resources will

--- a/doc/man3/flux_reactor_create.rst
+++ b/doc/man3/flux_reactor_create.rst
@@ -111,7 +111,7 @@ RESOURCES
 
 Flux: http://flux-framework.org
 
-`libev home page <http://software.schmorp.de/pkg/libev.html>`__
+libev: http://software.schmorp.de/pkg/libev.html
 
 
 SEE ALSO

--- a/doc/man3/flux_reactor_create.rst
+++ b/doc/man3/flux_reactor_create.rst
@@ -115,7 +115,7 @@ Github: http://github.com/flux-framework
 SEE ALSO
 ========
 
-flux_fd_watcher_create(3), flux_handle_watcher_create(3),
-flux_timer_watcher_create(3), flux_watcher_start(3)
+:man3:`flux_fd_watcher_create`, :man3:`flux_handle_watcher_create`,
+:man3:`flux_timer_watcher_create`, :man3:`flux_watcher_start`
 
 `libev home page <http://software.schmorp.de/pkg/libev.html>`__

--- a/doc/man3/flux_reactor_create.rst
+++ b/doc/man3/flux_reactor_create.rst
@@ -111,11 +111,11 @@ RESOURCES
 
 Github: http://github.com/flux-framework
 
+`libev home page <http://software.schmorp.de/pkg/libev.html>`__
+
 
 SEE ALSO
 ========
 
 :man3:`flux_fd_watcher_create`, :man3:`flux_handle_watcher_create`,
 :man3:`flux_timer_watcher_create`, :man3:`flux_watcher_start`
-
-`libev home page <http://software.schmorp.de/pkg/libev.html>`__

--- a/doc/man3/flux_reactor_create.rst
+++ b/doc/man3/flux_reactor_create.rst
@@ -109,7 +109,7 @@ ENOMEM
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org
 
 `libev home page <http://software.schmorp.de/pkg/libev.html>`__
 

--- a/doc/man3/flux_reactor_now.rst
+++ b/doc/man3/flux_reactor_now.rst
@@ -41,10 +41,10 @@ RESOURCES
 
 Github: http://github.com/flux-framework
 
+`libev home page <http://software.schmorp.de/pkg/libev.html>`__
+
 
 SEE ALSO
 ========
 
 :man3:`flux_reactor_create`
-
-`libev home page <http://software.schmorp.de/pkg/libev.html>`__

--- a/doc/man3/flux_reactor_now.rst
+++ b/doc/man3/flux_reactor_now.rst
@@ -45,6 +45,6 @@ Github: http://github.com/flux-framework
 SEE ALSO
 ========
 
-flux_reactor_create (3)
+:man3:`flux_reactor_create`
 
 `libev home page <http://software.schmorp.de/pkg/libev.html>`__

--- a/doc/man3/flux_reactor_now.rst
+++ b/doc/man3/flux_reactor_now.rst
@@ -39,7 +39,7 @@ on the behavior of reactor time, refer to the libev documentation on
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org
 
 `libev home page <http://software.schmorp.de/pkg/libev.html>`__
 

--- a/doc/man3/flux_reactor_now.rst
+++ b/doc/man3/flux_reactor_now.rst
@@ -41,7 +41,7 @@ RESOURCES
 
 Flux: http://flux-framework.org
 
-`libev home page <http://software.schmorp.de/pkg/libev.html>`__
+libev: http://software.schmorp.de/pkg/libev.html
 
 
 SEE ALSO

--- a/doc/man3/flux_recv.rst
+++ b/doc/man3/flux_recv.rst
@@ -92,4 +92,4 @@ Github: http://github.com/flux-framework
 SEE ALSO
 ========
 
-flux_open(3), flux_send(3), flux_requeue(3), flux_msg_cmp(3)
+:man3:`flux_open`, :man3:`flux_send`, :man3:`flux_requeue`, :man3:`flux_msg_cmp`

--- a/doc/man3/flux_recv.rst
+++ b/doc/man3/flux_recv.rst
@@ -37,7 +37,7 @@ FLUX_MATCH_ANY
 FLUX_MATCH_EVENT
    Match any event message.
 
-For additional details on how to use *match*, see flux_msg_cmp(3).
+For additional details on how to use *match*, see :man3:`flux_msg_cmp`.
 
 *flags* is the logical "or" of zero or more of the following flags:
 

--- a/doc/man3/flux_recv.rst
+++ b/doc/man3/flux_recv.rst
@@ -86,7 +86,7 @@ as they arrive.
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org
 
 
 SEE ALSO

--- a/doc/man3/flux_request_decode.rst
+++ b/doc/man3/flux_request_decode.rst
@@ -80,4 +80,4 @@ Github: http://github.com/flux-framework
 SEE ALSO
 ========
 
-flux_respond(3), flux_rpc(3)
+:man3:`flux_respond`, :man3:`flux_rpc`

--- a/doc/man3/flux_request_decode.rst
+++ b/doc/man3/flux_request_decode.rst
@@ -74,7 +74,7 @@ EPROTO
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org
 
 
 SEE ALSO

--- a/doc/man3/flux_request_encode.rst
+++ b/doc/man3/flux_request_encode.rst
@@ -59,4 +59,4 @@ Github: http://github.com/flux-framework
 SEE ALSO
 ========
 
-flux_response_decode(3), flux_rpc(3)
+:man3:`flux_response_decode`, :man3:`flux_rpc`

--- a/doc/man3/flux_request_encode.rst
+++ b/doc/man3/flux_request_encode.rst
@@ -53,7 +53,7 @@ ENOMEM
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org
 
 
 SEE ALSO

--- a/doc/man3/flux_requeue.rst
+++ b/doc/man3/flux_requeue.rst
@@ -52,4 +52,4 @@ Github: http://github.com/flux-framework
 SEE ALSO
 ========
 
-flux_open(3), flux_recv(3), flux_send(3)
+:man3:`flux_open`, :man3:`flux_recv`, :man3:`flux_send`

--- a/doc/man3/flux_requeue.rst
+++ b/doc/man3/flux_requeue.rst
@@ -46,7 +46,7 @@ ENOMEM
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org
 
 
 SEE ALSO

--- a/doc/man3/flux_respond.rst
+++ b/doc/man3/flux_respond.rst
@@ -98,9 +98,9 @@ RESOURCES
 
 Flux: http://flux-framework.org
 
-`RFC 6: Flux Remote Procedure Call Protocol <https://github.com/flux-framework/rfc/blob/master/spec_6.rst>`__
+RFC 6: Flux Remote Procedure Call Protocol: https://github.com/flux-framework/rfc/blob/master/spec_6.rst
 
-`RFC 3: Flux Message Protocol <https://github.com/flux-framework/rfc/blob/master/spec_3.rst>`__
+RFC 3: Flux Message Protocol: https://github.com/flux-framework/rfc/blob/master/spec_3.rst
 
 
 SEE ALSO

--- a/doc/man3/flux_respond.rst
+++ b/doc/man3/flux_respond.rst
@@ -96,7 +96,7 @@ EPROTO
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org
 
 `RFC 6: Flux Remote Procedure Call Protocol <https://github.com/flux-framework/rfc/blob/master/spec_6.rst>`__
 

--- a/doc/man3/flux_respond.rst
+++ b/doc/man3/flux_respond.rst
@@ -98,13 +98,12 @@ RESOURCES
 
 Github: http://github.com/flux-framework
 
+`RFC 6: Flux Remote Procedure Call Protocol <https://github.com/flux-framework/rfc/blob/master/spec_6.rst>`__
+
+`RFC 3: Flux Message Protocol <https://github.com/flux-framework/rfc/blob/master/spec_3.rst>`__
+
 
 SEE ALSO
 ========
 
 :man3:`flux_rpc`, :man3:`flux_rpc_raw`
-
-`RFC 6: Flux
-Remote Procedure Call Protocol <https://github.com/flux-framework/rfc/blob/master/spec_6.rst>`__
-
-`RFC 3: Flux Message Protocol <https://github.com/flux-framework/rfc/blob/master/spec_3.rst>`__

--- a/doc/man3/flux_respond.rst
+++ b/doc/man3/flux_respond.rst
@@ -102,7 +102,7 @@ Github: http://github.com/flux-framework
 SEE ALSO
 ========
 
-flux_rpc(3), flux_rpc_raw(3)
+:man3:`flux_rpc`, :man3:`flux_rpc_raw`
 
 `RFC 6: Flux
 Remote Procedure Call Protocol <https://github.com/flux-framework/rfc/blob/master/spec_6.rst>`__

--- a/doc/man3/flux_respond.rst
+++ b/doc/man3/flux_respond.rst
@@ -107,4 +107,4 @@ flux_rpc(3), flux_rpc_raw(3)
 `RFC 6: Flux
 Remote Procedure Call Protocol <https://github.com/flux-framework/rfc/blob/master/spec_6.rst>`__
 
-`RFC 3: CMB1 - Flux Comms Message Broker Protocol <https://github.com/flux-framework/rfc/blob/master/spec_3.rst>`__
+`RFC 3: Flux Message Protocol <https://github.com/flux-framework/rfc/blob/master/spec_3.rst>`__

--- a/doc/man3/flux_response_decode.rst
+++ b/doc/man3/flux_response_decode.rst
@@ -80,4 +80,4 @@ Github: http://github.com/flux-framework
 SEE ALSO
 ========
 
-flux_request_encode(3), flux_rpc(3)
+:man3:`flux_request_encode`, :man3:`flux_rpc`

--- a/doc/man3/flux_response_decode.rst
+++ b/doc/man3/flux_response_decode.rst
@@ -74,7 +74,7 @@ ENOENT
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org
 
 
 SEE ALSO

--- a/doc/man3/flux_rpc.rst
+++ b/doc/man3/flux_rpc.rst
@@ -71,9 +71,9 @@ A lower-level variant of ``flux_rpc()``, ``flux_rpc_message()`` accepts a
 pre-created request message, assigning *nodeid* and matchtag according
 to *flags*.
 
-``flux_future_then(3)`` may be used to register a reactor callback
+:man3:`flux_future_then` may be used to register a reactor callback
 (continuation) to be called once the response has been received.
-``flux_future_wait_for(3)`` may be used to block until the
+:man3:`flux_future_wait_for` may be used to block until the
 response has been received. Both accept an optional timeout.
 
 ``flux_rpc_get()``, ``flux_rpc_get_unpack()``, and ``flux_rpc_get_raw()``
@@ -132,7 +132,7 @@ RESPONSE OPTIONS
 ================
 
 The response message is stored in the future when the future is fulfilled.
-At that time it is decoded with ``flux_response_decode(3)``. If it cannot
+At that time it is decoded with :man3:`flux_response_decode`. If it cannot
 be decoded, or if the service returned an error, the future is fulfilled
 with an error. Otherwise it is fulfilled with the response message.
 If there was an error, ``flux_future_get()`` or the ``flux_rpc_get()`` variants
@@ -165,7 +165,7 @@ is received, its matchtag is only returned to the pool when an unclaimed
 
 It is essential that services which return multiple responses verify that
 requests were made with the FLUX_RPC_STREAMING flag and return an immediate
-EPROTO error if they were not. See flux_respond(3).
+EPROTO error if they were not. See :man3:`flux_respond`.
 
 
 CANCELLATION

--- a/doc/man3/flux_rpc.rst
+++ b/doc/man3/flux_rpc.rst
@@ -236,7 +236,7 @@ Github: http://github.com/flux-framework
 SEE ALSO
 ========
 
-flux_future_get(3), flux_respond(3)
+:man3:`flux_future_get`, :man3:`flux_respond`
 
 `RFC 6: Flux
 Remote Procedure Call Protocol <https://github.com/flux-framework/rfc/blob/master/spec_6.rst>`__

--- a/doc/man3/flux_rpc.rst
+++ b/doc/man3/flux_rpc.rst
@@ -230,7 +230,7 @@ This example registers a continuation to do the same thing asynchronously.
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org
 
 `RFC 6: Flux Remote Procedure Call Protocol <https://github.com/flux-framework/rfc/blob/master/spec_6.rst>`__
 

--- a/doc/man3/flux_rpc.rst
+++ b/doc/man3/flux_rpc.rst
@@ -232,7 +232,7 @@ RESOURCES
 
 Flux: http://flux-framework.org
 
-`RFC 6: Flux Remote Procedure Call Protocol <https://github.com/flux-framework/rfc/blob/master/spec_6.rst>`__
+RFC 6: Flux Remote Procedure Call Protocol: https://github.com/flux-framework/rfc/blob/master/spec_6.rst
 
 
 SEE ALSO

--- a/doc/man3/flux_rpc.rst
+++ b/doc/man3/flux_rpc.rst
@@ -232,11 +232,10 @@ RESOURCES
 
 Github: http://github.com/flux-framework
 
+`RFC 6: Flux Remote Procedure Call Protocol <https://github.com/flux-framework/rfc/blob/master/spec_6.rst>`__
+
 
 SEE ALSO
 ========
 
 :man3:`flux_future_get`, :man3:`flux_respond`
-
-`RFC 6: Flux
-Remote Procedure Call Protocol <https://github.com/flux-framework/rfc/blob/master/spec_6.rst>`__

--- a/doc/man3/flux_send.rst
+++ b/doc/man3/flux_send.rst
@@ -63,7 +63,7 @@ This example opens the Flux broker and publishes an event message.
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org
 
 
 SEE ALSO

--- a/doc/man3/flux_send.rst
+++ b/doc/man3/flux_send.rst
@@ -69,4 +69,4 @@ Github: http://github.com/flux-framework
 SEE ALSO
 ========
 
-flux_open(3), flux_recv(3), flux_requeue(3)
+:man3:`flux_open`, :man3:`flux_recv`, :man3:`flux_requeue`

--- a/doc/man3/flux_shell_add_completion_ref.rst
+++ b/doc/man3/flux_shell_add_completion_ref.rst
@@ -60,4 +60,4 @@ Github: http://github.com/flux-framework
 SEE ALSO
 ========
 
-flux_reactor_stop(3)
+:man3:`flux_reactor_stop`

--- a/doc/man3/flux_shell_add_completion_ref.rst
+++ b/doc/man3/flux_shell_add_completion_ref.rst
@@ -54,7 +54,7 @@ EINVAL
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org
 
 
 SEE ALSO

--- a/doc/man3/flux_shell_add_event_context.rst
+++ b/doc/man3/flux_shell_add_event_context.rst
@@ -44,4 +44,4 @@ EINVAL
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org

--- a/doc/man3/flux_shell_add_event_handler.rst
+++ b/doc/man3/flux_shell_add_event_handler.rst
@@ -47,4 +47,4 @@ EINVAL
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org

--- a/doc/man3/flux_shell_aux_set.rst
+++ b/doc/man3/flux_shell_aux_set.rst
@@ -90,7 +90,7 @@ ENOENT
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org
 
 
 SEE ALSO

--- a/doc/man3/flux_shell_aux_set.rst
+++ b/doc/man3/flux_shell_aux_set.rst
@@ -96,4 +96,4 @@ Github: http://github.com/flux-framework
 SEE ALSO
 ========
 
-flux_aux_get(3), flux_aux_set(3)
+:man3:`flux_aux_get`, :man3:`flux_aux_set`

--- a/doc/man3/flux_shell_current_task.rst
+++ b/doc/man3/flux_shell_current_task.rst
@@ -57,4 +57,4 @@ EAGAIN
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org

--- a/doc/man3/flux_shell_get_flux.rst
+++ b/doc/man3/flux_shell_get_flux.rst
@@ -72,4 +72,4 @@ EXAMPLE
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org

--- a/doc/man3/flux_shell_get_info.rst
+++ b/doc/man3/flux_shell_get_info.rst
@@ -94,4 +94,4 @@ RESOURCES
 
 Flux: http://flux-framework.org
 
-For an overview of the Jansson API, see https://jansson.readthedocs.io/en/2.10/apiref.html
+Jansson: https://jansson.readthedocs.io/en/2.10/apiref.html

--- a/doc/man3/flux_shell_get_info.rst
+++ b/doc/man3/flux_shell_get_info.rst
@@ -92,6 +92,6 @@ EINVAL
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org
 
 For an overview of the Jansson API, see https://jansson.readthedocs.io/en/2.10/apiref.html

--- a/doc/man3/flux_shell_get_info.rst
+++ b/doc/man3/flux_shell_get_info.rst
@@ -89,13 +89,9 @@ EINVAL
    ``shell_rank`` is less than -1.
 
 
-SEE ALSO
-========
-
-For an overview of the Jansson API, see https://jansson.readthedocs.io/en/2.10/apiref.html.
-
-
 RESOURCES
 =========
 
 Github: http://github.com/flux-framework
+
+For an overview of the Jansson API, see https://jansson.readthedocs.io/en/2.10/apiref.html

--- a/doc/man3/flux_shell_get_jobspec_info.rst
+++ b/doc/man3/flux_shell_get_jobspec_info.rst
@@ -68,13 +68,9 @@ EINVAL
    ``shell_rank`` is less than -1.
 
 
-SEE ALSO
-========
-
-For an overview of the Jansson API, see https://jansson.readthedocs.io/en/2.10/apiref.html.
-
-
 RESOURCES
 =========
 
 Github: http://github.com/flux-framework
+
+For an overview of the Jansson API, see https://jansson.readthedocs.io/en/2.10/apiref.html

--- a/doc/man3/flux_shell_get_jobspec_info.rst
+++ b/doc/man3/flux_shell_get_jobspec_info.rst
@@ -73,4 +73,4 @@ RESOURCES
 
 Flux: http://flux-framework.org
 
-For an overview of the Jansson API, see https://jansson.readthedocs.io/en/2.10/apiref.html
+Jansson: https://jansson.readthedocs.io/en/2.10/apiref.html

--- a/doc/man3/flux_shell_get_jobspec_info.rst
+++ b/doc/man3/flux_shell_get_jobspec_info.rst
@@ -71,6 +71,6 @@ EINVAL
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org
 
 For an overview of the Jansson API, see https://jansson.readthedocs.io/en/2.10/apiref.html

--- a/doc/man3/flux_shell_getenv.rst
+++ b/doc/man3/flux_shell_getenv.rst
@@ -69,4 +69,4 @@ EEXIST
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org

--- a/doc/man3/flux_shell_getenv.rst
+++ b/doc/man3/flux_shell_getenv.rst
@@ -42,7 +42,7 @@ DESCRIPTION
 ``flux_shell_get_environ()`` returns 0 on success with ``*json_str`` set
 to an allocated JSON string, or -1 on failure with ``errno`` set.
 ``flux_shell_setenvf()`` sets an environment variable in the global job
-environment using ``printf(3)`` style format arguments.
+environment using :linux:man3:`printf` style format arguments.
 ``flux_shell_unsetenv()`` unsets the specified environment variable in the global job environment.
 
 

--- a/doc/man3/flux_shell_getopt.rst
+++ b/doc/man3/flux_shell_getopt.rst
@@ -74,4 +74,4 @@ ENOMEM
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org

--- a/doc/man3/flux_shell_killall.rst
+++ b/doc/man3/flux_shell_killall.rst
@@ -39,4 +39,4 @@ None.
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org

--- a/doc/man3/flux_shell_log.rst
+++ b/doc/man3/flux_shell_log.rst
@@ -160,4 +160,4 @@ Github: http://github.com/flux-framework
 SEE ALSO
 ========
 
-flux_log(3)
+:man3:`flux_log`

--- a/doc/man3/flux_shell_log.rst
+++ b/doc/man3/flux_shell_log.rst
@@ -154,7 +154,7 @@ EINVAL
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org
 
 
 SEE ALSO

--- a/doc/man3/flux_shell_plugstack_call.rst
+++ b/doc/man3/flux_shell_plugstack_call.rst
@@ -44,4 +44,4 @@ EINVAL
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org

--- a/doc/man3/flux_shell_rpc_pack.rst
+++ b/doc/man3/flux_shell_rpc_pack.rst
@@ -44,4 +44,4 @@ EINVAL
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org

--- a/doc/man3/flux_shell_service_register.rst
+++ b/doc/man3/flux_shell_service_register.rst
@@ -45,7 +45,7 @@ EINVAL
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org
 
 
 SEE ALSO

--- a/doc/man3/flux_shell_service_register.rst
+++ b/doc/man3/flux_shell_service_register.rst
@@ -51,4 +51,4 @@ Github: http://github.com/flux-framework
 SEE ALSO
 ========
 
-``flux_msg_handler_create(3)``
+:man3:`flux_msg_handler_create`

--- a/doc/man3/flux_shell_task_channel_subscribe.rst
+++ b/doc/man3/flux_shell_task_channel_subscribe.rst
@@ -47,4 +47,4 @@ EEXIST
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org

--- a/doc/man3/flux_shell_task_get_info.rst
+++ b/doc/man3/flux_shell_task_get_info.rst
@@ -55,4 +55,4 @@ EINVAL
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org

--- a/doc/man3/flux_shell_task_subprocess.rst
+++ b/doc/man3/flux_shell_task_subprocess.rst
@@ -46,4 +46,4 @@ EINVAL
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org

--- a/doc/man3/flux_signal_watcher_create.rst
+++ b/doc/man3/flux_signal_watcher_create.rst
@@ -63,6 +63,6 @@ Github: http://github.com/flux-framework
 SEE ALSO
 ========
 
-flux_watcher_start(3), flux_reactor_run(3)
+:man3:`flux_watcher_start`, :man3:`flux_reactor_run`
 
 `libev home page <http://software.schmorp.de/pkg/libev.html>`__

--- a/doc/man3/flux_signal_watcher_create.rst
+++ b/doc/man3/flux_signal_watcher_create.rst
@@ -59,10 +59,10 @@ RESOURCES
 
 Github: http://github.com/flux-framework
 
+`libev home page <http://software.schmorp.de/pkg/libev.html>`__
+
 
 SEE ALSO
 ========
 
 :man3:`flux_watcher_start`, :man3:`flux_reactor_run`
-
-`libev home page <http://software.schmorp.de/pkg/libev.html>`__

--- a/doc/man3/flux_signal_watcher_create.rst
+++ b/doc/man3/flux_signal_watcher_create.rst
@@ -57,7 +57,7 @@ ENOMEM
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org
 
 `libev home page <http://software.schmorp.de/pkg/libev.html>`__
 

--- a/doc/man3/flux_signal_watcher_create.rst
+++ b/doc/man3/flux_signal_watcher_create.rst
@@ -59,7 +59,7 @@ RESOURCES
 
 Flux: http://flux-framework.org
 
-`libev home page <http://software.schmorp.de/pkg/libev.html>`__
+libev: http://software.schmorp.de/pkg/libev.html
 
 
 SEE ALSO

--- a/doc/man3/flux_stat_watcher_create.rst
+++ b/doc/man3/flux_stat_watcher_create.rst
@@ -69,7 +69,7 @@ ENOMEM
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org
 
 `libev home page <http://software.schmorp.de/pkg/libev.html>`__
 

--- a/doc/man3/flux_stat_watcher_create.rst
+++ b/doc/man3/flux_stat_watcher_create.rst
@@ -71,7 +71,7 @@ RESOURCES
 
 Flux: http://flux-framework.org
 
-`libev home page <http://software.schmorp.de/pkg/libev.html>`__
+libev: http://software.schmorp.de/pkg/libev.html
 
 
 SEE ALSO

--- a/doc/man3/flux_stat_watcher_create.rst
+++ b/doc/man3/flux_stat_watcher_create.rst
@@ -77,4 +77,5 @@ libev: http://software.schmorp.de/pkg/libev.html
 SEE ALSO
 ========
 
-:man3:`flux_watcher_start`, :man3:`flux_reactor_run`, stat(2)
+:man3:`flux_watcher_start`, :man3:`flux_reactor_run`,
+:linux:man2:`stat`

--- a/doc/man3/flux_stat_watcher_create.rst
+++ b/doc/man3/flux_stat_watcher_create.rst
@@ -71,10 +71,10 @@ RESOURCES
 
 Github: http://github.com/flux-framework
 
+`libev home page <http://software.schmorp.de/pkg/libev.html>`__
+
 
 SEE ALSO
 ========
 
 :man3:`flux_watcher_start`, :man3:`flux_reactor_run`, stat(2)
-
-`libev home page <http://software.schmorp.de/pkg/libev.html>`__

--- a/doc/man3/flux_stat_watcher_create.rst
+++ b/doc/man3/flux_stat_watcher_create.rst
@@ -37,7 +37,7 @@ DESCRIPTION
 ``flux_stat_watcher_create()`` creates a reactor watcher that
 monitors for changes in the status of the file system object
 represented by *path*. If the file system object exists,
-inotify(2) is used, if available; otherwise the reactor polls
+:linux:man2:`inotify` is used, if available; otherwise the reactor polls
 the file every *interval* seconds. A value of zero selects a
 conservative default (currently five seconds).
 

--- a/doc/man3/flux_stat_watcher_create.rst
+++ b/doc/man3/flux_stat_watcher_create.rst
@@ -75,6 +75,6 @@ Github: http://github.com/flux-framework
 SEE ALSO
 ========
 
-flux_watcher_start(3), flux_reactor_run(3), stat(2)
+:man3:`flux_watcher_start`, :man3:`flux_reactor_run`, stat(2)
 
 `libev home page <http://software.schmorp.de/pkg/libev.html>`__

--- a/doc/man3/flux_sync_create.rst
+++ b/doc/man3/flux_sync_create.rst
@@ -68,7 +68,7 @@ Set up a continuation callback for each heartbeat that arrives at least
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org
 
 
 SEE ALSO

--- a/doc/man3/flux_sync_create.rst
+++ b/doc/man3/flux_sync_create.rst
@@ -74,4 +74,4 @@ Github: http://github.com/flux-framework
 SEE ALSO
 ========
 
-flux_future_then(3), flux_future_get(3), flux_future_reset(3)
+:man3:`flux_future_then`, :man3:`flux_future_get`, :man3:`flux_future_reset`

--- a/doc/man3/flux_timer_watcher_create.rst
+++ b/doc/man3/flux_timer_watcher_create.rst
@@ -75,7 +75,7 @@ ENOMEM
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org
 
 `libev home page <http://software.schmorp.de/pkg/libev.html>`__
 

--- a/doc/man3/flux_timer_watcher_create.rst
+++ b/doc/man3/flux_timer_watcher_create.rst
@@ -81,6 +81,6 @@ Github: http://github.com/flux-framework
 SEE ALSO
 ========
 
-flux_watcher_start(3), flux_reactor_run(3), flux_reactor_now(3)
+:man3:`flux_watcher_start`, :man3:`flux_reactor_run`, :man3:`flux_reactor_now`
 
 `libev home page <http://software.schmorp.de/pkg/libev.html>`__

--- a/doc/man3/flux_timer_watcher_create.rst
+++ b/doc/man3/flux_timer_watcher_create.rst
@@ -77,7 +77,7 @@ RESOURCES
 
 Flux: http://flux-framework.org
 
-`libev home page <http://software.schmorp.de/pkg/libev.html>`__
+libev: http://software.schmorp.de/pkg/libev.html
 
 
 SEE ALSO

--- a/doc/man3/flux_timer_watcher_create.rst
+++ b/doc/man3/flux_timer_watcher_create.rst
@@ -77,10 +77,10 @@ RESOURCES
 
 Github: http://github.com/flux-framework
 
+`libev home page <http://software.schmorp.de/pkg/libev.html>`__
+
 
 SEE ALSO
 ========
 
 :man3:`flux_watcher_start`, :man3:`flux_reactor_run`, :man3:`flux_reactor_now`
-
-`libev home page <http://software.schmorp.de/pkg/libev.html>`__

--- a/doc/man3/flux_timer_watcher_create.rst
+++ b/doc/man3/flux_timer_watcher_create.rst
@@ -43,7 +43,7 @@ will automatically be stopped when *after* seconds have elapsed.
 
 Note that *after* is internally referenced to reactor time, which is
 only updated when the reactor is run/created, and therefore
-can be out of date. Use ``flux_reactor_now_update(3)`` to manually
+can be out of date. Use :man3:`flux_reactor_now_update` to manually
 update reactor time before creating timer watchers in such cases.
 Refer to "The special problem of time updates" in the libev manual
 for more information.

--- a/doc/man3/flux_watcher_start.rst
+++ b/doc/man3/flux_watcher_start.rst
@@ -45,4 +45,4 @@ Github: http://github.com/flux-framework
 SEE ALSO
 ========
 
-flux_reactor_create (3)
+:man3:`flux_reactor_create`

--- a/doc/man3/flux_watcher_start.rst
+++ b/doc/man3/flux_watcher_start.rst
@@ -39,7 +39,7 @@ set to ``EINVAL`` otherwise.
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org
 
 
 SEE ALSO

--- a/doc/man3/idset_add.rst
+++ b/doc/man3/idset_add.rst
@@ -101,7 +101,7 @@ ENOMEM
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org
 
 `RFC 22: Idset String Representation <https://github.com/flux-framework/rfc/blob/master/spec_22.rst>`__
 

--- a/doc/man3/idset_add.rst
+++ b/doc/man3/idset_add.rst
@@ -103,7 +103,7 @@ RESOURCES
 
 Flux: http://flux-framework.org
 
-`RFC 22: Idset String Representation <https://github.com/flux-framework/rfc/blob/master/spec_22.rst>`__
+RFC 22: Idset String Representation: https://github.com/flux-framework/rfc/blob/master/spec_22.rst
 
 
 SEE ALSO

--- a/doc/man3/idset_add.rst
+++ b/doc/man3/idset_add.rst
@@ -103,10 +103,10 @@ RESOURCES
 
 Github: http://github.com/flux-framework
 
+`RFC 22: Idset String Representation <https://github.com/flux-framework/rfc/blob/master/spec_22.rst>`__
+
 
 SEE ALSO
 ========
 
 :man3:`idset_create`, :man3:`idset_encode`
-
-`RFC 22: Idset String Representation <https://github.com/flux-framework/rfc/blob/master/spec_22.rst>`__

--- a/doc/man3/idset_add.rst
+++ b/doc/man3/idset_add.rst
@@ -107,6 +107,6 @@ Github: http://github.com/flux-framework
 SEE ALSO
 ========
 
-idset_create(3), idset_encode(3)
+:man3:`idset_create`, :man3:`idset_encode`
 
 `RFC 22: Idset String Representation <https://github.com/flux-framework/rfc/blob/master/spec_22.rst>`__

--- a/doc/man3/idset_add.rst
+++ b/doc/man3/idset_add.rst
@@ -54,7 +54,7 @@ cc [flags] files -lflux-idset [libraries]
 DESCRIPTION
 ===========
 
-Refer to ``idset_create(3)`` for a general description of idsets.
+Refer to :man3:`idset_create` for a general description of idsets.
 
 ``idset_union()`` creates a new idset that is the union of *a* and *b*.
 

--- a/doc/man3/idset_create.rst
+++ b/doc/man3/idset_create.rst
@@ -146,7 +146,7 @@ ENOMEM
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org
 
 `RFC 22: Idset String Representation <https://github.com/flux-framework/rfc/blob/master/spec_22.rst>`__
 

--- a/doc/man3/idset_create.rst
+++ b/doc/man3/idset_create.rst
@@ -148,10 +148,10 @@ RESOURCES
 
 Github: http://github.com/flux-framework
 
+`RFC 22: Idset String Representation <https://github.com/flux-framework/rfc/blob/master/spec_22.rst>`__
+
 
 SEE ALSO
 ========
 
 :man3:`idset_encode`, :man3:`idset_add`
-
-`RFC 22: Idset String Representation <https://github.com/flux-framework/rfc/blob/master/spec_22.rst>`__

--- a/doc/man3/idset_create.rst
+++ b/doc/man3/idset_create.rst
@@ -152,6 +152,6 @@ Github: http://github.com/flux-framework
 SEE ALSO
 ========
 
-idset_encode(3), idset_add(3)
+:man3:`idset_encode`, :man3:`idset_add`
 
 `RFC 22: Idset String Representation <https://github.com/flux-framework/rfc/blob/master/spec_22.rst>`__

--- a/doc/man3/idset_create.rst
+++ b/doc/man3/idset_create.rst
@@ -148,7 +148,7 @@ RESOURCES
 
 Flux: http://flux-framework.org
 
-`RFC 22: Idset String Representation <https://github.com/flux-framework/rfc/blob/master/spec_22.rst>`__
+RFC 22: Idset String Representation: https://github.com/flux-framework/rfc/blob/master/spec_22.rst
 
 
 SEE ALSO

--- a/doc/man3/idset_encode.rst
+++ b/doc/man3/idset_encode.rst
@@ -32,7 +32,7 @@ cc [flags] files -lflux-idset [libraries]
 DESCRIPTION
 ===========
 
-Refer to ``idset_create(3)`` for a general description of idsets.
+Refer to :man3:`idset_create` for a general description of idsets.
 
 ``idset_encode()`` creates a string from *idset*. The string contains
 a comma-separated list of ids, potentially modified by *flags*
@@ -81,7 +81,7 @@ RETURN VALUE
 ============
 
 ``idset_decode()`` and ``idset_ndecode()`` return idset on success which must
-be freed with ``idset_destroy(3)``. On error, NULL is returned with errno set.
+be freed with :man3:`idset_destroy`. On error, NULL is returned with errno set.
 
 ``idset_encode()`` returns a string on success which must be freed
 with ``free()``. On error, NULL is returned with errno set.

--- a/doc/man3/idset_encode.rst
+++ b/doc/man3/idset_encode.rst
@@ -102,10 +102,10 @@ RESOURCES
 
 Github: http://github.com/flux-framework
 
+`RFC 22: Idset String Representation <https://github.com/flux-framework/rfc/blob/master/spec_22.rst>`__
+
 
 SEE ALSO
 ========
 
 :man3:`idset_create`
-
-`RFC 22: Idset String Representation <https://github.com/flux-framework/rfc/blob/master/spec_22.rst>`__

--- a/doc/man3/idset_encode.rst
+++ b/doc/man3/idset_encode.rst
@@ -106,6 +106,6 @@ Github: http://github.com/flux-framework
 SEE ALSO
 ========
 
-idset_create(3)
+:man3:`idset_create`
 
 `RFC 22: Idset String Representation <https://github.com/flux-framework/rfc/blob/master/spec_22.rst>`__

--- a/doc/man3/idset_encode.rst
+++ b/doc/man3/idset_encode.rst
@@ -102,7 +102,7 @@ RESOURCES
 
 Flux: http://flux-framework.org
 
-`RFC 22: Idset String Representation <https://github.com/flux-framework/rfc/blob/master/spec_22.rst>`__
+RFC 22: Idset String Representation: https://github.com/flux-framework/rfc/blob/master/spec_22.rst
 
 
 SEE ALSO

--- a/doc/man3/idset_encode.rst
+++ b/doc/man3/idset_encode.rst
@@ -100,7 +100,7 @@ ENOMEM
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org
 
 `RFC 22: Idset String Representation <https://github.com/flux-framework/rfc/blob/master/spec_22.rst>`__
 

--- a/doc/man5/flux-config-bootstrap.rst
+++ b/doc/man5/flux-config-bootstrap.rst
@@ -35,9 +35,9 @@ enable_ipv6
    interface that only supports IPv4.
 
 curve_cert
-   (optional) Path to a CURVE certificate generated with flux-keygen(1).
-   The certificate should be identical on all broker ranks.
-   It is required for instance sizes > 1.
+   (optional) Path to a CURVE certificate generated with
+   :man1:`flux-keygen`.  The certificate should be identical on all
+   broker ranks.  It is required for instance sizes > 1.
 
 default_port
    (optional) The value is an integer port number that is substituted

--- a/doc/man5/flux-config-bootstrap.rst
+++ b/doc/man5/flux-config-bootstrap.rst
@@ -107,4 +107,4 @@ Github: http://github.com/flux-framework
 SEE ALSO
 ========
 
-flux-getattr(1), flux_attr_get(3)
+:man1:`flux-getattr`, :man3:`flux_attr_get`

--- a/doc/man5/flux-config-bootstrap.rst
+++ b/doc/man5/flux-config-bootstrap.rst
@@ -101,7 +101,7 @@ EXAMPLE
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org
 
 
 SEE ALSO

--- a/doc/man7/flux-broker-attributes.rst
+++ b/doc/man7/flux-broker-attributes.rst
@@ -199,4 +199,4 @@ Github: http://github.com/flux-framework
 SEE ALSO
 ========
 
-flux-getattr(1), flux_attr_get(3)
+:man1:`flux-getattr`, :man3:`flux_attr_get`

--- a/doc/man7/flux-broker-attributes.rst
+++ b/doc/man7/flux-broker-attributes.rst
@@ -193,7 +193,7 @@ hello.hwm
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org
 
 
 SEE ALSO

--- a/doc/man7/flux-broker-attributes.rst
+++ b/doc/man7/flux-broker-attributes.rst
@@ -8,7 +8,8 @@ DESCRIPTION
 
 Flux broker attributes are parameters that affect how different
 broker systems behave. Attributes can be listed and manipulated
-with flux-getattr(1), flux-setattr(1), and flux-lsattr(1).
+with :man1:`flux-getattr`, :man1:`flux-setattr`, and
+:man1:`flux-lsattr`.
 
 The broker currently exports the following attributes:
 
@@ -27,10 +28,11 @@ rundir
    content.backing-path are located (see below).  By default, each broker
    rank creates a unique rundir in $TMPDIR and removes it on exit.  If
    rundir is set on the command line, beware exceeding the UNIX domain socket
-   path limit described in unix(7), as low as 92 bytes on some systems.
-   If rundir is set to a pre-existing directory, the directory is not removed
-   on exit;  if the broker has to create the directory, it is removed.
-   In most cases this attribute should not be set by users.
+   path limit described in :linux:man7:`unix`, as low as 92 bytes on
+   some systems.  If rundir is set to a pre-existing directory, the
+   directory is not removed on exit; if the broker has to create the
+   directory, it is removed.  In most cases this attribute should not
+   be set by users.
 
 content.backing-path
    The path to the content backing store file(s). If this is set on the
@@ -83,13 +85,13 @@ tbon.parent-endpoint
    based overlay network. This attribute will not be set on rank zero.
 
 local-uri
-   The Flux URI that should be passed to flux_open(3) to establish
-   a connection to the local broker rank. By default, local-uri is
-   created as "local://<broker.rank>/local".
+   The Flux URI that should be passed to :man3:`flux_open` to
+   establish a connection to the local broker rank. By default,
+   local-uri is created as "local://<broker.rank>/local".
 
 parent-uri
-   The Flux URI that should be passed to flux_open(3) to establish
-   a connection to the enclosing instance.
+   The Flux URI that should be passed to :man3:`flux_open` to
+   establish a connection to the enclosing instance.
 
 
 LOGGING ATTRIBUTES
@@ -105,12 +107,13 @@ log-count
    The number of log entries ever stored in the ring buffer.
 
 log-forward-level
-   Log entries at syslog(3) level at or below this value are forwarded
-   to rank zero for permanent capture.
+   Log entries at :linux:man3:`syslog` level at or below this value
+   are forwarded to rank zero for permanent capture.
 
 log-critical-level
-   Log entries at syslog(3) level at or below this value are copied
-   to stderr on the logging rank, for capture by the enclosing instance.
+   Log entries at :linux:man3:`syslog` level at or below this value
+   are copied to stderr on the logging rank, for capture by the
+   enclosing instance.
 
 log-filename
    (rank zero only) If set, session log entries, as filtered by log-forward-level,
@@ -123,12 +126,12 @@ log-stderr-mode
    logs to stderr, subject to the constraints of log-stderr-level.
 
 log-stderr-level
-   Log entries at syslog(3) level at or below this value to stderr,
-   subject to log-stderr-mode.
+   Log entries at :linux:man3:`syslog` level at or below this value to
+   stderr, subject to log-stderr-mode.
 
 log-level
-   Log entries at syslog(3) level at or below this value are stored
-   in the ring buffer.
+   Log entries at :linux:man3:`syslog` level at or below this value
+   are stored in the ring buffer.
 
 
 CONTENT ATTRIBUTES

--- a/doc/man7/flux-jobtap-plugins.rst
+++ b/doc/man7/flux-jobtap-plugins.rst
@@ -34,7 +34,7 @@ passed along when registering the handler.
 Multiple plugins may be loaded in the job-manager simultaneously. In this
 case, all matching handlers are called in all loaded plugins in the order
 in which they were loaded. For more information about loading plugins
-see the :ref:`configuration` section below or the ``flux-jobtap(1)``
+see the :ref:`configuration` section below or the :man1:`flux-jobtap`
 manpage.
 
 JOBTAP PLUGIN NAMES
@@ -47,11 +47,11 @@ such that all dynamically loaded plugins have names such as
 ``plugin-name.so``.
 
 Builtin plugins, on the other hand, are named with a leading ``.``,
-and are hidden in ``flux jobtap list``, do not match the glob(7)
-``*`` or "all" keyword, etc. (similar to hidden filesystem files).
-To list builtin plugins, use the ``-a, --all`` option to
-``flux jobtap list``, and to remove them use the name explicitly or
-include the leading ``.`` in any pattern.
+and are hidden in ``flux jobtap list``, do not match the
+:linux:man7:`glob` ``*`` or "all" keyword, etc. (similar to hidden
+filesystem files).  To list builtin plugins, use the ``-a, --all``
+option to ``flux jobtap list``, and to remove them use the name
+explicitly or include the leading ``.`` in any pattern.
 
 A plugin may optionally assign a name with ``flux_plugin_set_name(3)``,
 however this name is not displayed in ``flux jobtap list`` or used in
@@ -140,7 +140,7 @@ job.dependency.*
   with a corresponding call to ``flux_jobtap_dependency_remove(3)``. See
   ``job.state.depend`` below for more information about dependencies.
   If there is an error in the dependency specification, the job may be
-  rejected with ``flux_jobtap_reject_job(3)`` and a negative return code 
+  rejected with :man3:`flux_jobtap_reject_job` and a negative return code 
   from the callback.
 
 job.new
@@ -338,10 +338,10 @@ conf
   With load only, pass an optional configuration table to the loaded plugin.
 
 remove
-  Remove all plugins matching the value. The value may be a glob(7). If
-  ``remove`` appears with ``load``, plugin removal is always handled first.
-  The special value ``all`` is a synonym for ``*``, but will not error when
-  no plugins match.
+  Remove all plugins matching the value. The value may be a
+  :linux:man7:`glob`. If ``remove`` appears with ``load``, plugin
+  removal is always handled first.  The special value ``all`` is a
+  synonym for ``*``, but will not error when no plugins match.
 
 For example
 
@@ -359,7 +359,7 @@ For example
     ]
 
 The list of loaded jobtap plugins may also be queried and controlled at
-runtime with the ``flux-jobtap(1)`` command
+runtime with the :man1:`flux-jobtap` command
 
 
 RESOURCES

--- a/doc/man7/flux-jobtap-plugins.rst
+++ b/doc/man7/flux-jobtap-plugins.rst
@@ -371,5 +371,5 @@ Github: http://github.com/flux-framework
 SEE ALSO
 ========
 
-flux-jobtap(1)
+:man1:`flux-jobtap`
 

--- a/doc/man7/flux-jobtap-plugins.rst
+++ b/doc/man7/flux-jobtap-plugins.rst
@@ -365,7 +365,7 @@ runtime with the ``flux-jobtap(1)`` command
 RESOURCES
 =========
 
-Github: http://github.com/flux-framework
+Flux: http://flux-framework.org
 
 
 SEE ALSO

--- a/doc/man7/flux-undocumented.rst
+++ b/doc/man7/flux-undocumented.rst
@@ -1,0 +1,15 @@
+====================
+flux-undocumented(7)
+====================
+
+
+DESCRIPTION
+===========
+
+This documentation does not exist
+Apparently something was missed
+We might need reminding
+Of the page you're not finding
+So sorry, please don't be pissed
+
+Issue or PR to http://github.com/flux-framework/flux-core welcome.


### PR DESCRIPTION
per #4003, a bunch of cleanup in the SEE ALSO and RESOURCES sections

- use domainrefs for all  "SEE ALSO" manpages listed at the bottom of manpages
- move all pointers to websites under RESOURCES instead of SEE ALSO
- consistently list all RESOURCES using the same format so they show up well in both manpages and read the docs
- update some jansson text
- all flux URLs point to flux-framework.org rather than github.

TODO - domainrefs for flux manpages and linux manpages in the middle of the actual text in the manpages.  I only did SEE ALSO and RESOURCES sections in this PR.