### PR TITLE
rename keepalive messages to control messages

### DIFF
--- a/doc/man5/flux-config-tbon.rst
+++ b/doc/man5/flux-config-tbon.rst
@@ -18,9 +18,9 @@ KEYS
 torpid_min
    (optional) The amount of time (in RFC 23 Flux Standard Duration format) that
    a broker will allow the connection to its TBON parent to remain idle before
-   sending a keepalive message.  The default value of ``5s`` should be
-   reasonable in most circumstances.  This configured value may be overridden
-   by setting the ``tbon.torpid_min`` broker attribute.
+   sending a control message to create activity.  The default value of
+   ``5s`` should be reasonable in most circumstances.  This configured value
+   may be overridden by setting the ``tbon.torpid_min`` broker attribute.
 
 torpid_max
    (optional) The amount of time (in RFC 23 Flux Standard Duration format) that

--- a/doc/man7/flux-broker-attributes.rst
+++ b/doc/man7/flux-broker-attributes.rst
@@ -82,7 +82,8 @@ tbon.prefertcp
 tbon.torpid_min
    The amount of time (in RFC 23 Flux Standard Duration format) that a broker
    will allow the connection to its TBON parent to remain idle before sending a
-   keepalive message.  This value may be adjusted on a live system.
+   control message to indicate create activity.  This value may be adjusted
+   on a live system.
 
 tbon.torpid_max
    The amount of time (in RFC 23 Flux Standard Duration format) that a broker

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -429,8 +429,8 @@ int main (int argc, char *argv[])
     /* These two broker-resident services call flux_sync_create(), thus
      * require event.subscribe to have a handler before running.
      */
-    if (overlay_keepalive_start (ctx.overlay) < 0) {
-        log_err ("error initializing overlay keepalives");
+    if (overlay_control_start (ctx.overlay) < 0) {
+        log_err ("error initializing overlay control messages");
         goto cleanup;
     }
     if (!(ctx.cache = content_cache_create (ctx.h, ctx.attrs))) {

--- a/src/broker/modservice.c
+++ b/src/broker/modservice.c
@@ -88,8 +88,8 @@ static void stats_get_cb (flux_t *h, flux_msg_handler_t *mh,
                            "#response (rx)", mcs.response_rx,
                            "#event (tx)", mcs.event_tx,
                            "#event (rx)", mcs.event_rx,
-                           "#keepalive (tx)", mcs.keepalive_tx,
-                           "#keepalive (rx)", mcs.keepalive_rx) < 0)
+                           "#control (tx)", mcs.control_tx,
+                           "#control (rx)", mcs.control_rx) < 0)
       FLUX_LOG_ERROR (h);
 }
 

--- a/src/broker/overlay.h
+++ b/src/broker/overlay.h
@@ -38,11 +38,11 @@ struct overlay *overlay_create (flux_t *h,
                                 void *arg);
 void overlay_destroy (struct overlay *ov);
 
-/* Start sending keepalive messages to parent and monitoring peers.
+/* Start sending control messages to parent and monitoring peers.
  * This registers a sync callback, and will fail if event.subscribe
  * doesn't have a handler yet.
  */
-int overlay_keepalive_start (struct overlay *ov);
+int overlay_control_start (struct overlay *ov);
 
 /* Set the overlay network size and rank of this broker.
  */
@@ -105,7 +105,7 @@ json_t *overlay_get_subtree_topo (struct overlay *ov, int rank);
  */
 const char *overlay_get_subtree_status (struct overlay *ov, int rank);
 
-/* A TBON child is "torpid" if no messages (including regular keepalives)
+/* A TBON child is "torpid" if no messages (including regular control messages)
  * have been received from it for a while.
  */
 bool overlay_peer_is_torpid (struct overlay *ov, uint32_t rank);

