### PR TITLE
job-manager: unwind job event posting recursion

### DIFF
--- a/src/modules/job-manager/event.c
+++ b/src/modules/job-manager/event.c
@@ -356,11 +356,10 @@ int event_job_action (struct event *event, struct job *job)
                 return -1;
             break;
         case FLUX_JOB_STATE_RUN:
-            /*
-             *  If job->perilog_active is nonzero then a prolog action
-             *   is still in progress so do not send start request.
+            /* Send the start request only if prolog is not running/pending.
              */
             if (!job->perilog_active
+                && !job_event_is_queued (job, "prolog-start")
                 && start_send_request (ctx->start, job) < 0)
                 return -1;
             break;

--- a/src/modules/job-manager/job.c
+++ b/src/modules/job-manager/job.c
@@ -86,7 +86,8 @@ int job_dependency_count (struct job *job)
 
 int job_dependency_add (struct job *job, const char *description)
 {
-    assert (job->state == FLUX_JOB_STATE_DEPEND);
+    assert (job->state == FLUX_JOB_STATE_NEW
+            || job->state == FLUX_JOB_STATE_DEPEND);
     if (grudgeset_add (&job->dependencies, description) < 0
         && errno != EEXIST)
         return -1;

--- a/src/modules/job-manager/job.c
+++ b/src/modules/job-manager/job.c
@@ -99,29 +99,6 @@ int job_dependency_remove (struct job *job, const char *description)
     return grudgeset_remove (job->dependencies, description);
 }
 
-bool job_dependency_event_valid (struct job *job,
-                                 const char *event,
-                                 const char *description)
-{
-    if (streq (event, "dependency-add")) {
-        if (grudgeset_used (job->dependencies, description)) {
-            errno = EEXIST;
-            return false;
-        }
-    }
-    else if (streq (event, "dependency-remove")) {
-        if (!grudgeset_contains (job->dependencies, description)) {
-            errno = ENOENT;
-            return false;
-        }
-    }
-    else {
-        errno = EINVAL;
-        return false;
-    }
-    return true;
-}
-
 static int job_flag_set_internal (struct job *job,
                                   const char *flag,
                                   bool dry_run)

