### PR TITLE
WIP: job-exec/sdexec: enable resource control properties MemoryMax, MemoryHigh, AllowedCPUs, etc.

### DIFF
--- a/doc/man5/flux-config-exec.rst
+++ b/doc/man5/flux-config-exec.rst
@@ -8,13 +8,15 @@ DESCRIPTION
 
 The Flux system instance **job-exec** service requires additional
 configuration via the ``exec`` table, for example to enlist the services
-of a setuid helper to launch jobs as guests.
+of a setuid helper to launch jobs as guests.  Additional configuration
+options may exist under the ``exec.<method>`` depending on the setting
+of ``method`` below.
+
+
+EXEC KEYS
+=========
 
 The ``exec`` table may contain the following keys:
-
-
-KEYS
-====
 
 imp
    (optional) Set the path to the IMP (Independent Minister of Privilege)
@@ -35,6 +37,46 @@ method
 job-shell
    (optional) Override the compiled-in default job shell path.
 
+
+EXEC.SYSTEMD KEYS
+=================
+
+The ``exec.systemd`` table may contain the following keys.  These are only valid
+if ``method`` is set to ``systemd``.
+
+cpu_set_affinity
+
+   (optional) Set to true to set CPU affinity to only allocated cores.
+
+cpu_set_allowed
+
+   (optional) Set to true to set limit execution to only allocated cores.
+
+MemoryHigh
+
+   (optional) Set to number of bytes memory high limit should be.
+   Memory usage can go above this limit but can be throttled.  The
+   suffixes k, m, g, and t can be used for kilobytes, megabytes,
+   gigabytes, and terabytes respectively.
+
+   Optionally, a percentage of memory can also be configured via a
+   number between 0 and 100 followed by a '%' sign.
+
+   The special value "infinity" can also be specified to indicate
+   100%.
+
+MemoryMax
+
+   (optional) Set to number of bytes memory max should be.  Memory
+   cannot go above this value, otherwise an out-of-memory failure will
+   occur.  The suffixes k, m, g, and t can be used for kilobytes,
+   megabytes, gigabytes, and terabytes respectively.
+
+   Optionally, a percentage of memory can also be configured via a
+   number between 0 and 100 followed by a '%' sign.
+
+   The special value "infinity" can also be specified to indicate
+   100%.
 
 EXAMPLE
 =======

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -706,3 +706,5 @@ libc
 unbuffered
 statex
 pmix
+MemoryHigh
+MemoryMax

--- a/src/common/libsdprocess/Makefile.am
+++ b/src/common/libsdprocess/Makefile.am
@@ -18,14 +18,17 @@ libsdprocess_la_SOURCES = \
 	sdprocess.h \
 	sdprocess_private.h \
 	strv.c \
-	strv.h
+	strv.h \
+	parse.c \
+	parse.h
 
 libsdprocess_la_LIBADD = \
 	$(LIBSYSTEMD_LIBS)
 
 TESTS = \
 	test_sdprocess.t \
-	test_strv.t
+	test_strv.t \
+	test_parse.t
 
 check_PROGRAMS = \
 	$(TESTS) \
@@ -56,6 +59,11 @@ test_strv_t_SOURCES = test/strv.c
 test_strv_t_CPPFLAGS = $(test_cppflags)
 test_strv_t_LDADD = $(test_ldadd)
 test_strv_t_LDFLAGS = $(test_ldflags)
+
+test_parse_t_SOURCES = test/parse.c
+test_parse_t_CPPFLAGS = $(test_cppflags)
+test_parse_t_LDADD = $(test_ldadd)
+test_parse_t_LDFLAGS = $(test_ldflags)
 
 test_sdprocess_t_SOURCES = test/sdprocess.c
 test_sdprocess_t_CPPFLAGS = \

--- a/src/common/libsdprocess/parse.c
+++ b/src/common/libsdprocess/parse.c
@@ -1,0 +1,113 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+# include "config.h"
+#endif
+
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <limits.h>
+
+#include "parse.h"
+
+int parse_percent (const char *s, double *percent)
+{
+    double p;
+    int len;
+    char *endptr;
+
+    if (!s || !percent) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    /* infinity = 100% */
+    if (!strcasecmp (s, "infinity")) {
+        (*percent) = 1.0;
+        return 0;
+    }
+
+    len = strlen (s);
+    if (len && s[len - 1] != '%') {
+        errno = EINVAL;
+        return -1;
+    }
+
+    errno = 0;
+    p = strtod (s, &endptr);
+    if (errno != 0)
+        return -1;
+    if (endptr != &s[len -1]
+        || p < 0.0
+        || p > 100.0) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    (*percent) = (p / 100.0);
+    return 0;
+}
+
+int parse_unsigned (const char *s, uint64_t *num)
+{
+    uint64_t n;
+    char *endptr;
+
+    if (!s || !num || s[0] == '-') {
+        errno = EINVAL;
+        return -1;
+    }
+
+    errno = 0;
+    n = strtoull (s, &endptr, 0);
+    if (errno != 0)
+        return -1;
+    if (n == 0) {
+        errno = EINVAL;
+        return -1;
+    }
+    if ((*endptr) != '\0') {
+        uint64_t mult = 1;
+        if (strlen (endptr) > 1) {
+            errno = EINVAL;
+            return -1;
+        }
+        if ((*endptr) == 'k'
+            || (*endptr) == 'K')
+            mult = 1024ULL;
+        else if ((*endptr) == 'm'
+                 || (*endptr) == 'M')
+            mult = 1024ULL * 1024ULL;
+        else if ((*endptr) == 'g'
+                 || (*endptr) == 'G')
+            mult = 1024ULL * 1024ULL * 1024ULL;
+        else if ((*endptr) == 't'
+                 || (*endptr) == 'T')
+            mult = 1024ULL * 1024ULL * 1024ULL * 1024ULL;
+        else {
+            errno = EINVAL;
+            return -1;
+        }
+        if ((ULLONG_MAX / mult) < n) {
+            errno = ERANGE;
+            return -1;
+        }
+        n *= mult;
+    }
+
+    (*num) = n;
+    return 0;
+}
+
+/*
+ * vi: ts=4 sw=4 expandtab
+ */

--- a/src/common/libsdprocess/parse.h
+++ b/src/common/libsdprocess/parse.h
@@ -1,0 +1,24 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _PARSE_H
+#define _PARSE_H
+
+#include <stdint.h>
+
+/* string parsing functions */
+
+/* parse strings in format "<double>%" */
+int parse_percent (const char *s, double *percent);
+
+/* parse strings in format "<unsigned long>[k,m,g,t]" */
+int parse_unsigned (const char *s, uint64_t *num);
+
+#endif /* !_PARSE_H */

