### PR TITLE
flux-shutdown: add --gc garbage collection option

### DIFF
--- a/etc/Makefile.am
+++ b/etc/Makefile.am
@@ -2,6 +2,10 @@
 systemdsystemunit_DATA = flux.service
 #endif
 
+tmpfilesdir = $(prefix)/lib/tmpfiles.d
+
+tmpfiles_DATA = flux.conf
+
 dist_fluxrc_SCRIPTS = \
         rc1 \
         rc3
@@ -43,6 +47,7 @@ noinst_SCRIPTS = \
 
 EXTRA_DIST = \
 	gen-cmdhelp.py \
+	flux.conf \
 	$(noinst_SCRIPTS)
 
 completions/flux: $(srcdir)/completions/flux.pre

--- a/etc/flux.conf
+++ b/etc/flux.conf
@@ -1,0 +1,4 @@
+# See tmpfiles.d(5)
+# remove Flux dump files older than 30 days
+
+e /var/lib/flux/dump - - - 30d

--- a/etc/flux.service.in
+++ b/etc/flux.service.in
@@ -21,6 +21,7 @@ ExecStart=/bin/bash -c '\
   -Sbroker.quorum=0 \
   -Sbroker.quorum-timeout=none \
   -Sbroker.exit-norestart=42 \
+  -Scontent.restore=auto \
 '
 SyslogIdentifier=flux
 ExecReload=@X_BINDIR@/flux config reload

--- a/etc/rc1
+++ b/etc/rc1
@@ -3,10 +3,6 @@
 # Allow connector-local more time to start listening on socket
 RANK=$(FLUX_LOCAL_CONNECTOR_RETRY_COUNT=30 flux getattr rank)
 
