### PR TITLE
job-list: support queue specific stats

### DIFF
--- a/doc/man1/flux-jobs.rst
+++ b/doc/man1/flux-jobs.rst
@@ -74,23 +74,27 @@ OPTIONS
    Defaults to *auto*.
 
 **--stats**
-   Output a summary of global job statistics before the header.
-   May be useful in conjunction with utilities like
-   :linux:man1:`watch`, e.g.::
+   Output a summary of job statistics before the header.  By default
+   shows global statistics.  If ``--queue`` is specified, shows
+   statistics for the specified queue.  May be useful in conjunction
+   with utilities like :linux:man1:`watch`, e.g.::
 
       $ watch -n 2 flux jobs --stats -f running -c 25
 
-   will display a summary of global statistics along with the top 25
+   will display a summary of statistics along with the top 25
    running jobs, updated every 2 seconds.
 
 **--stats-only**
-   Output a summary of global job statistics and exit.
-   ``flux jobs`` will exit with non-zero exit status with ``--stats-only``
-   if there are no active jobs. This allows the following loop to work::
+   Output a summary of job statistics and exit.  By default shows
+   global statistics.  If ``--queue`` is specified, shows statistics
+   for the specified queue.  ``flux jobs`` will exit with non-zero
+   exit status with ``--stats-only`` if there are no active jobs. This
+   allows the following loop to work::
 
        $ while flux jobs --stats-only; do sleep 2; done
 
-   All other options are ignored when ``--stats-only`` is used.
+   All options other than ``--queue`` are ignored when
+   ``--stats-only`` is used.
 
 **-R, --recursive**
    List jobs recursively. Each child job which is also an instance of

--- a/src/bindings/python/flux/job/stats.py
+++ b/src/bindings/python/flux/job/stats.py
@@ -11,6 +11,7 @@
 from flux.rpc import RPC
 
 
+# pylint: disable=too-many-instance-attributes
 class JobStats:
     """Container for job statistics as returned by job-list.job-stats
 
@@ -32,9 +33,10 @@ class JobStats:
 
     """
 
-    def __init__(self, handle):
+    def __init__(self, handle, queue=None):
         """Initialize a JobStats object with Flux handle ``handle``"""
         self.handle = handle
