### PR TITLE
add broker.starttime; add uptime to flux-top, flux-pstree

### DIFF
--- a/doc/man7/flux-broker-attributes.rst
+++ b/doc/man7/flux-broker-attributes.rst
@@ -44,6 +44,9 @@ content.backing-path
 hostlist
    An RFC 29 hostlist in broker rank order.
 
+broker.starttime
+   Timestamp of broker startup from :man3:`flux_reactor_now`.
+
 
 TOPOLOGY ATTRIBUTES
 ===================

--- a/src/broker/broker.h
+++ b/src/broker/broker.h
@@ -26,6 +26,8 @@ struct broker {
 
     bool online;
 
+    double starttime;
+
     struct broker_attr *attrs;
     struct flux_msg_cred cred;  /* instance owner */
 

--- a/src/cmd/flux-pstree.py
+++ b/src/cmd/flux-pstree.py
@@ -426,6 +426,10 @@ def get_root_jobinfo():
             nodelist=nodelist,
             annotations={"user": {"uri": uri}},
         )
+        try:
+            info["t_run"] = float(handle.attr_get("broker.starttime"))
+        except OSError:
+            pass
 
     #  If 'ranks' idset came from parent, it could be confusing,
     #   rewrite ranks to be relative to current instance, i.e.

--- a/src/cmd/top/summary_pane.c
+++ b/src/cmd/top/summary_pane.c
@@ -15,6 +15,7 @@
 #include <unistd.h>
 #include <time.h>
 #include <jansson.h>
+#include <math.h>
 
 #include "src/common/libutil/fsd.h"
 #include "src/common/librlist/rlist.h"
@@ -164,14 +165,14 @@ static void draw_bargraph (WINDOW *win, int y, int x, int x_length,
                suffix);
     /* Graph used */
     wattron (win, COLOR_PAIR (TOP_COLOR_YELLOW));
-    for (int i = 0; i < ((double)res.used / res.total) * slots; i++)
+    for (int i = 0; i < ceil (((double)res.used / res.total) * slots); i++)
         mvwaddch (win, y, x + strlen (prefix) + i, '|');
     wattroff (win, COLOR_PAIR (TOP_COLOR_YELLOW));
 
     /* Graph down */
     wattron (win, COLOR_PAIR (TOP_COLOR_RED));
     for (int i = slots - 1;
-         i >= slots - ((double)res.down / res.total) * slots; i--) {
+         i >= slots - ceil (((double)res.down / res.total) * slots); i--) {
         mvwaddch (win, y, x + strlen (prefix) + i, '|');
     }
     wattroff (win, COLOR_PAIR (TOP_COLOR_RED));

