### PR TITLE
doc: update flux-broker-attributes(7)

### DIFF
--- a/doc/man5/flux-config-tbon.rst
+++ b/doc/man5/flux-config-tbon.rst
@@ -64,8 +64,8 @@ EXAMPLE
 ::
 
    [tbon]
-   torpid_min = 10s
-   torpid_max = 1m
+   torpid_min = "10s"
+   torpid_max = "1m"
 
    keepalive_count = 12
    keepalive_interval = 10

--- a/doc/man7/flux-broker-attributes.rst
+++ b/doc/man7/flux-broker-attributes.rst
@@ -173,29 +173,12 @@ log-level
 CONTENT ATTRIBUTES
 ==================
 
-content.acct-dirty
-   The number of dirty cache entries on this rank.
-
-content.acct-entries
-   The total number of cache entries on this rank.
-
-content.acct-size
-   The estimated total size in bytes consumed by cache entries on
-   this rank, excluding overhead.
-
-content.acct-valid
-   The number of valid cache entries on this rank.
-
 content.backing-module
    The selected backing store module, if any. This attribute is only
    set on rank 0 where the content backing store is active.
 
 content.blob-size-limit
    The maximum size of a blob, the basic unit of content storage.
-
-content.flush-batch-count
-   The current number of outstanding store requests, either to the
-   backing store (rank 0) or upstream (rank > 0).
 
 content.flush-batch-limit
    The maximum number of outstanding store requests that will be

--- a/doc/man7/flux-broker-attributes.rst
+++ b/doc/man7/flux-broker-attributes.rst
@@ -283,8 +283,11 @@ RESOURCES
 Flux: http://flux-framework.org
 
 RFC 13: Simple Process Manager Interface v1: https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/spec_13.html
+
 RFC 22: Idset String Representation: https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/spec_22.html
+
 RFC 23: Flux Standard Duration: https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/spec_23.html
+
 RFC 29: Hostlist Format: https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/spec_29.html
 
 

--- a/doc/man7/flux-broker-attributes.rst
+++ b/doc/man7/flux-broker-attributes.rst
@@ -205,4 +205,4 @@ RFC 29: Hostlist Format: https://flux-framework.readthedocs.io/projects/flux-rfc
 SEE ALSO
 ========
 
-:man1:`flux-getattr`, :man3:`flux_attr_get`
+:man1:`flux-broker`, :man1:`flux-getattr`, :man3:`flux_attr_get`

--- a/doc/man7/flux-broker-attributes.rst
+++ b/doc/man7/flux-broker-attributes.rst
@@ -123,8 +123,7 @@ SOCKET ATTRIBUTES
 
 local-uri
    The Flux URI that should be passed to :man3:`flux_open` to
-   establish a connection to the local broker rank. By default,
-   local-uri is created as "local://<broker.rank>/local".
+   establish a connection to the local broker rank.
 
 parent-uri
    The Flux URI that should be passed to :man3:`flux_open` to

--- a/doc/man7/flux-broker-attributes.rst
+++ b/doc/man7/flux-broker-attributes.rst
@@ -7,11 +7,17 @@ DESCRIPTION
 ===========
 
 Flux broker attributes are broker parameters with a scope of a single broker
-rank, that may be set on the :man1:`flux-broker` command line using
-`--setattr=NAME=VALUE`, or manipulated on a running system with
-:man1:`flux-getattr`, :man1:`flux-setattr`, and :man1:`flux-lsattr`.
+rank.  They may be listed with :man1:`flux-lsattr` and queried with
+:man1:`flux-getattr`.
 
-The broker currently exports the following attributes:
+Attributes should be considered read-only, unless annotated below with:
+
+C
+   The attribute may be set on the :man1:`flux-broker` command line with
+   ``--setattr=NAME=VALUE``.
+
+R
+   The attribute may be updated on a running broker with :man1:`flux-setattr`.
 
 
 GENERAL
@@ -23,7 +29,10 @@ rank
 size
    The number of broker ranks in the flux instance
 
-rundir
+version
+   The version of flux-core that was used to build this broker.
+
+rundir [Updates: C]
    A temporary directory where UNIX domain sockets and the default
    content.backing-path are located (see below).  By default, each broker
    rank creates a unique rundir in $TMPDIR and removes it on exit.  If
@@ -34,26 +43,98 @@ rundir
    directory, it is removed.  In most cases this attribute should not
    be set by users.
 
