### PR TITLE
add flux-startlog and enter safe mode after crash

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -18,6 +18,7 @@ MAN1_FILES_PRIMARY = \
 	man1/flux-logger.1 \
 	man1/flux-ping.1 \
 	man1/flux-start.1 \
+	man1/flux-startlog.1 \
 	man1/flux-module.1 \
 	man1/flux-exec.1 \
 	man1/flux-env.1 \

--- a/doc/man1/flux-startlog.rst
+++ b/doc/man1/flux-startlog.rst
@@ -1,0 +1,64 @@
+.. flux-help-description: Show Flux instance start and stop times
+
+================
+flux-startlog(1)
+================
+
+
+SYNOPSIS
+========
+
+**flux** **startlog**
+
+
+DESCRIPTION
+===========
+
+List the Flux instance's start and stop times, by interpreting the contents
+of the KVS ``admin.eventlog``.
+
+A ``start`` event is posted to the eventlog at startup, and a ``finish`` event
+is posted to the eventlog at finalization.  The timestamps on the two events
+are used to calculate the instance run time, which is shown in the listing
+in Flux Standard Duration format.
+
+If the current ``start`` event is not immediately preceded by a ``finish``
+event (unless it is the first entry in the eventlog), then the Flux instance
+may have crashed and data may have been lost.  If this is detected on instance
+startup, Flux is placed into a safe mode where scheduling and job submission
+are disabled, to avoid further damage pending recovery.
+
+This command is not available to guest users.
+
+
+OPTIONS
+=======
+
+**-h, --help**
+   Summarize available options.
+
+**--check**
+   If the instance has most recently restarted from a crash, exit with a
+   return code of 1, otherwise 0.
+
+**--quiet**
+   Suppress non-error output.
+
+**-v, --show-version**
+   Show the flux-core software version associated with each start event.
+
+
+RESOURCES
+=========
+
+Flux: http://flux-framework.org
+
+RFC 18: KVS Event Log Format: https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/spec_18.html
+
+RFC 23: Flux Standard Duration: https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/spec_23.html
+
+
+SEE ALSO
+========
+
+:man1:`flux-uptime`, :man1:`flux-kvs`

--- a/doc/man1/index.rst
+++ b/doc/man1/index.rst
@@ -27,6 +27,7 @@ man1
    flux-pstree
    flux-resource
    flux-start
+   flux-startlog
    flux-shell
    flux-uptime
    flux-uri

