### PR TITLE
libutil: support "ms" suffix for Flux Standard Duration

### DIFF
--- a/src/bindings/python/flux/util.py
+++ b/src/bindings/python/flux/util.py
@@ -215,12 +215,12 @@ class CLIMain(object):
 
 
 def parse_fsd(fsd_string):
-    match = re.match(r".*([smhd])$", fsd_string)
+    match = re.match(r"(.*?)(s|m|h|d|ms)$", fsd_string)
     try:
-        value = float(fsd_string[:-1] if match else fsd_string)
+        value = float(match.group(1) if match else fsd_string)
     except:
         raise ValueError("invalid Flux standard duration")
-    unit = match.group(1) if match else "s"
+    unit = match.group(2) if match else "s"
 
     if unit == "m":
         seconds = timedelta(minutes=value).total_seconds()
@@ -228,6 +228,8 @@ def parse_fsd(fsd_string):
         seconds = timedelta(hours=value).total_seconds()
     elif unit == "d":
         seconds = timedelta(days=value).total_seconds()
+    elif unit == "ms":
+        seconds = timedelta(milliseconds=value).total_seconds()
     else:
         seconds = value
     if seconds < 0 or math.isnan(seconds) or math.isinf(seconds):

--- a/src/common/libutil/fsd.c
+++ b/src/common/libutil/fsd.c
@@ -18,6 +18,7 @@
 #include <stdlib.h>
 
 #include "fsd.h"
+#include "src/common/libccan/ccan/str/str.h"
 
 static int is_invalid_duration (double d)
 {
@@ -51,33 +52,22 @@ int fsd_parse_duration (const char *s, double *dp)
     }
     d = strtod (s, &p);
 
-    if (is_invalid_duration (d)) {
+    if (is_invalid_duration (d))
         return -1;
-    }
-
-    if (*p && *(p + 1)) {
-        errno = EINVAL;
-        return -1;
-    }
 
     if (*p != '\0') {
-        unsigned int multiplier = 0;
-        switch (*p) {
-            case 0:
-            case 's':
-                multiplier = 1;
-                break;
-            case 'm':
-                multiplier = 60;
-                break;
-            case 'h':
-                multiplier = 60 * 60;
-                break;
-            case 'd':
-                multiplier = 60 * 60 * 24;
-                break;
-        }
-        if (multiplier == 0) {
+        double multiplier = 0.;
+        if (streq (p, "ms"))
+            multiplier = .001;
+        else if (streq (p, "s"))
+            multiplier = 1;
+        else if (streq (p, "m"))
+            multiplier = 60;
+        else if (streq (p, "h"))
+            multiplier = 60 * 60;
+        else if (streq (p, "d"))
+            multiplier = 60 * 60 * 24;
+        else  {
             errno = EINVAL;
             return -1;
         }

--- a/src/common/libutil/fsd.c
+++ b/src/common/libutil/fsd.c
@@ -86,7 +86,15 @@ int fsd_format_duration_ex (char *buf,
         errno = EINVAL;
         return -1;
     }
-    if (duration < 60.)
+    /*  We'd rather present a result in seconds if possible, since that
+     *  is the base unit of FSD. However, if the duration is very small,
+     *  present in milliseconds since the result will be easier for a
+     *  human to read. E.g. 62.1ms vs 0.0621s, or more importantly
+     *  0.0123ms vs 1.23e-05s.
+     */
+    if (duration < 0.1 && duration != 0.)
+        return snprintf (buf, len, "%.*gms", precision, duration * 1000.);
+    else if (duration < 60.)
         return snprintf (buf, len, "%.*gs", precision, duration);
     else if (duration < 60. * 60.)
         return snprintf (buf, len, "%.*gm", precision, duration / 60.);

--- a/src/common/libutil/test/fsd.c
+++ b/src/common/libutil/test/fsd.c
@@ -42,6 +42,10 @@ int main(int argc, char** argv)
         "fsd_parse_duration (0) returns success");
     ok (d == 0., "got d == %g", d);
 
+    ok (fsd_parse_duration ("0ms", &d) == 0,
+        "fsd_parse_duration (0ms) returns success");
+    ok (d == 0., "got d == %g", d);
+
     ok (fsd_parse_duration ("0s", &d) == 0,
         "fsd_parse_duration (0s) returns success");
     ok (d == 0., "got d == %g", d);
@@ -57,6 +61,14 @@ int main(int argc, char** argv)
     ok (fsd_parse_duration ("0d", &d) == 0,
         "fsd_parse_duration (0d) returns success");
     ok (d == 0., "got d == %g", d);
+
+    ok (fsd_parse_duration ("500ms", &d) == 0,
+        "fsd_parse_duration (500ms) returns success");
+    ok (d == 0.5, "got d == %g", d);
+
+    ok (fsd_parse_duration ("0.2ms", &d) == 0,
+        "fsd_parse_duration (0.2ms) returns success");
+    ok (d == 0.0002, "got d == %g", d);
 
     ok (fsd_parse_duration ("0.5", &d) == 0,
         "fsd_parse_duration (0.5) returns success");
@@ -95,7 +107,11 @@ int main(int argc, char** argv)
 
     ok (fsd_format_duration (buf, sizeof (buf), .001),
         "fsd_format_duration (.001) works");
-    is (buf, "0.001s", "returns expected string = %s", buf);
+    is (buf, "1ms", "returns expected string = %s", buf);
+
+    ok (fsd_format_duration (buf, sizeof (buf), 0.01),
+        "fsd_format_duration (0.5) works");
+    is (buf, "10ms", "returns expected string = %s", buf);
 
     ok (fsd_format_duration (buf, sizeof (buf), 5.),
         "fsd_format_duration (5.0) works");

--- a/t/python/t0024-util.py
+++ b/t/python/t0024-util.py
@@ -40,10 +40,16 @@ class TestParseDatetime(unittest.TestCase):
         self.assertEqual(self.parse("+1m"), self.ts + 60)
         self.assertEqual(self.parse("+1.5m"), self.ts + 90)
         self.assertEqual(self.parse("+1h"), self.ts + 3600)
+        self.assertEqual(self.parse("+100ms"), self.ts + 0.1)
+        self.assertEqual(self.parse("+1ms"), self.ts + 0.001)
 
     def test_fsd_invalid(self):
         with self.assertRaises(ValueError):
-            self.parse("+1ms")
+            self.parse("+1ns")
+        with self.assertRaises(ValueError):
+            self.parse("+1x")
+        with self.assertRaises(ValueError):
+            self.parse("+x")
         with self.assertRaises(ValueError):
             self.parse("-")
 


### PR DESCRIPTION
This PR adds support for the `ms` suffix in `fsd_parse_duration(3)` and `fsd_format_duration(3)` now that the changes to [RFC 23](https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/spec_23.html) allowing that suffix have been merged. Mainly this is useful when small durations are printed, e.g. in logs:

before
```
 parent-none: join->init 3.312e-05s
```

after
```
 parent-none: join->init 0.169518ms
```

(Note these were from real examples, so the numbers are not meant to match)

The `ms` suffix may be useful in other situations as well, so it seemed prudent to go ahead and add support for it.