### PR TITLE
job-archive: use statedir path if dbpath is not set

### DIFF
--- a/doc/man5/flux-config-archive.rst
+++ b/doc/man5/flux-config-archive.rst
@@ -7,16 +7,15 @@ DESCRIPTION
 ===========
 
 The **job-archive** service periodically archives job data in a
-sqlite database for use by **flux-accounting**.  Its default parameters may
-be altered by the ``archive`` table which may contain the following keys:
+sqlite database for use by **flux-accounting**.  Parameters may
+be set by the ``archive`` table which may contain the following keys:
 
 
 KEYS
 ====
 
 period
-   (optional) Set the archival period (in RFC 23 Flux Standard Duration format).
-   The default is 60s.
+   (required) Set the archival period (in RFC 23 Flux Standard Duration format).
 
 dbpath
    (optional) Set the path to the sqlite database file.  The service does

--- a/doc/man5/flux-config-archive.rst
+++ b/doc/man5/flux-config-archive.rst
@@ -14,13 +14,13 @@ be altered by the ``archive`` table which may contain the following keys:
 KEYS
 ====
 
-dbpath
-   (optional) Set the path to the sqlite database file.  The service does
-   nothing if this key is unset.
-
 period
    (optional) Set the archival period (in RFC 23 Flux Standard Duration format).
    The default is 60s.
