### PR TITLE
resource: support configuration of resources in TOML config

### DIFF
--- a/doc/man5/flux-config-resource.rst
+++ b/doc/man5/flux-config-resource.rst
@@ -24,6 +24,36 @@ path
    passed from the enclosing Flux instance.  The ``flux R`` utility may be
    used to generate this file.
 
+config
+   (optional) An array of resource config entries used as an alternative to
+   a R object configured by ``resource.path``. Each array entry must contain
+   a ``hosts`` key in RFC 29 Hostlist Format which configures the list of
+   hosts to which the rest of the entry applies. The entry may also contain
+   ``cores`` and/or ``gpus`` keys which configure the set of core ids and
+   GPU ids (in RFC 22 idset form) available on the targeted hosts, or a
+   ``properties`` key which is an array of property strings to assign to
+   ``hosts``. It is not an error to list a host multiple times, instead
+   each entry updates ``hosts``. If the ``config`` array exists, then any
+   ``path`` is ignored.
+
+   Example::
+
+     [[resource.config]]
+     hosts = "test[1-100]"
+     cores = "0-7"
+
+     [[resource.config]]
+     hosts = "test[1,2]"
+     gpus = "0-1"
+
+     [[resource.config]]
+     hosts = "test[1-89]"
+     properties = ["batch"]
+
+     [[resource.config]]
+     hosts = "test[90-100]"
+     properties = ["debug"]
+
 exclude
    (optional) A string value that defines one or more nodes to withhold
    from scheduling, either in RFC 22 idset form, or in RFC 29 hostlist form.

--- a/src/cmd/flux-R.c
+++ b/src/cmd/flux-R.c
@@ -29,6 +29,7 @@
 #include "src/common/libutil/read_all.h"
 #include "src/common/librlist/rlist.h"
 #include "src/common/librlist/rhwloc.h"
+#include "src/common/libtomlc99/toml.h"
 
 #define RSET_DOC "\
 Read, generate, and process RFC 20 Resource Set objects.\n\
@@ -43,6 +44,7 @@ int cmd_rerank (optparse_t *p, int argc, char **argv);
 int cmd_decode (optparse_t *p, int argc, char **argv);
 int cmd_verify (optparse_t *p, int argc, char **argv);
 int cmd_set_property (optparse_t *p, int argc, char **argv);
