### PR TITLE
ingest: enable frobnicator when needed by [queues] or [policy]

### DIFF
--- a/doc/man5/flux-config-ingest.rst
+++ b/doc/man5/flux-config-ingest.rst
@@ -35,8 +35,14 @@ batch-count
 FROBNICATOR KEYS
 ================
 
+disable
+   (optional) A boolean indicating whether to disable job frobnication,
+   usually for testing purposes.
+
 plugins
-   (optional) An array of frobnicator plugins to use.
+   (optional) An array of frobnicator plugins to use.  The default value is
+   ``[ "defaults", "constraints" ]`` which are needed for assigning configured
+   jobspec defaults, and adding queue constraints, respectively.
    For a list of supported plugins on your system run
    ``flux job-frobnicator --list-plugins``
 

--- a/doc/man5/flux-config-queues.rst
+++ b/doc/man5/flux-config-queues.rst
@@ -35,10 +35,6 @@ EXAMPLE
 
 ::
 
-   [ingest]
-   validator.plugins = ["feasibility", "jobspec"]
-   frobnicator.plugins = ["defaults", "constraints"]
-
    [[resource.config]]
    hosts = test[0-7]
    properties = ["debug"]

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -636,6 +636,7 @@ parentof
 bg
 norestrict
 frobnicator
+frobnication
 fcfs
 lonodex
 nosched

