### PR TITLE
Adding GitLab CI File

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,36 @@
+.build_flux: &build_flux
+  script:
+   - module load python/3.8.2
+   - module load gcc/8.3.1
+   - mkdir -p $PWD/usr/local
+   - ./autogen.sh
+   - ./configure --without-python --prefix=$PWD/usr/local
+   - make VERBOSE=1
+   - make install
+   - tree $PWD/usr/local
+   - export PATH=$PWD/usr/local/bin:$PATH
+   - which flux
+   - module load spectrum-mpi && make check || echo "Spectrum MPI is not available."
+
+# https://lc.llnl.gov/gitlab/public-info/gitlab-ci/-/wikis/Gitlab-CI-Basic-Information
+test-lassen:
+ tags:
+  - lassen
+  - shell
+ stage: build
+ <<: *build_flux
+
+test-corona:
+ tags:
+  - corona
+  - shell
+ stage: build
+ <<: *build_flux
+  
+test-tioga:
+ tags:
+  - tioga
+  - shell
+ stage: build
+ <<: *build_flux
+

--- a/etc/gen-cmdhelp.py
+++ b/etc/gen-cmdhelp.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 ###############################################################
 # Copyright 2020 Lawrence Livermore National Security, LLC
 # (c.f. AUTHORS, NOTICE.LLNS, COPYING)


### PR DESCRIPTION
This is a very basic GitLab CI recipe that will, when GitLab is properly connected (see instructions here) run additional tests on a few clusters. This means:

 - we build flux
 - we load the MPI
 - we run make check

I currently only have access to one cluster, so I can only test 1: https://lc.llnl.gov/gitlab/flux/flux-core/-/jobs/789101

I didn't create the mirror providing a personal access token (and I'm not willing to) so likely someone else (or a flux bot) should provide one. The way we can do this, given someone found the flux-framework group (yay!) is to:

1. create the mirror under here https://lc.llnl.gov/gitlab/flux-framework it's basically a new project, and you select via the GitHub route to enter a PAT. I think you can create from the URL, but then the connection won't have permission to trigger runs in PRs. Instructions are here: https://lc.llnl.gov/confluence/display/GITLAB/Open+Source+on+GitHub%3A+LC+GitLab+for+CI+Only and I think more general ones here https://docs.gitlab.com/ee/ci/ci_cd_for_external_repos/#limitations
2. Whomever is running needs permission to access those clusters.
3. Once this is hooked up (and we know how to use it) we can extend testing to other things. I wanted to start with this basic setip.

Signed-off-by: vsoch <vsoch@users.noreply.github.com>