### PR TITLE
github: fix automated tag release action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -166,13 +166,6 @@ jobs:
       env: ${{matrix.env}}
       run: src/test/docker-deploy.sh
 
-    #   Prepare, create and deploy release on tag:
-    - name: prep release
-      id: prep_release
-      if: success() && matrix.create_release
-      env: ${{matrix.env}}
-      run: echo "tarball=$(echo flux-core*.tar.gz)" >> $GITHUB_OUTPUT
-
     - name: create release
       id: create_release
       if: |
@@ -183,7 +176,7 @@ jobs:
       uses: softprops/action-gh-release@18c81ca362701a5894253311aebebe23cce43e8b # v0.1.9
       with:
         tag_name: ${{ matrix.tag }}
-        release_name: flux-core ${{ matrix.tag }}
+        name: flux-core ${{ matrix.tag }}
         prerelease: true
         files: flux-core*.tar.gz
         body: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -173,7 +173,7 @@ jobs:
         && matrix.create_release
         && github.repository == 'flux-framework/flux-core'
       env: ${{matrix.env}}
-      uses: softprops/action-gh-release@18c81ca362701a5894253311aebebe23cce43e8b # v0.1.9
+      uses: softprops/action-gh-release@v1
       with:
         tag_name: ${{ matrix.tag }}
         name: flux-core ${{ matrix.tag }}


### PR DESCRIPTION
This fixes the github workflow that does our auto-release on tags. There was an incorrect key used in the yaml, and also step that wasn't necessary anymore. Also, "upgrades" the softprops/action-gh-release action which was inadvertently downgraded by a recent commit.

Fixes #4751  (though we really won't know until the next tag)