### PR TITLE
ci: add isort to pre-commit and linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,11 +20,12 @@ repos:
         types: [python]
         entry: black
 
-#      - id: isort
-#        name: isort
-#        language: python
-#        types: [python]
-#        entry: isort
+      - id: isort
+        name: isort
+        args: [--filter-files]
+        language: python
+        types: [python]
+        entry: isort
 
       - id: flake8
         name: flake8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,11 @@ target-version = ['py36']
 exclude = ["^env/", "^src/bindings/python/flux/utils/*/*.py", "^src/bindings/python/flux/utils/*/*/*.py"]
 
 [tool.isort]
-profile = "isort"
-exclude = ["^env/"]
+profile = "black" # needed for black/isort compatibility
+skip = [
+  "src/bindings/python/flux/job/kvs.py",
+  "src/bindings/python/flux/job/__init__.py",
+  "src/bindings/python/flux/resource/__init__.py"]
 
 [tool.mypy]
 python_version = 3.6

--- a/src/bindings/python/_flux/_core_build.py
+++ b/src/bindings/python/_flux/_core_build.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+
 from cffi import FFI
 
 ffi = FFI()

--- a/src/bindings/python/_flux/_hostlist_build.py
+++ b/src/bindings/python/_flux/_hostlist_build.py
@@ -1,5 +1,6 @@
-from cffi import FFI
 from pathlib import Path
+
+from cffi import FFI
 
 ffi = FFI()
 

--- a/src/bindings/python/_flux/_idset_build.py
+++ b/src/bindings/python/_flux/_idset_build.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+
 from cffi import FFI
 
 ffi = FFI()

--- a/src/bindings/python/_flux/_rlist_build.py
+++ b/src/bindings/python/_flux/_rlist_build.py
@@ -1,8 +1,8 @@
 from pathlib import Path
-from cffi import FFI
 
 from _hostlist_build import ffi as hostlist_ffi
 from _idset_build import ffi as idset_ffi
+from cffi import FFI
 
 ffi = FFI()
 

--- a/src/bindings/python/_flux/_security_build.py
+++ b/src/bindings/python/_flux/_security_build.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+
 from cffi import FFI
 
 ffi = FFI()

--- a/src/bindings/python/_flux/make_clean_header.py
+++ b/src/bindings/python/_flux/make_clean_header.py
@@ -8,10 +8,9 @@
 # SPDX-License-Identifier: LGPL-3.0
 ###############################################################
 
+import argparse
 import os
 import re
-
-import argparse
 
 parser = argparse.ArgumentParser()
 

