### PR TITLE
update clang-format and format some files as test

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,7 +1,10 @@
 BasedOnStyle : google
 SpaceBeforeParens : Always
 IndentWidth : 4
-BreakBeforeBraces : Linux
+BreakBeforeBraces : Custom
+BraceWrapping :
+  BeforeElse : true
+  AfterFunction : true
 UseTab: Never
 AllowShortIfStatementsOnASingleLine : false
 ConstructorInitializerAllOnOneLineOrOnePerLine : true
@@ -17,10 +20,58 @@ PenaltyBreakBeforeFirstCallParameter : 10000000
 PenaltyReturnTypeOnItsOwnLine : 65000
 PenaltyBreakString : 10
 
+# preserve formatting of arguments to pack/unpack functions
+# found by running: rg --only-matching --no-filename --no-line-number  '(flux|json)(_[^ ,()]+)?_(un)?pack' | sort -u
+WhitespaceSensitiveMacros :
+- flux_conf_unpack
+- flux_event_pack
+- flux_event_publish_pack
+- flux_event_unpack
+- flux_job_result_get_unpack
+- flux_jobspec1_attr_pack
+- flux_jobspec1_attr_unpack
+- flux_jobspec_info_unpack
+- flux_jobtap_event_post_pack
+- flux_kvs_lookup_get_unpack
+- flux_kvs_lookup_unpack
+- flux_kvs_txn_pack
+- flux_lookup_get_unpack
+- flux_mrpc_pack
+- flux_msg_pack
+- flux_msg_unpack
+- flux_plugin_arg_pack
+- flux_plugin_arg_unpack
+- flux_plugin_args_unpack
+- flux_plugin_conf_unpack
+- flux_request_unpack
+- flux_respond_pack
+- flux_rpc_get_unpack
+- flux_rpc_pack
+- flux_shell_getopt_unpack
+- flux_shell_info_unpack
+- flux_shell_jobspec_info_unpack
+- flux_shell_rank_info_unpack
+- flux_shell_rpc_pack
+- flux_shell_setopt_pack
+- flux_shell_setopt_unpack
+- flux_shell_task_info_unpack
+- json_pack
+- json_unpack
+
+# treat foreach macros as for loops
+ForEachMacros :
+- json_array_foreach
+- json_object_foreach
+
 # These improve formatting results but require clang 3.6/7 or higher
+SortIncludes : false
 BreakBeforeBinaryOperators : NonAssignment
 AlignAfterOpenBracket: true
 BinPackArguments : false
 AlignOperands : true
 BreakBeforeTernaryOperators : true
 AllowAllParametersOfDeclarationOnNextLine : false
+
+# 
+# vi:tabstop=4 shiftwidth=4 expandtab ft=yaml
+# 

--- a/.clang-format
+++ b/.clang-format
@@ -11,6 +11,7 @@ ConstructorInitializerAllOnOneLineOrOnePerLine : true
 AllowShortFunctionsOnASingleLine : false
 AllowShortLoopsOnASingleLine : false
 BinPackParameters : false
+BinPackArguments : false
 AllowAllParametersOfDeclarationOnNextLine : false
 AlignTrailingComments : true
 ColumnLimit : 88
@@ -66,11 +67,12 @@ ForEachMacros :
 # These improve formatting results but require clang 3.6/7 or higher
 SortIncludes : false
 BreakBeforeBinaryOperators : NonAssignment
-AlignAfterOpenBracket: true
-BinPackArguments : false
+AlignAfterOpenBracket: Align
 AlignOperands : true
 BreakBeforeTernaryOperators : true
 AllowAllParametersOfDeclarationOnNextLine : false
+SpaceBeforeSquareBrackets: false
+IndentPPDirectives: None
 
 # 
 # vi:tabstop=4 shiftwidth=4 expandtab ft=yaml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,30 @@
-files: '^(src/bindings/python/flux|src/cmd|t/.*\\.py)'
-exclude: "^(src/bindings/python/_flux/|src/bindings/python/flux/utils/)"
+files: |
+  (?x)^(
+     src/bindings/python/flux
+    |t/
+    # |src/cmd
+    # |t/.*\\.py
+  )
+exclude: |
+  (?x)^(
+     src/bindings/python/(_flux/|flux/utils/|pycotap/)
+    |src/broker/test
+    |src/common/libev
+    |src/common/libflux/test
+    |src/common/libidset/test
+    |src/common/libjob/test
+    |src/common/libkvs/test
+    |src/common/liblsd
+    |src/common/libminilzo
+    |src/common/libminilzo/test
+    |src/common/liboptparse/test
+    |src/common/libpmi/test
+    |src/common/libtap
+    |src/common/libtomlc99/test
+    |src/common/libutil/test
+    |src/modules/kvs/test
+  )
+fail_fast: false
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.0.1
@@ -42,3 +67,12 @@ repos:
     hooks:
       - id: vermin
         args: ['-t=3.6-', '--violations']
+  - repo: https://github.com/pocc/pre-commit-hooks
+    rev: v1.3.5
+    hooks:
+      - id: cppcheck
+        args:
+          - --std=c99
+          - --inline-suppr
+          - --suppress=variableScope
+          - --suppress=unusedFunction

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -288,10 +288,11 @@ int main (int argc, char *argv[])
 
     /* Parse config.
      */
-    if (!(ctx.config = brokercfg_create (ctx.h,
-                                         optparse_get_str (ctx.opts, "config-path", NULL),
-                                         ctx.attrs,
-                                         ctx.modhash)))
+    if (!(ctx.config =
+              brokercfg_create (ctx.h,
+                                optparse_get_str (ctx.opts, "config-path", NULL),
+                                ctx.attrs,
+                                ctx.modhash)))
         goto cleanup;
     conf = flux_get_conf (ctx.h);
 
@@ -530,6 +531,9 @@ cleanup:
      */
     if (sigprocmask (SIG_SETMASK, &old_sigmask, NULL) < 0
         || sigaction (SIGINT, &old_sigact_int, NULL) < 0
+        || sigaction (SIGINT, &old_sigact_int, NULL) < 0
+        || sigaction (SIGINT, &old_sigact_int, NULL) < 0
+        || sigaction (SIGINT, &old_sigact_int, NULL) < 0 || sigaction (SIGINT, NULL) < 0
         || sigaction (SIGTERM, &old_sigact_term, NULL) < 0)
         log_err ("error restoring signal mask");
 
