### PR TITLE
libjob: improve flux_job_statetostr(), flux_job_resulttostr() interface

### DIFF
--- a/src/bindings/python/flux/job/info.py
+++ b/src/bindings/python/flux/job/info.py
@@ -29,20 +29,20 @@ def statetostr(stateid, fmt="L"):
     return raw.flux_job_statetostr(stateid, fmt).decode("utf-8")
 
 
-def resulttostr(resultid, singlechar=False):
+def resulttostr(resultid, fmt="L"):
     # if result not returned, just return empty string back
     if resultid == "":
         return ""
-    return raw.flux_job_resulttostr(resultid, singlechar).decode("utf-8")
+    return raw.flux_job_resulttostr(resultid, fmt).decode("utf-8")
 
 
-def statustostr(stateid, resultid, abbrev=False):
+def statustostr(stateid, resultid, fmt="L"):
     if stateid & flux.constants.FLUX_JOB_STATE_PENDING:
-        statusstr = "PD" if abbrev else "PENDING"
+        statusstr = "PD" if fmt == "S" else "PENDING"
     elif stateid & flux.constants.FLUX_JOB_STATE_RUNNING:
-        statusstr = "R" if abbrev else "RUNNING"
+        statusstr = "R" if fmt == "S" else "RUNNING"
     else:  # flux.constants.FLUX_JOB_STATE_INACTIVE
-        statusstr = resulttostr(resultid, abbrev)
+        statusstr = resulttostr(resultid, fmt)
     return statusstr
 
 
@@ -305,7 +305,7 @@ class JobInfo:
 
     @memoized_property
     def result_abbrev(self):
-        return resulttostr(self.result_id, True)
+        return resulttostr(self.result_id, "S")
 
     @memoized_property
     def username(self):
@@ -317,11 +317,11 @@ class JobInfo:
 
     @memoized_property
     def status(self):
-        return statustostr(self.state_id, self.result_id, False)
+        return statustostr(self.state_id, self.result_id)
 
     @memoized_property
     def status_abbrev(self):
-        return statustostr(self.state_id, self.result_id, True)
+        return statustostr(self.state_id, self.result_id, fmt="S")
 
     @memoized_property
     def returncode(self):

--- a/src/bindings/python/flux/job/info.py
+++ b/src/bindings/python/flux/job/info.py
@@ -25,8 +25,8 @@ from flux.uri import JobURI
 from flux.core.inner import raw
 
 
-def statetostr(stateid, singlechar=False):
-    return raw.flux_job_statetostr(stateid, singlechar).decode("utf-8")
+def statetostr(stateid, fmt="L"):
+    return raw.flux_job_statetostr(stateid, fmt).decode("utf-8")
 
 
 def resulttostr(resultid, singlechar=False):
@@ -297,7 +297,7 @@ class JobInfo:
 
     @memoized_property
     def state_single(self):
-        return statetostr(self.state_id, True)
+        return statetostr(self.state_id, fmt="S")
 
     @memoized_property
     def result(self):

--- a/src/cmd/top/joblist_pane.c
+++ b/src/cmd/top/joblist_pane.c
@@ -125,7 +125,7 @@ void joblist_pane_draw (struct joblist_pane *joblist)
                    "%13.13s %8.8s %2.2s %6d %6d %7.7s %-*.*s",
                    idstr,
                    username,
-                   flux_job_statetostr (state, true),
+                   flux_job_statetostr (state, "S"),
                    ntasks,
                    nnodes,
                    run,

--- a/src/common/libjob/Makefile.am
+++ b/src/common/libjob/Makefile.am
@@ -32,7 +32,9 @@ libjob_la_SOURCES = \
 	job_hash.c \
 	job_hash.h \
 	jobspec1.c \
-	jobspec1_private.h
+	jobspec1_private.h \
+	strtab.c \
+	strtab.h
 
 TESTS = \
 	test_job.t \

--- a/src/common/libjob/job.h
+++ b/src/common/libjob/job.h
@@ -107,7 +107,7 @@ const char *flux_job_statetostr (flux_job_state_t state, const char *fmt);
  */
 int flux_job_strtostate (const char *s, flux_job_state_t *state);
 
