### PR TITLE
testsuite: fix non-bourne shell test failure

### DIFF
--- a/t/t1105-proxy.t
+++ b/t/t1105-proxy.t
@@ -132,6 +132,7 @@ test_expect_success NO_CHAIN_LINT 'flux-proxy attempts to restore terminal on er
 	grep "\[\?25h" pty.out
 '
 test_expect_success NO_CHAIN_LINT 'flux-proxy sends SIGHUP to children without --nohup' '
+	SHELL=/bin/sh &&
 	cat <<-EOF >test.sh &&
 	#!/bin/bash
 	flux --parent job cancel \$(flux getattr jobid)


### PR DESCRIPTION
Problem: Test in t1105-proxy failed because of quoting/escape
issues with non-bourne shells.

Solution: Set SHELL to /bin/sh in test.