### PR TITLE
shell: obtain hwloc XML from enclosing instance

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -61,6 +61,7 @@ MAN3_FILES_PRIMARY = \
 	man3/flux_shell_aux_set.3 \
 	man3/flux_shell_current_task.3 \
 	man3/flux_shell_get_flux.3 \
+	man3/flux_shell_get_hwloc_xml.3 \
 	man3/flux_shell_get_info.3 \
 	man3/flux_shell_get_jobspec_info.3 \
 	man3/flux_shell_getenv.3 \

--- a/doc/man3/flux_shell_get_hwloc_xml.rst
+++ b/doc/man3/flux_shell_get_hwloc_xml.rst
@@ -1,0 +1,49 @@
+===========================
+flux_shell_get_hwloc_xml(3)
+===========================
+
+
+SYNOPSIS
+========
+
+::
+
+   #include <flux/shell.h>
+   #include <errno.h>
+
+::
+
+   int flux_shell_get_hwloc_xml (flux_shell_t *shell,
+                                 const char **hwloc_xml);
+
+
+DESCRIPTION
+===========
+
+``flux_shell_get_hwloc_xml()`` returns an hwloc XML string which has
+been cached by the job shell. This XML string can be used to load an
+hwloc topology via ``hwloc_topology_load()`` without requiring shell
+components to rediscover the entire topology by probing the local
+system. This can make loading hwloc topology much more efficient.
+
+RETURN VALUE
+============
+
+``flux_shell_get_hwloc_xml()`` returns 0 on success and -1 on error.
+
+
+ERRORS
+======
+
+EINVAL
+   ``shell`` or ``hwloc_xml`` are NULL, or the current ``shell`` object
+   is being used uninitialized.
+    
+
+
+RESOURCES
+=========
+
+Flux: http://flux-framework.org
+
+Jansson: https://jansson.readthedocs.io/en/2.10/apiref.html

--- a/doc/man3/index.rst
+++ b/doc/man3/index.rst
@@ -54,6 +54,7 @@ man3
    flux_shell_aux_set
    flux_shell_current_task
    flux_shell_get_flux
+   flux_shell_get_hwloc_xml
    flux_shell_get_info
    flux_shell_get_jobspec_info
    flux_shell_getenv

--- a/doc/manpages.py
+++ b/doc/manpages.py
@@ -208,6 +208,7 @@ man_pages = [
     ('man3/flux_shell_current_task', 'flux_shell_task_next', 'Get and iterate over shell tasks', [author], 3),
     ('man3/flux_shell_current_task', 'flux_shell_current_task', 'Get and iterate over shell tasks', [author], 3),
     ('man3/flux_shell_get_flux', 'flux_shell_get_flux', 'Get a flux_t\* object from flux shell handle', [author], 3),
+    ('man3/flux_shell_get_hwloc_xml', 'flux_shell_get_hwloc_xml', 'Access the shell cached copy of local hwloc xml', [author], 3),
     ('man3/flux_shell_get_info', 'flux_shell_info_unpack', 'Manage shell info and rank info', [author], 3),
     ('man3/flux_shell_get_info', 'flux_shell_get_rank_info', 'Manage shell info and rank info', [author], 3),
     ('man3/flux_shell_get_info', 'flux_shell_get_rank_info', 'Manage shell info and rank info', [author], 3),

--- a/src/modules/resource/topo.c
+++ b/src/modules/resource/topo.c
@@ -257,7 +257,7 @@ error:
 
 static const struct flux_msg_handler_spec htab[] = {
     { FLUX_MSGTYPE_REQUEST, "resource.topo-reduce",  topo_reduce_cb, 0 },
-    { FLUX_MSGTYPE_REQUEST, "resource.topo-get", topo_get_cb, 0 },
+    { FLUX_MSGTYPE_REQUEST, "resource.topo-get", topo_get_cb, FLUX_ROLE_USER },
     FLUX_MSGHANDLER_TABLE_END,
 };
 

--- a/src/shell/Makefile.am
+++ b/src/shell/Makefile.am
@@ -90,6 +90,7 @@ flux_shell_SOURCES = \
 flux_shell_LDADD = \
 	$(builddir)/libshell.la \
 	$(builddir)/libmpir.la \
+	$(top_builddir)/src/common/librlist/librlist.la \
 	$(top_builddir)/src/bindings/lua/libfluxlua.la \
 	$(top_builddir)/src/common/libflux-core.la \
 	$(top_builddir)/src/common/libpmi/libpmi_server.la \

--- a/src/shell/info.h
+++ b/src/shell/info.h
@@ -30,6 +30,7 @@ struct shell_info {
     struct jobspec *jobspec;
     rcalc_t *rcalc;
     struct rcalc_rankinfo rankinfo;
+    char *hwloc_xml;
 };
 
 /* Create shell_info.

--- a/src/shell/shell.c
+++ b/src/shell/shell.c
@@ -421,6 +421,16 @@ int flux_shell_unsetenv (flux_shell_t *shell, const char *name)
     return json_object_del (shell->info->jobspec->environment, name);
 }
 
+int flux_shell_get_hwloc_xml (flux_shell_t *shell, const char **xmlp)
+{
+    if (!shell || !shell->info || !xmlp) {
+        errno = EINVAL;
+        return -1;
+    }
+    *xmlp = shell->info->hwloc_xml;
+    return 0;
+}
+
 static json_t *flux_shell_get_info_object (flux_shell_t *shell)
 {
     json_error_t err;

--- a/src/shell/shell.h
+++ b/src/shell/shell.h
@@ -93,6 +93,9 @@ int flux_shell_setenvf (flux_shell_t *shell, int overwrite,
  */
 int flux_shell_unsetenv (flux_shell_t *shell, const char *name);
 
+/*  Return the job shell's cached copy of hwloc XML.
+ */
+int flux_shell_get_hwloc_xml (flux_shell_t *shell, const char **xmlp);
 
 /*  Return shell info as a JSON string.
  *  {

--- a/t/shell/plugins/invalid-args.c
+++ b/t/shell/plugins/invalid-args.c
@@ -87,6 +87,11 @@ static int shell_cb (flux_plugin_t *p,
     ok (flux_shell_get_environ (shell, NULL) < 0 && errno == EINVAL,
         "flux_shell_get_environ with NULL json_str returns EINVAL");
 
+    ok (flux_shell_get_hwloc_xml (NULL, NULL) < 0 && errno == EINVAL,
+        "flux_shell_get_hwloc_xml with NULL args returns EINVAL");
+    ok (flux_shell_get_hwloc_xml (shell, NULL) < 0 && errno == EINVAL,
+        "flux_shell_get_hwloc_xml with NULL xml pointer returns EINVAL");
+
     ok (flux_shell_get_info (NULL, NULL) < 0 && errno == EINVAL,
         "flux_shell_get_info with NUll arg returns EINVAL");
     ok (flux_shell_get_info (shell, NULL) < 0 && errno == EINVAL,


### PR DESCRIPTION
Putting up this WIP PR before I head out of town (feel free to add early comments). This is a WIP because it still needs some tests added.

This change significantly speeds up throughput of many simultaneous jobs on systems with many cores like corona. Loading hwloc topology directly appears to be essentially serialized on these systems, so we go from a throughput of 6-8 job/s to 40-50 job/s by avoiding the redundant reload of topology via hwloc.

Loading hwloc topology is also very slow on corona (on the order of 1s), so it should help speed up short-lived jobs as well.
