### PR TITLE
Vscode setup

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -6,9 +6,20 @@ LABEL maintainer="Vanessasaurus <@vsoch>"
 RUN apt-get update
 COPY scripts/requirements-dev.txt /requirements.txt
 
-# For easier Python development. 
+# For easier Python development.
 RUN python3 -m pip install IPython && \
     python3 -m pip install -r /requirements.txt
 
 # Assuming installing to /usr/local
 ENV LD_LIBRARY_PATH=/usr/local/lib
+
+# Assuming installing to /usr/local
+ENV LD_LIBRARY_PATH=/usr/local/lib
+
+# extra interactive utilities and compilation_database generation
+RUN apt-get update \
+ && apt-get -qq install -y --no-install-recommends \
+    bear \
+    ripgrep \
+    fd-find \
+    gdb

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,14 +18,22 @@
             "/usr/local/lib/flux/python3.8",
             "/usr/local/lib/python3.8/site-packages",
             "/workspaces/flux-core/src/bindings/python"
-          ]      
-        }, 
+          ]
+        },
         // Note to Flux Developers! We can add extensions here that you like
         "extensions": [
-			"ms-python.python"
-		],
-      },
+          "ms-vscode.cpptools", // C and C++ support
+          "sumneko.lua", // Lua support
+          "ms-python.python", // Python support
+          "GitHub.vscode-pull-request-github", // manage and review PRs
+        ]
+      }
     },
-    // Needed for git security feature (this assumes you locally cloned to flux-core)
-    "postStartCommand": "git config --global --add safe.directory /workspaces/flux-core"    
-  }
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": "latest"
+    }
+  },
+  // Needed for git security feature (this assumes you locally cloned to flux-core)
+  "postStartCommand": "git config --global --add safe.directory /workspaces/flux-core"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -95,7 +95,6 @@ compile_commands.json
 compile_flags.txt
 
 # local editor config dirs
