### PR TITLE
kvs: remove excess logging of ENOTSUP

### DIFF
--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -1530,8 +1530,6 @@ static void relaycommit_request_cb (flux_t *h, flux_msg_handler_t *mh,
 
     /* namespace must exist given we are on rank 0 */
     if (!(root = kvsroot_mgr_lookup_root_safe (ctx->krm, ns))) {
-        flux_log (h, LOG_ERR, "%s: namespace %s not available",
-                  __FUNCTION__, ns);
         errno = ENOTSUP;
         goto error;
     }
@@ -1673,8 +1671,6 @@ static void relayfence_request_cb (flux_t *h, flux_msg_handler_t *mh,
 
     /* namespace must exist given we are on rank 0 */
     if (!(root = kvsroot_mgr_lookup_root_safe (ctx->krm, ns))) {
-        flux_log (h, LOG_ERR, "%s: namespace %s not available",
-                  __FUNCTION__, ns);
         errno = ENOTSUP;
         goto error;
     }
@@ -1919,7 +1915,6 @@ static void getroot_request_cb (flux_t *h, flux_msg_handler_t *mh,
     if (ctx->rank == 0) {
         /* namespace must exist given we are on rank 0 */
         if (!(root = kvsroot_mgr_lookup_root_safe (ctx->krm, ns))) {
-            flux_log (h, LOG_DEBUG, "namespace %s not available", ns);
             errno = ENOTSUP;
             goto error;
         }


### PR DESCRIPTION
Problem: When a namespace is not available (ENOTSUP) the kvs
module logs an error.  However, a namespace not available
error can be quite common, such as when the job-info module
transitions reading from a guest namespace to a primary namespace.
These log messages can be excessive in the logs.

Solution: Remove log messages when ENOTSUP is returned to
callers.  Let callers decide if ENOTSUP should be logged or not.

Fixes #4369