### PR TITLE
python: return `JobID` from flux.job.submit, not `int`

### DIFF
--- a/src/bindings/python/flux/job/submit.py
+++ b/src/bindings/python/flux/job/submit.py
@@ -12,6 +12,7 @@ import errno
 from flux import constants
 from flux.util import check_future_error
 from flux.future import Future
+from flux.job import JobID
 from flux.job.Jobspec import _convert_jobspec_arg_to_string
 from flux.job._wrapper import _RAW as RAW
 from _flux._core import ffi, lib
@@ -89,14 +90,14 @@ def submit_get_id(future):
     :param future: a Flux future object returned by job.submit_async()
     :type future: Future
     :returns: job ID
-    :rtype: int
+    :rtype: JobID
     """
     if future is None or future == ffi.NULL:
         raise EnvironmentError(errno.EINVAL, "future must not be None/NULL")
     future.wait_for()  # ensure the future is fulfilled
     jobid = ffi.new("flux_jobid_t[1]")
     RAW.submit_get_id(future, jobid)
-    return int(jobid[0])
+    return JobID(jobid[0])
 
 
 def submit(

--- a/src/cmd/flux-mini.py
+++ b/src/cmd/flux-mini.py
@@ -26,7 +26,7 @@ from urllib.parse import urlparse, parse_qs
 
 import flux
 from flux import job
-from flux.job import JobspecV1, JobID
+from flux.job import JobspecV1
 from flux import util
 from flux import debugged
 from flux.idset import IDset
@@ -675,7 +675,7 @@ class MiniCmd:
         )
 
     def submit(self, args, jobspec=None):
-        return JobID(self.submit_async(args, jobspec).get_id())
+        return self.submit_async(args, jobspec).get_id()
 
     def get_parser(self):
         return self.parser
@@ -938,7 +938,7 @@ class SubmitBulkCmd(SubmitBaseCmd):
 
     def submit_cb(self, future, args, label=""):
         try:
-            jobid = JobID(future.get_id())
+            jobid = future.get_id()
             if not args.quiet:
                 print(jobid, file=args.stdout)
         except OSError as exc:

--- a/src/test/throughput.py
+++ b/src/test/throughput.py
@@ -16,7 +16,7 @@ import json
 
 import flux
 from flux import job
-from flux.job import JobspecV1, JobID
+from flux.job import JobspecV1
 from flux.progress import Bottombar
 
 
@@ -155,7 +155,7 @@ class BulkRun:
     def submit_cb(self, future, args):
         # pylint: disable=broad-except
         try:
-            self.handle_submit(args, JobID(future.get_id()))
+            self.handle_submit(args, future.get_id())
         except Exception as exc:
             print(f"Submission failed: {exc}", file=sys.stderr)
 


### PR DESCRIPTION
As described in #3614, it would be much more convenient to return a `JobID` instead of `int` from `flux.job.submit` and `flux.job.SubmitFuture.get_id`, with no discernable drawbacks.

This PR updates these Python calls to return a `JobID` object. This should not break any existing code, since `JobID()` on an instance of `JobID` should work fine.

Once the calls are converted, unnecessary use of `JobID()` is removed in `flux-mini.py` and `throughput.py`.