### PR TITLE
shell: inherit FLUX_F58_FORCE_ASCII from job environment

### DIFF
--- a/t/t2602-job-shell.t
+++ b/t/t2602-job-shell.t
@@ -377,4 +377,13 @@ test_expect_success 'job-shell: -o nosetpgrp works' '
 	flux mini run -n2 -o nosetpgrp \
 	    flux python -c "import os,sys; sys.exit(os.getpid() == os.getpgrp())"
 '
+
+# Check that job shell inherits FLUX_F58_FORCE_ASCII.
+# If not, then output filename will not match jobid returned by submit,
+#  since one will be in UTF-8 and the other in ascii.
+test_expect_success 'job-shell: shell inherits FLUX_F58_FORCE_ASCII from job' '
+	FLUX_F58_FORCE_ASCII=t \
+		id=$(flux mini submit --wait --output={{id}}.out hostname) &&
+	test -f ${id}.out
+'
 test_done


### PR DESCRIPTION
As noted in #4540, setting `FLUX_F58_FORCE_ASCII=1` for a job does not change the encoding of a job output file with `{{id}}` in it. This is because the job shell isn't using the job environment, but the environment of the broker or the that created by the IMP (in multi-user mode).

This PR sets up the job shell to inherit a static list of environment variables from the job environment, starting with `FLUX_F58_FORCE_ASCII`.

Note that this can be fixed in current Flux versions by an addition to the shell `initrc.lua` or `lua.d` (see #4540 for the example). However, it seemed like some environment variables should always be inherited by the shell, so thus this PR.

Fixes #4540

