### PR TITLE
etc: support content.backing-module=none

### DIFF
--- a/etc/rc1
+++ b/etc/rc1
@@ -11,11 +11,15 @@ modload() {
     fi
 }
 
+backing_module() {
+    local backingmod=$(flux getattr content.backing-module 2>/dev/null) || :
+    echo ${backingmod:-content-sqlite}
+}
+
 modload all barrier
 
 if test $RANK -eq 0; then
-    backingmod=$(flux getattr content.backing-module 2>/dev/null) || :
-    backingmod=${backingmod:-content-sqlite}
+    backingmod=$(backing_module)
     dumpfile=$(flux getattr content.restore 2>/dev/null) || :
     if test -n "${dumpfile}"; then
         if test "${dumpfile}" = "auto"; then
@@ -30,13 +34,15 @@ if test $RANK -eq 0; then
         fi
     fi
     if test -n "${dumpfile}"; then
-        flux module load ${backingmod} truncate
+        if test "${backingmod}" != "none"; then
+            flux module load ${backingmod} truncate
+        fi
         echo "restoring content from ${dumpfile}"
         flux restore --quiet --checkpoint ${dumpfile}
         if test -n "${dumplink}"; then
             rm -f ${dumplink}
         fi
-    else
+    elif test "${backingmod}" != "none"; then
         flux module load ${backingmod}
     fi
 fi
@@ -45,7 +51,9 @@ modload all kvs
 modload all kvs-watch
 
 if test $RANK -eq 0; then
-    flux startlog --post-start-event
+    if test "$(backing_module)" != "none"; then
+        flux startlog --post-start-event
+    fi
 fi
 
 modload all resource
@@ -58,9 +66,13 @@ if test $RANK -eq 0 -a -n "${period}"; then
     flux module load job-archive
 fi
 
-if test $RANK -eq 0 && ! flux startlog --check --quiet; then
-    flux queue stop
-    flux queue disable "Flux is in safe mode due to an incomplete shutdown."
+if test $RANK -eq 0; then
+    if test "$(backing_module)" != "none"; then
+        if ! flux startlog --check --quiet; then
+            flux queue stop
+            flux queue disable "Flux is in safe mode due to an incomplete shutdown."
+        fi
+    fi
 fi
 
 modload all job-ingest

--- a/etc/rc3
+++ b/etc/rc3
@@ -11,6 +11,11 @@ modrm() {
     fi
 }
 
