### PR TITLE
flux config: add load subcommand

### DIFF
--- a/doc/man1/flux-config.rst
+++ b/doc/man1/flux-config.rst
@@ -10,6 +10,8 @@ SYNOPSIS
 
 **flux** **config** **reload**
 
+**flux** **config** **load** [*PATH*]
+
 **flux** **config** **get** [*OPTIONS*] [*NAME*]
 
 **flux** **config** **builtin** [*NAME*]
@@ -47,6 +49,8 @@ configuration key names.  This command is available to all users.
    specific values if found to be in tree.  This enables Flux testing without
    requiring installation.
 
+``flux config load`` replaces the current config with an object read from
+standard input (JSON or TOML), or from ``*.toml`` in *PATH*, if specified.
 
 GET SUBCOMMAND OPTIONS
 ======================

--- a/t/t2222-job-manager-limit-job-size.t
+++ b/t/t2222-job-manager-limit-job-size.t
@@ -4,26 +4,22 @@ test_description='Test flux job manager limit-job-size plugin'
 
 . $(dirname $0)/sharness.sh
 
-mkdir -p config
-
-test_under_flux 2 full -o,--config-path=$(pwd)/config
+test_under_flux 2 full
 
 flux setattr log-stderr-level 1
 
 test_expect_success 'configure an invalid job-size limit' '
-	cat >config/policy.toml <<-EOT &&
+	test_must_fail flux config load <<-EOT
 	[policy.limits]
 	job-size.max.nnodes = -42
 	EOT
-	test_must_fail flux config reload
 '
 test_expect_success 'configure valid job-size.*.nnodes limits' '
-	cat >config/policy.toml <<-EOT &&
+	flux config load <<-EOT
 	[policy.limits]
 	job-size.max.nnodes = 2
 	job-size.min.nnodes = 2
 	EOT
-	flux config reload
 '
 test_expect_success 'a job that exceeds job-size.max.nnodes is rejected' '
 	test_must_fail flux mini submit -N 3 /bin/true 2>max-nnodes.err &&
@@ -37,12 +33,11 @@ test_expect_success 'a job that is between both of those is accepted' '
 	flux mini submit -N 2 /bin/true
 '
 test_expect_success 'configure job-size.*.ncores limits' '
-	cat >config/policy.toml <<-EOT &&
+	flux config load <<-EOT
 	[policy.limits]
 	job-size.max.ncores = 2
 	job-size.min.ncores = 2
 	EOT
-	flux config reload
 '
 test_expect_success 'a job that exceeds job-size.max.ncores is rejected' '
 	test_must_fail flux mini submit -n 3 /bin/true 2>max-ncores.err &&
@@ -56,12 +51,11 @@ test_expect_success 'a job that is between both of those is accepted' '
 	flux mini submit -n 2 /bin/true
 '
 test_expect_success 'configure job-size.*.ngpus limits' '
-	cat >config/policy.toml <<-EOT &&
+	flux config load <<-EOT
 	[policy.limits]
 	job-size.max.ngpus = 2
 	job-size.min.ngpus = 2
 	EOT
-	flux config reload
 '
 test_expect_success 'a job that exceeds job-size.max.ngpus is rejected' '
 	test_must_fail flux mini submit -g 3 /bin/true 2>max-ngpus.err &&
@@ -75,14 +69,13 @@ test_expect_success 'a job that is between both of those is accepted' '
 	flux mini submit -g 2 /bin/true
 '
 test_expect_success 'configure job-size.max.ngpus and queue with unlimited' '
-	cat >config/policy.toml <<-EOT &&
+	flux config load <<-EOT
 	[policy.limits]
 	job-size.max.ngpus = 0
 	[queues.debug]
 	[queues.batch.policy.limits]
 	job-size.max.ngpus = -1
 	EOT
-	flux config reload
 '
 test_expect_success 'a job is accepted if under general gpu limit' '
 	flux mini submit --queue=debug -n1 /bin/true
