### PR TITLE
resource: assign ranks in R provided by job-info based on hostlist attribute

### DIFF
--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -282,6 +282,7 @@ dist_check_SCRIPTS = \
 	issues/t3960-job-exec-ehostunreach.sh \
 	issues/t3906-job-exec-exception.sh \
 	issues/t3982-python-message-ref.py \
+	issues/t4182-resource-rerank.sh \
 	python/__init__.py \
 	python/subflux.py \
 	python/tap \

--- a/t/issues/t4182-resource-rerank.sh
+++ b/t/issues/t4182-resource-rerank.sh
@@ -1,0 +1,51 @@
+#!/bin/sh -e
+#
+#  Ensure resource module resets ranks of R to match hostlist attribute
+#
+# test-prereqs: HAVE_JQ
+
+cat <<EOF >t4182-test.sh
+#!/bin/bash -e
+
+R="\$((flux R encode -r 0 -c 0 -H foo0 && \
+     flux R encode -r 1 -c 0-1 -H foo1 && \
+     flux R encode -r 2-3 -c 0-3 -H 'foo[2-3]' \
+    ) | flux R append)"
+
+flux kvs put resource.R="\$R"
+flux kvs get resource.R
+
+flux module remove sched-simple
+flux module reload resource monitor-force-up noverify
+flux module load sched-simple
+
+flux dmesg | grep 'sched-simple.*ready'  | tail -1
+
+flux resource list
+
+#  ensure R rerank failure is ignored (i.e. job completes successfully)
+flux mini run -o per-resource.type=node -o cpu-affinity=off -n 11 \
+        flux start flux getattr hostlist
+
+#  ensure R is reranked based on hostlist attribute:
+flux mini run -o per-resource.type=node -o cpu-affinity=off -n 11 \
+        flux broker --setattr hostlist="foo[3,2,1,0]" \
+	sh -c 'flux kvs get resource.R' >t4182-test.out
+
+EOF
+
+flux start -o,-Shostlist=foo[0-3] --test-size=4 bash ./t4182-test.sh
+
+jq -S . <t4182-test.out
+
+NODELIST="$(jq -r .execution.nodelist[0] <t4182-test.out)"
+EXPECTED="foo[3,2,1,0]"
+
+if test "$NODELIST" = "$EXPECTED"; then
+	exit 0
+else
+	echo >&2 "Got $NODELIST, expected $EXPECTED"
+	exit 1
+fi
+
+

--- a/t/kvs/issue1876.c
+++ b/t/kvs/issue1876.c
@@ -28,7 +28,8 @@ int main (int argc, char *argv[])
     for (i = 0; i < 1000; i++) {
         flux_future_t *f;
 
-        log_msg ("loop=%d", i);
+        if (i % 100 == 0)
+            log_msg ("loop=%d", i);
 
         if (!(f = flux_kvs_lookup (h, NULL, FLUX_KVS_WATCH
                                    | FLUX_KVS_WAITCREATE, key)))

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -315,11 +315,6 @@ test_expect_success 'hostlist attr is set on size 1 instance' '
 test_expect_success 'hostlist attr is set on all ranks of size 4 instance' '
 	flux start ${ARGS} -s4 flux exec flux getattr hostlist
 '
-test_expect_success 'setting hostlist on command line fails' '
-	test_must_fail flux start ${ARGS} -o,-Shostlist=xxx 2>hostlist.err &&
-	grep "failed to set hostlist attribute" hostlist.err
-'
-
 test_expect_success 'flux start (singlton) cleans up rundir' '
 	flux start ${ARGS} \
 		flux getattr rundir >rundir_pmi.out &&


### PR DESCRIPTION
As discussed in #4182, the job shell may not assign ranks in an order that follows the parent instance rank ordering. This occurs when there is a heterogeneous allocation of cores (i.e. different numbers of cores per execution target). This behavior is a hold over from a different time, and there is probably an argument that the shell should not do this, but there is a slightly better argument that the `hostlist` attribute is the canonical mapping of hosts to ranks for an instance, and R should follow this mapping not its own. (also, providing this solution is much easier than changing the shell behavior for now).

This PR adds support for re-ranking R in the resource module when R is provided by the parent, as it already does when R is provided by a bootstrap configuration. The re-ranking is only attempted when the `hostlist` attribute exists (which it always should), and there are no duplicates in `hostlist` (i.e. we're not running multiple brokers per node). Also, if re-ranking fails, this is not an error, since this can occur in testing when using a fake R. However, the re-ranking should fix the issue described in #4182, since there will always be a valid `hostlist` when the shell reorders hosts during a job launch of a heterogeneous allocation.

For testing purposes, the ability to set a `hostlist` on the command line is also introduced in this PR, and the test simply runs a job with a re-ordered set of hosts and ensures that the `resource.R` attribute in the resulting instance was properly rank-ordered.