### PR TITLE
testsuite: fix a couple intermittent test failures

### DIFF
--- a/t/t0007-ping.t
+++ b/t/t0007-ping.t
@@ -138,10 +138,10 @@ test_expect_success 'ping help output works' '
 '
 
 test_expect_success 'ping works with hostname' '
-        flux ping --count=1 $(hostname -s)
+        flux ping --count=1 $(hostname)
 '
 test_expect_success 'ping works with hostname!service' '
-        flux ping --count=1 "$(hostname -s)!broker"
+        flux ping --count=1 "$(hostname)!broker"
 '
 test_expect_success 'ping fails with unknown hostname' '
         test_must_fail flux ping --count=1 "notmyhost!broker"

--- a/t/t2900-job-timelimits.t
+++ b/t/t2900-job-timelimits.t
@@ -29,7 +29,8 @@ test_expect_success HAVE_JQ 'job timelimits are propagated' '
 
 	id1=\$(flux mini submit --wait-event=start sleep 300)
 	flux jobs -no "{id.f58} {expiration}"
-	test "\$(flux jobs -no {expiration} \$id1)" = "\$expiration"
+	exp1=\$(flux jobs -no {expiration} \$id1)
+	test "\$(round \$exp1)" = "\$(round \${expiration})"
 	flux job cancelall -f
 
 	id2=\$(flux mini submit --wait-event=start -t 1m sleep 300)


### PR DESCRIPTION
This PR fixes a couple minor test failures:

 * ping tests assume short hostname
 * timelimit test might fail due to inconsistent Python rounding

