### PR TITLE
ci: skip dumpfile check on release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -168,6 +168,7 @@ jobs:
         docker run -d -p 9000:9000 minio/minio server /data; \
 
     - name: generate dumpfile from most recent flux-core tag
+      if:  (matrix.create_release != true)
       run: |
         git tag -l ; \
         src/test/create-kvs-dumpfile.sh -d /tmp/dumpfile; \


### PR DESCRIPTION
Unfortunately the dumpfile check in ci didn't work when run against a tag.

This check isn't necessary on a tag anyway, since the tag represents no changes. Let's just skip it.

I'm going to delete the current tag and retag after this is merged.