### PR TITLE
flux-jobs: support collapsible format fields

### DIFF
--- a/doc/man1/flux-jobs.rst
+++ b/doc/man1/flux-jobs.rst
@@ -149,6 +149,15 @@ following is the format used for the default format:
 
    {id.f58:>12} {username:<8.8} {name:<10.10} {status_abbrev:>2.2} {ntasks:>6} {nnodes:>6h} {runtime!F:>8h} {nodelist:h}
 
+If a format field is preceded by the special string ``?:`` this will
+cause the field to be removed entirely from output if the result would
+be an empty string for all jobs in the listing. E.g.::
+
+   {id.f58:>12} ?:{exception.type}
+
+would eliminate the EXCEPTION-TYPE column if no jobs in the list received
+an exception.
+
 The special presentation type *h* can be used to convert an empty
 string, "0s", "0.0", or "0:00:00" to a hyphen. For example, normally
 "{nodelist}" would output an empty string if the job has not yet run.

--- a/src/cmd/flux-jobs.py
+++ b/src/cmd/flux-jobs.py
@@ -445,6 +445,7 @@ def print_jobs(jobs, args, formatter, path="", level=0):
                 f"{stats.running} running, {stats.successful} completed, "
                 f"{stats.failed} failed, {stats.pending} pending"
             )
+
         print_jobs(jobs, args, formatter, path=thispath, level=level + 1)
 
 
@@ -484,11 +485,12 @@ def main():
             sys.exit(0 if stats.active else 1)
 
     jobs = fetch_jobs(args, formatter.fields)
+    sformatter = formatter.filter_empty(jobs)
 
     if not args.suppress_header:
-        print(formatter.header())
+        print(sformatter.header())
 
-    print_jobs(jobs, args, formatter)
+    print_jobs(jobs, args, sformatter)
 
 
 if __name__ == "__main__":

--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -168,6 +168,16 @@ test_expect_success 'flux-jobs: custom format with numeric spec works' '
 	grep T_RUN format-test.out
 '
 
+test_expect_success 'flux-jobs: collapsible fields work' '
+	flux jobs -ao "{id.f58:<12} ?:{exception.type:>8}" >nocollapse.out &&
+	flux jobs -f running,completed \
+		-ao "{id.f58:<12} ?:{exception.type:>8}"   >collapsed.out &&
+	test_debug "head -n1 nocollapse.out" &&
+	test_debug "head -n1 collapsed.out" &&
+	grep EXCEPTION-TYPE nocollapse.out &&
+	test_must_fail grep EXCEPTION-TYPE collapsed.out
+'
+
 # TODO: need to submit jobs as another user and test -A again
 test_expect_success 'flux-jobs -a and -A works' '
 	nall=$(state_count all) &&


### PR DESCRIPTION
This PR adds a way to have format fields in flux-jobs that are optionally completely removed when they render as an empty string for all jobs. So-called "collapsible" fields are indicated in a format  by prepending `?:` before the format, e.g. `?:{name}`. The main use case here is so that we can optionally list jobs queues in the system instance in the default format, but not have this empty, useless field present for all single user instances which are most likely using anonymous queues. E.g.:

```console
$ flux jobs -ao '{id.f58:>12} ?:{exception.type:>16} {nodelist}'
       JOBID   EXCEPTION-TYPE NODELIST
    ƒEiwyRCb             exec asp
    ƒC5m5dL3          timeout asp
    ƒ4H3iwEo                  asp
    ƒ3uw9ATy                  asp
$ flux jobs -f completed -ao '{id.f58:>12} ?:{exception.type:>16} {nodelist}'
       JOBID NODELIST
    ƒ4H3iwEo asp
    ƒ3uw9ATy asp
```

There's no documentation here yet, I wanted to get this up in case anyone had strong objections to the approach.