### PR TITLE
flux-jobs: improve recursive job listing

### DIFF
--- a/doc/man1/flux-jobs.rst
+++ b/doc/man1/flux-jobs.rst
@@ -91,6 +91,14 @@ OPTIONS
    equivalent to ``flux jobs`` without ``-R``, and ``--level=1`` would
    limit recursive job listing to child jobs of the current instance.
 
+**--threads**\ *=N*
+   When ``flux jobs`` recursively queries job lists (with ``--recursive``)
+   or fetches info for jobs that are also instances (see
+   ``instance.*`` fields), a pool of threads is used to parallelize
+   the required RPCs. Normally, the default number of ThreadPoolExecutor
+   threads is used, but by using the ``--threads``, a specific number
+   of threads can be chosen.
+
 
 JOB STATUS
 ==========

--- a/doc/man1/flux-jobs.rst
+++ b/doc/man1/flux-jobs.rst
@@ -78,6 +78,13 @@ OPTIONS
    option is used, then each child instance in the hierararchy is listed
    with its stats.
 
+**--recurse-all**
+   By default, jobs not owned by the user running ``flux jobs`` are
+   skipped with ``-R, --recursive``, because normally Flux instances
+   only permit the instance owner to connect. This option forces the
+   command to attempt to recurse into the jobs of other users.  Implies
+   ``--recursive``.
+
 **-L, --level**\ *=N*
    With ``-R, --recursive``, stop recursive job listing at level **N**.
    Levels are counted starting at 0, so ``flux jobs -R --level=0`` is

--- a/src/cmd/flux-jobs.py
+++ b/src/cmd/flux-jobs.py
@@ -139,7 +139,7 @@ def fetch_jobs_flux(args, fields, flux_handle=None):
     jobs = jobs_rpc.jobs()
 
     if get_instance_info:
-        with concurrent.futures.ThreadPoolExecutor() as executor:
+        with concurrent.futures.ThreadPoolExecutor(args.threads) as executor:
             concurrent.futures.wait(
                 [executor.submit(job.get_instance_info) for job in jobs]
             )
@@ -278,6 +278,12 @@ def parse_args():
         + "not just jobs of current user",
     )
     parser.add_argument(
+        "--threads",
+        type=int,
+        metavar="N",
+        help="Set max number of worker threads",
+    )
+    parser.add_argument(
         "--stats", action="store_true", help="Print job statistics before header"
     )
     parser.add_argument(
@@ -368,7 +374,7 @@ def print_jobs(jobs, args, formatter, path="", level=0):
     args.jobids = None
 
     futures = []
-    with concurrent.futures.ThreadPoolExecutor() as executor:
+    with concurrent.futures.ThreadPoolExecutor(args.threads) as executor:
         for job in children:
             futures.append(
                 executor.submit(get_jobs_recursive, job, args, formatter.fields)


### PR DESCRIPTION
This PR makes some improvements to recursive job listing by

 * only attempting to recurse into current user's jobs by default, unless `--recurse-all` is used.
 * connect and fetch all child job info in parallel using a ThreadPoolExecutor. A new `--threads` option is added to optionally adjust the `max_workers` value for this recursive jobs as well as instance-info gathering ThreadPools.

This is based on top of #4022 