### PR TITLE
libterminus: fix memory leaks in pty code

### DIFF
--- a/src/common/libterminus/client.c
+++ b/src/common/libterminus/client.c
@@ -303,10 +303,6 @@ static void pty_client_resize (struct flux_pty_client *c)
 static void pty_die (struct flux_pty_client *c, int code, const char *message)
 {
     flux_pty_client_stop (c);
-    if (c->attached && (c->flags & FLUX_PTY_CLIENT_NOTIFY_ON_DETACH)) {
-        printf ("\033[999H[detached: %s]\033[K\n\r", message);
-        fflush (stdout);
-    }
     /*  Only overwrite c->wait_status for code > 0. O/w, we collect the
      *   actual task exit status
      */
@@ -315,6 +311,11 @@ static void pty_die (struct flux_pty_client *c, int code, const char *message)
     if (message) {
         free (c->exit_message);
         c->exit_message = strdup (message);
+    }
+    if (c->attached && (c->flags & FLUX_PTY_CLIENT_NOTIFY_ON_DETACH)) {
+        printf ("\033[999H[detached: %s]\033[K\n\r",
+                c->exit_message ? c->exit_message : "unknown reason");
+        fflush (stdout);
     }
     notify_exit (c);
 }

--- a/src/common/libterminus/pty.c
+++ b/src/common/libterminus/pty.c
@@ -230,6 +230,7 @@ void flux_pty_close (struct flux_pty *pty, int status)
         if (pty->leader >= 0)
             close (pty->leader);
         free (pty->follower);
+        aux_destroy (&pty->aux);
         free (pty);
     }
 }

--- a/src/common/libterminus/pty.c
+++ b/src/common/libterminus/pty.c
@@ -57,6 +57,7 @@
 #include "src/common/libutil/errno_safe.h"
 #include "src/common/libutil/aux.h"
 
+#define LLOG_SUBSYSTEM "pty"
 #include "src/common/libutil/llog.h"
 
 #include "pty.h"

--- a/src/common/libterminus/terminus.c
+++ b/src/common/libterminus/terminus.c
@@ -56,8 +56,11 @@
 
 #include <flux/idset.h>
 
-#include "src/common/libczmqcontainers/czmq_containers.h"
+#define LLOG_SUBSYSTEM "pty"
+
 #include "src/common/libutil/llog.h"
+
+#include "src/common/libczmqcontainers/czmq_containers.h"
 #include "src/common/libterminus/pty.h"
 
 #include "terminus.h"


### PR DESCRIPTION
This was split off from work on #4077. Still don't have the fix working, but these fixes for memory leaks seemed like they should go in sooner rather than later.