### PR TITLE
libsubprocess: avoid segfault on empty argv

### DIFF
--- a/src/common/libsubprocess/subprocess.c
+++ b/src/common/libsubprocess/subprocess.c
@@ -620,6 +620,12 @@ static flux_subprocess_t * flux_exec_wrap (flux_t *h, flux_reactor_t *r, int fla
         return NULL;
     }
 
+    /* user required to set some args */
+    if (!flux_cmd_argc (cmd)) {
+        errno = EINVAL;
+        goto error;
+    }
+
     if (!(p = subprocess_create (h, r, flags, cmd, ops, hooks, -1, true)))
         goto error;
 

--- a/src/common/libsubprocess/test/subprocess.c
+++ b/src/common/libsubprocess/test/subprocess.c
@@ -178,6 +178,9 @@ void test_basic_errors (flux_reactor_t *r)
 
     ok ((cmd = flux_cmd_create (0, avbad, NULL)) != NULL,
         "flux_cmd_create with 0 args works");
+    ok (flux_local_exec (r, 0, cmd, NULL, NULL) == NULL
+        && errno == EINVAL,
+        "flux_local_exec fails with cmd with zero args");
     ok (flux_rexec (h, 0, 0, cmd, NULL) == NULL
         && errno == EINVAL,
         "flux_rexec fails with cmd with zero args");


### PR DESCRIPTION
Problem: flux_local_exec() did not check if the user supplied
any arguments for execution.  This was not consistent to the
checks supplied by flux_rexec() and can lead to a segfault
internally.

Solution: Add a argument count check identical to the check done
in flux_rexec().  Add a unit test.

Fixes #4347