### PR TITLE
flux-jobs: add --since=WHEN and --name=NAME options

### DIFF
--- a/doc/man1/flux-jobs.rst
+++ b/doc/man1/flux-jobs.rst
@@ -36,8 +36,22 @@ OPTIONS
 **-u, --user**\ *=[USERNAME|UID]*
    List jobs for a specific username or userid. Specify *all* for all users.
 
+**--name**\ *=[JOB NAME]*
+   List jobs with a specific job name.
+
 **-c, --count**\ *=N*
    Limit output to N jobs (default 1000)
+
+**--since**\ *WHEN*
+   Limit output to jobs that completed or have become inactive since a
+   given timestamp. This option implies ``-a`` if no other ``--filter``
+   options are specified. If *WHEN* begins with ``-`` character, then
+   the remainder is considered to be a an offset in Flux standard duration
+   (RFC 23). Otherwise, any datetime expression accepted by the Python
+   `parsedatetime <https://github.com/bear/parsedatetime>`_ module is
+   accepted. Examples: "-6h", "-1d", "yesterday", "2021-06-21 6am",
+   "last Monday", etc. It is assumed to be an error if a timestamp in
+   the future is supplied.
 
 **-f, --filter**\ *=STATE|RESULT*
    List jobs with specific job state or result. Multiple states or

--- a/src/cmd/flux-jobs.py
+++ b/src/cmd/flux-jobs.py
@@ -43,6 +43,7 @@ def fetch_jobs_stdin():
     return jobs
 
 
+# pylint: disable=too-many-branches
 def fetch_jobs_flux(args, fields, flux_handle=None):
     if not flux_handle:
         flux_handle = flux.Flux()
@@ -124,6 +125,22 @@ def fetch_jobs_flux(args, fields, flux_handle=None):
     if args.A:
         args.user = str(flux.constants.FLUX_USERID_UNKNOWN)
 
+    since = 0.0
+    if args.since:
+        # Implies -a, *unless* another filter option is already in effect:
+        if not args.filter:
+            args.a = True
+
+        try:
+            since = flux.util.parse_datetime(args.since).timestamp()
+        except ValueError:
+            since = float(args.since)
+
+        # Ensure args.since is in the past
+        if since > flux.util.parse_datetime("now").timestamp():
+            LOGGER.error("--since=%s appears to be in the future", args.since)
+            sys.exit(1)
+
     if args.a:
         args.filter.update(["pending", "running", "inactive"])
 
@@ -137,6 +154,8 @@ def fetch_jobs_flux(args, fields, flux_handle=None):
         filters=args.filter,
         user=args.user,
         max_entries=args.count,
+        since=since,
+        name=args.name,
     )
 
     jobs = jobs_rpc.jobs()
@@ -236,6 +255,15 @@ def parse_args():
         help="List jobs with specific job state or result",
     )
     parser.add_argument(
+        "--since",
+        action=FilterAction,
+        type=str,
+        metavar="WHEN",
+        default=0.0,
+        help="Include jobs that have become inactive since WHEN. "
+        + "(implies -a if no other --filter option is specified)",
+    )
+    parser.add_argument(
         "-n",
         "--suppress-header",
         action="store_true",
@@ -250,6 +278,13 @@ def parse_args():
         default=str(os.getuid()),
         help="Limit output to specific username or userid "
         '(Specify "all" for all users)',
+    )
+    parser.add_argument(
+        "--name",
+        action=FilterAction,
+        type=str,
+        metavar="JOB-NAME",
+        help="Limit output to specific job name",
     )
     parser.add_argument(
         "-o",


### PR DESCRIPTION
Now that `job-list.list` supports the `since` and `name` parameters, this PR adds support to `flux-jobs` for these options.

The `--name` option restricts returned jobs to those matching a supplied name, and the `--since=WHEN` option restricts jobs to jobs that became inactive after WHEN. If no other filtering options are supplied, then `--since` implies `-a` (because obviously pending and running jobs will become inactive after any supplied time).

The argument to `--since` supports raw timestamp, (negative) offset in FSD, or anything handled by the `flux.util.parse_datetime()` function (e.g. `yesterday`, `an hour ago`, `last monday`).

Using `flux jobs --since` we can now easily determine which jobs were pending or running since yesterday
```console
$ flux jobs --since=8am,yesterday
```
jobs that failed in the last 24hrs
```console
$ flux jobs -f failed --since=-24h
```
or jobs that completed (regardless of status) the over the weekend
```console
$ flux jobs -f completed,failed,timeout --since 'last fri night'
```