@@ -94,24 +87,21 @@ test_expect_success 'same job is accepted with unlimited queue override' '
 	flux mini submit --queue=batch -n1 -g1 /bin/true
 '
 test_expect_success 'configure an invalid job-size object' '
-	cat >config/policy.toml <<-EOT &&
+	test_must_fail flux config load <<-EOT
 	[policy.limits]
 	job-size = "wrong"
 	EOT
-	test_must_fail flux config reload
 '
 test_expect_success 'configure an out of bounds job-size.max.nnodes object' '
-	cat >config/policy.toml <<-EOT &&
+	test_must_fail flux config load <<-EOT
 	[policy.limits]
 	job-size.max.nnodes = -42
 	EOT
-	test_must_fail flux config reload
 '
 test_expect_success 'configure an invalid queue job-size.min.nnodes object' '
-	cat >config/policy.toml <<-EOT &&
+	test_must_fail flux config load <<-EOT
 	[queues.debug.policy.limits]
 	job-size.min.nnodes = "xyz"
 	EOT
-	test_must_fail flux config reload
 '
 test_done

--- a/t/t2240-queue-cmd.t
+++ b/t/t2240-queue-cmd.t
@@ -3,9 +3,7 @@ test_description='Test flux queue command'
 
 . $(dirname $0)/sharness.sh
 
-mkdir -p conf.d
-
-test_under_flux 1 full -o,--config-path=$(pwd)/conf.d
+test_under_flux 1 full
 
 flux setattr log-stderr-level 1
 
@@ -304,11 +302,10 @@ test_expect_success 'ensure instance is drained' '
 	flux queue status -v
 '
 test_expect_success 'configure batch,debug queues' '
-	cat >conf.d/config.toml <<-EOT &&
+	flux config load <<-EOT
 	[queues.batch]
 	[queues.debug]
 	EOT
-	flux config reload
 '
 test_expect_success 'jobs may be submitted to either queue' '
 	flux mini submit -q batch /bin/true &&

--- a/t/t2241-policy-config.t
+++ b/t/t2241-policy-config.t
@@ -10,182 +10,155 @@ specified in RFC 33 for [policy] and [queue.<name>.policy].
 
 mkdir -p config
 
-test_under_flux 1 minimal -o,--config-path=$(pwd)/config
+test_under_flux 1 minimal
 
 flux setattr log-stderr-level 1
 
 test_expect_success 'unknown policy key fails' '
-	cat >config/policy.toml <<-EOT &&
+	test_must_fail flux config load <<-EOT
 	policy.foo = 1
 	EOT
-	test_must_fail flux config reload
 '
 test_expect_success 'unknown policy.jobspec key fails' '
-	cat >config/policy.toml <<-EOT &&
+	test_must_fail flux config load <<-EOT
 	policy.jobspec.foo = 1
 	EOT
-	test_must_fail flux config reload
 '
 test_expect_success 'unknown policy.jobspec.defaults key fails' '
-	cat >config/policy.toml <<-EOT &&
+	test_must_fail flux config load <<-EOT
 	policy.jobspec.defaults.foo = 1
 	EOT
-	test_must_fail flux config reload
 '
 test_expect_success 'unknown policy.jobspec.defaults.system key fails' '
-	cat >config/policy.toml <<-EOT &&
+	test_must_fail flux config load <<-EOT
 	policy.jobspec.defaults.system.foo = 1
 	EOT
-	test_must_fail flux config reload
 '
 test_expect_success 'malformed policy.jobspec.defaults.system.duration fails' '
-	cat >config/policy.toml <<-EOT &&
+	test_must_fail flux config load <<-EOT
 	policy.jobspec.defaults.system.duration = 1
 	EOT
-	test_must_fail flux config reload
 '
 test_expect_success 'wrong type policy.jobspec.defaults.system.queue fails' '
-	cat >config/policy.toml <<-EOT &&
+	test_must_fail flux config load <<-EOT
 	policy.jobspec.defaults.system.queue = 1
 	EOT
-	test_must_fail flux config reload
 '
 test_expect_success 'unknown policy.limits key fails' '
