### PR TITLE
flux-mini: improve an error message and documentation for per-resource options

### DIFF
--- a/doc/man1/flux-mini.rst
+++ b/doc/man1/flux-mini.rst
@@ -116,11 +116,16 @@ listed above:
 **--tasks-per-node=N**
    Set the number of tasks per node to run.
 
-**--tasks-per-core=N**
-   Force a number of tasks per core.
-
 **--gpus-per-node=N**
    With -N, --nodes, request a specific number of GPUs per node.
+
+**--tasks-per-core=N**
+   Force a number of tasks per core. Note that this will run *N* tasks per
+   *allocated* core. If nodes are exclusively scheduled by configuration or
+   use of the ``--exclusive`` flag, then this option could result in many
+   more tasks than expected. The default for this option is effectively 1,
+   so it is useful only for oversubscribing tasks to cores for testing
+   purposes. You probably don't want to use this option.
 
 Batch job options
 -----------------

--- a/src/bindings/python/flux/job/Jobspec.py
+++ b/src/bindings/python/flux/job/Jobspec.py
@@ -746,6 +746,8 @@ class JobspecV1(Jobspec):
             #  With nnodes, nslots is slots/node (total_slots=slots*nodes)
             nslots = 1
             slot_size = 1
+        else:
+            raise ValueError("must specify node or core count with per_resource")
 
         children = [cls._create_resource("core", slot_size)]
         if gpus_per_node:

--- a/t/t2700-mini-cmd.t
+++ b/t/t2700-mini-cmd.t
@@ -358,6 +358,12 @@ cat <<EOF >per-resource-failure.txt
 \
 --nodes=1 --tasks-per-core=1 --cores-per-task=1 \
 ==Per-resource options.*per-task options
+\
+--tasks-per-core=1 \
+==must specify node or core count with per_resource
+\
+--tasks-per-node=1 \
+==must specify node or core count with per_resource
 EOF
 
 while read line; do


### PR DESCRIPTION
This addresses the issues discovered in #4547 
  * unhelpful error message when neither `--cores` or `--nodes` are used with other per-resource options in `flux mini`
  * unhelpful documentation of `--tasks-per-core`