### PR TITLE
flux.service: use StateDirectory for content.sqlite

### DIFF
--- a/etc/flux.service.in
+++ b/etc/flux.service.in
@@ -16,7 +16,7 @@ ExecStart=/bin/bash -c '\
   -Slocal-uri=local://@X_RUNSTATEDIR@/flux/local \
   -Slog-stderr-level=6 \
   -Slog-stderr-mode=local \
-  -Scontent.backing-path=@X_LOCALSTATEDIR@/lib/flux/content.sqlite \
+  -Scontent.backing-path=${STATE_DIRECTORY:-/var/lib/flux}/content.sqlite \
   -Sbroker.rc2_none \
   -Sbroker.quorum=0 \
   -Sbroker.quorum-timeout=none \
@@ -29,10 +29,9 @@ User=flux
 Group=flux
 RuntimeDirectory=flux
 RuntimeDirectoryMode=0755
+StateDirectory=flux
+StateDirectoryMode=0700
 PermissionsStartOnly=true
-ExecStartPre=-/bin/mkdir -p @X_LOCALSTATEDIR@/lib/flux
-ExecStartPre=/bin/chown flux:flux @X_LOCALSTATEDIR@/lib/flux
-ExecStartPre=/bin/chmod 0700 @X_LOCALSTATEDIR@/lib/flux
 ExecStartPre=/usr/bin/loginctl enable-linger flux
 ExecStartPre=bash -c 'systemctl start user@$(id -u flux).service'
 


### PR DESCRIPTION
Problem: the flux service unit file currently creates, chowns,
and chmods `${localstatedir}/lib/flux` for the content.sqlite file
on startup using ExecStartPre, but systemd provides support for
standardized creation of a directory for persistent state.

One notable change is that the old directory was relative to
flux's --prefix and the new one is relative to systemd's.
This will have no effect on system-packaged flux which is the
main use case for execution under systemd.

Also of note: the directory may not be a symbolic link.
If content.sqlite needs to be redirected to a different file
system, a bind mount on `/var/lib/flux `may be used for now;
in the future, we could let this path be configured via TOML.

Since `${STATE_DIRECTORY}` was introduced in systemd v240 and
RHEL 8 is currently using v239, add a workaround to substitute
a default value if `${STATE_DIRECTORY}` is not set.

Fixes #4081

(This is basically @grondo's patch proposed in #4018 with the workaround for RHEL 8 - thanks for sorting out all the details)

I should test this on fluke before it is merged.