### PR TITLE
Fix broker segfault when an exception is raised on a job after completed prolog

### DIFF
--- a/src/modules/job-manager/plugins/perilog.c
+++ b/src/modules/job-manager/plugins/perilog.c
@@ -107,6 +107,15 @@ static void perilog_proc_destructor (void **item)
 {
     if (item) {
         struct perilog_proc *proc = *item;
+        /*  Delete this perilog_proc entry from job hash first,
+         *  since job-exception handler detects if a perilog is currently
+         *  executing by checking for the perilog_proc aux_item:
+         */
+        flux_jobtap_job_aux_set (proc->p,
+                                 proc->id,
+                                 "perilog_proc",
+                                 NULL,
+                                 NULL);
         perilog_proc_destroy (proc);
         *item = NULL;
     }

--- a/t/t2274-manager-perilog.t
+++ b/t/t2274-manager-perilog.t
@@ -129,6 +129,16 @@ test_expect_success 'perilog: job can be canceled while prolog is running' '
 	flux job wait-event -t 15 $jobid exception &&
 	test_must_fail flux job attach -vE $jobid
 '
+test_expect_success 'perilog: job can be canceled after prolog is complete' '
+	printf "#!/bin/sh\nsleep 0" > prolog.d/sleep.sh &&
+	chmod +x prolog.d/sleep.sh &&
+	test_when_finished "rm -f prolog.d/sleep.sh" &&
+	jobid=$(flux mini submit --job-name=cancel2 sleep 300) &&
+	flux job wait-event -t 15 $jobid prolog-finish &&
+	flux job cancel $jobid &&
+	flux job wait-event -t 15 $jobid exception &&
+	flux job wait-event -t 15 $jobid clean
+'
 test_expect_success HAVE_JQ 'perilog: prolog failure raises job exception' '
 	printf "#!/bin/sh\n/bin/false" > prolog.d/fail.sh &&
 	chmod +x prolog.d/fail.sh &&


### PR DESCRIPTION
This fixes the issue described in #4089, where the job-manager perilog plugin will segfault on a job-exception raised for a job which completed a prolog/epilog.