### PR TITLE
python: uri: use path to current flux executable in lsf resovler

### DIFF
--- a/src/bindings/python/flux/uri/resolvers/lsf.py
+++ b/src/bindings/python/flux/uri/resolvers/lsf.py
@@ -19,6 +19,7 @@ It can be used like:
 import getpass
 import os
 import subprocess
+import shutil
 from pathlib import PurePath
 
 import yaml
@@ -79,8 +80,19 @@ def lsf_get_uri(hostname, jobid):
     and converting the result from bytecode to a string.
     """
     ssh_path = os.getenv("FLUX_SSH", "ssh")
+
+    #  Allow path to remote flux to be overridden as in ssh connector,
+    #   o/w, use path the current `flux` executable:
+    flux_cmd_path = os.getenv("FLUX_SSH_RCMD", shutil.which("flux"))
     sp = subprocess.run(
-        [ssh_path, hostname, "flux", "uri", "--remote", f"lsf:{jobid}?is_compute"],
+        [
+            ssh_path,
+            hostname,
+            flux_cmd_path,
+            "uri",
+            "--remote",
+            f"lsf:{jobid}?is_compute",
+        ],
         stdout=subprocess.PIPE,
         check=True,
     )


### PR DESCRIPTION
Problem: The lsf URI resolver plugin executes `ssh flux uri resolve..` on a compute host during URI resolution, but this may not work if the remote host has a different version of Flux installed as the system instance.

Assume a shared filesystem by default and replace `flux` with the path to the local flux executable by using `shutil.which("flux")`. As with the ssh connector, allow this to be overridden with `FLUX_SSH_RCMD`.

Fixes #4558