### PR TITLE
job-list: add inactive purge count to job-list stats

### DIFF
--- a/src/bindings/python/flux/job/stats.py
+++ b/src/bindings/python/flux/job/stats.py
@@ -50,6 +50,7 @@ class JobStats:
             "failed",
             "timeout",
             "canceled",
+            "inactive_purged",
             "pending",
             "running",
             "active",
@@ -68,7 +69,7 @@ class JobStats:
 
         for state, count in resp["job_states"].items():
             setattr(self, state, count)
-        for state in ["successful", "failed", "timeout", "canceled"]:
+        for state in ["successful", "failed", "timeout", "canceled", "inactive_purged"]:
             setattr(self, state, resp[state])
 
         #  Compute some stats for convenience:

--- a/src/cmd/flux-jobs.py
+++ b/src/cmd/flux-jobs.py
@@ -471,7 +471,8 @@ def main():
 
         print(
             f"{stats.running} running, {stats.successful} completed, "
-            f"{stats.failed} failed, {stats.pending} pending"
+            f"{stats.failed} failed, {stats.pending} pending, "
+            f"{stats.inactive_purged} inactive purged"
         )
         if args.stats_only:
             sys.exit(0 if stats.active else 1)

--- a/src/modules/job-list/stats.c
+++ b/src/modules/job-list/stats.c
@@ -170,6 +170,7 @@ static void stats_purge (struct job_stats *stats, struct job *job)
     }
     else
         stats->successful--;