-	cat >config/policy.toml <<-EOT &&
+	test_must_fail flux config load <<-EOT
 	policy.limits.foo = 1
 	EOT
-	test_must_fail flux config reload
 '
 test_expect_success 'unknown policy.limits.job-size key fails' '
-	cat >config/policy.toml <<-EOT &&
+	test_must_fail flux config load <<-EOT
 	policy.limits.job-size.foo = 1
 	EOT
-	test_must_fail flux config reload
 '
 test_expect_success 'unknown policy.limits.job-size.max key fails' '
-	cat >config/policy.toml <<-EOT &&
+	test_must_fail flux config load <<-EOT
 	policy.limits.job-size.max.foo = 1
 	EOT
-	test_must_fail flux config reload
 '
 test_expect_success 'unknown policy.limits.job-size.min key fails' '
-	cat >config/policy.toml <<-EOT &&
+	test_must_fail flux config load <<-EOT
 	policy.limits.job-size.min.foo = 1
 	EOT
-	test_must_fail flux config reload
 '
 test_expect_success 'incorrect policy.limits.job-size.min.nnodes fails' '
-	cat >config/policy.toml <<-EOT &&
+	test_must_fail flux config load <<-EOT
 	policy.limits.job-size.min.nnodes = -2
 	EOT
-	test_must_fail flux config reload
 '
 test_expect_success 'malformed policy.limits.duration fails' '
-	cat >config/policy.toml <<-EOT &&
+	test_must_fail flux config load <<-EOT
 	policy.limits.duration = 1.0
 	EOT
-	test_must_fail flux config reload
 '
 test_expect_success 'unknown policy.access key fails' '
-	cat >config/policy.toml <<-EOT &&
+	test_must_fail flux config load <<-EOT
 	policy.access.foo = 1.0
 	EOT
-	test_must_fail flux config reload
 '
 test_expect_success 'malformed policy.access.allow-user key fails' '
-	cat >config/policy.toml <<-EOT &&
+	test_must_fail flux config load <<-EOT
 	policy.access.allow-user = 1.0
 	EOT
-	test_must_fail flux config reload
 '
 test_expect_success 'malformed policy.access.allow-group key fails' '
-	cat >config/policy.toml <<-EOT &&
+	test_must_fail flux config load <<-EOT
 	policy.access.allow-group = 1.0
 	EOT
-	test_must_fail flux config reload
 '
 test_expect_success 'malformed policy.access.allow-user entry fails' '
-	cat >config/policy.toml <<-EOT &&
+	test_must_fail flux config load <<-EOT
 	policy.access.allow-user = [ 1 ]
 	EOT
-	test_must_fail flux config reload
 '
 test_expect_success 'malformed policy.access.allow-group entry fails' '
-	cat >config/policy.toml <<-EOT &&
+	test_must_fail flux config load <<-EOT
 	policy.access.allow-group = [ 1 ]
 	EOT
-	test_must_fail flux config reload
 '
 test_expect_success 'well formed policy.access works' '
-	cat >config/policy.toml <<-EOT &&
+	flux config load <<-EOT
 	[policy.access]
 	allow-user = [ "alice", "bob" ]
 	allow-group = [ "smurfs" ]
 	EOT
-	flux config reload
 '
 test_expect_success 'malformed queues table fails' '
-	cat >config/policy.toml <<-EOT &&
+	test_must_fail flux config load <<-EOT
 	queues = 1
 	EOT
-	test_must_fail flux config reload
 '
 test_expect_success 'unknown queues.NAME.policy.foo key fails' '
-	cat >config/policy.toml <<-EOT &&
+	test_must_fail flux config load <<-EOT
 	queues.x.policy.foo = 1
 	EOT
-	test_must_fail flux config reload
 '
 test_expect_success 'malformed queues.NAME.policy.limits.duration key fails' '
-	cat >config/policy.toml <<-EOT &&
+	test_must_fail flux config load <<-EOT
 	queues.x.policy.limits.duration = 1
 	EOT
-	test_must_fail flux config reload
 '
 test_expect_success 'default queue as queue policy fails' '
