### PR TITLE
add flux_open_ex(3)

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -155,6 +155,7 @@ MAN3_FILES_SECONDARY = \
 	man3/flux_clone.3 \
 	man3/flux_close.3 \
 	man3/flux_reconnect.3 \
+	man3/flux_open_ex.3 \
 	man3/flux_aux_get.3 \
 	man3/flux_flags_unset.3 \
 	man3/flux_flags_get.3 \

--- a/doc/man3/flux_open.rst
+++ b/doc/man3/flux_open.rst
@@ -12,6 +12,8 @@ SYNOPSIS
 
    flux_t *flux_open (const char *uri, int flags);
 
+   flux_t *flux_open_ex (const char *uri, int flags, flux_error_t *error);
+
    void flux_close (flux_t *h);
 
    flux_t *flux_clone (flux_t *h);
@@ -22,8 +24,10 @@ SYNOPSIS
 DESCRIPTION
 ===========
 
-``flux_open()`` creates a ``flux_t`` handle, used to communicate with the
-Flux message broker.
+``flux_open()`` and ``flux_open_ex()`` create a ``flux_t`` handle, used
+to communicate with the Flux message broker. ``flux_open_ex()`` takes an
+optional pointer to a ``flux_error_t`` structure which, when non-NULL, will
+be used to store any errors which may have otherwise gone to ``stderr``.
 
 The *uri* scheme (before "://") specifies the "connector" that will be used
 to establish the connection. The *uri* path (after "://") is parsed by the

