### PR TITLE
flux-jobs: add configurable named formats

### DIFF
--- a/doc/man1/flux-jobs.rst
+++ b/doc/man1/flux-jobs.rst
@@ -61,9 +61,12 @@ OPTIONS
    results can be listed separated by comma. See JOB STATUS below for
    additional information. Defaults to *pending,running*.
 
-**-o, --format**\ *=FORMAT*
-   Specify output format using Python's string format syntax. See OUTPUT
-   FORMAT below for field names.
+**-o, --format**\ *=NAME|FORMAT*
+   Specify a named output format *NAME* or a format string using Python's
+   format syntax. See OUTPUT FORMAT below for field names. Named formats
+   may be listed via ``--format=help``. Additional named formats may be
+   registered with ``flux jobs`` via configuration. See the CONFIGURATION
+   section for more details.
 
 **--color**\ *=WHEN*
    Control output coloring. WHEN can be *never*, *always*, or *auto*.
@@ -369,6 +372,56 @@ include:
    number of cores, gpus in state ``state``, where ``state`` can be
    ``all``, ``up``, ``down``, ``allocated``, or ``free``, e.g.
    ``{instance.resources.all.ncores}``
+
+
+CONFIGURATION
+=============
+
+The ``flux-jobs`` command supports registration of named output formats
+in configuration files. The command loads configuration files from
+``flux-jobs.EXT`` from the following paths in order of increasing precedence:
+
+ * ``$XDG_CONFIG_DIRS/flux`` or ``/etc/flux/xdg`` if ``XDG_CONFIG_DIRS`` is
+   not set. Note that ``XDG_CONFIG_DIRS`` is traversed in reverse order
+   such that entries first in the colon separated path are highest priority.
+
+ * ``XDG_CONFIG_HOME/flux`` or ``$HOME/.config/flux`` if ``XDG_CONFIG_HOME``
+   is not set
+
+where ``EXT`` can be one of ``toml``, ``yaml``, or ``json``.
+
+If there are multiple ``flux-jobs.*`` files found in a directory, then
+they are loaded in lexical order (i.e. ``.json`` first, then ``.toml``,
+then ``.yaml``)
+
+Named formats are registered in a ``formats`` table or dictionary with a
+key per format pointing to a table or dictionary with the keys:
+
+**format**
+   (required) The format string
+
+**description**
+   (optional) A short description of the named format, displayed with
+   ``flux jobs --format=help``
+
+If a format name is specified in more than one config file, then the last
+one loaded is used. Due to the order that ``flux-jobs`` loads config files,
+this allows user configuration to override system configuration. It is an
+error to override any internally defined formats (such as ``default``).
+
+If a format name or string is not specified on the command line the
+internally defined format ``default`` is used.
+
+Example::
+
+  # $HOME/.config/flux/flux-jobs.toml
+
+  [formats.myformat]
+  description = "My useful format"
+  format = """\
+  {id.f58:>12} {name:>8.8} {t_submit!D:<19} \
+  {t_run!D:<19} {t_remaining!F}\
+  """
 
 
 EXAMPLES

--- a/doc/man1/flux-jobs.rst
+++ b/doc/man1/flux-jobs.rst
@@ -66,7 +66,8 @@ OPTIONS
    format syntax. See OUTPUT FORMAT below for field names. Named formats
    may be listed via ``--format=help``. Additional named formats may be
    registered with ``flux jobs`` via configuration. See the CONFIGURATION
-   section for more details.
+   section for more details. A configuration snippet for an existing
+   named format may be generated with ``--format=get-config=NAME``.
 
 **--color**\ *=WHEN*
    Control output coloring. WHEN can be *never*, *always*, or *auto*.
@@ -422,6 +423,14 @@ Example::
   {id.f58:>12} {name:>8.8} {t_submit!D:<19} \
   {t_run!D:<19} {t_remaining!F}\
   """
+
+It may be helpful to start with an existing named format by using the
+``--format=get-config=NAME`` option, e.g.::
+
+  $ flux jobs --format=get-config=default >> ~/.config/flux/flux-jobs.toml
+
+Be sure to change the name of the format string from ``default``. It is an
+error to redefine the default format string.
 
 
 EXAMPLES

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -641,3 +641,8 @@ lonodex
 nosched
 qmanager
 rv
+DIRS
+myformat
+xdg
+XDG
+yaml

--- a/mypy.ini
+++ b/mypy.ini
@@ -31,6 +31,15 @@ ignore_missing_imports = True
 [mypy-flux.utils.parsedatetime]
 ignore_missing_imports = True
 
+[mypy-flux.utils]
+ignore_missing_imports = True
+
+[mypy-flux.utils.tomli]
+ignore_missing_imports = True
+
+[mypy-tomllib]
+ignore_missing_imports = True
+
 [mypy-pycotap]
 follow_imports = silent
 

--- a/src/bindings/python/flux/Makefile.am
+++ b/src/bindings/python/flux/Makefile.am
@@ -66,7 +66,13 @@ nobase_fluxpy_PYTHON = \
 	utils/parsedatetime/pdt_locales/fr_FR.py \
 	utils/parsedatetime/pdt_locales/nl_NL.py \
 	utils/parsedatetime/pdt_locales/pt_BR.py \
-	utils/parsedatetime/pdt_locales/ru_RU.py
+	utils/parsedatetime/pdt_locales/ru_RU.py \
+	utils/tomli/_re.py \
+	utils/tomli/_parser.py \
+	utils/tomli/__init__.py \
+	utils/tomli/py.typed \
+	utils/tomli/LICENSE \
+	utils/tomli/_types.py
 
 if HAVE_FLUX_SECURITY
 nobase_fluxpy_PYTHON += security.py

--- a/src/bindings/python/flux/utils/README.md
+++ b/src/bindings/python/flux/utils/README.md
@@ -3,3 +3,4 @@ Place vendored Python modules here.
 Record commit hash of included version for convenience.
 
 parsedatetime c55337589ee582813182b74f2d3ae80e2fcd9738
+tomi	      345bd2a224f215fbb33546b6d7e358307b783793

--- a/src/bindings/python/flux/utils/tomli/LICENSE
+++ b/src/bindings/python/flux/utils/tomli/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Taneli Hukkinen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/bindings/python/flux/utils/tomli/__init__.py
+++ b/src/bindings/python/flux/utils/tomli/__init__.py
@@ -1,0 +1,9 @@
+"""A lil' TOML parser."""
+
+__all__ = ("loads", "load", "TOMLDecodeError")
+__version__ = "1.2.3"  # DO NOT EDIT THIS LINE MANUALLY. LET bump2version UTILITY DO IT
+
+from ._parser import TOMLDecodeError, load, loads
+
+# Pretend this exception was created here.
+TOMLDecodeError.__module__ = "tomli"

