### PR TITLE
shell: rlimit: improve handling of limits over hard limit

### DIFF
--- a/src/shell/rlimit.c
+++ b/src/shell/rlimit.c
@@ -108,6 +108,13 @@ static int rlimit_init (flux_plugin_t *p,
             continue;
         }
         rlim.rlim_cur = json_integer_value (value);
+        if (rlim.rlim_max != RLIM_INFINITY
+            && (rlim.rlim_max < rlim.rlim_cur
+                || rlim.rlim_cur == RLIM_INFINITY)) {
+            shell_warn ("%s exceeds current max, raising value to hard limit",
+                        key);
+            rlim.rlim_cur = rlim.rlim_max;
+        }
         if (setrlimit (resource, &rlim) < 0)
             shell_log_errno ("setrlimit %s", key);
     }

--- a/t/t2615-job-shell-rlimit.t
+++ b/t/t2615-job-shell-rlimit.t
@@ -26,7 +26,7 @@ test_expect_success 'flux-shell: works when no specific rlimit propagated' '
 '
 test_expect_success 'flux-shell: nonfatal rlimit errors are logged' '
 	flux mini run --output=nofile.out --rlimit nofile=inf /bin/true &&
-	grep "nofile: Invalid argument"  nofile.out
+	grep "nofile exceeds current max"  nofile.out
 '
 test_expect_success 'flux-shell: invalid rlimit option is fatal error' '
 	test_must_fail flux mini run -o rlimit.foo=1234 /bin/true


### PR DESCRIPTION
Problem: The job shell rlimit plugin issues a possibly confusing message when the requested soft limit exceeds the hard limit. Also, the limit is left alone instead of raising the limit as much as possible, which may be more helpful.

Check to see if the requested soft limit exceeds the hard limit and issue an explicit warning that the shell cannot set the requested value and instead will raise the soft limit to the hard limit.

Update a test in the testsuite with new expected error message.