--- a/src/common/libsdprocess/sdprocess.h
+++ b/src/common/libsdprocess/sdprocess.h
@@ -59,8 +59,14 @@ typedef int (*sdprocess_list_f) (flux_t *h,
 /* Launch process under systemd
  *
  * command must be an absolute path
- * argv & envv arrays are NULL terminated
+ * argv & envv & properties arrays are NULL terminated
  * if unnecessary, set fd to < 0
+ *
+ * Current properties supported:
+ * None
+ *
+ * Properties not allowed due to internal use:
+ * - RemainAfterExit
  *
  * Setup of XDG_RUNTIME_DIR and DBUS_SESSION_BUS_ADDRESS environment
  * variables are assumed.  If not, systemd will return error.
@@ -69,6 +75,7 @@ sdprocess_t *sdprocess_exec (flux_t *h,
                              const char *unitname,
                              char **argv,
                              char **envv,
+                             char **properties,
                              int stdin_fd,
                              int stdout_fd,
                              int stderr_fd);

--- a/src/common/libsdprocess/sdprocess.h
+++ b/src/common/libsdprocess/sdprocess.h
@@ -63,7 +63,7 @@ typedef int (*sdprocess_list_f) (flux_t *h,
  * if unnecessary, set fd to < 0
  *
  * Current properties supported:
- * None
+ * - CPUAffinity=<flux idset> (N.B. input different than systemd)
  *
  * Properties not allowed due to internal use:
  * - RemainAfterExit

--- a/src/common/libsdprocess/sdprocess.h
+++ b/src/common/libsdprocess/sdprocess.h
@@ -64,6 +64,7 @@ typedef int (*sdprocess_list_f) (flux_t *h,
  *
  * Current properties supported:
  * - CPUAffinity=<flux idset> (N.B. input different than systemd)
+ * - AllowedCPUs=<flux idset> (N.B. input different than systemd)
  *
  * Properties not allowed due to internal use:
  * - RemainAfterExit

--- a/src/common/libsdprocess/sdprocess.h
+++ b/src/common/libsdprocess/sdprocess.h
@@ -65,6 +65,12 @@ typedef int (*sdprocess_list_f) (flux_t *h,
  * Current properties supported:
  * - CPUAffinity=<flux idset> (N.B. input different than systemd)
  * - AllowedCPUs=<flux idset> (N.B. input different than systemd)
+ * - MemoryHigh=<bytes> (k, m, g, t suffix allowed)
+ *   OR MemoryHigh=<percent> (double + '%')
+ *   OR MemoryHigh=infinity (same as 100%)
+ * - MemoryMax=<bytes> (k, m, g, t suffix allowed)
+ *   OR MemoryMax=<percent> (double + '%')
+ *   OR MemoryMax=infinity (same as 100%)
  *
  * Properties not allowed due to internal use:
  * - RemainAfterExit

--- a/src/common/libsdprocess/test/parse.c
+++ b/src/common/libsdprocess/test/parse.c
@@ -1,0 +1,169 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <assert.h>
+
+#include "src/common/libtap/tap.h"
+#include "src/common/libsdprocess/parse.h"
+
+#define OUTOFRANGEPERCENT \
+    "100000000000000000000000000000000" \
+    "000000000000000000000000000000000" \
+    "000000000000000000000000000000000" \
+    "000000000000000000000000000000000" \
+    "000000000000000000000000000000000" \
+    "000000000000000000000000000000000" \
+    "000000000000000000000000000000000" \
+    "000000000000000000000000000000000" \
+    "000000000000000000000000000000000" \
+    "00000000000000000000000000000000%"
+
+#define OUTOFRANGENUM "20000000000000000000"
+
+static void test_parse_percent (void)
+{
+    double percent;
+    int ret;
+
+    errno = 0;
+    ret = parse_percent (NULL, NULL);
+    ok (ret < 0 && errno == EINVAL,
+        "parse_percent fails with EINVAL on NULL inputs");
+
+    errno = 0;
+    ret = parse_percent ("", &percent);
+    ok (ret < 0 && errno == EINVAL,
+        "parse_percent fails with EINVAL on empty string");
+
+    errno = 0;
+    ret = parse_percent ("123", &percent);
+    ok (ret < 0 && errno == EINVAL,
+        "parse_percent fails with EINVAL on not a percent input");
+
+    errno = 0;
+    ret = parse_percent (OUTOFRANGEPERCENT, &percent);
+    ok (ret < 0 && errno == ERANGE,
+        "parse_percent fails with ERANGE on percent out of range");
+
+    errno = 0;
+    ret = parse_percent ("-18%", &percent);
+    ok (ret < 0 && errno == EINVAL,
+        "parse_percent fails with EINVAL on negative percent");
+
+    errno = 0;
+    ret = parse_percent ("110%", &percent);
+    ok (ret < 0 && errno == EINVAL,
+        "parse_percent fails with EINVAL on percent > 100");
+
+    ret = parse_percent ("0%", &percent);
+    ok (ret == 0 && percent == 0.0,
+        "parse_percent work with 0 percent");
+
+    ret = parse_percent ("98%", &percent);
+    ok (ret == 0 && percent == 0.98,
+        "parse_percent work with 98.0 percent");
+
+    ret = parse_percent ("100%", &percent);
+    ok (ret == 0 && percent == 1.0,
+        "parse_percent work with 100 percent");
+
+    ret = parse_percent ("infinity", &percent);
+    ok (ret == 0 && percent == 1.0,
+        "parse_percent work with infinity");
+
+    ret = parse_percent ("0.25%", &percent);
+    ok (ret == 0 && percent == 0.0025,
+        "parse_percent work with 0.25 percent");
+
+    ret = parse_percent ("50.2%", &percent);
+    ok (ret == 0 && percent == 0.502,
+        "parse_percent work with 50.2 percent");
+}
+
+static void test_parse_unsigned (void)
+{
+    uint64_t num;
+    int ret;
+
+    errno = 0;
+    ret = parse_unsigned (NULL, NULL);
+    ok (ret < 0 && errno == EINVAL,
+        "parse_unsigned fails with EINVAL on NULL inputs");
+
+    errno = 0;
+    ret = parse_unsigned (OUTOFRANGENUM, &num);
+    ok (ret < 0 && errno == ERANGE,
+        "parse_unsigned fails with ERANGE on num out of range");
+
+    errno = 0;
+    ret = parse_unsigned ("", &num);
+    ok (ret < 0 && errno == EINVAL,
+        "parse_unsigned fails with EINVAL on empty string");
+
+    errno = 0;
+    ret = parse_unsigned ("0", &num);
+    ok (ret < 0 && errno == EINVAL,
+        "parse_unsigned fails with EINVAL on zero");
+
+    errno = 0;
+    ret = parse_unsigned ("-1000", &num);
+    ok (ret < 0 && errno == EINVAL,
+        "parse_unsigned fails with EINVAL on negative num");
+
+    errno = 0;
+    ret = parse_unsigned ("1000z", &num);
+    ok (ret < 0 && errno == EINVAL,
+        "parse_unsigned fails with EINVAL on bad suffix");
+
+    errno = 0;
+    ret = parse_unsigned ("1000kk", &num);
+    ok (ret < 0 && errno == EINVAL,
+        "parse_unsigned fails with EINVAL on long suffix");
+
+    ret = parse_unsigned ("1000", &num);
+    ok (ret == 0 && num == 1000,
+        "parse_unsigned work with just num");
+
+    ret = parse_unsigned ("1000k", &num);
+    ok (ret == 0 && num == (1000ULL * 1024ULL),
+        "parse_unsigned work with k suffix");
+
+    ret = parse_unsigned ("1000M", &num);
+    ok (ret == 0 && num == (1000ULL * 1024ULL * 1024ULL),
+        "parse_unsigned work with M suffix");
+
+    ret = parse_unsigned ("1000g", &num);
+    ok (ret == 0 && num == (1000ULL * 1024ULL * 1024ULL * 1024ULL),
+        "parse_unsigned work with g suffix");
+
+    ret = parse_unsigned ("1000T", &num);
+    ok (ret == 0 && num == (1000ULL * 1024ULL * 1024ULL * 1024ULL * 1024ULL),
+        "parse_unsigned work with T suffix");
+}
+
+int main (int argc, char *argv[])
+{
+    plan (NO_PLAN);
+
+    test_parse_percent ();
+    test_parse_unsigned ();
+
+    done_testing ();
+    return 0;
+}
+
+/*
+ * vi: ts=4 sw=4 expandtab
+ */

--- a/src/common/libsdprocess/test/sdprocess.c
+++ b/src/common/libsdprocess/test/sdprocess.c
@@ -17,6 +17,7 @@
 #include <sys/socket.h>
 #include <unistd.h>
 #include <time.h>
+#include <sched.h>
 
 #include "src/common/libtap/tap.h"
 #include "src/common/libsdprocess/sdprocess.h"
@@ -1716,6 +1717,192 @@ static void test_cleanup_failure_after_cleanup (flux_t *h)
     sdprocess_destroy (sdp);
 }
 
