### PR TITLE
libsdprocess: support cgroup memory configuration

### DIFF
--- a/doc/man5/flux-config-exec.rst
+++ b/doc/man5/flux-config-exec.rst
@@ -52,6 +52,31 @@ cpu_set_allowed
 
    (optional) Set to true to set limit execution to only allocated cores.
 
+MemoryHigh
+
+   (optional) Set to number of bytes memory high limit should be.
+   Memory usage can go above this limit but can be throttled.  The
+   suffixes k, m, g, and t can be used for kilobytes, megabytes,
+   gigabytes, and terabytes respectively.
+
+   Optionally, a percentage of memory can also be configured via a
+   number between 0 and 100 followed by a '%' sign.
+
+   The special value "infinity" can also be specified to indicate
+   100%.
+
+MemoryMax
+
+   (optional) Set to number of bytes memory max should be.  Memory
+   cannot go above this value, otherwise an out-of-memory failure will
+   occur.  The suffixes k, m, g, and t can be used for kilobytes,
+   megabytes, gigabytes, and terabytes respectively.
+
+   Optionally, a percentage of memory can also be configured via a
+   number between 0 and 100 followed by a '%' sign.
+
+   The special value "infinity" can also be specified to indicate
+   100%.
 
 EXAMPLE
 =======

--- a/doc/man5/flux-config-exec.rst
+++ b/doc/man5/flux-config-exec.rst
@@ -8,13 +8,15 @@ DESCRIPTION
 
 The Flux system instance **job-exec** service requires additional
 configuration via the ``exec`` table, for example to enlist the services
-of a setuid helper to launch jobs as guests.
+of a setuid helper to launch jobs as guests.  Additional configuration
+options may exist under the ``exec.<method>`` depending on the setting
+of ``method`` below.
+
+
+EXEC KEYS
+=========
 
 The ``exec`` table may contain the following keys:
-
-
-KEYS
-====
 
 imp
    (optional) Set the path to the IMP (Independent Minister of Privilege)
@@ -34,6 +36,21 @@ method
 
 job-shell
    (optional) Override the compiled-in default job shell path.
+
+
+EXEC.SYSTEMD KEYS
+=================
+
+The ``exec.systemd`` table may contain the following keys.  These are only valid
+if ``method`` is set to ``systemd``.
+
+cpu_set_affinity
+
+   (optional) Set to true to set CPU affinity to only allocated cores.
+
+cpu_set_allowed
+
+   (optional) Set to true to set limit execution to only allocated cores.
 
 
 EXAMPLE

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -629,3 +629,5 @@ tmpfiles
 EDEADLOCK
 setpgrp
 nosetpgrp
+MemoryHigh
+MemoryMax

--- a/src/common/libsdprocess/Makefile.am
+++ b/src/common/libsdprocess/Makefile.am
@@ -18,14 +18,17 @@ libsdprocess_la_SOURCES = \
 	sdprocess.h \
 	sdprocess_private.h \
 	strv.c \
-	strv.h
+	strv.h \
+	parse.c \
+	parse.h
 
 libsdprocess_la_LIBADD = \
 	$(LIBSYSTEMD_LIBS)
 
 TESTS = \
 	test_sdprocess.t \
-	test_strv.t
+	test_strv.t \
+	test_parse.t
 
 check_PROGRAMS = \
 	$(TESTS) \
@@ -56,6 +59,11 @@ test_strv_t_SOURCES = test/strv.c
 test_strv_t_CPPFLAGS = $(test_cppflags)
 test_strv_t_LDADD = $(test_ldadd)
 test_strv_t_LDFLAGS = $(test_ldflags)
+
+test_parse_t_SOURCES = test/parse.c
+test_parse_t_CPPFLAGS = $(test_cppflags)
+test_parse_t_LDADD = $(test_ldadd)
+test_parse_t_LDFLAGS = $(test_ldflags)
 
 test_sdprocess_t_SOURCES = test/sdprocess.c
 test_sdprocess_t_CPPFLAGS = \

--- a/src/common/libsdprocess/parse.c
+++ b/src/common/libsdprocess/parse.c
@@ -1,0 +1,113 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+# include "config.h"
+#endif
+
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <limits.h>
+
+#include "parse.h"
+
+int parse_percent (const char *s, double *percent)
+{
+    double p;
+    int len;
+    char *endptr;
+
+    if (!s || !percent) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    /* infinity = 100% */
+    if (!strcasecmp (s, "infinity")) {
+        (*percent) = 1.0;
+        return 0;
+    }
+
+    len = strlen (s);
+    if (s[len - 1] != '%') {
+        errno = EINVAL;
+        return -1;
+    }
+
+    errno = 0;
+    p = strtod (s, &endptr);
+    if (errno != 0)
+        return -1;
+    if (endptr != &s[len -1]
+        || p < 0.0
+        || p > 100.0) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    (*percent) = (p / 100.0);
+    return 0;
+}
+
+int parse_unsigned (const char *s, uint64_t *num)
+{
+    uint64_t n;
+    char *endptr;
+
+    if (!s || !num || s[0] == '-') {
+        errno = EINVAL;
+        return -1;
+    }
+
+    errno = 0;
+    n = strtoull (s, &endptr, 0);
+    if (errno != 0)
+        return -1;
+    if (n == 0) {
+        errno = EINVAL;
+        return -1;
+    }
+    if ((*endptr) != '\0') {
+        uint64_t mult = 1;
+        if (strlen (endptr) > 1) {
+            errno = EINVAL;
+            return -1;
+        }
+        if ((*endptr) == 'k'
+            || (*endptr) == 'K')
+            mult = 1024ULL;
+        else if ((*endptr) == 'm'
+                 || (*endptr) == 'M')
+            mult = 1024ULL * 1024ULL;
+        else if ((*endptr) == 'g'
+                 || (*endptr) == 'G')
+            mult = 1024ULL * 1024ULL * 1024ULL;
+        else if ((*endptr) == 't'
+                 || (*endptr) == 'T')
+            mult = 1024ULL * 1024ULL * 1024ULL * 1024ULL;
+        else {
+            errno = EINVAL;
+            return -1;
+        }
+        if ((ULLONG_MAX / mult) < n) {
+            errno = ERANGE;
+            return -1;
+        }
+        n *= mult;
+    }
+
+    (*num) = n;
+    return 0;
+}
+
+/*
+ * vi: ts=4 sw=4 expandtab
+ */

