### PR TITLE
flux-job: fix purge usage message

### DIFF
--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -500,7 +500,7 @@ static struct optparse_subcommand subcommands[] = {
       memo_opts,
     },
     { "purge",
-      "[--age-limit=FSD] [--count-limit=N]",
+      "[--age-limit=FSD] [--num-limit=N]",
       "Purge the oldest inactive jobs",
       cmd_purge,
       0,


### PR DESCRIPTION
Problem: purge usage string uses the wrong name for the
--num-usage option.

Fix usage string.

Fixes #4317