### PR TITLE
flux-mini: add `-q, --queue=NAME` option

### DIFF
--- a/doc/man1/flux-mini.rst
+++ b/doc/man1/flux-mini.rst
@@ -150,6 +150,13 @@ Additional job options
 The **run**, **submit**, **batch**, and **alloc** commands also take
 following additional job parameters:
 
+**-q, --queue=NAME**
+   Submit a job to a specific named queue. If a queue is not specified
+   and queues are configured, then the jobspec will be modified at ingest
+   to specify the default queue. If queues are not configured, then this
+   option is ignored, though :man1:`flux-jobs` may display the queue
+   name in its rendering of the ``{queue}`` attribute.
+
 **-t, --time-limit=MINUTES|FSD**
    Set a time limit for the job in either minutes or Flux standard duration
    (RFC 23). FSD is a floating point number with a single character units

--- a/doc/man1/flux-mini.rst
+++ b/doc/man1/flux-mini.rst
@@ -473,6 +473,9 @@ OTHER OPTIONS
    As with ``--cc``, ``{cc}`` in option arguments and commands will be
    replaced with the current ``id``.
 
+**--quiet**
+   *(submit,bulksubmit)* Suppress logging of jobids to stdout.
+
 **--log=FILE**
    *(submit,bulksubmit)* Log ``flux-mini`` output and stderr to ``FILE``
    instead of the terminal. If a replacement (e.g. ``{}`` or ``{cc}``)