@@ -725,7 +729,8 @@ static int create_runat_phases (broker_ctx_t *ctx)
     /* rc1 - initialization
      */
     if (rc1 && strlen (rc1) > 0) {
-        if (runat_push_shell_command (ctx->runat, "rc1", rc1, RUNAT_FLAG_LOG_STDIO) < 0) {
+        if (runat_push_shell_command (ctx->runat, "rc1", rc1, RUNAT_FLAG_LOG_STDIO)
+            < 0) {
             log_err ("runat_push_shell_command rc1");
             return -1;
         }
@@ -744,7 +749,8 @@ static int create_runat_phases (broker_ctx_t *ctx)
     /* rc3 - finalization
      */
     if (rc3 && strlen (rc3) > 0) {
-        if (runat_push_shell_command (ctx->runat, "rc3", rc3, RUNAT_FLAG_LOG_STDIO) < 0) {
+        if (runat_push_shell_command (ctx->runat, "rc3", rc3, RUNAT_FLAG_LOG_STDIO)
+            < 0) {
             log_err ("runat_push_shell_command rc3");
             return -1;
         }

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -1,3 +1,4 @@
+
 /************************************************************\
  * Copyright 2014 Lawrence Livermore National Security, LLC
  * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
@@ -165,8 +166,7 @@ void parse_command_line_arguments (int argc, char *argv[], broker_ctx_t *ctx)
         int e;
         if ((e = argz_create (argv + optindex,
                               &ctx->init_shell_cmd,
-                              &ctx->init_shell_cmd_len))
-            != 0)
+                              &ctx->init_shell_cmd_len)) != 0)
             log_errn_exit (e, "argz_create");
     }
 }
@@ -612,15 +612,13 @@ static void init_attrs_rc_paths (attr_t *attrs)
     if (attr_add (attrs,
                   "broker.rc1_path",
                   flux_conf_builtin_get ("rc1_path", FLUX_CONF_AUTO),
-                  0)
-        < 0)
+                  0) < 0)
         log_err_exit ("attr_add rc1_path");
 
     if (attr_add (attrs,
                   "broker.rc3_path",
                   flux_conf_builtin_get ("rc3_path", FLUX_CONF_AUTO),
-                  0)
-        < 0)
+                  0) < 0)
         log_err_exit ("attr_add rc3_path");
 }
 
@@ -629,14 +627,12 @@ static void init_attrs_shell_paths (attr_t *attrs)
     if (attr_add (attrs,
                   "conf.shell_pluginpath",
                   flux_conf_builtin_get ("shell_pluginpath", FLUX_CONF_AUTO),
-                  0)
-        < 0)
+                  0) < 0)
         log_err_exit ("attr_add conf.shell_pluginpath");
     if (attr_add (attrs,
                   "conf.shell_initrc",
                   flux_conf_builtin_get ("shell_initrc", FLUX_CONF_AUTO),
-                  0)
-        < 0)
+                  0) < 0)
         log_err_exit ("attr_add conf.shell_initrc");
 }
 
@@ -729,8 +725,7 @@ static int create_runat_phases (broker_ctx_t *ctx)
     /* rc1 - initialization
      */
     if (rc1 && strlen (rc1) > 0) {
-        if (runat_push_shell_command (ctx->runat, "rc1", rc1, RUNAT_FLAG_LOG_STDIO)
-            < 0) {
+        if (runat_push_shell_command (ctx->runat, "rc1", rc1, RUNAT_FLAG_LOG_STDIO) < 0) {
             log_err ("runat_push_shell_command rc1");
             return -1;
         }
@@ -739,8 +734,7 @@ static int create_runat_phases (broker_ctx_t *ctx)
     /* rc2 - initial program
      */
     if (ctx->rank == 0 && !rc2_none) {
-        if (create_runat_rc2 (ctx->runat, ctx->init_shell_cmd, ctx->init_shell_cmd_len)
-            < 0) {
+        if (create_runat_rc2 (ctx->runat, ctx->init_shell_cmd, ctx->init_shell_cmd_len) < 0) {
             log_err ("create_runat_rc2");
             return -1;
         }
@@ -749,8 +743,7 @@ static int create_runat_phases (broker_ctx_t *ctx)
     /* rc3 - finalization
      */
     if (rc3 && strlen (rc3) > 0) {
-        if (runat_push_shell_command (ctx->runat, "rc3", rc3, RUNAT_FLAG_LOG_STDIO)
-            < 0) {
+        if (runat_push_shell_command (ctx->runat, "rc3", rc3, RUNAT_FLAG_LOG_STDIO) < 0) {
             log_err ("runat_push_shell_command rc3");
             return -1;
         }
@@ -950,8 +943,7 @@ static int init_critical_ranks_attr (struct overlay *ov, attr_t *attrs)
             log_err ("unable to calculate critical-ranks attribute");
             goto out;
         }
-        if (attr_add (attrs, "broker.critical-ranks", ranks, FLUX_ATTRFLAG_IMMUTABLE)
-            < 0) {
+        if (attr_add (attrs, "broker.critical-ranks", ranks, FLUX_ATTRFLAG_IMMUTABLE) < 0) {
             log_err ("attr_add critical_ranks");
             goto out;
         }
@@ -964,8 +956,7 @@ static int init_critical_ranks_attr (struct overlay *ov, attr_t *attrs)
         }
         /*  Need to set immutable flag when attr set on command line
          */
-        if (attr_set_flags (attrs, "broker.critical-ranks", FLUX_ATTRFLAG_IMMUTABLE)
-            < 0) {
+        if (attr_set_flags (attrs, "broker.critical-ranks", FLUX_ATTRFLAG_IMMUTABLE) < 0) {
             log_err ("failed to make broker.criitcal-ranks attr immutable");
             goto out;
         }
@@ -1169,8 +1160,7 @@ static int load_module_bypath (broker_ctx_t *ctx,
                      module_get_name (p),
                      module_get_uuid (p),
                      mod_svc_cb,
-                     p)
-        < 0)
+                     p) < 0)
         goto module_remove;
     arg = argz_next (argz, argz_len, NULL);
     while (arg) {
@@ -2066,4 +2056,3 @@ void I_WRAP_SONAME_FNNAME_ZZ (Za, dlclose) (void *dso)
 
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab
- */

--- a/src/common/libflux/test/message.c
+++ b/src/common/libflux/test/message.c
@@ -53,8 +53,7 @@ void check_cornercase (void)
     if (!(any = flux_msg_create (FLUX_MSGTYPE_ANY)))
         BAIL_OUT ("flux_msg_create failed");
 
-    lives_ok ({flux_msg_destroy (NULL);},
-        "flux_msg_destroy msg=NULL doesnt crash");
+    lives_ok ({ flux_msg_destroy (NULL); }, "flux_msg_destroy msg=NULL doesnt crash");
 
     errno = 0;
     ok (flux_msg_aux_set (NULL, "foo", "bar", NULL) < 0 && errno == EINVAL,
@@ -70,8 +69,7 @@ void check_cornercase (void)
     errno = 0;
     ok (flux_msg_incref (NULL) == NULL && errno == EINVAL,
         "flux_msg_incref msg=NULL fails with EINVAL");
-    lives_ok ({flux_msg_decref (NULL);},
-        "flux_msg_decref msg=NULL doesnt crash");
+    lives_ok ({ flux_msg_decref (NULL); }, "flux_msg_decref msg=NULL doesnt crash");
 
     errno = 0;
     ok (flux_msg_encode_size (NULL) < 0 && errno == EINVAL,
@@ -92,8 +90,8 @@ void check_cornercase (void)
     errno = 0;
     ok (flux_msg_get_type (NULL, &type) < 0 && errno == EINVAL,
         "flux_msg_get_type fails with EINVAL on msg = NULL");
-    lives_ok ({flux_msg_get_type (msg, NULL);},
-        "flux_msg_get_type doesn't segfault with NULL type arg");
+    lives_ok ({ flux_msg_get_type (msg, NULL); },
+              "flux_msg_get_type doesn't segfault with NULL type arg");
 
     errno = 0;
     ok (flux_msg_set_private (NULL) < 0 && errno == EINVAL,
@@ -113,13 +111,13 @@ void check_cornercase (void)
 
     errno = 0;
     ok (flux_msg_set_topic (NULL, "foobar") < 0 && errno == EINVAL,
-       "flux_msg_set_topic fails with EINVAL on msg = NULL");
+        "flux_msg_set_topic fails with EINVAL on msg = NULL");
     errno = 0;
     ok (flux_msg_get_topic (msg, NULL) < 0 && errno == EINVAL,
-       "flux_msg_get_topic fails with EINVAL on in-and-out param = NULL");
+        "flux_msg_get_topic fails with EINVAL on in-and-out param = NULL");
     errno = 0;
     ok (flux_msg_get_topic (msg, &topic) < 0 && errno == EPROTO,
-       "flux_msg_get_topic fails with EPROTO on msg w/o topic");
+        "flux_msg_get_topic fails with EPROTO on msg w/o topic");
 
     errno = 0;
     ok (flux_msg_set_payload (NULL, NULL, 0) < 0 && errno == EINVAL,
@@ -127,20 +125,20 @@ void check_cornercase (void)
     errno = 0;
     ok (flux_msg_get_payload (NULL, NULL, NULL) < 0 && errno == EINVAL,
         "flux_msg_get_payload msg=NULL fails with EINVAL");
-    lives_ok ({flux_msg_get_payload (msg, NULL, NULL);},
-       "flux_msg_get_payload does not segfault on in-and-out params = NULL");
+    lives_ok ({ flux_msg_get_payload (msg, NULL, NULL); },
+              "flux_msg_get_payload does not segfault on in-and-out params = "
+              "NULL");
     errno = 0;
-    ok (flux_msg_get_payload (msg, &payload, &payload_size) < 0
-        && errno == EPROTO,
-       "flux_msg_get_payload fails with EPROTO on msg w/o payload");
+    ok (flux_msg_get_payload (msg, &payload, &payload_size) < 0 && errno == EPROTO,
+        "flux_msg_get_payload fails with EPROTO on msg w/o payload");
     ok (flux_msg_has_payload (NULL) == false,
         "flux_msg_has_payload returns false on msg = NULL");
 
     errno = 0;
     ok (flux_msg_get_flags (NULL, &flags) < 0 && errno == EINVAL,
         "flux_msg_get_flags msg=NULL fails with EINVAL");
-    lives_ok ({flux_msg_get_flags (msg, NULL);},
-        "flux_msg_get_flags flags=NULL does not segfault");
+    lives_ok ({ flux_msg_get_flags (msg, NULL); },
+              "flux_msg_get_flags flags=NULL does not segfault");
     errno = 0;
     ok (flux_msg_set_flags (NULL, 0) < 0 && errno == EINVAL,
         "flux_msg_set_flags msg=NULL fails with EINVAL");
@@ -148,27 +146,26 @@ void check_cornercase (void)
     ok (flux_msg_set_flags (msg, 0xff) < 0 && errno == EINVAL,
         "flux_msg_set_flags flags=(invalid) fails with EINVAL");
     errno = 0;
-    ok (flux_msg_set_flags (msg, FLUX_MSGFLAG_STREAMING
-                                | FLUX_MSGFLAG_NORESPONSE) < 0
-        && errno == EINVAL,
+    ok (flux_msg_set_flags (msg, FLUX_MSGFLAG_STREAMING | FLUX_MSGFLAG_NORESPONSE) < 0
+            && errno == EINVAL,
         "flux_msg_set_flags streaming|noresponse fails with EINVAL");
 
     errno = 0;
     ok (flux_msg_pack (NULL, "{s:i}", "foo", 42) < 0 && errno == EINVAL,
-       "flux_msg_pack msg=NULL fails with EINVAL");
+                       "flux_msg_pack msg=NULL fails with EINVAL");
     errno = 0;
     ok (flux_msg_pack (msg, NULL) < 0 && errno == EINVAL,
-        "flux_msg_pack fails with EINVAL with NULL format");
+                       "flux_msg_pack fails with EINVAL with NULL format");
     errno = 0;
     ok (flux_msg_unpack (NULL, "{s:i}", "type", &type) < 0 && errno == EINVAL,
-       "flux_msg_unpack msg=NULL fails with EINVAL");
+                         "flux_msg_unpack msg=NULL fails with EINVAL");
     errno = 0;
     ok (flux_msg_unpack (msg, NULL) < 0 && errno == EINVAL,
-        "flux_msg_unpack fails with EINVAL with NULL format");
+                         "flux_msg_unpack fails with EINVAL with NULL format");
 
     errno = 0;
     ok (flux_msg_set_nodeid (NULL, 0) < 0 && errno == EINVAL,
-                "flux_msg_set_nodeid fails with EINVAL on msg = NULL");
+        "flux_msg_set_nodeid fails with EINVAL on msg = NULL");
     errno = 0;
     ok (flux_msg_get_nodeid (NULL, &nodeid) < 0 && errno == EINVAL,
         "flux_msg_get_nodeid fails with EINVAL on msg = NULL");
@@ -178,16 +175,16 @@ void check_cornercase (void)
     errno = 0;
     ok (flux_msg_get_userid (NULL, &cred.userid) < 0 && errno == EINVAL,
         "flux_msg_get_userid msg=NULL fails with EINVAL");
-    lives_ok ({flux_msg_get_userid (msg, NULL);},
-        "flux_msg_get_userid userid=NULL does not segfault");
+    lives_ok ({ flux_msg_get_userid (msg, NULL); },
+              "flux_msg_get_userid userid=NULL does not segfault");
     errno = 0;
     ok (flux_msg_set_userid (NULL, cred.userid) < 0 && errno == EINVAL,
         "flux_msg_set_userid msg=NULL fails with EINVAL");
     errno = 0;
     ok (flux_msg_get_rolemask (NULL, &cred.rolemask) < 0 && errno == EINVAL,
         "flux_msg_get_rolemask msg=NULL fails with EINVAL");
-    lives_ok ({flux_msg_get_rolemask (msg, NULL);},
-        "flux_msg_get_rolemask rolemask=NULL does not segfault");
+    lives_ok ({ flux_msg_get_rolemask (msg, NULL); },
+              "flux_msg_get_rolemask rolemask=NULL does not segfault");
     errno = 0;
     ok (flux_msg_set_rolemask (NULL, cred.rolemask) < 0 && errno == EINVAL,
         "flux_msg_set_rolemask msg=NULL fails with EINVAL");
@@ -211,8 +208,8 @@ void check_cornercase (void)
     errno = 0;
     ok (flux_msg_get_errnum (NULL, &errnum) < 0 && errno == EINVAL,
         "flux_msg_get_errnum fails with EINVAL on msg = NULL");
-    lives_ok ({flux_msg_get_errnum (msg, NULL);},
-        "flux_msg_get_errnum errnum = NULL does not segfault");
+    lives_ok ({ flux_msg_get_errnum (msg, NULL); },
+              "flux_msg_get_errnum errnum = NULL does not segfault");
     errno = 0;
     ok (flux_msg_get_errnum (req, &errnum) < 0 && errno == EPROTO,
         "flux_msg_get_errnum fails with EPROTO on msg != response type");
@@ -222,8 +219,8 @@ void check_cornercase (void)
     errno = 0;
     ok (flux_msg_get_seq (NULL, &seq) < 0 && errno == EINVAL,
         "flux_msg_get_seq fails with EINVAL on msg = NULL");
-    lives_ok ({flux_msg_get_seq (msg, NULL);},
-        "flux_msg_get_seq seq = NULL does not segfault");
+    lives_ok ({ flux_msg_get_seq (msg, NULL); },
+              "flux_msg_get_seq seq = NULL does not segfault");
     errno = 0;
     ok (flux_msg_get_seq (req, &seq) < 0 && errno == EPROTO,
         "flux_msg_get_seq fails with EPROTO on msg != event type");
@@ -233,8 +230,8 @@ void check_cornercase (void)
     errno = 0;
     ok (flux_msg_get_control (NULL, &type, &status) < 0 && errno == EINVAL,
         "flux_msg_get_status fails with EINVAL on msg = NULL");
-    lives_ok ({flux_msg_get_control (msg, &type, NULL);},
-        "flux_msg_get_status status = NULL does not segfault");
+    lives_ok ({ flux_msg_get_control (msg, &type, NULL); },
+              "flux_msg_get_status status = NULL does not segfault");
     errno = 0;
     ok (flux_msg_get_control (req, &type, &status) < 0 && errno == EPROTO,
         "flux_msg_get_status fails with EPROTO on msg != control type");
@@ -244,18 +241,18 @@ void check_cornercase (void)
     errno = 0;
     ok (flux_msg_get_matchtag (NULL, &tag) < 0 && errno == EINVAL,
         "flux_msg_get_matchtag fails with EINVAL on msg = NULL");
-    lives_ok ({flux_msg_get_matchtag (msg, NULL);},
-        "flux_msg_get_matchtag matchtag = NULL does not segfault");
+    lives_ok ({ flux_msg_get_matchtag (msg, NULL); },
+              "flux_msg_get_matchtag matchtag = NULL does not segfault");
     errno = 0;
     ok (flux_msg_get_matchtag (evt, &tag) < 0 && errno == EPROTO,
         "flux_msg_get_matchtag fails with EPROTO on msg != req/rsp type");
 
-    lives_ok ({flux_msg_route_enable (NULL);},
-        "flux_msg_route_enable msg=NULL doesnt crash");
-    lives_ok ({flux_msg_route_disable (NULL);},
-        "flux_msg_route_disable msg=NULL doesnt crash");
-    lives_ok ({flux_msg_route_clear (NULL);},
-        "flux_msg_route_clear msg=NULL doesnt crash");
+    lives_ok ({ flux_msg_route_enable (NULL); },
+              "flux_msg_route_enable msg=NULL doesnt crash");
+    lives_ok ({ flux_msg_route_disable (NULL); },
+              "flux_msg_route_disable msg=NULL doesnt crash");
+    lives_ok ({ flux_msg_route_clear (NULL); },
+              "flux_msg_route_clear msg=NULL doesnt crash");
 
     errno = 0;
     ok (flux_msg_route_push (NULL, "foo") == -1 && errno == EINVAL,
@@ -265,7 +262,8 @@ void check_cornercase (void)
         "flux_msg_route_push returns -1 errno EINVAL on id = NULL");
     errno = 0;
     ok (flux_msg_route_push (msg, "foo") == -1 && errno == EPROTO,
-        "flux_msg_route_push returns -1 errno EPROTO on msg w/o routes enabled");
+        "flux_msg_route_push returns -1 errno EPROTO on msg w/o routes "
+        "enabled");
     errno = 0;
     ok (flux_msg_route_delete_last (NULL) == -1 && errno == EINVAL,
         "flux_msg_route_delete_last returns -1 errno EINVAL on id = NULL");
@@ -310,7 +308,7 @@ void check_routes (void)
     char *s;
 
     ok ((msg = flux_msg_create (FLUX_MSGTYPE_REQUEST)) != NULL
-        && flux_msg_frames (msg) == 1,
+            && flux_msg_frames (msg) == 1,
         "flux_msg_create works and creates msg with 1 frame");
 
     flux_msg_route_clear (msg);
@@ -334,20 +332,14 @@ void check_routes (void)
     ok ((flux_msg_route_count (msg) == 1),
         "flux_msg_route_count returns 1 on msg w/ id1");
 
-    ok ((route = flux_msg_route_first (msg)) != NULL,
-        "flux_msg_route_first works");
-    like (route, "sender",
-        "flux_msg_route_first returns id on msg w/ id1");
+    ok ((route = flux_msg_route_first (msg)) != NULL, "flux_msg_route_first works");
+    like (route, "sender", "flux_msg_route_first returns id on msg w/ id1");
 
-    ok ((route = flux_msg_route_last (msg)) != NULL,
-        "flux_msg_route_last works");
-    like (route, "sender",
-        "flux_msg_route_last returns id on msg w/ id1");
+    ok ((route = flux_msg_route_last (msg)) != NULL, "flux_msg_route_last works");
+    like (route, "sender", "flux_msg_route_last returns id on msg w/ id1");
 
-    ok ((s = flux_msg_route_string (msg)) != NULL,
-        "flux_msg_route_string works");
-    like (s, "sender",
-        "flux_msg_route_string returns correct string on msg w/ id1");
+    ok ((s = flux_msg_route_string (msg)) != NULL, "flux_msg_route_string works");
+    like (s, "sender", "flux_msg_route_string returns correct string on msg w/ id1");
     free (s);
 
     ok (flux_msg_route_push (msg, "router") == 0 && flux_msg_frames (msg) == 4,
@@ -355,20 +347,16 @@ void check_routes (void)
     ok ((flux_msg_route_count (msg) == 2),
         "flux_msg_route_count returns 2 on msg w/ id1+id2");
 
-    ok ((route = flux_msg_route_first (msg)) != NULL,
-        "flux_msg_route_first works");
-    like (route, "sender",
-        "flux_msg_route_first returns id1 on msg w/ id1+id2");
+    ok ((route = flux_msg_route_first (msg)) != NULL, "flux_msg_route_first works");
+    like (route, "sender", "flux_msg_route_first returns id1 on msg w/ id1+id2");
 
-    ok ((route = flux_msg_route_last (msg)) != NULL,
-        "flux_msg_route_last works");
-    like (route, "router",
-        "flux_msg_route_last returns id2 on message with id1+id2");
+    ok ((route = flux_msg_route_last (msg)) != NULL, "flux_msg_route_last works");
+    like (route, "router", "flux_msg_route_last returns id2 on message with id1+id2");
 
-    ok ((s = flux_msg_route_string (msg)) != NULL,
-        "flux_msg_route_string works");
-    like (s, "sender!router",
-        "flux_msg_route_string returns correct string on msg w/ id1+id2");
+    ok ((s = flux_msg_route_string (msg)) != NULL, "flux_msg_route_string works");
+    like (s,
+          "sender!router",
+          "flux_msg_route_string returns correct string on msg w/ id1+id2");
     free (s);
 
     ok (flux_msg_route_delete_last (msg) == 0 && flux_msg_frames (msg) == 3,
@@ -377,19 +365,18 @@ void check_routes (void)
         "flux_msg_route_count returns 1 on message w/ id1");
 
     flux_msg_route_clear (msg);
-    ok (flux_msg_route_count (msg) == 0,
-        "flux_msg_route_clear clear routing frames");
+    ok (flux_msg_route_count (msg) == 0, "flux_msg_route_clear clear routing frames");
     ok (flux_msg_frames (msg) == 2,
         "flux_msg_route_clear did not disable routing frames");
 
     ok (flux_msg_route_push (msg, "foobar") == 0 && flux_msg_frames (msg) == 3,
-        "flux_msg_route_push works and adds a frame after flux_msg_route_clear()");
+        "flux_msg_route_push works and adds a frame after "
+        "flux_msg_route_clear()");
     ok ((flux_msg_route_count (msg) == 1),
         "flux_msg_route_count returns 1 on msg w/ id1");
 
     flux_msg_route_disable (msg);
-    ok (flux_msg_frames (msg) == 1,
-        "flux_msg_route_disable clear routing frames");
+    ok (flux_msg_frames (msg) == 1, "flux_msg_route_disable clear routing frames");
 
     ok (flux_msg_route_push (msg, "boobar") < 0 && errno == EPROTO,
         "flux_msg_route_push fails with EPROTO after flux_msg_route_disable()");
@@ -415,7 +402,8 @@ void check_routes (void)
     if (flux_msg_route_push (msg2, "bar") < 0)
         BAIL_OUT ("flux_msg_route_push failed");
     ok (flux_msg_route_match_first (msg, msg2) == true,
-        "flux_msg_route_match_first still returns true with more routes pushed");
+        "flux_msg_route_match_first still returns true with more routes "
+        "pushed");
 
     flux_msg_destroy (msg);
     flux_msg_destroy (msg2);
@@ -429,21 +417,16 @@ void check_topic (void)
     const char *s;
 
     ok ((msg = flux_msg_create (FLUX_MSGTYPE_REQUEST)) != NULL,
-       "flux_msg_create works");
-    ok (flux_msg_set_topic (msg, "blorg") == 0,
-       "flux_msg_set_topic works");
-    ok (flux_msg_get_topic (msg, &s) == 0,
-       "flux_msg_get_topic works on msg w/topic");
-    like (s, "blorg",
-       "and we got back the topic string we set");
+        "flux_msg_create works");
+    ok (flux_msg_set_topic (msg, "blorg") == 0, "flux_msg_set_topic works");
+    ok (flux_msg_get_topic (msg, &s) == 0, "flux_msg_get_topic works on msg w/topic");
+    like (s, "blorg", "and we got back the topic string we set");
 
     flux_msg_route_enable (msg);
-    ok (flux_msg_route_push (msg, "id1") == 0,
-        "flux_msg_route_push works");
+    ok (flux_msg_route_push (msg, "id1") == 0, "flux_msg_route_push works");
     ok (flux_msg_get_topic (msg, &s) == 0,
-       "flux_msg_get_topic still works, with routes");
-    like (s, "blorg",
-       "and we got back the topic string we set");
+        "flux_msg_get_topic still works, with routes");
+    like (s, "blorg", "and we got back the topic string we set");
     flux_msg_destroy (msg);
 }
 
