### PR TITLE
flux-jobs: add --recursive option

### DIFF
--- a/doc/man1/flux-jobs.rst
+++ b/doc/man1/flux-jobs.rst
@@ -71,6 +71,19 @@ OPTIONS
 
    All other options are ignored when ``--stats-only`` is used. 
 
+**-R, --recursive**
+   List jobs recursively. Each child job which is also an instance of
+   Flux is prefixed by its jobid "path" followed by the list of jobs,
+   recursively up to any defined ``-L, --level``. If the ``--stats``
+   option is used, then each child instance in the hierararchy is listed
+   with its stats.
+
+**-L, --level**\ *=N*
+   With ``-R, --recursive``, stop recursive job listing at level **N**.
+   Levels are counted starting at 0, so ``flux jobs -R --level=0`` is
+   equivalent to ``flux jobs`` without ``-R``, and ``--level=1`` would
+   limit recursive job listing to child jobs of the current instance.
+
 
 JOB STATUS
 ==========

--- a/src/bindings/python/flux/job/info.py
+++ b/src/bindings/python/flux/job/info.py
@@ -19,6 +19,7 @@ from collections import namedtuple
 import flux.constants
 from flux.memoized_property import memoized_property
 from flux.job.JobID import JobID
+from flux.uri import JobURI
 from flux.core.inner import raw
 
 
@@ -186,6 +187,12 @@ class JobInfo:
         if tleft < 0.0:
             return 0.0
         return tleft
+
+    @memoized_property
+    def uri(self):
+        if str(self.user.uri):
+            return JobURI(self.user.uri)
+        return None
 
     @property
     def t_remaining(self):
@@ -395,6 +402,8 @@ class JobInfoFormat(flux.util.OutputFormat):
         "sched.reason_pending": "REASON",
         "sched.resource_summary": "RESOURCES",
         "user": "USER",
+        "uri": "URI",
+        "uri.local": "URI",
     }
 
     def __init__(self, fmt):

--- a/src/bindings/python/flux/uri/resolvers/jobid.py
+++ b/src/bindings/python/flux/uri/resolvers/jobid.py
@@ -10,6 +10,7 @@
 
 from pathlib import PurePath
 
+import os
 import flux
 from flux.job import JobID, job_list_id
 from flux.uri import URIResolverPlugin, URIResolverURI, JobURI
@@ -66,6 +67,6 @@ class URIResolver(URIResolverPlugin):
 
     def resolve(self, uri):
         force_local = False
-        if "local" in uri.query_dict:
+        if "local" in uri.query_dict or "FLUX_URI_RESOLVE_LOCAL" in os.environ:
             force_local = True
         return self._do_resolve(uri, flux.Flux(), force_local=force_local)

--- a/src/bindings/python/flux/uri/uri.py
+++ b/src/bindings/python/flux/uri/uri.py
@@ -8,6 +8,7 @@
 # SPDX-License-Identifier: LGPL-3.0
 ###############################################################
 
+import os
 import platform
 import re
 from abc import ABC, abstractmethod