-if ! content_backing=$(flux getattr content.backing-module 2>/dev/null); then
-    content_backing=content-sqlite
-fi
-
 # Usage: modload {all|<rank>} modname [args ...]
 modload() {
     local where=$1; shift
@@ -16,7 +12,34 @@ modload() {
 }
 
 modload all barrier
-modload 0 ${content_backing}
+
+if test $RANK -eq 0; then
+    backingmod=$(flux getattr content.backing-module 2>/dev/null) || :
+    backingmod=${backingmod:-content-sqlite}
+    dumpfile=$(flux getattr content.restore 2>/dev/null) || :
+    if test -n "${dumpfile}"; then
+        if test "${dumpfile}" = "auto"; then
+            statedir=$(flux getattr statedir 2>/dev/null) || :
+            dumplink="${statedir:-.}/dump/RESTORE"
+            if test -h "${dumplink}"; then
+                dumpfile=$(readlink -f ${dumplink}) || :
+            else
+                dumpfile=""
+                dumplink=""
+            fi
+        fi
+    fi
+    if test -n "${dumpfile}"; then
+        flux module load ${backingmod} truncate
+        echo "restoring content from ${dumpfile}"
+        flux restore --quiet --checkpoint ${dumpfile}
+        if test -n "${dumplink}"; then
+            rm -f ${dumplink}
+        fi
+    else
+        flux module load ${backingmod}
+    fi
+fi
 
 modload all kvs
 modload all kvs-watch

--- a/etc/rc3
+++ b/etc/rc3
@@ -45,7 +45,25 @@ modrm all kvs
 
 flux content flush || exit_rc=1
 
-backingmod=$(flux getattr content.backing-module 2>/dev/null)
-modrm 0 ${backingmod:-content-sqlite}
+if test $RANK -eq 0; then
+    backingmod=$(flux getattr content.backing-module 2>/dev/null)
+    backingmod=${backingmod:-content-sqlite}
+    dumpfile=$(flux getattr content.dump 2>/dev/null)
+    if test $exit_rc -eq 0 -a -n "${dumpfile}"; then
+        if test "${dumpfile}" = "auto"; then
+            statedir=$(flux getattr statedir 2>/dev/null)
+            mkdir -p "${statedir:-.}/dump"
+            dumpfile="${statedir:-.}/dump/$(date +%Y%m%d_%H%M%S).tgz"
+            dumplink="${statedir:-.}/dump/RESTORE"
+        fi
+        echo "dumping content to ${dumpfile}"
+        if flux dump --quiet --checkpoint ${dumpfile}; then
+            test -n "$dumplink" && ln -s $(basename ${dumpfile}) ${dumplink}
+        else
+            exit_rc=1
+        fi
+    fi
+    flux module remove ${backingmod} || exit_rc=1
+fi
 
 exit $exit_rc

--- a/src/cmd/builtin/shutdown.c
+++ b/src/cmd/builtin/shutdown.c
@@ -68,6 +68,15 @@ static int subcmd (optparse_t *p, int ac, char *av[])
     if (optparse_hasopt (p, "background"))
         flags &= ~FLUX_RPC_STREAMING;
 
+    if (optparse_hasopt (p, "gc") || optparse_hasopt (p, "dump")) {
+        const char *val = optparse_get_str (p, "dump", "auto");
+
+        if (flux_attr_set (h, "content.dump", val) < 0)
+            log_err_exit ("error setting content.dump attribute");
+
+        log_msg ("shutdown will dump KVS (this may take some time)");
+    }
+
     /* N.B. set nodeid=FLUX_NODEID_ANY so we get immediate error from
      * broker if run on rank > 0.
      */
@@ -90,6 +99,12 @@ static int subcmd (optparse_t *p, int ac, char *av[])
 }
 
 static struct optparse_option opts[] = {
+    { .name = "gc", .has_arg = 0,
+      .usage = "Garbage collect KVS (short for --dump=auto)",
+    },
+    { .name = "dump", .has_arg = 1, .arginfo = "PATH",
+      .usage = "Dump KVS content to specified archive file using flux-dump(1)."
+    },
     { .name = "background", .has_arg = 0,
       .usage = "Exit the command immediately after initiating shutdown",
     },

--- a/src/modules/content-files/content-files.c
+++ b/src/modules/content-files/content-files.c
@@ -362,8 +362,7 @@ static int parse_args (flux_t *h,
         else if (!strcmp (argv[i], "truncate"))
             *truncate = true;
         else {
-            errno = EINVAL;
-            flux_log_error (h, "%s", argv[i]);
+            flux_log (h, LOG_ERR, "Unknown module option: %s", argv[i]);
             return -1;
         }
     }

--- a/src/modules/content-s3/content-s3.c
+++ b/src/modules/content-s3/content-s3.c
@@ -480,7 +480,7 @@ static int parse_args (flux_t *h, int argc, char **argv)
             return -1;
         }
         else {
-            flux_log (h, LOG_ERR, "%s", argv[i]);
+            flux_log (h, LOG_ERR, "Unknown module option: %s", argv[i]);
             return -1;
         }
     }

--- a/src/modules/content-s3/content-s3.c
+++ b/src/modules/content-s3/content-s3.c
@@ -469,11 +469,31 @@ error:
     return NULL;
 }
 