-	cat >config/policy.toml <<-EOT &&
+	test_must_fail flux config load <<-EOT
 	queues.x.policy.jobspec.defaults.system.queue = "x"
 	EOT
-	test_must_fail flux config reload
 '
 test_expect_success 'unknown default queue fails' '
-	cat >config/policy.toml <<-EOT &&
+	test_must_fail flux config load <<-EOT
 	[queues.foo]
 	[policy]
 	jobspec.defaults.system.queue = "bar"
 	EOT
-	test_must_fail flux config reload
 '
 test_expect_success 'unknown queues.NAME.requires.foo key fails' '
-	cat >config/policy.toml <<-EOT &&
+	test_must_fail flux config load <<-EOT
 	queues.x.requires = 1
 	EOT
-	test_must_fail flux config reload
 '
 test_expect_success 'malformed queues.NAME.requires fails' '
-	cat >config/policy.toml <<-EOT &&
+	test_must_fail flux config load <<-EOT
 	queues.x.requires = [ 1 ]
 	EOT
-	test_must_fail flux config reload
 '
 test_expect_success 'malformed queues.NAME.requires property string' '
-	cat >config/policy.toml <<-EOT &&
+	test_must_fail flux config load <<-EOT
 	queues.x.requires = [ "foo|bar" ]
 	EOT
-	test_must_fail flux config reload
 '
 test_expect_success 'well formed queues.NAME.requires works' '
-	cat >config/policy.toml <<-EOT &&
+	flux config load <<-EOT
 	[queues.x]
 	requires = [ "batch" ]
 	[queues.z]
 	requires = [ "debug", "foo" ]
 	EOT
-	flux config reload
 '
 # Example from flux-config-policy(5)
 test_expect_success 'valid config passes' '
-	cat >config/policy.toml <<-EOT &&
+	flux config load <<-EOT
 	[policy.jobspec.defaults.system]
 	duration = "1h"
 	queue = "batch"
@@ -201,6 +174,5 @@ test_expect_success 'valid config passes' '
 
 	[queues.batch]
 	EOT
-	flux config reload
 '
 test_done

--- a/t/t2801-top-cmd.t
+++ b/t/t2801-top-cmd.t
@@ -4,9 +4,7 @@ test_description='Test flux top command'
 
 . $(dirname $0)/sharness.sh
 
-mkdir -p conf.d
-
-test_under_flux 4 full -o,--config-path=$(pwd)/conf.d
+test_under_flux 4 full
 
 runpty="${SHARNESS_TEST_SRCDIR}/scripts/runpty.py"
 waitfile="${SHARNESS_TEST_SRCDIR}/scripts/waitfile.lua"
@@ -131,10 +129,9 @@ test_expect_success NO_CHAIN_LINT 'flux-top does not exit on recursive failure' 
 	grep -qi "error connecting to Flux" recurse-fail.log
 '
 test_expect_success 'configure a test queue' '
-	cat >conf.d/config.toml <<-EOT &&
+	flux config load <<-EOT
 	[queues.testq]
 	EOT
-	flux config reload
 '
 test_expect_success 'flux-top displays job queues when present' '
 	$runpty -f asciicast -o no-queue.log flux top --test-exit &&


### PR DESCRIPTION
As discussed in #4678, this adds a new `flux config load` subcommand that takes a configuration object on stdin (JSON or TOML) and directly updates the broker.   E.g. you can do stuff like this:
```sh
flux config load <<EOF
tbon.tcp_user_timeout = "2s"
EOF
```
or
```sh
flux config get | jq '.tbon.tcp_user_timeout = "3s"' | flux config load
```
In this PR, the entire config object is replaced with each invocation of `flux config load`, which seems like the safest way to use this in test, since it makes it clear that no config lingers from earlier tests.   A simple extension (perhaps for a future PR?) would be to add an `--update` option to let changes be applied incrementally, e.g.  [json_object_update()](https://jansson.readthedocs.io/en/latest/apiref.html#c.json_object_update) style, which would be a bit more natural than the  `jq` example above.


