### PR TITLE
flux-jobs: improve bad username error message

### DIFF
--- a/src/bindings/python/flux/job/list.py
+++ b/src/bindings/python/flux/job/list.py
@@ -177,9 +177,10 @@ class JobList:
             try:
                 self.userid = pwd.getpwnam(user).pw_uid
             except KeyError:
-                self.userid = int(user)
-            except ValueError:
-                raise ValueError(f"Invalid user {user} specified")
+                try:
+                    self.userid = int(user)
+                except ValueError:
+                    raise ValueError(f"Invalid user {user} specified")
 
     def add_filter(self, fname):
         """Append a state or result filter to JobList query"""

--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -281,7 +281,8 @@ test_expect_success 'flux-jobs --user=USERNAME works' '
 
 test_expect_success 'flux-jobs --user with invalid username fails' '
 	username="foobarfoobaz" &&
-	test_must_fail flux jobs --suppress-header --user=${username}
+	test_must_fail flux jobs --suppress-header --user=${username} 2> baduser.out &&
+	grep "Invalid user" baduser.out
 '
 
 test_expect_success 'flux-jobs --user=all works' '


### PR DESCRIPTION
Problem: When an invalid username is provided to flux-jobs,
the error message is:

flux-jobs: ERROR: invalid literal for int() with base 10: 'fasdfsdafd'

which is not helpful.

Solution: Improve error message to:

flux-jobs: ERROR: Invalid user fasdfsdafd specified

Update test to check for correct error output message.