### PR TITLE
wait for 'finish' instead of 'clean' event in flux-mini run and flux-job attach

### DIFF
--- a/doc/man1/flux-mini.rst
+++ b/doc/man1/flux-mini.rst
@@ -431,10 +431,12 @@ OTHER OPTIONS
    This is equivalent to ``--wait-event=clean``.
 
 **--wait-event=NAME**
-   *(submit,bulksubmit)* Wait until all jobs have received event ``NAME``
+   *(run,submit,bulksubmit)* Wait until job or jobs have received event ``NAME``
    before exiting. E.g. to submit a job and block until the job begins
-   running, use ``--wait-event=start``. If ``NAME`` begins with ``exec.``,
-   then wait for an event in the exec eventlog, e.g. ``exec.shell.init``.
+   running, use ``--wait-event=start``. *(submit,bulksubmit only)* If ``NAME``
+   begins with ``exec.``, then wait for an event in the exec eventlog, e.g.
+   ``exec.shell.init``. For ``flux mini run`` the argument to this option
+   when used is passed directly to ``flux job attach``.
 
 **--watch**
    *(submit,bulksubmit)* Display output from all jobs. Implies ``--wait``.

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -2211,13 +2211,13 @@ int cmd_attach (optparse_t *p, int argc, char **argv)
         log_err_exit ("flux_get_reactor");
 
     /*  Check for the event name that attach should wait for in the
-     *   main job eventlog. The default is the "clean" event.
+     *   main job eventlog. The default is the "finish" event.
      *   If the event never appears in the eventlog, flux-job attach
      *   will still exit after the 'clean' event, since the job-info
      *   module reponds with ENODATA after the final event, which by
      *   definition is "clean".
      */
-    ctx.wait_event = optparse_get_str (p, "wait-event", "clean");
+    ctx.wait_event = optparse_get_str (p, "wait-event", "finish");
 
     if (optparse_hasopt (ctx.p, "debug")
         || optparse_hasopt (ctx.p, "debug-emulate")) {

--- a/src/cmd/flux-mini.py
+++ b/src/cmd/flux-mini.py
@@ -1385,6 +1385,11 @@ class RunCmd(SubmitBaseCmd):
     def __init__(self):
         super().__init__()
         self.parser.add_argument(
+            "--wait-event",
+            metavar="NAME",
+            help="Pass --wait-event=NAME to flux-job attach",
+        )
+        self.parser.add_argument(
             "command", nargs=argparse.REMAINDER, help="Job command and arguments"
         )
 
@@ -1408,6 +1413,8 @@ class RunCmd(SubmitBaseCmd):
             attach_args.append("--show-exec")
         if args.debug_emulate:
             attach_args.append("--debug-emulate")
+        if args.wait_event:
+            attach_args.append(f"--wait-event={args.wait_event}")
         attach_args.append(jobid.f58.encode("utf-8", errors="surrogateescape"))
 
         # Exec flux-job attach, searching for it in FLUX_EXEC_PATH.

--- a/t/t2274-manager-perilog.t
+++ b/t/t2274-manager-perilog.t
@@ -111,7 +111,7 @@ test_expect_success 'perilog: load perilog.so plugin' '
 test_expect_success 'perilog: configured prolog/epilog works for jobs' '
 	undrain_all &&
 	jobid=$(flux mini submit --job-name=works hostname) &&
-	flux job attach -vE $jobid > submit1.log 2>&1 &&
+	flux job attach -vE -w clean $jobid > submit1.log 2>&1 &&
 	test_debug "cat submit1.log" &&
 	grep prolog-start submit1.log &&
 	grep prolog-finish submit1.log &&

--- a/t/t2500-job-attach.t
+++ b/t/t2500-job-attach.t
@@ -15,10 +15,14 @@ test_expect_success 'attach: submit one job' '
 test_expect_success 'attach: job ran successfully' '
 	run_timeout 5 flux job attach $(cat jobid1)
 '
-
-test_expect_success 'attach: --show-events shows clean event' '
+test_expect_success 'attach: --show-events shows finish event' '
 	run_timeout 5 flux job attach \
 		--show-event $(cat jobid1) 2>jobid1.events &&
+	grep finish jobid1.events
+'
+test_expect_success 'attach: --show-events -w clean shows clean event' '
+	run_timeout 5 flux job attach \
+		--show-event -w clean $(cat jobid1) 2>jobid1.events &&
 	grep clean jobid1.events
 '
 test_expect_success 'attach: --show-events shows done event' '


### PR DESCRIPTION
This PR changes `flux job attach` (and thus `flux mini run`) to wait only for the job `finish` event instead of `clean` to avoid unnecessarily waiting in these interactive commands when there is a slow job epilog or some other  delay between the finish and clean events.

A new `--wait-event` option is added to `flux job attach` and exposed in `flux mini run`. `flux mini run --wait-event=clean ...` will restore the current behavior for example.