--- a/src/bindings/python/flux/utils/tomli/_parser.py
+++ b/src/bindings/python/flux/utils/tomli/_parser.py
@@ -1,0 +1,663 @@
+import string
+from types import MappingProxyType
+from typing import Any, BinaryIO, Dict, FrozenSet, Iterable, NamedTuple, Optional, Tuple
+import warnings
+
+from ._re import (
+    RE_DATETIME,
+    RE_LOCALTIME,
+    RE_NUMBER,
+    match_to_datetime,
+    match_to_localtime,
+    match_to_number,
+)
+from ._types import Key, ParseFloat, Pos
+
+ASCII_CTRL = frozenset(chr(i) for i in range(32)) | frozenset(chr(127))
+
+# Neither of these sets include quotation mark or backslash. They are
+# currently handled as separate cases in the parser functions.
+ILLEGAL_BASIC_STR_CHARS = ASCII_CTRL - frozenset("\t")
+ILLEGAL_MULTILINE_BASIC_STR_CHARS = ASCII_CTRL - frozenset("\t\n")
+
+ILLEGAL_LITERAL_STR_CHARS = ILLEGAL_BASIC_STR_CHARS
+ILLEGAL_MULTILINE_LITERAL_STR_CHARS = ILLEGAL_MULTILINE_BASIC_STR_CHARS
+
+ILLEGAL_COMMENT_CHARS = ILLEGAL_BASIC_STR_CHARS
+
+TOML_WS = frozenset(" \t")
+TOML_WS_AND_NEWLINE = TOML_WS | frozenset("\n")
+BARE_KEY_CHARS = frozenset(string.ascii_letters + string.digits + "-_")
+KEY_INITIAL_CHARS = BARE_KEY_CHARS | frozenset("\"'")
+HEXDIGIT_CHARS = frozenset(string.hexdigits)
+
+BASIC_STR_ESCAPE_REPLACEMENTS = MappingProxyType(
+    {
+        "\\b": "\u0008",  # backspace
+        "\\t": "\u0009",  # tab
+        "\\n": "\u000A",  # linefeed
+        "\\f": "\u000C",  # form feed
+        "\\r": "\u000D",  # carriage return
+        '\\"': "\u0022",  # quote
+        "\\\\": "\u005C",  # backslash
+    }
+)
+
+
+class TOMLDecodeError(ValueError):
+    """An error raised if a document is not valid TOML."""
+
+
+def load(fp: BinaryIO, *, parse_float: ParseFloat = float) -> Dict[str, Any]:
+    """Parse TOML from a binary file object."""
+    s_bytes = fp.read()
+    try:
+        s = s_bytes.decode()
+    except AttributeError:
+        warnings.warn(
+            "Text file object support is deprecated in favor of binary file objects."
+            ' Use `open("foo.toml", "rb")` to open the file in binary mode.',
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        s = s_bytes  # type: ignore[assignment]
+    return loads(s, parse_float=parse_float)
+
+
+def loads(s: str, *, parse_float: ParseFloat = float) -> Dict[str, Any]:  # noqa: C901
+    """Parse TOML from a string."""
+
+    # The spec allows converting "\r\n" to "\n", even in string
+    # literals. Let's do so to simplify parsing.
+    src = s.replace("\r\n", "\n")
+    pos = 0
+    out = Output(NestedDict(), Flags())
+    header: Key = ()
+
+    # Parse one statement at a time
+    # (typically means one line in TOML source)
+    while True:
+        # 1. Skip line leading whitespace
+        pos = skip_chars(src, pos, TOML_WS)
+
+        # 2. Parse rules. Expect one of the following:
+        #    - end of file
+        #    - end of line
+        #    - comment
+        #    - key/value pair
+        #    - append dict to list (and move to its namespace)
+        #    - create dict (and move to its namespace)
+        # Skip trailing whitespace when applicable.
+        try:
+            char = src[pos]
+        except IndexError:
+            break
+        if char == "\n":
+            pos += 1
+            continue
+        if char in KEY_INITIAL_CHARS:
+            pos = key_value_rule(src, pos, out, header, parse_float)
+            pos = skip_chars(src, pos, TOML_WS)
+        elif char == "[":
+            try:
+                second_char: Optional[str] = src[pos + 1]
+            except IndexError:
+                second_char = None
+            if second_char == "[":
+                pos, header = create_list_rule(src, pos, out)
+            else:
+                pos, header = create_dict_rule(src, pos, out)
+            pos = skip_chars(src, pos, TOML_WS)
+        elif char != "#":
+            raise suffixed_err(src, pos, "Invalid statement")
+
+        # 3. Skip comment
+        pos = skip_comment(src, pos)
+
+        # 4. Expect end of line or end of file
+        try:
+            char = src[pos]
+        except IndexError:
+            break
+        if char != "\n":
+            raise suffixed_err(
+                src, pos, "Expected newline or end of document after a statement"
+            )
+        pos += 1
+
+    return out.data.dict
+
+
+class Flags:
+    """Flags that map to parsed keys/namespaces."""
+
+    # Marks an immutable namespace (inline array or inline table).
+    FROZEN = 0
+    # Marks a nest that has been explicitly created and can no longer
+    # be opened using the "[table]" syntax.
+    EXPLICIT_NEST = 1
+
+    def __init__(self) -> None:
+        self._flags: Dict[str, dict] = {}
+
+    def unset_all(self, key: Key) -> None:
+        cont = self._flags
+        for k in key[:-1]:
+            if k not in cont:
+                return
+            cont = cont[k]["nested"]
+        cont.pop(key[-1], None)
+
+    def set_for_relative_key(self, head_key: Key, rel_key: Key, flag: int) -> None:
+        cont = self._flags
+        for k in head_key:
+            if k not in cont:
+                cont[k] = {"flags": set(), "recursive_flags": set(), "nested": {}}
+            cont = cont[k]["nested"]
+        for k in rel_key:
+            if k in cont:
+                cont[k]["flags"].add(flag)
+            else:
+                cont[k] = {"flags": {flag}, "recursive_flags": set(), "nested": {}}
+            cont = cont[k]["nested"]
+
+    def set(self, key: Key, flag: int, *, recursive: bool) -> None:  # noqa: A003
+        cont = self._flags
+        key_parent, key_stem = key[:-1], key[-1]
+        for k in key_parent:
+            if k not in cont:
+                cont[k] = {"flags": set(), "recursive_flags": set(), "nested": {}}
+            cont = cont[k]["nested"]
+        if key_stem not in cont:
+            cont[key_stem] = {"flags": set(), "recursive_flags": set(), "nested": {}}
+        cont[key_stem]["recursive_flags" if recursive else "flags"].add(flag)
+
+    def is_(self, key: Key, flag: int) -> bool:
+        if not key:
+            return False  # document root has no flags
+        cont = self._flags
+        for k in key[:-1]:
+            if k not in cont:
+                return False
+            inner_cont = cont[k]
+            if flag in inner_cont["recursive_flags"]:
+                return True
+            cont = inner_cont["nested"]
+        key_stem = key[-1]
+        if key_stem in cont:
+            cont = cont[key_stem]
+            return flag in cont["flags"] or flag in cont["recursive_flags"]
+        return False
+
+
+class NestedDict:
+    def __init__(self) -> None:
+        # The parsed content of the TOML document
+        self.dict: Dict[str, Any] = {}
+
+    def get_or_create_nest(
+        self,
+        key: Key,
+        *,
+        access_lists: bool = True,
+    ) -> dict:
+        cont: Any = self.dict
+        for k in key:
+            if k not in cont:
+                cont[k] = {}
+            cont = cont[k]
+            if access_lists and isinstance(cont, list):
+                cont = cont[-1]
+            if not isinstance(cont, dict):
+                raise KeyError("There is no nest behind this key")
+        return cont
+
+    def append_nest_to_list(self, key: Key) -> None:
+        cont = self.get_or_create_nest(key[:-1])
+        last_key = key[-1]
+        if last_key in cont:
+            list_ = cont[last_key]
+            try:
+                list_.append({})
+            except AttributeError:
+                raise KeyError("An object other than list found behind this key")
+        else:
+            cont[last_key] = [{}]
+
+
+class Output(NamedTuple):
+    data: NestedDict
+    flags: Flags
+
+
+def skip_chars(src: str, pos: Pos, chars: Iterable[str]) -> Pos:
+    try:
+        while src[pos] in chars:
+            pos += 1
+    except IndexError:
+        pass
+    return pos
+
+
+def skip_until(
+    src: str,
+    pos: Pos,
+    expect: str,
+    *,
+    error_on: FrozenSet[str],
+    error_on_eof: bool,
+) -> Pos:
+    try:
+        new_pos = src.index(expect, pos)
+    except ValueError:
+        new_pos = len(src)
+        if error_on_eof:
+            raise suffixed_err(src, new_pos, f"Expected {expect!r}") from None
+
+    if not error_on.isdisjoint(src[pos:new_pos]):
+        while src[pos] not in error_on:
+            pos += 1
+        raise suffixed_err(src, pos, f"Found invalid character {src[pos]!r}")
+    return new_pos
+
+
+def skip_comment(src: str, pos: Pos) -> Pos:
+    try:
+        char: Optional[str] = src[pos]
+    except IndexError:
+        char = None
+    if char == "#":
+        return skip_until(
+            src, pos + 1, "\n", error_on=ILLEGAL_COMMENT_CHARS, error_on_eof=False
+        )
+    return pos
+
+
+def skip_comments_and_array_ws(src: str, pos: Pos) -> Pos:
+    while True:
+        pos_before_skip = pos
+        pos = skip_chars(src, pos, TOML_WS_AND_NEWLINE)
+        pos = skip_comment(src, pos)
+        if pos == pos_before_skip:
+            return pos
+
+
+def create_dict_rule(src: str, pos: Pos, out: Output) -> Tuple[Pos, Key]:
+    pos += 1  # Skip "["
+    pos = skip_chars(src, pos, TOML_WS)
+    pos, key = parse_key(src, pos)
+
+    if out.flags.is_(key, Flags.EXPLICIT_NEST) or out.flags.is_(key, Flags.FROZEN):
+        raise suffixed_err(src, pos, f"Can not declare {key} twice")
+    out.flags.set(key, Flags.EXPLICIT_NEST, recursive=False)
+    try:
+        out.data.get_or_create_nest(key)
+    except KeyError:
+        raise suffixed_err(src, pos, "Can not overwrite a value") from None
+
+    if not src.startswith("]", pos):
+        raise suffixed_err(src, pos, 'Expected "]" at the end of a table declaration')
+    return pos + 1, key
+
+
+def create_list_rule(src: str, pos: Pos, out: Output) -> Tuple[Pos, Key]:
+    pos += 2  # Skip "[["
+    pos = skip_chars(src, pos, TOML_WS)
+    pos, key = parse_key(src, pos)
+
+    if out.flags.is_(key, Flags.FROZEN):
+        raise suffixed_err(src, pos, f"Can not mutate immutable namespace {key}")
+    # Free the namespace now that it points to another empty list item...
+    out.flags.unset_all(key)
+    # ...but this key precisely is still prohibited from table declaration
+    out.flags.set(key, Flags.EXPLICIT_NEST, recursive=False)
+    try:
+        out.data.append_nest_to_list(key)
+    except KeyError:
+        raise suffixed_err(src, pos, "Can not overwrite a value") from None
+
+    if not src.startswith("]]", pos):
+        raise suffixed_err(src, pos, 'Expected "]]" at the end of an array declaration')
+    return pos + 2, key
+
+
+def key_value_rule(
+    src: str, pos: Pos, out: Output, header: Key, parse_float: ParseFloat
+) -> Pos:
+    pos, key, value = parse_key_value_pair(src, pos, parse_float)
+    key_parent, key_stem = key[:-1], key[-1]
+    abs_key_parent = header + key_parent
+
+    if out.flags.is_(abs_key_parent, Flags.FROZEN):
+        raise suffixed_err(
+            src, pos, f"Can not mutate immutable namespace {abs_key_parent}"
+        )
+    # Containers in the relative path can't be opened with the table syntax after this
+    out.flags.set_for_relative_key(header, key, Flags.EXPLICIT_NEST)
+    try:
+        nest = out.data.get_or_create_nest(abs_key_parent)
+    except KeyError:
+        raise suffixed_err(src, pos, "Can not overwrite a value") from None
+    if key_stem in nest:
+        raise suffixed_err(src, pos, "Can not overwrite a value")
+    # Mark inline table and array namespaces recursively immutable
+    if isinstance(value, (dict, list)):
+        out.flags.set(header + key, Flags.FROZEN, recursive=True)
+    nest[key_stem] = value
+    return pos
+
+
+def parse_key_value_pair(
+    src: str, pos: Pos, parse_float: ParseFloat
+) -> Tuple[Pos, Key, Any]:
+    pos, key = parse_key(src, pos)
+    try:
+        char: Optional[str] = src[pos]
+    except IndexError:
+        char = None
+    if char != "=":
+        raise suffixed_err(src, pos, 'Expected "=" after a key in a key/value pair')
+    pos += 1
+    pos = skip_chars(src, pos, TOML_WS)
+    pos, value = parse_value(src, pos, parse_float)
+    return pos, key, value
+
+
+def parse_key(src: str, pos: Pos) -> Tuple[Pos, Key]:
+    pos, key_part = parse_key_part(src, pos)
+    key: Key = (key_part,)
+    pos = skip_chars(src, pos, TOML_WS)
+    while True:
+        try:
+            char: Optional[str] = src[pos]
+        except IndexError:
+            char = None
+        if char != ".":
+            return pos, key
+        pos += 1
+        pos = skip_chars(src, pos, TOML_WS)
+        pos, key_part = parse_key_part(src, pos)
+        key += (key_part,)
+        pos = skip_chars(src, pos, TOML_WS)
+
+
+def parse_key_part(src: str, pos: Pos) -> Tuple[Pos, str]:
+    try:
+        char: Optional[str] = src[pos]
+    except IndexError:
+        char = None
+    if char in BARE_KEY_CHARS:
+        start_pos = pos
+        pos = skip_chars(src, pos, BARE_KEY_CHARS)
+        return pos, src[start_pos:pos]
+    if char == "'":
+        return parse_literal_str(src, pos)
+    if char == '"':
+        return parse_one_line_basic_str(src, pos)
+    raise suffixed_err(src, pos, "Invalid initial character for a key part")
+
+
+def parse_one_line_basic_str(src: str, pos: Pos) -> Tuple[Pos, str]:
+    pos += 1
+    return parse_basic_str(src, pos, multiline=False)
+
+
+def parse_array(src: str, pos: Pos, parse_float: ParseFloat) -> Tuple[Pos, list]:
+    pos += 1
+    array: list = []
+
+    pos = skip_comments_and_array_ws(src, pos)
+    if src.startswith("]", pos):
+        return pos + 1, array
+    while True:
+        pos, val = parse_value(src, pos, parse_float)
+        array.append(val)
+        pos = skip_comments_and_array_ws(src, pos)
+
+        c = src[pos : pos + 1]
+        if c == "]":
+            return pos + 1, array
+        if c != ",":
+            raise suffixed_err(src, pos, "Unclosed array")
+        pos += 1
+
+        pos = skip_comments_and_array_ws(src, pos)
+        if src.startswith("]", pos):
+            return pos + 1, array
+
+
+def parse_inline_table(src: str, pos: Pos, parse_float: ParseFloat) -> Tuple[Pos, dict]:
+    pos += 1
+    nested_dict = NestedDict()
+    flags = Flags()
+
+    pos = skip_chars(src, pos, TOML_WS)
+    if src.startswith("}", pos):
+        return pos + 1, nested_dict.dict
+    while True:
+        pos, key, value = parse_key_value_pair(src, pos, parse_float)
+        key_parent, key_stem = key[:-1], key[-1]
+        if flags.is_(key, Flags.FROZEN):
+            raise suffixed_err(src, pos, f"Can not mutate immutable namespace {key}")
+        try:
+            nest = nested_dict.get_or_create_nest(key_parent, access_lists=False)
+        except KeyError:
+            raise suffixed_err(src, pos, "Can not overwrite a value") from None
+        if key_stem in nest:
+            raise suffixed_err(src, pos, f"Duplicate inline table key {key_stem!r}")
+        nest[key_stem] = value
+        pos = skip_chars(src, pos, TOML_WS)
+        c = src[pos : pos + 1]
+        if c == "}":
+            return pos + 1, nested_dict.dict
+        if c != ",":
+            raise suffixed_err(src, pos, "Unclosed inline table")
+        if isinstance(value, (dict, list)):
+            flags.set(key, Flags.FROZEN, recursive=True)
+        pos += 1
+        pos = skip_chars(src, pos, TOML_WS)
+
+
+def parse_basic_str_escape(  # noqa: C901
+    src: str, pos: Pos, *, multiline: bool = False
+) -> Tuple[Pos, str]:
+    escape_id = src[pos : pos + 2]
+    pos += 2
+    if multiline and escape_id in {"\\ ", "\\\t", "\\\n"}:
+        # Skip whitespace until next non-whitespace character or end of
+        # the doc. Error if non-whitespace is found before newline.
+        if escape_id != "\\\n":
+            pos = skip_chars(src, pos, TOML_WS)
+            try:
+                char = src[pos]
+            except IndexError:
+                return pos, ""
+            if char != "\n":
+                raise suffixed_err(src, pos, 'Unescaped "\\" in a string')
+            pos += 1
+        pos = skip_chars(src, pos, TOML_WS_AND_NEWLINE)
+        return pos, ""
+    if escape_id == "\\u":
+        return parse_hex_char(src, pos, 4)
+    if escape_id == "\\U":
+        return parse_hex_char(src, pos, 8)
+    try:
+        return pos, BASIC_STR_ESCAPE_REPLACEMENTS[escape_id]
+    except KeyError:
+        if len(escape_id) != 2:
+            raise suffixed_err(src, pos, "Unterminated string") from None
+        raise suffixed_err(src, pos, 'Unescaped "\\" in a string') from None
+
+
+def parse_basic_str_escape_multiline(src: str, pos: Pos) -> Tuple[Pos, str]:
+    return parse_basic_str_escape(src, pos, multiline=True)
+
+
+def parse_hex_char(src: str, pos: Pos, hex_len: int) -> Tuple[Pos, str]:
+    hex_str = src[pos : pos + hex_len]
+    if len(hex_str) != hex_len or not HEXDIGIT_CHARS.issuperset(hex_str):
+        raise suffixed_err(src, pos, "Invalid hex value")
+    pos += hex_len
+    hex_int = int(hex_str, 16)
+    if not is_unicode_scalar_value(hex_int):
+        raise suffixed_err(src, pos, "Escaped character is not a Unicode scalar value")
+    return pos, chr(hex_int)
+
+
+def parse_literal_str(src: str, pos: Pos) -> Tuple[Pos, str]:
+    pos += 1  # Skip starting apostrophe
+    start_pos = pos
+    pos = skip_until(
+        src, pos, "'", error_on=ILLEGAL_LITERAL_STR_CHARS, error_on_eof=True
+    )
+    return pos + 1, src[start_pos:pos]  # Skip ending apostrophe
+
+
+def parse_multiline_str(src: str, pos: Pos, *, literal: bool) -> Tuple[Pos, str]:
+    pos += 3
+    if src.startswith("\n", pos):
+        pos += 1
+
+    if literal:
+        delim = "'"
+        end_pos = skip_until(
+            src,
+            pos,
+            "'''",
+            error_on=ILLEGAL_MULTILINE_LITERAL_STR_CHARS,
+            error_on_eof=True,
+        )
+        result = src[pos:end_pos]
+        pos = end_pos + 3
+    else:
+        delim = '"'
+        pos, result = parse_basic_str(src, pos, multiline=True)
+
+    # Add at maximum two extra apostrophes/quotes if the end sequence
+    # is 4 or 5 chars long instead of just 3.
+    if not src.startswith(delim, pos):
+        return pos, result
+    pos += 1
+    if not src.startswith(delim, pos):
+        return pos, result + delim
+    pos += 1
+    return pos, result + (delim * 2)
+
+
+def parse_basic_str(src: str, pos: Pos, *, multiline: bool) -> Tuple[Pos, str]:
+    if multiline:
+        error_on = ILLEGAL_MULTILINE_BASIC_STR_CHARS
+        parse_escapes = parse_basic_str_escape_multiline
+    else:
+        error_on = ILLEGAL_BASIC_STR_CHARS
+        parse_escapes = parse_basic_str_escape
+    result = ""
+    start_pos = pos
+    while True:
+        try:
+            char = src[pos]
+        except IndexError:
+            raise suffixed_err(src, pos, "Unterminated string") from None
+        if char == '"':
+            if not multiline:
+                return pos + 1, result + src[start_pos:pos]
+            if src.startswith('"""', pos):
+                return pos + 3, result + src[start_pos:pos]
+            pos += 1
+            continue
+        if char == "\\":
+            result += src[start_pos:pos]
+            pos, parsed_escape = parse_escapes(src, pos)
+            result += parsed_escape
+            start_pos = pos
+            continue
+        if char in error_on:
+            raise suffixed_err(src, pos, f"Illegal character {char!r}")
+        pos += 1
+
+
+def parse_value(  # noqa: C901
+    src: str, pos: Pos, parse_float: ParseFloat
+) -> Tuple[Pos, Any]:
+    try:
+        char: Optional[str] = src[pos]
+    except IndexError:
+        char = None
+
+    # Basic strings
+    if char == '"':
+        if src.startswith('"""', pos):
+            return parse_multiline_str(src, pos, literal=False)
+        return parse_one_line_basic_str(src, pos)
+
+    # Literal strings
+    if char == "'":
+        if src.startswith("'''", pos):
+            return parse_multiline_str(src, pos, literal=True)
+        return parse_literal_str(src, pos)
+
+    # Booleans
+    if char == "t":
+        if src.startswith("true", pos):
+            return pos + 4, True
+    if char == "f":
+        if src.startswith("false", pos):
+            return pos + 5, False
+
+    # Dates and times
+    datetime_match = RE_DATETIME.match(src, pos)
+    if datetime_match:
+        try:
+            datetime_obj = match_to_datetime(datetime_match)
+        except ValueError as e:
+            raise suffixed_err(src, pos, "Invalid date or datetime") from e
+        return datetime_match.end(), datetime_obj
+    localtime_match = RE_LOCALTIME.match(src, pos)
+    if localtime_match:
+        return localtime_match.end(), match_to_localtime(localtime_match)
+
+    # Integers and "normal" floats.
+    # The regex will greedily match any type starting with a decimal
+    # char, so needs to be located after handling of dates and times.
+    number_match = RE_NUMBER.match(src, pos)
+    if number_match:
+        return number_match.end(), match_to_number(number_match, parse_float)
+
+    # Arrays
+    if char == "[":
+        return parse_array(src, pos, parse_float)
+
+    # Inline tables
+    if char == "{":
+        return parse_inline_table(src, pos, parse_float)
+
+    # Special floats
+    first_three = src[pos : pos + 3]
+    if first_three in {"inf", "nan"}:
+        return pos + 3, parse_float(first_three)
+    first_four = src[pos : pos + 4]
+    if first_four in {"-inf", "+inf", "-nan", "+nan"}:
+        return pos + 4, parse_float(first_four)
+
+    raise suffixed_err(src, pos, "Invalid value")
+
+
+def suffixed_err(src: str, pos: Pos, msg: str) -> TOMLDecodeError:
+    """Return a `TOMLDecodeError` where error message is suffixed with
+    coordinates in source."""
+
+    def coord_repr(src: str, pos: Pos) -> str:
+        if pos >= len(src):
+            return "end of document"
+        line = src.count("\n", 0, pos) + 1
+        if line == 1:
+            column = pos + 1
+        else:
+            column = pos - src.rindex("\n", 0, pos)
+        return f"line {line}, column {column}"
+
+    return TOMLDecodeError(f"{msg} (at {coord_repr(src, pos)})")
+
+
+def is_unicode_scalar_value(codepoint: int) -> bool:
+    return (0 <= codepoint <= 55295) or (57344 <= codepoint <= 1114111)

--- a/src/bindings/python/flux/utils/tomli/_re.py
+++ b/src/bindings/python/flux/utils/tomli/_re.py
@@ -1,0 +1,101 @@
+from datetime import date, datetime, time, timedelta, timezone, tzinfo
+from functools import lru_cache
+import re
+from typing import Any, Optional, Union
+
+from ._types import ParseFloat
+
+# E.g.
+# - 00:32:00.999999
+# - 00:32:00
+_TIME_RE_STR = r"([01][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9])(?:\.([0-9]{1,6})[0-9]*)?"
+
+RE_NUMBER = re.compile(
+    r"""
+0
+(?:
+    x[0-9A-Fa-f](?:_?[0-9A-Fa-f])*   # hex
+    |
+    b[01](?:_?[01])*                 # bin
+    |
+    o[0-7](?:_?[0-7])*               # oct
+)
+|
+[+-]?(?:0|[1-9](?:_?[0-9])*)         # dec, integer part
+(?P<floatpart>
+    (?:\.[0-9](?:_?[0-9])*)?         # optional fractional part
+    (?:[eE][+-]?[0-9](?:_?[0-9])*)?  # optional exponent part
+)
+""",
+    flags=re.VERBOSE,
+)
+RE_LOCALTIME = re.compile(_TIME_RE_STR)
+RE_DATETIME = re.compile(
+    fr"""
+([0-9]{{4}})-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])  # date, e.g. 1988-10-27
+(?:
+    [Tt ]
+    {_TIME_RE_STR}
+    (?:([Zz])|([+-])([01][0-9]|2[0-3]):([0-5][0-9]))?  # optional time offset
+)?
+""",
+    flags=re.VERBOSE,
+)
+
+
+def match_to_datetime(match: "re.Match") -> Union[datetime, date]:
+    """Convert a `RE_DATETIME` match to `datetime.datetime` or `datetime.date`.
+
+    Raises ValueError if the match does not correspond to a valid date
+    or datetime.
+    """
+    (
+        year_str,
+        month_str,
+        day_str,
+        hour_str,
+        minute_str,
+        sec_str,
+        micros_str,
+        zulu_time,
+        offset_sign_str,
+        offset_hour_str,
+        offset_minute_str,
+    ) = match.groups()
+    year, month, day = int(year_str), int(month_str), int(day_str)
+    if hour_str is None:
+        return date(year, month, day)
+    hour, minute, sec = int(hour_str), int(minute_str), int(sec_str)
+    micros = int(micros_str.ljust(6, "0")) if micros_str else 0
+    if offset_sign_str:
+        tz: Optional[tzinfo] = cached_tz(
+            offset_hour_str, offset_minute_str, offset_sign_str
+        )
+    elif zulu_time:
+        tz = timezone.utc
+    else:  # local date-time
+        tz = None
+    return datetime(year, month, day, hour, minute, sec, micros, tzinfo=tz)
+
+
+@lru_cache(maxsize=None)
+def cached_tz(hour_str: str, minute_str: str, sign_str: str) -> timezone:
+    sign = 1 if sign_str == "+" else -1
+    return timezone(
+        timedelta(
+            hours=sign * int(hour_str),
+            minutes=sign * int(minute_str),
+        )
+    )
+
+
+def match_to_localtime(match: "re.Match") -> time:
+    hour_str, minute_str, sec_str, micros_str = match.groups()
+    micros = int(micros_str.ljust(6, "0")) if micros_str else 0
+    return time(int(hour_str), int(minute_str), int(sec_str), micros)
+
+
+def match_to_number(match: "re.Match", parse_float: "ParseFloat") -> Any:
+    if match.group("floatpart"):
+        return parse_float(match.group())
+    return int(match.group(), 0)

--- a/src/bindings/python/flux/utils/tomli/_types.py
+++ b/src/bindings/python/flux/utils/tomli/_types.py
@@ -1,0 +1,6 @@
+from typing import Any, Callable, Tuple
+
+# Type annotations
+ParseFloat = Callable[[str], Any]
+Key = Tuple[str, ...]
+Pos = int

--- a/src/bindings/python/flux/utils/tomli/py.typed
+++ b/src/bindings/python/flux/utils/tomli/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561

--- a/src/cmd/flux-jobs.py
+++ b/src/cmd/flux-jobs.py
@@ -93,6 +93,20 @@ def load_format_string(args):
             except KeyError:
                 print()
         sys.exit(0)
+    elif args.format.startswith("get-config="):
+        _, name = args.format.split("=", 1)
+        try:
+            entry = config.formats[name]
+        except KeyError:
+            LOGGER.error("--format: No such format %s", name)
+            sys.exit(1)
+        print(f"[formats.{name}]")
+        try:
+            print(f"description = \"{entry['description']}\"")
+        except KeyError:
+            pass
+        print(f"format = \"{entry['format']}\"")
+        sys.exit(0)
     try:
         return config.formats[args.format]["format"]
     except KeyError:

--- a/src/cmd/flux-jobs.py
+++ b/src/cmd/flux-jobs.py
@@ -36,7 +36,14 @@ class FluxJobsConfig(UtilConfig):
                 "{status_abbrev:>2.2} {ntasks:>6} {nnodes:>6h} "
                 "{runtime!F:>8} {nodelist:h}"
             ),