-local-uri
-   The Flux URI that should be passed to :man3:`flux_open` to
-   establish a connection to the local broker rank.
+security.owner
+   The numeric userid of the owner of this Flux instance.
+
+local-uri [Updates: C]
+   The Flux URI that the local connector binds to for accepting connections
+   from local Flux clients.  The name must begin with ``local://``
+   and the path must refer to a :linux:man7:`unix` domain socket in an
+   existing directory.
 
 parent-uri
-   The Flux URI that should be passed to :man3:`flux_open` to
-   establish a connection to the enclosing instance.
+   The value of the broker's ``FLUX_URI`` environment variable.  This is the
+   URI that should be passed to :man3:`flux_open` to establish a connection to
+   the enclosing instance.
+
+instance-level
+   The nesting level of this Flux instance, or ``0`` if there is no enclosing
+   Flux instance.
+
+jobid
+   The Flux job ID of this Flux instance, if it was launched by Flux as a job.
+   The value is obtained from ``PMI_KVS_Get_my_name()`` which may be something
+   other than a Flux job ID if Flux was started by another means.
+
+parent-kvs-namespace
+   The value of the broker's ``FLUX_KVS_NAMESPACE`` environment variable.
+   This is the KVS namespace assigned to this Flux instance by its enclosing
+   instance, if it was launched by Flux as a job.
 
 hostlist
-   An RFC 29 hostlist in broker rank order.
+   An RFC 29 hostlist in broker rank order.  This value may be used to
+   translate between broker ranks and hostnames.
+
+broker.mapping
+   A string representing the process mapping of broker ranks in the Argonne
+   format described in RFC 13.  For example, ``(vector,(0,16,1))`` means
+   the instance has one broker per node on 16 nodes, and ``(vector,(0,1,16))``
+   means it has 16 brokers on one node.
+
+broker.pid
+   The process id of the local broker.
+
+broker.quorum [Updates: C]
+   An RFC 22 idset representing broker ranks that are required to be online
+   before the rank 0 broker enters the RUN state and starts the initial
+   program, if any.  Default: all ranks.
+
+broker.quorum-timeout [Updates: C]
+   The amount of time (in RFC 23 Flux Standard Duration format) that the
+   rank 0 broker waits for the ``broker.quorum`` set to come online before
+   aborting the Flux instance.   Default: ``60s``.
+
+broker.rc1_path [Updates: C]
+   The path to the broker's rc1 script.  Default: ``${prefix}/etc/flux/rc1``.
+
+broker.rc3_path [Updates: C]
+   The path to the broker's rc3 script.  Default: ``${prefix}/etc/flux/rc1``.
 
 broker.starttime
    Timestamp of broker startup from :man3:`flux_reactor_now`.
+
+conf.connector_path
+   The value of the broker's ``FLUX_CONNECTOR_PATH`` environment variable.
+
+conf.exec_path
+   The value of the broker's ``FLUX_EXEC_PATH`` environment variable.
+
+conf.module_path
+   The value of the broker's ``FLUX_MODULE_PATH`` environment variable.
+
+conf.pmi_library_path
+   The value of the broker's ``FLUX_PMI_LIBRARY_PATH`` environment variable.
+
+conf.shell_initrc [Updates: C, R]
+   The path to the :man1:`flux-shell` initrc script.  Default:
+   ``${prefix}/etc/flux/shell/initrc.lua``.
+
+conf.shell_pluginpath [Updates: C, R]
+   The list of colon-separated directories to be searched by :man1:`flux-shell`
+   for shell plugins.  Default: ``${prefix}/lib/flux/shell/plugins``.
+
+config.path [Updates: see below]
+   A directory containing ``*.toml`` config files for this Flux instance.
+   This attribute may be set via the FLUX_CONF_DIR environment variable,
+   or the :man1:`flux-broker` ``--config-path`` command line argument.
+   Default: none.  See also :man5:`flux-config`.
 
 
 TREE BASED OVERLAY NETWORK
 ==========================
 
-tbon.fanout
-   Branching factor of the tree based overlay network.
+tbon.fanout [Updates: C]
+   Branching factor of the tree based overlay network.  Default: ``2``.
 
 tbon.descendants
    Number of descendants "below" this node of the tree based
@@ -70,29 +151,27 @@ tbon.maxlevel
 tbon.parent-endpoint
    The ZeroMQ endpoint of this broker's TBON parent.
 
-tbon.zmqdebug
+tbon.zmqdebug [Updates: C]
    If set to an non-zero integer value, 0MQ socket event logging is enabled,
    if available.  This is potentially useful for debugging overlay
-   connectivity problems.  The attribute may not be changed during runtime.
+   connectivity problems.  Default: ``0``.
 
