### PR TITLE
python: fix ImportError for collections.abc.Mapping

### DIFF
--- a/src/bindings/python/flux/resource/ResourceSet.py
+++ b/src/bindings/python/flux/resource/ResourceSet.py
@@ -9,7 +9,7 @@
 ###############################################################
 
 import json
-from collections import Mapping
+from collections.abc import Mapping
 
 from flux.idset import IDset
 from flux.resource import Rlist

--- a/src/bindings/python/flux/resource/Rlist.py
+++ b/src/bindings/python/flux/resource/Rlist.py
@@ -10,7 +10,7 @@
 
 import json
 import socket
-from collections import Mapping
+from collections.abc import Mapping
 
 from _flux._rlist import ffi, lib
 from flux.wrapper import Wrapper, WrapperPimpl


### PR DESCRIPTION
Problem: On Python 3.10, the import of Mapping from collections
gets

 "ImportError: cannot import name 'Mapping' from 'collections'"

It turns out that Mapping should be imported from 'collections.abc'
not just 'collections'. Fix the import.