### PR TITLE
ci: run 32bit build under linux32 personality

### DIFF
--- a/src/test/checks_run.sh
+++ b/src/test/checks_run.sh
@@ -26,6 +26,17 @@
 #  CC, CXX, LDFLAGS, CFLAGS, etc.
 #
 
+
+#  Ensure uname -m reports 32bit architecture if platform was specified
+#   as 386:
+#
+case $PLATFORM in *386)
+  unset PLATFORM
+  echo "Rexecuting under linux32 personality"
+  exec setarch i386 $0 "$@"
+  ;;
+esac
+
 # if make is old, and scl is here, and devtoolset is available and not turned
 # on, re-exec ourself with it active to get a newer make
 if make --version | grep 'GNU Make 4' 2>&1 > /dev/null ; then

--- a/src/test/docker/docker-run-checks.sh
+++ b/src/test/docker/docker-run-checks.sh
@@ -164,6 +164,7 @@ if [[ -n "$MOUNT_HOME_ARGS" ]]; then
 fi
 echo "mounting $TOP as $WORKDIR"
 
+export PLATFORM
 export PROJECT
 export POISON
 export INCEPTION
@@ -198,6 +199,7 @@ else
         --volume=$TOP:$WORKDIR \
         ${PLATFORM} \
         $MOUNT_HOME_ARGS \
+        -e PLATFORM \
         -e CC \
         -e CXX \
         -e LDFLAGS \


### PR DESCRIPTION
Problem: At some point the docker 32bit builder (platform = linux/i386)
stopped setting the i386 personality(2), so uname -m reports x86_64
instead of i686, and thus configure detects an x86_64 target.

Check for a platform of linux/i386 in checks_run.sh and re-invoke the
script under `setarch i386` to force the "correct" uname.

Fixes #4226