### PR TITLE
job-list: refactor to abstract "idsync" logic better

### DIFF
--- a/src/modules/job-list/idsync.h
+++ b/src/modules/job-list/idsync.h
@@ -13,6 +13,8 @@
 
 #include <flux/core.h>
 
+#include "job_data.h"
+
 struct idsync_ctx {
     flux_t *h;
     zlistx_t *lookups;
@@ -34,13 +36,38 @@ void idsync_ctx_destroy (struct idsync_ctx *isctx);
 
 void idsync_data_destroy (void *data);
 
-void idsync_data_destroy_wrapper (void **data);
+/* lookup id in KVS to check if it is valid, futures will be tracked /
+ * managed in lookups list.  Future returned in idsync_data pointer
+ * under 'f_lookup'.
+ */
+struct idsync_data *idsync_check_id_valid (struct idsync_ctx *isctx,
+                                           flux_jobid_t id,
+                                           const flux_msg_t *msg,
+                                           json_t *attrs);
 
-struct idsync_data *idsync_data_create (flux_t *h,
-                                        flux_jobid_t id,
-                                        const flux_msg_t *msg,
-                                        json_t *attrs,
-                                        flux_future_t *f_lookup);
+
+/* free / cleanup 'struct idsync_data' after
+ * idsync_check_id_valid().  Don't call this if you re-use
+ * 'struct idsync_data' with idsync_wait_valid().
+ */
+void idsync_check_id_valid_cleanup (struct idsync_ctx *isctx,
+                                    struct idsync_data *isd);
+
+/* idsync_wait_valid*() add to job id waits hash, waiting for id to be
+ * legal in job-list.  idsync_check_waiting_id() will be able to
+ * respond to message at later time when job id becomes available.
+ */
+
+int idsync_wait_valid (struct idsync_ctx *isctx, struct idsync_data *isd);
+
+int idsync_wait_valid_id (struct idsync_ctx *isctx,
+                          flux_jobid_t id,
+                          const flux_msg_t *msg,
+                          json_t *attrs);
+
+/* check if 'job' is in waits list, if so respond to original
+ * message */
+void idsync_check_waiting_id (struct idsync_ctx *isctx, struct job *job);
 
 #endif /* ! _FLUX_JOB_LIST_IDSYNC_H */
 

--- a/src/modules/job-list/list.c
+++ b/src/modules/job-list/list.c
@@ -489,7 +489,7 @@ error:
         flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
 }
 
-int list_attrs_append (json_t *a, const char *attr)
+static int list_attrs_append (json_t *a, const char *attr)
 {
     json_t *o = json_string (attr);
     if (!o) {

--- a/src/modules/job-list/list.c
+++ b/src/modules/job-list/list.c
@@ -447,7 +447,7 @@ json_t *get_job_by_id (struct list_ctx *ctx,
 }
 
 void list_id_cb (flux_t *h, flux_msg_handler_t *mh,
-                  const flux_msg_t *msg, void *arg)
+                 const flux_msg_t *msg, void *arg)
 {
     struct list_ctx *ctx = arg;
     job_list_error_t err = {{0}};

--- a/src/modules/job-list/list.c
+++ b/src/modules/job-list/list.c
@@ -321,7 +321,7 @@ void check_id_valid_continuation (flux_future_t *f, void *arg)
             /* Must wait for job-list to see state change */
             if (wait_id_valid (jsctx->isctx, isd) < 0)
                 flux_log_error (jsctx->h, "%s: wait_id_valid", __FUNCTION__);
-            goto cleanup;
+            return;
         }
         else {
             json_t *o;


### PR DESCRIPTION
refactor round two, abstract the "idsync" logic better, instead of the logic being spread around and throughout all the code.