### PR TITLE
use ccan ARRAY_SIZE() macro

### DIFF
--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -42,6 +42,7 @@
 #include "src/common/libpmi/pmi_strerror.h"
 #include "src/common/libutil/fsd.h"
 #include "src/common/libutil/errno_safe.h"
+#include "ccan/array_size/array_size.h"
 
 #include "module.h"
 #include "brokercfg.h"
@@ -1113,7 +1114,7 @@ static int broker_handle_signals (broker_ctx_t *ctx)
     int blocked[] = { SIGPIPE };
     flux_watcher_t *w;
 
-    for (i = 0; i < sizeof (sigs) / sizeof (sigs[0]); i++) {
+    for (i = 0; i < ARRAY_SIZE (sigs); i++) {
         w = flux_signal_watcher_create (ctx->reactor, sigs[i], signal_cb, ctx);
         if (!w) {
             log_err ("flux_signal_watcher_create");
@@ -1128,7 +1129,7 @@ static int broker_handle_signals (broker_ctx_t *ctx)
     }
 
     /*  Block the list of signals in the blocked array */
-    for (i = 0; i < sizeof (blocked) / sizeof (blocked[0]); i++)
+    for (i = 0; i < ARRAY_SIZE (blocked); i++)
         signal(blocked[i], SIG_IGN);
     return 0;
 }
@@ -1631,7 +1632,7 @@ static bool allow_early_request (const flux_msg_t *msg)
         { FLUX_MSGTYPE_REQUEST, FLUX_MATCHTAG_NONE, "state-machine.get" },
         { FLUX_MSGTYPE_REQUEST, FLUX_MATCHTAG_NONE, "attr.get" },
     };
-    for (int i = 0; i < sizeof (match) / sizeof (match[0]); i++)
+    for (int i = 0; i < ARRAY_SIZE (match); i++)
         if (flux_msg_cmp (msg, match[i]))
             return true;
     return false;

--- a/src/broker/state_machine.c
+++ b/src/broker/state_machine.c
@@ -21,6 +21,7 @@
 #include "src/common/libidset/idset.h"
 #include "src/common/libhostlist/hostlist.h"
 #include "src/common/libutil/errprintf.h"
+#include "ccan/array_size/array_size.h"
 
 #include "state_machine.h"
 
