### PR TITLE
shell: do not allow instance owner to use guest shell services

### DIFF
--- a/src/shell/svc.c
+++ b/src/shell/svc.c
@@ -97,13 +97,11 @@ flux_future_t *shell_svc_vpack (struct shell_svc *svc,
 
 int shell_svc_allowed (struct shell_svc *svc, const flux_msg_t *msg)
 {
-    uint32_t rolemask;
     uint32_t userid;
 
-    if (flux_msg_get_rolemask (msg, &rolemask) < 0
-            || flux_msg_get_userid (msg, &userid) < 0)
+    if (flux_msg_get_userid (msg, &userid) < 0)
         return -1;
-    if (!(rolemask & FLUX_ROLE_OWNER) && userid != svc->uid) {
+    if (userid != svc->uid) {
         errno = EPERM;
         return -1;
     }


### PR DESCRIPTION
The system instance owner is by design an unprivileged user which should not have access to guest user services provided by the job shell, but currently most shell services allow FLUX_ROLE_OWNER.

Lock down access to shell-provided services to the job owner only.