### PR TITLE
job-list: add successful job count stat

### DIFF
--- a/src/bindings/python/flux/job/stats.py
+++ b/src/bindings/python/flux/job/stats.py
@@ -68,14 +68,13 @@ class JobStats:
 
         for state, count in resp["job_states"].items():
             setattr(self, state, count)
-        for state in ["failed", "timeout", "canceled"]:
+        for state in ["successful", "failed", "timeout", "canceled"]:
             setattr(self, state, resp[state])
 
         #  Compute some stats for convenience:
         #  pylint: disable=attribute-defined-outside-init
         self.pending = self.depend + self.priority + self.sched
         self.running = self.run + self.cleanup
-        self.successful = self.inactive - self.failed
         self.active = self.total - self.inactive
 
         if self.callback:

--- a/src/bindings/python/flux/job/stats.py
+++ b/src/bindings/python/flux/job/stats.py
@@ -23,13 +23,13 @@ class JobStats:
         run: Count of jobs in RUN state
         cleanup: Count of jobs in CLEANUP state
         inactive: Count of INACTIVE jobs
-        active: Total number of active jobs (all states but INACTIVE)
-        failed: Total number of jobs that did not exit with zero status
         successful: Total number of jobs completed with zero exit code
-        canceled: Total number of jobs that were canceled
+        failed: Total number of jobs that did not exit with zero status
         timeout: Total number of jobs that timed out
+        canceled: Total number of jobs that were canceled
         pending: Sum of "depend", "priority", and "sched"
         running: Sum of "run" and "cleanup"
+        active: Total number of active jobs (all states but INACTIVE)
 
     """
 
@@ -46,12 +46,12 @@ class JobStats:
             "run",
             "cleanup",
             "inactive",
+            "successful",
             "failed",
-            "canceled",
             "timeout",
+            "canceled",
             "pending",
             "running",
-            "successful",
             "active",
         ]:
             setattr(self, attr, -1)

--- a/src/modules/job-list/stats.h
+++ b/src/modules/job-list/stats.h
@@ -20,6 +20,7 @@
 
 struct job_stats {
     unsigned int state_count[FLUX_JOB_NR_STATES];
+    unsigned int successful;
     unsigned int failed;
     unsigned int timeout;
     unsigned int canceled;

--- a/t/t2260-job-list.t
+++ b/t/t2260-job-list.t
@@ -353,6 +353,7 @@ test_expect_success HAVE_JQ 'job stats lists jobs in correct state (mix)' '
         flux job stats | jq -e ".job_states.cleanup == 0" &&
         flux job stats | jq -e ".job_states.inactive == $(job_list_state_count inactive)" &&
         flux job stats | jq -e ".job_states.total == $(job_list_state_count all)" &&
+        flux job stats | jq -e ".successful == $(job_list_state_count completed)" &&
         flux job stats | jq -e ".failed == $(job_list_state_count failed canceled timeout)" &&
         flux job stats | jq -e ".canceled == $(job_list_state_count canceled)" &&
         flux job stats | jq -e ".timeout == $(job_list_state_count timeout)" &&
@@ -405,6 +406,7 @@ test_expect_success HAVE_JQ 'job stats lists jobs in correct state (all inactive
         flux job stats | jq -e ".job_states.cleanup == 0" &&
         flux job stats | jq -e ".job_states.inactive == $(job_list_state_count all)" &&
         flux job stats | jq -e ".job_states.total == $(job_list_state_count all)" &&
+        flux job stats | jq -e ".successful == $(job_list_state_count completed)" &&
         flux job stats | jq -e ".failed == $(job_list_state_count active failed canceled timeout)" &&
         flux job stats | jq -e ".canceled == $(job_list_state_count active canceled)" &&
         flux job stats | jq -e ".timeout == $(job_list_state_count timeout)" &&
@@ -1717,6 +1719,7 @@ test_expect_success HAVE_JQ 'job stats lists jobs in correct state in each queue
         echo $batchq | jq -e ".job_states.cleanup == 0" &&
         echo $batchq | jq -e ".job_states.inactive == 2" &&
         echo $batchq | jq -e ".job_states.total == 2" &&
+        echo $batchq | jq -e ".successful == 1" &&
         echo $batchq | jq -e ".failed == 1" &&
         echo $batchq | jq -e ".canceled == 0" &&
         echo $batchq | jq -e ".timeout == 0" &&
@@ -1727,6 +1730,7 @@ test_expect_success HAVE_JQ 'job stats lists jobs in correct state in each queue
         echo $debugq | jq -e ".job_states.cleanup == 0" &&
         echo $debugq | jq -e ".job_states.inactive == 2" &&
         echo $debugq | jq -e ".job_states.total == 2" &&
+        echo $debugq | jq -e ".successful == 1" &&
         echo $debugq | jq -e ".failed == 1" &&
         echo $debugq | jq -e ".canceled == 0" &&
         echo $debugq | jq -e ".timeout == 0"
@@ -1750,6 +1754,7 @@ test_expect_success HAVE_JQ 'job stats in each queue correct after reload' '
         echo $batchq | jq -e ".job_states.cleanup == 0" &&
         echo $batchq | jq -e ".job_states.inactive == 2" &&
         echo $batchq | jq -e ".job_states.total == 2" &&
+        echo $batchq | jq -e ".successful == 1" &&
         echo $batchq | jq -e ".failed == 1" &&
         echo $batchq | jq -e ".canceled == 0" &&
         echo $batchq | jq -e ".timeout == 0" &&
@@ -1760,6 +1765,7 @@ test_expect_success HAVE_JQ 'job stats in each queue correct after reload' '
         echo $debugq | jq -e ".job_states.cleanup == 0" &&
         echo $debugq | jq -e ".job_states.inactive == 2" &&
         echo $debugq | jq -e ".job_states.total == 2" &&
+        echo $debugq | jq -e ".successful == 1" &&
         echo $debugq | jq -e ".failed == 1" &&
         echo $debugq | jq -e ".canceled == 0" &&
         echo $debugq | jq -e ".timeout == 0"

--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -1225,7 +1225,7 @@ test_expect_success 'flux-jobs --stats works (global)' '
 	run=$(state_count run) &&
 	inactive=$(state_count inactive) &&
 	active=$(state_count active) &&
-	comp=$((inactive - fail)) &&
+	comp=$(state_count completed) &&
 	pend=$((active - run)) &&
 	cat <<-EOF >stats.expected &&
 	${run} running, ${comp} completed, ${fail} failed, ${pend} pending
@@ -1239,7 +1239,7 @@ test_expect_success 'flux-jobs --stats works (queue1)' '
 	test_debug "cat statsq1.output" &&
 	fail=$(state_count failed canceled timeout) &&
 	inactive=$(state_count inactive) &&
-	comp=$((inactive - fail)) &&
+	comp=$(state_count completed) &&
 	cat <<-EOF >statsq1.expected &&
 	0 running, ${comp} completed, 0 failed, 0 pending
 	EOF


### PR DESCRIPTION
built on top of #4684 

we had failed, timeout, and canceled counters, but not "successful" for some reason.  Probably some random "what is our current need" decision from long ago.