### PR TITLE
select safer content.sqlite consistency pragmas

### DIFF
--- a/src/broker/content-cache.c
+++ b/src/broker/content-cache.c
@@ -91,7 +91,7 @@ struct content_cache {
     uint32_t purge_target_size;
     uint32_t purge_old_entry;
 
-    uint32_t acct_size;             // total size of all cache entries
+    uint64_t acct_size;             // total size of all cache entries
     uint32_t acct_valid;            // count of valid cache entries
     uint32_t acct_dirty;            // count of dirty cache entries
 };
@@ -705,7 +705,7 @@ static void content_stats_request (flux_t *h, flux_msg_handler_t *mh,
 {
     struct content_cache *cache = arg;
 
-    if (flux_respond_pack (h, msg, "{s:i s:i s:i s:i s:i}",
+    if (flux_respond_pack (h, msg, "{s:i s:i s:i s:I s:i}",
                            "count", zhashx_size (cache->entries),
                            "valid", cache->acct_valid,
                            "dirty", cache->acct_dirty,

--- a/src/modules/content-sqlite/content-sqlite.c
+++ b/src/modules/content-sqlite/content-sqlite.c
@@ -13,7 +13,11 @@
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
+#include <sys/types.h>
+#include <sys/stat.h>
 #include <unistd.h>
+#include <unistd.h>
+#include <sys/statvfs.h>
 #include <sqlite3.h>
 #include <lz4.h>
 #include <flux/core.h>
@@ -22,6 +26,8 @@
 #include "src/common/libutil/blobref.h"
 #include "src/common/libutil/log.h"
 #include "src/common/libutil/errno_safe.h"
+#include "src/common/libutil/tstat.h"
+#include "src/common/libutil/monotime.h"
 
 #include "src/common/libcontent/content-util.h"
 
@@ -37,6 +43,7 @@ const char *sql_load = "SELECT object,size FROM objects"
                        "  WHERE hash = ?1 LIMIT 1";
 const char *sql_store = "INSERT INTO objects (hash,size,object) "
                         "  values (?1, ?2, ?3)";
+const char *sql_objects_count = "SELECT count(1) FROM objects";
 
 const char *sql_create_table_checkpt = "CREATE TABLE if not exists checkpt("
                                        "  key TEXT UNIQUE,"
@@ -46,6 +53,11 @@ const char *sql_checkpt_get = "SELECT value FROM checkpt"
                               "  WHERE key = ?1";
 const char *sql_checkpt_put = "REPLACE INTO checkpt (key,value) "
                               "  values (?1, ?2)";
+
+struct content_stats {
+    tstat_t load;
+    tstat_t store;
+};
 
 struct content_sqlite {
     flux_msg_handler_t **handlers;
@@ -59,6 +71,7 @@ struct content_sqlite {
     const char *hashfun;
     size_t lzo_bufsize;
     void *lzo_buf;
+    struct content_stats stats;
 };
 
 static void log_sqlite_error (struct content_sqlite *ctx, const char *fmt, ...)
@@ -284,6 +297,7 @@ static void load_cb (flux_t *h,
     int blobref_size;
     const void *data;
     int size;
+    struct timespec t0;
 
     if (flux_request_decode_raw (msg,
                                  NULL,
@@ -297,8 +311,10 @@ static void load_cb (flux_t *h,
         flux_log_error (h, "load: malformed blobref");
         goto error;
     }
+    monotime (&t0);
     if (content_sqlite_load (ctx, blobref, &data, &size) < 0)
         goto error;
+    tstat_push (&ctx->stats.load, monotime_since (t0));
     if (flux_respond_raw (h, msg, data, size) < 0)
         flux_log_error (h, "load: flux_respond_raw");
     (void )sqlite3_reset (ctx->load_stmt);
@@ -317,13 +333,16 @@ void store_cb (flux_t *h,
     const void *data;
     int size;
     char blobref[BLOBREF_MAX_STRING_SIZE];
+    struct timespec t0;
 
     if (flux_request_decode_raw (msg, NULL, &data, &size) < 0) {
         flux_log_error (h, "store: request decode failed");
         goto error;
     }
+    monotime (&t0);
     if (content_sqlite_store (ctx, data, size, blobref, sizeof (blobref)) < 0)
         goto error;
+    tstat_push (&ctx->stats.store, monotime_since (t0));
     if (flux_respond_raw (h, msg, blobref, strlen (blobref) + 1) < 0)
         flux_log_error (h, "store: flux_respond_raw");
     return;
@@ -481,6 +500,102 @@ static void content_sqlite_closedb (struct content_sqlite *ctx)
     }
 }
 
+/* sqlite3_exec() callback from sql_objects_count query.
+ * On success, return 0 and set *arg to the count result.
+ * On error, return -1 which causes sqlite3_exec() to fail with SQLITE_ABORT.
+ */
+static int set_count (void *arg, int ncols, char **cols, char **col_names)
+{
+    int *result = arg;
+    int count = 0;
+    int rc = -1;
+
+    if (ncols == 1) {
+        errno = 0;
+        count = strtoul (cols[0], NULL, 10);
+        if (errno == 0) {
+            *result = count;
+            rc = 0;
+        }
+    }
+    return rc; // returning -1 causes SQLITE_ABORT
+}
+
+static json_t *pack_tstat (tstat_t *ts)
+{
+    json_t *o;
+    if (!(o = json_pack ("{s:i s:f s:f s:f s:f}",
+                         "count", tstat_count (ts),
+                         "min", tstat_min (ts),
+                         "max", tstat_max (ts),
+                         "mean", tstat_mean (ts),
+                          "stddev", tstat_stddev (ts)))) {
+        errno = ENOMEM;
+        return NULL;
+    }
+    return o;
+}
+
+static unsigned long long get_file_size (const char *path)
+{
+    struct stat sb;
+
+    if (stat (path, &sb) < 0)
+        return 0;
+    return sb.st_size;
+}
+
+static unsigned long long get_fs_free (const char *path)
+{
+    struct statvfs sb;
+
+    if (statvfs (path, &sb) < 0)
+        return 0;
+    return sb.f_bsize * sb.f_bavail;
+}
+
+void stats_get_cb (flux_t *h,
+                   flux_msg_handler_t *mh,
+                   const flux_msg_t *msg,
+                   void *arg)
+{
+    struct content_sqlite *ctx = arg;
+    int count;
+    const char *errmsg = NULL;
+    json_t *load_time = NULL;
+    json_t *store_time = NULL;
+
+    if (sqlite3_exec (ctx->db,
+                      sql_objects_count,
+                      set_count,
+                      &count,
+                      NULL) != SQLITE_OK) {
+        errmsg = sqlite3_errmsg (ctx->db);
+        errno = EPERM;
+        goto error;
+    }
+    if (!(load_time = pack_tstat (&ctx->stats.load))
+        || !(store_time = pack_tstat (&ctx->stats.store)))
+        goto error;
+    if (flux_respond_pack (h,
+                           msg,
+                           "{s:i s:I s:I s:o s:o}",
+                           "object_count", count,
+                           "dbfile_size", get_file_size (ctx->dbfile),
+                           "dbfile_free", get_fs_free (ctx->dbfile),
+                           "load_time", load_time,
+                           "store_time", store_time) < 0)
+        flux_log_error (h, "error responding to stats.get request");
+    json_decref (load_time);
+    json_decref (store_time);
+    return;
+error:
+    if (flux_respond_error (h, msg, errno, errmsg) < 0)
+        flux_log_error (h, "error responding to stats.get request");
+    json_decref (load_time);
+    json_decref (store_time);
+}
+
 /* Open the database file ctx->dbfile and set up the database.
  */
 static int content_sqlite_opendb (struct content_sqlite *ctx)
@@ -586,6 +701,7 @@ static const struct flux_msg_handler_spec htab[] = {
     { FLUX_MSGTYPE_REQUEST, "content-backing.store",   store_cb, 0 },
     { FLUX_MSGTYPE_REQUEST, "kvs-checkpoint.get", checkpoint_get_cb, 0 },
     { FLUX_MSGTYPE_REQUEST, "kvs-checkpoint.put", checkpoint_put_cb, 0 },
+    { FLUX_MSGTYPE_REQUEST, "content-sqlite.stats.get", stats_get_cb, 0 },
     FLUX_MSGHANDLER_TABLE_END,
 };
 

--- a/src/modules/content-sqlite/content-sqlite.c
+++ b/src/modules/content-sqlite/content-sqlite.c
@@ -274,6 +274,10 @@ static int content_sqlite_store (struct content_sqlite *ctx,
         set_errno_from_sqlite_error (ctx);
         goto error;
     }
+    /* N.B. ignore SQLITE_CONSTRAINT errors - it means the insert failed
+     * because it violated the implicit primary key uniqueness constraint.
+     * Blob and blobref are indeed stored and storage is conserved - success!
+     */
     if (sqlite3_step (ctx->store_stmt) != SQLITE_DONE
                     && sqlite3_errcode (ctx->db) != SQLITE_CONSTRAINT) {
         log_sqlite_error (ctx, "store: executing stmt");


### PR DESCRIPTION
Problem: content.sqlite sets journal_mode=OFF, synchronous=OFF for performance, but we do occasionally see database corruption in the system instance, as noted in #4152.

This PR changes the content-sqlite pragmas to journal_mode=WAL, synchronous=NORMAL which is safer at the expense of some performance.  It also adds metrics to content-sqlite so we can get a window into the performance.   Below is a comparison of performance in both modes while running the throughput test with 32768 jobs.  Job throughput decreased by 23%.  This is likely an acceptable trade-off for the system instance, but perhaps not for single user instances.

Marking as a WIP for now.

**TL;DR**

Snippets from https://www.sqlite.org/pragma.html 

**journal_mode=OFF, synchronous=OFF**

> If the application crashes in the middle of a transaction when the OFF journaling mode is set, then the database file will very likely [go corrupt](https://www.sqlite.org/howtocorrupt.html#cfgerr). Without a journal, there is no way for a statement to unwind partially completed operations following a constraint error. This might also leave the database in a corrupted state.

> With synchronous OFF (0), SQLite continues without syncing as soon as it has handed data off to the operating system. If the application running SQLite crashes, the data will be safe, but the database [might become corrupted](https://www.sqlite.org/howtocorrupt.html#cfgerr) if the operating system crashes or the computer loses power before that data has been written to the disk surface. On the other hand, commits can be orders of magnitude faster with synchronous OFF.

**journal_mode=WAL, synchronous=NORMAL**

> The WAL journaling mode uses a [write-ahead log](https://www.sqlite.org/wal.html) instead of a rollback journal to implement transactions. The WAL journaling mode is persistent; after being set it stays in effect across multiple database connections and after closing and reopening the database.

 > When synchronous is NORMAL (1), the SQLite database engine will still sync at the most critical moments, but less often than in FULL mode.  [WAL mode](https://www.sqlite.org/wal.html) is always consistent with synchronous=NORMAL, but WAL mode does lose durability. A transaction committed in WAL mode with synchronous=NORMAL might roll back following a power loss or system crash. Transactions are durable across application crashes regardless of the synchronous setting or journal mode. The synchronous=NORMAL setting is a good choice for most applications running in WAL mode.

**journal_mode=WAL, synchronous=NORMAL**
```
$ src/test/throughput.py -sn 32768
 32768 jobs:  32768 submitted,      0 running, 32768 completed
number of jobs: 32768
submit time:    8.383 s (3908.9 job/s)
script runtime: 472.976s
job runtime:    206.300s
throughput:     158.8 job/s (script:  69.3 job/s)
$ flux module stats content
{
 "count": 30855,
 "valid": 30855,
 "dirty": 0,
 "size": 16775199,
 "flush-batch-count": 0
}
$ flux module stats content-sqlite
{
 "object_count": 1029997,
 "dbfile_size": 997396480,
 "dbfile_free": 277364133888,
 "load_time": {
  "count": 463050,
  "min": 0.0014220000000000001,
  "max": 0.26876100000000003,
  "mean": 0.0065742753590326119,
  "stddev": 0.0037543449026159067
 },
 "store_time": {
  "count": 1029997,
  "min": 0.0057210000000000004,
  "max": 40.314458999999999,
  "mean": 0.07438751751801416,
  "stddev": 0.91053893559580146
 }
}
```

**journal_mode=OFF, synchronous=OFF**
```
$ src/test/throughput.py -sn 32768
 32768 jobs:  32768 submitted,      0 running, 32768 completed
number of jobs: 32768
submit time:    7.961 s (4116.1 job/s)
script runtime: 468.344s
job runtime:    160.295s
throughput:     204.4 job/s (script:  70.0 job/s)
$ flux module stats content
{
 "count": 24508,
 "valid": 24508,
 "dirty": 0,
 "size": 16766936,
 "flush-batch-count": 0
}
$ flux module stats content-sqlite
{
 "object_count": 1041628,
 "dbfile_size": 1014226944,
 "dbfile_free": 277350973440,
 "load_time": {
  "count": 464516,
  "min": 0.001433,
  "max": 0.40983799999999998,
  "mean": 0.0063714025975424998,
  "stddev": 0.0037928408896549066
 },
 "store_time": {
  "count": 1041628,
  "min": 0.0032560000000000002,
  "max": 8.1697399999999991,
  "mean": 0.016616053997204328,
  "stddev": 0.042195470281613467
 }
}
```