### PR TITLE
resource: emit a more specific error when rlist_rerank() fails

### DIFF
--- a/src/broker/module.c
+++ b/src/broker/module.c
@@ -184,7 +184,7 @@ static void *module_thread (void *arg)
         mod_main_errno = errno;
         if (mod_main_errno == 0)
             mod_main_errno = ECONNRESET;
-        flux_log (p->h, LOG_CRIT, "fatal error: %s", strerror (errno));
+        flux_log (p->h, LOG_CRIT, "module exiting abnormally");
     }
 
     /* Before processing unhandled requests, ensure that this module

--- a/src/cmd/flux-R.c
+++ b/src/cmd/flux-R.c
@@ -562,7 +562,7 @@ int cmd_rerank (optparse_t *p, int argc, char **argv)
         log_err_exit ("Failed to transform R objects on stdin");
     if (argc != 2)
         log_err_exit ("Must provide a hostlist for re-ranking");
-    if (rlist_rerank (rl, argv[1]) < 0) {
+    if (rlist_rerank (rl, argv[1], NULL) < 0) {
         if (errno == ENOENT)
             log_msg_exit ("failed to find one or more provided hosts in R");
         else if (errno == EOVERFLOW)

--- a/src/common/librlist/rlist.h
+++ b/src/common/librlist/rlist.h
@@ -90,7 +90,7 @@ int rlist_assign_hosts (struct rlist *rl, const char *hosts);
  *   ENOENT:    a hostname in 'hosts' was not found in 'rl'
  *   ENOMEM:    out of memory
  */
-int rlist_rerank (struct rlist *rl, const char *hosts);
+int rlist_rerank (struct rlist *rl, const char *hosts, rlist_error_t *error);
 
 /*  Destroy an rlist object */
 void rlist_destroy (struct rlist *rl);

--- a/src/common/librlist/test/rlist.c
+++ b/src/common/librlist/test/rlist.c
@@ -930,7 +930,7 @@ void test_assign_hosts ()
             "reassign hosts to %s worked", hosts);
 
         free (hosts);
-        
+
         hostlist_destroy (hl);
         rlist_destroy (rl);
         free (R);
@@ -958,7 +958,7 @@ void test_rerank ()
         "rlist_rerank with too many hosts returns EOVERFLOW");
     ok (rlist_rerank (rl, "foo[1-16]") < 0 && errno == ENOENT,
         "rlist_rerank with invalid host returns ENOENT");