+
+dbpath
+   (optional) Set the path to the sqlite database file.  The service does
+   nothing if this key is unset.
 
 busytimeout
    (optional) Set the sqlite busy_timeout pragma (in RFC 23 Flux Standard

--- a/etc/rc1
+++ b/etc/rc1
@@ -30,7 +30,10 @@ modload 0 cron sync=heartbeat.pulse
 modload 0 job-manager
 modload all job-info
 modload 0 job-list
-modload 0 job-archive
+period=`flux config get --default= archive.period`
+if test $RANK -eq 0 -a -n "${period}"; then
+    flux module load job-archive
+fi
 
 if test $RANK -eq 0 && ! flux startlog --check --quiet; then
     flux queue stop

--- a/src/modules/content-files/content-files.c
+++ b/src/modules/content-files/content-files.c
@@ -277,8 +277,10 @@ static struct content_files *content_files_create (flux_t *h)
      */
     if (!(dbdir = flux_attr_get (h, "statedir")))
         dbdir = flux_attr_get (h, "rundir");
-    if (!dbdir)
+    if (!dbdir) {
         flux_log_error (h, "neither statedir nor rundir are set");
+        goto error;
+    }
     if (asprintf (&ctx->dbpath, "%s/content.files", dbdir) < 0)
         goto error;
     if (mkdir (ctx->dbpath, 0700) < 0 && errno != EEXIST) {

--- a/src/modules/content-sqlite/content-sqlite.c
+++ b/src/modules/content-sqlite/content-sqlite.c
@@ -616,8 +616,10 @@ static struct content_sqlite *content_sqlite_create (flux_t *h)
      */
     if (!(dbdir = flux_attr_get (h, "statedir")))
         dbdir = flux_attr_get (h, "rundir");
-    if (!dbdir)
+    if (!dbdir) {
         flux_log_error (h, "neither statedir nor rundir are set");
+        goto error;
+    }
     if (asprintf (&ctx->dbfile, "%s/content.sqlite", dbdir) < 0)
         goto error;
 

--- a/src/modules/job-archive/job-archive.c
+++ b/src/modules/job-archive/job-archive.c
@@ -58,8 +58,8 @@ const char *sql_since = "SELECT MAX(t_inactive) FROM jobs;";
 
 struct job_archive_ctx {
     flux_t *h;
-    char *dbpath;
     double period;
+    char *dbpath;
     unsigned int busy_timeout;
     flux_watcher_t *w;
     sqlite3 *db;
@@ -501,8 +501,8 @@ void job_archive_cb (flux_reactor_t *r,
 static void process_config (struct job_archive_ctx *ctx, int ac, char **av)
 {
     flux_conf_error_t err;
-    const char *dbpath = NULL;
     const char *period = NULL;
+    const char *dbpath = NULL;
     const char *busytimeout = NULL;
     int i;
 
@@ -510,8 +510,8 @@ static void process_config (struct job_archive_ctx *ctx, int ac, char **av)
                           &err,
                           "{s?{s?s s?s s?s}}",
                           "archive",
-                            "dbpath", &dbpath,
                             "period", &period,
+                            "dbpath", &dbpath,
                             "busytimeout", &busytimeout) < 0) {
         flux_log (ctx->h, LOG_ERR,
                   "error reading archive config: %s",
@@ -521,23 +521,23 @@ static void process_config (struct job_archive_ctx *ctx, int ac, char **av)
 
     /* module params override config file */
     for (i = 0; i < ac; i++) {
-        if (strncmp (av[i], "dbpath=", 7) == 0)
-            dbpath = (av[i])+7;
-        else if (strncmp (av[i], "period=", 7) == 0)
+        if (strncmp (av[i], "period=", 7) == 0)
             period = (av[i])+7;
+        else if (strncmp (av[i], "dbpath=", 7) == 0)
+            dbpath = (av[i])+7;
         else if (strncmp (av[i], "busytimeout=", 12) == 0)
             busytimeout = (av[i])+12;
         else
             flux_log (ctx->h, LOG_ERR, "Unknown option `%s'", av[i]);
     }
 
-    if (dbpath) {
-        if (!(ctx->dbpath = strdup (dbpath)))
-            flux_log_error (ctx->h, "dbpath not configured");
-    }
     if (period) {
         if (fsd_parse_duration (period, &ctx->period) < 0)
             flux_log_error (ctx->h, "period not configured");
+    }
+    if (dbpath) {
+        if (!(ctx->dbpath = strdup (dbpath)))
+            flux_log_error (ctx->h, "dbpath not configured");
     }
     if (busytimeout) {
         double tmp;

--- a/src/modules/job-archive/job-archive.c
+++ b/src/modules/job-archive/job-archive.c
@@ -498,13 +498,12 @@ void job_archive_cb (flux_reactor_t *r,
     }
 }
 
-static void process_config (struct job_archive_ctx *ctx, int ac, char **av)
+static void process_config (struct job_archive_ctx *ctx)
 {
     flux_conf_error_t err;
     const char *period = NULL;
     const char *dbpath = NULL;
     const char *busytimeout = NULL;
-    int i;
 
     if (flux_conf_unpack (flux_get_conf (ctx->h),
                           &err,
@@ -517,18 +516,6 @@ static void process_config (struct job_archive_ctx *ctx, int ac, char **av)
                   "error reading archive config: %s",
                   err.errbuf);
         return;
-    }
-
-    /* module params override config file */
-    for (i = 0; i < ac; i++) {
-        if (strncmp (av[i], "period=", 7) == 0)
-            period = (av[i])+7;
-        else if (strncmp (av[i], "dbpath=", 7) == 0)
-            dbpath = (av[i])+7;
-        else if (strncmp (av[i], "busytimeout=", 12) == 0)
-            busytimeout = (av[i])+12;
-        else
-            flux_log (ctx->h, LOG_ERR, "Unknown option `%s'", av[i]);
     }
 
     if (period) {
@@ -556,7 +543,7 @@ int mod_main (flux_t *h, int ac, char **av)
     if (!ctx)
         return -1;
 
-    process_config (ctx, ac, av);
+    process_config (ctx);
 
     /* we do nothing if no dbpath specified */
     if (ctx->dbpath) {

--- a/t/t2250-job-archive.t
+++ b/t/t2250-job-archive.t
@@ -262,28 +262,4 @@ test_expect_success 'job-archive: db exists after module unloaded' '
         test $count -eq 7
 '
 
-test_expect_success 'job-archive: load module, params override config' '
-        flux module load job-archive dbpath=${ARCHIVEDB}-NEW
-'
-
-test_expect_success 'job-archive: store inactive job info in new db' '
-        jobid=`flux mini submit hostname` &&
-        fj_wait_event $jobid clean &&
-        wait_jobid_state $jobid inactive &&
-        wait_db $jobid ${ARCHIVEDB}-NEW &&
-        db_check_entries $jobid ${ARCHIVEDB}-NEW &&
-        db_check_values_run $jobid ${ARCHIVEDB}-NEW
-'
-
-test_expect_success 'job-archive: unload module' '
-        flux module unload job-archive
-'
-
-test_expect_success 'job-archive: both db exists after module unloaded' '
-        count=`db_count_entries ${ARCHIVEDB}` &&
-        test $count -eq 7 &&
-        count=`db_count_entries ${ARCHIVEDB}-NEW` &&
-        test $count -eq 8
-'
-
 test_done

--- a/t/t2250-job-archive.t
+++ b/t/t2250-job-archive.t
@@ -164,8 +164,8 @@ test_expect_success 'job-archive: unload module' '
 test_expect_success 'job-archive: setup config file' '
         cat >archive.toml <<EOF &&
 [archive]
-dbpath = "${ARCHIVEDB}"
 period = "0.5s"
+dbpath = "${ARCHIVEDB}"
 busytimeout = "0.1s"
 EOF
 	flux config reload


### PR DESCRIPTION
Per discussion in #4251.

- make `period` required in `job-archive` to make it do its thing
- if `dbpath` is not set, assume a path in `statedir` for job-archive, otherwise error
- in `rc1`, don't load `job-archive` module unless we're rank 0 & `archive.period` has been set

i have one commit below that is purely anal retentive, it can be dropped :-)