### PR TITLE
kvs: support gc-threshold config 

### DIFF
--- a/doc/man1/flux-shutdown.rst
+++ b/doc/man1/flux-shutdown.rst
@@ -76,6 +76,12 @@ OPTIONS
    the dump, and the link is removed.  :linux:man8:`systemd-tmpfiles`
    automatically cleans up dump files in ``/var/lib/flux/dump`` after 30 days.
 
+**-y, --yes**
+   Answer yes to any yes/no questions.
+
+**-n, --no**
+   Answer no to any yes/no questions.
+
 
 RESOURCES
 =========
@@ -87,4 +93,4 @@ SEE ALSO
 ========
 
 :man1:`flux-start`, :man1:`flux-uptime`, :man1:`flux-uri`, :man1:`flux-dump`,
-:linux:man8:`systemd-tmpfiles`
+:man5:`flux-config-kvs`,:linux:man8:`systemd-tmpfiles`

--- a/doc/man5/flux-config-kvs.rst
+++ b/doc/man5/flux-config-kvs.rst
@@ -22,6 +22,13 @@ checkpoint-period
    primary namespace.  The checkpoint is used to protect against data
    loss in the event of a Flux broker crash.
 
+gc-threshold
+   (optional) Sets the number of KVS commits (distinct root snapshots)
+   after which offline garbage collection is performed by
+   :man1:`flux-shutdown`. A value of 100000 may be a good starting
+   point. (Default: garbage collection must be manually requested with
+   `flux-shutdown --gc`).
+
 
 EXAMPLE
 =======
@@ -30,7 +37,7 @@ EXAMPLE
 
    [kvs]
    checkpoint-period = "30m"
-
+   gc-threshold = 100000
 
 RESOURCES
 =========
@@ -43,4 +50,4 @@ RFC 23: Flux Standard Duration: https://flux-framework.readthedocs.io/projects/f
 SEE ALSO
 ========
 
-:man5:`flux-config`
+:man1:`flux-shutdown`,:man5:`flux-config`


### PR DESCRIPTION
Problem: KVS garbage collection is only done when an administrator runs flux-shutdown and chooses to garbage collect via the --dump or --gc options.

Solution: Support a kvs gc-threshold configuration option.  This configuration will take an integer count of KVS changes (the KVS version number or sequence number).  Once the threshold has been crossed, flux-shutdown will ask the user if they wish to garbage collect.  This offers an easy way for administrators to be reminded of garbage collection on a regular basis.

Fixes https://github.com/flux-framework/flux-core/issues/4311