@@ -455,16 +438,17 @@ void check_payload_json (void)
     int i;
 
     ok ((msg = flux_msg_create (FLUX_MSGTYPE_REQUEST)) != NULL,
-       "flux_msg_create works");
+        "flux_msg_create works");
 
     s = (char *)msg;
     ok (flux_msg_get_string (msg, &s) == 0 && s == NULL,
-       "flux_msg_get_string returns success with no payload");
+        "flux_msg_get_string returns success with no payload");
 
-    ok (strlen(flux_msg_last_error (msg)) == 0,
+    ok (strlen (flux_msg_last_error (msg)) == 0,
         "flux_msg_last_error() returns empty string before pack/unpack");
 
-    is (flux_msg_last_error (NULL), "msg object is NULL",
+    is (flux_msg_last_error (NULL),
+        "msg object is NULL",
         "flux_msg_last_error() returns 'msg object is NULL' on NULL arg");
 
     /* Unpack on a message with invalid string payload should be an error
@@ -474,25 +458,28 @@ void check_payload_json (void)
         "set invalid string payload on msg");
     errno = 0;
     ok (flux_msg_unpack (msg, "{s:i}", "foo", &i) < 0 && errno == EPROTO,
-        "flux_msg_unpack() on message with invalid payload returns EPROTO");
+                         "flux_msg_unpack() on message with invalid payload "
+                         "returns EPROTO");
     is (flux_msg_last_error (msg),
         "flux_msg_get_string: Protocol error",
         "flux_msg_last_error reports '%s'",
-        flux_msg_last_error(msg));
+        flux_msg_last_error (msg));
 
     /* RFC 3 - json payload must be an object
      * Encoding should return EINVAL.
      */
     errno = 0;
     ok (flux_msg_pack (msg, "[1,2,3]") < 0 && errno == EINVAL,
-       "flux_msg_pack array fails with EINVAL");
-    ok (strlen(flux_msg_last_error (msg)) > 0,
-        "flux_msg_last_error: %s", flux_msg_last_error (msg));
+                       "flux_msg_pack array fails with EINVAL");
+    ok (strlen (flux_msg_last_error (msg)) > 0,
+        "flux_msg_last_error: %s",
+        flux_msg_last_error (msg));
     errno = 0;
     ok (flux_msg_pack (msg, "3.14") < 0 && errno == EINVAL,
-       "flux_msg_pack scalar fails with EINVAL");
-    ok (strlen(flux_msg_last_error (msg)) > 0,
-        "flux_msg_last_error: %s", flux_msg_last_error (msg));
+                       "flux_msg_pack scalar fails with EINVAL");
+    ok (strlen (flux_msg_last_error (msg)) > 0,
+        "flux_msg_last_error: %s",
+        flux_msg_last_error (msg));
 
     /* Sneak in a malformed JSON payloads and test decoding.
      * 1) array
@@ -501,36 +488,38 @@ void check_payload_json (void)
         BAIL_OUT ("flux_msg_set_string failed");
     errno = 0;
     ok (flux_msg_unpack (msg, "o", &o) < 0 && errno == EPROTO,
-        "flux_msg_unpack array fails with EPROTO");
-    ok (strlen(flux_msg_last_error (msg)) > 0,
-        "flux_msg_last_error: %s", flux_msg_last_error (msg));
+                         "flux_msg_unpack array fails with EPROTO");
+    ok (strlen (flux_msg_last_error (msg)) > 0,
+        "flux_msg_last_error: %s",
+        flux_msg_last_error (msg));
     /* 2) bare value
      */
     if (flux_msg_set_string (msg, "3.14") < 0)
         BAIL_OUT ("flux_msg_set_string failed");
     errno = 0;
     ok (flux_msg_unpack (msg, "o", &o) < 0 && errno == EPROTO,
-        "flux_msg_unpack scalar fails with EPROTO");
-    ok (strlen(flux_msg_last_error (msg)) > 0,
-        "flux_msg_last_error: %s", flux_msg_last_error (msg));
+                         "flux_msg_unpack scalar fails with EPROTO");
+    ok (strlen (flux_msg_last_error (msg)) > 0,
+        "flux_msg_last_error: %s",
+        flux_msg_last_error (msg));
     /* 3) malformed object (no trailing })
      */
     if (flux_msg_set_string (msg, "{\"a\":42") < 0)
         BAIL_OUT ("flux_msg_set_string failed");
     errno = 0;
     ok (flux_msg_unpack (msg, "o", &o) < 0 && errno == EPROTO,
-        "flux_msg_unpack malformed object fails with EPROTO");
-    ok (strlen(flux_msg_last_error (msg)) > 0,
-        "flux_msg_last_error: %s", flux_msg_last_error (msg));
+                         "flux_msg_unpack malformed object fails with EPROTO");
+    ok (strlen (flux_msg_last_error (msg)) > 0,
+        "flux_msg_last_error: %s",
+        flux_msg_last_error (msg));
 
-    ok (flux_msg_pack (msg, "{s:i}", "foo", 42) == 0,
-       "flux_msg_pack works");
-    ok (strlen(flux_msg_last_error (msg)) == 0,
+    ok (flux_msg_pack (msg, "{s:i}", "foo", 42) == 0, "flux_msg_pack works");
+    ok (strlen (flux_msg_last_error (msg)) == 0,
         "flux_msg_last_error returns empty string after ok pack");
     i = 0;
     ok (flux_msg_unpack (msg, "{s:i}", "foo", &i) == 0 && i == 42,
-       "flux_msg_unpack returns payload intact");
-    ok (strlen(flux_msg_last_error (msg)) == 0,
+                         "flux_msg_unpack returns payload intact");
+    ok (strlen (flux_msg_last_error (msg)) == 0,
         "flux_msg_last_error returns empty string after ok unpack");
 
     flux_msg_destroy (msg);
@@ -543,31 +532,35 @@ void check_payload_json_formatted (void)
     const char *s;
 
     ok ((msg = flux_msg_create (FLUX_MSGTYPE_REQUEST)) != NULL,
-       "flux_msg_create works");
+        "flux_msg_create works");
     errno = 0;
     ok (flux_msg_unpack (msg, "{}") < 0 && errno == EPROTO,
-        "flux_msg_unpack fails with EPROTO with no payload");
+                         "flux_msg_unpack fails with EPROTO with no payload");
     ok (strlen (flux_msg_last_error (msg)) > 0,
-        "flux_msg_last_error: %s", flux_msg_last_error (msg));
+        "flux_msg_last_error: %s",
+        flux_msg_last_error (msg));
 
     errno = 0;
     ok (flux_msg_pack (msg, "[i,i,i]", 1,2,3) < 0 && errno == EINVAL,
-        "flux_msg_pack array fails with EINVAL");
-    is (flux_msg_last_error (msg), "payload is not a JSON object",
-        "flux_msg_last_error: %s", flux_msg_last_error (msg));
+                       "flux_msg_pack array fails with EINVAL");
+    is (flux_msg_last_error (msg),
+        "payload is not a JSON object",
+        "flux_msg_last_error: %s",
+        flux_msg_last_error (msg));
     errno = 0;
     ok (flux_msg_pack (msg, "i", 3.14) < 0 && errno == EINVAL,
-       "flux_msg_pack scalar fails with EINVAL");
+                       "flux_msg_pack scalar fails with EINVAL");
     ok (strlen (flux_msg_last_error (msg)) > 0,
-        "flux_msg_last_error: %s", flux_msg_last_error (msg));
+        "flux_msg_last_error: %s",
+        flux_msg_last_error (msg));
     ok (flux_msg_pack (msg, "{s:i, s:s}", "foo", 42, "bar", "baz") == 0,
-       "flux_msg_pack object works");
+                       "flux_msg_pack object works");
     ok (strlen (flux_msg_last_error (msg)) == 0,
         "flux_msg_last_error is empty string after ok pack");
     i = 0;
     s = NULL;
     ok (flux_msg_unpack (msg, "{s:i, s:s}", "foo", &i, "bar", &s) == 0,
-       "flux_msg_unpack object works");
+                         "flux_msg_unpack object works");
     ok (strlen (flux_msg_last_error (msg)) == 0,
         "flux_msg_last_error is empty string after ok unpack");
     ok (i == 42 && s != NULL && !strcmp (s, "baz"),
@@ -575,18 +568,18 @@ void check_payload_json_formatted (void)
 
     /* reset payload */
     ok (flux_msg_pack (msg, "{s:i, s:s}", "foo", 43, "bar", "smurf") == 0,
-       "flux_msg_pack can replace JSON object payload");
+                       "flux_msg_pack can replace JSON object payload");
     i = 0;
     s = NULL;
     ok (flux_msg_unpack (msg, "{s:i, s:s}", "foo", &i, "bar", &s) == 0,
-       "flux_msg_unpack object works");
+                         "flux_msg_unpack object works");
     ok (i == 43 && s != NULL && !strcmp (s, "smurf"),
         "decoded content matches new encoded content");
 
     i = 0;
     s = NULL;
     ok (flux_msg_unpack (msg, "{s:s, s:i}", "bar", &s, "foo", &i) == 0,
-       "flux_msg_unpack object works out of order");
+                         "flux_msg_unpack object works out of order");
     ok (i == 43 && s != NULL && !strcmp (s, "smurf"),
         "decoded content matches new encoded content");
 
@@ -595,15 +588,17 @@ void check_payload_json_formatted (void)
 
     errno = 0;
     ok (flux_msg_unpack (msg, "") < 0 && errno == EINVAL,
-        "flux_msg_unpack fails with EINVAL with \"\" format");
+                         "flux_msg_unpack fails with EINVAL with \"\" format");
     ok (strlen (flux_msg_last_error (msg)) == 0,
         "flux_msg_last_error is empty string on EINVAL");
 
     errno = 0;
     ok (flux_msg_unpack (msg, "{s:s}", "nope", &s) < 0 && errno == EPROTO,
-        "flux_msg_unpack fails with EPROTO with nonexistent key");
+                         "flux_msg_unpack fails with EPROTO with nonexistent "
+                         "key");
     ok (strlen (flux_msg_last_error (msg)) > 0,
-        "flux_msg_last_error is %s", flux_msg_last_error (msg));
+        "flux_msg_last_error is %s",
+        flux_msg_last_error (msg));
 
     /* flux_msg_pack/unpack doesn't reject packed NUL chars */
     char buf[4] = "foo";
@@ -611,13 +606,11 @@ void check_payload_json_formatted (void)
     size_t len = -1;
 
     ok (flux_msg_pack (msg, "{ss#}", "result", buf, 4) == 0,
-        "flux_msg_pack with NUL char works");
+                       "flux_msg_pack with NUL char works");
     ok (flux_msg_unpack (msg, "{ss%}", "result", &result, &len) == 0,
-        "flux_msg_unpack with NUL char works");
-    ok (len == 4,
-        "flux_msg_unpack returned correct length");
-    ok (memcmp (buf, result, 4) == 0,
-        "original buffer and result match");
+                         "flux_msg_unpack with NUL char works");
+    ok (len == 4, "flux_msg_unpack returned correct length");
+    ok (memcmp (buf, result, 4) == 0, "original buffer and result match");
 
     flux_msg_destroy (msg);
 }
@@ -633,78 +626,75 @@ void check_payload (void)
     int plen = sizeof (pay), len;
 
     ok ((msg = flux_msg_create (FLUX_MSGTYPE_REQUEST)) != NULL,
-       "flux_msg_create works");
+        "flux_msg_create works");
     errno = 0;
     ok (flux_msg_set_payload (msg, NULL, 0) == 0 && errno == 0,
         "flux_msg_set_payload NULL works with no payload");
     errno = 0;
     ok (flux_msg_get_payload (msg, &buf, &len) < 0 && errno == EPROTO,
-       "flux_msg_get_payload still fails");
+        "flux_msg_get_payload still fails");
 
     errno = 0;
     memset (pay, 42, plen);
-    ok (flux_msg_set_payload (msg, pay, plen) == 0
-        && flux_msg_frames (msg) == 2,
-       "flux_msg_set_payload works");
+    ok (flux_msg_set_payload (msg, pay, plen) == 0 && flux_msg_frames (msg) == 2,
+        "flux_msg_set_payload works");
 
-    len = 0; buf = NULL; errno = 0;
-    ok (flux_msg_get_payload (msg, &buf, &len) == 0
-        && buf && len == plen && errno == 0,
-       "flux_msg_get_payload works");
-    cmp_mem (buf, pay, len,
-       "and we got back the payload we set");
+    len = 0;
+    buf = NULL;
+    errno = 0;
+    ok (flux_msg_get_payload (msg, &buf, &len) == 0 && buf && len == plen && errno == 0,
+        "flux_msg_get_payload works");
+    cmp_mem (buf, pay, len, "and we got back the payload we set");
 
     ok (flux_msg_set_topic (msg, "blorg") == 0 && flux_msg_frames (msg) == 3,
-       "flux_msg_set_topic works");
-    len = 0; buf = NULL; errno = 0;
-    ok (flux_msg_get_payload (msg, &buf, &len) == 0
-        && buf && len == plen && errno == 0,
-       "flux_msg_get_payload works with topic");
-    cmp_mem (buf, pay, len,
-       "and we got back the payload we set");
+        "flux_msg_set_topic works");
+    len = 0;
+    buf = NULL;
+    errno = 0;
+    ok (flux_msg_get_payload (msg, &buf, &len) == 0 && buf && len == plen && errno == 0,
+        "flux_msg_get_payload works with topic");
+    cmp_mem (buf, pay, len, "and we got back the payload we set");
     ok (flux_msg_set_topic (msg, NULL) == 0 && flux_msg_frames (msg) == 2,
-       "flux_msg_set_topic NULL works");
+        "flux_msg_set_topic NULL works");
 
     flux_msg_route_enable (msg);
-    ok (flux_msg_frames (msg) == 3,
-        "flux_msg_route_enable works");
+    ok (flux_msg_frames (msg) == 3, "flux_msg_route_enable works");
     ok (flux_msg_route_push (msg, "id1") == 0 && flux_msg_frames (msg) == 4,
         "flux_msg_route_push works");
 
