### PR TITLE
fix segfault in uri_resolve() when argument has "/" prefix

### DIFF
--- a/src/common/libutil/uri.c
+++ b/src/common/libutil/uri.c
@@ -38,7 +38,7 @@ char *uri_resolve (const char *uri)
     char *cpy = strdup (uri);
     if (!cpy)
         return NULL;
-    if (yuarel_parse (&yuri, cpy) == 0) {
+    if (yuarel_parse (&yuri, cpy) == 0 && yuri.scheme) {
         if (strcmp (yuri.scheme, "ssh") == 0
             || strcmp (yuri.scheme, "local") == 0) {
             free (cpy);

--- a/t/t1105-proxy.t
+++ b/t/t1105-proxy.t
@@ -108,6 +108,11 @@ test_expect_success 'flux-proxy works with jobid argument' '
 	flux job wait-event -t 10 $id memo &&
 	uri=$(flux proxy $id?local flux getattr parent-uri) &&
 	test_debug "echo flux proxy $id flux getattr parent-uri = $uri" &&
+	test "$uri" = "$FLUX_URI"
+'
+test_expect_success 'flux-proxy works with /jobid argument' '
+	uri=$(flux proxy /$id?local flux getattr parent-uri) &&
+	test_debug "echo flux proxy $id flux getattr parent-uri = $uri" &&
 	test "$uri" = "$FLUX_URI" &&
 	flux job cancel $id &&
 	flux job wait-event -vt 10 $id clean


### PR DESCRIPTION
This PR fixes an embarrassing error in the `uri_resolve()` implementation which causes `flux proxy /JOBID` to segfault. :facepalm:

For a minute, I thought it would be cool if `/` resolved to the depth=0 instance (root) in the current hierarchy, and if we also supported `..` as "look in parent", but I'm pretty sure we don't want to go there, so `/JOBID` is treated the same as `JOBID`.