### PR TITLE
fix action syntax for output and yaml formatting

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -1,4 +1,4 @@
-on: [ push, pull_request ]
+on: [push, pull_request]
 name: asan
 jobs:
   check-asan:
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0

--- a/.github/workflows/build-containers.yaml
+++ b/.github/workflows/build-containers.yaml
@@ -5,13 +5,13 @@ on:
   # Enable just for testing cobntainer builds
   pull_request:
     paths:
-      - etc/docker/**
-      - etc/docker/*/*
-      - etc/**/Dockerfile.*
-  
+    - etc/docker/**
+    - etc/docker/*/*
+    - etc/**/Dockerfile.*
+
   # Always have a base image ready to go - this is a nightly build
   schedule:
-    - cron: 0 3 * * *
+  - cron: 0 3 * * *
 
   # Allow manual trigger of a build
   workflow_dispatch:
@@ -19,7 +19,7 @@ on:
   # On push to main we build and deploy images
   push:
     branches:
-      - master
+    - master
 
   # Publish packages on release
   release:
@@ -36,57 +36,57 @@ jobs:
 
         # Dockerfiles to build, a matrix supports future expanded builds
         # spack: flux-core built by spack, otherwise from source on ubuntu
-        container: [["etc/docker/spack/Dockerfile.base", "ghcr.io/flux-framework/flux-spack-base", "true"],
-                    ["etc/docker/spack/Dockerfile", "ghcr.io/flux-framework/flux-spack-ubuntu", "true"],
-                    ["etc/docker/ubuntu/Dockerfile", "ghcr.io/flux-framework/flux-ubuntu", "true"],
-                    ["etc/docker/ubuntu/Dockerfile.test", "ghcr.io/flux-framework/flux-ubuntu-test", "false"]]
+        container: [[etc/docker/spack/Dockerfile.base, ghcr.io/flux-framework/flux-spack-base, 'true'],
+                    [etc/docker/spack/Dockerfile, ghcr.io/flux-framework/flux-spack-ubuntu, 'true'],
+                    [etc/docker/ubuntu/Dockerfile, ghcr.io/flux-framework/flux-ubuntu, 'true'],
+                    [etc/docker/ubuntu/Dockerfile.test, ghcr.io/flux-framework/flux-ubuntu-test, 'false']]
 
     runs-on: ubuntu-latest
     name: Build
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+    - name: Checkout
+      uses: actions/checkout@v3
 
-      - name: Make Space For Build
-        run: |
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /opt/ghc
+    - name: Make Space For Build
+      run: |
+        sudo rm -rf /usr/share/dotnet
+        sudo rm -rf /opt/ghc
 
        # It's easier to reference named variables than indexes of the matrix
-      - name: Set Environment
-        env:
-          dockerfile: ${{ matrix.container[0] }}
-          uri: ${{ matrix.container[1] }}
-        run: |
-          echo "dockerfile=$dockerfile" >> $GITHUB_ENV
-          echo "uri=$uri" >> $GITHUB_ENV
+    - name: Set Environment
+      env:
+        dockerfile: ${{ matrix.container[0] }}
+        uri: ${{ matrix.container[1] }}
+      run: |
+        echo "dockerfile=$dockerfile" >> $GITHUB_ENV
+        echo "uri=$uri" >> $GITHUB_ENV
 
-      - name: Pull previous layers for cache
-        run: docker pull ${uri}:latest || echo "No container to pull"
+    - name: Pull previous layers for cache
+      run: docker pull ${uri}:latest || echo "No container to pull"
 
-      - name: Build Container
-        run: |
-           container=$uri:latest
-           docker build -f ${dockerfile} -t ${container} .
-           echo "container=$container" >> $GITHUB_ENV
+    - name: Build Container
+      run: |
+        container=$uri:latest
+        docker build -f ${dockerfile} -t ${container} .
+        echo "container=$container" >> $GITHUB_ENV
 
-      - name: GHCR Login
-        if: (github.event_name != 'pull_request')
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+    - name: GHCR Login
+      if: (github.event_name != 'pull_request')
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Deploy
-        if: (github.event_name != 'pull_request' && matrix.container[2] == 'true')
-        run: |
-            docker push ${container}
+    - name: Deploy
+      if: (github.event_name != 'pull_request' && matrix.container[2] == 'true')
+      run: |
+        docker push ${container}
 
