### PR TITLE
jobtap: add conf.update callback

### DIFF
--- a/doc/man7/flux-jobtap-plugins.rst
+++ b/doc/man7/flux-jobtap-plugins.rst
@@ -109,10 +109,10 @@ annotations by returning a value for the ``annotations`` key::
 
 .. _callback_topics:
 
-CALLBACK TOPICS
-===============
+JOB CALLBACK TOPICS
+===================
 
-The following callback "topic strings" are currently provided by the
+The following job callback "topic strings" are currently provided by the
 *jobtap* interface:
 
 job.create
@@ -219,6 +219,23 @@ job.priority.get
   all jobs by calling ``flux_jobtap_reprioritize_all()``. See the
   :ref:`priority` section for more information about plugin management
   of job priority.
+
+CONFIGURATION CALLBACK TOPIC
+============================
+
+Jobtap plugins may register a ``conf.update`` callback.  The current/proposed
+configuration object is present in the input arguments under the ``conf`` key.
+The callback is invoked in the following circumstances:
+
+  - When the plugin is first loaded.  If the callback returns failure,
+    the plugin load fails.
+
+  - Each time the configuration changes.  If the callback returns failure,
+    ``flux config reload`` fails.
+
+The callback should return 0 on success, and -1 on failure.  On failure,
+it may optionally set a human readable error string in the ``errstr`` output
+argument.  The ``flux_jobtap_error()`` convenience function may be useful here.
 
 .. _priority:
 

--- a/src/common/libutil/errprintf.c
+++ b/src/common/libutil/errprintf.c
@@ -18,22 +18,28 @@
 
 #include "errprintf.h"
 
-int errprintf (flux_error_t *errp, const char *fmt, ...)
+int verrprintf (flux_error_t *errp, const char *fmt, va_list ap)
 {
     if (errp) {
         int saved_errno = errno;
         memset (errp->text, 0, sizeof (errp->text));
         if (fmt) {
-            va_list ap;
             int n;
-            va_start (ap, fmt);
             n = vsnprintf (errp->text, sizeof (errp->text), fmt, ap);
             if (n > sizeof (errp->text))
                 errp->text[sizeof (errp->text) - 2] = '+';
-            va_end (ap);
         }
         errno = saved_errno;
     }
+    return -1;
+}
+
+int errprintf (flux_error_t *errp, const char *fmt, ...)
+{
+    va_list ap;
+    va_start (ap, fmt);
+    verrprintf (errp, fmt, ap);
+    va_end (ap);
     return -1;
 }
 

--- a/src/common/libutil/errprintf.h
+++ b/src/common/libutil/errprintf.h
@@ -11,6 +11,8 @@
 #ifndef _UTIL_ERRPRINTF_H
 #define _UTIL_ERRPRINTF_H
 
+#include <stdarg.h>
+
 #include "src/common/libflux/types.h" /* flux_error_t */
 
 /*
@@ -23,6 +25,9 @@
  */
 int errprintf (flux_error_t *errp, const char *fmt, ...)
      __attribute__ ((format (printf, 2, 3)));
+
+int verrprintf (flux_error_t *errp, const char *fmt, va_list ap);
+
 
 #endif /* !_UTIL_ERRPRINTF_H */
 

--- a/src/modules/job-manager/jobtap.c
+++ b/src/modules/job-manager/jobtap.c
@@ -461,7 +461,7 @@ static int load_builtins (struct jobtap *jobtap)
          *  If the size of the builtins list gets large this should be
          *   revisited.
          */
-        if (jobtap_load (jobtap, builtin->name, NULL, NULL) < 0)
+        if (!jobtap_load (jobtap, builtin->name, NULL, NULL))
             return -1;
         builtin++;
     }

--- a/src/modules/job-manager/jobtap.c
+++ b/src/modules/job-manager/jobtap.c
@@ -1275,7 +1275,7 @@ static int jobtap_handle_load_req (struct job_manager *ctx,
         if (flux_respond_error (ctx->h,
                                 msg,
                                 errno ? errno : EINVAL,
-                                error.text) < 0)
+                                error.text[0] ? error.text : NULL) < 0)
             flux_log_error (ctx->h, "jobtap_handler: flux_respond_error");
         return -1;
     }

