### PR TITLE
kvs: add defensive checkpoint via sync configuration option

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -292,7 +292,8 @@ MAN5_FILES_PRIMARY = \
 	man5/flux-config-resource.5 \
 	man5/flux-config-archive.5 \
 	man5/flux-config-job-manager.5 \
-	man5/flux-config-ingest.5 
+	man5/flux-config-ingest.5 \
+	man5/flux-config-kvs.5
 
 
 MAN7_FILES = $(MAN7_FILES_PRIMARY)

--- a/doc/man5/flux-config-kvs.rst
+++ b/doc/man5/flux-config-kvs.rst
@@ -1,0 +1,46 @@
+==================
+flux-config-kvs(5)
+==================
+
+
+DESCRIPTION
+===========
+
+The Flux system instance **kvs** service provides the primary key value
+store (i.e. "the KVS") for a large number of Flux services.  For
+example, job eventlogs are stored in the KVS.
+
+The ``kvs`` table may contain the following keys:
+
+
+KEYS
+====
+
+checkpoint-period
+   (optional) Sets a period of time (in RFC 23 Flux Standard Duration
+   format) that the KVS will regularly checkpoint a reference to its
+   primary namespace.  The checkpoint is used to protect against data
+   loss in the event of a Flux broker crash.
+
+
+EXAMPLE
+=======
+
+::
+
+   [kvs]
+   checkpoint-period = "30m"
+
+
+RESOURCES
+=========
+
+Flux: http://flux-framework.org
+
+RFC 23: Flux Standard Duration: https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/spec_23.html
+
+
+SEE ALSO
+========
+
+:man5:`flux-config`

--- a/doc/man5/flux-config.rst
+++ b/doc/man5/flux-config.rst
@@ -77,4 +77,4 @@ SEE ALSO
 :man1:`flux-broker`, :man5:`flux-config-access`, :man5:`flux-config-bootstrap`,
 :man5:`flux-config-tbon`, :man5:`flux-config-exec`, :man5:`flux-config-ingest`,
 :man5:`flux-config-resource`, :man5:`flux-config-archive`,
-:man5:`flux-config-job-manager`
+:man5:`flux-config-job-manager`, :man5:`flux-config-kvs`

--- a/doc/manpages.py
+++ b/doc/manpages.py
@@ -282,6 +282,7 @@ man_pages = [
     ('man5/flux-config-resource', 'flux-config-resource', 'configure Flux resource service', [author], 5),
     ('man5/flux-config-archive', 'flux-config-archive', 'configure Flux job archival service', [author], 5),
     ('man5/flux-config-job-manager', 'flux-config-job-manager', 'configure Flux job manager service', [author], 5),
+    ('man5/flux-config-kvs', 'flux-config-kvs', 'configure Flux kvs service', [author], 5),
     ('man7/flux-broker-attributes', 'flux-broker-attributes', 'overview Flux broker attributes', [author], 7),
     ('man7/flux-jobtap-plugins', 'flux-jobtap-plugins', 'overview Flux jobtap plugin API', [author], 7),
 ]

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -629,3 +629,4 @@ tmpfiles
 EDEADLOCK
 setpgrp
 nosetpgrp
+checkpointed

--- a/src/modules/kvs/Makefile.am
+++ b/src/modules/kvs/Makefile.am
@@ -29,7 +29,9 @@ kvs_la_SOURCES = \
 	kvsroot.h \
 	kvsroot.c \
 	kvs_wait_version.h \