+static void test_property_CPUAffinity_cpuset (flux_t *h,
+                                              char **properties,
+                                              cpu_set_t *cpuset_expected)
+{
+    char *unitname = get_unitname (NULL);
+    char *cmdv[] = { "/bin/sleep", "60", NULL };
+    sdprocess_t *sdp = NULL;
+    bool active;
+    int pid;
+    int ret;
+    int i;
+    cpu_set_t cpuset;
+
+    sdp = sdprocess_exec (h,
+                          unitname,
+                          cmdv,
+                          NULL,
+                          properties,
+                          STDIN_FILENO,
+                          STDOUT_FILENO,
+                          STDERR_FILENO);
+    ok (sdp != NULL,
+        "sdprocess_exec launched process under systemd");
+
+    active = sdprocess_active (sdp);
+    while (!active) {
+        usleep (100000);
+        active = sdprocess_active (sdp);
+    }
+    ok (active == true,
+        "sdprocess_active success");
+
+    pid = sdprocess_pid (sdp);
+    ok (pid > 0,
+        "sdprocess_pid returned pid of process");
+
+    /* systemd setup of CPU affinity can be racy aginst the following
+     * check.  loop a few times if necessary. */
+
+    ret = sched_getaffinity (pid, sizeof (cpu_set_t), &cpuset);
+    ok (ret == 0,
+        "sched_getaffinity get cpuset of process");
+
+    ret = CPU_EQUAL (&cpuset, cpuset_expected);
+
+    for (i = 0; i < 20 && ret == 0; i++) {
+        usleep (500000);
+
+        ret = sched_getaffinity (pid, sizeof (cpu_set_t), &cpuset);
+        ok (ret == 0,
+            "sched_getaffinity get cpuset of process");
+
+        ret = CPU_EQUAL (&cpuset, cpuset_expected);
+    }
+
+    ok (ret != 0,
+        "CPU Affinity of process set correctly");
+
+    sdprocess_kill_wrap (sdp, SIGKILL);
+
+    ret = sdprocess_wait (sdp);
+    ok (ret == 0,
+        "sdprocess_wait success");
+
+    sdprocess_systemd_cleanup_wrap (sdp);
+
+    free (unitname);
+    sdprocess_destroy (sdp);
+}
+
+static void test_property_CPUAffinity_cpu_count1 (flux_t *h,
+                                                  cpu_set_t *cpuset_avail)
+{
+    char *affinitystr = NULL;
+    char **properties = NULL;
+    cpu_set_t cpuset_expected;
+    int cpuid;
+    int i = 0;
+
+    while (1) {
+        if (CPU_ISSET (i, cpuset_avail) > 0) {
+            cpuid = i;
+            break;
+        }
+        i++;
+    }
+
+    CPU_ZERO (&cpuset_expected);
+    CPU_SET (cpuid, &cpuset_expected);
+
+    if (asprintf (&affinitystr, "CPUAffinity=%d", cpuid) < 0)
+        BAIL_OUT ("asprintf");
+
+    if (!(properties = strv_create (affinitystr, " ")))
+        BAIL_OUT ("strv_create");
+
+    diag ("testing %s", affinitystr);
+    test_property_CPUAffinity_cpuset (h, properties, &cpuset_expected);
+
+    strv_destroy (properties);
+    free (affinitystr);
+}
+
+static void test_property_CPUAffinity_cpu_count2 (flux_t *h,
+                                                  cpu_set_t *cpuset_avail)
+{
+    char *affinitystr = NULL;
+    char **properties = NULL;
+    cpu_set_t cpuset_expected;
+    int cpuid1 = -1;
+    int cpuid2 = -1;
+    int i = 0;
+
+    while (1) {
+        if (CPU_ISSET (i, cpuset_avail) > 0) {
+            if (cpuid1 == -1)
+                cpuid1 = i;
+            else {
+                cpuid2 = i;
+                break;
+            }
+        }
+        i++;
+    }
+
+    CPU_ZERO (&cpuset_expected);
+    CPU_SET (cpuid1, &cpuset_expected);
+    CPU_SET (cpuid2, &cpuset_expected);
+
+    /* Using comma style i.e, 0,1 */
+    if (asprintf (&affinitystr, "CPUAffinity=%d,%d", cpuid1, cpuid2) < 0)
+        BAIL_OUT ("asprintf");
+
+    if (!(properties = strv_create (affinitystr, " ")))
+        BAIL_OUT ("strv_create");
+
+    test_property_CPUAffinity_cpuset (h, properties, &cpuset_expected);
+
+    strv_destroy (properties);
+    free (affinitystr);
+
+    if ((cpuid2 - cpuid1) > 1)
+        return;
+
+    /* Using bracket range style i.e, [0-1] */
+    if (asprintf (&affinitystr, "CPUAffinity=[%d-%d]", cpuid1, cpuid2) < 0)
+        BAIL_OUT ("asprintf");
+
+    if (!(properties = strv_create (affinitystr, " ")))
+        BAIL_OUT ("strv_create");
+
+    test_property_CPUAffinity_cpuset (h, properties, &cpuset_expected);
+
+    strv_destroy (properties);
+    free (affinitystr);
+}
+
+/* N.B. We only test CPUAffinity property and not any other
+ * properties, predominantly b/c this is the only "easy" one to test
+ * in C code due to the ability to use sched_getaffinity().  Remaining
+ * properties would involve digging into, reading, and parsing various
+ * files in /sys/fs/cgroup.
+ *
+ * Sharness tests should handle testing other properaties.
+ */
+
+static void test_property_CPUAffinity (flux_t *h)
+{
+    cpu_set_t cpuset_avail;
+    int count;
+    if (sched_getaffinity (0, sizeof (cpu_set_t), &cpuset_avail) < 0)
+        BAIL_OUT ("sched_getaffinity");
+
+    count = CPU_COUNT (&cpuset_avail);
+
+    if (!count)
+        BAIL_OUT ("CPU_COUNT says no cpus available?");
+
+    test_property_CPUAffinity_cpu_count1 (h, &cpuset_avail);
+
+    if (count == 1)
+        return;
+
+    test_property_CPUAffinity_cpu_count2 (h, &cpuset_avail);
+}
+
 int main (int argc, char *argv[])
 {
     flux_t *h = loopback_create (0);
@@ -1827,6 +2014,8 @@ int main (int argc, char *argv[])
     test_cleanup_success_after_cleanup (h);
     diag ("cleanup_failure_after_cleanup");
     test_cleanup_failure_after_cleanup (h);
+    diag ("property_CPUAffinity");
+    test_property_CPUAffinity (h);
 
     flux_close (h);
     done_testing ();

--- a/src/common/libsdprocess/test/sdprocess.c
+++ b/src/common/libsdprocess/test/sdprocess.c
@@ -87,7 +87,7 @@ static void test_corner_case (void)
     bool active, exited;
     int ret;
 
-    sdp = sdprocess_exec (NULL, NULL, NULL, NULL, -1, -1, -1);
+    sdp = sdprocess_exec (NULL, NULL, NULL, NULL, NULL, -1, -1, -1);
     ok (sdp == NULL && errno == EINVAL,
         "sdprocess_exec returns EINVAL on invalid input");
 
@@ -156,6 +156,7 @@ static void test_basic (flux_t *h,
                           unitname,
                           cmdv,
                           NULL,
+                          NULL,
                           STDIN_FILENO,
                           STDOUT_FILENO,
                           STDERR_FILENO);
@@ -202,6 +203,7 @@ static void test_unitname (flux_t *h)
                           unitname,
                           cmdv,
                           NULL,
+                          NULL,
                           STDIN_FILENO,
                           STDOUT_FILENO,
                           STDERR_FILENO);
@@ -234,6 +236,7 @@ static void test_pid (flux_t *h)
     sdp = sdprocess_exec (h,
                           unitname,
                           cmdv,
+                          NULL,
                           NULL,
                           STDIN_FILENO,
                           STDOUT_FILENO,
@@ -283,6 +286,7 @@ static void test_duplicate (flux_t *h)
                           unitname,
                           cmdv,
                           NULL,
+                          NULL,
                           STDIN_FILENO,
                           STDOUT_FILENO,
                           STDERR_FILENO);
@@ -300,6 +304,7 @@ static void test_duplicate (flux_t *h)
     sdp_dup = sdprocess_exec (h,
                               unitname,
                               cmdv,
+                              NULL,
                               NULL,
                               STDIN_FILENO,
                               STDOUT_FILENO,
@@ -319,6 +324,54 @@ static void test_duplicate (flux_t *h)
     sdprocess_destroy (sdp);
 }
 
+static void test_property_illegal (flux_t *h)
+{
+    char *unitname = get_unitname (NULL);
+    char *cmdv[] = { "/bin/true", NULL };
+    char *properties1[] = { "foobar", NULL };
+    char *properties2[] = { "foobar=1", NULL };
+    char *properties3[] = { "RemainAfterExit=1", NULL };
+    sdprocess_t *sdp = NULL;
+
+    sdp = sdprocess_exec (h,
+                          unitname,
+                          cmdv,
+                          NULL,
+                          properties1,
+                          STDIN_FILENO,
+                          STDOUT_FILENO,
+                          STDERR_FILENO);
+    ok (sdp == NULL
+        && errno == EINVAL,
+        "sdprocess_exec failed with EINVAL on property name without value");
+
+    sdp = sdprocess_exec (h,
+                          unitname,
+                          cmdv,
+                          NULL,
+                          properties2,
+                          STDIN_FILENO,
+                          STDOUT_FILENO,
+                          STDERR_FILENO);
+    ok (sdp == NULL
+        && errno == EINVAL,
+        "sdprocess_exec failed with EINVAL on illegal property name");
+
+    sdp = sdprocess_exec (h,
+                          unitname,
+                          cmdv,
+                          NULL,
+                          properties3,
+                          STDIN_FILENO,
+                          STDOUT_FILENO,
+                          STDERR_FILENO);
+    ok (sdp == NULL
+        && errno == EINVAL,
+        "sdprocess_exec failed with EINVAL on RemainAfterExit");
+
+    free (unitname);
+}
+
 static void test_active (flux_t *h)
 {
     char *unitname = get_unitname (NULL);
@@ -330,6 +383,7 @@ static void test_active (flux_t *h)
     sdp = sdprocess_exec (h,
                           unitname,
                           cmdv,
+                          NULL,
                           NULL,
                           STDIN_FILENO,
                           STDOUT_FILENO,
@@ -369,6 +423,7 @@ static void test_exited (flux_t *h)
                           unitname,
                           cmdv,
                           NULL,
+                          NULL,
                           STDIN_FILENO,
                           STDOUT_FILENO,
                           STDERR_FILENO);
@@ -405,6 +460,7 @@ static void test_exit_status (flux_t *h)
     sdp = sdprocess_exec (h,
                           unitname,
                           cmdv,
+                          NULL,
                           NULL,
                           STDIN_FILENO,
                           STDOUT_FILENO,
@@ -443,6 +499,7 @@ static void test_wait_status (flux_t *h)
                           unitname,
                           cmdv,
                           NULL,
+                          NULL,
                           STDIN_FILENO,
                           STDOUT_FILENO,
                           STDERR_FILENO);
@@ -480,6 +537,7 @@ static void test_wait (flux_t *h)
                           unitname,
                           cmdv,
                           NULL,
+                          NULL,
                           STDIN_FILENO,
                           STDOUT_FILENO,
                           STDERR_FILENO);
