### PR TITLE
broker: content cache corner case corrections

### DIFF
--- a/src/broker/content-cache.c
+++ b/src/broker/content-cache.c
@@ -774,6 +774,8 @@ static void content_flush_request (flux_t *h, flux_msg_handler_t *mh,
     struct content_cache *cache = arg;
 
     if (cache->acct_dirty > 0) {
+        if (cache_flush (cache) < 0)
+            goto error;
         if (msgstack_push (&cache->flush_requests, msg) < 0)
             goto error;
         return;

--- a/src/broker/content-cache.c
+++ b/src/broker/content-cache.c
@@ -611,7 +611,6 @@ static int cache_flush (struct content_cache *cache)
 {
     struct cache_entry *e;
     int last_errno = 0;
-    int count = 0;
     int rc = 0;
 
     while (cache->flush_batch_count < cache->flush_batch_limit) {
@@ -621,7 +620,6 @@ static int cache_flush (struct content_cache *cache)
             last_errno = errno;           //   and continuation will decr
             rc = -1;
         }
-        count++;
     }
     if (rc < 0)
         errno = last_errno;

--- a/src/broker/content-cache.c
+++ b/src/broker/content-cache.c
@@ -591,6 +591,12 @@ static void content_store_request (flux_t *h, flux_msg_handler_t *mh,
                 return;
             }
         }
+        /* On rank 0, save to flush list in event backing module
+         * loaded later.  Note that dirty entries are not removed
+         * during purge or dropcache, so this does not alter
+         * behavior */
+        if (cache->rank == 0 && !cache->backing)
+            list_add_tail (&cache->flush, &e->list);
     }
     if (flux_respond_raw (h, msg, hash, hash_size) < 0)
         flux_log_error (h, "content store: flux_respond_raw");

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -294,6 +294,8 @@ dist_check_SCRIPTS = \
 	issues/t4184-sched-simple-restart.sh \
 	issues/t4222-kvs-assume-empty-dir.sh \
 	issues/t4331-job-manager-purged-events.sh \
+	issues/t4378-content-flush-force.sh \
+	issues/t4379-dirty-cache-entries-flush.sh \
 	python/__init__.py \
 	python/subflux.py \
 	python/tap \

--- a/t/issues/t4378-content-flush-force.sh
+++ b/t/issues/t4378-content-flush-force.sh
@@ -1,0 +1,13 @@
+#!/bin/bash -e
+
+flux content flush
+
+flux module remove content-sqlite
+
+# create a dirty cache entry in the content-cache
+flux kvs put issue4378=issue4378bug
+
+flux module load content-sqlite
+
+# Issue 4378 - without fix, this flux content flush would hang
+flux content flush

--- a/t/issues/t4379-dirty-cache-entries-flush.sh
+++ b/t/issues/t4379-dirty-cache-entries-flush.sh
@@ -1,0 +1,41 @@
+#!/bin/bash -e
+
+flux content flush
+
+count=`flux module stats --parse dirty content`
+if [ ${count} -ne 0 ]
+then
+    echo "dirty entries not 0 at start of test"
+    return 1
+fi
+
+flux module remove content-sqlite
+
+# create a dirty cache entry in the content-cache
+flux kvs put issue4379=issue4379bug
+
+count=`flux module stats --parse dirty content`
+if [ ${count} -ne 1 ]
+then
+    echo "dirty entries not 1 after a put"
+    return 1
+fi
+
+flux module load content-sqlite
+
+count=`flux module stats --parse dirty content`
+if [ ${count} -ne 1 ]
+then
+    echo "dirty entries still 1 after module reload"
+    return 1
+fi
+
+flux content flush
+
+# Issue 4378 - this dirty count would stay at 1
+count=`flux module stats --parse dirty content`
+if [ ${count} -ne 0 ]
+then
+    echo "dirty entries not 0 after final flush"
+    return 1
+fi


### PR DESCRIPTION
Fixes for #4378 and #4379.  Decided to try and fix both in one PR b/c they are very tightly integrated with each other.  One requires the other for a regression test, the other sort of doesn't appear without the other.