### PR TITLE
add support for resource properties

### DIFF
--- a/doc/man1/flux-mini.rst
+++ b/doc/man1/flux-mini.rst
@@ -131,6 +131,22 @@ emitting the job's I/O to its stdout and stderr.
 **-l, --label-io**
    Add task rank prefixes to each line of output.
 
+CONSTRAINTS
+===========
+
+.. note::
+   Flux supports an advanced constraint specification detailed in RFC 31.
+   However, the interface currently exported via the **flux mini** commands
+   is purposefully limited.
+
+**--requires=LIST**
+   Specify a *LIST* of resource property constraints for this job. *LIST*
+   is a single property or comma-separated list of properties which are
+   required for this job. The ``--requires`` option may be specified
+   multiple times. Currently, all properties are required (logical and).
+   If a property name starts with ``^``, then the job requires that property
+   *not* be present on assigned resources.
+
 DEPENDENCIES
 ============
 

--- a/src/bindings/python/flux/resource/ResourceSet.py
+++ b/src/bindings/python/flux/resource/ResourceSet.py
@@ -127,6 +127,26 @@ class ResourceSet:
     def intersect(self, *args):
         return self._run_op("intersect", *args)
 
+    def copy_constraint(self, constraint):
+        """
+        Return a copy of a ResourceSet containing only those resources that
+        match the RFC 31 constraint object `constraint`
+
+        :param constraint: An RFC 31 constraint object in encoded string
+                           form or as Python mapping. (The mapping will be
+                           converted to a JSON string)
+        """
+        return ResourceSet(self.impl.copy_constraint(constraint))
+
+    def set_property(self, name, ranks=None):
+        """
+        Set property 'name' on optional 'ranks' (all ranks if ranks is None)
+        """
+        if ranks is None:
+            ranks = str(self.ranks)
+        self.impl.set_property(name, ranks)
+        return self
+
     def remove_ranks(self, ranks):
         """
         Remove the rank or ranks specified from the ResourceSet

--- a/src/bindings/python/flux/resource/Rlist.py
+++ b/src/bindings/python/flux/resource/Rlist.py
@@ -110,3 +110,23 @@ class Rlist(WrapperPimpl):
     def add_child(self, rank, name, ids):
         self.pimpl.rank_add_child(rank, name, ids)
         return self
+
+    def set_property(self, name, ranks):
+        error = ffi.new("flux_error_t *")
+        try:
+            self.pimpl.add_property(error, name, ranks)
+        except OSError as exc:
+            raise ValueError(
+                "set_property: " + ffi.string(error.text).decode("utf-8")
+            ) from exc
+
+    def copy_constraint(self, constraint):
+        error = ffi.new("flux_error_t *")
+        if not isinstance(constraint, str):
+            constraint = json.dumps(constraint)
+        handle = self.pimpl.copy_constraint_string(constraint, error)
+        if not handle:
+            raise ValueError(
+                "copy_constraint: " + ffi.string(error.text).decode("utf-8")
+            )
+        return Rlist(handle=handle)

--- a/src/cmd/flux-mini.py
+++ b/src/cmd/flux-mini.py
@@ -241,6 +241,7 @@ class Xcmd:
         "log": "--log=",
         "log_stderr": "--log-stderr=",
         "dependency": "--dependency=",
+        "requires": "--requires=",
         "wait": "--wait-event=",
     }
 
@@ -468,6 +469,14 @@ class MiniCmd:
             metavar="URI",
         )
         parser.add_argument(
+            "--requires",
+            action="append",
+            help="Set one or more required resource properties for this job. "
+            + "Currently this option supports only a list of property names, "
+            + "optionally prefixed by ^ to indicate negation.",
+            metavar="LIST",
+        )
+        parser.add_argument(
             "--begin-time",
             action=BeginTimeAction,
             metavar="TIME",
@@ -567,6 +576,11 @@ class MiniCmd:
         if args.dependency is not None:
             jobspec.setattr(
                 "system.dependencies", dependency_array_create(args.dependency)
+            )
+        if args.requires is not None:
+            jobspec.setattr(
+                "system.constraints.properties",
+                list_split(args.requires),
             )
         if args.time_limit is not None:
             jobspec.duration = args.time_limit

--- a/src/common/libjob/jobspec1.c
+++ b/src/common/libjob/jobspec1.c
@@ -359,6 +359,13 @@ static int attr_system_check (json_t *o, flux_jobspec1_error_t *error)
                 return -1;
             }
         }
+        else if (!strcmp (key, "constraints")) {
+            if (!(json_is_object (value))) {
+                errprintf (error,
+                         "attributes.system.constraints must be a dictionary");
+                return -1;
+            }
+        }
         else if (!strcmp (key, "dependencies")) {
             size_t index;
             json_t *el;

--- a/src/common/librlist/Makefile.am
+++ b/src/common/librlist/Makefile.am
@@ -9,6 +9,7 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
 	-I$(top_srcdir)/src/common/libccan \
+	-I$(top_builddir)/src/common/libflux \
 	$(JANSSON_CFLAGS) \
 	$(HWLOC_CFLAGS)
 
@@ -18,6 +19,8 @@ noinst_LTLIBRARIES = \
 librlist_la_SOURCES = \
 	rnode.h \
 	rnode.c \
+	match.h \
+	match.c \
 	rlist.c \
 	rlist.h \
 	rhwloc.c \

--- a/src/common/librlist/Makefile.am
+++ b/src/common/librlist/Makefile.am
@@ -41,6 +41,7 @@ test_ldflags = \
 
 TESTS = \
 	test_rnode.t \
+	test_match.t \
 	test_rlist.t \
 	test_rhwloc.t
 
@@ -55,6 +56,16 @@ test_rnode_t_LDADD = \
 	librlist.la \
 	$(test_ldadd)
 test_rnode_t_LDFLAGS = \
+	$(test_ldflags)
+
+test_match_t_SOURCES = \
+	test/match.c
+test_match_t_CPPFLAGS = \
+	$(test_cppflags)
+test_match_t_LDADD = \
+	librlist.la \
+	$(test_ldadd)
+test_match_t_LDFLAGS = \
 	$(test_ldflags)
 
 test_rlist_t_SOURCES = \

--- a/src/common/librlist/Makefile.am
+++ b/src/common/librlist/Makefile.am
@@ -8,6 +8,7 @@ AM_LDFLAGS = \
 AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
+	-I$(top_srcdir)/src/common/libccan \
 	$(JANSSON_CFLAGS) \
 	$(HWLOC_CFLAGS)
 

--- a/src/common/librlist/match.c
+++ b/src/common/librlist/match.c
@@ -1,0 +1,196 @@
+/************************************************************\
+ * Copyright 2022 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <jansson.h>
+
+#include "src/common/libutil/errprintf.h"
+
+#include "match.h"
+
+static bool rnode_has (const struct rnode *n, const char *property)
+{
+    const char *prop = property;
+    bool match = false;
+    bool negate = false;
+
+    if (!property)
+        return false;
+
+    if (prop[0] == '^') {
+        prop++;
+        negate = true;
+    }
+
+    if ((n->properties && zhashx_lookup (n->properties, prop))
+        || strcmp (n->hostname, prop) == 0)
+        match = true;
+
+    return negate ? !match : match;
+}
+
+static bool rnode_has_all (const struct rnode *n, json_t *properties)
+{
+    json_t *entry;
+    size_t index;
+
+    json_array_foreach (properties, index, entry) {
+        if (!rnode_has (n, json_string_value (entry)))
+            return false;
+    }
+    return true;
+}
+
+static bool rnode_or (const struct rnode *n, json_t *args)
+{
+    json_t *constraint;
+    size_t index;
+    json_array_foreach (args, index, constraint) {
+        if (rnode_match (n, constraint))
+            return true;
+    }
+    /* No matches */
+    return false;
+}
+
+static bool rnode_and (const struct rnode *n, json_t *args)
+{
+    json_t *constraint;
+    size_t index;
+    json_array_foreach (args, index, constraint) {
+        if (!rnode_match (n, constraint))
+            return false;
+    }
+    /* All matches */
+    return true;
+}
+
+static bool rnode_not (const struct rnode *n, json_t *args)
+{
+    return !rnode_and (n, args);
+}
+
+bool rnode_match (const struct rnode *n, json_t *constraint)
+{
+    const char *op;
+    json_t *args;
+
+    if (!n || !constraint)
+        return false;
+
+    json_object_foreach (constraint, op, args) {
+        bool result;
+        if (strcmp (op, "properties") == 0)
+            result = rnode_has_all (n, args);
+        else if (strcmp (op, "or") == 0)
+            result = rnode_or (n, args);
+        else if (strcmp (op, "and") == 0)
+            result = rnode_and (n, args);
+        else if (strcmp (op, "not") == 0)
+            result = rnode_not (n, args);
+        else
+            result = false;
+
+        /*  Multiple keys in dict are treated like AND */
+        if (result == false)
+            return false;
+    }
+    return true;
+}
+
+static char * property_query_string_invalid (const char *s)
+{
+    /*  Return first invalid character.
+     *  Invalid chaaracters are listed in RFC 20, but we specifically
+     *   allow "^" since it is used as shorthand for `not`.
+     */
+    return strpbrk (s, "!&'\"`|()");
+}
+
+static int validate_properties (json_t *args, flux_error_t *errp)
+{
+    json_t *entry;
+    size_t index;
+
+    if (!json_is_array (args))
+        return errprintf (errp, "properties value must be an array");
+
+    json_array_foreach (args, index, entry) {
+        const char *value;
+        const char *invalid;
+
+        if (!json_is_string (entry))
+            return errprintf (errp, "non-string property specified");
+        value = json_string_value (entry);
+        if ((invalid = property_query_string_invalid (value)))
+            return errprintf (errp,
+                              "invalid character '%c' in property \"%s\"",
+                              *invalid,
+                              value);
+    }
+    return 0;
+}
+
+static int validate_conditional (const char *type,
+                                 json_t *args,
+                                 flux_error_t *errp)
+{
+    json_t *entry;
+    size_t index;
+
+    if (!json_is_array (args))
+        return errprintf (errp, "%s operator value must be an array", type);
+
+    json_array_foreach (args, index, entry) {
+        if (rnode_match_validate (entry, errp) < 0)
+            return -1;
+    }
+    return 0;
+}
+
+int rnode_match_validate (json_t *constraint, flux_error_t *errp)
+{
+    const char *op;
+    json_t *args;
+
+    if (!constraint || !json_is_object (constraint))
+        return errprintf (errp, "constraint must be JSON object");
+
+    json_object_foreach (constraint, op, args) {
+        if (strcmp (op, "properties") == 0) {
+            if (validate_properties (args, errp) < 0)
+                return -1;
+        }
+        else if (strcmp (op, "or") == 0
+                || strcmp (op, "and") == 0
+                || strcmp (op, "not") == 0) {
+            if (validate_conditional (op, args, errp) < 0)
+                return -1;
+        }
+        else
+            return errprintf (errp, "unknown constraint operator: %s", op);
+    }
+    return 0;
+}
+
+struct rnode *rnode_copy_match (const struct rnode *orig,
+                                json_t *constraint)
+{
+    return rnode_match (orig, constraint) ? rnode_copy (orig) : NULL;
+}
+
+/* vi: ts=4 sw=4 expandtab
+ */

--- a/src/common/librlist/match.h
+++ b/src/common/librlist/match.h
@@ -1,0 +1,38 @@
+/************************************************************\
+ * Copyright 2022 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef HAVE_RLIST_MATCH_H
+#define HAVE_RLIST_MATCH_H 1
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <flux/core.h> /* flux_error_t */
+
+#include "rnode.h"
+
+/*  Return true if rnode 'n' matches constraints in RFC 31 constraint
+ *   specification 'constraint'.
+ */
+bool rnode_match (const struct rnode *n, json_t *constraint);
+
+/*  Validate RFC 31 constraint spec 'constraint'
+ *
+ *  Returns 0 if constraint is valid spec,
+ *         -1 if not and sets error in errp if errp != NULL.
+ *
+ */
+int rnode_match_validate (json_t *constraint, flux_error_t *errp);
+
+/*  Copy an rnode only if it matches the RFC 31 constraints in `constraint` */
+struct rnode *rnode_copy_match (const struct rnode *n, json_t *constraint);
+
+#endif /* !HAVE_SCHED_RLIST_MATCH */

--- a/src/common/librlist/rlist.c
+++ b/src/common/librlist/rlist.c
@@ -162,10 +162,11 @@ static int rlist_add_rnode (struct rlist *rl, struct rnode *n)
     return 0;
 }
 
-typedef struct rnode * (*rnode_copy_f) (const struct rnode *);
+typedef struct rnode * (*rnode_copy_f) (const struct rnode *, void *arg);
 
 static struct rlist *rlist_copy_internal (const struct rlist *orig,
-                                          rnode_copy_f cpfn)
+                                          rnode_copy_f cpfn,
+                                          void *arg)
 {
     struct rnode *n;
     struct rlist *rl = rlist_create ();
@@ -174,7 +175,7 @@ static struct rlist *rlist_copy_internal (const struct rlist *orig,
 
     n = zlistx_first (orig->nodes);
     while (n) {
-        struct rnode *copy = (*cpfn) (n);
+        struct rnode *copy = (*cpfn) (n, arg);
         if (copy && rlist_add_rnode_new (rl, copy) < 0) {
             rnode_destroy (copy);
             goto fail;
@@ -201,19 +202,34 @@ fail:
     return NULL;
 }
 
+static struct rnode *copy_empty (const struct rnode *rnode, void *arg)
+{
+    return rnode_copy_empty (rnode);
+}
+
 struct rlist *rlist_copy_empty (const struct rlist *orig)
 {
-    return rlist_copy_internal (orig, rnode_copy_empty);
+    return rlist_copy_internal (orig, copy_empty, NULL);
+}
+
+static struct rnode *copy_alloc (const struct rnode *rnode, void *arg)
+{
+    return rnode_copy_alloc (rnode);
 }
 
 struct rlist *rlist_copy_allocated (const struct rlist *orig)
 {
-    return rlist_copy_internal (orig, rnode_copy_alloc);
+    return rlist_copy_internal (orig, copy_alloc, NULL);
+}
+
+static struct rnode *copy_cores (const struct rnode *rnode, void *arg)
+{
+    return rnode_copy_cores (rnode);
 }
 
 struct rlist *rlist_copy_cores (const struct rlist *orig)
 {
-    return rlist_copy_internal (orig, rnode_copy_cores);
+    return rlist_copy_internal (orig, copy_cores, NULL);
 }
 
 struct rlist *rlist_copy_down (const struct rlist *orig)

--- a/src/common/librlist/rlist.h
+++ b/src/common/librlist/rlist.h
@@ -31,6 +31,9 @@ struct rlist {
     /*  hash of resources to ignore on remap */
     zhashx_t *noremap;
 
+    /*  Hash of property->idset mapping */
+    zhashx_t *properties;
+
     /*  Rv1 optional starttime, expiration:
      */
     double starttime;
@@ -230,5 +233,18 @@ int rlist_set_allocated (struct rlist *rl, struct rlist *alloc);
 /*  Free resource list `to_free` from resource list `rl`
  */
 int rlist_free (struct rlist *rl, struct rlist *to_free);
+
+/*  Assign a single property 'name' to ranks in 'targets'
+ */
+int rlist_add_property (struct rlist *rl,
+                        flux_error_t *errp,
+                        const char *name,
+                        const char *targets);
+
+/*  Assign properties to targets
+ */
+int rlist_assign_properties (struct rlist *rl,
+                             json_t *properties,
+                             flux_error_t *errp);
 
 #endif /* !HAVE_SCHED_RLIST_H */

--- a/src/common/librlist/rlist.h
+++ b/src/common/librlist/rlist.h
@@ -68,6 +68,25 @@ struct rlist *rlist_copy_ranks (const struct rlist *rl, struct idset *ranks);
 
 struct rlist *rlist_copy_cores (const struct rlist *rl);
 
+/*  Create a copy of rl constrained by an RFC 31 constraint object
+ *
+ *  Returns a copy of rl with only those resource nodes that match
+ *   the provided constraint. The result 'struct rlist' may be empty
+ *   if no resources satisfy the constraint.
+ *
+ *  Returns NULL with `errp` set if the constraint object was invalid.
+ *
+ */
+struct rlist *rlist_copy_constraint (const struct rlist *rl,
+                                     json_t *constraint,
+                                     flux_error_t *errp);
+
+/*  Same as above, but takes a JSON string instead of json_t object.
+ */
+struct rlist *rlist_copy_constraint_string (const struct rlist *orig,
+                                            const char *constraint,
+                                            flux_error_t *errp);
+
 /*  Delete ranks in idset 'ranks' from rlist 'rl'
  */
 int rlist_remove_ranks (struct rlist *rl, struct idset *ranks);

--- a/src/common/librlist/rnode.h
+++ b/src/common/librlist/rnode.h
@@ -37,6 +37,8 @@ struct rnode {
 
     /* non-core children */
     zhashx_t *children;
+
+    zhashx_t *properties;
 };
 
 /*  Create a resource node object from an existing idset `set`
@@ -148,5 +150,13 @@ int rnode_hostname_cmp (const struct rnode *a, const struct rnode *b);
 int rnode_remap (struct rnode *n, zhashx_t *noremap);
 
 json_t *rnode_encode (const struct rnode *n, const struct idset *ids);
+
+/*  Set/remove/check for rnode properties
+ */
+int rnode_set_property (struct rnode *n, const char *name);
+
+void rnode_remove_property (struct rnode *n, const char *name);
+
+bool rnode_has_property (struct rnode *n, const char *name);
 
 #endif /* !HAVE_SCHED_RNODE_H */

--- a/src/common/librlist/test/match.c
+++ b/src/common/librlist/test/match.c
@@ -1,0 +1,253 @@
+/************************************************************\
+ * Copyright 2022 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#include <errno.h>
+
+#include "src/common/libtap/tap.h"
+#include "match.h"
+
+struct match_test {
+    const char *desc;
+    const char *json;
+    bool result;
+};
+
+struct validate_test {
+    const char *desc;
+    const char *json;
+    int rc;
+    const char *err;
+};
+
+/*  These tests all assume a rnode object foo0 with properties xx and yy.
+ */
+struct match_test match_tests[] = {
+    { "empty json object matches everything", "{}", true },
+    { "hostname property matches",
+       "{\"properties\": [\"foo0\"]}",
+       true
+    },
+    {  "empty properties dict matches everything",
+       "{\"properties\": [] }",
+       true
+    },
+    {  "property matches",
+       "{\"properties\": [\"xx\"]}",
+        true,
+    },
+    {  "logical not on property",
+       "{\"properties\": [\"^xx\"]}",
+        false,
+    },
+    {  "logical not on unset property",
+       "{\"properties\": [\"^zz\"]}",
+        true,
+    },
+    {  "property list matches like 'and'",
+       "{\"properties\": [\"xx\", \"yy\"]}",
+        true,
+    },
+    {  "property list match fails unless node has all",
+       "{\"properties\": [\"xx\", \"zz\"]}",
+        false,
+    },
+    { "property list match fails if property missing",
+       "{\"properties\": [\"zz\"]}",
+        false,
+    },
+    { "and with two true statements",
+      "{\"and\": [ {\"properties\": [\"xx\"]}, \
+                   {\"properties\": [\"yy\"]}  \
+                 ]}",
+        true,
+    },
+    { "and with one false statement",
+      "{\"and\": [ {\"properties\": [\"xx\"]}, \
+                   {\"properties\": [\"zz\"]}  \
+                 ]}",
+        false,
+    },
+    { "or with two true statements",
+      "{\"or\": [ {\"properties\": [\"xx\"]}, \
+                  {\"properties\": [\"yy\"]}  \
+                 ]}",
+        true,
+    },
+    { "or with one true statements",
+      "{\"or\": [ {\"properties\": [\"zz\"]}, \
+                  {\"properties\": [\"yy\"]}  \
+                 ]}",
+        true,
+    },
+    { "or with two false statements",
+      "{\"or\": [ {\"properties\": [\"zz\"]}, \
+                  {\"properties\": [\"aa\"]}  \
+                 ]}",
+        false,
+    },
+    { "not with or with one true statement",
+      "{\"not\": [ \
+        {\"or\": [ {\"properties\": [\"zz\"]}, \
+                   {\"properties\": [\"yy\"]}  \
+                 ]} \
+        ] \
+       }",
+       false,
+    },
+    { NULL, NULL, false },
+};
+
+struct validate_test validate_tests[] = {
+    { "non-object fails",
+      "[]",
+      -1,
+      "constraint must be JSON object",
+    },
+    { "Unknown operation fails",
+      "{ \"foo\": [] }",
+      -1,
+      "unknown constraint operator: foo",
+    },
+    { "non-array argument to 'and' fails",
+      "{ \"and\": \"foo\" }",
+      -1,
+      "and operator value must be an array",
+    },
+    { "non-array argument to 'or' fails",
+      "{ \"or\": \"foo\" }",
+      -1,
+      "or operator value must be an array",
+    },
+    { "non-array argument to 'properties' fails",
+      "{ \"properties\": \"foo\" }",
+      -1,
+      "properties value must be an array",
+    },
+    { "non-string property fails",
+      "{ \"properties\": [ \"foo\", 42 ] }",
+      -1,
+      "non-string property specified",
+    },
+    { "invalid property string fails",
+      "{ \"properties\": [ \"foo\", \"bar&\" ] }",
+      -1,
+      "invalid character '&' in property \"bar&\"",
+    },
+    { "empty object is valid constraint",
+      "{}",
+      0,
+      NULL
+    },
+    { "empty and object is valid constraint",
+      "{ \"and\": [] }",
+      0,
+      NULL
+    },
+    { "empty or object is valid constraint",
+      "{ \"or\": [] }",
+      0,
+      NULL
+    },
+    { "empty properties object is valid constraint",
+      "{ \"properties\": [] }",
+      0,
+      NULL
+    },
+    { "complex conditional works",
+      "{ \"and\": \
+         [ { \"or\": \
+             [ {\"properties\": [\"foo\"]}, \
+               {\"properties\": [\"bar\"]}  \
+             ] \
+           }, \
+           { \"and\": \
+             [ {\"properties\": [\"xx\"]}, \
+               {\"properties\": [\"yy\"]}  \
+             ] \
+           } \
+         ] \
+      }",
+      0,
+      NULL
+    },
+    { NULL, NULL, 0, NULL }
+};
+
+void test_match ()
+{
+    struct rnode *n;
+    if (!(n = rnode_create ("foo0", 0, "0-3")))
+        BAIL_OUT ("failed to create rnode object");
+
+    ok (rnode_set_property (n, "xx") == 0,
+        "rnode_set_property: foo0 has xx");
+    ok (rnode_set_property (n, "yy") == 0,
+        "rnode_set_property: foo0 has yy");
+
+    struct match_test *t = match_tests;
+    while (t->desc) {
+        json_t *o = json_loads (t->json, 0, NULL);
+        if (!o)
+            BAIL_OUT ("failed to parse json logic for '%s'", t->desc);
+        ok (rnode_match (n, o) == t->result, "%s", t->desc);
+        json_decref (o);
+        t++;
+    }
+    rnode_destroy (n);
+}
+
+void test_validate ()
+{
+    flux_error_t error;
+    struct validate_test *t = validate_tests;
+    while (t->desc) {
+        json_t *o = json_loads (t->json, 0, NULL);
+        if (!o)
+            BAIL_OUT ("failed to parse json logic for '%s'", t->desc);
+        int rc = rnode_match_validate (o, &error);
+        ok (rc == t->rc, "%s", t->desc);
+        if (rc != t->rc)
+            diag ("%s", error.text);
+        if (t->err)
+            is (error.text, t->err, "got expected error: %s", error.text);
+        json_decref (o);
+        t++;
+    }
+}
+
+void test_invalid ()
+{
+    json_t *o = json_object ();
+    if (!o)
+        BAIL_OUT ("test_invalid: json_object() failed");
+    ok (!rnode_match (NULL, NULL),
+        "rnode_match (NULL, NULL) returns false");
+    ok (!rnode_match (NULL, o),
+        "rnode_match (NULL, o) returns false");
+    ok (rnode_match_validate (NULL, NULL) == -1,
+        "rnode_match_validate (NULL, NULL) == -1");
+    lives_ok ({rnode_match_validate (o, NULL); },
+        "rnode_match_validate (o, NULL) doesn't crash");
+    ok (rnode_copy_match (NULL, NULL) == NULL,
+        "rnode_copy_match (NULL, NULL) returns NULL");
+    json_decref (o);
+}
+
+int main (int ac, char *av[])
+{
+    plan (NO_PLAN);
+    test_match ();
+    test_validate ();
+    test_invalid ();
+    done_testing ();
+}
+
+/* vi: ts=4 sw=4 expandtab
+ */

--- a/src/common/librlist/test/rnode.c
+++ b/src/common/librlist/test/rnode.c
@@ -212,6 +212,38 @@ void test_rnode_cmp ()
     rnode_destroy (b);
 }
 
+void test_properties ()
+{
+    struct rnode *a;
+    struct rnode *b;
+
+    if (!(a = rnode_create ("foo", 0, "0-3")))
+        BAIL_OUT ("failed to create rnode object");
+
+    ok (rnode_set_property (a, "blingy") == 0,
+        "rnode_set_property works");
+    ok (rnode_set_property (a, "blingy") == 0,
+        "rnode_set_property again works");
+    ok (rnode_has_property (a, "blingy"),
+        "rnode_has_property works");
+    ok (!rnode_has_property (a, "dull"),
+        "rnode_has_property returns false if property not set");
+    if (!(b = rnode_copy (a)))
+        BAIL_OUT ("failed to copy rnode");
+    ok (b != NULL,
+        "rnode_copy with properties");
+    ok (rnode_has_property (b, "blingy"),
+        "rnode_has_property works on copy");
+    ok (!rnode_has_property (b, "dull"),
+        "rnode_has_property on copy returns false if property not set");
+    rnode_remove_property (a, "blingy");
+    ok (!rnode_has_property (a, "blingy"),
+        "rnode_has_property now returns false");
+
+    rnode_destroy (a);
+    rnode_destroy (b);
+}
+
 int main (int ac, char *av[])
 {
     struct idset *ids = NULL;
@@ -327,6 +359,7 @@ int main (int ac, char *av[])
     test_intersect ();
     test_add_child ();
     test_copy ();
+    test_properties ();
     done_testing ();
 }
 

--- a/src/modules/job-ingest/schemas/jobspec.jsonschema
+++ b/src/modules/job-ingest/schemas/jobspec.jsonschema
@@ -100,6 +100,7 @@
             "duration": { "type": "number", "minimum": 0 },
             "cwd": { "type": "string" },
             "environment": { "type": "object" },
+            "constraints": { "type": "object" },
             "dependencies": {
               "type": "array",
               "items": {

--- a/src/modules/job-ingest/schemas/jobspec_v1.jsonschema
+++ b/src/modules/job-ingest/schemas/jobspec_v1.jsonschema
@@ -94,6 +94,7 @@
             "duration": { "type": "number", "minimum": 0 },
             "cwd": { "type": "string" },
             "environment": { "type": "object" },
+            "constraints": { "type": "object" },
             "dependencies": {
                "type": "array",
                "items": {

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -137,6 +137,7 @@ TESTSCRIPTS = \
 	t2273-job-alloc-bypass.t \
 	t2274-manager-perilog.t \
 	t2275-job-duration-validator.t \
+	t2276-job-requires.t \
 	t2280-job-memo.t \
 	t2300-sched-simple.t \
 	t2302-sched-simple-up-down.t \

--- a/t/jobspec/invalid/constraints_not_object.yaml
+++ b/t/jobspec/invalid/constraints_not_object.yaml
@@ -1,0 +1,18 @@
+version: 1
+resources:
+  - type: slot
+    count: 1
+    label: foo
+    with:
+      - type: core
+        count: 1
+tasks:
+  - command: [ "app" ]
+    slot: foo
+    count:
+      per_slot: 1
+attributes:
+  system:
+    constraints:
+      - foo
+      - bar

--- a/t/t2276-job-requires.t
+++ b/t/t2276-job-requires.t
@@ -1,0 +1,63 @@
+#!/bin/sh
+
+test_description='Test job constraints'
+
+. $(dirname $0)/sharness.sh
+
+test_under_flux 4 job
+
+flux setattr log-stderr-level 1
+
+test_expect_success HAVE_JQ 'flux-mini: --requires option works' '
+	flux mini run --dry-run \
+		--env=-* \
+		--requires=foo,bar \
+		--requires=^baz \
+		 true | \
+		jq '.attributes.system.constraints' > constraints.json &&
+	test_debug "jq -S . < constraints.json" &&
+	jq -e ".properties[0] == \"foo\"" < constraints.json &&
+	jq -e ".properties[1] == \"bar\"" < constraints.json &&
+	jq -e ".properties[2] == \"^baz\"" < constraints.json
+'
+test_expect_success 'reload scheduler with properties set' '
+	flux kvs put resource.R="$(flux kvs get resource.R | \
+		flux R set-property xx:2-3 yy:0-2)" &&
+	flux module unload sched-simple &&
+	flux module reload resource &&
+	flux module load sched-simple
+'
+test_expect_success 'reload ingest with feasibility validator' '
+	flux module reload -f job-ingest validator-plugins=jobspec,feasibility
+'
+test_expect_success 'scheduler rejects jobs with invalid requires' '
+	test_must_fail flux mini submit --requires=x hostname &&
+	test_must_fail flux mini submit --requires="&x" hostname
+'
+test_expect_success 'scheduler rejects jobs with invalid constraints' '
+	test_must_fail flux mini submit --setattr=system.constraints.foo=[] \
+		 hostname &&
+	test_must_fail flux mini submit --setattr=system.constraints.and={} \
+		 hostname
+'
+test_expect_success 'flux-mini: --requires works with scheduler' '
+	flux mini bulksubmit --wait --log=job.{}.id -n1 --requires={} \
+		flux getattr rank \
+		::: xx yy xx,yy ^xx ^yy &&
+	result=$(flux job attach $(cat job.xx.id)) &&
+	test_debug "echo xx: $result" &&
+	test $result -eq 2 -o $result -eq 3 &&
+	result=$(flux job attach $(cat job.yy.id)) &&
+	test_debug "echo yy: $result" &&
+	test $result -eq 0 -o $result -eq 1 &&
+	result=$(flux job attach $(cat job.xx,yy.id)) &&
+	test_debug "echo xx,yy: $result" &&
+	test $result -eq 2 &&
+	result=$(flux job attach $(cat "job.^yy.id")) &&
+	test_debug "echo ^yy: $result" &&
+	test $result -eq 3 &&
+	result=$(flux job attach $(cat "job.^xx.id")) &&
+	test_debug "echo ^xx: $result" &&
+	test $result -eq 0 -o $result -eq 1
+'
+test_done


### PR DESCRIPTION
This PR adds support for resource properties as specified in [RFC 20](https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/spec_20.html), along with basic support for [RFC 31](https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/spec_31.html) constraints.

Thus far, most of the groundwork has been completed, so I thought I'd post now to allow @dongahn an early comment and synchronization period. Still TODO is to add support for constructing RFC 31 constraints in jobspec from the `flux mini` command line tools (tentative support for selecting resources based on constraints is in sched-simple already), along with associated testing.

In summary, this PR contains the following enhancements:
 - support for RFC 20 `properties` key on encode and decode of Rv1 objects
 - new property-specific options to `flux R encode/decode`, along with a new `flux R set-property` command
 - a simple, librlist-based constraint matching function to support "filtering" resources with an RFC 31 constraint object
 - initial proof-of-concept change to sched-simple to support  `attributes.system.constraints` set in jobspec.
   
While RFC 31 only requires support for the `properties` operation in a job constraints object, it was simple enough to add basic logical operation support for `and`, `or`, and `not`, so that is included here.

In this implementation, all ranks inherit a default property of their hostname. This allows us to get support for excluding hosts via the `^hostname` property (though hostlist isn't supported). In retrospect, maybe it would be better to support hostnames as another kind of constraint (which could support hostlists).

You can experiment with this branch in a test instance by using `flux R set-property` to set some properties, e.g.:

```
 $ flux start -s 4
 $ flux kvs put resource.R="$(flux kvs get resource.R | flux R set-property foo:2-3)"
 $ flux module reload resource && flux module load sched-simple
2022-03-22T21:28:03.578409Z sched-simple.err[0]: exiting due to resource update failure: the resource module was unloaded
 $ flux mini run flux getattr rank
0
 $ flux mini run --setattr=system.constraints.properties='["foo"]' flux getattr rank
2

```