### PR TITLE
add flux-dump and flux-restore

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -352,6 +352,7 @@ PKG_CHECK_MODULES([LZ4], [liblz4], [], [])
 PKG_CHECK_MODULES([SQLITE], [sqlite3], [], [])
 PKG_CHECK_MODULES([LIBUUID], [uuid], [], [])
 PKG_CHECK_MODULES([CURSES], [ncursesw], [], [])
+PKG_CHECK_MODULES([LIBARCHIVE], [libarchive], [], [])
 LX_FIND_MPI
 AM_CONDITIONAL([HAVE_MPI], [test "$have_C_mpi" = yes])
 AX_VALGRIND_H

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -36,6 +36,7 @@ MAN1_FILES_PRIMARY = \
 	man1/flux-version.1 \
 	man1/flux-jobs.1 \
 	man1/flux-pstree.1 \
+	man1/flux-restore.1 \
 	man1/flux-shell.1 \
 	man1/flux-top.1 \
 	man1/flux-jobtap.1 \

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -24,6 +24,7 @@ MAN1_FILES_PRIMARY = \
 	man1/flux-env.1 \
 	man1/flux-getattr.1 \
 	man1/flux-dmesg.1 \
+	man1/flux-dump.1 \
 	man1/flux-content.1 \
 	man1/flux-config.1 \
 	man1/flux-hwloc.1 \

--- a/doc/man1/flux-dump.rst
+++ b/doc/man1/flux-dump.rst
@@ -1,0 +1,124 @@
+.. flux-help-description: Dump kvs to portable archive format
+
+============
+flux-dump(1)
+============
+
+
+SYNOPSIS
+========
+
+**flux** **dump** [*OPTIONS*] *OUTFILE*
+
+
+DESCRIPTION
+===========
+
+The ``flux-dump`` command writes a snapshot of the Flux key value store
+to a file in a portable archive format.
+
+The snapshot is of the primary namespace of the current KVS root by default.
+If *--checkpoint* is specified, the snapshot is of the last KVS checkpoint
+written to the content backing store.
+
+The format of the archive and compression algorithm, if any, is determined
+by the output file name extension.  The supported formats and compression
+algorithms are a capability of :linux:man3:`libarchive`.  Some common
+extensions that are supported by modern versions of that library are:
+
+.tar
+   POSIX *ustar* format, compatible with :linux:man1:`tar`.
+
+.tgz, .tar.gz
+   POSIX *ustar* format, compressed with :linux:man1:`gzip`.
+
+.tar.bz2
+   POSIX *ustar* format, compressed with :linux:man1:`bzip2`.
+
+.tar.xz
+   POSIX *ustar* format, compressed with :linux:man1:`xz`.
+
+.zip
+   ZIP archive, compatible with :linux:man1:`unzip`.
+
+.cpio
+   POSIX CPIO format, compatible with :linux:man1:`cpio`.
+
+.iso
+   ISO9660 CD image
+
+The output filename may be *-* to indicate standard output.  In that case,
+uncompressed tar format is used.
+
+
+OPTIONS
+=======
+
+**-h, --help**
+   Summarize available options.
+
+**-v, --verbose**
+   List keys on stderr as they are dumped instead of a periodic count of
+   dumped keys.
+
+**-q, --quiet**
+   Don't show periodic count of dumped keys on stderr.
+
+**--checkpoint**
+   Generate snapshot from the latest checkpoint written to the content
+   backing store, instead of from the current KVS root.
+
+**--no-cache**
+   Bypass the broker content cache and interact directly with the backing
+   store.  This may be slightly faster, depending on how frequently the same
+   content blobs are referenced by multiple keys.
+
+
+OTHER NOTES
+===========
+
+KVS commits are atomic and propagate to the root of the namespace.  Because of
+this, when ``flux-dump`` archives a snapshot of a live system, it reflects one
+point in time, and does not include any changes committed while the dump is
+in progress.
+
+Since ``flux-dump`` generates the archive by interacting directly with the
+content store, the *--checkpoint* option may be used to dump the most recent
+state of the KVS when the KVS module is not loaded.
+
+Only regular values and symbolic links are dumped to the archive.  Directories
+are not dumped as independent objects, so empty directories are omitted from
+the archive.
+
+KVS symbolic links represent the optional namespace component in the target
+as a *NAME::* prefix.
+
+The KVS path separator is converted to the UNIX-compatible slash so that the
+archive can be unpacked into a file system if desired.
+
+The modification time of files in the archive is set to the time that
+``flux-dump`` is started if dumping the current KVS root, or to the timestamp
+of the checkpoint if *--checkpoint* is used.
+
+The owner and group of files in the archive are set to the credentials of the
+user that ran ``flux-dump``.
+
+The mode of files in the archive is set to 0644.
+
+
+RESOURCES
+=========
+
+Flux: http://flux-framework.org
+
+RFC 10: Content Storage Service: https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/spec_10.html
+
+RFC 11: Key Value Store Tree Object Format v1: https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/spec_11.html
+
+
+
+
+SEE ALSO
+========
+
+:man1:`flux-restore`, :man1:`flux-kvs`

--- a/doc/man1/flux-restore.rst
+++ b/doc/man1/flux-restore.rst
@@ -1,0 +1,72 @@
+.. flux-help-description: Restore kvs from portable archive format
+
+===============
+flux-restore(1)
+===============
+
+
+SYNOPSIS
+========
+
+**flux** **restore** [*OPTIONS*] *INFILE*
+
+
+DESCRIPTION
+===========
+
+The ``flux-restore`` command reads a KVS snapshot from a portable archive
+format, usually written by :man1:`flux-dump`.
+
+The archive source may be specified as a file path or *-* for standard input.
+The format of the archive may be any of the formats supported by
+:linux:man3:`libarchive` and is determined on the fly based on the archive
+content.
+
+The snapshot may be restored to a KVS key if *--key=NAME* is used and the
+KVS service is running, or as a checkpoint in the content backing store
+if *--checkpoint* is used, without the KVS running.  One of those two options
+is required.
+
+
+OPTIONS
+=======
+
+**-h, --help**
+   Summarize available options.
+
+**-v, --verbose**
+   List keys on stderr as they are restored instead of a periodic count of
+   restored keys.
+
+**-q, --quiet**
+   Don't show a periodic count of restored keys on stderr.
+
+**--checkpoint**
+   After restoring the archived content, write the final root blobref
+   to the KVS checkpoint area in the content backing store.  The checkpoint
+   is used as the initial KVS root when the KVS module is loaded.  Unload
+   the KVS module before restoring with this option.
+
+**--key**\ =\ *NAME*
+   After restoring the archived content, write the final root blobref
+   to a KVS key, so the key becomes the restored root directory.
+
+**--no-cache**
+   Bypass the broker content cache and interact directly with the backing
+   store.  Performance will vary depending on the content of the archive.
+
+
+RESOURCES
+=========
+
+Flux: http://flux-framework.org
+
+RFC 10: Content Storage Service: https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/spec_10.html
+
+RFC 11: Key Value Store Tree Object Format v1: https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/spec_11.html
+
+
+SEE ALSO
+========
+
+:man1:`flux-dump`, :man1:`flux-kvs`

--- a/doc/man1/index.rst
+++ b/doc/man1/index.rst
@@ -10,6 +10,7 @@ man1
    flux-content
    flux-cron
    flux-dmesg
+   flux-dump
    flux-env
    flux-event
    flux-exec

--- a/doc/man1/index.rst
+++ b/doc/man1/index.rst
@@ -28,6 +28,7 @@ man1
    flux-proxy
    flux-pstree
    flux-resource
+   flux-restore
    flux-start
    flux-startlog
    flux-shell