-    len = 0; buf = NULL; errno = 0;
-    ok (flux_msg_get_payload (msg, &buf, &len) == 0
-        && buf && len == plen && errno == 0,
-       "flux_msg_get_payload still works, with routes");
-    cmp_mem (buf, pay, len,
-       "and we got back the payload we set");
+    len = 0;
+    buf = NULL;
+    errno = 0;
+    ok (flux_msg_get_payload (msg, &buf, &len) == 0 && buf && len == plen && errno == 0,
+        "flux_msg_get_payload still works, with routes");
+    cmp_mem (buf, pay, len, "and we got back the payload we set");
 
     ok (flux_msg_set_topic (msg, "blorg") == 0 && flux_msg_frames (msg) == 5,
-       "flux_msg_set_topic works");
-    len = 0; buf = NULL; errno = 0;
-    ok (flux_msg_get_payload (msg, &buf, &len) == 0
-        && buf && len == plen && errno == 0,
-       "flux_msg_get_payload works, with topic and routes");
-    cmp_mem (buf, pay, len,
-       "and we got back the payload we set");
+        "flux_msg_set_topic works");
+    len = 0;
+    buf = NULL;
+    errno = 0;
+    ok (flux_msg_get_payload (msg, &buf, &len) == 0 && buf && len == plen && errno == 0,
+        "flux_msg_get_payload works, with topic and routes");
+    cmp_mem (buf, pay, len, "and we got back the payload we set");
 
     errno = 0;
     ok (flux_msg_set_payload (msg, buf, len - 1) < 0 && errno == EINVAL,
-        "flux_msg_set_payload detects reuse of payload fragment and fails with EINVAL");
+        "flux_msg_set_payload detects reuse of payload fragment and fails with "
+        "EINVAL");
 
     ok (flux_msg_set_payload (msg, buf, len) == 0,
         "flux_msg_set_payload detects payload echo and works");
-    ok (flux_msg_get_payload (msg, &buf, &len) == 0
-        && buf && len == plen,
-       "flux_msg_get_payload works");
-    cmp_mem (buf, pay, len,
-       "and we got back the payload we set");
+    ok (flux_msg_get_payload (msg, &buf, &len) == 0 && buf && len == plen,
+        "flux_msg_get_payload works");
+    cmp_mem (buf, pay, len, "and we got back the payload we set");
 
     errno = 0;
     ok (flux_msg_set_payload (msg, NULL, 0) == 0 && errno == 0,
         "flux_msg_set_payload NULL works");
     errno = 0;
     ok (flux_msg_get_payload (msg, &buf, &len) < 0 && errno == EPROTO,
-       "flux_msg_get_payload now fails with EPROTO");
+        "flux_msg_get_payload now fails with EPROTO");
 
     flux_msg_destroy (msg);
 }
@@ -721,8 +711,7 @@ void check_proto (void)
     int errnum;
     int type;
 
-    ok ((msg = flux_msg_create (FLUX_MSGTYPE_ANY)) != NULL,
-        "flux_msg_create works");
+    ok ((msg = flux_msg_create (FLUX_MSGTYPE_ANY)) != NULL, "flux_msg_create works");
     ok (flux_msg_get_type (msg, &type) == 0 && type == FLUX_MSGTYPE_ANY,
         "flux_msg_get_type works with type FLUX_MSGTYPE_ANY");
     flux_msg_destroy (msg);
@@ -732,31 +721,25 @@ void check_proto (void)
     ok (flux_msg_get_type (msg, &type) == 0 && type == FLUX_MSGTYPE_RESPONSE,
         "flux_msg_get_type works and returns what we set");
 
-    ok (flux_msg_set_type (msg, FLUX_MSGTYPE_REQUEST) == 0,
-        "flux_msg_set_type works");
+    ok (flux_msg_set_type (msg, FLUX_MSGTYPE_REQUEST) == 0, "flux_msg_set_type works");
     ok (flux_msg_get_type (msg, &type) == 0 && type == FLUX_MSGTYPE_REQUEST,
         "flux_msg_get_type works and returns what we set");
