### PR TITLE
job-manager: allow dependencies on inactive jobs

### DIFF
--- a/doc/man1/flux-mini.rst
+++ b/doc/man1/flux-mini.rst
@@ -182,9 +182,10 @@ The following dependency schemes are built-in:
 
 .. note::
    The ``after*`` dependency schemes listed below all require that the
-   target JOBID be currently active. If the target JOBID has become
-   inactive by the time the dependent job is submitted, then the submission
-   will be rejected with an error that the dependency job cannot be found.
+   target JOBID be currently active or in the job manager's inactive job
+   cache. If a target JOBID has been purged by the time the dependent job
+   has been submitted, then the submission will be rejected with an error
+   that the target job cannot be found.
 
 after:JOBID
    This dependency is satisfied after JOBID starts.

--- a/src/modules/job-manager/jobtap.h
+++ b/src/modules/job-manager/jobtap.h
@@ -159,12 +159,13 @@ int flux_jobtap_event_post_pack (flux_plugin_t *p,
                                  const char *fmt,
                                  ...);
 
-/*  Return a flux_plugin_arg_t object for any active job.
+/*  Return a flux_plugin_arg_t object for a job.
  *
  *  The result can then be unpacked with flux_plugin_arg_unpack(3) to get
  *   active job information such as userid, state, etc.
  *
- *  If `id` is not an active job then NULL is returned with ENOENT set.
+ *  If `id` is not an active job or is not found in the job manager's
+ *   inactive job cache then NULL is returned with ENOENT set.
  *
  *  Caller must free with flux_plugin_arg_destroy(3).
  */


### PR DESCRIPTION
This PR allows jobtap plugins to lookup inactive jobs (where that makes sense). This in turn allows the dependency-after plugin to utilize jobs that are inactive as the antecedent for the various `after*` dependency schemes.