### PR TITLE
job-list: fix "duplicate event" errors

### DIFF
--- a/src/modules/job-list/job_state.c
+++ b/src/modules/job-list/job_state.c
@@ -1724,10 +1724,6 @@ static int journal_process_event (struct job_state_ctx *jsctx, json_t *event)
                                 timestamp) < 0)
             return -1;
     }
-    else {
-        (void) job_update_eventlog_seq (jsctx, job, eventlog_seq);
-    }
-
     return 0;
 }
 


### PR DESCRIPTION
Problem: An error is emitted from job-list for every job:

```
 job-list: job_update_eventlog_seq: job X duplicate event (last = N, latest = N)
```

The problem is the else clause in `journal_process_event()`, which
always calls `job_update_eventlog_seq()`, even though this function is
already called at the top of the function. This causes the function
to be called twice for events that are not handled explicitly, such
as the "start" event.

Remove the `else` clause. `job_update_eventlog_seq()` will never need
to be called here since it is always already called at the top of
the function when `job` is found in the hash, or the function exits
early if `job` is not found.

Fixes #4041