### PR TITLE
libkvs: add flux_kvs_commit_get_rootref() 

### DIFF
--- a/doc/man1/flux-kvs.rst
+++ b/doc/man1/flux-kvs.rst
@@ -80,7 +80,7 @@ COMMANDS
    directory. The *-f* option can be specified to monitor for many of
    these special situations.
 
-**put** [-N ns] [-O|-s] [-r|-t] [-n] [-A] *key=value* [*key=value* ...]
+**put** [-N ns] [-O|-b|-s] [-r|-t] [-n] [-A] *key=value* [*key=value* ...]
    Store *value* under *key* and commit it. Specify an alternate
    namespace to commit value(s) via *-N*. If it already has a value,
    overwrite it. If no options, value is stored directly. If *-r* or
@@ -89,9 +89,9 @@ COMMANDS
    If *-t*, value is stored as a RFC 11 object. *-n* prevents the commit
    from being merged with with other contemporaneous commits. *-A*
    appends the value to a key instead of overwriting the value. Append
-   is incompatible with the -j option. After a successful put, *-O* or
-   *-s* can be specified to output the RFC 11 treeobj or root sequence
-   number of the root containing the put(s).
+   is incompatible with the -j option. After a successful put, *-O*,
+   *-b*, or *-s* can be specified to output the RFC 11 treeobj, root
+   blobref, or root sequence number of the root containing the put(s).
 
 **ls** [-N ns] [-R] [-d] [-F] [-w COLS] [-1] [*key* ...]
    Display directory referred to by *key*, or "." (root) if unspecified.
@@ -113,21 +113,22 @@ COMMANDS
    treeobj* causes the lookup to be relative to an RFC 11 snapshot
    reference.
 
-**unlink** [-N ns] [-O|-s] [-R] [-f] *key* [*key* ...]
+**unlink** [-N ns] [-O|-b|-s] [-R] [-f] *key* [*key* ...]
    Remove *key* from the KVS and commit the change. Specify an alternate
    namespace to commit to via *-N*. If *key* represents a directory,
    specify *-R* to remove all keys underneath it. If *-f* is specified,
-   ignore nonexistent files. After a successful unlink, *-O* or *-s* can
-   be specified to output the RFC 11 treeobj or root sequence number of
-   the root containing the unlink(s).
+   ignore nonexistent files. After a successful unlink, *-O*, *-b*, or
+   *-s* can be specified to output the RFC 11 treeobj, root blobref,
+   or root sequence number of the root containing the unlink(s).
 
-**link** [-N ns] [-T ns] [-O|-s] *target* *linkname*
+**link** [-N ns] [-T ns] [-O|-b|-s] *target* *linkname*
    Create a new name for *target*, similar to a symbolic link, and commit
    the change. *target* does not have to exist. If *linkname* exists,
    it is overwritten. Specify an alternate namespace to commit linkname
    to via *-N*. Specify the target's namespace via *-T*. After a
-   successfully created link, *-O* or *-s* can be specified to output the
-   RFC 11 treeobj or root sequence number of the root containing the link.
+   successfully created link, *-O*, *-b*, or *-s* can be specified to
+   output the RFC 11 treeobj, root blobref, or root sequence number of
+   the root containing the link.
 
 **readlink** [-N ns] [-a treeobj] [ -o \| -k ] *key* [*key* ...]
    Retrieve the key a link refers to rather than its value, as would be
@@ -138,12 +139,12 @@ COMMANDS
    can be used to only output namespaces and the *-k* can be used to only
    output keys.
 
-**mkdir** [-N ns] [-O|-s] *key* [*key* ...]
+**mkdir** [-N ns] [-O|-b|-s] *key* [*key* ...]
    Create an empty directory and commit the change. If *key* exists,
    it is overwritten. Specify an alternate namespace to commit to via
