### PR TITLE
[WIP] libflux: support flux_watcher_is_actve()

### DIFF
--- a/src/common/libflux/reactor.c
+++ b/src/common/libflux/reactor.c
@@ -206,17 +206,28 @@ struct flux_watcher_ops * flux_watcher_get_ops (flux_watcher_t *w)
 void flux_watcher_start (flux_watcher_t *w)
 {
     if (w) {
-        if (w->ops->start)
+        if (w->ops->start) {
             w->ops->start (w);
+            w->is_active = true;
+        }
     }
 }
 
 void flux_watcher_stop (flux_watcher_t *w)
 {
     if (w) {
-        if (w->ops->stop)
+        if (w->ops->stop) {
             w->ops->stop (w);
+            w->is_active = false;
+        }
     }
+}
+
+bool flux_watcher_is_active (flux_watcher_t *w)
+{
+    if (w)
+        return w->is_active;
+    return false;
 }
 
 void flux_watcher_destroy (flux_watcher_t *w)

--- a/src/common/libflux/reactor.h
+++ b/src/common/libflux/reactor.h
@@ -80,6 +80,7 @@ typedef void (*flux_watcher_f)(flux_reactor_t *r, flux_watcher_t *w,
 
 void flux_watcher_start (flux_watcher_t *w);
 void flux_watcher_stop (flux_watcher_t *w);
+bool flux_watcher_is_active (flux_watcher_t *w);
 void flux_watcher_destroy (flux_watcher_t *w);
 double flux_watcher_next_wakeup (flux_watcher_t *w);
 

--- a/src/common/libflux/reactor_private.h
+++ b/src/common/libflux/reactor_private.h
@@ -30,6 +30,7 @@ struct flux_watcher {
     void *arg;
     struct flux_watcher_ops *ops;
     void *data;
+    bool is_active;
 };
 
 static inline int events_to_libev (int events)

--- a/src/common/libflux/test/reactor.c
+++ b/src/common/libflux/test/reactor.c
@@ -1336,6 +1336,45 @@ static void test_active_ref (flux_reactor_t *r)
     flux_watcher_destroy (w);
 }
 
+static void is_active_cb (flux_reactor_t *r,
+                          flux_watcher_t *w,
+                          int revents,
+                          void *arg)
+{
+    /* do nothing */
+}
+
+static void test_is_active (flux_reactor_t *r)
+{
+    flux_watcher_t *w;
+    bool ret;
+
+    ret = flux_watcher_is_active (NULL);
+    ok (ret == false,
+        "flux_watcher_is_active returns false in invalid input");
+
+    if (!(w = flux_idle_watcher_create (r, is_active_cb, NULL)))
+        BAIL_OUT ("flux_idle_watcher_create failed");
+
+    ret = flux_watcher_is_active (w);
+    ok (ret == false,
+        "flux_watcher_is_active returns false on just created watcher");
+
+    flux_watcher_start (w);
+
+    ret = flux_watcher_is_active (w);
+    ok (ret == true,
+        "flux_watcher_is_active returns true on started watcher");
+
+    flux_watcher_stop (w);
+
+    ret = flux_watcher_is_active (w);
+    ok (ret == false,
+        "flux_watcher_is_active returns false on just stopped watcher");
+
+    flux_watcher_destroy (w);
+}
+
 static void reactor_destroy_early (void)
 {
     flux_reactor_t *r;
@@ -1387,6 +1426,7 @@ int main (int argc, char *argv[])
     test_stat (reactor);
     test_active_ref (reactor);
     test_reactor_flags (reactor);
+    test_is_active (reactor);
 
     flux_reactor_destroy (reactor);
 


### PR DESCRIPTION
Problem: Presently there is no way to know if a watcher has
been started or stopped.  This can cause difficulty debugging
some situations in which watchers are regularly started / stopped.

Solution: Add a flux_watcher_is_active() function to determine the
start / stop state of a watcher.

Fixes #4156