@@ -143,12 +144,10 @@ static struct state_next nexttab[] = {
 
 static const double default_quorum_timeout = 60; // log slow joiners
 
-#define TABLE_LENGTH(t) (sizeof(t) / sizeof((t)[0]))
-
 static void state_action (struct state_machine *s, broker_state_t state)
 {
     int i;
-    for (i = 0; i < TABLE_LENGTH (statetab); i++) {
+    for (i = 0; i < ARRAY_SIZE (statetab); i++) {
         if (statetab[i].state == state) {
             if (statetab[i].action)
                 statetab[i].action (s);
@@ -160,7 +159,7 @@ static void state_action (struct state_machine *s, broker_state_t state)
 static const char *statestr (broker_state_t state)
 {
     int i;
-    for (i = 0; i < TABLE_LENGTH (statetab); i++) {
+    for (i = 0; i < ARRAY_SIZE (statetab); i++) {
         if (statetab[i].state == state)
             return statetab[i].name;
     }
@@ -170,7 +169,7 @@ static const char *statestr (broker_state_t state)
 static broker_state_t state_next (broker_state_t current, const char *event)
 {
     int i;
-    for (i = 0; i < TABLE_LENGTH (nexttab); i++) {
+    for (i = 0; i < ARRAY_SIZE (nexttab); i++) {
         if (nexttab[i].current == current && !strcmp (event, nexttab[i].event))
             return nexttab[i].next;
     }

--- a/src/cmd/builtin/config.c
+++ b/src/cmd/builtin/config.c
@@ -15,6 +15,7 @@
 
 #include "src/common/libutil/jpath.h"
 #include "src/common/libutil/fsd.h"
+#include "ccan/array_size/array_size.h"
 
 #include "builtin.h"
 
@@ -48,7 +49,7 @@ static int parse_json_type (const char *s,
                             json_type *type,
                             fsd_subtype_t *fsd_subtype)
 {
-    for (int i = 0; i < sizeof (typemap) / sizeof (typemap[0]); i++) {
+    for (int i = 0; i < ARRAY_SIZE (typemap); i++) {
         if (!strcasecmp (s, typemap[i].s)) {
             *type = typemap[i].type;
             *fsd_subtype = typemap[i].fsd_subtype;

--- a/src/cmd/flux-start.c
+++ b/src/cmd/flux-start.c
@@ -39,6 +39,7 @@
 #include "src/common/libpmi/dgetline.h"
 #include "src/common/libhostlist/hostlist.h"
 #include "src/common/librouter/usock_service.h"
+#include "ccan/array_size/array_size.h"
 
 #define DEFAULT_EXIT_TIMEOUT 20.0
 
@@ -216,7 +217,7 @@ int main (int argc, char *argv[])
 
     if (!optparse_hasopt (ctx.opts, "test-size")) {
         int i;
-        for (i = 0; i < sizeof (opts) / sizeof (opts[0]); i++) {
+        for (i = 0; i < ARRAY_SIZE (opts); i++) {
             if (opts[i].name
                 && !strncmp (opts[i].name, "test-", 5)
                 && optparse_hasopt (ctx.opts, opts[i].name))

--- a/src/common/libccan/Makefile.am
+++ b/src/common/libccan/Makefile.am
@@ -26,4 +26,5 @@ libccan_la_SOURCES = \
 	ccan/compiler/compiler.h \
 	ccan/ptrint/ptrint.h \
 	ccan/build_assert/build_assert.h \
-	ccan/container_of/container_of.h
+	ccan/container_of/container_of.h \
+	ccan/array_size/array_size.h

--- a/src/common/libccan/ccan/array_size/LICENSE
+++ b/src/common/libccan/ccan/array_size/LICENSE
@@ -1,0 +1,1 @@
+../../licenses/CC0

--- a/src/common/libccan/ccan/array_size/_info
+++ b/src/common/libccan/ccan/array_size/_info
@@ -1,0 +1,46 @@
+#include "config.h"
+#include <stdio.h>
+#include <string.h>
+
+/**
+ * array_size - routine for safely deriving the size of a visible array.
+ *
+ * This provides a simple ARRAY_SIZE() macro, which (given a good compiler)
+ * will also break compile if you try to use it on a pointer.
+ *
+ * This can ensure your code is robust to changes, without needing a gratuitous
+ * macro or constant.
+ *
+ * Example:
+ *	// Outputs "Initialized 32 values\n"
+ *	#include <ccan/array_size/array_size.h>
+ *	#include <stdlib.h>
+ *	#include <stdio.h>
+ *
+ *	// We currently use 32 random values.
+ *	static unsigned int vals[32];
+ *
+ *	int main(void)
+ *	{
+ *		unsigned int i;
+ *		for (i = 0; i < ARRAY_SIZE(vals); i++)
+ *			vals[i] = random();
+ *		printf("Initialized %u values\n", i);
+ *		return 0;
+ *	}
+ *
+ * License: CC0 (Public domain)
+ * Author: Rusty Russell <rusty@rustcorp.com.au>
+ */
+int main(int argc, char *argv[])
+{
+	if (argc != 2)
+		return 1;
+
+	if (strcmp(argv[1], "depends") == 0) {
+		printf("ccan/build_assert\n");
+		return 0;
+	}
+
+	return 1;
+}

--- a/src/common/libccan/ccan/array_size/array_size.h
+++ b/src/common/libccan/ccan/array_size/array_size.h
@@ -1,0 +1,26 @@
+/* CC0 (Public domain) - see LICENSE file for details */
+#ifndef CCAN_ARRAY_SIZE_H
+#define CCAN_ARRAY_SIZE_H
+#include "config.h"
+#include <ccan/build_assert/build_assert.h>
+
+/**
+ * ARRAY_SIZE - get the number of elements in a visible array
+ * @arr: the array whose size you want.
+ *
+ * This does not work on pointers, or arrays declared as [], or
+ * function parameters.  With correct compiler support, such usage
+ * will cause a build error (see build_assert).
+ */
+#define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]) + _array_size_chk(arr))
+
+#if HAVE_BUILTIN_TYPES_COMPATIBLE_P && HAVE_TYPEOF
+/* Two gcc extensions.
+ * &a[0] degrades to a pointer: a different type from an array */
+#define _array_size_chk(arr)						\
+	BUILD_ASSERT_OR_ZERO(!__builtin_types_compatible_p(typeof(arr),	\
+							typeof(&(arr)[0])))
+#else
+#define _array_size_chk(arr) 0
+#endif
+#endif /* CCAN_ALIGNOF_H */

--- a/src/common/libccan/ccan/array_size/test/compile_fail-function-param.c
+++ b/src/common/libccan/ccan/array_size/test/compile_fail-function-param.c
@@ -1,0 +1,24 @@
+#include <ccan/array_size/array_size.h>
+#include <stdlib.h>
+
+struct foo {
+	unsigned int a, b;
+};
+
+int check_parameter(const struct foo *array);
+int check_parameter(const struct foo *array)
+{
+#ifdef FAIL
+	return (ARRAY_SIZE(array) == 4);
+#if !HAVE_TYPEOF || !HAVE_BUILTIN_TYPES_COMPATIBLE_P
+#error "Unfortunately we don't fail if _array_size_chk is a noop."
+#endif
+#else
+	return sizeof(array) == 4 * sizeof(struct foo);
+#endif
+}
+
+int main(void)
+{
+	return check_parameter(NULL);
+}

--- a/src/common/libccan/ccan/array_size/test/compile_fail.c
+++ b/src/common/libccan/ccan/array_size/test/compile_fail.c
@@ -1,0 +1,16 @@
+#include <ccan/array_size/array_size.h>
+
+int main(int argc, char *argv[8])
+{
+	(void)argc;
+	(void)argv;
+	char array[100];
+#ifdef FAIL
+	return ARRAY_SIZE(argv) + ARRAY_SIZE(array);
+#if !HAVE_TYPEOF || !HAVE_BUILTIN_TYPES_COMPATIBLE_P
+#error "Unfortunately we don't fail if _array_size_chk is a noop."
+#endif
+#else
+	return ARRAY_SIZE(array);
+#endif
+}

--- a/src/common/libccan/ccan/array_size/test/run.c
+++ b/src/common/libccan/ccan/array_size/test/run.c
@@ -1,0 +1,33 @@
+#include <ccan/array_size/array_size.h>
+#include <ccan/tap/tap.h>
+
+static char array1[1];
+static int array2[2];
+static unsigned long array3[3][5];
+struct foo {
+	unsigned int a, b;
+	char string[100];
+};
+static struct foo array4[4];
+
+/* Make sure they can be used in initializers. */
+static int array1_size = ARRAY_SIZE(array1);
+static int array2_size = ARRAY_SIZE(array2);
+static int array3_size = ARRAY_SIZE(array3);
+static int array4_size = ARRAY_SIZE(array4);
+
+int main(void)
+{
+	plan_tests(8);
+	ok1(array1_size == 1);
+	ok1(array2_size == 2);
+	ok1(array3_size == 3);
+	ok1(array4_size == 4);
+
+	ok1(ARRAY_SIZE(array1) == 1);
+	ok1(ARRAY_SIZE(array2) == 2);
+	ok1(ARRAY_SIZE(array3) == 3);
+	ok1(ARRAY_SIZE(array4) == 4);
+
+	return exit_status();
+}

--- a/src/common/libflux/message.c
+++ b/src/common/libflux/message.c
@@ -39,6 +39,7 @@
 
 #include "src/common/libutil/aux.h"
 #include "src/common/libutil/errno_safe.h"
+#include "ccan/array_size/array_size.h"
 
 #include "message.h"
 
@@ -1191,13 +1192,12 @@ static struct typemap typemap[] = {
     { "event", "e", FLUX_MSGTYPE_EVENT},
     { "control", "c", FLUX_MSGTYPE_CONTROL},
 };
-static const int typemap_len = sizeof (typemap) / sizeof (typemap[0]);
 
 const char *flux_msg_typestr (int type)
 {
     int i;
 
-    for (i = 0; i < typemap_len; i++)
+    for (i = 0; i < ARRAY_SIZE (typemap); i++)
         if ((type & typemap[i].type))
             return typemap[i].name;
     return "unknown";
@@ -1207,7 +1207,7 @@ static const char *type2prefix (int type)
 {
     int i;
 
-    for (i = 0; i < typemap_len; i++)
+    for (i = 0; i < ARRAY_SIZE (typemap); i++)
         if ((type & typemap[i].type))
             return typemap[i].sname;
     return "?";
@@ -1227,13 +1227,12 @@ static struct flagmap flagmap[] = {
     { "private", FLUX_MSGFLAG_PRIVATE},
     { "streaming", FLUX_MSGFLAG_STREAMING},
 };
-static const int flagmap_len = sizeof (flagmap) / sizeof (flagmap[0]);
 
 static void flags2str (uint8_t flags, char *buf, int buflen)
 {
     int i, len = 0;
     buf[0] = '\0';
-    for (i = 0; i < flagmap_len; i++) {
+    for (i = 0; i < ARRAY_SIZE (flagmap); i++) {
         if ((flags & flagmap[i].flag)) {
             if (len) {
                 assert (len < (buflen - 1));

--- a/src/common/libflux/test/reactor.c
+++ b/src/common/libflux/test/reactor.c
@@ -19,6 +19,7 @@
 #include "src/common/libutil/xzmalloc.h"
 #include "src/common/libutil/fdutils.h"
 #include "src/common/libtap/tap.h"
+#include "ccan/array_size/array_size.h"
 
 static const size_t fdwriter_bufsize = 10*1024*1024;
 
@@ -924,7 +925,7 @@ static void test_timer (flux_reactor_t *reactor)
     oneshot_errno = 0;
     ok ((w = flux_timer_watcher_create (reactor, 0, 0, oneshot, NULL)) != NULL,
         "timer: creating timer watcher works");
-    for (i = 0; i < sizeof (t) / sizeof (t[0]); i++) {
+    for (i = 0; i < ARRAY_SIZE (t); i++) {
         flux_timer_watcher_reset (w, t[i], 0);
         flux_watcher_start (w);
         t0 = flux_reactor_now (reactor);

--- a/src/common/libidset/Makefile.am
+++ b/src/common/libidset/Makefile.am
@@ -8,6 +8,7 @@ AM_LDFLAGS = \
 AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
+	-I$(top_srcdir)/src/common/libccan \
 	-I$(top_builddir)/src/common/libflux
 
 noinst_LTLIBRARIES = libidset.la

--- a/src/common/libidset/test/idset.c
+++ b/src/common/libidset/test/idset.c
@@ -19,6 +19,7 @@
 #include "src/common/libczmqcontainers/czmq_containers.h"
 #include "src/common/libidset/idset.h"
 #include "src/common/libidset/idset_private.h"
+#include "ccan/array_size/array_size.h"
 
 struct inout {
     const char *in;
@@ -603,7 +604,7 @@ static void tryop (const char *s1,
 
 void test_ops (void)
 {
-    for (int i = 0; i < sizeof (optab) / sizeof (optab[0]); i++) {
+    for (int i = 0; i < ARRAY_SIZE (optab); i++) {
         tryop (optab[i].a,
                optab[i].op,
                optab[i].b,

--- a/src/common/libjob/Makefile.am
+++ b/src/common/libjob/Makefile.am
@@ -9,6 +9,7 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
 	-I$(top_builddir)/src/common/libflux \
+	-I$(top_srcdir)/src/common/libccan \
 	$(JANSSON_CFLAGS) \
 	$(FLUX_SECURITY_CFLAGS)
 

--- a/src/common/libjob/result.c
+++ b/src/common/libjob/result.c
@@ -13,6 +13,8 @@
 #endif
 #include <flux/core.h>
 
+#include "ccan/array_size/array_size.h"
+
 #include "job.h"
 #include "strtab.h"
 
@@ -24,19 +26,18 @@ static struct strtab results[] = {
     { FLUX_JOB_RESULT_CANCELED,  "CANCELED",  "canceled",  "CA", "ca" },
     { FLUX_JOB_RESULT_TIMEOUT,   "TIMEOUT",   "timeout",   "TO", "to" },
 };
-static const size_t results_count = sizeof (results) / sizeof (results[0]);
 
 
 const char *flux_job_resulttostr (flux_job_result_t result, const char *fmt)
 {
-    return strtab_numtostr (result, fmt, results, results_count);
+    return strtab_numtostr (result, fmt, results, ARRAY_SIZE (results));
 }
 
 int flux_job_strtoresult (const char *s, flux_job_result_t *result)
 {
     int num;
 
-    if ((num = strtab_strtonum (s, results, results_count)) < 0)
+    if ((num = strtab_strtonum (s, results, ARRAY_SIZE (results))) < 0)
         return -1;
     if (result)
         *result = num;

--- a/src/common/libjob/state.c
+++ b/src/common/libjob/state.c
@@ -13,6 +13,8 @@
 #endif
 #include <flux/core.h>
 
+#include "ccan/array_size/array_size.h"
+
 #include "job.h"
 #include "strtab.h"
 
@@ -25,19 +27,18 @@ static struct strtab states[] = {
     { FLUX_JOB_STATE_CLEANUP,   "CLEANUP",  "cleanup",  "C", "c" },
     { FLUX_JOB_STATE_INACTIVE,  "INACTIVE", "inactive", "I", "i" },
 };
-static const size_t states_count = sizeof (states) / sizeof (states[0]);
 
 
 const char *flux_job_statetostr (flux_job_state_t state, const char *fmt)
 {
-    return strtab_numtostr (state, fmt, states, states_count);
+    return strtab_numtostr (state, fmt, states, ARRAY_SIZE (states));
 }
 
 int flux_job_strtostate (const char *s, flux_job_state_t *state)
 {
     int num;
 
-    if ((num = strtab_strtonum (s, states, states_count)) < 0)
+    if ((num = strtab_strtonum (s, states, ARRAY_SIZE (states))) < 0)
         return -1;
     if (state)
         *state = num;

--- a/src/common/libjob/test/jobspec1.c
+++ b/src/common/libjob/test/jobspec1.c
@@ -19,13 +19,14 @@
 
 #include "src/common/libjob/jobspec1.h"
 #include "src/common/libtap/tap.h"
+#include "ccan/array_size/array_size.h"
 
 extern char **environ;
 
 void check_stdio_cwd (void)
 {
     char *argv[] = {"this", "is", "a", "test"};
-    int argc = sizeof (argv) / sizeof (argv[0]);
+    int argc = ARRAY_SIZE (argv);
     flux_jobspec1_t *jobspec;
     char *path;
 
@@ -115,7 +116,7 @@ void check_stdio_cwd (void)
 void check_env (void)
 {
     char *argv[] = {"this", "is", "a", "test"};
-    int argc = sizeof (argv) / sizeof (argv[0]);
+    int argc = ARRAY_SIZE (argv);
     flux_jobspec1_t *jobspec;
     char *val;
 
@@ -201,7 +202,7 @@ void check_env (void)
 void check_attr (void)
 {
     char *argv[] = {"this", "is", "a", "test"};
-    int argc = sizeof (argv) / sizeof (argv[0]);
+    int argc = ARRAY_SIZE (argv);
     flux_jobspec1_t *jobspec;
     json_t *json_ptr;
     int int_val;
@@ -260,7 +261,7 @@ void check_attr (void)
 void check_jobspec (void)
 {
     char *argv[] = {"this", "is", "a", "test"};
-    int argc = sizeof (argv) / sizeof (argv[0]);
+    int argc = ARRAY_SIZE (argv);
     flux_jobspec1_t *jobspec;
     flux_jobspec1_error_t error;
     char *str;
@@ -340,7 +341,7 @@ void check_jobspec (void)
 void check_encoding (void)
 {
     char *argv[] = {"this", "is", "a", "test"};
-    int argc = sizeof (argv) / sizeof (argv[0]);
+    int argc = ARRAY_SIZE (argv);
     flux_jobspec1_t *jobspec;
     char *encoded;
     flux_jobspec1_t *dup;
@@ -395,7 +396,7 @@ void check_encoding (void)
 void check_bad_args (void)
 {
     char *argv[] = {"this", "is", "a", "test"};
-    int argc = sizeof (argv) / sizeof (argv[0]);
+    int argc = ARRAY_SIZE (argv);
 
     ok (flux_jobspec1_from_command (-1, argv, NULL, 1, 1, 1, 0, 5.0) == NULL
             && errno == EINVAL,

--- a/src/common/liboptparse/Makefile.am
+++ b/src/common/liboptparse/Makefile.am
@@ -8,6 +8,7 @@ AM_LDFLAGS = \
 AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
+	-I$(top_srcdir)/src/common/libccan \
 	-I$(top_builddir)/src/common/libflux
 
 noinst_LTLIBRARIES = liboptparse.la

--- a/src/common/liboptparse/test/optparse.c
+++ b/src/common/liboptparse/test/optparse.c
@@ -15,6 +15,7 @@
 
 #include "src/common/libtap/tap.h"
 #include "src/common/liboptparse/optparse.h"
+#include "ccan/array_size/array_size.h"
 
 static void *myfatal_h = NULL;
 
@@ -298,7 +299,7 @@ void test_option_cb (void)
     optparse_err_t e;
     optparse_t *p = optparse_create ("test-help");
     char *av[] = { "test-help", "-h", NULL };
-    int ac = sizeof (av) / sizeof (av[0]) - 1;
+    int ac = ARRAY_SIZE (av) - 1;
     int optindex;
 
     ok (p != NULL, "optparse_create");
@@ -371,7 +372,7 @@ void test_convenience_accessors (void)
 
     char *av[] = { "test", "--foo", "--baz=hello", "--mnf=7", "--neg=-4",
                    "--dub=5.7", "--ndb=-3.2", "--dur=1.5m", NULL };
-    int ac = sizeof (av) / sizeof (av[0]) - 1;
+    int ac = ARRAY_SIZE (av) - 1;
     int rc, optindex;
 
     optparse_t *p = optparse_create ("test");
@@ -544,7 +545,7 @@ void test_multiret (void)
                    "-r", "one", "-mone", "-m", "two",
                    "-o", "-rtwo", "--multi-ret=a,b,c",
                    NULL };
-    int ac = sizeof (av) / sizeof (av[0]) - 1;
+    int ac = ARRAY_SIZE (av) - 1;
     int optindex;
 
     ok (p != NULL, "optparse_create");
@@ -615,7 +616,7 @@ void test_long_only (void)
     char *av[] = { "long-only-test",
                    "-b", "one", "--again-long-only",
                    NULL };
-    int ac = sizeof (av) / sizeof (av[0]) - 1;
+    int ac = ARRAY_SIZE (av) - 1;
     int optindex;
 
     ok (p != NULL, "optparse_create");
@@ -637,7 +638,7 @@ void test_long_only (void)
 
     char *av2[] = { "long-only-test", "--again-long-only", "-bxxx",
                     "--long-only=foo", NULL };
-    ac = sizeof (av2) / sizeof(av2[0]) - 1;
+    ac = ARRAY_SIZE (av2) - 1;
 
     optindex = optparse_parse_args (p, ac, av2);
     ok (optindex == ac, "parse options, verify optindex");
@@ -673,7 +674,7 @@ void test_optional_argument (void)
     char *av[] = { "optarg",
                    "--optional-arg", "extra-args",
                    NULL };
-    int ac = sizeof (av) / sizeof (av[0]) - 1;
+    int ac = ARRAY_SIZE (av) - 1;
     int optindex;
 
     e = optparse_add_option_table (p, opts);
@@ -692,7 +693,7 @@ void test_optional_argument (void)
     char *av2[] = { "optarg",
                    "--optional-arg=foo", "extra-args",
                    NULL };
-    ac = sizeof (av2) / sizeof (av2[0]) - 1;
+    ac = ARRAY_SIZE (av2) - 1;
 
     optindex = optparse_parse_args (p, ac, av2);
     ok (optindex == (ac - 1), "parse options, verify optindex");
@@ -866,7 +867,7 @@ Usage: test two [OPTIONS]...\n\
         "Usage output as expected with subcommands");
 
     char *av[] = { "test", "one", NULL };
-    int ac = sizeof (av) / sizeof (av[0]) - 1;
+    int ac = ARRAY_SIZE (av) - 1;
 
     n = optparse_parse_args (a, ac, av);
     ok (n == 1, "optparse_parse_args");
@@ -875,7 +876,7 @@ Usage: test two [OPTIONS]...\n\
     ok (called == 1, "optparse_run_subcommand: called subcmd_one()");
 
     char *av2[] = { "test", "two", NULL };
-    ac = sizeof (av2) / sizeof (av2[0]) - 1;
+    ac = ARRAY_SIZE (av2) - 1;
 
     n = optparse_parse_args (a, ac, av2);
     ok (n == 1, "optparse_parse_args");
@@ -884,7 +885,7 @@ Usage: test two [OPTIONS]...\n\
     ok (called == 2, "optparse_run_subcommand: called subcmd_two()");
 
     char *av3[] = { "test", "two", "--test-opt", "3", NULL };
-    ac = sizeof (av3) / sizeof (av3[0]) - 1;
+    ac = ARRAY_SIZE (av3) - 1;
 
     // Run subcommand before parse also runs subcommand:
     //
@@ -894,7 +895,7 @@ Usage: test two [OPTIONS]...\n\
 
     // Test unknown option prints expected error:
     char *av4[] = { "test", "two", "--unknown", NULL };
-    ac = sizeof (av4) / sizeof (av4[0]) - 1;
+    ac = ARRAY_SIZE (av4) - 1;
 
     e = optparse_set (b, OPTPARSE_FATALERR_FN, do_nothing);
 
@@ -908,7 +909,7 @@ Try `test two --help' for more information.\n",
 
     // Test unknown short option prints expected error
     char *av41[] = { "test", "two", "-X", NULL };
-    ac = sizeof (av41) / sizeof (av41[0]) - 1;
+    ac = ARRAY_SIZE (av41) - 1;
 
     diag ("parsing test two -X");
     n = optparse_run_subcommand (a, ac, av41);
@@ -921,7 +922,7 @@ Try `test two --help' for more information.\n",
 
     // Test unknown short option with good option prints expected error
     char *av42[] = { "test", "two", "-Zt", "foo", NULL};
-    ac = sizeof (av42) / sizeof (av42[0]) - 1;
+    ac = ARRAY_SIZE (av42) - 1;
 
     diag ("parsing test two -Zt foo");
     n = optparse_run_subcommand (a, ac, av42);
@@ -935,7 +936,7 @@ Try `test two --help' for more information.\n",
 
     // Test no subcommand (and subcommand required) prints error
     char *av5[] = { "test", NULL };
-    ac = sizeof (av5) / sizeof (av5[0]) - 1;
+    ac = ARRAY_SIZE (av5) - 1;
 
     // Set OPTPARSE_PRINT_SUBCMDS true:
     e = optparse_set (a, OPTPARSE_PRINT_SUBCMDS, 1);
@@ -1002,7 +1003,7 @@ Usage: test one [OPTIONS]\n\
     optparse_set_data (d, "argc", &value);
 
     char *av6[] = { "test", "three", "--help", NULL };
-    ac = sizeof (av6) / sizeof (av6[0]) - 1;
+    ac = ARRAY_SIZE (av6) - 1;
 
     n = optparse_run_subcommand (a, ac, av6);
     ok (n == 0, "optparse_run_subcommand with OPTPARSE_SUBCMD_NOOPTS");
@@ -1017,7 +1018,7 @@ void test_corner_case (void)
     optparse_err_t e;
     optparse_t *p = optparse_create ("optarg");
     char *av[] = { "cornercase", NULL };
-    int ac = sizeof (av) / sizeof (av[0]) - 1;
+    int ac = ARRAY_SIZE (av) - 1;
     int optindex;
 
     ok (p != NULL, "optparse_create");
@@ -1068,7 +1069,7 @@ void test_reset (void)
     ok (optparse_option_index (q) == -1, "subcmd: option index is -1");
 
     char *av[] = { "test", "-t", "2", "one", "--test-opt=5", NULL };
-    int ac = sizeof (av) / sizeof (av[0]) - 1;
+    int ac = ARRAY_SIZE (av) - 1;
 
     n = optparse_parse_args (p, ac, av);
     ok (n == 3, "optparse_parse_args() expected 3 got %d", n);
@@ -1118,7 +1119,7 @@ void test_non_option_arguments (void)
     };
     optparse_t *p = optparse_create ("non-option-arg");
     char *av[] = { "non-option-arg", "--test=foo", "--", "baz", NULL };
-    int ac = sizeof (av) / sizeof (*av) - 1;
+    int ac = ARRAY_SIZE (av) - 1;
     int optindex;
 
     ok (p != NULL, "optparse_create");
@@ -1132,7 +1133,7 @@ void test_non_option_arguments (void)
 
     optparse_reset (p);
     char *av2[] = { "non-option-arg", "foo", "bar", NULL };
-    ac = sizeof (av2) / sizeof (*av2) - 1;
+    ac = ARRAY_SIZE (av2) - 1;
     ok (optparse_parse_args (p, ac, av2) != -1, "optparse_parse_args");
     optindex = optparse_option_index (p);
     ok (optindex == 1, "argv with no options, optindex is 1");
@@ -1145,7 +1146,7 @@ void test_non_option_arguments (void)
     //
     optparse_reset (p);
     char *av3[] = { "non-option-arg", "-1234", NULL };
-    ac = sizeof (av3) / sizeof (*av3) - 1;
+    ac = ARRAY_SIZE (av3) - 1;
     ok (optparse_parse_args (p, ac, av3) != -1, "optparse_parse_args");
     optindex = optparse_option_index (p);
     ok (optindex == 1,
@@ -1154,7 +1155,7 @@ void test_non_option_arguments (void)
 
     optparse_reset (p);
     char *av4[] = { "non-option-arg", "1234", "--test=foo", NULL };
-    ac = sizeof (av4) / sizeof (*av4) - 1;
+    ac = ARRAY_SIZE (av4) - 1;
     ok (optparse_parse_args (p, ac, av4) != -1, "optparse_parse_args");
     optindex = optparse_option_index (p);
     ok (optindex == 1,
@@ -1273,13 +1274,13 @@ static void test_optparse_get ()
 static void test_optional_args ()
 {
     char *av1[] = { "test-optional-args", "-xx", "-y2", NULL };
-    int ac1 =  sizeof (av1) / sizeof (av1[0]) - 1;
+    int ac1 =  ARRAY_SIZE (av1) - 1;
 
     char *av2[] = { "test-optional-args", "--testx=2", "--testy=2", NULL };
-    int ac2 =  sizeof (av2) / sizeof (av2[0]) - 1;
+    int ac2 =  ARRAY_SIZE (av2) - 1;
 
     char *av3[] = { "test-optional-args", "--testx", "--testy", NULL };
-    int ac3 =  sizeof (av3) / sizeof (av3[0]) - 1;
+    int ac3 =  ARRAY_SIZE (av3) - 1;
 
     struct optparse_option opts [] = {
         { .name = "testx",

--- a/src/common/libpmi/Makefile.am
+++ b/src/common/libpmi/Makefile.am
@@ -8,6 +8,7 @@ AM_LDFLAGS = \
 AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
+	-I$(top_srcdir)/src/common/libccan \
 	-I$(top_builddir)/src/common/libflux
 
 noinst_LTLIBRARIES = \

--- a/src/common/libpmi/pmi_strerror.c
+++ b/src/common/libpmi/pmi_strerror.c
@@ -15,6 +15,8 @@
 #include <errno.h>
 #include <string.h>
 
+#include "ccan/array_size/array_size.h"
+
 #include "pmi.h"
 #include "pmi_strerror.h"
 
@@ -41,14 +43,13 @@ static etab_t pmi_errors[] = {
     { PMI_ERR_INVALID_KEYVALP,  "invalid keyvalp argument" },
     { PMI_ERR_INVALID_SIZE,     "invalid size argument" },
 };
-static const int pmi_errors_len = sizeof (pmi_errors) / sizeof (pmi_errors[0]);
 
 const char *pmi_strerror (int rc)
 {
     static char unknown[] = "pmi error XXXXXXXXX";
     int i;
 
-    for (i = 0; i < pmi_errors_len; i++) {
+    for (i = 0; i < ARRAY_SIZE (pmi_errors); i++) {
         if (pmi_errors[i].errnum == rc)
             return pmi_errors[i].errstr;
     }

--- a/src/common/librouter/test/rpc_track.c
+++ b/src/common/librouter/test/rpc_track.c
@@ -20,6 +20,7 @@
 #include "src/common/libczmqcontainers/czmq_containers.h"
 #include "src/common/librouter/msg_hash.h"
 #include "src/common/libtap/tap.h"
+#include "ccan/array_size/array_size.h"
 
 #ifndef UUID_STR_LEN
 #define UUID_STR_LEN 37     // defined in later libuuid headers
@@ -104,7 +105,7 @@ void test_purge (void)
     ok (count == 0,
         "rpc_track_purge does nothing on empty hash");
 
-    for (i = 0; i < sizeof (msg) / sizeof (msg[0]); i++)
+    for (i = 0; i < ARRAY_SIZE (msg); i++)
         rpc_track_update (rt, msg[i]);
     ok (rpc_track_count (rt) == 2,
         "rpc_track_update tracks 2 messages");
@@ -118,7 +119,7 @@ void test_purge (void)
 
     rpc_track_destroy (rt);
 
-    for (i = 0; i < sizeof (msg) / sizeof (msg[0]); i++)
+    for (i = 0; i < ARRAY_SIZE (msg); i++)
         flux_msg_decref (msg[i]);
 }
 
@@ -148,21 +149,21 @@ void test_basic (void)
     ok (rpc_track_count (rt) == 0,
         "rpc_track_count returns 0 on empty hash");
 
-    for (i = 0; i < sizeof (req) / sizeof (req[0]); i++)
+    for (i = 0; i < ARRAY_SIZE (req); i++)
         rpc_track_update (rt, req[i]);
     ok (rpc_track_count (rt) == 3,
         "rpc_track_update works (3 of 4 requests tracked)");
 
-    for (i = 0; i < sizeof (rep) / sizeof (rep[0]); i++)
+    for (i = 0; i < ARRAY_SIZE (rep); i++)
         rpc_track_update (rt, rep[i]);
     ok (rpc_track_count (rt) == 1,
         "rpc_track_update works (2 requests terminated)");
 
     rpc_track_destroy (rt);
 
-    for (i = 0; i < sizeof (req) / sizeof (req[0]); i++)
+    for (i = 0; i < ARRAY_SIZE (req); i++)
         flux_msg_decref (req[i]);
-    for (i = 0; i < sizeof (rep) / sizeof (rep[0]); i++)
+    for (i = 0; i < ARRAY_SIZE (rep); i++)
         flux_msg_decref (rep[i]);
 }
 
@@ -186,7 +187,7 @@ void test_disconnect (void)
     if (!(rt = rpc_track_create (MSG_HASH_TYPE_UUID_MATCHTAG)))
         BAIL_OUT ("rpc_track_create failed");
 
-    for (i = 0; i < sizeof (req) / sizeof (req[0]); i++)
+    for (i = 0; i < ARRAY_SIZE (req); i++)
         rpc_track_update (rt, req[i]);
     ok (rpc_track_count (rt) == 3,
         "rpc_track_update works (3 of 4 requests tracked)");
@@ -197,7 +198,7 @@ void test_disconnect (void)
 
     rpc_track_destroy (rt);
 
-    for (i = 0; i < sizeof (req) / sizeof (req[0]); i++)
+    for (i = 0; i < ARRAY_SIZE (req); i++)
         flux_msg_decref (req[i]);
     flux_msg_decref (dis);
 }

--- a/src/common/libsubprocess/Makefile.am
+++ b/src/common/libsubprocess/Makefile.am
@@ -8,6 +8,7 @@ AM_LDFLAGS = \
 AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
+	-I$(top_srcdir)/src/common/libccan \
 	-I$(top_builddir)/src/common/libflux
 
 noinst_LTLIBRARIES = \

--- a/src/common/libsubprocess/test/cmd.c
+++ b/src/common/libsubprocess/test/cmd.c
@@ -13,6 +13,7 @@
 
 #include "src/common/libtap/tap.h"
 #include "src/common/libsubprocess/command.h"
+#include "ccan/array_size/array_size.h"
 
 /*
  *  Check basic flux_cmd_create () with args
@@ -26,7 +27,7 @@ void check_basic_create ()
         "bar",
         NULL
     };
-    int argc = (sizeof (argv)/sizeof (argv[0])) - 1;
+    int argc = ARRAY_SIZE (argv) - 1;
     char * env[] = {
         "FOO=bar",
         "PATH=/bin",
@@ -204,7 +205,7 @@ void test_stringify (void)
         "bar",
         NULL
     };
-    int argc = (sizeof (argv)/sizeof (argv[0])) - 1;
+    int argc = ARRAY_SIZE (argv) - 1;
     char * env[] = {
         "FOO=bar",
         "PATH=/bin",
@@ -248,7 +249,7 @@ void test_arg_insert_delete (void)
         "bar",
         NULL
     };
-    int argc = (sizeof (argv)/sizeof (argv[0])) - 1;
+    int argc = ARRAY_SIZE (argv) - 1;
     char * env[] = {
         "FOO=bar",
         "PATH=/bin",

--- a/src/common/libutil/test/jpath.c
+++ b/src/common/libutil/test/jpath.c
@@ -17,6 +17,7 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "ccan/array_size/array_size.h"
 #include "src/common/libtap/tap.h"
 #include "jpath.h"
 
@@ -141,7 +142,7 @@ void basic (void)
     ok (jpath_del (o, "a.c.d") == 0,
         "jpath_del on nonexistent path does not fail");
 
-    for (i = 0; i < sizeof (val)/sizeof (val[0]); i++)
+    for (i = 0; i < ARRAY_SIZE (val); i++)
         json_decref (val[i]);
     json_decref (o);
 }

--- a/src/common/libzmqutil/monitor.c
+++ b/src/common/libzmqutil/monitor.c
@@ -15,6 +15,8 @@
 #include <zmq.h>
 #include <uuid.h>
 
+#include "ccan/array_size/array_size.h"
+
 #include "reactor.h"
 #include "monitor.h"
 
@@ -109,7 +111,7 @@ static struct {
 static const char *eventstr (struct monitor_event *mevent)
 {
     int i;
-    for (i = 0; i < sizeof (nametab) / sizeof (nametab[0]); i++) {
+    for (i = 0; i < ARRAY_SIZE (nametab); i++) {
         if (mevent->event == nametab[i].event)
             return nametab[i].desc;
     }
@@ -123,7 +125,7 @@ static const char *valuestr (struct monitor_event *mevent)
     static char buf[128];
 
     /* look up valtype for event */
-    for (i = 0; i < sizeof (nametab) / sizeof (nametab[0]); i++) {
+    for (i = 0; i < ARRAY_SIZE (nametab); i++) {
         if (mevent->event == nametab[i].event)
             valtype = nametab[i].valtype;
     }
@@ -135,7 +137,7 @@ static const char *valuestr (struct monitor_event *mevent)
         return buf;
     }
     if (valtype == VAL_PROTO) {
-        for (i = 0; i < sizeof (prototab) / sizeof (prototab[0]); i++) {
+        for (i = 0; i < ARRAY_SIZE (prototab); i++) {
             if (mevent->value == prototab[i].value)
                 return prototab[i].desc;
         }

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -8,6 +8,7 @@ AM_LDFLAGS = \
 AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
+	-I$(top_srcdir)/src/common/libccan \
 	-I$(top_builddir)/src/common/libflux
 
 #  Always set LUA_PATH such that builddir/?.lua is first so that the

--- a/t/request/treq.c
+++ b/t/request/treq.c
@@ -23,6 +23,7 @@
 #include "src/common/libutil/oom.h"
 #include "src/common/libutil/monotime.h"
 #include "src/common/libutil/xzmalloc.h"
+#include "ccan/array_size/array_size.h"
 
 void test_null (flux_t *h, uint32_t nodeid);
 void test_echo (flux_t *h, uint32_t nodeid);
@@ -60,7 +61,7 @@ static test_t tests[] = {
 test_t *test_lookup (const char *name)
 {
     int i;
-    for (i = 0; i < sizeof (tests) / sizeof (tests[0]); i++)
+    for (i = 0; i < ARRAY_SIZE (tests); i++)
         if (!strcmp (tests[i].name, name))
             return &tests[i];
     return NULL;


### PR DESCRIPTION
Use of this handy ccan macro seems justified.

It converts expressions like `sizeof (a) / sizeof (a[0])` to `ARRAY_SIZE(a)` and adds some saftey against using the macro on a function parameter or pointer.

Find all the places that idiom is used and use the macro instead.