### PR TITLE
libkvs: Support KVS_CHECKPOINT_FLAG_CACHE_BYPASS flag

### DIFF
--- a/src/broker/content-cache.c
+++ b/src/broker/content-cache.c
@@ -617,13 +617,13 @@ static void checkpoint_get_continuation (flux_future_t *f, void *arg)
         goto error;
 
     if (flux_respond (cache->h, msg, s) < 0)
-        flux_log_error (cache->h, "%s: flux_respond", __FUNCTION__);
+        flux_log_error (cache->h, "error responding to checkpoint-get");
     flux_future_destroy (f);
     return;
 
 error:
     if (flux_respond_error (cache->h, msg, errno, NULL) < 0)
-        flux_log_error (cache->h, "flux_respond_error");
+        flux_log_error (cache->h, "error responding to checkpoint-get");
     flux_future_destroy (f);
 }
 
@@ -676,13 +676,13 @@ static void checkpoint_put_continuation (flux_future_t *f, void *arg)
         goto error;
 
     if (flux_respond (cache->h, msg, s) < 0)
-        flux_log_error (cache->h, "%s: flux_respond", __FUNCTION__);
+        flux_log_error (cache->h, "error responding to checkpoint-put");
     flux_future_destroy (f);
     return;
 
 error:
     if (flux_respond_error (cache->h, msg, errno, NULL) < 0)
-        flux_log_error (cache->h, "flux_respond_error");
+        flux_log_error (cache->h, "error responding to checkpoint-put");
     flux_future_destroy (f);
 }
 

--- a/src/cmd/builtin/dump.c
+++ b/src/cmd/builtin/dump.c
@@ -371,7 +371,7 @@ static int cmd_dump (optparse_t *p, int ac, char *av[])
         const char *blobref;
         double timestamp;
 
