### PR TITLE
job-manager: add builtin job duration validator plugin

### DIFF
--- a/src/modules/job-manager/Makefile.am
+++ b/src/modules/job-manager/Makefile.am
@@ -65,7 +65,8 @@ libjob_manager_la_SOURCES = \
 	jobtap.c \
 	plugins/priority-default.c \
 	plugins/dependency-after.c \
-	plugins/begin-time.c
+	plugins/begin-time.c \
+	plugins/validate-duration.c
 
 fluxinclude_HEADERS = \
 	jobtap.h

--- a/src/modules/job-manager/jobtap.c
+++ b/src/modules/job-manager/jobtap.c
@@ -41,6 +41,7 @@
 extern int priority_default_plugin_init (flux_plugin_t *p);
 extern int after_plugin_init (flux_plugin_t *p);
 extern int begin_time_plugin_init (flux_plugin_t *p);
+extern int validate_duration_plugin_init (flux_plugin_t *p);
 
 struct jobtap_builtin {
     const char *name;
@@ -51,6 +52,7 @@ static struct jobtap_builtin jobtap_builtins [] = {
     { ".priority-default", priority_default_plugin_init },
     { ".dependency-after", after_plugin_init },
     { ".begin-time", &begin_time_plugin_init },
+    { ".validate-duration", &validate_duration_plugin_init },
     { 0 },
 };
 

--- a/src/modules/job-manager/plugins/validate-duration.c
+++ b/src/modules/job-manager/plugins/validate-duration.c
@@ -1,0 +1,119 @@
+/************************************************************\
+ * Copyright 2022 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/*  validate-duration.c - Ensure a job's duration doesn't exceed
+ *   the current resource expiration (at the moment of submission)
+ */
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <flux/core.h>
+#include <flux/jobtap.h>
+
+#include "src/common/libutil/fsd.h"
+
+static double expiration = 0.;
+
+static int job_duration_check (flux_plugin_t *p,
+                               flux_plugin_arg_t *args,
+                               double duration)
+{
+    flux_t *h = flux_jobtap_get_flux (p);
+
+    if (h && duration > 0. && expiration > 0.) {
+        flux_reactor_t *r = flux_get_reactor (h);
+        double now = r ? flux_reactor_now (r) : flux_reactor_time ();
+        double rem = expiration - now;
+
+        if (duration > rem) {
+            char dfsd [64];
+            char rfsd [64];
+
+            if (fsd_format_duration_ex (dfsd, sizeof (dfsd), duration, 2) < 0
+                || fsd_format_duration_ex (rfsd, sizeof (rfsd), rem, 2) < 0) {
+                const char *msg = "duration exceeds instance lifetime";
+                return flux_jobtap_reject_job (p, args, "%s", msg);
+            }
+            return flux_jobtap_reject_job (p,
+                                           args,
+                                           "job duration (%s) exceeds "
+                                           "remaining instance lifetime (%s)",
+                                           dfsd,
+                                           rfsd);
+        }
+    }
+    return 0;
+}
+
+static int validate_duration (flux_plugin_t *p,
+                              const char *topic,
+                              flux_plugin_arg_t *args,
+                              void *arg)
+{
+    double duration = -1.;
+
+    if (flux_plugin_arg_unpack (args, FLUX_PLUGIN_ARG_IN,
+                                "{s:{s:{s?{s?F}}}}",
+                                "jobspec",
+                                 "attributes",
+                                  "system",
+                                   "duration", &duration) < 0) {
+        return flux_jobtap_reject_job (p,
+                                       args,
+                                       "failed to unpack duration: %s",
+                                       flux_plugin_arg_strerror (args));
+    }
+    return job_duration_check (p, args, duration);
+}
+
+static void kvs_lookup_cb (flux_future_t *f, void *arg)
+{
+    flux_t *h = flux_future_get_flux (f);
+    if (flux_kvs_lookup_get_unpack (f,
+                                    "{s:{s:F}}",
+                                    "execution",
+                                    "expiration", &expiration) < 0) {
+        flux_log_error (h, "flux_kvs_lookup_unpack");
+    }
+    flux_future_reset (f);
+    flux_log (h,
+              LOG_DEBUG,
+              "duration-validator: updated expiration to %.2f",
+              expiration);
+}
+
+int validate_duration_plugin_init (flux_plugin_t *p)
+{
+    flux_t *h;
+    flux_future_t *f;
+
+    flux_plugin_set_name (p, ".validate-duration");
+
+    h = flux_jobtap_get_flux (p);
+
+    if (!(f = flux_kvs_lookup (h,
+                               NULL,
+                               FLUX_KVS_WATCH | FLUX_KVS_WAITCREATE,
+                               "resource.R"))) {
+        flux_log_error (h, "flux_kvs_lookup");
+        return -1;
+    }
+    flux_plugin_aux_set (p, NULL, f, (flux_free_f) flux_future_destroy);
+    if (flux_future_then (f, -1., kvs_lookup_cb, NULL) < 0) {
+        flux_log_error (h, "flux_kvs_lookup_get_unpack");
+        return -1;
+    }
+    return flux_plugin_add_handler (p,
+                                    "job.validate",
+                                    validate_duration,
+                                    NULL);
+}
+

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -136,6 +136,7 @@ TESTSCRIPTS = \
 	t2272-job-begin-time.t \
 	t2273-job-alloc-bypass.t \
 	t2274-manager-perilog.t \
+	t2275-job-duration-validator.t \
 	t2280-job-memo.t \
 	t2300-sched-simple.t \
 	t2302-sched-simple-up-down.t \

--- a/t/t2275-job-duration-validator.t
+++ b/t/t2275-job-duration-validator.t
@@ -1,0 +1,41 @@
+#!/bin/sh
+
+test_description='Test job duration validator plugin in job-manager'
+
+. $(dirname $0)/sharness.sh
+
+skip_all_unless_have jq
+
+test_under_flux 1 job
+
+flux setattr log-stderr-level 1
+
+test_expect_success 'duration: no validation when there is no expiration' '
+	flux mini submit -t 100d true
+'
+
+wait_duration_update() {
+	local value=$1
+	local n=10
+	while test $n -gt 0; do
+		flux dmesg | grep "duration-validator:.*$value" && return 0
+	done
+	return 1
+}
+test_expect_success 'duration: set an expiration on resource.R' '
+	expiration=$(($(date +%s)+60)) &&
+	flux kvs put \
+	    resource.R="$(flux kvs get resource.R | \
+			jq -S .execution.expiration=$expiration)" &&
+	wait_duration_update $expiration
+'
+test_expect_success 'duration: submit a job without duration' '
+	flux mini submit true
+'
+test_expect_success 'duration: submit a job with duration below expiration' '
+	flux mini submit -t 5s true
+'
+test_expect_success 'duration: submit a job with duration after expiration' '
+	test_must_fail flux mini submit -t 1h true
+'
+test_done


### PR DESCRIPTION
There are several ways to validate that the requested time limit of a job (as set in the `duration` key of jobspec) will not exceed the current instance lifetime (as set in `R.execution.expiration`). The approach used here is to add  a builtin jobtap plugin which fetches `resource.R` and rejects jobs where the submitted `duration` would exceed any instance `expiration` as set in _R_.

Another possible approach would be to do the validation in the scheduler "feasibility" RPC. But the feasibility RPC is only optionally enabled, and enabling it by default causes lots of tests to break. Also the feasibility plugin is only able to reject jobs when the scheduler is loaded, leaving a gap when the scheduler is unloaded or being reloaded for some reason.

A job validator plugin could also be developed which would run alongside the jobspec validator and optional scheduler feasibility validator. However, each time this plugin starts up it would have to fetch `resource.R` to get the current instance expiration and since the validator script is started on demand I don't think we want to pay the extra Python startup cost.

So, the approach taken in this PR is to have a jobtap plugin, loaded by default, which will validate job duration so that we get that functionality in all instances of Flux, regardless of scheduler.