### PR TITLE
flux-top: add minimal support for job queues

### DIFF
--- a/src/cmd/top/joblist_pane.c
+++ b/src/cmd/top/joblist_pane.c
@@ -207,6 +207,11 @@ static void joblist_continuation (flux_future_t *f, void *arg)
     json_decref (joblist->jobs);
     joblist->jobs = json_incref (jobs);
     joblist_pane_draw (joblist);
+    if (joblist->top->test_exit) {
+        /* Ensure joblist window is refreshed before exiting */
+        wrefresh (joblist->win);
+        flux_reactor_stop (flux_future_get_reactor (f));
+    }
     flux_future_destroy (f);
 }
 

--- a/src/cmd/top/top.c
+++ b/src/cmd/top/top.c
@@ -297,11 +297,16 @@ int main (int argc, char *argv[])
     if (!(top = top_create (target, NULL, &error)))
         fatal (0, "%s", error.text);
     if (optparse_hasopt (opts, "test-exit"))
-        reactor_flags |= FLUX_REACTOR_ONCE;
+        top->test_exit = 1;
     if (top_run (top, reactor_flags) < 0)
         fatal (errno, "reactor loop unexpectedly terminated");
 
-    endwin ();
+    if (top->test_exit) {
+        curs_set (1); // restore cursor
+        reset_shell_mode ();
+    }
+    else
+        endwin ();
     top_destroy (top);
     optparse_destroy (opts);
     return 0;

--- a/src/cmd/top/top.h
+++ b/src/cmd/top/top.h
@@ -30,6 +30,9 @@ struct top {
     flux_t *h;
     char *title;
     flux_jobid_t id;
+
+    unsigned int test_exit:1;    /*  Exit after first joblist pane update */
+
     uint32_t size;
     struct summary_pane *summary_pane;
     struct joblist_pane *joblist_pane;

--- a/t/t2801-top-cmd.t
+++ b/t/t2801-top-cmd.t
@@ -128,4 +128,14 @@ test_expect_success NO_CHAIN_LINT 'flux-top does not exit on recursive failure' 
 	        --input=recurse-fail.in flux top &&
 	grep -qi "error connecting to Flux" recurse-fail.log
 '
+test_expect_success 'flux-top displays job queues when present' '
+	$runpty -f asciicast -o no-queue.log flux top --test-exit &&
+	grep -v QUEUE no-queue.log &&
+	jobid=$(flux mini submit --wait-event=start -q testq sleep 30) &&
+	$runpty -f asciicast -o queue.log flux top --test-exit &&
+	grep QUEUE queue.log &&
+	grep testq queue.log &&
+	flux job cancel $jobid &&
+	flux job wait-event $jobid clean
+'
 test_done


### PR DESCRIPTION
This PR simply adds a QUEUE column to `flux-top` when any jobs in the job list have a queue defined.

I thought about adding a `--queue=NAME` option to filter jobs by queue, but this needs more thought since the resource list and job statistics will still apply the entire instance so this may cause more confusion than insight. 

(I'll open a new issue on this so that the original issue tied to our milestone can be closed)
