### PR TITLE
flux-resource: differentiate drained vs draining ranks

### DIFF
--- a/doc/man1/flux-resource.rst
+++ b/doc/man1/flux-resource.rst
@@ -34,6 +34,9 @@ A few notes on drained nodes:
 - When an instance is restarted, drained nodes remain drained.
 - The scheduler may determine that a job request is *feasible* if the total
   resource set, including drained nodes, would allow it to run.
+- In ``flux resource status`` and ``flux resource drain``, the drain state
+  of a node will be presented as "drained" if the node has no job allocations,
+  and "draining" if there are still jobs running on the node.
 
 Some further background on resource service operation may be found in the
 RESOURCE INVENTORY section below.
@@ -57,7 +60,9 @@ COMMANDS
    increase output verbosity.  *-n,--no-header* suppresses header from output.
    *-o,--format=FORMAT*, customizes output formatting (see below).
    *-s,--states=STATE,...* limits output to specified resource states, where
-   valid states are "online", "offline", "avail", "exclude", "drain", and "all".
+   valid states are "online", "offline", "avail", "exclude", "draining",
+   "drained", and "all". The special "drain" state is also supported, and
+   selects both draining and drained resources.
 
 **drain** [-f] [-u] [targets] [reason ...]
    If specified without arguments, list drained nodes.  The *targets* argument

--- a/t/flux-resource/status/drain.expected
+++ b/t/flux-resource/status/drain.expected
@@ -1,3 +1,3 @@
     STATUS NNODES RANKS           NODELIST
      avail      2 2-3             foo[3-4]
-     drain      2 0-1             foo[1-2]
+   drained      2 0-1             foo[1-2]

--- a/t/flux-resource/status/example.expected
+++ b/t/flux-resource/status/example.expected
@@ -2,4 +2,4 @@
      avail      2 2-3             foo[3-4]
    offline      1 1               foo2
    exclude      1 0               foo1
-     drain      2 0-1             foo[1-2]
+   drained      2 0-1             foo[1-2]

--- a/t/t2351-resource-status-input.t
+++ b/t/t2351-resource-status-input.t
@@ -67,8 +67,8 @@ test_expect_success 'flux-resource status: -vv displays REASON field' '
 	test_debug "echo verbose:; cat ${name}-vv.out" &&
 	test_must_fail grep REASON ${name}.out &&
 	grep REASON ${name}-vv.out &&
-	test $(grep -c drain ${name}.out) -eq 1 &&
-	test $(grep -c drain ${name}-vv.out) -eq 2
+	test $(grep -c drained  ${name}.out) -eq 1 &&
+	test $(grep -c drained ${name}-vv.out) -eq 2
 '
 
 test_expect_success 'flux-resource status: -o {reason} works w/out -vv' '


### PR DESCRIPTION
As described in #4185, `flux resource drain` and `flux resource status` do not differentiate between ranks that are drained and still have jobs allocated, vs ranks that are "idle" (and thus ready to be taken down for service).

This PR enhances `flux-resource` to fetch  the `sched.resource-status` RPC in addition to `resource.status` and uses the result to create an idset of "draining" ranks by taking the intersection of `drain` ranks with those the scheduler has allocated.

