### PR TITLE
job-info: handle invalid eventlog entry errors more carefully

### DIFF
--- a/src/modules/job-info/allow.c
+++ b/src/modules/job-info/allow.c
@@ -94,6 +94,11 @@ int eventlog_allow (struct info_ctx *ctx, const flux_msg_t *msg,
         return -1;
     if (!(cred.rolemask & FLUX_ROLE_OWNER)) {
         uint32_t userid;
+        /* RFC18: empty eventlog not allowed */
+        if (!s) {
+            errno = EPROTO;
+            return -1;
+        }
         if (eventlog_get_userid (ctx, s, &userid) < 0)
             return -1;
         store_lru (ctx, id, userid);

--- a/src/modules/job-info/allow.c
+++ b/src/modules/job-info/allow.c
@@ -47,7 +47,7 @@ static int eventlog_get_userid (struct info_ctx *ctx, const char *s,
         goto error;
     }
     if (strcmp (name, "submit") != 0 || !context) {
-        flux_log (ctx->h, LOG_ERR, "%s: invalid event", __FUNCTION__);
+        flux_log (ctx->h, LOG_ERR, "%s: invalid event: %s", __FUNCTION__, name);
         errno = EINVAL;
         goto error;
     }

--- a/src/modules/job-info/allow.c
+++ b/src/modules/job-info/allow.c
@@ -47,7 +47,7 @@ static int eventlog_get_userid (struct info_ctx *ctx, const char *s,
         goto error;
     }
     if (strcmp (name, "submit") != 0 || !context) {
-        flux_log_error (ctx->h, "%s: invalid event", __FUNCTION__);
+        flux_log (ctx->h, LOG_ERR, "%s: invalid event", __FUNCTION__);
         errno = EINVAL;
         goto error;
     }

--- a/src/modules/job-info/lookup.c
+++ b/src/modules/job-info/lookup.c
@@ -204,6 +204,12 @@ static void info_lookup_continuation (flux_future_t *fall, void *arg)
             goto error;
         }
 
+        /* treat empty value as invalid */
+        if (!s) {
+            errno = EPROTO;
+            goto error;
+        }
+
         if (!(str = json_string (s)))
             goto enomem;
 

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -301,6 +301,7 @@ dist_check_SCRIPTS = \
 	issues/t4375-content-flush-hang.sh \
 	issues/t4378-content-flush-force.sh \
 	issues/t4379-dirty-cache-entries-flush.sh \
+	issues/t4413-empty-eventlog.sh \
 	python/__init__.py \
 	python/subflux.py \
 	python/tap \

--- a/t/issues/t4413-empty-eventlog.sh
+++ b/t/issues/t4413-empty-eventlog.sh
@@ -1,0 +1,12 @@
+#!/bin/bash -e
+
+# create a fake job eventlog in the KVS, no normal mechanism will
+# create an empty eventlog
+
+jobpath=`flux job id --to=kvs 123456789`
+flux kvs put "${jobpath}.eventlog"=""
+
+# Issue 4413, previously would return Cannot allocate memory
+flux job info 123456789 eventlog 2>&1 | grep "Protocol error"
+
+


### PR DESCRIPTION
Per discussion in #4413, there was a corner case where ENOMEM was returned to a caller when an eventlog was empty.  The ENOMEM came from assumptions that an eventlog can never be empty (RFC18 says that an empty eventlog should be impossible).  Handle several corner cases around this fact.

I decided that since an empty eventlog should be impossible, instead of returning EINVAL, I returned EPROTO.  Right choice?

As a fallout, I updated other code to also return EPROTO if the eventlog was in error.

