### PR TITLE
job-list: remove circular header dependencies

### DIFF
--- a/src/modules/job-list/idsync.c
+++ b/src/modules/job-list/idsync.c
@@ -40,7 +40,7 @@ void idsync_data_destroy_wrapper (void **data)
     }
 }
 
-struct idsync_data *idsync_data_create (struct list_ctx *ctx,
+struct idsync_data *idsync_data_create (flux_t *h,
                                         flux_jobid_t id,
                                         const flux_msg_t *msg,
                                         json_t *attrs,
@@ -52,7 +52,7 @@ struct idsync_data *idsync_data_create (struct list_ctx *ctx,
     isd = calloc (1, sizeof (*isd));
     if (!isd)
         goto error_enomem;
-    isd->ctx = ctx;
+    isd->h = h;
     isd->id = id;
     if (!(isd->msg = flux_msg_copy (msg, false)))
         goto error;

--- a/src/modules/job-list/idsync.c
+++ b/src/modules/job-list/idsync.c
@@ -69,7 +69,7 @@ struct idsync_data *idsync_data_create (struct list_ctx *ctx,
     return NULL;
 }
 
-void idsync_waits_list_destroy (void **data)
+static void idsync_waits_list_destroy (void **data)
 {
     if (data)
         zlistx_destroy ((zlistx_t **) data);

--- a/src/modules/job-list/idsync.h
+++ b/src/modules/job-list/idsync.h
@@ -15,6 +15,12 @@
 
 #include "job-list.h"
 
+struct idsync_ctx {
+    flux_t *h;
+    zlistx_t *lookups;
+    zhashx_t *waits;
+};
+
 struct idsync_data {
     struct list_ctx *ctx;
     flux_jobid_t id;
@@ -24,9 +30,9 @@ struct idsync_data {
     flux_future_t *f_lookup;
 };
 
-int idsync_setup (struct list_ctx *ctx);
+struct idsync_ctx *idsync_ctx_create (flux_t *h);
 
-void idsync_cleanup (struct list_ctx *ctx);
+void idsync_ctx_destroy (struct idsync_ctx *isctx);
 
 void idsync_data_destroy (void *data);
 

--- a/src/modules/job-list/idsync.h
+++ b/src/modules/job-list/idsync.h
@@ -14,7 +14,6 @@
 #include <flux/core.h>
 
 #include "job-list.h"
-#include "job_state.h"
 
 struct idsync_data {
     struct list_ctx *ctx;

--- a/src/modules/job-list/idsync.h
+++ b/src/modules/job-list/idsync.h
@@ -13,8 +13,6 @@
 
 #include <flux/core.h>
 
-#include "job-list.h"
-
 struct idsync_ctx {
     flux_t *h;
     zlistx_t *lookups;
@@ -22,7 +20,7 @@ struct idsync_ctx {
 };
 
 struct idsync_data {
-    struct list_ctx *ctx;
+    flux_t *h;
     flux_jobid_t id;
     flux_msg_t *msg;
     json_t *attrs;
@@ -38,7 +36,7 @@ void idsync_data_destroy (void *data);
 
 void idsync_data_destroy_wrapper (void **data);
 
-struct idsync_data *idsync_data_create (struct list_ctx *ctx,
+struct idsync_data *idsync_data_create (flux_t *h,
                                         flux_jobid_t id,
                                         const flux_msg_t *msg,
                                         json_t *attrs,

--- a/src/modules/job-list/job-list.c
+++ b/src/modules/job-list/job-list.c
@@ -177,9 +177,9 @@ static struct list_ctx *list_ctx_create (flux_t *h)
         goto error;
     if (flux_msg_handler_addvec (h, htab, ctx, &ctx->handlers) < 0)
         goto error;
-    if (!(ctx->jsctx = job_state_create (ctx)))
-        goto error;
     if (!(ctx->isctx = idsync_ctx_create (ctx->h)))
+        goto error;
+    if (!(ctx->jsctx = job_state_create (ctx->isctx)))
         goto error;
     return ctx;
 error:

--- a/src/modules/job-list/job-list.c
+++ b/src/modules/job-list/job-list.c
@@ -196,7 +196,7 @@ int mod_main (flux_t *h, int argc, char **argv)
         flux_log_error (h, "initialization error");
         goto done;
     }
-    if (job_state_init_from_kvs (ctx) < 0)
+    if (job_state_init_from_kvs (ctx->jsctx) < 0)
         goto done;
     if (flux_reactor_run (flux_get_reactor (h), 0) < 0)
         goto done;

--- a/src/modules/job-list/job-list.h
+++ b/src/modules/job-list/job-list.h
@@ -21,8 +21,7 @@ struct list_ctx {
     flux_t *h;
     flux_msg_handler_t **handlers;
     struct job_state_ctx *jsctx;
-    zlistx_t *idsync_lookups;
-    zhashx_t *idsync_waits;
+    struct idsync_ctx *isctx;
 };
 
 const char **job_attrs (void);

--- a/src/modules/job-list/job_data.c
+++ b/src/modules/job-list/job_data.c
@@ -41,14 +41,13 @@ void job_destroy (void *data)
     }
 }
 
-struct job *job_create (struct list_ctx *ctx, flux_jobid_t id)
+struct job *job_create (flux_t *h, flux_jobid_t id)
 {
     struct job *job = NULL;
 
     if (!(job = calloc (1, sizeof (*job))))
         return NULL;
-    job->h = ctx->h;
-    job->ctx = ctx;
+    job->h = h;
     job->id = id;
     job->userid = FLUX_USERID_UNKNOWN;
     job->urgency = -1;

--- a/src/modules/job-list/job_data.h
+++ b/src/modules/job-list/job_data.h
@@ -14,7 +14,6 @@
 #include <flux/core.h>
 #include <jansson.h>
 
-#include "job-list.h"
 #include "src/common/libutil/grudgeset.h"
 #include "src/common/libczmqcontainers/czmq_containers.h"
 
@@ -31,7 +30,6 @@
  */
 struct job {
     flux_t *h;
-    struct list_ctx *ctx;
 
     flux_jobid_t id;
     uint32_t userid;
@@ -90,7 +88,7 @@ struct job {
 
 void job_destroy (void *data);
 
-struct job *job_create (struct list_ctx *ctx, flux_jobid_t id);
+struct job *job_create (flux_t *h, flux_jobid_t id);
 
 /* Parse and internally cache jobspec.  Set values for:
  * - job name

--- a/src/modules/job-list/job_state.c
+++ b/src/modules/job-list/job_state.c
@@ -414,8 +414,7 @@ static flux_future_t *state_run_lookup (struct job_state_ctx *jsctx,
 }
 
 /* calculate any remaining fields */
-static void eventlog_inactive_complete (struct list_ctx *ctx,
-                                        struct job *job)
+static void eventlog_inactive_complete (struct job *job)
 {
     /* Default result is failed, overridden below */
     if (job->success)
@@ -538,7 +537,7 @@ static void process_next_state (struct list_ctx *ctx, struct job *job)
             /* FLUX_JOB_STATE_INACTIVE */
 
             if (st->state == FLUX_JOB_STATE_INACTIVE)
-                eventlog_inactive_complete (ctx, job);
+                eventlog_inactive_complete (job);
 
             update_job_state_and_list (ctx, job, st->state, st->timestamp);
             zlist_remove (job->next_states, st);
@@ -761,7 +760,7 @@ static int depthfirst_map_one (struct list_ctx *ctx, const char *key,
     }
 
     if (job->states_mask & FLUX_JOB_STATE_INACTIVE)
-        eventlog_inactive_complete (ctx, job);
+        eventlog_inactive_complete (job);
 
     if (zhashx_insert (ctx->jsctx->index, &job->id, job) < 0) {
         flux_log_error (ctx->h, "%s: zhashx_insert", __FUNCTION__);

--- a/src/modules/job-list/job_state.c
+++ b/src/modules/job-list/job_state.c
@@ -282,14 +282,14 @@ static void check_waiting_id (struct list_ctx *ctx,
 {
     zlistx_t *list_isd;
 
-    if ((list_isd = zhashx_lookup (ctx->idsync_waits, &job->id))) {
+    if ((list_isd = zhashx_lookup (ctx->isctx->waits, &job->id))) {
         struct idsync_data *isd;
         isd = zlistx_first (list_isd);
         while (isd) {
             list_id_respond (ctx, isd, job);
             isd = zlistx_next (list_isd);
         }
-        zhashx_delete (ctx->idsync_waits, &job->id);
+        zhashx_delete (ctx->isctx->waits, &job->id);
     }
 }
 
@@ -1325,7 +1325,7 @@ static int journal_process_event (struct job_state_ctx *jsctx, json_t *event)
         }
         zhashx_delete (jsctx->index, &job->id);
         /* N.B. since invalid job ids are not released to the submitter, there
-         * should be no pending ctx->idsync_lookups requests to clean up here.
+         * should be no pending ctx->isctx->lookups requests to clean up here.
          * A test in t2212-job-manager-plugins.t does query invalid ids, but
          * it is careful to ensure that it does so only _after_ the invalidate
          * event has been processed here.

--- a/src/modules/job-list/job_state.h
+++ b/src/modules/job-list/job_state.h
@@ -67,7 +67,7 @@ void job_state_pause_cb (flux_t *h, flux_msg_handler_t *mh,
 void job_state_unpause_cb (flux_t *h, flux_msg_handler_t *mh,
                            const flux_msg_t *msg, void *arg);
 
-int job_state_init_from_kvs (struct list_ctx *ctx);
+int job_state_init_from_kvs (struct job_state_ctx *jsctx);
 
 #endif /* ! _FLUX_JOB_LIST_JOB_STATE_H */
 

--- a/src/modules/job-list/job_state.h
+++ b/src/modules/job-list/job_state.h
@@ -14,7 +14,7 @@
 #include <flux/core.h>
 #include <jansson.h>
 
-#include "job-list.h"
+#include "idsync.h"
 #include "stats.h"
 
 /* To handle the common case of user queries on job state, we will
@@ -38,7 +38,8 @@
 
 struct job_state_ctx {
     flux_t *h;
-    struct list_ctx *ctx;
+    struct idsync_ctx *isctx;
+
     zhashx_t *index;
     zlistx_t *pending;
     zlistx_t *running;
@@ -57,7 +58,7 @@ struct job_state_ctx {
     flux_future_t *events;
 };
 
-struct job_state_ctx *job_state_create (struct list_ctx *ctx);
+struct job_state_ctx *job_state_create (struct idsync_ctx *isctx);
 
 void job_state_destroy (void *data);
 

--- a/src/modules/job-list/list.c
+++ b/src/modules/job-list/list.c
@@ -274,19 +274,19 @@ int wait_id_valid (struct list_ctx *ctx, struct idsync_data *isd)
      * could wait on same id */
     if (!(list_isd = zhashx_lookup (ctx->idsync_waits, &isd->id))) {
         if (!(list_isd = zlistx_new ())) {
-            flux_log_error (isd->ctx->h, "%s: zlistx_new", __FUNCTION__);
+            flux_log_error (ctx->h, "%s: zlistx_new", __FUNCTION__);
             goto error_destroy;
         }
         zlistx_set_destructor (list_isd, idsync_data_destroy_wrapper);
 
         if (zhashx_insert (ctx->idsync_waits, &isd->id, list_isd) < 0) {
-            flux_log_error (isd->ctx->h, "%s: zhashx_insert", __FUNCTION__);
+            flux_log_error (ctx->h, "%s: zhashx_insert", __FUNCTION__);
             goto error_destroy;
         }
     }
 
     if (!zlistx_add_end (list_isd, isd)) {
-        flux_log_error (isd->ctx->h, "%s: zlistx_add_end", __FUNCTION__);
+        flux_log_error (ctx->h, "%s: zlistx_add_end", __FUNCTION__);
         goto error_destroy;
     }
 

--- a/src/modules/job-list/stats.h
+++ b/src/modules/job-list/stats.h
@@ -14,6 +14,8 @@
 #include <flux/core.h> /* FLUX_JOB_NR_STATES */
 #include <jansson.h>
 
+#include "job_data.h"
+
 struct job_stats {
     unsigned int state_count[FLUX_JOB_NR_STATES];
     unsigned int failed;
@@ -21,10 +23,6 @@ struct job_stats {
     unsigned int canceled;
 };
 
-/* Forward declaration of struct job to avoid circular header file
- *  dependemncy.
- */
-struct job;
 void job_stats_update (struct job_stats *stats,
                        struct job *job,
                        flux_job_state_t newstate);


### PR DESCRIPTION
some kruft developed over time, and some circular header / struct dependencies were the most notable.  Bunch of cleanup and resolution to that kruft.  Should make future changes (#4604, #4592) easier.  Note, some future refactoring perhaps coming, but thought this was a good stopping point.