### PR TITLE
broker: suppress online message with no members

### DIFF
--- a/src/broker/state_machine.c
+++ b/src/broker/state_machine.c
@@ -721,9 +721,11 @@ static void broker_online_cb (flux_future_t *f, void *arg)
         return;
     }
 
-    char *hosts = flux_hostmap_lookup (s->ctx->h, members, NULL);
-    flux_log (s->ctx->h, LOG_INFO, "online: %s (ranks %s)", hosts, members);
-    free (hosts);
+    if (strlen (members) > 0) {
+        char *hosts = flux_hostmap_lookup (s->ctx->h, members, NULL);
+        flux_log (s->ctx->h, LOG_INFO, "online: %s (ranks %s)", hosts, members);
+        free (hosts);
+    }
 
     idset_destroy (s->quorum.have);
     s->quorum.have = ids;


### PR DESCRIPTION
Problem: When a response to the groups.get request for the
broker.online group reports no members, the broker prints a confusing
log message:

```
 [  +0.002432] broker[0]: online:  (ranks )
```

Suppress this log message if the groups.get response contains an
empty set for members. This also avoids creating and destroying an
empty hosts string.