### PR TITLE
flux-mini: add --wait-event option to submit/bulksubmit

### DIFF
--- a/doc/man1/flux-mini.rst
+++ b/doc/man1/flux-mini.rst
@@ -405,6 +405,13 @@ OTHER OPTIONS
 
 **--wait**
    *(submit,bulksubmit)* Wait on completion of all jobs before exiting.
+   This is equivalent to ``--wait-event=clean``.
+
+**--wait-event=NAME**
+   *(submit,bulksubmit)* Wait until all jobs have received event ``NAME``
+   before exiting. E.g. to submit a job and block until the job begins
+   running, use ``--wait-event=start``. If ``NAME`` begins with ``exec.``,
+   then wait for an event in the exec eventlog, e.g. ``exec.shell.init``.
 
 **--watch**
    *(submit,bulksubmit)* Display output from all jobs. Implies ``--wait``.

--- a/scripts/.pylintrc
+++ b/scripts/.pylintrc
@@ -91,7 +91,7 @@ logging-modules=logging
 bad-functions=map,filter,apply,input,file
 
 # Good variable names which should always be accepted, separated by a comma
-good-names=i,j,k,x,y,z,ex,io,rc,Run,_
+good-names=i,j,k,x,y,z,ex,io,rc,Run,_,ts,t0
 
 # Bad variable names which should always be refused, separated by a comma
 bad-names=foo,bar,baz,toto,tutu,tata

--- a/src/bindings/python/flux/job/event.py
+++ b/src/bindings/python/flux/job/event.py
@@ -112,10 +112,16 @@ class JobEventWatchFuture(Future):
             self.reset()
         return event
 
-    def cancel(self):
-        """Cancel a streaming job.event_watch_async() future"""
+    def cancel(self, stop=False):
+        """Cancel a streaming job.event_watch_async() future
+
+        If stop=True, then deactivate the multi-response future so no
+        further callbacks are called.
+        """
         RAW.event_watch_cancel(self.pimpl)
         self.needs_cancel = False
+        if stop:
+            self.stop()
 
 
 def event_watch_async(flux_handle, jobid, eventlog="eventlog"):

--- a/src/bindings/python/flux/progress.py
+++ b/src/bindings/python/flux/progress.py
@@ -294,6 +294,7 @@ class ProgressBar(Bottombar):
         length = width - len(before) - len(after) - 2
 
         #  Calculate amount of bar fully filled and buil string
+        fraction = min(fraction, 1.0)
         fill = int(length * fraction)
         filled = style[-1] * fill
 

--- a/src/bindings/python/flux/progress.py
+++ b/src/bindings/python/flux/progress.py
@@ -293,7 +293,7 @@ class ProgressBar(Bottombar):
         #  Calculate remaining length for progress bar:
         length = width - len(before) - len(after) - 2
 
-        #  Calculate amount of bar fully filled and buil string
+        #  Calculate amount of bar fully filled and build string
         fraction = min(fraction, 1.0)
         fill = int(length * fraction)
         filled = style[-1] * fill

--- a/src/cmd/flux-mini.py
+++ b/src/cmd/flux-mini.py
@@ -760,6 +760,7 @@ class SubmitBulkCmd(SubmitBaseCmd):
 
         #  dictionary of open logfiles for --log, --log-stderr:
         self._logfiles = {}
+        self.t0 = None
 
         super().__init__()
         self.parser.add_argument(
@@ -866,6 +867,14 @@ class SubmitBulkCmd(SubmitBaseCmd):
         self.progress_update(jobinfo, event=event)
         if event is None:
             return
+
+        # Capture first timestamp if not already set
+        if not self.t0 or event.timestamp < self.t0:
+            self.t0 = event.timestamp
+        if args.verbose > 2:
+            ts = event.timestamp - self.t0
+            print(f"{jobid}: {ts:.3f}s {event.name}", file=sys.stderr)
+
         if args.wait and args.wait == event.name:
             # Done with this job: update progress bar if necessary
             #  and cancel future

--- a/src/cmd/flux-mini.py
+++ b/src/cmd/flux-mini.py
@@ -845,7 +845,7 @@ class SubmitBulkCmd(SubmitBaseCmd):
             return
         if args.verbose > 2:
             ts = event.timestamp - self.t0
-            print(f"{jobid}: {ts:.3f}s exec.{event.name}", file=sys.stderr)
+            print(f"{jobid}: {ts:.3f}s exec.{event.name}", file=args.stderr)
         if args.watch and event and event.name == "shell.init":
             #  Once the shell.init event is posted, then it is safe to
             #   begin watching the output eventlog:
@@ -887,7 +887,7 @@ class SubmitBulkCmd(SubmitBaseCmd):
             self.t0 = event.timestamp
         if args.verbose > 2:
             ts = event.timestamp - self.t0
-            print(f"{jobid}: {ts:.3f}s {event.name}", file=sys.stderr)
+            print(f"{jobid}: {ts:.3f}s {event.name}", file=args.stderr)
 
         if args.wait and args.wait == event.name:
             # Done with this job: update progress bar if necessary

--- a/t/t2703-mini-bulksubmit.t
+++ b/t/t2703-mini-bulksubmit.t
@@ -123,6 +123,16 @@ test_expect_success 'flux-mini bulksubmit --wait returns highest exit code' '
 	test_expect_code 143 \
 	    flux mini bulksubmit --wait sh -c "kill -{} \$\$" ::: 0 0 15
 '
+test_expect_success 'flux-mini bulksubmit --wait-event works' '
+	flux mini bulksubmit -vvv \
+		--wait-event={} \
+		--log-stderr=wait.{}.out \
+		true ::: start exec.shell.init &&
+	test_debug "cat wait.start.out" &&
+	test_debug "cat wait.exec.shell.init.out" &&
+	tail -n1 wait.start.out | grep start &&
+	tail -n1 wait.exec.shell.init.out | grep shell.init
+'
 test_expect_success 'flux-mini bulksubmit replacement format strings work' '
 	echo /a/b/c/d.txt /a/b/c/d c.txt | \
 	    flux mini bulksubmit --sep=None --dry-run \


### PR DESCRIPTION
Had this one sitting around and there's been a few times it would have be useful for testing, so I thought I'd go ahead and propose a PR.

This PR adds a `--wait-event=NAME` option to `flux mini submit` and `flux mini bulksubmit`. The current `--wait` option thus becomes equivalent to `--wait-event=clean`. This option reduces the need for constructs like 

```shell
    id=$(flux mini submit ...)
    flux job wait-event ${id} start
```
which can be replaced with simply
```
   id=$(flux mini submit --wait-event=start ...)
```
and allows waiting for _all_ submitted jobs to receive the indicated event when used with `bulksubmit` or `flux mini submit --cc`.

(It does not, however, provide a timeout option like `flux job wait-event`, so if a timeout is desired `wait-event` should be used.)

The `--wait-event` option optionally allows events from the exec eventlog when the event starts with `exec.`, e.g. `flux mini submit --wait-event=exec.shell.init`.

There's some other cleanup in this PR, namely adding a `stop=True` parameter to `future.cancel()` which allows further callbacks for a streaming RPC to be stopped immediately from Python (as if `flux_future_destroy()` had been called in C), a fix for the `--log` and `--log-stderr` options, and a small fix for `progressbar`.
