### PR TITLE
python: allow resource count of 0 in Jobspec v1

### DIFF
--- a/src/bindings/python/flux/job/Jobspec.py
+++ b/src/bindings/python/flux/job/Jobspec.py
@@ -219,6 +219,7 @@ class Jobspec(object):
             raise ValueError("operator must be one of {}".format(valid_operator_values))
 
     @classmethod
+    # pylint: disable=too-many-branches
     def _validate_resource(cls, res):
         if not isinstance(res, abc.Mapping):
             raise TypeError("resource must be a mapping")
@@ -237,8 +238,13 @@ class Jobspec(object):
             cls._validate_complex_range(count)
         elif not isinstance(count, int):
             raise TypeError("count must be an int or mapping")
-        elif count < 1:
-            raise ValueError("count must be > 0")
+        else:
+            # node, slot, and core must have count > 0, but allow 0 for
+            # any other resource type.
+            if res["type"] in ["node", "slot", "core"] and count < 1:
+                raise ValueError("node or slot count must be > 0")
+            if count < 0:
+                raise ValueError("count must be >= 0")
 
         # validate the string keys
         for key in ["id", "unit", "label"]:

--- a/src/common/libjob/jobspec1.c
+++ b/src/common/libjob/jobspec1.c
@@ -238,6 +238,7 @@ static int slot_vertex_check (json_t *slot, flux_jobspec1_error_t *error)
         goto error;
     }
     json_array_foreach (with, index, value) {
+        int min_count = 0;
         if (json_unpack_ex (value,
                             &json_error,
                             0,
@@ -251,8 +252,10 @@ static int slot_vertex_check (json_t *slot, flux_jobspec1_error_t *error)
             errprintf (error, "slot with type must be core or gpu");
             goto error;
         }
-        if (count < 1) {
-            errprintf (error, "slot %s count must be >= 1", type);
+        if (strcmp (type, "core") == 0)
+            min_count = 1;
+        if (count < min_count) {
+            errprintf (error, "slot %s count must be >= %d", type, min_count);
             goto error;
         }
     }

--- a/src/modules/job-ingest/schemas/jobspec.jsonschema
+++ b/src/modules/job-ingest/schemas/jobspec.jsonschema
@@ -31,7 +31,7 @@
         "type": { "type": "string" },
         "count": {
           "oneOf": [
-            { "type": "integer", "minimum" : 1 },
+            { "type": "integer", "minimum" : 0 },
             { "$ref": "#/definitions/complex_range" }
           ]
         },
@@ -52,19 +52,42 @@
         { "$ref": "#/definitions/resource_vertex_base" },
         {
           "properties": {
-            "type": { "enum": ["slot"] }
+            "type": { "enum": ["slot"] },
+            "count": {
+               "oneOf": [
+                 { "type": "integer", "minimum" : 1 },
+                 { "$ref": "#/definitions/complex_range" }
+                ]
+             }
           },
           "required": ["label"]
         }
       ]
     },
