### PR TITLE
WIP: shell: add unshare plugin

### DIFF
--- a/src/shell/Makefile.am
+++ b/src/shell/Makefile.am
@@ -87,7 +87,8 @@ flux_shell_SOURCES = \
 	mustache.c \
 	doom.c \
 	exception.c \
-	rlimit.c
+	rlimit.c \
+	unshare.c
 
 flux_shell_LDADD = \
 	$(builddir)/libshell.la \

--- a/src/shell/builtins.c
+++ b/src/shell/builtins.c
@@ -46,8 +46,10 @@ extern struct shell_builtin builtin_batch;
 extern struct shell_builtin builtin_doom;
 extern struct shell_builtin builtin_exception;
 extern struct shell_builtin builtin_rlimit;
+extern struct shell_builtin builtin_unshare;
 
 static struct shell_builtin * builtins [] = {
+    &builtin_unshare,
     &builtin_tmpdir,
     &builtin_log_eventlog,
     &builtin_pmi,

--- a/src/shell/unshare.c
+++ b/src/shell/unshare.c
@@ -1,0 +1,177 @@
+/************************************************************\
+ * Copyright 2022 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* unshare.c - unshare CLONE_NEWUSER or requested namespaces
+ *
+ * Shell options
+ *   unshare[=name,name,...]
+ */
+#define FLUX_SHELL_PLUGIN_NAME "unshare"
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <sched.h>
+#include <sys/types.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <argz.h>
+#include <flux/core.h>
+#include <jansson.h>
+
+#include "ccan/array_size/array_size.h"
+#include "ccan/str/str.h"
+#include "src/common/libutil/errprintf.h"
+
+#include "builtins.h"
+
+struct ns {
+    const char *name;
+    int flag;
+};
+
+static struct ns nsmap[] = {
+    { "files",      CLONE_FILES },
+    { "fs",         CLONE_FS },
+#ifdef CLONE_NEWCGROUP
+    { "cgroup",     CLONE_NEWCGROUP },
+#endif
+    { "ipc",        CLONE_NEWIPC },
+    { "net",        CLONE_NEWNET },
+    { "mount",      CLONE_NEWNS },
+    { "pid",        CLONE_NEWPID },
+    { "user",       CLONE_NEWUSER },
+#ifdef CLONE_NEWTIME
+    { "time",       CLONE_NEWTIME },
+#endif
+    { "uts",        CLONE_NEWUTS },
+    { "sysvsem",    CLONE_SYSVSEM },
+};
+
+static int getflag (const char *name, int *flagp)
+{
+    for (int i = 0; i < ARRAY_SIZE (nsmap); i++) {
+        if (name && streq (nsmap[i].name, name)) {
+            *flagp = nsmap[i].flag;
+            return 0;
+        }
+    }
+    return -1;
+}
+
+static int parse_options (const char *s, int *flagsp, bool *maprootp)
+{
+    error_t e;
+    char *argz = NULL;
+    size_t argz_len = 0;
+    bool maproot = false;
+    const char *name;
+    int flags = 0;
+
+    e = argz_create_sep (s, ',', &argz, &argz_len);
+    if (e != 0) {
+        shell_log_error ("%s", strerror (e));
+        return -1;
+    }
+    name = NULL;
+    while ((name = argz_next (argz, argz_len, name))) {
+        int newflag;
+        if (streq (name, "maproot"))
+            maproot = true;
+        else {
+            if (getflag (name, &newflag) < 0) {
+                shell_log_error ("unknown unshare name: %s", name);
+                free (argz);
+                return -1;
+            }
+            flags |= newflag;
+        }
+    }
+    *flagsp = flags;
+    *maprootp = maproot;
+    return 0;
+}
+
+static int write_file (const char *path, const char *s)
+{
+    int fd;
+    ssize_t count;
+
+    fd = open (path, O_WRONLY);
+    if (fd < 0)
+        return shell_log_errno ("error opening %s for writing", path);
+    if ((count = write (fd, s, strlen (s))) < 0) {
+        shell_log_errno ("error writing to %s", path);
+        goto error;
+    }
+    if (count < strlen (s)) {
+        shell_log_error ("short write to %s", path);
+        goto error;
+    }
+    if (close (fd) < 0)
+        return shell_log_errno ("error closing %s", path);
+    return 0;
+error:
+    (void)close (fd);
+    return -1;
+}
+
+static int write_idmap (const char *path, int from_id, int to_id)
+{
+    char buf[64];
+
+    snprintf (buf, sizeof (buf), "%d %d 1\n", to_id, from_id);
+    return write_file (path, buf);
+}
+
+static int unshare_init (flux_plugin_t *p,
+                         const char *topic,
+                         flux_plugin_arg_t *arg,
+                         void *data)
+{
+    flux_shell_t *shell;
+    json_t *o;
+    bool maproot = false;
+    int flags = 0;
+    int rc;
+    int old_uid = getuid ();
+    int old_gid = getgid ();
+
+    if (!(shell = flux_plugin_get_shell (p)))
+        return -1;
+    if ((rc = flux_shell_getopt_unpack (shell, "unshare", "o", &o)) < 0)
+        return shell_log_errno ("unshare option parse error");
+    if (rc == 0)
+        return 0;
+    if (json_is_string (o)) {
+        if (parse_options (json_string_value (o), &flags, &maproot) < 0)
+            return -1;
+    }
+    if (flags == 0)
+        flags |= CLONE_NEWUSER;
+    if (unshare (flags) < 0)
+        return shell_log_errno ("unshare system call");
+    if (maproot) {
+        /* Order is important here.  See user_namespaces(7).
+         */
+        if (write_idmap ("/proc/self/uid_map", old_uid, 0) < 0
+            || write_file ("/proc/self/setgroups", "deny") < 0
+            || write_idmap ("/proc/self/gid_map", old_gid, 0) < 0)
+            return -1;
+    }
+    return 0;
+}
+
+struct shell_builtin builtin_unshare = {
+    .name = FLUX_SHELL_PLUGIN_NAME,
+    .init = unshare_init,
+};
+
+// vi:ts=4 sw=4 expandtab

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -185,6 +185,7 @@ TESTSCRIPTS = \
 	t2613-job-shell-batch.t \
 	t2614-job-shell-doom.t \
 	t2615-job-shell-rlimit.t \
+	t2616-job-shell-unshare.t \
 	t2700-mini-cmd.t \
 	t2701-mini-batch.t \
 	t2702-mini-alloc.t \

--- a/t/t2616-job-shell-unshare.t
+++ b/t/t2616-job-shell-unshare.t
@@ -1,0 +1,36 @@
+#!/bin/sh
+#
+test_description='Test flux-shell unshare support'
+
+. `dirname $0`/sharness.sh
+
+if ! unshare -U /bin/true; then
+    skip_all='skipping unshare tests since system does not permit unshare(2)'
+    test_done
+fi
+
+test_under_flux 1
+
+test_expect_success 'flux-shell: unshare=user,maproot sets uid to 0' '
+	NEWUID=$(flux mini run -o unshare=user,maproot id -u) &&
+	test $NEWUID -eq 0
+'
+test_expect_success 'flux-shell: unshare=user,maproot,mount enables bind mounting' '
+	cat >bindtest.sh <<-EOT &&
+	#!/bin/bash -e
+	mkdir src dst
+	mount --bind $(pwd)/src $(pwd)/dst
+	touch src/foo
+	test -f dst/foo
+	EOT
+	chmod +x bindtest.sh &&
+	flux mini run -o unshare=user,maproot,mount ./bindtest.sh
+'
+test_expect_success 'flux-shell: unshare works without arguments' '
+	flux mini run -o unshare /bin/true
+'
+test_expect_success 'flux-shell: unshare rejects unknown argument' '
+	test_must_fail flux mini run -o unshare=badarg /bin/true
+'
+
+test_done


### PR DESCRIPTION
Here's a shell plugin that lets jobs run in private namespaces (when allowed by system configuration).  For example:
```
$ flux mini run -o unshare=user,maproot id
uid=0(root) gid=0(root) groups=0(root),65534(nogroup)
```
If you run `-o unshare`, it calls unshare (CLONE_NEWUSER).  The `unshare` option also takes a comma-separated list of arguments  which correspond to unshare flags, and also a special one `maproot` which maps root "in the container" to the invoking user outside of it.

I'm sure we don't want to replicate container tooling in Flux, but this seemed simple and powerful for enabling other shell plugins that might do some fs mounting or similar setup before launching the job.  It's fun to play with and explore what's possible, at least.

See also #3927