### PR TITLE
libsubprocess: don't segfault on empty argv

### DIFF
--- a/src/common/libsubprocess/local.c
+++ b/src/common/libsubprocess/local.c
@@ -527,6 +527,10 @@ static int local_child (flux_subprocess_t *p)
         fprintf (stderr, "out of memory\n");
         _exit (1);
     }
+    if (argv[0] == NULL) {
+        fprintf (stderr, "command argv array is empty\n");
+        _exit (1);
+    }
 #if CODE_COVERAGE_ENABLED
     __gcov_flush ();
 #endif


### PR DESCRIPTION
Problem: flux-shell segfaults in test when presented with
jobspec that has an empty command array.

libsubprocess does not protect against this situation,
and execvp(3) gets called with a NULL file parameter.

Add a check for argv[0] == NULL before the exec.

Fixes #4347