### PR TITLE
add assertions that rank, size, hostlist broker attributes are cacheable

### DIFF
--- a/src/broker/attr.c
+++ b/src/broker/attr.c
@@ -97,7 +97,8 @@ int attr_add (attr_t *attrs, const char *name, const char *val, int flags)
         errno = EEXIST;
         return -1;
     }
-    e = entry_create (name, val, flags);
+    if (!(e = entry_create (name, val, flags)))
+        return -1;
     zhash_update (attrs->hash, name, e);
     zhash_freefn (attrs->hash, name, entry_destroy);
     return 0;
@@ -121,7 +122,8 @@ int attr_add_active (attr_t *attrs, const char *name, int flags,
         if (set (name, e->val, arg) < 0)
             goto done;
     }
-    e = entry_create (name, NULL, flags);
+    if (!(e = entry_create (name, NULL, flags)))
+        goto done;
     e->set = set;
     e->get = get;
     e->arg = arg;

--- a/src/broker/boot_config.c
+++ b/src/broker/boot_config.c
@@ -256,8 +256,19 @@ int boot_config_attr (attr_t *attrs, json_t *hosts)
     char *val;
     int rv = -1;
 
-    if (!hosts || json_array_size (hosts) == 0)
+    if (!hosts || json_array_size (hosts) == 0) {
+        char hostname[MAXHOSTNAMELEN + 1];
+
+        if (gethostname (hostname, sizeof (hostname)) < 0
+            || attr_add (attrs,
+                         "hostlist",
+                         hostname,
+                         FLUX_ATTRFLAG_IMMUTABLE) < 0) {
+            log_err ("failed to set hostlist attribute to localhost");
+            goto error;
+        }
         return 0;
+    }
 
     if (!(hl = hostlist_create ()))
         goto error;

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -350,12 +350,21 @@ int main (int argc, char *argv[])
      */
     logbuf_initialize (ctx.h, ctx.rank, ctx.attrs);
 
-    /* Allow flux_get_rank() and flux_get_size() to work in the broker.
+    /* Allow flux_get_rank(), flux_get_size(), flux_get_hostybyrank(), etc.
+     * to work in the broker without causing a synchronous RPC to self that
+     * would deadlock.
      */
     if (attr_cache_immutables (ctx.attrs, ctx.h) < 0) {
         log_err ("error priming broker attribute cache");
         goto cleanup;
     }
+    int flags;
+    assert (attr_get (ctx.attrs, "rank", NULL, &flags) == 0
+            && (flags & FLUX_ATTRFLAG_IMMUTABLE));
+    assert (attr_get (ctx.attrs, "size", NULL, &flags) == 0
+            && (flags & FLUX_ATTRFLAG_IMMUTABLE));
+    assert (attr_get (ctx.attrs, "hostlist", NULL, &flags) == 0
+            && (flags & FLUX_ATTRFLAG_IMMUTABLE));
 
     if (!(ctx.groups = groups_create (&ctx))) {
         log_err ("groups_create");

--- a/src/broker/test/boot_config.c
+++ b/src/broker/test/boot_config.c
@@ -465,22 +465,24 @@ void test_attr (const char *dir)
     rc = boot_config_attr (attrs, NULL);
     ok (rc == 0,
         "boot_config_attr works NULL hosts");
-    errno = 0;
-    ok (attr_get (attrs, "hostlist", NULL, NULL) < 0
-        && errno == ENOENT,
-        "attr_get cannot find hostlist after NULL hosts");
+    ok (attr_get (attrs, "hostlist", NULL, NULL) == 0,
+        "attr_get finds hostlist after NULL hosts");
+    attr_destroy (attrs);
 
+    attrs = attr_create ();
+    if (!attrs)
+        BAIL_OUT ("attr_create failed");
     hosts = json_array ();
     if (hosts == NULL)
         BAIL_OUT ("cannot continue without empty hosts array");
     rc = boot_config_attr (attrs, hosts);
     ok (rc == 0,
         "boot_config_attr works empty hosts");
-    ok (attr_get (attrs, "hostlist", NULL, NULL) < 0
-        && errno == ENOENT,
-        "attr_get cannot find hostlist after hosts");
+    ok (attr_get (attrs, "hostlist", NULL, NULL) == 0,
+        "attr_get finds hostlist after empty hosts");
     json_decref (hosts);
     hosts = NULL;
+    attr_destroy (attrs);
 
     rc = boot_config_parse (cf, &conf, &hosts);
     ok (rc == 0,
@@ -488,6 +490,9 @@ void test_attr (const char *dir)
     if (hosts == NULL)
         BAIL_OUT ("cannot continue without hosts array");
 
+    attrs = attr_create ();
+    if (!attrs)
+        BAIL_OUT ("attr_create failed");
     rc = boot_config_attr (attrs, hosts);
     ok (rc == 0,
         "boot_config_attr works on input hosts");


### PR DESCRIPTION
Problem: rank, size, and hostlist are required to be in the `flux_t` handle attribute cache in the broker with the IMMUTABLE flag set, or deadlock could result in strange corners of the broker.

Add some assertions that will make this fail fast rather than hang, and a better comment.  Also, while puzzling about broker attributes, I found and fixed a couple of unchecked mallocs.

Thanks to @grondo for triggering this subtle footgun and wondering aloud about it, although I'm sure he enjoyed it so much that thanks will not be necessary.