### PR TITLE
flux-resource: support properties when listing resources

### DIFF
--- a/src/bindings/python/flux/resource/ResourceSet.py
+++ b/src/bindings/python/flux/resource/ResourceSet.py
@@ -107,7 +107,9 @@ class ResourceSet:
 
     def copy(self):
         """Return a copy of a ResourceSet"""
-        return ResourceSet(self.impl.copy())
+        rset = ResourceSet(self.impl.copy())
+        rset.state = self.state
+        return rset
 
     def _run_op(self, method, *args):
         result = self.copy()
@@ -116,6 +118,7 @@ class ResourceSet:
                 arg = ResourceSet(arg, version=self.version)
             impl = getattr(result.impl, method)(arg.impl)
             result = ResourceSet(impl)
+        result.state = self.state
         return result
 
     def union(self, *args):

--- a/src/bindings/python/flux/resource/ResourceSet.py
+++ b/src/bindings/python/flux/resource/ResourceSet.py
@@ -16,6 +16,7 @@ from flux.resource import Rlist
 from flux.resource.ResourceSetImplementation import ResourceSetImplementation
 
 
+# pylint: disable=too-many-public-methods
 class ResourceSet:
     def __init__(self, arg=None, version=1):
         """
@@ -150,6 +151,12 @@ class ResourceSet:
         self.impl.set_property(name, ranks)
         return self
 
+    def get_properties(self):
+        """
+        Return an RFC 20 properties object for this ResourceSet
+        """
+        return self.impl.get_properties()
+
     def remove_ranks(self, ranks):
         """
         Remove the rank or ranks specified from the ResourceSet
@@ -220,3 +227,7 @@ class ResourceSet:
     @property
     def rlist(self):
         return self.impl.dumps()
+
+    @property
+    def properties(self):
+        return ",".join(json.loads(self.get_properties()).keys())

--- a/src/bindings/python/flux/resource/ResourceSet.py
+++ b/src/bindings/python/flux/resource/ResourceSet.py
@@ -160,6 +160,22 @@ class ResourceSet:
         self.impl.remove_ranks(ranks)
         return self
 
