### PR TITLE
job-manager: misc cleanup

### DIFF
--- a/src/modules/job-manager/alloc.c
+++ b/src/modules/job-manager/alloc.c
@@ -697,7 +697,7 @@ static void cancel_all_pending (struct alloc *alloc)
 }
 
 /* Control resource allocation (query/start/stop).
- * If 'query_only' is true, report allocaction status without altering it.
+ * If 'query_only' is true, report allocation status without altering it.
  * Otherwise update the alloc->disable flag, and for disable only,
  * optionally set alloc->disable_reason.
  *

--- a/src/modules/job-manager/event.c
+++ b/src/modules/job-manager/event.c
@@ -769,13 +769,16 @@ static int event_job_cache (struct event *event,
 
 int event_job_post_entry (struct event *event,
                           struct job *job,
-                          const char *name,
                           int flags,
                           json_t *entry)
 {
     int rc;
     flux_job_state_t old_state = job->state;
     int eventlog_seq = job->eventlog_seq;
+    const char *name;
+
+    if (eventlog_entry_parse (entry, NULL, &name, NULL) < 0)
+        return -1;
 
     /*  Journal event sequence should match actual sequence of events
      *   in the job eventlog, so set eventlog_seq to -1 with
@@ -861,7 +864,7 @@ int event_job_post_vpack (struct event *event,
 
     if (!(entry = eventlog_entry_vpack (0., name, context_fmt, ap)))
         return -1;
-    rc = event_job_post_entry (event, job, name, flags, entry);
+    rc = event_job_post_entry (event, job, flags, entry);
 
     saved_errno = errno;
     json_decref (entry);

--- a/src/modules/job-manager/event.c
+++ b/src/modules/job-manager/event.c
@@ -859,10 +859,6 @@ int event_job_post_vpack (struct event *event,
     int saved_errno;
     int rc;
 
-    if (job->state == FLUX_JOB_STATE_NEW) {
-        errno = EAGAIN;
-        return -1;
-    }
     if (!(entry = eventlog_entry_vpack (0., name, context_fmt, ap)))
         return -1;
     rc = event_job_post_entry (event, job, name, flags, entry);

--- a/src/modules/job-manager/event.h
+++ b/src/modules/job-manager/event.h
@@ -71,7 +71,6 @@ int event_job_post_vpack (struct event *event,
 
 int event_job_post_entry (struct event *event,
                           struct job *job,
-                          const char *name,
                           int flags,
                           json_t *entry);
 

--- a/src/modules/job-manager/submit.c
+++ b/src/modules/job-manager/submit.c
@@ -133,7 +133,7 @@ static int submit_post_event (struct job_manager *ctx, struct job *job)
     if (!entry)
         return -1;
 
-    rv = event_job_post_entry (ctx->event, job, "submit", 0, entry);
+    rv = event_job_post_entry (ctx->event, job, 0, entry);
     ERRNO_SAFE_WRAP (json_decref, entry);
     return rv;
 }

--- a/t/t2212-job-manager-plugins.t
+++ b/t/t2212-job-manager-plugins.t
@@ -229,14 +229,28 @@ test_expect_success 'job-manager: test that job flags can be set' '
 	flux job wait-event -vt 20 $id debug.free-request &&
 	flux job wait-event -vt 20 $id clean
 '
-test_expect_success 'job-manager: jobtap plugin can emit events' '
-	for state in validate new depend priority run cleanup; do
-	    id=$(flux mini submit \
-	          --setattr system.${state}.post-event=testevent hostname) &&
-	    flux job wait-event -vt 20 $id testevent &&
-	    flux job wait-event -t 20 $id clean
-	done
-'
+
+check_event_post() {
+	local state=$1
+	local id
+
+	id=$(flux mini submit \
+	    --setattr system.${state}.post-event=testevent hostname) &&
+	flux job wait-event -vt 20 $id testevent &&
+	flux job wait-event -t 20 $id clean >/dev/null
+}
+
+for state in validate new; do
+    test_expect_failure "job-manager: jobtap job.$state can emit events" "
+        check_event_post ${state}
+    "
+done
+for state in depend priority run cleanup; do
+    test_expect_success "job-manager: jobtap job.$state can emit events" "
+        check_event_post ${state}
+    "
+done
+
 test_expect_success 'job-manager: load test jobtap plugin' '
 	flux jobtap load --remove=all ${PLUGINPATH}/test.so foo.test=1 &&
 	flux dmesg | grep "conf={\"foo\":{\"test\":1}}"

--- a/t/t2240-queue-cmd.t
+++ b/t/t2240-queue-cmd.t
@@ -106,8 +106,8 @@ test_expect_success 'flux-queue: status reports reason for stop' '
 	test_cmp status.exp status.out
 '
 
-test_expect_success 'flux-queue: submit 3 jobs' '
-	for i in $(seq 1 3); do flux mini submit /bin/true; done
+test_expect_success 'flux-queue: submit some jobs' '
+	flux mini submit --cc 1-3 --wait-event=priority /bin/true
 '
 
 test_expect_success 'flux-queue: start scheduling' '


### PR DESCRIPTION
Here are a few job manager/test cleanup commits split off from #4351.    They are  independent of that PR so I thought maybe it's better to submit them separately.