### PR TITLE
job-exec: fix more potential hangs after early shell failure

### DIFF
--- a/src/shell/shell.c
+++ b/src/shell/shell.c
@@ -1318,7 +1318,9 @@ int main (int argc, char *argv[])
             else if (errno == ENOENT)
                 ec = 127;
             shell_die (ec, "task %d: start failed: %s: %s",
-                       i, flux_cmd_arg (task->cmd, 0), strerror (errno));
+                       task->rank,
+                       flux_cmd_arg (task->cmd, 0),
+                       strerror (errno));
         }
 
         if (zlist_append (shell.tasks, task) < 0)

--- a/t/job-exec/dummy.sh
+++ b/t/job-exec/dummy.sh
@@ -104,6 +104,43 @@ get_traps() {
     fi
 }
 
+test_mock_failure() {
+    FAIL_MODE=$(json_get "$JOBSPEC" '.attributes.system.environment.FAIL_MODE')
+    case "$FAIL_MODE" in
+        before_barrier_entry)
+            #
+            #  Attempt to exit early from shell rank 1 *before* rank 0
+            #   enters the shell barrier. This is best effort since there
+            #   is not a good way to ensure a separate shell process has
+            #   reached the barrier.
+            #
+            echo "Got FAIL_MODE=$FAIL_MODE"
+            if test $JOB_SHELL_RANK -eq 0; then
+                sleep 1
+            elif test $JOB_SHELL_RANK -eq 1; then
+                echo >&2 "before_barrier: exiting early on job shell rank 1"
+                exit 1
+            fi
+            ;;
+        after_barrier_entry)
+            #
+            #  Similer to above, but try to ensure that rank 0 shell has
+            #   entered the barrier before rank 1 unexpectedly exits.
+            #   See caveats about best effort above.
+            #
+            echo "after_barrier_entry: rank=$JOB_SHELL_RANK"
+            if test $JOB_SHELL_RANK -eq 1; then
+                echo "after_barrier: exiting early on job shell rank 1"
+                sleep 1
+                echo "exiting"
+                exit 1
+            fi
+            ;;
+        *)
+            ;;
+    esac
+}
+
 barrier() {
     if [[ ${NNODES} -gt 1 && -n ${FLUX_EXEC_PROTOCOL_FD} ]]; then
         echo enter >&${FLUX_EXEC_PROTOCOL_FD}
@@ -124,8 +161,13 @@ get_duration
 get_command
 get_traps
 
+test_mock_failure
+barrier
+
 #
 #  Run specified COMMAND:
 #
 echo Running  "${COMMAND[@]}"
 eval "${COMMAND[@]}"
+
+# vi: ts=4 sw=4 expandtab

--- a/t/job-exec/dummy.sh
+++ b/t/job-exec/dummy.sh
@@ -74,7 +74,7 @@ get_job_shell_rank() {
     get_ranklist
     for r in "${RANKLIST[@]}"; do
         if [[ $r == $BROKER_RANK ]]; then
-            JOB_SHELL_RANK=$r
+            JOB_SHELL_RANK=$i
             return 0
         fi
         ((i++))

--- a/t/t2402-job-exec-dummy.t
+++ b/t/t2402-job-exec-dummy.t
@@ -94,4 +94,12 @@ test_expect_success 'job-exec: exception while starting terminates job' '
 		| flux job submit) &&
 	flux job wait-event -vt 5 $id clean
 '
+test_expect_success 'job-exec: failure after first barrier terminates job' '
+	for id in $(flux mini bulksubmit --env FAIL_MODE={} -N2 -n2 sleep 300 \
+		    ::: before_barrier_entry after_barrier_entry); do
+		echo checking on job $id &&
+		flux job wait-event -vt 600 $id clean &&
+		test_must_fail flux job status -v $id
+	done
+'
 test_done


### PR DESCRIPTION
As described in #4195 early exec failures _after_ the initial shell barrier may still cause job hangs since shells could block stuck at a barrier if for some reason an exception can't be raised, or even if signals can't be delivered due to a IMP bug or other issue.

Since the exec system knows that shells have exited during or before a barrier, we might as well have the module abort the barrier at the time, rather than waiting for "something else" to clean up the shells. This will result in a more timely job exit when everything is working correctly, and will also result in a proper cleanup when things are not working well (as was the case in #4195).