### PR TITLE
libsubprocess: fix excess logging and logging corner cases

### DIFF
--- a/src/common/libsubprocess/local.c
+++ b/src/common/libsubprocess/local.c
@@ -165,7 +165,7 @@ static int channel_local_setup (flux_subprocess_t *p,
     int buffer_size;
 
     if (!(c = channel_create (p, output_f, name, channel_flags))) {
-        flux_log_error (p->h, "calloc");
+        flux_log_error (p->h, "channel_create");
         goto error;
     }
 

--- a/src/common/libsubprocess/local.c
+++ b/src/common/libsubprocess/local.c
@@ -165,12 +165,12 @@ static int channel_local_setup (flux_subprocess_t *p,
     int buffer_size;
 
     if (!(c = channel_create (p, output_f, name, channel_flags))) {
-        flux_log_error (p->h, "channel_create");
+        flux_log (p->h, LOG_DEBUG, "channel_create");
         goto error;
     }
 
     if (socketpair (PF_LOCAL, SOCK_STREAM, 0, fds) < 0) {
-        flux_log_error (p->h, "socketpair");
+        flux_log (p->h, LOG_DEBUG, "socketpair");
         goto error;
     }
 
@@ -184,12 +184,12 @@ static int channel_local_setup (flux_subprocess_t *p,
     fds[1] = -1;
 
     if ((fd_flags = fd_set_nonblocking (c->parent_fd)) < 0) {
-        flux_log_error (p->h, "fd_set_nonblocking");
+        flux_log (p->h, LOG_DEBUG, "fd_set_nonblocking");
         goto error;
     }
 
     if ((buffer_size = cmd_option_bufsize (p, name)) < 0) {
-        flux_log_error (p->h, "cmd_option_bufsize");
+        flux_log (p->h, LOG_DEBUG, "cmd_option_bufsize");
         goto error;
     }
 
@@ -201,7 +201,7 @@ static int channel_local_setup (flux_subprocess_t *p,
                                                               0,
                                                               c);
         if (!c->buffer_write_w) {
-            flux_log_error (p->h, "flux_buffer_write_watcher_create");
+            flux_log (p->h, LOG_DEBUG, "flux_buffer_write_watcher_create");
             goto error;
         }
     }
@@ -210,7 +210,7 @@ static int channel_local_setup (flux_subprocess_t *p,
         int wflag;
 
         if ((wflag = cmd_option_line_buffer (p, name)) < 0) {
-            flux_log_error (p->h, "cmd_option_line_buffer");
+            flux_log (p->h, LOG_DEBUG, "cmd_option_line_buffer");
             goto error;
         }
 
@@ -224,7 +224,7 @@ static int channel_local_setup (flux_subprocess_t *p,
                                                             wflag,
                                                             c);
         if (!c->buffer_read_w) {
-            flux_log_error (p->h, "flux_buffer_read_watcher_create");
+            flux_log (p->h, LOG_DEBUG, "flux_buffer_read_watcher_create");
             goto error;
         }
 
@@ -233,7 +233,7 @@ static int channel_local_setup (flux_subprocess_t *p,
 
     if (channel_flags & CHANNEL_FD) {
         if (asprintf (&e, "%s", name) < 0) {
-            flux_log_error (p->h, "asprintf");
+            flux_log (p->h, LOG_DEBUG, "asprintf");
             goto error;
         }
 
@@ -244,17 +244,17 @@ static int channel_local_setup (flux_subprocess_t *p,
                               e,
                               "%d",
                               c->child_fd) < 0) {
-            flux_log_error (p->h, "flux_cmd_setenvf");
+            flux_log (p->h, LOG_DEBUG, "flux_cmd_setenvf");
             goto error;
         }
     }
 
     if (zhash_insert (p->channels, name, c) < 0) {
-        flux_log_error (p->h, "zhash_insert");
+        flux_log (p->h, LOG_DEBUG, "zhash_insert");
         goto error;
     }
     if (!zhash_freefn (p->channels, name, channel_destroy)) {
-        flux_log_error (p->h, "zhash_freefn");
+        flux_log (p->h, LOG_DEBUG, "zhash_freefn");
         goto error;
     }
 
@@ -322,7 +322,7 @@ static int local_setup_channels (flux_subprocess_t *p)
     int len;
 
     if (!(channels = flux_cmd_channel_list (p->cmd))) {
-        flux_log_error (p->h, "flux_cmd_channel_list");
+        flux_log (p->h, LOG_DEBUG, "flux_cmd_channel_list");
         return -1;
     }
 
@@ -409,7 +409,7 @@ static void closefd_child (void *arg, int fd)
  *   signal to proceed. This is done by writing 1 byte to child side of
  *   socketpair, and waiting for parent to write one byte back.
  *
- * Call fprintf instead of flux_log_error(), errors in child should
+ * Call fprintf instead of flux_log(), errors in child should
  *  go to parent error streams.
  */
 static int local_child_ready (flux_subprocess_t *p)
@@ -433,7 +433,7 @@ static int local_child_ready (flux_subprocess_t *p)
 static void local_child_report_exec_failed_errno (flux_subprocess_t *p, int e)
 {
     int fd = p->sync_fds[1];
-    /* Call fprintf instead of flux_log_error(), errors in child
+    /* Call fprintf instead of flux_log(), errors in child
      * should go to parent error streams. */
     if (write (fd, &e, sizeof (e)) != sizeof (e))
         fprintf (stderr, "local_child_report_exec_failed_errno: %s\n",
@@ -453,7 +453,7 @@ static int local_child (flux_subprocess_t *p)
     /* Throughout this function use _exit() instead of exit(), to
      * avoid calling any atexit() routines of parent.
      *
-     * Call fprintf instead of flux_log_error(), errors in child
+     * Call fprintf instead of flux_log(), errors in child
      * should go to parent error streams.
      */
 
@@ -553,7 +553,7 @@ static int subprocess_parent_wait_on_child (flux_subprocess_t *p)
     char c;
 
     if (read (p->sync_fds[0], &c, sizeof (c)) != 1) {
-        flux_log_error (p->h, "subprocess_parent_wait_on_child: read");
+        flux_log (p->h, LOG_DEBUG, "subprocess_parent_wait_on_child: read");
         return -1;
     }
     return 0;
@@ -609,7 +609,7 @@ static int local_fork (flux_subprocess_t *p)
                                                   true,
                                                   child_watch_cb,
                                                   p))) {
-        flux_log_error (p->h, "flux_child_watcher_create");
+        flux_log (p->h, LOG_DEBUG, "flux_child_watcher_create");
         return -1;
     }
 

--- a/src/common/libsubprocess/remote.c
+++ b/src/common/libsubprocess/remote.c
@@ -354,7 +354,7 @@ static int remote_channel_setup (flux_subprocess_t *p,
     int buffer_size;
 
     if (!(c = channel_create (p, output_f, name, channel_flags))) {
-        flux_log_error (p->h, "calloc");
+        flux_log_error (p->h, "channel_create");
         goto error;
     }
 

--- a/src/common/libsubprocess/remote.c
+++ b/src/common/libsubprocess/remote.c
@@ -698,6 +698,8 @@ static void remote_exec_cb (flux_future_t *f, void *arg)
     return;
 
 error:
+    process_new_state (p, FLUX_SUBPROCESS_FAILED,
+                       p->rank, -1, errno, 0);
     if (p->state == FLUX_SUBPROCESS_RUNNING) {
         flux_future_t *fkill;
         if (!(fkill = remote_kill (p, SIGKILL)))
@@ -708,8 +710,6 @@ error:
         else
             flux_future_destroy (fkill);
     }
-    process_new_state (p, FLUX_SUBPROCESS_FAILED,
-                       p->rank, -1, errno, 0);
     flux_future_destroy (f);
     p->f = NULL;
 }

--- a/src/common/libsubprocess/remote.c
+++ b/src/common/libsubprocess/remote.c
@@ -250,19 +250,15 @@ static void remote_in_check_cb (flux_reactor_t *r,
     flux_watcher_stop (c->in_idle_w);
 
     if (flux_buffer_bytes (c->write_buffer) > 0) {
-        if (remote_write (c) < 0) {
-            flux_log_error (c->p->h, "remote_write");
+        if (remote_write (c) < 0)
             goto error;
-        }
     }
 
     if (!flux_buffer_bytes (c->write_buffer)
         && c->closed
         && !c->write_eof_sent) {
-        if (remote_close (c) < 0) {
-            flux_log_error (c->p->h, "remote_close");
+        if (remote_close (c) < 0)
             goto error;
-        }
         c->write_eof_sent = true;
     }
 

--- a/src/common/libsubprocess/remote.c
+++ b/src/common/libsubprocess/remote.c
@@ -660,10 +660,11 @@ static void remote_exec_cb (flux_future_t *f, void *arg)
     if (flux_rpc_get_unpack (f, "{ s:s s:i }",
                              "type", &type,
                              "rank", &rank) < 0) {
-        flux_log_error (p->h,
-                        "%s: flux_rpc_get_unpack: rank %u",
-                        __FUNCTION__,
-                        flux_rpc_get_nodeid (f));
+        if (errno != EHOSTUNREACH) // broker is down, don't log
+            flux_log_error (p->h,
+                            "%s: flux_rpc_get_unpack: rank %u",
+                            __FUNCTION__,
+                            flux_rpc_get_nodeid (f));
         goto error;
     }
 

--- a/src/common/libsubprocess/remote.c
+++ b/src/common/libsubprocess/remote.c
@@ -597,8 +597,12 @@ static int remote_output (flux_subprocess_t *p, flux_future_t *f,
     }
 
     if (!(c = zhash_lookup (p->channels, stream))) {
-        flux_log_error (p->h, "invalid channel received: rank = %d, pid = %d, stream = %s",
-                 rank, pid, stream);
+        flux_log_error (p->h,
+                        "invalid channel received: "
+                        "rank = %d, pid = %d, stream = %s",
+                        rank,
+                        pid,
+                        stream);
         errno = EPROTO;
         goto cleanup;
     }
@@ -614,8 +618,13 @@ static int remote_output (flux_subprocess_t *p, flux_future_t *f,
         /* add list of msgs if there is overflow? */
 
         if (tmp != len) {
-            flux_log_error (p->h, "channel buffer error: rank = %d pid = %d, stream = %s, len = %d",
-                            rank, pid, stream, len);
+            flux_log_error (p->h,
+                            "channel buffer error: "
+                            "rank = %d pid = %d, stream = %s, len = %d",
+                            rank,
+                            pid,
+                            stream,
+                            len);
             errno = EOVERFLOW;
             goto cleanup;
         }

--- a/src/common/libsubprocess/remote.c
+++ b/src/common/libsubprocess/remote.c
@@ -169,7 +169,7 @@ static int remote_write (struct subprocess_channel *c)
     int rv = -1;
 
     if (!(ptr = flux_buffer_read (c->write_buffer, -1, &lenp))) {
-        flux_log_error (c->p->h, "flux_buffer_read");
+        flux_log (c->p->h, LOG_DEBUG, "flux_buffer_read");
         goto error;
     }
 
@@ -184,7 +184,7 @@ static int remote_write (struct subprocess_channel *c)
 
     /* rank not needed, set to 0 */
     if (!(io = ioencode (c->name, "0", ptr, lenp, eof))) {
-        flux_log_error (c->p->h, "ioencode");
+        flux_log (c->p->h, LOG_DEBUG, "ioencode");
         goto error;
     }
 
@@ -193,7 +193,7 @@ static int remote_write (struct subprocess_channel *c)
                              "{ s:i s:O }",
                              "pid", c->p->pid,
                              "io", io))) {
-        flux_log_error (c->p->h, "flux_rpc_pack");
+        flux_log (c->p->h, LOG_DEBUG, "flux_rpc_pack");
         goto error;
     }
 
@@ -215,7 +215,7 @@ static int remote_close (struct subprocess_channel *c)
 
     /* rank not needed, set to 0 */
     if (!(io = ioencode (c->name, "0", NULL, 0, true))) {
-        flux_log_error (c->p->h, "ioencode");
+        flux_log (c->p->h, LOG_DEBUG, "ioencode");
         goto error;
     }
 
@@ -224,7 +224,7 @@ static int remote_close (struct subprocess_channel *c)
                              "{ s:i s:O }",
                              "pid", c->p->pid,
                              "io", io))) {
-        flux_log_error (c->p->h, "flux_rpc_pack");
+        flux_log (c->p->h, LOG_DEBUG, "flux_rpc_pack");
         goto error;
     }
 
