### PR TITLE
resource: restrict resource verification to cores/hostnames only

### DIFF
--- a/src/common/librlist/rlist.c
+++ b/src/common/librlist/rlist.c
@@ -211,6 +211,11 @@ struct rlist *rlist_copy_allocated (const struct rlist *orig)
     return rlist_copy_internal (orig, rnode_copy_alloc);
 }
 
+struct rlist *rlist_copy_cores (const struct rlist *orig)
+{
+    return rlist_copy_internal (orig, rnode_copy_cores);
+}
+
 struct rlist *rlist_copy_down (const struct rlist *orig)
 {
     struct rnode *n;
@@ -621,7 +626,6 @@ static char * rnode_child_dumps (struct rnode *rnode)
     }
     return s;
 }
-
 
 int rlist_verify (flux_error_t *errp,
                   const struct rlist *expected,

--- a/src/common/librlist/rlist.h
+++ b/src/common/librlist/rlist.h
@@ -63,6 +63,8 @@ struct rlist *rlist_copy_allocated (const struct rlist *orig);
 /*  Create a copy of rl including only the ranks in 'ranks' idset */
 struct rlist *rlist_copy_ranks (const struct rlist *rl, struct idset *ranks);
 
+struct rlist *rlist_copy_cores (const struct rlist *rl);
+
 /*  Delete ranks in idset 'ranks' from rlist 'rl'
  */
 int rlist_remove_ranks (struct rlist *rl, struct idset *ranks);

--- a/src/common/librlist/rnode.c
+++ b/src/common/librlist/rnode.c
@@ -354,6 +354,28 @@ fail:
     return NULL;
 }
 
+struct rnode *rnode_copy_cores (const struct rnode *orig)
+{
+    struct rnode *n = rnode_copy (orig);
+    if (n) {
+        const char *name;
+        zlistx_t *keys = zhashx_keys (n->children);
+        if (!keys)
+            goto error;
+        name = zlistx_first (keys);
+        while (name) {
+            if (strcmp (name, "core") != 0)
+                zhashx_delete (n->children, name);
+            name = zlistx_next (keys);
+        }
+        zlistx_destroy (&keys);
+        return n;
+    }
+error:
+    rnode_destroy (n);
+    return NULL;
+}
+
 struct rnode *rnode_copy_empty (const struct rnode *orig)
 {
     struct rnode *n = rnode_copy (orig);

--- a/src/common/librlist/rnode.h
+++ b/src/common/librlist/rnode.h
@@ -78,6 +78,9 @@ struct rnode *rnode_copy_avail (const struct rnode *n);
 /*  Copy only allocated resources from rnode 'n' */
 struct rnode *rnode_copy_alloc (const struct rnode *n);
 
+/*  Copy only all cores in rnode 'n' */
+struct rnode *rnode_copy_cores (const struct rnode *n);
+
 int rnode_add (struct rnode *orig, struct rnode *n);
 
 /*  Return an rnode object that is the set difference of 'b' from 'a'.

--- a/src/common/librlist/test/rnode.c
+++ b/src/common/librlist/test/rnode.c
@@ -178,6 +178,14 @@ void test_copy ()
         "rnode_count_type (gpu) == 2");
 
     rnode_destroy (b);
+    ok ((b = rnode_copy_cores (n)) != NULL,
+        "copy rnode (cores only)");
+    ok (rnode_count_type (b, "core") == 4,
+        "rnode_count_type (gpu) == 4");
+    ok (rnode_count_type (b, "gpu") == 0,
+        "rnode_count_type (gpu) == 0");
+
+    rnode_destroy (b);
     rnode_destroy (n);
 }
 


### PR DESCRIPTION
As a stopgap solution for #4181, drop the verification of "gpu" resources (actually any resource except "core") by the flux-core `resource` module in all cases. The `rlist_verify()` used by the resource module will still verify that rank:hostname mapping is correct.

This should allow explicit configuration of GPUs by sysadmins without additionally requiring the `resource.noverify` option, for which we do not have a good plan for propagation to child instances.

Additionally, verification of cores and hostnames has proven valuable lately in the detection of incorrect rank ordering, so it would be nice to keep that part of it for now.

If at some point in the future the system-installed default libhwloc can detect GPUs reliably, then GPU devices can be added back into the verification step. (But we aren't holding our breath)
