### PR TITLE
testsuite: fix failing tests on parallel testsuite runs

### DIFF
--- a/t/t2701-mini-batch.t
+++ b/t/t2701-mini-batch.t
@@ -84,7 +84,7 @@ test_expect_success NO_ASAN 'flux-mini batch: submit a series of jobs' '
 	flux jobs &&
 	id4=$(flux mini batch --flags=waitable -N2 -n2 --exclusive batch-script.sh) &&
 	id5=$(flux mini batch --flags=waitable -N2 batch-script.sh) &&
-	run_timeout 60 flux job wait --verbose --all
+	run_timeout 180 flux job wait --verbose --all
 '
 test_expect_success NO_ASAN 'flux-mini batch: job results are expected' '
 	test_debug "grep . flux-*.out" &&

--- a/t/t2801-top-cmd.t
+++ b/t/t2801-top-cmd.t
@@ -93,12 +93,12 @@ test_expect_success NO_CHAIN_LINT 'flux-top can call itself recursively' '
 	cat <<-EOF >recurse.in &&
 	{ "version": 2 }
 	[0.5, "i", "j"]
-	[0.55, "i", "j"]
-	[0.60, "i", "j"]
-	[0.65, "i", "k"]
-	[0.70, "i", "\n"]
-	[1.00, "i", "q"]
-	[1.10, "i", "q"]
+	[1.0, "i", "j"]
+	[1.5, "i", "j"]
+	[2.0, "i", "k"]
+	[2.5, "i", "\n"]
+	[3.25, "i", "q"]
+	[3.75, "i", "q"]
 	EOF
 	$runpty -o recurse.log --input=recurse.in flux top &&
 	grep -q $(echo $(cat expected.id) | sed "s/ƒ//") recurse.log


### PR DESCRIPTION
I was regularly hitting two failures when I did `make -j16 check`.  Here are suggested fixes.

Note, that I sort of "jumped" big on my timeouts / input times.  Could be tweaked lower if people want them to be lower.