### PR TITLE
job-archive: use safer pragmas

### DIFF
--- a/src/modules/job-archive/job-archive.c
+++ b/src/modules/job-archive/job-archive.c
@@ -177,7 +177,7 @@ int job_archive_init (struct job_archive_ctx *ctx)
     }
 
     if (sqlite3_exec (ctx->db,
-                      "PRAGMA journal_mode=OFF",
+                      "PRAGMA journal_mode=WAL",
                       NULL,
                       NULL,
                       NULL) != SQLITE_OK) {
@@ -185,7 +185,7 @@ int job_archive_init (struct job_archive_ctx *ctx)
         goto error;
     }
     if (sqlite3_exec (ctx->db,
-                      "PRAGMA synchronous=OFF",
+                      "PRAGMA synchronous=NORMAL",
                       NULL,
                       NULL,
                       NULL) != SQLITE_OK) {

--- a/src/modules/job-archive/job-archive.c
+++ b/src/modules/job-archive/job-archive.c
@@ -26,6 +26,8 @@
 
 #include "src/common/libutil/log.h"
 #include "src/common/libutil/fsd.h"
+#include "src/common/libutil/tstat.h"
+#include "src/common/libutil/monotime.h"
 
 #define BUSY_TIMEOUT_DEFAULT 50
 #define BUFSIZE              1024
@@ -65,6 +67,7 @@ struct job_archive_ctx {
     sqlite3_stmt *store_stmt;
     double since;
     int kvs_lookup_count;
+    tstat_t sqlstore;
 };
 
 static void log_sqlite_error (struct job_archive_ctx *ctx, const char *fmt, ...)
@@ -263,6 +266,9 @@ void job_info_lookup_continuation (flux_future_t *f, void *arg)
     const char *jobspec = NULL;
     const char *R = NULL;
     char idbuf[64];
+    struct timespec t0;
+
+    monotime (&t0);
 
     if (flux_rpc_get_unpack (f, "{s:s s:s s?:s}",
                              "eventlog", &eventlog,
@@ -385,6 +391,8 @@ void job_info_lookup_continuation (flux_future_t *f, void *arg)
     if (t_inactive > ctx->since)
         ctx->since = t_inactive;
 
+    tstat_push (&ctx->sqlstore, monotime_since (t0));
+
 out:
     sqlite3_reset (ctx->store_stmt);
     flux_future_destroy (f);
@@ -497,6 +505,25 @@ void job_archive_cb (flux_reactor_t *r,
     }
 }
 
+void stats_get_cb (flux_t *h,
+                   flux_msg_handler_t *mh,
+                   const flux_msg_t *msg,
+                   void *arg)
+{
+    struct job_archive_ctx *ctx = arg;
+
+    if (flux_respond_pack (h,
+                           msg,
+                           "{s:i s:f s:f s:f s:f}",
+                           "count", tstat_count (&ctx->sqlstore),
+                           "min", tstat_min (&ctx->sqlstore),
+                           "max", tstat_max (&ctx->sqlstore),
+                           "mean", tstat_mean (&ctx->sqlstore),
+                           "stddev", tstat_stddev (&ctx->sqlstore)) < 0)
+        flux_log_error (h, "error responding to stats.get request");
+    return;
+}
+
 static int process_config (struct job_archive_ctx *ctx)
 {
     flux_error_t err;
@@ -553,9 +580,15 @@ static int process_config (struct job_archive_ctx *ctx)
     return 0;
 }
 
+static const struct flux_msg_handler_spec htab[] = {
+    { FLUX_MSGTYPE_REQUEST, "job-archive.stats.get", stats_get_cb, 0 },
+    FLUX_MSGHANDLER_TABLE_END,
+};
+
 int mod_main (flux_t *h, int ac, char **av)
 {
     struct job_archive_ctx *ctx = job_archive_ctx_create (h);
+    flux_msg_handler_t **handlers = NULL;
     int rc = -1;
 
     if (!ctx)
@@ -578,10 +611,16 @@ int mod_main (flux_t *h, int ac, char **av)
 
     flux_watcher_start (ctx->w);
 
+    if (flux_msg_handler_addvec (h, htab, ctx, &handlers) < 0) {
+        flux_log_error (h, "flux_msg_handler_addvec");
+        goto done;
+    }
+
     if ((rc = flux_reactor_run (flux_get_reactor (h), 0)) < 0)
         flux_log_error (h, "flux_reactor_run");
 
 done:
+    flux_msg_handler_delvec (handlers);
     job_archive_ctx_destroy (ctx);
     return rc;
 }

--- a/t/t2250-job-archive.t
+++ b/t/t2250-job-archive.t
@@ -249,6 +249,11 @@ test_expect_success 'job-archive: all jobs stored' '
         test $count -eq 7
 '
 
+# we don't check values in module stats b/c it can be racy w/ polling
+test_expect_success 'job-archive: get module stats' '
+        flux module stats job-archive
+'
+
 test_expect_success 'job-archive: unload module' '
         flux module unload job-archive
 '


### PR DESCRIPTION
Following up PR #4294 where `content-sqlite` used safer pragmas, this updates `job-archive` to do the same.

I wasn't entirely sure of the best way to test performance with `job-archive`.  Because it "polls" `job-list` data, there's a non trivial amount of wall clock time dependent on that polling.

So I ended up instrumenting `job-archive` with the following:

```
+    if (clock_gettime (CLOCK_MONOTONIC, &tp_start) < 0)
+        flux_log_error (ctx->h, "clock_gettime start");
     while (sqlite3_step (ctx->store_stmt) != SQLITE_DONE) {
         /* due to rounding errors in sqlite, duplicate entries could be
          * written out on occassion leading to a SQLITE_CONSTRAINT error.
@@ -381,6 +387,10 @@ void job_info_lookup_continuation (flux_future_t *f, void *arg)
             goto out;
         }
     }
+    ctx->total += monotime_since (tp_start);
+    ctx->count++;
+    if (ctx->count % 25 == 0)
+        flux_log (ctx->h, LOG_DEBUG, "count = %u, total = %f, average time = %f", ctx->count, ctx->total, ctx->total / ctx->count);
```

Basically, for every job archived, count up the time it takes to write an entry to the sqlite archive.  So no measurement time wasted on polling or job-info lookups in the KVS or anything else like that.

The results on 4096 jobs run (note these are all milliseconds, run on my laptop).

current master (`journal_mode=OFF` && `synchronous=OFF`)

`2022-04-28T00:14:15.180731Z job-archive.debug[0]: count = 4075, total = 327.133517, average time = 0.080278`

`journal_mode=WAL` && `synchronous=NORMAL`

`2022-04-28T00:39:40.350984Z job-archive.debug[0]: count = 4075, total = 541.424963, average time = 0.132865`

`journal_mode=DELETE` && `synchronous=FULL`

`2022-04-28T00:57:53.516332Z job-archive.debug[0]: count = 4075, total = 30441.640082, average time = 7.470341`

no pragmas set

`2022-04-28T01:21:22.601982Z job-archive.debug[0]: count = 4075, total = 30171.204437, average time = 7.403977a


So WAL & NORMAL slow things down 65%-ish.  But the default of DELETE & FULL is awful, slowing it down 100x-ish.

So I went with updating the pragmas with WAL & NORMAL, just like in `content-sqlite`.
