### PR TITLE
add flux-uptime command

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -35,6 +35,7 @@ MAN1_FILES_PRIMARY = \
 	man1/flux-pstree.1 \
 	man1/flux-shell.1 \
 	man1/flux-jobtap.1 \
+	man1/flux-uptime.1 \
 	man1/flux-uri.1 \
 	man1/flux-resource.1
 

--- a/doc/man1/flux-uptime.rst
+++ b/doc/man1/flux-uptime.rst
@@ -1,0 +1,58 @@
+.. flux-help-description: Tell how long Flux has been up and running
+
+==============
+flux-uptime(1)
+==============
+
+
+SYNOPSIS
+========
+
+**flux** **uptime**
+
+
+DESCRIPTION
+===========
+
+The ``flux-uptime`` displays the following information about the
+current Flux instance, on one or two lines:
+
+- The current wall clock time.
+
+- The elapsed time the Flux instance has been running, in RFC 23 Flux Standard
+  Duration format.  This is derived from the ``broker.starttime`` attribute
+  on the rank 0 broker.
+
+- The Flux instance owner.  On a system instance, this is probably the
+  ``flux`` user.
+
+- The Flux instance depth.  If the Flux instance was not launched as a job
+  within another Flux instance, the depth is zero.
+
+- The instance size.  This is the total number of brokers, which is usually
+  also the number of nodes.
+
+- The number of drained nodes, if greater than zero.  Drained nodes are
+  not eligible to run new jobs, although they may be online, and may currently
+  be running a job.
+
+- The number of offline nodes, if greater than zero.  A node is offline if
+  its broker is not connected to the instance overlay network.
+
+- A notice if job submission is disabled.
+
+- A notice if scheduling is disabled.
+
+
+RESOURCES
+=========
+
+Flux: http://flux-framework.org
+
+RFC 23: Flux Standard Duration: https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/spec_23.html
+
+
+SEE ALSO
+========
+
+:man1:`flux-resource`, :man1:`flux-getattr`, :man7:`flux-broker-attributes`

--- a/doc/man1/index.rst
+++ b/doc/man1/index.rst
@@ -28,6 +28,7 @@ man1
    flux-resource
    flux-start
    flux-shell
+   flux-uptime
    flux-uri
    flux-version
    flux

--- a/doc/manpages.py
+++ b/doc/manpages.py
@@ -31,6 +31,7 @@ man_pages = [
     ('man1/flux-jobs', 'flux-jobs', 'list jobs submitted to Flux', [author], 1),
     ('man1/flux-pstree', 'flux-pstree', 'display job hierarchies', [author], 1),
     ('man1/flux-jobtap', 'flux-jobtap', 'List, remove, and load job-manager plugins', [author], 1),
+    ('man1/flux-uptime', 'flux-uptime', 'Tell how long Flux has been up and running', [author], 1),
     ('man1/flux-uri', 'flux-uri', 'resolve Flux URIs', [author], 1),
     ('man1/flux-resource', 'flux-resource', 'list/manipulate Flux resource status', [author], 1),
     ('man1/flux-keygen', 'flux-keygen', 'generate keys for Flux security', [author], 1),

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -601,3 +601,4 @@ desynchronized
 multi
 sysctl
 pluginpath
+uptime

--- a/src/broker/groups.c
+++ b/src/broker/groups.c
@@ -764,12 +764,12 @@ static const struct flux_msg_handler_spec htab[] = {
     {   FLUX_MSGTYPE_REQUEST,
         "groups.get",
         get_request_cb,
-        0
+        FLUX_ROLE_USER,
     },
     {   FLUX_MSGTYPE_REQUEST,
         "groups.disconnect",
         disconnect_cb,
-        0
+        FLUX_ROLE_USER,
     },
     FLUX_MSGHANDLER_TABLE_END,
 };

--- a/src/broker/groups.c
+++ b/src/broker/groups.c
@@ -746,11 +746,31 @@ done:
 }
 
 static const struct flux_msg_handler_spec htab[] = {
-    { FLUX_MSGTYPE_REQUEST,  "groups.update", update_request_cb, 0 },
-    { FLUX_MSGTYPE_REQUEST,  "groups.join", join_request_cb, 0 },
-    { FLUX_MSGTYPE_REQUEST,  "groups.leave", leave_request_cb, 0 },
-    { FLUX_MSGTYPE_REQUEST,  "groups.get", get_request_cb, 0 },
-    { FLUX_MSGTYPE_REQUEST,  "groups.disconnect", disconnect_cb, 0 },
+    {   FLUX_MSGTYPE_REQUEST,
+        "groups.update",
+        update_request_cb,
+        0
+    },
+    {   FLUX_MSGTYPE_REQUEST,
+        "groups.join",
+        join_request_cb,
+        0
+    },
+    {   FLUX_MSGTYPE_REQUEST,
+        "groups.leave",
+        leave_request_cb,
+        0
+    },
+    {   FLUX_MSGTYPE_REQUEST,
+        "groups.get",
+        get_request_cb,
+        0
+    },
+    {   FLUX_MSGTYPE_REQUEST,
+        "groups.disconnect",
+        disconnect_cb,
+        0
+    },
     FLUX_MSGHANDLER_TABLE_END,
 };
 