--- a/src/common/libsdprocess/parse.h
+++ b/src/common/libsdprocess/parse.h
@@ -1,0 +1,24 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _PARSE_H
+#define _PARSE_H
+
+#include <stdint.h>
+
+/* string parsing functions */
+
+/* parse strings in format "<double>%" */
+int parse_percent (const char *s, double *percent);
+
+/* parse strings in format "<unsigned long>[k,m,g,t]" */
+int parse_unsigned (const char *s, uint64_t *num);
+
+#endif /* !_PARSE_H */

--- a/src/common/libsdprocess/sdprocess.h
+++ b/src/common/libsdprocess/sdprocess.h
@@ -59,8 +59,14 @@ typedef int (*sdprocess_list_f) (flux_t *h,
 /* Launch process under systemd
  *
  * command must be an absolute path
- * argv & envv arrays are NULL terminated
+ * argv & envv & properties arrays are NULL terminated
  * if unnecessary, set fd to < 0
+ *
+ * Current properties supported:
+ * None
+ *
+ * Properties not allowed due to internal use:
+ * - RemainAfterExit
  *
  * Setup of XDG_RUNTIME_DIR and DBUS_SESSION_BUS_ADDRESS environment
  * variables are assumed.  If not, systemd will return error.
@@ -69,6 +75,7 @@ sdprocess_t *sdprocess_exec (flux_t *h,
                              const char *unitname,
                              char **argv,
                              char **envv,
+                             char **properties,
                              int stdin_fd,
                              int stdout_fd,
                              int stderr_fd);

--- a/src/common/libsdprocess/sdprocess.h
+++ b/src/common/libsdprocess/sdprocess.h
@@ -63,7 +63,7 @@ typedef int (*sdprocess_list_f) (flux_t *h,
  * if unnecessary, set fd to < 0
  *
  * Current properties supported:
- * None
+ * - CPUAffinity=<flux idset> (N.B. input different than systemd)
  *
  * Properties not allowed due to internal use:
  * - RemainAfterExit

--- a/src/common/libsdprocess/sdprocess.h
+++ b/src/common/libsdprocess/sdprocess.h
@@ -64,6 +64,7 @@ typedef int (*sdprocess_list_f) (flux_t *h,
  *
  * Current properties supported:
  * - CPUAffinity=<flux idset> (N.B. input different than systemd)
+ * - AllowedCPUs=<flux idset> (N.B. input different than systemd)
  *
  * Properties not allowed due to internal use:
  * - RemainAfterExit

--- a/src/common/libsdprocess/sdprocess.h
+++ b/src/common/libsdprocess/sdprocess.h
@@ -65,6 +65,12 @@ typedef int (*sdprocess_list_f) (flux_t *h,
  * Current properties supported:
  * - CPUAffinity=<flux idset> (N.B. input different than systemd)
  * - AllowedCPUs=<flux idset> (N.B. input different than systemd)
+ * - MemoryHigh=<bytes> (k, m, g, t suffix allowed)
+ *   OR MemoryHigh=<percent> (double + '%')
+ *   OR MemoryHigh=infinity (same as 100%)
+ * - MemoryMax=<bytes> (k, m, g, t suffix allowed)
+ *   OR MemoryMax=<percent> (double + '%')
+ *   OR MemoryMax=infinity (same as 100%)
  *
  * Properties not allowed due to internal use:
  * - RemainAfterExit

--- a/src/common/libsdprocess/test/parse.c
+++ b/src/common/libsdprocess/test/parse.c
@@ -1,0 +1,159 @@
+/************************************************************\
+ * Copyright 2021 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <assert.h>
+
+#include "src/common/libtap/tap.h"
+#include "src/common/libsdprocess/parse.h"
+
+#define OUTOFRANGEPERCENT \
+    "100000000000000000000000000000000" \
+    "000000000000000000000000000000000" \
+    "000000000000000000000000000000000" \
+    "000000000000000000000000000000000" \
+    "000000000000000000000000000000000" \
+    "000000000000000000000000000000000" \
+    "000000000000000000000000000000000" \
+    "000000000000000000000000000000000" \
+    "000000000000000000000000000000000" \
+    "00000000000000000000000000000000%"
+
+#define OUTOFRANGENUM "20000000000000000000"
+
+static void test_parse_percent (void)
+{
+    double percent;
+    int ret;
+
+    errno = 0;
+    ret = parse_percent (NULL, NULL);
+    ok (ret < 0 && errno == EINVAL,
+        "parse_percent fails with EINVAL on NULL inputs");
+
+    errno = 0;
+    ret = parse_percent ("123", &percent);
+    ok (ret < 0 && errno == EINVAL,
+        "parse_percent fails with EINVAL on not a percent input");
+
+    errno = 0;
+    ret = parse_percent (OUTOFRANGEPERCENT, &percent);
+    ok (ret < 0 && errno == ERANGE,
+        "parse_percent fails with ERANGE on percent out of range");
+
+    errno = 0;
+    ret = parse_percent ("-18%", &percent);
+    ok (ret < 0 && errno == EINVAL,
+        "parse_percent fails with EINVAL on negative percent");
+
+    errno = 0;
+    ret = parse_percent ("110%", &percent);
+    ok (ret < 0 && errno == EINVAL,
+        "parse_percent fails with EINVAL on percent > 100");
+
+    ret = parse_percent ("0%", &percent);
+    ok (ret == 0 && percent == 0.0,
+        "parse_percent work with 0%");
+
+    ret = parse_percent ("98%", &percent);
+    ok (ret == 0 && percent == 0.98,
+        "parse_percent work with 98.0%");
+
+    ret = parse_percent ("100%", &percent);
+    ok (ret == 0 && percent == 1.0,
+        "parse_percent work with 100%");
+
+    ret = parse_percent ("infinity", &percent);
+    ok (ret == 0 && percent == 1.0,
+        "parse_percent work with infinity");
+
+    ret = parse_percent ("0.25%", &percent);
+    ok (ret == 0 && percent == 0.0025,
+        "parse_percent work with 0.25%");
+
+    ret = parse_percent ("50.2%", &percent);
+    ok (ret == 0 && percent == 0.502,
+        "parse_percent work with 50.2%");
+}
+
+static void test_parse_unsigned (void)
+{
+    uint64_t num;
+    int ret;
+
+    errno = 0;
+    ret = parse_unsigned (NULL, NULL);
+    ok (ret < 0 && errno == EINVAL,
+        "parse_unsigned fails with EINVAL on NULL inputs");
+
+    errno = 0;
+    ret = parse_unsigned (OUTOFRANGENUM, &num);
+    ok (ret < 0 && errno == ERANGE,
+        "parse_unsigned fails with ERANGE on num out of range");
+
+    errno = 0;
+    ret = parse_unsigned ("0", &num);
+    ok (ret < 0 && errno == EINVAL,
+        "parse_unsigned fails with EINVAL on zero");
+
+    errno = 0;
+    ret = parse_unsigned ("-1000", &num);
+    ok (ret < 0 && errno == EINVAL,
+        "parse_unsigned fails with EINVAL on negative num");
+
+    errno = 0;
+    ret = parse_unsigned ("1000z", &num);
+    ok (ret < 0 && errno == EINVAL,
+        "parse_unsigned fails with EINVAL on bad suffix");
+
+    errno = 0;
+    ret = parse_unsigned ("1000kk", &num);
+    ok (ret < 0 && errno == EINVAL,
+        "parse_unsigned fails with EINVAL on long suffix");
+
+    ret = parse_unsigned ("1000", &num);
+    ok (ret == 0 && num == 1000,
+        "parse_unsigned work with just num");
+
+    ret = parse_unsigned ("1000k", &num);
+    ok (ret == 0 && num == (1000ULL * 1024ULL),
+        "parse_unsigned work with k suffix");
+
+    ret = parse_unsigned ("1000M", &num);
+    ok (ret == 0 && num == (1000ULL * 1024ULL * 1024ULL),
+        "parse_unsigned work with M suffix");
+
+    ret = parse_unsigned ("1000g", &num);
+    ok (ret == 0 && num == (1000ULL * 1024ULL * 1024ULL * 1024ULL),
+        "parse_unsigned work with g suffix");
+
+    ret = parse_unsigned ("1000T", &num);
+    ok (ret == 0 && num == (1000ULL * 1024ULL * 1024ULL * 1024ULL * 1024ULL),
+        "parse_unsigned work with T suffix");
+}
+
+int main (int argc, char *argv[])
+{
+    plan (NO_PLAN);
+
+    test_parse_percent ();
+    test_parse_unsigned ();
+
+    done_testing ();
+    return 0;
+}
+
+/*
+ * vi: ts=4 sw=4 expandtab
+ */

--- a/src/common/libsdprocess/test/sdprocess.c
+++ b/src/common/libsdprocess/test/sdprocess.c
@@ -87,7 +87,7 @@ static void test_corner_case (void)
     bool active, exited;
     int ret;
 
-    sdp = sdprocess_exec (NULL, NULL, NULL, NULL, -1, -1, -1);
+    sdp = sdprocess_exec (NULL, NULL, NULL, NULL, NULL, -1, -1, -1);
     ok (sdp == NULL && errno == EINVAL,
         "sdprocess_exec returns EINVAL on invalid input");
 
@@ -156,6 +156,7 @@ static void test_basic (flux_t *h,
                           unitname,
                           cmdv,
                           NULL,
+                          NULL,
                           STDIN_FILENO,
                           STDOUT_FILENO,
                           STDERR_FILENO);
@@ -202,6 +203,7 @@ static void test_unitname (flux_t *h)
                           unitname,
                           cmdv,
                           NULL,
+                          NULL,
                           STDIN_FILENO,
                           STDOUT_FILENO,
                           STDERR_FILENO);
