### PR TITLE
support mpi=none shell option and make it the default for `flux mini batch` and `flux mini alloc`

### DIFF
--- a/src/bindings/lua/flux/shell.lua
+++ b/src/bindings/lua/flux/shell.lua
@@ -91,7 +91,7 @@ end
 --
 function shell.source_rcpath_option (opt)
     local name, version = shell.getopt_with_version (opt)
-    if name then
+    if name and name ~= "none" then
         for path in rcpath:gmatch ("[^:]+") do
             local basename = path .. "/" .. opt .. "/" .. name
             source_if_exists (basename .. ".lua")

--- a/src/bindings/python/flux/job/Jobspec.py
+++ b/src/bindings/python/flux/job/Jobspec.py
@@ -900,6 +900,7 @@ class JobspecV1(Jobspec):
             exclusive=exclusive,
         )
         jobspec.setattr_shell_option("per-resource.type", "node")
+        jobspec.setattr_shell_option("mpi", "none")
         #  Copy script contents into jobspec
         jobspec.setattr("system.batch.script", script)
         if broker_opts is not None:
@@ -947,4 +948,5 @@ class JobspecV1(Jobspec):
             exclusive=exclusive,
         )
         jobspec.setattr_shell_option("per-resource.type", "node")
+        jobspec.setattr_shell_option("mpi", "none")
         return jobspec

--- a/src/shell/lua.d/mvapich.lua
+++ b/src/shell/lua.d/mvapich.lua
@@ -8,6 +8,8 @@
 -- SPDX-License-Identifier: LGPL-3.0
 -------------------------------------------------------------
 
+if shell.options.mpi == "none" then return end
+
 local f, err = require 'flux'.new ()
 if not f then error (err) end
 

--- a/src/shell/lua.d/openmpi.lua
+++ b/src/shell/lua.d/openmpi.lua
@@ -8,6 +8,8 @@
 -- SPDX-License-Identifier: LGPL-3.0
 -------------------------------------------------------------
 
+if shell.options.mpi == "none" then return end
+
 shell.setenv ("OMPI_MCA_pmix", "flux")
 shell.setenv ("OMPI_MCA_schizo", "flux")
 

--- a/t/t2701-mini-batch.t
+++ b/t/t2701-mini-batch.t
@@ -151,4 +151,18 @@ test_expect_success 'flux mini batch: user can set broker.critical-ranks' '
 	EOF
 	test_cmp critical-ranks2.expected critical-ranks2.out
 '
+test_expect_success HAVE_JQ 'flux mini batch: sets mpi=none by default' '
+	flux mini batch -N1 --dry-run --wrap hostname | \
+		jq -e ".attributes.system.shell.options.mpi = \"none\""
+'
+test_expect_success HAVE_JQ 'flux mini batch: mpi option can be overridden' '
+	flux mini batch -o mpi=foo -N1 --dry-run --wrap hostname | \
+		jq -e ".attributes.system.shell.options.mpi = \"foo\""
+'
+test_expect_success 'flux mini batch: MPI env vars are not set in batch script' '
+	unset OMPI_MCA_pmix &&
+	id=$(flux mini batch -N1 --output=envtest.out --wrap printenv) &&
+	flux job status $id &&
+	test_must_fail grep OMPI_MCA_pmix envtest.out
+'
 test_done

--- a/t/t2702-mini-alloc.t
+++ b/t/t2702-mini-alloc.t
@@ -125,5 +125,19 @@ test_expect_success NO_CHAIN_LINT 'flux-mini alloc --bg errors when job is cance
 	test_must_fail wait $pid &&
 	grep "unexpectedly exited" canceled.log
 '
+test_expect_success HAVE_JQ 'flux mini alloc: sets mpi=none by default' '
+	flux mini alloc -N1 --dry-run hostname | \
+		jq -e ".attributes.system.shell.options.mpi = \"none\""
+'
+test_expect_success HAVE_JQ 'flux mini alloc: mpi option can be overridden' '
+	flux mini alloc -o mpi=foo -N1 --dry-run hostname | \
+		jq -e ".attributes.system.shell.options.mpi = \"foo\""
+'
+test_expect_success 'flux mini alloc: MPI vars are not set in initial program' '
+	flux queue start &&
+	unset OMPI_MCA_pmix &&
+	flux mini alloc -N1 printenv >envtest.out &&
+	test_must_fail grep OMPI_MCA_pmix envtest.out
+'
 
 test_done


### PR DESCRIPTION
This PR makes a couple changes to support the `mpi=none` job shell option to disable existing MPI shell plugins.

Then, this is made the default for `flux mini alloc` and `flux mini batch`. This prevents unnecessary MPI environment variables from being set in the initial program of subinstances created by these `flux-mini` subcommands. 

Fixes #4671