### PR TITLE
broker: launch non-interactive shells in a new process group

### DIFF
--- a/src/broker/runat.c
+++ b/src/broker/runat.c
@@ -431,6 +431,15 @@ int runat_push_shell_command (struct runat *r,
     }
     if (!(cmd = runat_command_create (environ, log_stdio)))
         return -1;
+
+    /*   For shell commands run the target cmdline in a separate process
+     *   group so that any processes spawned by the shell will be signaled
+     *   in runat_abort(). This is probably unnecessary for single commands,
+     *   and does not work for an interactive shell (seems to disable access
+     *   to the pty), so we set the flag only here for now.
+     */
+    cmd->flags |= FLUX_SUBPROCESS_FLAGS_SETPGRP;
+
     if (runat_command_set_cmdline (cmd, cmdline) < 0)
         goto error;
     if (runat_command_modenv (cmd, env_blocklist, r->local_uri) < 0)


### PR DESCRIPTION
Problem: When the broker launches a non-interactive shell via runat, e.g. when running a script as part of a batch job, and that script is later canceled, the signal is delivered only to the shell which may leave other processes running. This can cause batch jobs to hang after a `flux shutdown` if the batch script is running a command in the foreground. The shell will be terminated, but the command keeps running keeping the stdio file descriptors open so the job shell can't exit.

When the runat subsystem is spawning a shell command, add the subprocess flag FLUX_SUBPROCESS_FLAGS_SETPGRP, so that the shell is run in a new process group. This then causes flux_subprocess_kill(3) to call killpg(2) instead of only signaling the spawned shell.

Note: I believe this fixes hangs in `t2808-shutdown-cmd.t` we've been seeing in CI. That test runs a series of batch jobs that have a `sleep 300` in them. In my testing I was seeing many cases where `flux shutdown` killed the batch script, but left the `sleep` process running. This causes the job shell to hang around waiting for stdio file descriptors to close so the job doesn't exit. Once enough jobs are run as part of the test, a test job then gets stuck in SCHED state waiting for one of the other test jobs to exit, and thus the hang.

I'm not 100% sure though, so we should let this one run through CI a few times to be sure (and to be sure it doesn't cause other problems).


Fixes #4596

