### PR TITLE
ci: create kvs dumpfile from previous tag for testing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/setup-python@v1
       with:
         python-version: 3.6
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
@@ -36,7 +36,7 @@ jobs:
     - uses: actions/setup-python@v1
       with:
         python-version: 3.6
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
@@ -52,7 +52,7 @@ jobs:
     - uses: actions/setup-python@v1
       with:
         python-version: 3.6
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
@@ -66,7 +66,7 @@ jobs:
     name: flux-sched check
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
@@ -87,7 +87,7 @@ jobs:
     outputs:
         matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
@@ -114,7 +114,7 @@ jobs:
       fail-fast: false
     name: ${{matrix.name}}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
        ref: ${{ github.event.pull_request.head.sha }}
        fetch-depth: 0
@@ -125,7 +125,7 @@ jobs:
         github.ref != 'refs/heads/master'
       run: |
         # Ensure git-describe works on a tag.
-        #  (checkout@v2 action may have left current tag as
+        #  (checkout@v3 action may have left current tag as
         #   lightweight instead of annotated. See
         #   https://github.com/actions/checkout/issues/290)
         #

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -149,6 +149,12 @@ jobs:
       run: |
         docker run -d -p 9000:9000 minio/minio server /data; \
 
+    - name: generate dumpfile from most recent flux-core tag
+      run: |
+        git tag -l ; \
+        src/test/create-kvs-dumpfile.sh -d /tmp/dumpfile; \
+        cp /tmp/dumpfile/*.tar.bz2 $(pwd)/t/job-manager/dumps/valid
+
     - name: docker buildx
       uses: docker/setup-buildx-action@v1
       if: matrix.needs_buildx

--- a/src/test/create-kvs-dumpfile.sh
+++ b/src/test/create-kvs-dumpfile.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+#
+#  Run a workload in the docker container from a given flux-core tag
+#   (previous tag by default), and preserve a dumpfile.
+#
+OUTPUTDIR="$(pwd)/output"
+TAG=$(git describe --abbrev=0)
+WORKLOAD="\
+#!/bin/sh
+#
+#  Basic workload used to create a set of varied eventlogs in KVS
+#
+flux mini bulksubmit --quiet --cc=1-4 {} ::: true false nocommand &&
+id=\$(flux mini submit --urgency=hold hostname) &&
+flux job cancel \$id &&
+id=\$(flux mini submit --wait-event=start sleep 30) &&
+flux mini submit --quiet --dependency=afternotok:\$id true &&
+flux job cancel \$id &&
+flux queue drain &&
+flux jobs -a
+"
+declare -r prog=${0##*/}
+die() { echo -e "$prog: $@"; exit 1; }
+
+declare -r long_opts="help,tag:,workload:,statedir:"
+declare -r short_opts="ht:w:d:"
+declare -r usage="
+Usage: $prog [OPTIONS]\n\
+Run a workload under the latest flux-core tag docker image and save\n\
+the content file to a state directory.\n\
+\n\
+Options:\n\
+ -h, --help             Display this message\n\
+ -t, --tag=NAME         Run against flux-core tag NAME instead of latest tag\n\
+ -w, --workload=SCRIPT  Run workload SCRIPT instead of a default\n\
+ -d, --output=DIR       Save dumpfile to DIR (default=$OUTPUTDIR)
+"
+
+# check if running in OSX
+if [[ "$(uname)" == "Darwin" ]]; then
+    # BSD getopt
+    GETOPTS=`/usr/bin/getopt $short_opts -- $*`
+else
+    # GNU getopt
+    GETOPTS=`/usr/bin/getopt -u -o $short_opts -l $long_opts -n $prog -- $@`
+    if [[ $? != 0 ]]; then
+        die "$usage"
+    fi
+    eval set -- "$GETOPTS"
+fi
+
+while true; do
+    case "$1" in
+      -h|--help)     echo -ne "$usage";          exit 0  ;;
+      -t|--tag)      TAG="$2";                   shift 2 ;;
+      -w|--workload) WORKLOAD_PATH="$2";         shift 2 ;;
+      -d|--output)   OUTPUTDIR="$2";             shift 2 ;;
+      --)            shift; break;                       ;;
+      *)             die "Invalid option '$1'\n$usage"   ;;
+    esac
+done
+
+mkdir "${OUTPUTDIR}" || die "Failed to create $OUTPUTDIR"
+if test -n "$WORKLOAD_PATH"; then
+    cp $WORKLOAD_PATH ${OUTPUTDIR}/workload.sh
+else
+    printf "$WORKLOAD" > ${OUTPUTDIR}/workload.sh
+fi
+
+chmod +x ${OUTPUTDIR}/workload.sh
+
+DUMPFILE=flux-${TAG}.tar.bz2
+printf "Creating dumpfile in ${OUTPUTDIR}/${DUMPFILE}\n"
+docker run -i --rm -u $(id -u) \
+     --mount type=bind,source=${OUTPUTDIR},target=/data \
+     fluxrm/flux-core:bionic-${TAG} \
+     flux start sh -c "/data/workload.sh; flux dump /data/${DUMPFILE}"
+
+rm ${OUTPUTDIR}/workload.sh
+


### PR DESCRIPTION
This PR adds a script like the one proposed in #4401 to the GitHub workflow. This runs a small workload in the most recent tag and saves the dumpfile to `t/job-manager/dumps/valid` which will cause the dumpfile to get testing during `make check`.

This should, in theory, automatically catch PRs proposed that can't restart the previous tagged version KVS.

The workload here is very minimal, but could be easily extended if needed.