### PR TITLE
flux-proxy: require owner == proxy user

### DIFF
--- a/t/system/0001-basic.t
+++ b/t/system/0001-basic.t
@@ -11,3 +11,10 @@ test_expect_success 'system instance runs job as current uid' '
 test_expect_success 'flux jobs lists job with correct userid' '
 	test $(flux jobs -no {userid} $jobid) -eq $(id -u)
 '
+# flux-framework/flux-core#4648
+test_expect_success 'flux proxy to system instance fails' '
+	test_must fail flux proxy $(flux getattr local-uri) printenv FLUX_URI
+'
+test_expect_success 'flux proxy to system instance works with --force' '
+	flux proxy --force $(flux getattr local-uri) printenv FLUX_URI
+'


### PR DESCRIPTION
Problem: if proxy user is a guest in the Flux instance, `flux_job_submit()` can get confused about job request signing requirements.

For now just don't allow flux-proxy to connect as a guest to an instance, unless `--force` is specified.

Fixes #4648