@@ -506,6 +564,7 @@ static void test_wait_after_exited (flux_t *h)
     sdp = sdprocess_exec (h,
                           unitname,
                           cmdv,
+                          NULL,
                           NULL,
                           STDIN_FILENO,
                           STDOUT_FILENO,
@@ -551,6 +610,7 @@ static void test_state (flux_t *h)
     sdp = sdprocess_exec (h,
                           unitname,
                           cmdv,
+                          NULL,
                           NULL,
                           STDIN_FILENO,
                           STDOUT_FILENO,
@@ -601,6 +661,7 @@ static void test_state_after_exited (flux_t *h)
                           unitname,
                           cmdv,
                           NULL,
+                          NULL,
                           STDIN_FILENO,
                           STDOUT_FILENO,
                           STDERR_FILENO);
@@ -642,6 +703,7 @@ static void test_kill (flux_t *h)
     sdp = sdprocess_exec (h,
                           unitname,
                           cmdv,
+                          NULL,
                           NULL,
                           STDIN_FILENO,
                           STDOUT_FILENO,
@@ -688,6 +750,7 @@ static void test_kill_after_exited_success (flux_t *h)
                           unitname,
                           cmdv,
                           NULL,
+                          NULL,
                           STDIN_FILENO,
                           STDOUT_FILENO,
                           STDERR_FILENO);
@@ -718,6 +781,7 @@ static void test_kill_after_exited_failure (flux_t *h)
     sdp = sdprocess_exec (h,
                           unitname,
                           cmdv,
+                          NULL,
                           NULL,
                           STDIN_FILENO,
                           STDOUT_FILENO,
@@ -751,6 +815,7 @@ static void test_find_unit (flux_t *h)
     sdp = sdprocess_exec (h,
                           unitname,
                           cmdv,
+                          NULL,
                           NULL,
                           STDIN_FILENO,
                           STDOUT_FILENO,
@@ -807,6 +872,7 @@ static void test_find_unit_state (flux_t *h)
                           unitname,
                           cmdv,
                           NULL,
+                          NULL,
                           STDIN_FILENO,
                           STDOUT_FILENO,
                           STDERR_FILENO);
@@ -860,6 +926,7 @@ static void test_find_unit_after_exited (flux_t *h,
     sdp = sdprocess_exec (h,
                           unitname,
                           cmdv,
+                          NULL,
                           NULL,
                           STDIN_FILENO,
                           STDOUT_FILENO,
@@ -917,6 +984,7 @@ static void test_find_unit_after_signaled (flux_t *h)
     sdp = sdprocess_exec (h,
                           unitname,
                           cmdv,
+                          NULL,
                           NULL,
                           STDIN_FILENO,
                           STDOUT_FILENO,
@@ -1003,6 +1071,7 @@ static void test_output (flux_t *h,
                           unitname,
                           cmdv,
                           NULL,
+                          NULL,
                           -1,
                           do_stdout ? fds[1] : -1,
                           do_stdout ? -1 : fds[1]);
@@ -1065,6 +1134,7 @@ static void test_stdin (flux_t *h)
                           unitname,
                           cmdv,
                           NULL,
+                          NULL,
                           stdin_fds[1],
                           stdout_fds[1],
                           -1);
@@ -1125,6 +1195,7 @@ static void test_environment (flux_t *h)
                           unitname,
                           cmdv,
                           env,
+                          NULL,
                           -1,
                           fds[1],
                           -1);
@@ -1166,6 +1237,7 @@ static void test_no_such_command (flux_t *h)
     sdp = sdprocess_exec (h,
                           unitname,
                           cmdv,
+                          NULL,
                           NULL,
                           STDIN_FILENO,
                           STDOUT_FILENO,
@@ -1210,6 +1282,7 @@ static void test_list (flux_t *h)
                            unitname1,
                            cmdv,
                            NULL,
+                           NULL,
                            STDIN_FILENO,
                            STDOUT_FILENO,
                            STDERR_FILENO);
@@ -1219,6 +1292,7 @@ static void test_list (flux_t *h)
     sdp2 = sdprocess_exec (h,
                            unitname2,
                            cmdv,
+                           NULL,
                            NULL,
                            STDIN_FILENO,
                            STDOUT_FILENO,
@@ -1293,6 +1367,7 @@ static void test_list_error (flux_t *h)
                           unitname,
                           cmdv,
                           NULL,
+                          NULL,
                           STDIN_FILENO,
                           STDOUT_FILENO,
                           STDERR_FILENO);
@@ -1338,6 +1413,7 @@ static void test_list_early_exit (flux_t *h)
                            unitname1,
                            cmdv,
                            NULL,
+                           NULL,
                            STDIN_FILENO,
                            STDOUT_FILENO,
                            STDERR_FILENO);
@@ -1347,6 +1423,7 @@ static void test_list_early_exit (flux_t *h)
     sdp2 = sdprocess_exec (h,
                            unitname2,
                            cmdv,
+                           NULL,
                            NULL,
                            STDIN_FILENO,
                            STDOUT_FILENO,
@@ -1389,6 +1466,7 @@ static void test_invalid_permissions_command (flux_t *h)
     sdp = sdprocess_exec (h,
                           unitname,
                           cmdv,
+                          NULL,
                           NULL,
                           STDIN_FILENO,
                           STDOUT_FILENO,
@@ -1441,6 +1519,7 @@ static void test_cleanup_success (flux_t *h)
                           unitname,
                           cmdv,
                           NULL,
+                          NULL,
                           STDIN_FILENO,
                           STDOUT_FILENO,
                           STDERR_FILENO);
@@ -1483,6 +1562,7 @@ static void test_cleanup_failure (flux_t *h)
     sdp = sdprocess_exec (h,
                           unitname,
                           cmdv,
+                          NULL,
                           NULL,
                           STDIN_FILENO,
                           STDOUT_FILENO,
@@ -1527,6 +1607,7 @@ static void test_cleanup_before_exited (flux_t *h)
                           unitname,
                           cmdv,
                           NULL,
+                          NULL,
                           STDIN_FILENO,
                           STDOUT_FILENO,
                           STDERR_FILENO);
@@ -1568,6 +1649,7 @@ static void test_cleanup_success_after_cleanup (flux_t *h)
                           unitname,
                           cmdv,
                           NULL,
+                          NULL,
                           STDIN_FILENO,
                           STDOUT_FILENO,
                           STDERR_FILENO);
@@ -1605,6 +1687,7 @@ static void test_cleanup_failure_after_cleanup (flux_t *h)
     sdp = sdprocess_exec (h,
                           unitname,
                           cmdv,
+                          NULL,
                           NULL,
                           STDIN_FILENO,
                           STDOUT_FILENO,
@@ -1680,6 +1763,8 @@ int main (int argc, char *argv[])
     test_pid (h);
     diag ("duplicate");
     test_duplicate (h);
+    diag ("property_illegal");
+    test_property_illegal (h);
     diag ("active");
     test_active (h);
     diag ("exited");

--- a/src/modules/Makefile.am
+++ b/src/modules/Makefile.am
@@ -139,7 +139,8 @@ job_exec_la_LIBADD = \
 	$(top_builddir)/src/common/libsubprocess/libsubprocess.la \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la \
-	$(JANSSON_LIBS)
+	$(JANSSON_LIBS) \
+	$(HWLOC_LIBS)
 if HAVE_LIBSYSTEMD
 job_exec_la_LIBADD += \
 	$(top_builddir)/src/common/libsdprocess/libsdprocess.la

--- a/src/modules/job-exec/Makefile.am
+++ b/src/modules/job-exec/Makefile.am
@@ -10,7 +10,8 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir)/src/include \
 	-I$(top_builddir)/src/common/libflux \
 	-I$(top_builddir)/src/common/libccan \
-	$(JANSSON_CFLAGS)
+	$(JANSSON_CFLAGS) \
+	$(HWLOC_CFLAGS)
 
 noinst_LTLIBRARIES = \
 	libjob-exec.la \

--- a/src/modules/job-exec/rset.c
+++ b/src/modules/job-exec/rset.c
@@ -174,5 +174,10 @@ uint32_t resource_set_rank_index (struct resource_set *r, uint32_t rank)
     return IDSET_INVALID_ID;
 }
 
+const json_t *resource_set_R_lite (struct resource_set *r)
+{
+    return r->R_lite;
+}
+
 /* vi: ts=4 sw=4 expandtab
  */

--- a/src/modules/job-exec/rset.h
+++ b/src/modules/job-exec/rset.h
@@ -30,6 +30,8 @@ double resource_set_starttime (struct resource_set *rset);
 
 double resource_set_expiration (struct resource_set *rset);
 
+const json_t *resource_set_R_lite (struct resource_set *r);
+
 #endif /* !HAVE_JOB_EXEC_RSET_H */
 
 

--- a/src/modules/job-exec/sdexec.c
+++ b/src/modules/job-exec/sdexec.c
@@ -35,6 +35,21 @@
  * Based on the cores listed in R, set allowed CPUs in the launched
  * process via the systemd CPUAffinity property.
  *
+ * MemoryHigh = "<bytes>" (suffix k, m, g, t, allowed)
+ * Or
+ * MemoryHigh = "<percent>%"
+ *
+ * Configure high limit of memory usage.  Memory can go above this
+ * limit but can be throttled.
+ *
+ * MemoryMax = "<bytes>" (suffix k, m, g, t, allowed)
+ * Or
+ * MemoryMax = "<percent>%"
+ *
+ * Configure max memory usage.  Memory usage above this is not allowed
+ * and attempts to go above this configure will lead to a
+ * out-of-memory failure.
+ *
  * The following configurations are supported under
  * attributes.system.exec.sd in the jobspec.
  *
@@ -388,15 +403,19 @@ static int sdexec_setup_properties (struct sdexec *se, struct jobinfo *job)
     flux_error_t err;
     int cpu_set_affinity = 0;
     int cpu_set_allowed = 0;
+    const char *MemoryHigh = NULL;
+    const char *MemoryMax = NULL;
     int properties_len = 0;
     int index = 0;
 
     if (flux_conf_unpack (flux_get_conf (se->h),
                           &err,
-                          "{s?:{s?:{s?b s?b}}}",
+                          "{s?:{s?:{s?b s?b s?s s?s}}}",
                           "exec", "systemd",
                             "cpu_set_affinity", &cpu_set_affinity,
-                            "cpu_set_allowed", &cpu_set_allowed) < 0) {
+                            "cpu_set_allowed", &cpu_set_allowed,
+                            "MemoryHigh", &MemoryHigh,
+                            "MemoryMax", &MemoryMax) < 0) {
         flux_log (se->h, LOG_ERR,
                   "error reading systemd config: %s",
                   err.text);
@@ -406,6 +425,10 @@ static int sdexec_setup_properties (struct sdexec *se, struct jobinfo *job)
     if (cpu_set_affinity)
         properties_len++;
     if (cpu_set_allowed)
+        properties_len++;
+    if (MemoryHigh)
+        properties_len++;
+    if (MemoryMax)
         properties_len++;
 
     if (!properties_len) {
@@ -425,6 +448,14 @@ static int sdexec_setup_properties (struct sdexec *se, struct jobinfo *job)
     }
     if (cpu_set_allowed) {
         if (!(properties[index++] = sdexec_cpuset (job, "AllowedCPUs")))
+            goto error;
+    }
+    if (MemoryHigh) {
+        if (asprintf (&properties[index++], "MemoryHigh=%s", MemoryHigh) < 0)
+            goto error;
+    }
+    if (MemoryMax) {
+        if (asprintf (&properties[index++], "MemoryMax=%s", MemoryMax) < 0)
             goto error;
     }
 

--- a/src/modules/job-exec/sdexec.c
+++ b/src/modules/job-exec/sdexec.c
@@ -505,6 +505,7 @@ static int sdexec_launch (struct sdexec *se,
                                     unitname,
                                     cmdv,
                                     envv,
+                                    NULL,
                                     se->stdin_fds[1],
                                     se->stdout_fds[1],
                                     se->stderr_fds[1]))) {

--- a/src/modules/job-exec/sdexec.c
+++ b/src/modules/job-exec/sdexec.c
@@ -23,6 +23,13 @@
  * [exec]
  * method = systemd
  *
+ * Other configuration options available under [exec.systemd]:
+ *
+ * cpu_set_affinity = true
+ *
+ * Based on the cores listed in R, set CPU affinity in the launched
+ * process via the systemd CPUAffinity property.
+ *
  * The following configurations are supported under
  * attributes.system.exec.sd in the jobspec.
  *
@@ -51,6 +58,7 @@
 #include <sys/socket.h>
 #include <unistd.h>
 #include <jansson.h>
+#include <hwloc.h>
 #include <assert.h>
 
 #include "src/common/libsdprocess/sdprocess.h"
@@ -69,6 +77,7 @@ struct sdexec
     flux_t *h;
     struct jobinfo *job;
     flux_cmd_t *cmd;
+    char **properties;
 
     int start_errno;
     int test_exec_fail;
@@ -91,6 +100,18 @@ static int sdexec_config (flux_t *h, int argc, char **argv)
     return config_init (h, argc, argv);
 }
 
