### PR TITLE
job-exec: support new sdexec job launch plugin 

### DIFF
--- a/doc/man5/flux-config-exec.rst
+++ b/doc/man5/flux-config-exec.rst
@@ -22,6 +22,16 @@ imp
    the credentials of the guest user that submitted them.  If unset, only
    jobs submitted by the instance owner may be executed.
 
+method
+   (optional) Run job shell under a specific mechanism other than the default
+   forked subprocesses.  Potential configurations:
+
+   systemd
+
+   Run job shells are run under systemd, the job shell may be able to
+   survive an unexpected broker shutdown and be recovered when the
+   broker is restarted.
+
 job-shell
    (optional) Override the compiled-in default job shell path.
 

--- a/etc/rc1
+++ b/etc/rc1
@@ -89,10 +89,14 @@ if test $RANK -eq 0 -a "${FLUX_SCHED_MODULE}" != "none" \
     flux module load ${FLUX_SCHED_MODULE:-sched-simple}
 fi
 
-if test $RANK -eq 0 -a -z "${FLUX_DISABLE_JOB_CLEANUP}"; then
+if test $RANK -eq 0; then
+    method=$(flux config get --default=notset exec.method)
+    if test "${method}" != "systemd" \
+            -a -z "${FLUX_DISABLE_JOB_CLEANUP}"; then
 	flux admin cleanup-push <<-EOT
 	flux queue stop --quiet
 	flux job cancelall --user=all --quiet -f --states RUN
 	flux queue idle --quiet
 	EOT
+    fi
 fi

--- a/src/modules/job-exec/Makefile.am
+++ b/src/modules/job-exec/Makefile.am
@@ -37,6 +37,10 @@ job_exec_la_SOURCES = \
 	testexec.c \
 	exec.c
 
+if HAVE_LIBSYSTEMD
+job_exec_la_SOURCES += sdexec.c
+endif
+
 job_exec_la_LDFLAGS = \
 	$(fluxmod_ldflags) \
 	-module
@@ -47,6 +51,10 @@ job_exec_la_LIBADD = \
 	$(top_builddir)/src/common/libflux-core.la \
 	$(JANSSON_LIBS) \
 	libbulk-exec.la
+
+if HAVE_LIBSYSTEMD
+job_exec_la_LIBADD += $(top_builddir)/src/common/libsdprocess/libsdprocess.la
+endif
 
 bulk_exec_SOURCES = \
 	test/bulk-exec.c

--- a/src/modules/job-exec/Makefile.am
+++ b/src/modules/job-exec/Makefile.am
@@ -30,6 +30,8 @@ job_exec_la_SOURCES = \
 	job-exec.c \
 	checkpoint.h \
 	checkpoint.c \
+	exec_config.h \
+	exec_config.c \
 	rset.c \
 	rset.h \
 	testexec.c \

--- a/src/modules/job-exec/exec_config.c
+++ b/src/modules/job-exec/exec_config.c
@@ -1,0 +1,123 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* Flux job-exec configuration common code */
+
+#if HAVE_CONFIG_H
+# include "config.h"
+#endif
+
+#include <jansson.h>
+#include <unistd.h>
+
+#include "exec_config.h"
+
+static const char *default_cwd = "/tmp";
+static const char *default_job_shell = NULL;
+static const char *flux_imp_path = NULL;
+
+static const char *jobspec_get_job_shell (json_t *jobspec)
+{
+    const char *path = NULL;
+    if (jobspec)
+        (void) json_unpack (jobspec, "{s:{s:{s:{s:s}}}}",
+                                     "attributes", "system", "exec",
+                                     "job_shell", &path);
+    return path;
+}
+
+const char *config_get_job_shell (struct jobinfo *job)
+{
+    const char *path = NULL;
+    if (job)
+        path = jobspec_get_job_shell (job->jobspec);
+    return path ? path : default_job_shell;
+}
+
+static const char *jobspec_get_cwd (json_t *jobspec)
+{
+    const char *cwd = NULL;
+    if (jobspec)
+        (void) json_unpack (jobspec, "{s:{s:{s:s}}}",
+                                     "attributes", "system",
+                                     "cwd", &cwd);
+    return cwd;
+}
+
+const char *config_get_cwd (struct jobinfo *job)
+{
+    const char *cwd = NULL;
+    if (job) {
+        if (job->multiuser)
+            cwd = "/";
+        else if (!(cwd = jobspec_get_cwd (job->jobspec)))
+            cwd = default_cwd;
+    }
+    return cwd;
+}
+
+const char *config_get_imp_path (void)
+{
+    return flux_imp_path;
+}
+
+/*  Initialize common configurations for use by job-exec exec modules.
+ */
+int config_init (flux_t *h, int argc, char **argv)
+{
+    flux_error_t err;
+
+    /*  Set default job shell path from builtin configuration,
+     *   allow override via configuration, then cmdline.
+     */
+    default_job_shell = flux_conf_builtin_get ("shell_path", FLUX_CONF_AUTO);
+
+    /*  Check configuration for exec.job-shell */
+    if (flux_conf_unpack (flux_get_conf (h),
+                          &err,
+                          "{s?:{s?s}}",
+                          "exec",
+                            "job-shell", &default_job_shell) < 0) {
+        flux_log (h, LOG_ERR,
+                  "error reading config value exec.job-shell: %s",
+                  err.text);
+        return -1;
+    }
+
+    /*  Check configuration for exec.imp */
+    if (flux_conf_unpack (flux_get_conf (h),
+                          &err,
+                          "{s?:{s?s}}",
+                          "exec",
+                            "imp", &flux_imp_path) < 0) {
+        flux_log (h, LOG_ERR,
+                  "error reading config value exec.imp: %s",
+                  err.text);
+        return -1;
+    }
+
+    if (argv && argc) {
+        /* Finally, override values on cmdline */
+        for (int i = 0; i < argc; i++) {
+            if (strncmp (argv[i], "job-shell=", 10) == 0)
+                default_job_shell = argv[i]+10;
+            else if (strncmp (argv[i], "imp=", 4) == 0)
+                flux_imp_path = argv[i]+4;
+        }
+    }
+
+    flux_log (h, LOG_DEBUG, "using default shell path %s", default_job_shell);
+    if (flux_imp_path)
+        flux_log (h, LOG_DEBUG, "using imp path %s", flux_imp_path);
+    return 0;
+}
+
+/* vi: ts=4 sw=4 expandtab
+ */

--- a/src/modules/job-exec/exec_config.h
+++ b/src/modules/job-exec/exec_config.h
@@ -1,0 +1,29 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef HAVE_JOB_EXEC_CONFIG_H
+#define HAVE_JOB_EXEC_CONFIG_H 1
+
+#include <flux/core.h>
+
+#include "job-exec.h"
+
+const char *config_get_job_shell (struct jobinfo *job);
+
+const char *config_get_cwd (struct jobinfo *job);
+
+const char *config_get_imp_path (void);
+
+int config_init (flux_t *h, int argc, char **argv);
+
+#endif /* !HAVE_JOB_EXEC_CONFIG_EXEC_H */
+
+/* vi: ts=4 sw=4 expandtab
+ */

