### PR TITLE
support node exclusive allocations

### DIFF
--- a/doc/man1/flux-mini.rst
+++ b/doc/man1/flux-mini.rst
@@ -27,8 +27,8 @@ as a parallel job, while **batch** and **alloc** submit a script or launch
 a command as the initial program of a new Flux instance.
 
 If *--ntasks* is unspecified, a value of *N=1* is assumed. Commands that
-take *--nslots* have no default and require that *--nslots* be explicitly
-specified.
+take *--nslots* have no default and require that *--nslots* or *--nodes*
+be specified.
 
 The **submit** and **batch** commands enqueue the job and print its numerical
 Job ID on standard output.
@@ -97,6 +97,13 @@ following additional job parameters:
    evenly across the allocated nodes. It is an error to request more nodes
    than there are tasks. If unspecified, the number of nodes will be chosen
    by the scheduler.
+
+**--exclusive**
+   Indicate to the scheduler that nodes should be exclusively allocated to
+   this job. It is an error to specify this option without also using
+   *-N, --nodes*. If *--nodes* is specified without *--nslots* or *--ntasks*,
+   then this option will be enabled by default and the number of tasks
+   or slots will be set to the number of requested nodes.
 
 **-t, --time-limit=FSD**
    Set a time limit for the job in Flux standard duration (RFC 23).

--- a/src/bindings/python/flux/resource/Rlist.py
+++ b/src/bindings/python/flux/resource/Rlist.py
@@ -124,9 +124,10 @@ class Rlist(WrapperPimpl):
         error = ffi.new("flux_error_t *")
         if not isinstance(constraint, str):
             constraint = json.dumps(constraint)
-        handle = self.pimpl.copy_constraint_string(constraint, error)
-        if not handle:
+        try:
+            handle = self.pimpl.copy_constraint_string(constraint, error)
+        except OSError as exc:
             raise ValueError(
                 "copy_constraint: " + ffi.string(error.text).decode("utf-8")
-            )
+            ) from exc
         return Rlist(handle=handle)

--- a/src/cmd/flux-mini.py
+++ b/src/cmd/flux-mini.py
@@ -726,6 +726,11 @@ class SubmitBaseCmd(MiniCmd):
             help="Number of GPUs to allocate per task",
         )
         self.parser.add_argument(
+            "--exclusive",
+            action="store_true",
+            help="With -N, --nodes, allocate nodes exclusively",
+        )
+        self.parser.add_argument(
             "-v",
             "--verbose",
             action="count",
@@ -756,6 +761,7 @@ class SubmitBaseCmd(MiniCmd):
             cores_per_task=args.cores_per_task,
             gpus_per_task=args.gpus_per_task,
             num_nodes=args.nodes,
+            exclusive=args.exclusive,
         )
 
     def run_and_exit(self):
@@ -1445,6 +1451,11 @@ def add_batch_alloc_args(parser):
         metavar="N",
         help="Distribute allocated resource slots across N individual nodes",
     )
+    parser.add_argument(
+        "--exclusive",
+        action="store_true",
+        help="With --nodes, allocate nodes exclusively",
+    )
 
 
 def list_split(opts):
@@ -1511,6 +1522,7 @@ class BatchCmd(MiniCmd):
             gpus_per_slot=args.gpus_per_slot,
             num_nodes=args.nodes,
             broker_opts=list_split(args.broker_opts),
+            exclusive=args.exclusive,
         )
 
         # Default output is flux-{{jobid}}.out
@@ -1554,6 +1566,7 @@ class AllocCmd(MiniCmd):
             gpus_per_slot=args.gpus_per_slot,
             num_nodes=args.nodes,
             broker_opts=list_split(args.broker_opts),
+            exclusive=args.exclusive,
         )
         if sys.stdin.isatty():
             jobspec.setattr_shell_option("pty.interactive", 1)

--- a/src/common/librlist/rlist.c
+++ b/src/common/librlist/rlist.c
@@ -2012,9 +2012,9 @@ rlist_alloc_constrained (struct rlist *rl,
     return result;
 }
 
