### PR TITLE
broker: forward content.checkpoint-{get,put} RPCs to rank 0

### DIFF
--- a/src/broker/Makefile.am
+++ b/src/broker/Makefile.am
@@ -40,6 +40,8 @@ libbroker_la_SOURCES = \
 	log.c \
 	content-cache.h \
 	content-cache.c \
+	content-checkpoint.h \
+	content-checkpoint.c \
 	runat.h \
 	runat.c \
 	state_machine.h \

--- a/src/broker/content-cache.c
+++ b/src/broker/content-cache.c
@@ -27,6 +27,7 @@
 
 #include "attr.h"
 #include "content-cache.h"
+#include "content-checkpoint.h"
 
 /* A periodic callback purges the cache of least recently used entries.
  * The callback is synchronized with the instance heartbeat, with a
@@ -99,6 +100,8 @@ struct content_cache {
     uint64_t acct_size;             // total size of all cache entries
     uint32_t acct_valid;            // count of valid cache entries
     uint32_t acct_dirty;            // count of dirty cache entries
+
+    struct content_checkpoint *checkpoint;
 };
 
 static void flush_respond (struct content_cache *cache);
@@ -617,124 +620,6 @@ error:
         flux_log_error (h, "content store: flux_respond_error");
 }
 
-static void checkpoint_get_continuation (flux_future_t *f, void *arg)
-{
-    struct content_cache *cache = arg;
-    const flux_msg_t *msg = flux_future_aux_get (f, "msg");
-    const char *s;
-
-    assert (msg);
-
-    if (flux_rpc_get (f, &s) < 0)
-        goto error;
-
-    if (flux_respond (cache->h, msg, s) < 0)
-        flux_log_error (cache->h, "error responding to checkpoint-get");
-    flux_future_destroy (f);
-    return;
-
-error:
-    if (flux_respond_error (cache->h, msg, errno, NULL) < 0)
-        flux_log_error (cache->h, "error responding to checkpoint-get");
-    flux_future_destroy (f);
-}
-
-void content_checkpoint_get_request (flux_t *h, flux_msg_handler_t *mh,
-                                     const flux_msg_t *msg, void *arg)
-{
-    struct content_cache *cache = arg;
-    const char *topic = "content-backing.checkpoint-get";
-    const char *s = NULL;
-    const flux_msg_t *msgcpy = flux_msg_incref (msg);
-    flux_future_t *f = NULL;
-
-    /* Temporarily maintain ENOSYS behavior */
-    if (!cache->backing) {
-        errno = ENOSYS;
-        goto error;
-    }
-
-    if (flux_request_decode (msg, NULL, &s) < 0)
-        goto error;
-
-    if (!(f = flux_rpc (h, topic, s, 0, 0))
-        || flux_future_aux_set (f,
-                                "msg",
-                                (void *)msgcpy,
-                                (flux_free_f)flux_msg_decref) < 0
-        || flux_future_then (f, -1, checkpoint_get_continuation, cache) < 0) {
-        flux_log_error (h, "error starting checkpoint-get RPC");
-        goto error;
-    }
-
-    return;
-
-error:
-    if (flux_respond_error (h, msg, errno, NULL) < 0)
-        flux_log_error (h, "error responding to checkpoint-get request");
-    flux_future_destroy (f);
-    flux_msg_decref (msgcpy);
-}
-
-static void checkpoint_put_continuation (flux_future_t *f, void *arg)
-{
-    struct content_cache *cache = arg;
-    const flux_msg_t *msg = flux_future_aux_get (f, "msg");
-    const char *s;
-
-    assert (msg);
-
-    if (flux_rpc_get (f, &s) < 0)
-        goto error;
-
-    if (flux_respond (cache->h, msg, s) < 0)
-        flux_log_error (cache->h, "error responding to checkpoint-put");
-    flux_future_destroy (f);
-    return;
-
-error:
-    if (flux_respond_error (cache->h, msg, errno, NULL) < 0)
-        flux_log_error (cache->h, "error responding to checkpoint-put");
-    flux_future_destroy (f);
-}
-
-void content_checkpoint_put_request (flux_t *h, flux_msg_handler_t *mh,
-                                     const flux_msg_t *msg, void *arg)
-{
-    struct content_cache *cache = arg;
-    const char *topic = "content-backing.checkpoint-put";
-    const char *s = NULL;
-    const flux_msg_t *msgcpy = flux_msg_incref (msg);
-    flux_future_t *f = NULL;
-
-    /* Temporarily maintain ENOSYS behavior */
-    if (!cache->backing) {
-        errno = ENOSYS;
-        goto error;
-    }
-
-    if (flux_request_decode (msg, NULL, &s) < 0)
-        goto error;
-
-    if (!(f = flux_rpc (h, topic, s, 0, 0))
-        || flux_future_aux_set (f,
-                                "msg",
-                                (void *)msgcpy,
-                                (flux_free_f)flux_msg_decref) < 0
-        || flux_future_then (f, -1, checkpoint_put_continuation, cache) < 0) {
-        flux_log_error (h, "error starting checkpoint-put RPC");
-        goto error;
-    }
-
-    return;
-
-error:
-    if (flux_respond_error (h, msg, errno, NULL) < 0)
-        flux_log_error (h, "error responding to checkpoint-put request");
-    flux_future_destroy (f);
-    flux_msg_decref (msgcpy);
-}
-
 /* Backing store is enabled/disabled by modules that provide the
  * 'content.backing' service.  At module load time, the backing module
  * informs the content service of its availability, and entries are
@@ -1011,18 +896,6 @@ static const struct flux_msg_handler_spec htab[] = {
     },
     {
         FLUX_MSGTYPE_REQUEST,
-        "content.checkpoint-get",
-        content_checkpoint_get_request,
-        0
-    },
-    {
-        FLUX_MSGTYPE_REQUEST,
-        "content.checkpoint-put",
-        content_checkpoint_put_request,
-        0
-    },
-    {
-        FLUX_MSGTYPE_REQUEST,
         "content.unregister-backing",
         content_unregister_backing_request,
         0
@@ -1132,6 +1005,7 @@ void content_cache_destroy (struct content_cache *cache)
         free (cache->backing_name);
         zhashx_destroy (&cache->entries);
         msgstack_destroy (&cache->flush_requests);
+        content_checkpoint_destroy (cache->checkpoint);
         free (cache);
         errno = saved_errno;
     }
@@ -1169,9 +1043,13 @@ struct content_cache *content_cache_create (flux_t *h, attr_t *attrs)
         goto error;
     assert (content_hash_size >= sizeof (size_t)); // hasher assumes this
 
-    if (flux_msg_handler_addvec (h, htab, cache, &cache->handlers) < 0)
-        goto error;
     if (flux_get_rank (h, &cache->rank) < 0)
+        goto error;
+
+    if (!(cache->checkpoint = content_checkpoint_create (h, cache->rank, cache)))
+        goto error;
+
+    if (flux_msg_handler_addvec (h, htab, cache, &cache->handlers) < 0)
         goto error;
     if (!(cache->f_sync = flux_sync_create (h, 0))
         || flux_future_then (cache->f_sync, sync_max, sync_cb, cache) < 0)

--- a/src/broker/content-cache.c
+++ b/src/broker/content-cache.c
@@ -988,6 +988,11 @@ static void sync_cb (flux_future_t *f, void *arg)
     flux_future_reset (f);
 }
 
+bool content_cache_backing_loaded (struct content_cache *cache)
+{
+    return cache->backing;
+}
+
 /* Initialization
  */
 

