### PR TITLE
propagate process resource limits to jobs

### DIFF
--- a/doc/man1/flux-mini.rst
+++ b/doc/man1/flux-mini.rst
@@ -390,6 +390,54 @@ The above file would first clear the environment, then copy all variables
 starting with ``OMP`` from the current environment, set ``FOO=bar``,
 and then set ``BAR=bar/baz``.
 
+PROCESS RESOURCE LIMITS
+=======================
+
+By default flux mini propagates some common resource limits (as described
+in :linux:man2:`getrlimit`) to the job by setting the ``rlimit`` job shell
+option in jobspec.  The set of resource limits propagated can be controlled
+via the ``--rlimit=RULE`` option:
+
+**--rlimit=RULE**
+    Control how process resource limits are propagated with *RULE*. Rules
+    are applied in the order in which they are used on the command line.
+    This option may be used multiple times.
+
+The ``--rlimit`` rules work similar to the ``--env`` option rules:
+
+ * If a rule begins with ``-``, then the rest of the rule is a name or
+   :linux:man7:`glob` pattern which removes matching resource limits from
+   the set to propagate.
+
+   Example:
+     ``-*`` disables propagation of all resource limits.
+
+ * If a rule is of the form ``LIMIT=VALUE`` then *LIMIT* is explicitly
+   set to *VALUE*. If *VALUE* is ``unlimited``, ``infinity`` or ``inf``,
+   then the value is set to ``RLIM_INFINITY`` (no limit).
+
+   Example:
+     ``nofile=1024`` overrides the current ``RLIMIT_NOFILE`` limit to 1024.
+
+ * Otherwise, *RULE* is considered a pattern from which to match resource
+   limits and propagate the current limit to the job, e.g.
+
+      ``--rlimit=memlock``
+
+   will propagate ``RLIMIT_MEMLOCK`` (which is not in the list of limits
+   that are propagated by default).
+
+``flux-mini`` starts with a default list of resource limits to propagate,
+then applies all rules specified via ``--rlimit`` on the command line.
+Therefore, to propagate only one limit, ``-*`` should first be used to
+start with an empty set, e.g. ``--rlimit=-*,core`` will only propagate the
+``core`` resource limit.
+
+The set of resource limits propagated by default includes all those except
+``memlock``, ``ofile``, ``msgqueue``, ``nice``, ``rtprio``, ``rttime``,
+and ``sigpending``. To propagate all possible resource limits, use
+``--rlimit=*``.
+
 
 EXIT STATUS
 ===========

--- a/doc/man1/flux-shell.rst
+++ b/doc/man1/flux-shell.rst
@@ -294,6 +294,13 @@ options are supported by the builtin plugins of ``flux-shell``:
   If the first task to exit was signaled or exited with a nonzero status,
   raise a fatal exception on the job immediately.
 
+**rlimit**
+  A dictionary of soft process resource limits to apply to the job before
+  starting tasks. Resource limits are set to integer values by lowercase
+  name without the ``RLIMIT_`` prefix, e.g. ``core`` or ``nofile``. Users
+  should not need to set this shell option as it is handled by commands
+  like ``flux-mini``.
+
 SHELL INITRC
 ============
 

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -650,3 +650,16 @@ XDG
 yaml
 enqueued
 kary
+getrlimit
+memlock
+MEMLOCK
+msgqueue
+nofile
+NOFILE
+ofile
+RLIM
+rlimit
+RLIMIT
+rtprio
+rttime
+sigpending

--- a/etc/completions/flux.pre
+++ b/etc/completions/flux.pre
@@ -148,6 +148,7 @@ _flux_mini()
         --env= \
         --env-remove= \
         --env-file= \
+        --rlimit= \
         --input= \
         --output= \
         --error= \

--- a/src/cmd/flux-mini.py
+++ b/src/cmd/flux-mini.py
@@ -14,8 +14,6 @@ import fnmatch
 import itertools
 import json
 import logging
-
-# pylint: disable=duplicate-code
 import os
 import random
 import re

--- a/src/cmd/flux-mini.py
+++ b/src/cmd/flux-mini.py
@@ -19,6 +19,7 @@ import logging
 import os
 import random
 import re
+import resource
 import sys
 import time
 from collections import ChainMap
@@ -116,6 +117,69 @@ def filter_dict(env, pattern, reverseMatch=True):
     if reverseMatch:
         return dict(filter(lambda x: not regex.match(x[0]), env.items()))
     return dict(filter(lambda x: regex.match(x[0]), env.items()))
