### PR TITLE
flux-resource: unify output format options, support config files and named formats

### DIFF
--- a/doc/man1/flux-resource.rst
+++ b/doc/man1/flux-resource.rst
@@ -45,15 +45,14 @@ RESOURCE INVENTORY section below.
 COMMANDS
 ========
 
-**list** [-v] [-n] [-o FORMAT] [-s STATE,...]
-   Show scheduler view of resources.  One or more *-v,--verbose* options
-   increase output verbosity.  *-n,--no-header* suppresses header from output.
-   *-o,--format=FORMAT*, customizes output formatting (see below).
-   *-s,--states=STATE,...* limits output to specified resource states, where
-   valid states are "up", "down", "allocated", "free", and "all".  Note that
-   the scheduler represents "offline", "exclude", and "drain" resource states
-   as "down" due to its simplified interface with the resource service defined
-   by RFC 27.
+**list** [-n] [-o FORMAT] [-s STATE,...]
+   Show scheduler view of resources. The *-n,--no-header* option suppresses
+   header from output,  *-o,--format=FORMAT*, customizes output formatting
+   (see below), and  *-s,--states=STATE,...* limits output to specified
+   resource states, where valid states are "up", "down", "allocated",
+   "free", and "all".  Note that the scheduler represents "offline",
+   "exclude", and "drain" resource states as "down" due to its simplified
+   interface with the resource service defined by RFC 27.
 
 **info** [-s STATE,...]
    Show a brief, single line summary of scheduler view of resources.
@@ -61,18 +60,22 @@ COMMANDS
    states as with ``flux resource list``. By default, the *STATE* reported
    by ``flux resource info`` is "all".
 
-**status**  [-v] [-n] [-o FORMAT] [-s STATE,...]
-   Show system view of resources.  One or more *-v,--verbose* options
-   increase output verbosity.  *-n,--no-header* suppresses header from output.
-   *-o,--format=FORMAT*, customizes output formatting (see below).
-   *-s,--states=STATE,...* limits output to specified resource states, where
-   valid states are "online", "offline", "avail", "exclude", "draining",
-   "drained", and "all". The special "drain" state is also supported, and
-   selects both draining and drained resources.
+**status**  [-n] [-o FORMAT] [-s STATE,...] [--skip-empty]
+   Show system view of resources.  The *-n,--no-header* suppresses header
+   from output, *-o,--format=FORMAT* customizes output formatting (see
+   below), and *-s,--states=STATE,...* limits output to specified resource
+   states, where valid states are "online", "offline", "avail", "exclude",
+   "draining", "drained", and "all". The special "drain" state is also
+   supported, and selects both draining and drained resources. Normally,
+   ``flux resource status`` skips lines with no resources, unless the
+   ``-s, --states`` option is used. Suppression of empty lines can always
+   be forced with the ``--skip-empty`` option.
 
-**drain** [-f] [-u] [targets] [reason ...]
-   If specified without arguments, list drained nodes.  The *targets* argument
-   is an IDSET or HOSTLIST specifying nodes to drain.  Any remaining arguments
+**drain** [-n] [-o FORMAT] [-f] [-u] [targets] [reason ...]
+   If specified without arguments, list drained nodes. In this mode,
+   *-n,--no-header* suppresses header from output and *-o,--format=FORMAT*
+   customizes output formatting (see below).  The *targets* argument is an
+   IDSET or HOSTLIST specifying nodes to drain.  Any remaining arguments
    are assumed to be a reason to be recorded with the drain event.
 
    By default, **flux resource drain** will fail if any of the *targets*
@@ -100,9 +103,29 @@ OUTPUT FORMAT
 =============
 
 The *--format* option can be used to specify an output format using Python's
-string format syntax.  See :man1:`flux-jobs` for a detailed description of
-this syntax.
+string format syntax or a defined format by name. For a list of built-in
+and configured formats use ``-o help``. See :man1:`flux-jobs` *OUTPUT FORMAT*
+section for a detailed description of this syntax.
 