-const char *flux_job_resulttostr (flux_job_result_t result, bool abbrev);
+const char *flux_job_resulttostr (flux_job_result_t result, const char *fmt);
 
 int flux_job_strtoresult (const char *s, flux_job_result_t *result);
 

--- a/src/common/libjob/job.h
+++ b/src/common/libjob/job.h
@@ -92,8 +92,19 @@ int flux_job_id_parse (const char *s, flux_jobid_t *id);
 int flux_job_id_encode (flux_jobid_t id, const char *type,
                         char *buf, size_t bufsz);
 
-const char *flux_job_statetostr (flux_job_state_t state, bool single_char);
+/* Convert state to string.  'fmt' may be:
+ * "s" - lower case short name
+ * "S" - upper case short name
+ * "l" - lower case long name
+ * "L" - upper case long name
+ * This function always returns a valid string, though it may
+ * be something like "(unknown)".
+ */
+const char *flux_job_statetostr (flux_job_state_t state, const char *fmt);
 
+/* Convert state string in any of the forms produced by flux_job_statetostr()
+ * back to state.  Returns 0 on success, -1 on failure with errno set.
+ */
 int flux_job_strtostate (const char *s, flux_job_state_t *state);
 
 const char *flux_job_resulttostr (flux_job_result_t result, bool abbrev);

--- a/src/common/libjob/state.c
+++ b/src/common/libjob/state.c
@@ -14,53 +14,34 @@
 #include <flux/core.h>
 
 #include "job.h"
+#include "strtab.h"
 
