### PR TITLE
broker: block SIGPIPE

### DIFF
--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -1056,6 +1056,7 @@ static int broker_handle_signals (broker_ctx_t *ctx)
 {
     int i, sigs[] = { SIGHUP, SIGINT, SIGQUIT, SIGTERM, SIGSEGV, SIGFPE,
                       SIGALRM };
+    int blocked[] = { SIGPIPE };
     flux_watcher_t *w;
 
     for (i = 0; i < sizeof (sigs) / sizeof (sigs[0]); i++) {
@@ -1071,6 +1072,10 @@ static int broker_handle_signals (broker_ctx_t *ctx)
         zlist_freefn (ctx->sigwatchers, w, broker_destroy_sigwatcher, false);
         flux_watcher_start (w);
     }
+
+    /*  Block the list of signals in the blocked array */
+    for (i = 0; i < sizeof (blocked) / sizeof (blocked[0]); i++)
+        signal(blocked[i], SIG_IGN);
     return 0;
 }
 

--- a/t/sharness.d/flux-sharness.sh
+++ b/t/sharness.d/flux-sharness.sh
@@ -204,6 +204,9 @@ test_under_flux() {
         flags="${flags} --debug"
         export FLUX_PYCLI_LOGLEVEL=10
     fi
+    if test -n "$root"; then
+        flags="${flags} --root=$root"
+    fi
     if test "$chain_lint" = "t"; then
         flags="${flags} --chain-lint"
     fi


### PR DESCRIPTION
It turns out the root of the problem in #4183 is that the broker doesn't currently block `SIGPIPE`, and thus if the broker or any broker module writes to a closed fd, the broker is killed (with signal 13).

The actual problem of writing to a closed pipe was probably introduced via the exec system's use of `FLUX_EXEC_PROTOCOL_FD` with the shell. This doesn't seem to be a problem with the real job shell, but the dummy shell used in `t2402-job-exec-dummy.t` seems to exit quickly in some error case used in the tests, and likely causes SIGPIPE somewhere down in libsubprocess.

In any event, we probably want to be getting `EPIPE` errors locally and not `SIGPIPE` in the broker, so the fix here is to just block `SIGPIPE`. This seems to resolve the intermittent failures in `t2402-job-exec-dummy.t` as well as the `flux-start: 0 (pid XXX) Broken pipe` error at the end of the test.

In order to stress test the intermittent failures, I added the ability to use sharness' `--root=PATH` option with `test_under_flux()`. That allows one to execute the same sharness test in parallel, as long as the specified `PATH` is unique per-job. For example, to test this PR I ran:

```console
$ flux start -s 4 flux mini submit --cc=1-100 -o pty --wait --progress sh -c './t2402-job-exec-dummy.t -d -v --root=$TMPDIR'
```
which ran the failing test 100 times with (on my system) up to 16 in parallel. This works because `TMPDIR` is unique for each Flux job. Results:

```
PD:0   R:0   CD:100 F:0   │██████████████████████████████████████│100.0% 0:05:35
```