### PR TITLE
job-manager: add inactive job purge capability

### DIFF
--- a/doc/man1/flux-job.rst
+++ b/doc/man1/flux-job.rst
@@ -20,6 +20,8 @@ SYNOPSIS
 
 **flux** **job** **raiseall** [*OPTIONS*] *type* [*message...*]
 
+**flux** **job** **purge** [*OPTIONS*]
+
 DESCRIPTION
 ===========
 
@@ -89,6 +91,25 @@ type (positional argument) and accepts the following options:
 
 **-f, --force**
    Confirm the command.
+
+PURGE
+=====
+
+Inactive job data may be purged from the Flux instance with ``flux job purge``.
+The following options may be used to add selection criteria:
+
+**--age-limit=FSD**
+   Purge inactive jobs older than the specified Flux Standard Duration.
+
+**--num-limit=COUNT**
+   Purge the oldest inactive jobs until there are at most COUNT left.
+
+**-f, --force**
+   Confirm the command.
+
+Inactive jobs may also be purged automatically if the job manager is
+configured as described in :man5:`flux-config-job-manager`.
+
 
 RESOURCES
 =========

--- a/doc/man5/flux-config-job-manager.rst
+++ b/doc/man5/flux-config-job-manager.rst
@@ -18,6 +18,16 @@ journal-size-limit
    be retained in the in-memory journal used to answer queries.  The default
    is 1000.
 
+inactive-age-limit
+   (optional) String (in RFC 23 Flux Standard Duration format) that specifies
+   the maximum age of inactive jobs retained in the KVS.  The age is computed
+   since the job became inactive.  Once a job is removed from the KVS, its job
+   data is only available via the job-archive, if configured.  Inactive jobs
+   can also be manually purged with :man1:`flux-job` ``purge``.
+
+inactive-num-limit
+   (optional) Integer maximum number of inactive jobs retained in the KVS.
+
 plugins
    (optional) An array of objects defining a list of jobtap plugin directives.
    Each directive follows the format defined in the :ref:`plugin_directive`
@@ -54,6 +64,9 @@ EXAMPLE
    [job-manager]
 
    journal-size-limit = 10000
