### PR TITLE
flux-top: avoid premature exit on recursive top error

### DIFF
--- a/src/cmd/builtin/proxy.c
+++ b/src/cmd/builtin/proxy.c
@@ -361,7 +361,7 @@ static int cmd_proxy (optparse_t *p, int ac, char *av[])
         optparse_fatal_usage (p, 1, "URI argument is required\n");
 
     target = av[optindex++];
-    if (!(uri = uri_resolve (target)))
+    if (!(uri = uri_resolve (target, NULL)))
         log_msg_exit ("Unable to resolve %s to a URI", target);
 
     if (optparse_hasopt (p, "reconnect"))

--- a/src/cmd/builtin/shutdown.c
+++ b/src/cmd/builtin/shutdown.c
@@ -53,7 +53,7 @@ static int subcmd (optparse_t *p, int ac, char *av[])
     }
 
     if (target) {
-        char *uri = uri_resolve (target);
+        char *uri = uri_resolve (target, NULL);
         if (!uri)
             log_msg_exit ("failed to resolve target %s to a Flux URI", target);
         if (!(h = flux_open (uri, 0)))

--- a/src/cmd/top/joblist_pane.c
+++ b/src/cmd/top/joblist_pane.c
@@ -154,6 +154,47 @@ static void joblist_continuation (flux_future_t *f, void *arg)
     flux_future_destroy (f);
 }
 
+
+/* Attempt to create a popup box over the joblist pane to
+ *  display one or more errors. The box will stay open until
+ *  the user presses a key.
+ */
+static void error_popup (struct joblist_pane *joblist,
+                         const char *msg)
+{
+    WINDOW *popup = newwin (6, 78, 15, 2);
+    WINDOW *errors = NULL;
+    if (!popup)
+        goto out;
+    box (popup, 0, 0);
+    touchwin (popup);
+    overwrite (popup, joblist->win);
+
+    if (!(errors = derwin (popup, 3, 75, 2, 2)))
+        goto out;
+
+    mvwprintw (errors, 0, 0, "%s", msg);
+
+    /*  Refresh windows
+     */
+    wrefresh (popup);
+    wrefresh (errors);
+
+    /*  Display error for up to 4s. Any key exits prematurely */
+    halfdelay (40);
+    getch ();
+
+    /* Leave halfdelay mode */
+    nocbreak ();
+    cbreak ();
+
+out:
+    if (popup)
+        delwin (popup);
+    if (errors)
+        delwin (errors);
+}
+
 void joblist_pane_enter (struct joblist_pane *joblist)
 {
     struct top *top;
@@ -161,6 +202,7 @@ void joblist_pane_enter (struct joblist_pane *joblist)
     char *uri = NULL;
     char title [1024];
     char jobid [24];
+    flux_error_t error;
 
     json_t *job = get_current_job (joblist);
     if (!job)
@@ -185,8 +227,10 @@ void joblist_pane_enter (struct joblist_pane *joblist)
     /*  Lazily attempt to run top on jobid, but for now simply return to the
      *   original top window on failure.
      */
-    if ((top = top_create (uri, title, NULL)))
+    if ((top = top_create (uri, title, &error)))
         top_run (top, 0);
+    else
+        error_popup (joblist, error.text);
     top_destroy (top);
     return;
 }

--- a/src/cmd/top/joblist_pane.c
+++ b/src/cmd/top/joblist_pane.c
@@ -185,7 +185,7 @@ void joblist_pane_enter (struct joblist_pane *joblist)
     /*  Lazily attempt to run top on jobid, but for now simply return to the
      *   original top window on failure.
      */
-    if ((top = top_create (uri, title)))
+    if ((top = top_create (uri, title, NULL)))
         top_run (top, 0);
     top_destroy (top);
     return;

--- a/src/cmd/top/top.c
+++ b/src/cmd/top/top.c
@@ -110,7 +110,7 @@ static flux_t *open_flux_instance (const char *target)
     flux_future_t *f = NULL;
     char *uri = NULL;
 
-    if (target && !(uri = uri_resolve (target)))
+    if (target && !(uri = uri_resolve (target, NULL)))
         fatal (0, "failed to resolve target %s to a Flux URI", target);
     if (!(h = flux_open (uri, 0)))
         fatal (errno, "error connecting to Flux");

--- a/src/cmd/top/top.c
+++ b/src/cmd/top/top.c
@@ -16,6 +16,7 @@
 #include <locale.h>
 
 #include "src/common/libutil/uri.h"
+#include "src/common/libutil/errprintf.h"
 #include "top.h"
 
 static const double job_activity_rate_limit = 2;
