### PR TITLE
add flux jobtap query subcommand

### DIFF
--- a/doc/man1/flux-jobtap.rst
+++ b/doc/man1/flux-jobtap.rst
@@ -36,6 +36,12 @@ COMMANDS
   be removed explicitly or by preceding *NAME* with ``.``,
   e.g. ``.*``.
 
+**query** NAME
+  Print a JSON object with extended information about plugin NAME. This
+  includes at least the plugin name and path (or "builtin" if the plugin
+  was loaded internally), but may contain plugin-specific data if the plugin
+  supports the ``plugin.query`` callback topic.
+
 RESOURCES
 =========
 

--- a/doc/man7/flux-jobtap-plugins.rst
+++ b/doc/man7/flux-jobtap-plugins.rst
@@ -237,6 +237,21 @@ The callback should return 0 on success, and -1 on failure.  On failure,
 it may optionally set a human readable error string in the ``errstr`` output
 argument.  The ``flux_jobtap_error()`` convenience function may be useful here.
 
+
+PLUGIN CALLBACK TOPICS
+======================
+
+plugin.query
+  The job manager calls the ``plugin.query`` callback topic to give a plugin
+  the opportunity to provide extra data in response to a ``jobtap-query``
+  request (as used by the ``flux jobtap query PLUGIN`` command). This can be
+  used by a plugin to export internal plugin state for inspection by an admin
+  or user by placing the data in the output arguments of the callback, e.g.::
+
+    flux_plugin_arg_pack (p, FLUX_PLUGIN_ARG_OUT,
+                          "{s:O}"
+                          "data", internal_data);
+
 .. _priority:
 
 PRIORITY

--- a/src/cmd/flux-jobtap.py
+++ b/src/cmd/flux-jobtap.py
@@ -53,6 +53,12 @@ def jobtap_list(args):
             print(name)
 
 
+def jobtap_query(args):
+    """Query extended information about and from a specific plugin"""
+    service = "job-manager.jobtap-query"
+    print(flux.Flux().rpc(service, {"name": args.plugin}).get_str())
+
+
 LOGGER = logging.getLogger("flux-jobtap")
 
 
@@ -104,6 +110,12 @@ def main():
         action="store_true",
     )
     list_parser.set_defaults(func=jobtap_list)
+
+    query_parser = subparsers.add_parser(
+        "query", formatter_class=flux.util.help_formatter()
+    )
+    query_parser.add_argument("plugin", help="Plugin name to query")
+    query_parser.set_defaults(func=jobtap_query)
 
     args = parser.parse_args()
     args.func(args)

--- a/src/common/libflux/plugin.c
+++ b/src/common/libflux/plugin.c
@@ -229,6 +229,13 @@ const char * flux_plugin_get_uuid (flux_plugin_t *p)
     return p->uuid_str;
 }
 