--- a/doc/manpages.py
+++ b/doc/manpages.py
@@ -22,6 +22,7 @@ man_pages = [
     ('man1/flux-content', 'flux-content', 'access content service', [author], 1),
     ('man1/flux-cron', 'flux-cron', 'Cron-like utility for Flux', [author], 1),
     ('man1/flux-dmesg', 'flux-dmesg', 'access broker ring buffer', [author], 1),
+    ('man1/flux-dump', 'flux-dump', 'Dump kvs to portable archive format', [author], 1),
     ('man1/flux-env', 'flux-env', 'Print the flux environment or execute a command inside it', [author], 1),
     ('man1/flux-event', 'flux-event', 'Send and receive Flux events', [author], 1),
     ('man1/flux-exec', 'flux-exec', 'Execute processes across flux ranks', [author], 1),

--- a/doc/manpages.py
+++ b/doc/manpages.py
@@ -36,6 +36,7 @@ man_pages = [
     ('man1/flux-uptime', 'flux-uptime', 'Tell how long Flux has been up and running', [author], 1),
     ('man1/flux-uri', 'flux-uri', 'resolve Flux URIs', [author], 1),
     ('man1/flux-resource', 'flux-resource', 'list/manipulate Flux resource status', [author], 1),
+    ('man1/flux-restore', 'flux-restore', 'Restore portable archive dump to KVS', [author], 1),
     ('man1/flux-keygen', 'flux-keygen', 'generate keys for Flux security', [author], 1),
     ('man1/flux-kvs', 'flux-kvs', 'Flux key-value store utility', [author], 1),
     ('man1/flux-logger', 'flux-logger', 'create a Flux log entry', [author], 1),

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -616,6 +616,7 @@ cpio
 gzip
 libarchive
 OUTFILE
+INFILE
 POSIX
 ustar
 xz

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -611,3 +611,11 @@ cmdhelp
 MANPATH
 bargraph
 emoji
+bzip
+cpio
+gzip
+libarchive
+OUTFILE
+POSIX
+ustar
+xz

--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -59,7 +59,8 @@ flux_SOURCES = \
 	builtin/python.c \
 	builtin/uptime.c \
 	builtin/startlog.c \
-	builtin/dump.c
+	builtin/dump.c \
+	builtin/restore.c
 nodist_flux_SOURCES = \
 	builtin-cmds.c
 

--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -58,7 +58,8 @@ flux_SOURCES = \
 	builtin/relay.c \
 	builtin/python.c \
 	builtin/uptime.c \
-	builtin/startlog.c
+	builtin/startlog.c \
+	builtin/dump.c
 nodist_flux_SOURCES = \
 	builtin-cmds.c
 

--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -14,7 +14,8 @@ AM_CPPFLAGS = \
 	$(FLUX_SECURITY_CFLAGS) \
 	$(HWLOC_CFLAGS) \
 	$(PMIX_CFLAGS) \
-	$(JANSSON_CFLAGS)
+	$(JANSSON_CFLAGS) \
+	$(LIBARCHIVE_CFLAGS)
 
 fluxcmd_ldadd = \
 	$(top_builddir)/src/common/libkvs/libkvs.la \
@@ -25,7 +26,8 @@ fluxcmd_ldadd = \
 	$(FLUX_SECURITY_LIBS) \
 	$(LIBPTHREAD) \
 	$(HWLOC_LIBS) \
-	$(JANSSON_LIBS)
+	$(JANSSON_LIBS) \
+	$(LIBARCHIVE_LIBS)
 
 LDADD = $(fluxcmd_ldadd)
 

--- a/src/cmd/builtin/dump.c
+++ b/src/cmd/builtin/dump.c
@@ -1,0 +1,430 @@
+/************************************************************\
+ * Copyright 2022 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+# include <config.h>
+#endif
+#include <unistd.h>
+#include <stdarg.h>
+#include <jansson.h>
+#include <time.h>
+#include <archive.h>
+#include <archive_entry.h>
+
+#include "src/common/libeventlog/eventlog.h"
+#include "src/common/libkvs/treeobj.h"
+#include "src/common/libkvs/kvs_checkpoint.h"
+#include "src/common/libutil/fsd.h"
+#include "src/common/libutil/blobref.h"
+
+#include "builtin.h"
+
+static void dump_treeobj (struct archive *ar,
+                          flux_t *h,
+                          const char *path,
+                          json_t *treeobj);
+
+static bool verbose;
+static bool quiet;
+static int content_flags;
+static time_t dump_time;
+static gid_t dump_gid;
+static uid_t dump_uid;
+static int keycount;
+
+static void progress (int delta_keys)
+{
+    keycount += delta_keys;
+
+    if (!verbose
+        && !quiet
+        && (keycount % 100 == 0 || keycount < 10))
+        fprintf (stderr, "\rflux-dump: archived %d keys", keycount);
+}
+
+static void progress_end (void)
+{
+    if (!quiet && !verbose)
+        fprintf (stderr, "\rflux-dump: archived %d keys\n", keycount);
+}
+
+static struct archive *dump_create (const char *outfile)
+{
+    struct archive *ar;
+
+    if (!(ar = archive_write_new ()))
+        log_msg_exit ("error creating libarchive write context");
+    if (!strcmp (outfile, "-")) {
+        if (archive_write_set_format_pax_restricted (ar) != ARCHIVE_OK
+            || archive_write_open_FILE (ar, stdout) != ARCHIVE_OK)
+            log_msg_exit ("%s", archive_error_string (ar));
+    }
+    else {
+#if ARCHIVE_VERSION_NUMBER < 3002000
+        /* El7 has libarchive 3.1.2 (circa 2013), but
+         * archive_write_set_format_filter_by_ext() appeared in 3.2.0.
+         * Just force tar format / no compression on that platform.
+         */
+        if (archive_write_set_format_pax_restricted (ar) != ARCHIVE_OK
+#else
+        if (archive_write_set_format_filter_by_ext (ar, outfile) != ARCHIVE_OK
+#endif
+            || archive_write_open_filename (ar, outfile) != ARCHIVE_OK)
+            log_msg_exit ("%s", archive_error_string (ar));
+    }
+    return ar;
+}
+
+static void dump_destroy (struct archive *ar)
+{
+    if (archive_write_close (ar) != ARCHIVE_OK)
+        log_msg_exit ("%s", archive_error_string (ar));
+    archive_write_free (ar);
+}
+
+/* From archive_write_data(3):
+ *   Clients should treat any value less than zero as an error and consider
+ *   any non-negative value as success.
+ */
+static void dump_write_data (struct archive *ar, const void *data, int size)
+{
+    int n;
+
+    n = archive_write_data (ar, data, size);
+    if (n < 0)
+        log_msg_exit ("%s", archive_error_string (ar));
+    if (n != size)
+        log_msg ("short write to archive: %s",
+                 "assuming non-fatal libarchive write size reporting error");
+}
+
+static void dump_valref (struct archive *ar,
+                         flux_t *h,
+                         const char *path,
+                         json_t *treeobj)
+{
+    int count = treeobj_get_count (treeobj);
+    struct flux_msglist *l;
+    const flux_msg_t *msg;
+    int total_size = 0;
+    struct archive_entry *entry;
+    const void *data;
+    int len;
+
+    /* We need the total size before we start writing archive data,
+     * so make a first pass, saving the data for writing later.
+     */
+    /* N.B. first attempt was to save the futures in an array, but ran into:
+     *   flux: ev_epoll.c:134: epoll_modify: Assertion `("libev: I/O watcher
+     *    with invalid fd found in epoll_ctl", errno != EBADF && errno != ELOOP
+     *    && errno != EINVAL)' failed.
+     * while archiving a resource.eventlog with 781 entries.  Instead of
+     * retaining the futures for a second pass, just retain references to the
+     * content.load response messages.
+     */
+    if (!(l = flux_msglist_create ()))
+        log_err_exit ("could not create message list");
+    for (int i = 0; i < count; i++) {
+        flux_future_t *f;
+        if (!(f = flux_content_load (h,
+                                     treeobj_get_blobref (treeobj, i),
+                                     content_flags))
+            || flux_future_get (f, (const void **)&msg) < 0
+            || flux_msg_get_payload (msg, &data, &len) < 0) {
+            log_msg_exit ("%s: missing blobref %d: %s",
+                          path,
+                          i,
+                          future_strerror (f, errno));
+        }
+        if (flux_msglist_append (l, msg) < 0)
+            log_err_exit ("could not stash load response message");
+        total_size += len;
+        flux_future_destroy (f);
+    }
+    if (!(entry = archive_entry_new ()))
+        log_msg_exit ("error creating archive entry");
+    archive_entry_set_pathname (entry, path);
+    archive_entry_set_size (entry, total_size);
+    archive_entry_set_perm (entry, 0644);
+    archive_entry_set_filetype (entry, AE_IFREG);
+    archive_entry_set_mtime (entry, dump_time, 0);
+    archive_entry_set_uid (entry, dump_uid);
+    archive_entry_set_gid (entry, dump_gid);
+
+    if (archive_write_header (ar, entry) != ARCHIVE_OK)
+        log_msg_exit ("%s", archive_error_string (ar));
+    while ((msg = flux_msglist_pop (l))) {
+        if (flux_msg_get_payload (msg, &data, &len) < 0)
+            log_msg_exit ("error processing stashed valref responses");
+        dump_write_data (ar, data, len);
+        flux_msg_decref (msg);
+    }
+    archive_entry_free (entry);
+    progress (1);
+    flux_msglist_destroy (l);
+}
+
+static void dump_val (struct archive *ar,
+                      flux_t *h,
+                      const char *path,
+                      json_t *treeobj)
+{
+    struct archive_entry *entry;
+    void *data;
+    int len;
+
+    if (treeobj_decode_val (treeobj, &data, &len) < 0)
+        log_err_exit ("%s: invalid value object", path);
+    if (!(entry = archive_entry_new ()))
+        log_msg_exit ("error creating archive entry");
+    archive_entry_set_pathname (entry, path);
+    archive_entry_set_size (entry, len);
+    archive_entry_set_perm (entry, 0644);
+    archive_entry_set_filetype (entry, AE_IFREG);
+
+    if (archive_write_header (ar, entry) != ARCHIVE_OK)
+        log_msg_exit ("%s", archive_error_string (ar));
+    dump_write_data (ar, data, len);
+    progress (1);
+
+    archive_entry_free (entry);
+    free (data);
+}
+
+static void dump_symlink (struct archive *ar,
+                          flux_t *h,
+                          const char *path,
+                          json_t *treeobj)
+{
+    struct archive_entry *entry;
+    const char *ns;
+    const char *target;
+    char *target_with_ns = NULL;
+
+    if (treeobj_get_symlink (treeobj, &ns, &target) < 0)
+        log_err_exit ("%s: invalid symlink object", path);
+    if (ns) {
+        if (asprintf (&target_with_ns, "%s::%s", ns, target) < 0)
+            log_msg_exit ("out of memory");
+        target = target_with_ns;
+    }
+    if (!(entry = archive_entry_new ()))
+        log_msg_exit ("error creating archive entry");
+    archive_entry_set_pathname (entry, path);
+    archive_entry_set_perm (entry, 0644);
+    archive_entry_set_filetype (entry, AE_IFLNK);
+    archive_entry_set_symlink (entry, target);
+    if (archive_write_header (ar, entry) != ARCHIVE_OK)
+        log_msg_exit ("%s", archive_error_string (ar));
+    progress (1);
+
+    free (target_with_ns);
+    archive_entry_free (entry);
+}
+
+static void dump_dir (struct archive *ar,
+                      flux_t *h,
+                      const char *path,
+                      json_t *treeobj)
+{
+    json_t *dict = treeobj_get_data (treeobj);
+    const char *name;
+    json_t *entry;
+
+    json_object_foreach (dict, name, entry) {
+        char *newpath;
+        if (asprintf (&newpath, "%s/%s", path, name) < 0)
+            log_msg_exit ("out of memory");
+        dump_treeobj (ar, h, newpath, entry); // recurse
+        free (newpath);
+    }
+}
+
+static void dump_dirref (struct archive *ar,
+                         flux_t *h,
+                         const char *path,
+                         json_t *treeobj)
+{
+    flux_future_t *f;
+    const void *buf;
+    int buflen;
+    json_t *treeobj_deref = NULL;
+
+    if (treeobj_get_count (treeobj) != 1)
+        log_msg_exit ("%s: blobref count is not 1", path);
+    if (!(f = flux_content_load (h,
+                                 treeobj_get_blobref (treeobj, 0),
+                                 content_flags))
+        || flux_content_load_get (f, &buf, &buflen) < 0) {
+        log_msg_exit ("%s: missing blobref: %s",
+                      path,
+                      future_strerror (f, errno));
+    }
+    if (!(treeobj_deref = treeobj_decodeb (buf, buflen)))
+        log_err_exit ("%s: could not decode directory", path);
+    if (!treeobj_is_dir (treeobj_deref))
+        log_msg_exit ("%s: dirref references non-directory", path);
+    dump_dir (ar, h, path, treeobj_deref); // recurse
+    json_decref (treeobj_deref);
+    flux_future_destroy (f);
+}
+
+static void dump_treeobj (struct archive *ar,
+                          flux_t *h,
+                          const char *path,
+                          json_t *treeobj)
+{
+    if (treeobj_validate (treeobj) < 0)
+        log_msg_exit ("%s: invalid tree object", path);
+    if (treeobj_is_symlink (treeobj)) {
+        if (verbose)
+            fprintf (stderr, "%s\n", path);
+        dump_symlink (ar, h, path, treeobj);
+    }
+    else if (treeobj_is_val (treeobj)) {
+        if (verbose)
+            fprintf (stderr, "%s\n", path);
+        dump_val (ar, h, path, treeobj);
+    }
+    else if (treeobj_is_valref (treeobj)) {
+        if (verbose)
+            fprintf (stderr, "%s\n", path);
+        dump_valref (ar, h, path, treeobj);
+    }
+    else if (treeobj_is_dirref (treeobj)) {
+        dump_dirref (ar, h, path, treeobj); // recurse
+    }
+    else if (treeobj_is_dir (treeobj)) {
+        dump_dir (ar, h, path, treeobj); // recurse
+    }
+}
+
+static void dump_blobref (struct archive *ar,
+                          flux_t *h,
+                          const char *blobref)
+{
+    flux_future_t *f;
+    const void *buf;
+    int buflen;
+    json_t *treeobj;
+    json_t *dict;
+    const char *key;
+    json_t *entry;
+
+    if (!(f = flux_content_load (h, blobref, content_flags))
+        || flux_content_load_get (f, &buf, &buflen) < 0)
+        log_msg_exit ("cannot load root tree object: %s",
+                      future_strerror (f, errno));
+    if (!(treeobj = treeobj_decodeb (buf, buflen)))
+        log_err_exit ("cannot decode root tree object");
+    if (treeobj_validate (treeobj) < 0)
+        log_msg_exit ("invalid root tree object");
+    if (!treeobj_is_dir (treeobj))
+        log_msg_exit ("root tree object is not a directory");
+
+    dict = treeobj_get_data (treeobj);
+    json_object_foreach (dict, key, entry) {
+        dump_treeobj (ar, h, key, entry);
+    }
+    json_decref (treeobj);
+    flux_future_destroy (f);
+}
+
+static int cmd_dump (optparse_t *p, int ac, char *av[])
+{
+    int optindex =  optparse_option_index (p);
+    flux_t *h;
+    struct archive *ar;
+    const char *outfile;
+
+    log_init ("flux-dump");
+
+    if (optindex != ac - 1) {
+        optparse_print_usage (p);
+        exit (1);
+    }
+    outfile = av[optindex++];
+    if (optparse_hasopt (p, "verbose"))
+        verbose = true;
+    if (optparse_hasopt (p, "quiet"))
+        quiet = true;
+    if (optparse_hasopt (p, "no-cache"))
+        content_flags |= CONTENT_FLAG_CACHE_BYPASS;
+
+    dump_time = time (NULL);
+    dump_uid = getuid ();
+    dump_gid = getgid ();
+
+    h = builtin_get_flux_handle (p);
+    ar = dump_create (outfile);
+    if (optparse_hasopt (p, "checkpoint")) {
+        flux_future_t *f;
+        const char *blobref;
+        double timestamp;
+
+        if (!(f = kvs_checkpoint_lookup (h, NULL))
+            || kvs_checkpoint_lookup_get_rootref (f, &blobref) < 0
+            || kvs_checkpoint_lookup_get_timestamp (f, &timestamp) < 0)
+            log_msg_exit ("error fetching checkpoint: %s",
+                          future_strerror (f, errno));
+        dump_time = timestamp;
+        dump_blobref (ar, h, blobref);
+        flux_future_destroy (f);
+    }
+    else {
+        flux_future_t *f;
+        const char *blobref;
+
+        if (!(f = flux_kvs_getroot (h, NULL, 0))
+            || flux_kvs_getroot_get_blobref (f, &blobref) < 0)
+            log_msg_exit ("error fetching current KVS root: %s",
+                          future_strerror (f, errno));
+        dump_blobref (ar, h, blobref);
+        flux_future_destroy (f);
+    }
+
+    progress_end ();
+
+    dump_destroy (ar);
+    flux_close (h);
+
+    return 0;
+}
+
+static struct optparse_option dump_opts[] = {
+    { .name = "verbose", .key = 'v', .has_arg = 0,
+      .usage = "List keys on stderr as they are archived",
+    },
+    { .name = "quiet", .key = 'q', .has_arg = 0,
+      .usage = "Don't show periodic progress updates",
+    },
+    { .name = "checkpoint", .has_arg = 0,
+      .usage = "Dump from checkpoint",
+    },
+    { .name = "no-cache", .has_arg = 0,
+      .usage = "Bypass the broker content cache",
+    },
+    OPTPARSE_TABLE_END
+};
+
+int subcommand_dump_register (optparse_t *p)
+{
+    optparse_err_t e;
+    e = optparse_reg_subcommand (p,
+        "dump",
+        cmd_dump,
+        "[OPTIONS] OUTFILE",
+        "Dump KVS snapshot to a portable archive format",
+        0,
+        dump_opts);
+    return (e == OPTPARSE_SUCCESS ? 0 : -1);
+}
+
+// vi: ts=4 sw=4 expandtab

--- a/src/cmd/builtin/restore.c
+++ b/src/cmd/builtin/restore.c
@@ -1,0 +1,488 @@
+/************************************************************\
+ * Copyright 2022 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+# include <config.h>
+#endif
+#include <unistd.h>
+#include <stdarg.h>
+#include <jansson.h>
+#include <time.h>
+#include <archive.h>
+#include <archive_entry.h>
+#include <argz.h>
+
+#include "src/common/libeventlog/eventlog.h"
+#include "src/common/libkvs/treeobj.h"
+#include "src/common/libkvs/kvs_checkpoint.h"
+#include "src/common/libutil/fsd.h"
+#include "src/common/libutil/blobref.h"
+
+#include "builtin.h"
+
+#define BLOCKSIZE 10240 // taken from libarchive example
+
+static bool verbose;
+static bool quiet;
+static int content_flags;
+static time_t restore_timestamp;
+static int blobcount;
+static int keycount;
+
+static void progress (int delta_blob, int delta_keys)
+{
+    blobcount += delta_blob;
+    keycount += delta_keys;
+
+    if (!quiet
+        && !verbose
+        && (keycount % 100 == 0 || keycount < 10)) {
+        fprintf (stderr,
+                 "\rflux-restore: restored %d keys (%d blobs)",
+                 keycount,
+                 blobcount);
+    }
+}
+static void progress_end (void)
+{
+    if (!quiet && !verbose) {
+        fprintf (stderr,
+                 "\rflux-restore: restored %d keys (%d blobs)\n",
+                 keycount,
+                 blobcount);
+    }
+}
+
+static struct archive *restore_create (const char *infile)
+{
+    struct archive *ar;
+
+    if (!(ar = archive_read_new ()))
+        log_msg_exit ("error creating libarchive read context");
+    if (archive_read_support_format_all (ar) != ARCHIVE_OK
+        || archive_read_support_filter_all (ar) != ARCHIVE_OK)
+        log_msg_exit ("%s", archive_error_string (ar));
+    if (!strcmp (infile, "-")) {
+        if (archive_read_open_FILE (ar, stdin) != ARCHIVE_OK)
+            log_msg_exit ("%s", archive_error_string (ar));
+    }
+    else {
+        if (archive_read_open_filename (ar, infile, BLOCKSIZE) != ARCHIVE_OK)
+            log_msg_exit ("%s", archive_error_string (ar));
+    }
+    return ar;
+}
+
+static void restore_destroy (struct archive *ar)
+{
+    if (archive_read_close (ar) != ARCHIVE_OK)
+        log_msg_exit ("%s", archive_error_string (ar));
+    archive_read_free (ar);
+}
+
+static json_t *restore_dir (flux_t *h, json_t *dir)
+{
+    json_t *data = treeobj_get_data (dir);
+    const char *name;
+    json_t *entry;
+    json_t *ndir;
+
+    if (!(ndir = treeobj_create_dir ()))
+        log_msg_exit ("out of memory");
+    json_object_foreach (data, name, entry) {
+        json_t *nentry = NULL;
+        if (treeobj_is_dir (entry)) // recurse
+            nentry = restore_dir (h, entry);
+        if (treeobj_insert_entry_novalidate (ndir,
+                                             name,
+                                             nentry ? nentry : entry) < 0)
+            log_msg_exit ("error inserting object");
+        json_decref (nentry);
+    }
+
+    char *s;
+    flux_future_t *f;
+    const char *blobref;
+    json_t *dirref;
+
+    if (!(s = treeobj_encode (ndir)))
+        log_msg_exit ("out of memory");
+    if (!(f = flux_content_store (h, s, strlen (s), content_flags))
+        || flux_content_store_get (f, &blobref) < 0)
+        log_msg_exit ("error storing dirref blob: %s",
+                      future_strerror (f, errno));
+    progress (1, 0);
+    if (!(dirref = treeobj_create_dirref (blobref)))
+        log_msg_exit ("out of memory");
+    free (s);
+    flux_future_destroy (f);
+    json_decref (ndir);
+
+    return dirref;
+}
+
+static void restore_treeobj (json_t *root, const char *path, json_t *treeobj)
+{
+    char *argz = NULL;
+    size_t argz_len = 0;
+    int count;
+    char *name;
+    json_t *dir;
+    json_t *dp;
+
+    /* Walk 'path' to the penultimate component (creating any missing dirs)
+     * and leave 'dir' pointing to it.
+     */
+    if (argz_create_sep (path, '/', &argz, &argz_len) != 0)
+        log_msg_exit ("out of memory");
+    dir = root;
+    count = argz_count (argz, argz_len);
+    name = NULL;
+    for (int i = 0; i < count - 1; i++) {
+        name = argz_next (argz, argz_len, name);
+        if (!(dp = treeobj_get_entry (dir, name))) {
+            if (!(dp = treeobj_create_dir ())
+                || treeobj_insert_entry (dir, name, dp) < 0)
+                log_msg_exit ("out of memory");
+            json_decref (dp); // treeobj_insert_entry took a ref
+        }
+        else if (!treeobj_is_dir (dp))
+            log_msg_exit ("%s in %s is not a directory", name, path);
+        dir = dp;
+    }
+    /* Insert treeobj into 'dir' under final path component.
+     */
+    name = argz_next (argz, argz_len, name);
+    if (treeobj_insert_entry (dir, name, treeobj) < 0)
+        log_err_exit ("error inserting %s into root directory", path);
+
+    free (argz);
+}
+
+static void restore_symlink (flux_t *h,
+                             json_t *root,
+                             const char *path,
+                             const char *ns_target)
+{
+    char *cpy;
+    char *cp;
+    const char *ns;
+    const char *target;
+    json_t *treeobj;
+
+    if (!(cpy = strdup (ns_target)))
+        log_msg_exit ("out of memory");
+    if ((cp = strstr (cpy, "::"))) {
+        *cp = '\0';
+        ns = cpy;
+        target = cp + 2;
+    }
+    else {
+        ns = NULL;
+        target = cpy;
+    }
+    if (!(treeobj = treeobj_create_symlink (ns, target)))
+        log_err_exit ("cannot create symlink object for %s", path);
+    restore_treeobj (root, path, treeobj);
+    json_decref (treeobj);
+    free (cpy);
+    progress (0, 1);
+}
+
+static void restore_value (flux_t *h,
+                           json_t *root,
+                           const char *path,
+                           const void *buf,
+                           int size)
+{
+    json_t *treeobj;
+
+    if (size < BLOBREF_MAX_STRING_SIZE) {
+        if (!(treeobj = treeobj_create_val (buf, size)))
+            log_err_exit ("error creating val object for %s", path);
+    }
+    else {
+        flux_future_t *f;
+        const char *blobref;
+
+        if (!(f = flux_content_store (h, buf, size, content_flags))
+            || flux_content_store_get (f, &blobref) < 0)
+            log_msg_exit ("error storing blob for %s: %s",
+                          path,
+                          future_strerror (f, errno));
+        progress (1, 0);
+        if (!(treeobj = treeobj_create_valref (blobref)))
+            log_err_exit ("error creating valref object for %s", path);
+        flux_future_destroy (f);
+    }
+    restore_treeobj (root, path, treeobj);
+    json_decref (treeobj);
+    progress (0, 1);
+}
+
+/* Restore archive and return a 'dirref' object pointing to it.
+ */
+static json_t *restore_snapshot (struct archive *ar, flux_t *h)
+{
+    void *buf = NULL;
+    int bufsize = 0;
+    json_t *root;
+    json_t *rootref;
+
+    if (!(root = treeobj_create_dir ()))
+        log_msg_exit ("out of memory");
+
+    for (;;) {
+        struct archive_entry *entry;
+        int res;
+        const char *path;
+        mode_t type;
+        time_t mtime;
+
+        res = archive_read_next_header (ar, &entry);
+        if (res == ARCHIVE_EOF)
+            break;
+        if (res != ARCHIVE_OK)
+            log_msg_exit ("%s", archive_error_string (ar));
+        path = archive_entry_pathname (entry);
+        type = archive_entry_filetype (entry);
+        mtime = archive_entry_mtime (entry);
+
+        if (restore_timestamp < mtime)
+            restore_timestamp = mtime;
+
+        if (type == AE_IFLNK) {
+            const char *target = archive_entry_symlink (entry);
+
+            restore_symlink (h, root, path, target);
+            if (verbose)
+                fprintf (stderr, "%s -> %s\n", path, target);
+        }
+        else if (type == AE_IFREG) {
+            int size = archive_entry_size (entry);
+
+            if (size > bufsize) {
+                void *newbuf;
+                if (!(newbuf = realloc (buf, size)))
+                    log_msg_exit ("out of memory");
+                buf = newbuf;
+                bufsize = size;
+            }
+            res = archive_read_data (ar, buf, bufsize);
+            if (res != size) {
+                if (res < 0)
+                    log_msg_exit ("%s", archive_error_string (ar));
+                else
+                    log_msg_exit ("short read from archive");
+            }
+            restore_value (h, root, path, buf, size);
+            if (verbose)
+                fprintf (stderr, "%s\n", path);
+        }
+    }
+    free (buf);
+    rootref = restore_dir (h, root);
+    json_decref (root);
+
+    return rootref;
+}
+
+/* Work around #4222.
+ */
+static void store_empty_dir (flux_t *h)
+{
+    json_t *dir;
+    char *s;
+    flux_future_t *f = NULL;
+
+    if (!(dir = treeobj_create_dir ())
+        || !(s = treeobj_encode (dir))
+        || !(f = flux_content_store (h, s, strlen (s), content_flags))
+        || flux_rpc_get (f, NULL) < 0)
+        log_msg_exit ("error storing emtpy directory: %s",
+                      future_strerror (f, errno));
+    flux_future_destroy (f);
+    free (s);
+    json_decref (dir);
+    progress (1, 0);
+}
+
+/* Return the number of characters of 'blobref' that a human might want to see.
+ */
+static int shortblobref_length (const char *blobref)
+{
+    int len = 8;
+    char *cp;
+
+    if ((cp = strchr (blobref, '-')))
+        len += (cp - blobref) + 1;
+    return len;
+}
+
+static bool kvs_is_running (flux_t *h)
+{
+    flux_future_t *f;
+    bool running = true;
+
+    if ((f = flux_kvs_getroot (h, NULL, 0)) != NULL
+        && flux_rpc_get (f, NULL) < 0
+        && errno == ENOSYS)
+        running = false;
+    flux_future_destroy (f);
+    return running;
+}
+
+static void flush_content (flux_t *h, uint32_t rank)
+{
+    flux_future_t *f;
+
+    if (!(f = flux_rpc (h, "content.flush", NULL, rank, 0))
+        || flux_rpc_get (f, NULL) < 0)
+    log_msg ("error flushing content cache: %s", future_strerror (f, errno));
+    flux_future_destroy (f);
+}
+
+static int cmd_restore (optparse_t *p, int ac, char *av[])
+{
+    int optindex =  optparse_option_index (p);
+    flux_t *h;
+    struct archive *ar;
+    const char *infile;
+
+    log_init ("flux-restore");
+
+    if (optindex != ac - 1) {
+        optparse_print_usage (p);
+        exit (1);
+    }
+    infile = av[optindex++];
+    if (optparse_hasopt (p, "verbose"))
+        verbose = true;
+    if (optparse_hasopt (p, "quiet"))
+        quiet = true;
+    if (optparse_hasopt (p, "no-cache"))
+        content_flags |= CONTENT_FLAG_CACHE_BYPASS;
+
+    h = builtin_get_flux_handle (p);
+    ar = restore_create (infile);
+
+    if (optparse_hasopt (p, "checkpoint")) {
+        json_t *dirref;
+        const char *blobref;
+        flux_future_t *f;
+
+        if (kvs_is_running (h))
+            log_msg_exit ("please unload kvs module before using --checkpoint");
+
+        store_empty_dir (h);
+        dirref = restore_snapshot (ar, h);
+        blobref = treeobj_get_blobref (dirref, 0);
+        progress_end ();
+
+        if (!quiet) {
+            log_msg ("writing snapshot %.*s to checkpoint for next KVS start",
+                     shortblobref_length (blobref),
+                     blobref);
+        }
+        if (!(f = kvs_checkpoint_commit (h, NULL, blobref, restore_timestamp))
+            || flux_rpc_get (f, NULL) < 0) {
+            log_msg_exit ("error updating checkpoint: %s",
+                          future_strerror (f, errno));
+        }
+        flux_future_destroy (f);
+
+        json_decref (dirref);
+    }
+    else if (optparse_hasopt (p, "key")) {
+        const char *key = optparse_get_str (p, "key", NULL);
+        json_t *dirref;
+        char *s;
+        const char *blobref;
+        flux_kvs_txn_t *txn;
+        flux_future_t *f;
+
+        store_empty_dir (h);
+        dirref = restore_snapshot (ar, h);
+        blobref = treeobj_get_blobref (dirref, 0);
+        progress_end ();
+
+        if (!quiet) {
+            log_msg ("writing snapshot %.*s to KVS key '%s'",
+                     shortblobref_length (blobref),
+                     blobref,
+                     key);
+        }
+
+        if (!(s = json_dumps (dirref, JSON_COMPACT)))
+            log_msg_exit ("error encoding final dirref object");
+
+        f = NULL;
+        if (!(txn = flux_kvs_txn_create ())
+            || flux_kvs_txn_put_treeobj (txn, 0, key, s) < 0
+            || !(f = flux_kvs_commit (h, NULL, 0, txn))
+            || flux_rpc_get (f, NULL) < 0) {
+            log_msg_exit ("error updating %s: %s",
+                          key,
+                          future_strerror (f, errno));
+        }
+        flux_future_destroy (f);
+        flux_kvs_txn_destroy (txn);
+
+        free (s);
+        json_decref (dirref);
+    }
+    else {
+        log_msg_exit ("Please specify a restore target with"
+                      " --checkpoint or --key");
+    }
+
+    if (!optparse_hasopt (p, "no-cache"))
+        flush_content (h, 0);
+
+    restore_destroy (ar);
+    flux_close (h);
+
+    return 0;
+}
+
+static struct optparse_option restore_opts[] = {
+    { .name = "verbose", .key = 'v', .has_arg = 0,
+      .usage = "List keys on stderr as they are restored",
+    },
+    { .name = "quiet", .key = 'q', .has_arg = 0,
+      .usage = "Don't show periodic progress updates",
+    },
+    { .name = "checkpoint", .has_arg = 0,
+      .usage = "Restore to checkpoint",
+    },
+    { .name = "key", .has_arg = 1,
+      .arginfo = "KEY",
+      .usage = "Restore to KVS key",
+    },
+    { .name = "no-cache", .has_arg = 0,
+      .usage = "Bypass the broker content cache",
+    },
+    OPTPARSE_TABLE_END
+};
+
+int subcommand_restore_register (optparse_t *p)
+{
+    optparse_err_t e;
+    e = optparse_reg_subcommand (p,
+        "restore",
+        cmd_restore,
+        "[OPTIONS] INFILE",
+        "Restore KVS snapshot from a portable archive format",
+        0,
+        restore_opts);
+    return (e == OPTPARSE_SUCCESS ? 0 : -1);
+}
+
+// vi: ts=4 sw=4 expandtab

