### PR TITLE
job-ingest: add TOML config 

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -290,7 +290,8 @@ MAN5_FILES_PRIMARY = \
 	man5/flux-config-exec.5 \
 	man5/flux-config-resource.5 \
 	man5/flux-config-archive.5 \
-	man5/flux-config-job-manager.5
+	man5/flux-config-job-manager.5 \
+	man5/flux-config-ingest.5 
 
 
 MAN7_FILES = $(MAN7_FILES_PRIMARY)

--- a/doc/man5/flux-config-ingest.rst
+++ b/doc/man5/flux-config-ingest.rst
@@ -1,0 +1,69 @@
+=====================
+flux-config-ingest(5)
+=====================
+
+
+DESCRIPTION
+===========
+
+The Flux **job-ingest** service verifies and validates job requests
+before announcing new jobs to the **job-manager**. Configuration of the
+**job-ingest** module can be accomplished either via the module command
+line or an ``ingest`` TOML table. See the KEYS section below for supported
+``ingest`` table keys.
+
+The **job-ingest** module validates jobspec using a work crew of
+``flux job-validator`` processes. The validator supports a set of plugins,
+and each plugin may consume additional arguments from the command line
+for specific configuration. The validator plugins and any arguments are
+configured in the ``ingest.validator`` TOML table. See the VALIDATOR KEYS
+section below for supported ``ingest.validator`` keys.
+
+KEYS
+====
+
+batch-count
+   (optional) The job-ingest module batches sets of jobs together
+   for efficiency. Normally this is done using a timer, but if the
+   ``batch-count`` key is nonzero then jobs are batched based on a counter
+   instead. This is mostly useful for testing.
+
+VALIDATOR KEYS
+==============
+
+disable
+   (optional) A boolean indicating whether to disable job validation.
+   Disabling the job validator is not recommended, but may be useful
+   for testing or high job throughput scenarios.
+
+plugins
+   (optional) An array of validator plugins to use. The default
+   value is ``[ "jobspec" ]``, which uses the Python Jobspec class as
+   a validator.  For a list of supported plugins on your system run
+   ``flux job-validator --list-plugins``
+
+args
+   (optional) An array of extra arguments to pass on the validator
+   command line. Valid arguments can be found by running
+   ``flux job-validator --plugins=LIST --help``
+
+EXAMPLE
+=======
+
+::
+
+   [ingest.validator]
+   plugins = [ "jobspec", "feasibility" ]
+   args =  [ "--require-version=1" ]
+
+
+RESOURCES
+=========
+
+Flux: http://flux-framework.org
+
+
+SEE ALSO
+========
+
+:man5:`flux-config`

--- a/doc/man5/flux-config.rst
+++ b/doc/man5/flux-config.rst
@@ -75,6 +75,6 @@ SEE ALSO
 ========
 
 :man1:`flux-broker`, :man5:`flux-config-access`, :man5:`flux-config-bootstrap`,
-:man5:`flux-config-tbon`, :man5:`flux-config-exec`,
+:man5:`flux-config-tbon`, :man5:`flux-config-exec`, :man5:`flux-config-ingest`,
 :man5:`flux-config-resource`, :man5:`flux-config-archive`,
 :man5:`flux-config-job-manager`

--- a/doc/man5/index.rst
+++ b/doc/man5/index.rst
@@ -9,6 +9,7 @@ man5
    flux-config-access
    flux-config-bootstrap
    flux-config-tbon
+   flux-config-ingest
    flux-config-exec
    flux-config-resource
    flux-config-archive

--- a/doc/manpages.py
+++ b/doc/manpages.py
@@ -277,6 +277,7 @@ man_pages = [
     ('man5/flux-config-bootstrap', 'flux-config-bootstrap', 'configure Flux instance bootstrap', [author], 5),
     ('man5/flux-config-tbon', 'flux-config-tbon', 'configure Flux overlay network', [author], 5),
     ('man5/flux-config-exec', 'flux-config-exec', 'configure Flux job execution service', [author], 5),
+    ('man5/flux-config-ingest', 'flux-config-ingest', 'configure Flux job ingest service', [author], 5),
     ('man5/flux-config-resource', 'flux-config-resource', 'configure Flux resource service', [author], 5),
     ('man5/flux-config-archive', 'flux-config-archive', 'configure Flux job archival service', [author], 5),
     ('man5/flux-config-job-manager', 'flux-config-job-manager', 'configure Flux job manager service', [author], 5),

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -620,3 +620,4 @@ INFILE
 POSIX
 ustar
 xz
+validator

--- a/src/modules/job-ingest/job-ingest.c
+++ b/src/modules/job-ingest/job-ingest.c
@@ -914,10 +914,12 @@ int job_ingest_ctx_init (struct job_ingest_ctx *ctx,
             return -1;
         }
     }
