### PR TITLE
flux-jobs: support instance-specific fields in output

### DIFF
--- a/doc/man1/flux-jobs.rst
+++ b/doc/man1/flux-jobs.rst
@@ -294,6 +294,34 @@ The field names that can be specified are:
    short hand for *annotations.user*
 
 
+Field names which are specific to jobs which are also instances of Flux
+include:
+
+**instance.stats**
+   a short string describing current job statistics for the instance of
+   the form ``PD:{pending} R:{running} CD:{successful} F:{failed}``
+
+**instance.stats.total**
+   total number of jobs in any state in the instance.
+
+**instance.utilization**
+   number of cores currently allocated divided by the total number of cores.
+   Can be formatted as a percentage with ``!P``, e.g.
+   ``{instance.utilization!P:>4}``.
+
+**instance.gpu_utilization**
+   same as ``instance.utilization`` but for gpu resources
+
+**instance.progress**
+   number of inactive jobs divided by the total number of jobs.
+   Can be formatted as a percentage with ``{instance.progress!P:>4}``
+
+**instance.resources.<state>.{ncores,ngpus}**
+   number of cores, gpus in state ``state``, where ``state`` can be
+   ``all``, ``up``, ``down``, ``allocated``, or ``free``, e.g.
+   ``{instance.resources.all.ncores}``
+
+
 EXAMPLES
 ========
 

--- a/doc/man1/flux-jobs.rst
+++ b/doc/man1/flux-jobs.rst
@@ -141,10 +141,14 @@ the following conversion flags are supported by *flux-jobs*:
    convert a duration in floating point seconds to Flux Standard Duration (FSD).
    string.  Defaults to empty string if duration field does not exist.
 
-
 **!H**
    convert a duration to hours:minutes:seconds form (e.g. *{runtime!H}*).
    Defaults to empty string if duration field does not exist.
+
+**!P**
+   convert a floating point number into a percentage fitting in 4 characters
+   including the "%" character. E.g. 0.5 becomes "50%" 0.015 becomes 1.5%,
+   etc.
 
 Annotations can be retrieved via the *annotations* field name.
 Specific keys and sub-object keys can be retrieved separated by a

--- a/src/bindings/python/flux/Makefile.am
+++ b/src/bindings/python/flux/Makefile.am
@@ -37,6 +37,7 @@ nobase_fluxpy_PYTHON = \
 	resource/__init__.py \
 	resource/ResourceSetImplementation.py \
 	resource/ResourceSet.py \
+	resource/list.py \
 	hostlist.py \
 	idset.py \
 	progress.py \

--- a/src/bindings/python/flux/job/info.py
+++ b/src/bindings/python/flux/job/info.py
@@ -419,6 +419,19 @@ class JobInfoFormat(flux.util.OutputFormat):
                         value = ""
                     else:
                         raise
+            elif conv == "P":
+                #  Convert a floating point to percentage
+                try:
+                    value = value * 100
+                    if value < 100:
+                        value = f"{value:.2g}%"
+                    else:
+                        value = f"{value:3.0f}%"
+                except (TypeError, ValueError):
+                    if orig_value == "":
+                        value = ""
+                    else:
+                        raise
             else:
                 value = super().convert_field(value, conv)
             return value

--- a/src/bindings/python/flux/job/info.py
+++ b/src/bindings/python/flux/job/info.py
@@ -59,6 +59,29 @@ class ExceptionInfo:
         self.note = note
 
 
+class EmptyObject:
+    """Convenience "empty" object for use with string.format
+
+    This class can be used in place of a real class but returns
+    appropriate empty or unset value for various conversions, or
+    for string.format() calls.
+    """
+
+    def __getattr__(self, attr):
+        return EmptyObject()
+
+    def __repr__(self):
+        return ""
+
+    def __str__(self):
+        return ""
+
+    def __format__(self, spec):
+        # Strip trailing specifier (e.g. d, f)
+        spec = spec.rstrip("bcdoxXeEfFgGn%")
+        return "".__format__(spec)
+
+
 # AnnotationsInfo is a wrapper for a namedtuple.  We need this
 # object so that we can we detect when an attribute is missing and
 # ultimately return an empty string (e.g. when an attribute does not
@@ -86,9 +109,10 @@ class AnnotationsInfo:
         try:
             return object.__getattribute__(self.atuple, attr)
         except AttributeError:
-            # We return an empty AnnotationsInfo so that we can recursively
+            # We return an empty object so that we can recursively
             # handle errors.  e.g. annotations.user.illegal.illegal.illegal
