### PR TITLE
doc: document {id.dec} in flux-jobs(1)

### DIFF
--- a/doc/man1/flux-jobs.rst
+++ b/doc/man1/flux-jobs.rst
@@ -202,6 +202,9 @@ The field names that can be specified are:
 **id.f58**
   job ID in RFC 19 F58 (base58) encoding
 
+**id.dec**
+  job ID in decimal representation
+
 **id.hex**
    job ID in ``0x`` prefix hexadecimal representation
 


### PR DESCRIPTION
Problem: The output format of {id.dec} was not documented in flux-jobs(1).

Add it to the list of id output formats.