### PR TITLE
libflux: add flux_hostmap_lookup(3)

### DIFF
--- a/src/common/libflux/attr.c
+++ b/src/common/libflux/attr.c
@@ -17,6 +17,8 @@
 
 #include "src/common/libczmqcontainers/czmq_containers.h"
 #include "src/common/libhostlist/hostlist.h"
+#include "src/common/libidset/idset.h"
+#include "src/common/libutil/errprintf.h"
 
 #include "attr.h"
 #include "rpc.h"
@@ -188,24 +190,33 @@ int flux_get_rank (flux_t *h, uint32_t *rank)
     return 0;
 }
 
-const char *flux_get_hostbyrank (flux_t *h, uint32_t rank)
+static struct hostlist * get_hostlist (flux_t *h)
 {
     struct attr_cache *c;
+
+    if (!(c = get_attr_cache (h)))
+        return NULL;
+    if (!c->hostlist) {
+        const char *val;
+        if (!(val = flux_attr_get (h, "hostlist"))
+            || !(c->hostlist = hostlist_decode (val)))
+            return NULL;
+    }
+    return c->hostlist;
+}
+
+const char *flux_get_hostbyrank (flux_t *h, uint32_t rank)
+{
+    struct hostlist *hl;
     const char *result;
 
     if (rank == FLUX_NODEID_ANY)
         return "any";
     if (rank == FLUX_NODEID_UPSTREAM)
         return "upstream";
-    if (!(c = get_attr_cache (h)))
+    if (!(hl = get_hostlist (h)))
         goto error;
-    if (!c->hostlist) {
-        const char *val;
-        if (!(val = flux_attr_get (h, "hostlist"))
-            || !(c->hostlist = hostlist_decode (val)))
-            goto error;
-    }
-    if (!(result = hostlist_nth (c->hostlist, rank)))
+    if (!(result = hostlist_nth (hl, rank)))
         goto error;
     return result;
 error:
@@ -214,17 +225,93 @@ error:
 
 int flux_get_rankbyhost (flux_t *h, const char *host)
 {
-    struct attr_cache *c;
+    struct hostlist *hl;
 
-    if (!(c = get_attr_cache (h)))
+    if (!(hl = get_hostlist (h)))
         return -1;
-    if (!c->hostlist) {
-        const char *val;
-        if (!(val = flux_attr_get (h, "hostlist"))
-            || !(c->hostlist = hostlist_decode (val)))
-            return -1;
+    return hostlist_find (hl, host);
+}
+
+char *flux_hostmap_lookup (flux_t *h,
+                           const char *targets,
+                           flux_error_t *errp)
+{
+    struct hostlist *hostmap;
+    struct hostlist *hosts = NULL;
+    struct idset *ranks = NULL;
+    char *s = NULL;
+
+    if (!(hostmap = get_hostlist (h))) {
+        errprintf (errp, "%s", strerror (errno));
+        return NULL;
     }
-    return hostlist_find (c->hostlist, host);
+
+    if ((ranks = idset_decode (targets))) {
+        unsigned int rank;
+        if (!(hosts = hostlist_create ())) {
+            errprintf (errp, "Out of memory");
+            goto err;
+        }
+        rank = idset_first (ranks);
+        while (rank != IDSET_INVALID_ID) {
+            const char *host;
+            if (!(host = hostlist_nth (hostmap, rank))) {
+                errprintf (errp, "rank %u is not in host map", rank);
+                goto err;
+            }
+            if (hostlist_append (hosts, host) < 0) {
+                errprintf (errp,
+                           "failed appending host %s: %s",
+                           host,
+                           strerror (errno));
+                goto err;
+            }
+            rank = idset_next (ranks, rank);
+        }
+        if (!(s = hostlist_encode (hosts))) {
+            errprintf (errp,
+                       "hostlist_encode: %s",
+                       strerror (errno));
+            goto err;
+        }
+    }
+    else if ((hosts = hostlist_decode (targets))) {
+        const char *host;
+        int rank = 0;
+        if (!(ranks = idset_create (0, IDSET_FLAG_AUTOGROW))) {
+            errprintf (errp, "Out of memory");
+            goto err;
+        }
+        host = hostlist_first (hosts);
+        while (host) {
+            if ((rank = hostlist_find (hostmap, host)) < 0) {
+                errprintf (errp, "host %s not found in host map", host);
+                goto err;
+            }
+            if (idset_set (ranks, rank) < 0) {
+                errprintf (errp,
+                           "idset_set (rank=%d): %s",
+                           rank,
+                           strerror (errno));
+                goto err;
+            }
+            host = hostlist_next (hosts);
+        }
+        if (!(s = idset_encode (ranks, IDSET_FLAG_RANGE))) {
+            errprintf (errp,
+                       "error encoding idset: %s",
+                       strerror (errno));
+            goto err;
+        }
+    }
+    else {
+        errprintf (errp, "target must be a valid idset or hostlist");
+        goto err;
+    }
+err:
+    hostlist_destroy (hosts);
+    idset_destroy (ranks);
+    return s;
 }
 
 int flux_get_instance_starttime (flux_t *h, double *starttimep)

--- a/src/common/libflux/attr.h
+++ b/src/common/libflux/attr.h
@@ -72,6 +72,23 @@ const char *flux_get_hostbyrank (flux_t *h, uint32_t rank);
  */
 int flux_get_rankbyhost (flux_t *h, const char *host);
 
+/* Return a list/set of hosts/ranks in Hostlist/Idset form given 'targets'
+ * in Idset/Hostlist form. Caller must free returned value.
+ *
+ * Returns NULL on failure with error message in errp->text (if errp != NULL).
+ *
+ * NOTES:
+ *  - The source of the mapping is the rank-ordered broker 'hostlist' attribute.
+ *  - An Idset (RFC 22) is a set (unordered, no duplicates)
+ *  - A Hostlist (RFC 29) is a list (ordered, may be duplicates)
+ *  - If there are multiple ranks per host, this function can only map
+ *    hostnames to the first rank found on the host.
+ *
+ */
+char *flux_hostmap_lookup (flux_t *h,
+                           const char *targets,
+                           flux_error_t *errp);
+
 /* Look up the broker.starttime attribute on rank 0.
  * The instance uptime is flux_reactor_now() - starttime.
  * N.B. if the instance has been restarted, this value is the most


### PR DESCRIPTION
This PR abstracts the functionality provided by `flux overlay lookup` into a function `flux_hostmap_lookup(3)` exported from libflux-core for convenience.

The function can take either a set of ranks in Idset form or a set of hostnames in Hostlist form and will return the reverse as an allocated string.

I didn't add docs since there presently any for `flux_get_hostbyrank(3)` and `flux_get_rankbyhost(3)`, but I could if that is desired. (I'm guessing `flux_hostmap_lookup(3)` will be slightly less useful than the other two, but there is one use case in #4155, so it made sense to avoid the code duplication)