### PR TITLE
resource: drain torpid nodes

### DIFF
--- a/doc/man7/flux-broker-attributes.rst
+++ b/doc/man7/flux-broker-attributes.rst
@@ -76,6 +76,19 @@ tbon.prefertcp
    with PMI, tcp:// endpoints will be used instead of ipc://, even if all
    brokers are on a single node.
 
+tbon.torpid_min
+   The amount of time (in RFC 23 Flux Standard Duration format) that a broker
+   will allow the connection to its TBON parent to remain idle before sending a
+   keepalive message.  This value may be adjusted on a live system.
+
+tbon.torpid_max
+   The amount of time (in RFC 23 Flux Standard Duration format) that a broker
+   will wait for an idle TBON child connection to send messages before
+   declaring it torpid (unresponsive).  A value of 0 disables torpid node
+   checking.  Torpid nodes are automatically drained and require manual
+   undraining with :man1:`flux-resource`.  This value may be adjusted on a
+   live system.
+
 
 SOCKET ATTRIBUTES
 =================
@@ -197,6 +210,8 @@ RESOURCES
 =========
 
 Flux: http://flux-framework.org
+
+RFC 23: Flux Standard Duration: https://github.com/flux-framework/rfc/blob/master/spec_23.rst
 
 
 SEE ALSO

--- a/doc/man7/flux-broker-attributes.rst
+++ b/doc/man7/flux-broker-attributes.rst
@@ -63,8 +63,8 @@ tbon.maxlevel
    The maximum level number in the tree based overlay network.
    Maxlevel is 0 for a size=1 instance.
 
-tbon.endpoint
-   The endpoint for the tree based overlay network to communicate over.
+tbon.parent-endpoint
+   The ZeroMQ endpoint of this broker's TBON parent.
 
 tbon.zmqdebug
    If set to an non-zero integer value, 0MQ socket event logging is enabled,
@@ -92,10 +92,6 @@ tbon.torpid_max
 
 SOCKET ATTRIBUTES
 =================
-
-tbon.parent-endpoint
-   The URI of the ZeroMQ endpoint this rank is connected to in the tree
-   based overlay network. This attribute will not be set on rank zero.
 
 local-uri
    The Flux URI that should be passed to :man3:`flux_open` to

--- a/doc/man7/flux-broker-attributes.rst
+++ b/doc/man7/flux-broker-attributes.rst
@@ -190,22 +190,6 @@ content.purge-target-size
    size of the cache stays at or below this value.
 
 
-WIREUP ATTRIBUTES
-=================
-
-hello.timeout
-   The reduction timeout (in seconds) for the broker wireup protocol.
-   Before the timeout, a topology-based high water mark is applied
-   at each node of the tree based overlay network. After the timeout,
-   new wireup information is forwarded upstream without delay.
-   Set to 0 to disable the timeout.
-
-hello.hwm
-   The reduction high water mark for the broker wireup protocol,
-   normally calculated based on the topology.
-   Set to 0 to disable the high water mark.
-
-
 RESOURCES
 =========
 

--- a/src/broker/groups.c
+++ b/src/broker/groups.c
@@ -65,6 +65,7 @@ struct groups {
     uint32_t rank;
     struct idset *self;
     bool verbose;
+    struct idset *torpid; // current list of torpid peers at this broker rank
 };
 
 static void get_respond_all (struct groups *g, struct group *group);
@@ -645,30 +646,48 @@ static int add_subtree_ids (struct idset *ids, json_t *topology)
     return 0;
 }
 
-/* Detect when a TBON child has been lost (crashed) or goes offline (shutdown).
- * We must automatically generate LEAVEs for 'rank' and members of its TBON
- * subtree.
+/* Generate JOIN/LEAVE for 'rank' in 'broker.torpid' group if rank becomes
+ * torpid/non-torpid.  N.B. For now, just operate on the single rank, not
+ * its entire subtree.  Although it would be straightforward to add the subtree
+ * to the group when the root becomes torpid, removing the whole subtree when
+ * responsiveness returns is less clear, since only a broker's immediate
+ * parent really knows how responsive it is.
  */