-    if (use_validator &&
-        !(ctx->validate = validate_create (h, plugins, valargs))) {
-        flux_log_error (h, "validate_create");
-        return -1;
+    if (use_validator) {
+        if (!(ctx->validate = validate_create (h))
+            || validate_configure (ctx->validate, plugins, valargs) < 0) {
+            flux_log_error (h, "validate_create");
+            return -1;
+        }
     }
 
 #if HAVE_FLUX_SECURITY

--- a/src/modules/job-ingest/job-ingest.c
+++ b/src/modules/job-ingest/job-ingest.c
@@ -865,10 +865,182 @@ error:
         flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
 }
 
+static char *json_array_join (json_t *o)
+{
+    int n = 0;
+    size_t index;
+    json_t *value;
+    const char *arg;
+    char *result;
+
+    if (!json_is_array (o)) {
+        errno = EINVAL;
+        return NULL;
+    }
+
+    json_array_foreach (o, index, value) {
+        if (!(arg = json_string_value (value))) {
+            errno = EINVAL;
+            return NULL;
+        }
+        n += strlen (arg) + 1;  /* arg + "," */
+    }
+    n += 2; /* ',\0' */
+
+    if (!(result = malloc (n)))
+        return NULL;
+    result[0] = '\0';
+
+     json_array_foreach (o, index, value) {
+        strcat (result, json_string_value (value));
+        strcat (result, ",");
+    }
+    result[n-3] = '\0';
+
+    return result;
+}
+
+/*  Configure job ingest from flux_conf_t and/or  argc, argv.
+ *
+ *  Supported configuration:
+ *
+ *  [ingest]
+ *  batch-count = N
+ *
+ *  [ingest.validator]
+ *  disable = false
+ *  plugins = [ "jobspec" ]
+ *  args = []
+ *
+ */
+static int job_ingest_configure (struct job_ingest_ctx *ctx,
+                                 const flux_conf_t *conf,
+                                 int argc,
+                                 char **argv)
+{
+    flux_conf_error_t error;
+    json_t *plugins = NULL;
+    json_t *args = NULL;
+    char *validator_plugins = NULL;
+    char *validator_args = NULL;
+    int disable_validator = 0;
+    int rc = -1;
+
+    if (flux_conf_unpack (conf,
+                          &error,
+                          "{s?{s?{s?o s?o s?b !} s?i !}}",
+                          "ingest",
+                            "validator",
+                              "args", &args,
+                              "plugins", &plugins,
+                              "disable", &disable_validator,
+                            "batch-count", &ctx->batch_count) < 0) {
+        flux_log (ctx->h, LOG_ERR,
+                  "error reading [ingest] config table: %s",
+                  error.errbuf);
+        goto out;
+    }
+
+    if (plugins && !(validator_plugins = json_array_join (plugins))) {
+        flux_log_error (ctx->h,
+                        "error in [ingest.validator] plugins array");
+        goto out;
+    }
+    if (args && !(validator_args = json_array_join (args))) {
+        flux_log_error (ctx->h,
+                        "error in [ingest.validator] args array");
+        goto out;
+    }
+
+    /*  Process cmdline args */
+    for (int i = 0; i < argc; i++) {
+        if (!strncmp (argv[i], "validator-args=", 15)) {
+            free (validator_args);
+            validator_args = strdup (argv[i] + 15);
+        }
+        else if (!strncmp (argv[i], "validator-plugins=", 18)) {
+            free (validator_plugins);
+            validator_plugins = strdup (argv[i] + 18);
+        }
+        else if (!strncmp (argv[i], "batch-count=", 12)) {
+            char *endptr;
+            ctx->batch_count = strtol (argv[i]+12, &endptr, 0);
+            if (*endptr != '\0' || ctx->batch_count < 0) {
+                flux_log (ctx->h, LOG_ERR, "Invalid batch-count: %s", argv[i]);
+                goto out;
+            }
+        }
+        else if (!strcmp (argv[i], "disable-validator")) {
+            disable_validator = 1;
+        }
+        else {
+            flux_log (ctx->h, LOG_ERR, "invalid option %s", argv[i]);
+            errno = EINVAL;
+            goto out;
+        }
+    }
+    if (disable_validator) {
+        if (ctx->validate)
+            flux_log (ctx->h,
+                      LOG_ERR,
+                      "Unable to disable validator at runtime");
+        else {
+            flux_log (ctx->h,
+                      LOG_DEBUG,
+                      "Disabling job validator");
+            rc = 0;
+        }
+        goto out;
+    }
+    if (!ctx->validate && !(ctx->validate = validate_create (ctx->h))) {
+        flux_log_error (ctx->h, "validate_create");
+        goto out;
+    }
+
+    flux_log (ctx->h,
+              LOG_DEBUG,
+              "configuring with plugins=%s, args=%s",
+              validator_plugins,
+              validator_args);
+
+    if (validate_configure (ctx->validate,
+                            validator_plugins,
+                            validator_args) < 0) {
+        flux_log_error (ctx->h, "validate_configure");
+        goto out;
+    }
+    rc = 0;
+out:
+    free (validator_plugins);
+    free (validator_args);
+    return rc;
+}
+
+static void reload_cb (flux_t *h,
+                       flux_msg_handler_t *mh,
+                       const flux_msg_t *msg,
+                       void *arg)
+{
+    struct job_ingest_ctx *ctx = arg;
+    const flux_conf_t *conf;
+    const char *errstr = "Failed to reconfigure job-ingest";
+    if (flux_conf_reload_decode (msg, &conf) < 0)
+        goto error;
+    if (job_ingest_configure (ctx, conf, 0, NULL) < 0)
+        goto error;
+    if (flux_respond (h, msg, NULL) < 0)
+        flux_log_error (h, "error responding to config-reload request");
+    return;
+error:
+    if (flux_respond_error (h, msg, errno, errstr) < 0)
+        flux_log_error (h, "error responding to config-reload request");
+}
+
 static const struct flux_msg_handler_spec htab[] = {
     { FLUX_MSGTYPE_REQUEST,  "job-ingest.getinfo", getinfo_cb, 0},
     { FLUX_MSGTYPE_REQUEST,  "job-ingest.submit", submit_cb, FLUX_ROLE_USER },
     { FLUX_MSGTYPE_REQUEST,  "job-ingest.shutdown", shutdown_cb, 0 },
+    { FLUX_MSGTYPE_REQUEST,  "job-ingest.config-reload", reload_cb, 0 },
     FLUX_MSGHANDLER_TABLE_END,
 };
 