+static int parse_args (flux_t *h, int argc, char **argv)
+{
+    for (int i = 0; i < argc; i++) {
+        if (!strcmp (argv[i], "truncate")) {
+            flux_log (h,
+                      LOG_ERR,
+                      "truncate is not implemented.  Use S3 console"
+                      " or other external mechanism to empty bucket.");
+            return -1;
+        }
+        else {
+            flux_log (h, LOG_ERR, "%s", argv[i]);
+            return -1;
+        }
+    }
+    return 0;
+}
+
 int mod_main (flux_t *h, int argc, char **argv)
 {
     struct content_s3 *ctx;
     int rc = -1;
 
+    if (parse_args (h, argc, argv) < 0)
+        return -1;
     if (!(ctx = content_s3_create (h))) {
         flux_log_error (h, "content_s3_create failed");
         return -1;

--- a/src/modules/content-sqlite/content-sqlite.c
+++ b/src/modules/content-sqlite/content-sqlite.c
@@ -807,7 +807,7 @@ static int process_args (struct content_sqlite *ctx,
             *truncate = true;
         }
         else {
-            flux_log_error (ctx->h, "Unknown module option: '%s'", argv[i]);
+            flux_log (ctx->h, LOG_ERR, "Unknown module option: '%s'", argv[i]);
             return -1;
         }
     }

--- a/src/modules/content-sqlite/content-sqlite.c
+++ b/src/modules/content-sqlite/content-sqlite.c
@@ -76,6 +76,7 @@ struct content_sqlite {
     struct content_stats stats;
     const char *journal_mode;
     const char *synchronous;
+    bool truncate;
 };
 
 static void log_sqlite_error (struct content_sqlite *ctx, const char *fmt, ...)
@@ -600,11 +601,14 @@ error:
 
 /* Open the database file ctx->dbfile and set up the database.
  */
-static int content_sqlite_opendb (struct content_sqlite *ctx)
+static int content_sqlite_opendb (struct content_sqlite *ctx, bool truncate)
 {
     int flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE;
     char s[128];
     int count;
+
+    if (truncate)
+        (void)unlink (ctx->dbfile);
 
     if (sqlite3_open_v2 (ctx->dbfile, &ctx->db, flags, NULL) != SQLITE_OK) {
         log_sqlite_error (ctx, "opening %s", ctx->dbfile);
@@ -786,7 +790,10 @@ error:
     return NULL;
 }
 
-static int process_args (struct content_sqlite *ctx, int argc, char **argv)
+static int process_args (struct content_sqlite *ctx,
+                         int argc,
+                         char **argv,
+                         bool *truncate)
 {
     int i;
     for (i = 0; i < argc; i++) {
@@ -795,6 +802,9 @@ static int process_args (struct content_sqlite *ctx, int argc, char **argv)
         }
         else if (strncmp ("synchronous=", argv[i], 12) == 0) {
             ctx->synchronous = argv[i] + 12;
+        }
+        else if (strcmp ("truncate", argv[i]) == 0) {
+            *truncate = true;
         }
         else {
             flux_log_error (ctx->h, "Unknown module option: '%s'", argv[i]);
@@ -807,15 +817,17 @@ static int process_args (struct content_sqlite *ctx, int argc, char **argv)
 int mod_main (flux_t *h, int argc, char **argv)
 {
     struct content_sqlite *ctx;
+    bool truncate = false;
     int rc = -1;
 
     if (!(ctx = content_sqlite_create (h))) {
         flux_log_error (h, "content_sqlite_create failed");
         return -1;
     }
-    if (process_args (ctx, argc, argv) < 0) // override pragmas set above
+    // override pragmas set above
+    if (process_args (ctx, argc, argv, &truncate) < 0)
         goto done;
-    if (content_sqlite_opendb (ctx) < 0)
+    if (content_sqlite_opendb (ctx, truncate) < 0)
         goto done;
     if (content_register_backing_store (h, "content-sqlite") < 0)
         goto done;

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -187,6 +187,7 @@ TESTSCRIPTS = \
 	t2807-dump-cmd.t \
 	t2808-shutdown-cmd.t \
 	t2809-job-purge.t \
+	t2810-kvs-garbage-collect.t \
 	t2900-job-timelimits.t \
 	t3000-mpi-basic.t \
 	t3001-mpi-personalities.t \

--- a/t/sharness.d/flux-sharness.sh
+++ b/t/sharness.d/flux-sharness.sh
@@ -98,6 +98,7 @@ make_bootstrap_config() {
     local full="0-$(($size-1))"
 
     mkdir $workdir/conf.d
+    mkdir $workdir/state
     flux keygen $workdir/cert
     cat >$workdir/conf.d/bootstrap.toml <<-EOT
 	[bootstrap]
@@ -121,6 +122,7 @@ make_bootstrap_config() {
     echo "--test-start-mode=${TEST_UNDER_FLUX_START_MODE:-all}"
     echo "-o,-Stbon.fanout=${TEST_UNDER_FLUX_FANOUT:-$size}"
     echo "-o,-Stbon.zmqdebug=1"
+    echo "-o,-Sstatedir=$workdir/state"
 }
 
 #

--- a/t/t0012-content-sqlite.t
+++ b/t/t0012-content-sqlite.t
@@ -207,11 +207,13 @@ test_expect_success 'remove read permission from content.sqlite file' '
 	chmod u-w $(flux getattr rundir)/content.sqlite &&
 	test_must_fail flux module load content-sqlite
 '
+test_expect_success 'restore read permission on content.sqlite file' '
+	chmod u+w $(flux getattr rundir)/content.sqlite
+'
 
 # Clean slate for a few more tests
-test_expect_success 'remove content.sqlite file' '
-	rm $(flux getattr rundir)/content.sqlite &&
-	flux module load content-sqlite
+test_expect_success 'load content-sqlite with truncate option' '
+	flux module load content-sqlite truncate
 '
 test_expect_success 'content-sqlite and content-cache are empty' '
 	test $(flux module stats \

--- a/t/t0018-content-files.t
+++ b/t/t0018-content-files.t
@@ -73,6 +73,10 @@ kvs_checkpoint_get() {
 # Tests of the module by itself (no content cache)
 ##
 
+test_expect_success 'content-files module load fails with unknown option' '
+	test_must_fail flux module load content-files notoption
+'
+
 test_expect_success 'load content-files module' '
 	flux module load content-files testing
 '

--- a/t/t0018-content-files.t
+++ b/t/t0018-content-files.t
@@ -213,6 +213,18 @@ test_expect_success LONGTEST 'reload/verify various size large blobs through cac
 	test $err -eq 0
 '
 
+test_expect_success 'flux module stats reports nonzero object count' '
+	test $(flux module stats \
+	    --type int --parse object_count content-files) -gt 0
+'
+test_expect_success 'reload content-files with truncate option' '
+	flux module reload content-files truncate
+'
+test_expect_success 'flux module stats reports zero object count' '
+	test $(flux module stats \
+	    --type int --parse object_count content-files) -eq 0
+'
+
 test_expect_success 'remove content-files module' '
 	flux module remove content-files
 '

--- a/t/t0024-content-s3.t
+++ b/t/t0024-content-s3.t
@@ -78,6 +78,13 @@ kvs_checkpoint_get() {
 # Tests of the module by itself (no content cache)
 ##
 
+test_expect_success 'content-s3 module load fails with unknown option' '
+	test_must_fail flux module load content-s3 notoption
+'
+test_expect_success 'content-s3 module load fails with truncate option' '
+	test_must_fail flux module load content-s3 truncate
+'
+
 test_expect_success 'create creds.toml from env' '
 	mkdir -p creds &&
 	cat >creds/creds.toml <<-CREDS

--- a/t/t2810-kvs-garbage-collect.t
+++ b/t/t2810-kvs-garbage-collect.t
@@ -1,0 +1,92 @@
+#!/bin/sh
+
+test_description='Test offline KVS garbage collection'
+
+. $(dirname $0)/sharness.sh
+
+test_expect_success 'create test script' '
+	cat >runjobs.sh <<-EOT &&
+	#!/bin/bash -e
+	trap "" SIGHUP
+	flux mini submit --cc=1-10 /bin/true >/dev/null
+	flux queue drain
+	backingmod=\$(flux getattr content.backing-module)
+	flux module stats --type int --parse object_count \$backingmod
+	EOT
+	chmod +x runjobs.sh
+'
+test_expect_success 'run instance that leaves an auto dump' '
+	mkdir -p state &&
+	flux start -o,-Sstatedir=state \
+	    -o,-Scontent.dump=auto \
+	    -o,-Slog-filename=dmesg.log \
+	    ./runjobs.sh >object_count
+'
+test_expect_success 'broker logs report dump activity' '
+	grep "dumping content to" dmesg.log
+'
+test_expect_success 'dump exists and RESTORE symlink is valid' '
+	test -h state/dump/RESTORE &&
+	readlink -f state/dump/RESTORE >archive &&
+	test -f $(cat archive)
+'
+test_expect_success 'restart instance with auto restore' '
+	flux start -o,-Sstatedir=state \
+	    -o,-Scontent.restore=auto \
+	    -o,-Slog-filename=dmesg2.log \
+	    flux module stats \
+	        --type int --parse object_count content-sqlite >object_count2
+'
+test_expect_success 'broker logs report restore activity' '
+	grep "restoring content from" dmesg2.log
+'
+test_expect_success 'number of stored objects was reduced by GC' '
+	before=$(cat object_count) &&
+	after=$(cat object_count2) &&
+	test $before -gt $after
+'
+test_expect_success 'RESTORE symlink is gone' '
+	test_must_fail test -h state/dump/RESTORE
+'
+test_expect_success 'archive file remains' '
+	test -f $(cat archive)
+'
+
+#
+# Now repeat the above test with
+# - content-files backend
+# - no statedir
+# - explicitly named dump file (not auto)
+#
+test_expect_success 'run instance that leaves a named dump' '
+	flux start -o,-Slog-filename=dmesg3.log \
+	    -o,-Scontent.dump=foo.tgz \
+	    -o,-Scontent.backing-module=content-files \
+	    ./runjobs.sh >object_count3
+'
+test_expect_success 'broker logs report dump activity' '
+	grep "dumping content to" dmesg3.log
+'
+test_expect_success 'dump exists in current directory' '
+	test -f foo.tgz
+'
+test_expect_success 'no RESTORE link was created because path is explicit' '
+	test_must_fail test -h dump/RESTORE
+'
+test_expect_success 'restart instance and restore' '
+	flux start -o,-Slog-filename=dmesg4.log \
+	    -o,-Scontent.restore=foo.tgz \
+	    -o,-Scontent.backing-module=content-files \
+	    flux module stats \
+	        --type int --parse object_count content-files >object_count4
+'
+test_expect_success 'broker logs report restore activity' '
+	grep "restoring content from" dmesg4.log
+'
+test_expect_success 'number of stored objects was reduced by GC' '
+	before=$(cat object_count3) &&
+	after=$(cat object_count4) &&
+	test $before -gt $after
+'
+
+test_done


### PR DESCRIPTION
This adds some logic to rc1 and rc3 to enable offline garbage collection of a system instance using `flux-dump(1)` and `flux-restore(1)`.  If requested by `flux shutdown --gc`, a dump is produced in ${statedir} during shutdown with a RESTORE symlink pointed to it.  On startup, if RESTORE exists, the current backing store is truncated and content is restored from the archive file.  Then the RESTORE symlink is removed.

For example on my test system:
```
$ sudo flux shutdown --gc
flux-shutdown: shutdown will dump KVS (this may take some time)
broker.info[0]: cleanup.0: flux queue stop --quiet Exited (rc=0) 0.0s
broker.info[0]: cleanup.1: flux job cancelall --user=all --quiet -f --states RUN Exited (rc=0) 0.0s
broker.info[0]: cleanup.2: flux queue idle --quiet Exited (rc=0) 0.0s
broker.info[0]: cleanup-success: cleanup->shutdown 0.104717s
broker.info[0]: children-none: shutdown->finalize 0.179421ms
broker.info[0]: rc3.0: dumping content to /var/lib/flux/dump-20220425_174130.tgz
broker.info[0]: rc3.0: /usr/local/etc/flux/rc3 Exited (rc=0) 0.6s
broker.info[0]: rc3-success: finalize->goodbye 0.578407s
$ sudo ls -l /var/lib/flux
total 39684
-rw-r--r-- 1 flux flux  1073152 Apr 25 17:41 content.sqlite
-rw-r--r-- 1 flux flux    48183 Apr 25 17:41 dump-20220425_174130.tgz
-rw-r--r-- 1 flux flux 39510016 Apr 24 18:09 job-archive.sqlite
lrwxrwxrwx 1 flux flux       24 Apr 25 17:41 RESTORE -> dump-20220425_174130.tgz
$ sudo systemctl start flux
$ sudo ls -l /var/lib/flux
total 40896
-rw-r--r-- 1 flux flux     4096 Apr 25 17:42 content.sqlite
-rw-r--r-- 1 flux flux  2307232 Apr 25 17:42 content.sqlite-wal
-rw-r--r-- 1 flux flux    48183 Apr 25 17:41 dump-20220425_174130.tgz
-rw-r--r-- 1 flux flux 39510016 Apr 24 18:09 job-archive.sqlite
```

It's also possible to checkpoint/restart an instance with:
```
$ flux shutdown --dump=foo.tar.bz2
$ flux start -o,-Scontent.restore=foo.tar.bz2
```

although this is only practical if R hasn't changed at the moment.

Marking a WIP as I wanted to get feedback on the approach before writing tests.

I had thought maybe garbage collection could be automated somehow by tracking some metric that could be used as an indicator of the need.  However, maybe getting a bit of experience with doing it manually first makes sense.