-    ok (flux_msg_get_nodeid (msg, &nodeid) == 0
-        && nodeid == FLUX_NODEID_ANY,
+    ok (flux_msg_get_nodeid (msg, &nodeid) == 0 && nodeid == FLUX_NODEID_ANY,
         "flux_msg_get_nodeid works on request and default is sane");
 
     nodeid = 42;
-    ok (flux_msg_set_nodeid (msg, nodeid) == 0,
-        "flux_msg_set_nodeid works on request");
+    ok (flux_msg_set_nodeid (msg, nodeid) == 0, "flux_msg_set_nodeid works on request");
     nodeid = 0;
-    ok (flux_msg_get_nodeid (msg, &nodeid) == 0
-        && nodeid == 42,
+    ok (flux_msg_get_nodeid (msg, &nodeid) == 0 && nodeid == 42,
         "flux_msg_get_nodeid works and returns what we set");
 
     errno = 0;
     ok (flux_msg_set_errnum (msg, 42) < 0 && errno == EINVAL,
         "flux_msg_set_errnum on non-response fails with errno == EINVAL");
-    ok (flux_msg_set_type (msg, FLUX_MSGTYPE_RESPONSE) == 0,
-        "flux_msg_set_type works");
+    ok (flux_msg_set_type (msg, FLUX_MSGTYPE_RESPONSE) == 0, "flux_msg_set_type works");
     ok (flux_msg_get_type (msg, &type) == 0 && type == FLUX_MSGTYPE_RESPONSE,
         "flux_msg_get_type works and returns what we set");
-    ok (flux_msg_set_errnum (msg, 43) == 0,
-        "flux_msg_set_errnum works on response");
+    ok (flux_msg_set_errnum (msg, 43) == 0, "flux_msg_set_errnum works on response");
     errno = 0;
     ok (flux_msg_set_nodeid (msg, 0) < 0 && errno == EINVAL,
         "flux_msg_set_nodeid on non-request fails with errno == EINVAL");
@@ -764,12 +747,10 @@ void check_proto (void)
     ok (flux_msg_get_errnum (msg, &errnum) == 0 && errnum == 43,
         "flux_msg_get_errnum works and returns what we set");
 
-    ok (flux_msg_set_type (msg, FLUX_MSGTYPE_REQUEST) == 0,
-        "flux_msg_set_type works");
+    ok (flux_msg_set_type (msg, FLUX_MSGTYPE_REQUEST) == 0, "flux_msg_set_type works");
 
     errno = 0;
-    ok (flux_msg_set_nodeid (msg, FLUX_NODEID_UPSTREAM) < 0
-        && errno == EINVAL,
+    ok (flux_msg_set_nodeid (msg, FLUX_NODEID_UPSTREAM) < 0 && errno == EINVAL,
         "flux_msg_set_nodeid FLUX_NODEID_UPSTREAM fails with EINVAL");
 
     flux_msg_destroy (msg);
@@ -784,12 +765,9 @@ void check_matchtag (void)
         "flux_msg_create works");
     ok (flux_msg_get_matchtag (msg, &t) == 0 && t == FLUX_MATCHTAG_NONE,
         "flux_msg_get_matchtag returns FLUX_MATCHTAG_NONE  when uninitialized");
-    ok (flux_msg_set_matchtag (msg, 42) == 0,
-        "flux_msg_set_matchtag works");
-    ok (flux_msg_get_matchtag (msg, &t) == 0,
-        "flux_msg_get_matchtag works");
-    ok (t == 42,
-        "flux_msg_get_matchtag returns set value");
+    ok (flux_msg_set_matchtag (msg, 42) == 0, "flux_msg_set_matchtag works");
+    ok (flux_msg_get_matchtag (msg, &t) == 0, "flux_msg_get_matchtag works");
+    ok (t == 42, "flux_msg_get_matchtag returns set value");
     ok (flux_msg_cmp_matchtag (msg, 42) && !flux_msg_cmp_matchtag (msg, 0),
         "flux_msg_cmp_matchtag works");
 
@@ -800,40 +778,37 @@ void check_security (void)
 {
     flux_msg_t *msg;
     struct flux_msg_cred cred;
-    struct flux_msg_cred user_9 = { .rolemask = FLUX_ROLE_USER, .userid = 9 };
-    struct flux_msg_cred owner_2 = { .rolemask = FLUX_ROLE_OWNER, .userid = 2 };
-    struct flux_msg_cred user_unknown = { .rolemask = FLUX_ROLE_USER,
-                                          .userid = FLUX_USERID_UNKNOWN  };
-    struct flux_msg_cred none_9 = { .rolemask = FLUX_ROLE_NONE, .userid = 9 };
+    struct flux_msg_cred user_9 = {.rolemask = FLUX_ROLE_USER, .userid = 9};
+    struct flux_msg_cred owner_2 = {.rolemask = FLUX_ROLE_OWNER, .userid = 2};
+    struct flux_msg_cred user_unknown = {.rolemask = FLUX_ROLE_USER,
+                                         .userid = FLUX_USERID_UNKNOWN};
+    struct flux_msg_cred none_9 = {.rolemask = FLUX_ROLE_NONE, .userid = 9};
 
     /* Accessors work
      */
     ok ((msg = flux_msg_create (FLUX_MSGTYPE_REQUEST)) != NULL,
         "flux_msg_create works");
     ok (flux_msg_get_userid (msg, &cred.userid) == 0
-        && cred.userid == FLUX_USERID_UNKNOWN,
+            && cred.userid == FLUX_USERID_UNKNOWN,
         "message created with userid=FLUX_USERID_UNKNOWN");
     ok (flux_msg_get_rolemask (msg, &cred.rolemask) == 0
-        && cred.rolemask == FLUX_ROLE_NONE,
+            && cred.rolemask == FLUX_ROLE_NONE,
         "message created with rolemask=FLUX_ROLE_NONE");
     ok (flux_msg_set_userid (msg, 4242) == 0
-        && flux_msg_get_userid (msg, &cred.userid) == 0
-        && cred.userid == 4242,
+            && flux_msg_get_userid (msg, &cred.userid) == 0 && cred.userid == 4242,
         "flux_msg_set_userid 4242 works");
     ok (flux_msg_set_rolemask (msg, FLUX_ROLE_ALL) == 0
-        && flux_msg_get_rolemask (msg, &cred.rolemask) == 0
-        && cred.rolemask == FLUX_ROLE_ALL,
+            && flux_msg_get_rolemask (msg, &cred.rolemask) == 0
+            && cred.rolemask == FLUX_ROLE_ALL,
         "flux_msg_set_rolemask FLUX_ROLE_ALL works");
 
     memset (&cred, 0, sizeof (cred));
-    ok (flux_msg_get_cred (msg, &cred) == 0
-        && cred.userid == 4242 && cred.rolemask == FLUX_ROLE_ALL,
+    ok (flux_msg_get_cred (msg, &cred) == 0 && cred.userid == 4242
+            && cred.rolemask == FLUX_ROLE_ALL,
         "flux_msg_get_cred works");
 
-    ok (flux_msg_set_cred (msg, user_9) == 0
-        && flux_msg_get_cred (msg, &cred) == 0
-        && cred.userid == user_9.userid
-        && cred.rolemask == user_9.rolemask,
+    ok (flux_msg_set_cred (msg, user_9) == 0 && flux_msg_get_cred (msg, &cred) == 0
+            && cred.userid == user_9.userid && cred.rolemask == user_9.rolemask,
         "flux_msg_set_cred works");
 
     /* Simple authorization works
@@ -845,16 +820,14 @@ void check_security (void)
     ok (flux_msg_cred_authorize (user_9, 9) == 0,
         "flux_msg_cred_authorize allows guest when userids match");
     errno = 0;
-    ok (flux_msg_cred_authorize (user_9, 10) < 0
-        && errno == EPERM,
+    ok (flux_msg_cred_authorize (user_9, 10) < 0 && errno == EPERM,
         "flux_msg_cred_authorize denies guest (EPERM) when userids mismatch");
     errno = 0;
     ok (flux_msg_cred_authorize (user_unknown, FLUX_USERID_UNKNOWN) < 0
-        && errno == EPERM,
+            && errno == EPERM,
         "flux_msg_cred_authorize denies guest (EPERM) when userids=UNKNOWN");
     errno = 0;
-    ok (flux_msg_cred_authorize (none_9, 9) < 0
-        && errno == EPERM,
+    ok (flux_msg_cred_authorize (none_9, 9) < 0 && errno == EPERM,
         "flux_msg_cred_authorize denies guest (EPERM) when role=NONE");
 
     /* Repeat with the message version
@@ -870,20 +843,17 @@ void check_security (void)
     ok (flux_msg_authorize (msg, 9) == 0,
         "flux_msg_authorize allows guest when userid's match");
     errno = 0;
-    ok (flux_msg_authorize (msg, 10) < 0
-        && errno == EPERM,
+    ok (flux_msg_authorize (msg, 10) < 0 && errno == EPERM,
         "flux_msg_authorize denies guest (EPERM) when userid's mismatch");
     if (flux_msg_set_cred (msg, user_unknown) < 0)
         BAIL_OUT ("flux_msg_set_cred failed");
     errno = 0;
-    ok (flux_msg_authorize (msg, FLUX_USERID_UNKNOWN) < 0
-        && errno == EPERM,
+    ok (flux_msg_authorize (msg, FLUX_USERID_UNKNOWN) < 0 && errno == EPERM,
         "flux_msg_authorize denies guest (EPERM) when userids=UNKNOWN");
     if (flux_msg_set_cred (msg, none_9) < 0)
         BAIL_OUT ("flux_msg_set_cred failed");
     errno = 0;
-    ok (flux_msg_authorize (msg, 9) < 0
-        && errno == EPERM,
+    ok (flux_msg_authorize (msg, 9) < 0 && errno == EPERM,
         "flux_msg_authorize denies guest (EPERM) when role=NONE");
 
     flux_msg_destroy (msg);
@@ -896,38 +866,29 @@ void check_cmp (void)
     ok ((msg = flux_msg_create (FLUX_MSGTYPE_REQUEST)) != NULL,
         "flux_msg_create works");
 
-    ok (flux_msg_cmp (msg, match),
-        "flux_msg_cmp all-match works");
+    ok (flux_msg_cmp (msg, match), "flux_msg_cmp all-match works");
 
     match.typemask = FLUX_MSGTYPE_RESPONSE;
-    ok (!flux_msg_cmp (msg, match),
-        "flux_msg_cmp with request type not in mask works");
+    ok (!flux_msg_cmp (msg, match), "flux_msg_cmp with request type not in mask works");
 
     match.typemask |= FLUX_MSGTYPE_REQUEST;
-    ok (flux_msg_cmp (msg, match),
-        "flux_msg_cmp with request type in mask works");
+    ok (flux_msg_cmp (msg, match), "flux_msg_cmp with request type in mask works");
 
-    ok (flux_msg_set_topic (msg, "hello.foo") == 0,
-        "flux_msg_set_topic works");
+    ok (flux_msg_set_topic (msg, "hello.foo") == 0, "flux_msg_set_topic works");
     match.topic_glob = "hello.foobar";
-    ok (!flux_msg_cmp (msg, match),
-        "flux_msg_cmp with unmatched topic works");
+    ok (!flux_msg_cmp (msg, match), "flux_msg_cmp with unmatched topic works");
 
     match.topic_glob = "hello.foo";
-    ok (flux_msg_cmp (msg, match),
-        "flux_msg_cmp with exact topic works");
+    ok (flux_msg_cmp (msg, match), "flux_msg_cmp with exact topic works");
 
     match.topic_glob = "hello.*";
-    ok (flux_msg_cmp (msg, match),
-        "flux_msg_cmp with globbed '*' topic works");
+    ok (flux_msg_cmp (msg, match), "flux_msg_cmp with globbed '*' topic works");
 
     match.topic_glob = "hello.fo?";
-    ok (flux_msg_cmp (msg, match),
-        "flux_msg_cmp with globbed '?' topic works");
+    ok (flux_msg_cmp (msg, match), "flux_msg_cmp with globbed '?' topic works");
 
     match.topic_glob = "hello.fo[op]";
-    ok (flux_msg_cmp (msg, match),
-        "flux_msg_cmp with globbed '[' topic works");
+    ok (flux_msg_cmp (msg, match), "flux_msg_cmp with globbed '[' topic works");
     flux_msg_destroy (msg);
 }
 
@@ -942,27 +903,22 @@ void check_encode (void)
 
     ok ((msg = flux_msg_create (FLUX_MSGTYPE_REQUEST)) != NULL,
         "flux_msg_create works");
-    ok (flux_msg_set_topic (msg, "foo.bar") == 0,
-        "flux_msg_set_topic works");
+    ok (flux_msg_set_topic (msg, "foo.bar") == 0, "flux_msg_set_topic works");
     errno = 0;
     ok (flux_msg_encode (msg, smallbuf, 1) < 0 && errno == EINVAL,
         "flux_msg_encode fails on EINVAL with buffer too small");
     size = flux_msg_encode_size (msg);
-    ok (size > 0,
-        "flux_msg_encode_size works");
+    ok (size > 0, "flux_msg_encode_size works");
     buf = malloc (size);
     assert (buf != NULL);
-    ok (flux_msg_encode (msg, buf, size) == 0,
-        "flux_msg_encode works");
-    ok ((msg2 = flux_msg_decode (buf, size)) != NULL,
-        "flux_msg_decode works");
+    ok (flux_msg_encode (msg, buf, size) == 0, "flux_msg_encode works");
+    ok ((msg2 = flux_msg_decode (buf, size)) != NULL, "flux_msg_decode works");
     free (buf);
     ok (flux_msg_get_type (msg2, &type) == 0 && type == FLUX_MSGTYPE_REQUEST,
         "decoded expected message type");
     ok (flux_msg_get_topic (msg2, &topic) == 0 && !strcmp (topic, "foo.bar"),
         "decoded expected topic string");
-    ok (flux_msg_has_payload (msg2) == false,
-        "decoded expected (lack of) payload");
+    ok (flux_msg_has_payload (msg2) == false, "decoded expected (lack of) payload");
 
     flux_msg_destroy (msg);
     flux_msg_destroy (msg2);
@@ -979,8 +935,7 @@ void check_aux (void)
     flux_msg_t *msg;
     char *test_data = "Hello";
 
-    ok ((msg = flux_msg_create (FLUX_MSGTYPE_REQUEST)) != NULL,
-        "created test message");
+    ok ((msg = flux_msg_create (FLUX_MSGTYPE_REQUEST)) != NULL, "created test message");
     ok (flux_msg_aux_set (msg, "test", test_data, myfree) == 0,
         "hang aux data member on message with destructor");
     ok (flux_msg_aux_get (msg, "incorrect") == NULL,
@@ -988,8 +943,7 @@ void check_aux (void)
     ok (flux_msg_aux_get (msg, "test") == test_data,
         "flux_msg_aux_get aux data memeber key returns orig pointer");
     flux_msg_destroy (msg);
-    ok (myfree_arg == test_data,
-        "destroyed message and aux destructor was called");
+    ok (myfree_arg == test_data, "destroyed message and aux destructor was called");
 }
 
 void check_copy (void)
@@ -1004,50 +958,40 @@ void check_copy (void)
 
     ok ((msg = flux_msg_create (FLUX_MSGTYPE_CONTROL)) != NULL,
         "created no-payload control");
-    ok ((cpy = flux_msg_copy (msg, true)) != NULL,
-        "flux_msg_copy works");
+    ok ((cpy = flux_msg_copy (msg, true)) != NULL, "flux_msg_copy works");
     flux_msg_destroy (msg);
     type = -1;
-    ok (flux_msg_get_type (cpy, &type) == 0&& type == FLUX_MSGTYPE_CONTROL
-             && !flux_msg_has_payload (cpy)
-             && flux_msg_route_count (cpy) < 0
-             && flux_msg_get_topic (cpy, &topic) < 0,
+    ok (flux_msg_get_type (cpy, &type) == 0 && type == FLUX_MSGTYPE_CONTROL
+            && !flux_msg_has_payload (cpy) && flux_msg_route_count (cpy) < 0
+            && flux_msg_get_topic (cpy, &topic) < 0,
         "copy is keepalive: no routes, topic, or payload");
     flux_msg_destroy (cpy);
 
-    ok ((msg = flux_msg_create (FLUX_MSGTYPE_REQUEST)) != NULL,
-        "created request");
+    ok ((msg = flux_msg_create (FLUX_MSGTYPE_REQUEST)) != NULL, "created request");
     flux_msg_route_enable (msg);
-    ok (flux_msg_route_push (msg, "first") == 0,
-        "added route 1");
-    ok (flux_msg_route_push (msg, "second") == 0,
-        "added route 2");
-    ok (flux_msg_set_topic (msg, "foo") == 0,
-        "set topic string");
-    ok (flux_msg_set_payload (msg, buf, sizeof (buf)) == 0,
-        "added payload");
-    ok ((cpy = flux_msg_copy (msg, true)) != NULL,
-        "flux_msg_copy works");
+    ok (flux_msg_route_push (msg, "first") == 0, "added route 1");
+    ok (flux_msg_route_push (msg, "second") == 0, "added route 2");
+    ok (flux_msg_set_topic (msg, "foo") == 0, "set topic string");
+    ok (flux_msg_set_payload (msg, buf, sizeof (buf)) == 0, "added payload");
+    ok ((cpy = flux_msg_copy (msg, true)) != NULL, "flux_msg_copy works");
     type = -1;
     ok (flux_msg_get_type (cpy, &type) == 0 && type == FLUX_MSGTYPE_REQUEST
-             && flux_msg_has_payload (cpy)
-             && flux_msg_get_payload (cpy, &cpybuf, &cpylen) == 0
-             && cpylen == sizeof (buf) && memcmp (cpybuf, buf, cpylen) == 0
-             && flux_msg_route_count (cpy) == 2
-             && flux_msg_get_topic (cpy, &topic) == 0 && !strcmp (topic,"foo"),
+            && flux_msg_has_payload (cpy)
+            && flux_msg_get_payload (cpy, &cpybuf, &cpylen) == 0
+            && cpylen == sizeof (buf) && memcmp (cpybuf, buf, cpylen) == 0
+            && flux_msg_route_count (cpy) == 2 && flux_msg_get_topic (cpy, &topic) == 0
+            && !strcmp (topic, "foo"),
         "copy is request: w/routes, topic, and payload");
 
     ok ((s = flux_msg_route_last (cpy)) != NULL,
         "flux_msg_route_last gets route from copy");
-    like (s, "second",
-          "flux_msg_route_last returns correct second route");
+    like (s, "second", "flux_msg_route_last returns correct second route");
     ok (flux_msg_route_delete_last (cpy) == 0,
         "flux_msg_route_delete_last removes second route");
 
     ok ((s = flux_msg_route_last (cpy)) != NULL,
         "flux_msg_route_last pops route from copy");
-    like (s, "first",
-          "flux_msg_route_last returns correct first route");
+    like (s, "first", "flux_msg_route_last returns correct first route");
     ok (flux_msg_route_delete_last (cpy) == 0,
         "flux_msg_route_delete_last removes first route");
 
@@ -1057,9 +1001,8 @@ void check_copy (void)
         "flux_msg_copy works (payload=false)");
     type = -1;
     ok (flux_msg_get_type (cpy, &type) == 0 && type == FLUX_MSGTYPE_REQUEST
-             && !flux_msg_has_payload (cpy)
-             && flux_msg_route_count (cpy) == 2
-             && flux_msg_get_topic (cpy, &topic) == 0 && !strcmp (topic,"foo"),
+            && !flux_msg_has_payload (cpy) && flux_msg_route_count (cpy) == 2
+            && flux_msg_get_topic (cpy, &topic) == 0 && !strcmp (topic, "foo"),
         "copy is request: w/routes, topic, and no payload");
     flux_msg_destroy (cpy);
     flux_msg_destroy (msg);
@@ -1075,80 +1018,64 @@ void check_print (void)
     if (!f)
         BAIL_OUT ("cannot open /dev/null for writing");
 
-    ok ((msg = flux_msg_create (FLUX_MSGTYPE_CONTROL)) != NULL,
-        "created test message");
-    lives_ok ({flux_msg_fprint_ts (f, msg, 0.);},
-        "flux_msg_fprint_ts doesn't segfault on control");
+    ok ((msg = flux_msg_create (FLUX_MSGTYPE_CONTROL)) != NULL, "created test message");
+    lives_ok ({ flux_msg_fprint_ts (f, msg, 0.); },
+              "flux_msg_fprint_ts doesn't segfault on control");
     flux_msg_destroy (msg);
 
-    ok ((msg = flux_msg_create (FLUX_MSGTYPE_EVENT)) != NULL,
-        "created test message");
-    ok (flux_msg_set_topic (msg, "foo.bar") == 0,
-        "set topic string");
-    lives_ok ({flux_msg_fprint (f, msg);},
-        "flux_msg_fprint doesn't segfault on event with topic");
+    ok ((msg = flux_msg_create (FLUX_MSGTYPE_EVENT)) != NULL, "created test message");
+    ok (flux_msg_set_topic (msg, "foo.bar") == 0, "set topic string");
+    lives_ok ({ flux_msg_fprint (f, msg); },
+              "flux_msg_fprint doesn't segfault on event with topic");
     flux_msg_destroy (msg);
 
-    ok ((msg = flux_msg_create (FLUX_MSGTYPE_REQUEST)) != NULL,
-        "created test message");
-    ok (flux_msg_set_topic (msg, "foo.bar") == 0,
-        "set topic string");
+    ok ((msg = flux_msg_create (FLUX_MSGTYPE_REQUEST)) != NULL, "created test message");
+    ok (flux_msg_set_topic (msg, "foo.bar") == 0, "set topic string");
     flux_msg_route_enable (msg);
-    ok (flux_msg_route_push (msg, "id1") == 0,
-        "added one route");
-    ok (flux_msg_set_payload (msg, buf, strlen (buf)) == 0,
-        "added payload");
-    lives_ok ({flux_msg_fprint (f, msg);},
-        "flux_msg_fprint doesn't segfault on fully loaded request");
+    ok (flux_msg_route_push (msg, "id1") == 0, "added one route");
+    ok (flux_msg_set_payload (msg, buf, strlen (buf)) == 0, "added payload");
+    lives_ok ({ flux_msg_fprint (f, msg); },
+              "flux_msg_fprint doesn't segfault on fully loaded request");
     flux_msg_destroy (msg);
 
-    ok ((msg = flux_msg_create (FLUX_MSGTYPE_REQUEST)) != NULL,
-        "created test message");
-    ok (flux_msg_set_userid (msg, 42) == 0,
-        "set userid");
-    ok (flux_msg_set_rolemask (msg, FLUX_ROLE_OWNER) == 0,
-        "set rolemask");
-    ok (flux_msg_set_nodeid (msg, 42) == 0,
-        "set nodeid");
-    ok (flux_msg_set_string (msg, strpayload) == 0,
-        "added payload");
-    lives_ok ({flux_msg_fprint (f, msg);},
-        "flux_msg_fprint doesn't segfault on request settings #1");
+    ok ((msg = flux_msg_create (FLUX_MSGTYPE_REQUEST)) != NULL, "created test message");
+    ok (flux_msg_set_userid (msg, 42) == 0, "set userid");
+    ok (flux_msg_set_rolemask (msg, FLUX_ROLE_OWNER) == 0, "set rolemask");
+    ok (flux_msg_set_nodeid (msg, 42) == 0, "set nodeid");
+    ok (flux_msg_set_string (msg, strpayload) == 0, "added payload");
+    lives_ok ({ flux_msg_fprint (f, msg); },
+              "flux_msg_fprint doesn't segfault on request settings #1");
     flux_msg_destroy (msg);
 
-    ok ((msg = flux_msg_create (FLUX_MSGTYPE_REQUEST)) != NULL,
-        "created test message");
-    ok (flux_msg_set_rolemask (msg, FLUX_ROLE_USER) == 0,
-        "set rolemask");
+    ok ((msg = flux_msg_create (FLUX_MSGTYPE_REQUEST)) != NULL, "created test message");
+    ok (flux_msg_set_rolemask (msg, FLUX_ROLE_USER) == 0, "set rolemask");
     ok (flux_msg_set_flags (msg, FLUX_MSGFLAG_NORESPONSE | FLUX_MSGFLAG_UPSTREAM) == 0,
         "set new flags");
-    lives_ok ({flux_msg_fprint (f, msg);},
-        "flux_msg_fprint doesn't segfault on request settings #2");
+    lives_ok ({ flux_msg_fprint (f, msg); },
+              "flux_msg_fprint doesn't segfault on request settings #2");
     flux_msg_destroy (msg);
 
-    ok ((msg = flux_msg_create (FLUX_MSGTYPE_REQUEST)) != NULL,
-        "created test message");
-    ok (flux_msg_set_rolemask (msg, FLUX_ROLE_ALL) == 0,
-        "set rolemask");
+    ok ((msg = flux_msg_create (FLUX_MSGTYPE_REQUEST)) != NULL, "created test message");
+    ok (flux_msg_set_rolemask (msg, FLUX_ROLE_ALL) == 0, "set rolemask");
     ok (flux_msg_set_flags (msg, FLUX_MSGFLAG_PRIVATE | FLUX_MSGFLAG_STREAMING) == 0,
         "set new flags");
-    lives_ok ({flux_msg_fprint (f, msg);},
-        "flux_msg_fprint doesn't segfault on request settings #3");
+    lives_ok ({ flux_msg_fprint (f, msg); },
+              "flux_msg_fprint doesn't segfault on request settings #3");
     flux_msg_destroy (msg);
 
-    ok ((msg = flux_msg_create (FLUX_MSGTYPE_REQUEST)) != NULL,
-        "created test message");
+    ok ((msg = flux_msg_create (FLUX_MSGTYPE_REQUEST)) != NULL, "created test message");
     ok (flux_msg_set_payload (msg, buf_long, strlen (buf_long)) == 0,
         "added long payload");
-    lives_ok ({flux_msg_fprint (f, msg);},
-        "flux_msg_fprint doesn't segfault on long payload");
+    lives_ok ({ flux_msg_fprint (f, msg); },
+              "flux_msg_fprint doesn't segfault on long payload");
     flux_msg_destroy (msg);
 
     ok ((msg = flux_msg_create (FLUX_MSGTYPE_RESPONSE)) != NULL,
         "created test message");
     flux_msg_route_enable (msg);
-    lives_ok ({flux_msg_fprint (f, msg);},
-        "flux_msg_fprint doesn't segfault on response with empty route stack");
+    lives_ok ({ flux_msg_fprint (f, msg); },
+              "flux_msg_fprint doesn't segfault on response with empty route "
+              "stack");
     flux_msg_destroy (msg);
 
     fclose (f);
@@ -1161,60 +1088,44 @@ void check_flags (void)
 
     if (!(msg = flux_msg_create (FLUX_MSGTYPE_REQUEST)))
         BAIL_OUT ("flux_msg_create failed");
-    ok (flux_msg_get_flags (msg, &flags) == 0,
-        "flux_msg_get_flags works");
-    ok (flags == 0,
-        "flags are initially zero");
+    ok (flux_msg_get_flags (msg, &flags) == 0, "flux_msg_get_flags works");
+    ok (flags == 0, "flags are initially zero");
 
     /* FLUX_MSGFLAG_PRIVATE */
-    ok (flux_msg_is_private (msg) == false,
-        "flux_msg_is_private = false");
-    ok (flux_msg_set_private (msg) == 0,
-        "flux_msg_set_private_works");
-    ok (flux_msg_is_private (msg) == true,
-        "flux_msg_is_private = true");
+    ok (flux_msg_is_private (msg) == false, "flux_msg_is_private = false");
+    ok (flux_msg_set_private (msg) == 0, "flux_msg_set_private_works");
+    ok (flux_msg_is_private (msg) == true, "flux_msg_is_private = true");
 
     /* FLUX_MSGFLAG_STREAMING */
-    ok (flux_msg_is_streaming (msg) == false,
-        "flux_msg_is_streaming = false");
-    ok (flux_msg_set_streaming (msg) == 0,
-        "flux_msg_set_streaming_works");
-    ok (flux_msg_is_streaming (msg) == true,
-        "flux_msg_is_streaming = true");
+    ok (flux_msg_is_streaming (msg) == false, "flux_msg_is_streaming = false");
+    ok (flux_msg_set_streaming (msg) == 0, "flux_msg_set_streaming_works");
+    ok (flux_msg_is_streaming (msg) == true, "flux_msg_is_streaming = true");
 
     /* FLUX_MSGFLAG_NORESPONSE */
-    ok (flux_msg_is_noresponse (msg) == false,
-        "flux_msg_is_noresponse = false");
-    ok (flux_msg_set_noresponse (msg) == 0,
-        "flux_msg_set_noresponse_works");
-    ok (flux_msg_is_noresponse (msg) == true,
-        "flux_msg_is_noresponse = true");
+    ok (flux_msg_is_noresponse (msg) == false, "flux_msg_is_noresponse = false");
+    ok (flux_msg_set_noresponse (msg) == 0, "flux_msg_set_noresponse_works");
+    ok (flux_msg_is_noresponse (msg) == true, "flux_msg_is_noresponse = true");
 
     /* noresponse and streaming are mutually exclusive */
-    ok (flux_msg_set_streaming (msg) == 0
-        && flux_msg_set_noresponse (msg) == 0
-        && flux_msg_is_streaming (msg) == false
-        && flux_msg_is_noresponse (msg) == true,
+    ok (flux_msg_set_streaming (msg) == 0 && flux_msg_set_noresponse (msg) == 0
+            && flux_msg_is_streaming (msg) == false
+            && flux_msg_is_noresponse (msg) == true,
         "flux_msg_set_noresponse clears streaming flag");
-    ok (flux_msg_set_noresponse (msg) == 0
-        && flux_msg_set_streaming (msg) == 0
-        && flux_msg_is_noresponse (msg) == false
-        && flux_msg_is_streaming (msg) == true,
+    ok (flux_msg_set_noresponse (msg) == 0 && flux_msg_set_streaming (msg) == 0
+            && flux_msg_is_noresponse (msg) == false
+            && flux_msg_is_streaming (msg) == true,
         "flux_msg_set_streaming clears noresponse flag");
 
-    ok (flux_msg_set_topic (msg, "foo") == 0
-        && flux_msg_get_flags (msg, &flags) == 0
-        && (flags & FLUX_MSGFLAG_TOPIC),
+    ok (flux_msg_set_topic (msg, "foo") == 0 && flux_msg_get_flags (msg, &flags) == 0
+            && (flags & FLUX_MSGFLAG_TOPIC),
         "flux_msg_set_topic sets FLUX_MSGFLAG_TOPIC");
 
     ok (flux_msg_set_payload (msg, "foo", 3) == 0
-        && flux_msg_get_flags (msg, &flags) == 0
-        && (flags & FLUX_MSGFLAG_PAYLOAD),
+            && flux_msg_get_flags (msg, &flags) == 0 && (flags & FLUX_MSGFLAG_PAYLOAD),
         "flux_msg_set_payload sets FLUX_MSGFLAG_PAYLOAD");
 
     flux_msg_route_enable (msg);
-    ok (flux_msg_get_flags (msg, &flags) == 0
-        && (flags & FLUX_MSGFLAG_ROUTE),
+    ok (flux_msg_get_flags (msg, &flags) == 0 && (flags & FLUX_MSGFLAG_ROUTE),
         "flux_msg_route_enable sets FLUX_MSGFLAG_ROUTE");
 
     flux_msg_destroy (msg);
@@ -1229,8 +1140,7 @@ void check_refcount (void)
     if (!(msg = flux_msg_create (FLUX_MSGTYPE_CONTROL)))
         BAIL_OUT ("failed to create test message");
     p = flux_msg_incref (msg);
-    ok (p == msg,
-        "flux_msg_incref returns pointer to original");
+    ok (p == msg, "flux_msg_incref returns pointer to original");
     flux_msg_destroy (msg);
     ok (flux_msg_get_type (p, &type) == 0 && type == FLUX_MSGTYPE_CONTROL,
         "reference remains valid after destroy");
@@ -1265,15 +1175,14 @@ int main (int argc, char *argv[])
 
     check_encode ();
 
-    check_refcount();
+    check_refcount ();
 
     check_print ();
 
-    done_testing();
+    done_testing ();
     return (0);
 }
 
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab
  */
-

--- a/src/common/libflux/test/message.c
+++ b/src/common/libflux/test/message.c
@@ -1,3 +1,4 @@
+
 /************************************************************\
  * Copyright 2014 Lawrence Livermore National Security, LLC
  * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
@@ -1185,4 +1186,3 @@ int main (int argc, char *argv[])
 
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab
- */

--- a/src/common/libkvs/treeobj.c
+++ b/src/common/libkvs/treeobj.c
@@ -31,11 +31,12 @@ static int treeobj_unpack (json_t *obj, const char **typep, json_t **datap)
     json_t *data;
     int version;
     const char *type;
-    if (!obj || json_unpack (obj, "{s:i s:s s:o !}",
+    if (!obj
+        || json_unpack (obj, "{s:i s:s s:o !}",
                                   "ver", &version,
                                   "type", &type,
                                   "data", &data) < 0
-             || version != treeobj_version) {
+                        || version != treeobj_version) {
         errno = EINVAL;
         return -1;
     }
@@ -46,8 +47,7 @@ static int treeobj_unpack (json_t *obj, const char **typep, json_t **datap)
     return 0;
 }
 
-static int treeobj_peek (const json_t *obj, const char **typep,
-                         const json_t **datap)
+static int treeobj_peek (const json_t *obj, const char **typep, const json_t **datap)
 {
     json_t *data;
     int version;
@@ -56,11 +56,12 @@ static int treeobj_peek (const json_t *obj, const char **typep,
     /* N.B. it should be safe to cast away const on 'obj' as long as 'data'
      * parameter is not modified.  We make 'data' const to ensure that.
      */
-    if (!obj || json_unpack ((json_t *)obj, "{s:i s:s s:o !}",
+    if (!obj
+        || json_unpack ((json_t *)obj, "{s:i s:s s:o !}",
                                   "ver", &version,
                                   "type", &type,
                                   "data", &data) < 0
-             || version != treeobj_version) {
+                         || version != treeobj_version) {
         errno = EINVAL;
         return -1;
     }
@@ -176,17 +177,14 @@ json_t *treeobj_get_data (json_t *obj)
     return data;
 }
 
-int treeobj_get_symlink (const json_t *obj,
-                         const char **ns,
-                         const char **target)
+int treeobj_get_symlink (const json_t *obj, const char **ns, const char **target)
 {
     const char *type;
     const json_t *data;
     const json_t *n, *t;
     const char *n_str = NULL, *t_str = NULL;
 
-    if (treeobj_peek (obj, &type, &data) < 0
-            || strcmp (type, "symlink") != 0) {
+    if (treeobj_peek (obj, &type, &data) < 0 || strcmp (type, "symlink") != 0) {
         errno = EINVAL;
         return -1;
     }
@@ -220,14 +218,13 @@ int treeobj_decode_val (const json_t *obj, void **dp, int *lp)
     ssize_t datalen;
     char *data;
 
-    if (treeobj_peek (obj, &type, &xdata) < 0
-            || strcmp (type, "val") != 0) {
+    if (treeobj_peek (obj, &type, &xdata) < 0 || strcmp (type, "val") != 0) {
         errno = EINVAL;
         return -1;
     }
     xdatastr = json_string_value (xdata);
     xlen = strlen (xdatastr);
-    databuflen = base64_decoded_length (xlen) + 1; // +1  for a trailing \0
+    databuflen = base64_decoded_length (xlen) + 1;  // +1  for a trailing \0
 
     if (databuflen > 1) {
         if (!(data = malloc (databuflen)))
@@ -267,8 +264,9 @@ int treeobj_get_count (const json_t *obj)
     }
     else if (!strcmp (type, "symlink") || !strcmp (type, "val")) {
         count = 1;
-    } else {
-        errno = EINVAL; // unknown type
+    }
+    else {
+        errno = EINVAL;  // unknown type
         return -1;
     }
 done:
@@ -280,8 +278,7 @@ json_t *treeobj_get_entry (json_t *obj, const char *name)
     const char *type;
     json_t *data, *obj2;
 
-    if (treeobj_unpack (obj, &type, &data) < 0
-            || strcmp (type, "dir") != 0) {
+    if (treeobj_unpack (obj, &type, &data) < 0 || strcmp (type, "dir") != 0) {
         errno = EINVAL;
         return NULL;
     }
@@ -297,8 +294,7 @@ int treeobj_delete_entry (json_t *obj, const char *name)
     const char *type;
     json_t *data;
 
-    if (treeobj_unpack (obj, &type, &data) < 0
-            || strcmp (type, "dir") != 0) {
+    if (treeobj_unpack (obj, &type, &data) < 0 || strcmp (type, "dir") != 0) {
         errno = EINVAL;
         return -1;
     }
@@ -315,8 +311,7 @@ int treeobj_insert_entry (json_t *obj, const char *name, json_t *obj2)
     json_t *data;
 
     if (!name || !obj2 || treeobj_unpack (obj, &type, &data) < 0
-            || strcmp (type, "dir") != 0
-            || treeobj_validate (obj2) < 0) {
+        || strcmp (type, "dir") != 0 || treeobj_validate (obj2) < 0) {
         errno = EINVAL;
         return -1;
     }
@@ -329,16 +324,13 @@ int treeobj_insert_entry (json_t *obj, const char *name, json_t *obj2)
 
 /* identical to treeobj_insert_entry() but does not call
  * treeobj_validate() */
-int treeobj_insert_entry_novalidate (json_t *obj,
-                                     const char *name,
-                                     json_t *obj2)
+int treeobj_insert_entry_novalidate (json_t *obj, const char *name, json_t *obj2)
 {
     const char *type;
     json_t *data;
 
     if (!name || !obj2 || treeobj_unpack (obj, &type, &data) < 0
-            || strcmp (type, "dir") != 0
-            || treeobj_peek (obj2, NULL, NULL) < 0) {
+        || strcmp (type, "dir") != 0 || treeobj_peek (obj2, NULL, NULL) < 0) {
         errno = EINVAL;
         return -1;
     }
@@ -354,8 +346,7 @@ const json_t *treeobj_peek_entry (const json_t *obj, const char *name)
     const char *type;
     const json_t *data, *obj2;
 
-    if (treeobj_peek (obj, &type, &data) < 0
-            || strcmp (type, "dir") != 0) {
+    if (treeobj_peek (obj, &type, &data) < 0 || strcmp (type, "dir") != 0) {
         errno = EINVAL;
         return NULL;
     }
@@ -417,9 +408,8 @@ int treeobj_append_blobref (json_t *obj, const char *blobref)
     int rc = -1;
 
     if (!blobref || blobref_validate (blobref) < 0
-                 || treeobj_unpack (obj, &type, &data) < 0
-                 || (strcmp (type, "dirref") != 0
-                    && strcmp (type, "valref") != 0)) {
+        || treeobj_unpack (obj, &type, &data) < 0
+        || (strcmp (type, "dirref") != 0 && strcmp (type, "valref") != 0)) {
         errno = EINVAL;
         goto done;
     }
@@ -444,8 +434,7 @@ const char *treeobj_get_blobref (const json_t *obj, int index)
     const char *type, *blobref = NULL;
 
     if (treeobj_peek (obj, &type, &data) < 0
-            || (strcmp (type, "dirref") != 0
-                && strcmp (type, "valref") != 0)) {
+        || (strcmp (type, "dirref") != 0 && strcmp (type, "valref") != 0)) {
         errno = EINVAL;
         goto done;
     }
@@ -566,8 +555,7 @@ json_t *treeobj_create_dirref (const char *blobref)
     return obj;
 }
 
-json_t *treeobj_create_valref_buf (const char *hashtype, int maxblob,
-                                   void *data, int len)
+json_t *treeobj_create_valref_buf (const char *hashtype, int maxblob, void *data, int len)
 {
     json_t *valref = NULL;
     char blobref[BLOBREF_MAX_STRING_SIZE];
@@ -575,12 +563,11 @@ json_t *treeobj_create_valref_buf (const char *hashtype, int maxblob,
 
     if (!(valref = treeobj_create_valref (NULL)))
         goto error;
-    while (len >= 0) { // N.B. handle zero-length blob
+    while (len >= 0) {  // N.B. handle zero-length blob
         blob_len = len;
         if (maxblob > 0 && len > maxblob)
             blob_len = maxblob;
-        if (blobref_hash (hashtype, data, blob_len, blobref,
-                          sizeof (blobref)) < 0)
+        if (blobref_hash (hashtype, data, blob_len, blobref, sizeof (blobref)) < 0)
             goto error;
         if (treeobj_append_blobref (valref, blobref) < 0)
             goto error;
@@ -607,8 +594,7 @@ json_t *treeobj_decode (const char *buf)
 json_t *treeobj_decodeb (const char *buf, size_t buflen)
 {
     json_t *obj = NULL;
-    if (!(obj = json_loadb (buf, buflen, 0, NULL))
-            || treeobj_validate (obj) < 0) {
+    if (!(obj = json_loadb (buf, buflen, 0, NULL)) || treeobj_validate (obj) < 0) {
         errno = EPROTO;
         goto error;
     }
@@ -620,7 +606,7 @@ error:
 
 char *treeobj_encode (const json_t *obj)
 {
-    return json_dumps (obj, JSON_COMPACT|JSON_SORT_KEYS);
+    return json_dumps (obj, JSON_COMPACT | JSON_SORT_KEYS);
 }
 
 /*

--- a/src/common/libkvs/treeobj.c
+++ b/src/common/libkvs/treeobj.c
@@ -1,3 +1,4 @@
+
 /************************************************************\
  * Copyright 2016 Lawrence Livermore National Security, LLC
  * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
@@ -32,8 +33,7 @@ static int treeobj_unpack (json_t *obj, const char **typep, json_t **datap)
     int version;
     const char *type;
     if (!obj || version != treeobj_version
-        || json_unpack (obj, "{s:i s:s s:o !}", "ver", &version, "type", &type, "data", &data)
-                        < 0) {
+        || json_unpack (obj, "{s:i s:s s:o !}", "ver", &version, "type", &type, "data", &data) < 0) {
         errno = EINVAL;
         return -1;
     }
@@ -611,4 +611,3 @@ char *treeobj_encode (const json_t *obj)
 
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab
- */

--- a/src/common/libkvs/treeobj.c
+++ b/src/common/libkvs/treeobj.c
@@ -31,12 +31,9 @@ static int treeobj_unpack (json_t *obj, const char **typep, json_t **datap)
     json_t *data;
     int version;
     const char *type;
-    if (!obj
-        || json_unpack (obj, "{s:i s:s s:o !}",
-                                  "ver", &version,
-                                  "type", &type,
-                                  "data", &data) < 0
-                        || version != treeobj_version) {
+    if (!obj || version != treeobj_version
+        || json_unpack (obj, "{s:i s:s s:o !}", "ver", &version, "type", &type, "data", &data)
+                        < 0) {
         errno = EINVAL;
         return -1;
     }
@@ -555,7 +552,10 @@ json_t *treeobj_create_dirref (const char *blobref)
     return obj;
 }
 
-json_t *treeobj_create_valref_buf (const char *hashtype, int maxblob, void *data, int len)
+json_t *treeobj_create_valref_buf (const char *hashtype,
+                                   int maxblob,
+                                   void *data,
+                                   int len)
 {
     json_t *valref = NULL;
     char blobref[BLOBREF_MAX_STRING_SIZE];

--- a/src/common/libsubprocess/server.c
+++ b/src/common/libsubprocess/server.c
@@ -9,7 +9,7 @@
 \************************************************************/
 
 #if HAVE_CONFIG_H
-# include "config.h"
+#include "config.h"
 #endif
 
 #include <sys/types.h>
@@ -37,8 +37,8 @@
 static const char *auxkey = "flux::rexec";
 
 struct rexec {
-    const flux_msg_t *msg;          // rexec request message
-    flux_subprocess_server_t *s;    // server context
+    const flux_msg_t *msg;        // rexec request message
+    flux_subprocess_server_t *s;  // server context
 };
 
 static void rexec_destroy (struct rexec *rex)
@@ -49,8 +49,7 @@ static void rexec_destroy (struct rexec *rex)
     }
 }
 
-static struct rexec *rexec_create (const flux_msg_t *msg,
-                                   flux_subprocess_server_t *s)
+static struct rexec *rexec_create (const flux_msg_t *msg, flux_subprocess_server_t *s)
 {
     struct rexec *rex;
 
@@ -155,7 +154,8 @@ static void rexec_completion_cb (flux_subprocess_t *p)
         /* no fallback if this fails */
         if (flux_respond_pack (rex->s->h, rex->msg, "{s:s s:i}",
                                "type", "complete",
-                               "rank", rex->s->rank) < 0)
+                               "rank", rex->s->rank)
+                               < 0)
             flux_log_error (rex->s->h, "%s: flux_respond_pack", __FUNCTION__);
     }
 
@@ -182,8 +182,7 @@ static void internal_fatal (flux_subprocess_server_t *s, flux_subprocess_t *p)
     }
 }
 
-static void rexec_state_change_cb (flux_subprocess_t *p,
-                                   flux_subprocess_state_t state)
+static void rexec_state_change_cb (flux_subprocess_t *p, flux_subprocess_state_t state)
 {
     struct rexec *rex = flux_subprocess_aux_get (p, auxkey);
 
@@ -199,24 +198,29 @@ static void rexec_state_change_cb (flux_subprocess_t *p,
                                "state", state) < 0) {
             flux_log_error (rex->s->h, "%s: flux_respond_pack", __FUNCTION__);
         }
-    } else if (state == FLUX_SUBPROCESS_EXITED) {
+    }
+    else if (state == FLUX_SUBPROCESS_EXITED) {
         if (flux_respond_pack (rex->s->h, rex->msg, "{s:s s:i s:i s:i}",
                                "type", "state",
                                "rank", rex->s->rank,
                                "state", state,
-                               "status", flux_subprocess_status (p)) < 0) {
+                               "status", flux_subprocess_status (p))
+                               < 0) {
             flux_log_error (rex->s->h, "%s: flux_respond_pack", __FUNCTION__);
         }
-    } else if (state == FLUX_SUBPROCESS_FAILED) {
+    }
+    else if (state == FLUX_SUBPROCESS_FAILED) {
         if (flux_respond_pack (rex->s->h, rex->msg, "{s:s s:i s:i s:i}",
                                "type", "state",
                                "rank", rex->s->rank,
                                "state", FLUX_SUBPROCESS_FAILED,
-                               "errno", p->failed_errno) < 0) {
+                               "errno", p->failed_errno)
+                               < 0) {
             flux_log_error (rex->s->h, "%s: flux_respond_pack", __FUNCTION__);
         }
         subprocess_cleanup (p);
-    } else {
+    }
+    else {
         errno = EPROTO;
         flux_log_error (rex->s->h, "%s: illegal state", __FUNCTION__);
         goto error;
@@ -289,8 +293,10 @@ error:
     internal_fatal (rex->s, p);
 }
 
-static void server_exec_cb (flux_t *h, flux_msg_handler_t *mh,
-                              const flux_msg_t *msg, void *arg)
+static void server_exec_cb (flux_t *h,
+                            flux_msg_handler_t *mh,
+                            const flux_msg_t *msg,
+                            void *arg)
 {
     flux_subprocess_server_t *s = arg;
     const char *cmd_str;
@@ -353,17 +359,14 @@ static void server_exec_cb (flux_t *h, flux_msg_handler_t *mh,
         goto error;
     }
 
-    if (!(p = flux_exec (s->h,
-                         FLUX_SUBPROCESS_FLAGS_SETPGRP,
-                         cmd,
-                         &ops,
-                         NULL))) {
+    if (!(p = flux_exec (s->h, FLUX_SUBPROCESS_FLAGS_SETPGRP, cmd, &ops, NULL))) {
         /* error here, generate FLUX_SUBPROCESS_EXEC_FAILED state */
         if (flux_respond_pack (h, msg, "{s:s s:i s:i s:i}",
                                "type", "state",
                                "rank", s->rank,
                                "state", FLUX_SUBPROCESS_EXEC_FAILED,
-                               "errno", errno) < 0) {
+                               "errno", errno)
+                               < 0) {
             flux_log_error (h, "%s: flux_respond_pack", __FUNCTION__);
             goto error;
         }
@@ -372,10 +375,7 @@ static void server_exec_cb (flux_t *h, flux_msg_handler_t *mh,
 
     if (!(rex = rexec_create (msg, s)))
         goto error;
-    if (flux_subprocess_aux_set (p,
-                                auxkey,
-                                rex,
-                                (flux_free_f)rexec_destroy) < 0) {
+    if (flux_subprocess_aux_set (p, auxkey, rex, (flux_free_f)rexec_destroy) < 0) {
         rexec_destroy (rex);
         goto error;
     }
@@ -393,8 +393,11 @@ cleanup:
     flux_subprocess_unref (p);
 }
 
-static int write_subprocess (flux_subprocess_server_t *s, flux_subprocess_t *p,
-                             const char *stream, const char *data, int len)
+static int write_subprocess (flux_subprocess_server_t *s,
+                             flux_subprocess_t *p,
+                             const char *stream,
+                             const char *data,
+                             int len)
 {
     int tmp;
 
@@ -420,7 +423,8 @@ static int write_subprocess (flux_subprocess_server_t *s, flux_subprocess_t *p,
     return 0;
 }
 
-static int close_subprocess (flux_subprocess_server_t *s, flux_subprocess_t *p,
+static int close_subprocess (flux_subprocess_server_t *s,
+                             flux_subprocess_t *p,
                              const char *stream)
 {
     if (flux_subprocess_close (p, stream) < 0) {
@@ -431,8 +435,10 @@ static int close_subprocess (flux_subprocess_server_t *s, flux_subprocess_t *p,
     return 0;
 }
 
-static void server_write_cb (flux_t *h, flux_msg_handler_t *mh,
-                             const flux_msg_t *msg, void *arg)
+static void server_write_cb (flux_t *h,
+                             flux_msg_handler_t *mh,
+                             const flux_msg_t *msg,
+                             void *arg)
 {
     flux_subprocess_t *p;
     flux_subprocess_server_t *s = arg;
@@ -494,8 +500,10 @@ error:
     internal_fatal (s, p);
 }
 
-static void server_signal_cb (flux_t *h, flux_msg_handler_t *mh,
-                              const flux_msg_t *msg, void *arg)
+static void server_signal_cb (flux_t *h,
+                              flux_msg_handler_t *mh,
+                              const flux_msg_t *msg,
+                              void *arg)
 {
     flux_subprocess_server_t *s = arg;
     pid_t pid;
@@ -568,8 +576,10 @@ cleanup:
     return info;
 }
 
-static void server_processes_cb (flux_t *h, flux_msg_handler_t *mh,
-                                 const flux_msg_t *msg, void *arg)
+static void server_processes_cb (flux_t *h,
+                                 flux_msg_handler_t *mh,
+                                 const flux_msg_t *msg,
+                                 void *arg)
 {
     flux_subprocess_server_t *s = arg;
     flux_subprocess_t *p;
@@ -583,8 +593,7 @@ static void server_processes_cb (flux_t *h, flux_msg_handler_t *mh,
     p = zhash_first (s->subprocesses);
     while (p) {
         json_t *o = NULL;
-        if (!(o = process_info (p))
-            || json_array_append_new (procs, o) < 0) {
+        if (!(o = process_info (p)) || json_array_append_new (procs, o) < 0) {
             json_decref (o);
             errno = ENOMEM;
             goto error;
@@ -607,26 +616,10 @@ int server_start (flux_subprocess_server_t *s)
 {
     /* rexec.processes is primarily for testing */
     struct flux_msg_handler_spec htab[] = {
-        { FLUX_MSGTYPE_REQUEST,
-          "broker.rexec",
-          server_exec_cb,
-          0
-        },
-        { FLUX_MSGTYPE_REQUEST,
-          "broker.rexec.write",
-          server_write_cb,
-          0
-        },
-        { FLUX_MSGTYPE_REQUEST,
-          "broker.rexec.signal",
-          server_signal_cb,
-          0
-        },
-        { FLUX_MSGTYPE_REQUEST,
-          "broker.rexec.processes",
-          server_processes_cb,
-          0
-        },
+        {FLUX_MSGTYPE_REQUEST, "broker.rexec", server_exec_cb, 0},
+        {FLUX_MSGTYPE_REQUEST, "broker.rexec.write", server_write_cb, 0},
+        {FLUX_MSGTYPE_REQUEST, "broker.rexec.signal", server_signal_cb, 0},
+        {FLUX_MSGTYPE_REQUEST, "broker.rexec.processes", server_processes_cb, 0},
         FLUX_MSGHANDLER_TABLE_END,
     };
 
@@ -683,8 +676,7 @@ static void terminate_uuid (flux_subprocess_t *p, const char *id)
         server_signal_subprocess (p, SIGKILL);
 }
 
-int server_terminate_by_uuid (flux_subprocess_server_t *s,
-                              const char *id)
+int server_terminate_by_uuid (flux_subprocess_server_t *s, const char *id)
 {
     flux_subprocess_t *p;
 
@@ -706,10 +698,7 @@ static void terminate_prep_cb (flux_reactor_t *r,
     flux_watcher_start (s->terminate_idle_w);
 }
 
-static void terminate_cb (flux_reactor_t *r,
-                          flux_watcher_t *w,
-                          int revents,
-                          void *arg)
+static void terminate_cb (flux_reactor_t *r, flux_watcher_t *w, int revents, void *arg)
 {
     flux_subprocess_server_t *s = arg;
     flux_watcher_stop (s->terminate_timer_w);
@@ -731,13 +720,10 @@ void server_terminate_cleanup (flux_subprocess_server_t *s)
     s->terminate_check_w = NULL;
 }
 
-int server_terminate_setup (flux_subprocess_server_t *s,
-                            double wait_time)
+int server_terminate_setup (flux_subprocess_server_t *s, double wait_time)
 {
-    s->terminate_timer_w = flux_timer_watcher_create (s->r,
-                                                      wait_time, 0.,
-                                                      terminate_cb,
-                                                      s);
+    s->terminate_timer_w =
+        flux_timer_watcher_create (s->r, wait_time, 0., terminate_cb, s);
     if (!s->terminate_timer_w) {
         flux_log_error (s->h, "flux_timer_watcher_create");
         goto error;
@@ -746,25 +732,19 @@ int server_terminate_setup (flux_subprocess_server_t *s,
     if (s->terminate_prep_w)
         return 0;
 
-    s->terminate_prep_w = flux_prepare_watcher_create (s->r,
-                                                       terminate_prep_cb,
-                                                       s);
+    s->terminate_prep_w = flux_prepare_watcher_create (s->r, terminate_prep_cb, s);
     if (!s->terminate_prep_w) {
         flux_log_error (s->h, "flux_prepare_watcher_create");
         goto error;
     }
 
-    s->terminate_idle_w = flux_idle_watcher_create (s->r,
-                                                    NULL,
-                                                    s);
+    s->terminate_idle_w = flux_idle_watcher_create (s->r, NULL, s);
     if (!s->terminate_idle_w) {
         flux_log_error (s->h, "flux_idle_watcher_create");
         goto error;
     }
 
-    s->terminate_check_w = flux_check_watcher_create (s->r,
-                                                      terminate_cb,
-                                                      s);
+    s->terminate_check_w = flux_check_watcher_create (s->r, terminate_cb, s);
     if (!s->terminate_check_w) {
         flux_log_error (s->h, "flux_check_watcher_create");
         goto error;

--- a/src/common/libsubprocess/server.c
+++ b/src/common/libsubprocess/server.c
@@ -1,3 +1,4 @@
+
 /************************************************************\
  * Copyright 2018 Lawrence Livermore National Security, LLC
  * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
@@ -154,8 +155,7 @@ static void rexec_completion_cb (flux_subprocess_t *p)
         /* no fallback if this fails */
         if (flux_respond_pack (rex->s->h, rex->msg, "{s:s s:i}",
                                "type", "complete",
-                               "rank", rex->s->rank)
-                               < 0)
+                               "rank", rex->s->rank) < 0)
             flux_log_error (rex->s->h, "%s: flux_respond_pack", __FUNCTION__);
     }
 
@@ -204,8 +204,7 @@ static void rexec_state_change_cb (flux_subprocess_t *p, flux_subprocess_state_t
                                "type", "state",
                                "rank", rex->s->rank,
                                "state", state,
-                               "status", flux_subprocess_status (p))
-                               < 0) {
+                               "status", flux_subprocess_status (p)) < 0) {
             flux_log_error (rex->s->h, "%s: flux_respond_pack", __FUNCTION__);
         }
     }
@@ -214,8 +213,7 @@ static void rexec_state_change_cb (flux_subprocess_t *p, flux_subprocess_state_t
                                "type", "state",
                                "rank", rex->s->rank,
                                "state", FLUX_SUBPROCESS_FAILED,
-                               "errno", p->failed_errno)
-                               < 0) {
+                               "errno", p->failed_errno) < 0) {
             flux_log_error (rex->s->h, "%s: flux_respond_pack", __FUNCTION__);
         }
         subprocess_cleanup (p);
@@ -365,8 +363,7 @@ static void server_exec_cb (flux_t *h,
                                "type", "state",
                                "rank", s->rank,
                                "state", FLUX_SUBPROCESS_EXEC_FAILED,
-                               "errno", errno)
-                               < 0) {
+                               "errno", errno) < 0) {
             flux_log_error (h, "%s: flux_respond_pack", __FUNCTION__);
             goto error;
         }
@@ -771,4 +768,3 @@ int server_terminate_wait (flux_subprocess_server_t *s)
 
 /*
  * vi: ts=4 sw=4 expandtab
- */

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -1567,7 +1567,9 @@ static void finalize_transaction_bynames (struct kvs_ctx *ctx,
         if ((tr = treq_mgr_lookup_transaction (root->trm, nameval))) {
             treq_iter_request_copies (tr, finalize_transaction_req, &cbd);
             if (treq_mgr_remove_transaction (root->trm, nameval) < 0)
-                flux_log_error (ctx->h, "%s: treq_mgr_remove_transaction", __FUNCTION__);
+                flux_log_error (ctx->h,
+                                "%s: treq_mgr_remove_transaction",
+                                __FUNCTION__);
         }
     }
 }
@@ -1936,7 +1938,13 @@ static void wait_version_request_cb (flux_t *h,
     }
 
     if (root->seq < rootseq) {
-        if (kvs_wait_version_add (root, wait_version_request_cb, h, mh, msg, ctx, rootseq)
+        if (kvs_wait_version_add (root,
+                                  wait_version_request_cb,
+                                  h,
+                                  mh,
+                                  msg,
+                                  ctx,
+                                  rootseq)
             < 0) {
             flux_log_error (h, "%s: kvs_wait_version_add", __FUNCTION__);
             goto error;
@@ -2032,7 +2040,11 @@ static void error_event_cb (flux_t *h,
      *   cleaning up lingering transactions.
      */
     if (!(root = kvsroot_mgr_lookup_root (ctx->krm, ns))) {
-        flux_log (ctx->h, LOG_ERR, "%s: received unknown namespace %s", __FUNCTION__, ns);
+        flux_log (ctx->h,
+                  LOG_ERR,
+                  "%s: received unknown namespace %s",
+                  __FUNCTION__,
+                  ns);
         return;
     }
 
@@ -2092,7 +2104,11 @@ static void setroot_event_cb (flux_t *h,
      *   namespace remove event received before setroot).
      */
     if (!(root = kvsroot_mgr_lookup_root (ctx->krm, ns))) {
-        flux_log (ctx->h, LOG_ERR, "%s: received unknown namespace %s", __FUNCTION__, ns);
+        flux_log (ctx->h,
+                  LOG_ERR,
+                  "%s: received unknown namespace %s",
+                  __FUNCTION__,
+                  ns);
         return;
     }
 
@@ -2460,7 +2476,9 @@ static void start_root_remove (struct kvs_ctx *ctx, const char *ns)
          * this.
          */
 
-        if (treq_mgr_iter_transactions (root->trm, root_remove_process_transactions, &cbd)
+        if (treq_mgr_iter_transactions (root->trm,
+                                        root_remove_process_transactions,
+                                        &cbd)
             < 0)
             flux_log_error (ctx->h, "%s: treq_mgr_iter_transactions", __FUNCTION__);
     }
@@ -2703,7 +2721,8 @@ static void setroot_unpause_request_cb (flux_t *h,
         goto error;
     }
 
-    if (!(root = getroot (ctx, ns, mh, msg, NULL, setroot_unpause_request_cb, &stall))) {
+    if (!(root =
+              getroot (ctx, ns, mh, msg, NULL, setroot_unpause_request_cb, &stall))) {
         if (stall)
             return;
         goto error;
@@ -2773,7 +2792,10 @@ static const struct flux_msg_handler_spec htab[] = {
     {FLUX_MSGTYPE_REQUEST, "kvs.namespace-remove", namespace_remove_request_cb, 0},
     {FLUX_MSGTYPE_EVENT, "kvs.namespace-*-removed", namespace_removed_event_cb, 0},
     {FLUX_MSGTYPE_REQUEST, "kvs.namespace-list", namespace_list_request_cb, 0},
-    {FLUX_MSGTYPE_REQUEST, "kvs.setroot-pause", setroot_pause_request_cb, FLUX_ROLE_USER},
+    {FLUX_MSGTYPE_REQUEST,
+     "kvs.setroot-pause",
+     setroot_pause_request_cb,
+     FLUX_ROLE_USER},
     {FLUX_MSGTYPE_REQUEST,
      "kvs.setroot-unpause",
      setroot_unpause_request_cb,
@@ -3001,7 +3023,10 @@ int mod_main (flux_t *h, int argc, char **argv)
         goto done;
     }
     if (!(f_heartbeat_sync = flux_sync_create (h, heartbeat_sync_min))
-        || flux_future_then (f_heartbeat_sync, heartbeat_sync_max, heartbeat_sync_cb, ctx)
+        || flux_future_then (f_heartbeat_sync,
+                             heartbeat_sync_max,
+                             heartbeat_sync_cb,
+                             ctx)
                < 0) {
         flux_log_error (h, "error starting heartbeat synchronization");
         goto done;

--- a/src/modules/kvs/kvs.c
+++ b/src/modules/kvs/kvs.c
@@ -1,3 +1,4 @@
+
 /************************************************************\
  * Copyright 2014 Lawrence Livermore National Security, LLC
  * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
@@ -66,7 +67,7 @@ const double max_namespace_age = 3600.;
 struct kvs_ctx {
     struct cache *cache; /* blobref => cache_entry */
     kvsroot_mgr_t *krm;
-    int faults; /* for kvs.stats.get, etc. */
+    int faults;          /* for kvs.stats.get, etc. */
     flux_t *h;
     uint32_t rank;
     flux_watcher_t *prep_w;
@@ -321,8 +322,7 @@ static void getroot_completion (flux_future_t *f, void *arg)
                              "owner", &owner,
                              "rootseq", &rootseq,
                              "rootref", &ref,
-                             "flags", &flags)
-                             < 0) {
+                             "flags", &flags) < 0) {
         if (errno != ENOTSUP)
             flux_log_error (ctx->h, "%s: flux_rpc_get_unpack", __FUNCTION__);
         goto error;
@@ -1504,16 +1504,14 @@ static void lookup_plus_request_cb (flux_t *h,
         if (flux_respond_pack (h, msg, "{ s:i s:i s:s }",
                                "errno", ENOENT,
                                "rootseq", root_seq,
-                               "rootref", root_ref)
-                               < 0)
+                               "rootref", root_ref) < 0)
             flux_log_error (h, "%s: flux_respond_pack", __FUNCTION__);
     }
     else {
         if (flux_respond_pack (h, msg, "{ s:O s:i s:s }",
                                "val", val,
                                "rootseq", root_seq,
-                               "rootref", root_ref)
-                               < 0)
+                               "rootref", root_ref) < 0)
             flux_log_error (h, "%s: flux_respond_pack", __FUNCTION__);
     }
     lookup_destroy (lh);
@@ -1535,8 +1533,7 @@ static int finalize_transaction_req (treq_t *tr, const flux_msg_t *req, void *da
     else {
         if (flux_respond_pack (cbd->ctx->h, req, "{ s:s s:i }",
                                "rootref", cbd->root->ref,
-                               "rootseq", cbd->root->seq)
-                               < 0)
+                               "rootseq", cbd->root->seq) < 0)
             flux_log_error (cbd->ctx->h, "%s: flux_respond_pack", __FUNCTION__);
     }
 
@@ -1592,8 +1589,7 @@ static void relaycommit_request_cb (flux_t *h,
                              "ops", &ops,
                              "name", &name,
                              "namespace", &ns,
-                             "flags", &flags)
-                             < 0) {
+                             "flags", &flags) < 0) {
         flux_log_error (h, "%s: flux_request_unpack", __FUNCTION__);
         return;
     }
@@ -1640,8 +1636,7 @@ static void commit_request_cb (flux_t *h,
     if (flux_request_unpack (msg, NULL, "{ s:o s:s s:i }",
                              "ops", &ops,
                              "namespace", &ns,
-                             "flags", &flags)
-                             < 0) {
+                             "flags", &flags) < 0) {
         flux_log_error (h, "%s: flux_request_unpack", __FUNCTION__);
         goto error;
     }
@@ -1678,8 +1673,7 @@ static void commit_request_cb (flux_t *h,
          */
         treq_set_processed (tr, true);
 
-        if (kvstxn_mgr_add_transaction (root->ktm, treq_get_name (tr), ops, flags, 0)
-            < 0) {
+        if (kvstxn_mgr_add_transaction (root->ktm, treq_get_name (tr), ops, flags, 0) < 0) {
             flux_log_error (h, "%s: kvstxn_mgr_add_transaction", __FUNCTION__);
             goto error;
         }
@@ -1728,8 +1722,7 @@ static void relayfence_request_cb (flux_t *h,
                              "name", &name,
                              "namespace", &ns,
                              "flags", &flags,
-                             "nprocs", &nprocs)
-                             < 0) {
+                             "nprocs", &nprocs) < 0) {
         flux_log_error (h, "%s: flux_request_unpack", __FUNCTION__);
         return;
     }
@@ -1777,8 +1770,7 @@ static void relayfence_request_cb (flux_t *h,
                                         treq_get_name (tr),
                                         treq_get_ops (tr),
                                         treq_get_flags (tr),
-                                        0)
-            < 0) {
+                                        0) < 0) {
             flux_log_error (h, "%s: kvstxn_mgr_add_transaction", __FUNCTION__);
             goto error;
         }
@@ -1819,8 +1811,7 @@ static void fence_request_cb (flux_t *h,
                              "name", &name,
                              "namespace", &ns,
                              "flags", &flags,
-                             "nprocs", &nprocs)
-                             < 0) {
+                             "nprocs", &nprocs) < 0) {
         flux_log_error (h, "%s: flux_request_unpack", __FUNCTION__);
         goto error;
     }
@@ -1879,8 +1870,7 @@ static void fence_request_cb (flux_t *h,
                                             treq_get_name (tr),
                                             treq_get_ops (tr),
                                             treq_get_flags (tr),
-                                            0)
-                < 0) {
+                                            0) < 0) {
                 flux_log_error (h, "%s: kvstxn_mgr_add_transaction", __FUNCTION__);
                 goto error;
             }
@@ -1944,8 +1934,7 @@ static void wait_version_request_cb (flux_t *h,
                                   mh,
                                   msg,
                                   ctx,
-                                  rootseq)
-            < 0) {
+                                  rootseq) < 0) {
             flux_log_error (h, "%s: kvs_wait_version_add", __FUNCTION__);
             goto error;
         }
@@ -2006,8 +1995,7 @@ static void getroot_request_cb (flux_t *h,
                            "owner", root->owner,
                            "rootseq", root->seq,
                            "rootref", root->ref,
-                           "flags", root->flags)
-                           < 0)
+                           "flags", root->flags) < 0)
         flux_log_error (h, "%s: flux_respond_pack", __FUNCTION__);
     return;
 error:
@@ -2029,8 +2017,7 @@ static void error_event_cb (flux_t *h,
     if (flux_event_unpack (msg, NULL, "{ s:s s:o s:i }",
                            "namespace", &ns,
                            "names", &names,
-                           "errnum", &errnum)
-                           < 0) {
+                           "errnum", &errnum) < 0) {
         flux_log_error (ctx->h, "%s: flux_event_unpack", __FUNCTION__);
         return;
     }
@@ -2091,8 +2078,7 @@ static void setroot_event_cb (flux_t *h,
                            "namespace", &ns,
                            "rootseq", &rootseq,
                            "rootref", &rootref,
-                           "names", &names)
-                           < 0) {
+                           "names", &names) < 0) {
         flux_log_error (ctx->h, "%s: flux_event_unpack", __FUNCTION__);
         return;
     }
@@ -2404,8 +2390,7 @@ static void namespace_create_request_cb (flux_t *h,
                              "namespace", &ns,
                              "rootref", &rootref,
                              "owner", &owner,
-                             "flags", &flags)
-                             < 0) {
+                             "flags", &flags) < 0) {
         flux_log_error (h, "%s: flux_request_unpack", __FUNCTION__);
         goto error;
     }
@@ -2478,8 +2463,7 @@ static void start_root_remove (struct kvs_ctx *ctx, const char *ns)
 
         if (treq_mgr_iter_transactions (root->trm,
                                         root_remove_process_transactions,
-                                        &cbd)
-            < 0)
+                                        &cbd) < 0)
             flux_log_error (ctx->h, "%s: treq_mgr_iter_transactions", __FUNCTION__);
     }
 }
@@ -2689,8 +2673,7 @@ static void setroot_unpause_process_msg (struct kvs_ctx *ctx,
                            "namespace", &ns,
                            "rootseq", &rootseq,
                            "rootref", &rootref,
-                           "names", &names)
-                           < 0) {
+                           "names", &names) < 0) {
         flux_log_error (ctx->h, "%s: flux_event_unpack", __FUNCTION__);
         return;
     }