-    "resource_vertex_other": {
-      "description": "other (non-slot) resource type",
+    "resource_vertex_node_core": {
+      "description": "node or core resource type",
       "allOf": [
         { "$ref": "#/definitions/resource_vertex_base" },
         {
           "properties": {
-            "type": { "not": { "enum": ["slot"] } }
+            "type": { "enum": ["node", "core"] },
+            "count": {
+               "oneOf": [
+                 { "type": "integer", "minimum" : 1 },
+                 { "$ref": "#/definitions/complex_range" }
+                ]
+             }
+          }
+        }
+      ]
+    },
+    "resource_vertex_other": {
+      "description": "other (non slot, node, core) resource type",
+      "allOf": [
+        { "$ref": "#/definitions/resource_vertex_base" },
+        {
+          "properties": {
+            "type": { "not": { "enum": ["slot", "node", "core"] } }
           }
         }
       ]
@@ -72,6 +95,7 @@
     "resource_vertex": {
       "oneOf":[
         { "$ref": "#/definitions/resource_vertex_slot" },
+        { "$ref": "#/definitions/resource_vertex_node_core" },
         { "$ref": "#/definitions/resource_vertex_other" }
       ]
     }

--- a/src/modules/job-ingest/schemas/jobspec_v1.jsonschema
+++ b/src/modules/job-ingest/schemas/jobspec_v1.jsonschema
@@ -6,13 +6,24 @@
   "description":         "Flux jobspec version 1",
 
   "definitions": {
-    "intranode_resource_vertex": {
-      "description": "schema for resource vertices within a node, cannot have child vertices",
+    "core_resource_vertex": {
+      "description": "schema for core resource, cannot have child vertices",
       "type": "object",
       "required": ["type", "count"],
       "properties": {
-        "type": { "enum": ["core", "gpu"]},
+        "type": { "enum": ["core"]},
         "count": { "type": "integer", "minimum" : 1 },
+        "unit": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "gpu_resource_vertex": {
+      "description": "schema for gpu resource , cannot have child vertices",
+      "type": "object",
+      "required": ["type", "count"],
+      "properties": {
+        "type": { "enum": ["gpu"]},
+        "count": { "type": "integer", "minimum" : 0 },
         "unit": { "type": "string" }
       },
       "additionalProperties": false
@@ -54,7 +65,8 @@
           "maxItems": 2,
           "items": {
             "oneOf": [
-              {"$ref": "#/definitions/intranode_resource_vertex"}
+              {"$ref": "#/definitions/core_resource_vertex"},
+              {"$ref": "#/definitions/gpu_resource_vertex"}
             ]
           }
         }

--- a/t/jobspec/invalid/resource_slot_with_zero.yaml
+++ b/t/jobspec/invalid/resource_slot_with_zero.yaml
@@ -2,10 +2,10 @@ version: 1
 resources:
   - type: slot
     label: foo
-    count: 1
+    count: 0
     with:
       - type: core
-        count: 0
+        count: 1
 tasks:
   - command: [ "app" ]
     slot: foo

--- a/t/jobspec/invalid_v1/core_count_invalid.yaml
+++ b/t/jobspec/invalid_v1/core_count_invalid.yaml
@@ -1,0 +1,19 @@
+version: 1
+resources:
+  - type: node
+    count: 1
+    with:
+      - type: slot
+        count: 1
+        label: default
+        with:
+          - type: core
+            count: 0
+tasks:
+  - command: [ "app" ]
+    slot: default
+    count:
+      per_slot: 1
+attributes:
+  system:
+    duration: 3600.

--- a/t/jobspec/invalid_v1/gpu_count_invalid.yaml
+++ b/t/jobspec/invalid_v1/gpu_count_invalid.yaml
@@ -1,0 +1,22 @@
+version: 1
+resources:
+  - type: node
+    count: 1
+    with:
+      - type: slot
+        count: 1
+        label: default
+        with:
+          - type: core
+            count: 1
+          - type: gpu
+            count: -1
+
+tasks:
+  - command: [ "app" ]
+    slot: default
+    count:
+      per_slot: 1
+attributes:
+  system:
+    duration: 3600.

--- a/t/jobspec/valid_v1/gpu_count_zero.yaml
+++ b/t/jobspec/valid_v1/gpu_count_zero.yaml
@@ -1,0 +1,22 @@
+version: 1
+resources:
+  - type: node
+    count: 1
+    with:
+      - type: slot
+        count: 1
+        label: default
+        with:
+          - type: core
+            count: 1
+          - type: gpu
+            count: 0
+
+tasks:
+  - command: [ "app" ]
+    slot: default
+    count:
+      per_slot: 1
+attributes:
+  system:
+    duration: 3600.


### PR DESCRIPTION
When going through old issues I noticed #3275, which seemed like a reasonable and easy fix.

This change allows a count of 0 for core and gpu resources (not sure if core is all that useful, but this addresses the main point of the issue) 