### PR TITLE
ci: fix use of poison-libflux.sh and add poison fllux-* commands

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -369,7 +369,8 @@ AM_CFLAGS = \
 	$(CODE_COVERAGE_CFLAGS)
 
 AM_LDFLAGS = \
-	$(CODE_COVERAGE_LIBS)
+	$(CODE_COVERAGE_LIBS) \
+	-no-install
 
 AM_CPPFLAGS = \
 	-I$(top_srcdir) \

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -378,8 +378,8 @@ AM_CPPFLAGS = \
 	-I$(top_builddir)/src/common/libflux
 
 LDADD = \
-	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la \
+	$(top_builddir)/src/common/libflux-internal.la \
 	$(LIBPTHREAD)
 
 check_PROGRAMS = \

--- a/src/bindings/lua/Makefile.am
+++ b/src/bindings/lua/Makefile.am
@@ -42,8 +42,8 @@ luamod_ldflags = \
 	$(san_ld_zdef_flag)
 
 luamod_libadd = \
-	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la \
+	$(top_builddir)/src/common/libflux-internal.la \
 	$(LUA_LIB)
 
 flux_la_LDFLAGS = \

--- a/src/common/libioencode/Makefile.am
+++ b/src/common/libioencode/Makefile.am
@@ -29,8 +29,8 @@ T_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
 
 test_ldadd = \
         $(top_builddir)/src/common/libioencode/libioencode.la \
-        $(top_builddir)/src/common/libflux-internal.la \
         $(top_builddir)/src/common/libflux-core.la \
+        $(top_builddir)/src/common/libflux-internal.la \
         $(top_builddir)/src/common/libtap/libtap.la
 
 test_ldflags = \

--- a/src/common/librouter/Makefile.am
+++ b/src/common/librouter/Makefile.am
@@ -70,8 +70,8 @@ test_ldadd = \
         $(top_builddir)/src/common/librouter/librouter.la \
         $(top_builddir)/src/common/libtestutil/libtestutil.la \
         $(top_builddir)/src/common/libzmqutil/libzmqutil.la \
-        $(top_builddir)/src/common/libflux-internal.la \
         $(top_builddir)/src/common/libflux-core.la \
+        $(top_builddir)/src/common/libflux-internal.la \
         $(top_builddir)/src/common/libtap/libtap.la \
         $(ZMQ_LIBS)
 

--- a/src/common/libsubprocess/Makefile.am
+++ b/src/common/libsubprocess/Makefile.am
@@ -47,8 +47,8 @@ T_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
 test_ldadd = \
         $(top_builddir)/src/common/libtap/libtap.la \
         $(top_builddir)/src/common/libsubprocess/libsubprocess.la \
-        $(top_builddir)/src/common/libflux-internal.la \
-        $(top_builddir)/src/common/libflux-core.la
+        $(top_builddir)/src/common/libflux-core.la \
+        $(top_builddir)/src/common/libflux-internal.la
 
 test_ldflags = \
 	-no-install

--- a/src/common/libterminus/Makefile.am
+++ b/src/common/libterminus/Makefile.am
@@ -37,8 +37,8 @@ test_ldadd = \
 	$(top_builddir)/src/common/libutil/libutil.la \
 	$(top_builddir)/src/common/libtestutil/libtestutil.la \
 	$(top_builddir)/src/common/libzmqutil/libzmqutil.la \
-        $(top_builddir)/src/common/libflux-internal.la \
         $(top_builddir)/src/common/libflux-core.la \
+        $(top_builddir)/src/common/libflux-internal.la \
         $(top_builddir)/src/common/libtap/libtap.la \
         $(ZMQ_LIBS)
 

--- a/src/modules/content-files/Makefile.am
+++ b/src/modules/content-files/Makefile.am
@@ -26,8 +26,8 @@ content_files_la_LIBADD = \
 TESTS = test_filedb.t
 
 test_ldadd = \
-	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la \
+	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libtap/libtap.la \
 	$(LIBPTHREAD)
 

--- a/src/modules/job-exec/Makefile.am
+++ b/src/modules/job-exec/Makefile.am
@@ -58,8 +58,8 @@ bulk_exec_LDADD = \
 
 test_ldadd = \
 	$(top_builddir)/src/common/libtap/libtap.la \
-	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la \
+	$(top_builddir)/src/common/libflux-internal.la \
 	$(LIBPTHREAD) $(JANSSON_LIBS)
 
 test_ldflags = \

