### PR TITLE
github: modify stale-bot config

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -15,7 +15,7 @@ exemptLabels:
   - confirmed
 
 # Set to true to ignore issues in a project (defaults to false)
-exemptProjects: false
+exemptProjects: true
 
 # Set to true to ignore issues in a milestone (defaults to false)
 exemptMilestones: true
@@ -41,7 +41,7 @@ markComment: >
 #   Your comment here.
 
 # Limit the number of actions per hour, from 1-30. Default is 30
-limitPerRun: 2
+limitPerRun: 20
 
 # Limit to only `issues` or `pulls`
 # only: issues


### PR DESCRIPTION
Problem: The stale bot configuration limits the number of actions per
hour to 2, which just draws out the initial pain of marking many old
issues stale.

Update the number of actions per hour to 20.

Also, exempt issues that are part of a Project board.