### PR TITLE
docker: update default flux-security version to v0.6.0

### DIFF
--- a/src/test/docker/docker-run-checks.sh
+++ b/src/test/docker/docker-run-checks.sh
@@ -16,7 +16,7 @@ JOBS=2
 MOUNT_HOME_ARGS="--volume=$HOME:/home/$USER -e HOME"
 
 if test "$PROJECT" = "flux-core"; then
-  FLUX_SECURITY_VERSION=0.5.0
+  FLUX_SECURITY_VERSION=0.6.0
   POISON=t
 fi
 


### PR DESCRIPTION
This was peeled off of @chu11's PR #4070. It would be convenient to have flux-security v0.6.0 in the official `fluxrm/flux-core` docker images, so figured this would be nice to get in first.