### PR TITLE
flux-proxy: improve experience when proxied Flux instance terminates

### DIFF
--- a/doc/man1/flux-proxy.rst
+++ b/doc/man1/flux-proxy.rst
@@ -26,6 +26,14 @@ including a Flux jobid, a fully-resolved native ``ssh`` or ``local``
 URI, or a resolvable URI with a scheme supported by a ``flux uri``
 plugin.  See :man1:`flux-uri` for details.
 
+If the connection to the Flux instance is lost, for example when the
+target instance terminates, **flux proxy** will emit an error message,
+send ``SIGHUP`` and ``SIGCONT`` to the spawned shell or other process,
+and wait for it to terminate before exiting.  The delivery of signals
+can be disabled with the ``-n, --nohup`` option, but be aware that Flux
+commands running under a **flux proxy** which has lost its connection
+will likely result in errors.
+
 The purpose of **flux proxy** is to allow a connection to be reused,
 for example where connection establishment has high latency or
 requires authentication.
@@ -37,6 +45,15 @@ OPTIONS
 **-f, --force**
    Allow the proxy command to connect to a broker running a different
    version of Flux with a warning message instead of a fatal error.
+
+**-n, --nohup**
+   When an error occurs in the proxy connection, **flux proxy** will
+   normally shut down the proxy and send ``SIGHUP`` and ``SIGCONT`` to
+   the spawned shell or command. If the ``-n, --nohup`` option is used,
+   the ``SIGHUP`` and ``SIGCONT`` signals will not be sent.
+   **flux proxy** will still wait for the spawned shell or command to
+   exit before terminating to avoid having the child process reparented
+   and possibly lose its controlling tty.
 
 EXAMPLES
 ========

--- a/src/cmd/builtin/proxy.c
+++ b/src/cmd/builtin/proxy.c
@@ -281,6 +281,14 @@ static void version_check (flux_t *h, bool force)
     }
 }
 
+static void proxy_command_destroy_usock_and_router (struct proxy_command *ctx)
+{
+    usock_server_destroy (ctx->server); // destroy before router
+    ctx->server = NULL;
+    router_destroy (ctx->router);
+    ctx->router = NULL;
+}
+
 static int cmd_proxy (optparse_t *p, int ac, char *av[])
 {
     int n;
@@ -351,13 +359,26 @@ static int cmd_proxy (optparse_t *p, int ac, char *av[])
      */
     save_terminal_state ();
     if (flux_reactor_run (r, 0) < 0) {
+        if (errno == ECONNRESET)
+            log_msg ("Lost connection to Flux");
+        else
+            log_err ("flux_reactor_run");
+        if (!optparse_hasopt (p, "nohup")) {
+            log_msg ("Sending SIGHUP to child processes");
+            flux_future_destroy (flux_subprocess_kill (ctx.p, SIGHUP));
+            flux_future_destroy (flux_subprocess_kill (ctx.p, SIGCONT));
+        }
+        proxy_command_destroy_usock_and_router (&ctx);
+
+        /*
+         * Wait for child to normally terminate
+         */
+        flux_reactor_run (r, 0);
         restore_terminal_state ();
-        log_err ("flux_reactor_run");
         goto done;
     }
 done:
-    usock_server_destroy (ctx.server); // destroy before router
-    router_destroy (ctx.router);
+    proxy_command_destroy_usock_and_router (&ctx);
 
     if (ctx.exit_code)
         exit (ctx.exit_code);
@@ -369,6 +390,9 @@ done:
 static struct optparse_option proxy_opts[] = {
     { .name = "force",  .key = 'f',  .has_arg = 0,
       .usage = "Skip version check when connecting to Flux broker", },
+    { .name = "nohup",  .key = 'n',  .has_arg = 0,
+      .usage = "Do not send SIGHUP to child processes when connection"
+               " to Flux is lost", },
     OPTPARSE_TABLE_END,
 };
 

--- a/t/t1105-proxy.t
+++ b/t/t1105-proxy.t
@@ -13,6 +13,7 @@ export TEST_FLUX=${FLUX_BUILD_DIR}/src/cmd/flux
 export TEST_TMPDIR=${TMPDIR:-/tmp}
 RPC=${FLUX_BUILD_DIR}/t/request/rpc
 EVENT_TRACE="$SHARNESS_TEST_SRCDIR/scripts/event-trace.lua"
+RUNPTY="$SHARNESS_TEST_SRCDIR/scripts/runpty.py"
 
 test_expect_success 'flux-proxy creates new socket' '
 	PROXY_URI=$(flux proxy $TEST_URI printenv FLUX_URI) &&
@@ -116,6 +117,18 @@ test_expect_success 'flux-proxy works with /jobid argument' '
 	test "$uri" = "$FLUX_URI" &&
 	flux job cancel $id &&
 	flux job wait-event -vt 10 $id clean
+'
+test_expect_success NO_CHAIN_LINT 'flux-proxy attempts to restore terminal on error' '
+	cat <<-EOF >test.sh &&
+	#!/bin/bash
+	flux --parent job cancel \$(flux getattr jobid)
+	while true; do sleep 0.1; done
+	EOF
+	chmod +x test.sh
+	id=$(flux mini batch -n1 --wrap flux mini run sleep 600) &&
+	flux job wait-event -vt 60 $id memo &&
+	$RUNPTY -o pty.out -f asciicast flux proxy ${id}?local $(pwd)/test.sh &&
+	grep "\[\?25h" pty.out
 '
 
 test_done


### PR DESCRIPTION
This PR contains a few fixes (already described in #2139) to improve the experience of `flux proxy` users when the proxied Flux instance terminates.

Currently, `flux proxy` exits, leaving the child process (usually an interactive shell) to be reparented to PID 1 and lose its terminal. This typically causes the user's tty to get into a bad state. Sometimes I've even had myself logged out of my connection to the host from which I originally ran `flux proxy`.

This PR adds a couple mitigations for these problems:

  * Attempt to restore terminal when `flux proxy` gets an error. This seems to help me in most cases, though nothing is guaranteed. The code makes a best-effort attempt to do the restore.
  * Attempt to keep `flux proxy` running until the child process exits. This makes it so that the child process is not reparented to init and doesn't lose its controlling tty. This possibly obviates the need for the first approach above, but since restoring the terminal shouldn't hurt anything, we keep that for now.
  * Add a `-k, --kill` option that causes `flux-proxy` to send `SIGTERM` to the child process on error. This could be useful to ensure cleanup of the child when the proxied Flux instance terminates.

This can be considered a proposal PR. I'm open to any changes or adjustments.