### PR TITLE
allow guests to access flux configuration

### DIFF
--- a/doc/man1/flux-config.rst
+++ b/doc/man1/flux-config.rst
@@ -31,7 +31,6 @@ if *NAME* is unspecified, it dumps the entire configuration object.  Otherwise,
 *NAME* is expected to be a period-delimited path name representing a TOML key.
 Return values are printed in string-encoded JSON form, except for string values,
 which are printed without quotes to simplify their use in shell scripts.
-This command is restricted to the instance owner.
 
 ``flux config builtin`` prints compiled-in Flux configuration values.
 See BUILTIN VALUES below for a list of builtin

--- a/src/broker/brokercfg.c
+++ b/src/broker/brokercfg.c
@@ -606,7 +606,7 @@ error:
 static const struct flux_msg_handler_spec htab[] = {
     { FLUX_MSGTYPE_REQUEST,  "config.reload", reload_cb, 0 },
     { FLUX_MSGTYPE_REQUEST,  "config.load", load_cb, 0 },
-    { FLUX_MSGTYPE_REQUEST,  "config.get", get_cb, 0 },
+    { FLUX_MSGTYPE_REQUEST,  "config.get", get_cb, FLUX_ROLE_USER },
     FLUX_MSGHANDLER_TABLE_END,
 };
 

--- a/t/t2806-config-cmd.t
+++ b/t/t2806-config-cmd.t
@@ -19,6 +19,11 @@ EOF
 
 test_under_flux 1 minimal -o,--config-path=$(pwd)/config
 
+runas_guest() {
+        local userid=$(($(id -u)+1))
+        FLUX_HANDLE_USERID=$userid FLUX_HANDLE_ROLEMASK=0x2 "$@"
+}
+
 test_expect_success 'flux-config with no args fails with message' '
 	test_must_fail flux config 2>noargs.out &&
 	grep "missing subcommand" noargs.out
@@ -175,6 +180,18 @@ test_expect_success 'flux-config builtin fails on unknown key' '
 '
 test_expect_success 'flux-config builtin works on known key' '
 	flux config builtin rc1_path
+'
+test_expect_success 'flux-config get works as guest' '
+	runas_guest flux config get >obj
+'
+test_expect_success 'flux-config load fails as guest' '
+	test_must_fail runas_guest flux config load <obj
+'
+test_expect_success 'flux-config reload fails as guest' '
+	test_must_fail runas_guest flux config reload
+'
+test_expect_success 'flux-config builtin works as guest' '
+	runas_guest flux config builtin rc1_path
 '
 
 test_done


### PR DESCRIPTION
broker: allow guests to use config.get RPC

Problem: Flux command line utilities may require access to [policy]
and [queues] TOML config for proper display of limits and queue
resources.

Open the config.get RPC to guests.