### PR TITLE
broker: ignore ENOSYS from parent job-exec.critical-ranks RPC

### DIFF
--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -1117,7 +1117,7 @@ static int execute_parental_notifications (struct broker *ctx)
         log_err ("job-manager.memo uri");
         goto out;
     }
-    if (flux_future_get (f2, NULL) < 0) {
+    if (flux_future_get (f2, NULL) < 0 && errno != ENOSYS) {
         log_err ("job-exec.critical-ranks");
         goto out;
     }


### PR DESCRIPTION
Problem: A broker that supports sending its critical ranks to the parent via the job-exec.critical-ranks RPC can't be launched under an older Flux instance that doesn't support this RPC.

Ignore ENOSYS errors from the job-exec.critical-ranks RPC. It should not be a fatal error if this RPC fails.

Fixes #4679