+CONFIGURATION
+=============
+
+Similar to :man1:`flux-jobs`, the ``flux-resource`` command supports loading
+a set of config files for customizing utility output formats. Currently
+this can be used to register named format strings for the ``status``,
+``list``, and ``drain`` subcommands.
+
+Configuration for each ``flux-resource`` subcommand is defined in a separate
+table, so to add a new format ``myformat`` for ``flux resource list``,
+the following config file could be used::
+
+  # $HOME/.config/flux/flux-resource.toml
+  [list.formats.myformat]
+  description = "My flux resource list format"
+  format = "{state} {nodelist}"
+
+See :man1:`flux-jobs` *CONFIGURATION* section for more information about the
+order of precedence for loading these config files.
 
 RESOURCE INVENTORY
 ==================

--- a/src/bindings/python/flux/job/info.py
+++ b/src/bindings/python/flux/job/info.py
@@ -638,7 +638,7 @@ class JobInfoFormat(flux.util.OutputFormat):
         "instance.resources.free.nnodes": "FREE",
     }
 
-    def __init__(self, fmt):
+    def __init__(self, fmt, headings=None, prepend=None):
         """
         Parse the input format fmt with string.Formatter.
         Save off the fields and list of format tokens for later use,

--- a/src/bindings/python/flux/job/info.py
+++ b/src/bindings/python/flux/job/info.py
@@ -665,4 +665,4 @@ class JobInfoFormat(flux.util.OutputFormat):
                     if field_heading.startswith("RESOURCES."):
                         field_heading = field_heading[10:]
                     self.headings[field] = field_heading
-        super().__init__(self.headings, fmt, prepend="0.")
+        super().__init__(fmt)

--- a/src/bindings/python/flux/util.py
+++ b/src/bindings/python/flux/util.py
@@ -609,6 +609,43 @@ class OutputFormat:
         #  Return new format string created from pruned format_list
         return "".join(self._fmt_tuple(*x) for x in format_list)
 
+    def print_items(self, items, no_header=False, pre=None, post=None):
+        """
+        Handle printing a list of items with the current format.
+
+        First pre-process format using ``items`` to remove any empty
+        fields, if requested. (The pre-processing step could be extended
+        in the future.)
+
+        Then, generate a header unless no_header is True.
+
+        Finally output a formatted line for each provided item.
+
+        Args:
+            items (iterable): list of items to format
+            no_header (boolean): disable header row (default: False)
+            pre (callable): Function to call before printing each item
+            post (callable): Function to call after printing each item
+        """
+        #  Preprocess original format by processing with filter_empty():
+        newfmt = self.filter_empty(items)
+        #  Get the current class for creating a new formatter instance:
+        cls = self.__class__
+        #  Create new instance of the current class from filtered format:
+        formatter = cls(newfmt, headings=self.headings, prepend=self.prepend)
+        if not no_header:
+            print(formatter.header())
+        for item in items:
+            if callable(pre):
+                pre(item)
+            line = formatter.format(item)
+            try:
+                print(line)
+            except UnicodeEncodeError:
+                print(line.encode("utf-8", errors="surrogateescape").decode())
+            if callable(post):
+                post(item)
+
 
 class Tree:
     """Very simple pstree-like display for the console

--- a/src/bindings/python/flux/util.py
+++ b/src/bindings/python/flux/util.py
@@ -9,6 +9,7 @@
 ###############################################################
 
 import argparse
+import copy
 import errno
 import glob
 import json
@@ -905,7 +906,7 @@ class UtilConfig:
         self.name = name
         self.dict = {}
         if initial_dict:
-            self.dict = dict(initial_dict)
+            self.dict = copy.deepcopy(initial_dict)
         self.config = self.dict
 
         #  If not None,  use subcommand config in subtable = 'subtable'

--- a/src/bindings/python/flux/util.py
+++ b/src/bindings/python/flux/util.py
@@ -442,7 +442,7 @@ class OutputFormat:
                 return kwargs[field_name], None
             return super().get_field(field_name, args, kwargs)
 
-    def __init__(self, valid_headings, fmt, prepend=None):
+    def __init__(self, fmt, headings=None, prepend="0."):
         """
         Parse the input format fmt with string.Formatter.
         Save off the fields and list of format tokens for later use,
@@ -451,7 +451,10 @@ class OutputFormat:
         Throws an exception if any format fields do not match the allowed
         list of headings.
         """
