### PR TITLE
broker: allow custom topology to be configured

### DIFF
--- a/doc/man5/flux-config-tbon.rst
+++ b/doc/man5/flux-config-tbon.rst
@@ -15,6 +15,13 @@ It may contain the following keys:
 KEYS
 ====
 
+topo
+   (optional) A URI that selects a specific tree topology.  The default value
+   is ``kary:2`` when bootstrapping from PMI, and ``custom`` when bootstrapping
+   from configuration, as described in :man5:`flux-config-bootstrap`.
+   The configured value may be overridden by setting the ``tbon.topo`` broker
+   attribute.
+
 torpid_min
    (optional) The amount of time (in RFC 23 Flux Standard Duration format) that
    a broker will allow the connection to its TBON parent to remain idle before

--- a/doc/man7/flux-broker-attributes.rst
+++ b/doc/man7/flux-broker-attributes.rst
@@ -152,10 +152,12 @@ config.path [Updates: see below]
 TREE BASED OVERLAY NETWORK
 ==========================
 
-tbon.fanout [Updates: C]
-   Branching factor of the tree based overlay network.  A value of ``0``
-   means the topology is "flat" (rank 0 is the parent of all other ranks).
-   Default: ``2``.
+tbon.topo [Updates: C]
+   URI describing the TBON tree topology such as ``kary:16``.  The ``kary``
+   scheme selects a complete, k-ary tree with fanout *k*.  By convention
+   ``kary:0`` means that rank 0 is the parent of all other ranks.  Default:
+   ``kary:2``, unless bootstrapping by TOML configuration, then see
+   :man5:`flux-config-bootstrap`.
 
 tbon.descendants
    Number of descendants "below" this node of the tree based

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -649,3 +649,4 @@ xdg
 XDG
 yaml
 enqueued
+kary

--- a/src/bindings/lua/flux-lua.c
+++ b/src/bindings/lua/flux-lua.c
@@ -235,18 +235,6 @@ static int l_flux_size (lua_State *L)
     return (l_pushresult (L, size));
 }
 
-static int l_flux_fanout (lua_State *L)
-{
-    flux_t *f = lua_get_flux (L, 1);
-    const char *s;
-    int fanout;
-
-    if (!(s = flux_attr_get (f, "tbon.fanout")))
-        return lua_pusherror (L, "flux_attr_get tbon.fanout error");
-    fanout = strtoul (s, NULL, 10);
-    return (l_pushresult (L, fanout));
-}
-
 static int l_flux_index (lua_State *L)
 {
     const char *key = lua_tostring (L, 2);
@@ -258,8 +246,6 @@ static int l_flux_index (lua_State *L)
         return l_flux_size (L);
     if (strcmp (key, "rank") == 0)
         return l_flux_rank (L);
-    if (strcmp (key, "fanout") == 0)
-        return l_flux_fanout (L);
 
     lua_getmetatable (L, 1);
     lua_getfield (L, -1, key);

--- a/src/broker/boot_config.c
+++ b/src/broker/boot_config.c
@@ -165,8 +165,9 @@ static json_t *boot_config_expand_hosts (json_t *hosts)
             goto error;
         }
         if (!(hl = hostlist_decode (host))) {
-            log_err ("Config file error [bootstrap]");
-            log_msg ("Hint: host value '%s' is not a valid hostlist", host);
+            log_msg ("Config file error [bootstrap]:"
+                     " host value '%s' is not a valid hostlist",
+                     host);
             goto error;
         }
         s = hostlist_first (hl);

--- a/src/broker/boot_pmi.c
+++ b/src/broker/boot_pmi.c
@@ -31,8 +31,6 @@
 #include "boot_pmi.h"
 #include "pmiutil.h"
 
