### PR TITLE
fix hang when job with an interactive pty fails early

### DIFF
--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -2098,6 +2098,17 @@ void attach_event_continuation (flux_future_t *f, void *arg)
                          type,
                          severity,
                          note ? note : "");
+
+        /*  If this job has an interactive pty and the pty is not yet attached,
+         *   destroy the pty to avoid a potential hang attempting to connect
+         *   to job pty that will never exist.
+         */
+        if (severity == 0
+            && ctx->pty_client
+            && !flux_pty_client_attached (ctx->pty_client)) {
+            flux_pty_client_destroy (ctx->pty_client);
+            ctx->pty_client = NULL;
+        }
     }
     else if (!strcmp (name, "submit")) {
         if (!(ctx->exec_eventlog_f = flux_job_event_watch (ctx->h,

--- a/src/common/libterminus/client.c
+++ b/src/common/libterminus/client.c
@@ -548,10 +548,8 @@ int flux_pty_client_attach (struct flux_pty_client *c,
             flux_future_destroy (f);
             return -1;
         }
-        /*  No need to reset future `f` here. The fulfilled future will
-         *   immediately invoke pty_server_cb(), which expects a message
-         *   of type=attach from server
-         */
+        pty_client_attached (c);
+        flux_future_reset (f);
     }
     if (flux_future_then (f, -1, pty_server_cb, c) < 0) {
         flux_future_destroy (f);

--- a/src/common/libterminus/client.c
+++ b/src/common/libterminus/client.c
@@ -482,6 +482,11 @@ static void keepalive_cb (flux_reactor_t *r,
     }
 }
 
+bool flux_pty_client_attached (struct flux_pty_client *c)
+{
+    return c && c->attached;
+}
+
 int flux_pty_client_attach (struct flux_pty_client *c,
                             flux_t *h,
                             int rank,

--- a/src/common/libterminus/pty.h
+++ b/src/common/libterminus/pty.h
@@ -163,6 +163,11 @@ int flux_pty_client_attach (struct flux_pty_client *c,
                             int rank,
                             const char *service);
 
+/*  Return true if the pty has completed an attach, i.e. the attach
+ *   request has gotten its first response.
+ */
+bool flux_pty_client_attached (struct flux_pty_client *pty);
+
 /*  Write data out-of-band to remote pty.
  */
 flux_future_t *flux_pty_client_write (struct flux_pty_client *c,

--- a/src/common/libterminus/test/pty.c
+++ b/src/common/libterminus/test/pty.c
@@ -45,6 +45,8 @@ static void test_invalid_args ()
         "flux_pty_name() returns EINVAL with NULL arg");
     ok (flux_pty_attach (NULL) < 0 && errno == EINVAL,
         "flux_pty_attach() returns EINVAL with NULL arg");
+    ok (flux_pty_client_attached (NULL) == false,
+        "flux_pty_client_attached() returns false with NULL arg");
     ok (flux_pty_set_flux (NULL, NULL) < 0 && errno == EINVAL,
         "flux_pty_set_flux() returns EINVAL with NULL args");
     ok (flux_pty_set_flux (pty, NULL) < 0 && errno == EINVAL,
@@ -413,8 +415,14 @@ static void test_client()
     ok (flux_pty_client_notify_exit (c, pty_exit_cb, h) == 0,
         "flux_pty_client_notify_exit");
 
+    ok (flux_pty_client_attached (c) == false,
+        "flux_pty_client_attached is false");
+
     ok (flux_pty_client_attach (c, h, 0, "pty") == 0,
         "flux_pty_client_attach");
+
+    ok (flux_pty_client_attached (c),
+        "flux_pty_client_attached is true after synchronous attach");
 
     f = flux_pty_client_write (c, "foo\r", 4);
     ok (f != NULL,

--- a/t/t2612-job-shell-pty.t
+++ b/t/t2612-job-shell-pty.t
@@ -115,4 +115,9 @@ test_expect_success 'pty: -o pty.interactive and -o pty.capture can be used toge
 test_expect_success 'pty: unsupported -o pty.<opt> generates exception' '
 	test_must_fail flux mini run -o pty.foo hostname
 '
+
+test_expect_success 'pty: no hang when invalid command is run under pty' '
+	test_expect_code 127 run_timeout 15 \
+		flux mini run -o pty.interactive nosuchcommand
+'
 test_done


### PR DESCRIPTION
This PR fixes an issue that can cause `flux job attach` to hang when attaching to an interactive pty and the job gets an exception before the pty client is fully "attached". This occurs specifically when a non-existent command is supplied, for example:
```console
$ flux mini run -o pty.interactive foo
<hang>
```

This PR reworks the `attach_pty()` code so that the attach can be performed asynchronously, and adds an accessor so that the client can query if it is attached yet. When a job exception occurs while the pty is not yet attached, we can avoid the hang by destroying the pty client.

Now the command above no longer hangs:
```console
$ flux mini run -o pty.interactive foo
0.079s: flux-shell[0]: FATAL: task 0 (host eel): start failed: foo: No such file or directory
0.083s: job.exception type=exec severity=0 task 0 (host eel): start failed: foo: No such file or directory
flux-job: task(s) exited with exit code 127
```

Some other minor rework was required to allow the pty attach to occur asynchronously.