+const char * flux_plugin_get_path (flux_plugin_t *p)
+{
+    if (p)
+        return p->path;
+    return NULL;
+}
+
 int flux_plugin_aux_set (flux_plugin_t *p, const char *key,
                          void *val, aux_free_f free_fn)
 {

--- a/src/common/libflux/plugin.h
+++ b/src/common/libflux/plugin.h
@@ -63,6 +63,8 @@ const char * flux_plugin_get_name (flux_plugin_t *p);
 
 const char * flux_plugin_get_uuid (flux_plugin_t *p);
 
+const char * flux_plugin_get_path (flux_plugin_t *p);
+
 /*  Add a handler for topic 'topic' for the plugin 'p'.
  *  The topic string may be a glob to cause 'cb' to be invoked for
  *  a set of topic strings called by the host.

--- a/src/common/libflux/test/plugin.c
+++ b/src/common/libflux/test/plugin.c
@@ -73,6 +73,9 @@ void test_invalid_args ()
     ok (flux_plugin_get_uuid (NULL) == NULL && errno == EINVAL,
         "flux_plugin_get_uuid (NULL) returns EINVAL");
 
+    ok (flux_plugin_get_path (NULL) == NULL,
+        "flux_plugin_get_path (NULL) returns NULL");
+
     ok (flux_plugin_get_flags (NULL) == 0,
         "flux_plugin_get_flags (NULL) returns 0");
     ok (flux_plugin_set_flags (NULL, 0) < 0 && errno == EINVAL,
@@ -304,6 +307,9 @@ void test_basic ()
     is (flux_plugin_get_name (p), "op",
         "flux_plugin_get_name() works");
 
+    ok (flux_plugin_get_path (p) == NULL,
+        "flux_plugin_get_path() returns NULL when no loaded plugin path");
+
     ok (flux_plugin_add_handler (p, "foo.*", NULL, NULL) == 0,
         "flux_plugin_add_handler (p, 'foo.*', NULL) works");
     ok (flux_plugin_get_handler (p, "foo.*") == NULL,
@@ -426,6 +432,11 @@ void test_load ()
                   flux_plugin_strerror (p));
     is (flux_plugin_get_name (p), "plugin-test",
         "loaded dso registered its own name");
+
+    result = flux_plugin_get_path (p);
+    diag (result);
+    like (result, ".*test/.libs/plugin_foo.so",
+        "flux_plugin_get_path() on loaded dso works");
 
     flux_plugin_arg_t *args = flux_plugin_arg_create ();
     if (!args)

--- a/src/modules/job-manager/job-manager.c
+++ b/src/modules/job-manager/job-manager.c
@@ -125,6 +125,12 @@ static const struct flux_msg_handler_spec htab[] = {
     },
     {
         FLUX_MSGTYPE_REQUEST,
+        "job-manager.jobtap-query",
+        jobtap_query_handler,
+        FLUX_ROLE_OWNER,
+    },
+    {
+        FLUX_MSGTYPE_REQUEST,
         "job-manager.disconnect",
         disconnect_rpc,
         0

--- a/src/modules/job-manager/jobtap-internal.h
+++ b/src/modules/job-manager/jobtap-internal.h
@@ -79,6 +79,12 @@ void jobtap_handler (flux_t *h,
                      const flux_msg_t *msg,
                      void *arg);
 
+/*  Job manager RPC handler for querying jobtap plugin data.
+ */
+void jobtap_query_handler (flux_t *h,
+                           flux_msg_handler_t *mh,
+                           const flux_msg_t *msg,
+                           void *arg);
 
 int jobtap_notify_subscribers (struct jobtap *jobtap,
                                struct job *job,

--- a/t/t2212-job-manager-plugins.t
+++ b/t/t2212-job-manager-plugins.t
@@ -53,6 +53,17 @@ test_expect_success 'job-manager: loading duplicate plugins fails' '
 	test_must_fail flux jobtap load ${PLUGINPATH}/args.so &&
 	flux jobtap remove args.so
 '
+test_expect_success HAVE_JQ 'job-manager: query of plugin works' '
+	flux jobtap load ${PLUGINPATH}/test.so &&
+	flux jobtap query test.so >query.json &&
+	test_debug "jq -S . <query.json" &&
+	jq -e ".name == \"test.so\"" <query.json &&
+	jq -e ".path == \"${PLUGINPATH}/test.so\"" <query.json &&
+	flux jobtap remove test.so
+'
+test_expect_success 'job-manager: query of invalid plugin fals' '
+	test_must_fail flux jobtap query foo
+'
 test_expect_success 'job-manager: plugins can be loaded by configuration' '
 	mkdir testconf &&
 	cat <<-EOF >testconf/job-manager.toml &&


### PR DESCRIPTION
As described in #4506, this PR adds support for a new `flux jobtap query` subcommand which can fetch extended data about jobtap plugins (currently `name` and `path` by default). Optionally, plugins can register for a `plugin.query` callback topic and add arbitrary data to the response payload. This gives plugins a generic way to export internal state for debugging or other purposes.

As an example implementation, the `dependency-after` plugin is extended to support this interface and adds a `dependencies` key the query response which includes all active dependencies, e.g.:

```
$ flux jobtap query .dependency-after | jq
{
  "name": ".dependency-after",
  "path": "builtin",
  "dependencies": [
    {
      "id": 500699234304,
      "depid": 505581404160,
      "type": "after-success",
      "description": "after-success=fE9r5TG3"
    },
    {
      "id": 519590379520,
      "depid": 524053118976,
      "type": "after-success",
      "description": "after-success=fEedRWaK"
    },
    {
      "id": 533515468800,
      "depid": 537894322176,
      "type": "after-success",
      "description": "after-success=fF1qwEUX"
    }
  ]
}
```

If a plugin was loaded from a file, the path reflects the actual path of the original DSO:

```
$ flux jobtap query alloc-bypass.so | jq
{
  "name": "alloc-bypass.so",
  "path": "/home/grondo/git/flux-core.git/src/modules/job-manager/plugins/.libs/alloc-bypass.so"
}
```

