### PR TITLE
libflux: check reactor flags

### DIFF
--- a/src/cmd/builtin/proxy.c
+++ b/src/cmd/builtin/proxy.c
@@ -278,7 +278,7 @@ static int cmd_proxy (optparse_t *p, int ac, char *av[])
     free (uri);
     flux_log_set_appname (ctx.h, "proxy");
     ctx.proxy_user = getuid ();
-    if (!(r = flux_reactor_create (SIGCHLD)))
+    if (!(r = flux_reactor_create (FLUX_REACTOR_SIGCHLD)))
         log_err_exit ("flux_reactor_create");
     if (flux_set_reactor (ctx.h, r) < 0)
         log_err_exit ("flux_set_reactor");

--- a/src/common/libflux/test/reactor.c
+++ b/src/common/libflux/test/reactor.c
@@ -1350,6 +1350,17 @@ static void reactor_destroy_early (void)
     flux_watcher_destroy (w);
 }
 
+static void test_reactor_flags (flux_reactor_t *r)
+{
+    errno = 0;
+    ok (flux_reactor_run (r, 0xffff) < 0 && errno == EINVAL,
+        "flux_reactor_run flags=0xffff fails with EINVAL");
+
+    errno = 0;
+    ok (flux_reactor_create (0xffff) == NULL && errno == EINVAL,
+        "flux_reactor_create flags=0xffff fails with EINVAL");
+}
+
 int main (int argc, char *argv[])
 {
     flux_reactor_t *reactor;
@@ -1375,6 +1386,7 @@ int main (int argc, char *argv[])
     test_child (reactor);
     test_stat (reactor);
     test_active_ref (reactor);
+    test_reactor_flags (reactor);
 
     flux_reactor_destroy (reactor);
 


### PR DESCRIPTION
I happened to notice that `flux proxy` is calling `flux_reactor_create (SIGCHLD)`  but the flag should be `FLUX_REACTOR_SIGCHLD`.

Fix that, and add flag validation to `flux_reactor_create()` and `flux_reactor_run()`.