### PR TITLE
flux-overlay: add man page, open to guest users

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -16,6 +16,7 @@ MAN1_FILES_PRIMARY = \
 	man1/flux-kvs.1 \
 	man1/flux-keygen.1 \
 	man1/flux-logger.1 \
+	man1/flux-overlay.1 \
 	man1/flux-ping.1 \
 	man1/flux-start.1 \
 	man1/flux-startlog.1 \

--- a/doc/man1/flux-overlay.rst
+++ b/doc/man1/flux-overlay.rst
@@ -1,0 +1,165 @@
+.. flux-help-description: Show flux overlay network status
+
+===============
+flux-overlay(1)
+===============
+
+
+SYNOPSIS
+========
+
+**flux** **overlay** **status** [*OPTIONS*]
+
+**flux** **overlay** **lookup** [*OPTIONS*] *TARGET*
+
+**flux** **overlay** **parentof** [*OPTIONS*] *RANK*
+
+**flux** **overlay** **disconnect** [*OPTIONS*] *TARGET*
+
+
+DESCRIPTION
+===========
+
+``flux-overlay status`` reports the current status of the tree based
+overlay network.  The possible status values are:
+
+full
+    Node is online and no children are in *partial*, *offline*, *degraded*, or
+    *lost* state.
+
+partial
+    Node is online, and some children are in *partial* or *offline* state; no
+    children are in *degraded* or *lost* state.
+
+degraded
+    Node is online, and some children are in *degraded* or *lost* state.
+
+lost
+    Node has gone missing, from the parent perspective.
+
+offline
+    Node has not yet joined the instance, or has been cleanly shut down.
+
+By default, the status of the full Flux instance is shown in graphical form,
+e.g.
+
+::
+
+  $ flux overlay status
+  0 test0: partial
+  ├─ 1 test1: offline
+  ├─ 2 test2: full
+  ├─ 3 test3: full
+  ├─ 4 test4: full
+  ├─ 5 test5: offline
+  ├─ 6 test6: full
+  └─ 7 test7: offline
+
+The time in the current state is reported if ``-v`` is added, e.g.
+
+::
+
+  $ flux overlay status -v
+  0 test0: partial for 2.55448m
+  ├─ 1 test1: offline for 12.7273h
+  ├─ 2 test2: full for 2.55484m
+  ├─ 3 test3: full for 18.2725h
+  ├─ 4 test4: full for 18.2777h
+  ├─ 5 test5: offline for 12.7273h
+  ├─ 6 test6: full for 18.2784h
+  └─ 7 test7: offline for 12.7273h
+
+Round trip RPC times are shown with ``-vv``, e.g.
+
+::
+
+  0 test0: partial for 4.15692m (2.982 ms)
+  ├─ 1 test1: offline for 12.754h
+  ├─ 2 test2: full for 4.15755m (2.161 ms)
+  ├─ 3 test3: full for 18.2992h (2.332 ms)
+  ├─ 4 test4: full for 18.3045h (2.182 ms)
+  ├─ 5 test5: offline for 12.754h
+  ├─ 6 test6: full for 18.3052h (2.131 ms)
+  └─ 7 test7: offline for 12.754h
+
+A broker that is not responding but is not shown as *lost* or *offline* may
+be forcibly disconnected from the overlay network with
+
+::
+
+  $ flux overlay disconnect 2
+  flux-overlay: asking test0 (rank 0) to disconnect child test2 (rank 2)
+
+However, before doing that it may be useful to see if a broker acting as a
+router to that node is actually the problem.  The parent of a broker rank may
+be listed with
+
+::
+
+  $ flux overlay parentof 2
+  0
+
+Finally, translation between hostnames and broker ranks is accomplished with
+
+::
+
+  $ flux overlay lookup 2
+  test2
+  $ flux overlay lookup test2
+  2
+
+
+OPTIONS
+=======
+
+``flux-overlay status`` accepts the following options:
+
+**-h, --help**
+   Display options and exit.
+
+**-r, --rank=[RANK]**
+   Check health of sub-tree rooted at NODEID (default 0).
+
+**-v, --verbose=[LEVEL]**
+   Increase reporting detail: 1=show time since current state was entered,
+   2=show round-trip RPC times.
+
+**-t, --timeout=FSD**
+   Set RPC timeout, 0=disable (default 0.5s)
+
+**--summary**
+   Show only the root sub-tree status.
+
+**--down**
+   Show only the partial/degraded sub-trees.
+
+**--no-pretty**
+   Do not indent entries and use line drawing characters to show overlay
+   tree structure
+
+**--no-ghost**
+   Do not fill in presumed state of nodes that are inaccessible behind
+   offline/lost overlay parents.
+
+**-L, --color=WHEN**
+   Colorize output when supported; WHEN can be 'always' (default if omitted),
+   'never', or 'auto' (default).
+
+**-H, --highlight=TARGET**
+   Highlight one or more targets and their ancestors.
+
+**-w, --wait=STATE**
+   Wait until sub-tree enters *STATE* before reporting (full, partial, offline,
+   degraded, lost)>
+
+
+RESOURCES
+=========
+
+Flux: http://flux-framework.org
+
+
+SEE ALSO
+========
+
+:man1:`flux-ping`