--- a/src/modules/job-manager/Makefile.am
+++ b/src/modules/job-manager/Makefile.am
@@ -123,8 +123,8 @@ test_ldadd = \
 	libjob-manager.la \
 	$(top_builddir)/src/common/libtap/libtap.la \
 	$(top_builddir)/src/common/libjob/libjob.la \
-	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la \
+	$(top_builddir)/src/common/libflux-internal.la \
 	$(LIBPTHREAD) $(JANSSON_LIBS)
 
 test_cppflags = \

--- a/src/modules/kvs/Makefile.am
+++ b/src/modules/kvs/Makefile.am
@@ -48,8 +48,8 @@ TESTS = \
 
 test_ldadd = \
 	$(top_builddir)/src/common/libkvs/libkvs.la \
-	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la \
+	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libtap/libtap.la \
 	$(JANSSON_LIBS) \
         $(LIBPTHREAD)

--- a/src/modules/resource/Makefile.am
+++ b/src/modules/resource/Makefile.am
@@ -46,8 +46,8 @@ TESTS = test_rutil.t
 
 test_ldadd = \
         $(top_builddir)/src/common/librlist/librlist.la \
-        $(top_builddir)/src/common/libflux-internal.la \
         $(top_builddir)/src/common/libflux-core.la \
+        $(top_builddir)/src/common/libflux-internal.la \
         $(top_builddir)/src/common/libtap/libtap.la \
 	$(HWLOC_LIBS) \
 	$(JANSSON_LIBS) \

--- a/src/test/checks_run.sh
+++ b/src/test/checks_run.sh
@@ -190,8 +190,9 @@ checks_group "configure ${ARGS}"  ${WORKDIR}/configure ${ARGS} \
 checks_group "make clean..." make clean
 
 if test "$POISON" = "t" -a "$PROJECT" = "flux-core"; then
-  checks_group "Installing poison libflux..." \
-    bash src/test/docker/poison-libflux.sh
+  checks_group "Installing poison libflux and commands..." \
+    bash src/test/docker/poison-libflux.sh /tmp/poison-cmds
+  export FLUX_EXEC_PATH=/tmp/poison-cmds
 fi
 
 if test "$DISTCHECK" != "t"; then

--- a/src/test/checks_run.sh
+++ b/src/test/checks_run.sh
@@ -191,7 +191,7 @@ checks_group "make clean..." make clean
 
 if test "$POISON" = "t" -a "$PROJECT" = "flux-core"; then
   checks_group "Installing poison libflux and commands..." \
-    bash src/test/docker/poison-libflux.sh /tmp/poison-cmds
+    sudo bash src/test/docker/poison-libflux.sh /tmp/poison-cmds
   export FLUX_EXEC_PATH=/tmp/poison-cmds
 fi
 

--- a/src/test/docker/poison-libflux.sh.in
+++ b/src/test/docker/poison-libflux.sh.in
@@ -2,10 +2,14 @@
 #
 #  Build a "poison" libflux-core.so to install in system path.
 #
+#  Also put some poison commands in a fake FLUX_EXEC_PATH given on
+#   commandline.
+#
 #  This will hopefully ensure no flux-core internal tests try to
 #   load the system libflux-core.so
 #
 
+CMDDIR=${1:-/tmp/poison-cmds}
 WORKDIR=$(mktemp -d)
 printf " Changing working directory to $WORKDIR\n"
 cd $WORKDIR || exit 1
@@ -85,5 +89,19 @@ for lib in core idset optparse schedutil hostlist; do
     ln -sf ${LIBDIR}/libflux-${lib}.so ${LIBDIR}/libflux-${lib}.so.${suffix}
     ln -sf ${LIBDIR}/libflux-${lib}.so ${LIBDIR}/libflux-${lib}.so.${major}
 
+done
+
+printf " Installing poison flux commands...\n"
+mkdir -p -m 0755 $CMDDIR
+for cmd in \
+	terminus ping keygen logger event module kvs start job queue exec \
+	cron mini jobs reosurce admin jobtap job-validator \
+	job-exec-override perilog-run uri pstree; do
+	cat <<-EOF >${CMDDIR}/flux-${cmd}
+	#!/bin/sh
+	printf "Error: running poison command $0\n"
+	exit 1
+	EOF
+	chmod +x ${CMDDIR}/flux-${cmd}
 done
 

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -413,10 +413,10 @@ dist_check_DATA = \
 	valgrind/valgrind.supp
 
 test_ldadd = \