-            return AnnotationsInfo({})
+            return EmptyObject()
+
 
 
 class InfoList(list):

--- a/src/bindings/python/flux/job/info.py
+++ b/src/bindings/python/flux/job/info.py
@@ -191,7 +191,7 @@ class JobInfo:
             raise AttributeError
         try:
             return getattr(self, "_{0}".format(attr))
-        except KeyError:
+        except (KeyError, AttributeError):
             raise AttributeError("invalid JobInfo attribute '{}'".format(attr))
 
     def get_runtime(self):

--- a/src/bindings/python/flux/job/info.py
+++ b/src/bindings/python/flux/job/info.py
@@ -19,6 +19,8 @@ from collections import namedtuple
 import flux.constants
 from flux.memoized_property import memoized_property
 from flux.job.JobID import JobID
+from flux.job.stats import JobStats
+from flux.resource import SchedResourceList
 from flux.uri import JobURI
 from flux.core.inner import raw
 
@@ -114,6 +116,66 @@ class AnnotationsInfo:
             return EmptyObject()
 
 
+class StatsInfo(JobStats):
+    """Extend JobStats with default __repr__"""
+
+    def __init__(self, handle=None):
+        super().__init__(handle)
+
+    def __repr__(self):
+        return (
+            f"PD:{self.pending} R:{self.running} "
+            f"CD:{self.successful} F:{self.failed}"
+        )
+
+    def __format__(self, fmt):
+        return str(self).__format__(fmt)
+
+
+class InstanceInfo:
+    def __init__(self, uri=None):
+        self.initialized = False
+        try:
+            if not uri:
+                raise ValueError
+            handle = flux.Flux(str(uri))
+            future = handle.rpc("sched.resource-status")
+            self.stats = StatsInfo(handle).update_sync()
+            self.resources = SchedResourceList(future.get())
+            self.initialized = True
+            return
+        except (ValueError, OSError, FileNotFoundError):
+            self.stats = EmptyObject()
+            self.resources = EmptyObject()
+
+    @memoized_property
+    def utilization(self):
+        if self.initialized and self.resources.all.ncores:
+            res = self.resources
+            return res.allocated.ncores / res.all.ncores
+        return ""
+
+    @memoized_property
+    def gpu_utilization(self):
+        if self.initialized and self.resources.all.ngpus > 0:
+            res = self.resources
+            return res.allocated.ngpus / res.all.ngpus
+        return ""
+
+    @memoized_property
+    def progress(self):
+        if self.initialized:
+            stats = self.stats
+            if stats.total == 0:
+                return ""
+            return stats.inactive / stats.total
+        return ""
+
+    def __getattr__(self, attr):
+        if not self.initialized:
+            return ""
+        return self.__getattribute__(attr)
+
 
 class InfoList(list):
     """Extend list with string representation appropriate for JobInfo format"""
@@ -193,6 +255,13 @@ class JobInfo:
             return getattr(self, "_{0}".format(attr))
         except (KeyError, AttributeError):
             raise AttributeError("invalid JobInfo attribute '{}'".format(attr))
+
+    def get_instance_info(self):
+        if self.uri and self.state_single == "R":  # pylint: disable=W0143
+            setattr(self, "_instance", InstanceInfo(self.uri))
+        else:
+            setattr(self, "_instance", InstanceInfo())
+        return self
 
     def get_runtime(self):
         if self.t_cleanup > 0 and self.t_run > 0:
@@ -428,6 +497,25 @@ class JobInfoFormat(flux.util.OutputFormat):
         "user": "USER",
         "uri": "URI",
         "uri.local": "URI",
+        "instance.stats.total": "NJOBS",
+        "instance.utilization": "CPU%",
+        "instance.gpu_utilization": "GPU%",
+        "instance.progress": "PROG",
+        "instance.resources.all.ncores": "CORES",
+        "instance.resources.all.ngpus": "GPUS",
+        "instance.resources.all.nnodes": "NODES",
+        "instance.resources.up.ncores": "UP",
+        "instance.resources.up.ngpus": "UP",
+        "instance.resources.up.nnodes": "UP",
+        "instance.resources.down.ncores": "DOWN",
+        "instance.resources.down.ngpus": "DOWN",
+        "instance.resources.down.nnodes": "DOWN",
+        "instance.resources.allocated.ncores": "USED",
+        "instance.resources.allocated.ngpus": "USED",
+        "instance.resources.allocated.nnodes": "USED",
+        "instance.resources.free.ncores": "FREE",
+        "instance.resources.free.ngpus": "FREE",
+        "instance.resources.free.nnodes": "FREE",
     }
 
     def __init__(self, fmt):
