### PR TITLE
testsuite: ensure tests can run concurrently with --root=$FLUX_JOB_TMPDIR 

### DIFF
--- a/src/bindings/python/flux/util.py
+++ b/src/bindings/python/flux/util.py
@@ -88,9 +88,11 @@ def encode_payload(payload):
     if payload is None or payload == ffi.NULL:
         payload = ffi.NULL
     elif isinstance(payload, str):
-        payload = payload.encode("UTF-8")
+        payload = payload.encode("UTF-8", errors="surrogateescape")
     elif not isinstance(payload, bytes):
-        payload = json.dumps(payload, ensure_ascii=False).encode("UTF-8")
+        payload = json.dumps(payload, ensure_ascii=False).encode(
+            "UTF-8", errors="surrogateescape"
+        )
     return payload
 
 

--- a/t/issues/t3906-job-exec-exception.sh
+++ b/t/issues/t3906-job-exec-exception.sh
@@ -8,7 +8,7 @@
 #
 export startctl="flux python ${SHARNESS_TEST_SRCDIR}/scripts/startctl.py"
 SHELL=/bin/sh flux start -s 4 -o,-Stbon.fanout=4 --test-exit-mode=leader '\
-   id=$(flux mini submit -n4 -N4 sleep inf) \
+   id=$(flux mini submit -n4 -N4 sleep 300) \
 && flux job wait-event $id start \
 && $startctl kill 3 9 \
 && flux job wait-event $id exception >t3906.output 2>&1'

--- a/t/issues/t3960-job-exec-ehostunreach.sh
+++ b/t/issues/t3960-job-exec-ehostunreach.sh
@@ -13,7 +13,7 @@
 #
 export startctl="flux python ${SHARNESS_TEST_SRCDIR}/scripts/startctl.py"
 SHELL=/bin/sh flux start -s 4 -o,-Stbon.fanout=4 --test-exit-mode=leader '\
-   id=$(flux mini submit -n4 -N4 sleep inf) \
+   id=$(flux mini submit -n4 -N4 sleep 300) \
 && flux job wait-event $id start \
 && $startctl kill 3 19 \
 && flux job cancel $id \

--- a/t/job-archive/query.py
+++ b/t/job-archive/query.py
@@ -28,7 +28,11 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     try:
-        dburi = "file:" + args.dbpath[0] + "?mode=ro"
+        #  Required in non-utf-8 locale if dbpath contains multibyte
+        #   characters. Prevents Python from whining about surrogates
+        #   not allowed. Really there must be a better way, but this works:
+        dbpath = args.dbpath[0].encode("utf-8", errors="surrogateescape").decode()
+        dburi = "file:" + dbpath + "?mode=ro"
         con = sqlite3.connect(dburi, uri=True)
     except sqlite3.Error as e:
         print(e)

--- a/t/kvs/change-checkpoint.py
+++ b/t/kvs/change-checkpoint.py
@@ -6,8 +6,8 @@ import sqlite3
 if len(sys.argv) < 4:
     print("change-checkpoint.py <file> <key> <value>")
     sys.exit(1)
