### PR TITLE
github: remove deprecated use of set-output

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -169,13 +169,7 @@ jobs:
       env: ${{matrix.env}}
       run: src/test/docker-deploy.sh
 
-    #   Prepare, create and deploy release on tag:
-    - name: prep release
-      id: prep_release
-      if: success() && matrix.create_release
-      env: ${{matrix.env}}
-      run: echo "::set-output name=tarball::$(echo flux-core*.tar.gz)"
-
+    #  Create and deploy release on tag:
     - name: create release
       id: create_release
       if: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,11 +78,11 @@ jobs:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
     - id: set-matrix
-      run: echo "::set-output name=matrix::$(src/test/generate-matrix.py)"
+      run: echo "matrix=$(src/test/generate-matrix.py)" >>$GITHUB_OUTPUT
     - run: src/test/generate-matrix.py | jq -S .
-    - run: echo "::set-output name=GITHUB_BRANCH::${GITHUB_REF#refs/heads}"
-    - run: echo "::set-output name=GITHUB_TAG::${GITHUB_REF#refs/tags}"
-    - run: echo "::set-output name=EVENT_NAME::${{github.event_name}}"
+    - run: echo "GITHUB_BRANCH=${GITHUB_REF#refs/heads}" >>$GITHUB_OUTPUT
+    - run: echo "GITHUB_TAG=${GITHUB_REF#refs/tags}" >>$GITHUB_OUTPUT
+    - run: echo "EVENT_NAME=${{github.event_name}}" >>$GITHUB_OUTPUT
 
   ci-checks:
     needs: [ generate-matrix ]


### PR DESCRIPTION
This PR removes use of `set-output` in the github workflow files to silence warnings from the runners.

There should be no functional changes.