### PR TITLE
systemd: set restart=always

### DIFF
--- a/etc/flux.service.in
+++ b/etc/flux.service.in
@@ -22,7 +22,7 @@ ExecStart=/bin/bash -c '\
   -Sbroker.quorum-timeout=none \
 '
 ExecReload=@X_BINDIR@/flux config reload
-Restart=on-success
+Restart=always
 RestartSec=5s
 User=flux
 Group=flux


### PR DESCRIPTION
Problem: when an upstream broker fails, downstream brokers need to
be manually restarted.

This is sort of as designed but it's a pain.

Switch to Restart=always mode so the broker always tries again,
and sys admins won't have to mop up when something bad happens.

Fixes #3818