### PR TITLE
job-manager: introduce config callback

### DIFF
--- a/doc/man5/flux-config-job-manager.rst
+++ b/doc/man5/flux-config-job-manager.rst
@@ -13,7 +13,7 @@ table, which may contain the following keys:
 KEYS
 ====
 
-events_maxlen
+journal-size-limit
    (optional) Integer value that determines the maximum number of job events to
    be retained in the in-memory journal used to answer queries.  The default
    is 1000.
@@ -53,7 +53,7 @@ EXAMPLE
 
    [job-manager]
 
-   events_maxlen = 10000
+   journal-size-limit = 10000
 
    plugins = [
       {

--- a/src/modules/job-manager/Makefile.am
+++ b/src/modules/job-manager/Makefile.am
@@ -30,6 +30,8 @@ job_manager_la_SOURCES = \
 libjob_manager_la_SOURCES = \
 	job.c \
 	job.h \
+	conf.c \
+	conf.h \
 	submit.c \
 	submit.h \
 	drain.c \

--- a/src/modules/job-manager/conf.c
+++ b/src/modules/job-manager/conf.c
@@ -1,0 +1,177 @@
+/************************************************************\
+ * Copyright 2022 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* conf.c - handle job manager configuration
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/core.h>
+
+#include "src/common/libutil/fsd.h"
+#include "src/common/libutil/errprintf.h"
+
+#include "job-manager.h"
+#include "journal.h"
+#include "conf.h"
+
+struct conf_callback {
+    conf_update_f cb;
+    void *arg;
+};
+
+struct conf {
+    zlistx_t *callbacks;
+    flux_msg_handler_t **handlers;
+    struct job_manager *ctx;
+};
+
+static void conf_callback_destroy (struct conf_callback *ccb)
+{
+    if (ccb) {
+        int saved_errno = errno;
+        free (ccb);
+        errno = saved_errno;
+    }
+}
+
+// zlistx_destructor_fn signature
+static void conf_callback_destructor (void **item)
+{
+    if (item) {
+        conf_callback_destroy (*item);
+        *item = NULL;
+    }
+}
+
+static struct conf_callback *conf_callback_create (conf_update_f cb, void *arg)
+{
+    struct conf_callback *ccb;
+
+    if (!(ccb = calloc (1, sizeof (*ccb))))
+        return NULL;
+    ccb->cb = cb;
+    ccb->arg = arg;
+    return ccb;
+}
+
+void conf_unregister_callback (struct conf *conf, conf_update_f cb)
+{
+    struct conf_callback *ccb;
+
+    ccb = zlistx_first (conf->callbacks);
+    while (ccb) {
+        if (ccb->cb == cb) {
+            zlistx_delete (conf->callbacks, zlistx_cursor (conf->callbacks));
+            break;
+        }
+        ccb = zlistx_next (conf->callbacks);
+    }
+}
+
+int conf_register_callback (struct conf *conf,
+                            flux_error_t *error,
+                            conf_update_f cb,
+                            void *arg)
+{
+    struct conf_callback *ccb;
+    int rc;
+
+    rc = cb (flux_get_conf (conf->ctx->h), error, arg);
+
+    if (rc < 0) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (rc == 1) {
+        if (!(ccb = conf_callback_create (cb, arg))
+            || zlistx_add_end (conf->callbacks, ccb) == NULL) {
+            conf_callback_destroy (ccb);
+            errprintf (error, "out of memory adding config callback");
+            errno = ENOMEM;
+            return -1;
+        }
+    }
+    return 0;
+}
+
+static void config_reload_cb (flux_t *h,
+                              flux_msg_handler_t *mh,
+                              const flux_msg_t *msg,
+                              void *arg)
+{
+    struct conf *conf = arg;
+    const flux_conf_t *instance_conf;
+    struct conf_callback *ccb;
+    flux_error_t error;
+    const char *errstr = NULL;
+
+    if (flux_conf_reload_decode (msg, &instance_conf) < 0)
+        goto error;
+    ccb = zlistx_first (conf->callbacks);
+    while (ccb) {
+        if (ccb->cb (instance_conf, &error, ccb->arg) < 0) {
+            errstr = error.text;
+            errno = EINVAL;
+            goto error;
+        }
+        ccb = zlistx_next (conf->callbacks);
+    }
+    if (flux_set_conf (h, flux_conf_incref (instance_conf)) < 0) {
+        errstr = "error updating cached configuration";
+        flux_conf_decref (instance_conf);
+        goto error;
+    }
+    if (flux_respond (h, msg, NULL) < 0)
+        flux_log_error (h, "error responding to config-reload request");
+    return;
+error:
+    if (flux_respond_error (h, msg, errno, errstr) < 0)
+        flux_log_error (h, "error responding to config-reload request");
+}
+
+static const struct flux_msg_handler_spec htab[] = {
+    { FLUX_MSGTYPE_REQUEST, "job-manager.config-reload", config_reload_cb, 0 },
+    FLUX_MSGHANDLER_TABLE_END,
+};
+
+void conf_destroy (struct conf *conf)
+{
+    if (conf) {
+        int saved_errno = errno;
+        flux_msg_handler_delvec (conf->handlers);
+        zlistx_destroy (&conf->callbacks);
+        free (conf);
+        errno = saved_errno;
+    }
+}
+
+struct conf *conf_create (struct job_manager *ctx)
+{
+    struct conf *conf;
+
+    if (!(conf = calloc (1, sizeof (*conf))))
+        return NULL;
+    conf->ctx = ctx;
+    if (!(conf->callbacks = zlistx_new ())) {
+        errno = ENOMEM;
+        goto error;
+    }
+    zlistx_set_destructor (conf->callbacks, conf_callback_destructor);
+    if (flux_msg_handler_addvec (ctx->h, htab, conf, &conf->handlers) < 0)
+        goto error;
+    return conf;
+error:
+    conf_destroy (conf);
+    return NULL;
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/src/modules/job-manager/conf.h
+++ b/src/modules/job-manager/conf.h
@@ -1,0 +1,42 @@
+/************************************************************\
+ * Copyright 2022 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _FLUX_JOB_MANAGER_CONF_H
+#define _FLUX_JOB_MANAGER_CONF_H
+
+#include <stdbool.h>
+#include <flux/core.h>
+
+#include "job-manager.h"
+
+/* Return value:
+ *   0=success, one-shot
+ *  -1=falure (set 'error' but not errno)
+ *   1=success, continue to invoke callback on config updates
+ */
+typedef int (*conf_update_f)(const flux_conf_t *conf,
+                             flux_error_t *error,
+                             void *arg);
+
+struct conf *conf_create (struct job_manager *ctx);
+void conf_destroy (struct conf *conf);
+
+/* Immediately call 'cb' on current config object, and then on config updates
+ * as indicated by initial callback's return value (see above).
+ */
+int conf_register_callback (struct conf *conf,
+                            flux_error_t *error,
+                            conf_update_f cb,
+                            void *arg);
+void conf_unregister_callback (struct conf *conf, conf_update_f cb);
+
+#endif /* ! _FLUX_JOB_MANAGER_CONF_H */
+
+// vi:ts=4 sw=4 expandtab

--- a/src/modules/job-manager/job-manager.h
+++ b/src/modules/job-manager/job-manager.h
@@ -19,6 +19,7 @@ struct job_manager {
     zhashx_t *active_jobs;
     int running_jobs; // count of jobs in RUN | CLEANUP state
     flux_jobid_t max_jobid; // largest jobid allocated thus far
+    struct conf *conf;
     struct start *start;
     struct alloc *alloc;
     struct event *event;

--- a/t/t2210-job-manager-events-journal.t
+++ b/t/t2210-job-manager-events-journal.t
@@ -291,4 +291,20 @@ test_expect_success HAVE_JQ 'job-manager: events-journal request fails if deny n
 	grep "deny should be an object" cc3.err
 '
 
+test_expect_success 'job-manager: journal-size-limit can be reconfigured' '
+	cat >job-manager.toml <<-EOF &&
+	[job-manager]
+	journal-size-limit = 10
+	EOF
+	flux config reload
+'
+
+test_expect_success 'job-manager: journal-size-limit must be an integer' '
+	cat >job-manager.toml <<-EOF &&
+	[job-manager]
+	journal-size-limit = "not-a-number"
+	EOF
+	test_must_fail flux config reload
+'
+
 test_done

--- a/t/t2210-job-manager-events-journal.t
+++ b/t/t2210-job-manager-events-journal.t
@@ -6,13 +6,13 @@ test_description='Test flux job manager journal service'
 
 export FLUX_CONF_DIR=$(pwd)
 
-# set events_maxlen to something more sensible in testing,
+# set journal-size-limit to something more sensible in testing,
 # otherwise we'll be parsing 100s of entries regularly.  20 is a good
 # number, since it will always cover the prior two jobs that were
 # executed.
 cat >job-manager.toml <<EOF
 [job-manager]
-events_maxlen = 50
+journal-size-limit = 50
 EOF
 
 test_under_flux 4


### PR DESCRIPTION
Problem: the job manager has multiple subsystems that consume the TOML configuration object from the broker, but there is no mechanism for them to receive a callback when the configuration changes (e.g. sys admin calls `flux config reload` or `systemctl reload flux`).

To prepare to support a dynamically configurable purge policy in a future PR, this PR introduces a way for job manager subsystems to register a callback for configuration handling:
```c
/* Return value:
 *   0=success, one-shot
 *  -1=falure (set 'error' but not errno)
 *   1=success, continue to invoke callback on config updates
 */
typedef int (*conf_update_f)(const flux_conf_t *conf,
                             flux_error_t *error,
                             void *arg);
/* Immediately call 'cb' on current config object, and then on config updates
 * as indicated by initial callback's return value (see above).
 */
int conf_register_callback (struct conf *conf,
                            flux_error_t *error,
                            conf_update_f cb,
                            void *arg);
void conf_unregister_callback (struct conf *conf, conf_update_f cb);
```
The two existing users of TOML config are changed to use this.  As a demo the max journal size (renamed from `job-manager.events_maxlen`  to `job-manager.journal-size-limit`) can now be changed on the fly.

This could be generalized for all broker modules, but without a compelling use case elsewhere, I thought it best to hold off doing anything like that for now, minimizing the surface area of the configuration API so it will be easier to fix/replace later.  We can always generalize later if a need arises.