+static void strv_destroy (char **strv)
+{
+    if (strv) {
+        char **ptr = strv;
+        while (*ptr) {
+            free (*ptr);
+            ptr++;
+        }
+        free (strv);
+    }
+}
+
 static void sdexec_destroy (void *data)
 {
     struct sdexec *se = data;
@@ -103,6 +124,7 @@ static void sdexec_destroy (void *data)
             sdprocess_destroy (se->sdp);
         }
         flux_cmd_destroy (se->cmd);
+        strv_destroy (se->properties);
         close (se->stdin_fds[0]);
         close (se->stdin_fds[1]);
         close (se->stdout_fds[0]);
@@ -190,6 +212,213 @@ static void set_stdlog (struct sdexec *se,
     }
 }
 
+static int rank_in_idset (const char *idset_str,
+                          uint32_t rank,
+                          bool *in_idset)
+{
+    struct idset *idset = idset_decode (idset_str);
+
+    if (!idset)
+        return -1;
+
+    (*in_idset) = idset_test (idset, rank);
+    idset_destroy (idset);
+    return 0;
+}
+
+static char *hwloc_cpuset_2_systemd_property (hwloc_cpuset_t set)
+{
+    char *str = NULL;
+    size_t str_index = 0;
+    size_t str_len = 0;
+    int i;
+
+    /* N.B. It is assumed hwloc bitmap will always returns id in
+     * increasing numerical order */
+
+    i = hwloc_bitmap_first (set);
+    while (i >= 0) {
+        int len;
+        /* max printed int is 10 chars + comma = 11, we'll realloc if
+         * we're ever below 16 bytes left */
+        if ((str_len - str_index) < 16) {
+            str_len += 256;
+            if (!(str = realloc (str, str_len)))
+                goto error;
+        }
+        len = snprintf (str + str_index,
+                        str_len - str_index,
+                        "%s%d",
+                        str_index ? "," : "CPUAffinity=",
+                        i);
+        assert (len < (str_len - str_index));
+        str_index += len;
+        i = hwloc_bitmap_next (set, i);
+    }
+
+    return str;
+
+error:
+    free (str);
+    return NULL;
+}
+
+static char *CPUAffinity_list (struct jobinfo *job,
+                               const char *cores)
+{
+    hwloc_topology_t topo = NULL;
+    hwloc_cpuset_t coreset = NULL;
+    hwloc_cpuset_t puset = NULL;
+    int depth;
+    int i;
+    char *rv = NULL;
+
+    if (hwloc_topology_init (&topo) < 0
+        || hwloc_topology_load (topo) < 0) {
+        flux_log_error (job->h, "hwloc topology setup");
+        goto error;
+    }
+
+    depth = hwloc_get_type_depth (topo, HWLOC_OBJ_CORE);
+    if (depth == HWLOC_TYPE_DEPTH_UNKNOWN
+        || depth == HWLOC_TYPE_DEPTH_MULTIPLE) {
+        flux_log_error (job->h, "invalid depth returned");
+        goto error;
+    }
+
+    if (!(coreset = hwloc_bitmap_alloc ())
+        || !(puset = hwloc_bitmap_alloc ())) {
+        flux_log_error (job->h, "hwloc_bitmap_alloc");
+        goto error;
+    }
+
+    if (hwloc_bitmap_list_sscanf (coreset, cores) < 0) {
+        flux_log_error (job->h, "hwloc_bitmap_list_sscanf");
+        goto error;
+    }
+
+    /* A core may be hyperthreaded, so we have to figure out all
+     * processor units that need to be "affinitied" */
+
+    i = hwloc_bitmap_first (coreset);
+    while (i >= 0) {
+        hwloc_obj_t core;
+        if (!(core = hwloc_get_obj_by_depth (topo, depth, i))) {
+            flux_log_error (job->h, "hwloc_get_obj_by_depth");
+            goto error;
+        }
+        if (!core->cpuset) {
+            flux_log_error (job->h, "hwloc obj invalid");
+            goto error;
+        }
+        hwloc_bitmap_or (puset, puset, core->cpuset);
+        i = hwloc_bitmap_next (coreset, i);
+    }
+
+    rv = hwloc_cpuset_2_systemd_property (puset);
+error:
+    if (topo)
+        hwloc_topology_destroy (topo);
+    if (coreset)
+        hwloc_bitmap_free (coreset);
+    if (puset)
+        hwloc_bitmap_free (puset);
+    return rv;
+}
+
+static char *sdexec_CPUAffinity (struct jobinfo *job)
+{
+    const json_t *R_lite;
+    json_t *entry;
+    uint32_t myrank;
+    size_t index;
+    const char *cores = NULL;
+
+    if (!(R_lite = resource_set_R_lite (job->R)))
+        return NULL;
+
+    if (flux_get_rank (job->h, &myrank) < 0) {
+        flux_log_error (job->h, "flux_get_rank");
+        return NULL;
+    }
+
+    json_array_foreach (R_lite, index, entry) {
+        const char *ranks;
+        bool in_ranks;
+        if (json_unpack_ex (entry, NULL, 0, "{s:s}", "rank", &ranks) < 0)
+            return NULL;
+        if (rank_in_idset (ranks, myrank, &in_ranks) < 0)
+            return NULL;
+        if (in_ranks) {
+            if (json_unpack_ex (entry,
+                                NULL,
+                                0,
+                                "{s:{s:s}}",
+                                "children",
+                                "core",
+                                &cores) < 0) {
+                flux_log_error (job->h, "cannot get rank cores");
+                return NULL;
+            }
+            break;
+        }
+    }
+    if (!cores) {
+        flux_log (job->h, LOG_ERR, "cores for rank %u not found in R", myrank);
+        return NULL;
+    }
+    return CPUAffinity_list (job, cores);
+}
+
+static int sdexec_setup_properties (struct sdexec *se, struct jobinfo *job)
+{
+    /* currently supported properties
+     * - CPUAffinity
+     */
+    char **properties = NULL;
+    flux_error_t err;
+    int cpu_set_affinity = 0;
+    int properties_len = 0;
+    int index = 0;
+
+    if (flux_conf_unpack (flux_get_conf (se->h),
+                          &err,
+                          "{s?:{s?:{s?b}}}",
+                          "exec", "systemd",
+                            "cpu_set_affinity", &cpu_set_affinity) < 0) {
+        flux_log (se->h, LOG_ERR,
+                  "error reading systemd config: %s",
+                  err.text);
+        return -1;
+    }
+
+    if (cpu_set_affinity)
+        properties_len++;
+
+    if (!properties_len) {
+        se->properties = NULL;
+        return 0;
+    }
+
+    /* +1 for NULL terminator */
+    properties_len++;
+
+    if (!(properties = calloc (properties_len, sizeof (char *))))
+        return -1;
+
+    if (cpu_set_affinity) {
+        if (!(properties[index++] = sdexec_CPUAffinity (job)))
+            goto error;
+    }
+
+    se->properties = properties;
+    return 0;
+
+error:
+    strv_destroy (properties);
+    return -1;
+}
+
 static struct sdexec *sdexec_create (flux_t *h,
                                      struct jobinfo *job,
                                      const char *job_shell)
