### PR TITLE
broker: reduce tbon.tcp_user_timeout

### DIFF
--- a/doc/man5/flux-config-tbon.rst
+++ b/doc/man5/flux-config-tbon.rst
@@ -35,10 +35,9 @@ tcp_user_timeout
    a broker waits for a TBON child connection to acknowledge transmitted TCP
    data before forcibly closing the connection.  A value of 0 means use the
    system default.  This value affects how Flux responds to an abruptly turned
-   off node, which could take up to 20m if this value is not set.  This
-   configured value may be overridden by setting the ``tbon.tcp_user_timeout``
-   broker attribute.  See also: :linux:man7:`tcp`, TCP_USER_TIMEOUT socket
-   option.
+   off node.  The configured value may be overridden by setting the
+   ``tbon.tcp_user_timeout`` broker attribute.  See also: :linux:man7:`tcp`,
+   TCP_USER_TIMEOUT socket option.  Default: 20s.
 
 zmqdebug
    (optional) Integer value indicating whether ZeroMQ socket debug logging

--- a/t/t0013-config-file.t
+++ b/t/t0013-config-file.t
@@ -233,9 +233,9 @@ test_expect_success '[bootstrap] curve_cert file must be mode o-r' '
 # [tbon] test
 #
 
-test_expect_success MAXRT 'tbon.tcp_user_timeout is zero by default' '
+test_expect_success MAXRT 'tbon.tcp_user_timeout is 20s by default' '
 	cat <<-EOT >maxrt.exp &&
-	0s
+	20s
 	EOT
 	flux broker ${ARGS} \
 		flux getattr tbon.tcp_user_timeout >maxrt.out &&


### PR DESCRIPTION
Problem: a batch job takes around 20m to notice that a peer has been turned off.

The `tbon.tcp_user_timeout` can be used to tune this value in the system instance, and we encourage that.  But batch jobs get the system default.

Since the system default is probably not suitable for flux _ever_, set our own default.  Let's try 20s.