### PR TITLE
Add a posix_spawn() implementation to libsubprocess and use it to launch job shells

### DIFF
--- a/src/cmd/flux-exec.c
+++ b/src/cmd/flux-exec.c
@@ -346,8 +346,10 @@ int main (int argc, char *argv[])
             log_err_exit ("get_current_dir_name");
     }
 
-    if (flux_cmd_setcwd (cmd, cwd) < 0)
-        log_err_exit ("flux_cmd_setcwd");
+    if (strcmp (cwd, "none") != 0) {
+        if (flux_cmd_setcwd (cmd, cwd) < 0)
+            log_err_exit ("flux_cmd_setcwd");
+    }
 
     if (!(h = flux_open (NULL, 0)))
         log_err_exit ("flux_open");

--- a/src/common/libsubprocess/Makefile.am
+++ b/src/common/libsubprocess/Makefile.am
@@ -18,6 +18,8 @@ libsubprocess_la_SOURCES = \
 	command.h \
 	local.c \
 	local.h \
+	fork.c \
+	fork.h \
 	remote.c \
 	remote.h \
 	server.c \

--- a/src/common/libsubprocess/Makefile.am
+++ b/src/common/libsubprocess/Makefile.am
@@ -20,6 +20,8 @@ libsubprocess_la_SOURCES = \
 	local.h \
 	fork.c \
 	fork.h \
+	posix_spawn.c \
+	posix_spawn.h \
 	remote.c \
 	remote.h \
 	server.c \

--- a/src/common/libsubprocess/command.c
+++ b/src/common/libsubprocess/command.c
@@ -662,7 +662,7 @@ flux_cmd_t * flux_cmd_fromjson (const char *json_str, json_error_t *errp)
     json_t *jargv = NULL;
     json_t *jopts = NULL;
     json_t *jchans = NULL;
-    const char *cwd;
+    const char *cwd = NULL;
     flux_cmd_t *cmd = NULL;;
 
     if (!(o = json_loads (json_str, 0, errp))) {
@@ -673,7 +673,7 @@ flux_cmd_t * flux_cmd_fromjson (const char *json_str, json_error_t *errp)
         errnum = ENOMEM;
         goto fail;
     }
