### PR TITLE
sched-simple: fix counting bug that can cause scheduler to fail after a restart

### DIFF
--- a/src/common/librlist/rlist.c
+++ b/src/common/librlist/rlist.c
@@ -1660,7 +1660,8 @@ static int rlist_alloc_rnode (struct rlist *rl, struct rnode *n)
     }
     if (rnode_alloc_idset (rnode, n->cores->avail) < 0)
         return -1;
-    rl->avail -= idset_count (n->cores->avail);
+    if (rnode->up)
+        rl->avail -= idset_count (n->cores->avail);
     return 0;
 }
 

--- a/src/common/librlist/test/rlist.c
+++ b/src/common/librlist/test/rlist.c
@@ -1549,6 +1549,38 @@ void test_hosts_to_ranks (void)
     }
 }
 
+void test_issue4184 ()
+{
+    char *R;
+    struct rlist *rl = NULL;
+    struct rlist *alloc = NULL;
+
+    if (!(R = R_create_num (4, 4))
+        || !(rl = rlist_from_R (R)))
+        BAIL_OUT ("issue4184: failed to create rlist");
+
+    free (R);
+    if (!(R = R_create_num (4, 4))
+        || !(alloc = rlist_from_R (R)))
+        BAIL_OUT ("issue4184: failed to create alloc rlist");
+
+    ok (rlist_mark_down (rl, "all") == 0,
+        "rlist_mark_down");
+
+    ok (rl->avail == 0,
+        "rlist avail = %d (expected 0)", rl->avail);
+
+    ok (rlist_set_allocated (rl, alloc) == 0,
+        "rlist_set_allocated");
+
+    ok (rl->avail == 0,
+        "rlist avail = %d (expected 0)", rl->avail);
+
+    rlist_destroy (alloc);
+    rlist_destroy (rl);
+    free (R);
+}
+
 int main (int ac, char *av[])
 {
     plan (NO_PLAN);
@@ -1573,6 +1605,7 @@ int main (int ac, char *av[])
     test_assign_hosts ();
     test_rerank ();
     test_hosts_to_ranks ();
+    test_issue4184 ();
 
     done_testing ();
 }

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -283,6 +283,7 @@ dist_check_SCRIPTS = \
 	issues/t3906-job-exec-exception.sh \
 	issues/t3982-python-message-ref.py \
 	issues/t4182-resource-rerank.sh \
+	issues/t4184-sched-simple-restart.sh \
 	python/__init__.py \
 	python/subflux.py \
 	python/tap \

--- a/t/issues/t4184-sched-simple-restart.sh
+++ b/t/issues/t4184-sched-simple-restart.sh
@@ -1,0 +1,46 @@
+#!/bin/bash -e
+
+cat <<-EOF >t4184.sh
+#!/bin/sh -e
+
+which flux
+
+NCORES=\$(flux resource list -s up -no {ncores})
+jobids=\$(flux mini submit --cc=0-1 -n \$NCORES sleep 600)
+id=\$(echo \$jobids | cut -d ' ' -f1)
+id2=\$(echo \$jobids | cut -d ' ' -f2)
+flux job wait-event \$id start
+
+flux resource drain 0
+
+flux module reload sched-simple
+
+flux resource list
+flux resource undrain 0
+
+echo "t4184: waiting for resources to be back up:"
+while test \$(flux resource list -s up -no {ncores}) -ne \$NCORES; do
+  sleep 0.25
+done
+
+echo "t4184: canceling \$id"
+flux job cancel \${id}
+
+echo "t4184: waiting for \$id to end"
+flux job wait-event \$id clean
+
+echo "t4184: waiting for \$id2 to start..."
+
+flux job wait-event -t 15 \$id2 start
+
+echo "t4184: canceling \$id2..."
+flux job cancel \$id2
+
+echo "t4184: waiting for \$id2 to end..."
+flux job wait-event -t 15 \$id2 clean
+
+EOF
+
+chmod +x t4184.sh
+
+flux start -s 1 ./t4184.sh


### PR DESCRIPTION
This fixes a counting bug in librlist where cores allocated from ranks that are down caused an underflow in count of available cores. This caused sched-simple to think there were less than zero cores available after a restart with running jobs, so no further jobs could be scheduled.