### PR TITLE
python: fix return from flux.importer.import_plugins() when no plugins found

### DIFF
--- a/src/bindings/python/flux/importer.py
+++ b/src/bindings/python/flux/importer.py
@@ -36,7 +36,7 @@ def import_plugins(pkg_name, pluginpath=None):
         pkg = importlib.import_module(pkg_name)
         plugins = import_plugins_pkg(pkg)
     except ModuleNotFoundError:
-        return []
+        return {}
 
     if pluginpath is not None:
         #  Undo any added pluginpath elements.

--- a/t/t2110-job-ingest-validator.t
+++ b/t/t2110-job-ingest-validator.t
@@ -44,6 +44,13 @@ test_expect_success 'flux job-validator --list-plugins works' '
 	grep feasibility list-plugins.output &&
 	grep require-instance list-plugins.output
 '
+test_expect_success 'validator plugin behaves when no plugins are found' '
+	cat <<-EOF >test-importer.py &&
+	from flux.importer import import_plugins
+	type(import_plugins("xxyyzz112233"))
+	EOF
+	flux python ./test-importer.py
+'
 test_expect_success 'flux job-validator --help shows help for selected plugins' '
 	flux job-validator --plugins=jobspec --help >help.jobspec.out 2>&1 &&
 	flux job-validator --plugins=schema --help >help.schema.out 2>&1 &&


### PR DESCRIPTION
Problem: When flux.importer.import_plugins() does not find any
plugins to import, it returns an empty list, but the function should
always return a dict.

Return an empty dict when no plugins are found in import_plugins().

As discovered by @wkharold in #4285