### PR TITLE
kvs: add date to kvs-primary checkpoint

### DIFF
--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -294,6 +294,7 @@ dist_check_SCRIPTS = \
 	valgrind/valgrind-workload.sh \
 	valgrind/workload.d/job \
 	kvs/kvs-helper.sh \
+	kvs/change-checkpoint.py \
 	job-manager/exec-service.lua \
 	job-manager/drain-cancel.py \
 	job-manager/bulk-state.py \

--- a/t/kvs/change-checkpoint.py
+++ b/t/kvs/change-checkpoint.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+
+import sys
+import sqlite3
+
+if len(sys.argv) < 4:
+    print("change-checkpoint.py <file> <key> <value>")
+    sys.exit(1)
+
+conn = sqlite3.connect(sys.argv[1])
+cursor = conn.cursor()
+s = (
+    'REPLACE INTO checkpt (key,value) values ("'
+    + sys.argv[2]
+    + '", "'
+    + sys.argv[3]
+    + '")'
+)
+cursor.execute(s)
+conn.commit()
+sys.exit(0)

--- a/t/t2010-kvs-snapshot-restore.t
+++ b/t/t2010-kvs-snapshot-restore.t
@@ -10,6 +10,7 @@ test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
 test_under_flux 1
 
 CHECKPOINT=${FLUX_BUILD_DIR}/t/kvs/checkpoint
+CHANGECHECKPOINT=${FLUX_SOURCE_DIR}/t/kvs/change-checkpoint.py
 
 test_expect_success 'store kvs-checkpoint key-val pairs' '
 	$CHECKPOINT put foo bar &&
@@ -57,6 +58,36 @@ test_expect_success 're-run instance with content.backing-path set' '
 test_expect_success 'content from previous instance survived' '
 	echo 42 >get.exp &&
 	test_cmp get.exp get.out
+'
+
+test_expect_success 're-run instance, verify checkpoint date saved' '
+	flux start -o,--setattr=content.backing-path=$(pwd)/content.sqlite \
+	           flux dmesg >dmesg1.out
+'
+
+# just check for todays date, not time for obvious reasons
+test_expect_success 'verify date in flux logs' '
+	today=`date --iso-8601` &&
+	grep checkpoint dmesg1.out | grep ${today}
+'
+
+test_expect_success 're-run instance, get rootref' '
+	flux start -o,--setattr=content.backing-path=$(pwd)/content.sqlite \
+	           flux kvs getroot -b > getroot.out
+'
+
+test_expect_success 'write rootref to checkpoint path, emulating original checkpoint' '
+        rootref=$(cat getroot.out) &&
+        ${CHANGECHECKPOINT} $(pwd)/content.sqlite "kvs-primary" ${rootref}
+'
+
+test_expect_success 're-run instance, verify checkpoint correctly loaded' '
+	flux start -o,--setattr=content.backing-path=$(pwd)/content.sqlite \
+	           flux dmesg >dmesg2.out
+'
+
+test_expect_success 'verify checkpoint loaded with no date' '
+	grep checkpoint dmesg2.out | grep "N\/A"
 '
 
 test_done


### PR DESCRIPTION
Thought I'd tackle this old issue.  I did a relatively simple thing for the check pointing, writing out a serialized json object storing the rootref + timestamp instead of just the rootref.

Multiple other possibilities, but thought this was the simplest / reasonable (i.e. no need to change content store implementation).  Other options include writing two keys out instead of one.

Note that I intentionally did not support backwards compatibility.  Figured use of this was rare at the moment.

```
Problem: It'd be convenient if we knew the date when the kvs
primary checkpoint was checkpointed.

Solution: When checkpointing the primary KVS, store a json
object with both the rootref and timestamp, instead of just
the rootref string.  On retrieval, parse appropriately and
retrieve timestamp for output in logs.

Fixes #3580
```