--- a/src/cmd/builtin/startlog.c
+++ b/src/cmd/builtin/startlog.c
@@ -54,7 +54,7 @@ static void kvs_checkpoint_put (flux_t *h, const char *treeobj)
         || !(rootref = treeobj_get_blobref (o, 0)))
         log_err_exit ("Error decoding treeobj from eventlog commit");
 
-    if (!(f = kvs_checkpoint_commit (h, "kvs-primary", rootref, 0))
+    if (!(f = kvs_checkpoint_commit (h, NULL, rootref, 0))
         || flux_rpc_get (f, NULL) < 0)
         log_msg_exit ("Error writing kvs checkpoint: %s",
                       future_strerror (f, errno));

--- a/src/cmd/builtin/startlog.c
+++ b/src/cmd/builtin/startlog.c
@@ -54,7 +54,7 @@ static void kvs_checkpoint_put (flux_t *h, const char *treeobj)
         || !(rootref = treeobj_get_blobref (o, 0)))
         log_err_exit ("Error decoding treeobj from eventlog commit");
 
-    if (!(f = kvs_checkpoint_commit (h, "kvs-primary", rootref))
+    if (!(f = kvs_checkpoint_commit (h, "kvs-primary", rootref, 0))
         || flux_rpc_get (f, NULL) < 0)
         log_msg_exit ("Error writing kvs checkpoint: %s",
                       future_strerror (f, errno));

--- a/src/common/libkvs/kvs_checkpoint.c
+++ b/src/common/libkvs/kvs_checkpoint.c
@@ -27,10 +27,12 @@ flux_future_t *kvs_checkpoint_commit (flux_t *h,
 {
     flux_future_t *f = NULL;
 
-    if (!h || !key || !rootref) {
+    if (!h || !rootref) {
         errno = EINVAL;
         return NULL;
     }
+    if (!key)
+        key = KVS_DEFAULT_CHECKPOINT;
     if (timestamp == 0)
         timestamp = flux_reactor_now (flux_get_reactor (h));
 
@@ -52,10 +54,12 @@ flux_future_t *kvs_checkpoint_commit (flux_t *h,
 
 flux_future_t *kvs_checkpoint_lookup (flux_t *h, const char *key)
 {
-    if (!h || !key) {
+    if (!h) {
         errno = EINVAL;
         return NULL;
     }
+    if (!key)
+        key = KVS_DEFAULT_CHECKPOINT;
 
     return flux_rpc_pack (h,
                           "kvs-checkpoint.get",

--- a/src/common/libkvs/kvs_checkpoint.c
+++ b/src/common/libkvs/kvs_checkpoint.c
@@ -91,45 +91,25 @@ int kvs_checkpoint_lookup_get_rootref (flux_future_t *f, const char **rootref)
     return 0;
 }
 
-/* returns "N/A" if not available */
-int kvs_checkpoint_lookup_get_formatted_timestamp (flux_future_t *f,
-                                                   char *buf,
-                                                   size_t len)
+int kvs_checkpoint_lookup_get_timestamp (flux_future_t *f, double *timestamp)
 {
     int version;
-    double timestamp = 0.;
+    double ts = 0.;
 
-    if (!f || !buf) {
+    if (!f || !timestamp) {
         errno = EINVAL;
         return -1;
     }
-
     if (flux_rpc_get_unpack (f, "{s:{s:i s?f}}",
                                 "value",
                                 "version", &version,
-                                "timestamp", &timestamp) < 0)
+                                "timestamp", &ts) < 0)
         return -1;
-
     if (version != 0 && version != 1) {
         errno = EINVAL;
         return -1;
     }
-
-    if (version == 1) {
-        time_t sec = timestamp;
-        struct tm tm;
-        gmtime_r (&sec, &tm);
-        if (strftime (buf, len, "%FT%T", &tm) == 0) {
-            errno = EINVAL;
-            return -1;
-        }
-    }
-    else { /* version == 0 */
-        if (snprintf (buf, len, "N/A") >= len) {
-            errno = EINVAL;
-            return -1;
-        }
-    }
+    *timestamp = ts;
     return 0;
 }
 

--- a/src/common/libkvs/kvs_checkpoint.c
+++ b/src/common/libkvs/kvs_checkpoint.c
@@ -22,17 +22,17 @@
 
 flux_future_t *kvs_checkpoint_commit (flux_t *h,
                                       const char *key,
-                                      const char *rootref)
+                                      const char *rootref,
+                                      double timestamp)
 {
     flux_future_t *f = NULL;
-    double timestamp;
 
     if (!h || !key || !rootref) {
         errno = EINVAL;
         return NULL;
     }
-
-    timestamp = flux_reactor_now (flux_get_reactor (h));
+    if (timestamp == 0)
+        timestamp = flux_reactor_now (flux_get_reactor (h));
 
     if (!(f = flux_rpc_pack (h,
                              "kvs-checkpoint.put",

--- a/src/common/libkvs/kvs_checkpoint.h
+++ b/src/common/libkvs/kvs_checkpoint.h
@@ -15,7 +15,8 @@
 
 flux_future_t *kvs_checkpoint_commit (flux_t *h,
                                       const char *key,
-                                      const char *rootref);
+                                      const char *rootref,
+                                      double timestamp);
 
 flux_future_t *kvs_checkpoint_lookup (flux_t *h, const char *key);
 

--- a/src/common/libkvs/kvs_checkpoint.h
+++ b/src/common/libkvs/kvs_checkpoint.h
@@ -13,6 +13,8 @@
 
 #include <flux/core.h>
 
+#define KVS_DEFAULT_CHECKPOINT "kvs-primary"
+
 flux_future_t *kvs_checkpoint_commit (flux_t *h,
                                       const char *key,
                                       const char *rootref,

--- a/src/common/libkvs/kvs_checkpoint.h
+++ b/src/common/libkvs/kvs_checkpoint.h
@@ -21,10 +21,9 @@ flux_future_t *kvs_checkpoint_lookup (flux_t *h, const char *key);
 
 int kvs_checkpoint_lookup_get_rootref (flux_future_t *f, const char **rootref);
 
-/* returns "N/A" if not available */
-int kvs_checkpoint_lookup_get_formatted_timestamp (flux_future_t *f,
-                                                   char *buf,
-                                                   size_t len);
+/* sets timestamp to 0 if unavailable
+ */
+int kvs_checkpoint_lookup_get_timestamp (flux_future_t *f, double *timestamp);
 
 #endif /* !_KVS_CHECKPOINT_H */
 

--- a/src/common/libkvs/test/kvs_checkpoint.c
+++ b/src/common/libkvs/test/kvs_checkpoint.c
@@ -26,7 +26,7 @@ void errors (void)
     const char *rootref;
 
     errno = 0;
-    ok (kvs_checkpoint_commit (NULL, NULL, NULL) == NULL
+    ok (kvs_checkpoint_commit (NULL, NULL, NULL, 0) == NULL
         && errno == EINVAL,
         "kvs_checkpoint_commit fails on bad input");
 

--- a/src/common/libkvs/test/kvs_checkpoint.c
+++ b/src/common/libkvs/test/kvs_checkpoint.c
@@ -24,7 +24,6 @@ void errors (void)
 {
     flux_future_t *f;
     const char *rootref;
-    char buf[128];
 
     errno = 0;
     ok (kvs_checkpoint_commit (NULL, NULL, NULL) == NULL
@@ -42,9 +41,9 @@ void errors (void)
         "kvs_checkpoint_lookup_get_rootref fails on bad input");
 
     errno = 0;
-    ok (kvs_checkpoint_lookup_get_formatted_timestamp (NULL, NULL, 0) < 0
+    ok (kvs_checkpoint_lookup_get_timestamp (NULL, NULL) < 0
         && errno == EINVAL,
-        "kvs_checkpoint_lookup_get_formatted_timestamp fails on bad input");
+        "kvs_checkpoint_lookup_get_timestamp fails on bad input");
 
     if (!(f = flux_future_create (NULL, NULL)))
         BAIL_OUT ("flux_future_create failed");
@@ -55,10 +54,10 @@ void errors (void)
         "kvs_checkpoint_lookup_get_rootref fails on unfulfilled future");
 
     errno = 0;
-    ok (kvs_checkpoint_lookup_get_formatted_timestamp (f, buf, 128) < 0
+    double timestamp;
+    ok (kvs_checkpoint_lookup_get_timestamp (f, &timestamp) < 0
         && errno == EINVAL,
-        "kvs_checkpoint_lookup_get_formatted_timestamp "
-        "fails on unfulfilled future");
+        "kvs_checkpoint_lookup_get_timestamp fails on unfulfilled future");
 
     flux_future_destroy (f);
 }

--- a/src/modules/content-sqlite/content-sqlite.c
+++ b/src/modules/content-sqlite/content-sqlite.c
@@ -625,7 +625,7 @@ static struct content_sqlite *content_sqlite_create (flux_t *h)
             goto error;
         if (access (ctx->dbfile, F_OK) == 0) {
             if (access (ctx->dbfile, R_OK | W_OK) < 0) {
-                flux_log_error (h, "ctx->dbfile");
+                flux_log_error (h, "%s", ctx->dbfile);
                 goto error;
             }
         }

--- a/src/modules/job-exec/job-exec.c
+++ b/src/modules/job-exec/job-exec.c
@@ -746,7 +746,7 @@ static int jobinfo_load_implementation (struct jobinfo *job)
     return -1;
 }
 
-/*  Completion for jobinfo_initialize(), finish init of jobinfo using
+/*  Completion for jobinfo_start_init (), finish init of jobinfo using
  *   data fetched from KVS
  */
 static void jobinfo_start_continue (flux_future_t *f, void *arg)

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -2713,7 +2713,7 @@ static void process_args (struct kvs_ctx *ctx, int ac, char **av)
  * Copy rootref buf with '\0' termination.
  * Return 0 on success, -1 on failure,
  */
-static int checkpoint_get (flux_t *h, const char *key, char *buf, size_t len)
+static int checkpoint_get (flux_t *h, char *buf, size_t len)
 {
     flux_future_t *f = NULL;
     const char *rootref;
@@ -2721,7 +2721,7 @@ static int checkpoint_get (flux_t *h, const char *key, char *buf, size_t len)
     char datestr[128] = "N/A";
     int rv = -1;
 
-    if (!(f = kvs_checkpoint_lookup (h, "kvs-primary")))
+    if (!(f = kvs_checkpoint_lookup (h, NULL)))
         return -1;
 
     if (kvs_checkpoint_lookup_get_rootref (f, &rootref) < 0)
@@ -2738,7 +2738,7 @@ static int checkpoint_get (flux_t *h, const char *key, char *buf, size_t len)
         timestamp_tostr (timestamp, datestr, sizeof (datestr));
 
     flux_log (h, LOG_INFO,
-              "restored kvs-primary from checkpoint on %s", datestr);
+              "restored KVS from checkpoint on %s", datestr);
 
     rv = 0;
 error:
@@ -2746,15 +2746,15 @@ error:
     return rv;
 }
 
-/* Synchronously store key-value pair to checkpoint service.
+/* Synchronously store checkpoint to checkpoint service.
  * Returns 0 on success, -1 on failure.
  */
-static int checkpoint_put (flux_t *h, const char *key, const char *rootref)
+static int checkpoint_put (flux_t *h, const char *rootref)
 {
     flux_future_t *f = NULL;
     int rv = -1;
 
-    if (!(f = kvs_checkpoint_commit (h, "kvs-primary", rootref, 0))
+    if (!(f = kvs_checkpoint_commit (h, NULL, rootref, 0))
         || flux_rpc_get (f, NULL) < 0)
         goto error;
     rv = 0;
@@ -2855,7 +2855,7 @@ int mod_main (flux_t *h, int argc, char **argv)
         /* Look for a checkpoint and use it if found.
          * Otherwise start the primary root namespace with an empty directory.
          */
-        if (checkpoint_get (h, "kvs-primary", rootref, sizeof (rootref)) < 0) {
+        if (checkpoint_get (h, rootref, sizeof (rootref)) < 0) {
             if (store_initial_rootdir (ctx, rootref, sizeof (rootref)) < 0) {
                 flux_log_error (h, "storing initial root object");
                 goto done;
@@ -2910,7 +2910,7 @@ int mod_main (flux_t *h, int argc, char **argv)
             flux_log_error (h, "error looking up primary root");
             goto done;
         }
-        if (checkpoint_put (ctx->h, "kvs-primary", root->ref) < 0) {
+        if (checkpoint_put (ctx->h, root->ref) < 0) {
             if (errno != ENOSYS) { // service not loaded is not an error
                 flux_log_error (h, "error saving primary KVS checkpoint");
                 goto done;

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -2754,7 +2754,7 @@ static int checkpoint_put (flux_t *h, const char *key, const char *rootref)
     flux_future_t *f = NULL;
     int rv = -1;
 
-    if (!(f = kvs_checkpoint_commit (h, "kvs-primary", rootref))
+    if (!(f = kvs_checkpoint_commit (h, "kvs-primary", rootref, 0))
         || flux_rpc_get (f, NULL) < 0)
         goto error;
     rv = 0;

--- a/src/test/docker/bionic/Dockerfile
+++ b/src/test/docker/bionic/Dockerfile
@@ -88,6 +88,7 @@ RUN apt-get update \
         libmpich-dev \
         libs3-dev \
         libevent-dev \
+        libarchive-dev \
  && rm -rf /var/lib/apt/lists/*
 
 # Testing utils and libs

--- a/src/test/docker/bionic/Dockerfile
+++ b/src/test/docker/bionic/Dockerfile
@@ -65,6 +65,7 @@ RUN apt-get update \
 
 RUN for PY in python3.6 python3.7 python3.8 ; do \
         sudo $PY -m pip install --upgrade --ignore-installed \
+	    "markupsafe==2.0.0" \
             coverage cffi six pyyaml "jsonschema>=2.6,<4.0" \
             sphinx sphinx-rtd-theme sphinxcontrib-spelling; \
     done ; \

--- a/src/test/docker/el7/Dockerfile
+++ b/src/test/docker/el7/Dockerfile
@@ -63,6 +63,7 @@ RUN yum -y update \
       lz4-devel \
       jq \
       libs3-devel \
+      libarchive-devel \
  && yum clean all
 
 # Sphinx packages for docs

--- a/src/test/docker/el8/Dockerfile
+++ b/src/test/docker/el8/Dockerfile
@@ -60,6 +60,7 @@ RUN yum -y update \
 	valgrind-devel \
 	libs3-devel \
 	systemd-devel \
+	libarchive-devel \
 #  Other deps
 	perl-Time-HiRes \
 	lua-posix \

--- a/src/test/docker/fedora33/Dockerfile
+++ b/src/test/docker/fedora33/Dockerfile
@@ -57,6 +57,7 @@ RUN yum -y update \
 	lua-devel \
 	valgrind-devel \
 	libs3-devel \
+	libarchive-devel \
 #  Other deps
 	perl-Time-HiRes \
 	lua-posix \

--- a/src/test/docker/fedora34/Dockerfile
+++ b/src/test/docker/fedora34/Dockerfile
@@ -57,6 +57,7 @@ RUN yum -y update \
 	lua-devel \
 	valgrind-devel \
 	libs3-devel \
+	libarchive-devel \
 #  Other deps
 	perl-Time-HiRes \
 	lua-posix \

--- a/src/test/docker/focal/Dockerfile
+++ b/src/test/docker/focal/Dockerfile
@@ -88,6 +88,7 @@ RUN apt-get update \
         libhwloc-dev \
         libopenmpi-dev \
         libs3-dev \
+        libarchive-dev \
  && rm -rf /var/lib/apt/lists/*
 
 # Testing utils and libs

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -296,6 +296,7 @@ dist_check_SCRIPTS = \
 	scripts/runpty.py \
 	scripts/dmesg-grep.py \
 	scripts/stats-listen.py \
+	scripts/sqlite-query.py \
 	valgrind/valgrind-workload.sh \
 	valgrind/workload.d/job \
 	kvs/kvs-helper.sh \
@@ -316,8 +317,7 @@ dist_check_SCRIPTS = \
 	job-list/list-id.py \
 	job-list/list-rpc.py \
 	job-list/jobspec-permissive.jsonschema \
-	ingest/bad-validate.py \
-	job-archive/query.py
+	ingest/bad-validate.py
 
 check_PROGRAMS = \
 	shmem/backtoback.t \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -183,6 +183,7 @@ TESTSCRIPTS = \
 	t2804-uptime-cmd.t \
 	t2805-startlog-cmd.t \
 	t2806-config-cmd.t \
+	t2807-dump-cmd.t \
 	t2900-job-timelimits.t \
 	t3000-mpi-basic.t \
 	t3001-mpi-personalities.t \

--- a/t/scripts/sqlite-query.py
+++ b/t/scripts/sqlite-query.py
@@ -8,7 +8,7 @@
 # SPDX-License-Identifier: LGPL-3.0
 ###############################################################
 
-# Query a job-archive db for testing purposes
+# Query a sqlite db for testing purposes
 
 # Usage: flux python query.py [OPTIONS] dbpath query
 

--- a/t/t2250-job-archive.t
+++ b/t/t2250-job-archive.t
@@ -10,7 +10,7 @@ test_under_flux 4 job
 ARCHIVEDIR=`pwd`
 ARCHIVEDB="${ARCHIVEDIR}/jobarchive.db"
 
-QUERYCMD="flux python ${FLUX_SOURCE_DIR}/t/job-archive/query.py"
+QUERYCMD="flux python ${FLUX_SOURCE_DIR}/t/scripts/sqlite-query.py"
 
 fj_wait_event() {
   flux job wait-event --timeout=20 "$@"

--- a/t/t2807-dump-cmd.t
+++ b/t/t2807-dump-cmd.t
@@ -1,0 +1,224 @@
+#!/bin/sh
+
+test_description='Test flux dump/restore'
+
+. $(dirname $0)/sharness.sh
+
+test_under_flux 1 minimal
+
+QUERYCMD="flux python ${FLUX_SOURCE_DIR}/t/scripts/sqlite-query.py"
+
+countblobs() {
+	$QUERYCMD -t 100 $(flux getattr content.backing-path) \
+		"select count(*) from objects;" | sed -e 's/.*= //'
+}
+
+test_expect_success 'flux-dump with no args prints Usage message' '
+	test_must_fail flux dump 2>dump-noargs.out &&
+	grep "Usage" dump-noargs.out
+'
+test_expect_success 'flux-restore with no args prints Usage message' '
+	test_must_fail flux restore 2>restore-noargs.out &&
+	grep "Usage" restore-noargs.out
+'
+test_expect_success 'flux-dump with no backing store fails' '
+	test_must_fail flux dump --checkpoint foo.tar 2>nostore.err &&
+	grep "No service matching kvs-checkpoint.get" nostore.err
+'
+test_expect_success 'flux-dump with bad archive file fails' '
+	test_must_fail flux dump /badfile.tar 2>badfile.err &&
+	grep badfile.tar badfile.err
+'
+test_expect_success 'load content-sqlite' '
+	flux module load content-sqlite
+'
+test_expect_success 'flux-dump --checkpoint with missing checkpoint fails' '
+	test_must_fail flux dump --checkpoint foo.tar 2>nocheck.err &&
+	grep "error fetching checkpoint" nocheck.err
+'
+
+test_expect_success 'load kvs and create some kvs content' '
+	printf "%-.*d" 100 0 >x.val &&
+	flux module load kvs &&
+	flux kvs put --no-merge a.b.c=testkey &&
+	flux kvs link linkedthing y &&
+	flux kvs put --no-merge x=$(cat x.val) &&
+	flux kvs link --target-namespace=smurf otherthing z
+'
+test_expect_success 'unload kvs' '
+	flux module remove kvs
+'
+test_expect_success 'dump default=kvs-primary checkpoint' '
+	flux dump --checkpoint foo.tar
+'
+test_expect_success 'repeat dump with -q' '
+	flux dump -q --checkpoint foo.tar
+'
+test_expect_success 'repeat dump with -v' '
+	flux dump -v --checkpoint foo.tar
+'
+test_expect_success 'repeat dump with --no-cache' '
+	flux dump --no-cache --checkpoint foo.tar
+'
+test_expect_success 'unload content-sqlite' '
+	flux content flush &&
+	flux content dropcache &&
+	flux module remove content-sqlite
+'
+
+# Small values and symlnks are contained in dirent rather than separate
+# objects, so after the above kvs commands, expect a blobcount of:
+# (1) rootdir 1st version
+# (3) rootdir 2nd version + 'a' directory + 'b' directory (c is contained in b)
+# (1) rootdir 3rd version (y is contained in root)
+# (2) rootdir 4th version + 'x'
+# (1) rootdir 5th version (z is contained in root)
+# Total: 8 blobs
+#
+test_expect_success 'count blobs representing those four keys' '
+	echo 8 >blobcount.exp &&
+	countblobs >blobcount.out &&
+	test_cmp blobcount.exp blobcount.out
+'
+test_expect_success 'remove backing file and load content-sqlite' '
+	rm -f $(flux getattr content.backing-path) &&
+	flux module load content-sqlite
+'
+test_expect_success 'restore content' '
+	flux restore --checkpoint foo.tar
+'
+test_expect_success 'repeat restore with -v' '
+	flux restore -v --checkpoint foo.tar
+'
+test_expect_success 'repeat restore with -q' '
+	flux restore -q --checkpoint foo.tar
+'
+test_expect_success 'repeat restore with --no-cache' '
+	flux restore --no-cache --checkpoint foo.tar
+'
+test_expect_success 'unload content-sqlite' '
+	flux content flush &&
+	flux content dropcache &&
+	flux module remove content-sqlite
+'
+
+# Intermediate rootdir versions are not preserved across dump/restore.
+# Expect a blobcount of 4: rootdir 5th version + 'a' + 'b' + 'x',
+# plus 1 for empty directory added as workaround for #4222
+#
+test_expect_success 'count blobs after restore'\'s' implicit garbage collection' '
+	echo 5 >blobcount2.exp &&
+	countblobs >blobcount2.out &&
+	test_cmp blobcount2.exp blobcount2.out
+'
+
+test_expect_success 'load content-sqlite + kvs and list content' '
+	flux module load content-sqlite &&
+	flux module load kvs &&
+	flux kvs dir -R
+'
+test_expect_success 'verify that exact KVS content was restored' '
+	test $(flux kvs get a.b.c) = "testkey" &&
+	test $(flux kvs get x) = $(cat x.val) &&
+	test $(flux kvs readlink y) = "linkedthing" &&
+	test $(flux kvs readlink z) = "smurf::otherthing"
+'
+test_expect_success 'now restore to key and verify content' '
+	flux restore -v --key zz foo.tar &&
+	test $(flux kvs get zz.a.b.c) = "testkey" &&
+	test $(flux kvs get zz.x) = $(cat x.val)
+'
+test_expect_success 'try dump - | restore - to key and verify content' '
+	flux dump - | flux restore --key yy - &&
+	test $(flux kvs get a.b.c) = "testkey" &&
+	test $(flux kvs get zz.a.b.c) = "testkey" &&
+	test $(flux kvs get yy.zz.a.b.c) = "testkey" &&
+	test $(flux kvs get x) = $(cat x.val) &&
+	test $(flux kvs get zz.x) = $(cat x.val) &&
+	test $(flux kvs get yy.zz.x) = $(cat x.val) &&
+	test $(flux kvs readlink y) = "linkedthing" &&
+	test $(flux kvs readlink zz.y) = "linkedthing" &&
+	test $(flux kvs readlink yy.zz.y) = "linkedthing" &&
+	test $(flux kvs readlink z) = "smurf::otherthing" &&
+	test $(flux kvs readlink zz.z) = "smurf::otherthing" &&
+	test $(flux kvs readlink yy.zz.z) = "smurf::otherthing"
+'
+test_expect_success 'dump ignores empty kvs directories' '
+	flux kvs mkdir emtpy &&
+	flux dump -v foo3.tar &&
+	tar tvf foo3.tar >toc &&
+	test_must_fail grep empty toc
+'
+test_expect_success 'restore ignores directories added by tar of filesystem' '
+	mkdir tmp &&
+	(cd tmp &&
+	tar xvf ../foo3.tar &&
+	tar cf - . | flux restore --key test -)
+'
+test_expect_success 'restore without required argument fails' '
+	test_must_fail flux restore foo.tar 2>restore-argmissing.err &&
+	grep "Please specify a restore target" restore-argmissing.err
+'
+test_expect_success 'restore --checkpoint fails with kvs loaded' '
+	test_must_fail flux restore --checkpoint foo.tar 2>restore-cpkvs.err &&
+	grep "please unload kvs" restore-cpkvs.err
+'
+test_expect_success 'unload kvs' '
+	flux module remove kvs
+'
+test_expect_success 'restore to key fails when kvs is not loaded' '
+	test_must_fail flux restore --key foo foo.tar 2>restore-nokvs.err &&
+	grep "error updating" restore-nokvs.err
+'
+test_expect_success 'unload content-sqlite' '
+	flux module remove content-sqlite
+'
+test_expect_success 'restore --checkpoint with no backing store fails' '
+	test_must_fail flux restore --checkpoint foo.tar 2>noback.err &&
+	grep "error updating checkpoint" noback.err
+'
+test_expect_success 'dump --no-cache with no backing store fails' '
+	test_must_fail flux dump --no-cache --checkpoint x.tar
+'
+test_expect_success 'restore --no-cache with no backing store fails' '
+	test_must_fail flux restore --no-cache --checkpoint foo.tar
+'
+test_expect_success 'run a flux instance, preserving content.sqlite' '
+	flux start -o,-Scontent.backing-path=content.sqlite /bin/true
+'
+
+reader() {
+	local dbfile=$1
+        flux start -o,-Sbroker.rc1_path= \
+                -o,-Sbroker.rc3_path=\
+                -o,-Scontent.backing-path=$dbfile \
+                bash -c "\
+                        flux module load content-sqlite && \
+                        flux dump --no-cache -q --checkpoint - &&\
+                        flux module remove content-sqlite
+                "
+}
+
+writer() {
+	local dbfile=$1
+        flux start -o,-Sbroker.rc1_path= \
+                -o,-Sbroker.rc3_path= \
+                -o,-Scontent.backing-path=$dbfile \
+                bash -c "\
+                        flux module load content-sqlite && \
+                        flux restore --checkpoint - && \
+                        flux module remove content-sqlite
+                "
+}
+
+test_expect_success 'perform offline garbage collection with dump/restore' '
+	mv content.sqlite content.sqlite.bak &&
+	reader content.sqlite.bak | writer content.sqlite
+'
+
+test_expect_success 'restart flux instance and try to run a job' '
+	flux start -o,-Scontent.backing-path=content.sqlite \
+		flux mini run /bin/true
+'
+
+test_done


### PR DESCRIPTION
As proposed in #4202, here are dump/restore utilities that walk KVS metadata using the content interface so they can be used when the KVS is not loaded.  They use [libarchive](https://www.libarchive.org/) to support various portable archive formats.

Still playing with these and plan to add tests and man pages but wanted to get this checkpointed.