@@ -59,6 +60,8 @@ class JobURI(URI):
       local: If a remote URI, convert to a local URI. Otherwise return the URI.
     """
 
+    force_local = os.environ.get("FLUX_URI_RESOLVE_LOCAL", False)
+
     def __init__(self, uri):
         super().__init__(uri)
         if self.scheme == "":
@@ -96,6 +99,8 @@ class JobURI(URI):
         return self.local_uri
 
     def __str__(self):
+        if self.force_local:
+            return self.local
         return self.uri
 
 

--- a/src/cmd/flux-jobs.py
+++ b/src/cmd/flux-jobs.py
@@ -109,6 +109,7 @@ def fetch_jobs_flux(args, fields, flux_handle=None):
 
     if args.color == "always" or args.color == "auto":
         attrs.update(fields2attrs["result"])
+        attrs.update(fields2attrs["annotations"])
     if args.recursive:
         attrs.update(fields2attrs["annotations"])
         attrs.update(fields2attrs["status"])
@@ -291,6 +292,9 @@ def color_setup(args, job):
                 sys.stdout.write("\033[37m")
             elif job.result == "TIMEOUT":
                 sys.stdout.write("\033[01;31m")
+            return True
+        if job.uri:
+            sys.stdout.write("\033[01;34m")
             return True
     return False
 

--- a/src/cmd/flux-jobs.py
+++ b/src/cmd/flux-jobs.py
@@ -89,6 +89,8 @@ def fetch_jobs_flux(args, fields):
         # Special cases, pointers to sub-dicts in annotations
         "sched": ("annotations",),
         "user": ("annotations",),
+        "uri": ("annotations",),
+        "uri.local": ("annotations",),
     }
 
     attrs = set()

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -174,6 +174,7 @@ TESTSCRIPTS = \
 	t2702-mini-alloc.t \
 	t2703-mini-bulksubmit.t \
 	t2800-jobs-cmd.t \
+	t2800-jobs-recursive.t \
 	t2801-top-cmd.t \
 	t2802-uri-cmd.t \
 	t2900-job-timelimits.t \

--- a/t/t2800-jobs-recursive.t
+++ b/t/t2800-jobs-recursive.t
@@ -1,0 +1,68 @@
+#!/bin/sh
+
+test_description='Test flux jobs command with --recursive'
+
+. $(dirname $0)/sharness.sh
+
+test_under_flux 2 job
+
+export FLUX_URI_RESOLVE_LOCAL=t
+runpty="${SHARNESS_TEST_SRCDIR}/scripts/runpty.py --line-buffer -f asciicast"
+waitfile="${SHARNESS_TEST_SRCDIR}/scripts/waitfile.lua"
+
+#  Start a child instance that immediately exits, so that we can test
+#   that `flux jobs -R` doesn't error on child instances that are no
+#   longer running.
+#
+#  Then, start a job hiearachy with 2 child instances, each of which
+#   run a sleep job, touch a ready.<id> file, then block waiting for
+#   the sleep job to finish.
+#
+test_expect_success 'start a recursive job' '
+	id=$(flux mini submit flux start /bin/true) &&
+	rid=$(flux mini submit -n2 \
+		flux start \
+		flux mini submit --wait --cc=1-2 flux start \
+			"flux mini submit sleep inf && \
+			 touch ready.\$FLUX_JOB_CC && \
+			 flux queue idle") &&
+	flux job wait-event $id clean
+'
+blue_line_count() {
+        grep -c -o "\\u001b\[01\;34m" $1 || true
+}
+test_expect_success 'instance jobs are highlighted in blue' '
+	$runpty -o jobs.cast flux jobs  &&
+	test $(blue_line_count jobs.cast) -eq 1
+'
+test_expect_success 'wait for hierarchy to be ready' '
+	flux getattr broker.pid &&
+	$waitfile -t 60 ready.1 &&
+	$waitfile -t 60 ready.2
+'
+test_expect_success 'flux jobs --recursive works' '
+	flux jobs --recursive > recursive.out &&
+	test_debug "cat recursive.out" &&
+	test $(grep -c : recursive.out) -eq 3
+'
+test_expect_success 'flux jobs -o {id} --recursive works' '
+	flux jobs -o {id.f58} --recursive > recursive-o.out &&
+	test_debug "cat recursive.out" &&
+	test $(grep -c : recursive.out) -eq 3
+'
+test_expect_success 'flux jobs --recursive --stats works' '
+	flux jobs --recursive --stats > recursive-stats.out &&
+	test_debug "cat recursive-stats.out" &&
+	test $(grep -c running recursive-stats.out) -eq 4
+'
+test_expect_success 'flux jobs --recursive --level  works' '
+	flux jobs --recursive --level=1 >recursive-level.out &&
+	test_debug "cat recursive-level.out" &&
+	test $(grep -c : recursive-level.out) -eq 1
+'
+test_expect_success 'flux jobs --recursive JOBID works' '
+	flux jobs --recursive $rid > recursive-jobid.out &&
+	test_debug "cat recursive.out" &&
+	test $(grep -c : recursive-jobid.out) -eq 3
+'
+test_done


### PR DESCRIPTION
This PR adds a very simple `-R, --recursive` option to `flux-jobs` which lists child jobs recursively.

Similar to `ls -R`, when listing recursive jobs, each child instance of Flux is prefixed with its "path", which also happens to be a suitable jobid URI for use with `flux-uri` (and thus `flux-proxy(1)` and `flux-top(1)`).

If `--stats` is given, then the jobid path is also accompanied by that job's statistics.

A `-L, --level=N` option can be used to stop the recursion at a defined depth.

As part of this work, a convenience `uri` property was introduced for `JobInfo` objects, along with support for listing `{uri}` and `{uri.local}` attributes in `flux-jobs`.

Finally, in keeping with the visual cue introduced recently in `flux-top(1)` running jobs which are also instances of Flux are now colored blue in `flux-jobs(1)` output.

Example:

```console
$ flux jobs
       JOBID USER     NAME       ST NTASKS NNODES  RUNTIME NODELIST
  ƒD4Z3ADV9H grondo   flux        R      2      1   6.974m asp

$ flux jobs -Rf running
       JOBID USER     NAME       ST NTASKS NNODES  RUNTIME NODELIST
  ƒD4Z3ADV9H grondo   flux        R      2      1    7.08m asp

ƒD4Z3ADV9H:
     ƒdRdMaQ grondo   flux        R      1      1   7.044m asp
     ƒdRdMaP grondo   flux        R      1      1   7.044m asp

ƒD4Z3ADV9H/ƒdRdMaQ:
     ƒSWaeF9 grondo   flux        R      1      1   7.016m asp
     ƒSV6exo grondo   flux        R      1      1   7.016m asp

ƒD4Z3ADV9H/ƒdRdMaQ/ƒSWaeF9:
     ƒSZYcoq grondo   flux        R      1      1   6.987m asp

ƒD4Z3ADV9H/ƒdRdMaQ/ƒSWaeF9/ƒSZYcoq:
     ƒT5CNSj grondo   flux        R      1      1   6.958m asp

ƒD4Z3ADV9H/ƒdRdMaQ/ƒSWaeF9/ƒSZYcoq/ƒT5CNSj:
     ƒTQUD7D grondo   flux        R      1      1   6.928m asp

ƒD4Z3ADV9H/ƒdRdMaQ/ƒSWaeF9/ƒSZYcoq/ƒT5CNSj/ƒTQUD7D:
     ƒU3Xu9q grondo   flux        R      1      1   6.899m asp

ƒD4Z3ADV9H/ƒdRdMaQ/ƒSWaeF9/ƒSZYcoq/ƒT5CNSj/ƒTQUD7D/ƒU3Xu9q:
     ƒSyGRKM grondo   flux        R      1      1    6.87m asp

ƒD4Z3ADV9H/ƒdRdMaQ/ƒSWaeF9/ƒSZYcoq/ƒT5CNSj/ƒTQUD7D/ƒU3Xu9q/ƒSyGRKM:
    ƒ2gN1qQT grondo   sleep       R      1      1   0.033s asp

ƒD4Z3ADV9H/ƒdRdMaQ/ƒSV6exo:
     ƒm6Pe7q grondo   flux        R      1      1   6.965m asp

ƒD4Z3ADV9H/ƒdRdMaQ/ƒSV6exo/ƒm6Pe7q:
     ƒnGb55h grondo   flux        R      1      1    6.91m asp

ƒD4Z3ADV9H/ƒdRdMaQ/ƒSV6exo/ƒm6Pe7q/ƒnGb55h:
     ƒnVvxco grondo   flux        R      1      1   6.855m asp

ƒD4Z3ADV9H/ƒdRdMaQ/ƒSV6exo/ƒm6Pe7q/ƒnGb55h/ƒnVvxco:
     ƒoaCSTH grondo   flux        R      1      1   6.798m asp

ƒD4Z3ADV9H/ƒdRdMaQ/ƒSV6exo/ƒm6Pe7q/ƒnGb55h/ƒnVvxco/ƒoaCSTH:
     ƒnw8kQf grondo   flux        R      1      1   6.742m asp

ƒD4Z3ADV9H/ƒdRdMaQ/ƒSV6exo/ƒm6Pe7q/ƒnGb55h/ƒnVvxco/ƒoaCSTH/ƒnw8kQf:
    ƒ3djD1oU grondo   sleep       R      1      1   0.332s asp

ƒD4Z3ADV9H/ƒdRdMaP:
     ƒSjvXnF grondo   flux        R      1      1   7.016m asp

ƒD4Z3ADV9H/ƒdRdMaP/ƒSjvXnF:
     ƒqhFQqu grondo   flux        R      1      1   6.962m asp

ƒD4Z3ADV9H/ƒdRdMaP/ƒSjvXnF/ƒqhFQqu:
     ƒrLK6tX grondo   flux        R      1      1   6.906m asp

ƒD4Z3ADV9H/ƒdRdMaP/ƒSjvXnF/ƒqhFQqu/ƒrLK6tX:
     ƒrSF41u grondo   flux        R      1      1    6.85m asp

ƒD4Z3ADV9H/ƒdRdMaP/ƒSjvXnF/ƒqhFQqu/ƒrLK6tX/ƒrSF41u:
     ƒrLK6tX grondo   flux        R      1      1   6.794m asp

ƒD4Z3ADV9H/ƒdRdMaP/ƒSjvXnF/ƒqhFQqu/ƒrLK6tX/ƒrSF41u/ƒrLK6tX:
     ƒqx5HfM grondo   flux        R      1      1   6.737m asp

ƒD4Z3ADV9H/ƒdRdMaP/ƒSjvXnF/ƒqhFQqu/ƒrLK6tX/ƒrSF41u/ƒrLK6tX/ƒqx5HfM:
    ƒ4hjryTu grondo   sleep       R      1      1   0.380s asp


$ flux jobs -Rf running -L2 --stats
1 running, 10 completed, 6 failed, 0 pending
       JOBID USER     NAME       ST NTASKS NNODES  RUNTIME NODELIST
  ƒD4Z3ADV9H grondo   flux        R      2      1   7.434m asp

ƒD4Z3ADV9H:
2 running, 0 completed, 0 failed, 1 pending
     ƒdRdMaQ grondo   flux        R      1      1   7.398m asp
     ƒdRdMaP grondo   flux        R      1      1   7.398m asp

ƒD4Z3ADV9H/ƒdRdMaQ:
2 running, 0 completed, 0 failed, 0 pending
     ƒSWaeF9 grondo   flux        R      1      1   7.369m asp
     ƒSV6exo grondo   flux        R      1      1   7.369m asp

ƒD4Z3ADV9H/ƒdRdMaP:
1 running, 0 completed, 0 failed, 1 pending
     ƒSjvXnF grondo   flux        R      1      1   7.369m asp
```