### PR TITLE
build: ensure autogen.sh updates package version

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -6,6 +6,6 @@
 #
 echo "Running libtoolize --automake --copy ... "
 libtoolize --automake --copy || exit
-echo "Running autoreconf --verbose --install"
-autoreconf --verbose --install || exit
+echo "Running autoreconf --force --verbose --install"
+autoreconf --force --verbose --install || exit
 echo "Now run ./configure."


### PR DESCRIPTION
Problem: PACKAGE_VERSION is not updated to match "git describe"
in a development tree when autogen.sh is run.

The previous value is retained in the autom4te.cache directory,
even when configure is regenerated, which seems counterintuitive.

Add the --force option to autoreconf (as called from autogen.sh)
to ensure that nothing is cached from previous builds.