### PR TITLE
improve logging of overlay peer authentication

### DIFF
--- a/doc/man1/flux-keygen.rst
+++ b/doc/man1/flux-keygen.rst
@@ -6,7 +6,7 @@ flux-keygen(1)
 SYNOPSIS
 ========
 
-**flux** **keygen** *PATH*
+**flux** **keygen** [*--name=NAME*] *PATH*
 
 
 DESCRIPTION
@@ -26,6 +26,17 @@ certificate.  The certificate is part of the bootstrap configuration.
 Flux instances that bootstrap with PMI do not require a configured certificate.
 In that case, each broker self-generates a unique certificate and the
 public keys are exchanged with PMI.
+
+
+OPTIONS
+=======
+
+``flux-keygen`` accepts the following options:
+
+**-n, --name=NAME**
+   Set the certificate metadata ``name`` field.  The value is logged when
+   :man1:`flux-broker` authenticates a peer that presents this certificate.
+   A cluster name might be appropriate here.  Default: the local hostname.
 
 
 RESOURCES

--- a/src/cmd/flux-keygen.c
+++ b/src/cmd/flux-keygen.c
@@ -19,6 +19,8 @@
 #include "src/common/libutil/log.h"
 
 static struct optparse_option opts[] = {
+    { .name = "name", .key = 'n', .has_arg = 1, .arginfo = "NAME",
+      .usage = "Set certificate name (default: hostname)", },
     OPTPARSE_TABLE_END,
 };
 
@@ -67,7 +69,8 @@ int main (int argc, char *argv[])
     if (gethostname (buf, sizeof (buf)) < 0)
         log_err_exit ("gethostname");
     zcert_set_meta (cert, "hostname", "%s", buf);
-    zcert_set_meta (cert, "name", "%s", buf); // used in overlay logging
+    // name is used in overlay logging
+    zcert_set_meta (cert, "name", "%s", optparse_get_str (p, "name", buf));
     zcert_set_meta (cert, "time", "%s", ctime_iso8601_now (buf, sizeof (buf)));
     zcert_set_meta (cert, "userid", "%d", getuid ());
 

--- a/src/common/libzmqutil/zap.c
+++ b/src/common/libzmqutil/zap.c
@@ -127,7 +127,11 @@ static void zap_cb (flux_reactor_t *r,
         }
         if (!name)
             name = "unknown";
-        logger (zap, log_level, "overlay auth %s %s", name, status_text);
+        logger (zap,
+                log_level,
+                "overlay auth cert-name=%s %s",
+                name,
+                status_text);
 
         if (!(rep = zmsg_new ()))
             goto done;

--- a/src/common/libzmqutil/zap.c
+++ b/src/common/libzmqutil/zap.c
@@ -123,7 +123,7 @@ static void zap_cb (flux_reactor_t *r,
             status_text = "OK";
             user_id = pubkey;
             name = zcert_meta (cert, "name");
-            log_level = LOG_INFO;
+            log_level = LOG_DEBUG;
         }
         if (!name)
             name = "unknown";

--- a/t/sharness.d/flux-sharness.sh
+++ b/t/sharness.d/flux-sharness.sh
@@ -99,7 +99,7 @@ make_bootstrap_config() {
 
     mkdir $workdir/conf.d
     mkdir $workdir/state
-    flux keygen $workdir/cert
+    flux keygen --name testcert $workdir/cert
     cat >$workdir/conf.d/bootstrap.toml <<-EOT
 	[bootstrap]
 	    curve_cert = "$workdir/cert"

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -37,6 +37,14 @@ test_expect_success 'flux-keygen works' '
 	flux keygen cert &&
 	test -f cert
 '
+test_expect_success 'flux-keygen --name=test works' '
+	flux keygen --name=testcert cert2 &&
+	test -f cert2 &&
+	grep testcert cert2
+'
+test_expect_success 'flux-keygen fails with extra positional argument' '
+	test_must_fail flux keygen cert xyz
+'
 test_expect_success 'flux-keygen generated cert with u=rw access' '
 	echo '-rw-------' >cert-access.exp &&
 	stat --format=%A cert >cert-access.out &&

--- a/t/t3300-system-basic.t
+++ b/t/t3300-system-basic.t
@@ -31,6 +31,10 @@ test_expect_success 'startctl status works' '
 test_expect_success HAVE_JQ 'broker overlay shows 2 connected children' '
 	test $(overlay_connected_children) -eq 2
 '
+test_expect_success 'testcert was used to authenticate' '
+	flux dmesg |grep "overlay auth" >auth.log &&
+	grep testcert auth.log
+'
 
 test_expect_success 'overlay status is full' '
 	test "$(flux overlay status --timeout=0 --summary)" = "full"


### PR DESCRIPTION
This works on the problem described in #4341, where logs that look like this:
```
2022-05-24T22:40:04.389347Z broker.info[0]: overlay auth picl0 OK
```
are potentially misleading, since `picl0` is the hostname where the cert was generated not the peer that is authenticating.

We change the log slightly so it at least indicates what that name is:
```
2022-05-24T22:40:04.389347Z broker.info[0]: overlay auth cert-name=picl0 OK
```
and then add a `flux keygen --name=NAME` option that lets the certificate name be set to something other than the local hostname.  I was thinking we would recommend the cluster name in the admin guide.