+        self.queue = queue
         self.callback = None
         self.cb_kwargs = {}
         for attr in [
@@ -56,6 +58,14 @@ class JobStats:
 
     def _update_cb(self, rpc):
         resp = rpc.get()
+        if self.queue:
+            tmpstat = None
+            if resp["queues"]:
+                tmpstat = [x for x in resp["queues"] if x["name"] == self.queue]
+            if not tmpstat:
+                raise ValueError(f"no stats available for queue {self.queue}")
+            resp = tmpstat[0]
+
         for state, count in resp["job_states"].items():
             setattr(self, state, count)
         for state in ["failed", "timeout", "canceled"]:

--- a/src/bindings/python/flux/job/stats.py
+++ b/src/bindings/python/flux/job/stats.py
@@ -39,6 +39,7 @@ class JobStats:
         self.cb_kwargs = {}
         for attr in [
             "depend",
+            "priority",
             "sched",
             "run",
             "cleanup",

--- a/src/cmd/flux-jobs.py
+++ b/src/cmd/flux-jobs.py
@@ -463,7 +463,12 @@ def main():
         raise ValueError("Error in user format: " + str(err))
 
     if args.stats or args.stats_only:
-        stats = JobStats(flux.Flux()).update_sync()
+        try:
+            stats = JobStats(flux.Flux(), queue=args.queue).update_sync()
+        except ValueError as err:
+            LOGGER.error("error retrieving job stats: %s", str(err))
+            sys.exit(1)
+
         print(
             f"{stats.running} running, {stats.successful} completed, "
             f"{stats.failed} failed, {stats.pending} pending"

--- a/src/modules/job-list/idsync.h
+++ b/src/modules/job-list/idsync.h
@@ -13,6 +13,8 @@
 
 #include <flux/core.h>
 
+#include "src/common/libczmqcontainers/czmq_containers.h"
+
 #include "job_data.h"
 
 struct idsync_ctx {

--- a/src/modules/job-list/job-list.c
+++ b/src/modules/job-list/job-list.c
@@ -20,6 +20,7 @@
 #include "job_data.h"
 #include "list.h"
 #include "idsync.h"
+#include "stats.h"
 
 static const char *attrs[] = {
     "userid", "urgency", "priority", "t_submit",
@@ -68,7 +69,7 @@ static void job_stats_cb (flux_t *h, flux_msg_handler_t *mh,
                           const flux_msg_t *msg, void *arg)
 {
     struct list_ctx *ctx = arg;
-    json_t *o = job_stats_encode (&ctx->jsctx->stats);
+    json_t *o = job_stats_encode (ctx->jsctx->statsctx);
     if (o == NULL)
         goto error;
     if (flux_respond_pack (h, msg, "o", o) < 0) {
@@ -101,7 +102,7 @@ static void purge_cb (flux_t *h,
         if ((job = zhashx_lookup (ctx->jsctx->index, &id))) {
             if (job->state != FLUX_JOB_STATE_INACTIVE)
                 continue;
-            job_stats_purge (&ctx->jsctx->stats, job);
+            job_stats_purge (ctx->jsctx->statsctx, job);
             if (job->list_handle)
                 zlistx_delete (ctx->jsctx->inactive, job->list_handle);
             zhashx_delete (ctx->jsctx->index, &id);

--- a/src/modules/job-list/job-list.h
+++ b/src/modules/job-list/job-list.h
@@ -16,6 +16,7 @@
 #include "src/common/libczmqcontainers/czmq_containers.h"
 
 #include "job_state.h"
+#include "idsync.h"
 
 struct list_ctx {
     flux_t *h;

--- a/src/modules/job-list/job_state.c
+++ b/src/modules/job-list/job_state.c
@@ -721,6 +721,12 @@ static int depthfirst_map_one (struct job_state_ctx *jsctx,
     if (job_parse_jobspec (job, jobspec) < 0)
         goto done;
 
+    /* eventlog parsing above would not have tracked queue specific
+     * stats b/c queue was unknown until the jobspec was parsed.  Must
+     * add this stat in specifically. */
+    if (job->queue)
+        job_stats_add_queue (jsctx->statsctx, job);
+
     if (job->states_mask & FLUX_JOB_STATE_RUN) {
         if (flux_job_kvs_key (path, sizeof (path), id, "R") < 0) {
             errno = EINVAL;

--- a/src/modules/job-list/job_state.c
+++ b/src/modules/job-list/job_state.c
@@ -140,7 +140,7 @@ static void update_job_state (struct job_state_ctx *jsctx,
                               flux_job_state_t new_state,
                               double timestamp)
 {
-    job_stats_update (&jsctx->stats, job, new_state);
+    job_stats_update (jsctx->statsctx, job, new_state);
 
     job->state = new_state;
     if (job->state == FLUX_JOB_STATE_DEPEND)
@@ -1525,6 +1525,9 @@ struct job_state_ctx *job_state_create (struct idsync_ctx *isctx)
     if (!(jsctx->futures = zlistx_new ()))
         goto error;
 
+    if (!(jsctx->statsctx = job_stats_ctx_create (jsctx->h)))
+        goto error;
+
     if (!(jsctx->backlog = flux_msglist_create ()))
         goto error;
 
@@ -1564,6 +1567,7 @@ void job_state_destroy (void *data)
         zlistx_destroy (&jsctx->running);
         zlistx_destroy (&jsctx->pending);
         zhashx_destroy (&jsctx->index);
+        job_stats_ctx_destroy (jsctx->statsctx);
         flux_msglist_destroy (jsctx->backlog);
         flux_future_destroy (jsctx->events);
         free (jsctx);

--- a/src/modules/job-list/job_state.h
+++ b/src/modules/job-list/job_state.h
@@ -14,6 +14,8 @@
 #include <flux/core.h>
 #include <jansson.h>
 
+#include "src/common/libczmqcontainers/czmq_containers.h"
+
 #include "idsync.h"
 #include "stats.h"
 

--- a/src/modules/job-list/job_state.h
+++ b/src/modules/job-list/job_state.h
@@ -50,7 +50,7 @@ struct job_state_ctx {
     zlistx_t *futures;
 
     /*  Job statistics: */
-    struct job_stats stats;
+    struct job_stats_ctx *statsctx;
 
     /* debug/testing - journal responses queued during pause */
     bool pause;

--- a/src/modules/job-list/stats.c
+++ b/src/modules/job-list/stats.c
@@ -42,11 +42,11 @@ void job_stats_update (struct job_stats *stats,
                        struct job *job,
                        flux_job_state_t newstate)
 {
-    stats->state_count[state_index(newstate)]++;
+    stats->state_count[state_index (newstate)]++;
 
     /*  Stats for NEW are not tracked */
     if (job->state != FLUX_JOB_STATE_NEW)
-        stats->state_count[state_index(job->state)]--;
+        stats->state_count[state_index (job->state)]--;
 
     if (newstate == FLUX_JOB_STATE_INACTIVE && !job->success) {
         stats->failed++;
@@ -65,7 +65,7 @@ void job_stats_purge (struct job_stats *stats, struct job *job)
 {
     assert (job->state == FLUX_JOB_STATE_INACTIVE);
 
-    stats->state_count[state_index(job->state)]--;
+    stats->state_count[state_index (job->state)]--;
 
     if (!job->success) {
         stats->failed--;

--- a/src/modules/job-list/stats.c
+++ b/src/modules/job-list/stats.c
@@ -18,6 +18,14 @@
 #include "stats.h"
 #include "job_data.h"
 
+static void free_wrapper (void **item)
+{
+    if (item) {
+        free (*item);
+        (*item) = NULL;
+    }
+}
+
 struct job_stats_ctx *job_stats_ctx_create (flux_t *h)
 {
     struct job_stats_ctx *statsctx = NULL;
@@ -25,12 +33,47 @@ struct job_stats_ctx *job_stats_ctx_create (flux_t *h)
     if (!(statsctx = calloc (1, sizeof (*statsctx))))
         return NULL;
     statsctx->h = h;
+
+    if (!(statsctx->queue_stats = zhashx_new ()))
+        goto error;
+    zhashx_set_destructor (statsctx->queue_stats, free_wrapper);
+
     return statsctx;
+
+error:
+    job_stats_ctx_destroy (statsctx);
+    return NULL;
 }
 
 void job_stats_ctx_destroy (struct job_stats_ctx *statsctx)
 {
-    free (statsctx);
+    if (statsctx) {
+        int save_errno = errno;
+        zhashx_destroy (&statsctx->queue_stats);
+        free (statsctx);
+        errno = save_errno;
+    }
+}
+
+static struct job_stats *queue_stats_lookup (struct job_stats_ctx *statsctx,
+                                             struct job *job)
+{
+    struct job_stats *stats = NULL;
+
+    if (!job->queue)
+        return NULL;
+
+    stats = zhashx_lookup (statsctx->queue_stats, job->queue);
+    if (!stats) {
+        if (!(stats = calloc (1, sizeof (*stats))))
+            return NULL;
+        if (zhashx_insert (statsctx->queue_stats, job->queue, stats) < 0) {
+            flux_log_error (statsctx->h, "%s: zhashx_insert", __FUNCTION__);
+            free (stats);
+            return NULL;
+        }
+    }
+    return stats;
 }
 
 /*  Return the index into stats->state_count[] array for the
@@ -53,17 +96,16 @@ static const char *state_index_name (int index)
     return flux_job_statetostr ((1<<index), "l");
 }
 
-static void stats_update (struct job_stats *stats,
-                          struct job *job,
-                          flux_job_state_t newstate)
+static void stats_add (struct job_stats *stats,
+                       struct job *job,
+                       flux_job_state_t state)
 {
-    stats->state_count[state_index (newstate)]++;
+    if (state == FLUX_JOB_STATE_NEW)
+        return;
 
-    /*  Stats for NEW are not tracked */
-    if (job->state != FLUX_JOB_STATE_NEW)
-        stats->state_count[state_index (job->state)]--;
+    stats->state_count[state_index (state)]++;
 
-    if (newstate == FLUX_JOB_STATE_INACTIVE && !job->success) {
+    if (state == FLUX_JOB_STATE_INACTIVE && !job->success) {
         stats->failed++;
         if (job->exception_occurred) {
             if (strcmp (job->exception_type, "cancel") == 0)
@@ -74,11 +116,36 @@ static void stats_update (struct job_stats *stats,
     }
 }
 
+static void stats_update (struct job_stats *stats,
+                          struct job *job,
+                          flux_job_state_t newstate)
+{
+    /*  Stats for NEW are not tracked */
+    if (job->state != FLUX_JOB_STATE_NEW)
+        stats->state_count[state_index (job->state)]--;
+
+    stats_add (stats, job, newstate);
+}
+
 void job_stats_update (struct job_stats_ctx *statsctx,
                        struct job *job,
                        flux_job_state_t newstate)
 {
+    struct job_stats *stats;
+
     stats_update (&statsctx->all, job, newstate);
+
+    if ((stats = queue_stats_lookup (statsctx, job)))
+        stats_update (stats, job, newstate);
+}
+
+void job_stats_add_queue (struct job_stats_ctx *statsctx,
+                          struct job *job)
+{
+    struct job_stats *stats;
+
+    if ((stats = queue_stats_lookup (statsctx, job)))
+        stats_add (stats, job, job->state);
 }
 
 static void stats_purge (struct job_stats *stats, struct job *job)
@@ -100,9 +167,14 @@ static void stats_purge (struct job_stats *stats, struct job *job)
  */
 void job_stats_purge (struct job_stats_ctx *statsctx, struct job *job)
 {
+    struct job_stats *stats;
+
     assert (job->state == FLUX_JOB_STATE_INACTIVE);
 
     stats_purge (&statsctx->all, job);
+
+    if ((stats = queue_stats_lookup (statsctx, job)))
+        stats_purge (stats, job);
 }
 
 static int object_set_integer (json_t *o,
@@ -138,7 +210,7 @@ error:
     return NULL;
 }
 
-static json_t *stats_encode (struct job_stats *stats)
+static json_t *stats_encode (struct job_stats *stats, const char *name)
 {
     json_t *o;
     json_t *states;
@@ -154,12 +226,74 @@ static json_t *stats_encode (struct job_stats *stats)
         return NULL;
     }
     json_decref (states);
+
+    if (name) {
+        json_t *no = json_string (name);
+        if (!no || json_object_set_new (o, "name", no) < 0) {
+            json_decref (no);
+            json_decref (o);
+            errno = ENOMEM;
+            return NULL;
+        }
+    }
     return o;
+}
+
+static json_t *queue_stats_encode (struct job_stats_ctx *statsctx)
+{
+    struct job_stats *stats;
+    json_t *queues;
+
+    if (!(queues = json_array ())) {
+        errno = ENOMEM;
+        return NULL;
+    }
+
+    stats = zhashx_first (statsctx->queue_stats);
+    while (stats) {
+        const char *name = zhashx_cursor (statsctx->queue_stats);
+        json_t *qo = stats_encode (stats, name);
+        if (!qo) {
+            int save_errno = errno;
+            json_decref (queues);
+            errno = save_errno;
+            return NULL;
+        }
+        if (json_array_append_new (queues, qo) < 0) {
+            json_decref (qo);
+            json_decref (queues);
+            errno = ENOMEM;
+            return NULL;
+        }
+        stats = zhashx_next (statsctx->queue_stats);
+    }
+
+    return queues;
 }
 
 json_t * job_stats_encode (struct job_stats_ctx *statsctx)
 {
-    return stats_encode (&statsctx->all);
+    json_t *o = NULL;
+    json_t *queues;
+
+    if (!(o = stats_encode (&statsctx->all, NULL)))
+        return NULL;
+
+    if (!(queues = queue_stats_encode (statsctx))) {
+        int save_errno = errno;
+        json_decref (o);
+        errno = save_errno;
+        return NULL;
+    }
+
+    if (json_object_set_new (o, "queues", queues) < 0) {
+        json_decref (queues);
+        json_decref (o);
+        errno = ENOMEM;
+        return NULL;
+    }
+
+    return o;
 }
 
 // vi: ts=4 sw=4 expandtab

--- a/src/modules/job-list/stats.h
+++ b/src/modules/job-list/stats.h
@@ -14,6 +14,8 @@
 #include <flux/core.h> /* FLUX_JOB_NR_STATES */
 #include <jansson.h>
 
+#include "src/common/libczmqcontainers/czmq_containers.h"
+
 #include "job_data.h"
 
 struct job_stats {
@@ -26,6 +28,7 @@ struct job_stats {
 struct job_stats_ctx {
     flux_t *h;
     struct job_stats all;
+    zhashx_t *queue_stats;
 };
 
 struct job_stats_ctx *job_stats_ctx_create (flux_t *h);
@@ -35,6 +38,9 @@ void job_stats_ctx_destroy (struct job_stats_ctx *statsctx);
 void job_stats_update (struct job_stats_ctx *statsctx,
                        struct job *job,
                        flux_job_state_t newstate);
+
+void job_stats_add_queue (struct job_stats_ctx *statsctx,
+                          struct job *job);
 
 void job_stats_purge (struct job_stats_ctx *statsctx, struct job *job);
 

--- a/src/modules/job-list/stats.h
+++ b/src/modules/job-list/stats.h
@@ -23,13 +23,22 @@ struct job_stats {
     unsigned int canceled;
 };
 
-void job_stats_update (struct job_stats *stats,
+struct job_stats_ctx {
+    flux_t *h;
+    struct job_stats all;
+};
+
+struct job_stats_ctx *job_stats_ctx_create (flux_t *h);
+
+void job_stats_ctx_destroy (struct job_stats_ctx *statsctx);
+
+void job_stats_update (struct job_stats_ctx *statsctx,
                        struct job *job,
                        flux_job_state_t newstate);
 
-void job_stats_purge (struct job_stats *stats, struct job *job);
+void job_stats_purge (struct job_stats_ctx *statsctx, struct job *job);
 
-json_t * job_stats_encode (struct job_stats *stats);
+json_t * job_stats_encode (struct job_stats_ctx *statsctx);
 
 #endif /* ! _FLUX_JOB_LIST_JOB_STATS_H */
 

--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -1218,7 +1218,7 @@ done
 
 
 # job stats
-test_expect_success 'flux-jobs --stats works' '
+test_expect_success 'flux-jobs --stats works (global)' '
 	flux jobs --stats -a >stats.output &&
 	test_debug "cat stats.output" &&
 	fail=$(state_count failed canceled timeout) &&
@@ -1232,6 +1232,43 @@ test_expect_success 'flux-jobs --stats works' '
 	EOF
 	head -1 stats.output > stats.actual &&
 	test_cmp stats.expected stats.actual
+'
+
+test_expect_success 'flux-jobs --stats works (queue1)' '
+	flux jobs --stats -a --queue=queue1 >statsq1.output &&
+	test_debug "cat statsq1.output" &&
+	fail=$(state_count failed canceled timeout) &&
+	inactive=$(state_count inactive) &&
+	comp=$((inactive - fail)) &&
+	cat <<-EOF >statsq1.expected &&
+	0 running, ${comp} completed, 0 failed, 0 pending
+	EOF
+	head -1 statsq1.output > statsq1.actual &&
+	test_cmp statsq1.expected statsq1.actual
+'
+
+test_expect_success 'flux-jobs --stats works (queue2)' '
+	flux jobs --stats -a --queue=queue2 >statsq2.output &&
+	test_debug "cat statsq2.output" &&
+	run=$(state_count run) &&
+	active=$(state_count active) &&
+	pend=$((active - run)) &&
+	cat <<-EOF >statsq2.expected &&
+	${run} running, 0 completed, 0 failed, ${pend} pending
+	EOF
+	head -1 statsq2.output > statsq2.actual &&
+	test_cmp statsq2.expected statsq2.actual
+'
+
+test_expect_success 'flux-jobs --stats works (defaultqueue)' '
+	flux jobs --stats -a --queue=defaultqueue >statsqdefault.output &&
+	test_debug "cat statsqdefault.output" &&
+	fail=$(state_count failed canceled timeout) &&
+	cat <<-EOF >statsqdefault.expected &&
+	0 running, 0 completed, ${fail} failed, 0 pending
+	EOF
+	head -1 statsqdefault.output > statsqdefault.actual &&
+	test_cmp statsqdefault.expected statsqdefault.actual
 '
 
 test_expect_success 'flux-jobs --stats-only works' '


### PR DESCRIPTION
per #4604, get queue specific job stats.  in `flux-jobs`, the `--queue` option can now also select which queue `--stats` outputs.