### PR TITLE
job-list: store inactive job data in job database

### DIFF
--- a/src/modules/job-list/Makefile.am
+++ b/src/modules/job-list/Makefile.am
@@ -10,7 +10,8 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir)/src/include \
 	-I$(top_builddir)/src/common/libflux \
 	$(FLUX_SECURITY_CFLAGS) \
-	$(JANSSON_CFLAGS)
+	$(JANSSON_CFLAGS) \
+	$(SQLITE_CFLAGS)
 
 fluxmod_LTLIBRARIES = job-list.la
 
@@ -21,6 +22,8 @@ job_list_la_SOURCES = \
 	job_state.c \
 	job_data.h \
 	job_data.c \
+	job_db.h \
+	job_db.c \
 	list.h \
 	list.c \
 	job_util.h \
@@ -28,7 +31,9 @@ job_list_la_SOURCES = \
 	idsync.h \
 	idsync.c \
 	stats.h \
-	stats.c
+	stats.c \
+	util.h \
+	util.c
 
 job_list_la_LDFLAGS = $(fluxmod_ldflags) -module
 job_list_la_LIBADD = \
@@ -38,4 +43,5 @@ job_list_la_LIBADD = \
 	$(top_builddir)/src/common/libflux-optparse.la \
 	$(top_builddir)/src/common/librlist/librlist.la \
 	$(JANSSON_LIBS) \
-	$(HWLOC_LIBS)
+	$(HWLOC_LIBS) \
+	$(SQLITE_LIBS)

--- a/src/modules/job-list/Makefile.am
+++ b/src/modules/job-list/Makefile.am
@@ -19,6 +19,8 @@ job_list_la_SOURCES = \
 	job-list.h \
 	job_state.h \
 	job_state.c \
+	job_data.h \
+	job_data.c \
 	list.h \
 	list.c \
 	job_util.h \

--- a/src/modules/job-list/job-list.c
+++ b/src/modules/job-list/job-list.c
@@ -17,6 +17,7 @@
 
 #include "job-list.h"
 #include "job_state.h"
+#include "job_data.h"
 #include "list.h"
 #include "idsync.h"
 

--- a/src/modules/job-list/job-list.c
+++ b/src/modules/job-list/job-list.c
@@ -165,6 +165,8 @@ static void list_ctx_destroy (struct list_ctx *ctx)
         flux_msg_handler_delvec (ctx->handlers);
         if (ctx->jsctx)
             job_state_destroy (ctx->jsctx);
+        if (ctx->dbctx)
+            job_db_ctx_destroy (ctx->dbctx);
         if (ctx->idsync_lookups)
             idsync_cleanup (ctx);
         free (ctx);
@@ -172,7 +174,7 @@ static void list_ctx_destroy (struct list_ctx *ctx)
     }
 }
 
