### PR TITLE
job-manager: improve robustness of max job id recovery on restart

### DIFF
--- a/src/modules/job-manager/job-manager.c
+++ b/src/modules/job-manager/job-manager.c
@@ -219,8 +219,8 @@ int mod_main (flux_t *h, int argc, char **argv)
         flux_log_error (h, "flux_reactor_run");
         goto done;
     }
-    if (checkpoint_to_kvs (&ctx) < 0) {
-        flux_log_error (h, "checkpoint_to_kvs");
+    if (restart_save_state (&ctx) < 0) {
+        flux_log_error (h, "error saving job manager state to KVS");
         goto done;
     }
     rc = 0;

--- a/src/modules/job-manager/job-manager.c
+++ b/src/modules/job-manager/job-manager.c
@@ -76,12 +76,12 @@ static void stats_cb (flux_t *h, flux_msg_handler_t *mh,
 {
     struct job_manager *ctx = arg;
     int journal_listeners = journal_listeners_count (ctx->journal);
-    if (flux_respond_pack (h, msg, "{s:{s:i} s:i s:i}",
+    if (flux_respond_pack (h, msg, "{s:{s:i} s:i s:i s:I}",
                            "journal",
                              "listeners", journal_listeners,
                            "active_jobs", zhashx_size (ctx->active_jobs),
-                           "inactive_jobs", zhashx_size (ctx->inactive_jobs)
-                           ) < 0) {
+                           "inactive_jobs", zhashx_size (ctx->inactive_jobs),
+                           "max_jobid", ctx->max_jobid) < 0) {
         flux_log_error (h, "%s: flux_respond_pack", __FUNCTION__);
         goto error;
     }

--- a/src/modules/job-manager/restart.c
+++ b/src/modules/job-manager/restart.c
@@ -208,7 +208,7 @@ static int restart_map_cb (struct job *job, void *arg, flux_error_t *error)
     return 0;
 }
 
-static int checkpoint_save (struct job_manager *ctx)
+int restart_save_state (struct job_manager *ctx)
 {
     flux_future_t *f = NULL;
     flux_kvs_txn_t *txn;
@@ -234,7 +234,7 @@ done:
     return rc;
 }
 
-static int checkpoint_restore (struct job_manager *ctx)
+static int restart_restore_state (struct job_manager *ctx)
 {
     flux_future_t *f;
 
@@ -348,26 +348,17 @@ int restart_from_kvs (struct job_manager *ctx)
 
     /* Restore misc state.
      */
-    if (checkpoint_restore (ctx) < 0) {
+    if (restart_restore_state (ctx) < 0) {
         if (errno != ENOENT) {
             flux_log_error (ctx->h, "restart: %s", checkpoint_key);
             return -1;
         }
-        flux_log (ctx->h, LOG_INFO, "restart: no checkpoint object");
+        flux_log (ctx->h, LOG_INFO, "restart: %s not found", checkpoint_key);
     }
     flux_log (ctx->h,
               LOG_DEBUG,
               "restart: max_jobid=%ju",
               (uintmax_t)ctx->max_jobid);
-    return 0;
-}
-
-int checkpoint_to_kvs (struct job_manager *ctx)
-{
-    if (checkpoint_save (ctx) < 0) {
-        flux_log_error (ctx->h, "checkpoint");
-        return -1;
-    }
     return 0;
 }
 

--- a/src/modules/job-manager/restart.h
+++ b/src/modules/job-manager/restart.h
@@ -22,6 +22,9 @@ int restart_count_char (const char *s, char c);
 
 int restart_save_state (struct job_manager *ctx);
 
+int restart_save_state_to_txn (struct job_manager *ctx, flux_kvs_txn_t *txn);
+
+
 #endif /* _FLUX_JOB_MANAGER_RESTART_H */
 
 /*

--- a/src/modules/job-manager/restart.h
+++ b/src/modules/job-manager/restart.h
@@ -20,7 +20,7 @@ int restart_from_kvs (struct job_manager *ctx);
 /* exposed for unit testing only */
 int restart_count_char (const char *s, char c);
 
-int checkpoint_to_kvs (struct job_manager *ctx);
+int restart_save_state (struct job_manager *ctx);
 
 #endif /* _FLUX_JOB_MANAGER_RESTART_H */
 

--- a/t/t2219-job-manager-restart.t
+++ b/t/t2219-job-manager-restart.t
@@ -13,11 +13,45 @@ test_expect_success 'start instance with empty kvs, run one job, and dump' '
 '
 
 restart_flux() {
-	flux start -o,-Scontent.restore=$1 /bin/true
+	flux start -o,-Scontent.restore=$1 \
+		flux module stats job-manager
 }
 
 test_expect_success 'verify that job manager can restart with current dump' '
-	restart_flux dump.tar
+	restart_flux dump.tar >stats.out
+'
+test_expect_success HAVE_JQ 'and max_jobid is greater than zero' '
+	jq -e ".max_jobid > 0" <stats.out
+'
+test_expect_success 'delete checkpoint from dump' '
+	mkdir -p tmp &&
+	(cd tmp && tar -xf -) <dump.tar &&
+	rm tmp/checkpoint/job-manager &&
+	(cd tmp && tar -cf - *) >dump-nock.tar
+'
+test_expect_success 'verify that job manager can restart with modified dump' '
+	restart_flux dump-nock.tar >stats-nock.out
+'
+test_expect_success HAVE_JQ 'and max_jobid is still greater than zero' '
+	jq -e ".max_jobid > 0" <stats-nock.out
+'
+test_expect_success 'delete job from dump' '
+	mkdir -p tmp &&
+	(cd tmp && tar -xf -) <dump.tar &&
+	rm -r tmp/job/* &&
+	(cd tmp && tar -cf - *) >dump-nojob.tar
+'
+test_expect_success 'verify that job manager can restart with modified dump' '
+	restart_flux dump-nojob.tar >stats-nojob.out
+'
+test_expect_success HAVE_JQ 'and max_jobid is still greater than zero' '
+	jq -e ".max_jobid > 0" <stats-nojob.out
+'
+
+test_expect_success 'purging all jobs triggers jobid checkpoint update' '
+	flux start bash -c "flux mini run --env-remove=* /bin/true && \
+	    flux job purge -f --num-limit=0 && \
+	    flux kvs get checkpoint.job-manager"
 '
 
 for dump in ${DUMPS}/valid/*.tar.bz2; do


### PR DESCRIPTION
Problem:  as noted in #4300, the job-manager only writes out the max job ID to the KVS when it is unloading, so despite best efforts to preserve KVS content (e.g. with defensive checkpoints added in #4383) when there is a crash or a failed shutdown, we are in danger of starting from an old max ID value and issuing duplicate job IDs.

This just uses the greater of the checkpoint value or the maximum job ID replayed from the KVS to improve robustness.

Also, since purging can eliminate all jobs in the KVS, we add code to update the checkpoint value in the KVS if  the job matching the current max job ID happens to be purged, as suggested by @grondo.
