### PR TITLE
job-manager: do not ignore failure to load configured plugins

### DIFF
--- a/src/modules/job-manager/jobtap.c
+++ b/src/modules/job-manager/jobtap.c
@@ -389,10 +389,7 @@ static int jobtap_conf_entry (struct jobtap *jobtap,
                           remove,
                           jobtap_err.text);
     }
-    if (load && jobtap_load_plugin (jobtap,
-                                    load,
-                                    conf,
-                                    &jobtap_err) < 0) {
+    if (load && !jobtap_load_plugin (jobtap, load, conf, &jobtap_err)) {
         return errprintf (errp,
                           "[job-manager.plugins][%d]: load %s: %s",
                           index,


### PR DESCRIPTION
This PR fixes #4645. A `< 0` was inadvertently used to test for failure from a function that returns a pointer. :facepalm: 

I also added @garlick's enhancement to the testsuite.