### PR TITLE
flux-top: allow top to recursively call itself

### DIFF
--- a/src/cmd/flux-uri.py
+++ b/src/cmd/flux-uri.py
@@ -8,6 +8,7 @@
 # SPDX-License-Identifier: LGPL-3.0
 ##############################################################
 
+import os
 import sys
 import logging
 import argparse
@@ -44,6 +45,7 @@ def main():
         "--local",
         action="store_true",
         help="convert a remote URI to local",
+        default=os.environ.get("FLUX_URI_RESOLVE_LOCAL"),
     )
     parser.add_argument(
         "uri",

--- a/src/cmd/top/joblist_pane.c
+++ b/src/cmd/top/joblist_pane.c
@@ -104,7 +104,7 @@ void joblist_pane_draw (struct joblist_pane *joblist)
                          "annotations",
                            "user",
                              "uri", &uri) < 0)
-            fatal (errno, "error decoding a job record from job-list RPC");
+            fatal (0, "error decoding a job record from job-list RPC");
         if (flux_job_id_encode (id, "f58", idstr, sizeof (idstr)) < 0)
             fatal (errno, "error encoding jobid as F58");
         if (fsd_format_duration_ex (run, sizeof (run), now - t_run, 2) < 0)

--- a/src/cmd/top/joblist_pane.c
+++ b/src/cmd/top/joblist_pane.c
@@ -20,7 +20,7 @@
 
 #include "top.h"
 
-static const struct dimension win_dim = { 0, 5, 80, 60 };
+static const struct dimension win_dim = { 0, 6, 80, 60 };
 
 struct joblist_pane {
     struct top *top;

--- a/src/cmd/top/joblist_pane.c
+++ b/src/cmd/top/joblist_pane.c
@@ -142,8 +142,12 @@ static void joblist_continuation (flux_future_t *f, void *arg)
     struct joblist_pane *joblist = arg;
     json_t *jobs;
 
-    if (flux_rpc_get_unpack (f, "{s:o}", "jobs", &jobs) < 0)
-        fatal (errno, "error decoding job-list.list RPC response");
+    if (flux_rpc_get_unpack (f, "{s:o}", "jobs", &jobs) < 0) {
+        if (errno != ENOSYS)
+            fatal (errno, "error decoding job-list.list RPC response");
+        flux_future_destroy (f);
+        return;
+    }
     json_decref (joblist->jobs);
     joblist->jobs = json_incref (jobs);
     joblist_pane_draw (joblist);

--- a/src/cmd/top/joblist_pane.c
+++ b/src/cmd/top/joblist_pane.c
@@ -27,7 +27,39 @@ struct joblist_pane {
     WINDOW *win;
     json_t *jobs;
     struct ucache *ucache;
+
+    /*  Currently selected jobid. Ironically FLUX_JOBID_ANY means
+     *   no current selection.
+     */
+    flux_jobid_t current;
 };
+
+static int lookup_jobid_index (json_t *jobs, flux_jobid_t id)
+{
+    int result = -1;
+    size_t index;
+    json_t *job;
+
+    if (jobs) {
+        json_array_foreach (jobs, index, job) {
+            flux_jobid_t jobid;
+
+            if (json_unpack (job, "{s:I}", "id", &jobid) < 0)
+                continue;
+            if (jobid == id)
+                return (int) index;
+        }
+    }
+    return result;
+}
+
+static json_t *get_current_job (struct joblist_pane *joblist)
+{
+    int index = lookup_jobid_index (joblist->jobs,
+                                    joblist->current);
+    return json_array_get (joblist->jobs, index);
+}
+
 
 void joblist_pane_draw (struct joblist_pane *joblist)
 {
@@ -48,6 +80,7 @@ void joblist_pane_draw (struct joblist_pane *joblist)
     if (joblist->jobs == NULL)
         return;
     json_array_foreach (joblist->jobs, index, job) {
+        char *uri = NULL;
         char idstr[16];
         char run[16];
         flux_jobid_t id;
@@ -60,14 +93,17 @@ void joblist_pane_draw (struct joblist_pane *joblist)
         double t_run;
 
         if (json_unpack (job,
-                         "{s:I s:i s:i s:s s:i s:i s:f}",
+                         "{s:I s:i s:i s:s s:i s:i s:f s?{s?{s?s}}}",
                          "id", &id,
                          "userid", &userid,
                          "state", &state,
                          "name", &name,
                          "nnodes", &nnodes,
                          "ntasks", &ntasks,
-                         "t_run", &t_run) < 0)
+                         "t_run", &t_run,
+                         "annotations",
+                           "user",
+                             "uri", &uri) < 0)
             fatal (errno, "error decoding a job record from job-list RPC");
         if (flux_job_id_encode (id, "f58", idstr, sizeof (idstr)) < 0)
             fatal (errno, "error encoding jobid as F58");
@@ -75,6 +111,14 @@ void joblist_pane_draw (struct joblist_pane *joblist)
             fatal (errno, "error formating expiration time as FSD");
         if (!(username = ucache_lookup (joblist->ucache, userid)))
             fatal (errno, "error looking up userid %d in ucache", (int)userid);
+
+        /*  Highlight current selection in blue, o/w color jobs that
+         *   are Flux instances blue (and bold for non-color terminals)
+         */
+        if (id == joblist->current)
+            wattron (joblist->win, A_REVERSE);
+        if (uri != NULL)
+            wattron (joblist->win, COLOR_PAIR(TOP_COLOR_BLUE) | A_BOLD);
         mvwprintw (joblist->win,
                    1 + index,
                    0,
@@ -88,6 +132,8 @@ void joblist_pane_draw (struct joblist_pane *joblist)
                    name_width,
                    name_width,
                    name);
+        wattroff (joblist->win, A_REVERSE);
+        wattroff (joblist->win, COLOR_PAIR(TOP_COLOR_BLUE) | A_BOLD);
     }
 }
 
