### PR TITLE
flux-resource: remove ranks from default status output

### DIFF
--- a/src/cmd/flux-resource.py
+++ b/src/cmd/flux-resource.py
@@ -350,9 +350,9 @@ def status(args):
 
     #  Include reason field only with -vv
     if args.verbose >= 2:
-        fmt = "{state:>10} {nnodes:>6} {ranks:<15} {reason:<25} {nodelist}"
+        fmt = "{state:>10} {nnodes:>6} {reason:<25} {nodelist}"
     else:
-        fmt = "{state:>10} {nnodes:>6} {ranks:<15} {nodelist}"
+        fmt = "{state:>10} {nnodes:>6} {nodelist}"
     if args.format:
         fmt = args.format
 


### PR DESCRIPTION
Problem: The `flux resource status` output includes ranks *and* hostnames
in default output, but this just clutters the output, especially when the
ranks idset overflows its column.

Remove the ranks column from default output for a cleaner result.

Fixes #4269

Before:
```
    STATUS NNODES RANKS           NODELIST
     avail     89 4-13,15-20,22-53,55,57,59-62,64-75,77-88,90-100 fluke[7-16,18-23,25-56,58,60,62-65,67-78,80-91,93-103]
   offline      8 14,21,54,56,58,63,76,89 fluke[17,24,57,59,61,66,79,92]
   exclude      3 0-2             fluke[1,3,108]
   drained      9 3,14,21,54,56,58,63,76,89 fluke[6,17,24,57,59,61,66,79,92]
```

After:
```
    STATUS NNODES NODELIST
     avail     89 fluke[7-16,18-23,25-56,58,60,62-65,67-78,80-91,93-103]
   offline      8 fluke[17,24,57,59,61,66,79,92]
   exclude      3 fluke[1,3,108]
   drained      9 fluke[6,17,24,57,59,61,66,79,92]
```