### PR TITLE
broker: return error in content.flush if no backing store exists 

### DIFF
--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -294,6 +294,7 @@ dist_check_SCRIPTS = \
 	issues/t4184-sched-simple-restart.sh \
 	issues/t4222-kvs-assume-empty-dir.sh \
 	issues/t4331-job-manager-purged-events.sh \
+	issues/t4375-content-flush-hang.sh \
 	issues/t4378-content-flush-force.sh \
 	issues/t4379-dirty-cache-entries-flush.sh \
 	python/__init__.py \

--- a/t/issues/t4375-content-flush-hang.sh
+++ b/t/issues/t4375-content-flush-hang.sh
@@ -1,0 +1,13 @@
+#!/bin/bash -e
+
+flux content flush
+
+flux module remove content-sqlite
+
+# we need to have a dirty entry in the content-cache for content-flush
+# to mean anything.
+flux kvs put issue4375=issue4375
+
+! flux content flush
+
+flux module load content-sqlite


### PR DESCRIPTION
Problem: The content.flush target will never respond to a request if a backing store is never loaded.

Solution: Return error with ENOSYS if content.flush cannot be completed.  In addition, return ENOSYS if a content.flush is in progress when the backing store is unregistered.  Add regression test.

Fixes https://github.com/flux-framework/flux-core/issues/4375