--- a/src/common/libflux/Makefile.am
+++ b/src/common/libflux/Makefile.am
@@ -67,7 +67,7 @@ fluxcoreinclude_HEADERS = \
 	message.h \
 	msglist.h \
 	request.h \
-	keepalive.h \
+	control.h \
 	response.h \
 	rpc.h \
 	panic.h \
@@ -118,7 +118,7 @@ libflux_la_SOURCES = \
 	ev_buffer_read.c \
 	ev_buffer_write.h \
 	ev_buffer_write.c \
-	keepalive.c \
+	control.c \
 	content.c \
 	future.c \
 	composite_future.c \

--- a/src/common/libflux/control.c
+++ b/src/common/libflux/control.c
@@ -13,17 +13,15 @@
 #endif
 #include <flux/core.h>
 
-#include "keepalive.h"
+#include "control.h"
 
-flux_msg_t *flux_keepalive_encode (int errnum, int status)
+flux_msg_t *flux_control_encode (int type, int status)
 {
     flux_msg_t *msg;
 
-    if (!(msg = flux_msg_create (FLUX_MSGTYPE_KEEPALIVE)))
+    if (!(msg = flux_msg_create (FLUX_MSGTYPE_CONTROL)))
         goto error;
-    if (flux_msg_set_errnum (msg, errnum) < 0)
-        goto error;
-    if (flux_msg_set_status (msg, status) < 0)
+    if (flux_msg_set_control (msg, type, status) < 0)
         goto error;
     return msg;
 error:
@@ -31,22 +29,17 @@ error:
     return NULL;
 }
 
-int flux_keepalive_decode (const flux_msg_t *msg, int *ep, int *sp)
+int flux_control_decode (const flux_msg_t *msg, int *typep, int *statusp)
 {
-    int rc = -1;
-    int errnum, status;
+    int type, status;
 
-    if (flux_msg_get_errnum (msg, &errnum) < 0)
-        goto done;
-    if (flux_msg_get_status (msg, &status) < 0)
-        goto done;
-    if (ep)
-        *ep = errnum;
-    if (sp)
-        *sp = status;
-    rc = 0;
-done:
-    return rc;
+    if (flux_msg_get_control (msg, &type, &status) < 0)
+        return -1;
+    if (typep)
+        *typep = type;
+    if (statusp)
+        *statusp = status;
+    return 0;
 }
 
 /*

--- a/src/common/libflux/control.h
+++ b/src/common/libflux/control.h
@@ -8,22 +8,22 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
-#ifndef _FLUX_CORE_KEEPALIVE_H
-#define _FLUX_CORE_KEEPALIVE_H
+#ifndef _FLUX_CORE_CONTROL_H
+#define _FLUX_CORE_CONTROL_H
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-flux_msg_t *flux_keepalive_encode (int errnum, int status);
+flux_msg_t *flux_control_encode (int type, int status);
 
-int flux_keepalive_decode (const flux_msg_t *msg, int *errnum, int *status);
+int flux_control_decode (const flux_msg_t *msg, int *type, int *status);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif /* !_FLUX_CORE_KEEPALIVE_H */
+#endif /* !_FLUX_CORE_CONTROL_H */
 
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab

--- a/src/common/libflux/flux.h
+++ b/src/common/libflux/flux.h
@@ -20,7 +20,7 @@
 #include "msglist.h"
 #include "request.h"
 #include "response.h"
-#include "keepalive.h"
+#include "control.h"
 #include "rpc.h"
 #include "panic.h"
 #include "event.h"

--- a/src/common/libflux/handle.c
+++ b/src/common/libflux/handle.c
@@ -181,7 +181,7 @@ static void profiling_msg_snapshot (flux_t *h,
     }
 
     const char *msg_topic;
-    if (type != FLUX_MSGTYPE_KEEPALIVE)
+    if (type != FLUX_MSGTYPE_CONTROL)
         flux_msg_get_topic (msg, &msg_topic);
     else
         msg_topic = "NONE";
