### PR TITLE
libflux: return better errno in future wait path

### DIFF
--- a/doc/man3/flux_future_get.rst
+++ b/doc/man3/flux_future_get.rst
@@ -129,6 +129,9 @@ ETIMEDOUT
    A timeout passed to ``flux_future_wait_for()`` expired before the future
    was fulfilled.
 
+EDEADLOCK
+   ``flux_future_wait_for()`` would likely deadlock due to an
+   improperly initialized future.
 
 RESOURCES
 =========

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -626,3 +626,4 @@ num
 gc
 tgz
 tmpfiles
+EDEADLOCK

--- a/src/common/libflux/test/future.c
+++ b/src/common/libflux/test/future.c
@@ -122,8 +122,8 @@ void test_simple (void)
     ok (!flux_future_is_ready (f),
         "flux_future_is_ready returns false");
     errno = 0;
-    ok (flux_future_wait_for (f, -1.0) < 0 && errno == EINVAL,
-        "flux_future_wait_for fails with EINVAL with timeout < 0");
+    ok (flux_future_wait_for (f, -1.0) < 0 && errno == EDEADLOCK,
+        "flux_future_wait_for fails with EDEADLOCK with timeout < 0");
     ok (!flux_future_is_ready (f),
         "flux_future_is_ready returns false");
     errno = 0;

--- a/src/common/libkvs/test/kvs_checkpoint.c
+++ b/src/common/libkvs/test/kvs_checkpoint.c
@@ -50,13 +50,13 @@ void errors (void)
 
     errno = 0;
     ok (kvs_checkpoint_lookup_get_rootref (f, &rootref) < 0
-        && errno == EINVAL,
+        && errno == EDEADLOCK,
         "kvs_checkpoint_lookup_get_rootref fails on unfulfilled future");
 
     errno = 0;
     double timestamp;
     ok (kvs_checkpoint_lookup_get_timestamp (f, &timestamp) < 0
-        && errno == EINVAL,
+        && errno == EDEADLOCK,
         "kvs_checkpoint_lookup_get_timestamp fails on unfulfilled future");
 
     flux_future_destroy (f);


### PR DESCRIPTION
Problem: In flux_future_wait_for() the errno EINVAL is returned
when a flux future is not initialized properly.  This errno is
generic and confusing.

Solution: Return EDEADLOCK instead.  Update comments to give
more details on how a hang / deadlock may occur.  Update unit
tests accordingly.

Fixes #4343