### PR TITLE
shell: fix duplicate logging after evlog plugin is initialized

### DIFF
--- a/doc/man3/flux_shell_log.rst
+++ b/doc/man3/flux_shell_log.rst
@@ -131,6 +131,14 @@ be logged to any log destination). Macros include:
    #define shell_set_quiet(n) \
    flux_shell_log_setlevel(FLUX_SHELL_NOTICE-n, NULL)
 
+As a special case, if ``level`` is set to ``FLUX_SHELL_QUIET``, then
+logging will be completely disabled to ``dest``. For example, to disable
+logging to ``stderr``, use:
+
+::
+
+   flux_shell_log_setlevel (FLUX_SHELL_QUIET, "stderr");
+
 
 RETURN VALUE
 ============

--- a/src/shell/evlog.c
+++ b/src/shell/evlog.c
@@ -79,6 +79,9 @@ static int log_eventlog (flux_plugin_t *p,
 
 static void evlog_destroy (struct evlog *evlog)
 {
+    /*  Redirect future logging to stderr */
+    flux_shell_log_setlevel (evlog->level, "stderr");
+
     eventlogger_flush (evlog->ev);
     eventlogger_destroy (evlog->ev);
     free (evlog);

--- a/src/shell/evlog.c
+++ b/src/shell/evlog.c
@@ -206,7 +206,8 @@ static int log_eventlog_start (flux_plugin_t *p,
                                    evlog) < 0)
         goto err;
 
-    flux_shell_log_setlevel (FLUX_SHELL_ERROR, "stderr");
+    /*  Disable stderr logging */
+    flux_shell_log_setlevel (FLUX_SHELL_QUIET, "stderr");
     return 0;
 err:
     evlog_destroy (evlog);

--- a/src/shell/evlog.c
+++ b/src/shell/evlog.c
@@ -79,6 +79,7 @@ static int log_eventlog (flux_plugin_t *p,
 
 static void evlog_destroy (struct evlog *evlog)
 {
+    eventlogger_flush (evlog->ev);
     eventlogger_destroy (evlog->ev);
     free (evlog);
 }

--- a/src/shell/evlog.c
+++ b/src/shell/evlog.c
@@ -107,7 +107,7 @@ static void evlog_error (struct eventlogger *ev,
         fprintf (stderr, "evlog_error: failed to unpack message\n");
         return;
     }
-    fprintf (stderr, "flux-shell: evlog failure: %s: msg=%s\n",
+    fprintf (stderr, "evlog: %s: msg=%s\n",
                      strerror (errnum), msg);
 }
 

--- a/src/shell/log.c
+++ b/src/shell/log.c
@@ -337,7 +337,7 @@ out:
 
 int flux_shell_log_setlevel (int level, const char *dest)
 {
-    if (level < FLUX_SHELL_FATAL || level > FLUX_SHELL_TRACE) {
+    if (level < FLUX_SHELL_QUIET || level > FLUX_SHELL_TRACE) {
         errno = EINVAL;
         return -1;
     }

--- a/src/shell/shell.h
+++ b/src/shell/shell.h
@@ -289,6 +289,7 @@ int flux_shell_task_channel_subscribe (flux_shell_task_t *task,
  *  in the context of shell logging.
  */
 enum {
+    FLUX_SHELL_QUIET  = -1,
     FLUX_SHELL_FATAL  = 0,  /* LOG_EMERG   */
     /* Level 1 Reserved */  /* LOG_ALERT   */
     /* Level 2 Reserved */  /* LOG_CRIT    */
@@ -387,6 +388,8 @@ void flux_shell_raise (const char *type, int severity, const char *fmt, ...);
  *   If dest == NULL then set the internal log dispatch level --
  *   (i.e. no messages above severity level will be logged to any
  *    log destination)
+ *
+ *  If 'level' is FLUX_SHELL_QUIET, then logging to 'dest' is disabled.
  */
 int flux_shell_log_setlevel (int level, const char *dest);
 

--- a/t/shell/plugins/log.c
+++ b/t/shell/plugins/log.c
@@ -93,6 +93,9 @@ int flux_plugin_init (flux_plugin_t *p)
 
     ok (flux_plugin_add_handler (p, "*", check_shell_log, NULL) == 0,
         "flux_plugin_add_handler works");
+
+    ok (flux_shell_log_setlevel (-2, NULL) < 0 && errno == EINVAL,
+        "flux_shell_log_setlevel with invalid level fails");
     return 0;
 }
 


### PR DESCRIPTION
Error messages from the job shell are currently duplicated to the `evlog` plugin and `stderr`, and since job-exec copies `stderr` to the output eventlog, these errors are also duplicated in the output of `flux job attach`, which makes for a bit more output than is strictly necessary, e.g.:

```
ƒ(s=1,d=0) grondo@fluke108:~$ flux mini run badprog
0.060s: flux-shell[0]: FATAL: task 0: start failed: badprog: No such file or directory
0.060s: flux-shell[0]: stderr: flux-shell: FATAL: task 0: start failed: badprog: No such file or directory
0.061s: job.exception type=exec severity=0 task 0: start failed: badprog: No such file or directory
flux-job: task(s) exited with exit code 127
```

This PR adds a way to suppress all `stderr` log messages once the `evlog` plugin is initialized. It is unlikely we'll lose important errors, since the `evlog` plugin copies log messages that fail to get committed to the eventlog to `stderr` anyway.