### PR TITLE
job-list: support new "all" attribute to get all job attributes

### DIFF
--- a/src/bindings/python/flux/job/list.py
+++ b/src/bindings/python/flux/job/list.py
@@ -17,35 +17,6 @@ from flux.job.info import JobInfo
 from flux.rpc import RPC
 
 
-VALID_ATTRS = [
-    "userid",
-    "urgency",
-    "priority",
-    "t_submit",
-    "t_depend",
-    "t_run",
-    "t_cleanup",
-    "t_inactive",
-    "state",
-    "name",
-    "ntasks",
-    "nnodes",
-    "ranks",
-    "nodelist",
-    "waitstatus",
-    "success",
-    "exception_occurred",
-    "exception_type",
-    "exception_severity",
-    "exception_note",
-    "result",
-    "expiration",
-    "annotations",
-    "dependencies",
-    "all",
-]
-
-
 class JobListRPC(RPC):
     def get_jobs(self):
         return self.get()["jobs"]
@@ -178,7 +149,7 @@ class JobList:
     def __init__(
         self,
         flux_handle,
-        attrs=VALID_ATTRS,
+        attrs=["all"],
         filters=[],
         ids=[],
         user=None,

--- a/src/bindings/python/flux/job/list.py
+++ b/src/bindings/python/flux/job/list.py
@@ -42,6 +42,7 @@ VALID_ATTRS = [
     "expiration",
     "annotations",
     "dependencies",
+    "all",
 ]
 
 

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -1092,14 +1092,6 @@ int cmd_cancelall (optparse_t *p, int argc, char **argv)
     return 0;
 }
 