--- a/src/modules/job-exec/job-exec.c
+++ b/src/modules/job-exec/job-exec.c
@@ -104,10 +104,16 @@
 static double kill_timeout=5.0;
 
 extern struct exec_implementation testexec;
+#ifdef HAVE_LIBSYSTEMD
+extern struct exec_implementation sdexec;
+#endif
 extern struct exec_implementation bulkexec;
 
 static struct exec_implementation * implementations[] = {
     &testexec,
+#ifdef HAVE_LIBSYSTEMD
+    &sdexec,
+#endif
     &bulkexec,
     NULL
 };

--- a/src/modules/job-exec/sdexec.c
+++ b/src/modules/job-exec/sdexec.c
@@ -1,0 +1,790 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* Flux job systemd exec implementation
+ *
+ * DESCRIPTION
+ *
+ * This exec module runs job-shells under systemd using the libsdprocess
+ * library.
+ *
+ * CONFIGURATION
+ *
+ * To enable use of this exec implementation, it must be enabled via
+ * the following flux configuration:
+ *
+ * [exec]
+ * method = systemd
+ *
+ * The following configurations are supported under
+ * attributes.system.exec.sd in the jobspec.
+ *
+ * "test":b - use sdexec for this specific job (used for testing)
+ *
+ * "test_exec_fail":b - assume sdprocess_exec() failed (used for testing)
+ *
+ * "stdoutlog":s - send stdout to {"eventlog","systemd"}
+ *
+ * "stderrlog":s - send stderr to {"eventlog","systemd"}
+ *
+ * "no_cleanup":b - do not cleanup systemd after running process
+ *                  (useful for debugging)
+ *
+ */
+
+#if HAVE_CONFIG_H
+# include "config.h"
+#endif
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+#include <stdio.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <unistd.h>
+#include <jansson.h>
+#include <assert.h>
+
+#include "src/common/libsdprocess/sdprocess.h"
+#include "src/common/libsubprocess/subprocess.h"
+#include "src/common/libsubprocess/command.h"
+#include "src/common/libutil/fsd.h"
+#include "job-exec.h"
+#include "exec_config.h"
+
+enum {
+    SDEXEC_LOG_EVENTLOG,
+    SDEXEC_LOG_SYSTEMD,
+};
+
+struct sdexec
+{
+    flux_t *h;
+    struct jobinfo *job;
+    flux_cmd_t *cmd;
+
+    int start_errno;
+    int test_exec_fail;
+    int stdoutlog;
+    int stderrlog;
+    int no_cleanup;
+
+    sdprocess_t *sdp;
+    int stdin_fds[2];
+    int stdout_fds[2];
+    int stderr_fds[2];
+    flux_watcher_t *w_stdout;
+    flux_watcher_t *w_stderr;
+
+    bool jobinfo_tasks_complete_called;
+};
+
+static int sdexec_config (flux_t *h, int argc, char **argv)
+{
+    return config_init (h, argc, argv);
+}
+
+static void sdexec_destroy (void *data)
+{
+    struct sdexec *se = data;
+    if (se) {
+        if (se->sdp) {
+            if (!se->no_cleanup) {
+                if (sdprocess_systemd_cleanup (se->sdp) < 0)
+                    flux_log_error (se->h, "sdprocess_systemd_cleanup");
+            }
+            sdprocess_destroy (se->sdp);
+        }
+        flux_cmd_destroy (se->cmd);
+        close (se->stdin_fds[0]);
+        close (se->stdin_fds[1]);
+        close (se->stdout_fds[0]);
+        close (se->stdout_fds[1]);
+        close (se->stderr_fds[0]);
+        close (se->stderr_fds[1]);
+        if (se->w_stdout) {
+            flux_watcher_stop (se->w_stdout);
+            flux_watcher_destroy (se->w_stdout);
+        }
+        if (se->w_stderr) {
+            flux_watcher_stop (se->w_stderr);
+            flux_watcher_destroy (se->w_stderr);
+        }
+        free (se);
+    }
+}
+
+/* systemd can break with some environments that export weird
+ * environment variables, such as
+ *
+ * BASH_FUNC_ml%%=() {  eval $($LMOD_DIR/ml_cmd "$@") }
+ *
+ * So we manually add the common ones we are confident flux needs.
+ */
+
+static int add_env (struct sdexec *se, const char *var)
+{
+    char *val;
+    assert (var);
+    if ((val = getenv (var))) {
+        if (flux_cmd_setenvf (se->cmd,
+                              1,
+                              var,
+                              "%s",
+                              val) < 0) {
+            flux_log_error (se->h, "flux_cmd_setenvf");
+            return -1;
+        }
+    }
+    return 0;
+}
+
+static int add_flux_env (struct sdexec *se)
+{
+    if (add_env (se, "PATH") < 0)
+        return -1;
+    if (add_env (se, "PYTHONPATH") < 0)
+        return -1;
+    if (add_env (se, "MANPATH") < 0)
+        return -1;
+    if (add_env (se, "LUA_PATH") < 0)
+        return -1;
+    if (add_env (se, "LUA_CPATH") < 0)
+        return -1;
+    if (add_env (se, "FLUX_CONNECTOR_PATH") < 0)
+        return -1;
+    if (add_env (se, "FLUX_EXEC_PATH") < 0)
+        return -1;
+    if (add_env (se, "FLUX_MODULE_PATH") < 0)
+        return -1;
+    if (add_env (se, "FLUX_PMI_LIBRARY_PATH") < 0)
+        return -1;
+    return 0;
+}
+
+static void set_stdlog (struct sdexec *se,
+                        const char *logstr,
+                        int *logp,
+                        const char *var)
+{
+    if (logstr) {
+        assert (logp);
+        if (!strcasecmp (logstr, "eventlog"))
+            (*logp) = SDEXEC_LOG_EVENTLOG;
+        else if (!strcasecmp (logstr, "systemd"))
+            (*logp) = SDEXEC_LOG_SYSTEMD;
+        else {
+            (*logp) = SDEXEC_LOG_EVENTLOG;
+            flux_log (se->h, LOG_ERR,
+                      "invalid %s value '%s', defaulting to eventlog",
+                      var,
+                      logstr);
+        }
+    }
+}
+
+static struct sdexec *sdexec_create (flux_t *h,
+                                     struct jobinfo *job,
+                                     const char *job_shell)
+{
+    struct sdexec *se = NULL;
+    const char *local_uri;
+    const char *stdoutlog = NULL;
+    const char *stderrlog = NULL;
+
+    if (!(se = calloc (1, sizeof (*se))))
+        return NULL;
+    se->h = h;
+    se->job = job;
+
+    if (!(se->cmd = flux_cmd_create (0, NULL, NULL))) {
+        flux_log_error (job->h, "flux_cmd_create");
+        goto cleanup;
+    }
+
+    if (job->multiuser) {
+        if (flux_cmd_argv_append (se->cmd, config_get_imp_path ()) < 0
+            || flux_cmd_argv_append (se->cmd, "exec") < 0) {
+            flux_log_error (job->h, "flux_cmd_argv_append");
+            goto cleanup;
+        }
+    }
+
+    if (flux_cmd_argv_append (se->cmd, job_shell) < 0
+        || flux_cmd_argv_appendf (se->cmd, "%ju", (uintmax_t) job->id) < 0) {
+        flux_log_error (job->h, "flux_cmd_argv_append");
+        goto cleanup;
+    }
+
+    if (add_flux_env (se) < 0)
+        goto cleanup;
+
+    /* XXX
+     *
+     * need to add if not in environment?
+     *
+     * XDG_RUNTIME_DIR=/run/user/8556
+     * DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/8556/bus
+     *
+     */
+
+    if (flux_cmd_setenvf (se->cmd,
+                          1,
+                          "FLUX_KVS_NAMESPACE",
+                          "%s",
+                          job->ns) < 0) {
+        flux_log_error (job->h, "flux_cmd_setenvf");
+        goto cleanup;
+    }
+
+    if (!(local_uri = flux_attr_get (se->h, "local-uri"))) {
+        flux_log_error (job->h, "flux_cmd_setenvf");
+        goto cleanup;
+    }
+
+    if (flux_cmd_setenvf (se->cmd, 1, "FLUX_URI", "%s", local_uri) < 0) {
+        flux_log_error (job->h, "flux_cmd_setenvf");
+        goto cleanup;
+    }
+
+    se->stdoutlog = SDEXEC_LOG_EVENTLOG;
+    se->stderrlog = SDEXEC_LOG_EVENTLOG;
+
+    (void) json_unpack_ex (job->jobspec, NULL, 0,
+                           "{s:{s:{s:{s:{s?b s?s s?s s?b}}}}}",
+                           "attributes", "system", "exec", "sd",
+                           "test_exec_fail", &se->test_exec_fail,
+                           "stdoutlog", &stdoutlog,
+                           "stderrlog", &stderrlog,
+                           "no_cleanup", &se->no_cleanup);
+
+    set_stdlog (se, stdoutlog, &se->stdoutlog, "stdout");
+    set_stdlog (se, stderrlog, &se->stderrlog, "stderr");
+
+    se->stdin_fds[0] = -1;
+    se->stdin_fds[1] = -1;
+    se->stdout_fds[0] = -1;
+    se->stdout_fds[1] = -1;
+    se->stderr_fds[0] = -1;
+    se->stderr_fds[1] = -1;
+
+    return se;
+cleanup:
+    sdexec_destroy (se);
+    return NULL;
+}
+
+static int sdexec_init (struct jobinfo *job)
+{
+    flux_t *h = job->h;
+    flux_error_t err;
+    struct sdexec *se = NULL;
+    int enable = 0;
+
+    (void)json_unpack_ex (job->jobspec, NULL, 0,
+                          "{s:{s:{s:{s:{s:b}}}}}",
+                          "attributes", "system", "exec",
+                          "sd", "test", &enable);
+
+    if (!enable) {
+        const char *method = NULL;
+        if (flux_conf_unpack (flux_get_conf (h),
+                              &err,
+                              "{s?:{s?s}}",
+                              "exec",
+                                "method", &method) < 0) {
+            flux_log (h, LOG_ERR,
+                      "error reading job-exec config: %s",
+                      err.text);
+            return 0;
+        }
+
+        if (method && strcasecmp (method, "systemd") == 0)
+            enable = 1;
+    }
+
+    if (!enable)
+        return 0;
+
+    if (job->multiuser && !config_get_imp_path ()) {
+        flux_log (job->h,
+                  LOG_ERR,
+                  "unable run multiuser job with no IMP configured!");
+        return -1;
+    }
+
+    if (!(se = sdexec_create (h, job, config_get_job_shell (job))))
+        return -1;
+
+    job->data = se;
+    return 1;
+}
+
+static void output_stream (struct sdexec *se,
+                           int fd,
+                           const char *stream)
+{
+    const char *cmd = flux_cmd_arg (se->cmd, 0);
+    char buf[1024];
+    int len;
+    if ((len = read (fd, buf, 1024)) < 0) {
+        if (errno != EWOULDBLOCK)
+            jobinfo_fatal_error (se->job, errno, "read");
+    }
+    else if (len > 0)
+        jobinfo_log_output (se->job,
+                            0,
+                            basename (cmd),
+                            stream,
+                            buf,
+                            len);
+}
+
+static void state_cb (sdprocess_t *sdp, sdprocess_state_t state, void *arg)
+{
+    struct sdexec *se = arg;
+
+    /* Under libsdprocess, it is conceivable a process starts and
+     * exits before the state watcher is setup.  This is unlikely
+     * except when failure is immediate (e.g. invalid command
+     * specified, or bad job shell path).  So we must call
+     * jobinfo_started() regardless if the state passed into here is
+     * ACTIVE or EXITED.
+     */
+    if (!se->job->reattach && !se->job->running)
+        jobinfo_started (se->job);
+
+    if (state == SDPROCESS_ACTIVE) {
+        if (se->job->multiuser) {
+            char *input = NULL;
+            json_t *o = json_pack ("{s:s}", "J", se->job->J);
+            if (!o || !(input = json_dumps (o, JSON_COMPACT))) {
+                jobinfo_fatal_error (se->job, errno, "Failed to get input to IMP");
+                return;
+            }
+            if (write (se->stdin_fds[0], input, strlen (input)) < 0) {
+                jobinfo_fatal_error (se->job, errno, "write");
+                return;
+            }
+            close (se->stdin_fds[0]);
+            se->stdin_fds[0] = -1;
+        }
+    }
+    else if (state == SDPROCESS_EXITED
+             && !se->jobinfo_tasks_complete_called) {
+
+        /* Since we are calling jobinfo_tasks_complete(), the
+         * stdout/stderr fd watchers may be stopped.  So if there is
+         * any lingering data on the stdout/stderr streams, they may
+         * not be output.  This is possible because the reactor may
+         * call this state callback before stdio callbacks below.
+         *
+         * Note that fds may be uninitialized (still set to -1) if
+         * flux was restarted and this job was reattached.
+         */
+
+        if (se->stdoutlog == SDEXEC_LOG_EVENTLOG
+            && se->stdout_fds[0] >= 0)
+            output_stream (se, se->stdout_fds[0], "stdout");
+        if (se->stderrlog == SDEXEC_LOG_EVENTLOG
+            && se->stderr_fds[0] >= 0)
+            output_stream (se, se->stderr_fds[0], "stderr");
+
+        jobinfo_tasks_complete (se->job,
+                                resource_set_ranks (se->job->R),
+                                sdprocess_wait_status (se->sdp));
+        se->jobinfo_tasks_complete_called = true;
+    }
+}
+
+static void output_cb (struct sdexec *se,
+                       int revents,
+                       int fd,
+                       const char *stream)
+{
+    if (revents & FLUX_POLLIN)
+        output_stream (se, fd, stream);
+}
+
+static void stdout_cb (flux_reactor_t *r, flux_watcher_t *w,
+                       int revents, void *arg)
+{
+    struct sdexec *se = arg;
+    output_cb (se, revents, se->stdout_fds[0], "stdout");
+}
+
+static void stderr_cb (flux_reactor_t *r, flux_watcher_t *w,
+                       int revents, void *arg)
+{
+    struct sdexec *se = arg;
+    output_cb (se, revents, se->stderr_fds[0], "stderr");
+}
+
+static int sdexec_reattach (struct sdexec *se,
+                            struct jobinfo *job,
+                            const char *unitname)
+{
+    int rv = -1;
+
+    if (!(se->sdp = sdprocess_find_unit (se->h, unitname))) {
+        se->start_errno = errno;
+        jobinfo_fatal_error (job, errno, "sdprocess_find_unit");
+        goto cleanup;
+    }
+
+    if (sdprocess_state (se->sdp, state_cb, se) < 0) {
+        jobinfo_fatal_error (job, errno, "sdprocess_state");
+        goto cleanup;
+    }
+
+    jobinfo_reattached (job);
+    rv = 0;
+cleanup:
+    return rv;
+}
+
+static int sdexec_launch (struct sdexec *se,
+                          struct jobinfo *job,
+                          const char *unitname)
+{
+    char **cmdv = NULL;
+    char **envv = NULL;
+    int rv = -1;
+
+    if (socketpair (PF_LOCAL, SOCK_STREAM, 0, se->stdin_fds) < 0) {
+        jobinfo_fatal_error (job, errno, "socketpair");
+        goto cleanup;
+    }
+
+    if (se->stdoutlog == SDEXEC_LOG_EVENTLOG) {
+        if (socketpair (PF_LOCAL,
+                        SOCK_STREAM | SOCK_NONBLOCK,
+                        0,
+                        se->stdout_fds) < 0) {
+            jobinfo_fatal_error (job, errno, "socketpair");
+            goto cleanup;
+        }
+    }
+    if (se->stderrlog == SDEXEC_LOG_EVENTLOG) {
+        if (socketpair (PF_LOCAL,
+                        SOCK_STREAM | SOCK_NONBLOCK,
+                        0,
+                        se->stderr_fds) < 0) {
+            jobinfo_fatal_error (job, errno, "socketpair");
+            goto cleanup;
+        }
+    }
+
+    cmdv = flux_cmd_argv_expand (se->cmd);
+    envv = flux_cmd_env_expand (se->cmd);
+
+    if (se->test_exec_fail) {
+        /* we select a somewhat random errno for this test exec fail */
+        errno = EPERM;
+        jobinfo_fatal_error (job, errno, "test sdprocess_exec");
+        goto cleanup;
+    }
+
+    /* if stdout_fds and stderr_fds were not created above, they stay
+     * at their default of -1, leading stdout/stderr to be routed to
+     * journald in most systemd configurations (i.e. the
+     * SDEXEC_LOG_SYSTEMD setting).
+     */
+    if (!(se->sdp = sdprocess_exec (se->h,
+                                    unitname,
+                                    cmdv,
+                                    envv,
+                                    se->stdin_fds[1],
+                                    se->stdout_fds[1],
+                                    se->stderr_fds[1]))) {
+        se->start_errno = errno;
+        jobinfo_fatal_error (job, errno, "sdprocess_exec");
+        goto cleanup;
+    }
+
+    if (sdprocess_state (se->sdp, state_cb, se) < 0) {
+        jobinfo_fatal_error (job, errno, "sdprocess_state");
+        goto cleanup;
+    }
+
+    if (se->stdoutlog == SDEXEC_LOG_EVENTLOG) {
+        if (!(se->w_stdout = flux_fd_watcher_create (flux_get_reactor (se->h),
+                                                     se->stdout_fds[0],
+                                                     FLUX_POLLIN,
+                                                     stdout_cb,
+                                                     se))) {
+            jobinfo_fatal_error (job, errno, "flux_fd_watcher_create");
+            goto cleanup;
+        }
+        flux_watcher_start (se->w_stdout);
+    }
+
+    if (se->stderrlog == SDEXEC_LOG_EVENTLOG) {
+        if (!(se->w_stderr = flux_fd_watcher_create (flux_get_reactor (se->h),
+                                                     se->stderr_fds[0],
+                                                     FLUX_POLLIN,
+                                                     stderr_cb,
+                                                     se))) {
+            jobinfo_fatal_error (job, errno, "flux_fd_watcher_create");
+            goto cleanup;
+        }
+        flux_watcher_start (se->w_stderr);
+    }
+
+    rv = 0;
+cleanup:
+    free (cmdv);
+    free (envv);
+    return rv;
+}
+
+static int sdexec_start (struct jobinfo *job)
+{
+    struct sdexec *se = job->data;
+    char *unitname = NULL;
+    uint32_t rank;
+    int rv = -1;
+
+    if (flux_get_rank (se->h, &rank) < 0) {
+        jobinfo_fatal_error (job, errno, "flux_get_rank");
+        goto cleanup;
+    }
+
+    if (asprintf (&unitname,
+                  "flux-sdexec-%u-%ju",
+                  rank,
+                  (uintmax_t)job->id) < 0) {
+        jobinfo_fatal_error (job, errno, "asprintf");
+        goto cleanup;
+    }
+
+    if (job->reattach)
+        rv = sdexec_reattach (se, job, unitname);
+    else
+        rv = sdexec_launch (se, job, unitname);
+cleanup:
+    free (unitname);
+    return rv;
+}
+
+static void kill_completion_cb (flux_subprocess_t *p)
+{
+    struct sdexec *se = flux_subprocess_aux_get (p, "sdexec::kill");
+    assert (se != NULL);
+    if (flux_subprocess_exit_code (p))
+        flux_log_error (se->h, "imp kill failure");
+    flux_subprocess_destroy (p);
+    jobinfo_decref (se->job);
+}
+
+static void kill_output_cb (flux_subprocess_t *p, const char *stream)
+{
+    struct sdexec *se = flux_subprocess_aux_get (p, "sdexec::kill");
+    const char *cmd = flux_cmd_arg (se->cmd, 0);
+    const char *s;
+    int len;
+
+    assert (se != NULL);
+
+    if (!(s = flux_subprocess_getline (p, stream, &len))) {
+        flux_log_error (se->h, "flux_subprocess_getline");
+        return;
+    }
+    if (len)
+        jobinfo_log_output (se->job,
+                            0,
+                            basename (cmd),
+                            stream,
+                            s,
+                            len);
+}
+
+/* Observations have shown that if a systemd process fails and
+ * a terminating signal such as SIGTERM is sent immediately
+ * afterwards, the state callback may not be called upon
+ * process exit.  The assumption is that if the process ended
+ * in two different ways (signal and failure) in very short
+ * succession, that systemd is not sure what prompted the
+ * failure and thus does not initiate the callback.  Unclear
+ * if this is a bug in systemd or not.
+ *
+ * For example, this could happen if the user input a bad
+ * command.  The job-shell could immediately fail (exit code
+ * == 127), generate an exception, leading to job-exec sending
+ * a SIGTERM.
+ *
+ * If job-exec has reached the point of using SIGKILL and
+ * jobinfo_tasks_complete() has not yet been called, assume
+ * the state callback will never be called.  We'll go ahead and
+ * call jobinfo_tasks_complete() here instead.
+ */
+static void sdexec_handle_exit_race (struct sdexec *se)
+{
+    int wait_status;
+
+    if (se->jobinfo_tasks_complete_called)
+        return;
+
+    flux_log (se->h,
+              LOG_DEBUG,
+              "Calling jobinfo_tasks_complete() due to SIGKILL");
+
+    wait_status = sdprocess_wait_status (se->sdp);
+    if (wait_status < 0) {
+        flux_log (se->h,
+                  LOG_ERR,
+                  "wait status unavailable, set to SIGKILL");
+        wait_status = __W_EXITCODE (0, SIGKILL);
+    }
+    jobinfo_tasks_complete (se->job,
+                            resource_set_ranks (se->job->R),
+                            wait_status);
+    se->jobinfo_tasks_complete_called = true;
+}
+
+static int sdexec_kill_multiuser (struct sdexec *se, int signum)
+{
+    flux_cmd_t *cmd = NULL;
+    flux_subprocess_ops_t ops = {
+        .on_completion =   kill_completion_cb,
+        .on_stdout =       kill_output_cb,
+        .on_stderr =       kill_output_cb,
+    };
+    int save_errno, pid, rv = -1;
+    flux_subprocess_t *p = NULL;
+    uint32_t rank;
+
+    if ((pid = sdprocess_pid (se->sdp)) < 0) {
+        /* Always a chance the shell has exited already and there
+         * is no "main" PID to retrieve.  For example, this could
+         * happen if the user input a bad command and the shell
+         * exited immediately.
+         */
+        if (errno == EPERM) {
+            if (signum == SIGKILL)
+                sdexec_handle_exit_race (se);
+            return 0;
+        }
+        else
+            flux_log_error (se->h, "sdprocess_pid");
+        return -1;
+    }
+
+    if (!(cmd = flux_cmd_create (0, NULL, NULL))) {
+        flux_log_error (se->h, "flux_cmd_create");
+        goto cleanup;
+    }
+
+    if (flux_cmd_argv_append (cmd, config_get_imp_path ()) < 0
+        || flux_cmd_argv_append (cmd, "kill") < 0
+        || flux_cmd_argv_appendf (cmd, "%d", signum) < 0
+        || flux_cmd_argv_appendf (cmd, "%d", pid) < 0) {
+        flux_log_error (se->h, "flux_cmd_argv_append");
+        goto cleanup;
+    }
+
+    if (flux_cmd_setcwd (cmd, config_get_cwd (se->job)) < 0) {
+        flux_log_error (se->h, "flux_cmd_setcwd");
+        goto cleanup;
+    }
+
+    if (flux_get_rank (se->h, &rank) < 0) {
+        flux_log_error (se->h, "flux_get_rank");
+        goto cleanup;
+    }
+
+    if (!(p = flux_rexec (se->h, rank, 0, cmd, &ops))) {
+        flux_log_error (se->h, "flux_rexec");
+        goto cleanup;
+    }
+
+    /* increment jobinfo refcount, so that sdexec_exit() will not be
+     * called until after it is decremented in kill_completion_cb()
+     * (i.e. after the kill subprocess has completed).
+     */
+    jobinfo_incref (se->job);
+
+    if (flux_subprocess_aux_set (p, "sdexec::kill", se, NULL) < 0) {
+        flux_log_error (se->h, "flux_subprocess_aux_set");
+        jobinfo_decref (se->job);
+        goto cleanup;
+    }
+
+    rv = 0;
+cleanup:
+    save_errno = errno;
+    flux_cmd_destroy (cmd);
+    errno = save_errno;
+    return rv;
+}
+
+static int sdexec_kill_single (struct sdexec *se, int signum)
+{
+    int ret = sdprocess_kill (se->sdp, signum);
+    if (ret < 0)
+        flux_log_error (se->h, "sdprocess_kill");
+    if (signum == SIGKILL)
+        sdexec_handle_exit_race (se);
+    return ret;
+}
+
+static int sdexec_kill (struct jobinfo *job, int signum)
+{
+    struct sdexec *se = job->data;
+
+    if (!se->sdp)
+        return 0;
+
+    if (job->multiuser)
+        return sdexec_kill_multiuser (se, signum);
+    return sdexec_kill_single (se, signum);
+}
+
+static void sdexec_exit (struct jobinfo *job)
+{
+    struct sdexec *se = job->data;
+    sdexec_destroy (se);
+    job->data = NULL;
+}
+
+static int sdexec_cancel (struct jobinfo *job)
+{
+    struct sdexec *se = job->data;
+
+    /* sdp can be NULL if sdprocess_create() or sdprocess_find_unit()
+     * fails, such as if systemd is not setup correctly.  If sdp is
+     * non-NULL, job-exec must call 'sdexec_kill' to properly kill
+     * the process that has been started.
+     */
+    if (!se->sdp) {
+        /* use errno from startup failure for exit code if available,
+         * otherwise just use EPERM */
+        int tmp_errno = se->start_errno ? se->start_errno : EPERM;
+        int wait_status = __W_EXITCODE (0, tmp_errno);
+        jobinfo_tasks_complete (se->job,
+                                resource_set_ranks (se->job->R),
+                                wait_status);
+    }
+    return 0;
+}
+
+struct exec_implementation sdexec = {
+    .name =     "sdexec",
+    .config =   sdexec_config,
+    .init =     sdexec_init,
+    .exit =     sdexec_exit,
+    .start =    sdexec_start,
+    .kill =     sdexec_kill,
+    .cancel =   sdexec_cancel,
+};
+
+/* vi: ts=4 sw=4 expandtab
+ */

