### PR TITLE
libflux: support flux_get_process_scope()

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -35,6 +35,7 @@ MAN1_FILES_PRIMARY = \
 	man1/flux-mini.1 \
 	man1/flux-job.1 \
 	man1/flux-version.1 \
+	man1/flux-scope.1 \
 	man1/flux-jobs.1 \
 	man1/flux-pstree.1 \
 	man1/flux-restore.1 \

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -126,7 +126,8 @@ MAN3_FILES_PRIMARY = \
 	man3/idset_encode.3 \
 	man3/idset_add.3 \
 	man3/flux_jobtap_get_flux.3 \
-	man3/flux_sync_create.3
+	man3/flux_sync_create.3 \
+	man3/flux_get_process_scope.3
 
 
 # These files are generated as clones of a primary page.

--- a/doc/man1/flux-scope.rst
+++ b/doc/man1/flux-scope.rst
@@ -1,0 +1,66 @@
+.. flux-help-description : Get current process scope
+
+=============
+flux-scope(1)
+=============
+
+
+SYNOPSIS
+========
+
+**flux** **scope**
+
+
+DESCRIPTION
+===========
+
+flux-scopes(1) prints the current process scope.  This command may be
+useful to quickly determine the context of how a process is running.
+The potential outputs are:
+
+none
+    The process is not running under flux.
+
+system instance
+    The process is running under the system instance.  For example,
+    if you submitted ``flux scope`` as a job to the system instance:
+
+       $ flux mini submit flux scope
+
+    the output would be "system instance".   
+
+initial program
+    The process is the initial program running a non-system instance
+    of flux.  For example, if ``flux scope`` were executed as the
+    initial program for a flux sub-instance:
+
+       $ flux mini submit flux start flux scope
+
+    the output would be "initial program".
+
+    As another example, "initial program" would be output if ``flux
+    scope`` were executed as the initial program under a test
+    instance.
+    
+       $ flux start --test-size=4 flux scope
+
+job
+    The process is a job running under a non-system instance of flux.
+    For example, if ``flux scope`` were submitted as a job to a flux
+    sub-instance:
+
+       $ flux mini submit flux start flux mini run flux scope
+
+    the output would be "job".
+
+
+RESOURCES
+=========
+
+Flux: http://flux-framework.org
+
+
+SEE ALSO
+========
+
+:man1:`flux-start`, :man1:`flux-mini`

--- a/doc/man3/flux_get_process_scope.rst
+++ b/doc/man3/flux_get_process_scope.rst
@@ -1,0 +1,51 @@
+=========================
+flux_get_process_scope(3)
+=========================
+
+
+SYNOPSIS
+========
+
+#include <flux/core.h>
+
+int flux_get_process_scope (flux_process_scope_t *scope);
+
+
+DESCRIPTION
+===========
+
+``flux_get_process_scope()`` determines if the calling process is
+running under one of the following situations returned via ``scope``.
+
+FLUX_PROCESS_SCOPE_NONE
+    Process is not running under flux.
+
+FLUX_PROCESS_SCOPE_SYSTEM_INSTANCE
+    Process is running under the system instance.
+
+FLUX_PROCESS_SCOPE_INITIAL_PROGRAM
+    Process is the initial program running under a non-system instance.
+
+FLUX_PROCESS_SCOPE_JOB
+    Process is a job running under a non-system instance.
+
+
+RETURN VALUE
+============
+
+``flux_get_process_scope()`` returns zero on success . On error, -1 is
+returned, and errno is set appropriately.
+
+
+ERRORS
+======
+
+EINVAL
+   Some arguments were invalid.
+
+
+RESOURCES
+=========
+
+Flux: http://flux-framework.org
+

