### PR TITLE
WIP: add asyncio

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
     - name: install black
-      run: python3 -m pip install 'black==20.08.b1' --force-reinstall
+      run: python3 -m pip install 'black' --force-reinstall
     - name: check format
       run: ./scripts/check-format
 

--- a/etc/docker/ubuntu/Dockerfile
+++ b/etc/docker/ubuntu/Dockerfile
@@ -47,7 +47,7 @@ COPY . /code
 
 RUN chmod +x etc/gen-cmdhelp.py && \
     ./autogen.sh && \
-    ./configure --prefix=/usr/local --without-python && \
+    ./configure --prefix=/usr/local && \
     make && \
     make install && \
     ldconfig

--- a/etc/docker/ubuntu/README.md
+++ b/etc/docker/ubuntu/README.md
@@ -11,6 +11,12 @@ Build the main `flux-ubuntu` image:
 $ docker build -f etc/docker/ubuntu/Dockerfile -t ghcr.io/flux-framework/flux-ubuntu .
 ```
 
+If you want to shell inside (and bind for re-compile and development):
+
+```bash
+$ docker run -it -v $PWD:/code ghcr.io/flux-framework/flux-ubuntu
+```
+
 And then tests:
 
 ```bash

--- a/src/bindings/python/flux/Makefile.am
+++ b/src/bindings/python/flux/Makefile.am
@@ -1,5 +1,8 @@
 nobase_fluxpy_PYTHON = \
 	__init__.py \
+	asyncio/__init__.py \
+	asyncio/events.py \
+	asyncio/selector.py \
 	kvs.py \
 	wrapper.py \
 	rpc.py \

--- a/src/bindings/python/flux/asyncio/__init__.py
+++ b/src/bindings/python/flux/asyncio/__init__.py
@@ -1,0 +1,1 @@
+from flux.asyncio.events import FluxEventLoop, loop, submit

--- a/src/bindings/python/flux/asyncio/events.py
+++ b/src/bindings/python/flux/asyncio/events.py
@@ -1,0 +1,71 @@
+###############################################################
+# Copyright 2022 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+import asyncio
+
+import flux
+import flux.core.watchers
+
+from flux.asyncio.selector import FluxSelector
+
+# The loop *must* have the same handle as the submit or else the loop will
+# run forever.
+HANDLE = flux.Flux()
+
+
+async def submit(jobspec, flux_handle=None):
+    """Submit a Flux jobspec and return a job ID.
+
+    Example usage
+    =============
+    # ensure the script is running in an active flux instance
+    import asyncio
+    from flux.asyncio import loop
+    import flux.job
+
+    fluxsleep = flux.job.JobspecV1.from_command(['sleep', '2'])
+    fluxecho = flux.job.JobspecV1.from_command(['echo', 'pancakes'])
+
+    tasks = [
+       loop.create_task(asyncio.sleep(5)),
+       loop.create_task(flux.asyncio.submit(fluxecho)),
+       loop.create_task(flux.asyncio.submit(fluxsleep)),
+    ]
+
+    asyncio.set_event_loop(loop)
+    results = loop.run_until_complete(asyncio.gather(*tasks))
+    # [JobID(456004999315456), JobID(456004999315457)]
+    """
+    handle = flux_handle or HANDLE
+    uid = await flux.job.submit_async(handle, jobspec)
+    return uid
+
+
+class FluxEventLoop(asyncio.SelectorEventLoop):
+    """An asyncio loop that handles running Flux."""
+
+    def __init__(self, flux_handle=None):
+        # This can be provided by a user that knows what they are doing.
+        # The handle to the submit job and loop must be the same.
+        if not flux_handle:
+            flux_handle = HANDLE
+        selector = FluxSelector(flux_handle)
+
+        # Reverse reference is needed for watchers
+        selector.loop = self
+        super().__init__(selector)
+
+    @property
+    def selector(self):
+        return self._selector
+
+
+# This loop needs to be accessible from all places!
+loop = FluxEventLoop()  # pylint: disable=invalid-name