-tbon.prefertcp
+tbon.prefertcp [Updates: C]
    If set to an integer value other than zero, and the broker is bootstrapping
    with PMI, tcp:// endpoints will be used instead of ipc://, even if all
-   brokers are on a single node.
+   brokers are on a single node.  Default: ``0``.
 
-tbon.torpid_min
+tbon.torpid_min [Updates: C, R]
    The amount of time (in RFC 23 Flux Standard Duration format) that a broker
    will allow the connection to its TBON parent to remain idle before sending a
-   control message to indicate create activity.  This value may be adjusted
-   on a live system.
+   control message to indicate create activity.  Default: ``5s``.
 
-tbon.torpid_max
+tbon.torpid_max [Updates: C, R]
    The amount of time (in RFC 23 Flux Standard Duration format) that a broker
    will wait for an idle TBON child connection to send messages before
    declaring it torpid (unresponsive).  A value of 0 disables torpid node
    checking.  Torpid nodes are automatically drained and require manual
-   undraining with :man1:`flux-resource`.  This value may be adjusted on a
-   live system.
+   undraining with :man1:`flux-resource`.  Default: ``30s``.
 
 tbon.keepalive_enable
    An integer value to disable (0) or enable (1) TCP keepalives on TBON
@@ -125,71 +204,77 @@ LOGGING
 log-ring-used
    The number of log entries currently stored in the ring buffer.
 
-log-ring-size
+log-ring-size [Updates: C, R]
    The maximum number of log entries that can be stored in the ring buffer.
+   Default: ``1024``.
 
 log-count
    The number of log entries ever stored in the ring buffer.
 
-log-forward-level
+log-forward-level [Updates: C, R]
    Log entries at :linux:man3:`syslog` level at or below this value
-   are forwarded to rank zero for permanent capture.
+   are forwarded to rank zero for permanent capture.  Default ``7``
+   (LOG_DEBUG).
 
-log-critical-level
+log-critical-level [Updates: C, R]
    Log entries at :linux:man3:`syslog` level at or below this value
    are copied to stderr on the logging rank, for capture by the
-   enclosing instance.
+   enclosing instance.  Default ``2`` (LOG_CRIT).
 
-log-filename
-   (rank zero only) If set, session log entries, as filtered by log-forward-level,
-   are directed to this file.
+log-filename [Updates: C, R]
+   (rank zero only) If set, session log entries, as filtered by
+   ``log-forward-level``, are directed to this file.  Default: none.
 
-log-stderr-mode
+log-stderr-mode [Updates: C, R]
    If set to "leader" (default), broker rank 0 emits forwarded logs from
    other ranks to stderr, subject to the constraints of log-forward-level
    and log-stderr-level.  If set to "local", each broker emits its own
    logs to stderr, subject to the constraints of log-stderr-level.
+   Default: ``leader``.
 
-log-stderr-level
+log-stderr-level (Updates: C, R)
    Log entries at :linux:man3:`syslog` level at or below this value to
-   stderr, subject to log-stderr-mode.
+   stderr, subject to log-stderr-mode.  Default: ``3`` (LOG_ERR).
 
-log-level
+log-level (Updates: C, R)
    Log entries at :linux:man3:`syslog` level at or below this value
-   are stored in the ring buffer.
+   are stored in the ring buffer.  Default: ``7`` (LOG_DEBUG).
 
 
 CONTENT
 =======
 
-content.backing-module
-   The selected backing store module, if any. This attribute is only
-   set on rank 0 where the content backing store is active.
+content.backing-module (Updates: C)
+   The selected backing store module, if any. This attribute is only set
+   on rank 0 where the content backing store is active.  Default:
+   ``content-sqlite``.
 
-content.backing-path
+content.backing-path (Updates: C)
    The path to the content backing store file(s). If this is set on the
    broker command line, the backing store uses this path instead of
    a temporary one, and content is preserved on instance exit.
    If file exists, its content is imported into the instance.
-   If it doesn't exist, it is created.
+   If it doesn't exist, it is created.  Default: ``content.sqlite``
+   located within ``rundir``.
 
-content.blob-size-limit
+content.blob-size-limit (Updates: C, R)
    The maximum size of a blob, the basic unit of content storage.
+   Default: ``1073741824``.
 
-content.flush-batch-limit
-   The maximum number of outstanding store requests that will be
-   initiated when handling a flush or backing store load operation.
+content.flush-batch-limit (Updates: C, R)
+   The maximum number of outstanding store requests that will be initiated
+   when handling a flush or backing store load operation.  Default: ``256``.
 
-content.hash
-   The selected hash algorithm, default sha1.
+content.hash (Updates: C)
+   The selected hash algorithm.  Default ``sha1``.  Other options: ``sha256``.
 