@@ -254,6 +483,9 @@ static struct sdexec *sdexec_create (flux_t *h,
         flux_log_error (job->h, "flux_cmd_setenvf");
         goto cleanup;
     }
+
+    if (sdexec_setup_properties (se, job) < 0)
+        goto cleanup;
 
     se->stdoutlog = SDEXEC_LOG_EVENTLOG;
     se->stderrlog = SDEXEC_LOG_EVENTLOG;
@@ -505,7 +737,7 @@ static int sdexec_launch (struct sdexec *se,
                                     unitname,
                                     cmdv,
                                     envv,
-                                    NULL,
+                                    se->properties,
                                     se->stdin_fds[1],
                                     se->stdout_fds[1],
                                     se->stderr_fds[1]))) {

--- a/src/modules/job-exec/test/rset.c
+++ b/src/modules/job-exec/test/rset.c
@@ -162,6 +162,7 @@ int main (int ac, char *av[])
                 const struct idset *ids = resource_set_ranks (r);
                 double starttime = resource_set_starttime (r);
                 double expiration = resource_set_expiration (r);
+                const json_t *R_lite = resource_set_R_lite (r);
                 if (ids == NULL)
                     fail ("%s: resource_set_ranks() failed", e->descr);
                 else {
@@ -176,6 +177,8 @@ int main (int ac, char *av[])
                 ok (expiration == e->expiration,
                     "%s: expect expiration %.2f (got %.2f)", e->descr,
                     e->expiration, expiration);
+                ok (R_lite != NULL,
+                    "%s: non-NULL R_lite returned", e->descr);
             }
             else {
                 fail ("%s: %d:[%s]",

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -374,6 +374,7 @@ dist_check_SCRIPTS = \
 	job-exec/dummy.sh \
 	job-exec/imp.sh \
 	job-exec/imp-fail.sh \
+	job-exec/idset2bitmask.py \
 	job-list/list-id.py \
 	job-list/list-rpc.py \
 	job-list/job-list-helper.sh \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -175,6 +175,7 @@ TESTSCRIPTS = \
 	t2404-job-exec-multiuser.t \
 	t2405-job-exec-sdexec.t \
 	t2406-job-exec-cleanup.t \
+	t2407-job-exec-sdexec-properties.t \
 	t2410-exec-systemd.t \
 	t2500-job-attach.t \
 	t2501-job-status.t \

--- a/t/job-exec/idset2bitmask.py
+++ b/t/job-exec/idset2bitmask.py
@@ -1,0 +1,26 @@
+###############################################################
+# Copyright 2022 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+# idset 2 bitmask tool
+
+import sys
+import flux.idset as idset
+
+if len(sys.argv) != 2:
+    print("Usage: idset2bitmask <idset>")
+    sys.exit(1)
+
+ids = idset.decode(sys.argv[1])
+n = 0
+for i in ids:
+    n |= 0x1 << i
+print(f"0x{n:x}")
+
+# vi: ts=4 sw=4 expandtab

--- a/t/sdprocess/sim-broker.c
+++ b/t/sdprocess/sim-broker.c
@@ -137,6 +137,7 @@ int cmd_run (optparse_t *p, int argc, char **argv)
                                 unitname,
                                 cmdv,
                                 NULL,
+                                NULL,
                                 -1,
                                 STDOUT_FILENO,
                                 STDERR_FILENO))) {
@@ -257,6 +258,7 @@ int cmd_run_wait_exit (optparse_t *p, int argc, char **argv)
     if (!(sdp = sdprocess_exec (h,
                                 unitname,
                                 cmdv,
+                                NULL,
                                 NULL,
                                 -1,
                                 STDOUT_FILENO,

--- a/t/t2407-job-exec-sdexec-properties.t
+++ b/t/t2407-job-exec-sdexec-properties.t
@@ -45,6 +45,10 @@ if echo ${delegations} | grep cpuset
 then
     test_set_prereq CPUSET
 fi
+if echo ${delegations} | grep memory
+then
+    test_set_prereq MEMORY
+fi
 
 IDSET2BITMASK="flux python ${FLUX_SOURCE_DIR}/t/job-exec/idset2bitmask.py"
 
@@ -54,6 +58,15 @@ jobid2unitname() {
     jobiddec=`flux job id --to=dec $jobid`
     rank=`flux getattr rank`
     echo "flux-sdexec-${rank}-${jobiddec}"
+}
+
+# arg1 - jobid
+get_cgrouppath() {
+    jobid=$1
+    unitname=`jobid2unitname ${jobid}`
+    cgroupsuffix=`systemctl show --property ControlGroup --user --value ${unitname}`
+    cgrouppath="/sys/fs/cgroup/${cgroupsuffix}"
+    echo $cgrouppath
 }
 
 # arg1 - jobid
@@ -68,12 +81,32 @@ get_cpuaffinity() {
 # arg1 - jobid
 get_cpusallowed() {
     jobid=$1
-    unitname=`jobid2unitname ${jobid}`
-    cgroupsuffix=`systemctl show --property ControlGroup --user --value ${unitname}`
-    cgrouppath="/sys/fs/cgroup/${cgroupsuffix}"
+    cgrouppath=`get_cgrouppath ${jobid}`
     cpuset=`cat ${cgrouppath}/cpuset.cpus`
     cpusallowed=`${IDSET2BITMASK} ${cpuset}`
     echo ${cpusallowed}
+}
+
+# arg1 - jobid
+get_memoryhigh() {
+    jobid=$1
+    cgrouppath=`get_cgrouppath ${jobid}`
+    memory=`cat ${cgrouppath}/memory.high`
+    echo ${memory}
+}
+
+# arg1 - jobid
+get_memorymax() {
+    jobid=$1
+    cgrouppath=`get_cgrouppath ${jobid}`
+    memory=`cat ${cgrouppath}/memory.max`
+    echo ${memory}
+}
+
+get_system_mem_bytes() {
+    memkb=`cat /proc/meminfo | head -n 1 | awk '{print $2}'`
+    membytes=$((memkb * 1024))
+    echo $membytes
 }
 
 # arg1 - cpu bitmask
@@ -96,6 +129,46 @@ validate_cpuset() {
         return 0
     fi
     return 1
+}
+
+# arg1 - memory read
+# arg2 - expected memory
+validate_memory() {
+    # there can be rounding errors, so we just try to make sure the
+    # memory is within 1 percent of what is expected
+    memory=$1
+    expected=$2
+    if [ "${expected}" = "infinity" ]
+    then
+        expected=`get_system_mem_bytes`
+    fi
+    expected_low=`echo "${expected} * 0.99" | bc`
+    expected_high=`echo "${expected} * 1.01" | bc`
+    if [ ${memory} -gt ${expected_low%.*} ] && [ ${memory} -lt ${expected_high%.*} ]
+    then
+        return 0
+    fi
+    return 1
+}
+
+# arg1 - memory read
+# arg2 - percent
+validate_memory_percent() {
+    memory=$1
+    percent=$2
+    membytes=`get_system_mem_bytes`
+    expected=`echo "${membytes} * ${percent}" | bc`
+    validate_memory ${memory} ${expected%.*}
+    return $?
+}
+
+# arg1 - memory read
+# arg2 - memory expected
+validate_memory_bytes() {
+    memory=$1
+    expected=$2
+    validate_memory ${memory} ${expected}
+    return $?
 }
 
 #
@@ -171,6 +244,98 @@ test_expect_success MULTICORE,CGROUP2,CPUSET 'job-exec: cpu_set_allowed (2 core)
         flux job cancel ${jobid} &&
         flux job wait-event -t 30 $jobid clean &&
         validate_cpuset ${cpusallowed} 2
+'
+#
+# MemoryHigh
+# MemoryMax
+#
+test_expect_success CGROUP2,MEMORY 'job-exec: config sdexec with memory settings (bytes)' '
+        cat >exec.toml <<EOF &&
+[exec]
+method = "systemd"
+
+[exec.systemd]
+MemoryHigh = "1048576"
+MemoryMax = "2097152"
+EOF
+        flux config reload &&
+        flux module reload job-exec
+'
+test_expect_success CGROUP2,MEMORY 'job-exec: sdexec memory settings work (bytes)' '
+        jobid=$(flux submit -n1 sleep 60) &&
+        flux job wait-event -t 30 $jobid start &&
+        memhigh=`get_memoryhigh ${jobid}` &&
+        memmax=`get_memorymax ${jobid}` &&
+        flux job cancel ${jobid} &&
+        flux job wait-event -t 30 $jobid clean &&
+        validate_memory_bytes ${memhigh} 1048576 &&
+        validate_memory_bytes ${memmax} 2097152
+'
+test_expect_success CGROUP2,MEMORY 'job-exec: config sdexec with memory settings (suffix)' '
+        cat >exec.toml <<EOF &&
+[exec]
+method = "systemd"
+
+[exec.systemd]
+MemoryHigh = "1024k"
+MemoryMax = "2m"
+EOF
+        flux config reload &&
+        flux module reload job-exec
+'
+test_expect_success CGROUP2,MEMORY 'job-exec: sdexec memory settings work (suffix)' '
+        jobid=$(flux submit -n1 sleep 60) &&
+        flux job wait-event -t 30 $jobid start &&
+        memhigh=`get_memoryhigh ${jobid}` &&
+        memmax=`get_memorymax ${jobid}` &&
+        flux job cancel ${jobid} &&
+        flux job wait-event -t 30 $jobid clean &&
+        validate_memory_bytes ${memhigh} 1048576 &&
+        validate_memory_bytes ${memmax} 2097152
+'
+test_expect_success CGROUP2,MEMORY 'job-exec: config sdexec with memory settings (percent)' '
+        cat >exec.toml <<EOF &&
+[exec]
+method = "systemd"
+
+[exec.systemd]
+MemoryHigh = "80%"
+MemoryMax = "90%"
+EOF
+        flux config reload &&
+        flux module reload job-exec
+'
+test_expect_success CGROUP2,MEMORY 'job-exec: sdexec memory settings work (percent)' '
+        jobid=$(flux submit -n1 sleep 60) &&
+        flux job wait-event -t 30 $jobid start &&
+        memhigh=`get_memoryhigh ${jobid}` &&
+        memmax=`get_memorymax ${jobid}` &&
+        flux job cancel ${jobid} &&
+        flux job wait-event -t 30 $jobid clean &&
+        validate_memory_percent ${memhigh} 0.80 &&
+        validate_memory_percent ${memmax} 0.90
+'
+test_expect_success CGROUP2,MEMORY 'job-exec: config sdexec with memory settings (infinity)' '
+        cat >exec.toml <<EOF &&
+[exec]
+method = "systemd"
+
+[exec.systemd]
+MemoryHigh = "infinity"
+MemoryMax = "infinity"
+EOF
+        flux config reload &&
+        flux module reload job-exec
+'
+test_expect_success CGROUP2,MEMORY 'job-exec: sdexec memory settings work (infinity)' '
+        jobid=$(flux submit -n1 sleep 60) &&
+        flux job wait-event -t 30 $jobid start &&
+        memhigh=`get_memoryhigh ${jobid}` &&
+        memmax=`get_memorymax ${jobid}` &&
+        flux job cancel ${jobid} &&
+        flux job wait-event -t 30 $jobid clean &&
+        validate_memory_bytes ${memhigh} "infinity" &&
+        validate_memory_bytes ${memmax} "infinity"
 '
 
 test_done

--- a/t/t2407-job-exec-sdexec-properties.t
+++ b/t/t2407-job-exec-sdexec-properties.t
@@ -1,0 +1,121 @@
+#!/bin/sh
+
+test_description='Test properties using systemd job execution service'
+
+. $(dirname $0)/sharness.sh
+
+if ! flux version | grep systemd; then
+    skip_all='flux not built with systemd'
+    test_done
+fi
+
+#  Don't run if systemd environment variables not setup
+if test -z "$DBUS_SESSION_BUS_ADDRESS" \
+     -o -z "$XDG_RUNTIME_DIR"; then
+    skip_all='DBUS_SESSION_BUS_ADDRESS and/or XDG_RUNTIME_DIR not set'
+    test_done
+fi
+
+uid=`id -u`
+userservice="user@${uid}.service"
+if ! systemctl list-units | grep ${userservice}
+then
+    skip_all='systemd user service not running'
+    test_done
+fi
+
+export FLUX_CONF_DIR=$(pwd)
+test_under_flux 1 job
+flux setattr log-stderr-level 1
+
+if ! which hwloc-bind > /dev/null; then
+    skip_all='skipping sdexec affinity tests since hwloc-bind not found'
+    test_done
+fi
+
+corecount=`hwloc-bind --get | hwloc-calc --number-of core | tail -n 1`
+test ${corecount} = 1 || test_set_prereq MULTICORE
+
+# arg1 jobid
+jobid2unitname() {
+    jobid=$1
+    jobiddec=`flux job id --to=dec $jobid`
+    rank=`flux getattr rank`
+    echo "flux-sdexec-${rank}-${jobiddec}"
+}
+
+# arg1 - jobid
+get_cpuaffinity() {
+    jobid=$1
+    unitname=`jobid2unitname ${jobid}`
+    mainpid=`systemctl show --property MainPID --user --value ${unitname}`
+    cpuaffinity=`taskset -p ${mainpid} | awk '{print $NF}'`
+    echo "0x${cpuaffinity}"
+}
+
+# arg1 - cpubind info
+# arg2 - expected number of processor units with affinity
+validate_affinity() {
+    cpubind=$1
+    expected=$2
+
+    pu_count=`echo ${cpubind} | hwloc-calc --number-of pu | tail -n 1`
+    if [ "${pu_count}" = "${expected}" ]
+    then
+        return 0
+    fi
+    # Possible pu_count > expected b/c of hyperthreading and similar
+    # effects so check core count
+    core_count=`echo ${cpubind} | hwloc-calc --number-of core | tail -n 1`
+    if [ ${pu_count} > ${core_count} ] \
+        && [ "${core_count}" = "${expected}" ]
+    then
+        return 0
+    fi
+    return 1
+}
+
+test_expect_success 'job-exec: config sdexec and cpu_set_affinity' '
+        cat >exec.toml <<EOF &&
+[exec]
+method = "systemd"
+
+[exec.systemd]
+cpu_set_affinity = true
+EOF
+        flux config reload &&
+        flux module reload job-exec
+'
+# the default flux job-shell sets CPU affinity as well, so we use a fake
+# job shell to test CPU affinity settings via systemd
+test_expect_success 'job-exec: create fake shell script' '
+        cat >sleepshell.sh <<-EOF &&
+#!/bin/bash
+echo "fake shell sleeping"
+sleep 60
+EOF
+        chmod +x sleepshell.sh
+'
+test_expect_success 'job-exec: cpu_set_affinity (1 core)' '
+        jobid=$(flux submit -n1 \
+                --setattr=system.exec.job_shell="$(pwd)/sleepshell.sh" \
+                hostname) &&
+        flux job wait-event -t 30 $jobid start &&
+        cpubind=`get_cpuaffinity ${jobid}` &&
+        flux job cancel ${jobid} &&
+        flux job wait-event -t 30 $jobid clean &&
+        validate_affinity ${cpubind} 1
+'
+test_expect_success MULTICORE 'job-exec: cpu_set_affinity (2 core)' '
+        jobid=$(flux submit -n2 \
+                --setattr=system.exec.job_shell="$(pwd)/sleepshell.sh" \
+                hostname) &&
+        flux job wait-event -t 30 $jobid start &&
+        cpubind=`get_cpuaffinity ${jobid}` &&
+        flux job cancel ${jobid} &&
+        flux job wait-event -t 30 $jobid clean &&
+        validate_affinity ${cpubind} 2
+'
+
+test_done
+

--- a/t/t2407-job-exec-sdexec-properties.t
+++ b/t/t2407-job-exec-sdexec-properties.t
@@ -35,6 +35,18 @@ fi
 
 corecount=`hwloc-bind --get | hwloc-calc --number-of core | tail -n 1`
 test ${corecount} = 1 || test_set_prereq MULTICORE
+if mount | grep cgroup2
+then
+    test_set_prereq CGROUP2
+fi
+
+delegations=`systemctl show ${userservice} | grep DelegateControllers`
+if echo ${delegations} | grep cpuset
+then
+    test_set_prereq CPUSET
+fi
+
+IDSET2BITMASK="flux python ${FLUX_SOURCE_DIR}/t/job-exec/idset2bitmask.py"
 
 # arg1 jobid
 jobid2unitname() {
@@ -53,20 +65,31 @@ get_cpuaffinity() {
     echo "0x${cpuaffinity}"
 }
 
-# arg1 - cpubind info
-# arg2 - expected number of processor units with affinity
-validate_affinity() {
-    cpubind=$1
+# arg1 - jobid
+get_cpusallowed() {
+    jobid=$1
+    unitname=`jobid2unitname ${jobid}`
+    cgroupsuffix=`systemctl show --property ControlGroup --user --value ${unitname}`
+    cgrouppath="/sys/fs/cgroup/${cgroupsuffix}"
+    cpuset=`cat ${cgrouppath}/cpuset.cpus`
+    cpusallowed=`${IDSET2BITMASK} ${cpuset}`
+    echo ${cpusallowed}
+}
+
+# arg1 - cpu bitmask
+# arg2 - expected number of processor units with bitmask
+validate_cpuset() {
+    cpubitmask=$1
     expected=$2
 
-    pu_count=`echo ${cpubind} | hwloc-calc --number-of pu | tail -n 1`
+    pu_count=`echo ${cpubitmask} | hwloc-calc --number-of pu | tail -n 1`
     if [ "${pu_count}" = "${expected}" ]
     then
         return 0
     fi
     # Possible pu_count > expected b/c of hyperthreading and similar
     # effects so check core count
-    core_count=`echo ${cpubind} | hwloc-calc --number-of core | tail -n 1`
+    core_count=`echo ${cpubitmask} | hwloc-calc --number-of core | tail -n 1`
     if [ ${pu_count} > ${core_count} ] \
         && [ "${core_count}" = "${expected}" ]
     then
@@ -75,6 +98,9 @@ validate_affinity() {
     return 1
 }
 
+#
+# CPUAffinity
+#
 test_expect_success 'job-exec: config sdexec and cpu_set_affinity' '
         cat >exec.toml <<EOF &&
 [exec]
@@ -104,7 +130,7 @@ test_expect_success 'job-exec: cpu_set_affinity (1 core)' '
         cpubind=`get_cpuaffinity ${jobid}` &&
         flux job cancel ${jobid} &&
         flux job wait-event -t 30 $jobid clean &&
-        validate_affinity ${cpubind} 1
+        validate_cpuset ${cpubind} 1
 '
 test_expect_success MULTICORE 'job-exec: cpu_set_affinity (2 core)' '
         jobid=$(flux submit -n2 \
@@ -114,7 +140,37 @@ test_expect_success MULTICORE 'job-exec: cpu_set_affinity (2 core)' '
         cpubind=`get_cpuaffinity ${jobid}` &&
         flux job cancel ${jobid} &&
         flux job wait-event -t 30 $jobid clean &&
-        validate_affinity ${cpubind} 2
+        validate_cpuset ${cpubind} 2
+'
+#
+# AllowedCPUs
+#
+test_expect_success CGROUP2,CPUSET 'job-exec: config sdexec and cpu_set_allowed' '
+        cat >exec.toml <<EOF &&
+[exec]
+method = "systemd"
+
+[exec.systemd]
+cpu_set_allowed = true
+EOF
+        flux config reload &&
+        flux module reload job-exec
+'
+test_expect_success CGROUP2,CPUSET 'job-exec: cpu_set_allowed (1 core)' '
+        jobid=$(flux submit -n1 sleep 60) &&
+        flux job wait-event -t 30 $jobid start &&
+        cpusallowed=`get_cpusallowed ${jobid}` &&
+        flux job cancel ${jobid} &&
+        flux job wait-event -t 30 $jobid clean &&
+        validate_cpuset ${cpusallowed} 1
+'
+test_expect_success MULTICORE,CGROUP2,CPUSET 'job-exec: cpu_set_allowed (2 core)' '
+        jobid=$(flux submit -n2 sleep 60) &&
+        flux job wait-event -t 30 $jobid start &&
+        cpusallowed=`get_cpusallowed ${jobid}` &&
+        flux job cancel ${jobid} &&
+        flux job wait-event -t 30 $jobid clean &&
+        validate_cpuset ${cpusallowed} 2
 '
 
 test_done


### PR DESCRIPTION
This PR adds initial support to configure systemd properties via `libsdprocess`.

Long term we will want to support many potential configurations, such as cgroups configurations or hard/soft limits.

As an initial implementation for testing, I added support for `CPUAffinity` settings and had the `sdexec` module set `CPUAffinity` for a process based on the resources given to it in R.

Note, this is built on top of #4070.

Review considerations:

- in order to convert from "cores" to "processing units", did some `hwloc` hackery, hope I did it right :-)

- the "cores" -> "processing units" calculation is done in `sdexec` instead of `libsdprocess`.  Maybe that's a bad idea.  It was done mostly b/c systemd expects the caller to do that.  So I similarly left it like that for callers of `libsdprocess`.

Other note:

I initially tried to implement `AllowedCPUs` (cpu containment), but that is only supported in RHEL8 with cgroups v2.  cgroups v1 is the default on RHEL8 and cgroups v2 is a tech preview.  Something to think about for the future and what we'd want to do.
