### PR TITLE
cmd/flux-ping: make help output clearer

### DIFF
--- a/src/cmd/flux-ping.c
+++ b/src/cmd/flux-ping.c
@@ -262,6 +262,7 @@ void parse_service (const char *s, uint32_t *nodeid, char **topic)
 int main (int argc, char *argv[])
 {
     int pad_bytes;
+    char *cmdusage = "[OPTIONS] TARGET";
     flux_watcher_t *tw = NULL;
     optparse_t *opts;
     struct ping_ctx ctx;
@@ -272,6 +273,8 @@ int main (int argc, char *argv[])
     log_init ("flux-ping");
 
     opts = optparse_create ("flux-ping");
+    if (optparse_set (opts, OPTPARSE_USAGE, cmdusage) != OPTPARSE_SUCCESS)
+        log_msg_exit ("optparse_set (USAGE)");
     if (optparse_add_option_table (opts, cmdopts) != OPTPARSE_SUCCESS)
         log_msg_exit ("optparse_add_option_table");
     if ((optindex = optparse_parse_args (opts, argc, argv)) < 0)

--- a/t/t0007-ping.t
+++ b/t/t0007-ping.t
@@ -132,4 +132,9 @@ test_expect_success 'ping with "upstream" works (format 3)' '
         grep -q -E "time=[0-9]+\.[0-9]+ ms" stdout
 '
 
+test_expect_success 'ping help output works' '
+        flux ping --help 2> help.err &&
+        grep "Usage: flux-ping \[OPTIONS\] TARGET" help.err
+'
+
 test_done


### PR DESCRIPTION
Problem: The default help output says "flux-ping [OPTIONS] ..."
which is not clear.

Solution: Update output to "flux-ping [OPTIONS] \<target\>".

Fixes #3892