### PR TITLE
codecov: minor improvements for coverage reporting

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -166,7 +166,7 @@ jobs:
       if: success() && matrix.coverage && matrix.image == 'bionic'
       env:
         DOCKER_REPO:
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v2
       with:
         flags: ci-basic
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -26,3 +26,4 @@ coverage:
 comment:
  layout: "header, diff, changes, tree"
  behavior: new
+ after_n_builds: 2


### PR DESCRIPTION
This PR has a couple tweaks to codecov configuration and uploader which may help with some of the strange coverage reports we've seen since adding the "system" coverage builder.

 1. Update the codecov GH action to v2. The system coverage builder uses the newest uploader, so perhaps there is some inconsistency in the two uploads which is causing differences.
 2. Delay the codecov PR comment until both coverage reports are uploaded by setting `after_n_builds: 2`. This may give codecov a change to merge reports before commenting.

It is unclear if either of these will help with the report of ~3% coverage drop due to the system coverage builder, but they both seem like a good idea for now.