### PR TITLE
kvs: add root sequence number to checkpoint object

### DIFF
--- a/src/cmd/builtin/restore.c
+++ b/src/cmd/builtin/restore.c
@@ -371,7 +371,8 @@ static int cmd_restore (optparse_t *p, int ac, char *av[])
                      shortblobref_length (blobref),
                      blobref);
         }
-        if (!(f = kvs_checkpoint_commit (h, NULL, blobref, restore_timestamp))
+        /* restoring, therefore we restart sequence number at 0 */
+        if (!(f = kvs_checkpoint_commit (h, NULL, blobref, 0, restore_timestamp))
             || flux_rpc_get (f, NULL) < 0) {
             log_msg_exit ("error updating checkpoint: %s",
                           future_strerror (f, errno));

--- a/src/common/libkvs/kvs.h
+++ b/src/common/libkvs/kvs.h
@@ -59,7 +59,7 @@ flux_future_t *flux_kvs_namespace_remove (flux_t *h, const char *ns);
  * Process B waits for the store version to be >= V, then reads data.
  */
 int flux_kvs_get_version (flux_t *h, const char *ns, int *versionp);
-int flux_kvs_wait_version (flux_t *h,const char *ns, int version);
+int flux_kvs_wait_version (flux_t *h, const char *ns, int version);
 
 /* Garbage collect the cache.  On the root node, drop all data that
  * doesn't have a reference in the namespace.  On other nodes, the entire

--- a/src/common/libkvs/kvs_checkpoint.h
+++ b/src/common/libkvs/kvs_checkpoint.h
@@ -26,6 +26,7 @@
 flux_future_t *kvs_checkpoint_commit (flux_t *h,
                                       const char *key,
                                       const char *rootref,
+                                      int sequence,
                                       double timestamp);
 
 flux_future_t *kvs_checkpoint_lookup (flux_t *h, const char *key);
@@ -35,6 +36,10 @@ int kvs_checkpoint_lookup_get_rootref (flux_future_t *f, const char **rootref);
 /* sets timestamp to 0 if unavailable
  */
 int kvs_checkpoint_lookup_get_timestamp (flux_future_t *f, double *timestamp);
+
+/* sets sequence to 0 if unavailable
+ */
+int kvs_checkpoint_lookup_get_sequence (flux_future_t *f, int *sequence);
 
 #endif /* !_KVS_CHECKPOINT_H */
 

--- a/src/common/libkvs/test/kvs_checkpoint.c
+++ b/src/common/libkvs/test/kvs_checkpoint.c
@@ -26,7 +26,7 @@ void errors (void)
     const char *rootref;
 
     errno = 0;
-    ok (kvs_checkpoint_commit (NULL, NULL, NULL, 0) == NULL
+    ok (kvs_checkpoint_commit (NULL, NULL, NULL, 0, 0) == NULL
         && errno == EINVAL,
         "kvs_checkpoint_commit fails on bad input");
 
@@ -45,6 +45,11 @@ void errors (void)
         && errno == EINVAL,
         "kvs_checkpoint_lookup_get_timestamp fails on bad input");
 
+    errno = 0;
+    ok (kvs_checkpoint_lookup_get_sequence (NULL, NULL) < 0
+        && errno == EINVAL,
+        "kvs_checkpoint_lookup_get_sequence fails on bad input");
+
     if (!(f = flux_future_create (NULL, NULL)))
         BAIL_OUT ("flux_future_create failed");
 
@@ -58,6 +63,12 @@ void errors (void)
     ok (kvs_checkpoint_lookup_get_timestamp (f, &timestamp) < 0
         && errno == EDEADLOCK,
         "kvs_checkpoint_lookup_get_timestamp fails on unfulfilled future");
+
+    errno = 0;
+    int sequence;
+    ok (kvs_checkpoint_lookup_get_sequence (f, &sequence) < 0
+        && errno == EDEADLOCK,
+        "kvs_checkpoint_lookup_get_sequence fails on unfulfilled future");
 
     flux_future_destroy (f);
 }

--- a/src/modules/content-sqlite/content-sqlite.c
+++ b/src/modules/content-sqlite/content-sqlite.c
@@ -390,9 +390,10 @@ void checkpoint_get_cb (flux_t *h,
         }
         /* assume "version 0" if value is a bare blobref and return it
          * in a json envelope */
-        if (!(o = json_pack ("{s:i s:s s:f}",
+        if (!(o = json_pack ("{s:i s:s s:i s:f}",
                              "version", 0,
                              "rootref", s,
+                             "sequence", 0,
                              "timestamp", 0.))) {
             errstr = "failed to encode blobref in json envelope";
             errno = EINVAL;

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -963,7 +963,9 @@ static void kvstxn_apply (kvstxn_t *kt)
     if ((errnum = kvstxn_get_aux_errnum (kt)))
         goto done;
 
-    if ((ret = kvstxn_process (kt, root->ref)) == KVSTXN_PROCESS_ERROR) {
+    if ((ret = kvstxn_process (kt,
+                               root->ref,
+                               root->seq)) == KVSTXN_PROCESS_ERROR) {
         errnum = kvstxn_get_errnum (kt);
         goto done;
     }

--- a/src/modules/kvs/kvstxn.c
+++ b/src/modules/kvs/kvstxn.c
@@ -842,7 +842,7 @@ error:
     return NULL;
 }
 
-kvstxn_process_t kvstxn_process (kvstxn_t *kt, const char *rootdir_ref)
+kvstxn_process_t kvstxn_process (kvstxn_t *kt, const char *root_ref)
 {
     /* Incase user calls kvstxn_process() again */
     if (kt->errnum)
@@ -877,10 +877,10 @@ kvstxn_process_t kvstxn_process (kvstxn_t *kt, const char *rootdir_ref)
 
             kt->state = KVSTXN_STATE_LOAD_ROOT;
 
-            if (!(entry = cache_lookup (kt->ktm->cache, rootdir_ref))
+            if (!(entry = cache_lookup (kt->ktm->cache, root_ref))
                 || !cache_entry_get_valid (entry)) {
 
-                if (add_missing_ref (kt, rootdir_ref) < 0) {
+                if (add_missing_ref (kt, root_ref) < 0) {
                     kt->errnum = errno;
                     return KVSTXN_PROCESS_ERROR;
                 }
@@ -913,7 +913,7 @@ kvstxn_process_t kvstxn_process (kvstxn_t *kt, const char *rootdir_ref)
             }
             else {
                 /* place current rootref into newroot, it won't change */
-                strcpy (kt->newroot, rootdir_ref);
+                strcpy (kt->newroot, root_ref);
                 kt->state = KVSTXN_STATE_GENERATE_KEYS;
             }
         }

--- a/src/modules/kvs/kvstxn.c
+++ b/src/modules/kvs/kvstxn.c
@@ -1091,9 +1091,18 @@ kvstxn_process_t kvstxn_process (kvstxn_t *kt,
         else if (kt->state == KVSTXN_STATE_SYNC_CHECKPOINT) {
 
             if (!(kt->f_sync_checkpoint)) {
+                int newseq = root_seq;
+
+                /* if we're publishing, seq will be the seq after
+                 * the current one.
+                 */
+                if (!(kt->internal_flags & KVSTXN_INTERNAL_FLAG_NO_PUBLISH))
+                    newseq++;
+
                 kt->f_sync_checkpoint = kvs_checkpoint_commit (kt->ktm->h,
                                                                NULL,
                                                                kt->newroot,
+                                                               newseq,
                                                                0);
                 if (!kt->f_sync_checkpoint) {
                     kt->errnum = errno;

--- a/src/modules/kvs/kvstxn.c
+++ b/src/modules/kvs/kvstxn.c
@@ -842,7 +842,9 @@ error:
     return NULL;
 }
 
-kvstxn_process_t kvstxn_process (kvstxn_t *kt, const char *root_ref)
+kvstxn_process_t kvstxn_process (kvstxn_t *kt,
+                                 const char *root_ref,
+                                 int root_seq)
 {
     /* Incase user calls kvstxn_process() again */
     if (kt->errnum)

--- a/src/modules/kvs/kvstxn.h
+++ b/src/modules/kvs/kvstxn.h
@@ -113,7 +113,7 @@ json_t *kvstxn_get_keys (kvstxn_t *kt);
  * on completion, call kvstxn_get_newroot_ref() to get reference to
  * new root to be stored.
  */
-kvstxn_process_t kvstxn_process (kvstxn_t *kt, const char *rootdir_ref);
+kvstxn_process_t kvstxn_process (kvstxn_t *kt, const char *root_ref);
 
 /* on stall, iterate through all missing refs that the caller should
  * load into the cache

--- a/src/modules/kvs/kvstxn.h
+++ b/src/modules/kvs/kvstxn.h
@@ -113,7 +113,9 @@ json_t *kvstxn_get_keys (kvstxn_t *kt);
  * on completion, call kvstxn_get_newroot_ref() to get reference to
  * new root to be stored.
  */
-kvstxn_process_t kvstxn_process (kvstxn_t *kt, const char *root_ref);
+kvstxn_process_t kvstxn_process (kvstxn_t *kt,
+                                 const char *root_ref,
+                                 int root_seq);
 
 /* on stall, iterate through all missing refs that the caller should
  * load into the cache

--- a/src/modules/kvs/test/kvstxn.c
+++ b/src/modules/kvs/test/kvstxn.c
@@ -732,7 +732,7 @@ void kvstxn_corner_case_tests (void)
     ok ((kt = kvstxn_mgr_get_ready_transaction (ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns ready kvstxn");
 
-    ok (kvstxn_process (kt, rootref) == KVSTXN_PROCESS_ERROR
+    ok (kvstxn_process (kt, rootref, 0) == KVSTXN_PROCESS_ERROR
         && kvstxn_get_errnum (kt) == EINVAL,
         "kvstxn_sync_checkpoint returns EINVAL on FLUX_KVS_SYNC "
         "with non-default namespace");
@@ -839,7 +839,7 @@ void kvstxn_basic_kvstxn_process_test (void)
     ok ((kt = kvstxn_mgr_get_ready_transaction (ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns ready kvstxn");
 
-    ok (kvstxn_process (kt, rootref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
+    ok (kvstxn_process (kt, rootref, 0) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
         "kvstxn_process returns KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES");
 
     ok (kvstxn_iter_dirty_cache_entries (kt, cache_count_dirty_cb, &count) == 0,
@@ -848,7 +848,7 @@ void kvstxn_basic_kvstxn_process_test (void)
     ok (count == 1,
         "correct number of cache entries were dirty");
 
-    ok (kvstxn_process (kt, rootref) == KVSTXN_PROCESS_FINISHED,
+    ok (kvstxn_process (kt, rootref, 0) == KVSTXN_PROCESS_FINISHED,
         "kvstxn_process returns KVSTXN_PROCESS_FINISHED");
 
     ok ((newroot = kvstxn_get_newroot_ref (kt)) != NULL,
@@ -896,7 +896,7 @@ void kvstxn_basic_kvstxn_process_test_empty_ops (void)
     ok ((kt = kvstxn_mgr_get_ready_transaction (ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns ready kvstxn");
 
-    ok (kvstxn_process (kt, rootref) == KVSTXN_PROCESS_FINISHED,
+    ok (kvstxn_process (kt, rootref, 0) == KVSTXN_PROCESS_FINISHED,
         "kvstxn_process returns KVSTXN_PROCESS_FINISHED");
 
     ok ((newroot = kvstxn_get_newroot_ref (kt)) != NULL,
@@ -956,7 +956,7 @@ void kvstxn_basic_kvstxn_process_test_internal_flags (void)
     ok (flags == KVSTXN_INTERNAL_FLAG_NO_PUBLISH,
         "kvstxn_get_internal_flags returns correct flags");
 
-    ok (kvstxn_process (kt, rootref) == KVSTXN_PROCESS_FINISHED,
+    ok (kvstxn_process (kt, rootref, 0) == KVSTXN_PROCESS_FINISHED,
         "kvstxn_process returns KVSTXN_PROCESS_FINISHED");
 
     ok ((newroot = kvstxn_get_newroot_ref (kt)) != NULL,
@@ -1007,7 +1007,7 @@ void kvstxn_basic_kvstxn_process_test_normalization (void)
     ok ((kt = kvstxn_mgr_get_ready_transaction (ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns ready kvstxn");
 
-    ok (kvstxn_process (kt, rootref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
+    ok (kvstxn_process (kt, rootref, 0) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
         "kvstxn_process returns KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES");
 
     ok (kvstxn_iter_dirty_cache_entries (kt, cache_count_dirty_cb, &count) == 0,
@@ -1016,7 +1016,7 @@ void kvstxn_basic_kvstxn_process_test_normalization (void)
     ok (count == 2,
         "correct number of cache entries were dirty");
 
-    ok (kvstxn_process (kt, rootref) == KVSTXN_PROCESS_FINISHED,
+    ok (kvstxn_process (kt, rootref, 0) == KVSTXN_PROCESS_FINISHED,
         "kvstxn_process returns KVSTXN_PROCESS_FINISHED");
 
     ok ((newroot = kvstxn_get_newroot_ref (kt)) != NULL,
@@ -1072,7 +1072,7 @@ void kvstxn_basic_kvstxn_process_test_multiple_transactions (void)
     ok ((kt = kvstxn_mgr_get_ready_transaction (ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns ready kvstxn");
 
-    ok (kvstxn_process (kt, rootref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
+    ok (kvstxn_process (kt, rootref, 0) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
         "kvstxn_process returns KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES");
 
     ok (kvstxn_iter_dirty_cache_entries (kt, cache_count_dirty_cb, &count) == 0,
@@ -1081,7 +1081,7 @@ void kvstxn_basic_kvstxn_process_test_multiple_transactions (void)
     ok (count == 1,
         "correct number of cache entries were dirty");
 
-    ok (kvstxn_process (kt, rootref) == KVSTXN_PROCESS_FINISHED,
+    ok (kvstxn_process (kt, rootref, 0) == KVSTXN_PROCESS_FINISHED,
         "kvstxn_process returns KVSTXN_PROCESS_FINISHED");
 
     ok ((newroot = kvstxn_get_newroot_ref (kt)) != NULL,
@@ -1097,7 +1097,7 @@ void kvstxn_basic_kvstxn_process_test_multiple_transactions (void)
     ok ((kt = kvstxn_mgr_get_ready_transaction (ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns ready kvstxn");
 
-    ok (kvstxn_process (kt, rootref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
+    ok (kvstxn_process (kt, rootref, 0) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
         "kvstxn_process returns KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES");
 
     count = 0;
@@ -1109,7 +1109,7 @@ void kvstxn_basic_kvstxn_process_test_multiple_transactions (void)
     ok (count == 2,
         "correct number of cache entries were dirty");
 
-    ok (kvstxn_process (kt, rootref) == KVSTXN_PROCESS_FINISHED,
+    ok (kvstxn_process (kt, rootref, 0) == KVSTXN_PROCESS_FINISHED,
         "kvstxn_process returns KVSTXN_PROCESS_FINISHED");
 
     ok ((newroot = kvstxn_get_newroot_ref (kt)) != NULL,
@@ -1174,7 +1174,7 @@ void kvstxn_basic_kvstxn_process_test_multiple_transactions_merge (void)
     ok ((kt = kvstxn_mgr_get_ready_transaction (ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns ready kvstxn");
 
-    ok (kvstxn_process (kt, rootref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
+    ok (kvstxn_process (kt, rootref, 0) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
         "kvstxn_process returns KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES");
 
     ok (kvstxn_iter_dirty_cache_entries (kt, cache_count_dirty_cb, &count) == 0,
@@ -1187,7 +1187,7 @@ void kvstxn_basic_kvstxn_process_test_multiple_transactions_merge (void)
     ok (count == 3,
         "correct number of cache entries were dirty");
 
-    ok (kvstxn_process (kt, rootref) == KVSTXN_PROCESS_FINISHED,
+    ok (kvstxn_process (kt, rootref, 0) == KVSTXN_PROCESS_FINISHED,
         "kvstxn_process returns KVSTXN_PROCESS_FINISHED");
 
     ok ((newroot = kvstxn_get_newroot_ref (kt)) != NULL,
@@ -1207,13 +1207,13 @@ void kvstxn_basic_kvstxn_process_test_multiple_transactions_merge (void)
     ok ((kt = kvstxn_mgr_get_ready_transaction (ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns NULL, no more kvstxns");
 
-    ok (kvstxn_process (kt, rootref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
+    ok (kvstxn_process (kt, rootref, 0) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
         "kvstxn_process returns KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES");
 
     ok (kvstxn_iter_dirty_cache_entries (kt, cache_count_dirty_cb, &count) == 0,
         "kvstxn_iter_dirty_cache_entries works for dirty cache entries");
 
-    ok (kvstxn_process (kt, rootref) == KVSTXN_PROCESS_FINISHED,
+    ok (kvstxn_process (kt, rootref, 0) == KVSTXN_PROCESS_FINISHED,
         "kvstxn_process returns KVSTXN_PROCESS_FINISHED");
 
     ok ((newroot = kvstxn_get_newroot_ref (kt)) != NULL,
@@ -1265,7 +1265,7 @@ void kvstxn_basic_kvstxn_process_test_invalid_transaction (void)
     ok ((kt = kvstxn_mgr_get_ready_transaction (ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns ready transaction");
 
-    ok (kvstxn_process (ktbad, rootref) == KVSTXN_PROCESS_ERROR
+    ok (kvstxn_process (ktbad, rootref, 0) == KVSTXN_PROCESS_ERROR
         && kvstxn_get_errnum (ktbad) == EINVAL,
         "kvstxn_process fails on bad kvstxn");
 
@@ -1305,11 +1305,11 @@ void kvstxn_basic_root_not_dir (void)
     ok ((kt = kvstxn_mgr_get_ready_transaction (ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns ready kvstxn");
 
-    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_ERROR,
+    ok (kvstxn_process (kt, root_ref, 0) == KVSTXN_PROCESS_ERROR,
         "kvstxn_process returns KVSTXN_PROCESS_ERROR");
 
     /* error is caught continuously */
-    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_ERROR,
+    ok (kvstxn_process (kt, root_ref, 0) == KVSTXN_PROCESS_ERROR,
         "kvstxn_process returns KVSTXN_PROCESS_ERROR again");
 
     ok (kvstxn_get_errnum (kt) == EINVAL,
@@ -1382,11 +1382,11 @@ void kvstxn_process_root_missing (void)
     ok ((kt = kvstxn_mgr_get_ready_transaction (ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns ready kvstxn");
 
-    ok (kvstxn_process (kt, rootref) == KVSTXN_PROCESS_LOAD_MISSING_REFS,
+    ok (kvstxn_process (kt, rootref, 0) == KVSTXN_PROCESS_LOAD_MISSING_REFS,
         "kvstxn_process returns KVSTXN_PROCESS_LOAD_MISSING_REFS");
 
     /* user forgot to call kvstxn_iter_missing_refs() test */
-    ok (kvstxn_process (kt, rootref) == KVSTXN_PROCESS_LOAD_MISSING_REFS,
+    ok (kvstxn_process (kt, rootref, 0) == KVSTXN_PROCESS_LOAD_MISSING_REFS,
         "kvstxn_process returns KVSTXN_PROCESS_LOAD_MISSING_REFS again");
 
     rd.cache = cache;
@@ -1395,17 +1395,17 @@ void kvstxn_process_root_missing (void)
     ok (kvstxn_iter_missing_refs (kt, rootref_cb, &rd) == 0,
         "kvstxn_iter_missing_refs works for dirty cache entries");
 
-    ok (kvstxn_process (kt, rootref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
+    ok (kvstxn_process (kt, rootref, 0) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
         "kvstxn_process returns KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES");
 
     /* user forgot to call kvstxn_iter_dirty_cache_entries() test */
-    ok (kvstxn_process (kt, rootref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
+    ok (kvstxn_process (kt, rootref, 0) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
         "kvstxn_process returns KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES again");
 
     ok (kvstxn_iter_dirty_cache_entries (kt, cache_noop_cb, NULL) == 0,
         "kvstxn_iter_dirty_cache_entries works for dirty cache entries");
 
-    ok (kvstxn_process (kt, rootref) == KVSTXN_PROCESS_FINISHED,
+    ok (kvstxn_process (kt, rootref, 0) == KVSTXN_PROCESS_FINISHED,
         "kvstxn_process returns KVSTXN_PROCESS_FINISHED");
 
     ok ((newroot = kvstxn_get_newroot_ref (kt)) != NULL,
@@ -1483,11 +1483,11 @@ void kvstxn_process_missing_ref (void)
     ok ((kt = kvstxn_mgr_get_ready_transaction (ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns ready kvstxn");
 
-    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_LOAD_MISSING_REFS,
+    ok (kvstxn_process (kt, root_ref, 0) == KVSTXN_PROCESS_LOAD_MISSING_REFS,
         "kvstxn_process returns KVSTXN_PROCESS_LOAD_MISSING_REFS");
 
     /* user forgot to call kvstxn_iter_missing_refs() test */
-    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_LOAD_MISSING_REFS,
+    ok (kvstxn_process (kt, root_ref, 0) == KVSTXN_PROCESS_LOAD_MISSING_REFS,
         "kvstxn_process returns KVSTXN_PROCESS_LOAD_MISSING_REFS again");
 
     ok (kvstxn_iter_missing_refs (kt, missingref_count_cb, &count) == 0,
@@ -1503,17 +1503,17 @@ void kvstxn_process_missing_ref (void)
 
     (void)cache_insert (cache, entry);
 
-    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
+    ok (kvstxn_process (kt, root_ref, 0) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
         "kvstxn_process returns KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES");
 
     /* user forgot to call kvstxn_iter_dirty_cache_entries() test */
-    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
+    ok (kvstxn_process (kt, root_ref, 0) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
         "kvstxn_process returns KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES again");
 
     ok (kvstxn_iter_dirty_cache_entries (kt, cache_noop_cb, NULL) == 0,
         "kvstxn_iter_dirty_cache_entries works for dirty cache entries");
 
-    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_FINISHED,
+    ok (kvstxn_process (kt, root_ref, 0) == KVSTXN_PROCESS_FINISHED,
         "kvstxn_process returns KVSTXN_PROCESS_FINISHED");
 
     ok ((newroot = kvstxn_get_newroot_ref (kt)) != NULL,
@@ -1626,7 +1626,7 @@ void kvstxn_process_multiple_missing_ref (void)
     ok ((kt = kvstxn_mgr_get_ready_transaction (ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns ready kvstxn");
 
-    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_LOAD_MISSING_REFS,
+    ok (kvstxn_process (kt, root_ref, 0) == KVSTXN_PROCESS_LOAD_MISSING_REFS,
         "kvstxn_process returns KVSTXN_PROCESS_LOAD_MISSING_REFS");
 
     ok (kvstxn_iter_missing_refs (kt, missingref_count_cb, &count) == 0,
@@ -1652,13 +1652,13 @@ void kvstxn_process_multiple_missing_ref (void)
 
     (void)cache_insert (cache, entry);
 
-    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
+    ok (kvstxn_process (kt, root_ref, 0) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
         "kvstxn_process returns KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES");
 
     ok (kvstxn_iter_dirty_cache_entries (kt, cache_noop_cb, NULL) == 0,
         "kvstxn_iter_dirty_cache_entries works for dirty cache entries");
 
-    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_FINISHED,
+    ok (kvstxn_process (kt, root_ref, 0) == KVSTXN_PROCESS_FINISHED,
         "kvstxn_process returns KVSTXN_PROCESS_FINISHED");
 
     ok ((newroot = kvstxn_get_newroot_ref (kt)) != NULL,
@@ -1750,7 +1750,7 @@ void kvstxn_process_multiple_identical_missing_ref (void)
     ok ((kt = kvstxn_mgr_get_ready_transaction (ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns ready kvstxn");
 
-    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_LOAD_MISSING_REFS,
+    ok (kvstxn_process (kt, root_ref, 0) == KVSTXN_PROCESS_LOAD_MISSING_REFS,
         "kvstxn_process returns KVSTXN_PROCESS_LOAD_MISSING_REFS");
 
     ok (kvstxn_iter_missing_refs (kt, missingref_count_cb, &count) == 0,
@@ -1766,13 +1766,13 @@ void kvstxn_process_multiple_identical_missing_ref (void)
 
     (void)cache_insert (cache, entry);
 
-    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
+    ok (kvstxn_process (kt, root_ref, 0) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
         "kvstxn_process returns KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES");
 
     ok (kvstxn_iter_dirty_cache_entries (kt, cache_noop_cb, NULL) == 0,
         "kvstxn_iter_dirty_cache_entries works for dirty cache entries");
 
-    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_FINISHED,
+    ok (kvstxn_process (kt, root_ref, 0) == KVSTXN_PROCESS_FINISHED,
         "kvstxn_process returns KVSTXN_PROCESS_FINISHED");
 
     ok ((newroot = kvstxn_get_newroot_ref (kt)) != NULL,
@@ -1860,7 +1860,7 @@ void kvstxn_process_missing_ref_removed (void)
     ok ((kt = kvstxn_mgr_get_ready_transaction (ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns ready kvstxn");
 
-    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_LOAD_MISSING_REFS,
+    ok (kvstxn_process (kt, root_ref, 0) == KVSTXN_PROCESS_LOAD_MISSING_REFS,
         "kvstxn_process returns KVSTXN_PROCESS_LOAD_MISSING_REFS");
 
     ok (kvstxn_iter_missing_refs (kt, missingref_count_cb, &count) == 0,
@@ -1876,13 +1876,13 @@ void kvstxn_process_missing_ref_removed (void)
 
     (void)cache_insert (cache, entry);
 
-    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
+    ok (kvstxn_process (kt, root_ref, 0) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
         "kvstxn_process returns KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES");
 
     ok (kvstxn_iter_dirty_cache_entries (kt, cache_noop_cb, NULL) == 0,
         "kvstxn_iter_dirty_cache_entries works for dirty cache entries");
 
-    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_FINISHED,
+    ok (kvstxn_process (kt, root_ref, 0) == KVSTXN_PROCESS_FINISHED,
         "kvstxn_process returns KVSTXN_PROCESS_FINISHED");
 
     ok ((newroot = kvstxn_get_newroot_ref (kt)) != NULL,
@@ -1967,7 +1967,7 @@ void kvstxn_process_error_callbacks (void)
     ok ((kt = kvstxn_mgr_get_ready_transaction (ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns ready kvstxn");
 
-    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_LOAD_MISSING_REFS,
+    ok (kvstxn_process (kt, root_ref, 0) == KVSTXN_PROCESS_LOAD_MISSING_REFS,
         "kvstxn_process returns KVSTXN_PROCESS_LOAD_MISSING_REFS");
 
     errno = 0;
@@ -1979,7 +1979,7 @@ void kvstxn_process_error_callbacks (void)
      * kvstxn_process call */
     (void)cache_insert (cache, create_cache_entry_treeobj (dir_ref, dir));
 
-    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
+    ok (kvstxn_process (kt, root_ref, 0) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
         "kvstxn_process returns KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES");
 
     errno = 0;
@@ -2067,7 +2067,7 @@ void kvstxn_process_error_callbacks_partway (void)
     ok ((kt = kvstxn_mgr_get_ready_transaction (ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns ready kvstxn");
 
-    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
+    ok (kvstxn_process (kt, root_ref, 0) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
         "kvstxn_process returns KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES");
 
     errno = 0;
@@ -2117,11 +2117,11 @@ void kvstxn_process_invalid_operation (void)
     ok ((kt = kvstxn_mgr_get_ready_transaction (ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns ready kvstxn");
 
-    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_ERROR,
+    ok (kvstxn_process (kt, root_ref, 0) == KVSTXN_PROCESS_ERROR,
         "kvstxn_process returns KVSTXN_PROCESS_ERROR");
 
     /* error is caught continuously */
-    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_ERROR,
+    ok (kvstxn_process (kt, root_ref, 0) == KVSTXN_PROCESS_ERROR,
         "kvstxn_process returns KVSTXN_PROCESS_ERROR again");
 
     ok (kvstxn_get_errnum (kt) == EINVAL,
@@ -2171,7 +2171,7 @@ void kvstxn_process_malformed_operation (void)
      */
     ok ((kt = kvstxn_mgr_get_ready_transaction (ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns ready kvstxn");
-    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_ERROR
+    ok (kvstxn_process (kt, root_ref, 0) == KVSTXN_PROCESS_ERROR
         && kvstxn_get_errnum (kt) == EPROTO,
         "kvstxn_process encountered EPROTO error");
 
@@ -2212,11 +2212,11 @@ void kvstxn_process_invalid_hash (void)
     ok ((kt = kvstxn_mgr_get_ready_transaction (ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns ready kvstxn");
 
-    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_ERROR,
+    ok (kvstxn_process (kt, root_ref, 0) == KVSTXN_PROCESS_ERROR,
         "kvstxn_process returns KVSTXN_PROCESS_ERROR");
 
     /* verify kvstxn_process() does not continue processing */
-    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_ERROR,
+    ok (kvstxn_process (kt, root_ref, 0) == KVSTXN_PROCESS_ERROR,
         "kvstxn_process returns KVSTXN_PROCESS_ERROR on second call");
 
     ok (kvstxn_get_errnum (kt) == EINVAL,
@@ -2283,13 +2283,13 @@ void kvstxn_process_follow_link_no_namespace (void)
     ok ((kt = kvstxn_mgr_get_ready_transaction (ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns ready kvstxn");
 
-    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
+    ok (kvstxn_process (kt, root_ref, 0) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
         "kvstxn_process returns KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES");
 
     ok (kvstxn_iter_dirty_cache_entries (kt, cache_noop_cb, NULL) == 0,
         "kvstxn_iter_dirty_cache_entries works for dirty cache entries");
 
-    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_FINISHED,
+    ok (kvstxn_process (kt, root_ref, 0) == KVSTXN_PROCESS_FINISHED,
         "kvstxn_process returns KVSTXN_PROCESS_FINISHED");
 
     ok ((newroot = kvstxn_get_newroot_ref (kt)) != NULL,
@@ -2351,13 +2351,13 @@ void kvstxn_process_follow_link_namespace (void)
     ok ((kt = kvstxn_mgr_get_ready_transaction (ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns ready kvstxn");
 
-    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
+    ok (kvstxn_process (kt, root_ref, 0) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
         "kvstxn_process returns KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES");
 
     ok (kvstxn_iter_dirty_cache_entries (kt, cache_noop_cb, NULL) == 0,
         "kvstxn_iter_dirty_cache_entries works for dirty cache entries");
 
-    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_FINISHED,
+    ok (kvstxn_process (kt, root_ref, 0) == KVSTXN_PROCESS_FINISHED,
         "kvstxn_process returns KVSTXN_PROCESS_FINISHED");
 
     ok ((newroot = kvstxn_get_newroot_ref (kt)) != NULL,
@@ -2387,7 +2387,7 @@ void kvstxn_process_follow_link_namespace (void)
     ok ((kt = kvstxn_mgr_get_ready_transaction (ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns ready kvstxn");
 
-    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_ERROR,
+    ok (kvstxn_process (kt, root_ref, 0) == KVSTXN_PROCESS_ERROR,
         "kvstxn_process returns KVSTXN_PROCESS_ERROR");
 
     ok (kvstxn_get_errnum (kt) == EINVAL,
@@ -2445,13 +2445,13 @@ void kvstxn_process_dirval_test (void)
     ok ((kt = kvstxn_mgr_get_ready_transaction (ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns ready kvstxn");
 
-    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
+    ok (kvstxn_process (kt, root_ref, 0) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
         "kvstxn_process returns KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES");
 
     ok (kvstxn_iter_dirty_cache_entries (kt, cache_noop_cb, NULL) == 0,
         "kvstxn_iter_dirty_cache_entries works for dirty cache entries");
 
-    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_FINISHED,
+    ok (kvstxn_process (kt, root_ref, 0) == KVSTXN_PROCESS_FINISHED,
         "kvstxn_process returns KVSTXN_PROCESS_FINISHED");
 
     ok ((newroot = kvstxn_get_newroot_ref (kt)) != NULL,
@@ -2522,13 +2522,13 @@ void kvstxn_process_delete_test (void)
     ok ((kt = kvstxn_mgr_get_ready_transaction (ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns ready kvstxn");
 
-    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
+    ok (kvstxn_process (kt, root_ref, 0) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
         "kvstxn_process returns KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES");
 
     ok (kvstxn_iter_dirty_cache_entries (kt, cache_noop_cb, NULL) == 0,
         "kvstxn_iter_dirty_cache_entries works for dirty cache entries");
 
-    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_FINISHED,
+    ok (kvstxn_process (kt, root_ref, 0) == KVSTXN_PROCESS_FINISHED,
         "kvstxn_process returns KVSTXN_PROCESS_FINISHED");
 
     ok ((newroot = kvstxn_get_newroot_ref (kt)) != NULL,
@@ -2580,7 +2580,7 @@ void kvstxn_process_delete_nosubdir_test (void)
     ok ((kt = kvstxn_mgr_get_ready_transaction (ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns ready kvstxn");
 
-    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_FINISHED,
+    ok (kvstxn_process (kt, root_ref, 0) == KVSTXN_PROCESS_FINISHED,
         "kvstxn_process returns KVSTXN_PROCESS_FINISHED");
 
     ok ((newroot = kvstxn_get_newroot_ref (kt)) != NULL,
@@ -2651,7 +2651,7 @@ void kvstxn_process_delete_filevalinpath_test (void)
     ok ((kt = kvstxn_mgr_get_ready_transaction (ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns ready kvstxn");
 
-    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_FINISHED,
+    ok (kvstxn_process (kt, root_ref, 0) == KVSTXN_PROCESS_FINISHED,
         "kvstxn_process returns KVSTXN_PROCESS_FINISHED");
 
     ok ((newroot = kvstxn_get_newroot_ref (kt)) != NULL,
@@ -2722,11 +2722,11 @@ void kvstxn_process_bad_dirrefs (void)
     ok ((kt = kvstxn_mgr_get_ready_transaction (ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns ready kvstxn");
 
-    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_ERROR,
+    ok (kvstxn_process (kt, root_ref, 0) == KVSTXN_PROCESS_ERROR,
         "kvstxn_process returns KVSTXN_PROCESS_ERROR");
 
     /* error is caught continuously */
-    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_ERROR,
+    ok (kvstxn_process (kt, root_ref, 0) == KVSTXN_PROCESS_ERROR,
         "kvstxn_process returns KVSTXN_PROCESS_ERROR again");
 
     ok (kvstxn_get_errnum (kt) == ENOTRECOVERABLE,
@@ -2805,7 +2805,7 @@ void kvstxn_process_big_fileval (void)
     ok ((kt = kvstxn_mgr_get_ready_transaction (ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns ready kvstxn");
 
-    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
+    ok (kvstxn_process (kt, root_ref, 0) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
         "kvstxn_process returns KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES");
 
     cache_count.treeobj_count = 0;
@@ -2820,7 +2820,7 @@ void kvstxn_process_big_fileval (void)
     ok (cache_count.total_count == 1,
         "correct number of cache entries were dirty");
 
-    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_FINISHED,
+    ok (kvstxn_process (kt, root_ref, 0) == KVSTXN_PROCESS_FINISHED,
         "kvstxn_process returns KVSTXN_PROCESS_FINISHED");
 
     ok ((newroot = kvstxn_get_newroot_ref (kt)) != NULL,
@@ -2844,7 +2844,7 @@ void kvstxn_process_big_fileval (void)
     ok ((kt = kvstxn_mgr_get_ready_transaction (ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns ready kvstxn");
 
-    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
+    ok (kvstxn_process (kt, root_ref, 0) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
         "kvstxn_process returns KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES");
 
     cache_count.treeobj_count = 0;
@@ -2862,7 +2862,7 @@ void kvstxn_process_big_fileval (void)
     ok (cache_count.total_count == 2,
         "correct number of cache entries were dirty");
 
-    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_FINISHED,
+    ok (kvstxn_process (kt, root_ref, 0) == KVSTXN_PROCESS_FINISHED,
         "kvstxn_process returns KVSTXN_PROCESS_FINISHED");
 
     ok ((newroot = kvstxn_get_newroot_ref (kt)) != NULL,
@@ -2975,13 +2975,13 @@ void kvstxn_process_giant_dir (void)
     ok ((kt = kvstxn_mgr_get_ready_transaction (ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns ready kvstxn");
 
-    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
+    ok (kvstxn_process (kt, root_ref, 0) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
         "kvstxn_process returns KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES");
 
     ok (kvstxn_iter_dirty_cache_entries (kt, cache_noop_cb, NULL) == 0,
         "kvstxn_iter_dirty_cache_entries works for dirty cache entries");
 
-    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_FINISHED,
+    ok (kvstxn_process (kt, root_ref, 0) == KVSTXN_PROCESS_FINISHED,
         "kvstxn_process returns KVSTXN_PROCESS_FINISHED");
 
     ok ((newroot = kvstxn_get_newroot_ref (kt)) != NULL,
@@ -3058,7 +3058,7 @@ void kvstxn_process_append (void)
     ok ((kt = kvstxn_mgr_get_ready_transaction (ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns ready kvstxn");
 
-    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
+    ok (kvstxn_process (kt, root_ref, 0) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
         "kvstxn_process returns KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES");
 
     count = 0;
@@ -3070,7 +3070,7 @@ void kvstxn_process_append (void)
     ok (count == 3,
         "correct number of cache entries were dirty");
 
-    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_FINISHED,
+    ok (kvstxn_process (kt, root_ref, 0) == KVSTXN_PROCESS_FINISHED,
         "kvstxn_process returns KVSTXN_PROCESS_FINISHED");
 
     ok ((newroot = kvstxn_get_newroot_ref (kt)) != NULL,
@@ -3091,7 +3091,7 @@ void kvstxn_process_append (void)
     ok ((kt = kvstxn_mgr_get_ready_transaction (ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns ready kvstxn");
 
-    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
+    ok (kvstxn_process (kt, root_ref, 0) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
         "kvstxn_process returns KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES");
 
     count = 0;
@@ -3103,7 +3103,7 @@ void kvstxn_process_append (void)
     ok (count == 2,
         "correct number of cache entries were dirty");
 
-    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_FINISHED,
+    ok (kvstxn_process (kt, root_ref, 0) == KVSTXN_PROCESS_FINISHED,
         "kvstxn_process returns KVSTXN_PROCESS_FINISHED");
 
     ok ((newroot = kvstxn_get_newroot_ref (kt)) != NULL,
@@ -3124,7 +3124,7 @@ void kvstxn_process_append (void)
     ok ((kt = kvstxn_mgr_get_ready_transaction (ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns ready kvstxn");
 
-    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
+    ok (kvstxn_process (kt, root_ref, 0) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
         "kvstxn_process returns KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES");
 
     count = 0;
@@ -3135,7 +3135,7 @@ void kvstxn_process_append (void)
     ok (count == 1,
         "correct number of cache entries were dirty");
 
-    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_FINISHED,
+    ok (kvstxn_process (kt, root_ref, 0) == KVSTXN_PROCESS_FINISHED,
         "kvstxn_process returns KVSTXN_PROCESS_FINISHED");
 
     ok ((newroot = kvstxn_get_newroot_ref (kt)) != NULL,
@@ -3199,7 +3199,7 @@ void kvstxn_process_append_errors (void)
     ok ((kt = kvstxn_mgr_get_ready_transaction (ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns ready kvstxn");
 
-    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_ERROR,
+    ok (kvstxn_process (kt, root_ref, 0) == KVSTXN_PROCESS_ERROR,
         "kvstxn_process returns KVSTXN_PROCESS_ERROR");
 
     ok (kvstxn_get_errnum (kt) == EISDIR,
@@ -3216,7 +3216,7 @@ void kvstxn_process_append_errors (void)
     ok ((kt = kvstxn_mgr_get_ready_transaction (ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns ready kvstxn");
 
-    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_ERROR,
+    ok (kvstxn_process (kt, root_ref, 0) == KVSTXN_PROCESS_ERROR,
         "kvstxn_process returns KVSTXN_PROCESS_ERROR");
 
     ok (kvstxn_get_errnum (kt) == EOPNOTSUPP,
@@ -3233,7 +3233,7 @@ void kvstxn_process_append_errors (void)
     ok ((kt = kvstxn_mgr_get_ready_transaction (ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns ready kvstxn");
 
-    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_ERROR,
+    ok (kvstxn_process (kt, root_ref, 0) == KVSTXN_PROCESS_ERROR,
         "kvstxn_process returns KVSTXN_PROCESS_ERROR");
 
     ok (kvstxn_get_errnum (kt) == EOPNOTSUPP,
@@ -3322,7 +3322,7 @@ void kvstxn_process_append_no_duplicate (void)
     ok ((kt = kvstxn_mgr_get_ready_transaction (ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns ready kvstxn");
 
-    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_LOAD_MISSING_REFS,
+    ok (kvstxn_process (kt, root_ref, 0) == KVSTXN_PROCESS_LOAD_MISSING_REFS,
         "kvstxn_process returns KVSTXN_PROCESS_LOAD_MISSING_REFS");
 
     ok (kvstxn_iter_missing_refs (kt, missingref_count_cb, &count) == 0,
@@ -3338,7 +3338,7 @@ void kvstxn_process_append_no_duplicate (void)
 
     (void)cache_insert (cache, entry);
 
-    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
+    ok (kvstxn_process (kt, root_ref, 0) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
         "kvstxn_process returns KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES");
 
     count = 0;
@@ -3351,7 +3351,7 @@ void kvstxn_process_append_no_duplicate (void)
     ok (count == 4,
         "correct number of cache entries were dirty");
 
-    ok (kvstxn_process (kt, root_ref) == KVSTXN_PROCESS_FINISHED,
+    ok (kvstxn_process (kt, root_ref, 0) == KVSTXN_PROCESS_FINISHED,
         "kvstxn_process returns KVSTXN_PROCESS_FINISHED");
 
     ok ((newroot = kvstxn_get_newroot_ref (kt)) != NULL,
@@ -3416,7 +3416,7 @@ void kvstxn_process_fallback_merge (void)
     ok (kvstxn_fallback_mergeable (kt) == true,
         "kvstxn_fallback_mergeable returns true on merged transaction");
 
-    ok (kvstxn_process (kt, rootref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
+    ok (kvstxn_process (kt, rootref, 0) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
         "kvstxn_process returns KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES");
 
     ok (kvstxn_iter_dirty_cache_entries (kt, cache_count_dirty_cb, &count) == 0,
@@ -3425,7 +3425,7 @@ void kvstxn_process_fallback_merge (void)
     ok (count == 1,
         "correct number of cache entries were dirty");
 
-    ok (kvstxn_process (kt, rootref) == KVSTXN_PROCESS_FINISHED,
+    ok (kvstxn_process (kt, rootref, 0) == KVSTXN_PROCESS_FINISHED,
         "kvstxn_process returns KVSTXN_PROCESS_FINISHED");
 
     ok ((newroot = kvstxn_get_newroot_ref (kt)) != NULL,
@@ -3456,7 +3456,7 @@ void kvstxn_process_fallback_merge (void)
     ok ((kt = kvstxn_mgr_get_ready_transaction (ktm)) != NULL,
         "kvstxn_mgr_get_ready_transaction returns ready transaction");
 
-    ok (kvstxn_process (kt, rootref) == KVSTXN_PROCESS_ERROR,
+    ok (kvstxn_process (kt, rootref, 0) == KVSTXN_PROCESS_ERROR,
         "kvstxn_process returns KVSTXN_PROCESS_ERROR");
 
     ok (kvstxn_get_errnum (kt) == EINVAL,
@@ -3479,7 +3479,7 @@ void kvstxn_process_fallback_merge (void)
     ok (kvstxn_fallback_mergeable (kt) == false,
         "kvstxn_fallback_mergeable returns false on unmerged transaction");
 
-    ok (kvstxn_process (kt, rootref) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
+    ok (kvstxn_process (kt, rootref, 0) == KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES,
         "kvstxn_process returns KVSTXN_PROCESS_DIRTY_CACHE_ENTRIES");
 
     count = 0;
@@ -3489,7 +3489,7 @@ void kvstxn_process_fallback_merge (void)
     ok (count == 1,
         "correct number of cache entries were dirty");
 
-    ok (kvstxn_process (kt, rootref) == KVSTXN_PROCESS_FINISHED,
+    ok (kvstxn_process (kt, rootref, 0) == KVSTXN_PROCESS_FINISHED,
         "kvstxn_process returns KVSTXN_PROCESS_FINISHED");
 
     ok ((newroot = kvstxn_get_newroot_ref (kt)) != NULL,
@@ -3511,7 +3511,7 @@ void kvstxn_process_fallback_merge (void)
     ok (kvstxn_fallback_mergeable (kt) == false,
         "kvstxn_fallback_mergeable returns false on unmerged transaction");
 
-    ok (kvstxn_process (kt, rootref) == KVSTXN_PROCESS_ERROR,
+    ok (kvstxn_process (kt, rootref, 0) == KVSTXN_PROCESS_ERROR,
         "kvstxn_process returns KVSTXN_PROCESS_ERROR");
 
     ok (kvstxn_get_errnum (kt) == EINVAL,

--- a/t/t2010-kvs-snapshot-restore.t
+++ b/t/t2010-kvs-snapshot-restore.t
@@ -51,7 +51,7 @@ test_expect_success 're-run instance, get rootref (sqlite)' '
 	           flux kvs getroot -b > getrootsqlite.out
 '
 
-test_expect_success 'write rootref to checkpoint path, emulating original checkpoint (sqlite)' '
+test_expect_success 'write rootref to checkpoint path, emulating checkpoint version=0 (sqlite)' '
         rootref=$(cat getrootsqlite.out) &&
         ${CHANGECHECKPOINT} $(pwd)/content.sqlite "kvs-primary" ${rootref}
 '

--- a/t/t2010-kvs-snapshot-restore.t
+++ b/t/t2010-kvs-snapshot-restore.t
@@ -17,7 +17,7 @@ CHANGECHECKPOINT=${FLUX_SOURCE_DIR}/t/kvs/change-checkpoint.py
 
 test_expect_success 'run instance with statedir set (sqlite)' '
 	flux start -o,--setattr=statedir=$(pwd) \
-	           flux kvs put testkey=42
+		   flux kvs put --sequence testkey=42 > start_sequence.out
 '
 
 test_expect_success 'content.sqlite file exists after instance exited' '
@@ -33,6 +33,32 @@ test_expect_success 're-run instance with statedir set (sqlite)' '
 test_expect_success 'content from previous instance survived (sqlite)' '
 	echo 42 >getsqlite.exp &&
 	test_cmp getsqlite.exp getsqlite.out
+'
+
+# due to other KVS activity that testing can't control, we simply want
+# to ensure the sequence number does not restart at 0, it must
+# increase over several restarts
+
+test_expect_success 're-run instance, get sequence number 1 (sqlite)' '
+	flux start -o,--setattr=statedir=$(pwd) \
+	           flux kvs version > restart_version1.out
+'
+
+test_expect_success 'restart sequence number increasing 1 (sqlite)' '
+	seq1=$(cat start_sequence.out) &&
+	seq2=$(cat restart_version1.out) &&
+	test $seq1 -lt $seq2
+'
+
+test_expect_success 're-run instance, get sequence number 2 (sqlite)' '
+	flux start -o,--setattr=statedir=$(pwd) \
+	           flux kvs version > restart_version2.out
+'
+
+test_expect_success 'restart sequence number increasing 2 (sqlite)' '
+	seq1=$(cat restart_version1.out) &&
+	seq2=$(cat restart_version2.out) &&
+	test $seq1 -lt $seq2
 '
 
 test_expect_success 're-run instance, verify checkpoint date saved (sqlite)' '


### PR DESCRIPTION
Problem: The KVS root sequence number isn't persisted across
restarts.  It restarts at zero everytime the KVS module is loaded.

Solution: Add the root sequence number to the checkpoint object, read
it in and initialize the KVS primary namespace to that sequence
number.

Fixes #4446 