### PR TITLE
content-sqlite: check that file has rw permission

### DIFF
--- a/src/modules/content-sqlite/content-sqlite.c
+++ b/src/modules/content-sqlite/content-sqlite.c
@@ -13,6 +13,7 @@
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
+#include <unistd.h>
 #include <sqlite3.h>
 #include <lz4.h>
 #include <flux/core.h>
@@ -622,6 +623,12 @@ static struct content_sqlite *content_sqlite_create (flux_t *h)
     if (backing_path) {
         if (!(ctx->dbfile = strdup (backing_path)))
             goto error;
+        if (access (ctx->dbfile, F_OK) == 0) {
+            if (access (ctx->dbfile, R_OK | W_OK) < 0) {
+                flux_log_error (h, "ctx->dbfile");
+                goto error;
+            }
+        }
     }
     else {
         const char *rundir = flux_attr_get (h, "rundir");

--- a/t/t0012-content-sqlite.t
+++ b/t/t0012-content-sqlite.t
@@ -198,5 +198,10 @@ test_expect_success 'remove heartbeat module' '
 	flux module remove heartbeat
 '
 
+# test for issue #4210
+test_expect_success 'remove read permission from content.sqlite file' '
+	chmod u-w $(flux getattr content.backing-path) &&
+	test_must_fail flux module load content-sqlite
+'
 
 test_done


### PR DESCRIPTION
Problem: when restarting Flux with an existing content.sqlite
file, sqlite does not raise an error if the db is open read-write
but the file is not writable.  Instead, it fails store RPCs one
by one.

Add an access(2) call before opening the database with the sqlite3 API.

Fixes #4210