### PR TITLE
flux-job: support multiple jobids for `cancel`, `raise`, and `kill`

### DIFF
--- a/doc/man1/flux-job.rst
+++ b/doc/man1/flux-job.rst
@@ -8,15 +8,15 @@ flux-job(1)
 SYNOPSIS
 ========
 
-**flux** **job** **cancel** *id* [*message...*]
+**flux** **job** **cancel** [*OPTIONS*] *ids...* [*--*] [*message...*]
 
 **flux** **job** **cancelall** [*OPTIONS*] [*message...*]
 
-**flux** **job** **kill** [*--signal=SIG*] *id*
+**flux** **job** **kill** [*--signal=SIG*] *id* [*id...*]
 
 **flux** **job** **killall** [*OPTIONS*]
 
-**flux** **job** **raise** [*OPTIONS*] *id* [*message...*]
+**flux** **job** **raise** [*OPTIONS*] *ids...* [*--*] [*message...*]
 
 **flux** **job** **raiseall** [*OPTIONS*] *type* [*message...*]
 
@@ -30,7 +30,15 @@ flux-job(1) performs various job related housekeeping functions.
 CANCEL
 ======
 
-A single job may be canceled with ``flux job cancel``.
+One or more jobs by may be canceled with ``flux job cancel``.  An optional
+message included with the cancel exception may be provided via the *-m,
+--message=NOTE* option or after the list of jobids. The special argument
+*"--"* forces the end of jobid processing and can be used to separate the
+exception message from the jobids when necessary.
+
+**-m, --message=NOTE**
+   Set the optional exception note. It is an error to specify the message
+   via this option and on the command line after the jobid list.
 
 Jobs may be canceled in bulk with ``flux job cancelall``.  Target jobs are
 selected with:
@@ -50,7 +58,7 @@ selected with:
 SIGNAL
 ======
 
-Running jobs may be signaled with ``flux job kill``.
+One or more running jobs may be signaled by jobid with ``flux job kill``.
 
 **-s, --signal=SIG**
    Send signal SIG (default: SIGTERM).
@@ -67,8 +75,15 @@ to the option above, target jobs are selected with:
 EXCEPTION
 =========
 
-An exception may raised on a single job with ``flux job raise``.
+An exception may raised on one or more jobids with ``flux job raise``.
+An optional message included with the job exception may be provided via
+the *-m, --message=NOTE* option or after the list of jobids. The special
+argument *"--"* forces the end of jobid processing and can be used to
+separate the exception message from the jobids when necessary.
 
+**-m, --message=NOTE**
+   Set the optional exception note. It is an error to specify the message
+   via this option and on the command line after the jobid list.
 **-s, --severity=N**
    Set exception severity.  The severity may range from 0=fatal to
    7=least severe (default: 0).

--- a/t/t2201-job-cmd.t
+++ b/t/t2201-job-cmd.t
@@ -229,6 +229,14 @@ test_expect_success 'flux-job: raise fails with invalid jobid' '
 	test_must_fail flux job raise foo
 '
 
+test_expect_success 'flux-job: raise fails with invalid jobids' '
+	test_must_fail flux job raise foo fee
+'
+
+test_expect_success 'flux-job: raise fails if note set twice' '
+	test_must_fail flux job raise --message=hi ${validjob} -- hello
+'
+
 test_expect_success 'flux-job: raise fails with inactive jobid' '
 	test_must_fail flux job raise $(cat inactivejob)
 '
@@ -243,6 +251,14 @@ test_expect_success 'flux-job: cancel fails with bad FLUX_URI' '
 
 test_expect_success 'flux-job: cancel fails with unknown job id' '
 	test_must_fail flux job cancel 0
+'
+
+test_expect_success 'flux-job: cancel fails with unknown job ids' '
+	test_must_fail flux job cancel 0 f123
+'
+
+test_expect_success 'flux-job: cancel fails if note set twice' '
+	test_must_fail flux job cancel --message=hi ${validjob} -- hello
 '
 
 test_expect_success 'flux-job: cancel fails with no args' '
@@ -612,4 +628,21 @@ test_expect_success 'flux job: killall -f kills one job' '
 	run_timeout 60 flux queue drain
 '
 
+test_expect_success 'flux job: cancel can operate on multiple jobs' '
+	ids=$(flux mini submit --bcc=1-3 sleep 600) &&
+	flux job cancel ${ids} cancel multiple jobs &&
+	for id in ${ids}; do
+		flux job wait-event -t 5 ${id} exception >exception.out &&
+		grep multiple exception.out
+	done
+'
+
+test_expect_success 'flux job: raise can operate on multiple jobs' '
+	ids=$(flux mini submit --bcc=1-3 sleep 600) &&
+	flux job raise ${ids} raise multiple jobs &&
+	for id in ${ids}; do
+		flux job wait-event -t 5 ${id} exception >exception2.out &&
+		grep multiple exception2.out
+	done
+'
 test_done

