### PR TITLE
job-info: return error on invalid eventlog append

### DIFF
--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -312,6 +312,7 @@ dist_check_SCRIPTS = \
 	issues/t4413-empty-eventlog.sh \
 	issues/t4465-job-list-use-after-free.sh \
 	issues/t4482-flush-list-corruption.sh \
+	issues/t4612-eventlog-overwrite-crash.sh \
 	python/__init__.py \
 	python/subflux.py \
 	python/tap \

--- a/t/issues/t4612-eventlog-overwrite-crash.sh
+++ b/t/issues/t4612-eventlog-overwrite-crash.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -e
+
+waitfile=${SHARNESS_TEST_SRCDIR}/scripts/waitfile.lua
+
+jobid=$(flux mini submit --wait-event=start sh -c "echo foo; sleep 300")
+
+kvsdir=$(flux job id --to=kvs $jobid)
+
+# issue a command that will watch / monitor the job's eventlog
+flux job attach $jobid > t4612.out &
+
+# ensure backgrounded process has started to monitor eventlog
+$waitfile --count=1 --timeout=30 --pattern=foo t4612.out
+
+# now overwrite the eventlog without changing its length
+flux kvs get --raw ${kvsdir}.eventlog \
+	| sed -e s/submit/foobar/ \
+	| flux kvs put --raw ${kvsdir}.eventlog=-
+
+wait
+
+# if flux broker segfaulted, this won't work
+flux mini run hostname


### PR DESCRIPTION
Problem: If an eventlog is illegally overwritten, it can result in the appearance of a "zero length" append.  If a user is watching
this eventlog, this "zero length" append can result in a segfault in the job-info module.

Solution: If a "zero length" append occurs in an eventlog being watched, consider the eventlog malformed and return an error.

Issue https://github.com/flux-framework/flux-core/issues/4612

Side notes: 

EINVAL the best error to return?  I considered EPROTO as well, but that didn't seem quite right.  Open to suggestions.