### PR TITLE
libflux: convert flux_conf_error_t to flux_error_t

### DIFF
--- a/src/broker/boot_config.c
+++ b/src/broker/boot_config.c
@@ -175,7 +175,7 @@ int boot_config_parse (const flux_conf_t *cf,
                        struct boot_conf *conf,
                        json_t **hostsp)
 {
-    flux_conf_error_t error;
+    flux_error_t error;
     const char *default_bind = NULL;
     const char *default_connect = NULL;
     json_t *hosts = NULL;
@@ -191,7 +191,7 @@ int boot_config_parse (const flux_conf_t *cf,
                             "default_connect", &default_connect,
                             "hosts", &conf->hosts,
                             "enable_ipv6", &conf->enable_ipv6) < 0) {
-        log_msg ("Config file error [bootstrap]: %s", error.errbuf);
+        log_msg ("Config file error [bootstrap]: %s", error.text);
         return -1;
     }
 

--- a/src/broker/brokercfg.c
+++ b/src/broker/brokercfg.c
@@ -42,25 +42,15 @@ static int brokercfg_parse (flux_t *h,
                             char *errbuf,
                             int errbufsize)
 {
-    flux_conf_error_t error;
+    flux_error_t error;
     flux_conf_t *conf;
 
     if (path) {
         if (!(conf = flux_conf_parse (path, &error))) {
-            if (error.lineno == -1)
-                (void)snprintf (errbuf,
-                                errbufsize,
-                                "Config file error: %s%s%s",
-                                error.filename,
-                                *error.filename ? ": " : "",
-                                error.errbuf);
-            else
-                (void)snprintf (errbuf,
-                                errbufsize,
-                                "Config file error: %s:%d: %s",
-                                error.filename,
-                                error.lineno,
-                                error.errbuf);
+            (void)snprintf (errbuf,
+                            errbufsize,
+                            "Config file error: %s",
+                            error.text);
             return -1;
         }
     }
@@ -219,13 +209,13 @@ static void get_cb (flux_t *h,
                     void *arg)
 {
     const char *errmsg = NULL;
-    flux_conf_error_t error;
+    flux_error_t error;
     json_t *o;
 
     if (flux_request_decode (msg, NULL, NULL) < 0)
         goto error;
     if (flux_conf_unpack (flux_get_conf (h), &error, "o", &o) < 0) {
-        errmsg = error.errbuf;
+        errmsg = error.text;
         goto error;
     }
     if (flux_respond_pack (h, msg, "O", o) < 0)

--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -1796,7 +1796,7 @@ static int overlay_configure_torpid (struct overlay *ov)
     /* Override with config file settings, if any.
      */
     if ((cf = flux_get_conf (ov->h))) {
-        flux_conf_error_t error;
+        flux_error_t error;
         const char *min_fsd = NULL;
         const char *max_fsd = NULL;
 
@@ -1806,7 +1806,7 @@ static int overlay_configure_torpid (struct overlay *ov)
                               "tbon",
                                 "torpid_min", &min_fsd,
                                 "torpid_max", &max_fsd) < 0) {
-            log_msg ("Config file error [tbon]: %s", error.errbuf);
+            log_msg ("Config file error [tbon]: %s", error.text);
             return -1;
         }
         if (min_fsd) {
@@ -1850,14 +1850,14 @@ static int overlay_configure_tcp_user_timeout (struct overlay *ov)
     const char *fsd = NULL;
 
     if ((cf = flux_get_conf (ov->h))) {
-        flux_conf_error_t error;
+        flux_error_t error;
 
         if (flux_conf_unpack (cf,
                               &error,
                               "{s?{s?s}}",
                               "tbon",
                                 "tcp_user_timeout", &fsd) < 0) {
-            log_msg ("Config file error [tbon]: %s", error.errbuf);
+            log_msg ("Config file error [tbon]: %s", error.text);
             return -1;
         }
         if (fsd) {
@@ -1904,14 +1904,14 @@ static int overlay_configure_zmqdebug (struct overlay *ov)
 
     ov->zmqdebug = 0;
     if ((cf = flux_get_conf (ov->h))) {
-        flux_conf_error_t error;
+        flux_error_t error;
 
         if (flux_conf_unpack (cf,
                               &error,
                               "{s?{s?i}}",
                               "tbon",
                                 "zmqdebug", &ov->zmqdebug) < 0) {
-            log_msg ("Config file error [tbon]: %s", error.errbuf);
+            log_msg ("Config file error [tbon]: %s", error.text);
             return -1;
         }
     }

--- a/src/broker/test/boot_config.c
+++ b/src/broker/test/boot_config.c
@@ -313,7 +313,7 @@ void test_toml_mixed_array (const char *dir)
 {
     char path[PATH_MAX + 1];
     flux_conf_t *cf;
-    flux_conf_error_t error;
+    flux_error_t error;
     const char *input = \
 "[bootstrap]\n" \
 "hosts = [\n" \
@@ -324,10 +324,10 @@ void test_toml_mixed_array (const char *dir)
     create_test_file (dir, "boot", path, sizeof (path), input);
 
     cf = flux_conf_parse (dir, &error);
-    ok (cf == NULL && (strstr (error.errbuf, "array type mismatch")
-        || strstr (error.errbuf, "string array can only contain strings")),
+    ok (cf == NULL && (strstr (error.text, "array type mismatch")
+        || strstr (error.text, "string array can only contain strings")),
         "Mixed type hosts array fails with reasonable error");
-    diag ("%s: line %d: %s", error.filename, error.lineno, error.errbuf);
+    diag ("%s", error.text);
 
     if (unlink (path) < 0)
         BAIL_OUT ("could not cleanup test file %s", path);

--- a/src/common/libflux/conf.h
+++ b/src/common/libflux/conf.h
@@ -36,12 +36,6 @@ const char *flux_conf_builtin_get (const char *name,
 
 typedef struct flux_conf flux_conf_t;
 
-typedef struct {
-    char filename[80];  // if unused, will be set to empty string
-    int lineno;         // if unused, will be set to -1
-    char errbuf[160];
-} flux_conf_error_t;
-
 /* Create/copy/incref/decref config object
  */
 flux_conf_t *flux_conf_create (void);
@@ -56,7 +50,7 @@ int flux_conf_reload_decode (const flux_msg_t *msg, const flux_conf_t **conf);
 
 /* Parse *.toml in 'path' directory.
  */
-flux_conf_t *flux_conf_parse (const char *path, flux_conf_error_t *error);
+flux_conf_t *flux_conf_parse (const char *path, flux_error_t *error);
 
 /* Get/set config object cached in flux_t handle, with destructor.
  * Re-setting the object decrefs the old one.
@@ -68,12 +62,12 @@ int flux_set_conf (flux_t *h, const flux_conf_t *conf);
  * If error is non-NULL, it is filled with error details on failure.
  */
 int flux_conf_vunpack (const flux_conf_t *conf,
-                       flux_conf_error_t *error,
+                       flux_error_t *error,
                        const char *fmt,
                        va_list ap);
 
 int flux_conf_unpack (const flux_conf_t *conf,
-                      flux_conf_error_t *error,
+                      flux_error_t *error,
                       const char *fmt, ...);
 
 #ifdef __cplusplus

--- a/src/common/libflux/conf_private.h
+++ b/src/common/libflux/conf_private.h
@@ -15,7 +15,7 @@
 
 /* Set errno and optionally 'error' based on glob error return code.
  */
-void conf_globerr (flux_conf_error_t *error, const char *pattern, int rc);
+void conf_globerr (flux_error_t *error, const char *pattern, int rc);
 
 #endif /* !_FLUX_CORE_CONF_PRIVATE_H */
 

--- a/src/modules/connector-local/local.c
+++ b/src/modules/connector-local/local.c
@@ -207,7 +207,7 @@ int parse_config (struct connector_local *ctx,
                   char *errbuf,
                   int errbufsize)
 {
-    flux_conf_error_t error;
+    flux_error_t error;
     int allow_guest_user = 0;
     int allow_root_owner = 0;
 
@@ -222,7 +222,7 @@ int parse_config (struct connector_local *ctx,
         (void)snprintf (errbuf,
                         errbufsize,
                         "error parsing [access] configuration: %s",
-                        error.errbuf);
+                        error.text);
         return -1;
     }
     ctx->allow_guest_user = allow_guest_user;

--- a/src/modules/content-s3/content-s3.c
+++ b/src/modules/content-s3/content-s3.c
@@ -136,7 +136,7 @@ static struct s3_config *parse_config (const flux_conf_t *conf,
                                        int eb_size)
 {
     struct s3_config *cfg;
-    flux_conf_error_t error;
+    flux_error_t error;
     const char *uri = NULL;
     const char *bucket = NULL;
     const char *cred_file = NULL;
@@ -163,7 +163,7 @@ static struct s3_config *parse_config (const flux_conf_t *conf,
                           &uri,
                           "virtual-host-style",
                           &is_virtual_host) < 0) {
-        snprintf(errbuff, eb_size, "%s", error.errbuf);
+        snprintf(errbuff, eb_size, "%s", error.text);
         goto error;
     }
 

--- a/src/modules/job-archive/job-archive.c
+++ b/src/modules/job-archive/job-archive.c
@@ -499,7 +499,7 @@ void job_archive_cb (flux_reactor_t *r,
 
 static int process_config (struct job_archive_ctx *ctx)
 {
-    flux_conf_error_t err;
+    flux_error_t err;
     const char *period = NULL;
     const char *dbpath = NULL;
     const char *busytimeout = NULL;
@@ -513,7 +513,7 @@ static int process_config (struct job_archive_ctx *ctx)
                             "busytimeout", &busytimeout) < 0) {
         flux_log (ctx->h, LOG_ERR,
                   "error reading archive config: %s",
-                  err.errbuf);
+                  err.text);
         return -1;
     }
 

--- a/src/modules/job-exec/exec.c
+++ b/src/modules/job-exec/exec.c
@@ -472,7 +472,7 @@ static void exec_exit (struct jobinfo *job)
  */
 static int exec_config (flux_t *h, int argc, char **argv)
 {
-    flux_conf_error_t err;
+    flux_error_t err;
 
     /*  Set default job shell path from builtin configuration,
      *   allow override via configuration, then cmdline.
@@ -488,7 +488,7 @@ static int exec_config (flux_t *h, int argc, char **argv)
                             "job-shell", &default_job_shell) < 0) {
         flux_log (h, LOG_ERR,
                   "error reading config value exec.job-shell: %s",
-                  err.errbuf);
+                  err.text);
         return -1;
     }
 
@@ -500,7 +500,7 @@ static int exec_config (flux_t *h, int argc, char **argv)
                             "imp", &flux_imp_path) < 0) {
         flux_log (h, LOG_ERR,
                   "error reading config value exec.imp: %s",
-                  err.errbuf);
+                  err.text);
         return -1;
     }
 

--- a/src/modules/job-exec/job-exec.c
+++ b/src/modules/job-exec/job-exec.c
@@ -1153,7 +1153,7 @@ static int exec_hello (flux_t *h, const char *service)
  */
 static int job_exec_initialize (flux_t *h, int argc, char **argv)
 {
-    flux_conf_error_t err;
+    flux_error_t err;
     const char *kto = NULL;
 
     if (flux_conf_unpack (flux_get_conf (h),
@@ -1163,7 +1163,7 @@ static int job_exec_initialize (flux_t *h, int argc, char **argv)
                             "kill-timeout", &kto) < 0) {
         flux_log (h, LOG_ERR,
                   "error reading config value exec.kill-timeout: %s",
-                  err.errbuf);
+                  err.text);
         return -1;
     }
     /* Override via commandline */

--- a/src/modules/job-ingest/job-ingest.c
+++ b/src/modules/job-ingest/job-ingest.c
@@ -918,7 +918,7 @@ static int job_ingest_configure (struct job_ingest_ctx *ctx,
                                  int argc,
                                  char **argv)
 {
-    flux_conf_error_t error;
+    flux_error_t error;
     json_t *plugins = NULL;
     json_t *args = NULL;
     char *validator_plugins = NULL;
@@ -937,7 +937,7 @@ static int job_ingest_configure (struct job_ingest_ctx *ctx,
                             "batch-count", &ctx->batch_count) < 0) {
         flux_log (ctx->h, LOG_ERR,
                   "error reading [ingest] config table: %s",
-                  error.errbuf);
+                  error.text);
         goto out;
     }
 

--- a/src/modules/job-manager/jobtap.c
+++ b/src/modules/job-manager/jobtap.c
@@ -396,7 +396,7 @@ static int jobtap_parse_config (struct jobtap *jobtap,
                                 flux_error_t *errp)
 {
     json_t *plugins = NULL;
-    flux_conf_error_t error;
+    flux_error_t error;
     json_t *entry;
     int i;
 
@@ -410,7 +410,7 @@ static int jobtap_parse_config (struct jobtap *jobtap,
                             "plugins", &plugins) < 0) {
         return errprintf (errp,
                           "[job-manager.plugins]: unpack error: %s",
-                          error.errbuf);
+                          error.text);
     }
 
     if (!plugins)

--- a/src/modules/job-manager/journal.c
+++ b/src/modules/job-manager/journal.c
@@ -285,7 +285,7 @@ static const struct flux_msg_handler_spec htab[] = {
 struct journal *journal_ctx_create (struct job_manager *ctx)
 {
     struct journal *journal;
-    flux_conf_error_t err;
+    flux_error_t err;
 
     if (!(journal = calloc (1, sizeof (*journal))))
         return NULL;
@@ -306,7 +306,7 @@ struct journal *journal_ctx_create (struct job_manager *ctx)
                             &journal->events_maxlen) < 0) {
         flux_log (ctx->h, LOG_ERR,
                   "error reading job-manager config: %s",
-                  err.errbuf);
+                  err.text);
     }
 
     return journal;

--- a/src/modules/job-manager/plugins/perilog.c
+++ b/src/modules/job-manager/plugins/perilog.c
@@ -452,7 +452,7 @@ fail:
  */
 static int conf_init (flux_t *h, struct perilog_conf *conf)
 {
-    flux_conf_error_t error;
+    flux_error_t error;
     json_t *prolog = NULL;
     json_t *epilog = NULL;
 
@@ -474,7 +474,7 @@ static int conf_init (flux_t *h, struct perilog_conf *conf)
                             "command", &epilog) < 0) {
         flux_log (h, LOG_ERR,
                   "prolog/epilog configuration error: %s",
-                  error.errbuf);
+                  error.text);
         return -1;
     }
     if (prolog &&

--- a/src/modules/resource/resource.c
+++ b/src/modules/resource/resource.c
@@ -51,7 +51,7 @@ static int parse_config (struct resource_ctx *ctx,
                          char *errbuf,
                          int errbufsize)
 {
-    flux_conf_error_t error;
+    flux_error_t error;
     const char *exclude  = NULL;
     const char *path = NULL;
     int noverify = 0;
@@ -67,7 +67,7 @@ static int parse_config (struct resource_ctx *ctx,
         (void)snprintf (errbuf,
                         errbufsize,
                         "error parsing [resource] configuration: %s",
-                        error.errbuf);
+                        error.text);
         return -1;
     }
     if (path) {

--- a/t/t0013-config-file.t
+++ b/t/t0013-config-file.t
@@ -323,5 +323,49 @@ test_expect_success MAXRT 'tbon.zmqdebug with bad value on command line fails' '
 		/bin/true 2>zbadattr.err &&
 	grep "value must be an integer" zbadattr.err
 '
+test_expect_success MAXRT 'tbon.zmqdebug configured with wrong type fails' '
+	mkdir conf19 &&
+	cat <<-EOT >conf19/tbon.toml &&
+	[tbon]
+	zmqdebug = "notint"
+	EOT
+	test_must_fail flux broker ${ARGS} -c conf19 \
+		/bin/true 2>zbadconf.err &&
+	grep "Expected integer" zbadconf.err
+'
+test_expect_success MAXRT 'tbon.zmqdebug configured with wrong type fails' '
+	mkdir conf20 &&
+	cat <<-EOT >conf20/tbon.toml &&
+	[tbon]
+	zmqdebug = "notint"
+	EOT
+	test_must_fail flux broker ${ARGS} -c conf20 \
+		/bin/true 2>zbadconf.err &&
+	grep "Expected integer" zbadconf.err
+'
+test_expect_success 'tbon.torpid_max, tbon.torpid_min can be configured' '
+	mkdir conf21 &&
+	cat <<-EOT >conf21/tbon.toml &&
+	[tbon]
+	torpid_max = "5s"
+	torpid_min = "2s"
+	EOT
+	flux broker ${ARGS} -c conf21 \
+		flux getattr tbon.torpid_min >torpid_min.out &&
+	flux broker ${ARGS} -c conf21 \
+		flux getattr tbon.torpid_max >torpid_max.out &&
+	grep 2s torpid_min.out &&
+	grep 5s torpid_max.out
+'
+test_expect_success 'tbon.torpid_max configured with wrong type fails' '
+	mkdir conf22 &&
+	cat <<-EOT >conf22/tbon.toml &&
+	[tbon]
+	torpid_max = 5
+	EOT
+	test_must_fail flux broker ${ARGS} -c conf22 \
+		/bin/true 2>badtorpid.err &&
+	grep "Expected string" badtorpid.err
+'
 
 test_done


### PR DESCRIPTION
Problem: #4165 introduced a common type for returning human readable errors from Flux API calls, but `flux_conf_unpack()` and related functions were not converted.  Furthermore, the file and line structure members in `flux_conf_error_t` are pretty useless after the initial parsing of TOML files since most of the time these functions access the JSON config object and any unpack error would not generate a useful file and line.

Drop the `flux_conf_error_t` type from the API and convert the `flux_conf_*()` functions to use `flux_error_t`.

Update tests and users.

I did not find any users in `flux-sched`, `flux-accounting`, `flux-coral2`, or `flux-pmix` so at least nothing breaks in those projects as a result of this change.  