@@ -234,6 +236,7 @@ static void test_pid (flux_t *h)
     sdp = sdprocess_exec (h,
                           unitname,
                           cmdv,
+                          NULL,
                           NULL,
                           STDIN_FILENO,
                           STDOUT_FILENO,
@@ -283,6 +286,7 @@ static void test_duplicate (flux_t *h)
                           unitname,
                           cmdv,
                           NULL,
+                          NULL,
                           STDIN_FILENO,
                           STDOUT_FILENO,
                           STDERR_FILENO);
@@ -300,6 +304,7 @@ static void test_duplicate (flux_t *h)
     sdp_dup = sdprocess_exec (h,
                               unitname,
                               cmdv,
+                              NULL,
                               NULL,
                               STDIN_FILENO,
                               STDOUT_FILENO,
@@ -319,6 +324,54 @@ static void test_duplicate (flux_t *h)
     sdprocess_destroy (sdp);
 }
 
+static void test_property_illegal (flux_t *h)
+{
+    char *unitname = get_unitname (NULL);
+    char *cmdv[] = { "/bin/true", NULL };
+    char *properties1[] = { "foobar", NULL };
+    char *properties2[] = { "foobar=1", NULL };
+    char *properties3[] = { "RemainAfterExit=1", NULL };
+    sdprocess_t *sdp = NULL;
+
+    sdp = sdprocess_exec (h,
+                          unitname,
+                          cmdv,
+                          NULL,
+                          properties1,
+                          STDIN_FILENO,
+                          STDOUT_FILENO,
+                          STDERR_FILENO);
+    ok (sdp == NULL
+        && errno == EINVAL,
+        "sdprocess_exec failed with EINVAL on property name without value");
+
+    sdp = sdprocess_exec (h,
+                          unitname,
+                          cmdv,
+                          NULL,
+                          properties2,
+                          STDIN_FILENO,
+                          STDOUT_FILENO,
+                          STDERR_FILENO);
+    ok (sdp == NULL
+        && errno == EINVAL,
+        "sdprocess_exec failed with EINVAL on illegal property name");
+
+    sdp = sdprocess_exec (h,
+                          unitname,
+                          cmdv,
+                          NULL,
+                          properties3,
+                          STDIN_FILENO,
+                          STDOUT_FILENO,
+                          STDERR_FILENO);
+    ok (sdp == NULL
+        && errno == EINVAL,
+        "sdprocess_exec failed with EINVAL on RemainAfterExit");
+
+    free (unitname);
+}
+
 static void test_active (flux_t *h)
 {
     char *unitname = get_unitname (NULL);
@@ -330,6 +383,7 @@ static void test_active (flux_t *h)
     sdp = sdprocess_exec (h,
                           unitname,
                           cmdv,
+                          NULL,
                           NULL,
                           STDIN_FILENO,
                           STDOUT_FILENO,
@@ -369,6 +423,7 @@ static void test_exited (flux_t *h)
                           unitname,
                           cmdv,
                           NULL,
+                          NULL,
                           STDIN_FILENO,
                           STDOUT_FILENO,
                           STDERR_FILENO);
@@ -405,6 +460,7 @@ static void test_exit_status (flux_t *h)
     sdp = sdprocess_exec (h,
                           unitname,
                           cmdv,
+                          NULL,
                           NULL,
                           STDIN_FILENO,
                           STDOUT_FILENO,
@@ -443,6 +499,7 @@ static void test_wait_status (flux_t *h)
                           unitname,
                           cmdv,
                           NULL,
+                          NULL,
                           STDIN_FILENO,
                           STDOUT_FILENO,
                           STDERR_FILENO);
@@ -480,6 +537,7 @@ static void test_wait (flux_t *h)
                           unitname,
                           cmdv,
                           NULL,
+                          NULL,
                           STDIN_FILENO,
                           STDOUT_FILENO,
                           STDERR_FILENO);