@@ -636,8 +636,8 @@ static void update_tx_stats (flux_t *h, const flux_msg_t *msg)
             case FLUX_MSGTYPE_EVENT:
                 h->msgcounters.event_tx++;
                 break;
-            case FLUX_MSGTYPE_KEEPALIVE:
-                h->msgcounters.keepalive_tx++;
+            case FLUX_MSGTYPE_CONTROL:
+                h->msgcounters.control_tx++;
                 break;
         }
     } else
@@ -658,8 +658,8 @@ static void update_rx_stats (flux_t *h, const flux_msg_t *msg)
             case FLUX_MSGTYPE_EVENT:
                 h->msgcounters.event_rx++;
                 break;
-        case FLUX_MSGTYPE_KEEPALIVE:
-            h->msgcounters.keepalive_rx++;
+        case FLUX_MSGTYPE_CONTROL:
+            h->msgcounters.control_rx++;
             break;
         }
     } else

--- a/src/common/libflux/handle.h
+++ b/src/common/libflux/handle.h
@@ -31,8 +31,8 @@ typedef struct {
     int response_rx;
     int event_tx;
     int event_rx;
-    int keepalive_tx;
-    int keepalive_rx;
+    int control_tx;
+    int control_rx;
 } flux_msgcounters_t;
 
 typedef int (*flux_comms_error_f)(flux_t *h, void *arg);

--- a/src/common/libflux/message.h
+++ b/src/common/libflux/message.h
@@ -28,7 +28,7 @@ enum {
     FLUX_MSGTYPE_REQUEST    = 0x01,
     FLUX_MSGTYPE_RESPONSE   = 0x02,
     FLUX_MSGTYPE_EVENT      = 0x04,
-    FLUX_MSGTYPE_KEEPALIVE  = 0x08,
+    FLUX_MSGTYPE_CONTROL    = 0x08,
     FLUX_MSGTYPE_ANY        = 0x0f,
     FLUX_MSGTYPE_MASK       = 0x0f,
 };
@@ -254,7 +254,7 @@ int flux_msg_cred_authorize (struct flux_msg_cred cred, uint32_t userid);
  */
 int flux_msg_authorize (const flux_msg_t *msg, uint32_t userid);
 
-/* Get/set errnum (response/keepalive only)
+/* Get/set errnum (response only)
  */
 int flux_msg_set_errnum (flux_msg_t *msg, int errnum);
 int flux_msg_get_errnum (const flux_msg_t *msg, int *errnum);
@@ -264,10 +264,10 @@ int flux_msg_get_errnum (const flux_msg_t *msg, int *errnum);
 int flux_msg_set_seq (flux_msg_t *msg, uint32_t seq);
 int flux_msg_get_seq (const flux_msg_t *msg, uint32_t *seq);
 
-/* Get/set status (keepalive only)
+/* Get/set type, status (control only)
  */
-int flux_msg_set_status (flux_msg_t *msg, int status);
-int flux_msg_get_status (const flux_msg_t *msg, int *status);
+int flux_msg_set_control (flux_msg_t *msg, int type, int status);
+int flux_msg_get_control (const flux_msg_t *msg, int *type, int *status);
 
 /* Get/set/compare match tag (request/response only)
  */

