### PR TITLE
ingest: require job queue if [queues] are configured

### DIFF
--- a/src/bindings/python/flux/job/frobnicator/plugins/defaults.py
+++ b/src/bindings/python/flux/job/frobnicator/plugins/defaults.py
@@ -78,6 +78,8 @@ class DefaultsConfig:
             if queue_defaults:
                 for attr in queue_defaults:
                     self.setattr_default(jobspec, attr, queue_defaults[attr])
+        elif self.queues:
+            raise ValueError(f"no queue specified")
 
 
 class Frobnicator(FrobnicatorPlugin):

--- a/t/t2112-job-ingest-frobnicator.t
+++ b/t/t2112-job-ingest-frobnicator.t
@@ -165,5 +165,16 @@ test_expect_success HAVE_JQ 'defaults plugin allows queues without default' '
 	    > nodefault.out &&
 	jq -e "has(\"data\")" <nodefault.out
 '
+test_expect_success HAVE_JQ 'defaults plugin requires queue if configured' '
+	cat <<-EOF >conf.d/conf.toml &&
+	[queues.debug]
+	requires = [ "debug" ]
+	EOF
+	flux config reload &&
+	flux mini run --env=-* --dry-run hostname \
+	   | flux job-frobnicator --jobspec-only --plugins=defaults \
+	    > nodefaultnojob.out &&
+	jq -e ".errstr == \"no queue specified\"" <nodefaultnojob.out
+'
 
 test_done

--- a/t/t2222-job-manager-limit-job-size.t
+++ b/t/t2222-job-manager-limit-job-size.t
@@ -78,19 +78,20 @@ test_expect_success 'configure job-size.max.ngpus and queue with unlimited' '
 	cat >config/policy.toml <<-EOT &&
 	[policy.limits]
 	job-size.max.ngpus = 0
-	[queues.debug.policy.limits]
+	[queues.debug]
+	[queues.batch.policy.limits]
 	job-size.max.ngpus = -1
 	EOT
 	flux config reload
 '
-test_expect_success 'a job with no queue is accepted if under gpu limit' '
-	flux mini submit -n1 /bin/true
+test_expect_success 'a job is accepted if under general gpu limit' '
+	flux mini submit --queue=debug -n1 /bin/true
 '
-test_expect_success 'a job with no queue is rejected if over gpu limit' '
-	test_must_fail flux mini submit -n1 -g1 /bin/true
+test_expect_success 'a job is rejected if over gpu limit' '
+	test_must_fail flux mini submit --queue=debug -n1 -g1 /bin/true
 '
 test_expect_success 'same job is accepted with unlimited queue override' '
-	flux mini submit --queue=debug -n1 -g1 /bin/true
+	flux mini submit --queue=batch -n1 -g1 /bin/true
 '
 test_expect_success 'configure an invalid job-size object' '
 	cat >config/policy.toml <<-EOT &&


### PR DESCRIPTION
Problem: if queues are configured, but no default queue is configured, and a job is submitted without a queue, the job is ingested and allowed to fail later.

Modify the 'defaults' frobnicator plugin to reject such a job at ingest.