### PR TITLE
job-manager: fix race in job eventlog commit and job shell start

### DIFF
--- a/src/modules/job-manager/event.h
+++ b/src/modules/job-manager/event.h
@@ -50,6 +50,10 @@ int event_batch_pub_state (struct event *event, struct job *job,
  */
 int event_batch_respond (struct event *event, const flux_msg_t *msg);
 
+/* Add job to batch, job event handling will be paused until batch completion.
+ */
+int event_batch_add_job (struct event *event, struct job *job);
+
 /* Post event 'name' and optionally 'context' to 'job'.
  * Internally, calls event_job_update(), then event_job_action(), then commits
  * the event to job KVS eventlog.  The KVS commit completes asynchronously.

--- a/src/modules/job-manager/job.h
+++ b/src/modules/job-manager/job.h
@@ -44,6 +44,7 @@ struct job {
     uint8_t start_pending:1;// start request sent to job-exec
     uint8_t reattach:1;
     uint8_t eventlog_readonly:1;// job is inactive or invalid
+    uint8_t hold_events:1;  // queue events instead of posting immediately
 
     uint8_t perilog_active; // if nonzero, prolog/epilog active
 

--- a/src/modules/job-manager/submit.c
+++ b/src/modules/job-manager/submit.c
@@ -110,6 +110,15 @@ static int submit_job (struct job_manager *ctx,
      */
     (void) jobtap_call (ctx->jobtap, job, "job.new", NULL);
 
+    /* Add this job to current commit batch. This pauses event processing
+     *  for the job until the current batch is committed to the KVS. This
+     *  ensures that the job eventlog is available in the KVS before further
+     *  state transitions for the job are made (i.e. before the job is
+     *  allocated resources and is started by the job exec system.)
+     */
+    if (event_batch_add_job (ctx->event, job) < 0)
+        goto error;
+
     /* Post the validate event.
      */
     if (event_job_post_pack (ctx->event, job, "validate", 0, NULL) < 0) {


### PR DESCRIPTION
As described in #4409, this PR fixes the race between eventlog creation in the job manager and job startup by adding a flag which queues events until the initial submit event in the eventlog is committed to the KVS.

Additionally, the event batch timeout is made tunable at runtime via a new `job-manager.set-event-timeout` RPC (much easier to use than a module option), and that is used in a reproducer in the tesuite using @chu11's trick of extending the timeout to 1s.

