### PR TITLE
shell: enhance pty support

### DIFF
--- a/doc/man1/flux-shell.rst
+++ b/doc/man1/flux-shell.rst
@@ -215,7 +215,34 @@ see the documentation for the specific plugin in question. The following
 options are supported by the builtin plugins of ``flux-shell``:
 
 **pty**
-  Allocate a pty for the first task rank.
+  Allocate a pty to all task ranks for non-interactive use. Output
+  from all ranks will be captured to the same location as ``stdout``.
+  This is the same as setting **pty.ranks=all** and **pty.capture**.
+  (see below).
+
+**pty.ranks**\ =\ *OPT*
+  Set the task ranks for which to allocate a pty. *OPT* may be either
+  an RFC 22 IDset of target ranks, an integer rank, or the string "all"
+  to indicate all ranks.
+
+**pty.capture**
+  Enable capture of pty output to the same location as stdout. This is
+  the default unless **pty.interactive** is set.
+
+**pty.interactive**
+  Enable a a pty on rank 0 that is set up for interactive attach by
+  a front-end program (i.e. ``flux job attach``). With no other **pty**
+  options, only rank 0 will be assigned a pty and output will not
+  be captured. These defaults can be changed by setting other
+  **pty** options after **pty.interactive**, e.g.
+
+  .. code-block:: console
+
+    $  flux mini run -o pty.interactive -o pty.capture ...
+
+  would allocate an interactive pty on rank 0 and also capture the
+  pty session to the KVS (so it can be displayed after the job exits
+  with ``flux job attach``).
 
 **cpu-affinity**\ =\ *OPT*
   Adjust the operation of the builtin shell ``affinity`` plugin.

--- a/src/cmd/flux-mini.py
+++ b/src/cmd/flux-mini.py
@@ -1503,7 +1503,7 @@ class AllocCmd(MiniCmd):
             broker_opts=list_split(args.broker_opts),
         )
         if sys.stdin.isatty():
-            jobspec.setattr_shell_option("pty", True)
+            jobspec.setattr_shell_option("pty.interactive", 1)
         return jobspec
 
     def main(self, args):

--- a/src/common/libterminus/pty.c
+++ b/src/common/libterminus/pty.c
@@ -350,7 +350,7 @@ int flux_pty_attach (struct flux_pty *pty)
     return 0;
 }
 
-static void pty_client_send_data (struct flux_pty *pty, void *data, int len)
+void pty_client_send_data (struct flux_pty *pty, void *data, int len)
 {
     struct pty_client *c = zlist_first (pty->clients);
 

--- a/src/common/libterminus/pty.c
+++ b/src/common/libterminus/pty.c
@@ -55,6 +55,7 @@
 #include "src/common/libczmqcontainers/czmq_containers.h"
 #include "src/common/libutil/fdutils.h"
 #include "src/common/libutil/errno_safe.h"
+#include "src/common/libutil/aux.h"
 
 #include "src/common/libutil/llog.h"
 
@@ -82,6 +83,9 @@ struct flux_pty {
     int exit_status;
 
     zlist_t *clients;
+
+    pty_monitor_f monitor;
+    struct aux_item *aux;
 };
 
 static void pty_client_destroy (struct pty_client *c)
@@ -283,6 +287,19 @@ void flux_pty_set_log (struct flux_pty *pty,
     }
 }
 
