### PR TITLE
broker: use TCP level keepalives

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -68,6 +68,10 @@ domainrefs = {
         'text': '%s(7)',
         'url': 'https://linux.die.net/man/7/%s',
     },
+    'linux:man8': {
+        'text': '%s(8)',
+        'url': 'https://linux.die.net/man/8/%s',
+    },
 }
 
 # Disable "smartquotes" to avoid things such as turning long-options

--- a/doc/man5/flux-config-tbon.rst
+++ b/doc/man5/flux-config-tbon.rst
@@ -30,6 +30,33 @@ torpid_max
    undraining with :man1:`flux-resource`.  This configured value may be
    overridden by setting the ``tbon.torpid_max`` broker attribute.
 
+keepalive_enable
+   (optional) An integer value to disable (0) or enable (1) TCP keepalives
+   on TBON child connections.  TCP keepalives are required to detect abruptly
+   turned off peers that are unable to shutdown their TCP connection
+   (default 1).  This configured value may be overridden by setting the
+   ``tbon.keepalive_enable`` broker attribute.
+
+keepalive_count
+   (optional) The integer number of TCP keepalive packets to send to an idle
+   downstream peer with no response before disconnecting it, overriding the
+   system value from :linux:man8:`sysctl` ``net.ipv4.tcp_keepalive_probes``.
+   This configured value may be overridden by setting the
+   ``tbon.keepalive_count`` broker attribute.
+
+keepalive_idle
+   (optional) The integer number of seconds to wait for an idle downstream
+   peer to send messages before beginning to send keepalive packets, overriding
+   the system value from :linux:man8:`sysctl` ``net.ipv4.tcp_keepalive_time``.
+   This configured value may be overridden by setting the
+   ``tbon.keepalive_idle`` broker attribute.
+
+keepalive_interval
+   (optional) The integer number of seconds to wait between sending keepalive
+   packets, overriding the system value from :linux:man8:`sysctl`
+   ``net.ipv4.tcp_keepalive_intvl``.  This configured value may be overridden
+   by setting the ``tbon.keepalive_interval`` broker attribute.
+
 
 EXAMPLE
 =======
@@ -39,6 +66,10 @@ EXAMPLE
    [tbon]
    torpid_min = 10s
    torpid_max = 1m
+
+   keepalive_count = 12
+   keepalive_interval = 10
+   keepalive_idle = 30
 
 
 RESOURCES

--- a/doc/man7/flux-broker-attributes.rst
+++ b/doc/man7/flux-broker-attributes.rst
@@ -92,6 +92,30 @@ tbon.torpid_max
    undraining with :man1:`flux-resource`.  This value may be adjusted on a
    live system.
 
+tbon.keepalive_enable
+   An integer value to disable (0) or enable (1) TCP keepalives on TBON
+   child connections.  TCP keepalives are required to detect abruptly turned
+   off peers that are unable to shutdown their TCP connection.  Default 1
+   or as configured in :man5:`flux-config-tbon`.
+
+tbon.keepalive_count
+   The integer number of TCP keepalive packets to send to an idle downstream
+   peer with no response before disconnecting it.  Set to -1 to use the
+   system value from :linux:man8:`sysctl` ``net.ipv4.tcp_keepalive_probes``.
+   Default -1 or as configured in :man5:`flux-config-tbon`.
+
+tbon.keepalive_idle
+   The integer number of seconds to wait for an idle downstream peer to send
+   messages before beginning to send keepalive packets.  Set to -1 to use the
+   system value from :linux:man8:`sysctl` ``net.ipv4.tcp_keepalive_time``.
+   Default -1 or as configured in :man5:`flux-config-tbon`.
+
+tbon.keepalive_interval
+   The integer number of seconds to wait between sending keepalive packets.
+   Set to -1 to use the system value from :linux:man8:`sysctl`
+   ``net.ipv4.tcp_keepalive_intvl``.  Default -1 or as configured in
+   :man5:`flux-config-tbon`.
+
 
 SOCKET ATTRIBUTES
 =================

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -599,3 +599,4 @@ MQ
 prefertcp
 desynchronized
 multi
