### PR TITLE
resource: enhance resource.drain RPC with "update" and "overwrite" modes

### DIFF
--- a/doc/man1/flux-resource.rst
+++ b/doc/man1/flux-resource.rst
@@ -59,11 +59,20 @@ COMMANDS
    *-s,--states=STATE,...* limits output to specified resource states, where
    valid states are "online", "offline", "avail", "exclude", "drain", and "all".
 
-**drain** [targets] [reason ...]
+**drain** [-f] [-u] [targets] [reason ...]
    If specified without arguments, list drained nodes.  The *targets* argument
    is an IDSET or HOSTLIST specifying nodes to drain.  Any remaining arguments
-   are assumed to be a reason to be recorded with the drain event.  This
-   command, when run with arguments, is restricted to the Flux instance owner.
+   are assumed to be a reason to be recorded with the drain event.
+
+   By default, **flux resource drain** will fail if any of the *targets*
+   are already drained. To change this behavior, use either of the
+   *-f, --force* or *-u, --update* options. With *--force*, the *reason* for
+   all existing drained targets is overwritten, while with *--update*,
+   only those ranks that are not already drained or do not have a *reason* set
+   have their *reason* updated.
+
+   This command, when run with arguments, is restricted to the Flux instance
+   owner.
 
 **undrain** targets
    The *targets* argument is an IDSET or HOSTLIST specifying nodes to undrain.

--- a/src/cmd/flux-perilog-run.py
+++ b/src/cmd/flux-perilog-run.py
@@ -36,7 +36,7 @@ def drain(handle, ids, reason):
 
     handle.rpc(
         "resource.drain",
-        {"targets": str(ids), "reason": reason},
+        {"targets": str(ids), "reason": reason, "mode": "update"},
         nodeid=0,
     )
 

--- a/src/cmd/flux-resource.py
+++ b/src/cmd/flux-resource.py
@@ -42,11 +42,15 @@ def drain(args):
     if args.targets is None:
         drain_list()
         return
-
+    payload = {
+        "targets": args.targets,
+    }
+    if args.reason:
+        payload["reason"] = " ".join(args.reason)
     RPC(
         flux.Flux(),
         "resource.drain",
-        {"targets": args.targets, "reason": " ".join(args.reason)},
+        payload,
         nodeid=0,
     ).get()
 

--- a/src/cmd/flux-resource.py
+++ b/src/cmd/flux-resource.py
@@ -45,6 +45,13 @@ def drain(args):
     payload = {
         "targets": args.targets,
     }
