### PR TITLE
flux-dump: fix handling of empty blobref value

### DIFF
--- a/src/cmd/builtin/dump.c
+++ b/src/cmd/builtin/dump.c
@@ -138,7 +138,7 @@ static void dump_valref (struct archive *ar,
                                           treeobj_get_blobref (treeobj, i),
                                           content_flags))
             || flux_future_get (f, (const void **)&msg) < 0
-            || flux_msg_get_payload (msg, &data, &len) < 0) {
+            || flux_response_decode_raw (msg, NULL, &data, &len) < 0) {
             log_msg_exit ("%s: missing blobref %d: %s",
                           path,
                           i,
@@ -162,9 +162,10 @@ static void dump_valref (struct archive *ar,
     if (archive_write_header (ar, entry) != ARCHIVE_OK)
         log_msg_exit ("%s", archive_error_string (ar));
     while ((msg = flux_msglist_pop (l))) {
-        if (flux_msg_get_payload (msg, &data, &len) < 0)
-            log_msg_exit ("error processing stashed valref responses");
-        dump_write_data (ar, data, len);
+        if (flux_response_decode_raw (msg, NULL, &data, &len) < 0)
+            log_err_exit ("error processing stashed valref responses");
+        if (len > 0)
+            dump_write_data (ar, data, len);
         flux_msg_decref (msg);
     }
     archive_entry_free (entry);

--- a/t/t2807-dump-cmd.t
+++ b/t/t2807-dump-cmd.t
@@ -43,7 +43,9 @@ test_expect_success 'load kvs and create some kvs content' '
 	flux kvs put --no-merge a.b.c=testkey &&
 	flux kvs link linkedthing y &&
 	flux kvs put --no-merge x=$(cat x.val) &&
-	flux kvs link --target-namespace=smurf otherthing z
+	flux kvs link --target-namespace=smurf otherthing z &&
+	flux kvs put --no-merge w= &&
+	flux kvs put --no-merge --append w=foo
 '
 test_expect_success 'unload kvs' '
 	flux module remove kvs
@@ -73,10 +75,12 @@ test_expect_success 'unload content-sqlite' '
 # (1) rootdir 3rd version (y is contained in root)
 # (2) rootdir 4th version + 'x'
 # (1) rootdir 5th version (z is contained in root)
-# Total: 8 blobs
+# (1) rootdir 6th version (w probably contained in root)
+# (3) rootdir 7th version ('w' empty blobref + append to 'w')
+# Total: 12 blobs
 #
-test_expect_success 'count blobs representing those four keys' '
-	echo 8 >blobcount.exp &&
+test_expect_success 'count blobs representing those five keys' '
+	echo 12 >blobcount.exp &&
 	countblobs >blobcount.out &&
 	test_cmp blobcount.exp blobcount.out
 '
@@ -120,7 +124,8 @@ test_expect_success 'verify that exact KVS content was restored' '
 	test $(flux kvs get a.b.c) = "testkey" &&
 	test $(flux kvs get x) = $(cat x.val) &&
 	test $(flux kvs readlink y) = "linkedthing" &&
-	test $(flux kvs readlink z) = "smurf::otherthing"
+	test $(flux kvs readlink z) = "smurf::otherthing" &&
+	test $(flux kvs get w) = "foo"
 '
 test_expect_success 'now restore to key and verify content' '
 	flux restore -v --key zz foo.tar &&


### PR DESCRIPTION
This fixes the issue described in #4414 by switching `flux-dump` to use `flux_response_decode_raw()` instead of `flux_msg_get_payload()`, the former of which handles responses with an "empty" payload in the expected way.

An attempt to add the precipitating condition to the tests in `t2807-dump-cmd.t`was also made, though I stumbled around a bit trying to figure out the correct blob counts and description of what is happening in the KVS under the covers for the empty, then appended, key. Please forgive and correct any mistakes therein.
