### PR TITLE
Flux reactor backend timeout

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -26,6 +26,8 @@ AM_MAINTAINER_MODE([enable])
 
 AC_DEFINE([_GNU_SOURCE], 1,
           [Define _GNU_SOURCE so that we get all necessary prototypes])
+AC_DEFINE([EV_WALK_ENABLE], 1,
+          [Define EV_WALK_ENABLE to enable ev_walk])
 
 ##
 # Generate project versions from PACKAGE_VERSION (set from git describe above)

--- a/src/common/libflux/reactor.h
+++ b/src/common/libflux/reactor.h
@@ -53,6 +53,12 @@ void flux_reactor_destroy (flux_reactor_t *r);
 flux_reactor_t *flux_get_reactor (flux_t *h);
 int flux_set_reactor (flux_t *h, flux_reactor_t *r);
 
+/* seconds until the loop should be resumed to make progress efficiently
+   <0 for blocking ok
+   0 for return as soon as possible
+   >0 for time in floating point seconds */
+double flux_reactor_resume_timeout(flux_reactor_t *r);
+
 int flux_reactor_run (flux_reactor_t *r, int flags);
 
 void flux_reactor_stop (flux_reactor_t *r);


### PR DESCRIPTION
This interface mirrors the one used by libuv, which offers:

* uv_backend_fd
* uv_backend_timeout

For flux this adds flux_reactor_resume_timeout, which when combined with
flux_pollfd and some extra timer logic can be used to drive a handle
to completion with relatively efficient blocking behavior.  The design
is that the external event loop should set up watchers much like ev_flux
does to handle IO events, but additionally in the check callback
should invoke flux_reactor_resume_timeout to determine what blocking
mode flux expects.  The logic is:
* If the reactor has a prepare, check, or idle watcher *currently
  active* then it will return 0, and expect the outer loop to call back
  into it on the next iteration of the outer loop.  The outer loop
  should use an idle watcher or similar to ensure this makes progress.
* If the reactor has either timer or periodic watchers registered, then
  it will return the minimum registered relative timeout or pending
  fire time.  The outer loop is expected to call back into the flux
  reactor at that timeout, and possibly before.  Using a timer or
  periodic call into flux should both work.
* If the reactor finds neither pending timeouts nor per-iteration
  watchers, then it will return -1, indicating that the outer loop
  can block on the pollfd of the handle being embedded until an IO
  event arrives.

For the case of embedding a handle's pollfd and associated continuations
and reactor events into an external loop this appears to work well.  It
does not handle *all* reactor events well necessarily.  Using a pollfd, all IO watchers,
signal and child watchers are suspect, and should not be used with this
interface.  The per-iteration and time event watchers should all be
safe.
(NOTE: updated with corrections for pollfd rather than backend_fd)

Here's a small(ish) application that embeds a handle and reactor in a libuv event loop.  It seems to work well with a kvs lookup with a continuation on the future as well as with a timer.  More experimentation would be good, but I think this will let us manage both embedding in other event loops and embedding flux handles in other flux handles for asyncio.  