--- a/src/broker/content-cache.h
+++ b/src/broker/content-cache.h
@@ -13,6 +13,7 @@
 
 struct content_cache *content_cache_create (flux_t *h, attr_t *attr);
 void content_cache_destroy (struct content_cache *cache);
+bool content_cache_backing_loaded (struct content_cache *cache);
 
 #endif /* !HAVE_BROKER_CONTENT_CACHE_H */
 

--- a/src/broker/content-cache.h
+++ b/src/broker/content-cache.h
@@ -11,6 +11,10 @@
 #ifndef HAVE_BROKER_CONTENT_CACHE_H
 #define HAVE_BROKER_CONTENT_CACHE_H 1
 
+#include "attr.h"
+
+struct content_cache;
+
 struct content_cache *content_cache_create (flux_t *h, attr_t *attr);
 void content_cache_destroy (struct content_cache *cache);
 bool content_cache_backing_loaded (struct content_cache *cache);

--- a/src/broker/content-checkpoint.c
+++ b/src/broker/content-checkpoint.c
@@ -1,0 +1,205 @@
+/************************************************************\
+ * Copyright 2015 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* See RFC 10 */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <inttypes.h>
+#include <assert.h>
+#include <flux/core.h>
+
+#include "src/common/libczmqcontainers/czmq_containers.h"
+
+#include "content-checkpoint.h"
+#include "content-cache.h"
+
+struct content_checkpoint {
+    flux_t *h;
+    flux_msg_handler_t **handlers;
+    uint32_t rank;
+    struct content_cache *cache;
+};
+
+static void checkpoint_get_continuation (flux_future_t *f, void *arg)
+{
+    struct content_checkpoint *checkpoint = arg;
+    const flux_msg_t *msg = flux_future_aux_get (f, "msg");
+    const char *s;
+
+    assert (msg);
+
+    if (flux_rpc_get (f, &s) < 0)
+        goto error;
+
+    if (flux_respond (checkpoint->h, msg, s) < 0)
+        flux_log_error (checkpoint->h, "error responding to checkpoint-get");
+    flux_future_destroy (f);
+    return;
+
+error:
+    if (flux_respond_error (checkpoint->h, msg, errno, NULL) < 0)
+        flux_log_error (checkpoint->h, "error responding to checkpoint-get");
+    flux_future_destroy (f);
+}
+
+void content_checkpoint_get_request (flux_t *h, flux_msg_handler_t *mh,
+                                     const flux_msg_t *msg, void *arg)
+{
+    struct content_checkpoint *checkpoint = arg;
+    const char *topic = "content-backing.checkpoint-get";
+    const char *s = NULL;
+    const flux_msg_t *msgcpy = flux_msg_incref (msg);
+    flux_future_t *f = NULL;
+
+    /* Temporarily maintain ENOSYS behavior */
+    if (!content_cache_backing_loaded (checkpoint->cache)) {
+        errno = ENOSYS;
+        goto error;
+    }
+
+    if (flux_request_decode (msg, NULL, &s) < 0)
+        goto error;
+
+    if (!(f = flux_rpc (h, topic, s, 0, 0))
+        || flux_future_aux_set (f,
+                                "msg",
+                                (void *)msgcpy,
+                                (flux_free_f)flux_msg_decref) < 0
+        || flux_future_then (f,
+                             -1,
+                             checkpoint_get_continuation,
+                             checkpoint) < 0) {
+        flux_log_error (h, "error starting checkpoint-get RPC");
+        goto error;
+    }
+
+    return;
+
+error:
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "error responding to checkpoint-get request");
+    flux_future_destroy (f);
+    flux_msg_decref (msgcpy);
+}
+
+static void checkpoint_put_continuation (flux_future_t *f, void *arg)
+{
+    struct content_checkpoint *checkpoint = arg;
+    const flux_msg_t *msg = flux_future_aux_get (f, "msg");
+    const char *s;
+
+    assert (msg);
+
+    if (flux_rpc_get (f, &s) < 0)
+        goto error;
+
+    if (flux_respond (checkpoint->h, msg, s) < 0)
+        flux_log_error (checkpoint->h, "error responding to checkpoint-put");
+    flux_future_destroy (f);
+    return;
+
+error:
+    if (flux_respond_error (checkpoint->h, msg, errno, NULL) < 0)
+        flux_log_error (checkpoint->h, "error responding to checkpoint-put");
+    flux_future_destroy (f);
+}
+
+void content_checkpoint_put_request (flux_t *h, flux_msg_handler_t *mh,
+                                     const flux_msg_t *msg, void *arg)
+{
+    struct content_checkpoint *checkpoint = arg;
+    const char *topic = "content-backing.checkpoint-put";
+    const char *s = NULL;
+    const flux_msg_t *msgcpy = flux_msg_incref (msg);
+    flux_future_t *f = NULL;
+
+    /* Temporarily maintain ENOSYS behavior */
+    if (!content_cache_backing_loaded (checkpoint->cache)) {
+        errno = ENOSYS;
+        goto error;
+    }
+
+    if (flux_request_decode (msg, NULL, &s) < 0)
+        goto error;
+
+    if (!(f = flux_rpc (h, topic, s, 0, 0))
+        || flux_future_aux_set (f,
+                                "msg",
+                                (void *)msgcpy,
+                                (flux_free_f)flux_msg_decref) < 0
+        || flux_future_then (f,
+                             -1,
+                             checkpoint_put_continuation,
+                             checkpoint) < 0) {
+        flux_log_error (h, "error starting checkpoint-put RPC");
+        goto error;
+    }
+
+    return;
+
+error:
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "error responding to checkpoint-put request");
+    flux_future_destroy (f);
+    flux_msg_decref (msgcpy);
+}
+
+static const struct flux_msg_handler_spec htab[] = {
+    {
+        FLUX_MSGTYPE_REQUEST,
+        "content.checkpoint-get",
+        content_checkpoint_get_request,
+        0
+    },
+    {
+        FLUX_MSGTYPE_REQUEST,
+        "content.checkpoint-put",
+        content_checkpoint_put_request,
+        0
+    },
+    FLUX_MSGHANDLER_TABLE_END,
+};
+
+void content_checkpoint_destroy (struct content_checkpoint *checkpoint)
+{
+    if (checkpoint) {
+        int saved_errno = errno;
+        flux_msg_handler_delvec (checkpoint->handlers);
+        free (checkpoint);
+        errno = saved_errno;
+    }
+}
+
+struct content_checkpoint *content_checkpoint_create (
+    flux_t *h,
+    uint32_t rank,
+    struct content_cache *cache)
+{
+    struct content_checkpoint *checkpoint;
+
+    if (!(checkpoint = calloc (1, sizeof (*checkpoint))))
+        return NULL;
+    checkpoint->h = h;
+    checkpoint->rank = rank;
+    checkpoint->cache = cache;
+    if (flux_msg_handler_addvec (h, htab, checkpoint, &checkpoint->handlers) < 0)
+        goto error;
+    return checkpoint;
+
+error:
+    content_checkpoint_destroy (checkpoint);
+    return NULL;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/broker/content-checkpoint.h
+++ b/src/broker/content-checkpoint.h
@@ -1,0 +1,26 @@
+/************************************************************\
+ * Copyright 2015 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef HAVE_BROKER_CONTENT_CHECKPOINT_H
+#define HAVE_BROKER_CONTENT_CHECKPOINT_H 1
+
+#include "content-cache.h"
+
+struct content_checkpoint *content_checkpoint_create (
+    flux_t *h,
+    uint32_t rank,
+    struct content_cache *cache);
+void content_checkpoint_destroy (struct content_checkpoint *checkpoint);
+
+#endif /* !HAVE_BROKER_CONTENT_CHECKPOINT_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -323,6 +323,7 @@ dist_check_SCRIPTS = \
 	scripts/sqlite-query.py \
 	valgrind/valgrind-workload.sh \
 	valgrind/workload.d/job \
+	content/content-helper.sh \
 	kvs/kvs-helper.sh \
 	kvs/change-checkpoint.py \
 	job-manager/exec-service.lua \

--- a/t/content/content-helper.sh
+++ b/t/content/content-helper.sh
@@ -3,15 +3,30 @@
 
 # content module test helper functions
 
+# Get RPC message contents for checkpoint put
+# Usage: checkpoint_put_msg key rootref
+checkpoint_put_msg() {
+	o="{key:\"$1\",value:{version:1,rootref:\"$2\",timestamp:2.2}}"
+	echo ${o}
+}
+
 # checkpoint rootref at specific key
 # Usage: checkpoint_put key rootref
 checkpoint_put() {
-	o="{key:\"$1\",value:{version:1,rootref:\"$2\",timestamp:2.2}}"
-	jq -j -c -n  ${o} | $RPC content.checkpoint-put
+	o=$(checkpoint_put_msg $1 $2)
+	jq -j -c -n ${o} | $RPC content.checkpoint-put
+}
+
+# Get RPC message contents for checkpoint get
+# Usage: checkpoint_get_msg key
+checkpoint_get_msg() {
+	o="{key:\"$1\"}"
+	echo ${o}
 }
 
 # get checkpoint rootref at key
 # Usage: checkpoint_get key
 checkpoint_get() {
-	jq -j -c -n  "{key:\"$1\"}" | $RPC content.checkpoint-get
+	o=$(checkpoint_get_msg $1)
+	jq -j -c -n ${o} | $RPC content.checkpoint-get
 }

--- a/t/content/content-helper.sh
+++ b/t/content/content-helper.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+#
+
+# content module test helper functions
+
+# checkpoint rootref at specific key
+# Usage: checkpoint_put key rootref
+checkpoint_put() {
+	o="{key:\"$1\",value:{version:1,rootref:\"$2\",timestamp:2.2}}"
+	jq -j -c -n  ${o} | $RPC content.checkpoint-put
+}
+
+# get checkpoint rootref at key
+# Usage: checkpoint_get key
+checkpoint_get() {
+	jq -j -c -n  "{key:\"$1\"}" | $RPC content.checkpoint-get
+}

--- a/t/t0012-content-sqlite.t
+++ b/t/t0012-content-sqlite.t
@@ -133,6 +133,20 @@ test_expect_success HAVE_JQ 'checkpoint-get foo returned rootref bar' '
 	test_cmp rootref.exp rootref.out
 '
 
+test_expect_success HAVE_JQ 'checkpoint-put on rank 1 forwards to rank 0' '
+       o=$(checkpoint_put_msg rankone rankref) &&
+       jq -j -c -n ${o} | flux exec -r 1 ${RPC} content.checkpoint-put
+'
+
+test_expect_success HAVE_JQ 'checkpoint-get on rank 1 forwards to rank 0' '
+       echo rankref >rankref.exp &&
+       o=$(checkpoint_get_msg rankone) &&
+       jq -j -c -n ${o} \
+	   | flux exec -r 1 ${RPC} content.checkpoint-get \
+	   | jq -r .value | jq -r .rootref > rankref.out &&
+       test_cmp rankref.exp rankref.out
+'
+
 # use grep instead of compare, incase of floating point rounding
 test_expect_success HAVE_JQ 'checkpoint-get foo returned correct timestamp' '
         checkpoint_get foo | jq -r .value | jq -r .timestamp >timestamp.out &&

--- a/t/t0012-content-sqlite.t
+++ b/t/t0012-content-sqlite.t
@@ -2,6 +2,8 @@
 
 test_description='Test content-sqlite service'
 
+. `dirname $0`/content/content-helper.sh
+
 . `dirname $0`/sharness.sh
 
 # Size the session to one more than the number of cores, minimum of 4
@@ -120,14 +122,6 @@ test_expect_success 'drop the cache' '
 test_expect_success 'fill the cache with more data for later purging' '
 	${SPAMUTIL} 10000 200 >/dev/null
 '
-
-checkpoint_put() {
-	o="{key:\"$1\",value:{version:1,rootref:\"$2\",timestamp:2.2}}"
-	jq -j -c -n  ${o} | $RPC content.checkpoint-put
-}
-checkpoint_get() {
-	jq -j -c -n  "{key:\"$1\"}" | $RPC content.checkpoint-get
-}
 
 test_expect_success HAVE_JQ 'checkpoint-put foo w/ rootref bar' '
 	checkpoint_put foo bar

--- a/t/t0018-content-files.t
+++ b/t/t0018-content-files.t
@@ -2,6 +2,8 @@
 
 test_description='Test content-files backing store service'
 
+. `dirname $0`/content/content-helper.sh
+
 . `dirname $0`/sharness.sh
 
 test_under_flux 1 minimal -o,-Sstatedir=$(pwd)
@@ -54,15 +56,6 @@ recheck_cache_blob() {
 	local blobref=$($BLOBREF sha1 <blob.$1)
 	flux content load $blobref >blob.$1.cachecheck &&
 	test_cmp blob.$1 blob.$1.cachecheck
-}
-# Usage: checkpoint_put key rootref
-checkpoint_put() {
-        o="{key:\"$1\",value:{version:1,rootref:\"$2\",timestamp:2.2}}"
-        jq -j -c -n  ${o} | $RPC content.checkpoint-put
-}
-# Usage: checkpoint_get key >value
-checkpoint_get() {
-        jq -j -c -n  "{key:\"$1\"}" | $RPC content.checkpoint-get
 }
 
 ##

--- a/t/t0024-content-s3.t
+++ b/t/t0024-content-s3.t
@@ -2,6 +2,8 @@
 
 test_description='Test content-s3 backing store service'
 
+. `dirname $0`/content/content-helper.sh
+
 . `dirname $0`/sharness.sh
 
 if test -z "$S3_HOSTNAME"; then
@@ -59,15 +61,6 @@ recheck_cache_blob() {
 	local blobref=$($BLOBREF sha1 <blob.$1)
 	flux content load $blobref >blob.$1.cachecheck &&
 	test_cmp blob.$1 blob.$1.cachecheck
-}
-# Usage: checkpoint_put key rootref
-checkpoint_put() {
-        o="{key:\"$1\",value:{version:1,rootref:\"$2\",timestamp:2.2}}"
-        jq -j -c -n  ${o} | $RPC content.checkpoint-put
-}
-# Usage: checkpoint_get key >value
-checkpoint_get() {
-        jq -j -c -n  "{key:\"$1\"}" | $RPC content.checkpoint-get
 }
 
 ##


### PR DESCRIPTION
Per a discussion in #4492, there was a mistake in PR #4463 were non-rank 0 brokers did not forward checkpoint RPCs to rank 0.  Instead, they were forwarded to rank 0's backing module.  It has little effect / meaning before the work in #4492, but felt it wise to split it out into its own PR as it solves a specific thing.  I also put some of the work from #4492 into this PR, since it made sense.  Most notably, the movement of the content-checkpoint code out of `content-cache` and into its own `content-checkpoint` files.  

Also added a helper lib for the content tests, b/c I was getting irritated constantly modifying all three content tests all of the time.