### PR TITLE
doc: fix cross-references

### DIFF
--- a/doc/man1/flux-content.rst
+++ b/doc/man1/flux-content.rst
@@ -132,4 +132,4 @@ RESOURCES
 
 Flux: http://flux-framework.org
 
-RFC 10: Content Storage Service: https://github.com/flux-framework/rfc/blob/master/spec_10.rst
+RFC 10: Content Storage Service: https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/spec_10.html

--- a/doc/man1/flux-kvs.rst
+++ b/doc/man1/flux-kvs.rst
@@ -90,7 +90,7 @@ COMMANDS
    from being merged with with other contemporaneous commits. *-A*
    appends the value to a key instead of overwriting the value. Append
    is incompatible with the -j option. After a successful put, *-O* or
-   *-s* can be specified to output the RFC11 treeobj or root sequence
+   *-s* can be specified to output the RFC 11 treeobj or root sequence
    number of the root containing the put(s).
 
 **ls** [-N ns] [-R] [-d] [-F] [-w COLS] [-1] [*key* ...]
@@ -118,7 +118,7 @@ COMMANDS
    namespace to commit to via *-N*. If *key* represents a directory,
    specify *-R* to remove all keys underneath it. If *-f* is specified,
    ignore nonexistent files. After a successful unlink, *-O* or *-s* can
-   be specified to output the RFC11 treeobj or root sequence number of
+   be specified to output the RFC 11 treeobj or root sequence number of
    the root containing the unlink(s).
 
 **link** [-N ns] [-T ns] [-O|-s] *target* *linkname*
@@ -127,7 +127,7 @@ COMMANDS
    it is overwritten. Specify an alternate namespace to commit linkname
    to via *-N*. Specify the target's namespace via *-T*. After a
    successfully created link, *-O* or *-s* can be specified to output the
-   RFC11 treeobj or root sequence number of the root containing the link.
+   RFC 11 treeobj or root sequence number of the root containing the link.
 
 **readlink** [-N ns] [-a treeobj] [ -o \| -k ] *key* [*key* ...]
    Retrieve the key a link refers to rather than its value, as would be
@@ -142,7 +142,7 @@ COMMANDS
    Create an empty directory and commit the change. If *key* exists,
    it is overwritten. Specify an alternate namespace to commit to via
    *-N*. After a successful mkdir, *-O* or *-s* can be specified to
-   output the RFC11 treeobj or root sequence number of the root
+   output the RFC 11 treeobj or root sequence number of the root
    containing the new directory.
 
 **copy** [-S src-ns] [-D dst-ns] *source* *destination*
@@ -214,3 +214,5 @@ RESOURCES
 =========
 
 Flux: http://flux-framework.org
+
+RFC 11: Key Value Store Tree Object Format v1: https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/spec_11.html

--- a/doc/man1/flux-resource.rst
+++ b/doc/man1/flux-resource.rst
@@ -133,6 +133,6 @@ RESOURCES
 
 Flux: http://flux-framework.org
 
-RFC 20: Resource Set Specification Version 1: https://github.com/flux-framework/rfc/blob/master/spec_22.rst
+RFC 20: Resource Set Specification Version 1: https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/spec_20.html
 
-RFC 27: Flux Resource Allocation Protocol Version 1: https://github.com/flux-framework/rfc/blob/master/spec_27.rst
+RFC 27: Flux Resource Allocation Protocol Version 1: https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/spec_27.html

--- a/doc/man3/flux_attr_get.rst
+++ b/doc/man3/flux_attr_get.rst
@@ -67,8 +67,6 @@ RESOURCES
 
 Flux: http://flux-framework.org
 
-RFC 3: Flux Message Protocol: https://github.com/flux-framework/rfc/blob/master/spec_3.rst
-
 
 SEE ALSO
 ========