@@ -104,6 +150,31 @@ static void joblist_continuation (flux_future_t *f, void *arg)
     flux_future_destroy (f);
 }
 
+void joblist_pane_enter (struct joblist_pane *joblist)
+{
+    struct top *top;
+    char *uri = NULL;
+    json_t *job = get_current_job (joblist);
+    if (!job)
+        return;
+    if (json_unpack (job,
+                     "{s:{s:{s:s}}}",
+                     "annotations",
+                       "user",
+                         "uri", &uri) < 0)
+        return;
+    if (uri == NULL)
+        return;
+
+    /*  Lazily attempt to run top on jobid, but for now simply return to the
+     *   original top window on failure.
+     */
+    if ((top = top_create (uri)))
+        top_run (top, 0);
+    top_destroy (top);
+    return;
+}
+
 void joblist_pane_query (struct joblist_pane *joblist)
 {
     flux_future_t *f;
@@ -112,12 +183,13 @@ void joblist_pane_query (struct joblist_pane *joblist)
                              "job-list.list",
                              0,
                              0,
-                             "{s:i s:i s:i s:i s:[s,s,s,s,s,s]}",
+                             "{s:i s:i s:i s:i s:[s,s,s,s,s,s,s]}",
                              "max_entries", win_dim.y_length - 1,
                              "userid", FLUX_USERID_UNKNOWN,
                              "states", FLUX_JOB_STATE_RUNNING,
                              "results", 0,
                              "attrs",
+                               "annotations",
                                "userid",
                                "state",
                                "name",
@@ -133,6 +205,37 @@ void joblist_pane_refresh (struct joblist_pane *joblist)
     wnoutrefresh (joblist->win);
 }
 
