### PR TITLE
improve signal/noise ratio in systemd journal logs

### DIFF
--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -1064,7 +1064,7 @@ static void hello_request_handler (struct overlay *ov, const flux_msg_t *msg)
     flux_msg_t *response;
     const char *uuid;
     int status;
-    int hello_log_level = LOG_INFO;
+    int hello_log_level = LOG_DEBUG;
 
     if (flux_request_unpack (msg,
                              NULL,

--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -897,8 +897,13 @@ static void child_cb (flux_reactor_t *r, flux_watcher_t *w,
          * Send CONTROL_DISCONNECT to force subtree panic.
          */
         else {
-            if (overlay_control_child (ov, uuid, CONTROL_DISCONNECT, 0) < 0)
-                flux_log_error (ov->h, "failed to send CONTROL_DISCONNECT");
+            if (overlay_control_child (ov, uuid, CONTROL_DISCONNECT, 0) < 0) {
+                // not LOG_ERR per flux-framework/flux-core#4464
+                flux_log (ov->h,
+                          LOG_DEBUG,
+                          "failed to send CONTROL_DISCONNECT: %s",
+                          strerror (errno));
+            }
         }
         goto done;
     }

--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -1092,10 +1092,9 @@ static void hello_request_handler (struct overlay *ov, const flux_msg_t *msg)
      */
     if (subtree_is_online (child->status)) { // crash
         flux_log (ov->h, LOG_ERR,
-                  "%s (rank %lu) reconnected after crash, dropping old uuid %s",
+        "%s (rank %lu) reconnected after crash, dropping old connection state",
                   flux_get_hostbyrank (ov->h, child->rank),
-                  (unsigned long)child->rank,
-                  child->uuid);
+                  (unsigned long)child->rank);
         overlay_child_status_update (ov, child, SUBTREE_STATUS_LOST);
         hello_log_level = LOG_ERR; // want hello log to stand out in this case
     }
@@ -1112,10 +1111,9 @@ static void hello_request_handler (struct overlay *ov, const flux_msg_t *msg)
 
     flux_log (ov->h,
               hello_log_level,
-              "accepting connection from %s (rank %lu) uuid %s status %s",
+              "accepting connection from %s (rank %lu) status %s",
               flux_get_hostbyrank (ov->h, child->rank),
               (unsigned long)child->rank,
-              child->uuid,
               subtree_status_str (child->status));
 
     if (!(response = flux_response_derive (msg, 0))
@@ -1126,10 +1124,9 @@ static void hello_request_handler (struct overlay *ov, const flux_msg_t *msg)
     return;
 error_log:
     flux_log (ov->h, LOG_ERR,
-              "rejecting connection from %s (rank %lu) uuid %s: %s",
+              "rejecting connection from %s (rank %lu): %s",
               flux_get_hostbyrank (ov->h, rank),
               (unsigned long)rank,
-              uuid,
               reason);
 error:
     if (!(response = flux_response_derive (msg, errno))


### PR DESCRIPTION
Problem: there is a lot of garbage to sift through when trying to do a post-mortem on a flux problem by looking at `journalctl -u flux` on the rank 0 node.

Eliminate, rate-limit, and reduce severity of several offending messages.