--- a/src/bindings/python/flux/asyncio/selector.py
+++ b/src/bindings/python/flux/asyncio/selector.py
@@ -1,0 +1,149 @@
+###############################################################
+# Copyright 2022 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+import selectors
+import signal
+
+import flux.constants
+from flux.core.watchers import FDWatcher
+
+
+def stop_callback(handle, _watcher, _fd_int, events, args=None):
+    """
+    This is called by the watcher, and stops the reactor add adds ready jobs.
+    """
+    handle.reactor_stop()
+
+    # TimerWatcher won't know a file descriptor, just needs to stop the reactor
+    if not args:
+        return
+    selector = args["select"]
+    selector_event = get_selector_event(events)
+    selector.ready.add((args["key"], selector_event & args["key"].events))
+
+
+def get_selector_event(events):
+    """
+    Given an int, return the corresponding flux identifier.
+    """
+    event = 0
+    if events & flux.constants.FLUX_POLLIN:
+        event |= selectors.EVENT_READ
+    if events & flux.constants.FLUX_POLLOUT:
+        event |= selectors.EVENT_WRITE
+    return event
+
+
+def get_flux_event(events):
+    """
+    Given an int, return the corresponding selector identifier
+    """
+    event = 0
+    if events & selectors.EVENT_READ:
+        event |= flux.constants.FLUX_POLLIN
+    if events & selectors.EVENT_WRITE:
+        event |= flux.constants.FLUX_POLLOUT
+    return event
+
+
+class FluxSelector(selectors._BaseSelectorImpl):  # pylint: disable=protected-access # type: ignore
+    """
+    A Flux selector supports registering file objects to be monitored for
+    specific I/O events (for Flux).
+    """
+
+    def __init__(self, handle):
+        super().__init__()
+        self.handle = handle
+        self.ready = set()
+        self._watchers = {}
+
+    def register(self, fileobj, events, data=None):
+        """
+        Register a new file descriptor event.
+        """
+        key = super().register(fileobj, events, data)
+        watcher = FDWatcher(
+            self.handle,
+            fileobj,
+            get_flux_event(events),
+            stop_callback,
+            args={"key": key, "select": self},
+        )
+        watcher.start()
+        self._watchers[fileobj] = watcher
+        return key
+
+    def unregister(self, fileobj):
+        """
+        Remove the key and the watcher.
+        """
+        try:
+            key = self._fd_to_key.pop(self._fileobj_lookup(fileobj))
+            self._watchers[key.fileobj].stop()
+        except KeyError:
+            raise KeyError("{!r} is not registered".format(fileobj)) from None
+        return key
+
+    def select(self, timeout=None):
+        """
+        Perform the actual selection, until some monitored file objects are
+        ready or a timeout expires.
+        Parameters:
+        timeout -- if timeout > 0, this specifies the maximum wait time, in
+                   seconds, waited for by a flux TimerWatcher
+                   if timeout <= 0, the select() call won't block, and will
+                   report the currently ready file objects
+                   if timeout is None, select() will block until a monitored
+                   file object becomes ready
+        Returns:
+        list of (key, events) for ready file objects
+        `events` is a bitwise mask of EVENT_READ|EVENT_WRITE
+        """
+        reactor = self.handle.get_reactor()
+        reactor_interrupted = False
+
+        def reactor_interrupt(handle, *_args):
+            #  ensure reactor_interrupted from enclosing scope:
+            nonlocal reactor_interrupted
+            reactor_interrupted = True
+            handle.reactor_stop(reactor)
+
+        with self.handle.signal_watcher_create(signal.SIGINT, reactor_interrupt):
+            with self.handle.in_reactor():
+
+                # Ensure previous events are cleared
+                self.ready.clear()
+
+                # 0 == "run until I tell you to stop"
+                if timeout is not None:
+                    if timeout > 0:
+
+                        # Block for a specified timeout
+                        with self.handle.timer_watcher_create(timeout, stop_callback):
+                            watcher_count = self.handle.flux_reactor_run(reactor, 0)
+
+                    # If timeout <= 0, select won't block
+                    else:
+                        watcher_count = self.handle.flux_reactor_run(
+                            reactor, flux.constants.FLUX_REACTOR_NOWAIT
+                        )
+
+                # If timeout is None, block until a monitored object ready
+                else:
+                    watcher_count = self.handle.flux_reactor_run(reactor, 0)
+
+            if reactor_interrupted:
+                raise KeyboardInterrupt
+
+            if watcher_count < 0:
+                self.handle.raise_if_exception()
+
+        return list(self.ready)