@@ -506,6 +564,7 @@ static void test_wait_after_exited (flux_t *h)
     sdp = sdprocess_exec (h,
                           unitname,
                           cmdv,
+                          NULL,
                           NULL,
                           STDIN_FILENO,
                           STDOUT_FILENO,
@@ -551,6 +610,7 @@ static void test_state (flux_t *h)
     sdp = sdprocess_exec (h,
                           unitname,
                           cmdv,
+                          NULL,
                           NULL,
                           STDIN_FILENO,
                           STDOUT_FILENO,
@@ -601,6 +661,7 @@ static void test_state_after_exited (flux_t *h)
                           unitname,
                           cmdv,
                           NULL,
+                          NULL,
                           STDIN_FILENO,
                           STDOUT_FILENO,
                           STDERR_FILENO);
@@ -642,6 +703,7 @@ static void test_kill (flux_t *h)
     sdp = sdprocess_exec (h,
                           unitname,
                           cmdv,
+                          NULL,
                           NULL,
                           STDIN_FILENO,
                           STDOUT_FILENO,
@@ -688,6 +750,7 @@ static void test_kill_after_exited_success (flux_t *h)
                           unitname,
                           cmdv,
                           NULL,
+                          NULL,
                           STDIN_FILENO,
                           STDOUT_FILENO,
                           STDERR_FILENO);
@@ -718,6 +781,7 @@ static void test_kill_after_exited_failure (flux_t *h)
     sdp = sdprocess_exec (h,
                           unitname,
                           cmdv,
+                          NULL,
                           NULL,
                           STDIN_FILENO,
                           STDOUT_FILENO,
@@ -751,6 +815,7 @@ static void test_find_unit (flux_t *h)
     sdp = sdprocess_exec (h,
                           unitname,
                           cmdv,
+                          NULL,
                           NULL,
                           STDIN_FILENO,
                           STDOUT_FILENO,
@@ -807,6 +872,7 @@ static void test_find_unit_state (flux_t *h)
                           unitname,
                           cmdv,
                           NULL,
+                          NULL,
                           STDIN_FILENO,
                           STDOUT_FILENO,
                           STDERR_FILENO);
@@ -860,6 +926,7 @@ static void test_find_unit_after_exited (flux_t *h,
     sdp = sdprocess_exec (h,
                           unitname,
                           cmdv,
+                          NULL,
                           NULL,
                           STDIN_FILENO,
                           STDOUT_FILENO,
@@ -917,6 +984,7 @@ static void test_find_unit_after_signaled (flux_t *h)
     sdp = sdprocess_exec (h,
                           unitname,
                           cmdv,
+                          NULL,
                           NULL,
                           STDIN_FILENO,
                           STDOUT_FILENO,
@@ -1003,6 +1071,7 @@ static void test_output (flux_t *h,
                           unitname,
                           cmdv,
                           NULL,
+                          NULL,
                           -1,
                           do_stdout ? fds[1] : -1,
                           do_stdout ? -1 : fds[1]);
@@ -1065,6 +1134,7 @@ static void test_stdin (flux_t *h)
                           unitname,
                           cmdv,
                           NULL,
+                          NULL,
                           stdin_fds[1],
                           stdout_fds[1],
                           -1);
@@ -1125,6 +1195,7 @@ static void test_environment (flux_t *h)
                           unitname,
                           cmdv,
                           env,
+                          NULL,
                           -1,
                           fds[1],
                           -1);
@@ -1166,6 +1237,7 @@ static void test_no_such_command (flux_t *h)
     sdp = sdprocess_exec (h,
                           unitname,
                           cmdv,
+                          NULL,
                           NULL,
                           STDIN_FILENO,
                           STDOUT_FILENO,
@@ -1210,6 +1282,7 @@ static void test_list (flux_t *h)
                            unitname1,
                            cmdv,
                            NULL,
+                           NULL,
                            STDIN_FILENO,
                            STDOUT_FILENO,
                            STDERR_FILENO);
@@ -1219,6 +1292,7 @@ static void test_list (flux_t *h)
     sdp2 = sdprocess_exec (h,
                            unitname2,
                            cmdv,
+                           NULL,
                            NULL,
                            STDIN_FILENO,
                            STDOUT_FILENO,
@@ -1293,6 +1367,7 @@ static void test_list_error (flux_t *h)
                           unitname,
                           cmdv,
                           NULL,
+                          NULL,
                           STDIN_FILENO,
                           STDOUT_FILENO,
                           STDERR_FILENO);
@@ -1338,6 +1413,7 @@ static void test_list_early_exit (flux_t *h)
                            unitname1,
                            cmdv,
                            NULL,
+                           NULL,
                            STDIN_FILENO,
                            STDOUT_FILENO,
                            STDERR_FILENO);
@@ -1347,6 +1423,7 @@ static void test_list_early_exit (flux_t *h)
     sdp2 = sdprocess_exec (h,
                            unitname2,
                            cmdv,
+                           NULL,
                            NULL,
                            STDIN_FILENO,
                            STDOUT_FILENO,
@@ -1389,6 +1466,7 @@ static void test_invalid_permissions_command (flux_t *h)
     sdp = sdprocess_exec (h,
                           unitname,
                           cmdv,
+                          NULL,
                           NULL,
                           STDIN_FILENO,
                           STDOUT_FILENO,
@@ -1441,6 +1519,7 @@ static void test_cleanup_success (flux_t *h)
                           unitname,
                           cmdv,
                           NULL,
+                          NULL,
                           STDIN_FILENO,
                           STDOUT_FILENO,
                           STDERR_FILENO);
@@ -1483,6 +1562,7 @@ static void test_cleanup_failure (flux_t *h)
     sdp = sdprocess_exec (h,
                           unitname,
                           cmdv,
+                          NULL,
                           NULL,
                           STDIN_FILENO,
                           STDOUT_FILENO,
@@ -1527,6 +1607,7 @@ static void test_cleanup_before_exited (flux_t *h)
                           unitname,
                           cmdv,
                           NULL,
+                          NULL,
                           STDIN_FILENO,
                           STDOUT_FILENO,
                           STDERR_FILENO);
@@ -1568,6 +1649,7 @@ static void test_cleanup_success_after_cleanup (flux_t *h)
                           unitname,
                           cmdv,
                           NULL,
+                          NULL,
                           STDIN_FILENO,
                           STDOUT_FILENO,
                           STDERR_FILENO);
@@ -1605,6 +1687,7 @@ static void test_cleanup_failure_after_cleanup (flux_t *h)
     sdp = sdprocess_exec (h,
                           unitname,
                           cmdv,
+                          NULL,
                           NULL,
                           STDIN_FILENO,
                           STDOUT_FILENO,
@@ -1680,6 +1763,8 @@ int main (int argc, char *argv[])
     test_pid (h);
     diag ("duplicate");
     test_duplicate (h);
+    diag ("property_illegal");
+    test_property_illegal (h);
     diag ("active");
     test_active (h);
     diag ("exited");

--- a/src/common/libsdprocess/test/sdprocess.c
+++ b/src/common/libsdprocess/test/sdprocess.c
@@ -1874,6 +1874,15 @@ static void test_property_CPUAffinity_cpu_count2 (flux_t *h,
     free (affinitystr);
 }
 
+/* N.B. We only test CPUAffinity property and not any other
+ * properties, predominantly b/c this is the only "easy" one to test
+ * in C code due to the ability to use sched_getaffinity().  Remaining
+ * properties would involve digging into, reading, and parsing various
+ * files in /sys/fs/cgroup.
+ *
+ * Sharness tests should handle testing other properaties.
+ */
+
 static void test_property_CPUAffinity (flux_t *h)
 {
     cpu_set_t cpuset_avail;

--- a/src/modules/job-exec/Makefile.am
+++ b/src/modules/job-exec/Makefile.am
@@ -10,7 +10,8 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir)/src/include \
 	-I$(top_builddir)/src/common/libflux \
 	-I$(top_builddir)/src/common/libccan \
-	$(JANSSON_CFLAGS)
+	$(JANSSON_CFLAGS) \
+	$(HWLOC_CFLAGS)
 
 fluxmod_LTLIBRARIES = \
 	job-exec.la
@@ -50,6 +51,7 @@ job_exec_la_LIBADD = \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la \
 	$(JANSSON_LIBS) \
+	$(HWLOC_LIBS) \
 	libbulk-exec.la
 
 if HAVE_LIBSYSTEMD

--- a/src/modules/job-exec/rset.c
+++ b/src/modules/job-exec/rset.c
@@ -136,6 +136,10 @@ double resource_set_expiration (struct resource_set *r)
     return r->expiration;
 }
 
+const json_t *resource_set_R_lite (struct resource_set *r)
+{
+    return r->R_lite;
+}
 
 /* vi: ts=4 sw=4 expandtab
  */

--- a/src/modules/job-exec/rset.h
+++ b/src/modules/job-exec/rset.h
@@ -25,6 +25,8 @@ double resource_set_starttime (struct resource_set *rset);
 
 double resource_set_expiration (struct resource_set *rset);
 
+const json_t *resource_set_R_lite (struct resource_set *r);
+
 #endif /* !HAVE_JOB_EXEC_RSET_H */
 
 

--- a/src/modules/job-exec/sdexec.c
+++ b/src/modules/job-exec/sdexec.c
@@ -506,6 +506,7 @@ static int sdexec_launch (struct sdexec *se,
                                     unitname,
                                     cmdv,
                                     envv,
+                                    NULL,
                                     se->stdin_fds[1],
                                     se->stdout_fds[1],
                                     se->stderr_fds[1]))) {

--- a/src/modules/job-exec/sdexec.c
+++ b/src/modules/job-exec/sdexec.c
@@ -30,6 +30,11 @@
  * Based on the cores listed in R, set CPU affinity in the launched
  * process via the systemd CPUAffinity property.
  *
+ * cpu_set_allowed = true
+ *
+ * Based on the cores listed in R, set allowed CPUs in the launched
+ * process via the systemd CPUAffinity property.
+ *
  * The following configurations are supported under
  * attributes.system.exec.sd in the jobspec.
  *
@@ -227,7 +232,8 @@ static int rank_in_idset (const char *idset_str,
     return 0;
 }
 
-static char *hwloc_cpuset_2_systemd_property (hwloc_cpuset_t set)
+static char *hwloc_cpuset_2_systemd_property (hwloc_cpuset_t set,
+                                              const char *property)
 {
     char *str = NULL;
     size_t str_index = 0;
@@ -249,8 +255,9 @@ static char *hwloc_cpuset_2_systemd_property (hwloc_cpuset_t set)
         }
         len = snprintf (str + str_index,
                         str_len - str_index,
-                        "%s%d",
-                        str_index ? "," : "CPUAffinity=",
+                        "%s%s%d",
+                        str_index ? "," : property,
+                        str_index ? "" : "=",
                         i);
         assert (len < (str_len - str_index));
         str_index += len;
@@ -264,8 +271,9 @@ error:
     return NULL;
 }
 
