### PR TITLE
WIP: broker: add ability to mmap files into content cache

### DIFF
--- a/src/broker/Makefile.am
+++ b/src/broker/Makefile.am
@@ -42,6 +42,8 @@ libbroker_la_SOURCES = \
 	content-cache.c \
 	content-checkpoint.h \
 	content-checkpoint.c \
+	content-mmap.h \
+	content-mmap.c \
 	runat.h \
 	runat.c \
 	state_machine.h \

--- a/src/broker/content-cache.c
+++ b/src/broker/content-cache.c
@@ -420,8 +420,6 @@ void content_load_request (flux_t *h, flux_msg_handler_t *mh,
     struct content_cache *cache = arg;
     const void *hash;
     int hash_size;
-    void *data = NULL;
-    int len = 0;
     struct cache_entry *e;
 
     if (flux_request_decode_raw (msg, NULL, &hash, &hash_size) < 0)
@@ -449,9 +447,7 @@ void content_load_request (flux_t *h, flux_msg_handler_t *mh,
         }
         return; /* RPC continuation will respond to msg */
     }
-    data = e->data;
-    len = e->len;
-    if (flux_respond_raw (h, msg, data, len) < 0)
+    if (flux_respond_raw (h, msg, e->data, e->len) < 0)
         flux_log_error (h, "content load: flux_respond_raw");
     return;
 error:

--- a/src/broker/content-cache.c
+++ b/src/broker/content-cache.c
@@ -67,6 +67,7 @@ struct cache_entry {
     uint8_t valid:1;                // entry contains valid data
     uint8_t dirty:1;                // entry needs to be stored upstream
                                     //   or to backing store (rank 0)
+    uint8_t ephemeral:1;            // clean entry is not on backing store
     uint8_t load_pending:1;
     uint8_t store_pending:1;
     struct msgstack *load_requests;
@@ -146,14 +147,20 @@ static void msgstack_destroy (struct msgstack **msp)
  */
 static void request_list_respond_raw (struct msgstack **l,
                                       flux_t *h,
+                                      bool user1_flag,
                                       const void *data,
                                       int len,
                                       const char *type)
 {
     const flux_msg_t *msg;
     while ((msg = msgstack_pop (l))) {
-        if (flux_respond_raw (h, msg, data, len) < 0)
+        flux_msg_t *response;
+        if (!(response = flux_response_derive (msg, 0))
+            || flux_msg_set_payload (response, data, len) < 0
+            || (user1_flag && flux_msg_set_user1 (response) < 0)
+            || flux_send (h, response, 0) < 0)
             flux_log_error (h, "%s (%s):", __FUNCTION__, type);
+        flux_msg_decref (response);
         flux_msg_decref (msg);
     }
 }
@@ -239,6 +246,7 @@ static void cache_entry_dirty_clear (struct content_cache *cache,
 
         request_list_respond_raw (&e->store_requests,
                                   cache->h,
+                                  false,
                                   e->hash,
                                   content_hash_size,
                                   "store");
@@ -348,12 +356,15 @@ static void cache_load_continuation (flux_future_t *f, void *arg)
         }
         e->data_container = (void *)flux_msg_incref (msg);
         e->valid = 1;
+        if (flux_msg_is_user1 (msg))
+            e->ephemeral = 1;
         cache->acct_valid++;
         cache->acct_size += e->len;
         list_add (&cache->lru, &e->list);
         e->lastused = flux_reactor_now (cache->reactor);
         request_list_respond_raw (&e->load_requests,
                                   cache->h,
+                                  e->ephemeral ? true : 0, // FLUX_MSGFLAG_USER1
                                   e->data,
                                   e->len,
                                   "load");
@@ -423,8 +434,18 @@ static void content_load_request (flux_t *h, flux_msg_handler_t *mh,
         }
         return; /* RPC continuation will respond to msg */
     }
