### PR TITLE
flux resource: allow limited guest access

### DIFF
--- a/doc/man1/flux-resource.rst
+++ b/doc/man1/flux-resource.rst
@@ -58,13 +58,12 @@ COMMANDS
    *-o,--format=FORMAT*, customizes output formatting (see below).
    *-s,--states=STATE,...* limits output to specified resource states, where
    valid states are "online", "offline", "avail", "exclude", "drain", and "all".
-   This command is restricted to the Flux instance owner.
 
 **drain** [targets] [reason ...]
    If specified without arguments, list drained nodes.  The *targets* argument
    is an IDSET or HOSTLIST specifying nodes to drain.  Any remaining arguments
    are assumed to be a reason to be recorded with the drain event.  This
-   command is restricted to the Flux instance owner.
+   command, when run with arguments, is restricted to the Flux instance owner.
 
 **undrain** targets
    The *targets* argument is an IDSET or HOSTLIST specifying nodes to undrain.

--- a/src/cmd/flux-resource.py
+++ b/src/cmd/flux-resource.py
@@ -98,7 +98,7 @@ def drain_list():
         "reason": "REASON",
         "nodelist": "NODELIST",
     }
-    resp = RPC(flux.Flux(), "resource.status").get()
+    resp = RPC(flux.Flux(), "resource.status", nodeid=0).get()
     rset = ResourceSet(resp["R"])
     nodelist = rset.nodelist
 

--- a/src/modules/resource/resource.c
+++ b/src/modules/resource/resource.c
@@ -261,7 +261,7 @@ static const struct flux_msg_handler_spec htab[] = {
         .typemask = FLUX_MSGTYPE_REQUEST,
         .topic_glob = "resource.status",
         .cb = status_cb,
-        .rolemask = 0
+        .rolemask = FLUX_ROLE_USER,
     },
     {
         .typemask = FLUX_MSGTYPE_REQUEST,

--- a/t/t2311-resource-drain.t
+++ b/t/t2311-resource-drain.t
@@ -137,6 +137,10 @@ test_expect_success 'drain with no arguments works on rank > 0' '
 	flux exec -r 1 flux resource drain
 '
 
+test_expect_success 'drain with no arguments works for guest' '
+	FLUX_HANDLE_ROLEMASK=0x2 flux resource drain
+'
+
 drain_onrank() {
 	local op=$1
 	local nodeid=$2

--- a/t/t2311-resource-drain.t
+++ b/t/t2311-resource-drain.t
@@ -141,14 +141,13 @@ drain_onrank() {
 }
 
 test_expect_success 'resource.drain RPC fails on rank > 0' '
-       test_must_fail drain_onrank drain 1 0 2>drain1.err &&
-       grep -i "unknown service method" drain1.err
+	test_must_fail drain_onrank drain 1 0 2>drain1.err &&
+	grep -i "unknown service method" drain1.err
 '
 
 test_expect_success 'resource.undrain RPC fails on rank > 0' '
-       test_must_fail drain_onrank undrain 1 0 2>undrain1.err &&
-       grep -i "unknown service method" undrain1.err
+	test_must_fail drain_onrank undrain 1 0 2>undrain1.err &&
+	grep -i "unknown service method" undrain1.err
 '
-
 
 test_done

--- a/t/t2311-resource-drain.t
+++ b/t/t2311-resource-drain.t
@@ -133,6 +133,10 @@ test_expect_success 'drain/undrain works on rank > 0' '
 	flux exec -r 1 flux resource drain 0 whee drained again
 '
 
+test_expect_success 'drain with no arguments works on rank > 0' '
+	flux exec -r 1 flux resource drain
+'
+
 drain_onrank() {
 	local op=$1
 	local nodeid=$2


### PR DESCRIPTION
This PR ensures that `flux resource drain` (no args) can be used on any rank to list drained nodes, not just rank 0.

Also, allow guests to access the `resource.status` RPC, thus allowing them to use the above command plus `flux resource status`.  This eliminates an unnecessary sudo for sys admins, and also may be useful to users debugging a problem with their jobs.  There is no reason to restrict access that I can think of.

Update tests and man page.