### PR TITLE
shell: fix reconnect hang

### DIFF
--- a/src/common/libeventlog/eventlog.c
+++ b/src/common/libeventlog/eventlog.c
@@ -341,7 +341,7 @@ char *eventlog_entry_encode (json_t *entry)
     return buf;
 }
 
-char *eventlog_encode (json_t *array)
+char *eventlog_encode (json_t *a)
 {
     json_t *value;
     size_t index;
@@ -349,11 +349,11 @@ char *eventlog_encode (json_t *array)
     int bufsz = 0;
     int used = 0;
 
-    if (!array || !json_is_array (array)) {
+    if (!a || !json_is_array (a)) {
         errno = EINVAL;
         return NULL;
     }
-    json_array_foreach (array, index, value) {
+    json_array_foreach (a, index, value) {
         char *s = json_dumps (value, JSON_COMPACT);
 
         if (!s || (used = append_string_nl (&buf, &bufsz, used, s)) < 0) {

--- a/src/common/libeventlog/eventlog.c
+++ b/src/common/libeventlog/eventlog.c
@@ -369,6 +369,39 @@ char *eventlog_encode (json_t *a)
     return buf;
 }
 
+int eventlog_contains_event (const char *s, const char *name)
+{
+    json_t *a = NULL;
+    size_t index;
+    json_t *value;
+    int rv = -1;
+
+    if (!s || !name) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    if (!(a = eventlog_decode (s)))
+        return -1;
+
+    json_array_foreach (a, index, value) {
+        double t;
+        const char *n;
+        json_t *c;
+        if (eventlog_entry_parse (value, &t, &n, &c) < 0)
+            goto out;
+        if (!strcmp (name, n)) {
+            rv = 1;
+            goto out;
+        }
+    }
+
+    rv = 0;
+out:
+    json_decref (a);
+    return rv;
+}
+
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab
  */

--- a/src/common/libeventlog/eventlog.h
+++ b/src/common/libeventlog/eventlog.h
@@ -52,6 +52,11 @@ json_t *eventlog_entry_vpack (double timestamp,
 
 char *eventlog_entry_encode (json_t *entry);
 
+/* Convenience function to search eventlog for event with name.
+ * Returns 1 if found, 0 if not, -1 on error.
+ */
+int eventlog_contains_event (const char *s, const char *name);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/common/libeventlog/eventlog.h
+++ b/src/common/libeventlog/eventlog.h
@@ -28,7 +28,7 @@ int eventlog_entry_parse (json_t *entry,
 json_t *eventlog_decode (const char *s);
 
 /* encode json array of event objects into an eventlog */
-char *eventlog_encode (json_t *o);
+char *eventlog_encode (json_t *a);
 
 /* decode a single eventlog entry into a json object */
 json_t *eventlog_entry_decode (const char *entry);

--- a/src/common/libeventlog/test/eventlog.c
+++ b/src/common/libeventlog/test/eventlog.c
@@ -479,6 +479,34 @@ void eventlog_entry_encoding_errors (void)
         "eventlog_entry_vpack context=\"[\"foo\"]\" fails with EINVAL");
 }
 
+void eventlog_contains_event_test (void)
+{
+    char *goodlog =
+        "{\"timestamp\":42.0,\"name\":\"foo\"}\n"
+        "{\"timestamp\":43.0,\"name\":\"bar\",\"context\":{\"bar\":16}}\n";
+    char *badlog = "fdsafdsafsdafd";
+
+    errno = 0;
+    ok (eventlog_contains_event (NULL, NULL) < 0
+        && errno == EINVAL,
+        "eventlog_contains_event returns EINVAL on bad input");
+
+    errno = 0;
+    ok (eventlog_contains_event (badlog, "foo") < 0
+        && errno == EINVAL,
+        "eventlog_contains_event returns EINVAL on bad log");
+
+    ok (eventlog_contains_event ("", "foo") == 0,
+        "eventlog_contains_event returns 0, no events in eventlog");
+
+    ok (eventlog_contains_event (goodlog, "foo") == 1,
+        "eventlog_contains_event returns 1, found foo event in eventlog");
+    ok (eventlog_contains_event (goodlog, "bar") == 1,
+        "eventlog_contains_event returns 1, found bar event in eventlog");
+    ok (eventlog_contains_event (goodlog, "foobar") == 0,
+        "eventlog_contains_event returns 0, no foobar event in eventlog");
+}
+
 int main (int argc, char *argv[])
 {
     plan (NO_PLAN);
@@ -490,6 +518,7 @@ int main (int argc, char *argv[])
     eventlog_entry_decoding_errors ();
     eventlog_entry_encoding ();
     /* eventlog_entry_encoding_errors (); */
+    eventlog_contains_event_test ();
 
     done_testing ();
 }

--- a/src/shell/builtins.c
+++ b/src/shell/builtins.c
@@ -74,6 +74,8 @@ static int shell_load_builtin (flux_shell_t *shell,
         || flux_plugin_set_name (p, sb->name) < 0
         || flux_plugin_add_handler (p, "shell.validate", sb->validate, NULL) < 0
         || flux_plugin_add_handler (p, "shell.connect",  sb->connect, NULL) < 0
+        || flux_plugin_add_handler (p, "shell.reconnect",
+                                    sb->reconnect, NULL) < 0
         || flux_plugin_add_handler (p, "shell.init", sb->init, NULL) < 0
         || flux_plugin_add_handler (p, "shell.exit", sb->exit, NULL) < 0
         || flux_plugin_add_handler (p, "task.init",  sb->task_init, NULL) < 0

--- a/src/shell/builtins.h
+++ b/src/shell/builtins.h
@@ -18,6 +18,7 @@ struct shell_builtin {
     const char *name;
     flux_plugin_f validate;
     flux_plugin_f connect;
+    flux_plugin_f reconnect;
     flux_plugin_f init;
     flux_plugin_f task_init;
     flux_plugin_f task_exec;

--- a/src/shell/events.c
+++ b/src/shell/events.c
@@ -18,16 +18,27 @@
 #endif
 
 #include <jansson.h>
+#include <assert.h>
 
 #include <flux/shell.h>
 
 #include "src/common/libczmqcontainers/czmq_containers.h"
+#include "src/common/libeventlog/eventlog.h"
 #include "src/common/libeventlog/eventlogger.h"
+
+#include "events.h"
 
 struct shell_eventlogger {
     flux_shell_t *shell;
     zhashx_t *contexts;
+    zlistx_t *emitted_events;
     struct eventlogger *ev;
+};
+
+struct emitted_event {
+    char *event;
+    void *handle;
+    bool confirmed_logged;
 };
 
 static void json_free (void **item)
@@ -37,6 +48,49 @@ static void json_free (void **item)
         json_decref (o);
         *item = NULL;
     }
+}
+
+static void emitted_event_destroy (void *data)
+{
+    if (data) {
+        struct emitted_event *e = data;
+        free (e->event);
+        free (e);
+    }
+}
+
+static void emitted_event_destroy_wrapper (void **data)
+{
+    if (data) {
+        struct emitted_event *e = *((struct emitted_event **)data);
+        emitted_event_destroy (e);
+    }
+}
+
+static struct emitted_event *emitted_event_create (const char *event)
+{
+    struct emitted_event *e = calloc (1, sizeof (*e));
+    if (!e)
+        return NULL;
+    if (!(e->event = strdup (event)))
+        goto error;
+    return e;
+
+error:
+    emitted_event_destroy (e);
+    return NULL;
+}
+
+static int emitted_event_append (struct shell_eventlogger *shev, const char *event)
+{
+    struct emitted_event *e = emitted_event_create (event);
+    if (!e)
+        return -1;
+    if (!(e->handle = zlistx_add_end (shev->emitted_events, e))) {
+        emitted_event_destroy (e);
+        return -1;
+    }
+    return 0;
 }
 
 static void shell_eventlogger_ref (struct eventlogger *ev, void *arg)
@@ -51,6 +105,69 @@ static void shell_eventlogger_unref (struct eventlogger *ev, void *arg)
     flux_shell_remove_completion_ref (shev->shell, "shell_eventlogger");
 }
 
+static int emit_event (struct shell_eventlogger *shev,
+                       const char *event,
+                       bool save_to_emitted_events)
+{
+    int rc = -1;
+    char *context = NULL;
+    json_t *o = zhashx_lookup (shev->contexts, event);
+    if (o != NULL)
+        context = json_dumps (o, JSON_COMPACT);
+    if (eventlogger_append (shev->ev,
+                            EVENTLOGGER_FLAG_WAIT,
+                            "exec.eventlog",
+                            event,
+                            context) < 0)
+        goto error;
+    if (save_to_emitted_events) {
+        if (emitted_event_append (shev, event) < 0)
+            goto error;
+    }
+    rc = 0;
+error:
+    free (context);
+    return rc;
+}
+
+static int shell_eventlogger_compare_eventlog (struct shell_eventlogger *shev)
+{
+    flux_future_t *f = NULL;
+    struct emitted_event *e;
+    const char *s = NULL;
+    int rv = -1;
+
+    if (!(f = flux_kvs_lookup (flux_shell_get_flux (shev->shell),
+                               NULL,
+                               0,
+                               "exec.eventlog")))
+        return -1;
+
+    /* do this synchronously, since we are reconnecting */
+    if (flux_kvs_lookup_get (f, &s) < 0)
+        goto error;
+
+    e = zlistx_first (shev->emitted_events);
+    while (e) {
+        if (!e->confirmed_logged) {
+            int ret;
+            if ((ret = eventlog_contains_event (s, e->event)) < 0)
+                goto error;
+            if (ret == 1) {
+                if (emit_event (shev, e->event, false) < 0)
+                    goto error;
+                e->confirmed_logged = true;
+            }
+        }
+        e = zlistx_next (shev->emitted_events);
+    }
+
+    rv = 0;
+error:
+    flux_future_destroy (f);
+    return rv;
+}
+
 int shell_eventlogger_reconnect (struct shell_eventlogger *shev)
 {
     /* during a reconnect, response to event logging may not occur,
@@ -61,6 +178,13 @@ int shell_eventlogger_reconnect (struct shell_eventlogger *shev)
     while (flux_shell_remove_completion_ref (shev->shell,
                                              "shell_eventlogger") == 0);
 
+    /* exec.eventlog events are often critical to correct function, so
+     * if any were lost during a reconnect, we need to make sure it
+     * was logged, otherwise try to write it out again.
+     */
+    if (shell_eventlogger_compare_eventlog (shev) < 0)
+        return -1;
+
     return 0;
 }
 
@@ -68,6 +192,7 @@ void shell_eventlogger_destroy (struct shell_eventlogger *shev)
 {
     if (shev) {
         zhashx_destroy (&shev->contexts);
+        zlistx_destroy (&shev->emitted_events);
         eventlogger_destroy (shev->ev);
         free (shev);
     }
@@ -84,30 +209,21 @@ struct shell_eventlogger *shell_eventlogger_create (flux_shell_t *shell)
 
     if (!(h = flux_shell_get_flux (shell))
         || !(shev->ev = eventlogger_create (h, 0.01, &ops, shev))
-        || !(shev->contexts = zhashx_new ())) {
+        || !(shev->contexts = zhashx_new ())
+        || !(shev->emitted_events = zlistx_new ())) {
         shell_eventlogger_destroy (shev);
         return NULL;
     }
     shev->shell = shell;
     zhashx_set_destructor (shev->contexts, json_free);
+    zlistx_set_destructor (shev->emitted_events, emitted_event_destroy_wrapper);
     return shev;
 }
 
 int shell_eventlogger_emit_event (struct shell_eventlogger *shev,
                                   const char *event)
 {
-    int rc;
-    char *context = NULL;
-    json_t *o = zhashx_lookup (shev->contexts, event);
-    if (o != NULL)
-        context = json_dumps (o, JSON_COMPACT);
-    rc = eventlogger_append (shev->ev,
-                             EVENTLOGGER_FLAG_WAIT,
-                             "exec.eventlog",
-                             event,
-                             context);
-    free (context);
-    return rc;
+    return emit_event (shev, event, true);
 }
 
 static int context_set (struct shell_eventlogger *shev,

--- a/src/shell/events.c
+++ b/src/shell/events.c
@@ -75,6 +75,7 @@ struct shell_eventlogger *shell_eventlogger_create (flux_shell_t *shell)
         shell_eventlogger_destroy (shev);
         return NULL;
     }
+    shev->shell = shell;
     zhashx_set_destructor (shev->contexts, json_free);
     return shev;
 }

--- a/src/shell/events.c
+++ b/src/shell/events.c
@@ -81,7 +81,6 @@ struct shell_eventlogger *shell_eventlogger_create (flux_shell_t *shell)
 }
 
 int shell_eventlogger_emit_event (struct shell_eventlogger *shev,
-                                  int flags,
                                   const char *event)
 {
     int rc;

--- a/src/shell/events.c
+++ b/src/shell/events.c
@@ -51,6 +51,19 @@ static void shell_eventlogger_unref (struct eventlogger *ev, void *arg)
     flux_shell_remove_completion_ref (shev->shell, "shell_eventlogger");
 }
 
+int shell_eventlogger_reconnect (struct shell_eventlogger *shev)
+{
+    /* during a reconnect, response to event logging may not occur,
+     * thus shell_eventlogger_unref() may not be called.  Clear all
+     * completion references to inflight transactions.
+     */
+
+    while (flux_shell_remove_completion_ref (shev->shell,
+                                             "shell_eventlogger") == 0);
+
+    return 0;
+}
+
 void shell_eventlogger_destroy (struct shell_eventlogger *shev)
 {
     if (shev) {

--- a/src/shell/events.h
+++ b/src/shell/events.h
@@ -17,7 +17,6 @@ void shell_eventlogger_destroy (struct shell_eventlogger *shev);
 struct shell_eventlogger *shell_eventlogger_create (flux_shell_t *shell);
 
 int shell_eventlogger_emit_event (struct shell_eventlogger *shev,
-                                  int flags,
                                   const char *event);
 
 int shell_eventlogger_context_vpack (struct shell_eventlogger *shev,

--- a/src/shell/events.h
+++ b/src/shell/events.h
@@ -24,6 +24,9 @@ int shell_eventlogger_context_vpack (struct shell_eventlogger *shev,
                                      int flags,
                                      const char *fmt,
                                      va_list ap);
+
+int shell_eventlogger_reconnect (struct shell_eventlogger *shev);
+
 #endif /* !_SHELL_EVENTS_H */
 
 /* vi: ts=4 sw=4 expandtab

--- a/src/shell/output.c
+++ b/src/shell/output.c
@@ -1051,6 +1051,22 @@ static void output_unref (struct eventlogger *ev, void *arg)
     flux_shell_remove_completion_ref (out->shell, "output.txn");
 }
 
+static int output_eventlogger_reconnect (flux_plugin_t *p,
+                                         const char *topic,
+                                         flux_plugin_arg_t *args,
+                                         void *data)
+{
+    flux_shell_t *shell = flux_plugin_get_shell (p);
+
+    /* during a reconnect, response to event logging may not occur,
+     * thus output_unref() may not be called.  Clear all completion
+     * references to inflight transactions.
+     */
+
+    while (flux_shell_remove_completion_ref (shell, "output.txn") == 0);
+    return 0;
+}
+
 static int output_eventlogger_start (struct shell_output *out)
 {
     flux_t *h = flux_shell_get_flux (out->shell);
@@ -1336,6 +1352,7 @@ static int shell_output_init (flux_plugin_t *p,
 
 struct shell_builtin builtin_output = {
     .name = FLUX_SHELL_PLUGIN_NAME,
+    .reconnect = output_eventlogger_reconnect,
     .init = shell_output_init,
     .task_init = shell_output_task_init,
     .task_exit = shell_output_task_exit,

--- a/src/shell/output.c
+++ b/src/shell/output.c
@@ -218,7 +218,7 @@ static int shell_output_redirect_stream (struct shell_output *out,
                                        "stream", stream,
                                        "rank", rankptr,
                                        "path", path))) {
-        shell_log_errno ("eventlog_entry_create");
+        shell_log_errno ("eventlog_entry_pack");
         goto error;
     }
     if (!(entrystr = eventlog_entry_encode (entry))) {

--- a/src/shell/shell.c
+++ b/src/shell/shell.c
@@ -265,6 +265,10 @@ static int reconnect (flux_t *h, void *arg)
     if (flux_rpc_get (f, NULL) < 0)
         shell_die (1, "flux_service_register: %s", future_strerror (f, errno));
     flux_future_destroy (f);
+
+    if (plugstack_call (shell->plugstack, "shell.reconnect", NULL) < 0)
+        shell_log_errno ("shell.reconnect");
+
     shell_log ("broker: reconnected");
     return 0;
 }

--- a/src/shell/shell.c
+++ b/src/shell/shell.c
@@ -269,6 +269,9 @@ static int reconnect (flux_t *h, void *arg)
     if (plugstack_call (shell->plugstack, "shell.reconnect", NULL) < 0)
         shell_log_errno ("shell.reconnect");
 
+    if (shell_eventlogger_reconnect (shell->ev) < 0)
+        shell_log_errno ("shell_eventlogger_reconnect");
+
     shell_log ("broker: reconnected");
     return 0;
 }

--- a/src/shell/shell.c
+++ b/src/shell/shell.c
@@ -1342,7 +1342,7 @@ int main (int argc, char *argv[])
      */
     if (shell.info->shell_rank == 0
         && !shell.standalone
-        && shell_eventlogger_emit_event (shell.ev, 0, "shell.init") < 0)
+        && shell_eventlogger_emit_event (shell.ev, "shell.init") < 0)
             shell_die_errno (1, "failed to emit event shell.init");
 
     /* Create tasks
@@ -1408,7 +1408,7 @@ int main (int argc, char *argv[])
      */
     if (shell.info->shell_rank == 0
         && !shell.standalone
-        && shell_eventlogger_emit_event (shell.ev, 0, "shell.start") < 0)
+        && shell_eventlogger_emit_event (shell.ev, "shell.start") < 0)
             shell_die_errno (1, "failed to emit event shell.start");
 
     /* Main reactor loop

--- a/t/t9000-system.t
+++ b/t/t9000-system.t
@@ -44,7 +44,7 @@ fi
 #
 expect_success_wrap() {
 	if test $# -eq 3; then
-		test_expect_success "$TEST_LABEL: $1" "$2" "$3"
+		test_expect_success "$1" "$TEST_LABEL: $2" "$3"
 	else
 		test_expect_success "$TEST_LABEL: $1" "$2"
 	fi


### PR DESCRIPTION
Per discussion in #4070, this fixes a hang in the shell due to reconnects occurring at the wrong time and shell "completion references" never getting cleared.

Note that I created a new callback for when we reconnect, called `reconnect_init()`.  This is presently unused.  I only added it because adding only a `reconnect_cleanup()` callback seemed "unbalanced".  Can nix if people think it should be nixed.  There are things that could be done with a `reconnect_init()` though.  Perhaps we want to re-try writing to an eventlog by caching unconfirmed eventlog writes?  That's just an idea and not for this PR.

This is built on top of #4070.  Note that this is independent of #4255, does not have to go in before / after it.

Note I don't have an issue created for this, b/c it seems weird to create an issue for a bug that can't exist yet b/c of in progress PR.  Will create an issue later.