```c
/************************************************************\
 * Copyright 2014 Lawrence Livermore National Security, LLC
 * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
 *
 * This file is part of the Flux resource manager framework.
 * For details, see https://github.com/flux-framework.
 *
 * SPDX-License-Identifier: LGPL-3.0
\************************************************************/

#include <flux/core.h>
#include <stdbool.h>
#include <stddef.h>
#include <stdio.h>
#include <uv.h>

#include "src/common/libev/ev.h"

struct uv_flux;

typedef void (*uv_flux_f) (uv_loop_t *loop, struct uv_flux *w, int revents);
double get_flux_timeout (flux_reactor_t *r);

struct uv_flux {
    uv_poll_t io_w;
    uv_prepare_t prepare_w;
    uv_idle_t idle_w;
    uv_check_t check_w;
    uv_timer_t timer_w;
    flux_t *h;
    int pollfd;
    int events;
    uv_flux_f cb;
    void *data;
    uv_loop_t loop;
    flux_future_t *fut;
};

/* Get flux poll events, converted to libev
 */
static int get_pollevents (flux_t *h)
{
    int e = flux_pollevents (h);
    int events = 0;
    if (e < 0 || (e & FLUX_POLLERR))
        events |= UV_DISCONNECT;
    if ((e & FLUX_POLLIN))
        events |= UV_READABLE;
    if ((e & FLUX_POLLOUT))
        events |= UV_WRITABLE;
    return events;
}

void null_cb (uv_handle_t *h)
{
}

static void prepare_cb (uv_prepare_t *w)
{
    struct uv_flux *fw =
        (struct uv_flux *)((char *)w - offsetof (struct uv_flux, prepare_w));
    int events = get_pollevents (fw->h);
    printf ("prepare_cb events: %d\n", events);
    get_flux_timeout (flux_get_reactor (fw->h));

    if ((events & fw->events) || (events & EV_ERROR))
        uv_idle_start (&fw->idle_w, null_cb);
    else
        uv_poll_start (&fw->io_w, UV_READABLE, null_cb);
}
static void timer_cb (uv_timer_t *w)
{
    struct uv_flux *fw =
        (struct uv_flux *)((char *)w - offsetof (struct uv_flux, timer_w));
    printf ("timer_cb\n");
    get_flux_timeout (flux_get_reactor (fw->h));
    fw->cb (&fw->loop, fw, 0);
    get_flux_timeout (flux_get_reactor (fw->h));
}

static void check_cb (uv_check_t *w)
{
    struct uv_flux *fw =
        (struct uv_flux *)((char *)w - offsetof (struct uv_flux, check_w));

    // if (ev_is_pending (&fw->io_w)
    //         && ev_clear_pending (loop, &fw->io_w) & EV_ERROR) {
    //     fw->cb (loop, fw, EV_ERROR);
    //     return;
    // }
    int events = get_pollevents (fw->h);
    printf ("check_cb events: %d\n", events);
    fw->cb (&fw->loop, fw, events);

    double to = get_flux_timeout (flux_get_reactor (fw->h));
    uv_poll_stop (&fw->io_w);
    uv_idle_stop (&fw->idle_w);

    if (to < 1e-100 && to > -1e-100) {
        uv_idle_start (&fw->idle_w, null_cb);
    } else if (to > 0)
        uv_timer_start (&fw->timer_w, timer_cb, to * 1000, 0);
}

int uv_flux_init (struct uv_flux *w, uv_flux_f cb, flux_t *h, int events)
{
    w->cb = cb;
    w->h = h;
    w->events = events;
    if ((w->pollfd = flux_pollfd (h)) < 0)
        return -1;

    w->prepare_w.data = w;
    w->check_w.data = w;
    uv_prepare_init (&w->loop, &w->prepare_w);
    uv_timer_init (&w->loop, &w->timer_w);
    uv_check_init (&w->loop, &w->check_w);
    uv_idle_init (&w->loop, &w->idle_w);
    uv_poll_init (&w->loop, &w->io_w, w->pollfd);

    return 0;
}

void uv_flux_start (uv_loop_t *loop, struct uv_flux *w)
{
    uv_prepare_start (&w->prepare_w, prepare_cb);
    uv_check_start (&w->check_w, check_cb);
}

void uv_flux_stop (uv_loop_t *loop, struct uv_flux *w)
{
    uv_prepare_stop (&w->prepare_w);
    uv_check_stop (&w->check_w);
    uv_poll_stop (&w->io_w);
    uv_idle_stop (&w->idle_w);
    uv_timer_stop (&w->timer_w);
}

void run_loop_cb (uv_loop_t *loop, struct uv_flux *w, int revents)
{
    flux_reactor_t *r = flux_get_reactor (w->h);
    flux_reactor_run (r, FLUX_REACTOR_ONCE);
}
double get_flux_timeout (flux_reactor_t *r)
{
    double ret = flux_reactor_resume_timeout (r);
    printf ("timeout: %lf\n", ret);
    return ret;
}

void tw_cb (flux_reactor_t *r, flux_watcher_t *w, int revents, void *data)
{
    struct uv_flux *fw = data;
    printf ("We made it into timer!\n");
    get_flux_timeout (flux_get_reactor (fw->h));
    uv_flux_stop (&fw->loop, fw);
    uv_stop (&fw->loop);
}

void then_cb (flux_future_t *fut, void *data)
{
    struct uv_flux *ef = data;
    printf ("We made it!\n");
    flux_future_destroy(fut);
    // uv_flux_stop(&ef->loop, ef);
    // uv_stop(&ef->loop);
}

int main (int argc, char *argv[])
{
    struct uv_flux ef = {0};
    flux_t *f = flux_open (NULL, 0);
    flux_reactor_t *r = flux_get_reactor (f);
    uv_loop_init (&ef.loop);
    uv_flux_init (&ef, run_loop_cb, f, UV_READABLE);
    uv_flux_start (&ef.loop, &ef);
    get_flux_timeout (r);
    flux_future_t *fut = flux_kvs_lookup (f, NULL, 0, "resource.R");
    ef.fut = fut;
    flux_future_then (fut, -1, then_cb, &ef);
    get_flux_timeout (r);
    flux_watcher_t *timer_watcher = flux_timer_watcher_create (r, 5, 0, tw_cb, &ef);
    flux_watcher_start (timer_watcher);
    get_flux_timeout (r);
    return uv_run (&ef.loop, UV_RUN_DEFAULT);
}

/*
 * vi:tabstop=4 shiftwidth=4 expandtab
 */
```

@vchuravy, you might want to check this out.