### PR TITLE
broker: fix content-cache flush list corruption

### DIFF
--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -307,6 +307,7 @@ dist_check_SCRIPTS = \
 	issues/t4379-dirty-cache-entries-flush.sh \
 	issues/t4413-empty-eventlog.sh \
 	issues/t4465-job-list-use-after-free.sh \
+	issues/t4482-flush-list-corruption.sh \
 	python/__init__.py \
 	python/subflux.py \
 	python/tap \

--- a/t/issues/t4482-flush-list-corruption.sh
+++ b/t/issues/t4482-flush-list-corruption.sh
@@ -1,0 +1,40 @@
+#!/bin/sh -e
+
+# How this test works
+#
+# add some unique data to the content cache, we do several stores to
+# build up a decent length internal list of flushable cache entries.
+#
+# write some of the same data again, if error present internal flush
+# list will be messed up and length of flush list < number of dirty
+# entries (acct_dirty).
+#
+# before fix, flux content flush will hang b/c number of dirty entries
+# (acct_dirty) never reaches zero.
+
+cat <<-EOF >t4482.sh
+#!/bin/sh -e
+
+echo "abcde" | flux content store
+echo "fghij" | flux content store
+echo "klmno" | flux content store
+echo "pqrst" | flux content store
+echo "tuvwx" | flux content store
+
+echo "fghij" | flux content store
+echo "klmno" | flux content store
+
+flux module load content-sqlite
+
+flux content flush
+
+flux module remove content-sqlite
+
+EOF
+
+chmod +x t4482.sh
+
+flux start -s 1 \
+    -o,--setattr=broker.rc1_path= \
+    -o,--setattr=broker.rc3_path= \
+    ./t4482.sh


### PR DESCRIPTION
Problem: A dirty cache entry has to potential to be added onto the flush list twice.  This double addition can lead to list corruption.
The observed side effect was a list that was shortened and no longer accurate with respects to the `acct_dirty` counter.  This could lead to hangs with content flush, missed flushes to the backing store, and segfault/memory corruption in the worst case.

Solution: Check if the cache entry is already on the flush list before adding it.

Fixes https://github.com/flux-framework/flux-core/issues/4482