--- a/src/modules/job-exec/sdexec.c
+++ b/src/modules/job-exec/sdexec.c
@@ -364,7 +364,10 @@ static void state_cb (sdprocess_t *sdp, sdprocess_state_t state, void *arg)
         jobinfo_started (se->job);
 
     if (state == SDPROCESS_ACTIVE) {
-        if (se->job->multiuser) {
+        /*  Don't try to write J to stdin_fd of -1
+         *  This probably indicates we've reattached to this job
+         */
+        if (se->job->multiuser && se->stdin_fds[0] >= 0) {
             char *input = NULL;
             json_t *o = json_pack ("{s:s}", "J", se->job->J);
             if (!o || !(input = json_dumps (o, JSON_COMPACT))) {

--- a/src/modules/job-exec/sdexec.c
+++ b/src/modules/job-exec/sdexec.c
@@ -219,6 +219,7 @@ static struct sdexec *sdexec_create (flux_t *h,
     }
 
     if (flux_cmd_argv_append (se->cmd, job_shell) < 0
+        || flux_cmd_argv_append (se->cmd, "--reconnect") < 0
         || flux_cmd_argv_appendf (se->cmd, "%ju", (uintmax_t) job->id) < 0) {
         flux_log_error (job->h, "flux_cmd_argv_append");
         goto cleanup;

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -153,6 +153,7 @@ TESTSCRIPTS = \
 	t2402-job-exec-dummy.t \
 	t2403-job-exec-conf.t \
 	t2404-job-exec-multiuser.t \
+	t2405-job-exec-sdexec.t \
 	t2410-exec-systemd.t \
 	t2500-job-attach.t \
 	t2501-job-status.t \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -270,6 +270,8 @@ EXTRA_DIST= \
 dist_check_SCRIPTS = \
 	$(TESTSCRIPTS) \
 	system/0001-basic.t \
+	system/0002-job-exec-sdexec-basic.t \
+	system/0003-instance-restart.t \
 	issues/t0441-kvs-put-get.sh \
 	issues/t0505-msg-handler-reg.lua \
 	issues/t0821-kvs-segfault.sh \

--- a/t/system/0002-job-exec-sdexec-basic.t
+++ b/t/system/0002-job-exec-sdexec-basic.t
@@ -1,0 +1,71 @@
+#
+#  Basic job-exec sdexec / systemd tests
+#
+
+test_expect_success 'job-exec: setup system instance to use systemd' '
+        method=$(sudo -u flux flux config get --default=notset exec.method)
+        if test "${method}" != "systemd"
+        then
+                if ! sudo test -f /etc/flux/system/conf.d/exec.toml
+                then
+                        sudo touch /etc/flux/system/conf.d/exec.toml
+                        sudo bash -c "echo [exec] >> /etc/flux/system/conf.d/exec.toml"
+                fi
+                sudo bash -c "echo method = \\\"systemd\\\" >> /etc/flux/system/conf.d/exec.toml"
+                sudo systemctl restart flux
+                until flux mini run hostname 2>/dev/null; do
+                        sleep 1
+                done
+        fi
+'
+test_expect_success 'job-exec: verify system instance using systemd' '
+        jobid=$(flux mini submit sleep 100) &&
+        flux job wait-event -v -t 60 $jobid start &&
+        jobiddec=`flux job id --to=dec $jobid` &&
+        rank=`flux getattr rank` &&
+        sudo -u flux systemctl list-units --user | grep "flux-sdexec-${rank}-${jobiddec}" &&
+        flux job cancel ${jobid}
+'
+test_expect_success 'job-exec: simple job exits 0 on success' '
+        jobid=$(flux mini submit /bin/true) &&
+        test_expect_code 0 flux job status $jobid
+'
+test_expect_success 'job-exec: simple job exits 1 on failure' '
+        jobid=$(flux mini submit /bin/false) &&
+        test_expect_code 1 flux job status -vv $jobid
+'
+test_expect_success 'job-exec: simple job exits 127 on bad command' '
+        jobid=$(flux mini submit /bin/foobar) &&
+        test_expect_code 127 flux job status $jobid
+'
+# When sending a signal very shortly after a job is started, there is
+# a small race where we don't know where the signal is actually sent.
+# It could be sent to the imp or job shell before actual job tasks are
+# started.  To ensure consistent test results, wait for shell.start in
+# guest.exec.eventlog.
+test_expect_success 'job-exec: simple job exits 138 on signaled job' '
+        jobid=$(flux mini submit sleep 30) &&
+        flux job wait-event -t 10 ${jobid} start &&
+        flux job wait-event -p guest.exec.eventlog -t 10 ${jobid} shell.start &&
+        flux job kill --signal=SIGUSR1 $jobid &&
+        test_expect_code 138 flux job status $jobid
+'
+# Similar to above test, wait for shell.start in guest.exec.eventlog
+# to ensure consistent test results.  The job cancel will send a
+# SIGTERM to the shell/tasks.
+test_expect_success 'job-exec: simple job can be canceled' '
+        jobid=$(flux mini submit sleep 30) &&
+        flux job wait-event -t 10 ${jobid} start &&
+        flux job wait-event -p guest.exec.eventlog -t 10 ${jobid} shell.start &&
+        flux job cancel $jobid &&
+        flux job wait-event -t 10 ${jobid} clean &&
+        test_expect_code 143 flux job status $jobid
+'
+test_expect_success 'job-exec: job fails correctly if user service not setup' '
+        jobid=$(flux mini submit \
+                --setattr=system.exec.sd.test_exec_fail=true \
+                hostname) &&
+        flux job wait-event -v -t 60 $jobid clean &&
+        flux job eventlog ${jobid} | grep "test sdprocess_exec" \
+             | grep "Operation not permitted"
+'

--- a/t/system/0003-instance-restart.t
+++ b/t/system/0003-instance-restart.t
@@ -1,0 +1,62 @@
+#
+#  Ensure jobs and scheduling continue to work if instance is restarted
+#
+
+test_expect_success 'job-exec: setup system instance to use systemd' '
+        method=$(sudo -u flux flux config get --default=notset exec.method)
+        if test "${method}" != "systemd"
+        then
+                if ! sudo test -f /etc/flux/system/conf.d/exec.toml
+                then
+                        sudo touch /etc/flux/system/conf.d/exec.toml
+                        sudo bash -c "echo [exec] >> /etc/flux/system/conf.d/exec.toml"
+                fi
+                sudo bash -c "echo method = \\\"systemd\\\" >> /etc/flux/system/conf.d/exec.toml"
+                sudo systemctl restart flux
+                until flux mini run hostname 2>/dev/null; do
+                        sleep 1
+                done
+        fi
+'
+test_expect_success 'job-exec: verify system instance using systemd' '
+        jobid=$(flux mini submit sleep 100) &&
+        flux job wait-event -v -t 60 $jobid start &&
+        jobiddec=`flux job id --to=dec $jobid` &&
+        rank=`flux getattr rank` &&
+        sudo -u flux systemctl list-units --user | grep "flux-sdexec-${rank}-${jobiddec}" &&
+        flux job cancel ${jobid}
+'
+test_expect_success 'job-exec: submit two jobs that consumes all resources' '
+        NCORES=$(flux resource list -s up -no "{ncores}") &&
+        flux mini submit -n ${NCORES} sleep 1000 > jobid1 &&
+        flux job wait-event $(cat jobid1) start &&
+        flux mini submit -n ${NCORES} sleep 1000 > jobid2
+'
+test_expect_success 'job-exec: verify jobs listed and in expected state' '
+        flux jobs --filter=running | grep $(cat jobid1) &&
+        flux jobs --filter=pending | grep $(cat jobid2)
+'
+test_expect_success 'job-exec: restart flux' '
+        sudo systemctl restart flux
+'
+test_expect_success 'job-exec: wait for flux to finish setting up' '
+        until flux jobs | grep $(cat jobid1) 2>/dev/null; do
+              sleep 1
+        done
+'
+test_expect_success 'job-exec: verify jobs still listed and in expected state' '
+        flux jobs --filter=running | grep $(cat jobid1) &&
+        flux jobs --filter=pending | grep $(cat jobid2)
+'
+test_expect_success 'job-exec: cancel job1 and make sure job2 will run' '
+        flux job cancel $(cat jobid1) &&
+        flux job wait-event -t 60 $(cat jobid1) clean &&
+        flux job wait-event -t 60 $(cat jobid2) start
+'
+test_expect_success 'job-exec: verify jobs listed and in new expected state' '
+        flux jobs --filter=canceled | grep $(cat jobid1) &&
+        flux jobs --filter=running | grep $(cat jobid2)
+'
+test_expect_success 'job-exec: cancel jobs' '
+        flux job cancel $(cat jobid2)
+'

--- a/t/t2405-job-exec-sdexec.t
+++ b/t/t2405-job-exec-sdexec.t
@@ -1,0 +1,225 @@
+#!/bin/sh
+
+test_description='Test flux job execution service using systemd'
+
+. $(dirname $0)/sharness.sh
+
+if ! flux version | grep systemd; then
+    skip_all='flux not built with systemd'
+    test_done
+fi
+
+#  Don't run if systemd environment variables not setup
+if test -z "$DBUS_SESSION_BUS_ADDRESS" \
+     -o -z "$XDG_RUNTIME_DIR"; then
+    skip_all='DBUS_SESSION_BUS_ADDRESS and/or XDG_RUNTIME_DIR not set'
+    test_done
+fi
+
+uid=`id -u`
+userservice="user@${uid}.service"
+if ! systemctl list-units | grep ${userservice}
+then
+    skip_all='systemd user service not running'
+    test_done
+fi
+
+export FLUX_CONF_DIR=$(pwd)
+test_under_flux 1 job
+
+flux setattr log-stderr-level 1
+
+TEST_SDPROCESS_DIR=${FLUX_BUILD_DIR}/src/common/libsdprocess
+
+test_expect_success 'job-exec: basic test sdexec works' '
+        jobid=$(flux mini submit \
+                --setattr=system.exec.sd.test=true \
+                sleep 30) &&
+        flux job wait-event -t 10 ${jobid} start &&
+        jobiddec=`flux job id --to=dec $jobid` &&
+        rank=`flux getattr rank` &&
+        systemctl list-units --user | grep "flux-sdexec-${rank}-${jobiddec}" &&
+        flux job cancel ${jobid} &&
+        flux job wait-event -t 10 ${jobid} clean
+'
+
+test_expect_success 'job-exec: config sdexec as executor' '
+        cat >exec.toml <<EOF &&
+[exec]
+method = "systemd"
+EOF
+        flux config reload &&
+        flux module reload job-exec
+'
+
+test_expect_success 'job-exec: basic sdexec with exec config works' '
+        jobid=$(flux mini submit sleep 30) &&
+        flux job wait-event -t 10 ${jobid} start &&
+        jobiddec=`flux job id --to=dec $jobid` &&
+        rank=`flux getattr rank` &&
+        systemctl list-units --user | grep "flux-sdexec-${rank}-${jobiddec}" &&
+        flux job cancel ${jobid} &&
+        flux job wait-event -t 10 ${jobid} clean
+'
+
+test_expect_success 'job-exec: generate jobspec for simple test job' '
+        flux mini run --dry-run hostname > basic.json
+'
+test_expect_success 'job-exec: basic job runs through all states under systemd' '
+        jobid=$(flux job submit basic.json) &&
+        flux job wait-event -t 10 ${jobid} start &&
+        flux job wait-event -t 10 ${jobid} finish &&
+        flux job wait-event -t 10 ${jobid} release &&
+        flux job wait-event -t 10 ${jobid} clean
+'
+test_expect_success 'job-exec: simple job outputs stdout under systemd' '
+        jobid=$(flux mini submit ${TEST_SDPROCESS_DIR}/test_echo -O foobar) &&
+        flux job attach $jobid 1> stdout.out &&
+        echo foobar > stdout.expected &&
+        test_cmp stdout.expected stdout.out
+'
+test_expect_success 'job-exec: simple job outputs stderr under systemd' '
+        jobid=$(flux mini submit ${TEST_SDPROCESS_DIR}/test_echo -E boobar) &&
+        flux job attach $jobid 2> stderr.out &&
+        echo boobar > stderr.expected &&
+        test_cmp stderr.expected stderr.out
+'
+test_expect_success 'job-exec: simple job takes stdin under systemd' '
+        jobid=$(flux mini submit ${TEST_SDPROCESS_DIR}/test_echo -O) &&
+        echo -n "boobaz" | flux job attach $jobid 1> stdout.out &&
+        echo boobaz > stdout.expected &&
+        test_cmp stdout.expected stdout.out
+'
+test_expect_success 'job-exec: simple job exits 0 on success' '
+        jobid=$(flux mini submit /bin/true) &&
+        test_expect_code 0 flux job status $jobid
+'
+test_expect_success 'job-exec: simple job exits 1 on failure' '
+        jobid=$(flux mini submit /bin/false) &&
+        test_expect_code 1 flux job status -vv $jobid
+'
+test_expect_success 'job-exec: simple job exits 127 on bad command' '
+        jobid=$(flux mini submit /bin/foobar) &&
+        test_expect_code 127 flux job status $jobid
+'
+test_expect_success 'job-exec: simple job exits 138 on signaled job' '
+        jobid=$(flux mini submit sleep 30) &&
+        flux job wait-event -t 10 ${jobid} start &&
+        flux job kill --signal=SIGUSR1 $jobid &&
+        test_expect_code 138 flux job status $jobid
+'
+test_expect_success 'job-exec: simple job can be canceled' '
+        jobid=$(flux mini submit sleep 30) &&
+        flux job wait-event -t 10 ${jobid} start &&
+        flux job cancel $jobid &&
+        flux job wait-event -t 10 ${jobid} clean &&
+        test_expect_code 143 flux job status $jobid
+'
+test_expect_success 'job-exec: job fails correctly if user service not setup' '
+        jobid=$(flux mini submit \
+                --setattr=system.exec.sd.test_exec_fail=true \
+                hostname) &&
+        flux job wait-event -v -t 30 $jobid clean &&
+        flux job eventlog ${jobid} | grep "test sdprocess_exec" \
+             | grep "Operation not permitted"
+'
+test_expect_success 'job-exec: systemd cleaned up after job completes' '
+        jobid=$(flux mini submit sleep 30) &&
+        flux job wait-event -v -t 30 $jobid start &&
+        jobiddec=`flux job id --to=dec $jobid` &&
+        rank=`flux getattr rank` &&
+        systemctl list-units --user | grep "flux-sdexec-${rank}-${jobiddec}" &&
+        flux job cancel ${jobid} &&
+        flux job wait-event -v -t 30 $jobid clean &&
+        systemctl list-units --user > list-units.out &&
+        test_must_fail grep "flux-sdexec-${rank}-${jobiddec}" list-units.out
+'
+test_expect_success 'job-exec: no cleanup does not cleanup systemd' '
+        jobid=$(flux mini submit \
+                --setattr=system.exec.sd.no_cleanup=true \
+                hostname) &&
+        flux job wait-event -v -t 30 $jobid clean &&
+        jobiddec=`flux job id --to=dec $jobid` &&
+        rank=`flux getattr rank` &&
+        systemctl list-units --user | grep "flux-sdexec-${rank}-${jobiddec}" &&
+        systemctl stop --user "flux-sdexec-${rank}-${jobiddec}.service"
+'
+test_expect_success 'job-exec: shell stdout/err goto eventlog logged by default' '
+        cat >testdefaultlog.sh <<-EOF &&
+#!/bin/bash
+echo "default stdout"
+echo "default stderr" 1>&2
+EOF
+        chmod +x testdefaultlog.sh &&
+        jobid=$(flux mini submit --wait \
+                --setattr=system.exec.job_shell="$(pwd)/testdefaultlog.sh" \
+                hostname) &&
+        flux job eventlog -p guest.exec.eventlog ${jobid} > defaultlog.out &&
+        grep "default stdout" defaultlog.out | grep "stream=\"stdout\"" &&
+        grep "default stderr" defaultlog.out | grep "stream=\"stderr\""
+'
+test_expect_success 'job-exec: shell stdout/err goto eventlog when configured' '
+        cat >testeventloglog.sh <<-EOF &&
+#!/bin/bash
+echo "eventlog stdout"
+echo "eventlog stderr" 1>&2
+EOF
+        chmod +x testeventloglog.sh &&
+        jobid=$(flux mini submit --wait \
+                --setattr=system.exec.job_shell="$(pwd)/testeventloglog.sh" \
+                --setattr=system.exec.sd.stdoutlog="eventlog" \
+                --setattr=system.exec.sd.stderrlog="eventlog" \
+                hostname) &&
+        flux job eventlog -p guest.exec.eventlog ${jobid} > eventloglog.out &&
+        grep "eventlog stdout" eventloglog.out | grep "stream=\"stdout\"" &&
+        grep "eventlog stderr" eventloglog.out | grep "stream=\"stderr\""
+'
+# we can't be 100% sure how systemd is setup, so we don't check the
+# systemd journal for logging, we just make sure the logging did not
+# go to the guest.exec.eventlog
+test_expect_success 'job-exec: shell stdout/err dont goto eventlog when configured' '
+        cat >testsystemdlog.sh <<-EOF &&
+#!/bin/bash
+echo "systemd stdout"
+echo "systemd stderr" 1>&2
+EOF
+        chmod +x testsystemdlog.sh &&
+        jobid=$(flux mini submit --wait \
+                --setattr=system.exec.job_shell="$(pwd)/testsystemdlog.sh" \
+                --setattr=system.exec.sd.stdoutlog="systemd" \
+                --setattr=system.exec.sd.stderrlog="systemd" \
+                hostname) &&
+        flux job eventlog -p guest.exec.eventlog ${jobid} > systemdlog.out &&
+        test_must_fail grep "systemd stdout" systemdlog.out &&
+        test_must_fail grep "systemd stderr" systemdlog.out
+'
+test_expect_success 'job-exec: shell stdout/err goto eventlog with bad config' '
+        cat >testbadlog.sh <<-EOF &&
+#!/bin/bash
+echo "bad stdout"
+echo "bad stderr" 1>&2
+EOF
+        chmod +x testbadlog.sh &&
+        jobid=$(flux mini submit --wait \
+                --setattr=system.exec.job_shell="$(pwd)/testbadlog.sh" \
+                --setattr=system.exec.sd.stdoutlog="bad" \
+                --setattr=system.exec.sd.stderrlog="bad" \
+                hostname) &&
+        flux job eventlog -p guest.exec.eventlog ${jobid} > badlog.out &&
+        grep "bad stdout" badlog.out | grep "stream=\"stdout\"" &&
+        grep "bad stderr" badlog.out | grep "stream=\"stderr\""
+'
+# BUS_DEFAULT_TIMEOUT = 25 seconds, to be on safe side we sleep a bit
+# above 30 given the test.
+# N.B. in newer systemds could speed up test by setting SYSTEMD_BUS_TIMEOUT
+test_expect_success LONGTEST 'job-exec: can run job longer than 25 seconds' '
+        jobid=$(flux mini submit sleep 40) &&
+        test_expect_code 0 flux job status $jobid
+'
+test_expect_success LONGTEST 'job-exec: can cancel job after 25 seconds' '
+        jobid=$(flux mini submit sleep 60) &&
+        sleep 40 &&
+        flux job cancel $jobid &&
+        test_expect_code 143 flux job status $jobid
+'
+test_done

--- a/t/valgrind/valgrind.supp
+++ b/t/valgrind/valgrind.supp
@@ -133,3 +133,15 @@
    fun:ev_run
    ...
 }
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   obj:/usr/lib64/libgcrypt.so.20.2.5
+   obj:/usr/lib64/libgcrypt.so.20.2.5
+   obj:/usr/lib64/libgcrypt.so.20.2.5
+   obj:/usr/lib64/libgcrypt.so.20.2.5
+   obj:/usr/lib64/libgcrypt.so.20.2.5
+   ...
+}

--- a/t/valgrind/workload.d/job-sdexec
+++ b/t/valgrind/workload.d/job-sdexec
@@ -1,0 +1,36 @@
+#!/bin/bash -e
+
+if ! flux version | grep systemd; then
+    echo "flux not built with systemd"
+    exit 0
+fi
+
+#  Don't run if systemd environment variables not setup
+if test -z "$DBUS_SESSION_BUS_ADDRESS" \
+     -o -z "$XDG_RUNTIME_DIR"; then
+    echo "DBUS_SESSION_BUS_ADDRESS and/or XDG_RUNTIME_DIR not set"
+    exit 0
+fi
+
+uid=`id -u`
+userservice="user@${uid}.service"
+if ! systemctl list-units | grep ${userservice}
+then
+    echo "systemd user service not running"
+    exit 0
+fi
+
+# sdexec cannot work in a multi-broker test environment b/c sdexec
+# cannot execute a process on remote ranks (i.e. rank > 0).
+#
+# to get around this, submit 1 job at a time, effectively ensuring
+# job is always run on rank 0
+
+NJOBS=${NJOBS:-10}
+
+for i in `seq 1 ${NJOBS}`
+do
+    flux mini submit --wait \
+	--setattr=system.exec.sd.test=true \
+	${SHARNESS_TEST_DIRECTORY}/shell/lptest 78 2
+done


### PR DESCRIPTION
Built on top of #3864.  Hope is that we can add @grondo's `job-shell` reconnect on top of this, then hopefully add a simple test that will allow flux to restart and the job to be "re-attached".