### PR TITLE
jobtap: add job.create, job.destroy callbacks

### DIFF
--- a/src/modules/job-manager/event.c
+++ b/src/modules/job-manager/event.c
@@ -395,6 +395,7 @@ int event_job_action (struct event *event, struct job *job)
             }
             break;
         case FLUX_JOB_STATE_INACTIVE:
+            job->eventlog_readonly = 1;
             if ((job->flags & FLUX_JOB_WAITABLE))
                 wait_notify_inactive (ctx->wait, job);
             if (zhashx_insert (ctx->inactive_jobs, &job->id, job) < 0
@@ -591,6 +592,9 @@ int event_job_update (struct job *job, json_t *event)
                                          &job->userid,
                                          &job->flags) < 0)
             goto error;
+    }
+    else if (streq (name, "invalidate")) {
+        job->eventlog_readonly = 1;
     }
     else if (streq (name, "validate")) {
         job->state = FLUX_JOB_STATE_DEPEND;
@@ -838,16 +842,20 @@ static int event_job_post_deferred (struct event *event, struct job *job)
     int flags;
     json_t *entry;
 
-    while (job_event_peek (job, &flags, &entry) == 0) {
+    job_incref (job); // in case event_job_process_entry() decrefs job
+    while (job_event_peek (job, &flags, &entry) == 0
+        && !job->eventlog_readonly) {
         if (event_job_process_entry (event, job, flags, entry) < 0) {
             int saved_errno = errno;
             while (job_event_dequeue (job, NULL, NULL) == 0)
                 ;
             errno = saved_errno;
+            job_decref (job);
             return -1;
         }
         job_event_dequeue (job, NULL, NULL);
     }
+    job_decref (job);
     return 0;
 }
 

--- a/src/modules/job-manager/event.c
+++ b/src/modules/job-manager/event.c
@@ -403,6 +403,7 @@ int event_job_action (struct event *event, struct job *job)
                                 "%ju: error preserving inactive job",
                                 (uintmax_t) job->id);
             }
+            (void) jobtap_call (ctx->jobtap, job, "job.destroy", NULL);
             zhashx_delete (ctx->active_jobs, &job->id);
             drain_check (ctx->drain);
             break;

