### PR TITLE
flux-relay: initialize log prefix to hostname when possible

### DIFF
--- a/src/cmd/builtin/relay.c
+++ b/src/cmd/builtin/relay.c
@@ -131,8 +131,18 @@ static int cmd_relay (optparse_t *p, int ac, char *av[])
     flux_t *h;
     int optindex;
     char *uri;
+    char hostname [HOST_NAME_MAX + 1];
 
-    log_init ("flux-relay");
+    /*  If possible, initalize logging prefix as local hostname. (In the
+     *  unlikely event gethostname(3) fails, use "uknown-host".)
+     *
+     *  This will be more helpful than a literal "flux-relay" logging prefix
+     *  for end users that may be uknowningly using flux-relay as part of
+     *  the ssh connector.
+     */
+    log_init ("uknown-host");
+    if (gethostname (hostname, sizeof (hostname)) == 0)
+        log_init (hostname);
 
     optindex = optparse_option_index (p);
     if (optindex == ac)


### PR DESCRIPTION
When the ssh connector fails to connect to a remote uri, but the ssh was successfully able to execute `flux-relay`, an error such as the following is displayed
```
flux-relay: local:///tmp/flux-xoZRkf/local-0: Permission denied
```
The `flux-relay` prefix probably isn't all that helpful for users, and may be confusing, since `flux-relay` was only indirectly run as part of the `ssh` connector. Instead it may be more useful to use the hostname as the command prefix. This way, the user is made aware of the host on which the local connection failed e.g

```
fluke89: local:///tmp/flux-xoZRkf/local-0: Permission denied
```