-#define DEFAULT_FANOUT 2
-
 
 /*  If the broker is launched via flux-shell, then the shell may opt
  *  to set a "flux.instance-level" parameter in the PMI kvs to tell
@@ -180,7 +178,8 @@ static int set_hostlist_attr (attr_t *attrs, struct hostlist *hl)
 
 int boot_pmi (struct overlay *overlay, attr_t *attrs)
 {
-    uint32_t fanout;
+    const char *topo_uri;
+    flux_error_t error;
     char key[64];
     char val[1024];
     char hostname[MAXHOSTNAMELEN + 1];
@@ -195,21 +194,12 @@ int boot_pmi (struct overlay *overlay, attr_t *attrs)
     int result;
     const char *uri;
     int i;
-    char topo_uri[32];
 
-    /* Fetch the tbon.fanout attribute and supply a default value if unset.
-     */
-    if (attr_get_uint32 (attrs, "tbon.fanout", &fanout) < 0)
-        fanout = DEFAULT_FANOUT;
-    else
-        (void)attr_delete (attrs, "tbon.fanout", true);
-    if (attr_add_uint32 (attrs,
-                         "tbon.fanout",
-                         fanout,
-                         FLUX_ATTRFLAG_IMMUTABLE) < 0)
+    // N.B. overlay_create() sets the tbon.topo attribute
+    if (attr_get (attrs, "tbon.topo", &topo_uri, NULL) < 0) {
+        log_msg ("error fetching tbon.topo attribute");
         return -1;
-
-
+    }
     memset (&pmi_params, 0, sizeof (pmi_params));
     if (!(pmi = broker_pmi_create ())) {
         log_err ("broker_pmi_create");
@@ -233,9 +223,11 @@ int boot_pmi (struct overlay *overlay, attr_t *attrs)
         log_err ("error setting broker.mapping attribute");
         goto error;
     }
-    snprintf (topo_uri, sizeof (topo_uri), "kary:%d", fanout);
-    if (!(topo = topology_create (topo_uri, pmi_params.size, NULL))
-        || topology_set_rank (topo, pmi_params.rank) < 0
+    if (!(topo = topology_create (topo_uri, pmi_params.size, &error))) {
+        log_msg ("error creating '%s' topology: %s", topo_uri, error.text);
+        goto error;
+    }
+    if (topology_set_rank (topo, pmi_params.rank) < 0
         || overlay_set_topology (overlay, topo) < 0)
         goto error;
     if (gethostname (hostname, sizeof (hostname)) < 0) {

--- a/src/broker/boot_pmi.c
+++ b/src/broker/boot_pmi.c
@@ -195,6 +195,7 @@ int boot_pmi (struct overlay *overlay, attr_t *attrs)
     int result;
     const char *uri;
     int i;
+    char topo_uri[32];
 
     /* Fetch the tbon.fanout attribute and supply a default value if unset.
      */
@@ -232,8 +233,8 @@ int boot_pmi (struct overlay *overlay, attr_t *attrs)
         log_err ("error setting broker.mapping attribute");
         goto error;
     }
-    if (!(topo = topology_create (pmi_params.size))
-        || topology_set_kary (topo, fanout) < 0
+    snprintf (topo_uri, sizeof (topo_uri), "kary:%d", fanout);
+    if (!(topo = topology_create (topo_uri, pmi_params.size, NULL))
         || topology_set_rank (topo, pmi_params.rank) < 0
         || overlay_set_topology (overlay, topo) < 0)
         goto error;

--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -280,7 +280,11 @@ int overlay_set_topology (struct overlay *ov, struct topology *topo)
             child->tracker = rpc_track_create (MSG_HASH_TYPE_UUID_MATCHTAG);
             if (!child->tracker)
                 return -1;
-            if (topology_aux_set (topo, child->rank, "child", child, NULL) < 0)
+            if (topology_rank_aux_set (topo,
+                                       child->rank,
+                                       "child",
+                                       child,
+                                       NULL) < 0)
                 return -1;
         }
         ov->status = SUBTREE_STATUS_PARTIAL;
@@ -446,7 +450,7 @@ bool overlay_msg_is_local (const flux_msg_t *msg)
  */
 static struct child *child_lookup_byrank (struct overlay *ov, uint32_t rank)
 {
-    return topology_aux_get (ov->topo, rank, "child");
+    return topology_rank_aux_get (ov->topo, rank, "child");
 }
 
 /* Look up child that provides route to 'rank' (NULL if none).

--- a/src/broker/test/boot_config.c
+++ b/src/broker/test/boot_config.c
@@ -280,7 +280,6 @@ void test_bad_host_bind (const char *dir)
     flux_conf_t *cf;
     struct boot_conf conf;
     json_t *hosts;
-    char uri[MAX_URI + 1];
     const char *input = \
 "[bootstrap]\n" \
 "hosts = [\n" \
@@ -291,13 +290,8 @@ void test_bad_host_bind (const char *dir)
     if (!(cf = flux_conf_parse (dir, NULL)))
         BAIL_OUT ("flux_conf_parse failed");
 
-    /* hosts will initially parse OK then fail in getbindbyrank */
-    if (boot_config_parse (cf, &conf, &hosts) < 0)
-        BAIL_OUT ("boot_config_parse unexpectedly failed");
-    ok (boot_config_getbindbyrank (hosts, &conf, 0, uri, sizeof (uri)) < 0,
-        "boot_config_getbindbyrank failed on host entry with wrong bind type");
-
-    json_decref (hosts);
+    ok (boot_config_parse (cf, &conf, &hosts) < 0,
+        "boot_config_parse failed on host entry with wrong bind type");
 
     if (unlink (path) < 0)
         BAIL_OUT ("could not cleanup test file %s", path);
@@ -305,6 +299,30 @@ void test_bad_host_bind (const char *dir)
     flux_conf_decref (cf);
 }
 