-        self.headings = valid_headings
+        if headings is not None:
+            self.headings = headings
+        if prepend is not None:
+            self.prepend = prepend
         self.fmt = fmt
         self.fmt_orig = fmt
         #  Parse format into list of (string, field, spec, conv) tuples,
@@ -472,8 +475,8 @@ class OutputFormat:
                 raise ValueError("Unknown format field: " + field)
 
         #  Prepend arbitrary string to format fields if requested
-        if prepend:
-            self.fmt = self.get_format_prepended(prepend)
+        if self.prepend:
+            self.fmt = self.get_format_prepended(self.prepend)
 
     @property
     def fields(self):

--- a/src/bindings/python/flux/util.py
+++ b/src/bindings/python/flux/util.py
@@ -1049,7 +1049,10 @@ class UtilConfig:
                 entry = formats[name]
             except KeyError:
                 raise ValueError(f"--format: No such format {name}")
-            print(f"[formats.{name}]")
+            if self.subtable:
+                print(f"[{self.subtable}.formats.{name}]")
+            else:
+                print(f"[formats.{name}]")
             if "description" in entry:
                 print(f"description = \"{entry['description']}\"")
             print(f"format = \"{entry['format']}\"")

--- a/src/bindings/python/flux/util.py
+++ b/src/bindings/python/flux/util.py
@@ -333,8 +333,6 @@ def fsd(secs):
 class UtilFormatter(Formatter):
     # pylint: disable=too-many-branches
 
-    headings: Mapping[str, str] = {}
-
     def convert_field(self, value, conv):
         """
         Flux utility-specific field conversions. Avoids the need
@@ -427,6 +425,7 @@ class OutputFormat:
     """
 
     formatter = UtilFormatter