-      - name: Tag and Push Release
-        if: (github.event_name == 'release' && matrix.container[2] == 'true')
-        run: |
-            tag=${GITHUB_REF#refs/tags/}
-            echo "Tagging and releasing ${uri}:${tag}"
-            docker tag ${uri}:latest ${uri}:${tag}
-            docker push ${uri}:${tag}
+    - name: Tag and Push Release
+      if: (github.event_name == 'release' && matrix.container[2] == 'true')
+      run: |
+        tag=${GITHUB_REF#refs/tags/}
+        echo "Tagging and releasing ${uri}:${tag}"
+        docker tag ${uri}:latest ${uri}:${tag}
+        docker push ${uri}:${tag}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-on: [ pull_request, push ]
+on: [pull_request, push]
 name: ci
 jobs:
   check-pr:
@@ -40,11 +40,10 @@ jobs:
         fetch-depth: 0
     - run: git fetch --tags || true
     - run: >
-        src/test/docker/docker-run-checks.sh --install-only
-        --tag=fluxrm/flux-core:bionic
+        src/test/docker/docker-run-checks.sh --install-only \
+          --tag=fluxrm/flux-core:bionic
     - run: >
-        cd .. &&
-        git clone https://github.com/flux-framework/flux-sched &&
+        cd .. && git clone https://github.com/flux-framework/flux-sched &&
         cd flux-sched &&
         src/test/docker/docker-run-checks.sh -j 4 -i bionic
 
@@ -58,34 +57,32 @@ jobs:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
     - run: >
-        src/test/docker/docker-run-checks.sh --image=el8 --install-only
-        --tag=fluxrm/flux-core:el8
+        src/test/docker/docker-run-checks.sh --image=el8 --install-only \
+          --tag=fluxrm/flux-core:el8
     - run: >
-        cd .. &&
-        git clone https://github.com/flux-framework/flux-accounting &&
-        cd flux-accounting &&
-        src/test/docker/docker-run-checks.sh -j 4 
+        cd .. && git clone https://github.com/flux-framework/flux-accounting &&
+        cd flux-accounting && src/test/docker/docker-run-checks.sh -j 4 
 
   generate-matrix:
     # https://stackoverflow.com/questions/59977364
     name: Generate build matrix
     runs-on: ubuntu-latest
     outputs:
-        matrix: ${{ steps.set-matrix.outputs.matrix }}
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
     - uses: actions/checkout@v3
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
     - id: set-matrix
-      run: echo "::set-output name=matrix::$(src/test/generate-matrix.py)"
+      run: echo "matrix=$(src/test/generate-matrix.py)" >> $GITHUB_OUTPUT
     - run: src/test/generate-matrix.py | jq -S .
-    - run: echo "::set-output name=GITHUB_BRANCH::${GITHUB_REF#refs/heads}"
-    - run: echo "::set-output name=GITHUB_TAG::${GITHUB_REF#refs/tags}"
-    - run: echo "::set-output name=EVENT_NAME::${{github.event_name}}"
+    - run: echo "GITHUB_BRANCH=${GITHUB_REF#refs/heads}" >> $GITHUB_OUTPUT
+    - run: echo "GITHUB_TAG=${GITHUB_REF#refs/tags}" >> $GITHUB_OUTPUT
+    - run: echo "EVENT_NAME=${{ github.event_name }}" >> $GITHUB_OUTPUT
 
   ci-checks:
-    needs: [ generate-matrix ]
+    needs: [generate-matrix]
     runs-on: ubuntu-latest
     env:
       TAP_DRIVER_QUIET: 1
@@ -102,8 +99,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3
       with:
-       ref: ${{ github.event.pull_request.head.sha }}
-       fetch-depth: 0
+        ref: ${{ github.event.pull_request.head.sha }}
+        fetch-depth: 0
 
     - name: fetch annotated tag
       if: >
@@ -136,7 +133,7 @@ jobs:
         docker run -d -p 9000:9000 minio/minio server /data; \
 
     - name: generate dumpfile from most recent flux-core tag
-      if:  (matrix.create_release != true)
+      if: (matrix.create_release != true)
       run: |
         src/test/create-kvs-dumpfile.sh -d /tmp/dumpfile &&
         if test -f /tmp/dumpfile/*.bz2; then
@@ -160,7 +157,7 @@ jobs:
       if: success() && matrix.coverage && matrix.image == 'bionic'
       env:
         DOCKER_REPO:
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@858dd794fbb81941b6d60b0dca860878cba60fa9 # v3.1.1
       with:
         flags: ci-basic
 
@@ -174,7 +171,7 @@ jobs:
       id: prep_release
       if: success() && matrix.create_release
       env: ${{matrix.env}}
-      run: echo "::set-output name=tarball::$(echo flux-core*.tar.gz)"
+      run: echo "tarball=$(echo flux-core*.tar.gz)" >> $GITHUB_OUTPUT
 
     - name: create release
       id: create_release
@@ -183,7 +180,7 @@ jobs:
         && matrix.create_release
         && github.repository == 'flux-framework/flux-core'
       env: ${{matrix.env}}
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@18c81ca362701a5894253311aebebe23cce43e8b # v0.1.9
       with:
         tag_name: ${{ matrix.tag }}
         release_name: flux-core ${{ matrix.tag }}


### PR DESCRIPTION
GitHub actions is deprecating the set-output, and it looks like there are a few extra mentions in some of the workflows here! In addition, this fix:

 - uses the [action updater](https://github.com/vsoch/action-updater) to bump some of the major actions to their latest versions.
 - Also saves the yaml so serves as a spacing / formatting tool too.

The way the updater works is to use major versions for "trusted" actions (e.g., docker/login, checkout) and for all others chooses a release, and a specific commit (and comments with the tag).

Signed-off-by: vsoch <vsoch@users.noreply.github.com>