-.vscode
 .idea
 .clangd
 

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,0 +1,29 @@
+{
+    "configurations": [
+        {
+            "name": "Linux arm64",
+            "includePath": [
+                "${workspaceFolder}/**"
+            ],
+            "defines": [],
+            "compilerPath": "/usr/bin/gcc",
+            "cStandard": "c99",
+            "cppStandard": "c++14",
+            "intelliSenseMode": "linux-gcc-arm64",
+            "compileCommands": "",
+            "mergeConfigurations": false
+        },
+        {
+            "name": "Linux amd64",
+            "includePath": [
+                "${workspaceFolder}/**"
+            ],
+            "defines": [],
+            "compilerPath": "/usr/bin/gcc",
+            "cStandard": "c99",
+            "cppStandard": "c++14",
+            "intelliSenseMode": "linux-gcc-x64",
+        }
+    ],
+    "version": 4
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+    "recommendations": [
+        "ms-vscode.cpptools",
+        "github.vscode-pull-request-github",
+        "sumneko.lua",
+        "ms-python.python"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,34 @@
+{
+    "python.defaultInterpreterPath": "python3",
+    "python.autoComplete.extraPaths": [
+        "./build/src/bindings/python",
+        "./src/bindings/python",
+        "./t/python/tap",
+    ],
+    "python.analysis.extraPaths": [
+        "./build/src/bindings/python",
+        "./src/bindings/python",
+        "./t/python/tap",
+    ],
+    "Lua.runtime.path": [
+        "?.lua",
+        "?/init.lua",
+        "${workspaceFolder}/src/bindings/lua/?.lua",
+        "${workspaceFolder}/src/bindings/lua/?/init.lua"
+    ],
+    "files.associations": {
+        "**/lua/**/*.t": "lua",
+        "*.t": "shellscript"
+    },
+    "C_Cpp.autoAddFileAssociations": false,
+    "Lua.completion.autoRequire": true,
+    "Lua.diagnostics.globals": [
+        "shell",
+        "plugin",
+        "task"
+    ],
+    "python.formatting.provider": "black",
+    "python.linting.flake8Enabled": true,
+    "python.linting.enabled": true,
+    "python.linting.mypyEnabled": true,
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,54 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "configure",
+            "type": "shell",
+            "command": "libtoolize --automake --copy && autoreconf --verbose --install && ./configure --prefix=$(pwd)/install",
+            "group": {
+                "kind": "build",
+                "isDefault": false
+            }
+        },
+        {
+            "label": "make",
+            "type": "shell",
+            "command": "env SHELL=/bin/sh make -j 8 all V=1",
+            "problemMatcher": [
+                "$gcc"
+            ],
+            "group": {
+                "kind": "build",
+                "isDefault": false
+            }
+        },
+        {
+            "label": "check",
+            "type": "shell",
+            "command": "env SHELL=/bin/sh make -j 8 check V=1 VERBOSE=1",
+            "problemMatcher": [
+                "$gcc",
+                {
+                    "owner": "automake",
+                    "fileLocation": [
+                        "relative",
+                        "${workspaceFolder}/t/"
+                    ],
+                    "pattern": [{
+                        "kind": "file",
+                        "regexp": "^([FE][^\\s:]*):\\s+([^\\s]+)\\s+(\\d+)\\s+(.*)$",
+                        "severity": 1,
+                        "file": 2,
+                        "message": 4
+                    }]
+                }
+            ],
+            "group": {
+                "kind": "test",
+                "isDefault": true
+            }
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -99,16 +99,30 @@ make check
 
 If you use VSCode we have a [Dev Container](https://code.visualstudio.com/docs/remote/containers)
 provided via the assets in [.devcontainer](https://code.visualstudio.com/docs/remote/containers#_create-a-devcontainerjson-file).
+
+<details>
+  <summary>Click to expand for more information</summary>
 You can follow the [tutorial](https://code.visualstudio.com/docs/remote/containers-tutorial) where you'll basically
 need to:
 
-1. Install Docker
+1. Install Docker, or compatible engine
 2. Install the [Development Containers](vscode:extension/ms-vscode-remote.remote-containers) extension
 
 Then you can go to the command palette (View -> Command Palette) and select `Dev Containers: Open Workspace in Container.`
 and select your cloned Flux repository root. This will build a development environment from [fluxrm/testenv](https://hub.docker.com/r/fluxrm/testenv/tags)
-that are built from [src/test/docker](src/test/docker) (the focal tag) with a few tweaks to add linting tools. 
-You are free to change the base image and rebuild if you need to test on another operating system! 
+that are built from [src/test/docker](src/test/docker) (the focal tag) with a few tweaks to add linting and dev tools.
+
+In addition to the usual flux dev requirements, you get:
+
+* bear
+* fd
+* gdb
+* GitHub CLI
+* ripgrep
+* and several useful vscode extensions in the vscode server instance, pre-configured for lua, c and python in flux-core
+
+
+You are free to change the base image and rebuild if you need to test on another operating system!
 When your container is built, when you open `Terminal -> New Terminal`, surprise! You're
 in the container! The dependencies for building Flux are installed. Try building Flux - it will work without a hitch!
 
@@ -118,6 +132,11 @@ in the container! The dependencies for building Flux are installed. Try building
 make
 # This will install in the container!
 make install
+# This will test in the container!
+make check
+# If you want a compilation database
+make clean
+./scripts/generate_compile_commands # this runs `bear make check` by default to generate for all tests as well
 ```
 
 And try starting flux
@@ -143,6 +162,7 @@ $ sudo chown -R $USER .git/
 
 Hopefully we will find a workaround for this so everything works from inside of a VSCode terminal.
 For the time being, make sure you fix permissions and commit from outside the container on your local machine!
+</details>
 
 
 #### Bootstrapping a Flux instance

--- a/scripts/generate_compile_commands
+++ b/scripts/generate_compile_commands
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+: ${OUTPUT:=$(pwd)/compile_commands.json}
+: ${APPEND:=--append}
+: ${TARGET:=all}
+while test $# -gt 0 ; do
+    case $1 in
+    -f)
+    # overwrite existing, do not append
+    APPEND=''
+    shift
+    ;;
+    -t)
+    # include tests, this means running all of check, prepare to wait
+    TARGET=check
+    shift
+    ;;
+    *)
+    break
+    ;;
+    esac
+done
+
+bear -o "${OUTPUT}" $APPEND make "$TARGET" "$@"

--- a/src/bindings/lua/Test/More.lua
+++ b/src/bindings/lua/Test/More.lua
@@ -1,4 +1,4 @@
-
+--- @diagnostic disable
 --
 -- lua-TestMore : <http://fperrad.github.com/lua-TestMore/>
 --
@@ -15,7 +15,7 @@ local _G = _G
 
 local tb = require 'Test.Builder'.new()
 
-_ENV = nil
+-- _ENV = nil
 local m = {}
 
 function m.plan (arg)
@@ -373,9 +373,38 @@ function m.cleanup (func)
     tb:cleanup(func)
 end
 
-for k, v in pairs(m) do  -- injection
-    _G[k] = v
-end
+-- replaced by explicit below to fix test warnings
+-- for k, v in pairs(m) do  -- injection
+--     _G[k] = v
+-- end
+plan = m.plan
+done_testing = m.done_testing
+skip_all = m.skip_all
+BAIL_OUT = m.BAIL_OUT
+ok = m.ok
+nok = m.nok
+is = m.is
+isnt = m.isnt
+like = m.like
+unlike = m.unlike
+cmp_ok = m.cmp_ok
+type_ok = m.type_ok
+subtest = m.subtest
+pass = m.pass
+fail = m.fail
+require_ok = m.require_ok
+eq_array = m.eq_array
+is_deeply = m.is_deeply
+error_is = m.error_is
+error_like = m.error_like
+lives_ok = m.lives_ok
+diag = m.diag
+note = m.note
+skip = m.skip
+todo_skip = m.todo_skip
+skip_rest = m.skip_rest
+todo = m.todo
+cleanup = m.cleanup
 
 m._VERSION = "0.3.1"
 m._DESCRIPTION = "lua-TestMore : an Unit Testing Framework"

--- a/src/bindings/python/.style.yapf
+++ b/src/bindings/python/.style.yapf
@@ -1,5 +1,0 @@
-[style]
-based_on_style = pep8
-spaces_before_comment = 4
-split_before_logical_operator = true
-align_closing_bracket_with_visual_indent = true

--- a/src/test/docker/focal/Dockerfile
+++ b/src/test/docker/focal/Dockerfile
@@ -113,7 +113,7 @@ RUN mkdir caliper \
  && wget -O - https://github.com/LLNL/Caliper/archive/v1.7.0.tar.gz | tar xvz --strip-components 1 \
  && mkdir build \
  && cd build \
- && CC=gcc CXX=g++ cmake .. -DCMAKE_INSTALL_PREFIX=/usr \
+ && CC=gcc CXX=g++ cmake .. -DCMAKE_INSTALL_PREFIX=/usr -DWITH_GOTCHA=Off \
  && make -j 4 \
  && make install \
  && cd ../.. \


### PR DESCRIPTION
New setup for vscode and similar.  The commits and messages provide much more detail, but this builds on the devcontainer setup so we get a pretty full featured semi-IDE with all of flux's paths and idioms working and correctly identifying things.

If and when we get the python linting PR in, it would be good to refactor a bit of this, like to have the dockerfile use the requirements from the top level, and to better integrate the settings that has for flake8 and mypy (they are on in here but not well configured since I didn't want to duplicate all that good work).