### PR TITLE
broker: avoid leaking Cray environment

### DIFF
--- a/src/broker/runat.c
+++ b/src/broker/runat.c
@@ -83,6 +83,16 @@ static const char *env_blocklist[] = {
     "PMIX_SERVER_URI2",
     "PMIX_SERVER_URI",
 #endif
+    /* Cray shasta plugin for slurm/flux sets these variables.
+     * If set in flux's environment, don't leak through to applications
+     * launched by flux or incorrect job info could be conveyed.
+     */
+    "PALS_APID",
+    "PALS_RANKID",
+    "PALS_NODEID",
+    "PALS_SPOOL_DIR",
+    "PALS_APINFO",
+    "PMI_CONTROL_PORT",
     NULL,
 };
 


### PR DESCRIPTION
Problem: if flux is launched by slurm on a cray system with
the cray_shasta plugin loaded, and then flux tries to launch
cray MPI, the job may start with incorrect job information.

Flux cannot launch cray MPI on a shasta system without its
own similar plugin.  When that is written it will likely overwrite
any existing values.  However, it may not be loaded by default,
so these changes are still useful.

Add cray shasta runtime variables to runat skiplist, which
prevents them from being set in the Flux initial program,
which is often the initial environment for work submitted to flux.