### PR TITLE
kvs: always store empty directory object to content store

### DIFF
--- a/src/cmd/builtin/restore.c
+++ b/src/cmd/builtin/restore.c
@@ -295,26 +295,6 @@ static json_t *restore_snapshot (struct archive *ar, flux_t *h)
     return rootref;
 }
 
-/* Work around #4222.
- */
-static void store_empty_dir (flux_t *h)
-{
-    json_t *dir;
-    char *s;
-    flux_future_t *f = NULL;
-
-    if (!(dir = treeobj_create_dir ())
-        || !(s = treeobj_encode (dir))
-        || !(f = content_store (h, s, strlen (s), content_flags))
-        || flux_rpc_get (f, NULL) < 0)
-        log_msg_exit ("error storing emtpy directory: %s",
-                      future_strerror (f, errno));
-    flux_future_destroy (f);
-    free (s);
-    json_decref (dir);
-    progress (1, 0);
-}
-
 /* Return the number of characters of 'blobref' that a human might want to see.
  */
 static int shortblobref_length (const char *blobref)
@@ -382,7 +362,6 @@ static int cmd_restore (optparse_t *p, int ac, char *av[])
         if (kvs_is_running (h))
             log_msg_exit ("please unload kvs module before using --checkpoint");
 
-        store_empty_dir (h);
         dirref = restore_snapshot (ar, h);
         blobref = treeobj_get_blobref (dirref, 0);
         progress_end ();
@@ -409,7 +388,6 @@ static int cmd_restore (optparse_t *p, int ac, char *av[])
         flux_kvs_txn_t *txn;
         flux_future_t *f;
 
-        store_empty_dir (h);
         dirref = restore_snapshot (ar, h);
         blobref = treeobj_get_blobref (dirref, 0);
         progress_end ();

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -286,6 +286,7 @@ dist_check_SCRIPTS = \
 	issues/t3982-python-message-ref.py \
 	issues/t4182-resource-rerank.sh \
 	issues/t4184-sched-simple-restart.sh \
+	issues/t4222-kvs-assume-empty-dir.sh \
 	python/__init__.py \
 	python/subflux.py \
 	python/tap \

--- a/t/issues/t4222-kvs-assume-empty-dir.sh
+++ b/t/issues/t4222-kvs-assume-empty-dir.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -e
+
+flux module remove kvs
+
+flux dump --checkpoint issue4222.tar
+
+flux content flush
+flux content dropcache
+flux module remove content-sqlite
+
+sqlitepath=`flux getattr content.backing-path`
+mv $sqlitepath $sqlitepath.bak
+
+flux module load content-sqlite
+
+flux restore --checkpoint issue4222.tar
+
+flux module load kvs
+
+flux kvs namespace create issue4222ns
+flux kvs put --namespace=issue4222ns a=1

--- a/t/t2807-dump-cmd.t
+++ b/t/t2807-dump-cmd.t
@@ -104,10 +104,9 @@ test_expect_success 'unload content-sqlite' '
 
 # Intermediate rootdir versions are not preserved across dump/restore.
 # Expect a blobcount of 4: rootdir 5th version + 'a' + 'b' + 'x',
-# plus 1 for empty directory added as workaround for #4222
 #
 test_expect_success 'count blobs after restore'\'s' implicit garbage collection' '
-	echo 5 >blobcount2.exp &&
+	echo 4 >blobcount2.exp &&
 	countblobs >blobcount2.out &&
 	test_cmp blobcount2.exp blobcount2.out
 '


### PR DESCRIPTION
Problem: The kvs has always assumed an empty directory treeobj
has been stored in the content store, because that is how the first
kvs root was originally initialized.  The introduction of kvs dump / restore
can prune non-referenced objects in the content store, such as the
empty directory treeobj.  This can lead to errors.

Solution: Always store an empty directory object into the content
store when loading the kvs module.

Fixes https://github.com/flux-framework/flux-core/issues/4222