--- a/doc/man1/index.rst
+++ b/doc/man1/index.rst
@@ -23,6 +23,7 @@ man1
    flux-logger
    flux-mini
    flux-module
+   flux-overlay
    flux-ping
    flux-proxy
    flux-pstree

--- a/doc/manpages.py
+++ b/doc/manpages.py
@@ -43,6 +43,7 @@ man_pages = [
     ('man1/flux-mini', 'flux-mini', 'Minimal Job Submission Tool', [author], 1),
     ('man1/flux-job', 'flux-job', 'Job Housekeeping Tool', [author], 1),
     ('man1/flux-module', 'flux-module', 'manage Flux extension modules', [author], 1),
+    ('man1/flux-overlay', 'flux-overlay', 'Show flux overlay network status', [author], 1),
     ('man1/flux-ping', 'flux-ping', 'measure round-trip latency to Flux services', [author], 1),
     ('man1/flux-proxy', 'flux-proxy', 'create proxy environment for Flux instance', [author], 1),
     ('man1/flux-queue', 'flux-queue', 'manage the job queue', [author], 1),

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -632,3 +632,4 @@ nosetpgrp
 checkpointed
 pbatch
 pdebug
+parentof

--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -1984,7 +1984,7 @@ static const struct flux_msg_handler_spec htab[] = {
     },
     {
         FLUX_MSGTYPE_REQUEST,
-        "overlay.disconnect",
+        "overlay.disconnect", // clean up after 'flux overlay status --wait'
         disconnect_cb,
         FLUX_ROLE_USER,
     },
@@ -1996,7 +1996,7 @@ static const struct flux_msg_handler_spec htab[] = {
     },
     {
         FLUX_MSGTYPE_REQUEST,
-        "overlay.disconnect-subtree",
+        "overlay.disconnect-subtree",   // handle 'flux overlay disconnect'
         overlay_disconnect_subtree_cb,
         0
     },

--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -1974,25 +1974,25 @@ static const struct flux_msg_handler_spec htab[] = {
         FLUX_MSGTYPE_REQUEST,
         "overlay.stats.get",
         overlay_stats_get_cb,
-        0
+        FLUX_ROLE_USER,
     },
     {
         FLUX_MSGTYPE_REQUEST,
         "overlay.health",
         overlay_health_cb,
-        0
+        FLUX_ROLE_USER,
     },
     {
         FLUX_MSGTYPE_REQUEST,
         "overlay.disconnect",
         disconnect_cb,
-        0
+        FLUX_ROLE_USER,
     },
     {
         FLUX_MSGTYPE_REQUEST,
         "overlay.topology",
         overlay_topology_cb,
-        0
+        FLUX_ROLE_USER,
     },
     {
         FLUX_MSGTYPE_REQUEST,

--- a/src/cmd/builtin/overlay.c
+++ b/src/cmd/builtin/overlay.c
@@ -893,11 +893,15 @@ static int subcmd_disconnect (optparse_t *p, int ac, char *av[])
     if (parent == -1)
         parent = lookup_parentof (h, rank); // might return -1 (unlikely)
 
+    char *host = strdup (flux_get_hostbyrank (h, rank));
+    if (!host)
+        log_msg_exit ("out of memory");
     log_msg ("asking %s (rank %d) to disconnect child %s (rank %d)",
              flux_get_hostbyrank (h, parent),
              parent,
-             flux_get_hostbyrank (h, rank),
+             host,
              rank);
+    free (host);
 
     if (!(f = flux_rpc_pack (h,
                              "overlay.disconnect-subtree",

--- a/src/common/libflux/disconnect.h
+++ b/src/common/libflux/disconnect.h
@@ -18,7 +18,8 @@ extern "C" {
 #endif
 
 /* Return true if disconnect request msg1 came from same sender as
- * msg2 and has appropraite authorization */
+ * msg2 and has appropriate authorization
+ */
 bool flux_disconnect_match (const flux_msg_t *msg1, const flux_msg_t *msg2);
 
 /* Remove all messages in 'l' with the same sender as 'msg'.


### PR DESCRIPTION
Problem: `flux overlay status` is restricted to guests for no particular reason, requiring sys admins to run under sudo.

Make the necessary RPCs available to guest users.

Also, add missing man page, and fix a bug in the `flux overlay disconnect` output (still restricted to instance owner).