### PR TITLE
job-list: avoid segfault after job purge

### DIFF
--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -306,6 +306,7 @@ dist_check_SCRIPTS = \
 	issues/t4378-content-flush-force.sh \
 	issues/t4379-dirty-cache-entries-flush.sh \
 	issues/t4413-empty-eventlog.sh \
+	issues/t4465-job-list-use-after-free.sh \
 	python/__init__.py \
 	python/subflux.py \
 	python/tap \

--- a/t/issues/t4465-job-list-use-after-free.sh
+++ b/t/issues/t4465-job-list-use-after-free.sh
@@ -1,0 +1,27 @@
+#!/bin/sh -e
+
+VALGRIND=`which valgrind`
+if test -z "${VALGRIND}"; then
+    exit 0
+fi
+
+STATEDIR=issue4470-statedir
+
+rm -rf ${STATEDIR}
+mkdir ${STATEDIR}
+
+# This test reproduces the failure more often when jobs complete in
+# a different order than submitted, hence number of jobs submitted equals
+# number of broker ranks.
+#
+flux start --test-size=8 -o,-Sstatedir=${STATEDIR} \
+    bash -c "flux mini submit --cc 1-8 -q /bin/true && flux queue drain"
+
+flux start --test-size=1 -o,-Sstatedir=${STATEDIR} \
+    --wrap=libtool,e,${VALGRIND} \
+    --wrap=--tool=memcheck \
+    --wrap=--trace-children=no \
+    --wrap=--child-silent-after-fork=yes \
+    --wrap=--num-callers=30 \
+    --wrap=--error-exitcode=1 \
+    bash -c "flux job purge --force --num-limit=4 && flux jobs -a 2>/dev/null"


### PR DESCRIPTION
@grondo and I ran this fix to #4465, which crashed the rank 0 broker on fluke twice this morning.

I'll see if I can come up with a test.  It's a use-after-free so the test may not be a reliable reproducer unless run under valgrind.  That's still probably useful I guess.

Edit: I did confirm that the valgrind test described in the issue (which involves restart from fluke's kvs dump) no longer produces errors with this fix.