-    if (json_unpack_ex (o, errp, 0, "{s:s, s:o, s:o, s:o, s:o}",
+    if (json_unpack_ex (o, errp, 0, "{s?s, s:o, s:o, s:o, s:o}",
                 "cwd", &cwd,
                 "cmdline", &jargv,
                 "env", &jenv,
@@ -682,7 +682,7 @@ flux_cmd_t * flux_cmd_fromjson (const char *json_str, json_error_t *errp)
         errnum = EPROTO;
         goto fail;
     }
-    if (!(cmd->cwd = strdup (cwd))
+    if ((cwd && !(cmd->cwd = strdup (cwd)))
         || (argz_fromjson (jargv, &cmd->argz, &cmd->argz_len) < 0)
         || (envz_fromjson (jenv, &cmd->envz, &cmd->envz_len) < 0)
         || !(cmd->opts = zhash_fromjson (jopts))

--- a/src/common/libsubprocess/fork.c
+++ b/src/common/libsubprocess/fork.c
@@ -192,6 +192,9 @@ static int local_child (flux_subprocess_t *p)
     close (STDOUT_FILENO);
     local_child_report_exec_failed_errno (p, errnum);
     close (STDERR_FILENO);
+#if CODE_COVERAGE_ENABLED
+    __gcov_flush ();
+#endif
     /* exit code doesn't matter, can't be returned to user */
     _exit (1);
 }

--- a/src/common/libsubprocess/fork.c
+++ b/src/common/libsubprocess/fork.c
@@ -1,0 +1,284 @@
+/************************************************************\
+ * Copyright 2022 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+# include "config.h"
+#endif
+
+#include <wait.h>
+#include <unistd.h>
+#include <errno.h>
+
+#include <flux/core.h>
+
+#include "src/common/libczmqcontainers/czmq_containers.h"
+#include "src/common/libutil/fdwalk.h"
+
+#include "subprocess_private.h"
+#include "command.h"
+
+static int sigmask_unblock_all (void)
+{
+    sigset_t mask;
+    sigemptyset (&mask);
+    return sigprocmask (SIG_SETMASK, &mask, NULL);
+}
+
+static void close_parent_fds (flux_subprocess_t *p)
+{
+    struct subprocess_channel *c;
+    c = zhash_first (p->channels);
+    while (c) {
+        if (c->parent_fd >= 0) {
+            close (c->parent_fd);
+            c->parent_fd = -1;
+        }
+        c = zhash_next (p->channels);
+    }
+}
+
+static void closefd_child (void *arg, int fd)
+{
+    struct idset *ids = arg;
+    if (idset_test (ids, fd))
+        return;
+    close (fd);
+}
+
+/*  Signal parent that child is ready for exec(2) and wait for parent's
+ *   signal to proceed. This is done by writing 1 byte to child side of
+ *   socketpair, and waiting for parent to write one byte back.
+ *
+ * Call fprintf instead of flux_log(), errors in child should
+ *  go to parent error streams.
+ */
+static int local_child_ready (flux_subprocess_t *p)
+{
+    int n;
+    int fd = p->sync_fds[1];
+    char c = 0;
+
+    if (write (fd, &c, sizeof (c)) != 1) {
+        fprintf (stderr, "local_child_ready: write: %s\n", strerror (errno));
+        return -1;
+    }
+    if ((n = read (fd, &c, sizeof (c))) != 1) {
+        fprintf (stderr, "local_child_ready: read (fd=%d): rc=%d: %s\n",
+                 fd, n, strerror (errno));
+        return -1;
+    }
+    return 0;
+}
+
+static void local_child_report_exec_failed_errno (flux_subprocess_t *p, int e)
+{
+    int fd = p->sync_fds[1];
+    /* Call fprintf instead of flux_log(), errors in child
+     * should go to parent error streams. */
+    if (write (fd, &e, sizeof (e)) != sizeof (e))
+        fprintf (stderr, "local_child_report_exec_failed_errno: %s\n",
+                 strerror (errno));
+}
+
+#if CODE_COVERAGE_ENABLED
+void __gcov_flush (void);
+#endif
+static int local_child (flux_subprocess_t *p)
+{
+    struct subprocess_channel *c;
+    int errnum;
+    char **argv;
+    const char *cwd;
+    struct idset *ids;
+
+    /* Throughout this function use _exit() instead of exit(), to
+     * avoid calling any atexit() routines of parent.
+     *
+     * Call fprintf instead of flux_log(), errors in child
+     * should go to parent error streams.
+     */
+
+    if (sigmask_unblock_all () < 0)
+        fprintf (stderr, "sigprocmask: %s\n", strerror (errno));
+
+    close_parent_fds (p);
+
+    if (!(p->flags & FLUX_SUBPROCESS_FLAGS_STDIO_FALLTHROUGH)) {
+        if ((c = zhash_lookup (p->channels, "stdin"))) {
+            if (dup2 (c->child_fd, STDIN_FILENO) < 0) {
+                fprintf (stderr, "dup2: %s\n", strerror (errno));
+                _exit (1);
+            }
+        }
+
+        if ((c = zhash_lookup (p->channels, "stdout"))) {
+            if (dup2 (c->child_fd, STDOUT_FILENO) < 0) {
+                fprintf (stderr, "dup2: %s\n", strerror (errno));
+                _exit (1);
+            }
+        }
+        else
+            close (STDOUT_FILENO);
+
+        if ((c = zhash_lookup (p->channels, "stderr"))) {
+            if (dup2 (c->child_fd, STDERR_FILENO) < 0) {
+                fprintf (stderr, "dup2: %s\n", strerror (errno));
+                _exit (1);
+            }
+        }
+        else
+            close (STDERR_FILENO);
+    }
+
+    // Change working directory
+    if ((cwd = flux_cmd_getcwd (p->cmd)) && chdir (cwd) < 0) {
+        fprintf (stderr,
+                 "Could not change dir to %s: %s. Going to /tmp instead\n",
+                 cwd, strerror (errno));
+        if (chdir ("/tmp") < 0)
+            _exit (1);
+    }
+
+    // Send ready to parent
+    if (local_child_ready (p) < 0)
+        _exit (1);
+
+    // Close fds
+    if (!(ids = subprocess_childfds (p))
+        || fdwalk (closefd_child, (void *) ids) < 0) {
+        fprintf (stderr, "Failed closing all fds: %s", strerror (errno));
+        _exit (1);
+    }
+    idset_destroy (ids);
+
+    if (p->hooks.pre_exec) {
+        p->in_hook = true;
+        (*p->hooks.pre_exec) (p, p->hooks.pre_exec_arg);
+        p->in_hook = false;
+    }
+
+    if (p->flags & FLUX_SUBPROCESS_FLAGS_SETPGRP
+        && getpgrp () != getpid ()) {
+        if (setpgrp () < 0) {
+            fprintf (stderr, "setpgrp: %s\n", strerror (errno));
+            _exit (1);
+        }
+    }
+
+    environ = flux_cmd_env_expand (p->cmd);
+    argv = flux_cmd_argv_expand (p->cmd);
+    if (!environ || !argv) {
+        fprintf (stderr, "out of memory\n");
+        _exit (1);
+    }
+#if CODE_COVERAGE_ENABLED
+    __gcov_flush ();
+#endif
+    execvp (argv[0], argv);
+
+    errnum = errno;
+    /*
+     * NB: close stdout and stderr here to avoid flushing buffers at exit.
+     *  This can cause duplicate output if parent was running in fully
+     *  bufferred mode, and there was buffered output.
+     */
+    close (STDOUT_FILENO);
+    local_child_report_exec_failed_errno (p, errnum);
+    close (STDERR_FILENO);
+    /* exit code doesn't matter, can't be returned to user */
+    _exit (1);
+}
+
+/*  Wait for child to indicate it is ready for exec(2) by doing a blocking
+ *   read() of one byte on parent side of sync_fds.
+ */
+static int subprocess_parent_wait_on_child (flux_subprocess_t *p)
+{
+    char c;
+
+    if (read (p->sync_fds[0], &c, sizeof (c)) != 1) {
+        flux_log (p->h, LOG_DEBUG, "subprocess_parent_wait_on_child: read");
+        return -1;
+    }
+    return 0;
+}
+
+/*  Signal child to proceed with exec(2) and read any error from exec
+ *   back on sync_fds.  Return < 0 on failure to signal, or > 0 errnum if
+ *   an exec error was returned from child.
+ */
+static int local_release_child (flux_subprocess_t *p)
+{
+    int fd = p->sync_fds[0];
+    char c = 0;
+    int e = 0;
+    ssize_t n;
+
+    if (write (fd, &c, sizeof (c)) != 1)
+        return -1;
+    if ((n = read (fd, &e, sizeof (e))) < 0)
+        return -1;
+    else if (n == sizeof (int)) {
+        // exec error received
+        return e;
+    }
+    /* else n == 0, child exec'ed and closed sync_fds[1] */
+
+    /* no longer need this fd */
+    close (p->sync_fds[0]);
+    p->sync_fds[0] = -1;
+    return 0;
+}
+
+static int local_exec (flux_subprocess_t *p)
+{
+    if ((p->exec_failed_errno = local_release_child (p)) != 0) {
+        /*
+         *  Reap child immediately. Expectation from caller is that
+         *   failure to exec will not require subsequent reaping of
+         *   child.
+         */
+        int status;
+        pid_t pid;
+        if ((pid = waitpid (p->pid, &status, 0)) <= 0)
+            return -1;
+        p->status = status;
+
+        /* spiritually FLUX_SUBPROCESS_EXEC_FAILED state at this
+         * point */
+        errno = p->exec_failed_errno;
+        return -1;
+    }
+    return 0;
+}
+
+int create_process_fork (flux_subprocess_t *p)
+{
+    if ((p->pid = fork ()) < 0)
+        return -1;
+
+    if (p->pid == 0)
+        local_child (p); /* No return */
+
+    p->pid_set = true;
+
+    /*  close child end of the sync_fd */
+    close (p->sync_fds[1]);
+    p->sync_fds[1] = -1;
+
+    if (subprocess_parent_wait_on_child (p) < 0)
+        return -1;
+
+    return local_exec (p);
+}
+
+/*
+ * vi: ts=4 sw=4 expandtab
+ */

--- a/src/common/libsubprocess/fork.h
+++ b/src/common/libsubprocess/fork.h
@@ -1,0 +1,18 @@
+/************************************************************\
+ * Copyright 2022 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _SUBPROCESS_FORK_H
+#define _SUBPROCESS_FORK_H
+
+#include "subprocess.h"
+
+int create_process_fork (flux_subprocess_t *p);
+
+#endif /* !_SUBPROCESS_FORK_H */

--- a/src/common/libsubprocess/local.c
+++ b/src/common/libsubprocess/local.c
@@ -30,6 +30,7 @@
 #include "command.h"
 #include "local.h"
 #include "fork.h"
+#include "posix_spawn.h"
 #include "util.h"
 
 static void local_channel_flush (struct subprocess_channel *c)
@@ -395,6 +396,8 @@ static void child_watch_cb (flux_reactor_t *r, flux_watcher_t *w,
 
 static int create_process (flux_subprocess_t *p)
 {
+    if (!p->hooks.pre_exec && !flux_cmd_getcwd (p->cmd))
+        return create_process_spawn (p);
     return create_process_fork (p);
 }
 

--- a/src/common/libsubprocess/local.c
+++ b/src/common/libsubprocess/local.c
@@ -29,6 +29,7 @@
 #include "subprocess_private.h"
 #include "command.h"
 #include "local.h"
+#include "fork.h"
 #include "util.h"
 
 static void local_channel_flush (struct subprocess_channel *c)
@@ -347,207 +348,17 @@ static int local_setup_channels (flux_subprocess_t *p)
     return 0;
 }
 
-static int sigmask_unblock_all (void)
-{
-    sigset_t mask;
-    sigemptyset (&mask);
-    return sigprocmask (SIG_SETMASK, &mask, NULL);
-}
-
-static void close_fds (flux_subprocess_t *p, bool parent)
+static void close_child_fds (flux_subprocess_t *p)
 {
     struct subprocess_channel *c;
-
-    /* note, it is safe to iterate via zhash, child & parent will have
-     * different copies of zhash */
     c = zhash_first (p->channels);
     while (c) {
-        if (parent && c->parent_fd != -1) {
-            close (c->parent_fd);
-            c->parent_fd = -1;
-        }
-        else if (!parent && c->child_fd != -1) {
+        if (c->child_fd != -1) {
             close (c->child_fd);
             c->child_fd = -1;
         }
         c = zhash_next (p->channels);
     }
-}
-
-static void close_parent_fds (flux_subprocess_t *p)
-{
-    close_fds (p, true);
-}
-
-static void close_child_fds (flux_subprocess_t *p)
-{
-    close_fds (p, false);
-}
-
-static void closefd_child (void *arg, int fd)
-{
-    struct idset *ids = arg;
-    if (idset_test (ids, fd))
-        return;
-    close (fd);
-}
-
-/*  Signal parent that child is ready for exec(2) and wait for parent's
- *   signal to proceed. This is done by writing 1 byte to child side of
- *   socketpair, and waiting for parent to write one byte back.
- *
- * Call fprintf instead of flux_log(), errors in child should
- *  go to parent error streams.
- */
-static int local_child_ready (flux_subprocess_t *p)
-{
-    int n;
-    int fd = p->sync_fds[1];
-    char c = 0;
-
-    if (write (fd, &c, sizeof (c)) != 1) {
-        fprintf (stderr, "local_child_ready: write: %s\n", strerror (errno));
-        return -1;
-    }
-    if ((n = read (fd, &c, sizeof (c))) != 1) {
-        fprintf (stderr, "local_child_ready: read (fd=%d): rc=%d: %s\n",
-                 fd, n, strerror (errno));
-        return -1;
-    }
-    return 0;
-}
-
-static void local_child_report_exec_failed_errno (flux_subprocess_t *p, int e)
-{
-    int fd = p->sync_fds[1];
-    /* Call fprintf instead of flux_log(), errors in child
-     * should go to parent error streams. */
-    if (write (fd, &e, sizeof (e)) != sizeof (e))
-        fprintf (stderr, "local_child_report_exec_failed_errno: %s\n",
-                 strerror (errno));
-}
-
-#if CODE_COVERAGE_ENABLED
-void __gcov_flush (void);
-#endif
-static int local_child (flux_subprocess_t *p)
-{
-    struct subprocess_channel *c;
-    int errnum;
-    char **argv;
-    const char *cwd;
-    struct idset *ids;
-
-    /* Throughout this function use _exit() instead of exit(), to
-     * avoid calling any atexit() routines of parent.
-     *
-     * Call fprintf instead of flux_log(), errors in child
-     * should go to parent error streams.
-     */
-
-    if (sigmask_unblock_all () < 0)
-        fprintf (stderr, "sigprocmask: %s\n", strerror (errno));
-
-    close_parent_fds (p);
-
-    if (!(p->flags & FLUX_SUBPROCESS_FLAGS_STDIO_FALLTHROUGH)) {
-        if ((c = zhash_lookup (p->channels, "stdin"))) {
-            if (dup2 (c->child_fd, STDIN_FILENO) < 0) {
-                fprintf (stderr, "dup2: %s\n", strerror (errno));
-                _exit (1);
-            }
-        }
-
-        if ((c = zhash_lookup (p->channels, "stdout"))) {
-            if (dup2 (c->child_fd, STDOUT_FILENO) < 0) {
-                fprintf (stderr, "dup2: %s\n", strerror (errno));
-                _exit (1);
-            }
-        }
-        else
-            close (STDOUT_FILENO);
-
-        if ((c = zhash_lookup (p->channels, "stderr"))) {
-            if (dup2 (c->child_fd, STDERR_FILENO) < 0) {
-                fprintf (stderr, "dup2: %s\n", strerror (errno));
-                _exit (1);
-            }
-        }
-        else
-            close (STDERR_FILENO);
-    }
-
-    // Change working directory
-    if ((cwd = flux_cmd_getcwd (p->cmd)) && chdir (cwd) < 0) {
-        fprintf (stderr,
-                 "Could not change dir to %s: %s. Going to /tmp instead\n",
-                 cwd, strerror (errno));
-        if (chdir ("/tmp") < 0)
-            _exit (1);
-    }
-
-    // Send ready to parent
-    if (local_child_ready (p) < 0)
-        _exit (1);
-
-    // Close fds
-    if (!(ids = subprocess_childfds (p))
-        || fdwalk (closefd_child, (void *) ids) < 0) {
-        fprintf (stderr, "Failed closing all fds: %s", strerror (errno));
-        _exit (1);
-    }
-    idset_destroy (ids);
-
-    if (p->hooks.pre_exec) {
-        p->in_hook = true;
-        (*p->hooks.pre_exec) (p, p->hooks.pre_exec_arg);
-        p->in_hook = false;
-    }
-
-    if (p->flags & FLUX_SUBPROCESS_FLAGS_SETPGRP
-        && getpgrp () != getpid ()) {
-        if (setpgrp () < 0) {
-            fprintf (stderr, "setpgrp: %s\n", strerror (errno));
-            _exit (1);
-        }
-    }
-
-    environ = flux_cmd_env_expand (p->cmd);
-    argv = flux_cmd_argv_expand (p->cmd);
-    if (!environ || !argv) {
-        fprintf (stderr, "out of memory\n");
-        _exit (1);
-    }
-#if CODE_COVERAGE_ENABLED
-    __gcov_flush ();
-#endif
-    execvp (argv[0], argv);
-
-    errnum = errno;
-    /*
-     * NB: close stdout and stderr here to avoid flushing buffers at exit.
-     *  This can cause duplicate output if parent was running in fully
-     *  bufferred mode, and there was buffered output.
-     */
-    close (STDOUT_FILENO);
-    local_child_report_exec_failed_errno (p, errnum);
-    close (STDERR_FILENO);
-    /* exit code doesn't matter, can't be returned to user */
-    _exit (1);
-}
-
-/*  Wait for child to indicate it is ready for exec(2) by doing a blocking
- *   read() of one byte on parent side of sync_fds.
- */
-static int subprocess_parent_wait_on_child (flux_subprocess_t *p)
-{
-    char c;
-
-    if (read (p->sync_fds[0], &c, sizeof (c)) != 1) {
-        flux_log (p->h, LOG_DEBUG, "subprocess_parent_wait_on_child: read");
-        return -1;
-    }
-    return 0;
 }
 
 static void child_watch_cb (flux_reactor_t *r, flux_watcher_t *w,
@@ -582,75 +393,10 @@ static void child_watch_cb (flux_reactor_t *r, flux_watcher_t *w,
         subprocess_check_completed (p);
 }
 
-/*  Signal child to proceed with exec(2) and read any error from exec
- *   back on sync_fds.  Return < 0 on failure to signal, or > 0 errnum if
- *   an exec error was returned from child.
- */
-static int local_release_child (flux_subprocess_t *p)
-{
-    int fd = p->sync_fds[0];
-    char c = 0;
-    int e = 0;
-    ssize_t n;
-
-    if (write (fd, &c, sizeof (c)) != 1)
-        return -1;
-    if ((n = read (fd, &e, sizeof (e))) < 0)
-        return -1;
-    else if (n == sizeof (int)) {
-        // exec error received
-        return e;
-    }
-    /* else n == 0, child exec'ed and closed sync_fds[1] */
-
-    /* no longer need this fd */
-    close (p->sync_fds[0]);
-    p->sync_fds[0] = -1;
-    return 0;
-}
-
-static int local_exec (flux_subprocess_t *p)
-{
-    if ((p->exec_failed_errno = local_release_child (p)) != 0) {
-        /*
-         *  Reap child immediately. Expectation from caller is that
-         *   failure to exec will not require subsequent reaping of
-         *   child.
-         */
-        int status;
-        pid_t pid;
-        if ((pid = waitpid (p->pid, &status, 0)) <= 0)
-            return -1;
-        p->status = status;
-
-        /* spiritually FLUX_SUBPROCESS_EXEC_FAILED state at this
-         * point */
-        errno = p->exec_failed_errno;
-        return -1;
-    }
-    return 0;
-}
-
 static int create_process (flux_subprocess_t *p)
 {
-    if ((p->pid = fork ()) < 0)
-        return -1;
-
-    if (p->pid == 0)
-        local_child (p); /* No return */
-
-    p->pid_set = true;
-
-    /*  close child end of the sync_fd */
-    close (p->sync_fds[1]);
-    p->sync_fds[1] = -1;
-
-    if (subprocess_parent_wait_on_child (p) < 0)
-        return -1;
-
-    return local_exec (p);
+    return create_process_fork (p);
 }
-
 
 static int start_local_watchers (flux_subprocess_t *p)
 {

--- a/src/common/libsubprocess/posix_spawn.c
+++ b/src/common/libsubprocess/posix_spawn.c
@@ -1,0 +1,168 @@
+/************************************************************\
+ * Copyright 2022 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+# include "config.h"
+#endif
+
+#include <unistd.h>
+#include <signal.h>
+#include <spawn.h>
+
+#include <flux/core.h>
+#include <flux/idset.h>
+
+#include "src/common/libczmqcontainers/czmq_containers.h"
+#include "src/common/libutil/fdwalk.h"
+
+#include "subprocess_private.h"
+#include "command.h"
+
+struct spawn_close_arg {
+    posix_spawn_file_actions_t *fa;
+    struct idset *childfds;
+};
+
+static void spawn_closefd (void *arg, int fd)
+{
+    struct spawn_close_arg *sc = arg;
+    if (idset_test (sc->childfds, fd))
+        return;
+    posix_spawn_file_actions_addclose (sc->fa, fd);
+}
+
+/*  Setup posix_spawn_file_actions_t for this subprocess.
+ *  - dup stdin/out/err fds onto standard file descriptor numbers
+ *  - set up other file descriptors to close in the child
+ */
+static int spawn_setup_fds (flux_subprocess_t *p,
+                            posix_spawn_file_actions_t *fa)
+{
+    int rc = -1;
+    struct subprocess_channel *c;
+    struct spawn_close_arg sc;
+
+    sc.fa = fa;
+    if (!(sc.childfds = subprocess_childfds (p)))
+        return -1;
+
+    if (!(p->flags & FLUX_SUBPROCESS_FLAGS_STDIO_FALLTHROUGH)) {
+        if ((c = zhash_lookup (p->channels, "stdin"))) {
+            if (posix_spawn_file_actions_adddup2 (fa,
+                                                  c->child_fd,
+                                                  STDIN_FILENO) < 0)
+                goto out;
+        }
+        if ((c = zhash_lookup (p->channels, "stdout"))) {
+            if (posix_spawn_file_actions_adddup2 (fa,
+                                                  c->child_fd,
+                                                  STDOUT_FILENO) < 0)
+                goto out;
+        }
+        else if (posix_spawn_file_actions_addclose (fa, STDOUT_FILENO) < 0)
+                goto out;
+
+        if ((c = zhash_lookup (p->channels, "stderr"))) {
+            if (posix_spawn_file_actions_adddup2 (fa,
+                                                  c->child_fd,
+                                                  STDERR_FILENO) < 0)
+                goto out;
+        }
+        else if (posix_spawn_file_actions_addclose (fa, STDERR_FILENO) < 0)
+                goto out;
+    }
+
+    if (fdwalk (spawn_closefd, (void *) &sc) < 0)
+        goto out;
+
+    rc = 0;
+out:
+    idset_destroy (sc.childfds);
+    return rc;
+}
+
+/*  Reset (most) signals to default mask and handlers in child.
+ */
+static int setup_signals (posix_spawnattr_t *attr)
+{
+    sigset_t mask;
+
+    if (sigemptyset (&mask) < 0
+        || posix_spawnattr_setsigmask (attr, &mask) < 0)
+        return -1;
+
+    /*  Iterate list of signals to reset.
+     *
+     *  Note: It has been experimentally determined that setting
+     *  unblockable signals like SIGKILL and SIGSTOP, as well as high
+     *  signal numbers (> 64)  in the sigdefault mask cause spawn
+     *  failures in the child process (exit code 127). Therefore, we
+     *  have to be more targeted than just using sigfillset(3).
+     */
+    for (int i = 1; i < SIGSYS; i++) {
+        if (i != SIGKILL && i != SIGSTOP)
+            if (sigaddset (&mask, i) < 0)
+                return -1;
+    }
+    return posix_spawnattr_setsigdefault (attr, &mask);
+}
+
+/*  Create a child process using posix_spawnp(3).
+ */
+int create_process_spawn (flux_subprocess_t *p)
+{
+    int rc = -1;
+    int retval;
+    int saved_errno;
+    posix_spawn_file_actions_t file_actions;
+    posix_spawnattr_t attr;
+    short flags = POSIX_SPAWN_SETSIGDEF | POSIX_SPAWN_SETSIGMASK;
+    char **env = flux_cmd_env_expand (p->cmd);
+    char **argv = flux_cmd_argv_expand (p->cmd);
+
+    posix_spawnattr_init (&attr);
+    posix_spawn_file_actions_init (&file_actions);
+
+    if (setup_signals (&attr) < 0)
+        goto out;
+
+    /*  If setpgrp(2) is desired for the child process, then add this
+     *  flag to the spawnattr flags.
+     */
+    if (p->flags & FLUX_SUBPROCESS_FLAGS_SETPGRP)
+        flags |= POSIX_SPAWN_SETPGROUP;
+    posix_spawnattr_setflags (&attr, flags);
+
+    /*  Setup file descriptors in file_actions
+     */
+    spawn_setup_fds (p, &file_actions);
+
+    /*  Attempt to spawn a new child process */
+    retval = posix_spawnp (&p->pid, argv[0], &file_actions, &attr, argv, env);
+    if (retval != 0) {
+        errno = retval;
+        goto out;
+    }
+    p->pid_set = true;
+    rc = 0;
+out:
+    saved_errno = errno;
+    posix_spawnattr_destroy (&attr);
+    posix_spawn_file_actions_destroy (&file_actions);
+
+    free (env);
+    free (argv);
+
+    errno = saved_errno;
+    return rc;
+}
+
+/*  vi: ts=4 sw=4 expandtab
+ */

--- a/src/common/libsubprocess/posix_spawn.h
+++ b/src/common/libsubprocess/posix_spawn.h
@@ -1,0 +1,18 @@
+/************************************************************\
+ * Copyright 2022 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _SUBPROCESS_SPAWN_H
+#define _SUBPROCESS_SPAWN_H
+
+#include "subprocess.h"
+
+int create_process_spawn (flux_subprocess_t *p);
+
+#endif /* !_SUBPROCESS_SPAWN_H */

--- a/src/common/libsubprocess/server.c
+++ b/src/common/libsubprocess/server.c
@@ -332,11 +332,6 @@ static void server_exec_cb (flux_t *h, flux_msg_handler_t *mh,
         goto error;
     }
 
-    if (!flux_cmd_getcwd (cmd)) {
-        errno = EPROTO;
-        goto error;
-    }
-
     if (!(env = flux_cmd_env_expand (cmd)))
         goto error;
 

--- a/src/common/libsubprocess/subprocess.c
+++ b/src/common/libsubprocess/subprocess.c
@@ -117,6 +117,29 @@ error:
     return NULL;
 }
 
+/*  Return the set of valid child file descriptors as an idset
+ */
+struct idset *subprocess_childfds (flux_subprocess_t *p)
+{
+    struct subprocess_channel *c;
+    struct idset *ids;
+
+    /*  fds 0,1,2 always remain open in the child (stdin,out,err)
+     */
+    if (!(ids = idset_decode ("0-2")))
+        return NULL;
+
+    if (p->sync_fds[1] > 0)
+        idset_set (ids, p->sync_fds[1]);
+
+    c = zhash_first (p->channels);
+    while (c) {
+        idset_set (ids, c->child_fd);
+        c = zhash_next (p->channels);
+    }
+    return ids;
+}
+
 static void subprocess_free (flux_subprocess_t *p)
 {
     if (p && p->magic == SUBPROCESS_MAGIC) {

--- a/src/common/libsubprocess/subprocess.c
+++ b/src/common/libsubprocess/subprocess.c
@@ -732,12 +732,6 @@ flux_subprocess_t *flux_rexec (flux_t *h, int rank, int flags,
         goto error;
     }
 
-    /* user required to set cwd */
-    if (!flux_cmd_getcwd (cmd)) {
-        errno = EINVAL;
-        goto error;
-    }
-
     /* make sure user didn't set local only cmd options */
     if (check_local_only_cmd_options (cmd)) {
         errno = EINVAL;

--- a/src/common/libsubprocess/subprocess_private.h
+++ b/src/common/libsubprocess/subprocess_private.h
@@ -11,6 +11,8 @@
 #ifndef _SUBPROCESS_PRIVATE_H
 #define _SUBPROCESS_PRIVATE_H
 
+#include <flux/idset.h>
+
 #include "subprocess.h"
 
 #define SUBPROCESS_MAGIC           0xbeefcafe
@@ -146,5 +148,7 @@ struct subprocess_channel *channel_create (flux_subprocess_t *p,
                                            flux_subprocess_output_f output_f,
                                            const char *name,
                                            int flags);
+
+struct idset * subprocess_childfds (flux_subprocess_t *p);
 
 #endif /* !_SUBPROCESS_PRIVATE_H */

--- a/src/common/libsubprocess/test/subprocess.c
+++ b/src/common/libsubprocess/test/subprocess.c
@@ -195,13 +195,6 @@ void test_basic_errors (flux_reactor_t *r)
 
     ok ((cmd = flux_cmd_create (1, avgood, NULL)) != NULL,
         "flux_cmd_create with 0 args works");
-    ok (flux_rexec (h, 0, 0, cmd, NULL) == NULL
-        && errno == EINVAL,
-        "flux_rexec fails with cmd with no cwd");
-    flux_cmd_destroy (cmd);
-
-    ok ((cmd = flux_cmd_create (1, avgood, NULL)) != NULL,
-        "flux_cmd_create with 0 args works");
     ok (flux_cmd_setcwd (cmd, "foobar") == 0,
         "flux_cmd_setcwd works");
     ok (flux_cmd_setopt (cmd, "stdout_STREAM_STOP", "true") == 0,

--- a/src/common/libsubprocess/test/subprocess.c
+++ b/src/common/libsubprocess/test/subprocess.c
@@ -66,7 +66,7 @@ void completion_cb (flux_subprocess_t *p)
     ok (flux_subprocess_status (p) != -1,
         "subprocess status is valid");
     ok (flux_subprocess_exit_code (p) == 0,
-        "subprocess exit code is 0");
+        "subprocess exit code is 0, got %d", flux_subprocess_exit_code (p));
     completion_cb_count++;
 }
 
@@ -1450,12 +1450,17 @@ void test_state_strings (void)
 
 void test_exec_fail (flux_reactor_t *r)
 {
+    char path [4096];
     char *av_eacces[]  = { "/", NULL };
     char *av_enoent[]  = { "/usr/bin/foobarbaz", NULL };
     flux_cmd_t *cmd = NULL;
     flux_subprocess_t *p = NULL;
 
     ok ((cmd = flux_cmd_create (1, av_eacces, NULL)) != NULL, "flux_cmd_create");
+
+    /*  Set cwd to force use of fork/exec */
+    ok (flux_cmd_setcwd (cmd, getcwd (path, sizeof (path))) == 0,
+        "flux_cmd_setcwd");
 
     p = flux_local_exec (r, 0, cmd, NULL, NULL);
     ok (p == NULL
@@ -1465,6 +1470,10 @@ void test_exec_fail (flux_reactor_t *r)
     flux_cmd_destroy (cmd);
 
     ok ((cmd = flux_cmd_create (1, av_enoent, NULL)) != NULL, "flux_cmd_create");
+
+    /*  Set cwd to force use of fork/exec */
+    ok (flux_cmd_setcwd (cmd, getcwd (path, sizeof (path))) == 0,
+        "flux_cmd_setcwd");
 
     p = flux_local_exec (r, 0, cmd, NULL, NULL);
     ok (p == NULL

--- a/src/modules/job-exec/bulk-exec.c
+++ b/src/modules/job-exec/bulk-exec.c
@@ -628,7 +628,6 @@ flux_future_t *bulk_exec_imp_kill (struct bulk_exec *exec,
             flux_cmd_t *cmd = flux_cmd_create (0, NULL, environ);
 
             if (!cmd
-                || flux_cmd_setcwd (cmd, "/tmp") < 0
                 || flux_cmd_argv_append (cmd, imp_path) < 0
                 || flux_cmd_argv_append (cmd, "kill") < 0
                 || flux_cmd_argv_appendf (cmd, "%d", signum) < 0

--- a/src/modules/job-exec/exec.c
+++ b/src/modules/job-exec/exec.c
@@ -308,10 +308,6 @@ static int exec_init (struct jobinfo *job)
         flux_log_error (job->h, "exec_init: flux_cmd_argv_append");
         goto err;
     }
-    if (flux_cmd_setcwd (cmd, config_get_cwd (job)) < 0) {
-        flux_log_error (job->h, "exec_init: flux_cmd_setcwd");
-        goto err;
-    }
 
     /*  If more than one shell is involved in this job, set up a channel
      *   for exec system based barrier:

--- a/src/modules/job-ingest/worker.c
+++ b/src/modules/job-ingest/worker.c
@@ -41,7 +41,6 @@
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
-#include <limits.h>
 #include <unistd.h>
 #include <jansson.h>
 #include <flux/core.h>
@@ -391,16 +390,10 @@ void worker_destroy (struct worker *w)
 
 int worker_set_cmdline (struct worker *w, int argc, char **argv)
 {
-    char path[PATH_MAX + 1];
-
     flux_cmd_destroy (w->cmd);
 
     if (!(w->cmd = flux_cmd_create (argc, argv, environ))) {
         flux_log_error (w->h, "flux_cmd_create");
-        return -1;
-    }
-    if (flux_cmd_setcwd (w->cmd, getcwd (path, sizeof (path))) < 0) {
-        flux_log_error (w->h, "flux_cmd_setcwd");
         return -1;
     }
     return 0;

--- a/src/shell/shell.c
+++ b/src/shell/shell.c
@@ -1174,11 +1174,6 @@ static int shell_init (flux_shell_t *shell)
             default_rcfile = result;
     }
 
-    /*  Load initrc file if necessary
-     */
-    if (load_initrc (shell, default_rcfile) < 0)
-        return -1;
-
     /* Change current working directory once before all tasks are
      * created, so that each task does not need to chdir().
      */
@@ -1195,6 +1190,11 @@ static int shell_init (flux_shell_t *shell)
             }
         }
     }
+
+    /*  Load initrc file if necessary
+     */
+    if (load_initrc (shell, default_rcfile) < 0)
+        return -1;
 
     return plugstack_call (shell->plugstack, "shell.init", NULL);
 }

--- a/t/job-exec/dummy.sh
+++ b/t/job-exec/dummy.sh
@@ -93,6 +93,11 @@ get_duration() {
     if test "$DURATION" = "null"; then DURATION=0.01; fi
 }
 
+get_cwd() {
+    CWD=$(json_get "$JOBSPEC" .attributes.system.cwd)
+    if test "$CWD" = "null"; then CWD=.; fi
+}
+
 get_command() {
     COMMAND=($(json_get "$JOBSPEC" '.tasks[0].command[]' | tr '\n' ' '))
 }
@@ -160,6 +165,9 @@ barrier
 get_duration
 get_command
 get_traps
+get_cwd
+
+cd $CWD
 
 test_mock_failure
 barrier

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -122,7 +122,12 @@ test_expect_success 'flux-start exec fails on bad broker shell script' "
 	test_must_fail bash -c 'FLUX_EXEC_PATH_PREPEND=. flux start /bin/true'
 "
 test_expect_success 'flux-start test exec fails on bad broker shell script' "
-	test_must_fail bash -c 'FLUX_EXEC_PATH_PREPEND=. flux start -s1 /bin/true'
+	#
+	# We can't use test_must_fail here because on some OSes this command
+	# might fail with exit code 127, which test_must_fail does not
+	# acccept, so we use ! here since any failure is acceptable here
+	#
+	! bash -c 'FLUX_EXEC_PATH_PREPEND=. flux start -s1 /bin/true'
 "
 test_expect_success 'flux-start -s1 works' "
 	flux start ${ARGS} -s1 /bin/true

--- a/t/t0005-exec.t
+++ b/t/t0005-exec.t
@@ -93,6 +93,10 @@ test_expect_success 'flux exec -d option works' '
 	flux exec -n -d ${TMPDIR} sh -c "test \`pwd\` = \"${TMPDIR}\""
 '
 
+test_expect_success 'flux exec -d none works' '
+	(cd /tmp && flux exec -n -d none sh -c "test \$(pwd) != /tmp")
+'
+
 # Run a script on ranks 0-3 simultaneously with each rank writing the
 #  rank id to a file. After successful completion, the contents of the files
 #  are verfied to ensure each rank connected to the right broker.


### PR DESCRIPTION
This PR started as an experiment to verify a theoretical cause of slow job throughput on systems with many cores. The effect of switching to `posix_spawnp(3)` on even my small home system was significant, so I thought I'd submit more polished changes as a PR.

The changes here introduce an alternate mechanism for launching local subprocesses in libsubprocess. Whenever possible, a this new implementation, which uses `posix_spawn(3)`, is preferred over the existing mechanism. However, libsubprocess will still fall back to fork/exec in cases where `posix_spawn()` will not work, e.g. if the subprocess uses a pre_exec hook or sets a working directory.

The requirement that all subprocesses have a current working directory is then relaxed, so that the cwd can be removed in job-exec and other select users of libsubprocess. This change then allows the execution of job shells to switch to `posix_spawn()` instead of fork/exec.

On versions of glibc since about 2.24, `posix_spawn()` uses a replacement for fork (`clone` plus `CLONE_VM` and `CLONE_VFORK`) which is must faster than `fork(2)` since no page tables have to be copied. This means that on somewhat recent Linux distros (not RHEL7 though), we see quite a difference in the throughput microbenchmark:

Current `master`, with 4 back to back runs of `throughput -sxn 1024`:
```
throughput:     42.5 job/s (script:  41.8 job/s)
throughput:     39.1 job/s (script:  38.5 job/s)
throughput:     38.5 job/s (script:  38.0 job/s)
throughput:     37.0 job/s (script:  36.6 job/s)
```

This PR branch:
```
throughput:     49.1 job/s (script:  48.2 job/s)
throughput:     50.7 job/s (script:  49.4 job/s)
throughput:     48.3 job/s (script:  47.6 job/s)
throughput:     49.0 job/s (script:  48.1 job/s)
```

Note also that we can compare the difference between fork/exec and `posix_spawn` using a new undocumented option to `flux exec ` which unsets the current working directory , `flux exec -d none`:

using fork:
```console
$ time flux exec -r 0 hostname
asp

real	0m0.063s
user	0m0.028s
sys	0m0.016s
```

using posix_spawn:
```console
$ time flux exec -d none -r 0 hostname 
asp

real	0m0.036s
user	0m0.037s
sys	0m0.004s
```

Obviously, this would only get more drastic as the size of the broker increases.

Fixes #384