### PR TITLE
flux-jobs: support width and alignment with `!d` conversion specifier

### DIFF
--- a/doc/man1/flux-jobs.rst
+++ b/doc/man1/flux-jobs.rst
@@ -177,10 +177,11 @@ the following conversion flags are supported by *flux-jobs*:
    Defaults to empty string if timestamp field does not exist.
 
 **!d**
-   convert a timestamp to a Python datetime object. This allows datetime specific
-   format to be used, e.g. *{t_inactive!d:%H:%M:%S}*. However, note that width
-   and alignment specifiers are not supported for datetime formatting.
-   Defaults to datetime of epoch if timestamp field does not exist.
+   convert a timestamp to a Python datetime object. This allows datetime
+   specific format to be used, e.g. *{t_inactive!d:%H:%M:%S}*. Additionally,
+   width and alignment can be specified after the time format by using
+   two colons (``::``), e.g. *{t_inactive:%H:%M:%S::>20}*. Defaults to
+   datetime of epoch if timestamp field does not exist.
 
 **!F**
    convert a duration in floating point seconds to Flux Standard Duration (FSD).

--- a/src/bindings/python/flux/util.py
+++ b/src/bindings/python/flux/util.py
@@ -352,13 +352,15 @@ class OutputFormat:
         for (text, field, spec, _) in self.format_list:
             #  Remove number formatting on any spec:
             spec = re.sub(r"(0?\.)?(\d+)?[bcdoxXeEfFgGn%]$", r"\2", spec)
+
             #  Only keep fill, align, and min width of the result.
             #  This strips possible type-specific formatting spec that
             #   will not apply to a heading, but keeps width and alignment.
-            match = re.match(r"(.?[<>=^])?(\d+)", spec)
+            match = re.search(r"([<>=^])?(\d+)", spec)
             if match is None:
                 spec = ""
-
+            else:
+                spec = match[0]
             #  Remove any conversion, these do not make sense for headings
             format_list.append(self._fmt_tuple(text, field, spec, None))
         fmt = "".join(format_list)

--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -815,6 +815,23 @@ test_expect_success 'flux-jobs --format={expiration!d:%FT%T},{t_remaining!H} wor
 	test_debug "echo expiration OK" &&
 	echo ${t_remaining} | grep "[0-9]:[0-9][0-9]:[0-9][0-9]"
 '
+test_expect_success 'flux-jobs --format={expiration!d:%FT%T::>20.20} works' '
+	cat expiration.in | \
+	    flux jobs --from-stdin -o "{expiration!d:%b%d %R::>20.20}" \
+	    >exp-fmt.out &&
+	test_debug "cat exp-fmt.out" &&
+	grep "          EXPIRATION" exp-fmt.out &&
+	grep "         $(date --date=@${exp} +%b%d\ %R)" exp-fmt.out
+'
+test_expect_success 'flux-jobs --format={expiration!d:%FT%T::=^20} works' '
+	cat expiration.in | \
+	    flux jobs --from-stdin -o "{expiration!d:%b%d %R::=^20}" \
+	    >exp-fmt.out &&
+	test_debug "cat exp-fmt.out" &&
+	grep "     EXPIRATION     " exp-fmt.out &&
+	grep "====$(date --date=@${exp} +%b%d\ %R)====" exp-fmt.out
+'
+test_done
 test_expect_success 'flux-jobs --format={expiration!D:h},{t_remaining!H:h} works' '
 	cat <<-EOF >expiration.in &&
 {"id": 1447588528128, "state": 8,  "expiration": 0 }


### PR DESCRIPTION
The `flux-jobs` `!d` conversion specifier converts job timestamps to Python `datetime` objects so that `strftime(3)` format specifiers can be used to generate flexible representations of time. However, a drawback of this is that the `datetime` class' `__format__` method does not support width and alignment specifiers (i.e. `:>20`), which makes it impossible to use with other fields because the placement of the field (and the header) can't be controlled.

This PR introduces a `JobDatetime` class which subclasses `datetime` and replaces the `__format__` method with a version that allows the Python format spec to occur after any time format separated by `::`. The `!d` conversion specifier is then updated to convert to `JobDatetime` instead of `datetime`.

Now this works:
```console
$ flux jobs -ao '{id.f58:>12} {t_submit!d:%b%d %R::>12}'
       JOBID     T_SUBMIT
  ƒ5C6TPdeHm  Sep21 19:32
  ƒ5C52XDnfq  Sep21 19:32
  ƒ3CqkPSKDR  Sep21 15:19
```