### PR TITLE
ingest: set configured queue constraints

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -297,7 +297,8 @@ MAN5_FILES_PRIMARY = \
 	man5/flux-config-job-manager.5 \
 	man5/flux-config-ingest.5 \
 	man5/flux-config-kvs.5 \
-	man5/flux-config-policy.5
+	man5/flux-config-policy.5 \
+	man5/flux-config-queues.5
 
 
 MAN7_FILES = $(MAN7_FILES_PRIMARY)

--- a/doc/man5/flux-config-policy.rst
+++ b/doc/man5/flux-config-policy.rst
@@ -92,6 +92,7 @@ EXAMPLE
    duration = "30m"
    job-size.max.ngpus = -1  # unlimited
 
+   [queues.batch]
 
 RESOURCES
 =========

--- a/doc/man5/flux-config-queues.rst
+++ b/doc/man5/flux-config-queues.rst
@@ -1,0 +1,88 @@
+=====================
+flux-config-queues(5)
+=====================
+
+
+DESCRIPTION
+===========
+
+The ``queues`` table configures job queues, as described in RFC 33.
+Normally, Flux has a single anonymous queue, but when queues are configured,
+all queues are named, and a job submitted without a queue name is rejected
+unless a default queue is configured.
+
+Each key in the ``queues`` table is a queue name, whose value is a table
+consisting of the following optional keys:
+
+requires (array)
+   A list of resource property names that selects a subset of the total
+   configured resources for the queue.  Each property name is a string, as
+   defined in RFC 20.  If multiple properties are listed, they are combined
+   in a logical *and* operation.  Properties are attached to resources in the
+   ``resource`` table as described in :man5:`flux-config-resource`.
+
+policy (table)
+   A policy table as described in :man5:`flux-config-policy` that overrides
+   the general system policy for jobs submitted to this queue.
+
+A default queue name may be configured by setting
+``policy.jobspec.defaults.system.queue`` as described in
+:man5:`flux-config-policy`.
+
+
+EXAMPLE
+=======
+
+::
+
+   [ingest]
+   validator.plugins = ["feasibility", "jobspec"]
+   frobnicator.plugins = ["defaults", "constraints"]
+
+   [[resource.config]]
+   hosts = test[0-7]
+   properties = ["debug"]
+
+   [[resource.config]]
+   hosts = test[8-127]
+   properties = ["batch"]
+
+   [queues.debug]
+   policy.limits.duration = "30m"
+   requires = [ "debug" ]
+
+   [queues.batch]
+   policy.limits.duration = "8h"
+   requires = [ "batch" ]
+
+   [policy.jobspec.defaults.system]
+   queue = "batch"
+
+   [sched-fluxion-qmanager]
+   queues = "batch debug"
+   queue-policy-per-queue="batch:easy debug:fcfs"
+
+   [sched-fluxion-resource]
+   match-policy = "lonodex"
+   match-format = "rv1_nosched"
+
+
+CAVEATS
+=======
+
+Queue resources should not overlap.
+
+
+RESOURCES
+=========
+
+Flux: http://flux-framework.org
+
+RFC 20: Resource Set Specification Version 1: https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/spec_20.html
+
+RFC 33: Flux Job Queues: https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/spec_33.html
+
+SEE ALSO
+========
+
+:man5:`flux-config`, :man5:`flux-config-policy`, :man5:`flux-config-resource`

--- a/doc/man5/index.rst
+++ b/doc/man5/index.rst
@@ -15,3 +15,4 @@ man5
    flux-config-archive
    flux-config-job-manager
    flux-config-policy
+   flux-config-queues