--- a/doc/manpages.py
+++ b/doc/manpages.py
@@ -43,6 +43,7 @@ man_pages = [
     ('man1/flux-ping', 'flux-ping', 'measure round-trip latency to Flux services', [author], 1),
     ('man1/flux-proxy', 'flux-proxy', 'create proxy environment for Flux instance', [author], 1),
     ('man1/flux-start', 'flux-start', 'bootstrap a local Flux instance', [author], 1),
+    ('man1/flux-startlog', 'flux-startlog', 'Show Flux instance start and stop times', [author], 1),
     ('man1/flux-version', 'flux-version', 'Display flux version information', [author], 1),
     ('man1/flux', 'flux', 'the Flux resource management framework', [author], 1),
     ('man1/flux-shell', 'flux-shell', 'the Flux job shell', [author], 1),

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -602,3 +602,5 @@ multi
 sysctl
 pluginpath
 uptime
+startlog
+timestamps

--- a/etc/rc1
+++ b/etc/rc1
@@ -32,6 +32,11 @@ modload all job-info
 modload 0 job-list
 modload 0 job-archive
 
+if test $RANK -eq 0 && ! flux startlog --check --quiet; then
+    flux queue stop
+    flux queue disable "Flux is in safe mode due to an incomplete shutdown."
+fi
+
 modload all job-ingest
 modload 0 job-exec
 modload 0 heartbeat

--- a/etc/rc1
+++ b/etc/rc1
@@ -58,9 +58,10 @@ if test $RANK -eq 0 -a "${FLUX_SCHED_MODULE}" != "none" \
     flux module load ${FLUX_SCHED_MODULE:-sched-simple}
 fi
 
-test $RANK -ne 0 -o "${FLUX_INSTANCE_RESTART}" = "t" \
-     || flux admin cleanup-push <<-EOT
+if test $RANK -eq 0 -a -z "${FLUX_DISABLE_JOB_CLEANUP}"; then
+	flux admin cleanup-push <<-EOT
 	flux queue stop --quiet
 	flux job cancelall --user=all --quiet -f --states RUN
 	flux queue idle --quiet
-EOT
+	EOT
+fi

--- a/etc/rc1
+++ b/etc/rc1
@@ -21,6 +21,10 @@ modload 0 ${content_backing}
 modload all kvs
 modload all kvs-watch
 
+if test $RANK -eq 0; then
+    flux startlog --post-start-event
+fi
+
 modload all resource
 modload 0 cron sync=heartbeat.pulse
 modload 0 job-manager

--- a/etc/rc3
+++ b/etc/rc3
@@ -35,6 +35,10 @@ modrm all job-ingest
 modrm 0 cron
 modrm all barrier
 
+if test $RANK -eq 0; then
+    flux startlog --post-finish-event
+fi
+
 modrm all kvs-watch
 modrm all kvs
 

--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -55,7 +55,8 @@ flux_SOURCES = \
 	builtin/overlay.c \
 	builtin/relay.c \
 	builtin/python.c \
-	builtin/uptime.c
+	builtin/uptime.c \
+	builtin/startlog.c
 nodist_flux_SOURCES = \
 	builtin-cmds.c
 

--- a/src/cmd/builtin/startlog.c
+++ b/src/cmd/builtin/startlog.c
@@ -1,0 +1,315 @@
+/************************************************************\
+ * Copyright 2022 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+# include <config.h>
+#endif
+#include <unistd.h>
+#include <stdarg.h>
+#include <jansson.h>
+#include <time.h>
+
+#include "src/common/libeventlog/eventlog.h"
+#include "src/common/libkvs/treeobj.h"
+#include "src/common/libutil/fsd.h"
+
+#include "builtin.h"
+
+#define DEFAULT_STARTLOG_KEY "admin.eventlog"
+#define DEFAULT_STARTLOG_VERSION 1
+
+static const char *startlog_key;
+static int startlog_version;
+
+enum post_flags {
+    POST_FLAG_FLUSH,
+};
+
+static void content_flush (flux_t *h)
+{
+    flux_future_t *f;
+
+    if (!(f = flux_rpc (h, "content.flush", NULL, 0, 0))
+        || flux_rpc_get (f, NULL) < 0)
+        log_msg_exit ("Error flushing content cache: %s",
+                      future_strerror (f, errno));
+    flux_future_destroy (f);
+}
+
+static void kvs_checkpoint_put (flux_t *h, const char *treeobj)
+{
+    json_t *o;
+    const char *rootref;
+    flux_future_t *f;
+
+    if (!(o = treeobj_decode (treeobj))
+        || !(rootref = treeobj_get_blobref (o, 0)))
+        log_err_exit ("Error decoding treeobj from eventlog commit");
+    if (!(f = flux_rpc_pack (h,
+                             "kvs-checkpoint.put",
+                             0,
+                             0,
+                             "{s:s s:s}",
+                             "key",
+                             "kvs-primary",
+                             "value",
+                             rootref))
+        || flux_rpc_get (f, NULL) < 0)
+        log_msg_exit ("Error writing kvs checkpoint: %s",
+                      future_strerror (f, errno));
+    flux_future_destroy (f);
+    json_decref (o);
+}
+
+static void post_startlog_event (flux_t *h,
+                                 enum post_flags flags,
+                                 const char *name,
+                                 const char *fmt, ...)
+{
+    va_list ap;
+    json_t *o;
+    char *event;
+    flux_kvs_txn_t *txn;
+    flux_future_t *f;
+    const char *treeobj;
+    uint32_t rank;
+
+    if (flux_get_rank (h, &rank) < 0)
+        log_err_exit ("Error fetching rank");
+    if (rank > 0)
+        log_msg_exit ("Startlog events may only be posted from rank 0");
+
+    va_start (ap, fmt);
+    o = eventlog_entry_vpack (0., name, fmt, ap);
+    va_end (ap);
+
+    if (!o
+        || !(event = eventlog_entry_encode (o))
+        || !(txn = flux_kvs_txn_create ())
+        || flux_kvs_txn_put (txn,
+                             FLUX_KVS_APPEND,
+                             startlog_key,
+                             event) < 0)
+        log_err_exit ("Error creating %s event", name);
+    if (!(f = flux_kvs_commit (h, NULL, 0, txn))
+        || flux_kvs_commit_get_treeobj (f, &treeobj) < 0)
+        log_msg_exit ("Error commiting %s event: %s",
+                      name,
+                      future_strerror (f, errno));
+
+    if (flags == POST_FLAG_FLUSH) {
+        content_flush (h);
+        kvs_checkpoint_put (h, treeobj);
+    }
+
+    flux_future_destroy (f);
+    flux_kvs_txn_destroy (txn);
+    free (event);
+    json_decref (o);
+}
+
+static int startlog_parse_event (json_t *entry,
+                                 double *timestampp,
+                                 const char **namep,
+                                 json_t **contextp)
+{
+    double timestamp;
+    const char *name;
+    json_t *context;
+    int version;
+
+    if (eventlog_entry_parse (entry, &timestamp, &name, &context) < 0
+        || json_unpack (context, "{s:i}", "version", &version) < 0
+        || version < 0
+        || version > startlog_version)
+        return -1;
+    if (timestampp)
+        *timestampp = timestamp;
+    if (namep)
+        *namep = name;
+    if (contextp)
+        *contextp = context;
+    return 0;
+}
+
+static void startlog_post_start_event (flux_t *h, optparse_t *p)
+{
+    post_startlog_event (h,
+                         POST_FLAG_FLUSH,
+                         "start",
+                         "{s:i s:s}",
+                         "version", startlog_version,
+                         "core_version", flux_core_version_string ());
+}
+
+static void startlog_post_finish_event (flux_t *h, optparse_t *p)
+{
+    post_startlog_event (h,
+                         0,
+                         "finish",
+                         "{s:i}",
+                         "version", startlog_version);
+}
+
+static json_t *startlog_fetch (flux_t *h)
+{
+    flux_future_t *f;
+    const char *raw;
+    json_t *event_array;
+
+    if (!(f = flux_kvs_lookup (h, NULL, 0, startlog_key))
+        || flux_kvs_lookup_get (f, &raw) < 0)
+        log_msg_exit ("Error fetching eventlog: %s",
+                      future_strerror (f, errno));
+    if (!(event_array = eventlog_decode (raw)))
+        log_err_exit ("Error decoding eventlog");
+    flux_future_destroy (f);
+    return event_array;
+}
+
+static int format_timestamp (char *buf, size_t size, time_t t)
+{
+    struct tm tm;
+    if (t < 0 || !localtime_r (&t, &tm))
+        return -1;
+    if (strftime (buf, size, "%F %R", &tm) == 0)
+        return -1;
+    return 0;
+}
+
+/* Interpret startlog and list instance restart durations.
+ */
+static void startlog_list (flux_t *h, optparse_t *p)
+{
+    json_t *event_array = startlog_fetch (h);
+    bool check = optparse_hasopt (p, "check");
+    bool quiet = optparse_hasopt (p, "quiet");
+    bool crashed = false;
+    size_t index;
+    json_t *entry;
+    double timestamp;
+    const char *name;
+    json_t *context;
+    char timebuf[64];
+    bool started = false;
+    double last_timestamp = 0;
+    char fsd[64];
+
+    json_array_foreach (event_array, index, entry) {
+        if (startlog_parse_event (entry, &timestamp, &name, &context) < 0)
+            continue; // ignore (but tolerate) non-conforming entries
+        format_timestamp (timebuf, sizeof (timebuf), timestamp);
+        if (!strcmp (name, "start")) {
+            if (started) {
+                if (!quiet)
+                    printf ("crashed\n");
+                crashed = true;
+            }
+            if (!quiet) {
+                const char *s = "";
+                if (optparse_hasopt (p, "show-version")) {
+                    (void)json_unpack (context, "{s:s}", "core_version", &s);
+                    printf ("%25s  ", s);
+                }
+                printf ("%s - ", timebuf);
+            }
+            started = true;
+        }
+        else if (!strcmp (name, "finish")) {
+            if (started) {
+                fsd_format_duration_ex (fsd,
+                                        sizeof (fsd),
+                                        timestamp - last_timestamp,
+                                        2);
+                if (!quiet)
+                    printf ("%s (%s)\n", timebuf, fsd);
+                crashed = false;
+            }
+            started = false;
+        }
+        last_timestamp = timestamp;
+    }
+    if (started) {
+        flux_reactor_t *r = flux_get_reactor (h);
+        fsd_format_duration_ex (fsd,
+                                sizeof (fsd),
+                                flux_reactor_now (r) - last_timestamp,
+                                2);
+        if (!quiet)
+            printf ("running (%s)\n", fsd);
+    }
+    if (check && crashed)
+        exit (1);
+}
+
+static int cmd_startlog (optparse_t *p, int ac, char *av[])
+{
+    flux_t *h = builtin_get_flux_handle (p);
+
+    startlog_key = optparse_get_str (p,
+                                     "test-startlog-key",
+                                     DEFAULT_STARTLOG_KEY);
+    startlog_version = optparse_get_int (p,
+                                         "test-startlog-version",
+                                         DEFAULT_STARTLOG_VERSION);
+    if (optparse_hasopt (p, "post-start-event"))
+        startlog_post_start_event (h, p);
+    else if (optparse_hasopt (p, "post-finish-event"))
+        startlog_post_finish_event (h, p);
+    else
+        startlog_list (h, p);
+    return 0;
+}
+
+static struct optparse_option startlog_opts[] = {
+    { .name = "check", .has_arg = 0,
+      .usage = "Check if instance was properly shut down",
+    },
+    { .name = "quiet", .has_arg = 0,
+      .usage = "Suppress listing, useful with --check",
+    },
+    { .name = "show-version", .key = 'v', .has_arg = 0,
+      .usage = "Show the flux-core version string in output",
+    },
+    { .name = "post-start-event", .has_arg = 0,
+      .usage = "Post start event to eventlog (for rc use only)",
+      .flags = OPTPARSE_OPT_HIDDEN,
+    },
+    { .name = "post-finish-event", .has_arg = 0,
+      .usage = "Post finish event to eventlog (for rc use only)",
+      .flags = OPTPARSE_OPT_HIDDEN,
+    },
+    { .name = "test-startlog-key", .has_arg = 1, .arginfo = "PATH",
+      .usage = "override startlog key (test only)",
+      .flags = OPTPARSE_OPT_HIDDEN,
+    },
+    { .name = "test-startlog-version", .has_arg = 1, .arginfo = "VERSION",
+      .usage = "override startlog version (test only)",
+      .flags = OPTPARSE_OPT_HIDDEN,
+    },
+    OPTPARSE_TABLE_END
+};
+
+int subcommand_startlog_register (optparse_t *p)
+{
+    optparse_err_t e;
+    e = optparse_reg_subcommand (p,
+        "startlog",
+        cmd_startlog,
+        "[OPTIONS]",
+        "List Flux instance startlog",
+        0,
+        startlog_opts);
+    return (e == OPTPARSE_SUCCESS ? 0 : -1);
+}
+
+/*
+ * vi: ts=4 sw=4 expandtab
+ */

--- a/src/cmd/builtin/uptime.c
+++ b/src/cmd/builtin/uptime.c
@@ -219,8 +219,7 @@ static void append_count_if (char *buf,
         int n = strlen (buf);
         snprintf (buf + n,
                   len - n,
-                  "%s%d %s",
-                  n > 0 ? ",  " : "",
+                  ",  %d %s",
                   count,
                   name);
     }

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -181,6 +181,7 @@ TESTSCRIPTS = \
 	t2802-uri-cmd.t \
 	t2803-flux-pstree.t \
 	t2804-uptime-cmd.t \
+	t2805-startlog-cmd.t \
 	t2900-job-timelimits.t \
 	t3000-mpi-basic.t \
 	t3001-mpi-personalities.t \

--- a/t/t2805-startlog-cmd.t
+++ b/t/t2805-startlog-cmd.t
@@ -1,0 +1,64 @@
+#!/bin/sh
+
+test_description='Test flux startlog command'
+
+. $(dirname $0)/sharness.sh
+
+test_under_flux 2
+
+test_expect_success 'flux-startlog works on rank 0' '
+	flux startlog >startlog.out
+'
+test_expect_success 'there is one run interval' '
+	test $(wc -l <startlog.out) -eq 1
+'
+test_expect_success 'the entry shows the instance is still running' '
+	tail -1 startlog.out | grep running
+'
+test_expect_success 'flux-startlog --check --quiet works' '
+	flux startlog --check --quiet
+'
+test_expect_success 'flux-startlog works on rank 1' '
+	flux exec -r 1 flux startlog
+'
+test_expect_success 'flux-startlog posts start+finish to test eventlog' '
+	flux startlog --test-startlog-key=testlog --post-start-event &&
+	flux startlog --test-startlog-key=testlog --post-finish-event
+'
+test_expect_success 'one run interval is listed' '
+	flux startlog --test-startlog-key=testlog >testlog.out &&
+	test $(wc -l <testlog.out) -eq 1
+'
+test_expect_success 'it is not shown as running' '
+	test_must_fail grep running testlog.out
+'
+test_expect_success 'flux-startlog --check returns success on test eventlog' '
+	flux startlog --test-startlog-key=testlog --check
+'
+test_expect_success 'flux-startlog posts start to test eventlog' '
+	flux startlog --test-startlog-key=testlog --post-start-event
+'
+test_expect_success 'flux-startlog --check returns success on test eventlog' '
+	flux startlog --test-startlog-key=testlog --check
+'
+test_expect_success 'flux-startlog posts start to test eventlog' '
+	flux startlog --test-startlog-key=testlog --post-start-event
+'
+test_expect_success 'flux-startlog --check returns failure on test eventlog' '
+	test_must_fail flux startlog --test-startlog-key=testlog --check
+'
+test_expect_success 'append unknown version finish event to test eventlog' '
+	flux kvs eventlog append testlog finish "{\"version\":99}" &&
+	flux kvs eventlog get testlog | tail -1 | grep finish
+'
+test_expect_success 'flux-startlog --check ignores bogus finish event' '
+	test_must_fail flux startlog --test-startlog-key=testlog --check
+'
+test_expect_success 'flux-startlog --badopt fails' '
+	test_must_fail flux startlog --badopt
+'
+test_expect_success 'flux-startlog cannot post events on rank > 0' '
+	test_must_fail flux exec -r 1 flux startlog --post-start-event
+'
+
+test_done

--- a/t/t3202-instance-restart-testexec.t
+++ b/t/t3202-instance-restart-testexec.t
@@ -6,7 +6,7 @@ test_description='Test instance restart and still running jobs with testexec'
 test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
 . `dirname $0`/sharness.sh
 
-export FLUX_INSTANCE_RESTART=t
+export FLUX_DISABLE_JOB_CLEANUP=t
 
 test_expect_success 'run a testexec job in persistent instance (long run)' '
 	flux start -o,--setattr=content.backing-path=$(pwd)/content.sqlite \


### PR DESCRIPTION
This adds a  `flux-startlog` utility that operates on `admin.eventlog`.

The rc1 adds a `start` event to the eventlog, and rc3 adds a `finish` event.  If the last two events are both starts, then flux is restarting after a crash, since it means rc3 didn't execute.   In that case, run `flux queue stop` and `flux queue disable` (later in rc1) to avoid further damage.

The command provides a history of flux restarts similar to last(1):
```
$ sudo flux startlog
2022-02-23 19:08 - running (58s)
$ sudo systemctl restart flux
$ sudo flux startlog
2022-02-23 19:08 - 2022-02-23 19:10 (1.3m)
2022-02-23 19:10 - running (2.6s)
$ sudo kill -9 89249  # kill the broker
$ sudo systemctl start flux
$ sudo flux startlog
2022-02-23 19:08 - 2022-02-23 19:10 (1.3m)
2022-02-23 19:10 - crashed
2022-02-23 19:10 - running (21s)
$ flux uptime
 11:12:37 up 1.9m,  owner flux,  depth 0,  size 8,  4 offline
  submit disabled,  scheduler disabled
$ flux queue status
flux-queue: Job submission is disabled: Flux is in safe mode due to an incomplete shutdown.
flux-queue: Scheduling is disabled
```
Marking as WIP since feedback on the interface would be useful before drilling down on remaining test coverage.  Also, oops - I need to print time in the local timezone.