--- a/doc/man3/flux_content_load.rst
+++ b/doc/man3/flux_content_load.rst
@@ -125,7 +125,7 @@ RESOURCES
 
 Flux: http://flux-framework.org
 
-RFC 10: Content Storage Service: https://github.com/flux-framework/rfc/blob/master/spec_10.rst
+RFC 10: Content Storage Service: https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/spec_10.html
 
 
 SEE ALSO

--- a/doc/man3/flux_get_rank.rst
+++ b/doc/man3/flux_get_rank.rst
@@ -50,4 +50,3 @@ RESOURCES
 
 Flux: http://flux-framework.org
 
-RFC 3: Flux Message Protocol: https://github.com/flux-framework/rfc/blob/master/spec_3.rst

--- a/doc/man3/flux_kvs_lookup.rst
+++ b/doc/man3/flux_kvs_lookup.rst
@@ -239,10 +239,5 @@ RESOURCES
 
 Flux: http://flux-framework.org
 
-RFC 11: Key Value Store Tree Object Format v1: https://github.com/flux-framework/rfc/blob/master/spec_11.rst
+RFC 11: Key Value Store Tree Object Format v1: https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/spec_11.html
 
-
-SEE ALSO
-========
-
-:man3:`flux_rpc`, :man3:`flux_future_then`

--- a/doc/man3/flux_kvs_txn_create.rst
+++ b/doc/man3/flux_kvs_txn_create.rst
@@ -141,7 +141,7 @@ RESOURCES
 
 Flux: http://flux-framework.org
 
-RFC 11: Key Value Store Tree Object Format v1: https://github.com/flux-framework/rfc/blob/master/spec_11.rst
+RFC 11: Key Value Store Tree Object Format v1: https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/spec_11.html
 
 
 SEE ALSO

--- a/doc/man3/flux_respond.rst
+++ b/doc/man3/flux_respond.rst
@@ -98,9 +98,9 @@ RESOURCES
 
 Flux: http://flux-framework.org
 
-RFC 6: Flux Remote Procedure Call Protocol: https://github.com/flux-framework/rfc/blob/master/spec_6.rst
+RFC 6: Flux Remote Procedure Call Protocol: https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/spec_6.html
 
-RFC 3: Flux Message Protocol: https://github.com/flux-framework/rfc/blob/master/spec_3.rst
+RFC 3: Flux Message Protocol: https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/spec_3.html
 
 
 SEE ALSO

--- a/doc/man3/flux_rpc.rst
+++ b/doc/man3/flux_rpc.rst
@@ -232,7 +232,7 @@ RESOURCES
 
 Flux: http://flux-framework.org
 
-RFC 6: Flux Remote Procedure Call Protocol: https://github.com/flux-framework/rfc/blob/master/spec_6.rst
+RFC 6: Flux Remote Procedure Call Protocol: https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/spec_6.html
 
 
 SEE ALSO

--- a/doc/man3/idset_add.rst
+++ b/doc/man3/idset_add.rst
@@ -103,7 +103,7 @@ RESOURCES
 
 Flux: http://flux-framework.org
 
-RFC 22: Idset String Representation: https://github.com/flux-framework/rfc/blob/master/spec_22.rst
+RFC 22: Idset String Representation: https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/spec_22.html
 
 
 SEE ALSO

--- a/doc/man3/idset_create.rst
+++ b/doc/man3/idset_create.rst
@@ -148,7 +148,7 @@ RESOURCES
 
 Flux: http://flux-framework.org
 
-RFC 22: Idset String Representation: https://github.com/flux-framework/rfc/blob/master/spec_22.rst
+RFC 22: Idset String Representation: https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/spec_22.html
 
 
 SEE ALSO

--- a/doc/man3/idset_encode.rst
+++ b/doc/man3/idset_encode.rst
@@ -102,7 +102,7 @@ RESOURCES
 
 Flux: http://flux-framework.org
 
