### PR TITLE
ci: update setup-python/buildx actions to v4/v2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
     name: python linting
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/setup-python@v1
+    - uses: actions/setup-python@v4
       with:
         python-version: 3.6
     - uses: actions/checkout@v3
@@ -144,7 +144,7 @@ jobs:
         fi
 
     - name: docker buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v2
       if: matrix.needs_buildx
 
     - name: docker-run-checks
@@ -160,7 +160,7 @@ jobs:
       if: success() && matrix.coverage && matrix.image == 'bionic'
       env:
         DOCKER_REPO:
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v3
       with:
         flags: ci-basic
 


### PR DESCRIPTION
nodejs 12 actions are being deprecated, so we should update the setup-python action to be latest (v4) that will have the newest version of nodeJS. This will close #4692 

Signed-off-by: vsoch <vsoch@users.noreply.github.com>