### PR TITLE
kvs: support FLUX_KVS_SYNC

### DIFF
--- a/doc/man1/flux-kvs.rst
+++ b/doc/man1/flux-kvs.rst
@@ -80,7 +80,7 @@ COMMANDS
    directory. The *-f* option can be specified to monitor for many of
    these special situations.
 
-**put** [-N ns] [-O|-b|-s] [-r|-t] [-n] [-A] *key=value* [*key=value* ...]
+**put** [-N ns] [-O|-b|-s] [-r|-t] [-n] [-A] [-S] *key=value* [*key=value* ...]
    Store *value* under *key* and commit it. Specify an alternate
    namespace to commit value(s) via *-N*. If it already has a value,
    overwrite it. If no options, value is stored directly. If *-r* or
@@ -89,9 +89,12 @@ COMMANDS
    If *-t*, value is stored as a RFC 11 object. *-n* prevents the commit
    from being merged with with other contemporaneous commits. *-A*
    appends the value to a key instead of overwriting the value. Append
-   is incompatible with the -j option. After a successful put, *-O*,
-   *-b*, or *-s* can be specified to output the RFC 11 treeobj, root
-   blobref, or root sequence number of the root containing the put(s).
+   is incompatible with the -j option. *-S* flushes and checkpoints
+   the primary KVS namespace after the put.  This can be used to
+   ensure critical data has been stored to non-volatile storage.
+   After a successful put, *-O*, *-b*, or *-s* can be specified to
+   output the RFC 11 treeobj, root blobref, or root sequence number of
+   the root containing the put(s).
 
 **ls** [-N ns] [-R] [-d] [-F] [-w COLS] [-1] [*key* ...]
    Display directory referred to by *key*, or "." (root) if unspecified.

--- a/src/cmd/flux-kvs.c
+++ b/src/cmd/flux-kvs.c
@@ -128,6 +128,9 @@ static struct optparse_option put_opts[] =  {
     { .name = "append", .key = 'A', .has_arg = 0,
       .usage = "Append value(s) to key instead of overwriting",
     },
+    { .name = "sync", .key = 'S', .has_arg = 0,
+      .usage = "Flushes content and checkpoints after completing put",
+    },
     OPTPARSE_TABLE_END
 };
 
