### PR TITLE
content: track RFC 10 protocol changes

### DIFF
--- a/src/broker/content-cache.c
+++ b/src/broker/content-cache.c
@@ -377,7 +377,7 @@ static int cache_load (struct content_cache *cache, struct cache_entry *e)
         return 0;
     if (cache->rank == 0)
         flags = CONTENT_FLAG_CACHE_BYPASS;
-    if (!(f = content_load (cache->h, e->blobref, flags))
+    if (!(f = content_load_byblobref (cache->h, e->blobref, flags))
         || flux_future_aux_set (f, "entry", e, NULL) < 0
         || flux_future_then (f, -1., cache_load_continuation, cache) < 0) {
         flux_log_error (cache->h, "content load");
@@ -474,7 +474,7 @@ static void cache_store_continuation (flux_future_t *f, void *arg)
     e->store_pending = 0;
     assert (cache->flush_batch_count > 0);
     cache->flush_batch_count--;
-    if (content_store_get (f, &blobref) < 0) {
+    if (content_store_get_blobref (f, &blobref) < 0) {
         if (cache->rank == 0 && errno == ENOSYS)
             flux_log (cache->h, LOG_DEBUG, "content store: %s",
                       "backing store service unavailable");

--- a/src/broker/content-cache.c
+++ b/src/broker/content-cache.c
@@ -48,6 +48,11 @@ static const uint32_t default_blob_size_limit = 1048576*1024;
 
 static const uint32_t default_flush_batch_limit = 256;
 
+/* Hash digests are used as zhashx keys.  The digest size needs to be
+ * available to zhashx comparator so make this global.
+ */
+static int content_hash_size;
+
 struct msgstack {
     const flux_msg_t *msg;
     struct msgstack *next;
@@ -56,7 +61,7 @@ struct msgstack {
 struct cache_entry {
     void *data;
     int len;
-    char *blobref;
+    void *hash;                     // key storage is contiguous with struct
     uint8_t valid:1;                // entry contains valid data
     uint8_t dirty:1;                // entry needs to be stored upstream
                                     //   or to backing store (rank 0)
@@ -188,22 +193,31 @@ static void cache_entry_destructor (void **item)
         *item = NULL;
     }
 }
+/* zhashx_hash_fn footprint
+ */
+static size_t cache_entry_hasher (const void *key)
+{
+    return *(size_t *)key;
+}
+/* zhashx_comparator_fn footprint
+ */
+static int cache_entry_comparator (const void *item1, const void *item2)
+{
+    return memcmp (item1, item2, content_hash_size);
+}
 
 /* Create a cache entry.
- * Entries are created with a blobref, but no data (e.g. "invalid").
- * The blobref is copied to the space following the entry struct so the entry
- * and the blobref can be co-located in memory, and allocated with one malloc.
+ * Entries are created with no data (e.g. "invalid").
  * Returns entry on success, NULL with errno set on failure.
  */
-static struct cache_entry *cache_entry_create (const char *blobref)
+static struct cache_entry *cache_entry_create (const void *hash)
 {
     struct cache_entry *e;
-    int bloblen = strlen (blobref) + 1;
 
-    if (!(e = calloc (1, sizeof (*e) + bloblen)))
+    if (!(e = calloc (1, sizeof (*e) + content_hash_size)))
         return NULL;
-    e->blobref = (char *)(e + 1);
-    memcpy (e->blobref, blobref, bloblen);
+    e->hash = (char *)(e + 1);
+    memcpy (e->hash, hash, content_hash_size);
     list_node_init (&e->list);
     return e;
 }
@@ -264,23 +278,29 @@ static void cache_entry_dirty_clear (struct content_cache *cache,
 
         request_list_respond_raw (&e->store_requests,
                                   cache->h,
-                                  e->blobref,
-                                  strlen (e->blobref) + 1,
+                                  e->hash,
+                                  content_hash_size,
                                   "store");
     }
 }
 
 
-/* Create and insert a cache entry, using 'blobref' as the hash key.
+/* Create and insert a cache entry.
  * Returns 0 on success, -1 on failure with errno set.
  */
 static struct cache_entry *cache_entry_insert (struct content_cache *cache,
-                                               const char *blobref)
+                                               const void *hash,
+                                               int hash_size)
 {
     struct cache_entry *e;
-    if (!(e = cache_entry_create (blobref)))
+
+    if (hash_size != content_hash_size) {
+        errno = EINVAL;
         return NULL;
-    if (zhashx_insert (cache->entries, e->blobref, e) < 0) {
+    }
+    if (!(e = cache_entry_create (hash)))
+        return NULL;
+    if (zhashx_insert (cache->entries, e->hash, e) < 0) {
         errno = EEXIST;
         cache_entry_destroy (e);
         return NULL;
@@ -288,16 +308,20 @@ static struct cache_entry *cache_entry_insert (struct content_cache *cache,
     return e;
 }
 
-/* Look up a cache entry, by blobref.
+/* Look up a cache entry.
  * Move to front of LRU because it was looked up.
  * Returns entry on success, NULL on failure.
  * N.B. errno is not set
  */
 static struct cache_entry *cache_entry_lookup (struct content_cache *cache,
-                                               const char *blobref)
+                                               const void *hash,
+                                               int hash_size)
 {
     struct cache_entry *e;
-    if (!(e = zhashx_lookup (cache->entries, blobref)))
+
+    if (hash_size != content_hash_size)
+        return NULL;
+    if (!(e = zhashx_lookup (cache->entries, hash)))
         return NULL;
 
     if (e->valid && !e->dirty) {
@@ -323,7 +347,7 @@ static void cache_entry_remove (struct content_cache *cache,
     }
     if (e->dirty)
         cache->acct_dirty--;
-    zhashx_delete (cache->entries, e->blobref);
+    zhashx_delete (cache->entries, e->hash);
 }
 
 /* Load operation
@@ -377,7 +401,7 @@ static int cache_load (struct content_cache *cache, struct cache_entry *e)
         return 0;
     if (cache->rank == 0)
         flags = CONTENT_FLAG_CACHE_BYPASS;
-    if (!(f = content_load_byblobref (cache->h, e->blobref, flags))
+    if (!(f = content_load_byhash (cache->h, e->hash, content_hash_size, flags))
         || flux_future_aux_set (f, "entry", e, NULL) < 0
         || flux_future_then (f, -1., cache_load_continuation, cache) < 0) {
         flux_log_error (cache->h, "content load");
@@ -392,25 +416,24 @@ void content_load_request (flux_t *h, flux_msg_handler_t *mh,
                            const flux_msg_t *msg, void *arg)
 {
     struct content_cache *cache = arg;
-    const char *blobref;
-    int blobref_size;
+    const void *hash;
+    int hash_size;
     void *data = NULL;
     int len = 0;
     struct cache_entry *e;
 
-    if (flux_request_decode_raw (msg, NULL, (const void **)&blobref,
-                                 &blobref_size) < 0)
+    if (flux_request_decode_raw (msg, NULL, &hash, &hash_size) < 0)
         goto error;
-    if (!blobref || blobref[blobref_size - 1] != '\0') {
+    if (hash_size != content_hash_size) {
         errno = EPROTO;
         goto error;
     }
-    if (!(e = cache_entry_lookup (cache, blobref))) {
+    if (!(e = cache_entry_lookup (cache, hash, hash_size))) {
         if (cache->rank == 0 && !cache->backing) {
             errno = ENOENT;
             goto error;
         }
-        if (!(e = cache_entry_insert (cache, blobref))) {
+        if (!(e = cache_entry_insert (cache, hash, hash_size))) {
             flux_log_error (h, "content load");
             goto error;
         }
@@ -469,12 +492,13 @@ static void cache_store_continuation (flux_future_t *f, void *arg)
 {
     struct content_cache *cache = arg;
     struct cache_entry *e = flux_future_aux_get (f, "entry");
-    const char *blobref;
+    const void *hash;
+    int hash_size;
 
     e->store_pending = 0;
     assert (cache->flush_batch_count > 0);
     cache->flush_batch_count--;
-    if (content_store_get_blobref (f, &blobref) < 0) {
+    if (content_store_get_hash (f, &hash, &hash_size) < 0) {
         if (cache->rank == 0 && errno == ENOSYS)
             flux_log (cache->h, LOG_DEBUG, "content store: %s",
                       "backing store service unavailable");
@@ -482,8 +506,8 @@ static void cache_store_continuation (flux_future_t *f, void *arg)
             flux_log_error (cache->h, "content store");
         goto error;
     }
-    if (strcmp (blobref, e->blobref)) {
-        flux_log (cache->h, LOG_ERR, "content store: wrong blobref");
+    if (hash_size != content_hash_size
+        || memcmp (hash, e->hash, content_hash_size) != 0) {
         errno = EIO;
         goto error;
     }
@@ -536,7 +560,8 @@ static void content_store_request (flux_t *h, flux_msg_handler_t *mh,
     const void *data;
     int len;
     struct cache_entry *e = NULL;
-    char blobref[BLOBREF_MAX_STRING_SIZE];
+    uint8_t hash[BLOBREF_MAX_DIGEST_SIZE];
+    int hash_size;
 
     if (flux_request_decode_raw (msg, NULL, &data, &len) < 0)
         goto error;
@@ -544,12 +569,14 @@ static void content_store_request (flux_t *h, flux_msg_handler_t *mh,
         errno = EFBIG;
         goto error;
     }
-    if (blobref_hash (cache->hash_name, (uint8_t *)data, len, blobref,
-                      sizeof (blobref)) < 0)
+    if ((hash_size = blobref_hash_raw (cache->hash_name,
+                                       data,
+                                       len,
+                                       hash,
+                                       sizeof (hash))) < 0)
         goto error;
-
-    if (!(e = cache_entry_lookup (cache, blobref))) {
-        if (!(e = cache_entry_insert (cache, blobref)))
+    if (!(e = cache_entry_lookup (cache, hash, hash_size))) {
+        if (!(e = cache_entry_insert (cache, hash, hash_size)))
             goto error;
     }
     if (cache_entry_fill (cache, e, data, len, true) < 0)
@@ -565,7 +592,7 @@ static void content_store_request (flux_t *h, flux_msg_handler_t *mh,
             }
         }
     }
-    if (flux_respond_raw (h, msg, blobref, strlen (blobref) + 1) < 0)
+    if (flux_respond_raw (h, msg, hash, hash_size) < 0)
         flux_log_error (h, "content store: flux_respond_raw");
     return;
 error:
@@ -890,13 +917,15 @@ static int register_attrs (struct content_cache *cache, attr_t *attr)
             return -1;
     }
     else {
-        if (blobref_validate_hashtype (s) < 0) {
+        int hash_size;
+        if ((hash_size = blobref_validate_hashtype (s)) < 0) {
             log_msg ("%s: unknown hash type", s);
             return -1;
         }
         if (attr_set_flags (attr, "content.hash", FLUX_ATTRFLAG_IMMUTABLE) < 0)
             return -1;
         cache->hash_name = s;
+        content_hash_size = hash_size;
     }
 
     /* Purge tunables
@@ -944,7 +973,10 @@ struct content_cache *content_cache_create (flux_t *h, attr_t *attrs)
         return NULL;
     if (!(cache->entries = zhashx_new ()))
         goto nomem;
+
     zhashx_set_destructor (cache->entries, cache_entry_destructor);
+    zhashx_set_key_hasher (cache->entries, cache_entry_hasher);
+    zhashx_set_key_comparator (cache->entries, cache_entry_comparator);
     zhashx_set_key_destructor (cache->entries, NULL); // key is part of entry
     zhashx_set_key_duplicator (cache->entries, NULL); // key is part of entry
 
@@ -954,6 +986,8 @@ struct content_cache *content_cache_create (flux_t *h, attr_t *attrs)
     cache->purge_target_size = default_cache_purge_target_size;
     cache->purge_old_entry = default_cache_purge_old_entry;
     cache->hash_name = default_hash;
+    if ((content_hash_size = blobref_validate_hashtype (default_hash)) < 0)
+        goto error;
     cache->h = h;
     cache->reactor = flux_get_reactor (h);
     list_head_init (&cache->lru);
@@ -961,6 +995,7 @@ struct content_cache *content_cache_create (flux_t *h, attr_t *attrs)
 
     if (register_attrs (cache, attrs) < 0)
         goto error;
+    assert (content_hash_size >= sizeof (size_t)); // hasher assumes this
 
     if (flux_msg_handler_addvec (h, htab, cache, &cache->handlers) < 0)
         goto error;

--- a/src/cmd/builtin/content.c
+++ b/src/cmd/builtin/content.c
@@ -39,8 +39,8 @@ static int internal_content_load (optparse_t *p, int ac, char *av[])
         log_err_exit ("flux_open");
     if (optparse_hasopt (p, "bypass-cache"))
         flags |= CONTENT_FLAG_CACHE_BYPASS;
-    if (!(f = content_load (h, ref, flags)))
-        log_err_exit ("content_load");
+    if (!(f = content_load_byblobref (h, ref, flags)))
+        log_err_exit ("content_load_byblobref");
     if (content_load_get (f, (const void **)&data, &size) < 0)
         log_err_exit ("content_load_get");
     if (write_all (STDOUT_FILENO, data, size) < 0)
@@ -71,8 +71,8 @@ static int internal_content_store (optparse_t *p, int ac, char *av[])
         log_err_exit ("read");
     if (!(f = content_store (h, data, size, flags)))
         log_err_exit ("content_store");
-    if (content_store_get (f, &blobref) < 0)
-        log_err_exit ("content_store_get");
+    if (content_store_get_blobref (f, &blobref) < 0)
+        log_err_exit ("content_store_get_blobref");
     printf ("%s\n", blobref);
     flux_future_destroy (f);
     flux_close (h);

--- a/src/cmd/builtin/dump.c
+++ b/src/cmd/builtin/dump.c
@@ -134,9 +134,9 @@ static void dump_valref (struct archive *ar,
         log_err_exit ("could not create message list");
     for (int i = 0; i < count; i++) {
         flux_future_t *f;
-        if (!(f = content_load (h,
-                                treeobj_get_blobref (treeobj, i),
-                                content_flags))
+        if (!(f = content_load_byblobref (h,
+                                          treeobj_get_blobref (treeobj, i),
+                                          content_flags))
             || flux_future_get (f, (const void **)&msg) < 0
             || flux_msg_get_payload (msg, &data, &len) < 0) {
             log_msg_exit ("%s: missing blobref %d: %s",
@@ -260,9 +260,9 @@ static void dump_dirref (struct archive *ar,
 
     if (treeobj_get_count (treeobj) != 1)
         log_msg_exit ("%s: blobref count is not 1", path);
-    if (!(f = content_load (h,
-                            treeobj_get_blobref (treeobj, 0),
-                            content_flags))
+    if (!(f = content_load_byblobref (h,
+                                      treeobj_get_blobref (treeobj, 0),
+                                      content_flags))
         || content_load_get (f, &buf, &buflen) < 0) {
         log_msg_exit ("%s: missing blobref: %s",
                       path,
@@ -319,7 +319,7 @@ static void dump_blobref (struct archive *ar,
     const char *key;
     json_t *entry;
 
-    if (!(f = content_load (h, blobref, content_flags))
+    if (!(f = content_load_byblobref (h, blobref, content_flags))
         || content_load_get (f, &buf, &buflen) < 0)
         log_msg_exit ("cannot load root tree object: %s",
                       future_strerror (f, errno));

--- a/src/cmd/builtin/restore.c
+++ b/src/cmd/builtin/restore.c
@@ -116,7 +116,7 @@ static json_t *restore_dir (flux_t *h, json_t *dir)
     if (!(s = treeobj_encode (ndir)))
         log_msg_exit ("out of memory");
     if (!(f = content_store (h, s, strlen (s), content_flags))
-        || content_store_get (f, &blobref) < 0)
+        || content_store_get_blobref (f, &blobref) < 0)
         log_msg_exit ("error storing dirref blob: %s",
                       future_strerror (f, errno));
     progress (1, 0);
@@ -214,7 +214,7 @@ static void restore_value (flux_t *h,
         const char *blobref;
 
         if (!(f = content_store (h, buf, size, content_flags))
-            || content_store_get (f, &blobref) < 0)
+            || content_store_get_blobref (f, &blobref) < 0)
             log_msg_exit ("error storing blob for %s: %s",
                           path,
                           future_strerror (f, errno));

--- a/src/common/libcontent/content.c
+++ b/src/common/libcontent/content.c
@@ -20,7 +20,9 @@
 
 #include "src/common/libutil/blobref.h"
 
-flux_future_t *content_load (flux_t *h, const char *blobref, int flags)
+flux_future_t *content_load_byblobref (flux_t *h,
+                                       const char *blobref,
+                                       int flags)
 {
     const char *topic = "content.load";
     uint32_t rank = FLUX_NODEID_ANY;
@@ -57,7 +59,7 @@ flux_future_t *content_store (flux_t *h, const void *buf, int len, int flags)
     return flux_rpc_raw (h, topic, buf, len, rank, 0);
 }
 
-int content_store_get (flux_future_t *f, const char **blobref)
+int content_store_get_blobref (flux_future_t *f, const char **blobref)
 {
     int ref_size;
     const char *ref;

--- a/src/common/libcontent/content.h
+++ b/src/common/libcontent/content.h
@@ -19,7 +19,9 @@ enum {
 
 /* Send request to load blob by blobref.
  */
-flux_future_t *content_load (flux_t *h, const char *blobref, int flags);
+flux_future_t *content_load_byblobref (flux_t *h,
+                                       const char *blobref,
+                                       int flags);
 
 /* Get result of load request (blob).
  * This blocks until response is received.
@@ -33,10 +35,10 @@ int content_load_get (flux_future_t *f, const void **buf, int *len);
 flux_future_t *content_store (flux_t *h, const void *buf, int len, int flags);
 
 /* Get result of store request (blobref).
- * Storage for 'blobref' belongs to 'f' and is valid until 'f' is destroyed.
+ * Storage belongs to 'f' and is valid until 'f' is destroyed.
  * Returns 0 on success, -1 on failure with errno set.
  */
-int content_store_get (flux_future_t *f, const char **blobref);
+int content_store_get_blobref (flux_future_t *f, const char **blobref);
 
 #endif /* !_FLUX_CONTENT_H */
 

--- a/src/common/libcontent/content.h
+++ b/src/common/libcontent/content.h
@@ -17,8 +17,12 @@ enum {
     CONTENT_FLAG_UPSTREAM = 2,    /* make request of upstream TBON peer */
 };
 
-/* Send request to load blob by blobref.
+/* Send request to load blob by hash or blobref.
  */
+flux_future_t *content_load_byhash (flux_t *h,
+                                    const void *hash,
+                                    int hash_len,
+                                    int flags);
 flux_future_t *content_load_byblobref (flux_t *h,
                                        const char *blobref,
                                        int flags);
@@ -34,10 +38,11 @@ int content_load_get (flux_future_t *f, const void **buf, int *len);
  */
 flux_future_t *content_store (flux_t *h, const void *buf, int len, int flags);
 
-/* Get result of store request (blobref).
+/* Get result of store request (hash or blobref).
  * Storage belongs to 'f' and is valid until 'f' is destroyed.
  * Returns 0 on success, -1 on failure with errno set.
  */
+int content_store_get_hash (flux_future_t *f, const void **hash, int *hash_len);
 int content_store_get_blobref (flux_future_t *f, const char **blobref);
 
 #endif /* !_FLUX_CONTENT_H */

--- a/src/common/libutil/blobref.c
+++ b/src/common/libutil/blobref.c
@@ -205,12 +205,17 @@ inval:
     return -1;
 }
 
-int blobref_validate_hashtype (const char *name)
+ssize_t blobref_validate_hashtype (const char *name)
 {
-    if (name == NULL || !lookup_blobhash (name))
+    struct blobhash *bh;
+
+    if (name == NULL || !(bh = lookup_blobhash (name))) {
+        errno = EINVAL;
         return -1;
-    return 0;
+    }
+    return bh->hashlen;
 }
+
 
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab

--- a/src/common/libutil/blobref.c
+++ b/src/common/libutil/blobref.c
@@ -182,6 +182,23 @@ int blobref_hash (const char *hashtype,
     return hashtostr (bh, hash, bh->hashlen, blobref, blobref_len);
 }
 
+int blobref_hash_raw (const char *hashtype,
+                      const void *data, int len,
+                      void *hash, int hash_len)
+{
+    struct blobhash *bh;
+
+    if (!hashtype
+        || !(bh = lookup_blobhash (hashtype))
+        || hash_len < bh->hashlen
+        || !hash) {
+        errno = EINVAL;
+        return -1;
+    }
+    bh->hashfun (data, len, hash, bh->hashlen);
+    return bh->hashlen;
+}
+
 int blobref_validate (const char *blobref)
 {
     struct blobhash *bh;

--- a/src/common/libutil/blobref.h
+++ b/src/common/libutil/blobref.h
@@ -38,6 +38,14 @@ int blobref_hash (const char *hashtype,
                   const void *data, int len,
                   void *blobref, int blobref_len);
 
+/* Compute hash over data and store it in 'hash'.
+ * The hash algorithm is selected by 'hashtype', e.g. "sha1".
+ * Returns hash size on success, -1 on error with errno set.
+ */
+int blobref_hash_raw (const char *hashtype,
+                      const void *data, int len,
+                      void *hash, int hash_len);
+
 /* Check validity of blobref string.
  */
 int blobref_validate (const char *blobref);

--- a/src/common/libutil/blobref.h
+++ b/src/common/libutil/blobref.h
@@ -43,9 +43,10 @@ int blobref_hash (const char *hashtype,
 int blobref_validate (const char *blobref);
 
 /* Check the validity of hash type (by name)
+ * If valid, the digest size is returned.
+ * If invalid, -1 is returned with errno set.
  */
-int blobref_validate_hashtype (const char *name);
-
+ssize_t blobref_validate_hashtype (const char *name);
 
 #endif /* _UTIL_BLOBREF_H */
 /*

--- a/src/common/libutil/test/blobref.c
+++ b/src/common/libutil/test/blobref.c
@@ -148,9 +148,9 @@ int main(int argc, char** argv)
     }
 
     /* blobref_validate_hashtype */
-    ok (blobref_validate_hashtype ("sha1") == 0,
+    ok (blobref_validate_hashtype ("sha1") == SHA1_DIGEST_SIZE,
         "blobref_validate_hashtype sha1 is valid");
-    ok (blobref_validate_hashtype ("sha256") == 0,
+    ok (blobref_validate_hashtype ("sha256") == SHA256_BLOCK_SIZE,
         "blobref_validate_hashtype sha256 is valid");
     ok (blobref_validate_hashtype ("nerf") == -1,
         "blobref_validate_hashtype nerf is invalid");

--- a/src/common/libutil/test/blobref.c
+++ b/src/common/libutil/test/blobref.c
@@ -55,6 +55,20 @@ int main(int argc, char** argv)
         "blobref_hash fails EINVAL with invalid ref length");
 
     errno = 0;
+    ok (blobref_hash_raw ("nerf", data, sizeof (data),
+                          digest, sizeof (digest)) < 0
+        && errno == EINVAL,
+        "blobref_hash_raw fails EINVAL with unknown hash name");
+    errno = 0;
+    ok (blobref_hash_raw ("sha1", data, sizeof (data), NULL, 0) < 0
+        && errno == EINVAL,
+        "blobref_hash_raw fails EINVAL with NULL hash pointer");
+    errno = 0;
+    ok (blobref_hash_raw ("sha1", data, sizeof (data), digest, 1) < 0
+        && errno == EINVAL,
+        "blobref_hash_raw fails EINVAL with invalid hash length");
+
+    errno = 0;
     ok (blobref_strtohash (badref[0], digest, sizeof (digest)) < 0
         && errno == EINVAL,
         "blobref_strtohash fails EINVAL with unknown hash prefix");
@@ -105,6 +119,15 @@ int main(int argc, char** argv)
         "blobref_hash sha1 works");
     diag ("%s", ref);
 
+    ok (blobref_hash_raw ("sha1",
+                          NULL, 0,
+                          digest, sizeof (digest)) == SHA1_DIGEST_SIZE,
+        "blobref_hash_raw sha1 handles zero length data");
+    ok (blobref_hash_raw ("sha1",
+                          data, sizeof (data),
+                          digest, sizeof (digest)) == SHA1_DIGEST_SIZE,
+        "blobref_hash_raw sha1 works");
+
     ok (blobref_strtohash (ref, digest, sizeof (digest)) == SHA1_DIGEST_SIZE,
         "blobref_strtohash returns expected size hash");
     ok (blobref_hashtostr ("sha1", digest, SHA1_DIGEST_SIZE, ref2,
@@ -121,6 +144,15 @@ int main(int argc, char** argv)
     ok (blobref_hash ("sha256", data, sizeof (data), ref, sizeof (ref)) == 0,
         "blobref_hash sha256 works");
     diag ("%s", ref);
+
+    ok (blobref_hash_raw ("sha256",
+                          NULL, 0,
+                          digest, sizeof (digest)) == SHA256_BLOCK_SIZE,
+        "blobref_hash_raw sha256 handles zero length data");
+    ok (blobref_hash_raw ("sha256",
+                          data, sizeof (data),
+                          digest, sizeof (digest)) == SHA256_BLOCK_SIZE,
+        "blobref_hash_raw sha256 works");
 
     ok (blobref_strtohash (ref, digest, sizeof (digest)) == SHA256_BLOCK_SIZE,
         "blobref_strtohash returns expected size hash");

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -492,8 +492,8 @@ static int content_load_request_send (struct kvs_ctx *ctx, const char *ref)
     char *refcpy;
     int saved_errno;
 
-    if (!(f = content_load (ctx->h, ref, 0))) {
-        flux_log_error (ctx->h, "%s: content_load", __FUNCTION__);
+    if (!(f = content_load_byblobref (ctx->h, ref, 0))) {
+        flux_log_error (ctx->h, "%s: content_load_byblobref", __FUNCTION__);
         goto error;
     }
     if (!(refcpy = strdup (ref)))
@@ -593,8 +593,8 @@ static void content_store_completion (flux_future_t *f, void *arg)
     cache_blobref = flux_future_aux_get (f, "cache_blobref");
     assert (cache_blobref);
 
-    if (content_store_get (f, &blobref) < 0) {
-        flux_log_error (ctx->h, "%s: content_store_get", __FUNCTION__);
+    if (content_store_get_blobref (f, &blobref) < 0) {
+        flux_log_error (ctx->h, "%s: content_store_get_blobref", __FUNCTION__);
         goto error;
     }
 
@@ -2809,7 +2809,7 @@ static int store_initial_rootdir (struct kvs_ctx *ctx, char *ref, int ref_len)
             goto error_uncache;
         }
         if (!(f = content_store (ctx->h, data, len, 0))
-                || content_store_get (f, &newref) < 0) {
+                || content_store_get_blobref (f, &newref) < 0) {
             flux_log_error (ctx->h, "%s: content_store", __FUNCTION__);
             goto error_uncache;
         }

--- a/t/kvs/content-spam.c
+++ b/t/kvs/content-spam.c
@@ -30,7 +30,7 @@ static void store_completion (flux_future_t *f, void *arg)
     flux_t *h = arg;
     const char *blobref;
 
-    if (content_store_get (f, &blobref) < 0)
+    if (content_store_get_blobref (f, &blobref) < 0)
         log_err_exit ("store");
     printf ("%s\n", blobref);
     flux_future_destroy (f);

--- a/t/t0012-content-sqlite.t
+++ b/t/t0012-content-sqlite.t
@@ -145,7 +145,7 @@ test_expect_success HAVE_JQ 'kvs-checkpoint.get foo returned correct timestamp' 
         grep 2.2 timestamp.out
 '
 
-test_expect_success HAVE_JQ 'kvs-checkpoint.put updates foo rooref to baz' '
+test_expect_success HAVE_JQ 'kvs-checkpoint.put updates foo rootref to baz' '
 	kvs_checkpoint_put foo baz
 '
 

--- a/t/t0012-content-sqlite.t
+++ b/t/t0012-content-sqlite.t
@@ -171,9 +171,9 @@ test_expect_success HAVE_JQ 'kvs-checkpoint.get noexist fails with No such...' '
 	grep "No such file or directory" badkey.err
 '
 
-test_expect_success 'content-backing.load invalid blobref fails' '
-	echo -n sha999-000 >bad.blobref &&
-	$RPC content-backing.load 2 <bad.blobref 2>load.err
+test_expect_success 'content-backing.load wrong size hash fails with EPROTO' '
+	echo -n xxx >badhash &&
+	$RPC content-backing.load 71 <badhash 2>load.err
 '
 
 getsize() {

--- a/t/t0018-content-files.t
+++ b/t/t0018-content-files.t
@@ -115,7 +115,7 @@ test_expect_success HAVE_JQ 'kvs-checkpoint.get foo returned correct timestamp' 
         grep 2.2 timestamp.out
 '
 
-test_expect_success HAVE_JQ 'kvs-checkpoint.put updates foo rooref to baz' '
+test_expect_success HAVE_JQ 'kvs-checkpoint.put updates foo rootref to baz' '
         kvs_checkpoint_put foo baz
 '
 
@@ -151,7 +151,7 @@ test_expect_success HAVE_JQ 'kvs-checkpoint.get foo still returns rootref baz' '
         test_cmp rootref3.exp rootref3.out
 '
 
-test_expect_success HAVE_JQ 'kvs-checkpoint.put updates foo rooref with longer rootref' '
+test_expect_success HAVE_JQ 'kvs-checkpoint.put updates foo rootref with longer rootref' '
         kvs_checkpoint_put foo abcdefghijklmnopqrstuvwxyz
 '
 
@@ -161,7 +161,7 @@ test_expect_success HAVE_JQ 'kvs-checkpoint.get foo returned rootref with longer
         test_cmp rootref3.exp rootref3.out
 '
 
-test_expect_success HAVE_JQ 'kvs-checkpoint.put updates foo rooref to shorter rootref' '
+test_expect_success HAVE_JQ 'kvs-checkpoint.put updates foo rootref to shorter rootref' '
         kvs_checkpoint_put foo foobar
 '
 

--- a/t/t0024-content-s3.t
+++ b/t/t0024-content-s3.t
@@ -27,11 +27,11 @@ LARGE_SIZES="8388608 10000000 16777216 33554432 67108864"
 # Functions used by tests
 ##
 
-# Usage: backing_load blobref
+# Usage: backing_load <hash
 backing_load() {
-        echo -n $1 | $RPC content-backing.load
+        $RPC -r content-backing.load
 }
-# Usage: backing_store <blob >blobref
+# Usage: backing_store <blob >hash
 backing_store() {
         $RPC -r content-backing.store
 }
@@ -44,23 +44,24 @@ make_blob() {
 	fi
 }
 # Usage: check_blob size
-# Leaves behind blob.<size> and blobref.<size>
+# Leaves behind blob.<size> and hash.<size>
 check_blob() {
 	make_blob $1 >blob.$1 &&
-	backing_store <blob.$1 >blobref.$1 &&
-	backing_load $(cat blobref.$1) >blob.$1.check &&
+	backing_store <blob.$1 >hash.$1 &&
+	backing_load <hash.$1 >blob.$1.check &&
 	test_cmp blob.$1 blob.$1.check
 }
 # Usage: check_blob size
-# Relies on existence of blob.<size> and blobref.<size>
+# Relies on existence of blob.<size> and hash.<size>
 recheck_blob() {
-	backing_load $(cat blobref.$1) >blob.$1.recheck &&
+	backing_load <hash.$1 >blob.$1.recheck &&
 	test_cmp blob.$1 blob.$1.recheck
 }
 # Usage: recheck_cache_blob size
-# Relies on existence of blob.<size> and blobref.<size>
+# Relies on existence of blob.<size>
 recheck_cache_blob() {
-	flux content load $(cat blobref.$1) >blob.$1.cachecheck &&
+	local blobref=$($BLOBREF sha1 <blob.$1)
+	flux content load $blobref >blob.$1.cachecheck &&
 	test_cmp blob.$1 blob.$1.cachecheck
 }
 # Usage: kvs_checkpoint_put key rootref

--- a/t/t0024-content-s3.t
+++ b/t/t0024-content-s3.t
@@ -136,7 +136,7 @@ test_expect_success HAVE_JQ 'kvs-checkpoint.get foo returned correct timestamp' 
         grep 2.2 timestamp.out
 '
 
-test_expect_success HAVE_JQ 'kvs-checkpoint.put updates foo rooref to baz' '
+test_expect_success HAVE_JQ 'kvs-checkpoint.put updates foo rootref to baz' '
         kvs_checkpoint_put foo baz
 '
 

--- a/t/t2008-althash.t
+++ b/t/t2008-althash.t
@@ -67,7 +67,7 @@ test_expect_success S3 'Content store nil returns correct hash for sha256' '
         test "$OUT" = "$nil256"
 '
 
-test_expect_success S3 'Attempt to start instance with invalid hash fails hard' '
+test_expect_success 'Attempt to start instance with invalid hash fails hard' '
     test_must_fail flux start -o,-Scontent.hash=wronghash /bin/true
 '
 

--- a/t/t2008-althash.t
+++ b/t/t2008-althash.t
@@ -43,12 +43,13 @@ test_expect_success S3 'create creds.toml from env' '
 	CREDS
 '
 
+# N.B. don't reuse the bucket from previous tests
 test_expect_success S3 'create content-s3.toml from env' '
 	cat >content-s3.toml <<-TOML
 	[content-s3]
 	credential-file = "$(pwd)/creds/creds.toml"
 	uri = "http://$S3_HOSTNAME"
-	bucket = "$S3_BUCKET"
+	bucket = "${S3_BUCKET}althash"
 	virtual-host-style = false
 	TOML
 '
@@ -64,13 +65,6 @@ test_expect_success S3 'Content store nil returns correct hash for sha256' '
           -o,-Scontent.backing-module=content-s3 \
           flux content store </dev/null) &&
         test "$OUT" = "$nil256"
-'
-
-test_expect_success S3 'Content store nil returns correct hash for sha1' '
-    OUT=$(flux start -o,-Scontent.hash=sha1 \
-          -o,-Scontent.backing-module=content-s3 \
-          flux content store </dev/null) &&
-        test "$OUT" = "$nil1"
 '
 
 test_expect_success S3 'Attempt to start instance with invalid hash fails hard' '


### PR DESCRIPTION
This implements the protocol change proposed in flux-framework/rfc#330, in which blobref strings are replaced with the raw hash in content load/store RPCs.  The broker content-cache also now uses hashes instead of blobrefs as the zhashx key.

The RPC wrappers in libcontent were updated, so their users including `flux-content`, `flux-dump`, `flux-restore`, and the KVS module did not really have to change, although some of the libcontent functions were renamed.

One thing that superficially worked before but no longer works at all after this change is modifying the hash algorithm across an instance restart.  If we want to enable a system instance to migrate from sha1 to sha256, a dump/restore will be required and the content back ends will need to treat an attempt to restart under a different hash as a fatal error.  Since we don't yet have TOML support for changing the hash algorithm, I think we don't necessarily need to fix that here.



