### PR TITLE
job-manager: add limits plugins for duration and job size

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -294,7 +294,8 @@ MAN5_FILES_PRIMARY = \
 	man5/flux-config-archive.5 \
 	man5/flux-config-job-manager.5 \
 	man5/flux-config-ingest.5 \
-	man5/flux-config-kvs.5
+	man5/flux-config-kvs.5 \
+	man5/flux-config-policy.5
 
 
 MAN7_FILES = $(MAN7_FILES_PRIMARY)

--- a/doc/man5/flux-config-policy.rst
+++ b/doc/man5/flux-config-policy.rst
@@ -1,0 +1,108 @@
+=====================
+flux-config-policy(5)
+=====================
+
+
+DESCRIPTION
+===========
+
+The ``policy`` table captures general site preferences for job request defaults
+and limits, as described in RFC 33.
+
+Each queue defined in the ``queues`` table described in
+:man5:`flux-config-queues` may have a ``policy`` sub-table that follows the
+same rules as the main table.  The per-queue table overrides the general table
+for jobs submitted to that queue.
+
+DEFAULTS
+========
+
+Default values for job requests may be configured in the
+``policy.jobspec.defaults.system`` table.  If a job request does not specify
+a value for a system attribute that is configured in the table, the configured
+value is substituted.  Some common examples are:
+
+policy.jobspec.defaults.system.duration (float seconds or FSD string)
+   (optional) If a job is submitted without specifying a job duration,
+   this value is substituted.
+
+policy.jobspec.defaults.system.queue (string)
+   (optional) If a job is submitted without specifying a queue name,
+   this value is substituted.
+
+LIMITS
+======
+
+Limits may be configured in the ``policy.limits`` table.  Job requests are
+rejected at submission time if they violate configured limits.
+
+.. note::
+   It is possible to set a queue-specific limit to an `unlimited` value,
+   and thereby defeat a configured general limit for jobs submitted to that
+   queue.  The actual value used to indicate `unlimited` varies by limit
+   type and is noted below.
+
+policy.limits.duration (float seconds or FSD string)
+   (optional) Maximum duration that a job may request (0 = unlimited).
+
+.. note::
+   Limit checks take place before the scheduler sees the request, so it is
+   possible to bypass a node limit by requesting only cores, or the core limit
+   by requesting only nodes (exclusively) since this part of the system does
+   not have detailed resource information.  Generally node and core limits
+   should be configured in tandem to be effective on resource sets with
+   uniform cores per node.  Flux does not yet have a solution for node/core
+   limits on heterogeneous resources.
+
+policy.limits.job-size.max.nnodes (integer)
+   (optional) Maximum number of nodes that may be requested (-1 = unlimited).
+
+policy.limits.job-size.max.ncores (integer)
+   (optional) Maximum number of cores that may be requested (-1 = unlimited).
+
+policy.limits.job-size.max.ngpus (integer)
+   (optional) Maximum number of GPUs that may be requested (-1 = unlimited).
+
+policy.limits.job-size.min.nnodes (integer)
+   (optional) Minimum number of nodes that may be requested (-1 = unlimited).
+
+policy.limits.job-size.min.ncores (integer)
+   (optional) Minimum number of cores that may be requested (-1 = unlimited).
+
+policy.limits.job-size.min.ngpus (integer)
+   (optional) Minimum number of GPUs that may be requested (-1 = unlimited).
+
+
+
+EXAMPLE
+=======
+
+::
+
+   [policy.defaults]
+   duration = "1h"
+   queue = "pbatch"
+
+   [policy.limits]
+   duration = "4h"
+   job-size.max.nnodes = 8
+   job-size.max.gpus = 4
+
+   [queues.pdebug.policy.limits]
+   duration = "30m"
+   job-size.max.gpus = -1  # unlimited
+
+
+RESOURCES
+=========
+
+Flux: http://flux-framework.org
+
+RFC 23: Flux Standard Duration: https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/spec_23.html
+
+RFC 33: Flux Job Queues: https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/spec_33.html
+
+SEE ALSO
+========
+
+:man5:`flux-config`

--- a/doc/man5/index.rst
+++ b/doc/man5/index.rst
@@ -14,3 +14,4 @@ man5
    flux-config-resource
    flux-config-archive
    flux-config-job-manager
+   flux-config-policy

--- a/doc/manpages.py
+++ b/doc/manpages.py
@@ -282,6 +282,7 @@ man_pages = [
     ('man5/flux-config-ingest', 'flux-config-ingest', 'configure Flux job ingest service', [author], 5),
     ('man5/flux-config-resource', 'flux-config-resource', 'configure Flux resource service', [author], 5),
     ('man5/flux-config-archive', 'flux-config-archive', 'configure Flux job archival service', [author], 5),
+    ('man5/flux-config-policy', 'flux-config-policy', 'configure Flux job policy', [author], 5),
     ('man5/flux-config-job-manager', 'flux-config-job-manager', 'configure Flux job manager service', [author], 5),
     ('man5/flux-config-kvs', 'flux-config-kvs', 'configure Flux kvs service', [author], 5),
     ('man7/flux-broker-attributes', 'flux-broker-attributes', 'overview Flux broker attributes', [author], 7),

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -630,3 +630,5 @@ EDEADLOCK
 setpgrp
 nosetpgrp
 checkpointed
+pbatch
+pdebug

--- a/src/common/libjob/Makefile.am
+++ b/src/common/libjob/Makefile.am
@@ -34,7 +34,9 @@ libjob_la_SOURCES = \
 	jobspec1.c \
 	jobspec1_private.h \
 	strtab.c \
-	strtab.h
+	strtab.h \
+	jj.c \
+	jj.h
 
 TESTS = \
 	test_job.t \

--- a/src/common/libjob/jj.c
+++ b/src/common/libjob/jj.c
@@ -16,7 +16,7 @@
 #include <string.h>
 #include <jansson.h>
 
-#include "libjj.h"
+#include "jj.h"
 
 static int jj_read_level (json_t *o, int level, struct jj_counts *jj);
 
@@ -82,7 +82,7 @@ static int jj_read_level (json_t *o, int level, struct jj_counts *jj)
     return 0;
 }
 
-int libjj_get_counts (const char *spec, struct jj_counts *jj)
+int jj_get_counts (const char *spec, struct jj_counts *jj)
 {
     json_t *o = NULL;
     json_error_t error;
@@ -95,12 +95,12 @@ int libjj_get_counts (const char *spec, struct jj_counts *jj)
         return -1;
     }
 
-    rc = libjj_get_counts_json (o, jj);
+    rc = jj_get_counts_json (o, jj);
     json_decref (o);
     return rc;
 }
 
