### PR TITLE
shell: execute job tasks in their own process group

### DIFF
--- a/doc/man1/flux-mini.rst
+++ b/doc/man1/flux-mini.rst
@@ -592,6 +592,13 @@ overridden in some cases:
 **verbose**
    Increase verbosity of the job shell log.
 
+**nosetpgrp**
+   Normally the job shell runs each task in its own process group to
+   facilitate delivering signals to tasks which may call :linux:man2:`fork`.
+   With this option, the shell avoids calling :linux:man2:`setpgrp`, and
+   each task will run in the process group of the shell. This will cause
+   signals to be delivered only to direct children of the shell.
+
 **pmi.kvs=native**
    Use the native Flux KVS instead of the PMI plugin's built-in key exchange
    algorithm.

--- a/doc/man1/flux-shell.rst
+++ b/doc/man1/flux-shell.rst
@@ -204,6 +204,11 @@ Options supported by ``flux-shell`` proper include:
   verbosity, though setting this value larger than 2 currently has no
   effect.
 
+**nosetpgrp**\ =\ *INT*
+  If nonzero, disables the use of :linux:man2:`setpgrp` to launch each
+  job task in its own process group. This will cause signals to be
+  delivered only to direct children of the shell.
+
 **initrc**\ =\ *FILE*
   Load flux-shell initrc.lua file from *FILE* instead of the default
   initrc path. For details of the job shell initrc.lua file format,

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -627,3 +627,5 @@ gc
 tgz
 tmpfiles
 EDEADLOCK
+setpgrp
+nosetpgrp

--- a/src/common/libsubprocess/local.c
+++ b/src/common/libsubprocess/local.c
@@ -514,7 +514,8 @@ static int local_child (flux_subprocess_t *p)
         p->in_hook = false;
     }
 
-    if (p->flags & FLUX_SUBPROCESS_FLAGS_SETPGRP) {
+    if (p->flags & FLUX_SUBPROCESS_FLAGS_SETPGRP
+        && getpgrp () != getpid ()) {
         if (setpgrp () < 0) {
             fprintf (stderr, "setpgrp: %s\n", strerror (errno));
             _exit (1);

--- a/src/shell/internal.h
+++ b/src/shell/internal.h
@@ -46,6 +46,7 @@ struct flux_shell {
 
     int verbose;
     bool standalone;
+    int nosetpgrp;
 
     struct aux_item *aux;
 };

--- a/src/shell/shell.c
+++ b/src/shell/shell.c
@@ -1322,6 +1322,12 @@ int main (int argc, char *argv[])
     if (flux_shell_getopt_unpack (&shell, "verbose", "i", &shell.verbose) < 0)
         shell_die (1, "failed to parse attributes.system.shell.verbose");
 
+    /* Set no_process_group if nosetpgrp option is set */
+    if (flux_shell_getopt_unpack (&shell,
+                                  "nosetpgrp", "i",
+                                  &shell.nosetpgrp) < 0)
+        shell_die (1, "failed to parse attributes.system.shell.nosetpgrp");
+
     /* Reinitialize log facility with new verbosity/shell.info */
     if (shell_log_reinit (&shell) < 0)
         shell_die_errno (1, "shell_log_reinit");
@@ -1371,7 +1377,7 @@ int main (int argc, char *argv[])
         if (shell_task_init (&shell) < 0)
             shell_die (1, "failed to initialize taskid=%d", i);
 
-        if (shell_task_start (task, shell.r, task_completion_cb, &shell) < 0) {
+        if (shell_task_start (&shell, task, task_completion_cb, &shell) < 0) {
             int ec = 1;
             /* bash standard, 126 for permission/access denied, 127
              * for command not found.  Note that shell only launches

--- a/src/shell/task.c
+++ b/src/shell/task.c
@@ -193,7 +193,7 @@ int shell_task_start (struct shell_task *task,
                       shell_task_completion_f cb,
                       void *arg)
 {
-    int flags = 0;
+    int flags = FLUX_SUBPROCESS_FLAGS_SETPGRP;
     flux_subprocess_hooks_t hooks = {
         .pre_exec = subproc_preexec_hook,
         .pre_exec_arg = task,

--- a/src/shell/task.c
+++ b/src/shell/task.c
@@ -44,6 +44,7 @@
 
 #include "src/common/libczmqcontainers/czmq_containers.h"
 
+#include "internal.h"
 #include "task.h"
 #include "info.h"
 
@@ -188,16 +189,20 @@ static void subproc_preexec_hook (flux_subprocess_t *p, void *arg)
         (*task->pre_exec_cb) (task, task->pre_exec_arg);
 }
 
-int shell_task_start (struct shell_task *task,
-                      flux_reactor_t *r,
+int shell_task_start (struct flux_shell *shell,
+                      struct shell_task *task,
                       shell_task_completion_f cb,
                       void *arg)
 {
     int flags = FLUX_SUBPROCESS_FLAGS_SETPGRP;
+    flux_reactor_t *r = shell->r;
     flux_subprocess_hooks_t hooks = {
         .pre_exec = subproc_preexec_hook,
         .pre_exec_arg = task,
     };
+
+    if (shell->nosetpgrp)
+        flags &= ~FLUX_SUBPROCESS_FLAGS_SETPGRP;
 
     task->proc = flux_local_exec (r, flags, task->cmd, &subproc_ops, &hooks);
     if (!task->proc)

--- a/src/shell/task.h
+++ b/src/shell/task.h
@@ -56,8 +56,8 @@ void shell_task_destroy (struct shell_task *task);
 
 struct shell_task *shell_task_create (struct shell_info *info, int index);
 
-int shell_task_start (struct shell_task *task,
-                      flux_reactor_t *r,
+int shell_task_start (struct flux_shell *shell,
+                      struct shell_task *task,
                       shell_task_completion_f cb,
                       void *arg);
 

--- a/t/t2602-job-shell.t
+++ b/t/t2602-job-shell.t
@@ -342,4 +342,18 @@ test_expect_success 'job-shell: fails if FLUX_EXEC_PROTOCOL_FD incorrect' '
 		-n2 -N2 hostname 2>protocol_fd_invalid.err &&
 	grep FLUX_EXEC_PROTOCOL_FD protocol_fd_invalid.err
 '
+
+#  Note: in below tests, os.exit(True) returns with nonzero exit code,
+#   so the sense of the tests is reversed so the tasks exit with zero exit
+#   code for success.
+#
+test_expect_success 'job-shell: runs tasks in process group by default' '
+	flux mini run -n2 \
+	    flux python -c "import os,sys; sys.exit(os.getpid() != os.getpgrp())"
+'
+
+test_expect_success 'job-shell: -o nosetpgrp works' '
+	flux mini run -n2 -o nosetpgrp \
+	    flux python -c "import os,sys; sys.exit(os.getpid() == os.getpgrp())"
+'
 test_done


### PR DESCRIPTION
This PR makes a slight change in the way the job shell launches tasks so that each task is in its own process group. This allows the shell to use `killpg(2)` (via libsubprocess) when forwarding signals to a job, so that even children of job tasks are delivered a signal. This should result in better cleanup when job tasks call `fork()`, though note that this may affect an existing use case: #3445.

IMO, it makes sense that the job shell would treat tasks similar to the real shell and use process groups to manage sets of tasks. However, since this could break existing users, maybe we need a shell option to disable it?

I'll work on that next since it should be fairly trivial to implement. Then we'll need some tests. I'm thinking `-o nosetpgrp` but if someone has a better idea please let me know.