-RFC 22: Idset String Representation: https://github.com/flux-framework/rfc/blob/master/spec_22.rst
+RFC 22: Idset String Representation: https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/spec_22.html
 
 
 SEE ALSO

--- a/doc/man5/flux-config-archive.rst
+++ b/doc/man5/flux-config-archive.rst
@@ -43,7 +43,8 @@ RESOURCES
 
 Flux: http://flux-framework.org
 
-RFC 23: Flux Standard Duration: https://github.com/flux-framework/rfc/blob/master/spec_23.rst
+RFC 23: Flux Standard Duration: https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/spec_23.html
+
 
 SEE ALSO
 ========

--- a/doc/man5/flux-config-bootstrap.rst
+++ b/doc/man5/flux-config-bootstrap.rst
@@ -66,7 +66,7 @@ COMPACT HOSTS
 
 Since it would be tedious to repeat host entries for every compute
 node in a large cluster, the ``hosts`` array may be abbreviated using
-RFC29 hostlists.  For example, the list of hosts foo0, foo1, foo2,
+RFC 29 hostlists.  For example, the list of hosts foo0, foo1, foo2,
 foo3, foo18, foo4, foo20 can be represented as "foo[0-3,18,4,20]".
 
 
@@ -97,6 +97,8 @@ RESOURCES
 =========
 
 Flux: http://flux-framework.org
+
+RFC 29: Hostlist Format: https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/spec_29.html
 
 
 SEE ALSO

--- a/doc/man5/flux-config-exec.rst
+++ b/doc/man5/flux-config-exec.rst
@@ -41,7 +41,7 @@ RESOURCES
 
 Flux: http://flux-framework.org
 
-RFC 15: Flux Security: https://github.com/flux-framework/rfc/blob/master/spec_15.rs
+RFC 15: Flux Security: https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/spec_15.html
 
 
 SEE ALSO

--- a/doc/man5/flux-config-resource.rst
+++ b/doc/man5/flux-config-resource.rst
@@ -48,9 +48,9 @@ RESOURCES
 
 Flux: http://flux-framework.org
 
-RFC 22: Idset String Representation: https://github.com/flux-framework/rfc/blob/master/spec_22.rs
+RFC 22: Idset String Representation: https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/spec_22.html
 
-RFC 29: Hostlist Format: https://github.com/flux-framework/rfc/blob/master/spec_29.rs
+RFC 29: Hostlist Format: https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/spec_29.html
 
 
 SEE ALSO

--- a/doc/man5/flux-config-tbon.rst
+++ b/doc/man5/flux-config-tbon.rst
@@ -46,7 +46,7 @@ RESOURCES
 
 Flux: http://flux-framework.org
 
-RFC 23: Flux Standard Duration: https://github.com/flux-framework/rfc/blob/master/spec_23.rst
+RFC 23: Flux Standard Duration: https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/spec_23.html
 
 
 SEE ALSO

--- a/doc/man7/flux-broker-attributes.rst
+++ b/doc/man7/flux-broker-attributes.rst
@@ -42,7 +42,7 @@ content.backing-path
    If it doesn't exist, it is created.
 
 hostlist
-   An RFC29 hostlist in broker rank order.
+   An RFC 29 hostlist in broker rank order.
 
 
 TOPOLOGY ATTRIBUTES
@@ -191,7 +191,9 @@ RESOURCES
 
 Flux: http://flux-framework.org
 
-RFC 23: Flux Standard Duration: https://github.com/flux-framework/rfc/blob/master/spec_23.rst
+RFC 23: Flux Standard Duration: https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/spec_23.html
+
+RFC 29: Hostlist Format: https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/spec_29.html
 
 
 SEE ALSO


### PR DESCRIPTION
Problem: man page RESOURCES often point to RFCs at github rather than readthedocs.

Update references.
Add a couple missing ones.
Fix some RFC references to include a space between RFC and the number.
Drop some man page references that were inappropriate.