### PR TITLE
content: cleanup and minor tooling updates

### DIFF
--- a/doc/man1/flux-content.rst
+++ b/doc/man1/flux-content.rst
@@ -6,9 +6,9 @@ flux-content(1)
 SYNOPSIS
 ========
 
-**flux** **content** **load** [*--bypass-cache*] *blobref*
+**flux** **content** **load** [*--bypass-cache*] [*blobref* ...]
 
-**flux** **content** **store** [*--bypass-cache*]
+**flux** **content** **store** [*--bypass-cache*] [*--chunksize=N*]
 
 **flux** **content** **flush**
 
@@ -21,13 +21,15 @@ Each Flux instance implements an append-only, content addressable
 storage service, which stores blobs of arbitrary content under
 message digest keys termed "blobrefs".
 
-**flux content store** accepts a blob on standard input, stores it,
-and prints the blobref on standard output.
+**flux content store** reads data from standard input to EOF, stores it
+(possibly splitting into multiple blobs), and prints blobref(s) on
+standard output, one per line.
 
-**flux content load** accepts a blobref argument, retrieves the
-corresponding blob, and writes it to standard output.
+**flux content load** reads blobrefs from standard input, one per line, or
+parses blobrefs on the command line (but not both).  It then loads the
+corresponding blob(s), and concatenates them on standard output.
 
-After a store operation completes on any rank, the blob may be
+After a store operation completes on any rank, the blobs may be
 retrieved from any other rank.
 
 The content service includes a cache on each broker which improves
@@ -46,6 +48,9 @@ OPTIONS
 **-b, --bypass-cache**
    Bypass the in-memory cache, and directly access the backing store,
    if available (see below).
+
+**--chunksize**\ =\ *N*
+   Split a blob into chunks of *N* bytes (store only).
 
 
 BACKING STORE

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -663,3 +663,4 @@ RLIMIT
 rtprio
 rttime
 sigpending
+chunksize

--- a/src/broker/content-cache.c
+++ b/src/broker/content-cache.c
@@ -420,8 +420,6 @@ void content_load_request (flux_t *h, flux_msg_handler_t *mh,
     struct content_cache *cache = arg;
     const void *hash;
     int hash_size;
-    void *data = NULL;
-    int len = 0;
     struct cache_entry *e;
 
     if (flux_request_decode_raw (msg, NULL, &hash, &hash_size) < 0)
@@ -449,9 +447,7 @@ void content_load_request (flux_t *h, flux_msg_handler_t *mh,
         }
         return; /* RPC continuation will respond to msg */
     }
-    data = e->data;
-    len = e->len;
-    if (flux_respond_raw (h, msg, data, len) < 0)
+    if (flux_respond_raw (h, msg, e->data, e->len) < 0)
         flux_log_error (h, "content load: flux_respond_raw");
     return;
 error:

--- a/src/broker/content-cache.c
+++ b/src/broker/content-cache.c
@@ -414,8 +414,8 @@ static int cache_load (struct content_cache *cache, struct cache_entry *e)
     return 0;
 }
 
