### PR TITLE
job-manager: fix memory corruption due to json reference counting bug

### DIFF
--- a/src/cmd/flux-queue.c
+++ b/src/cmd/flux-queue.c
@@ -68,7 +68,7 @@ static struct optparse_option status_opts[] = {
 
 static struct optparse_option enable_opts[] = {
     { .name = "queue", .key = 'q', .has_arg = 1, .arginfo = "NAME",
-      .usage = "Specify queue to enable (default all)",
+      .usage = "Specify queue to enable",
     },
     { .name = "all", .key = 'a', .has_arg = 0,
       .usage = "Force command to apply to all queues if none specified",
@@ -78,7 +78,7 @@ static struct optparse_option enable_opts[] = {
 
 static struct optparse_option disable_opts[] = {
     { .name = "queue", .key = 'q', .has_arg = 1, .arginfo = "NAME",
-      .usage = "Specify queue to disable (default all)",
+      .usage = "Specify queue to disable",
     },
     { .name = "all", .key = 'a', .has_arg = 0,
       .usage = "Force command to apply to all queues if none specified",

--- a/src/modules/job-manager/queue.c
+++ b/src/modules/job-manager/queue.c
@@ -345,7 +345,7 @@ static void queue_list_cb (flux_t *h,
             q = zhashx_next (queue->named);
         }
     }
-    if (flux_respond_pack (h, msg, "{s:o}", "queues", a) < 0)
+    if (flux_respond_pack (h, msg, "{s:O}", "queues", a) < 0)
         flux_log_error (h, "error responding to job-manager.queue-list");
     json_decref (a);
     return;

--- a/src/modules/job-manager/queue.c
+++ b/src/modules/job-manager/queue.c
@@ -100,10 +100,8 @@ static int queue_enable_all (struct queue *queue,
                              bool enable,
                              const char *reason)
 {
-    struct jobq *q;
-
     if (queue->have_named_queues) {
-        q = zhashx_first (queue->named);
+        struct jobq *q = zhashx_first (queue->named);
         while (q) {
             if (jobq_enable (q, enable, reason) < 0)
                 return -1;

--- a/t/t2240-queue-cmd.t
+++ b/t/t2240-queue-cmd.t
@@ -297,6 +297,9 @@ test_expect_success 'flux queue status --queue fails with no queues' '
 test_expect_success 'flux queue enable --queue fails with no queues' '
 	test_must_fail flux queue enable --queue=batch
 '
+test_expect_success 'flux queue disable --queue fails with no queues' '
+	test_must_fail flux queue disable --queue=batch
+'
 test_expect_success 'ensure instance is drained' '
 	flux queue drain &&
 	flux queue status -v
@@ -326,7 +329,7 @@ test_expect_success 'flux-queue disable without --queue or --all fails' '
 test_expect_success 'flux-queue disable --all affects all queues' '
 	flux queue disable --all test reasons &&
 	flux queue status >mqstatus_dis.out &&
-	test $(grep -c "submission is disabled" mqstatus_dis.out) -eq 2
+	test $(grep -c "submission is disabled: test reason" mqstatus_dis.out) -eq 2
 '
 test_expect_success 'jobs may not be submitted to either queue' '
 	test_must_fail flux mini submit -q batch /bin/true &&
@@ -344,6 +347,7 @@ test_expect_success 'flux-queue disable can do one queue' '
 	flux queue disable -q batch nobatch &&
 	flux queue status >mqstatus_batchdis.out &&
 	test $(grep -c "submission is enabled" mqstatus_batchdis.out) -eq 1 &&
+	test $(grep -c "submission is disabled: nobatch" mqstatus_batchdis.out) -eq 1 &&
 	test_must_fail flux mini submit -q batch /bin/true &&
 	flux mini submit -q debug /bin/true
 '
@@ -356,6 +360,9 @@ test_expect_success 'flux-queue enable can do one queue' '
 '
 test_expect_success 'flux-queue enable fails on unknown queue' '
 	test_must_fail flux queue enable -q notaqueue
+'
+test_expect_success 'flux-queue disable fails on unknown queue' '
+	test_must_fail flux queue disable -q notaqueue
 '
 test_expect_success 'flux-queue status fails on unknown queue' '
 	test_must_fail flux queue status -q notaqueue

--- a/t/t2260-job-list.t
+++ b/t/t2260-job-list.t
@@ -1504,7 +1504,8 @@ test_expect_success 'job-list parses flux-restart events' '
         flux module load job-list &&
         wait_jobid $jobid &&
         flux module reload job-exec &&
-        flux module reload sched-simple
+        flux module reload sched-simple &&
+        flux queue start
 '
 
 #

--- a/t/t2302-sched-simple-up-down.t
+++ b/t/t2302-sched-simple-up-down.t
@@ -44,11 +44,11 @@ test_expect_success 'sched-simple: reload sched-simple with default resource.R' 
 	test "$($query)" = "rank[0-1]/core[0-3]"
 '
 test_expect_success 'sched-simple: all nodes up after reload' '
-	test_debug "flux resource list -v --states=up,down,allocated" &&
+	test_debug "flux resource list --format=rlist --states=up,down,allocated" &&
 	check_rlist "free" "rank[0-1]/core[0-3]" &&
 	check_nnodes "up" 2 &&
 	check_ncores "up" 8 &&
-	check_ncores "down" 0 
+	check_ncores "down" 0
 '
 test_expect_success 'sched-simple: flux-resource drain works' '
 	flux resource drain 0 &&


### PR DESCRIPTION
While working on #4629 found a memory corruption bug that somehow has never caused us any grief :-) (Edit: So far ... )

threw in a whole bunch of other cleanups / minor fixes that I had in my branch too.

