### PR TITLE
testsuite: remove errant test_done call

### DIFF
--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -831,7 +831,7 @@ test_expect_success 'flux-jobs --format={expiration!d:%FT%T::=^20} works' '
 	grep "     EXPIRATION     " exp-fmt.out &&
 	grep "====$(date --date=@${exp} +%b%d\ %R)====" exp-fmt.out
 '
-test_done
+
 test_expect_success 'flux-jobs --format={expiration!D:h},{t_remaining!H:h} works' '
 	cat <<-EOF >expiration.in &&
 {"id": 1447588528128, "state": 8,  "expiration": 0 }


### PR DESCRIPTION
Problem: An debugging test_done call was left in t2800-jobs-cmd.t, therefore not running any tests after the call.

Remove the errant call.