### PR TITLE
python: uri: fix intermittent failure of fallback pid resolver

### DIFF
--- a/src/bindings/python/flux/uri/resolvers/pid.py
+++ b/src/bindings/python/flux/uri/resolvers/pid.py
@@ -37,9 +37,15 @@ def _get_broker_child_fallback(broker_pid):
             #  of a TOU-TOC race here, so just ignore all errors
             pass
         else:
-            ppid = int(data.split()[3])
-            if ppid == broker_pid:
-                return pid
+            match = re.match(r"^[0-9]+ \(.*\) \w+ ([0-9]+)", data)
+            #  Attempt to convert match to integer. On regex match failure,
+            #   or integer conversion failure, just skip this entry
+            try:
+                ppid = int(match.group(1))
+                if ppid == broker_pid:
+                    return pid
+            except (IndexError, ValueError):
+                pass
     raise ValueError(f"PID {broker_pid} is a flux-broker and no child found")
 
 


### PR DESCRIPTION
Problem: The fallback PID URI resolver was failing intermittently
during testing due to what was presumed whitespace in the command
string found in /proc/[pid]/stat. Since the /proc/[pid]/stat contents
were split into fields on whitespace, the incorrect field was passed
to int() and an exception thrown, resulting in the inscrutable error:

 flux-uri: ERROR: invalid literal for int() with base 10: 'S'

To fix, use a regex instead of simply splitting the contents on
whitespace. This allows whitespace to possibly occur in the command
name, since we now consume everything between parentheses as the
command name.

Fixes #4168