--- a/src/bindings/python/flux/__init__.py
+++ b/src/bindings/python/flux/__init__.py
@@ -13,6 +13,7 @@ python bindings to flux-core, the main core of the flux resource manager
 """
 import flux.core.handle
 
+
 # Manually lazy
 # pylint: disable=invalid-name
 def Flux(*args, **kwargs):

--- a/src/bindings/python/flux/constants.py
+++ b/src/bindings/python/flux/constants.py
@@ -10,8 +10,9 @@
 
 """Global constants for the flux interface"""
 
-import sys
 import re
+import sys
+
 from _flux._core import lib
 
 MOD = sys.modules[__name__]

--- a/src/bindings/python/flux/core/handle.py
+++ b/src/bindings/python/flux/core/handle.py
@@ -12,18 +12,15 @@ import signal
 import threading
 from contextlib import contextmanager
 
-from flux.wrapper import Wrapper
-from flux.future import Future
-from flux.rpc import RPC
-from flux.message import Message
-from flux.util import encode_topic, encode_payload
-from flux.core.inner import raw
-from flux.message import MessageWatcher
-from flux.core.watchers import TimerWatcher
-from flux.core.watchers import SignalWatcher
-from flux.core.watchers import FDWatcher
-from flux.constants import FLUX_POLLIN, FLUX_POLLOUT, FLUX_POLLERR
 from _flux._core import ffi, lib
+from flux.constants import FLUX_POLLERR, FLUX_POLLIN, FLUX_POLLOUT
+from flux.core.inner import raw
+from flux.core.watchers import FDWatcher, SignalWatcher, TimerWatcher
+from flux.future import Future
+from flux.message import Message, MessageWatcher
+from flux.rpc import RPC
+from flux.util import encode_payload, encode_topic
+from flux.wrapper import Wrapper
 
 
 # pylint: disable=too-many-public-methods

--- a/src/bindings/python/flux/core/trampoline.py
+++ b/src/bindings/python/flux/core/trampoline.py
@@ -9,6 +9,7 @@
 ###############################################################
 
 import importlib
+
 from _flux._core import lib
 from flux.core.handle import Flux
 

--- a/src/bindings/python/flux/core/watchers.py
+++ b/src/bindings/python/flux/core/watchers.py
@@ -11,7 +11,8 @@
 import abc
 import errno
 import signal
-from flux.core.inner import raw, lib, ffi
+
+from flux.core.inner import ffi, lib, raw
 
 __all__ = ["TimerWatcher", "FDWatcher", "SignalWatcher"]
 

--- a/src/bindings/python/flux/future.py
+++ b/src/bindings/python/flux/future.py
@@ -9,12 +9,11 @@
 ###############################################################
 
 import errno
-
 from typing import Dict
 
+from flux.core.inner import ffi, lib, raw
 from flux.util import check_future_error, interruptible
 from flux.wrapper import Wrapper, WrapperPimpl
-from flux.core.inner import ffi, lib, raw
 
 # Reference count dictionary to keep futures with a pending `then` callback
 # alive, even if there are no remaining references to the future in the user's

--- a/src/bindings/python/flux/hostlist.py
+++ b/src/bindings/python/flux/hostlist.py
@@ -8,8 +8,9 @@
 # SPDX-License-Identifier: LGPL-3.0
 ###############################################################
 
-import numbers
 import collections
+import numbers
+
 from _flux._hostlist import ffi, lib
 from flux.wrapper import Wrapper, WrapperPimpl
 

--- a/src/bindings/python/flux/idset.py
+++ b/src/bindings/python/flux/idset.py
@@ -8,8 +8,9 @@
 # SPDX-License-Identifier: LGPL-3.0
 ###############################################################
 
-import numbers
 import collections
+import numbers
+
 from _flux._idset import ffi, lib
 from flux.wrapper import Wrapper, WrapperPimpl
 

--- a/src/bindings/python/flux/importer.py
+++ b/src/bindings/python/flux/importer.py
@@ -8,10 +8,10 @@
 # SPDX-License-Identifier: LGPL-3.0
 ###############################################################
 
-import sys
+import importlib
 import os
 import pkgutil
-import importlib
+import sys
 
 
 def import_plugins_pkg(ns_pkg):

--- a/src/bindings/python/flux/job/JobID.py
+++ b/src/bindings/python/flux/job/JobID.py
@@ -8,8 +8,8 @@
 # SPDX-License-Identifier: LGPL-3.0
 ###############################################################
 
-from flux.job._wrapper import _RAW as RAW
 from _flux._core import ffi
+from flux.job._wrapper import _RAW as RAW
 
 
 def id_parse(jobid_str):

--- a/src/bindings/python/flux/job/Jobspec.py
+++ b/src/bindings/python/flux/job/Jobspec.py
@@ -7,17 +7,16 @@
 #
 # SPDX-License-Identifier: LGPL-3.0
 ###############################################################
-import os
-import math
-import json
-import errno
-import datetime
 import collections
 import collections.abc as abc
+import datetime
+import errno
+import json
+import math
 import numbers
+import os
 
 import yaml
-
 from _flux._core import ffi
 from flux.util import parse_fsd, set_treedict
 

--- a/src/bindings/python/flux/job/_wrapper.py
+++ b/src/bindings/python/flux/job/_wrapper.py
@@ -8,8 +8,8 @@
 # SPDX-License-Identifier: LGPL-3.0
 ###############################################################
 
-from flux.wrapper import Wrapper
 from _flux._core import ffi, lib
+from flux.wrapper import Wrapper
 
 
 class JobWrapper(Wrapper):

--- a/src/bindings/python/flux/job/event.py
+++ b/src/bindings/python/flux/job/event.py
@@ -7,13 +7,12 @@
 #
 # SPDX-License-Identifier: LGPL-3.0
 ###############################################################
-import json
 import errno
+import json
 
+from _flux._core import ffi
 from flux.future import Future
 from flux.job._wrapper import _RAW as RAW
-from _flux._core import ffi
-
 
 # Names of events that may appear in the main eventlog (i.e. ``eventlog="eventlog"``)
 # See Flux RFC 21 for documentation on each event.

--- a/src/bindings/python/flux/job/executor.py
+++ b/src/bindings/python/flux/job/executor.py
@@ -12,19 +12,18 @@
 This module defines the ``FluxExecutor`` and ``FluxExecutorFuture`` classes.
 """
 