-
-conn = sqlite3.connect(sys.argv[1])
+path = sys.argv[1].encode("utf-8", errors="surrogateescape").decode()
+conn = sqlite3.connect(path)
 cursor = conn.cursor()
 s = (
     'REPLACE INTO checkpt (key,value) values ("'

--- a/t/python/subflux.py
+++ b/t/python/subflux.py
@@ -13,6 +13,7 @@
 import os
 import sys
 import subprocess
+import argparse
 
 script_dir = os.path.dirname(os.path.abspath(__file__))
 
@@ -26,6 +27,17 @@ builddir = os.path.abspath(
 flux_exe = os.path.join(builddir, "src", "cmd", "flux")
 
 sys.path.append(script_dir + "/tap")
+
+
+#  Ignore -v, --verbose and --root options so that python test scripts
+#   can absorb the same options as sharness tests. Later, something could
+#   be done with these options, but for now they are dropped silently.
+parser = argparse.ArgumentParser()
+parser.add_argument("--debug", "-d", action="store_true")
+parser.add_argument("--root", metavar="PATH", type=str)
+args, remainder = parser.parse_known_args()
+
+sys.argv[1:] = remainder
 
 
 def is_exe(fpath):

--- a/t/sharness.d/flux-sharness.sh
+++ b/t/sharness.d/flux-sharness.sh
@@ -383,6 +383,7 @@ for var in $(env | grep ^SLURM); do unset ${var%%=*}; done
 unset FLUX_SHELL_RC_PATH
 unset FLUX_RC_EXTRA
 unset FLUX_CONF_DIR
+unset FLUX_JOB_CC
 
 # Individual tests that need to force local URI resolution should set
 #  this specifically. In general it breaks other URI tests:

--- a/t/sharness.d/flux-sharness.sh
+++ b/t/sharness.d/flux-sharness.sh
@@ -204,9 +204,6 @@ test_under_flux() {
         flags="${flags} --debug"
         export FLUX_PYCLI_LOGLEVEL=10
     fi
-    if test -n "$root"; then
-        flags="${flags} --root=$root"
-    fi
     if test "$chain_lint" = "t"; then
         flags="${flags} --chain-lint"
     fi
@@ -229,6 +226,7 @@ test_under_flux() {
         # Place the re-executed test script trash within the first invocation's
         # trash to preserve config files for broker restart in test
         flags="${flags} --root=$SHARNESS_TRASH_DIRECTORY"
+        unset root
     elif test "$personality" != "full"; then
         RC1_PATH=$FLUX_SOURCE_DIR/t/rc/rc1-$personality
         RC3_PATH=$FLUX_SOURCE_DIR/t/rc/rc3-$personality
@@ -237,6 +235,10 @@ test_under_flux() {
     else
         unset RC1_PATH
         unset RC3_PATH
+    fi
+
+    if test -n "$root"; then
+        flags="${flags} --root=$root"
     fi
 
     if test -n "$FLUX_TEST_VALGRIND" ; then

--- a/t/t0000-sharness.t
+++ b/t/t0000-sharness.t
@@ -66,6 +66,7 @@ run_sub_test_lib_test () {
 		cat >>".$name.t" &&
 		chmod +x ".$name.t" &&
 		export SHARNESS_TEST_SRCDIR &&
+		if $roof; then opt="$opt --root=$root"; fi
 		$prefix ./".$name.t" $opt --chain-lint >out 2>err
 	)
 }

--- a/t/t2110-job-ingest-validator.t
+++ b/t/t2110-job-ingest-validator.t
@@ -15,13 +15,13 @@ BAD_VALIDATOR=${SHARNESS_TEST_SRCDIR}/ingest/bad-validate.py
 
 test_valid ()
 {
-	flux mini bulksubmit --quiet --wait --watch --progress \
+	flux mini bulksubmit --quiet --wait --watch \
 		sh -c "cat {} | $Y2J | $SUBMITBENCH --urgency=0 -" ::: $*
 }
 
 test_invalid ()
 {
-	flux mini bulksubmit --quiet --wait --watch --progress \
+	flux mini bulksubmit --quiet --wait --watch \
 		sh -c "cat {} | $Y2J | $SUBMITBENCH --urgency=0 -" ::: $*
 	test $? -ne 0
 }

--- a/t/t2212-job-manager-plugins.t
+++ b/t/t2212-job-manager-plugins.t
@@ -81,7 +81,7 @@ test_expect_success 'job-manager: bad plugins config is detected' '
 	remove = "notfound.so"
 	EOF
 	test_must_fail \
-	    flux mini bulksubmit -n1 --progress --watch --log=badconf.{}.log \
+	    flux mini bulksubmit -n1 --watch --log=badconf.{}.log \
 	        flux start -o,-c$(pwd)/badconf/{} ::: a b c &&
 	test_debug "echo a:; cat badconf.a.log" &&
 	grep "config must be an array" badconf.a.log &&

--- a/t/t2273-job-alloc-bypass.t
+++ b/t/t2273-job-alloc-bypass.t
@@ -24,7 +24,7 @@ submit_as_alternate_user()
 test_expect_success 'alloc-bypass: start a job using all resources' '
 	SLEEPID=$(flux mini submit \
 	            -n $(flux resource list -s up -no {ncores}) \
-	            sleep inf)
+	            sleep 300)
 '
 test_expect_success 'alloc-bypass: load alloc-bypass plugin' '
 	flux jobtap load alloc-bypass.so

--- a/t/t2800-jobs-instance-info.t
+++ b/t/t2800-jobs-instance-info.t
@@ -24,7 +24,7 @@ test_expect_success 'start a set of Flux instances' '
 	id=$(flux mini submit flux start /bin/true) &&
 	id2=$(flux mini submit -n2 -c1 flux start \
 		"flux mini run /bin/false ; \
-		 flux mini submit --cc=1-4 sleep inf && \
+		 flux mini submit --cc=1-4 sleep 300 && \
 		 touch ready && \
 		 flux queue idle") &&
 	flux mini submit sleep 600 &&

--- a/t/t2800-jobs-recursive.t
+++ b/t/t2800-jobs-recursive.t
@@ -40,7 +40,7 @@ test_expect_success 'start a recursive job' '
 	rid=$(flux mini submit -n2 \
 		flux start \
 		flux mini submit --wait --cc=1-2 flux start \
-			"flux mini submit sleep inf && \
+			"flux mini submit sleep 300 && \
 			 touch ready.\$FLUX_JOB_CC && \
 			 flux queue idle") &&
 	flux job wait-event $id clean

--- a/t/t2801-top-cmd.t
+++ b/t/t2801-top-cmd.t
@@ -57,7 +57,7 @@ test_expect_success 'submit batch script and wait for it to start' '
 	cat >batch.sh <<-EOT &&
 	#!/bin/sh
 	touch job2-has-started
-	flux mini run sleep inf
+	flux mini run sleep 300
 	EOT
 	chmod +x batch.sh &&
 	flux mini batch -t30m -n1 batch.sh >jobid2 &&
@@ -69,7 +69,7 @@ test_expect_success 'flux-top JOBID works' '
 '
 test_expect_success 'submit non-batch job and wait for it to start' '
 	flux mini submit -n1 \
-		bash -c "touch job3-has-started && sleep inf" >jobid3 &&
+		bash -c "touch job3-has-started && sleep 300" >jobid3 &&
 	$waitfile job3-has-started
 '
 test_expect_success 'flux-top JOBID fails when JOBID is not a flux instance' '

--- a/t/t2803-flux-pstree.t
+++ b/t/t2803-flux-pstree.t
@@ -71,7 +71,7 @@ test_expect_success 'start a recursive job' '
 	rid=$(flux mini submit -n2 \
 		flux start \
 		flux mini submit --wait --cc=1-2 flux start \
-			"flux mini submit sleep inf && \
+			"flux mini submit sleep 300 && \
 			 touch ready.\$FLUX_JOB_CC && \
 			 flux queue idle") &&
 	flux job wait-event $id clean

--- a/t/test-inception.sh
+++ b/t/test-inception.sh
@@ -14,7 +14,9 @@ stats() {
 stats &
 PID=$!
 export FLUX_TESTS_LOGFILE=t
-flux mini bulksubmit -o pty --watch -q ./{} ::: t[0-9]*.t python/t*.py lua/t*.t
+flux mini bulksubmit -o pty --watch -q \
+	sh -c './{} --root=$FLUX_JOB_TMPDIR' \
+	::: t[0-9]*.t python/t*.py lua/t*.t
 RC=$?
 kill $PID
 wait


### PR DESCRIPTION
A good stress test for the testsuite is to run multiple copies of every test across a flux instance via
```
$ flux mini bulksubmit --quiet --shuffle --watch --progress -o pty --cc=1-4  --job-name={./%} \
   sh -c './{} -d -v --root=$FLUX_JOB_TMPDIR' ::: t*.t python/t*.py lua/t*.t
```
This command submits 4 copies of every test in the testsuite as a job to the current instance, watching progress and output as the tests progress.

However, when attempting this on fluke, I ran into several issues, including:

 - Because the testsuite runs with `LANG=C` and `FLUX_JOB_TMPDIR` contains the jobid in f58 encoding, a few test scripts and one core flux Python module broke due to Unicode errors.
 - at least one test broke when `FLUX_JOB_CC` was set in the current environment
 - a couple tests used static files or ports outside of the trash directory, so could not tolerate being run concurrently
 - the python tests don't accept or ignore options like `-d, --debug` or `--root=PATH` and instead abort with unknown option errors

This PR fixes all the little issues above.

I was then able to grab a large allocation on fluke and run the above command (even using `--cc=1-10` to run 10 copies of every test) successfully. 

```
PD:0    R:0    CD:1699 F:1    │██████████████████████████████████│100.0% 0:01:48
$ flux jobs -f failed -o {name}
NAME
t0000-sharness
```

There are still a couple issues I hope to run down:

 - `t0000-sharness.t` intermittently fails in this mode
 -  Some Lua tests need to get the ability to run in a unique directory
 -  Some tests emit special pty characters when running, which messes up the top-level `--progress` meter

Therefore this is still a WIP