-	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libtap/libtap.la \
 	$(top_builddir)/src/common/libflux-optparse.la \
 	$(top_builddir)/src/common/libflux-core.la \
+	$(top_builddir)/src/common/libflux-internal.la \
 	$(LIBPTHREAD)
 
 test_ldflags = \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -419,6 +419,9 @@ test_ldadd = \
 	$(top_builddir)/src/common/libflux-core.la \
 	$(LIBPTHREAD)
 
+test_ldflags = \
+	-no-install
+
 test_cppflags = \
 	-I$(top_srcdir)/src/common/libtap \
 	$(AM_CPPFLAGS)
@@ -426,134 +429,167 @@ test_cppflags = \
 shmem_backtoback_t_SOURCES = shmem/backtoback.c
 shmem_backtoback_t_CPPFLAGS = $(test_cppflags)
 shmem_backtoback_t_LDADD = $(test_ldadd)
+shmem_backtoback_t_LDFLAGS = $(test_ldflags)
 
 loop_logstderr_SOURCES = loop/logstderr.c
 loop_logstderr_CPPFLAGS = $(test_cppflags)
 loop_logstderr_LDADD = $(test_ldadd)
+loop_logstderr_LDFLAGS = $(test_ldflags)
 
 loop_issue2337_SOURCES = loop/issue2337.c
 loop_issue2337_CPPFLAGS = $(test_cppflags)
 loop_issue2337_LDADD = $(test_ldadd)
+loop_issue2337_LDFLAGS = $(test_ldflags)
 
 loop_issue2711_SOURCES = loop/issue2711.c
 loop_issue2711_CPPFLAGS = $(test_cppflags)
 loop_issue2711_LDADD = $(test_ldadd)
+loop_issue2711_LDFLAGS = $(test_ldflags)
 
 mpi_hello_SOURCES = mpi/hello.c
 mpi_hello_CPPFLAGS = $(MPI_CFLAGS) $(test_cppflags)
 mpi_hello_LDADD = $(MPI_CLDFLAGS) $(test_ldadd)
+mpi_hello_LDFLAGS = $(test_ldflags)
 
 mpi_abort_SOURCES = mpi/abort.c
 mpi_abort_CPPFLAGS = $(MPI_CFLAGS) $(test_cppflags)
 mpi_abort_LDADD = $(MPI_CLDFLAGS) $(test_ldadd)
+mpi_abort_LDFLAGS = $(test_ldflags)
 
 mpi_version_SOURCES = mpi/version.c
 mpi_version_CPPFLAGS = $(MPI_CFLAGS) $(test_cppflags)
 mpi_version_LDADD = $(MPI_CLDFLAGS) $(test_ldadd)
+mpi_version_LDFLAGS = $(test_ldflags)
 
 mpi_mpich_basic_adapt_SOURCES = mpi/mpich_basic/adapt.c mpi/mpich_basic/GetOpt.c mpi/mpich_basic/GetOpt.h
 mpi_mpich_basic_adapt_CPPFLAGS = $(MPI_CFLAGS) $(test_cppflags)
-mpi_mpich_basic_adapt_LDADD = $(MPI_CLDFLAGS) $(test_ldadd)
+mpi_mpich_basic_adapt_LDADD = $(test_ldadd)
+mpi_mpich_basic_adapt_LDFLAGS = $(MPI_CLDFLAGS) $(test_ldflags)
 
 mpi_mpich_basic_netpipe_SOURCES = mpi/mpich_basic/netmpi.c mpi/mpich_basic/GetOpt.c mpi/mpich_basic/GetOpt.h
 mpi_mpich_basic_netpipe_CPPFLAGS = $(MPI_CFLAGS) $(test_cppflags)
-mpi_mpich_basic_netpipe_LDADD = $(MPI_CLDFLAGS) $(test_ldadd)
+mpi_mpich_basic_netpipe_LDADD = $(test_ldadd)
+mpi_mpich_basic_netpipe_LDFLAGS = $(MPI_CLDFLAGS) $(test_ldflags)
 
 mpi_mpich_basic_patterns_SOURCES = mpi/mpich_basic/patterns.c
 mpi_mpich_basic_patterns_CPPFLAGS = $(MPI_CFLAGS) $(test_cppflags)
