### PR TITLE
add flux-pstree command

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -32,6 +32,7 @@ MAN1_FILES_PRIMARY = \
 	man1/flux-job.1 \
 	man1/flux-version.1 \
 	man1/flux-jobs.1 \
+	man1/flux-pstree.1 \
 	man1/flux-shell.1 \
 	man1/flux-jobtap.1 \
 	man1/flux-uri.1 \

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -168,6 +168,7 @@ man_pages = [
     ('man1/flux-getattr', 'flux-getattr', 'access broker attributes', [author], 1),
     ('man1/flux-hwloc', 'flux-hwloc', 'Control/query resource-hwloc service', [author], 1),
     ('man1/flux-jobs', 'flux-jobs', 'list jobs submitted to Flux', [author], 1),
+    ('man1/flux-pstree', 'flux-pstree', 'display job hierarchies', [author], 1),
     ('man1/flux-jobtap', 'flux-jobtap', 'List, remove, and load job-manager plugins', [author], 1),
     ('man1/flux-uri', 'flux-uri', 'resolve Flux URIs', [author], 1),
     ('man1/flux-resource', 'flux-resource', 'list/manipulate Flux resource status', [author], 1),

--- a/doc/man1/flux-jobs.rst
+++ b/doc/man1/flux-jobs.rst
@@ -161,9 +161,9 @@ the following conversion flags are supported by *flux-jobs*:
    Defaults to empty string if duration field does not exist.
 
 **!P**
-   convert a floating point number into a percentage fitting in 4 characters
+   convert a floating point number into a percentage fitting in 5 characters
    including the "%" character. E.g. 0.5 becomes "50%" 0.015 becomes 1.5%,
-   etc.
+   and 0.0005 becomes 0.05% etc.
 
 Annotations can be retrieved via the *annotations* field name.
 Specific keys and sub-object keys can be retrieved separated by a

--- a/doc/man1/flux-jobs.rst
+++ b/doc/man1/flux-jobs.rst
@@ -394,3 +394,8 @@ RESOURCES
 =========
 
 Flux: http://flux-framework.org
+
+SEE ALSO
+========
+
+:man1:`flux-pstree`

--- a/doc/man1/flux-pstree.rst
+++ b/doc/man1/flux-pstree.rst
@@ -1,0 +1,233 @@
+.. flux-help-include: true
+
+==============
+flux-pstree(1)
+==============
+
+
+SYNOPSIS
+========
+
+**flux** **pstree** [*OPTIONS*] [JOBID ...]
+
+DESCRIPTION
+===========
+
+flux-pstree(1) displays a tree of running jobs by job name, similar to
+what the :linux:man1:`pstree` command does for system processes.
+
+Like pstree(1), identical leaves of the job tree are combined, which
+results in a more compact output when many jobs within a Flux instance
+share the same job name.
+
+The flux-pstree(1) command supports custom labels for jobs, including
+separately labeling parent jobs, using the same format string syntax
+supported by :man1:`flux-jobs`.
+
+The command lists actively running jobs by default, but a ``-a, --all``
+option lists all jobs in all states for the current user. In the case
+that ``-a`` is used, the job labels will automatically be amended to
+include the job status (i.e. ``{name}:{status_abbrev}``), though this
+can be overridden on the command line.
+
+The flux-pstree(1) command additionally supports listing extended
+job information before the tree display with the ``-x, --extended``,
+``-d, --details=NAME``, or ``--detail-format=FORMAT``  options, e.g.
+
+::
+
+  $ flux pstree -x
+       JOBID USER     ST NTASKS NNODES  RUNTIME
+  ƒJqUHUCzX9 user1     R      2      2   10.68s flux
+     ƒe1j54L user1     R      1      1   8.539s ├── flux
+     ƒuusNLo user1     R      1      1   5.729s │   ├── sleep
+     ƒutPP4T user1     R      1      1   5.731s │   └── sleep
+     ƒe1j54K user1     R      1      1   8.539s └── flux
+    ƒ2MYrwzf user1     R      1      1   4.736s     └── sleep
+
+Several detail formats are available via the ``-d, --details=NAME``
+option, including progree, resources, and stats. For example, the
+``progress`` display attempts to show the overall progress and
+utilization of all Flux instances in a hierarchy by displaying the
+total number of jobs in that instance (``NJOBS``), the "progress"
+(``PROG`` - inactive/finished jobs divided by total jobs), and
+core and GPU utilization (``CORE%`` and ``GPU%`` - number of used
+resources divided by total available resources):
+
+::
+
+  $ flux pstree --details=progress
+
+       JOBID NTASKS  NJOBS  PROG CORE%  GPU%    RUNTIME
+  ƒJqUHUCzX9      2      3    0% 37.5%          0:02:15 flux
+     ƒe1j54L      1   1000   23%  100%          0:02:13 ├── flux
+    ƒ2HmSnHd      1                             0:00:01 │   ├── sleep
+    ƒ2Hjxo1K      1                             0:00:01 │   └── sleep
+     ƒe1j54K      1   1000 11.5%  100%          0:02:13 └── flux
+    ƒ2b6cPMS      1                             0:00:01     └── sleep
+
+
+By default, flux-pstree(1) truncates lines that exceed the current
+value of the ``COLUMNS`` environment variable or the terminal width
+if ``COLUMNS`` is not set. To disable truncation, use the ``-l, --long``
+option.
+
+
+By default, the enclosing Flux instance, or root of the tree, is included
+in output, unless extended details are displayed as when any of the
+``-x, --extended``, ``-d, --details=NAME`` or ``--detail-format=FORMAT``
+options are used, or if one or more jobids are directly targetted with
+a ``JOBID`` argument. This behavior can be changed via the
+``--skip-root=[yes|no]`` option.
+
+
+OPTIONS
+=======
+
+**-a, --all**
+   Include jobs in all states, including inactive jobs.
+   This is shorthand for *--filter=pending,running,inactive*.
+
+**-c, --count**\ *=N*
+   Limit output to N jobs at every level (default 1000).
+
+**-f, --filter**\ *=STATE|RESULT*
+   Include jobs with specific job state or result. Multiple states or
+   results can be listed separated by comma. See the JOB STATUS section
+   of the :man1:`flux-jobs` manual for more detail.
+
+**-l, --long**
+   Do not truncate long lines at ``COLUMNS`` characters.
+
+**-p, --parent-ids**
+   Prepend jobid to parent labels.
+
+**-L, --level** *=N*
+   Only descend *N* levels of the job hierarchy.
+
+**-x, --extended**
+   Print extended details before tree output. This is the same as
+   ``--details=default``.
+
+**-d, --detail**\ *=NAME*
+   Select a named extended details format. The list of supported names
+   can be seen in ``flux pstree --help`` output.
+
+**-n, --no-header**
+   For output with extended details, do not print header row.
+
+**-X, --no-combine**
+   Typically, identical child jobs that are leaves in the tree display
+   are combined as ``n*[label]``. With this option, the combination of
+   like jobs is disabled.
+
+**-o, --label**\ *=FORMAT*
+   Specify output format for node labels using Python format strings.
+   Supports all format fields supported by :man1:`flux-jobs`.
+
+**--parent-label**\ *=FORMAT*
+   Label tree parents with a different format than child jobs.
+
+**--detail-format**\ *=FORMAT*
+   Specify an explicit details format to display before the tree part.
+   Care should be taken that each line of the format is the same width
+   to ensure that the tree display is rendered correctly (i.e. by judicious
+   use of format field widths, e.g. ``{id.f58:>12}`` instead of just
+   ``{id.f58}``.
+
+**--skip-root**\ *=yes|no*
+   Excplicitly skip (yes)  or force (no) display of the enclosing instance,
+   or root of the tree, in output.
+
+**-C, --compact**
+   Use compact tree connectors. Usefully for deep hieararchies.
+
+**--ascii**
+   Use ascii tree connectors.
+   
+
+EXAMPLES
+========
+
+The default output of flux-pstree(1) shows all running jobs for the
+current user by name, including any running sub-jobs. If there are
+currently no running jobs for the current user, only the enclosing
+instance is displayed as a ``.``, to indicate the root of the tree:
+
+::
+
+  $ flux pstree
+  .
+
+
+If there is a running job, it is displayed under the root instance,
+and includes all child jobs. Identical children are combined:
+
+::
+
+  $ flux pstree
+  .
+  └── flux
+      ├── flux
+      │   └── 2*[sleep]
+      └── flux
+          └── sleep
+  
+
+Extra information can be added to parents, which are instances of
+flux. For example, summary job stats can be easily added:
+
+::
+
+  $ flux pstree --skip-root=yes --parent-label='{name} {instance.stats}'
+  flux PD:1 R:2 CD:0 F:0
+  ├── flux PD:592 R:2 CD:406 F:0
+  │   └── 2*[sleep]
+  └── flux PD:794 R:1 CD:205 F:0
+      └── sleep
+  
+Or utilization:
+
+::
+
+  $ flux pstree --skip-root=yes \
+    --parent-label='cores={instance.resources.all.ncores} {instance.utilization!P}' \
+  cores=8 37.5%
+  ├── cores=2 100%
+  │   └── 2*[sleep]
+  └── cores=1 100%
+
+Displaying jobs in all states automatically adds the job *status* to the
+display, which offers a compact representation of the state of jobs
+throughout a hierarchy:
+
+::
+
+  $ flux pstree -a
+  .
+  ├── flux
+  │   ├── flux:PD
+  │   ├── flux
+  │   │   ├── 824*[sleep:PD]
+  │   │   ├── 2*[sleep:R]
+  │   │   └── 174*[sleep:CD]
+  │   └── flux
+  │       ├── 914*[sleep:PD]
+  │       ├── sleep:R
+  │       └── 85*[sleep:CD]
+  ├── flux:CA
+  ├── 36*[flux:CD]
+  ├── hostname:CA
+  └── hostname:CD
+  
+
+
+RESOURCES
+=========
+
+Flux: http://flux-framework.org
+
+SEE ALSO
+========
+
+:man1:`flux-jobs`

--- a/doc/man1/index.rst
+++ b/doc/man1/index.rst
@@ -24,6 +24,7 @@ man1
    flux-module
    flux-ping
    flux-proxy
+   flux-pstree
    flux-resource
    flux-start
    flux-shell

--- a/src/bindings/python/flux/job/info.py
+++ b/src/bindings/python/flux/job/info.py
@@ -423,10 +423,10 @@ class JobInfoFormat(flux.util.OutputFormat):
                 #  Convert a floating point to percentage
                 try:
                     value = value * 100
-                    if value < 100:
-                        value = f"{value:.2g}%"
+                    if 0 < value < 1:
+                        value = f"{value:.2f}%"
                     else:
-                        value = f"{value:3.0f}%"
+                        value = f"{value:.3g}%"
                 except (TypeError, ValueError):
                     if orig_value == "":
                         value = ""
@@ -511,7 +511,7 @@ class JobInfoFormat(flux.util.OutputFormat):
         "uri": "URI",
         "uri.local": "URI",
         "instance.stats.total": "NJOBS",
-        "instance.utilization": "CPU%",
+        "instance.utilization": "CORE%",
         "instance.gpu_utilization": "GPU%",
         "instance.progress": "PROG",
         "instance.resources.all.ncores": "CORES",

--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -72,7 +72,8 @@ dist_fluxcmd_SCRIPTS = \
 	flux-job-validator.py \
 	flux-job-exec-override.py \
 	flux-perilog-run.py \
-	flux-uri.py
+	flux-uri.py \
+	flux-pstree.py
 
 fluxcmd_PROGRAMS = \
 	flux-terminus \

--- a/src/cmd/flux-pstree.py
+++ b/src/cmd/flux-pstree.py
@@ -1,0 +1,490 @@
+##############################################################
+# Copyright 2021 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+##############################################################
+
+import sys
+import logging
+import argparse
+import concurrent.futures
+
+import flux
+import flux.uri
+from flux.util import Tree
+from flux.job import JobInfo, JobInfoFormat, JobList, JobID
+
+DETAILS_FORMAT = {
+    "default": (
+        "{id.f58:>12} {username:<8.8} {status_abbrev:>2.2} {ntasks:>6h}"
+        " {nnodes:>6h} {runtime!F:>8h}"
+    ),
+    "resources": (
+        "{id.f58:>12} "
+        "{instance.resources.all.nnodes:>5} "
+        "{instance.resources.allocated.nnodes:>5} "
+        "{instance.resources.all.ncores:>5} "
+        "{instance.resources.allocated.ncores:>5} "
+        "{instance.resources.all.ngpus:>5} "
+        "{instance.resources.allocated.ngpus:>5}"
+    ),
+    "progress": (
+        "{id.f58:>12} {ntasks:>6h} {instance.stats.total:>6} "
+        "{instance.progress!P:>5} {instance.utilization!P:>5} "
+        "{instance.gpu_utilization!P:>5} {runtime!H:>10}"
+    ),
+    "stats": "{id.f58:>12} {instance.stats:^25} {runtime!H:>10}",
+}
+
+LABEL_FORMAT = {
+    "default": "{name}",
+    "all": "{name}:{status_abbrev}",
+}
+PARENT_FORMAT = {
+    "default": "{name}",
+    "all": "{name}",
+}
+
+LOGGER = logging.getLogger("flux-pstree")
+
+
+class TreeFormatter:
+    """
+    Initialize formatters for Tree labels, parent labels, and optional
+    prefix
+    """
+
+    def __init__(self, args):
+
+        #  If -o, --label used, then also set parent label format:
+        if args.label and not args.parent_label:
+            args.parent_label = args.label
+
+        #  If -a, --all, then use "all" specific labels unless labels
+        #   were set explicitly:
+        if args.all:
+            if not args.label:
+                args.label = LABEL_FORMAT["all"]
+            if not args.parent_label:
+                args.parent_label = PARENT_FORMAT["all"]
+
+        #  O/w, set default labels:
+        if not args.label:
+            args.label = LABEL_FORMAT["default"]
+        if not args.parent_label:
+            args.parent_label = PARENT_FORMAT["default"]
+
+        #  For -p, --parent-ids, prepend jobid to parent labels:
+        if args.parent_ids:
+            args.parent_label = f"{{id.f58}} {args.parent_label}"
+
+        self.label = JobInfoFormat(args.label)
+        self.parent = JobInfoFormat(args.parent_label)
+
+        #  Set prefix format if -x, --details, or --prefix-format was used
+        self.prefix = None
+        if args.extended or args.details or args.prefix_format:
+            if not args.details:
+                args.details = "default"
+            if not args.prefix_format:
+                try:
+                    args.prefix_format = DETAILS_FORMAT[args.details]
+                except KeyError:
+                    LOGGER.error("Unknown --details format '%s'", args.details)
+                    sys.exit(1)
+            self.prefix = JobInfoFormat(args.prefix_format)
+
+    def format(self, job, parent):
+        """Format provided job label (as parent label if parent == True)"""
+        if parent:
+            return self.parent.format(job)
+        return self.label.format(job)
+
+    def format_prefix(self, job):
+        """Format Tree prefix if configured, otherwise return empty string"""
+        if self.prefix:
+            return self.prefix.format(job)
+        return ""
+
+
+def process_entry(entry, formatter, filters, level, max_level, combine):
+
+    job = JobInfo(entry).get_instance_info()
+
+    # pylint: disable=comparison-with-callable
+    parent = job.uri and job.state_single == "R"
+
+    label = formatter.format(job, parent)
+    prefix = formatter.format_prefix(job)
+
+    if not parent:
+        return Tree(label, prefix)
+    return load_tree(
+        label,
+        formatter,
+        prefix=prefix,
+        uri=str(job.uri),
+        filters=filters,
+        level=level + 1,
+        max_level=max_level,
+        combine_children=combine,
+    )
+
+
+# pylint: disable=too-many-locals
+def load_tree(
+    label,
+    formatter,
+    prefix="",
+    uri=None,
+    filters=None,
+    combine_children=True,
+    max_level=999,
+    level=0,
+    skip_root=True,
+    jobids=None,
+):
+
+    #  Only apply filters below root unless no_skip_root
+    orig_filters = filters
+    if filters is None or (level == 0 and skip_root):
+        filters = ["running"]
+
+    tree = Tree(label, prefix=prefix, combine_children=combine_children)
+    if level > max_level:
+        return tree
+
+    #  Attempt to load jobs from uri
+    #  This may fail if the instance hasn't loaded the job-list module
+    #   or if the current user is not owner
+    #
+    attrs = flux.job.list.VALID_ATTRS
+    try:
+        jobs = (
+            JobList(flux.Flux(uri), ids=jobids, filters=filters, attrs=attrs)
+            .fetch_jobs()
+            .get_jobs()
+        )
+    except (OSError, FileNotFoundError):
+        return tree
+
+    #  Since the executor cannot be used recursively, start one per
+    #   loop iteration. This is very wasteful but greatly speeds up
+    #   execution with even a moderate number of jobs using the ssh:
+    #   connector. At some point this should be replaced by a global
+    #   thread pool that can work with recursive execution.
+    #
+    executor = concurrent.futures.ThreadPoolExecutor()
+    futures = []
+    for entry in jobs:
+        futures.append(
+            executor.submit(
+                process_entry,
+                entry,
+                formatter,
+                orig_filters,
+                level,
+                max_level,
+                combine_children,
+            )
+        )
+
+    for future in futures:
+        tree.append_tree(future.result())
+
+    return tree
+
+
+class FilterAction(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        setattr(namespace, self.dest, values)
+        setattr(namespace, "filtered", True)
+
+
+# pylint: disable=redefined-builtin
+class FilterTrueAction(argparse.Action):
+    def __init__(
+        self,
+        option_strings,
+        dest,
+        const=True,
+        default=False,
+        required=False,
+        help=None,
+        metavar=None,
+    ):
+        super(FilterTrueAction, self).__init__(
+            option_strings=option_strings,
+            dest=dest,
+            nargs=0,
+            const=const,
+            default=default,
+            help=help,
+        )
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        setattr(namespace, self.dest, self.const)
+        setattr(namespace, "filtered", True)
+
+
+class YesNoAction(argparse.Action):
+    """Simple argparse.Action for options with yes|no arguments"""
+
+    def __init__(
+        self,
+        option_strings,
+        dest,
+        help=None,
+        metavar="[yes|no]",
+    ):
+        super().__init__(
+            option_strings=option_strings, dest=dest, help=help, metavar=metavar
+        )
+
+    def __call__(self, parser, namespace, value, option_string=None):
+        if value not in ["yes", "no"]:
+            raise ValueError(f"{option_string} requires either 'yes' or 'no'")
+        setattr(namespace, self.dest, value == "yes")
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        prog="flux-pstree", formatter_class=flux.util.help_formatter()
+    )
+    parser.add_argument(
+        "-a",
+        "--all",
+        action=FilterTrueAction,
+        help="Include all jobs for current user in all states",
+    )
+    parser.add_argument(
+        "-c",
+        "--count",
+        action=FilterAction,
+        type=int,
+        metavar="N",
+        default=1000,
+        help="Limit to N jobs per instance (default 1000)",
+    )
+    parser.add_argument(
+        "-f",
+        "--filter",
+        action=FilterAction,
+        type=str,
+        metavar="STATE|RESULT",
+        default="running",
+        help="list jobs with specific job state or result",
+    )
+    parser.add_argument(
+        "-x",
+        "--extended",
+        action="store_true",
+        help="print extended details before tree output",
+    )
+    parser.add_argument(
+        "-l",
+        "--long",
+        action="store_false",
+        dest="truncate",
+        help="do not truncate long lines to terminal width",
+    )
+    parser.add_argument(
+        "-L",
+        "--level",
+        type=int,
+        metavar="N",
+        default=999,
+        help="only descend N levels",
+    )
+    parser.add_argument(
+        "-p",
+        "--parent-ids",
+        action="store_true",
+        help="include jobids in parent labels",
+    )
+    parser.add_argument(
+        "-n",
+        "--no-header",
+        action="store_true",
+        help="Suppress header with -x, --extended",
+    )
+    parser.add_argument(
+        "-X",
+        "--no-combine",
+        action="store_false",
+        dest="combine_children",
+        help="disable combination of identical children",
+    )
+    parser.add_argument(
+        "-o",
+        "--label",
+        metavar="FORMAT",
+        help="change label format (default='{name}')",
+    )
+    parser.add_argument(
+        "--parent-label",
+        metavar="FORMAT",
+        help="change label format for parent only",
+    )
+    parser.add_argument(
+        "--detail-format",
+        metavar="FORMAT",
+        help="specify output format for extended details " + "(implies -x, --extended)",
+        dest="prefix_format",
+    )
+    parser.add_argument(
+        "-d",
+        "--details",
+        metavar="NAME",
+        help="Select a named extended details format ("
+        + ",".join(DETAILS_FORMAT.keys())
+        + ")",
+    )
+    parser.add_argument(
+        "-C",
+        "--compact",
+        action="store_true",
+        help="Use compact tree connectors",
+    )
+    parser.add_argument(
+        "--ascii",
+        action="store_true",
+        help="Use ASCII character tree connectors",
+    )
+    parser.add_argument(
+        "--skip-root",
+        action=YesNoAction,
+        help="suppress or include the enclosing instance in output. "
+        + "Default is 'no' unless the -x, --extended or -d, --details "
+        + "options are used.",
+    )
+    parser.add_argument(
+        "jobids",
+        metavar="JOBID",
+        type=JobID,
+        nargs="*",
+        help="Limit output to specific jobids",
+    )
+    parser.set_defaults(filtered=False)
+    return parser.parse_args()
+
+
+class RootJobID(JobID):
+    """Mock JobID class for pstree root (enclosing instance)
+
+    Replaces the encode method of the JobID class to always return ".",
+    so that normal `job.id.X` formatting always returns "." to indicate
+    root of our tree.
+    """
+
+    def __new__(cls):
+        return int.__new__(cls, 0)
+
+    # pylint: disable=no-self-use
+    # pylint: disable=unused-argument
+    def encode(self, encoding="dec"):
+        return "."
+
+
+def get_root_jobinfo():
+    """Fetch a mock JobInfo object for the current enclosing instance"""
+
+    handle = flux.Flux()
+    size = handle.attr_get("size")
+
+    try:
+        #  If the enclosing instance has a jobid and a parent-uri, then
+        #   fill in data from job-list in the parent:
+        #
+        jobid = JobID(handle.attr_get("jobid"))
+        parent = flux.Flux(handle.attr_get("parent-uri"))
+        info = JobList(parent, ids=[jobid]).fetch_jobs().get_jobs()[0]
+    except OSError:
+        #  Make a best-effort attempt to create a mock job info dictionary
+        uri = handle.attr_get("local-uri")
+        nodelist = handle.attr_get("hostlist")
+        userid = handle.attr_get("security.owner")
+        info = dict(
+            id=0,
+            userid=int(userid),
+            state=flux.constants.FLUX_JOB_STATE_RUN,
+            name=".",
+            ntasks=int(size),
+            nnodes=int(size),
+            nodelist=nodelist,
+            annotations={"user": {"uri": uri}},
+        )
+
+    #  If 'ranks' idset came from parent, it could be confusing,
+    #   rewrite ranks to be relative to current instance, i.e.
+    #   0-(size-1)
+    #
+    info["ranks"] = "0-{}".format(int(size) - 1)
+
+    #  Fetch instance-specific information for the current instance:
+    job = JobInfo(info).get_instance_info()
+
+    #  If no jobid was discovered for the root instance, use RootJobID()
+    if job.id == 0:
+        job.id = RootJobID()
+
+    return job
+
+
+@flux.util.CLIMain(LOGGER)
+def main():
+
+    sys.stdout = open(sys.stdout.fileno(), "w", encoding="utf8")
+
+    args = parse_args()
+    if args.jobids and args.filtered:
+        LOGGER.warning("filtering options ignored with jobid list")
+    if args.ascii and args.compact:
+        LOGGER.fatal("Choose only one of --ascii, --compact")
+
+    if args.all:
+        args.filter = "pending,running,inactive"
+
+    formatter = TreeFormatter(args)
+
+    #  Default for skip_root is True if there is a "prefix" format or
+    #   specific jobids are targetted, possibly overridden by the value of
+    #   --skip-root provided by user
+    #
+    skip_root = formatter.prefix is not None or args.jobids
+    if args.skip_root is not None:
+        skip_root = args.skip_root
+
+    if skip_root:
+        label = "."
+        prefix = None
+    else:
+        root = get_root_jobinfo()
+        label = formatter.format(root, True)
+        prefix = formatter.format_prefix(root)
+
+    tree = load_tree(
+        label,
+        formatter,
+        prefix=prefix,
+        filters=[args.filter],
+        max_level=args.level,
+        skip_root=skip_root,
+        combine_children=args.combine_children,
+        jobids=args.jobids,
+    )
+
+    if args.compact:
+        style = "compact"
+    elif args.ascii:
+        style = "ascii"
+    else:
+        style = "box"
+
+    if formatter.prefix and not args.no_header:
+        print(formatter.prefix.header())
+    tree.render(skip_root=skip_root, style=style, truncate=args.truncate)

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -217,6 +217,7 @@ TESTSCRIPTS = \
 	python/t0023-executor.py \
 	python/t0024-util.py \
 	python/t0025-uri.py \
+	python/t0026-tree.py \
 	python/t1000-service-add-remove.py
 
 if HAVE_FLUX_SECURITY

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -178,6 +178,7 @@ TESTSCRIPTS = \
 	t2800-jobs-instance-info.t \
 	t2801-top-cmd.t \
 	t2802-uri-cmd.t \
+	t2803-flux-pstree.t \
 	t2900-job-timelimits.t \
 	t3000-mpi-basic.t \
 	t3001-mpi-personalities.t \

--- a/t/python/t0026-tree.py
+++ b/t/python/t0026-tree.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+###############################################################
+# Copyright 2022 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+import io
+import os
+import sys
+import unittest
+import unittest.mock
+import platform
+import subflux  # To set up PYTHONPATH
+from pycotap import TAPTestRunner
+from flux.util import Tree
+
+
+class TestTree(unittest.TestCase):
+    @unittest.mock.patch("sys.stdout", new_callable=io.StringIO)
+    def assertTreeRender(
+        self,
+        tree,
+        mock_stdout,
+        style="box",
+        level=None,
+        skip_root=False,
+        truncate=True,
+        expected_output=None,
+    ):
+        tree.render(style=style, level=level, skip_root=skip_root, truncate=truncate)
+        self.assertEqual(mock_stdout.getvalue(), expected_output)
+
+    @classmethod
+    def setUpClass(self):
+        self.trees = []
+        for combine in [True, False]:
+            root = Tree("Root", combine_children=combine)
+            child = Tree("flux", combine_children=combine)
+            child.append("sleep")
+
+            child2 = child.append("flux")
+            child2.append("foo")
+            child2.append("bar")
+
+            child.append("sleep")
+            child.append("sleep")
+
+            root.append_tree(child)
+            root.append("sleep")
+            root.append("sleep")
+            root.append("sleep")
+            self.trees.append(root)
+
+    def test_create_tree(self):
+        for tree in self.trees:
+            self.assertIsNotNone(tree)
+
+    def test_render_not_combined(self):
+        expected_output = """\
+Root
+├── flux
+│   ├── sleep
+│   ├── flux
+│   │   ├── foo
+│   │   └── bar
+│   ├── sleep
+│   └── sleep
+├── sleep
+├── sleep
+└── sleep
+"""
+        self.assertTreeRender(self.trees[1], expected_output=expected_output)
+
+    def test_render_combined(self):
+        expected_output = """\
+Root
+├── flux
+│   ├── 3*[sleep]
+│   └── flux
+│       ├── foo
+│       └── bar
+└── 3*[sleep]
+"""
+        self.assertTreeRender(self.trees[0], expected_output=expected_output)
+
+    def test_render_skip_root(self):
+        expected_output = """\
+flux
+├── 3*[sleep]
+└── flux
+    ├── foo
+    └── bar
+3*[sleep]
+"""
+        self.assertTreeRender(
+            self.trees[0], skip_root=True, expected_output=expected_output
+        )
+
+    def test_render_level0(self):
+        expected_output = """\
+Root
+"""
+        self.assertTreeRender(self.trees[1], level=0, expected_output=expected_output)
+
+    def test_render_level1(self):
+        expected_output = """\
+Root
+├── flux
+├── sleep
+├── sleep
+└── sleep
+"""
+        self.assertTreeRender(self.trees[1], level=1, expected_output=expected_output)
+
+    def test_render_level2(self):
+        expected_output = """\
+Root
+├── flux
+│   ├── sleep
+│   ├── flux
+│   ├── sleep
+│   └── sleep
+├── sleep
+├── sleep
+└── sleep
+"""
+        self.assertTreeRender(self.trees[1], level=2, expected_output=expected_output)
+
+    def test_render_style_compact(self):
+        expected_output = """\
+Root
+├─flux
+│ ├─3*[sleep]
+│ └─flux
+│   ├─foo
+│   └─bar
+└─3*[sleep]
+"""
+        self.assertTreeRender(
+            self.trees[0], style="compact", expected_output=expected_output
+        )
+
+    def test_render_style_ascii(self):
+        expected_output = """\
+Root
+|-- flux
+|   |-- sleep
+|   |-- flux
+|   |   |-- foo
+|   |   `-- bar
+|   |-- sleep
+|   `-- sleep
+|-- sleep
+|-- sleep
+`-- sleep
+"""
+        self.assertTreeRender(
+            self.trees[1], style="ascii", expected_output=expected_output
+        )
+
+    def test_render_truncate(self):
+        expected_output = """\
+Root
+|-- flux
+|   |-- sl+
+|   |-- fl+
+|   |   |-+
+|   |   `-+
+|   |-- sl+
+|   `-- sl+
+|-- sleep
+|-- sleep
+`-- sleep
+"""
+        columns = os.environ.get("COLUMNS")
+        os.environ["COLUMNS"] = "11"
+        self.assertTreeRender(
+            self.trees[1], style="ascii", truncate=True, expected_output=expected_output
+        )
+        if columns:
+            os.environ["COLUMNS"] = columns
+
+
+if __name__ == "__main__":
+    unittest.main(testRunner=TAPTestRunner())

--- a/t/t2800-jobs-instance-info.t
+++ b/t/t2800-jobs-instance-info.t
@@ -32,7 +32,7 @@ test_expect_success 'start a set of Flux instances' '
 	$waitfile -t 60 ready
 '
 test_expect_success 'flux-jobs can get instance info' "
-	flux jobs -ao '{id.f58:>12} {instance.stats:^25} {instance.utilization!P:>4} {instance.gpu_utilization!P:>4}' > jobs.out &&
+	flux jobs -ao '{id.f58:>12} {instance.stats:^25} {instance.utilization!P:>5} {instance.gpu_utilization!P:>5}' > jobs.out &&
 	test_debug 'cat jobs.out'
 "
 test_expect_success 'flux-jobs -o {instance.stats} worked' '
@@ -55,7 +55,7 @@ test_expect_success 'flux-jobs instance fields empty for completed job' '
 '
 test_expect_success 'flux-jobs instance headers work' '
 	cat >headers.expected <<-EOF &&
-	       JOBID           STATS           CPU% GPU%
+	       JOBID           STATS           CORE%  GPU%
 	EOF
 	head -n1 jobs.out >headers &&
 	test_cmp headers.expected headers

--- a/t/t2803-flux-pstree.t
+++ b/t/t2803-flux-pstree.t
@@ -1,0 +1,270 @@
+#!/bin/sh
+
+test_description='Test the flux-pstree command'
+
+. $(dirname $0)/sharness.sh
+
+test_under_flux 2 job
+
+export FLUX_PYCLI_LOGLEVEL=10
+export FLUX_URI_RESOLVE_LOCAL=t
+runpty="${SHARNESS_TEST_SRCDIR}/scripts/runpty.py --line-buffer -f asciicast"
+waitfile="${SHARNESS_TEST_SRCDIR}/scripts/waitfile.lua"
+export SHELL=/bin/sh
+
+test_expect_success 'flux-pstree errors on invalid arguments' '
+	test_must_fail flux pstree --skip-root=foo &&
+	test_must_fail flux pstree --details=foo &&
+	test_must_fail flux pstree --filter=bubbling
+'
+test_expect_success 'flux-pstree works in an empty instance' '
+	name="empty" &&
+	flux pstree > ${name}.output &&
+	test_debug "cat ${name}.output" &&
+	cat <<-EOF >${name}.expected &&
+	.
+	EOF
+	test_cmp ${name}.expected ${name}.output
+'
+test_expect_success 'flux-pstree --skip-root=yes works in empty instance' '
+	name="empty-skip-root" &&
+	flux pstree --skip-root=yes > ${name}.output &&
+	test_debug "cat ${name}.output" &&
+	cat <<-EOF >${name}.expected &&
+	EOF
+	test_cmp ${name}.expected ${name}.output
+'
+test_expect_success 'flux-pstree -x works in empty instance' '
+	name="empty-extended" &&
+	flux pstree -x > ${name}.output &&
+	test_debug "cat ${name}.output" &&
+	cat <<-EOF >${name}.expected &&
+	       JOBID USER     ST NTASKS NNODES  RUNTIME
+	EOF
+	test_cmp ${name}.expected ${name}.output
+'
+test_expect_success 'flux-pstree -a works in empty instance' '
+	name="empty-all" &&
+	flux pstree -a > ${name}.output &&
+	test_debug "cat ${name}.output" &&
+	cat <<-EOF >${name}.expected &&
+	.
+	EOF
+	test_cmp ${name}.expected ${name}.output
+'
+test_expect_success 'flux-pstree -x --skip-root=no works in empty instance' '
+	name="empty-extended-no-skip-root" &&
+	flux pstree -x --skip-root=no > ${name}.output &&
+	test_debug "cat ${name}.output" &&
+	test $(cat ${name}.output | wc -l) -eq 2
+'
+#  Start a child instance that immediately exits, so that we can test
+#   that `flux pstree` doesn't error on child instances that are no
+#   longer running.
+#
+#  Then, start a job hiearachy with 2 child instances, each of which
+#   run a sleep job, touch a ready.<id> file, then block waiting for
+#   the sleep job to finish.
+#
+test_expect_success 'start a recursive job' '
+	id=$(flux mini submit flux start /bin/true) &&
+	rid=$(flux mini submit -n2 \
+		flux start \
+		flux mini submit --wait --cc=1-2 flux start \
+			"flux mini submit sleep inf && \
+			 touch ready.\$FLUX_JOB_CC && \
+			 flux queue idle") &&
+	flux job wait-event $id clean
+'
+test_expect_success 'wait for hierarchy to be ready' '
+	flux getattr broker.pid &&
+	$waitfile -t 60 ready.1 &&
+	$waitfile -t 60 ready.2
+'
+test_expect_success 'flux-pstree works' '
+	name="normal" &&
+	flux pstree > ${name}.output &&
+	test_debug "cat ${name}.output" &&
+	cat <<-EOF >${name}.expected &&
+	.
+	└── flux
+	    ├── flux
+	    │   └── sleep
+	    └── flux
+	        └── sleep
+	EOF
+	test_cmp ${name}.expected ${name}.output
+'
+test_expect_success 'flux-pstree JOBID works' '
+	name="jobid" &&
+	flux pstree $rid > ${name}.output &&
+	test_debug "cat ${name}.output" &&
+	cat <<-EOF >${name}.expected &&
+	flux
+	├── flux
+	│   └── sleep
+	└── flux
+	    └── sleep
+	EOF
+	test_cmp ${name}.expected ${name}.output
+'
+test_expect_success 'flux-pstree works when run inside child job' '
+	name="proxy" &&
+	flux proxy $rid flux pstree > ${name}.output &&
+	test_debug "cat ${name}.output" &&
+	cat <<-EOF >${name}.expected &&
+	flux
+	├── flux
+	│   └── sleep
+	└── flux
+	    └── sleep
+	EOF
+	test_cmp ${name}.expected ${name}.output
+'
+
+test_expect_success 'flux-pstree -a works' '
+	name="all" &&
+	flux pstree -a > ${name}.output &&
+	test_debug "cat ${name}.output" &&
+	cat <<-EOF >${name}.expected &&
+	.
+	├── flux
+	│   ├── flux
+	│   │   └── sleep:R
+	│   └── flux
+	│       └── sleep:R
+	└── flux:CD
+	EOF
+	test_cmp ${name}.expected ${name}.output
+'
+test_expect_success 'flux-pstree truncates at COLUMNS' '
+	name="truncated" &&
+	COLUMNS=16 flux pstree -a > ${name}.output &&
+	test_debug "cat ${name}.output" &&
+	cat <<-EOF >${name}.expected &&
+	.
+	├── flux
+	│   ├── flux
+	│   │   └── sle+
+	│   └── flux
+	│       └── sle+
+	└── flux:CD
+	EOF
+	test_cmp ${name}.expected ${name}.output
+'
+test_expect_success 'flux-pstree does not truncate with -l' '
+	name="notruncate" &&
+	COLUMNS=16 flux pstree -al > ${name}.output &&
+	test_debug "cat ${name}.output" &&
+	cat <<-EOF >${name}.expected &&
+	.
+	├── flux
+	│   ├── flux
+	│   │   └── sleep:R
+	│   └── flux
+	│       └── sleep:R
+	└── flux:CD
+	EOF
+	test_cmp ${name}.expected ${name}.output
+'
+test_expect_success 'flux-pstree --skip-root=yes works' '
+	name="skip-root" &&
+	flux pstree --skip-root=yes > ${name}.output &&
+	test_debug "cat ${name}.output" &&
+	cat <<-EOF >${name}.expected &&
+	flux
+	├── flux
+	│   └── sleep
+	└── flux
+	    └── sleep
+	EOF
+	test_cmp ${name}.expected ${name}.output
+'
+test_expect_success 'flux-pstree --level=1 works' '
+	name="level1" &&
+	flux pstree --level=1 > ${name}.output &&
+	test_debug "cat ${name}.output" &&
+	cat <<-EOF >${name}.expected &&
+	.
+	└── flux
+	    └── 2*[flux]
+	EOF
+	test_cmp ${name}.expected ${name}.output
+'
+test_expect_success 'flux-pstree --level=1 --no-combine works' '
+	name="level1-no-combine" &&
+	flux pstree -L1 --no-combine > ${name}.output &&
+	test_debug "cat ${name}.output" &&
+	cat <<-EOF >${name}.expected &&
+	.
+	└── flux
+	    ├── flux
+	    └── flux
+	EOF
+	test_cmp ${name}.expected ${name}.output
+'
+test_expect_success 'flux-pstree -x' '
+	name="extended" &&
+	flux pstree -x > ${name}.output &&
+	test_debug "cat ${name}.output" &&
+	test $(cat ${name}.output | wc -l) -eq 6 &&
+	head -n 1 ${name}.output | grep NNODES
+'
+test_expect_success 'flux-pstree --details=NAME works' '
+	flux mini bulksubmit --watch \
+		--job-name=details-{} \
+		--output=details-{}.output \
+		flux pstree --details={} \
+		::: resources progress stats &&
+	test_debug "cat details-*.output" &&
+	grep STATS details-stats.output &&
+	grep CORES details-resources.output &&
+	grep PROG details-progress.output
+'
+test_expect_success 'flux-pstree --label= works' '
+	name="label-format" &&
+	flux pstree --label="{name} foo" > ${name}.output &&
+	test_debug "cat ${name}.output" &&
+	cat <<-EOF >${name}.expected &&
+	. foo
+	└── flux foo
+	    ├── flux foo
+	    │   └── sleep foo
+	    └── flux foo
+	        └── sleep foo
+	EOF
+	test_cmp ${name}.expected ${name}.output
+'
+test_expect_success 'flux-pstree --parent-label= works' '
+	name="label-format" &&
+	flux pstree \
+		--label="{name} foo" \
+		--parent-label="{name} bar" \
+		> ${name}.output &&
+	test_debug "cat ${name}.output" &&
+	cat <<-EOF >${name}.expected &&
+	. bar
+	└── flux bar
+	    ├── flux bar
+	    │   └── sleep foo
+	    └── flux bar
+	        └── sleep foo
+	EOF
+	test_cmp ${name}.expected ${name}.output
+'
+test_expect_success 'flux-pstree --detail-format works' '
+	name="detail-format" &&
+	flux pstree --detail-format="{id.f58:<12}" > ${name}.output &&
+	test_debug "cat ${name}.output" &&
+	test $(head -n1 ${name}.output) = "JOBID"
+'
+test_expect_success 'flux-pstree --detail-format --skip-root=no works' '
+	name="detail-format2" &&
+	flux pstree \
+		--no-header \
+		--skip-root=no \
+		--detail-format="{id.f58}" > ${name}.output &&
+	test_debug "cat ${name}.output" &&
+	test "$(head -n1 ${name}.output)" = ". ."
+'
+test_done


### PR DESCRIPTION
This PR adds a `flux-pstree(1)` command which offers [`pstree(1)`](https://man7.org/linux/man-pages/man1/pstree.1.html)  like output for Flux job hierarchies. 

This is still a WIP because there isn't yet any documentation or tests. It seemed a good idea to get some early feedback before taking a pass at either, in case the interface needs to be changed. It is built on top of the two pending PRs #4024 and #4022.

Currently this command only targets jobs for the calling user, as it didn't seem too useful to attempt to list other user's jobs at this time. Perhaps in the future a `-A, --user=all` option could be added if necessary.

The commit that adds the command has a good overview, so I won't repeat that here. Mainly I'll just show some examples:

```console
$ flux jobs
       JOBID USER     NAME       ST NTASKS NNODES  RUNTIME NODELIST
  ƒ7vazapGzs grondo   flux        R      2      2   1.807m asp,asp
$ flux pstree --help
usage: flux-pstree [-h] [-a] [-c N] [-f STATE|RESULT] [-x] [-l] [-L N] [-p]
                   [-n] [-X] [-o FORMAT] [--parent-label FORMAT]
                   [--detail-format FORMAT] [-d NAME] [-C] [--ascii]
                   [--no-skip-root]
                   [JOBID [JOBID ...]]

positional arguments:
  JOBID                       Limit output to specific jobids

optional arguments:
  -h, --help                  show this help message and exit
  -a, --all                   Include all jobs for current user in all states
  -c, --count=N               Limit to N jobs per instance (default 1000)
  -f, --filter=STATE|RESULT   list jobs with specific job state or result
  -x, --extended              print extended details before tree output
  -l, --long                  do not truncate long lines to terminal width
  -L, --level=N               only descend N levels
  -p, --parent-ids            include jobids in parent labels
  -n, --no-header             Suppress header with -x, --extended
  -X, --no-combine            disable combination of identical children
  -o, --label=FORMAT          change label format (default='{name}')
      --parent-label=FORMAT   change label format for parent only
      --detail-format=FORMAT  specify output format for extended details
                              (implies -x, --extended)
  -d, --details=NAME          Select a named extended details format
                              (default,resources,progress,stats)
  -C, --compact               Use compact tree connectors
      --ascii                 Use ASCII character tree connectors
      --no-skip-root          Include root in output

$ flux pstree
flux
├── flux
│   └── 2*[sleep]
├── flux
│   └── sleep
└── flux
    └── 4*[sleep]
$ flux pstree --no-combine
flux
├── flux
│   ├── sleep
│   └── sleep
├── flux
│   └── sleep
└── flux
    ├── sleep
    ├── sleep
    ├── sleep
    └── sleep
$ flux pstree -x
       JOBID USER     ST NTASKS NNODES  RUNTIME
  ƒ7vazapGzs grondo    R      2      2   2.313m flux
     ƒejEiwz grondo    R      1      1   2.275m ├── flux
    ƒ2QsbLdY grondo    R      1      1   0.790s │   ├── sleep
    ƒ2QsbLdX grondo    R      1      1   0.830s │   └── sleep
     ƒejEiwy grondo    R      1      1   2.275m ├── flux
    ƒ2UNheEj grondo    R      1      1   1.017s │   └── sleep
     ƒehkjfd grondo    R      1      1   2.275m └── flux
    ƒ2VJ5CPF grondo    R      1      1   0.454s     ├── sleep
    ƒ2VJ5CPE grondo    R      1      1   0.736s     ├── sleep
    ƒ2VJ5CPD grondo    R      1      1   0.784s     ├── sleep
    ƒ2VJ5CPC grondo    R      1      1   0.795s     └── sleep
$ flux pstree --details=progress
       JOBID NTASKS  NJOBS PROG CPU% GPU%    RUNTIME
  ƒ7vazapGzs      2      3   0%  88%         0:02:34 flux
     ƒejEiwz      1   1000  26% 100%         0:02:32 ├── flux
    ƒ2R11H3F      1                          0:00:01 │   ├── sleep
    ƒ2R11H3E      1                          0:00:01 │   └── sleep
     ƒejEiwy      1   1000  13% 100%         0:02:32 ├── flux
    ƒ2VGbD6o      1                          0:00:01 │   └── sleep
     ƒehkjfd      1   1000  53% 100%         0:02:32 └── flux
    ƒ2WuUR8w      1                          0:00:01     ├── sleep
    ƒ2WuUR8v      1                          0:00:01     ├── sleep
    ƒ2WuUR8u      1                          0:00:01     ├── sleep
    ƒ2WuUR8t      1                          0:00:01     └── sleep
$ flux pstree --details=stats
       JOBID           STATS              RUNTIME
  ƒ7vazapGzs     PD:0 R:3 CD:0 F:0        0:02:53 flux
     ƒejEiwz   PD:702 R:2 CD:296 F:0      0:02:51 ├── flux
    ƒ2S2JnK1                              0:00:01 │   ├── sleep
    ƒ2R8RDSz                              0:00:01 │   └── sleep
     ƒejEiwy   PD:850 R:1 CD:149 F:0      0:02:51 ├── flux
    ƒ2WLrgwK                              0:00:01 │   └── sleep
     ƒehkjfd   PD:397 R:4 CD:599 F:0      0:02:51 └── flux
    ƒ2YA7owm                              0:00:01     ├── sleep
    ƒ2Y8dpfT                              0:00:01     ├── sleep
    ƒ2Y8dpfS                              0:00:01     ├── sleep
    ƒ2Y8dpfR                              0:00:01     └── sleep
$ flux pstree --details=resources
       JOBID NODES  USED CORES  USED  GPUS  USED
  ƒ7vazapGzs     2     2     8     7     0     0 flux
     ƒejEiwz     1     1     2     2     0     0 ├── flux
    ƒ2S3nmbQ                                     │   ├── sleep
    ƒ2S3nmbP                                     │   └── sleep
     ƒejEiwy     1     1     1     1     0     0 ├── flux
    ƒ2XAJHxK                                     │   └── sleep
     ƒehkjfd     1     1     4     4     0     0 └── flux
    ƒ2YTufKu                                         ├── sleep
    ƒ2YPThUv                                         ├── sleep
    ƒ2YPThUu                                         ├── sleep
    ƒ2YPThUt                                         └── sleep
$ flux pstree -a
flux
├── flux
│   ├── 676*[sleep:PD]
│   ├── 2*[sleep:R]
│   └── 322*[sleep:CD]
├── flux
│   ├── 836*[sleep:PD]
│   ├── sleep:R
│   └── 163*[sleep:CD]
└── flux
    ├── 341*[sleep:PD]
    ├── 4*[sleep:R]
    └── 655*[sleep:CD]
$ flux pstree -a --no-skip-root
.
├── flux
│   ├── flux
│   │   ├── 664*[sleep:PD]
│   │   ├── 2*[sleep:R]
│   │   └── 334*[sleep:CD]
│   ├── flux
│   │   ├── 829*[sleep:PD]
│   │   ├── sleep:R
│   │   └── 170*[sleep:CD]
│   └── flux
│       ├── 314*[sleep:PD]
│       ├── 3*[sleep:R]
│       └── 683*[sleep:CD]
├── 5*[flux:CA]
├── 6*[flux:F]
└── 4*[flux:CD]
```

You can watch a complex hierarchy form using `watch -n1 flux pstree` (here I've used the `--ascii` option since Unicode box connectors don't show up with `asciicast2gif`:

![output](https://user-images.githubusercontent.com/741970/148252762-668b63e6-c9ae-4553-85e2-bf6e1c2aaabd.gif)
