### PR TITLE
flux-mini: change default unit for --time-limit to minutes

### DIFF
--- a/doc/man1/flux-mini.rst
+++ b/doc/man1/flux-mini.rst
@@ -150,11 +150,12 @@ Additional job options
 The **run**, **submit**, **batch**, and **alloc** commands also take
 following additional job parameters:
 
-**-t, --time-limit=FSD**
-   Set a time limit for the job in Flux standard duration (RFC 23).
-   FSD is a floating point number with a single character units suffix
-   ("s", "m", "h", or "d"). If unspecified, the job is subject to the
-   system default time limit.
+**-t, --time-limit=MINUTES|FSD**
+   Set a time limit for the job in either minutes or Flux standard duration
+   (RFC 23). FSD is a floating point number with a single character units
+   suffix ("s", "m", "h", or "d"). The default unit for the ``--time-limit``
+   option is minutes when no units are otherwise specified. If the time
+   limit is unspecified, the job is subject to the system default time limit.
 
 STANDARD I/O
 ============

--- a/src/cmd/flux-mini.py
+++ b/src/cmd/flux-mini.py
@@ -461,8 +461,9 @@ class MiniCmd:
             "-t",
             "--time-limit",
             type=str,
-            metavar="FSD",
-            help="Time limit in Flux standard duration, e.g. 2d, 1.5h",
+            metavar="MIN|FSD",
+            help="Time limit in minutes when no units provided, otherwise "
+            + "in Flux standard duration, e.g. 30s, 2d, 1.5h",
         )
         parser.add_argument(
             "--urgency",
@@ -614,6 +615,13 @@ class MiniCmd:
                 list_split(args.requires),
             )
         if args.time_limit is not None:
+            #  With no units, time_limit is in minutes, but jobspec.duration
+            #  takes seconds or FSD by default, so convert here if necessary.
+            try:
+                limit = float(args.time_limit)
+                args.time_limit = limit * 60
+            except ValueError:
+                pass
             jobspec.duration = args.time_limit
 
         if args.job_name is not None:

--- a/t/t2212-job-manager-plugins.t
+++ b/t/t2212-job-manager-plugins.t
@@ -223,7 +223,7 @@ test_expect_success 'job-manager: load jobtap_api test plugin' '
 		/bin/false) &&
 	test_expect_code 1 flux job attach -vEX $id &&
 	test_must_fail flux job wait-event $id exception &&