+void test_bad_host_key (const char *dir)
+{
+    char path[PATH_MAX + 1];
+    flux_conf_t *cf;
+    struct boot_conf conf;
+    json_t *hosts;
+    const char *input = \
+"[bootstrap]\n" \
+"hosts = [\n" \
+"  { host=\"foo\", wrongkey=42 },\n" \
+"]\n";
+
+    create_test_file (dir, "boot", path, sizeof (path), input);
+    if (!(cf = flux_conf_parse (dir, NULL)))
+        BAIL_OUT ("flux_conf_parse failed");
+
+    ok (boot_config_parse (cf, &conf, &hosts) < 0,
+        "boot_config_parse failed on host entry with unknown key");
+
+    if (unlink (path) < 0)
+        BAIL_OUT ("could not cleanup test file %s", path);
+
+    flux_conf_decref (cf);
+}
 
 /* Just double check that an array with mismatched types
  * fails early with the expected libtomlc99 error.
@@ -622,6 +640,7 @@ int main (int argc, char **argv)
     test_bad_hosts_entry (dir);
     test_bad_host_hostlist (dir);
     test_bad_host_bind (dir);
+    test_bad_host_key (dir);
     test_empty (dir);
     test_empty_hosts (dir);
     test_missing_info (dir);

--- a/src/broker/test/topology.c
+++ b/src/broker/test/topology.c
@@ -517,27 +517,30 @@ void test_invalid (void)
         "topology_get_json_subtree_at rank=-1 fails with EINVAL");
 
     errno = 0;
-    ok (topology_aux_get (NULL, 0, "foo") == NULL && errno == EINVAL,
-        "topology_aux_get topo=NULL fails with EINVAL");
+    ok (topology_rank_aux_get (NULL, 0, "foo") == NULL && errno == EINVAL,
+        "topology_rank_aux_get topo=NULL fails with EINVAL");
     errno = 0;
-    ok (topology_aux_get (topo, -1, "foo") == NULL && errno == EINVAL,
-        "topology_aux_get rank=-1 fails with EINVAL");
+    ok (topology_rank_aux_get (topo, -1, "foo") == NULL && errno == EINVAL,
+        "topology_rank_aux_get rank=-1 fails with EINVAL");
     errno = 0;
-    ok (topology_aux_get (topo, 99, "foo") == NULL && errno == EINVAL,
-        "topology_aux_get rank=99 fails with EINVAL");
+    ok (topology_rank_aux_get (topo, 99, "foo") == NULL && errno == EINVAL,
+        "topology_rank_aux_get rank=99 fails with EINVAL");
     errno = 0;
-    ok (topology_aux_get (topo, 0, "foo") == NULL && errno == ENOENT,
-        "topology_aux_get key=unknown fails with ENOENT");
+    ok (topology_rank_aux_get (topo, 0, "foo") == NULL && errno == ENOENT,
+        "topology_rank_aux_get key=unknown fails with ENOENT");
 
     errno = 0;
-    ok (topology_aux_set (NULL, 0, "foo", "bar", NULL) < 0 && errno == EINVAL,
-        "topology_aux_set topo=NULL fails with EINVAL");
+    ok (topology_rank_aux_set (NULL, 0, "foo", "bar", NULL) < 0
+        && errno == EINVAL,
+        "topology_rank_aux_set topo=NULL fails with EINVAL");
     errno = 0;
-    ok (topology_aux_set (topo, -1, "foo", "bar", NULL) < 0 && errno == EINVAL,
-        "topology_aux_set rank=-1 fails with EINVAL");
+    ok (topology_rank_aux_set (topo, -1, "foo", "bar", NULL) < 0
+        && errno == EINVAL,
+        "topology_rank_aux_set rank=-1 fails with EINVAL");
     errno = 0;
-    ok (topology_aux_set (topo, 99, "foo", "bar", NULL) < 0 && errno == EINVAL,
-        "topology_aux_set rank=99 fails with EINVAL");
+    ok (topology_rank_aux_set (topo, 99, "foo", "bar", NULL) < 0
+        && errno == EINVAL,
+        "topology_rank_aux_set rank=99 fails with EINVAL");
 
     errno = 0;
     ok (topology_get_internal_ranks (NULL) == NULL && errno == EINVAL,
@@ -546,7 +549,7 @@ void test_invalid (void)
     topology_decref (topo);
 }
 
-void test_aux (void)
+void test_rank_aux (void)
 {
     struct topology *topo;
     int errors;
@@ -556,20 +559,20 @@ void test_aux (void)
 
     errors = 0;
     for (int i = 0; i < 16; i++) {
-        if (topology_aux_set (topo, i, "rank", int2ptr (i + 1), NULL) < 0)
+        if (topology_rank_aux_set (topo, i, "rank", int2ptr (i + 1), NULL) < 0)
             errors++;
     }
     ok (errors == 0,
-        "topology_aux_set works for all ranks");
+        "topology_rank_aux_set works for all ranks");
     errors = 0;
     for (int i = 0; i < 16; i++) {
         void *ptr;
-        if (!(ptr = (topology_aux_get (topo, i, "rank")))
+        if (!(ptr = (topology_rank_aux_get (topo, i, "rank")))
             || ptr2int (ptr) != i + 1)
             errors++;
     }
     ok (errors == 0,
-        "topology_aux_get returns expected result for all ranks");
+        "topology_rank_aux_get returns expected result for all ranks");
 
     topology_decref (topo);
 }
@@ -585,7 +588,7 @@ int main (int argc, char *argv[])
     test_invalid ();
     test_internal_ranks ();
     test_custom ();
-    test_aux ();
+    test_rank_aux ();
 
     done_testing ();
 }

--- a/src/broker/topology.c
+++ b/src/broker/topology.c
@@ -151,7 +151,7 @@ int topology_set_rank (struct topology *topo, int rank)
     return 0;
 }
 
-void *topology_aux_get (struct topology *topo, int rank, const char *name)
+void *topology_rank_aux_get (struct topology *topo, int rank, const char *name)
 {
     if (!topo || rank < 0 || rank >= topo->size) {
         errno = EINVAL;
@@ -160,11 +160,11 @@ void *topology_aux_get (struct topology *topo, int rank, const char *name)
     return aux_get (topo->node[rank].aux, name);
 }
 
-int topology_aux_set (struct topology *topo,
-                      int rank,
-                      const char *name,
-                      void *val,
-                      flux_free_f destroy)
+int topology_rank_aux_set (struct topology *topo,
+                           int rank,
+                           const char *name,
+                           void *val,
+                           flux_free_f destroy)
 {
     if (!topo || rank < 0 || rank >= topo->size) {
         errno = EINVAL;

--- a/src/broker/topology.h
+++ b/src/broker/topology.h
@@ -17,16 +17,19 @@
 #include <flux/idset.h>
 
 /* Create/destroy tree topology of size.
- * The initial topology is "flat" (rank 0 is parent of all other ranks),
+ * The default topology is "flat" (rank 0 is parent of all other ranks),
  * and queries are from the perspective of rank 0.
+ * If uri is non-NULL, the scheme selects a topology type, and the path
+ * provides additional detail.  The following schemes are available:
+ *
+ * kary:K
+ * Set the topology to a complete k-ary tree with fanout K.
  */