@@ -2981,8 +2964,7 @@ int mod_main (flux_t *h, int argc, char **argv)
         int seq = 0;
         uint32_t owner = getuid ();
 
-        if (store_initial_rootdir (ctx, empty_dir_rootref, sizeof (empty_dir_rootref))
-            < 0) {
+        if (store_initial_rootdir (ctx, empty_dir_rootref, sizeof (empty_dir_rootref)) < 0) {
             flux_log_error (h, "store_initial_rootdir");
             goto done;
         }
@@ -3026,8 +3008,7 @@ int mod_main (flux_t *h, int argc, char **argv)
         || flux_future_then (f_heartbeat_sync,
                              heartbeat_sync_max,
                              heartbeat_sync_cb,
-                             ctx)
-               < 0) {
+                             ctx) < 0) {
         flux_log_error (h, "error starting heartbeat synchronization");
         goto done;
     }
@@ -3065,4 +3046,3 @@ MOD_NAME ("kvs");
 
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab
- */


### PR DESCRIPTION
Update clang-format using some options from versions up to 11, and format some files with version 12 so we can see what they look like.  This is not really meant to be merged, but to pick a few large-ish files with various code patterns so we can figure out if this is what we want.

The only thing that really stood out to me in here is the `ok ()` and similar functions/macros seem like they are almost always formatted in a non-standard way.  Should those go in with the pack/unpack functions so they're left alone?