@@ -450,6 +538,12 @@ class JobInfoFormat(flux.util.OutputFormat):
                     self.headings[field] = field_heading
                 elif field.startswith("sched.") or field.startswith("user."):
                     field_heading = field.upper()
+                    self.headings[field] = field_heading
+                elif field.startswith("instance."):
+                    field_heading = field[9:].upper()
+                    #  Shorten RESOURCES. headings
+                    if field_heading.startswith("RESOURCES."):
+                        field_heading = field_heading[10:]
                     self.headings[field] = field_heading
         super().__init__(self.headings, fmt, prepend="0.")
 

--- a/src/bindings/python/flux/resource/__init__.py
+++ b/src/bindings/python/flux/resource/__init__.py
@@ -10,3 +10,4 @@
 
 from flux.resource.Rlist import Rlist
 from flux.resource.ResourceSet import ResourceSet
+from flux.resource.list import resource_list, SchedResourceList

--- a/src/bindings/python/flux/resource/list.py
+++ b/src/bindings/python/flux/resource/list.py
@@ -1,0 +1,70 @@
+###############################################################
+# Copyright 2021 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+from flux.resource import ResourceSet
+from flux.rpc import RPC
+from flux.memoized_property import memoized_property
+
+
+class SchedResourceList:
+    """
+    Encapsulate response from sched.resource-status query.
+    The response will contain 3 Rv1 resource sets:
+        "all"       - all resources known to scheduler
+        "down"      - resources currently unavailable (drained or down)
+        "allocated" - resources currently allocated to jobs
+
+    From these sets, the "up" and "free" resource sets are
+    computed on-demand.
+
+    """
+
+    def __init__(self, resp):
+        for state in ["all", "down", "allocated"]:
+            rset = ResourceSet(resp.get(state))
+            rset.state = state
+            setattr(self, f"_{state}", rset)
+
+    def __getattr__(self, attr):
+        if attr.startswith("_"):
+            raise AttributeError
+        try:
+            return getattr(self, f"_{attr}")
+        except KeyError:
+            raise AttributeError(f"Invalid SchedResourceList attr {attr}")
+
+    #  Make class subscriptable, e.g. resources[state]
+    def __getitem__(self, item):
+        return getattr(self, item)
+
+    @memoized_property
+    # pylint: disable=invalid-name
+    def up(self):
+        res = self.all - self.down
+        res.state = "up"
+        return res
+
+    @memoized_property
+    def free(self):
+        res = self.up - self.allocated
+        res.state = "free"
+        return res
+
+
+class ResourceListRPC(RPC):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def get(self):
+        return SchedResourceList(super().get())
+
+
+def resource_list(flux_handle):
+    return ResourceListRPC(flux_handle, "sched.resource-status")

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -175,6 +175,7 @@ TESTSCRIPTS = \
 	t2703-mini-bulksubmit.t \
 	t2800-jobs-cmd.t \
 	t2800-jobs-recursive.t \
+	t2800-jobs-instance-info.t \
 	t2801-top-cmd.t \
 	t2802-uri-cmd.t \
 	t2900-job-timelimits.t \

