### PR TITLE
make child instances resilient to non-critical node failures

### DIFF
--- a/doc/man1/flux-start.rst
+++ b/doc/man1/flux-start.rst
@@ -92,7 +92,8 @@ OPTIONS
 **--test-pmi-clique**\ =\ *MODE*
    Set the pmi clique mode, which determines how ``PMI_process_mapping`` is set
    in the PMI server used to bootstrap the brokers.  If ``none``, the mapping
-   is not created.  If ``single``, all brokers are placed in one clique.
+   is not created.  If ``single``, all brokers are placed in one clique. If
+   ``per-broker``, each broker is placed in its own clique.
    Default: ``single``.
 
 VERBOSITY LEVELS

--- a/doc/man7/flux-broker-attributes.rst
+++ b/doc/man7/flux-broker-attributes.rst
@@ -89,6 +89,13 @@ broker.mapping
    the instance has one broker per node on 16 nodes, and ``(vector,(0,1,16))``
    means it has 16 brokers on one node.
 
+broker.critical-ranks [Updates: C]
+   An RFC 22 idset representing broker ranks that are considered critical
+   to instance operation. The broker notifies the job execution system in
+   the parent instance of these ranks such that a fatal job exception
+   is raised when a failing node or other error occurs affecting any rank
+   in this set. Default: rank 0 plus any other overlay network routers.
+
 broker.pid
    The process id of the local broker.
 

--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -1547,6 +1547,20 @@ const char *overlay_get_subtree_status (struct overlay *ov, int rank)
     return result;
 }
 
+struct idset *overlay_get_default_critical_ranks (struct overlay *ov)
+{
+    struct idset *ranks;
+
+    /* For now, return all internal ranks plus rank 0
+     */
+    if (!(ranks = topology_get_internal_ranks (ov->topo))
+        || idset_set (ranks, 0) < 0) {
+        idset_destroy (ranks);
+        return NULL;
+    }
+    return ranks;
+}
+
 /* Recursive function to build subtree topology object.
  * Right now the tree is regular.  In the future support the configuration
  * of irregular tree topologies.

--- a/src/broker/overlay.h
+++ b/src/broker/overlay.h
@@ -89,6 +89,10 @@ bool overlay_uuid_is_parent (struct overlay *ov, const char *uuid);
 bool overlay_uuid_is_child (struct overlay *ov, const char *uuid);
 void overlay_set_ipv6 (struct overlay *ov, int enable);
 
+/* Return an idset of critical ranks, i.e. non-leaf brokers
+ */
+struct idset *overlay_get_default_critical_ranks (struct overlay *ov);
+
 /* Fetch TBON subtree topo at 'rank'.  The returned topology object has the
  * following recursive structure, where "children" is an array of topology
  * objects:

--- a/src/broker/test/overlay.c
+++ b/src/broker/test/overlay.c
@@ -124,6 +124,8 @@ void single (flux_t *h)
 {
     struct context *ctx = ctx_create (h, "single", 1, 0, 2, NULL);
     flux_msg_t *msg;
+    char *s;
+    struct idset *critical_ranks;
 
     ok (overlay_set_topology (ctx->ov, ctx->topo) == 0,
         "%s: overlay_set_topology size=1 rank=0 works", ctx->name);
@@ -132,6 +134,16 @@ void single (flux_t *h)
         "%s: overlay_get_size returns 1", ctx->name);
     ok (overlay_get_rank (ctx->ov) == 0,
         "%s: overlay_get_rank returns 0", ctx->name);
+
+    ok ((critical_ranks = overlay_get_default_critical_ranks (ctx->ov)) != NULL,
+        "%s: overlay_get_default_critical_ranks works");
+    if (!(s = idset_encode (critical_ranks, IDSET_FLAG_RANGE)))
+        BAIL_OUT ("idset_encode");
+    is (s, "0",
+        "%s: overlay_get_default_critical_ranks returned %s",
+        s);
+    free (s);
+    idset_destroy (critical_ranks);
 
     ok (overlay_register_attrs (ctx->ov) == 0,
         "%s: overlay_register_attrs works", ctx->name);

--- a/src/broker/topology.c
+++ b/src/broker/topology.c
@@ -302,4 +302,24 @@ error:
 
 }
 
+struct idset *topology_get_internal_ranks (struct topology *topo)
+{
+    struct idset *ranks;
+
+    if (!topo) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (!(ranks = idset_create (0, IDSET_FLAG_AUTOGROW)))
+        return NULL;
+    for (int i = 1; i < topo->size; i++) {
+        if (idset_set (ranks, topo->node[i].parent) < 0)
+            goto error;
+    }
+    return ranks;
+error:
+    idset_destroy (ranks);
+    return NULL;
+}
+
 // vi:ts=4 sw=4 expandtab

--- a/src/broker/topology.h
+++ b/src/broker/topology.h
@@ -14,6 +14,7 @@
 #include <sys/types.h>
 #include <jansson.h>
 #include <flux/core.h>
+#include <flux/idset.h>
 
 /* Create/destroy tree topology of size.
  * The initial topology is "flat" (rank 0 is parent of all other ranks),
@@ -53,6 +54,10 @@ int topology_get_maxlevel (struct topology *topo);
 int topology_get_descendant_count (struct topology *topo);
 int topology_get_child_route (struct topology *topo, int rank);
 json_t *topology_get_json_subtree_at (struct topology *topo, int rank);
+
+/*  Return internal ranks (ranks that have one or more children)
+ */
+struct idset *topology_get_internal_ranks (struct topology *topo);
 
 #endif /* !_BROKER_TOPOLOGY_H */
 

