### PR TITLE
flux-ping: support hostnames in TARGET

### DIFF
--- a/doc/man1/flux-ping.rst
+++ b/doc/man1/flux-ping.rst
@@ -22,13 +22,13 @@ give insight into how various addresses are routed.
 
 *target* may be the name of a Flux service, e.g. "kvs".
 flux-ping(1) will send a request to "kvs.ping". As a shorthand,
-*target* can include a rank prefix delimited by an exclamation point.
+*target* can include a rank or host prefix delimited by an exclamation point.
 "flux ping 4!kvs" is equivalent to "flux ping --rank 4 kvs" (see --rank
 option below). Don't forget to quote the exclamation point if it is
 interpreted by your shell.
 
-As a shorthand, *target* may also simply be a rank by itself
-indicating that the broker on that rank or ranks, rather than a Flux
+As a shorthand, *target* may also simply be a rank or host by itself
+indicating that the broker on that rank/host, rather than a Flux
 service, is to be pinged. "flux ping 1" is equivalent to
 "flux ping --rank 1 broker".
 

--- a/src/common/libflux/attr.c
+++ b/src/common/libflux/attr.c
@@ -212,6 +212,21 @@ error:
     return "(null)";
 }
 
+int flux_get_rankbyhost (flux_t *h, const char *host)
+{
+    struct attr_cache *c;
+
+    if (!(c = get_attr_cache (h)))
+        return -1;
+    if (!c->hostlist) {
+        const char *val;
+        if (!(val = flux_attr_get (h, "hostlist"))
+            || !(c->hostlist = hostlist_decode (val)))
+            return -1;
+    }
+    return hostlist_find (c->hostlist, host);
+}
+
 int flux_get_instance_starttime (flux_t *h, double *starttimep)
 {
     flux_future_t *f;

--- a/src/common/libflux/attr.h
+++ b/src/common/libflux/attr.h
@@ -66,6 +66,12 @@ int flux_get_size (flux_t *h, uint32_t *size);
  */
 const char *flux_get_hostbyrank (flux_t *h, uint32_t rank);
 
+/* Find the lowest numbered broker rank running on 'host', by consulting
+ * the "hostlist" attribute.
+ * Returns rank on success, -1 on failure with errno set.
+ */
+int flux_get_rankbyhost (flux_t *h, const char *host);
+
 /* Look up the broker.starttime attribute on rank 0.
  * The instance uptime is flux_reactor_now() - starttime.
  * N.B. if the instance has been restarted, this value is the most

--- a/src/common/libflux/test/attr.c
+++ b/src/common/libflux/test/attr.c
@@ -300,6 +300,19 @@ int main (int argc, char *argv[])
         && !strcmp (value, "(null)"),
         "flux_get_hostbyrank 3 returns (null)");
 
+    /* test flux_get_rankbyhost () */
+    errno = 0;
+    ok (flux_get_rankbyhost (NULL, "foo2") < 0 && errno == EINVAL,
+        "flux_get_rankbyhost h=NULL fails with EINVAL");
+    errno = 0;
+    ok (flux_get_rankbyhost (h, NULL) < 0 && errno == EINVAL,
+        "flux_get_rankbyhost host=NULL fails with EINVAL");
+    errno = 0;
+    ok (flux_get_rankbyhost (h, "foo3") < 0 && errno == ENOENT,
+        "flux_get_rankbyhost host=foo3 fails with ENOENT");
+    ok (flux_get_rankbyhost (h, "foo2") == 2,
+        "flux_get_rankbyhost host=foo2 returns 2");
+
     /* test flux_get_instance_starttime */
     double d;
     ok (flux_get_instance_starttime (h, &d) == 0 && d == 3.14,

--- a/t/t0007-ping.t
+++ b/t/t0007-ping.t
@@ -137,4 +137,14 @@ test_expect_success 'ping help output works' '
         grep "Usage: flux-ping \[OPTIONS\] TARGET" help.err
 '
 
+test_expect_success 'ping works with hostname' '
+        flux ping --count=1 $(hostname -s)
+'
+test_expect_success 'ping works with hostname!service' '
+        flux ping --count=1 "$(hostname -s)!broker"
+'
+test_expect_success 'ping fails with unknown hostname' '
+        test_must_fail flux ping --count=1 "notmyhost!broker"
+'
+
 test_done


### PR DESCRIPTION
This changes `flux-ping` to accept a hostname as part of the TARGET instead of a rank, e.g.
```
$ ./flux ping system76-pc
0!broker.ping pad=0 seq=0 time=0.200 ms (1c36d225!b4330dc7!b6026d87)
0!broker.ping pad=0 seq=1 time=0.198 ms (1c36d225!b4330dc7!b6026d87)
^C
```
or
```
$ ./flux ping 'system76-pc!kvs'
0!kvs.ping pad=0 seq=0 time=0.232 ms (85d88d89!b4330dc7!b6026d87!e92cbac2)
0!kvs.ping pad=0 seq=1 time=0.363 ms (85d88d89!b4330dc7!b6026d87!e92cbac2)
^C
```
It also adds a general function for resolving hosts to ranks:
```c
/* Find the lowest numbered broker rank running on 'host', by consulting
 * the "hostlist" attribute.
 * Returns rank on success, -1 on failure with errno set.
 */
int flux_get_rankbyhost (flux_t *h, const char *host);
```