### PR TITLE
content-sqlite,files,s3: register backing module after setup is complete

### DIFF
--- a/src/modules/content-files/content-files.c
+++ b/src/modules/content-files/content-files.c
@@ -394,14 +394,14 @@ int mod_main (flux_t *h, int argc, char **argv)
         flux_log_error (h, "content_files_create failed");
         return -1;
     }
+    if (content_register_service (h, "content-backing") < 0)
+        goto done;
+    if (content_register_service (h, "kvs-checkpoint") < 0)
+        goto done;
     if (!testing) {
         if (content_register_backing_store (h, "content-files") < 0)
             goto done;
     }
-    if (content_register_service (h, "content-backing") < 0)
-        goto done_unreg;
-    if (content_register_service (h, "kvs-checkpoint") < 0)
-        goto done_unreg;
     if (flux_reactor_run (flux_get_reactor (h), 0) < 0) {
         flux_log_error (h, "flux_reactor_run");
         goto done_unreg;

--- a/src/modules/content-files/content-files.c
+++ b/src/modules/content-files/content-files.c
@@ -399,19 +399,17 @@ int mod_main (flux_t *h, int argc, char **argv)
             goto done;
     }
     if (content_register_service (h, "content-backing") < 0)
-        goto done;
+        goto done_unreg;
     if (content_register_service (h, "kvs-checkpoint") < 0)
-        goto done;
+        goto done_unreg;
     if (flux_reactor_run (flux_get_reactor (h), 0) < 0) {
         flux_log_error (h, "flux_reactor_run");
-        goto done;
+        goto done_unreg;
     }
-    if (!testing) {
-        if (content_unregister_backing_store (h) < 0)
-            goto done;
-    }
-
     rc = 0;
+done_unreg:
+    if (!testing)
+        (void)content_unregister_backing_store (h);
 done:
     content_files_destroy (ctx);
     return rc;

--- a/src/modules/content-s3/content-s3.c
+++ b/src/modules/content-s3/content-s3.c
@@ -497,12 +497,12 @@ int mod_main (flux_t *h, int argc, char **argv)
         flux_log_error (h, "content_s3_create failed");
         return -1;
     }
+    if (content_register_service (h, "content-backing") < 0)
+        goto done;
+    if (content_register_service (h, "kvs-checkpoint") < 0)
+        goto done;
     if (content_register_backing_store (h, "content-s3") < 0)
         goto done;
-    if (content_register_service (h, "content-backing") < 0)
-        goto done_unreg;
-    if (content_register_service (h, "kvs-checkpoint") < 0)
-        goto done_unreg;
     if (flux_reactor_run (flux_get_reactor (h), 0) < 0) {
         flux_log_error (h, "flux_reactor_run");
         goto done_unreg;

--- a/src/modules/content-s3/content-s3.c
+++ b/src/modules/content-s3/content-s3.c
@@ -500,17 +500,16 @@ int mod_main (flux_t *h, int argc, char **argv)
     if (content_register_backing_store (h, "content-s3") < 0)
         goto done;
     if (content_register_service (h, "content-backing") < 0)
-        goto done;
+        goto done_unreg;
     if (content_register_service (h, "kvs-checkpoint") < 0)
-        goto done;
+        goto done_unreg;
     if (flux_reactor_run (flux_get_reactor (h), 0) < 0) {
         flux_log_error (h, "flux_reactor_run");
-        goto done;
+        goto done_unreg;
     }
-    if (content_unregister_backing_store (h) < 0)
-        goto done;
-
     rc = 0;
+done_unreg:
+    (void)content_unregister_backing_store (h);
 done:
     content_s3_destroy (ctx);
     return rc;

--- a/src/modules/content-sqlite/content-sqlite.c
+++ b/src/modules/content-sqlite/content-sqlite.c
@@ -837,12 +837,12 @@ int mod_main (flux_t *h, int argc, char **argv)
         goto done;
     if (content_sqlite_opendb (ctx, truncate) < 0)
         goto done;
+    if (content_register_service (h, "content-backing") < 0)
+        goto done;
+    if (content_register_service (h, "kvs-checkpoint") < 0)
+        goto done;
     if (content_register_backing_store (h, "content-sqlite") < 0)
         goto done;
-    if (content_register_service (h, "content-backing") < 0)
-        goto done_unreg;
-    if (content_register_service (h, "kvs-checkpoint") < 0)
-        goto done_unreg;
     if (flux_reactor_run (flux_get_reactor (h), 0) < 0) {
         flux_log_error (h, "flux_reactor_run");
         goto done_unreg;

--- a/t/issues/t4379-dirty-cache-entries-flush.sh
+++ b/t/issues/t4379-dirty-cache-entries-flush.sh
@@ -32,7 +32,7 @@ fi
 
 flux content flush
 
-# Issue 4378 - this dirty count would stay at 1
+# Issue 4379 - this dirty count would stay at 1
 count=`flux module stats --parse dirty content`
 if [ ${count} -ne 0 ]
 then

--- a/t/issues/t4379-dirty-cache-entries-flush.sh
+++ b/t/issues/t4379-dirty-cache-entries-flush.sh
@@ -23,19 +23,18 @@ fi
 
 flux module load content-sqlite
 
-count=`flux module stats --parse dirty content`
-if [ ${count} -ne 1 ]
-then
-    echo "dirty entries still 1 after module reload"
-    return 1
-fi
-
-flux content flush
-
 # Issue 4379 - this dirty count would stay at 1
+# Check count in a loop, although highly improbable, technically could
+# be racy
 count=`flux module stats --parse dirty content`
+i=0
+while [ ${count} -ne 0 ] && [ $i -lt 50 ]
+do
+    sleep 0.1
+    i=$((i + 1))
+done
 if [ ${count} -ne 0 ]
 then
-    echo "dirty entries not 0 after final flush"
+    echo "dirty entries not 0"
     return 1
 fi


### PR DESCRIPTION
Problem: In the content-sqlite, content-files, and content-s3 modules,
the backing module is registered before setup of module services is
complete.  This can cause problems if the broker's content-cache
wants to make calls into the module during registration time.

Solution: Ensure that all setup is complete before registering the
backing module.

Update regression test which would fail with this change.

Fixes https://github.com/flux-framework/flux-core/issues/4456