### PR TITLE
testsuite: use flux jobs in valgrind workload

### DIFF
--- a/t/valgrind/workload.d/job-list
+++ b/t/valgrind/workload.d/job-list
@@ -8,4 +8,4 @@ set -x
 flux mini submit -n 1 /bin/true
 flux mini submit -n 1 /bin/false
 
-flux job list -A
+flux jobs -a -A


### PR DESCRIPTION
Problem: In commit

ad5cd8bf1d2c2a3e4226d7318683bc08fdae505b

the "flux job list" command will give a warning / error to the user
to use "flux jobs" when the output is a tty.  The valgrind workload
still uses "flux job list", which can lead to errors when running the
valgrind unit tests by hand on the command line.

Solution: Use "flux jobs" instead of "flux job list" in the valgrind
workload.