### PR TITLE
make queue state persist across instance restart

### DIFF
--- a/src/modules/job-manager/queue.h
+++ b/src/modules/job-manager/queue.h
@@ -18,10 +18,12 @@
 struct queue *queue_create (struct job_manager *ctx);
 void queue_destroy (struct queue *queue);
 
+json_t *queue_save_state (struct queue *queue);
+int queue_restore_state (struct queue *queue, json_t *o);
+
 int queue_submit_check (struct queue *queue,
                         json_t *jobspec,
                         flux_error_t *error);
-
 
 #endif /* ! _FLUX_JOB_MANAGER_QUEUE_H */
 


### PR DESCRIPTION
This adds the queue enable/disable state to the job manager KVS checkpoint so that it persists across an instance restat.

This PR is currently based on #4440 (only the most recent 2 commits are part of this PR).