### PR TITLE
cmd: add "per-resource" allocation options to flux-mini run and submit

### DIFF
--- a/doc/man1/flux-mini.rst
+++ b/doc/man1/flux-mini.rst
@@ -64,8 +64,34 @@ JOB PARAMETERS
 These commands accept only the simplest parameters for expressing
 the size of the parallel program and the geometry of its task slots:
 
-The **run** and **submit** commands take the following options to specify
-the size of the job request:
+Common resource options
+-----------------------
+
+All subcommands take the following common resource allocation options:
+
+**-N, --nodes=N**
+   Set the number of nodes to assign to the job. Tasks will be distributed
+   evenly across the allocated nodes, unless the per-resource options
+   (noted below) are used with *submit*, *run*, or *bulksubmit*. It is
+   an error to request more nodes than there are tasks. If unspecified,
+   the number of nodes will be chosen by the scheduler.
+
+**--exclusive**
+   Indicate to the scheduler that nodes should be exclusively allocated to
+   this job. It is an error to specify this option without also using
+   *-N, --nodes*. If *--nodes* is specified without *--nslots* or *--ntasks*,
+   then this option will be enabled by default and the number of tasks
+   or slots will be set to the number of requested nodes.
+
+
+Per-task options
+----------------
+
+The **run**, **submit** and **bulksubmit** commands take two sets
+of mutually exclusive options to specify the size of the job request.
+The most common form uses the total number of tasks to run along with
+the amount of resources required per task to specify the resources for
+the entire job:
 
 **-n, --ntasks=N**
    Set the number of tasks to launch (default 1).
@@ -75,6 +101,29 @@ the size of the job request:
 
 **-g, --gpus-per-task=N**
    Set the number of GPU devices to assign to each task (default none).
+
+Per-resource options
+--------------------
+
+The second set of options allows an amount of resources to be specified
+with the number of tasks per core or node set on the command line. It is
+an error to specify any of these options when using any per-task option
+listed above:
+
+**--cores=N**
+   Set the total number of cores.
+
+**--tasks-per-node=N**
+   Set the number of tasks per node to run.
+
+**--tasks-per-core=N**
+   Force a number of tasks per core.
+
+**--gpus-per-node=N**
+   With -N, --nodes, request a specific number of GPUs per node.
+
+Batch job options
+-----------------
 
 The **batch** and **alloc** commands do not launch tasks directly, and
 therefore job parameters are specified in terms of resource slot size
@@ -90,21 +139,11 @@ resources required for a virtual task. The default slot size is 1 core.
 **-g, --gpus-per-slot=N**
    Set the number of GPU devices to assign to each slot (default none).
 
+Additional job options
+----------------------
+
 The **run**, **submit**, **batch**, and **alloc** commands also take
 following additional job parameters:
-
-**-N, --nodes=N**
-   Set the number of nodes to assign to the job. Tasks will be distributed
-   evenly across the allocated nodes. It is an error to request more nodes
-   than there are tasks. If unspecified, the number of nodes will be chosen
-   by the scheduler.
-
-**--exclusive**
-   Indicate to the scheduler that nodes should be exclusively allocated to
-   this job. It is an error to specify this option without also using
-   *-N, --nodes*. If *--nodes* is specified without *--nslots* or *--ntasks*,
-   then this option will be enabled by default and the number of tasks
-   or slots will be set to the number of requested nodes.
 
 **-t, --time-limit=FSD**
    Set a time limit for the job in Flux standard duration (RFC 23).

--- a/src/bindings/python/flux/job/Jobspec.py
+++ b/src/bindings/python/flux/job/Jobspec.py
@@ -648,6 +648,124 @@ class JobspecV1(Jobspec):
             raise ValueError("attributes.system.duration must be a number")
 
     @classmethod