--- a/src/cmd/flux-start.c
+++ b/src/cmd/flux-start.c
@@ -135,7 +135,9 @@ static struct optparse_option opts[] = {
       .name = "test-rundir-cleanup", .has_arg = 0,
       .usage = "Clean up --test-rundir DIR upon flux-start completion", },
     { .group = 2,
-      .name = "test-pmi-clique", .has_arg = 1, .arginfo = "single|none",
+      .name = "test-pmi-clique",
+      .has_arg = 1,
+      .arginfo = "single|per-broker|none",
       .usage = "Set PMI_process_mapping mode (default=single)", },
     { .flags = OPTPARSE_OPT_HIDDEN,
       .name = "killer-timeout", .has_arg = 1, .arginfo = "FSD",
@@ -617,6 +619,17 @@ void pmi_server_initialize (int flags)
             .nodeid = 0,
             .nodes = 1,
             .procs = ctx.test_size,
+        };
+        char buf[256];
+        if (pmi_process_mapping_encode (&mapblock, 1, buf, sizeof (buf)) < 0)
+            log_msg_exit ("error encoding PMI_process_mapping");
+        zhash_update (ctx.pmi.kvs, "PMI_process_mapping", xstrdup (buf));
+    }
+    else if (!strcmp (mode, "per-broker")) {
+        struct pmi_map_block mapblock = {
+            .nodeid = 0,
+            .nodes = ctx.test_size,
+            .procs = 1,
         };
         char buf[256];
         if (pmi_process_mapping_encode (&mapblock, 1, buf, sizeof (buf)) < 0)

--- a/src/modules/job-exec/bulk-exec.c
+++ b/src/modules/job-exec/bulk-exec.c
@@ -188,8 +188,17 @@ static void exec_state_cb (flux_subprocess_t *p, flux_subprocess_state_t state)
             code = EXIT_CODE(126);
         else if (errnum == ENOENT)
             code = EXIT_CODE(127);
-        else if (errnum == EHOSTUNREACH)
-            code = EXIT_CODE(68);
+        else if (errnum == EHOSTUNREACH) {
+            /*  Do not set a "failure" exit code for a lost job shell.
+             *  This is because if the child job is an instance of Flux
+             *  that wants to continue running after losing a broker, then
+             *  we don't want to force a nonzero instance exit code which
+             *  would make the job appear to have failed. If the instance
+             *  does exit due to a node failure, then a nonzero exit code
+             *  will be set later anyway by the resultant job exception.
+             */
+            code = 0;
+        }
 
         if (code > exec->exit_status)
             exec->exit_status = code;

--- a/src/modules/job-exec/job-exec.h
+++ b/src/modules/job-exec/job-exec.h
@@ -136,6 +136,12 @@ void jobinfo_log_output (struct jobinfo *job,
                          const char *data,
                          int len);
 
+
+flux_future_t *jobinfo_shell_rpc_pack (struct jobinfo *job,
+                                       const char *topic,
+                                       const char *fmt,
+                                       ...);
+
 #endif /* !HAVE_JOB_EXEC_EXEC_H */
 
 /* vi: ts=4 sw=4 expandtab

--- a/src/modules/job-exec/job-exec.h
+++ b/src/modules/job-exec/job-exec.h
@@ -122,6 +122,11 @@ void jobinfo_tasks_complete (struct jobinfo *job,
 void jobinfo_fatal_error (struct jobinfo *job, int errnum,
                           const char *fmt, ...);
 
+void jobinfo_raise (struct jobinfo *job,
+                    const char *type,
+                    int severity,
+                    const char *fmt, ...);
+
 /* Append a log output message to exec.eventlog for job
  */
 void jobinfo_log_output (struct jobinfo *job,

--- a/src/modules/job-exec/job-exec.h
+++ b/src/modules/job-exec/job-exec.h
@@ -70,6 +70,8 @@ struct jobinfo {
     json_t *              jobspec;   /* Fetched jobspec */
     char *                J;         /* Signed jobspec */
 
+    struct idset *        critical_ranks;  /* critical shell ranks */
+
     uint8_t               multiuser:1;
     uint8_t               has_namespace:1;
     uint8_t               exception_in_progress:1;

--- a/src/modules/job-exec/rset.c
+++ b/src/modules/job-exec/rset.c
@@ -136,6 +136,43 @@ double resource_set_expiration (struct resource_set *r)
     return r->expiration;
 }
 
+uint32_t resource_set_nth_rank (struct resource_set *r, int n)
+{
+    uint32_t rank;
+
+    if (r == NULL || n < 0) {
+        errno = EINVAL;
+        return IDSET_INVALID_ID;
+    }
+
+    rank = idset_first (r->ranks);
+    while (n-- && rank != IDSET_INVALID_ID)
+        rank = idset_next (r->ranks, rank);
+    if (rank == IDSET_INVALID_ID)
+        errno = ENOENT;
+    return rank;
+}
+
+uint32_t resource_set_rank_index (struct resource_set *r, uint32_t rank)
+{
+    uint32_t i, n;
+
+    if (r == NULL) {
+        errno = EINVAL;
+        return IDSET_INVALID_ID;
+    }
+
+    i = 0;
+    n = idset_first (r->ranks);
+    while (n != IDSET_INVALID_ID) {
+        if (n == rank)
+            return i;
+        i++;
+        n = idset_next (r->ranks, n);
+    }
+    errno = ENOENT;
+    return IDSET_INVALID_ID;
+}
 
 /* vi: ts=4 sw=4 expandtab
  */

--- a/src/modules/job-exec/rset.h
+++ b/src/modules/job-exec/rset.h
@@ -12,6 +12,7 @@
 #define HAVE_JOB_EXEC_RSET_H 1
 #include <flux/idset.h>
 #include <jansson.h>
+#include <stdint.h>
 
 struct resource_set;
 
@@ -20,6 +21,10 @@ struct resource_set *resource_set_create (const char *R, json_error_t *errp);
 void resource_set_destroy (struct resource_set *rset);
 
 const struct idset * resource_set_ranks (struct resource_set *rset);
+
+uint32_t resource_set_nth_rank (struct resource_set *r, int n);
+
+uint32_t resource_set_rank_index (struct resource_set *r, uint32_t rank);
 
 double resource_set_starttime (struct resource_set *rset);
 

--- a/src/shell/Makefile.am
+++ b/src/shell/Makefile.am
@@ -85,7 +85,8 @@ flux_shell_SOURCES = \
 	mpir/ptrace.c \
 	mustache.h \
 	mustache.c \
-	doom.c
+	doom.c \
+	exception.c
 
 flux_shell_LDADD = \
 	$(builddir)/libshell.la \

--- a/src/shell/builtins.c
+++ b/src/shell/builtins.c
@@ -44,6 +44,7 @@ extern struct shell_builtin builtin_ptrace;
 extern struct shell_builtin builtin_pty;
 extern struct shell_builtin builtin_batch;
 extern struct shell_builtin builtin_doom;
+extern struct shell_builtin builtin_exception;
 
 static struct shell_builtin * builtins [] = {
     &builtin_tmpdir,
@@ -60,6 +61,7 @@ static struct shell_builtin * builtins [] = {
     &builtin_pty,
     &builtin_batch,
     &builtin_doom,
+    &builtin_exception,
     &builtin_list_end,
 };
 

--- a/src/shell/exception.c
+++ b/src/shell/exception.c
@@ -1,0 +1,97 @@
+/************************************************************\
+ * Copyright 2022 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* shell plugin handling direct notification of job exceptions
+ *
+ */
+#define FLUX_SHELL_PLUGIN_NAME "exception"
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/core.h>
+#include <flux/shell.h>
+
+#include "ccan/str/str.h"
+#include "src/common/libeventlog/eventlog.h"
+
+#include "internal.h"
+#include "builtins.h"
+
+static void exception_handler (flux_t *h,
+                               flux_msg_handler_t *mh,
+                               const flux_msg_t *msg,
+                               void *arg)
+{
+    flux_shell_t *shell = arg;
+    const char *type;
+    int severity = -1;
+    int shell_rank = -1;
+
+    if (flux_request_unpack (msg,
+                             NULL,
+                             "{s:s s:i s:i}",
+                             "type", &type,
+                             "severity", &severity,
+                             "shell_rank", &shell_rank) < 0)
+        goto error;
+
+    if (streq (type, "lost-shell") && severity > 0)
+        flux_shell_plugstack_call (shell, "shell.lost", NULL);
+
+    if (flux_respond (h, msg, NULL) < 0)
+        shell_log_errno ("flux_respond");
+
+error:
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
+        shell_log_errno ("flux_respond_error");
+
+}
+
+static int exception_init (flux_plugin_t *p,
+                           const char *topic,
+                           flux_plugin_arg_t *args,
+                           void *data)
+{
+    flux_t *h;
+    flux_jobid_t id;
+    int shell_rank;
+    int standalone;
+    flux_shell_t *shell = flux_plugin_get_shell (p);
+    if (!shell)
+        return -1;
+    if (!(h = flux_shell_get_flux (shell)))
+        return -1;
+    if (flux_shell_info_unpack (shell,
+                                "{s:I s:i s:{s:b}}",
+                                "jobid", &id,
+                                "rank", &shell_rank,
+                                "options",
+                                  "standalone", &standalone) < 0)
+        return -1;
+    if (standalone || shell_rank != 0)
+        return 0;
+
+    if (flux_shell_service_register (shell,
+                                     "exception",
+                                     exception_handler,
+                                     shell) < 0)
+        return -1;
+    return 0;
+}
+
+struct shell_builtin builtin_exception = {
+    .name = FLUX_SHELL_PLUGIN_NAME,
+    .init = exception_init,
+};
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/shell/output.c
+++ b/src/shell/output.c
@@ -107,11 +107,15 @@ static void shell_output_control_task (struct shell_task *task,
 {
     if (stop) {
         if (flux_subprocess_stream_stop (task->proc, stream) < 0)
-            shell_log_errno ("flux_subprocess_stream_stop %d:%s", task->rank, stream);
+            shell_log_errno ("flux_subprocess_stream_stop %d:%s",
+                             task->rank,
+                             stream);
     }
     else {
         if (flux_subprocess_stream_start (task->proc, stream) < 0)
-            shell_log_errno ("flux_subprocess_stream_start %d:%s", task->rank, stream);
+            shell_log_errno ("flux_subprocess_stream_start %d:%s",
+                             task->rank,
+                             stream);
     }
 }
 
@@ -918,7 +922,8 @@ static int parse_alternate_buffer_type (struct shell_output *out,
     if (buffer_type) {
         if (strcasecmp (buffer_type, "none")
             && strcasecmp (buffer_type, "line"))
-            shell_log_error ("invalid buffer type specified: %s", buffer_type);
+            shell_log_error ("invalid buffer type specified: %s",
+                             buffer_type);
         else
             (*buffer_type_ptr) = buffer_type;
     }
@@ -1172,11 +1177,13 @@ struct shell_output *shell_output_create (flux_shell_t *shell)
                 goto error;
             }
             if (out->stdout_type == FLUX_OUTPUT_TYPE_FILE) {
-                if (shell_output_type_file_setup (out, &(out->stdout_file)) < 0)
+                if (shell_output_type_file_setup (out,
+                                                  &(out->stdout_file)) < 0)
                     goto error;
             }
             if (out->stderr_type == FLUX_OUTPUT_TYPE_FILE) {
-                if (shell_output_type_file_setup (out, &(out->stderr_file)) < 0)
+                if (shell_output_type_file_setup (out,
+                                                  &(out->stderr_file)) < 0)
                     goto error;
             }
         }
@@ -1222,11 +1229,21 @@ static void task_line_output_cb (struct shell_task *task,
         shell_log_errno ("read %s task %d", stream, task->rank);
     }
     else if (len > 0) {
-        if (shell_output_write (out, task->rank, stream, data, len, false) < 0)
+        if (shell_output_write (out,
+                                task->rank,
+                                stream,
+                                data,
+                                len,
+                                false) < 0)
             shell_log_errno ("write %s task %d", stream, task->rank);
     }
     else if (flux_subprocess_read_stream_closed (task->proc, stream)) {
-        if (shell_output_write (out, task->rank, stream, NULL, 0, true) < 0)
+        if (shell_output_write (out,
+                                task->rank,
+                                stream,
+                                NULL,
+                                0,
+                                true) < 0)
             shell_log_errno ("write eof %s task %d", stream, task->rank);
     }
 }
@@ -1251,11 +1268,21 @@ static void task_none_output_cb (struct shell_task *task,
         }
     }
     if (len > 0) {
-        if (shell_output_write (out, task->rank, stream, data, len, false) < 0)
+        if (shell_output_write (out,
+                                task->rank,
+                                stream,
+                                data,
+                                len,
+                                false) < 0)
             shell_log_errno ("write %s task %d", stream, task->rank);
     }
     else if (flux_subprocess_read_stream_closed (task->proc, stream)) {
-        if (shell_output_write (out, task->rank, stream, NULL, 0, true) < 0)
+        if (shell_output_write (out,
+                                task->rank,
+                                stream,
+                                NULL,
+                                0,
+                                true) < 0)
             shell_log_errno ("write eof %s task %d", stream, task->rank);
     }
 }