--- a/src/modules/job-manager/job.h
+++ b/src/modules/job-manager/job.h
@@ -43,6 +43,7 @@ struct job {
     uint8_t has_resources:1;
     uint8_t start_pending:1;// start request sent to job-exec
     uint8_t reattach:1;
+    uint8_t eventlog_readonly:1;// job is inactive or invalid
 
     uint8_t perilog_active; // if nonzero, prolog/epilog active
 

--- a/src/modules/job-manager/jobtap-internal.h
+++ b/src/modules/job-manager/jobtap-internal.h
@@ -46,6 +46,10 @@ int jobtap_validate (struct jobtap *jobtap,
                      struct job *job,
                      char **errp);
 
+int jobtap_call_create (struct jobtap *jobtap,
+                        struct job *job,
+                        char **errp);
+
 /*  Jobtap call to iterate attributes.system.dependencies dictionary
  *   and call job.dependency.<schema> for each entry.
  *

--- a/src/modules/job-manager/plugins/alloc-bypass.c
+++ b/src/modules/job-manager/plugins/alloc-bypass.c
@@ -252,3 +252,5 @@ int flux_plugin_init (flux_plugin_t *p)
 {
     return flux_plugin_register (p, "alloc-bypass", tab);
 }
+
+// vi:ts=4 sw=4 expandtab

--- a/src/modules/job-manager/plugins/begin-time.c
+++ b/src/modules/job-manager/plugins/begin-time.c
@@ -181,3 +181,5 @@ int begin_time_plugin_init (flux_plugin_t *p)
                                     depend_cb,
                                     NULL);
 }
+
+// vi:ts=4 sw=4 expandtab

--- a/src/modules/job-manager/plugins/perilog.c
+++ b/src/modules/job-manager/plugins/perilog.c
@@ -530,3 +530,5 @@ int flux_plugin_init (flux_plugin_t *p)
     }
     return flux_plugin_register (p, "perilog", tab);
 }
+
+// vi:ts=4 sw=4 expandtab

--- a/src/modules/job-manager/plugins/submit-hold.c
+++ b/src/modules/job-manager/plugins/submit-hold.c
@@ -51,3 +51,5 @@ int flux_plugin_init (flux_plugin_t *p)
 {
     return flux_plugin_add_handler (p, "job.state.depend", depend_cb, NULL);
 }
+
+// vi:ts=4 sw=4 expandtab

--- a/src/modules/job-manager/plugins/validate-duration.c
+++ b/src/modules/job-manager/plugins/validate-duration.c
@@ -117,3 +117,4 @@ int validate_duration_plugin_init (flux_plugin_t *p)
                                     NULL);
 }
 
+// vi:ts=4 sw=4 expandtab

--- a/src/modules/job-manager/restart.c
+++ b/src/modules/job-manager/restart.c
@@ -234,16 +234,19 @@ int restart_from_kvs (struct job_manager *ctx)
             free (errmsg);
         }
         /*
-         *  On restart, call 'job.new' plugin callbacks since this is
-         *   the first time this instance of the job-manager has seen
-         *   this job. Be sure to call this before posting any other
-         *   events below, since job.new should always be the first
-         *   callback for a job.
+         *  On restart, call 'job.create' and 'job.new' plugin callbacks
+         *   since this is the first time this instance of the job-manager
+         *   has seen this job. Be sure to call these before posting any
+         *   other events below, since these should always be the first
+         *   callbacks for a job.
          *
          *  Jobs in SCHED state may also immediately transition back to
          *   PRIORITY, potentially generating two other plugin callbacks
          *   after this one. (job.priority, job.sched...)
          */
+        if (jobtap_call (ctx->jobtap, job, "job.create", NULL) < 0)
+            flux_log_error (ctx->h, "jobtap_call (id=%ju, create)",
+                                (uintmax_t) job->id);
         if (jobtap_call (ctx->jobtap, job, "job.new", NULL) < 0)
             flux_log_error (ctx->h, "jobtap_call (id=%ju, new)",
                                 (uintmax_t) job->id);

--- a/src/modules/job-manager/restart.c
+++ b/src/modules/job-manager/restart.c
@@ -256,7 +256,7 @@ int restart_from_kvs (struct job_manager *ctx)
              * This is confusing. In order to update priority on transition
              *  back to PRIORITY state, the priority must be reset to "-1",
              *  even though the last priority value was reconstructed from
-             *  the eventlog. This is becuase the transitioning "priority"
+             *  the eventlog. This is because the transitioning "priority"
              *  event is only posted when the priority changes.
              */
             job->priority = -1;

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -424,6 +424,8 @@ check_LTLIBRARIES = \
 	job-manager/plugins/dependency-test.la \
 	job-manager/plugins/subscribe.la \
 	job-manager/plugins/cleanup-event.la \
+	job-manager/plugins/create-event.la \
+	job-manager/plugins/create-reject.la \
 	job-manager/plugins/perilog-test.la \
 	stats/stats-basic.la \
 	stats/stats-immediate.la
@@ -887,6 +889,25 @@ job_manager_plugins_cleanup_event_la_LDFLAGS = \
 	$(fluxplugin_ldflags) -module -rpath /nowhere
 job_manager_plugins_cleanup_event_la_LIBADD = \
 	$(top_builddir)/src/common/libflux-core.la
+
+job_manager_plugins_create_event_la_SOURCES = \
+	job-manager/plugins/create-event.c
+job_manager_plugins_create_event_la_CPPFLAGS = \
+	$(test_cppflags)
+job_manager_plugins_create_event_la_LDFLAGS = \
+	$(fluxplugin_ldflags) -module -rpath /nowhere
+job_manager_plugins_create_event_la_LIBADD = \
+	$(top_builddir)/src/common/libflux-core.la
+
+job_manager_plugins_create_reject_la_SOURCES = \
+	job-manager/plugins/create-reject.c
+job_manager_plugins_create_reject_la_CPPFLAGS = \
+	$(test_cppflags)
+job_manager_plugins_create_reject_la_LDFLAGS = \
+	$(fluxplugin_ldflags) -module -rpath /nowhere
+job_manager_plugins_create_reject_la_LIBADD = \
+	$(top_builddir)/src/common/libflux-core.la
+
 
 job_manager_plugins_perilog_test_la_SOURCES = \
 	job-manager/plugins/perilog-test.c

--- a/t/job-manager/plugins/args.c
+++ b/t/job-manager/plugins/args.c
@@ -92,3 +92,5 @@ int flux_plugin_init (flux_plugin_t *p)
     flux_plugin_set_name (p, "args");
     return flux_plugin_add_handler (p, "job.*", cb, NULL);
 }