--- a/src/modules/job-manager/job.h
+++ b/src/modules/job-manager/job.h
@@ -30,6 +30,7 @@ struct job {
     json_t *jobspec_redacted;
     int eventlog_seq;           // eventlog count / sequence number
     flux_job_state_t state;
+    json_t *event_queue;
     json_t *end_event;      // event that caused transition to CLEANUP state
     const flux_msg_t *waiter; // flux_job_wait() request
     double t_clean;
@@ -122,6 +123,14 @@ void job_events_unsubscribe (struct job *job, flux_plugin_t *p);
  */
 int job_event_id_set (struct job *job, int id);
 int job_event_id_test (struct job *job, int id);
+
+/*  Enqeue/dequeue event from job's event queue.
+ */
+int job_event_enqueue (struct job *job, int flags, json_t *entry);
+int job_event_dequeue (struct job *job, int *flagsp, json_t **entryp);
+int job_event_peek (struct job *job, int *flagsp, json_t **entryp);
+bool job_event_is_queued (struct job *job, const char *name);
+const char *job_event_queue_print (struct job *job, char *buf, int size);
 
 #endif /* _FLUX_JOB_MANAGER_JOB_H */
 

--- a/src/modules/job-manager/job.h
+++ b/src/modules/job-manager/job.h
@@ -92,18 +92,6 @@ int job_dependency_add (struct job *job, const char *description);
 int job_dependency_remove (struct job *job, const char *description);
 int job_dependency_count (struct job *job);
 
-/*  Test if dependency event 'event' (dependency-add or dependency-remove)
- *    is valid for this job.
- *  Returns false if:
- *   - EEXIST - when adding a dependency if dependency has already been used
- *   - ENOENT - when removing a dependency that does not exist
- *   - EINVAL - event name is not dependency-add or -remove
- */
-bool job_dependency_event_valid (struct job *job,
-                                 const char *event,
-                                 const char *description);
-
-
 /*  Set a limited set of flags by name on job
  */
 int job_flag_set (struct job *job, const char *flag);

--- a/src/modules/job-manager/jobtap.c
+++ b/src/modules/job-manager/jobtap.c
@@ -1535,13 +1535,6 @@ static int jobtap_emit_dependency_event (struct jobtap *jobtap,
         errno = EINVAL;
         return -1;
     }
-    if (!job_dependency_event_valid (job, event, description)) {
-        /*  Ignore duplicate dependency-add/remove events
-         */
-        if (errno == EEXIST)
-            return 0;
-        return -1;
-    }
     return event_job_post_pack (jobtap->ctx->event,
                                 job,
                                 event,

--- a/src/modules/job-manager/jobtap.c
+++ b/src/modules/job-manager/jobtap.c
@@ -77,9 +77,6 @@ static int jobtap_job_raise (struct jobtap *jobtap,
                              int severity,
                              const char *fmt, ...);
 
-static int job_emit_pending_dependencies (struct jobtap *jobtap,
-                                          struct job *job);
-
 static int dependencies_unpack (struct jobtap * jobtap,
                                 struct job * job,
                                 char **errp,
@@ -92,30 +89,6 @@ static int jobtap_check_dependency (struct jobtap *jobtap,
                                     int index,
                                     json_t *entry,
                                     char **errp);
-
-static struct dependency * dependency_create (bool add,
-                                              const char *description)
-{
-    struct dependency *dp = calloc (1, sizeof (*dp));
-    if (!dp || !(dp->description = strdup (description))) {
-        free (dp);
-        return NULL;
-    }
-    dp->add = add;
-    return dp;
-}
-
-static void dependency_destroy (void **item)
-{
-    if (*item) {
-        struct dependency *dp = *item;
-        int saved_errno = errno;
-        free (dp->description);
-        free (dp);
-        *item = NULL;
-        errno = saved_errno;
-    }
-}
 
 /*  zlistx_t plugin destructor */
 static void plugin_destroy (void **item)
@@ -924,15 +897,6 @@ int jobtap_call (struct jobtap *jobtap,
     int64_t priority = FLUX_JOBTAP_PRIORITY_UNAVAIL;
     va_list ap;
 
-    if (job->state == FLUX_JOB_STATE_DEPEND) {
-        /*  Ensure any pending dependencies are emitted before calling
-         *   into job.state.depend callback to prevent the depend event
-         *   itself when not all dependencies are resolved.
-         */
-        if (job_emit_pending_dependencies (jobtap, job) < 0)
-            return -1;
-    }
-
     if (jobtap_topic_match_count (jobtap, topic) == 0)
         return 0;
 
@@ -1481,39 +1445,6 @@ static struct job *lookup_job (struct job_manager *ctx, flux_jobid_t id)
     return job;
 }
 
-static void zlist_free (void *arg)
-{
-    if (arg)
-        zlistx_destroy ((zlistx_t **) &arg);
-}
-
-static int add_pending_dependency (struct job *job,
-                                   bool add,
-                                   const char *description)
-{
-    struct dependency *dp = NULL;
-    zlistx_t *l = job_aux_get (job, "pending-dependencies");
-    if (!l) {
-        if (!(l = zlistx_new ())) {
-            errno = ENOMEM;
-            return -1;
-        }
-        zlistx_set_destructor (l, dependency_destroy);
-        if (job_aux_set (job, "pending-dependencies", l, zlist_free) < 0) {
-            zlistx_destroy (&l);
-            errno = ENOMEM;
-            return -1;
-        }
-    }
-    if (!(dp = dependency_create (add, description))
-        || !zlistx_add_end (l, dp)) {
-        dependency_destroy ((void **) &dp);
-        errno = ENOMEM;
-        return -1;
-    }
-    return 0;
-}
-
 static int jobtap_emit_dependency_event (struct jobtap *jobtap,
                                          struct job *job,
                                          bool add,
@@ -1522,16 +1453,8 @@ static int jobtap_emit_dependency_event (struct jobtap *jobtap,
     int flags = 0;
     const char *event = add ? "dependency-add" : "dependency-remove";
 
-    if (job->state == FLUX_JOB_STATE_NEW) {
-        /*  Dependencies cannot be emitted before DEPEND state, but it
-         *   is useful for plugins to generate them in job.validate or
-         *   job.new. In this case, stash these dependencies as pending
-         *   within the job itself. These will later be emitted as the job
-         *   enters DEPEND state.
-         */
-        return add_pending_dependency (job, add, description);
-    }
-    if (job->state != FLUX_JOB_STATE_DEPEND) {
+    if (job->state != FLUX_JOB_STATE_DEPEND
+        && job->state != FLUX_JOB_STATE_NEW) {
         errno = EINVAL;
         return -1;
     }
@@ -1574,52 +1497,6 @@ int flux_jobtap_dependency_remove (flux_plugin_t *p,
                                    const char *description)
 {
     return emit_dependency_event (p, id, false, description);
-}
-
-static void emit_pending_dependencies_type (struct jobtap *jobtap,
-                                            struct job *job,
-                                            zlistx_t *l,
-                                            bool add)
-{
-    struct dependency *dp;
-    FOREACH_ZLISTX (l, dp) {
-        if (dp->add != add)
-            continue;
-        if (jobtap_emit_dependency_event (jobtap,
-                                          job,
-                                          dp->add,
-                                          dp->description) < 0) {
-            if (jobtap_job_raise (jobtap, job,
-                                  "dependency",
-                                  0,
-                                  "failed to %s dependency %s",
-                                  dp->add ? "add" : "remove",
-                                  dp->description) < 0) {
-                flux_log_error (jobtap->ctx->h,
-                                "%s: jobtap_job_raise: id=%ju",
-                                __FUNCTION__, (uintmax_t) job->id);
-            }
-            /*  Proceed no further, job has exception and will proceed
-             *   to INACTIVE state
-             */
-            return;
-        }
-        /*  Shorten list for next iteration.
-         */
-        (void) zlistx_delete (l, zlistx_cursor (l));
-    }
-}
-
-static int job_emit_pending_dependencies (struct jobtap *jobtap,
-                                          struct job *job)
-{
-    zlistx_t *l = job_aux_get (job, "pending-dependencies");
-    if (l) {
-        emit_pending_dependencies_type (jobtap, job, l, true);
-        emit_pending_dependencies_type (jobtap, job, l, false);
-        job_aux_delete (job, l);
-    }
-    return 0;
 }
 
 static struct job * jobtap_lookup_jobid (flux_plugin_t *p, flux_jobid_t id)

--- a/t/job-manager/plugins/jobtap_api.c
+++ b/t/job-manager/plugins/jobtap_api.c
@@ -216,25 +216,6 @@ static int test_event_post_pack (flux_plugin_t *p,
                                      errno,
                                      ENOENT);
 
-    if (strcmp (topic, "job.validate") == 0
-        || strcmp (topic, "job.new") == 0) {
-        /* Events may not be emitted before DEPEND state */
-        if (flux_jobtap_event_post_pack (p,
-                                         FLUX_JOBTAP_CURRENT_JOB,
-                                         "foo",
-                                         NULL) == 0
-            || errno != EAGAIN)
-            flux_jobtap_raise_exception (p, FLUX_JOBTAP_CURRENT_JOB,
-                                         "test", 0,
-                                         "%s: %s (%s): errno=%d != %d",
-                                         topic,
-                                         "flux_jobtap_event_post_pack",
-                                         " (topic=%S)",
-                                         errno,
-                                         EINVAL);
-        return 0;
-    }
-
     const char *state;
     if (strncmp (topic, "job.state.", 10) == 0)
         state = topic+10;
@@ -298,14 +279,6 @@ static int test_job_flags (flux_plugin_t *p,
                            flux_plugin_arg_t *args)
 {
     const char *flag = NULL;
-
-    if (strcmp (topic, "job.validate") == 0
-        || strcmp (topic, "job.new") == 0) {
-        /*  Flag cannot be set before job.state.depend (errno EAGAIN) */
-        set_flag_expect_error (topic, p, FLUX_JOBTAP_CURRENT_JOB, "foo",
-                               "p, CURRENT, foo", EAGAIN);
-        return 0;
-    }
 
     set_flag_expect_error (topic, NULL, 0, NULL,    "NULL, 0, NULL", EINVAL);
     set_flag_expect_error (topic, p,    0, NULL,    "p, 0, NULL",    EINVAL);

--- a/t/t2212-job-manager-plugins.t
+++ b/t/t2212-job-manager-plugins.t
@@ -222,12 +222,7 @@ check_event_post() {
 	flux job wait-event -t 20 $id clean >/dev/null
 }
 
-for state in validate new; do
-    test_expect_failure "job-manager: jobtap job.$state can emit events" "
-        check_event_post ${state}
-    "
-done
-for state in depend priority run cleanup; do
+for state in validate new depend priority run cleanup; do
     test_expect_success "job-manager: jobtap job.$state can emit events" "
         check_event_post ${state}
     "

--- a/t/t2270-job-dependencies.t
+++ b/t/t2270-job-dependencies.t
@@ -167,19 +167,6 @@ test_expect_success 'dependency add/remove in callback does not incorrectly rele
 	flux python dep-remove.py ${id} foo &&
 	flux job wait-event -vt 15 ${id} clean
 '
-test_expect_success 'invalid dependency-remove is ignored' '
-	jobid=$(flux mini submit \
-		--dependency=test:bar \
-		hostname) &&
-	flux job wait-event -t 15 -m description=bar ${jobid} dependency-add &&
-	test_must_fail flux python dep-remove.py ${jobid} foo  &&
-	flux job eventlog ${jobid} &&
-	flux jobs -o {id}:{dependencies} ${jobid} &&
-	test "$(flux jobs -no {dependencies} ${jobid})" = "bar" &&
-	flux python dep-remove.py ${jobid} bar &&
-	flux job wait-event -vt 15 ${jobid} clean &&
-	test "$(flux jobs -no {dependencies:h} ${jobid})" = "-"
-'
 test_expect_success 'restart: start job with 2 dependencies to test restart' '
 	jobid=$(flux mini submit \
 		--dependency=test:foo \


### PR DESCRIPTION
Problem: when a job event is posted to a job in the job manager, the "action" for the event might post more events.  Since each event is processed immediately, this can lead to re-entry to the event posting code, and myriad corner cases.

This PR does not switch to a full asynchronous event posting model like the broker's state machine, where events are posted to a queue and always processed in another reactor handler. I went there first and found there was quite a bit of code that assumed that the effects of posting an event are immediate.  Instead this takes a more conservative step: an event queue is added to each job.  Any events that are posted while another event is in progress are added to the queue.  Then when the event is finished, the queue is processed in order.  The queue is always left empty when the original event posting returns.

Effectively this means that some events happen immediately, but others happen "later", depending on whether or not they are posted from an event "action".  But it does keep the events in order and avoids the recursion that was hard to think about.  The current set of tests are all passing, but this difference in event posting semantics could pose problems down the road.  We may be able to convert to a fully asynchronous model at some point and then we would have consistency.

Marking as WIP because I'd like a bit more time to think about this and decide whether more tests are needed.