### PR TITLE
broker: prevent systemd restart if rc1 fails

### DIFF
--- a/doc/man7/flux-broker-attributes.rst
+++ b/doc/man7/flux-broker-attributes.rst
@@ -100,6 +100,10 @@ broker.rc1_path [Updates: C]
 broker.rc3_path [Updates: C]
    The path to the broker's rc3 script.  Default: ``${prefix}/etc/flux/rc1``.
 
+broker.exit-restart [Updates: C, R]
+   A numeric exit code that the broker uses to indicate that it should not be
+   restarted.  This is set by the systemd unit file.  Default: unset.
+
 broker.starttime
    Timestamp of broker startup from :man3:`flux_reactor_now`.
 

--- a/etc/flux.service.in
+++ b/etc/flux.service.in
@@ -20,11 +20,13 @@ ExecStart=/bin/bash -c '\
   -Sbroker.rc2_none \
   -Sbroker.quorum=0 \
   -Sbroker.quorum-timeout=none \
+  -Sbroker.exit-norestart=42 \
 '
 SyslogIdentifier=flux
 ExecReload=@X_BINDIR@/flux config reload
 Restart=always
 RestartSec=5s
+RestartPreventExitStatus=42
 User=flux
 Group=flux
 RuntimeDirectory=flux

--- a/src/broker/state_machine.c
+++ b/src/broker/state_machine.c
@@ -460,8 +460,15 @@ static void runat_completion_cb (struct runat *r, const char *name, void *arg)
         log_err ("runat_get_exit_code %s", name);
 
     if (!strcmp (name, "rc1")) {
-        if (rc != 0)
-            s->ctx->exit_rc = rc;
+        /* If rc1 fails, it most likely will fail again on restart, so if
+         * running under systemd, exit with the broker.exit-norestart value.
+         */
+        if (rc != 0) {
+            if (s->exit_norestart != 0)
+                s->ctx->exit_rc = s->exit_norestart;
+            else
+                s->ctx->exit_rc = rc;
+        }
         state_machine_post (s, rc == 0 ? "rc1-success" : "rc1-fail");
     }
     else if (!strcmp (name, "rc2")) {

--- a/t/t0025-broker-state-machine.t
+++ b/t/t0025-broker-state-machine.t
@@ -183,7 +183,7 @@ test_expect_success 'all expected events and state transitions occurred on rank 
 '
 
 test_expect_success 'capture state transitions from instance with rc1 failure' '
-	test_must_fail flux start \
+	test_expect_code 1 flux start \
 	    -o,-Slog-filename=states_rc1.log \
 	    -o,-Sbroker.rc1_path=/bin/false \
 	    -o,-Sbroker.rc3_path= \
@@ -199,7 +199,7 @@ test_expect_success 'all expected events and state transitions occurred' '
 '
 
 test_expect_success 'capture state transitions from instance with rc2 failure' '
-	test_must_fail flux start \
+	test_expect_code 1 flux start \
 	    -o,-Slog-filename=states_rc2.log \
 	    ${ARGS} \
 	    /bin/false
@@ -217,7 +217,7 @@ test_expect_success 'all expected events and state transitions occurred' '
 '
 
 test_expect_success 'capture state transitions from instance with rc3 failure' '
-	test_must_fail flux start \
+	test_expect_code 1 flux start \
 	    -o,-Slog-filename=states_rc3.log \
 	    -o,-Sbroker.rc1_path= \
 	    -o,-Sbroker.rc3_path=/bin/false \
@@ -233,6 +233,14 @@ test_expect_success 'all expected events and state transitions occurred' '
 	grep "cleanup-none: cleanup->shutdown"		states_rc3.log &&
 	grep "children-none: shutdown->finalize"	states_rc3.log &&
 	grep "rc3-fail: finalize->exit"			states_rc3.log
+'
+
+test_expect_success 'instance rc1 failure exits with norestart code' '
+	test_expect_code 99 flux start \
+	    -o,-Sbroker.exit-norestart=99 \
+	    -o,-Sbroker.rc1_path=/bin/false \
+	    -o,-Sbroker.rc3_path= \
+	    /bin/true
 '
 
 test_expect_success 'broker.quorum-timeout=none is accepted' '


### PR DESCRIPTION
Problem:  if rc1 fails, for example, due to a misconfiguration, systemd will restart the broker over and over, filling up logs with useless noise until someone notices and fixes the problem.

If rc1 fails, most likely it is going to fail again on restart.   It seems more appropriate to not restart in this case.

This PR configures a special "don't restart" exit code using  `RestartPreventExitStatus`, and then uses it in place of the rc1 script exit code when rc1 fails, but only when run from systemd.

This was peeled off of work on #3895 - it seemed like it should stand alone for the release notes.