--- a/t/t2800-jobs-instance-info.t
+++ b/t/t2800-jobs-instance-info.t
@@ -1,0 +1,69 @@
+#!/bin/sh
+
+test_description='Test flux jobs command with instance.* attributes'
+
+. $(dirname $0)/sharness.sh
+
+test_under_flux 4 job
+
+export FLUX_URI_RESOLVE_LOCAL=t
+waitfile="${SHARNESS_TEST_SRCDIR}/scripts/waitfile.lua"
+
+#  Launch some test instance jobs with varying characteristics
+#
+#  1. Launch a job that exits immediately so we have a completed instance
+#
+#  2. Launch an instance job that then submits 4 sleep jobs, touches a
+#     file so we know when the jobs have been submitted, and waits for
+#     all jobs to complete (essentially forever)
+#
+#  3. Start a normal job to ensure instance info is blank for non-instance
+#     jobs.
+#
+test_expect_success 'start a set of Flux instances' '
+	id=$(flux mini submit flux start /bin/true) &&
+	id2=$(flux mini submit -n2 -c1 flux start \
+		"flux mini run /bin/false ; \
+		 flux mini submit --cc=1-4 sleep inf && \
+		 touch ready && \
+		 flux queue idle") &&
+	flux mini submit sleep 600 &&
+	flux job wait-event $id clean &&
+	$waitfile -t 60 ready
+'
+test_expect_success 'flux-jobs can get instance info' "
+	flux jobs -ao '{id.f58:>12} {instance.stats:^25} {instance.utilization!P:>4} {instance.gpu_utilization!P:>4}' > jobs.out &&
+	test_debug 'cat jobs.out'
+"
+test_expect_success 'flux-jobs -o {instance.stats} worked' '
+	grep F:1 jobs.out
+'
+test_expect_success 'flux-jobs {instance.utilization!P} works as expected' "
+	flux jobs -ano \
+		'{instance.utilization!P},{instance.utilization!P:h}' \
+		> jobs-P.out &&
+	cat >jobs-P.expected <<-EOF &&
+	,-
+	100%,100%
+	,-
+	EOF
+	test_cmp jobs-P.expected jobs-P.out
+"
+test_expect_success 'flux-jobs instance fields empty for completed job' '
+	grep $id jobs.out > completed.out &&
+	grep "$id  *$" completed.out
+'
+test_expect_success 'flux-jobs instance headers work' '
+	cat >headers.expected <<-EOF &&
+	       JOBID           STATS           CPU% GPU%
+	EOF
+	head -n1 jobs.out >headers &&
+	test_cmp headers.expected headers
+'
+test_expect_success 'flux-jobs {instance.stats.total} works' '
+	test $(flux jobs -no {instance.stats.total} $id2) = 5
+'
+test_expect_success 'flux-jobs {instance.progress} works' '
+	test $(flux jobs -no {instance.progress:.1f} $id2) = 0.2
+'
+test_done


### PR DESCRIPTION
This PR adds a small set of `instance.` fields to the `JobInfo` class, and therefore also to `flux-jobs` output

By default, the extra information is not fetched for `JobInfo` objects. Instead a new class method `.get_instance_info()` is added which can optionally be run to fetch Flux instance data if the job is indeed an instance, and if the job is currently running.

The instance-specific data is encapsulated in a new `InstanceInfo` class, which currently contains `JobStats` and `SchedResourceList` objects at the time the data was fetched. The class also provides some possibly useful high-level attributes including:

 * `instance.utilization`: the number of cores used divided by the total number of cores in the instance
 * `instance.gpu_utilization`: same as above but for GPU resources, if any
 * `instance.progress`: number of inactive jobs divided by the total number of jobs
 * `instance.stats`: returns a string job stats summary of the form `PD:N R:N CD:N F:N`, where `PD` is pending job count, `R` is running job count, `CD` is number of successfully completed jobs and `F` is number of failed jobs.

To assist in output of percentage based fields like `instance.utilization` and `instance.progress`, a new
conversion character `P` is added that converts a floating-point number to a percentage. (See below for examples)

In `flux-jobs`, the extra instance info is only fetched if any requested field starts with `instance.`

e.g.:

```console
$ flux jobs -Rf running -o '{id.f58:>12} {instance.stats:^26} {instance.progress!P:>4h} {instance.resources.all.ncores:>5} {instance.utilization!P:>4}'
       JOBID           STATS            PROG CORES CPU%
    ƒ3tuqfCB     PD:2 R:1 CD:0 F:0        0%     1 100%

ƒ3tuqfCB:
     ƒTXt9Ww     PD:0 R:1 CD:0 F:0        0%     1 100%

ƒ3tuqfCB/ƒTXt9Ww:
     ƒT5CNSj   PD:678 R:1 CD:321 F:0     32%     1 100%

ƒ3tuqfCB/ƒTXt9Ww/ƒT5CNSj:
    ƒ2dnH5wj                               -           
```

While working on this PR, I noticed while testing in a multi-user instance that `flux jobs -R` is slow when there are multi-user jobs on the system and `-A` is used. This is because the command will try to recurse all instance jobs, not just those for the current user, and it does so serially, which when is slow when `flux_open(3)` fails for other users' jobs.

That is fixed here by:

 * Do not recurse into other users' jobs  by default. This can be disabled by using a new `--recurse-all` option.
 * Update flux-jobs to use a ThreadPoolExecutor when querying instance info or recursing. This does indeed speed up the fetch of sub-job listing or instance info since timeouts or other errors can occur in parallel. A new `--threads=N` option is provided in case the default ThreadPool max workers needs to be adjusted.

I could move these latter fixes to a separate PR if requested.
