### PR TITLE
testsuite: remove unportable cshism

### DIFF
--- a/t/t2410-exec-systemd.t
+++ b/t/t2410-exec-systemd.t
@@ -32,14 +32,14 @@ waitfile=${SHARNESS_TEST_SRCDIR}/scripts/waitfile.lua
 test_expect_success 'run process under systemd and wait till exits (success)' '
         ${SHARNESS_TEST_DIRECTORY}/sdprocess/sim-broker \
             run-wait-exit --unitname=simtest-success \
-            /bin/true >& run-wait-exitA.out &&
+            /bin/true >run-wait-exitA.out 2>&1 &&
         grep simtest-success run-wait-exitA.out | grep exited | grep "status=0"
 '
 
 test_expect_success 'run process under systemd and wait till exits (failure)' '
         ${SHARNESS_TEST_DIRECTORY}/sdprocess/sim-broker \
             run-wait-exit --unitname=simtest-failure \
-            /bin/false >& run-wait-exitB.out &&
+            /bin/false >run-wait-exitB.out 2>&1 &&
         grep simtest-failure run-wait-exitB.out | grep exited | grep "status=1"
 '
 
@@ -47,7 +47,7 @@ test_expect_success 'run process under systemd and wait till exits (failure)' '
 test_expect_success NO_CHAIN_LINT 'run process under systemd and wait till exits (signal)' '
         ${SHARNESS_TEST_DIRECTORY}/sdprocess/sim-broker \
             run-wait-exit --unitname=simtest-signal \
-            /usr/bin/sleep 30 >& run-wait-exitC.out &
+            /usr/bin/sleep 30 >run-wait-exitC.out 2>&1 &
         $waitfile --count=1 --timeout=10 --pattern=active run-wait-exitC.out &&
         systemctl kill --user simtest-signal.service &&
         $waitfile --count=1 --timeout=10 --pattern=exited run-wait-exitC.out &&
@@ -57,7 +57,7 @@ test_expect_success NO_CHAIN_LINT 'run process under systemd and wait till exits
 test_expect_success 'run process under systemd and let it keep running (success)' '
         ${SHARNESS_TEST_DIRECTORY}/sdprocess/sim-broker \
             run --unitname=simtest-reattach-run-success \
-            ${SHARNESS_TEST_DIRECTORY}/sdprocess/job-signal-exit 60 >& runD.out &&
+            ${SHARNESS_TEST_DIRECTORY}/sdprocess/job-signal-exit 60 >runD.out 2>&1 &&
         grep simtest-reattach-run-success runD.out | grep active &&
         systemctl list-units --user | grep simtest-reattach-run-success | grep active
 '
@@ -72,7 +72,7 @@ test_expect_success 'run process under systemd and let it keep running (success)
 # SIGINT will make job-signal-exit with status 0
 test_expect_success NO_CHAIN_LINT 'attach to running process and wait for exit (success)' '
         ${SHARNESS_TEST_DIRECTORY}/sdprocess/sim-broker \
-            wait --unitname=simtest-reattach-run-success >& waitE.out &
+            wait --unitname=simtest-reattach-run-success >waitE.out 2>&1 &
         $waitfile --count=1 --timeout=10 --pattern=attached waitE.out &&
         $waitfile --count=1 --timeout=10 --pattern=active waitE.out &&
         systemctl kill --user --signal=SIGINT simtest-reattach-run-success.service &&
@@ -83,7 +83,7 @@ test_expect_success NO_CHAIN_LINT 'attach to running process and wait for exit (
 test_expect_success 'run process under systemd and let it keep running (failure)' '
         ${SHARNESS_TEST_DIRECTORY}/sdprocess/sim-broker \
             run --unitname=simtest-reattach-run-failure \
-            ${SHARNESS_TEST_DIRECTORY}/sdprocess/job-signal-exit 60 >& runF.out &&
+            ${SHARNESS_TEST_DIRECTORY}/sdprocess/job-signal-exit 60 >runF.out 2>&1 &&
         grep simtest-reattach-run-failure runF.out | grep active &&
         systemctl list-units --user | grep simtest-reattach-run-failure | grep active
 '
@@ -91,7 +91,7 @@ test_expect_success 'run process under systemd and let it keep running (failure)
 # SIGTERM will make job-signal-exit with status 1
 test_expect_success NO_CHAIN_LINT 'attach to running process and wait for exit (failure)' '
         ${SHARNESS_TEST_DIRECTORY}/sdprocess/sim-broker \
