### PR TITLE
flux-overlay: replace --no-color with --color=WHEN option, add -H, --highlight=TARGETS

### DIFF
--- a/src/cmd/builtin/overlay.c
+++ b/src/cmd/builtin/overlay.c
@@ -29,6 +29,9 @@ static double default_timeout = 0.5;
 static const char *ansi_default = "\033[39m";
 static const char *ansi_red = "\033[31m";
 static const char *ansi_yellow = "\033[33m";
+static const char *ansi_blue = "\033[01;34m";
+static const char *ansi_reset = "\033[0m";
+
 //static const char *ansi_green = "\033[32m";
 static const char *ansi_dark_gray = "\033[90m";
 
@@ -62,6 +65,9 @@ static struct optparse_option status_opts[] = {
       .usage = "Colorize output when supported; WHEN can be 'always' "
                "(default if omitted), 'never', or 'auto' (default)."
     },
+    { .name = "highlight", .key = 'H', .has_arg = 1, .arginfo = "TARGET",
+      .usage = "Highlight one or more TARGETs and their ancestors."
+    },
     { .name = "wait", .key = 'w', .has_arg = 1, .arginfo = "STATE",
       .usage = "Wait until subtree enters STATE before reporting"
                " (full, partial, offline, degraded, lost)",
@@ -84,6 +90,7 @@ struct status {
     optparse_t *opt;
     struct timespec start;
     const char *wait;
+    struct idset *highlight;
     zlistx_t *stack;
 };
 
@@ -97,6 +104,7 @@ enum connector {
 
 struct status_node {
     int rank;
+    struct idset *subtree_ranks;
     const char *status;
     double duration;
     bool ghost;
@@ -242,15 +250,29 @@ static const char *status_indent (struct status *ctx, int n)
 
 /* Return string containing hostname and rank.
  */
-static const char *status_getname (struct status *ctx, int rank)
+static const char *status_getname (struct status *ctx,
+                                   struct status_node *node)
 {
     static char buf[128];
+    const char * highlight_start = "";
+    const char * highlight_end = "";
+
+    /*  Highlight name if colorized output is enabled and this rank's
+     *   subtree (when known) intersects requested highlighted ranks:
+     */
+    if (node->subtree_ranks
+        && idset_has_intersection (ctx->highlight, node->subtree_ranks)) {
+        highlight_start = ctx->color ? ansi_blue : "<<";
+        highlight_end = ctx->color ? ansi_reset : ">>";
+    }
 
     snprintf (buf,
               sizeof (buf),
-              "%d %s",
-              rank,
-              flux_get_hostbyrank (ctx->h, rank));
+              "%s%d %s%s",
+              highlight_start,
+              node->rank,
+              flux_get_hostbyrank (ctx->h, node->rank),
+              highlight_end);
     return buf;
 }
 
@@ -278,7 +300,7 @@ static void status_print (struct status *ctx,
     printf ("%s%s%s: %s%s%s\n",
             status_indent (ctx, level),
             connector_string (connector),
-            status_getname (ctx, node->rank),
+            status_getname (ctx, node),
             status_colorize (ctx, node->status, node->ghost),
             status_duration (ctx, node->duration),
             parent ? status_rpctime (ctx) : "");
@@ -326,6 +348,86 @@ static json_t *topo_lookup (struct status *ctx,
     return topo;
 }
 
+/* Recursive function to walk 'topology', adding all subtree ranks to 'ids'.
+ * Returns 0 on success, -1 on failure (errno is not set).
+ *
+ * Note: Lifted directly from src/broker/groups.c
+ */
+static int add_subtree_ids (struct idset *ids, json_t *topology)
+{
+    int rank;
+    json_t *a;
+    size_t index;
+    json_t *entry;
+
+    if (json_unpack (topology, "{s:i s:o}", "rank", &rank, "children", &a) < 0
+        || idset_set (ids, rank) < 0)
+        return -1;
+    json_array_foreach (a, index, entry) {
+        if (add_subtree_ids (ids, entry) < 0)
+            return -1;
+    }
+    return 0;
+}
+
+/*  Return an idset of ranks included in subtree 'topology'
+ *   (including root rank).
+ */
+static struct idset *topology_subtree_ranks (json_t *topology)
+{
+    struct idset *ids;
+
+    if (!topology)
+        return NULL;
+
+    if (!(ids = idset_create (0, IDSET_FLAG_AUTOGROW))
+        || add_subtree_ids (ids, topology))
+        goto error;
+    return ids;
+error:
+    idset_destroy (ids);
+    return NULL;
+}
+
+/*  Return the subtree topology rooted at 'subtree_rank'.
+ */
+static json_t *get_subtree_topology (json_t *topo, int subtree_rank)
+{
+    int rank;
+    json_t *a;
+    json_t *result;
+    size_t index;
+    json_t *entry;
+
+    if (json_unpack (topo, "{s:i s:o}", "rank", &rank, "children", &a) < 0)
+        return NULL;
+    if (rank == subtree_rank)
+        return topo;
+    json_array_foreach (a, index, entry) {
+        if (json_unpack (entry, "{s:i}", "rank", &rank) < 0)
+            return NULL;
+        if (rank == subtree_rank)
+            return entry;
+        else if ((result = get_subtree_topology (entry, subtree_rank)))
+            return result;
+    }
+    return NULL;
+}
+
+/*  Return an idset of all ranks in the topology subtree rooted at 'rank'.
+ */
+static struct idset *subtree_ranks (flux_t *h, int rank)
+{
+    json_t *topo;
+    json_t *topology = get_topology (h);
+
+    if (!(topo = get_subtree_topology (topology, rank))) {
+        log_err ("get_subtree_topology");
+        return NULL;
+    }
+    return topology_subtree_ranks (topo);
+}
+
 /* Walk a "ghost" subtree from the fixed topology.  Each node is assumed to
  * have the same 'status' as the offline/lost parent at the subtree root.
  * This augments healthwalk() to fill in nodes that would otherwise be missing
@@ -349,6 +451,7 @@ static void status_ghostwalk (struct status *ctx,
         .duration = -1., // invalid - don't print
         .ghost = true,
         .connector = connector,
+        .subtree_ranks = NULL,
     };
 
     if (json_unpack (topo, "{s:o}", "children", &children) < 0)
@@ -365,6 +468,9 @@ static void status_ghostwalk (struct status *ctx,
             status_prefix_push (ctx, PIPE);
             node.connector = TEE;
         }
+        if (!(node.subtree_ranks = topology_subtree_ranks (entry)))
+            log_err_exit ("Unable to get subtree ranks for rank %d",
+                          node.rank);
         if (fun (ctx, &node, false, level + 1))
             status_ghostwalk (ctx,
                               entry,
@@ -373,6 +479,7 @@ static void status_ghostwalk (struct status *ctx,
                               node.connector,
                               fun);
         status_prefix_pop (ctx);
+        idset_destroy (node.subtree_ranks);
     }
 }
 
@@ -425,13 +532,18 @@ static int status_healthwalk (struct status *ctx,
                               enum connector connector,
                               map_f fun)
 {
-    struct status_node node = { .ghost = false, .connector = connector };
+    struct status_node node = {
+        .ghost = false,
+        .connector = connector,
+        .rank = rank
+    };
     flux_future_t *f;
     json_t *children;
     const char *errstr;
     int rc = 0;
 
     monotime (&ctx->start);
+    node.subtree_ranks = NULL;
 
     if (!(f = health_rpc (ctx, rank, ctx->wait, ctx->timeout))
         || flux_rpc_get_unpack (f,
@@ -452,12 +564,13 @@ static int status_healthwalk (struct status *ctx,
         printf ("%s%s%s: %s%s\n",
                 status_indent (ctx, level),
                 connector_string (connector),
-                status_getname (ctx, rank),
+                status_getname (ctx, &node),
                 errstr,
                 status_rpctime (ctx));
         rc = -1;
         goto done;
     }
+    node.subtree_ranks = subtree_ranks (ctx->h, node.rank);
     if (fun (ctx, &node, true, level)) {
         if (children) {
             size_t index;
@@ -474,6 +587,9 @@ static int status_healthwalk (struct status *ctx,
                                  "status", &child.status,
                                  "duration", &child.duration) < 0)
                     log_msg_exit ("error parsing child array entry");
+                if (!(child.subtree_ranks = subtree_ranks (ctx->h, child.rank)))
+                      log_err_exit ("Unable to get subtree idset for rank %d",
+                                    child.rank);
                 if (index == total - 1) {
                     status_prefix_push (ctx, BLANK);
                     connector = child.connector = ELBOW;
@@ -497,10 +613,12 @@ static int status_healthwalk (struct status *ctx,
                     }
                 }
                 status_prefix_pop (ctx);
+                idset_destroy (child.subtree_ranks);
             }
         }
     }
 done:
+    idset_destroy (node.subtree_ranks);
     flux_future_destroy (f);
     return rc;
 }
@@ -576,6 +694,62 @@ static int status_use_color (optparse_t *p)
     return color;
 }
 
+static struct idset *highlight_ranks (struct status *ctx, optparse_t *p)
+{
+    const char *arg;
+    struct idset *ids;
+    struct idset *diff = NULL;
+    struct idset *allranks = NULL;
+    uint32_t size;
+
+    if (flux_get_size (ctx->h, &size) < 0)
+        log_err_exit ("flux_get_size");
+
+    if (!(allranks = idset_create (0, IDSET_FLAG_AUTOGROW))
+        || idset_range_set (allranks, 0, size - 1) < 0
+        || !(ids = idset_create (0, IDSET_FLAG_AUTOGROW)))
+        log_err_exit ("Failed to create highlight idset");
+
+    optparse_getopt_iterator_reset (p, "highlight");
+    while ((arg = optparse_getopt_next (p, "highlight"))) {
+        flux_error_t error;
+        struct idset *idset;
+        char *result;
+
+        /*  First, attempt to decode as idset. If that fails, assume
+         *   a hostlist was provided and lookup using the hostmap.
+         */
+        if (!(idset = idset_decode (arg))) {
+            if (!(result = flux_hostmap_lookup (ctx->h, arg, &error)))
+                log_msg_exit ("Error decoding %s: %s", arg, error.text);
+            if (!(idset = idset_decode (result)))
+                log_err_exit ("Unable to decode %s", arg);
+            free (result);
+        }
+
+        /*  Accumulate ids in result idset
+         */
+        if (idset_add (ids, idset) < 0)
+            log_err_exit ("Failed to append %s to highlight idset", arg);
+        idset_destroy (idset);
+    }
+
+    /*  Fail with error if any ranks in returned idset will fall outside
+     *   the range 0-size.
+     */
+    if (!(diff = idset_difference (ids, allranks)))
+        log_err_exit ("Failed to determine validity of highlight idset");
+    if (idset_count (diff) > 0)
+        log_msg_exit ("--highlight: rank%s %s not in set %s",
+                      idset_count (diff) > 1 ? "s" : "",
+                      idset_encode (diff, IDSET_FLAG_RANGE),
+                      idset_encode (allranks, IDSET_FLAG_RANGE));
+
+    idset_destroy (diff);
+    idset_destroy (allranks);
+    return ids;
+}
+
 static int subcmd_status (optparse_t *p, int ac, char *av[])
 {
     int rank = optparse_get_int (p, "rank", 0);
@@ -594,6 +768,8 @@ static int subcmd_status (optparse_t *p, int ac, char *av[])
         log_msg_exit ("invalid --wait state");
     if (!(ctx.stack = zlistx_new ()))
         log_msg_exit ("failed to create status zlistx");
+    if (!(ctx.highlight = highlight_ranks (&ctx, p)))
+        log_msg_exit ("failed to create highlight idset");
 
     if (optparse_hasopt (p, "summary"))
         fun = show_top;
@@ -605,6 +781,7 @@ static int subcmd_status (optparse_t *p, int ac, char *av[])
     status_healthwalk (&ctx, rank, 0, NIL, fun);
 
     zlistx_destroy (&ctx.stack);
+    idset_destroy (ctx.highlight);
     return 0;
 }
 

--- a/t/t3303-system-healthcheck.t
+++ b/t/t3303-system-healthcheck.t
@@ -96,6 +96,13 @@ test_expect_success 'flux overlay status --highlight expected failures' '
 	test_must_fail flux overlay status --highlight=fake16
 '
 
+test_expect_success 'flux overlay status --color option works' '
+	test_must_fail flux overlay status --color=foo &&
+	flux overlay status --color=never --highlight=0 | grep "<<0" &&
+	flux overlay status --color=auto --highlight=0 | grep "<<0" &&
+	flux overlay status --color --highlight=0 | grep "\["
+'
+
 test_expect_success 'stop broker 3 with children 7,8' '
 	$startctl kill 3 15
 '

--- a/t/t3303-system-healthcheck.t
+++ b/t/t3303-system-healthcheck.t
@@ -91,7 +91,7 @@ test_expect_success 'flux overlay status -vv works' '
 
 test_expect_success 'flux overlay status shows rank 3 offline' '
 	echo "3 fake3: offline" >health.exp &&
-	flux overlay status --timeout=0 --no-pretty --no-color \
+	flux overlay status --timeout=0 --no-pretty \
 		| grep fake3 >health.out &&
 	test_cmp health.exp health.out
 '
@@ -109,14 +109,14 @@ test_expect_success 'flux overlay status -vv' '
 '
 
 test_expect_success 'flux overlay status: 0,1:partial, 3:offline' '
-	flux overlay status --timeout=0 --no-color --no-pretty  >health2.out &&
+	flux overlay status --timeout=0 --no-pretty  >health2.out &&
 	grep "0 fake0: partial" health2.out &&
 	grep "1 fake1: partial" health2.out &&
 	grep "3 fake3: offline" health2.out
 '
 
 test_expect_success 'flux overlay status: 0-1:partial, 3,7-8:offline' '
-	flux overlay status --timeout=0 --no-color --no-pretty >health3.out &&
+	flux overlay status --timeout=0 --no-pretty >health3.out &&
 	grep "0 fake0: partial" health3.out &&
 	grep "1 fake1: partial" health3.out &&
 	grep "3 fake3: offline" health3.out &&
@@ -125,7 +125,7 @@ test_expect_success 'flux overlay status: 0-1:partial, 3,7-8:offline' '
 '
 
 test_expect_success 'flux overlay status: 0,1:partial, 3,7-8:offline, rest:full' '
-	flux overlay status --timeout=0 --no-color --no-pretty >health4.out &&
+	flux overlay status --timeout=0 --no-pretty >health4.out &&
 	grep "0 fake0: partial" health4.out &&
 	grep "1 fake1: partial" health4.out &&
 	grep "3 fake3: offline" health4.out &&
@@ -234,7 +234,7 @@ test_expect_success 'stop broker 12' '
 '
 
 test_expect_success 'flux overlay status prints connection timed out on 12' '
-	flux overlay status --no-pretty --no-color >status.out &&
+	flux overlay status --no-pretty >status.out &&
 	grep "fake12: Connection timed out" status.out
 '
 

--- a/t/t3303-system-healthcheck.t
+++ b/t/t3303-system-healthcheck.t
@@ -69,6 +69,33 @@ test_expect_success 'wait timeout of zero is not an immediate timeout' '
 	flux overlay status --wait=full --summary --timeout=0
 '
 
+test_expect_success 'flux overlay status --highlight option works (color)' '
+	flux overlay status --highlight=14 --color=always > highlight.out &&
+	grep "\[01;34" highlight.out > highlighted.out &&
+	cat <<-EOF >highlighted.expected &&
+	[01;34m0 fake0[0m: full
+	└─ [01;34m2 fake2[0m: full
+	   └─ [01;34m6 fake6[0m: full
+	      └─ [01;34m14 fake14[0m: full
+	EOF
+	test_cmp highlighted.expected highlighted.out
+'
+
+test_expect_success 'flux overlay status --highlight option takes hostlist' '
+	flux overlay status --highlight=fake[2,6] | grep "<<" > hl2.out &&
+	cat <<-EOF >hl2.expected &&
+	<<0 fake0>>: full
+	└─ <<2 fake2>>: full
+	   └─ <<6 fake6>>: full
+	EOF
+	test_cmp hl2.expected hl2.out
+'
+
+test_expect_success 'flux overlay status --highlight expected failures' '
+	test_must_fail flux overlay status --highlight=0-16 &&
+	test_must_fail flux overlay status --highlight=fake16
+'
+
 test_expect_success 'stop broker 3 with children 7,8' '
 	$startctl kill 3 15
 '

--- a/t/t3305-system-rpctrack-up.t
+++ b/t/t3305-system-rpctrack-up.t
@@ -97,7 +97,7 @@ test_expect_success 'report health status' '
 '
 test_expect_success 'health status for rank 6 is lost' '
 	echo "6 fake6: lost" >status.exp &&
-	flux overlay status --timeout=0 --down --no-color --no-pretty \
+	flux overlay status --timeout=0 --down --no-pretty \
 		| grep fake6 >status.out &&
 	test_cmp status.exp status.out
 '


### PR DESCRIPTION
While I was working on something recently, I wanted an option like the [pstree(1)](https://linux.die.net/man/1/pstree) `--highlight` option for `flux overlay status` to highlight one or more ranks and their ancestors in the overlay. For example, for the new distributed job-exec module, it would be nice to easily know which ranks handled messages for a job after knowing the job's assigned idset or hostlist.

This PR adds a new `-H, --highlight=TARGETS` to `flux overlay status` which will highlight the given ranks and their ancestors (i.e. the subtree involving TARGETS) in color if color is enabled or via the special characters `<< >>` if not (useful for testing, and also _almost_ as visible as color).

This PR also replaces the `--no-color` option with the more standard `--color=WHEN` option we've used in a couple other commands.  Since `--color=auto` is the default, color is now disabled by default when stdout is not connected to a tty, which means `--no-color` can simply be dropped where it was required in test.

This was a little more work than I initially thought when I started the endeavour, however since the feature is nominally working I elected to share it here. I realize the feature only fulfills a rare corner case, so I would leave it up to others if we want to actually merge it.

Examples:

![Screenshot from 2022-05-04 21-13-01](https://user-images.githubusercontent.com/741970/166862789-c024eb81-6651-4898-816a-3154f4cbfbda.png)

![Screenshot from 2022-05-04 21-16-23](https://user-images.githubusercontent.com/741970/166862979-1863d06b-b01b-4e3f-bc2f-f87ff8994fc5.png)

```console
ƒ(s=16,d=0,builddir) grondo@asp:~$ flux overlay status -H 10-12 --color=never
<<0 asp>>: full
├─ <<1 asp>>: full
│  ├─ 3 asp: full
│  │  ├─ 7 asp: full
│  │  │  └─ 15 asp: full
│  │  └─ 8 asp: full
│  └─ <<4 asp>>: full
│     ├─ 9 asp: full
│     └─ <<10 asp>>: full
└─ <<2 asp>>: full
   ├─ <<5 asp>>: full
   │  ├─ <<11 asp>>: full
   │  └─ <<12 asp>>: full
   └─ 6 asp: full
      ├─ 13 asp: full
      └─ 14 asp: full
```