-struct rlist *rlist_alloc_ex (struct rlist *rl,
-                              const struct rlist_alloc_info *ai,
-                              flux_error_t *errp)
+struct rlist *rlist_alloc (struct rlist *rl,
+                           const struct rlist_alloc_info *ai,
+                           flux_error_t *errp)
 {
     struct rlist *result = NULL;
 
@@ -2044,35 +2044,6 @@ struct rlist *rlist_alloc_ex (struct rlist *rl,
     }
 
     return result;
-}
-
-struct rlist *rlist_alloc (struct rlist *rl, const char *mode,
-                          int nnodes, int slots, int slotsz)
-{
-    struct rlist *result = NULL;
-    struct rlist_alloc_info ai = {
-        .nnodes = nnodes,
-        .nslots = slots,
-        .slot_size = slotsz,
-        .mode = mode
-    };
-
-    if (alloc_info_check (rl, &ai, NULL) < 0)
-        return NULL;
-
-    /*
-     *   Try allocation. If it fails with not enough resources (ENOSPC),
-     *    then try again on an empty copy of rlist to see the request could
-     *    *ever* be satisfied. Adjust errno to EOVERFLOW if not.
-     */
-    result = rlist_try_alloc (rl, &ai);
-    if (!result && (errno == ENOSPC)) {
-        if (rlist_alloc_feasible (rl, mode, nnodes, slots, slotsz))
-            errno = ENOSPC;
-        else
-            errno = EOVERFLOW;
-    }
-    return (result);
 }
 
 static int rlist_free_rnode (struct rlist *rl, struct rnode *n)