--- a/doc/manpages.py
+++ b/doc/manpages.py
@@ -103,6 +103,7 @@ man_pages = [
     ('man3/flux_future_wait_all_create', 'flux_future_next_child', 'functions for future composition', [author], 3),
     ('man3/flux_future_wait_all_create', 'flux_future_get_child', 'functions for future composition', [author], 3),
     ('man3/flux_future_wait_all_create', 'flux_future_wait_all_create', 'functions for future composition', [author], 3),
+    ('man3/flux_get_process_scope','flux_get_process_scope', 'Get current process scope', [author], 3),
     ('man3/flux_get_rank', 'flux_get_size', 'query Flux broker info', [author], 3),
     ('man3/flux_get_rank', 'flux_get_rank', 'query Flux broker info', [author], 3),
     ('man3/flux_get_reactor', 'flux_set_reactor', 'get/set reactor associated with broker handle', [author], 3),

--- a/doc/manpages.py
+++ b/doc/manpages.py
@@ -47,6 +47,7 @@ man_pages = [
     ('man1/flux-ping', 'flux-ping', 'measure round-trip latency to Flux services', [author], 1),
     ('man1/flux-proxy', 'flux-proxy', 'create proxy environment for Flux instance', [author], 1),
     ('man1/flux-queue', 'flux-queue', 'manage the job queue', [author], 1),
+    ('man1/flux-scope', 'flux-scope', 'Get current process scope', [author], 1),
     ('man1/flux-start', 'flux-start', 'bootstrap a local Flux instance', [author], 1),
     ('man1/flux-startlog', 'flux-startlog', 'Show Flux instance start and stop times', [author], 1),
     ('man1/flux-top', 'flux-top', 'Display running Flux jobs', [author], 1),

--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -96,7 +96,8 @@ fluxcmd_PROGRAMS = \
 	flux-queue \
 	flux-exec \
 	flux-R \
-	flux-top
+	flux-top \
+	flux-scope
 
 flux_start_LDADD = \
 	$(fluxcmd_ldadd) \
@@ -149,6 +150,9 @@ flux_top_CPPFLAGS = \
 flux_top_LDADD = \
 	$(fluxcmd_ldadd) \
 	$(CURSES_LIBS)
+
+flux_scope_LDADD = \
+	$(fluxcmd_ldadd)
 
 #
 # Automatically build list of flux(1) builtins from

--- a/src/cmd/flux-scope.c
+++ b/src/cmd/flux-scope.c
@@ -1,0 +1,52 @@
+/************************************************************\
+ * Copyright 2022 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/core.h>
+
+#include "src/common/libutil/log.h"
+
+int main (int argc, char *argv[])
+{
+    flux_process_scope_t scope;
+    const char *str;
+
+    log_init ("flux-scope");
+
+    if (flux_get_process_scope (&scope) < 0)
+        log_err_exit ("flux_get_process_scope");
+
+    switch (scope) {
+    case FLUX_PROCESS_SCOPE_NONE:
+        str = "none";
+        break;
+    case FLUX_PROCESS_SCOPE_SYSTEM_INSTANCE:
+        str = "system instance";
+        break;
+    case FLUX_PROCESS_SCOPE_INITIAL_PROGRAM:
+        str = "initial program";
+        break;
+    case FLUX_PROCESS_SCOPE_JOB:
+        str = "job";
+        break;
+    default:
+        str = "unspecified";
+        break;
+    }
+    printf ("%s\n", str);
+    log_fini ();
+    return (0);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/cmd/flux.c
+++ b/src/cmd/flux.c
@@ -95,7 +95,7 @@ static optparse_t * setup_optparse_parse_args (int argc, char *argv[])
         log_msg_exit ("optparse_set() failed");
 
     // Don't print internal subcommands in --help (we print subcommands using
-    //  emit_command_help() above.
+    //  emit_command_help()
     e = optparse_set (p, OPTPARSE_PRINT_SUBCMDS, 0);
     if (e != OPTPARSE_SUCCESS)
         log_msg_exit ("optparse_set (OPTPARSE_PRINT_SUBCMDS");

--- a/src/cmd/top/summary_pane.c
+++ b/src/cmd/top/summary_pane.c
@@ -311,15 +311,15 @@ done:
 static int get_instance_attr_int (flux_t *h, const char *attr)
 {
     const char *s;
-    unsigned long level;
+    unsigned long val;
 
     if (!(s = flux_attr_get (h, attr)))
         fatal (errno, "error fetching %s broker attribute", attr);
     errno = 0;
-    level = strtoul (s, NULL, 10);
+    val = strtoul (s, NULL, 10);
     if (errno != 0)
         fatal (errno, "error parsing %s", attr);
-    return level;
+    return val;
 }
 
 

--- a/src/common/libflux/Makefile.am
+++ b/src/common/libflux/Makefile.am
@@ -83,7 +83,8 @@ fluxcoreinclude_HEADERS = \
 	plugin.h \
 	sync.h \
 	disconnect.h \
-	stats.h
+	stats.h \
+	util.h
 
 nodist_fluxcoreinclude_HEADERS = \
 	version.h
@@ -130,7 +131,8 @@ libflux_la_SOURCES = \
 	disconnect.c \
 	stats.c \
 	fripp.h \
-	fripp.c
+	fripp.c \
+	util.c
 
 libflux_la_CPPFLAGS = \
 	$(installed_conf_cppflags) \
@@ -167,6 +169,7 @@ TESTS = test_message.t \
 	test_handle.t \
 	test_msg_handler.t \
 	test_version.t \
+	test_util.t \
 	test_dispatch.t \
 	test_handle.t \
 	test_log.t \
@@ -264,6 +267,10 @@ test_msg_handler_t_LDADD = $(test_ldadd)
 test_version_t_SOURCES = test/version.c
 test_version_t_CPPFLAGS = $(test_cppflags)
 test_version_t_LDADD = $(test_ldadd)
+
+test_util_t_SOURCES = test/util.c
+test_util_t_CPPFLAGS = $(test_cppflags)
+test_util_t_LDADD = $(test_ldadd)
 
 test_rpc_t_SOURCES = test/rpc.c
 test_rpc_t_CPPFLAGS = $(test_cppflags)

--- a/src/common/libflux/flux.h
+++ b/src/common/libflux/flux.h
@@ -37,6 +37,7 @@
 #include "sync.h"
 #include "disconnect.h"
 #include "stats.h"
+#include "util.h"
 
 #endif /* !_FLUX_CORE_FLUX_H */
 

--- a/src/common/libflux/test/util.c
+++ b/src/common/libflux/test/util.c
@@ -1,0 +1,33 @@
+/************************************************************\
+ * Copyright 2022 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#include "src/common/libflux/util.h"
+#include "src/common/libtap/tap.h"
+
+#include <string.h>
+
+int main (int argc, char *argv[])
+{
+    int ret;
+
+    plan (NO_PLAN);
+
+    ret = flux_get_process_scope (NULL);
+    ok (ret < 0 && errno == EINVAL,
+        "flux_get_process_scope returns EINVAL on invalid input");
+
+    done_testing();
+    return (0);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */
+

--- a/src/common/libflux/util.c
+++ b/src/common/libflux/util.c
@@ -1,0 +1,85 @@
+/************************************************************\
+ * Copyright 2022 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <flux/core.h>
+
+#include "util.h"
+
+static int get_attr_uint (flux_t *h, const char *attr, unsigned int *valp)
+{
+    const char *s;
+    unsigned long val;
+
+    if (!(s = flux_attr_get (h, attr)))
+        return -1;
+    errno = 0;
+    val = strtoul (s, NULL, 10);
+    if (errno != 0)
+        return -1;
+    (*valp) = val;
+    return 0;
+}
+
+int flux_get_process_scope (flux_process_scope_t *scope)
+{
+    flux_t *h;
+    unsigned int instance_level;
+    uid_t security_owner;
+    const char *jobid;
+    const char *kvsns;
+
+    if (!scope) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (!(h = flux_open (NULL, 0))) {
+        if (errno != ENOENT)
+            return -1;
+        (*scope) = FLUX_PROCESS_SCOPE_NONE;
+        return 0;
+    }
+
+    if (get_attr_uint (h, "instance-level", &instance_level) < 0)
+        return -1;
+
+    if (get_attr_uint (h, "security.owner", &security_owner) < 0)
+        return -1;
+
+    jobid = flux_attr_get (h, "jobid");
+
+    if (instance_level == 0
+        && !jobid
+        && security_owner != getuid ()) {
+        (*scope) = FLUX_PROCESS_SCOPE_SYSTEM_INSTANCE;
+        return 0;
+    }
+    /* else
+     *   instance_level > 0 - running within flux job
+     *   jobid != NULL - running sub instance
+     *   security_owner == getuid () - user instance
+     */
+
+    kvsns = getenv ("FLUX_KVS_NAMESPACE");
+    if (kvsns)
+        (*scope) = FLUX_PROCESS_SCOPE_JOB;
+    else
+        (*scope) = FLUX_PROCESS_SCOPE_INITIAL_PROGRAM;
+    return 0;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libflux/util.h
+++ b/src/common/libflux/util.h
@@ -1,0 +1,56 @@
+/************************************************************\
+ * Copyright 2022 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _FLUX_CORE_UTIL_H
+#define _FLUX_CORE_UTIL_H
+
+#include <flux/core.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum flux_process_scope {
+    FLUX_PROCESS_SCOPE_NONE = 0,
+    FLUX_PROCESS_SCOPE_SYSTEM_INSTANCE = 1,
+    FLUX_PROCESS_SCOPE_INITIAL_PROGRAM = 2,
+    FLUX_PROCESS_SCOPE_JOB = 3,
+} flux_process_scope_t;
+
+/* Retrieve information on the scope of a job
+ *
+ * NONE - process is not running under flux
+ *
+ * SYSTEM_INSTANCE - process is running under the system instance
+ * - e.g. flux mini run my_process.sh
+ *
+ * INITIAL_PROGRAM - process is running as the initial program
+ * of a user flux instance
+ * - e.g. flux mini submit flux start my_process.sh
+ * - e.g. flux start --test-size=1 my_process.sh
+ *
+ * JOB - process is running as a job in a non-system instance
+ * - e.g. > flux mini submit flux start flux mini submit my_process.sh
+ * - e.g. > flux mini alloc -N1
+ *        > flux mini run my_process.sh
+ *
+ * Returns 0 on success, -1 on error
+ */
+int flux_get_process_scope (flux_process_scope_t *scope);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* !_FLUX_CORE_UTIL_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/t/system/0004-process-scope.t
+++ b/t/system/0004-process-scope.t
@@ -1,0 +1,8 @@
+#
+#  Process scope test
+#
+test_expect_success 'scope returns system instance' '
+	flux scope > scope.out &&
+	echo "system instance" > scope.exp &&
+	test_cmp scope.exp scope.out
+'

--- a/t/t0010-generic-utils.t
+++ b/t/t0010-generic-utils.t
@@ -79,4 +79,15 @@ test_expect_success 'heaptrace.dump request with empty payload fails with EPROTO
 	${RPC} heaptrace.dump 71 </dev/null
 '
 
+test_expect_success 'scope returns correct value for initial program' '
+	flux start flux scope > scope1.out &&
+	echo "initial program" > scope1.exp &&
+	test_cmp scope1.exp scope1.out
+'
+test_expect_success 'scope returns correct value for job' '
+	flux start flux mini run flux scope > scope2.out &&
+	echo "job" > scope2.exp &&
+	test_cmp scope2.exp scope2.out
+'
+
 test_done


### PR DESCRIPTION
Per #3817.  This is super WIP with no testing yet, but wanted to post to get initial high level feedback.

- basic logic within function for the 5 categories discussed in #3817
- should be 4 categories instead of 5?  some discussion for this in #3817 too
- API style / enum names
- location of the function, I put it in new files `libflux/util.[ch]` ... but could go in `libjob` instead? but that's not the super right place either ... 

TODO
- the command
- tons of tests
- do we need a nice python wrapper?
- document it / add nice comments & examples