--- a/src/bindings/python/flux/future.py
+++ b/src/bindings/python/flux/future.py
@@ -8,6 +8,7 @@
 # SPDX-License-Identifier: LGPL-3.0
 ###############################################################
 
+import asyncio
 import errno
 
 from typing import Dict
@@ -53,9 +54,8 @@ def continuation_callback(c_future, opaque_handle):
             del _THEN_HANDLES[py_future]
 
 
-class Future(WrapperPimpl):
-    """
-    A wrapper for interfaces that create and consume flux futures
+class Future(WrapperPimpl):  # pylint: disable=too-many-instance-attributes
+    """A wrapper for interfaces that create and consume flux futures
     """
 
     class InnerWrapper(Wrapper):
@@ -100,6 +100,7 @@ class Future(WrapperPimpl):
 
     def stop(self):
         """Stop a future from calling the user callback.
+
         Useful for streaming futures given lack of destroy.
         """
         self.stopped = True
@@ -176,14 +177,67 @@ class Future(WrapperPimpl):
 
     @interruptible
     def get(self):
-        """
-        Base Future.get() method. Does not return a result, just blocks
+        """Base Future.get() method. Does not return a result, just blocks
         until future is fulfilled and throws OSError on failure.
         """
         self.pimpl.flux_future_get(ffi.NULL)
 
     def incref(self):
         self.pimpl.flux_future_incref()
+
+    # asyncio functions
+
+    def __await__(self):
+        """Await to work with asyncio.
+        """
+        if not hasattr(self, "_loop"):
+            self._loop = asyncio.get_running_loop()  # pylint: disable=attribute-defined-outside-init
+
+        # Is the future handle the same as the loop handle? This is currently
+        # required otherwise the loop isn't really watching the same handle
+        # and the jobs will run forever.
+        loop_handle = self._loop.selector.handle
+        future_handle = self.get_flux()
+
+        if future_handle.handle != loop_handle.handle:
+            msg = "Found different future and loop handle - ensure the same."
+            raise RuntimeError(msg)
+
+        if not self.is_ready():
+            self._asyncio_future_blocking = True  # pylint: disable=attribute-defined-outside-init
+
+            # Yielding here tells the task to wait for completion.
+            yield self
+
+        if not self.is_ready():
+            raise RuntimeError("await wasn't used with future")
+        return self.get()
+
+    def add_done_callback(self, func, *, context=None):
+        """Add a callback to be run when the future becomes done.
+        """
+        if self.is_ready():
+            self._loop.call_soon(func, self, context=context)
+        else:
+            def call_wrapper(_, future):
+                # A wrapper to a future to stop the reactor and run the callback
+                func(future)
+                handle = self.get_flux()
+                reactor = handle.get_reactor()
+                handle.reactor_stop(reactor)
+
+            # self.then alone (if passed directly) provides an extra argument
+            # that the asyncio.Task cannot accept
+            self.then(call_wrapper, self)
+
+    def result(self):
+        """Result is called by asyncio Task (in C) to determine done-ness.
+        """
+        if self.is_ready():
+            return self.get()
+        raise RuntimeError('Result is not ready.')
+
+    __iter__ = __await__  # make compatible with 'yield from'.
 
 
 class WaitAllFuture(Future):

--- a/src/bindings/python/flux/job/executor.py
+++ b/src/bindings/python/flux/job/executor.py
@@ -334,7 +334,9 @@ class FluxExecutorFuture(concurrent.futures.Future):
     result.__doc__ = concurrent.futures.Future.result.__doc__
 
     def set_exception(self, exception):
