### PR TITLE
job-list: ensure purged jobs are inactive

### DIFF
--- a/src/modules/job-list/job-list.c
+++ b/src/modules/job-list/job-list.c
@@ -99,6 +99,8 @@ static void purge_cb (flux_t *h,
         struct job *job;
 
         if ((job = zhashx_lookup (ctx->jsctx->index, &id))) {
+            if (job->state != FLUX_JOB_STATE_INACTIVE)
+                continue;
             job_stats_purge (&ctx->jsctx->stats, job);
             if (job->list_handle)
                 zlistx_delete (ctx->jsctx->inactive, job->list_handle);

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -313,6 +313,7 @@ dist_check_SCRIPTS = \
 	issues/t4482-flush-list-corruption.sh \
 	issues/t4583-free-range-test.sh \
 	issues/t4612-eventlog-overwrite-crash.sh \
+	issues/t4711-job-list-purge-inactive.sh \
 	python/__init__.py \
 	python/subflux.py \
 	python/tap \

--- a/t/issues/t4711-job-list-purge-inactive.sh
+++ b/t/issues/t4711-job-list-purge-inactive.sh
@@ -1,0 +1,26 @@
+#!/bin/bash -e
+
+# test-prereqs: HAVE_JQ
+
+prejob=$(flux job stats | jq .job_states.run)
+
+jobid=$(flux mini submit --wait-event=start sleep 100 | flux job id)
+
+postjob=$(flux job stats | jq .job_states.run)
+
+if [ ${postjob} -ne $((prejob + 1)) ]
+then
+    echo "stat counts invalid: ${postjob}, ${prejob}"
+    exit 1
+fi
+
+flux event pub job-purge-inactive "{\"jobs\":[${jobid}]}"
+
+# if job-list module asserted this won't work
+
+# this is technically a bit racy, as we won't know for sure if the
+# event has been received / processed by the job-list module yet.  In
+# the rare event the racy bit is hit and our fix regresses, subsequent
+# flux actions should catch a failure.
+
+flux job stats


### PR DESCRIPTION
Problem: The handler for the job-purge-inactive event does not check if the requested job ids are inactive.  Purging a non-inactive job id can lead to various issues such as stats miscalculations and (worst case) an assertion could be triggered.

Add check to ensure job is inactive before doing purge.

Fixes #4711