### PR TITLE
create-kvs-dumpfile.sh: do nothing if run on a tag

### DIFF
--- a/src/test/create-kvs-dumpfile.sh
+++ b/src/test/create-kvs-dumpfile.sh
@@ -60,6 +60,12 @@ while true; do
     esac
 done
 
+if test "${TAG}" = "$(git describe)"; then
+    printf "Doing nothing by default since this commit is a tag\n"
+    printf "To force: use --tag=TAG option\n"
+    exit 0
+fi
+
 mkdir "${OUTPUTDIR}" || die "Failed to create $OUTPUTDIR"
 if test -n "$WORKLOAD_PATH"; then
     cp $WORKLOAD_PATH ${OUTPUTDIR}/workload.sh


### PR DESCRIPTION
Problem: The create-kvs-dumpfile.sh script doesn't work when the
current commit is a tag because no docker image will exist for
that tag yet.

Do nothing if run on a tag by default.