### PR TITLE
python: add missing methods and improve efficiency of IDset class

### DIFF
--- a/src/bindings/python/flux/idset.py
+++ b/src/bindings/python/flux/idset.py
@@ -79,6 +79,8 @@ class IDset(WrapperPimpl):
             arg = str(arg)
         elif isinstance(arg, collections.Iterable) and not isinstance(arg, str):
             arg = ",".join(str(i) for i in sorted(arg))
+        elif isinstance(arg, int):
+            arg = str(arg)
 
         self.default_flags = flags
         try:

--- a/src/bindings/python/flux/idset.py
+++ b/src/bindings/python/flux/idset.py
@@ -71,12 +71,22 @@ class IDset(WrapperPimpl):
 
     def __init__(self, arg="", flags=IDSET_FLAG_RANGE, handle=None):
         super().__init__()
-        if isinstance(arg, collections.Iterable) and not isinstance(arg, str):
-            self.pimpl = self.InnerWrapper()
-            self.add(arg)
-        else:
-            self.pimpl = self.InnerWrapper(arg=arg, handle=handle)
+        if isinstance(arg, IDset):
+            #  Encode incoming IDset to string to generate a copy.
+            #  Note: Trying to use handle=arg.copy() here failed for some
+            #   reason and conversion to string just works, though it is
+            #   slightly less efficient.
+            arg = str(arg)
+        elif isinstance(arg, collections.Iterable) and not isinstance(arg, str):
+            arg = ",".join(str(i) for i in sorted(arg))
+
         self.default_flags = flags
+        try:
+            self.pimpl = self.InnerWrapper(arg=arg, handle=handle)
+        except (TypeError, AttributeError):
+            raise TypeError(
+                "IDset() expected an idset string or iterable, got " + type(arg)
+            )
 
     def __str__(self):
         return self.encode()
@@ -216,35 +226,22 @@ class IDset(WrapperPimpl):
         """Return the greatest id set in an IDset"""
         return self.pimpl.last()
 
-    @staticmethod
-    def arg_to_set(arg, method):
-        if isinstance(arg, str):
-            try:
-                arg = IDset(arg)
-            except:
-                raise ValueError(f"IDset.{method}(): string isn't a valid idset")
-        elif not isinstance(arg, collections.Iterable):
-            typestr = type(arg)
-            method = f"IDset.{method}()"
-            raise TypeError(
-                f"{method}: expected an idset string or iterable, got {typestr}"
-            )
-        return set(arg)
-
     def add(self, arg):
         """Add all ids or values in arg to IDset
         :param: arg: IDset, string, or iterable of integers to add
         """
-        for i in self.arg_to_set(arg, "add"):
-            self.set(i)
+        if not isinstance(arg, IDset):
+            arg = IDset(arg)
+        self.pimpl.add(arg)
         return self
 
     def subtract(self, arg):
         """subtract all ids or values in arg from IDset
         :param: arg: IDset, string, or iterable of integers to subtract
         """
-        for i in self.arg_to_set(arg, "subtract"):
-            self.clear(i)
+        if not isinstance(arg, IDset):
+            arg = IDset(arg)
+        self.pimpl.subtract(arg)
         return self
 
     def union(self, *args):
@@ -253,12 +250,12 @@ class IDset(WrapperPimpl):
         All args will be converted to IDsets if possible, i.e. any IDset,
         valid idset string, or iterable composed of integers will work.
         """
-        result = set(self)
+        result = self.copy()
         for idset in args:
             if not isinstance(idset, IDset):
                 idset = IDset(idset)
-            result = result | set(idset)
-        return IDset(result)
+            result = IDset(handle=result.pimpl.union(idset))
+        return result
 
     def intersect(self, *args):
         """Return the set intersection of the target IDset and all args