+    # pylint: disable=too-many-branches,too-many-locals,too-many-statements
+    def per_resource(
+        cls,
+        command,
+        ncores=None,
+        nnodes=None,
+        per_resource_type=None,
+        per_resource_count=None,
+        gpus_per_node=None,
+        exclusive=False,
+    ):
+        """
+        Factory function that builds a v1 jobspec from an explicit count
+        of nodes or cores and a number of tasks per one of these resources.
+
+        Use setters to assign additional properties.
+
+        Args:
+            ncores: Total number of cores to allocate
+            nnodes: Total number of nodes to allocate
+            per_resource_type: (optional) Type of resource over which to
+                               schedule a count of tasks. Only "node" or
+                               "core" are currently supported.
+            per_resource_count: (optional) Count of tasks per
+                                `per_resource_type`
+            gpus_per_node: With nnodes, request a number of gpus per node
+            exclusive: with nnodes, request whole nodes exclusively
+        """
+
+        #  Handle per-resource specification:
+        #  It is an error to specify one of per_resource_{type,count} and
+        #   not the other:
+        #
+        per_resource = None
+        if per_resource_type is not None and per_resource_count is not None:
+            if not isinstance(per_resource_type, str):
+                raise ValueError("per_resource_type must be a string")
+            if per_resource_type not in ("node", "core"):
+                raise ValueError(
+                    f"Invalid per_resource_type='{per_resource_type}' specified"
+                )
+            if not isinstance(per_resource_count, int):
+                raise ValueError("per_resource_count must be an integer")
+            if per_resource_count < 1:
+                raise ValueError("per_resource_count must be >= 1")
+
+            per_resource = {"type": per_resource_type, "count": per_resource_count}
+        elif per_resource_type is not None:
+            raise ValueError("must specify a per_resource_count with per_resource_type")
+        elif per_resource_count is not None:
+            raise ValueError("must specify a per_resource_type with per_resource_count")
+
+        if ncores is not None:
+            if not isinstance(ncores, int) or ncores < 1:
+                raise ValueError("ncores must be an integer >= 1")
+        if gpus_per_node is not None:
+            if not isinstance(gpus_per_node, int) or gpus_per_node < 0:
+                raise ValueError("gpus_per_node must be an integer >= 0")
+            if not nnodes:
+                raise ValueError("gpus_per_node must be specified with nnodes")
+        if nnodes is not None:
+            if not isinstance(nnodes, int) or nnodes < 1:
+                raise ValueError("nnodes must be an integer >= 1")
+        elif exclusive:
+            raise ValueError("exclusive can only be set with a node count")
+
+        nslots = None
+        slot_size = 1
+        if nnodes and ncores:
+            #  Request ncores across nnodes, actually running a given
+            #   number of tasks per node or core
+            if ncores < nnodes:
+                raise ValueError("number of cores cannot be less than nnodes")
+            if ncores % nnodes != 0:
+                raise ValueError(
+                    "number of cores must be evenly divisible by node count"
+                )
+            #
+            #  With nnodes, nslots is slots/node (total_slots=slots*nodes)
+            nslots = 1
+            slot_size = int(ncores / nnodes)
+        elif ncores:
+            #  Request ncores total, actually running a given
+            #   number of tasks per node or core
+            #
+            #  Without nnodes, nslots is total number of slots:
+            nslots = ncores
+            slot_size = 1
+        elif nnodes:
+            #  Request nnodes total with a given number of tasks per node
+            #   or per core. (requires exclusive)
+            if not exclusive:
+                raise ValueError(
+                    "Specifying nnodes also requires ncores or exclusive",
+                )
+            #  With nnodes, nslots is slots/node (total_slots=slots*nodes)
+            nslots = 1
+            slot_size = 1
+
+        children = [cls._create_resource("core", slot_size)]
+        if gpus_per_node:
+            children.append(cls._create_resource("gpu", gpus_per_node))
+
+        slot = cls._create_slot("task", nslots, children)
+
+        if nnodes:
+            resources = cls._create_resource("node", nnodes, [slot], exclusive)
+        else:
+            resources = slot
+
+        resources = [resources]
+        tasks = [{"command": command, "slot": "task", "count": {"per_slot": 1}}]
+        attributes = {"system": {"duration": 0}}
+        if per_resource:
+            set_treedict(attributes, "system.shell.options.per-resource", per_resource)
+        return cls(resources, tasks, attributes=attributes)
+
+    @classmethod
     # pylint: disable=too-many-branches
     def from_command(
         cls,

--- a/src/cmd/flux-mini.py
+++ b/src/cmd/flux-mini.py
@@ -721,32 +721,38 @@ class SubmitBaseCmd(MiniCmd):
 
     def __init__(self):
         super().__init__()
-        self.parser.add_argument(
+        group = self.parser.add_argument_group("Common resource options")
+        group.add_argument(
             "-N", "--nodes", metavar="N", help="Number of nodes to allocate"
         )
-        self.parser.add_argument(
+        group.add_argument(
+            "--exclusive",
+            action="store_true",
+            help="With -N, --nodes, allocate nodes exclusively",
+        )
+        group = self.parser.add_argument_group(
+            "Per task options",
+            "The following options allow per-task specification of resources, "
+            + "and should not be combined with per-resource options.",
+        )
+        group.add_argument(
             "-n",
             "--ntasks",
             metavar="N",
             help="Number of tasks to start",
         )
-        self.parser.add_argument(
+        group.add_argument(
             "-c",
             "--cores-per-task",
             metavar="N",
             default=1,
             help="Number of cores to allocate per task",
         )
-        self.parser.add_argument(
+        group.add_argument(
             "-g",
             "--gpus-per-task",
             metavar="N",
             help="Number of GPUs to allocate per task",
-        )
-        self.parser.add_argument(
-            "--exclusive",
-            action="store_true",
-            help="With -N, --nodes, allocate nodes exclusively",
         )
         self.parser.add_argument(
             "-v",

--- a/src/cmd/flux-mini.py
+++ b/src/cmd/flux-mini.py
@@ -452,7 +452,7 @@ class MiniCmd:
         """
         Create default parser with args for mini subcommands
         """
-        parser = argparse.ArgumentParser(add_help=False)
+        parser = argparse.ArgumentParser(add_help=False, allow_abbrev=False)
         parser.add_argument(
             "-t",
             "--time-limit",


### PR DESCRIPTION
This is a request for comments PR (and a WIP) since I'm not sure if this will be an acceptable way to solve #4533. I first made an attempt to add `--tasks-per-node` support to the base `flux mini run,submit` commands and `JobspecV1.from_command()`, but I fear "that way madness lies" and I eventually gave up. Trying to get consistent and expected behavior when trying to mix the existing `--ntasks`, `--nodes`, `--cores-per-task` and new `--tasks-per-node` and `--cores` options was too much for me.

Instead, the approach taken here is to add a new `JobspecV1.per_node()` constructor:
```python
    def per_node(
        cls,
        command,
        ncores=None,
        nnodes=None,
        tasks_per_node=None,
        tasks_per_core=None,
        gpus_per_node=None,
        exclusive=False,
    ):
        """
        Factory function that builds a v1 jobspec from an explicit count
        of nodes or cores and a number of tasks per one of these resources.

        Use setters to assign additional properties.

        Args:
            ncores: Total number of cores to allocate
            nnodes: Total number of nodes to allocate
            tasks_per_node: Force the number of tasks per node
            tasks_per_core: Force > 1 tasks per core
            gpus_per_node: With nnodes, request a number of gpus per node
            exclusive: with nnodes, request whole nodes exclusively
        """
```

This function uses the shell `per-resource` option to satisfy the user request in most cases, but note that it bails out instead of trying to solve many corner cases, since it seemed best at this time to solve only the obvious cases for now.

If any of the new options `--cores`, `--tasks-per-node`, `--tasks-per-core`, `--gpus-per-node` are used, then `flux mini run` and `flux mini submit` use `JobspecV1.per_node()` to construct the jobspec, instead of `JobspecV1.from_command()`. These new options are split off in the `--help` now to make it clear they operate in a different "mode":
```
Common resource options:
  -N, --nodes=N             Number of nodes to allocate
      --exclusive           With -N, --nodes, allocate nodes exclusively

Per task options:
  The following options allow per-task specification of resources, and
  should not be combined with per-resource options.

  -n, --ntasks=N            Number of tasks to start
  -c, --cores-per-task=N    Number of cores to allocate per task
  -g, --gpus-per-task=N     Number of GPUs to allocate per task

Per resource options:
  The following options allow per-resource specification of tasks, and
  should not be used with per-task options above

      --cores=N             Request a total number of cores
      --tasks-per-node=N    Force number of tasks per node
      --tasks-per-core=N    Force number of tasks per core
      --gpus-per-node=N     Request a number of GPUs per node. Only with
                            --nnodes, --tasks-per-node
```

This allows us to avoid changing the `from_command()` implementation, and only invoke the new behavior when the new command options are used. This should make maintenance of the two "modes" a little easier going forward.

This satisfies the use case of explicitly specify a number of tasks per node without specifying the exact number of total nodes, while also allowing some other cases (like oversubscribing tasks to cores), however, it seems like it might be a dangerous step extending our "minimal" interface in this way. However, I'm unsure how to do a better job at this time. Thus, before I go any further adding more testing and documentation, I'm pausing to get some feedback.
