### PR TITLE
flux-resource: fix scalability issues with large sets of resources

### DIFF
--- a/src/bindings/python/flux/resource/ResourceSet.py
+++ b/src/bindings/python/flux/resource/ResourceSet.py
@@ -104,6 +104,16 @@ class ResourceSet:
             self.impl.append(arg.impl)
         return self
 
+    def add(self, *args):
+        """
+        Add resources to a ResourceSet that are not already members
+        """
+        for arg in args:
+            if not isinstance(arg, ResourceSet):
+                arg = ResourceSet(arg, version=self.version)
+            self.impl.add(arg.impl)
+        return self
+
     def copy(self):
         """Return a copy of a ResourceSet"""
         rset = ResourceSet(self.impl.copy())

--- a/src/bindings/python/flux/resource/ResourceSetImplementation.py
+++ b/src/bindings/python/flux/resource/ResourceSetImplementation.py
@@ -82,6 +82,11 @@ class ResourceSetImplementation(ABC):  # pragma: no cover
         raise NotImplementedError
 
     @abstractmethod
+    def add(self, rset):
+        """Add resources not existing in one set to the other"""
+        raise NotImplementedError
+
+    @abstractmethod
     def remove_ranks(self, ranks):
         """Remove an IDset of ranks from a resource set"""
         raise NotImplementedError

--- a/src/bindings/python/flux/resource/Rlist.py
+++ b/src/bindings/python/flux/resource/Rlist.py
@@ -88,6 +88,10 @@ class Rlist(WrapperPimpl):
         self.pimpl.append(arg)
         return self
 
+    def add(self, arg):
+        self.pimpl.add(arg)
+        return self
+
     def copy(self):
         return Rlist(handle=self.pimpl.copy_empty())
 

--- a/src/cmd/flux-resource.py
+++ b/src/cmd/flux-resource.py
@@ -419,7 +419,7 @@ def resources_uniq_lines(resources, states, formatter):
             if key not in lines:
                 lines[key] = rset
             else:
-                lines[key] = lines[key].union(rset)
+                lines[key].add(rset)
             continue
 
         for rank in resources[state].ranks:
@@ -429,7 +429,7 @@ def resources_uniq_lines(resources, states, formatter):
             if key not in lines:
                 lines[key] = rset
             else:
-                lines[key] = lines[key].union(rset)
+                lines[key].add(rset)
 
     return lines
 

--- a/src/common/librlist/rlist.c
+++ b/src/common/librlist/rlist.c
@@ -581,6 +581,26 @@ struct rlist *rlist_union (const struct rlist *rla, const struct rlist *rlb)
     return result;
 }
 