+int cmd_parse_config (optparse_t *p, int argc, char **argv);
 
 static struct optparse_option global_opts[] =  {
     OPTPARSE_TABLE_END
@@ -145,6 +147,11 @@ static struct optparse_option decode_opts[] = {
     OPTPARSE_TABLE_END
 };
 
+static struct optparse_option parse_config_opts[] = {
+    OPTPARSE_TABLE_END
+};
+
+
 static struct optparse_subcommand subcommands[] = {
     { "encode",
       "[OPTIONS]...",
@@ -217,6 +224,13 @@ static struct optparse_subcommand subcommands[] = {
       cmd_set_property,
       0,
       set_property_opts,
+    },
+    { "parse-config",
+      "PATH",
+      "Read config from resource.config array",
+      cmd_parse_config,
+      0,
+      parse_config_opts,
     },
     OPTPARSE_SUBCMD_END
 };
@@ -823,6 +837,33 @@ int cmd_set_property (optparse_t *p, int argc, char **argv)
 
     json_decref (o);
     free (allranks);
+    rlist_destroy (rl);
+
+    return 0;
+}
+
+int cmd_parse_config (optparse_t *p, int argc, char **argv)
+{
+    flux_error_t error;
+    json_t *o = NULL;
+    struct rlist *rl = NULL;
+    flux_conf_t *conf;
+
+    if (!(conf = flux_conf_parse (argv[1], &error)))
+        log_msg_exit ("flux_conf_parse: %s", error.text);
+
+    if (flux_conf_unpack (conf, &error,
+                          "{s:{s:o}}",
+                          "resource",
+                          "config", &o) < 0)
+        log_msg_exit ("Config file error: %s", error.text);
+
+    if (!(rl = rlist_from_config (o, &error)))
+        log_msg_exit ("Config file error: %s", error.text);
+
+    rlist_puts (rl);
+
+    flux_conf_decref (conf);
     rlist_destroy (rl);
 
     return 0;

--- a/src/common/librlist/rlist.h
+++ b/src/common/librlist/rlist.h
@@ -280,4 +280,6 @@ int rlist_assign_properties (struct rlist *rl,
  */
 char *rlist_properties_encode (struct rlist *rl);
 
+struct rlist *rlist_from_config (json_t *conf, flux_error_t *errp);
+
 #endif /* !HAVE_SCHED_RLIST_H */

--- a/src/common/librlist/rnode.c
+++ b/src/common/librlist/rnode.c
@@ -187,6 +187,7 @@ fail:
 
 int rnode_add (struct rnode *orig, struct rnode *n)
 {
+    int rc = 0;
     struct rnode_child *c;
     if (!orig || !n)
         return -1;
@@ -197,7 +198,21 @@ int rnode_add (struct rnode *orig, struct rnode *n)
             return -1;
         c = zhashx_next (n->children);
     }
-    return 0;
+    if (n->properties) {
+        zlistx_t *l = zhashx_keys (n->properties);
+        if (l != NULL) {
+            const char *property = zlistx_first (l);
+            while (property) {
+                if (rnode_set_property (orig, property) < 0)
+                    rc = -1;
+                property = zlistx_next (l);
+            }
+            zlistx_destroy (&l);
+        }
+        else
+            rc = -1;
+    }
+    return rc;
 }
 
 struct rnode *rnode_create (const char *name, uint32_t rank, const char *ids)

--- a/src/common/librlist/rnode.c
+++ b/src/common/librlist/rnode.c
@@ -125,10 +125,10 @@ out:
  *   then add 'ids' to that child (it is an error if one or more ids
  *   are already set in child 'name'.
  */
-static struct rnode_child * rnode_add_child_idset (struct rnode *n,
-                                                   const char *name,
-                                                   const struct idset *ids,
-                                                   const struct idset *avail)
+struct rnode_child * rnode_add_child_idset (struct rnode *n,
+                                            const char *name,
+                                            const struct idset *ids,
+                                            const struct idset *avail)
 {
     struct rnode_child *c = zhashx_lookup (n->children, name);
 

--- a/src/common/librlist/rnode.h
+++ b/src/common/librlist/rnode.h
@@ -41,6 +41,13 @@ struct rnode {
     zhashx_t *properties;
 };
 
+struct rnode *rnode_new (const char *name, uint32_t rank);
+
+struct rnode_child * rnode_add_child_idset (struct rnode *n,
+                                            const char *name,
+                                            const struct idset *ids,
+                                            const struct idset *avail);
+
 /*  Create a resource node object from an existing idset `set`
  */
 struct rnode *rnode_create_idset (const char *name,

--- a/src/common/librlist/test/rlist.c
+++ b/src/common/librlist/test/rlist.c
@@ -1947,6 +1947,36 @@ static void test_issue4290 (void)
     free (R);
 }
 
+static void test_rlist_config_inval (void)
+{
+    flux_error_t error;
+    json_t *o;
+
+    ok (rlist_from_config (NULL, &error) == NULL,
+        "rlist_from_config (NULL) fails");
+    is (error.text, "resource config must be an array",
+        "error.text is expected: %s",
+        error.text);
+
+    if (!(o = json_object()))
+        BAIL_OUT ("test_rlist_config_inval: json_object: %s", strerror (errno));
+    ok (rlist_from_config (o, &error) == NULL,
+        "rlist_from_config() with empty object fails");
+    is (error.text, "resource config must be an array",
+        "error.text is expected: %s",
+        error.text);
+    json_decref (o);
+
+    if (!(o = json_array ()))
+        BAIL_OUT ("test_rlist_config_inval: json_array: %s", strerror (errno));
+    ok (rlist_from_config (o, &error) == NULL,
+        "rlist_from_config() with empty array fails");
+    is (error.text, "no hosts configured",
+        "error.text is expected: %s",
+        error.text);
+    json_decref (o);
+}
+
 int main (int ac, char *av[])
 {
     plan (NO_PLAN);
@@ -1975,6 +2005,7 @@ int main (int ac, char *av[])
     test_issue4184 ();
     test_properties ();
     test_issue4290 ();
+    test_rlist_config_inval ();
 
     done_testing ();
 }

--- a/src/modules/resource/inventory.c
+++ b/src/modules/resource/inventory.c
@@ -280,6 +280,7 @@ static int convert_R_conf (flux_t *h, json_t *conf_R, json_t **Rp)
         errno = ENOMEM;
         goto error;
     }
+    rlist_destroy (rl);
     *Rp = R;
     return 0;
 error:

--- a/src/modules/resource/resource.c
+++ b/src/modules/resource/resource.c
@@ -437,6 +437,9 @@ int mod_main (flux_t *h, int argc, char **argv)
     }
     if (!(ctx->inventory = inventory_create (ctx, R_from_config)))
         goto error;
+    /*  Done with R_from_config now, so free it.
+     */
+    json_decref (R_from_config);
     if (!(ctx->topology = topo_create (ctx, noverify, norestrict)))
         goto error;
     if (!(ctx->monitor = monitor_create (ctx, monitor_force_up)))

--- a/src/modules/resource/resource.c
+++ b/src/modules/resource/resource.c
@@ -22,6 +22,7 @@
 #include "src/common/libutil/errprintf.h"
 #include "src/common/libidset/idset.h"
 #include "src/common/libeventlog/eventlog.h"
+#include "src/common/librlist/rlist.h"
 
 #include "resource.h"
 #include "inventory.h"
@@ -38,8 +39,11 @@
  * exclude = "targets"
  *   Exclude specified broker rank(s) or hosts from scheduling
  *
+ * [[resource.confg]]
+ *   Resource configuration array
+ *
  * path = "/path"
- *   Set path to resource object
+ *   Set path to resource object (if no resource.config array)
  *
  * noverify = true
  *   Skip verification that configured resources match local hwloc
@@ -61,12 +65,14 @@ static int parse_config (struct resource_ctx *ctx,
     int noverify = 0;
     int norestrict = 0;
     json_t *o = NULL;
+    json_t *config = NULL;
 
     if (flux_conf_unpack (conf,
                           &error,
-                          "{s?:{s?:s s?:s s?:b s?b !}}",
+                          "{s?:{s?:s s?:o s?:s s?:b s?b !}}",
                           "resource",
                             "path", &path,
+                            "config", &config,
                             "exclude", &exclude,
                             "norestrict", &norestrict,
                             "noverify", &noverify) < 0) {
@@ -75,7 +81,19 @@ static int parse_config (struct resource_ctx *ctx,
                    error.text);
         return -1;
     }
-    if (path) {
+    if (config) {
+        struct rlist *rl = rlist_from_config (config, &error);
+        if (!rl) {
+            errprintf (errp,
+                       "error parsing [resource.config] array: %s",
+                       error.text);
+            return -1;
+        }
+        if (!(o = rlist_to_R (rl)))
+            return errprintf (errp, "rlist_to_R: %s", strerror (errno));
+        rlist_destroy (rl);
+    }
+    else if (path) {
         FILE *f;
         json_error_t e;
 
@@ -96,10 +114,7 @@ static int parse_config (struct resource_ctx *ctx,
                        e.line);
             return -1;
         }
-        if (!R)
-            json_decref (o);
     }
-
     *excludep = exclude;
     if (noverifyp)
         *noverifyp = noverify ? true : false;
@@ -107,6 +122,8 @@ static int parse_config (struct resource_ctx *ctx,
         *norestrictp = norestrict ? true : false;
     if (R)
         *R = o;
+    else
+        json_decref (o);
     return 0;
 }
 

--- a/t/t0026-flux-R.t
+++ b/t/t0026-flux-R.t
@@ -2,212 +2,214 @@
 
 test_description='Test flux-R front-end command'
 
+# Append --logfile option if FLUX_TESTS_LOGFILE is set in environment
+test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
 . `dirname $0`/sharness.sh
 
 test_expect_success 'flux R fails on invalid R objects' '
-    test_expect_code 1 flux R decode </dev/null &&
-    echo {} | test_expect_code 1 flux R decode &&
-    echo "{\"version\": 1}" | test_expect_code 1 flux R decode &&
-    echo "{\"version\": 1, \"execution\": {}}" \
-        | test_expect_code 1 flux R decode
+	test_expect_code 1 flux R decode </dev/null &&
+	echo {} | test_expect_code 1 flux R decode &&
+	echo "{\"version\": 1}" | test_expect_code 1 flux R decode &&
+	echo "{\"version\": 1, \"execution\": {}}" \
+	    | test_expect_code 1 flux R decode
 '
 test_expect_success 'flux R decode works with empty R_lite' '
-    echo "{\"version\": 1, \"execution\": {\"R_lite\": {}}}" \
-        | flux R decode > R.empty &&
-    test $(flux R decode --count core < R.empty) -eq 0
+	echo "{\"version\": 1, \"execution\": {\"R_lite\": {}}}" \
+	    | flux R decode > R.empty &&
+	test $(flux R decode --count core < R.empty) -eq 0
 '
 test_expect_success 'flux R encode with no args creates expected result' '
-    flux R encode | flux R decode &&
-    test $(flux R encode | flux R decode --count node) -eq 1 &&
-    test $(flux R encode | flux R decode --count core) -eq 1 &&
-    test $(flux R encode | flux R decode --count gpu) -eq 0 &&
-    test "$(flux R encode | flux R decode --short)" = "rank0/core0"
+	flux R encode | flux R decode &&
+	test $(flux R encode | flux R decode --count node) -eq 1 &&
+	test $(flux R encode | flux R decode --count core) -eq 1 &&
+	test $(flux R encode | flux R decode --count gpu) -eq 0 &&
+	test "$(flux R encode | flux R decode --short)" = "rank0/core0"
 '
 test_expect_success 'flux R encode --ranks works' '
-    test $(flux R encode --ranks 0-1 | flux R decode --count node) -eq 2 &&
-    test $(flux R encode --ranks 0,2 | flux R decode --count node) -eq 2 &&
-    test $(flux R encode --ranks 0,2 | flux R decode --count core) -eq 2 &&
-    test $(flux R encode --ranks 0,2 | flux R decode --ranks) = "0,2"
+	test $(flux R encode --ranks 0-1 | flux R decode --count node) -eq 2 &&
+	test $(flux R encode --ranks 0,2 | flux R decode --count node) -eq 2 &&
+	test $(flux R encode --ranks 0,2 | flux R decode --count core) -eq 2 &&
+	test $(flux R encode --ranks 0,2 | flux R decode --ranks) = "0,2"
 '
 test_expect_success 'flux R encode --cores works ' '
-    test $(flux R encode --cores 0-1 | flux R decode --count node) -eq 1 &&
-    test $(flux R encode --cores 0-1 | flux R decode --count core) -eq 2 &&
-    test $(flux R encode -c 0-1 -r 0-1 | flux R decode -c core) -eq 4
+	test $(flux R encode --cores 0-1 | flux R decode --count node) -eq 1 &&
+	test $(flux R encode --cores 0-1 | flux R decode --count core) -eq 2 &&
+	test $(flux R encode -c 0-1 -r 0-1 | flux R decode -c core) -eq 4
 '
 test_expect_success 'flux R encode --gpus works' '
-    test $(flux R encode --gpus 0 | flux R decode --count node) -eq 1 &&
-    test $(flux R encode --gpus 0 | flux R decode --count gpu) -eq 1 &&
-    test $(flux R encode --gpus 0 | flux R decode --count core) -eq 0 &&
-    test $(flux R encode --cores 0-1 -g 0 | flux R decode --count core) -eq 2 &&
-    test $(flux R encode --cores 0-1 -g 0 | flux R decode --count gpu) -eq 1
+	test $(flux R encode --gpus 0 | flux R decode --count node) -eq 1 &&
+	test $(flux R encode --gpus 0 | flux R decode --count gpu) -eq 1 &&
+	test $(flux R encode --gpus 0 | flux R decode --count core) -eq 0 &&
+	test $(flux R encode --cores 0-1 -g 0 | flux R decode --count core) -eq 2 &&
+	test $(flux R encode --cores 0-1 -g 0 | flux R decode --count gpu) -eq 1
 '
 test_expect_success 'flux R encode --hosts works' '
-    test $(flux R encode --hosts=foo[0-1] | flux R decode -c node) -eq 2 &&
-    hosts=$(flux R encode --hosts=foo[0-1] | flux R decode --nodelist) &&
-    test "$hosts" = "foo[0-1]"
+	test $(flux R encode --hosts=foo[0-1] | flux R decode -c node) -eq 2 &&
+	hosts=$(flux R encode --hosts=foo[0-1] | flux R decode --nodelist) &&
+	test "$hosts" = "foo[0-1]"
 '
 test_expect_success 'flux R encode/decode --property works' '
-    flux R encode --hosts=foo[0-1] --gpus 0 --cores 0-1  \
-        --property xx:0 \
-        --property yy:1 \
-        --property all > properties.json &&
-    test $(flux R decode -c node <properties.json) -eq 2 &&
-    test $(flux R decode -c node --properties all <properties.json) -eq 2 &&
-    test $(flux R decode -c node --properties xx <properties.json) -eq 1 &&
-    test $(flux R decode -c node --properties yy <properties.json) -eq 1 &&
-    test $(flux R decode -c node --properties ^all <properties.json) -eq 0 &&
-    test $(flux R decode -c node --properties all,yy <properties.json) -eq 1 &&
-    test $(flux R decode --nodelist --properties xx <properties.json) = foo0 &&
-    test $(flux R decode --nodelist --properties yy <properties.json) = foo1 &&
-    test $(flux R decode --nodelist --properties ^yy <properties.json) = foo0
+	flux R encode --hosts=foo[0-1] --gpus 0 --cores 0-1  \
+	    --property xx:0 \
+	    --property yy:1 \
+	    --property all > properties.json &&
+	test $(flux R decode -c node <properties.json) -eq 2 &&
+	test $(flux R decode -c node --properties all <properties.json) -eq 2 &&
+	test $(flux R decode -c node --properties xx <properties.json) -eq 1 &&
+	test $(flux R decode -c node --properties yy <properties.json) -eq 1 &&
+	test $(flux R decode -c node --properties ^all <properties.json) -eq 0 &&
+	test $(flux R decode -c node --properties all,yy <properties.json) -eq 1 &&
+	test $(flux R decode --nodelist --properties xx <properties.json) = foo0 &&
+	test $(flux R decode --nodelist --properties yy <properties.json) = foo1 &&
+	test $(flux R decode --nodelist --properties ^yy <properties.json) = foo0
 '
 test_expect_success 'flux R encode --property fails with invalid rank' '
-    test_must_fail flux R encode -r 0-3 -p xx:3-5 >property-fail.out 2>&1 &&
-    test_debug "cat property-fail.out" &&
-    grep "ranks 4-5 not found" property-fail.out
+	test_must_fail flux R encode -r 0-3 -p xx:3-5 >property-fail.out 2>&1 &&
+	test_debug "cat property-fail.out" &&
+	grep "ranks 4-5 not found" property-fail.out
 '
 test_expect_success 'flux R encode --xml works' '
-    flux R encode --xml=$SHARNESS_TEST_SRCDIR/hwloc-data/sierra2/0.xml \
-        > R.sierra2 &&
-    result=$(flux R decode --short < R.sierra2) &&
-    test_debug "echo encode XML = $result" &&
-    test "$result" = "rank0/core[0-43],gpu[0-3]"
+	flux R encode --xml=$SHARNESS_TEST_SRCDIR/hwloc-data/sierra2/0.xml \
+	    > R.sierra2 &&
+	result=$(flux R decode --short < R.sierra2) &&
+	test_debug "echo encode XML = $result" &&
+	test "$result" = "rank0/core[0-43],gpu[0-3]"
 '
 test_expect_success 'flux R encode --xml works with AMD RSMI gpus' '
-    flux R encode --xml=$SHARNESS_TEST_SRCDIR/hwloc-data/corona/0.xml \
-        > R.corona &&
-    result=$(flux R decode --short < R.corona) &&
-    test_debug "echo encode XML = $result" &&
-    test "$result" = "rank0/core[0-47],gpu[0-7]"
+	flux R encode --xml=$SHARNESS_TEST_SRCDIR/hwloc-data/corona/0.xml \
+	    > R.corona &&
+	result=$(flux R decode --short < R.corona) &&
+	test_debug "echo encode XML = $result" &&
+	test "$result" = "rank0/core[0-47],gpu[0-7]"
 '
 test_expect_success 'flux R decode --include works' '
-    result=$(flux R encode -r 0-1023 | flux R decode --include 5-7 --short) &&
-    test_debug "echo $result" &&
-    test "$result" = "rank[5-7]/core0"
+	result=$(flux R encode -r 0-1023 | flux R decode --include 5-7 --short) &&
+	test_debug "echo $result" &&
+	test "$result" = "rank[5-7]/core0"
 '
 test_expect_success 'flux R decode --exclude works' '
-    result=$(flux R encode -r 1-10 | flux R decode --exclude 5-7 --short) &&
-    test_debug "echo $result" &&
-    test "$result" = "rank[1-4,8-10]/core0"
+	result=$(flux R encode -r 1-10 | flux R decode --exclude 5-7 --short) &&
+	test_debug "echo $result" &&
+	test "$result" = "rank[1-4,8-10]/core0"
 '
 test_expect_success 'flux R append fails if R sets intersect' '
-    (flux R encode -r 0-1 && flux R encode -r 1-2) \
-        | test_must_fail flux R append  &&
-    (flux R encode -r 0-1 -c 0-1 -g 0 && flux R encode -r 1 -c 2-3 -g 0) \
-        | test_must_fail flux R append
+	(flux R encode -r 0-1 && flux R encode -r 1-2) \
+	    | test_must_fail flux R append  &&
+	(flux R encode -r 0-1 -c 0-1 -g 0 && flux R encode -r 1 -c 2-3 -g 0) \
+	    | test_must_fail flux R append
 '
 test_expect_success 'flux R append works' '
-    result=$( (flux R encode -r 0-1 -c 0-1 && flux R encode -r 1-2 -c 2-3) \
-        | flux R append | flux R decode --short) &&
-    test_debug "echo $result" &&
-    test "$result" = "rank0/core[0-1] rank1/core[0-3] rank2/core[2-3]"
+	result=$( (flux R encode -r 0-1 -c 0-1 && flux R encode -r 1-2 -c 2-3) \
+	    | flux R append | flux R decode --short) &&
+	test_debug "echo $result" &&
+	test "$result" = "rank0/core[0-1] rank1/core[0-3] rank2/core[2-3]"
 '
 test_expect_success 'flux R append works when only some nodes have gpus' '
-    result=$( (flux R encode -r 0-1 -c 0-1 && \
+	result=$( (flux R encode -r 0-1 -c 0-1 && \
 	       flux R encode -r 2-3 -c 0-1 -g 0-1) \
-        | flux R append | flux R decode --short) &&
-    test_debug "echo $result" &&
-    test "$result" = "rank[0-1]/core[0-1] rank[2-3]/core[0-1],gpu[0-1]"
+	    | flux R append | flux R decode --short) &&
+	test_debug "echo $result" &&
+	test "$result" = "rank[0-1]/core[0-1] rank[2-3]/core[0-1],gpu[0-1]"
 '
 
 test_expect_success 'flux R diff works' '
-    result=$( (flux R encode -r 0-1 -c 0-1 && flux R encode -r 0-1 -c 0) \
-        | flux R diff | flux R decode --short) &&
-    test_debug "echo $result" &&
-    test "$result" = "rank[0-1]/core1"
+	result=$( (flux R encode -r 0-1 -c 0-1 && flux R encode -r 0-1 -c 0) \
+	    | flux R diff | flux R decode --short) &&
+	test_debug "echo $result" &&
+	test "$result" = "rank[0-1]/core1"
 '
 test_expect_success 'flux R intersect works' '
-    result=$( (flux R encode -r 0-3 -c 0-1 && flux R encode -r 1-5 -c 0) \
-        | flux R intersect | flux R decode --short) &&
-    test_debug "echo $result" &&
-    test "$result" = "rank[1-3]/core0" &&
-    result=$( (flux R encode -r 0-3 -c 0-1 && flux R encode -r 4-5 -c 0) \
-        | flux R intersect | flux R decode --short) &&
-    test_debug "echo $result" &&
-    test -z "$result"
+	result=$( (flux R encode -r 0-3 -c 0-1 && flux R encode -r 1-5 -c 0) \
+	    | flux R intersect | flux R decode --short) &&
+	test_debug "echo $result" &&
+	test "$result" = "rank[1-3]/core0" &&
+	result=$( (flux R encode -r 0-3 -c 0-1 && flux R encode -r 4-5 -c 0) \
+	    | flux R intersect | flux R decode --short) &&
+	test_debug "echo $result" &&
+	test -z "$result"
 '
 test_expect_success 'flux R remap works' '
-    result=$(flux R encode -r 5,99,1000 | flux R remap | flux R decode -s) &&
-    test_debug "echo $result" &&
-    test "$result" = "rank[0-2]/core0"
+	result=$(flux R encode -r 5,99,1000 | flux R remap | flux R decode -s) &&
+	test_debug "echo $result" &&
+	test "$result" = "rank[0-2]/core0"
 '
 test_expect_success 'flux R rerank works' '
-    result=$(flux R encode -r 0-3 -H foo[0-3] \
-        | flux R rerank foo[3,2,1,0] | flux R decode --nodelist) &&
-    test_debug "echo reranked $result" &&
-    test "$result" = "foo[3,2,1,0]"
+	result=$(flux R encode -r 0-3 -H foo[0-3] \
+	    | flux R rerank foo[3,2,1,0] | flux R decode --nodelist) &&
+	test_debug "echo reranked $result" &&
+	test "$result" = "foo[3,2,1,0]"
 '
 test_expect_success 'flux R verify works' '
-    result=$( (flux R encode -r 1-10 -c 0-3 && flux R encode -r 1 -c 0-3) \
-            | flux R verify 2>&1) &&
-    test_debug "echo $result"
+	result=$( (flux R encode -r 1-10 -c 0-3 && flux R encode -r 1 -c 0-3) \
+	        | flux R verify 2>&1) &&
+	test_debug "echo $result"
 '
 test_expect_success 'flux R verify fails with mismatched ranks' '
-    result=$( (flux R encode -r 1-10 -c 0-3 && flux R encode -r 0 -c 0-3) \
-            | test_must_fail flux R verify 2>&1) &&
-    test_debug "echo $result"
+	result=$( (flux R encode -r 1-10 -c 0-3 && flux R encode -r 0 -c 0-3) \
+	        | test_must_fail flux R verify 2>&1) &&
+	test_debug "echo $result"
 '
 test_expect_success 'flux R verify fails with mismatched hosts' '
-    result=$( (flux R encode -r 1 -c 0-3 -H foo1 \
-               && flux R encode -r 1 -c 0-3 -H foo12) \
-            | test_must_fail flux R verify 2>&1) &&
-    test_debug "echo $result"
+	result=$( (flux R encode -r 1 -c 0-3 -H foo1 \
+	           && flux R encode -r 1 -c 0-3 -H foo12) \
+	        | test_must_fail flux R verify 2>&1) &&
+	test_debug "echo $result"
 '
 test_expect_success 'flux R verify fails with mismatched resources' '
-    (flux R encode  -r 1 -c 0-3 && flux R encode -r 1 -c 0-2) \
-        | test_must_fail flux R verify
+	(flux R encode  -r 1 -c 0-3 && flux R encode -r 1 -c 0-2) \
+	    | test_must_fail flux R verify
 '
 test_expect_success 'flux R verify reports extra resources' '
-    (flux R encode  -r 1 -c 0-3 && flux R encode -r 1 -c 0-7 -g 1) \
-        | flux R verify
+	(flux R encode  -r 1 -c 0-3 && flux R encode -r 1 -c 0-7 -g 1) \
+	    | flux R verify
 '
 test_expect_success 'flux R set-property works' '
-    flux R encode -r 0-1 -c 0-3 -H foo[0-1] | \
-        flux R set-property all | \
-        flux R set-property xx:0 yy:1 > setprop.json &&
-    test $(flux R decode -c node <setprop.json) -eq 2 &&
-    test $(flux R decode -c node --properties all <setprop.json) -eq 2 &&
-    test $(flux R decode -c node --properties xx <setprop.json) -eq 1 &&
-    test $(flux R decode -c node --properties yy <setprop.json) -eq 1 &&
-    test $(flux R decode -c node --properties ^all <setprop.json) -eq 0 &&
-    test $(flux R decode -c node --properties all,yy <setprop.json) -eq 1 &&
-    test $(flux R decode --nodelist --properties xx <setprop.json) = foo0 &&
-    test $(flux R decode --nodelist --properties yy <setprop.json) = foo1 &&
-    test $(flux R decode --nodelist --properties ^yy <setprop.json) = foo0
+	flux R encode -r 0-1 -c 0-3 -H foo[0-1] | \
+	    flux R set-property all | \
+	    flux R set-property xx:0 yy:1 > setprop.json &&
+	test $(flux R decode -c node <setprop.json) -eq 2 &&
+	test $(flux R decode -c node --properties all <setprop.json) -eq 2 &&
+	test $(flux R decode -c node --properties xx <setprop.json) -eq 1 &&
+	test $(flux R decode -c node --properties yy <setprop.json) -eq 1 &&
+	test $(flux R decode -c node --properties ^all <setprop.json) -eq 0 &&
+	test $(flux R decode -c node --properties all,yy <setprop.json) -eq 1 &&
+	test $(flux R decode --nodelist --properties xx <setprop.json) = foo0 &&
+	test $(flux R decode --nodelist --properties yy <setprop.json) = foo1 &&
+	test $(flux R decode --nodelist --properties ^yy <setprop.json) = foo0
 '
 test_expect_success 'flux R set-property fails with unknown ranks' '
-    flux R encode -r 0-1 | test_must_fail flux R set-property foo:1-2
+	flux R encode -r 0-1 | test_must_fail flux R set-property foo:1-2
 '
 test_expect_success HAVE_JQ 'scheduling opaque key is preserved' '
-    flux R encode -r 0-3 -c 0-3 -g 0 -H foo[0-3] \
-        | jq ".scheduling = 42" > R.orig &&
-    flux R decode < R.orig | jq -e ".scheduling == 42" &&
-    flux R decode --include 0 < R.orig | jq -e ".scheduling == 42" &&
-    flux R decode --exclude 0 < R.orig | jq -e ".scheduling == 42"
+	flux R encode -r 0-3 -c 0-3 -g 0 -H foo[0-3] \
+	    | jq ".scheduling = 42" > R.orig &&
+	flux R decode < R.orig | jq -e ".scheduling == 42" &&
+	flux R decode --include 0 < R.orig | jq -e ".scheduling == 42" &&
+	flux R decode --exclude 0 < R.orig | jq -e ".scheduling == 42"
 '
 test_expect_success HAVE_JQ 'scheduling opaque key is preserved with append' '
-    (cat R.orig && flux R encode -r 4 ) | flux R append \
-        | flux R decode | jq -e ".scheduling == 42"
+	(cat R.orig && flux R encode -r 4 ) | flux R append \
+	    | flux R decode | jq -e ".scheduling == 42"
 '
 test_expect_success HAVE_JQ 'scheduling opaque key is preserved with remap' '
-    flux R remap < R.orig | flux R decode | jq -e ".scheduling == 42"
+	flux R remap < R.orig | flux R decode | jq -e ".scheduling == 42"
 '
 test_expect_success HAVE_JQ 'scheduling opaque key is preserved with diff' '
-    (cat R.orig && flux R encode -r 1 ) | flux R diff \
-        | jq -e ".scheduling == 42"
+	(cat R.orig && flux R encode -r 1 ) | flux R diff \
+	    | jq -e ".scheduling == 42"
 '
 test_expect_success HAVE_JQ 'scheduling key is preserved with intersect' '
-    (cat R.orig && flux R encode -r 1 -H foo1) | flux R intersect \
-        | jq -e ".scheduling == 42"
+	(cat R.orig && flux R encode -r 1 -H foo1) | flux R intersect \
+	    | jq -e ".scheduling == 42"
 '
 test_expect_success HAVE_JQ 'use of --local,--xml and --hosts is supported' '
-    ncores=$(flux R encode --local | flux R decode --count cores) &&
-    flux R encode --local --hosts=fluke[0-16] > R.hosts &&
-    test_debug "flux R decode --short < R.hosts" &&
-    count=$(flux R decode --count cores < R.hosts) &&
-    test "$count" = "$ncores" &&
-    hosts=$(flux R decode --nodelist < R.hosts) &&
-    test_debug "echo got $hosts" &&
-    test "$hosts" = "fluke[0-16]"
+	ncores=$(flux R encode --local | flux R decode --count cores) &&
+	flux R encode --local --hosts=fluke[0-16] > R.hosts &&
+	test_debug "flux R decode --short < R.hosts" &&
+	count=$(flux R decode --count cores < R.hosts) &&
+	test "$count" = "$ncores" &&
+	hosts=$(flux R decode --nodelist < R.hosts) &&
+	test_debug "echo got $hosts" &&
+	test "$hosts" = "fluke[0-16]"
 '
 test_done


### PR DESCRIPTION
After lamenting that configuration of resources via a hand edited _R_ or via use of `flux R encode` was confusing and error prone, @garlick and I had the idea that a simple configuration of resources in the `[resource]` TOML table might be a huge improvement.

This PR introduces support for a `resource.config` array which can be used to configure resources instead of `resource.path` pointing to the system _R_. The format of each entry in `resource.config` is a required `hosts` key pointing to a hostlist of node names to which the entry applies, then optional `cores`, `gpus` (in idset form), and `properties` (an array of properties to assign to `hosts`). It is not an error to specify a hostname more than once - in that case the host is updated not overwritten. E.g.:

```toml
[[resource.config]]
hosts = "corona[171-207,211-296]"
cores = "0-47"
gpus =  "0-7" 

[[resource.config]]
hosts = "corona[171-207,211-280]"
properties = ["batch"]

[[resource.config]]
hosts = "corona[281-296]"
properties = ["debug"]
```

The main benefit of this format is that the admin does not have to worry about ranks, which would be reassigned by the `resource` module based on the `[bootstrap]` hostlist anyway, and can focus on assigning resources and properties to hosts by name.