### PR TITLE
job-list: split out job information into new files                                                                                          

### DIFF
--- a/src/modules/job-list/Makefile.am
+++ b/src/modules/job-list/Makefile.am
@@ -20,6 +20,8 @@ job_list_la_SOURCES = \
 	job-list.h \
 	job_state.h \
 	job_state.c \
+	job_data.h \
+	job_data.c \
 	list.h \
 	list.c \
 	job_util.h \

--- a/src/modules/job-list/job-list.c
+++ b/src/modules/job-list/job-list.c
@@ -17,6 +17,7 @@
 
 #include "job-list.h"
 #include "job_state.h"
+#include "job_data.h"
 #include "list.h"
 #include "idsync.h"
 

--- a/src/modules/job-list/job_data.c
+++ b/src/modules/job-list/job_data.c
@@ -1,0 +1,345 @@
+/************************************************************\
+ * Copyright 2022 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* job_data.c - primary struct job helper functions */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <jansson.h>
+#include <flux/core.h>
+#include <assert.h>
+
+#include "src/common/libczmqcontainers/czmq_containers.h"
+#include "src/common/librlist/rlist.h"
+
+#include "job_data.h"
+
+void job_destroy (void *data)
+{
+    struct job *job = data;
+    if (job) {
+        free (job->ranks);
+        free (job->nodelist);
+        json_decref (job->annotations);
+        grudgeset_destroy (job->dependencies);
+        json_decref (job->jobspec);
+        json_decref (job->R);
+        json_decref (job->exception_context);
+        zlist_destroy (&job->next_states);
+        free (job);
+    }
+}
+
+struct job *job_create (struct list_ctx *ctx, flux_jobid_t id)
+{
+    struct job *job = NULL;
+
+    if (!(job = calloc (1, sizeof (*job))))
+        return NULL;
+    job->h = ctx->h;
+    job->ctx = ctx;
+    job->id = id;
+    job->userid = FLUX_USERID_UNKNOWN;
+    job->urgency = -1;
+    /* pending jobs that are not yet assigned a priority shall be
+     * listed after those who do, so we set the job priority to MIN */
+    job->priority = FLUX_JOB_PRIORITY_MIN;
+    job->state = FLUX_JOB_STATE_NEW;
+    job->ntasks = -1;
+    job->nnodes = -1;
+    job->expiration = -1.0;
+    job->wait_status = -1;
+    job->result = FLUX_JOB_RESULT_FAILED;
+
+    if (!(job->next_states = zlist_new ())) {
+        errno = ENOMEM;
+        job_destroy (job);
+        return NULL;
+    }
+
+    job->states_mask = FLUX_JOB_STATE_NEW;
+    job->states_events_mask = FLUX_JOB_STATE_NEW;
+    job->eventlog_seq = -1;
+    return job;
+}
+
+struct res_level {
+    const char *type;
+    int count;
+    json_t *with;
+};
+
+static int parse_res_level (struct job *job,
+                            json_t *o,
+                            struct res_level *resp)
+{
+    json_error_t error;
+    struct res_level res;
+
+    res.with = NULL;
+    /* For jobspec version 1, expect exactly one array element per level.
+     */
+    if (json_unpack_ex (o, &error, 0,
+                        "[{s:s s:i s?o}]",
+                        "type", &res.type,
+                        "count", &res.count,
+                        "with", &res.with) < 0) {
+        flux_log (job->h, LOG_ERR,
+                  "%s: job %ju invalid jobspec: %s",
+                  __FUNCTION__, (uintmax_t)job->id, error.text);
+        return -1;
+    }
+    *resp = res;
+    return 0;
+}
+
+/* Return basename of path if there is a '/' in path.  Otherwise return
+ * full path */
+static const char *parse_job_name (const char *path)
+{
+    char *p = strrchr (path, '/');
+    if (p) {
+        p++;
+        /* user mistake, specified a directory with trailing '/',
+         * return full path */
+        if (*p == '\0')
+            return path;
+        return p;
+    }
+    return path;
+}
+
+int job_parse_jobspec (struct job *job, const char *s)
+{
+    json_error_t error;
+    json_t *jobspec_job = NULL;
+    json_t *command = NULL;
+    json_t *tasks, *resources;
+    struct res_level res[3];
+    int rc = -1;
+
+    if (!(job->jobspec = json_loads (s, 0, &error))) {
+        flux_log (job->h, LOG_ERR,
+                  "%s: job %ju invalid jobspec: %s",
+                  __FUNCTION__, (uintmax_t)job->id, error.text);
+        goto error;
+    }
+
+    if (json_unpack_ex (job->jobspec, &error, 0,
+                        "{s:{s:{s?:o}}}",
+                        "attributes",
+                        "system",
+                        "job",
+                        &jobspec_job) < 0) {
+        flux_log (job->h, LOG_ERR,
+                  "%s: job %ju invalid jobspec: %s",
+                  __FUNCTION__, (uintmax_t)job->id, error.text);
+        goto nonfatal_error;
+    }
+
+    if (jobspec_job) {
+        if (!json_is_object (jobspec_job)) {
+            flux_log (job->h, LOG_ERR,
+                      "%s: job %ju invalid jobspec",
+                      __FUNCTION__, (uintmax_t)job->id);
+            goto nonfatal_error;
+        }
+    }
+
+    if (json_unpack_ex (job->jobspec, &error, 0,
+                        "{s:o}",
+                        "tasks", &tasks) < 0) {
+        flux_log (job->h, LOG_ERR,
+                  "%s: job %ju invalid jobspec: %s",
+                  __FUNCTION__, (uintmax_t)job->id, error.text);
+        goto nonfatal_error;
+    }
+    if (json_unpack_ex (tasks, &error, 0,
+                        "[{s:o}]",
+                        "command", &command) < 0) {
+        flux_log (job->h, LOG_ERR,
+                  "%s: job %ju invalid jobspec: %s",
+                  __FUNCTION__, (uintmax_t)job->id, error.text);
+        goto nonfatal_error;
+    }
+
+    if (!json_is_array (command)) {
+        flux_log (job->h, LOG_ERR,
+                  "%s: job %ju invalid jobspec",
+                  __FUNCTION__, (uintmax_t)job->id);
+        goto nonfatal_error;
+    }
+
+    if (jobspec_job) {
+        if (json_unpack_ex (jobspec_job, &error, 0,
+                            "{s?:s}",
+                            "name", &job->name) < 0) {
+            flux_log (job->h, LOG_ERR,
+                      "%s: job %ju invalid job dictionary: %s",
+                      __FUNCTION__, (uintmax_t)job->id, error.text);
+            goto nonfatal_error;
+        }
+    }
+
+    /* If user did not specify job.name, we treat arg 0 of the command
+     * as the job name */
+    if (!job->name) {
+        json_t *arg0 = json_array_get (command, 0);
+        if (!arg0 || !json_is_string (arg0)) {
+            flux_log (job->h, LOG_ERR,
+                      "%s: job %ju invalid job command",
+                      __FUNCTION__, (uintmax_t)job->id);
+            goto nonfatal_error;
+        }
+        job->name = parse_job_name (json_string_value (arg0));
+        assert (job->name);
+    }
+
+    if (json_unpack_ex (job->jobspec, &error, 0,
+                        "{s:o}",
+                        "resources", &resources) < 0) {
+        flux_log (job->h, LOG_ERR,
+                  "%s: job %ju invalid jobspec: %s",
+                  __FUNCTION__, (uintmax_t)job->id, error.text);
+        goto nonfatal_error;
+    }
+
+    /* For jobspec version 1, expect either:
+     * - node->slot->core->NIL
+     * - slot->core->NIL
+     */
+    memset (res, 0, sizeof (res));
+    if (parse_res_level (job, resources, &res[0]) < 0)
+        goto nonfatal_error;
+    if (res[0].with && parse_res_level (job, res[0].with, &res[1]) < 0)
+        goto nonfatal_error;
+    if (res[1].with && parse_res_level (job, res[1].with, &res[2]) < 0)
+        goto nonfatal_error;
+
+    /* Set job->nnodes if available.  In jobspec version 1, only if
+     * resources listed as node->slot->core->NIL
+     */
+    if (res[0].type != NULL && !strcmp (res[0].type, "node")
+        && res[1].type != NULL && !strcmp (res[1].type, "slot")
+        && res[2].type != NULL && !strcmp (res[2].type, "core")
+        && res[2].with == NULL)
+        job->nnodes = res[0].count;
+
+    /* Set job->ntasks
+     */
+    if (json_unpack_ex (tasks, NULL, 0,
+                        "[{s:{s:i}}]",
+                        "count", "total", &job->ntasks) < 0) {
+        int per_slot, slot_count = 0;
+
+        if (json_unpack_ex (tasks, &error, 0,
+                            "[{s:{s:i}}]",
+                            "count", "per_slot", &per_slot) < 0) {
+            flux_log (job->h, LOG_ERR,
+                      "%s: job %ju invalid jobspec: %s",
+                      __FUNCTION__, (uintmax_t)job->id, error.text);
+            goto nonfatal_error;
+        }
+        if (per_slot != 1) {
+            flux_log (job->h, LOG_ERR,
+                      "%s: job %ju: per_slot count: expected 1 got %d",
+                      __FUNCTION__, (uintmax_t)job->id, per_slot);
+            goto nonfatal_error;
+        }
+        if (res[0].type != NULL && !strcmp (res[0].type, "slot")
+            && res[1].type != NULL && !strcmp (res[1].type, "core")
+            && res[1].with == NULL) {
+            slot_count = res[0].count;
+        }
+        else if (res[0].type != NULL && !strcmp (res[0].type, "node")
+                 && res[1].type != NULL && !strcmp (res[1].type, "slot")
+                 && res[2].type != NULL && !strcmp (res[2].type, "core")
+                 && res[2].with == NULL) {
+            slot_count = res[0].count * res[1].count;
+        }
+        else {
+            flux_log (job->h, LOG_WARNING,
+                      "%s: job %ju: Unexpected resources: %s->%s->%s%s",
+                      __FUNCTION__,
+                      (uintmax_t)job->id,
+                      res[0].type ? res[0].type : "NULL",
+                      res[1].type ? res[1].type : "NULL",
+                      res[2].type ? res[2].type : "NULL",
+                      res[2].with ? "->..." : NULL);
+            slot_count = -1;
+        }
+        job->ntasks = slot_count;
+    }
+
+    /* nonfatal error - jobspec illegal, but we'll continue on.  job
+     * listing will return whatever data is available */
+nonfatal_error:
+    rc = 0;
+error:
+    return rc;
+}
+
+int job_parse_R (struct job *job, const char *s)
+{
+    struct rlist *rl = NULL;
+    struct idset *idset = NULL;
+    struct hostlist *hl = NULL;
+    json_error_t error;
+    int flags = IDSET_FLAG_BRACKETS | IDSET_FLAG_RANGE;
+    int saved_errno, rc = -1;
+
+    if (!(job->R = json_loads (s, 0, &error))) {
+        flux_log (job->h, LOG_ERR,
+                  "%s: job %ju invalid R: %s",
+                  __FUNCTION__, (uintmax_t)job->id, error.text);
+        goto nonfatal_error;
+    }
+
+    if (!(rl = rlist_from_json (job->R, &error))) {
+        flux_log_error (job->h, "rlist_from_json: %s", error.text);
+        goto nonfatal_error;
+    }
+
+    job->expiration = rl->expiration;
+
+    if (!(idset = rlist_ranks (rl)))
+        goto nonfatal_error;
+
+    job->nnodes = idset_count (idset);
+    if (!(job->ranks = idset_encode (idset, flags)))
+        goto nonfatal_error;
+
+    /* reading nodelist from R directly would avoid the creation /
+     * destruction of a hostlist.  However, we get a hostlist to
+     * ensure that the nodelist we return to users is consistently
+     * formatted.
+     */
+    if (!(hl = rlist_nodelist (rl)))
+        goto nonfatal_error;
+
+    if (!(job->nodelist = hostlist_encode (hl)))
+        goto nonfatal_error;
+
+    /* nonfatal error - invalid R, but we'll continue on.  job listing
+     * will get initialized data */
+nonfatal_error:
+    rc = 0;
+    saved_errno = errno;
+    hostlist_destroy (hl);
+    idset_destroy (idset);
+    rlist_destroy (rl);
+    errno = saved_errno;
+    return rc;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/job-list/job_data.h
+++ b/src/modules/job-list/job_data.h
@@ -1,0 +1,110 @@
+/************************************************************\
+ * Copyright 2018 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _FLUX_JOB_LIST_JOB_DATA_H
+#define _FLUX_JOB_LIST_JOB_DATA_H
+
+#include <flux/core.h>
+#include <jansson.h>
+
+#include "job-list.h"
+#include "src/common/libutil/grudgeset.h"
+#include "src/common/libczmqcontainers/czmq_containers.h"
+
+/* timestamp of when we enter the state
+ *
+ * associated eventlog entries when restarting
+ *
+ * t_depend - "submit"
+ * t_priority - "priority" (not saved, can be entered multiple times)
+ * t_sched - "depend" (not saved, can be entered multiple times)
+ * t_run - "alloc"
+ * t_cleanup - "finish" or "exception" w/ severity == 0
+ * t_inactive - "clean"
+ */
+struct job {
+    flux_t *h;
+    struct list_ctx *ctx;
+
+    flux_jobid_t id;
+    uint32_t userid;
+    int urgency;
+    int64_t priority;
+    double t_submit;
+    // t_depend is identical to t_submit
+    // double t_depend;
+    double t_run;
+    double t_cleanup;
+    double t_inactive;
+    flux_job_state_t state;
+    const char *name;
+    int ntasks;
+    int nnodes;
+    char *ranks;
+    char *nodelist;
+    double expiration;
+    int wait_status;
+    bool success;
+    bool exception_occurred;
+    int exception_severity;
+    const char *exception_type;
+    const char *exception_note;
+    flux_job_result_t result;
+    json_t *annotations;
+    struct grudgeset *dependencies;
+
+    /* cache of job information */
+    json_t *jobspec;
+    json_t *R;
+    json_t *exception_context;
+
+    /* Track which states we have seen and have completed transition
+     * to.  We do not immediately update to the new state and place
+     * onto a new list until we have retrieved any necessary data
+     * associated to that state.  For example, when the 'depend' state
+     * has been seen, we don't immediately place it on the `pending`
+     * list.  We wait until we've retrieved data such as userid,
+     * urgency, etc.
+     *
+     * Track which states we've seen via the states_mask.
+     *
+     * Track states seen via events stream in states_events_mask.
+     */
+    zlist_t *next_states;
+    unsigned int states_mask;
+    unsigned int states_events_mask;
+    void *list_handle;
+
+    int eventlog_seq;           /* last event seq read */
+};
+
+void job_destroy (void *data);
+
+struct job *job_create (struct list_ctx *ctx, flux_jobid_t id);
+
+/* Parse and internally cache jobspec.  Set values for:
+ * - job name
+ * - ntasks
+ * - nnodes (if available)
+ */
+int job_parse_jobspec (struct job *job, const char *s);
+
+/* Parse and internally cache R.  Set values for:
+ * - expiration
+ * - nnodes
+ * - nodelist
+ */
+int job_parse_R (struct job *job, const char *s);
+
+#endif /* ! _FLUX_JOB_LIST_JOB_DATA_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/modules/job-list/job_state.c
+++ b/src/modules/job-list/job_state.c
@@ -24,10 +24,10 @@
 #include "src/common/libutil/jpath.h"
 #include "src/common/libutil/grudgeset.h"
 #include "src/common/libjob/job_hash.h"
-#include "src/common/librlist/rlist.h"
 #include "src/common/libidset/idset.h"
 
 #include "job_state.h"
+#include "job_data.h"
 #include "idsync.h"
 #include "job_util.h"
 
@@ -114,58 +114,10 @@ static int job_inactive_cmp (const void *a1, const void *a2)
     return NUMCMP (j2->t_inactive, j1->t_inactive);
 }
 