-	kvs_wait_version.c
+	kvs_wait_version.c \
+	kvs_checkpoint.h \
+	kvs_checkpoint.c
 
 kvs_la_LDFLAGS = $(fluxmod_ldflags) -module
 kvs_la_LIBADD = $(top_builddir)/src/common/libkvs/libkvs.la \

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -1044,6 +1044,7 @@ static void kvstxn_apply (kvstxn_t *kt)
 done:
     if (errnum == 0) {
         json_t *names = kvstxn_get_names (kt);
+        int internal_flags = kvstxn_get_internal_flags (kt);
         int count;
         if ((count = json_array_size (names)) > 1) {
             int opcount = 0;
@@ -1051,8 +1052,10 @@ done:
             flux_log (ctx->h, LOG_DEBUG, "aggregated %d transactions (%d ops)",
                       count, opcount);
         }
-        setroot (ctx, root, kvstxn_get_newroot_ref (kt), root->seq + 1);
-        setroot_event_send (ctx, root, names, kvstxn_get_keys (kt));
+        if (!(internal_flags & KVSTXN_INTERNAL_FLAG_NO_PUBLISH)) {
+            setroot (ctx, root, kvstxn_get_newroot_ref (kt), root->seq + 1);
+            setroot_event_send (ctx, root, names, kvstxn_get_keys (kt));
+        }
     } else {
         fallback = kvstxn_fallback_mergeable (kt);
 

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -1570,7 +1570,7 @@ static void relaycommit_request_cb (flux_t *h, flux_msg_handler_t *mh,
         goto error;
     }
 
-    if (kvstxn_mgr_add_transaction (root->ktm, name, ops, flags) < 0) {
+    if (kvstxn_mgr_add_transaction (root->ktm, name, ops, flags, 0) < 0) {
         flux_log_error (h, "%s: kvstxn_mgr_add_transaction",
                         __FUNCTION__);
         goto error;
@@ -1651,7 +1651,8 @@ static void commit_request_cb (flux_t *h, flux_msg_handler_t *mh,
         if (kvstxn_mgr_add_transaction (root->ktm,
                                         treq_get_name (tr),
                                         ops,
-                                        flags) < 0) {
+                                        flags,
+                                        0) < 0) {
             flux_log_error (h, "%s: kvstxn_mgr_add_transaction",
                             __FUNCTION__);
             goto error;
@@ -1749,7 +1750,8 @@ static void relayfence_request_cb (flux_t *h, flux_msg_handler_t *mh,
         if (kvstxn_mgr_add_transaction (root->ktm,
                                         treq_get_name (tr),
                                         treq_get_ops (tr),
-                                        treq_get_flags (tr)) < 0) {
+                                        treq_get_flags (tr),
+                                        0) < 0) {
             flux_log_error (h, "%s: kvstxn_mgr_add_transaction",
                             __FUNCTION__);
             goto error;
@@ -1856,7 +1858,8 @@ static void fence_request_cb (flux_t *h, flux_msg_handler_t *mh,
             if (kvstxn_mgr_add_transaction (root->ktm,
                                             treq_get_name (tr),
                                             treq_get_ops (tr),
-                                            treq_get_flags (tr)) < 0) {
+                                            treq_get_flags (tr),
+                                            0) < 0) {
                 flux_log_error (h, "%s: kvstxn_mgr_add_transaction",
                                 __FUNCTION__);
                 goto error;

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -29,11 +29,13 @@
 #include "src/common/libutil/monotime.h"
 #include "src/common/libutil/tstat.h"
 #include "src/common/libutil/timestamp.h"
+#include "src/common/libutil/errprintf.h"
 #include "src/common/libkvs/treeobj.h"
 #include "src/common/libkvs/kvs_checkpoint.h"
 #include "src/common/libkvs/kvs_txn_private.h"
 #include "src/common/libkvs/kvs_util_private.h"
 #include "src/common/libcontent/content.h"
+#include "src/common/libutil/fsd.h"
 
 #include "waitqueue.h"
 #include "cache.h"
@@ -43,6 +45,7 @@
 #include "kvstxn.h"
 #include "kvsroot.h"
 #include "kvs_wait_version.h"
+#include "kvs_checkpoint.h"
 
 /* heartbeat_sync_cb() is called periodically to manage cached content
  * and namespaces.  Synchronize with the system heartbeat if possible,
@@ -73,6 +76,7 @@ struct kvs_ctx {
     bool events_init;            /* flag */
     const char *hash_name;
     unsigned int seq;           /* for commit transactions */
+    kvs_checkpoint_t *kcp;
     struct list_head work_queue;
 };
 
@@ -89,6 +93,8 @@ static void transaction_prep_cb (flux_reactor_t *r, flux_watcher_t *w,
 static void transaction_check_cb (flux_reactor_t *r, flux_watcher_t *w,
                                   int revents, void *arg);
 static void start_root_remove (struct kvs_ctx *ctx, const char *ns);
+static void work_queue_check_append (struct kvs_ctx *ctx,
+                                     struct kvsroot *root);
 static void kvstxn_apply (kvstxn_t *kt);
 
 /*
@@ -103,9 +109,17 @@ static void kvs_ctx_destroy (struct kvs_ctx *ctx)
         flux_watcher_destroy (ctx->prep_w);
         flux_watcher_destroy (ctx->check_w);
         flux_watcher_destroy (ctx->idle_w);
+        kvs_checkpoint_destroy (ctx->kcp);
         free (ctx);
         errno = saved_errno;
     }
+}
+
+static void work_queue_check_append_wrapper (struct kvsroot *root,
+                                             void *arg)
+{
+    struct kvs_ctx *ctx = arg;
+    work_queue_check_append (ctx, root);
 }
 
 static struct kvs_ctx *kvs_ctx_create (flux_t *h)
@@ -138,6 +152,13 @@ static struct kvs_ctx *kvs_ctx_create (flux_t *h)
             goto error;
         flux_watcher_start (ctx->prep_w);
         flux_watcher_start (ctx->check_w);
+        ctx->kcp = kvs_checkpoint_create (h,
+                                          NULL, /* set later */
+                                          0.0,  /* default 0.0, set later */
+                                          work_queue_check_append_wrapper,
+                                          ctx);
+        if (!ctx->kcp)
+            goto error;
     }
     ctx->transaction_merge = 1;
     list_head_init (&ctx->work_queue);
@@ -2704,6 +2725,30 @@ error:
         flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
 }
 
+static void config_reload_cb (flux_t *h,
+                              flux_msg_handler_t *mh,
+                              const flux_msg_t *msg,
+                              void *arg)
+{
+    struct kvs_ctx *ctx = arg;
+    const flux_conf_t *conf;
+    const char *errstr = NULL;
+    flux_error_t error;
+
+    if (flux_conf_reload_decode (msg, &conf) < 0)
+        goto error;
+    if (kvs_checkpoint_reload (ctx->kcp, conf, &error) < 0) {
+        errstr = error.text;
+        goto error;
+    }
+    if (flux_respond (h, msg, NULL) < 0)
+        flux_log_error (h, "error responding to config-reload request");
+    return;
+ error:
+    if (flux_respond_error (h, msg, errno, errstr) < 0)
+        flux_log_error (h, "error responding to config-reload request");
+}
+
 /* see comments above in event_subscribe() regarding event
  * subscriptions to kvs.namespace */
 static const struct flux_msg_handler_spec htab[] = {
@@ -2741,8 +2786,21 @@ static const struct flux_msg_handler_spec htab[] = {
                             setroot_pause_request_cb, FLUX_ROLE_USER },
     { FLUX_MSGTYPE_REQUEST, "kvs.setroot-unpause",
                             setroot_unpause_request_cb, FLUX_ROLE_USER },
+    { FLUX_MSGTYPE_REQUEST, "kvs.config-reload", config_reload_cb, 0 },
     FLUX_MSGHANDLER_TABLE_END,
 };
+
+static int process_config (struct kvs_ctx *ctx)
+{
+    flux_error_t error;
+    if (kvs_checkpoint_config_parse (ctx->kcp,
+                                     flux_get_conf (ctx->h),
+                                     &error) < 0) {
+        flux_log (ctx->h, LOG_ERR, "%s", error.text);
+        return -1;
+    }
+    return 0;
+}
 
 static void process_args (struct kvs_ctx *ctx, int ac, char **av)
 {
@@ -2897,6 +2955,8 @@ int mod_main (flux_t *h, int argc, char **argv)
         flux_log_error (h, "error creating KVS context");
         goto done;
     }
+    if (process_config (ctx) < 0)
+        goto done;
     process_args (ctx, argc, argv);
     if (ctx->rank == 0) {
         struct kvsroot *root;
@@ -2940,6 +3000,8 @@ int mod_main (flux_t *h, int argc, char **argv)
             flux_log_error (h, "event_subscribe");
             goto done;
         }
+
+        kvs_checkpoint_update_root_primary (ctx->kcp, root);
     }
     if (flux_msg_handler_addvec (h, htab, ctx, &handlers) < 0) {
         flux_log_error (h, "flux_msg_handler_addvec");
@@ -2953,6 +3015,7 @@ int mod_main (flux_t *h, int argc, char **argv)
         flux_log_error (h, "error starting heartbeat synchronization");
         goto done;
     }
+    kvs_checkpoint_start (ctx->kcp);
     if (flux_reactor_run (flux_get_reactor (h), 0) < 0) {
         flux_log_error (h, "flux_reactor_run");
         goto done;

--- a/src/modules/kvs/kvs_checkpoint.c
+++ b/src/modules/kvs/kvs_checkpoint.c
@@ -1,0 +1,233 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <ctype.h>
+#include <errno.h>
+#include <jansson.h>
+#include <flux/core.h>
+
+#include "src/common/libutil/errprintf.h"
+#include "src/common/libutil/fsd.h"
+
+#include "kvs_checkpoint.h"
+#include "kvsroot.h"
+
+struct kvs_checkpoint {
+    flux_t *h;
+    struct kvsroot *root_primary;
+    double checkpoint_period;   /* in seconds */
+    flux_watcher_t *checkpoint_w;
+    kvs_checkpoint_txn_cb txn_cb;
+    void *txn_cb_arg;
+    int last_checkpoint_seq;
+};
+
+static int checkpoint_period_parse (const flux_conf_t *conf,
+                                    flux_error_t *errp,
+                                    double *checkpoint_period)
+{
+    flux_error_t error;
+    const char *str = NULL;
+
+    if (flux_conf_unpack (conf,
+                          &error,
+                          "{s?{s?s}}",
+                          "kvs",
+                          "checkpoint-period", &str) < 0) {
+        errprintf (errp,
+                   "error reading config for kvs: %s",
+                   error.text);
+        return -1;
+    }
+
+    if (str) {
+        if (fsd_parse_duration (str, checkpoint_period) < 0) {
+            errprintf (errp,
+                       "invalid checkpoint-period config: %s",
+                       str);
+            return -1;
+        }
+    }
+
+    return 0;
+}
+
+int kvs_checkpoint_config_parse (kvs_checkpoint_t *kcp,
+                                 const flux_conf_t *conf,
+                                 flux_error_t *errp)
+{
+    if (kcp) {
+        double checkpoint_period = kcp->checkpoint_period;
+        if (checkpoint_period_parse (conf, errp, &checkpoint_period) < 0)
+            return -1;
+        kcp->checkpoint_period = checkpoint_period;
+    }
+    return 0;
+}
+
+int kvs_checkpoint_reload (kvs_checkpoint_t *kcp,
+                           const flux_conf_t *conf,
+                           flux_error_t *errp)
+{
+    if (kcp) {
+        double checkpoint_period = kcp->checkpoint_period;
+        if (checkpoint_period_parse (conf,
+                                     errp,
+                                     &checkpoint_period) < 0)
+            return -1;
+
+        if (checkpoint_period != kcp->checkpoint_period) {
+            kcp->checkpoint_period = checkpoint_period;
+            flux_watcher_stop (kcp->checkpoint_w);
+
+            if (kcp->root_primary
+                && kcp->checkpoint_period > 0.0) {
+                flux_timer_watcher_reset (kcp->checkpoint_w,
+                                          kcp->checkpoint_period,
+                                          kcp->checkpoint_period);
+                flux_watcher_start (kcp->checkpoint_w);
+            }
+        }
+    }
+    return 0;
+}
+
+
+static void checkpoint_cb (flux_reactor_t *r,
+                           flux_watcher_t *w,
+                           int revents,
+                           void *arg)
+{
+    kvs_checkpoint_t *kcp = arg;
+    char name[64];
+    json_t *ops = NULL;
+
+    /* if no changes to root since last checkpoint-period, do
+     * nothing */
+    if (kcp->last_checkpoint_seq == kcp->root_primary->seq)
+        return;
+
+    snprintf (name,
+              sizeof (name),
+              "checkpoint-period.%u",
+              kcp->root_primary->seq);
+
+    if (!(ops = json_array ())) {
+        errno = ENOMEM;
+        flux_log_error (kcp->h, "checkpoint-period setup failure");
+        goto done;
+    }
+
+    /* Set FLUX_KVS_SYNC, to perform the checkpoint.
+     *
+     * Set KVSTXN_INTERNAL_FLAG_NO_PUBLISH, this is an internal KVS
+     * module transaction to checkpoint.  It has no operations so the
+     * KVS data will not change.  Therefore no setroot() needs to be
+     * called after this is done.
+     */
+    if (kvstxn_mgr_add_transaction (kcp->root_primary->ktm,
+                                    name,
+                                    ops,
+                                    FLUX_KVS_SYNC,
+                                    KVSTXN_INTERNAL_FLAG_NO_PUBLISH) < 0) {
+        flux_log_error (kcp->h, "%s: kvstxn_mgr_add_transaction",
+                        __FUNCTION__);
+        goto done;
+    }
+
+    if (kcp->txn_cb)
+        kcp->txn_cb (kcp->root_primary, kcp->txn_cb_arg);
+
+    /* N.B. "last_checkpoint_seq" protects against unnecessary
+     * checkpointing when there is no activity in the primary KVS.
+     */
+    kcp->last_checkpoint_seq = kcp->root_primary->seq;
+
+done:
+    json_decref (ops);
+}
+
+kvs_checkpoint_t *kvs_checkpoint_create (flux_t *h,
+                                         struct kvsroot *root_primary,
+                                         double checkpoint_period,
+                                         kvs_checkpoint_txn_cb txn_cb,
+                                         void *txn_cb_arg)
+{
+    kvs_checkpoint_t *kcp = NULL;
+
+    if (!(kcp = calloc (1, sizeof (*kcp))))
+        goto error;
+
+    kcp->h = h;
+    kcp->root_primary = root_primary; /* can be NULL initially */
+    kcp->checkpoint_period = checkpoint_period;
+    kcp->txn_cb = txn_cb;
+    kcp->txn_cb_arg = txn_cb_arg;
+
+    /* create regardless of checkpoint-period value, in case user
+     * reconfigures later.
+     */
+    if (!(kcp->checkpoint_w =
+          flux_timer_watcher_create (flux_get_reactor (h),
+                                     kcp->checkpoint_period,
+                                     kcp->checkpoint_period,
+                                     checkpoint_cb,
+                                     kcp))) {
+        flux_log_error (kcp->h, "flux_timer_watcher_create");
+        goto error;
+
+    }
+
+    return kcp;
+
+ error:
+    kvs_checkpoint_destroy (kcp);
+    return NULL;
+}
+
+void kvs_checkpoint_update_root_primary (kvs_checkpoint_t *kcp,
+                                         struct kvsroot *root_primary)
+{
+    if (kcp && root_primary)
+        kcp->root_primary = root_primary;
+}
+
+void kvs_checkpoint_start (kvs_checkpoint_t *kcp)
+{
+    if (kcp
+        && kcp->root_primary
+        && kcp->checkpoint_period > 0.0) {
+        flux_watcher_stop (kcp->checkpoint_w);
+        flux_timer_watcher_reset (kcp->checkpoint_w,
+                                  kcp->checkpoint_period,
+                                  kcp->checkpoint_period);
+        flux_watcher_start (kcp->checkpoint_w);
+    }
+}
+
+void kvs_checkpoint_destroy (kvs_checkpoint_t *kcp)
+{
+    if (kcp) {
+        int save_errno = errno;
+        flux_watcher_destroy (kcp->checkpoint_w);
+        free (kcp);
+        errno = save_errno;
+    }
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/kvs/kvs_checkpoint.h
+++ b/src/modules/kvs/kvs_checkpoint.h
@@ -1,0 +1,74 @@
+/************************************************************\
+ * Copyright 2019 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _FLUX_KVS_CHECKPOINT_H
+#define _FLUX_KVS_CHECKPOINT_H
+
+#include <flux/core.h>
+
+#include "kvsroot.h"
+
+/* kvs_checkpoint will handle checkpointing for the checkpoint-period
+ * configuration under the [kvs] table.  Internally the checkpoint-period
+ * value and a timer are managed.
+ *
+ * To avoid excess comparisons for `rank == 0` throughout KVS code,
+ * most functions below are no-ops if the `kvs_checkpoint_t` argument
+ * is NULL.
+ */
+
+typedef struct kvs_checkpoint kvs_checkpoint_t;
+
+/* callback after sync/checkpoint transaction submitted */
+typedef void (*kvs_checkpoint_txn_cb)(struct kvsroot *root, void *arg);
+
+/* root_primary - root of primary namespace, will be passed to txn_cb
+ *              - can be NULL if not available at creation time, use
+ *                kvs_checkpoint_update_root_primary() to set later.
+ * checkpoint_period - timer will trigger a checkpoint every X seconds,
+ *                   - no timer will be done if <= 0.0.
+ * txn_cb - callback after each checkpoint transaction submitted
+ * txn_cb_arg - passed to txn_cb
+ */
+kvs_checkpoint_t *kvs_checkpoint_create (flux_t *h,
+                                         struct kvsroot *root_primary,
+                                         double checkpoint_period,
+                                         kvs_checkpoint_txn_cb txn_cb,
+                                         void *txn_cb_arg);
+
+/* update internal checkpoint_period setting as needed */
+int kvs_checkpoint_config_parse (kvs_checkpoint_t *kcp,
+                                 const flux_conf_t *conf,
+                                 flux_error_t *errp);
+
+/* update internal checkpoint_period setting as needed and restart
+ * internal timers if needed
+ */
+int kvs_checkpoint_reload (kvs_checkpoint_t *kcp,
+                           const flux_conf_t *conf,
+                           flux_error_t *errp);
+
+/* update kvsroot used internally */
+void kvs_checkpoint_update_root_primary (kvs_checkpoint_t *kcp,
+                                         struct kvsroot *root_primary);
+
+/* start / restart checkpoint timer.  If root_primary not yet set or
+ * checkpoint_period <= 0.0, will do nothing.
+ */
+void kvs_checkpoint_start (kvs_checkpoint_t *kcp);
+
+void kvs_checkpoint_destroy (kvs_checkpoint_t *kcp);
+
+
+#endif /* !_FLUX_KVS_CHECKPOINT_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/kvs/kvsroot.h
+++ b/src/modules/kvs/kvsroot.h
@@ -20,6 +20,7 @@
 #include "waitqueue.h"
 #include "src/common/libutil/blobref.h"
 #include "src/common/libccan/ccan/list/list.h"
+#include "src/common/libczmqcontainers/czmq_containers.h"
 
 typedef struct kvsroot_mgr kvsroot_mgr_t;
 

--- a/src/modules/kvs/kvstxn.c
+++ b/src/modules/kvs/kvstxn.c
@@ -1253,8 +1253,7 @@ int kvstxn_mgr_add_transaction (kvstxn_mgr_t *ktm,
                                 int internal_flags)
 {
     kvstxn_t *kt;
-    /* N.B. No internal_flags supported at the moment */
-    int valid_internal_flags = 0;
+    int valid_internal_flags = KVSTXN_INTERNAL_FLAG_NO_PUBLISH;
 
     if (!name
         || !ops

--- a/src/modules/kvs/kvstxn.h
+++ b/src/modules/kvs/kvstxn.h
@@ -27,6 +27,16 @@ typedef enum {
     KVSTXN_PROCESS_FINISHED = 6,
 } kvstxn_process_t;
 
+/* api flags, to be used with kvstxn_mgr_add_transaction()
+ *
+ * KVSTXN_INTERNAL_FLAG_NO_PUBLISH - Indicate that this transaction
+ * should not publish its change after the transaction completes.
+ * Note that kvstxn does not use this flag internally, users can check
+ * that it has been set via kvstxn_get_internal_flags().
+ */
+
+#define KVSTXN_INTERNAL_FLAG_NO_PUBLISH 0x01
+
 /*
  * kvstxn_t API
  */

--- a/src/modules/kvs/kvstxn.h
+++ b/src/modules/kvs/kvstxn.h
@@ -60,6 +60,7 @@ bool kvstxn_fallback_mergeable (kvstxn_t *kt);
 json_t *kvstxn_get_ops (kvstxn_t *kt);
 json_t *kvstxn_get_names (kvstxn_t *kt);
 int kvstxn_get_flags (kvstxn_t *kt);
+int kvstxn_get_internal_flags (kvstxn_t *kt);
 
 /* returns namespace passed into kvstxn_mgr_create() */
 const char *kvstxn_get_namespace (kvstxn_t *kt);
@@ -155,7 +156,8 @@ void kvstxn_mgr_destroy (kvstxn_mgr_t *ktm);
 int kvstxn_mgr_add_transaction (kvstxn_mgr_t *ktm,
                                 const char *name,
                                 json_t *ops,
-                                int flags);
+                                int flags,
+                                int internal_flags);
 
 /* returns true if there is a transaction ready for processing and is
  * not blocked, false if not.

--- a/src/modules/kvs/test/kvsroot.c
+++ b/src/modules/kvs/test/kvsroot.c
@@ -275,6 +275,7 @@ void basic_kvstxn_mgr_tests (void)
     ok (kvstxn_mgr_add_transaction (root->ktm,
                                     "foo",
                                     ops,
+                                    0,
                                     0) == 0,
         "kvstxn_mgr_add_transaction works");
 

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -90,6 +90,7 @@ TESTSCRIPTS = \
 	t1008-kvs-eventlog.t \
 	t1009-kvs-copy.t \
 	t1010-kvs-commit-sync.t \
+	t1011-kvs-checkpoint-period.t \
 	t1101-barrier-basic.t \
 	t1102-cmddriver.t \
 	t1103-apidisconnect.t \

--- a/t/t1011-kvs-checkpoint-period.t
+++ b/t/t1011-kvs-checkpoint-period.t
@@ -1,0 +1,165 @@
+#!/bin/sh
+#
+
+test_description='Test kvs module checkpoint-period config.'
+
+. `dirname $0`/kvs/kvs-helper.sh
+
+. `dirname $0`/sharness.sh
+
+RPC=${FLUX_BUILD_DIR}/t/request/rpc
+
+skip_all_unless_have jq
+
+export FLUX_CONF_DIR=$(pwd)
+SIZE=4
+test_under_flux ${SIZE} minimal
+
+kvs_checkpoint_get() {
+	jq -j -c -n  "{key:\"$1\"}" \
+	    | $RPC kvs-checkpoint.get \
+	    | jq -r .value.rootref
+}
+
+# arg1 - old ref
+# arg2 - timeout (seconds)
+kvs_checkpoint_changed() {
+	old_ref=$1
+	local i=0
+	local iters=$(($2 * 10))
+	while [ $i -lt ${iters} ]
+	do
+	    ref=$(kvs_checkpoint_get kvs-primary)
+	    if [ "${old_ref}" != "${ref}" ]
+	    then
+		return 0
+	    fi
+	    sleep 0.1
+	    i=$((i + 1))
+	done
+	return 1
+}
+
+test_expect_success 'configure bad checkpoint-period timer in kvs' '
+	cat >kvs.toml <<-EOF &&
+	[kvs]
+	checkpoint-period = "1Z"
+	EOF
+	flux config reload &&
+	test_must_fail flux module load kvs
+'
+
+test_expect_success 'configure checkpoint-period, place initial value' '
+	cat >kvs.toml <<-EOF &&
+	[kvs]
+	checkpoint-period = "200ms"
+	EOF
+	flux config reload &&
+	flux module load content-sqlite &&
+	flux module load kvs &&
+	flux kvs put --blobref --sync a=1 > blob1.out
+'
+
+test_expect_success 'kvs: put some more data to kvs (1)' '
+	flux kvs put --blobref b=1 > blob2.out
+'
+
+test_expect_success 'kvs: checkpoint of kvs-primary should change in time (1)' '
+	kvs_checkpoint_changed $(cat blob1.out) 5 &&
+	kvs_checkpoint_get kvs-primary > checkpoint2.out &&
+	test_cmp checkpoint2.out blob2.out
+'
+
+test_expect_success 'kvs: put some more data to kvs (2)' '
+	flux kvs put --blobref c=1 > blob3.out
+'
+
+test_expect_success 'kvs: checkpoint of kvs-primary should change in time (2)' '
+	kvs_checkpoint_changed $(cat blob2.out) 5 &&
+	kvs_checkpoint_get kvs-primary > checkpoint3.out &&
+	test_cmp checkpoint3.out blob3.out
+'
+
+test_expect_success 'kvs: put some data to non-primary namespace' '
+	flux kvs namespace create "test-ns" &&
+	flux kvs put --namespace=test-ns d=1
+'
+
+test_expect_success 'kvs: checkpoint of kvs-primary should not change (1)' '
+	test_must_fail kvs_checkpoint_changed $(cat blob3.out) 2
+'
+
+test_expect_success 'configure bad checkpoint-period timer in kvs on reload' '
+	cat >kvs.toml <<-EOF &&
+	[kvs]
+	checkpoint-period = "1Z"
+	EOF
+	test_must_fail flux config reload
+'
+
+test_expect_success 're-config checkpoint-period timer, set large period' '
+	cat >kvs.toml <<-EOF &&
+	[kvs]
+	checkpoint-period = "60m"
+	EOF
+	flux config reload
+'
+
+test_expect_success 'kvs: put some more data to kvs (3)' '
+	flux kvs put --blobref d=1 > blob4.out
+'
+
+test_expect_success 'kvs: checkpoint of kvs-primary should not change (2)' '
+	test_must_fail kvs_checkpoint_changed $(cat blob3.out) 2
+'
+
+test_expect_success 're-config checkpoint-period timer, set small period' '
+	cat >kvs.toml <<-EOF &&
+	[kvs]
+	checkpoint-period = "200ms"
+	EOF
+	flux config reload
+'
+
+test_expect_success 'kvs: checkpoint of kvs-primary should change in time (3)' '
+	kvs_checkpoint_changed $(cat blob3.out) 5 &&
+	kvs_checkpoint_get kvs-primary > checkpoint4.out &&
+	test_cmp checkpoint4.out blob4.out
+'
+
+test_expect_success 're-config checkpoint-period timer, disable it' '
+	cat >kvs.toml <<-EOF &&
+	[kvs]
+	checkpoint-period = "0s"
+	EOF
+	flux config reload
+'
+
+test_expect_success 'kvs: put some more data to kvs (4)' '
+	flux kvs put --blobref e=1 > blob5.out
+'
+
+test_expect_success 'kvs: checkpoint of kvs-primary should not change (3)' '
+	test_must_fail kvs_checkpoint_changed $(cat blob4.out) 2
+'
+
+test_expect_success 're-config checkpoint-period timer in kvs, re-enable it' '
+	cat >kvs.toml <<-EOF &&
+	[kvs]
+	checkpoint-period = "200ms"
+	EOF
+	flux config reload
+'
+
+test_expect_success 'kvs: checkpoint of kvs-primary should change in time (4)' '
+	kvs_checkpoint_changed $(cat blob4.out) 5 &&
+	kvs_checkpoint_get kvs-primary > checkpoint5.out &&
+	test_cmp checkpoint5.out blob5.out
+'
+
+test_expect_success 'kvs: remove modules' '
+	flux module remove kvs &&
+	flux module remove content-sqlite
+'
+
+test_done


### PR DESCRIPTION
Per discussion in #4301, add a `sync = <time>` option to the KVS, so that the primary kvs namespace can be checkpointed on a regular basis.