### PR TITLE
shell: fix race in attach to interactive job pty

### DIFF
--- a/src/common/libterminus/test/pty.c
+++ b/src/common/libterminus/test/pty.c
@@ -32,8 +32,8 @@ static void test_invalid_args ()
 
     lives_ok ({flux_pty_set_log (NULL, NULL, NULL);},
               "flux_pty_set_log does nothing with NULL args");
-    lives_ok ({flux_pty_close (NULL, 0);},
-              "flux_pty_close does nothing with NULL arg");
+    lives_ok ({flux_pty_destroy (NULL);},
+              "flux_pty_destroy does nothing with NULL arg");
 
     ok (flux_pty_kill (NULL, SIGINT) < 0 && errno == EINVAL,
         "flux_pty_kill() with NULL pty returns EINVAL");
@@ -97,7 +97,7 @@ static void test_invalid_args ()
     ok (flux_pty_aux_get (NULL, NULL) == NULL && errno == EINVAL,
         "flux_pty_aux_get (NULL, NULL) fails");
 
-    flux_pty_close (pty, 0);
+    flux_pty_destroy (pty);
     flux_pty_client_destroy (c);
 }
 
@@ -111,7 +111,7 @@ static void test_empty_server ()
         "pty leader fd is valid");
     ok (flux_pty_client_count (pty) == 0,
         "pty client count is 0 for newly created pty server");
-    flux_pty_close (pty, 0);
+    flux_pty_destroy (pty);
 }
 
 static void tap_logger (void *arg,
@@ -168,7 +168,7 @@ static int pty_server (flux_t *h, void *arg)
     diag ("pty server exiting");
 out:
     flux_msg_handler_destroy (mh);
-    flux_pty_close (pty, 0);
+    flux_pty_destroy (pty);
     return rc;
 }
 
@@ -467,7 +467,7 @@ void test_monitor ()
     ok (total == 12,
         "monitor received 12 bytes");
 
-    flux_pty_close (pty, 0);
+    flux_pty_destroy (pty);
     flux_close (h);
 }
 

--- a/t/t2612-job-shell-pty.t
+++ b/t/t2612-job-shell-pty.t
@@ -104,13 +104,13 @@ test_expect_success HAVE_JQ 'pty: pty.interactive forces a pty on rank 0' '
 		-n2 \
 		tty) &&
 	terminus_jobid $id list &&
-	flux job attach ${id} &&
+	$runpty flux job attach ${id} &&
 	flux job eventlog -p guest.output ${id} | grep "adding pty to rank 0"
 '
 test_expect_success 'pty: -o pty.interactive and -o pty.capture can be used together' '
 	id=$(flux mini submit -o pty.interactive -o pty.capture tty) &&
-	flux job attach $id >ptyim.out 2>&1 &&
-	flux job attach $id
+	$runpty flux job attach $id >ptyim.out 2>&1 &&
+	$runpty flux job attach $id
 '
 test_expect_success 'pty: unsupported -o pty.<opt> generates exception' '
 	test_must_fail flux mini run -o pty.foo hostname

--- a/t/t2612-job-shell-pty.t
+++ b/t/t2612-job-shell-pty.t
@@ -35,11 +35,10 @@ terminus_jobid() {
 }
 
 test_expect_success HAVE_JQ 'pty: submit a job with an interactive pty' '
-	id=$(flux mini submit --flags waitable -o pty.interactive bash) &&
+	id=$(flux mini submit --flags waitable -o pty.interactive tty) &&
 	terminus_jobid $id list &&
-	flux job cancel ${id} &&
-	$runpty flux job attach ${id} && # pty waiting for first client attach
-	test_must_fail flux job wait $id
+	$runpty flux job attach ${id} &&
+	flux job wait $id
 '
 test_expect_success HAVE_JQ,NO_CHAIN_LINT 'pty: run job with pty' '
 	printf "PS1=XXX:\n" >ps1.rc
@@ -56,34 +55,9 @@ test_expect_success HAVE_JQ,NO_CHAIN_LINT 'pty: run job with pty' '
 '
 # Interactively attach to pty many times to ensure no hangs, etc.
 #
