### PR TITLE
[EXAMPLE] add proto example using Python

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,8 +2,8 @@ FROM fluxrm/testenv:focal
 
 LABEL maintainer="Vanessasaurus <@vsoch>"
 
-# Pip not provided in this version
-RUN apt-get update
+# Captain proto (this can eventually go in testenv container)
+RUN apt-get update && apt-get install -y capnproto
 COPY scripts/requirements-dev.txt /requirements.txt
 
 # For easier Python development. 

--- a/etc/proto/README.md
+++ b/etc/proto/README.md
@@ -1,0 +1,36 @@
+# Captain Proto
+
+> No... Captain Flux! He's a hero! 👩‍🚒️
+
+I am following the [installation](https://capnproto.org/install.html) instructions here.
+The tool should be installed to the devcontainers environment. Then we define our protocol buffer
+file as [schema.capnp](schema.capnp) and use within Python. This is a fairly simple setup
+(to test things out and learn about this library!). First, you'll need flux bindings on your
+path and to start flux:
+
+```consoel
+export PYTHONPATH=/usr/local/lib/python3.8/site-packages
+flux start --test-size=4
+```
+
+Note that the path will be default added in the devcontainers environment soon!
+To start the server portion:
+
+```console
+$ python3 run-server.py
+Starting Flux Message Interface! pkill python3 in another terminal to 🔴
+```
+
+Yes - nothing elegant here - we are using a pkill to python3 to kill the server! 💀 
+That will start the server running on `127.0.0.1:12345`. Then we can test the client with [run-client.py](run-client.py):
+
+```console
+$ python3 run-client.py 
+🍓 Created client <capnp.lib.capnp.TwoPartyClient object at 0x7f071c5e3220>
+{'fee': 'fi', 'route': 'de5d06ad!e058728f!0ae58f31!ee699da9', 'userid': 0, 'rolemask': 1}
+```
+
+What we basically do via the client is prepare the request, send it to the server, and then
+print what is returned. The server handles created a Flux RPC and running "get" for it.
+It's super simple, but kind of neat! I think we can make cooler stuff off of this 
+basic idea.

--- a/etc/proto/run-client.py
+++ b/etc/proto/run-client.py
@@ -1,0 +1,35 @@
+import capnp
+import json
+
+# Load the schema (this method is more reliable)
+capnp.remove_import_hook()
+schema_capnp = capnp.load('schema.capnp')
+
+
+# Create a new message
+# message = schema_capnp.FluxMessage.new_message()
+ 
+
+def main():
+
+    client = capnp.TwoPartyClient('127.0.0.1:12345')
+    print(f"🍓 Created client {client}")
+
+    # Bootstrap the server capability and cast it to the FluxMessageInterface
+    msg = client.bootstrap().cast_as(schema_capnp.FluxMessageInterface)
+    request = msg.get_request()
+    
+    # Prepare the flux message!
+    request.m.topic = "kvs.ping"
+    request.m.payload = json.dumps({"fee": "fi"})
+    promise = request.send()
+
+    # asynchronous
+    # promise.then(lambda ret: print(ret)).wait()
+
+    # synchronous
+    result = promise.wait()
+    print(json.loads(result.x))
+    
+if __name__ == "__main__":
+    main()

--- a/etc/proto/run-server.py
+++ b/etc/proto/run-server.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+
+import capnp
+import flux 
+import json
+from flux.rpc import RPC
+ 
+# Load the schema (this method is more reliable)
+capnp.remove_import_hook()
+schema_capnp = capnp.load('schema.capnp')
+
+# You'll need flux bindings on your path and start flux
+# export PYTHONPATH=/usr/local/lib/python3.8/site-packages
+# flux start --test-size=4
+
+class TestServer(schema_capnp.FluxMessageInterface.Server):
+    def __init__(self):
+        self.handle = flux.Flux()
+
+    def get(self, m, **kwargs):
+        """
+        m should be a FluxMessage with topic, nodeid, etc.
+        """
+        print(f"Topic: {m.topic}")
+        print(f"Payload: {m.payload}")
+        print(f"NodeId: {m.nodeid}")
+        print(f"Flags: {m.flags}")
+        rpc = RPC(self.handle, m.topic, m.payload, m.nodeid, m.flags)
+        # This loads but is expecting a string (text)
+        return json.dumps(rpc.get())
+
+def main():
+    # Let's write / read from a server
+    write = '127.0.0.1:12345'
+
+    # This can also be a socket pair I think?
+    # read, write = socket.socketpair()
+    server = capnp.TwoPartyServer(write, bootstrap=TestServer())
+    print('Starting Flux Message Interface! pkill python3 in another terminal to 🔴')
+    server.run_forever()
+
+if __name__ == "__main__":
+    main()

--- a/etc/proto/schema.capnp
+++ b/etc/proto/schema.capnp
@@ -1,0 +1,12 @@
+@0xf7298542d948dda7;
+
+interface FluxMessageInterface {
+  get @0 (m: FluxMessage) -> (x: Text);
+}
+
+struct FluxMessage {
+  topic @0 :Text;
+  payload @1 :Text;
+  nodeid @2 :Int16 = 0;
+  flags @3 :Int16 = 0;
+}

--- a/scripts/requirements-dev.txt
+++ b/scripts/requirements-dev.txt
@@ -7,3 +7,4 @@ isort>=5.9.3
 mypy==0.971
 pre-commit>=2.9.2
 types-PyYAML
+pycapnp


### PR DESCRIPTION
Problem: we want to eventually support a more standard rpc interface, and using Captain Proto (cue superhero music) can likely help us. This is not intended to merge in, but is an example of creating a simple client/server model using the Python library for captain proto, and it uses a schema for a FluxMessage to create the message, and then send to the server, and the server creates the flux RPC and returns the result (serialized as a string, which likely we can improve upon.

This PR is intended for discussion - pinging @trws to discuss next steps and @alecbcs to join in on the fun! :unicorn: 

Signed-off-by: vsoch <vsoch@users.noreply.github.com>