--- a/src/cmd/top/summary_pane.c
+++ b/src/cmd/top/summary_pane.c
@@ -53,6 +53,7 @@ struct summary_pane {
     WINDOW *win;
     int instance_level;
     int instance_size;
+    double starttime;
     const char *instance_version;
     double expiration;
     struct stats stats;
@@ -209,6 +210,11 @@ static void draw_heartbeat (struct summary_pane *sum)
 
 static void draw_info (struct summary_pane *sum)
 {
+    double now = flux_reactor_now (flux_get_reactor (sum->top->h));
+    char fsd[32] = "";
+
+    (void)fsd_format_duration_ex (fsd, sizeof (fsd), now - sum->starttime, 2);
+
     wattron (sum->win, A_DIM);
     mvwprintw (sum->win,
                info_dim.y_begin,
@@ -221,6 +227,11 @@ static void draw_info (struct summary_pane *sum)
                    info_dim.x_begin + 10,
                    "depth: %d",
                    sum->instance_level);
+    mvwprintw (sum->win,
+               info_dim.y_begin,
+               info_dim.x_begin + 30,
+               "uptime: %s",
+               fsd);
     mvwprintw (sum->win,
                info_dim.y_begin,
                info_dim.x_begin +
@@ -417,6 +428,8 @@ struct summary_pane *summary_pane_create (struct top *top)
     sum->instance_level = get_instance_attr_int (top->h, "instance-level");
     sum->instance_size = get_instance_attr_int (top->h, "size");
     sum->instance_version = flux_attr_get (top->h, "version");
+    if (flux_get_instance_starttime (top->h, &sum->starttime) < 0)
+        sum->starttime = flux_reactor_now (flux_get_reactor (top->h));
 
     summary_pane_query (sum);
     summary_pane_draw (sum);

--- a/src/cmd/top/top.h
+++ b/src/cmd/top/top.h
@@ -19,10 +19,10 @@ int mvwprintw(WINDOW *win, int y, int x, const char *fmt, ...)
     __attribute__ ((format (printf, 4, 5)));
 
 enum {
-    TOP_COLOR_YELLOW = 1,
-    TOP_COLOR_RED = 2,
-    TOP_COLOR_BLUE = 3,
-    TOP_COLOR_BLUE_HIGHLIGHT = 4,
+    TOP_COLOR_YELLOW = 1, // origin of 1 since 0 is an invalid color pair index
+    TOP_COLOR_RED,
+    TOP_COLOR_BLUE,
+    TOP_COLOR_BLUE_HIGHLIGHT,
 };
 
 struct top {

--- a/src/common/libflux/attr.c
+++ b/src/common/libflux/attr.c
@@ -212,6 +212,30 @@ error:
     return "(null)";
 }
 
+int flux_get_instance_starttime (flux_t *h, double *starttimep)
+{
+    flux_future_t *f;
+    const char *attr = "broker.starttime";
+    const char *s;
+    double starttime;
+
+    if (!(f = flux_rpc_pack (h, "attr.get", 0, 0, "{s:s}", "name", attr)))
+        return -1;
+    if (flux_rpc_get_unpack (f, "{s:s}", "value", &s) < 0)
+        goto error;
+    errno = 0;
+    starttime = strtod (s, NULL);
+    if (errno != 0)
+        goto error;
+    flux_future_destroy (f);
+    if (starttimep)
+        *starttimep = starttime;
+    return 0;
+error:
+    flux_future_destroy (f);
+    return -1;
+}
+
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab
  */

--- a/src/common/libflux/attr.h
+++ b/src/common/libflux/attr.h
@@ -66,6 +66,13 @@ int flux_get_size (flux_t *h, uint32_t *size);
  */
 const char *flux_get_hostbyrank (flux_t *h, uint32_t rank);
 
+/* Look up the broker.starttime attribute on rank 0.
+ * The instance uptime is flux_reactor_now() - starttime.
+ * N.B. if the instance has been restarted, this value is the most
+ * recent restart time.
+ */
+int flux_get_instance_starttime (flux_t *h, double *starttime);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/common/libflux/test/attr.c
+++ b/src/common/libflux/test/attr.c
@@ -52,11 +52,6 @@ static bool lookup_hardwired (const char *key, const char **val, int *flags)
     return false;
 }
 
-/* Two hardwired value:
- *   cow=moo (flags = 1)
- *   chicken=cluck (flags = 1)
- * all other values come from the hash and are returned with (flags = 0)
- */
 static volatile int get_count = 0;
 void get_cb (flux_t *h, flux_msg_handler_t *mh,
              const flux_msg_t *msg, void *arg)

--- a/src/common/libflux/test/attr.c
+++ b/src/common/libflux/test/attr.c
@@ -33,6 +33,7 @@ static struct entry hardwired[] = {
     { .key = "fox",     .val = "-",     .flags = 1  },
     { .key = "bear",    .val = "roar",  .flags = 1  },
     { .key = "hostlist", .val = "foo[0-2]", .flags = 1 },
+    { .key = "broker.starttime", .val = "3.14", .flags = 1 },
     { .key = NULL,      .val = NULL,    .flags = 1  },
 };
 
@@ -303,6 +304,14 @@ int main (int argc, char *argv[])
     ok ((value = flux_get_hostbyrank (h, 3)) != NULL
         && !strcmp (value, "(null)"),
         "flux_get_hostbyrank 3 returns (null)");
+
+    /* test flux_get_instance_starttime */
+    double d;
+    ok (flux_get_instance_starttime (h, &d) == 0 && d == 3.14,
+        "flux_get_instance_starttime works");
+    errno = 0;
+    ok (flux_get_instance_starttime (NULL, &d) < 0 && errno == EINVAL,
+        "flux_get_instance_starttime h=NULL fails with EINVAL");
 
     test_server_stop (h);
     flux_close (h);


### PR DESCRIPTION
This adds a `broker.starttime` attribute as discussed in #4033, and a convenience function for fetching it from rank 0 so it can be used to calculate instance uptime.  Then the uptime is displayed in `flux-top`.

There are a couple of small cleanups tacked on also.