### PR TITLE
configure: remove --without-python

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -204,14 +204,6 @@ X_AC_CHECK_COND_LIB(dl, dlerror)
 X_AC_MALLOC
 AC_CHECK_LIB(m, floor)
 
-
-AC_ARG_WITH([python],
-  [AS_HELP_STRING([--without-python],
-    [build Flux without python (mainly useful for building a libflux.so for external bindings) @<:@default=with@:>@])],
-  [],
-  [with_python=with])
-AM_CONDITIONAL([WITH_PYTHON], [test "x$with_python" != "xno"])
-
 AC_ARG_ENABLE([docs],
 	      AS_HELP_STRING([--disable-docs], [disable building docs]))
 
@@ -229,55 +221,51 @@ if test "X$PYTHON_VERSION" = "X" ; then
   fi
 fi
 
-AM_COND_IF([WITH_PYTHON], [
+# Do not let AX_PYTHON_DEVEL set PYTHON_SITE_PKG
+saved_PYTHON_SITE_PKG=$PYTHON_SITE_PKG
+AX_PYTHON_DEVEL([>='3.6'])
+PYTHON_SITE_PKG=$saved_PYTHON_SITE_PKG
 
-  # Do not let AX_PYTHON_DEVEL set PYTHON_SITE_PKG
-  saved_PYTHON_SITE_PKG=$PYTHON_SITE_PKG
-  AX_PYTHON_DEVEL([>='3.6'])
-  PYTHON_SITE_PKG=$saved_PYTHON_SITE_PKG
+AM_PATH_PYTHON([$ac_python_version])
+if test "X$PYTHON" = "X"; then
+    AC_MSG_ERROR([could not find python])
+fi
+#  Restore original PATH:
+export PATH=${saved_PATH}
 
-  AM_PATH_PYTHON([$ac_python_version])
-  if test "X$PYTHON" = "X"; then
-      AC_MSG_ERROR([could not find python])
-  fi
-  #  Restore original PATH:
-  export PATH=${saved_PATH}
+# Flag for PYTHON_LDFLAGS workaround below.
+if test -n "$PYTHON_LDFLAGS"; then
+  ac_python_ldflags_set_by_user=true
+fi
 
-  # Flag for PYTHON_LDFLAGS workaround below.
-  if test -n "$PYTHON_LDFLAGS"; then
-    ac_python_ldflags_set_by_user=true
-  fi
+AM_CHECK_PYMOD(cffi,
+               [cffi.__version_info__ >= (1,1)],
+               ,
+               [AC_MSG_ERROR([could not find python module cffi, version 1.1+ required])]
+               )
+AM_CHECK_PYMOD(yaml,
+               [StrictVersion(yaml.__version__) >= StrictVersion ('3.10.0')],
+               ,
+               [AC_MSG_ERROR([could not find python module yaml, version 3.10+ required])]
+               )
+AM_CHECK_PYMOD(jsonschema,
+               [StrictVersion(jsonschema.__version__) >= StrictVersion ('2.3.0')],
+               ,
+               [AC_MSG_ERROR([could not find python module jsonschema, version 2.3.0+ required])]
+               )
 
-  AM_CHECK_PYMOD(cffi,
-                 [cffi.__version_info__ >= (1,1)],
-                 ,
-                 [AC_MSG_ERROR([could not find python module cffi, version 1.1+ required])]
-                 )
-  AM_CHECK_PYMOD(yaml,
-                 [StrictVersion(yaml.__version__) >= StrictVersion ('3.10.0')],
-                 ,
-                 [AC_MSG_ERROR([could not find python module yaml, version 3.10+ required])]
-                 )
-  AM_CHECK_PYMOD(jsonschema,
-                 [StrictVersion(jsonschema.__version__) >= StrictVersion ('2.3.0')],
-                 ,
-                 [AC_MSG_ERROR([could not find python module jsonschema, version 2.3.0+ required])]
-                 )
-
-  AS_IF([test "x$enable_docs" != "xno"], [
-              AM_CHECK_PYMOD(sphinx,
-                             [StrictVersion(sphinx.__version__) >= StrictVersion ('1.6.7')],
-                             [sphinx=true],
-                             [sphinx=false; AC_MSG_WARN([could not find sphinx to generate docs, version 1.6.7+ required])]
-                             )
-              AM_CHECK_PYMOD(docutils,
-                             [StrictVersion(docutils.__version__) >= StrictVersion ('0.11.0')],
-                             [docutils=true],
-                             [docutils=false; AC_MSG_WARN([could not find docutils to generate docs, version 0.11.0+ required])]
-                             )
-  ])
+AS_IF([test "x$enable_docs" != "xno"], [
+            AM_CHECK_PYMOD(sphinx,
+                           [StrictVersion(sphinx.__version__) >= StrictVersion ('1.6.7')],
+                           [sphinx=true],
+                           [sphinx=false; AC_MSG_WARN([could not find sphinx to generate docs, version 1.6.7+ required])]
+                           )
+            AM_CHECK_PYMOD(docutils,
+                           [StrictVersion(docutils.__version__) >= StrictVersion ('0.11.0')],
+                           [docutils=true],
+                           [docutils=false; AC_MSG_WARN([could not find docutils to generate docs, version 0.11.0+ required])]
+                           )
 ])
-
 #  If --enable-docs=yes, but no doc generator found,
 #   then error immediately:
 #

--- a/src/bindings/python/Makefile.am
+++ b/src/bindings/python/Makefile.am
@@ -1,7 +1,4 @@
-
-if WITH_PYTHON
 SUBDIRS=_flux flux
-endif
 
 clean-local:
 	-rm -f .coverage*


### PR DESCRIPTION
The `--without-python` flag does not make sense if Flux cannot build without it. This PR tests removing the flag (and if checks) for building the bindings. Discussion in https://github.com/flux-framework/flux-core/pull/4577#issuecomment-1250493250. It could be that we want to keep the flag, but have it only control building the Python wrappers (and not the core logic for getting python working for generating commands, etc.) I'm happy to try both - let me know.

Signed-off-by: vsoch <vsoch@users.noreply.github.com>