@@ -350,39 +350,39 @@ static int remote_channel_setup (flux_subprocess_t *p,
     int buffer_size;
 
     if (!(c = channel_create (p, output_f, name, channel_flags))) {
-        flux_log_error (p->h, "channel_create");
+        flux_log (p->h, LOG_DEBUG, "channel_create");
         goto error;
     }
 
     if ((buffer_size = cmd_option_bufsize (p, name)) < 0) {
-        flux_log_error (p->h, "cmd_option_bufsize");
+        flux_log (p->h, LOG_DEBUG, "cmd_option_bufsize");
         goto error;
     }
 
     if (channel_flags & CHANNEL_WRITE) {
         if (!(c->write_buffer = flux_buffer_create (buffer_size))) {
-            flux_log_error (p->h, "flux_buffer_create");
+            flux_log (p->h, LOG_DEBUG, "flux_buffer_create");
             goto error;
         }
 
         if (!(c->in_prep_w = flux_prepare_watcher_create (p->reactor,
                                                           remote_in_prep_cb,
                                                           c))) {
-            flux_log_error (p->h, "flux_prepare_watcher_create");
+            flux_log (p->h, LOG_DEBUG, "flux_prepare_watcher_create");
             goto error;
         }
 
         if (!(c->in_idle_w = flux_idle_watcher_create (p->reactor,
                                                        NULL,
                                                        c))) {
-            flux_log_error (p->h, "flux_idle_watcher_create");
+            flux_log (p->h, LOG_DEBUG, "flux_idle_watcher_create");
             goto error;
         }
 
         if (!(c->in_check_w = flux_check_watcher_create (p->reactor,
                                                          remote_in_check_cb,
                                                          c))) {
-            flux_log_error (p->h, "flux_check_watcher_create");
+            flux_log (p->h, LOG_DEBUG, "flux_check_watcher_create");
             goto error;
         }
 
@@ -395,7 +395,7 @@ static int remote_channel_setup (flux_subprocess_t *p,
         int wflag;
 
         if ((wflag = cmd_option_line_buffer (p, name)) < 0) {
-            flux_log_error (p->h, "cmd_option_line_buffer");
+            flux_log (p->h, LOG_DEBUG, "cmd_option_line_buffer");
             goto error;
         }
 
@@ -403,7 +403,7 @@ static int remote_channel_setup (flux_subprocess_t *p,
             c->line_buffered = true;
 
         if (!(c->read_buffer = flux_buffer_create (buffer_size))) {
-            flux_log_error (p->h, "flux_buffer_create");
+            flux_log (p->h, LOG_DEBUG, "flux_buffer_create");
             goto error;
         }
         p->channels_eof_expected++;
@@ -411,21 +411,21 @@ static int remote_channel_setup (flux_subprocess_t *p,
         if (!(c->out_prep_w = flux_prepare_watcher_create (p->reactor,
                                                            remote_out_prep_cb,
                                                            c))) {
-            flux_log_error (p->h, "flux_prepare_watcher_create");
+            flux_log (p->h, LOG_DEBUG, "flux_prepare_watcher_create");
             goto error;
         }
 
         if (!(c->out_idle_w = flux_idle_watcher_create (p->reactor,
                                                         NULL,
                                                         c))) {
-            flux_log_error (p->h, "flux_idle_watcher_create");
+            flux_log (p->h, LOG_DEBUG, "flux_idle_watcher_create");
             goto error;
         }
 
         if (!(c->out_check_w = flux_check_watcher_create (p->reactor,
                                                           remote_out_check_cb,
                                                           c))) {
-            flux_log_error (p->h, "flux_check_watcher_create");
+            flux_log (p->h, LOG_DEBUG, "flux_check_watcher_create");
             goto error;
         }
 
@@ -434,11 +434,11 @@ static int remote_channel_setup (flux_subprocess_t *p,
     }
 
     if (zhash_insert (p->channels, name, c) < 0) {
-        flux_log_error (p->h, "zhash_insert");
+        flux_log (p->h, LOG_DEBUG, "zhash_insert");
         goto error;
     }
     if (!zhash_freefn (p->channels, name, channel_destroy)) {
-        flux_log_error (p->h, "zhash_freefn");
+        flux_log (p->h, LOG_DEBUG, "zhash_freefn");
         goto error;
     }
 
@@ -496,7 +496,7 @@ static int remote_setup_channels (flux_subprocess_t *p)
     int len;
 
     if (!(channels = flux_cmd_channel_list (p->cmd))) {
-        flux_log_error (p->h, "flux_cmd_channel_list");
+        flux_log (p->h, LOG_DEBUG, "flux_cmd_channel_list");
         return -1;
     }
 
@@ -537,16 +537,17 @@ static int remote_state (flux_subprocess_t *p, flux_future_t *f,
     int status = 0;
 
     if (flux_rpc_get_unpack (f, "{ s:i }", "state", &state) < 0) {
-        flux_log_error (p->h,
-                        "%s: flux_rpc_get_unpack: rank %u",
-                        __FUNCTION__,
-                        flux_rpc_get_nodeid (f));
+        flux_log (p->h,
+                  LOG_DEBUG,
+                  "%s: flux_rpc_get_unpack: rank %u",
+                  __FUNCTION__,
+                  flux_rpc_get_nodeid (f));
         return -1;
     }
 
     if (state == FLUX_SUBPROCESS_RUNNING) {
         if (flux_rpc_get_unpack (f, "{ s:i }", "pid", &pid) < 0) {
-            flux_log_error (p->h, "%s: flux_rpc_get_unpack", __FUNCTION__);
+            flux_log (p->h, LOG_DEBUG, "%s: flux_rpc_get_unpack", __FUNCTION__);
             return -1;
         }
     }
@@ -554,14 +555,14 @@ static int remote_state (flux_subprocess_t *p, flux_future_t *f,
     if (state == FLUX_SUBPROCESS_EXEC_FAILED
         || state == FLUX_SUBPROCESS_FAILED) {
         if (flux_rpc_get_unpack (f, "{ s:i }", "errno", &errnum) < 0) {
-            flux_log_error (p->h, "%s: flux_rpc_get_unpack", __FUNCTION__);
+            flux_log (p->h, LOG_DEBUG, "%s: flux_rpc_get_unpack", __FUNCTION__);
             return -1;
         }
     }
 
     if (state == FLUX_SUBPROCESS_EXITED) {
         if (flux_rpc_get_unpack (f, "{ s:i }", "status", &status) < 0) {
-            flux_log_error (p->h, "%s: flux_rpc_get_unpack", __FUNCTION__);
+            flux_log (p->h, LOG_DEBUG, "%s: flux_rpc_get_unpack", __FUNCTION__);
             return -1;
         }
     }
@@ -583,22 +584,23 @@ static int remote_output (flux_subprocess_t *p, flux_future_t *f,
     int rv = -1;
 
     if (flux_rpc_get_unpack (f, "{ s:o }", "io", &io)) {
-        flux_log_error (p->h, "flux_rpc_get_unpack EPROTO io");
+        flux_log (p->h, LOG_DEBUG, "flux_rpc_get_unpack EPROTO io");
         goto cleanup;
     }
 
     if (iodecode (io, &stream, NULL, &data, &len, &eof) < 0) {
-        flux_log_error (p->h, "iodecode");
+        flux_log (p->h, LOG_DEBUG, "iodecode");
         goto cleanup;
     }
 
     if (!(c = zhash_lookup (p->channels, stream))) {
-        flux_log_error (p->h,
-                        "invalid channel received: "
-                        "rank = %d, pid = %d, stream = %s",
-                        rank,
-                        pid,
-                        stream);
+        flux_log (p->h,
+                  LOG_DEBUG,
+                  "invalid channel received: "
+                  "rank = %d, pid = %d, stream = %s",
+                  rank,
+                  pid,
+                  stream);
         errno = EPROTO;
         goto cleanup;
     }
@@ -607,20 +609,21 @@ static int remote_output (flux_subprocess_t *p, flux_future_t *f,
         int tmp;
 
         if ((tmp = flux_buffer_write (c->read_buffer, data, len)) < 0) {
-            flux_log_error (p->h, "flux_buffer_write");
+            flux_log (p->h, LOG_DEBUG, "flux_buffer_write");
             goto cleanup;
         }
 
         /* add list of msgs if there is overflow? */
 
         if (tmp != len) {
-            flux_log_error (p->h,
-                            "channel buffer error: "
-                            "rank = %d pid = %d, stream = %s, len = %d",
-                            rank,
-                            pid,
-                            stream,
-                            len);
+            flux_log (p->h,
+                      LOG_DEBUG,
+                      "channel buffer error: "
+                      "rank = %d pid = %d, stream = %s, len = %d",
+                      rank,
+                      pid,
+                      stream,
+                      len);
             errno = EOVERFLOW;
             goto cleanup;
         }
@@ -628,7 +631,7 @@ static int remote_output (flux_subprocess_t *p, flux_future_t *f,
     if (eof) {
         c->read_eof_received = true;
         if (flux_buffer_readonly (c->read_buffer) < 0)
-            flux_log_error (p->h, "flux_buffer_readonly");
+            flux_log (p->h, LOG_DEBUG, "flux_buffer_readonly");
     }
 
     rv = 0;
@@ -657,10 +660,11 @@ static void remote_exec_cb (flux_future_t *f, void *arg)
                              "type", &type,
                              "rank", &rank) < 0) {
         if (errno != EHOSTUNREACH) // broker is down, don't log
-            flux_log_error (p->h,
-                            "%s: flux_rpc_get_unpack: rank %u",
-                            __FUNCTION__,
-                            flux_rpc_get_nodeid (f));
+            flux_log (p->h,
+                      LOG_DEBUG,
+                      "%s: flux_rpc_get_unpack: rank %u",
+                      __FUNCTION__,
+                      flux_rpc_get_nodeid (f));
         goto error;
     }
 
@@ -677,7 +681,7 @@ static void remote_exec_cb (flux_future_t *f, void *arg)
     }
     else if (!strcmp (type, "output")) {
         if (flux_rpc_get_unpack (f, "{ s:i }", "pid", &pid) < 0) {
-            flux_log_error (p->h, "%s: flux_rpc_get_unpack", __FUNCTION__);
+            flux_log (p->h, LOG_DEBUG, "%s: flux_rpc_get_unpack", __FUNCTION__);
             goto error;
         }
         if (remote_output (p, f, rank, pid) < 0)
@@ -690,7 +694,7 @@ static void remote_exec_cb (flux_future_t *f, void *arg)
         p->f = NULL;
     }
     else {
-        flux_log_error (p->h, "%s: EPROTO", __FUNCTION__);
+        flux_log (p->h, LOG_DEBUG, "%s: EPROTO", __FUNCTION__);
         errno = EPROTO;
         goto error;
     }
@@ -725,22 +729,23 @@ static void remote_continuation_cb (flux_future_t *f, void *arg)
                              "type", &type,
                              "rank", &rank) < 0) {
         if (errno != EHOSTUNREACH) // broker is down, don't log
-            flux_log_error (p->h,
-                            "%s: flux_rpc_get_unpack: rank %u",
-                            __FUNCTION__,
-                            flux_rpc_get_nodeid (f));
+            flux_log (p->h,
+                      LOG_DEBUG,
+                      "%s: flux_rpc_get_unpack: rank %u",
+                      __FUNCTION__,
+                      flux_rpc_get_nodeid (f));
         goto error;
     }
 
     if (!strcmp (type, "start")) {
         flux_future_reset (f);
         if (flux_future_then (f, -1., remote_exec_cb, p) < 0) {
-            flux_log_error (p->h, "flux_future_then");
+            flux_log (p->h, LOG_DEBUG, "flux_future_then");
             goto error;
         }
     }
     else {
-        flux_log_error (p->h, "%s: EPROTO", __FUNCTION__);
+        flux_log (p->h, LOG_DEBUG, "%s: EPROTO", __FUNCTION__);
         errno = EPROTO;
         goto error;
     }
@@ -766,7 +771,7 @@ int remote_exec (flux_subprocess_t *p)
     int save_errno;
 
     if (!(cmd_str = flux_cmd_tojson (p->cmd))) {
-        flux_log_error (p->h, "flux_cmd_tojson");
+        flux_log (p->h, LOG_DEBUG, "flux_cmd_tojson");
         goto error;
     }
 
@@ -780,12 +785,12 @@ int remote_exec (flux_subprocess_t *p)
                              "on_channel_out", p->ops.on_channel_out ? 1 : 0,
                              "on_stdout", p->ops.on_stdout ? 1 : 0,
                              "on_stderr", p->ops.on_stderr ? 1 : 0))) {
-        flux_log_error (p->h, "flux_rpc");
+        flux_log (p->h, LOG_DEBUG, "flux_rpc");
         goto error;
     }
 
     if (flux_future_then (f, -1., remote_continuation_cb, p) < 0) {
-        flux_log_error (p->h, "flux_future_then");
+        flux_log (p->h, LOG_DEBUG, "flux_future_then");
         goto error;
     }
 
@@ -809,7 +814,7 @@ flux_future_t *remote_kill (flux_subprocess_t *p, int signum)
                              "{s:i s:i}",
                              "pid", p->pid,
                              "signum", signum))) {
-        flux_log_error (p->h, "%s: flux_rpc_pack", __FUNCTION__);
+        flux_log (p->h, LOG_DEBUG, "%s: flux_rpc_pack", __FUNCTION__);
         return NULL;
     }
     return f;

--- a/src/common/libsubprocess/server.c
+++ b/src/common/libsubprocess/server.c
@@ -408,8 +408,13 @@ static int write_subprocess (flux_subprocess_server_t *s, flux_subprocess_t *p,
     /* add list of msgs if there is overflow? */
 
     if (tmp != len) {
-        flux_log_error (s->h, "channel buffer error: rank = %d pid = %d, stream = %s, len = %d",
-                        s->rank, flux_subprocess_pid (p), stream, len);
+        flux_log_error (s->h,
+                        "channel buffer error: "
+                        "rank = %d pid = %d, stream = %s, len = %d",
+                        s->rank,
+                        flux_subprocess_pid (p),
+                        stream,
+                        len);
         errno = EOVERFLOW;
         return -1;
     }


### PR DESCRIPTION
Initially spawned by issue #3964, ending up fixing many minor things.

- some lines > 80 chars
- some invalid error messages
- do not log common EHOSTUNREACH errors
- remove duplicate logging
- fix potential errno clobbering error
- (and then finally) when error is returned to the user, do not log to LOG_ERR, log to LOG_DEBUG to avoid likely redundant error logs