### PR TITLE
doc: add note about flux --parent option in flux-mini(1)

### DIFF
--- a/doc/man1/flux-mini.rst
+++ b/doc/man1/flux-mini.rst
@@ -57,6 +57,16 @@ over time, making them suitable for use in scripts.
 
 The available OPTIONS are detailed below.
 
+.. note::
+
+  These commands target the *enclosing instance*. For example, within
+  a *SCRIPT* submitted with ``flux mini batch``, a ``flux mini`` command
+  will submit a job to the batch instance, not the parent instance under
+  which the batch instance is running. To target the parent instance,
+  the ``--parent`` option of :man1:`flux` should be used, e.g::
+
+   flux --parent mini batch [OPTIONS].. ARGS..
+
 
 JOB PARAMETERS
 ==============


### PR DESCRIPTION
Problem: A common use case is for a user to submit a new batch script to the parent instance from within a batch job, but the flux-mini(1) man page doesn't mention how to do this.

Add a note to the flux-mini(1) man page about the flux(1) `--parent` option, which can be used to target the parent instance for any flux command, but is useful here to submit a new batch job from a batch script.