### PR TITLE
add flux-resource info subcommand

### DIFF
--- a/doc/man1/flux-resource.rst
+++ b/doc/man1/flux-resource.rst
@@ -55,6 +55,12 @@ COMMANDS
    as "down" due to its simplified interface with the resource service defined
    by RFC 27.
 
+**info** [-s STATE,...]
+   Show a brief, single line summary of scheduler view of resources.
+   With *-s, --states=STATE,...*, limit the output to specified resource
+   states as with ``flux resource list``. By default, the *STATE* reported
+   by ``flux resource info`` is "all".
+
 **status**  [-v] [-n] [-o FORMAT] [-s STATE,...]
    Show system view of resources.  One or more *-v,--verbose* options
    increase output verbosity.  *-n,--no-header* suppresses header from output.

--- a/src/cmd/flux-resource.py
+++ b/src/cmd/flux-resource.py
@@ -481,6 +481,16 @@ def list_handler(args):
         print(formatter.format(line))
 
 
+def info(args):
+    """Convenience function that wraps flux-resource list"""
+    if not args.states:
+        args.states = "all"
+    args.no_header = True
+    args.format = "{nnodes} Nodes, {ncores} Cores, {ngpus} GPUs"
+    args.verbose = 0
+    list_handler(args)
+
+
 LOGGER = logging.getLogger("flux-resource")
 
 
@@ -580,6 +590,21 @@ def main():
         "--from-stdin", action="store_true", help=argparse.SUPPRESS
     )
     list_parser.set_defaults(func=list_handler)
+
+    # flux-resource info:
+    info_parser = subparsers.add_parser(
+        "info", formatter_class=flux.util.help_formatter()
+    )
+    info_parser.add_argument(
+        "-s",
+        "--states",
+        metavar="STATE,...",
+        help="Show output only for resources in given states",
+    )
+    info_parser.add_argument(
+        "--from-stdin", action="store_true", help=argparse.SUPPRESS
+    )
+    info_parser.set_defaults(func=info)
 
     reload_parser = subparsers.add_parser(
         "reload", formatter_class=flux.util.help_formatter()

--- a/t/flux-resource/list/fluxion-info.expected
+++ b/t/flux-resource/list/fluxion-info.expected
@@ -1,0 +1,1 @@
+4 Nodes, 16 Cores, 0 GPUs

--- a/t/flux-resource/list/missing-info.expected
+++ b/t/flux-resource/list/missing-info.expected
@@ -1,0 +1,1 @@
+4 Nodes, 16 Cores, 0 GPUs

--- a/t/flux-resource/list/normal-input-info.expected
+++ b/t/flux-resource/list/normal-input-info.expected
@@ -1,0 +1,1 @@
+4 Nodes, 16 Cores, 0 GPUs

--- a/t/flux-resource/list/null-info.expected
+++ b/t/flux-resource/list/null-info.expected
@@ -1,0 +1,1 @@
+4 Nodes, 16 Cores, 0 GPUs

--- a/t/flux-resource/list/properties-info.expected
+++ b/t/flux-resource/list/properties-info.expected
@@ -1,0 +1,1 @@
+4 Nodes, 16 Cores, 0 GPUs

--- a/t/t2350-resource-list.t
+++ b/t/t2350-resource-list.t
@@ -11,15 +11,19 @@ test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
 FORMAT="{state:>10} {properties:<10} {nnodes:>6} {ncores:>8} {ngpus:>8}"
 
 for input in ${SHARNESS_TEST_SRCDIR}/flux-resource/list/*.json; do
-    name=$(basename ${input%%.json})
-    test_expect_success "flux-resource list input check: $name" '
-        base=${input%%.json} &&
-        expected=${base}.expected &&
-        name=$(basename $base) &&
+    testname=$(basename ${input%%.json}) &&
+    base=${input%%.json} &&
+    name=$(basename $base) &&
+    test_expect_success "flux-resource list input check: $testname" '
         flux resource list -o "$FORMAT" \
             --from-stdin < $input > $name.output 2>&1 &&
         test_debug "cat $name.output" &&
-        test_cmp $expected $name.output
+        test_cmp ${base}.expected $name.output
+    '
+    test_expect_success "flux-resource info input check: $testname" '
+        flux resource info --from-stdin < $input > ${name}-info.output 2>&1 &&
+        test_debug "cat ${name}-info.output" &&
+        test_cmp ${base}-info.expected ${name}-info.output
     '
 done
 


### PR DESCRIPTION
This PR adds a `flux resource info` subcommand as described in #4266.
e.g.
```
grondo@fluke108:~/git/flux-core.git$ src/cmd/flux resource info
101 Nodes, 404 Cores, 0 GPUs
grondo@fluke108:~/git/flux-core.git$ src/cmd/flux resource info -s up
89 Nodes, 356 Cores, 0 GPUs
grondo@fluke108:~/git/flux-core.git$ src/cmd/flux resource info -s down
12 Nodes, 48 Cores, 0 GPUs
```

The implementation is just a thin wrapper around `flux resource list`, i.e. the `sched.resource-status` RPC. I thought at first it would be more appropriate to use the `resource.status` RPC but due to the structure of the code it was much easier to use the scheduler-based call. Therefore, this command won't work if a scheduler is not loaded.

