### PR TITLE
python: add flux.job.get_job

### DIFF
--- a/doc/python/job_submission.rst
+++ b/doc/python/job_submission.rst
@@ -81,6 +81,49 @@ of the asynchronous interfaces.
 
 .. autofunction:: flux.job.wait
 
+.. autofunction:: flux.job.get_job
+
+
+``get_job``
+~~~~~~~~~~~
+
+After submitting a job, if you quickly want to see information for it,
+you can use ``flux.job.get_job``. Here is an example:
+
+.. code:: python
+
+    import flux
+    import flux.job
+
+    # It's encouraged to create a handle to use across commands
+    handle = flux.Flux()
+
+    jobspec = flux.job.JobspecV1.from_command(["sleep", "60"])
+    jobid = flux.job.submit(handle, jobspec)
+    job_meta = flux.job.get_job(handle, jobid)
+
+    {
+        "job": {
+            "id": 676292747853824,
+            "userid": 0,
+            "urgency": 16,
+            "priority": 16,
+            "t_submit": 1667760398.4034982,
+            "t_depend": 1667760398.4034982,
+            "state": "SCHED",
+            "name": "sleep",
+            "ntasks": 1,
+            "ncores": 1,
+            "duration": 0.0
+        }
+    }
+
+If the jobid you are asking for does not exist, ``None`` will be returned.
+For the interested user, this is a courtesy function that wraps using the identifier
+to create an RPC object, serializing that to string, and loading as JSON. 
+Since it is likely you, as the user, will be interacting with ``flux.job``, it
+is also logical you would look for this function to retrieve the job on the same
+module.
 
 ``result`` vs ``wait``
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/src/bindings/python/flux/job/__init__.py
+++ b/src/bindings/python/flux/job/__init__.py
@@ -14,7 +14,7 @@ from flux.job.kvs import job_kvs, job_kvs_guest
 from flux.job.kill import kill_async, kill, cancel_async, cancel
 from flux.job.submit import submit_async, submit, submit_get_id
 from flux.job.info import JobInfo, JobInfoFormat, job_fields_to_attrs
-from flux.job.list import job_list, job_list_inactive, job_list_id, JobList
+from flux.job.list import job_list, job_list_inactive, job_list_id, JobList, get_job
 from flux.job.wait import wait_async, wait, wait_get_status, result_async, result
 from flux.job.event import (
     event_watch_async,

--- a/src/bindings/python/flux/job/list.py
+++ b/src/bindings/python/flux/job/list.py
@@ -13,7 +13,7 @@ import pwd
 
 import flux.constants
 from flux.future import WaitAllFuture
-from flux.job.info import JobInfo
+from flux.job.info import JobInfo, statetostr
 from flux.rpc import RPC
 
 
@@ -95,6 +95,47 @@ def job_list_id(flux_handle, jobid, attrs=["all"]):
     #  save original JobId argument for error reporting
     rpc.jobid = jobid
     return rpc
+
+
+# get_job is the single variant of job_list_id, and returns the
+# expected data structure (dict) to describe one job (or None)
+def get_job(flux_handle, jobid):
+    """Get job information dictionary based on a jobid
+
+    This is a courtesy, blocking function for users looking for
+    details about a job after submission. The dictionary includes
+    the job identifier, userid that submit it, urgency, priority,
+    t_submit, t_depend, (and others when finished), state, name,
+    ntasks, ncores, duration, nnodes, result, runtime, returncode,
+    waitstatus, nodelist, and exception type, severity, and note.
+    """
+    payload = {"id": int(jobid), "attrs": ["all"]}
+    rpc = JobListIdRPC(flux_handle, "job-list.list-id", payload)
+    try:
+        jobinfo = rpc.get()
+
+    # The job does not exist!
+    except FileNotFoundError:
+        return None
+
+    jobinfo = jobinfo["job"]
+
+    # User friendly string from integer
+    state = jobinfo["state"]
+    jobinfo["state"] = statetostr(state)
+
+    # Get job info to add to result
+    info = rpc.get_jobinfo()
+    jobinfo["nnodes"] = info._nnodes
+    jobinfo["result"] = info.result
+    jobinfo["returncode"] = info.returncode
+    jobinfo["runtime"] = info.runtime
+    jobinfo["priority"] = info._priority
+    jobinfo["waitstatus"] = info._waitstatus
+    jobinfo["nodelist"] = info._nodelist
+    jobinfo["nodelist"] = info._nodelist
+    jobinfo["exception"] = info._exception.__dict__
+    return jobinfo
 
 
 class JobListIdsFuture(WaitAllFuture):

--- a/t/python/t0010-job.py
+++ b/t/python/t0010-job.py
@@ -672,7 +672,41 @@ class TestJob(unittest.TestCase):
         # synchronous job.result() test
         self.assertEqual(job.result(self.fh, ids[3]), result[ids[3]].get_info())
 
+    def test_33_get_job(self):
+        self.sleep_jobspec = JobspecV1.from_command(["sleep", "5"])
+        jobid = job.submit(self.fh, self.sleep_jobspec)
+        meta = job.get_job(self.fh, jobid)
+        self.assertIsInstance(meta, dict)
+        for key in ['id',
+                    'userid',
+                    'urgency',
+                    'priority',
+                    't_submit',
+                    't_depend',
+                    'state',
+                    'name',
+                    'ntasks',
+                    'ncores',
+                    'duration',
+                    'nnodes',
+                    'result',
+                    'runtime',
+                    'returncode',
+                    'waitstatus',
+                    'nodelist',
+                    'exception']:
+            self.assertIn(key, meta)
 
+        self.assertEqual(meta['id'], jobid)
+        self.assertEqual(meta['name'], "sleep")
+        self.assertTrue(meta['state'] in ["SCHED", "DEPEND", "RUN"])
+        self.assertEqual(meta['ntasks'], 1)
+        self.assertEqual(meta['ncores'], 1)
+
+        # Test a job that does not exist
+        meta = job.get_job(self.fh, 123456)
+        self.assertIsNone(meta)
+        
 if __name__ == "__main__":
     from subflux import rerun_under_flux
 


### PR DESCRIPTION
Problem: most users of the Python API (or any API in general) ideally want an intuitive user interface. An early likely interaction is to do a flux.job.submit, and then (for many use cases) the next desire is to get more information about the job. As currently implemented, the user needs to stumble on flux.job.job_list_id and decide to try it, and then further to look at the rpc object returned and figure out they can do get_str and json loads that, OR a less intuitive "get" to do the same. OR they could figure out some interaction with a JobInfo object, which to be frank, I do not see how they would know to go there because it is located in a totally separate place, and requires knowing how to instantiate (and is not just calling an easy function). I think the most ideal solution here, from the point of user expectation, is to place an obvious "get_job" directly on the same module the user is already interacting with. That way, it is quickly found and returns the expected data structure without further parsing needed.

- Fixes #4760 

Signed-off-by: vsoch <vsoch@users.noreply.github.com>