### PR TITLE
testsuite: misc cleanup and activate valgrind suppression needed on aarch64

### DIFF
--- a/t/issues/t4465-job-list-use-after-free.sh
+++ b/t/issues/t4465-job-list-use-after-free.sh
@@ -4,6 +4,7 @@ VALGRIND=`which valgrind`
 if test -z "${VALGRIND}"; then
     exit 0
 fi
+VALGRIND_SUPPRESSIONS=${SHARNESS_TEST_SRCDIR}/valgrind/valgrind.supp
 
 STATEDIR=issue4470-statedir
 
@@ -24,4 +25,5 @@ flux start --test-size=1 -o,-Sstatedir=${STATEDIR} \
     --wrap=--child-silent-after-fork=yes \
     --wrap=--num-callers=30 \
     --wrap=--error-exitcode=1 \
+    --wrap=--suppressions=$VALGRIND_SUPPRESSIONS \
     bash -c "flux job purge --force --num-limit=4 && flux jobs -a 2>/dev/null"

--- a/t/issues/t4465-job-list-use-after-free.sh
+++ b/t/issues/t4465-job-list-use-after-free.sh
@@ -1,7 +1,14 @@
 #!/bin/sh -e
 
+prog=$(basename $0)
+
+if test -z "$FLUX_ENABLE_VALGRIND_TEST"; then
+    echo "skipping ${prog}: FLUX_ENABLE_VALGRIND_TEST is not set" >&2
+    exit 0
+fi
 VALGRIND=`which valgrind`
 if test -z "${VALGRIND}"; then
+    echo "skipping ${prog}: valgrind executable not found" >&2
     exit 0
 fi
 VALGRIND_SUPPRESSIONS=${SHARNESS_TEST_SRCDIR}/valgrind/valgrind.supp

--- a/t/t5000-valgrind.t
+++ b/t/t5000-valgrind.t
@@ -34,8 +34,6 @@ if ! have_valgrind_h && test "$debug" = ""; then
     test_done
 fi
 
-export FLUX_PMI_SINGLETON=1 # avoid finding leaks in slurm libpmi.so
-
 VALGRIND=`which valgrind`
 VALGRIND_SUPPRESSIONS=${SHARNESS_TEST_SRCDIR}/valgrind/valgrind.supp
 VALGRIND_WORKLOAD=${SHARNESS_TEST_SRCDIR}/valgrind/valgrind-workload.sh


### PR DESCRIPTION
Problem: a recently added issue test runs valgrind unconditionally, and the test fails on aarch64.

Honor the FLUX_ENABLE_VALGRIND_TEST in that issue test and activate the valgrind suppressions there, since the test was failing due to a false positive in libev that we already have a suppression for.

Then a tiny bit of random cleanup noticed along the way.