### PR TITLE
broker: log content store errors to LOG_CRIT

### DIFF
--- a/src/broker/content-cache.c
+++ b/src/broker/content-cache.c
@@ -505,7 +505,8 @@ static void cache_store_continuation (flux_future_t *f, void *arg)
             flux_log (cache->h, LOG_DEBUG, "content store: %s",
                       "backing store service unavailable");
         else
-            flux_log_error (cache->h, "content store");
+            flux_log (cache->h, LOG_CRIT, "content store: %s",
+                      strerror (errno));
         goto error;
     }
     if (hash_size != content_hash_size


### PR DESCRIPTION
Problem: In the event of content store errors, such as ENOSPC
if the disk is full, error messages are logged to LOG_ERR.  This
does not properly signify the severity of the error, as something
like ENOSPC would mean no data is being backed up to disk.

Solution: Log to LOG_CRIT, to signify the importance of this
issue and the need for it to be resolved.