### PR TITLE
improve error message from flux-proxy and flux-jobs for invalid and unknown jobids

### DIFF
--- a/src/bindings/python/flux/job/JobID.py
+++ b/src/bindings/python/flux/job/JobID.py
@@ -55,7 +55,10 @@ class JobID(int):
         if isinstance(value, int):
             jobid = value
         else:
-            jobid = id_parse(value)
+            try:
+                jobid = id_parse(value)
+            except OSError:
+                raise ValueError(f"{value} is not a valid Flux jobid")
         self = super(cls, cls).__new__(cls, jobid)
         self.orig_str = str(value)
         return self

--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -299,7 +299,7 @@ test_expect_success 'flux jobs can take specific IDs in any form' '
 	test_cmp ids.specific.expected ids.specific.out
 '
 
-test_expect_success 'flux-jobs error on bad IDs' '
+test_expect_success 'flux-jobs error on unknown IDs' '
 	flux jobs --suppress-header 0 1 2 2> ids.err &&
 	count=`grep -i unknown ids.err | wc -l` &&
 	test $count -eq 3

--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -305,6 +305,11 @@ test_expect_success 'flux-jobs error on bad IDs' '
 	test $count -eq 3
 '
 
+test_expect_success 'flux-jobs errors with illegal IDs' '
+	test_must_fail flux jobs --suppress-header IllegalID 2> illegal_ids.err &&
+	grep "invalid JobID value" illegal_ids.err
+'
+
 test_expect_success 'flux-jobs good and bad IDs works' '
 	ids=$(state_ids sched) &&
 	flux jobs --suppress-header ${ids} 0 1 2 > ids.out 2> ids.err &&

--- a/t/t2803-flux-pstree.t
+++ b/t/t2803-flux-pstree.t
@@ -108,6 +108,12 @@ test_expect_success 'flux-pstree JOBID works' '
 	EOF
 	test_cmp ${name}.expected ${name}.output
 '
+test_expect_success 'flux-pstree errors on unknown JOBID' '
+	name="jobidunknown" &&
+	flux pstree 123456789 2> ${name}.output &&
+	test_debug "cat ${name}.output" &&
+	grep "unknown" ${name}.output
+'
 test_expect_success 'flux-pstree errors on illegal JOBID' '
 	name="jobidillegal" &&
 	test_must_fail flux pstree IllegalID 2> ${name}.output &&

--- a/t/t2803-flux-pstree.t
+++ b/t/t2803-flux-pstree.t
@@ -108,6 +108,12 @@ test_expect_success 'flux-pstree JOBID works' '
 	EOF
 	test_cmp ${name}.expected ${name}.output
 '
+test_expect_success 'flux-pstree errors on illegal JOBID' '
+	name="jobidillegal" &&
+	test_must_fail flux pstree IllegalID 2> ${name}.output &&
+	test_debug "cat ${name}.output" &&
+	grep "invalid JobID value" ${name}.output
+'
 test_expect_success 'flux-pstree works when run inside child job' '
 	name="proxy" &&
 	flux proxy $rid flux pstree > ${name}.output &&


### PR DESCRIPTION
Problem: When the user inputs an illegal job id the error
message is a very generic:

flux-jobs: ERROR: [Errno 22] EINVAL: Invalid argument

which can be confusing and unclear what was done wrong.

Solution: Improve error message to:

flux-jobs: error: argument JOBID: illegal JobID <invalid arg>

Add a test case.

Fixes #3882