### PR TITLE
cmd/flux-jobs: include job state in status output

### DIFF
--- a/doc/man1/flux-jobs.rst
+++ b/doc/man1/flux-jobs.rst
@@ -130,9 +130,9 @@ CANCELED, TIMEOUT. Under the *result_abbrev* field name, these are
 abbreviated as CD, F, CA, and TO respectively.
 
 The job status is a user friendly mix of both, a job is always in one
-of the following five statuses: PENDING, RUNNING, COMPLETED, FAILED,
-CANCELED, or TIMEOUT. Under the *status_abbrev* field name, these are
-abbreviated as P, R, CD, F, CA, and TO respectively.
+of the following statuses: DEPEND, SCHED, RUN, CLEANUP, COMPLETED,
+FAILED, CANCELED, or TIMEOUT. Under the *status_abbrev* field name,
+these are abbreviated as D, S, R, C, CD, F, CA, and TO respectively.
 
 
 OUTPUT FORMAT
@@ -227,7 +227,8 @@ The field names that can be specified are:
    list of any currently outstanding job dependencies
 
 **status**
-   job status (PENDING, RUNNING, COMPLETED, FAILED, CANCELED, or TIMEOUT)
+   job status (DEPEND, SCHED, RUN, CLEANUP, COMPLETED, FAILED,
+   CANCELED, or TIMEOUT)
 
 **status_abbrev**
    status but in a max 2 character abbreviation

--- a/src/bindings/python/flux/job/info.py
+++ b/src/bindings/python/flux/job/info.py
@@ -36,11 +36,13 @@ def resulttostr(resultid, fmt="L"):
     return raw.flux_job_resulttostr(resultid, fmt).decode("utf-8")
 
 
+# Status is the job state when pending/running (i.e. not inactive)
+# status is the result when inactive
 def statustostr(stateid, resultid, fmt="L"):
-    if stateid & flux.constants.FLUX_JOB_STATE_PENDING:
-        statusstr = "PD" if fmt == "S" else "PENDING"
-    elif stateid & flux.constants.FLUX_JOB_STATE_RUNNING:
-        statusstr = "R" if fmt == "S" else "RUNNING"
+    if (stateid & flux.constants.FLUX_JOB_STATE_PENDING) or (
+        stateid & flux.constants.FLUX_JOB_STATE_RUNNING
+    ):
+        statusstr = statetostr(stateid, fmt)
     else:  # flux.constants.FLUX_JOB_STATE_INACTIVE
         statusstr = resulttostr(resultid, fmt)
     return statusstr
@@ -276,7 +278,7 @@ class JobInfo:
 
     def get_remaining_time(self):
         status = str(self.status)
-        if status != "RUNNING":
+        if status != "RUN":
             return 0.0
         tleft = self.expiration - time.time()
         if tleft < 0.0:

--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -149,7 +149,7 @@ test_expect_success 'flux-jobs --suppress-header works' '
 test_expect_success 'flux-jobs default output works' '
 	flux jobs -n > default.out &&
 	test $(wc -l < default.out) -eq $(state_count active) &&
-	test $(grep -c " PD " default.out) -eq $(state_count sched) &&
+	test $(grep -c "  S " default.out) -eq $(state_count sched) &&
 	test $(grep -c "  R " default.out) -eq $(state_count run) &&
 	test $(grep -c " CD " default.out) -eq 0 &&
 	test $(grep -c " CA " default.out) -eq 0 &&
@@ -693,12 +693,12 @@ test_expect_success 'flux-jobs --format={result},{result:h},{result_abbrev},{res
 '
 
 test_expect_success 'flux-jobs --format={status},{status_abbrev} works' '
-	flux jobs --filter=pending  -no "{status},{status_abbrev}" > statusP.out &&
-	flux jobs --filter=running  -no "{status},{status_abbrev}" > statusR.out &&
+	flux jobs --filter=sched    -no "{status},{status_abbrev}" > statusS.out &&
+	flux jobs --filter=run      -no "{status},{status_abbrev}" > statusR.out &&
 	flux jobs --filter=inactive -no "{status},{status_abbrev}" > statusI.out &&
-	count=$(grep -c "PENDING,PD" statusP.out) &&
+	count=$(grep -c "SCHED,S" statusS.out) &&
 	test $count -eq $(state_count sched) &&
-	count=$(grep -c "RUNNING,R" statusR.out) &&
+	count=$(grep -c "RUN,R" statusR.out) &&
 	test $count -eq $(state_count run) &&
 	count=$(grep -c "CANCELED,CA" statusI.out) &&
 	test $count -eq $(state_count canceled) &&


### PR DESCRIPTION
Problem: Currently the job status outputs "PENDING"
when the job is in the DEPEND or SCHED state and "RUNNING" when the
job is in the RUN or CLEANUP states.  This abstraction of job states
in the job status doesn't give enough detail about what is going
on with a job.

Solution: Update the job status to output the job state when a job
is not inactive.  Output the job result when it is inactive.  In
other words, the list of outputs for the job status is now:

DEPEND, SCHED, RUN, CLEANUP, COMPLETED, FAILED, CANCELED, or TIMEOUT

Update tests for new output accordingly.

Update documentation accordingly.

Fixes #4495