-static void overlay_monitor_cb (struct overlay *ov, uint32_t rank, void *arg)
+static void torpid_update (struct groups *g,
+                           uint32_t rank,
+                           struct idset *subtree_ids,
+                           bool torpid)
 {
-    struct groups *g = arg;
-    const char *status = overlay_get_subtree_status (ov, rank);
-    json_t *topology;
-    struct idset *ids = NULL;
-    struct group *group;
+    struct idset *ids;
+    bool set_flag;
+    json_t *update = NULL;
 
-    if (strcmp (status, "lost") != 0
-        && strcmp (status, "offline") != 0)
-        return;
-
-    if (!(topology = overlay_get_subtree_topo (ov, rank)))
-        flux_log_error (g->ctx->h, "groups: error fetching subtree");
-
-    batch_flush (g); // handle any JOINs before loss
+    if (torpid && !idset_test (g->torpid, rank))
+        set_flag = true;
+    else if (!torpid && idset_test (g->torpid, rank))
+        set_flag = false;
+    else
+        return; // nothing to do
 
     if (!(ids = idset_create (0, IDSET_FLAG_AUTOGROW))
-        || add_subtree_ids (ids, topology) < 0)
-        goto done;
+        || idset_set (ids, rank) < 0
+        || !(update = update_encode (ids, set_flag))
+        || batch_append (g, "broker.torpid", update) < 0
+        || (set_flag ? idset_set (g->torpid, rank)
+                     : idset_clear (g->torpid, rank)) < 0) {
+        flux_log_error (g->ctx->h, "error updating broker.torpid");
+    }
+    idset_destroy (ids);
+    json_decref (update);
+}
+
+static void auto_leave (struct groups *g,
+                        const char *status,
+                        uint32_t rank,
+                        struct idset *ids)
+{
+    struct group *group;
+
     group = zhashx_first (g->groups);
     while (group) {
         struct idset *x;
@@ -698,6 +717,39 @@ static void overlay_monitor_cb (struct overlay *ov, uint32_t rank, void *arg)
         idset_destroy (x);
         group = zhashx_next (g->groups);
     }
+}
+
+static void overlay_monitor_cb (struct overlay *ov, uint32_t rank, void *arg)
+{
+    struct groups *g = arg;
+    const char *status = overlay_get_subtree_status (ov, rank);
+    json_t *topology;
+    struct idset *ids = NULL;
+
+    batch_flush (g); // handle any pending ops first
+
+    /* Prepare a list of ranks that are members of subtree rooted at rank.
+     */
+    if (!(topology = overlay_get_subtree_topo (ov, rank))
+        || !(ids = idset_create (0, IDSET_FLAG_AUTOGROW))
+        || add_subtree_ids (ids, topology) < 0)
+        goto done;
+
+    /* Generate LEAVEs for any groups 'rank' (and subtree) may be a member
+     * of if transitioning to lost (crashed) or offline (shutdown).
+     */
+    if (!strcmp (status, "lost") || !strcmp (status, "offline")) {
+        auto_leave (g, status, rank, ids);
+    }
+    /* Update broker.torpid if torpidity has changed while subtree is in
+     * one of the "online" states.
+     */
+    else if (!strcmp (status, "full")
+        || !strcmp (status, "partial")
+        || !strcmp (status, "degraded")) {
+        torpid_update (g, rank, ids, overlay_peer_is_torpid (ov, rank));
+    }
+
 done:
     idset_destroy (ids);
     json_decref (topology);
@@ -720,6 +772,7 @@ void groups_destroy (struct groups *g)
         zhashx_destroy (&g->groups);
         json_decref (g->batch);
         idset_destroy (g->self);
+        idset_destroy (g->torpid);
         flux_msg_handler_delvec (g->handlers);
         flux_watcher_destroy (g->batch_timer);
         free (g);
@@ -741,7 +794,8 @@ struct groups *groups_create (struct broker *ctx)
         goto error;
     }
     if (!(g->self = idset_create (0, IDSET_FLAG_AUTOGROW))
-        || idset_set (g->self, g->ctx->rank) < 0)
+        || idset_set (g->self, g->ctx->rank) < 0
+        || !(g->torpid = idset_create (0, IDSET_FLAG_AUTOGROW)))
         goto error;
     zhashx_set_destructor (g->groups, group_destructor);
     zhashx_set_key_duplicator (g->groups, NULL);