-   *-N*. After a successful mkdir, *-O* or *-s* can be specified to
-   output the RFC 11 treeobj or root sequence number of the root
-   containing the new directory.
+   *-N*. After a successful mkdir, *-O*, *-b*, or *-s* can be
+   specified to output the RFC 11 treeobj, root blobref, or root
+   sequence number of the root containing the new directory.
 
 **copy** [-S src-ns] [-D dst-ns] *source* *destination*
    Copy *source* key to *destination* key. Optionally, specify a source

--- a/src/cmd/flux-kvs.c
+++ b/src/cmd/flux-kvs.c
@@ -110,6 +110,9 @@ static struct optparse_option put_opts[] =  {
     { .name = "treeobj-root", .key = 'O', .has_arg = 0,
       .usage = "Output resulting RFC11 root containing puts",
     },
+    { .name = "blobref", .key = 'b', .has_arg = 0,
+      .usage = "Output blobref of root containing puts",
+    },
     { .name = "sequence", .key = 's', .has_arg = 0,
       .usage = "Output root sequence of root containing puts",
     },
@@ -183,6 +186,9 @@ static struct optparse_option unlink_opts[] =  {
     { .name = "treeobj-root", .key = 'O', .has_arg = 0,
       .usage = "Output resulting RFC11 root containing unlinks",
     },
+    { .name = "blobref", .key = 'b', .has_arg = 0,
+      .usage = "Output blobref of root containing unlinks",
+    },
     { .name = "sequence", .key = 's', .has_arg = 0,
       .usage = "Output root sequence of root containing unlinks",
     },
@@ -231,6 +237,9 @@ static struct optparse_option link_opts[] =  {
     { .name = "treeobj-root", .key = 'O', .has_arg = 0,
       .usage = "Output resulting RFC11 root containing link",
     },
+    { .name = "blobref", .key = 'b', .has_arg = 0,
+      .usage = "Output blobref of root containing link",
+    },
     { .name = "sequence", .key = 's', .has_arg = 0,
       .usage = "Output root sequence of root containing link",
     },
@@ -243,6 +252,9 @@ static struct optparse_option mkdir_opts[] =  {
     },
     { .name = "treeobj-root", .key = 'O', .has_arg = 0,
       .usage = "Output resulting RFC11 root containing new directory",
+    },
+    { .name = "blobref", .key = 'b', .has_arg = 0,
+      .usage = "Output blobref of root containing new directory",
     },
     { .name = "sequence", .key = 's', .has_arg = 0,
       .usage = "Output root sequence of root containing new directory",
@@ -274,7 +286,7 @@ static struct optparse_subcommand subcommands[] = {
       get_opts
     },
     { "put",
-      "[-N ns] [-O|-s] [-r|-t] [-n] [-A] key=value [key=value...]",
+      "[-N ns] [-O|-b|-s] [-r|-t] [-n] [-A] key=value [key=value...]",
       "Store value under key",
       cmd_put,
       0,
@@ -295,14 +307,14 @@ static struct optparse_subcommand subcommands[] = {
       ls_opts
     },
     { "unlink",
-      "[-N ns] [-O|-s] [-R] [-f] key [key...]",
+      "[-N ns] [-O|-b|-s] [-R] [-f] key [key...]",
       "Remove key",
       cmd_unlink,
       0,
       unlink_opts
     },
     { "link",
-      "[-N ns] [-T ns] [-O|-s] target linkname",
+      "[-N ns] [-T ns] [-O|-b|-s] target linkname",
       "Create a new name for target",
       cmd_link,
       0,
@@ -316,7 +328,7 @@ static struct optparse_subcommand subcommands[] = {
       readlink_opts
     },
     { "mkdir",
-      "[-N ns] [-O|-s] key [key...]",
+      "[-N ns] [-O|-b|-s] key [key...]",
       "Create a directory",
       cmd_mkdir,
       0,
@@ -792,6 +804,12 @@ void commit_finish (flux_future_t *f, optparse_t *p)
         if (flux_kvs_commit_get_treeobj (f, &treeobj) < 0)
             log_err_exit ("flux_kvs_commit_get_treeobj");
         printf ("%s\n", treeobj);
+    }
+    else if (optparse_hasopt (p, "blobref")) {
+        const char *blobref = NULL;
+        if (flux_kvs_commit_get_rootref (f, &blobref) < 0)
+            log_err_exit ("flux_kvs_commit_get_rootref");
+        printf ("%s\n", blobref);
     }
     else if (optparse_hasopt (p, "sequence")) {
         int sequence;

--- a/src/common/libkvs/kvs_commit.c
+++ b/src/common/libkvs/kvs_commit.c
@@ -163,6 +163,15 @@ static int decode_response (flux_future_t *f, const char **rootrefp,
     return 0;
 }
 
+int flux_kvs_commit_get_rootref (flux_future_t *f, const char **rootref)
+{
+    if (!f || !rootref) {
+        errno = EINVAL;
+        return -1;
+    }
+    return decode_response (f, rootref, NULL);
+}
+
 int flux_kvs_commit_get_sequence (flux_future_t *f, int *rootseq)
 {
     if (!f || !rootseq) {

--- a/src/common/libkvs/kvs_commit.h
+++ b/src/common/libkvs/kvs_commit.h
@@ -39,6 +39,7 @@ flux_future_t *flux_kvs_fence (flux_t *h, const char *ns, int flags,
 
 /* accessors can be used for commit or fence futures */
 int flux_kvs_commit_get_treeobj (flux_future_t *f, const char **treeobj);
+int flux_kvs_commit_get_rootref (flux_future_t *f, const char **rootref);
 int flux_kvs_commit_get_sequence (flux_future_t *f, int *rootseq);
 
 #ifdef __cplusplus

--- a/src/common/libkvs/test/kvs_commit.c
+++ b/src/common/libkvs/test/kvs_commit.c
@@ -54,6 +54,11 @@ void errors (void)
         "flux_kvs_commit_get_treeobj fails on bad input");
 
     errno = 0;
+    ok (flux_kvs_commit_get_rootref (NULL, NULL) < 0
+        && errno == EINVAL,
+        "flux_kvs_commit_get_rootref fails on bad input");
+
+    errno = 0;
     ok (flux_kvs_commit_get_sequence (NULL, NULL) < 0
         && errno == EINVAL,
         "flux_kvs_commit_get_sequence fails on bad input");

--- a/t/t1000-kvs.t
+++ b/t/t1000-kvs.t
@@ -1114,7 +1114,7 @@ test_expect_success 'kvs: get --at: fails bad on dirent' '
 '
 
 #
-# -O, -s options in write commands
+# -O, -b, -s options in write commands
 #
 
 test_expect_success 'kvs: --treeobj-root on write ops works' '
@@ -1127,6 +1127,22 @@ test_expect_success 'kvs: --treeobj-root on write ops works' '
         grep "dirref" output &&
         flux kvs link -O $DIR.a $DIR.b > output &&
         grep "dirref" output
+'
+
+test_expect_success 'kvs: --blobref on write ops works' '
+	flux kvs unlink -Rf $DIR &&
+        flux kvs put -b $DIR.a=1 > output &&
+        flux kvs getroot -b > expected &&
+        test_cmp output expected &&
+        flux kvs unlink -b $DIR.a > output &&
+        flux kvs getroot -b > expected &&
+        test_cmp output expected &&
+        flux kvs mkdir -b $DIR.a > output &&
+        flux kvs getroot -b > expected &&
+        test_cmp output expected &&
+        flux kvs link -b $DIR.a $DIR.b > output &&
+        flux kvs getroot -b > expected &&
+        test_cmp output expected
 '
 
 test_expect_success 'kvs: --sequence on write ops works' '


### PR DESCRIPTION
split off from #4348.  A minor helper function and subsequent helper option in kvs commands.  The fact this was missing before seems to be an oversight / we just didn't have the random use case for it and just didn't do it.
