### PR TITLE
improve flux-config-bootstrap(5)

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -54,19 +54,19 @@ extensions = [
 domainrefs = {
     'linux:man1': {
         'text': '%s(1)',
-        'url': 'http://man7.org/linux/man-pages/man1/%s.1.html',
+        'url': 'https://linux.die.net/man/1/%s',
     },
     'linux:man2': {
         'text': '%s(2)',
-        'url': 'http://man7.org/linux/man-pages/man2/%s.2.html',
+        'url': 'https://linux.die.net/man/2/%s',
     },
     'linux:man3': {
         'text': '%s(3)',
-        'url': 'http://man7.org/linux/man-pages/man3/%s.3.html',
+        'url': 'https://linux.die.net/man/3/%s',
     },
     'linux:man7': {
         'text': '%s(7)',
-        'url': 'http://man7.org/linux/man-pages/man7/%s.7.html',
+        'url': 'https://linux.die.net/man/7/%s',
     },
 }
 

--- a/doc/man3/flux_stat_watcher_create.rst
+++ b/doc/man3/flux_stat_watcher_create.rst
@@ -37,7 +37,7 @@ DESCRIPTION
 ``flux_stat_watcher_create()`` creates a reactor watcher that
 monitors for changes in the status of the file system object
 represented by *path*. If the file system object exists,
-:linux:man2:`inotify` is used, if available; otherwise the reactor polls
+:linux:man7:`inotify` is used, if available; otherwise the reactor polls
 the file every *interval* seconds. A value of zero selects a
 conservative default (currently five seconds).
 

--- a/doc/man5/flux-config-bootstrap.rst
+++ b/doc/man5/flux-config-bootstrap.rst
@@ -30,7 +30,9 @@ enable_ipv6
 curve_cert
    (optional) Path to a CURVE certificate generated with
    :man1:`flux-keygen`.  The certificate should be identical on all
-   broker ranks.  It is required for instance sizes > 1.
+   broker ranks.  It is required for instance sizes > 1.  The file should
+   be owned by the instance owner (e.g. `flux` user) and only readable by
+   that user.
 
 default_port
    (optional) The value is an integer port number that is substituted

--- a/doc/man5/flux-config-bootstrap.rst
+++ b/doc/man5/flux-config-bootstrap.rst
@@ -75,9 +75,40 @@ foo3, foo18, foo4, foo20 can be represented as "foo[0-3,18,4,20]".
 EXAMPLE
 =======
 
+The following example is a simple, two node cluster with a fully specified
+``hosts`` array.
+
 ::
 
    [bootstrap]
+
+   curve_cert = "/etc/flux/system/curve.cert"
+
+   hosts = [
+       {
+           host="foo",
+           bind="tcp://eth0:9001",
+           connect="tcp://10.0.1.1:9001"
+       },
+       {
+           host = "bar"
+       },
+   ]
+
+
+Host ``foo`` is assigned rank 0, and binds to the interface ``eth0`` port 9001.
+
+Host ``bar`` is assigned rank 1, and connects to ``10.0.1.1`` port 9001.
+
+The following example is a 1024 node cluster that relies on default settings
+and compact hosts.  We assume a ``tbon.fanout`` of 2 (see
+:man7:`flux-broker-attributes`).
+
+::
+
+   [bootstrap]
+
+   curve_cert = "/etc/flux/system/curve.cert"
 
    default_port = 8050
    default_bind = "tcp://en0:%p"
@@ -93,6 +124,18 @@ EXAMPLE
            host = "test[1-1023]"
        },
    ]
+
+
+Host ``test0`` is assigned rank 0, and binds to interface ``en4`` port 9001.
+
+Host ``test1`` is assigned rank 1, binds to interface ``en0`` port 8050,
+and connects to ``test-mgmt`` port 9001.
+
+Host ``test2`` is assigned rank 2, binds to interface ``en0`` port 8050,
+and connects to ``test-mgmt`` port 9001.
+
+Host ``test3`` is assigned rank 3, binds to interface ``en0`` port 8050,
+and connects to ``etest1`` port 8050, and so on.
 
 
 RESOURCES

--- a/doc/man5/flux-config-bootstrap.rst
+++ b/doc/man5/flux-config-bootstrap.rst
@@ -63,6 +63,35 @@ hosts
    substitutions work here as well.
 
 
+ZEROMQ ENDPOINTS
+================
+
+In this context, ZeroMQ endpoint URIs normally use the :linux:man7:`zmq_tcp`
+transport, consisting of the transport name ``tcp://`` followed by an address.
+
+Bind addresses specify interface followed by a colon and the TCP port.
+The interface may be one of:
+
+- the wild-card ``*`` meaning all available interfaces
+
+- the primary IP address assigned to the interface (numeric only)
+
+- the interface name
+
+The port should be an explicit numerical port number.
+
+Connect addresses specify a peer address followed by a colon and the TCP port.
+The peer address may be one of:
+
+- the DNS name of the peer
+
+- the IP address of the peer in its numeric representation
+
+When specifying the ``bind`` and ``connect`` URIs for a hosts entry, ensure
+that another host can use the ``connect`` URI to reach the Flux service bound
+to the ``bind`` address on the host.
+
+
 COMPACT HOSTS
 =============
 


### PR DESCRIPTION
The documentation in flux-config-bootstrap(5) is really minimal and probably not all that useful.  This PR expounds a bit and adds a simpler example.