--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -54,7 +54,8 @@ flux_SOURCES = \
 	builtin/proxy.c \
 	builtin/overlay.c \
 	builtin/relay.c \
-	builtin/python.c
+	builtin/python.c \
+	builtin/uptime.c
 nodist_flux_SOURCES = \
 	builtin-cmds.c
 

--- a/src/cmd/builtin/uptime.c
+++ b/src/cmd/builtin/uptime.c
@@ -1,0 +1,301 @@
+/************************************************************\
+ * Copyright 2022 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+# include <config.h>
+#endif
+#include <unistd.h>
+#include <sys/types.h>
+#include <pwd.h>
+#include <time.h>
+#include <jansson.h>
+
+#include "src/common/libidset/idset.h"
+#include "src/common/libutil/fsd.h"
+
+#include "builtin.h"
+
+/* Fetch the named broker group idset membership, and return the
+ * number of members.
+ */
+static int groups_get_count (flux_t *h, const char *name)
+{
+    flux_future_t *f;
+    const char *members;
+    struct idset *ids;
+    int count;
+
+    if (!(f = flux_rpc_pack (h, "groups.get", 0, 0, "{s:s}", "name", name))
+        || flux_rpc_get_unpack (f, "{s:s}", "members", &members) < 0
+        || !(ids = idset_decode (members)))
+        log_err_exit ("Error fetching %s group", name);
+    count = idset_count (ids);
+    idset_destroy (ids);
+    flux_future_destroy (f);
+    return count;
+}
+
+/* Return true if scheduling is disabled.
+ */
+static bool sched_disabled (flux_t *h)
+{
+    flux_future_t *f;
+    int enable;
+
+    if (!(f = flux_rpc_pack (h,
+                             "job-manager.alloc-admin",
+                             0,
+                             0,
+                             "{s:b s:b s:s}",
+                             "query_only", 1,
+                             "enable", 0,
+                             "reason", ""))
+        || flux_rpc_get_unpack (f, "{s:b}", "enable", &enable) < 0)
+        log_err_exit ("Error fetching alloc status");
+    return enable ? false : true;
+}
+
+/* Return true if job submission is disabled.
+ */
+static bool submit_disabled (flux_t *h)
+{
+    flux_future_t *f;
+    int enable;
+
+    if (!(f = flux_rpc_pack (h,
+                             "job-manager.submit-admin",
+                             0,
+                             0,
+                             "{s:b s:b s:s}",
+                             "query_only", 1,
+                             "enable", 0,
+                             "reason", ""))
+        || flux_rpc_get_unpack (f, "{s:b}", "enable", &enable) < 0)
+        log_err_exit ("Error fetching submit status");
+    return enable ? false : true;
+}
+
+/* Each key in the drain object is an idset representing a group
+ * of drained nodes.  Sum the member count of all idsets and set 'countp'.
+ * Return 0 on success, -1 on failure.
+ */
+static int parse_drain_object (json_t *drain, int *countp)
+{
+    const char *key;
+    json_t *value;
+    struct idset *ids;
+    int count = 0;
+
+    json_object_foreach (drain, key, value) {
+        if (!(ids = idset_decode (key)))
+            return -1;
+        count += idset_count (ids);
+        idset_destroy (ids);
+    }
+    *countp = count;
+    return 0;
+}
+
+/* Get the number of drained nodes.
+ */
+static int resource_status_drained (flux_t *h)
+{
+    flux_future_t *f;
+    int count;
+    json_t *drain;
+
+    if (!(f = flux_rpc (h, "resource.status", NULL, 0, 0))
+        || flux_rpc_get_unpack (f, "{s:o}", "drain", &drain) < 0
+        || parse_drain_object (drain, &count) < 0)
+        log_err_exit ("Error fetching resource status");
+    flux_future_destroy (f);
+    return count;
+}
+
+/* Fetch an attribute and return its value as integer.
+ */
+static int attr_get_int (flux_t *h, const char *name)
+{
+    const char *s;
+    char *endptr;
+    int i;
+
+    if (!(s = flux_attr_get (h, name)))
+        log_err_exit ("Error fetching %s attribute", name);
+    errno = 0;
+    i = strtol (s, &endptr, 10);
+    if (errno != 0 || *endptr != '\0')
+        log_msg_exit ("Error parsing %s", name);
+    return i;
+}
+
+/* Fetch broker.starttime from rank 0 and return its value as double.
+ */
+static double attr_get_starttime (flux_t *h)
+{
+    const char *name = "broker.starttime";
+    flux_future_t *f;
+    const char *s;
+    char *endptr;
+    double d;
+
+    if (!(f = flux_rpc_pack (h, "attr.get", 0, 0, "{s:s}", "name", name))
+        || flux_rpc_get_unpack (f, "{s:s}", "value", &s) < 0)
+        log_err_exit ("Error fetching %s attribute", name);
+    errno = 0;
+    d = strtod (s, &endptr);
+    if (errno != 0 || *endptr != '\0')
+        log_msg_exit ("Error parsing %s", name);
+    return d;
+}
+
+/* Format seconds-since-epoch time in HH:MM:SS (24-hour) format.
+ */
+static int format_time (char *buf, size_t len, double t)
+{
+    struct tm tm;
+    time_t tt = t;
+
+    if (localtime_r (&tt, &tm) == NULL)
+        return -1;
+    if (strftime (buf, len, "%T", &tm) == 0)
+        return -1;
+    return 0;
+}
+
+/* Get the username for 'uid'.  If that fails, convert uid to string.
+ */
+static int format_user (char *buf, size_t len, int uid)
+{
+    char pwbuf[16384];
+    struct passwd pwd;
+    struct passwd *result;
+    int n;
+
+    if (getpwuid_r (uid, &pwd, pwbuf, sizeof (pwbuf), &result) < 0)
+        n = snprintf (buf, len, "%d", uid);
+    else
+        n = snprintf (buf, len, "%s", result->pw_name);
+    if (n >= len)
+        return -1;
+    return 0;
+}
+
+/* Append ",  name" to buf if condition is true.
+ * Ignore truncation errors.
+ */
+static void append_if (char *buf,
+                       size_t len,
+                       const char *name,
+                       bool condition)
+{
+    if (condition) {
+        int n = strlen (buf);
+        snprintf (buf + n,
+                  len - n,
+                  "%s%s",
+                  n > 0 ? ",  " : "",
+                  name);
+    }
+}
+
+/* Append ",  count name" to buf if condition is true
+ * Ignore truncation errors.
+ */
+static void append_count_if (char *buf,
+                             size_t len,
+                             const char *name,
+                             int count,
+                             bool condition)
+{
+    if (condition) {
+        int n = strlen (buf);
+        snprintf (buf + n,
+                  len - n,
+                  "%s%d %s",
+                  n > 0 ? ",  " : "",
+                  count,
+                  name);
+    }
+}
+
+/* Mimic uptime(1), sort of.
+ */
+static void default_summary (flux_t *h)
+{
+    double t_start = attr_get_starttime (h);
+    double t_now = flux_reactor_now (flux_get_reactor (h));
+    int userid = attr_get_int (h, "security.owner");
+    int size = attr_get_int (h, "size");
+    int level = attr_get_int (h, "instance-level");
+    int drained = resource_status_drained (h);
+    int online = groups_get_count (h, "broker.online");
+    int offline = size - online;
+    char fsd[32];
+    char now[32];
+    char owner[32];
+    char extra[512] = "";
+
+    if (fsd_format_duration_ex (fsd, sizeof (fsd), t_now - t_start, 2) < 0)
+        log_err_exit ("Error formatting uptime duration");
+    if (format_time (now, sizeof (now), t_now) < 0)
+        log_msg_exit ("Error formatting current time");
+    if (format_user (owner, sizeof (owner), userid) < 0)
+        log_msg_exit ("Error formatting instance owner");
+    append_count_if (extra, sizeof (extra), "drained", drained, drained > 0);
+    append_count_if (extra, sizeof (extra), "offline", offline, offline > 0);
+    printf (" %s up %s,  owner %s,  depth %d,  size %d%s\n",
+            now,
+            fsd,
+            owner,
+            level,
+            size,
+            extra);
+
+    /* optional 2nd line for submit/sched disabled
+     */
+    extra[0] = '\0';
+    append_if (extra,
+               sizeof (extra),
+               "submit disabled",
+               submit_disabled (h));
+    append_if (extra,
+               sizeof (extra),
+               "scheduler disabled",
+               sched_disabled (h));
+    if (strlen (extra) > 0)
+        printf ("  %s\n", extra);
+}
+
+static int cmd_uptime (optparse_t *p, int ac, char *av[])
+{
+    flux_t *h = builtin_get_flux_handle (p);
+
+    default_summary (h);
+
+    return (0);
+}
+
+int subcommand_uptime_register (optparse_t *p)
+{
+    optparse_err_t e;
+    e = optparse_reg_subcommand (p,
+        "uptime",
+        cmd_uptime,
+        NULL,
+        "Show how long this Flux instance has been running",
+        0,
+        NULL);
+    return (e == OPTPARSE_SUCCESS ? 0 : -1);
+}
+
+/*
+ * vi: ts=4 sw=4 expandtab
+ */