-import threading
-import logging
-import itertools
 import collections
 import concurrent.futures
-import weakref
-import time
+import itertools
+import logging
 import os
+import threading
+import time
+import weakref
 
 import flux
+from flux.job.event import MAIN_EVENTS, JobException, event_watch_async
 from flux.job.submit import submit_async, submit_get_id
-from flux.job.event import event_watch_async, JobException, MAIN_EVENTS
-
 
 _SubmitPackage = collections.namedtuple(
     "_SubmitPackage", ["submit_args", "submit_kwargs", "future"]

--- a/src/bindings/python/flux/job/frobnicator/__init__.py
+++ b/src/bindings/python/flux/job/frobnicator/__init__.py
@@ -8,4 +8,4 @@
 # SPDX-License-Identifier: LGPL-3.0
 ###############################################################
 
-from flux.job.frobnicator.frobnicator import JobFrobnicator, FrobnicatorPlugin
+from flux.job.frobnicator.frobnicator import FrobnicatorPlugin, JobFrobnicator

--- a/src/bindings/python/flux/job/frobnicator/frobnicator.py
+++ b/src/bindings/python/flux/job/frobnicator/frobnicator.py
@@ -8,12 +8,12 @@
 # SPDX-License-Identifier: LGPL-3.0
 ###############################################################
 
-import os
 import argparse
+import os
 from abc import abstractmethod
 
 import flux
-from flux.importer import import_plugins, import_path
+from flux.importer import import_path, import_plugins
 from flux.job import Jobspec
 
 

--- a/src/bindings/python/flux/job/info.py
+++ b/src/bindings/python/flux/job/info.py
@@ -8,20 +8,20 @@
 # SPDX-License-Identifier: LGPL-3.0
 ###############################################################
 
-import os
-import time
-import pwd
 import json
+import os
+import pwd
 import string
+import time
 from collections import namedtuple
 
 import flux.constants
-from flux.memoized_property import memoized_property
+from flux.core.inner import raw
 from flux.job.JobID import JobID
 from flux.job.stats import JobStats
+from flux.memoized_property import memoized_property
 from flux.resource import SchedResourceList
 from flux.uri import JobURI
-from flux.core.inner import raw
 
 
 def statetostr(stateid, fmt="L"):

--- a/src/bindings/python/flux/job/kill.py
+++ b/src/bindings/python/flux/job/kill.py
@@ -8,13 +8,13 @@
 # SPDX-License-Identifier: LGPL-3.0
 ###############################################################
 import signal
-from typing import Union, Optional
+from typing import Optional, Union
 
+from _flux._core import ffi
+from flux.core.handle import Flux  # for typing
 from flux.future import Future
 from flux.job._wrapper import _RAW as RAW
-from flux.core.handle import Flux  # for typing
 from flux.job.JobID import JobID  # for typing
-from _flux._core import ffi
 
 
 def kill_async(

--- a/src/bindings/python/flux/job/list.py
+++ b/src/bindings/python/flux/job/list.py
@@ -7,9 +7,9 @@
 #
 # SPDX-License-Identifier: LGPL-3.0
 ###############################################################
+import errno
 import os
 import pwd
-import errno
 
 import flux.constants
 from flux.future import WaitAllFuture

--- a/src/bindings/python/flux/job/submit.py
+++ b/src/bindings/python/flux/job/submit.py
@@ -9,13 +9,13 @@
 ###############################################################
 import errno
 
+from _flux._core import ffi, lib
 from flux import constants
-from flux.util import check_future_error
 from flux.future import Future
 from flux.job import JobID
-from flux.job.Jobspec import _convert_jobspec_arg_to_string
 from flux.job._wrapper import _RAW as RAW
-from _flux._core import ffi, lib
+from flux.job.Jobspec import _convert_jobspec_arg_to_string
+from flux.util import check_future_error
 
 
 class SubmitFuture(Future):

--- a/src/bindings/python/flux/job/validator/plugins/feasibility.py
+++ b/src/bindings/python/flux/job/validator/plugins/feasibility.py
@@ -24,6 +24,7 @@ does not support the sched.feasibility RPC
 """
 
 import errno
+
 from flux.job.validator import ValidatorPlugin
 
 

--- a/src/bindings/python/flux/job/validator/plugins/jobspec.py
+++ b/src/bindings/python/flux/job/validator/plugins/jobspec.py
@@ -16,6 +16,7 @@ supplied, then only that version of jobspec is permitted.
 """
 
 import json
+
 from flux.job import validate_jobspec
 from flux.job.validator import ValidatorPlugin
 

--- a/src/bindings/python/flux/job/validator/plugins/require-instance.py
+++ b/src/bindings/python/flux/job/validator/plugins/require-instance.py
@@ -21,6 +21,7 @@ not directly via `flux broker` or `flux start`.
 
 import errno
 from os.path import basename
+
 from flux.job.validator import ValidatorPlugin
 
 

--- a/src/bindings/python/flux/job/validator/plugins/schema.py
+++ b/src/bindings/python/flux/job/validator/plugins/schema.py
@@ -15,8 +15,9 @@ specified via the ``--schema=SCHEMA`` option.
 
 """
 
-import sys
 import json
+import sys
+
 import jsonschema
 from flux.job.validator import ValidatorPlugin
 

--- a/src/bindings/python/flux/job/validator/validator.py
+++ b/src/bindings/python/flux/job/validator/validator.py
@@ -8,13 +8,14 @@
 # SPDX-License-Identifier: LGPL-3.0
 ###############################################################
 
-import json
 import argparse
-import threading
 import concurrent.futures
+import json
+import threading
 from abc import ABC, abstractmethod
+
 import flux
-from flux.importer import import_plugins, import_path
+from flux.importer import import_path, import_plugins
 
 
 class ValidatorResult:

--- a/src/bindings/python/flux/job/wait.py
+++ b/src/bindings/python/flux/job/wait.py
@@ -7,15 +7,15 @@
 #
 # SPDX-License-Identifier: LGPL-3.0
 ###############################################################
-import errno
 import collections
+import errno
 import json
 
 import flux
-from flux.util import check_future_error, interruptible
+from _flux._core import ffi, lib
 from flux.future import Future
 from flux.job._wrapper import _RAW as RAW
-from _flux._core import ffi, lib
+from flux.util import check_future_error, interruptible
 
 
 class JobWaitFuture(Future):

--- a/src/bindings/python/flux/kvs.py
+++ b/src/bindings/python/flux/kvs.py
@@ -8,10 +8,9 @@
 # SPDX-License-Identifier: LGPL-3.0
 ###############################################################
 
-import json
-import errno
-
 import collections.abc as abc
+import errno
+import json
 from typing import Any, Mapping
 
 from _flux._core import ffi, lib

--- a/src/bindings/python/flux/message.py
+++ b/src/bindings/python/flux/message.py
@@ -11,11 +11,11 @@
 import errno
 import json
 
-from flux.wrapper import Wrapper, WrapperPimpl
+import flux.constants
 from flux.core.inner import ffi, lib, raw
 from flux.core.watchers import Watcher
-import flux.constants
 from flux.util import encode_payload, encode_topic
+from flux.wrapper import Wrapper, WrapperPimpl
 
 __all__ = ["Message", "MessageWatcher", "msg_typestr"]
 

--- a/src/bindings/python/flux/progress.py
+++ b/src/bindings/python/flux/progress.py
@@ -8,11 +8,11 @@
 # SPDX-License-Identifier: LGPL-3.0
 ###############################################################
 
-import sys
-import shutil
 import atexit
-import time
 import datetime
+import shutil
+import sys
+import time
 
 # Bottombar heavily borrows from
 #

--- a/src/bindings/python/flux/resource/Rlist.py
+++ b/src/bindings/python/flux/resource/Rlist.py
@@ -13,11 +13,10 @@ import socket
 from collections.abc import Mapping
 
 from _flux._rlist import ffi, lib
-from flux.wrapper import Wrapper, WrapperPimpl
-
-from flux.resource.ResourceSetImplementation import ResourceSetImplementation
 from flux.hostlist import Hostlist
 from flux.idset import IDset
+from flux.resource.ResourceSetImplementation import ResourceSetImplementation
+from flux.wrapper import Wrapper, WrapperPimpl
 
 
 @ResourceSetImplementation.register

--- a/src/bindings/python/flux/resource/list.py
+++ b/src/bindings/python/flux/resource/list.py
@@ -8,9 +8,9 @@
 # SPDX-License-Identifier: LGPL-3.0
 ###############################################################
 
+from flux.memoized_property import memoized_property
 from flux.resource import ResourceSet
 from flux.rpc import RPC
-from flux.memoized_property import memoized_property
 
 
 class SchedResourceList:

--- a/src/bindings/python/flux/rpc.py
+++ b/src/bindings/python/flux/rpc.py
@@ -10,12 +10,11 @@
 
 import json
 
-from flux.util import check_future_error
-from flux.wrapper import Wrapper
-from flux.future import Future
-from flux.core.inner import ffi, lib, raw
 import flux.constants
-from flux.util import encode_payload, encode_topic, interruptible
+from flux.core.inner import ffi, lib, raw
+from flux.future import Future
+from flux.util import check_future_error, encode_payload, encode_topic, interruptible
+from flux.wrapper import Wrapper
 
 
 class RPC(Future):

--- a/src/bindings/python/flux/security.py
+++ b/src/bindings/python/flux/security.py
@@ -9,7 +9,7 @@
 ###############################################################
 
 from _flux._security import ffi, lib
-from flux.wrapper import Wrapper, WrapperPimpl, FunctionWrapper
+from flux.wrapper import FunctionWrapper, Wrapper, WrapperPimpl
 
 
 class SecurityFunctionWrapper(FunctionWrapper):

--- a/src/bindings/python/flux/uri/__init__.py
+++ b/src/bindings/python/flux/uri/__init__.py
@@ -8,4 +8,4 @@
 # SPDX-License-Identifier: LGPL-3.0
 ###############################################################
 
-from flux.uri.uri import URI, JobURI, URIResolverURI, FluxURIResolver, URIResolverPlugin
+from flux.uri.uri import URI, FluxURIResolver, JobURI, URIResolverPlugin, URIResolverURI

--- a/src/bindings/python/flux/uri/resolvers/jobid.py
+++ b/src/bindings/python/flux/uri/resolvers/jobid.py
@@ -8,12 +8,12 @@
 # SPDX-License-Identifier: LGPL-3.0
 ###############################################################
 
+import os
 from pathlib import PurePath
 
-import os
 import flux
 from flux.job import JobID, job_list_id
-from flux.uri import URIResolverPlugin, URIResolverURI, JobURI
+from flux.uri import JobURI, URIResolverPlugin, URIResolverURI
 
 
 def filter_slash(iterable):

--- a/src/bindings/python/flux/uri/resolvers/lsf.py
+++ b/src/bindings/python/flux/uri/resolvers/lsf.py
@@ -18,14 +18,13 @@ It can be used like:
 
 import getpass
 import os
-import subprocess
 import shutil
+import subprocess
 from pathlib import PurePath
 
-import yaml
-
 import flux.hostlist as hostlist
-from flux.uri import URIResolverPlugin, FluxURIResolver
+import yaml
+from flux.uri import FluxURIResolver, URIResolverPlugin
 
 
 def lsf_find_compute_node(jobid):

--- a/src/bindings/python/flux/uri/resolvers/slurm.py
+++ b/src/bindings/python/flux/uri/resolvers/slurm.py
@@ -8,12 +8,12 @@
 # SPDX-License-Identifier: LGPL-3.0
 ###############################################################
 
-import os
 import errno
+import os
 import subprocess
 from pathlib import PurePath
 
-from flux.uri import URIResolverPlugin, FluxURIResolver
+from flux.uri import FluxURIResolver, URIResolverPlugin
 
 
 def slurm_job_pids(jobid):

--- a/src/bindings/python/flux/uri/uri.py
+++ b/src/bindings/python/flux/uri/uri.py
@@ -12,8 +12,7 @@ import os
 import platform
 import re
 from abc import ABC, abstractmethod
-
-from urllib.parse import urlparse, parse_qs
+from urllib.parse import parse_qs, urlparse
 
 from flux.importer import import_plugins
 

--- a/src/bindings/python/flux/util.py
+++ b/src/bindings/python/flux/util.py
@@ -8,27 +8,26 @@
 # SPDX-License-Identifier: LGPL-3.0
 ###############################################################
 
-import re
-import sys
+import argparse
 import errno
+import glob
 import json
 import logging
-import os
 import math
-import argparse
-import traceback
-import signal
-import threading
+import os
+import re
 import shutil
-import glob
-from datetime import datetime, timedelta
-from string import Formatter
+import signal
+import sys
+import threading
+import traceback
 from collections import namedtuple
+from datetime import datetime, timedelta
 from pathlib import Path, PurePosixPath
+from string import Formatter
 from typing import Mapping
 
 import yaml
-
 
 try:
     import tomllib

--- a/src/bindings/python/flux/wrapper.py
+++ b/src/bindings/python/flux/wrapper.py
@@ -13,12 +13,12 @@ Flux interface wrapper generator.
 This could, in principle, be used for other projects as well, but it encodes a
 number of assumptions about the error propagation and handling that flux uses.
 """
-import re
-import os
 import errno
 import inspect
+import os
+import re
 from types import MethodType
-from typing import Dict, Any
+from typing import Any, Dict
 
 
 class MissingFunctionError(Exception):

--- a/src/bindings/python/setup.py
+++ b/src/bindings/python/setup.py
@@ -8,8 +8,9 @@
 # SPDX-License-Identifier: LGPL-3.0
 ###############################################################
 
-from setuptools import setup
 import os
+
+from setuptools import setup
 
 here = os.path.abspath(os.path.dirname(__file__))
 cffi_dep = "cffi>=1.1"

--- a/src/cmd/flux-admin.py
+++ b/src/cmd/flux-admin.py
@@ -8,9 +8,9 @@
 # SPDX-License-Identifier: LGPL-3.0
 ##############################################################
 
-import sys
-import logging
 import argparse
+import logging
+import sys
 
 import flux
 from flux.rpc import RPC

--- a/src/cmd/flux-job-exec-override.py
+++ b/src/cmd/flux-job-exec-override.py
@@ -9,9 +9,9 @@
 # SPDX-License-Identifier: LGPL-3.0
 ##############################################################
 
-import sys
-import logging
 import argparse
+import logging
+import sys
 
 import flux
 from flux.job import JobID

--- a/src/cmd/flux-job-frobnicator.py
+++ b/src/cmd/flux-job-frobnicator.py
@@ -8,15 +8,15 @@
 # SPDX-License-Identifier: LGPL-3.0
 ###############################################################
 
+import argparse
+import json
+import logging
 import os
 import sys
-import logging
-import json
-import argparse
-import flux
-from flux.job.frobnicator import JobFrobnicator
-from flux.job import Jobspec
 
+import flux
+from flux.job import Jobspec
+from flux.job.frobnicator import JobFrobnicator
 
 LOGGER = logging.getLogger("flux-job-frobnicator")
 

--- a/src/cmd/flux-job-validator.py
+++ b/src/cmd/flux-job-validator.py
@@ -8,14 +8,14 @@
 # SPDX-License-Identifier: LGPL-3.0
 ###############################################################
 
+import argparse
+import json
+import logging
 import os
 import sys
-import logging
-import json
-import argparse
+
 import flux
 from flux.job.validator import JobValidator
-
 
 LOGGER = logging.getLogger("flux-job-validator")
 

--- a/src/cmd/flux-jobs.py
+++ b/src/cmd/flux-jobs.py
@@ -8,17 +8,16 @@
 # SPDX-License-Identifier: LGPL-3.0
 ##############################################################
 
-import os
-import sys
-import logging
 import argparse
+import concurrent.futures
 import fileinput
 import json
-import concurrent.futures
+import logging
+import os
+import sys
 
 import flux.constants
-from flux.job import JobInfo, JobInfoFormat, JobList, job_fields_to_attrs
-from flux.job import JobID
+from flux.job import JobID, JobInfo, JobInfoFormat, JobList, job_fields_to_attrs
 from flux.job.stats import JobStats
 from flux.util import UtilConfig
 

--- a/src/cmd/flux-jobtap.py
+++ b/src/cmd/flux-jobtap.py
@@ -9,9 +9,9 @@
 # SPDX-License-Identifier: LGPL-3.0
 ##############################################################
 
-import sys
-import logging
 import argparse
+import logging
+import sys
 
 import flux
 from flux.util import TreedictAction

--- a/src/cmd/flux-mini.py
+++ b/src/cmd/flux-mini.py
@@ -8,29 +8,28 @@
 # SPDX-License-Identifier: LGPL-3.0
 ##############################################################
 
+import argparse
+import atexit
+import fnmatch
+import itertools
+import json
+import logging
+
 # pylint: disable=duplicate-code
 import os
-import sys
-import logging
-import argparse
-import json
-import fnmatch
-import re
 import random
-import itertools
-import atexit
+import re
+import sys
 import time
+from collections import ChainMap
 from itertools import chain
 from string import Template
-from collections import ChainMap
-from urllib.parse import urlparse, parse_qs
+from urllib.parse import parse_qs, urlparse
 
 import flux
-from flux import job
-from flux.job import JobspecV1
-from flux import util
-from flux import debugged
+from flux import debugged, job, util
 from flux.idset import IDset
+from flux.job import JobspecV1
 from flux.progress import ProgressBar
 from flux.uri import JobURI
 

--- a/src/cmd/flux-perilog-run.py
+++ b/src/cmd/flux-perilog-run.py
@@ -8,18 +8,18 @@
 # SPDX-License-Identifier: LGPL-3.0
 ##############################################################
 
-import os
-import sys
-import subprocess
 import argparse
 import logging
+import os
 import signal
+import subprocess
+import sys
 from pathlib import Path
 
 import flux
-from flux.resource import ResourceSet
 from flux.idset import IDset
 from flux.job import JobID
+from flux.resource import ResourceSet
 
 
 def fetch_job_ranks(handle, jobid):

--- a/src/cmd/flux-pstree.py
+++ b/src/cmd/flux-pstree.py
@@ -8,15 +8,15 @@
 # SPDX-License-Identifier: LGPL-3.0
 ##############################################################
 
-import sys
-import logging
 import argparse
 import concurrent.futures
+import logging
+import sys
 
 import flux
 import flux.uri
+from flux.job import JobID, JobInfo, JobInfoFormat, JobList
 from flux.util import Tree
-from flux.job import JobInfo, JobInfoFormat, JobList, JobID
 
 DETAILS_FORMAT = {
     "default": (

--- a/src/cmd/flux-resource.py
+++ b/src/cmd/flux-resource.py
@@ -8,19 +8,19 @@
 # SPDX-License-Identifier: LGPL-3.0
 ##############################################################
 
-import sys
-import logging
 import argparse
-import os.path
 import json
+import logging
+import os.path
+import sys
 from datetime import datetime
 
 import flux
-from flux.idset import IDset
-from flux.hostlist import Hostlist
-from flux.resource import ResourceSet, resource_list, SchedResourceList
-from flux.rpc import RPC
 from flux.future import WaitAllFuture
+from flux.hostlist import Hostlist
+from flux.idset import IDset
+from flux.resource import ResourceSet, SchedResourceList, resource_list
+from flux.rpc import RPC
 
 
 def reload(args):

--- a/src/cmd/flux-uri.py
+++ b/src/cmd/flux-uri.py
@@ -8,10 +8,10 @@
 # SPDX-License-Identifier: LGPL-3.0
 ##############################################################
 
+import argparse
+import logging
 import os
 import sys
-import logging
-import argparse
 
 import flux
 from flux.uri import FluxURIResolver


### PR DESCRIPTION
I intend to incrementally test isort - and because the ultimate source of truth are the tests here (and I couldn't reproduce locally) it makes most sense to test in the CI on GitHub. I [tried opening this on my repository](https://github.com/researchapps/flux-core/pull/2) to not add traffic here, but the tests already failed, so unless my first change hit the sorting order issue, I think I'll need to test here. Understandably this might use a lot of CI juice so I'll try to do it in off hours and weekends! You can safely ignore this branch for the time being - I need to carefully change files in small groups until tests break (and maybe they already have, lol).

### Current Failures

The following, when isort-ed, break tests.

- flux/resources:
  - `__init__.py`
- flux/job:
  - `__init__.py`
  - kvs.py
- flux/kvs.py (this one really doesn't make sense to me, but failed twice!)