+/*  Add resource set rlb to rla: rla becomes the union of a and b.
+ */
+int rlist_add (struct rlist *rla, const struct rlist *rlb)
+{
+    int rc;
+    struct rlist *diff = NULL;
+
+    /*  Take the set difference of a from b so there are no overlapping
+     *   resources with rla in `diff`
+     */
+    if (!(diff = rlist_diff (rlb, rla)))
+        return -1;
+
+    /*  Now append diff to rla
+     */
+    rc = rlist_append (rla, diff);
+    rlist_destroy (diff);
+    return rc;
+}
+
 struct rlist *rlist_intersect (const struct rlist *rla,
                                const struct rlist *rlb)
 {

--- a/src/common/librlist/rlist.c
+++ b/src/common/librlist/rlist.c
@@ -31,6 +31,55 @@
 
 static int by_rank (const void *item1, const void *item2);
 
+static size_t rank_hasher (const void *key)
+{
+    const int *id = key;
+    return *id;
+}
+
+static int rank_hash_key_cmp (const void *key1, const void *key2)
+{
+    const int *a = key1;
+    const int *b = key2;
+    return *a - *b;
+}
+
+static zhashx_t *rank_hash_create (void)
+{
+    zhashx_t *hash;
+
+    if (!(hash = zhashx_new ())) {
+        errno = ENOMEM;
+        return NULL;
+    }
+    zhashx_set_key_hasher (hash, rank_hasher);
+    zhashx_set_key_comparator (hash, rank_hash_key_cmp);
+    zhashx_set_key_duplicator (hash, NULL);
+    zhashx_set_key_destructor (hash, NULL);
+
+    return hash;
+}
+
+static struct rnode * rank_hash_lookup (const struct rlist *rl, int rank)
+{
+    return zhashx_lookup (rl->rank_index, &rank);
+}
+
+static void rank_hash_delete (const struct rlist *rl, int rank)
+{
+    zhashx_delete (rl->rank_index, &rank);
+}
+
+static int rank_hash_insert (struct rlist *rl, struct rnode *n)
+{
+    return zhashx_insert (rl->rank_index, &n->rank, n);
+}
+
+static void rank_hash_purge (struct rlist *rl)
+{
+    zhashx_purge (rl->rank_index);
+}
+
 static int
 sprintfcat (char **s, size_t *sz, size_t *lenp, const char *fmt, ...)
 {
@@ -62,6 +111,7 @@ void rlist_destroy (struct rlist *rl)
         int saved_errno = errno;
         zlistx_destroy (&rl->nodes);
         zhashx_destroy (&rl->noremap);
+        zhashx_destroy (&rl->rank_index);
         json_decref (rl->scheduling);
         free (rl);
         errno = saved_errno;
@@ -89,7 +139,8 @@ struct rlist *rlist_create (void)
         goto err;
     zlistx_set_destructor (rl->nodes, rn_free_fn);
 
-    if (!(rl->noremap = zhashx_new ()))
+    if (!(rl->rank_index = rank_hash_create ())
+        || !(rl->noremap = zhashx_new ()))
         goto err;
     zhashx_set_destructor (rl->noremap, valfree);
     zhashx_set_duplicator (rl->noremap, (zhashx_duplicator_fn *) strdup);
@@ -121,13 +172,7 @@ static json_t * scheduling_key_append (json_t *s1, json_t *s2)
 
 static struct rnode *rlist_find_rank (const struct rlist *rl, uint32_t rank)
 {
-    struct rnode *n = zlistx_first (rl->nodes);
-    while (n) {
-        if (n->rank == rank)
-            return (n);
-        n = zlistx_next (rl->nodes);
-    }
-    return NULL;
+    return rank_hash_lookup (rl, rank);
 }
 
 static void rlist_update_totals (struct rlist *rl, struct rnode *n)
@@ -139,7 +184,10 @@ static void rlist_update_totals (struct rlist *rl, struct rnode *n)
 
 static int rlist_add_rnode_new (struct rlist *rl, struct rnode *n)
 {
-    if (!zlistx_add_end (rl->nodes, n))
+    void *handle;
+    if (!(handle = zlistx_add_end (rl->nodes, n)))
+        return -1;
+    if (rank_hash_insert (rl, n) < 0)
         return -1;
     rlist_update_totals (rl, n);
     return 0;
@@ -334,18 +382,28 @@ struct rlist *rlist_copy_constraint_string (const struct rlist *orig,
     return rl;
 }
 
+static int rlist_remove_rank (struct rlist *rl, int rank)
+{
+    void *handle;
+    struct rnode *n;
+
+    if (!(n = rank_hash_lookup (rl, rank))
+        || !(handle = zlistx_find (rl->nodes, n))) {
+        errno = ENOENT;
+        return -1;
+    }
+    zlistx_delete (rl->nodes, handle);
+    return 0;
+}
 
 int rlist_remove_ranks (struct rlist *rl, struct idset *ranks)
 {
     int count = 0;
-    struct rnode *n;
     unsigned int i;
     i = idset_first (ranks);
     while (i != IDSET_INVALID_ID) {
-        if ((n = rlist_find_rank (rl, i))) {
-            zlistx_delete (rl->nodes, zlistx_cursor (rl->nodes));
+        if (rlist_remove_rank (rl, i) == 0)
             count++;
-        }
         i = idset_next (ranks, i);
     }
     return count;
@@ -356,6 +414,8 @@ int rlist_remap (struct rlist *rl)
     uint32_t rank = 0;
     struct rnode *n;
 
+    rank_hash_purge (rl);
+
     /*   Sort list by ascending rank, then rerank starting at 0
      */
     zlistx_set_comparator (rl->nodes, by_rank);
@@ -364,6 +424,8 @@ int rlist_remap (struct rlist *rl)
     n = zlistx_first (rl->nodes);
     while (n) {
         n->rank = rank++;
+        if (rank_hash_insert (rl, n) < 0)
+            return -1;
         if (rnode_remap (n, rl->noremap) < 0)
             return -1;
         n = zlistx_next (rl->nodes);
@@ -396,6 +458,10 @@ static int rlist_rerank_hostlist (struct rlist *rl,
             return -1;
         }
         n->rank = rank++;
+        if (rank_hash_insert (rl, n) < 0) {
+            errprintf (errp, "failed to hash rank %u", n->rank);
+            return -1;
+        }
         host = hostlist_next (hl);
     }
     return 0;
@@ -429,6 +495,8 @@ int rlist_rerank (struct rlist *rl, const char *hosts, flux_error_t *errp)
         goto done;
     }
 
+    rank_hash_purge (rl);
+
     /* Save original rank mapping in case of undo
      */
     if (!(orig = rlist_nodelist (rl)))
@@ -451,8 +519,10 @@ done:
 static struct rnode *rlist_detach_rank (struct rlist *rl, uint32_t rank)
 {
     struct rnode *n = rlist_find_rank (rl, rank);
-    if (n)
-        zlistx_detach_cur (rl->nodes);
+    if (n) {
+        zlistx_detach (rl->nodes, zlistx_find (rl->nodes, n));
+        rank_hash_delete (rl, rank);
+    }
     return n;
 }
 

--- a/src/common/librlist/rlist.h
+++ b/src/common/librlist/rlist.h
@@ -146,6 +146,11 @@ int rlist_rank_add_child (struct rlist *rl,
  */
 int rlist_append (struct rlist *rl, const struct rlist *rl2);
 
+/*  Like append, but it is not an error if resources in `rl` also
+ *   exist in `rl2`.
+ */
+int rlist_add (struct rlist *rl, const struct rlist *rl2);
+
 /*  Return the set difference of 'rlb' from 'rla'.
  */
 struct rlist *rlist_diff (const struct rlist *rla, const struct rlist *rlb);

--- a/src/common/librlist/rlist.h
+++ b/src/common/librlist/rlist.h
@@ -28,6 +28,8 @@ struct rlist {
     int avail;
     zlistx_t *nodes;
 
+    zhashx_t *rank_index;
+
     /*  hash of resources to ignore on remap */
     zhashx_t *noremap;
 

--- a/t/python/t0022-resource-set.py
+++ b/t/python/t0022-resource-set.py
@@ -131,6 +131,16 @@ class TestRSet(unittest.TestCase):
         rset.append(rset2)
         self.assertEqual(str(rset), "rank[0-4]/core[0-3],gpu0")
 
+    def test_add(self):
+        rset = ResourceSet(self.R_input)
+        rset2 = ResourceSet(Rlist().add_rank(4, cores="0-3").add_child(4, "gpu", "0"))
+        rset.add(rset2)
+        self.assertEqual(str(rset), "rank[0-4]/core[0-3],gpu0")
+        # adding same resources allowed
+        rset2 = ResourceSet(Rlist().add_rank(4, cores="0-3").add_child(4, "gpu", "0"))
+        rset.add(rset2)
+        self.assertEqual(str(rset), "rank[0-4]/core[0-3],gpu0")
+
     def test_nodelist(self):
         rset = ResourceSet(self.R_input)
         self.assertIsInstance(rset.nodelist, Hostlist)

--- a/t/t2350-resource-list.t
+++ b/t/t2350-resource-list.t
@@ -101,16 +101,16 @@ test_expect_success 'create test input with properties' '
 test_expect_success 'flux resource list -no {properties} works' '
 	flux resource list -no {properties} \
 		--from-stdin <properties-test.in >properties.out &&
-	test $(cat properties.out) = "foo,xx"
+	test $(cat properties.out) = "xx,foo"
 '
 test_expect_success 'flux resource list -no {properties:>4.4+} works' '
 	flux resource list -no "{properties:>5.5+}" \
 		--from-stdin <properties-test.in >properties-trunc.out &&
 	test_debug "cat properties-trunc.out" &&
-	test $(cat properties-trunc.out) = "foo,+" &&
+	test $(cat properties-trunc.out) = "xx,f+" &&
 	flux resource list -no "{properties:>5.5h+}" \
 		--from-stdin <properties-test.in >properties-trunc+h.out &&
 	test_debug "cat properties-trunc+h.out" &&
-	test $(cat properties-trunc.out) = "foo,+"
+	test $(cat properties-trunc.out) = "xx,f+"
 '
 test_done


### PR DESCRIPTION
This PR fixes an embarrassing scaling issue with `flux resource list`. The most severe issue is that `flux-resource`  uses the `ResourceSet.union` method to build up resource sets with matching lines of output. Since the `union` method returns a new resource set on each iteration, this causes an exponential slowdown as the program iterates over all ranks in the returned resource set.

This PR adds an `add` method to librlist and `ResourceSet`, which is like `union` but modifies the target resource set instead of returning a copy. This solves 90% of the issue since NRANKS copy and destroys are now avoided.

The other issue is that lookups by rank in `librlist` is a linear search and this is done frequently in `flux resource` since it iterates over all ranks at least once. To address this issue, a rank hash is added to `librlist` to allow fast lookups of resources by rank. This fixes another 5% of the scaling issue.

Before these changes, it would take almost 2 minutes for `flux resource list` on a cluster with 3000 nodes. After this PR the operation takes <1s.

master:
```console
$ time flux resource list --from-stdin <  t.json 
     STATE NNODES   NCORES    NGPUS NODELIST
      free   2988   143424        0 quartz[11-499,501-998,1000-3000]
 allocated     13      624        0 quartz[0-10,500,999]
      down      0        0        0 

real	1m50.031s
user	1m49.967s
sys	0m0.064s
```

This branch:
```console
$ time flux resource list --from-stdin <  t.json 
     STATE NNODES   NCORES    NGPUS NODELIST
      free   2988   143424        0 quartz[11-499,501-998,1000-3000]
 allocated     13      624        0 quartz[0-10,500,999]
      down      0        0        0 

real	0m0.854s
user	0m0.792s
sys	0m0.066s
```