-        }
+        },
+        "deps": {
+            "description": "Show job urgency, priority, and dependencies",
+            "format": (
+                "{id.f58:>12} {name:<10.10} {urgency:<3} {priority:<12} "
+                "{state:<8.8} {dependencies}"
+            ),
+        },
     }
 
     def __init__(self):

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -189,6 +189,7 @@ TESTSCRIPTS = \
 	t2800-jobs-cmd.t \
 	t2800-jobs-recursive.t \
 	t2800-jobs-instance-info.t \
+	t2800-jobs-config.t \
 	t2801-top-cmd.t \
 	t2802-uri-cmd.t \
 	t2803-flux-pstree.t \

--- a/t/sharness.d/flux-sharness.sh
+++ b/t/sharness.d/flux-sharness.sh
@@ -394,4 +394,11 @@ unset FLUX_F58_FORCE_ASCII
 #  this specifically. In general it breaks other URI tests:
 unset FLUX_URI_RESOLVE_LOCAL
 
+# Set XDG_CONFIG_DIRS and XDG_CONFIG_HOME to a nonexistent directory to
+#  avoid system or user configuration influencing tests for utilities
+#  that use flux.util.UtilConfig or other config classes utilizing
+#  the XDG base directory specification.
+export XDG_CONFIG_DIRS=/noexist
+export XDG_CONFIG_HOME=/noexist
+
 # vi: ts=4 sw=4 expandtab

