### PR TITLE
job-exec: fix job hang after early IMP/shell exit

### DIFF
--- a/src/modules/job-exec/Makefile.am
+++ b/src/modules/job-exec/Makefile.am
@@ -9,6 +9,7 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
 	-I$(top_builddir)/src/common/libflux \
+	-I$(top_builddir)/src/common/libccan \
 	$(JANSSON_CFLAGS)
 
 fluxmod_LTLIBRARIES = \

--- a/src/modules/job-exec/bulk-exec.c
+++ b/src/modules/job-exec/bulk-exec.c
@@ -542,9 +542,9 @@ static void imp_kill_output (struct bulk_exec *kill,
 {
     int rank = flux_subprocess_rank (p);
     flux_log (kill->h, LOG_INFO,
-              "rank%d: flux-imp kill: %s: %s",
+              "%s (rank %d): imp kill: %s",
+              flux_get_hostbyrank (kill->h, rank),
               rank,
-              stream,
               data);
 }
 
@@ -561,9 +561,11 @@ static void imp_kill_error (struct bulk_exec *kill,
                             flux_subprocess_t *p,
                             void *arg)
 {
+    int rank = flux_subprocess_rank (p);
     flux_log_error (kill->h,
-                    "imp kill: rank=%d: failed",
-                    flux_subprocess_rank (p));
+                    "imp kill on %s (rank %d) failed",
+                    flux_get_hostbyrank (kill->h, rank),
+                    rank);
 }
 
 

--- a/src/modules/job-exec/bulk-exec.c
+++ b/src/modules/job-exec/bulk-exec.c
@@ -375,6 +375,7 @@ struct bulk_exec * bulk_exec_create (struct bulk_exec_ops *ops, void *arg)
     flux_subprocess_ops_t sp_ops = {
         .on_completion =   exec_complete_cb,
         .on_state_change = exec_state_cb,
+        .on_channel_out =  exec_output_cb,
         .on_stdout =       exec_output_cb,
         .on_stderr =       exec_output_cb,
     };

--- a/src/modules/job-exec/exec.c
+++ b/src/modules/job-exec/exec.c
@@ -43,6 +43,8 @@ static const char *flux_imp_path = NULL;
 
 struct exec_ctx {
     const char * mock_exception;   /* fake exception */
+    int barrier_enter_count;
+    int barrier_completion_count;
 };
 
 static void exec_ctx_destroy (struct exec_ctx *tc)
@@ -140,6 +142,23 @@ static void complete_cb (struct bulk_exec *exec, void *arg)
                             bulk_exec_rc (exec));
 }
 