+    def copy_ranks(self, ranks):
+        """
+        Copy only the rank or ranks specified from the ResourceSet
+
+        :param ranks: A flux.idset.IDset object, or number or string which
+                      can be converted into an IDset, containing the ranks
+                      to copy
+        """
+        if not isinstance(ranks, IDset):
+            ranks = IDset(str(ranks))
+        rset = ResourceSet(self.impl.copy_ranks(ranks))
+
+        #  Preserve current state
+        rset.state = self.state
+        return rset
+
     @property
     def nodelist(self):
         """

--- a/src/bindings/python/flux/resource/ResourceSetImplementation.py
+++ b/src/bindings/python/flux/resource/ResourceSetImplementation.py
@@ -38,6 +38,11 @@ class ResourceSetImplementation(ABC):  # pragma: no cover
         raise NotImplementedError
 
     @abstractmethod
+    def get_properties(self):
+        """Return an RFC 20 properties object for this resource set"""
+        raise NotImplementedError
+
+    @abstractmethod
     def nnodes(self):
         """Return the number of nodes in the resource set as an IDset"""
         raise NotImplementedError

--- a/src/bindings/python/flux/resource/ResourceSetImplementation.py
+++ b/src/bindings/python/flux/resource/ResourceSetImplementation.py
@@ -53,6 +53,10 @@ class ResourceSetImplementation(ABC):  # pragma: no cover
         raise NotImplementedError
 
     @abstractmethod
+    def copy_ranks(self, ranks):
+        """Return a copy of resource set with only 'ranks' included"""
+
+    @abstractmethod
     def union(self, rset):
         """Return the union of two resource sets"""
         raise NotImplementedError

--- a/src/bindings/python/flux/resource/Rlist.py
+++ b/src/bindings/python/flux/resource/Rlist.py
@@ -107,6 +107,9 @@ class Rlist(WrapperPimpl):
         self.pimpl.remove_ranks(ranks)
         return self
 
+    def copy_ranks(self, ranks):
+        return Rlist(handle=self.pimpl.copy_ranks(ranks))
+
     def add_child(self, rank, name, ids):
         self.pimpl.rank_add_child(rank, name, ids)
         return self

--- a/src/bindings/python/flux/resource/Rlist.py
+++ b/src/bindings/python/flux/resource/Rlist.py
@@ -64,6 +64,12 @@ class Rlist(WrapperPimpl):
     def nodelist(self):
         return Hostlist(handle=self.pimpl.nodelist())
 
+    def get_properties(self):
+        val = lib.rlist_properties_encode(self.handle)
+        result = ffi.string(val).decode("utf-8")
+        lib.free(val)
+        return result
+
     def ranks(self, hosts=None):
         if hosts is None:
             return IDset(handle=self.pimpl.ranks())

--- a/src/common/librlist/rlist.c
+++ b/src/common/librlist/rlist.c
@@ -1595,6 +1595,20 @@ out:
     return rc;
 }
 
+char *rlist_properties_encode (struct rlist *rl)
+{
+    char *result = NULL;
+    json_t *o = NULL;
+
+    if (rlist_json_properties (rl, &o) < 0)
+        return NULL;
+    if (o == NULL)
+        return (strdup ("{}"));
+    result = json_dumps (o, 0);
+    json_decref (o);
+    return result;
+}
+
 json_t *rlist_to_R (struct rlist *rl)
 {
     json_t *R = NULL;

--- a/src/common/librlist/rlist.c
+++ b/src/common/librlist/rlist.c
@@ -1539,13 +1539,18 @@ error:
     return NULL;
 }
 
-int rlist_json_properties (struct rlist *rl, json_t **result)
+static int rlist_json_properties (struct rlist *rl, json_t **result)
 {
     int saved_errno;
     int rc = -1;
     zhashx_t *properties = NULL;;
     json_t *o = NULL;
     struct idset *ids;
+
+    if (!rl || !result) {
+        errno = EINVAL;
+        return -1;
+    }
 
     if (!(properties = rlist_properties (rl)))
         return -1;

--- a/src/common/librlist/rlist.h
+++ b/src/common/librlist/rlist.h
@@ -275,4 +275,9 @@ int rlist_assign_properties (struct rlist *rl,
                              json_t *properties,
                              flux_error_t *errp);
 
+/*  Encode properties to a JSON string which conforms to RFC 20 properties
+ *   specification. Caller must free.
+ */
+char *rlist_properties_encode (struct rlist *rl);
+
 #endif /* !HAVE_SCHED_RLIST_H */

--- a/t/flux-resource/list/fluxion.expected
+++ b/t/flux-resource/list/fluxion.expected
@@ -1,4 +1,4 @@
-     STATE NNODES   NCORES    NGPUS
-      free      3        8        0
- allocated      2        4        0
-      down      1        4        0
+     STATE PROPERTIES NNODES   NCORES    NGPUS
+      free                 3        8        0
+ allocated                 2        4        0
+      down                 1        4        0

--- a/t/flux-resource/list/missing.expected
+++ b/t/flux-resource/list/missing.expected
@@ -1,4 +1,4 @@
-     STATE NNODES   NCORES    NGPUS
-      free      4       16        0
- allocated      0        0        0
-      down      0        0        0
+     STATE PROPERTIES NNODES   NCORES    NGPUS
+      free                 4       16        0
+ allocated                 0        0        0
+      down                 0        0        0

--- a/t/flux-resource/list/normal-input.expected
+++ b/t/flux-resource/list/normal-input.expected
@@ -1,4 +1,4 @@
-     STATE NNODES   NCORES    NGPUS
-      free      4       16        0
- allocated      0        0        0
-      down      0        0        0
+     STATE PROPERTIES NNODES   NCORES    NGPUS
+      free                 4       16        0
+ allocated                 0        0        0
+      down                 0        0        0

--- a/t/flux-resource/list/null.expected
+++ b/t/flux-resource/list/null.expected
@@ -1,4 +1,4 @@
-     STATE NNODES   NCORES    NGPUS
-      free      4       16        0
- allocated      0        0        0
-      down      0        0        0
+     STATE PROPERTIES NNODES   NCORES    NGPUS
+      free                 4       16        0
+ allocated                 0        0        0
+      down                 0        0        0

--- a/t/t2350-resource-list.t
+++ b/t/t2350-resource-list.t
@@ -8,7 +8,7 @@ test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
 
 # Use a static format to avoid breaking output if default flux-resource list
 #  format ever changes
-FORMAT="{state:>10} {nnodes:>6} {ncores:>8} {ngpus:>8}"
+FORMAT="{state:>10} {properties:<10} {nnodes:>6} {ncores:>8} {ngpus:>8}"
 
 for input in ${SHARNESS_TEST_SRCDIR}/flux-resource/list/*.json; do
     name=$(basename ${input%%.json})
@@ -23,4 +23,76 @@ for input in ${SHARNESS_TEST_SRCDIR}/flux-resource/list/*.json; do
     '
 done
 
+test_expect_success 'flux resource list -no {properties} works' '
+	flux resource list -no {properties} \
+		--from-stdin <<-EOF >properties.out &&
+	{
+	  "all": {
+	    "version": 1,
+	    "execution": {
+	      "R_lite": [
+	        {
+	          "rank": "0-3",
+	          "children": {
+	            "core": "0-3"
+	          }
+	        }
+	      ],
+	      "starttime": 0,
+	      "expiration": 0,
+	      "nodelist": [
+	        "asp,asp,asp,asp"
+	      ],
+	      "properties": {
+	        "foo": "2-3",
+	        "xx": "1-2"
+	      }
+	    }
+	  },
+	  "allocated": {
+	    "version": 1,
+	    "execution": {
+	      "R_lite": [
+	        {
+	          "rank": "1",
+	          "children": {
+	            "core": "0"
+	          }
+	        }
+	      ],
+	      "starttime": 0,
+	      "expiration": 0,
+	      "nodelist": [
+	        "asp"
+	      ],
+	      "properties": {
+	        "xx": "1"
+	      }
+	    }
+	  },
+	  "down": {
+	    "version": 1,
+	    "execution": {
+	      "R_lite": [
+	        {
+	          "rank": "1",
+	          "children": {
+	            "core": "0-3"
+	          }
+	        }
+	      ],
+	      "starttime": 0,
+	      "expiration": 0,
+	      "nodelist": [
+	        "asp"
+	      ],
+	      "properties": {
+	        "xx": "1"
+	      }
+	    }
+	  }
+	}
+	EOF
+	test $(cat properties.out) = "foo,xx"
+'
 test_done


### PR DESCRIPTION
It occurred to me that while we added support for execution target properties in #4236, there was no way to actually query what properties were available from the current instance.

This PR adds some missing calls to the librlist API to make this possible, adds similar methods to the Python `ResourceSet` class, and and finally makes a `{properties}` field available from `flux resource list`. This field is now displayed by default if any properties exist in the current instance:

```console
$ flux resource list
     STATE PROPERTIES NNODES   NCORES    NGPUS NODELIST
      free                 1        4        0 asp
      free xx              1        4        0 asp
      free foo,xx          1        3        0 asp
      free foo             1        4        0 asp
 allocated foo,xx          1        1        0 asp
      down                 0        0        0 
```

The list of all properties available can easily be reported with `flux resource list -s all -no {properties}`:
```console
$ flux resource list -s all -no {properties}
foo,xx
```

This required a small rework of how `flux-resource list` collects similar lines together, which is explained in the commit message.