--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -1478,6 +1478,20 @@ static void disconnect_cb (flux_t *h,
         flux_log (h, LOG_DEBUG, "overlay: goodbye to %d health clients", count);
 }
 
+const char *overlay_get_subtree_status (struct overlay *ov, int rank)
+{
+    const char *result = "unknown";
+
+    if (rank == ov->rank)
+        result = subtree_status_str (ov->status);
+    else {
+        struct child *child;
+        if ((child = child_lookup_byrank (ov, rank)))
+            result = subtree_status_str (child->status);
+    }
+    return result;
+}
+
 /* Recursive function to build subtree topology object.
  * Right now the tree is regular.  In the future support the configuration
  * of irregular tree topologies.

--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -353,9 +353,11 @@ void overlay_log_torpid_children (struct overlay *ov)
     double now = flux_reactor_now (ov->reactor);
     char fsd[64];
     double torpid;
+    bool child_torpid_prev;
 
     if (torpid_max > 0) {
         foreach_overlay_child (ov, child) {
+            child_torpid_prev = child->torpid;
             if (subtree_is_online (child->status) && child->lastseen > 0) {
                 torpid = now - child->lastseen;
 
@@ -382,6 +384,8 @@ void overlay_log_torpid_children (struct overlay *ov)
                     }
                 }
             }
+            if (child_torpid_prev != child->torpid)
+                overlay_monitor_notify (ov, child->rank);
         }
     }
 }

--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -329,12 +329,6 @@ bool overlay_parent_error (struct overlay *ov)
             || ov->parent.offline);
 }
 
-bool overlay_parent_success (struct overlay *ov)
-{
-    return (ov->parent.hello_responded
-            && !ov->parent.hello_error);
-}
-
 void overlay_set_version (struct overlay *ov, int version)
 {
     ov->version = version;

--- a/src/broker/overlay.h
+++ b/src/broker/overlay.h
@@ -105,6 +105,11 @@ void overlay_set_ipv6 (struct overlay *ov, int enable);
  */
 json_t *overlay_get_subtree_topo (struct overlay *ov, int rank);
 
+/* Fetch status for TBON subtree rooted at 'rank'.  If 'rank' is not this
+ * broker's rank or one of its direct descendants, "unknown" is returned.
+ */
+const char *overlay_get_subtree_status (struct overlay *ov, int rank);
+
 /* Broker should call overlay_bind() if there are children.  This may happen
  * before any peers are authorized as long as they are authorized before they
  * try to connect.

--- a/src/broker/overlay.h
+++ b/src/broker/overlay.h
@@ -24,14 +24,9 @@ typedef enum {
 
 struct overlay;
 
-typedef void (*overlay_monitor_f)(struct overlay *ov, void *arg);
+typedef void (*overlay_monitor_f)(struct overlay *ov, uint32_t rank, void *arg);
 typedef void (*overlay_recv_f)(const flux_msg_t *msg,
                                overlay_where_t from,
-                               void *arg);
-typedef void (*overlay_loss_f)(struct overlay *ov,
-                               uint32_t rank,
-                               const char *status,
-                               json_t *topo,
                                void *arg);
 
 /* Create overlay network, registering 'cb' to be called with each
@@ -121,17 +116,18 @@ int overlay_bind (struct overlay *ov, const char *uri);
  */
 int overlay_connect (struct overlay *ov);
 
-/* 'cb' is called each time the number of connected TBON peers changes,
- * or when a TBON parent error occurs.  Use overlay_get_child_peer_count(),
- * overlay_parent_error() from the callback.
+/* Arrange for 'cb' to be called if:
+ * - error on TBON parent (rank = FLUX_NODEID_ANY)
+ * - a subtree rooted at rank (child) has changed status
+ * The following accessors may be useful in the callback:
+ * - overlay_parent_error() - test whether TBON parent connection has failed
+ * - overlay_get_child_peer_count() - number of online children
+ * - overlay_get_subtree_status (rank) - subtree status of child
+ * - overlay_get_subtree_topo (rank) - topology of subtree rooted at child
  */