+    stats->inactive_purged++;
 }
 
 /* An inactive job is being purged, so statistics must be updated.
@@ -225,12 +226,13 @@ static json_t *stats_encode (struct job_stats *stats, const char *name)
     json_t *states;
 
     if (!(states = job_states_encode (stats))
-        || !(o = json_pack ("{ s:O s:i s:i s:i s:i }",
+        || !(o = json_pack ("{ s:O s:i s:i s:i s:i s:i }",
                             "job_states", states,
                             "successful", stats->successful,
                             "failed", stats->failed,
                             "canceled", stats->canceled,
-                            "timeout", stats->timeout))) {
+                            "timeout", stats->timeout,
+                            "inactive_purged", stats->inactive_purged))) {
         json_decref (states);
         errno = ENOMEM;
         return NULL;

--- a/src/modules/job-list/stats.h
+++ b/src/modules/job-list/stats.h
@@ -24,6 +24,7 @@ struct job_stats {
     unsigned int failed;
     unsigned int timeout;
     unsigned int canceled;
+    unsigned int inactive_purged;
 };
 
 struct job_stats_ctx {

--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -1227,7 +1227,7 @@ test_expect_success 'flux-jobs --stats works (global)' '
 	comp=$(state_count completed) &&
 	pend=$((active - run)) &&
 	cat <<-EOF >stats.expected &&
-	${run} running, ${comp} completed, ${fail} failed, ${pend} pending
+	${run} running, ${comp} completed, ${fail} failed, ${pend} pending, 0 inactive purged
 	EOF
 	head -1 stats.output > stats.actual &&
 	test_cmp stats.expected stats.actual
@@ -1238,7 +1238,7 @@ test_expect_success 'flux-jobs --stats works (queue1)' '
 	test_debug "cat statsq1.output" &&
 	comp=$(state_count completed) &&
 	cat <<-EOF >statsq1.expected &&
-	0 running, ${comp} completed, 0 failed, 0 pending
+	0 running, ${comp} completed, 0 failed, 0 pending, 0 inactive purged
 	EOF
 	head -1 statsq1.output > statsq1.actual &&
 	test_cmp statsq1.expected statsq1.actual
@@ -1251,7 +1251,7 @@ test_expect_success 'flux-jobs --stats works (queue2)' '
 	active=$(state_count active) &&
 	pend=$((active - run)) &&
 	cat <<-EOF >statsq2.expected &&
-	${run} running, 0 completed, 0 failed, ${pend} pending
+	${run} running, 0 completed, 0 failed, ${pend} pending, 0 inactive purged
 	EOF
 	head -1 statsq2.output > statsq2.actual &&
 	test_cmp statsq2.expected statsq2.actual
@@ -1262,7 +1262,7 @@ test_expect_success 'flux-jobs --stats works (defaultqueue)' '
 	test_debug "cat statsqdefault.output" &&
 	fail=$(state_count failed canceled timeout) &&
 	cat <<-EOF >statsqdefault.expected &&
-	0 running, 0 completed, ${fail} failed, 0 pending
+	0 running, 0 completed, ${fail} failed, 0 pending, 0 inactive purged
 	EOF
 	head -1 statsqdefault.output > statsqdefault.actual &&
 	test_cmp statsqdefault.expected statsqdefault.actual

--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -1223,7 +1223,6 @@ test_expect_success 'flux-jobs --stats works (global)' '
 	test_debug "cat stats.output" &&
 	fail=$(state_count failed canceled timeout) &&
 	run=$(state_count run) &&
-	inactive=$(state_count inactive) &&
 	active=$(state_count active) &&
 	comp=$(state_count completed) &&
 	pend=$((active - run)) &&
@@ -1237,8 +1236,6 @@ test_expect_success 'flux-jobs --stats works (global)' '
 test_expect_success 'flux-jobs --stats works (queue1)' '
 	flux jobs --stats -a --queue=queue1 >statsq1.output &&
 	test_debug "cat statsq1.output" &&
-	fail=$(state_count failed canceled timeout) &&
-	inactive=$(state_count inactive) &&
 	comp=$(state_count completed) &&
 	cat <<-EOF >statsq1.expected &&
 	0 running, ${comp} completed, 0 failed, 0 pending

--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -1280,4 +1280,56 @@ test_expect_success 'cleanup job listing jobs ' '
 	done
 '
 
+test_expect_success 'purge all jobs' '
+	flux job purge --force --num-limit=0
+'
+
+#
+# All stat tests below assume all jobs purged
+#
+
+test_expect_success 'flux-jobs --stats works after jobs purged (all)' '
+	flux jobs --stats -a >statspurge.output &&
+	test_debug "cat statspurge.output" &&
+	all=$(state_count all) &&
+	cat <<-EOF >statspurge.expected &&
+	0 running, 0 completed, 0 failed, 0 pending, ${all} inactive purged
+	EOF
+	head -1 statspurge.output > statspurge.actual &&
+	test_cmp statspurge.expected statspurge.actual
+'
+
+test_expect_success 'flux-jobs --stats works after jobs purged (queue1)' '
+	flux jobs --stats -a --queue=queue1 >statspurgeq1.output &&
+	test_debug "cat statspurgeq1.output" &&
+	comp=$(state_count completed) &&
+	cat <<-EOF >statspurgeq1.expected &&
+	0 running, 0 completed, 0 failed, 0 pending, ${comp} inactive purged
+	EOF
+	head -1 statspurgeq1.output > statspurgeq1.actual &&
+	test_cmp statspurgeq1.expected statspurgeq1.actual
+'
+
+test_expect_success 'flux-jobs --stats works after jobs purged (queue2)' '
+	flux jobs --stats -a --queue=queue2 >statspurgeq2.output &&
+	test_debug "cat statspurgeq2.output" &&
+	active=$(state_count active) &&
+	cat <<-EOF >statspurgeq2.expected &&
+	0 running, 0 completed, 0 failed, 0 pending, ${active} inactive purged
+	EOF
+	head -1 statspurgeq2.output > statspurgeq2.actual &&
+	test_cmp statspurgeq2.expected statspurgeq2.actual
+'
+
+test_expect_success 'flux-jobs --stats works after jobs purged (defaultqueue)' '
+	flux jobs --stats -a --queue=defaultqueue >statspurgeqdefault.output &&
+	test_debug "cat statspurgeqdefault.output" &&
+	fail=$(state_count failed canceled timeout) &&
+	cat <<-EOF >statspurgeqdefault.expected &&
+	0 running, 0 completed, 0 failed, 0 pending, ${fail} inactive purged
+	EOF
+	head -1 statspurgeqdefault.output > statspurgeqdefault.actual &&
+	test_cmp statspurgeqdefault.expected statspurgeqdefault.actual
+'
+
 test_done

--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -1283,7 +1283,4 @@ test_expect_success 'cleanup job listing jobs ' '
 	done
 '
 
-#
-# leave job cleanup to rc3
-#
 test_done


### PR DESCRIPTION
Following up #4753 for issue #4719, instead of adding a purge timestamp to the job stats, add a count of jobs purged.  Definitely like this approach better.

pro:
- can do purge counts per queue as well as total
- cleaner, not as much refactoring needed to be done in job-list

con:
- modifies default flux-jobs stats output

but overall, I like this better than the prior attempt that I went ahead and added tests thinking this a worthwhile candidate for merging.