-int libjj_get_counts_json (json_t *jobspec, struct jj_counts *jj)
+int jj_get_counts_json (json_t *jobspec, struct jj_counts *jj)
 {
     int version;
     json_t *resources = NULL;

--- a/src/common/libjob/jj.c
+++ b/src/common/libjob/jj.c
@@ -53,6 +53,8 @@ static int jj_read_vertex (json_t *o, int level, struct jj_counts *jj)
         jj->nslots = count;
     else if (strcmp (type, "core") == 0)
         jj->slot_size = count;
+    else if (strcmp (type, "gpu") == 0)
+        jj->slot_gpus = count;
     else {
         sprintf (jj->error, "Unsupported resource type '%s'", type);
         errno = EINVAL;

--- a/src/common/libjob/jj.h
+++ b/src/common/libjob/jj.h
@@ -24,6 +24,7 @@ struct jj_counts {
     int nnodes;    /* total number of nodes requested */
     int nslots;    /* total number of slots requested */
     int slot_size; /* number of cores per slot        */
+    int slot_gpus; /* number of gpus per slot        */
 
     bool exclusive;  /* enable node exclusive allocation if available */
 

--- a/src/common/libjob/jj.h
+++ b/src/common/libjob/jj.h
@@ -8,8 +8,8 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
-#ifndef HAVE_SCHED_LIBJJ_H
-#define HAVE_SCHED_LIBJJ_H 1
+#ifndef HAVE_JJ_H
+#define HAVE_JJ_H 1
 
 #if HAVE_CONFIG_H
 #include "config.h"
@@ -38,9 +38,9 @@ struct jj_counts {
  *   with an error message string.
  */
 
-int libjj_get_counts (const char *spec, struct jj_counts *counts);
+int jj_get_counts (const char *spec, struct jj_counts *counts);
 
-/*  Identical to libjj_get_counts, but take json_t  */
-int libjj_get_counts_json (json_t *jobspec, struct jj_counts *counts);
+/*  Identical to jj_get_counts, but take json_t  */
+int jj_get_counts_json (json_t *jobspec, struct jj_counts *counts);
 
-#endif /* !HAVE_SCHED_LIBJJ_H */
+#endif /* !HAVE_JJ_H */

--- a/src/modules/job-manager/Makefile.am
+++ b/src/modules/job-manager/Makefile.am
@@ -69,6 +69,7 @@ libjob_manager_la_SOURCES = \
 	jobtap.c \
 	plugins/priority-default.c \
 	plugins/jobspec-default.c \
+	plugins/limit-job-size.c \
 	plugins/dependency-after.c \
 	plugins/begin-time.c \
 	plugins/validate-duration.c

--- a/src/modules/job-manager/Makefile.am
+++ b/src/modules/job-manager/Makefile.am
@@ -70,6 +70,7 @@ libjob_manager_la_SOURCES = \
 	plugins/priority-default.c \
 	plugins/jobspec-default.c \
 	plugins/limit-job-size.c \
+	plugins/limit-duration.c \
 	plugins/dependency-after.c \
 	plugins/begin-time.c \
 	plugins/validate-duration.c

--- a/src/modules/job-manager/jobtap.c
+++ b/src/modules/job-manager/jobtap.c
@@ -43,6 +43,7 @@
 
 extern int priority_default_plugin_init (flux_plugin_t *p);
 extern int jobspec_default_plugin_init (flux_plugin_t *p);
+extern int limit_job_size_plugin_init (flux_plugin_t *p);
 extern int after_plugin_init (flux_plugin_t *p);
 extern int begin_time_plugin_init (flux_plugin_t *p);
 extern int validate_duration_plugin_init (flux_plugin_t *p);
@@ -55,6 +56,7 @@ struct jobtap_builtin {
 static struct jobtap_builtin jobtap_builtins [] = {
     { ".priority-default", priority_default_plugin_init },
     { ".jobspec-default", jobspec_default_plugin_init },
+    { ".limit-job-size", limit_job_size_plugin_init },
     { ".dependency-after", after_plugin_init },
     { ".begin-time", &begin_time_plugin_init },
     { ".validate-duration", &validate_duration_plugin_init },

--- a/src/modules/job-manager/jobtap.c
+++ b/src/modules/job-manager/jobtap.c
@@ -44,6 +44,7 @@
 extern int priority_default_plugin_init (flux_plugin_t *p);
 extern int jobspec_default_plugin_init (flux_plugin_t *p);
 extern int limit_job_size_plugin_init (flux_plugin_t *p);
+extern int limit_duration_plugin_init (flux_plugin_t *p);
 extern int after_plugin_init (flux_plugin_t *p);
 extern int begin_time_plugin_init (flux_plugin_t *p);
 extern int validate_duration_plugin_init (flux_plugin_t *p);
@@ -57,6 +58,7 @@ static struct jobtap_builtin jobtap_builtins [] = {
     { ".priority-default", priority_default_plugin_init },
     { ".jobspec-default", jobspec_default_plugin_init },
     { ".limit-job-size", limit_job_size_plugin_init },
+    { ".limit-duration", limit_duration_plugin_init },
     { ".dependency-after", after_plugin_init },
     { ".begin-time", &begin_time_plugin_init },
     { ".validate-duration", &validate_duration_plugin_init },

--- a/src/modules/job-manager/plugins/jobspec-default.c
+++ b/src/modules/job-manager/plugins/jobspec-default.c
@@ -255,7 +255,7 @@ static json_t *generate_update (json_t *defaults, json_t *jobspec)
          */
         if (val != NULL
             && streq (key, "duration")
-            && json_real_value (val) == 0)
+            && json_number_value (val) == 0)
             val = NULL;
 
         if (val == NULL) {

--- a/src/modules/job-manager/plugins/limit-duration.c
+++ b/src/modules/job-manager/plugins/limit-duration.c
@@ -1,0 +1,341 @@
+/************************************************************\
+ * Copyright 2022 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* limit-duration.c - validate job requests against configured duration limits
+ *
+ * This plugin uses the job.validate callback to accept or reject job
+ * requests.  Any default jobspec values would have been applied earlier
+ * (where applicable) in the job.create callback.
+ *
+ * General limit:
+ *  policy.limits.duration
+ * Queue-specific limit:
+ *  queues.<name>.policy.limits.duration
+ *
+ * N.B. a queue limit may override the general limit with a higher or lower
+ * limit, even "unlimited" (0).
+ *
+ * See also:
+ *  RFC 33/Flux Job Queues
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <jansson.h>
+#include <flux/core.h>
+#include <flux/jobtap.h>
+
+#include "src/common/libutil/fsd.h"
+#include "src/common/libutil/errprintf.h"
+#include "src/common/libutil/errno_safe.h"
+#include "src/common/libczmqcontainers/czmq_containers.h"
+#include "ccan/str/str.h"
+
+struct limit_duration {
+    double general_limit;   // general duration limit (seconds)
+    zhashx_t *queues;       // queue name => duration limit (double * seconds)
+    flux_t *h;
+};
+
+#define DURATION_INVALID      (-1)
+#define DURATION_UNLIMITED    (0)
+
+static const char *auxkey = "limit-duration";
+
+// zhashx_destructor_fn footprint
+static void duration_destroy (void **item)
+{
+    if (item) {
+        free (*item);
+        *item = NULL;
+    }
+}
+
+// zhashx_duplicator_fn footprint
+static void *duration_duplicate (const void *item)
+{
+    double *cpy;
+    if (!(cpy = calloc (1, sizeof (*cpy))))
+        return NULL;
+    *cpy = *(double *)item;
+    return cpy;
+}
+
+static zhashx_t *queues_create (void)
+{
+    zhashx_t *queues;
+
+    if (!(queues = zhashx_new ())) {
+        errno = ENOMEM;
+        return NULL;
+    }
+    zhashx_set_destructor (queues, duration_destroy);
+    zhashx_set_duplicator (queues, duration_duplicate);
+    return queues;
+}
+
+static double queues_lookup (zhashx_t *queues, const char *name)
+{
+    double *dp;
+
+    if (name && (dp = zhashx_lookup (queues, name)))
+        return *dp;
+    return DURATION_INVALID;
+}
+
+static int queues_insert (zhashx_t *queues, const char *name, double duration)
+{
+    if (zhashx_insert (queues, name, &duration) < 0) { // dups duration
+        errno = ENOMEM;
+        return -1;
+    }
+    return 0;
+}
+
+static void limit_duration_destroy (struct limit_duration *ctx)
+{
+    if (ctx) {
+        int saved_errno = errno;
+        zhashx_destroy (&ctx->queues);
+        free (ctx);
+        errno = saved_errno;
+    }
+}
+
+static struct limit_duration *limit_duration_create (flux_t *h)
+{
+    struct limit_duration *ctx;
+
+    if (!(ctx = calloc (1, sizeof (*ctx))))
+        return NULL;
+    if (!(ctx->queues = queues_create ()))
+        goto error;
+    ctx->h = h;
+    ctx->general_limit = DURATION_INVALID;
+    return ctx;
+error:
+    limit_duration_destroy (ctx);
+    return NULL;
+}
+
+static int duration_parse (double *duration,
+                           json_t *conf,
+                           flux_error_t *error)
+{
+    double d = DURATION_INVALID;
+    json_t *o = NULL;
+    json_error_t jerror;
+    const char *name = "policy.limits.duration";
+
+    if (json_unpack_ex (conf,
+                        &jerror,
+                        0,
+                        "{s?{s?{s?o}}}",
+                        "policy",
+                          "limits",
+                            "duration", &o) < 0) {
+        errprintf (error, "%s: %s", name, jerror.text);
+        return -1;
+    }
+    if (o) {
+        if (json_is_string (o)) {
+            if (fsd_parse_duration (json_string_value (o), &d) < 0) {
+                errprintf (error, "%s: FSD value is malformed", name);
+                return -1;
+            }
+        }
+        else if (json_is_number (o)) {
+            if ((d = json_number_value (o)) < 0) {
+                errprintf (error, "%s: must be >= 0", name);
+                goto inval;
+            }
+        }
+        else {
+            errprintf (error, "%s: must be FSD (string) or seconds", name);
+            goto inval;
+        }
+    }
+    *duration = d;
+    return 0;
+inval:
+    errno = EINVAL;
+    return -1;
+}
+
+static int queues_parse (zhashx_t **zhp,
+                         json_t *conf,
+                         flux_error_t *error)
+{
+    json_t *queues;
+    zhashx_t *zh;
+
+    if (!(zh = queues_create ())) {
+        errprintf (error, "out of memory parsing [queues]");
+        goto error;
+    }
+    if ((queues = json_object_get (conf, "queues"))) {
+        const char *name;
+        json_t *entry;
+        double duration;
+        flux_error_t e;
+
+        json_object_foreach (queues, name, entry) {
+            if (duration_parse (&duration, entry, &e) < 0) {
+                errprintf (error, "queues.%s.%s", name, e.text);
+                goto error;
+            }
+            if (queues_insert (zh, name, duration) < 0) {
+                errprintf (error, "out of memory parsing [queues]");
+                goto error;
+            }
+        }
+    }
+    *zhp = zh;
+    return 0;
+error:
+    ERRNO_SAFE_WRAP (zhashx_destroy, &zh);
+    return -1;
+}
+
+static int check_limit (struct limit_duration *ctx,
+                        double duration,
+                        const char *queue,
+                        flux_error_t *error)
+{
+    if (duration != DURATION_UNLIMITED) {
+        double limit = ctx->general_limit;
+        double qlimit = queues_lookup (ctx->queues, queue);
+
+        if (qlimit != DURATION_INVALID)
+            limit = qlimit;
+        if (limit != DURATION_INVALID
+            && limit != DURATION_UNLIMITED
+            && duration > limit) {
+            char fsd[64];
+            fsd_format_duration_ex (fsd, sizeof (fsd), limit, 1);
+            return errprintf (error,
+                              "requested duration exceeds policy limit of %s",
+                              fsd);
+        }
+    }
+    return 0;
+}
+
+static int validate_cb (flux_plugin_t *p,
+                        const char *topic,
+                        flux_plugin_arg_t *args,
+                        void *arg)
+{
+    struct limit_duration *ctx = flux_plugin_aux_get (p, auxkey);
+    flux_job_state_t state;
+    double duration = DURATION_UNLIMITED;
+    const char *queue = NULL;
+    flux_error_t error;
+
+    /* If no limits are configured, return immediately.  This is the common
+     * case for a non-system instance and since this plugin is always loaded,
+     * don't waste time.
+     */
+    if ((ctx->general_limit == DURATION_INVALID
+        || ctx->general_limit == DURATION_UNLIMITED)
+        && zhashx_size (ctx->queues) == 0)
+        return 0;
+
+    /* Parse jobspec attributes:
+     * - attributes.system.queue (NULL if unspecified)
+     * - attributes.system.duration (DURATION_UNLIMITED if unspecified)
+     */
+    if (flux_plugin_arg_unpack (args,
+                                FLUX_PLUGIN_ARG_IN,
+                                "{s:i s?{s?{s?{s?F s?s}}}}",
+                                "state", &state,
+                                "jobspec",
+                                  "attributes",
+                                    "system",
+                                      "duration", &duration,
+                                      "queue", &queue) < 0) {
+        errprintf (&error,
+                   "limit-duration: error unpacking job.validate arguments: %s",
+                   flux_plugin_arg_strerror (args));
+        goto error;
+    }
+
+    if (state != FLUX_JOB_STATE_NEW) // flux restart or plugin reload
+        return 0;
+
+    if (check_limit (ctx, duration, queue, &error) < 0)
+        goto error;
+
+    return 0;
+error:
+    flux_jobtap_reject_job (p, args, "%s", error.text);
+    return -1;
+}
+
+/* conf.update callback - called on plugin load, and when config is updated
+ * This function has two purposes:
+ * - Validate proposed 'conf' and return human readable errors if rejected
+ * - Pre-parse and cache the config in 'ctx' to streamline job validation
+ */
+static int conf_update_cb (flux_plugin_t *p,
+                           const char *topic,
+                           flux_plugin_arg_t *args,
+                           void *arg)
+{
+    struct limit_duration *ctx = flux_plugin_aux_get (p, auxkey);
+    flux_error_t error;
+    json_t *conf;
+    double duration;
+    zhashx_t *queues;
+
+    if (flux_plugin_arg_unpack (args,
+                                FLUX_PLUGIN_ARG_IN,
+                                "{s:o}",
+                                "conf", &conf) < 0) {
+        errprintf (&error,
+                   "limit-duration: error unpacking conf.update arguments: %s",
+                   flux_plugin_arg_strerror (args));
+        goto error;
+    }
+    if (duration_parse (&duration, conf, &error) < 0
+        || queues_parse (&queues, conf, &error) < 0)
+        goto error;
+    ctx->general_limit = duration;
+    zhashx_destroy (&ctx->queues);
+    ctx->queues = queues;
+    return 0;
+error:
+    return flux_jobtap_error (p, args, "%s", error.text);
+}
+
+static const struct flux_plugin_handler tab[] = {
+    { "job.validate", validate_cb, NULL },
+    { "conf.update", conf_update_cb, NULL },
+    { 0 }
+};
+
+int limit_duration_plugin_init (flux_plugin_t *p)
+{
+    struct limit_duration *ctx;
+
+    if (!(ctx = limit_duration_create (flux_jobtap_get_flux (p)))
+        || flux_plugin_aux_set (p,
+                                auxkey,
+                                ctx,
+                                (flux_free_f)limit_duration_destroy) < 0) {
+        limit_duration_destroy (ctx);
+        return -1;
+    }
+
+    return flux_plugin_register (p, ".limit-duration", tab);
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/src/modules/job-manager/plugins/limit-job-size.c
+++ b/src/modules/job-manager/plugins/limit-job-size.c
@@ -1,0 +1,481 @@
+/************************************************************\
+ * Copyright 2022 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* limit-job-size.c - validate job requests against configured job size limits
+ *
+ * This plugin uses the job.validate callback to accept or reject job
+ * requests.  Any default jobspec values would have been applied earlier
+ * (where applicable) in the job.create callback.
+ *
+ * General limit:
+ *  [policy.limits.job-size]
+ * Queue-specific limit:
+ *  [queues.<name>.policy.limits.job-size]
+ *
+ * N.B. a queue limit may override the general limit with a higher or lower
+ * limit, even "unlimited".  Since 0 may be a valid size limit, -1 is reserved
+ * to mean unlimited in this situation.
+ *
+ * See also:
+ *  RFC 33/Flux Job Queues
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <jansson.h>
+#include <flux/core.h>
+#include <flux/jobtap.h>
+
+#include "src/common/libjob/jj.h"
+#include "src/common/libutil/fsd.h"
+#include "src/common/libutil/errprintf.h"
+#include "src/common/libutil/errno_safe.h"
+#include "src/common/libczmqcontainers/czmq_containers.h"
+#include "ccan/str/str.h"
+
+#define SIZE_INVALID   (-2)
+#define SIZE_UNLIMITED (-1)
+
+#define SIZE_IS_OUT_OF_BOUNDS(n) \
+    ((n) < 0 && (n) != SIZE_INVALID && (n) != SIZE_UNLIMITED)
+
+#define LIMIT_OVER(limit,val) \
+    ((limit) != SIZE_INVALID && (limit) != SIZE_UNLIMITED && (val) > (limit))
+#define LIMIT_UNDER(limit,val) \
+    ((limit) != SIZE_INVALID && (limit) != SIZE_UNLIMITED && (val) < (limit))
+
+struct job_size {
+    int nnodes;
+    int ncores;
+    int ngpus;
+};
+
+struct limits {
+    struct job_size max;
+    struct job_size min;
+};
+
+struct limit_job_size {
+    struct limits general_limits;
+    zhashx_t *queues; // queue name => struct limits
+    flux_t *h;
+};
+
+const char *auxkey = "limit-job-size";
+
+static void job_size_clear (struct job_size *js)
+{
+    js->nnodes = SIZE_INVALID;
+    js->ncores = SIZE_INVALID;
+    js->ngpus = SIZE_INVALID;
+}
+
+static bool job_size_isset (struct job_size *js)
+{
+    if (js) {
+        if (js->nnodes != SIZE_INVALID
+            || js->ncores != SIZE_INVALID
+            || js->ngpus != SIZE_INVALID)
+            return true;
+    }
+    return false;
+}
+
+static void job_size_override (struct job_size *js1,
+                               struct job_size *js2)
+{
+    if (js1 && js2) {
+        if (js2->nnodes != SIZE_INVALID)
+            js1->nnodes = js2->nnodes;
+        if (js2->ncores != SIZE_INVALID)
+            js1->ncores = js2->ncores;
+        if (js2->ngpus != SIZE_INVALID)
+            js1->ngpus = js2->ngpus;
+    }
+}
+
+static void limits_clear (struct limits *l)
+{
+    job_size_clear (&l->max);
+    job_size_clear (&l->min);
+}
+
+static bool limits_isset (struct limits *l)
+{
+    if (l) {
+        if (job_size_isset (&l->max)
+            || job_size_isset (&l->min))
+            return true;
+    }
+    return false;
+}
+
+static void limits_override (struct limits *l1,
+                             struct limits *l2)
+{
+    if (l1 && l2) {
+        job_size_override (&l1->max, &l2->max);
+        job_size_override (&l1->min, &l2->min);
+    }
+}
+
+// zhashx_destructor_fn footprint
+static void limits_destroy (void **item)
+{
+    if (item) {
+        free (*item);
+        *item = NULL;
+    }
+}
+
+// zhashx_duplicator_fn footprint
+static void *limits_duplicate (const void *item)
+{
+    struct limits *limits;
+
+    if (!(limits = calloc (1, sizeof (*limits))))
+        return NULL;
+    *limits = *(struct limits *)item;
+    return limits;
+}
+
+static zhashx_t *queues_create (void)
+{
+    zhashx_t *queues;
+
+    if (!(queues = zhashx_new ())) {
+        errno = ENOMEM;
+        return NULL;
+    }
+    zhashx_set_destructor (queues, limits_destroy);
+    zhashx_set_duplicator (queues, limits_duplicate);
+    return queues;
+}
+
+static int queues_insert (zhashx_t *queues,
+                          const char *name,
+                          struct limits *limits)
+{
+    if (zhashx_insert (queues, name, limits) < 0) { // dups limits
+        errno = ENOMEM;
+        return -1;
+    }
+    return 0;
+}
+
+static struct limits *queues_lookup (zhashx_t *queues, const char *name)
+{
+    return queues ? zhashx_lookup (queues, name) : NULL;
+}
+
+static void limit_job_size_destroy (struct limit_job_size *ctx)
+{
+    if (ctx) {
+        int saved_errno = errno;
+        zhashx_destroy (&ctx->queues);
+        free (ctx);
+        errno = saved_errno;
+    }
+}
+
+static struct limit_job_size *limit_job_size_create (flux_t *h)
+{
+    struct limit_job_size *ctx;
+
+    if (!(ctx = calloc (1, sizeof (*ctx))))
+        return NULL;
+    if (!(ctx->queues = queues_create ()))
+        goto error;
+    ctx->h = h;
+    limits_clear (&ctx->general_limits);
+    return ctx;
+error:
+    limit_job_size_destroy (ctx);
+    return NULL;
+}
+
+static int job_size_parse (struct job_size *jsp,
+                           json_t *o,
+                           flux_error_t *error)
+{
+    struct job_size js;
+
+    job_size_clear (&js);
+    if (o) {
+        json_error_t jerror;
+
+        if (json_unpack_ex (o,
+                            &jerror,
+                            0,
+                            "{s?i s?i s?i}",
+                            "nnodes", &js.nnodes,
+                            "ncores", &js.ncores,
+                            "ngpus", &js.ngpus) < 0) {
+            errprintf (error, "%s", jerror.text);
+            errno = EINVAL;
+            return -1;
+        }
+        if (SIZE_IS_OUT_OF_BOUNDS (js.nnodes)
+            || SIZE_IS_OUT_OF_BOUNDS (js.ncores)
+            || SIZE_IS_OUT_OF_BOUNDS (js.ngpus)) {
+            errprintf (error, "size must be -1 (unlimited), or >= 0");
+            errno = EINVAL;
+            return -1;
+        }
+    }
+    *jsp = js;
+    return 0;
+}
+
+static int limits_parse (struct limits *limitsp,
+                         json_t *conf,
+                         flux_error_t *error)
+{
+    struct limits limits;
+    json_t *min = NULL;
+    json_t *max = NULL;
+    json_error_t jerror;
+    flux_error_t e;
+
+    if (json_unpack_ex (conf,
+                        &jerror,
+                        0,
+                        "{s?{s?{s?{s?o s?o}}}}",
+                        "policy",
+                          "limits",
+                            "job-size",
+                              "max", &max,
+                              "min", &min) < 0) {
+        errprintf (error, "policy.limits.job-size: %s", jerror.text);
+        return -1;
+    }
+    if (job_size_parse (&limits.max, max, &e) < 0) {
+        errprintf (error, "policy.limits.job-size.max: %s", e.text);
+        return -1;
+    }
+    if (job_size_parse (&limits.min, min, &e) < 0) {
+        errprintf (error, "policy.limits.job-size.min: %s", e.text);
+        return -1;
+    }
+    *limitsp = limits;
+    return 0;
+}
+
+static int queues_parse (zhashx_t **zhp,
+                         json_t *conf,
+                         flux_error_t *error)
+{
+    json_t *queues;
+    zhashx_t *zh;
+
+    if (!(zh = queues_create ())) {
+        errprintf (error, "out of memory parsing [queues]");
+        goto error;
+    }
+    if ((queues = json_object_get (conf, "queues"))) {
+        const char *name;
+        json_t *entry;
+        struct limits limits;
+        flux_error_t e;
+
+        json_object_foreach (queues, name, entry) {
+            if (limits_parse (&limits, entry, &e) < 0) {
+                errprintf (error, "queues.%s.%s", name, e.text);
+                goto error;
+            }
+            if (queues_insert (zh, name, &limits) < 0) {
+                errprintf (error, "out of memory parsing [queues]");
+                goto error;
+            }
+        }
+    }
+    *zhp = zh;
+    return 0;
+error:
+    ERRNO_SAFE_WRAP (zhashx_destroy, &zh);
+    return -1;
+}
+
+static int check_limits (struct limit_job_size *ctx,
+                         struct jj_counts *counts,
+                         const char *queue,
+                         flux_error_t *error)
+{
+    struct limits limits;
+    struct limits *queue_limits;
+
+    limits = ctx->general_limits;
+    if (queue && (queue_limits = queues_lookup (ctx->queues, queue)))
+        limits_override (&limits, queue_limits);
+
+    if (LIMIT_OVER (limits.max.nnodes, counts->nnodes)) {
+        return errprintf (error,
+                          "requested nnodes exceeds policy limit of %d",
+                          limits.max.nnodes);
+    }
+    if (LIMIT_OVER (limits.max.ncores, counts->nslots * counts->slot_size)) {
+        return errprintf (error,
+                          "requested ncores exceeds policy limit of %d",
+                          limits.max.ncores);
+    }
+    if (LIMIT_OVER (limits.max.ngpus, counts->nslots * counts->slot_gpus)) {
+        return errprintf (error,
+                          "requested ngpus exceeds policy limit of %d",
+                          limits.max.ngpus);
+    }
+    if (LIMIT_UNDER (limits.min.nnodes, counts->nnodes)) {
+        return errprintf (error,
+                          "requested nnodes is under policy limit of %d",
+                          limits.min.nnodes);
+    }
+    if (LIMIT_UNDER (limits.min.ncores, counts->nslots * counts->slot_size)) {
+        return errprintf (error,
+                          "requested ncores is under policy limit of %d",
+                          limits.min.ncores);
+    }
+    if (LIMIT_UNDER (limits.min.ngpus, counts->nslots * counts->slot_gpus)) {
+        return errprintf (error,
+                          "requested ngpus is under policy limit of %d",
+                          limits.min.ngpus);
+    }
+
+    return 0;
+}
+
+static int validate_cb (flux_plugin_t *p,
+                        const char *topic,
+                        flux_plugin_arg_t *args,
+                        void *arg)
+{
+    struct limit_job_size *ctx = flux_plugin_aux_get (p, auxkey);
+    flux_job_state_t state;
+    json_t *jobspec = NULL;
+    struct jj_counts counts;
+    const char *queue = NULL;
+    flux_error_t error;
+    json_error_t jerror;
+
+    /* If no limits are configured, return immediately.  This is the common
+     * case for a non-system instance and since this plugin is always loaded,
+     * don't waste time.
+     */
+    if (!limits_isset (&ctx->general_limits)
+        && zhashx_size (ctx->queues) == 0)
+        return 0;
+
+    if (flux_plugin_arg_unpack (args,
+                                FLUX_PLUGIN_ARG_IN,
+                                "{s:i s:o}",
+                                "state", &state,
+                                "jobspec", &jobspec) < 0) {
+        errprintf (&error,
+                   "limit-job-size: error unpacking job.validate arguments: %s",
+                   flux_plugin_arg_strerror (args));
+        goto error;
+    }
+
+    /* Jobs that have already been accepted must bypass the limits check.
+     * This occurs when Flux is restarted with pending jobs in the KVS.
+     */
+    if (state != FLUX_JOB_STATE_NEW)
+        return 0;
+
+    if (jj_get_counts_json (jobspec, &counts) < 0) {
+        errprintf (&error, "%s", counts.error);
+        goto error;
+    }
+
+    /* Parse (optional) jobspec attributes.system.queue.
+     * Leave queue NULL if unspecified.
+     * Throw an error if it's the wrong type or related.
+     */
+    if (json_unpack_ex (jobspec,
+                        &jerror,
+                        0,
+                        "{s?{s?{s?s}}}",
+                        "attributes",
+                          "system",
+                            "queue", &queue) < 0) {
+        errprintf (&error,
+                   "Error parsing jobspec attributes.system.queue: %s",
+                   jerror.text);
+        goto error;
+    }
+
+    if (check_limits (ctx, &counts, queue, &error) < 0)
+        goto error;
+
+    return 0;
+error:
+    flux_jobtap_reject_job (p, args, "%s", error.text);
+    return -1;
+}
+
+/* conf.update callback - called on plugin load, and when config is updated
+ * This function has two purposes:
+ * - Validate proposed 'conf' and return human readable errors if rejected
+ * - Pre-parse and cache the config in 'ctx' to streamline job validation
+ */
+static int conf_update_cb (flux_plugin_t *p,
+                           const char *topic,
+                           flux_plugin_arg_t *args,
+                           void *arg)
+{
+    struct limit_job_size *ctx = flux_plugin_aux_get (p, auxkey);
+    flux_error_t error;
+    json_t *conf;
+    struct limits limits;
+    zhashx_t *queues;
+
+    if (flux_plugin_arg_unpack (args,
+                                FLUX_PLUGIN_ARG_IN,
+                                "{s:o}",
+                                "conf", &conf) < 0) {
+        errprintf (&error,
+                   "limit-job-size: error unpacking conf.update arguments: %s",
+                   flux_plugin_arg_strerror (args));
+        goto error;
+    }
+    if (limits_parse (&limits, conf, &error) < 0)
+        goto error;
+    if (queues_parse (&queues, conf, &error) < 0)
+        goto error;
+    ctx->general_limits = limits;
+    zhashx_destroy (&ctx->queues);
+    ctx->queues = queues;
+    return 0;
+error:
+    return flux_jobtap_error (p, args, "%s", error.text);
+}
+
+static const struct flux_plugin_handler tab[] = {
+    { "job.validate", validate_cb, NULL },
+    { "conf.update", conf_update_cb, NULL },
+    { 0 }
+};
+
+int limit_job_size_plugin_init (flux_plugin_t *p)
+{
+    struct limit_job_size *ctx;
+
+    if (!(ctx = limit_job_size_create (flux_jobtap_get_flux (p)))
+        || flux_plugin_aux_set (p,
+                                auxkey,
+                                ctx,
+                                (flux_free_f)limit_job_size_destroy) < 0) {
+        limit_job_size_destroy (ctx);
+        return -1;
+    }
+
+    return flux_plugin_register (p, ".limit-job-size", tab);
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/src/modules/sched-simple/Makefile.am
+++ b/src/modules/sched-simple/Makefile.am
@@ -14,13 +14,6 @@ AM_CPPFLAGS = \
 fluxmod_LTLIBRARIES = \
 	sched-simple.la
 
-noinst_LTLIBRARIES = \
-	libjj.la
-
-libjj_la_SOURCES = \
-	libjj.h \
-	libjj.c
-
 sched_simple_la_SOURCES = \
 	sched.c
 
@@ -29,9 +22,9 @@ sched_simple_la_LDFLAGS = \
 	-module
 
 sched_simple_la_LIBADD = \
-	libjj.la \
 	$(top_builddir)/src/common/librlist/librlist.la \
 	$(top_builddir)/src/common/libschedutil/libschedutil.la \
+	$(top_builddir)/src/common/libjob/libjob.la \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la \
 	$(top_builddir)/src/common/libflux-optparse.la \

--- a/src/modules/sched-simple/sched.c
+++ b/src/modules/sched-simple/sched.c
@@ -18,8 +18,8 @@
 #include "src/common/libutil/errno_safe.h"
 #include "src/common/libutil/errprintf.h"
 #include "src/common/libjob/job.h"
+#include "src/common/libjob/jj.h"
 #include "src/common/librlist/rlist.h"
-#include "libjj.h"
 
 // e.g. flux module debug --setbit 0x1 sched-simple
 // e.g. flux module debug --clearbit 0x1 sched-simple
@@ -115,7 +115,7 @@ jobreq_create (const flux_msg_t *msg)
                          "jobspec", &jobspec) < 0)
         goto err;
     job->msg = flux_msg_incref (msg);
-    if (libjj_get_counts_json (jobspec, &job->jj) < 0)
+    if (jj_get_counts_json (jobspec, &job->jj) < 0)
         job->errnum = errno;
     if (json_unpack (jobspec,
                      "{s?{s?{s?O}}}",
@@ -606,7 +606,7 @@ static void feasibility_cb (flux_t *h,
                      "constraints", &constraints) < 0)
         goto err;
 
-    if (libjj_get_counts_json (jobspec, &jj) < 0) {
+    if (jj_get_counts_json (jobspec, &jj) < 0) {
         errmsg = jj.error;
         goto err;
     }

--- a/src/modules/sched-simple/sched.c
+++ b/src/modules/sched-simple/sched.c
@@ -117,6 +117,13 @@ jobreq_create (const flux_msg_t *msg)
     job->msg = flux_msg_incref (msg);
     if (jj_get_counts_json (jobspec, &job->jj) < 0)
         job->errnum = errno;
+    else if (job->jj.slot_gpus > 0) {
+        snprintf (job->jj.error,
+                  sizeof (job->jj.error),
+                  "Unsupported resource type 'gpu'");
+        errno = EINVAL;
+        job->errnum = errno;
+    }
     if (json_unpack (jobspec,
                      "{s?{s?{s?O}}}",
                      "attributes",
@@ -608,6 +615,11 @@ static void feasibility_cb (flux_t *h,
 
     if (jj_get_counts_json (jobspec, &jj) < 0) {
         errmsg = jj.error;
+        goto err;
+    }
+    if (jj.slot_gpus > 0) {
+        errno = EINVAL;
+        errmsg = "Unsupported resource type 'gpu'";
         goto err;
     }
 

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -127,6 +127,7 @@ TESTSCRIPTS = \
 	t2218-job-manager-priority-order-unlimited.t \
 	t2219-job-manager-restart.t \
 	t2220-job-manager-jobspec-default.t \
+	t2221-job-manager-limit-duration.t \
 	t2230-job-info-lookup.t \
 	t2231-job-info-eventlog-watch.t \
 	t2232-job-info-security.t \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -735,7 +735,7 @@ disconnect_watcher_la_LIBADD = $(test_ldadd)
 sched_simple_jj_reader_SOURCES = sched-simple/jj-reader.c
 sched_simple_jj_reader_CPPFLAGS = $(test_cppflags)
 sched_simple_jj_reader_LDADD = \
-	$(top_builddir)/src/modules/sched-simple/libjj.la \
+	$(top_builddir)/src/common/libjob/libjob.la \
 	$(test_ldadd)
 sched_simple_jj_reader_LDFLAGS = $(test_ldflags)
 

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -128,6 +128,7 @@ TESTSCRIPTS = \
 	t2219-job-manager-restart.t \
 	t2220-job-manager-jobspec-default.t \
 	t2221-job-manager-limit-duration.t \
+	t2222-job-manager-limit-job-size.t \
 	t2230-job-info-lookup.t \
 	t2231-job-info-eventlog-watch.t \
 	t2232-job-info-security.t \

--- a/t/sched-simple/jj-reader.c
+++ b/t/sched-simple/jj-reader.c
@@ -16,7 +16,7 @@
 
 #include "src/common/libutil/log.h"
 #include "src/common/libutil/read_all.h"
-#include "src/modules/sched-simple/libjj.h"
+#include "src/common/libjob/jj.h"
 
 int main (int ac, char *av[])
 {
@@ -25,7 +25,7 @@ int main (int ac, char *av[])
     log_init ("jj-reader");
     if (read_all (STDIN_FILENO, (void **) &s) < 0)
         log_err_exit ("Failed to read stdin");
-    if (libjj_get_counts (s, &jj) < 0)
+    if (jj_get_counts (s, &jj) < 0)
         log_msg_exit ("%s", jj.error);
     printf ("nnodes=%d nslots=%d slot_size=%d exclusive=%s duration=%.1f\n",
             jj.nnodes,

--- a/t/sched-simple/jj-reader.c
+++ b/t/sched-simple/jj-reader.c
@@ -27,10 +27,11 @@ int main (int ac, char *av[])
         log_err_exit ("Failed to read stdin");
     if (jj_get_counts (s, &jj) < 0)
         log_msg_exit ("%s", jj.error);
-    printf ("nnodes=%d nslots=%d slot_size=%d exclusive=%s duration=%.1f\n",
+    printf ("nnodes=%d nslots=%d slot_size=%d slot_gpus=%d exclusive=%s duration=%.1f\n",
             jj.nnodes,
             jj.nslots,
             jj.slot_size,
+            jj.slot_gpus,
             jj.exclusive ? "true" : "false",
             jj.duration);
     log_fini ();

--- a/t/t0022-jj-reader.t
+++ b/t/t0022-jj-reader.t
@@ -103,17 +103,19 @@ done <invalid.txt
 # <jobspec command args> == <expected result>
 #
 cat <<EOF >inputs.txt
-run              ==nnodes=0 nslots=1 slot_size=1 exclusive=false duration=0.0
-run -N1 -n1      ==nnodes=1 nslots=1 slot_size=1 exclusive=false duration=0.0
-run -N1 -n4      ==nnodes=1 nslots=4 slot_size=1 exclusive=false duration=0.0
-run -N1 -n4 -c4  ==nnodes=1 nslots=4 slot_size=4 exclusive=false duration=0.0
-run -n4 -c4      ==nnodes=0 nslots=4 slot_size=4 exclusive=false duration=0.0
-run -n4 -c4      ==nnodes=0 nslots=4 slot_size=4 exclusive=false duration=0.0
-run -n4 -c1      ==nnodes=0 nslots=4 slot_size=1 exclusive=false duration=0.0
-run -N4 -n4 -c4  ==nnodes=4 nslots=4 slot_size=4 exclusive=false duration=0.0
-run -t 1m -N4 -n4 ==nnodes=4 nslots=4 slot_size=1 exclusive=false duration=60.0
-run -t 5s -N4 -n4 ==nnodes=4 nslots=4 slot_size=1 exclusive=false duration=5.0
-run -t 1h -N4 -n4 ==nnodes=4 nslots=4 slot_size=1 exclusive=false duration=3600.0
+run              ==nnodes=0 nslots=1 slot_size=1 slot_gpus=0 exclusive=false duration=0.0
+run -N1 -n1      ==nnodes=1 nslots=1 slot_size=1 slot_gpus=0 exclusive=false duration=0.0
+run -N1 -n4      ==nnodes=1 nslots=4 slot_size=1 slot_gpus=0 exclusive=false duration=0.0
+run -N1 -n4 -c4  ==nnodes=1 nslots=4 slot_size=4 slot_gpus=0 exclusive=false duration=0.0
+run -n4 -c4      ==nnodes=0 nslots=4 slot_size=4 slot_gpus=0 exclusive=false duration=0.0
+run -n4 -c4      ==nnodes=0 nslots=4 slot_size=4 slot_gpus=0 exclusive=false duration=0.0
+run -n4 -c1      ==nnodes=0 nslots=4 slot_size=1 slot_gpus=0 exclusive=false duration=0.0
+run -N4 -n4 -c4  ==nnodes=4 nslots=4 slot_size=4 slot_gpus=0 exclusive=false duration=0.0
+run -t 1m -N4 -n4 ==nnodes=4 nslots=4 slot_size=1 slot_gpus=0 exclusive=false duration=60.0
+run -t 5s -N4 -n4 ==nnodes=4 nslots=4 slot_size=1 slot_gpus=0 exclusive=false duration=5.0
+run -t 1h -N4 -n4 ==nnodes=4 nslots=4 slot_size=1 slot_gpus=0 exclusive=false duration=3600.0
+run -g1           ==nnodes=0 nslots=1 slot_size=1 slot_gpus=1 exclusive=false duration=0.0
+run -N1 -n2 -c2 -g1 ==nnodes=1 nslots=2 slot_size=2 slot_gpus=1 exclusive=false duration=0.0
 EOF
 
 while read line; do
@@ -127,27 +129,6 @@ while read line; do
 		test_cmp expected.$test_count output.$test_count
 	'
 done < inputs.txt
-
-
-# Invalid inputs:
-# <mini command args> == <expected result>
-#
-cat <<EOF >mini-invalid.txt
-run -g1             ==jj-reader: Unsupported resource type 'gpu'
-run -N1 -n2 -c2 -g1 ==jj-reader: Unsupported resource type 'gpu'
-EOF
-
-while read line; do
-	args=$(echo $line | awk -F== '{print $1}' | sed 's/  *$//')
-	expected=$(echo $line | awk -F== '{print $2}')
-
-	test_expect_success "jj-reader: flux mini $args gets expected error" '
-		echo $expected >expected.$test_count &&
-		flux mini $args --dry-run hostname >$test_count.json &&
-		test_expect_code 1 $jj<$test_count.json > out.$test_count 2>&1 &&
-		test_cmp expected.$test_count out.$test_count
-	'
-done <mini-invalid.txt
 
 
 test_done

--- a/t/t2221-job-manager-limit-duration.t
+++ b/t/t2221-job-manager-limit-duration.t
@@ -1,0 +1,138 @@
+#!/bin/sh
+
+test_description='Test flux job manager limit-duration plugin'
+
+. $(dirname $0)/sharness.sh
+
+mkdir -p config
+
+test_under_flux 2 full -o,--config-path=$(pwd)/config
+
+flux setattr log-stderr-level 1
+
+test_expect_success 'unload all built-in plugins' '
+	flux jobtap remove ".*"
+'
+test_expect_success 'configure an invalid numerical duration limit' '
+	cat >config/policy.toml <<-EOT &&
+	[policy.limits]
+	duration = -1.0
+	EOT
+	flux config reload
+'
+test_expect_success 'cannot load the limit-duration plugin' '
+	test_must_fail flux jobtap load .limit-duration
+'
+test_expect_success 'configure a valid duration limit (FSD)' '
+	cat >config/policy.toml <<-EOT &&
+	[policy.limits]
+	duration = "1m"
+	EOT
+	flux config reload
+'
+test_expect_success 'the limit-duration plugin can now be laoded' '
+	flux jobtap load .limit-duration
+'
+test_expect_success 'a job that exceeds policy.limits.duration is rejected' '
+	test_must_fail flux mini submit -t 1h /bin/true 2>duration.err &&
+	grep "exceeds policy limit of 1m" duration.err
+'
+test_expect_success 'a job that sets no explicit duration is accepted' '
+	flux mini submit /bin/true
+'
+test_expect_success 'a job that is under policy.limits.duration is accepted' '
+	flux mini submit -t 30s /bin/true
+'
+test_expect_success 'configure policy.limits.duration and queue durations' '
+	cat >config/policy.toml <<-EOT &&
+	[policy.limits]
+	duration = "1h"
+	[queues.pdebug.policy.limits]
+	duration = "1m"
+	[queues.pbatch.policy.limits]
+	duration = "8h"
+	EOT
+	flux config reload
+'
+test_expect_success 'a no-queue job that exceeds policy.limits.duration is rejected' '
+	test_must_fail flux mini submit -t 2h /bin/true
+'
+test_expect_success 'but is accepted by a queue with higher limit' '
+	flux mini submit \
+	    --setattr=system.queue=pbatch \
+	    -t 2h \
+	    /bin/true
+'
+test_expect_success 'and is rejected when it exceeds the queue limit' '
+	test_must_fail flux mini submit \
+	    --setattr=system.queue=pbatch \
+	    -t 16h \
+	    /bin/true
+'
+test_expect_success 'a job that is under policy.limits.duration is accepted' '
+	flux mini submit -t 1h /bin/true
+'
+test_expect_success 'but is rejected on a queue with lower limit' '
+	test_must_fail flux mini submit \
+	    --setattr=system.queue=pdebug \
+	    -t 1h \
+	    /bin/true
+'
+test_expect_success 'configure policy.limits.duration and an unlimited queue' '
+	cat >config/policy.toml <<-EOT &&
+	[policy.limits]
+	duration = "1h"
+	[queues.pdebug.policy.limits]
+	duration = 0
+	EOT
+	flux config reload
+'
+test_expect_success 'a job that is over policy.limits.duration is rejected' '
+	test_must_fail flux mini submit -t 2h /bin/true
+'
+test_expect_success 'but is accepted by the unlimited queue' '
+	flux mini submit \
+	    --setattr=system.queue=pdebug \
+	    -t 2h /bin/true
+'
+test_expect_success 'a job that sets no explicit duration is accepted by the unlimited queue' '
+	flux mini submit \
+	    --setattr=system.queue=pdebug \
+	    /bin/true
+'
+test_expect_success 'configure an invalid string duration limit' '
+	cat >config/policy.toml <<-EOT &&
+	[policy.limits]
+	duration = "xyz123"
+	EOT
+	test_must_fail flux config reload
+'
+test_expect_success 'configure a duration limit of an invalid type' '
+	cat >config/policy.toml <<-EOT &&
+	[policy.limits]
+	duration = [ 0 ]
+	EOT
+	test_must_fail flux config reload
+'
+test_expect_success 'configure an invalid queue duration limit' '
+	cat >config/policy.toml <<-EOT &&
+	[queues.pdebug.policy.limits]
+	duration = "xyz123"
+	EOT
+	test_must_fail flux config reload
+'
+test_expect_success 'configure a default duration that exceeds duration limit' '
+	cat >config/policy.toml <<-EOT &&
+	policy.limits.duration = 3600
+	policy.jobspec.defaults.system.duration = 3601
+	EOT
+	flux config reload
+'
+test_expect_success 'load jobspec-default plugin' '
+	flux jobtap load .jobspec-default
+'
+test_expect_success 'job with no duration specified is rejected' '
+	test_must_fail flux mini submit /bin/true
+'
+
+test_done

--- a/t/t2222-job-manager-limit-job-size.t
+++ b/t/t2222-job-manager-limit-job-size.t
@@ -1,0 +1,126 @@
+#!/bin/sh
+
+test_description='Test flux job manager limit-job-size plugin'
+
+. $(dirname $0)/sharness.sh
+
+mkdir -p config
+
+test_under_flux 2 full -o,--config-path=$(pwd)/config
+
+flux setattr log-stderr-level 1
+
+test_expect_success 'unload all built-in plugins' '
+        flux jobtap remove ".*"
+'
+test_expect_success 'configure an invalid job-size limit' '
+	cat >config/policy.toml <<-EOT &&
+	[policy.limits]
+	job-size.max.nnodes = -42
+	EOT
+	flux config reload
+'
+test_expect_success 'cannot load the limit-job-size plugin' '
+        test_must_fail flux jobtap load .limit-job-size
+'
+test_expect_success 'configure valid job-size.*.nnodes limits' '
+	cat >config/policy.toml <<-EOT &&
+	[policy.limits]
+	job-size.max.nnodes = 2
+	job-size.min.nnodes = 2
+	EOT
+	flux config reload
+'
+test_expect_success 'and plugin can now be loaded' '
+        flux jobtap load .limit-job-size
+'
+test_expect_success 'a job that exceeds job-size.max.nnodes is rejected' '
+	test_must_fail flux mini submit -N 3 /bin/true 2>max-nnodes.err &&
+	grep "exceeds policy limit of 2" max-nnodes.err
+'
+test_expect_success 'a job that is under job-size.min.nnodes is rejected' '
+	test_must_fail flux mini submit -N 1 /bin/true 2>min-nnodes.err &&
+	grep "is under policy limit of 2" min-nnodes.err
+'
+test_expect_success 'a job that is between both of those is accepted' '
+	flux mini submit -N 2 /bin/true
+'
+test_expect_success 'configure job-size.*.ncores limits' '
+	cat >config/policy.toml <<-EOT &&
+	[policy.limits]
+	job-size.max.ncores = 2
+	job-size.min.ncores = 2
+	EOT
+	flux config reload
+'
+test_expect_success 'a job that exceeds job-size.max.ncores is rejected' '
+	test_must_fail flux mini submit -n 3 /bin/true 2>max-ncores.err &&
+	grep "exceeds policy limit of 2" max-ncores.err
+'
+test_expect_success 'a job that is under job-size.min.ncores is rejected' '
+	test_must_fail flux mini submit -n 1 /bin/true 2>min-ncores.err &&
+	grep "is under policy limit of 2" min-ncores.err
+'
+test_expect_success 'a job that is between both of those is accepted' '
+	flux mini submit -n 2 /bin/true
+'
+test_expect_success 'configure job-size.*.ngpus limits' '
+	cat >config/policy.toml <<-EOT &&
+	[policy.limits]
+	job-size.max.ngpus = 2
+	job-size.min.ngpus = 2
+	EOT
+	flux config reload
+'
+test_expect_success 'a job that exceeds job-size.max.ngpus is rejected' '
+	test_must_fail flux mini submit -g 3 /bin/true 2>max-ngpus.err &&
+	grep "exceeds policy limit of 2" max-ngpus.err
+'
+test_expect_success 'a job that is under job-size.min.ngpus is rejected' '
+	test_must_fail flux mini submit -g 1 /bin/true 2>min-ngpus.err &&
+	grep "is under policy limit of 2" min-ngpus.err
+'
+test_expect_success 'a job that is between both of those is accepted' '
+	flux mini submit -g 2 /bin/true
+'
+test_expect_success 'configure job-size.max.ngpus and queue with unlimited' '
+	cat >config/policy.toml <<-EOT &&
+	[policy.limits]
+	job-size.max.ngpus = 0
+	[queues.pdebug.policy.limits]
+	job-size.max.ngpus = -1
+	EOT
+	flux config reload
+'
+test_expect_success 'a job with no queue is accepted if under gpu limit' '
+	flux mini submit -n1 /bin/true
+'
+test_expect_success 'a job with no queue is rejected if over gpu limit' '
+	test_must_fail flux mini submit -n1 -g1 /bin/true
+'
+test_expect_success 'same job is accepted with unlimited queue override' '
+	flux mini submit \
+	    --setattr=system.queue=pdebug -n1 -g1 /bin/true
+'
+test_expect_success 'configure an invalid job-size object' '
+	cat >config/policy.toml <<-EOT &&
+	[policy.limits]
+	job-size = "wrong"
+	EOT
+	test_must_fail flux config reload
+'
+test_expect_success 'configure an out of bounds job-size.max.nnodes object' '
+	cat >config/policy.toml <<-EOT &&
+	[policy.limits]
+	job-size.max.nnodes = -42
+	EOT
+	test_must_fail flux config reload
+'
+test_expect_success 'configure an invalid queue job-size.min.nnodes object' '
+	cat >config/policy.toml <<-EOT &&
+	[queues.pdebug.policy.limits]
+	job-size.min.nnodes = "xyz"
+	EOT
+	test_must_fail flux config reload
+'
+test_done


### PR DESCRIPTION
This adds a plugin that implements general and per-queue limits as described in RFC 33, based on just checking the jobspec against the TOML config.

As I was looking for an issue to reference when posting this, I came across #4309 and realized I dove into this today without remembering the idea of using a dependency like scheme to add/remove limits.  Which was a good idea!  Tomorrow I'll pause this and spend some considering that approach instead.