### PR TITLE
 job-manager: use allocation terms consistently

### DIFF
--- a/src/cmd/builtin/uptime.c
+++ b/src/cmd/builtin/uptime.c
@@ -53,10 +53,9 @@ static bool sched_disabled (flux_t *h)
                              "job-manager.alloc-admin",
                              0,
                              0,
-                             "{s:b s:b s:s}",
+                             "{s:b s:b}",
                              "query_only", 1,
-                             "enable", 0,
-                             "reason", ""))
+                             "enable", 0))
         || flux_rpc_get_unpack (f, "{s:b}", "enable", &enable) < 0)
         log_err_exit ("Error fetching alloc status");
     flux_future_destroy (f);

--- a/src/cmd/flux-queue.c
+++ b/src/cmd/flux-queue.c
@@ -236,7 +236,7 @@ void alloc_admin (flux_t *h,
                   bool verbose,
                   bool quiet,
                   int query_only,
-                  int enable,
+                  int start,
                   const char *reason)
 {
     flux_future_t *f;
@@ -252,15 +252,15 @@ void alloc_admin (flux_t *h,
                              "{s:b s:b s:s}",
                              "query_only",
                              query_only,
-                             "enable",
-                             enable,
+                             "start",
+                             start,
                              "reason",
                              reason ? reason : "")))
         log_err_exit ("error sending alloc-admin request");
     if (flux_rpc_get_unpack (f,
                              "{s:b s:s s:i s:i s:i s:i}",
-                             "enable",
-                             &enable,
+                             "start",
+                             &start,
                              "reason",
                              &reason,
                              "queue_length",
@@ -274,7 +274,7 @@ void alloc_admin (flux_t *h,
         log_msg_exit ("alloc-admin: %s", future_strerror (f, errno));
     if (!quiet) {
         printf ("Scheduling is %s%s%s\n",
-                enable ? "enabled" : "disabled",
+                start ? "started" : "stopped",
                 reason && strlen (reason) > 0 ? ": " : "",
                 reason ? reason : "");
     }

--- a/t/t2240-queue-cmd.t
+++ b/t/t2240-queue-cmd.t
@@ -101,7 +101,7 @@ test_expect_success 'flux-queue: status reports reason for stop' '
 	flux queue status >status.out &&
 	cat <<-EOT >status.exp &&
 	Job submission is enabled
-	Scheduling is disabled: my unique message
+	Scheduling is stopped: my unique message
 	EOT
 	test_cmp status.exp status.out
 '
@@ -156,16 +156,16 @@ wait_for_sched_offline() {
 	local n=$1
 	for try in $(seq 1 $n); do
 		echo Check queue status for offline, try ${try} of $n 2>&1
-		flux queue status 2>&1 | grep disabled && return
+		flux queue status 2>&1 | grep stopped && return
 	done
 }
 
-test_expect_success 'flux-queue: queue says scheduling disabled' '
+test_expect_success 'flux-queue: queue says scheduling stopped' '
 	wait_for_sched_offline 10 &&
 	flux queue status >sched_stat.out &&
 	cat <<-EOT >sched_stat.exp &&
 	Job submission is enabled
-	Scheduling is disabled: Scheduler is offline
+	Scheduling is stopped: Scheduler is offline
 	EOT
 	test_cmp sched_stat.exp sched_stat.out
 '
@@ -183,7 +183,7 @@ test_expect_success 'flux-queue: queue says scheduling is enabled' '
 	flux queue status >sched_stat2.out &&
 	cat <<-EOT >sched_stat2.exp &&
 	Job submission is enabled
-	Scheduling is enabled
+	Scheduling is started
 	EOT
 	test_cmp sched_stat2.exp sched_stat2.out
 '
@@ -211,7 +211,7 @@ test_expect_success 'flux-queue: queue status -v shows expected counts' '
 	flux queue status -v >stat.out &&
 	cat <<-EOT >stat.exp &&
 	Job submission is enabled
-	Scheduling is enabled
+	Scheduling is started
 	1 alloc requests queued
 	1 alloc requests pending to scheduler
 	0 free requests pending to scheduler
@@ -233,7 +233,7 @@ test_expect_success 'flux-queue: queue status -v shows expected counts' '
 	flux queue status -v >stat2.out &&
 	cat <<-EOT >stat2.exp &&
 	Job submission is enabled
-	Scheduling is disabled
+	Scheduling is stopped
 	2 alloc requests queued
 	0 alloc requests pending to scheduler
 	0 free requests pending to scheduler

--- a/t/t2804-uptime-cmd.t
+++ b/t/t2804-uptime-cmd.t
@@ -27,9 +27,9 @@ test_expect_success 'flux-uptime reports submit disabled' '
 	flux queue disable "testing" &&
 	flux uptime | grep "submit disabled"
 '
-test_expect_success 'flux-uptime reports scheduler disabled' '
+test_expect_success 'flux-uptime reports scheduler stopped' '
 	flux queue stop &&
-	flux uptime | grep "scheduler disabled"
+	flux uptime | grep "scheduler stopped"
 '
 test_expect_success 'flux-uptime reports drained node count' '
 	flux resource drain 1,3 &&


### PR DESCRIPTION
Problem: The terms enable/disable and start/stop are used interchangeably when referencing if a scheduler can allocate resources or not.

Consistently use the terms start/stop when referring to scheduler allocations being "allowed" vs "not-allowed".  This includes changes to variables, comments, rpc parameters, tool output, and tests.