-            wait --unitname=simtest-reattach-run-failure >& waitG.out &
+            wait --unitname=simtest-reattach-run-failure >waitG.out 2>&1  &
         $waitfile --count=1 --timeout=10 --pattern=attached waitG.out &&
         $waitfile --count=1 --timeout=10 --pattern=active waitG.out &&
         systemctl kill --user --signal=SIGTERM simtest-reattach-run-failure.service &&
@@ -102,7 +102,7 @@ test_expect_success NO_CHAIN_LINT 'attach to running process and wait for exit (
 test_expect_success 'run process under systemd and let it keep running (failure)' '
         ${SHARNESS_TEST_DIRECTORY}/sdprocess/sim-broker \
             run --unitname=simtest-reattach-run-failure \
-            /usr/bin/sleep 60 >& runH.out &&
+            /usr/bin/sleep 60 >runH.out 2>&1 &&
         grep simtest-reattach-run-failure runH.out | grep active &&
         systemctl list-units --user | grep simtest-reattach-run-failure | grep active
 '
@@ -110,7 +110,7 @@ test_expect_success 'run process under systemd and let it keep running (failure)
 # N.B. SIGTERM=15
 test_expect_success NO_CHAIN_LINT 'attach to running process and wait for exit (failure)' '
         ${SHARNESS_TEST_DIRECTORY}/sdprocess/sim-broker \
-            wait --unitname=simtest-reattach-run-failure >& waitI.out &
+            wait --unitname=simtest-reattach-run-failure >waitI.out 2>&1 &
         $waitfile --count=1 --timeout=10 --pattern=attached waitI.out &&
         $waitfile --count=1 --timeout=10 --pattern=active waitI.out &&
         systemctl kill --user --signal=SIGTERM simtest-reattach-run-failure.service &&
@@ -121,22 +121,22 @@ test_expect_success NO_CHAIN_LINT 'attach to running process and wait for exit (
 test_expect_success 'attach to process that finished (success)' '
         ${SHARNESS_TEST_DIRECTORY}/sdprocess/sim-broker \
             run-wait-exit --unitname=simtest-reattach-exit-success --no-cleanup \
-            /bin/true >& run-wait-exitJ.out &&
+            /bin/true >run-wait-exitJ.out 2>&1 &&
         grep simtest-reattach-exit-success run-wait-exitJ.out \
             | grep exited | grep "status=0"
         ${SHARNESS_TEST_DIRECTORY}/sdprocess/sim-broker \
-            wait --unitname=simtest-reattach-exit-success >& waitJ.out &&
+            wait --unitname=simtest-reattach-exit-success >waitJ.out 2>&1 &&
         grep simtest-reattach-exit-success waitJ.out | grep exited | grep status=0
 '
 
 test_expect_success 'attach to process that finished (failure)' '
         ${SHARNESS_TEST_DIRECTORY}/sdprocess/sim-broker \
             run-wait-exit --unitname=simtest-reattach-exit-failure --no-cleanup \
-            /bin/false >& run-wait-exitK.out &&
+            /bin/false >run-wait-exitK.out 2>&1 &&
         grep simtest-reattach-exit-failure run-wait-exitK.out \
             | grep exited | grep "status=0"
         ${SHARNESS_TEST_DIRECTORY}/sdprocess/sim-broker \
-            wait --unitname=simtest-reattach-exit-failure >& waitK.out &&
+            wait --unitname=simtest-reattach-exit-failure >waitK.out 2>&1 &&
         grep simtest-reattach-exit-failure waitK.out | grep exited | grep status=1
 '
 
@@ -144,12 +144,12 @@ test_expect_success 'attach to process that finished (failure)' '
 test_expect_success NO_CHAIN_LINT 'attach to process that finished (signal)' '
         ${SHARNESS_TEST_DIRECTORY}/sdprocess/sim-broker \
             run-wait-exit --unitname=simtest-reattach-exit-signal --no-cleanup \
-            /usr/bin/sleep 30 >& run-wait-exitL.out &
+            /usr/bin/sleep 30 >run-wait-exitL.out 2>&1 &
         $waitfile --count=1 --timeout=10 --pattern=active run-wait-exitL.out &&
         systemctl kill --user simtest-reattach-exit-signal.service &&
         $waitfile --count=1 --timeout=10 --pattern=exited run-wait-exitL.out &&
         ${SHARNESS_TEST_DIRECTORY}/sdprocess/sim-broker \
-            wait --unitname=simtest-reattach-exit-signal >& waitL.out &&
+            wait --unitname=simtest-reattach-exit-signal >waitL.out 2>&1 &&
         grep simtest-reattach-exit-signal waitL.out | grep exited | grep status=15
 '
 


### PR DESCRIPTION
Problem: t2410-exec-systemd.t fails with dash 0.5.10

Replace ">& filename" idiom with ">filename 2>&1".

Fixes #4114