### PR TITLE
systemd: set SyslogIdentifier to flux

### DIFF
--- a/etc/flux.service.in
+++ b/etc/flux.service.in
@@ -21,6 +21,7 @@ ExecStart=/bin/bash -c '\
   -Sbroker.quorum=0 \
   -Sbroker.quorum-timeout=none \
 '
+SyslogIdentifier=flux
 ExecReload=@X_BINDIR@/flux config reload
 Restart=always
 RestartSec=5s


### PR DESCRIPTION
Problem: Flux is started under "/bin/bash -c", leading to journal / log
entries being listed under the program "bash".  Example:

Feb 01 04:30:06 fluxorama bash[51]: broker.info[0]: start: none->join 0.0084658>
Feb 01 04:30:06 fluxorama bash[51]: broker.info[0]: parent-none: join->init 5.2>

Solution: Set the SyslogIdentifier to "flux-broker" so journal / log
entries are more obviously associated with the flux-broker.  Example
after the change:

Mar 10 05:02:52 fluxorama flux-broker[62]: broker.info[0]: start: none->join 0.>
Mar 10 05:02:52 fluxorama flux-broker[62]: broker.info[0]: parent-none: join->i>

Fixes #4084