### PR TITLE
fetch J instead of jobspec in the job shell, support flux job info --original jobspec

### DIFF
--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -105,6 +105,8 @@ flux_start_LDADD = \
 flux_job_LDADD = \
 	$(fluxcmd_ldadd) \
 	$(top_builddir)/src/shell/libmpir.la \
+	$(top_builddir)/src/common/libjob/libjob.la \
+	$(top_builddir)/src/common/libutil/libutil.la \
 	$(top_builddir)/src/common/libczmqcontainers/libczmqcontainers.la \
 	$(top_builddir)/src/common/libdebugged/libdebugged.la \
 	$(top_builddir)/src/common/libterminus/libterminus.la

--- a/src/common/libjob/Makefile.am
+++ b/src/common/libjob/Makefile.am
@@ -37,7 +37,9 @@ libjob_la_SOURCES = \
 	strtab.c \
 	strtab.h \
 	jj.c \
-	jj.h
+	jj.h \
+	unwrap.c \
+	unwrap.h
 
 TESTS = \
 	test_job.t \

--- a/src/common/libjob/Makefile.am
+++ b/src/common/libjob/Makefile.am
@@ -44,6 +44,7 @@ libjob_la_SOURCES = \
 TESTS = \
 	test_job.t \
 	test_sign_none.t \
+	test_unwrap.t \
 	test_jobspec1.t
 
 check_PROGRAMS = \
@@ -74,6 +75,10 @@ test_job_t_LDADD = $(test_ldadd)
 test_sign_none_t_SOURCES = test/sign_none.c
 test_sign_none_t_CPPFLAGS = $(test_cppflags)
 test_sign_none_t_LDADD = $(test_ldadd)
+
+test_unwrap_t_SOURCES = test/unwrap.c
+test_unwrap_t_CPPFLAGS = $(test_cppflags)
+test_unwrap_t_LDADD = $(test_ldadd)
 
 test_jobspec1_t_SOURCES = test/jobspec1.c
 test_jobspec1_t_CPPFLAGS = $(test_cppflags)

