### PR TITLE
flux-mini: add -x short option for --exclusive

### DIFF
--- a/doc/man1/flux-mini.rst
+++ b/doc/man1/flux-mini.rst
@@ -86,7 +86,7 @@ All subcommands take the following common resource allocation options:
    an error to request more nodes than there are tasks. If unspecified,
    the number of nodes will be chosen by the scheduler.
 
-**--exclusive**
+**-x, --exclusive**
    Indicate to the scheduler that nodes should be exclusively allocated to
    this job. It is an error to specify this option without also using
    *-N, --nodes*. If *--nodes* is specified without *--nslots* or *--ntasks*,

--- a/src/cmd/flux-mini.py
+++ b/src/cmd/flux-mini.py
@@ -748,6 +748,7 @@ class SubmitBaseCmd(MiniCmd):
             "-N", "--nodes", metavar="N", help="Number of nodes to allocate"
         )
         group.add_argument(
+            "-x",
             "--exclusive",
             action="store_true",
             help="With -N, --nodes, allocate nodes exclusively",


### PR DESCRIPTION
Not much to see here, this PR just adds a `-x` short option equivalent for `--exclusive` as suggested in #4668