### PR TITLE
python: by default return all attrs in job listing functions

### DIFF
--- a/src/bindings/python/flux/job/list.py
+++ b/src/bindings/python/flux/job/list.py
@@ -37,7 +37,7 @@ class JobListRPC(RPC):
 def job_list(
     flux_handle,
     max_entries=1000,
-    attrs=[],
+    attrs=["all"],
     userid=os.getuid(),
     states=0,
     results=0,
@@ -61,7 +61,7 @@ def job_list(
 
 
 def job_list_inactive(
-    flux_handle, since=0.0, max_entries=1000, attrs=[], name=None, queue=None
+    flux_handle, since=0.0, max_entries=1000, attrs=["all"], name=None, queue=None
 ):
     return job_list(
         flux_handle,
@@ -89,7 +89,7 @@ class JobListIdRPC(RPC):
 
 # list-id is not like list or list-inactive, it doesn't return an
 # array, so don't use JobListRPC
-def job_list_id(flux_handle, jobid, attrs=[]):
+def job_list_id(flux_handle, jobid, attrs=["all"]):
     payload = {"id": int(jobid), "attrs": attrs}
     rpc = JobListIdRPC(flux_handle, "job-list.list-id", payload)
     #  save original JobId argument for error reporting

--- a/src/common/libjob/job.h
+++ b/src/common/libjob/job.h
@@ -138,7 +138,7 @@ int flux_job_wait_get_id (flux_future_t *f, flux_jobid_t *id);
 
 /* Request a list of jobs.
  * If 'max_entries' > 0, fetch at most that many jobs.
- * 'json_str' is an encoded JSON array of attribute strings, e.g.
+ * 'attrs_json_str' is an encoded JSON array of attribute strings, e.g.
  * ["id","userid",...] that will be returned in response.
  *
  * Process the response payload with flux_rpc_get() or flux_rpc_get_unpack().
@@ -155,7 +155,7 @@ int flux_job_wait_get_id (flux_future_t *f, flux_jobid_t *id);
  */
 flux_future_t *flux_job_list (flux_t *h,
                               int max_entries,
-                              const char *json_str,
+                              const char *attrs_json_str,
                               uint32_t userid,
                               int states);
 
@@ -165,13 +165,13 @@ flux_future_t *flux_job_list (flux_t *h,
 flux_future_t *flux_job_list_inactive (flux_t *h,
                                        int max_entries,
                                        double since,
-                                       const char *json_str);
+                                       const char *attrs_json_str);
 
 /* Similar to flux_job_list(), but retrieve job info for a single
  * job id */
 flux_future_t *flux_job_list_id (flux_t *h,
                                  flux_jobid_t id,
-                                 const char *json_str);
+                                 const char *attrs_json_str);
 
 /* Raise an exception for job.
  * Severity is 0-7, with severity=0 causing the job to abort.

--- a/src/common/libjob/list.c
+++ b/src/common/libjob/list.c
@@ -19,7 +19,7 @@
 
 flux_future_t *flux_job_list (flux_t *h,
                               int max_entries,
-                              const char *json_str,
+                              const char *attrs_json_str,
                               uint32_t userid,
                               int states)
 {
@@ -30,8 +30,8 @@ flux_future_t *flux_job_list (flux_t *h,
                         | FLUX_JOB_STATE_INACTIVE);
     int saved_errno;
 
-    if (!h || max_entries < 0 || !json_str
-           || !(o = json_loads (json_str, 0, NULL))
+    if (!h || max_entries < 0 || !attrs_json_str
+           || !(o = json_loads (attrs_json_str, 0, NULL))
            || states & ~valid_states) {
         json_decref (o);
         errno = EINVAL;
@@ -55,14 +55,14 @@ flux_future_t *flux_job_list (flux_t *h,
 flux_future_t *flux_job_list_inactive (flux_t *h,
                                        int max_entries,
                                        double since,
-                                       const char *json_str)
+                                       const char *attrs_json_str)
 {
     flux_future_t *f;
     json_t *o = NULL;
     int saved_errno;
 
-    if (!h || max_entries < 0 || since < 0. || !json_str
-           || !(o = json_loads (json_str, 0, NULL))) {
+    if (!h || max_entries < 0 || since < 0. || !attrs_json_str
+           || !(o = json_loads (attrs_json_str, 0, NULL))) {
         errno = EINVAL;
         return NULL;
     }
@@ -84,14 +84,14 @@ flux_future_t *flux_job_list_inactive (flux_t *h,
 
 flux_future_t *flux_job_list_id (flux_t *h,
                                  flux_jobid_t id,
-                                 const char *json_str)
+                                 const char *attrs_json_str)
 {
     flux_future_t *f;
     json_t *o = NULL;
     int saved_errno;
 
-    if (!h || !json_str
-           || !(o = json_loads (json_str, 0, NULL))) {
+    if (!h || !attrs_json_str
+           || !(o = json_loads (attrs_json_str, 0, NULL))) {
         errno = EINVAL;
         return NULL;
     }

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -236,7 +236,7 @@ TESTSCRIPTS = \
 	python/t0007-watchers.py \
 	python/t0010-job.py \
 	python/t0012-futures.py \
-	python/t0013-job-list-inactive.py \
+	python/t0013-job-list.py \
 	python/t0020-hostlist.py \
 	python/t0021-idset.py \
 	python/t0022-resource-set.py \

--- a/t/python/t0013-job-list.py
+++ b/t/python/t0013-job-list.py
@@ -64,7 +64,7 @@ class TestJob(unittest.TestCase):
         waiting = 0  # number of seconds we have been waiting
         while True:
             rpc_handle = flux.job.job_list(
-                self.fh, 0, self.attrs, states=flux.constants.FLUX_JOB_STATE_INACTIVE
+                self.fh, 0, states=flux.constants.FLUX_JOB_STATE_INACTIVE
             )
             jobs = self.getJobs(rpc_handle)
             if len(jobs) >= jobs_list_length:
@@ -73,8 +73,6 @@ class TestJob(unittest.TestCase):
             waiting += 1
             if waiting > 60:
                 raise TimeoutError()
-
-    attrs = ["userid", "state", "name", "ntasks", "t_submit", "t_run", "t_inactive"]
 
     # flux job list should return an empty list if there are no jobs
     def test_00_list_expect_empty_list(self):
@@ -87,9 +85,7 @@ class TestJob(unittest.TestCase):
     # flux job list-inactive should return an empty list if there are
     # no inactive jobs
     def test_01_list_inactive_expect_empty_list(self):
-        rpc_handle = flux.job.job_list_inactive(
-            self.fh, time.time() - 3600, 10, self.attrs
-        )
+        rpc_handle = flux.job.job_list_inactive(self.fh, time.time() - 3600, 10)
 
         jobs = self.getJobs(rpc_handle)
 
@@ -110,9 +106,7 @@ class TestJob(unittest.TestCase):
 
     # flux job list-inactive make sure one job is read from RPC
     def test_03_list_inactive_success(self):
-        rpc_handle = flux.job.job_list_inactive(
-            self.fh, time.time() - 3600, 10, self.attrs
-        )
+        rpc_handle = flux.job.job_list_inactive(self.fh, time.time() - 3600, 10)
 
         jobs = self.getJobs(rpc_handle)
 
@@ -137,9 +131,7 @@ class TestJob(unittest.TestCase):
     # flux job list-inactive multiple jobs submitted should return a
     # longer list of inactive jobs
     def test_05_list_inactive_multiple_inactive(self):
-        rpc_handle = flux.job.job_list_inactive(
-            self.fh, time.time() - 3600, 20, self.attrs
-        )
+        rpc_handle = flux.job.job_list_inactive(self.fh, time.time() - 3600, 20)
 
         jobs = self.getJobs(rpc_handle)
 
@@ -147,7 +139,7 @@ class TestJob(unittest.TestCase):
 
     # flux job list-inactive with since = 0.0 should return all inactive jobs
     def test_06_list_inactive_all(self):
-        rpc_handle = flux.job.job_list_inactive(self.fh, 0.0, 20, self.attrs)
+        rpc_handle = flux.job.job_list_inactive(self.fh, 0.0, 20)
 
         jobs = self.getJobs(rpc_handle)
 
@@ -155,7 +147,7 @@ class TestJob(unittest.TestCase):
 
     # flux job list-inactive with max_entries = 5 should only return a subset
     def test_07_list_inactive_subset_of_inactive(self):
-        rpc_handle = flux.job.job_list_inactive(self.fh, 0.0, 5, self.attrs)
+        rpc_handle = flux.job.job_list_inactive(self.fh, 0.0, 5)
 
         jobs = self.getJobs(rpc_handle)
 
@@ -169,9 +161,7 @@ class TestJob(unittest.TestCase):
 
         jobs = self.getJobs(rpc_handle)
 
-        rpc_handle = flux.job.job_list_inactive(
-            self.fh, jobs[0]["t_inactive"], 1, self.attrs
-        )
+        rpc_handle = flux.job.job_list_inactive(self.fh, jobs[0]["t_inactive"], 1)
 
         jobs_inactive = self.getJobs(rpc_handle)
 
@@ -185,9 +175,7 @@ class TestJob(unittest.TestCase):
 
         jobs = self.getJobs(rpc_handle)
 
-        rpc_handle = flux.job.job_list_inactive(
-            self.fh, jobs[1]["t_inactive"], 1, self.attrs
-        )
+        rpc_handle = flux.job.job_list_inactive(self.fh, jobs[1]["t_inactive"], 1)
 
         jobs_inactive = self.getJobs(rpc_handle)
 
@@ -202,9 +190,7 @@ class TestJob(unittest.TestCase):
 
         jobs = self.getJobs(rpc_handle)
 
-        rpc_handle = flux.job.job_list_inactive(
-            self.fh, jobs[4]["t_inactive"], 10, self.attrs
-        )
+        rpc_handle = flux.job.job_list_inactive(self.fh, jobs[4]["t_inactive"], 10)
 
         jobs_inactive = self.getJobs(rpc_handle)
 
@@ -218,9 +204,7 @@ class TestJob(unittest.TestCase):
 
         jobs = self.getJobs(rpc_handle)
 
-        rpc_handle = flux.job.job_list_inactive(
-            self.fh, jobs[5]["t_inactive"], 20, self.attrs
-        )
+        rpc_handle = flux.job.job_list_inactive(self.fh, jobs[5]["t_inactive"], 20)
 
         jobs_inactive = self.getJobs(rpc_handle)
 
@@ -234,9 +218,7 @@ class TestJob(unittest.TestCase):
 
         jobs = self.getJobs(rpc_handle)
 
-        rpc_handle = flux.job.job_list_inactive(
-            self.fh, jobs[7]["t_inactive"], 20, self.attrs
-        )
+        rpc_handle = flux.job.job_list_inactive(self.fh, jobs[7]["t_inactive"], 20)
 
         jobs_inactive = self.getJobs(rpc_handle)
 
@@ -251,15 +233,13 @@ class TestJob(unittest.TestCase):
         # 16 = 5 + 11 in previous tests
         self.waitForConsistency(16)
 
-        rpc_handle = flux.job.job_list_inactive(self.fh, 0.0, 20, self.attrs, "sleep")
+        rpc_handle = flux.job.job_list_inactive(self.fh, 0.0, 20, name="sleep")
 
         jobs_inactive = self.getJobs(rpc_handle)
 
         self.assertEqual(len(jobs_inactive), 11)
 
-        rpc_handle = flux.job.job_list_inactive(
-            self.fh, 0.0, 20, self.attrs, "hostname"
-        )
+        rpc_handle = flux.job.job_list_inactive(self.fh, 0.0, 20, name="hostname")
 
         jobs_inactive = self.getJobs(rpc_handle)
 

--- a/t/python/t0013-job-list.py
+++ b/t/python/t0013-job-list.py
@@ -44,7 +44,7 @@ class TestJob(unittest.TestCase):
         )
         compute_jobreq.cwd = os.getcwd()
         compute_jobreq.environment = dict(os.environ)
-        flux.job.submit(self.fh, compute_jobreq, waitable=True)
+        return flux.job.submit(self.fh, compute_jobreq, waitable=True)
 
     @classmethod
     def getJobs(self, rpc_handle):
@@ -76,8 +76,17 @@ class TestJob(unittest.TestCase):
 
     attrs = ["userid", "state", "name", "ntasks", "t_submit", "t_run", "t_inactive"]
 
-    # should return an empty list if there are no inactive jobs
-    def test_00_list_inactive_expect_empty_list(self):
+    # flux job list should return an empty list if there are no jobs
+    def test_00_list_expect_empty_list(self):
+        rpc_handle = flux.job.job_list(self.fh)
+
+        jobs = self.getJobs(rpc_handle)
+
+        self.assertEqual(len(jobs), 0)
+
+    # flux job list-inactive should return an empty list if there are
+    # no inactive jobs
+    def test_01_list_inactive_expect_empty_list(self):
         rpc_handle = flux.job.job_list_inactive(
             self.fh, time.time() - 3600, 10, self.attrs
         )
@@ -86,13 +95,21 @@ class TestJob(unittest.TestCase):
 
         self.assertEqual(len(jobs), 0)
 
-    # make sure one job is read from RPC
-    def test_01_list_inactive_success(self):
+    # flux job list make sure one job is read from RPC
+    def test_02_list_success(self):
         # submit a sleep 0 job
         self.submitJob()
 
         self.waitForConsistency(1)
 
+        rpc_handle = flux.job.job_list(self.fh)
+
+        jobs = self.getJobs(rpc_handle)
+
+        self.assertEqual(len(jobs), 1)
+
+    # flux job list-inactive make sure one job is read from RPC
+    def test_03_list_inactive_success(self):
         rpc_handle = flux.job.job_list_inactive(
             self.fh, time.time() - 3600, 10, self.attrs
         )
@@ -101,8 +118,9 @@ class TestJob(unittest.TestCase):
 
         self.assertEqual(len(jobs), 1)
 
-    # multiple jobs submitted should return a longer list of inactive jobs
-    def test_02_list_multiple_inactive(self):
+    # flux job list multiple jobs submitted should return a
+    # longer list of inactive jobs
+    def test_04_list_multiple_inactive(self):
         # submit a bundle of sleep 0 jobs
         for i in range(10):
             jobid = self.submitJob()
@@ -110,6 +128,15 @@ class TestJob(unittest.TestCase):
         # 11 = 10 + 1 in previous tests
         self.waitForConsistency(11)
 
+        rpc_handle = flux.job.job_list(self.fh)
+
+        jobs = self.getJobs(rpc_handle)
+
+        self.assertEqual(len(jobs), 11)
+
+    # flux job list-inactive multiple jobs submitted should return a
+    # longer list of inactive jobs
+    def test_05_list_inactive_multiple_inactive(self):
         rpc_handle = flux.job.job_list_inactive(
             self.fh, time.time() - 3600, 20, self.attrs
         )
@@ -119,7 +146,7 @@ class TestJob(unittest.TestCase):
         self.assertEqual(len(jobs), 11)
 
     # flux job list-inactive with since = 0.0 should return all inactive jobs
-    def test_03_list_all_inactive(self):
+    def test_06_list_inactive_all(self):
         rpc_handle = flux.job.job_list_inactive(self.fh, 0.0, 20, self.attrs)
 
         jobs = self.getJobs(rpc_handle)
@@ -127,7 +154,7 @@ class TestJob(unittest.TestCase):
         self.assertEqual(len(jobs), 11)
 
     # flux job list-inactive with max_entries = 5 should only return a subset
-    def test_04_list_subset_of_inactive(self):
+    def test_07_list_inactive_subset_of_inactive(self):
         rpc_handle = flux.job.job_list_inactive(self.fh, 0.0, 5, self.attrs)
 
         jobs = self.getJobs(rpc_handle)
@@ -135,7 +162,7 @@ class TestJob(unittest.TestCase):
         self.assertEqual(len(jobs), 5)
 
     # flux job list-inactive with the most recent timestamp should return len(0)
-    def test_05_most_recent_inactive(self):
+    def test_08_list_inactive_most_recent_inactive(self):
         rpc_handle = flux.job.job_list(
             self.fh, 1, ["t_inactive"], states=flux.constants.FLUX_JOB_STATE_INACTIVE
         )
@@ -151,7 +178,7 @@ class TestJob(unittest.TestCase):
         self.assertEqual(len(jobs_inactive), 0)
 
     # flux job list-inactive with second to most recent timestamp
-    def test_06_second_most_recent_timestamp(self):
+    def test_09_list_inactive_second_most_recent_timestamp(self):
         rpc_handle = flux.job.job_list(
             self.fh, 2, ["t_inactive"], states=flux.constants.FLUX_JOB_STATE_INACTIVE
         )
@@ -168,7 +195,7 @@ class TestJob(unittest.TestCase):
         self.assertEqual(jobs_inactive[0]["t_inactive"], jobs[0]["t_inactive"])
 
     # flux job list-inactive with oldest timestamp
-    def test_07_oldest_timestamp(self):
+    def test_10_list_inactive_oldest_timestamp(self):
         rpc_handle = flux.job.job_list(
             self.fh, 5, ["t_inactive"], states=flux.constants.FLUX_JOB_STATE_INACTIVE
         )
@@ -184,7 +211,7 @@ class TestJob(unittest.TestCase):
         self.assertEqual(len(jobs_inactive), 4)
 
     # flux job list-inactive with middle timestamp #1
-    def test_08_middle_timestamp_1(self):
+    def test_11_list_inactive_middle_timestamp_1(self):
         rpc_handle = flux.job.job_list(
             self.fh, 20, ["t_inactive"], states=flux.constants.FLUX_JOB_STATE_INACTIVE
         )
@@ -200,7 +227,7 @@ class TestJob(unittest.TestCase):
         self.assertEqual(len(jobs_inactive), 5)
 
     # flux job list-inactive with middle timestamp #2
-    def test_09_middle_timestamp_2(self):
+    def test_12_list_inactive_middle_timestamp_2(self):
         rpc_handle = flux.job.job_list(
             self.fh, 20, ["t_inactive"], states=flux.constants.FLUX_JOB_STATE_INACTIVE
         )
@@ -216,7 +243,7 @@ class TestJob(unittest.TestCase):
         self.assertEqual(len(jobs_inactive), 7)
 
     # flux job list-inactive with name filter
-    def test_10_name_filter(self):
+    def test_13_list_inactive_name_filter(self):
         # submit a bundle of hostname jobs
         for i in range(5):
             jobid = self.submitJob(["hostname"])
@@ -237,6 +264,29 @@ class TestJob(unittest.TestCase):
         jobs_inactive = self.getJobs(rpc_handle)
 
         self.assertEqual(len(jobs_inactive), 5)
+
+    # flux job list-id works
+    def test_14_list_id(self):
+        jobid = self.submitJob(["hostname"])
+
+        self.waitForConsistency(17)
+
+        rpc_handle = flux.job.job_list_id(self.fh, jobid)
+
+        job = rpc_handle.get_job()
+        self.assertEqual(job["id"], jobid)
+
+    # flux job list-id fails on bad id
+    def test_15_list_id_fail(self):
+        rpc_handle = flux.job.job_list_id(self.fh, 123456789)
+        notfound = False
+
+        try:
+            jobinfo = rpc_handle.get_jobinfo()
+        except FileNotFoundError:
+            notfound = True
+
+        self.assertEqual(notfound, True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Following up #4757, all of the python list functions return all attributes by default, instead of no entries.  This is the more obvious / expected behavior users should expect.