### PR TITLE
job-manager: misc cleanup

### DIFF
--- a/src/modules/job-manager/alloc.c
+++ b/src/modules/job-manager/alloc.c
@@ -25,6 +25,7 @@
 #include <assert.h>
 
 #include "src/common/libczmqcontainers/czmq_containers.h"
+#include "ccan/str/str.h"
 
 #include "job.h"
 #include "alloc.h"
@@ -410,14 +411,14 @@ static void ready_cb (flux_t *h, flux_msg_handler_t *mh,
                                         "mode", &mode,
                                         "limit", &limit) < 0)
         goto error;
-    if (!strcmp (mode, "limited")) {
+    if (streq (mode, "limited")) {
         if (limit <= 0) {
             errno = EPROTO;
             goto error;
         }
         ctx->alloc->alloc_limit = limit;
     }
-    else if (!strcmp (mode, "unlimited"))
+    else if (streq (mode, "unlimited"))
         ctx->alloc->alloc_limit = 0;
     else {
         errno = EPROTO;
@@ -793,7 +794,7 @@ void alloc_disconnect_rpc (flux_t *h,
     if (alloc->sched_sender) {
         const char *sender;
         if ((sender = flux_msg_route_first (msg))
-            && !strcmp (sender, alloc->sched_sender))
+            && streq (sender, alloc->sched_sender))
             interface_teardown (ctx->alloc, "disconnect", 0);
     }
 }

--- a/src/modules/job-manager/event.c
+++ b/src/modules/job-manager/event.c
@@ -353,7 +353,7 @@ int event_job_action (struct event *event, struct job *job)
             break;
         case FLUX_JOB_STATE_RUN:
             /*
-             *  If job->request_refcount is nonzero then a prolog action
+             *  If job->perilog_active is nonzero then a prolog action
              *   is still in progress so do not send start request.
              */
             if (!job->perilog_active

--- a/src/modules/job-manager/event.c
+++ b/src/modules/job-manager/event.c
@@ -43,6 +43,7 @@
 #include "src/common/libczmqcontainers/czmq_containers.h"
 #include "src/common/libeventlog/eventlog.h"
 #include "ccan/ptrint/ptrint.h"
+#include "ccan/str/str.h"
 
 #include "alloc.h"
 #include "start.h"
@@ -477,9 +478,9 @@ static int event_handle_dependency (struct job *job,
         errno = EPROTO;
         return -1;
     }
-    if (strcmp (cmd, "add") == 0)
+    if (streq (cmd, "add"))
         return job_dependency_add (job, desc);
-    else if (strcmp (cmd, "remove") == 0)
+    else if (streq (cmd, "remove"))
         return job_dependency_remove (job, desc);
     else {
         errno = EINVAL;
@@ -514,14 +515,14 @@ static int event_handle_perilog (struct job *job,
                                  const char *cmd,
                                  json_t *context)
 {
-    if (strcmp (cmd, "start") == 0) {
+    if (streq (cmd, "start")) {
         if (job->perilog_active == UINT8_MAX) {
             errno = EOVERFLOW;
             return -1;
         }
         job->perilog_active++;
     }
-    else if (strcmp (cmd, "finish") == 0) {
+    else if (streq (cmd, "finish")) {
         if (job->perilog_active > 0)
             job->perilog_active--;
     }
@@ -577,7 +578,7 @@ int event_job_update (struct job *job, json_t *event)
     if (eventlog_entry_parse (event, &timestamp, &name, &context) < 0)
         goto error;
 
-    if (!strcmp (name, "submit")) {
+    if (streq (name, "submit")) {
         if (job->state != FLUX_JOB_STATE_NEW)
             goto inval;
         job->t_submit = timestamp;
@@ -594,20 +595,20 @@ int event_job_update (struct job *job, json_t *event)
         if (event_handle_dependency (job, name+11, context) < 0)
             goto error;
     }
-    else if (!strcmp (name, "set-flags")) {
+    else if (streq (name, "set-flags")) {
         if (event_handle_set_flags (job, context) < 0)
             goto error;
     }
-    else if (!strcmp (name, "memo")) {
+    else if (streq (name, "memo")) {
         if (event_handle_memo (job, context) < 0)
             goto error;
     }
-    else if (!strcmp (name, "depend")) {
+    else if (streq (name, "depend")) {
         if (job->state != FLUX_JOB_STATE_DEPEND)
             goto inval;
         job->state = FLUX_JOB_STATE_PRIORITY;
     }
-    else if (!strcmp (name, "priority")) {
+    else if (streq (name, "priority")) {
         if (job->state != FLUX_JOB_STATE_PRIORITY
             && job->state != FLUX_JOB_STATE_SCHED)
             goto inval;
@@ -615,11 +616,11 @@ int event_job_update (struct job *job, json_t *event)
             goto error;
         job->state = FLUX_JOB_STATE_SCHED;
     }
-    else if (!strcmp (name, "urgency")) {
+    else if (streq (name, "urgency")) {
         if (event_urgency_context_decode (context, &job->urgency) < 0)
             goto error;
     }
-    else if (!strcmp (name, "exception")) {
+    else if (streq (name, "exception")) {
         int severity;
         if (job->state == FLUX_JOB_STATE_NEW
             || job->state == FLUX_JOB_STATE_INACTIVE)
@@ -633,7 +634,7 @@ int event_job_update (struct job *job, json_t *event)
             job->state = FLUX_JOB_STATE_CLEANUP;
         }
     }
-    else if (!strcmp (name, "alloc")) {
+    else if (streq (name, "alloc")) {
         if (job->state != FLUX_JOB_STATE_SCHED
             && job->state != FLUX_JOB_STATE_CLEANUP)
             goto inval;
@@ -641,13 +642,13 @@ int event_job_update (struct job *job, json_t *event)
         if (job->state == FLUX_JOB_STATE_SCHED)
             job->state = FLUX_JOB_STATE_RUN;
     }
-    else if (!strcmp (name, "free")) {
+    else if (streq (name, "free")) {
         if (job->state != FLUX_JOB_STATE_CLEANUP
             || !job->has_resources)
             goto inval;
         job->has_resources = 0;
     }
-    else if (!strcmp (name, "finish")) {
+    else if (streq (name, "finish")) {
         if (job->state != FLUX_JOB_STATE_RUN
             && job->state != FLUX_JOB_STATE_CLEANUP)
             goto inval;
@@ -658,7 +659,7 @@ int event_job_update (struct job *job, json_t *event)
             job->state = FLUX_JOB_STATE_CLEANUP;
         }
     }
-    else if (!strcmp (name, "release")) {
+    else if (streq (name, "release")) {
         int final;
         if (job->state != FLUX_JOB_STATE_RUN
             && job->state != FLUX_JOB_STATE_CLEANUP)
@@ -668,7 +669,7 @@ int event_job_update (struct job *job, json_t *event)
         if (final && job->state == FLUX_JOB_STATE_RUN)
             goto inval;
     }
-    else if (!strcmp (name, "clean")) {
+    else if (streq (name, "clean")) {
         if (job->state != FLUX_JOB_STATE_CLEANUP)
             goto inval;
         job->state = FLUX_JOB_STATE_INACTIVE;
@@ -686,7 +687,7 @@ int event_job_update (struct job *job, json_t *event)
         if (event_handle_perilog (job, name+7, context) < 0)
             goto error;
     }
-    else if (!strcmp (name, "flux-restart")) {
+    else if (streq (name, "flux-restart")) {
         /* The flux-restart event is currently only posted to jobs in
          * SCHED state since that is the only state transition defined
          * for the event in RFC21.  In the future, other transitions
@@ -737,7 +738,7 @@ static int event_jobtap_call (struct event *event,
                             "entry", entry,
                             "prev_state", old_state);
     }
-    else if (strcmp (name, "urgency") == 0) {
+    else if (streq (name, "urgency")) {
         /*
          *  An urgency update ocurred. Get new priority value from plugin
          *   and reprioritize job if there was a change.

--- a/src/modules/job-manager/getattr.c
+++ b/src/modules/job-manager/getattr.c
@@ -27,6 +27,7 @@
 
 #include "src/common/libutil/errno_safe.h"
 #include "src/common/libczmqcontainers/czmq_containers.h"
+#include "ccan/str/str.h"
 
 #include "job.h"
 #include "job-manager.h"
@@ -51,7 +52,7 @@ static json_t *make_dict (struct job *job,
             errno = EPROTO;
             goto error;
         }
-        if (!strcmp (key, "jobspec")) {
+        if (streq (key, "jobspec")) {
             if (!job->jobspec_redacted) {
                 snprintf (errstr, errstrsz, "jobspec is NULL");
                 errno = ENOENT;

--- a/src/modules/job-manager/job.c
+++ b/src/modules/job-manager/job.c
@@ -21,6 +21,7 @@
 #include "src/common/libutil/grudgeset.h"
 #include "src/common/libutil/jpath.h"
 #include "src/common/libutil/aux.h"
+#include "ccan/str/str.h"
 
 #include "job.h"
 #include "event.h"
@@ -95,13 +96,13 @@ bool job_dependency_event_valid (struct job *job,
                                  const char *event,
                                  const char *description)
 {
-    if (strcmp (event, "dependency-add") == 0) {
+    if (streq (event, "dependency-add")) {
         if (grudgeset_used (job->dependencies, description)) {
             errno = EEXIST;
             return false;
         }
     }
-    else if (strcmp (event, "dependency-remove") == 0) {
+    else if (streq (event, "dependency-remove")) {
         if (!grudgeset_contains (job->dependencies, description)) {
             errno = ENOENT;
             return false;
@@ -118,11 +119,11 @@ static int job_flag_set_internal (struct job *job,
                                   const char *flag,
                                   bool dry_run)
 {
-   if (strcmp (flag, "alloc-bypass") == 0) {
+   if (streq (flag, "alloc-bypass")) {
         if (!dry_run)
             job->alloc_bypass = 1;
     }
-    else if (strcmp (flag, "debug") == 0) {
+    else if (streq (flag, "debug")) {
         if (!dry_run)
             job->flags |= FLUX_JOB_DEBUG;
     }

--- a/src/modules/job-manager/plugins/dependency-after.c
+++ b/src/modules/job-manager/plugins/dependency-after.c
@@ -21,6 +21,7 @@
 
 #include "src/common/libutil/iterators.h"
 #include "src/common/libczmqcontainers/czmq_containers.h"
+#include "ccan/str/str.h"
 
 /* Types of "after*" dependencies:
  */
@@ -62,13 +63,13 @@ static const char * after_typestr (enum after_type type)
 
 static int after_type_parse (const char *s, enum after_type *tp)
 {
-    if (strcmp (s, "after") == 0)
+    if (streq (s, "after"))
         *tp = AFTER_START;
-    else if (strcmp (s, "afterany") == 0)
+    else if (streq (s, "afterany"))
         *tp = AFTER_FINISH;
-    else if (strcmp (s, "afterok") == 0)
+    else if (streq (s, "afterok"))
         *tp = AFTER_SUCCESS;
-    else if (strcmp (s, "afternotok") == 0)
+    else if (streq (s, "afternotok"))
         *tp = AFTER_FAILURE;
     else
         return -1;

--- a/src/modules/job-manager/plugins/perilog.c
+++ b/src/modules/job-manager/plugins/perilog.c
@@ -50,6 +50,7 @@
 
 #include "src/common/libjob/job_hash.h"
 #include "src/common/libczmqcontainers/czmq_containers.h"
+#include "ccan/str/str.h"
 
 extern char **environ;
 
@@ -234,7 +235,7 @@ static void io_cb (flux_subprocess_t *sp, const char *stream)
     }
     if (len) {
         int level = LOG_INFO;
-        if (strcmp (stream, "stderr") == 0)
+        if (streq (stream, "stderr"))
             level = LOG_ERR;
         flux_log (h,
                   level,

--- a/src/modules/job-manager/start.c
+++ b/src/modules/job-manager/start.c
@@ -86,6 +86,7 @@
 #include <assert.h>
 
 #include "src/common/libczmqcontainers/czmq_containers.h"
+#include "ccan/str/str.h"
 
 #include "job.h"
 #include "event.h"
@@ -183,7 +184,7 @@ static void start_response_cb (flux_t *h, flux_msg_handler_t *mh,
 
     if (flux_response_decode (msg, &topic, NULL) < 0)
         goto teardown; // e.g. ENOSYS
-    if (!start->topic || strcmp (start->topic, topic) != 0) {
+    if (!start->topic || !streq (start->topic, topic)) {
         flux_log_error (h, "start: topic=%s not registered", topic);
         goto error;
     }
@@ -199,7 +200,7 @@ static void start_response_cb (flux_t *h, flux_msg_handler_t *mh,
         errno = EINVAL;
         goto error;
     }
-    if (!strcmp (type, "start")) {
+    if (streq (type, "start")) {
         if (job->reattach)
             flux_log (h,
                       LOG_ERR,
@@ -210,7 +211,7 @@ static void start_response_cb (flux_t *h, flux_msg_handler_t *mh,
                 goto error_post;
         }
     }
-    else if (!strcmp (type, "reattached")) {
+    else if (streq (type, "reattached")) {
         if ((job->flags & FLUX_JOB_DEBUG)) {
             if (event_job_post_pack (ctx->event,
                                      job,
@@ -220,7 +221,7 @@ static void start_response_cb (flux_t *h, flux_msg_handler_t *mh,
                 goto error_post;
         }
     }
-    else if (!strcmp (type, "release")) {
+    else if (streq (type, "release")) {
         const char *idset;
         int final;
         if (json_unpack (data, "{s:s s:b}", "ranks", &idset,
@@ -237,7 +238,7 @@ static void start_response_cb (flux_t *h, flux_msg_handler_t *mh,
                                  "final", final) < 0)
             goto error_post;
     }
-    else if (!strcmp (type, "exception")) {
+    else if (streq (type, "exception")) {
         int xseverity;
         const char *xtype;
         const char *xnote = NULL;
@@ -256,7 +257,7 @@ static void start_response_cb (flux_t *h, flux_msg_handler_t *mh,
                                  "note", xnote ? xnote : "")  < 0)
             goto error_post;
     }
-    else if (!strcmp (type, "finish")) {
+    else if (streq (type, "finish")) {
         int status;
         if (json_unpack (data, "{s:i}", "status", &status) < 0) {
             errno = EPROTO;

--- a/src/modules/job-manager/wait.c
+++ b/src/modules/job-manager/wait.c
@@ -56,6 +56,7 @@
 #include "src/common/libutil/errno_safe.h"
 #include "src/common/libeventlog/eventlog.h"
 #include "src/common/libjob/job_hash.h"
+#include "ccan/str/str.h"
 
 #include "drain.h"
 #include "submit.h"
@@ -85,7 +86,7 @@ static int decode_job_result (struct job *job,
 
     /* Exception - set errbuf=description, set success=false
      */
-    if (!strcmp (name, "exception")) {
+    if (streq (name, "exception")) {
         const char *type;
         const char *note = NULL;
 
@@ -106,7 +107,7 @@ static int decode_job_result (struct job *job,
     /* Shells exited - set errbuf=decoded status byte,
      * set success=true if all shells exited with 0, otherwise false.
      */
-    else if (!strcmp (name, "finish")) {
+    else if (streq (name, "finish")) {
         int status;
 
         if (json_unpack (context, "{s:i}", "status", &status) < 0)

--- a/t/t2212-job-manager-plugins.t
+++ b/t/t2212-job-manager-plugins.t
@@ -367,7 +367,7 @@ test_expect_success 'job-manager: plugin can reject some jobs in a batch' '
 	grep "Job had reject_id" validate-plugin.out &&
 	test 4 -eq $(grep -c foo validate-plugin.out)
 '
-test_expect_success 'job-manager: plugin can manage depedencies' '
+test_expect_success 'job-manager: plugin can manage dependencies' '
 	cat <<-EOF >dep-remove.py &&
 	import flux
 	from flux.job import JobID


### PR DESCRIPTION
Here's some more misc. job manager cleanup peeled off of #4351.  The main thing is converting strcmp to streq (inspired by @grondo's PR this afternoon).