-static struct list_ctx *list_ctx_create (flux_t *h)
+static struct list_ctx *list_ctx_create (flux_t *h, int argc, char **argv)
 {
     struct list_ctx *ctx = calloc (1, sizeof (*ctx));
     if (!ctx)
@@ -184,6 +186,10 @@ static struct list_ctx *list_ctx_create (flux_t *h)
         goto error;
     if (!(ctx->jsctx = job_state_create (ctx)))
         goto error;
+    if (!(ctx->dbctx = job_db_setup (h, argc, argv))) {
+        if (errno != ENOTBLK)
+            goto error;
+    }
     if (idsync_setup (ctx) < 0)
         goto error;
     return ctx;
@@ -197,7 +203,7 @@ int mod_main (flux_t *h, int argc, char **argv)
     struct list_ctx *ctx;
     int rc = -1;
 
-    if (!(ctx = list_ctx_create (h))) {
+    if (!(ctx = list_ctx_create (h, argc, argv))) {
         flux_log_error (h, "initialization error");
         goto done;
     }

--- a/src/modules/job-list/job_data.c
+++ b/src/modules/job-list/job_data.c
@@ -1,0 +1,74 @@
+/************************************************************\
+ * Copyright 2022 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* job_data.c - primary struct job helper functions */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <jansson.h>
+#include <flux/core.h>
+
+#include "src/common/libczmqcontainers/czmq_containers.h"
+
+#include "job_data.h"
+
+void job_destroy (void *data)
+{
+    struct job *job = data;
+    if (job) {
+        free (job->ranks);
+        free (job->nodelist);
+        json_decref (job->annotations);
+        grudgeset_destroy (job->dependencies);
+        json_decref (job->jobspec);
+        json_decref (job->R);
+        free (job->eventlog);
+        json_decref (job->exception_context);
+        zlist_destroy (&job->next_states);
+        free (job);
+    }
+}
+
+struct job *job_create (struct list_ctx *ctx, flux_jobid_t id)
+{
+    struct job *job = NULL;
+
+    if (!(job = calloc (1, sizeof (*job))))
+        return NULL;
+    job->ctx = ctx;
+    job->id = id;
+    job->userid = FLUX_USERID_UNKNOWN;
+    job->urgency = -1;
+    /* pending jobs that are not yet assigned a priority shall be
+     * listed after those who do, so we set the job priority to MIN */
+    job->priority = FLUX_JOB_PRIORITY_MIN;
+    job->state = FLUX_JOB_STATE_NEW;
+    job->ntasks = -1;
+    job->nnodes = -1;
+    job->expiration = -1.0;
+    job->wait_status = -1;
+    job->result = FLUX_JOB_RESULT_FAILED;
+
+    if (!(job->next_states = zlist_new ())) {
+        errno = ENOMEM;
+        job_destroy (job);
+        return NULL;
+    }
+
+    job->states_mask = FLUX_JOB_STATE_NEW;
+    job->states_events_mask = FLUX_JOB_STATE_NEW;
+    job->eventlog_seq = -1;
+    return job;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/job-list/job_data.c
+++ b/src/modules/job-list/job_data.c
@@ -28,11 +28,13 @@ void job_destroy (void *data)
         free (job->nodelist);
         json_decref (job->annotations);
         grudgeset_destroy (job->dependencies);
+        json_decref (job->dependencies_db);
         json_decref (job->jobspec);
         json_decref (job->R);
         free (job->eventlog);
         json_decref (job->exception_context);
         zlist_destroy (&job->next_states);
+        json_decref (job->job_dbdata);
         free (job);
     }
 }

--- a/src/modules/job-list/job_data.h
+++ b/src/modules/job-list/job_data.h
@@ -57,7 +57,11 @@ struct job {
     const char *exception_note;
     flux_job_result_t result;
     json_t *annotations;
+    /* dependencies - built up
+     * dependencies_db - recovered from db
+     */
     struct grudgeset *dependencies;
+    json_t *dependencies_db;
 
     /* cache of job information */
     json_t *jobspec;
@@ -65,6 +69,9 @@ struct job {
     char *eventlog;
     size_t eventlog_len;
     json_t *exception_context;
+
+    /* all job data from db */
+    json_t *job_dbdata;
 
     /* Track which states we have seen and have completed transition
      * to.  We do not immediately update to the new state and place

--- a/src/modules/job-list/job_data.h
+++ b/src/modules/job-list/job_data.h
@@ -1,0 +1,97 @@
+/************************************************************\
+ * Copyright 2018 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _FLUX_JOB_LIST_JOB_DATA_H
+#define _FLUX_JOB_LIST_JOB_DATA_H
+
+#include <flux/core.h>
+#include <jansson.h>
+
+#include "job-list.h"
+#include "src/common/libutil/grudgeset.h"
+#include "src/common/libczmqcontainers/czmq_containers.h"
+
+/* timestamp of when we enter the state
+ *
+ * associated eventlog entries when restarting
+ *
+ * t_depend - "submit"
+ * t_priority - "priority" (not saved, can be entered multiple times)
+ * t_sched - "depend" (not saved, can be entered multiple times)
+ * t_run - "alloc"
+ * t_cleanup - "finish" or "exception" w/ severity == 0
+ * t_inactive - "clean"
+ */
+struct job {
+    struct list_ctx *ctx;
+
+    flux_jobid_t id;
+    uint32_t userid;
+    int urgency;
+    int64_t priority;
+    double t_submit;
+    // t_depend is identical to t_submit
+    // double t_depend;
+    double t_run;
+    double t_cleanup;
+    double t_inactive;
+    flux_job_state_t state;
+    const char *name;
+    int ntasks;
+    int nnodes;
+    char *ranks;
+    char *nodelist;
+    double expiration;
+    int wait_status;
+    bool success;
+    bool exception_occurred;
+    int exception_severity;
+    const char *exception_type;
+    const char *exception_note;
+    flux_job_result_t result;
+    json_t *annotations;
+    struct grudgeset *dependencies;
+
+    /* cache of job information */
+    json_t *jobspec;
+    json_t *R;
+    char *eventlog;
+    size_t eventlog_len;
+    json_t *exception_context;
+
+    /* Track which states we have seen and have completed transition
+     * to.  We do not immediately update to the new state and place
+     * onto a new list until we have retrieved any necessary data
+     * associated to that state.  For example, when the 'depend' state
+     * has been seen, we don't immediately place it on the `pending`
+     * list.  We wait until we've retrieved data such as userid,
+     * urgency, etc.
+     *
+     * Track which states we've seen via the states_mask.
+     *
+     * Track states seen via events stream in states_events_mask.
+     */
+    zlist_t *next_states;
+    unsigned int states_mask;
+    unsigned int states_events_mask;
+    void *list_handle;
+
+    int eventlog_seq;           /* last event seq read */
+};
+
+void job_destroy (void *data);
+
+struct job *job_create (struct list_ctx *ctx, flux_jobid_t id);
+
+#endif /* ! _FLUX_JOB_LIST_JOB_DATA_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/job-list/job_db.c
+++ b/src/modules/job-list/job_db.c
@@ -1,0 +1,374 @@
+/************************************************************\
+ * Copyright 2016 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* job_db: support storing inactive jobs to db */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdio.h>
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <unistd.h>
+#include <stdbool.h>
+#include <flux/core.h>
+#include <jansson.h>
+#include <sqlite3.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "src/common/libutil/log.h"
+#include "src/common/libutil/fsd.h"
+#include "src/common/libutil/tstat.h"
+#include "src/common/libutil/monotime.h"
+
+#include "job_db.h"
+#include "job_util.h"
+#include "util.h"
+
+#define BUSY_TIMEOUT_DEFAULT 50
+#define BUFSIZE              1024
+
+const char *sql_create_table = "CREATE TABLE if not exists jobs("
+                               "  id CHAR(16) PRIMARY KEY,"
+                               "  t_inactive REAL,"
+                               "  jobdata JSON,"
+                               "  eventlog TEXT,"
+                               "  jobspec JSON,"
+                               "  R JSON"
+    ");";
+
+const char *sql_store =    \
+    "INSERT INTO jobs"     \
+    "("                    \
+    "  id,t_inactive,jobdata," \
+    "  eventlog,jobspec,R" \
+    ") values ("           \
+    "  ?1, ?2, ?3, ?4, ?5, ?6" \
+    ")";
+
+void job_db_ctx_destroy (struct job_db_ctx *ctx)
+{
+    if (ctx) {
+        free (ctx->dbpath);
+        if (ctx->store_stmt) {
+            if (sqlite3_finalize (ctx->store_stmt) != SQLITE_OK)
+                log_sqlite_error (ctx, "sqlite_finalize store_stmt");
+        }
+        if (ctx->db) {
+            if (sqlite3_close (ctx->db) != SQLITE_OK)
+                log_sqlite_error (ctx, "sqlite3_close");
+        }
+        if (ctx->handlers)
+            flux_msg_handler_delvec (ctx->handlers);
+        free (ctx);
+    }
+}
+
+static struct job_db_ctx * job_db_ctx_create (flux_t *h)
+{
+    struct job_db_ctx *ctx = calloc (1, sizeof (*ctx));
+
+    if (!ctx) {
+        flux_log_error (h, "job_db_ctx_create");
+        goto error;
+    }
+
+    ctx->h = h;
+    ctx->busy_timeout = BUSY_TIMEOUT_DEFAULT;
+
+    return ctx;
+ error:
+    job_db_ctx_destroy (ctx);
+    return (NULL);
+}
+
+static unsigned long long get_file_size (const char *path)
+{
+    struct stat sb;
+
+    if (stat (path, &sb) < 0)
+        return 0;
+    return sb.st_size;
+}
+
+static void db_stats_cb (flux_t *h,
+                         flux_msg_handler_t *mh,
+                         const flux_msg_t *msg,
+                         void *arg)
+{
+    struct job_db_ctx *ctx = arg;
+
+    if (flux_respond_pack (h,
+                           msg,
+                           "{s:I s:{s:i s:f s:f s:f s:f}}",
+                           "dbfile_size", get_file_size (ctx->dbpath),
+                           "store",
+                             "count", tstat_count (&ctx->sqlstore),
+                             "min", tstat_min (&ctx->sqlstore),
+                             "max", tstat_max (&ctx->sqlstore),
+                             "mean", tstat_mean (&ctx->sqlstore),
+                             "stddev", tstat_stddev (&ctx->sqlstore)) < 0)
+        flux_log_error (h, "error responding to db-stats request");
+    return;
+}
+
+static const struct flux_msg_handler_spec htab[] = {
+    { FLUX_MSGTYPE_REQUEST, "job-list.db-stats", db_stats_cb, 0 },
+    FLUX_MSGHANDLER_TABLE_END,
+};
+
+int job_db_init (struct job_db_ctx *ctx)
+{
+    int flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE;
+    char buf[1024];
+    int rc = -1;
+
+    if (sqlite3_open_v2 (ctx->dbpath, &ctx->db, flags, NULL) != SQLITE_OK) {
+        log_sqlite_error (ctx, "opening %s", ctx->dbpath);
+        goto error;
+    }
+
+    if (sqlite3_exec (ctx->db,
+                      "PRAGMA journal_mode=WAL",
+                      NULL,
+                      NULL,
+                      NULL) != SQLITE_OK) {
+        log_sqlite_error (ctx, "setting sqlite 'journal_mode' pragma");
+        goto error;
+    }
+    if (sqlite3_exec (ctx->db,
+                      "PRAGMA synchronous=NORMAL",
+                      NULL,
+                      NULL,
+                      NULL) != SQLITE_OK) {
+        log_sqlite_error (ctx, "setting sqlite 'synchronous' pragma");
+        goto error;
+    }
+    snprintf (buf, 1024, "PRAGMA busy_timeout=%u;", ctx->busy_timeout);
+    if (sqlite3_exec (ctx->db,
+                      buf,
+                      NULL,
+                      NULL,
+                      NULL) != SQLITE_OK) {
+        log_sqlite_error (ctx, "setting sqlite 'busy_timeout' pragma");
+        goto error;
+    }
+    if (sqlite3_exec (ctx->db,
+                      sql_create_table,
+                      NULL,
+                      NULL,
+                      NULL) != SQLITE_OK) {
+        log_sqlite_error (ctx, "creating object table");
+        goto error;
+    }
+
+    if (sqlite3_prepare_v2 (ctx->db,
+                            sql_store,
+                            -1,
+                            &ctx->store_stmt,
+                            NULL) != SQLITE_OK) {
+        log_sqlite_error (ctx, "preparing store stmt");
+        goto error;
+    }
+
+    if (flux_msg_handler_addvec (ctx->h, htab, ctx, &ctx->handlers) < 0) {
+        flux_log_error (ctx->h, "flux_msg_handler_addvec");
+        goto error;
+    }
+
+    rc = 0;
+error:
+    return rc;
+}
+
+int job_db_store (struct job_db_ctx *ctx, struct job *job)
+{
+    json_t *o = NULL;
+    job_list_error_t err;
+    char *job_str = NULL;
+    char *jobspec = NULL;
+    char *R = NULL;
+    char idbuf[64];
+    struct timespec t0;
+    int rv = -1;
+
+    monotime (&t0);
+
+    snprintf (idbuf, 64, "%llu", (unsigned long long)job->id);
+    if (sqlite3_bind_text (ctx->store_stmt,
+                           1,
+                           idbuf,
+                           strlen (idbuf),
+                           SQLITE_STATIC) != SQLITE_OK) {
+        log_sqlite_error (ctx, "store: binding id");
+        goto out;
+    }
+    if (sqlite3_bind_double (ctx->store_stmt,
+                             2,
+                             job->t_inactive) != SQLITE_OK) {
+        log_sqlite_error (ctx, "store: binding t_inactive");
+        goto out;
+    }
+    if (!(o = job_to_json_dbdata (job, &err)))
+        goto out;
+    if (!(job_str = json_dumps (o, JSON_COMPACT))) {
+        errno = ENOMEM;
+        goto out;
+    }
+    if (sqlite3_bind_text (ctx->store_stmt,
+                           3,
+                           job_str,
+                           strlen (job_str),
+                           SQLITE_STATIC) != SQLITE_OK) {
+        log_sqlite_error (ctx, "store: binding jobdata");
+        goto out;
+    }
+    if (sqlite3_bind_text (ctx->store_stmt,
+                           4,
+                           job->eventlog,
+                           strlen (job->eventlog),
+                           SQLITE_STATIC) != SQLITE_OK) {
+        log_sqlite_error (ctx, "store: binding eventlog");
+        goto out;
+    }
+    if (!(jobspec = json_dumps (job->jobspec, 0))) {
+        flux_log_error (ctx->h, "json_dumps jobspec");
+        goto out;
+    }
+    if (sqlite3_bind_text (ctx->store_stmt,
+                           5,
+                           jobspec,
+                           strlen (jobspec),
+                           SQLITE_STATIC) != SQLITE_OK) {
+        log_sqlite_error (ctx, "store: binding jobspec");
+        goto out;
+    }
+    if (job->R) {
+        if (!(R = json_dumps (job->R, 0))) {
+            flux_log_error (ctx->h, "json_dumps R");
+            goto out;
+        }
+    }
+    if (sqlite3_bind_text (ctx->store_stmt,
+                           6,
+                           R ? R: "",
+                           R ? strlen (R) : 0,
+                           SQLITE_STATIC) != SQLITE_OK) {
+        log_sqlite_error (ctx, "store: binding R");
+        goto out;
+    }
+    while (sqlite3_step (ctx->store_stmt) != SQLITE_DONE) {
+        /* due to rounding errors in sqlite, duplicate entries could be
+         * written out on occassion leading to a SQLITE_CONSTRAINT error.
+         * We accept this and move on.
+         */
+        int err = sqlite3_errcode (ctx->db);
+        if (err == SQLITE_CONSTRAINT)
+            break;
+        else if (err == SQLITE_BUSY) {
+            /* In the rare case this cannot complete within the normal
+             * busytimeout, we elect to spin till it completes.  This
+             * may need to be revisited in the future: */
+            flux_log (ctx->h, LOG_DEBUG, "%s: BUSY", __FUNCTION__);
+            usleep (1000);
+            continue;
+        }
+        else {
+            log_sqlite_error (ctx, "store: executing stmt");
+            goto out;
+        }
+    }
+
+    tstat_push (&ctx->sqlstore, monotime_since (t0));
+
+    rv = 0;
+out:
+    sqlite3_reset (ctx->store_stmt);
+    json_decref (o);
+    free (job_str);
+    free (jobspec);
+    free (R);
+    return rv;
+}
+
+static int process_config (struct job_db_ctx *ctx)
+{
+    flux_error_t err;
+    const char *dbpath = NULL;
+    const char *busytimeout = NULL;
+
+    if (flux_conf_unpack (flux_get_conf (ctx->h),
+                          &err,
+                          "{s?{s?s s?s}}",
+                          "job-list",
+                            "dbpath", &dbpath,
+                            "busytimeout", &busytimeout) < 0) {
+        flux_log (ctx->h, LOG_ERR,
+                  "error reading db config: %s",
+                  err.text);
+        return -1;
+    }
+
+    if (dbpath) {
+        if (!(ctx->dbpath = strdup (dbpath)))
+            flux_log_error (ctx->h, "dbpath not configured");
+    }
+    else {
+        const char *dbdir = flux_attr_get (ctx->h, "statedir");
+        if (dbdir) {
+            if (asprintf (&ctx->dbpath, "%s/job-db.sqlite", dbdir) < 0) {
+                flux_log_error (ctx->h, "asprintf");
+                return -1;
+            }
+        }
+    }
+    if (busytimeout) {
+        double tmp;
+        if (fsd_parse_duration (busytimeout, &tmp) < 0)
+            flux_log_error (ctx->h, "busytimeout not configured");
+        else
+            ctx->busy_timeout = (int)(1000 * tmp);
+    }
+
+    return 0;
+}
+
+struct job_db_ctx * job_db_setup (flux_t *h, int ac, char **av)
+{
+    struct job_db_ctx *ctx = job_db_ctx_create (h);
+
+    if (!ctx)
+        return NULL;
+
+    if (process_config (ctx) < 0)
+        goto done;
+
+    if (!ctx->dbpath) {
+        errno = ENOTBLK;
+        goto done;
+    }
+
+    if (job_db_init (ctx) < 0)
+        goto done;
+
+    return ctx;
+
+done:
+    job_db_ctx_destroy (ctx);
+    return NULL;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/job-list/job_db.h
+++ b/src/modules/job-list/job_db.h
@@ -8,28 +8,34 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
-#ifndef _FLUX_JOB_LIST_H
-#define _FLUX_JOB_LIST_H
+#ifndef _FLUX_JOB_DB_H
+#define _FLUX_JOB_DB_H
 
 #include <flux/core.h>
+#include <sqlite3.h>
 
 #include "src/common/libczmqcontainers/czmq_containers.h"
+#include "src/common/libutil/tstat.h"
 
-#include "job_state.h"
-#include "job_db.h"
+#include "job_data.h"
 
-struct list_ctx {
+struct job_db_ctx {
     flux_t *h;
+    char *dbpath;
+    unsigned int busy_timeout;
+    sqlite3 *db;
+    sqlite3_stmt *store_stmt;
     flux_msg_handler_t **handlers;
-    struct job_state_ctx *jsctx;
-    struct job_db_ctx *dbctx;
-    zlistx_t *idsync_lookups;
-    zhashx_t *idsync_waits;
+    tstat_t sqlstore;
 };
 
-const char **job_attrs (void);
+struct job_db_ctx *job_db_setup (flux_t *h, int ac, char **av);
 
-#endif /* _FLUX_JOB_LIST_H */
+void job_db_ctx_destroy (struct job_db_ctx *ctx);
+
+int job_db_store (struct job_db_ctx *ctx, struct job *job);
+
+#endif /* _FLUX_JOB_DB_H */
 
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab

--- a/src/modules/job-list/job_state.c
+++ b/src/modules/job-list/job_state.c
@@ -28,6 +28,7 @@
 #include "src/common/libidset/idset.h"
 
 #include "job_state.h"
+#include "job_data.h"
 #include "idsync.h"
 #include "job_util.h"
 
@@ -114,59 +115,10 @@ static int job_inactive_cmp (const void *a1, const void *a2)
     return NUMCMP (j2->t_inactive, j1->t_inactive);
 }
 
-static void job_destroy (void *data)
-{
-    struct job *job = data;
-    if (job) {
-        free (job->ranks);
-        free (job->nodelist);
-        json_decref (job->annotations);
-        grudgeset_destroy (job->dependencies);
-        json_decref (job->jobspec);
-        json_decref (job->R);
-        free (job->eventlog);
-        json_decref (job->exception_context);
-        zlist_destroy (&job->next_states);
-        free (job);
-    }
-}
-
 static void job_destroy_wrapper (void **data)
 {
     struct job **job = (struct job **)data;
     job_destroy (*job);
-}
-
-static struct job *job_create (struct list_ctx *ctx, flux_jobid_t id)
-{
-    struct job *job = NULL;
-
-    if (!(job = calloc (1, sizeof (*job))))
-        return NULL;
-    job->ctx = ctx;
-    job->id = id;
-    job->userid = FLUX_USERID_UNKNOWN;
-    job->urgency = -1;
-    /* pending jobs that are not yet assigned a priority shall be
-     * listed after those who do, so we set the job priority to MIN */
-    job->priority = FLUX_JOB_PRIORITY_MIN;
-    job->state = FLUX_JOB_STATE_NEW;
-    job->ntasks = -1;
-    job->nnodes = -1;
-    job->expiration = -1.0;
-    job->wait_status = -1;
-    job->result = FLUX_JOB_RESULT_FAILED;
-
-    if (!(job->next_states = zlist_new ())) {
-        errno = ENOMEM;
-        job_destroy (job);
-        return NULL;
-    }
-
-    job->states_mask = FLUX_JOB_STATE_NEW;
-    job->states_events_mask = FLUX_JOB_STATE_NEW;
-    job->eventlog_seq = -1;
-    return job;
 }
 
 /* zlistx_insert() and zlistx_reorder() take a 'low_value' parameter

--- a/src/modules/job-list/job_state.c
+++ b/src/modules/job-list/job_state.c
@@ -29,6 +29,7 @@
 
 #include "job_state.h"
 #include "job_data.h"
+#include "job_db.h"
 #include "idsync.h"
 #include "job_util.h"
 
@@ -807,12 +808,26 @@ static void process_next_state (struct list_ctx *ctx, struct job *job)
             /* FLUX_JOB_STATE_SCHED */
             /* FLUX_JOB_STATE_CLEANUP */
             /* FLUX_JOB_STATE_INACTIVE */
+            bool inactive = false;
 
-            if (st->state == FLUX_JOB_STATE_INACTIVE)
+            if (st->state == FLUX_JOB_STATE_INACTIVE) {
                 eventlog_inactive_complete (ctx, job);
+                inactive = true;
+            }
 
             update_job_state_and_list (ctx, job, st->state, st->timestamp);
             zlist_remove (job->next_states, st);
+
+            if (inactive) {
+                assert (job->state == FLUX_JOB_STATE_INACTIVE);
+
+                /* if no eventlog, assume from restart */
+                if (job->eventlog && jsctx->ctx->dbctx) {
+                    if (job_db_store (jsctx->ctx->dbctx, job) < 0)
+                        flux_log_error (jsctx->h, "%s: job_db_store",
+                                        __FUNCTION__);
+                }
+            }
         }
     }
 }

--- a/src/modules/job-list/job_state.c
+++ b/src/modules/job-list/job_state.c
@@ -124,6 +124,7 @@ static void job_destroy (void *data)
         grudgeset_destroy (job->dependencies);
         json_decref (job->jobspec);
         json_decref (job->R);
+        free (job->eventlog);
         json_decref (job->exception_context);
         zlist_destroy (&job->next_states);
         free (job);
@@ -899,6 +900,42 @@ error:
         flux_log_error (h, "error responding to unpause request");
 }
 
