### PR TITLE
testsuite: unset FLUX_F58_FORCE_ASCII during testsuite

### DIFF
--- a/t/sharness.d/flux-sharness.sh
+++ b/t/sharness.d/flux-sharness.sh
@@ -388,6 +388,7 @@ unset FLUX_SHELL_RC_PATH
 unset FLUX_RC_EXTRA
 unset FLUX_CONF_DIR
 unset FLUX_JOB_CC
+unset FLUX_F58_FORCE_ASCII
 
 # Individual tests that need to force local URI resolution should set
 #  this specifically. In general it breaks other URI tests:


### PR DESCRIPTION
Problem: If FLUX_F58_FORCE_ASCII is set in the environment before
running `make check`, a few tests will fail.

Add FLUX_F58_FORCE_ASCII to the list of environment variables to
unset before the testsuite.