### PR TITLE
flux-top: support split of inactive jobs into completed and failed

### DIFF
--- a/doc/man1/flux-top.rst
+++ b/doc/man1/flux-top.rst
@@ -34,6 +34,9 @@ j, down-arrow
 k, up-arrow
    Move cursor up in the job listing.
 
+d
+   Toggle display of inactive job details (failed vs successful jobs).
+
 enter
    Open the job at the current cursor position.  Only Flux instances (colored
    blue in the job listing) owned by the user running ``flux-top`` may be
@@ -70,7 +73,10 @@ The summary pane shows the following information:
 
 - The gpus bargraph, with the same layout as the nodes bargraph.
 
-- The number of pending, running, and inactive jobs.
+- The number of pending, running, and inactive jobs. When executed as the
+  instance owner, inactive jobs are split into completed (successful) and
+  failed (unsuccessful and canceled) jobs. This display can be toggled with
+  the ``d`` key.
 
 - A heart icon that appears each time the instance heartbeat event is
   published.

--- a/src/cmd/top/keys.c
+++ b/src/cmd/top/keys.c
@@ -46,6 +46,9 @@ static void keys_cb (flux_reactor_t *r,
         case KEY_ENTER:
             joblist_pane_enter (keys->top->joblist_pane);
             break;
+        case 'd':
+            summary_pane_toggle_details (keys->top->summary_pane);
+            break;
         case '':
             clear ();
             summary_pane_draw (keys->top->summary_pane);

--- a/src/cmd/top/top.c
+++ b/src/cmd/top/top.c
@@ -138,6 +138,7 @@ static void initialize_curses (void)
     start_color ();
     init_pair (TOP_COLOR_YELLOW, COLOR_YELLOW, -1);
     init_pair (TOP_COLOR_RED, COLOR_RED, -1);
+    init_pair (TOP_COLOR_GREEN, COLOR_GREEN, -1);
     init_pair (TOP_COLOR_BLUE, COLOR_BLUE, -1);
     init_pair (TOP_COLOR_BLUE_HIGHLIGHT, COLOR_BLACK, COLOR_BLUE);
     clear ();

--- a/src/cmd/top/top.h
+++ b/src/cmd/top/top.h
@@ -21,6 +21,7 @@ int mvwprintw(WINDOW *win, int y, int x, const char *fmt, ...)
 enum {
     TOP_COLOR_YELLOW = 1, // origin of 1 since 0 is an invalid color pair index
     TOP_COLOR_RED,
+    TOP_COLOR_GREEN,
     TOP_COLOR_BLUE,
     TOP_COLOR_BLUE_HIGHLIGHT,
 };
@@ -56,6 +57,7 @@ void summary_pane_draw (struct summary_pane *sum);
 void summary_pane_refresh (struct summary_pane *sum);
 void summary_pane_query (struct summary_pane *sum);
 void summary_pane_heartbeat (struct summary_pane *sum);
+void summary_pane_toggle_details (struct summary_pane *sum);
 
 struct joblist_pane *joblist_pane_create (struct top *top);
 void joblist_pane_destroy (struct joblist_pane *sum);


### PR DESCRIPTION
@woodard had requested splitting the flux-top(1) inactive job stats into successful vs failed for easier monitoring of a test workload.

I already had this lying around, so I thought I'd propose it. I think @garlick had something similar but in a different form? We could use that instead, but I could not find it.

This version keeps the default display unless you are connecting to the instance as the owner, then details are displayed by default. In either case, the display can be toggled with the `d` key. The end result is fairly simple:

![Screenshot from 2022-07-26 09-53-17](https://user-images.githubusercontent.com/741970/181828578-8c9dc374-0f26-499a-81cc-cdadb584ec54.png)