-struct topology *topology_create (int size);
+struct topology *topology_create (const char *uri,
+                                  int size,
+                                  flux_error_t *error);
 void topology_decref (struct topology *topo);
 struct topology *topology_incref (struct topology *topo);
-
-/* Configure topology as a complete k-ary tree with fanout k
- */
-int topology_set_kary (struct topology *topo, int k);
 
 /* Set "my rank", which provides the point of view for queries.
  */
@@ -58,6 +61,13 @@ json_t *topology_get_json_subtree_at (struct topology *topo, int rank);
 /*  Return internal ranks (ranks that have one or more children)
  */
 struct idset *topology_get_internal_ranks (struct topology *topo);
+
+/* Plugins
+ */
+struct topology_plugin {
+    const char *name;
+    int (*init)(struct topology *topo, const char *path, flux_error_t *error);
+};
 
 #endif /* !_BROKER_TOPOLOGY_H */
 

--- a/src/broker/topology.h
+++ b/src/broker/topology.h
@@ -62,6 +62,8 @@ json_t *topology_get_json_subtree_at (struct topology *topo, int rank);
  */
 struct idset *topology_get_internal_ranks (struct topology *topo);
 
+void topology_hosts_set (json_t *hosts);
+
 /* Plugins
  */
 struct topology_plugin {

--- a/src/broker/topology.h
+++ b/src/broker/topology.h
@@ -37,12 +37,12 @@ int topology_set_rank (struct topology *topo, int rank);
 
 /* Associate aux data with rank for lookup in O(1*rank_aux_elements)
  */
-void *topology_aux_get (struct topology *topo, int rank, const char *name);
-int topology_aux_set (struct topology *topo,
-                      int rank,
-                      const char *name,
-                      void *aux,
-                      flux_free_f destroy);
+void *topology_rank_aux_get (struct topology *topo, int rank, const char *name);
+int topology_rank_aux_set (struct topology *topo,
+                           int rank,
+                           const char *name,
+                           void *aux,
+                           flux_free_f destroy);
 
 /* Queries
  */

--- a/src/connectors/loop/loop.c
+++ b/src/connectors/loop/loop.c
@@ -107,11 +107,10 @@ flux_t *connector_init (const char *path, int flags, flux_error_t *errp)
         goto error;
     if (!(c->h = flux_handle_create (c, &handle_ops, flags)))
         goto error;
-    /* Fake out size, rank, tbon.fanout attributes for testing.
+    /* Fake out size, rank attributes for testing.
      */
     if (flux_attr_set_cacheonly(c->h, "rank", "0") < 0
-                || flux_attr_set_cacheonly (c->h, "size", "1") < 0
-                || flux_attr_set_cacheonly (c->h, "tbon.fanout", "2") < 0)
+                || flux_attr_set_cacheonly (c->h, "size", "1") < 0)
         goto error;
     c->cred.userid = getuid ();
     c->cred.rolemask = FLUX_ROLE_OWNER;

