### PR TITLE
broker/test: Fix runat race on older glibc versions

### DIFF
--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -679,15 +679,15 @@ static int create_runat_rc2 (struct runat *r, const char *argz, size_t argz_len)
          */
         if (!isatty (STDIN_FILENO))
             log_msg_exit ("stdin is not a tty - can't run interactive shell");
-        if (runat_push_shell (r, "rc2") < 0)
+        if (runat_push_shell (r, "rc2", 0) < 0)
             return -1;
     }
     else if (argz_count (argz, argz_len) == 1) { // run shell -c "command"
-        if (runat_push_shell_command (r, "rc2", argz, false) < 0)
+        if (runat_push_shell_command (r, "rc2", argz, 0) < 0)
             return -1;
     }
     else { // direct exec
-        if (runat_push_command (r, "rc2", argz, argz_len, false) < 0)
+        if (runat_push_command (r, "rc2", argz, argz_len, 0) < 0)
             return -1;
     }
     return 0;
@@ -721,7 +721,10 @@ static int create_runat_phases (broker_ctx_t *ctx)
     /* rc1 - initialization
      */
     if (rc1 && strlen (rc1) > 0) {
-        if (runat_push_shell_command (ctx->runat, "rc1", rc1, true) < 0) {
+        if (runat_push_shell_command (ctx->runat,
+                                      "rc1",
+                                      rc1,
+                                      RUNAT_FLAG_LOG_STDIO) < 0) {
             log_err ("runat_push_shell_command rc1");
             return -1;
         }
@@ -740,7 +743,10 @@ static int create_runat_phases (broker_ctx_t *ctx)
     /* rc3 - finalization
      */
     if (rc3 && strlen (rc3) > 0) {
-        if (runat_push_shell_command (ctx->runat, "rc3", rc3, true) < 0) {
+        if (runat_push_shell_command (ctx->runat,
+                                      "rc3",
+                                      rc3,
+                                      RUNAT_FLAG_LOG_STDIO) < 0) {
             log_err ("runat_push_shell_command rc3");
             return -1;
         }

--- a/src/broker/runat.c
+++ b/src/broker/runat.c
@@ -298,6 +298,8 @@ static struct runat_command *runat_command_create (char **env, int flags)
         return NULL;
     if (!(flags & RUNAT_FLAG_LOG_STDIO))
         cmd->flags |= FLUX_SUBPROCESS_FLAGS_STDIO_FALLTHROUGH;
+    if (flags & RUNAT_FLAG_FORK_EXEC)
+        cmd->flags |= FLUX_SUBPROCESS_FLAGS_FORK_EXEC;
     if (!(cmd->cmd = flux_cmd_create (0, NULL, env)))
         goto error;
     return cmd;

--- a/src/broker/runat.h
+++ b/src/broker/runat.h
@@ -14,6 +14,11 @@
 #ifndef _BROKER_RUNAT_H
 #define _BROKER_RUNAT_H
 
+enum {
+    RUNAT_FLAG_LOG_STDIO = 1,   /* stdout/stderr go to flux_log (o/w
+                                 * combine w/ broker) */
+};
+
 struct runat;
 
 typedef void (*runat_completion_f)(struct runat *r,
@@ -24,26 +29,25 @@ struct runat *runat_create (flux_t *h, const char *local_uri);
 void runat_destroy (struct runat *r);
 
 /* Push command, to be run under shell -c, onto named list.
- * If log_stdio is true, stdout/stderr go to flux_log (o/w combine w/broker)
  */
 int runat_push_shell_command (struct runat *r,
                               const char *name,
                               const char *cmdline,
-                              bool log_stdio);
+                              int flags);
 
 /* Push interactive shell onto named list.
+ * Note: RUNAT_FLAG_LOG_STDIO flag not allowed
  */
-int runat_push_shell (struct runat *r, const char *name);
+int runat_push_shell (struct runat *r, const char *name, int flags);
 
 /* Push command, to be run directly, onto named list.
  * The command is specified by argz.
- * If log_stdio is true, stdout/stderr go to flux_log (o/w combine w/broker)
  */
 int runat_push_command (struct runat *r,
                         const char *name,
                         const char *argz,
                         size_t argz_len,
-                        bool log_stdio);
+                        int flags);
 
 /* Get exit code of completed command list.
  * If multiple commands fail, the exit code is that of the first failure.

--- a/src/broker/runat.h
+++ b/src/broker/runat.h
@@ -17,6 +17,8 @@
 enum {
     RUNAT_FLAG_LOG_STDIO = 1,   /* stdout/stderr go to flux_log (o/w
                                  * combine w/ broker) */
+    RUNAT_FLAG_FORK_EXEC = 2,  /* require use of fork/exec, not
+                                * posix_spawn */
 };
 
 struct runat;

--- a/src/broker/test/runat.c
+++ b/src/broker/test/runat.c
@@ -196,7 +196,7 @@ void basic (flux_t *h)
     /* N.B. if sleep has started, the abort function kills it.
      * If it is not yet started, the subprocess state callback kills it
      * when it transitions to running.  Either way we should see an
-     * exit code inidicating terminated.
+     * exit code indicating terminated.
      */
     clear_list (logs);
     ok (runat_push_shell_command (r, "test7", "/bin/true", false) == 0

--- a/src/common/libsubprocess/local.c
+++ b/src/common/libsubprocess/local.c
@@ -396,7 +396,9 @@ static void child_watch_cb (flux_reactor_t *r, flux_watcher_t *w,
 
 static int create_process (flux_subprocess_t *p)
 {
-    if (!p->hooks.pre_exec && !flux_cmd_getcwd (p->cmd))
+    if (!(p->flags & FLUX_SUBPROCESS_FLAGS_FORK_EXEC)
+        && !p->hooks.pre_exec
+        && !flux_cmd_getcwd (p->cmd))
         return create_process_spawn (p);
     return create_process_fork (p);
 }

--- a/src/common/libsubprocess/subprocess.c
+++ b/src/common/libsubprocess/subprocess.c
@@ -631,7 +631,8 @@ static flux_subprocess_t * flux_exec_wrap (flux_t *h, flux_reactor_t *r, int fla
 {
     flux_subprocess_t *p = NULL;
     int valid_flags = (FLUX_SUBPROCESS_FLAGS_STDIO_FALLTHROUGH
-                       | FLUX_SUBPROCESS_FLAGS_SETPGRP);
+                       | FLUX_SUBPROCESS_FLAGS_SETPGRP
+                       | FLUX_SUBPROCESS_FLAGS_FORK_EXEC);
 
     if (!r || !cmd) {
         errno = EINVAL;

--- a/src/common/libsubprocess/subprocess.h
+++ b/src/common/libsubprocess/subprocess.h
@@ -70,6 +70,8 @@ enum {
     FLUX_SUBPROCESS_FLAGS_STDIO_FALLTHROUGH = 1,
     /* flux_exec(): call setpgrp() before exec(2) */
     FLUX_SUBPROCESS_FLAGS_SETPGRP = 2,
+    /* use fork(2)/exec(2) even if posix_spawn(3) available */
+    FLUX_SUBPROCESS_FLAGS_FORK_EXEC = 4,
 };
 
 /*


### PR DESCRIPTION
Problem: On older glibc versions, the setting of the child process group via POSIX_SPAWN_SETPGROUP can be racy.  A call to killpg() immediately after a spawned process is launched may not kill a child process.  In one runat test, this can give the appearance of a hang as a 3600 second sleep call is being waited on.

- support a new flag in libsubprocess to force the use of FORK/EXEC
- refactor runat code to take flags instead of bool for log_stdio
- have runat flags take a flag for forced use for FORK/EXEC
- have test use FORK/EXEC if using older versions of glibc

Fixes https://github.com/flux-framework/flux-core/issues/4657