+
+// vi:ts=4 sw=4 expandtab

--- a/t/job-manager/plugins/cleanup-event.c
+++ b/t/job-manager/plugins/cleanup-event.c
@@ -33,3 +33,4 @@ int flux_plugin_init (flux_plugin_t *p)
                                      NULL);
 }
 
+// vi:ts=4 sw=4 expandtab

--- a/t/job-manager/plugins/create-event.c
+++ b/t/job-manager/plugins/create-event.c
@@ -1,0 +1,33 @@
+/************************************************************\
+ * Copyright 2022 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* create-event.c - emit a test event from the job.create callback
+ */
+
+#include <flux/jobtap.h>
+
+static int create_cb (flux_plugin_t *p,
+                      const char *topic,
+                      flux_plugin_arg_t *args,
+                      void *arg)
+{
+    return flux_jobtap_event_post_pack (p,
+                                        FLUX_JOBTAP_CURRENT_JOB,
+                                       "test-event",
+                                       NULL);
+}
+
+
+int flux_plugin_init (flux_plugin_t *p)
+{
+    return flux_plugin_add_handler (p, "job.create", create_cb, NULL);
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/t/job-manager/plugins/create-reject.c
+++ b/t/job-manager/plugins/create-reject.c
@@ -1,0 +1,30 @@
+/************************************************************\
+ * Copyright 2022 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* create-reject.c - reject a job from job.create callback
+ */
+
+#include <flux/jobtap.h>
+
+static int create_cb (flux_plugin_t *p,
+                      const char *topic,
+                      flux_plugin_arg_t *args,
+                      void *arg)
+{
+    return flux_jobtap_reject_job (p, args, "nope");
+}
+
+
+int flux_plugin_init (flux_plugin_t *p)
+{
+    return flux_plugin_add_handler (p, "job.create", create_cb, NULL);
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/t/job-manager/plugins/dependency-test.c
+++ b/t/job-manager/plugins/dependency-test.c
@@ -135,3 +135,5 @@ int flux_plugin_init (flux_plugin_t *p)
         return -1;
     return 0;
 }
+
+// vi:ts=4 sw=4 expandtab

--- a/t/job-manager/plugins/job_aux.c
+++ b/t/job-manager/plugins/job_aux.c
@@ -124,3 +124,5 @@ int flux_plugin_init (flux_plugin_t *p)
         return -1;
     return 0;
 }
+
+// vi:ts=4 sw=4 expandtab

--- a/t/job-manager/plugins/jobtap_api.c
+++ b/t/job-manager/plugins/jobtap_api.c
@@ -576,3 +576,5 @@ int flux_plugin_init (flux_plugin_t *p)
 {
     return flux_plugin_register (p, "api-test", tab);
 }
