### PR TITLE
doc: add flux-resource(1),  clean up help output

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -34,7 +34,8 @@ MAN1_FILES_PRIMARY = \
 	man1/flux-jobs.1 \
 	man1/flux-shell.1 \
 	man1/flux-jobtap.1 \
-	man1/flux-uri.1
+	man1/flux-uri.1 \
+	man1/flux-resource.1
 
 # These files are generated as clones of a primary page.
 # Sphinx handles this automatically if declared in the conf.py

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -170,6 +170,7 @@ man_pages = [
     ('man1/flux-jobs', 'flux-jobs', 'list jobs submitted to Flux', [author], 1),
     ('man1/flux-jobtap', 'flux-jobtap', 'List, remove, and load job-manager plugins', [author], 1),
     ('man1/flux-uri', 'flux-uri', 'resolve Flux URIs', [author], 1),
+    ('man1/flux-resource', 'flux-resource', 'list/manipulate Flux resource status', [author], 1),
     ('man1/flux-keygen', 'flux-keygen', 'generate keys for Flux security', [author], 1),
     ('man1/flux-kvs', 'flux-kvs', 'Flux key-value store utility', [author], 1),
     ('man1/flux-logger', 'flux-logger', 'create a Flux log entry', [author], 1),

--- a/doc/man1/flux-broker.rst
+++ b/doc/man1/flux-broker.rst
@@ -1,5 +1,3 @@
-.. flux-help-description: Invoke Flux message broker daemon
-
 ==============
 flux-broker(1)
 ==============

--- a/doc/man1/flux-content.rst
+++ b/doc/man1/flux-content.rst
@@ -1,6 +1,3 @@
-.. flux-help-command: content
-.. flux-help-description: Access instance content storage
-
 ===============
 flux-content(1)
 ===============

--- a/doc/man1/flux-event.rst
+++ b/doc/man1/flux-event.rst
@@ -1,5 +1,3 @@
-.. flux-help-include: true
-
 =============
 flux-event(1)
 =============

--- a/doc/man1/flux-getattr.rst
+++ b/doc/man1/flux-getattr.rst
@@ -1,4 +1,4 @@
-.. flux-help-command: get,set,lsattr
+.. flux-help-command: {get,set,ls}attr
 .. flux-help-description: Access, modify, and list broker attributes
 
 ===============

--- a/doc/man1/flux-hwloc.rst
+++ b/doc/man1/flux-hwloc.rst
@@ -1,6 +1,3 @@
-.. flux-help-command: hwloc
-.. flux-help-description: Control/query resource-hwloc service
-
 =============
 flux-hwloc(1)
 =============

--- a/doc/man1/flux-keygen.rst
+++ b/doc/man1/flux-keygen.rst
@@ -1,5 +1,3 @@
-.. flux-help-include: true
-
 ==============
 flux-keygen(1)
 ==============

--- a/doc/man1/flux-logger.rst
+++ b/doc/man1/flux-logger.rst
@@ -1,5 +1,3 @@
-.. flux-help-include: true
-
 ==============
 flux-logger(1)
 ==============

--- a/doc/man1/flux-module.rst
+++ b/doc/man1/flux-module.rst
@@ -1,5 +1,3 @@
-.. flux-help-include: true
-
 ==============
 flux-module(1)
 ==============

--- a/doc/man1/flux-resource.rst
+++ b/doc/man1/flux-resource.rst
@@ -1,0 +1,138 @@
+.. flux-help-include: true
+
+================
+flux-resource(1)
+================
+
+
+SYNOPSIS
+========
+
+**flux** **resource** *COMMAND* [*OPTIONS*]
+
+DESCRIPTION
+===========
+
+flux-resource(1) lists and manipulates Flux resources.  The resource inventory
+is maintained and monitored by the resource service.  The scheduler acquires
+a subset of resources from the resource service to allocate to jobs, and relies
+on the resource service to inform it of status changes that affect the
+usability of resources by jobs as described in RFC 27.
+
+The flux-resource(1) **list** subcommand queries the scheduler for its view
+of resources, including allocated/free status.
+
+The other flux-resource(1) subcommands operate on the resource service and
+are primarily of interest to system administrators of a Flux system instance.
+For example, they can show whether or not a node is booted, and may be used to
+administratively drain and undrain nodes.
+
+A few notes on drained nodes:
+
+- While a node is drained, the scheduler will not allocate it to jobs.
+- The act of draining a node does not affect running jobs.
+- When an instance is restarted, drained nodes remain drained.
+- The scheduler may determine that a job request is *feasible* if the total
+  resource set, including drained nodes, would allow it to run.
+
+Some further background on resource service operation may be found in the
+RESOURCE INVENTORY section below.
+
+
+COMMANDS
+========
+
+**list** [-v] [-n] [-o FORMAT] [-s STATE,...]
+   Show scheduler view of resources.  One or more *-v,--verbose* options
+   increase output verbosity.  *-n,--no-header* suppresses header from output.
+   *-o,--format=FORMAT*, customizes output formatting (see below).
+   *-s,--states=STATE,...* limits output to specified resource states, where
+   valid states are "up", "down", "allocated", "free", and "all".  Note that
+   the scheduler represents "offline", "exclude", and "drain" resource states
+   as "down" due to its simplified interface with the resource service defined
+   by RFC 27.
+
+**status**  [-v] [-n] [-o FORMAT] [-s STATE,...]
+   Show system view of resources.  One or more *-v,--verbose* options
+   increase output verbosity.  *-n,--no-header* suppresses header from output.
+   *-o,--format=FORMAT*, customizes output formatting (see below).
+   *-s,--states=STATE,...* limits output to specified resource states, where
+   valid states are "online", "offline", "avail", "exclude", "drain", and "all".
+   This command is restricted to the Flux instance owner.
+
+**drain** [targets] [reason ...]
+   If specified without arguments, list drained nodes.  The *targets* argument
+   is an IDSET or HOSTLIST specifying nodes to drain.  Any remaining arguments
+   are assumed to be a reason to be recorded with the drain event.  This
+   command is restricted to the Flux instance owner.
+
+**undrain** targets
+   The *targets* argument is an IDSET or HOSTLIST specifying nodes to undrain.
+   This command is restricted to the Flux instance owner.
+
+**reload** [-x] [-f] PATH
+   Reload the resource inventory from a file in RFC 20 format, or if the
+   *-x,--xml* option, a directory of hlwoc ``<rank>.xml`` files.  If
+   *-f,--force*, resources may contain invalid ranks.  This command is
+   primarily used in test.
+
+
+OUTPUT FORMAT
+=============
+
+The *--format* option can be used to specify an output format using Python's
+string format syntax.  See :man1:`flux-jobs` for a detailed description of
+this syntax.
+
+
+RESOURCE INVENTORY
+==================
+
+The Flux instance's inventory of resources is managed by the resource service,
+which determines the set of available resources through one of three
+mechanisms:
+
+configuration
+   Resources are read from a config file in RFC 20 (R version 1) format.
+   This mechanism is typically used in a system instance of Flux.
+
+enclosing instance
+   Resources are assigned by the enclosing Flux instance.  The assigned
+   resources are read from the job's ``R`` key in the enclosing instance KVS.
+
+dynamic discovery
+   Resources are aggregated from the set of resources reported by hwloc
+   on each broker.
+
+Once the inventory has been determined, it is stored the KVS ``resource.R``
+key, in RFC 20 (R version 1) format.
+
+Events that affect the availability of resources are posted to the KVS
+*resource.eventlog*.  Such events include:
+
+resource-define
+   The resource inventory is defined with an initial set of drained, online,
+   and excluded nodes.
+
+drain
+   One or more nodes are administratively removed from scheduling.
+
+undrain
+   One or more nodes are no longer drained.
+
+offline
+   One or more nodes are removed from scheduling due to unavailability,
+   e.g. node was shutdown or crashed.
+
+online
+   One or more nodes are no longer offline.
+
+
+RESOURCES
+=========
+
+Flux: http://flux-framework.org
+
+RFC 20: Resource Set Specification Version 1: https://github.com/flux-framework/rfc/blob/master/spec_22.rst
+
+RFC 27: Flux Resource Allocation Protocol Version 1: https://github.com/flux-framework/rfc/blob/master/spec_27.rst

--- a/doc/man1/flux.rst
+++ b/doc/man1/flux.rst
@@ -72,10 +72,6 @@ setenv FLUX_CONNECTOR_PATH
       [getenv FLUX_CONNECTOR_PATH_PREPEND]:install-path:\
         [getenv FLUX_CONNECTOR_PATH]
 
-setenv FLUX_SEC_DIRECTORY
-   Set directory for Flux CURVE keys. This is not a search path.
-   If unset, flux(1) sets it to $HOME/flux.
-
 setenv LUA_PATH
    Set Lua module search path:
 

--- a/doc/man1/index.rst
+++ b/doc/man1/index.rst
@@ -24,6 +24,7 @@ man1
    flux-module
    flux-ping
    flux-proxy
+   flux-resource
    flux-start
    flux-shell
    flux-uri

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,3 +1,3 @@
 sphinx==3.4.3
-sphinx-rtd-theme==0.5.1
+sphinx-rtd-theme>=0.5.2
 docutils>=0.14,<0.18

--- a/src/cmd/flux.c
+++ b/src/cmd/flux.c
@@ -71,6 +71,9 @@ void usage (optparse_t *p)
 
     optparse_print_usage (p);
     fprintf (stderr, "\n");
+    fprintf (stderr, "For general Flux documentation, please visit\n");
+    fprintf (stderr, "    https://flux-framework.readthedocs.io\n");
+    fprintf (stderr, "\n");
     emit_command_help (help_pattern, stderr);
     free (help_pattern);
 }


### PR DESCRIPTION
As discussed in #4000, `flux help` prints some commands that are probably not going to be very popular.  Drop those from the output, and add a reference to our [readthedocs documentation](https://flux-framework.readthedocs.io).  Also add a missing `flux-resource(1)` man page.  There are others but that one seemed egregious. 

After these changes, output is:
```
$ flux help
Usage: flux [OPTIONS] COMMAND ARGS
  -h, --help             Display this message.
  -v, --verbose          Be verbose about environment and command search
  -V, --version          Display command and component versions
  -p, --parent           Set environment of parent instead of current instance

Common commands from flux-core:
   cron               Schedule tasks on timers and events
   dmesg              manipulate broker log ring buffer
   env                Print the flux environment or execute a command inside it
   exec               Execute processes across flux ranks
   {get,set,ls}attr   Access, modify, and list broker attributes
   jobs               list jobs submitted to Flux
   resource           list/manipulate Flux resource status
   kvs                Flux key-value store utility
   mini               Minimal Job Submission Tool
   job                Job Housekeeping Tool
   ping               measure round-trip latency to Flux services
   proxy              Create proxy environment for Flux instance
   start              bootstrap a local Flux instance
   version            Display flux version information

See also: https://flux-framework.readthedocs.io
```