--- a/doc/manpages.py
+++ b/doc/manpages.py
@@ -159,6 +159,7 @@ man_pages = [
     ('man3/flux_open', 'flux_clone', 'open/close connection to Flux Message Broker', [author], 3),
     ('man3/flux_open', 'flux_close', 'open/close connection to Flux Message Broker', [author], 3),
     ('man3/flux_open', 'flux_open', 'open/close connection to Flux Message Broker', [author], 3),
+    ('man3/flux_open', 'flux_open_ex', 'open/close connection to Flux Message Broker', [author], 3),
     ('man3/flux_open', 'flux_reconnect', 'open/close connection to Flux Message Broker', [author], 3),
     ('man3/flux_periodic_watcher_create', 'flux_periodic_watcher_reset', 'set/reset a timer', [author], 3),
     ('man3/flux_periodic_watcher_create', 'flux_periodic_watcher_create', 'set/reset a timer', [author], 3),

--- a/src/bindings/python/flux/core/handle.py
+++ b/src/bindings/python/flux/core/handle.py
@@ -61,10 +61,15 @@ class Flux(Wrapper):
             self.tls.exception = None
 
         if handle is None:
+            error = ffi.new("flux_error_t[1]")
             try:
-                self.handle = raw.flux_open(url, flags)
-            except EnvironmentError as err:
-                raise EnvironmentError(err.errno, "Unable to connect to Flux")
+                self.handle = raw.flux_open_ex(url, flags, error)
+            except OSError as err:
+                msg = "Unable to connect to Flux"
+                errmsg = ffi.string(error[0].text).decode("utf-8")
+                if errmsg:
+                    msg += f": {errmsg}"
+                raise OSError(err.errno, msg)
 
         self.aux_txn = None
         self._active_watchers = set()

--- a/src/common/libflux/connector.h
+++ b/src/common/libflux/connector.h
@@ -19,7 +19,9 @@ extern "C" {
  ** Only handle implementation stuff below.
  ** Flux_t handle users should not use these interfaces.
  */
-typedef flux_t *(connector_init_f)(const char *uri, int flags);
+typedef flux_t *(connector_init_f)(const char *uri,
+                                   int flags,
+                                   flux_error_t *errp);
 
 struct flux_handle_ops {
     int         (*setopt)(void *impl, const char *option,

--- a/src/common/libflux/handle.h
+++ b/src/common/libflux/handle.h
@@ -76,6 +76,13 @@ enum {
  * in the environment variable FLUX_URI.
  */
 flux_t *flux_open (const char *uri, int flags);
+
+/* Like flux_open(), but if optional flux_error_t parameter is non-NULL,
+ * then any errors normally emitted to stderr will instead be returned
+ * in error->text.
+ */
+flux_t *flux_open_ex (const char *uri, int flags, flux_error_t *error);
+
 void flux_close (flux_t *h);
 
 /* Increment internal reference count on 'h'.

--- a/src/common/libflux/test/handle.c
+++ b/src/common/libflux/test/handle.c
@@ -69,6 +69,24 @@ void test_handle_invalid_args (flux_t *h)
     flux_msg_destroy (msg);
 }
 
+static void test_flux_open_ex ()
+{
+    flux_error_t error;
+
+    ok (flux_open_ex ("foo://foo", 0, &error) == NULL,
+        "flux_open_ex with invalid connector name fails");
+    is ("Unable to find connector name 'foo'", error.text,
+        "flux_open_ex returns expected error in error.text");
+
+    ok (flux_open_ex (NULL, 0x1000000, &error) == NULL,
+        "flux_open_ex with invalid flags fails");
+    is ("invalid flags specified", error.text,
+        "flux_open_ex returns expected error in error.text");
+
+    lives_ok ({flux_open_ex ("foo://foo", 0, NULL);},
+        "flux_open_ex doesn't crash if error parameter is NULL");
+}
+
 int main (int argc, char *argv[])
 {
     flux_t *h;
@@ -229,6 +247,10 @@ int main (int argc, char *argv[])
         "flux_reconnect with null reconnect method fails with ENOSYS");
 
     flux_close (h);
+
+    /* flux_open_ex() */
+    test_flux_open_ex ();
+
     done_testing();
     return (0);
 }

--- a/src/common/libutil/Makefile.am
+++ b/src/common/libutil/Makefile.am
@@ -123,7 +123,8 @@ TESTS = test_sha1.t \
 	test_grudgeset.t \
 	test_digest.t \
 	test_jpath.t \
-	test_errprintf.t
+	test_errprintf.t \
+	test_strstrip.t
 
 test_ldadd = \
 	$(top_builddir)/src/common/libutil/libutil.la \
@@ -254,3 +255,7 @@ test_jpath_t_LDADD = $(test_ldadd)
 test_errprintf_t_SOURCES = test/errprintf.c
 test_errprintf_t_CPPFLAGS = $(test_cppflags)
 test_errprintf_t_LDADD = $(test_ldadd)
+
+test_strstrip_t_SOURCES = test/strstrip.c
+test_strstrip_t_CPPFLAGS = $(test_cppflags)
+test_strstrip_t_LDADD = $(test_ldadd)

--- a/src/common/libutil/Makefile.am
+++ b/src/common/libutil/Makefile.am
@@ -92,7 +92,9 @@ libutil_la_SOURCES = \
 	uri.c \
 	uri.h \
 	errprintf.c \
-	errprintf.h
+	errprintf.h \
+	strstrip.c \
+	strstrip.h
 
 EXTRA_DIST = veb_mach.c
 

--- a/src/common/libutil/errprintf.h
+++ b/src/common/libutil/errprintf.h
@@ -12,6 +12,7 @@
 #define _UTIL_ERRPRINTF_H
 
 #include <stdarg.h>
+#include <string.h>
 
 #include "src/common/libflux/types.h" /* flux_error_t */
 
@@ -28,6 +29,12 @@ int errprintf (flux_error_t *errp, const char *fmt, ...)
 
 int verrprintf (flux_error_t *errp, const char *fmt, va_list ap);
 
+
+static inline void err_init (flux_error_t *errp)
+{
+    if (errp)
+        memset (errp->text, 0, sizeof (errp->text));
+}
 
 #endif /* !_UTIL_ERRPRINTF_H */
 

--- a/src/common/libutil/popen2.c
+++ b/src/common/libutil/popen2.c
@@ -88,11 +88,10 @@ struct popen2_child *popen2 (const char *path, char *const argv[])
     struct popen2_child *p = NULL;
     int n, saved_errno;
 
-    if (!(p = malloc (sizeof (*p)))) {
+    if (!(p = calloc (1, sizeof (*p)))) {
         saved_errno = ENOMEM;
         goto error;
     }
-    memset (p, 0, sizeof (*p));
     p->magic = PXOPEN_CHILD_MAGIC;
     p->fd[SP_CHILD] = -1;
     p->fd[SP_PARENT] = -1;

--- a/src/common/libutil/popen2.c
+++ b/src/common/libutil/popen2.c
@@ -50,8 +50,10 @@ int popen2_get_fd (struct popen2_child *p)
 static void popen2_child_close_fd (void *arg, int fd)
 {
     struct popen2_child *p = arg;
-    if (fd != STDIN_FILENO && fd != STDOUT_FILENO && fd != STDERR_FILENO
-                                                  && fd != p->ctl[SP_CHILD])
+    if (fd != STDIN_FILENO
+        && fd != STDOUT_FILENO
+        && fd != STDERR_FILENO
+        && fd != p->ctl[SP_CHILD])
         (void)close (fd);
 }
 
@@ -167,9 +169,9 @@ int pclose2 (struct popen2_child *p)
             }
         }
         if ((p->fd[SP_PARENT] >= 0 && close (p->fd[SP_PARENT]) < 0)
-         || (p->fd[SP_CHILD] >= 0 && close (p->fd[SP_CHILD]) < 0)
-         || (p->ctl[SP_PARENT] >= 0 && close (p->ctl[SP_PARENT]) < 0)
-         || (p->ctl[SP_CHILD] >= 0 && close (p->ctl[SP_CHILD]) < 0)) {
+            || (p->fd[SP_CHILD] >= 0 && close (p->fd[SP_CHILD]) < 0)
+            || (p->ctl[SP_PARENT] >= 0 && close (p->ctl[SP_PARENT]) < 0)
+            || (p->ctl[SP_CHILD] >= 0 && close (p->ctl[SP_CHILD]) < 0)) {
             saved_errno = errno;
             rc = -1;
         }

--- a/src/common/libutil/popen2.c
+++ b/src/common/libutil/popen2.c
@@ -162,10 +162,12 @@ int pclose2 (struct popen2_child *p)
                 saved_errno = errno;
                 rc = -1;
             } else {
-                if (!WIFEXITED (status) || WEXITSTATUS (status) != 0) {
+                if (!WIFEXITED (status)) {
                     saved_errno = EIO;
                     rc = -1;
                 }
+                else
+                    rc = status;
             }
         }
         if ((p->fd[SP_PARENT] >= 0 && close (p->fd[SP_PARENT]) < 0)

--- a/src/common/libutil/popen2.c
+++ b/src/common/libutil/popen2.c
@@ -63,10 +63,8 @@ static void child (struct popen2_child *p, const char *path, char *const argv[])
 {
     int saved_errno;
 
-    (void)close (STDIN_FILENO);
-    (void)close (STDOUT_FILENO);
-    if (    dup2 (p->fd[SP_CHILD], STDIN_FILENO) < 0
-         || dup2 (p->fd[SP_CHILD], STDOUT_FILENO) < 0) {
+    if (dup2 (p->fd[SP_CHILD], STDIN_FILENO) < 0
+        || dup2 (p->fd[SP_CHILD], STDOUT_FILENO) < 0) {
         saved_errno = errno;
         goto error;
     }

--- a/src/common/libutil/popen2.h
+++ b/src/common/libutil/popen2.h
@@ -11,11 +11,18 @@
 #ifndef _UTIL_POPEN2_H
 #define _UTIL_POPEN2_H
 
+enum {
+    POPEN2_CAPTURE_STDERR = 0x1,
+};
+
 struct popen2_child;
 
-struct popen2_child *popen2 (const char *path, char *const argv[]);
+struct popen2_child *popen2 (const char *path,
+                             char *const argv[],
+                             int flags);
 
 int popen2_get_fd (struct popen2_child *p);
+int popen2_get_stderr_fd (struct popen2_child *p);
 
 int pclose2 (struct popen2_child *p);
 

--- a/src/common/libutil/strstrip.c
+++ b/src/common/libutil/strstrip.c
@@ -1,0 +1,79 @@
+/************************************************************\
+ * Copyright 2022 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <string.h>
+#include <errno.h>
+#include <ctype.h>
+
+char *strstrip (char *s)
+{
+    size_t size;
+    char *end;
+
+    if (!s) {
+        errno = EINVAL;
+        return NULL;
+    }
+
+    size = strlen (s);
+
+    if (!size)
+        return s;
+
+    end = s + size - 1;
+    while (end >= s && isspace ((unsigned char) *end))
+        end--;
+    *(end + 1) = '\0';
+
+    while (*s && isspace((unsigned char) *s))
+        s++;
+
+    return s;
+}
+
+char *strstrip_copy (const char *s)
+{
+    size_t size;
+    char *end;
+    char *result = NULL;
+
+    if (!s) {
+        errno = EINVAL;
+        return NULL;
+    }
+
+    if (s[0] == '\0')
+        return strdup (s);
+
+    /* Work from front to back so we do not have to copy all of 's'
+     */
+    while (*s && isspace ((unsigned char) *s))
+        s++;
+
+    if (!(result = strdup (s)))
+        return NULL;
+
+    if ((size = strlen (result)) == 0)
+        return result;
+
+    end = result + size - 1;
+    while (end >= result && isspace ((unsigned char) *end))
+        end--;
+    *(end + 1) = '\0';
+
+    return result;
+}
+
+/* vi: ts=4 sw=4 expandtab
+ */

--- a/src/common/libutil/strstrip.h
+++ b/src/common/libutil/strstrip.h
@@ -1,0 +1,25 @@
+/************************************************************\
+ * Copyright 2022 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _UTIL_STRSTRIP_H
+#define _UTIL_STRSTRIP_H
+
+/*  Strip leading and trailing whitespace from string 's'.
+ *  Returns a pointer inside of 's'.
+ */
+char *strstrip (char *s);
+
+/*  Like strstrip(), but returns a copy of stripped 's'
+ */
+char *strstrip_copy (char *s);
+
+#endif /* !_UTIL_STRSTRIP_H */
+
+// vi:ts=4 sw=4 expandtab

--- a/src/common/libutil/test/errprintf.c
+++ b/src/common/libutil/test/errprintf.c
@@ -23,6 +23,9 @@ int main(int argc, char** argv)
     flux_error_t error;
     char longstring[256];
 
+    lives_ok ({err_init (NULL);},
+              "err_init with NULL args doesn't crash");
+
     lives_ok ({errprintf (NULL, NULL);},
               "errprintf with no args doesn't crash");
     lives_ok ({errprintf (&error, NULL);},
@@ -33,6 +36,10 @@ int main(int argc, char** argv)
     errprintf (&error, "foo");
     is (error.text, "foo",
         "errprintf with static format works");
+
+    err_init (&error);
+    is (error.text, "",
+        "err_init zeros error.text buffer");
 
     errno = 64;
     errprintf (&error, "foo");

--- a/src/common/libutil/test/popen2.c
+++ b/src/common/libutil/test/popen2.c
@@ -27,13 +27,13 @@ int main(int argc, char** argv)
     plan (NO_PLAN);
 
     /* open/close */
-    ok ((p = popen2 ("cat", av)) != NULL,
+    ok ((p = popen2 ("cat", av, 0)) != NULL,
         "popen2 cat worked");
     ok (pclose2 (p) == 0,
         "immediate pclose2 OK");
 
     /* open/write/close */
-    ok ((p = popen2 ("cat", av)) != NULL,
+    ok ((p = popen2 ("cat", av, 0)) != NULL,
         "popen2 cat worked");
     fd = popen2_get_fd (p);
     ok (fd >= 0,
@@ -44,7 +44,7 @@ int main(int argc, char** argv)
         "pclose2 with read data pending OK");
 
     /* open/write/read/close */
-    ok ((p = popen2 ("cat", av)) != NULL,
+    ok ((p = popen2 ("cat", av, 0)) != NULL,
         "popen2 cat worked");
     fd = popen2_get_fd (p);
     ok (fd >= 0,
@@ -59,12 +59,12 @@ int main(int argc, char** argv)
 
     /* open failure */
     errno = 0;
-    p = popen2 ("/noexist", av);
+    p = popen2 ("/noexist", av, 0);
     ok (p == NULL && errno == ENOENT,
         "popen2 /noexist failed with ENOENT");
 
     /* open/close (child exit error) */
-    ok ((p = popen2 ("/bin/false", av)) != NULL,
+    ok ((p = popen2 ("/bin/false", av, 0)) != NULL,
         "popen2 /bin/false OK");
     ok (pclose2 (p) == 0x100,
         "pclose2 returns child exit code 1");

--- a/src/common/libutil/test/popen2.c
+++ b/src/common/libutil/test/popen2.c
@@ -66,9 +66,8 @@ int main(int argc, char** argv)
     /* open/close (child exit error) */
     ok ((p = popen2 ("/bin/false", av)) != NULL,
         "popen2 /bin/false OK");
-    errno = 0;
-    ok (pclose2 (p) < 0 && errno == EIO,
-        "pclose2 failed with EIO");
+    ok (pclose2 (p) == 0x100,
+        "pclose2 returns child exit code 1");
 
     done_testing();
 }

--- a/src/common/libutil/test/popen2.c
+++ b/src/common/libutil/test/popen2.c
@@ -11,10 +11,40 @@
 #include <string.h>
 #include <errno.h>
 #include <stdint.h>
+#include <sys/wait.h>
 
 #include "src/common/libtap/tap.h"
 #include "src/common/libutil/popen2.h"
 #include "src/common/libutil/read_all.h"
+
+static void test_popen2_stderr ()
+{
+    struct popen2_child *p;
+    char *av[] = { "cat",  "/nosuchfile", NULL };
+    char *buf;
+    int efd;
+
+    ok (popen2 ("cat", av, 42) == NULL && errno == EINVAL,
+        "popen2() with invalid flags returns EINVAL");
+
+    ok ((p = popen2 ("cat", av, POPEN2_CAPTURE_STDERR)) != NULL,
+        "popen2() with POPEN2_CAPTURE_STDERR works");
+    ok (pclose2 (p) == 0x100,
+        "immediate pclose2 returns failed exit status of command");
+
+    ok ((p = popen2 ("cat", av, POPEN2_CAPTURE_STDERR)) != NULL,
+        "popen2() with POPEN2_CAPTURE_STDERR works");
+    ok ((efd = popen2_get_stderr_fd (p)) >= 0,
+        "popen2_get_stderr_fd() works");
+    ok (read_all (efd, (void **) &buf) > 0,
+        "read from stderr fd worked");
+    ok (pclose2 (p) == 0x100,
+        "pclose2 returns failed exit status of command");
+
+    like (buf, ".*: No such file or directory",
+        "stderr contained expected error");
+    free (buf);
+}
 
 int main(int argc, char** argv)
 {
@@ -69,6 +99,7 @@ int main(int argc, char** argv)
     ok (pclose2 (p) == 0x100,
         "pclose2 returns child exit code 1");
 
+    test_popen2_stderr ();
     done_testing();
 }
 

--- a/src/common/libutil/test/strstrip.c
+++ b/src/common/libutil/test/strstrip.c
@@ -1,0 +1,83 @@
+/************************************************************\
+ * Copyright 2022 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#include <errno.h>
+#include <string.h>
+
+#include "src/common/libtap/tap.h"
+#include "src/common/libutil/strstrip.h"
+
+struct str_test {
+    const char *input;
+    const char *printable;
+    const char *expected;
+};
+
+struct str_test tests[] = {
+    { "",               "",                 ""  },
+    { "   ",            "",                 ""  },
+    { "\t",             "",                 ""  },
+    { "a",              "a",                "a" },
+    { "no thing",       "no thing",         "no thing" },
+    { "   no thing",    "   no thing",      "no thing" },
+    { "   no thing\n",  "   no thing\\n",   "no thing" },
+    { "   no thing  \n","   no thing \\n",  "no thing" },
+    { "a     ",         "     a",           "a" },
+    { "\na   ",         "\\n  a",           "a" },
+    { NULL, NULL, NULL },
+};
+
+int main(int argc, char** argv)
+{
+    struct str_test *st = tests;
+
+    plan (NO_PLAN);
+
+    ok (strstrip (NULL) == NULL && errno == EINVAL,
+        "strstrip (NULL) returns EINVAL");
+    ok (strstrip_copy (NULL) == NULL && errno == EINVAL,
+        "strstrip_copy (NULL) returns EINVAL");
+
+    while (st->input != NULL) {
+        char *result;
+        char *s = strdup (st->input);
+        if (!s)
+            BAIL_OUT ("Failed to copy input string %s", st->input);
+
+        /* strstrip() */
+        ok ((result = strstrip (s)) != NULL,
+            "strstrip (\"%s\")",
+            st->printable);
+        is (result, st->expected,
+           "got expected result");
+        free (s);
+
+        /* strstrip_copy() */
+        if (!(s = strdup (st->input)))
+            BAIL_OUT ("Failed to copy input string %s", st->input);
+        ok ((result = strstrip_copy (s)) != NULL,
+            "strstrip_copy (\"%s\")",
+            st->printable);
+        is (result, st->expected,
+           "got expected result");
+        is (s, st->input,
+           "original string unmodified");
+        free (s);
+        free (result);
+
+        st++;
+    }
+
+    done_testing();
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libutil/uri.c
+++ b/src/common/libutil/uri.c
@@ -60,12 +60,12 @@ char *uri_resolve (const char *uri)
     }
     free (cpy);
 
-    if (!(child = popen2 ("flux", argv))
+    if (!(child = popen2 ("flux", argv, 0))
         || (read_all (popen2_get_fd (child), (void **)&result) < 0))
         goto out;
     nullify_newline (result);
 out:
-    if (pclose2 (child) < 0) {
+    if (pclose2 (child) != 0) {
         /* flux-uri returned error */
         free (result);
         result = NULL;

--- a/src/connectors/local/local.c
+++ b/src/connectors/local/local.c
@@ -174,7 +174,7 @@ static int override_retry_count (struct usock_retry_params *retry)
     return 0;
 }
 
-flux_t *connector_init (const char *path, int flags)
+flux_t *connector_init (const char *path, int flags, flux_error_t *errp)
 {
     struct local_connector *ctx;
 

--- a/src/connectors/loop/loop.c
+++ b/src/connectors/loop/loop.c
@@ -95,7 +95,7 @@ static void op_fini (void *impl)
     free (c);
 }
 
-flux_t *connector_init (const char *path, int flags)
+flux_t *connector_init (const char *path, int flags, flux_error_t *errp)
 {
     loop_ctx_t *c = malloc (sizeof (*c));
     if (!c) {

--- a/src/connectors/shmem/shmem.c
+++ b/src/connectors/shmem/shmem.c
@@ -102,7 +102,7 @@ static void op_fini (void *impl)
     free (ctx);
 }
 
-flux_t *connector_init (const char *path, int flags)
+flux_t *connector_init (const char *path, int flags, flux_error_t *errp)
 {
 #if HAVE_CALIPER
     cali_id_t uuid   = cali_create_attribute ("flux.uuid",

--- a/src/connectors/ssh/ssh.c
+++ b/src/connectors/ssh/ssh.c
@@ -232,7 +232,7 @@ flux_t *connector_init (const char *path, int flags)
 
     /* Start the ssh command
      */
-    if (!(ctx->p = popen2 (ssh_cmd, argv))) {
+    if (!(ctx->p = popen2 (ssh_cmd, argv, 0))) {
         /* If popen fails because ssh cannot be found, flux_open()
          * will just fail with errno = ENOENT, which is not all that helpful.
          * Emit a hint on stderr even though this is perhaps not ideal.


### PR DESCRIPTION
This stack of changes is prereq for some other, much simpler, work, but the addition of `flux_open_ex(3)` seemed like a good place to stop to ensure this new function gets documented in release notes.

Currently, `flux_open(3)` may emit errors to stderr, especially when using the ssh connector, since all errors from `ssh` will go to the current terminal's `stderr`. This can be inconvenient for some users of libflux, since libraries typically aren't expected to write directly to `stderr`.

This PR first augments `popen2()` to allow capture of `stderr` (along with other minor cleanup), adds some other helper functions, then adds a new `flux_open_ex(3)` interface to libflux which takes an optional `flux_error_t` parameter in which errors can be returned to the caller. Then, the `ssh` connector is updated to capture stderr of the underlying `ssh` command on failure with the new `popen2()` functionality, and copies this back to the user (possibly truncated). Specific errors are added in a few other scenarios, but this wasn't done exhaustively for now to save time.

Finally, the Python `flux.Flux()` implementation is updated to use `flux_open_ex()`, which is probably the right thing, and also has the side effect of testing the interface (though presently there are no specific tests, the existing `flux_open()` tests are assumed to handle most of the testing since it calls `flux_open_ex()`).

This is a WIP because I'm still pondering how to add some specific tests.