--- a/src/shell/svc.c
+++ b/src/shell/svc.c
@@ -97,15 +97,7 @@ flux_future_t *shell_svc_vpack (struct shell_svc *svc,
 
 int shell_svc_allowed (struct shell_svc *svc, const flux_msg_t *msg)
 {
-    uint32_t userid;
-
-    if (flux_msg_get_userid (msg, &userid) < 0)
-        return -1;
-    if (userid != svc->uid) {
-        errno = EPERM;
-        return -1;
-    }
-    return 0;
+    return flux_msg_authorize (msg, svc->uid);
 }
 
 int shell_svc_register (struct shell_svc *svc,

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -50,7 +50,8 @@ LONGTESTSCRIPTS = \
 	t5000-valgrind.t \
 	t3100-flux-in-flux.t \
 	t3200-instance-restart.t \
-	t3202-instance-restart-testexec.t
+	t3202-instance-restart-testexec.t \
+	t4000-issues-test-driver.t
 
 # This list is included in both TESTS and dist_check_SCRIPTS.
 TESTSCRIPTS = \
@@ -216,7 +217,6 @@ TESTSCRIPTS = \
 	t3307-system-leafcrash.t \
 	t3308-system-torpid.t \
 	t3309-system-reconnect.t \
-	t4000-issues-test-driver.t \
 	lua/t0001-send-recv.t \
 	lua/t0002-rpc.t \
 	lua/t0003-events.t \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -312,6 +312,7 @@ dist_check_SCRIPTS = \
 	issues/t4413-empty-eventlog.sh \
 	issues/t4465-job-list-use-after-free.sh \
 	issues/t4482-flush-list-corruption.sh \
+	issues/t4583-free-range-test.sh \
 	issues/t4612-eventlog-overwrite-crash.sh \
 	python/__init__.py \
 	python/subflux.py \

--- a/t/issues/t4583-free-range-test.sh
+++ b/t/issues/t4583-free-range-test.sh
@@ -1,0 +1,80 @@
+#!/bin/bash -e
+#
+#  Test that batch/alloc jobs are resilient to leaf not failures
+#
+
+log ()
+{
+    printf "free-range-test: $@"
+}
+
+list_descendants ()
+{
+    local children=$(ps -o pid= --ppid "$1")
+
+    for pid in $children; do
+        list_descendants "$pid"
+    done
+
+    echo "$children"
+}
+
+
+#  Check if we need to start parent job, if so, reexec under flux-start
+#  using the per-broker for test-pmi-clique so that the instance mapping
+#  simulates multiple nodes.
+#
+export FLUX_URI_RESOLVE_LOCAL=t
+if test "$FREE_RANGE_TEST_ACTIVE" != "t"; then
+    export FREE_RANGE_TEST_ACTIVE=t
+    log "Re-launching test script under flux-start\n"
+    exec flux start -s 4 \
+        --test-exit-mode=leader \
+        --test-pmi-clique=per-broker \
+        -o -Stbon.fanout=0 $0
+fi
+
+#  Start a job with tbon.fanout=0
+log "Starting a child instance with flat topology\n"
+jobid=$(flux mini alloc -N4 --bg --broker-opts=-Stbon.fanout=0)
+
+log "Started job $jobid\n"
+
+#  Run a job on all ranks of child job
+log "Current overlay status of $jobid:\n"
+flux proxy $jobid flux overlay status 
+
+log "Launch a sleep job within $jobid:\n"
+flux proxy $jobid flux mini submit -N4 sleep inf
+
+flux pstree -x --skip-root=no
+
+#  Now simulate a node failure by killing a broker in parent
+#  instance, along with all its children
+broker_pid=$(flux exec -r 3 flux getattr broker.pid)
+
+log "Killing rank 3 (pid %d) and all children\n" $broker_pid
+kill -9 $(list_descendants $broker_pid) $broker_pid
+
+log "Wait for exception event in $jobid\n"
+flux job wait-event -t 5 $jobid exception
+
+log "But running a 3 node job in $jobid still works:\n"
+flux proxy $jobid flux mini run -t 5s -N3 hostname
+
+log "Overlay status of $jobid should show rank offline:\n"
+flux proxy $jobid flux overlay status 
+
+log "Call flux shutdown on $jobid\n"
+flux shutdown --quiet $jobid
+
+log "job $jobid should exit cleanly (no hang) and a zero exit code:\n"
+flux job wait-event -t 2 $jobid finish
+
+log "dump output from job:\n\n"
+flux job attach $jobid
+rc=$?
+printf "\n"
+log "flux-job attach exited with code=$rc\n"
+
+exit $rc

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -500,6 +500,9 @@ test_expect_success 'broker -Stbon.fanout=4 option works' '
 test_expect_success 'broker -Stbon.fanout=0 works' '
 	flux start ${ARGS} -o,-Stbon.fanout=0 /bin/true
 '
+test_expect_success 'broker fails on invalid broker.critical-ranks option' '
+	test_must_fail flux start ${ARGS} -o,-Sbroker.critical-ranks=0-1
+'
 test_expect_success 'broker fails on unknown option' '
 	test_must_fail flux start ${ARGS} -o,--not-an-option /bin/true
 '

--- a/t/t2701-mini-batch.t
+++ b/t/t2701-mini-batch.t
@@ -117,4 +117,38 @@ test_expect_success 'flux-mini batch: --broker-opts works' '
 	grep "boot: rank=0 size=1" flux-${id2}.out &&
 	grep "entering event loop" flux-${id2}.out
 '
+test_expect_success 'flux mini batch: critical-ranks attr is set on all ranks' '
+	id=$(flux mini batch -N4 \
+		--output=critical-ranks.out \
+		--error=critical-ranks.err \
+		--broker-opts=-Stbon.fanout=2 \
+		--wrap flux exec flux getattr broker.critical-ranks) &&
+	flux job status $id &&
+	test_debug "cat critical-ranks.out" &&
+	test_debug "cat critical-ranks.err" &&
+	cat <<-EOF >critical-ranks.expected &&
+	0-1
+	0-1
+	0-1
+	0-1
+	EOF
+	test_cmp critical-ranks.expected critical-ranks.out
+'
+test_expect_success 'flux mini batch: user can set broker.critical-ranks' '
+	id=$(flux mini batch -N4 \
+		--output=critical-ranks2.out \
+		--error=critical-ranks2.err \
+		--broker-opts=-Sbroker.critical-ranks=0 \
+		--wrap flux exec flux getattr broker.critical-ranks) &&
+	flux job status $id &&
+	test_debug "cat critical-ranks2.out" &&
+	test_debug "cat critical-ranks2.err" &&
+	cat <<-EOF >critical-ranks2.expected &&
+	0
+	0
+	0
+	0
+	EOF
+	test_cmp critical-ranks2.expected critical-ranks2.out
+'
 test_done


### PR DESCRIPTION
This is a WIP, more of an experiment or proof-of-concept really, to address #4417 and #4573. (So no need for code review just yet, but looking for comments on the general approach.)

I was able to run down what was causing instances started with the experimental `exec.ignore-lost-ranks` to hang around after the rank 0 broker exits. It turns out the Flux instance was exiting normally, but the `output` plugin in the rank 0 job shell was not releasing its "completion reference" because it was still waiting for EOF from the lost shell rank.

This PR adds support for notifying the rank 0 job shell that a shell has been lost (actually through a couple different methods), along with an experimental `shell.lost` plugin callback, which the `output` plugin uses to decrement its internal refcount since it won't need to wait for that job shell anymore.

A new `exception` job shell plugin handles waiting for the appropriate exception and calling the `shell.lost` plugin callbacks. At first this plugin watched the job eventlog for the exception, but this had an impact on job throughput since it adds a new eventlog watcher for every job even though this particular exception will be very rare.

The second attempt adds an `exception` shell service endpoint to the `exception` plugin via which the job-exec module can notify the rank 0 shell of the non-fatal exception. This obviously has much better performance, but in order for that to work, the shell service handler had to be extended to allow messages from the instance owner as well as from the job owner.

I've kept these two solutions separate in the commit history for now until we've settled on the right approach.

I also think @garlick's suggestion of having the broker in the child notify the job-exec service of "critical ranks" is a superior method. In fact, maybe this should just be the default for all instances and users could select the level of resiliency by selecting a larger fanout or fanout=0 for the maximum resiliency? This will take a little longer to implement, and we may want to get at least basic support into the next release which is why I stopped here.

The following script is how I'm testing this feature:

```sh
#!/bin/bash
#
# 

log ()
{
    printf "free-range-test: $@"
}

list_descendants ()
{
    local children=$(ps -o pid= --ppid "$1")

    for pid in $children; do
        list_descendants "$pid"
    done

    echo "$children"
}


#  Check if we need to start parent job, if so, reexec under flux-start:
export FLUX_URI_RESOLVE_LOCAL=t
if test "$FREE_RANGE_TEST_ACTIVE" != "t"; then
    export FREE_RANGE_TEST_ACTIVE=t
    log "Re-launching test script under flux-start\n"
    exec flux start -s 4 --test-exit-mode=leader -o -Stbon.fanout=0 $0
fi

#  Start a free range job
log "Starting a free range child instance\n"
jobid=$(flux mini alloc -N4 --bg \
	--setattr=exec.ignore-lost-ranks \
	--broker-opts=-Stbon.fanout=0)

log "Started job $jobid\n"

#  Run a job on all ranks of child job
log "Current overlay status of $jobid:\n"
flux proxy $jobid flux overlay status 

log "Launch a sleep job within $jobid:\n"
flux proxy $jobid flux mini submit -N4 sleep inf

flux pstree -x --skip-root=no

#  Now simulate a node failure by killing a broker in parent
#  instance, along with all its children
broker_pid=$(flux exec -r 3 flux getattr broker.pid)

log "Killing rank 3 (pid %d) and all children\n" $broker_pid
kill -9 $(list_descendants $broker_pid) $broker_pid

log "Wait for exception event in $jobid\n"
flux job wait-event -t 5 $jobid exception

log "But running a 3 node job in $jobid still works:\n"
flux proxy $jobid flux mini run -t 5s -N3 hostname

log "Overlay status of $jobid should show rank offline:\n"
flux proxy $jobid flux overlay status 

log "Call flux shutdown on $jobid\n"
flux shutdown --quiet $jobid

log "job $jobid should exit cleanly (no hang) and a zero exit code:\n"
flux job wait-event -t 2 $jobid finish

log "dump output from job:\n\n"
flux job attach $jobid

printf "\n"
log "flux-job attach exited with code=$?\n"
```
E.g. on this branch:

```console
$ src/cmd/flux ./free-range-test.sh 
free-range-test: Re-launching test script under flux-start
free-range-test: Starting a free range child instance
free-range-test: Started job ƒjFeXq1
free-range-test: Current overlay status of ƒjFeXq1:
0 asp: full
├─ 1 asp: full
├─ 2 asp: full
└─ 3 asp: full
free-range-test: Launch a sleep job within ƒjFeXq1:
ƒw4ap2K
       JOBID USER     ST NTASKS NNODES  RUNTIME
           . grondo    R      4      4   5.556s .
     ƒjFeXq1 grondo    R      4      4   3.198s └── flux
     ƒw4ap2K grondo    R      4      4   0.260s     └── sleep
free-range-test: Killing rank 3 (pid 4765) and all children
free-range-test: Wait for exception event in ƒjFeXq1
flux-start: 3 (pid 4765) Killed
2022-09-26T00:37:05.183617Z broker.err[0]: asp (rank 3) transitioning to LOST due to EHOSTUNREACH error on send
1664152625.184043 exception type="node-failure" severity=2 userid=4294967295 note="lost contact with job shell on asp (shell rank 3)"
free-range-test: But running a 3 node job in ƒjFeXq1 still works:
asp
asp
asp
free-range-test: Overlay status of ƒjFeXq1 should show rank offline:
0 asp: degraded
├─ 1 asp: full
├─ 2 asp: full
└─ 3 asp: lost
free-range-test: Call flux shutdown on ƒjFeXq1
free-range-test: job ƒjFeXq1 should exit cleanly (no hang) and a zero exit code:
1664152632.296247 finish status=0
free-range-test: dump output from job:

4.447s: job.exception type=node-failure severity=2 lost contact with job shell on asp (shell rank 3)
2022-09-26T00:37:05.666283Z broker.err[0]: asp (rank 3) transitioning to LOST due to EHOSTUNREACH error on send

free-range-test: flux-job attach exited with code=0
```