+
+// vi:ts=4 sw=4 expandtab

--- a/t/job-manager/plugins/perilog-test.c
+++ b/t/job-manager/plugins/perilog-test.c
@@ -140,3 +140,5 @@ int flux_plugin_init (flux_plugin_t *p)
         return -1;
     return 0;
 }
+
+// vi:ts=4 sw=4 expandtab

--- a/t/job-manager/plugins/priority-invert.c
+++ b/t/job-manager/plugins/priority-invert.c
@@ -86,3 +86,5 @@ int flux_plugin_init (flux_plugin_t *p)
 
     return 0;
 }
+
+// vi:ts=4 sw=4 expandtab

--- a/t/job-manager/plugins/priority-wait.c
+++ b/t/job-manager/plugins/priority-wait.c
@@ -67,3 +67,5 @@ int flux_plugin_init (flux_plugin_t *p)
         return -1;
     return 0;
 }
+
+// vi:ts=4 sw=4 expandtab

--- a/t/job-manager/plugins/subscribe.c
+++ b/t/job-manager/plugins/subscribe.c
@@ -80,3 +80,5 @@ int flux_plugin_init (flux_plugin_t *p)
     }
     return 0;
 }
+
+// vi:ts=4 sw=4 expandtab

--- a/t/job-manager/plugins/test.c
+++ b/t/job-manager/plugins/test.c
@@ -145,3 +145,5 @@ int flux_plugin_init (flux_plugin_t *p)
     }
     return flux_plugin_add_handler (p, "job.*", cb, NULL);
 }
+
+// vi:ts=4 sw=4 expandtab

--- a/t/job-manager/plugins/validate.c
+++ b/t/job-manager/plugins/validate.c
@@ -46,3 +46,5 @@ int flux_plugin_init (flux_plugin_t *p)
     flux_plugin_set_name (p, "test-validate");
     return flux_plugin_add_handler (p, "job.validate", validate, NULL);
 }
+
+// vi:ts=4 sw=4 expandtab

--- a/t/t2212-job-manager-plugins.t
+++ b/t/t2212-job-manager-plugins.t
@@ -170,7 +170,7 @@ test_expect_success 'job-manager: run args test plugin' '
 	flux mini run hostname &&
 	flux dmesg | grep args-check > args-check.log &&
 	test_debug "cat args-check.log" &&
-	test $(grep -c OK args-check.log) = 18
+	test $(grep -c OK args-check.log) = 20
 '
 test_expect_success 'job-manager: run subscribe test plugin' '
 	flux jobtap load --remove=all ${PLUGINPATH}/subscribe.so &&

--- a/t/t2212-job-manager-plugins.t
+++ b/t/t2212-job-manager-plugins.t
@@ -430,4 +430,20 @@ test_expect_success 'job-manager: job prolog/epilog events work' '
 	test_debug "echo Checking that epilog-finish=$n_epilog event occurs before free=$n_free event" &&
 	test $n_prolog -lt $n_start -a $n_epilog -lt $n_free
 '
+
+test_expect_success 'job-manager: job.create posts events before validation' '
+	flux jobtap load --remove=all ${PLUGINPATH}/create-event.so &&
+	jobid=$(flux mini submit hostname) &&
+	flux job wait-event -v $jobid validate >create-event.out &&
+	n_test=$(lineno test-event create-event.out) &&
+	n_create=$(lineno validate create-event.out) &&
+	test $n_test -lt $n_create
+'
+
+test_expect_success 'job-manager: job.create can reject a job' '
+	flux jobtap load --remove=all ${PLUGINPATH}/create-reject.so &&
+	test_must_fail flux mini submit hostname 2>submit.err &&
+	grep nope submit.err
+'
+
 test_done


### PR DESCRIPTION
This was split off from #4386.

It just adds the job.create, job.destroy jobtap callbacks and related stuff as discussed in #4368.