### PR TITLE
testsuite: fix broken proxy system test

### DIFF
--- a/t/system/0001-basic.t
+++ b/t/system/0001-basic.t
@@ -13,7 +13,7 @@ test_expect_success 'flux jobs lists job with correct userid' '
 '
 # flux-framework/flux-core#4648
 test_expect_success 'flux proxy to system instance fails' '
-	test_must fail flux proxy $(flux getattr local-uri) printenv FLUX_URI
+	test_must_fail flux proxy $(flux getattr local-uri) printenv FLUX_URI
 '
 test_expect_success 'flux proxy to system instance works with --force' '
 	flux proxy --force $(flux getattr local-uri) printenv FLUX_URI


### PR DESCRIPTION
Problem: there is a typo in the flux-proxy test added to t/system/0001-basic.t.

Fix typo.