### PR TITLE
add devcontainer autocomplete

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,10 +6,24 @@
     "customizations": {
       "vscode": {
         "settings": {
-          "terminal.integrated.defaultProfile.linux": "bash"
+          "terminal.integrated.defaultProfile.linux": "bash",
+
+          // Ensure that Python autocomplete works out of the box
+          "python.autoComplete.extraPaths": [
+            "/usr/local/lib/flux/python3.8",
+            "/usr/local/lib/python3.8/site-packages",
+            "/workspaces/flux-core/src/bindings/python"
+          ],
+          "python.analysis.extraPaths": [
+            "/usr/local/lib/flux/python3.8",
+            "/usr/local/lib/python3.8/site-packages",
+            "/workspaces/flux-core/src/bindings/python"
+          ]      
         }, 
         // Note to Flux Developers! We can add extensions here that you like
-        "extensions": [],
+        "extensions": [
+			"ms-python.python"
+		],
       },
     },
     // Needed for git security feature (this assumes you locally cloned to flux-core)


### PR DESCRIPTION
Problem: if we are using the devcontainer to develop Python scripts that use Flux, we cannot take advantage of autocomplete without the Python plugin installed (must be installed in the container) along with having the custom Flux paths included to be seen. This fix will ensure the Python extension is installed, and that all search paths are provided where the module could be (pre and post compile, with preference for installed locations if flux is ultimately built)

Examples (this is newly starting the dev container):

![Screenshot from 2022-10-21 18-28-09](https://user-images.githubusercontent.com/814322/197308809-c3050116-9315-4ca5-baac-d94d33fb1cda.png)
![Screenshot from 2022-10-21 18-28-23](https://user-images.githubusercontent.com/814322/197308810-0d6ed280-1b40-4b9b-bd22-2adb7ac012e2.png)


Signed-off-by: vsoch <vsoch@users.noreply.github.com>