-mpi_mpich_basic_patterns_LDADD = $(MPI_CLDFLAGS) $(test_ldadd)
+mpi_mpich_basic_patterns_LDADD = $(test_ldadd)
+mpi_mpich_basic_patterns_LDFLAGS = $(MPI_CLDFLAGS) $(test_ldflags)
 
 mpi_mpich_basic_srtest_SOURCES = mpi/mpich_basic/srtest.c
 mpi_mpich_basic_srtest_CPPFLAGS = $(MPI_CFLAGS) $(test_cppflags)
-mpi_mpich_basic_srtest_LDADD = $(MPI_CLDFLAGS) $(test_ldadd)
+mpi_mpich_basic_srtest_LDADD = $(test_ldadd)
+mpi_mpich_basic_srtest_LDFLAGS = $(MPI_CLDFLAGS) $(test_ldflags)
 
 mpi_mpich_basic_self_SOURCES = mpi/mpich_basic/self.c
 mpi_mpich_basic_self_CPPFLAGS = $(MPI_CFLAGS) $(test_cppflags)
 mpi_mpich_basic_self_LDADD = $(MPI_CLDFLAGS) $(test_ldadd)
+mpi_mpich_basic_self_LDFLAGS = $(MPI_CLDFLAGS) $(test_ldflags)
 
 mpi_mpich_basic_sendrecv_SOURCES = mpi/mpich_basic/sendrecv.c
 mpi_mpich_basic_sendrecv_CPPFLAGS = $(MPI_CFLAGS) $(test_cppflags)
 mpi_mpich_basic_sendrecv_LDADD = $(MPI_CLDFLAGS) $(test_ldadd)
+mpi_mpich_basic_sendrecv_LDFLAGS = $(MPI_CLDFLAGS) $(test_ldflags)
 
 mpi_mpich_basic_simple_SOURCES = mpi/mpich_basic/simple.c
 mpi_mpich_basic_simple_CPPFLAGS = $(MPI_CFLAGS) $(test_cppflags)
 mpi_mpich_basic_simple_LDADD = $(MPI_CLDFLAGS) $(test_ldadd)
+mpi_mpich_basic_simple_LDFLAGS = $(MPI_CLDFLAGS) $(test_ldflags)
 
 kvs_torture_SOURCES = kvs/torture.c
 kvs_torture_CPPFLAGS = $(test_cppflags)
 kvs_torture_LDADD = $(test_ldadd)
+kvs_torture_LDFLAGS = $(test_ldflags)
 
 kvs_dtree_SOURCES = kvs/dtree.c
 kvs_dtree_CPPFLAGS = $(test_cppflags)
 kvs_dtree_LDADD = $(test_ldadd)
+kvs_dtree_LDFLAGS = $(test_ldflags)
 
 kvs_blobref_SOURCES = kvs/blobref.c
 kvs_blobref_CPPFLAGS = $(test_cppflags)
 kvs_blobref_LDADD = $(test_ldadd)
+kvs_blobref_LDFLAGS = $(test_ldflags)
 
 kvs_commit_SOURCES = kvs/commit.c
 kvs_commit_CPPFLAGS = $(test_cppflags)
 kvs_commit_LDADD = $(test_ldadd)
+kvs_commit_LDFLAGS = $(test_ldflags)
 
 kvs_fence_api_SOURCES = kvs/fence_api.c
 kvs_fence_api_CPPFLAGS = $(test_cppflags)
 kvs_fence_api_LDADD = $(test_ldadd)
+kvs_fence_api_LDFLAGS = $(test_ldflags)
 
 kvs_transactionmerge_SOURCES = kvs/transactionmerge.c
 kvs_transactionmerge_CPPFLAGS = $(test_cppflags)
 kvs_transactionmerge_LDADD = $(test_ldadd)
+kvs_transactionmerge_LDFLAGS = $(test_ldflags)
 
 kvs_fence_namespace_remove_SOURCES = kvs/fence_namespace_remove.c
 kvs_fence_namespace_remove_CPPFLAGS = $(test_cppflags)
 kvs_fence_namespace_remove_LDADD = $(test_ldadd)
+kvs_fence_namespace_remove_LDFLAGS = $(test_ldflags)
 
 kvs_fence_invalid_SOURCES = kvs/fence_invalid.c
 kvs_fence_invalid_CPPFLAGS = $(test_cppflags)
 kvs_fence_invalid_LDADD = $(test_ldadd)