-        """When setting an exception on the future, set the jobid if it hasn't
+        """Set an exception.
+
+        When setting an exception on the future, set the jobid if it hasn't
         been set already. The jobid will already have been set unless the exception
         was generated before the job could be successfully submitted.
         """
@@ -350,7 +352,9 @@ class FluxExecutorFuture(concurrent.futures.Future):
     set_exception.__doc__ = concurrent.futures.Future.set_exception.__doc__
 
     def cancel(self, *args, **kwargs):  # pylint: disable=arguments-differ
-        """If a thread is waiting for the future's jobid, and another
+        """Cancel a future job.
+
+        If a thread is waiting for the future's jobid, and another
         thread cancels the future, the waiting thread would never wake up
         because the jobid would never be set.
 

--- a/src/bindings/python/flux/job/submit.py
+++ b/src/bindings/python/flux/job/submit.py
@@ -25,6 +25,10 @@ class SubmitFuture(Future):
         """Return the job ID represented by this future."""
         return submit_get_id(self)
 
+    def get(self):
+        """Return the job represented by this future."""
+        super().get()
+        return submit_get_id(self)
 
 def submit_async(
     flux_handle,

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -232,6 +232,7 @@ TESTSCRIPTS = \
 	python/t0005-kvs.py \
 	python/t0006-request.py \
 	python/t0007-watchers.py \
+	python/t0008-asyncio.py \
 	python/t0010-job.py \
 	python/t0012-futures.py \
 	python/t0013-job-list-inactive.py \

--- a/t/python/t0008-asyncio.py
+++ b/t/python/t0008-asyncio.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+
+###############################################################
+# Copyright 2022 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+import unittest
+
+import asyncio
+from flux.asyncio import loop
+import flux.job
+import flux.job.JobID
+import time
+
+def __flux_size():
+    return 1
+
+
+class TestFluxAsyncio(unittest.TestCase):
+    """
+    Tests for Flux Asyncio.
+    """
+
+    def test_as_completed(self):
+        fluxjob = flux.job.JobspecV1.from_command(["true"])
+        sleep_time = 5
+        tasks = [
+            loop.create_task(asyncio.sleep(sleep_time)),
+            loop.create_task(flux.asyncio.submit(fluxjob)),
+        ]
+        asyncio.set_event_loop(loop)
+        start = time.time()
+        results = loop.run_until_complete(asyncio.gather(*tasks))
+        end = time.time()
+
+        # Event loop "run until complete" means we are as long as longest job
+        assert end - start > sleep_time
+
+        # Sleep result has no result
+        self.assertEqual(results[0], None)
+
+        # This is a job id
+        self.assertTrue(isinstance(results[1], flux.job.JobID))
+
+
+    def test_handle_equality(self):
+        """
+        The underlying flux handle's must be the same!
+        """
+        fluxjob = flux.job.JobspecV1.from_command(["true"])
+        
+        # Note here we are creating a new handle
+        task = loop.create_task(flux.asyncio.submit(fluxjob, flux.Flux()))
+        asyncio.set_event_loop(loop)
+
+        #  test string with invalid version
+        with self.assertRaises(RuntimeError):
+            loop.run_until_complete(asyncio.gather(*[task]))
+
+
+if __name__ == "__main__":
+    from subflux import rerun_under_flux
+
+    if rerun_under_flux(size=__flux_size(), personality="job"):
+        from pycotap import TAPTestRunner
+
+        unittest.main(testRunner=TAPTestRunner())
+
+# vi: ts=4 sw=4 expandtab


### PR DESCRIPTION
this will allow us to run two tasks using asyncio, and it is a start because it needs a few tweaks (I think) to make it better! Namely, we might want to handle a timeout > 0 in select via a flux Timeout(?) watcher, and we likely want to add proper tests and documentation (somewhere?) for the time being I have just put the example usage into the submit docstrings.

Thanks to @trws for two really fun pair programming sessions hacking on this!! asyncio is _so weird_!!! 

## Dinosaur TODO

- [x] I want to test the Timeout watcher to use with select to better honor the timeout passed (I have a prototype for this).
- [x] Where to write tests / what tests to write (this will be my first time, guidance appreciated!)
- [x] And documentation? Are flux docs all in an external repository from here?

Signed-off-by: vsoch <vsoch@users.noreply.github.com>