### PR TITLE
resource: stop collecting/reducing hwloc XML 

### DIFF
--- a/src/modules/resource/inventory.h
+++ b/src/modules/resource/inventory.h
@@ -18,8 +18,6 @@
 struct inventory *inventory_create (struct resource_ctx *ctx, json_t *R);
 void inventory_destroy (struct inventory *inv);
 
-json_t *inventory_get_xml (struct inventory *inv);
-
 /* Get resource object.
  * Returned resource object shall not be modified or freed by the caller.
  */
@@ -37,8 +35,6 @@ const char *inventory_get_method (struct inventory *inv);
  * 'resource-define' to resource.eventlog.  The KVS commits are asynchronous.
  */
 int inventory_put (struct inventory *inv, json_t *R, const char *method);
-
-int inventory_put_xml (struct inventory *inv, json_t *xml);
 
 /* Return a set of ranks for a string of "targets". The 'targets' argument
  * may be an RFC22 encoded idset or RFC29 hostlist. If an idset, the

--- a/t/t3301-system-latestart.t
+++ b/t/t3301-system-latestart.t
@@ -17,10 +17,6 @@ test_under_flux 2 system
 
 startctl="flux python ${SHARNESS_TEST_SRCDIR}/scripts/startctl.py"
 
-get_hwloc () {
-        flux python -c "import flux; print(flux.Flux().rpc(\"resource.get-xml\",nodeid=$1).get_str())"
-}
-
 test_expect_success 'broker.quorum was set to 0 by system test personality' '
 	echo 0 >quorum.exp &&
 	flux getattr broker.quorum >quorum.out &&
@@ -57,12 +53,6 @@ test_expect_success 'single node job can run with only rank 0 up' '
 
 test_expect_success 'two node job is accepted although it cannot run yet' '
 	flux mini submit -N2 -n2 echo Hello >jobid
-'
-
-# bug 3884
-test_expect_success 'resource.get-xml RPC fails with reasonable error' '
-	test_must_fail get_hwloc 0 2>get_hwloc.err &&
-	grep "may block forever" get_hwloc.err
 '
 
 test_expect_success 'start rank 1' '


### PR DESCRIPTION
Now that fluxion has the Rv1 reader (flux-framework/flux-sched#921), it no longer requires the `resource.get-xml` RPC to fetch aggregated hwloc XML for the instance.   This PR removes that RPC and leaves the hwloc XML out of the R<sub>local</sub> :arrow_right: reduction, greatly reducing the amount of data that needs to be moved before the scheduler can be started when resources are dynamically discovered (e.g. under slurm).

This PR is based on top of #4262 (remove `flux-hwloc`)