--- a/src/common/libjob/test/unwrap.c
+++ b/src/common/libjob/test/unwrap.c
@@ -1,0 +1,234 @@
+/************************************************************\
+ * Copyright 2022 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <flux/core.h>
+#if HAVE_FLUX_SECURITY
+#include <flux/security/sign.h>
+#endif
+
+#include "src/common/libtap/tap.h"
+#include "src/common/libjob/sign_none.h"
+#include "src/common/libjob/unwrap.h"
+
+typedef char * (*unwrap_f) (const char *s,
+                            bool verify,
+                            uint32_t *uidp,
+                            flux_error_t *error);
+
+static void test_api (unwrap_f unwrap)
+{
+    flux_error_t error;
+    uint32_t userid;
+    char *result;
+    char *s;
+
+    if (!(s = sign_none_wrap ("bar", 4, getuid ())))
+        BAIL_OUT ("sign_none_wrap failed");
+
+    userid = 0;
+    memset (error.text, 0, sizeof (error.text));
+    result = (*unwrap) (NULL, false, &userid, &error);
+    ok (result == NULL,
+        "unwrapp_string() fails with NULL argument");
+    ok (userid == 0,
+        "userid argument unmodified");
+    ok (strlen (error.text),
+        "error.text says: %s",
+        error.text);
+
+    userid = 0;
+    result = (*unwrap) (s, false, NULL, NULL);
+    ok (result != NULL && userid == 0,
+        "unwrap_string() works wih NULL userid and error paramters");
+    is (result, "bar",
+        "got expected result");
+    free (result);
+
+    userid = 0;
+    result = (*unwrap) (s, true, NULL, NULL);
+    ok (result != NULL && userid == 0,
+        "unwrap_string() works wih verify and NULL userid and error paramters");
+    is (result, "bar",
+        "got expected result");
+    free (result);
+    free (s);
+
+    if (!(s = sign_none_wrap ("bar", 4, getuid () - 1)))
+        BAIL_OUT ("sign_none_wrap failed");
+
+    userid = 0;
+    result = (*unwrap) (s, true, &userid, NULL);
+    ok (result == NULL,
+        "unwrap_string() fails with verify == true and errp == NULL");
+    free (result);
+
+    free (s);
+}
+
+/*  Test a good and bad payload (cribbed from test/sign_none.c)
+ */
+static void decode_bad_other (unwrap_f unwrap)
+{
+    const char *good = "dmVyc2lvbgBpMQB1c2VyaWQAaTEwMDAAbWVjaGFuaXNtAHNub25lAA==.Zm9vAA==.none";
+    /* invalid base64 payload (% character) */
+    const char *bad  = "dmVyc2lvbgBpMQB1c2VyaWQAaTEwMDAAbWVjaGFuaXNtAHNub25lAA==.%m9vAA==.none";
+
+    flux_error_t error;
+    uint32_t userid;
+    char *result;
+
+    /* Double check good input, the basis for bad input.
+     *  (do not verify since uid will not match)
+     */
+    result = (*unwrap) (good, false, &userid, &error);
+    ok (result != NULL,
+        "unwrap_string() works for good sign-none payload");
+    if (!result)
+        diag ("%s", error.text);
+    is (result, "foo",
+        "result is %s", result);
+    if (result)
+        free (result);
+
+    result = (*unwrap) (bad, false, &userid, &error);
+    ok (result == NULL,
+        "unwrap_string() fails on bad payload");
+    diag ("%s", error.text);
+    if (result)
+        free (result);
+}
+
+static void unwrap_sign_none (unwrap_f unwrap)
+{
+    flux_error_t error;
+    uint32_t userid;
+    char *s;
+    char *result;
+
+    if (!(s = sign_none_wrap ("bar", 4, 1000)))
+        BAIL_OUT ("sign_none_wrap failed");
+
+    userid = 0;
+    result = (*unwrap) (s, false, &userid, &error);
+    ok (result != NULL && userid == 1000,
+        "unwrap_string() after sign_none_wrap() works");
+    is (result, "bar",
+        "got expected result");
+    free (result);
+    free (s);
+
+
+    if (!(s = sign_none_wrap ("bar", 3, 1000)))
+        BAIL_OUT ("sign_none_wrap failed");
+    userid = 0;
+    result = (*unwrap) (s, false, &userid, &error);
+    ok (result != NULL && userid == 1000,
+        "unwrap_string() after sign_none_wrap() excluding NUL works");
+    is (result, "bar",
+        "got expected result");
+    free (result);
+    free (s);
+
+}
+
+#if HAVE_FLUX_SECURITY
+static void sign_security (void)
+{
+    flux_security_t *sec;
+    flux_error_t error;
+    uint32_t userid;
+    char *result;
+    const char *s;
+
+    if (!(sec = flux_security_create (0)))
+        BAIL_OUT ("error creating flux-security context");
+    if (flux_security_configure (sec, NULL) < 0)
+        BAIL_OUT ("error configuring flux-security");
+
+    s = flux_sign_wrap_as (sec, 1000, "foo", 4, "none", 0);
+    if (!s) {
+        BAIL_OUT ("flux_sign_wrap_as returned NULL: %s",
+                  flux_security_last_error (sec));
+    }
+
+    userid = 0;
+    result = unwrap_string (s, false, &userid, &error);
+    ok (result && userid == 1000,
+        "unwrap_string() from flux-security signer");
+    free (result);
+
+    /* valid userid */
+    if (!(s = flux_sign_wrap_as (sec, getuid (), "foo", 4, "none", 0)))
+        BAIL_OUT ("flux_sign_wrap_as returned NULL: %s",
+                  flux_security_last_error (sec));
+    userid = 0;
+    result = unwrap_string (s, true, &userid, &error);
+    ok (result && userid == getuid (),
+        "unwrap_string() with verify = true works");
+    free (result);
+
+    /* Invalid userid */
+    if (!(s = flux_sign_wrap_as (sec, getuid() - 1, "foo", 4, "none", 0)))
+        BAIL_OUT ("flux_sign_wrap_as returned NULL: %s",
+                  flux_security_last_error (sec));
+    userid = 0;
+    memset (error.text, 0, sizeof (error.text));
+    result = unwrap_string (s, true, &userid, &error);
+    ok (result == NULL,
+        "unwrap_string() with verify = true and incorrect userid fails");
+    ok (strlen (error.text),
+        "unwrap_string() expected error: %s",
+        error.text);
+    free (result);
+
+    /* Invalid userid (noverify) */
+    userid = 0;
+    memset (error.text, 0, sizeof (error.text));
+    result = unwrap_string (s, false, &userid, &error);
+    ok (result != NULL,
+        "unwrap_string() with verify = false and incorrect userid succeeds");
+    ok (userid == getuid() - 1,
+        "unwrap_string() returned userid used for signing");
+    ok (strlen (error.text) == 0,
+        "unwrap_string() error.text still empty");
+    free (result);
+
+
+    flux_security_destroy (sec);
+}
+#endif
+
+int main (int argc, char *argv[])
+{
+    plan (NO_PLAN);
+
+    test_api (unwrap_string);
+    test_api (unwrap_string_sign_none);
+
+    decode_bad_other (unwrap_string);
+    decode_bad_other (unwrap_string_sign_none);
+
+    unwrap_sign_none (unwrap_string);
+    unwrap_sign_none (unwrap_string_sign_none);
+#if HAVE_FLUX_SECURITY
+    sign_security ();
+#endif
+
+    done_testing ();
+    return 0;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libjob/unwrap.c
+++ b/src/common/libjob/unwrap.c
@@ -1,0 +1,116 @@
+/************************************************************\
+ * Copyright 2022 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <errno.h>
+#include <string.h>
+#include <stdint.h>
+#include <unistd.h>
+
+#if HAVE_FLUX_SECURITY
+#include <flux/security/context.h>
+#include <flux/security/sign.h>
+#endif
+
+#include "src/common/libutil/errprintf.h"
+
+#include "unwrap.h"
+#include "sign_none.h"
+
+char *unwrap_string_sign_none (const char *s,
+                               bool verify,
+                               uint32_t *userid,
+                               flux_error_t *errp)
+{
+    char *result = NULL;
+    int len;
+    uint32_t uid;
+    void *data = NULL;
+    if (sign_none_unwrap (s, (void **) &data, &len, &uid) < 0) {
+        errprintf (errp, "sign-none-unwrap failed: %s", strerror (errno));
+        return NULL;
+    }
+    if (verify && uid != getuid ()) {
+        errprintf (errp,
+                   "sign-none-unwrap: signing userid %lu != current %lu",
+                   (unsigned long) uid,
+                   (unsigned long) getuid ());
+        free (data);
+        return NULL;
+    }
+    /*  Add one extra byte to ensure NUL termination
+     */
+    if (!(result = calloc (1, len+1))) {
+        errprintf (errp, "Out of memory");
+        goto out;
+    }
+    memcpy (result, data, len);
+    if (userid)
+        *userid = uid;
+out:
+    free (data);
+    return result;
+}
+
+char *unwrap_string (const char *s,
+                     bool verify,
+                     uint32_t *userid,
+                     flux_error_t *errp)
+{
+#if HAVE_FLUX_SECURITY
+    flux_security_t *sec;
+    const void *data = NULL;
+    char *result = NULL;
+    int len;
+    const char *mech;
+    int64_t userid64;
+    int flags = verify ? 0 : FLUX_SIGN_NOVERIFY;
+
+    if (!(sec = flux_security_create (0))
+        || flux_security_configure (sec, NULL) < 0) {
+        errprintf (errp,
+                   "failed to initialize security context: %s",
+                   strerror (errno));
+        return NULL;
+    }
+    if (flux_sign_unwrap_anymech (sec,
+                                  s,
+                                  &data,
+                                  &len,
+                                  &mech,
+                                  &userid64,
+                                  flags) < 0) {
+        errprintf (errp, "%s", flux_security_last_error (sec));
+        goto done;
+    }
+    /*  Add one extra byte to ensure NUL termination in case NUL byte
+     *   not included in len:
+     */
+    if (!(result = calloc (1, len+1))) {
+        errprintf (errp, "Out of memory");
+        goto done;
+    }
+    memcpy (result, data, len);
+    if (userid)
+        *userid = (uint32_t) userid64;
+done:
+    flux_security_destroy (sec);
+    return result;
+#else
+    return unwrap_string_sign_none (s, verify, userid, errp);
+#endif /* !HAVE_FLUX_SECURITY */
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libjob/unwrap.h
+++ b/src/common/libjob/unwrap.h
@@ -1,0 +1,46 @@
+/************************************************************\
+ * Copyright 2022 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _UNWRAP_STRING
+#define _UNWRAP_STRING
+
+#include <flux/core.h>
+
+/*  Unwrap signed data to a NUL terminated string, e.g. J -> jobspec.
+ *
+ *  If verify is true, then fail if signing mechanism is invalid or
+ *   signing user does not match current uid. On failure, error.text
+ *   is filled in with an error message. (errno not necessarily
+ *   guaranteed to be valid).
+ *
+ *  Works when flux-core is built with or without flux-security
+ *
+ *  Caller must free returned value if non-NULL.
+ *
+ *  flux-core internal use only.
+ */
+char *unwrap_string (const char *in,
+                     bool verify,
+                     uint32_t *userid,
+                     flux_error_t *error);
+
+
+/*  As above but use version without flux-security (for testing only)
+ */
+char *unwrap_string_sign_none (const char *s,
+                               bool verify,
+                               uint32_t *userid,
+                               flux_error_t *errp);
+
+#endif /* !_UNWRAP_STRING */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/shell/Makefile.am
+++ b/src/shell/Makefile.am
@@ -90,6 +90,7 @@ flux_shell_SOURCES = \
 flux_shell_LDADD = \
 	$(builddir)/libshell.la \
 	$(builddir)/libmpir.la \
+	$(top_builddir)/src/common/libjob/libjob.la \
 	$(top_builddir)/src/common/librlist/librlist.la \
 	$(top_builddir)/src/bindings/lua/libfluxlua.la \
 	$(top_builddir)/src/common/libflux-core.la \

--- a/t/job-exec/dummy.sh
+++ b/t/job-exec/dummy.sh
@@ -46,7 +46,7 @@ declare -r JOBID=$1
 #  Fetch read-only job information and verify all values found:
 #
 declare -r BROKER_RANK=$(flux getattr rank)
-declare -r JOBSPEC=$(flux job info $JOBID jobspec)
+declare -r JOBSPEC=$(flux job info --original $JOBID jobspec)
 declare -r R=$(flux job info $JOBID R)
 
 for var in FLUX_KVS_NAMESPACE BROKER_RANK JOBSPEC R; do

--- a/t/job-exec/dummy.sh
+++ b/t/job-exec/dummy.sh
@@ -29,6 +29,7 @@
 #
 
 die() { echo "dummy-shell: $@" >&2; exit 1; }
+log() { echo "dummy-shell: $@" >&2; }
 
 #
 #  Declare globals:
@@ -103,6 +104,7 @@ get_command() {
 }
 
 get_traps() {
+    trap "/bin/echo got SIGTERM" 15
     TRAP=$(json_get "$JOBSPEC" '.attributes.system.environment.TRAP')
     if test "x$TRAP" != "xnull" ; then
         trap "/bin/echo got signal $TRAP" $TRAP
@@ -119,11 +121,11 @@ test_mock_failure() {
             #   is not a good way to ensure a separate shell process has
             #   reached the barrier.
             #
-            echo "Got FAIL_MODE=$FAIL_MODE"
+            log "Got FAIL_MODE=$FAIL_MODE"
             if test $JOB_SHELL_RANK -eq 0; then
                 sleep 1
             elif test $JOB_SHELL_RANK -eq 1; then
-                echo >&2 "before_barrier: exiting early on job shell rank 1"
+                log "before_barrier: exiting early on job shell rank 1"
                 exit 1
             fi
             ;;
@@ -135,9 +137,9 @@ test_mock_failure() {
             #
             echo "after_barrier_entry: rank=$JOB_SHELL_RANK"
             if test $JOB_SHELL_RANK -eq 1; then
-                echo "after_barrier: exiting early on job shell rank 1"
+                log "after_barrier: exiting early on job shell rank 1"
                 sleep 1
-                echo "exiting"
+                log "exiting"
                 exit 1
             fi
             ;;
@@ -175,7 +177,8 @@ barrier
 #
 #  Run specified COMMAND:
 #
-echo Running  "${COMMAND[@]}"
+log Running  "${COMMAND[@]}"
+flux kvs eventlog append exec.eventlog shell.start
 eval "${COMMAND[@]}"
 
 # vi: ts=4 sw=4 expandtab

--- a/t/job-exec/imp.sh
+++ b/t/job-exec/imp.sh
@@ -18,7 +18,7 @@ case "$cmd" in
         shift 3;
         printf "test-imp: Kill pid $pid signal $signal\n" >&2
         ps -fp $pid >&2
-        kill -$signal $pid ;;
+        kill -$signal -$pid ;;
     *)
         printf "test-imp: Fatal: Unknown cmd=$cmd\n" >&2; exit 1 ;;
 esac

--- a/t/t2230-job-info-lookup.t
+++ b/t/t2230-job-info-lookup.t
@@ -73,6 +73,12 @@ test_expect_success 'flux job info jobspec works' '
 	grep sleep jobspec_a.out
 '
 
+test_expect_success 'flux job info --original jobspec works' '
+	jobid=$(flux mini submit --env=ORIGINALTHING=t true) &&
+	flux job info --original $jobid jobspec > jobspec_original.out &&
+	grep ORIGINALTHING jobspec_original.out
+'
+
 test_expect_success 'flux job info jobspec fails on bad id' '
 	test_must_fail flux job info 12345 jobspec
 '


### PR DESCRIPTION
This PR is prepares some consumers of jobspec for the possibility that Flux instance may store redacted and/or modified jobspec in the "jobspec" KVS key.

First, a new `flux job info --original` option is added which, when used with the `jobspec` key, fetches and "unwraps" J into jobspec. If the jobspec in the KVS is redacted, this will be the only way to get the originally submitted jobspec.

Similarly, the job shell is modified to fetch and verify J instead of the jobspec from the job-info service.

In order to support decoding J into a jobspec string in two places, a new function `unwrap_string()` is added (to libjob since there didn't seem to be a better place) to avoid cut and pasting the code to unwrap signed data into a NUL terminated string (when built with or without flux-security).

Finally, some modifications and additions to the testsuite are made to test and adapt to these changes.