### PR TITLE
cmd/flux-jobs: re-work -A option and clarify -a option

### DIFF
--- a/doc/man1/flux-jobs.rst
+++ b/doc/man1/flux-jobs.rst
@@ -24,12 +24,11 @@ OPTIONS
 =======
 
 **-a**
-   List all jobs of the current user, including inactive jobs.
-   Equivalent to specifying *--filter=pending,running,inactive*.
+   List jobs in all states, including inactive jobs.
+   This is shorthand for *--filter=pending,running,inactive*.
 
 **-A**
-   List all jobs from all users, including inactive jobs. Equivalent to
-   specifying *--filter=pending,running,inactive --user=all*.
+   List jobs of all users. This is shorthand for *--user=all*.
 
 **-n, --suppress-header**
    For default output, do not output column headers.

--- a/src/cmd/flux-jobs.py
+++ b/src/cmd/flux-jobs.py
@@ -107,11 +107,10 @@ def fetch_jobs_flux(args, fields):
     if args.color == "always" or args.color == "auto":
         attrs.update(fields2attrs["result"])
 
-    if args.a:
-        args.user = str(os.getuid())
     if args.A:
         args.user = str(flux.constants.FLUX_USERID_UNKNOWN)
-    if args.a or args.A:
+
+    if args.a:
         args.filter = "pending,running,inactive"
 
     jobs_rpc = JobList(
@@ -184,9 +183,7 @@ def parse_args():
         prog="flux-jobs", formatter_class=flux.util.help_formatter()
     )
     # -a equivalent to -s "pending,running,inactive" and -u set to userid
-    parser.add_argument(
-        "-a", action=FilterTrueAction, help="List all jobs for current user"
-    )
+    parser.add_argument("-a", action=FilterTrueAction, help="List jobs in all states")
     # -A equivalent to -s "pending,running,inactive" and -u set to "all"
     parser.add_argument(
         "-A", action=FilterTrueAction, help="List all jobs for all users"

--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -159,7 +159,7 @@ test_expect_success 'flux-jobs -a and -A works' '
 	nall=$(state_count all) &&
 	count=`flux jobs --suppress-header -a | wc -l` &&
 	test $count -eq $nall &&
-	count=`flux jobs --suppress-header -a | wc -l` &&
+	count=`flux jobs --suppress-header -A | wc -l` &&
 	test $count -eq $nall
 '
 

--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -159,7 +159,7 @@ test_expect_success 'flux-jobs -a and -A works' '
 	nall=$(state_count all) &&
 	count=`flux jobs --suppress-header -a | wc -l` &&
 	test $count -eq $nall &&
-	count=`flux jobs --suppress-header -A | wc -l` &&
+	count=`flux jobs --suppress-header -a -A | wc -l` &&
 	test $count -eq $nall
 '
 


### PR DESCRIPTION
Per #3993 

- make `-A` option be a convenience for `--user=all` and nothing else.  This allows `-A` to be used alongside `--filter`.
- re-word documentation that `-a` lists jobs in all states.  The documentation that it lists all jobs for the current user is redundant b/c the current user is always the default.  It is basically now a shortcut for `--filter=pending,running,inactive`
- as a result, `flux jobs -a -A` may be commonly used as a shortcut for listing all jobs, in all states, for all users