### PR TITLE
broker: don't leave shutdown state prematurely

### DIFF
--- a/t/t0025-broker-state-machine.t
+++ b/t/t0025-broker-state-machine.t
@@ -155,6 +155,33 @@ test_expect_success 'all expected events and state transitions occurred' '
 	grep "rc3-none: finalize->exit"			states.log
 '
 
+test_expect_success 'capture state transitions from size=2 instance' '
+	flux start ${ARGS} --test-size=2 -o,-Slog-stderr-level=6 \
+		/bin/true 2>states2.log
+'
+
+test_expect_success 'all expected events and state transitions occurred on rank 0' '
+	grep "\[0\]: start: none->join"				states2.log &&
+	grep "\[0\]: parent-none: join->init"			states2.log &&
+	grep "\[0\]: rc1-none: init->quorum"			states2.log &&
+	grep "\[0\]: quorum-full: quorum->run"			states2.log &&
+	grep "\[0\]: rc2-success: run->cleanup"			states2.log &&
+	grep "\[0\]: cleanup-none: cleanup->shutdown"		states2.log &&
+	grep "\[0\]: children-complete: shutdown->finalize"	states2.log &&
+	grep "\[0\]: rc3-none: finalize->exit"			states2.log
+'
+
+test_expect_success 'all expected events and state transitions occurred on rank 1' '
+	grep "\[1\]: start: none->join"				states2.log &&
+	grep "\[1\]: parent-ready: join->init"			states2.log &&
+	grep "\[1\]: rc1-none: init->quorum"			states2.log &&
+	grep "\[1\]: quorum-full: quorum->run"			states2.log &&
+	grep "\[1\]: shutdown-abort: run->cleanup"		states2.log &&
+	grep "\[1\]: cleanup-none: cleanup->shutdown"		states2.log &&
+	grep "\[1\]: children-none: shutdown->finalize"	        states2.log &&
+	grep "\[1\]: rc3-none: finalize->exit"			states2.log
+'
+
 test_expect_success 'capture state transitions from instance with rc1 failure' '
 	test_must_fail flux start \
 	    -o,-Slog-filename=states_rc1.log \


### PR DESCRIPTION
Problem: broker immediately posts "children-none" on entry to STATE_SHUTDOWN, even if it has TBON children.

`state_machine->child_count` is always set to zero on entry to STATE_SHUTDOWN because it hasn't been updated since it was
initialized, when no peers were  online.  There is actually no reason to be saving this value - just call the `overlay_get_child_peer_count()` accessor when the count is needed instead of caching it.

Add a failing test to the broker state machine sharness test script.

This bug means that leaves-to-root rc3 execution has been running without synchronization.  The rc3's effectively all start at the same time across the instance, and upstream could complete before downstream, which violates a primary invariant of our distributed service design.  Most likely what has been saving us from data loss is the "cleanup" scripts which ensure all jobs cancel or complete before any rc3 scripts begin executing, and the fact that rank 0 has more to do than the other ranks so it takes longer.

This bug seems to have been introduced in release 0.26.0 (2021-04-22).