### PR TITLE
python: indicate truncation for some fields in flux-jobs and flux-resource

### DIFF
--- a/doc/man1/flux-jobs.rst
+++ b/doc/man1/flux-jobs.rst
@@ -151,7 +151,7 @@ following is the format used for the default format:
 
 ::
 
-   {id.f58:>12} ?:{queue:<8.8} {username:<8.8} {name:<10.10} \
+   {id.f58:>12} ?:{queue:<8.8} {username:<8.8} {name:<10.10+} \
    {status_abbrev:>2.2} {ntasks:>6} {nnodes:>6h} \
    {contextual_time!F:>8h} {contextual_info}
 
@@ -169,6 +169,10 @@ The special presentation type *h* can be used to convert an empty
 string, "0s", "0.0", or "0:00:00" to a hyphen. For example, normally
 "{nodelist}" would output an empty string if the job has not yet run.
 By specifying, "{nodelist:h}", a hyphen would be presented instead.
+
+The special suffix *+* can be used to indicate if a string was truncated
+by including a ``+`` character when truncation occurs. If both *h* and
+*+* are being used, then the *+* must appear after the *h*.
 
 Additionally, the custom job formatter supports a set of special
 conversion flags. Conversion flags follow the format field and are

--- a/src/bindings/python/flux/util.py
+++ b/src/bindings/python/flux/util.py
@@ -402,11 +402,22 @@ class UtilFormatter(Formatter):
         return value
 
     def format_field(self, value, spec):
+
+        denote_truncation = False
+        if spec.endswith("+"):
+            denote_truncation = True
+            spec = spec[:-1]
+
         if spec.endswith("h"):
             basecases = ("", "0s", "0.0", "0:00:00", "1970-01-01T00:00:00")
             value = "-" if str(value) in basecases else str(value)
             spec = spec[:-1] + "s"
-        return super().format_field(value, spec)
+        retval = super().format_field(value, spec)
+
+        if denote_truncation and len(retval) < len(str(value)):
+            retval = retval[:-1] + "+"
+
+        return retval
 
 
 class OutputFormat:

--- a/src/cmd/flux-jobs.py
+++ b/src/cmd/flux-jobs.py
@@ -32,7 +32,7 @@ class FluxJobsConfig(UtilConfig):
         "default": {
             "description": "Default flux-jobs format string",
             "format": (
-                "{id.f58:>12} ?:{queue:<8.8} {username:<8.8} {name:<10.10} "
+                "{id.f58:>12} ?:{queue:<8.8} {username:<8.8} {name:<10.10+} "
                 "{status_abbrev:>2.2} {ntasks:>6} {nnodes:>6h} "
                 "{contextual_time!F:>8h} {contextual_info}"
             ),
@@ -40,7 +40,7 @@ class FluxJobsConfig(UtilConfig):
         "long": {
             "description": "Extended flux-jobs format string",
             "format": (
-                "{id.f58:>12} ?:{queue:<8.8} {username:<8.8} {name:<10.10} "
+                "{id.f58:>12} ?:{queue:<8.8} {username:<8.8} {name:<10.10+} "
                 "{status:>9.9} {ntasks:>6} {nnodes:>6h} "
                 "{t_submit!d:%b%d %R::>12} {t_remaining!F:>12h} "
                 "{contextual_time!F:>8h} {contextual_info}"
@@ -49,7 +49,7 @@ class FluxJobsConfig(UtilConfig):
         "deps": {
             "description": "Show job urgency, priority, and dependencies",
             "format": (
-                "{id.f58:>12} ?:{queue:<8.8} {name:<10.10} {urgency:<3} "
+                "{id.f58:>12} ?:{queue:<8.8} {name:<10.10+} {urgency:<3} "
                 "{priority:<12} {state:<8.8} {dependencies}"
             ),
         },

--- a/src/cmd/flux-resource.py
+++ b/src/cmd/flux-resource.py
@@ -462,7 +462,7 @@ def list_handler(args):
 
     # Only include properties list if properties exist in set:
     if resources.all.properties:
-        fmt += " {properties:<10.10}"
+        fmt += " {properties:<10.10+}"
     if args.verbose:
         fmt += " {nnodes:>6} {ncores:>8} {ngpus:>8} {rlist}"
     else:

--- a/t/t2350-resource-list.t
+++ b/t/t2350-resource-list.t
@@ -27,9 +27,8 @@ for input in ${SHARNESS_TEST_SRCDIR}/flux-resource/list/*.json; do
     '
 done
 
-test_expect_success 'flux resource list -no {properties} works' '
-	flux resource list -no {properties} \
-		--from-stdin <<-EOF >properties.out &&
+test_expect_success 'create test input with properties' '
+	cat <<-EOF >properties-test.in
 	{
 	  "all": {
 	    "version": 1,
@@ -97,6 +96,21 @@ test_expect_success 'flux resource list -no {properties} works' '
 	  }
 	}
 	EOF
+'
+
+test_expect_success 'flux resource list -no {properties} works' '
+	flux resource list -no {properties} \
+		--from-stdin <properties-test.in >properties.out &&
 	test $(cat properties.out) = "foo,xx"
+'
+test_expect_success 'flux resource list -no {properties:>4.4+} works' '
+	flux resource list -no "{properties:>5.5+}" \
+		--from-stdin <properties-test.in >properties-trunc.out &&
+	test_debug "cat properties-trunc.out" &&
+	test $(cat properties-trunc.out) = "foo,+" &&
+	flux resource list -no "{properties:>5.5h+}" \
+		--from-stdin <properties-test.in >properties-trunc+h.out &&
+	test_debug "cat properties-trunc+h.out" &&
+	test $(cat properties-trunc.out) = "foo,+"
 '
 test_done

--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -188,6 +188,13 @@ test_expect_success 'flux-jobs: collapsible fields work' '
 	test_must_fail grep EXCEPTION-TYPE collapsed.out
 '
 
+test_expect_success 'flux-jobs: request indication of truncation works' '
+	flux jobs -n -c1 -ano "{id.f58:<5.5+}" | grep + &&
+	flux jobs -n -c1 -ano "{id.f58:<5.5h+}" | grep + &&
+	flux jobs -n -c1 -ano "{id.f58:<20.20h+}" > notruncate.out &&
+	test_must_fail grep + notruncate.out
+'
+
 # TODO: need to submit jobs as another user and test -A again
 test_expect_success 'flux-jobs -a and -A works' '
 	nall=$(state_count all) &&


### PR DESCRIPTION
This PR (built on #4669) adds a way to request that truncation be indicated in output format strings, and adds that flag to the job `{name}` field for `flux jobs` builtin format strings, and the `{properties}` list for `flux resource list`.

 This is a WIP since I haven't yet added any testing since I wanted to make sure the approach was acceptable.