### PR TITLE
content-{sqlite,files,s3}: route checkpoint-get and checkpoint-put through broker

### DIFF
--- a/src/broker/content-cache.c
+++ b/src/broker/content-cache.c
@@ -340,13 +340,12 @@ static void cache_entry_remove (struct content_cache *cache,
 {
     assert (e->load_requests == NULL);
     assert (e->store_requests == NULL);
+    assert (!e->dirty);
     list_del (&e->list);
     if (e->valid) {
         cache->acct_size -= e->len;
         cache->acct_valid--;
     }
-    if (e->dirty)
-        cache->acct_dirty--;
     zhashx_delete (cache->entries, e->hash);
 }
 

--- a/src/broker/content-cache.c
+++ b/src/broker/content-cache.c
@@ -605,6 +605,124 @@ error:
         flux_log_error (h, "content store: flux_respond_error");
 }
 
+static void checkpoint_get_continuation (flux_future_t *f, void *arg)
+{
+    struct content_cache *cache = arg;
+    const flux_msg_t *msg = flux_future_aux_get (f, "msg");
+    const char *s;
+
+    assert (msg);
+
+    if (flux_rpc_get (f, &s) < 0)
+        goto error;
+
+    if (flux_respond (cache->h, msg, s) < 0)
+        flux_log_error (cache->h, "%s: flux_respond", __FUNCTION__);
+    flux_future_destroy (f);
+    return;
+
+error:
+    if (flux_respond_error (cache->h, msg, errno, NULL) < 0)
+        flux_log_error (cache->h, "flux_respond_error");
+    flux_future_destroy (f);
+}
+
+void content_checkpoint_get_request (flux_t *h, flux_msg_handler_t *mh,
+                                     const flux_msg_t *msg, void *arg)
+{
+    struct content_cache *cache = arg;
+    const char *topic = "content-backing.checkpoint-get";
+    const char *s = NULL;
+    const flux_msg_t *msgcpy = flux_msg_incref (msg);
+    flux_future_t *f = NULL;
+
+    /* Temporarily maintain ENOSYS behavior */
+    if (!cache->backing) {
+        errno = ENOSYS;
+        goto error;
+    }
+
+    if (flux_request_decode (msg, NULL, &s) < 0)
+        goto error;
+
+    if (!(f = flux_rpc (h, topic, s, 0, 0))
+        || flux_future_aux_set (f,
+                                "msg",
+                                (void *)msgcpy,
+                                (flux_free_f)flux_msg_decref) < 0
+        || flux_future_then (f, -1, checkpoint_get_continuation, cache) < 0) {
+        flux_log_error (h, "error starting checkpoint-get RPC");
+        goto error;
+    }
+
+    return;
+
+error:
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "error responding to checkpoint-get request");
+    flux_future_destroy (f);
+    flux_msg_decref (msgcpy);
+}
+
+static void checkpoint_put_continuation (flux_future_t *f, void *arg)
+{
+    struct content_cache *cache = arg;
+    const flux_msg_t *msg = flux_future_aux_get (f, "msg");
+    const char *s;
+
+    assert (msg);
+
+    if (flux_rpc_get (f, &s) < 0)
+        goto error;
+
+    if (flux_respond (cache->h, msg, s) < 0)
+        flux_log_error (cache->h, "%s: flux_respond", __FUNCTION__);
+    flux_future_destroy (f);
+    return;
+
+error:
+    if (flux_respond_error (cache->h, msg, errno, NULL) < 0)
+        flux_log_error (cache->h, "flux_respond_error");
+    flux_future_destroy (f);
+}
+
+void content_checkpoint_put_request (flux_t *h, flux_msg_handler_t *mh,
+                                     const flux_msg_t *msg, void *arg)
+{
+    struct content_cache *cache = arg;
+    const char *topic = "content-backing.checkpoint-put";
+    const char *s = NULL;
+    const flux_msg_t *msgcpy = flux_msg_incref (msg);
+    flux_future_t *f = NULL;
+
+    /* Temporarily maintain ENOSYS behavior */
+    if (!cache->backing) {
+        errno = ENOSYS;
+        goto error;
+    }
+
+    if (flux_request_decode (msg, NULL, &s) < 0)
+        goto error;
+
+    if (!(f = flux_rpc (h, topic, s, 0, 0))
+        || flux_future_aux_set (f,
+                                "msg",
+                                (void *)msgcpy,
+                                (flux_free_f)flux_msg_decref) < 0
+        || flux_future_then (f, -1, checkpoint_put_continuation, cache) < 0) {
+        flux_log_error (h, "error starting checkpoint-put RPC");
+        goto error;
+    }
+
+    return;
+
+error:
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "error responding to checkpoint-put request");
+    flux_future_destroy (f);
+    flux_msg_decref (msgcpy);
+}
+
 /* Backing store is enabled/disabled by modules that provide the
  * 'content.backing' service.  At module load time, the backing module
  * informs the content service of its availability, and entries are
@@ -872,6 +990,18 @@ static const struct flux_msg_handler_spec htab[] = {
         FLUX_MSGTYPE_REQUEST,
         "content.store",
         content_store_request,
+        0
+    },
+    {
+        FLUX_MSGTYPE_REQUEST,
+        "content.checkpoint-get",
+        content_checkpoint_get_request,
+        0
+    },
+    {
+        FLUX_MSGTYPE_REQUEST,
+        "content.checkpoint-put",
+        content_checkpoint_put_request,
         0
     },
     {

--- a/src/cmd/builtin/restore.c
+++ b/src/cmd/builtin/restore.c
@@ -326,7 +326,7 @@ static void flush_content (flux_t *h, uint32_t rank)
 
     if (!(f = flux_rpc (h, "content.flush", NULL, rank, 0))
         || flux_rpc_get (f, NULL) < 0)
-    log_msg ("error flushing content cache: %s", future_strerror (f, errno));
+        log_msg ("error flushing content cache: %s", future_strerror (f, errno));
     flux_future_destroy (f);
 }
 

--- a/src/common/libkvs/kvs_checkpoint.c
+++ b/src/common/libkvs/kvs_checkpoint.c
@@ -37,7 +37,7 @@ flux_future_t *kvs_checkpoint_commit (flux_t *h,
         timestamp = flux_reactor_now (flux_get_reactor (h));
 
     if (!(f = flux_rpc_pack (h,
-                             "kvs-checkpoint.put",
+                             "content-backing.checkpoint-put",
                              0,
                              0,
                              "{s:s s:{s:i s:s s:f}}",
@@ -62,7 +62,7 @@ flux_future_t *kvs_checkpoint_lookup (flux_t *h, const char *key)
         key = KVS_DEFAULT_CHECKPOINT;
 
     return flux_rpc_pack (h,
-                          "kvs-checkpoint.get",
+                          "content-backing.checkpoint-get",
                           0,
                           0,
                           "{s:s}",

--- a/src/common/libkvs/kvs_checkpoint.c
+++ b/src/common/libkvs/kvs_checkpoint.c
@@ -37,7 +37,7 @@ flux_future_t *kvs_checkpoint_commit (flux_t *h,
         timestamp = flux_reactor_now (flux_get_reactor (h));
 
     if (!(f = flux_rpc_pack (h,
-                             "content-backing.checkpoint-put",
+                             "content.checkpoint-put",
                              0,
                              0,
                              "{s:s s:{s:i s:s s:f}}",
@@ -62,7 +62,7 @@ flux_future_t *kvs_checkpoint_lookup (flux_t *h, const char *key)
         key = KVS_DEFAULT_CHECKPOINT;
 
     return flux_rpc_pack (h,
-                          "content-backing.checkpoint-get",
+                          "content.checkpoint-get",
                           0,
                           0,
                           "{s:s}",

--- a/src/modules/content-s3/content-s3.c
+++ b/src/modules/content-s3/content-s3.c
@@ -329,7 +329,7 @@ error:
         flux_log_error (h, "error responding to store request");
 }
 
-/* Handle a kvs-checkpoint.get request from the rank 0 kvs module.
+/* Handle a content-backing.checkpoint-get request from the rank 0 kvs module.
  * The KVS stores its last root reference here for restart purposes.
  *
  * N.B. filedb_get() calls read_all() which ensures that the returned buffer
@@ -368,8 +368,7 @@ void checkpoint_get_cb (flux_t *h,
                            "value",
                            o) < 0) {
         errno = EIO;
-        flux_log_error (h,
-                        "error responding to kvs-checkpoint.get request (pack)");
+        flux_log_error (h, "error responding to checkpoint-get request (pack)");
     }
     free (data);
     json_decref (o);
@@ -377,12 +376,12 @@ void checkpoint_get_cb (flux_t *h,
 
 error:
     if (flux_respond_error (h, msg, errno, errstr) < 0)
-        flux_log_error (h, "error responding to kvs-checkpoint.get request");
+        flux_log_error (h, "error responding to checkpoint-get request");
     free (data);
     json_decref (o);
 }
 
-/* Handle a kvs-checkpoint.put request from the rank 0 kvs module.
+/* Handle a content-backing.checkpoint-put request from the rank 0 kvs module.
  * The KVS stores its last root reference here for restart purposes.
  */
 void checkpoint_put_cb (flux_t *h,
@@ -412,13 +411,13 @@ void checkpoint_put_cb (flux_t *h,
     if (s3_put (ctx->cfg, key, value, strlen (value), &errstr) < 0)
         goto error;
     if (flux_respond (h, msg, NULL) < 0)
-        flux_log_error (h, "error responding to kvs-checkpoint.put request (pack)");
+        flux_log_error (h, "error responding to checkpoint-put request (pack)");
     free (value);
     return;
 
 error:
     if (flux_respond_error (h, msg, errno, errstr) < 0)
-        flux_log_error (h, "error responding to kvs-checkpoint.put request");
+        flux_log_error (h, "error responding to checkpoint-put request");
     free (value);
 }
 
@@ -428,8 +427,10 @@ error:
 static const struct flux_msg_handler_spec htab[] = {
     { FLUX_MSGTYPE_REQUEST, "content-backing.load",    load_cb, 0 },
     { FLUX_MSGTYPE_REQUEST, "content-backing.store",   store_cb, 0 },
-    { FLUX_MSGTYPE_REQUEST, "kvs-checkpoint.get", checkpoint_get_cb, 0 },
-    { FLUX_MSGTYPE_REQUEST, "kvs-checkpoint.put", checkpoint_put_cb, 0 },
+    { FLUX_MSGTYPE_REQUEST, "content-backing.checkpoint-get",
+                            checkpoint_get_cb, 0 },
+    { FLUX_MSGTYPE_REQUEST, "content-backing.checkpoint-put",
+                            checkpoint_put_cb, 0 },
     { FLUX_MSGTYPE_REQUEST, "content-s3.config-reload", config_reload_cb, 0 },
     FLUX_MSGHANDLER_TABLE_END,
 };
@@ -509,8 +510,6 @@ int mod_main (flux_t *h, int argc, char **argv)
         return -1;
     }
     if (content_register_service (h, "content-backing") < 0)