-void overlay_set_monitor_cb (struct overlay *ov,
-                             overlay_monitor_f cb,
-                             void *arg);
-
-void overlay_set_loss_cb (struct overlay *ov,
-                          overlay_loss_f cb,
-                          void *arg);
+int overlay_set_monitor_cb (struct overlay *ov,
+                            overlay_monitor_f cb,
+                            void *arg);
 
 /* Register overlay-related broker attributes.
  */

--- a/src/broker/overlay.h
+++ b/src/broker/overlay.h
@@ -88,7 +88,6 @@ const char *overlay_get_bind_uri (struct overlay *ov);
 const char *overlay_get_parent_uri (struct overlay *ov);
 int overlay_set_parent_uri (struct overlay *ov, const char *uri);
 bool overlay_parent_error (struct overlay *ov);
-bool overlay_parent_success (struct overlay *ov);
 void overlay_set_version (struct overlay *ov, int version); // test only
 const char *overlay_get_uuid (struct overlay *ov);
 bool overlay_uuid_is_parent (struct overlay *ov, const char *uuid);
@@ -108,7 +107,7 @@ int overlay_connect (struct overlay *ov);
 
 /* 'cb' is called each time the number of connected TBON peers changes,
  * or when a TBON parent error occurs.  Use overlay_get_child_peer_count(),
- * overlay_parent_error(), or overlay_parent_connected() from the callback.
+ * overlay_parent_error() from the callback.
  */
 void overlay_set_monitor_cb (struct overlay *ov,
                              overlay_monitor_f cb,

--- a/src/broker/overlay.h
+++ b/src/broker/overlay.h
@@ -105,6 +105,11 @@ json_t *overlay_get_subtree_topo (struct overlay *ov, int rank);
  */
 const char *overlay_get_subtree_status (struct overlay *ov, int rank);
 
+/* A TBON child is "torpid" if no messages (including regular keepalives)
+ * have been received from it for a while.
+ */
+bool overlay_peer_is_torpid (struct overlay *ov, uint32_t rank);
+
 /* Broker should call overlay_bind() if there are children.  This may happen
  * before any peers are authorized as long as they are authorized before they
  * try to connect.

--- a/src/broker/overlay.h
+++ b/src/broker/overlay.h
@@ -31,7 +31,7 @@ typedef void (*overlay_recv_f)(const flux_msg_t *msg,
 typedef void (*overlay_loss_f)(struct overlay *ov,
                                uint32_t rank,
                                const char *status,
-                               json_t *topology,
+                               json_t *topo,
                                void *arg);
 
 /* Create overlay network, registering 'cb' to be called with each
@@ -93,6 +93,17 @@ const char *overlay_get_uuid (struct overlay *ov);
 bool overlay_uuid_is_parent (struct overlay *ov, const char *uuid);
 bool overlay_uuid_is_child (struct overlay *ov, const char *uuid);
 void overlay_set_ipv6 (struct overlay *ov, int enable);
+
+/* Fetch TBON subtree topo at 'rank'.  The returned topology object has the
+ * following recursive structure, where "children" is an array of topology
+ * objects:
+ *
+ * {"rank":i, "size":i, "children":o}
+ *
+ * If rank has no children, the "children" array will be present but empty.
+ * Caller must release returned object with json_decref().
+ */
+json_t *overlay_get_subtree_topo (struct overlay *ov, int rank);
 
 /* Broker should call overlay_bind() if there are children.  This may happen
  * before any peers are authorized as long as they are authorized before they

--- a/src/broker/state_machine.c
+++ b/src/broker/state_machine.c
@@ -767,7 +767,9 @@ static flux_future_t *monitor_parent (flux_t *h, void *arg)
 
 /* This callback is called when the overlay connection state has changed.
  */
-static void overlay_monitor_cb (struct overlay *overlay, void *arg)
+static void overlay_monitor_cb (struct overlay *overlay,
+                                uint32_t rank,
+                                void *arg)
 {
     struct state_machine *s = arg;
 

--- a/src/broker/test/overlay.c
+++ b/src/broker/test/overlay.c
@@ -522,10 +522,9 @@ void test_destroy (int size, struct context *ctx[])
 void monitor_diag_cb (struct overlay *ov, void *arg)
 {
     struct context *ctx = arg;
-    diag ("%s: children=%d parent_success=%s parent_error=%s",
+    diag ("%s: children=%d parent_error=%s",
           ctx->name,
           overlay_get_child_peer_count (ov),
-          overlay_parent_success (ov) ? "true" : "false",
           overlay_parent_error (ov) ? "true" : "false");
 }
 
@@ -568,8 +567,8 @@ void check_monitor (flux_t *h)
         "%s: reactor ran until child connected", ctx[0]->name);
     ok (overlay_get_child_peer_count (ctx[0]->ov) == 2,
         "%s: overlay_get_child_peer_count returns 2", ctx[0]->name);
-    ok (overlay_parent_success (ctx[2]->ov) == true,
-        "%s: overlay_parent_connected returns true", ctx[2]->name);
+    ok (overlay_parent_error (ctx[2]->ov) == false,
+        "%s: overlay_parent_error returns false", ctx[2]->name);
 
     /* rank 3 will try to connect with simulated wrong flux-core version
      * Disable rank 0 stopping the reactor and enable rank 3 to do it.
@@ -584,7 +583,7 @@ void check_monitor (flux_t *h)
     ok (overlay_get_child_peer_count (ctx[0]->ov) == 2,
         "%s: overlay_get_child_peer_count is still 2", ctx[0]->name);
     ok (overlay_parent_error (ctx[3]->ov) == true,
-        "%s: overlay_parent_connected returns true", ctx[3]->name);
+        "%s: overlay_parent_error returns true", ctx[3]->name);
     overlay_set_monitor_cb (ctx[3]->ov, monitor_diag_cb, ctx[3]);
 
     /* rank 4 will have its rank altered to '42' for overlay.hello
@@ -599,7 +598,7 @@ void check_monitor (flux_t *h)
     ok (overlay_get_child_peer_count (ctx[0]->ov) == 2,
         "%s: overlay_get_child_peer_count is still 2", ctx[0]->name);
     ok (overlay_parent_error (ctx[4]->ov) == true,
-        "%s: overlay_parent_connected returns true", ctx[4]->name);
+        "%s: overlay_parent_error returns true", ctx[4]->name);
 
     test_destroy (size, ctx);
 }

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -193,6 +193,7 @@ TESTSCRIPTS = \
 	t3305-system-rpctrack-up.t \
 	t3306-system-routercrash.t \
 	t3307-system-leafcrash.t \
+	t3308-system-torpid.t \
 	t4000-issues-test-driver.t \
 	lua/t0001-send-recv.t \
 	lua/t0002-rpc.t \

--- a/t/t3308-system-torpid.t
+++ b/t/t3308-system-torpid.t
@@ -1,0 +1,119 @@
+#!/bin/sh
+#
+
+test_description='Check torpid broker detection
+'
+
+. `dirname $0`/sharness.sh
+
+test_under_flux 2 system
+
+startctl="flux python ${SHARNESS_TEST_SRCDIR}/scripts/startctl.py"
+groups="flux python ${SHARNESS_TEST_SRCDIR}/scripts/groups.py"
+
+test_expect_success 'tell brokers to log to stderr' '
+	flux exec flux setattr log-stderr-mode local
+'
+test_expect_success 'load heartbeat module with fast rate for testing' '
+        flux module reload heartbeat period=0.5s
+'
+
+test_expect_success 'tbon.torpid max/min have expected values' '
+	TMIN=$(flux getattr tbon.torpid_min) &&
+	TMAX=$(flux getattr tbon.torpid_max) &&
+	test "$TMAX" = "30s" &&
+	test "$TMIN" = "5s"
+'
+
+test_expect_success 'tbon.torpid min/max can be set on live system' '
+	flux setattr tbon.torpid_max 60s &&
+	TMAX=$(flux getattr tbon.torpid_max) &&
+	test "$TMAX" = "1m" &&
+	flux setattr tbon.torpid_min 30s &&
+	TMIN=$(flux getattr tbon.torpid_min) &&
+	test "$TMIN" = "30s"
+'
+
+test_expect_success 'tbon.torpid min/max cannot be set to non-FSD value' '
+	test_must_fail flux setattr tbon.torpid_min foo &&
+	test_must_fail flux setattr tbon.torpid_max bar
+'
+
+test_expect_success 'tbon.torpid_min cannot be set to zero' '
+	test_must_fail flux setattr tbon.torpid_min 0
+'
+
+test_expect_success 'torpid_min can be set via config' '
+	mkdir -p conf.d &&
+	cat >conf.d/tbon.toml <<-EOT &&
+	tbon.torpid_min = "6s"
+	EOT
+	TMIN=$(FLUX_CONF_DIR=conf.d flux start flux getattr tbon.torpid_min) &&
+	test "$TMIN" = "6s"
+'
+
+test_expect_success 'torpid_min cannot be set to 0 via config' '
+	mkdir -p conf.d &&
+	cat >conf.d/tbon.toml <<-EOT &&
+	tbon.torpid_min = "0"
+	EOT
+	test_must_fail bash -c "FLUX_CONF_DIR=conf.d flux start \
+		flux getattr tbon.torpid_min"
+'
+
+test_expect_success 'torpid_max can be set to 0 via config' '
+	mkdir -p conf.d &&
+	cat >conf.d/tbon.toml <<-EOT &&
+	tbon.torpid_max = "0"
+	EOT
+	TMAX=$(FLUX_CONF_DIR=conf.d flux start flux getattr tbon.torpid_max) &&
+	test "$TMAX" = "0s"
+'
+
+# tbon.torpid_min should be >= sync_min (1s hardwired)
+test_expect_success 'reduce tbon.torpid max/min values for testing' '
+	flux exec flux setattr tbon.torpid_min 1s &&
+	flux exec flux setattr tbon.torpid_max 2s
+'
+
+test_expect_success 'kill -STOP broker 1' '
+	$startctl kill 1 19
+'
+
+test_expect_success 'rank 1 is added to broker.torpid group' '
+	$groups waitfor --count=1 broker.torpid
+'
+
+test_expect_success 'kill -CONT broker 1' '
+	$startctl kill 1 18
+'
+
+test_expect_success 'rank 1 is removed from broker.torpid group' '
+	$groups waitfor --count=0 broker.torpid
+'
+
+test_expect_success 'set tbon.torpid_max to impossible to attain value' '
+	flux setattr tbon.torpid_max 0.1s
+'
+
+test_expect_success 'rank 1 is added to broker.torpid group' '
+	$groups waitfor --count=1 broker.torpid
+'
+
+test_expect_success 'set tbon.torpid_max to zero to disable' '
+	flux setattr tbon.torpid_max 0
+'
+
+test_expect_success 'rank 1 is removed from broker.torpid group' '
+	$groups waitfor --count=0 broker.torpid
+'
+
+test_expect_success 'rank 1 is removed from broker.torpid group' '
+	$groups waitfor --count=0 broker.torpid
+'
+
+test_expect_success 'rank 1 was drained' '
+	test $(flux resource status -s drain -no {nnodes}) -eq 1
+'
+
+test_done


### PR DESCRIPTION
Here is a first cut at changes to drain nodes that are "torpid" (unresponsive).

A broker group `broker.torpid` is set up to track torpid nodes based on the existing code for logging them.  Then the resource module watches that group.  Any broker ranks (er execution targets) entering the group are drained with the message `broker was unresponsive` and will remain drained until someone manually runs `flux resource undrain target`.

The parameters affecting this behavior can be set via config file or broker attribute.  The broker attribute can be set on the fly.  In case it becomes annoying during a DAT or something, it can be disabled with `flux exec flux setattr tbon.torpid_max 0`.

I just realized while writing this that I didn't update man pages so adding WIP and will take care of that later.