### PR TITLE
broker: reject remote exec requests on rank 0

### DIFF
--- a/src/broker/overlay.h
+++ b/src/broker/overlay.h
@@ -138,6 +138,11 @@ int overlay_set_monitor_cb (struct overlay *ov,
  */
 int overlay_register_attrs (struct overlay *overlay);
 
+/* Return true if this message was routed locally, i.e. wasn't delivered
+ *  via an overlay parent or child.
+ */
+bool overlay_msg_is_local (const flux_msg_t *msg);
+
 #endif /* !_BROKER_OVERLAY_H */
 
 /*

--- a/src/broker/test/overlay.c
+++ b/src/broker/test/overlay.c
@@ -315,6 +315,9 @@ void trio (flux_t *h)
     rmsg = recvmsg_timeout (ctx[0], 5);
     ok (rmsg != NULL,
         "%s: request was received by overlay", ctx[0]->name);
+    ok (!overlay_msg_is_local (rmsg),
+        "%s: overlay_msg_is_local fails on parent from child",
+        ctx[1]->name);
     ok (flux_msg_get_topic (rmsg, &topic) == 0 && !strcmp (topic, "meep"),
         "%s: received message has expected topic", ctx[0]->name);
     ok ((sender = flux_msg_route_first (rmsg)) != NULL
@@ -336,6 +339,9 @@ void trio (flux_t *h)
     rmsg = recvmsg_timeout (ctx[1], 5);
     ok (rmsg != NULL,
         "%s: request was received by overlay", ctx[1]->name);
+    ok (!overlay_msg_is_local (rmsg),
+        "%s: overlay_msg_is_local fails on child from parent",
+        ctx[1]->name);
     ok (flux_msg_get_topic (rmsg, &topic) == 0 && !strcmp (topic, "errr"),
         "%s: request has expected topic", ctx[1]->name);
     ok ((sender = flux_msg_route_first (rmsg)) != NULL
@@ -355,6 +361,8 @@ void trio (flux_t *h)
     rmsg = recvmsg_timeout (ctx[0], 5);
     ok (rmsg != NULL,
         "%s: response was received by overlay", ctx[0]->name);
+    ok (!overlay_msg_is_local (rmsg),
+        "%s: overlay_msg_is_local returns false for response from child");
     ok (flux_msg_get_topic (rmsg, &topic) == 0 && !strcmp (topic, "m000"),
         "%s: received message has expected topic", ctx[0]->name);
     ok (flux_msg_route_count (rmsg) == 0,
@@ -373,7 +381,8 @@ void trio (flux_t *h)
         "%s: event was received by overlay", ctx[0]->name);
     ok (flux_msg_get_topic (rmsg, &topic) == 0 && !strcmp (topic, "eeek"),
         "%s: received message has expected topic", ctx[0]->name);
-
+    ok (!overlay_msg_is_local (rmsg),
+        "%s: overlay_msg_is_local returns false for event from child");
 
     /* Response 0->1
      */
@@ -640,6 +649,9 @@ void wrongness (flux_t *h)
     errno = 0;
     ok (overlay_bind (ov, "ipc://@foobar") < 0 && errno == EINVAL,
         "overlay_bind fails if called before rank is known");
+
+    ok (!overlay_msg_is_local (NULL),
+        "overlay_msg_is_local (NULL) returns false");
 
     overlay_destroy (ov);
     attr_destroy (attrs);

--- a/src/common/libsubprocess/server.c
+++ b/src/common/libsubprocess/server.c
@@ -307,6 +307,9 @@ static void server_exec_cb (flux_t *h, flux_msg_handler_t *mh,
     int on_channel_out, on_stdout, on_stderr;
     char **env = NULL;
 
+    if (s->auth_cb && (*s->auth_cb) (msg, s->arg) < 0)
+        goto error;
+
     if (flux_request_unpack (msg, NULL, "{s:s s:i s:i s:i}",
                              "cmd", &cmd_str,
                              "on_channel_out", &on_channel_out,

--- a/src/common/libsubprocess/subprocess.c
+++ b/src/common/libsubprocess/subprocess.c
@@ -295,6 +295,14 @@ error:
     return NULL;
 }
 
+void flux_subprocess_server_set_auth_cb (flux_subprocess_server_t *s,
+                                         flux_subprocess_server_auth_f fn,
+                                         void *arg)
+{
+    s->auth_cb = fn;
+    s->arg = arg;
+}
+
 void flux_subprocess_server_stop (flux_subprocess_server_t *s)
 {
     if (s && s->magic == SUBPROCESS_SERVER_MAGIC) {

--- a/src/common/libsubprocess/subprocess.h
+++ b/src/common/libsubprocess/subprocess.h
@@ -124,6 +124,19 @@ flux_subprocess_server_t *flux_subprocess_server_start (flux_t *h,
                                                         const char *local_uri,
                                                         uint32_t rank);
 
+
+typedef int (*flux_subprocess_server_auth_f) (const flux_msg_t *msg,
+                                              void *arg);
+
+/*   Register an authorization function to the subprocess server
+ *
+ *   The registered function should return 0 to allow the request to
+ *    proceed, and -1 with errno set to deny the request.
+ */
+void flux_subprocess_server_set_auth_cb (flux_subprocess_server_t *s,
+                                         flux_subprocess_server_auth_f fn,
+                                         void *arg);
+
 /*  Stop a subprocess server / cleanup flux_subprocess_server_t.  Will
  *  send a SIGKILL to all remaining subprocesses.
  */

--- a/src/common/libsubprocess/subprocess_private.h
+++ b/src/common/libsubprocess/subprocess_private.h
@@ -126,6 +126,8 @@ struct flux_subprocess_server {
     uint32_t rank;
     zhash_t *subprocesses;
     flux_msg_handler_t **handlers;
+    flux_subprocess_server_auth_f auth_cb;
+    void *arg;
 
     /* for teardown / termination */
     flux_watcher_t *terminate_timer_w;

--- a/t/t0005-exec.t
+++ b/t/t0005-exec.t
@@ -41,6 +41,10 @@ test_expect_success 'exec to all except a set of ranks' '
 	EOT
 '
 
+test_expect_success 'exec to rank 0 from another rank is an error' '
+	test_must_fail flux exec -n -r 1 flux exec -n -r 0 /bin/true
+'
+
 test_expect_success 'exec to non-existent rank is an error' '
 	test_must_fail flux exec -n -r $(invalid_rank) /bin/true
 '


### PR DESCRIPTION
This PR addresses #3202. A simple approach is taken for now: rather than offering configuration, remote subprocess exec requests to rank 0 are always rejected.

It is unlikely that use of `flux exec` or `flux_rexec()` to rank 0 from another broker is a current use case, so this approach was considered the most safe for now.