+void flux_pty_monitor (struct flux_pty *pty, pty_monitor_f fn)
+{
+    if (!pty)
+        return;
+
+    pty->monitor = fn;
+    /*  If a monitor function is provided, and there are currently no
+     *   other clients, ensure the pty fd_watcher is started.
+     */
+    if (fn != NULL && zlist_size (pty->clients) == 0)
+        flux_watcher_start (pty->fdw);
+}
+
 int flux_pty_leader_fd (struct flux_pty *pty)
 {
     if (!pty) {
@@ -336,6 +353,9 @@ int flux_pty_attach (struct flux_pty *pty)
 static void pty_client_send_data (struct flux_pty *pty, void *data, int len)
 {
     struct pty_client *c = zlist_first (pty->clients);
+
+    if (pty->monitor)
+        (*pty->monitor) (pty, data, len);
 
     while (c) {
         if (c->read_enabled) {
@@ -595,6 +615,28 @@ int flux_pty_set_flux (struct flux_pty *pty, flux_t *h)
     fd_set_nonblocking (pty->leader);
 
     return 0;
+}
+
+int flux_pty_aux_set (struct flux_pty *pty,
+                      const char *key,
+                      void *val,
+                      flux_free_f destroy)
+{
+    if (!pty) {
+        errno = EINVAL;
+        return -1;
+    }
+    return aux_set (&pty->aux, key, val, destroy);
+}
+
+void * flux_pty_aux_get (struct flux_pty *pty, const char *name)
+{
+    if (!pty) {
+        errno = EINVAL;
+        return NULL;
+    }
+    return aux_get (pty->aux, name);
+
 }
 
 

--- a/src/common/libterminus/pty.h
+++ b/src/common/libterminus/pty.h
@@ -167,6 +167,10 @@ int flux_pty_aux_set (struct flux_pty *pty,
 
 void * flux_pty_aux_get (struct flux_pty *pty, const char *name);
 
+/*  Function exported for testing only
+ */
+void pty_client_send_data (struct flux_pty *pty, void *data, int len);
+
 #endif /* !FLUX_PTY_H */
 
 /*

--- a/src/common/libterminus/pty.h
+++ b/src/common/libterminus/pty.h
@@ -24,9 +24,13 @@ typedef void (*pty_log_f) (void *arg,
                            const char *fmt,
                            va_list args);
 
+
 struct flux_pty;
 struct flux_pty_client;
 
+typedef void (*pty_monitor_f) (struct flux_pty *pty,
+                               void *data,
+                               int len);
 
 /* server:
  */
@@ -50,6 +54,11 @@ int  flux_pty_kill (struct flux_pty *pty, int sig);
 void flux_pty_set_log (struct flux_pty *pty,
                        pty_log_f log,
                        void *log_data);
+
+/*  Set a callback to receive data events locally.
+ *  (Usefully if we want to locally monitor the pty for logging, etc.)
+ */
+void flux_pty_monitor (struct flux_pty *pty, pty_monitor_f fn);
 
 int flux_pty_leader_fd (struct flux_pty *pty);
 
@@ -150,6 +159,13 @@ int flux_pty_client_notify_exit (struct flux_pty_client *c,
 int flux_pty_client_exit_status (struct flux_pty_client *c, int *statusp);
 
 void flux_pty_client_restore_terminal (void);
+
+int flux_pty_aux_set (struct flux_pty *pty,
+                      const char *key,
+                      void *val,
+                      flux_free_f destroy);
+
+void * flux_pty_aux_get (struct flux_pty *pty, const char *name);
 
 #endif /* !FLUX_PTY_H */
 

--- a/src/common/libterminus/terminus.c
+++ b/src/common/libterminus/terminus.c
@@ -870,7 +870,7 @@ flux_terminus_server_create (flux_t *h, const char *service)
     if (strlen (service) > sizeof (ts->service) - 1)
         goto err;
     strcpy (ts->service, service);
-    
+
     if (start_msghandlers (ts, handler_tab) < 0)
         goto err;
 

--- a/src/shell/Makefile.am
+++ b/src/shell/Makefile.am
@@ -7,6 +7,7 @@ AM_LDFLAGS = \
 AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
+	-I$(top_srcdir)/src/common/libccan \
 	-I$(top_builddir)/src/common/libflux \
 	$(VALGRIND_CFLAGS) \
 	$(LUA_INCLUDE) \

--- a/t/t2500-job-attach.t
+++ b/t/t2500-job-attach.t
@@ -121,8 +121,8 @@ test_expect_success HAVE_JQ 'attach: -v option displays file and line info in lo
 	grep "$file:$line: $message" verbose.output
 '
 
-test_expect_success 'attach: cannot attach to pty when --read-only specified' '
-	jobid=$(flux mini submit -o pty bash) &&
+test_expect_success 'attach: cannot attach to interactive pty when --read-only specified' '
+	jobid=$(flux mini submit -o pty.interactive bash) &&
 	test_must_fail flux job attach --read-only $jobid &&
 	flux job cancel $jobid
 '

--- a/t/test-inception.sh
+++ b/t/test-inception.sh
@@ -14,7 +14,7 @@ stats() {
 stats &
 PID=$!
 export FLUX_TESTS_LOGFILE=t
-flux mini bulksubmit --watch -q ./{} ::: t[0-9]*.t python/t*.py lua/t*.t
+flux mini bulksubmit -o pty --watch -q ./{} ::: t[0-9]*.t python/t*.py lua/t*.t
 RC=$?
 kill $PID
 wait


### PR DESCRIPTION
This is something I had sitting around for a bit and thought I'd throw up here for now as a WIP for comments.

The job shell pty support is currently pretty limited. It only allows allocating a pty to rank 0, and only supports "interactive" use, where the pty is interactively attached immediately after start. All data sent from the task running under a pty is lost, meaning it is not logged anywhere.

The above is fine for the `flux mini alloc` use case, however there is currently no way to allocate a pty for tasks when run non-interactively or to allocate a pty to all tasks. This may be useful when running asynchronous jobs that expect a pty, e.g. a testsuite that wants to emit color output.

This PR modifies the job shell's `pty` option to be a JSON object with multiple, optional keys, including:

 * `"ranks"` (int or string): an integer rank or RFC 22 idset of ranks for which a pty should be allocated
 * `"capture"` (int): If nonzero, capture pty output and send it to the same location as `stdout`
 * `"interactive"` (int): If nonzero, emit the rank 0 pty service endpoint along with the `shell.init` event. This allows `flux job attach` or other entities to know that an interactive attach to the rank 0 pty is desired.

If the supplied `pty` option is _not_ an object, then a default of `{"ranks":"all","capture":1,"interactive":0}` is used. This means that the default behavior of `-o pty` is changed, it will now run all tasks in a job with a pty, and send output to the same location as `stdout` (the kvs by default). This seems like the right default, since attaching to jobs interactively is probably not the common case, except as used by `flux mini alloc`, in which case we can set up the pty for interactive use within the command.

If only `interactive` is set, then `ranks` defaults to `0` as does `capture`. Therefore to get the old behavior of allocating a pty on rank 0 for interactive use `-o pty.interactive` can be used. `flux mini alloc` is updated here to use this mechanism.

The main use case I had in mind here was running the flux-core testsuite in bulk with color output. That is, the following now works

```console
 $ flux mini bulksubmit --watch --progress -o pty -n1 ./{} ::: t*.t python/t*.py lua/t*.t
```

and the testsuite is run in parallel with color output. I figure this may be useful in similar scenarios.

This is a WIP since tests still would need to be written, if the approach seems acceptable.

The main issue is probably the change in default behavior with `-o pty`.  My assumption is that this option is really only used by `flux mini alloc` at this time, however people could be using it for something like:

```console
$ flux mini run -o pty -n8 flux start
```
and uses like this would have to be updated to use `-o pty.interactive`. However I feel like in the long run, the non-interactive case is likely to be most common so I wanted to make that the easiest to use.

Anyone have any opinions?