+    headings: Mapping[str, str] = {}
 
     class HeaderFormatter(UtilFormatter):
         """Custom formatter for flux utilities header row.

--- a/src/cmd/flux-jobs.py
+++ b/src/cmd/flux-jobs.py
@@ -66,25 +66,6 @@ class FluxJobsConfig(UtilConfig):
         initial_dict = {"formats": dict(self.builtin_formats)}
         super().__init__(name="flux-jobs", initial_dict=initial_dict)
 
-    def validate_formats(self, path, formats):
-        if not isinstance(formats, dict):
-            raise ValueError(f"{path}: the 'formats' key must be a mapping")
-        for name, entry in formats.items():
-            if name in self.builtin_formats:
-                raise ValueError(
-                    f"{path}: override of builtin format '{name}' not permitted"
-                )
-            if not isinstance(entry, dict):
-                raise ValueError(f"{path}: 'formats.{name}' must be a mapping")
-            if "format" not in entry:
-                raise ValueError(
-                    f"{path}: formats.{name}: required key 'format' missing"
-                )
-            if not isinstance(entry["format"], str):
-                raise ValueError(
-                    f"{path}: formats.{name}: 'format' key must be a string"
-                )
-
     def validate(self, path, config):
         """Validate a loaded flux-jobs config file as dictionary"""
         for key, value in config.items():
@@ -92,42 +73,6 @@ class FluxJobsConfig(UtilConfig):
                 self.validate_formats(path, value)
             else:
                 raise ValueError(f"{path}: invalid key {key}")
-
-
-def load_format_string(args):
-    if "{" in args.format:
-        return args.format
-
-    config = FluxJobsConfig().load()
-
-    if args.format == "help":
-        print("\nConfigured flux-jobs output formats:\n")
-        for name, entry in config.formats.items():
-            print(f"  {name:<12}", end="")
-            try:
-                print(f" {entry['description']}")
-            except KeyError:
-                print()
-        sys.exit(0)
-    elif args.format.startswith("get-config="):
-        _, name = args.format.split("=", 1)
-        try:
-            entry = config.formats[name]
-        except KeyError:
-            LOGGER.error("--format: No such format %s", name)
-            sys.exit(1)
-        print(f"[formats.{name}]")
-        try:
-            print(f"description = \"{entry['description']}\"")
-        except KeyError:
-            pass
-        print(f"format = \"{entry['format']}\"")
-        sys.exit(0)
-    try:
-        return config.formats[args.format]["format"]
-    except KeyError:
-        LOGGER.error("--format: No such format %s", args.format)
-        sys.exit(1)
 
 
 def fetch_jobs_stdin():
@@ -511,7 +456,7 @@ def main():
     if args.recurse_all:
         args.recursive = True
 
-    fmt = load_format_string(args)
+    fmt = FluxJobsConfig().load().get_format_string(args.format)
     try:
         formatter = JobInfoFormat(fmt)
     except ValueError as err:

--- a/src/cmd/flux-jobs.py
+++ b/src/cmd/flux-jobs.py
@@ -459,16 +459,15 @@ def get_jobs_recursive(job, args, fields):
 def print_jobs(jobs, args, formatter, path="", level=0):
     children = []
 
-    for job in jobs:
-        color_set = color_setup(args, job)
-        line = formatter.format(job)
-        try:
-            print(line)
-        except UnicodeEncodeError:
-            print(line.encode("utf-8", errors="surrogateescape").decode())
-        color_reset(color_set)
+    def pre(job):
+        job.color_set = color_setup(args, job)
+
+    def post(job):
+        color_reset(job.color_set)
         if args.recursive and is_user_instance(job, args):
             children.append(job)
+
+    formatter.print_items(jobs, no_header=True, pre=pre, post=post)
 
     if not args.recursive or args.level == level:
         return

--- a/src/cmd/flux-resource.py
+++ b/src/cmd/flux-resource.py
@@ -54,6 +54,13 @@ class FluxResourceConfig(UtilConfig):
                 "{ncores:>8} {ngpus:>8} {nodelist}"
             ),
         },
+        "rlist": {
+            "description": "Format including resource list details",
+            "format": (
+                "{state:>10} ?:{properties:<10.10+} {nnodes:>6} "
+                "{ncores:>8} {ngpus:>8} {rlist}"
+            ),
+        },
     }
 
     def __init__(self, subcommand):

--- a/src/cmd/flux-resource.py
+++ b/src/cmd/flux-resource.py
@@ -13,7 +13,6 @@ import json
 import logging
 import os.path
 import sys
-from datetime import datetime
 
 import flux
 from flux.future import WaitAllFuture
@@ -82,7 +81,7 @@ class StatusLine:
         else:
             self.reason = ""
         if timestamp:
-            self.timestamp = datetime.fromtimestamp(timestamp).strftime("%FT%T")
+            self.timestamp = timestamp
         else:
             self.timestamp = ""
 
@@ -186,7 +185,7 @@ def drain_list():
             )
             lines.append(line)
 
-    fmt = "{timestamp:<20} {state:<8.8} {ranks:<8.8} {reason:<30} {nodelist}"
+    fmt = "{timestamp!d:%FT%T::<20} {state:<8.8} {ranks:<8.8} {reason:<30} {nodelist}"
     formatter = flux.util.OutputFormat(headings, fmt, prepend="0.")
     print(formatter.header())
     for line in lines:

--- a/src/cmd/flux-resource.py
+++ b/src/cmd/flux-resource.py
@@ -375,11 +375,14 @@ def status(args):
     formatter = flux.util.OutputFormat(headings, fmt, prepend="0.")
     if not args.no_header:
         print(formatter.header())
+
+    #  Skip empty lines unless --verbose or --states or ---skip-empty
+    skip_empty = args.skip_empty or (not args.verbose and not args.states)
+
     for line in sorted(rstat, key=lambda x: valid_states.index(x.state)):
         if line.state not in states:
             continue
-        #  Skip empty lines unless --verbose or --states
-        if line.nnodes == 0 and args.states is None and not args.verbose:
+        if line.nnodes == 0 and skip_empty:
             continue
         print(formatter.format(line))
 
@@ -563,6 +566,11 @@ def main():
     )
     status_parser.add_argument(
         "--from-stdin", action="store_true", help=argparse.SUPPRESS
+    )
+    status_parser.add_argument(
+        "--skip-empty",
+        action="store_true",
+        help="Skip empty lines of output even with --states/--verbose",
     )
     status_parser.set_defaults(func=status)
 

--- a/src/cmd/flux-resource.py
+++ b/src/cmd/flux-resource.py
@@ -32,6 +32,10 @@ class FluxResourceConfig(UtilConfig):
             "description": "Default flux-resource status format string",
             "format": "{state:>10} {nnodes:>6} {nodelist}",
         },
+        "long": {
+            "description": "Long flux-resource status format string",
+            "format": "{state:>10} {nnodes:>6} {reason:<30.30+} {nodelist}",
+        },
     }
     builtin_formats["drain"] = {
         "default": {

--- a/src/cmd/flux-resource.py
+++ b/src/cmd/flux-resource.py
@@ -333,7 +333,7 @@ def status(args):
 
     rstat = ResourceStatus.from_status_response(resp, fmt, allocated)
 
-    formatter = flux.util.OutputFormat(headings, fmt, prepend="0.")
+    formatter = flux.util.OutputFormat(fmt, headings=headings)
     if not args.no_header:
         print(formatter.header())
 
@@ -383,7 +383,7 @@ def resources_uniq_lines(resources, states, formatter):
             if field in uniq_fields:
                 uniq_fmt += "{" + field + "}:"
 
-    fmt = flux.util.OutputFormat(formatter.headings, uniq_fmt, prepend="0.")
+    fmt = flux.util.OutputFormat(uniq_fmt, headings=formatter.headings)
 
     #  Create a mapping of resources sets that generate uniq "lines":
     lines = {}
@@ -452,7 +452,7 @@ def list_handler(args):
     if args.format:
         fmt = args.format
 
-    formatter = flux.util.OutputFormat(headings, fmt, prepend="0.")
+    formatter = flux.util.OutputFormat(fmt, headings=headings)
 
     lines = resources_uniq_lines(resources, states, formatter)
 

--- a/src/cmd/flux-resource.py
+++ b/src/cmd/flux-resource.py
@@ -262,8 +262,6 @@ class ResourceStatus:
 def status_help(args, valid_states, headings):
     if args.states == "help":
         LOGGER.info("valid states: %s", ",".join(valid_states))
-    if args.format == "help":
-        LOGGER.info("valid formats: %s", ",".join(headings.keys()))
     sys.exit(0)
 
 
@@ -307,8 +305,8 @@ def status(args):
         "timestamp": "TIME",
     }
 
-    #  Emit list of valid states or formats if requested
-    if "help" in [args.states, args.format]:
+    #  Emit list of valid states if requested
+    if args.states == "help":
         status_help(args, valid_states, headings)
 
     #  Get state list from args or defaults:

--- a/src/cmd/flux-resource.py
+++ b/src/cmd/flux-resource.py
@@ -38,11 +38,17 @@ class FluxResourceConfig(UtilConfig):
         },
     }
     builtin_formats["drain"] = {
-        "default": {
-            "description": "Default flux-resource drain format string",
+        "long": {
+            "description": "Long flux-resource drain format string",
             "format": (
                 "{timestamp!d:%FT%T::<20} {state:<8.8} {ranks:<8.8+} "
                 "{reason:<30.30+} {nodelist}"
+            ),
+        },
+        "default": {
+            "description": "Default flux-resource drain format string",
+            "format": (
+                "{timestamp!d:%b%d %R::<12} {state:<8.8} {reason:<30.30+} {nodelist}"
             ),
         },
     }

--- a/src/cmd/flux-resource.py
+++ b/src/cmd/flux-resource.py
@@ -334,18 +334,19 @@ def status(args):
     rstat = ResourceStatus.from_status_response(resp, fmt, allocated)
 
     formatter = flux.util.OutputFormat(fmt, headings=headings)
-    if not args.no_header:
-        print(formatter.header())
 
     #  Skip empty lines unless --verbose or --states or ---skip-empty
     skip_empty = args.skip_empty or (not args.verbose and not args.states)
 
+    lines = []
     for line in sorted(rstat, key=lambda x: valid_states.index(x.state)):
         if line.state not in states:
             continue
         if line.nnodes == 0 and skip_empty:
             continue
-        print(formatter.format(line))
+        lines.append(line)
+
+    formatter.print_items(lines, no_header=args.no_header)
 
 
 def drain_list(args):
@@ -455,11 +456,7 @@ def list_handler(args):
     formatter = flux.util.OutputFormat(fmt, headings=headings)
 
     lines = resources_uniq_lines(resources, states, formatter)
-
-    if not args.no_header:
-        print(formatter.header())
-    for _, line in lines.items():
-        print(formatter.format(line))
+    formatter.print_items(lines.values(), no_header=args.no_header)
 
 
 def info(args):

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -159,6 +159,7 @@ TESTSCRIPTS = \
 	t2315-resource-system.t \
 	t2350-resource-list.t \
 	t2351-resource-status-input.t \
+	t2352-resource-cmd-config.t \
 	t2400-job-exec-test.t \
 	t2401-job-exec-hello.t \
 	t2402-job-exec-dummy.t \

--- a/t/t2311-resource-drain.t
+++ b/t/t2311-resource-drain.t
@@ -225,5 +225,8 @@ test_expect_success 'flux resource drain works without scheduler loaded' '
 	test $(flux resource status -s drain -no {nnodes}) -eq ${SIZE}
 '
 
+test_expect_success 'load scheduler again to free end-of-test resources' '
+	flux module load sched-simple
+'
 
 test_done

--- a/t/t2350-resource-list.t
+++ b/t/t2350-resource-list.t
@@ -113,4 +113,10 @@ test_expect_success 'flux resource list -no {properties:>4.4+} works' '
 	test_debug "cat properties-trunc+h.out" &&
 	test $(cat properties-trunc.out) = "xx,f+"
 '
+test_expect_success 'flux resource list -o rlist works' '
+	flux resource list -o rlist \
+		--from-stdin <properties-test.in >rlist.out &&
+	test_debug "cat rlist.out" &&
+	grep -i list rlist.out
+'
 test_done

--- a/t/t2351-resource-status-input.t
+++ b/t/t2351-resource-status-input.t
@@ -47,31 +47,7 @@ test_expect_success 'flux-resource status: --no-header works' '
 	test $(wc -l < ${name}.out) -eq 1
 '
 
-test_expect_success 'flux-resource status: -v displays empty states' '
-	INPUT=${INPUTDIR}/simple.json &&
-	name=verbose &&
-	flux resource status -o {nnodes} --from-stdin \
-	    < $INPUT > ${name}-no-v.out &&
-	flux resource status -v -o {nnodes} --from-stdin \
-	    < $INPUT > ${name}-v.out &&
-	test_must_fail grep ^0 ${name}-no-v.out &&
-	grep ^0 ${name}-v.out
-'
-
-test_expect_success 'flux-resource status: -vv displays REASON field' '
-	INPUT=${INPUTDIR}/drain.json &&
-	name=vv &&
-	flux resource status --from-stdin < $INPUT > ${name}.out &&
-	flux resource status -vv --from-stdin < $INPUT > ${name}-vv.out &&
-	test_debug "echo no verbose:; cat ${name}.out" &&
-	test_debug "echo verbose:; cat ${name}-vv.out" &&
-	test_must_fail grep REASON ${name}.out &&
-	grep REASON ${name}-vv.out &&
-	test $(grep -c drained  ${name}.out) -eq 1 &&
-	test $(grep -c drained ${name}-vv.out) -eq 2
-'
-
-test_expect_success 'flux-resource status: -o {reason} works w/out -vv' '
+test_expect_success 'flux-resource status: -o {reason} works' '
 	INPUT=${INPUTDIR}/drain.json &&
 	name=reason &&
 	flux resource status --from-stdin -s drain -no {reason} \
@@ -88,10 +64,6 @@ test_expect_success 'flux-resource status: -s always displays that state' '
 
 test_expect_success 'flux-resource status: -s help displays states list' '
 	flux resource status --from-stdin -s help < /dev/null 2>&1 \
-	    | grep -i valid
-'
-test_expect_success 'flux-resource status: -o help displays format list' '
-	flux resource status --from-stdin -o help < /dev/null 2>&1 \
 	    | grep -i valid
 '
 

--- a/t/t2352-resource-cmd-config.t
+++ b/t/t2352-resource-cmd-config.t
@@ -1,0 +1,71 @@
+#!/bin/sh
+
+test_description='flux-resource config tests'
+
+# Append --logfile option if FLUX_TESTS_LOGFILE is set in environment:
+test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
+. $(dirname $0)/sharness.sh
+
+test_under_flux 1 job
+
+for cmd in list status drain; do
+    test_expect_success "flux-resource ${cmd} --format=invalid fails" '
+	test_must_fail flux resource ${cmd} --format=invalid
+    '
+done
+
+#  We can't add configuration to ~/.config or /etc/xdg/flux, so
+#   just test that XDG_CONFIG_HOME works.
+#
+test_expect_success 'Create flux-resource.toml config file' '
+        mkdir -p dir/flux &&
+        cat <<-EOF >dir/flux/flux-resource.toml
+	[status.formats.myformat]
+	description = "my status format"
+	format = "{nodelist}"
+	[list.formats.myformat]
+	description = "my list format"
+	format = "{state:>8.8} {nodelist}"
+	[drain.formats.myformat]
+	description = "my drain format"
+	format = "{state} {reason}"
+	EOF
+'
+
+for cmd in list status drain; do
+    test_expect_success "flux-resource ${cmd} accepts configured formats" '
+        XDG_CONFIG_HOME="$(pwd)/dir" \
+		flux resource ${cmd} --format=help > ${cmd}-help.out &&
+	test_debug "cat ${cmd}-help.out" &&
+	grep myformat ${cmd}-help.out &&
+        XDG_CONFIG_HOME="$(pwd)/dir" \
+		flux resource ${cmd} --format=get-config=myformat \
+		>${cmd}-get-config.out &&
+	test_debug "cat ${cmd}-get-config.out" &&
+	grep ${cmd}\.formats\.myformat ${cmd}-get-config.out &&
+        XDG_CONFIG_HOME="$(pwd)/dir" \
+		flux resource ${cmd}  --format=myformat
+    '
+done
+
+test_expect_success 'flux-resource invalid key in subtable raises error' '
+        cat <<-EOF >dir/flux/flux-resource.toml &&
+	list.formats.foo = "nothing"
+	EOF
+	( export XDG_CONFIG_HOME="$(pwd)/dir" &&
+	  test_must_fail flux resource list --format=help >invalidkey.out 2>&1
+	) &&
+	test_debug "cat invalidkey.out" &&
+	grep "flux-resource.toml" invalidkey.out
+'
+test_expect_success 'flux-resource invalid config key raises error' '
+        cat <<-EOF >dir/flux/flux-resource.toml &&
+	invalid.formats.foo.format = "nothing"
+	EOF
+	( export XDG_CONFIG_HOME="$(pwd)/dir" &&
+	  test_must_fail flux resource list --format=help >invalidkey.out 2>&1
+	) &&
+	test_debug "cat invalidkey.out" &&
+	grep "flux-resource.toml" invalidkey.out
+'
+test_done


### PR DESCRIPTION
This PR updates `flux resource list`, `status`, and `drain` commands to unify the output format options (all subcommands now take the `-n, --no-header` and `-o, --format=FORMAT` options), adds support for `flux-resource.{toml,yaml,json}` config files as with `flux-jobs(1)`, and makes some other minor improvements.

To get there required a lot of refactoring of some Python classes in `flux.util` for better reusability of `UtilConfig` and `UtilFormat` classes etc. Perhaps that work should be split out into a separate PR, but since it was all in support of the changes to `flux-resource` I've left everything in one big PR for now for the sake of 

Also in this PR, the default output format used by `flux resource drain` with no arguments was improved to be more readable and compact. The old format is now available with `flux resource drain -o long`.

Fixes #4672 
Fixes #4673

The flux-sched tests on this PR will currently fail until flux-framework/flux-sched#985 is merged.