### PR TITLE
job-manager: fix dependency-add from job.state.depend callback

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,6 +80,24 @@ jobs:
         cd flux-sched &&
         src/test/docker/docker-run-checks.sh -j 4 -i bionic
 
+  check-accounting:
+    needs: [ python-format, python-lint, mypy ]
+    name: flux-accounting check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+        fetch-depth: 0
+    - run: >
+        src/test/docker/docker-run-checks.sh --image=el8 --install-only
+        --tag=fluxrm/flux-core:el8
+    - run: >
+        cd .. &&
+        git clone https://github.com/flux-framework/flux-accounting &&
+        cd flux-accounting &&
+        src/test/docker/docker-run-checks.sh -j 4 
+
   generate-matrix:
     # https://stackoverflow.com/questions/59977364
     name: Generate build matrix

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -4,6 +4,7 @@ queue_rules:
       - base=master
       - status-success="validate commits"
       - status-success="flux-sched check"
+      - status-success="flux-accounting check"
       - status-success="python format"
       - status-success="python lint"
       - status-success="mypy"

--- a/src/modules/job-manager/event.c
+++ b/src/modules/job-manager/event.c
@@ -333,6 +333,7 @@ int event_job_action (struct event *event, struct job *job)
              *   transition the job to the PRIORITY state.
              */
             if (job_dependency_count (job) == 0
+                && !job_event_is_queued (job, "dependency-add")
                 && !job->depend_posted) {
                 if (event_job_post_pack (event, job, "depend", 0, NULL) < 0)
                     return -1;


### PR DESCRIPTION
As noted in #4405, recent changes to how posted events are handled by the job manager broke the addition of dependencies in the `job.state.depend` callback. This PR fixes that issue by avoiding post of the `depend` event if there is a `dependency-add` event queued.

A test is also added, since that was clearly missing coverage. (All the tests apparently used `job.dependency.*` callbacks instead)

Finally, to avoid merging PRs which break flux-accounting, a CI check similar to the existing flux-sched check is added for flux-accounting.

Since this modifies mergify config it will likely need a manual merge.