### PR TITLE
support cyclic, manual job taskmaps and `flux job taskmap` command

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -91,6 +91,12 @@ LIBFLUX_HOSTLIST_AGE=0
 LIBFLUX_HOSTLIST_VERSION_INFO=$LIBFLUX_HOSTLIST_CURRENT:$LIBFLUX_HOSTLIST_REVISION:$LIBFLUX_HOSTLIST_AGE
 AC_SUBST([LIBFLUX_HOSTLIST_VERSION_INFO])
 
+LIBFLUX_TASKMAP_CURRENT=1
+LIBFLUX_TASKMAP_REVISION=0
+LIBFLUX_TASKMAP_AGE=0
+LIBFLUX_TASKMAP_VERSION_INFO=$LIBFLUX_TASKMAP_CURRENT:$LIBFLUX_TASKMAP_REVISION:$LIBFLUX_TASKMAP_AGE
+AC_SUBST([LIBFLUX_TASKMAP_VERSION_INFO])
+
 ##
 # Checks for programs
 ##
@@ -533,6 +539,7 @@ AC_CONFIG_FILES( \
   src/common/libczmqcontainers/Makefile \
   src/common/libccan/Makefile \
   src/common/libzmqutil/Makefile \
+  src/common/libtaskmap/Makefile \
   src/bindings/Makefile \
   src/bindings/lua/Makefile \
   src/bindings/python/Makefile \

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -66,6 +66,7 @@ MAN3_FILES_PRIMARY = \
 	man3/flux_shell_get_hwloc_xml.3 \
 	man3/flux_shell_get_info.3 \
 	man3/flux_shell_get_jobspec_info.3 \
+	man3/flux_shell_get_taskmap.3 \
 	man3/flux_shell_getenv.3 \
 	man3/flux_shell_getopt.3 \
 	man3/flux_shell_killall.3 \

--- a/doc/man1/flux-job.rst
+++ b/doc/man1/flux-job.rst
@@ -20,6 +20,8 @@ SYNOPSIS
 
 **flux** **job** **raiseall** [*OPTIONS*] *type* [*message...*]
 
+**flux** **job** **taskmap** [*OPTIONS*] *id*|*taskmap*
+
 **flux** **job** **purge** [*OPTIONS*]
 
 DESCRIPTION
@@ -107,6 +109,40 @@ type (positional argument) and accepts the following options:
 **-f, --force**
    Confirm the command.
 
+TASKMAP
+=======
+
+The mapping between job task ranks to node IDs is encoded in the RFC 34
+Flux Task Map format and posted to the job's ``shell.start`` event in the
+exec eventlog. The ``flux job taskmap`` utility is provided to assist in
+working with these task maps.
+
+When executed with a jobid argument and no options, the taskmap for the job
+is printed after the ``shell.start`` event has been posted.
+
+With one of the following arguments, the job taskmap may be used to convert
+a nodeid to a list of tasks, or to query on which node or host a given
+taskid ran. The command may also be used to convert between different
+support task mapping formats:
+
+**--taskids=NODEID**
+   Print an idset of tasks which ran on node  *NODEID*
+
+**--ntasks=NODEID**
+   Print the number of tasks  which ran on node *NODEID*
+
+**--nodeid=TASKID**
+   Print the node ID that ran task *TASKID*
+
+**--hostname=TASKID**
+   Print the hostname of the node that rank task *TASKID*
+
+**--to=raw|pmi|multiline**
+   Convert the taskmap to *raw* or *pmi* formats (described in RFC 34), or
+   *multiline* which prints the node ID of each task, one per line.
+
+One one of the above options may be used per call.
+
 PURGE
 =====
 
@@ -130,4 +166,6 @@ RESOURCES
 =========
 
 Flux: http://flux-framework.org
+
+RFC 34: Flux Task Map: https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/spec_34.html
 

--- a/doc/man1/flux-mini.rst
+++ b/doc/man1/flux-mini.rst
@@ -495,6 +495,28 @@ OTHER OPTIONS
    is accepted, e.g. ``2021-06-21 8am``, ``in an hour``,
    ``tomorrow morning``, etc.
 
+**--taskmap=SCHEME[:VALUE]**
+   Choose an alternate method for mapping job task IDs to nodes of the
+   job. The job shell maps tasks using a "block" distribution scheme by
+   default (consecutive tasks share nodes) This option allows the
+   activation of alternate schemes by name, including an optional *VALUE*.
+   Supported schemes which are built in to the job shell include
+
+   cyclic[:N]
+    Tasks are distributed over consecutive nodes with a stride of *N*
+    (where N=1 by default).
+
+   manual:TASKMAP
+    An explicit RFC 34 taskmap is provided and used to manually map
+    task ids to nodes. The provided *TASKMAP* must match the total number
+    of tasks in the job and the number of tasks per node assigned by
+    the job shell, so this option is not useful unless the total number
+    of nodes and tasks per node are known at job submission time.
+
+   However, shell plugins may provide other task mapping schemes, so
+   check the current job shell configuration for a full list of supported
+   taskmap schemes.
+
 **--dry-run**
    Don't actually submit job. Just emit jobspec on stdout and exit for
    ``run``, ``submit``, ``alloc``, and ``batch``. For ``bulksubmit``,

--- a/doc/man1/flux-shell.rst
+++ b/doc/man1/flux-shell.rst
@@ -138,6 +138,17 @@ file itself (see INITRC section, ``plugin.register()`` below)
 
 By default, flux-shell supports the following plugin callback topics:
 
+**taskmap.SCHEME**
+  Called when a taskmap scheme *SCHEME* is requested via the taskmap
+  shell option or corresponding ``--taskmap`` ``flux-mini`` option.
+  Plugins that want to offer a different taskmap scheme than the defaults
+  of ``block``, ``cyclic``, and ``manual`` can register a ``taskmap.*``
+  plugin callback and then users can request this mapping with the
+  appropriate ``--taskmap=name`` option. The default block taskmap is
+  passed to the plugin as "taskmap" in the plugin input arguments, and
+  the plugin should return the new taskmap as a string in the output args.
+  This callback is called before ``shell.init``.
+
 **shell.connect**
   Called just after the shell connects to the local Flux broker. (Only
   available to builtin shell plugins.)
@@ -300,6 +311,14 @@ options are supported by the builtin plugins of ``flux-shell``:
   name without the ``RLIMIT_`` prefix, e.g. ``core`` or ``nofile``. Users
   should not need to set this shell option as it is handled by commands
   like ``flux-mini``.
+
+**taskmap**
+  Request an alternate job task mapping. This option is an object
+  consisting of required key ``scheme`` and optional key ``value``. The
+  shell will attempt to call a ``taskmap.scheme`` plugin callback in the
+  shell to invoke the alternate requested mapping. If ``value`` is set,
+  this will also be passed to the invoked plugin. Normally, this option will
+  be set by the ``flux mini --taskmap`` option.
 
 SHELL INITRC
 ============

--- a/doc/man3/flux_shell_get_taskmap.rst
+++ b/doc/man3/flux_shell_get_taskmap.rst
@@ -1,0 +1,48 @@
+=========================
+flux_shell_get_taskmap(3)
+=========================
+
+
+SYNOPSIS
+========
+
+::
+
+   #include <flux/shell.h>
+   #include <errno.h>
+
+::
+
+   const struct taskmap * flux_shell_get_taskmap (flux_shell_t *shell);
+
+
+DESCRIPTION
+===========
+
+``flux_shell_get_taskmap()`` returns the current shell task map. The
+task map can be used to map job task ranks to node IDs and get the set
+of tasks assigned to any node ID. The returned ``struct taskmap`` object
+can be queried via the functions exported in ``libflux-taskmap.so``.
+
+
+RETURN VALUE
+============
+
+This function returns a pointer to the shell's internal ``struct taskmap``
+or ``NULL`` on failure with ``errno`` set.
+
+
+ERRORS
+======
+
+EINVAL
+   if ``shell`` is NULL or the function is called before the initial taskmap
+   is set by the shell.
+
+
+RESOURCES
+=========
+
+Flux: http://flux-framework.org
+
+RFC 34 - Flux Task Map: https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/spec_34.html

--- a/doc/manpages.py
+++ b/doc/manpages.py
@@ -219,6 +219,7 @@ man_pages = [
     ('man3/flux_shell_get_info', 'flux_shell_get_info', 'Manage shell info and rank info', [author], 3),
     ('man3/flux_shell_get_jobspec_info', 'flux_shell_jobspec_info_unpack', 'Manage shell jobspec summary information', [author], 3),
     ('man3/flux_shell_get_jobspec_info', 'flux_shell_get_jobspec_info', 'Manage shell jobspec summary information', [author], 3),
+    ('man3/flux_shell_get_taskmap', 'flux_shell_get_taskmap', 'Get shell task mapping', [author], 3),
     ('man3/flux_shell_getenv', 'flux_shell_get_environ', 'Get and set global environment variables', [author], 3),
     ('man3/flux_shell_getenv', 'flux_shell_setenvf', 'Get and set global environment variables', [author], 3),
     ('man3/flux_shell_getenv', 'flux_shell_unsetenv', 'Get and set global environment variables', [author], 3),

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -664,3 +664,5 @@ rtprio
 rttime
 sigpending
 chunksize
+taskmap
+multiline

--- a/etc/completions/flux.pre
+++ b/etc/completions/flux.pre
@@ -304,6 +304,18 @@ _flux_resource()
     return 0
 }
 
+_flux_complete_taskmap_name() {
+    if [[ "$prev" == "--to" || "$cur" == "--to"* ]]; then
+        local formats="pmi raw multiline"
+        if [[ "$cur" == "--to"* ]]; then
+            formats=$(printf -- '--to=%s ' $formats)
+        fi
+        _flux_compgen_with_equals "${formats}"
+        return 0
+    fi
+    return 1
+}
+
 # flux-job(1) completions
 _flux_job()
 {
@@ -420,11 +432,16 @@ _flux_job()
     "
     if [[ $cmd != "job" ]]; then
         if [[ $cur != -* ]]; then
-            if _flux_contains_word ${cmd} ${subcmds}; then
+           if _flux_contains_word ${cmd} ${subcmds}; then
                 #  These commands take active jobids by default:
                 compopt +o filenames
                 active_jobs=$(flux jobs -no {id})
                 COMPREPLY=( $(compgen -W "${active_jobs}" -- "$cur") )
+                return 0
+            fi
+        fi
+        if _flux_contains_word "taskmap" "${COMP_WORDS[@]}"; then
+            if _flux_complete_taskmap_name; then
                 return 0
             fi
         fi

--- a/etc/completions/flux.pre
+++ b/etc/completions/flux.pre
@@ -168,6 +168,7 @@ _flux_mini()
         --tasks-per-core= \
         --gpus-per-node= \
         -v --verbose \
+        --taskmap= \
     "
     local BATCH_ALLOC_OPTIONS="\
         -n --nslots= \
@@ -335,6 +336,7 @@ _flux_job()
         namespace \
         wait \
         memo \
+        taskmap \
     "
     local nojob_subcmds="\
         cancelall \
@@ -423,6 +425,13 @@ _flux_job()
     "
     local memo_OPTS="\
         --volatile
+    "
+    local taskmap_OPTS="\
+        --taskids= \
+        --ntasks= \
+        --nodeid= \
+        --hostname= \
+        --to= \
     "
     local purge_OPTS="\
         --age-limit= \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -13,4 +13,5 @@ noinst_HEADERS = \
 	include/flux/schedutil.h \
 	include/flux/shell.h \
 	include/flux/hostlist.h \
-	include/flux/jobtap.h
+	include/flux/jobtap.h \
+	include/flux/taskmap.h

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -29,6 +29,8 @@
 #include <argz.h>
 #include <flux/core.h>
 #include <flux/optparse.h>
+#include <flux/hostlist.h>
+#include <flux/taskmap.h>
 #if HAVE_FLUX_SECURITY
 #include <flux/security/sign.h>
 #endif
@@ -47,6 +49,8 @@
 #include "src/shell/mpir/proctable.h"
 #include "src/common/libdebugged/debugged.h"
 #include "src/common/libterminus/pty.h"
+#include "src/common/libtaskmap/taskmap_private.h"
+#include "src/common/librlist/rlist.h"
 #include "ccan/str/str.h"
 
 #ifndef VOLATILE
@@ -94,6 +98,7 @@ int cmd_stats (optparse_t *p, int argc, char **argv);
 int cmd_wait (optparse_t *p, int argc, char **argv);
 int cmd_memo (optparse_t *p, int argc, char **argv);
 int cmd_purge (optparse_t *p, int argc, char **argv);
+int cmd_taskmap (optparse_t *p, int argc, char **argv);
 
 int stdin_flags;
 
@@ -373,6 +378,24 @@ static struct optparse_option purge_opts[] = {
     OPTPARSE_TABLE_END
 };
 
+static struct optparse_option taskmap_opts[] = {
+    { .name = "taskids", .has_arg = 1, .arginfo = "NODEID",
+      .usage = "Print idset of tasks on node NODEID",
+    },
+    { .name = "ntasks", .has_arg = 1, .arginfo = "NODEID",
+      .usage = "Print number of tasks on node NODEID",
+    },
+    { .name = "nodeid", .has_arg = 1, .arginfo = "TASKID",
+      .usage = "Print the shell rank/nodeid on which a taskid executed",
+    },
+    { .name = "hostname", .has_arg = 1, .arginfo = "TASKID",
+      .usage = "Print the hostname on which a taskid executed",
+    },
+    { .name = "to", .has_arg = 1, .arginfo="raw|pmi",
+      .usage = "Convert an RFC 34 taskmap to another form",
+    },
+};
+
 static struct optparse_subcommand subcommands[] = {
     { "list",
       "[OPTIONS]",
@@ -521,6 +544,13 @@ static struct optparse_subcommand subcommands[] = {
       cmd_memo,
       0,
       memo_opts,
+    },
+    { "taskmap",
+      "[OPTION] JOBID|TASKMAP",
+      "Utility function for working with job task maps",
+      cmd_taskmap,
+      0,
+      taskmap_opts,
     },
     { "purge",
       "[--age-limit=FSD] [--num-limit=N]",
@@ -3353,6 +3383,162 @@ int cmd_purge (optparse_t *p, int argc, char **argv)
     flux_close (h);
 
     return rc;
+}
+
+static struct taskmap *flux_job_taskmap (flux_jobid_t id)
+{
+    struct taskmap *map;
+    flux_t *h;
+    flux_future_t *f;
+
+    if (!(h = flux_open (NULL, 0)))
+        log_err_exit ("flux_open");
+
+    if (!(f = flux_job_event_watch (h, id, "guest.exec.eventlog", 0)))
+        log_err_exit ("flux_job_event_watch");
+    while (true) {
+        json_t *o;
+        json_t *context;
+        const char *event;
+        const char *name;
+        if (flux_job_event_watch_get (f, &event) < 0) {
+            if (errno == ENODATA)
+                log_msg_exit ("No taskmap found for job");
+            if (errno == ENOENT)
+                log_msg_exit ("Unable to get job taskmap: no such job");
+            log_msg_exit ("waiting for shell.start event: %s",
+                          future_strerror (f, errno));
+        }
+        if (!(o = eventlog_entry_decode (event)))
+            log_err_exit ("eventlog_entry_decode");
+        if (eventlog_entry_parse (o, NULL, &name, &context) < 0)
+            log_err_exit ("eventlog_entry_parse");
+        if (streq (name, "shell.start")) {
+            flux_error_t error;
+            json_t *omap;
+            if (!(omap = json_object_get (context, "taskmap"))
+                || !(map = taskmap_decode_json (omap, &error)))
+                log_msg_exit ("failed to get taskmap from shell.start event");
+            json_decref (o);
+            flux_job_event_watch_cancel (f);
+            break;
+        }
+        json_decref (o);
+        flux_future_reset (f);
+    }
+    flux_future_destroy (f);
+    flux_close (h);
+    return map;
+}
+
+static char *flux_job_nodeid_to_hostname (flux_jobid_t id, int nodeid)
+{
+    flux_t *h;
+    flux_future_t *f;
+    char *result;
+    const char *host;
+    const char *R;
+    struct rlist *rl;
+    struct hostlist *hl;
+
+    if (!(h = flux_open (NULL, 0)))
+        log_err_exit ("flux_open");
+
+    if (!(f = flux_rpc_pack (h, "job-info.lookup", FLUX_NODEID_ANY, 0,
+                            "{s:I s:[s] s:i}",
+                            "id", id,
+                            "keys", "R",
+                            "flags", 0)))
+        log_err_exit ("flux_rpc_pack");
+    if (flux_rpc_get_unpack (f, "{s:s}", "R", &R) < 0
+        || !(rl = rlist_from_R (R))
+        || !(hl = rlist_nodelist (rl)))
+        log_err_exit ("failed to get hostlist for job");
+    if (!(host = hostlist_nth (hl, nodeid)))
+        log_err_exit ("failed to get hostname for node %d", nodeid);
+    result = strdup (host);
+    hostlist_destroy (hl);
+    rlist_destroy (rl);
+    flux_future_destroy (f);
+    return result;
+}
+
+int cmd_taskmap (optparse_t *p, int argc, char **argv)
+{
+    int optindex = optparse_option_index (p);
+    struct taskmap *map = NULL;
+    int val;
+    const char *to;
+    char *s;
+    flux_jobid_t id;
+
+    if (flux_job_id_parse (argv[optindex], &id) < 0) {
+        flux_error_t error;
+        if (!(map = taskmap_decode (argv[optindex], &error)))
+            log_msg_exit ("error decoding taskmap: %s", error.text);
+    }
+    else
+        map = flux_job_taskmap (id);
+
+    if ((val = optparse_get_int (p, "taskids", -1)) != -1) {
+        const struct idset *ids = taskmap_taskids (map, val);
+        if (!ids || !(s = idset_encode (ids, IDSET_FLAG_RANGE)))
+            log_err_exit ("No taskids for node %d", val);
+        printf ("%s\n", s);
+        free (s);
+        taskmap_destroy (map);
+        return 0;
+    }
+    if ((val = optparse_get_int (p, "ntasks", -1)) != -1) {
+        int result = taskmap_ntasks (map, val);
+        if (result < 0)
+            log_err_exit ("failed to get task count for node %d", val);
+        printf ("%d\n", result);
+        taskmap_destroy (map);
+        return 0;
+    }
+    if ((val = optparse_get_int (p, "nodeid", -1)) != -1
+        || (val = optparse_get_int (p, "hostname", -1)) != -1) {
+        int result = taskmap_nodeid (map, val);
+        if (result < 0)
+            log_err_exit ("failed to get nodeid for task %d", val);
+        if (optparse_hasopt (p, "hostname")) {
+            char *host = flux_job_nodeid_to_hostname (id, result);
+            printf ("%s\n", host);
+            free (host);
+        }
+        else
+            printf ("%d\n", result);
+        taskmap_destroy (map);
+        return 0;
+    }
+    if ((to = optparse_get_str (p, "to", NULL))) {
+        if (streq (to, "raw"))
+            s = taskmap_encode (map, TASKMAP_ENCODE_RAW);
+        else if (streq (to, "pmi"))
+            s = taskmap_encode (map, TASKMAP_ENCODE_PMI);
+        else if (streq (to, "multiline")) {
+            for (int i = 0; i < taskmap_total_ntasks (map); i++) {
+                printf ("%d: %d\n", i, taskmap_nodeid (map, i));
+            }
+            taskmap_destroy (map);
+            return 0;
+        }
+        else
+            log_msg_exit ("invalid value --to=%s", to);
+        if (s == NULL)
+            log_err_exit ("failed to convert taskmap to %s", to);
+        printf ("%s\n", s);
+        free (s);
+        taskmap_destroy (map);
+        return 0;
+    }
+    if (!(s = taskmap_encode (map, 0)))
+        log_err_exit ("taskmap_encode");
+    printf ("%s\n", s);
+    free (s);
+    taskmap_destroy (map);
+    return 0;
 }
 
 /*

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -391,8 +391,9 @@ static struct optparse_option taskmap_opts[] = {
     { .name = "hostname", .has_arg = 1, .arginfo = "TASKID",
       .usage = "Print the hostname on which a taskid executed",
     },
-    { .name = "to", .has_arg = 1, .arginfo="raw|pmi",
-      .usage = "Convert an RFC 34 taskmap to another form",
+    { .name = "to", .has_arg = 1, .arginfo="FORMAT",
+      .usage = "Convert an RFC 34 taskmap to another format "
+               "(FORMAT can be raw, pmi, or multiline)",
     },
 };
 
@@ -3472,6 +3473,10 @@ int cmd_taskmap (optparse_t *p, int argc, char **argv)
     char *s;
     flux_jobid_t id;
 
+    if (optindex == argc) {
+        optparse_print_usage (p);
+        exit (1);
+    }
     if (flux_job_id_parse (argv[optindex], &id) < 0) {
         flux_error_t error;
         if (!(map = taskmap_decode (argv[optindex], &error)))

--- a/src/cmd/flux-mini.py
+++ b/src/cmd/flux-mini.py
@@ -33,20 +33,25 @@ from flux.progress import ProgressBar
 from flux.uri import JobURI
 
 
-class Dependency:
+class URIArg:
     """Convenience class for handling dependencies
 
     Splits a dependency URI into fields and returns an RFC 26 dependency
     entry via the entry attribute.
     """
 
-    def __init__(self, uri):
+    def __init__(self, uri, name):
+        # append `:` if missing in uri so that a plain string is treated as
+        # a scheme with no path.
+        if ":" not in uri:
+            uri += ":"
+
         # replace first ':' with ':FXX' to work around urlparse refusal
         # to treat integer only path as a scheme:path.
         self.uri = urlparse(uri.replace(":", ":FXX", 1))
 
         if not self.uri.scheme or not self.uri.path:
-            raise ValueError(f'Invalid dependency URI "{uri}"')
+            raise ValueError(f'Invalid {name} URI "{uri}"')
 
         self.path = self.uri.path.replace("FXX", "", 1)
         self.scheme = self.uri.scheme
@@ -81,7 +86,7 @@ class Dependency:
 def dependency_array_create(uris):
     dependencies = []
     for uri in uris:
-        dependencies.append(Dependency(uri).entry)
+        dependencies.append(URIArg(uri, "dependency").entry)
     return dependencies
 
 

--- a/src/cmd/flux-mini.py
+++ b/src/cmd/flux-mini.py
@@ -314,6 +314,7 @@ class Xcmd:
         "log": "--log=",
         "log_stderr": "--log-stderr=",
         "dependency": "--dependency=",
+        "taskmap": "--taskmap=",
         "requires": "--requires=",
         "wait": "--wait-event=",
     }
@@ -695,6 +696,13 @@ class MiniCmd:
         if rlimits:
             jobspec.setattr_shell_option("rlimit", rlimits)
 
+        # --taskmap is only defined for run/submit, but we check
+        # for it in the base jobspec_create() for convenience
+        if hasattr(args, "taskmap") and args.taskmap is not None:
+            jobspec.setattr_shell_option(
+                "taskmap", URIArg(args.taskmap, "taskmap").entry
+            )
+
         if args.dependency is not None:
             jobspec.setattr(
                 "system.dependencies", dependency_array_create(args.dependency)
@@ -826,6 +834,14 @@ class SubmitBaseCmd(MiniCmd):
 
     def __init__(self):
         super().__init__()
+        self.parser.add_argument(
+            "--taskmap",
+            type=str,
+            help="Select the scheme for mapping task ids to nodes as a URI "
+            + "(i.e. SCHEME[:VALUE]). Value options include block, cyclic, "
+            + "cyclic:N, or manual:TASKMAP (default: block)",
+            metavar="URI",
+        )
         group = self.parser.add_argument_group("Common resource options")
         group.add_argument(
             "-N", "--nodes", metavar="N", help="Number of nodes to allocate"

--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -24,7 +24,8 @@ SUBDIRS = \
 	librlist \
 	libczmqcontainers \
 	libccan \
-	libzmqutil
+	libzmqutil \
+	libtaskmap
 
 if HAVE_LIBSYSTEMD
 SUBDIRS += libsdprocess
@@ -53,6 +54,7 @@ libflux_internal_la_LIBADD = \
 	$(builddir)/libhostlist/libhostlist.la \
 	$(builddir)/libczmqcontainers/libczmqcontainers.la \
 	$(builddir)/libcontent/libcontent.la \
+	$(builddir)/libtaskmap/libtaskmap.la \
 	$(JANSSON_LIBS) \
 	$(LIBUUID_LIBS) \
 	$(LIBPTHREAD) \
@@ -65,7 +67,8 @@ lib_LTLIBRARIES = libflux-core.la \
 	libflux-optparse.la \
 	libflux-idset.la \
 	libflux-schedutil.la \
-	libflux-hostlist.la
+	libflux-hostlist.la \
+	libflux-taskmap.la
 
 fluxlib_LTLIBRARIES = libpmi.la libpmi2.la
 
@@ -126,6 +129,23 @@ libflux_hostlist_la_LDFLAGS = \
 	-shared -export-dynamic --disable-static \
 	$(san_ld_zdef_flag)
 
+libflux_taskmap_la_SOURCES =
+libflux_taskmap_la_LIBADD = \
+	$(builddir)/libtaskmap/libtaskmap.la \
+	$(builddir)/libczmqcontainers/libczmqcontainers.la  \
+	$(builddir)/libutil/libutil.la  \
+	$(builddir)/libccan/libccan.la  \
+	$(builddir)/libtomlc99/libtomlc99.la  \
+	$(builddir)/libyuarel/libyuarel.la  \
+	libflux-core.la \
+	libflux-idset.la \
+	$(JANSSON_LIBS)
+libflux_taskmap_la_LDFLAGS = \
+	-Wl,--version-script=$(srcdir)/libflux-taskmap.map \
+	-version-info @LIBFLUX_TASKMAP_VERSION_INFO@ \
+	-shared -export-dynamic --disable-static \
+	$(san_ld_zdef_flag)
+
 libpmi_la_SOURCES =
 libpmi_la_LIBADD = \
 	$(builddir)/libpmi/libpmi_client.la \
@@ -154,5 +174,6 @@ EXTRA_DIST = \
 	libflux-idset.map \
 	libflux-schedutil.map \
 	libflux-hostlist.map \
+	libflux-taskmap.map \
 	libpmi.map \
 	libpmi2.map

--- a/src/common/libflux-taskmap.map
+++ b/src/common/libflux-taskmap.map
@@ -1,0 +1,6 @@
+{ global:
+    taskmap_*;
+    __asan*;
+    local: *;
+};
+

--- a/src/common/libtaskmap/Makefile.am
+++ b/src/common/libtaskmap/Makefile.am
@@ -1,0 +1,47 @@
+AM_CFLAGS = \
+	$(WARNING_CFLAGS) \
+	$(CODE_COVERAGE_CFLAGS)
+
+AM_LDFLAGS = \
+	$(CODE_COVERAGE_LIBS)
+
+AM_CPPFLAGS = \
+	-I$(top_srcdir) \
+	-I$(top_srcdir)/src/include \
+	-I$(top_srcdir)/src/common/libccan \
+	-I$(top_builddir)/src/common/libflux
+
+noinst_LTLIBRARIES = \
+	libtaskmap.la
+fluxinclude_HEADERS = \
+	taskmap.h
+libtaskmap_la_SOURCES = \
+	taskmap_private.h \
+	taskmap.c
+
+libtaskmap_la_CPPFLAGS = \
+	$(AM_CPPFLAGS)
+libtaskmap_la_LDFLAGS = \
+	-avoid-version -module -shared -export-dynamic \
+	$(AM_LDFLAGS)
+
+
+TESTS = test_taskmap.t
+
+check_PROGRAMS = \
+	$(TESTS)
+
+TEST_EXTENSIONS = .t
+T_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
+       $(top_srcdir)/config/tap-driver.sh
+
+test_taskmap_t_SOURCES = test/taskmap.c
+test_taskmap_t_CPPFLAGS = $(AM_CPPFLAGS)
+test_taskmap_t_LDADD = \
+	$(top_builddir)/src/common/libtap/libtap.la \
+	$(top_builddir)/src/common/libtaskmap/libtaskmap.la \
+	$(top_builddir)/src/common/libutil/libutil.la \
+	$(top_builddir)/src/common/libutil/veb.lo \
+	$(top_builddir)/src/common/libidset/libidset.la \
+	$(top_builddir)/src/common/libczmqcontainers/libczmqcontainers.la \
+	$(JANSSON_LIBS)

--- a/src/common/libtaskmap/taskmap.c
+++ b/src/common/libtaskmap/taskmap.c
@@ -1,0 +1,693 @@
+/************************************************************\
+ * Copyright 2022 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <jansson.h>
+
+#include <flux/core.h>
+#include <flux/idset.h>
+
+#include "src/common/libczmqcontainers/czmq_containers.h"
+#include "src/common/libutil/errprintf.h"
+#include "src/common/libutil/lru_cache.h"
+#include "src/common/libutil/errno_safe.h"
+#include "taskmap.h"
+
+struct taskmap_block {
+    int start;
+    int nnodes;
+    int ppn;
+    int repeat;
+};
+
+struct taskmap {
+    zlistx_t *blocklist;
+    lru_cache_t *idsets;
+};
+
+static struct taskmap_block * taskmap_block_create (int nodeid,
+                                                    int nnodes,
+                                                    int ppn,
+                                                    int repeat)
+{
+    struct taskmap_block *block = calloc (1, sizeof (*block));
+    if (!block)
+        return NULL;
+
+    block->start = nodeid;
+    block->nnodes = nnodes;
+    block->ppn = ppn;
+    block->repeat = repeat;
+    return block;
+}
+
+static void taskmap_block_destroy (struct taskmap_block *block)
+{
+    if (block) {
+        int saved_errno = errno;
+        free (block);
+        errno = saved_errno;
+    }
+}
+
+static int taskmap_block_end (struct taskmap_block *block)
+{
+    return block->start + block->nnodes - 1;
+}
+
+static struct taskmap_block *taskmap_block_from_json (json_t *entry,
+                                                      flux_error_t *errp)
+{
+    int nodeid;
+    int nnodes;
+    int ppn;
+    int repeat;
+    json_error_t error;
+    struct taskmap_block *block;
+
+    if (json_unpack_ex (entry, &error, JSON_DECODE_ANY,
+                        "[iiii]",
+                        &nodeid,
+                        &nnodes,
+                        &ppn,
+                        &repeat) < 0) {
+        errprintf (errp, "error in taskmap entry: %s", error.text);
+        return NULL;
+    }
+    if (nodeid < 0 || nnodes <= 0 || ppn <= 0 || repeat <= 0) {
+        errprintf (errp,
+                   "invalid entry [%d,%d,%d,%d]",
+                   nodeid,
+                   nnodes,
+                   ppn,
+                   repeat);
+        return NULL;
+    }
+    if (!(block = taskmap_block_create (nodeid, nnodes, ppn, repeat)))
+        errprintf (errp, "Out of memory");
+    return block;
+}
+
+static void taskmap_block_destructor (void **item)
+{
+    if (item) {
+        taskmap_block_destroy (*item);
+        *item = NULL;
+    }
+}
+
+void taskmap_destroy (struct taskmap *map)
+{
+    if (map) {
+        int saved_errno = errno;
+        zlistx_destroy (&map->blocklist);
+        lru_cache_destroy (map->idsets);
+        free (map);
+        errno = saved_errno;
+    }
+}
+
+struct taskmap *taskmap_create (void)
+{
+    struct taskmap *map = NULL;
+
+    if (!(map = calloc (1, sizeof (*map)))
+        || !(map->blocklist = zlistx_new ())
+        || !(map->idsets = lru_cache_create (16))) {
+        errno = ENOMEM;
+        goto error;
+    }
+    zlistx_set_destructor (map->blocklist, taskmap_block_destructor);
+    lru_cache_set_free_f (map->idsets, (lru_cache_free_f) idset_destroy);
+    return map;
+error:
+    taskmap_destroy (map);
+    return NULL;
+}
+
+static char *to_string (int n, char *buf, int len)
+{
+    (void) snprintf (buf, len, "%d", n);
+    return buf;
+}
+
+static void cache_idset (const struct taskmap *map,
+                         int nodeid,
+                         struct idset *idset)
+{
+    char id[24];
+    (void) lru_cache_put (map->idsets,
+                          to_string (nodeid, id, sizeof (id)),
+                          idset);
+}
+
+static void decache_idset (struct taskmap *map, int nodeid)
+{
+    char id[24];
+    (void) lru_cache_remove (map->idsets,
+                             to_string (nodeid, id, sizeof (id)));
+}
+
+/*  Wrapper for zlistx_add_end that sets errno.
+ *  Note: zlistx_add_end() asserts on failure, so there is currently no
+ *  way this function can fail. Here we assume if in the future it does
+ *  then ENOMEM is the likely cause.
+ */
+static int append_to_zlistx (zlistx_t *l, void *item)
+{
+    if (!zlistx_add_end (l, item)) {
+        errno = ENOMEM;
+        return -1;
+    }
+    return 0;
+}
+
+static void taskmap_find_repeats (struct taskmap *map)
+{
+    struct taskmap_block *block;
+    struct taskmap_block *prev = NULL;
+
+    prev = zlistx_first (map->blocklist);
+    block = zlistx_next (map->blocklist);
+    while (block) {
+        if (block->start == prev->start
+            && block->nnodes == prev->nnodes
+            && block->ppn == prev->ppn) {
+            prev->repeat += block->repeat;
+            zlistx_delete (map->blocklist, zlistx_cursor (map->blocklist));
+        }
+        else
+            prev = block;
+        block = zlistx_next (map->blocklist);
+    }
+}
+
+int taskmap_append (struct taskmap *map, int nodeid, int nnodes, int ppn)
+{
+    struct taskmap_block *block;
+
+    if (!map || nodeid < 0 || nnodes <= 0 || ppn <= 0) {
+        errno = EINVAL;
+        return -1;
+    }
+    decache_idset (map, nodeid);
+    if ((block = zlistx_tail (map->blocklist))) {
+        /*  If previous block ends at nodeid - 1, and has the same ppn
+         *  and a repeat of 1, then add nnodes to the previous block
+         *  instead of appending a new block.
+         */
+        if (nodeid == taskmap_block_end (block) + 1
+            && ppn == block->ppn
+            && block->repeat == 1) {
+            block->nnodes += nnodes;
+            /*  Check for any new repeated blocks, then return
+             */
+            taskmap_find_repeats (map);
+            return 0;
+        }
+        /*  If previous block and this block are a single, identical
+         *  node, then increment block->ppn by ppn.
+         */
+        if (block->start == nodeid
+            && block->nnodes == 1
+            && nnodes == 1) {
+            block->ppn += ppn;
+            taskmap_find_repeats (map);
+            return 0;
+        }
+        /*  O/w, if previous block matches (nodeid, nnodes, ppn), then
+         *  increment the repeat of the previous block.
+         */
+        if (block->start == nodeid
+            && block->nnodes == nnodes
+            && block->ppn == ppn) {
+            block->repeat++;
+            return 0;
+        }
+        /* Else fall through and append a new block
+         */
+    }
+    if (!(block = taskmap_block_create (nodeid, nnodes, ppn, 1))
+        || append_to_zlistx (map->blocklist, block) < 0) {
+        taskmap_block_destroy (block);
+        return -1;
+    }
+    return 0;
+}
+
+static struct taskmap *taskmap_decode_array (json_t *o, flux_error_t *errp)
+{
+    size_t index;
+    json_t *entry;
+    struct taskmap *map = NULL;
+
+    if (!json_is_array (o)) {
+        errprintf (errp, "taskmap must be an array");
+        goto err;
+    }
+
+    if (!(map = taskmap_create ())) {
+        errprintf (errp, "Out of memory");
+        goto err;
+    }
+
+    json_array_foreach (o, index, entry) {
+        struct taskmap_block *block;
+        if (!json_is_array (entry)) {
+            errprintf (errp, "entry %lu in taskmap is not an array", index);
+            goto err;
+        }
+        if (!(block = taskmap_block_from_json (entry, errp))
+            || append_to_zlistx (map->blocklist, block) < 0)
+            goto err;
+    }
+    return map;
+err:
+    taskmap_destroy (map);
+    return NULL;
+}
+
+struct taskmap *taskmap_decode_json (json_t *o, flux_error_t *errp)
+{
+    struct taskmap *map = NULL;
+    json_t *array;
+
+    err_init (errp);
+
+    if (!o) {
+        errprintf (errp, "Invalid argument");
+        goto error;
+    }
+
+    array = o;
+    if (json_is_object (o)) {
+        int version;
+        json_error_t error;
+        if (json_unpack_ex (o, &error, 0,
+                            "{s:i s:o}",
+                            "version", &version,
+                            "map", &array) < 0) {
+            errprintf (errp, "%s", error.text);
+            goto error;
+        }
+        if (version != 1) {
+            errprintf (errp, "expected version=1, got %d", version);
+            goto error;
+        }
+    }
+    else if (!json_is_array (o)) {
+        errprintf (errp, "taskmap must be an object or array");
+        goto error;
+    }
+    map = taskmap_decode_array (array, errp);
+error:
+    return map;
+}
+
+struct taskmap *taskmap_decode (const char *s, flux_error_t *errp)
+{
+    struct taskmap *map = NULL;
+    json_t *o = NULL;
+    json_error_t error;
+
+    err_init (errp);
+
+    if (s == NULL || strlen (s) == 0) {
+        errprintf (errp, "Invalid argument");
+        goto out;
+    }
+
+    if (!(o = json_loads (s, JSON_DECODE_ANY, &error))) {
+        errprintf (errp, "%s", error.text);
+        goto out;
+    }
+
+    map = taskmap_decode_json (o, errp);
+out:
+    json_decref (o);
+    return map;
+}
+
+static struct idset *lookup_idset (const struct taskmap *map, int nodeid)
+{
+    char id[24];
+    return lru_cache_get (map->idsets, to_string (nodeid, id, sizeof (id)));
+}
+
+const struct idset *taskmap_taskids (const struct taskmap *map, int nodeid)
+{
+    int current;
+    struct taskmap_block *block;
+    struct idset *taskids;
+
+    if (!map || nodeid < 0) {
+        errno = EINVAL;
+        return NULL;
+    }
+
+    if ((taskids = lookup_idset (map, nodeid)))
+        return taskids;
+
+    if (!(taskids = idset_create (0, IDSET_FLAG_AUTOGROW)))
+        return NULL;
+
+    current = 0;
+    block = zlistx_first (map->blocklist);
+    while (block) {
+        for (int n = 0; n < block->repeat; n++) {
+            int start = block->start;
+            if (nodeid >= start && nodeid <= taskmap_block_end (block)) {
+                int offset = nodeid - start;
+                start = current + (offset * block->ppn);
+                idset_range_set (taskids, start, start + block->ppn - 1);
+            }
+            current += block->nnodes * block->ppn;
+        }
+        block = zlistx_next (map->blocklist);
+    }
+
+    if (idset_count (taskids) == 0) {
+        idset_destroy (taskids);
+        errno = ENOENT;
+        return NULL;
+    }
+
+    cache_idset (map, nodeid, taskids);
+    return taskids;
+}
+
+int taskmap_nodeid (const struct taskmap *map, int taskid)
+{
+    struct taskmap_block *block;
+    int current = 0;
+
+    if (!map || taskid < 0) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    block = zlistx_first (map->blocklist);
+    while (block) {
+        for (int n = 0; n < block->repeat; n++) {
+            int last = current + block->nnodes * block->ppn - 1;
+            if (taskid <= last) {
+                int distance = taskid - current;
+                return block->start + (distance / block->ppn);
+            }
+            current = last + 1;
+        }
+        block = zlistx_next (map->blocklist);
+    }
+    errno = ENOENT;
+    return -1;
+}
+
+int taskmap_ntasks (const struct taskmap *map, int nodeid)
+{
+    const struct idset *taskids = taskmap_taskids (map, nodeid);
+    if (!taskids)
+        return -1;
+    return idset_count (taskids);
+}
+
+int taskmap_nnodes (const struct taskmap *map)
+{
+    struct taskmap_block *block;
+    int n;
+
+    if (!map) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    n = 0;
+    block = zlistx_first (map->blocklist);
+    while (block) {
+        int end = block->start + block->nnodes;
+        if (n < end)
+            n = end;
+        block = zlistx_next (map->blocklist);
+    }
+    return n;
+}
+
+int taskmap_total_ntasks (const struct taskmap *map)
+{
+    struct taskmap_block *block;
+    int n;
+
+    if (!map) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    n = 0;
+    block = zlistx_first (map->blocklist);
+    while (block) {
+        n += block->nnodes * block->repeat * block->ppn;
+        block = zlistx_next (map->blocklist);
+    }
+    return n;
+}
+
+static json_t *taskmap_block_encode (struct taskmap_block *block)
+{
+    return json_pack ("[iiii]",
+                      block->start,
+                      block->nnodes,
+                      block->ppn,
+                      block->repeat);
+}
+
+json_t *taskmap_encode_json (const struct taskmap *map, int flags)
+{
+    struct taskmap_block *block;
+    json_t *blocks = NULL;
+    json_t *taskmap = NULL;
+
+    if (!(blocks = json_array ()))
+        goto error;
+
+    block = zlistx_first (map->blocklist);
+    while (block) {
+        json_t *o = taskmap_block_encode (block);
+        if (!o)
+            goto error;
+        if (json_array_append_new (blocks, o) < 0) {
+            json_decref (o);
+            goto error;
+        }
+        block = zlistx_next (map->blocklist);
+    }
+    if (!(flags & TASKMAP_ENCODE_WRAPPED))
+        return blocks;
+    if (!(taskmap = json_pack ("{s:i s:o}",
+                               "version", 1,
+                               "map", blocks)))
+        goto error;
+    return taskmap;
+error:
+    json_decref (blocks);
+    json_decref (taskmap);
+
+    /* Note: Only possible reason for error exit is ENOMEM
+     */
+    errno = ENOMEM;
+    return NULL;
+}
+
+static bool valid_encode_flags (int flags)
+{
+    int count = 0;
+    int possible_flags = TASKMAP_ENCODE_WRAPPED
+                         | TASKMAP_ENCODE_PMI
+                         | TASKMAP_ENCODE_RAW;
+    if ((flags & possible_flags) != flags)
+        return false;
+    while (flags) {
+        flags = flags & (flags - 1); /* clear the least significant bit set */
+        count++;
+    }
+    if (count > 1)
+        return false;
+    return true;
+}
+
+static char *taskmap_encode_map (const struct taskmap *map, int flags)
+{
+    char *s;
+    json_t *taskmap;
+    if (!(taskmap = taskmap_encode_json (map, flags)))
+        return NULL;
+    if (!(s = json_dumps (taskmap, JSON_COMPACT)))
+        errno = ENOMEM;
+    ERRNO_SAFE_WRAP (json_decref, taskmap);
+    return s;
+}
+
+static char *list_join (zlistx_t *l, char *sep)
+{
+    char *result = NULL;
+    char *s;
+    int seplen = strlen (sep);
+    int len = 0;
+    int n = 0;
+
+    /* special case: zero length list returns zero length string
+    */
+    if (zlistx_size (l) == 0)
+        return strdup ("");
+
+    s = zlistx_first (l);
+    while (s) {
+        len += strlen (s) + seplen;
+        s = zlistx_next (l);
+    }
+    if (!(result = malloc (len+1)))
+        return NULL;
+
+    s = zlistx_first (l);
+    n = 0;
+    while (s) {
+        n += sprintf (result+n, "%s%s", s, sep);
+        s = zlistx_next (l);
+    }
+    result[len - seplen] = '\0';
+    return result;
+}
+
+static void item_destructor (void **item)
+{
+    if (item) {
+        free (*item);
+        *item = NULL;
+    }
+}
+
+static char *taskmap_encode_raw (const struct taskmap *map)
+{
+    char *result = NULL;
+    zlistx_t *l;
+    int nnodes;
+    int saved_errno;
+
+    if (!(l = zlistx_new ())) {
+        errno = ENOMEM;
+        return NULL;
+    }
+    zlistx_set_destructor (l, item_destructor);
+
+    nnodes = taskmap_nnodes (map);
+    for (int i = 0; i < nnodes; i++) {
+        const struct idset *ids = NULL;
+        char *s = NULL;
+        if (!(ids = taskmap_taskids (map, i))
+            || !(s = idset_encode (ids, IDSET_FLAG_RANGE))
+            || append_to_zlistx (l, s) < 0)
+            goto error;
+    }
+    result = list_join (l, ";");
+error:
+    saved_errno = errno;
+    zlistx_destroy (&l);
+    errno = saved_errno;
+    return result;
+}
+
+static char *taskmap_encode_pmi (const struct taskmap *map)
+{
+    char *result = NULL;
+    char *s;
+    struct taskmap_block *block;
+    zlistx_t *l;
+    int saved_errno;
+
+    if (!(l = zlistx_new ())) {
+        errno = ENOMEM;
+        return NULL;
+    }
+    zlistx_set_destructor (l, item_destructor);
+
+    block = zlistx_first (map->blocklist);
+    while (block) {
+        for (int i = 0; i < block->repeat; i++)
+            if (asprintf (&s,
+                          "(%d,%d,%d)",
+                          block->start,
+                          block->nnodes,
+                          block->ppn) < 0
+                || append_to_zlistx (l, s) < 0)
+                goto error;
+        block = zlistx_next (map->blocklist);
+    }
+    if (!(s = list_join (l, ",")))
+        goto error;
+    if (asprintf (&result, "(vector,%s)", s) < 0)
+        result = NULL;
+error:
+    saved_errno = errno;
+    free (s);
+    zlistx_destroy (&l);
+    errno = saved_errno;
+    return result;
+}
+
+char *taskmap_encode (const struct taskmap *map, int flags)
+{
+    if (!map || !valid_encode_flags (flags)) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (flags & TASKMAP_ENCODE_RAW)
+        return taskmap_encode_raw (map);
+    if (flags & TASKMAP_ENCODE_PMI)
+        return taskmap_encode_pmi (map);
+    return taskmap_encode_map (map, flags);
+}
+
+int taskmap_check (const struct taskmap *old,
+                   const struct taskmap *new,
+                   flux_error_t *errp)
+{
+    int nnodes_old, nnodes_new;
+    int ntasks_old, ntasks_new;
+    if (!old || !new)
+        return errprintf (errp, "Invalid argument");
+    nnodes_old = taskmap_nnodes (old);
+    nnodes_new = taskmap_nnodes (new);
+    if (nnodes_old != nnodes_new)
+        return errprintf (errp,
+                          "got %d nodes, expected %d",
+                          nnodes_new,
+                          nnodes_old);
+    ntasks_old = taskmap_total_ntasks (old);
+    ntasks_new = taskmap_total_ntasks (new);
+    if (ntasks_old != ntasks_new)
+        return errprintf (errp,
+                          "got %d total tasks, expected %d",
+                          ntasks_new,
+                          ntasks_old);
+    for (int i = 0; i < nnodes_old; i++) {
+        ntasks_old = taskmap_ntasks (old, i);
+        ntasks_new = taskmap_ntasks (new, i);
+        if (ntasks_old != ntasks_new)
+            return errprintf (errp,
+                              "node %d has %d tasks, expected %d",
+                              i,
+                              ntasks_new,
+                              ntasks_old);
+    }
+    return 0;
+}
+
+// vi: ts=4 sw=4 expandtab

--- a/src/common/libtaskmap/taskmap.h
+++ b/src/common/libtaskmap/taskmap.h
@@ -1,0 +1,102 @@
+/************************************************************\
+ * Copyright 2022 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _UTIL_TASKMAP_H
+#define _UTIL_TASKMAP_H
+
+#include <flux/core.h>
+#include <flux/idset.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+enum taskmap_flags {
+    TASKMAP_ENCODE_WRAPPED = 1,      /* Encode as RFC 34 wrapped object      */
+    TASKMAP_ENCODE_PMI =     1 << 1, /* Encode as PMI-1 PMI_process_mapping  */
+    TASKMAP_ENCODE_RAW =     1 << 2, /* Encode as semicolon-delimited taskids*/
+};
+
+/*  Create an empty taskmap
+ *  Returns taskmap on success, NULL on failure with errno set.
+ */
+struct taskmap *taskmap_create ();
+
+/*  Destroy a taskmap
+ */
+void taskmap_destroy (struct taskmap *map);
+
+/*  Append a block of tasks to a taskmap starting at 'nodeid', for 'nnodes'
+ *   with 'ppn' tasks per node.
+ *  Returns 0 on success, -1 on failure with errno set.
+ */
+int taskmap_append (struct taskmap *map, int nodeid, int nnodes, int ppn);
+
+/*  Decode string 'map' into taskmap object.
+ *  The string may be a JSON array or RFC 34 wrapped object.
+ *  Returns taskmap on success, or NULL on error with error string in 'errp'.
+ */
+struct taskmap *taskmap_decode (const char *map, flux_error_t *errp);
+
+/*  Encode taskmap 'map' to a string, which the caller must free.
+ *  'flags' may indicate
+ *    TASKMAP_ENCODE_WRAPPED to create an RFC 34 wrapped taskmap object.
+ *    TASKMAP_ENCODE_PMI to create a PMI-1 PMI_process_mapping encoding
+ *    TASKMAP_ENCODE_RAW to create a semicolon-delimited list of taskids
+ *  The default is to encode as a JSON array.
+ *  Returns string on success, or NULL on failure with errno set.
+ */
+char *taskmap_encode (const struct taskmap *map, int flags);
+
+/*  Return an idset of taskids encoded in 'map' for nodeid 'nodeid'.
+ *  Returns an idset on success, which may only be vaild until the next
+ *   call to taskmap_taskids(), caller should use idset_copy() if necessary.
+ *  Returns NULL on error with errno set.
+ */
+const struct idset *taskmap_taskids (const struct taskmap *map, int nodeid);
+
+/*  Return the nodeid which contains task id 'taskid' in taskmap 'map'.
+ *  Returns the nodeid or -1 on failure with errno set.
+ */
+int taskmap_nodeid (const struct taskmap *map, int taskid);
+
+/*  Return the total number of tasks assigned to node 'nodeid' in 'map'.
+ *  Returns a task count or -1 on failure with errno set.
+ */
+int taskmap_ntasks (const struct taskmap *map, int nodeid);
+
+/*  Return the total number of nodes in 'map'.
+ *  Returns a count of nodes on success, -1 on failure with errno set.
+ */
+int taskmap_nnodes (const struct taskmap *map);
+
+/*  Return the total number of tasks in 'map'.
+ *  Returns a count of tasks on success, -1 on failure with errno set.
+ */
+int taskmap_total_ntasks (const struct taskmap *map);
+
+/*  Check if 'a' and 'b' taskmaps are compatible, i.e. they
+ *  have equivalent numbers of total tasks, total nodes, and tasks assigned
+ *  to each node.
+ *  Returns 0 on success, -1 with error message in 'errp' on failure.
+ */
+int taskmap_check (const struct taskmap *a,
+                   const struct taskmap *b,
+                   flux_error_t *errp);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* !_UTIL_TASKMAP_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libtaskmap/taskmap_private.h
+++ b/src/common/libtaskmap/taskmap_private.h
@@ -1,0 +1,25 @@
+/************************************************************\
+ * Copyright 2022 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _UTIL_TASKMAP_PRIVATE_H
+#define _UTIL_TASKMAP_PRIVATE_H
+
+#include <jansson.h>
+#include <flux/taskmap.h>
+
+json_t *taskmap_encode_json (const struct taskmap *map, int flags);
+
+struct taskmap *taskmap_decode_json (json_t *o, flux_error_t *errp);
+
+#endif /* !_UTIL_TASKMAP_PRIVATE_H */
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/common/libtaskmap/test/taskmap.c
+++ b/src/common/libtaskmap/test/taskmap.c
@@ -1,0 +1,478 @@
+/************************************************************\
+ * Copyright 2022 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <errno.h>
+
+#include <flux/taskmap.h>
+#include "taskmap_private.h"
+
+#include "src/common/libtap/tap.h"
+
+struct test_args {
+    const char *input;
+    int nnodes;
+    int total_nnodes;
+    int total_ntasks;
+    char *idsets[24];
+};
+
+struct test_vector {
+    const char *taskmap;
+    const char *expected;
+};
+
+struct test_vector rfc34_test_vectors[] = {
+    { "[]", "" },
+    { "[[0,1,1,1]]",
+      "0" },
+    { "[[0,2,1,1]]",
+      "0;1" },
+    { "[[0,1,2,1]]",
+      "0-1" },
+    { "[[0,2,2,1]]",
+      "0-1;2-3" },
+    { "[[0,2,1,2]]",
+      "0,2;1,3" },
+    { "[[1,1,1,1],[0,1,1,1]]",
+      "1;0" },
+    { "[[0,4,4,1]]",
+      "0-3;4-7;8-11;12-15" },
+    { "[[0,4,1,4]]",
+      "0,4,8,12;1,5,9,13;2,6,10,14;3,7,11,15" },
+    { "[[0,4,2,2]]",
+      "0-1,8-9;2-3,10-11;4-5,12-13;6-7,14-15" },
+    { "[[0,4,2,1],[4,2,4,1]]",
+      "0-1;2-3;4-5;6-7;8-11;12-15" },
+    { "[[0,6,1,2],[4,2,1,2]]",
+      "0,6;1,7;2,8;3,9;4,10,12,14;5,11,13,15" },
+    { "[[5,1,4,1],[4,1,4,1],[3,1,2,1],[2,1,2,1],[1,1,2,1],[0,1,2,1]]",
+      "14-15;12-13;10-11;8-9;4-7;0-3" },
+    { "[[0,5,2,1],[6,1,2,1],[5,1,2,1],[7,1,2,1]]",
+      "0-1;2-3;4-5;6-7;8-9;12-13;10-11;14-15" },
+    { "[[3,1,4,1],[2,1,4,1],[1,1,4,1],[0,1,4,1]]",
+      "12-15;8-11;4-7;0-3" },
+    { NULL, NULL },
+};
+
+static void rfc34_tests ()
+{
+    struct test_vector *t;
+    for (t = &rfc34_test_vectors[0]; t->taskmap != NULL; t++) {
+        char *s;
+        struct taskmap *map = taskmap_decode (t->taskmap, NULL);
+        if (!map)
+            BAIL_OUT("taskmap_decode failed!");
+        ok (map != NULL,
+            "taskmap_decode (%s)",
+            t->taskmap);
+        ok ((s = taskmap_encode (map, TASKMAP_ENCODE_RAW)) != NULL,
+            "taskmap_encode_raw works");
+        is (s, t->expected,
+            "taskmap raw=%s",
+            s);
+        taskmap_destroy (map);
+        free (s);
+    }
+}
+
+struct test_vector pmi_tests[] = {
+    { "[[0,4,4,1]]", "(vector,(0,4,4))" },
+    { "[[0,4,2,1],[4,2,4,1]]", "(vector,(0,4,2),(4,2,4))" },
+    { "[[0,4,1,4]]", "(vector,(0,4,1),(0,4,1),(0,4,1),(0,4,1))" },
+    { "[[0,4096,256,1]]", "(vector,(0,4096,256))" },
+    { NULL, NULL },
+};
+
+static void pmi_mapping_tests ()
+{
+    struct test_vector *t;
+    for (t = &pmi_tests[0]; t->taskmap != NULL; t++) {
+        char *s;
+        struct taskmap *map = taskmap_decode (t->taskmap, NULL);
+        if (!map)
+            BAIL_OUT("taskmap_decode failed!");
+        ok (map != NULL,
+            "taskmap_decode (%s)",
+            t->taskmap);
+        ok ((s = taskmap_encode (map, TASKMAP_ENCODE_PMI)) != NULL,
+            "taskmap_encode_pmi works");
+        is (s, t->expected,
+            "taskmap pmi=%s",
+            s);
+        taskmap_destroy (map);
+        free (s);
+    }
+}
+
+struct test_args tests[] = {
+    { "[[0,2,2,1]]", 2, 2, 4, { "0-1", "2-3" } },
+    { "[[0,2,1,2]]", 2, 2, 4, { "0,2", "1,3" } },
+    { "[[0,16,16,1]]", 16, 16, 256,
+      { "0-15", "16-31", "32-47", "48-63", "64-79", "80-95",
+        "96-111", "112-127", "128-143", "144-159", "160-175",
+        "176-191", "192-207", "208-223", "224-239", "240-255",
+        NULL,
+      },
+    },
+    { "[[0,8,16,1],[8,4,32,1]]", 12, 12, 256,
+      { "0-15", "16-31", "32-47", "48-63", "64-79", "80-95",
+        "96-111", "112-127", "128-159", "160-191", "192-223", "224-255",
+        NULL
+      },
+    },
+    { "[[0,4096,1,256]]", 2, 4096, 1048576,
+      { "0,4096,8192,12288,16384,20480,24576,28672,32768,36864,40960,45056,49152,53248,57344,61440,65536,69632,73728,77824,81920,86016,90112,94208,98304,102400,106496,110592,114688,118784,122880,126976,131072,135168,139264,143360,147456,151552,155648,159744,163840,167936,172032,176128,180224,184320,188416,192512,196608,200704,204800,208896,212992,217088,221184,225280,229376,233472,237568,241664,245760,249856,253952,258048,262144,266240,270336,274432,278528,282624,286720,290816,294912,299008,303104,307200,311296,315392,319488,323584,327680,331776,335872,339968,344064,348160,352256,356352,360448,364544,368640,372736,376832,380928,385024,389120,393216,397312,401408,405504,409600,413696,417792,421888,425984,430080,434176,438272,442368,446464,450560,454656,458752,462848,466944,471040,475136,479232,483328,487424,491520,495616,499712,503808,507904,512000,516096,520192,524288,528384,532480,536576,540672,544768,548864,552960,557056,561152,565248,569344,573440,577536,581632,585728,589824,593920,598016,602112,606208,610304,614400,618496,622592,626688,630784,634880,638976,643072,647168,651264,655360,659456,663552,667648,671744,675840,679936,684032,688128,692224,696320,700416,704512,708608,712704,716800,720896,724992,729088,733184,737280,741376,745472,749568,753664,757760,761856,765952,770048,774144,778240,782336,786432,790528,794624,798720,802816,806912,811008,815104,819200,823296,827392,831488,835584,839680,843776,847872,851968,856064,860160,864256,868352,872448,876544,880640,884736,888832,892928,897024,901120,905216,909312,913408,917504,921600,925696,929792,933888,937984,942080,946176,950272,954368,958464,962560,966656,970752,974848,978944,983040,987136,991232,995328,999424,1003520,1007616,1011712,1015808,1019904,1024000,1028096,1032192,1036288,1040384,1044480",
+       "1,4097,8193,12289,16385,20481,24577,28673,32769,36865,40961,45057,49153,53249,57345,61441,65537,69633,73729,77825,81921,86017,90113,94209,98305,102401,106497,110593,114689,118785,122881,126977,131073,135169,139265,143361,147457,151553,155649,159745,163841,167937,172033,176129,180225,184321,188417,192513,196609,200705,204801,208897,212993,217089,221185,225281,229377,233473,237569,241665,245761,249857,253953,258049,262145,266241,270337,274433,278529,282625,286721,290817,294913,299009,303105,307201,311297,315393,319489,323585,327681,331777,335873,339969,344065,348161,352257,356353,360449,364545,368641,372737,376833,380929,385025,389121,393217,397313,401409,405505,409601,413697,417793,421889,425985,430081,434177,438273,442369,446465,450561,454657,458753,462849,466945,471041,475137,479233,483329,487425,491521,495617,499713,503809,507905,512001,516097,520193,524289,528385,532481,536577,540673,544769,548865,552961,557057,561153,565249,569345,573441,577537,581633,585729,589825,593921,598017,602113,606209,610305,614401,618497,622593,626689,630785,634881,638977,643073,647169,651265,655361,659457,663553,667649,671745,675841,679937,684033,688129,692225,696321,700417,704513,708609,712705,716801,720897,724993,729089,733185,737281,741377,745473,749569,753665,757761,761857,765953,770049,774145,778241,782337,786433,790529,794625,798721,802817,806913,811009,815105,819201,823297,827393,831489,835585,839681,843777,847873,851969,856065,860161,864257,868353,872449,876545,880641,884737,888833,892929,897025,901121,905217,909313,913409,917505,921601,925697,929793,933889,937985,942081,946177,950273,954369,958465,962561,966657,970753,974849,978945,983041,987137,991233,995329,999425,1003521,1007617,1011713,1015809,1019905,1024001,1028097,1032193,1036289,1040385,1044481",
+       NULL },
+    },
+    { NULL, 0, 0, 0, {0} },
+};
+
+static bool check_all_tasks (struct taskmap *map,
+                             const struct idset *taskids,
+                             int nodeid)
+{
+    unsigned int i = idset_first (taskids);
+
+    while (i != IDSET_INVALID_ID) {
+        int n = taskmap_nodeid (map, i);
+        if (n != nodeid) {
+            fail ("task %u is on node %d (expected %d)",
+                  i,
+                  n,
+                  nodeid);
+            return false;
+        }
+        i = idset_next (taskids, i);
+    }
+    return true;
+}
+
+static void main_tests ()
+{
+    struct test_args *t;
+
+    for (t = &tests[0]; t->input != NULL; t++) {
+        flux_error_t error;
+        char *s;
+        struct taskmap *map = taskmap_decode (t->input, &error);
+        if (!map)
+            BAIL_OUT ("taskmap_decode(%s): %s", t->input, error.text);
+        ok (map != NULL,
+            "taskmap_decode (%s)",
+            t->input);
+        ok (taskmap_nnodes (map) == t->total_nnodes,
+            "taskmap_nnodes returned %d (expected %d)",
+            taskmap_nnodes (map),
+            t->total_nnodes);
+        ok (taskmap_total_ntasks (map) == t->total_ntasks,
+            "taskmap_total_ntasks returned %d (expected %d)",
+            taskmap_total_ntasks (map),
+            t->total_ntasks);
+        ok ((s = taskmap_encode (map, 0)) != NULL,
+            "taskmap_encode works");
+        is (s, t->input,
+            "taskmap_encode returns expected string: %s", s);
+        free (s);
+        for (int i = 0; i < t->nnodes; i++) {
+            const struct idset *taskids = taskmap_taskids (map, i);
+            if (!taskids)
+                BAIL_OUT ("taskmap_taskids (%s, %d) failed", t->input, i);
+            char *s = idset_encode (taskids, IDSET_FLAG_RANGE);
+            is (s, t->idsets[i],
+                "node %d idset is %s", i, s);
+
+            ok (check_all_tasks (map, taskids, i),
+                "%d tasksids on nodeid %d",
+                idset_count (taskids), i);
+
+            free (s);
+        }
+        taskmap_destroy (map);
+    }
+}
+
+static const char *invalid[] = {
+    "}",
+    "42",
+    "{}",
+    "{\"version\":1}",
+    "{\"version\":1,\"map\":{}}",
+    "{\"version\":2,\"map\":[[1,1,1,1]]}",
+    "{\"version\":1,\"map\":[[]]}",
+    "{\"version\":1,\"map\":[[\"1\",\"1\",\"1\"]]}",
+    "[[-1,1,1,1]]",
+    "[[0,1,1,1],[-1,1,1,1]]",
+    "[[0,1,1,1],1]",
+    NULL
+};
+
+static void error_tests ()
+{
+    struct taskmap *map;
+    flux_error_t error;
+
+    if (!(map = taskmap_create ()))
+        BAIL_OUT ("taskmap_create");
+
+    ok (taskmap_encode (NULL, 0) == NULL && errno == EINVAL,
+        "taskmap_encode (NULL) returns EINVAL");
+    ok (taskmap_encode (map, 0xff) == NULL && errno == EINVAL,
+        "taskmap_encode (map, 0xff) returns EINVAL");
+    ok (taskmap_encode (map, TASKMAP_ENCODE_RAW | TASKMAP_ENCODE_PMI) == NULL
+        && errno == EINVAL,
+        "taskmap_encode (map, MULTIPLE_ENCODINGS) returns EINVAL");
+
+    ok (taskmap_taskids (map, -1) == NULL && errno == EINVAL,
+        "taskmap_taskids (map, -1) returns EINVAL");
+    ok (taskmap_taskids (map, 1) == NULL && errno == ENOENT,
+        "taskmap_taskids (map, 1) returns ENOENT");
+
+    ok (taskmap_nodeid (NULL, 0) < 0 && errno == EINVAL,
+        "Ttaskmap_nodeid (NULL, 0) returns EINVAL");
+    ok (taskmap_nodeid (map, -1) < 0 && errno == EINVAL,
+        "Ttaskmap_nodeid (map, -1) returns EINVAL");
+
+    ok (taskmap_ntasks (NULL, 0) < 0 && errno == EINVAL,
+        "taskmap_ntasks (NULL) returns EINVAL");
+    ok (taskmap_ntasks (map, -1) < 0 && errno == EINVAL,
+        "taskmap_ntasks (map, -1) returns EINVAL");
+    ok (taskmap_ntasks (map, 1) < 0 && errno == ENOENT,
+        "taskmap_ntasks (map, 1) returns ENOENT");
+
+    ok (taskmap_nnodes (NULL) < 0 && errno == EINVAL,
+        "taskmap_nnodes (NULL) returns EINVAL");
+    ok (taskmap_total_ntasks (NULL) < 0 && errno == EINVAL,
+        "taskmap_total_ntasks (NULL) returns EINVAL");
+
+    ok (taskmap_decode (NULL, &error) == NULL,
+        "taskmap_decode (NULL) fails");
+    is (error.text, "Invalid argument",
+        "taskmap_decode (NULL) sets error.text=%s",
+        error.text);
+
+    ok (taskmap_decode_json (NULL, &error) == NULL,
+        "taskmap_decode_json (NULL) fails");
+    is (error.text, "Invalid argument",
+        "taskmape_decode_json (NULL) sets error.text=%s",
+        error.text);
+
+    ok (taskmap_decode ("", &error) == NULL,
+        "taskmap_decode (\"\") fails");
+    is (error.text, "Invalid argument",
+        "taskmap_decode (\"\") sets error.text=%s",
+        error.text);
+
+    /* Do not try to match jansson errors exactly */
+    for (const char **input = &invalid[0]; *input != NULL; input++) {
+        ok (taskmap_decode (*input, &error) == NULL,
+            "taskmap_decode (%s) fails with %s",
+            *input,
+            error.text);
+    }
+
+    ok (taskmap_append (NULL, 0, 0, 0) < 0 && errno == EINVAL,
+        "taskmap_append (NULL) returns EINVAL");
+    ok (taskmap_append (map, 0, 0, 0) < 0 && errno == EINVAL,
+        "taskmap_append (NULL, 0, 0, 0) returns EINVAL");
+
+    taskmap_destroy (map);
+}
+
+void append_tests ()
+{
+    int n;
+    char *s;
+    struct taskmap *map = taskmap_create ();
+    if (!map)
+        BAIL_OUT ("taskmap_create");
+
+    for (int i = 0; i < 4; i++) {
+        ok (taskmap_append (map, i, 1, 4) == 0,
+            "taskmap_append (%d, 1, 4)",
+            i);
+    }
+    n = taskmap_nnodes (map);
+    ok (n == 4,
+        "taskmap_nnodes() == 4 (got %d)",
+        n);
+    n = taskmap_total_ntasks (map);
+    ok (n == 16,
+        "taskmap_nnodes() == 16 (got %d)",
+        n);
+    s = taskmap_encode (map, 0);
+    ok (s != NULL,
+        "taskmap_encode works");
+    is (s, "[[0,4,4,1]]",
+        "map = %s",
+        s);
+    free (s);
+
+    /* Add another couple nodes with higher tasks-per-node count */
+    for (int i = 4; i < 6; i++) {
+        ok (taskmap_append (map, i, 1, 8) == 0,
+            "taskmap_append (%d, 1, 8)",
+            i);
+    }
+
+    n = taskmap_nnodes (map);
+    ok (n == 6,
+        "taskmap_nnodes() == 6 (got %d)",
+        n);
+    n = taskmap_total_ntasks (map);
+    ok (n == 32,
+        "taskmap_nnodes() == 32 (got %d)",
+        n);
+    s = taskmap_encode (map, 0);
+    ok (s != NULL,
+        "taskmap_encode works");
+    is (s, "[[0,4,4,1],[4,2,8,1]]",
+        "map = %s",
+        s);
+    free (s);
+
+    /* Add one more block of nodes that matches previous block */
+    ok (taskmap_append (map, 4, 2, 8) == 0,
+        "taskmap_append (4, 2, 8)");
+    s = taskmap_encode (map, 0);
+    ok (s != NULL,
+        "taskmap_encode works");
+    is (s, "[[0,4,4,1],[4,2,8,2]]",
+        "map = %s",
+        s);
+
+    free (s);
+    taskmap_destroy (map);
+}
+
+void append_cyclic_test ()
+{
+    int n;
+    char *s;
+    struct taskmap *map = taskmap_create ();
+    if (!map)
+        BAIL_OUT ("taskmap_create");
+
+    for (int i = 0; i < 4; i++) {
+        for (int j = 0; j < 4; j++) {
+            ok (taskmap_append (map, j, 1, 1) == 0,
+                "taskmap_append (%d, 1, 1)", j);
+        }
+    }
+    n = taskmap_nnodes (map);
+    ok (n == 4,
+        "taskmap_nnodes() == 4 (got %d)",
+        n);
+    n = taskmap_total_ntasks (map);
+    ok (n == 16,
+        "taskmap_nnodes() == 16 (got %d)",
+        n);
+    s = taskmap_encode (map, 0);
+    ok (s != NULL,
+        "taskmap_encode works");
+    is (s, "[[0,4,1,4]]",
+        "map = %s",
+        s);
+    free (s);
+    taskmap_destroy (map);
+}
+
+void append_cyclic_one ()
+{
+    int n;
+    char *s;
+    struct taskmap *map = taskmap_create ();
+    if (!map)
+        BAIL_OUT ("taskmap_create");
+
+    for (int i = 0; i < 4; i++) {
+        ok (taskmap_append (map, 0, 1, 1) == 0,
+            "taskmap_append (0, 1, 1)");
+    }
+    n = taskmap_nnodes (map);
+    ok (n == 1,
+        "taskmap_nnodes() == 1 (got %d)",
+        n);
+    n = taskmap_total_ntasks (map);
+    ok (n == 4,
+        "taskmap_nnodes() == 16 (got %d)",
+        n);
+    s = taskmap_encode (map, 0);
+    ok (s != NULL,
+        "taskmap_encode works");
+    is (s, "[[0,1,4,1]]",
+        "map = %s",
+        s);
+    free (s);
+    taskmap_destroy (map);
+
+}
+
+struct check_test {
+    const char *a;
+    const char *b;
+    int rc;
+    const char *errmsg;
+};
+
+struct check_test check_tests[] = {
+    { "[[0,4,4,1]]", "[[0,4,1,4]]", 0, NULL },
+    { "[[0,4,4,1]]", "[[0,4,2,2]]", 0, NULL },
+    { "[[0,4,4,1]]", "[[0,4,3,1],[0,4,1,1]]", 0, NULL },
+    { "[[0,4,4,1]]", "[[0,4,3,1]]", -1,
+      "got 12 total tasks, expected 16" },
+    { "[[0,4,4,1]]", "[[0,2,8,1]]", -1,
+      "got 2 nodes, expected 4" },
+    { "[[0,4,4,1]]", "[[0,2,4,1],[2,1,3,1],[3,1,5,1]]", -1,
+      "node 2 has 3 tasks, expected 4" },
+    { NULL, NULL, 0, NULL },
+};
+
+static void test_check ()
+{
+    for (struct check_test *t = &check_tests[0]; t->a != NULL; t++) {
+        flux_error_t error;
+        struct taskmap *a = taskmap_decode (t->a, &error);
+        struct taskmap *b = taskmap_decode (t->b, &error);
+        if (!a || !b)
+            BAIL_OUT ("taskmap_decode failed: %s", error.text);
+        ok (taskmap_check (a, b, &error) == t->rc,
+            "taskmap_check ('%s','%s') == %d",
+            t->a,
+            t->b,
+            t->rc);
+        if (t->errmsg)
+            is (error.text, t->errmsg,
+                "got expected error message: %s", error.text);
+        taskmap_destroy (a);
+        taskmap_destroy (b);
+    }
+}
+
+int main (int ac, char **av)
+{
+    plan (NO_PLAN);
+    main_tests ();
+    rfc34_tests ();
+    pmi_mapping_tests ();
+    error_tests ();
+    append_tests ();
+    append_cyclic_test ();
+    append_cyclic_one ();
+    test_check ();
+    done_testing ();
+}
+
+/*
+ * vi: ts=4 sw=4 expandtab
+ */

--- a/src/include/flux/taskmap.h
+++ b/src/include/flux/taskmap.h
@@ -1,0 +1,14 @@
+/************************************************************\
+ * Copyright 2022 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* Allow in-tree programs to #include <flux/taskmap.h> like out-of-tree would.
+ */
+
+#include "src/common/libtaskmap/taskmap.h"

--- a/src/shell/Makefile.am
+++ b/src/shell/Makefile.am
@@ -96,6 +96,7 @@ flux_shell_LDADD = \
 	$(top_builddir)/src/common/librlist/librlist.la \
 	$(top_builddir)/src/bindings/lua/libfluxlua.la \
 	$(top_builddir)/src/common/libflux-core.la \
+	$(top_builddir)/src/common/libflux-taskmap.la \
 	$(top_builddir)/src/common/libpmi/libpmi_server.la \
 	$(top_builddir)/src/common/libczmqcontainers/libczmqcontainers.la \
 	$(top_builddir)/src/common/libflux-internal.la \

--- a/src/shell/Makefile.am
+++ b/src/shell/Makefile.am
@@ -87,7 +87,8 @@ flux_shell_SOURCES = \
 	mustache.c \
 	doom.c \
 	exception.c \
-	rlimit.c
+	rlimit.c \
+	cyclic.c
 
 flux_shell_LDADD = \
 	$(builddir)/libshell.la \

--- a/src/shell/builtins.c
+++ b/src/shell/builtins.c
@@ -89,6 +89,8 @@ static int shell_load_builtin (flux_shell_t *shell,
         return -1;
 
     shell_debug ("loading builtin plugin \"%s\"", sb->name);
+    if (sb->plugin_init && (*sb->plugin_init) (p) < 0)
+        return -1;
     if (plugstack_push (shell->plugstack, p) < 0)
         return -1;
     return (0);

--- a/src/shell/builtins.c
+++ b/src/shell/builtins.c
@@ -46,6 +46,7 @@ extern struct shell_builtin builtin_batch;
 extern struct shell_builtin builtin_doom;
 extern struct shell_builtin builtin_exception;
 extern struct shell_builtin builtin_rlimit;
+extern struct shell_builtin builtin_cyclic;
 
 static struct shell_builtin * builtins [] = {
     &builtin_tmpdir,
@@ -64,6 +65,7 @@ static struct shell_builtin * builtins [] = {
     &builtin_doom,
     &builtin_exception,
     &builtin_rlimit,
+    &builtin_cyclic,
     &builtin_list_end,
 };
 

--- a/src/shell/builtins.h
+++ b/src/shell/builtins.h
@@ -16,6 +16,7 @@
 
 struct shell_builtin {
     const char *name;
+    int (*plugin_init) (flux_plugin_t *p);
     flux_plugin_f validate;
     flux_plugin_f connect;
     flux_plugin_f reconnect;

--- a/src/shell/cyclic.c
+++ b/src/shell/cyclic.c
@@ -1,0 +1,111 @@
+/************************************************************\
+ * Copyright 2022 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* shell taskmap.cyclic plugin
+ */
+#define FLUX_SHELL_PLUGIN_NAME "taskmap.cyclic"
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/core.h>
+#include <flux/taskmap.h>
+
+#include "builtins.h"
+
+char *taskmap_cyclic (const struct taskmap *orig, int stride)
+{
+    struct taskmap *map = NULL;
+    char *result = NULL;
+    int ntasks;
+    int nnodes;
+
+    if (!(map = taskmap_create ()))
+        goto error;
+
+    ntasks = taskmap_total_ntasks (orig);
+    nnodes = taskmap_nnodes (orig);
+    while (ntasks > 0) {
+        for (int i = 0; i < nnodes; i++) {
+            int ppn = stride;
+            int avail = taskmap_ntasks (orig, i) - taskmap_ntasks (map, i);
+            if (avail == 0)
+                continue;
+            if (ppn > avail)
+                ppn = avail;
+            if (taskmap_append (map, i, 1, ppn) < 0)
+                goto error;
+            ntasks -= ppn;
+        }
+    }
+    result = taskmap_encode (map, TASKMAP_ENCODE_WRAPPED);
+error:
+    taskmap_destroy (map);
+    return result;
+}
+
+static int map_cyclic (flux_plugin_t *p,
+                       const char *topic,
+                       flux_plugin_arg_t *args,
+                       void *data)
+{
+    flux_shell_t *shell;
+    char *cyclic;
+    const char *value = NULL;
+    int stride = 1;
+    int rc = -1;
+
+    if (!(shell = flux_plugin_get_shell (p)))
+        return -1;
+
+    if (flux_plugin_arg_unpack (args,
+                                FLUX_PLUGIN_ARG_IN,
+                                "{s?s}",
+                                "value", &value) < 0) {
+        shell_log_error ("unpack: %s", flux_plugin_arg_strerror (args));
+        return -1;
+    }
+    if (value && *value != '\0') {
+        char *endptr;
+        errno = 0;
+        stride = strtol (value, &endptr, 10);
+        if (errno != 0 || *endptr != '\0' || stride <= 0) {
+            shell_log_error ("invalid cyclic stride: %s", value);
+            return -1;
+        }
+    }
+    if (!(cyclic = taskmap_cyclic (flux_shell_get_taskmap (shell), stride))) {
+        shell_log_error ("failed to map tasks with cyclic:%d", stride);
+        goto out;
+    }
+    if (flux_plugin_arg_pack (args,
+                              FLUX_PLUGIN_ARG_OUT,
+                              "{s:s}",
+                              "taskmap", cyclic) < 0)
+        goto out;
+    rc = 0;
+out:
+    free (cyclic);
+    return rc;
+}
+
+static int plugin_init (flux_plugin_t *p)
+{
+    return flux_plugin_add_handler (p, "taskmap.cyclic", map_cyclic, NULL);
+}
+
+struct shell_builtin builtin_cyclic = {
+    .name = FLUX_SHELL_PLUGIN_NAME,
+    .plugin_init = plugin_init,
+};
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/shell/info.h
+++ b/src/shell/info.h
@@ -13,6 +13,7 @@
 
 #include <flux/core.h>
 #include <flux/shell.h>
+#include <flux/taskmap.h>
 
 #include <jansson.h>
 #include <stdbool.h>
@@ -30,6 +31,8 @@ struct shell_info {
     struct jobspec *jobspec;
     rcalc_t *rcalc;
     struct rcalc_rankinfo rankinfo;
+    struct taskmap *taskmap;
+    struct idset *taskids;
     char *hwloc_xml;
 };
 
@@ -40,6 +43,11 @@ struct shell_info {
 struct shell_info *shell_info_create (flux_shell_t *shell);
 
 void shell_info_destroy (struct shell_info *info);
+
+/*  Set or replace current shell taskmap and taskids idset
+ *  Reference to `map` is stolen on success.
+ */
+int shell_info_set_taskmap (struct shell_info *info, struct taskmap *map);
 
 #endif /* !_SHELL_INFO_H */
 

--- a/src/shell/rcalc.c
+++ b/src/shell/rcalc.c
@@ -37,7 +37,6 @@ struct rankinfo {
 struct allocinfo {
     int ncores_avail;
     int ntasks;
-    int basis;
 };
 
 struct rcalc {
@@ -296,16 +295,6 @@ static bool allocinfo_add_task (struct allocinfo *ai, int size)
     return (false);
 }
 
-static void rcalc_compute_taskids (rcalc_t *r)
-{
-    int i;
-    int taskid = 0;
-    for (i = 0; i < r->nranks; i++) {
-        r->alloc[i].basis = taskid;
-        taskid += r->alloc[i].ntasks;
-    }
-}
-
 /*
  *  Distribute ntasks over the ranks in `r` "evenly" by a heuristic
  *   that first assigns a number of cores per task, then distributes
@@ -353,9 +342,6 @@ int rcalc_distribute (rcalc_t *r, int ntasks, int cores_per_task)
         }
     }
     zlist_destroy (&l);
-
-    /*  Assign taskid basis to each rank in block allocation order */
-    rcalc_compute_taskids (r);
     return (0);
 }
 
@@ -391,8 +377,6 @@ int rcalc_distribute_per_resource (rcalc_t *r, const char *name, int ntasks)
             r->ntasks += n;
         }
     }
-
-    rcalc_compute_taskids (r);
     return 0;
 }
 
@@ -430,7 +414,6 @@ static void rcalc_rankinfo_set (rcalc_t *r, int id,
     rli->rank =   ri->rank;
     rli->ncores = ri->ncores;
     rli->ntasks = ai->ntasks;
-    rli->global_basis =  ai->basis;
     /*  Copy cores string to rli, in the very unlikely event that
      *   we get a huge cores string, indicate truncation.
      */

--- a/src/shell/rcalc.c
+++ b/src/shell/rcalc.c
@@ -342,7 +342,11 @@ int rcalc_distribute (rcalc_t *r, int ntasks, int cores_per_task)
      *  and leaving "full" ranks off the list.
      */
     while (assigned < ntasks) {
-        ai = zlist_pop (l);
+        if (!(ai = zlist_pop (l))) {
+            zlist_destroy (&l);
+            errno = ENOSPC;
+            return -1;
+        }
         if (allocinfo_add_task (ai, cores_per_task)) {
             zlist_append (l, ai);
             assigned++;

--- a/src/shell/rcalc.c
+++ b/src/shell/rcalc.c
@@ -19,6 +19,7 @@
 
 #include "src/common/libczmqcontainers/czmq_containers.h"
 #include "src/common/libidset/idset.h"
+#include "src/common/libutil/errprintf.h"
 
 #include "rcalc.h"
 
@@ -29,7 +30,8 @@ struct rankinfo {
     int ngpus;
     const char *cores;
     const char *gpus;
-    cpu_set_t cpuset;
+    struct idset *cpuset;
+    struct idset *gpuset;
 };
 
 struct allocinfo {
@@ -40,6 +42,8 @@ struct allocinfo {
 
 struct rcalc {
     json_t *json;
+    json_t *R_lite;
+    struct idset *orig_ranks;
     int nranks;
     int ncores;
     int ngpus;
@@ -48,219 +52,151 @@ struct rcalc {
     struct allocinfo *alloc;
 };
 
-
-static const char * nexttoken (const char *p, int sep)
-{
-    if (p)
-        p = strchr (p, sep);
-    if (p)
-        p++;
-    return (p);
-}
-
-/*
- *  Temporarily copied from src/bindings/lua/lua-affinity
- */
-static int cstr_to_cpuset(cpu_set_t *mask, const char* str)
-{
-    const char *p, *q;
-    char *endptr;
-    q = str;
-    CPU_ZERO(mask);
-
-    if (strlen (str) == 0)
-        return 0;
-
-    while (p = q, q = nexttoken(q, ','), p) {
-        unsigned long a; /* beginning of range */
-        unsigned long b; /* end of range */
-        unsigned long s; /* stride */
-        const char *c1, *c2;
-
-        a = strtoul(p, &endptr, 10);
-        if (endptr == p)
-            return EINVAL;
-        if (a >= CPU_SETSIZE)
-            return E2BIG;
-        /*
-         *  Leading zeros are an error:
-         */
-        if ((a != 0 && *p == '0') || (a == 0 && memcmp (p, "00", 2L) == 0))
-            return 1;
-
-        b = a;
-        s = 1;
-
-        c1 = nexttoken(p, '-');
-        c2 = nexttoken(p, ',');
-        if (c1 != NULL && (c2 == NULL || c1 < c2)) {
-
-            /*
-             *  Previous conversion should have used up all characters
-             *     up to next '-'
-             */
-            if (endptr != (c1-1)) {
-                return 1;
-            }
-
-            b = strtoul (c1, &endptr, 10);
-            if (endptr == c1)
-                return EINVAL;
-            if (b >= CPU_SETSIZE)
-                return E2BIG;
-
-            c1 = nexttoken(c1, ':');
-            if (c1 != NULL && (c2 == NULL || c1 < c2)) {
-                s = strtoul (c1, &endptr, 10);
-                if (endptr == c1)
-                    return EINVAL;
-                if (b >= CPU_SETSIZE)
-                    return E2BIG;
-            }
-        }
-
-        if (!(a <= b))
-            return EINVAL;
-        while (a <= b) {
-            CPU_SET(a, mask);
-            a += s;
-        }
-    }
-
-    /*  Error if there are left over characters */
-    if (endptr && *endptr != '\0')
-        return EINVAL;
-
-    return 0;
-}
-
-static int cstr_count (const char *str)
-{
-    cpu_set_t set;
-    if (str == NULL)
-        return 0;
-    if (cstr_to_cpuset (&set, str))
-        return -1;
-    return CPU_COUNT (&set);
-}
-
-static int rankinfo_get (json_t *o, struct rankinfo *ri)
-{
-    json_error_t error;
-    int rc = json_unpack_ex (o, &error, 0, "{s:i, s:{s:s,s?:s}}",
-                "rank", &ri->rank,
-                "children",
-                "core", &ri->cores,
-                "gpu",  &ri->gpus);
-    if (rc < 0) {
-        fprintf (stderr, "json_unpack: %s\n", error.text);
-        return -1;
-    }
-
-    if (!ri->cores || cstr_to_cpuset (&ri->cpuset, ri->cores))
-        return -1;
-
-    ri->ncores = CPU_COUNT (&ri->cpuset);
-    ri->ngpus = cstr_count (ri->gpus);
-    return (0);
-}
-
-static int expand_rank_ranges_one (json_t *out, json_t *entry)
-{
-    const char *rank;
-    json_t *children;
-    struct idset *ids;
-    unsigned int id;
-    json_t *n;
-
-    if (json_unpack_ex (entry, NULL, 0,
-                        "{s:s s:o}",
-                        "rank", &rank,
-                        "children", &children) < 0)
-        return -1;
-    if (!(ids = idset_decode (rank)))
-        return -1;
-    id = idset_first (ids);
-    while (id != IDSET_INVALID_ID) {
-        if (!(n = json_pack ("{s:i s:O}",
-                             "rank", id,
-                             "children", children)))
-            return -1;
-        if (json_array_append_new (out, n) < 0) {
-            json_decref (n);
-            return -1;
-        }
-        id = idset_next (ids, id);
-    }
-    idset_destroy (ids);
-    return 0;
-}
-
-/* Convert from R version 1 internal R_lite object to the earlier wreck R_lite
- * object understood by this module.  They are the same except Rv1 specifies
- * ranks as an idset rather than integer, allowing for compact representation.
- */
-static json_t *expand_rank_ranges (json_t *R_lite)
-{
-    json_t *out;
-    json_t *entry;
-    size_t index;
-
-    if (!(out = json_array ())) // accumulate new array
-        return NULL;
-    json_array_foreach (R_lite, index, entry) {
-        if (expand_rank_ranges_one (out, entry) < 0)
-            goto error;
-    }
-    return out;
-error:
-    json_decref (out);
-    return NULL;
-}
-
 void rcalc_destroy (rcalc_t *r)
 {
     if (r == NULL)
         return;
     json_decref (r->json);
+    idset_destroy (r->orig_ranks);
+    for (int i = 0; i < r->nranks; i++) {
+        idset_destroy (r->ranks[i].cpuset);
+        idset_destroy (r->ranks[i].gpuset);
+    }
     free (r->ranks);
     free (r->alloc);
     memset (r, 0, sizeof (*r));
     free (r);
 }
 
+static struct idset * rcalc_ranks (rcalc_t *r, flux_error_t *errp)
+{
+    json_t *entry;
+    size_t index;
+    json_error_t error;
+    struct idset *ranks;
+
+    if (!(ranks = idset_create (0, IDSET_FLAG_AUTOGROW)))
+        return NULL;
+
+    json_array_foreach (r->R_lite, index, entry) {
+        struct idset *ids;
+        const char *rank;
+        if (json_unpack_ex (entry, &error, 0,
+                            "{s:s}",
+                            "rank", &rank) < 0) {
+            errprintf (errp, "%s", error.text);
+            goto err;
+        }
+        if (!(ids = idset_decode (rank))) {
+            errprintf (errp, "invalid idset %s", rank);
+            goto err;
+        }
+        if (idset_add (ranks, ids) < 0) {
+            idset_destroy (ids);
+            errprintf (errp, "idset_add (%s): %s", rank, strerror (errno));
+            goto err;
+        }
+        idset_destroy (ids);
+    }
+    return ranks;
+err:
+    idset_destroy (ranks);
+    return NULL;
+}
+
+static int rankinfo_get_children (struct rankinfo *ri,
+                                  json_t *children,
+                                  flux_error_t *errp)
+{
+    json_error_t error;
+
+    if (json_unpack_ex (children, &error, 0,
+                        "{s:s s?s}",
+                        "core", &ri->cores,
+                        "gpu", &ri->gpus) < 0)
+        return errprintf (errp, "%s", error.text);
+
+    if (!(ri->cpuset = idset_decode (ri->cores))
+        || !(ri->gpuset = idset_decode (ri->gpus ? ri->gpus : "")))
+        return errprintf (errp, "Failed to decode cpu or gpu sets");
+
+    ri->ncores = idset_count (ri->cpuset);
+    ri->ngpus = idset_count (ri->gpuset);
+
+    return 0;
+}
+
+static int rcalc_process_all_ranks (rcalc_t *r, flux_error_t *errp)
+{
+    json_t *entry;
+    size_t index;
+    json_error_t error;
+    int n = 0;
+
+    json_array_foreach (r->R_lite, index, entry) {
+        const char *rank;
+        json_t *children;
+        unsigned int i;
+        struct idset *ids;
+
+        if (json_unpack_ex (entry, &error, 0,
+                            "{s:s s:o}",
+                            "rank", &rank,
+                            "children", &children) < 0)
+            return errprintf (errp, "%s", error.text);
+
+        if (!(ids = idset_decode (rank)))
+            return errprintf (errp,
+                              "idset_decode (%s): %s",
+                              rank,
+                              strerror (errno));
+
+        i = idset_first (ids);
+        while (i != IDSET_INVALID_ID) {
+            struct rankinfo *ri = &r->ranks[n];
+            ri->id = n;
+            ri->rank = i;
+            if (rankinfo_get_children (ri, children, errp) < 0) {
+                idset_destroy (ids);
+                return -1;
+            }
+            r->ncores += ri->ncores;
+            r->ngpus += ri->ngpus;
+            n++;
+            i = idset_next (ids, i);
+        }
+        idset_destroy (ids);
+    }
+    return 0;
+}
+
 rcalc_t * rcalc_create_json (json_t *o)
 {
-    int i;
     int version;
-    json_t *R_lite;
+    flux_error_t error;
     rcalc_t *r = calloc (1, sizeof (*r));
     if (!r)
         return (NULL);
+    r->json = json_incref (o);
     if (json_unpack_ex (o, NULL, 0,
                         "{s:i s:{s:o}}",
                         "version", &version,
                         "execution",
-                        "R_lite", &R_lite) < 0)
+                        "R_lite", &r->R_lite) < 0)
         goto fail;
     if (version != 1) {
         errno = EINVAL;
         goto fail;
     }
-    if (!(r->json = expand_rank_ranges (R_lite))) {
-        errno = EINVAL;
+    if (!(r->orig_ranks = rcalc_ranks (r, &error)))
         goto fail;
-    }
-    r->nranks = json_array_size (r->json);
+    r->nranks = idset_count (r->orig_ranks);
     r->ranks = calloc (r->nranks, sizeof (struct rankinfo));
     r->alloc = calloc (r->nranks, sizeof (struct allocinfo));
-    for (i = 0; i < r->nranks; i++) {
-        r->ranks[i].id = i;
-        if (rankinfo_get (json_array_get (r->json, i), &r->ranks[i]) < 0)
-            goto fail;
-        r->ncores += r->ranks[i].ncores;
-        r->ngpus += r->ranks[i].ngpus;
-    }
+
+    if (rcalc_process_all_ranks (r, &error) < 0)
+        goto fail;
+
     return (r);
 fail:
     rcalc_destroy (r);
@@ -491,7 +427,6 @@ static void rcalc_rankinfo_set (rcalc_t *r, int id,
     rli->ncores = ri->ncores;
     rli->ntasks = ai->ntasks;
     rli->global_basis =  ai->basis;
-    memcpy (&rli->cpuset, &ri->cpuset, sizeof (cpu_set_t));
     /*  Copy cores string to rli, in the very unlikely event that
      *   we get a huge cores string, indicate truncation.
      */

--- a/src/shell/rcalc.h
+++ b/src/shell/rcalc.h
@@ -23,7 +23,6 @@ struct rcalc_rankinfo {
     int ntasks;               /* Number of tasks assigned to this rank   */
     int global_basis;         /* Task id of the first task on this rank  */
     int ncores;               /* Number of cores allocated on this rank  */
-    cpu_set_t cpuset;         /* cpu_set_t representation of cores list  */
     char cores [128];         /* String core list (directly from R_lite) */
     char gpus [128];          /* String gpu list (directly from R)       */
 };

--- a/src/shell/rcalc.h
+++ b/src/shell/rcalc.h
@@ -21,7 +21,6 @@ struct rcalc_rankinfo {
     int nodeid;               /* This rank's nodeid within the job       */
     int rank;                 /* The current broker rank                 */
     int ntasks;               /* Number of tasks assigned to this rank   */
-    int global_basis;         /* Task id of the first task on this rank  */
     int ncores;               /* Number of cores allocated on this rank  */
     char cores [128];         /* String core list (directly from R_lite) */
     char gpus [128];          /* String gpu list (directly from R)       */

--- a/src/shell/shell.c
+++ b/src/shell/shell.c
@@ -1355,9 +1355,6 @@ int main (int argc, char *argv[])
     if (shell_log_reinit (&shell) < 0)
         shell_die_errno (1, "shell_log_reinit");
 
-    /* Now that verbosity may have changed, log shell startup info */
-    shell_log_info (&shell);
-
     /* Register service on the leader shell.
      */
     if (!(shell.svc = shell_svc_create (&shell)))
@@ -1380,6 +1377,11 @@ int main (int argc, char *argv[])
      */
     if (shell_init (&shell) < 0)
         shell_die_errno (1, "shell_init");
+
+    /* Now that verbosity, task mapping, etc. may have changed, log
+     * basic shell info.
+     */
+    shell_log_info (&shell);
 
     /* Barrier to ensure initialization has completed across all shells.
      */

--- a/src/shell/shell.c
+++ b/src/shell/shell.c
@@ -1341,9 +1341,6 @@ int main (int argc, char *argv[])
     if (shell_export_environment_from_job (&shell) < 0)
         exit (1);
 
-    if (shell_register_event_context (&shell) < 0)
-        shell_die (1, "failed to add standard shell event context");
-
     /* Set verbose flag if set in attributes.system.shell.verbose */
     if (flux_shell_getopt_unpack (&shell, "verbose", "i", &shell.verbose) < 0)
         shell_die (1, "failed to parse attributes.system.shell.verbose");
@@ -1370,6 +1367,14 @@ int main (int argc, char *argv[])
      */
     if (shell_initrc (&shell) < 0)
         shell_die_errno (1, "shell_initrc");
+
+    /* Register the default components of the shell.init eventlog event
+     * context. This includes the current taskmap, which may have been
+     * altered by a plugin during shell_initrc(), so this must be done
+     * after that call completes.
+     */
+    if (shell_register_event_context (&shell) < 0)
+        shell_die (1, "failed to add standard shell event context");
 
     /* Call "shell_init" plugins.
      */

--- a/src/shell/shell.c
+++ b/src/shell/shell.c
@@ -1152,7 +1152,7 @@ static int load_initrc (flux_shell_t *shell, const char *default_rcfile)
     return 0;
 }
 
-static int shell_init (flux_shell_t *shell)
+static int shell_initrc (flux_shell_t *shell)
 {
     const char *default_rcfile = shell_conf_get ("shell_initrc");
 
@@ -1186,9 +1186,11 @@ static int shell_init (flux_shell_t *shell)
 
     /*  Load initrc file if necessary
      */
-    if (load_initrc (shell, default_rcfile) < 0)
-        return -1;
+    return load_initrc (shell, default_rcfile);
+}
 
+static int shell_init (flux_shell_t *shell)
+{
     return plugstack_call (shell->plugstack, "shell.init", NULL);
 }
 
@@ -1364,7 +1366,12 @@ int main (int argc, char *argv[])
     if (!(shell.svc = shell_svc_create (&shell)))
         shell_die (1, "shell_svc_create");
 
-    /* Call shell initialization routines and "shell_init" plugins.
+    /* Change working directory and Load shell initrc
+     */
+    if (shell_initrc (&shell) < 0)
+        shell_die_errno (1, "shell_initrc");
+
+    /* Call "shell_init" plugins.
      */
     if (shell_init (&shell) < 0)
         shell_die_errno (1, "shell_init");

--- a/src/shell/shell.c
+++ b/src/shell/shell.c
@@ -431,6 +431,15 @@ int flux_shell_get_hwloc_xml (flux_shell_t *shell, const char **xmlp)
     return 0;
 }
 
+const struct taskmap *flux_shell_get_taskmap (flux_shell_t *shell)
+{
+    if (!shell || !shell->info) {
+        errno = EINVAL;
+        return NULL;
+    }
+    return shell->info->taskmap;
+}
+
 static json_t *flux_shell_get_info_object (flux_shell_t *shell)
 {
     json_error_t err;

--- a/src/shell/shell.h
+++ b/src/shell/shell.h
@@ -12,6 +12,7 @@
 #define FLUX_SHELL_H
 
 #include <flux/core.h>
+#include <flux/taskmap.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -96,6 +97,10 @@ int flux_shell_unsetenv (flux_shell_t *shell, const char *name);
 /*  Return the job shell's cached copy of hwloc XML.
  */
 int flux_shell_get_hwloc_xml (flux_shell_t *shell, const char **xmlp);
+
+/*  Return the current shell taskmap
+ */
+const struct taskmap *flux_shell_get_taskmap (flux_shell_t *shell);
 
 /*  Return shell info as a JSON string.
  *  {

--- a/src/shell/task.c
+++ b/src/shell/task.c
@@ -91,7 +91,8 @@ error:
 }
 
 struct shell_task *shell_task_create (struct shell_info *info,
-                                      int index)
+                                      int index,
+                                      int taskid)
 {
     struct shell_task *task;
     const char *key;
@@ -103,7 +104,7 @@ struct shell_task *shell_task_create (struct shell_info *info,
         return NULL;
 
     task->index = index;
-    task->rank = info->rankinfo.global_basis + index;
+    task->rank = taskid;
     task->size = info->total_ntasks;
     if (!(task->cmd = flux_cmd_create (0, NULL, NULL)))
         goto error;

--- a/src/shell/task.h
+++ b/src/shell/task.h
@@ -54,7 +54,9 @@ struct shell_task {
 
 void shell_task_destroy (struct shell_task *task);
 
-struct shell_task *shell_task_create (struct shell_info *info, int index);
+struct shell_task *shell_task_create (struct shell_info *info,
+                                      int index,
+                                      int taskid);
 
 int shell_task_start (struct flux_shell *shell,
                       struct shell_task *task,

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -185,6 +185,7 @@ TESTSCRIPTS = \
 	t2613-job-shell-batch.t \
 	t2614-job-shell-doom.t \
 	t2615-job-shell-rlimit.t \
+	t2616-job-shell-taskmap.t \
 	t2700-mini-cmd.t \
 	t2701-mini-batch.t \
 	t2702-mini-alloc.t \
@@ -431,6 +432,7 @@ check_LTLIBRARIES = \
 	shell/plugins/log.la \
 	shell/plugins/test-event.la \
 	shell/plugins/jobspec-info.la \
+	shell/plugins/taskmap-reverse.la \
 	job-manager/plugins/priority-wait.la \
 	job-manager/plugins/priority-invert.la \
 	job-manager/plugins/args.la \
@@ -807,6 +809,13 @@ shell_plugins_jobspec_info_la_LDFLAGS = \
 	$(fluxplugin_ldflags) -module -rpath /nowhere
 shell_plugins_jobspec_info_la_LIBADD = \
 	$(top_builddir)/src/common/libtap/libtap.la \
+	$(top_builddir)/src/common/libflux-core.la
+
+shell_plugins_taskmap_reverse_la_SOURCES = shell/plugins/taskmap-reverse.c
+shell_plugins_taskmap_reverse_la_CPPFLAGS = $(test_cppflags)
+shell_plugins_taskmap_reverse_la_LDFLAGS = \
+	$(fluxplugin_ldflags) -module -rpath /nowhere
+shell_plugins_taskmap_reverse_la_LIBADD = \
 	$(top_builddir)/src/common/libflux-core.la
 
 job_manager_plugins_priority_wait_la_SOURCES = \

--- a/t/shell/output/1r1c.1.expected
+++ b/t/shell/output/1r1c.1.expected
@@ -1,3 +1,3 @@
 Distributing 1 tasks across 1 nodes with 1 cores
 Used 1 nodes
-0: rank=0 ntasks=1 basis=0 cores=0
+0: rank=0 ntasks=1 cores=0

--- a/t/shell/output/1r1c2gpu.1.expected
+++ b/t/shell/output/1r1c2gpu.1.expected
@@ -1,3 +1,3 @@
 Distributing 1 tasks across 1 nodes with 1 cores 2 gpus
 Used 1 nodes
-0: rank=0 ntasks=1 basis=0 cores=0 gpus=0-1
+0: rank=0 ntasks=1 cores=0 gpus=0-1

--- a/t/shell/output/1r2c.1.expected
+++ b/t/shell/output/1r2c.1.expected
@@ -1,3 +1,3 @@
 Distributing 1 tasks across 1 nodes with 2 cores
 Used 1 nodes
-0: rank=0 ntasks=1 basis=0 cores=0-1
+0: rank=0 ntasks=1 cores=0-1

--- a/t/shell/output/1r2c.2.expected
+++ b/t/shell/output/1r2c.2.expected
@@ -1,3 +1,3 @@
 Distributing 2 tasks across 1 nodes with 2 cores
 Used 1 nodes
-0: rank=0 ntasks=2 basis=0 cores=0-1
+0: rank=0 ntasks=2 cores=0-1

--- a/t/shell/output/4r4c4r1c.16.expected
+++ b/t/shell/output/4r4c4r1c.16.expected
@@ -1,10 +1,10 @@
 Distributing 16 tasks across 8 nodes with 20 cores
 Used 8 nodes
-0: rank=0 ntasks=3 basis=0 cores=0-3
-1: rank=1 ntasks=3 basis=3 cores=0-3
-2: rank=2 ntasks=3 basis=6 cores=0-3
-3: rank=3 ntasks=3 basis=9 cores=0-3
-4: rank=4 ntasks=1 basis=12 cores=0
-5: rank=5 ntasks=1 basis=13 cores=0
-6: rank=6 ntasks=1 basis=14 cores=0
-7: rank=7 ntasks=1 basis=15 cores=0
+0: rank=0 ntasks=3 cores=0-3
+1: rank=1 ntasks=3 cores=0-3
+2: rank=2 ntasks=3 cores=0-3
+3: rank=3 ntasks=3 cores=0-3
+4: rank=4 ntasks=1 cores=0
+5: rank=5 ntasks=1 cores=0
+6: rank=6 ntasks=1 cores=0
+7: rank=7 ntasks=1 cores=0

--- a/t/shell/output/4r4c4r1c.20.expected
+++ b/t/shell/output/4r4c4r1c.20.expected
@@ -1,10 +1,10 @@
 Distributing 20 tasks across 8 nodes with 20 cores
 Used 8 nodes
-0: rank=0 ntasks=4 basis=0 cores=0-3
-1: rank=1 ntasks=4 basis=4 cores=0-3
-2: rank=2 ntasks=4 basis=8 cores=0-3
-3: rank=3 ntasks=4 basis=12 cores=0-3
-4: rank=4 ntasks=1 basis=16 cores=0
-5: rank=5 ntasks=1 basis=17 cores=0
-6: rank=6 ntasks=1 basis=18 cores=0
-7: rank=7 ntasks=1 basis=19 cores=0
+0: rank=0 ntasks=4 cores=0-3
+1: rank=1 ntasks=4 cores=0-3
+2: rank=2 ntasks=4 cores=0-3
+3: rank=3 ntasks=4 cores=0-3
+4: rank=4 ntasks=1 cores=0
+5: rank=5 ntasks=1 cores=0
+6: rank=6 ntasks=1 cores=0
+7: rank=7 ntasks=1 cores=0

--- a/t/shell/output/4r4c4r1c.4.expected
+++ b/t/shell/output/4r4c4r1c.4.expected
@@ -1,10 +1,10 @@
 Distributing 4 tasks across 8 nodes with 20 cores
 Used 4 nodes
-0: rank=0 ntasks=1 basis=0 cores=0-3
-1: rank=1 ntasks=1 basis=1 cores=0-3
-2: rank=2 ntasks=1 basis=2 cores=0-3
-3: rank=3 ntasks=1 basis=3 cores=0-3
-4: rank=4 ntasks=0 basis=4 cores=0
-5: rank=5 ntasks=0 basis=4 cores=0
-6: rank=6 ntasks=0 basis=4 cores=0
-7: rank=7 ntasks=0 basis=4 cores=0
+0: rank=0 ntasks=1 cores=0-3
+1: rank=1 ntasks=1 cores=0-3
+2: rank=2 ntasks=1 cores=0-3
+3: rank=3 ntasks=1 cores=0-3
+4: rank=4 ntasks=0 cores=0
+5: rank=5 ntasks=0 cores=0
+6: rank=6 ntasks=0 cores=0
+7: rank=7 ntasks=0 cores=0

--- a/t/shell/output/4r4c4r1c.8.expected
+++ b/t/shell/output/4r4c4r1c.8.expected
@@ -1,10 +1,10 @@
 Distributing 8 tasks across 8 nodes with 20 cores
 Used 8 nodes
-0: rank=0 ntasks=1 basis=0 cores=0-3
-1: rank=1 ntasks=1 basis=1 cores=0-3
-2: rank=2 ntasks=1 basis=2 cores=0-3
-3: rank=3 ntasks=1 basis=3 cores=0-3
-4: rank=4 ntasks=1 basis=4 cores=0
-5: rank=5 ntasks=1 basis=5 cores=0
-6: rank=6 ntasks=1 basis=6 cores=0
-7: rank=7 ntasks=1 basis=7 cores=0
+0: rank=0 ntasks=1 cores=0-3
+1: rank=1 ntasks=1 cores=0-3
+2: rank=2 ntasks=1 cores=0-3
+3: rank=3 ntasks=1 cores=0-3
+4: rank=4 ntasks=1 cores=0
+5: rank=5 ntasks=1 cores=0
+6: rank=6 ntasks=1 cores=0
+7: rank=7 ntasks=1 cores=0

--- a/t/shell/output/4r4c4r1c.9.expected
+++ b/t/shell/output/4r4c4r1c.9.expected
@@ -1,10 +1,10 @@
 Distributing 9 tasks across 8 nodes with 20 cores
 Used 8 nodes
-0: rank=0 ntasks=2 basis=0 cores=0-3
-1: rank=1 ntasks=1 basis=2 cores=0-3
-2: rank=2 ntasks=1 basis=3 cores=0-3
-3: rank=3 ntasks=1 basis=4 cores=0-3
-4: rank=4 ntasks=1 basis=5 cores=0
-5: rank=5 ntasks=1 basis=6 cores=0
-6: rank=6 ntasks=1 basis=7 cores=0
-7: rank=7 ntasks=1 basis=8 cores=0
+0: rank=0 ntasks=2 cores=0-3
+1: rank=1 ntasks=1 cores=0-3
+2: rank=2 ntasks=1 cores=0-3
+3: rank=3 ntasks=1 cores=0-3
+4: rank=4 ntasks=1 cores=0
+5: rank=5 ntasks=1 cores=0
+6: rank=6 ntasks=1 cores=0
+7: rank=7 ntasks=1 cores=0

--- a/t/shell/output/8r1c.4.expected
+++ b/t/shell/output/8r1c.4.expected
@@ -1,10 +1,10 @@
 Distributing 4 tasks across 8 nodes with 8 cores
 Used 4 nodes
-0: rank=0 ntasks=1 basis=0 cores=0
-1: rank=1 ntasks=1 basis=1 cores=0
-2: rank=2 ntasks=1 basis=2 cores=0
-3: rank=3 ntasks=1 basis=3 cores=0
-4: rank=4 ntasks=0 basis=4 cores=0
-5: rank=5 ntasks=0 basis=4 cores=0
-6: rank=6 ntasks=0 basis=4 cores=0
-7: rank=7 ntasks=0 basis=4 cores=0
+0: rank=0 ntasks=1 cores=0
+1: rank=1 ntasks=1 cores=0
+2: rank=2 ntasks=1 cores=0
+3: rank=3 ntasks=1 cores=0
+4: rank=4 ntasks=0 cores=0
+5: rank=5 ntasks=0 cores=0
+6: rank=6 ntasks=0 cores=0
+7: rank=7 ntasks=0 cores=0

--- a/t/shell/output/8r1c.8.expected
+++ b/t/shell/output/8r1c.8.expected
@@ -1,10 +1,10 @@
 Distributing 8 tasks across 8 nodes with 8 cores
 Used 8 nodes
-0: rank=0 ntasks=1 basis=0 cores=0
-1: rank=1 ntasks=1 basis=1 cores=0
-2: rank=2 ntasks=1 basis=2 cores=0
-3: rank=3 ntasks=1 basis=3 cores=0
-4: rank=4 ntasks=1 basis=4 cores=0
-5: rank=5 ntasks=1 basis=5 cores=0
-6: rank=6 ntasks=1 basis=6 cores=0
-7: rank=7 ntasks=1 basis=7 cores=0
+0: rank=0 ntasks=1 cores=0
+1: rank=1 ntasks=1 cores=0
+2: rank=2 ntasks=1 cores=0
+3: rank=3 ntasks=1 cores=0
+4: rank=4 ntasks=1 cores=0
+5: rank=5 ntasks=1 cores=0
+6: rank=6 ntasks=1 cores=0
+7: rank=7 ntasks=1 cores=0

--- a/t/shell/output/per-resource/1r1c.core.1.expected
+++ b/t/shell/output/per-resource/1r1c.core.1.expected
@@ -1,3 +1,3 @@
 Distributing 1 tasks per-core across 1 nodes with 1 cores
 Used 1 nodes
-0: rank=0 ntasks=1 basis=0 cores=0
+0: rank=0 ntasks=1 cores=0

--- a/t/shell/output/per-resource/1r1c.core.2.expected
+++ b/t/shell/output/per-resource/1r1c.core.2.expected
@@ -1,3 +1,3 @@
 Distributing 2 tasks per-core across 1 nodes with 1 cores
 Used 1 nodes
-0: rank=0 ntasks=2 basis=0 cores=0
+0: rank=0 ntasks=2 cores=0

--- a/t/shell/output/per-resource/1r1c.node.1.expected
+++ b/t/shell/output/per-resource/1r1c.node.1.expected
@@ -1,3 +1,3 @@
 Distributing 1 tasks per-node across 1 nodes with 1 cores
 Used 1 nodes
-0: rank=0 ntasks=1 basis=0 cores=0
+0: rank=0 ntasks=1 cores=0

--- a/t/shell/output/per-resource/1r1c.node.2.expected
+++ b/t/shell/output/per-resource/1r1c.node.2.expected
@@ -1,3 +1,3 @@
 Distributing 2 tasks per-node across 1 nodes with 1 cores
 Used 1 nodes
-0: rank=0 ntasks=2 basis=0 cores=0
+0: rank=0 ntasks=2 cores=0

--- a/t/shell/output/per-resource/1r1c2gpu.core.1.expected
+++ b/t/shell/output/per-resource/1r1c2gpu.core.1.expected
@@ -1,3 +1,3 @@
 Distributing 1 tasks per-core across 1 nodes with 1 cores 2 gpus
 Used 1 nodes
-0: rank=0 ntasks=1 basis=0 cores=0 gpus=0-1
+0: rank=0 ntasks=1 cores=0 gpus=0-1

--- a/t/shell/output/per-resource/1r1c2gpu.core.2.expected
+++ b/t/shell/output/per-resource/1r1c2gpu.core.2.expected
@@ -1,3 +1,3 @@
 Distributing 2 tasks per-core across 1 nodes with 1 cores 2 gpus
 Used 1 nodes
-0: rank=0 ntasks=2 basis=0 cores=0 gpus=0-1
+0: rank=0 ntasks=2 cores=0 gpus=0-1

--- a/t/shell/output/per-resource/1r1c2gpu.node.1.expected
+++ b/t/shell/output/per-resource/1r1c2gpu.node.1.expected
@@ -1,3 +1,3 @@
 Distributing 1 tasks per-node across 1 nodes with 1 cores 2 gpus
 Used 1 nodes
-0: rank=0 ntasks=1 basis=0 cores=0 gpus=0-1
+0: rank=0 ntasks=1 cores=0 gpus=0-1

--- a/t/shell/output/per-resource/1r1c2gpu.node.2.expected
+++ b/t/shell/output/per-resource/1r1c2gpu.node.2.expected
@@ -1,3 +1,3 @@
 Distributing 2 tasks per-node across 1 nodes with 1 cores 2 gpus
 Used 1 nodes
-0: rank=0 ntasks=2 basis=0 cores=0 gpus=0-1
+0: rank=0 ntasks=2 cores=0 gpus=0-1

--- a/t/shell/output/per-resource/1r2c.core.1.expected
+++ b/t/shell/output/per-resource/1r2c.core.1.expected
@@ -1,3 +1,3 @@
 Distributing 1 tasks per-core across 1 nodes with 2 cores
 Used 1 nodes
-0: rank=0 ntasks=2 basis=0 cores=0-1
+0: rank=0 ntasks=2 cores=0-1

--- a/t/shell/output/per-resource/1r2c.core.2.expected
+++ b/t/shell/output/per-resource/1r2c.core.2.expected
@@ -1,3 +1,3 @@
 Distributing 2 tasks per-core across 1 nodes with 2 cores
 Used 1 nodes
-0: rank=0 ntasks=4 basis=0 cores=0-1
+0: rank=0 ntasks=4 cores=0-1

--- a/t/shell/output/per-resource/1r2c.node.1.expected
+++ b/t/shell/output/per-resource/1r2c.node.1.expected
@@ -1,3 +1,3 @@
 Distributing 1 tasks per-node across 1 nodes with 2 cores
 Used 1 nodes
-0: rank=0 ntasks=1 basis=0 cores=0-1
+0: rank=0 ntasks=1 cores=0-1

--- a/t/shell/output/per-resource/1r2c.node.2.expected
+++ b/t/shell/output/per-resource/1r2c.node.2.expected
@@ -1,3 +1,3 @@
 Distributing 2 tasks per-node across 1 nodes with 2 cores
 Used 1 nodes
-0: rank=0 ntasks=2 basis=0 cores=0-1
+0: rank=0 ntasks=2 cores=0-1

--- a/t/shell/output/per-resource/4r4c4r1c.core.1.expected
+++ b/t/shell/output/per-resource/4r4c4r1c.core.1.expected
@@ -1,10 +1,10 @@
 Distributing 1 tasks per-core across 8 nodes with 20 cores
 Used 8 nodes
-0: rank=0 ntasks=4 basis=0 cores=0-3
-1: rank=1 ntasks=4 basis=4 cores=0-3
-2: rank=2 ntasks=4 basis=8 cores=0-3
-3: rank=3 ntasks=4 basis=12 cores=0-3
-4: rank=4 ntasks=1 basis=16 cores=0
-5: rank=5 ntasks=1 basis=17 cores=0
-6: rank=6 ntasks=1 basis=18 cores=0
-7: rank=7 ntasks=1 basis=19 cores=0
+0: rank=0 ntasks=4 cores=0-3
+1: rank=1 ntasks=4 cores=0-3
+2: rank=2 ntasks=4 cores=0-3
+3: rank=3 ntasks=4 cores=0-3
+4: rank=4 ntasks=1 cores=0
+5: rank=5 ntasks=1 cores=0
+6: rank=6 ntasks=1 cores=0
+7: rank=7 ntasks=1 cores=0

--- a/t/shell/output/per-resource/4r4c4r1c.core.2.expected
+++ b/t/shell/output/per-resource/4r4c4r1c.core.2.expected
@@ -1,10 +1,10 @@
 Distributing 2 tasks per-core across 8 nodes with 20 cores
 Used 8 nodes
-0: rank=0 ntasks=8 basis=0 cores=0-3
-1: rank=1 ntasks=8 basis=8 cores=0-3
-2: rank=2 ntasks=8 basis=16 cores=0-3
-3: rank=3 ntasks=8 basis=24 cores=0-3
-4: rank=4 ntasks=2 basis=32 cores=0
-5: rank=5 ntasks=2 basis=34 cores=0
-6: rank=6 ntasks=2 basis=36 cores=0
-7: rank=7 ntasks=2 basis=38 cores=0
+0: rank=0 ntasks=8 cores=0-3
+1: rank=1 ntasks=8 cores=0-3
+2: rank=2 ntasks=8 cores=0-3
+3: rank=3 ntasks=8 cores=0-3
+4: rank=4 ntasks=2 cores=0
+5: rank=5 ntasks=2 cores=0
+6: rank=6 ntasks=2 cores=0
+7: rank=7 ntasks=2 cores=0

--- a/t/shell/output/per-resource/4r4c4r1c.node.1.expected
+++ b/t/shell/output/per-resource/4r4c4r1c.node.1.expected
@@ -1,10 +1,10 @@
 Distributing 1 tasks per-node across 8 nodes with 20 cores
 Used 8 nodes
-0: rank=0 ntasks=1 basis=0 cores=0-3
-1: rank=1 ntasks=1 basis=1 cores=0-3
-2: rank=2 ntasks=1 basis=2 cores=0-3
-3: rank=3 ntasks=1 basis=3 cores=0-3
-4: rank=4 ntasks=1 basis=4 cores=0
-5: rank=5 ntasks=1 basis=5 cores=0
-6: rank=6 ntasks=1 basis=6 cores=0
-7: rank=7 ntasks=1 basis=7 cores=0
+0: rank=0 ntasks=1 cores=0-3
+1: rank=1 ntasks=1 cores=0-3
+2: rank=2 ntasks=1 cores=0-3
+3: rank=3 ntasks=1 cores=0-3
+4: rank=4 ntasks=1 cores=0
+5: rank=5 ntasks=1 cores=0
+6: rank=6 ntasks=1 cores=0
+7: rank=7 ntasks=1 cores=0

--- a/t/shell/output/per-resource/4r4c4r1c.node.2.expected
+++ b/t/shell/output/per-resource/4r4c4r1c.node.2.expected
@@ -1,10 +1,10 @@
 Distributing 2 tasks per-node across 8 nodes with 20 cores
 Used 8 nodes
-0: rank=0 ntasks=2 basis=0 cores=0-3
-1: rank=1 ntasks=2 basis=2 cores=0-3
-2: rank=2 ntasks=2 basis=4 cores=0-3
-3: rank=3 ntasks=2 basis=6 cores=0-3
-4: rank=4 ntasks=2 basis=8 cores=0
-5: rank=5 ntasks=2 basis=10 cores=0
-6: rank=6 ntasks=2 basis=12 cores=0
-7: rank=7 ntasks=2 basis=14 cores=0
+0: rank=0 ntasks=2 cores=0-3
+1: rank=1 ntasks=2 cores=0-3
+2: rank=2 ntasks=2 cores=0-3
+3: rank=3 ntasks=2 cores=0-3
+4: rank=4 ntasks=2 cores=0
+5: rank=5 ntasks=2 cores=0
+6: rank=6 ntasks=2 cores=0
+7: rank=7 ntasks=2 cores=0

--- a/t/shell/output/per-resource/8r1c.core.1.expected
+++ b/t/shell/output/per-resource/8r1c.core.1.expected
@@ -1,10 +1,10 @@
 Distributing 1 tasks per-core across 8 nodes with 8 cores
 Used 8 nodes
-0: rank=0 ntasks=1 basis=0 cores=0
-1: rank=1 ntasks=1 basis=1 cores=0
-2: rank=2 ntasks=1 basis=2 cores=0
-3: rank=3 ntasks=1 basis=3 cores=0
-4: rank=4 ntasks=1 basis=4 cores=0
-5: rank=5 ntasks=1 basis=5 cores=0
-6: rank=6 ntasks=1 basis=6 cores=0
-7: rank=7 ntasks=1 basis=7 cores=0
+0: rank=0 ntasks=1 cores=0
+1: rank=1 ntasks=1 cores=0
+2: rank=2 ntasks=1 cores=0
+3: rank=3 ntasks=1 cores=0
+4: rank=4 ntasks=1 cores=0
+5: rank=5 ntasks=1 cores=0
+6: rank=6 ntasks=1 cores=0
+7: rank=7 ntasks=1 cores=0

--- a/t/shell/output/per-resource/8r1c.core.2.expected
+++ b/t/shell/output/per-resource/8r1c.core.2.expected
@@ -1,10 +1,10 @@
 Distributing 2 tasks per-core across 8 nodes with 8 cores
 Used 8 nodes
-0: rank=0 ntasks=2 basis=0 cores=0
-1: rank=1 ntasks=2 basis=2 cores=0
-2: rank=2 ntasks=2 basis=4 cores=0
-3: rank=3 ntasks=2 basis=6 cores=0
-4: rank=4 ntasks=2 basis=8 cores=0
-5: rank=5 ntasks=2 basis=10 cores=0
-6: rank=6 ntasks=2 basis=12 cores=0
-7: rank=7 ntasks=2 basis=14 cores=0
+0: rank=0 ntasks=2 cores=0
+1: rank=1 ntasks=2 cores=0
+2: rank=2 ntasks=2 cores=0
+3: rank=3 ntasks=2 cores=0
+4: rank=4 ntasks=2 cores=0
+5: rank=5 ntasks=2 cores=0
+6: rank=6 ntasks=2 cores=0
+7: rank=7 ntasks=2 cores=0

--- a/t/shell/output/per-resource/8r1c.node.1.expected
+++ b/t/shell/output/per-resource/8r1c.node.1.expected
@@ -1,10 +1,10 @@
 Distributing 1 tasks per-node across 8 nodes with 8 cores
 Used 8 nodes
-0: rank=0 ntasks=1 basis=0 cores=0
-1: rank=1 ntasks=1 basis=1 cores=0
-2: rank=2 ntasks=1 basis=2 cores=0
-3: rank=3 ntasks=1 basis=3 cores=0
-4: rank=4 ntasks=1 basis=4 cores=0
-5: rank=5 ntasks=1 basis=5 cores=0
-6: rank=6 ntasks=1 basis=6 cores=0
-7: rank=7 ntasks=1 basis=7 cores=0
+0: rank=0 ntasks=1 cores=0
+1: rank=1 ntasks=1 cores=0
+2: rank=2 ntasks=1 cores=0
+3: rank=3 ntasks=1 cores=0
+4: rank=4 ntasks=1 cores=0
+5: rank=5 ntasks=1 cores=0
+6: rank=6 ntasks=1 cores=0
+7: rank=7 ntasks=1 cores=0

--- a/t/shell/output/per-resource/8r1c.node.2.expected
+++ b/t/shell/output/per-resource/8r1c.node.2.expected
@@ -1,10 +1,10 @@
 Distributing 2 tasks per-node across 8 nodes with 8 cores
 Used 8 nodes
-0: rank=0 ntasks=2 basis=0 cores=0
-1: rank=1 ntasks=2 basis=2 cores=0
-2: rank=2 ntasks=2 basis=4 cores=0
-3: rank=3 ntasks=2 basis=6 cores=0
-4: rank=4 ntasks=2 basis=8 cores=0
-5: rank=5 ntasks=2 basis=10 cores=0
-6: rank=6 ntasks=2 basis=12 cores=0
-7: rank=7 ntasks=2 basis=14 cores=0
+0: rank=0 ntasks=2 cores=0
+1: rank=1 ntasks=2 cores=0
+2: rank=2 ntasks=2 cores=0
+3: rank=3 ntasks=2 cores=0
+4: rank=4 ntasks=2 cores=0
+5: rank=5 ntasks=2 cores=0
+6: rank=6 ntasks=2 cores=0
+7: rank=7 ntasks=2 cores=0

--- a/t/shell/plugins/invalid-args.c
+++ b/t/shell/plugins/invalid-args.c
@@ -107,6 +107,9 @@ static int shell_cb (flux_plugin_t *p,
     ok (flux_shell_get_jobspec_info (shell, NULL) < 0 && errno == EINVAL,
         "flux_shell_get_info with NULL json_str returns EINVAL");
 
+    ok (flux_shell_get_taskmap (NULL) == NULL && errno == EINVAL,
+        "flux_shell_get_taskmap (NULL) returns EINVAL");
+
     ok (flux_shell_jobspec_info_unpack (NULL, NULL) < 0 && errno == EINVAL,
         "flux_shell_info_unpack with NULL arg returns EINVAL");
     ok (flux_shell_jobspec_info_unpack (shell, NULL) < 0 && errno == EINVAL,

--- a/t/shell/plugins/taskmap-reverse.c
+++ b/t/shell/plugins/taskmap-reverse.c
@@ -1,0 +1,78 @@
+/************************************************************\
+ * Copyright 2022 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* test taskmap plugin
+ */
+#define FLUX_SHELL_PLUGIN_NAME "taskmap.reverse"
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <flux/core.h>
+#include <flux/shell.h>
+#include <flux/taskmap.h>
+
+static char *taskmap_reverse (const char *arg)
+{
+    struct taskmap *map = NULL;
+    struct taskmap *orig = NULL;
+    char *result = NULL;
+    int nnodes;
+    if (!(orig = taskmap_decode (arg, NULL))
+        || !(map = taskmap_create ()))
+        goto error;
+
+    nnodes = taskmap_nnodes (orig);
+    for (int i = nnodes - 1; i >= 0; i--) {
+        if (taskmap_append (map, i, 1, taskmap_ntasks (orig, i)) < 0)
+            goto error;
+    }
+    result = taskmap_encode (map, TASKMAP_ENCODE_WRAPPED);
+error:
+    taskmap_destroy (orig);
+    taskmap_destroy (map);
+    return result;
+}
+
+static int map_reverse (flux_plugin_t *p,
+                        const char *topic,
+                        flux_plugin_arg_t *args,
+                        void *data)
+{
+    const char *blockmap;
+    char *map;
+    if (flux_plugin_arg_unpack (args,
+                                FLUX_PLUGIN_ARG_IN,
+                                "{s:s}",
+                                "taskmap", &blockmap) < 0) {
+        shell_log_error ("unpack: %s", flux_plugin_arg_strerror (args));
+        return -1;
+    }
+    if (!(map = taskmap_reverse (blockmap))) {
+        shell_log_error ("failed to map tasks reverse");
+        return -1;
+    }
+    if (flux_plugin_arg_pack (args,
+                              FLUX_PLUGIN_ARG_OUT,
+                              "{s:s}",
+                              "taskmap", map) < 0)
+        return -1;
+    free (map);
+    return 0;
+}
+
+int flux_plugin_init (flux_plugin_t *p)
+{
+    return flux_plugin_add_handler (p, "taskmap.reverse", map_reverse, NULL);
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/t/shell/rcalc.c
+++ b/t/shell/rcalc.c
@@ -97,8 +97,8 @@ int main (int ac, char **av)
                      i, strerror (errno));
             exit (1);
         }
-        printf ("%d: rank=%d ntasks=%d basis=%d cores=%s",
-                ri.nodeid, ri.rank, ri.ntasks, ri.global_basis, ri.cores);
+        printf ("%d: rank=%d ntasks=%d cores=%s",
+                ri.nodeid, ri.rank, ri.ntasks, ri.cores);
         if (strlen(ri.gpus))
             printf (" gpus=%s", ri.gpus);
         printf ("\n");

--- a/t/t2600-job-shell-rcalc.t
+++ b/t/t2600-job-shell-rcalc.t
@@ -50,8 +50,8 @@ test_expect_success 'rcalc: distribute 5 slots of size 5 across 6 allocated' '
 	cat >55.expected <<-EOF &&
 	Distributing 5 tasks across 2 nodes with 30 cores
 	Used 2 nodes
-	0: rank=0 ntasks=3 basis=0 cores=0-14
-	1: rank=1 ntasks=2 basis=3 cores=0-14
+	0: rank=0 ntasks=3 cores=0-14
+	1: rank=1 ntasks=2 cores=0-14
 	EOF
 	test_cmp 55.expected 55.out
 '

--- a/t/t2609-job-shell-events.t
+++ b/t/t2609-job-shell-events.t
@@ -16,9 +16,9 @@ test_expect_success 'flux-shell: 1N: init and start shell events are emitted' '
 	flux job wait-event -vt 5 -p guest.exec.eventlog \
 		-m leader-rank=0 ${id} shell.init &&
 	flux job wait-event -vt 5 -p guest.exec.eventlog \
-		-m size=1 ${id} shell.init  &&
+		${id} shell.init  &&
 	flux job wait-event -vt 5 -p guest.exec.eventlog \
-		-m task-count=1 ${id} shell.start 
+		${id} shell.start
 '
 test_expect_success 'flux-shell: 2N: init and start shell events are emitted' '
 	id=$(flux mini submit -n4 -N2 /bin/true)  &&
@@ -27,7 +27,7 @@ test_expect_success 'flux-shell: 2N: init and start shell events are emitted' '
 	flux job wait-event -vt 5 -p guest.exec.eventlog \
 		-m size=2 ${id} shell.init  &&
 	flux job wait-event -vt 5 -p guest.exec.eventlog \
-		-m task-count=4 ${id} shell.start 
+		${id} shell.start
 '
 test_expect_success 'flux-shell: plugin can add event context' '
 	cat >test-event.lua <<-EOT &&

--- a/t/t2616-job-shell-taskmap.t
+++ b/t/t2616-job-shell-taskmap.t
@@ -1,0 +1,171 @@
+#!/bin/sh
+#
+test_description='Test flux-mini/flux-shell taskmap plugin support'
+
+. `dirname $0`/sharness.sh
+
+skip_all_unless_have jq
+
+test_under_flux 4 job
+
+# Test that actual task ranks match expected ranks.
+# Assumes job ouptut is `echo $FLUX_TASK_RANK: $(flux getattr rank)`
+test_check_taskmap() {
+	local id=$1
+	flux job attach $id | sort -n >$id.output &&
+	flux job taskmap --to=multiline $id >$id.expected &&
+	test_cmp $id.expected $id.output
+}
+
+test_expect_success 'create script for testing task mapping' '
+	cat <<-EOF >map.sh &&
+	#!/bin/sh
+	echo \$FLUX_TASK_RANK: \$(flux getattr rank)
+	EOF
+	chmod +x map.sh
+'
+test_expect_success 'flux job taskmap works' '
+	id=$(flux mini submit -N4 --tasks-per-node=4 ./map.sh) &&
+	test_must_fail flux job taskmap &&
+	test "$(flux job taskmap $id)" = "[[0,4,4,1]]" &&
+	test "$(flux job taskmap --taskids=0 $id)" = "0-3" &&
+	test "$(flux job taskmap --ntasks=0 $id)" = "4" &&
+	test "$(flux job taskmap --nodeid=15 $id)" = "3" &&
+	test "$(flux job taskmap --hostname=0 $id)" = "$(hostname -s)" &&
+	test "$(flux job taskmap --to=pmi $id)" = "(vector,(0,4,4))"
+'
+test_expect_success 'flux job taskmap works with taskmap on cmdline' '
+	flux job taskmap --to=raw "[[0,4,4,1]]" &&
+	flux job taskmap --to=raw "[[0,4,1,4]]"
+'
+test_expect_success 'flux job taskmap fails with invalid taskmap on cmdline' '
+	test_must_fail flux job taskmap "[[0,4,4]]"
+'
+test_expect_success 'flux job taskmap fails for canceled job' '
+	flux queue stop &&
+	id=$(flux mini submit -N4 true) &&
+	flux job cancel $id &&
+	flux queue start &&
+	test_must_fail flux job taskmap $id
+'
+test_expect_success 'flux job taskmap fails for invalid job' '
+	test_must_fail flux job taskmap f1
+'
+test_expect_success 'flux job taskmap fails with invalid arguments' '
+	id=$(flux mini submit -N4 --tasks-per-node=4 ./map.sh) &&
+	flux job taskmap $id &&
+	test_must_fail flux job taskmap --taskids=4 $id 2>no-taskids.err &&
+	test_debug "cat no-taskids.err" &&
+	grep "No taskids for node 4" no-taskids.err &&
+	test_must_fail flux job taskmap --ntasks=4 $id  2>no-ntasks.err &&
+	test_debug "cat no-ntasks.err" &&
+	grep "failed to get task count for node 4" no-ntasks.err &&
+	test_must_fail flux job taskmap --nodeid=24 $id 2>no-nodeid.err &&
+	test_debug "cat no-nodeid.err" &&
+	grep "failed to get nodeid for task 24" no-nodeid.err &&
+	test_must_fail flux job taskmap --to=foo $id 2>bad-to.err &&
+	test_debug "cat bad-to.err" &&
+	grep "invalid value" bad-to.err
+'
+test_expect_success 'taskmap is posted in shell.start event' '
+	id=$(flux mini submit ./map.sh) &&
+	flux job wait-event -p guest.exec.eventlog -f json $id shell.start \
+		| jq -e ".context.taskmap.map == [[0,1,1,1]]" &&
+	test_check_taskmap $id
+'
+test_expect_success 'taskmap is correct for --tasks-per-node=4' '
+	id=$(flux mini submit -N4 --tasks-per-node=4 ./map.sh) &&
+	flux job wait-event -p guest.exec.eventlog -f json $id shell.start \
+		| jq -e ".context.taskmap.map == [[0,4,4,1]]" &&
+	test_check_taskmap $id
+'
+test_expect_success 'taskmap is unchanged with --taskmap=block' '
+	id=$(flux mini submit -N4 --tasks-per-node=4 \
+		--taskmap=block ./map.sh) &&
+	flux job wait-event -p guest.exec.eventlog -f json $id shell.start \
+		| jq -e ".context.taskmap.map == [[0,4,4,1]]" &&
+	test_check_taskmap $id
+'
+test_expect_success 'taskmap is correct for --tasks-per-node=2' '
+	id=$(flux mini submit -N4 --tasks-per-node=2 ./map.sh) &&
+	flux job wait-event -p guest.exec.eventlog -f json $id shell.start &&
+	flux job wait-event -p guest.exec.eventlog -f json $id shell.start \
+		| jq -e ".context.taskmap.map == [[0,4,2,1]]" &&
+	test_check_taskmap $id
+'
+test_expect_success 'taskmap=cyclic works with valid args' '
+	id=$(flux mini submit --taskmap=cyclic -N4 --tasks-per-node=4 ./map.sh) &&
+	flux job wait-event -p guest.exec.eventlog -f json $id shell.start &&
+	flux job wait-event -p guest.exec.eventlog -f json $id shell.start \
+		| jq -e ".context.taskmap.map == [[0,4,1,4]]" &&
+	test_check_taskmap $id
+'
+test_expect_success 'taskmap=cyclic:2 works' '
+	id=$(flux mini submit --taskmap=cyclic:2 -N4 --tasks-per-node=4 ./map.sh) &&
+	flux job wait-event -p guest.exec.eventlog -f json $id shell.start &&
+	flux job wait-event -p guest.exec.eventlog -f json $id shell.start \
+		| jq -e ".context.taskmap.map == [[0,4,2,2]]" &&
+	test_check_taskmap $id
+'
+test_expect_success 'taskmap=cyclic:3 works' '
+	id=$(flux mini submit --taskmap=cyclic:3 -N4 --tasks-per-node=4 ./map.sh) &&
+	flux job wait-event -p guest.exec.eventlog -f json $id shell.start &&
+	flux job wait-event -p guest.exec.eventlog -f json $id shell.start \
+		| jq -e ".context.taskmap.map == [[0,4,3,1],[0,4,1,1]]" &&
+	test_check_taskmap $id
+'
+test_expect_success 'taskmap=manual works' '
+	id=$(flux mini submit \
+	     --taskmap=manual:"[[1,3,4,1],[0,1,4,1]]" \
+	     -N4 --tasks-per-node=4 ./map.sh) &&
+	flux job wait-event -p guest.exec.eventlog -f json $id shell.start \
+		| jq -e ".context.taskmap.map == [[1,3,4,1],[0,1,4,1]]" &&
+	test_check_taskmap $id
+'
+test_expect_success 'invalid taskmap causes job failure' '
+	test_must_fail_or_be_terminated \
+		flux mini run -vvv --taskmap=foo true
+'
+test_expect_success 'invalid manual taskmaps fail predictably' '
+	ids=$(flux mini bulksubmit --taskmap=manual:{} \
+		-N4 --tasks-per-node=4 true ::: \
+		"{}" \
+		"[[1,3,4,1]]" \
+		"[[1,3,4,1],[0,1,3,1]]" \
+		"[[3,1,1,1],[0,3,5,1]]") &&
+	for id in $ids; do
+		test_must_fail_or_be_terminated flux job attach $id
+	done
+'
+test_expect_success 'invalid taskmap shell option fails' '
+	test_must_fail_or_be_terminated \
+		flux mini run -o taskmap.foo=bar true
+'
+test_expect_success 'invalid taskmap scheme causes job failure' '
+	test_must_fail_or_be_terminated \
+		flux mini run -vvv --taskmap=foo true
+'
+test_expect_success 'invalid cyclic value causes job failure' '
+	test_must_fail_or_be_terminated \
+		flux mini run -vvv --taskmap=cyclic:0 true
+'
+test_expect_success 'invalid cyclic value causes job failure' '
+	test_must_fail_or_be_terminated \
+		flux mini run -vvv --taskmap=cyclic:foo true
+'
+
+INITRC_PLUGINPATH="${SHARNESS_TEST_DIRECTORY}/shell/plugins/.libs"
+test_expect_success 'shell supports dynamically loaded taskmap plugin' '
+	cat <<-EOF >taskmap-initrc.lua &&
+	plugin.searchpath = "${INITRC_PLUGINPATH}"
+	plugin.load { file = "taskmap-reverse.so" }
+	EOF
+	id=$(flux mini submit -o userrc=taskmap-initrc.lua \
+		-N4 --tasks-per-node=4 \
+		--taskmap=reverse ./map.sh) &&
+	flux job taskmap $id  &&
+	test $(flux job taskmap $id) \
+		= "[[3,1,4,1],[2,1,4,1],[1,1,4,1],[0,1,4,1]]" && \
+	test_check_taskmap $id
+'
+test_done

--- a/t/t3002-pmi.t
+++ b/t/t3002-pmi.t
@@ -24,7 +24,18 @@ test_expect_success 'pmi_info --clique shows each node with own clique' '
 	count=$(cut -f2 -d: clique.out | sort | uniq | wc -l) &&
 	test $count -eq ${SIZE}
 '
-
+test_expect_success 'pmi_info --clique single shows everything in one clique' '
+	flux mini run -opmi.clique=single -n${SIZE} -N${SIZE} \
+		${pmi_info} --clique >clique.out &&
+	count=$(cut -f2 -d: clique.out | sort | uniq | wc -l) &&
+	test $count -eq 1
+'
+test_expect_success 'pmi_info --clique none shows each task in its own clique' '
+	flux mini run -opmi.clique=none -n${SIZE} -N${SIZE} \
+		${pmi_info} --clique >clique.none.out &&
+	count=$(cut -f2 -d: clique.none.out | sort | uniq | wc -l) &&
+	test $count -eq ${SIZE}
+'
 test_expect_success 'kvstest works' '
 	flux mini run -n${SIZE} -N${SIZE} ${kvstest}
 '


### PR DESCRIPTION
This PR is mostly functional, but I"m posting it as a WIP while I work on more testing in case there are any comments on the design and implementation.

This PR adds support for [RFC 34](https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/spec_34.html) "taskmaps".

The end result is support for a new `taskmap` job shell option and corresponding `--taskmap=SCHEME[:VALUE]` option to `flux mini run/submit`, including support for `cyclic:N` and `manual:TASKMAP` options. The final taskmap after any plugin remapping
is posted to the exec eventlog `shell.start` context. A `libflux-taskmap.so` library is also included for working with RFC 34 taskmaps. A `flux job taskmap` command is also provided for fetching, querying, and converting these taskmaps.

Because the mapping of tasks to nodes occurs in the job shell before any plugins are loaded, some reorganization of the shell startup code was required to make it possible to allow dynamic loading of `taskmap.*` plugins. The plugins work by registering a `taskmap.<scheme>` callback, effectively registering a new mapping `scheme` with the job shell. The taskmap shell option in jobspec takes the form of a `{"scheme": "name", "value": "val"}` where the value is optional. If this jobspec shell option is set, then the shell will call that `taskmap.<scheme>` callback, passing the value and the existing (block mapped) taskmap as plugin IN arguments.

Examples:
```
ƒ(s=4,d=0,builddir) grondo@asp:~$ flux job taskmap --help
Usage: flux-job taskmap [OPTION] JOBID|TASKMAP
Utility function for working with job task maps
  -h, --help             Display this message.
      --taskids=NODEID   Print idset of tasks on node NODEID
      --ntasks=NODEID    Print number of tasks on node NODEID
      --nodeid=TASKID    Print the shell rank/nodeid on which a taskid executed
      --hostname=TASKID  Print the hostname on which a taskid executed
      --to=raw|pmi       Convert an RFC 34 taskmap to another form
ƒ(s=4,d=0,builddir) grondo@asp:~$ flux mini submit -n4 -n16 true
ƒ8TbCQY26K
ƒ(s=4,d=0,builddir) grondo@asp:~$ flux job taskmap ƒ8TbCQY26K
[[0,4,4,1]]
ƒ(s=4,d=0,builddir) grondo@asp:~$ flux mini submit --taskmap=cyclic -n4 -n16 true
ƒ8UCHRtBuR
ƒ(s=4,d=0,builddir) grondo@asp:~$ flux job taskmap ƒ8UCHRtBuR
[[0,4,1,4]]
ƒ(s=4,d=0,builddir) grondo@asp:~$ flux mini submit --taskmap=cyclic:3 -n4 -n16 true
ƒ8UJ3CxVkB
ƒ(s=4,d=0,builddir) grondo@asp:~$ flux job taskmap ƒ8UJ3CxVkB
[[0,4,3,1],[0,4,1,1]]
ƒ(s=4,d=0,builddir) grondo@asp:~$ flux job taskmap --taskids=0 ƒ8UJ3CxVkB
0-2,12
ƒ(s=4,d=0,builddir) grondo@asp:~$ flux mini submit -n16 -N4 --taskmap=manual:"[[1,3,4,1],[0,1,4,1]]" true
ƒ8VYwXaAKZ
ƒ(s=4,d=0,builddir) grondo@asp:~$ flux job taskmap ƒ8VYwXaAKZ
[[1,3,4,1],[0,1,4,1]]
ƒ(s=4,d=0,builddir) grondo@asp:~$ flux job taskmap --taskids=0 ƒ8VYwXaAKZ
12-15
```

TODO:
 - [x] expand testing
 - [x] documentation
 - [x] add method to get taskmap from shell plugins (add to "shell info" object or add `flux_shell_get_taskmap()`)
 - [x] test that an external plugin can remap tasks

Fixes #4706 
Fixes #4759 