--- a/doc/manpages.py
+++ b/doc/manpages.py
@@ -285,6 +285,7 @@ man_pages = [
     ('man5/flux-config-resource', 'flux-config-resource', 'configure Flux resource service', [author], 5),
     ('man5/flux-config-archive', 'flux-config-archive', 'configure Flux job archival service', [author], 5),
     ('man5/flux-config-policy', 'flux-config-policy', 'configure Flux job policy', [author], 5),
+    ('man5/flux-config-queues', 'flux-config-queues', 'configure Flux job queues', [author], 5),
     ('man5/flux-config-job-manager', 'flux-config-job-manager', 'configure Flux job manager service', [author], 5),
     ('man5/flux-config-kvs', 'flux-config-kvs', 'configure Flux kvs service', [author], 5),
     ('man7/flux-broker-attributes', 'flux-broker-attributes', 'overview Flux broker attributes', [author], 7),

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -636,3 +636,8 @@ parentof
 bg
 norestrict
 frobnicator
+fcfs
+lonodex
+nosched
+qmanager
+rv

--- a/src/bindings/python/flux/Makefile.am
+++ b/src/bindings/python/flux/Makefile.am
@@ -37,6 +37,7 @@ nobase_fluxpy_PYTHON = \
 	job/frobnicator/__init__.py \
 	job/frobnicator/frobnicator.py \
 	job/frobnicator/plugins/defaults.py \
+	job/frobnicator/plugins/constraints.py \
 	resource/Rlist.py \
 	resource/__init__.py \
 	resource/ResourceSetImplementation.py \

--- a/src/bindings/python/flux/job/frobnicator/plugins/constraints.py
+++ b/src/bindings/python/flux/job/frobnicator/plugins/constraints.py
@@ -1,0 +1,63 @@
+##############################################################
+# Copyright 2022 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+##############################################################
+
+"""Apply constraints to incoming jobspec based on broker config.
+
+"""
+
+from flux.job.frobnicator import FrobnicatorPlugin
+
+
+class QueueConfig:
+    """Convenience class for handling jobspec queues configuration"""
+
+    def __init__(self, config={}):
+        self.queues = {}
+        try:
+            self.queues = config["queues"]
+        except KeyError:
+            pass
+
+    def queue_constraints(self, name):
+        try:
+            return self.queues[name]["requires"]
+        except KeyError:
+            return None
+
+    def apply_constraints(self, jobspec):
+        """Apply queue-specific constraints to jobspec"""
+
+        if jobspec.queue:
+            if jobspec.queue not in self.queues:
+                raise ValueError(f"Invalid queue '{jobspec.queue}' specified")
+            queue_constraints = self.queue_constraints(jobspec.queue)
+            if queue_constraints is None:
+                return
+            prop = []
+            try:
+                prop = jobspec.attributes["system"]["constraints"]["properties"]
+            except KeyError:
+                pass
+
+            for value in queue_constraints:
+                if value not in prop:
+                    prop.append(value)
+            jobspec.setattr("system.constraints.properties", prop)
+
+
+class Frobnicator(FrobnicatorPlugin):
+    def __init__(self, parser):
+        super().__init__(parser)
+
+    def configure(self, args, config):
+        self.config = QueueConfig(config)
+
+    def frob(self, jobspec, user, urgency, flags):
+        self.config.apply_constraints(jobspec)

--- a/src/broker/brokercfg.c
+++ b/src/broker/brokercfg.c
@@ -289,6 +289,10 @@ static int validate_queues_config (flux_conf_t *conf, flux_error_t *error)
         const char *name;
         json_t *entry;
 
+        if (!json_is_object (queues)) {
+            errprintf (error, "queues must be a table");
+            goto inval;
+        }
         json_object_foreach (queues, name, entry) {
             json_error_t jerror;
             json_t *policy = NULL;

--- a/t/t2112-job-ingest-frobnicator.t
+++ b/t/t2112-job-ingest-frobnicator.t
@@ -95,5 +95,47 @@ test_expect_success HAVE_JQ 'job-frobnicator sets specified queue duration' '
 	jq -e ".data.attributes.system.queue == \"batch\"" < queue-batch.out &&
 	jq -e ".data.attributes.system.duration == 28800"  < queue-batch.out
 '
+test_expect_success 'configure queue constraints' '
+	cat <<-EOF >conf.d/conf.toml &&
+	[queues.debug]
+	requires = [ "debug" ]
+	EOF
+	flux config reload
+'
+test_expect_success HAVE_JQ 'constraints plugin sets queue constraint' '
+	flux mini run --env=-* --dry-run --setattr queue=debug hostname \
+	   | flux job-frobnicator --jobspec-only --plugins=constraints \
+	   > constraint-setqueue.out &&
+	jq -e ".data.attributes.system.constraints.properties \
+	    == [ \"debug\" ]" < constraint-setqueue.out
+'
+test_expect_success HAVE_JQ 'constraints plugin appends queue constraint' '
+	flux mini run --env=-* --dry-run --requires=foo \
+	  --setattr queue=debug hostname \
+	   | flux job-frobnicator --jobspec-only --plugins=constraints \
+	   > constraint-addqueue.out &&
+	jq -e ".data.attributes.system.constraints.properties \
+	   == [ \"foo\", \"debug\" ]" \
+	   < constraint-addqueue.out
+'
+test_expect_success HAVE_JQ 'constraints plugin works with no configured queues' '
+	cp /dev/null conf.d/conf.toml &&
+	flux config reload &&
+	flux mini run --env=-* --dry-run hostname \
+	   | flux job-frobnicator --jobspec-only --plugins=constraints \
+	> constraint-noqueue.out &&
+	jq -e "has(\"data\")" <constraint-noqueue.out
+'
+test_expect_success HAVE_JQ 'constraints plugin works without requires' '
+	cat >conf.d/conf.toml <<-EOT &&
+	[queues.debug]
+	EOT
+	flux config reload &&
+	flux mini run --env=-* --dry-run hostname \
+           --setattr queue=debug \
+	   | flux job-frobnicator --jobspec-only --plugins=constraints \
+	> constraint-norequires.out &&
+	jq -e "has(\"data\")" <constraint-norequires.out
+'
 
 test_done

--- a/t/t2112-job-ingest-frobnicator.t
+++ b/t/t2112-job-ingest-frobnicator.t
@@ -95,30 +95,5 @@ test_expect_success HAVE_JQ 'job-frobnicator sets specified queue duration' '
 	jq -e ".data.attributes.system.queue == \"batch\"" < queue-batch.out &&
 	jq -e ".data.attributes.system.duration == 28800"  < queue-batch.out
 '
-test_expect_success 'job-frobnicator errors on a missing queue config' '
-	cat <<-EOF >conf.d/conf.toml &&
-	[policy.jobspec.defaults.system]
-	queue = "debug"
-	EOF
-	flux config reload &&
-	flux mini run --env=-* --dry-run hostname \
-	   | test_expect_code 1 \
-	       flux job-frobnicator --jobspec-only --plugins=defaults \
-	       >bad1.out 2>&1 &&
-	grep "default queue.*debug.*must be in" bad1.out
-'
-test_expect_success 'job-frobnicator errors on an invalid queue config' '
-	cat <<-EOF >conf.d/conf.toml &&
-	queues = 42
-	[policy.jobspec.defaults.system]
-	queue = "debug"
-	EOF
-	flux config reload &&
-	flux mini run --env=-* --dry-run hostname \
-	   | test_expect_code 1 \
-	       flux job-frobnicator --jobspec-only --plugins=defaults \
-	       >bad2.out 2>&1 &&
-	grep "queues must be a table" bad2.out
-'
 
 test_done

--- a/t/t2241-policy-config.t
+++ b/t/t2241-policy-config.t
@@ -142,6 +142,20 @@ test_expect_success 'malformed queues.NAME.policy.limits.duration key fails' '
 	EOT
 	test_must_fail flux config reload
 '
+test_expect_success 'default queue as queue policy fails' '
+	cat >config/policy.toml <<-EOT &&
+	queues.x.policy.jobspec.defaults.system.queue = "x"
+	EOT
+	test_must_fail flux config reload
+'
+test_expect_success 'unknown default queue fails' '
+	cat >config/policy.toml <<-EOT &&
+	[queues.foo]
+	[policy]
+	jobspec.defaults.system.queue = "bar"
+	EOT
+	test_must_fail flux config reload
+'
 test_expect_success 'unknown queues.NAME.requires.foo key fails' '
 	cat >config/policy.toml <<-EOT &&
 	queues.x.requires = 1
@@ -184,6 +198,8 @@ test_expect_success 'valid config passes' '
 	[queues.debug.policy.limits]
 	duration = "30m"
 	job-size.max.ngpus = -1  # unlimited
+
+	[queues.batch]
 	EOT
 	flux config reload
 '

--- a/t/t2241-policy-config.t
+++ b/t/t2241-policy-config.t
@@ -124,6 +124,12 @@ test_expect_success 'well formed policy.access works' '
 	EOT
 	flux config reload
 '
+test_expect_success 'malformed queues table fails' '
+	cat >config/policy.toml <<-EOT &&
+	queues = 1
+	EOT
+	test_must_fail flux config reload
+'
 test_expect_success 'unknown queues.NAME.policy.foo key fails' '
 	cat >config/policy.toml <<-EOT &&
 	queues.x.policy.foo = 1

--- a/t/t2241-policy-config.t
+++ b/t/t2241-policy-config.t
@@ -136,6 +136,33 @@ test_expect_success 'malformed queues.NAME.policy.limits.duration key fails' '
 	EOT
 	test_must_fail flux config reload
 '
+test_expect_success 'unknown queues.NAME.requires.foo key fails' '
+	cat >config/policy.toml <<-EOT &&
+	queues.x.requires = 1
+	EOT
+	test_must_fail flux config reload
+'
+test_expect_success 'malformed queues.NAME.requires fails' '
+	cat >config/policy.toml <<-EOT &&
+	queues.x.requires = [ 1 ]
+	EOT
+	test_must_fail flux config reload
+'
+test_expect_success 'malformed queues.NAME.requires property string' '
+	cat >config/policy.toml <<-EOT &&
+	queues.x.requires = [ "foo|bar" ]
+	EOT
+	test_must_fail flux config reload
+'
+test_expect_success 'well formed queues.NAME.requires works' '
+	cat >config/policy.toml <<-EOT &&
+	[queues.x]
+	requires = [ "batch" ]
+	[queues.z]
+	requires = [ "debug", "foo" ]
+	EOT
+	flux config reload
+'
 # Example from flux-config-policy(5)
 test_expect_success 'valid config passes' '
 	cat >config/policy.toml <<-EOT &&


### PR DESCRIPTION
This adds an ingest "frobnicator" plugin (thanks @grondo) that works with the RFC 33 `queues.NAME.requires` spec proposed in flux-framework/rfc#342. The broker policy/queue config validator is also modified to allow `queues.NAME.requires`.

This was sufficient to get my test system queues working again with this config
```toml
[ingest.validator]
plugins = ["feasibility", "jobspec" ]

[ingest.frobnicator]
plugins = [ "defaults", "constraints" ]

[[resource.config]]
hosts = "picl[0-7]"
cores = "0-3"

[[resource.config]]
hosts = "picl[1-5]"
properties = ["batch"]

[[resource.config]]
hosts = "picl[6-7]"
properties = ["debug"]

[queues.debug]
requires = [ "debug" ]

[queues.batch]
requires = [ "batch" ]

[policy.jobspec.defaults.system]
queue = "debug"
```
Marked as WIP pending

- [x] more testing
- [x] add flux-config-queues(5)