-static void job_destroy (void *data)
-{
-    struct job *job = data;
-    if (job) {
-        free (job->ranks);
-        free (job->nodelist);
-        json_decref (job->annotations);
-        grudgeset_destroy (job->dependencies);
-        json_decref (job->jobspec);
-        json_decref (job->R);
-        json_decref (job->exception_context);
-        zlist_destroy (&job->next_states);
-        free (job);
-    }
-}
-
 static void job_destroy_wrapper (void **data)
 {
     struct job **job = (struct job **)data;
     job_destroy (*job);
-}
-
-static struct job *job_create (struct list_ctx *ctx, flux_jobid_t id)
-{
-    struct job *job = NULL;
-
-    if (!(job = calloc (1, sizeof (*job))))
-        return NULL;
-    job->ctx = ctx;
-    job->id = id;
-    job->userid = FLUX_USERID_UNKNOWN;
-    job->urgency = -1;
-    /* pending jobs that are not yet assigned a priority shall be
-     * listed after those who do, so we set the job priority to MIN */
-    job->priority = FLUX_JOB_PRIORITY_MIN;
-    job->state = FLUX_JOB_STATE_NEW;
-    job->ntasks = -1;
-    job->nnodes = -1;
-    job->expiration = -1.0;
-    job->wait_status = -1;
-    job->result = FLUX_JOB_RESULT_FAILED;
-
-    if (!(job->next_states = zlist_new ())) {
-        errno = ENOMEM;
-        job_destroy (job);
-        return NULL;
-    }
-
-    job->states_mask = FLUX_JOB_STATE_NEW;
-    job->states_events_mask = FLUX_JOB_STATE_NEW;
-    job->eventlog_seq = -1;
-    return job;
 }
 
 /* zlistx_insert() and zlistx_reorder() take a 'low_value' parameter
@@ -342,225 +294,6 @@ static void check_waiting_id (struct list_ctx *ctx,
     }
 }
 
-struct res_level {
-    const char *type;
-    int count;
-    json_t *with;
-};
-
-static int parse_res_level (struct list_ctx *ctx,
-                            struct job *job,
-                            json_t *o,
-                            struct res_level *resp)
-{
-    json_error_t error;
-    struct res_level res;
-
-    res.with = NULL;
-    /* For jobspec version 1, expect exactly one array element per level.
-     */
-    if (json_unpack_ex (o, &error, 0,
-                        "[{s:s s:i s?o}]",
-                        "type", &res.type,
-                        "count", &res.count,
-                        "with", &res.with) < 0) {
-        flux_log (ctx->h, LOG_ERR,
-                  "%s: job %ju invalid jobspec: %s",
-                  __FUNCTION__, (uintmax_t)job->id, error.text);
-        return -1;
-    }
-    *resp = res;
-    return 0;
-}
-
-/* Return basename of path if there is a '/' in path.  Otherwise return
- * full path */
-static const char *parse_job_name (const char *path)
-{
-    char *p = strrchr (path, '/');
-    if (p) {
-        p++;
-        /* user mistake, specified a directory with trailing '/',
-         * return full path */
-        if (*p == '\0')
-            return path;
-        return p;
-    }
-    return path;
-}
-
-static int jobspec_parse (struct list_ctx *ctx,
-                          struct job *job,
-                          const char *s)
-{
-    json_error_t error;
-    json_t *jobspec_job = NULL;
-    json_t *command = NULL;
-    json_t *tasks, *resources;
-    struct res_level res[3];
-    int rc = -1;
-
-    if (!(job->jobspec = json_loads (s, 0, &error))) {
-        flux_log (ctx->h, LOG_ERR,
-                  "%s: job %ju invalid jobspec: %s",
-                  __FUNCTION__, (uintmax_t)job->id, error.text);
-        goto error;
-    }
-
-    if (json_unpack_ex (job->jobspec, &error, 0,
-                        "{s:{s:{s?:o}}}",
-                        "attributes",
-                        "system",
-                        "job",
-                        &jobspec_job) < 0) {
-        flux_log (ctx->h, LOG_ERR,
-                  "%s: job %ju invalid jobspec: %s",
-                  __FUNCTION__, (uintmax_t)job->id, error.text);
-        goto nonfatal_error;
-    }
-
-    if (jobspec_job) {
-        if (!json_is_object (jobspec_job)) {
-            flux_log (ctx->h, LOG_ERR,
-                      "%s: job %ju invalid jobspec",
-                      __FUNCTION__, (uintmax_t)job->id);
-            goto nonfatal_error;
-        }
-    }
-
-    if (json_unpack_ex (job->jobspec, &error, 0,
-                        "{s:o}",
-                        "tasks", &tasks) < 0) {
-        flux_log (ctx->h, LOG_ERR,
-                  "%s: job %ju invalid jobspec: %s",
-                  __FUNCTION__, (uintmax_t)job->id, error.text);
-        goto nonfatal_error;
-    }
-    if (json_unpack_ex (tasks, &error, 0,
-                        "[{s:o}]",
-                        "command", &command) < 0) {
-        flux_log (ctx->h, LOG_ERR,
-                  "%s: job %ju invalid jobspec: %s",
-                  __FUNCTION__, (uintmax_t)job->id, error.text);
-        goto nonfatal_error;
-    }
-
-    if (!json_is_array (command)) {
-        flux_log (ctx->h, LOG_ERR,
-                  "%s: job %ju invalid jobspec",
-                  __FUNCTION__, (uintmax_t)job->id);
-        goto nonfatal_error;
-    }
-
-    if (jobspec_job) {
-        if (json_unpack_ex (jobspec_job, &error, 0,
-                            "{s?:s}",
-                            "name", &job->name) < 0) {
-            flux_log (ctx->h, LOG_ERR,
-                      "%s: job %ju invalid job dictionary: %s",
-                      __FUNCTION__, (uintmax_t)job->id, error.text);
-            goto nonfatal_error;
-        }
-    }
-
-    /* If user did not specify job.name, we treat arg 0 of the command
-     * as the job name */
-    if (!job->name) {
-        json_t *arg0 = json_array_get (command, 0);
-        if (!arg0 || !json_is_string (arg0)) {
-            flux_log (ctx->h, LOG_ERR,
-                      "%s: job %ju invalid job command",
-                      __FUNCTION__, (uintmax_t)job->id);
-            goto nonfatal_error;
-        }
-        job->name = parse_job_name (json_string_value (arg0));
-        assert (job->name);
-    }
-
-    if (json_unpack_ex (job->jobspec, &error, 0,
-                        "{s:o}",
-                        "resources", &resources) < 0) {
-        flux_log (ctx->h, LOG_ERR,
-                  "%s: job %ju invalid jobspec: %s",
-                  __FUNCTION__, (uintmax_t)job->id, error.text);
-        goto nonfatal_error;
-    }
-
-    /* For jobspec version 1, expect either:
-     * - node->slot->core->NIL
-     * - slot->core->NIL
-     */
-    memset (res, 0, sizeof (res));
-    if (parse_res_level (ctx, job, resources, &res[0]) < 0)
-        goto nonfatal_error;
-    if (res[0].with && parse_res_level (ctx, job, res[0].with, &res[1]) < 0)
-        goto nonfatal_error;
-    if (res[1].with && parse_res_level (ctx, job, res[1].with, &res[2]) < 0)
-        goto nonfatal_error;
-
-    /* Set job->nnodes if available.  In jobspec version 1, only if
-     * resources listed as node->slot->core->NIL
-     */
-    if (res[0].type != NULL && !strcmp (res[0].type, "node")
-        && res[1].type != NULL && !strcmp (res[1].type, "slot")
-        && res[2].type != NULL && !strcmp (res[2].type, "core")
-        && res[2].with == NULL)
-        job->nnodes = res[0].count;
-
-    /* Set job->ntasks
-     */
-    if (json_unpack_ex (tasks, NULL, 0,
-                        "[{s:{s:i}}]",
-                        "count", "total", &job->ntasks) < 0) {
-        int per_slot, slot_count = 0;
-
-        if (json_unpack_ex (tasks, &error, 0,
-                            "[{s:{s:i}}]",
-                            "count", "per_slot", &per_slot) < 0) {
-            flux_log (ctx->h, LOG_ERR,
-                      "%s: job %ju invalid jobspec: %s",
-                      __FUNCTION__, (uintmax_t)job->id, error.text);
-            goto nonfatal_error;
-        }
-        if (per_slot != 1) {
-            flux_log (ctx->h, LOG_ERR,
-                      "%s: job %ju: per_slot count: expected 1 got %d",
-                      __FUNCTION__, (uintmax_t)job->id, per_slot);
-            goto nonfatal_error;
-        }
-        if (res[0].type != NULL && !strcmp (res[0].type, "slot")
-            && res[1].type != NULL && !strcmp (res[1].type, "core")
-            && res[1].with == NULL) {
-            slot_count = res[0].count;
-        }
-        else if (res[0].type != NULL && !strcmp (res[0].type, "node")
-                 && res[1].type != NULL && !strcmp (res[1].type, "slot")
-                 && res[2].type != NULL && !strcmp (res[2].type, "core")
-                 && res[2].with == NULL) {
-            slot_count = res[0].count * res[1].count;
-        }
-        else {
-            flux_log (ctx->h, LOG_WARNING,
-                      "%s: job %ju: Unexpected resources: %s->%s->%s%s",
-                      __FUNCTION__,
-                      (uintmax_t)job->id,
-                      res[0].type ? res[0].type : "NULL",
-                      res[1].type ? res[1].type : "NULL",
-                      res[2].type ? res[2].type : "NULL",
-                      res[2].with ? "->..." : NULL);
-            slot_count = -1;
-        }
-        job->ntasks = slot_count;
-    }
-
-    /* nonfatal error - jobspec illegal, but we'll continue on.  job
-     * listing will return whatever data is available */
-nonfatal_error:
-    rc = 0;
-error:
-    return rc;
-}
-
 static void state_depend_lookup_continuation (flux_future_t *f, void *arg)
 {
     struct job *job = arg;
@@ -575,7 +308,7 @@ static void state_depend_lookup_continuation (flux_future_t *f, void *arg)
         goto out;
     }
 