-static char *CPUAffinity_list (struct jobinfo *job,
-                               const char *cores)
+static char *cpuset_list (struct jobinfo *job,
+                          const char *property,
+                          const char *cores)
 {
     hwloc_topology_t topo = NULL;
     hwloc_cpuset_t coreset = NULL;
@@ -316,7 +324,7 @@ static char *CPUAffinity_list (struct jobinfo *job,
         i = hwloc_bitmap_next (coreset, i);
     }
 
-    rv = hwloc_cpuset_2_systemd_property (puset);
+    rv = hwloc_cpuset_2_systemd_property (puset, property);
 error:
     if (topo)
         hwloc_topology_destroy (topo);
@@ -327,7 +335,7 @@ error:
     return rv;
 }
 
-static char *sdexec_CPUAffinity (struct jobinfo *job)
+static char *sdexec_cpuset (struct jobinfo *job, const char *property)
 {
     const json_t *R_lite;
     json_t *entry;
@@ -368,25 +376,28 @@ static char *sdexec_CPUAffinity (struct jobinfo *job)
         flux_log (job->h, LOG_ERR, "cores for rank %u not found in R", myrank);
         return NULL;
     }
-    return CPUAffinity_list (job, cores);
+    return cpuset_list (job, property, cores);
 }
 
 static int sdexec_setup_properties (struct sdexec *se, struct jobinfo *job)
 {
     /* currently supported properties
      * - CPUAffinity
+     * - AllowedCPUs
      */
     char **properties = NULL;
     flux_error_t err;
     int cpu_set_affinity = 0;
+    int cpu_set_allowed = 0;
     int properties_len = 0;
     int index = 0;
 
     if (flux_conf_unpack (flux_get_conf (se->h),
                           &err,
-                          "{s?:{s?:{s?b}}}",
+                          "{s?:{s?:{s?b s?b}}}",
                           "exec", "systemd",
-                            "cpu_set_affinity", &cpu_set_affinity) < 0) {
+                            "cpu_set_affinity", &cpu_set_affinity,
+                            "cpu_set_allowed", &cpu_set_allowed) < 0) {
         flux_log (se->h, LOG_ERR,
                   "error reading systemd config: %s",
                   err.text);
@@ -394,6 +405,8 @@ static int sdexec_setup_properties (struct sdexec *se, struct jobinfo *job)
     }
 
     if (cpu_set_affinity)