-        goto done;
-    if (content_register_service (h, "kvs-checkpoint") < 0)
         goto done;
     if (content_register_backing_store (h, "content-s3") < 0)
         goto done;

--- a/src/modules/content-s3/content-s3.c
+++ b/src/modules/content-s3/content-s3.c
@@ -228,7 +228,8 @@ static void config_reload_cb (flux_t *h,
         goto error;
     }
     free (cfg);
-    flux_log (h, LOG_WARNING, "config-reload: changes will not take effect until next flux restart");
+    flux_log (h, LOG_WARNING, "config-reload: changes will not take effect "
+                              "until next flux restart");
 
     if (flux_set_conf (h, flux_conf_incref (conf)) < 0) {
         errstr = "error updating cached configuration";
@@ -290,7 +291,10 @@ error:
  * The raw response payload is a hash digest.
  * These payloads are specified in RFC 10.
  */
-void store_cb (flux_t *h, flux_msg_handler_t *mh, const flux_msg_t *msg, void *arg)
+void store_cb (flux_t *h,
+               flux_msg_handler_t *mh,
+               const flux_msg_t *msg,
+               void *arg)
 {
     struct content_s3 *ctx = arg;
     const void *data;
@@ -332,7 +336,10 @@ error:
  * is padded with an extra NULL not included in the returned length,
  * so it is safe to use the result as a string argument in flux_respond_pack().
  */
-void checkpoint_get_cb (flux_t *h, flux_msg_handler_t *mh, const flux_msg_t *msg, void *arg)
+void checkpoint_get_cb (flux_t *h,
+                        flux_msg_handler_t *mh,
+                        const flux_msg_t *msg,
+                        void *arg)
 {
     const char *errstr = NULL;
     struct content_s3 *ctx = arg;
@@ -361,7 +368,8 @@ void checkpoint_get_cb (flux_t *h, flux_msg_handler_t *mh, const flux_msg_t *msg
                            "value",
                            o) < 0) {
         errno = EIO;
-        flux_log_error (h, "error responding to kvs-checkpoint.get request (pack)");
+        flux_log_error (h,
+                        "error responding to kvs-checkpoint.get request (pack)");
     }
     free (data);
     json_decref (o);
@@ -377,7 +385,10 @@ error:
 /* Handle a kvs-checkpoint.put request from the rank 0 kvs module.
  * The KVS stores its last root reference here for restart purposes.
  */
-void checkpoint_put_cb (flux_t *h, flux_msg_handler_t *mh, const flux_msg_t *msg, void *arg)
+void checkpoint_put_cb (flux_t *h,
+                        flux_msg_handler_t *mh,
+                        const flux_msg_t *msg,
+                        void *arg)
 {
     struct content_s3 *ctx = arg;
     const char *key;

--- a/src/modules/content-sqlite/content-sqlite.c
+++ b/src/modules/content-sqlite/content-sqlite.c
@@ -732,8 +732,10 @@ static void content_sqlite_destroy (struct content_sqlite *ctx)
 static const struct flux_msg_handler_spec htab[] = {
     { FLUX_MSGTYPE_REQUEST, "content-backing.load",    load_cb, 0 },
     { FLUX_MSGTYPE_REQUEST, "content-backing.store",   store_cb, 0 },
-    { FLUX_MSGTYPE_REQUEST, "kvs-checkpoint.get", checkpoint_get_cb, 0 },
-    { FLUX_MSGTYPE_REQUEST, "kvs-checkpoint.put", checkpoint_put_cb, 0 },
+    { FLUX_MSGTYPE_REQUEST, "content-backing.checkpoint-get",
+                            checkpoint_get_cb, 0 },
+    { FLUX_MSGTYPE_REQUEST, "content-backing.checkpoint-put",
+                            checkpoint_put_cb, 0 },
     { FLUX_MSGTYPE_REQUEST, "content-sqlite.stats.get", stats_get_cb, 0 },
     FLUX_MSGHANDLER_TABLE_END,
 };
@@ -838,8 +840,6 @@ int mod_main (flux_t *h, int argc, char **argv)
     if (content_sqlite_opendb (ctx, truncate) < 0)
         goto done;
     if (content_register_service (h, "content-backing") < 0)
-        goto done;
-    if (content_register_service (h, "kvs-checkpoint") < 0)
         goto done;
     if (content_register_backing_store (h, "content-sqlite") < 0)
         goto done;

--- a/t/t0012-content-sqlite.t
+++ b/t/t0012-content-sqlite.t
@@ -123,10 +123,10 @@ test_expect_success 'fill the cache with more data for later purging' '
 
 checkpoint_put() {
 	o="{key:\"$1\",value:{version:1,rootref:\"$2\",timestamp:2.2}}"
-	jq -j -c -n  ${o} | $RPC content-backing.checkpoint-put
+	jq -j -c -n  ${o} | $RPC content.checkpoint-put
 }
 checkpoint_get() {
-	jq -j -c -n  "{key:\"$1\"}" | $RPC content-backing.checkpoint-get
+	jq -j -c -n  "{key:\"$1\"}" | $RPC content.checkpoint-get
 }
 
 test_expect_success HAVE_JQ 'checkpoint-put foo w/ rootref bar' '

--- a/t/t0012-content-sqlite.t
+++ b/t/t0012-content-sqlite.t
@@ -121,37 +121,37 @@ test_expect_success 'fill the cache with more data for later purging' '
 	${SPAMUTIL} 10000 200 >/dev/null
 '
 
-kvs_checkpoint_put() {
+checkpoint_put() {
 	o="{key:\"$1\",value:{version:1,rootref:\"$2\",timestamp:2.2}}"
-	jq -j -c -n  ${o} | $RPC kvs-checkpoint.put
+	jq -j -c -n  ${o} | $RPC content-backing.checkpoint-put
 }
-kvs_checkpoint_get() {
-	jq -j -c -n  "{key:\"$1\"}" | $RPC kvs-checkpoint.get
+checkpoint_get() {
+	jq -j -c -n  "{key:\"$1\"}" | $RPC content-backing.checkpoint-get
 }
 
-test_expect_success HAVE_JQ 'kvs-checkpoint.put foo w/ rootref bar' '
-	kvs_checkpoint_put foo bar
+test_expect_success HAVE_JQ 'checkpoint-put foo w/ rootref bar' '
+	checkpoint_put foo bar
 '
 
-test_expect_success HAVE_JQ 'kvs-checkpoint.get foo returned rootref bar' '
+test_expect_success HAVE_JQ 'checkpoint-get foo returned rootref bar' '
 	echo bar >rootref.exp &&
-	kvs_checkpoint_get foo | jq -r .value | jq -r .rootref >rootref.out &&
+	checkpoint_get foo | jq -r .value | jq -r .rootref >rootref.out &&
 	test_cmp rootref.exp rootref.out
 '
 
 # use grep instead of compare, incase of floating point rounding
-test_expect_success HAVE_JQ 'kvs-checkpoint.get foo returned correct timestamp' '
-        kvs_checkpoint_get foo | jq -r .value | jq -r .timestamp >timestamp.out &&
+test_expect_success HAVE_JQ 'checkpoint-get foo returned correct timestamp' '
+        checkpoint_get foo | jq -r .value | jq -r .timestamp >timestamp.out &&
         grep 2.2 timestamp.out
 '
 
-test_expect_success HAVE_JQ 'kvs-checkpoint.put updates foo rootref to baz' '
-	kvs_checkpoint_put foo baz
+test_expect_success HAVE_JQ 'checkpoint-put updates foo rootref to baz' '
+	checkpoint_put foo baz
 '
 
-test_expect_success HAVE_JQ 'kvs-checkpoint.get foo returned rootref baz' '
+test_expect_success HAVE_JQ 'checkpoint-get foo returned rootref baz' '
 	echo baz >rootref2.exp &&
-	kvs_checkpoint_get foo | jq -r .value | jq -r .rootref >rootref2.out &&
+	checkpoint_get foo | jq -r .value | jq -r .rootref >rootref2.out &&
 	test_cmp rootref2.exp rootref2.out
 '
 
@@ -160,14 +160,14 @@ test_expect_success 'flush + reload content-sqlite module on rank 0' '
 	flux module reload content-sqlite
 '
 
-test_expect_success HAVE_JQ 'kvs-checkpoint.get foo still returns rootref baz' '
+test_expect_success HAVE_JQ 'checkpoint-get foo still returns rootref baz' '
 	echo baz >rootref3.exp &&
-	kvs_checkpoint_get foo | jq -r .value | jq -r .rootref >rootref3.out &&
+	checkpoint_get foo | jq -r .value | jq -r .rootref >rootref3.out &&
 	test_cmp rootref3.exp rootref3.out
 '
 
-test_expect_success HAVE_JQ 'kvs-checkpoint.get noexist fails with No such...' '
-	test_must_fail kvs_checkpoint_get noexist 2>badkey.err &&
+test_expect_success HAVE_JQ 'checkpoint-get noexist fails with No such...' '
+	test_must_fail checkpoint_get noexist 2>badkey.err &&
 	grep "No such file or directory" badkey.err
 '
 

--- a/t/t0018-content-files.t
+++ b/t/t0018-content-files.t
@@ -157,9 +157,9 @@ test_expect_success HAVE_JQ 'kvs-checkpoint.put updates foo rootref with longer 
 '
 
 test_expect_success HAVE_JQ 'kvs-checkpoint.get foo returned rootref with longer rootref' '
-        echo abcdefghijklmnopqrstuvwxyz >rootref3.exp &&
-        kvs_checkpoint_get foo | jq -r .value | jq -r .rootref >rootref3.out &&
-        test_cmp rootref3.exp rootref3.out
+        echo abcdefghijklmnopqrstuvwxyz >rootref4.exp &&
+        kvs_checkpoint_get foo | jq -r .value | jq -r .rootref >rootref4.out &&
+        test_cmp rootref4.exp rootref4.out
 '
 
 test_expect_success HAVE_JQ 'kvs-checkpoint.put updates foo rootref to shorter rootref' '
@@ -167,9 +167,9 @@ test_expect_success HAVE_JQ 'kvs-checkpoint.put updates foo rootref to shorter r
 '
 
 test_expect_success HAVE_JQ 'kvs-checkpoint.get foo returned rootref with shorter rootref' '
-        echo foobar >rootref4.exp &&
-        kvs_checkpoint_get foo | jq -r .value | jq -r .rootref >rootref4.out &&
-        test_cmp rootref4.exp rootref4.out
+        echo foobar >rootref5.exp &&
+        kvs_checkpoint_get foo | jq -r .value | jq -r .rootref >rootref5.out &&
+        test_cmp rootref5.exp rootref5.out
 '
 
 test_expect_success 'load with invalid hash size fails with EPROTO' '

--- a/t/t0018-content-files.t
+++ b/t/t0018-content-files.t
@@ -180,7 +180,7 @@ test_expect_success 'kvs-checkpoint.get bad request fails with EPROTO' '
 	test_must_fail $RPC kvs-checkpoint.get </dev/null 2>badget.err &&
 	grep "Protocol error" badget.err
 '
-test_expect_success 'kvs-checkpoint.get bad request fails with EPROTO' '
+test_expect_success 'kvs-checkpoint.put bad request fails with EPROTO' '
 	test_must_fail $RPC kvs-checkpoint.put </dev/null 2>badput.err &&
 	grep "Protocol error" badput.err
 '

--- a/t/t0018-content-files.t
+++ b/t/t0018-content-files.t
@@ -55,14 +55,14 @@ recheck_cache_blob() {
 	flux content load $blobref >blob.$1.cachecheck &&
 	test_cmp blob.$1 blob.$1.cachecheck
 }
-# Usage: kvs_checkpoint_put key rootref
-kvs_checkpoint_put() {
+# Usage: checkpoint_put key rootref
+checkpoint_put() {
         o="{key:\"$1\",value:{version:1,rootref:\"$2\",timestamp:2.2}}"
-        jq -j -c -n  ${o} | $RPC kvs-checkpoint.put
+        jq -j -c -n  ${o} | $RPC content-backing.checkpoint-put
 }
-# Usage: kvs_checkpoint_get key >value
-kvs_checkpoint_get() {
-        jq -j -c -n  "{key:\"$1\"}" | $RPC kvs-checkpoint.get
+# Usage: checkpoint_get key >value
+checkpoint_get() {
+        jq -j -c -n  "{key:\"$1\"}" | $RPC content-backing.checkpoint-get
 }
 
 ##
@@ -100,29 +100,29 @@ test_expect_success LONGTEST 'store/load/verify various size large blobs' '
 	test $err -eq 0
 '
 
-test_expect_success HAVE_JQ 'kvs-checkpoint.put foo w/ rootref bar' '
-	kvs_checkpoint_put foo bar
+test_expect_success HAVE_JQ 'checkpoint-put foo w/ rootref bar' '
+	checkpoint_put foo bar
 '
 
-test_expect_success HAVE_JQ 'kvs-checkpoint.get foo returned rootref bar' '
+test_expect_success HAVE_JQ 'checkpoint-get foo returned rootref bar' '
         echo bar >rootref.exp &&
-        kvs_checkpoint_get foo | jq -r .value | jq -r .rootref >rootref.out &&
+        checkpoint_get foo | jq -r .value | jq -r .rootref >rootref.out &&
         test_cmp rootref.exp rootref.out
 '
 
 # use grep instead of compare, incase of floating point rounding
-test_expect_success HAVE_JQ 'kvs-checkpoint.get foo returned correct timestamp' '
-        kvs_checkpoint_get foo | jq -r .value | jq -r .timestamp >timestamp.out &&
+test_expect_success HAVE_JQ 'checkpoint-get foo returned correct timestamp' '
+        checkpoint_get foo | jq -r .value | jq -r .timestamp >timestamp.out &&
         grep 2.2 timestamp.out
 '
 
-test_expect_success HAVE_JQ 'kvs-checkpoint.put updates foo rootref to baz' '
-        kvs_checkpoint_put foo baz
+test_expect_success HAVE_JQ 'checkpoint-put updates foo rootref to baz' '
+        checkpoint_put foo baz
 '
 
-test_expect_success HAVE_JQ 'kvs-checkpoint.get foo returned rootref baz' '
+test_expect_success HAVE_JQ 'checkpoint-get foo returned rootref baz' '
         echo baz >rootref2.exp &&
-        kvs_checkpoint_get foo | jq -r .value | jq -r .rootref >rootref2.out &&
+        checkpoint_get foo | jq -r .value | jq -r .rootref >rootref2.out &&
         test_cmp rootref2.exp rootref2.out
 '
 
@@ -146,29 +146,29 @@ test_expect_success LONGTEST 'reload/verify various size large blobs' '
 	test $err -eq 0
 '
 
-test_expect_success HAVE_JQ 'kvs-checkpoint.get foo still returns rootref baz' '
+test_expect_success HAVE_JQ 'checkpoint-get foo still returns rootref baz' '
         echo baz >rootref3.exp &&
-        kvs_checkpoint_get foo | jq -r .value | jq -r .rootref >rootref3.out &&
+        checkpoint_get foo | jq -r .value | jq -r .rootref >rootref3.out &&
         test_cmp rootref3.exp rootref3.out
 '
 
-test_expect_success HAVE_JQ 'kvs-checkpoint.put updates foo rootref with longer rootref' '
-        kvs_checkpoint_put foo abcdefghijklmnopqrstuvwxyz
+test_expect_success HAVE_JQ 'checkpoint-put updates foo rootref with longer rootref' '
+        checkpoint_put foo abcdefghijklmnopqrstuvwxyz
 '
 
-test_expect_success HAVE_JQ 'kvs-checkpoint.get foo returned rootref with longer rootref' '
+test_expect_success HAVE_JQ 'checkpoint-get foo returned rootref with longer rootref' '
         echo abcdefghijklmnopqrstuvwxyz >rootref4.exp &&
-        kvs_checkpoint_get foo | jq -r .value | jq -r .rootref >rootref4.out &&
+        checkpoint_get foo | jq -r .value | jq -r .rootref >rootref4.out &&
         test_cmp rootref4.exp rootref4.out
 '
 
-test_expect_success HAVE_JQ 'kvs-checkpoint.put updates foo rootref to shorter rootref' '
-        kvs_checkpoint_put foo foobar
+test_expect_success HAVE_JQ 'checkpoint-put updates foo rootref to shorter rootref' '
+        checkpoint_put foo foobar
 '
 
-test_expect_success HAVE_JQ 'kvs-checkpoint.get foo returned rootref with shorter rootref' '
+test_expect_success HAVE_JQ 'checkpoint-get foo returned rootref with shorter rootref' '
         echo foobar >rootref5.exp &&
-        kvs_checkpoint_get foo | jq -r .value | jq -r .rootref >rootref5.out &&
+        checkpoint_get foo | jq -r .value | jq -r .rootref >rootref5.out &&
         test_cmp rootref5.exp rootref5.out
 '
 
@@ -176,12 +176,12 @@ test_expect_success 'load with invalid hash size fails with EPROTO' '
 	test_must_fail backing_load </dev/null 2>badhash.err &&
 	grep "Protocol error" badhash.err
 '
-test_expect_success 'kvs-checkpoint.get bad request fails with EPROTO' '
-	test_must_fail $RPC kvs-checkpoint.get </dev/null 2>badget.err &&
+test_expect_success 'checkpoint-get bad request fails with EPROTO' '
+	test_must_fail $RPC content-backing.checkpoint-get </dev/null 2>badget.err &&
 	grep "Protocol error" badget.err
 '
-test_expect_success 'kvs-checkpoint.put bad request fails with EPROTO' '
-	test_must_fail $RPC kvs-checkpoint.put </dev/null 2>badput.err &&
+test_expect_success 'checkpoint-put bad request fails with EPROTO' '
+	test_must_fail $RPC content-backing.checkpoint-put </dev/null 2>badput.err &&
 	grep "Protocol error" badput.err
 '
 

--- a/t/t0018-content-files.t
+++ b/t/t0018-content-files.t
@@ -58,11 +58,11 @@ recheck_cache_blob() {
 # Usage: checkpoint_put key rootref
 checkpoint_put() {
         o="{key:\"$1\",value:{version:1,rootref:\"$2\",timestamp:2.2}}"
-        jq -j -c -n  ${o} | $RPC content-backing.checkpoint-put
+        jq -j -c -n  ${o} | $RPC content.checkpoint-put
 }
 # Usage: checkpoint_get key >value
 checkpoint_get() {
-        jq -j -c -n  "{key:\"$1\"}" | $RPC content-backing.checkpoint-get
+        jq -j -c -n  "{key:\"$1\"}" | $RPC content.checkpoint-get
 }
 
 ##
@@ -100,32 +100,6 @@ test_expect_success LONGTEST 'store/load/verify various size large blobs' '
 	test $err -eq 0
 '
 
-test_expect_success HAVE_JQ 'checkpoint-put foo w/ rootref bar' '
-	checkpoint_put foo bar
-'
-
-test_expect_success HAVE_JQ 'checkpoint-get foo returned rootref bar' '
-        echo bar >rootref.exp &&
-        checkpoint_get foo | jq -r .value | jq -r .rootref >rootref.out &&
-        test_cmp rootref.exp rootref.out
-'
-
-# use grep instead of compare, incase of floating point rounding
-test_expect_success HAVE_JQ 'checkpoint-get foo returned correct timestamp' '
-        checkpoint_get foo | jq -r .value | jq -r .timestamp >timestamp.out &&
-        grep 2.2 timestamp.out
-'
-
-test_expect_success HAVE_JQ 'checkpoint-put updates foo rootref to baz' '
-        checkpoint_put foo baz
-'
-
-test_expect_success HAVE_JQ 'checkpoint-get foo returned rootref baz' '
-        echo baz >rootref2.exp &&
-        checkpoint_get foo | jq -r .value | jq -r .rootref >rootref2.out &&
-        test_cmp rootref2.exp rootref2.out
-'
-
 test_expect_success 'reload content-files module' '
 	flux module reload content-files testing
 '
@@ -146,43 +120,9 @@ test_expect_success LONGTEST 'reload/verify various size large blobs' '
 	test $err -eq 0
 '
 
-test_expect_success HAVE_JQ 'checkpoint-get foo still returns rootref baz' '
-        echo baz >rootref3.exp &&
-        checkpoint_get foo | jq -r .value | jq -r .rootref >rootref3.out &&
-        test_cmp rootref3.exp rootref3.out
-'
-
-test_expect_success HAVE_JQ 'checkpoint-put updates foo rootref with longer rootref' '
-        checkpoint_put foo abcdefghijklmnopqrstuvwxyz
-'
-
-test_expect_success HAVE_JQ 'checkpoint-get foo returned rootref with longer rootref' '
-        echo abcdefghijklmnopqrstuvwxyz >rootref4.exp &&
-        checkpoint_get foo | jq -r .value | jq -r .rootref >rootref4.out &&
-        test_cmp rootref4.exp rootref4.out
-'
-
-test_expect_success HAVE_JQ 'checkpoint-put updates foo rootref to shorter rootref' '
-        checkpoint_put foo foobar
-'
-
-test_expect_success HAVE_JQ 'checkpoint-get foo returned rootref with shorter rootref' '
-        echo foobar >rootref5.exp &&
-        checkpoint_get foo | jq -r .value | jq -r .rootref >rootref5.out &&
-        test_cmp rootref5.exp rootref5.out
-'
-
 test_expect_success 'load with invalid hash size fails with EPROTO' '
 	test_must_fail backing_load </dev/null 2>badhash.err &&
 	grep "Protocol error" badhash.err
-'
-test_expect_success 'checkpoint-get bad request fails with EPROTO' '
-	test_must_fail $RPC content-backing.checkpoint-get </dev/null 2>badget.err &&
-	grep "Protocol error" badget.err
-'
-test_expect_success 'checkpoint-put bad request fails with EPROTO' '
-	test_must_fail $RPC content-backing.checkpoint-put </dev/null 2>badput.err &&
-	grep "Protocol error" badput.err
 '
 
 ##
@@ -223,6 +163,71 @@ test_expect_success 'reload content-files with truncate option' '
 test_expect_success 'flux module stats reports zero object count' '
 	test $(flux module stats \
 	    --type int --parse object_count content-files) -eq 0
+'
+
+test_expect_success HAVE_JQ 'checkpoint-put foo w/ rootref bar' '
+	checkpoint_put foo bar
+'
+
+test_expect_success HAVE_JQ 'checkpoint-get foo returned rootref bar' '
+        echo bar >rootref.exp &&
+        checkpoint_get foo | jq -r .value | jq -r .rootref >rootref.out &&
+        test_cmp rootref.exp rootref.out
+'
+
+# use grep instead of compare, incase of floating point rounding
+test_expect_success HAVE_JQ 'checkpoint-get foo returned correct timestamp' '
+        checkpoint_get foo | jq -r .value | jq -r .timestamp >timestamp.out &&
+        grep 2.2 timestamp.out
+'
+
+test_expect_success HAVE_JQ 'checkpoint-put updates foo rootref to baz' '
+        checkpoint_put foo baz
+'
+
+test_expect_success HAVE_JQ 'checkpoint-get foo returned rootref baz' '
+        echo baz >rootref2.exp &&
+        checkpoint_get foo | jq -r .value | jq -r .rootref >rootref2.out &&
+        test_cmp rootref2.exp rootref2.out
+'
+
+test_expect_success 'reload content-files module' '
+	flux module reload content-files
+'
+
+test_expect_success HAVE_JQ 'checkpoint-get foo still returns rootref baz' '
+        echo baz >rootref3.exp &&
+        checkpoint_get foo | jq -r .value | jq -r .rootref >rootref3.out &&
+        test_cmp rootref3.exp rootref3.out
+'
+
+test_expect_success HAVE_JQ 'checkpoint-put updates foo rootref with longer rootref' '
+        checkpoint_put foo abcdefghijklmnopqrstuvwxyz
+'
+
+test_expect_success HAVE_JQ 'checkpoint-get foo returned rootref with longer rootref' '
+        echo abcdefghijklmnopqrstuvwxyz >rootref4.exp &&
+        checkpoint_get foo | jq -r .value | jq -r .rootref >rootref4.out &&
+        test_cmp rootref4.exp rootref4.out
+'
+
+test_expect_success HAVE_JQ 'checkpoint-put updates foo rootref to shorter rootref' '
+        checkpoint_put foo foobar
+'
+
+test_expect_success HAVE_JQ 'checkpoint-get foo returned rootref with shorter rootref' '
+        echo foobar >rootref5.exp &&
+        checkpoint_get foo | jq -r .value | jq -r .rootref >rootref5.out &&
+        test_cmp rootref5.exp rootref5.out
+'
+
+test_expect_success 'checkpoint-get bad request fails with EPROTO' '
+	test_must_fail $RPC content.checkpoint-get </dev/null 2>badget.err &&
+	grep "Protocol error" badget.err
+'
+test_expect_success 'checkpoint-put bad request fails with EPROTO' '
+	test_must_fail $RPC content.checkpoint-put </dev/null 2>badput.err &&
+	grep "Protocol error" badput.err
 '
 
 test_expect_success 'remove content-files module' '

--- a/t/t0024-content-s3.t
+++ b/t/t0024-content-s3.t
@@ -60,14 +60,14 @@ recheck_cache_blob() {
 	flux content load $blobref >blob.$1.cachecheck &&
 	test_cmp blob.$1 blob.$1.cachecheck
 }
-# Usage: kvs_checkpoint_put key rootref
-kvs_checkpoint_put() {
+# Usage: checkpoint_put key rootref
+checkpoint_put() {
         o="{key:\"$1\",value:{version:1,rootref:\"$2\",timestamp:2.2}}"
-        jq -j -c -n  ${o} | $RPC kvs-checkpoint.put
+        jq -j -c -n  ${o} | $RPC content-backing.checkpoint-put
 }
-# Usage: kvs_checkpoint_get key >value
-kvs_checkpoint_get() {
-        jq -j -c -n  "{key:\"$1\"}" | $RPC kvs-checkpoint.get
+# Usage: checkpoint_get key >value
+checkpoint_get() {
+        jq -j -c -n  "{key:\"$1\"}" | $RPC content-backing.checkpoint-get
 }
 
 ##
@@ -124,29 +124,29 @@ test_expect_success LONGTEST 'store/load/verify various size large blobs' '
 '
 
 
-test_expect_success HAVE_JQ 'kvs-checkpoint.put foo w/ rootref bar' '
-	kvs_checkpoint_put foo bar
+test_expect_success HAVE_JQ 'checkpoint-put foo w/ rootref bar' '
+	checkpoint_put foo bar
 '
 
-test_expect_success HAVE_JQ 'kvs-checkpoint.get foo returned rootref bar' '
+test_expect_success HAVE_JQ 'checkpoint-get foo returned rootref bar' '
         echo bar >rootref.exp &&
-        kvs_checkpoint_get foo | jq -r .value | jq -r .rootref >rootref.out &&
+        checkpoint_get foo | jq -r .value | jq -r .rootref >rootref.out &&
         test_cmp rootref.exp rootref.out
 '
 
 # use grep instead of compare, incase of floating point rounding
-test_expect_success HAVE_JQ 'kvs-checkpoint.get foo returned correct timestamp' '
-        kvs_checkpoint_get foo | jq -r .value | jq -r .timestamp >timestamp.out &&
+test_expect_success HAVE_JQ 'checkpoint-get foo returned correct timestamp' '
+        checkpoint_get foo | jq -r .value | jq -r .timestamp >timestamp.out &&
         grep 2.2 timestamp.out
 '
 
-test_expect_success HAVE_JQ 'kvs-checkpoint.put updates foo rootref to baz' '
-        kvs_checkpoint_put foo baz
+test_expect_success HAVE_JQ 'checkpoint-put updates foo rootref to baz' '
+        checkpoint_put foo baz
 '
 
-test_expect_success HAVE_JQ 'kvs-checkpoint.get foo returned rootref baz' '
+test_expect_success HAVE_JQ 'checkpoint-get foo returned rootref baz' '
         echo baz >rootref2.exp &&
-        kvs_checkpoint_get foo | jq -r .value | jq -r .rootref >rootref2.out &&
+        checkpoint_get foo | jq -r .value | jq -r .rootref >rootref2.out &&
         test_cmp rootref2.exp rootref2.out
 '
 
@@ -170,9 +170,9 @@ test_expect_success LONGTEST 'reload/verify various size large blobs' '
 	test $err -eq 0
 '
 
-test_expect_success HAVE_JQ 'kvs-checkpoint.get foo still returns rootref baz' '
+test_expect_success HAVE_JQ 'checkpoint-get foo still returns rootref baz' '
         echo baz >rootref3.exp &&
-        kvs_checkpoint_get foo | jq -r .value | jq -r .rootref >rootref3.out &&
+        checkpoint_get foo | jq -r .value | jq -r .rootref >rootref3.out &&
         test_cmp rootref3.exp rootref3.out
 '
 

--- a/t/t0024-content-s3.t
+++ b/t/t0024-content-s3.t
@@ -63,11 +63,11 @@ recheck_cache_blob() {
 # Usage: checkpoint_put key rootref
 checkpoint_put() {
         o="{key:\"$1\",value:{version:1,rootref:\"$2\",timestamp:2.2}}"
-        jq -j -c -n  ${o} | $RPC content-backing.checkpoint-put
+        jq -j -c -n  ${o} | $RPC content.checkpoint-put
 }
 # Usage: checkpoint_get key >value
 checkpoint_get() {
-        jq -j -c -n  "{key:\"$1\"}" | $RPC content-backing.checkpoint-get
+        jq -j -c -n  "{key:\"$1\"}" | $RPC content.checkpoint-get
 }
 
 ##

--- a/t/t1010-kvs-commit-sync.t
+++ b/t/t1010-kvs-commit-sync.t
@@ -16,8 +16,8 @@ test_under_flux ${SIZE} minimal
 
 TESTNAMESPACE="testnamespace"
 
-kvs_checkpoint_get() {
-        jq -j -c -n  "{key:\"$1\"}" | $RPC kvs-checkpoint.get
+checkpoint_get() {
+        jq -j -c -n  "{key:\"$1\"}" | $RPC content-backing.checkpoint-get
 }
 
 test_expect_success 'load content-sqlite and kvs and add some data' '
@@ -28,7 +28,7 @@ test_expect_success 'load content-sqlite and kvs and add some data' '
 '
 
 test_expect_success 'kvs: no checkpoint of kvs-primary should exist yet' '
-        test_must_fail kvs_checkpoint_get kvs-primary
+        test_must_fail checkpoint_get kvs-primary
 '
 
 test_expect_success 'kvs: put some data to kvs and sync it' '
@@ -36,11 +36,11 @@ test_expect_success 'kvs: put some data to kvs and sync it' '
 '
 
 test_expect_success 'kvs: checkpoint of kvs-primary should exist now' '
-        kvs_checkpoint_get kvs-primary
+        checkpoint_get kvs-primary
 '
 
 test_expect_success 'kvs: checkpoint of kvs-primary should match rootref' '
-        kvs_checkpoint_get kvs-primary | jq -r .value.rootref > checkpoint.out &&
+        checkpoint_get kvs-primary | jq -r .value.rootref > checkpoint.out &&
         test_cmp syncblob.out checkpoint.out
 '
 
@@ -50,7 +50,7 @@ test_expect_success 'kvs: fence some data to kvs and sync it' '
 
 test_expect_success 'kvs: rootref of kvs-primary should match rootref' '
         flux kvs getroot -b > fenceroot.exp &&
-        kvs_checkpoint_get kvs-primary | jq -r .value.rootref > fenceroot.out &&
+        checkpoint_get kvs-primary | jq -r .value.rootref > fenceroot.out &&
         test_cmp fenceroot.exp fenceroot.out
 '
 

--- a/t/t1010-kvs-commit-sync.t
+++ b/t/t1010-kvs-commit-sync.t
@@ -17,7 +17,7 @@ test_under_flux ${SIZE} minimal
 TESTNAMESPACE="testnamespace"
 
 checkpoint_get() {
-        jq -j -c -n  "{key:\"$1\"}" | $RPC content-backing.checkpoint-get
+        jq -j -c -n  "{key:\"$1\"}" | $RPC content.checkpoint-get
 }
 
 test_expect_success 'load content-sqlite and kvs and add some data' '

--- a/t/t1011-kvs-checkpoint-period.t
+++ b/t/t1011-kvs-checkpoint-period.t
@@ -15,21 +15,21 @@ export FLUX_CONF_DIR=$(pwd)
 SIZE=4
 test_under_flux ${SIZE} minimal
 
-kvs_checkpoint_get() {
+checkpoint_get() {
 	jq -j -c -n  "{key:\"$1\"}" \
-	    | $RPC kvs-checkpoint.get \
+	    | $RPC content-backing.checkpoint-get \
 	    | jq -r .value.rootref
 }
 
 # arg1 - old ref
 # arg2 - timeout (seconds)
-kvs_checkpoint_changed() {
+checkpoint_changed() {
 	old_ref=$1
 	local i=0
 	local iters=$(($2 * 10))
 	while [ $i -lt ${iters} ]
 	do
-	    ref=$(kvs_checkpoint_get kvs-primary)
+	    ref=$(checkpoint_get kvs-primary)
 	    if [ "${old_ref}" != "${ref}" ]
 	    then
 		return 0
@@ -65,8 +65,8 @@ test_expect_success 'kvs: put some more data to kvs (1)' '
 '
 
 test_expect_success 'kvs: checkpoint of kvs-primary should change in time (1)' '
-	kvs_checkpoint_changed $(cat blob1.out) 5 &&
-	kvs_checkpoint_get kvs-primary > checkpoint2.out &&
+	checkpoint_changed $(cat blob1.out) 5 &&
+	checkpoint_get kvs-primary > checkpoint2.out &&
 	test_cmp checkpoint2.out blob2.out
 '
 
@@ -75,8 +75,8 @@ test_expect_success 'kvs: put some more data to kvs (2)' '
 '
 
 test_expect_success 'kvs: checkpoint of kvs-primary should change in time (2)' '
-	kvs_checkpoint_changed $(cat blob2.out) 5 &&
-	kvs_checkpoint_get kvs-primary > checkpoint3.out &&
+	checkpoint_changed $(cat blob2.out) 5 &&
+	checkpoint_get kvs-primary > checkpoint3.out &&
 	test_cmp checkpoint3.out blob3.out
 '
 
@@ -86,7 +86,7 @@ test_expect_success 'kvs: put some data to non-primary namespace' '
 '
 
 test_expect_success 'kvs: checkpoint of kvs-primary should not change (1)' '
-	test_must_fail kvs_checkpoint_changed $(cat blob3.out) 2
+	test_must_fail checkpoint_changed $(cat blob3.out) 2
 '
 
 test_expect_success 'configure bad checkpoint-period timer in kvs on reload' '
@@ -110,7 +110,7 @@ test_expect_success 'kvs: put some more data to kvs (3)' '
 '
 
 test_expect_success 'kvs: checkpoint of kvs-primary should not change (2)' '
-	test_must_fail kvs_checkpoint_changed $(cat blob3.out) 2
+	test_must_fail checkpoint_changed $(cat blob3.out) 2
 '
 
 test_expect_success 're-config checkpoint-period timer, set small period' '
@@ -122,8 +122,8 @@ test_expect_success 're-config checkpoint-period timer, set small period' '
 '
 
 test_expect_success 'kvs: checkpoint of kvs-primary should change in time (3)' '
-	kvs_checkpoint_changed $(cat blob3.out) 5 &&
-	kvs_checkpoint_get kvs-primary > checkpoint4.out &&
+	checkpoint_changed $(cat blob3.out) 5 &&
+	checkpoint_get kvs-primary > checkpoint4.out &&
 	test_cmp checkpoint4.out blob4.out
 '
 
@@ -140,7 +140,7 @@ test_expect_success 'kvs: put some more data to kvs (4)' '
 '
 
 test_expect_success 'kvs: checkpoint of kvs-primary should not change (3)' '
-	test_must_fail kvs_checkpoint_changed $(cat blob4.out) 2
+	test_must_fail checkpoint_changed $(cat blob4.out) 2
 '
 
 test_expect_success 're-config checkpoint-period timer in kvs, re-enable it' '
@@ -152,8 +152,8 @@ test_expect_success 're-config checkpoint-period timer in kvs, re-enable it' '
 '
 
 test_expect_success 'kvs: checkpoint of kvs-primary should change in time (4)' '
-	kvs_checkpoint_changed $(cat blob4.out) 5 &&
-	kvs_checkpoint_get kvs-primary > checkpoint5.out &&
+	checkpoint_changed $(cat blob4.out) 5 &&
+	checkpoint_get kvs-primary > checkpoint5.out &&
 	test_cmp checkpoint5.out blob5.out
 '
 

--- a/t/t1011-kvs-checkpoint-period.t
+++ b/t/t1011-kvs-checkpoint-period.t
@@ -17,7 +17,7 @@ test_under_flux ${SIZE} minimal
 
 checkpoint_get() {
 	jq -j -c -n  "{key:\"$1\"}" \
-	    | $RPC content-backing.checkpoint-get \
+	    | $RPC content.checkpoint-get \
 	    | jq -r .value.rootref
 }
 

--- a/t/t2807-dump-cmd.t
+++ b/t/t2807-dump-cmd.t
@@ -23,7 +23,7 @@ test_expect_success 'flux-restore with no args prints Usage message' '
 '
 test_expect_success 'flux-dump with no backing store fails' '
 	test_must_fail flux dump --checkpoint foo.tar 2>nostore.err &&
-	grep "No service matching kvs-checkpoint.get" nostore.err
+	grep "No service matching content-backing.checkpoint-get" nostore.err
 '
 test_expect_success 'flux-dump with bad archive file fails' '
 	test_must_fail flux dump /badfile.tar 2>badfile.err &&

--- a/t/t2807-dump-cmd.t
+++ b/t/t2807-dump-cmd.t
@@ -23,7 +23,7 @@ test_expect_success 'flux-restore with no args prints Usage message' '
 '
 test_expect_success 'flux-dump with no backing store fails' '
 	test_must_fail flux dump --checkpoint foo.tar 2>nostore.err &&
-	grep "No service matching content-backing.checkpoint-get" nostore.err
+	grep "Function not implemented" nostore.err
 '
 test_expect_success 'flux-dump with bad archive file fails' '
 	test_must_fail flux dump /badfile.tar 2>badfile.err &&


### PR DESCRIPTION
As per-requisite support for issue #4267, we will need to route checkpoints through the broker into the content backing modules.

There is a nice chunk of cleanup to do before this can happen, mostly surrounding topic names.  So this is a bit of a pre-requisite PR I'm splitting off from the main PR since it doesn't really do much but touches a lot of lines of code.

Note that in the last commit, there is some code that is "common" and would look like I should add a common function.  But they will be modified shortly so I left them separate.  I could clean that up if desired.