### PR TITLE
job-list: cleanup error logging, remove excess logging

### DIFF
--- a/src/modules/job-list/idsync.c
+++ b/src/modules/job-list/idsync.c
@@ -26,10 +26,12 @@ void idsync_data_destroy (void *data)
 {
     if (data) {
         struct idsync_data *isd = data;
+        int save_errno = errno;
         flux_msg_destroy (isd->msg);
         json_decref (isd->attrs);
         flux_future_destroy (isd->f_lookup);
         free (isd);
+        errno = save_errno;
     }
 }
 
@@ -49,7 +51,6 @@ static struct idsync_data *idsync_data_create (flux_t *h,
                                                flux_future_t *f_lookup)
 {
     struct idsync_data *isd = NULL;
-    int saved_errno;
 
     isd = calloc (1, sizeof (*isd));
     if (!isd)
@@ -65,9 +66,7 @@ static struct idsync_data *idsync_data_create (flux_t *h,
  error_enomem:
     errno = ENOMEM;
  error:
-    saved_errno = errno;
     idsync_data_destroy (isd);
-    errno = saved_errno;
     return NULL;
 }
 
@@ -132,7 +131,6 @@ struct idsync_data *idsync_check_id_valid (struct idsync_ctx *isctx,
     flux_future_t *f = NULL;
     struct idsync_data *isd = NULL;
     char path[256];
-    int saved_errno;
 
     /* Check to see if the ID is legal, job-list may have not yet
      * seen the ID publication yet */
@@ -159,10 +157,8 @@ struct idsync_data *idsync_check_id_valid (struct idsync_ctx *isctx,
     return isd;
 
 error:
-    saved_errno = errno;
     flux_future_destroy (f);
     idsync_data_destroy (isd);
-    errno = saved_errno;
     return NULL;
 }
 

--- a/src/modules/job-list/idsync.c
+++ b/src/modules/job-list/idsync.c
@@ -82,10 +82,8 @@ struct idsync_ctx *idsync_ctx_create (flux_t *h)
     struct idsync_ctx *isctx = NULL;
     int saved_errno;
 
-    if (!(isctx = calloc (1, sizeof (*isctx)))) {
-        flux_log_error (h, "calloc");
+    if (!(isctx = calloc (1, sizeof (*isctx))))
         return NULL;
-    }
     isctx->h = h;
 
     if (!(isctx->lookups = zlistx_new ()))
@@ -185,22 +183,16 @@ static int idsync_add_waiter (struct idsync_ctx *isctx,
     /* isctx->waits holds lists of ids waiting on, b/c multiple callers
      * could wait on same id */
     if (!(list_isd = zhashx_lookup (isctx->waits, &isd->id))) {
-        if (!(list_isd = zlistx_new ())) {
-            flux_log (isctx->h, LOG_ERR, "%s: zlistx_new", __FUNCTION__);
+        if (!(list_isd = zlistx_new ()))
             goto enomem;
-        }
         zlistx_set_destructor (list_isd, idsync_data_destroy_wrapper);
 
-        if (zhashx_insert (isctx->waits, &isd->id, list_isd) < 0) {
-            flux_log (isctx->h, LOG_ERR, "%s: zhashx_insert", __FUNCTION__);
+        if (zhashx_insert (isctx->waits, &isd->id, list_isd) < 0)
             goto enomem;
-        }
     }
 
-    if (!zlistx_add_end (list_isd, isd)) {
-        flux_log (isctx->h, LOG_ERR, "%s: zlistx_add_end", __FUNCTION__);
+    if (!zlistx_add_end (list_isd, isd))
         goto enomem;
-    }
 
     return 0;
 
@@ -231,10 +223,8 @@ int idsync_wait_valid_id (struct idsync_ctx *isctx,
 {
     struct idsync_data *isd = NULL;
 
-    if (!(isd = idsync_data_create (isctx->h, id, msg, attrs, NULL))) {
-        flux_log_error (isctx->h, "%s: idsync_data_create", __FUNCTION__);
+    if (!(isd = idsync_data_create (isctx->h, id, msg, attrs, NULL)))
         return -1;
-    }
 
     return idsync_add_waiter (isctx, isd);
 }

--- a/src/modules/job-list/idsync.c
+++ b/src/modules/job-list/idsync.c
@@ -153,7 +153,8 @@ struct idsync_data *idsync_check_id_valid (struct idsync_ctx *isctx,
     f = NULL;
 
     if (!zlistx_add_end (isctx->lookups, isd)) {
-        flux_log_error (isctx->h, "%s: zlistx_add_end", __FUNCTION__);
+        flux_log (isctx->h, LOG_ERR, "%s: zlistx_add_end", __FUNCTION__);
+        errno = ENOMEM;
         goto error;
     }
 
@@ -186,19 +187,22 @@ static int idsync_add_waiter (struct idsync_ctx *isctx,
      * could wait on same id */
     if (!(list_isd = zhashx_lookup (isctx->waits, &isd->id))) {
         if (!(list_isd = zlistx_new ())) {
-            flux_log_error (isctx->h, "%s: zlistx_new", __FUNCTION__);
+            flux_log (isctx->h, LOG_ERR, "%s: zlistx_new", __FUNCTION__);
+            errno = ENOMEM;
             goto error;
         }
         zlistx_set_destructor (list_isd, idsync_data_destroy_wrapper);
 
         if (zhashx_insert (isctx->waits, &isd->id, list_isd) < 0) {
-            flux_log_error (isctx->h, "%s: zhashx_insert", __FUNCTION__);
+            flux_log (isctx->h, LOG_ERR, "%s: zhashx_insert", __FUNCTION__);
+            errno = ENOMEM;
             goto error;
         }
     }
 
     if (!zlistx_add_end (list_isd, isd)) {
-        flux_log_error (isctx->h, "%s: zlistx_add_end", __FUNCTION__);
+        flux_log (isctx->h, LOG_ERR, "%s: zlistx_add_end", __FUNCTION__);
+        errno = ENOMEM;
         goto error;
     }
 

--- a/src/modules/job-list/job-list.c
+++ b/src/modules/job-list/job-list.c
@@ -199,8 +199,10 @@ int mod_main (flux_t *h, int argc, char **argv)
         flux_log_error (h, "initialization error");
         goto done;
     }
-    if (job_state_init_from_kvs (ctx->jsctx) < 0)
+    if (job_state_init_from_kvs (ctx->jsctx) < 0) {
+        flux_log_error (h, "initialization from kvs error");
         goto done;
+    }
     if (flux_reactor_run (flux_get_reactor (h), 0) < 0)
         goto done;
     rc = 0;

--- a/src/modules/job-list/job_data.c
+++ b/src/modules/job-list/job_data.c
@@ -29,6 +29,7 @@ void job_destroy (void *data)
 {
     struct job *job = data;
     if (job) {
+        int save_errno = errno;
         free (job->ranks);
         free (job->nodelist);
         json_decref (job->annotations);
@@ -38,6 +39,7 @@ void job_destroy (void *data)
         json_decref (job->exception_context);
         zlist_destroy (&job->next_states);
         free (job);
+        errno = save_errno;
     }
 }
 

--- a/src/modules/job-list/job_state.c
+++ b/src/modules/job-list/job_state.c
@@ -208,7 +208,10 @@ static void job_change_list (struct job_state_ctx *jsctx,
                              flux_job_state_t newstate)
 {
     if (zlistx_detach (oldlist, job->list_handle) < 0)
-        flux_log (jsctx->h, LOG_ERR, "%s: zlistx_detach", __FUNCTION__);
+        flux_log (jsctx->h,
+                  LOG_ERR,
+                  "%s: zlistx_detach: out of memory",
+                  __FUNCTION__);
     job->list_handle = NULL;
 
     if (job_insert_list (jsctx, job, newstate) < 0)
@@ -470,7 +473,10 @@ static void process_next_state (struct job_state_ctx *jsctx, struct job *job)
             }
 
             if (!zlistx_add_end (jsctx->futures, f)) {
-                flux_log (jsctx->h, LOG_ERR, "%s: zlistx_add_end", __FUNCTION__);
+                flux_log (jsctx->h,
+                          LOG_ERR,
+                          "%s: zlistx_add_end: out of memory",
+                          __FUNCTION__);
                 flux_future_destroy (f);
                 return;
             }

--- a/src/modules/job-list/job_state.c
+++ b/src/modules/job-list/job_state.c
@@ -181,21 +181,18 @@ static void job_insert_list (struct job_state_ctx *jsctx,
         if (!(job->list_handle = zlistx_insert (jsctx->pending,
                                                 job,
                                                 search_direction (job))))
-            flux_log_error (jsctx->h, "%s: zlistx_insert",
-                            __FUNCTION__);
+            flux_log (jsctx->h, LOG_ERR, "%s: zlistx_insert", __FUNCTION__);
     }
     else if (newstate == FLUX_JOB_STATE_RUN
              || newstate == FLUX_JOB_STATE_CLEANUP) {
         if (!(job->list_handle = zlistx_add_start (jsctx->running,
                                                    job)))
-            flux_log_error (jsctx->h, "%s: zlistx_add_start",
-                            __FUNCTION__);
+            flux_log (jsctx->h, LOG_ERR, "%s: zlistx_add_start", __FUNCTION__);
     }
     else { /* newstate == FLUX_JOB_STATE_INACTIVE */
         if (!(job->list_handle = zlistx_add_start (jsctx->inactive,
                                                    job)))
-            flux_log_error (jsctx->h, "%s: zlistx_add_start",
-                            __FUNCTION__);
+            flux_log (jsctx->h, LOG_ERR, "%s: zlistx_add_start", __FUNCTION__);
     }
 }
 
@@ -207,8 +204,7 @@ static void job_change_list (struct job_state_ctx *jsctx,
                              flux_job_state_t newstate)
 {
     if (zlistx_detach (oldlist, job->list_handle) < 0)
-        flux_log_error (jsctx->h, "%s: zlistx_detach",
-                        __FUNCTION__);
+        flux_log (jsctx->h, LOG_ERR, "%s: zlistx_detach", __FUNCTION__);
     job->list_handle = NULL;
 
     job_insert_list (jsctx, job, newstate);
@@ -497,7 +493,7 @@ static void process_next_state (struct job_state_ctx *jsctx, struct job *job)
             }
 
             if (!zlistx_add_end (jsctx->futures, f)) {
-                flux_log_error (jsctx->h, "%s: zlistx_add_end", __FUNCTION__);
+                flux_log (jsctx->h, LOG_ERR, "%s: zlistx_add_end", __FUNCTION__);
                 flux_future_destroy (f);
                 return;
             }
@@ -946,14 +942,14 @@ static int journal_submit_event (struct job_state_ctx *jsctx,
             return -1;
         }
         if (zhashx_insert (jsctx->index, &job->id, job) < 0) {
-            flux_log_error (jsctx->h, "%s: zhashx_insert", __FUNCTION__);
+            flux_log (jsctx->h, LOG_ERR, "%s: zhashx_insert", __FUNCTION__);
             job_destroy (job);
             errno = ENOMEM;
             return -1;
         }
         /* job always starts off on processing list */
         if (!(job->list_handle = zlistx_add_end (jsctx->processing, job))) {
-            flux_log_error (jsctx->h, "%s: zlistx_add_end", __FUNCTION__);
+            flux_log (jsctx->h, LOG_ERR, "%s: zlistx_add_end", __FUNCTION__);
             errno = ENOMEM;
             return -1;
         }

--- a/src/modules/job-list/list.c
+++ b/src/modules/job-list/list.c
@@ -308,37 +308,26 @@ int check_id_valid (struct job_state_ctx *jsctx,
                     json_t *attrs)
 {
     struct idsync_data *isd = NULL;
-    int saved_errno;
 
     if (!(isd = idsync_check_id_valid (jsctx->isctx,
                                        id,
                                        msg,
-                                       attrs)))
-        goto error;
-
-    if (flux_future_aux_set (isd->f_lookup,
-                             "job_state_ctx",
-                             jsctx,
-                             NULL) < 0) {
-        flux_log_error (jsctx->h, "%s: flux_future_aux_set", __FUNCTION__);
-        goto error;
-    }
-
-    if (flux_future_then (isd->f_lookup,
-                          -1,
-                          check_id_valid_continuation,
-                          isd) < 0) {
-        flux_log_error (jsctx->h, "%s: flux_future_then", __FUNCTION__);
-        goto error;
+                                       attrs))
+        || flux_future_aux_set (isd->f_lookup,
+                                "job_state_ctx",
+                                jsctx,
+                                NULL) < 0
+        || flux_future_then (isd->f_lookup,
+                             -1,
+                             check_id_valid_continuation,
+                             isd) < 0) {
+        int saved_errno = errno;
+        idsync_data_destroy (isd);
+        errno = saved_errno;
+        return -1;
     }
 
     return 0;
-
-error:
-    saved_errno = errno;
-    idsync_data_destroy (isd);
-    errno = saved_errno;
-    return -1;
 }
 
 /* Returns JSON object which the caller must free.  On error, return

--- a/src/modules/job-list/list.c
+++ b/src/modules/job-list/list.c
@@ -321,9 +321,7 @@ int check_id_valid (struct job_state_ctx *jsctx,
                              -1,
                              check_id_valid_continuation,
                              isd) < 0) {
-        int saved_errno = errno;
         idsync_data_destroy (isd);
-        errno = saved_errno;
         return -1;
     }
 

--- a/src/modules/job-list/stats.c
+++ b/src/modules/job-list/stats.c
@@ -68,7 +68,10 @@ static struct job_stats *queue_stats_lookup (struct job_stats_ctx *statsctx,
         if (!(stats = calloc (1, sizeof (*stats))))
             return NULL;
         if (zhashx_insert (statsctx->queue_stats, job->queue, stats) < 0) {
-            flux_log (statsctx->h, LOG_ERR, "%s: zhashx_insert", __FUNCTION__);
+            flux_log (statsctx->h,
+                      LOG_ERR,
+                      "%s: zhashx_insert: out of memory",
+                      __FUNCTION__);
             free (stats);
             return NULL;
         }

--- a/src/modules/job-list/stats.c
+++ b/src/modules/job-list/stats.c
@@ -68,7 +68,7 @@ static struct job_stats *queue_stats_lookup (struct job_stats_ctx *statsctx,
         if (!(stats = calloc (1, sizeof (*stats))))
             return NULL;
         if (zhashx_insert (statsctx->queue_stats, job->queue, stats) < 0) {
-            flux_log_error (statsctx->h, "%s: zhashx_insert", __FUNCTION__);
+            flux_log (statsctx->h, LOG_ERR, "%s: zhashx_insert", __FUNCTION__);
             free (stats);
             return NULL;
         }


### PR DESCRIPTION
Problem: A number of error logging functions assumed zhashx and zlistx functions set errno and thus flux_log_error() was called to log an error.  However it is not a safe assumption to assume they set errno on error.

Solution: Replace flux_log_error() calls with flux_log() calls after zhashx or zlistx errors.  When necessary, set errno = ENOMOM or remove setting of errno = ENOMEM when it is not necessary to set.

Fixes #4741