+kvs_fence_invalid_LDFLAGS = $(test_ldflags)
 
 kvs_lookup_invalid_SOURCES = kvs/lookup_invalid.c
 kvs_lookup_invalid_CPPFLAGS = $(test_cppflags)
 kvs_lookup_invalid_LDADD = $(test_ldadd)
+kvs_lookup_invalid_LDFLAGS = $(test_ldflags)
 
 kvs_commit_order_SOURCES = kvs/commit_order.c
 kvs_commit_order_CPPFLAGS = $(test_cppflags)
 kvs_commit_order_LDADD = $(test_ldadd)
+kvs_commit_order_LDFLAGS = $(test_ldflags)
 
 kvs_watch_disconnect_SOURCES = kvs/watch_disconnect.c
 kvs_watch_disconnect_CPPFLAGS = $(test_cppflags)
 kvs_watch_disconnect_LDADD = $(test_ldadd)
+kvs_watch_disconnect_LDFLAGS = $(test_ldflags)
 
 kvs_issue1760_SOURCES = kvs/issue1760.c
 kvs_issue1760_CPPFLAGS = $(test_cppflags)
 kvs_issue1760_LDADD = $(test_ldadd)
+kvs_issue1760_LDFLAGS = $(test_ldflags)
 
 kvs_issue1876_SOURCES = kvs/issue1876.c
 kvs_issue1876_CPPFLAGS = $(test_cppflags)
 kvs_issue1876_LDADD = $(test_ldadd)
+kvs_issue1876_LDFLAGS = $(test_ldflags)
 
 kvs_waitcreate_cancel_SOURCES = kvs/waitcreate_cancel.c
 kvs_waitcreate_cancel_CPPFLAGS = $(test_cppflags)
 kvs_waitcreate_cancel_LDADD = $(test_ldadd)
+kvs_waitcreate_cancel_LDFLAGS = $(test_ldflags)
 
 kvs_setrootevents_SOURCES = kvs/setrootevents.c
 kvs_setrootevents_CPPFLAGS = $(test_cppflags)
 kvs_setrootevents_LDADD = $(test_ldadd)
+kvs_setrootevents_LDFLAGS = $(test_ldflags)
 
 kvs_checkpoint_SOURCES = kvs/checkpoint.c
 kvs_checkpoint_CPPFLAGS = $(test_cppflags)
 kvs_checkpoint_LDADD = $(test_ldadd)
+kvs_checkpoint_LDFLAGS = $(test_ldflags)
 
 request_treq_SOURCES = request/treq.c
 request_treq_CPPFLAGS = $(test_cppflags)
 request_treq_LDADD = $(test_ldadd)
+request_treq_LDFLAGS = $(test_ldflags)
 
 request_rpc_SOURCES = request/rpc.c
 request_rpc_CPPFLAGS = $(test_cppflags)
 request_rpc_LDADD = $(test_ldadd)
+request_rpc_LDFLAGS = $(test_ldflags)
 
 request_rpc_stream_SOURCES = request/rpc_stream.c
 request_rpc_stream_CPPFLAGS = $(test_cppflags)
 request_rpc_stream_LDADD = $(test_ldadd)
+request_rpc_stream_LDFLAGS = $(test_ldflags)
 
 module_parent_la_SOURCES = module/parent.c
 module_parent_la_CPPFLAGS = $(test_cppflags)
@@ -573,6 +609,7 @@ module_running_la_LIBADD = $(test_ldadd)
 barrier_tbarrier_SOURCES = barrier/tbarrier.c
 barrier_tbarrier_CPPFLAGS = $(test_cppflags)
 barrier_tbarrier_LDADD = $(test_ldadd)
+barrier_tbarrier_LDFLAGS = $(test_ldflags)
 
 request_req_la_SOURCES = request/req.c
 request_req_la_CPPFLAGS = $(test_cppflags)
@@ -583,16 +620,19 @@ shell_rcalc_SOURCES = shell/rcalc.c
 shell_rcalc_CPPFLAGS = $(test_cppflags)
 shell_rcalc_LDADD = $(top_builddir)/src/shell/libshell.la \
 	$(test_ldadd)