-        if (!(f = kvs_checkpoint_lookup (h, NULL))
+        if (!(f = kvs_checkpoint_lookup (h, NULL, 0))
             || kvs_checkpoint_lookup_get_rootref (f, &blobref) < 0
             || kvs_checkpoint_lookup_get_timestamp (f, &timestamp) < 0)
             log_msg_exit ("error fetching checkpoint: %s",

--- a/src/cmd/builtin/dump.c
+++ b/src/cmd/builtin/dump.c
@@ -345,6 +345,7 @@ static int cmd_dump (optparse_t *p, int ac, char *av[])
     flux_t *h;
     struct archive *ar;
     const char *outfile;
+    int kvs_checkpoint_flags = 0;
 
     log_init ("flux-dump");
 
@@ -357,8 +358,10 @@ static int cmd_dump (optparse_t *p, int ac, char *av[])
         verbose = true;
     if (optparse_hasopt (p, "quiet"))
         quiet = true;
-    if (optparse_hasopt (p, "no-cache"))
+    if (optparse_hasopt (p, "no-cache")) {
         content_flags |= CONTENT_FLAG_CACHE_BYPASS;
+        kvs_checkpoint_flags |= KVS_CHECKPOINT_FLAG_CACHE_BYPASS;
+    }
 
     dump_time = time (NULL);
     dump_uid = getuid ();
@@ -371,7 +374,7 @@ static int cmd_dump (optparse_t *p, int ac, char *av[])
         const char *blobref;
         double timestamp;
 
-        if (!(f = kvs_checkpoint_lookup (h, NULL, 0))
+        if (!(f = kvs_checkpoint_lookup (h, NULL, kvs_checkpoint_flags))
             || kvs_checkpoint_lookup_get_rootref (f, &blobref) < 0
             || kvs_checkpoint_lookup_get_timestamp (f, &timestamp) < 0)
             log_msg_exit ("error fetching checkpoint: %s",

--- a/src/cmd/builtin/restore.c
+++ b/src/cmd/builtin/restore.c
@@ -372,7 +372,12 @@ static int cmd_restore (optparse_t *p, int ac, char *av[])
                      blobref);
         }
         /* restoring, therefore we restart sequence number at 0 */
-        if (!(f = kvs_checkpoint_commit (h, NULL, blobref, 0, restore_timestamp))
+        if (!(f = kvs_checkpoint_commit (h,
+                                         NULL,
+                                         blobref,
+                                         0,
+                                         restore_timestamp,
+                                         0))
             || flux_rpc_get (f, NULL) < 0) {
             log_msg_exit ("error updating checkpoint: %s",
                           future_strerror (f, errno));

--- a/src/cmd/builtin/restore.c
+++ b/src/cmd/builtin/restore.c
@@ -336,6 +336,7 @@ static int cmd_restore (optparse_t *p, int ac, char *av[])
     flux_t *h;
     struct archive *ar;
     const char *infile;
+    int kvs_checkpoint_flags = 0;
 
     log_init ("flux-restore");
 
@@ -348,8 +349,10 @@ static int cmd_restore (optparse_t *p, int ac, char *av[])
         verbose = true;
     if (optparse_hasopt (p, "quiet"))
         quiet = true;
-    if (optparse_hasopt (p, "no-cache"))
+    if (optparse_hasopt (p, "no-cache")) {
         content_flags |= CONTENT_FLAG_CACHE_BYPASS;
+        kvs_checkpoint_flags |= KVS_CHECKPOINT_FLAG_CACHE_BYPASS;
+    }
 
     h = builtin_get_flux_handle (p);
     ar = restore_create (infile);
@@ -377,7 +380,7 @@ static int cmd_restore (optparse_t *p, int ac, char *av[])
                                          blobref,
                                          0,
                                          restore_timestamp,
-                                         0))
+                                         kvs_checkpoint_flags))
             || flux_rpc_get (f, NULL) < 0) {
             log_msg_exit ("error updating checkpoint: %s",
                           future_strerror (f, errno));

--- a/src/common/libkvs/kvs_checkpoint.c
+++ b/src/common/libkvs/kvs_checkpoint.c
@@ -24,11 +24,13 @@ flux_future_t *kvs_checkpoint_commit (flux_t *h,
                                       const char *key,
                                       const char *rootref,
                                       int sequence,
-                                      double timestamp)
+                                      double timestamp,
+                                      int flags)
 {
     flux_future_t *f = NULL;
 
-    if (!h || !rootref || sequence < 0) {
+    /* no flags supported at the moment */
+    if (!h || !rootref || flags) {
         errno = EINVAL;
         return NULL;
     }
@@ -54,9 +56,10 @@ flux_future_t *kvs_checkpoint_commit (flux_t *h,
     return f;
 }
 
-flux_future_t *kvs_checkpoint_lookup (flux_t *h, const char *key)
+flux_future_t *kvs_checkpoint_lookup (flux_t *h, const char *key, int flags)
 {
-    if (!h) {
+    /* no flags supported at the moment */
+    if (!h || flags) {
         errno = EINVAL;
         return NULL;
     }

--- a/src/common/libkvs/kvs_checkpoint.h
+++ b/src/common/libkvs/kvs_checkpoint.h
@@ -27,9 +27,10 @@ flux_future_t *kvs_checkpoint_commit (flux_t *h,
                                       const char *key,
                                       const char *rootref,
                                       int sequence,
-                                      double timestamp);
+                                      double timestamp,
+                                      int flags);
 
-flux_future_t *kvs_checkpoint_lookup (flux_t *h, const char *key);
+flux_future_t *kvs_checkpoint_lookup (flux_t *h, const char *key, int flags);
 
 int kvs_checkpoint_lookup_get_rootref (flux_future_t *f, const char **rootref);
 

--- a/src/common/libkvs/kvs_checkpoint.h
+++ b/src/common/libkvs/kvs_checkpoint.h
@@ -13,6 +13,11 @@
 
 #include <flux/core.h>
 
+/* flags */
+enum {
+    KVS_CHECKPOINT_FLAG_CACHE_BYPASS = 1,/* request direct to backing store */
+};
+
 #define KVS_DEFAULT_CHECKPOINT "kvs-primary"
 
 /* Calls to kvs_checkpoint_commit() can be racy when the KVS module is

--- a/src/common/libkvs/test/kvs_checkpoint.c
+++ b/src/common/libkvs/test/kvs_checkpoint.c
@@ -26,12 +26,12 @@ void errors (void)
     const char *rootref;
 
     errno = 0;
-    ok (kvs_checkpoint_commit (NULL, NULL, NULL, 0, 0) == NULL
+    ok (kvs_checkpoint_commit (NULL, NULL, NULL, 0, 0, -1) == NULL
         && errno == EINVAL,
         "kvs_checkpoint_commit fails on bad input");
 
     errno = 0;
-    ok (kvs_checkpoint_lookup (NULL, NULL) == NULL
+    ok (kvs_checkpoint_lookup (NULL, NULL, -1) == NULL
         && errno == EINVAL,
         "kvs_checkpoint_lookup fails on bad input");
 

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -2828,7 +2828,7 @@ static int checkpoint_get (flux_t *h, char *buf, size_t len, int *seq)
     char datestr[128] = "N/A";
     int rv = -1;
 
-    if (!(f = kvs_checkpoint_lookup (h, NULL)))
+    if (!(f = kvs_checkpoint_lookup (h, NULL, 0)))
         return -1;
 
     if (kvs_checkpoint_lookup_get_rootref (f, &rootref) < 0)
@@ -2863,7 +2863,7 @@ static int checkpoint_put (flux_t *h, const char *rootref, int rootseq)
     flux_future_t *f = NULL;
     int rv = -1;
 
-    if (!(f = kvs_checkpoint_commit (h, NULL, rootref, rootseq, 0))
+    if (!(f = kvs_checkpoint_commit (h, NULL, rootref, rootseq, 0, 0))
         || flux_rpc_get (f, NULL) < 0)
         goto error;
     rv = 0;

--- a/src/modules/kvs/kvstxn.c
+++ b/src/modules/kvs/kvstxn.c
@@ -1103,6 +1103,7 @@ kvstxn_process_t kvstxn_process (kvstxn_t *kt,
                                                                NULL,
                                                                kt->newroot,
                                                                newseq,
+                                                               0,
                                                                0);
                 if (!kt->f_sync_checkpoint) {
                     kt->errnum = errno;


### PR DESCRIPTION
Problem: The kvs_checkpoint functions checkpoint data to the backing
store through the broker's content-cache.  There is no way to
bypass the cache, similar to libcontent's CONTENT_FLAG_CACHE_BYPASS
flag.

Solution: Support a new KVS_CHECKPOINT_FLAG_CACHE_BYPASS, that will
get/put directly to the backing store.  The flag is very similar to
libcontent's CONTENT_FLAG_CACHE_BYPASS flag.

Fixes https://github.com/flux-framework/flux-core/issues/4476