### PR TITLE
flux-dmesg: add --new option, plus logging cleanup

### DIFF
--- a/doc/man1/flux-dmesg.rst
+++ b/doc/man1/flux-dmesg.rst
@@ -31,6 +31,9 @@ OPTIONS
    After printing the contents of the ring buffer, wait for new entries
    and print them as they arrive.
 
+**-n, --new**
+   Follow only new log entries.
+
 
 EXAMPLES
 ========

--- a/src/broker/log.c
+++ b/src/broker/log.c
@@ -561,11 +561,22 @@ static void disconnect_request_cb (flux_t *h,
     flux_msglist_disconnect (logbuf->followers, msg);
 }
 
+static void cancel_request_cb (flux_t *h,
+                                flux_msg_handler_t *mh,
+                                const flux_msg_t *msg,
+                                void *arg)
+{
+    logbuf_t *logbuf = arg;
+
+    flux_msglist_cancel (h, logbuf->followers, msg);
+}
+
 static const struct flux_msg_handler_spec htab[] = {
     { FLUX_MSGTYPE_REQUEST, "log.append",         append_request_cb, 0 },
     { FLUX_MSGTYPE_REQUEST, "log.clear",          clear_request_cb, 0 },
     { FLUX_MSGTYPE_REQUEST, "log.dmesg",          dmesg_request_cb, 0 },
     { FLUX_MSGTYPE_REQUEST, "log.disconnect",     disconnect_request_cb, 0 },
+    { FLUX_MSGTYPE_REQUEST, "log.cancel",         cancel_request_cb, 0 },
     FLUX_MSGHANDLER_TABLE_END,
 };
 

--- a/src/broker/log.c
+++ b/src/broker/log.c
@@ -17,7 +17,6 @@
 #include "config.h"
 #endif
 #include <inttypes.h>
-#include <assert.h>
 
 #include "src/common/libczmqcontainers/czmq_containers.h"
 #include "src/common/libutil/log.h"
@@ -244,54 +243,40 @@ static int logbuf_set_filename (logbuf_t *logbuf, const char *destination)
     return 0;
 }
 
