### PR TITLE
broker: avoid inappropriate quorum.timeout

### DIFF
--- a/src/broker/state_machine.c
+++ b/src/broker/state_machine.c
@@ -280,7 +280,7 @@ static void action_quorum (struct state_machine *s)
     }
     if (s->ctx->rank > 0)
         quorum_check_parent (s);
-    else {
+    else if (s->quorum.timeout > 0.) {
         flux_timer_watcher_reset (s->quorum.timer, s->quorum.timeout, 0.);
         flux_watcher_start (s->quorum.timer);
     }


### PR DESCRIPTION
Problem: spurious 'quorum delayed' log messages are emitted on rank 0
of a system instance.

The timer is armed even if the timeout value is set to -1, as it the
case for the system instance, where the systemd unit file sets th
quorum.timeout attribute to "none".

Don't arm the timer unless the timeout is greater than zero.

Fixes #4017

Co-authored-by: Mark A. Grondona <mark.grondona@gmail.com>