-const char *flux_job_statetostr (flux_job_state_t state, bool single_char)
+static struct strtab states[] = {
+    { FLUX_JOB_STATE_NEW,       "NEW",      "new",      "N", "n" },
+    { FLUX_JOB_STATE_DEPEND,    "DEPEND",   "depend",   "D", "d" },
+    { FLUX_JOB_STATE_PRIORITY,  "PRIORITY", "priority", "P", "p" },
+    { FLUX_JOB_STATE_SCHED,     "SCHED",    "sched",    "S", "s" },
+    { FLUX_JOB_STATE_RUN,       "RUN",      "run",      "R", "r" },
+    { FLUX_JOB_STATE_CLEANUP,   "CLEANUP",  "cleanup",  "C", "c" },
+    { FLUX_JOB_STATE_INACTIVE,  "INACTIVE", "inactive", "I", "i" },
+};
+static const size_t states_count = sizeof (states) / sizeof (states[0]);
+
+
+const char *flux_job_statetostr (flux_job_state_t state, const char *fmt)
 {
-    switch (state) {
-        case FLUX_JOB_STATE_NEW:
-            return single_char ? "N" : "NEW";
-        case FLUX_JOB_STATE_DEPEND:
-            return single_char ? "D" : "DEPEND";
-        case FLUX_JOB_STATE_PRIORITY:
-            return single_char ? "P" : "PRIORITY";
-        case FLUX_JOB_STATE_SCHED:
-            return single_char ? "S" : "SCHED";
-        case FLUX_JOB_STATE_RUN:
-            return single_char ? "R" : "RUN";
-        case FLUX_JOB_STATE_CLEANUP:
-            return single_char ? "C" : "CLEANUP";
-        case FLUX_JOB_STATE_INACTIVE:
-            return single_char ? "I" : "INACTIVE";
-    }
-    return single_char ? "?" : "(unknown)";
+    return strtab_numtostr (state, fmt, states, states_count);
 }
 
 int flux_job_strtostate (const char *s, flux_job_state_t *state)
 {
-    if (!s || !state)
-        goto inval;
-    if (!strcasecmp (s, "N") || !strcasecmp (s, "NEW"))
-        *state = FLUX_JOB_STATE_NEW;
-    else if (!strcasecmp (s, "D") || !strcasecmp (s, "DEPEND"))
-        *state = FLUX_JOB_STATE_DEPEND;
-    else if (!strcasecmp (s, "P") || !strcasecmp (s, "PRIORITY"))
-        *state = FLUX_JOB_STATE_PRIORITY;
-    else if (!strcasecmp (s, "S") || !strcasecmp (s, "SCHED"))
-        *state = FLUX_JOB_STATE_SCHED;
-    else if (!strcasecmp (s, "R") || !strcasecmp (s, "RUN"))
-        *state = FLUX_JOB_STATE_RUN;
-    else if (!strcasecmp (s, "C") || !strcasecmp (s, "CLEANUP"))
-        *state = FLUX_JOB_STATE_CLEANUP;
-    else if (!strcasecmp (s, "I") || !strcasecmp (s, "INACTIVE"))
-        *state = FLUX_JOB_STATE_INACTIVE;
-    else
-        goto inval;
+    int num;
 
+    if ((num = strtab_strtonum (s, states, states_count)) < 0)
+        return -1;
+    if (state)
+        *state = num;
     return 0;
-inval:
-    errno = EINVAL;
-    return -1;
 }
 
 /*

--- a/src/common/libjob/strtab.c
+++ b/src/common/libjob/strtab.c
@@ -1,0 +1,63 @@
+/************************************************************\
+ * Copyright 2022 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/core.h>
+
+#include "strtab.h"
+
+static const char *format_entry (struct strtab *entry, const char *fmt)
+{
+    switch (fmt ? *fmt : 0) {
+        case 's':
+            return entry->short_lower;
+        case 'S':
+            return entry->short_upper;
+        case 'l':
+            return entry->long_lower;
+        case 'L':
+        default:
+            return entry->long_upper;
+    }
+}
+
+const char *strtab_numtostr (int num,
+                             const char *fmt,
+                             struct strtab *strtab,
+                             size_t count)
+{
+    struct strtab unknown = { 0, "(unknown)", "(unknown)", "?", "?" };
+
+    for (int i = 0; i < count; i++)
+        if (strtab[i].num == num)
+            return format_entry (&strtab[i], fmt);
+    return format_entry (&unknown, fmt);
+}
+
+int strtab_strtonum (const char *s, struct strtab *strtab, size_t count)
+{
+    if (s) {
+        for (int i = 0; i < count; i++) {
+            if (!strcmp (strtab[i].short_lower, s)
+                || !strcmp (strtab[i].short_upper, s)
+                || !strcmp (strtab[i].long_lower, s)
+                || !strcmp (strtab[i].long_upper, s))
+                return strtab[i].num;
+        }
+    }
+    errno = EINVAL;
+    return -1;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libjob/strtab.h
+++ b/src/common/libjob/strtab.h
@@ -1,0 +1,39 @@
+/************************************************************\
+ * Copyright 2022 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <sys/types.h>
+
+#ifndef _LIBJOB_STRTAB_H
+#define _LIBJOB_STRTAB_H
+
+struct strtab {
+    int num;
+    const char *long_upper;
+    const char *long_lower;
+    const char *short_upper;
+    const char *short_lower;
+};
+
+const char *strtab_numtostr (int num,
+                             const char *fmt,
+                             struct strtab *strtab,
+                             size_t count);
+
+int strtab_strtonum (const char *s, struct strtab *strtab, size_t count);
+
+#endif // !_LIBJOB_STRTAB_H
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libjob/test/job.c
+++ b/src/common/libjob/test/job.c
@@ -228,17 +228,19 @@ struct ss {
     flux_job_state_t state;
     const char *s;
     const char *s_long;
+    const char *s_lower;
+    const char *s_long_lower;
 };
 
 struct ss sstab[] = {
-    { FLUX_JOB_STATE_NEW,      "N", "NEW" },
-    { FLUX_JOB_STATE_DEPEND,   "D", "DEPEND" },
-    { FLUX_JOB_STATE_PRIORITY, "P", "PRIORITY" },
-    { FLUX_JOB_STATE_SCHED,    "S", "SCHED" },
-    { FLUX_JOB_STATE_RUN,      "R", "RUN" },
-    { FLUX_JOB_STATE_CLEANUP,  "C", "CLEANUP" },
-    { FLUX_JOB_STATE_INACTIVE, "I", "INACTIVE" },
-    { -1, NULL, NULL },
+    { FLUX_JOB_STATE_NEW,      "N", "NEW", "n", "new" },
+    { FLUX_JOB_STATE_DEPEND,   "D", "DEPEND", "d", "depend" },
+    { FLUX_JOB_STATE_PRIORITY, "P", "PRIORITY", "p", "priority" },
+    { FLUX_JOB_STATE_SCHED,    "S", "SCHED", "s", "sched" },
+    { FLUX_JOB_STATE_RUN,      "R", "RUN", "r", "run" },
+    { FLUX_JOB_STATE_CLEANUP,  "C", "CLEANUP", "c", "cleanup" },
+    { FLUX_JOB_STATE_INACTIVE, "I", "INACTIVE", "i", "inactive" },
+    { -1, NULL, NULL, NULL, NULL },
 };
 
 void check_statestr(void)
@@ -246,24 +248,46 @@ void check_statestr(void)
     struct ss *ss;
 
     for (ss = &sstab[0]; ss->s != NULL; ss++) {
-        const char *s = flux_job_statetostr (ss->state, true);
-        const char *s_long = flux_job_statetostr (ss->state, false);
+        const char *s = flux_job_statetostr (ss->state, "S");
+        const char *s_long = flux_job_statetostr (ss->state, "L");
+        const char *s_lower = flux_job_statetostr (ss->state, "s");
+        const char *s_long_lower = flux_job_statetostr (ss->state, "l");
         ok (s && !strcmp (s, ss->s),
-            "flux_job_statetostr (%d, true) = %s", ss->state, ss->s);
+            "flux_job_statetostr (%d, S) = %s", ss->state, ss->s);
         ok (s_long && !strcmp (s_long, ss->s_long),
-            "flux_job_statetostr (%d, false) = %s", ss->state, ss->s_long);
+            "flux_job_statetostr (%d, L) = %s", ss->state, ss->s_long);
+        ok (s_lower && !strcmp (s_lower, ss->s_lower),
+            "flux_job_statetostr (%d, s) = %s", ss->state, ss->s_lower);
+        ok (s_long_lower && !strcmp (s_long_lower, ss->s_long_lower),
+            "flux_job_statetostr (%d, l) = %s", ss->state, ss->s_long_lower);
     }
     for (ss = &sstab[0]; ss->s != NULL; ss++) {
         flux_job_state_t state;
-        ok (flux_job_strtostate (ss->s, &state) == 0 && state == ss->state,
+        ok (flux_job_strtostate (ss->s, &state) == 0
+            && state == ss->state,
             "flux_job_strtostate (%s) = %d", ss->s, ss->state);
-        ok (flux_job_strtostate (ss->s_long, &state) == 0 && state == ss->state,
+        ok (flux_job_strtostate (ss->s_long, &state) == 0
+            && state == ss->state,
             "flux_job_strtostate (%s) = %d", ss->s_long, ss->state);
+        ok (flux_job_strtostate (ss->s_lower, &state) == 0
+            && state == ss->state,
+            "flux_job_strtostate (%s) = %d", ss->s_lower, ss->state);
+        ok (flux_job_strtostate (ss->s_long_lower, &state) == 0
+            && state == ss->state,
+            "flux_job_strtostate (%s) = %d", ss->s_long_lower, ss->state);
     }
-    ok (flux_job_statetostr (0, true) != NULL,
-        "flux_job_statetostr (0, true) returned non-NULL");
-    ok (flux_job_statetostr (0, false) != NULL,
-        "flux_job_statetostr (0, false) returned non-NULL");
+    ok (flux_job_statetostr (0, "S") != NULL,
+        "flux_job_statetostr (0, S) returned non-NULL");
+    ok (flux_job_statetostr (0, "s") != NULL,
+        "flux_job_statetostr (0, s) returned non-NULL");
+    ok (flux_job_statetostr (0, "L") != NULL,
+        "flux_job_statetostr (0, L) returned non-NULL");
+    ok (flux_job_statetostr (0, "l") != NULL,
+        "flux_job_statetostr (0, l) returned non-NULL");
+    ok (flux_job_statetostr (0, "") != NULL,
+        "flux_job_statetostr (0, <emtpy string>) returned non-NULL");
+    ok (flux_job_statetostr (0, NULL) != NULL,
+        "flux_job_statetostr (0, NULL) returned non-NULL");
 }
 
 struct rr {

--- a/src/common/libjob/test/job.c
+++ b/src/common/libjob/test/job.c
@@ -294,14 +294,16 @@ struct rr {
     flux_job_result_t result;
     const char *r;
     const char *r_long;
+    const char *r_lower;
+    const char *r_long_lower;
 };
 
 struct rr rrtab[] = {
-    { FLUX_JOB_RESULT_COMPLETED, "CD", "COMPLETED" },
-    { FLUX_JOB_RESULT_FAILED,    "F",  "FAILED" },
-    { FLUX_JOB_RESULT_CANCELED,  "CA", "CANCELED" },
-    { FLUX_JOB_RESULT_TIMEOUT,   "TO", "TIMEOUT" },
-    { -1, NULL, NULL },
+    { FLUX_JOB_RESULT_COMPLETED, "CD", "COMPLETED", "cd", "completed" },
+    { FLUX_JOB_RESULT_FAILED,    "F",  "FAILED", "f", "failed" },
+    { FLUX_JOB_RESULT_CANCELED,  "CA", "CANCELED", "ca", "canceled" },
+    { FLUX_JOB_RESULT_TIMEOUT,   "TO", "TIMEOUT", "to", "timeout" },
+    { -1, NULL, NULL, NULL, NULL },
 };
 
 void check_resultstr(void)
@@ -309,12 +311,18 @@ void check_resultstr(void)
     struct rr *rr;
 
     for (rr = &rrtab[0]; rr->r != NULL; rr++) {
-        const char *r = flux_job_resulttostr (rr->result, true);
-        const char *r_long = flux_job_resulttostr (rr->result, false);
+        const char *r = flux_job_resulttostr (rr->result, "S");
+        const char *r_long = flux_job_resulttostr (rr->result, "L");
+        const char *r_lower = flux_job_resulttostr (rr->result, "s");
+        const char *r_long_lower = flux_job_resulttostr (rr->result, "l");
         ok (r && !strcmp (r, rr->r),
-            "flux_job_resulttostr (%d, true) = %s", rr->result, rr->r);
+            "flux_job_resulttostr (%d, S) = %s", rr->result, rr->r);
         ok (r_long && !strcmp (r_long, rr->r_long),
-            "flux_job_resulttostr (%d, false) = %s", rr->result, rr->r_long);
+            "flux_job_resulttostr (%d, L) = %s", rr->result, rr->r_long);
+        ok (r_lower && !strcmp (r_lower, rr->r_lower),
+            "flux_job_resulttostr (%d, s) = %s", rr->result, rr->r_lower);
+        ok (r_long_lower && !strcmp (r_long_lower, rr->r_long_lower),
+            "flux_job_resulttostr (%d, l) = %s", rr->result, rr->r_long_lower);
     }
     for (rr = &rrtab[0]; rr->r != NULL; rr++) {
         flux_job_result_t result;
@@ -323,10 +331,14 @@ void check_resultstr(void)
         ok (flux_job_strtoresult (rr->r_long, &result) == 0 && result == rr->result,
             "flux_job_strtoresult (%s) = %d", rr->r_long, rr->result);
     }
-    ok (flux_job_resulttostr (0, true) != NULL,
-        "flux_job_resulttostr (0, true) returned non-NULL");
-    ok (flux_job_resulttostr (0, false) != NULL,
-        "flux_job_resulttostr (0, false) returned non-NULL");
+    ok (flux_job_resulttostr (0, "S") != NULL,
+        "flux_job_resulttostr (0, S) returned non-NULL");
+    ok (flux_job_resulttostr (0, "L") != NULL,
+        "flux_job_resulttostr (0, L) returned non-NULL");
+    ok (flux_job_resulttostr (0, "") != NULL,
+        "flux_job_resulttostr (0, <empty string>) returned non-NULL");
+    ok (flux_job_resulttostr (0, NULL) != NULL,
+        "flux_job_resulttostr (0, NULL) returned non-NULL");
 }
 
 void check_kvs_namespace (void)

--- a/src/modules/job-list/stats.c
+++ b/src/modules/job-list/stats.c
@@ -35,17 +35,7 @@ static inline int state_index (flux_job_state_t state)
  */
 static const char *state_index_name (int index)
 {
-    static char name[64];
-    char *p;
-
-    memset (name, 0, sizeof (name));
-    strncpy (name,
-            flux_job_statetostr ((1<<index), false),
-            sizeof (name) - 1);
-
-    for (p = name; *p != '\0'; ++p)
-        *p = tolower(*p);
-    return name;
+    return flux_job_statetostr ((1<<index), "l");
 }
 
 void job_stats_update (struct job_stats *stats,

--- a/src/modules/job-manager/event.c
+++ b/src/modules/job-manager/event.c
@@ -279,7 +279,7 @@ int event_batch_pub_state (struct event *event, struct job *job,
     }
     if (!(o = json_pack ("[I,s,f]",
                          job->id,
-                         flux_job_statetostr (job->state, false),
+                         flux_job_statetostr (job->state, "L"),
                          timestamp)))
         goto nomem;
     if (json_array_append_new (event->batch->state_trans, o)) {

--- a/t/job-manager/job-conv.py
+++ b/t/job-manager/job-conv.py
@@ -40,11 +40,14 @@ def strtostate(args):
 
 
 def resulttostr(args):
+    fmt = "L"
+    if args.abbrev:
+        fmt = "S"
     if not args.results:
         args.results = [line.strip() for line in sys.stdin]
 
     for result in args.results:
-        print(raw.flux_job_resulttostr(int(result), args.abbrev).decode("utf-8"))
+        print(raw.flux_job_resulttostr(int(result), fmt).decode("utf-8"))
 
 
 def strtoresult(args):

--- a/t/job-manager/job-conv.py
+++ b/t/job-manager/job-conv.py
@@ -15,11 +15,14 @@ from flux.core.inner import ffi, raw
 
 
 def statetostr(args):
+    fmt = "L"
+    if args.single:
+        fmt = "S"
     if not args.states:
         args.states = [line.strip() for line in sys.stdin]
 
     for state in args.states:
-        print(raw.flux_job_statetostr(int(state), args.single).decode("utf-8"))
+        print(raw.flux_job_statetostr(int(state), fmt).decode("utf-8"))
 
 
 def strtostate(args):

--- a/t/stats/stats-immediate.c
+++ b/t/stats/stats-immediate.c
@@ -41,8 +41,8 @@ static int state_cb (flux_plugin_t *p,
         return -1;
     }
 
-    flux_stats_gauge_inc (h, flux_job_statetostr (state, false), 1);
-    flux_stats_gauge_inc (h, flux_job_statetostr (prev_state, false), -1);
+    flux_stats_gauge_inc (h, flux_job_statetostr (state, "L"), 1);
+    flux_stats_gauge_inc (h, flux_job_statetostr (prev_state, "L"), -1);
 
     switch (state) {
         case FLUX_JOB_STATE_CLEANUP:


### PR DESCRIPTION
This is a small "upgrade" to the interfaces for converting job states to strings that fell out of some other work I was doing.
```c
/* Convert state to string.  'fmt' may be:
 * "s" - lower case short name
 * "S" - upper case short name
 * "l" - lower case long name
 * "L" - upper case long name
 * This function always returns a valid string, though it may
 * be something like "(unknown)".
 */
const char *flux_job_statetostr (flux_job_state_t state, const char *fmt);
```
Identical change here, just to keep interfaces similar
```c
const char *flux_job_resulttostr (flux_job_result_t result, const char *fmt);
```