--- a/t/t2202-job-manager.t
+++ b/t/t2202-job-manager.t
@@ -142,9 +142,7 @@ test_expect_success HAVE_JQ 'job-manager: priority listed as priority=4294967295
 '
 
 test_expect_success HAVE_JQ 'job-manager: cancel jobs' '
-	for jobid in $($jq .id <list3.out); do \
-		flux job cancel ${jobid}; \
-	done
+	flux job cancel $($jq .id <list3.out)
 '
 
 test_expect_success 'job-manager: queue contains 0 jobs' '
@@ -230,9 +228,7 @@ test_expect_success HAVE_JQ 'job-manager: max_jobid has not changed' '
 '
 
 test_expect_success HAVE_JQ 'job-manager: cancel jobs' '
-	for jobid in $($jq .id <list_reload.out); do \
-		flux job cancel ${jobid}; \
-	done &&
+	flux job cancel $($jq .id <list_reload.out) &&
 	test $(${LIST_JOBS} | wc -l) -eq 0
 '
 

--- a/t/t2260-job-list.t
+++ b/t/t2260-job-list.t
@@ -355,9 +355,11 @@ test_expect_success HAVE_JQ 'job stats lists jobs in correct state (mix)' '
 '
 
 test_expect_success 'cleanup job listing jobs ' '
-        for jobid in `cat active.ids`; do \
-            flux job cancel $jobid; \
-            fj_wait_event $jobid clean; \
+	# NOTE: do not use flux job cancel `cat active.ids` as it races
+	# with the reconstruction of job-list somehow
+        for jobid in `cat active.ids`; do
+	    flux job cancel $jobid &&
+            fj_wait_event $jobid clean
         done
 '
 
@@ -1204,8 +1206,7 @@ test_expect_success HAVE_JQ 'flux job list lists nnodes for pending jobs if node
         flux job list -s pending | grep ${id2} &&
         flux job list-ids ${id1} | jq -e ".nnodes == 1" &&
         flux job list-ids ${id2} | jq -e ".nnodes == 3" &&
-        flux job cancel ${id1} &&
-        flux job cancel ${id2} &&
+        flux job cancel ${id1} ${id2} &&
         flux queue start
 '
 

--- a/t/t2261-job-list-update.t
+++ b/t/t2261-job-list-update.t
@@ -193,9 +193,9 @@ EOT
 '
 
 test_expect_success 'cleanup job listing jobs ' '
-        for jobid in `cat active.ids`; do \
-            flux job cancel $jobid; \
-            fj_wait_event $jobid clean; \
+	flux job cancel $(cat active.ids) &&
+        for jobid in `cat active.ids`; do
+            fj_wait_event $jobid clean;
         done
 '
 

--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -1240,10 +1240,10 @@ test_expect_success 'flux-jobs --stats-only works' '
 '
 
 test_expect_success 'cleanup job listing jobs ' '
-        for jobid in `cat active.ids`; do \
-            flux job cancel $jobid; \
-            fj_wait_event $jobid clean; \
-        done
+	flux job cancel $(cat active.ids) &&
+	for jobid in `cat active.ids`; do
+		fj_wait_event $jobid clean;
+	done
 '
 
 #

--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -976,14 +976,14 @@ test_expect_success 'flux-jobs emits empty string on invalid annotations fields'
 '
 
 test_expect_success 'flux-jobs "user" short hands work for job memo' '
-       for id in $(state_ids sched); do
-               flux job memo $id foo=42
-       done &&
-       fmt="{annotations.user},{annotations.user.foo}" &&
-       flux jobs -no "${fmt}" > user_long_hand.out &&
-       fmt="{user},{user.foo}" &&
-       flux jobs -no "${fmt}" > user_short_hand.out &&
-       test_cmp user_long_hand.out user_short_hand.out
+	for id in $(state_ids sched); do
+		flux job memo $id foo=42
+	done &&
+	fmt="{annotations.user},{annotations.user.foo}" &&
+	flux jobs -no "${fmt}" > user_long_hand.out &&
+	fmt="{user},{user.foo}" &&
+	flux jobs -no "${fmt}" > user_short_hand.out &&
+	test_cmp user_long_hand.out user_short_hand.out
 '
 
 test_expect_success 'flux-jobs emits empty string for special case t_estimate' '


### PR DESCRIPTION
I thought I'd throw this implementation up in a PR for comments since it seems to be working.

This PR allows the `flux job cancel`, `flux job raise`, and `flux job kill` subcommands to target multiple jobids per invocation. The ability to set an option message in the free arguments is preserved by stopping the processing of jobids at the first argument that doesn't look like a FLUID, or when the string `--` is encountered. This heuristic could get easily confused if the first word of the message could be interpreted as a jobid, e.g. if it starts with the letter `f` or is a number. The result would be that the command would error on that one jobid, and the message set in the exception note would be missing one or more words. Therefore, it will probably be best practice to use `--` to separate jobids from the message, or to use the new `-m, --message=NOTE` option added here to `flux job raise` and `flux job cancel`.

Given the rarity with which the an exception note is actually used with these commands, this solution and its caveats may be acceptable given the useful outcome.