+shell_rcalc_LDFLAGS = $(test_ldflags)
 
 shell_lptest_SOURCES = shell/lptest.c
 shell_lptest_CPPFLAGS = $(test_cppflags)
 shell_lptest_LDADD = $(test_ldadd)
+shell_lptest_LDFLAGS = $(test_ldflags)
 
 shell_mpir_SOURCES = shell/mpir.c
 shell_mpir_CPPFLAGS = $(test_cppflags)
 shell_mpir_LDADD = \
 	$(top_builddir)/src/shell/libmpir.la \
 	$(test_ldadd)
+shell_mpir_LDFLAGS = $(test_ldflags)
 
 debug_stall_SOURCES = debug/stall.c
 debug_stall_CPPFLAGS = $(test_cppflags)
@@ -600,22 +640,27 @@ debug_stall_CPPFLAGS = $(test_cppflags)
 reactor_reactorcat_SOURCES = reactor/reactorcat.c
 reactor_reactorcat_CPPFLAGS = $(test_cppflags)
 reactor_reactorcat_LDADD = $(test_ldadd)
+reactor_reactorcat_LDFLAGS = $(test_ldflags)
 
 rexec_rexec_SOURCES = rexec/rexec.c
 rexec_rexec_CPPFLAGS = $(test_cppflags)
 rexec_rexec_LDADD = $(test_ldadd)
+rexec_rexec_LDFLAGS = $(test_ldflags)
 
 rexec_rexec_ps_SOURCES = rexec/rexec_ps.c
 rexec_rexec_ps_CPPFLAGS = $(test_cppflags)
 rexec_rexec_ps_LDADD = $(test_ldadd)
+rexec_rexec_ps_LDFLAGS = $(test_ldflags)
 
 rexec_rexec_count_stdout_SOURCES = rexec/rexec_count_stdout.c
 rexec_rexec_count_stdout_CPPFLAGS = $(test_cppflags)
 rexec_rexec_count_stdout_LDADD = $(test_ldadd)
+rexec_rexec_count_stdout_LDFLAGS = $(test_ldflags)
 
 rexec_rexec_getline_SOURCES = rexec/rexec_getline.c
 rexec_rexec_getline_CPPFLAGS = $(test_cppflags)
 rexec_rexec_getline_LDADD = $(test_ldadd)
+rexec_rexec_getline_LDFLAGS = $(test_ldflags)
 
 ingest_job_manager_dummy_la_SOURCES = ingest/job-manager-dummy.c
 ingest_job_manager_dummy_la_CPPFLAGS = $(test_cppflags)
@@ -625,18 +670,22 @@ ingest_job_manager_dummy_la_LIBADD = $(test_ldadd)
 ingest_submitbench_SOURCES = ingest/submitbench.c
 ingest_submitbench_CPPFLAGS = $(test_cppflags)
 ingest_submitbench_LDADD = $(test_ldadd)
+ingest_submitbench_LDFLAGS = $(test_ldflags)
 
 job_manager_list_jobs_SOURCES = job-manager/list-jobs.c
 job_manager_list_jobs_CPPFLAGS = $(test_cppflags)
 job_manager_list_jobs_LDADD = $(test_ldadd)
+job_manager_list_jobs_LDFLAGS = $(test_ldflags)
 
 job_manager_print_constants_SOURCES = job-manager/print-constants.c
 job_manager_print_constants_CPPFLAGS = $(test_cppflags)
 job_manager_print_constants_LDADD = $(test_ldadd)
+job_manager_print_constants_LDFLAGS = $(test_ldflags)
 
 job_manager_events_journal_stream_SOURCES = job-manager/events_journal_stream.c
 job_manager_events_journal_stream_CPPFLAGS = $(test_cppflags)
 job_manager_events_journal_stream_LDADD = $(test_ldadd)
+job_manager_events_journal_stream_LDFLAGS = $(test_ldflags)
 
 disconnect_watcher_la_SOURCES = disconnect/watcher.c
 disconnect_watcher_la_CPPFLAGS = $(test_cppflags)
@@ -648,6 +697,7 @@ sched_simple_jj_reader_CPPFLAGS = $(test_cppflags)
 sched_simple_jj_reader_LDADD = \
 	$(top_builddir)/src/modules/sched-simple/libjj.la \
 	$(test_ldadd)
+sched_simple_jj_reader_LDFLAGS = $(test_ldflags)
 
 shell_plugins_dummy_la_SOURCES = shell/plugins/dummy.c
 shell_plugins_dummy_la_CPPFLAGS = $(test_cppflags)
