### PR TITLE
use correct type in content-sqlite, misc. content test cleanup

### DIFF
--- a/src/modules/content-sqlite/content-sqlite.c
+++ b/src/modules/content-sqlite/content-sqlite.c
@@ -36,7 +36,7 @@ const size_t lzo_buf_chunksize = 1024*1024;
 const size_t compression_threshold = 256; /* compress blobs >= this size */
 
 const char *sql_create_table = "CREATE TABLE if not exists objects("
-                               "  hash CHAR(20) PRIMARY KEY,"
+                               "  hash BLOB PRIMARY KEY,"
                                "  size INT,"
                                "  object BLOB"
                                ");";

--- a/t/t2008-althash.t
+++ b/t/t2008-althash.t
@@ -61,8 +61,7 @@ test_expect_success S3 'Started instance with content.hash=sha256,content-s3' '
 	OUT=$(flux start -o,-Scontent.hash=sha256 \
 	    -o,-Scontent.backing-module=content-s3 \
 	    flux getattr content.hash) &&
-	test "$OUT" = "sha256" &&
-	ls -1 content.files | tail -1 | grep sha256
+	test "$OUT" = "sha256"
 '
 test_expect_success S3 'Content store nil returns correct hash for sha256' '
 	OUT=$(flux start -o,-Scontent.hash=sha256 \

--- a/t/t2008-althash.t
+++ b/t/t2008-althash.t
@@ -18,21 +18,24 @@ if test -n "$S3_ACCESS_KEY_ID"; then
 fi
 
 test_expect_success 'Started instance with content.hash=sha1' '
-    OUT=$(flux start -o,-Scontent.hash=sha1 \
-          flux getattr content.hash) && test "$OUT" = "sha1"
+	OUT=$(flux start -o,-Scontent.hash=sha1 \
+	    flux getattr content.hash) &&
+	test "$OUT" = "sha1"
 '
 
 test_expect_success 'Started instance with content.hash=sha256' '
-    OUT=$(flux start -o,-Scontent.hash=sha256 \
-          flux getattr content.hash) && test "$OUT" = "sha256"
+	OUT=$(flux start -o,-Scontent.hash=sha256 \
+	    flux getattr content.hash) &&
+	test "$OUT" = "sha256"
 '
 
 test_expect_success 'Started instance with content.hash=sha256,content-files' '
-    OUT=$(flux start -o,-Scontent.hash=sha256 \
-          -o,-Scontent.backing-module=content-files \
-          -o,-Sstatedir=$(pwd) \
-          flux getattr content.hash) && test "$OUT" = "sha256" &&
-    ls -1 content.files | tail -1 | grep sha256
+	OUT=$(flux start -o,-Scontent.hash=sha256 \
+	    -o,-Scontent.backing-module=content-files \
+	    -o,-Sstatedir=$(pwd) \
+	    flux getattr content.hash) &&
+	test "$OUT" = "sha256" &&
+	ls -1 content.files | tail -1 | grep sha256
 '
 
 test_expect_success S3 'create creds.toml from env' '
@@ -55,20 +58,21 @@ test_expect_success S3 'create content-s3.toml from env' '
 '
 
 test_expect_success S3 'Started instance with content.hash=sha256,content-s3' '
-    OUT=$(flux start -o,-Scontent.hash=sha256 \
-          -o,-Scontent.backing-module=content-s3 \
-          flux getattr content.hash) && test "$OUT" = "sha256" &&
-    ls -1 content.files | tail -1 | grep sha256
+	OUT=$(flux start -o,-Scontent.hash=sha256 \
+	    -o,-Scontent.backing-module=content-s3 \
+	    flux getattr content.hash) &&
+	test "$OUT" = "sha256" &&
+	ls -1 content.files | tail -1 | grep sha256
 '
 test_expect_success S3 'Content store nil returns correct hash for sha256' '
-    OUT=$(flux start -o,-Scontent.hash=sha256 \
-          -o,-Scontent.backing-module=content-s3 \
-          flux content store </dev/null) &&
-        test "$OUT" = "$nil256"
+	OUT=$(flux start -o,-Scontent.hash=sha256 \
+	    -o,-Scontent.backing-module=content-s3 \
+	    flux content store </dev/null) &&
+	test "$OUT" = "$nil256"
 '
 
 test_expect_success 'Attempt to start instance with invalid hash fails hard' '
-    test_must_fail flux start -o,-Scontent.hash=wronghash /bin/true
+	test_must_fail flux start -o,-Scontent.hash=wronghash /bin/true
 '
 
 test_done


### PR DESCRIPTION
This PR modifies the schema of the content-sqlite database to use BLOB instead of CHAR(20) as the type for the hash key in the objects table, as discussed in #2795.

Although this is a schema change, it shouldn't cause problems for system instances on upgrade.  The change only affects the command used to create the objects table if does not already exist.  So if the database already has an objects table, it will continue to use CHAR(20).  The next time the database is recreated (for example after `flux shutdown --gc`) the new column type will be used.

There is also some minor test cleanup here.