-content.purge-old-entry
-   When the cache size footprint needs to be reduced, only consider
-   purging entries that are older than this number of seconds.
+content.purge-old-entry (Updates: C, R)
+   When the cache size footprint needs to be reduced, only consider purging
+   entries that are older than this number of seconds.  Default:  ``10``.
 
-content.purge-target-size
-   If possible, the cache size purged periodically so that the total
-   size of the cache stays at or below this value.
+content.purge-target-size (Updates: C, R)
+   If possible, the cache size purged periodically so that the total size of
+   the cache stays at or below this value, in bytes.  Default: ``16777216``.
 
 
 RESOURCES
@@ -197,8 +282,9 @@ RESOURCES
 
 Flux: http://flux-framework.org
 
+RFC 13: Simple Process Manager Interface v1: https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/spec_13.html
+RFC 22: Idset String Representation: https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/spec_22.html
 RFC 23: Flux Standard Duration: https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/spec_23.html
-
 RFC 29: Hostlist Format: https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/spec_29.html
 
 

--- a/doc/man7/flux-broker-attributes.rst
+++ b/doc/man7/flux-broker-attributes.rst
@@ -6,16 +6,16 @@ flux-broker-attributes(7)
 DESCRIPTION
 ===========
 
-Flux broker attributes are parameters that affect how different
-broker systems behave. Attributes can be listed and manipulated
-with :man1:`flux-getattr`, :man1:`flux-setattr`, and
-:man1:`flux-lsattr`.
+Flux broker attributes are broker parameters with a scope of a single broker
+rank, that may be set on the :man1:`flux-broker` command line using
+`--setattr=NAME=VALUE`, or manipulated on a running system with
+:man1:`flux-getattr`, :man1:`flux-setattr`, and :man1:`flux-lsattr`.
 
 The broker currently exports the following attributes:
 
 
-SESSION ATTRIBUTES
-==================
+GENERAL
+=======
 
 rank
    The rank of the local broker.
@@ -34,12 +34,13 @@ rundir
    directory, it is removed.  In most cases this attribute should not
    be set by users.
 
-content.backing-path
-   The path to the content backing store file(s). If this is set on the
-   broker command line, the backing store uses this path instead of
-   a temporary one, and content is preserved on instance exit.
-   If file exists, its content is imported into the instance.
-   If it doesn't exist, it is created.
+local-uri
+   The Flux URI that should be passed to :man3:`flux_open` to
+   establish a connection to the local broker rank.
+
+parent-uri
+   The Flux URI that should be passed to :man3:`flux_open` to
+   establish a connection to the enclosing instance.
 
 hostlist
    An RFC 29 hostlist in broker rank order.
@@ -48,8 +49,8 @@ broker.starttime
    Timestamp of broker startup from :man3:`flux_reactor_now`.
 
 
-TOPOLOGY ATTRIBUTES
-===================
+TREE BASED OVERLAY NETWORK
+==========================
 
 tbon.fanout
    Branching factor of the tree based overlay network.
@@ -118,20 +119,8 @@ tbon.keepalive_interval
    :man5:`flux-config-tbon`.
 
 
-SOCKET ATTRIBUTES
-=================
-
-local-uri
-   The Flux URI that should be passed to :man3:`flux_open` to
-   establish a connection to the local broker rank.
-
-parent-uri
-   The Flux URI that should be passed to :man3:`flux_open` to
-   establish a connection to the enclosing instance.
-
-
-LOGGING ATTRIBUTES
-==================
+LOGGING
+=======
 
 log-ring-used
    The number of log entries currently stored in the ring buffer.
@@ -170,12 +159,19 @@ log-level
    are stored in the ring buffer.
 
 
-CONTENT ATTRIBUTES
-==================
+CONTENT
+=======
 
 content.backing-module
    The selected backing store module, if any. This attribute is only
    set on rank 0 where the content backing store is active.
+
+content.backing-path
+   The path to the content backing store file(s). If this is set on the
+   broker command line, the backing store uses this path instead of
+   a temporary one, and content is preserved on instance exit.
+   If file exists, its content is imported into the instance.
+   If it doesn't exist, it is created.
 
 content.blob-size-limit
    The maximum size of a blob, the basic unit of content storage.

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -600,3 +600,4 @@ prefertcp
 desynchronized
 multi
 sysctl
+pluginpath


### PR DESCRIPTION
This adds missing broker attributes to flux-broker-attributes(7) and reorganizes its sections.

Also there's a fix for an error in flux-config-tbon(5).