--- a/src/cmd/flux-mini.py
+++ b/src/cmd/flux-mini.py
@@ -933,7 +933,6 @@ class SubmitBulkCmd(SubmitBaseCmd):
 
         super().__init__()
         self.parser.add_argument(
-            "-q",
             "--quiet",
             action="store_true",
             help="Do not print jobid to stdout on submission",

--- a/src/cmd/flux-mini.py
+++ b/src/cmd/flux-mini.py
@@ -224,6 +224,7 @@ class Xcmd:
     # dict of mutable argparse args. The values are used in
     #  the string representation of an Xcmd object.
     mutable_args = {
+        "queue": "-q",
         "ntasks": "-n",
         "nodes": "-N",
         "cores_per_task": "-c",
@@ -458,6 +459,13 @@ class MiniCmd:
         """
         parser = argparse.ArgumentParser(add_help=False, allow_abbrev=False)
         parser.add_argument(
+            "-q",
+            "--queue",
+            type=str,
+            metavar="NAME",
+            help="Submit a job to a specific named queue",
+        )
+        parser.add_argument(
             "-t",
             "--time-limit",
             type=str,
@@ -651,6 +659,9 @@ class MiniCmd:
         if debugged.get_mpir_being_debugged() == 1:
             # if stop-tasks-in-exec is present, overwrite
             jobspec.setattr_shell_option("stop-tasks-in-exec", json.loads("1"))
+
+        if args.queue is not None:
+            jobspec.setattr("system.queue", args.queue)
 
         if args.setattr is not None:
             for keyval in args.setattr:

--- a/t/issues/t4465-job-list-use-after-free.sh
+++ b/t/issues/t4465-job-list-use-after-free.sh
@@ -23,7 +23,7 @@ mkdir ${STATEDIR}
 # number of broker ranks.
 #
 flux start --test-size=8 -o,-Sstatedir=${STATEDIR} \
-    bash -c "flux mini submit --cc 1-8 -q /bin/true && flux queue drain"
+    bash -c "flux mini submit --cc 1-8 --quiet /bin/true && flux queue drain"
 
 flux start --test-size=1 -o,-Sstatedir=${STATEDIR} \
     --wrap=libtool,e,${VALGRIND} \

--- a/t/t2112-job-ingest-frobnicator.t
+++ b/t/t2112-job-ingest-frobnicator.t
@@ -89,7 +89,7 @@ test_expect_success HAVE_JQ 'job-frobnicator sets default queue duration' '
 	jq -e ".data.attributes.system.duration == 3600"   < queue-debug.out
 '
 test_expect_success HAVE_JQ 'job-frobnicator sets specified queue duration' '
-	flux mini run --env=-* --setattr queue=batch --dry-run hostname \
+	flux mini run --env=-* --queue=batch --dry-run hostname \
 		| flux job-frobnicator --jobspec-only --plugins=defaults \
 		> queue-batch.out &&
 	jq -e ".data.attributes.system.queue == \"batch\"" < queue-batch.out &&
@@ -103,7 +103,7 @@ test_expect_success 'configure queue constraints' '
 	flux config reload
 '
 test_expect_success HAVE_JQ 'constraints plugin sets queue constraint' '
-	flux mini run --env=-* --dry-run --setattr queue=debug hostname \
+	flux mini run --env=-* --dry-run --queue=debug hostname \
 	   | flux job-frobnicator --jobspec-only --plugins=constraints \
 	   > constraint-setqueue.out &&
 	jq -e ".data.attributes.system.constraints.properties \
@@ -111,7 +111,7 @@ test_expect_success HAVE_JQ 'constraints plugin sets queue constraint' '
 '
 test_expect_success HAVE_JQ 'constraints plugin appends queue constraint' '
 	flux mini run --env=-* --dry-run --requires=foo \
-	  --setattr queue=debug hostname \
+	  --queue=debug hostname \
 	   | flux job-frobnicator --jobspec-only --plugins=constraints \
 	   > constraint-addqueue.out &&
 	jq -e ".data.attributes.system.constraints.properties \
@@ -132,7 +132,7 @@ test_expect_success HAVE_JQ 'constraints plugin works without requires' '
 	EOT
 	flux config reload &&
 	flux mini run --env=-* --dry-run hostname \
-           --setattr queue=debug \
+           --queue=debug \
 	   | flux job-frobnicator --jobspec-only --plugins=constraints \
 	> constraint-norequires.out &&
 	jq -e "has(\"data\")" <constraint-norequires.out

--- a/t/t2212-job-manager-plugins.t
+++ b/t/t2212-job-manager-plugins.t
@@ -272,7 +272,7 @@ test_expect_success 'job-manager: run all test plugin test modes' '
 	EOF
 	COUNT=$(cat test-modes.txt | wc -l) &&
 	run_timeout 20 \
-	  flux mini bulksubmit -q --watch \
+	  flux mini bulksubmit --quiet --watch \
 	    --setattr=system.jobtap.test-mode={} \
 	    hostname :::: test-modes.txt >test-plugin.out &&
 	test_debug "cat test-plugin.out" &&

--- a/t/t2221-job-manager-limit-duration.t
+++ b/t/t2221-job-manager-limit-duration.t
@@ -50,13 +50,13 @@ test_expect_success 'a no-queue job that exceeds policy.limits.duration is rejec
 '
 test_expect_success 'but is accepted by a queue with higher limit' '
 	flux mini submit \
-	    --setattr=system.queue=pbatch \
+	    --queue=pbatch \
 	    -t 2h \
 	    /bin/true
 '
 test_expect_success 'and is rejected when it exceeds the queue limit' '
 	test_must_fail flux mini submit \
-	    --setattr=system.queue=pbatch \
+	    --queue=pbatch \
 	    -t 16h \
 	    /bin/true
 '
@@ -65,7 +65,7 @@ test_expect_success 'a job that is under policy.limits.duration is accepted' '
 '
 test_expect_success 'but is rejected on a queue with lower limit' '
 	test_must_fail flux mini submit \
-	    --setattr=system.queue=pdebug \
+	    --queue=pdebug \
 	    -t 1h \
 	    /bin/true
 '
@@ -83,12 +83,12 @@ test_expect_success 'a job that is over policy.limits.duration is rejected' '
 '
 test_expect_success 'but is accepted by the unlimited queue' '
 	flux mini submit \
-	    --setattr=system.queue=pdebug \
+	    --queue=pdebug \
 	    -t 2h /bin/true
 '
 test_expect_success 'a job that sets no explicit duration is accepted by the unlimited queue' '
 	flux mini submit \
-	    --setattr=system.queue=pdebug \
+	    --queue=pdebug \
 	    /bin/true
 '
 test_expect_success 'configure an invalid duration limit' '

--- a/t/t2222-job-manager-limit-job-size.t
+++ b/t/t2222-job-manager-limit-job-size.t
@@ -90,8 +90,7 @@ test_expect_success 'a job with no queue is rejected if over gpu limit' '
 	test_must_fail flux mini submit -n1 -g1 /bin/true
 '
 test_expect_success 'same job is accepted with unlimited queue override' '
-	flux mini submit \
-	    --setattr=system.queue=pdebug -n1 -g1 /bin/true
+	flux mini submit --queue=pdebug -n1 -g1 /bin/true
 '
 test_expect_success 'configure an invalid job-size object' '
 	cat >config/policy.toml <<-EOT &&

--- a/t/t2260-job-list.t
+++ b/t/t2260-job-list.t
@@ -650,7 +650,7 @@ test_expect_success HAVE_JQ 'flux job list output no queue if queue not set' '
 '
 
 test_expect_success HAVE_JQ 'flux job list outputs queue' '
-        jobid=`flux mini submit --wait --setattr=queue=foo /bin/true | flux job id` &&
+        jobid=`flux mini submit --wait --queue=foo /bin/true | flux job id` &&
         echo $jobid > jobqueue2.id &&
         wait_jobid_state $jobid inactive &&
         flux job list -s inactive | grep $jobid | jq -e ".queue == \"foo\""

--- a/t/t2700-mini-cmd.t
+++ b/t/t2700-mini-cmd.t
@@ -125,6 +125,15 @@ test_expect_success 'flux mini submit --time-limit=4-00:30:00 fails' '
 	grep -i "invalid Flux standard duration" st2.err
 '
 
+test_expect_success HAVE_JQ 'flux mini submit --queue works' '
+	flux mini submit --env=-* --dry-run \
+		--queue=batch hostname >queue.out &&
+	jq -e ".attributes.system.queue == \"batch\"" &&
+	flux mini submit --env=-* --dry-run \
+		-q debug hostname >queue2.out &&
+	jq -e ".attributes.system.queue == \"debug\""
+'
+
 test_expect_success HAVE_JQ 'flux mini submit --setattr works' '
 	flux mini submit --env=-* --dry-run \
 		--setattr user.meep=false \

--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -82,11 +82,11 @@ test_expect_success HAVE_JQ 'submit jobs for job list testing' '
 	#  for efficiency (vs serial `flux mini submit`.
 	#
 	flux mini submit --dry-run \
-		--setattr=queue=queue1 \
+		--queue=queue1 \
 		hostname >hostname.json &&
 	flux mini submit --dry-run \
 		--time-limit=5m \
-		--setattr=queue=queue2 \
+		--queue=queue2 \
 		sleep 600 > sleeplong.json &&
 	#
 	#  Submit jobs that will complete

--- a/t/test-inception.sh
+++ b/t/test-inception.sh
@@ -14,7 +14,7 @@ stats() {
 stats &
 PID=$!
 export FLUX_TESTS_LOGFILE=t
-flux mini bulksubmit -o pty --watch -q \
+flux mini bulksubmit -o pty --watch --quiet \
 	sh -c './{} --root=$FLUX_JOB_TMPDIR' \
 	::: t[0-9]*.t python/t*.py lua/t*.t
 RC=$?


### PR DESCRIPTION
The title says it all. This is just shorthand for `--setattr=queue=NAME`.

Fixes #4437