+sysctl

--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -114,6 +114,17 @@ static const double sync_max = 5.0;
 static const double default_torpid_min = 5.0;
 static const double default_torpid_max = 30.0;
 
+/* TCP keepalives for child connections.
+ * These are distinct from the application level keepalives described above
+ * and are needed to detect nodes that are turned off before they can send FIN.
+ * The values of -1 below mean "use OS default" and are 0MQ-specific.
+ * The OS defaults can be tuned with sysctl.
+ */
+static int default_keepalive_enable = 1;    // 0=disable, 1=enable
+static int default_keepalive_count = -1;
+static int default_keepalive_idle = -1;
+static int default_keepalive_interval = -1;
+
 struct overlay_monitor {
     overlay_monitor_f cb;
     void *arg;
@@ -138,6 +149,10 @@ struct overlay {
     int zmqdebug;
     double torpid_min;
     double torpid_max;
+    int keepalive_enable;
+    int keepalive_count;
+    int keepalive_idle;
+    int keepalive_interval;
 
     struct parent parent;
 
@@ -1223,10 +1238,12 @@ int overlay_connect (struct overlay *ov)
         zsock_set_unbounded (ov->parent.zsock);
         zsock_set_linger (ov->parent.zsock, 5);
         zsock_set_ipv6 (ov->parent.zsock, ov->enable_ipv6);
+
         zsock_set_zap_domain (ov->parent.zsock, FLUX_ZAP_DOMAIN);
         zcert_apply (ov->cert, ov->parent.zsock);
         zsock_set_curve_serverkey (ov->parent.zsock, ov->parent.pubkey);
         zsock_set_identity (ov->parent.zsock, ov->uuid);
+
         if (zsock_connect (ov->parent.zsock, "%s", ov->parent.uri) < 0)
             goto nomem;
         if (!(ov->parent.w = zmqutil_watcher_create (ov->reactor,
@@ -1284,6 +1301,11 @@ int overlay_bind (struct overlay *ov, const char *uri)
     zsock_set_linger (ov->bind_zsock, 5);
     zsock_set_router_mandatory (ov->bind_zsock, 1);
     zsock_set_ipv6 (ov->bind_zsock, ov->enable_ipv6);
+
+    zsock_set_tcp_keepalive (ov->bind_zsock, ov->keepalive_enable);
+    zsock_set_tcp_keepalive_idle (ov->bind_zsock, ov->keepalive_idle);
+    zsock_set_tcp_keepalive_intvl (ov->bind_zsock, ov->keepalive_interval);
+    zsock_set_tcp_keepalive_cnt (ov->bind_zsock, ov->keepalive_count);
 
     zsock_set_zap_domain (ov->bind_zsock, FLUX_ZAP_DOMAIN);
     zcert_apply (ov->cert, ov->bind_zsock);
@@ -1793,6 +1815,87 @@ static int overlay_configure_torpid (struct overlay *ov)
                          set_torpid,
                          ov) < 0)
         return -1;
+
+    return 0;
+}
+
+static int check_keepalive_values (struct overlay *ov, const char *msg)
+{
+    if (ov->keepalive_enable != 0 && ov->keepalive_enable != 1) {
+        log_msg ("%s: %s must be 0 or 1", msg, "tbon.keepalive_enable");
+        return -1;
+    }
+    if (ov->keepalive_count != -1 && !(ov->keepalive_count > 0)) {
+        log_msg ("%s: %s must be -1 or >0", msg, "tbon.keepalive_count");
+        return -1;
+    }
+    if (ov->keepalive_idle != -1 && !(ov->keepalive_idle > 0)) {
+        log_msg ("%s: %s must be -1 or >0", msg, "tbon.keepalive_idle");
+        return -1;
+    }
+    if (ov->keepalive_interval != -1 && !(ov->keepalive_interval > 0)) {
+        log_msg ("%s: %s must be -1 or >0", msg, "tbon.keepalive_interval");
+        return -1;
+    }
+    return 0;
+}
+
+static int overlay_configure_keepalive (struct overlay *ov)
+{
+    const flux_conf_t *cf;
+
+    /* Start with compiled in defaults.
+     */
+    ov->keepalive_enable = default_keepalive_enable;
+    ov->keepalive_count = default_keepalive_count;
+    ov->keepalive_idle = default_keepalive_idle;
+    ov->keepalive_interval = default_keepalive_interval;
+
+    /* Override with config file settings, if any.
+     */
+    if ((cf = flux_get_conf (ov->h))) {
+        flux_conf_error_t error;
+
+        if (flux_conf_unpack (flux_get_conf (ov->h),
+                              &error,
+                              "{s?{s?i s?i s?i s?i}}",
+                              "tbon",
+                                "keepalive_enable", &ov->keepalive_enable,
+                                "keepalive_count", &ov->keepalive_count,
+                                "keepalive_idle", &ov->keepalive_idle,
+                                "keepalive_interval",
+                                    &ov->keepalive_interval) < 0) {
+            log_msg ("Config file error [tbon]: %s", error.errbuf);
+            return -1;
+        }
+        if (check_keepalive_values (ov, "Config file error") < 0)
+            return -1;
+    }
+
+    /* Override with broker attribute (command line only) settings, if any.
+     */
+    if (overlay_configure_attr_int (ov->attrs,
+                                    "tbon.keepalive_enable",
+                                    ov->keepalive_enable,
+                                    &ov->keepalive_enable) < 0)
+        return -1;
+    if (overlay_configure_attr_int (ov->attrs,
+                                    "tbon.keepalive_count",
+                                    ov->keepalive_count,
+                                    &ov->keepalive_count) < 0)
+        return -1;
+    if (overlay_configure_attr_int (ov->attrs,
+                                    "tbon.keepalive_idle",
+                                    ov->keepalive_idle,
+                                    &ov->keepalive_idle) < 0)
+        return -1;
+    if (overlay_configure_attr_int (ov->attrs,
+                                    "tbon.keepalive_interval",
+                                    ov->keepalive_interval,
+                                    &ov->keepalive_interval) < 0)
+        return -1;
+    if (check_keepalive_values (ov, "broker attribute error") < 0)
+        return -1;
     return 0;
 }
 
@@ -1916,6 +2019,8 @@ struct overlay *overlay_create (flux_t *h,
     if (overlay_configure_attr_int (ov->attrs, "tbon.prefertcp", 0, NULL) < 0)
         goto error;
     if (overlay_configure_torpid (ov) < 0)
+        goto error;
+    if (overlay_configure_keepalive (ov) < 0)
         goto error;
     if (flux_msg_handler_addvec (h, htab, ov, &ov->handlers) < 0)
         goto error;

--- a/t/t0013-config-file.t
+++ b/t/t0013-config-file.t
@@ -212,4 +212,120 @@ test_expect_success '[bootstrap] curve_cert file must be mode o-r' '
 	test_must_fail flux broker ${ARGS} -c conf14 /bin/true
 '
 
+#
+# [tbon] keepalive_* tests
+#
+
+test_expect_success 'tbon.keepalive is enabled and using sysctl defaults' '
+	cat <<-EOT >attrs_keepalive.exp &&
+	tbon.keepalive_count                    -1
+	tbon.keepalive_enable                   1
+	tbon.keepalive_idle                     -1
+	tbon.keepalive_interval                 -1
+	EOT
+	flux broker ${ARGS} flux lsattr -v >attrs.out &&
+	grep "^tbon.keepalive_" attrs.out | sort >attrs_keepalive.out &&
+	test_cmp attrs_keepalive.exp attrs_keepalive.out
+'
+
+test_expect_success 'tbon.keepalive values can be set via config' '
+
+	cat <<-EOT2 >attrs_keepalive2.exp &&
+	tbon.keepalive_count                    42
+	tbon.keepalive_enable                   0
+	tbon.keepalive_idle                     43
+	tbon.keepalive_interval                 44
+	EOT2
+	mkdir conf15 &&
+	cat <<-EOT >conf15/tbon.toml &&
+	[tbon]
+	keepalive_enable = 0
+	keepalive_count = 42
+	keepalive_idle = 43
+	keepalive_interval = 44
+	EOT
+	flux broker ${ARGS} -c conf15 flux lsattr -v >attrs2.out &&
+	grep "^tbon.keepalive_" attrs2.out | sort >attrs_keepalive2.out &&
+	test_cmp attrs_keepalive2.exp attrs_keepalive2.out
+'
+
+test_expect_success 'tbon.keepalive_enable command line overrides config' '
+	cat <<-EOT >attrs_keepalive3.exp &&
+	tbon.keepalive_count                    5
+	tbon.keepalive_enable                   1
+	tbon.keepalive_idle                     30
+	tbon.keepalive_interval                 1
+	EOT
+	flux broker ${ARGS} -c conf15 \
+		-Stbon.keepalive_enable=1 \
+		-Stbon.keepalive_idle=30 \
+		-Stbon.keepalive_interval=1 \
+		-Stbon.keepalive_count=5 \
+		flux lsattr -v >attrs3.out &&
+	grep "^tbon.keepalive_" attrs3.out | sort >attrs_keepalive3.out &&
+	test_cmp attrs_keepalive3.exp attrs_keepalive3.out
+'
+
+test_expect_success 'tbon.keepalive_enable attr value check works' '
+	test_must_fail flux broker ${ARGS} \
+		-Stbon.keepalive_enable=2 /bin/true 2>attr_enable.err &&
+	grep "broker attribute error" attr_enable.err
+'
+test_expect_success 'tbon.keepalive_count attr value check works' '
+	test_must_fail flux broker ${ARGS} \
+		-Stbon.keepalive_count=0 /bin/true 2>attr_count.err &&
+	grep "broker attribute error" attr_count.err
+'
+test_expect_success 'tbon.keepalive_idle attr value check works' '
+	test_must_fail flux broker ${ARGS} \
+		-Stbon.keepalive_idle=0 /bin/true 2>attr_idle.err &&
+	grep "broker attribute error" attr_idle.err
+'
+test_expect_success 'tbon.keepalive_interval attr value check works' '
+	test_must_fail flux broker ${ARGS} \
+		-Stbon.keepalive_interval=0 /bin/true 2>attr_interval.err &&
+	grep "broker attribute error" attr_interval.err
+'
+
+test_expect_success 'tbon.keepalive_enable config check works' '
+	mkdir conf16 &&
+	cat <<-EOT >conf16/tbon.toml &&
+	[tbon]
+	keepalive_enable = -9
+	EOT
+	test_must_fail flux broker ${ARGS} -c conf16 /bin/true \
+		2>conf_enable.err &&
+	grep "Config file error" conf_enable.err
+'
+test_expect_success 'tbon.keepalive_count config check works' '
+	mkdir conf17 &&
+	cat <<-EOT >conf17/tbon.toml &&
+	[tbon]
+	keepalive_count = 0
+	EOT
+	test_must_fail flux broker ${ARGS} -c conf17 /bin/true \
+		2>conf_count.err &&
+	grep "Config file error" conf_count.err
+'
+test_expect_success 'tbon.keepalive_idle config check works' '
+	mkdir conf18 &&
+	cat <<-EOT >conf18/tbon.toml &&
+	[tbon]
+	keepalive_idle = 0
+	EOT
+	test_must_fail flux broker ${ARGS} -c conf18 /bin/true \
+		2>conf_idle.err &&
+	grep "Config file error" conf_idle.err
+'
+test_expect_success 'tbon.keepalive_interval config check works' '
+	mkdir conf19 &&
+	cat <<-EOT >conf19/tbon.toml &&
+	[tbon]
+	keepalive_interval = 0
+	EOT
+	test_must_fail flux broker ${ARGS} -c conf19 /bin/true \
+		2>conf_interval.err &&
+	grep "Config file error" conf_interval.err
+'
+
 test_done


### PR DESCRIPTION
Enable TCP keepalives so Flux can disconnect from nodes that have been turned off.