### PR TITLE
shell: capture job shell error messages in designated output file

### DIFF
--- a/src/shell/output.c
+++ b/src/shell/output.c
@@ -184,7 +184,7 @@ static int shell_output_redirect_stream (struct shell_output *out,
                                          const char *stream,
                                          const char *path)
 {
-    struct idset *idset;
+    struct idset *idset = NULL;
     json_t *entry = NULL;
     char *entrystr = NULL;
     int saved_errno, rc = -1;
@@ -236,6 +236,7 @@ error:
     json_decref (entry);
     free (entrystr);
     free (rankptr);
+    idset_destroy (idset);
     errno = saved_errno;
     return rc;
 }

--- a/t/t2606-job-shell-output-redirection.t
+++ b/t/t2606-job-shell-output-redirection.t
@@ -326,4 +326,12 @@ test_expect_success NO_CHAIN_LINT 'job-shell: job attach waits if no kvs output 
         flux job cancel $id &&
         ! wait $pid
 '
+test_expect_success 'job-shell: shell errors are captured in output file' '
+	test_expect_code 127 flux mini run --output=test.out nosuchcommand &&
+	grep "nosuchcommand: No such file or directory" test.out
+'
+test_expect_success 'job-shell: shell errors are captured in error file' '
+	test_expect_code 127  flux mini run --error=test.err nosuchcommand &&
+	grep "nosuchcommand: No such file or directory" test.err
+'
 test_done


### PR DESCRIPTION
This PR is a stopgap fix for #4117. 

When an output or error file is specified, re-route log messages to the same output file as stderr, instead of sending them to the output eventlog.

Since the output files aren't opened until after the shell has connected to Flux and initialized, some log messages and errors still end up in the output eventlog, e.g. if something goes wrong before shell.init, but at least there isn't likely to be an _empty_ output file when a job fails after it gets that far, so the spirit of the issue is resolved.

Eventually, perhaps a better fix would be to have the exec system read the output and error options from the jobspec and, if the output type is `file`, pass this along in new `--output` and `--error` options to the job shell. This would allow the job shell to open output file immediately, and even the earliest of errors could be captured. However, I'm not sure at this point if that is the "right" fix.

before:
```console
$ id=$(flux mini submit --wait --output=example.out nosuchcommand) && flux job status $id; ls -l example.out; cat example.out
ƒJSBRFaBzRm: exception: type=exec note=task 0: start failed: nosuchcommand: No such file or directory
-rw-r--r-- 1 grondo grondo 0 Feb 11 07:43 example.out
``` 

after:
```console
$ id=$(flux mini submit --wait --output=example.out nosuchcommand) && flux job status $id; ls -l example.out; cat example.out
ƒ2uW3UFh: exception: type=exec note=task 0: start failed: nosuchcommand: No such file or directory
-rw-r--r-- 1 grondo grondo 85 Feb 11 07:44 example.out
flux-shell[0]: FATAL: task 0: start failed: nosuchcommand: No such file or directory
```