+
+
+def get_rlimits(name="*"):
+    """
+    Return set of rlimits matching `name` in a dict
+    """
+    rlimits = {}
+    pattern = f"RLIMIT_{name}".upper()
+    for limit in fnmatch.filter(resource.__dict__.keys(), pattern):
+        soft, hard = resource.getrlimit(getattr(resource, limit))
+        #  Remove RLIMIT_ prefix and lowercase the result for compatibility
+        #  with rlimit shell plugin:
+        rlimits[limit[7::].lower()] = soft
+    if not rlimits:
+        raise ValueError(f'No corresponding rlimit matching "{name}"')
+    return rlimits
+
+
+def get_filtered_rlimits(user_rules=None):
+    """
+    Get a filtered set of rlimits based on user rules and defaults
+    """
+    #  We start with the entire set of available rlimits and then apply
+    #  rules to remove or override them. Therefore, the set of default
+    #  rules excludes limits *not* to propagate by default.
+    rules = [
+        "-memlock",
+        "-ofile",
+        "-msgqueue",
+        "-nice",
+        "-rtprio",
+        "-rttime",
+        "-sigpending",
+    ]
+
+    if user_rules:
+        rules.extend(list_split(user_rules))
+
+    rlimits = get_rlimits()
+    for rule in rules:
+        if rule.startswith("-"):
+            # -name removes RLIMIT_{pattern} from propagated rlimits
+            rlimits = filter_dict(rlimits, rule[1::].lower())
+        else:
+            name, *rest = rule.split("=", 1)
+            if not rest:
+                #  limit with no value pulls in current limit(s)
+                limits = get_rlimits(name.lower())
+                for key, value in limits.items():
+                    rlimits[key] = value
+            else:
+                if not hasattr(resource, f"RLIMIT_{name}".upper()):
+                    raise ValueError(f'Invalid rlimit "{name}"')
+                #  limit with value sets limit to that value
+                if rest[0] in ["unlimited", "infinity", "inf"]:
+                    value = resource.RLIM_INFINITY
+                else:
+                    try:
+                        value = int(rest[0])
+                    except ValueError:
+                        raise ValueError(f"Invalid value in {name}={rest[0]}")
+                rlimits[name.lower()] = value
+    return rlimits
 
 
 def get_filtered_environment(rules, environ=None):
