### PR TITLE
Use flux_error_t and errprintf() over char buf and snprintf()

### DIFF
--- a/src/modules/content-s3/content-s3.c
+++ b/src/modules/content-s3/content-s3.c
@@ -165,7 +165,7 @@ static struct s3_config *parse_config (const flux_conf_t *conf,
                           &uri,
                           "virtual-host-style",
                           &is_virtual_host) < 0) {
-        snprintf(errbuff, eb_size, "%s", error.text);
+        snprintf (errbuff, eb_size, "%s", error.text);
         goto error;
     }
 
@@ -173,13 +173,13 @@ static struct s3_config *parse_config (const flux_conf_t *conf,
         goto error;
 
     if (yuarel_parse (&yuri, cpy) < 0) {
-        snprintf(errbuff, eb_size, "failed to parse uri");
+        snprintf (errbuff, eb_size, "failed to parse uri");
         errno = EINVAL;
         goto error;
     }
 
     if (!(cfg->hostname = hostport (yuri.host, yuri.port))) {
-        snprintf(errbuff, eb_size, "failed to form hostname");
+        snprintf (errbuff, eb_size, "failed to form hostname");
         errno = ENOMEM;
         goto error;
     }

--- a/src/modules/content-s3/content-s3.c
+++ b/src/modules/content-s3/content-s3.c
@@ -449,12 +449,12 @@ static struct content_s3 *content_s3_create (flux_t *h)
     }
 
     if (s3_init (ctx->cfg, &errstr) < 0) {
-        flux_log_error (h, "content-s3 init");
+        flux_log (h, LOG_ERR, "content-s3 init: %s", errstr);
         goto error;
     }
 
     if (s3_bucket_create (ctx->cfg, &errstr) < 0) {
-        flux_log_error (h, "content-s3 create bucket");
+        flux_log (h, LOG_ERR, "content-s3 create bucket: %s", errstr);
         goto error;
     }
 

--- a/src/modules/resource/exclude.h
+++ b/src/modules/resource/exclude.h
@@ -16,8 +16,7 @@ void exclude_destroy (struct exclude *exclude);
 
 int exclude_update (struct exclude *exclude,
                     const char *idset,
-                    char *errbuf,
-                    int errbufsize);
+                    flux_error_t *errp);
 
 const struct idset *exclude_get (struct exclude *exclude);
 

--- a/src/modules/resource/inventory.h
+++ b/src/modules/resource/inventory.h
@@ -45,8 +45,7 @@ int inventory_put (struct inventory *inv, json_t *R, const char *method);
  */
 struct idset *inventory_targets_to_ranks (struct inventory *inv,
                                           const char *targets,
-                                          char *errbuf,
-                                          int errsize);
+                                          flux_error_t *errp);
 
 #endif /* !_FLUX_RESOURCE_INVENTORY_H */
 

