### PR TITLE
rc1: reload configuration on rank > 0

### DIFF
--- a/etc/rc1
+++ b/etc/rc1
@@ -16,6 +16,12 @@ backing_module() {
     echo ${backingmod:-content-sqlite}
 }
 
+# Get the latest config in case it changed while upstream broker was down.
+# See also: flux-framework/flux-core#4663
+if test $RANK -gt 0; then
+    flux config reload
+fi
+
 modload all barrier
 
 if test $RANK -eq 0; then


### PR DESCRIPTION
Problem: although flux shutdown stops the rank 0 broker in a system instance, the other ranks are immediately restarted by systemd. This means that altering the configuration while flux is "down" may be too late for the brokers that have already restarted but have not yet rejoined the instance.

To avoid confusing people, run flux config reload in rc1 on rank > 0 to ensure it starts with the latest configuration.

Fixes #4663