+static int store_eventlog_entry (struct list_ctx *ctx,
+                                 struct job *job,
+                                 json_t *entry)
+{
+    char *s = json_dumps (entry, 0);
+    int rv = -1;
+
+    /* entry should have been verified via eventlog_entry_parse()
+     * earlier */
+    assert (s);
+
+    if (!job->eventlog) {
+        job->eventlog_len = strlen (s) + 2; /* +2 for \n and \0 */
+        if (!(job->eventlog = calloc (1, job->eventlog_len))) {
+            flux_log_error (ctx->h, "calloc");
+            goto error;
+
+        }
+        strcpy (job->eventlog, s);
+        strcat (job->eventlog, "\n");
+    }
+    else {
+        job->eventlog_len += strlen (s) + 1; /* +1 for \n */
+        if (!(job->eventlog = realloc (job->eventlog, job->eventlog_len))) {
+            flux_log_error (ctx->h, "realloc");
+            goto error;
+        }
+        strcat (job->eventlog, s);
+        strcat (job->eventlog, "\n");
+    }
+    rv = 0;
+error:
+    free (s);
+    return rv;
+}
+
 static struct job *eventlog_restart_parse (struct list_ctx *ctx,
                                            const char *eventlog,
                                            flux_jobid_t id)
@@ -927,6 +964,9 @@ static struct job *eventlog_restart_parse (struct list_ctx *ctx,
                             __FUNCTION__, (uintmax_t)job->id);
             goto error;
         }
