### PR TITLE
libflux: handle flux_respond_error (errnum=0)

### DIFF
--- a/doc/man3/flux_respond.rst
+++ b/doc/man3/flux_respond.rst
@@ -51,7 +51,7 @@ building the payload using variable arguments with a format string in
 the style of jansson's ``json_pack()`` (used internally).
 
 ``flux_respond_error()`` returns an error response to the sender.
-*errnum* must be non-zero. If *errmsg* is non-NULL, an error string
+If *errnum* is zero, EINVAL is used.  If *errmsg* is non-NULL, an error string
 payload is included in the response. The error string may be used to
 provide a more detailed error message than can be conveyed via *errnum*.
 

--- a/src/common/libflux/response.c
+++ b/src/common/libflux/response.c
@@ -315,8 +315,10 @@ int flux_respond_error (flux_t *h, const flux_msg_t *request,
 {
     flux_msg_t *msg = NULL;
 
-    if (!h || !request || errnum == 0)
+    if (!h || !request)
         goto inval;
+    if (errnum == 0)
+        errnum = EINVAL;
     if (flux_msg_is_noresponse (request))
         return 0;
     msg = flux_response_derive (request, errnum);

--- a/src/common/libflux/response.h
+++ b/src/common/libflux/response.h
@@ -86,7 +86,8 @@ int flux_respond_raw (flux_t *h, const flux_msg_t *request,
                       const void *data, int len);
 
 /* Create an error response to the provided request message with optional
- * error string payload (if errstr is non-NULL).
+ * error string payload (if errstr is non-NULL).  If errnum is zero, EINVAL
+ * is substituted.
  */
 int flux_respond_error (flux_t *h, const flux_msg_t *request,
                         int errnum, const char *errstr);


### PR DESCRIPTION
Problem: if `flux_respond_error()` is called with errnum of 0, no response is sent, which can cause hard to diagnose problems.

Use EINVAL if errnum is zero.

Fixes #3036