### PR TITLE
broker: clean up shutdown logs

### DIFF
--- a/src/broker/runat.c
+++ b/src/broker/runat.c
@@ -101,8 +101,15 @@ static char *get_cmdline (flux_cmd_t *cmd)
     char *buf = NULL;
     size_t len = 0;
     int i;
+    int start = 0;
 
-    for (i = 0; i < flux_cmd_argc (cmd); i++) {
+    /* Drop the "/bin/bash -c" from logging for brevity.
+     */
+    if (flux_cmd_argc (cmd) > 2
+        && !strcmp (flux_cmd_arg (cmd, 0), get_shell ())
+        && !strcmp (flux_cmd_arg (cmd, 1), "-c"))
+        start += 2;
+    for (i = start; i < flux_cmd_argc (cmd); i++) {
         if (argz_add (&buf, &len, flux_cmd_arg (cmd, i)) != 0) {
             free (buf);
             return NULL;

--- a/src/broker/state_machine.c
+++ b/src/broker/state_machine.c
@@ -396,7 +396,7 @@ static void process_event (struct state_machine *s, const char *event)
     }
     else {
         flux_log (s->ctx->h,
-                  LOG_INFO,
+                  LOG_DEBUG,
                   "%s: ignored in %s",
                   event,
                   statestr (s->state));

--- a/src/broker/state_machine.c
+++ b/src/broker/state_machine.c
@@ -689,21 +689,25 @@ static void broker_online_cb (flux_future_t *f, void *arg)
         || !(ids = idset_decode (members))) {
         flux_log_error (s->ctx->h, "groups.get failed");
         state_machine_post (s, "quorum-fail");
+        return;
     }
-    else {
-        idset_destroy (s->quorum.have);
-        s->quorum.have = ids;
-        if (is_subset_of (s->quorum.want, s->quorum.have)) {
-            if (s->state != STATE_RUN) {
-                state_machine_post (s, "quorum-full");
-                if (s->quorum.warned) {
-                    flux_log (s->ctx->h, LOG_ERR, "quorum reached");
-                    s->quorum.warned = false;
-                }
+
+    char *hosts = flux_hostmap_lookup (s->ctx->h, members, NULL);
+    flux_log (s->ctx->h, LOG_INFO, "online: %s (ranks %s)", hosts, members);
+    free (hosts);
+
+    idset_destroy (s->quorum.have);
+    s->quorum.have = ids;
+    if (is_subset_of (s->quorum.want, s->quorum.have)) {
+        if (s->state != STATE_RUN) {
+            state_machine_post (s, "quorum-full");
+            if (s->quorum.warned) {
+                flux_log (s->ctx->h, LOG_ERR, "quorum reached");
+                s->quorum.warned = false;
             }
         }
-        flux_future_reset (f);
     }
+    flux_future_reset (f);
 }
 
 static bool wait_respond (flux_t *h,

--- a/src/modules/sched-simple/sched.c
+++ b/src/modules/sched-simple/sched.c
@@ -662,7 +662,7 @@ static int ss_resource_update (struct simple_sched *ss, flux_future_t *f)
     }
 
     flux_rpc_get (f, &s);
-    flux_log (ss->h, LOG_INFO, "resource update: %s", s);
+    flux_log (ss->h, LOG_DEBUG, "resource update: %s", s);
 
     /* Update resource states:
      */


### PR DESCRIPTION
Some logs look more silly now that we're displaying them in the output of `flux-shutdown(1)`.  This PR cleans up a few.

Before:
```
$ sudo flux shutdown
broker.info[0]: cleanup.0: /bin/bash -c flux queue stop --quiet Exited (rc=0) 0.0s
broker.info[0]: cleanup.1: /bin/bash -c flux job cancelall --user=all --quiet -f --states RUN Exited (rc=0) 0.0s
broker.info[0]: cleanup.2: /bin/bash -c flux queue idle --quiet Exited (rc=0) 0.0s
broker.info[0]: cleanup-success: cleanup->shutdown 0.199253s
broker.info[0]: quorum-full: ignored in shutdown
broker.info[0]: quorum-full: ignored in shutdown
broker.info[0]: quorum-full: ignored in shutdown
sched-simple.info[0]: resource update: {"down":"3,5,7"}
broker.info[0]: quorum-full: ignored in shutdown
sched-simple.info[0]: resource update: {"down":"6"}
broker.info[0]: children-complete: shutdown->finalize 0.373673s
broker.info[0]: quorum-full: ignored in finalize
broker.info[0]: rc3.0: /bin/bash -c /usr/local/etc/flux/rc3 Exited (rc=0) 1.0s
broker.info[0]: rc3-success: finalize->goodbye 0.997001s
$
```
After:
```
$ sudo flux shutdown
broker.info[0]: cleanup.0: flux queue stop --quiet Exited (rc=0) 0.0s
broker.info[0]: cleanup.1: flux job cancelall --user=all --quiet -f --states RUN Exited (rc=0) 0.0s
broker.info[0]: cleanup.2: flux queue idle --quiet Exited (rc=0) 0.0s
broker.info[0]: cleanup-success: cleanup->shutdown 0.219129s
broker.info[0]: online: picl[0,2-3,5-6] (ranks 0,2-3,5-6)
broker.info[0]: online: picl[0,2-3,6] (ranks 0,2-3,6)
broker.info[0]: online: picl[0,2,6] (ranks 0,2,6)
broker.info[0]: children-complete: shutdown->finalize 0.231531s
broker.info[0]: online: picl[0,6] (ranks 0,6)
broker.info[0]: online: picl0 (ranks 0)
broker.info[0]: rc3.0: /usr/local/etc/flux/rc3 Exited (rc=0) 1.0s
broker.info[0]: rc3-success: finalize->goodbye 1.00106s
```
