### PR TITLE
shell: add hostname to a couple key log messages

### DIFF
--- a/src/shell/internal.h
+++ b/src/shell/internal.h
@@ -14,6 +14,7 @@
 #include <flux/core.h>
 #include <flux/optparse.h>
 #include <flux/shell.h>
+#include <sys/param.h>
 
 #include "src/common/libutil/aux.h"
 #include "src/common/libczmqcontainers/czmq_containers.h"
@@ -24,6 +25,7 @@
 struct flux_shell {
     flux_jobid_t jobid;
     int broker_rank;
+    char hostname [MAXHOSTNAMELEN + 1];
     int protocol_fd;
 
     optparse_t *p;

--- a/src/shell/shell.c
+++ b/src/shell/shell.c
@@ -908,6 +908,9 @@ static void shell_initialize (flux_shell_t *shell)
 
     memset (shell, 0, sizeof (struct flux_shell));
 
+    if (gethostname (shell->hostname, sizeof (shell->hostname)) < 0)
+        shell_die_errno (1, "gethostname");
+
     if (get_protocol_fd (&shell->protocol_fd) < 0)
         shell_die_errno (1, "Failed to parse FLUX_EXEC_PROTOCOL_FD");
 

--- a/src/shell/shell.c
+++ b/src/shell/shell.c
@@ -1114,9 +1114,11 @@ static int shell_init (flux_shell_t *shell)
      */
     if (shell->info->jobspec->cwd) {
         if (chdir (shell->info->jobspec->cwd) < 0) {
-            shell_log_error ("Could not change dir to %s: %s. "
+            shell_log_error ("host %s: Could not change dir to %s: %s. "
                              "Going to /tmp instead",
-                             shell->info->jobspec->cwd, strerror (errno));
+                             shell->hostname,
+                             shell->info->jobspec->cwd,
+                             strerror (errno));
             if (chdir ("/tmp") < 0) {
                 shell_log_errno ("Could not change dir to /tmp");
                 return -1;
@@ -1320,8 +1322,9 @@ int main (int argc, char *argv[])
                 ec = 126;
             else if (errno == ENOENT)
                 ec = 127;
-            shell_die (ec, "task %d: start failed: %s: %s",
+            shell_die (ec, "task %d (host %s): start failed: %s: %s",
                        task->rank,
+                       shell.hostname,
                        flux_cmd_arg (task->cmd, 0),
                        strerror (errno));
         }

--- a/t/python/t0010-job.py
+++ b/t/python/t0010-job.py
@@ -511,7 +511,10 @@ class TestJob(unittest.TestCase):
         if y.exception.occurred:
             self.assertEqual(x.exception.type, y.exception.type)
             self.assertEqual(x.exception.severity, y.exception.severity)
-            self.assertEqual(x.exception.note, y.exception.note)
+            if y.exception.note:
+                self.assertRegexpMatches(x.exception.note, y.exception.note)
+            else:
+                self.assertEqual(x.exception.note, y.exception.note)
 
     def test_32_job_result(self):
         result = {}
@@ -589,7 +592,7 @@ class TestJob(unittest.TestCase):
                     "waitstatus": 32512,
                     "exception_occurred": True,
                     "exception_type": "exec",
-                    "exception_note": "task 0: start failed: nosuchprog: "
+                    "exception_note": "task 0.*: start failed: nosuchprog: "
                     "No such file or directory",
                     "exception_severity": 0,
                 }

--- a/t/t2608-job-shell-log.t
+++ b/t/t2608-job-shell-log.t
@@ -134,16 +134,16 @@ done
 
 test_expect_success 'flux-shell: missing command logs fatal error' '
 	test_expect_code 127 flux mini run nosuchcommand 2>missing.err &&
-	grep "flux-shell\[0\]: FATAL: task 0: start failed" missing.err &&
-	grep "job.exception type=exec severity=0 task 0: start failed" missing.err &&
+	grep "flux-shell\[0\]: FATAL: task 0.*: start failed" missing.err &&
+	grep "job.exception type=exec severity=0 task 0.*: start failed" missing.err &&
         grep "No such file or directory" missing.err
 '
 
 test_expect_success 'flux-shell: illegal command logs fatal error' '
 	mkdir adirectory &&
 	test_expect_code 126 flux mini run ./adirectory 2>illegal.err &&
-	grep "flux-shell\[0\]: FATAL: task 0: start failed" illegal.err &&
-	grep "job.exception type=exec severity=0 task 0: start failed" illegal.err &&
+	grep "flux-shell\[0\]: FATAL: task 0.*: start failed" illegal.err &&
+	grep "job.exception type=exec severity=0 task 0.*: start failed" illegal.err &&
 	grep "Permission denied" illegal.err
 '
 


### PR DESCRIPTION
This PR adds the hostname to the log message (and exception note) when a task fails to start (e.g. due to missing executable), or when the shell is unable to `chdir()` to the indicated `cwd` in jobspec.

It will be helpful to have hostnames associated with these errors readily available in the logs or exception note when only a subset of job shells encounter them. We don't go as far as adding the hostname to every error or log message, however, as the rank to hostname mapping is available after the fact for other, more rare errors.

We could eventually _optionally_ display hostnames instead of shell ranks from `flux job attach` by having the command fetch _R_ and use that to lookup the mapping when displaying log messages. That wasn't done for now since it doesn't seem like a critical enhancement at this time.