### PR TITLE
content-sqlite: verify database integrity during module load

### DIFF
--- a/src/modules/content-sqlite/content-sqlite.c
+++ b/src/modules/content-sqlite/content-sqlite.c
@@ -641,6 +641,14 @@ static int content_sqlite_opendb (struct content_sqlite *ctx, bool truncate)
         goto error;
     }
     if (sqlite3_exec (ctx->db,
+                      "PRAGMA quick_check",
+                      NULL,
+                      NULL,
+                      NULL) != SQLITE_OK) {
+        log_sqlite_error (ctx, "setting sqlite 'quick_check' pragma");
+        goto error;
+    }
+    if (sqlite3_exec (ctx->db,
                       sql_create_table,
                       NULL,
                       NULL,

--- a/src/modules/content-sqlite/content-sqlite.c
+++ b/src/modules/content-sqlite/content-sqlite.c
@@ -832,16 +832,16 @@ int mod_main (flux_t *h, int argc, char **argv)
     if (content_register_backing_store (h, "content-sqlite") < 0)
         goto done;
     if (content_register_service (h, "content-backing") < 0)
-        goto done;
+        goto done_unreg;
     if (content_register_service (h, "kvs-checkpoint") < 0)
-        goto done;
+        goto done_unreg;
     if (flux_reactor_run (flux_get_reactor (h), 0) < 0) {
         flux_log_error (h, "flux_reactor_run");
-        goto done;
+        goto done_unreg;
     }
-    if (content_unregister_backing_store (h) < 0)
-        goto done;
     rc = 0;
+done_unreg:
+    (void)content_unregister_backing_store (h);
 done:
     content_sqlite_closedb (ctx);
     content_sqlite_destroy (ctx);


### PR DESCRIPTION
Problem: if the content-sqlite database is corrupted, this is typically discovered at runtime when the KVS attempts to load/store a blob, which causes secondary fallout.  It would be better to catch that condition early.

Add the [quick_check](https://www.sqlite.org/pragma.html#pragma_quick_check) sqlite pragma.  Since pragmas are executed before the module enters the reactor, if this check fails, the module load fails, and rc1 aborts before the higher level services are loaded.

This addresses #4338