### PR TITLE
broker: support binomial tree topology

### DIFF
--- a/doc/man7/flux-broker-attributes.rst
+++ b/doc/man7/flux-broker-attributes.rst
@@ -154,10 +154,11 @@ TREE BASED OVERLAY NETWORK
 
 tbon.topo [Updates: C]
    URI describing the TBON tree topology such as ``kary:16``.  The ``kary``
-   scheme selects a complete, k-ary tree with fanout *k*.  By convention
-   ``kary:0`` means that rank 0 is the parent of all other ranks.  Default:
-   ``kary:2``, unless bootstrapping by TOML configuration, then see
-   :man5:`flux-config-bootstrap`.
+   scheme selects a complete, k-ary tree with fanout *k*, with ``kary:0``
+   meaning that rank 0 is the parent of all other ranks by convention.  The
+   ``binomial`` scheme selects a binomial tree topology of the minimum order
+   that fits the instance size.  Default: ``kary:2``, unless bootstrapping by
+   TOML configuration, then see :man5:`flux-config-bootstrap`.
 
 tbon.descendants
    Number of descendants "below" this node of the tree based

--- a/src/broker/test/topology.c
+++ b/src/broker/test/topology.c
@@ -247,6 +247,9 @@ struct internal_ranks_test internal_ranks_tests[] = {
     { 48, "kary:2",  "0-23"},
     { 48, "kary:0",  "0"   },
     { 48, "kary:16", "0-2" },
+    { 4,  "binomial","0,2" },
+    { 8,  "binomial","0,2,4,6" },
+    { 16, "binomial","0,2,4,6,8,10,12,14" },
     { -1, NULL, NULL  }
 };
 
@@ -577,6 +580,63 @@ void test_rank_aux (void)
     topology_decref (topo);
 }
 
+void test_binomial5 (void)
+{
+    struct topology *topo;
+    flux_error_t error;
+    int children[16];
+
+    topo = topology_create ("binomial:zz", 5, &error);
+    if (!topo)
+        diag ("%s", error.text);
+    ok (topo == NULL,
+        "binomial topology fails with unknown path");
+
+    topo = topology_create ("binomial", 5, &error);
+    ok (topo != NULL,
+        "binomal topology of size=5 (non power of 2) works");
+
+    ok (topology_set_rank (topo, 1) == 0,
+        "set rank to 1");
+    ok (topology_get_parent (topo) == 0,
+        "rank 1 parent is 0");
+    ok (topology_get_child_ranks (topo, NULL, 0) == 0,
+        "rank 1 has no children");
+    ok (topology_get_level (topo) == 1,
+        "rank 1 level is 1");
+
+    ok (topology_set_rank (topo, 2) == 0,
+        "set rank to 2");
+    ok (topology_get_parent (topo) == 0,
+        "rank 2 parent is 0");
+    ok (topology_get_child_ranks (topo, children, ARRAY_SIZE (children)) == 1,
+        "rank 2 has 1 child");
+    ok (children[0] == 3,
+        "child is rank 3");
+    ok (topology_get_level (topo) == 1,
+        "rank 2 level is 1");
+
+    ok (topology_set_rank (topo, 3) == 0,
+        "set rank to 3");
+    ok (topology_get_parent (topo) == 2,
+        "rank 3 parent is 2");
+    ok (topology_get_child_ranks (topo, NULL, 0) == 0,
+        "rank 3 has no children");
+    ok (topology_get_level (topo) == 2,
+        "rank 3 level is 2");
+
+    ok (topology_set_rank (topo, 4) == 0,
+        "set rank to 4");
+    ok (topology_get_parent (topo) == 0,
+        "rank 4 parent is 0");
+    ok (topology_get_child_ranks (topo, NULL, 0) == 0,
+        "rank 4 has no children");
+    ok (topology_get_level (topo) == 1,
+        "rank 4 level is 2");
+
+    topology_decref (topo);
+}
+
 int main (int argc, char *argv[])
 {
     plan (NO_PLAN);
@@ -589,6 +649,7 @@ int main (int argc, char *argv[])
     test_internal_ranks ();
     test_custom ();
     test_rank_aux ();
+    test_binomial5 ();
 
     done_testing ();
 }

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -512,6 +512,12 @@ test_expect_success 'broker -Stbon.topo=custom option works' '
 		flux getattr tbon.topo >topo2.out &&
 	test_cmp topo2.exp topo2.out
 '
+test_expect_success 'broker -Stbon.topo=binomial option works' '
+	echo binomial >topo_binomial.exp &&
+	flux start ${ARGS} -o,-Stbon.topo=binomial \
+		flux getattr tbon.topo >topo_binomial.out &&
+	test_cmp topo_binomial.exp topo_binomial.out
+'
 test_expect_success 'broker fails on invalid broker.critical-ranks option' '
 	test_must_fail flux start ${ARGS} -o,-Sbroker.critical-ranks=0-1
 '


### PR DESCRIPTION
I think @trws  suggested we try a binomial tree overlay topology.  This adds an option to play with:
```
$ ./flux start -s16 -o,-Stbon.topo=binomial flux overlay status
0 system76-pc: full
├─ 1 system76-pc: full
├─ 2 system76-pc: full
│  └─ 3 system76-pc: full
├─ 4 system76-pc: full
│  ├─ 5 system76-pc: full
│  └─ 6 system76-pc: full
│     └─ 7 system76-pc: full
└─ 8 system76-pc: full
   ├─ 9 system76-pc: full
   ├─ 10 system76-pc: full
   │  └─ 11 system76-pc: full
   └─ 12 system76-pc: full
      ├─ 13 system76-pc: full
      └─ 14 system76-pc: full
         └─ 15 system76-pc: full
```