### PR TITLE
add flux-config get

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -25,6 +25,7 @@ MAN1_FILES_PRIMARY = \
 	man1/flux-getattr.1 \
 	man1/flux-dmesg.1 \
 	man1/flux-content.1 \
+	man1/flux-config.1 \
 	man1/flux-hwloc.1 \
 	man1/flux-proxy.1 \
 	man1/flux-cron.1 \

--- a/doc/man1/flux-config.rst
+++ b/doc/man1/flux-config.rst
@@ -1,0 +1,164 @@
+.. flux-help-description: Manage/query Flux configuration
+
+==============
+flux-config(1)
+==============
+
+
+SYNOPSIS
+========
+
+**flux** **config** **reload**
+
+**flux** **config** **get** [*OPTIONS*] [*NAME*]
+
+**flux** **config** **builtin** [*NAME*]
+
+
+DESCRIPTION
+===========
+
+``flux config reload`` tells :man1:`flux-broker` to reload its TOML
+configuration.  Further details of Flux configuration are described in
+:man5:`flux-config`, including some caveats on configuration updates.
+On Flux instances started with :linux:man1:`systemd`, ``systemctl reload flux``
+invokes this command.  This command is restricted to the instance owner.
+
+``flux config get`` queries the TOML configuration for a given Flux broker.
+if *NAME* is unspecified, it dumps the entire configuration object.  Otherwise,
+*NAME* is expected to be a period-delimited path name representing a TOML key.
+Return values are printed in string-encoded JSON form, except for string values,
+which are printed without quotes to simplify their use in shell scripts.
+This command is restricted to the instance owner.
+
+``flux config builtin`` prints compiled-in Flux configuration values.
+See BUILTIN VALUES below for a list of builtin
+configuration key names.  This command is available to all users.
+
+.. note::
+   ``flux config get`` and ``flux config builtin`` refer to disjoint key
+   namespaces.  Flux behavior is determined by a combination of these values,
+   :man7:`flux-broker-attributes`, and other factors.  This disjoint
+   configuration scheme is subject to change in future releases of Flux.
+
+.. note::
+   ``flux config builtin`` uses a heuristic to determine if :man1:`flux`
+   was run from the flux-core source tree, and substitutes source tree
+   specific values if found to be in tree.  This enables Flux testing without
+   requiring installation.
+
+
+GET SUBCOMMAND OPTIONS
+======================
+
+**-h, --help**
+   Display subcommand help.
+
+**-d, --default**\ =\ *VALUE*
+   Substitute *VALUE* if *NAME* is not set in the configuration, and exit
+   with a return code of zero.
+
+**-q, --quiet**
+   Suppress printing of errors if *NAME* is not set and *--default* was not
+   specified.  This may be convenient to avoid needing to redirect standard
+   error in a shell script.
+
+**-t, --type**\ =\ *TYPE*
+   Require that the value has the specified type, or exit with a nonzero exit
+   code.  Valid types are *string*, *integer*, *real*, *boolean*, *object*, and
+   *array*.  In addition, types of *fsd*, *fsd-integer*, and *fsd-real* ensure
+   that a value is a both a string and valid Flux Standard Duration.
+   *fsd* prints the value in its human-readable, string form. *fsd-integer*
+   and *fsd-real* print the value in integer and real seconds, respectively.
+
+
+BUILTIN VALUES
+==============
+
+The following configuration keys may be printed with ``flux config builtin``:
+
+**rc1_path**
+   The rc1 script path used by :man1:`flux-broker`, unless overridden by
+   the ``broker.rc1_path`` broker attribute.
+
+**rc3_path**
+   The rc3 script path used by :man1:`flux-broker`, unless overridden by
+   the ``broker.rc1_path`` broker attribute.
+
+**shell_path**
+   The path to the :man1:`flux-shell` executable used by the exec service.
+
+**shell_pluginpath**
+   The search path used by :man1:`flux-shell` to locate plugins, unless
+   overridden by setting the ``conf.shell_pluginpath`` broker attribute.
+
+**shell_initrc**
+   The initrc script path used by :man1:`flux-shell`, unless overridden by
+   setting the ``conf.shell_pluginpath`` broker attribute.
+
+**jobtap_pluginpath**
+   The search path used by the job manager to locate
+   :man7:`flux-jobtap-plugins`.
+
+**rundir**
+   The configured ``${runstatedir}/flux`` directory.
+
+**bindir**
+   The configured ``${libexecdir/flux/cmd`` directory.
+
+**lua_cpath_add**
+   Consulted by :man1:`flux` when setting the LUA_CPATH environment variable.
+
+**lua_path_add**
+   Consulted by :man1:`flux` when setting the LUA_PATH environment variable.
+
+**python_path**
+   Consulted by :man1:`flux` when setting the PYTHONPATH environment variable.
+
+**man_path**
+   Consulted by :man1:`flux` when setting the MANPATH environment variable.
+
+**exec_path**
+   Consulted by :man1:`flux` when setting the FLUX_EXEC_PATH environment
+   variable.
+
+**connector_path**
+   Consulted by :man1:`flux` when setting the FLUX_CONNECTOR_PATH environment
+   variable.
+
+**module_path**
+   Consulted by :man1:`flux` when setting the FLUX_MODULE_PATH environment
+   variable.
+
+**pmi_library_path**
+   Consulted by :man1:`flux` when setting the FLUX_PMI_LIBRARY_PATH environment
+   variable.
+
+**cmdhelp_pattern**
+   Used by :man1:`flux` to generate a list of common commands when run without
+   arguments.
+
+**no_docs_path**
+
+
+EXAMPLES
+========
+
+::
+
+   $ flux config get --type=fsd-integer tbon.tcp_user_timeout
+   60
+
+
+RESOURCES
+=========
+
+Flux: http://flux-framework.org
+
+RFC 23: Flux Standard Duration: https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/spec_23.html
+
+
+SEE ALSO
+========
+
+:man5:`flux-config`, :man1:`flux-getattr`

--- a/doc/man1/flux-uptime.rst
+++ b/doc/man1/flux-uptime.rst
@@ -14,7 +14,7 @@ SYNOPSIS
 DESCRIPTION
 ===========
 
-The ``flux-uptime`` displays the following information about the
+The ``flux-uptime`` command displays the following information about the
 current Flux instance, on one or two lines:
 
 - The current wall clock time.

--- a/doc/man1/index.rst
+++ b/doc/man1/index.rst
@@ -6,6 +6,7 @@ man1
    :maxdepth: 1
 
    flux-broker
+   flux-config
    flux-content
    flux-cron
    flux-dmesg

--- a/doc/manpages.py
+++ b/doc/manpages.py
@@ -18,6 +18,7 @@ author = 'This page is maintained by the Flux community.'
 # - Manual section
 man_pages = [
     ('man1/flux-broker', 'flux-broker', 'Flux message broker daemon', [author], 1),
+    ('man1/flux-config', 'flux-config', 'Manage/query Flux configuration', [author], 1),
     ('man1/flux-content', 'flux-content', 'access content service', [author], 1),
     ('man1/flux-cron', 'flux-cron', 'Cron-like utility for Flux', [author], 1),
     ('man1/flux-dmesg', 'flux-dmesg', 'access broker ring buffer', [author], 1),

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -604,3 +604,8 @@ pluginpath
 uptime
 startlog
 timestamps
+runstatedir
+libexecdir
+bindir
+cmdhelp
+MANPATH

--- a/src/cmd/builtin/config.c
+++ b/src/cmd/builtin/config.c
@@ -8,6 +8,10 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #include "builtin.h"
 
 static int internal_config_reload (optparse_t *p, int ac, char *av[])

--- a/src/cmd/builtin/config.c
+++ b/src/cmd/builtin/config.c
@@ -11,8 +11,147 @@
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
+#include <jansson.h>
+
+#include "src/common/libutil/jpath.h"
+#include "src/common/libutil/fsd.h"
 
 #include "builtin.h"
+
+typedef enum {
+    FSD_NONE,
+    FSD_INTEGER,
+    FSD_REAL,
+    FSD_STRING,
+} fsd_subtype_t;
+
+struct map {
+    const char *s;
+    json_type type;
+    fsd_subtype_t fsd_subtype;
+};
+
+static struct map typemap[] = {
+    { "object", JSON_OBJECT, FSD_NONE },
+    { "array", JSON_ARRAY, FSD_NONE },
+    { "string", JSON_STRING, FSD_NONE },
+    { "integer", JSON_INTEGER, FSD_NONE },
+    { "real", JSON_REAL, FSD_NONE },
+    { "boolean", JSON_TRUE, FSD_NONE }, // special case
+    { "any", JSON_NULL, FSD_NONE },     // special case
+    { "fsd", JSON_STRING, FSD_STRING },
+    { "fsd-integer", JSON_STRING, FSD_INTEGER },
+    { "fsd-real", JSON_STRING, FSD_REAL },
+};
+
+static int parse_json_type (const char *s,
+                            json_type *type,
+                            fsd_subtype_t *fsd_subtype)
+{
+    for (int i = 0; i < sizeof (typemap) / sizeof (typemap[0]); i++) {
+        if (!strcasecmp (s, typemap[i].s)) {
+            *type = typemap[i].type;
+            *fsd_subtype = typemap[i].fsd_subtype;
+            return 0;
+        }
+    }
+    return -1;
+}
+
+static void print_object (json_t *o)
+{
+    if (json_is_string (o))
+        printf ("%s\n", json_string_value (o));
+    else {
+        char *s;
+        if (!(s = json_dumps (o, JSON_COMPACT | JSON_ENCODE_ANY)))
+            log_msg_exit ("error encoding json object");
+        printf ("%s\n", s);
+        free (s);
+    }
+}
+
+static void print_config_item (json_t *o,
+                               const char *path,
+                               json_type want_type,
+                               fsd_subtype_t fsd_subtype,
+                               optparse_t *p)
+{
+    json_type type;
+    double t;
+
+    if (path) {
+        if (!(o = jpath_get (o, path))) {
+            if (errno == ENOENT) {
+                if (optparse_hasopt (p, "default")) {
+                    printf ("%s\n", optparse_get_str (p, "default", NULL));
+                    return;
+                }
+                if (optparse_hasopt (p, "quiet"))
+                    exit (1);
+                log_msg_exit ("%s is not set", path);
+            }
+            log_err_exit ("%s", path);
+        }
+    }
+    type = json_typeof (o);
+    if (want_type == JSON_NULL // any
+        || (want_type == JSON_TRUE && type == JSON_FALSE) // boolean
+        || (want_type == type && fsd_subtype == FSD_NONE)) {
+        print_object (o);
+    }
+    else if (want_type == type
+        && fsd_subtype != FSD_NONE
+        && fsd_parse_duration (json_string_value (o), &t) == 0) {
+        if (fsd_subtype == FSD_INTEGER)
+            printf ("%d\n", (int)t);
+        else if (fsd_subtype == FSD_REAL)
+            printf ("%f\n", t);
+        else
+            printf ("%s\n", json_string_value (o));
+    }
+    else
+        log_msg_exit ("%s does not have the requested type",
+                      path ? path : "value");
+}
+
+static int config_get (optparse_t *p, int ac, char *av[])
+{
+    int optindex = optparse_option_index (p);
+    flux_t *h;
+    flux_future_t *f = NULL;
+    json_t *o;
+    const char *path = NULL;
+    const char *typestr;
+    json_type type;
+    fsd_subtype_t fsd_subtype;
+
+    if (optindex < ac)
+        path = av[optindex++];
+    if (ac - optindex > 0) {
+        optparse_print_usage (p);
+        exit (1);
+    }
+    if (!(h = builtin_get_flux_handle (p)))
+        log_err_exit ("flux_open");
+    if (!(f = flux_rpc (h, "config.get", NULL, FLUX_NODEID_ANY, 0))
+        || flux_rpc_get_unpack (f, "o", &o) < 0)
+        log_msg_exit ("Error fetching config object: %s",
+                      future_strerror (f, errno));
+    typestr = optparse_get_str (p, "type", "any");
+    if (parse_json_type (typestr, &type, &fsd_subtype) < 0)
+        log_msg_exit ("Unknown type");
+
+    print_config_item (o,
+                       path,
+                       type,
+                       fsd_subtype,
+                       p);
+
+    flux_future_destroy (f);
+    flux_close (h);
+    return (0);
+}
 
 static int internal_config_reload (optparse_t *p, int ac, char *av[])
 {
@@ -43,13 +182,35 @@ int cmd_config (optparse_t *p, int ac, char *av[])
     return (0);
 }
 
+static struct optparse_option get_opts[] = {
+    { .name = "type", .key = 't', .has_arg = 1, .arginfo = "TYPE",
+      .usage = "Set expected type (any, string, integer, real, boolean"
+          ", object, array, fsd, fsd-integer, fsd-real)",
+    },
+    { .name = "quiet", .key = 'q', .has_arg = 0,
+      .usage = "Suppress printing of \"[key] is not set\" errors."
+    },
+    { .name = "default", .key = 'd', .has_arg = 1, .arginfo = "VAL",
+      .usage = "Use this value if config key is unset"
+    },
+    OPTPARSE_TABLE_END
+};
+
+
 static struct optparse_subcommand config_subcmds[] = {
     { "reload",
       "[OPTIONS]",
-      "Reload configuration from files",
+      "Reload broker configuration from files",
       internal_config_reload,
       0,
       NULL,
+    },
+    { "get",
+      "[--type=TYPE] [--quiet] [--default=VAL] [PATH]",
+      "Query broker configuration values",
+      config_get,
+      0,
+      get_opts,
     },
     OPTPARSE_SUBCMD_END
 };

--- a/src/cmd/builtin/config.c
+++ b/src/cmd/builtin/config.c
@@ -153,6 +153,24 @@ static int config_get (optparse_t *p, int ac, char *av[])
     return (0);
 }
 
+static int builtin_get (optparse_t *p, int ac, char *av[])
+{
+    int optindex = optparse_option_index (p);
+    const char *name;
+    const char *value;
+
+    if (optindex != ac - 1) {
+        optparse_print_usage (p);
+        exit (1);
+    }
+    name = av[optindex];
+    value = flux_conf_builtin_get (name, FLUX_CONF_AUTO);
+    if (!value)
+        log_msg_exit ("%s is invalid", name);
+    printf ("%s\n", value);
+    return (0);
+}
+
 static int internal_config_reload (optparse_t *p, int ac, char *av[])
 {
     flux_t *h;
@@ -211,6 +229,13 @@ static struct optparse_subcommand config_subcmds[] = {
       config_get,
       0,
       get_opts,
+    },
+    { "builtin",
+      "NAME",
+      "Print compiled-in Flux configuration values",
+      builtin_get,
+      0,
+      NULL,
     },
     OPTPARSE_SUBCMD_END
 };

--- a/src/cmd/builtin/config.c
+++ b/src/cmd/builtin/config.c
@@ -140,7 +140,7 @@ static int config_get (optparse_t *p, int ac, char *av[])
                       future_strerror (f, errno));
     typestr = optparse_get_str (p, "type", "any");
     if (parse_json_type (typestr, &type, &fsd_subtype) < 0)