+static const char *int_to_string (int n)
+{
+    static char s[32]; // ample room to avoid overflow
+    (void)snprintf (s, sizeof (s), "%d", n);
+    return s;
+}
+
 static int attr_get_log (const char *name, const char **val, void *arg)
 {
     logbuf_t *logbuf = arg;
-    static char s[32];
-    int n, rc = -1;
 
-    if (!strcmp (name, "log-forward-level")) {
-        n = snprintf (s, sizeof (s), "%d", logbuf->forward_level);
-        assert (n < sizeof (s));
-        *val = s;
-    } else if (!strcmp (name, "log-critical-level")) {
-        n = snprintf (s, sizeof (s), "%d", logbuf->critical_level);
-        assert (n < sizeof (s));
-        *val = s;
-    } else if (!strcmp (name, "log-stderr-level")) {
-        n = snprintf (s, sizeof (s), "%d", logbuf->stderr_level);
-        assert (n < sizeof (s));
-        *val = s;
-    } else if (!strcmp (name, "log-stderr-mode")) {
-        n = snprintf (s, sizeof (s), "%s",
-                      logbuf->stderr_mode == MODE_LEADER ? "leader" : "local");
-        assert (n < sizeof (s));
-        *val = s;
-    } else if (!strcmp (name, "log-ring-size")) {
-        n = snprintf (s, sizeof (s), "%d", logbuf->ring_size);
-        assert (n < sizeof (s));
-        *val = s;
-    } else if (!strcmp (name, "log-ring-used")) {
-        n = snprintf (s, sizeof (s), "%zd", zlist_size (logbuf->buf));
-        assert (n < sizeof (s));
-        *val = s;
-    } else if (!strcmp (name, "log-count")) {
-        n = snprintf (s, sizeof (s), "%d", logbuf->seq);
-        assert (n < sizeof (s));
-        *val = s;
-    } else if (!strcmp (name, "log-filename")) {
+    if (!strcmp (name, "log-forward-level"))
+        *val = int_to_string (logbuf->forward_level);
+    else if (!strcmp (name, "log-critical-level"))
+        *val = int_to_string (logbuf->critical_level);
+    else if (!strcmp (name, "log-stderr-level"))
+        *val = int_to_string (logbuf->stderr_level);
+    else if (!strcmp (name, "log-stderr-mode"))
+        *val = logbuf->stderr_mode == MODE_LEADER ? "leader" : "local";
+    else if (!strcmp (name, "log-ring-size"))
+        *val = int_to_string (logbuf->ring_size);
+    else if (!strcmp (name, "log-ring-used"))
+        *val = int_to_string (zlist_size (logbuf->buf));
+    else if (!strcmp (name, "log-count"))
+        *val = int_to_string (logbuf->seq);
+    else if (!strcmp (name, "log-filename"))
         *val = logbuf->filename;
-    } else if (!strcmp (name, "log-level")) {
-        n = snprintf (s, sizeof (s), "%d", logbuf->level);
-        assert (n < sizeof (s));
-        *val = s;
-    } else {
+    else if (!strcmp (name, "log-level"))
+        *val = int_to_string (logbuf->level);
+    else {
         errno = ENOENT;
-        goto done;
+        return -1;
     }
-    rc = 0;
-done:
-    return rc;
+    return 0;
 }
 
 static int attr_set_log (const char *name, const char *val, void *arg)

--- a/src/cmd/builtin/dmesg.c
+++ b/src/cmd/builtin/dmesg.c
@@ -26,122 +26,66 @@ static struct optparse_option dmesg_opts[] = {
     OPTPARSE_TABLE_END,
 };
 
-enum {
-    DMESG_CLEAR = 1,
-    DMESG_FOLLOW = 2,
-};
-
-static int dmesg_clear (flux_t *h)
+void dmesg_print (const char *buf, int len)
 {
-    flux_future_t *f;
-    int rc = -1;
-
-    if (!(f = flux_rpc (h, "log.clear", NULL, FLUX_NODEID_ANY, 0)))
-        goto done;
-    if (flux_future_get (f, NULL) < 0)
-        goto done;
-    rc = 0;
-done:
-    flux_future_destroy (f);
-    return rc;
-}
-
-static flux_future_t *dmesg_rpc (flux_t *h, bool follow)
-{
-    return flux_rpc_pack (h, "log.dmesg", FLUX_NODEID_ANY, FLUX_RPC_STREAMING,
-                          "{s:b}", "follow", follow);
-}
-
-static int dmesg_rpc_get (flux_future_t *f, flux_log_f fun, void *arg)
-{
-    const char *buf;
-    int rc = -1;
-
-    if (flux_rpc_get (f, &buf) < 0)
-        goto done;
-    fun (buf, strlen (buf), arg);
-    rc = 0;
-done:
-    return rc;
-}
-
-int dmesg (flux_t *h, int flags, flux_log_f fun, void *arg)
-{
-    int rc = -1;
-    bool eof = false;
-    bool follow = false;
-
-    if (flags & DMESG_FOLLOW)
-        follow = true;
-    if (fun) {
-        flux_future_t *f;
-        if (!(f = dmesg_rpc (h, follow)))
-            goto done;
-        while (!eof) {
-            if (dmesg_rpc_get (f, fun, arg) < 0) {
-                if (errno != ENODATA) {
-                    flux_future_destroy (f);
-                    goto done;
-                }
-                eof = true;
-            }
-            flux_future_reset (f);
-        }
-        flux_future_destroy (f);
-    }
-    if ((flags & DMESG_CLEAR)) {
-        if (dmesg_clear (h) < 0)
-            goto done;
-    }
-    rc = 0;
-done:
-    return rc;
-}
-
-void dmesg_fprint (const char *buf, int len, void *arg)
-{
-    FILE *f = arg;
     struct stdlog_header hdr;
     const char *msg;
     int msglen, severity;
     uint32_t nodeid;
 
-    if (f) {
-        if (stdlog_decode (buf, len, &hdr, NULL, NULL, &msg, &msglen) < 0)
-            fprintf (f, "%.*s\n", len, buf);
-        else {
-            nodeid = strtoul (hdr.hostname, NULL, 10);
-            severity = STDLOG_SEVERITY (hdr.pri);
-            fprintf (f, "%s %s.%s[%" PRIu32 "]: %.*s\n",
-                     hdr.timestamp,
-                     hdr.appname,
-                     stdlog_severity_to_string (severity),
-                     nodeid,
-                     msglen, msg);
-        }
-        fflush (f);
+    if (stdlog_decode (buf, len, &hdr, NULL, NULL, &msg, &msglen) < 0)
+        printf ("%.*s\n", len, buf);
+    else {
+        nodeid = strtoul (hdr.hostname, NULL, 10);
+        severity = STDLOG_SEVERITY (hdr.pri);
+        printf ("%s %s.%s[%" PRIu32 "]: %.*s\n",
+                 hdr.timestamp,
+                 hdr.appname,
+                 stdlog_severity_to_string (severity),
+                 nodeid,
+                 msglen, msg);
     }
+    fflush (stdout);
 }
 
 static int cmd_dmesg (optparse_t *p, int ac, char *av[])
 {
     int n;
     flux_t *h;
-    int flags = 0;
-    flux_log_f print_cb = dmesg_fprint;
 
     if ((n = optparse_option_index (p)) != ac)
         log_msg_exit ("flux-dmesg accepts no free arguments");
 
     h = builtin_get_flux_handle (p);
-    if (optparse_hasopt (p, "read-clear") || optparse_hasopt (p, "clear"))
-        flags |= DMESG_CLEAR;
-    if (optparse_hasopt (p, "clear"))
-        print_cb = NULL;
-    if (optparse_hasopt (p, "follow"))
-        flags |= DMESG_FOLLOW;
-    if (dmesg (h, flags, print_cb, stdout) < 0)
-        log_err_exit ("log.dmesg");
+
+    if (!optparse_hasopt (p, "clear")) {
+        flux_future_t *f;
+        const char *buf;
+
+        if (!(f = flux_rpc_pack (h,
+                                 "log.dmesg",
+                                 FLUX_NODEID_ANY,
+                                 FLUX_RPC_STREAMING,
+                                 "{s:b}",
+                                 "follow", optparse_hasopt (p, "follow"))))
+            log_err_exit ("error sending log.dmesg request");
+        while (flux_rpc_get (f, &buf) == 0) {
+            dmesg_print (buf, strlen (buf));
+            flux_future_reset (f);
+        }
+        if (errno != ENODATA)
+            log_msg_exit ("log.dmesg: %s", future_strerror (f, errno));
+        flux_future_destroy (f);
+    }
+    if (optparse_hasopt (p, "read-clear") || optparse_hasopt (p, "clear")) {
+        flux_future_t *f;
+
+        if (!(f = flux_rpc (h, "log.clear", NULL, FLUX_NODEID_ANY, 0))
+            || flux_future_get (f, NULL) < 0)
+            log_msg_exit ("log.clear: %s", future_strerror (f, errno));
+        flux_future_destroy (f);
+    }
+
     flux_close (h);
     return (0);
 }

--- a/src/cmd/builtin/dmesg.c
+++ b/src/cmd/builtin/dmesg.c
@@ -23,6 +23,8 @@ static struct optparse_option dmesg_opts[] = {
       .usage = "Clear the ring buffer contents after printing", },
     { .name = "follow",  .key = 'f',  .has_arg = 0,
       .usage = "Track new entries as are logged", },
+    { .name = "new",  .key = 'n',  .has_arg = 0,
+      .usage = "Show only new log messages", },
     OPTPARSE_TABLE_END,
 };
 
@@ -66,8 +68,9 @@ static int cmd_dmesg (optparse_t *p, int ac, char *av[])
                                  "log.dmesg",
                                  FLUX_NODEID_ANY,
                                  FLUX_RPC_STREAMING,
-                                 "{s:b}",
-                                 "follow", optparse_hasopt (p, "follow"))))
+                                 "{s:b s:b}",
+                                 "follow", optparse_hasopt (p, "follow"),
+                                 "nobacklog", optparse_hasopt (p, "new"))))
             log_err_exit ("error sending log.dmesg request");
         while (flux_rpc_get (f, &buf) == 0) {
             dmesg_print (buf, strlen (buf));

--- a/src/cmd/builtin/dmesg.c
+++ b/src/cmd/builtin/dmesg.c
@@ -133,8 +133,7 @@ static int cmd_dmesg (optparse_t *p, int ac, char *av[])
     if ((n = optparse_option_index (p)) != ac)
         log_msg_exit ("flux-dmesg accepts no free arguments");
 
-    if (!(h = builtin_get_flux_handle (p)))
-        log_err_exit ("flux_open");
+    h = builtin_get_flux_handle (p);
     if (optparse_hasopt (p, "read-clear") || optparse_hasopt (p, "clear"))
         flags |= DMESG_CLEAR;
     if (optparse_hasopt (p, "clear"))

--- a/src/common/libflux/msg_handler.c
+++ b/src/common/libflux/msg_handler.c
@@ -334,7 +334,7 @@ static void call_handler (flux_msg_handler_t *mh, const flux_msg_t *msg)
             && matchtag != FLUX_MATCHTAG_NONE) {
             const char *errmsg;
             if (mh->rolemask == 0 || mh->rolemask == FLUX_ROLE_OWNER)
-                errmsg = "Request requires owner credentals";
+                errmsg = "Request requires owner credentials";
             else
                 errmsg = "Request rejected due to insufficient privilege";
             (void)flux_respond_error (mh->d->h, msg, EPERM, errmsg);

--- a/src/modules/job-manager/alloc.c
+++ b/src/modules/job-manager/alloc.c
@@ -725,7 +725,7 @@ static void alloc_admin_cb (flux_t *h,
         goto error;
     if (!query_only) {
         if (flux_msg_authorize (msg, FLUX_USERID_UNKNOWN) < 0) {
-            errmsg = "Request requires owner credentals";
+            errmsg = "Request requires owner credentials";
             goto error;
         }
         if (!enable) {

--- a/src/modules/job-manager/submit.c
+++ b/src/modules/job-manager/submit.c
@@ -303,7 +303,7 @@ static void submit_admin_cb (flux_t *h, flux_msg_handler_t *mh,
         goto error;
     if (!query_only) {
         if (flux_msg_authorize (msg, FLUX_USERID_UNKNOWN) < 0) {
-            errmsg = "Request requires owner credentals";
+            errmsg = "Request requires owner credentials";
             goto error;
         }
         if (!enable) {

--- a/t/t0009-dmesg.t
+++ b/t/t0009-dmesg.t
@@ -60,6 +60,15 @@ test_expect_success NO_CHAIN_LINT 'flux dmesg -f works' '
 	$waitfile -t 20 -p hello_follow dmesg.out &&
 	kill $pid
 '
+test_expect_success NO_CHAIN_LINT 'flux dmesg -f --new works' '
+	flux logger hello_old &&
+	flux dmesg -f --new > dmesg2.out &
+	pid=$! &&
+	for i in $(seq 1 10); do flux logger hello_new; done &&
+	$waitfile -t 20 -p hello_new dmesg2.out &&
+	test_must_fail grep hello_old dmesg2.out &&
+	kill $pid
+'
 test_expect_success 'ring buffer wraps over old entries' '
 	OLD_RINGSIZE=`flux getattr log-ring-size` &&
 	flux setattr log-ring-size 2 &&

--- a/t/t0017-security.t
+++ b/t/t0017-security.t
@@ -137,7 +137,7 @@ test_expect_success 'flux logger not allowed for non-owner' '
 
 test_expect_success 'flux dmesg not allowed for non-owner' '
 	! FLUX_HANDLE_ROLEMASK=0x2 flux dmesg 2>dmesg.err &&
-	grep -q "Operation not permitted" dmesg.err
+	grep -q "Request requires owner credentials" dmesg.err
 '
 
 # Note these rules:

--- a/t/t2240-queue-cmd.t
+++ b/t/t2240-queue-cmd.t
@@ -260,7 +260,7 @@ test_expect_success 'flux-queue: status allowed for guest' '
 test_expect_success 'flux-queue: stop denied for guest' '
 	test_must_fail runas_guest flux queue stop 2>guest_stop.err &&
 	cat <<-EOT >guest_alloc.exp &&
-	flux-queue: alloc-admin: Request requires owner credentals
+	flux-queue: alloc-admin: Request requires owner credentials
 	EOT
 	test_cmp guest_alloc.exp guest_stop.err
 '
@@ -273,7 +273,7 @@ test_expect_success 'flux-queue: start denied for guest' '
 test_expect_success 'flux-queue: disable denied for guest' '
 	test_must_fail runas_guest flux queue disable foo 2>guest_dis.err &&
 	cat <<-EOT >guest_submit.exp &&
-	flux-queue: submit-admin: Request requires owner credentals
+	flux-queue: submit-admin: Request requires owner credentials
 	EOT
 	test_cmp guest_submit.exp guest_dis.err
 '
@@ -286,7 +286,7 @@ test_expect_success 'flux-queue: enable denied for guest' '
 test_expect_success 'flux-queue: drain denied for guest' '
 	test_must_fail runas_guest flux queue drain 2>guest_drain.err &&
 	cat <<-EOT >guest_drain.exp &&
-	flux-queue: drain: Request requires owner credentals
+	flux-queue: drain: Request requires owner credentials
 	EOT
 	test_cmp guest_drain.exp guest_drain.err
 '
@@ -294,7 +294,7 @@ test_expect_success 'flux-queue: drain denied for guest' '
 test_expect_success 'flux-queue: idle denied for guest' '
 	test_must_fail runas_guest flux queue idle 2>guest_idle.err &&
 	cat <<-EOT >guest_idle.exp &&
-	flux-queue: idle: Request requires owner credentals
+	flux-queue: idle: Request requires owner credentials
 	EOT
 	test_cmp guest_idle.exp guest_idle.err
 '


### PR DESCRIPTION
Problem: `flux-dmesg(1)` (and associated RPC service) can "follow" broker log messages, but always requires the entire ring buffer to be dumped first.

This PR adds a flag to the RPC to skip dumping the ring buffer, and then adds the `--new` option to `flux-dmesg(1)`:
```
Usage: flux dmesg [OPTIONS...]
Print or control log ring buffer
  -h, --help             Display this message.
  -C, --clear            Clear the ring buffer
  -c, --read-clear       Clear the ring buffer contents after printing
  -f, --follow           Track new entries as are logged
  -n, --new              Show only new log messages
```
I actually needed this capability in the RPC for work on a `flux-shutdown(1)` command as discussed in #3895, where I thought it would be useful to have an option to show log messages as the instance is shutting down.  Touching that old code also resulted in some gratuitous cleanup and modernization, and ultimately I figured it was best as a standalone PR.