### PR TITLE
add missing taskmap pkg-config file

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -579,6 +579,7 @@ AC_CONFIG_FILES( \
   etc/flux-idset.pc \
   etc/flux-schedutil.pc \
   etc/flux-hostlist.pc \
+  etc/flux-taskmap.pc \
   etc/flux.service \
   doc/Makefile \
   doc/test/Makefile \

--- a/etc/Makefile.am
+++ b/etc/Makefile.am
@@ -38,7 +38,8 @@ pkgconfig_DATA = flux-core.pc \
 	flux-optparse.pc \
 	flux-idset.pc \
 	flux-schedutil.pc \
-    flux-hostlist.pc
+	flux-hostlist.pc \
+	flux-taskmap.pc
 endif
 
 noinst_SCRIPTS = \

--- a/etc/flux-taskmap.pc.in
+++ b/etc/flux-taskmap.pc.in
@@ -1,0 +1,10 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: flux-taskmap
+Description: Flux Resource Manager Taskmap Library
+Version: @PACKAGE_VERSION@
+Libs: -L${libdir} -lflux-taskmap
+Cflags: -I${includedir}


### PR DESCRIPTION
Problem: The pkg-config file for libflux-taskmap is missing.

Add the missing flux-taskmap.pc file.