+static int exec_barrier_enter (struct bulk_exec *exec)
+{
+    struct exec_ctx *ctx = bulk_exec_aux_get (exec, "ctx");
+    if (!ctx)
+        return -1;
+    if (++ctx->barrier_enter_count == bulk_exec_total (exec)) {
+        if (bulk_exec_write (exec,
+                             "FLUX_EXEC_PROTOCOL_FD",
+                             "exit=0\n",
+                             7) < 0)
+            return -1;
+        ctx->barrier_enter_count = 0;
+        ctx->barrier_completion_count++;
+    }
+    return 0;
+}
+
 static void output_cb (struct bulk_exec *exec, flux_subprocess_t *p,
                        const char *stream,
                        const char *data,
@@ -148,6 +167,16 @@ static void output_cb (struct bulk_exec *exec, flux_subprocess_t *p,
 {
     struct jobinfo *job = arg;
     const char *cmd = flux_cmd_arg (flux_subprocess_get_cmd (p), 0);
+
+    if (strcmp (stream, "FLUX_EXEC_PROTOCOL_FD") == 0) {
+        if (strcmp (data, "enter\n") == 0
+            && exec_barrier_enter (exec) < 0) {
+            jobinfo_fatal_error (job,
+                                 errno,
+                                 "Failed to handle barrier");
+        }
+        return;
+    }
     jobinfo_log_output (job,
                         flux_subprocess_rank (p),
                         basename (cmd),
@@ -191,9 +220,42 @@ static void error_cb (struct bulk_exec *exec, flux_subprocess_t *p, void *arg)
                              rank);
 }
 
+
+static void exit_cb (struct bulk_exec *exec,
+                     void *arg,
+                     const struct idset *ranks)
+{
+    struct jobinfo *job = arg;
+    struct exec_ctx *ctx = bulk_exec_aux_get (exec, "ctx");
+
+    if (bulk_exec_total (exec) > 1
+        && ctx->barrier_completion_count == 0) {
+        char *ids = idset_encode (ranks, IDSET_FLAG_RANGE);
+        char *hosts = flux_hostmap_lookup (job->h, ids, NULL);
+        jobinfo_fatal_error (job, 0,
+                             "%s (rank%s %s) terminated before first barrier",
+                              hosts ? hosts : "(unknown)",
+                              idset_count (ranks) ? "s" : "",
+                              ids ? ids : "(unknown)");
+        free (ids);
+        free (hosts);
+
+        /*  Terminate barrier with failed exit status.
+         *  This will allow any shells that do get to the barrier to exit
+         *   immediately, instead of waiting to be killed by exec system.
+         */
+        if (bulk_exec_write (exec,
+                             "FLUX_EXEC_PROTOCOL_FD",
+                             "exit=1\n",
+                             7) < 0)
+            flux_log_error (job->h,
+                            "Failed to write failed barrier exit status");
+    }
+}
+
 static struct bulk_exec_ops exec_ops = {
     .on_start =     start_cb,
-    .on_exit =      NULL,
+    .on_exit =      exit_cb,
     .on_complete =  complete_cb,
     .on_output =    output_cb,
     .on_error =     error_cb
@@ -253,6 +315,19 @@ static int exec_init (struct jobinfo *job)
     if (flux_cmd_setcwd (cmd, job_get_cwd (job)) < 0) {
         flux_log_error (job->h, "exec_init: flux_cmd_setcwd");
         goto err;
+    }
+
+    /*  If more than one shell is involved in this job, set up a channel
+     *   for exec system based barrier:
+     */
+    if (idset_count (ranks) > 1) {
+        if (flux_cmd_add_channel (cmd, "FLUX_EXEC_PROTOCOL_FD") < 0
+            || flux_cmd_setopt (cmd,
+                                "FLUX_EXEC_PROTOCOL_FD_LINE_BUFFER",
+                                "true") < 0) {
+            flux_log_error (job->h, "exec_init: flux_cmd_add_channel");
+            goto err;
+        }
     }
     if (bulk_exec_push_cmd (exec, ranks, cmd, 0) < 0) {
         flux_log_error (job->h, "exec_init: bulk_exec_push_cmd");

--- a/src/shell/internal.h
+++ b/src/shell/internal.h
@@ -24,6 +24,7 @@
 struct flux_shell {
     flux_jobid_t jobid;
     int broker_rank;
+    int protocol_fd;
 
     optparse_t *p;
     flux_t *h;

--- a/src/shell/shell.c
+++ b/src/shell/shell.c
@@ -30,6 +30,7 @@
 #include "src/common/libeventlog/eventlog.h"
 #include "src/common/libutil/log.h"
 #include "src/common/libutil/errno_safe.h"
+#include "src/common/libutil/fdutils.h"
 
 #include "internal.h"
 #include "builtins.h"
@@ -878,11 +879,38 @@ static const char *shell_conf_get (const char *name)
     return flux_conf_builtin_get (name, FLUX_CONF_AUTO);
 }
 
+static int get_protocol_fd (int *pfd)
+{
+    const char *s;
+
+    if ((s = getenv ("FLUX_EXEC_PROTOCOL_FD"))) {
+        char *endptr;
+        int fd;
+
+        errno = 0;
+        fd = strtol (s, &endptr, 10);
+        if (errno != 0 || *endptr != '\0') {
+            errno = EINVAL;
+            return -1;
+        }
+        if (fd_set_cloexec (fd) < 0)
+            return -1;
+        *pfd = fd;
+        return 0;
+    }
+    *pfd = -1;
+    return 0;
+}
+
 static void shell_initialize (flux_shell_t *shell)
 {
     const char *pluginpath = shell_conf_get ("shell_pluginpath");
 
     memset (shell, 0, sizeof (struct flux_shell));
+
+    if (get_protocol_fd (&shell->protocol_fd) < 0)
+        shell_die_errno (1, "Failed to parse FLUX_EXEC_PROTOCOL_FD");
+
     if (!(shell->completion_refs = zhashx_new ()))
         shell_die_errno (1, "zhashx_new");
     zhashx_set_destructor (shell->completion_refs, item_free);
@@ -1060,6 +1088,16 @@ static int shell_barrier (flux_shell_t *shell, const char *name)
 
     if (shell->standalone || shell->info->shell_size == 1)
         return 0; // NO-OP
+
+    if (shell->protocol_fd != -1) {
+        char buf [64];
+        dprintf (shell->protocol_fd, "enter\n");
+        if (read (shell->protocol_fd, buf, 7) < 0
+            || strcmp (buf, "exit=1\n") == 0)
+            exit (1);
+        return 0;
+    }
+
     id = shell->info->jobid;
     if (snprintf (fqname,
                   sizeof (fqname),
@@ -1076,6 +1114,7 @@ static int shell_barrier (flux_shell_t *shell, const char *name)
      */
     if (!(h = flux_clone (shell->h)))
         shell_die_errno (1, "flux_handle_clone");
+
 
     if (!(f = flux_barrier (h, fqname, shell->info->shell_size))) {
         shell_log_errno ("flux_barrier");

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -310,6 +310,7 @@ dist_check_SCRIPTS = \
 	job-attach/outputsleep.sh \
 	job-exec/dummy.sh \
 	job-exec/imp.sh \
+	job-exec/imp-fail.sh \
 	job-list/list-id.py \
 	job-list/list-rpc.py \
 	job-list/jobspec-permissive.jsonschema \

--- a/t/job-exec/dummy.sh
+++ b/t/job-exec/dummy.sh
@@ -76,7 +76,7 @@ get_job_shell_rank() {
         if [[ $r == $BROKER_RANK ]]; then
             JOB_SHELL_RANK=$r
             return 0
-	fi
+        fi
         ((i++))
     done
     die "My rank: $BROKER_RANK, not found in ranklist!"
@@ -104,11 +104,22 @@ get_traps() {
     fi
 }
 
+barrier() {
+    if [[ ${NNODES} -gt 1 && -n ${FLUX_EXEC_PROTOCOL_FD} ]]; then
+        echo enter >&${FLUX_EXEC_PROTOCOL_FD}
+        read -u ${FLUX_EXEC_PROTOCOL_FD} line
+        if [[ ${line##*=} -ne 0 ]]; then
+            exit ${line##*=}
+        fi
+    fi
+}
+
 #
 #  Gather remaining job information:
 #
 get_job_shell_rank
 get_nnodes
+barrier
 get_duration
 get_command
 get_traps

--- a/t/job-exec/imp-fail.sh
+++ b/t/job-exec/imp-fail.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+#
+#  Mock flux-imp that fails on broker rank 1
+#
+cmd=$1
+
+# Test requirement, make sure we change back to sharness trash directory,
+#  multiuser jobs do not cause IMP to chdir to cwd of job:
+cd $SHARNESS_TRASH_DIRECTORY
+
+case "$cmd" in
+    exec)
+        shift;
+        printf "test-imp: Going to fail on rank 1\n" >&2
+        if test $(flux getattr rank) = 1; then exit 0; fi
+        exec "$@" ;;
+    kill)
+        #  Note: kill must be implemented in test since job-exec
+        #  module will run `flux-imp kill PID`.
+        #
+        signal=$2;
+        pid=$3;
+        printf "test-imp: kill -$signal $pid\n" >&2
+        shift 3;
+        printf "test-imp: Kill pid $pid signal $signal\n" >&2
+        kill -$signal $pid ;;
+    *)
+        printf "test-imp: Fatal: Unknown cmd=$cmd\n" >&2; exit 1 ;;
+esac
+
+# vi: ts=4 sw=4 expandtab


### PR DESCRIPTION
This PR fixes an issue in job launch where an early exit of the IMP/shell (before the shell has connected to Flux) causes a job hang. The problem occurs because the exec system doesn't presently have any knowledge of the state of job launch, and it is not considered an exceptional condition if a shell exits with nonzero status (since this could just mean one or more tasks exited with the same). Therefore, no job exception is raised when this condition occurs.

This PR adds a new `FLUX_EXEC_PROTOCOL_FD` channel to the job-exec's execution of the IMP/shell. The channel is then used to replace the `flux_barrier(3)` used by the shell. This allows the exec system to know when the job shell has executed at least one barrier, and it can raise an exception if any job shell (or IMP for mulituser execution) exits before that first barrier.

In order to log hostnames instead of ranks in the exception message, the `flux overlay lookup` code to translate a set of ranks/hostnames into the reverse was abstracted into a new `flux_hostmap_lookup(3)` function. I'm actually now wondering if that should be a separate PR.