### PR TITLE
flux-uptime: provide useful output for slow/stuck broker state

### DIFF
--- a/doc/man1/flux-uptime.rst
+++ b/doc/man1/flux-uptime.rst
@@ -19,9 +19,11 @@ current Flux instance, on one or two lines:
 
 - The current wall clock time.
 
+- The broker state.  See BROKER STATES.
+
 - The elapsed time the Flux instance has been running, in RFC 23 Flux Standard
-  Duration format.  This is derived from the ``broker.starttime`` attribute
-  on the rank 0 broker.
+  Duration format.  If the local broker is not in **run** state, the elapsed
+  time in the current state is reported instead.
 
 - The Flux instance owner.  On a system instance, this is probably the
   ``flux`` user.
@@ -42,6 +44,36 @@ current Flux instance, on one or two lines:
 - A notice if job submission is disabled.
 
 - A notice if scheduling is disabled.
+
+
+BROKER STATES
+=============
+
+join
+   The local broker is trying to connect to its overlay network parent,
+   or is waiting for the parent to complete initialization and reach
+   **quorum** state.
+
+init
+   The local broker is waiting for the ``rc1`` script to complete locally.
+
+quorum
+   All brokers are waiting for a configured set of brokers to reach **quorum**
+   state.  The default quorum set is all brokers.  A Flux system instance
+   typically defines the quorum set to only the rank 0 broker.
+
+run
+   Flux is fully up and running.
+
+cleanup
+   Cleanup scripts are executing.  This state appears on the rank 0 broker only.
+
+shutdown
+   The local broker is waiting for its overlay network children to finalize
+   and disconnect.
+
+finalize
+   The local broker is waiting for the ``rc3`` script to complete locally.
 
 
 RESOURCES

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -1558,6 +1558,9 @@ static bool allow_early_request (const flux_msg_t *msg)
     const struct flux_match match[] = {
         // state-machine.wait may be needed early by flux_reconnect(3) users
         { FLUX_MSGTYPE_REQUEST, FLUX_MATCHTAG_NONE, "state-machine.wait" },
+        // let state-machine.get and attr.get work for flux-uptime(1)
+        { FLUX_MSGTYPE_REQUEST, FLUX_MATCHTAG_NONE, "state-machine.get" },
+        { FLUX_MSGTYPE_REQUEST, FLUX_MATCHTAG_NONE, "attr.get" },
     };
     for (int i = 0; i < sizeof (match) / sizeof (match[0]); i++)
         if (flux_msg_cmp (msg, match[i]))

--- a/src/broker/state_machine.c
+++ b/src/broker/state_machine.c
@@ -873,6 +873,31 @@ static void overlay_monitor_cb (struct overlay *overlay,
     }
 }
 
+static void state_machine_get_cb (flux_t *h,
+                                  flux_msg_handler_t *mh,
+                                  const flux_msg_t *msg,
+                                  void *arg)
+{
+    struct state_machine *s = arg;
+    double duration = monotime_since (s->t_start) * 1E-3;
+
+    if (flux_request_decode (msg, NULL, NULL) < 0)
+        goto error;
+    if (flux_respond_pack (h,
+                           msg,
+                           "{s:s s:f}",
+                           "state", statestr (s->state),
+                           "duration", duration) < 0)
+        flux_log_error (h,
+                        "error responding to state-machine.get request");
+    return;
+error:
+    if (flux_respond_error (h, msg, errno, NULL) < 0) {
+        flux_log_error (h,
+                        "error responding to state-machine.get request");
+    }
+}
+
 /* If a disconnect is received for streaming monitor request,
  * drop the request.
  */
@@ -903,6 +928,11 @@ static const struct flux_msg_handler_spec htab[] = {
         "state-machine.disconnect",
         disconnect_cb,
         0
+    },
+    {    FLUX_MSGTYPE_REQUEST,
+        "state-machine.get",
+        state_machine_get_cb,
+        FLUX_ROLE_USER,
     },
     FLUX_MSGHANDLER_TABLE_END,
 };

