### PR TITLE
job-manager: ensure job aux items are destroyed safely

### DIFF
--- a/src/common/libflux/plugin.h
+++ b/src/common/libflux/plugin.h
@@ -61,6 +61,8 @@ int flux_plugin_set_name (flux_plugin_t *p, const char *name);
 
 const char * flux_plugin_get_name (flux_plugin_t *p);
 
+const char * flux_plugin_get_uuid (flux_plugin_t *p);
+
 /*  Add a handler for topic 'topic' for the plugin 'p'.
  *  The topic string may be a glob to cause 'cb' to be invoked for
  *  a set of topic strings called by the host.

--- a/src/common/libflux/test/plugin.c
+++ b/src/common/libflux/test/plugin.c
@@ -69,6 +69,10 @@ void test_invalid_args ()
     ok (flux_plugin_get_name (NULL) == NULL && errno == EINVAL,
         "flux_plugin_get_name (NULL) returns EINVAL");
 
+    errno = 0;
+    ok (flux_plugin_get_uuid (NULL) == NULL && errno == EINVAL,
+        "flux_plugin_get_uuid (NULL) returns EINVAL");
+
     ok (flux_plugin_get_flags (NULL) == 0,
         "flux_plugin_get_flags (NULL) returns 0");
     ok (flux_plugin_set_flags (NULL, 0) < 0 && errno == EINVAL,
@@ -469,6 +473,31 @@ void test_load_rtld_now ()
     flux_plugin_destroy (p);
 }
 
+void test_uuid (void)
+{
+    flux_plugin_t *p;
+    const char *uuid;
+    char *ouuid;
+
+    if (!(p = flux_plugin_create ()))
+        BAIL_OUT ("flux_plugin_create failed");
+    uuid = flux_plugin_get_uuid (p);
+    ok (uuid != NULL,
+        "flux_plugin_get_uuid works");
+    if (!(ouuid = strdup (uuid)))
+        BAIL_OUT ("strdup failed");
+    flux_plugin_destroy (p);
+
+    if (!(p = flux_plugin_create ()))
+        BAIL_OUT ("flux_plugin_create failed");
+    uuid = flux_plugin_get_uuid (p);
+
+    ok (uuid != NULL && strcmp (ouuid, uuid) != 0,
+        "second plugin instance has different uuid");
+    flux_plugin_destroy (p);
+    free (ouuid);
+}
+
 
 int main (int argc, char *argv[])
 {
@@ -479,6 +508,7 @@ int main (int argc, char *argv[])
     test_register ();
     test_load ();
     test_load_rtld_now ();
+    test_uuid ();
     done_testing();
     return (0);
 }

--- a/src/modules/job-manager/event.c
+++ b/src/modules/job-manager/event.c
@@ -405,6 +405,7 @@ int event_job_action (struct event *event, struct job *job)
                                 (uintmax_t) job->id);
             }
             (void) jobtap_call (ctx->jobtap, job, "job.destroy", NULL);
+            job_aux_destroy (job);
             zhashx_delete (ctx->active_jobs, &job->id);
             drain_check (ctx->drain);
             break;

--- a/src/modules/job-manager/job-manager.c
+++ b/src/modules/job-manager/job-manager.c
@@ -237,6 +237,11 @@ done:
     alloc_ctx_destroy (ctx.alloc);
     submit_ctx_destroy (ctx.submit);
     event_ctx_destroy (ctx.event);
+    /* job aux containers may call destructors in jobtap plugins, so destroy
+     * jobs before unloading plugins; but don't destroy job hashes until after.
+     */
+    zhashx_purge (ctx.active_jobs);
+    zhashx_purge (ctx.inactive_jobs);
     jobtap_destroy (ctx.jobtap);
     conf_destroy (ctx.conf);
     zhashx_destroy (&ctx.active_jobs);

--- a/src/modules/job-manager/job.c
+++ b/src/modules/job-manager/job.c
@@ -149,6 +149,11 @@ void job_aux_delete (struct job *job, const void *val)
     aux_delete (&job->aux, val);
 }
 
