### PR TITLE
build: fix use of system bash-completion dir

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -341,9 +341,17 @@ PKG_CHECK_MODULES([LIBUUID], [uuid], [], [])
 PKG_CHECK_MODULES([CURSES], [ncursesw], [], [])
 PKG_CHECK_MODULES([LIBARCHIVE], [libarchive], [], [])
 
-PKG_CHECK_EXISTS([bash-completion],
-    [bashcompdir=`$PKG_CONFIG --variable=completionsdir bash-completion`],
-    [bashcompdir="${sysconfdir}/bash_completion.d"])
+AC_ARG_WITH([system-bash-completion-dir],
+    AS_HELP_STRING([--with-system-bash-completion-dir],
+                   [Build with system bash-completion dir]))
+AS_IF([test "x$with_system_bash_completion_dir" = "xyes"], [
+    PKG_CHECK_EXISTS([bash-completion],
+      [bashcompdir=`$PKG_CONFIG --variable=completionsdir bash-completion`],
+      [bashcompdir="${sysconfdir}/bash_completion.d"])
+  ], [
+    bashcompdir="${sysconfdir}/bash_completion.d"
+  ]
+)
 AC_SUBST(bashcompdir)
 
 LX_FIND_MPI


### PR DESCRIPTION
Problem: commit ee47ced changed the installation path for the flux bash completion file to the result of

  pkg-config --variable=completionsdir bash-completion

ignoring `--prefix`. However, this will break `make install` to side install locations, temporary installs, and possibly spack builds since the system bash-completion path is always used.

Set `bashcompdir=${sysconfdir}/etc/bash_completion.d` by default and add a new option `--with-system-bash-completion-dir` for users that want to force installation of the completion file to the system-defined bash-completion path.

Fixes #4666