### PR TITLE
systemd: make directory init failure non-fatal

### DIFF
--- a/etc/flux.service.in
+++ b/etc/flux.service.in
@@ -31,8 +31,8 @@ RuntimeDirectory=flux
 RuntimeDirectoryMode=0755
 PermissionsStartOnly=true
 ExecStartPre=-/bin/mkdir -p @X_LOCALSTATEDIR@/lib/flux
-ExecStartPre=/bin/chown flux:flux @X_LOCALSTATEDIR@/lib/flux
-ExecStartPre=/bin/chmod 0700 @X_LOCALSTATEDIR@/lib/flux
+ExecStartPre=-/bin/chown flux:flux @X_LOCALSTATEDIR@/lib/flux
+ExecStartPre=-/bin/chmod 0700 @X_LOCALSTATEDIR@/lib/flux
 ExecStartPre=/usr/bin/loginctl enable-linger flux
 ExecStartPre=bash -c 'systemctl start user@$(id -u flux).service'
 


### PR DESCRIPTION
Problem: the `content.sqlite` file is only created on rank 0 but if the systemd unit file ExecStartPre fails to set the owner and mode of `${localstatedir}/lib/flux` on any rank, then flux fails to start.

Example: `${localstatedir}/lib/flux` is a symbolic link pointing to `/scratch/flux` on all ranks, but `/scratch` is only mounted on rank 0.  Flux fails to start on the nonzero ranks.

Add a "-" in front of the commands so that the unit succeeds even if those commands fail.