### PR TITLE
docker: typo in path to Dockerfile

### DIFF
--- a/.github/workflows/build-container.yaml
+++ b/.github/workflows/build-container.yaml
@@ -28,7 +28,7 @@ jobs:
       matrix:
 
         # Dockerfiles to build, a matrix supports future expanded builds
-        container: [["config/docker/Dockerfile.base", "ghcr.io/flux-framework/flux-core-base"]]
+        container: [["etc/docker/Dockerfile.base", "ghcr.io/flux-framework/flux-core-base"]]
                     # This will be enabled after the first container builds.
                     #["config/docker/Dockerfile", "ghcr.io/flux-framework/flux-core-ubuntu"]]
 


### PR DESCRIPTION
There is a typo in the path to the Dockerfile we missed.

Signed-off-by: vsoch <vsoch@users.noreply.github.com>