### PR TITLE
testsuite: add timeout job tests

### DIFF
--- a/t/job-list/job-list-helper.sh
+++ b/t/job-list/job-list-helper.sh
@@ -7,7 +7,7 @@ JOB_LIST_WAIT_ITERS=50
 
 # Return the expected jobids list in a given state:
 #   "all", "pending", "running", "inactive", "active",
-#   "completed", "canceled", "failed"
+#   "completed", "canceled", "failed", "timeout"
 #
 job_list_state_ids() {
     for f in "$@"; do

--- a/t/t2260-job-list.t
+++ b/t/t2260-job-list.t
@@ -159,7 +159,7 @@ test_expect_success HAVE_JQ 'flux job list inactive jobs in completed order' '
 '
 
 test_expect_success HAVE_JQ 'flux job list inactive jobs with correct state' '
-        for count in `seq 1 6`; do \
+        for count in `seq 1 $(job_list_state_count inactive)`; do \
             echo "INACTIVE" >> list_state_I.exp; \
         done &&
         flux job list -s inactive | jq .state | ${JOB_CONV} statetostr > list_state_I.out &&

--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -538,7 +538,7 @@ test_expect_success 'flux jobs --format={t_cleanup/{in}active} works' '
 	count=`cut -d, -f4 t_cleanupPR.out | grep "^-$" | wc -l` &&
 	test $count -eq $(state_count sched run) &&
 	count=`cut -d, -f2 t_cleanupI.out | grep -v "^0.0$" | wc -l` &&
-	test $count -eq 6
+	test $count -eq $(state_count inactive)
 '
 
 test_expect_success 'flux-jobs --format={runtime},{runtime!F},{runtime!F:h},{runtime!H},{runtime!H:h} works' '

--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -466,12 +466,12 @@ test_expect_success 'flux-jobs --format={ranks},{ranks:h} works' '
 	flux jobs --filter=running -no "{ranks},{ranks:h}" > ranksR.out &&
 	test_debug "cat ranksR.out" &&
 	test "$(sort -n ranksR.out | head -1)" = "0,0" &&
-	flux jobs -no "{ranks},{ranks:h}" $(state_ids completed) > ranksI.out &&
-	test_debug "cat ranksI.out" &&
-	test "$(sort -n ranksI.out | head -1)" = "0,0" &&
-	flux jobs -no "{ranks},{ranks:h}" $(state_ids canceled) > ranksC.out &&
-	test_debug "cat ranksC.out" &&
-	test "$(sort -n ranksC.out | head -1)" = ",-"
+	flux jobs -no "{ranks},{ranks:h}" $(state_ids completed) > ranksCD.out &&
+	test_debug "cat ranksCD.out" &&
+	test "$(sort -n ranksCD.out | head -1)" = "0,0" &&
+	flux jobs -no "{ranks},{ranks:h}" $(state_ids canceled) > ranksCA.out &&
+	test_debug "cat ranksCA.out" &&
+	test "$(sort -n ranksCA.out | head -1)" = ",-"
 '
 
 test_expect_success 'flux-jobs --format={nodelist},{nodelist:h} works' '
@@ -487,17 +487,17 @@ test_expect_success 'flux-jobs --format={nodelist},{nodelist:h} works' '
 	done &&
 	test_debug "cat nodelistR.out" &&
 	test_cmp nodelistR.out nodelistR.exp &&
-	flux jobs -no "{nodelist},{nodelist:h}" $(state_ids completed) > nodelistI.out &&
+	flux jobs -no "{nodelist},{nodelist:h}" $(state_ids completed) > nodelistCD.out &&
 	for id in $(state_ids completed); do
 		nodes=`flux job info ${id} R | flux R decode --nodelist`
-		echo "${nodes},${nodes}" >> nodelistI.exp
+		echo "${nodes},${nodes}" >> nodelistCD.exp
 	done &&
-	test_debug "cat nodelistI.out" &&
-	test_cmp nodelistI.out nodelistI.exp &&
-	flux jobs -no "{nodelist},{nodelist:h}" $(state_ids canceled) > nodelistC.out &&
-	test_debug "cat nodelistC.out" &&
-	echo ",-" > nodelistC.exp &&
-	test_cmp nodelistC.out nodelistC.exp
+	test_debug "cat nodelistCD.out" &&
+	test_cmp nodelistCD.out nodelistCD.exp &&
+	flux jobs -no "{nodelist},{nodelist:h}" $(state_ids canceled) > nodelistCA.out &&
+	test_debug "cat nodelistCA.out" &&
+	echo ",-" > nodelistCA.exp &&
+	test_cmp nodelistCA.out nodelistCA.exp
 '
 
 # test just make sure numbers are zero or non-zero given state of job


### PR DESCRIPTION
So I'm admittedly not sure if the pros outweigh the cons on this.  This was initially going to be just comments to point readers to the tests in `t2900-job-limits`, but as I was skimming things I realized "oh this isn't covered ... and this isn't covered ... and ..." and I slowly started adding things.

The addition of the timed out job to the job list tests is probably racy, which we can add things to try and limit that.

I maybe added too many permutations to the job list filtering tests, which can be whittled down.

Do the pros outweigh the cons?