--- a/src/common/librlist/rlist.c
+++ b/src/common/librlist/rlist.c
@@ -309,8 +309,10 @@ struct rlist *rlist_copy_constraint (const struct rlist *orig,
                                      json_t *constraint,
                                      flux_error_t *errp)
 {
-    if (rnode_match_validate (constraint, errp) < 0)
+    if (rnode_match_validate (constraint, errp) < 0) {
+        errno = EINVAL;
         return NULL;
+    }
     return rlist_copy_internal (orig,
                                 (rnode_copy_f) rnode_copy_match,
                                 (void *) constraint);

--- a/src/common/librlist/rlist.h
+++ b/src/common/librlist/rlist.h
@@ -244,19 +244,14 @@ int rlist_verify (flux_error_t *error,
  *   "first-fit"         - allocate first free slots found in rank order
  *
  *  Returns a new rlist representing the allocation on success,
- *   NULL on failure with errno set:
+ *   NULL on failure with errno set.
  *
  *   ENOSPC - unable to fulfill allocation.
  *   EINVAL - An argument was invalid.
  */
-struct rlist * rlist_alloc (struct rlist *rl, const char *mode,
-                            int nnodes, int slot_size, int nslots);
-
-/*  As above, but arguments are passed in an rlist_alloc_info object
- */
-struct rlist * rlist_alloc_ex (struct rlist *rl,
-                               const struct rlist_alloc_info *ai,
-                               flux_error_t *errp);
+struct rlist * rlist_alloc (struct rlist *rl,
+                            const struct rlist_alloc_info *ai,
+                            flux_error_t *errp);
 
 /*  Mark rlist "alloc" as allocated in rlist "rl".
  */

--- a/src/common/librlist/rlist.h
+++ b/src/common/librlist/rlist.h
@@ -43,6 +43,14 @@ struct rlist {
     json_t *scheduling;
 };
 
+struct rlist_alloc_info {
+    int nnodes;
+    int slot_size;
+    int nslots;
+    const char *mode;
+    json_t *constraints;
+};
+
 /*  Create an empty rlist object */
 struct rlist *rlist_create (void);
 

--- a/src/common/librlist/rlist.h
+++ b/src/common/librlist/rlist.h
@@ -48,6 +48,7 @@ struct rlist_alloc_info {
     int slot_size;
     int nslots;
     const char *mode;
+    bool exclusive;
     json_t *constraints;
 };
 

--- a/src/common/librlist/rlist.h
+++ b/src/common/librlist/rlist.h
@@ -252,6 +252,11 @@ int rlist_verify (flux_error_t *error,
 struct rlist * rlist_alloc (struct rlist *rl, const char *mode,
                             int nnodes, int slot_size, int nslots);
 
+/*  As above, but arguments are passed in an rlist_alloc_info object
+ */
+struct rlist * rlist_alloc_ex (struct rlist *rl,
+                               const struct rlist_alloc_info *ai,
+                               flux_error_t *errp);
 
 /*  Mark rlist "alloc" as allocated in rlist "rl".
  */

--- a/src/common/librlist/test/rlist.c
+++ b/src/common/librlist/test/rlist.c
@@ -19,6 +19,7 @@ struct testalloc {
     int nnodes;
     int nslots;
     int slot_size;
+    int exclusive;
 };
 
 struct rlist_test_entry {
@@ -34,97 +35,97 @@ struct rlist_test_entry {
 };
 
 #define RLIST_TEST_END { NULL, NULL, NULL, \
-                         { 0, 0, 0 },      \
+                         { 0, 0, 0, 0 },      \
                          NULL, NULL, NULL, \
                          0, false }
 
 struct rlist_test_entry test_2n_4c[] = {
     { "too large of slot returns EOVERFLOW", NULL, NULL,
-      { 0, 1, 5 },
+      { 0, 1, 5, 0 },
       NULL,
       "",
       "rank[0-1]/core[0-3]",
       EOVERFLOW, false },
     { "too many slots returns error", NULL, NULL,
-      { 0, 9, 1 },
+      { 0, 9, 1, 0 },
       NULL,
       "",
       "rank[0-1]/core[0-3]",
       EOVERFLOW, false },
     { "invalid number of nodes returns error", NULL, NULL,
-      { -1, 1, 1 },
+      { -1, 1, 1, 0 },
       NULL,
       "",
       "rank[0-1]/core[0-3]",
       EINVAL, false },
     { "Too many nodes returns error", NULL, NULL,
-      { 3, 4, 1 },
+      { 3, 4, 1, 0 },
       NULL,
       "",
       "rank[0-1]/core[0-3]",
       EOVERFLOW, false },
     { "nodes > slots returns error", NULL, NULL,
-      { 2, 1, 1 },
+      { 2, 1, 1, 0 },
       NULL,
       "",
       "rank[0-1]/core[0-3]",
       EINVAL, false },
     { "invalid number of slots return error", NULL, NULL,
-      { 0, 0, 1 },
+      { 0, 0, 1, 0 },
       NULL,
       "",
       "rank[0-1]/core[0-3]",
       EINVAL, false },
     { "invalid slot size returns error", NULL, NULL,
-      { 0, 1, -1},
+      { 0, 1, -1, 0 },
       NULL,
       "",
       "rank[0-1]/core[0-3]",
       EINVAL, false },
     { "allocate with all nodes down returns ENOSPC", NULL, "0-1",
-      { 0, 1, 1},
+      { 0, 1, 1, 0 },
       NULL,
       "",
       "",
       ENOSPC, false },
     { "allocating a single core gets expected result", NULL, NULL,
-      { 0, 1, 1 },
+      { 0, 1, 1, 0 },
       "rank0/core0",
       "rank0/core0",
       "rank0/core[1-3] rank1/core[0-3]",
       0, true },
     { "allocating a single core with down rank", NULL, "0",
-      { 0, 1, 1 },
+      { 0, 1, 1, 0 },
       "rank1/core0",
       "rank1/core0",
       "rank1/core[1-3]",
       0, false },
     { "allocating another core (all ranks up)", NULL, NULL,
-      { 0, 1, 1 },
+      { 0, 1, 1, 0 },
       "rank0/core0",
       "rank[0-1]/core0",
       "rank[0-1]/core[1-3]",
       0, false },
     { "allocating another core gets expected result", NULL, NULL,
-      { 0, 1, 1 },
+      { 0, 1, 1, 0 },
       "rank0/core1",
       "rank0/core[0-1] rank1/core0",
       "rank0/core[2-3] rank1/core[1-3]",
       0, false },
     { "allocate 1 slot of size 3 lands on correct node", NULL, NULL,
-      { 0, 1, 3 },
+      { 0, 1, 3, 0 },
       "rank1/core[1-3]",
       "rank0/core[0-1] rank1/core[0-3]",
       "rank0/core[2-3]",
       0, false },
     { "allocate 4 slots of 1 core now returns ENOSPC", NULL, NULL,
-      { 0, 4, 1 },
+      { 0, 4, 1, 0 },
       NULL,
       "rank0/core[0-1] rank1/core[0-3]",
       "rank0/core[2-3]",
       ENOSPC, false },
     { "allocate remaining 2 cores", NULL, NULL,
-      { 0, 1, 2 },
+      { 0, 1, 2, 0 },
       "rank0/core[2-3]",
       "rank[0-1]/core[0-3]",
       "",
@@ -134,31 +135,31 @@ struct rlist_test_entry test_2n_4c[] = {
 
 struct rlist_test_entry test_6n_4c[] = {
     { "best-fit: alloc 1 core", "best-fit", NULL,
-      { 0, 1, 1 },
+      { 0, 1, 1, 0 },
       "rank0/core0",
       "rank0/core0",
       "rank0/core[1-3] rank[1-5]/core[0-3]",
       0, false },
     { "best-fit: alloc 1 slot/size 3 fits on rank0", "best-fit", NULL,
-      { 0, 1, 3 },
+      { 0, 1, 3, 0 },
       "rank0/core[1-3]",
       "rank0/core[0-3]",
       "rank[1-5]/core[0-3]",
       0, false },
     { "best-fit: alloc 2 slots/size 2 fits on rank1","best-fit", NULL,
-      { 0, 2, 2 },
+      { 0, 2, 2, 0 },
       "rank1/core[0-3]",
       "rank[0-1]/core[0-3]",
       "rank[2-5]/core[0-3]",
       0, false },
     { "best-fit: alloc 3 slot of size 1",            "best-fit", NULL,
-      { 0, 3, 1 },
+      { 0, 3, 1, 0 },
       "rank2/core[0-2]",
       "rank[0-1]/core[0-3] rank2/core[0-2]",
       "rank2/core3 rank[3-5]/core[0-3]",
       0, false },
     { "best-fit alloc 3 slots of 1 core",            "best-fit", NULL,
-      { 0, 3, 1 },
+      { 0, 3, 1, 0 },
       "rank2/core3 rank3/core[0-1]",
       "rank[0-2]/core[0-3] rank3/core[0-1]",
       "rank3/core[2-3] rank[4-5]/core[0-3]",
@@ -168,31 +169,96 @@ struct rlist_test_entry test_6n_4c[] = {
 
 struct rlist_test_entry test_1024n_4c[] = {
     { "large: 512 nodes with 2 cores", NULL, NULL,
-      { 512, 512, 2 },
+      { 512, 512, 2, 0 },
       "rank[0-511]/core[0-1]",
       "rank[0-511]/core[0-1]",
       "rank[0-511]/core[2-3] rank[512-1023]/core[0-3]",
       0, false
     },
     { "large: 512 slots of 4 cores", NULL, NULL,
-      { 0, 512, 4 },
+      { 0, 512, 4, 0 },
       "rank[512-1023]/core[0-3]",
       "rank[0-511]/core[0-1] rank[512-1023]/core[0-3]",
       "rank[0-511]/core[2-3]",
       0, true
     },
     { "large: 1 core on 10 nodes", NULL, NULL,
-      { 10, 10, 1 },
+      { 10, 10, 1, 0 },
       "rank[512-521]/core0",
       "rank[0-511]/core[0-1] rank[512-521]/core0",
       "rank[0-511]/core[2-3] rank[512-521]/core[1-3] rank[522-1023]/core[0-3]",
       0, false },
     { "large: alloc 2 cores on 128 nodes with free", NULL, NULL,
-      { 128, 256, 1 },
+      { 128, 256, 1, 0 },
       "rank[522-649]/core[0-1]",
       "rank[0-511,522-649]/core[0-1] rank[512-521]/core0",
       "rank[0-511,522-649]/core[2-3] rank[512-521]/core[1-3] rank[650-1023]/core[0-3]",
       0, true
+    },
+    RLIST_TEST_END,
+};
+
+
+struct rlist_test_entry test_exclusive[] = {
+    { "exclusive: exclusive without nnodes fails",
+      NULL,
+      NULL,
+      { 0, 1, 1, 1 },
+      NULL,
+      "",
+      "rank[0-3]/core[0-3]",
+      EINVAL,
+      false
+    },
+    { "exclusive: allocate one core first",
+      NULL,
+      NULL,
+      { 0, 1, 1, 0 },
+      "rank0/core0",
+      "rank0/core0",
+      "rank0/core[1-3] rank[1-3]/core[0-3]",
+      0,
+      false
+    },
+    { "exclusive: exclusively allocate 2 nodes",
+      NULL,
+      NULL,
+      { 2, 2, 1, 1 },
+      "rank[1-2]/core[0-3]",
+      "rank0/core0 rank[1-2]/core[0-3]",
+      "rank0/core[1-3] rank3/core[0-3]",
+      0,
+      false
+    },
+    { "exclusive: exclusively allocate 2 nodes fails",
+      NULL,
+      NULL,
+      { 2, 2, 1, 1 },
+      NULL,
+      "rank0/core0 rank[1-2]/core[0-3]",
+      "rank0/core[1-3] rank3/core[0-3]",
+      ENOSPC,
+      false
+    },
+    { "exclusive: but 1 node works",
+      NULL,
+      NULL,
+      { 1, 1, 1, 1 },
+      "rank3/core[0-3]",
+      "rank0/core0 rank[1-3]/core[0-3]",
+      "rank0/core[1-3]",
+      0,
+      false
+    },
+    { "exclusive: last 3 cores can be allocated non-exclusively",
+      NULL,
+      NULL,
+      { 0, 3, 1, 0 },
+      "rank0/core[1-3]",
+      "rank[0-3]/core[0-3]",
+      "",
+      0,
+      false,
     },
     RLIST_TEST_END,
 };
@@ -260,15 +326,21 @@ static struct rlist * rl_alloc (struct rlist *rl,
                                 const char *mode,
                                 int nnodes,
                                 int nslots,
-                                int slot_size)
+                                int slot_size,
+                                int exclusive)
 {
     struct rlist_alloc_info ai = {
         .mode = mode,
         .nnodes = nnodes,
         .nslots = nslots,
-        .slot_size = slot_size
+        .slot_size = slot_size,
+        .exclusive = exclusive
     };
-    return rlist_alloc (rl, &ai, NULL);
+    flux_error_t error;
+    struct rlist *result = rlist_alloc (rl, &ai, &error);
+    if (!result)
+        diag ("rlist_alloc: %s", error.text);
+    return result;
 }
 
 static struct rlist * rlist_testalloc (struct rlist *rl,
@@ -277,7 +349,8 @@ static struct rlist * rlist_testalloc (struct rlist *rl,
     return rl_alloc (rl, e->mode,
                      e->alloc.nnodes,
                      e->alloc.nslots,
-                     e->alloc.slot_size);
+                     e->alloc.slot_size,
+                     e->alloc.exclusive);
 }
 
 static char * rlist_tostring (struct rlist *rl, bool allocated)
@@ -367,7 +440,9 @@ void run_test_entries (struct rlist_test_entry tests[], int ranks, int cores)
                 rlist_destroy (alloc);
             }
             else {
-                fail ("%s: %s", e->description, strerror (errno));
+                fail ("%s: rlist_testalloc: %s",
+                      e->description,
+                      strerror (errno));
             }
         }
 
@@ -402,7 +477,7 @@ static void test_simple (void)
         "rlist_append_rank_cores 1, 0-3");
     ok (rl->total == 8 && rl->avail == 8,
         "rlist: avail and total == 4");
-    ok ((alloc = rl_alloc (rl, NULL, 0, 8, 1)) != NULL,
+    ok ((alloc = rl_alloc (rl, NULL, 0, 8, 1, 0)) != NULL,
         "rlist: alloc all cores works");
     ok (alloc->total == 8 && alloc->avail == 8,
         "rlist: alloc: got %d/%d (expected 8/8)",
@@ -501,7 +576,7 @@ static void test_issue2202 (void)
         "issue2202: rlist_dumps works");
     free (result);
 
-    a = rl_alloc (rl, "best-fit", 1, 1, 1);
+    a = rl_alloc (rl, "best-fit", 1, 1, 1, 0);
     ok (a != NULL,
         "issue2202: rlist_alloc worked");
     if (a) {
@@ -538,7 +613,7 @@ static void test_issue2202 (void)
         "issue2202b: rlist_dumps works");
     free (result);
 
-    a = rl_alloc (rl, "best-fit", 1, 1, 1);
+    a = rl_alloc (rl, "best-fit", 1, 1, 1, 0);
     ok (a != NULL,
         "issue2202b: rlist_alloc worked");
     if (a) {
@@ -602,7 +677,7 @@ static void test_issue2473 (void)
     free (result);
 
     /* problem: allocated 3 cores on one node */
-    a = rl_alloc (rl, "worst-fit", 3, 3, 1);
+    a = rl_alloc (rl, "worst-fit", 3, 3, 1, 0);
     ok (a != NULL,
         "issue2473: rlist_alloc nnodes=3 slots=3 slotsz=1 worked");
     if (!a)
@@ -619,7 +694,7 @@ static void test_issue2473 (void)
     rlist_destroy (a);
 
     /* problem: unsatisfiable */
-    a = rl_alloc (rl, "worst-fit", 3, 8, 1);
+    a = rl_alloc (rl, "worst-fit", 3, 8, 1, 0);
     ok (a != NULL,
         "issue2473: rlist_alloc nnodes=3 slots=8 slotsz=1 worked");
     if (a) {
@@ -633,7 +708,7 @@ static void test_issue2473 (void)
      * - ask for 2 cores spread across 2 nodes
      * - we should get cores on rank[0-1] not rank[1-2]
      */
-    a = rl_alloc (rl, "worst-fit", 1, 1, 1);
+    a = rl_alloc (rl, "worst-fit", 1, 1, 1, 0);
     ok (a != NULL,
         "issue2473: rlist_alloc nnodes=1 slots=1 slotsz=1 worked");
     if (!a)
@@ -645,7 +720,7 @@ static void test_issue2473 (void)
         "issue2473: one core was allocated from rank0");
     free (result);
 
-    a2 = rl_alloc (rl, "worst-fit", 2, 2, 1);
+    a2 = rl_alloc (rl, "worst-fit", 2, 2, 1, 0);
     ok (a2 != NULL,
         "issue2473: rlist_alloc nnodes=2 slots=2 slotsz=1 worked");
     result = rlist_dumps (a2);
@@ -724,7 +799,7 @@ static void test_updown ()
     ok (rl->avail == 16,
         "rl avail == 16");
 
-    rl2 = rl_alloc (rl, NULL, 0, 4, 1);
+    rl2 = rl_alloc (rl, NULL, 0, 4, 1, 0);
     ok (rl2 != NULL,
         "rlist_alloc() works when all nodes up");
 
@@ -747,12 +822,12 @@ static void test_updown ()
     ok (rlist_mark_up (rl, "0-2") == 0,
         "rlist_mark_up all but rank 3 up");
 
-    ok (rl_alloc (rl, NULL, 4, 4, 1) == NULL && errno == ENOSPC,
+    ok (rl_alloc (rl, NULL, 4, 4, 1, 0) == NULL && errno == ENOSPC,
         "allocation with 4 nodes fails with ENOSPC");
 
     ok (rlist_mark_up (rl, "3") == 0,
         "rlist_mark_up 3");
-    rl2 = rl_alloc (rl, NULL, 4, 4, 1);
+    rl2 = rl_alloc (rl, NULL, 4, 4, 1, 0);
 
     ok (rl2 != NULL,
         "rlist_alloc() for 4 nodes now succeeds");
@@ -1799,6 +1874,7 @@ int main (int ac, char *av[])
     run_test_entries (test_2n_4c,       2, 4);
     run_test_entries (test_6n_4c,       6, 4);
     run_test_entries (test_1024n_4c, 1024, 4);
+    run_test_entries (test_exclusive,   4, 4);
     test_issue2202 ();
     test_issue2473 ();
     test_updown ();

--- a/src/common/librlist/test/rlist.c
+++ b/src/common/librlist/test/rlist.c
@@ -268,7 +268,7 @@ static struct rlist * rl_alloc (struct rlist *rl,
         .nslots = nslots,
         .slot_size = slot_size
     };
-    return rlist_alloc_ex (rl, &ai, NULL);
+    return rlist_alloc (rl, &ai, NULL);
 }
 
 static struct rlist * rlist_testalloc (struct rlist *rl,

--- a/src/modules/sched-simple/libjj.c
+++ b/src/modules/sched-simple/libjj.c
@@ -26,10 +26,12 @@ static int jj_read_vertex (json_t *o, int level, struct jj_counts *jj)
     const char *type = NULL;
     json_t *with = NULL;
     json_error_t error;
+    int exclusive = 0;
 
-    if (json_unpack_ex (o, &error, 0, "{ s:s s:i s?o }",
+    if (json_unpack_ex (o, &error, 0, "{ s:s s:i s?b s?o }",
                        "type", &type,
                        "count", &count,
+                       "exclusive", &exclusive,
                        "with", &with) < 0) {
         snprintf (jj->error, sizeof (jj->error) - 1,
                   "level %d: %s", level, error.text);
@@ -42,8 +44,11 @@ static int jj_read_vertex (json_t *o, int level, struct jj_counts *jj)
         errno = EINVAL;
         return -1;
     }
-    if (strcmp (type, "node") == 0)
+    if (strcmp (type, "node") == 0) {
         jj->nnodes = count;
+        if (exclusive)
+            jj->exclusive = true;
+    }
     else if (strcmp (type, "slot") == 0)
         jj->nslots = count;
     else if (strcmp (type, "core") == 0)

--- a/src/modules/sched-simple/libjj.h
+++ b/src/modules/sched-simple/libjj.h
@@ -16,6 +16,7 @@
 #endif
 
 #include <jansson.h>
+#include <stdbool.h>
 
 #define JJ_ERROR_TEXT_LENGTH 256
 
@@ -23,6 +24,8 @@ struct jj_counts {
     int nnodes;    /* total number of nodes requested */
     int nslots;    /* total number of slots requested */
     int slot_size; /* number of cores per slot        */
+
+    bool exclusive;  /* enable node exclusive allocation if available */
 
     double duration; /* attributes.system.duration if set */
 

--- a/src/modules/sched-simple/sched.c
+++ b/src/modules/sched-simple/sched.c
@@ -197,7 +197,7 @@ static struct rlist *sched_alloc (struct simple_sched *ss,
         .slot_size = job->jj.slot_size,
         .constraints = job->constraints
     };
-    return rlist_alloc_ex (ss->rlist, &ai, errp);
+    return rlist_alloc (ss->rlist, &ai, errp);
 }
 
 static int try_alloc (flux_t *h, struct simple_sched *ss)
@@ -617,7 +617,7 @@ static void feasibility_cb (flux_t *h,
         .slot_size = jj.slot_size,
         .constraints = constraints
     };
-    if (!(alloc = rlist_alloc_ex (ss->rlist, &ai, &error))) {
+    if (!(alloc = rlist_alloc (ss->rlist, &ai, &error))) {
         if (errno != ENOSPC) {
             errmsg = error.text;
             goto err;

--- a/src/modules/sched-simple/sched.c
+++ b/src/modules/sched-simple/sched.c
@@ -195,6 +195,7 @@ static struct rlist *sched_alloc (struct simple_sched *ss,
         .nnodes = job->jj.nnodes,
         .nslots = job->jj.nslots,
         .slot_size = job->jj.slot_size,
+        .exclusive = job->jj.exclusive,
         .constraints = job->constraints
     };
     return rlist_alloc (ss->rlist, &ai, errp);

--- a/t/sched-simple/jj-reader.c
+++ b/t/sched-simple/jj-reader.c
@@ -27,8 +27,12 @@ int main (int ac, char *av[])
         log_err_exit ("Failed to read stdin");
     if (libjj_get_counts (s, &jj) < 0)
         log_msg_exit ("%s", jj.error);
-    printf ("nnodes=%d nslots=%d slot_size=%d duration=%.1f\n",
-            jj.nnodes, jj.nslots, jj.slot_size, jj.duration);
+    printf ("nnodes=%d nslots=%d slot_size=%d exclusive=%s duration=%.1f\n",
+            jj.nnodes,
+            jj.nslots,
+            jj.slot_size,
+            jj.exclusive ? "true" : "false",
+            jj.duration);
     log_fini ();
     free (s);
     return 0;

--- a/t/t0022-jj-reader.t
+++ b/t/t0022-jj-reader.t
@@ -103,17 +103,17 @@ done <invalid.txt
 # <jobspec command args> == <expected result>
 #
 cat <<EOF >inputs.txt
-run              ==nnodes=0 nslots=1 slot_size=1 duration=0.0
-run -N1 -n1      ==nnodes=1 nslots=1 slot_size=1 duration=0.0
-run -N1 -n4      ==nnodes=1 nslots=4 slot_size=1 duration=0.0
-run -N1 -n4 -c4  ==nnodes=1 nslots=4 slot_size=4 duration=0.0
-run -n4 -c4      ==nnodes=0 nslots=4 slot_size=4 duration=0.0
-run -n4 -c4      ==nnodes=0 nslots=4 slot_size=4 duration=0.0
-run -n4 -c1      ==nnodes=0 nslots=4 slot_size=1 duration=0.0
-run -N4 -n4 -c4  ==nnodes=4 nslots=4 slot_size=4 duration=0.0
-run -t 1m -N4 -n4 ==nnodes=4 nslots=4 slot_size=1 duration=60.0
-run -t 5s -N4 -n4 ==nnodes=4 nslots=4 slot_size=1 duration=5.0
-run -t 1h -N4 -n4 ==nnodes=4 nslots=4 slot_size=1 duration=3600.0
+run              ==nnodes=0 nslots=1 slot_size=1 exclusive=false duration=0.0
+run -N1 -n1      ==nnodes=1 nslots=1 slot_size=1 exclusive=false duration=0.0
+run -N1 -n4      ==nnodes=1 nslots=4 slot_size=1 exclusive=false duration=0.0
+run -N1 -n4 -c4  ==nnodes=1 nslots=4 slot_size=4 exclusive=false duration=0.0
+run -n4 -c4      ==nnodes=0 nslots=4 slot_size=4 exclusive=false duration=0.0
+run -n4 -c4      ==nnodes=0 nslots=4 slot_size=4 exclusive=false duration=0.0
+run -n4 -c1      ==nnodes=0 nslots=4 slot_size=1 exclusive=false duration=0.0
+run -N4 -n4 -c4  ==nnodes=4 nslots=4 slot_size=4 exclusive=false duration=0.0
+run -t 1m -N4 -n4 ==nnodes=4 nslots=4 slot_size=1 exclusive=false duration=60.0
+run -t 5s -N4 -n4 ==nnodes=4 nslots=4 slot_size=1 exclusive=false duration=5.0
+run -t 1h -N4 -n4 ==nnodes=4 nslots=4 slot_size=1 exclusive=false duration=3600.0
 EOF
 
 while read line; do

--- a/t/t2110-job-ingest-validator.t
+++ b/t/t2110-job-ingest-validator.t
@@ -128,11 +128,14 @@ test_expect_success 'job-ingest: feasibility check succceeds with ENOSYS' '
 '
 test_expect_success 'job-ingest: infeasible jobs are now rejected' '
 	test_must_fail flux mini submit -g 1 hostname 2>infeasible1.err &&
+	test_debug "cat infeasible1.err" &&
 	grep -i "unsupported resource type" infeasible1.err &&
 	test_must_fail flux mini submit -n 10000 hostname 2>infeasible2.err &&
-	grep "request is not satisfiable" infeasible2.err &&
+	test_debug "cat infeasible2.err" &&
+	grep "unsatisfiable request" infeasible2.err &&
 	test_must_fail flux mini submit -N 12 -n12 hostname 2>infeasible3.err &&
-	grep "request is not satisfiable" infeasible3.err
+	test_debug "cat infeasible3.err" &&
+	grep "unsatisfiable request" infeasible3.err
 '
 test_expect_success 'job-ingest: feasibility validator works with jobs running' '
 	ncores=$(flux resource list -s up -no {ncores}) &&
@@ -142,7 +145,7 @@ test_expect_success 'job-ingest: feasibility validator works with jobs running' 
 	flux queue stop &&
 	flux mini submit -n 2 hostname &&
 	test_must_fail flux mini submit -N 12 -n12 hostname 2>infeasible4.err &&
-	grep "request is not satisfiable" infeasible4.err &&
+	grep "unsatisfiable request" infeasible4.err &&
 	flux job cancel ${jobid} &&
 	flux job wait-event ${jobid} clean
 '

--- a/t/t2700-mini-cmd.t
+++ b/t/t2700-mini-cmd.t
@@ -49,10 +49,6 @@ test_expect_success 'flux mini run --ntasks=1 --nodes=2 fails' '
 		2>run1n2N.err &&
 	grep -i "node count must not be greater than task count" run1n2N.err
 '
-test_expect_success 'flux mini run (default ntasks) --nodes=2 fails' '
-	test_must_fail flux mini run --nodes=2 hostname 2>run2N.err &&
-	grep -i "node count must not be greater than task count" run2N.err
-'
 test_expect_success 'flux mini submit --urgency=6 works' '
 	jobid=$(flux mini submit --urgency=6 hostname) &&
 	flux job eventlog $jobid | grep submit | grep urgency=6

--- a/t/t2700-mini-cmd.t
+++ b/t/t2700-mini-cmd.t
@@ -41,8 +41,12 @@ test_expect_success HAVE_MULTICORE 'flux mini submit --ntasks=2 --cores-per-task
 	jobid=$(flux mini submit --ntasks=2 --cores-per-task=2 hostname) &&
 	flux job attach $jobid
 '
-test_expect_success 'flux mini run --ntasks=2 --nodes=2 works' '
+test_expect_success 'flux mini submit --ntasks=2 --nodes=2 works' '
 	flux mini run --ntasks=2 --nodes=2 hostname
+'
+test_expect_success 'flux mini run --nodes=2 allocates 2 nodes exclusively' '
+	id=$(flux mini submit --wait-event=start --nodes=2 hostname) &&
+	test $(flux job info ${id} R | flux R decode --count=node) = 2
 '
 test_expect_success 'flux mini run --ntasks=1 --nodes=2 fails' '
 	test_must_fail flux mini run --ntasks=1 --nodes=2 hostname \

--- a/t/t2702-mini-alloc.t
+++ b/t/t2702-mini-alloc.t
@@ -28,6 +28,19 @@ test_expect_success HAVE_JQ 'flux-mini alloc can set initial-program' '
 	flux mini alloc -n1 --dry-run myapp --foo | \
 	    jq -e ".tasks[0].command == [ \"flux\", \"broker\", \"myapp\", \"--foo\" ]"
 '
+test_expect_success HAVE_JQ 'flux-mini alloc -N2 requests 2 nodes exclusively' '
+	flux mini alloc -N2 --dry-run hostname | \
+		jq -S ".resources[0]" | \
+		jq -e ".type == \"node\" and .exclusive"
+'
+test_expect_success HAVE_JQ 'flux-mini alloc --exclusive works' '
+	flux mini alloc -N1 -n1 --exclusive --dry-run hostname | \
+		jq -S ".resources[0]" | \
+		jq -e ".type == \"node\" and .exclusive"
+'
+test_expect_success 'flux-mini alloc fails if N > n' '
+	test_expect_code 1 flux mini alloc -N2 -n1 --dry-run hostname
+'
 test_expect_success 'flux-mini alloc works' '
 	$runpty -o single.out flux mini alloc -n1 \
 		flux resource list -s up -no {rlist} &&


### PR DESCRIPTION
This PR adds an `--exclusive` flag in the `flux-mini` set of commands, which only works when `-N, --nodes` is also specified, and sets the `exclusive` key to `true` on the node vertex in jobspec. Support for node exclusive requests is added to sched-simple (mainly for testing), and finally the number of tasks/slots in `flux mini` commands is defaulted to the number of nodes, and the `exclusive` flag enabled, when number of tasks is not otherwise specified on the command line (fixes #4228).

As noted above, the new `--exclusive` flag only works if `-N, --nodes` is also specified. I was having trouble deciding if Jobspec V1 could even support setting the exclusive flag on nodes without also specifying the number of required nodes, though I admittedly didn't spend too much time on it. The current approach addresses the main concern here, which was defaulting ntasks/slots to nnodes in a coherent manner, so that seemed good enough for now.

There is a difference in behavior between Fluxion and sched-simple when allocating nodes exclusively. Fluxion will emit R with only the minimum resources required by the jobspec on each node (but all resources on the node will show as allocated), whereas sched-simple currently emits all exclusive node resources in the emitted R. Thus, for sched-simple:

```console
$ flux mini alloc -N4 flux resource list
     STATE NNODES   NCORES    NGPUS NODELIST
      free      4       16        0 fluke[7-10]
 allocated      0        0        0 
      down      0        0        0 
```

whereas with Fluxion:
```console
$ flux mini alloc -N4 flux resource list
     STATE NNODES   NCORES    NGPUS NODELIST
      free      4        4        0 fluke[7-10]
 allocated      0        0        0 
      down      0        0        0 
```

I'm not sure, but this seems like something we'll want to fix. Though I may be missing some subtlety here, it seems like it would be surprising behavior if users ask for nodes exclusively but only get one core from each node in their child instance. @dongahn?