+backing_module() {
+    local backingmod=$(flux getattr content.backing-module 2>/dev/null) || :
+    echo ${backingmod:-content-sqlite}
+}
+
 core_dir=$(cd ${0%/*} && pwd -P)
 all_dirs=$core_dir${FLUX_RC_EXTRA:+":$FLUX_RC_EXTRA"}
 IFS=:
@@ -37,17 +42,20 @@ modrm 0 cron
 modrm all barrier
 
 if test $RANK -eq 0; then
-    flux startlog --post-finish-event || exit_rc=1
+    if test "$(backing_module)" != "none"; then
+        flux startlog --post-finish-event || exit_rc=1
+    fi
 fi
 
 modrm all kvs-watch
 modrm all kvs
 
-flux content flush || exit_rc=1
+if test "$(backing_module)" != "none"; then
+    flux content flush || exit_rc=1
+fi
 
 if test $RANK -eq 0; then
-    backingmod=$(flux getattr content.backing-module 2>/dev/null)
-    backingmod=${backingmod:-content-sqlite}
+    backingmod=$(backing_module)
     dumpfile=$(flux getattr content.dump 2>/dev/null)
     if test $exit_rc -eq 0 -a -n "${dumpfile}"; then
         if test "${dumpfile}" = "auto"; then
@@ -63,7 +71,9 @@ if test $RANK -eq 0; then
             exit_rc=1
         fi
     fi
-    flux module remove ${backingmod} || exit_rc=1
+    if test "${backingmod}" != "none"; then
+        flux module remove ${backingmod} || exit_rc=1
+    fi
 fi
 
 exit $exit_rc

--- a/src/broker/content-cache.c
+++ b/src/broker/content-cache.c
@@ -692,6 +692,7 @@ static void content_register_backing_request (flux_t *h,
     if (flux_respond (h, msg, NULL) < 0)
         flux_log_error (h, "error responding to register-backing request");
     (void)cache_flush (cache);
+    (void)checkpoints_flush (cache->checkpoint);
     return;
 error:
     if (flux_respond_error (h, msg, errno, errstr) < 0)

--- a/src/broker/content-checkpoint.c
+++ b/src/broker/content-checkpoint.c
@@ -15,6 +15,7 @@
 #endif
 #include <inttypes.h>
 #include <assert.h>
+#include <jansson.h>
 #include <flux/core.h>
 
 #include "src/common/libczmqcontainers/czmq_containers.h"
@@ -27,21 +28,95 @@ struct content_checkpoint {
     flux_msg_handler_t **handlers;
     uint32_t rank;
     struct content_cache *cache;
+    zhashx_t *hash;
+    unsigned int hash_dirty;
 };
+
+struct checkpoint_data {
+    struct content_checkpoint *checkpoint;
+    json_t *value;
+    uint8_t dirty:1;
+    bool in_progress;
+    int refcount;
+};
+
+static struct checkpoint_data *
+checkpoint_data_incref (struct checkpoint_data *data)
+{
+    if (data)
+        data->refcount++;
+    return data;
+}
+
+static void checkpoint_data_decref (struct checkpoint_data *data)
+{
+    if (data && --data->refcount == 0) {
+        if (data->dirty)
+            data->checkpoint->hash_dirty--;
+        json_decref (data->value);
+        free (data);
+    }
+}
+
+/* zhashx_destructor_fn */
+static void checkpoint_data_decref_wrapper (void **arg)
+{
+    if (arg) {
+        struct checkpoint_data *data = *arg;
+        checkpoint_data_decref (data);
+    }
+}
+
+static struct checkpoint_data *
+checkpoint_data_create (struct content_checkpoint *checkpoint,
+                        json_t *value)
+{
+    struct checkpoint_data *data = NULL;
+
+    if (!(data = calloc (1, sizeof (*data))))
+        return NULL;
+    data->checkpoint = checkpoint;
+    data->value = json_incref (value);
+    data->refcount = 1;
+    return data;
+}
+
+static int checkpoint_data_update (struct content_checkpoint *checkpoint,
+                                   const char *key,
+                                   json_t *value)
+{
+    struct checkpoint_data *data = NULL;
+
+    if (!(data = checkpoint_data_create (checkpoint, value)))
+        return -1;
+
+    zhashx_update (checkpoint->hash, key, data);
+    data->dirty = 1;
+    checkpoint->hash_dirty++;
+    return 0;
+}
 
 static void checkpoint_get_continuation (flux_future_t *f, void *arg)
 {
     struct content_checkpoint *checkpoint = arg;
     const flux_msg_t *msg = flux_future_aux_get (f, "msg");
-    const char *s;
+    const char *key;
+    json_t *value = NULL;
 
     assert (msg);
 
-    if (flux_rpc_get (f, &s) < 0)
+    if (flux_request_unpack (msg, NULL, "{s:s}", "key", &key) < 0)
         goto error;
 
-    if (flux_respond (checkpoint->h, msg, s) < 0)
+    if (flux_rpc_get_unpack (f, "{s:o}", "value", &value) < 0)
+        goto error;
+
+    if (checkpoint_data_update (checkpoint, key, value) < 0)
+        goto error;
+
+    if (flux_respond_pack (checkpoint->h, msg, "{s:O}", "value", value) < 0)
         flux_log_error (checkpoint->h, "error responding to checkpoint-get");
+
     flux_future_destroy (f);
     return;
 
@@ -53,7 +128,7 @@ error:
 
 static int checkpoint_get_forward (struct content_checkpoint *checkpoint,
                                    const flux_msg_t *msg,
-                                   const char *s,
+                                   const char *key,
                                    const char **errstr)
 {
     const char *topic = "content.checkpoint-get";
@@ -66,7 +141,12 @@ static int checkpoint_get_forward (struct content_checkpoint *checkpoint,
         rank = 0;
     }
 
-    if (!(f = flux_rpc (checkpoint->h, topic, s, rank, 0))
+    if (!(f = flux_rpc_pack (checkpoint->h,
+                             topic,
+                             rank,
+                             0,
+                             "{s:s}",
+                             "key", key))
         || flux_future_then (f,
                              -1,
                              checkpoint_get_continuation,
@@ -93,20 +173,31 @@ void content_checkpoint_get_request (flux_t *h, flux_msg_handler_t *mh,
                                      const flux_msg_t *msg, void *arg)
 {
     struct content_checkpoint *checkpoint = arg;
-    const char *s = NULL;
+    const char *key;
     const char *errstr = NULL;
 
-    if (checkpoint->rank == 0) {
-        if (!content_cache_backing_loaded (checkpoint->cache)) {
-            errno = ENOSYS;
-            goto error;
-        }
-    }
-
-    if (flux_request_decode (msg, NULL, &s) < 0)
+    if (flux_request_unpack (msg, NULL, "{s:s}", "key", &key) < 0)
         goto error;
 
-    if (checkpoint_get_forward (checkpoint, msg, s, &errstr) < 0)
+    if (checkpoint->rank == 0
+        && !content_cache_backing_loaded (checkpoint->cache)) {
+        struct checkpoint_data *data = zhashx_lookup (checkpoint->hash, key);
+        if (!data) {
+            errstr = "checkpoint key unavailable";
+            errno = ENOENT;
+            goto error;
+        }
+        if (flux_respond_pack (h, msg,
+                               "{s:O}",
+                               "value", data->value) < 0)
+            flux_log_error (h, "error responding to checkpoint-get");
+        return;
+    }
+
+    if (checkpoint_get_forward (checkpoint,
+                                msg,
+                                key,
+                                &errstr) < 0)
         goto error;
 
     return;
@@ -140,7 +231,8 @@ error:
 
 static int checkpoint_put_forward (struct content_checkpoint *checkpoint,
                                    const flux_msg_t *msg,
-                                   const char *s,
+                                   const char *key,
+                                   json_t *value,
                                    const char **errstr)
 {
     const char *topic = "content.checkpoint-put";
@@ -153,7 +245,10 @@ static int checkpoint_put_forward (struct content_checkpoint *checkpoint,
         rank = 0;
     }
 
-    if (!(f = flux_rpc (checkpoint->h, topic, s, rank, 0))
+    if (!(f = flux_rpc_pack (checkpoint->h, topic, rank, 0,
+                             "{s:s s:O}",
+                             "key", key,
+                             "value", value))
         || flux_future_then (f,
                              -1,
                              checkpoint_put_continuation,
@@ -180,20 +275,35 @@ void content_checkpoint_put_request (flux_t *h, flux_msg_handler_t *mh,
                                      const flux_msg_t *msg, void *arg)
 {
     struct content_checkpoint *checkpoint = arg;
-    const char *s = NULL;
+    const char *key;
+    json_t *value;
     const char *errstr = NULL;
 
+    if (flux_request_unpack (msg,
+                             NULL,
+                             "{s:s s:o}",
+                             "key",
+                             &key,
+                             "value",
+                             &value) < 0)
+        goto error;
+
     if (checkpoint->rank == 0) {
-        if (!content_cache_backing_loaded (checkpoint->cache)) {
-            errno = ENOSYS;
+        if (checkpoint_data_update (checkpoint, key, value) < 0)
             goto error;
+
+        if (!content_cache_backing_loaded (checkpoint->cache)) {
+            if (flux_respond (h, msg, NULL) < 0)
+                flux_log_error (checkpoint->h, "error responding to checkpoint-put");
+            return;
         }
     }
 
-    if (flux_request_decode (msg, NULL, &s) < 0)
-        goto error;
-
-    if (checkpoint_put_forward (checkpoint, msg, s, &errstr) < 0)
+    if (checkpoint_put_forward (checkpoint,
+                                msg,
+                                key,
+                                value,
+                                &errstr) < 0)
         goto error;
 
     return;
@@ -201,6 +311,72 @@ void content_checkpoint_put_request (flux_t *h, flux_msg_handler_t *mh,
 error:
     if (flux_respond_error (h, msg, errno, errstr) < 0)
         flux_log_error (h, "error responding to checkpoint-put request");
+}
+
+static void checkpoint_flush_continuation (flux_future_t *f, void *arg)
+{
+    struct checkpoint_data *data = arg;
+    int rv;
+
+    assert (data);
+    if ((rv = flux_rpc_get (f, NULL)) < 0)
+        flux_log_error (data->checkpoint->h, "checkpoint flush rpc");
+    if (!rv) {
+        data->dirty = 0;
+        data->checkpoint->hash_dirty--;
+    }
+    data->in_progress = false;
+    checkpoint_data_decref (data);
+    flux_future_destroy (f);
+}
+
+static int checkpoint_flush (struct content_checkpoint *checkpoint,
+                             struct checkpoint_data *data)
+{
+    if (data->dirty && !data->in_progress) {
+        const char *key = zhashx_cursor (checkpoint->hash);
+        const char *topic = "content-backing.checkpoint-put";
+        flux_future_t *f;
+        if (!(f = flux_rpc_pack (checkpoint->h, topic, 0, 0,
+                                 "{s:s s:O}",
+                                 "key", key,
+                                 "value", data->value))
+            || flux_future_then (f,
+                                 -1,
+                                 checkpoint_flush_continuation,
+                                 (void *)checkpoint_data_incref (data)) < 0) {
+            flux_log_error (checkpoint->h, "%s: checkpoint flush", __FUNCTION__);
+            flux_future_destroy (f);
+            return -1;
+        }
+        data->in_progress = true;
+    }
+    return 0;
+}
+
+int checkpoints_flush (struct content_checkpoint *checkpoint)
+{
+    int last_errno = 0;
+    int rc = 0;
+
+    if (checkpoint->hash_dirty > 0) {
+        struct checkpoint_data *data = zhashx_first (checkpoint->hash);
+        while (data) {
+            if (checkpoint_flush (checkpoint, data) < 0) {
+                last_errno = errno;
+                rc = -1;
+                /* A few errors we will consider "unrecoverable", so
+                 * break out */
+                if (errno == ENOSYS
+                    || errno == ENOMEM)
+                    break;
+            }
+            data = zhashx_next (checkpoint->hash);
+        }
+    }
+    if (rc < 0)
+        errno = last_errno;
+    return rc;
 }
 
 static const struct flux_msg_handler_spec htab[] = {
@@ -224,6 +400,7 @@ void content_checkpoint_destroy (struct content_checkpoint *checkpoint)
     if (checkpoint) {
         int saved_errno = errno;
         flux_msg_handler_delvec (checkpoint->handlers);
+        zhashx_destroy (&checkpoint->hash);
         free (checkpoint);
         errno = saved_errno;
     }
@@ -241,10 +418,17 @@ struct content_checkpoint *content_checkpoint_create (
     checkpoint->h = h;
     checkpoint->rank = rank;
     checkpoint->cache = cache;
+
+    if (!(checkpoint->hash = zhashx_new ()))
+        goto nomem;
+    zhashx_set_destructor (checkpoint->hash, checkpoint_data_decref_wrapper);
+
     if (flux_msg_handler_addvec (h, htab, checkpoint, &checkpoint->handlers) < 0)
         goto error;
     return checkpoint;
 
+nomem:
+    errno = ENOMEM;
 error:
     content_checkpoint_destroy (checkpoint);
     return NULL;

--- a/src/broker/content-checkpoint.h
+++ b/src/broker/content-checkpoint.h
@@ -19,6 +19,8 @@ struct content_checkpoint *content_checkpoint_create (
     struct content_cache *cache);
 void content_checkpoint_destroy (struct content_checkpoint *checkpoint);
 
+int checkpoints_flush (struct content_checkpoint *checkpoint);
+
 #endif /* !HAVE_BROKER_CONTENT_CHECKPOINT_H */
 
 /*

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -69,6 +69,7 @@ TESTSCRIPTS = \
 	t0011-content-cache.t \
 	t0012-content-sqlite.t \
 	t0024-content-s3.t \
+	t0028-content-backing-none.t \
 	t0025-broker-state-machine.t \
 	t0027-broker-groups.t \
 	t0013-config-file.t \

--- a/t/content/content-helper.sh
+++ b/t/content/content-helper.sh
@@ -30,3 +30,17 @@ checkpoint_get() {
 	o=$(checkpoint_get_msg $1)
 	jq -j -c -n ${o} | $RPC content.checkpoint-get
 }
+
+# Identical to checkpoint_put(), but go directly to backing store
+# Usage: checkpoint_put key rootref
+checkpoint_backing_put() {
+	o=$(checkpoint_put_msg $1 $2)
+	jq -j -c -n ${o} | $RPC content-backing.checkpoint-put
+}
+
+# Identical to checkpoint_get(), but go directly to backing store
+# Usage: checkpoint_get key
+checkpoint_backing_get() {
+	o=$(checkpoint_get_msg $1)
+	jq -j -c -n ${o} | $RPC content-backing.checkpoint-get
+}

--- a/t/t0028-content-backing-none.t
+++ b/t/t0028-content-backing-none.t
@@ -80,4 +80,8 @@ test_expect_success 'unload kvs' '
         flux module remove kvs
 '
 
+test_expect_success 'content.backing-module input of none works' '
+        flux start -o,-Scontent.backing-module=none /bin/true
+'
+
 test_done

--- a/t/t0028-content-backing-none.t
+++ b/t/t0028-content-backing-none.t
@@ -1,0 +1,83 @@
+#!/bin/sh
+
+test_description='Test broker content checkpoint w/o backing module'
+
+. `dirname $0`/content/content-helper.sh
+
+. `dirname $0`/sharness.sh
+
+test_under_flux 2 minimal
+echo "# $0: flux session size will be ${SIZE}"
+
+RPC=${FLUX_BUILD_DIR}/t/request/rpc
+
+test_expect_success HAVE_JQ 'checkpoint-get fails, no checkpoints yet' '
+        checkpoint_put foo bar
+'
+
+test_expect_success HAVE_JQ 'checkpoint-put foo w/ rootref bar' '
+        checkpoint_put foo bar
+'
+
+test_expect_success HAVE_JQ 'checkpoint-get foo returned rootref bar' '
+        echo bar >rootref.exp &&
+        checkpoint_get foo | jq -r .value | jq -r .rootref >rootref.out &&
+        test_cmp rootref.exp rootref.out
+'
+
+test_expect_success HAVE_JQ 'checkpoint-put on rank 1 forwards to rank 0' '
+        o=$(checkpoint_put_msg rankone rankref) &&
+        jq -j -c -n ${o} | flux exec -r 1 ${RPC} content.checkpoint-put
+'
+
+test_expect_success HAVE_JQ 'checkpoint-get on rank 1 forwards to rank 0' '
+        echo rankref >rankref.exp &&
+        o=$(checkpoint_get_msg rankone) &&
+        jq -j -c -n ${o} \
+            | flux exec -r 1 ${RPC} content.checkpoint-get \
+            | jq -r .value | jq -r .rootref > rankref.out &&
+        test_cmp rankref.exp rankref.out
+'
+
+test_expect_success 'flux-dump --checkpoint with missing checkpoint fails' '
+        test_must_fail flux dump --checkpoint foo.tar
+'
+
+test_expect_success 'load kvs and create some kvs data' '
+        flux module load kvs &&
+        flux kvs put a=1 &&
+        flux kvs put b=foo
+'
+
+test_expect_success 'reload kvs' '
+        flux module reload kvs &&
+        test $(flux kvs get a) = "1" &&
+        test $(flux kvs get b) = "foo"
+'
+
+test_expect_success 'unload kvs' '
+        flux module remove kvs
+'
+
+test_expect_success 'dump default=kvs-primary checkpoint works' '
+        flux dump --checkpoint foo.tar
+'
+
+test_expect_success 'restore content' '
+        flux restore --checkpoint foo.tar
+'
+
+test_expect_success 'reload kvs' '
+        flux module load kvs
+'
+
+test_expect_success 'verify KVS content restored' '
+        test $(flux kvs get a) = "1" &&
+        test $(flux kvs get b) = "foo"
+'
+
+test_expect_success 'unload kvs' '
+        flux module remove kvs
+'
+
+test_done

--- a/t/t2807-dump-cmd.t
+++ b/t/t2807-dump-cmd.t
@@ -23,7 +23,7 @@ test_expect_success 'flux-restore with no args prints Usage message' '
 '
 test_expect_success 'flux-dump with no backing store fails' '
 	test_must_fail flux dump --checkpoint foo.tar 2>nostore.err &&
-	grep "Function not implemented" nostore.err
+	grep "checkpoint key unavailable" nostore.err
 '
 test_expect_success 'flux-dump with bad archive file fails' '
 	test_must_fail flux dump /badfile.tar 2>badfile.err &&
@@ -177,9 +177,9 @@ test_expect_success 'restore to key fails when kvs is not loaded' '
 test_expect_success 'unload content-sqlite' '
 	flux module remove content-sqlite
 '
-test_expect_success 'restore --checkpoint with no backing store fails' '
-	test_must_fail flux restore --checkpoint foo.tar 2>noback.err &&
-	grep "error updating checkpoint" noback.err
+test_expect_success 'restore --checkpoint with no backing store cant flush' '
+	flux restore --checkpoint foo.tar 2>noback.err &&
+	grep "error flushing content cache" noback.err
 '
 test_expect_success 'dump --no-cache with no backing store fails' '
 	test_must_fail flux dump --no-cache --checkpoint x.tar


### PR DESCRIPTION
Per discussion in #4267, always loading the backing module content-sqlite can lead to performance issues, especially for shorter lived single user instances.   Default to not loading a backing module.

- to enable this, cache checkpoint put/get in the broker even when a backing module does not exist.  This allows a number of checkpoint operations to still work even if a backing module isn't loaded.
- update rc1/rc3 to not load the checkpoint module by default
  - update systemd service file to default configure loading `content-sqlite`
  - update tests that require content-sqlite to specifically configure for it

one possible remaining gotcha is that if the user doesn't set a backing module, they are still allowed to load one and that becomes the backing module.  Dunno if we'd like to support a special backing module config of "none" (or equivalent word) to say "do not allow a backing module to be loaded"?