--- a/src/modules/job-manager/alloc.c
+++ b/src/modules/job-manager/alloc.c
@@ -801,11 +801,31 @@ void alloc_ctx_destroy (struct alloc *alloc)
 }
 
 static const struct flux_msg_handler_spec htab[] = {
-    { FLUX_MSGTYPE_REQUEST,  "job-manager.sched-hello", hello_cb, 0},
-    { FLUX_MSGTYPE_REQUEST,  "job-manager.sched-ready", ready_cb, 0},
-    { FLUX_MSGTYPE_REQUEST,  "job-manager.alloc-admin", alloc_admin_cb, 0},
-    { FLUX_MSGTYPE_RESPONSE, "sched.alloc", alloc_response_cb, 0},
-    { FLUX_MSGTYPE_RESPONSE, "sched.free", free_response_cb, 0},
+    {   FLUX_MSGTYPE_REQUEST,
+        "job-manager.sched-hello",
+        hello_cb,
+        0
+    },
+    {   FLUX_MSGTYPE_REQUEST,
+        "job-manager.sched-ready",
+        ready_cb,
+        0
+    },
+    {   FLUX_MSGTYPE_REQUEST,
+        "job-manager.alloc-admin",
+        alloc_admin_cb,
+        0
+    },
+    {   FLUX_MSGTYPE_RESPONSE,
+        "sched.alloc",
+        alloc_response_cb,
+        0
+    },
+    {   FLUX_MSGTYPE_RESPONSE,
+        "sched.free",
+        free_response_cb,
+        0
+    },
     FLUX_MSGHANDLER_TABLE_END,
 };
 