+
+        if (store_eventlog_entry (ctx, job, value) < 0)
+            goto error;
 
         job->eventlog_seq++;
         if (!strcmp (name, "submit")) {
@@ -1257,11 +1297,16 @@ static int journal_submit_event (struct job_state_ctx *jsctx,
                                  flux_jobid_t id,
                                  int eventlog_seq,
                                  double timestamp,
+                                 json_t *entry,
                                  json_t *context)
 {
     if (!job) {
         if (!(job = job_create (jsctx->ctx, id))){
             flux_log_error (jsctx->h, "%s: job_create", __FUNCTION__);
+            return -1;
+        }
+        if (store_eventlog_entry (jsctx->ctx, job, entry) < 0) {
+            job_destroy (job);
             return -1;
         }
         if (zhashx_insert (jsctx->index, &job->id, job) < 0) {
@@ -1621,12 +1666,18 @@ static int journal_process_event (struct job_state_ctx *jsctx, json_t *event)
         return 0;
     }
 
+    if (job && job->eventlog) {
+        if (store_eventlog_entry (jsctx->ctx, job, entry) < 0)
+            return -1;
+    }
+
     if (!strcmp (name, "submit")) {
         if (journal_submit_event (jsctx,
                                   job,
                                   id,
                                   eventlog_seq,
                                   timestamp,
+                                  entry,
                                   context) < 0)
             return -1;
     }

--- a/src/modules/job-list/job_state.c
+++ b/src/modules/job-list/job_state.c
@@ -122,8 +122,7 @@ static void job_destroy (void *data)
         free (job->nodelist);
         json_decref (job->annotations);
         grudgeset_destroy (job->dependencies);
-        json_decref (job->jobspec_job);
-        json_decref (job->jobspec_cmd);
+        json_decref (job->jobspec);
         json_decref (job->R);
         json_decref (job->exception_context);
         zlist_destroy (&job->next_states);
@@ -397,7 +396,9 @@ static int jobspec_parse (struct list_ctx *ctx,
 {
     json_error_t error;
     json_t *jobspec = NULL;
-    json_t *tasks, *resources, *command, *jobspec_job = NULL;
+    json_t *jobspec_job = NULL;
+    json_t *command = NULL;
+    json_t *tasks, *resources;
     int rc = -1;
 
     if (!(jobspec = json_loads (s, 0, &error))) {
@@ -406,6 +407,8 @@ static int jobspec_parse (struct list_ctx *ctx,
                   __FUNCTION__, (uintmax_t)job->id, error.text);
         goto error;
     }
+
+    job->jobspec = json_incref (jobspec);
 
     if (json_unpack_ex (jobspec, &error, 0,
                         "{s:{s:{s?:o}}}",
@@ -426,7 +429,6 @@ static int jobspec_parse (struct list_ctx *ctx,
                       __FUNCTION__, (uintmax_t)job->id);
             goto nonfatal_error;
         }
-        job->jobspec_job = json_incref (jobspec_job);
     }
 
     if (json_unpack_ex (jobspec, &error, 0,
@@ -453,10 +455,8 @@ static int jobspec_parse (struct list_ctx *ctx,
         goto nonfatal_error;
     }
 
-    job->jobspec_cmd = json_incref (command);
-
-    if (job->jobspec_job) {
-        if (json_unpack_ex (job->jobspec_job, &error, 0,
+    if (jobspec_job) {
+        if (json_unpack_ex (jobspec_job, &error, 0,
                             "{s?:s}",
                             "name", &job->name) < 0) {
             flux_log (ctx->h, LOG_ERR,
@@ -469,7 +469,7 @@ static int jobspec_parse (struct list_ctx *ctx,
     /* If user did not specify job.name, we treat arg 0 of the command
      * as the job name */
     if (!job->name) {
-        json_t *arg0 = json_array_get (job->jobspec_cmd, 0);
+        json_t *arg0 = json_array_get (command, 0);
         if (!arg0 || !json_is_string (arg0)) {
             flux_log (ctx->h, LOG_ERR,
                       "%s: job %ju invalid job command",

--- a/src/modules/job-list/job_state.h
+++ b/src/modules/job-list/job_state.h
@@ -101,8 +101,7 @@ struct job {
     struct grudgeset *dependencies;
 
     /* cache of job information */
-    json_t *jobspec_job;
-    json_t *jobspec_cmd;
+    json_t *jobspec;
     json_t *R;
     json_t *exception_context;
 

--- a/src/modules/job-list/job_state.h
+++ b/src/modules/job-list/job_state.h
@@ -103,6 +103,8 @@ struct job {
     /* cache of job information */
     json_t *jobspec;
     json_t *R;
+    char *eventlog;
+    size_t eventlog_len;
     json_t *exception_context;
 
     /* Track which states we have seen and have completed transition

--- a/src/modules/job-list/job_state.h
+++ b/src/modules/job-list/job_state.h
@@ -16,8 +16,6 @@
 
 #include "job-list.h"
 #include "stats.h"
-#include "src/common/libutil/grudgeset.h"
-#include "src/common/libczmqcontainers/czmq_containers.h"
 
 /* To handle the common case of user queries on job state, we will
  * store jobs in three different lists.
@@ -57,74 +55,6 @@ struct job_state_ctx {
 
     /* stream of job events from the job-manager */
     flux_future_t *events;
-};
-
-/* timestamp of when we enter the state
- *
- * associated eventlog entries when restarting
- *
- * t_depend - "submit"
- * t_priority - "priority" (not saved, can be entered multiple times)
- * t_sched - "depend" (not saved, can be entered multiple times)
- * t_run - "alloc"
- * t_cleanup - "finish" or "exception" w/ severity == 0
- * t_inactive - "clean"
- */
-struct job {
-    struct list_ctx *ctx;
-
-    flux_jobid_t id;
-    uint32_t userid;
-    int urgency;
-    int64_t priority;
-    double t_submit;
-    // t_depend is identical to t_submit
-    // double t_depend;
-    double t_run;
-    double t_cleanup;
-    double t_inactive;
-    flux_job_state_t state;
-    const char *name;
-    int ntasks;
-    int nnodes;
-    char *ranks;
-    char *nodelist;
-    double expiration;
-    int wait_status;
-    bool success;
-    bool exception_occurred;
-    int exception_severity;
-    const char *exception_type;
-    const char *exception_note;
-    flux_job_result_t result;
-    json_t *annotations;
-    struct grudgeset *dependencies;
-
-    /* cache of job information */
-    json_t *jobspec;
-    json_t *R;
-    char *eventlog;
-    size_t eventlog_len;
-    json_t *exception_context;
-
-    /* Track which states we have seen and have completed transition
-     * to.  We do not immediately update to the new state and place
-     * onto a new list until we have retrieved any necessary data
-     * associated to that state.  For example, when the 'depend' state
-     * has been seen, we don't immediately place it on the `pending`
-     * list.  We wait until we've retrieved data such as userid,
-     * urgency, etc.
-     *
-     * Track which states we've seen via the states_mask.
-     *
-     * Track states seen via events stream in states_events_mask.
-     */
-    zlist_t *next_states;
-    unsigned int states_mask;
-    unsigned int states_events_mask;
-    void *list_handle;
-
-    int eventlog_seq;           /* last event seq read */
 };
 
 struct job_state_ctx *job_state_create (struct list_ctx *ctx);

--- a/src/modules/job-list/job_util.c
+++ b/src/modules/job-list/job_util.c
@@ -22,7 +22,6 @@
 
 #include "job-list.h"
 #include "job_util.h"
-#include "job_state.h"
 
 void seterror (job_list_error_t *errp, const char *fmt, ...)
 {

--- a/src/modules/job-list/job_util.c
+++ b/src/modules/job-list/job_util.c
@@ -163,7 +163,10 @@ static int store_attr (struct job *job,
     else if (!strcmp (attr, "dependencies")) {
         if (!job->dependencies)
             return 0;
-        val = json_incref (grudgeset_tojson (job->dependencies));
+        if (job->dependencies_db)
+            val = json_incref (job->dependencies_db);
+        else
+            val = json_incref (grudgeset_tojson (job->dependencies));
     }
     else {
         seterror (errp, "%s is not a valid attribute", attr);

--- a/src/modules/job-list/job_util.c
+++ b/src/modules/job-list/job_util.c
@@ -247,6 +247,38 @@ json_t *job_to_json (struct job *job, json_t *attrs, job_list_error_t *errp)
     return NULL;
 }
 
+json_t *job_to_json_dbdata (struct job *job, job_list_error_t *errp)
+{
+    json_t *val = NULL;
+    json_t *o;
+
+    memset (errp, 0, sizeof (*errp));
+
+    if (!(o = json_object ()))
+        goto error_nomem;
+    if (!(val = json_integer (job->id)))
+        goto error_nomem;
+    if (json_object_set_new (o, "id", val) < 0) {
+        json_decref (val);
+        goto error_nomem;
+    }
+    if (store_all_attr (job, o, errp) < 0)
+        goto error;
+    if (!(val = json_integer (job->states_mask)))
+        goto error_nomem;
+    if (json_object_set_new (o, "states_mask", val) < 0) {
+        json_decref (val);
+        goto error_nomem;
+    }
+    return o;
+error_nomem:
+    errno = ENOMEM;
+error:
+    ERRNO_SAFE_WRAP (json_decref, o);
+    return NULL;
+}
+
+
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab
  */

--- a/src/modules/job-list/job_util.h
+++ b/src/modules/job-list/job_util.h
@@ -13,7 +13,7 @@
 
 #include <flux/core.h>
 
-#include "job_state.h"
+#include "job_data.h"
 
 typedef struct {
     char text[160];

--- a/src/modules/job-list/list.c
+++ b/src/modules/job-list/list.c
@@ -24,7 +24,7 @@
 #include "idsync.h"
 #include "list.h"
 #include "job_util.h"
-#include "job_state.h"
+#include "job_data.h"
 
 json_t *get_job_by_id (struct list_ctx *ctx,
                        job_list_error_t *errp,

--- a/src/modules/job-list/list.c
+++ b/src/modules/job-list/list.c
@@ -15,6 +15,8 @@
 #endif
 #include <jansson.h>
 #include <flux/core.h>
+#include <float.h>
+#include <sqlite3.h>
 #include <assert.h>
 
 #include "src/common/libutil/errno_safe.h"
@@ -25,6 +27,8 @@
 #include "list.h"
 #include "job_util.h"
 #include "job_data.h"
+#include "job_db.h"
+#include "util.h"
 
 json_t *get_job_by_id (struct list_ctx *ctx,
                        job_list_error_t *errp,
@@ -59,7 +63,8 @@ int get_jobs_from_list (json_t *jobs,
                         json_t *attrs,
                         uint32_t userid,
                         int states,
-                        int results)
+                        int results,
+                        double *t_inactive_last)
 {
     struct job *job;
 
@@ -74,6 +79,8 @@ int get_jobs_from_list (json_t *jobs,
                 errno = ENOMEM;
                 return -1;
             }
+            if (t_inactive_last)
+                (*t_inactive_last) = job->t_inactive;
             if (json_array_size (jobs) == max_entries)
                 return 1;
         }
@@ -81,6 +88,181 @@ int get_jobs_from_list (json_t *jobs,
     }
 
     return 0;
+}
+
+struct job *sqliterow_2_job (struct list_ctx *ctx, sqlite3_stmt *res)
+{
+    struct job *job = NULL;
+    const char *s;
+    int success;
+    int exception_occurred;
+    const char *ranks = NULL;
+    const char *nodelist = NULL;
+
+    if (!(job = job_create (ctx, 0)))
+        return NULL;
+
+    /* index 0 - id - will be taken care of below */
+    /* index 1 - t_inactive - will be taken care of below */
+
+    s = (const char *)sqlite3_column_text (res, 2);
+    assert (s);
+    job->job_dbdata = json_loads (s, 0, NULL);
+    assert (job->job_dbdata);
+
+    s = (const char *)sqlite3_column_text (res, 3);
+    assert (s);
+    job->eventlog = strdup (s);
+    assert (job->eventlog);
+
+    s = (const char *)sqlite3_column_text (res, 4);
+    assert (s);
+    job->jobspec = json_loads (s, 0, NULL);
+    assert (job->jobspec);
+
+    s = (const char *)sqlite3_column_text (res, 5);
+    assert (s);
+    if (strlen (s) > 0) {
+        job->R = json_loads (s, 0, NULL);
+        assert (job->R);
+    }
+
+    if (json_unpack (job->job_dbdata,
+                     "{s:I s:i s:i s:I s:f s?:f s?:f s:f s:i s:i}",
+                     "id", &job->id,
+                     "userid", &job->userid,
+                     "urgency", &job->urgency,
+                     "priority", &job->priority,
+                     "t_submit", &job->t_submit,
+                     "t_run", &job->t_run,
+                     "t_cleanup", &job->t_cleanup,
+                     "t_inactive", &job->t_inactive,
+                     "state", &job->state,
+                     "states_mask", &job->states_mask) < 0) {
+        flux_log (ctx->h, LOG_ERR, "json_unpack");
+        return NULL;
+    }
+
+    if (json_unpack (job->job_dbdata,
+                     "{s?:s s?:i s?:i s?:s s?:s s?:f s?:i s:b}",
+                     "name", &job->name,
+                     "ntasks", &job->ntasks,
+                     "nnodes", &job->nnodes,
+                     "ranks", &ranks,
+                     "nodelist", &nodelist,
+                     "expiration", &job->expiration,
+                     "waitstatus", &job->wait_status,
+                     "success", &success) < 0) {
+        flux_log (ctx->h, LOG_ERR, "json_unpack");
+        return NULL;
+    }
+
+    if (json_unpack (job->job_dbdata,
+                     "{s:b s?:s s?:i s?:s s:i s?:O s?:O}",
+                     "exception_occurred", &exception_occurred,
+                     "exception_type", &job->exception_type,
+                     "exception_severity", &job->exception_severity,
+                     "exception_note", &job->exception_note,
+                     "result", &job->result,
+                     "annotations", &job->annotations,
+                     "dependencies", &job->dependencies_db) < 0) {
+        flux_log (ctx->h, LOG_ERR, "json_unpack");
+        return NULL;
+    }
+
+    job->success = success;
+    job->exception_occurred = exception_occurred;
+
+    if (ranks) {
+        job->ranks = strdup (ranks);
+        assert (job->ranks);
+    }
+    if (nodelist) {
+        job->nodelist = strdup (nodelist);
+        assert (job->nodelist);
+    }
+
+    return job;
+}
+
+int get_jobs_from_sqlite (struct list_ctx *ctx,
+                          json_t *jobs,
+                          job_list_error_t *errp,
+                          int max_entries,
+                          json_t *attrs,
+                          uint32_t userid,
+                          int states,
+                          int results,
+                          double t_inactive_last)
+{
+    char *sql = \
+        "SELECT * "
+        "FROM jobs "
+        "WHERE t_inactive < ?1 "
+        "ORDER BY t_inactive DESC;";
+    char *sqllimit = \
+        "SELECT * "
+        "FROM jobs "
+        "WHERE t_inactive < ?1 "
+        "ORDER BY t_inactive DESC LIMIT ?2";
+    sqlite3_stmt *res = NULL;
+    int rv = -1;
+
+    if (!ctx->dbctx)
+        return 0;
+
+    if (sqlite3_prepare_v2 (ctx->dbctx->db,
+                            max_entries ? sqllimit : sql,
+                            -1,
+                            &res,
+                            0) != SQLITE_OK) {
+        log_sqlite_error (ctx->dbctx, "sqlite3_prepare_v2");
+        goto out;
+    }
+    if (sqlite3_bind_double (res, 1, t_inactive_last) != SQLITE_OK) {
+        log_sqlite_error (ctx->dbctx, "sqlite3_bind_int");
+        goto out;
+    }
+    if (max_entries) {
+        int count = max_entries - json_array_size (jobs);
+        if (sqlite3_bind_int (res, 2, count) != SQLITE_OK) {
+            log_sqlite_error (ctx->dbctx, "sqlite3_bind_int");
+            goto out;
+        }
+    }
+
+    while (sqlite3_step (res) == SQLITE_ROW) {
+        struct job *job;
+        if (!(job = sqliterow_2_job (ctx, res))) {
+            log_sqlite_error (ctx->dbctx, "sqliterow_2_job");
+            goto out;
+        }
+        if (job_filter (job, userid, states, results)) {
+            json_t *o;
+            if (!(o = job_to_json (job, attrs, errp))) {
+                job_destroy (job);
+                goto out;
+            }
+            if (json_array_append_new (jobs, o) < 0) {
+                json_decref (o);
+                job_destroy (job);
+                errno = ENOMEM;
+                goto out;
+            }
+            if (json_array_size (jobs) == max_entries) {
+                job_destroy (job);
+                rv = 1;
+                goto out;
+            }
+        }
+
+        job_destroy (job);
+    }
+
+    rv = 0;
+ out:
+    sqlite3_finalize (res);
+    return rv;
 }
 
 /* Create a JSON array of 'job' objects.  'max_entries' determines the
@@ -116,7 +298,8 @@ json_t *get_jobs (struct list_ctx *ctx,
                                        attrs,
                                        userid,
                                        states,
-                                       results)) < 0)
+                                       results,
+                                       NULL)) < 0)
             goto error;
     }
 
@@ -129,13 +312,16 @@ json_t *get_jobs (struct list_ctx *ctx,
                                            attrs,
                                            userid,
                                            states,
-                                           results)) < 0)
+                                           results,
+                                           NULL)) < 0)
                 goto error;
         }
     }
 
     if (states & FLUX_JOB_STATE_INACTIVE) {
         if (!ret) {
+            double t_inactive_last = DBL_MAX;
+
             if ((ret = get_jobs_from_list (jobs,
                                            errp,
                                            ctx->jsctx->inactive,
@@ -143,8 +329,22 @@ json_t *get_jobs (struct list_ctx *ctx,
                                            attrs,
                                            userid,
                                            states,
-                                           results)) < 0)
+                                           results,
+                                           &t_inactive_last)) < 0)
                 goto error;
+
+            if (!ret) {
+                if ((ret = get_jobs_from_sqlite (ctx,
+                                                 jobs,
+                                                 errp,
+                                                 max_entries,
+                                                 attrs,
+                                                 userid,
+                                                 states,
+                                                 results,
+                                                 t_inactive_last)) < 0)
+                    goto error;
+            }
         }
     }
 
@@ -219,6 +419,141 @@ error:
         flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
 }
 
+/* Put jobs from inactive list onto jobs array, breaking if
+ * max_entries has been reached. Returns 1 if jobs array is full, 0 if
+ * continue, -1 one error with errno set:
+ *
+ * ENOMEM - out of memory
+ */
+int get_inactive_jobs_list (struct list_ctx *ctx,
+                            json_t *jobs,
+                            job_list_error_t *errp,
+                            int max_entries,
+                            double since,
+                            json_t *attrs,
+                            const char *name,
+                            double *t_inactive_last)
+{
+    struct job *job;
+
+    job = zlistx_first (ctx->jsctx->inactive);
+    while (job && (job->t_inactive > since)) {
+        if (!name || strcmp (job->name, name) == 0) {
+            json_t *o;
+            if (!(o = job_to_json (job, attrs, errp)))
+                return -1;
+            if (json_array_append_new (jobs, o) < 0) {
+                json_decref (o);
+                errno = ENOMEM;
+                return -1;
+            }
+            if (t_inactive_last)
+                (*t_inactive_last) = job->t_inactive;
+            if (json_array_size (jobs) == max_entries)
+                return 1;
+        }
+        job = zlistx_next (ctx->jsctx->inactive);
+    }
+
+    return 0;
+}
+
+/* Put jobs from inactive list onto jobs array, breaking if
+ * max_entries has been reached. Returns 1 if jobs array is full, 0 if
+ * continue, -1 one error with errno set:
+ *
+ * ENOMEM - out of memory
+ */
+int get_inactive_jobs_sqlite (struct list_ctx *ctx,
+                              json_t *jobs,
+                              job_list_error_t *errp,
+                              int max_entries,
+                              double since,
+                              json_t *attrs,
+                              const char *name,
+                              double t_inactive_last)
+{
+    char *sql = \
+        "SELECT * "
+        "FROM jobs "
+        "WHERE t_inactive > ?1 AND t_inactive < ?2 "
+        "ORDER BY t_inactive DESC;";
+    char *sqllimit = \
+        "SELECT * "
+        "FROM jobs "
+        "WHERE t_inactive > ?1 AND t_inactive < ?2 "
+        "ORDER BY t_inactive DESC LIMIT ?3";
+    sqlite3_stmt *res = NULL;
+    struct job *job;
+    int saved_errno;
+    int rv = -1;
+
+    if (!ctx->dbctx)
+        return 0;
+
+    if (sqlite3_prepare_v2 (ctx->dbctx->db,
+                            max_entries ? sqllimit : sql,
+                            -1,
+                            &res,
+                            0) != SQLITE_OK) {
+        log_sqlite_error (ctx->dbctx, "sqlite3_prepare_v2");
+        goto error;
+    }
+    if (sqlite3_bind_double (res, 1, since) != SQLITE_OK) {
+        log_sqlite_error (ctx->dbctx, "sqlite3_bind_int");
+        goto error;
+    }
+    if (sqlite3_bind_double (res, 2, t_inactive_last) != SQLITE_OK) {
+        log_sqlite_error (ctx->dbctx, "sqlite3_bind_int");
+        goto error;
+    }
+    if (max_entries) {
+        int count = max_entries - json_array_size (jobs);
+        if (sqlite3_bind_int (res, 3, count) != SQLITE_OK) {
+            log_sqlite_error (ctx->dbctx, "sqlite3_bind_int");
+            goto error;
+        }
+    }
+
+    while (sqlite3_step (res) == SQLITE_ROW) {
+        if (!(job = sqliterow_2_job (ctx, res))) {
+            log_sqlite_error (ctx->dbctx, "sqliterow_2_job");
+            goto error;
+        }
+        if (!name || strcmp (job->name, name) == 0) {
+            json_t *o;
+            if (!(o = job_to_json (job, attrs, errp))) {
+                job_destroy (job);
+                goto error;
+            }
+            if (json_array_append_new (jobs, o) < 0) {
+                json_decref (o);
+                job_destroy (job);
+                errno = ENOMEM;
+                goto error;
+            }
+            if (json_array_size (jobs) == max_entries) {
+                job_destroy (job);
+                rv = 1;
+                goto out;
+            }
+        }
+
+        job_destroy (job);
+    }
+
+    rv = 0;
+out:
+    sqlite3_finalize (res);
+    return rv;
+
+error:
+    saved_errno = errno;
+    sqlite3_finalize (res);
+    errno = saved_errno;
+    return -1;
+}
+
 /* Create a JSON array of 'job' objects.  'since' limits entries
  * returned, only returning entries with 't_inactive' newer than the
  * timestamp.  Returns JSON object which the caller must free.  On
@@ -235,38 +570,43 @@ json_t *get_inactive_jobs (struct list_ctx *ctx,
                            const char *name)
 {
     json_t *jobs = NULL;
-    struct job *job;
-    int saved_errno;
+    double t_inactive_last = DBL_MAX;
+    int ret;
 
-    if (!(jobs = json_array ()))
-        goto error_nomem;
-
-    job = zlistx_first (ctx->jsctx->inactive);
-    while (job && (job->t_inactive > since)) {
-        json_t *o;
-        if (!name || strcmp (job->name, name) == 0) {
-            if (!(o = job_to_json (job, attrs, errp)))
-                goto error;
-            if (json_array_append_new (jobs, o) < 0) {
-                json_decref (o);
-                errno = ENOMEM;
-                goto error;
-            }
-            if (json_array_size (jobs) == max_entries)
-                goto out;
-        }
-        job = zlistx_next (ctx->jsctx->inactive);
+    if (!(jobs = json_array ())) {
+        errno = ENOMEM;
+        goto error;
     }
+
+    if ((ret = get_inactive_jobs_list (ctx,
+                                       jobs,
+                                       errp,
+                                       max_entries,
+                                       since,
+                                       attrs,
+                                       name,
+                                       &t_inactive_last)) < 0)
+        goto error;
+
+    if (ret)
+        goto out;
+
+    if ((ret = get_inactive_jobs_sqlite (ctx,
+                                         jobs,
+                                         errp,
+                                         max_entries,
+                                         since,
+                                         attrs,
+                                         name,
+                                         t_inactive_last)) < 0)
+        goto error;
+
 
 out:
     return jobs;
 
-error_nomem:
-    errno = ENOMEM;
 error:
-    saved_errno = errno;
     json_decref (jobs);
-    errno = saved_errno;
     return NULL;
 }
 
@@ -450,6 +790,49 @@ error:
     return -1;
 }
 
+struct job *get_job_by_id_sqlite (struct list_ctx *ctx,
+                                  job_list_error_t *errp,
+                                  const flux_msg_t *msg,
+                                  flux_jobid_t id,
+                                  json_t *attrs,
+                                  bool *stall)
+{
+    char *sql = "SELECT * FROM jobs WHERE id = ?;";
+    sqlite3_stmt *res = NULL;
+    struct job *job = NULL;
+    struct job *rv = NULL;
+
+    if (!ctx->dbctx)
+        return NULL;
+
+    if (sqlite3_prepare_v2 (ctx->dbctx->db,
+                            sql,
+                            -1,
+                            &res,
+                            0) != SQLITE_OK) {
+        log_sqlite_error (ctx->dbctx, "sqlite3_prepare_v2");
+        goto error;
+    }
+
+    if (sqlite3_bind_int64 (res, 1, id) != SQLITE_OK) {
+        log_sqlite_error (ctx->dbctx, "sqlite3_bind_int64");
+        goto error;
+    }
+
+    if (sqlite3_step (res) == SQLITE_ROW) {
+        if (!(job = sqliterow_2_job (ctx, res))) {
+            log_sqlite_error (ctx->dbctx, "sqliterow_2_job");
+            goto error;
+        }
+    }
+
+    rv = job;
+error:
+    sqlite3_finalize (res);
+    return rv;
+}
+
+
 /* Returns JSON object which the caller must free.  On error, return
  * NULL with errno set:
  *
@@ -467,14 +850,16 @@ json_t *get_job_by_id (struct list_ctx *ctx,
     struct job *job;
 
     if (!(job = zhashx_lookup (ctx->jsctx->index, &id))) {
-        if (stall) {
-            if (check_id_valid (ctx, msg, id, attrs) < 0) {
-                flux_log_error (ctx->h, "%s: check_id_valid", __FUNCTION__);
-                return NULL;
+        if (!(job = get_job_by_id_sqlite (ctx, errp, msg, id, attrs, stall))) {
+            if (stall) {
+                if (check_id_valid (ctx, msg, id, attrs) < 0) {
+                    flux_log_error (ctx->h, "%s: check_id_valid", __FUNCTION__);
+                    return NULL;
+                }
+                (*stall) = true;
             }
-            (*stall) = true;
+            return NULL;
         }
-        return NULL;
     }
 
     if (job->state == FLUX_JOB_STATE_NEW) {

--- a/src/modules/job-list/stats.c
+++ b/src/modules/job-list/stats.c
@@ -15,8 +15,8 @@
 #include <ctype.h>
 #include <flux/core.h>
 
-#include "job_state.h"
 #include "stats.h"
+#include "job_data.h"
 
 /*  Return the index into stats->state_count[] array for the
  *   job state 'state'

--- a/src/modules/job-list/stats.h
+++ b/src/modules/job-list/stats.h
@@ -12,6 +12,7 @@
 #define _FLUX_JOB_LIST_JOB_STATS_H
 
 #include <flux/core.h> /* FLUX_JOB_NR_STATES */
+#include <jansson.h>
 
 struct job_stats {
     unsigned int state_count[FLUX_JOB_NR_STATES];

--- a/src/modules/job-list/util.c
+++ b/src/modules/job-list/util.c
@@ -1,0 +1,48 @@
+/************************************************************\
+ * Copyright 2022 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* util.c - utility functions */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <jansson.h>
+#include <stdarg.h>
+#include <sqlite3.h>
+#include <flux/core.h>
+#include <assert.h>
+
+#include "util.h"
+
+void log_sqlite_error (struct job_db_ctx *ctx, const char *fmt, ...)
+{
+    char buf[128];
+    va_list ap;
+
+    va_start (ap, fmt);
+    (void)vsnprintf (buf, sizeof (buf), fmt, ap);
+    va_end (ap);
+
+    if (ctx->db) {
+        const char *errmsg = sqlite3_errmsg (ctx->db);
+        flux_log (ctx->h,
+                  LOG_ERR,
+                  "%s: %s(%d)",
+                  buf,
+                  errmsg ? errmsg : "unknown error code",
+                  sqlite3_extended_errcode (ctx->db));
+    }
+    else
+        flux_log (ctx->h, LOG_ERR, "%s: unknown error, no sqlite3 handle", buf);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/job-list/util.h
+++ b/src/modules/job-list/util.h
@@ -8,27 +8,17 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
-#ifndef _FLUX_JOB_LIST_JOB_UTIL_H
-#define _FLUX_JOB_LIST_JOB_UTIL_H
+#ifndef _FLUX_JOB_LIST_UTIL_H
+#define _FLUX_JOB_LIST_UTIL_H
 
-#include <flux/core.h>
+#include <stdarg.h>
 
 #include "job_data.h"
 
-typedef struct {
-    char text[160];
-} job_list_error_t;
-
 void __attribute__((format (printf, 2, 3)))
-seterror (job_list_error_t *errp, const char *fmt, ...);
+log_sqlite_error (struct job_db_ctx *ctx, const char *fmt, ...);
 
-json_t *job_to_json (struct job *job, json_t *attrs, job_list_error_t *errp);
-
-/* similar to job_to_json(), but all data to be stored in db.
- */
-json_t *job_to_json_dbdata (struct job *job, job_list_error_t *errp);
-
-#endif /* ! _FLUX_JOB_LIST_JOB_UTIL_H */
+#endif /* ! _FLUX_JOB_LIST_UTIL_H */
 
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -130,6 +130,7 @@ TESTSCRIPTS = \
 	t2250-job-archive.t \
 	t2260-job-list.t \
 	t2261-job-list-update.t \
+	t2262-job-list-db.t \
 	t2270-job-dependencies.t \
 	t2271-job-dependency-after.t \
 	t2272-job-begin-time.t \

--- a/t/t2262-job-list-db.t
+++ b/t/t2262-job-list-db.t
@@ -1,0 +1,387 @@
+#!/bin/sh
+
+test_description='Test flux job list db'
+
+. $(dirname $0)/job-list/job-list-helper.sh
+
+. $(dirname $0)/sharness.sh
+
+export FLUX_CONF_DIR=$(pwd)
+if test -z "${TEST_UNDER_FLUX_ACTIVE}"; then
+    STATEDIR=$(mktemp -d)
+fi
+test_under_flux 4 job -o,-Sstatedir=${STATEDIR}
+
+RPC=${FLUX_BUILD_DIR}/t/request/rpc
+
+QUERYCMD="flux python ${FLUX_SOURCE_DIR}/t/scripts/sqlite-query.py"
+
+fj_wait_event() {
+  flux job wait-event --timeout=20 "$@"
+}
+
+get_statedir_dbpath() {
+    statedir=`flux getattr statedir` &&
+    echo ${statedir}/job-db.sqlite
+}
+
+# count number of entries in database
+# arg1 - database path
+db_count_entries() {
+        local dbpath=$1
+        query="select id from jobs;"
+        count=`${QUERYCMD} -t 10000 ${dbpath} "${query}" | grep "^id =" | wc -l`
+        echo $count
+}
+
+# verify entries stored in database
+# arg1 - jobid
+# arg2 - database path
+db_check_entries() {
+        local id=$(flux job id $1)
+        local dbpath=$2
+        query="select * from jobs where id=$id;"
+        ${QUERYCMD} -t 10000 ${dbpath} "${query}" > query.out
+        if grep -q "^id = " query.out \
+            && grep -q "t_inactive = " query.out \
+            && grep -q "jobdata = " query.out \
+            && grep -q "eventlog = " query.out \
+            && grep -q "jobspec = " query.out \
+            && grep -q "R = " query.out
+        then
+            return 0
+        fi
+        return 1
+}
+
+# get job values via job list
+# arg1 - jobid
+# arg2 - database path
+get_job_list_values() {
+        local id=$(flux job id $1)
+        jobdata=`flux job list-ids ${id}`
+        list_userid=`echo ${jobdata} | jq ".userid"`
+        list_urgency=`echo ${jobdata} | jq ".urgency"`
+        list_priority=`echo ${jobdata} | jq ".priority"`
+        list_state=`echo ${jobdata} | jq ".state"`
+        list_ranks=`echo ${jobdata} | jq ".ranks"`
+        list_nnodes=`echo ${jobdata} | jq ".nnodes"`
+        list_nodelist=`echo ${jobdata} | jq -r ".nodelist"`
+        list_ntasks=`echo ${jobdata} | jq ".ntasks"`
+        list_name=`echo ${jobdata} | jq -r ".name"`
+        list_waitstatus=`echo ${jobdata} | jq ".waitstatus"`
+        list_success=`echo ${jobdata} | jq ".success"`
+        list_result=`echo ${jobdata} | jq ".result"`
+        list_expiration=`echo ${jobdata} | jq ".expiration"`
+        list_annotations=`echo ${jobdata} | jq ".annotations"`
+        list_dependencies=`echo ${jobdata} | jq ".dependencies"`
+        list_exception_occurred=`echo ${jobdata} | jq ".exception_occurred"`
+        list_exception_type=`echo ${jobdata} | jq -r ".exception_type"`
+        list_exception_severity=`echo ${jobdata} | jq ".exception_severity"`
+        list_exception_note=`echo ${jobdata} | jq -r ".exception_note"`
+        list_t_submit=`echo ${jobdata} | jq ".t_submit"`
+        list_t_run=`echo ${jobdata} | jq ".t_run"`
+        list_t_cleanup=`echo ${jobdata} | jq ".t_cleanup"`
+        list_t_inactive=`echo ${jobdata} | jq ".t_inactive"`
+}
+
+# get job values from database
+# arg1 - jobid
+# arg2 - database path
+get_db_values() {
+        local id=$(flux job id $1)
+        local dbpath=$2
+        query="select * from jobs where id=$id;"
+        ${QUERYCMD} -t 10000 ${dbpath} "${query}" > query.out
+        db_jobdata=`grep "jobdata = " query.out | cut -f3- -d' '`
+        db_eventlog=`grep "eventlog = " query.out | awk '{print \$3}'`
+        db_jobspec=`grep "jobspec = " query.out | awk '{print \$3}'`
+        db_R=`grep "R = " query.out | awk '{print \$3}'`
+        db_userid=`echo ${jobdata} | jq ".userid"`
+        db_urgency=`echo ${jobdata} | jq ".urgency"`
+        db_priority=`echo ${jobdata} | jq ".priority"`
+        db_state=`echo ${jobdata} | jq ".state"`
+        db_ranks=`echo ${jobdata} | jq ".ranks"`
+        db_nnodes=`echo ${jobdata} | jq ".nnodes"`
+        db_nodelist=`echo ${jobdata} | jq -r ".nodelist"`
+        db_ntasks=`echo ${jobdata} | jq ".ntasks"`
+        db_name=`echo ${jobdata} | jq -r ".name"`
+        db_waitstatus=`echo ${jobdata} | jq ".waitstatus"`
+        db_success=`echo ${jobdata} | jq ".success"`
+        db_result=`echo ${jobdata} | jq ".result"`
+        db_expiration=`echo ${jobdata} | jq ".expiration"`
+        db_annotations=`echo ${jobdata} | jq ".annotations"`
+        db_dependencies=`echo ${jobdata} | jq ".dependencies"`
+        db_exception_occurred=`echo ${jobdata} | jq ".exception_occurred"`
+        db_exception_type=`echo ${jobdata} | jq -r ".exception_type"`
+        db_exception_severity=`echo ${jobdata} | jq ".exception_severity"`
+        db_exception_note=`echo ${jobdata} | jq -r ".exception_note"`
+        db_t_submit=`echo ${jobdata} | jq ".t_submit"`
+        db_t_run=`echo ${jobdata} | jq ".t_run"`
+        db_t_cleanup=`echo ${jobdata} | jq ".t_cleanup"`
+        db_t_inactive=`echo ${jobdata} | jq ".t_inactive"`
+}
+
+# compare data from job list and job db
+# arg1 - job id
+# arg2 - dbpath
+db_compare_data() {
+        local id=$(flux job id $1)
+        local dbpath=$2
+        get_job_list_values ${id}
+        get_db_values ${id} ${dbpath}
+        if [ "${list_userid}" != "${db_userid}" ] \
+            || [ "${list_urgency}" != "${db_urgency}" ] \
+            || [ "${list_priority}" != "${db_priority}" ] \
+            || [ "${list_state}" != "${db_state}" ] \
+            || [ "${list_ranks}" != "${db_ranks}" ] \
+            || [ "${list_nnodes}" != "${db_nnodes}" ] \
+            || [ "${list_nodelist}" != "${db_nodelist}" ] \
+            || [ "${list_ntasks}" != "${db_ntasks}" ] \
+            || [ "${list_name}" != "${db_name}" ] \
+            || [ "${list_waitstatus}" != "${db_waitstatus}" ] \
+            || [ "${list_success}" != "${db_success}" ] \
+            || [ "${list_result}" != "${db_result}" ] \
+            || [ "${list_expiration}" != "${db_expiration}" ] \
+            || [ "${list_annotations}" != "${db_annotations}" ] \
+            || [ "${list_dependencies}" != "${db_dependencies}" ] \
+            || [ "${list_exception_occurred}" != "${db_exception_occurred}" ] \
+            || [ "${list_exception_type}" != "${db_exception_type}" ] \
+            || [ "${list_exception_severity}" != "${db_exception_severity}" ] \
+            || [ "${list_exception_note}" != "${db_exception_note}" ] \
+            || [ "${list_t_submit}" != "${db_t_submit}" ] \
+            || [ "${list_t_run}" != "${db_t_run}" ] \
+            || [ "${list_t_cleanup}" != "${db_t_cleanup}" ] \
+            || [ "${list_t_inactive}" != "${db_t_inactive}" ]
+        then
+            return 1
+        fi
+        return 0
+}
+
+# wait for inactive job list to reach expected count
+# arg1 - expected final count
+# Usage: wait_inactive_count method target tries
+# where method is job-manager, job-list, or job-list-stats (jq required)
+wait_inactive_list_count() {
+    local target=$1
+    local tries=50
+    local count
+    while test $tries -gt 0; do
+        count=$(flux module stats -p jobs.inactive job-list)
+        test $count -eq $target && return 0
+        sleep 0.25
+        tries=$(($tries-1))
+    done
+    return 1
+}
+
+# submit jobs for job list & job-list db testing
+
+test_expect_success 'submit jobs for job list testing' '
+        #  Create `hostname` jobspec
+        #  N.B. Used w/ `flux job submit` for serial job submission
+        #  for efficiency (vs serial `flux mini submit`.
+        #
+        flux mini submit --dry-run hostname >hostname.json &&
+        #
+        # submit jobs that will complete
+        #
+        for i in $(seq 0 3); do
+                flux job submit hostname.json >> inactiveids
+                fj_wait_event `tail -n 1 inactiveids` clean
+        done &&
+        #
+        #  Currently all inactive ids are "completed"
+        #
+        tac inactiveids | flux job id > completed.ids &&
+        #
+        #  Run a job that will fail, copy its JOBID to both inactive and
+        #   failed lists.
+        #
+        ! jobid=`flux mini submit --wait nosuchcommand` &&
+        echo $jobid >> inactiveids &&
+        flux job id $jobid > failed.ids &&
+        touch pending.ids &&
+        touch running.ids &&
+        tac inactiveids | flux job id > inactive.ids &&
+        cat inactive.ids > all.ids &&
+        #
+        #  Synchronize all expected states
+        #
+        job_list_wait_states
+'
+
+test_expect_success HAVE_JQ 'flux job list inactive jobs (pre purge)' '
+        flux job list -s inactive | jq .id > listI.out &&
+        test_cmp listI.out inactive.ids
+'
+
+test_expect_success HAVE_JQ 'flux job list inactive jobs w/ count (pre purge)' '
+        count=$(job_list_state_count inactive)
+        count=$((count - 2))
+        flux job list -s inactive -c ${count} | jq .id > listI_count.out &&
+        head -n ${count} inactive.ids > listI_count.exp &&
+        test_cmp listI_count.out listI_count.exp
+'
+
+test_expect_success HAVE_JQ 'flux job list-inactive jobs (pre purge)' '
+        flux job list-inactive | jq .id > list_inactive.out &&
+        test_cmp list_inactive.out inactive.ids
+'
+
+test_expect_success HAVE_JQ 'flux job list-inactive jobs w/ count (pre purge)' '
+        count=$(job_list_state_count inactive)
+        count=$((count - 2))
+        flux job list-inactive -c ${count} | jq .id > list_inactive_count.out &&
+        head -n ${count} inactive.ids > list_inactive_count.exp &&
+        test_cmp list_inactive_count.out list_inactive_count.exp
+'
+
+test_expect_success 'flux job list-ids jobs (pre purge)' '
+        for id in `cat inactive.ids`
+        do
+            flux job list-ids ${id}
+        done
+'
+
+test_expect_success 'flux job list has all inactive jobs cached' '
+        cached=`flux module stats -p jobs.inactive job-list` &&
+        test ${cached} -eq $(job_list_state_count inactive)
+'
+
+test_expect_success 'job-list db: db stored in statedir' '
+        dbpath=$(get_statedir_dbpath) &&
+        ls ${dbpath}
+'
+
+test_expect_success 'job-list db: has correct number of entries' '
+        dbpath=$(get_statedir_dbpath) &&
+        entries=$(db_count_entries ${dbpath}) &&
+        test ${entries} -eq $(job_list_state_count inactive)
+'
+
+test_expect_success 'job-list db: make sure job data looks ok' '
+        dbpath=$(get_statedir_dbpath) &&
+        for id in `cat list_inactive.out`
+        do
+            db_check_entries ${id} ${dbpath}
+        done
+'
+
+test_expect_success HAVE_JQ 'job-list db: make sure job data correct' '
+        dbpath=$(get_statedir_dbpath) &&
+        for id in `cat list_inactive.out`
+        do
+            db_compare_data ${id} ${dbpath}
+        done
+'
+
+test_expect_success 'job-list db: purge 2 jobs' '
+        len=$(job_list_state_count inactive) &&
+        len=$((len - 2)) &&
+        flux job purge --force --num-limit=${len} &&
+        mv inactive.ids inactive.ids.orig &&
+        head -n ${len} inactive.ids.orig > inactive.ids &&
+        wait_inactive_list_count ${len}
+'
+
+test_expect_success HAVE_JQ 'flux job list inactive jobs (post purge)' '
+        flux job list -s inactive | jq .id > listI2.out &&
+        test_cmp listI2.out inactive.ids.orig
+'
+
+test_expect_success HAVE_JQ 'flux job list inactive jobs w/ count (post purge)' '
+        count=$(cat inactive.ids.orig | wc -l)
+        count=$((count - 2))
+        flux job list -s inactive -c ${count} | jq .id > listI_count2.out &&
+        head -n ${count} inactive.ids.orig > listI_count2.exp &&
+        test_cmp listI_count2.out listI_count2.exp
+'
+
+test_expect_success HAVE_JQ 'flux job list-inactive jobs (post purge)' '
+        flux job list-inactive | jq .id > list_inactive2.out &&
+        test_cmp list_inactive2.out inactive.ids.orig
+'
+
+test_expect_success HAVE_JQ 'flux job list-inactive jobs w/ count (post purge)' '
+        count=$(cat inactive.ids.orig | wc -l)
+        count=$((count - 2))
+        flux job list-inactive -c ${count} | jq .id > list_inactive_count2.out &&
+        head -n ${count} inactive.ids.orig > list_inactive_count2.exp &&
+        test_cmp list_inactive_count2.out list_inactive_count2.exp
+'
+
+test_expect_success 'flux job list-ids jobs (post purge)' '
+        for id in `cat inactive.ids.orig`
+        do
+            flux job list-ids ${id}
+        done
+'
+
+test_expect_success 'job-list db: purge all jobs' '
+        len=$(job_list_state_count inactive) &&
+        flux job purge --force --num-limit=0 &&
+        : > inactive.ids &&
+        wait_inactive_list_count 0
+'
+
+test_expect_success HAVE_JQ 'flux job list inactive jobs (all purge)' '
+        flux job list -s inactive | jq .id > listI3.out &&
+        test_cmp listI3.out inactive.ids.orig
+'
+
+test_expect_success HAVE_JQ 'flux job list inactive jobs w/ count (all purge)' '
+        count=$(cat inactive.ids.orig | wc -l)
+        count=$((count - 2))
+        flux job list -s inactive -c ${count} | jq .id > listI_count3.out &&
+        head -n ${count} inactive.ids.orig > listI_count3.exp &&
+        test_cmp listI_count3.out listI_count3.exp
+'
+
+test_expect_success HAVE_JQ 'flux job list-inactive jobs (all purge)' '
+        flux job list-inactive | jq .id > list_inactive3.out &&
+        test_cmp list_inactive3.out inactive.ids.orig
+'
+
+test_expect_success HAVE_JQ 'flux job list-inactive jobs w/ count (all purge)' '
+        count=$(cat inactive.ids.orig | wc -l)
+        count=$((count - 2))
+        flux job list-inactive -c ${count} | jq .id > list_inactive_count3.out &&
+        head -n ${count} inactive.ids.orig > list_inactive_count3.exp &&
+        test_cmp list_inactive_count3.out list_inactive_count3.exp
+'
+
+test_expect_success 'flux job list-ids jobs (all purge)' '
+        for id in `cat inactive.ids.orig`
+        do
+            flux job list-ids ${id}
+        done
+'
+
+test_expect_success 'reload the job-list module with alternate config' '
+        statedir=`flux getattr statedir` &&
+        cat >job-list.toml <<EOF &&
+[job-list]
+dbpath = "${statedir}/testdb.sqlite"
+busytimeout = "0.1s"
+EOF
+        flux config reload &&
+        flux module reload job-list
+'
+
+test_expect_success 'configured db is there' '
+        ls ${statedir}/testdb.sqlite
+'
+
+test_expect_success 'flux job list inactive jobs (new db)' '
+        count=$(flux job list -s inactive | wc -l) &&
+        test ${count} -eq 0
+'
+
+test_expect_success 'flux job list-inactive jobs (new db)' '
+        count=$(flux job list-inactive | wc -l) &&
+        test ${count} -eq 0
+'
+
+test_done

--- a/t/t2809-job-purge.t
+++ b/t/t2809-job-purge.t
@@ -15,7 +15,7 @@ inactive_count() {
 	if test $how = "job-manager"; then
 		flux module stats --parse=inactive_jobs job-manager
 	elif test $how = "job-list"; then
-		flux jobs --suppress-header --filter=inactive|wc -l
+		flux module stats -p jobs.inactive job-list
 	elif test $how = "job-list-stats"; then
 		flux job stats | jq .job_states.inactive
 	else


### PR DESCRIPTION
Per discussion in #4273, some notes on what this does:

- add an sqlite database that stores all inactive data to it.

- db table is:

```
const char *sql_create_table = "CREATE TABLE if not exists jobs("
                               "  id CHAR(16) PRIMARY KEY,"
                               "  t_inactive REAL,"
                               "  jobdata JSON,"
                               "  eventlog TEXT,"
                               "  jobspec JSON,"
                               "  R JSON"
```

Where `jobdata` is a json blob containing all job data (the `all` `job-list` attribute from #4324, but added a `states_mask` which is used internally)

The main reason we have a `t_inactive` column is b/c this is backwards compatible to sqlite versions that don't have json support.

- database archiving is only enabled if a dbpath is specified in a `job-list` toml config or if `statedir` is configured.  So in other words, if no db is configured, it behaves just like before.

Ideas:

- should the `jobdata` have a version embedded?  if things like job states bitmask or things like that change?
