### PR TITLE
systemd: set linger on flux user

### DIFF
--- a/etc/flux.service.in
+++ b/etc/flux.service.in
@@ -32,6 +32,7 @@ PermissionsStartOnly=true
 ExecStartPre=-/bin/mkdir -p @X_LOCALSTATEDIR@/lib/flux
 ExecStartPre=/bin/chown flux:flux @X_LOCALSTATEDIR@/lib/flux
 ExecStartPre=/bin/chmod 0700 @X_LOCALSTATEDIR@/lib/flux
+ExecStartPre=/usr/bin/loginctl enable-linger flux
 ExecStartPre=bash -c 'systemctl start user@$(id -u flux).service'
 
 #


### PR DESCRIPTION
Problem: Systemd user services can be stopped after the last
user session for that user has exited.  This can become a problem
during development / testing / debugging if someone runs something
under the flux user (e.g. 'sudo -u flux ...`) or su's to the flux
user and then exits.

Solution: Set linger on the flux user to ensure systemd user
services will not be stopped.

Fixes #4030