-void content_load_request (flux_t *h, flux_msg_handler_t *mh,
-                           const flux_msg_t *msg, void *arg)
+static void content_load_request (flux_t *h, flux_msg_handler_t *mh,
+                                  const flux_msg_t *msg, void *arg)
 {
     struct content_cache *cache = arg;
     const void *hash;

--- a/src/broker/content-checkpoint.c
+++ b/src/broker/content-checkpoint.c
@@ -1,5 +1,5 @@
 /************************************************************\
- * Copyright 2015 Lawrence Livermore National Security, LLC
+ * Copyright 2022 Lawrence Livermore National Security, LLC
  * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
  *
  * This file is part of the Flux resource manager framework.

--- a/src/broker/content-checkpoint.h
+++ b/src/broker/content-checkpoint.h
@@ -1,5 +1,5 @@
 /************************************************************\
- * Copyright 2015 Lawrence Livermore National Security, LLC
+ * Copyright 2022 Lawrence Livermore National Security, LLC
  * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
  *
  * This file is part of the Flux resource manager framework.

--- a/src/cmd/builtin/content.c
+++ b/src/cmd/builtin/content.c
@@ -33,6 +33,39 @@ static void load_to_fd (flux_t *h, int fd, const char *blobref, int flags)
     flux_future_destroy (f);
 }
 
+static void store_blob (flux_t *h, const void *data, size_t size, int flags)
+{
+    flux_future_t *f;
+    const char *blobref;
+
+    if (!(f = content_store (h, data, size, flags))
+        || content_store_get_blobref (f, &blobref) < 0)
+        log_msg_exit ("error storing blob: %s", future_strerror (f, errno));
+    printf ("%s\n", blobref);
+    flux_future_destroy (f);
+}
+
+static void store_from_fd (flux_t *h, int fd, size_t chunksize, int flags)
+{
+    void *data;
+    ssize_t total_size;
+
+    if ((total_size = read_all (fd, &data)) < 0)
+        log_err_exit ("read from stdin");
+    if (chunksize == 0)
+        chunksize = total_size;
+    if (total_size == 0) // an empty blob is still valid
+        store_blob (h, data, total_size, flags);
+    else {
+        for (off_t offset = 0; offset < total_size; offset += chunksize) {
+            if (chunksize > total_size - offset)
+                chunksize = total_size - offset;
+            store_blob (h, data + offset, chunksize, flags);
+        }
+    }
+    free (data);
+}
+
 static int internal_content_load (optparse_t *p, int ac, char *av[])
 {
     int n;
@@ -67,14 +100,11 @@ static int internal_content_load (optparse_t *p, int ac, char *av[])
 
 static int internal_content_store (optparse_t *p, int ac, char *av[])
 {
-    uint8_t *data;
-    int size;
     flux_t *h;
-    flux_future_t *f;
-    const char *blobref;
     int flags = 0;
+    int chunksize = optparse_get_int (p, "chunksize", 0);
 
-    if (optparse_option_index (p)  != ac) {
+    if (optparse_option_index (p) != ac || chunksize < 0) {
         optparse_print_usage (p);
         exit (1);
     }
@@ -82,16 +112,8 @@ static int internal_content_store (optparse_t *p, int ac, char *av[])
         flags |= CONTENT_FLAG_CACHE_BYPASS;
     if (!(h = builtin_get_flux_handle (p)))
         log_err_exit ("flux_open");
-    if ((size = read_all (STDIN_FILENO, (void **)&data)) < 0)
-        log_err_exit ("read");
-    if (!(f = content_store (h, data, size, flags)))
-        log_err_exit ("content_store");
-    if (content_store_get_blobref (f, &blobref) < 0)
-        log_err_exit ("content_store_get_blobref");
-    printf ("%s\n", blobref);
-    flux_future_destroy (f);
+    store_from_fd (h, STDIN_FILENO, chunksize, flags);
     flux_close (h);
-    free (data);
     return (0);
 }
 
@@ -153,7 +175,9 @@ static struct optparse_option load_opts[] = {
 static struct optparse_option store_opts[] = {
     { .name = "bypass-cache",  .key = 'b',  .has_arg = 0,
       .usage = "Store directly to rank 0 content service", },
-      OPTPARSE_TABLE_END,
+    { .name = "chunksize", .has_arg = 1, .arginfo = "N",
+      .usage = "Limit blob size to N bytes with 0=unlimited (default 0)", },
+      OPTPARSE_TABLE_END
 };
 
 static struct optparse_subcommand content_subcmds[] = {
@@ -166,7 +190,7 @@ static struct optparse_subcommand content_subcmds[] = {
     },
     { "store",
       "[OPTIONS]",
-      "Store blob from stdin, print BLOBREF on stdout",
+      "Store blob from stdin, print BLOBREF(s) on stdout",
       internal_content_store,
       0,
       store_opts,

--- a/t/t0017-security.t
+++ b/t/t0017-security.t
@@ -333,7 +333,7 @@ test_expect_success 'store a value with content service' '
 test_expect_success 'flux content load not allowed for guest user' '
 	test_must_fail bash -c "FLUX_HANDLE_ROLEMASK=0x2 \
 	    flux content load $(cat content.blobref) 2>content-load.err" &&
-	    grep "not permitted" content-load.err
+	    grep "Request requires owner credentials" content-load.err
 '
 
 test_expect_success 'flux content store not allowed for guest user' '

--- a/t/t0017-security.t
+++ b/t/t0017-security.t
@@ -339,7 +339,7 @@ test_expect_success 'flux content load not allowed for guest user' '
 test_expect_success 'flux content store not allowed for guest user' '
 	test_must_fail bash -c "FLUX_HANDLE_ROLEMASK=0x2 \
 	    flux content store <content.blob 2>content-store.err" &&
-	    grep "not permitted" content-store.err
+	    grep "Request requires owner credentials" content-store.err
 '
 
 test_done


### PR DESCRIPTION
This splits off some broker content service cleanup from #4546, and also adds support to flux-content(1) for "split content" which will be used in tests to be written for #4546 and shouldn't break any existing uses of the command.