### PR TITLE
job-manager: post submit event, instead of job-ingest

### DIFF
--- a/src/modules/job-ingest/job-ingest.c
+++ b/src/modules/job-ingest/job-ingest.c
@@ -232,7 +232,8 @@ static void batch_response_destroy (struct batch_response *bresp)
 static void *jobid_duplicator (const void *item)
 {
     flux_jobid_t *id = calloc (1, sizeof (flux_jobid_t));
-    *id = *((flux_jobid_t *)item);
+    if (id)
+        *id = *((flux_jobid_t *)item);
     return id;
 }
 

--- a/src/modules/job-manager/event.c
+++ b/src/modules/job-manager/event.c
@@ -780,12 +780,8 @@ int event_job_post_entry (struct event *event,
     /*  Journal event sequence should match actual sequence of events
      *   in the job eventlog, so set eventlog_seq to -1 with
      *   EVENT_NO_COMMIT and do not advance job->eventlog_seq.
-     *
-     *  However, if EVENT_FORCE_SEQUENCE flag is supplied, then we
-     *   do set and advance an actual sequence number (the event may
-     *   already be in the eventlog such as the "submit" event)
      */
-    if ((flags & EVENT_NO_COMMIT) && !(flags & EVENT_FORCE_SEQUENCE))
+    if ((flags & EVENT_NO_COMMIT))
         eventlog_seq = -1;
 
     /* call before eventlog_seq increment below */

--- a/src/modules/job-manager/event.h
+++ b/src/modules/job-manager/event.h
@@ -27,12 +27,6 @@ enum job_manager_event_flags {
      *   the eventlog in the KVS.
      */
     EVENT_NO_COMMIT = 1,
-
-    /*  With EVENT_NO_COMMIT, force the event to get a journal sequence
-     *   numnber. This is useful for events that may already be in the
-     *   job eventlog, such as the "submit" event.
-     */
-    EVENT_FORCE_SEQUENCE = 2,
 };
 
 /* Take any action for 'job' currently needed based on its internal state.

--- a/src/modules/job-manager/event.h
+++ b/src/modules/job-manager/event.h
@@ -59,7 +59,6 @@ int event_batch_respond (struct event *event, const flux_msg_t *msg);
 /* Post event 'name' and optionally 'context' to 'job'.
  * Internally, calls event_job_update(), then event_job_action(), then commits
  * the event to job KVS eventlog.  The KVS commit completes asynchronously.
- * The future passed in as an argument should not be destroyed.
  * Returns 0 on success, -1 on failure with errno set.
  */
 int event_job_post_pack (struct event *event,

--- a/src/modules/job-manager/test/submit.c
+++ b/src/modules/job-manager/test/submit.c
@@ -69,12 +69,11 @@ void single_job_check (zhashx_t *active_jobs)
     newjobs_saved = zlistx_dup (newjobs);
 
     /* resubmit orig job */
-    ok (submit_hash_jobs (active_jobs, newjobs) == 0,
-        "submit_hash_jobs with duplicates works");
+    errno = 0;
+    ok (submit_hash_jobs (active_jobs, newjobs) < 0 && errno == EEXIST,
+        "submit_hash_jobs with duplicate fails");
     ok (zhashx_size (active_jobs) == 1,
-        "but hash contains one job");
-    ok (zlistx_size (newjobs) == 0,
-        "and newjobs now has zero jobs");
+        "the hash still contains one job");
 
     /* clean up (batch submit error path) */
     submit_add_jobs_cleanup (active_jobs, newjobs_saved); // destroys newjobs

--- a/t/t2100-job-ingest.t
+++ b/t/t2100-job-ingest.t
@@ -92,14 +92,6 @@ test_expect_success 'job-ingest: job announced to job manager' '
 	grep -q "\"userid\":$(id -u)" jobman.out
 '
 
-test_expect_success 'job-ingest: submit event logged with userid, urgency' '
-	jobid=$(flux job submit --urgency=11 basic.json) &&
-	kvspath=`flux job id --to=kvs ${jobid}` &&
-	flux kvs eventlog get ${kvspath}.eventlog |grep submit >eventlog.out &&
-	grep -q "\"urgency\":11" eventlog.out &&
-	grep -q "\"userid\":$(id -u)" eventlog.out
-'
-
 test_expect_success 'job-ingest: instance owner can submit urgency=31' '
 	flux job submit --urgency=31 basic.json
 '


### PR DESCRIPTION
Problem: job-ingest posts the submit event, but every other job
    event is posted by the job manager. This results in some special
    cases in the job manager that can be confusing.
    
Since job-ingest now waits for the job manager to "approve" each
    job before responding to the user, this division of labor is no
    longer required.
    
Have the job manager post the submit event.  Maintain the invariant
    that the user does not receive the job ID until the submit event
    has been committed to the KVS by deferring the response to job-ingest
    until the KVS batch completes.
    
Impact on submit latency:  latency is increased because job-ingest does
    not send its request to the job manager until the jobspec is committed
    to the KVS, and now the job manager does not respond until the submit
    event is committed to the KVS.  An individual submit must now wait for
    two back to back KVS commits instead of one.
    
Impact on job throughput:  any impact on job throughput should be
    mitigated by KVS commit batching.  For example, the submit event is
    likely now batched with the depend event that usually follows it,
    whereas before it was batched with the jobspec.

This PR includes a little bit of ancillary cleanup as well.