### PR TITLE
broker: allow tbon.zmqdebug to be set in config file and make sure it's really off if set to 0

### DIFF
--- a/doc/man5/flux-config-tbon.rst
+++ b/doc/man5/flux-config-tbon.rst
@@ -40,6 +40,11 @@ tcp_user_timeout
    broker attribute.  See also: :linux:man7:`tcp`, TCP_USER_TIMEOUT socket
    option.
 
+zmqdebug
+   (optional) Integer value indicating whether ZeroMQ socket debug logging
+   should be enabled: 0=disabled, 1=enabled.  Default: ``0``.  This configured
+   value may be overridden by setting the ``tbon.zmqdebug`` broker attribute.
+
 
 EXAMPLE
 =======

--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -1276,7 +1276,7 @@ int overlay_bind (struct overlay *ov, const char *uri)
     /* The socket monitor is only used for logging.
      * Setup may fail if libzmq is too old.
      */
-    if (attr_get (ov->attrs, "tbon.zmqdebug", NULL, NULL) == 0) {
+    if (ov->zmqdebug) {
         ov->bind_monitor = zmqutil_monitor_create (ov->bind_zsock,
                                                    ov->reactor,
                                                    bind_monitor_cb,

--- a/t/t0013-config-file.t
+++ b/t/t0013-config-file.t
@@ -286,4 +286,33 @@ test_expect_success NOMAXRT 'tbon.tcp_user_timeout attr cannot be set with old z
 		/bin/true 2>noattr.err &&
 	grep "unsupported by this zeromq version" noattr.err
 '
+
+test_expect_success 'tbon.zmqdebug is zero by default' '
+	cat <<-EOT >zmqdebug.exp &&
+	0
+	EOT
+	flux broker ${ARGS} \
+		flux getattr tbon.zmqdebug >zmqdebug.out &&
+	test_cmp zmqdebug.exp zmqdebug.out
+'
+test_expect_success 'tbon.zmqdebug can be configured' '
+	mkdir conf18 &&
+	cat <<-EOT2 >zmqdebug2.exp &&
+	1
+	EOT2
+	cat <<-EOT >conf18/tbon.toml &&
+	[tbon]
+	zmqdebug = 1
+	EOT
+	flux broker ${ARGS} -c conf18 flux getattr tbon.zmqdebug \
+		>zmqdebug2.out &&
+	test_cmp zmqdebug2.exp zmqdebug2.out
+'
+test_expect_success MAXRT 'tbon.zmqdebug with bad value on command line fails' '
+	test_must_fail flux broker ${ARGS} \
+		-Stbon.zmqdebug=zzz \
+		/bin/true 2>zbadattr.err &&
+	grep "value must be an integer" zbadattr.err
+'
+
 test_done


### PR DESCRIPTION
This fixes a bug in the way the `tbon.zmqdebug` attribute setting was interpreted, and adds support for configuring it via the TOML config file.