-# Ensure `flux job attach` has a chance to attach to pty before `stty size`
-#  is executed by blocking and waiting for `test-ready` key to appear in
-#  the job's kvs namespace.
-#
-# Test driver waits for "shell.start" event to be output by `flux-job attach`
-#  which guarantees we're attached to pty, since this is done synchronously
-#  in flux-job attach after the `shell.init` event.
-#
-# Finally, put the test-ready key into kvs, unblocking the test job so
-#  it can proceed to print result.
-#
 test_expect_success NO_CHAIN_LINT 'pty: interactive job with pty' '
-	cat <<-EOF >stty-test.sh &&
-	#!/bin/sh
-	# Do not continue until test is ready:
-	flux kvs get --waitcreate --count=1 --label test-ready
-	stty size
-	EOF
-	chmod +x stty-test.sh &&
-	for i in `seq 0 10`; do
-	    id=$(flux mini submit -n1 -o pty.interactive ./stty-test.sh)
-	    { $runpty -w 80x25 -o log.interactive.$i \
-	        flux job attach --show-exec ${id} & } &&
-	    pid=$! &&
-	    $waitfile -t 20 -vp "shell.start" log.interactive.$i &&
-	    flux kvs put -N $(flux job namespace ${id}) test-ready=${i} &&
-	    $waitfile -t 20 -vp "25 80" log.interactive.$i
-	done
+	flux mini submit --cc=1-10 -n1 -o pty.interactive stty size >jobids &&
+	for id in $(cat jobids); do $runpty flux job attach $id; done
 '
 
 test_expect_success 'pty: client is detached from terminated job' '
@@ -125,15 +99,13 @@ test_expect_success 'pty: pty.ranks can take an idset' '
 	test_must_fail grep "not a tty" ptyss.out
 '
 test_expect_success HAVE_JQ 'pty: pty.interactive forces a pty on rank 0' '
-	id=$(flux mini submit --flags waitable \
+	id=$(flux mini submit \
 		-o pty.interactive -o pty.ranks=1 \
 		-n2 \
-		bash) &&
+		tty) &&
 	terminus_jobid $id list &&
-	flux job cancel ${id} &&
 	flux job attach ${id} &&
-	flux job eventlog -p guest.output ${id} | grep "adding pty to rank 0" &&
-	test_must_fail flux job wait $id
+	flux job eventlog -p guest.output ${id} | grep "adding pty to rank 0"
 '
 test_expect_success 'pty: -o pty.interactive and -o pty.capture can be used together' '
 	id=$(flux mini submit -o pty.interactive -o pty.capture tty) &&

--- a/t/t2612-job-shell-pty.t
+++ b/t/t2612-job-shell-pty.t
@@ -38,6 +38,7 @@ test_expect_success HAVE_JQ 'pty: submit a job with an interactive pty' '
 	id=$(flux mini submit --flags waitable -o pty.interactive bash) &&
 	terminus_jobid $id list &&
 	flux job cancel ${id} &&
+	$runpty flux job attach ${id} && # pty waiting for first client attach
 	test_must_fail flux job wait $id
 '
 test_expect_success HAVE_JQ,NO_CHAIN_LINT 'pty: run job with pty' '
@@ -130,6 +131,7 @@ test_expect_success HAVE_JQ 'pty: pty.interactive forces a pty on rank 0' '
 		bash) &&
 	terminus_jobid $id list &&
 	flux job cancel ${id} &&
+	flux job attach ${id} &&
 	flux job eventlog -p guest.output ${id} | grep "adding pty to rank 0" &&
 	test_must_fail flux job wait $id
 '


### PR DESCRIPTION
This PR reworks the pty code to close a race condition when attaching to a short-lived process which has been allocated a pty.

The major visible change here is that, when running a job with `-o pty.interactive`, the shell will keep the rank 0 pty available until at least one client attaches, even if the task has exited. If no client attaches the shell `doom` plugin will terminate the job after 30s by default. This can be disabled via `-o exit-timeout=-1`, in which case the shell could hang until the job times out waiting for a client to attach.