### PR TITLE
python: add contextual_time jobinfo field

### DIFF
--- a/doc/man1/flux-jobs.rst
+++ b/doc/man1/flux-jobs.rst
@@ -152,8 +152,8 @@ following is the format used for the default format:
 ::
 
    {id.f58:>12} ?:{queue:<8.8} {username:<8.8} {name:<10.10} \
-   {status_abbrev:>2.2} {ntasks:>6} {nnodes:>6h} {runtime!F:>8h} \
-   {contextual_info}
+   {status_abbrev:>2.2} {ntasks:>6} {nnodes:>6h} \
+   {contextual_time!F:>8h} {contextual_info}
 
 If a format field is preceded by the special string ``?:`` this will
 cause the field to be removed entirely from output if the result would
@@ -394,6 +394,9 @@ the state of the job or other context:
    job will run is returned (if the scheduler supports it). Otherwise,
    the assigned nodelist is returned (if resources were assigned).
 
+**contextual_info**
+   Returns the job runtime for jobs in RUN state or later, otherwise the
+   job duration (if set) is returned.
 
 CONFIGURATION
 =============

--- a/src/bindings/python/flux/job/info.py
+++ b/src/bindings/python/flux/job/info.py
@@ -377,6 +377,16 @@ class JobInfo:
         else:
             return self.nodelist
 
+    @memoized_property
+    def contextual_time(self):
+        """
+        Return job duration if job is not running, otherwise runtime
+        """
+        state = str(self.state)
+        if state in ["PRIORITY", "DEPEND", "SCHED"]:
+            return self.duration
+        return self.runtime
+
 
 def job_fields_to_attrs(fields):
     # Note there is no attr for "id", it is always returned
@@ -423,6 +433,7 @@ def job_fields_to_attrs(fields):
         "annotations": ("annotations",),
         "dependencies": ("dependencies",),
         "contextual_info": ("state", "dependencies", "annotations", "nodelist"),
+        "contextual_time": ("state", "t_run", "t_cleanup", "duration"),
         # Special cases, pointers to sub-dicts in annotations
         "sched": ("annotations",),
         "user": ("annotations",),
@@ -632,6 +643,7 @@ class JobInfoFormat(flux.util.OutputFormat):
         "annotations": "ANNOTATIONS",
         "dependencies": "DEPENDENCIES",
         "contextual_info": "INFO",
+        "contextual_time": "TIME",
         # The following are special pre-defined cases per RFC27
         "annotations.sched.t_estimate": "T_ESTIMATE",
         "annotations.sched.reason_pending": "REASON",

--- a/src/cmd/flux-jobs.py
+++ b/src/cmd/flux-jobs.py
@@ -34,7 +34,7 @@ class FluxJobsConfig(UtilConfig):
             "format": (
                 "{id.f58:>12} ?:{queue:<8.8} {username:<8.8} {name:<10.10} "
                 "{status_abbrev:>2.2} {ntasks:>6} {nnodes:>6h} "
-                "{runtime!F:>8} {contextual_info}"
+                "{contextual_time!F:>8h} {contextual_info}"
             ),
         },
         "deps": {

--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -571,6 +571,20 @@ test_expect_success 'flux-jobs --format={runtime:0.3f} works' '
 	[ "$(grep -E "\.[0-9]{3}" runtime-dotRI.out | wc -l)" = "15" ]
 '
 
+test_expect_success 'flux-jobs --format={contextual_time} works' '
+	flux jobs --filter=pending -c1 -no "{contextual_time:h}" \
+		>ctx_timeP.out &&
+	flux jobs --filter=running -c1 -no "{contextual_time:h}" \
+		>ctx_timeR.out &&
+	flux jobs --filter=completed -c1 -no "{contextual_time:0.3f}" \
+		>ctx_timeCD.out &&
+	echo "300.0" >duration.expected &&
+	test_cmp duration.expected ctx_timeP.out &&
+	test_must_fail test_cmp duration.expected ctx_timeR.out &&
+	test_must_fail test_cmp duration.expected ctx_timeCD.out &&
+	grep -E "\.[0-9]{3}" ctx_timeCD.out
+'
+
 test_expect_success 'flux-jobs emits useful error on invalid format' '
 	test_expect_code 1 flux jobs --format="{runtime" >invalid.out 2>&1 &&
 	test_debug "cat invalid.out" &&
@@ -945,6 +959,7 @@ test_expect_success 'flux-jobs: header included with all custom formats' '
 	ranks==RANKS
 	nodelist==NODELIST
 	contextual_info==INFO
+	contextual_time==TIME
 	success==SUCCESS
 	exception.occurred==EXCEPTION-OCCURRED
 	exception.severity==EXCEPTION-SEVERITY


### PR DESCRIPTION
This PR follows up the `contextual_info` with a `contextual_time` field. As discussed in #4613, it might be useful to display the job duration when available for pending jobs in the default `flux jobs` output. To allow that feature easily, a new contextual jobinfo property is introduced, `contextual_time`, which displays runtime for jobs that hit the RUN state, but job duration (if set) otherwise. The heading is simply `TIME` as proposed in that issue.