+
+   inactive-age-limit = "7d"
+   inactive-num-limit = 10000
 
    plugins = [
       {

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -622,3 +622,4 @@ ustar
 xz
 validator
 statedir
+num

--- a/src/modules/job-list/job-list.c
+++ b/src/modules/job-list/job-list.c
@@ -82,6 +82,7 @@ static void purge_cb (flux_t *h,
         struct job *job;
 
         if ((job = zhashx_lookup (ctx->jsctx->index, &id))) {
+            job_stats_purge (&ctx->jsctx->stats, job);
             if (job->list_handle)
                 zlistx_delete (ctx->jsctx->inactive, job->list_handle);
             zhashx_delete (ctx->jsctx->index, &id);

--- a/src/modules/job-list/stats.c
+++ b/src/modules/job-list/stats.c
@@ -59,6 +59,25 @@ void job_stats_update (struct job_stats *stats,
     }
 }
 
+/* An inactive job is being purged, so statistics must be updated.
+ */
+void job_stats_purge (struct job_stats *stats, struct job *job)
+{
+    assert (job->state == FLUX_JOB_STATE_INACTIVE);
+
+    stats->state_count[state_index(job->state)]--;
+
+    if (!job->success) {
+        stats->failed--;
+        if (job->exception_occurred) {
+            if (strcmp (job->exception_type, "cancel") == 0)
+                stats->canceled--;
+            else if (strcmp (job->exception_type, "timeout") == 0)
+                stats->timeout--;
+        }
+    }
+}
+
 static int object_set_integer (json_t *o,
                                const char *key,
                                unsigned int n)

--- a/src/modules/job-list/stats.h
+++ b/src/modules/job-list/stats.h
@@ -28,6 +28,8 @@ void job_stats_update (struct job_stats *stats,
                        struct job *job,
                        flux_job_state_t newstate);
 
+void job_stats_purge (struct job_stats *stats, struct job *job);
+
 json_t * job_stats_encode (struct job_stats *stats);
 
 #endif /* ! _FLUX_JOB_LIST_JOB_STATS_H */

--- a/src/modules/job-manager/Makefile.am
+++ b/src/modules/job-manager/Makefile.am
@@ -52,6 +52,8 @@ libjob_manager_la_SOURCES = \
 	start.c \
 	list.h \
 	list.c \
+	purge.h \
+	purge.c \
 	urgency.h \
 	urgency.c \
 	annotate.h \

--- a/src/modules/job-manager/alloc.c
+++ b/src/modules/job-manager/alloc.c
@@ -649,7 +649,7 @@ int alloc_queue_recalc_pending (struct alloc *alloc)
     while (alloc->alloc_limit
            && head
            && tail) {
-        if (job_comparator (head, tail) < 0) {
+        if (job_priority_comparator (head, tail) < 0) {
             if (alloc_cancel_alloc_request (alloc, tail) < 0) {
                 flux_log_error (alloc->ctx->h, "%s: alloc_cancel_alloc_request",
                                 __FUNCTION__);
@@ -845,13 +845,13 @@ struct alloc *alloc_ctx_create (struct job_manager *ctx)
     if (!(alloc->queue = zlistx_new()))
         goto error;
     zlistx_set_destructor (alloc->queue, job_destructor);
-    zlistx_set_comparator (alloc->queue, job_comparator);
+    zlistx_set_comparator (alloc->queue, job_priority_comparator);
     zlistx_set_duplicator (alloc->queue, job_duplicator);
 
     if (!(alloc->pending_jobs = zlistx_new()))
         goto error;
     zlistx_set_destructor (alloc->pending_jobs, job_destructor);
-    zlistx_set_comparator (alloc->pending_jobs, job_comparator);
+    zlistx_set_comparator (alloc->pending_jobs, job_priority_comparator);
     zlistx_set_duplicator (alloc->pending_jobs, job_duplicator);
 
     if (flux_msg_handler_addvec (ctx->h, htab, ctx, &alloc->handlers) < 0)

--- a/src/modules/job-manager/annotate.c
+++ b/src/modules/job-manager/annotate.c
@@ -149,7 +149,10 @@ void annotate_memo_request (flux_t *h,
         || flux_msg_get_cred (msg, &cred) < 0)
         goto error;
     if (!(job = zhashx_lookup (ctx->active_jobs, &id))) {
-        errstr = "unknown job id";
+        if (!(job = zhashx_lookup (ctx->inactive_jobs, &id)))
+            errstr = "unknown job id";
+        else
+            errstr = "job is inactive";
         errno = ENOENT;
         goto error;
     }

--- a/src/modules/job-manager/event.c
+++ b/src/modules/job-manager/event.c
@@ -51,6 +51,7 @@
 #include "wait.h"
 #include "prioritize.h"
 #include "annotate.h"
+#include "purge.h"
 #include "jobtap-internal.h"
 
 #include "event.h"
@@ -392,7 +393,8 @@ int event_job_action (struct event *event, struct job *job)
         case FLUX_JOB_STATE_INACTIVE:
             if ((job->flags & FLUX_JOB_WAITABLE))
                 wait_notify_inactive (ctx->wait, job);
-            if (zhashx_insert (ctx->inactive_jobs, &job->id, job) < 0) {
+            if (zhashx_insert (ctx->inactive_jobs, &job->id, job) < 0
+                || purge_enqueue_job (ctx->purge, job) < 0) {
                 flux_log_error (event->ctx->h,
                                 "%ju: error preserving inactive job",
                                 (uintmax_t) job->id);

--- a/src/modules/job-manager/event.c
+++ b/src/modules/job-manager/event.c
@@ -670,6 +670,7 @@ int event_job_update (struct job *job, json_t *event)
         if (job->state != FLUX_JOB_STATE_CLEANUP)
             goto inval;
         job->state = FLUX_JOB_STATE_INACTIVE;
+        job->t_clean = timestamp;
     }
     else if (!strncmp (name, "prolog-", 7)) {
         if (job->start_pending)

--- a/src/modules/job-manager/event.c
+++ b/src/modules/job-manager/event.c
@@ -392,6 +392,11 @@ int event_job_action (struct event *event, struct job *job)
         case FLUX_JOB_STATE_INACTIVE:
             if ((job->flags & FLUX_JOB_WAITABLE))
                 wait_notify_inactive (ctx->wait, job);
+            if (zhashx_insert (ctx->inactive_jobs, &job->id, job) < 0) {
+                flux_log_error (event->ctx->h,
+                                "%ju: error preserving inactive job",
+                                (uintmax_t) job->id);
+            }
             zhashx_delete (ctx->active_jobs, &job->id);
             drain_check (ctx->drain);
             break;

--- a/src/modules/job-manager/getattr.c
+++ b/src/modules/job-manager/getattr.c
@@ -96,7 +96,8 @@ void getattr_handle_request (flux_t *h,
                              "attrs", &attrs) < 0
                     || flux_msg_get_cred (msg, &cred) < 0)
         goto error;
-    if (!(job = zhashx_lookup (ctx->active_jobs, &id))) {
+    if (!(job = zhashx_lookup (ctx->active_jobs, &id))
+        && !(job = zhashx_lookup (ctx->inactive_jobs, &id))) {
         errstr = "unknown job";
         errno = EINVAL;
         goto error;

--- a/src/modules/job-manager/job-manager.c
+++ b/src/modules/job-manager/job-manager.c
@@ -144,12 +144,15 @@ int mod_main (flux_t *h, int argc, char **argv)
     memset (&ctx, 0, sizeof (ctx));
     ctx.h = h;
 
-    if (!(ctx.active_jobs = job_hash_create ())) {
-        flux_log_error (h, "error creating active_jobs hash");
+    if (!(ctx.active_jobs = job_hash_create ())
+        || !(ctx.inactive_jobs = job_hash_create ())) {
+        flux_log_error (h, "error creating jobs hash");
         goto done;
     }
     zhashx_set_destructor (ctx.active_jobs, job_destructor);
     zhashx_set_duplicator (ctx.active_jobs, job_duplicator);
+    zhashx_set_destructor (ctx.inactive_jobs, job_destructor);
+    zhashx_set_duplicator (ctx.inactive_jobs, job_duplicator);
     if (!(ctx.conf = conf_create (&ctx))) {
         flux_log_error (h, "error creating conf context");
         goto done;
@@ -230,6 +233,7 @@ done:
     jobtap_destroy (ctx.jobtap);
     conf_destroy (ctx.conf);
     zhashx_destroy (&ctx.active_jobs);
+    zhashx_destroy (&ctx.inactive_jobs);
     return rc;
 }
 

--- a/src/modules/job-manager/job-manager.c
+++ b/src/modules/job-manager/job-manager.c
@@ -29,6 +29,7 @@
 #include "event.h"
 #include "drain.h"
 #include "wait.h"
+#include "purge.h"
 #include "annotate.h"
 #include "journal.h"
 #include "getattr.h"
@@ -160,6 +161,10 @@ int mod_main (flux_t *h, int argc, char **argv)
         flux_log_error (h, "error creating conf context");
         goto done;
     }
+    if (!(ctx.purge = purge_create (&ctx))) {
+        flux_log_error (h, "error creating purge context");
+        goto done;
+    }
     if (!(ctx.event = event_ctx_create (&ctx))) {
         flux_log_error (h, "error creating event batcher");
         goto done;
@@ -223,6 +228,7 @@ int mod_main (flux_t *h, int argc, char **argv)
     rc = 0;
 done:
     flux_msg_handler_delvec (ctx.handlers);
+    purge_destroy (ctx.purge);
     journal_ctx_destroy (ctx.journal);
     annotate_ctx_destroy (ctx.annotate);
     kill_ctx_destroy (ctx.kill);

--- a/src/modules/job-manager/job-manager.c
+++ b/src/modules/job-manager/job-manager.c
@@ -75,9 +75,12 @@ static void stats_cb (flux_t *h, flux_msg_handler_t *mh,
 {
     struct job_manager *ctx = arg;
     int journal_listeners = journal_listeners_count (ctx->journal);
-    if (flux_respond_pack (h, msg, "{s:{s:i}}",
+    if (flux_respond_pack (h, msg, "{s:{s:i} s:i s:i}",
                            "journal",
-                             "listeners", journal_listeners) < 0) {
+                             "listeners", journal_listeners,
+                           "active_jobs", zhashx_size (ctx->active_jobs),
+                           "inactive_jobs", zhashx_size (ctx->inactive_jobs)
+                           ) < 0) {
         flux_log_error (h, "%s: flux_respond_pack", __FUNCTION__);
         goto error;
     }

--- a/src/modules/job-manager/job-manager.h
+++ b/src/modules/job-manager/job-manager.h
@@ -31,6 +31,7 @@ struct job_manager {
     struct kill *kill;
     struct annotate *annotate;
     struct journal *journal;
+    struct purge *purge;
     struct jobtap *jobtap;
 };
 

--- a/src/modules/job-manager/job-manager.h
+++ b/src/modules/job-manager/job-manager.h
@@ -17,6 +17,7 @@ struct job_manager {
     flux_t *h;
     flux_msg_handler_t **handlers;
     zhashx_t *active_jobs;
+    zhashx_t *inactive_jobs;
     int running_jobs; // count of jobs in RUN | CLEANUP state
     flux_jobid_t max_jobid; // largest jobid allocated thus far
     struct conf *conf;

--- a/src/modules/job-manager/job.c
+++ b/src/modules/job-manager/job.c
@@ -237,6 +237,16 @@ int job_priority_comparator (const void *a1, const void *a2)
     return rc;
 }
 
+/* Compare inactive jobs, ordering by the time they became inactive.
+ * N.B. zlistx_comparator_fn signature
+ */
+int job_age_comparator (const void *a1, const void *a2)
+{
+    const struct job *j1 = a1;
+    const struct job *j2 = a2;
+
+    return NUMCMP (j1->t_clean, j2->t_clean);
+}
 
 /*  This structure is stashed in a plugin which has subscribed to
  *   job events. The reference to the plugin itself is required so

--- a/src/modules/job-manager/job.c
+++ b/src/modules/job-manager/job.c
@@ -226,7 +226,7 @@ void *job_duplicator (const void *item)
 /* Compare jobs, ordering by (1) priority, (2) job id.
  * N.B. zlistx_comparator_fn signature
  */
-int job_comparator (const void *a1, const void *a2)
+int job_priority_comparator (const void *a1, const void *a2)
 {
     const struct job *j1 = a1;
     const struct job *j2 = a2;

--- a/src/modules/job-manager/job.h
+++ b/src/modules/job-manager/job.h
@@ -77,10 +77,12 @@ void job_aux_delete (struct job *job, const void *val);
 
 /* Helpers for maintaining czmq containers of 'struct job'.
  * job_priority_comparator sorts by (1) priority, then (2) jobid.
+ * job_age_comparator sorts by the time the job became inactive.
  */
 void job_destructor (void **item);
 void *job_duplicator (const void *item);
 int job_priority_comparator (const void *a1, const void *a2);
+int job_age_comparator (const void *a1, const void *a2);
 
 /*  Add and remove job dependencies
  */

--- a/src/modules/job-manager/job.h
+++ b/src/modules/job-manager/job.h
@@ -32,6 +32,7 @@ struct job {
     flux_job_state_t state;
     json_t *end_event;      // event that caused transition to CLEANUP state
     const flux_msg_t *waiter; // flux_job_wait() request
+    double t_clean;
 
     uint8_t depend_posted:1;// depend event already posted
     uint8_t alloc_queued:1; // queued for alloc, but alloc request not sent

--- a/src/modules/job-manager/job.h
+++ b/src/modules/job-manager/job.h
@@ -76,11 +76,11 @@ void *job_aux_get (struct job *job, const char *name);
 void job_aux_delete (struct job *job, const void *val);
 
 /* Helpers for maintaining czmq containers of 'struct job'.
- * The comparator sorts by (1) priority, then (2) jobid.
+ * job_priority_comparator sorts by (1) priority, then (2) jobid.
  */
 void job_destructor (void **item);
 void *job_duplicator (const void *item);
-int job_comparator (const void *a1, const void *a2);
+int job_priority_comparator (const void *a1, const void *a2);
 
 /*  Add and remove job dependencies
  */

--- a/src/modules/job-manager/kill.c
+++ b/src/modules/job-manager/kill.c
@@ -84,7 +84,10 @@ void kill_handle_request (flux_t *h,
         goto error;
     }
     if (!(job = zhashx_lookup (ctx->active_jobs, &id))) {
-        errstr = "unknown job id";
+        if (!(job = zhashx_lookup (ctx->inactive_jobs, &id)))
+            errstr = "unknown job id";
+        else
+            errstr = "job is inactive";
         errno = EINVAL;
         goto error;
     }

--- a/src/modules/job-manager/purge.c
+++ b/src/modules/job-manager/purge.c
@@ -1,0 +1,431 @@
+/************************************************************\
+ * Copyright 2022 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* purge.c - remove old inactive jobs
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/core.h>
+#include <assert.h>
+
+#include "src/common/libutil/errprintf.h"
+#include "src/common/libutil/fsd.h"
+#include "src/common/libutil/errprintf.h"
+#include "src/common/libccan/ccan/ptrint/ptrint.h"
+
+#include "job-manager.h"
+#include "job.h"
+#include "purge.h"
+#include "conf.h"
+
+#define INACTIVE_NUM_UNLIMITED  (-1)
+#define INACTIVE_AGE_UNLIMITED  (-1.)
+
+struct purge {
+    struct job_manager *ctx;
+    double age_limit;
+    int num_limit;
+    zlistx_t *queue;
+    flux_future_t *f_sync;
+    flux_future_t *f_purge;
+
+    flux_msg_handler_t **handlers;
+    struct flux_msglist *requests;
+};
+
+static const int purge_batch_max = 100; // max KVS ops per txn
+
+/* Add an inactive job to the "purge queue".
+ * The queue is ordered by the time the job became inactive, so
+ * the first job in the queue is the oldest.
+ */
+int purge_enqueue_job (struct purge *purge, struct job *job)
+{
+    assert (job->handle == NULL);
+    if (!(job->handle = zlistx_insert (purge->queue, job, false))) {
+        errno = ENOMEM;
+        return -1;
+    }
+    return 0;
+}
+
+/* Return true if candidate job is eligible for purging based on
+ * provided limits.  A job is purgeable if either limit is exceeded.
+ */
+static bool purge_eligible (double age,
+                            double age_limit,
+                            int num,
+                            int num_limit)
+{
+    if (age_limit != INACTIVE_AGE_UNLIMITED && age > age_limit)
+        return true;
+    if (num_limit != INACTIVE_NUM_UNLIMITED && num > num_limit)
+        return true;
+    return false;
+}
+
+static int purge_eligible_count (struct purge *purge,
+                                 double age_limit,
+                                 int num_limit)
+{
+    double now = flux_reactor_now (flux_get_reactor (purge->ctx->h));
+    struct job *job;
+    int count = 0;
+
+    job = zlistx_first (purge->queue);
+    while (job) {
+        if (!purge_eligible (now - job->t_clean,
+                             age_limit,
+                             zlistx_size (purge->queue) - count,
+                             num_limit))
+            break;
+        count++;
+        job = zlistx_next (purge->queue);
+    }
+    return count;
+}
+
+/* Send a KVS commit containing unlinks for one or more inactive jobs.
+ * Return future if successful, with 'count' added to aux hash.
+ * Return NULL on failure with errno set.
+ * N.B. Failure with errno=ENODATA just means there were no eligible jobs.
+ */
+static flux_future_t *purge_inactive_jobs (struct purge *purge,
+                                           double age_limit,
+                                           int num_limit,
+                                           int max_purge_count)
+{
+    double now = flux_reactor_now (flux_get_reactor (purge->ctx->h));
+    struct job *job;
+    flux_kvs_txn_t *txn;
+    char key[64];
+    flux_future_t *f = NULL;
+    int count = 0;
+
+    if (!(txn = flux_kvs_txn_create ()))
+        return NULL;
+    while ((job = zlistx_first (purge->queue)) && count < max_purge_count) {
+        if (!purge_eligible (now - job->t_clean,
+                             age_limit,
+                             zlistx_size (purge->queue),
+                             num_limit))
+            break;
+        if (flux_job_kvs_key (key, sizeof (key), job->id, NULL) < 0
+            || flux_kvs_txn_unlink (txn, 0, key) < 0)
+            goto error;
+        (void)zlistx_delete (purge->queue, job->handle);
+        job->handle = NULL;
+        zhashx_delete (purge->ctx->inactive_jobs, &job->id);
+        count++;
+    }
+    if (count == 0) {
+        errno = ENODATA;
+        goto error;
+    }
+    if (!(f = flux_kvs_commit (purge->ctx->h, NULL, 0, txn))
+        || flux_future_aux_set (f, "count", int2ptr (count), NULL) < 0)
+        goto error;
+    flux_kvs_txn_destroy (txn);
+    /* N.B. if kvs commit fails, jobs are still removed from the hash/list.
+     * It doesn't seem worth the effort to structure the code to avoid this
+     * due to high complexity of solution, low probability of error, and
+     * minor consequences.
+     */
+    return f;
+error:
+    flux_kvs_txn_destroy (txn);
+    flux_future_destroy (f);
+    return NULL;
+}
+
+/* Complete periodic purge.
+ */
+static void purge_continuation (flux_future_t *f, void *arg)
+{
+    flux_t *h = flux_future_get_flux (f);
+    struct purge *purge = arg;
+    int count = ptr2int (flux_future_aux_get (f, "count"));
+
+    if (flux_rpc_get (f, NULL) < 0) {
+        flux_log (h,
+                  LOG_ERR,
+                  "error committing purge KVS transaction: %s",
+                  future_strerror (f, errno));
+        goto done;
+    }
+    flux_log (h, LOG_DEBUG, "purged %d inactive jobs", count);
+done:
+    if (purge->f_purge == f)
+        purge->f_purge = NULL;
+    flux_future_destroy (f);
+}
+
+/* Periodically check for inactive jobs that meet purge criteria, if
+ * criteria are configured.  If not configured, this callback is not enabled.
+ */
+static void sync_cb (flux_future_t *f_sync, void *arg)
+{
+    flux_t *h = flux_future_get_flux (f_sync);
+    struct purge *purge = arg;
+
+    if (flux_future_get (f_sync, NULL) < 0) {
+        flux_log (h,
+                  LOG_ERR,
+                  "purge synchronization error: %s",
+                  future_strerror (f_sync, errno));
+    }
+    if (!(purge->f_purge)) {
+        flux_future_t *f;
+        if (!(f = purge_inactive_jobs (purge,
+                                       purge->age_limit,
+                                       purge->num_limit,
+                                       purge_batch_max))
+            || flux_future_then (f, -1, purge_continuation, purge) < 0) {
+            flux_future_destroy (f);
+            if (errno != ENODATA)
+                flux_log_error (h, "error creating purge KVS transaction");
+            goto done;
+        }
+        purge->f_purge = f;
+    }
+done:
+    flux_future_reset (f_sync);
+}
+
+/* Start or stop heartbeat driven sync callback after configuration change.
+ */
+int purge_sync_update (struct purge *purge)
+{
+    if (purge->age_limit != INACTIVE_AGE_UNLIMITED
+        || purge->num_limit != INACTIVE_NUM_UNLIMITED) {
+        if (!purge->f_sync) {
+            if (!(purge->f_sync = flux_sync_create (purge->ctx->h, 0.))
+                || flux_future_then (purge->f_sync, -1, sync_cb, purge) < 0) {
+                flux_future_destroy (purge->f_sync);
+                purge->f_sync = NULL;
+                return -1;
+            }
+        }
+    }
+    else {
+        if (purge->f_sync) {
+            flux_future_destroy (purge->f_sync);
+            purge->f_sync = NULL;
+        }
+    }
+    return 0;
+}
+
+/* Locate the message containing 'f'.
+ * Side effect: cursor is parked on this message, so flux_msglist_delete()
+ * can be used to delete it later.
+ */
+static const flux_msg_t *find_request (struct flux_msglist *l, flux_future_t *f)
+{
+    const flux_msg_t *msg;
+
+    msg = flux_msglist_first (l);
+    while (msg) {
+        if (flux_msg_aux_get (msg, "future") == f)
+            return msg;
+        msg = flux_msglist_next (l);
+    }
+    return NULL;
+}
+
+static void purge_request_continuation (flux_future_t *f, void *arg)
+{
+    flux_t *h = flux_future_get_flux (f);
+    struct purge *purge = arg;
+    int count = ptr2int (flux_future_aux_get (f, "count"));
+    const flux_msg_t *msg = find_request (purge->requests, f);
+
+    assert (msg != NULL);
+    if (flux_rpc_get (f, NULL) < 0) {
+        if (flux_respond_error (h, msg, errno, future_strerror (f, errno)) < 0)
+            flux_log_error (h, "error responding to purge request");
+        goto done;
+    }
+    if (flux_respond_pack (h, msg, "{s:i}", "count", count) < 0)
+        flux_log_error (h, "error responding to purge request");
+done:
+    // assumes cursor still positioned from find_request(), and destroys f
+    flux_msglist_delete (purge->requests);
+}
+
+static void purge_request_cb (flux_t *h,
+                              flux_msg_handler_t *mh,
+                              const flux_msg_t *msg,
+                              void *arg)
+{
+    struct purge *purge = arg;
+    double age_limit;
+    int num_limit;
+    int batch;
+    int force;
+    flux_future_t *f;
+    const char *errmsg = NULL;
+    flux_error_t error;
+    int count = 0;
+
+    if (flux_request_unpack (msg,
+                             NULL,
+                             "{s:f s:i s:i s:b}",
+                             "age_limit", &age_limit,
+                             "num_limit", &num_limit,
+                             "batch", &batch,
+                             "force", &force) < 0)
+        goto error;
+    if (age_limit != INACTIVE_AGE_UNLIMITED && age_limit < 0) {
+        errmsg = "if set, age limit must be >= 0";
+        errno = EINVAL;
+        goto error;
+    }
+    if (num_limit != INACTIVE_NUM_UNLIMITED && num_limit < 0) {
+        errmsg = "if set, num limit must be >= 0";
+        errno = EINVAL;
+        goto error;
+    }
+    if (batch < 1 || batch > purge_batch_max) {
+        errprintf (&error, "batch must be >= 1 and <= %d", purge_batch_max);
+        errmsg = error.text;
+        errno = EINVAL;
+        goto error;
+    }
+    if (!force) { // just return count
+        count = purge_eligible_count (purge, age_limit, num_limit);
+        goto done;
+    }
+    if (!(f = purge_inactive_jobs (purge,
+                                   age_limit,
+                                   num_limit,
+                                   batch))
+        || flux_future_then (f, -1, purge_request_continuation, purge) < 0) {
+        flux_future_destroy (f);
+        if (errno == ENODATA) // ENODATA means zero jobs can be purged
+            goto done;
+        goto error;
+    }
+    if (flux_msg_aux_set (msg,
+                          "future",
+                          f,
+                          (flux_free_f)flux_future_destroy) < 0) {
+        flux_future_destroy (f);
+        goto error;
+    }
+    if (flux_msglist_append (purge->requests, msg) < 0)
+        goto error; // future destroyed with msg by dispatcher
+    return;
+done:
+    if (flux_respond_pack (h, msg, "{s:i}", "count", count) < 0)
+        flux_log_error (h, "error responding to purge request");
+    return;
+error:
+    if (flux_respond_error (h, msg, errno, errmsg) < 0)
+        flux_log_error (h, "error responding to purge request");
+}
+
+static int purge_parse_config (const flux_conf_t *conf,
+                               flux_error_t *error,
+                               void *arg)
+{
+    struct purge *purge = arg;
+    flux_error_t e;
+    const char *fsd = NULL;
+    double age_limit = INACTIVE_AGE_UNLIMITED;
+    int num_limit = INACTIVE_NUM_UNLIMITED;
+
+    if (flux_conf_unpack (conf,
+                          &e,
+                          "{s?{s?s s?i}}",
+                          "job-manager",
+                            "inactive-age-limit", &fsd,
+                            "inactive-num-limit", &num_limit) < 0)
+        return errprintf (error, "job-manager.max-inactive-*: %s", e.text);
+    if (fsd) {
+        double t;
+        if (fsd_parse_duration (fsd, &t) < 0)
+            return errprintf (error,
+                              "job-manager.inactive-age-limit: invalid FSD");
+        age_limit = t;
+    }
+    if (num_limit != INACTIVE_NUM_UNLIMITED) {
+        if (num_limit < 0)
+            return errprintf (error,
+                              "job-manager.inactive-num-limit: must be >= 0");
+    }
+    purge->age_limit = age_limit;
+    purge->num_limit = num_limit;
+
+    if (purge_sync_update (purge) < 0)
+        flux_log_error (purge->ctx->h, "could not start purge sync callbacks");
+    return 1; // indicates to conf.c that callback wants updates
+}
+
+static const struct flux_msg_handler_spec htab[] = {
+    { FLUX_MSGTYPE_REQUEST, "job-manager.purge", purge_request_cb, 0 },
+    FLUX_MSGHANDLER_TABLE_END,
+};
+
+void purge_destroy (struct purge *purge)
+{
+    if (purge) {
+        int saved_errno = errno;
+        flux_msg_handler_delvec (purge->handlers);
+        zlistx_destroy (&purge->queue);
+        flux_msglist_destroy (purge->requests);
+        conf_unregister_callback (purge->ctx->conf, purge_parse_config);
+        flux_future_destroy (purge->f_sync);
+        flux_future_destroy (purge->f_purge);
+        free (purge);
+        errno = saved_errno;
+    }
+}
+
+struct purge *purge_create (struct job_manager *ctx)
+{
+    struct purge *purge;
+    flux_error_t error;
+
+    if (!(purge = calloc (1, sizeof (*purge))))
+        return NULL;
+    purge->ctx = ctx;
+    purge->age_limit = INACTIVE_AGE_UNLIMITED;
+    purge->num_limit = INACTIVE_NUM_UNLIMITED;
+
+    if (!(purge->queue = zlistx_new()))
+        goto error;
+    zlistx_set_destructor (purge->queue, job_destructor);
+    zlistx_set_comparator (purge->queue, job_age_comparator);
+    zlistx_set_duplicator (purge->queue, job_duplicator);
+
+    if (conf_register_callback (ctx->conf,
+                                &error,
+                                purge_parse_config,
+                                purge) < 0) {
+        flux_log (ctx->h,
+                  LOG_ERR,
+                  "error parsing job-manager config: %s",
+                  error.text);
+        goto error;
+    }
+    if (flux_msg_handler_addvec (ctx->h, htab, purge, &purge->handlers) < 0)
+        goto error;
+    if (!(purge->requests = flux_msglist_create ()))
+        goto error;
+    return purge;
+error:
+    purge_destroy (purge);
+    return NULL;
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/src/modules/job-manager/purge.h
+++ b/src/modules/job-manager/purge.h
@@ -1,0 +1,26 @@
+/************************************************************\
+ * Copyright 2022 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _FLUX_JOB_MANAGER_PURGE_H
+#define _FLUX_JOB_MANAGER_PURGE_H
+
+#include <stdbool.h>
+#include <flux/core.h>
+
+#include "job-manager.h"
+
+struct purge *purge_create (struct job_manager *ctx);
+void purge_destroy (struct purge *purge);
+
+int purge_enqueue_job (struct purge *purge, struct job *job);
+
+#endif /* ! _FLUX_JOB_MANAGER_PURGE_H */
+
+// vi:ts=4 sw=4 expandtab

--- a/src/modules/job-manager/raise.c
+++ b/src/modules/job-manager/raise.c
@@ -131,7 +131,10 @@ void raise_handle_request (flux_t *h,
         goto error;
     }
     if (!(job = zhashx_lookup (ctx->active_jobs, &id))) {
-        errstr = "unknown job id";
+        if (!(job = zhashx_lookup (ctx->inactive_jobs, &id)))
+            errstr = "unknown job id";
+        else
+            errstr = "job is inactive";
         errno = ENOENT;
         goto error;
     }

--- a/src/modules/job-manager/urgency.c
+++ b/src/modules/job-manager/urgency.c
@@ -63,7 +63,10 @@ void urgency_handle_request (flux_t *h,
         goto error;
     }
     if (!(job = zhashx_lookup (ctx->active_jobs, &id))) {
-        errstr = "unknown job";
+        if (!(job = zhashx_lookup (ctx->inactive_jobs, &id)))
+            errstr = "unknown job";
+        else
+            errstr = "job is inactive";
         errno = EINVAL;
         goto error;
     }

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -186,6 +186,7 @@ TESTSCRIPTS = \
 	t2806-config-cmd.t \
 	t2807-dump-cmd.t \
 	t2808-shutdown-cmd.t \
+	t2809-job-purge.t \
 	t2900-job-timelimits.t \
 	t3000-mpi-basic.t \
 	t3001-mpi-personalities.t \

--- a/t/t2201-job-cmd.t
+++ b/t/t2201-job-cmd.t
@@ -66,7 +66,7 @@ test_expect_success 'flux-job: submit with nonexistent jobpsec fails' '
 '
 
 test_expect_success 'flux-job: submit with bad broker connection fails' '
-	! FLUX_URI=/wrong flux job submit basic.json
+	(FLUX_URI=/wrong test_must_fail flux job submit basic.json)
 '
 
 test_expect_success HAVE_FLUX_SECURITY 'flux-job: submit with bad security config fails' '
@@ -186,7 +186,7 @@ test_expect_success 'flux-job: id fails on bad words input' '
 '
 
 test_expect_success 'flux-job: urgency fails with bad FLUX_URI' '
-	! FLUX_URI=/wrong flux job urgency ${validjob} 0
+	(FLUX_URI=/wrong test_must_fail flux job urgency ${validjob} 0)
 '
 
 test_expect_success 'flux-job: urgency fails with non-numeric jobid' '
@@ -206,7 +206,7 @@ test_expect_success 'job-manager: flux job urgency fails on invalid jobid' '
 '
 
 test_expect_success 'flux-job: raise fails with bad FLUX_URI' '
-	! FLUX_URI=/wrong flux job raise ${validjob}
+	(FLUX_URI=/wrong test_must_fail flux job raise ${validjob})
 '
 
 test_expect_success 'flux-job: raise fails with no args' '
@@ -222,7 +222,7 @@ test_expect_success 'flux-job: raise fails with invalid option' '
 '
 
 test_expect_success 'flux-job: cancel fails with bad FLUX_URI' '
-	! FLUX_URI=/wrong flux job cancel ${validjob}
+	(FLUX_URI=/wrong test_must_fail flux job cancel ${validjob})
 '
 
 test_expect_success 'flux-job: cancel fails with unknown job id' '
@@ -242,7 +242,7 @@ test_expect_success 'flux-job: cancel fails with invalid option' '
 '
 
 test_expect_success 'flux-job: list fails with bad FLUX_URI' '
-	! FLUX_URI=/wrong flux job list
+	(FLUX_URI=/wrong test_must_fail flux job list)
 '
 
 test_expect_success 'flux-job: list fails with wrong number of arguments' '
@@ -345,7 +345,7 @@ test_expect_success 'flux job: killall with no args works' '
 '
 
 test_expect_success 'flux-job: killall with bad broker connection fails' '
-	! FLUX_URI=/wrong flux job killall
+	(FLUX_URI=/wrong test_must_fail flux job killall)
 '
 
 test_expect_success 'flux job: killall with extra free args prints usage' '
@@ -397,7 +397,7 @@ test_expect_success 'flux job: cancelall with no args works' '
 '
 
 test_expect_success 'flux-job: cancelall with bad broker connection fails' '
-	! FLUX_URI=/wrong flux job cancelall
+	(FLUX_URI=/wrong test_must_fail flux job cancelall)
 '
 
 test_expect_success 'flux job: cancelall with reason works' '
@@ -456,7 +456,7 @@ test_expect_success 'flux job: raiseall with type works' '
 '
 
 test_expect_success 'flux-job: raiseall with bad broker connection fails' '
-	! FLUX_URI=/wrong flux job raiseall test
+	(FLUX_URI=/wrong test_must_fail flux job raiseall test)
 '
 
 test_expect_success 'flux job: raiseall with type and reason works' '

--- a/t/t2280-job-memo.t
+++ b/t/t2280-job-memo.t
@@ -25,6 +25,10 @@ test_expect_success 'memo: error on insufficient arguments' '
 test_expect_success 'memo: error on invalide jobid' '
 	test_expect_code 1 flux job memo f1 foo=bar
 '
+test_expect_success 'memo: create one inactive job' '
+	flux mini submit /bin/true >inactivejob &&
+	flux queue drain
+'
 test_expect_success 'memo: submit a running and pending job' '
 	flux mini bulksubmit --urgency={} sleep 300 ::: 16 16 0 >jobids &&
 	runid=$(head -n 1 jobids) &&
@@ -36,6 +40,9 @@ test_expect_success 'memo: only job owner can add memo' '
 	    runas 9999 flux job memo $pendingid foo=24 2>memo.guest.err &&
 	test_debug "cat memo.guest.err" &&
 	grep "guests can only add a memo to their own jobs" memo.guest.err
+'
+test_expect_success 'memo: memo cannot be added to inactive job' '
+	test_must_fail flux job memo $(cat inactivejob) foo=42
 '
 test_expect_success HAVE_JQ 'memo: add memo to pending job works' '
 	flux job memo $pendingid foo=42 a=b &&

--- a/t/t2809-job-purge.t
+++ b/t/t2809-job-purge.t
@@ -1,0 +1,196 @@
+#!/bin/sh
+
+test_description='Test flux job purge'
+
+. $(dirname $0)/sharness.sh
+
+mkdir -p config
+
+test_under_flux 1 full -o,--config-path=$(pwd)/config
+
+# Get the number of inactive jobs
+inactive_count() {
+	local how=$1
+
+	if test $how = "job-manager"; then
+		flux module stats --parse=inactive_jobs job-manager
+	elif test $how = "job-list"; then
+		flux jobs --suppress-header --filter=inactive|wc -l
+	elif test $how = "job-list-stats"; then
+		flux job stats | jq .job_states.inactive
+	else
+		echo Unknown method: $how >&2
+		return 1
+	fi
+}
+
+# Poll for a specific number of inactive jobs
+# Usage: wait_inactive_count method target tries
+# where method is job-manager, job-list, or job-list-stats (jq required)
+wait_inactive_count() {
+	local how=$1
+	local target=$2
+	local tries=$3
+	local count
+	while test $tries -gt 0; do
+		count=$(inactive_count $how)
+		echo $count inactive jobs >&2
+		test $count -eq $target && return 0
+		sleep 0.25
+		tries=$(($tries-1))
+	done
+	return 1
+}
+
+# Speed up heartbeat-driven purge results to make the test run faster
+test_expect_success 'reload heartbeat module with fast rate' '
+        flux module reload heartbeat period=0.1s
+'
+test_expect_success 'create 10 inactive jobs' '
+	flux mini submit --cc=1-10 /bin/true >jobids &&
+	flux queue drain
+'
+test_expect_success 'verify job KVS eventlogs exist' '
+	for id in $(cat jobids); do \
+	    flux job eventlog $id >/dev/null;  \
+	done
+'
+test_expect_success 'flux job purge with no args says use force' '
+	flux job purge >noargs.out &&
+	grep "use --force to purge" noargs.out
+'
+test_expect_success 'flux job purge with no limits purges 0' '
+	flux job purge --force >noforce.out &&
+	grep "purged 0 inactive jobs" noforce.out
+'
+test_expect_success 'flux job purge --batch=10000 fails' '
+	test_must_fail flux job purge --force --batch=10000 2>bigbatch.err &&
+	grep "batch must be" bigbatch.err
+'
+test_expect_success 'flux job purge --force --num-limit=-42 fails' '
+	test_must_fail flux job purge --num-limit=-42 2>negnum.err &&
+	grep "num limit must be" negnum.err
+'
+test_expect_success 'flux job purge with extra free argument fails' '
+	test_must_fail flux job purge xyz 2>freearg.err &&
+	grep "Usage:" freearg.err
+'
+test_expect_success 'flux job purge --num-limit=8 would purge 2' '
+	flux job purge --num-limit=8 >num8.out &&
+	grep "use --force to purge 2 " num8.out
+'
+test_expect_success 'flux job purge --force --num-limit=8 purges 2' '
+	flux job purge --force --num-limit=8 >num8f.out &&
+	grep "purged 2 inactive jobs" num8f.out
+'
+test_expect_success 'flux job purge --num-limit=8 would purge 0' '
+	flux job purge --num-limit=8 >num8_again.out &&
+	grep "use --force to purge 0 " num8_again.out
+'
+test_expect_success 'flux job purge --force --num-limit=8 purges 0' '
+	flux job purge --force --num-limit=8 >num8f_again.out &&
+	grep "purged 0 inactive jobs" num8f_again.out
+'
+test_expect_success 'flux job purge --num-limit=6 would purge 2' '
+	flux job purge --num-limit=6 --batch=1 >num6.out &&
+	grep "use --force to purge 2 " num6.out
+'
+test_expect_success 'flux job purge --force --num-limit=6 purges 2' '
+	flux job purge --force --num-limit=6 --batch=1 >num6f.out &&
+	grep "purged 2 inactive jobs" num6f.out
+'
+test_expect_success 'flux job purge --force --num-limit=1000 --age-limit=1ms purges 6' '
+	flux job purge --force --age-limit=1ms >both.out &&
+	grep "purged 6 inactive jobs" both.out
+'
+test_expect_success 'flux job purge --force --num-limit=1 purges 0' '
+	flux job purge --force --num-limit=1 >num1.out &&
+	grep "purged 0 inactive jobs" num1.out
+'
+test_expect_success 'verify job KVS eventlogs do not exist' '
+	for id in $(cat jobids); do \
+	    test_must_fail flux job eventlog $id; \
+	done
+'
+test_expect_success 'create 2 inactive jobs with known completion order' '
+	flux mini submit /bin/true >jobid1 &&
+	flux job wait-event $(cat jobid1) clean &&
+	flux mini submit /bin/true >jobid2 &&
+	flux job wait-event $(cat jobid2) clean
+'
+test_expect_success 'purge the oldest job - youngest is still there' '
+	flux job purge --force --num-limit=1 &&
+	flux job eventlog $(cat jobid2) >/dev/null
+'
+test_expect_success 'purge the last job' '
+	flux job purge --force --num-limit=0 &&
+	wait_inactive_count job-manager 0 30
+'
+test_expect_success 'create 10 inactive jobs' '
+	flux mini submit --cc=1-10 /bin/true &&
+	flux queue drain
+'
+test_expect_success 'reconfigure job manager with inactive-num-limit=5' '
+	cat >config/system.toml <<-EOT &&
+	[job-manager]
+	inactive-num-limit = 5
+	EOT
+	flux config reload
+'
+test_expect_success 'wait for job-list inactive job count to reach 5' '
+	wait_inactive_count job-list 5 30
+'
+test_expect_success NO_CHAIN_LINT 'run multiple flux-job purges concurrently' '
+	flux job purge --force --num-limit=4 &
+	pid=$! &&
+	flux job purge --force --num-limit=3 &&
+	wait $pid
+'
+test_expect_success NO_CHAIN_LINT 'wait for job-list inactive job count to reach 3' '
+	wait_inactive_count job-list 3 30
+'
+test_expect_success 'reconfigure job manager with inactive-age-limit=1ms' '
+	cat >config/system.toml <<-EOT &&
+	[job-manager]
+	inactive-age-limit = "1ms"
+	EOT
+	flux config reload
+'
+test_expect_success 'wait for job-list inactive job count to reach 0' '
+	wait_inactive_count job-list 0 30
+'
+test_expect_success HAVE_JQ 'confirm job-list stats show zero inactive jobs' '
+	test $(inactive_count job-list-stats) -eq 0
+'
+test_expect_success 'reconfigure job manager with incorrect type limit' '
+	cat >config/system.toml <<-EOT &&
+	[job-manager]
+	inactive-age-limit = 42
+	EOT
+	test_must_fail flux config reload 2>badtype.err &&
+	grep "Expected string" badtype.err
+'
+test_expect_success 'reconfigure job manager with bad age-limit fsd' '
+	cat >config/system.toml <<-EOT &&
+	[job-manager]
+	inactive-age-limit = "notfsd"
+	EOT
+	test_must_fail flux config reload 2>badfsd.err &&
+	grep "invalid FSD" badfsd.err
+'
+test_expect_success 'reconfigure job manager with invalid num-limit' '
+	cat >config/system.toml <<-EOT &&
+	[job-manager]
+	inactive-num-limit = -42
+	EOT
+	test_must_fail flux config reload 2>badnum.err &&
+	grep "must be >= 0" badnum.err
+'
+# Reuse bad config from previous test
+test_expect_success 'new instance with bad config fails to start' '
+	test_must_fail flux start -o,--config-path=$(pwd)/config \
+		/bin/true 2>badnum2.err &&
+	grep "must be >= 0" badnum2.err
+'
+
+test_done


### PR DESCRIPTION
This adds two methods of purging inactive jobs:

One can purge interactively, e.g.
```
$ flux job purge --num-limit=10
purged 90 inactive jobs, 10 remaining
```

or one can configure automatic purging via TOML
```toml
[job-manager]

inactive-age-limit = "7d"
inactive-num-limit = 10000
```

The job manager retains inactive jobs in a hash and places them in a list ordered by the time they became inactive.  When jobs are purged, the entry in the hash is removed along with the corresponding KVS directory.
