### PR TITLE
t2201-job-cmd.t: fix bug in UTF-8 test

### DIFF
--- a/t/t2201-job-cmd.t
+++ b/t/t2201-job-cmd.t
@@ -169,9 +169,10 @@ test_expect_success 'flux-job: id --to=f58 works' '
 	test "$jobid" = "$MINJOBID_F58"
 '
 
-UTF8_LOCALE=$(locale -a | grep UTF-8)
+UTF8_LOCALE=$(locale -a | grep UTF-8 | head -n1)
 test -n "$UTF8_LOCALE" && test_set_prereq UTF8_LOCALE
 test_expect_success UTF8_LOCALE 'flux-job: f58 can use multibyte prefix' '
+	test_debug "echo UTF8_LOCALE=${UTF8_LOCALE}" &&
 	jobid=$(LC_ALL=${UTF8_LOCALE} flux job id --to=f58 1) &&
 	test "$jobid" = "ƒ2"
 '


### PR DESCRIPTION
Problem: Before the test "f58 can use multibyte prefix", the test
script attempts to find a valid utf8 locale using locale -a piped
to grep.  However, if multiple locales match the pattern, then the
UTF8_LOCALE variable used to set LC_ALL is invalid since it will
contain newlines.  This breaks the test on machines with many locales.

Use head(1) to ensure UTF8_LOCALE only contains a single line.

Add a line of debug output to the test in case there are further
problems in the future.

Fixes #4359