### PR TITLE
testsuite: fix non-bourne shell test failure

### DIFF
--- a/t/t2802-uri-cmd.t
+++ b/t/t2802-uri-cmd.t
@@ -162,7 +162,7 @@ test_expect_success 'setup fake csm_allocation_query for mock lsf testing' '
 	export FLUX_SSH=${SHARNESS_TEST_SRCDIR}/scripts/tssh
 '
 test_expect_success 'flux-uri mock testing of lsf resolver works' '
-	result=$(flux uri --local lsf:12345) &&
+	result=$(SHELL=/bin/sh flux uri --local lsf:12345) &&
 	test "$result" = "$FLUX_URI"
 '
 test_expect_success 'cleanup jobs' '


### PR DESCRIPTION
Problem: Test in t2802-uri-cmd failed because of quoting
issues with non-bourne shells.  Test was recently broken due to
change in:

testsuite: make sure test ssh runs $SHELL

c6a760ce61de5c3228d0a452a77b52eb0784558c

Solution: Set SHELL to /bin/sh in test.