-    if (flux_respond_raw (h, msg, e->data, e->len) < 0)
-        flux_log_error (h, "content load: flux_respond_raw");
+
+    /* Send load response with FLUX_MSGFLAG_USER1 representing the
+     * ephemeral flag, if set.
+     */
+    flux_msg_t *response;
+    if (!(response = flux_response_derive (msg, 0))
+        || flux_msg_set_payload (response, e->data, e->len) < 0
+        || (e->ephemeral && flux_msg_set_user1 (response) < 0)
+        || flux_send (h, response, 0) < 0) {
+        flux_log_error (h, "content load: error sending response");
+    }
+    flux_msg_decref (response);
     return;
 error:
     if (flux_respond_error (h, msg, errno, NULL) < 0)
@@ -583,9 +604,19 @@ static void content_store_request (flux_t *h, flux_msg_handler_t *mh,
         cache->acct_dirty++;
         request_list_respond_raw (&e->load_requests,
                                   cache->h,
+                                  false,
                                   e->data,
                                   e->len,
                                   "load");
+    }
+    /* If existing, valid entry has the ephemeral bit set, then make it dirty
+     * so the entry reaches the backing store.
+     */
+    else {
+        if (e->ephemeral) {
+            e->ephemeral = 0;
+            e->dirty = 1;
+        }
     }
     if (e->dirty) {
         if (cache->rank > 0 || cache->backing) {
@@ -781,6 +812,7 @@ static void flush_respond (struct content_cache *cache)
     if (!cache->acct_dirty) {
         request_list_respond_raw (&cache->flush_requests,
                                   cache->h,
+                                  false,
                                   NULL,
                                   0,
                                   "flush");

--- a/src/broker/content-cache.c
+++ b/src/broker/content-cache.c
@@ -414,8 +414,8 @@ static int cache_load (struct content_cache *cache, struct cache_entry *e)
     return 0;
 }
 
-void content_load_request (flux_t *h, flux_msg_handler_t *mh,
-                           const flux_msg_t *msg, void *arg)
+static void content_load_request (flux_t *h, flux_msg_handler_t *mh,
+                                  const flux_msg_t *msg, void *arg)
 {
     struct content_cache *cache = arg;
     const void *hash;

--- a/src/broker/content-cache.c
+++ b/src/broker/content-cache.c
@@ -28,6 +28,7 @@
 #include "attr.h"
 #include "content-cache.h"
 #include "content-checkpoint.h"
+#include "content-mmap.h"
 
 /* A periodic callback purges the cache of least recently used entries.
  * The callback is synchronized with the instance heartbeat, with a
@@ -70,6 +71,7 @@ struct cache_entry {
     uint8_t ephemeral:1;            // clean entry is not on backing store
     uint8_t load_pending:1;
     uint8_t store_pending:1;
+    uint8_t mmapped:1;
     struct msgstack *load_requests;
     struct msgstack *store_requests;
     double lastused;
@@ -104,6 +106,7 @@ struct content_cache {
     uint32_t acct_dirty;            // count of dirty cache entries
 
     struct content_checkpoint *checkpoint;
+    struct content_mmap *mmap;
 };
 
 static void flush_respond (struct content_cache *cache);
@@ -189,7 +192,10 @@ static void cache_entry_destroy (struct cache_entry *e)
         int saved_errno = errno;
         assert (e->load_requests == NULL);
         assert (e->store_requests == NULL);
-        flux_msg_decref (e->data_container);
+        if (e->mmapped)
+            content_mmap_region_decref (e->data_container);
+        else
+            flux_msg_decref (e->data_container);
         free (e);
         errno = saved_errno;
     }
@@ -416,13 +422,36 @@ static void content_load_request (flux_t *h, flux_msg_handler_t *mh,
         goto error;
     }
     if (!(e = cache_entry_lookup (cache, hash, hash_size))) {
-        if (cache->rank == 0 && !cache->backing) {
-            errno = ENOENT;
-            goto error;
+        struct content_region *region = NULL;
+        const void *data = NULL;
+        int len = 0;
+
+        if (cache->rank == 0) {
+            region = content_mmap_region_lookup (cache->mmap,
+                                                 hash,
+                                                 hash_size,
+                                                 &data,
+                                                 &len);
+            if (!region && !cache->backing) {
+                errno = ENOENT;
+                goto error;
+            }
         }
         if (!(e = cache_entry_insert (cache, hash, hash_size))) {
             flux_log_error (h, "content load");
             goto error;
+        }
+        if (region) {
+            e->data_container = content_mmap_region_incref (region);
+            e->data = data;
+            e->len = len;
+            e->valid = 1;
+            e->ephemeral = 1;
+            e->mmapped = 1;
+            cache->acct_valid++;
+            cache->acct_size += e->len;
+            list_add (&cache->lru, &e->list);
+            e->lastused = flux_reactor_now (cache->reactor);
         }
     }
     if (!e->valid) {
@@ -610,12 +639,15 @@ static void content_store_request (flux_t *h, flux_msg_handler_t *mh,
                                   "load");
     }
     /* If existing, valid entry has the ephemeral bit set, then make it dirty
-     * so the entry reaches the backing store.
+     * so the entry reaches the backing store.  Remove from the LRU since
+     * entries in that list must not be dirty.
      */
     else {
         if (e->ephemeral) {
             e->ephemeral = 0;
             e->dirty = 1;
+            list_del (&e->list);
+            cache->acct_dirty++;
         }
     }
     if (e->dirty) {
@@ -1031,6 +1063,7 @@ void content_cache_destroy (struct content_cache *cache)
         zhashx_destroy (&cache->entries);
         msgstack_destroy (&cache->flush_requests);
         content_checkpoint_destroy (cache->checkpoint);
+        content_mmap_destroy (cache->mmap);
         free (cache);
         errno = saved_errno;
     }
@@ -1073,7 +1106,12 @@ struct content_cache *content_cache_create (flux_t *h, attr_t *attrs)
 
     if (!(cache->checkpoint = content_checkpoint_create (h, cache->rank, cache)))
         goto error;
-
+    if (cache->rank == 0) {
+        if (!(cache->mmap = content_mmap_create (h,
+                                                 cache->hash_name,
+                                                 content_hash_size)))
+            goto error;
+    }
     if (flux_msg_handler_addvec (h, htab, cache, &cache->handlers) < 0)
         goto error;
     if (!(cache->f_sync = flux_sync_create (h, 0))

--- a/src/broker/content-checkpoint.c
+++ b/src/broker/content-checkpoint.c
@@ -1,5 +1,5 @@
 /************************************************************\
- * Copyright 2015 Lawrence Livermore National Security, LLC
+ * Copyright 2022 Lawrence Livermore National Security, LLC
  * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
  *
  * This file is part of the Flux resource manager framework.

--- a/src/broker/content-checkpoint.h
+++ b/src/broker/content-checkpoint.h
@@ -1,5 +1,5 @@
 /************************************************************\
- * Copyright 2015 Lawrence Livermore National Security, LLC
+ * Copyright 2022 Lawrence Livermore National Security, LLC
  * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
  *
  * This file is part of the Flux resource manager framework.

--- a/src/broker/content-mmap.c
+++ b/src/broker/content-mmap.c
@@ -1,0 +1,355 @@
+/************************************************************\
+ * Copyright 2022 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* content-mmap.c - map files into content cache
+ *
+ * Purpose: leverage the hierarchical content cache for file broadcast.
+ *
+ * Before sending a load request to the backing store, the content cache on
+ * rank 0 checks here to see if a blob can be pulled in from a mmapped file.
+ *
+ * A request to mmap a file returns an array of blobrefs which must be passed
+ * to readers out of band.  Those blobs may be read through the cache to
+ * reconstitute the original file at any broker, scalably.
+ *
+ * The file may be unmapped explicitly with a content.munmap request, or if the
+ * "sticky" bit is was not set on the map request, may be unmapped when the
+ * requestor disconnects.  The actual munmap(2) occurs once all blobs'
+ * reference counts reach zero, indicating that any blobs in the rank 0 cache
+ * that reference the mmapped region have been dropped from the cache.
+ *
+ * N.B. mmapped blobs are not written to the backing store; however, if a
+ * blob is stored with the same hash as a mmapped blob, the blob then becomes
+ * dirty in the cache and propagates to the backing store.  To facilitate this,
+ * mmapped blobs are tracked in the cache with a special 'ephemeral' bit.
+ */
+
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <sys/mman.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <limits.h>
+#include <stdlib.h>
+#include <jansson.h>
+#include <assert.h>
+#include <flux/core.h>
+
+#include "src/common/libczmqcontainers/czmq_containers.h"
+#include "src/common/libutil/errno_safe.h"
+#include "src/common/libutil/blobref.h"
+#include "ccan/ptrint/ptrint.h"
+
+#include "content-mmap.h"
+
+struct content_region {
+    char *path;
+    void *data;
+    off_t data_size;
+    int refcount;
+    int blob_size;
+    int blob_count;
+    void **hashes;
+    zhashx_t *fast_lookup; // hash digest -> blob index (origin=1)
+    struct content_mmap *mm;
+};
+
+struct content_mmap {
+    flux_t *h;
+    char *hash_name;
+    flux_msg_handler_t **handlers;
+    zhashx_t *regions;
+};
+
+#ifndef MIN
+#define MIN(a,b) ((a)<(b)?(a):(b))
+#endif
+
+static int content_hash_size;
+
+static size_t fast_lookup_hasher (const void *key)
+{
+    return *(size_t *)key;
+}
+static int fast_lookup_comparator (const void *item1, const void *item2)
+{
+    return memcmp (item1, item2, content_hash_size);
+}
+
+void content_mmap_region_decref (struct content_region *reg)
+{
+    if (reg && --reg->refcount == 0) {
+        int saved_errno = errno;
+        if (reg->data != MAP_FAILED)
+            (void)munmap (reg->data, reg->data_size);
+        zhashx_destroy (&reg->fast_lookup);
+        free (reg->path);
+        free (reg);
+        errno = saved_errno;
+    }
+}
+
+// zhashx_destructor_fn footprint
+static void content_mmap_region_destructor (void **item)
+{
+    if (item) {
+        content_mmap_region_decref (*item);
+        *item = NULL;
+    }
+}
+
+struct content_region *content_mmap_region_incref (struct content_region *reg)
+{
+    if (reg)
+        reg->refcount++;
+    return reg;
+}
+
+struct content_region *content_mmap_region_lookup (struct content_mmap *mm,
+                                                   const void *hash,
+                                                   int hash_len,
+                                                   const void **data,
+                                                   int *data_len)
+{
+    struct content_region *reg;
+
+    assert (content_hash_size == hash_len);
+    reg = zhashx_first (mm->regions);
+    while (reg) {
+        void *result;
+        if ((result = zhashx_lookup (reg->fast_lookup, hash))) {
+            off_t i = ptr2int (result) - 1;
+            *data = (char *)reg->data + i*reg->blob_size;
+            *data_len = MIN (reg->blob_size,
+                             reg->data_size - i*reg->blob_size);
+            return reg;
+        }
+        reg = zhashx_next (mm->regions);
+    }
+    return NULL;
+}
+
+static struct content_region *content_region_create (struct content_mmap *mm,
+                                                     const char *path,
+                                                     int blob_size)
+{
+    struct content_region *reg = NULL;
+    int fd;
+    struct stat sb;
+    int blob_count;
+
+    if ((fd = open (path, O_RDONLY)) < 0
+        || fstat (fd, &sb) < 0)
+        goto error;
+    if (sb.st_size == 0) {
+        errno = EINVAL;
+        goto error;
+    }
+    blob_count = sb.st_size / blob_size;
+    if (sb.st_size % blob_size > 0)
+        blob_count++;
+
+    if (!(reg = calloc (1, sizeof (*reg) + (blob_count * content_hash_size))))
+        goto error;
+    reg->refcount = 1;
+    reg->mm = mm;
+    reg->hashes = (void **)(reg + 1);
+    reg->blob_count = blob_count;
+    reg->blob_size = blob_size;
+    reg->data_size = sb.st_size;
+    reg->data = mmap (NULL, reg->data_size, PROT_READ, MAP_PRIVATE, fd, 0);
+    if (reg->data == MAP_FAILED)
+        goto error;
+    if (!(reg->fast_lookup = zhashx_new ()))
+        goto error;
+    zhashx_set_key_hasher (reg->fast_lookup, fast_lookup_hasher);
+    zhashx_set_key_comparator (reg->fast_lookup, fast_lookup_comparator);
+    zhashx_set_key_duplicator (reg->fast_lookup, NULL);
+    zhashx_set_key_destructor (reg->fast_lookup, NULL);
+    for (off_t i = 0; i < blob_count; i++) {
+        if (blobref_hash_raw (mm->hash_name,
+                              (char *)reg->data + i*blob_size,
+                              MIN (blob_size, reg->data_size - i*blob_size),
+                              (char *)reg->hashes + i*content_hash_size,
+                              content_hash_size) < 0)
+            goto error;
+        // ignore EEXIST
+        (void)zhashx_insert (reg->fast_lookup,
+                             (char *)reg->hashes + i*content_hash_size,
+                             int2ptr (i + 1));
+    }
+    if (!(reg->path = strdup (path)))
+        goto error;
+    close (fd);
+    return reg;
+error:
+    ERRNO_SAFE_WRAP (close, fd);
+    content_mmap_region_decref (reg);
+    return NULL;
+}
+
+static json_t *get_blobrefs (struct content_region *reg)
+{
+    struct content_mmap *mm = reg->mm;
+    json_t *array;
+    json_t *o;
+    char blobref[BLOBREF_MAX_STRING_SIZE];
+
+    if (!(array = json_array ()))
+        goto nomem;
+    for (int i = 0; i < reg->blob_count; i++) {
+        if (blobref_hashtostr (mm->hash_name,
+                               (char *)reg->hashes + i*content_hash_size,
+                               content_hash_size,
+                               blobref,
+                               sizeof (blobref)) < 0)
+            goto error;
+        if (!(o = json_string (blobref))
+            || json_array_append_new (array, o) < 0) {
+            json_decref (o);
+            goto nomem;
+        }
+    }
+    return array;
+nomem:
+    errno = ENOMEM;
+error:
+    ERRNO_SAFE_WRAP (json_decref, array);
+    return NULL;
+}
+
+static void content_mmap_cb (flux_t *h,
+                             flux_msg_handler_t *mh,
+                             const flux_msg_t *msg,
+                             void *arg)
+{
+    struct content_mmap *mm = arg;
+    const char *path;
+    int blob_size;
+    struct content_region *reg;
+    const char *errmsg = NULL;
+    json_t *blobrefs;
+
+    if (flux_request_unpack (msg,
+                             NULL,
+                             "{s:s s:i}",
+                             "path", &path,
+                             "blobsize", &blob_size) < 0)
+        goto error;
+    if (blob_size < 1) {
+        errno = EINVAL;
+        errmsg = "blob size must be > 0";
+        goto error;
+    }
+    if (!(reg = content_region_create (mm, path, blob_size)))
+        goto error;
+    if (zhashx_insert (mm->regions, reg->path, reg) < 0) {
+        content_mmap_region_decref (reg);
+        errno = EEXIST;
+        errmsg = "file is already mapped";
+        goto error;
+    }
+    if (!(blobrefs = get_blobrefs (reg)))
+        goto error;
+    if (flux_respond_pack (h, msg, "{s:O}", "blobrefs", blobrefs) < 0)
+        flux_log_error (h, "error responding to content.mmap request");
+    json_decref (blobrefs);
+    return;
+error:
+    if (flux_respond_error (h, msg, errno, errmsg) < 0)
+        flux_log_error (h, "error responding to content.mmap request");
+}
+
+static void content_munmap_cb (flux_t *h,
+                               flux_msg_handler_t *mh,
+                               const flux_msg_t *msg,
+                               void *arg)
+{
+    struct content_mmap *mm = arg;
+    const char *path;
+
+    if (flux_request_unpack (msg,
+                             NULL,
+                             "{s:s}",
+                             "path", &path) < 0)
+        goto error;
+    if (zhashx_lookup (mm->regions, path) < 0) {
+        errno = ENOENT;
+        goto error;
+    }
+    zhashx_delete (mm->regions, path);
+    if (flux_respond (h, msg, NULL) < 0)
+        flux_log_error (h, "error responding to content.munmap request");
+    return;
+error:
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "error responding to content.munmap request");
+}
+
+static const struct flux_msg_handler_spec htab[] = {
+    {
+        FLUX_MSGTYPE_REQUEST,
+        "content.mmap",
+        content_mmap_cb,
+        0
+    },
+    {
+        FLUX_MSGTYPE_REQUEST,
+        "content.munmap",
+        content_munmap_cb,
+        0
+    },
+    FLUX_MSGHANDLER_TABLE_END,
+};
+
+void content_mmap_destroy (struct content_mmap *mm)
+{
+    if (mm) {
+        int saved_errno = errno;
+        flux_msg_handler_delvec (mm->handlers);
+        zhashx_destroy (&mm->regions);
+        free (mm->hash_name);
+        free (mm);
+        errno = saved_errno;
+    }
+}
+
+struct content_mmap *content_mmap_create (flux_t *h,
+                                          const char *hash_name,
+                                          int hash_size)
+{
+    struct content_mmap *mm;
+
+    if (!(mm = calloc (1, sizeof (*mm))))
+        return NULL;
+    if (!(mm->hash_name = strdup (hash_name)))
+        goto error;
+    content_hash_size = hash_size;
+    mm->h = h;
+    if (flux_msg_handler_addvec (h, htab, mm, &mm->handlers) < 0)
+        goto error;
+    if (!(mm->regions = zhashx_new ())) {
+        errno = ENOMEM;
+        goto error;
+    }
+    zhashx_set_destructor (mm->regions, content_mmap_region_destructor);
+    zhashx_set_key_destructor (mm->regions, NULL);
+    zhashx_set_key_duplicator (mm->regions, NULL);
+    return mm;
+error:
+    content_mmap_destroy (mm);
+    return NULL;
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/src/broker/content-mmap.h
+++ b/src/broker/content-mmap.h
@@ -1,0 +1,32 @@
+/************************************************************\
+ * Copyright 2022 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef BROKER_CONTENT_MMAP_H
+#define BROKER_CONTENT_MMAP_H 1
+
+#include "content-cache.h"
+
+struct content_mmap *content_mmap_create (flux_t *h,
+                                          const char *hash_name,
+                                          int hash_size);
+void content_mmap_destroy (struct content_mmap *mm);
+
+struct content_region *content_mmap_region_lookup (struct content_mmap *mm,
+                                                   const void *hash,
+                                                   int hash_len,
+                                                   const void **data,
+                                                   int *data_len);
+
+void content_mmap_region_decref (struct content_region *reg);
+struct content_region *content_mmap_region_incref (struct content_region *reg);
+
+#endif /* !BROKER_CONTENT_MMAP_H */
+
+// vi:ts=4 sw=4 expandtab

--- a/src/common/libflux/message.c
+++ b/src/common/libflux/message.c
@@ -353,7 +353,7 @@ int flux_msg_set_flags (flux_msg_t *msg, uint8_t flags)
     const uint8_t valid_flags = FLUX_MSGFLAG_TOPIC | FLUX_MSGFLAG_PAYLOAD
                               | FLUX_MSGFLAG_ROUTE | FLUX_MSGFLAG_UPSTREAM
                               | FLUX_MSGFLAG_PRIVATE | FLUX_MSGFLAG_STREAMING
-                              | FLUX_MSGFLAG_NORESPONSE;
+                              | FLUX_MSGFLAG_NORESPONSE | FLUX_MSGFLAG_USER1;
 
     if (msg_validate (msg) < 0)
         return -1;
@@ -427,6 +427,23 @@ bool flux_msg_is_noresponse (const flux_msg_t *msg)
         return true;
     return (msg->flags & FLUX_MSGFLAG_NORESPONSE) ? true : false;
 }
+
+int flux_msg_set_user1 (flux_msg_t *msg)
+{
+    if (msg_validate (msg) < 0)
+        return -1;
+    if (flux_msg_set_flags (msg, msg->flags | FLUX_MSGFLAG_USER1) < 0)
+        return -1;
+    return 0;
+}
+
+bool flux_msg_is_user1 (const flux_msg_t *msg)
+{
+    if (msg_validate (msg) < 0)
+        return false;
+    return (msg->flags & FLUX_MSGFLAG_USER1) ? true : false;
+}
+
 
 int flux_msg_set_userid (flux_msg_t *msg, uint32_t userid)
 {

--- a/src/common/libflux/message.h
+++ b/src/common/libflux/message.h
@@ -41,6 +41,7 @@ enum {
     FLUX_MSGFLAG_UPSTREAM   = 0x10, /* request nodeid is sender (route away) */
     FLUX_MSGFLAG_PRIVATE    = 0x20, /* private to instance owner and sender */
     FLUX_MSGFLAG_STREAMING  = 0x40, /* request/response is streaming RPC */
+    FLUX_MSGFLAG_USER1      = 0x80, /* user-defined message flag */
 };
 
 /* N.B. FLUX_NODEID_UPSTREAM should be used in the RPC interface only.
@@ -156,6 +157,11 @@ bool flux_msg_is_streaming (const flux_msg_t *msg);
  */
 int flux_msg_set_noresponse (flux_msg_t *msg);
 bool flux_msg_is_noresponse (const flux_msg_t *msg);
+
+/* Get/set USER1 flag.
+ */
+int flux_msg_set_user1 (flux_msg_t *msg);
+bool flux_msg_is_user1 (const flux_msg_t *msg);
 
 /* Get/set/compare message topic string.
  * set adds/deletes/replaces topic frame as needed.

--- a/src/common/libflux/test/message.c
+++ b/src/common/libflux/test/message.c
@@ -295,6 +295,11 @@ void check_cornercase (void)
     ok ((flux_msg_route_string (msg) == NULL && errno == EPROTO),
         "flux_msg_route_string returns NULL errno EPROTO on msg "
         "w/o routes enabled");
+    errno = 0;
+    ok (flux_msg_set_user1 (NULL) < 0 && errno == EINVAL,
+        "flux_msg_set_user1 msg=NULL fails with EINVAL");
+    ok (flux_msg_is_user1 (NULL) == false,
+        "flux_msg_is_user1 msg=NULL returns false");
 
     flux_msg_destroy (msg);
 }
@@ -1165,6 +1170,15 @@ void check_flags (void)
         "flux_msg_get_flags works");
     ok (flags == 0,
         "flags are initially zero");
+
+    /* FLUX_MSGFLAG_USER1 */
+    ok (flux_msg_is_user1 (msg) == false,
+        "flux_msg_is_user1 = false");
+    ok (flux_msg_set_user1 (msg) == 0,
+        "flux_msg_set_user1_works");
+    ok (flux_msg_is_user1 (msg) == true,
+        "flux_msg_is_user1 = true");
+
 
     /* FLUX_MSGFLAG_PRIVATE */
     ok (flux_msg_is_private (msg) == false,

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -70,6 +70,7 @@ TESTSCRIPTS = \
 	t0012-content-sqlite.t \
 	t0024-content-s3.t \
 	t0028-content-backing-none.t \
+	t0029-content-mmap.t \
 	t0025-broker-state-machine.t \
 	t0027-broker-groups.t \
 	t0013-config-file.t \

--- a/t/t0029-content-mmap.t
+++ b/t/t0029-content-mmap.t
@@ -1,0 +1,92 @@
+#!/bin/sh
+
+test_description='Test content-mapped files'
+
+. `dirname $0`/content/content-helper.sh
+
+. `dirname $0`/sharness.sh
+
+LPTEST=${FLUX_BUILD_DIR}/t/shell/lptest
+
+test_under_flux 2 minimal
+
+test_expect_success 'flux content load handles blobrefs on stdin' '
+        echo foo >foo &&
+	flux content store < foo | flux content load >bar &&
+	test_cmp foo bar
+'
+test_expect_success 'create test file' '
+	${LPTEST} >testfile
+'
+test_expect_success 'mmap nonexistent file fails' '
+	test_must_fail flux content mmap notafile
+'
+test_expect_success 'mmap test file' '
+	flux content mmap ./testfile >testfile.blobrefs
+'
+test_expect_success 'mmap test file again fails' '
+	test_must_fail flux content mmap ./testfile
+'
+test_expect_success 'test file can be read through content cache on rank 0' '
+	flux content load <testfile.blobrefs >testfile.copy0 &&
+	test_cmp testfile testfile.copy0
+'
+test_expect_success 'test file can be read through content cache on rank 1' '
+	flux exec -r 1 flux content load <testfile.blobrefs >testfile.copy1 &&
+	test_cmp testfile testfile.copy1
+'
+test_expect_success 'mumnap test file' '
+	flux content munmap ./testfile
+'
+test_expect_success 'drop the cache' '
+	flux exec -r 1 flux content dropcache &&
+	flux content dropcache
+'
+test_expect_success 'test file cannot be read through content cache' '
+	test_must_fail flux content load <testfile.blobrefs
+'
+test_expect_success 'mmap test file with small blobsize' '
+	flux content mmap ./testfile 10 >testfile.blobrefs2
+'
+test_expect_success 'test file can be read through content cache on rank 0' '
+	flux content load <testfile.blobrefs2 >testfile.copy0a &&
+	test_cmp testfile testfile.copy0a
+'
+test_expect_success 'test file can be read through content cache on rank 1' '
+	flux exec -r 1 flux content load <testfile.blobrefs2 >testfile.copy1a &&
+	test_cmp testfile testfile.copy1a
+'
+test_expect_success 'mumnap test file' '
+	flux content munmap ./testfile
+'
+test_expect_success 'drop the cache' '
+	flux exec -r 1 flux content dropcache &&
+	flux content dropcache
+'
+test_expect_success 'create test file' '
+	echo abcdefghijklmnopqrstuvwxyz >testfile2
+'
+test_expect_success 'mmap test file' '
+	flux content mmap ./testfile2 >testfile2.blobrefs
+'
+test_expect_success 'test file can be read through content cache on rank 1' '
+	flux exec -r 1 flux content load <testfile2.blobrefs >testfile2.copy &&
+	test_cmp testfile2 testfile2.copy
+'
+test_expect_success 'store the same blob on rank 1' '
+	flux exec -r 1 flux content store <testfile2 >testfile2.blobrefs2 &&
+	test_cmp testfile2.blobrefs testfile2.blobrefs2
+'
+test_expect_success 'mumnap test file' '
+	flux content munmap ./testfile2
+'
+test_expect_success 'drop the cache' '
+	flux exec -r 1 flux content dropcache &&
+	flux content dropcache
+'
+test_expect_success 'test file can be read through content cache on rank 1' '
+	flux exec -r 1 flux content load <testfile2.blobrefs >testfile2.copy2 &&
+	test_cmp testfile2 testfile2.copy2
+'
+
+test_done


### PR DESCRIPTION
I'm parking this weekend experiment pending some time to test scalability.

This adds a feature I had been thinking about for some time - support for mmapping a file into the broker content cache on rank 0, and reading it through the cache on the other broker ranks of the instance, leveraging the tree based overlay network fanout for scalability.

For preliminary tooling I added
- `flux content mmap FILENAME [BLOBSIZE]` which maps a file and lists blobrefs for chunks on stdout
- `flux content mumnap FILE` which unmaps the file
- a new  `flux content load` mode which reads blobrefs on stdin and contcatenates the blobs on stdout

With this one can do something like:
```
ƒ(s=64,d=0,builddir) $ flux content mmap 4g.img | flux exec sh -c "flux content load | md5sum"
[snip]
ƒ(s=64,d=0,builddir) $ flux content munmap 4g.img
```
In that command, the list of blobrefs is being distributed to the stdin of the remote commands through flux exec, then the file contents is being loaded through the cache.

On the relevance to the file broadcast tool being discussed in #3744 and #3631, I'm not sure if this is a direct fit because
- this service is only available to the instance owner
- the source file must be on broker rank 0
- the source must be a file (it cannot be a stream)

If we did want to go forward with such a tool though, I was thinking it could be made standalone so it could map the file, perform the copy by using the broker subprocess exec service directly, and then unmap the file when done.  In the above example, the file has to be manually unmapped after the command completes.

Mostly though, in this PR, I just wanted to see if we could implement the basic capability since it's been on the back burner for so long, and then we'll at least have something to compare other ideas to.  Sometimes these demons must be exorcised.