--- a/src/modules/job-manager/submit.c
+++ b/src/modules/job-manager/submit.c
@@ -339,8 +339,17 @@ void submit_ctx_destroy (struct submit *submit)
 }
 
 static const struct flux_msg_handler_spec htab[] = {
-    { FLUX_MSGTYPE_REQUEST, "job-manager.submit", submit_cb, 0},
-    { FLUX_MSGTYPE_REQUEST, "job-manager.submit-admin", submit_admin_cb, 0},
+    {   FLUX_MSGTYPE_REQUEST,
+        "job-manager.submit",
+        submit_cb,
+        0
+    },
+    {
+        FLUX_MSGTYPE_REQUEST,
+        "job-manager.submit-admin",
+        submit_admin_cb,
+        0
+    },
     FLUX_MSGHANDLER_TABLE_END,
 };
 

--- a/src/modules/job-manager/submit.c
+++ b/src/modules/job-manager/submit.c
@@ -287,6 +287,7 @@ static void submit_admin_cb (flux_t *h, flux_msg_handler_t *mh,
 {
     struct job_manager *ctx = arg;
     const char *error_prefix = "job submission is disabled: ";
+    const char *errmsg = NULL;
     int enable;
     int query_only;
     const char *reason;
@@ -302,6 +303,10 @@ static void submit_admin_cb (flux_t *h, flux_msg_handler_t *mh,
                              &reason) < 0)
         goto error;
     if (!query_only) {
+        if (flux_msg_authorize (msg, FLUX_USERID_UNKNOWN) < 0) {
+            errmsg = "Request requires owner credentals";
+            goto error;
+        }
         if (!enable) {
             char *errmsg;
             if (asprintf (&errmsg, "%s%s", error_prefix, reason) < 0)
@@ -323,7 +328,7 @@ static void submit_admin_cb (flux_t *h, flux_msg_handler_t *mh,
         flux_log_error (h, "%s: flux_respond", __FUNCTION__);
     return;
 error:
-    if (flux_respond_error (h, msg, errno, NULL) < 0)
+    if (flux_respond_error (h, msg, errno, errmsg) < 0)
         flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
 }
 
@@ -348,7 +353,7 @@ static const struct flux_msg_handler_spec htab[] = {
         FLUX_MSGTYPE_REQUEST,
         "job-manager.submit-admin",
         submit_admin_cb,
-        0
+        FLUX_ROLE_USER,
     },
     FLUX_MSGHANDLER_TABLE_END,
 };

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -180,6 +180,7 @@ TESTSCRIPTS = \
 	t2801-top-cmd.t \
 	t2802-uri-cmd.t \
 	t2803-flux-pstree.t \
+	t2804-uptime-cmd.t \
 	t2900-job-timelimits.t \
 	t3000-mpi-basic.t \
 	t3001-mpi-personalities.t \

--- a/t/t2240-queue-cmd.t
+++ b/t/t2240-queue-cmd.t
@@ -253,6 +253,10 @@ runas_guest() {
         FLUX_HANDLE_USERID=$userid FLUX_HANDLE_ROLEMASK=0x2 "$@"
 }
 
+test_expect_success 'flux-queue: status allowed for guest' '
+	runas_guest flux queue status
+'
+
 test_expect_success 'flux-queue: stop denied for guest' '
 	test_must_fail runas_guest flux queue stop 2>guest_stop.err &&
 	cat <<-EOT >guest_alloc.exp &&

--- a/t/t2804-uptime-cmd.t
+++ b/t/t2804-uptime-cmd.t
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+test_description='Test flux uptime command'
+
+. $(dirname $0)/sharness.sh
+
+test_under_flux 4
+
+runas_guest() {
+        local userid=$(($(id -u)+1))
+        FLUX_HANDLE_USERID=$userid FLUX_HANDLE_ROLEMASK=0x2 "$@"
+}
+
+test_expect_success 'flux-uptime works on rank 0' '
+	flux uptime
+'
+test_expect_success 'flux-uptime works on rank 1' '
+	flux exec -r 1 flux uptime
+'
+test_expect_success 'flux-uptime works as guest' '
+	runas_guest flux uptime
+'
+test_expect_success 'flux-uptime reports correct size' '
+	flux uptime | grep "size 4"
+'
+test_expect_success 'flux-uptime reports submit disabled' '
+	flux queue disable "testing" &&
+	flux uptime | grep "submit disabled"
+'
+test_expect_success 'flux-uptime reports scheduler disabled' '
+	flux queue stop &&
+	flux uptime | grep "scheduler disabled"
+'
+test_expect_success 'flux-uptime reports drained node count' '
+	flux resource drain 1,3 &&
+	flux uptime | grep "2 drained"
+'
+
+test_done


### PR DESCRIPTION
OK here's a crack at a `flux-uptime` command per discussion in #4146.  Here's some example output on a single user instance:
```
$ flux uptime
 17:29:27 up 3.7s, owner garlick, depth 0, size 4
```

Here's some output on a system instance, that happens to have a drained node, some offline nodes, and both scheduling and job submission disabled
```
$ flux uptime
 17:31:46 up 46m, owner flux, depth 0, size 8, drained 1, offline 5, submit disabled, sched disabled
```

It gets a little long if everything is showing, but most of the time that won't be the case.