--- a/src/modules/resource/rutil.h
+++ b/src/modules/resource/rutil.h
@@ -38,9 +38,9 @@ int rutil_set_json_idset (json_t *o,
  *   a JSON object with ranks as keys and XML strings as values.
  * On error put human readable error in errbuf and return NULL
  */
-char *rutil_read_file (const char *path, char *errbuf, int errbufsize);
-json_t *rutil_load_file (const char *path, char *errbuf, int errbufsize);
-json_t *rutil_load_xml_dir (const char *path, char *errbuf, int errbufsize);
+char *rutil_read_file (const char *path, flux_error_t *errp);
+json_t *rutil_load_file (const char *path, flux_error_t *errp);
+json_t *rutil_load_xml_dir (const char *path, flux_error_t *errp);
 
 /* Build object with idset keys.
  * Start with empty json_t object, then insert objects by id.

--- a/src/modules/resource/test/rutil.c
+++ b/src/modules/resource/test/rutil.c
@@ -181,18 +181,18 @@ static char *create_tmp_file (const char *content)
 
 void test_read_file (void)
 {
-    char ebuf[128];
+    flux_error_t error;
     char *s;
     char *tmp = create_tmp_file ("XXX");
 
     errno = 0;
-    ebuf[0] = '\0';
-    s = rutil_read_file ("/noexist", ebuf, sizeof (ebuf));
-    ok (s == NULL && errno == ENOENT && strlen (ebuf) > 0,
+    error.text[0] = '\0';
+    s = rutil_read_file ("/noexist", &error);
+    ok (s == NULL && errno == ENOENT && strlen (error.text) > 0,
          "rutil_read_file path=/noexist fails with ENOENT and human error");
-    diag ("%s", ebuf);
+    diag ("%s", error.text);
 
-    s = rutil_read_file (tmp, ebuf, sizeof (ebuf));
+    s = rutil_read_file (tmp, &error);
     ok (s != NULL && !strcmp (s, "XXX"),
         "rutil_read_file works");
     free (s);
@@ -202,26 +202,26 @@ void test_read_file (void)
 
 void test_load_file (void)
 {
-    char ebuf[128];
+    flux_error_t error;
     json_t *o;
     char *good = create_tmp_file ("{\"foo\":42}");
     char *bad = create_tmp_file ("XXX");
 
     errno = 0;
-    ebuf[0] = '\0';
-    o = rutil_load_file ("/noexist", ebuf, sizeof (ebuf));
-    ok (o == NULL && errno == ENOENT && strlen (ebuf) > 0,
+    error.text[0] = '\0';
+    o = rutil_load_file ("/noexist", &error);
+    ok (o == NULL && errno == ENOENT && strlen (error.text) > 0,
          "rutil_load_file path=/noexist fails with ENOENT and human error");
-    diag ("%s", ebuf);
+    diag ("%s", error.text);
 
     errno = 0;
-    ebuf[0] = '\0';
-    o = rutil_load_file (bad, ebuf, sizeof (ebuf));
-    ok (o == NULL && errno != 0 && strlen (ebuf) > 0,
+    error.text[0] = '\0';
+    o = rutil_load_file (bad, &error);
+    ok (o == NULL && errno != 0 && strlen (error.text) > 0,
          "rutil_load_file with errno and human error on bad JSON");
-    diag ("%s", ebuf);
+    diag ("%s", error.text);
 
-    o = rutil_load_file (good, ebuf, sizeof (ebuf));
+    o = rutil_load_file (good, &error);
     ok (o != NULL && json_object_get (o, "foo"),
          "rutil_load_file with good JSON works");
     json_decref (o);
@@ -264,17 +264,17 @@ void test_load_xml_dir (void)
 {
     const int count = 8;
     char *path = create_tmp_xml_dir (count);
-    char ebuf[128];
+    flux_error_t error;
     json_t *o;
 
     errno = 0;
-    ebuf[0] = '\0';
-    o = rutil_load_xml_dir ("/noexist", ebuf, sizeof (ebuf));
-    ok (o == NULL && errno == ENOENT && strlen (ebuf) > 0,
+    error.text[0] = '\0';
+    o = rutil_load_xml_dir ("/noexist", &error);
+    ok (o == NULL && errno == ENOENT && strlen (error.text) > 0,
          "rutil_load_xml_dir path=/noexist fails with ENOENT and human error");
-    diag ("%s", ebuf);
+    diag ("%s", error.text);
 
-    o = rutil_load_xml_dir (path, ebuf, sizeof (ebuf));
+    o = rutil_load_xml_dir (path, &error);
     ok (o != NULL,
         "rutil_load_xml_dir works");
     if (o) {


### PR DESCRIPTION
While working on #4383, review comments noted that I did not use `flux_error_t` and `errprintf()` for writing out error messages in the `kvs` module.  It ended up I had copied the style of usage from the `resource` module.

I noticed that style was still used in a number of places, so updated its usage in lots of places.  Hopefully I did not go too overboard and update more than I should have :-|  This was not a super deep audit.

Note that in a few locations the char buf size was larger than the 160 bytes of `flux_error_t` (like 256).  We could make `flux_error_t` larger?  But I suspect the 256 bytes was arbitrarily chosen and unlikely to matter.
