### PR TITLE
flux-config-archive(5): fix TOML example

### DIFF
--- a/doc/man5/flux-config-archive.rst
+++ b/doc/man5/flux-config-archive.rst
@@ -34,8 +34,8 @@ EXAMPLE
 
    [archive]
    dbpath = "/var/lib/flux/job-archive.sqlite"
-   period = 60
-   busytimeout = 50
+   period = "1m"
+   busytimeout = "50s"
 
 
 RESOURCES


### PR DESCRIPTION
Problem: the [archive] configuration example uses integer seconds where FSD is required.

Update example.

Fixes #4163