### PR TITLE
sched-simple: fix allocation of down nodes when using constraints

### DIFF
--- a/src/common/librlist/match.c
+++ b/src/common/librlist/match.c
@@ -189,7 +189,12 @@ int rnode_match_validate (json_t *constraint, flux_error_t *errp)
 struct rnode *rnode_copy_match (const struct rnode *orig,
                                 json_t *constraint)
 {
-    return rnode_match (orig, constraint) ? rnode_copy (orig) : NULL;
+    struct rnode *n = NULL;
+    if (rnode_match (orig, constraint)) {
+        if ((n = rnode_copy (orig)))
+            n->up = orig->up;
+    }
+    return n;
 }
 
 /* vi: ts=4 sw=4 expandtab

--- a/t/t2276-job-requires.t
+++ b/t/t2276-job-requires.t
@@ -24,7 +24,7 @@ test_expect_success 'reload scheduler with properties set' '
 	flux kvs put resource.R="$(flux kvs get resource.R | \
 		flux R set-property xx:2-3 yy:0-2)" &&
 	flux module unload sched-simple &&
-	flux module reload resource &&
+	flux module reload resource noverify &&
 	flux module load sched-simple
 '
 test_expect_success 'reload ingest with feasibility validator' '


### PR DESCRIPTION
This PR fixes #4424. As suspected, when copying the internal sched-simple rlist for constraint matching, the up/down state of nodes was not preserved. This PR fixes that issue, and adds the unfortunately missing tests that ensure down nodes are not scheduled to jobs that include a constraint.