+void job_aux_destroy (struct job *job)
+{
+    aux_destroy (&job->aux);
+}
+
 struct job *job_create_from_eventlog (flux_jobid_t id,
                                       const char *eventlog,
                                       const char *jobspec,

--- a/src/modules/job-manager/job.h
+++ b/src/modules/job-manager/job.h
@@ -72,12 +72,15 @@ struct job *job_create_from_eventlog (flux_jobid_t id,
                                       flux_error_t *error);
 struct job *job_create_from_json (json_t *o);
 
+/* N.B. aux items are destroyed when job transitions to inactive.
+ */
 int job_aux_set (struct job *job,
                  const char *name,
                  void *val,
                  flux_free_f destroy);
 void *job_aux_get (struct job *job, const char *name);
 void job_aux_delete (struct job *job, const void *val);
+void job_aux_destroy (struct job *job);
 
 /* Helpers for maintaining czmq containers of 'struct job'.
  * job_priority_comparator sorts by (1) priority, then (2) jobid.

--- a/t/job-manager/plugins/job_aux.c
+++ b/t/job-manager/plugins/job_aux.c
@@ -3,6 +3,12 @@
 #include <flux/core.h>
 #include <flux/jobtap.h>
 
+static void my_cleanup (void *arg)
+{
+    flux_t *h = arg;
+
+    flux_log (h, LOG_INFO, "job_aux test destructor invoked");
+}
 
 static int depend_cb (flux_plugin_t *p,
                       const char *topic,
@@ -12,6 +18,7 @@ static int depend_cb (flux_plugin_t *p,
     int rc;
     void *val;
     flux_jobid_t id;
+    flux_t *h = flux_jobtap_get_flux (p);
 
     /*  Test job_aux by jobid here since the current job will be active */
 
@@ -52,6 +59,10 @@ static int depend_cb (flux_plugin_t *p,
                                             "test", 0,
                                             "flux_jobtap_aux_get: %s",
                                             "unexpected success");
+
+    /* Leave an entry for cleanup later */
+    (void)flux_jobtap_job_aux_set (p, id, "foo", h, my_cleanup);
+
 
     return 0;
 }

--- a/t/t2212-job-manager-plugins.t
+++ b/t/t2212-job-manager-plugins.t
@@ -180,8 +180,23 @@ test_expect_success 'job-manager: run subscribe test plugin' '
 	test $(grep -c OK subscribe-check.log) = 6
 '
 test_expect_success 'job-manager: run job_aux test plugin' '
+	flux dmesg --clear &&
 	flux jobtap load --remove=all ${PLUGINPATH}/job_aux.so &&
 	flux mini run hostname
+'
+test_expect_success 'job-manager: job aux cleared on transition to inactive' '
+	flux dmesg >aux-dmesg.out &&
+	grep "test destructor invoked" aux-dmesg.out
+'
+test_expect_success 'job-manager: start another job and remove plugin' '
+	flux dmesg --clear &&
+	jobid=$(flux mini submit --wait-event=alloc sleep 60) &&
+	flux jobtap remove job_aux.so &&
+	flux job cancel $jobid
+'
+test_expect_success 'job-manager: job aux cleared when plugin removed' '
+	flux dmesg >aux-dmesg2.out &&
+	grep "test destructor invoked" aux-dmesg2.out
 '
 test_expect_success 'job-manager: load jobtap_api test plugin' '
 	flux jobtap load --remove=all ${PLUGINPATH}/jobtap_api.so &&


### PR DESCRIPTION
This PR addresses two problems:
- If a jobtap plugin stores an aux item with a destructor, and the plugin is unloaded before the job is destroyed, the destructor might no longer be resident, leading to a segfault
- now that jobs are kept in memory after transition to inactive, any job aux items are not automatically cleaned up (#4296)

This addresses the first problem by leaking the items if the module that registered them is no longer loaded  (see commit message for further details).  The "solution" presumes that it's unlikely that jobtap plugins are going to be loaded and unloaded on a live system except in test or rare debug siutations where a little leakage is no big deal.

The second problem is addressed by destroying the aux container upon transition to inactive, as suggested by @grondo.  I didn't rename it as we had discussed - just left a comment in the header instead (hope that's ok).

Edit: this is based on top of #4392