-static const char *list_attrs =
-    "[\"userid\",\"urgency\",\"priority\",\"t_submit\",\"state\"," \
-    "\"name\",\"ntasks\",\"nnodes\",\"ranks\",\"nodelist\",\"expiration\"," \
-    "\"success\",\"exception_occurred\",\"exception_severity\"," \
-    "\"exception_type\",\"exception_note\",\"result\",\"waitstatus\","  \
-    "\"t_depend\",\"t_run\",\"t_cleanup\"," \
-    "\"t_inactive\",\"annotations\",\"dependencies\"]";
-
 int cmd_list (optparse_t *p, int argc, char **argv)
 {
     int optindex = optparse_option_index (p);
@@ -1133,7 +1125,7 @@ int cmd_list (optparse_t *p, int argc, char **argv)
     else
         userid = getuid ();
 
-    if (!(f = flux_job_list (h, max_entries, list_attrs, userid, states)))
+    if (!(f = flux_job_list (h, max_entries, "[\"all\"]", userid, states)))
         log_err_exit ("flux_job_list");
     if (flux_rpc_get_unpack (f, "{s:o}", "jobs", &jobs) < 0)
         log_err_exit ("flux_job_list");
@@ -1169,7 +1161,7 @@ int cmd_list_inactive (optparse_t *p, int argc, char **argv)
     if (!(h = flux_open (NULL, 0)))
         log_err_exit ("flux_open");
 
-    if (!(f = flux_job_list_inactive (h, max_entries, since, list_attrs)))
+    if (!(f = flux_job_list_inactive (h, max_entries, since, "[\"all\"]")))
         log_err_exit ("flux_job_list_inactive");
     if (flux_rpc_get_unpack (f, "{s:o}", "jobs", &jobs) < 0)
         log_err_exit ("flux_job_list_inactive");
@@ -1218,7 +1210,7 @@ int cmd_list_ids (optparse_t *p, int argc, char **argv)
     for (i = 0; i < ids_len; i++) {
         flux_jobid_t id = parse_jobid (argv[optindex + i]);
         flux_future_t *f;
-        if (!(f = flux_job_list_id (h, id, list_attrs)))
+        if (!(f = flux_job_list_id (h, id, "[\"all\"]")))
             log_err_exit ("flux_job_list_id");
         if (flux_future_then (f, -1, list_id_continuation, NULL) < 0)
             log_err_exit ("flux_future_then");

--- a/src/cmd/flux-pstree.py
+++ b/src/cmd/flux-pstree.py
@@ -162,10 +162,9 @@ def load_tree(
     #  This may fail if the instance hasn't loaded the job-list module
     #   or if the current user is not owner
     #
-    attrs = flux.job.list.VALID_ATTRS
     try:
         jobs_rpc = JobList(
-            flux.Flux(uri), ids=jobids, filters=filters, attrs=attrs
+            flux.Flux(uri), ids=jobids, filters=filters, attrs=["all"]
         ).fetch_jobs()
         jobs = jobs_rpc.get_jobs()
     except (OSError, FileNotFoundError):

--- a/src/modules/job-list/job-list.c
+++ b/src/modules/job-list/job-list.c
@@ -20,6 +20,22 @@
 #include "list.h"
 #include "idsync.h"
 
+static const char *attrs[] = {
+    "userid", "urgency", "priority", "t_submit",
+    "t_depend", "t_run", "t_cleanup", "t_inactive",
+    "state", "name", "ntasks", "nnodes",
+    "ranks", "nodelist", "success", "exception_occurred",
+    "exception_type", "exception_severity",
+    "exception_note", "result", "expiration",
+    "annotations", "waitstatus", "dependencies",
+    NULL
+};
+
+const char **job_attrs (void)
+{
+    return attrs;
+}
+
 static void stats_cb (flux_t *h, flux_msg_handler_t *mh,
                       const flux_msg_t *msg, void *arg)
 {

--- a/src/modules/job-list/job-list.h
+++ b/src/modules/job-list/job-list.h
@@ -25,6 +25,8 @@ struct list_ctx {
     zhashx_t *idsync_waits;
 };
 
+const char **job_attrs (void);
+
 #endif /* _FLUX_JOB_LIST_H */
 
 /*

--- a/src/modules/job-list/job_util.c
+++ b/src/modules/job-list/job_util.c
@@ -34,6 +34,152 @@ void seterror (job_list_error_t *errp, const char *fmt, ...)
     }
 }
 
+static int store_attr (struct job *job,
+                       const char *attr,
+                       json_t *o,
+                       job_list_error_t *errp)
+{
+    json_t *val = NULL;
+
+    if (!strcmp (attr, "userid")) {
+        val = json_integer (job->userid);
+    }
+    else if (!strcmp (attr, "urgency")) {
+        val = json_integer (job->urgency);
+    }
+    else if (!strcmp (attr, "priority")) {
+        if (!(job->states_mask & FLUX_JOB_STATE_SCHED))
+            return 0;
+        val = json_integer (job->priority);
+    }
+    else if (!strcmp (attr, "t_submit")
+             || !strcmp (attr, "t_depend")) {
+        if (!(job->states_mask & FLUX_JOB_STATE_DEPEND))
+            return 0;
+        val = json_real (job->t_submit);
+    }
+    else if (!strcmp (attr, "t_run")) {
+        if (!(job->states_mask & FLUX_JOB_STATE_RUN))
+            return 0;
+        val = json_real (job->t_run);
+    }
+    else if (!strcmp (attr, "t_cleanup")) {
+        if (!(job->states_mask & FLUX_JOB_STATE_CLEANUP))
+            return 0;
+        val = json_real (job->t_cleanup);
+    }
+    else if (!strcmp (attr, "t_inactive")) {
+        if (!(job->states_mask & FLUX_JOB_STATE_INACTIVE))
+            return 0;
+        val = json_real (job->t_inactive);
+    }
+    else if (!strcmp (attr, "state")) {
+        val = json_integer (job->state);
+    }
+    else if (!strcmp (attr, "name")) {
+        /* potentially NULL if jobspec invalid */
+        if (job->name)
+            val = json_string (job->name);
+        else
+            val = json_string ("");
+    }
+    else if (!strcmp (attr, "ntasks")) {
+        val = json_integer (job->ntasks);
+    }
+    else if (!strcmp (attr, "nnodes")) {
+        if (!(job->states_mask & FLUX_JOB_STATE_RUN))
+            return 0;
+        val = json_integer (job->nnodes);
+    }
+    else if (!strcmp (attr, "ranks")) {
+        if (!(job->states_mask & FLUX_JOB_STATE_RUN))
+            return 0;
+        /* potentially NULL if R invalid */
+        if (job->ranks)
+            val = json_string (job->ranks);
+        else
+            val = json_string ("");
+    }
+    else if (!strcmp (attr, "nodelist")) {
+        if (!(job->states_mask & FLUX_JOB_STATE_RUN))
+            return 0;
+        /* potentially NULL if R invalid */
+        if (job->nodelist)
+            val = json_string (job->nodelist);
+        else
+            val = json_string ("");
+    }
+    else if (!strcmp (attr, "expiration")) {
+        if (!(job->states_mask & FLUX_JOB_STATE_RUN))
+            return 0;
+        val = json_real (job->expiration);
+    }
+    else if (!strcmp (attr, "waitstatus")) {
+        if (job->wait_status < 0)
+            return 0;
+        val = json_integer (job->wait_status);
+    }
+    else if (!strcmp (attr, "success")) {
+        if (!(job->states_mask & FLUX_JOB_STATE_INACTIVE))
+            return 0;
+        val = json_boolean (job->success);
+    }
+    else if (!strcmp (attr, "exception_occurred")) {
+        if (!(job->states_mask & FLUX_JOB_STATE_INACTIVE))
+            return 0;
+        val = json_boolean (job->exception_occurred);
+    }
+    else if (!strcmp (attr, "exception_severity")) {
+        if (!(job->states_mask & FLUX_JOB_STATE_INACTIVE)
+            || !job->exception_occurred)
+            return 0;
+        val = json_integer (job->exception_severity);
+    }
+    else if (!strcmp (attr, "exception_type")) {
+        if (!(job->states_mask & FLUX_JOB_STATE_INACTIVE)
+            || !job->exception_occurred)
+            return 0;
+        val = json_string (job->exception_type);
+    }
+    else if (!strcmp (attr, "exception_note")) {
+        if (!(job->states_mask & FLUX_JOB_STATE_INACTIVE)
+            || !job->exception_occurred)
+            return 0;
+        val = json_string (job->exception_note);
+    }
+    else if (!strcmp (attr, "result")) {
+        if (!(job->states_mask & FLUX_JOB_STATE_INACTIVE))
+            return 0;
+        val = json_integer (job->result);
+    }
+    else if (!strcmp (attr, "annotations")) {
+        if (!job->annotations)
+            return 0;
+        val = json_incref (job->annotations);
+    }
+    else if (!strcmp (attr, "dependencies")) {
+        if (!job->dependencies)
+            return 0;
+        val = json_incref (grudgeset_tojson (job->dependencies));
+    }
+    else {
+        seterror (errp, "%s is not a valid attribute", attr);
+        errno = EINVAL;
+        return -1;
+    }
+    if (val == NULL) {
+        errno = ENOMEM;
+        return -1;
+    }
+    if (json_object_set_new (o, attr, val) < 0) {
+        json_decref (val);
+        errno = ENOMEM;
+        return -1;
+    }
+
+    return 0;
+}
+
 /* For a given job, create a JSON object containing the jobid and any
  * additional requested attributes and their values.  Returns JSON
  * object which the caller must free.  On error, return NULL with
@@ -44,10 +190,10 @@ void seterror (job_list_error_t *errp, const char *fmt, ...)
  */
 json_t *job_to_json (struct job *job, json_t *attrs, job_list_error_t *errp)
 {
+    json_t *val = NULL;
     size_t index;
     json_t *value;
     json_t *o;
-    json_t *val = NULL;
 
     memset (errp, 0, sizeof (*errp));
 
@@ -66,138 +212,8 @@ json_t *job_to_json (struct job *job, json_t *attrs, job_list_error_t *errp)
             errno = EINVAL;
             goto error;
         }
-        if (!strcmp (attr, "userid")) {
-            val = json_integer (job->userid);
-        }
-        else if (!strcmp (attr, "urgency")) {
-            val = json_integer (job->urgency);
-        }
-        else if (!strcmp (attr, "priority")) {
-            if (!(job->states_mask & FLUX_JOB_STATE_SCHED))
-                continue;
-            val = json_integer (job->priority);
-        }
-        else if (!strcmp (attr, "t_submit")
-                 || !strcmp (attr, "t_depend")) {
-            if (!(job->states_mask & FLUX_JOB_STATE_DEPEND))
-                continue;
-            val = json_real (job->t_submit);
-        }
-        else if (!strcmp (attr, "t_run")) {
-            if (!(job->states_mask & FLUX_JOB_STATE_RUN))
-                continue;
-            val = json_real (job->t_run);
-        }
-        else if (!strcmp (attr, "t_cleanup")) {
-            if (!(job->states_mask & FLUX_JOB_STATE_CLEANUP))
-                continue;
-            val = json_real (job->t_cleanup);
-        }
-        else if (!strcmp (attr, "t_inactive")) {
-            if (!(job->states_mask & FLUX_JOB_STATE_INACTIVE))
-                continue;
-            val = json_real (job->t_inactive);
-        }
-        else if (!strcmp (attr, "state")) {
-            val = json_integer (job->state);
-        }
-        else if (!strcmp (attr, "name")) {
-            /* potentially NULL if jobspec invalid */
-            if (job->name)
-                val = json_string (job->name);
-            else
-                val = json_string ("");
-        }
-        else if (!strcmp (attr, "ntasks")) {
-            val = json_integer (job->ntasks);
-        }
-        else if (!strcmp (attr, "nnodes")) {
-            if (!(job->states_mask & FLUX_JOB_STATE_RUN))
-                continue;
-            val = json_integer (job->nnodes);
-        }
-        else if (!strcmp (attr, "ranks")) {
-            if (!(job->states_mask & FLUX_JOB_STATE_RUN))
-                continue;
-            /* potentially NULL if R invalid */
-            if (job->ranks)
-                val = json_string (job->ranks);
-            else
-                val = json_string ("");
-        }
-        else if (!strcmp (attr, "nodelist")) {
-            if (!(job->states_mask & FLUX_JOB_STATE_RUN))
-                continue;
-            /* potentially NULL if R invalid */
-            if (job->nodelist)
-                val = json_string (job->nodelist);
-            else
-                val = json_string ("");
-        }
-        else if (!strcmp (attr, "expiration")) {
-            if (!(job->states_mask & FLUX_JOB_STATE_RUN))
-                continue;
-            val = json_real (job->expiration);
-        }
-        else if (!strcmp (attr, "waitstatus")) {
-            if (job->wait_status < 0)
-                continue;
-            val = json_integer (job->wait_status);
-        }
-        else if (!strcmp (attr, "success")) {
-            if (!(job->states_mask & FLUX_JOB_STATE_INACTIVE))
-                continue;
-            val = json_boolean (job->success);
-        }
-        else if (!strcmp (attr, "exception_occurred")) {
-            if (!(job->states_mask & FLUX_JOB_STATE_INACTIVE))
-                continue;
-            val = json_boolean (job->exception_occurred);
-        }
-        else if (!strcmp (attr, "exception_severity")) {
-            if (!(job->states_mask & FLUX_JOB_STATE_INACTIVE)
-                || !job->exception_occurred)
-                continue;
-            val = json_integer (job->exception_severity);
-        }
-        else if (!strcmp (attr, "exception_type")) {
-            if (!(job->states_mask & FLUX_JOB_STATE_INACTIVE)
-                || !job->exception_occurred)
-                continue;
-            val = json_string (job->exception_type);
-        }
-        else if (!strcmp (attr, "exception_note")) {
-            if (!(job->states_mask & FLUX_JOB_STATE_INACTIVE)
-                || !job->exception_occurred)
-                continue;
-            val = json_string (job->exception_note);
-        }
-        else if (!strcmp (attr, "result")) {
-            if (!(job->states_mask & FLUX_JOB_STATE_INACTIVE))
-                continue;
-            val = json_integer (job->result);
-        }
-        else if (!strcmp (attr, "annotations")) {
-            if (!job->annotations)
-                continue;
-            val = json_incref (job->annotations);
-        }
-        else if (!strcmp (attr, "dependencies")) {
-            if (!job->dependencies)
-                continue;
-            val = json_incref (grudgeset_tojson (job->dependencies));
-        }
-        else {
-            seterror (errp, "%s is not a valid attribute", attr);
-            errno = EINVAL;
+        if (store_attr (job, attr, o, errp) < 0)
             goto error;
-        }
-        if (val == NULL)
-            goto error_nomem;
-        if (json_object_set_new (o, attr, val) < 0) {
-            json_decref (val);
-            goto error_nomem;
-        }
     }
     return o;
  error_nomem:

--- a/src/modules/job-list/list.c
+++ b/src/modules/job-list/list.c
@@ -574,6 +574,9 @@ void list_attrs_cb (flux_t *h, flux_msg_handler_t *mh,
             goto error;
     }
 
+    if (list_attrs_append (a, "all") < 0)
+        goto error;
+
     if (flux_respond_pack (h, msg, "{s:O}", "attrs", a) < 0)
         flux_log_error (h, "%s: flux_respond_pack", __FUNCTION__);
 

--- a/src/modules/job-list/list.c
+++ b/src/modules/job-list/list.c
@@ -15,6 +15,7 @@
 #endif
 #include <jansson.h>
 #include <flux/core.h>
+#include <assert.h>
 
 #include "src/common/libutil/errno_safe.h"
 #include "src/common/libczmqcontainers/czmq_containers.h"
@@ -556,14 +557,7 @@ int list_attrs_append (json_t *a, const char *attr)
 void list_attrs_cb (flux_t *h, flux_msg_handler_t *mh,
                     const flux_msg_t *msg, void *arg)
 {
-    const char *attrs[] = { "userid", "urgency", "priority", "t_submit",
-                            "t_depend", "t_run", "t_cleanup", "t_inactive",
-                            "state", "name", "ntasks", "nnodes",
-                            "ranks", "nodelist", "success", "exception_occurred",
-                            "exception_type", "exception_severity",
-                            "exception_note", "result", "expiration",
-                            "annotations", "waitstatus", "dependencies",
-                            NULL };
+    const char **attrs;
     json_t *a;
     int i;
 
@@ -571,6 +565,9 @@ void list_attrs_cb (flux_t *h, flux_msg_handler_t *mh,
         errno = ENOMEM;
         goto error;
     }
+
+    attrs = job_attrs ();
+    assert (attrs);
 
     for (i = 0; attrs[i] != NULL; i++) {
         if (list_attrs_append (a, attrs[i]) < 0)

--- a/t/python/t0010-job.py
+++ b/t/python/t0010-job.py
@@ -28,7 +28,6 @@ import flux.kvs
 import flux.constants
 from flux import job
 from flux.job import Jobspec, JobspecV1, ffi, JobID, JobInfo
-from flux.job.list import VALID_ATTRS
 from flux.job.stats import JobStats
 from flux.future import Future
 
@@ -453,8 +452,35 @@ class TestJob(unittest.TestCase):
                     self.assertEqual(getattr(jobid, key), test[key])
 
     def test_25_job_list_attrs(self):
+        expected_attrs = [
+            "userid",
+            "urgency",
+            "priority",
+            "t_submit",
+            "t_depend",
+            "t_run",
+            "t_cleanup",
+            "t_inactive",
+            "state",
+            "name",
+            "ntasks",
+            "nnodes",
+            "ranks",
+            "nodelist",
+            "waitstatus",
+            "success",
+            "exception_occurred",
+            "exception_type",
+            "exception_severity",
+            "exception_note",
+            "result",
+            "expiration",
+            "annotations",
+            "dependencies",
+            "all",
+        ]
         valid_attrs = self.fh.rpc("job-list.list-attrs", "{}").get()["attrs"]
-        self.assertEqual(set(valid_attrs), set(VALID_ATTRS))
+        self.assertEqual(set(valid_attrs), set(expected_attrs))
 
     def test_30_job_stats_sync(self):
         stats = JobStats(self.fh)

--- a/t/t2260-job-list.t
+++ b/t/t2260-job-list.t
@@ -906,7 +906,8 @@ exception_note \
 result \
 expiration \
 annotations \
-waitstatus
+waitstatus \
+dependencies
 "
 
 test_expect_success HAVE_JQ 'list request with empty attrs works' '


### PR DESCRIPTION
Per discussion in #4313, support a new "all" attribute to get all job-list attrs from a job.

- its much easier than listing / maintaining like 25+ keywords
- has potential benefits when we want to archive all data in 1 big blob
- flexibility for future new attributes and need to update less stuff

side notes:

- i didn't support this in `flux-jobs` as I felt it wasn't necessary
- i pondered ways to make it so we didn't need to maintain a list of attrs in `t/python/t0010-job.py`.  Like hypothetically stick all attrs in a text file and have a script that generates C code / python list.  But I'll leave that for another day. (#3572)