+        properties_len++;
+    if (cpu_set_allowed)
         properties_len++;
 
     if (!properties_len) {
@@ -408,7 +421,11 @@ static int sdexec_setup_properties (struct sdexec *se, struct jobinfo *job)
         return -1;
 
     if (cpu_set_affinity) {
-        if (!(properties[index++] = sdexec_CPUAffinity (job)))
+        if (!(properties[index++] = sdexec_cpuset (job, "CPUAffinity")))
+            goto error;
+    }
+    if (cpu_set_allowed) {
+        if (!(properties[index++] = sdexec_cpuset (job, "AllowedCPUs")))
             goto error;
     }
 

--- a/src/modules/job-exec/test/rset.c
+++ b/src/modules/job-exec/test/rset.c
@@ -110,6 +110,7 @@ int main (int ac, char *av[])
                 const struct idset *ids = resource_set_ranks (r);
                 double starttime = resource_set_starttime (r);
                 double expiration = resource_set_expiration (r);
+                const json_t *R_lite = resource_set_R_lite (r);
                 if (ids == NULL)
                     fail ("%s: resource_set_ranks() failed", e->descr);
                 else {
@@ -124,6 +125,8 @@ int main (int ac, char *av[])
                 ok (expiration == e->expiration,
                     "%s: expect expiration %.2f (got %.2f)", e->descr,
                     e->expiration, expiration);
+                ok (R_lite != NULL,
+                    "%s: non-NULL R_lite returned", e->descr);
             }
             else {
                 fail ("%s: %d:[%s]",

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -325,6 +325,7 @@ dist_check_SCRIPTS = \
 	job-exec/dummy.sh \
 	job-exec/imp.sh \
 	job-exec/imp-fail.sh \
+	job-exec/idset2bitmask.py \
 	job-list/list-id.py \
 	job-list/list-rpc.py \
 	job-list/job-list-helper.sh \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -154,6 +154,7 @@ TESTSCRIPTS = \
 	t2403-job-exec-conf.t \
 	t2404-job-exec-multiuser.t \
 	t2405-job-exec-sdexec.t \
+	t2406-job-exec-sdexec-properties.t \
 	t2410-exec-systemd.t \
 	t2500-job-attach.t \
 	t2501-job-status.t \

--- a/t/job-exec/idset2bitmask.py
+++ b/t/job-exec/idset2bitmask.py
@@ -1,0 +1,26 @@
+###############################################################
+# Copyright 2022 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+# idset 2 bitmask tool
+
+import sys
+import flux.idset as idset
+
+if len(sys.argv) != 2:
+    print("Usage: idset2bitmask <idset>")
+    sys.exit(1)
+
+ids = idset.decode(sys.argv[1])
+n = 0
+for i in ids:
+    n |= 0x1 << i
+print(f"0x{n:x}")
+
+# vi: ts=4 sw=4 expandtab

--- a/t/sdprocess/sim-broker.c
+++ b/t/sdprocess/sim-broker.c
@@ -137,6 +137,7 @@ int cmd_run (optparse_t *p, int argc, char **argv)
                                 unitname,
                                 cmdv,
                                 NULL,
+                                NULL,
                                 -1,
                                 STDOUT_FILENO,
                                 STDERR_FILENO))) {
@@ -257,6 +258,7 @@ int cmd_run_wait_exit (optparse_t *p, int argc, char **argv)
     if (!(sdp = sdprocess_exec (h,
                                 unitname,
                                 cmdv,
+                                NULL,
                                 NULL,
                                 -1,
                                 STDOUT_FILENO,

--- a/t/t2406-job-exec-sdexec-properties.t
+++ b/t/t2406-job-exec-sdexec-properties.t
@@ -1,0 +1,121 @@
+#!/bin/sh
+
+test_description='Test properties using systemd job execution service'
+
+. $(dirname $0)/sharness.sh
+
+if ! flux version | grep systemd; then
+    skip_all='flux not built with systemd'
+    test_done
+fi
+
+#  Don't run if systemd environment variables not setup
+if test -z "$DBUS_SESSION_BUS_ADDRESS" \
+     -o -z "$XDG_RUNTIME_DIR"; then
+    skip_all='DBUS_SESSION_BUS_ADDRESS and/or XDG_RUNTIME_DIR not set'
+    test_done
+fi
+
+uid=`id -u`
+userservice="user@${uid}.service"
+if ! systemctl list-units | grep ${userservice}
+then
+    skip_all='systemd user service not running'
+    test_done
+fi
+
+export FLUX_CONF_DIR=$(pwd)
+test_under_flux 1 job
+flux setattr log-stderr-level 1
+
+if ! which hwloc-bind > /dev/null; then
+    skip_all='skipping sdexec affinity tests since hwloc-bind not found'
+    test_done
+fi
+
+corecount=`hwloc-bind --get | hwloc-calc --number-of core | tail -n 1`
+test ${corecount} = 1 || test_set_prereq MULTICORE
+
+# arg1 jobid
+jobid2unitname() {
+    jobid=$1
+    jobiddec=`flux job id --to=dec $jobid`
+    rank=`flux getattr rank`
+    echo "flux-sdexec-${rank}-${jobiddec}"
+}
+
+# arg1 - jobid
+get_cpuaffinity() {
+    jobid=$1
+    unitname=`jobid2unitname ${jobid}`
+    mainpid=`systemctl show --property MainPID --user --value ${unitname}`
+    cpuaffinity=`taskset -p ${mainpid} | awk '{print $NF}'`
+    echo "0x${cpuaffinity}"
+}
+
+# arg1 - cpubind info
+# arg2 - expected number of processor units with affinity
+validate_affinity() {
+    cpubind=$1
+    expected=$2
+
+    pu_count=`echo ${cpubind} | hwloc-calc --number-of pu | tail -n 1`
+    if [ "${pu_count}" = "${expected}" ]
+    then
+        return 0
+    fi
+    # Possible pu_count > expected b/c of hyperthreading and similar
+    # effects so check core count
+    core_count=`echo ${cpubind} | hwloc-calc --number-of core | tail -n 1`
+    if [ ${pu_count} > ${core_count} ] \
+        && [ "${core_count}" = "${expected}" ]
+    then
+        return 0
+    fi
+    return 1
+}
+
+test_expect_success 'job-exec: config sdexec and cpu_set_affinity' '
+        cat >exec.toml <<EOF &&
+[exec]
+method = "systemd"
+
+[exec.systemd]
+cpu_set_affinity = true
+EOF
+        flux config reload &&
+        flux module reload job-exec
+'
+# the default flux job-shell sets CPU affinity as well, so we use a fake
+# job shell to test CPU affinity settings via systemd
+test_expect_success 'job-exec: create fake shell script' '
+        cat >sleepshell.sh <<-EOF &&
+#!/bin/bash
+echo "fake shell sleeping"
+sleep 60
+EOF
+        chmod +x sleepshell.sh
+'
+test_expect_success 'job-exec: cpu_set_affinity (1 core)' '
+        jobid=$(flux mini submit -n1 \
+                --setattr=system.exec.job_shell="$(pwd)/sleepshell.sh" \
+                hostname) &&
+        flux job wait-event -t 30 $jobid start &&
+        cpubind=`get_cpuaffinity ${jobid}` &&
+        flux job cancel ${jobid} &&
+        flux job wait-event -t 30 $jobid clean &&
+        validate_affinity ${cpubind} 1
+'
+test_expect_success MULTICORE 'job-exec: cpu_set_affinity (2 core)' '
+        jobid=$(flux mini submit -n2 \
+                --setattr=system.exec.job_shell="$(pwd)/sleepshell.sh" \
+                hostname) &&
+        flux job wait-event -t 30 $jobid start &&
+        cpubind=`get_cpuaffinity ${jobid}` &&
+        flux job cancel ${jobid} &&
+        flux job wait-event -t 30 $jobid clean &&
+        validate_affinity ${cpubind} 2
+'
+
+test_done
+


### PR DESCRIPTION
In this PR support `MemoryHigh` and `MemoryMax` configuration via systemd in launched processes.  They both can take bytes or percentages as input.

Built on top of #4255.  Decided to separate this out since it's a completely different type of property being supported in `sdprocess`.  However, the changes are much smaller than anticipated, could conceive of merging into #4255 if we wanted to.