-        log_msg_exit ("Unknown type");
+        log_msg_exit ("Unknown type: %s", typestr);
 
     print_config_item (o,
                        path,

--- a/src/cmd/builtin/content.c
+++ b/src/cmd/builtin/content.c
@@ -8,6 +8,9 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
 #include "builtin.h"
 
 #include <unistd.h>

--- a/src/cmd/builtin/dmesg.c
+++ b/src/cmd/builtin/dmesg.c
@@ -8,6 +8,9 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
 #include "builtin.h"
 #include <inttypes.h>
 

--- a/src/cmd/builtin/env.c
+++ b/src/cmd/builtin/env.c
@@ -8,6 +8,9 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
 #include <unistd.h>
 
 #include "builtin.h"

--- a/src/cmd/builtin/heaptrace.c
+++ b/src/cmd/builtin/heaptrace.c
@@ -8,6 +8,9 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
 #include "builtin.h"
 
 static int internal_heaptrace_start (optparse_t *p, int ac, char *av[])

--- a/src/cmd/builtin/help.c
+++ b/src/cmd/builtin/help.c
@@ -8,6 +8,9 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
 #include <stdlib.h>
 
 #include "src/common/libutil/setenvf.h"

--- a/src/cmd/builtin/hwloc.c
+++ b/src/cmd/builtin/hwloc.c
@@ -8,6 +8,9 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
 #include "builtin.h"
 
 #include <sys/types.h> /* WIFEXTED */

--- a/src/cmd/builtin/python.c
+++ b/src/cmd/builtin/python.c
@@ -8,6 +8,9 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
 #include <unistd.h>
 
 #include "builtin.h"

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -182,6 +182,7 @@ TESTSCRIPTS = \
 	t2803-flux-pstree.t \
 	t2804-uptime-cmd.t \
 	t2805-startlog-cmd.t \
+	t2806-config-cmd.t \
 	t2900-job-timelimits.t \
 	t3000-mpi-basic.t \
 	t3001-mpi-personalities.t \

--- a/t/t2806-config-cmd.t
+++ b/t/t2806-config-cmd.t
@@ -1,0 +1,137 @@
+#!/bin/sh
+
+test_description='Test flux config get'
+
+. $(dirname $0)/sharness.sh
+
+mkdir config
+cat <<EOF >config/config.toml
+[foo]
+a = 42
+b = "meep"
+c = "50s"
+d = 3.14
+e = false
+f = [ "fubar", "barfu" ]
+[foo.bar]
+a = true
+EOF
+
+test_under_flux 1 minimal -o,--config-path=$(pwd)/config
+
+test_expect_success 'flux-config with no args fails with message' '
+	test_must_fail flux config 2>noargs.out &&
+	grep "missing subcommand" noargs.out
+'
+test_expect_success 'flux-config get --help prints usage' '
+	flux config get --help 2>get_help.out &&
+	grep -i "query broker configuration values" get_help.out
+'
+test_expect_success HAVE_JQ 'flux-config dumps entire object' '
+	echo 42 >foo.a.exp &&
+	flux config get | jq -r .foo.a >foo.a.out &&
+	test_cmp foo.a.exp foo.a.out
+'
+test_expect_success HAVE_JQ 'flux-config get dumps table' '
+	flux config get foo | jq -r .a >foo.a2.out &&
+	test_cmp foo.a.exp foo.a2.out
+'
+test_expect_success 'flux-config get dumps integer table member' '
+	flux config get foo.a >foo.a3.out &&
+	test_cmp foo.a.exp foo.a3.out
+'
+test_expect_success 'flux-config get --type=integer dumps int table member' '
+	flux config get --type=integer foo.a >foo.a4.out &&
+	test_cmp foo.a.exp foo.a4.out
+'
+test_expect_success 'flux-config get --type=string dumps string table member' '
+	echo "meep" >foo.b.exp &&
+	flux config get --type=string foo.b >foo.b.out &&
+	test_cmp foo.b.exp foo.b.out
+'
+test_expect_success 'flux-config get --type=fsd dumps fsd table member' '
+	echo "50s" >foo.c.exp &&
+	flux config get --type=fsd foo.c >foo.c.out &&
+	test_cmp foo.c.exp foo.c.out
+'
+test_expect_success 'flux-config get --type=fsd-integer works' '
+	echo "50" >foo.c_fsd_int.exp &&
+	flux config get --type=fsd-integer foo.c >foo.c_fsd_int.out &&
+	test_cmp foo.c_fsd_int.exp foo.c_fsd_int.out
+'
+test_expect_success 'flux-config get --type=fsd-real works' '
+	echo "50.0" >foo.c_fsd_real.exp &&
+	flux config get --type=fsd-real foo.c | cut -c1-4 >foo.c_fsd_real.out &&
+	test_cmp foo.c_fsd_real.exp foo.c_fsd_real.out
+'
+test_expect_success 'flux-config get --type=fsd fails on non-fsd string' '
+	test_must_fail flux config get --type=fsd foo.b 2>badfsd.err &&
+	grep "does not have the requested type" badfsd.err
+'
+test_expect_success 'flux-config get --type=real dumps real table member' '
+	echo "3.14" >foo.d.exp &&
+	flux config get --type=real foo.d | cut -c1-4 >foo.d.out &&
+	test_cmp foo.d.exp foo.d.out
+'
+test_expect_success 'flux-config get --type=boolean dumps bool table member' '
+	echo "false" >foo.e.exp &&
+	flux config get --type=boolean foo.e >foo.e.out &&
+	test_cmp foo.d.exp foo.d.out
+'
+test_expect_success HAVE_JQ 'flux-config get --type=array dumps array' '
+	echo barfu >foo.f1.exp &&
+	flux config get --type=array foo.f | jq -r -e ".[1]" >foo.f1.out &&
+	test_cmp foo.f1.exp foo.f1.out
+'
+test_expect_success HAVE_JQ 'flux-config get --type=object dumps table' '
+	echo true >foo.bar.a.exp &&
+	flux config get --type=object foo.bar | jq -e ".a" >foo.bar.a.out &&
+	test_cmp foo.bar.a.exp foo.bar.a.out
+'
+test_expect_success 'flux-config get dumps subtable value' '
+	flux config get --type=boolean foo.bar.a >foo.bar.a2.out &&
+	test_cmp foo.bar.a.exp foo.bar.a2.out
+'
+test_expect_success 'flux-config get wrong --type fails' '
+	test_must_fail flux config get --type=string foo.a 2>foo.a.type.err &&
+	grep "does not have the requested type" foo.a.type.err
+'
+test_expect_success 'flux-config get unknown --type fails' '
+	test_must_fail flux config get --type=oops foo.a 2>unknown.err &&
+	grep "Unknown type: oops" unknown.err
+'
+test_expect_success 'flux-config get --default dumps integer table member' '
+	flux config get --default=2 foo.a >foo.a5.out &&
+	test_cmp foo.a.exp foo.a5.out
+'
+test_expect_success 'flux-config get fails on non-existent key' '
+	test_must_fail flux config get nokey 2>nokey.err &&
+	grep "is not set" nokey.err
+'
+test_expect_success 'flux-config get --default works on non-existent key' '
+	echo 42 >def.nokey.exp &&
+	flux config get --default=42 nokey >def.nokey.out &&
+	test_cmp def.nokey.exp def.nokey.out
+'
+
+test_expect_success 'flux-config reload works' '
+	rm -f config/config.toml &&
+	flux config reload
+'
+test_expect_success 'flux-config get returns empty object if no config' '
+	echo "{}" >empty.exp &&
+	flux config get >empty.out &&
+	test_cmp empty.exp empty.out
+'
+test_expect_success 'flux-config builtin requires key name' '
+	test_must_fail flux config builtin
+'
+test_expect_success 'flux-config builtin fails on unknown key' '
+	test_must_fail flux config builtin unknown 2>bi_unknown.err &&
+	grep "unknown is invalid" bi_unknown.err
+'
+test_expect_success 'flux-config builtin works on known key' '
+	flux config builtin rc1_path
+'
+
+test_done


### PR DESCRIPTION
Here's a new command and corresponding RPC:
```
$ flux config get -h
Usage: flux config get [--type=TYPE] [--quiet] [PATH]
Query broker configuration values
  -h, --help             Display this message.
  -t, --type=TYPE        Set expected type (any, string, int, real, boolean,
                         object, array, fsd, fsd-int, fsd-real)
  -q, --quiet            Suppress printing of "[key] is not set" errors.
```

Parking this as a WIP until I have a chance to write tests and man page.  Meanwhile, how's the usage look?  I was mainly intending to support usage from shell scripts like rc1.