@@ -266,12 +263,12 @@ class IDset(WrapperPimpl):
         All args will be converted to IDsets if possible, i.e. any IDset,
         valid idset string, or iterable composed of integers will work.
         """
-        result = set(self)
+        result = self.copy()
         for idset in args:
             if not isinstance(idset, IDset):
                 idset = IDset(idset)
-            result = result & set(idset)
-        return IDset(result)
+            result = IDset(handle=result.pimpl.intersect(idset))
+        return result
 
 
 def decode(string):

--- a/src/bindings/python/flux/idset.py
+++ b/src/bindings/python/flux/idset.py
@@ -122,7 +122,34 @@ class IDset(WrapperPimpl):
             self.clear(i)
 
     def __eq__(self, idset):
+        """Test if two idsets are equal"""
         return self.equal(idset)
+
+    def __add__(self, arg):
+        """Returns the union of an idset and argument"""
+        return self.union(arg)
+
+    def __sub__(self, arg):
+        """Returns the difference of an idset and argument"""
+        return self.difference(arg)
+
+    def __and__(self, arg):
+        """Returns the set intersection of an idset and argument"""
+        return self.intersect(arg)
+
+    def __or__(self, arg):
+        """Returns the union of an idset and argument"""
+        return self.union(arg)
+
+    def __iadd__(self, arg):
+        """Adds the provided argument to an idset in-place"""
+        self.add(arg)
+        return self
+
+    def __isub__(self, arg):
+        """Subtracts the provided argument to an idset in-place"""
+        self.subtract(arg)
+        return self
 
     def equal(self, idset):
         if not isinstance(idset, IDset):

--- a/src/bindings/python/flux/idset.py
+++ b/src/bindings/python/flux/idset.py
@@ -270,6 +270,19 @@ class IDset(WrapperPimpl):
             result = IDset(handle=result.pimpl.intersect(idset))
         return result
 
+    def difference(self, *args):
+        """Return the set difference of the target IDset and all args
+
+        All args will be converted to IDsets if possible, i.e. any IDset,
+        valid idset string, or iterable composted of integers will work.
+        """
+        result = self.copy()
+        for idset in args:
+            if not isinstance(idset, IDset):
+                idset = IDset(idset)
+            result = IDset(handle=result.pimpl.difference(idset))
+        return result
+
 
 def decode(string):
     """Decode an idset string and return IDset object"""

--- a/t/python/t0021-idset.py
+++ b/t/python/t0021-idset.py
@@ -16,6 +16,16 @@ import flux.idset as idset
 
 
 class TestIDsetMethods(unittest.TestCase):
+    def test_constructor(self):
+        self.assertEqual(str(idset.IDset()), "")
+        self.assertEqual(str(idset.IDset(idset.IDset())), "")
+        self.assertEqual(str(idset.IDset(0)), "0")
+        self.assertEqual(str(idset.IDset(42)), "42")
+        self.assertEqual(str(idset.IDset([42])), "42")
+        self.assertEqual(str(idset.IDset("40,41,42")), "40-42")
+        self.assertEqual(str(idset.IDset([40, 41, 42])), "40-42")
+        self.assertEqual(str(idset.IDset([42, 41, 40])), "40-42")
+
     def test_str(self):
         tests = [
             {"input": "", "flags": None, "output": ""},

--- a/t/python/t0021-idset.py
+++ b/t/python/t0021-idset.py
@@ -166,14 +166,35 @@ class TestIDsetMethods(unittest.TestCase):
 
     def test_add_subtract(self):
         ids = idset.decode("0-9")
+        ids2 = ids.copy()
+
         self.assertEqual(str(ids.add("10-11")), "0-11")
         self.assertEqual(str(ids.add([20, 21])), "0-11,20-21")
         self.assertEqual(str(ids.add(idset.decode(""))), "0-11,20-21")
+
+        ids2 += "10-11"
+        self.assertEqual(str(ids2), "0-11")
+        ids2 += [20, 21]
+        self.assertEqual(str(ids2), "0-11,20-21")
+        ids2 += idset.decode("")
+        self.assertEqual(str(ids2), "0-11,20-21")
 
         self.assertEqual(str(ids.subtract([])), "0-11,20-21")
         self.assertEqual(str(ids.subtract("11-20")), "0-10,21")
         self.assertEqual(str(ids.subtract(idset.decode("0-10"))), "21")
         self.assertEqual(str(ids.subtract([21])), "")
+
+        ids2 -= ""
+        self.assertEqual(str(ids2), "0-11,20-21")
+        ids2 -= idset.IDset()
+        self.assertEqual(str(ids2), "0-11,20-21")
+        ids2 -= "11-20"
+        self.assertEqual(str(ids2), "0-10,21")
+        ids2 -= idset.decode("0-10")
+        self.assertEqual(str(ids2), "21")
+        ids2 -= 21
+        self.assertEqual(str(ids2), "")
+
         with self.assertRaises(ValueError):
             ids.subtract("foo")
         with self.assertRaises(TypeError):
@@ -199,6 +220,12 @@ class TestIDsetMethods(unittest.TestCase):
             result = ids.intersect(*map(idset.decode, test["args"]))
             self.assertEqual(str(result), test["result"])
 
+            # and finally with & operator
+            result = ids.copy()
+            for arg in test["args"]:
+                result = result & arg
+            self.assertEqual(str(result), test["result"])
+
     def test_union(self):
         tests = [
             {"idset": "0-10", "args": ["5-15", "0-3"], "result": "0-15"},
@@ -207,6 +234,16 @@ class TestIDsetMethods(unittest.TestCase):
         for test in tests:
             ids = idset.decode(test["idset"])
             result = ids.union(*test["args"])
+            self.assertEqual(str(result), test["result"])
+
+            result = ids.copy()
+            for arg in test["args"]:
+                result = result + arg
+            self.assertEqual(str(result), test["result"])
+
+            result = ids.copy()
+            for arg in test["args"]:
+                result = result | arg
             self.assertEqual(str(result), test["result"])
 
     def test_difference(self):
@@ -220,6 +257,11 @@ class TestIDsetMethods(unittest.TestCase):
         for test in tests:
             ids = idset.decode(test["idset"])
             result = ids.difference(*test["args"])
+            self.assertEqual(str(result), test["result"])
+
+            result = ids.copy()
+            for arg in test["args"]:
+                result = result - arg
             self.assertEqual(str(result), test["result"])
 
 

--- a/t/python/t0021-idset.py
+++ b/t/python/t0021-idset.py
@@ -177,11 +177,11 @@ class TestIDsetMethods(unittest.TestCase):
         with self.assertRaises(ValueError):
             ids.subtract("foo")
         with self.assertRaises(TypeError):
-            ids.subtract(42)
+            ids.subtract(42.0)
         with self.assertRaises(ValueError):
             ids.add("foo")
         with self.assertRaises(TypeError):
-            ids.add(42)
+            ids.add(42.0)
 
     def test_intersect(self):
         tests = [

--- a/t/python/t0021-idset.py
+++ b/t/python/t0021-idset.py
@@ -209,6 +209,19 @@ class TestIDsetMethods(unittest.TestCase):
             result = ids.union(*test["args"])
             self.assertEqual(str(result), test["result"])
 
+    def test_difference(self):
+        tests = [
+            {"idset": "0-10", "args": ["0-3"], "result": "4-10"},
+            {"idset": "0-10", "args": ["0-10"], "result": ""},
+            {"idset": "0-10", "args": ["5-7", "1-3"], "result": "0,4,8-10"},
+            {"idset": "0-1", "args": ["0-10"], "result": ""},
+            {"idset": "0-1024", "args": ["500-600"], "result": "0-499,601-1024"},
+        ]
+        for test in tests:
+            ids = idset.decode(test["idset"])
+            result = ids.difference(*test["args"])
+            self.assertEqual(str(result), test["result"])
+
 
 if __name__ == "__main__":
     unittest.main(testRunner=TAPTestRunner())


### PR DESCRIPTION
This PR was split off from some work on #4205.

The Python `IDset` class was implemented before the C libidset API exposed important set operations directly, and so the class converted IDsets to Python `set` objects and used that class for set operations. While we don't use Python because it is fast, it turns out that the libidset equivalent set operations (added since the original `IDset` class implementation, I think) are much faster (~11x faster).

This PR converts many of the `IDset` class methods to use the underlying C implementation. Also, a missing `difference` method is added, and some Python operators are overloaded to match the Python `set` conventions (`|/+` for union, `-` for difference, `&` for intersect).

Finally, the `IDset()` constructor is improved to allow more types (`int` now works to create an idset of one element, lists of integers can be out of order, and `IDset()` on an idset creates a copy)

The following times an intersection operation on an idset of size 1024 1000x:

```python
import time
from flux.idset import IDset
ids = IDset("0-1023")
t = time.time()
for i in range(1000):
    result = ids.intersect("100-200,300-400")
dt = time.time() - t
print(f"1000 intersect took {dt:<5.3f}s")
````

Before:
```
1000 intersect took 4.412s
```

After:
```
1000 intersect took 0.372s
```

`IDset` objects are iterable, so if a programmer prefers they can still do set operations the slow Python way by converting to a set with `set(idset)`.