-	id=$(flux mini submit -t 0.1 \
+	id=$(flux mini submit -t 0.1s \
 		--setattr=system.expected-result=timeout \
 		sleep 10) &&
 	test_must_fail flux job wait-event -vm type=test $id exception &&

--- a/t/t2220-job-manager-jobspec-default.t
+++ b/t/t2220-job-manager-jobspec-default.t
@@ -74,7 +74,7 @@ test_expect_success HAVE_JQ 'the redacted jobspec contains default duration' '
 	jq -e ".jobspec.attributes.system.duration == 3600" <getattr4.json
 '
 test_expect_success 'submit a job that overrides the default duration' '
-	flux mini submit -t5 /bin/true >id5
+	flux mini submit -t5s /bin/true >id5
 '
 test_expect_success HAVE_JQ 'the redacted jobspec contains the override' '
 	jm_getattr $(cat id5) jobspec >getattr5.json &&
@@ -158,7 +158,7 @@ test_expect_success HAVE_JQ 'the redacted jobspec contains queue duration' '
 	jq -e ".jobspec.attributes.system.duration == 99" <getattr8.json
 '
 test_expect_success 'submit a job with with queue and duration' '
-	flux mini submit --setattr=system.queue=pdebug -t 111 /bin/true >id9
+	flux mini submit --setattr=system.queue=pdebug -t 111s /bin/true >id9
 '
 test_expect_success HAVE_JQ 'the redacted jobspec contains user duration' '
 	jm_getattr $(cat id9) jobspec >getattr9.json &&

--- a/t/t2260-job-list.t
+++ b/t/t2260-job-list.t
@@ -778,7 +778,7 @@ test_expect_success HAVE_JQ 'flux job list outputs exceptions correctly (excepti
 # expiration time
 
 test_expect_success HAVE_JQ 'flux job list outputs expiration time when set' '
-	jobid=$(flux mini submit -t 30 sleep 1000 | flux job id) &&
+	jobid=$(flux mini submit -t 30s sleep 1000 | flux job id) &&
 	fj_wait_event $jobid start &&
 	flux job list | grep $jobid > expiration.json &&
 	test_debug "cat expiration.json" &&

--- a/t/t2607-job-shell-input.t
+++ b/t/t2607-job-shell-input.t
@@ -73,7 +73,7 @@ test_expect_success NO_CHAIN_LINT 'flux-shell: attach twice, one with data' '
 '
 
 test_expect_success 'flux-shell: multiple jobs, each want stdin' '
-	flux mini submit --cc=1-4 -n1 -t 30 \
+	flux mini submit --cc=1-4 -n1 -t 30s \
 	    ${TEST_SUBPROCESS_DIR}/test_echo -O -n >pipe5.jobids &&
 	test_debug "cat pipe5.jobids" &&
 	i=1 &&
@@ -151,7 +151,7 @@ test_expect_success 'flux-shell: run 2-task input file as stdin job' '
 '
 
 test_expect_success 'flux-shell: multiple jobs, each want stdin via file' '
-	flux mini submit --cc=1-4 -n1 -t 30 --input=input_stdin_file \
+	flux mini submit --cc=1-4 -n1 -t 30s --input=input_stdin_file \
 	    ${TEST_SUBPROCESS_DIR}/test_echo -O -n >file2.jobids &&
 	test_debug "cat file2.jobids" &&
 	i=1 &&

--- a/t/t2700-mini-cmd.t
+++ b/t/t2700-mini-cmd.t
@@ -112,6 +112,10 @@ test_expect_success HAVE_JQ 'flux mini submit -t5s works' '
 	flux mini submit --dry-run -t5s hostname >t5s.out &&
 	jq -e ".attributes.system.duration == 5" < t5s.out
 '
+test_expect_success HAVE_JQ 'flux mini submit -t5 sets 5m duration' '
+	flux mini submit --dry-run -t5 hostname >t5.out &&
+	jq -e ".attributes.system.duration == 300" < t5.out
+'
 test_expect_success 'flux mini submit --time-limit=00:30 fails' '
 	test_must_fail flux mini submit --time-limit=00:30 hostname 2>st.err &&
 	grep -i "invalid Flux standard duration" st.err

--- a/t/t2700-mini-cmd.t
+++ b/t/t2700-mini-cmd.t
@@ -112,10 +112,6 @@ test_expect_success HAVE_JQ 'flux mini submit -t5s works' '
 	flux mini submit --dry-run -t5s hostname >t5s.out &&
 	jq -e ".attributes.system.duration == 5" < t5s.out
 '
-test_expect_success HAVE_JQ 'flux mini submit -t5 works' '
-	flux mini submit --dry-run -t5 hostname >t5.out &&
-	jq -r ".attributes.system.duration == 300"
-'
 test_expect_success 'flux mini submit --time-limit=00:30 fails' '
 	test_must_fail flux mini submit --time-limit=00:30 hostname 2>st.err &&
 	grep -i "invalid Flux standard duration" st.err

--- a/t/t2700-mini-cmd.t
+++ b/t/t2700-mini-cmd.t
@@ -98,19 +98,19 @@ test_expect_success 'flux mini run -vvv produces exec events on stderr' '
 '
 test_expect_success HAVE_JQ 'flux mini submit --time-limit=5d works' '
 	flux mini submit --dry-run --time-limit=5d hostname >t5d.out &&
-	jq -r ".attributes.system.duration == 432000"
+	jq -e ".attributes.system.duration == 432000" < t5d.out
 '
 test_expect_success HAVE_JQ 'flux mini submit --time-limit=4h works' '
 	flux mini submit --dry-run --time-limit=4h hostname >t4h.out &&
-	jq -r ".attributes.system.duration == 14400"
+	jq -e ".attributes.system.duration == 14400" < t4h.out
 '
 test_expect_success HAVE_JQ 'flux mini submit --time-limit=1m works' '
 	flux mini submit --dry-run --time-limit=5m hostname >t5m.out &&
-	jq -r ".attributes.system.duration == 300"
+	jq -e ".attributes.system.duration == 300" < t5m.out
 '
 test_expect_success HAVE_JQ 'flux mini submit -t5s works' '
 	flux mini submit --dry-run -t5s hostname >t5s.out &&
-	jq -r ".attributes.system.duration == 300"
+	jq -e ".attributes.system.duration == 5" < t5s.out
 '
 test_expect_success HAVE_JQ 'flux mini submit -t5 works' '
 	flux mini submit --dry-run -t5 hostname >t5.out &&

--- a/t/t2900-job-timelimits.t
+++ b/t/t2900-job-timelimits.t
@@ -16,7 +16,7 @@ test_have_prereq ASAN && TIMEOUT=3
 
 test_expect_success 'job time limits are enforced' '
 	test_expect_code 142 \
-		flux mini run --time-limit=${TIMEOUT} sleep 30 2>limit1.err &&
+		flux mini run --time-limit=${TIMEOUT}s sleep 30 2>limit1.err &&
 	grep "resource allocation expired" limit1.err
 '
 test_expect_success HAVE_JQ 'job timelimits are propagated' '
@@ -57,7 +57,7 @@ sigalrm_sigkill_test() {
 	flux module reload job-exec kill-timeout=$kill_timeout &&
 	ofile=trap.$scale.out &&
 	test_must_fail_or_be_terminated \
-           flux mini run -vvv --time-limit=${timeout} bash -xc \
+           flux mini run -vvv --time-limit=${timeout}s bash -xc \
                "trap \"echo got SIGALRM>>$ofile\" SIGALRM;sleep 10;sleep 15" \
                    > $ofile 2> trap.$scale.err &&
         test_debug "grep . trap.*" &&
@@ -74,7 +74,7 @@ test_expect_success 'expired jobs are sent SIGALRM, then SIGKILL' '
 	done
 '
 expired_cancel_test() {
-	id=$(flux mini submit --time-limit=$1 bash -c \
+	id=$(flux mini submit --time-limit=${1}s bash -c \
             "trap \"echo got SIGALRM>>trap2.out\" SIGALRM;sleep 60;sleep 60" ) &&
 	flux job wait-event --timeout=30 $id exception &&
 	flux job cancel $id &&


### PR DESCRIPTION
As proposed in #4552, this PR changes `flux-mini` so it now refuses to accept a `--time-limit` of less than 300s unless units are explicitly specified. A hopefully helpful error message is displayed instead:
```console
$ flux mini run -t 30 myapp
flux-mini: ERROR: time limit is 30 seconds. Are you sure? Force with "30s".
```