@@ -549,6 +613,18 @@ class MiniCmd:
             metavar="FILE",
         )
         parser.add_argument(
+            "--rlimit",
+            action="append",
+            help="Control how soft resource limits are propagated to the job. "
+            + "If RULE starts with a '-', then do not propagate matching "
+            + "resource limits (e.g. '-*' propagates nothing). Otherwise, "
+            + "propagate the current limit or a specific value, e.g. "
+            + "--rlimit=core or --rlimit=core=16. The option may be used "
+            + "multiple times to build a reduced set of propagated limits, "
+            + "e.g. --rlimit=-*,core will only propagate RLIMIT_CORE.",
+            metavar="RULE",
+        )
+        parser.add_argument(
             "--input",
             type=str,
             help="Redirect job stdin from FILENAME, bypassing KVS"
@@ -612,6 +688,10 @@ class MiniCmd:
         jobspec = self.init_jobspec(args)
         jobspec.cwd = os.getcwd()
         jobspec.environment = get_filtered_environment(args.env)
+        rlimits = get_filtered_rlimits(args.rlimit)
+        if rlimits:
+            jobspec.setattr_shell_option("rlimit", rlimits)
+
         if args.dependency is not None:
             jobspec.setattr(
                 "system.dependencies", dependency_array_create(args.dependency)

--- a/src/shell/Makefile.am
+++ b/src/shell/Makefile.am
@@ -86,7 +86,8 @@ flux_shell_SOURCES = \
 	mustache.h \
 	mustache.c \
 	doom.c \
-	exception.c
+	exception.c \
+	rlimit.c
 
 flux_shell_LDADD = \
 	$(builddir)/libshell.la \

--- a/src/shell/builtins.c
+++ b/src/shell/builtins.c
@@ -45,6 +45,7 @@ extern struct shell_builtin builtin_pty;
 extern struct shell_builtin builtin_batch;
 extern struct shell_builtin builtin_doom;
 extern struct shell_builtin builtin_exception;
+extern struct shell_builtin builtin_rlimit;
 
 static struct shell_builtin * builtins [] = {
     &builtin_tmpdir,
@@ -62,6 +63,7 @@ static struct shell_builtin * builtins [] = {
     &builtin_batch,
     &builtin_doom,
     &builtin_exception,
+    &builtin_rlimit,
     &builtin_list_end,
 };
 

--- a/src/shell/rlimit.c
+++ b/src/shell/rlimit.c
@@ -1,0 +1,124 @@
+/************************************************************\
+ * Copyright 2022 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* shell rlimit propagations
+ *
+ * Call setrlimit(2) for any resource limits defined in
+ * attributes.system.shell.options.rlimit
+ */
+#define FLUX_SHELL_PLUGIN_NAME "rlimit"
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <signal.h>
+#include <sys/resource.h>
+#include <jansson.h>
+
+#include <flux/core.h>
+#include <flux/shell.h>
+
+#include "ccan/str/str.h"
+
+#include "internal.h"
+#include "builtins.h"
+
+static int rlimit_name_to_string (const char *name)
+{
+    if (streq (name, "cpu"))
+        return RLIMIT_CPU;
+    if (streq (name, "fsize"))
+        return RLIMIT_FSIZE;
+    if (streq (name, "data"))
+        return RLIMIT_DATA;
+    if (streq (name, "stack"))
+        return RLIMIT_STACK;
+    if (streq (name, "core"))
+        return RLIMIT_CORE;
+    if (streq (name, "nofile"))
+        return RLIMIT_NOFILE;
+    if (streq (name, "ofile"))
+        return RLIMIT_OFILE;
+    if (streq (name, "as"))
+        return RLIMIT_AS;
+    if (streq (name, "rss"))
+        return RLIMIT_RSS;
+    if (streq (name, "nproc"))
+        return RLIMIT_NPROC;
+    if (streq (name, "memlock"))
+        return RLIMIT_MEMLOCK;
+    if (streq (name, "msgqueue"))
+        return RLIMIT_MSGQUEUE;
+    if (streq (name, "nice"))
+        return RLIMIT_NICE;
+    if (streq (name, "rtprio"))
+        return RLIMIT_RTPRIO;
+    if (streq (name, "rttime"))
+        return RLIMIT_RTTIME;
+    if (streq (name, "sigpending"))
+        return RLIMIT_SIGPENDING;
+    return -1;
+}
+
+static int rlimit_init (flux_plugin_t *p,
+                        const char *topic,
+                        flux_plugin_arg_t *args,
+                        void *data)
+{
+    int rc = 0;
+    json_t *value;
+    const char *key;
+    json_t *o = NULL;
+    flux_shell_t *shell = flux_plugin_get_shell (p);
+
+    if (!shell)
+        return -1;
+
+    switch (flux_shell_getopt_unpack (shell, "rlimit", "o", &o)) {
+        case -1:
+            return shell_log_errno ("failed to parse rlimit shell option");
+        case 0:
+            return 0;
+        case 1:
+            break;
+    }
+    json_object_foreach (o, key, value) {
+        int resource;
+        struct rlimit rlim;
+        if (!json_is_integer (value)
+            || (resource = rlimit_name_to_string (key)) < 0) {
+            char *s = json_dumps (value, JSON_ENCODE_ANY);
+            shell_log_error ("invalid shell option rlimit.%s%s%s",
+                             key,
+                             s ? "=" : "",
+                             s ? s : "");
+            free (s);
+            rc = -1;
+            continue;
+        }
+        if (getrlimit (resource, &rlim) < 0) {
+            shell_log_errno ("getrlimit %s", key);
+            continue;
+        }
+        rlim.rlim_cur = json_integer_value (value);
+        if (setrlimit (resource, &rlim) < 0)
+            shell_log_errno ("setrlimit %s", key);
+    }
+    return rc;
+}
+
+struct shell_builtin builtin_rlimit = {
+    .name = FLUX_SHELL_PLUGIN_NAME,
+    .init = rlimit_init,
+};
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -184,6 +184,7 @@ TESTSCRIPTS = \
 	t2612-job-shell-pty.t \
 	t2613-job-shell-batch.t \
 	t2614-job-shell-doom.t \
+	t2615-job-shell-rlimit.t \
 	t2700-mini-cmd.t \
 	t2701-mini-batch.t \
 	t2702-mini-alloc.t \

--- a/t/t2603-job-shell-initrc.t
+++ b/t/t2603-job-shell-initrc.t
@@ -272,13 +272,13 @@ test_expect_success HAVE_JQ 'flux-shell: initrc: load getopt plugin' '
 		> ${name}.log 2>&1 &&
 	test_debug "cat ${name}.log"
 '
-test_expect_success 'flux-shell: plugins can use setopt with empty options' '
+test_expect_success HAVE_JQ 'flux-shell: plugins can use setopt with empty options' '
 	name=setopt &&
 	cat >${name}.lua <<-EOF &&
 	plugin.searchpath = "${INITRC_PLUGINPATH}"
 	plugin.load { file = "${name}.so" }
 	EOF
-	cat j1 >j.${name} &&
+	cat j1 | jq "del(.attributes.system.shell.options)" >j.${name} &&
 	${FLUX_SHELL} -v -s -r 0 -j j.${name} -R R1 --initrc=${name}.lua 0 \
 		> ${name}.log 2>&1 &&
 	test_debug "cat ${name}.log"

--- a/t/t2615-job-shell-rlimit.t
+++ b/t/t2615-job-shell-rlimit.t
@@ -1,0 +1,34 @@
+#!/bin/sh
+#
+test_description='Test flux-shell rlimit support'
+
+. `dirname $0`/sharness.sh
+
+test_under_flux 1 job
+
+test_expect_success 'flux-shell: propagates rlimits' '
+	( ulimit -n 123 &&
+	  flux mini run sh -c "ulimit -n" >ulimit-n.out
+	) &&
+	test_debug "cat ulimit-n.out" &&
+	test "$(cat ulimit-n.out)" = "123"
+'
+test_expect_success 'flux-shell: works when no rlimits propagated' '
+	flux mini run --rlimit=-* hostname
+'
+test_expect_success 'flux-shell: works when all rlimits propagated' '
+	flux mini run --rlimit=* sh -c "ulimit -a"
+'
+test_expect_success 'flux-shell: works when no specific rlimit propagated' '
+	flux mini run --rlimit=nofile=123 sh -c "ulimit -n" >ulimit-n2.out &&
+	test_debug "cat ulimit-n2.out" &&
+	test "$(cat ulimit-n.out)" = "123"
+'
+test_expect_success 'flux-shell: nonfatal rlimit errors are logged' '
+	flux mini run --output=nofile.out --rlimit nofile=inf /bin/true &&
+	grep "nofile: Invalid argument"  nofile.out
+'
+test_expect_success 'flux-shell: invalid rlimit option is fatal error' '
+	test_must_fail flux mini run -o rlimit.foo=1234 /bin/true
+'
+test_done

--- a/t/t2700-mini-cmd.t
+++ b/t/t2700-mini-cmd.t
@@ -251,11 +251,11 @@ test_expect_success HAVE_JQ 'flux-mini --env=PATTERN works' '
 	FOO_ONE=bar FOO_TWO=baz flux mini submit --dry-run \
 	    --env=-* --env="FOO_*" hostname >FOO-pattern-env.out &&
 	jq -e ".attributes.system.environment == \
-           {\"FOO_ONE\": \"bar\", \"FOO_TWO\": \"baz\"}" FOO-pattern-env.out &&
+	    {\"FOO_ONE\": \"bar\", \"FOO_TWO\": \"baz\"}" FOO-pattern-env.out &&
 	FOO_ONE=bar FOO_TWO=baz flux mini submit --dry-run \
 	    --env=-* --env="/^FOO_.*/" hostname >FOO-pattern2-env.out &&
 	jq -e ".attributes.system.environment == \
-           {\"FOO_ONE\": \"bar\", \"FOO_TWO\": \"baz\"}" FOO-pattern2-env.out
+	    {\"FOO_ONE\": \"bar\", \"FOO_TWO\": \"baz\"}" FOO-pattern2-env.out
 
 '
 test_expect_success HAVE_JQ 'flux-mini --env=VAR=VAL works' '
@@ -267,17 +267,17 @@ test_expect_success HAVE_JQ 'flux-mini --env=VAR=VAL works' '
 	jq -e ".attributes.system.environment == {\"FOO\": \"bar:baz\"}" FOO-append.out
 '
 test_expect_success 'flux-mini --env=VAR=${VAL:-default} fails' '
-    test_expect_code 1 flux mini run --dry-run \
-        --env=* --env=VAR=\${VAL:-default} hostname >env-fail.err 2>&1 &&
-    test_debug "cat env-fail.err" &&
-    grep "Unable to substitute" env-fail.err
+	test_expect_code 1 flux mini run --dry-run \
+	    --env=* --env=VAR=\${VAL:-default} hostname >env-fail.err 2>&1 &&
+	test_debug "cat env-fail.err" &&
+	grep "Unable to substitute" env-fail.err
 '
 test_expect_success 'flux-mini --env=VAR=$VAL fails when VAL not in env' '
-    unset VAL &&
-    test_expect_code 1 flux mini run --dry-run \
-        --env=* --env=VAR=\$VAL hostname >env-notset.err 2>&1 &&
-    test_debug "cat env-notset.err" &&
-    grep "env: Variable .* not found" env-notset.err
+	unset VAL &&
+	test_expect_code 1 flux mini run --dry-run \
+	    --env=* --env=VAR=\$VAL hostname >env-notset.err 2>&1 &&
+	test_debug "cat env-notset.err" &&
+	grep "env: Variable .* not found" env-notset.err
 '
 test_expect_success HAVE_JQ 'flux-mini --env-file works' '
 	cat <<-EOF >envfile &&
@@ -285,11 +285,11 @@ test_expect_success HAVE_JQ 'flux-mini --env-file works' '
 	FOO=bar
 	BAR=\${FOO}/baz
 	EOF
-    for arg in "--env=^envfile" "--env-file=envfile"; do
+	for arg in "--env=^envfile" "--env-file=envfile"; do
 	  flux mini submit --dry-run ${arg} hostname >envfile.out &&
 	  jq -e ".attributes.system.environment == \
 	       {\"FOO\":\"bar\", \"BAR\":\"bar/baz\"}" envfile.out
-    done
+	done
 '
 test_expect_success 'flux-mini submit --cc works' '
 	flux mini submit --cc=0-3 sh -c "echo \$FLUX_JOB_CC" >cc.jobids &&
@@ -434,20 +434,20 @@ EOF
 
 jj=${FLUX_BUILD_DIR}/t/sched-simple/jj-reader
 while read line; do
-        args=$(echo $line | awk -F== '{print $1}' | sed 's/  *$//')
-        expected=$(echo $line | awk -F== '{print $2}')
-        per_resource=$(echo $line | awk -F== '{print $3}' | sed 's/  *$//')
+	args=$(echo $line | awk -F== '{print $1}' | sed 's/  *$//')
+	expected=$(echo $line | awk -F== '{print $2}')
+	per_resource=$(echo $line | awk -F== '{print $3}' | sed 's/  *$//')
 	test_expect_success HAVE_JQ "per-resource: $args" '
-		echo $expected >expected.$test_count &&
-                flux mini run $args --dry-run hostname > jobspec.$test_count &&
-		$jj < jobspec.$test_count >output.$test_count &&
-		test_debug "cat output.$test_count" &&
-                test_cmp expected.$test_count output.$test_count &&
-		if test -n "$per_resource"; then
-		    test_debug "echo expected $per_resource" &&
-		    jq -e ".attributes.system.shell.options.per_resource == \
-			   $per_resource"
-		fi
+	    echo $expected >expected.$test_count &&
+	    flux mini run $args --dry-run hostname > jobspec.$test_count &&
+	    $jj < jobspec.$test_count >output.$test_count &&
+	    test_debug "cat output.$test_count" &&
+	    test_cmp expected.$test_count output.$test_count &&
+	    if test -n "$per_resource"; then
+	        test_debug "echo expected $per_resource" &&
+	        jq -e ".attributes.system.shell.options.per_resource == \
+		   $per_resource"
+	    fi
 	'
 done < per-resource-args.txt
 


### PR DESCRIPTION
Ok, here's a proposed solution to #4743. This PR adds a new `rlimit` shell plugin and corresponding `rlimit` shell option where process soft rlimits and the values to propagate can be set in jobspec. Then, `flux-mini` commands are all extended to add a set of default rlimits to propagate.

A new `--rlimit=RULE` option is added which works similarly to the existing `--env=RULE` option, i.e. if `RULE` starts with a `-` then that name is explicitly excluded from rlimit propagation, otherwise the name is explicitly included, or with `name=value` an value is set. For example, `--rlimit=-*` propagates nothing, `--rlimit=core=1024` sets `RLIMIT_CORE` to `1024` and `--rlimit=-*,core` propagates only the current core rlimit.

I wasn't sure if the `rlimit` key should be directly in `attributes.system` like the `environment`. For now it is treated as a shell option since setting the rlimits is done by a shell plugin.