### PR TITLE
add 'require-instance' job validator plugin

### DIFF
--- a/src/bindings/python/flux/Makefile.am
+++ b/src/bindings/python/flux/Makefile.am
@@ -33,6 +33,7 @@ nobase_fluxpy_PYTHON = \
 	job/validator/plugins/jobspec.py \
 	job/validator/plugins/schema.py \
 	job/validator/plugins/feasibility.py \
+	job/validator/plugins/require-instance.py \
 	resource/Rlist.py \
 	resource/__init__.py \
 	resource/ResourceSetImplementation.py \

--- a/src/bindings/python/flux/job/validator/plugins/require-instance.py
+++ b/src/bindings/python/flux/job/validator/plugins/require-instance.py
@@ -1,0 +1,39 @@
+##############################################################
+# Copyright 2022 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+##############################################################
+
+"""Require that all jobs are new instances of Flux
+
+This plugin validates that submitted jobs are new instances of Flux.
+That is, either the `batch` system attribute is set, or the first
+2 arguments of the command are `flux broker` or `flux start`.
+
+This is not a foolproof solution. The validator could reject jobs that
+are new instances of Flux if an instance is launched by a script and
+not directly via `flux broker` or `flux start`.
+"""
+
+import errno
+from os.path import basename
+from flux.job.validator import ValidatorPlugin
+
+
+class Validator(ValidatorPlugin):
+    def validate(self, args):
+        if "batch" in args.jobspec["attributes"]["system"]:
+            return
+        command = args.jobspec["tasks"][0]["command"]
+        arg0 = basename(command[0])
+        if arg0 == "flux" and command[1] in ["broker", "start"]:
+            return
+        return (
+            errno.EINVAL,
+            "Direct job submission is disabled for this instance."
+            + " Please use the batch or alloc subcommands of flux-mini(1)",
+        )

--- a/t/t2110-job-ingest-validator.t
+++ b/t/t2110-job-ingest-validator.t
@@ -41,7 +41,8 @@ test_expect_success 'flux job-validator --list-plugins works' '
 	flux job-validator --list-plugins >list-plugins.output 2>&1 &&
 	test_debug "cat list-plugins.output" &&
 	grep jobspec list-plugins.output &&
-	grep feasibility list-plugins.output
+	grep feasibility list-plugins.output &&
+	grep require-instance list-plugins.output
 '
 test_expect_success 'flux job-validator --help shows help for selected plugins' '
 	flux job-validator --plugins=jobspec --help >help.jobspec.out 2>&1 &&
@@ -157,5 +158,13 @@ test_expect_success 'job-ingest: validator unexpected exit is handled' '
 		validator-plugins=${BAD_VALIDATOR} &&
 		test_must_fail flux mini submit hostname 2>badvalidator.out &&
 	grep "unexpectedly exited" badvalidator.out
+'
+test_expect_success 'job-ingest: require-instance validator plugin works' '
+	ingest_module reload validator-plugins=require-instance &&
+	flux mini batch -n1 --wrap flux resource list &&
+	flux mini submit -n1 flux start flux resource list &&
+	flux mini submit -n1 flux broker flux resource list &&
+	test_must_fail flux mini submit hostname &&
+	test_must_fail flux mini submit flux getattr rank
 '
 test_done


### PR DESCRIPTION
This PR adds a validator plugin which attempts to require that all submitted jobs will result in a new instance of Flux. The idea is that we may not want to allow regular parallel jobs (as submitted by `flux mini run` and `flux mini submit` for example) in a system instance, since this results in potential extra burden on the system instance TBON and KVS.

At first it was thought that admins could just drop a validator plugin into the correct path if this was required, but in the end it seemed like offering a native solution (which also serves as another validator plugin example) was probably wise.