--- a/src/common/libflux/message_iovec.c
+++ b/src/common/libflux/message_iovec.c
@@ -53,7 +53,7 @@ int iovec_to_msg (flux_msg_t *msg,
     if (msg->type != FLUX_MSGTYPE_REQUEST
         && msg->type != FLUX_MSGTYPE_RESPONSE
         && msg->type != FLUX_MSGTYPE_EVENT
-        && msg->type != FLUX_MSGTYPE_KEEPALIVE) {
+        && msg->type != FLUX_MSGTYPE_CONTROL) {
         errno = EPROTO;
         return -1;
     }

--- a/src/common/libflux/message_private.h
+++ b/src/common/libflux/message_private.h
@@ -40,12 +40,13 @@ struct flux_msg {
     union {
         uint32_t nodeid;  // request
         uint32_t sequence; // event
-        uint32_t errnum; // response, keepalive
+        uint32_t errnum; // response
+        uint32_t control_type; // control
         uint32_t aux1; // common accessor
     };
     union {
         uint32_t matchtag; // request, response
-        uint32_t status; // keepalive
+        uint32_t control_status; // control
         uint32_t aux2; // common accessor
     };
 

--- a/src/common/libflux/message_proto.h
+++ b/src/common/libflux/message_proto.h
@@ -28,14 +28,14 @@
  * request - nodeid
  * response - errnum
  * event - sequence
- * keepalive - errnum
+ * control - type
  *
  * aux2
  *
  * request - matchtag
  * response - matchtag
  * event - not used
- * keepalive - status
+ * control - status
  */
 #define PROTO_IND_USERID    0
 #define PROTO_IND_ROLEMASK  1

--- a/src/common/libflux/module.c
+++ b/src/common/libflux/module.c
@@ -19,7 +19,6 @@
 
 #include "module.h"
 #include "message.h"
-#include "keepalive.h"
 #include "rpc.h"
 
 #include "src/common/libutil/log.h"

--- a/src/common/libflux/test/message.c
+++ b/src/common/libflux/test/message.c
@@ -228,16 +228,16 @@ void check_cornercase (void)
     ok (flux_msg_get_seq (req, &seq) < 0 && errno == EPROTO,
         "flux_msg_get_seq fails with EPROTO on msg != event type");
     errno = 0;
-    ok (flux_msg_set_status (NULL, 0) < 0 && errno == EINVAL,
+    ok (flux_msg_set_control (NULL, 0, 0) < 0 && errno == EINVAL,
         "flux_msg_set_status fails with EINVAL on msg = NULL");
     errno = 0;
-    ok (flux_msg_get_status (NULL, &status) < 0 && errno == EINVAL,
+    ok (flux_msg_get_control (NULL, &type, &status) < 0 && errno == EINVAL,
         "flux_msg_get_status fails with EINVAL on msg = NULL");
-    lives_ok ({flux_msg_get_status (msg, NULL);},
+    lives_ok ({flux_msg_get_control (msg, &type, NULL);},
         "flux_msg_get_status status = NULL does not segfault");
     errno = 0;
-    ok (flux_msg_get_status (req, &status) < 0 && errno == EPROTO,
-        "flux_msg_get_status fails with EPROTO on msg != keepalive type");
+    ok (flux_msg_get_control (req, &type, &status) < 0 && errno == EPROTO,
+        "flux_msg_get_status fails with EPROTO on msg != control type");
     errno = 0;
     ok (flux_msg_set_matchtag (NULL, 42) < 0 && errno == EINVAL,
         "flux_msg_set_matchtag fails with EINVAL on msg = NULL");
@@ -978,13 +978,13 @@ void check_copy (void)
     const void *cpybuf;
     const char *s;
 
-    ok ((msg = flux_msg_create (FLUX_MSGTYPE_KEEPALIVE)) != NULL,
-        "created no-payload keepalive");
+    ok ((msg = flux_msg_create (FLUX_MSGTYPE_CONTROL)) != NULL,
+        "created no-payload control");
     ok ((cpy = flux_msg_copy (msg, true)) != NULL,
         "flux_msg_copy works");
     flux_msg_destroy (msg);
     type = -1;
-    ok (flux_msg_get_type (cpy, &type) == 0 && type == FLUX_MSGTYPE_KEEPALIVE
+    ok (flux_msg_get_type (cpy, &type) == 0&& type == FLUX_MSGTYPE_CONTROL
              && !flux_msg_has_payload (cpy)
              && flux_msg_route_count (cpy) < 0
              && flux_msg_get_topic (cpy, &topic) < 0,
@@ -1051,10 +1051,10 @@ void check_print (void)
     if (!f)
         BAIL_OUT ("cannot open /dev/null for writing");
 
-    ok ((msg = flux_msg_create (FLUX_MSGTYPE_KEEPALIVE)) != NULL,
+    ok ((msg = flux_msg_create (FLUX_MSGTYPE_CONTROL)) != NULL,
         "created test message");
     lives_ok ({flux_msg_fprint_ts (f, msg, 0.);},
-        "flux_msg_fprint_ts doesn't segfault on keepalive");
+        "flux_msg_fprint_ts doesn't segfault on control");
     flux_msg_destroy (msg);
 
     ok ((msg = flux_msg_create (FLUX_MSGTYPE_EVENT)) != NULL,
@@ -1202,13 +1202,13 @@ void check_refcount (void)
     const flux_msg_t *p;
     int type;
 
-    if (!(msg = flux_msg_create (FLUX_MSGTYPE_KEEPALIVE)))
+    if (!(msg = flux_msg_create (FLUX_MSGTYPE_CONTROL)))
         BAIL_OUT ("failed to create test message");
     p = flux_msg_incref (msg);
     ok (p == msg,
         "flux_msg_incref returns pointer to original");
     flux_msg_destroy (msg);
-    ok (flux_msg_get_type (p, &type) == 0 && type == FLUX_MSGTYPE_KEEPALIVE,
+    ok (flux_msg_get_type (p, &type) == 0 && type == FLUX_MSGTYPE_CONTROL,
         "reference remains valid after destroy");
     flux_msg_decref (p);
 }

--- a/src/common/librouter/test/rpc_track.c
+++ b/src/common/librouter/test/rpc_track.c
@@ -248,11 +248,11 @@ void test_badarg (void)
         "rpc_track_update msg=event is a no-op");
     flux_msg_decref (msg);
 
-    if (!(msg = flux_keepalive_encode (42, 43)))
+    if (!(msg = flux_control_encode (42, 43)))
         BAIL_OUT ("could not create test message");
     rpc_track_update (rt, NULL);
     ok (rpc_track_count (rt) == 0,
-        "rpc_track_update msg=keepalive is a no-op");
+        "rpc_track_update msg=control is a no-op");
     flux_msg_decref (msg);
 
     if (!(msg = flux_request_encode ("foo", NULL)))

--- a/src/common/libtestutil/util.c
+++ b/src/common/libtestutil/util.c
@@ -90,7 +90,7 @@ static void diag_cb (flux_t *h, flux_msg_handler_t *mh,
 
     if (flux_msg_get_type (msg, &msgtype) < 0)
         goto badmsg;
-    if (msgtype != FLUX_MSGTYPE_KEEPALIVE) {
+    if (msgtype != FLUX_MSGTYPE_CONTROL) {
         if (flux_msg_get_topic (msg, &topic) < 0)
             goto badmsg;
     }

--- a/t/t0003-module.t
+++ b/t/t0003-module.t
@@ -195,8 +195,8 @@ test_expect_success 'flux module stats gets comms statistics' '
 	grep -q "#response (rx)" comms.stats &&
 	grep -q "#event (tx)" comms.stats &&
 	grep -q "#event (rx)" comms.stats &&
-	grep -q "#keepalive (tx)" comms.stats &&
-	grep -q "#keepalive (rx)" comms.stats
+	grep -q "#control (tx)" comms.stats &&
+	grep -q "#control (rx)" comms.stats
 '
 
 test_expect_success 'flux module stats --parse "#event (tx)" counts events' '


### PR DESCRIPTION
This changes all references to application level keepalives and the Flux keepalive message type to "control messages" per the proposed change to RFC 3 in flux-framework/flux-core#312.

This should avoid some confusion between TCP keepalives, which we now support, and these control messages, now only used between brokers after #4110.