### PR TITLE
broker: handle network partition

### DIFF
--- a/src/broker/groups.c
+++ b/src/broker/groups.c
@@ -221,9 +221,9 @@ static void batch_apply (struct groups *g)
             char *s = idset_encode (group->members, IDSET_FLAG_RANGE);
             flux_log (g->ctx->h,
                       LOG_DEBUG,
-                      "groups: set %s %s",
+                      "groups: %s=%s",
                       name,
-                      s ? s : "NULL");
+                      s && strlen (s) > 0 ? s : "");
             free (s);
         }
         get_respond_all (g, group);

--- a/src/broker/groups.c
+++ b/src/broker/groups.c
@@ -702,17 +702,6 @@ static void auto_leave (struct groups *g,
                         group->name);
             }
             json_decref (update);
-            if (g->verbose) {
-                char *s = idset_encode (x, IDSET_FLAG_RANGE);
-                flux_log (g->ctx->h,
-                          LOG_DEBUG,
-                          "groups: subtree loss rank=%d (%s) LEAVE %s %s",
-                          (int)rank,
-                          status,
-                          group->name,
-                          s ? s : "NULL");
-                free (s);
-            }
         }
         idset_destroy (x);
         group = zhashx_next (g->groups);

--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -886,8 +886,7 @@ static void child_cb (flux_reactor_t *r, flux_watcher_t *w,
          * Send CONTROL_DISCONNECT to force subtree panic.
          */
         else {
-            logdrop (ov, OVERLAY_DOWNSTREAM, msg,
-                     "didn't say hello, sending disconnect");
+            logdrop (ov, OVERLAY_DOWNSTREAM, msg, "unknown uuid");
             if (overlay_control_child (ov, uuid, CONTROL_DISCONNECT, 0) < 0)
                 flux_log_error (ov->h, "failed to send CONTROL_DISCONNECT");
         }

--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -865,8 +865,9 @@ static void child_cb (flux_reactor_t *r, flux_watcher_t *w,
          */
         if ((child = child_lookup (ov, uuid))) {
             logdrop (ov, OVERLAY_DOWNSTREAM, msg,
-                     "message from %s rank %lu",
+                     "message from %s child %s (rank %lu)",
                      subtree_status_str (child->status),
+                     flux_get_hostbyrank (ov->h, child->rank),
                      (unsigned long)child->rank);
             (void)overlay_control_child (ov, uuid, CONTROL_DISCONNECT, 0);
         }

--- a/src/broker/state_machine.c
+++ b/src/broker/state_machine.c
@@ -672,10 +672,12 @@ static void broker_online_cb (flux_future_t *f, void *arg)
         idset_destroy (s->quorum.have);
         s->quorum.have = ids;
         if (is_subset_of (s->quorum.want, s->quorum.have)) {
-            state_machine_post (s, "quorum-full");
-            if (s->quorum.warned) {
-                flux_log (s->ctx->h, LOG_ERR, "quorum reached");
-                s->quorum.warned = false;
+            if (s->state != STATE_RUN) {
+                state_machine_post (s, "quorum-full");
+                if (s->quorum.warned) {
+                    flux_log (s->ctx->h, LOG_ERR, "quorum reached");
+                    s->quorum.warned = false;
+                }
             }
         }
         flux_future_reset (f);


### PR DESCRIPTION
Problem:   If a network cable is unplugged long enough for a TBON child to be disconnected, and then re-plugged, the TBON child does not recover, as noted in #4124.

What happens is this:
- parent times out waiting for TCP ACK, and connection to child is dropped
- child is marked "lost" (now it must restart in order to reconnect)
- child is blocked waiting for connection to parent to be re-established
- when network is plugged back in, zeromq tries to send a message, gets RST which triggers disconnect
- zeromq reconnects
- queued messages are sent
- parent receives queued messages but they come from child marked disconnected
- current code silently discards those messages (resulting in hang)

Solution: in the last step, instead of silently dropping those messages, we log them and send a disconnect control message.  The child then exits and systemd restarts it.

This was tested on little test cluster.

Some changes were also made to log messages to improve the signal to noise ratio in this scenario.