### PR TITLE
broker: fix startup failure when broker.mapping is not set

### DIFF
--- a/t/t2701-mini-batch.t
+++ b/t/t2701-mini-batch.t
@@ -151,6 +151,11 @@ test_expect_success 'flux mini batch: user can set broker.critical-ranks' '
 	EOF
 	test_cmp critical-ranks2.expected critical-ranks2.out
 '
+test_expect_success 'flux mini batch: flux can bootstrap without broker.mapping' '
+	id=$(flux mini batch -N4 -o pmi.clique=none \
+		--wrap flux resource info) &&
+	flux job status $id
+'
 test_expect_success HAVE_JQ 'flux mini batch: sets mpi=none by default' '
 	flux mini batch -N1 --dry-run --wrap hostname | \
 		jq -e ".attributes.system.shell.options.mpi = \"none\""


### PR DESCRIPTION
This PR fixes an issue introduced by #4615: When the `broker.mapping` attribute isn't set, the broker can't calculate the instance critical ranks and this is treated as a fatal error when it should not be. This can occur when `-o pmi.clique=none` is used or if `PMI_process_mapping` overflows the PMI max value length.

This PR simply makes an error sending the critical ranks to the upstream job-exec service a non-fatal error.