--- a/t/issues/t3906-job-exec-exception.sh
+++ b/t/issues/t3906-job-exec-exception.sh
@@ -7,7 +7,7 @@
 #  3. Ensure job exception is raised and includes appropriate error note
 #
 export startctl="flux python ${SHARNESS_TEST_SRCDIR}/scripts/startctl.py"
-SHELL=/bin/sh flux start -s 4 -o,-Stbon.fanout=4 --test-exit-mode=leader '\
+SHELL=/bin/sh flux start -s 4 -o,-Stbon.topo=kary:4 --test-exit-mode=leader '\
    id=$(flux mini submit -n4 -N4 sleep 300) \
 && flux job wait-event $id start \
 && $startctl kill 3 9 \

--- a/t/issues/t3960-job-exec-ehostunreach.sh
+++ b/t/issues/t3960-job-exec-ehostunreach.sh
@@ -12,7 +12,7 @@
 #
 #
 export startctl="flux python ${SHARNESS_TEST_SRCDIR}/scripts/startctl.py"
-SHELL=/bin/sh flux start -s 4 -o,-Stbon.fanout=4 --test-exit-mode=leader '\
+SHELL=/bin/sh flux start -s 4 -o,-Stbon.topo=kary:4 --test-exit-mode=leader '\
    id=$(flux mini submit -n4 -N4 sleep 300) \
 && flux job wait-event $id start \
 && $startctl kill 3 19 \

--- a/t/issues/t4583-free-range-test.sh
+++ b/t/issues/t4583-free-range-test.sh
@@ -31,12 +31,12 @@ if test "$FREE_RANGE_TEST_ACTIVE" != "t"; then
     exec flux start -s 4 \
         --test-exit-mode=leader \
         --test-pmi-clique=per-broker \
-        -o -Stbon.fanout=0 $0
+        -o -Stbon.topo=kary:0 $0
 fi
 
-#  Start a job with tbon.fanout=0
+#  Start a job with tbon.topo=kary:0
 log "Starting a child instance with flat topology\n"
-jobid=$(flux mini alloc -N4 --bg --broker-opts=-Stbon.fanout=0)
+jobid=$(flux mini alloc -N4 --bg --broker-opts=-Stbon.topo=kary:0)
 
 log "Started job $jobid\n"
 

--- a/t/lua/t0002-rpc.t
+++ b/t/lua/t0002-rpc.t
@@ -5,7 +5,7 @@
 local test = require 'fluxometer'.init (...)
 test:start_session { size=2 }
 