--- a/src/bindings/python/flux/job/frobnicator/frobnicator.py
+++ b/src/bindings/python/flux/job/frobnicator/frobnicator.py
@@ -66,6 +66,7 @@ class JobFrobnicator:
     namespace.
     """
 
+    default_frobnicators = ["defaults", "constraints"]
     plugin_namespace = "flux.job.frobnicator.plugins"
 
     def __init__(self, argv, pluginpath=None, parser=None):
@@ -90,7 +91,9 @@ class JobFrobnicator:
         self.parser_group.add_argument("--plugins", action="append", default=[])
 
         args, self.remaining_args = self.parser.parse_known_args(argv)
-        if args.plugins:
+        if not args.plugins:
+            args.plugins = self.default_frobnicators
+        else:
             args.plugins = [x for xs in args.plugins for x in xs.split(",")]
 
         #  Load all available frobnicator plugins

--- a/src/bindings/python/flux/job/frobnicator/plugins/defaults.py
+++ b/src/bindings/python/flux/job/frobnicator/plugins/defaults.py
@@ -26,6 +26,10 @@ class DefaultsConfig:
         try:
             self.defaults = config["policy"]["jobspec"]["defaults"]["system"]
             self.default_queue = self.defaults["queue"]
+        except KeyError:
+            pass
+
+        try:
             self.queues = config["queues"]
         except KeyError:
             pass

--- a/t/t2112-job-ingest-frobnicator.t
+++ b/t/t2112-job-ingest-frobnicator.t
@@ -154,5 +154,16 @@ test_expect_success HAVE_JQ 'frobnicator defaults are defaults,constraints' '
 	    == [ \"debug\" ]" \
 	    <defaultplugins.out
 '
+test_expect_success HAVE_JQ 'defaults plugin allows queues without default' '
+	cat <<-EOF >conf.d/conf.toml &&
+	[queues.debug]
+	requires = [ "debug" ]
+	EOF
+	flux config reload &&
+	flux mini run --env=-* --dry-run --queue=debug hostname \
+	   | flux job-frobnicator --jobspec-only --plugins=defaults \
+	    > nodefault.out &&
+	jq -e "has(\"data\")" <nodefault.out
+'
 
 test_done

--- a/t/t2112-job-ingest-frobnicator.t
+++ b/t/t2112-job-ingest-frobnicator.t
@@ -137,5 +137,22 @@ test_expect_success HAVE_JQ 'constraints plugin works without requires' '
 	> constraint-norequires.out &&
 	jq -e "has(\"data\")" <constraint-norequires.out
 '
+test_expect_success HAVE_JQ 'frobnicator defaults are defaults,constraints' '
+	cat <<-EOF >conf.d/conf.toml &&
+	[policy]
+	jobspec.defaults.system.queue = "debug"
+	[queues.debug]
+	requires = [ "debug" ]
+	EOF
+	flux config reload &&
+	flux mini run --env=-* --dry-run hostname \
+	   | flux job-frobnicator --jobspec-only \
+	> defaultplugins.out &&
+	jq -e ".data.attributes.system.queue == \"debug\"" \
+	    <defaultplugins.out &&
+	jq -e ".data.attributes.system.constraints.properties \
+	    == [ \"debug\" ]" \
+	    <defaultplugins.out
+'
 
 test_done

--- a/t/t2221-job-manager-limit-duration.t
+++ b/t/t2221-job-manager-limit-duration.t
@@ -38,9 +38,9 @@ test_expect_success 'configure policy.limits.duration and queue durations' '
 	cat >config/policy.toml <<-EOT &&
 	[policy.limits]
 	duration = "1h"
-	[queues.pdebug.policy.limits]
+	[queues.debug.policy.limits]
 	duration = "1m"
-	[queues.pbatch.policy.limits]
+	[queues.batch.policy.limits]
 	duration = "8h"
 	EOT
 	flux config reload
@@ -50,13 +50,13 @@ test_expect_success 'a no-queue job that exceeds policy.limits.duration is rejec
 '
 test_expect_success 'but is accepted by a queue with higher limit' '
 	flux mini submit \
-	    --queue=pbatch \
+	    --queue=batch \
 	    -t 2h \
 	    /bin/true
 '
 test_expect_success 'and is rejected when it exceeds the queue limit' '
 	test_must_fail flux mini submit \
-	    --queue=pbatch \
+	    --queue=batch \
 	    -t 16h \
 	    /bin/true
 '
@@ -65,7 +65,7 @@ test_expect_success 'a job that is under policy.limits.duration is accepted' '
 '
 test_expect_success 'but is rejected on a queue with lower limit' '
 	test_must_fail flux mini submit \
-	    --queue=pdebug \
+	    --queue=debug \
 	    -t 1h \
 	    /bin/true
 '
@@ -73,7 +73,7 @@ test_expect_success 'configure policy.limits.duration and an unlimited queue' '
 	cat >config/policy.toml <<-EOT &&
 	[policy.limits]
 	duration = "1h"
-	[queues.pdebug.policy.limits]
+	[queues.debug.policy.limits]
 	duration = "0"
 	EOT
 	flux config reload
@@ -83,12 +83,12 @@ test_expect_success 'a job that is over policy.limits.duration is rejected' '
 '
 test_expect_success 'but is accepted by the unlimited queue' '
 	flux mini submit \
-	    --queue=pdebug \
+	    --queue=debug \
 	    -t 2h /bin/true
 '
 test_expect_success 'a job that sets no explicit duration is accepted by the unlimited queue' '
 	flux mini submit \
-	    --queue=pdebug \
+	    --queue=debug \
 	    /bin/true
 '
 test_expect_success 'configure an invalid duration limit' '
@@ -107,7 +107,7 @@ test_expect_success 'configure a duration limit of an invalid type' '
 '
 test_expect_success 'configure an invalid queue duration limit' '
 	cat >config/policy.toml <<-EOT &&
-	[queues.pdebug.policy.limits]
+	[queues.debug.policy.limits]
 	duration = "xyz123"
 	EOT
 	test_must_fail flux config reload

--- a/t/t2222-job-manager-limit-job-size.t
+++ b/t/t2222-job-manager-limit-job-size.t
@@ -78,7 +78,7 @@ test_expect_success 'configure job-size.max.ngpus and queue with unlimited' '
 	cat >config/policy.toml <<-EOT &&
 	[policy.limits]
 	job-size.max.ngpus = 0
-	[queues.pdebug.policy.limits]
+	[queues.debug.policy.limits]
 	job-size.max.ngpus = -1
 	EOT
 	flux config reload
@@ -90,7 +90,7 @@ test_expect_success 'a job with no queue is rejected if over gpu limit' '
 	test_must_fail flux mini submit -n1 -g1 /bin/true
 '
 test_expect_success 'same job is accepted with unlimited queue override' '
-	flux mini submit --queue=pdebug -n1 -g1 /bin/true
+	flux mini submit --queue=debug -n1 -g1 /bin/true
 '
 test_expect_success 'configure an invalid job-size object' '
 	cat >config/policy.toml <<-EOT &&
@@ -108,7 +108,7 @@ test_expect_success 'configure an out of bounds job-size.max.nnodes object' '
 '
 test_expect_success 'configure an invalid queue job-size.min.nnodes object' '
 	cat >config/policy.toml <<-EOT &&
-	[queues.pdebug.policy.limits]
+	[queues.debug.policy.limits]
 	job-size.min.nnodes = "xyz"
 	EOT
 	test_must_fail flux config reload


### PR DESCRIPTION
Problem: the configuration of queues and jobspec defaults is made more error prone by the need to configure the ingest frobnicator.

Since we know the frobnicator is needed when those other things are configured, just enable if implicitly when those configs are present.  Also, to simplify this, implement a default plugin list that includes `defaults` and `constraints`.

A small bug fix to the defaults plugin is included, and a little bit of test cleanup.