### PR TITLE
Add devcontainer environment for vscode

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,13 @@
+FROM fluxrm/testenv:focal
+
+LABEL maintainer="Vanessasaurus <@vsoch>"
+
+# For easier Pyton development. 
+# TODO add pre-commit installs here when added!
+RUN python3 -m pip install IPython && \
+    python3 -m pip install 'black==20.08.b1' --force-reinstall && \
+    python3 -m pip install 'pylint==2.4.4' --force-reinstall && \
+    python3 -m pip install 'mypy==0.770' --force-reinstall
+
+# Assuming installing to /usr/local
+ENV LD_LIBRARY_PATH=/usr/local/lib

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,16 @@
+{
+    "name": "Flux Core Python 3.6",
+    "dockerFile": "Dockerfile",
+  
+    "customizations": {
+      "vscode": {
+        "settings": {
+          "terminal.integrated.defaultProfile.linux": "bash"
+        }, 
+        // Note to Flux Developers! We can add extensions here that you like
+        "extensions": [],
+      },
+    },
+    // Needed for git security feature
+    "postStartCommand": "git config --global --add safe.directory /workspaces/core"    
+  }

--- a/README.md
+++ b/README.md
@@ -95,6 +95,56 @@ make
 make check
 ```
 
+##### VSCode Dev Containers
+
+If you use VSCode we have a [Dev Container](https://code.visualstudio.com/docs/remote/containers)
+provided via the assets in [.devcontainer](https://code.visualstudio.com/docs/remote/containers#_create-a-devcontainerjson-file).
+You can follow the [tutorial](https://code.visualstudio.com/docs/remote/containers-tutorial) where you'll basically
+need to:
+
+1. Install Docker
+2. Install the [Development Containers](vscode:extension/ms-vscode-remote.remote-containers) extension
+
+Then you can go to the command palette (View -> Command Palette) and select `Dev Containers: Open Workspace in Container.`
+and select your cloned Flux repository root. This will build a development environment from [fluxrm/testenv](https://hub.docker.com/r/fluxrm/testenv/tags)
+that are built from [src/test/docker](src/test/docker) (the focal tag) with a few tweaks to add linting tools. 
+You are free to change the base image and rebuild if you need to test on another operating system! 
+When your container is built, when you open `Terminal -> New Terminal`, surprise! You're
+in the container! The dependencies for building Flux are installed. Try building Flux - it will work without a hitch!
+
+```bash
+./autogen.sh
+./configure --prefix=/usr/local
+make
+# This will install in the container!
+make install
+```
+
+And try starting flux
+
+```bash
+flux start --test-size=4
+```
+
+Note that the above assumes installing flux to `/usr/local`. If you install elsewhere, you'll need to adjust your
+`LD_LIBRARY_PATH` or similar. IPython is provided in the container for Python development, along with other linting tools.
+If you ever need to rebuild, you can either restart VSCode and open in the same way (and it will give you the option)
+or you can do on demand in the command palette with `Dev Containers: Rebuild Container` (with or without cache).
+
+**Important** it's recommended that you commit (or otherwise write to the .git folder) from the outside
+of the container. The reason is two-fold - first, if you need to sign your commits, the container doesn't
+have access and won't be able to. Second, if you write to .git it will change permissions of the directory.
+If you accidentally do this and need to fix, you can run this from your terminal outside of VSCode:
+
+```bash
+$ sudo chown -R $USER .git/
+# and then commit
+```
+
+Hopefully we will find a workaround for this so everything works from inside of a VSCode terminal.
+For the time being, make sure you fix permissions and commit from outside the container on your local machine!
+
+
 #### Bootstrapping a Flux instance
 
 A Flux instance is composed of a set of `flux-broker` processes


### PR DESCRIPTION
Problem: it is hard to develop flux-core locally.

Solution: This addition will allow VSCode users to quickly run (and work in) a development container, defined under .devcontainer in the root, which contains a devcontainer.json file and a Dockerfile that uses the fluxrm/testenv:focal base to quickly pull and
spin up the container. We need the Dockerfile to support a post start command to fix a git security issue, and also add developer tools like formatters, linters, etc. This is a vanilla install, meaning it just will allow for build of the core flux, and as other developers try this out we can easily add other extensions that make the development experience better!

The one sticky bit was with git permissions - if you sign you can't commit from inside the container (no keys) and then when you go outside the container, having commit inside the container, you get a permissions issue (that can be fixed with a chown). Likely the best solution is just not to write to git (commit) from inside the container for now, and people can play around and see if there is a better way to go about it. I don't personally mind bringing up another terminal.

My thinking is that we can get a vanilla version in first, and then those that try it with VSCode that have preferences for extensions can propose adding them separately.

Signed-off-by: vsoch <vsoch@users.noreply.github.com>