@@ -104,16 +105,25 @@ void refresh_cb (flux_reactor_t *r,
  * If id = FLUX_JOBID_ANY, merely call flux_open().
  * Otherwise, fetch remote-uri from job and open that.
  */
-static flux_t *open_flux_instance (const char *target)
+static flux_t *open_flux_instance (const char *target, flux_error_t *errp)
 {
     flux_t *h;
+    flux_error_t error;
     flux_future_t *f = NULL;
     char *uri = NULL;
 
-    if (target && !(uri = uri_resolve (target, NULL)))
-        fatal (0, "failed to resolve target %s to a Flux URI", target);
-    if (!(h = flux_open (uri, 0)))
-        fatal (errno, "error connecting to Flux");
+    if (target && !(uri = uri_resolve (target, &error))) {
+        errprintf (errp,
+                   "%s\n%s",
+                   "failed to resolve target to a Flux URI",
+                   error.text);
+        return NULL;
+    }
+    if (!(h = flux_open_ex (uri, 0, &error)))
+        errprintf (errp,
+                   "error connecting to Flux: %s\n%s",
+                   strerror (errno),
+                   error.text);
     free (uri);
     flux_future_destroy (f);
     return h;
@@ -204,11 +214,13 @@ static char * build_title (struct top *top, const char *title)
     return strdup (title);
 }
 
-struct top *top_create (const char *uri, const char *title)
+struct top *top_create (const char *uri,
+                        const char *title,
+                        flux_error_t *errp)
 {
     struct top *top = calloc (1, sizeof (*top));
 
-    if (!top || !(top->h = open_flux_instance (uri)))
+    if (!top || !(top->h = open_flux_instance (uri, errp)))
         goto fail;
 
     top->id = get_jobid (top->h);
@@ -259,6 +271,7 @@ int main (int argc, char *argv[])
     int reactor_flags = 0;
     const char *target = NULL;
     optparse_t *opts;
+    flux_error_t error;
 
     setlocale (LC_ALL, "");
 
@@ -281,8 +294,8 @@ int main (int argc, char *argv[])
         fatal (0, "stdin is not a terminal");
     initialize_curses ();
 
-    if (!(top = top_create (target, NULL)))
-        fatal (errno, "failed to initialize top");
+    if (!(top = top_create (target, NULL, &error)))
+        fatal (0, "%s", error.text);
     if (optparse_hasopt (opts, "test-exit"))
         reactor_flags |= FLUX_REACTOR_ONCE;
     if (top_run (top, reactor_flags) < 0)

--- a/src/cmd/top/top.h
+++ b/src/cmd/top/top.h
@@ -47,7 +47,9 @@ struct dimension {
     int y_length;
 };
 
-struct top *top_create (const char *uri, const char *prefix);
+struct top *top_create (const char *uri,
+                        const char *prefix,
+                        flux_error_t *errp);
 void top_destroy (struct top *top);
 int top_run (struct top *top, int reactor_flags);
 

--- a/src/common/libutil/uri.h
+++ b/src/common/libutil/uri.h
@@ -11,22 +11,26 @@
 #ifndef _UTIL_URI_H
 #define _UTIL_URI_H
 
+#include <flux/core.h>
+
 /*  Resolve a target or "high-level" URI with the flux-uri(1) command,
  *   returning the result. If the URI is already a native Flux URI (e.g.
  *   `local://` or `ssh://`), then `flux uri` is *not* called and instead
  *   the target is returned unmodified to avoid the extra overhead of
  *   running a subprocess.
  *
- *  On failure, NULL is returned. Stderr is not redirected or consumed,
- *   so the expectation is that the underlying `flux uri` error will
- *   already be copied to the callers tty.
+ *  On failure, NULL is returned. If errp is not NULL, then stderr from
+ *   the underlying command will be copied there (possibly truncated).
+ *   Otherwise, stderr is not redirected or consumed, so the expectation
+ *   is that the underlying `flux uri` error will already be copied to the
+ *   callers tty.
  *
  *  Caller must free the returned string on success.
  *
  *  Note: this function uses popen2() to execute flux-uri as a subprocess,
  *   so care should be taken in when and how this function is called.
  */
-char *uri_resolve (const char *target);
+char *uri_resolve (const char *target, flux_error_t *errp);
 
 #endif /* !_UTIL_URI_H */
 


### PR DESCRIPTION
Problem: When recursive top_create() fails due to a `flux_open()` error, e.g. the user cannot access the job's URI, top exits with an error when the intention is just to fall back to the current top instance.

This PR removes some calls to `fatal()` in `top_create()` and instead passes errors back via a `flux_error_t`. On error, a popup dialog is displayed instead of raising a fatal error. The dialog is dismissed after 4s or if any key is pressed.

This PR makes use of `flux_open_ex(3)`, so is based on top of #4450. In addition, the internal `uri_resolve()` function is augmented similarly to `flux_open_ex(3)` so that errors to `stderr` from `popen2()` of `flux uri` are captured.

Example of error popup:

![Screenshot from 2022-07-29 11-10-17](https://user-images.githubusercontent.com/741970/181849076-4298af1e-0ef7-43a5-a1a8-610d59af21cf.png)
