### PR TITLE
WIP: job-list: return all attrs by default in job-list-id

### DIFF
--- a/src/bindings/python/flux/job/list.py
+++ b/src/bindings/python/flux/job/list.py
@@ -89,8 +89,11 @@ class JobListIdRPC(RPC):
 
 # list-id is not like list or list-inactive, it doesn't return an
 # array, so don't use JobListRPC
-def job_list_id(flux_handle, jobid, attrs=[]):
-    payload = {"id": int(jobid), "attrs": attrs}
+def job_list_id(flux_handle, jobid, attrs=None):
+    if attrs:
+        payload = {"id": int(jobid), "attrs": attrs}
+    else:
+        payload = {"id": int(jobid)}
     rpc = JobListIdRPC(flux_handle, "job-list.list-id", payload)
     #  save original JobId argument for error reporting
     rpc.jobid = jobid

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -1386,7 +1386,8 @@ int cmd_list_ids (optparse_t *p, int argc, char **argv)
     for (i = 0; i < ids_len; i++) {
         flux_jobid_t id = parse_jobid (argv[optindex + i]);
         flux_future_t *f;
-        if (!(f = flux_job_list_id (h, id, "[\"all\"]")))
+        /* by default flux_job_list_id gets all attrs */
+        if (!(f = flux_job_list_id (h, id, NULL)))
             log_err_exit ("flux_job_list_id");
         if (flux_future_then (f, -1, list_id_continuation, NULL) < 0)
             log_err_exit ("flux_future_then");

--- a/src/common/libjob/job.h
+++ b/src/common/libjob/job.h
@@ -168,7 +168,7 @@ flux_future_t *flux_job_list_inactive (flux_t *h,
                                        const char *json_str);
 
 /* Similar to flux_job_list(), but retrieve job info for a single
- * job id */
+ * job id.  `json_str` may be NULL, to retrieve all attributes. */
 flux_future_t *flux_job_list_id (flux_t *h,
                                  flux_jobid_t id,
                                  const char *json_str);

--- a/src/common/libjob/list.c
+++ b/src/common/libjob/list.c
@@ -90,15 +90,21 @@ flux_future_t *flux_job_list_id (flux_t *h,
     json_t *o = NULL;
     int saved_errno;
 
-    if (!h || !json_str
-           || !(o = json_loads (json_str, 0, NULL))) {
+    if (!h || (json_str
+               && !(o = json_loads (json_str, 0, NULL)))) {
         errno = EINVAL;
         return NULL;
     }
-    if (!(f = flux_rpc_pack (h, "job-list.list-id", FLUX_NODEID_ANY, 0,
-                             "{s:I s:O}",
-                             "id", id,
-                             "attrs", o)))
+    if (o)
+        f = flux_rpc_pack (h, "job-list.list-id", FLUX_NODEID_ANY, 0,
+                           "{s:I s:O}",
+                           "id", id,
+                           "attrs", o);
+    else
+        f = flux_rpc_pack (h, "job-list.list-id", FLUX_NODEID_ANY, 0,
+                           "{s:I}",
+                           "id", id);
+    if (!f)
         goto error;
 
     json_decref (o);

--- a/src/common/libjob/test/job.c
+++ b/src/common/libjob/test/job.c
@@ -162,11 +162,6 @@ void check_corner_case (void)
         "flux_job_list_id h=NULL fails with EINVAL");
 
     errno = 0;
-    ok (flux_job_list_id (h, 0, NULL) == NULL
-        && errno == EINVAL,
-        "flux_job_list_id json_str=NULL fails with EINVAL");
-
-    errno = 0;
     ok (flux_job_list_id (h, 0, "wrong") == NULL
         && errno == EINVAL,
         "flux_job_list_id json_str=(inval JSON) fails with EINVAL");


### PR DESCRIPTION
By default, job-list-id returns no attributes if the user does not specify any.  This is probably not what most users expect.  This is especially true with the python interface, where the average user while likely do:

`job = flux.job.job_list_id(conn, job_id)`

vs.

`job = flux.job.job_list_id(conn, job_id, attrs=["id", "state", "nodelist", ...])`

So I went with job-list-rpc now taking "attrs" as an optional json key and if not-specified, returns all attributes.  The python interface follows accordingly.

I contemplated only having the python interface set `attrs=["all"]` by default, but that felt inconsistent so I did it on the main RPC too.  

Also contemplated having the python interface default to a set of "common" attrs like `attrs=["id", "state", "nodelist", ...]` which would be a reduced list and not have all of the less common attrs (`t_depend`, `annotations`, etc.).  But again, felt inconsistent.

Edit: Oh yeah, and another option is to make `attrs` in the Python `job_list_id()` a required positional input.  Thus a user would be required to set `attrs=["all"]`, but given we're trying to make the API easier, decided against that as well.

So by doing this:

pro:
- users get all data by default, which is probably what they expect

con:
- more data sent back by default (more processing, etc.)
- inconsistent with primary job listing "job-list" rpc.  But we probably do not want "all" by default there, b/c that's probably too much data coming back.  Where as this is specific to just the id requested by the user.

any initial thoughts / comments?  think is good idea?  or perhaps one of the other ideas I list above?