@@ -286,7 +289,7 @@ static struct optparse_subcommand subcommands[] = {
       get_opts
     },
     { "put",
-      "[-N ns] [-O|-b|-s] [-r|-t] [-n] [-A] key=value [key=value...]",
+      "[-N ns] [-O|-b|-s] [-r|-t] [-n] [-A] [-S] key=value [key=value...]",
       "Store value under key",
       cmd_put,
       0,
@@ -842,6 +845,9 @@ int cmd_put (optparse_t *p, int argc, char **argv)
 
     if (optparse_hasopt (p, "no-merge"))
         commit_flags |= FLUX_KVS_NO_MERGE;
+
+    if (optparse_hasopt (p, "sync"))
+        commit_flags |= FLUX_KVS_SYNC;
 
     if (!(h = flux_open (NULL, 0)))
         log_err_exit ("flux_open");

--- a/src/common/libkvs/kvs_checkpoint.h
+++ b/src/common/libkvs/kvs_checkpoint.h
@@ -15,6 +15,14 @@
 
 #define KVS_DEFAULT_CHECKPOINT "kvs-primary"
 
+/* Calls to kvs_checkpoint_commit() can be racy when the KVS module is
+ * loaded, as callers can use the FLUX_KVS_SYNC flag with
+ * flux_kvs_commit().
+ *
+ * In most cases, use the FLUX_KVS_SYNC flag with flux_kvs_commit() to
+ * ensure committed data survives a Flux restart.
+ */
+
 flux_future_t *kvs_checkpoint_commit (flux_t *h,
                                       const char *key,
                                       const char *rootref,

--- a/src/common/libkvs/kvs_commit.h
+++ b/src/common/libkvs/kvs_commit.h
@@ -24,10 +24,23 @@ extern "C" {
  * operations will be illegal to compact and result in an error.  Most
  * notably, if a key has data appended to it, then is overwritten in
  * the same transaction, a compaction of appends is not possible.
+ *
+ * FLUX_KVS_SYNC will ensure all data flushed to the backing store and
+ * the root reference is checkpointed.  It effectively performs a:
+ *
+ * content.flush on rank 0
+ * checkpoint on the new root reference from the commit
+ *
+ * FLUX_KVS_SYNC only works against the primary KVS namespace.  If any
+ * part of the content.flush or checkpoint fails an error will be
+ * returned and the entire commit will fail.  For example, if a
+ * content backing store is not loaded, ENOSYS will returned from this
+ * commit.
  */
 enum kvs_commit_flags {
     FLUX_KVS_NO_MERGE = 1, /* disallow commits to be mergeable with others */
     FLUX_KVS_TXN_COMPACT = 2, /* try to combine ops on same key within txn */
+    FLUX_KVS_SYNC = 4, /* flush and checkpoint after commit is done */
 };
 
 flux_future_t *flux_kvs_commit (flux_t *h, const char *ns, int flags,

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -113,6 +113,7 @@ static struct kvs_ctx *kvs_ctx_create (flux_t *h)
 
     if (!(ctx = calloc (1, sizeof (*ctx))))
         return NULL;
+    ctx->h = h;
     if (!(ctx->hash_name = flux_attr_get (h, "content.hash"))) {
         flux_log_error (h, "getattr content.hash");
         goto error;
@@ -121,8 +122,7 @@ static struct kvs_ctx *kvs_ctx_create (flux_t *h)
         goto error;
     if (!(ctx->krm = kvsroot_mgr_create (ctx->h, ctx)))
         goto error;
-    ctx->h = h;
-    if (flux_get_rank (h, &ctx->rank) < 0)
+    if (flux_get_rank (ctx->h, &ctx->rank) < 0)
         goto error;
     if (ctx->rank == 0) {
         ctx->prep_w = flux_prepare_watcher_create (r, transaction_prep_cb, ctx);

--- a/src/modules/kvs/kvstxn.c
+++ b/src/modules/kvs/kvstxn.c
@@ -63,6 +63,24 @@ struct kvstxn {
     zlist_t *dirty_cache_entries_list;
     int internal_flags;
     kvstxn_mgr_t *ktm;
+    /* State transitions
+     *
+     * INIT - perform initializations / checks
+     * LOAD_ROOT - load KVS root
+     *           - if needed, report missing refs to caller and stall
+     * APPLY_OPS - apply changes to KVS
+     *           - if needed, report missing refs to caller and stall
+     * STORE - generate dirty entries for caller to store
+     * PRE_FINISHED - stall until stores complete
+     *              - generate keys modified in txn
+     * FINISHED - end state
+     *
+     * INIT -> LOAD_ROOT
+     * LOAD_ROOT -> APPLY_OPS
+     * APPLY_OPS -> STORE
+     * STORE -> PRE_FINISHED
+     * PRE_FINISHED -> FINISHED
+     */
     enum {
         KVSTXN_STATE_INIT = 1,
         KVSTXN_STATE_LOAD_ROOT = 2,

--- a/src/modules/kvs/kvstxn.h
+++ b/src/modules/kvs/kvstxn.h
@@ -22,7 +22,9 @@ typedef enum {
     KVSTXN_PROCESS_ERROR = 1,
     KVSTXN_PROCESS_LOAD_MISSING_REFS = 2,
     KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES = 3,
-    KVSTXN_PROCESS_FINISHED = 4,
+    KVSTXN_PROCESS_SYNC_CONTENT_FLUSH = 4,
+    KVSTXN_PROCESS_SYNC_CHECKPOINT = 5,
+    KVSTXN_PROCESS_FINISHED = 6,
 } kvstxn_process_t;
 
 /*
@@ -82,6 +84,8 @@ json_t *kvstxn_get_keys (kvstxn_t *kt);
  * KVSTXN_PROCESS_LOAD_MISSING_REFS stall & load,
  * KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES stall & process dirty cache
  * entries,
+ * KVSTXN_PROCESS_SYNC_CONTENT_FLUSH stall & wait for future to fulfill
+ * KVSTXN_PROCESS_SYNC_CHECKPOINT stall & wait for future to fulfill
  * KVSTXN_PROCESS_FINISHED all done
  *
  * on error, call kvstxn_get_errnum() to get error number
@@ -90,6 +94,10 @@ json_t *kvstxn_get_keys (kvstxn_t *kt);
  *
  * on stall & process dirty cache entries, call
  * kvstxn_iter_dirty_cache_entries() to process entries.
+ *
+ * on stall & content-flush, call kvstxn_sync_content_flush() to get future.
+ *
+ * on stall & checkpoint, call kvstxn_sync_checkpoint() to get future.
  *
  * on completion, call kvstxn_get_newroot_ref() to get reference to
  * new root to be stored.
@@ -118,6 +126,12 @@ int kvstxn_iter_dirty_cache_entries (kvstxn_t *kt,
  * kvstxn_iter_dirty_cache_entries().
  */
 void kvstxn_cleanup_dirty_cache_entry (kvstxn_t *kt, struct cache_entry *entry);
+
+/* on stall, get confent.flush future to wait for fulfillment on */
+flux_future_t *kvstxn_sync_content_flush (kvstxn_t *kt);
+
+/* on stall, get checkpoint future to wait for fulfillment on */
+flux_future_t *kvstxn_sync_checkpoint (kvstxn_t *kt);
 
 /*
  * kvstxn_mgr_t API

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -89,6 +89,7 @@ TESTSCRIPTS = \
 	t1007-kvs-lookup-watch.t \
 	t1008-kvs-eventlog.t \
 	t1009-kvs-copy.t \
+	t1010-kvs-commit-sync.t \
 	t1101-barrier-basic.t \
 	t1102-cmddriver.t \
 	t1103-apidisconnect.t \

--- a/t/t1010-kvs-commit-sync.t
+++ b/t/t1010-kvs-commit-sync.t
@@ -1,0 +1,82 @@
+#!/bin/sh
+#
+
+test_description='Test flux-kvs commit sync.'
+
+. `dirname $0`/kvs/kvs-helper.sh
+
+. `dirname $0`/sharness.sh
+
+RPC=${FLUX_BUILD_DIR}/t/request/rpc
+
+skip_all_unless_have jq
+
+SIZE=1
+test_under_flux ${SIZE} minimal
+
+TESTNAMESPACE="testnamespace"
+
+kvs_checkpoint_get() {
+        jq -j -c -n  "{key:\"$1\"}" | $RPC kvs-checkpoint.get
+}
+
+test_expect_success 'load content-sqlite and kvs and add some data' '
+        flux module load content-sqlite &&
+        flux module load kvs &&
+        flux kvs put a=1 &&
+        flux kvs put b=2
+'
+
+test_expect_success 'kvs: no checkpoint of kvs-primary should exist yet' '
+        test_must_fail kvs_checkpoint_get kvs-primary
+'
+
+test_expect_success 'kvs: put some data to kvs and sync it' '
+        flux kvs put --blobref --sync c=3 > syncblob.out
+'
+
+test_expect_success 'kvs: checkpoint of kvs-primary should exist now' '
+        kvs_checkpoint_get kvs-primary
+'
+
+test_expect_success 'kvs: checkpoint of kvs-primary should match rootref' '
+        kvs_checkpoint_get kvs-primary | jq -r .value.rootref > checkpoint.out &&
+        test_cmp syncblob.out checkpoint.out
+'
+
+test_expect_success 'kvs: fence some data to kvs and sync it' '
+        ${FLUX_BUILD_DIR}/t/kvs/fence_api --sync 4 apisynctest
+'
+
+test_expect_success 'kvs: rootref of kvs-primary should match rootref' '
+        flux kvs getroot -b > fenceroot.exp &&
+        kvs_checkpoint_get kvs-primary | jq -r .value.rootref > fenceroot.out &&
+        test_cmp fenceroot.exp fenceroot.out
+'
+
+test_expect_success 'kvs: sync fails against non-primary namespace' '
+        flux kvs namespace create ${TESTNAMESPACE} &&
+        flux kvs put --namespace=${TESTNAMESPACE} a=10 &&
+        test_must_fail flux kvs put --namespace=${TESTNAMESPACE} --sync b=11
+'
+
+test_expect_success 'kvs: sync fence fails against non-primary namespace' '
+        ${FLUX_BUILD_DIR}/t/kvs/fence_api \
+                         --namespace=${TESTNAMESPACE} 4 apisynctestns &&
+        test_must_fail ${FLUX_BUILD_DIR}/t/kvs/fence_api \
+                         --namespace=${TESTNAMESPACE} --sync 4 apisynctestns
+'
+
+test_expect_success 'kvs: unload content-sqlite' '
+	flux module remove content-sqlite
+'
+
+test_expect_success 'kvs: sync without backing store fails' '
+        test_must_fail flux kvs put --sync d=4
+'
+
+test_expect_success 'kvs: unload kvs' '
+	flux module remove kvs
+'
+
+test_done


### PR DESCRIPTION
Per discussion in #4308.

Thought I'd park this to get any initial thoughts.  I have some very simple tests but could use more, perhaps after I see how coverage is after this PR starts.

- Basically added several states to the "kvs transaction" state machine to do the `content.flush`  and `checkpoint`.  I don't think the code change is shocking.  Perhaps the most interesting refactoring was to change the state machine's "switch" statement into a loop, b/c doing a "fallthrough" between states no longer makes sense with the new states.  Right now it sort of looks weird that the primary state machine is a `while (1)` loop and exits are all based on `break`, `goto`, and `return`.

- Only works with primary namespace, but could work with another namespaces.  We'd just have to come up with a consistent key naming scheme for the checkpoints of other namespaces?
  - OR `flux_kvs_commit()` could be altered to take a key for the checkpoint location?

- Only works with `flux_kvs_commit()` and not `flux_kvs_fence()` at the moment.  Dunno if we need to do both?  In some ways doesn't make sense for fence?  But in some ways might as well add it?