-plan (19)
+plan (18)
 
 local flux = require_ok ('flux')
 local f, err = flux.new()
@@ -14,7 +14,6 @@ is (err, nil, "error is nil")
 
 is (f.rank, 0, "running on rank 0")
 is (f.size, 2, "session size is 2")
-is (f.fanout, 2, "session fanout is 2")
 
 --
 --  Use 'ping' packet to test rpc

--- a/t/sharness.d/flux-sharness.sh
+++ b/t/sharness.d/flux-sharness.sh
@@ -120,7 +120,7 @@ make_bootstrap_config() {
     echo "--test-exit-timeout=${TEST_UNDER_FLUX_EXIT_TIMEOUT:-0}"
     echo "-o,-Sbroker.quorum=${TEST_UNDER_FLUX_QUORUM:-$full}"
     echo "--test-start-mode=${TEST_UNDER_FLUX_START_MODE:-all}"
-    echo "-o,-Stbon.fanout=${TEST_UNDER_FLUX_FANOUT:-$size}"
+    echo "-o,-Stbon.topo=${TEST_UNDER_FLUX_TOPO:-custom}"
     echo "-o,-Stbon.zmqdebug=1"
     echo "-o,-Sstatedir=$workdir/state"
 }
@@ -176,8 +176,8 @@ remove_trashdir_wrapper() {
 #        Set the broker.quorum attribute (default: 0-<highest_rank>)
 #    - TEST_UNDER_FLUX_START_MODE
 #        Set the flux-start start mode (default: all)
-#    - TEST_UNDER_FLUX_FANOUT
-#        Set the TBON fanout (default: size (flat))
+#    - TEST_UNDER_FLUX_TOPO
+#        Set the TBON topology (default: custom (flat))
 #
 test_under_flux() {
     size=${1:-1}

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -491,14 +491,26 @@ test_expect_success 'broker broker.pid attribute is immutable' '
 test_expect_success 'broker --verbose option works' '
 	flux start ${ARGS} -o,-v /bin/true
 '
-test_expect_success 'broker -Stbon.fanout=4 option works' '
-	echo 4 >fanout.exp &&
+test_expect_success 'broker -Stbon.fanout=4 is an alias for tbon.topo=kary:4' '
+	echo kary:4 >fanout.exp &&
 	flux start ${ARGS} -o,-Stbon.fanout=4 \
-		flux getattr tbon.fanout >fanout.out &&
+		flux getattr tbon.topo >fanout.out &&
 	test_cmp fanout.exp fanout.out
 '
-test_expect_success 'broker -Stbon.fanout=0 works' '
-	flux start ${ARGS} -o,-Stbon.fanout=0 /bin/true
+test_expect_success 'broker -Stbon.topo=kary:8 option works' '
+	echo kary:8 >topo.exp &&
+	flux start ${ARGS} -o,-Stbon.topo=kary:8 \
+		flux getattr tbon.topo >topo.out &&
+	test_cmp topo.exp topo.out
+'
+test_expect_success 'broker -Stbon.topo=kary:0 works' '
+	flux start ${ARGS} -o,-Stbon.topo=kary:0 /bin/true
+'
+test_expect_success 'broker -Stbon.topo=custom option works' '
+	echo custom >topo2.exp &&
+	flux start ${ARGS} -o,-Stbon.topo=custom \
+		flux getattr tbon.topo >topo2.out &&
+	test_cmp topo2.exp topo2.out
 '
 test_expect_success 'broker fails on invalid broker.critical-ranks option' '
 	test_must_fail flux start ${ARGS} -o,-Sbroker.critical-ranks=0-1

--- a/t/t0013-config-file.t
+++ b/t/t0013-config-file.t
@@ -458,5 +458,48 @@ test_expect_success 'tbon.torpid_max configured with wrong type fails' '
 		/bin/true 2>badtorpid.err &&
 	grep "Expected string" badtorpid.err
 '
+test_expect_success 'tbon.topo with unknown scheme fails' '
+	mkdir conf23 &&
+	cat <<-EOT >conf23/tbon.toml &&
+	[tbon]
+	topo = "notascheme:42"
+	EOT
+	test_must_fail flux broker ${ARGS} -c conf23 \
+		/bin/true 2>badscheme.err &&
+	grep "unknown topology scheme" badscheme.err
+'
+test_expect_success 'tbon.topo is kary:2 by default' '
+	echo "kary:2" >topo.exp &&
+	flux broker ${ARGS} flux getattr tbon.topo >topo.out &&
+	test_cmp topo.exp topo.out
+'
+test_expect_success 'tbon.topo can be changed by configuration' '
+	mkdir conf24 &&
+	cat <<-EOT >conf24/tbon.toml &&
+	[tbon]
+	topo = "kary:8"
+	EOT
+	echo "kary:8" >topo2.exp &&
+	flux broker ${ARGS} -c conf24 \
+		flux getattr tbon.topo >topo2.out &&
+	test_cmp topo2.exp topo2.out
+'
+test_expect_success 'tbon.topo can be overridden on the command line' '
+	echo "kary:16" >topo3.exp &&
+	flux broker ${ARGS} -c conf24 -Stbon.topo=kary:16 \
+		flux getattr tbon.topo >topo3.out &&
+	test_cmp topo3.exp topo3.out
+'
+test_expect_success 'tbon.topo is custom when bootstrap is configured' '
+	mkdir conf25 &&
+	cat <<-EOT >conf25/bootstrap.toml &&
+	[bootstrap]
+	EOT
+	echo "custom" >topo4.exp &&
+	flux broker ${ARGS} -c conf25 \
+		flux getattr tbon.topo >topo4.out &&
+	test_cmp topo4.exp topo4.out
+'
+
 
 test_done

--- a/t/t0013-config-file.t
+++ b/t/t0013-config-file.t
@@ -79,6 +79,39 @@ test_expect_success '[bootstrap] config with bad hosts array element' '
 	test_must_fail flux broker ${ARGS} -c conf4 /bin/true
 '
 
+test_expect_success '[bootstrap] config with hosts array element with extra key' '
+	mkdir conf4a &&
+	cat <<-EOT >conf4a/bootstrap.toml &&
+	[bootstrap]
+	hosts = [
+	    { host = "xyz", extrakey = 42 },
+	]
+	EOT
+	test_must_fail flux broker ${ARGS} -c conf4a /bin/true
+'
+
+test_expect_success '[bootstrap] config with hosts array element missing host' '
+	mkdir conf4b &&
+	cat <<-EOT >conf4b/bootstrap.toml &&
+	[bootstrap]
+	hosts = [
+	    { },
+	]
+	EOT
+	test_must_fail flux broker ${ARGS} -c conf4b /bin/true
+'
+
+test_expect_success '[bootstrap] config with bad hostlist' '
+	mkdir conf4c &&
+	cat <<-EOT >conf4c/bootstrap.toml &&
+	[bootstrap]
+	hosts = [
+	    { host = "foo[0-254}" },
+	]
+	EOT
+	test_must_fail flux broker ${ARGS} -c conf4c /bin/true
+'
+
 test_expect_success '[bootstrap] config with hostname not found' '
 	mkdir conf5 &&
 	cat <<-EOT >conf5/bootstrap.toml &&

--- a/t/t0013-config-file.t
+++ b/t/t0013-config-file.t
@@ -185,10 +185,12 @@ test_expect_success 'start size=2 instance with ipc://' '
 	cat <<-EOT >conf8/bootstrap.toml &&
 	[bootstrap]
 	curve_cert = "testcert"
-	hosts = [
-	    { host="fake0", bind="ipc://${BINDDIR}/test-ipc2-0", connect="ipc://${BINDDIR}/test-ipc2-0" },
-	    { host="fake1" }
-	]
+	[[bootstrap.hosts]]
+	host = "fake0"
+	bind = "ipc://${BINDDIR}/test-ipc2-0"
+	connect = "ipc://${BINDDIR}/test-ipc2-0"
+	[[bootstrap.hosts]]
+	host = "fake1"
 	EOT
 	flux start -s2 --test-hosts=fake[0-1] \
 		-o,-Sbroker.rc1_path=,-Sbroker.rc3_path= \
@@ -213,11 +215,11 @@ test_expect_success 'start size=3 instance with ipc:// and custom topology' '
 	bind = "ipc://${BINDDIR}/fake0"
 	connect = "ipc://${BINDDIR}/fake0"
 	[[bootstrap.hosts]]
-	host="fake1"
+	host = "fake1"
 	bind = "ipc://${BINDDIR}/fake1"
 	connect = "ipc://${BINDDIR}/fake1"
 	[[bootstrap.hosts]]
-	host="fake2"
+	host = "fake2"
 	parent = "fake1"
 	EOT
 	flux start --test-size=3 --test-hosts=fake[0-2] \
@@ -240,11 +242,16 @@ test_expect_success 'start size=4 instance with tcp://' '
 	cat <<-EOT >conf9/bootstrap.toml &&
 	[bootstrap]
 	curve_cert = "testcert"
-	hosts = [
-	    { host="fake0", bind="tcp://127.0.0.1:$PORT1", connect="tcp://127.0.0.1:$PORT1" },
-	    { host="fake1", bind="tcp://127.0.0.1:$PORT2", connect="tcp://127.0.0.1:$PORT2" },
-	    { host="fake[2-3]" }
-	]
+	[[bootstrap.hosts]]
+	host = "fake0"
+	bind = "tcp://127.0.0.1:$PORT1"
+	connect = "tcp://127.0.0.1:$PORT1"
+	[[bootstrap.hosts]]
+	host = "fake1"
+	bind = "tcp://127.0.0.1:$PORT2"
+	connect ="tcp://127.0.0.1:$PORT2"
+	[[bootstrap.hosts]]
+	host = "fake[2-3]"
 	EOT
 	flux start -s4 --test-hosts=fake[0-3] \
 		-o,-Sbroker.rc1_path=,-Sbroker.rc3_path= \

--- a/t/t3302-system-offline.t
+++ b/t/t3302-system-offline.t
@@ -11,7 +11,7 @@ confirm that the user gets a reasonable error.
 
 . `dirname $0`/sharness.sh
 
-export TEST_UNDER_FLUX_FANOUT=1
+export TEST_UNDER_FLUX_TOPO=kary:1
 export TEST_UNDER_FLUX_QUORUM=0
 export TEST_UNDER_FLUX_START_MODE=leader
 

--- a/t/t3303-system-healthcheck.t
+++ b/t/t3303-system-healthcheck.t
@@ -11,7 +11,7 @@ through their paces.
 
 . `dirname $0`/sharness.sh
 
-export TEST_UNDER_FLUX_FANOUT=2
+export TEST_UNDER_FLUX_TOPO=kary:2
 
 test_under_flux 15 system
 

--- a/t/t3304-system-rpctrack-down.t
+++ b/t/t3304-system-rpctrack-down.t
@@ -10,7 +10,7 @@ the RPC goes down, either nicely, or a hard crash.
 
 . `dirname $0`/sharness.sh
 
-export TEST_UNDER_FLUX_FANOUT=1
+export TEST_UNDER_FLUX_TOPO=kary:1
 
 test_under_flux 3 system
 

--- a/t/t3305-system-rpctrack-up.t
+++ b/t/t3305-system-rpctrack-up.t
@@ -13,7 +13,7 @@ commands/RPCs through their paces.
 
 . `dirname $0`/sharness.sh
 
-export TEST_UNDER_FLUX_FANOUT=2
+export TEST_UNDER_FLUX_TOPO=kary:2
 
 test_under_flux 15 system
 

--- a/t/t3306-system-routercrash.t
+++ b/t/t3306-system-routercrash.t
@@ -13,7 +13,7 @@ This test verifies that the invariant holds when ther router crashes.
 
 . `dirname $0`/sharness.sh
 
-export TEST_UNDER_FLUX_FANOUT=1
+export TEST_UNDER_FLUX_TOPO=kary:1
 
 test_under_flux 3 system
 


### PR DESCRIPTION
As discussed in #3799, this adds an optional "parent" key to `[bootstrap]` hosts array entries so that a custom topology can be expressed.  Here's an example from a tiny test cluster:
```toml
hosts = [
    { host = "picl0" },
    { host = "picl[1-2]", parent = "picl0" },
    { host = "picl[3-5]", parent = "picl1" },
    { host = "picl[6-7]", parent = "picl2" },
]
```
```
 garlick@picl0:~$ flux overlay status
0 picl0: full
├─ 1 picl1: full
│  ├─ 3 picl3: full
│  ├─ 4 picl4: full
│  └─ 5 picl5: full
└─ 2 picl2: full
   ├─ 6 picl6: full
   └─ 7 picl7: full
```
A larger cluster that preserves the mapping of ranks to hostname suffixes while using non consecutive nodes as routers as might be done in a system with scalable units:
```toml
[[bootstrap.hosts]]
host = "test[0-127]"

[[bootstrap.hosts]]
host = "test[1,64]"
parent = "test0"
[[bootstrap.hosts]]
host = "test[2-63]"
parent = "test1"
[[bootstrap.hosts]]
host = "test[65-127]"
parent = "test64"
```