### PR TITLE
doc: add man pages for config files

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -288,7 +288,9 @@ MAN5_FILES_PRIMARY = \
 	man5/flux-config-tbon.5 \
 	man5/flux-config-exec.5 \
 	man5/flux-config-resource.5 \
-	man5/flux-config-archive.5
+	man5/flux-config-archive.5 \
+	man5/flux-config-job-manager.5
+
 
 MAN7_FILES = $(MAN7_FILES_PRIMARY)
 

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -285,7 +285,8 @@ MAN5_FILES_PRIMARY = \
 	man5/flux-config.5 \
 	man5/flux-config-access.5 \
 	man5/flux-config-bootstrap.5 \
-	man5/flux-config-tbon.5
+	man5/flux-config-tbon.5 \
+	man5/flux-config-exec.5
 
 MAN7_FILES = $(MAN7_FILES_PRIMARY)
 

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -287,7 +287,8 @@ MAN5_FILES_PRIMARY = \
 	man5/flux-config-bootstrap.5 \
 	man5/flux-config-tbon.5 \
 	man5/flux-config-exec.5 \
-	man5/flux-config-resource.5
+	man5/flux-config-resource.5 \
+	man5/flux-config-archive.5
 
 MAN7_FILES = $(MAN7_FILES_PRIMARY)
 

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -286,7 +286,8 @@ MAN5_FILES_PRIMARY = \
 	man5/flux-config-access.5 \
 	man5/flux-config-bootstrap.5 \
 	man5/flux-config-tbon.5 \
-	man5/flux-config-exec.5
+	man5/flux-config-exec.5 \
+	man5/flux-config-resource.5
 
 MAN7_FILES = $(MAN7_FILES_PRIMARY)
 

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -284,7 +284,8 @@ MAN5_FILES = $(MAN5_FILES_PRIMARY)
 MAN5_FILES_PRIMARY = \
 	man5/flux-config.5 \
 	man5/flux-config-access.5 \
-	man5/flux-config-bootstrap.5
+	man5/flux-config-bootstrap.5 \
+	man5/flux-config-tbon.5
 
 MAN7_FILES = $(MAN7_FILES_PRIMARY)
 

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -283,6 +283,7 @@ MAN5_FILES = $(MAN5_FILES_PRIMARY)
 
 MAN5_FILES_PRIMARY = \
 	man5/flux-config.5 \
+	man5/flux-config-access.5 \
 	man5/flux-config-bootstrap.5
 
 MAN7_FILES = $(MAN7_FILES_PRIMARY)

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -282,6 +282,7 @@ MAN3_FILES_SECONDARY = \
 MAN5_FILES = $(MAN5_FILES_PRIMARY)
 
 MAN5_FILES_PRIMARY = \