-    
+
     if (!(hl = rlist_nodelist (rl)) || !(s = hostlist_encode (hl)))
         BAIL_OUT ("rlist_nodelist/hostlist_encode failed!");
     is (s, "foo[0-15]",

--- a/src/common/librlist/test/rlist.c
+++ b/src/common/librlist/test/rlist.c
@@ -946,18 +946,29 @@ void test_rerank ()
     struct hostlist *hl = NULL;
     char *s = NULL;
     struct rlist *rl = NULL;
+    rlist_error_t err;
     char *R = R_create ("0-15", "0-3", NULL, "foo[0-15]");
     if (!R)
         BAIL_OUT ("R_create failed");
     if (!(rl = rlist_from_R (R)))
         BAIL_OUT ("rlist_from_R failed");
 
-    ok (rlist_rerank (rl, "foo[1-15]") < 0 && errno == ENOSPC,
+    ok (rlist_rerank (rl, "foo[1-15]", &err) < 0 && errno == ENOSPC,
         "rlist_rerank with too few hosts returns ENOSPC");
-    ok (rlist_rerank (rl, "foo[0-16]") < 0 && errno == EOVERFLOW,
+    is (err.text, "Number of hosts (15) is less than node count (16)",
+        "rlist_rerank error message is expected");
+    ok (rlist_rerank (rl, "foo[0-16]", &err) < 0 && errno == EOVERFLOW,
         "rlist_rerank with too many hosts returns EOVERFLOW");
-    ok (rlist_rerank (rl, "foo[1-16]") < 0 && errno == ENOENT,
+    is (err.text, "Number of hosts (17) is greater than node count (16)",
+        "rlist_rerank error message is expected");
+    ok (rlist_rerank (rl, "foo[1-16]", &err) < 0 && errno == ENOENT,
         "rlist_rerank with invalid host returns ENOENT");
+    is (err.text, "Host foo16 not found in resources",
+        "rlist_rerank error message is expected");
+    ok (rlist_rerank (rl, "foo[0-", &err) < 0 && errno == EINVAL,
+        "rlist_rerank fails with invalid hostlist");
+    is (err.text, "hostlist_decode: foo[0-: Invalid argument",
+        "rlist_rerank error message is expected");
 
     if (!(hl = rlist_nodelist (rl)) || !(s = hostlist_encode (hl)))
         BAIL_OUT ("rlist_nodelist/hostlist_encode failed!");
@@ -967,7 +978,7 @@ void test_rerank ()
     hostlist_destroy (hl);
 
     /* Swap rank 0 to rank 15 */
-    ok (rlist_rerank (rl, "foo[1-15,0]") == 0,
+    ok (rlist_rerank (rl, "foo[1-15,0]", NULL) == 0,
         "rlist_rerank works");
 
     if (!(hl = rlist_nodelist (rl)) || !(s = hostlist_encode (hl)))

--- a/src/modules/resource/inventory.c
+++ b/src/modules/resource/inventory.c
@@ -345,6 +345,7 @@ static int convert_R_conf (flux_t *h, json_t *conf_R, json_t **Rp)
 {
     json_error_t e;
     struct rlist *rl;
+    rlist_error_t err;
     json_t *R;
     const char *hosts;
 
@@ -353,10 +354,11 @@ static int convert_R_conf (flux_t *h, json_t *conf_R, json_t **Rp)
         errno = EINVAL;
         return -1;
     }
+    err.text[0] = '\0';
     if (conf_has_bootstrap (h)) {
         if (!(hosts = flux_attr_get (h, "hostlist"))
-            || rlist_rerank (rl, hosts) < 0) { // sets errno
-            flux_log (h, LOG_ERR, "error reranking R");
+            || rlist_rerank (rl, hosts, &err) < 0) { // sets errno
+            flux_log (h, LOG_ERR, "error reranking R: %s", err.text);
             goto error;
         }
     }

--- a/src/modules/resource/inventory.c
+++ b/src/modules/resource/inventory.c
@@ -354,11 +354,22 @@ static int convert_R_conf (flux_t *h, json_t *conf_R, json_t **Rp)
         errno = EINVAL;
         return -1;
     }
-    err.text[0] = '\0';
     if (conf_has_bootstrap (h)) {
-        if (!(hosts = flux_attr_get (h, "hostlist"))
-            || rlist_rerank (rl, hosts, &err) < 0) { // sets errno
+        if (!(hosts = flux_attr_get (h, "hostlist"))) {
+            flux_log_error (h, "Unable to get hostlist attribute");
+            goto error;
+        }
+        err.text[0] = '\0';
+        if (rlist_rerank (rl, hosts, &err) < 0) {
             flux_log (h, LOG_ERR, "error reranking R: %s", err.text);
+            /*
+             *  rlist_rerank() repurposes errno like EOVERFLOW and ENOSPC,
+             *   but this may cause confusion when logging an error
+             *   return from this function. Since the specific error has
+             *   already been printed, reset errno to EINVAL so that
+             *   the calling function simply prints "Invalid argument".
+             */
+            errno = EINVAL;
             goto error;
         }
     }


### PR DESCRIPTION
This PR adds an `rlist_error_t` parameter to `rlist_rerank()` which offers a more specific error when the rerank operation fails.

The parameter is then used in the `resource` module to print a specific error along with the general `error reranking R`.

Finally, to avoid the confusing error message when the `resource` module exits due to `rlist_rerank`'s use of `errno` like `ENOSPC` and `EOVERFLOW`, reset `errno` to `EINVAL` when `rlist_rerank()` fails.