+void joblist_pane_set_current (struct joblist_pane *joblist, bool next)
+{
+    int current = -1;;
+    json_t *job;
+    flux_jobid_t id = FLUX_JOBID_ANY;
+    int njobs;
+
+    if (joblist->jobs == NULL)
+        return;
+
+    if (joblist->current != FLUX_JOBID_ANY)
+        current = lookup_jobid_index (joblist->jobs, joblist->current);
+
+    njobs = json_array_size (joblist->jobs);
+    if (next && current == njobs -1)
+        current = -1;
+    else if (!next && current <= 0)
+        current = njobs;
+
+    if (!(job = json_array_get (joblist->jobs,
+                                next ? current + 1 : current - 1)))
+        return;
+    if (job && json_unpack (job, "{s:I}", "id", &id) < 0)
+        return;
+
+    if (id != joblist->current) {
+        joblist->current = id;
+        joblist_pane_draw (joblist);
+    }
+}
+
 struct joblist_pane *joblist_pane_create (struct top *top)
 {
     struct joblist_pane *joblist;
@@ -142,6 +245,7 @@ struct joblist_pane *joblist_pane_create (struct top *top)
     if (!(joblist->ucache = ucache_create ()))
         fatal (errno, "could not create ucache");
     joblist->top = top;
+    joblist->current = FLUX_JOBID_ANY;
     if (!(joblist->win = newwin (win_dim.y_length,
                                  win_dim.x_length,
                                  win_dim.y_begin,

--- a/src/cmd/top/keys.c
+++ b/src/cmd/top/keys.c
@@ -30,9 +30,21 @@ static void keys_cb (flux_reactor_t *r,
     struct keys *keys = arg;
     int c;
 
-    switch ((c = getch ())) {
+    switch ((c = getch())) {
         case 'q':
             flux_reactor_stop (r);
+            break;
+        case 'j':
+        case KEY_DOWN:
+            joblist_pane_set_current (keys->top->joblist_pane, true);
+            break;
+        case 'k':
+        case KEY_UP:
+            joblist_pane_set_current (keys->top->joblist_pane, false);
+            break;
+        case '\n':
+        case KEY_ENTER:
+            joblist_pane_enter (keys->top->joblist_pane);
             break;
         case '':
             clear ();

--- a/src/cmd/top/summary_pane.c
+++ b/src/cmd/top/summary_pane.c
@@ -59,6 +59,8 @@ struct summary_pane {
     struct resource_count gpu;
     flux_watcher_t *heartblink;
     bool heart_visible;
+    flux_jobid_t current;
+    json_t *jobs;
 };
 
 static void draw_timeleft (struct summary_pane *sum)

--- a/src/cmd/top/top.c
+++ b/src/cmd/top/top.c
@@ -135,7 +135,8 @@ static void initialize_curses (void)
     start_color ();
     init_pair (TOP_COLOR_YELLOW, COLOR_YELLOW, -1);
     init_pair (TOP_COLOR_RED, COLOR_RED, -1);
-
+    init_pair (TOP_COLOR_BLUE, COLOR_BLUE, -1);
+    init_pair (TOP_COLOR_BLUE_HIGHLIGHT, COLOR_BLACK, COLOR_BLUE);
     clear ();
     refresh ();
 }

--- a/src/cmd/top/top.c
+++ b/src/cmd/top/top.c
@@ -128,7 +128,11 @@ static flux_t *open_flux_instance (const char *target)
  */
 static void initialize_curses (void)
 {
+    char *cap;
     initscr ();
+    if (!(cap = tigetstr ("cup")) || cap == (char *) -1)
+        fatal (0, "terminal does not support required capabilities");
+
     curs_set (0); // make cursor disappear
 
     use_default_colors ();

--- a/src/cmd/top/top.c
+++ b/src/cmd/top/top.c
@@ -140,11 +140,69 @@ static void initialize_curses (void)
     refresh ();
 }
 
+int top_run (struct top *top, int reactor_flags)
+{
+    /*  Force curses to redraw screen in case we're calling top recursively.
+     *  (unsure why refresh() doesn't have same effect as wrefresh (curscr))
+     */
+    wrefresh (curscr);
+    return flux_reactor_run (flux_get_reactor (top->h), reactor_flags);
+}
+
 static const struct flux_msg_handler_spec htab[] = {
     { FLUX_MSGTYPE_EVENT, "job-state", job_state_cb, 0 },
     { FLUX_MSGTYPE_EVENT, "heartbeat.pulse", heartbeat_cb, 0 },
     FLUX_MSGHANDLER_TABLE_END,
 };
+
+void top_destroy (struct top *top)
+{
+    if (top) {
+        flux_watcher_destroy (top->refresh);
+        flux_watcher_destroy (top->jobtimer);
+        flux_msg_handler_delvec (top->handlers);
+        joblist_pane_destroy (top->joblist_pane);
+        summary_pane_destroy (top->summary_pane);
+        keys_destroy (top->keys);
+        flux_close (top->h);
+        free (top);
+    }
+}
+
+struct top *top_create (const char *uri)
+{
+    struct top *top = calloc (1, sizeof (*top));
+
+    if (!top || !(top->h = open_flux_instance (uri)))
+        goto fail;
+
+    flux_fatal_set (top->h, flux_fatal, &top);
+    top->refresh = flux_prepare_watcher_create (flux_get_reactor (top->h),
+                                                refresh_cb,
+                                                top);
+    top->jobtimer = flux_timer_watcher_create (flux_get_reactor (top->h),
+                                               0.,
+                                               0.,
+                                               jobtimer_cb,
+                                               top);
+    if (!top->refresh || !top->jobtimer)
+        goto fail;
+    flux_watcher_start (top->refresh);
+
+    if (flux_msg_handler_addvec (top->h, htab, top, &top->handlers) < 0)
+        goto fail;
+    if (flux_event_subscribe (top->h, "job-state") < 0
+        || flux_event_subscribe (top->h, "heartbeat.pulse") < 0)
+        fatal (errno, "error subscribing to events");
+
+    top->keys = keys_create (top);
+    top->summary_pane = summary_pane_create (top);
+    top->joblist_pane = joblist_pane_create (top);
+    return top;
+fail:
+    top_destroy (top);
+    return NULL;
+}
 
 static struct optparse_option cmdopts[] = {
     { .name = "test-exit", .has_arg = 0, .flags = OPTPARSE_OPT_HIDDEN,
@@ -158,70 +216,42 @@ static const char *usage_msg = "[OPTIONS] [TARGET]";
 int main (int argc, char *argv[])
 {
     int optindex;
-    struct top top;
+    struct top *top;
     int reactor_flags = 0;
     const char *target = NULL;
-
-    memset (&top, 0, sizeof (top));
-    top.id = FLUX_JOBID_ANY;
+    optparse_t *opts;
 
     setlocale (LC_ALL, "");
 
-    if (!(top.opts = optparse_create ("flux-top"))
-        || optparse_add_option_table (top.opts, cmdopts) != OPTPARSE_SUCCESS
-        || optparse_set (top.opts,
+    if (!(opts = optparse_create ("flux-top"))
+        || optparse_add_option_table (opts, cmdopts) != OPTPARSE_SUCCESS
+        || optparse_set (opts,
                          OPTPARSE_USAGE,
                          usage_msg) != OPTPARSE_SUCCESS)
         fatal (0, "error setting up option parsing");
 
-    if ((optindex = optparse_parse_args (top.opts, argc, argv)) < 0)
+    if ((optindex = optparse_parse_args (opts, argc, argv)) < 0)
         exit (1);
     if (optindex < argc)
         target = argv[optindex++];
     if (optindex != argc) {
-        optparse_print_usage (top.opts);
+        optparse_print_usage (opts);
         exit (1);
     }
-    top.h = open_flux_instance (target);
-    flux_fatal_set (top.h, flux_fatal, &top);
-    if (!(top.refresh = flux_prepare_watcher_create (flux_get_reactor (top.h),
-                                                     refresh_cb,
-                                                     &top))
-        || !(top.jobtimer = flux_timer_watcher_create (flux_get_reactor (top.h),
-                                                       0.,
-                                                       0.,
-                                                       jobtimer_cb,
-                                                       &top)))
-        fatal (errno, "could not create timers");
-    flux_watcher_start (top.refresh);
-
-    if (flux_msg_handler_addvec (top.h, htab, &top, &top.handlers) < 0)
-        fatal (errno, "error registering message handlers");
-    if (flux_event_subscribe (top.h, "job-state") < 0
-        || flux_event_subscribe (top.h, "heartbeat.pulse") < 0)
-        fatal (errno, "error subscribing to events");
-
     if (!isatty (STDIN_FILENO))
         fatal (0, "stdin is not a terminal");
     initialize_curses ();
-    top.keys = keys_create (&top);
-    top.summary_pane = summary_pane_create (&top);
-    top.joblist_pane = joblist_pane_create (&top);
 
-    if (optparse_hasopt (top.opts, "test-exit"))
+    if (!(top = top_create (target)))
+        fatal (errno, "failed to initialize top");
+    if (optparse_hasopt (opts, "test-exit"))
         reactor_flags |= FLUX_REACTOR_ONCE;
-    if (flux_reactor_run (flux_get_reactor (top.h), reactor_flags) < 0)
+    if (top_run (top, reactor_flags) < 0)
         fatal (errno, "reactor loop unexpectedly terminated");
 
-    flux_watcher_destroy (top.refresh);
-    flux_watcher_destroy (top.jobtimer);
-    flux_msg_handler_delvec (top.handlers);
-    joblist_pane_destroy (top.joblist_pane);
-    summary_pane_destroy (top.summary_pane);
-    keys_destroy (top.keys);
     endwin ();
-    flux_close (top.h);
-    optparse_destroy (top.opts);
+    top_destroy (top);
+    optparse_destroy (opts);
     return 0;
 }
 

--- a/src/cmd/top/top.h
+++ b/src/cmd/top/top.h
@@ -21,6 +21,8 @@ int mvwprintw(WINDOW *win, int y, int x, const char *fmt, ...)
 enum {
     TOP_COLOR_YELLOW = 1,
     TOP_COLOR_RED = 2,
+    TOP_COLOR_BLUE = 3,
+    TOP_COLOR_BLUE_HIGHLIGHT = 4,
 };
 
 struct top {
@@ -60,6 +62,8 @@ void joblist_pane_destroy (struct joblist_pane *sum);
 void joblist_pane_draw (struct joblist_pane *sum);
 void joblist_pane_refresh (struct joblist_pane *sum);
 void joblist_pane_query (struct joblist_pane *sum);
+void joblist_pane_set_current (struct joblist_pane *joblist, bool next);
+void joblist_pane_enter (struct joblist_pane *joblist);
 
 struct keys *keys_create (struct top *top);
 void keys_destroy (struct keys *keys);

--- a/src/cmd/top/top.h
+++ b/src/cmd/top/top.h
@@ -29,7 +29,6 @@ struct top {
     flux_t *h;
     char *title;
     flux_jobid_t id;
-    uint32_t userid;
     uint32_t size;
     struct summary_pane *summary_pane;
     struct joblist_pane *joblist_pane;

--- a/src/cmd/top/top.h
+++ b/src/cmd/top/top.h
@@ -35,7 +35,6 @@ struct top {
     flux_watcher_t *jobtimer;
     bool jobtimer_running;
     flux_msg_handler_t **handlers;
-    optparse_t *opts;
 };
 
 struct dimension {
@@ -44,6 +43,10 @@ struct dimension {
     int x_length;
     int y_length;
 };
+
+struct top *top_create (const char *uri);
+void top_destroy (struct top *top);
+int top_run (struct top *top, int reactor_flags);
 
 struct summary_pane *summary_pane_create (struct top *top);
 void summary_pane_destroy (struct summary_pane *sum);

--- a/src/cmd/top/top.h
+++ b/src/cmd/top/top.h
@@ -27,6 +27,7 @@ enum {
 
 struct top {
     flux_t *h;
+    char *title;
     flux_jobid_t id;
     uint32_t userid;
     uint32_t size;
@@ -46,7 +47,7 @@ struct dimension {
     int y_length;
 };
 
-struct top *top_create (const char *uri);
+struct top *top_create (const char *uri, const char *prefix);
 void top_destroy (struct top *top);
 int top_run (struct top *top, int reactor_flags);
 

--- a/src/common/libutil/uri.c
+++ b/src/common/libutil/uri.c
@@ -11,6 +11,7 @@
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -28,6 +29,14 @@ static void nullify_newline (char *str)
     }
 }
 
+static char *uri_to_local (struct yuarel *yuri)
+{
+    char *uri = NULL;
+    if (asprintf (&uri, "local:///%s", yuri->path) < 0)
+        return NULL;
+    return uri;
+}
+
 char *uri_resolve (const char *uri)
 {
     struct popen2_child *child = NULL;
@@ -41,8 +50,12 @@ char *uri_resolve (const char *uri)
     if (yuarel_parse (&yuri, cpy) == 0 && yuri.scheme) {
         if (strcmp (yuri.scheme, "ssh") == 0
             || strcmp (yuri.scheme, "local") == 0) {
+            if (getenv ("FLUX_URI_RESOLVE_LOCAL"))
+                result = uri_to_local (&yuri);
+            else
+                result = strdup (uri);
             free (cpy);
-            return strdup (uri);
+            return result;
         }
     }
     free (cpy);

--- a/t/scripts/runpty.py
+++ b/t/scripts/runpty.py
@@ -119,6 +119,7 @@ def parse_args():
     parser.add_argument(
         "-o", "--output", help="set output file. Default=stdout", default="-"
     )
+    parser.add_argument("--stderr", help="redirect stderr of process")
     parser.add_argument(
         "-f",
         "--format",
@@ -213,6 +214,10 @@ def main():
         """
         In child
         """
+        if args.stderr:
+            sys.stderr = open(args.stderr, "w")
+            os.dup2(sys.stderr.fileno(), 2)
+
         setwinsize(pty.STDIN_FILENO, height, width)
         os.execvp(args.COMMAND, [args.COMMAND, *args.ARGS])
     else:

--- a/t/scripts/runpty.py
+++ b/t/scripts/runpty.py
@@ -143,6 +143,12 @@ def parse_args():
         default=ws_default,
     )
     parser.add_argument(
+        "--term",
+        metavar="TERMINAL",
+        help=f"set value of TERM variable for client (default xterm)",
+        default="xterm",
+    )
+    parser.add_argument(
         "-c",
         "--quit-char",
         metavar="C",
@@ -237,6 +243,7 @@ def main():
             sys.stderr = open(args.stderr, "w")
             os.dup2(sys.stderr.fileno(), 2)
 
+        os.environ["TERM"] = args.term
         setwinsize(pty.STDIN_FILENO, height, width)
         os.execvp(args.COMMAND, [args.COMMAND, *args.ARGS])
     else:

--- a/t/t2801-top-cmd.t
+++ b/t/t2801-top-cmd.t
@@ -10,6 +10,8 @@ runpty="${SHARNESS_TEST_SRCDIR}/scripts/runpty.py"
 waitfile="${SHARNESS_TEST_SRCDIR}/scripts/waitfile.lua"
 testssh="${SHARNESS_TEST_SRCDIR}/scripts/tssh"
 
+export FLUX_URI_RESOLVE_LOCAL=t
+
 test_expect_success 'flux-top -h prints custom usage' '
 	flux top -h 2>usage &&
 	grep "Usage:.*TARGET" usage

--- a/t/t2801-top-cmd.t
+++ b/t/t2801-top-cmd.t
@@ -19,23 +19,24 @@ test_expect_success 'flux-top fails on unknown option' '
 	grep "unrecognized option" notopt.err
 '
 test_expect_success 'flux-top fails if FLUX_URI is set wrong' '
-	(FLUX_URI=noturi test_must_fail flux top) 2>baduri.err &&
+	(FLUX_URI=noturi test_must_fail $runpty -n --stderr=baduri.err flux top) &&
 	grep "connecting to Flux" baduri.err
 '
 test_expect_success 'flux-top fails if job argument is not a valid URI' '
-	test_must_fail flux top baduri 2>baduri.err &&
+	test_must_fail $runpty -n --stderr=baduri.err flux top baduri &&
 	test_debug "cat baduri.err" &&
 	grep "failed to resolve" baduri.err
 '
 test_expect_success 'flux-top fails if job argument is unknown' '
-	test_must_fail flux top 12345 2>unkjobid.err &&
+	test_must_fail $runpty -n --stderr=unkjobid.err flux top 12345 &&
 	grep "jobid 12345 not found" unkjobid.err
 '
 test_expect_success 'run a test job to completion' '
 	flux mini submit --wait -n1 flux start /bin/true >jobid
 '
 test_expect_success 'flux-top fails if job is not running' '
-	test_must_fail flux top $(cat jobid)?local 2>notrun.err &&
+	test_must_fail \
+		$runpty -n --stderr=notrun.err flux top $(cat jobid) &&
 	test_debug "cat notrun.err" &&
 	grep "jobid $(cat jobid) is not running" notrun.err
 '

--- a/t/t2801-top-cmd.t
+++ b/t/t2801-top-cmd.t
@@ -46,6 +46,10 @@ test_expect_success 'flux-top fails if stdin is not a tty' '
 	test_must_fail flux top --test-exit </dev/null 2>notty.err &&
 	grep "stdin is not a terminal" notty.err
 '
+test_expect_success 'flux-top fails if TERM is not supported' '
+	test_must_fail $runpty --term=dumb --stderr=dumb.err flux top &&
+	grep "terminal does not support required capabilities" dumb.err
+'
 test_expect_success 'flux-top --test-exit works with a pty' '
 	$runpty flux top --test-exit >/dev/null
 '


### PR DESCRIPTION
This started as an experiment but turned out to be useful, so posting it as a PR to get comments.

Now that instance URIs are available in job listing, add the `annotations` attribute to the `flux top` `job-list` query and have jobs that are instances colored blue (or made bold if there's no color support).

Introduce the idea of a current or "selected" job. The selection is made by traversing the `flux top` job listing with the `j` and `k` or arrow keys. The currently selected job is highlighted. On the "enter" key, `flux top` recursively calls itself on the currently selected job, if that job is an instance (nothing happens for a normal job).

Since the new function `top_run()` is called recursively, hitting the `q` key in the nested `top` call pops you back up to the previous job, while `Ctrl-c` still quits immediately.

This turns `flux top` into a very limited instance explorer:

It might be a little hard to follow, but here's a screencast of an example:

![test](https://user-images.githubusercontent.com/741970/146470226-0f088343-6c8e-42a2-8a59-30aae10666a9.gif)

BTW, in order to assist in testing this there's a couple underlying enhancements

 * A new `FLUX_URI_RESOLVE_LOCAL` environment variable causes `uri_resolve()` and `flux uri` to always return the `local://` equivalent of URIs.
 * The `runpty.py` script was given a `--input` option which reads input in asciicast v2 format and feeds it the child pty. The cast above in fact was created from the following input:
   ```json
   { "version": 2 }
   [2.00, "i", "j"]
   [2.50, "i", "j"]
   [2.80, "i", "j"]
   [3.50, "i", "\n"]
   [3.55, "i", "\\x0c"]
   [3.80, "i", "j"]
   [5.00, "i", "\n"]
   [5.05, "i", "\\x0c"]
   [7.00, "i", "q"]
   [7.05, "i", "\\x0c"]
   [9.00, "i", "q"]
   [9.05, "i", "\\x0c"]
   [9.55, "i", "k"]
   [10.0, "i", "\n"]
   [10.05, "i", "\\x0c"]
   [12.50, "i", "q"]
   [12.55, "i", "\\x0c"]
   [14.0, "i", "q"]
   ```