### PR TITLE
testsuite: document FLUX_TEST_VALGRIND

### DIFF
--- a/t/README.md
+++ b/t/README.md
@@ -107,6 +107,9 @@ The environment variable `FLUX_TEST_INSTALLED_PATH` may also be set
 to the path to an *installed* version of the `flux(1)` command, for
 running the testsuite against an installed version of flux-core.
 
+The environment variable `FLUX_TEST_VALGRIND` may be set to `t`
+to run tests under valgrind.
+
 
 Skipping Tests
 --------------


### PR DESCRIPTION
I can never remember what to set, so document it in the testsuite README.  Note that in the sharness script it appears setting it to non-empty is fine, but I just documented to set to "t" since that's we seem to do the most in the issues.