--- a/t/t2800-jobs-config.t
+++ b/t/t2800-jobs-config.t
@@ -65,6 +65,11 @@ test_expect_success 'flux-jobs config may omit description' '
 	test_debug "cat myformat.out" &&
 	grep "myformat" myformat.out
 '
+test_expect_success 'flux-jobs --format=get-config works' '
+	flux jobs --format=get-config=default >get-config.out &&
+	test_debug "cat get-config.out" &&
+	grep default get-config.out
+'
 test_expect_success 'XDG_CONFIG_DIRS can be colon-separated paths' '
 	mkdir -p dir2/flux &&
 	cat <<-EOF >dir2/flux/flux-jobs.toml &&

--- a/t/t2800-jobs-config.t
+++ b/t/t2800-jobs-config.t
@@ -1,0 +1,145 @@
+#!/bin/sh
+
+test_description='Test flux jobs command config file support'
+
+. $(dirname $0)/sharness.sh
+
+test_under_flux 1 job
+
+test_expect_success 'run a job for job listing purposes' '
+	flux mini submit sleep 300
+'
+test_expect_success 'flux-jobs --format=help works' '
+	flux jobs --format=help >help.out &&
+	test_debug "cat help.out" &&
+	grep "flux-jobs output formats:" help.out
+'
+test_expect_success 'flux-jobs --format=invalid fails' '
+	test_must_fail flux jobs --format=invalid
+'
+#  We can't add configuration to ~/.config or /etc/xdg/flux, so
+#   just test that XDG_CONFIG_HOME works.
+#
+test_expect_success 'Additional formats can be added to XDG_CONFIG_HOME' '
+	mkdir -p dir/flux &&
+	cat <<-EOF >dir/flux/flux-jobs.toml &&
+	[formats.myformat]
+        description = "my format"
+	format = "{id.words}"
+	EOF
+	XDG_CONFIG_HOME="$(pwd)/dir" flux jobs --format=help >myformat.out &&
+	test_debug "cat myformat.out" &&
+	grep "my format" myformat.out &&
+	XDG_CONFIG_HOME="$(pwd)/dir" flux jobs --format=myformat
+'
+test_expect_success 'flux-jobs config can be yaml' '
+	mkdir -p yaml/flux &&
+	cat <<-EOF >yaml/flux/flux-jobs.yaml &&
+	formats:
+	  myformat:
+	    description: My YAML Format
+	    format: "{id.f58} {runtime}"
+	EOF
+	XDG_CONFIG_HOME="$(pwd)/yaml" flux jobs --format=help >yaml.out &&
+	test_debug "cat yaml.out" &&
+	grep "My YAML Format" yaml.out &&
+	XDG_CONFIG_HOME="$(pwd)/yaml" flux jobs --format=myformat
+'
+test_expect_success 'flux-jobs config can be json' '
+	mkdir -p json/flux &&
+	cat <<-EOF >json/flux/flux-jobs.json &&
+	{ "formats": { "myformat": { "description": "My JSON Format",
+	    "format": "{id.words} {runtime}" } } }
+	EOF
+	XDG_CONFIG_HOME="$(pwd)/json" flux jobs --format=help >json.out &&
+	test_debug "cat json.out" &&
+	grep "My JSON Format" json.out &&
+	XDG_CONFIG_HOME="$(pwd)/json" flux jobs --format=myformat
+'
+test_expect_success 'flux-jobs config may omit description' '
+	cat <<-EOF >dir/flux/flux-jobs.toml &&
+	[formats.myformat]
+	format = "{id.words}"
+	EOF
+	XDG_CONFIG_HOME="$(pwd)/dir" flux jobs --format=help >myformat.out &&
+	test_debug "cat myformat.out" &&
+	grep "myformat" myformat.out
+'
+test_expect_success 'XDG_CONFIG_DIRS can be colon-separated paths' '
+	mkdir -p dir2/flux &&
+	cat <<-EOF >dir2/flux/flux-jobs.toml &&
+	[formats.myformat]
+        description = "my new format"
+	format = "{id.words} {name}"
+	EOF
+	XDG_CONFIG_DIRS="$(pwd)/dir2:$(pwd)/dir" \
+		flux jobs --format=help >myformat.out &&
+	test_debug "cat myformat.out" &&
+	grep "my new format" myformat.out &&
+	XDG_CONFIG_DIRS="$(pwd)/dir:$(pwd)/dir2" \
+		flux jobs --format=myformat
+'
+test_expect_success 'Invalid flux-jobs config file causes meaningful error' '
+	mkdir -p dir/flux &&
+	cat <<-EOF >dir/flux/flux-jobs.toml &&
+	[formats.myformat]
+        description = "missing format"
+	EOF
+	( export XDG_CONFIG_HOME="$(pwd)/dir" &&
+	  test_must_fail flux jobs --format=help >missing.out 2>&1
+	) &&
+	grep "required key .* missing" missing.out
+'
+test_expect_success 'flux-jobs does not allow internal formats to be overridden' '
+	cat <<-EOF >dir/flux/flux-jobs.toml &&
+	[formats.default]
+	description  = "override of default format"
+	format = "{id}"
+	EOF
+	( export XDG_CONFIG_HOME="$(pwd)/dir" &&
+	  test_must_fail flux jobs --format=help >no-override.out 2>&1
+	) &&
+	grep "override of builtin format" no-override.out
+
+'
+test_expect_success 'flux-jobs checks that formats is a mapping' '
+	cat <<-EOF >dir/flux/flux-jobs.toml &&
+	formats = "yay"
+	EOF
+	( export XDG_CONFIG_HOME="$(pwd)/dir" &&
+	  test_must_fail flux jobs --format=help >notamapping.out 2>&1
+	) &&
+	grep "must be a mapping" notamapping.out
+'
+test_expect_success 'flux-jobs checks that formats.NAME is a mapping' '
+	cat <<-EOF >dir/flux/flux-jobs.toml &&
+	formats.myformat = 42
+	EOF
+	( export XDG_CONFIG_HOME="$(pwd)/dir" &&
+	  test_must_fail flux jobs --format=help >notamapping2.out 2>&1
+	) &&
+	grep "must be a mapping" notamapping2.out
+'
+test_expect_success 'flux-jobs checks that formats.NAME.format is a string' '
+	cat <<-EOF >dir/flux/flux-jobs.toml &&
+	[formats.myformat]
+	format = 42
+	EOF
+	( export XDG_CONFIG_HOME="$(pwd)/dir" &&
+	  test_must_fail flux jobs --format=help >notastring.out 2>&1
+	) &&
+	grep "must be a string" notastring.out
+'
+test_expect_success 'Invalid flux-jobs invalid config causes meaningful error' '
+	mkdir -p dir/flux &&
+	cat <<-EOF >dir/flux/flux-jobs.toml &&
+	[formats.myformat]
+        description = "invalid toml"
+	format = "{id.f58}
+	EOF
+	( export XDG_CONFIG_HOME="$(pwd)/dir" &&
+	  test_must_fail flux jobs --format=help >badtoml.out 2>&1
+	) &&
+	grep "flux-jobs.toml" badtoml.out
+'
+test_done


### PR DESCRIPTION
It turns out it wasn't so difficult to reject overrides of internal default formats in the `flux jobs` configuration support.

Unfortunately, I can't re-open #4571, so we'll have to start over here.

This updates #4571 such that any internally defined formats for `flux-jobs` can't be overridden by system or user configuration.
```conf
$ flux jobs 
flux-jobs: ERROR: /home/grondo/.config/flux/flux-jobs.toml: override of builtin format 'default' not permitted
```

It also tentatively adds support for `--format=get-config=NAME` as requested:
```console
$ flux jobs -o get-config=default
[formats.default]
description = "Default flux-jobs format string"
format = "{id.f58:>12} {username:<8.8} {name:<10.10} {status_abbrev:>2.2} {ntasks:>6} {nnodes:>6h} {runtime!F:>8} {nodelist:h}"
```

This feature is added and tested in separate commits for now in case we want to drop that feature.

The ability to list what config file defined a given format was not added at this time, because I could not determine an easy way to do that. If that is a showstopper then PR #4594 should be merged instead and we can table this one again.