-    if (jobspec_parse (ctx, job, s) < 0)
+    if (job_parse_jobspec (job, s) < 0)
         goto out;
 
     st = zlist_head (job->next_states);
@@ -621,61 +354,6 @@ static flux_future_t *state_depend_lookup (struct job_state_ctx *jsctx,
     return NULL;
 }
 
-static int R_lookup_parse (struct list_ctx *ctx,
-                           struct job *job,
-                           const char *s)
-{
-    struct rlist *rl = NULL;
-    struct idset *idset = NULL;
-    struct hostlist *hl = NULL;
-    json_error_t error;
-    int flags = IDSET_FLAG_BRACKETS | IDSET_FLAG_RANGE;
-    int saved_errno, rc = -1;
-
-    if (!(job->R = json_loads (s, 0, &error))) {
-        flux_log (ctx->h, LOG_ERR,
-                  "%s: job %ju invalid R: %s",
-                  __FUNCTION__, (uintmax_t)job->id, error.text);
-        goto nonfatal_error;
-    }
-
-    if (!(rl = rlist_from_json (job->R, &error))) {
-        flux_log_error (ctx->h, "rlist_from_json: %s", error.text);
-        goto nonfatal_error;
-    }
-
-    job->expiration = rl->expiration;
-
-    if (!(idset = rlist_ranks (rl)))
-        goto nonfatal_error;
-
-    job->nnodes = idset_count (idset);
-    if (!(job->ranks = idset_encode (idset, flags)))
-        goto nonfatal_error;
-
-    /* reading nodelist from R directly would avoid the creation /
-     * destruction of a hostlist.  However, we get a hostlist to
-     * ensure that the nodelist we return to users is consistently
-     * formatted.
-     */
-    if (!(hl = rlist_nodelist (rl)))
-        goto nonfatal_error;
-
-    if (!(job->nodelist = hostlist_encode (hl)))
-        goto nonfatal_error;
-
-    /* nonfatal error - invalid R, but we'll continue on.  job listing
-     * will get initialized data */
-nonfatal_error:
-    rc = 0;
-    saved_errno = errno;
-    hostlist_destroy (hl);
-    idset_destroy (idset);
-    rlist_destroy (rl);
-    errno = saved_errno;
-    return rc;
-}
-
 static void state_run_lookup_continuation (flux_future_t *f, void *arg)
 {
     struct job *job = arg;
@@ -690,7 +368,7 @@ static void state_run_lookup_continuation (flux_future_t *f, void *arg)
         goto out;
     }
 
