### PR TITLE
broker: emit error when running interactive shell without tty

### DIFF
--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -661,6 +661,11 @@ static void set_proctitle (uint32_t rank)
 static int create_runat_rc2 (struct runat *r, const char *argz, size_t argz_len)
 {
     if (argz == NULL) { // run interactive shell
+        /*  Check if stdin is a tty and error out if not to avoid
+         *   confusing users with what appears to be a hang.
+         */
+        if (!isatty (STDIN_FILENO))
+            log_msg_exit ("stdin is not a tty - can't run interactive shell");
         if (runat_push_shell (r, "rc2") < 0)
             return -1;
     }

--- a/t/scripts/runpty.py
+++ b/t/scripts/runpty.py
@@ -218,6 +218,13 @@ def main():
     # Avoid asyncio DEBUG log messages (why is this on by default??)
     logging.getLogger("asyncio").setLevel(logging.WARNING)
 
+    sys.stdout = open(
+        sys.stdout.fileno(), "w", encoding="utf8", errors="surrogateescape"
+    )
+    sys.stderr = open(
+        sys.stderr.fileno(), "w", encoding="utf8", errors="surrogateescape"
+    )
+
     args = parse_args()
     if args.no_output and args.output != "-":
         log.error("Do not specify --no-output and --output")

--- a/t/scripts/runpty.py
+++ b/t/scripts/runpty.py
@@ -126,7 +126,8 @@ def parse_args():
     parser.add_argument(
         "-i",
         "--input",
-        help="set an input file in asciicast format",
+        help="set an input file in asciicast format. "
+        + "Use the special value 'none' to close stdin of pty immediately.",
     )
     parser.add_argument("--stderr", help="redirect stderr of process")
     parser.add_argument(
@@ -262,7 +263,23 @@ def main():
 
         loop = asyncio.get_event_loop()
 
-        if args.input:
+        if args.input and args.input == "none":
+
+            def write_eof(fd):
+                os.write(fd, bytes([termios.CEOF]))
+
+            #  Sometimes the shell (if that is the target of runpty)
+            #   does not read EOF if it is sent too soon. Therefore send
+            #   EOF control character now, then 3 extra times to ensure it is
+            #   read eventually.
+            #
+            write_eof(fd)
+            loop.call_later(0.1, write_eof, fd)
+            loop.call_later(0.5, write_eof, fd)
+            loop.call_later(1.0, write_eof, fd)
+            loop.call_later(15, write_eof, fd)
+
+        elif args.input:
 
             def write_tty(s):
                 os.write(fd, s.encode("utf-8"))

--- a/t/t0014-runlevel.t
+++ b/t/t0014-runlevel.t
@@ -30,9 +30,11 @@ test_expect_success 'rc1 bad path handled same as failure' '
 '
 
 test_expect_success 'default initial program is $SHELL' '
-	SHELL=/bin/sh flux start -o,-Slog-stderr-level=6 \
+	run_timeout --env=SHELL=/bin/sh 15 \
+		flux $SHARNESS_TEST_SRCDIR/scripts/runpty.py -i none \
+		flux start -o,-Slog-stderr-level=6 \
 		-o,-Sbroker.rc1_path=,-Sbroker.rc3_path= \
-		</dev/null 2>shell.log &&
+		>shell.log &&
 	grep "rc2.0: /bin/sh Exited" shell.log
 '
 

--- a/t/t0014-runlevel.t
+++ b/t/t0014-runlevel.t
@@ -3,6 +3,8 @@
 
 test_description='Verify rc scripts excute with proper semantics
 '
+# Append --logfile option if FLUX_TESTS_LOGFILE is set in environment:
+test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile --debug
 
 . `dirname $0`/sharness.sh
 

--- a/t/t0014-runlevel.t
+++ b/t/t0014-runlevel.t
@@ -40,6 +40,14 @@ test_expect_success 'default initial program is $SHELL' '
 	grep "rc2.0: /bin/sh Exited" shell.log
 '
 
+test_expect_success 'rc2 failure if stdin not a tty' '
+	test_expect_code 1 \
+		flux start -o,-Slog-stderr-level=6 \
+		-o,-Sbroker.rc1_path=,-Sbroker.rc3_path= \
+                2>shell-notty.log &&
+	grep "not a tty" shell-notty.log
+'
+
 test_expect_success 'rc3 failure causes instance failure' '
 	test_expect_code 1 flux start \
 		-o,-Sbroker.rc3_path=/bin/false \

--- a/t/t2212-job-manager-plugins.t
+++ b/t/t2212-job-manager-plugins.t
@@ -82,7 +82,7 @@ test_expect_success 'job-manager: bad plugins config is detected' '
 	EOF
 	test_must_fail \
 	    flux mini bulksubmit -n1 --watch --log=badconf.{}.log \
-	        flux start -o,-c$(pwd)/badconf/{} ::: a b c &&
+	        flux start -o,-c$(pwd)/badconf/{} /bin/true ::: a b c &&
 	test_debug "echo a:; cat badconf.a.log" &&
 	grep "config must be an array" badconf.a.log &&
 	test_debug "echo b:; cat badconf.b.log" &&


### PR DESCRIPTION
While going through some old issues I found one that seemed easy and valuable to fix

 * #2032

This PR has the broker check for a tty on stdin when invoking an interactive shell. If there is no tty the broker exits with an error:

```console
$ flux mini run flux start                                                                              
lt-flux-broker: stdin is not a tty - can't run interactive shell               
flux-job: task(s) exited with exit code 1                                      
```

This prevents wasting time when you think an interactive job is taking a long time to start, but really you've forgotten `-o pty`/`-o pty.interactive` or the `--pty` option with `srun`.

There was a little test fallout from this one, and most of my time was actually spent trying to fix Python encoding errors in the `runpty` test script (as well as working around timing issues getting EOF to the shell in the one case that is required for testing)