@@ -819,19 +869,23 @@ hwloc_hwloc_convert_SOURCES = hwloc/hwloc-convert.c
 hwloc_hwloc_convert_CPPFLAGS = $(HWLOC_CFLAGS) $(test_cppflags)
 hwloc_hwloc_convert_LDADD = $(HWLOC_LIBS) \
 	$(test_ldadd)
+hwloc_hwloc_convert_LDFLAGS = $(test_ldadd)
 
 hwloc_hwloc_version_SOURCES = hwloc/hwloc-version.c
 hwloc_hwloc_version_CPPFLAGS = $(HWLOC_CFLAGS) $(test_cppflags)
 hwloc_hwloc_version_LDADD = $(HWLOC_LIBS) \
 	$(test_ldadd)
+hwloc_hwloc_version_LDFLAGS = $(test_ldadd)
 
 util_jobspec1_validate_SOURCES = util/jobspec1-validate.c
 util_jobspec1_validate_CPPFLAGS = $(test_cppflags)
 util_jobspec1_validate_LDADD = $(test_ldadd)
+util_jobspec1_validate_LDFLAGS = $(test_ldflags)
 
 util_handle_SOURCES = util/handle.c
 util_handle_CPPFLAGS = $(test_cppflags)
 util_handle_LDADD = $(test_ldadd)
+util_handle_LDFLAGS = $(test_ldflags)
 
 stats_stats_basic_la_SOURCES = stats/stats-basic.c
 stats_stats_basic_la_CPPFLAGS = $(test_cppflags)

--- a/t/sharness.d/01-setup.sh
+++ b/t/sharness.d/01-setup.sh
@@ -39,6 +39,13 @@ if test -n "$FLUX_TEST_INSTALLED_PATH"; then
 else # normal case, use ${top_builddir}/src/cmd/flux
     PATH=$FLUX_BUILD_DIR/src/cmd:$PATH
     fluxbin=$FLUX_BUILD_DIR/src/cmd/flux
+
+    #  Ensure that the built libflux-*.so are found before any system
+    #   installed versions. This is necessary because sometimes libtool
+    #   will use -rpath /usr/lib64 even for uninstalled test programs
+    #   (e.g. compiled MPI test programs like t/mpi/version)
+    #
+    export LD_LIBRARY_PATH="${FLUX_BUILD_DIR}/src/common/.libs:$LD_LIBRARY_PATH"
 fi
 export PATH
 

--- a/t/t2802-uri-cmd.t
+++ b/t/t2802-uri-cmd.t
@@ -71,7 +71,7 @@ test_expect_success 'start a small hierarchy of Flux instances' '
 	EOF
 	chmod +x batch.sh &&
 	jobid=$(flux mini batch -n1 batch.sh) &&
-	flux job wait-event -T offset -vt 15 -c 2 $jobid memo
+	flux job wait-event -T offset -vt 30 -c 2 $jobid memo
 '
 test_expect_success 'flux uri resolves jobid argument' '
 	flux proxy $(flux uri --local $jobid) flux getattr jobid >jobid1.out &&

--- a/t/t9000-system.t
+++ b/t/t9000-system.t
@@ -11,7 +11,7 @@ fi
 #  Do not run system tests by default unless FLUX_ENABLE_SYSTEM_TESTS
 #   is set in environment (e.g. by CI), or the test run run with -d, --debug
 #
-if test -z "$FLUX_ENABLE_SYSTEM_TESTS" && test "$debug" = ""; then
+if test -z "$FLUX_ENABLE_SYSTEM_TESTS"; then
 	skip_all='skipping system tests since FLUX_ENABLE_SYSTEM_TESTS not set'
 	test_done
 fi


### PR DESCRIPTION
This PR fixes the use of the `poison-libflux.sh` script during `docker-run-checks.sh`. It turns out the script wasn't actually being used because it needs to be run under `sudo`.

Once that was fixed, it turns out many tests were being linked with system `libflux-*.so` libraries under some distros. This required some further fixes and experimental workarounds to the build system.

Finally, some poisoned `flux-*` commands are added to a fake `FLUX_EXEC_PATH` to ensure we never call out to commands in the system or previously registered `FLUX_EXEC_PATH` during the testsuite (as was seen with #4038)

Along the way a couple other minor testsuite issues were fixed.