-    if (R_lookup_parse (ctx, job, s) < 0)
+    if (job_parse_R (job, s) < 0)
         goto out;
 
     st = zlist_head (job->next_states);
@@ -1065,7 +743,7 @@ static int depthfirst_map_one (struct list_ctx *ctx, const char *key,
     if (flux_kvs_lookup_get (f2, &jobspec) < 0)
         goto done;
 
-    if (jobspec_parse (ctx, job, jobspec) < 0)
+    if (job_parse_jobspec (job, jobspec) < 0)
         goto done;
 
     if (job->states_mask & FLUX_JOB_STATE_RUN) {
@@ -1078,7 +756,7 @@ static int depthfirst_map_one (struct list_ctx *ctx, const char *key,
         if (flux_kvs_lookup_get (f3, &R) < 0)
             goto done;
 
-        if (R_lookup_parse (ctx, job, R) < 0)
+        if (job_parse_R (job, R) < 0)
             goto done;
     }
 
@@ -1457,7 +1135,7 @@ static int dependency_add (struct job *job,
     if (grudgeset_add (&job->dependencies, description) < 0
         && errno != EEXIST)
         /*  Log non-EEXIST errors, but it is not fatal */
-        flux_log_error (job->ctx->h,
+        flux_log_error (job->h,
                         "job %ju: dependency-add",
                          (uintmax_t) job->id);
     return 0;
@@ -1469,7 +1147,7 @@ static int dependency_remove (struct job *job,
     int rc = grudgeset_remove (job->dependencies, description);
     if (rc < 0 && errno == ENOENT) {
         /*  No matching dependency is non-fatal error */
-        flux_log (job->ctx->h,
+        flux_log (job->h,
                   LOG_DEBUG,
                   "job %ju: dependency-remove '%s' not found",
                   (uintmax_t) job->id,

--- a/src/modules/job-list/job_state.c
+++ b/src/modules/job-list/job_state.c
@@ -711,7 +711,7 @@ out:
 }
 
 static flux_future_t *state_run_lookup (struct job_state_ctx *jsctx,
-                                           struct job *job)
+                                        struct job *job)
 {
     flux_future_t *f = NULL;
     int saved_errno;

--- a/src/modules/job-list/job_state.c
+++ b/src/modules/job-list/job_state.c
@@ -283,7 +283,7 @@ static void update_job_state_and_list (struct list_ctx *ctx,
                                        double timestamp)
 {
     zlistx_t *oldlist, *newlist;
-    struct job_state_ctx *jsctx = job->ctx->jsctx;
+    struct job_state_ctx *jsctx = ctx->jsctx;
 
     oldlist = get_list (jsctx, job->state);
     newlist = get_list (jsctx, newstate);
@@ -802,7 +802,7 @@ static int add_state_transition (struct job *job,
 static void process_next_state (struct list_ctx *ctx, struct job *job)
 {
     struct state_transition *st;
-    struct job_state_ctx *jsctx = job->ctx->jsctx;
+    struct job_state_ctx *jsctx = ctx->jsctx;
 
     while ((st = zlist_head (job->next_states))
            && !st->processed) {

--- a/src/modules/job-list/job_state.h
+++ b/src/modules/job-list/job_state.h
@@ -101,8 +101,7 @@ struct job {
     struct grudgeset *dependencies;
 
     /* cache of job information */
-    json_t *jobspec_job;
-    json_t *jobspec_cmd;
+    json_t *jobspec;
     json_t *R;
     json_t *exception_context;
 

--- a/src/modules/job-list/job_state.h
+++ b/src/modules/job-list/job_state.h
@@ -16,8 +16,6 @@
 
 #include "job-list.h"
 #include "stats.h"
-#include "src/common/libutil/grudgeset.h"
-#include "src/common/libczmqcontainers/czmq_containers.h"
 
 /* To handle the common case of user queries on job state, we will
  * store jobs in three different lists.
@@ -57,72 +55,6 @@ struct job_state_ctx {
 
     /* stream of job events from the job-manager */
     flux_future_t *events;
-};
-
-/* timestamp of when we enter the state
- *
- * associated eventlog entries when restarting
- *
- * t_depend - "submit"
- * t_priority - "priority" (not saved, can be entered multiple times)
- * t_sched - "depend" (not saved, can be entered multiple times)
- * t_run - "alloc"
- * t_cleanup - "finish" or "exception" w/ severity == 0
- * t_inactive - "clean"
- */
-struct job {
-    struct list_ctx *ctx;
-
-    flux_jobid_t id;
-    uint32_t userid;
-    int urgency;
-    int64_t priority;
-    double t_submit;
-    // t_depend is identical to t_submit
-    // double t_depend;
-    double t_run;
-    double t_cleanup;
-    double t_inactive;
-    flux_job_state_t state;
-    const char *name;
-    int ntasks;
-    int nnodes;
-    char *ranks;
-    char *nodelist;
-    double expiration;
-    int wait_status;
-    bool success;
-    bool exception_occurred;
-    int exception_severity;
-    const char *exception_type;
-    const char *exception_note;
-    flux_job_result_t result;
-    json_t *annotations;
-    struct grudgeset *dependencies;
-
-    /* cache of job information */
-    json_t *jobspec;
-    json_t *R;
-    json_t *exception_context;
-
-    /* Track which states we have seen and have completed transition
-     * to.  We do not immediately update to the new state and place
-     * onto a new list until we have retrieved any necessary data
-     * associated to that state.  For example, when the 'depend' state
-     * has been seen, we don't immediately place it on the `pending`
-     * list.  We wait until we've retrieved data such as userid,
-     * urgency, etc.
-     *
-     * Track which states we've seen via the states_mask.
-     *
-     * Track states seen via events stream in states_events_mask.
-     */
-    zlist_t *next_states;
-    unsigned int states_mask;
-    unsigned int states_events_mask;
-    void *list_handle;
-
-    int eventlog_seq;           /* last event seq read */
 };
 
 struct job_state_ctx *job_state_create (struct list_ctx *ctx);

--- a/src/modules/job-list/job_util.c
+++ b/src/modules/job-list/job_util.c
@@ -22,7 +22,6 @@
 
 #include "job-list.h"
 #include "job_util.h"
-#include "job_state.h"
 
 void seterror (job_list_error_t *errp, const char *fmt, ...)
 {

--- a/src/modules/job-list/job_util.h
+++ b/src/modules/job-list/job_util.h
@@ -13,7 +13,7 @@
 
 #include <flux/core.h>
 
-#include "job_state.h"
+#include "job_data.h"
 
 typedef struct {
     char text[160];

--- a/src/modules/job-list/list.c
+++ b/src/modules/job-list/list.c
@@ -25,7 +25,7 @@
 #include "idsync.h"
 #include "list.h"
 #include "job_util.h"
-#include "job_state.h"
+#include "job_data.h"
 
 json_t *get_job_by_id (struct list_ctx *ctx,
                        job_list_error_t *errp,

--- a/src/modules/job-list/stats.c
+++ b/src/modules/job-list/stats.c
@@ -15,8 +15,8 @@
 #include <ctype.h>
 #include <flux/core.h>
 
-#include "job_state.h"
 #include "stats.h"
+#include "job_data.h"
 
 /*  Return the index into stats->state_count[] array for the
  *   job state 'state'

--- a/src/modules/job-list/stats.h
+++ b/src/modules/job-list/stats.h
@@ -12,6 +12,7 @@
 #define _FLUX_JOB_LIST_JOB_STATS_H
 
 #include <flux/core.h> /* FLUX_JOB_NR_STATES */
+#include <jansson.h>
 
 struct job_stats {
     unsigned int state_count[FLUX_JOB_NR_STATES];


### PR DESCRIPTION
This is a general refactoring PR.                                                                                                           
                                                                                                                                            
I actually did some similar refactoring in #4336

I did some similar refactoring in a (now tabled) PR for #4404

@garlick commented on some potential refactoring in #4555                                                                                   

So thus this refactoring, and why I put it in a separate PR.
                                                                                                                                            
I could add some unit tests to capture some worst offending failure cases (e.g. like jobspec that is just a curly brace), but didn't given its limited coverage increase.  Some of this is already handled in sharness tests.