### PR TITLE
configure.ac: fix error message when running autogen.sh

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Prologue
 ##
 AC_INIT([flux-core],
-        m4_esyscmd([test -n $FLUX_VERSION && printf $FLUX_VERSION || git describe --always | awk '/.*/ {sub(/^v/, ""); printf "%s",$1; exit}']))
+        m4_esyscmd([test -n "$FLUX_VERSION" && printf $FLUX_VERSION || git describe --always | awk '/.*/ {sub(/^v/, ""); printf "%s",$1; exit}']))
 AC_CONFIG_AUX_DIR([config])
 AC_CONFIG_MACRO_DIR([config])
 AC_CONFIG_SRCDIR([NEWS.md])


### PR DESCRIPTION
This fixes a quoting error in configure.ac that was missed before #4577 was merged.