--- a/src/broker/state_machine.c
+++ b/src/broker/state_machine.c
@@ -727,10 +727,10 @@ static void wait_update (flux_t *h,
  * broker is offline" errors.  This request is specifically excluded from that
  * error path.
  */
-static void wait_cb (flux_t *h,
-                     flux_msg_handler_t *mh,
-                     const flux_msg_t *msg,
-                     void *arg)
+static void state_machine_wait_cb (flux_t *h,
+                                   flux_msg_handler_t *mh,
+                                   const flux_msg_t *msg,
+                                   void *arg)
 {
     struct state_machine *s = arg;
 
@@ -771,10 +771,10 @@ static void monitor_update (flux_t *h,
     }
 }
 
-static void monitor_cb (flux_t *h,
-                        flux_msg_handler_t *mh,
-                        const flux_msg_t *msg,
-                        void *arg)
+static void state_machine_monitor_cb (flux_t *h,
+                                      flux_msg_handler_t *mh,
+                                      const flux_msg_t *msg,
+                                      void *arg)
 {
     struct state_machine *s = arg;
 
@@ -891,12 +891,12 @@ static void disconnect_cb (flux_t *h,
 static const struct flux_msg_handler_spec htab[] = {
     {    FLUX_MSGTYPE_REQUEST,
         "state-machine.monitor",
-        monitor_cb,
+        state_machine_monitor_cb,
         0
     },
     {   FLUX_MSGTYPE_REQUEST,
         "state-machine.wait",
-        wait_cb,
+        state_machine_wait_cb,
         FLUX_ROLE_USER
     },
     {   FLUX_MSGTYPE_REQUEST,

--- a/src/broker/state_machine.c
+++ b/src/broker/state_machine.c
@@ -889,9 +889,21 @@ static void disconnect_cb (flux_t *h,
 }
 
 static const struct flux_msg_handler_spec htab[] = {
-    { FLUX_MSGTYPE_REQUEST,  "state-machine.monitor", monitor_cb, 0 },
-    { FLUX_MSGTYPE_REQUEST,  "state-machine.wait", wait_cb, FLUX_ROLE_USER },
-    { FLUX_MSGTYPE_REQUEST,  "state-machine.disconnect", disconnect_cb, 0 },
+    {    FLUX_MSGTYPE_REQUEST,
+        "state-machine.monitor",
+        monitor_cb,
+        0
+    },
+    {   FLUX_MSGTYPE_REQUEST,
+        "state-machine.wait",
+        wait_cb,
+        FLUX_ROLE_USER
+    },
+    {   FLUX_MSGTYPE_REQUEST,
+        "state-machine.disconnect",
+        disconnect_cb,
+        0
+    },
     FLUX_MSGHANDLER_TABLE_END,
 };
 

--- a/t/t3302-system-offline.t
+++ b/t/t3302-system-offline.t
@@ -34,4 +34,11 @@ test_expect_success 'flux mini run on rank 2 fails with offline error' '
 	grep "broker is offline" online.err
 '
 
+test_expect_success 'flux uptime on rank 2 reports join state' '
+	bash -c \
+		"FLUX_URI=$(echo $FLUX_URI | sed s/local-0/local-2/) \
+			flux uptime" >uptime.out &&
+	grep join uptime.out
+'
+
 test_done


### PR DESCRIPTION
Problem: my system instance was taking a long time to get through `rc1`, but some tools fail in that state and others hang on rank 0.  I thought it might be useful for `flux-uptime` to report how long the broker has been in the current state if it's not in _run_ state.  Here's an example:
```
 garlick@picl0:~/proj/flux-conf$ flux uptime
 13:03:07 init 6.2s,  owner flux,  depth 0,  size 8
```
Meanwhile, a compute node reports:
```
 garlick@picl2:~$ flux jobs
flux-jobs: ERROR: [Errno 11] Upstream Flux broker is offline. Try again later.
 garlick@picl2:~$ flux uptime
 12:53:51 join 21m,  owner flux,  depth 0,  size 8
```
After rank 0 finally gets to run state, it looks like before, except it says _run_ instead of _up_:
```
 garlick@picl0:~/proj/flux-conf$ flux uptime
 13:06:21 run 3.3m,  owner flux,  depth 0,  size 8,  2 offline

I updated the flux-uptime(1) man page with a description of the broker states that might appear in the output, FWIW.