### PR TITLE
job-manager: fix case where a job manager epilog can't be configured without a prolog

### DIFF
--- a/t/t2274-manager-perilog.t
+++ b/t/t2274-manager-perilog.t
@@ -216,4 +216,17 @@ test_expect_success 'perilog: prolog is killed even if it ignores SIGTERM' '
 	test_must_fail flux job attach -vEX $jobid
 '
 
+test_expect_success 'perilog: epilog can be specified without a prolog' '
+	cat <<-EOF >config/perilog.toml &&
+	[job-manager.epilog]
+	command = [ "/bin/true" ]
+	EOF
+	flux config reload &&
+	flux jobtap load --remove=*.so perilog.so &&
+	jobid=$(flux mini submit hostname) &&
+	test_must_fail flux job wait-event -t 15 $jobid prolog-start &&
+	flux job wait-event -t 15 $jobid epilog-start &&
+	flux job wait-event -t 15 $jobid epilog-finish
+'
+
 test_done


### PR DESCRIPTION
I noticed this while doing some testing. If only a `[job-manager.epilog]` is configured, without also configuring a `[job-manager.prolog]`, then the epilog does not get initiated by the job manager `perilog.so` plugin.

The problem is that the plugin only subscribes to job events during the prolog handler. So, if a prolog is not configured, this subscription doesn't happen and the `job.event.finish` callback isn't received by the plugin.

The fix is to always subscribe to events in the `job.state.run` callback if either a prolog or epilog action is configured.