@@ -878,49 +1050,11 @@ int job_ingest_ctx_init (struct job_ingest_ctx *ctx,
                          char **argv)
 {
     flux_reactor_t *r = flux_get_reactor (h);
-    const char *usage_message =
-        "Usage: flux module load [OPTIONS] job-ingest"
-        " [validator-plugins=LIST] [validator-args=ARGS]";
-    const char *plugins = NULL;
-    const char *valargs = NULL;
-    bool use_validator = true;
-
     memset (ctx, 0, sizeof (*ctx));
     ctx->h = h;
 
-    /*  Process cmdline args */
-    for (int i = 0; i < argc; i++) {
-        if (!strncmp (argv[i], "validator-args=", 15)) {
-            valargs = argv[i] + 15;
-        }
-        else if (!strncmp (argv[i], "validator-plugins=", 18)) {
-            plugins = argv[i] + 18;
-        }
-        else if (!strncmp (argv[i], "batch-count=", 12)) {
-            char *endptr;
-            ctx->batch_count = strtol (argv[i]+12, &endptr, 0);
-            if (*endptr != '\0' || ctx->batch_count < 0) {
-                flux_log (h, LOG_ERR, "Invalid batch-count: %s", argv[i]);
-                return -1;
-            }
-        }
-        else if (!strcmp (argv[i], "disable-validator")) {
-            use_validator = false;
-        }
-        else {
-            flux_log (h, LOG_ERR, "invalid option %s", argv[i]);
-            flux_log (h, LOG_ERR, "%s", usage_message);
-            errno = EINVAL;
-            return -1;
-        }
-    }
-    if (use_validator) {
-        if (!(ctx->validate = validate_create (h))
-            || validate_configure (ctx->validate, plugins, valargs) < 0) {
-            flux_log_error (h, "validate_create");
-            return -1;
-        }
-    }
+    if (job_ingest_configure (ctx, flux_get_conf (h), argc, argv) < 0)
+        return -1;
 
 #if HAVE_FLUX_SECURITY
     if (!(ctx->sec = flux_security_create (0))) {

--- a/src/modules/job-ingest/validate.h
+++ b/src/modules/job-ingest/validate.h
@@ -28,9 +28,16 @@ flux_future_t *validate_job (struct validate *v, json_t *job);
  */
 int validate_stop_notify (struct validate *v, process_exit_f cb, void *arg);
 
-struct validate *validate_create (flux_t *h,
-                                  const char *validator_plugins,
-                                  const char *validator_args);
+struct validate *validate_create (flux_t *h);
+
+/*  Configure or reconfigure validators. This must be called at least
+ *   once to initially configure validator workers. It then may be called
+ *   to reconfigure workers (which will pick up the changes on the next
+ *   restart)
+ */
+int validate_configure (struct validate *v,
+                        const char *validator_plugins,
+                        const char *validator_args);
 
 void validate_destroy (struct validate *v);
 

--- a/src/modules/job-ingest/worker.h
+++ b/src/modules/job-ingest/worker.h
@@ -25,10 +25,15 @@ bool worker_is_running (struct worker *w);
 
 flux_future_t *worker_kill (struct worker *w, int signo);
 void worker_destroy (struct worker *w);
-struct worker *worker_create (flux_t *h, double inactivity_timeout,
-                              const char *worker_name,
-                              int argc, char **argv);
 
+struct worker *worker_create (flux_t *h,
+                              double inactivity_timeout,
+                              const char *worker_name);
+
+/*  (re)set cmdline for worker `w`. The new command will be used the
+ *   next time the worker starts.
+ */
+int worker_set_cmdline (struct worker *w, int argc, char **argv);
 
 /* Tell worker to stop.
  * Return a count of running processes.

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -106,6 +106,7 @@ TESTSCRIPTS = \
 	t2010-kvs-snapshot-restore.t \
 	t2100-job-ingest.t \
 	t2110-job-ingest-validator.t \
+	t2111-job-ingest-config.t \
 	t2201-job-cmd.t \
 	t2202-job-manager.t \
 	t2203-job-manager-single.t \

--- a/t/t2111-job-ingest-config.t
+++ b/t/t2111-job-ingest-config.t
@@ -1,0 +1,81 @@
+#!/bin/sh
+test_description='Test job ingest config file'
+
+. $(dirname $0)/sharness.sh
+
+#
+# Setup a config dir for this test_under_flux
+#
+export FLUX_CONF_DIR=$(pwd)/conf.d
+mkdir -p conf.d
+cat <<EOF >conf.d/ingest.toml
+[ingest.validator]
+disable = true
+EOF
+
+test_under_flux 1 job
+
+flux setattr log-stderr-level 1
+
+SUBMITBENCH="${FLUX_BUILD_DIR}/t/ingest/submitbench"
+SCHEMA=${FLUX_SOURCE_DIR}/src/modules/job-ingest/schemas/jobspec.jsonschema
+dmesg_grep=${SHARNESS_TEST_SRCDIR}/scripts/dmesg-grep.py
+
+test_expect_success 'job-ingest: validator was disabled by config' '
+	$dmesg_grep -t 5 "Disabling job validator"
+'
+test_expect_success 'job-ingest: command line overrides config' '
+	rm conf.d/ingest.toml &&
+	flux config reload &&
+	flux dmesg -C &&
+	flux module reload job-ingest disable-validator &&
+	$dmesg_grep -t 10 "Disabling job validator"
+'
+test_expect_success 'job-ingest: configuration can be reloaded' '
+	cat <<-EOF >conf.d/ingest.toml &&
+	[ingest.validator]
+	plugins = [ "feasibility", "jobspec" ]
+	args = [ "--require-version=1" ]
+	EOF
+	flux dmesg -C &&
+	flux config reload &&
+	$dmesg_grep -vt 10 \
+	"configuring with plugins=feasibility,jobspec, args=--require-version=1"
+'
+test_expect_success 'job-ingest: verify that feasibility plugin is in effect' '
+	test_must_fail flux mini submit -n 1024 hostname
+'
+test_expect_success 'job-ingest: invalid config detected on reload' '
+	cat <<-EOF >conf.d/ingest.toml &&
+	[ingest.validator]
+	foo = 42
+	args = "--require-version=1"
+	EOF
+	test_must_fail flux config reload &&
+	flux dmesg | grep ingest
+'
+test_expect_success 'job-ingest: job still runs after failed config reload' '
+	flux mini run true
+'
+test_expect_success 'job-ingest: invalid ingest.validator.plugins' '
+	cat <<-EOF >conf.d/ingest.toml &&
+	[ingest.validator]
+	plugins = [  42 ]
+	EOF
+	test_must_fail flux config reload
+'
+test_expect_success 'job-ingest: job still runs after failed config reload' '
+	flux mini run true
+'
+test_expect_success 'job-ingest: invalid ingest.validator.plugins' '
+	cat <<-EOF >conf.d/ingest.toml &&
+	[ingest.validator]
+	plugins = [ "feasibility" ]
+	args = [ 1 ]
+	EOF
+	test_must_fail flux config reload
+'
+test_expect_success 'job-ingest: job still runs after failed config reload' '
+	flux mini run true
+'
+test_done


### PR DESCRIPTION
This PR adds a TOML config for `job-ingest` module in order to make configuration of validator plugins in the system possible using config files.

`flux config reload` is supported for `ingest.validator.plugins` and `ingest.validator.args`, but it would have been a little too much development to allow disabling the validator on reload, so that is not supported now (and this can be done by reloading the job-ingest module anyway).