### PR TITLE
libsubprocess: remove prefix on server setup

### DIFF
--- a/src/broker/exec.c
+++ b/src/broker/exec.c
@@ -92,7 +92,7 @@ int exec_initialize (flux_t *h, uint32_t rank, attr_t *attrs)
 
     if (attr_get (attrs, "local-uri", &local_uri, NULL) < 0)
         goto cleanup;
-    if (!(s = flux_subprocess_server_start (h, "broker", local_uri, rank)))
+    if (!(s = flux_subprocess_server_start (h, local_uri, rank)))
         goto cleanup;
     if (rank == 0)
         flux_subprocess_server_set_auth_cb (s, reject_nonlocal, NULL);

--- a/src/common/libsubprocess/server.c
+++ b/src/common/libsubprocess/server.c
@@ -608,45 +608,37 @@ error:
     json_decref (procs);
 }
 
-int server_start (flux_subprocess_server_t *s, const char *prefix)
+int server_start (flux_subprocess_server_t *s)
 {
     /* rexec.processes is primarily for testing */
     struct flux_msg_handler_spec htab[] = {
-        { FLUX_MSGTYPE_REQUEST, "rexec",        server_exec_cb, 0 },
-        { FLUX_MSGTYPE_REQUEST, "rexec.write",  server_write_cb, 0 },
-        { FLUX_MSGTYPE_REQUEST, "rexec.signal", server_signal_cb, 0 },
-        { FLUX_MSGTYPE_REQUEST, "rexec.processes", server_processes_cb, 0 },
+        { FLUX_MSGTYPE_REQUEST,
+          "broker.rexec",
+          server_exec_cb,
+          0
+        },
+        { FLUX_MSGTYPE_REQUEST,
+          "broker.rexec.write",
+          server_write_cb,
+          0
+        },
+        { FLUX_MSGTYPE_REQUEST,
+          "broker.rexec.signal",
+          server_signal_cb,
+          0
+        },
+        { FLUX_MSGTYPE_REQUEST,
+          "broker.rexec.processes",
+          server_processes_cb,
+          0
+        },
         FLUX_MSGHANDLER_TABLE_END,
     };
-    char *topic_globs[4] = {NULL, NULL, NULL, NULL};
-    int rv = -1;
-
-    assert (prefix);
-
-    if (asprintf (&topic_globs[0], "%s.rexec", prefix) < 0)
-        goto cleanup;
-    if (asprintf (&topic_globs[1], "%s.rexec.write", prefix) < 0)
-        goto cleanup;
-    if (asprintf (&topic_globs[2], "%s.rexec.signal", prefix) < 0)
-        goto cleanup;
-    if (asprintf (&topic_globs[3], "%s.rexec.processes", prefix) < 0)
-        goto cleanup;
-
-    htab[0].topic_glob = (const char *)topic_globs[0];
-    htab[1].topic_glob = (const char *)topic_globs[1];
-    htab[2].topic_glob = (const char *)topic_globs[2];
-    htab[3].topic_glob = (const char *)topic_globs[3];
 
     if (flux_msg_handler_addvec (s->h, htab, s, &s->handlers) < 0)
-        goto cleanup;
+        return -1;
 
-    rv = 0;
-cleanup:
-    free (topic_globs[0]);
-    free (topic_globs[1]);
-    free (topic_globs[2]);
-    free (topic_globs[3]);
-    return rv;
+    return 0;
 }
 
 void server_stop (flux_subprocess_server_t *s)

--- a/src/common/libsubprocess/server.h
+++ b/src/common/libsubprocess/server.h
@@ -13,7 +13,7 @@
 
 #include "subprocess.h"
 
-int server_start (flux_subprocess_server_t *s, const char *prefix);
+int server_start (flux_subprocess_server_t *s);
 
 void server_stop (flux_subprocess_server_t *s);
 

--- a/src/common/libsubprocess/subprocess.c
+++ b/src/common/libsubprocess/subprocess.c
@@ -268,14 +268,13 @@ int subprocess_status (flux_subprocess_t *p)
  */
 
 flux_subprocess_server_t *flux_subprocess_server_start (flux_t *h,
-                                                        const char *prefix,
                                                         const char *local_uri,
                                                         uint32_t rank)
 {
     flux_subprocess_server_t *s = NULL;
     int save_errno;
 
-    if (!h || !prefix || !local_uri) {
+    if (!h || !local_uri) {
         errno = EINVAL;
         goto error;
     }
@@ -283,7 +282,7 @@ flux_subprocess_server_t *flux_subprocess_server_start (flux_t *h,
     if (!(s = subprocess_server_create (h, local_uri, rank)))
         goto error;
 
-    if (server_start (s, prefix) < 0)
+    if (server_start (s) < 0)
         goto error;
 
     return s;

--- a/src/common/libsubprocess/subprocess.h
+++ b/src/common/libsubprocess/subprocess.h
@@ -115,12 +115,9 @@ typedef struct {
  */
 
 /*  Start a subprocess server on the handle `h`. Registers message
- *   handlers, etc for remote execution. "prefix" is the topic prefix
- *   used to listen for this service, e.g. `broker` would listen
- *   for `broker.exec`.
+ *   handlers, etc for remote execution.
  */
 flux_subprocess_server_t *flux_subprocess_server_start (flux_t *h,
-                                                        const char *prefix,
                                                         const char *local_uri,
                                                         uint32_t rank);
 

--- a/src/common/libsubprocess/test/subprocess.c
+++ b/src/common/libsubprocess/test/subprocess.c
@@ -150,7 +150,7 @@ void test_basic_errors (flux_reactor_t *r)
     ok ((h = flux_open ("loop://", 0)) != NULL,
         "flux_open on loop works");
 
-    ok (!flux_subprocess_server_start (NULL, NULL, NULL, 0)
+    ok (!flux_subprocess_server_start (NULL, NULL, 0)
         && errno == EINVAL,
         "flux_subprocess_server_start fails with NULL pointer inputs");
     ok (flux_subprocess_server_terminate_by_uuid (NULL, NULL) < 0


### PR DESCRIPTION
Problem: The flux_subprocess_server_start() function takes
a prefix for setting up server targets.  However the flux_rexec()
function is not configurable on what target should be used to
launch a remote subprocess.  This inconsistency is likely due
to a forgotten design decision / hope from long ago.

Solution: Remove the prefix for server setup and always internally
assume the prefix is "broker".

Fixes #4176