### PR TITLE
etc: update bash completion functions

### DIFF
--- a/etc/completions/flux.pre
+++ b/etc/completions/flux.pre
@@ -61,6 +61,17 @@ _flux_get_subcmd() {
     echo $firstword
 }
 
+# Handle compgen for words that may contain an '=', so we need to remove
+# any `=` from COMP_WORDBREAKS
+_flux_compgen_with_equals() {
+    # Grab values to pass to compgen, removing possible trailing space
+    local values="${1%% }"
+    COMP_WORDBREAKS_saved="$COMP_WORDBREAKS"
+    COMP_WORDBREAKS="$(echo \"$COMP_WORDBREAKS\" | tr -d =)"
+    COMPREPLY=( $(compgen -W "${values}" -- "$cur") )
+    COMP_WORDBREAKS="$COMP_WORDBREAKS"
+}
+
 # Autocomplete queue name for `-q, --queue=NAME`
 # returns failure if cur or prev option is not -q,--queue
 #
@@ -73,7 +84,7 @@ _flux_complete_queue() {
         if [[ "$cur" == "--que"* ]]; then
             queues=$(printf -- '--queue=%s ' $queues)
         fi
-        COMPREPLY=( $(compgen -W "${queues}" -- "$cur") )
+        _flux_compgen_with_equals "${queues}"
         return 0
     fi
     return 1

--- a/etc/completions/flux.pre
+++ b/etc/completions/flux.pre
@@ -336,11 +336,19 @@ _flux_job()
     local urgency_OPTS="\
         -v --verbose \
     "
+    local cancel_OPTS="\
+        -m --message= \
+    "
     local cancelall_OPTS="\
         -u --user= \
         -S --states= \
         -f --force \
         -q --quiet \
+    "
+    local raise_OPTS="\
+        -s --severity= \
+        -t, --type= \
+        -m --message= \
     "
     local raiseall_OPTS="\
         -s --severity= \

--- a/etc/completions/flux.pre
+++ b/etc/completions/flux.pre
@@ -1163,11 +1163,17 @@ _flux_core()
 {
     local cur prev cmd subcmd
     local cmds=$(__get_flux_subcommands)
-
-    cur=${COMP_WORDS[COMP_CWORD]}
-    prev=${COMP_WORDS[COMP_CWORD-1]}
     cmd=$(_flux_get_cmd)
     subcmd=$(_flux_get_subcmd $cmd)
+
+    #  If available, use bash-completion _get_comp_words_by_ref()
+    #  This better handles not splitting on `=` for long options.
+    if type _get_comp_words_by_ref >/dev/null 2>&1; then
+        _get_comp_words_by_ref -n = cur prev
+    else
+        cur=${COMP_WORDS[COMP_CWORD]}
+        prev=${COMP_WORDS[COMP_CWORD-1]}
+    fi
 
     case "${cmd}" in
     mini)

--- a/etc/completions/flux.pre
+++ b/etc/completions/flux.pre
@@ -90,6 +90,21 @@ _flux_complete_queue() {
     return 1
 }
 
+# Autocomplete format names for commands that take -o, --format
+_flux_complete_format_name() {
+    if [[ "$prev" == "--format" \
+        || "$prev" == "-o" \
+        || "$cur" == "--form"* ]]; then
+        local formats=$($@ --format=help | grep -v ^Conf | awk 'NF {print $1}')
+        if [[ "$cur" == "--for"* ]]; then
+            formats=$(printf -- '--format=%s ' $formats)
+        fi
+        _flux_compgen_with_equals "${formats}"
+        return 0
+    fi
+    return 1
+}
+
 #  Get the list of subcommands from FLUX_EXEC_PATH and hard-coded builtins
 __get_flux_subcommands() {
     local subcommands
@@ -836,6 +851,9 @@ _flux_jobs()
         --stats-only \
     "
     if _flux_complete_queue; then
+        return 0
+    fi
+    if _flux_complete_format_name flux jobs; then
         return 0
     fi
     COMPREPLY=( $(compgen -W "${OPTS} -h --help" -- "$cur") )

--- a/etc/completions/flux.pre
+++ b/etc/completions/flux.pre
@@ -264,7 +264,6 @@ _flux_resource()
     "
     local list_OPTS="\
         -h --help \
-        -v --verbose \
         -o --format= \
         -s --states= \
         -n --no-header \
@@ -279,6 +278,8 @@ _flux_resource()
         -h --help \
         -f --force \
         -u --update \
+        -o --format= \
+        -n --no-header \
     "
 
     if [[ $cmd != "resource" ]]; then
@@ -292,6 +293,9 @@ _flux_resource()
         if [[ "${COMPREPLY[@]}" == *= ]]; then
             # Add space if there is not a '=' in suggestions
             compopt -o nospace
+        fi
+        if _flux_complete_format_name flux resource ${cmd}; then
+            return 0
         fi
     else
         COMPREPLY=( $(compgen -W "${subcmds}" -- "$cur") )


### PR DESCRIPTION
Some options were changed and removed recently without corresponding updates in our bash completion functions. This PR addresses that issue. It also adds tab completion for named formats with `-o, --format=` with `flux resource` and `flux jobs`.

Additionally, some strange behavior with long options was found with an older bash version. The bash-completion initialization function seems to help with that (along with some `COMP_WORDBREAKS` machinations), but we don't yet require bash-completion so only call that project's `_init_completion()` function when it is available.