+    if args.update and args.force:
+        LOGGER.error("Only one of --force and --update may be specified")
+        sys.exit(1)
+    if args.update:
+        payload["mode"] = "update"
+    elif args.force:
+        payload["mode"] = "overwrite"
     if args.reason:
         payload["reason"] = " ".join(args.reason)
     RPC(
@@ -344,6 +351,19 @@ def main():
 
     drain_parser = subparsers.add_parser(
         "drain", formatter_class=flux.util.help_formatter()
+    )
+    drain_parser.add_argument(
+        "-f",
+        "--force",
+        action="store_true",
+        help="Force overwrite of existing drain reason",
+    )
+    drain_parser.add_argument(
+        "-u",
+        "--update",
+        action="store_true",
+        help="Update only. Do not return an error if one or more targets "
+        + "are already drained. Do not overwrite any existing drain reason.",
     )
     drain_parser.add_argument(
         "targets", nargs="?", help="List of targets to drain (IDSET or HOSTLIST)"

--- a/src/modules/resource/drain.c
+++ b/src/modules/resource/drain.c
@@ -96,8 +96,10 @@ static int update_draininfo_rank (struct drain *drain,
 
     free (drain->info[rank].reason);
     drain->info[rank].reason = cpy;
-    drain->info[rank].drained = drained;
-    drain->info[rank].timestamp = timestamp;
+    if (drain->info[rank].drained != drained) {
+        drain->info[rank].drained = drained;
+        drain->info[rank].timestamp = timestamp;
+    }
     return 0;
 }
 

--- a/src/modules/resource/drain.c
+++ b/src/modules/resource/drain.c
@@ -483,9 +483,10 @@ static int replay_eventlog (struct drain *drain, const json_t *eventlog)
             else if (!strcmp (name, "drain")) {
                 int overwrite = 1;
                 if (json_unpack (context,
-                                 "{s:s s?s}",
+                                 "{s:s s?s s?i}",
                                  "idset", &s,
-                                 "reason", &reason) < 0) {
+                                 "reason", &reason,
+                                 "overwrite", &overwrite) < 0) {
                     errno = EPROTO;
                     return -1;
                 }

--- a/src/modules/resource/drain.c
+++ b/src/modules/resource/drain.c
@@ -307,12 +307,10 @@ int drain_rank (struct drain *drain, uint32_t rank, const char *reason)
     char rankstr[16];
     double timestamp;
 
-    if (rank >= drain->ctx->size) {
+    if (rank >= drain->ctx->size || !reason) {
         errno = EINVAL;
         return -1;
     }
-    if (!reason)
-        reason = "unknown";
     if (get_timestamp_now (&timestamp) < 0)
         return -1;
     if (update_draininfo_rank (drain, rank, true, timestamp, reason) < 0)

--- a/src/modules/resource/drain.c
+++ b/src/modules/resource/drain.c
@@ -431,7 +431,7 @@ int drain_rank (struct drain *drain, uint32_t rank, const char *reason)
     }
     if (get_timestamp_now (&timestamp) < 0)
         return -1;
-    if (update_draininfo_rank (drain, rank, true, timestamp, reason, 1) < 0)
+    if (update_draininfo_rank (drain, rank, true, timestamp, reason, 0) < 0)
         return -1;
     snprintf (rankstr, sizeof (rankstr), "%ju", (uintmax_t)rank);
     if (reslog_post_pack (drain->ctx->reslog,

--- a/src/modules/resource/drain.c
+++ b/src/modules/resource/drain.c
@@ -297,7 +297,7 @@ static void drain_cb (flux_t *h,
     return;
 error:
     if (flux_respond_error (h, msg, errno, errstr) < 0)
-        flux_log_error (h, "error responding to undrain request");
+        flux_log_error (h, "error responding to drain request");
     free (idstr);
     idset_destroy (idset);
 }

--- a/src/modules/resource/drain.c
+++ b/src/modules/resource/drain.c
@@ -459,11 +459,9 @@ static int replay_eventlog (struct drain *drain, const json_t *eventlog)
             }
             else if (!strcmp (name, "drain")) {
                 if (json_unpack (context,
-                                 "{s:s s:s}",
-                                 "idset",
-                                 &s,
-                                 "reason",
-                                 &reason) < 0) {
+                                 "{s:s s?s}",
+                                 "idset", &s,
+                                 "reason", &reason) < 0) {
                     errno = EPROTO;
                     return -1;
                 }

--- a/src/modules/resource/topo.c
+++ b/src/modules/resource/topo.c
@@ -70,11 +70,10 @@ static int drain_self (struct topo *topo, const char *reason)
                                  "resource.drain",
                                  0,
                                  0,
-                                 "{s:s s:s}",
-                                 "targets",
-                                 rankstr,
-                                 "reason",
-                                 reason)))
+                                 "{s:s s:s s:s}",
+                                 "targets", rankstr,
+                                 "reason", reason,
+                                 "mode", "update")))
             return -1;
         if (flux_rpc_get (f, NULL) < 0) {
             flux_future_destroy (f);

--- a/t/t2311-resource-drain.t
+++ b/t/t2311-resource-drain.t
@@ -44,16 +44,6 @@ test_expect_success 'resource.eventlog has two drain events' '
 	test $(has_resource_event drain | wc -l) -eq 2
 '
 
-test_expect_success 'reason can be updated after node is drained' '
-	flux resource drain 1 test_reason_01 &&
-	test $(flux resource list -n -s down -o {nnodes}) -eq 1 &&
-	test $(flux resource status -s drain -no {reason}) = "test_reason_01"
-'
-
-test_expect_success 'resource.eventlog has three drain events' '
-	test $(has_resource_event drain | wc -l) -eq 3
-'
-
 test_expect_success 'drain works with idset' '
 	flux resource drain 2-3 &&
 	test $(flux resource list -n -s down -o {nnodes}) -eq 3 &&


### PR DESCRIPTION
This PR introduces some changes in behavior for the `resource.drain` RPC, reflected in a change in the default behavior of `flux resource drain` along with some additional options:

 * By default, a `resource.drain` RPC now fails if any targets are already drained. This matches the behavior of `flux resource undrain` and also avoids overwriting existing drain `reasons` without positive verification that you really mean it.
 * An optional `mode` member of the RPC request is introduced to change the default drain mode to either:
   - mode=`update`: The RPC does not fail if one or more targets are already drained, and does not overwrite existing `reason` for any drained target (it will, however, update a `reason` that is not set)
   - mode=`overwrite`: The RPC does not fail if one or more targets are already drained. All `reason` fields are overwritten
   - `flux resource drain` gets two new options `--force` (overwrite) and `--update` to optionally select one of these two modes.
  * The drain `timestamp` is only updated when the drain state changes. Thus the timestamp indicates when a node was drained, not when its reason field was last updated. (That timestamp can be obtained from the resource eventlog)
  * internally, the `resource` module uses "update" mode when draining ranks due to a resource topology issue such as missing resources. This preserves a reason possibly set by the instance owner/admin. The drain events due to topo errors can still be seen in the resource eventlog.
  * Internally, `reason=NULL` is now considered "unset". Places where `NULL` was replaced with `unknown` have been removed. An unset `reason` can be updated - it doesn't require `overwrite` mode.

Finally, the `flux perilog-run` command is switched to `update` mode so that valid `reason` fields are not overwritten when a rank is drained due to a failed prolog/epilog.

This PR might have some controversial choices, especially in how `NULL` reason is treated.  I was balancing most convenient with least surprising, and just decided to go with it. 

Fixes #4111