### PR TITLE
top: fix detailed report in summary pane

### DIFF
--- a/src/cmd/top/summary_pane.c
+++ b/src/cmd/top/summary_pane.c
@@ -137,9 +137,7 @@ static void draw_stats (struct summary_pane *sum)
                sum->stats.run + sum->stats.cleanup);
 
     if (sum->show_details) {
-        int failed = sum->stats.failed +
-                     sum->stats.canceled +
-                     sum->stats.timeout;
+        int failed = sum->stats.failed;
         int complete = sum->stats.inactive - failed;
 
         if (complete)


### PR DESCRIPTION
Problem: The summary pane detailed breakdown of failed vs complete
jobs computes the failed job count as the sum of failed + cancelled +
timeout jobs, but the failed count reported by the job-list module
already includes timeout and cancelled jobs.

Fix the reporting of the failed job count in flux-top.

Fixes #4478