+	man5/flux-config.5 \
 	man5/flux-config-bootstrap.5
 
 MAN7_FILES = $(MAN7_FILES_PRIMARY)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -416,6 +416,7 @@ man_pages = [
     ('man5/flux-config-tbon', 'flux-config-tbon', 'configure Flux overlay network', [author], 5),
     ('man5/flux-config-exec', 'flux-config-exec', 'configure Flux job execution service', [author], 5),
     ('man5/flux-config-resource', 'flux-config-resource', 'configure Flux resource service', [author], 5),
+    ('man5/flux-config-archive', 'flux-config-archive', 'configure Flux job archival service', [author], 5),
     ('man7/flux-broker-attributes', 'flux-broker-attributes', 'overview Flux broker attributes', [author], 7),
     ('man7/flux-jobtap-plugins', 'flux-jobtap-plugins', 'overview Flux jobtap plugin API', [author], 7),
 ]

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -415,6 +415,7 @@ man_pages = [
     ('man5/flux-config-bootstrap', 'flux-config-bootstrap', 'configure Flux instance bootstrap', [author], 5),
     ('man5/flux-config-tbon', 'flux-config-tbon', 'configure Flux overlay network', [author], 5),
     ('man5/flux-config-exec', 'flux-config-exec', 'configure Flux job execution service', [author], 5),
+    ('man5/flux-config-resource', 'flux-config-resource', 'configure Flux resource service', [author], 5),
     ('man7/flux-broker-attributes', 'flux-broker-attributes', 'overview Flux broker attributes', [author], 7),
     ('man7/flux-jobtap-plugins', 'flux-jobtap-plugins', 'overview Flux jobtap plugin API', [author], 7),
 ]

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -413,6 +413,7 @@ man_pages = [
     ('man5/flux-config', 'flux-config', 'Flux configuration files', [author], 5),
     ('man5/flux-config-access', 'flux-config-access', 'configure Flux instance access', [author], 5),
     ('man5/flux-config-bootstrap', 'flux-config-bootstrap', 'configure Flux instance bootstrap', [author], 5),
+    ('man5/flux-config-tbon', 'flux-config-tbon', 'configure Flux overlay network', [author], 5),
     ('man7/flux-broker-attributes', 'flux-broker-attributes', 'overview Flux broker attributes', [author], 7),
     ('man7/flux-jobtap-plugins', 'flux-jobtap-plugins', 'overview Flux jobtap plugin API', [author], 7),
 ]

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -411,6 +411,7 @@ man_pages = [
     ('man3/flux_jobtap_get_flux','flux_jobtap_reject_job', 'Flux jobtap plugin interfaces', [author], 3),
     ('man3/flux_sync_create','flux_sync_create', 'Synchronize on system heartbeat', [author], 3),
     ('man5/flux-config', 'flux-config', 'Flux configuration files', [author], 5),
+    ('man5/flux-config-access', 'flux-config-access', 'configure Flux instance access', [author], 5),
     ('man5/flux-config-bootstrap', 'flux-config-bootstrap', 'configure Flux instance bootstrap', [author], 5),
     ('man7/flux-broker-attributes', 'flux-broker-attributes', 'overview Flux broker attributes', [author], 7),
     ('man7/flux-jobtap-plugins', 'flux-jobtap-plugins', 'overview Flux jobtap plugin API', [author], 7),

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -414,6 +414,7 @@ man_pages = [
     ('man5/flux-config-access', 'flux-config-access', 'configure Flux instance access', [author], 5),
     ('man5/flux-config-bootstrap', 'flux-config-bootstrap', 'configure Flux instance bootstrap', [author], 5),
     ('man5/flux-config-tbon', 'flux-config-tbon', 'configure Flux overlay network', [author], 5),
+    ('man5/flux-config-exec', 'flux-config-exec', 'configure Flux job execution service', [author], 5),
     ('man7/flux-broker-attributes', 'flux-broker-attributes', 'overview Flux broker attributes', [author], 7),
     ('man7/flux-jobtap-plugins', 'flux-jobtap-plugins', 'overview Flux jobtap plugin API', [author], 7),
 ]

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -410,6 +410,7 @@ man_pages = [
     ('man3/flux_jobtap_get_flux','flux_jobtap_priority_unavail', 'Flux jobtap plugin interfaces', [author], 3),
     ('man3/flux_jobtap_get_flux','flux_jobtap_reject_job', 'Flux jobtap plugin interfaces', [author], 3),
     ('man3/flux_sync_create','flux_sync_create', 'Synchronize on system heartbeat', [author], 3),
+    ('man5/flux-config', 'flux-config', 'Flux configuration files', [author], 5),
     ('man5/flux-config-bootstrap', 'flux-config-bootstrap', 'configure Flux instance bootstrap', [author], 5),
     ('man7/flux-broker-attributes', 'flux-broker-attributes', 'overview Flux broker attributes', [author], 7),
     ('man7/flux-jobtap-plugins', 'flux-jobtap-plugins', 'overview Flux jobtap plugin API', [author], 7),

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -417,6 +417,7 @@ man_pages = [
     ('man5/flux-config-exec', 'flux-config-exec', 'configure Flux job execution service', [author], 5),
     ('man5/flux-config-resource', 'flux-config-resource', 'configure Flux resource service', [author], 5),
     ('man5/flux-config-archive', 'flux-config-archive', 'configure Flux job archival service', [author], 5),
+    ('man5/flux-config-job-manager', 'flux-config-job-manager', 'configure Flux job manager service', [author], 5),
     ('man7/flux-broker-attributes', 'flux-broker-attributes', 'overview Flux broker attributes', [author], 7),
     ('man7/flux-jobtap-plugins', 'flux-jobtap-plugins', 'overview Flux jobtap plugin API', [author], 7),
 ]

--- a/doc/man5/flux-config-access.rst
+++ b/doc/man5/flux-config-access.rst
@@ -1,0 +1,50 @@
+=====================
+flux-config-access(5)
+=====================
+
+
+DESCRIPTION
+===========
+
+Flux normally denies access to all users except the instance owner (the user
+running the Flux instance).  The system instance, however, runs as the
+``flux`` user and permits limited access to guests, such as submitting work
+and manipulating their own jobs.
+
+The ``access`` table is required for a multi-user Flux system instance and may
+contain the following keys:
+
+
+KEYS
+====
+
+allow-guest-user
+   (optional) Boolean value to allow guest users to connect and assigns them
+   the ``user`` role.  If set to false or not present, connection attempts
+   by guests fail with EPERM.
+
+allow-root-owner
+   (optional) Boolean value to assign ``owner`` role to root user.  If set to false
+   or not present, root is treated like any other guest.
+
+
+EXAMPLE
+=======
+
+::
+
+   [access]
+   allow-guest-user = true
+   allow-root-owner = true
+
+
+RESOURCES
+=========
+
+Flux: http://flux-framework.org
+
+
+SEE ALSO
+========
+
+:man5:`flux-config`

--- a/doc/man5/flux-config-archive.rst
+++ b/doc/man5/flux-config-archive.rst
@@ -1,0 +1,51 @@
+======================
+flux-config-archive(5)
+======================
+
+
+DESCRIPTION
+===========
+
+The **job-archive** service periodically archives job data in a
+sqlite database for use by **flux-accounting**.  Its default parameters may
+be altered by the ``archive`` table which may contain the following keys:
+
+
+KEYS
+====
+
+dbpath
+   (optional) Set the path to the sqlite database file.  The service does
+   nothing if this key is unset.
+
+period
+   (optional) Set the archival period (in RFC 23 Flux Standard Duration format).
+   The default is 60s.
+
+busytimeout
+   (optional) Set the sqlite busy_timeout pragma (in RFC 23 Flux Standard
+   Duration format).  The default is 50s.
+
+
+EXAMPLE
+=======
+
+::
+
+   [archive]
+   dbpath = "/var/lib/flux/job-archive.sqlite"
+   period = 60
+   busytimeout = 50
+
+
+RESOURCES
+=========
+
+Flux: http://flux-framework.org
+
+RFC 23: Flux Standard Duration: https://github.com/flux-framework/rfc/blob/master/spec_23.rst
+
+SEE ALSO
+========
+
+:man5:`flux-config`

--- a/doc/man5/flux-config-bootstrap.rst
+++ b/doc/man5/flux-config-bootstrap.rst
@@ -6,28 +6,21 @@ flux-config-bootstrap(5)
 DESCRIPTION
 ===========
 
-The broker discovers the size of the Flux instance, the broker's rank,
-and overlay network wireup information either dynamically using a PMI
-service, such as when being launched by Flux or another resource manager,
-or statically using the ``bootstrap`` section of the Flux configuration,
-such as when being launched by systemd.
+The system instance requires that the overlay network configuration be
+statically configured.  The ``bootstrap`` TOML table defines these details
+for a given cluster.
 
-The default bootstrap mode is PMI. To select config file bootstrap,
-specify the config directory with the ``--config-path=PATH`` broker command
-line option or set ``FLUX_CONF_DIR`` in the broker's environment. Ensure that
-this directory contains a file that defines the ``bootstrap`` section.
+WARNING:  Although ``flux config reload`` works on a live system, these
+settings do not take effect until the next broker restart.  As such, they
+must only be changed in conjunction with a full system instance restart in
+order to avoid brokers becoming de-synchronized if they are independently
+restarted before the next instance restart.
 
-
-CONFIG FILES
-============
-
-Flux uses the TOML configuration file format. The ``bootstrap`` section is
-a TOML table containing the following keys. Each node in a cluster is
-expected to bootstrap from an identical config file.
+The ``bootstrap`` table contains the following keys:
 
 
-KEYWORDS
-========
+KEYS
+====
 
 enable_ipv6
    (optional) Boolean value for enabling IPv6.  By default only IPv4 is
@@ -89,12 +82,14 @@ EXAMPLE
    default_connect = "tcp://e%h:%p"
 
    hosts = [
-       {
-           host="fluke0",
+       {   # Management requires non-default config
+           host="test0",
            bind="tcp://en4:9001",
-           connect="tcp://fluke-mgmt:9001"
+           connect="tcp://test-mgmt:9001"
        },
-       { host = "fluke[1-1023]" },
+       {   # Other nodes use defaults
+           host = "test[1-1023]"
+       },
    ]
 
 
@@ -107,4 +102,4 @@ Flux: http://flux-framework.org
 SEE ALSO
 ========
 
-:man1:`flux-getattr`, :man3:`flux_attr_get`
+:man5:`flux-config`

--- a/doc/man5/flux-config-exec.rst
+++ b/doc/man5/flux-config-exec.rst
@@ -1,0 +1,50 @@
+===================
+flux-config-exec(5)
+===================
+
+
+DESCRIPTION
+===========
+
+The Flux system instance **job-exec** service requires additional
+configuration via the ``exec`` table, for example to enlist the services
+of a setuid helper to launch jobs as guests.
+
+The ``exec`` table may contain the following keys:
+
+
+KEYS
+====
+
+imp
+   (optional) Set the path to the IMP (Independent Minister of Privilege)
+   helper program, as described in RFC 15, so that jobs may be launched with
+   the credentials of the guest user that submitted them.  If unset, only
+   jobs submitted by the instance owner may be executed.
+
+job-shell
+   (optional) Override the compiled-in default job shell path.
+
+
+EXAMPLE
+=======
+
+::
+
+   [exec]
+   imp = "/usr/libexec/flux/flux-imp"
+   job-shell = "/usr/libexec/flux/flux-shell-special"
+
+
+RESOURCES
+=========
+
+Flux: http://flux-framework.org
+
+RFC 15: Flux Security: https://github.com/flux-framework/rfc/blob/master/spec_15.rs
+
+
+SEE ALSO
+========
+
+:man5:`flux-config`

--- a/doc/man5/flux-config-job-manager.rst
+++ b/doc/man5/flux-config-job-manager.rst
@@ -1,0 +1,78 @@
+==========================
+flux-config-job-manager(5)
+==========================
+
+
+DESCRIPTION
+===========
+
+The Flux **job-manager** service may be configured via the ``job-manager``
+table, which may contain the following keys:
+
+
+KEYS
+====
+
+events_maxlen
+   (optional) Integer value that determines the maximum number of job events to
+   be retained in the in-memory journal used to answer queries.  The default
+   is 1000.
+
+plugins
+   (optional) An array of objects defining a list of jobtap plugin directives.
+   Each directive follows the format defined in the :ref:`plugin_directive`
+   section.
+
+
+.. _plugin_directive:
+
+PLUGIN DIRECTIVE
+================
+
+load
+   (optional) A string instructing the job manager to load a plugin matching
+   the given filename into the job-manager.  If the path is not absolute,
+   then the first plugin matching the job-manager searchpath will be loaded.
+
+remove
+   (optional) A string instructing the job manager to remove all plugins
+   matching  the  value.  The  value may be a :linux:man7:`glob`. If ``remove``
+   appears with ``load``, plugin removal is always handled first.  The special
+   value ``all`` is a synonym for ``*``, but will not fail when no plugins
+   match.
+
+conf
+   (optional) An object, valid with ``load`` only, that defines a configuration
+   table to pass to the loaded plugin.
+
+
+EXAMPLE
+=======
+
+::
+
+   [job-manager]
+
+   events_maxlen = 10000
+
+   plugins = [
+      {
+        load = "priority-custom.so",
+        conf = {
+           job-limit = 100,
+           size-limit = 128
+        }
+      }
+   ]
+
+
+RESOURCES
+=========
+
+Flux: http://flux-framework.org
+
+
+SEE ALSO
+========
+
+:man5:`flux-config`, :man1:`flux-jobtap`, :man7:`flux-jobtap-plugins`

--- a/doc/man5/flux-config-resource.rst
+++ b/doc/man5/flux-config-resource.rst
@@ -1,0 +1,59 @@
+=======================
+flux-config-resource(5)
+=======================
+
+
+DESCRIPTION
+===========
+
+The Flux **resource** service provides an interface to the scheduler
+for acquiring instance resources.  It accepts some configuration, especially
+useful in the Flux system instance where resources must be known before
+all brokers are online.
+
+The ``resource`` table may contain the following keys:
+
+
+KEYS
+====
+
+path
+   (optional) Set the path to an RFC 20 (R version 1) resource description
+   which defines the resources available to the system.  If undefined,
+   resources are determined either by dynamic discovery, or by information
+   passed from the enclosing Flux instance.  The ``flux R`` utility may be
+   used to generate this file.
+
+exclude
+   (optional) A string value that defines one or more nodes to withhold
+   from scheduling, either in RFC 22 idset form, or in RFC 29 hostlist form.
+   This value may be changed on a live system by reloading the configuration
+   on the rank 0 broker.  A newly excluded node will appear as "down" to
+   the scheduler, but will still be used to determine satisfiability of job
+   requests until the instance is restarted.
+
+
+EXAMPLE
+=======
+
+::
+
+   [resource]
+   path = "/etc/flux/system/R"
+   exclude = "test[3,108]"
+
+
+RESOURCES
+=========
+
+Flux: http://flux-framework.org
+
+RFC 22: Idset String Representation: https://github.com/flux-framework/rfc/blob/master/spec_22.rs
+
+RFC 29: Hostlist Format: https://github.com/flux-framework/rfc/blob/master/spec_29.rs
+
+
+SEE ALSO
+========
+
+:man5:`flux-config`

--- a/doc/man5/flux-config-tbon.rst
+++ b/doc/man5/flux-config-tbon.rst
@@ -1,0 +1,55 @@
+===================
+flux-config-tbon(5)
+===================
+
+
+DESCRIPTION
+===========
+
+The ``tbon`` table may be used to tune the configuration of the Flux tree-based
+overlay network (TBON).
+
+It may contain the following keys:
+
+
+KEYS
+====
+
+torpid_min
+   (optional) The amount of time (in RFC 23 Flux Standard Duration format) that
+   a broker will allow the connection to its TBON parent to remain idle before
+   sending a keepalive message.  The default value of ``5s`` should be
+   reasonable in most circumstances.  This configured value may be overridden
+   by setting the ``tbon.torpid_min`` broker attribute.
+
+torpid_max
+   (optional) The amount of time (in RFC 23 Flux Standard Duration format) that
+   a broker will wait for an idle TBON child connection to send messages before
+   declaring it torpid  (unresponsive). A value of 0 disables torpid node
+   checking.  Torpid nodes are automatically drained and require manual
+   undraining with :man1:`flux-resource`.  This configured value may be
+   overridden by setting the ``tbon.torpid_max`` broker attribute.
+
+
+EXAMPLE
+=======
+
+::
+
+   [tbon]
+   torpid_min = 10s
+   torpid_max = 1m
+
+
+RESOURCES
+=========
+
+Flux: http://flux-framework.org
+
+RFC 23: Flux Standard Duration: https://github.com/flux-framework/rfc/blob/master/spec_23.rst
+
+
+SEE ALSO
+========
+
+:man5:`flux-config`, :man7:`flux-broker-attributes`

--- a/doc/man5/flux-config.rst
+++ b/doc/man5/flux-config.rst
@@ -76,4 +76,5 @@ SEE ALSO
 
 :man1:`flux-broker`, :man5:`flux-config-access`, :man5:`flux-config-bootstrap`,
 :man5:`flux-config-tbon`, :man5:`flux-config-exec`,
-:man5:`flux-config-resource`, :man5:`flux-config-archive`
+:man5:`flux-config-resource`, :man5:`flux-config-archive`,
+:man5:`flux-config-job-manager`

--- a/doc/man5/flux-config.rst
+++ b/doc/man5/flux-config.rst
@@ -75,4 +75,4 @@ SEE ALSO
 ========
 
 :man1:`flux-broker`, :man5:`flux-config-access`, :man5:`flux-config-bootstrap`,
-:man5:`flux-config-tbon`
+:man5:`flux-config-tbon`, :man5:`flux-config-exec`

--- a/doc/man5/flux-config.rst
+++ b/doc/man5/flux-config.rst
@@ -1,0 +1,77 @@
+==============
+flux-config(5)
+==============
+
+DESCRIPTION
+===========
+
+Flux normally operates without configuration files.  If configuration is
+needed, the :man1:`flux-broker` **--config-path=DIR** option may be used
+to instruct Flux to parse all files matching the glob **DIR/*.toml**.
+Alteratively, the FLUX_CONF_DIR environment variable may be set the config
+directory path.  If both are set, the command line argument takes precedence.
+The option value must be a directory, not a file.
+
+The Flux systemd unit file starts the system instance broker with
+``--config-path=${sysconfdir}/flux/system/conf.d``.  Further discussion of the
+system instance configuration as a whole may be found in the Flux
+Administrator's Guide.
+
+Flux configuration files follow the TOML file format, with configuration
+subdivided by function into separate TOML tables.  The tables may all appear
+in a single ``.toml`` file or be fragmented in multiple files.  For example,
+the Flux Administrator's Guide suggests one file per top level TOML table.
+
+Each Flux broker parses configuration files independently, however it is
+assumed that config files are identical across the brokers of a given instance.
+System administrators managing Flux configuration files should ensure that
+this is the case, and be mindful that old ``.toml`` files must be removed from
+the configuration directory or renamed so they no longer match the glob.
+
+The configuration may be altered at runtime by changing the files, then running
+``flux config reload`` on each broker, or ``systemctl reload flux`` on each
+node of the system instance.  However see CAVEATS below.
+
+
+CAVEATS
+=======
+
+Although most Flux framework projects such as **fluxion** and
+**flux-accounting** are built upon the **flux-core** configuration mechanism
+described above, the **flux-security** project use a similar, but independent
+TOML configuration.  The security components unconditionally parse ``*.toml``
+from compiled-in directories: ``${sysconfdir}/flux/security/conf.d`` for the
+signing library, and ``${sysconfdir}/flux/imp/conf.d`` for the IMP.
+``flux config reload`` does not affect the security components.  Refer to the
+Flux Administrator's Guide for more information on configuring security.
+
+Some portions of the configuration use formats other than TOML:
+
+- The ``resource.path`` key optionally points to a file in RFC 20 (R version 1) JSON format.
+- The ``bootstrap.curve_cert`` key optionally points to a CURVE certificate in a ZeroMQ certificate file format.
+For clarity, these files should be located outside of the TOML configuration
+directory.
+
+Although configuration can be reloaded on a live system, it should be assumed
+that configuration parameters take effect on the next Flux broker restart
+unless otherwise noted in their documentation.  This means that some
+parameters, such as the system instance network topology, must only be
+changed in conjunction with a full system instance restart in order to avoid
+brokers becoming out of sync if they are independently restarted before the
+next instance restart.
+
+
+RESOURCES
+=========
+
+Flux: http://flux-framework.org
+
+Flux Administrator's Guide: https://flux-framework.readthedocs.io/en/latest/adminguide.html
+
+TOML: Tom's Obvious Minimal Language: https://toml.io/en/
+
+
+SEE ALSO
+========
+
+:man1:`flux-broker`, :man5:`flux-config-bootstrap`

--- a/doc/man5/flux-config.rst
+++ b/doc/man5/flux-config.rst
@@ -74,4 +74,5 @@ TOML: Tom's Obvious Minimal Language: https://toml.io/en/
 SEE ALSO
 ========
 
-:man1:`flux-broker`, :man5:`flux-config-access`, :man5:`flux-config-bootstrap`
+:man1:`flux-broker`, :man5:`flux-config-access`, :man5:`flux-config-bootstrap`,
+:man5:`flux-config-tbon`

--- a/doc/man5/flux-config.rst
+++ b/doc/man5/flux-config.rst
@@ -76,4 +76,4 @@ SEE ALSO
 
 :man1:`flux-broker`, :man5:`flux-config-access`, :man5:`flux-config-bootstrap`,
 :man5:`flux-config-tbon`, :man5:`flux-config-exec`,
-:man5:`flux-config-resource`
+:man5:`flux-config-resource`, :man5:`flux-config-archive`

--- a/doc/man5/flux-config.rst
+++ b/doc/man5/flux-config.rst
@@ -74,4 +74,4 @@ TOML: Tom's Obvious Minimal Language: https://toml.io/en/
 SEE ALSO
 ========
 
-:man1:`flux-broker`, :man5:`flux-config-bootstrap`
+:man1:`flux-broker`, :man5:`flux-config-access`, :man5:`flux-config-bootstrap`

--- a/doc/man5/flux-config.rst
+++ b/doc/man5/flux-config.rst
@@ -75,4 +75,5 @@ SEE ALSO
 ========
 
 :man1:`flux-broker`, :man5:`flux-config-access`, :man5:`flux-config-bootstrap`,
-:man5:`flux-config-tbon`, :man5:`flux-config-exec`
+:man5:`flux-config-tbon`, :man5:`flux-config-exec`,
+:man5:`flux-config-resource`

--- a/doc/man5/index.rst
+++ b/doc/man5/index.rst
@@ -11,3 +11,4 @@ man5
    flux-config-tbon
    flux-config-exec
    flux-config-resource
+   flux-config-archive

--- a/doc/man5/index.rst
+++ b/doc/man5/index.rst
@@ -6,4 +6,5 @@ man5
    :maxdepth: 1
 
    flux-config
+   flux-config-access
    flux-config-bootstrap

--- a/doc/man5/index.rst
+++ b/doc/man5/index.rst
@@ -12,3 +12,4 @@ man5
    flux-config-exec
    flux-config-resource
    flux-config-archive
+   flux-config-job-manager

--- a/doc/man5/index.rst
+++ b/doc/man5/index.rst
@@ -10,3 +10,4 @@ man5
    flux-config-bootstrap
    flux-config-tbon
    flux-config-exec
+   flux-config-resource

--- a/doc/man5/index.rst
+++ b/doc/man5/index.rst
@@ -9,3 +9,4 @@ man5
    flux-config-access
    flux-config-bootstrap
    flux-config-tbon
+   flux-config-exec

--- a/doc/man5/index.rst
+++ b/doc/man5/index.rst
@@ -8,3 +8,4 @@ man5
    flux-config
    flux-config-access
    flux-config-bootstrap
+   flux-config-tbon

--- a/doc/man5/index.rst
+++ b/doc/man5/index.rst
@@ -5,4 +5,5 @@ man5
    :caption: File formats and conventions
    :maxdepth: 1
 
+   flux-config
    flux-config-bootstrap

--- a/doc/man7/flux-jobtap-plugins.rst
+++ b/doc/man7/flux-jobtap-plugins.rst
@@ -34,8 +34,7 @@ passed along when registering the handler.
 Multiple plugins may be loaded in the job-manager simultaneously. In this
 case, all matching handlers are called in all loaded plugins in the order
 in which they were loaded. For more information about loading plugins
-see the :ref:`configuration` section below or the :man1:`flux-jobtap`
-manpage.
+see the :man5:`flux-conf-job-manager` or :man1:`flux-jobtap` manpage.
 
 JOBTAP PLUGIN NAMES
 ===================
@@ -239,7 +238,7 @@ plugin may explicitly be removed with
 
     flux jobtap remove .priority-default
 
-or via configuration (See :ref:`configuration` below)
+or via configuration (See :man5:`flux-conf-job-manager`)
 
 ::
 
@@ -320,47 +319,6 @@ called for a job in an invaid state, these function will return -1 with
 
 Multiple prolog or epilog actions can be active at the same time.
 
-.. _configuration:
-
-CONFIGURATION
-=============
-
-Job-manager plugin configuration is defined in the ``job-manager.plugins``
-section of the Flux TOML configuration file. This section is an array of
-plugin directives which include the following keys:
-
-load
-  Load a plugin matching the given filename into the job-manager. If the
-  path is not absolute, then the first plugin matching the job-manager
-  searchpath will be loaded.
-
-conf
-  With load only, pass an optional configuration table to the loaded plugin.
-
-remove
-  Remove all plugins matching the value. The value may be a
-  :linux:man7:`glob`. If ``remove`` appears with ``load``, plugin
-  removal is always handled first.  The special value ``all`` is a
-  synonym for ``*``, but will not error when no plugins match.
-
-For example
-
-::
-
-    [job-manager]
-    plugins = [
-       {
-         load = "priority-custom.so",
-         conf = {
-            job-limit = 100,
-            size-limit = 128
-         }
-       }
-    ]
-
-The list of loaded jobtap plugins may also be queried and controlled at
-runtime with the :man1:`flux-jobtap` command
-
 
 RESOURCES
 =========
@@ -371,5 +329,5 @@ Flux: http://flux-framework.org
 SEE ALSO
 ========
 
-:man1:`flux-jobtap`
+:man1:`flux-jobtap`, :man5:`flux-conf-job-manager`
 


### PR DESCRIPTION
This PR fills in some missing man pages in section 5.  For a start it adds `flux-config(5)` which is an overview of config files, and pages for a couple of additional tables, including for `tbon` so we can document the new "torpid" knobs.  I wanted to see if this pattern looks OK before adding more (hence WIP).  I was thinking we could have a man page for each top level table, named with the pattern `flux-config-NAME.5` where NAME is the table name.  That seem reasonable?

Then we can reference these pages from the configuration section of the [Administrator's Guide](https://flux-framework.readthedocs.io/en/latest/adminguide.html).