### PR TITLE
Container base: remove view copy

### DIFF
--- a/.github/workflows/build-container.yaml
+++ b/.github/workflows/build-container.yaml
@@ -2,8 +2,8 @@ name: Build and Deploy Container
 
 on:
 
-  # Added just for testing
-  pull_request: []
+  # Enable just for testing cobntainer builds
+  # pull_request: []
   
   # Always have a base image ready to go - this is a nightly build
   schedule:

--- a/.github/workflows/build-container.yaml
+++ b/.github/workflows/build-container.yaml
@@ -2,6 +2,9 @@ name: Build and Deploy Container
 
 on:
 
+  # Added just for testing
+  pull_request: []
+  
   # Always have a base image ready to go - this is a nightly build
   schedule:
     - cron: 0 3 * * *

--- a/etc/docker/Dockerfile.base
+++ b/etc/docker/Dockerfile.base
@@ -20,7 +20,7 @@ RUN mkdir -p /opt/flux-env \
 &&   echo "  view:" \
 &&   echo "    mfem:" \
 &&   echo "      root: /opt/flux-view" \
-&&   echo "      link_type: copy" \
+# &&   echo "      link_type: copy" \
 &&   echo "  packages:" \
 &&   echo "    all:" \
 &&   echo "      target:" \


### PR DESCRIPTION
spack is still borked w.r.t view copying so I want to try disabling it for now. We will not be able to do multi-stage builds, but having builds will be better than nothing! I added a test here on PR so we can verify it builds before merge, and I can remove that if/when it does! If It still doesn't build, oh spack, why do you anguish me so! :laughing: :sob: 

Signed-off-by: vsoch <vsoch@users.noreply.github.com>