--- a/src/modules/job-manager/jobtap.c
+++ b/src/modules/job-manager/jobtap.c
@@ -450,6 +450,7 @@ static int plugin_byname (const void *item1, const void *item2)
 static int load_builtins (struct jobtap *jobtap)
 {
     struct jobtap_builtin *builtin = jobtap_builtins;
+    flux_error_t error;
 
     while (builtin && builtin->name) {
         /*  Yes, this will require re-scanning the builtin plugin list
@@ -461,8 +462,14 @@ static int load_builtins (struct jobtap *jobtap)
          *  If the size of the builtins list gets large this should be
          *   revisited.
          */
-        if (!jobtap_load (jobtap, builtin->name, NULL, NULL))
+        if (!jobtap_load (jobtap, builtin->name, NULL, &error)) {
+            flux_log (jobtap->ctx->h,
+                      LOG_ERR,
+                      "jobtap: %s: %s",
+                      builtin->name,
+                      error.text);
             return -1;
+        }
         builtin++;
     }
     return 0;

--- a/src/modules/job-manager/jobtap.h
+++ b/src/modules/job-manager/jobtap.h
@@ -56,11 +56,19 @@ int flux_jobtap_reprioritize_job (flux_plugin_t *p,
 int flux_jobtap_priority_unavail (flux_plugin_t *p,
                                   flux_plugin_arg_t *args);
 
-/*  Convenience function to be used in job.validate callback to reject a
- *   job with error message formatted by the fmt string.
- *   returns -1 to allow an idiom like:
+/*  Convenience function to set 'errstr' in return args to formatted message.
+ *   returns -1 to allow an idiom like
  *
- *   return flux_jobtap_reject_job (p, args, "failed validation");
+ *   return flux_jobtap_error (p, args, "error message");
+ */
+int flux_jobtap_error (flux_plugin_t *p,
+                       flux_plugin_arg_t *args,
+                       const char *fmt, ...)
+                       __attribute__ ((format (printf, 3, 4)));
+
+/*  Convenience function to be used in job.validate callback to reject a job.
+ *   Identical to flux_jobtap_error () except if 'fmt' is NULL, a default
+ *   message of the form "rejected by job-manager plugin <name>" is substituted.
  */
 int flux_jobtap_reject_job (flux_plugin_t *p,
                             flux_plugin_arg_t *args,

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -429,6 +429,7 @@ check_LTLIBRARIES = \
 	job-manager/plugins/create-event.la \
 	job-manager/plugins/create-reject.la \
 	job-manager/plugins/perilog-test.la \
+	job-manager/plugins/config.la \
 	stats/stats-basic.la \
 	stats/stats-immediate.la
 
@@ -910,6 +911,14 @@ job_manager_plugins_create_reject_la_LDFLAGS = \
 job_manager_plugins_create_reject_la_LIBADD = \
 	$(top_builddir)/src/common/libflux-core.la
 
+job_manager_plugins_config_la_SOURCES = \
+	job-manager/plugins/config.c
+job_manager_plugins_config_la_CPPFLAGS = \
+	$(test_cppflags)
+job_manager_plugins_config_la_LDFLAGS = \
+	$(fluxplugin_ldflags) -module -rpath /nowhere
+job_manager_plugins_config_la_LIBADD = \
+	$(top_builddir)/src/common/libflux-core.la
 
 job_manager_plugins_perilog_test_la_SOURCES = \
 	job-manager/plugins/perilog-test.c

--- a/t/job-manager/plugins/config.c
+++ b/t/job-manager/plugins/config.c
@@ -1,0 +1,43 @@
+/************************************************************\
+ * Copyright 2022 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* config.c - test conf.update callback
+ */
+
+#include <jansson.h>
+#include <flux/jobtap.h>
+
+static int conf_update_cb (flux_plugin_t *p,
+                           const char *topic,
+                           flux_plugin_arg_t *args,
+                           void *arg)
+{
+    const char *test;
+
+    if (flux_plugin_arg_unpack (args,
+                                FLUX_PLUGIN_ARG_IN,
+                                "{s:{s:{s:s}}}",
+                                "conf",
+                                  "testconfig",
+                                    "testkey", &test) < 0)
+        return flux_jobtap_error (p,
+                                  args,
+                                  "Error parsing [testconfig]: %s",
+                                  flux_plugin_arg_strerror (args));
+    return 0;
+}
+
+
+int flux_plugin_init (flux_plugin_t *p)
+{
+    return flux_plugin_add_handler (p, "conf.update", conf_update_cb, NULL);
+}
+
+// vi:ts=4 sw=4 expandtab


### PR DESCRIPTION
Problem: jobtap plugins have no simple way to be notified when TOML configuration changes. 

This adds a `conf.update` callback topic.  It is called 
- when the plugin is initially loaded
- each time `flux config reload` is run

The "proposed" config object is found in the callback input arguments under `conf`.  The plugin may reject the configuration by returning  `flux_jobtap_error()` with a human readable error (preferably calling out the offending TOML section).  If the config is rejected at plugin load time, the plugin load fails, e.g.
```
$ flux jobtap load config.so
flux-jobtap: ERROR: [Errno 22] Error parsing [testconfig]: Object item not found: testconfig
```
or if rejected at config reload time, `flux config reload` fails, e.g.
```
$ flux config reload
flux-config: reload: job-manager: Error parsing [testconfig]: Expected string, got integer
```

Note that this callback is not mandatory for access to configuration, since plugins can always fetch the current configuration object by calling
```c
flux_get_conf (flux_jobtap_get_flux (plugin))
```

Split from #4386