### PR TITLE
libflux/future: set missing errno in flux_future_wait_for() 

### DIFF
--- a/src/common/libflux/future.c
+++ b/src/common/libflux/future.c
@@ -480,8 +480,14 @@ int flux_future_wait_for (flux_future_t *f, double timeout)
             flux_dispatch_requeue (f->now->h);
         f->now->running = false;
     }
-    if (!future_is_ready (f))
+    if (!future_is_ready (f)) {
+        /* Typically this error should be "impossible", but can occur
+         * if the future does not get initialized properly to use the
+         * now reactor.
+         */
+        errno = EINVAL;
         return -1;
+    }
     return 0;
 }
 

--- a/src/common/libflux/test/future.c
+++ b/src/common/libflux/test/future.c
@@ -122,6 +122,11 @@ void test_simple (void)
     ok (!flux_future_is_ready (f),
         "flux_future_is_ready returns false");
     errno = 0;
+    ok (flux_future_wait_for (f, -1.0) < 0 && errno == EINVAL,
+        "flux_future_wait_for fails with EINVAL with timeout < 0");
+    ok (!flux_future_is_ready (f),
+        "flux_future_is_ready returns false");
+    errno = 0;
     const void *result = NULL;
     result_destroy_called = 0;
     result_destroy_arg = NULL;


### PR DESCRIPTION
Problem: When a negative timeout is passed to flux_future_wait_for()
and a future is not properly initialized to be tied to a localized
'now' reactor, flux_future_wait_for() can return -1 without setting
an errno.

Set errno of EINVAL when the above corner case occurs.  Add unit
test.

Fixes #4160