### PR TITLE
add flux start --recovery

### DIFF
--- a/doc/man1/flux-start.rst
+++ b/doc/man1/flux-start.rst
@@ -96,6 +96,20 @@ OPTIONS
    ``per-broker``, each broker is placed in its own clique.
    Default: ``single``.
 
+**-r, --recovery**\ =\ *[TARGET]*
+   Start the rank 0 broker of an instance in recovery mode.  If *TARGET*
+   is a directory, treat it as a *statedir* from a previous instance.
+   If *TARGET* is a file, treat it as an archive file from :man1:`flux-dump`.
+   If *TARGET* is unspecified, assume the system instance is to be recovered.
+   In recovery mode, any rc1 errors are ignored, broker peers are not allowed
+   to connect, and resources are offline.
+
+**--sysconfig**
+   Run the broker with ``--config-path`` set to the default system instance
+   configuration directory.  This option is unnecessary if ``--recovery``
+   is specified without its optional argument.  It may be required if
+   recovering a dump from a system instance.
+
 VERBOSITY LEVELS
 ================
 
@@ -122,6 +136,18 @@ shell as the initial program:
 ::
 
    srun --pty -N8 flux start
+
+Start the system instance rank 0 broker in recovery mode:
+
+::
+
+   sudo -u flux flux start --recovery
+
+Start a non-system instance in recovery mode:
+
+::
+
+   flux start --recovery=/tmp/statedir
 
 
 RESOURCES

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -666,3 +666,5 @@ sigpending
 chunksize
 taskmap
 multiline
+sudo
+sysconfig

--- a/src/broker/boot_config.c
+++ b/src/broker/boot_config.c
@@ -553,7 +553,8 @@ int boot_config (flux_t *h, struct overlay *overlay, attr_t *attrs)
      * attribute to the URI peers will connect to.  If broker has no
      * downstream peers, set tbon.endpoint to NULL.
      */
-    if (topology_get_child_ranks (topo, NULL, 0) > 0) {
+    if (topology_get_child_ranks (topo, NULL, 0) > 0
+        && attr_get (attrs, "broker.recovery-mode", NULL, NULL) < 0) {
         char bind_uri[MAX_URI + 1];
         char my_uri[MAX_URI + 1];
 

--- a/src/broker/runat.h
+++ b/src/broker/runat.h
@@ -78,6 +78,10 @@ bool runat_is_defined (struct runat *r, const char *name);
  */
 bool runat_is_completed (struct runat *r, const char *name);
 
+/* Test whether named list contains interactive commands.
+ */
+bool runat_is_interactive (struct runat *r, const char *name);
+
 #endif /* !_BROKER_RUNAT_H */
 
 /*

--- a/src/modules/resource/inventory.c
+++ b/src/modules/resource/inventory.c
@@ -571,6 +571,23 @@ done:
     return rc;
 }
 
+int inventory_get_size (struct inventory *inv)
+{
+    struct rlist *rl = NULL;
+    struct idset *ids = NULL;
+    int count = 0;
+
+    if (inv != NULL
+        && inv->R != NULL
+        && (rl = rlist_from_json (inv->R, NULL))
+        && (ids = rlist_ranks (rl))) {
+        count = idset_count (ids);
+    }
+    idset_destroy (ids);
+    rlist_destroy (rl);
+    return count;
+}
+
 static void resource_reload (flux_t *h,
                              flux_msg_handler_t *mh,
                              const flux_msg_t *msg,

--- a/src/modules/resource/inventory.h
+++ b/src/modules/resource/inventory.h
@@ -47,6 +47,10 @@ struct idset *inventory_targets_to_ranks (struct inventory *inv,
                                           const char *targets,
                                           flux_error_t *errp);
 
+/* Get the number of execution targets in R
+ */
+int inventory_get_size (struct inventory *inv);
+
 #endif /* !_FLUX_RESOURCE_INVENTORY_H */
 
 

--- a/src/modules/resource/monitor.c
+++ b/src/modules/resource/monitor.c
@@ -246,7 +246,7 @@ struct monitor *monitor_create (struct resource_ctx *ctx,
             if (idset_range_set (monitor->up, 0, ctx->size - 1) < 0)
                 goto error;
         }
-        else {
+        else if (!flux_attr_get (ctx->h, "broker.recovery-mode")) {
             if (!(monitor->f = flux_rpc_pack (ctx->h,
                                               "groups.get",
                                                FLUX_NODEID_ANY,

--- a/src/modules/resource/monitor.h
+++ b/src/modules/resource/monitor.h
@@ -12,6 +12,7 @@
 #define _FLUX_RESOURCE_MONITOR_H
 
 struct monitor *monitor_create (struct resource_ctx *ctx,
+                                int inventory_size,
                                 bool monitor_force_up);
 void monitor_destroy (struct monitor *monitor);
 

--- a/src/modules/resource/resource.c
+++ b/src/modules/resource/resource.c
@@ -459,7 +459,9 @@ int mod_main (flux_t *h, int argc, char **argv)
     json_decref (R_from_config);
     if (!(ctx->topology = topo_create (ctx, noverify, norestrict)))
         goto error;
-    if (!(ctx->monitor = monitor_create (ctx, monitor_force_up)))
+    if (!(ctx->monitor = monitor_create (ctx,
+                                         inventory_get_size (ctx->inventory),
+                                         monitor_force_up)))
         goto error;
     if (ctx->rank == 0) {
         if (!(ctx->acquire = acquire_create (ctx)))

--- a/src/modules/resource/resource.c
+++ b/src/modules/resource/resource.c
@@ -444,6 +444,8 @@ int mod_main (flux_t *h, int argc, char **argv)
     }
     if (parse_args (h, argc, argv, &monitor_force_up, &noverify) < 0)
         goto error;
+    if (flux_attr_get (ctx->h, "broker.recovery-mode"))
+        noverify = true;
     if (ctx->rank == 0) {
         if (!(ctx->reslog = reslog_create (h)))
             goto error;

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -51,6 +51,7 @@ LONGTESTSCRIPTS = \
 	t3100-flux-in-flux.t \
 	t3200-instance-restart.t \
 	t3202-instance-restart-testexec.t \
+	t3203-instance-recovery.t \
 	t4000-issues-test-driver.t
 
 # This list is included in both TESTS and dist_check_SCRIPTS.

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -286,6 +286,7 @@ dist_check_SCRIPTS = \
 	system/0001-basic.t \
 	system/0002-job-exec-sdexec-basic.t \
 	system/0003-instance-restart.t \
+	system/0004-recovery.t \
 	issues/t0441-kvs-put-get.sh \
 	issues/t0505-msg-handler-reg.lua \
 	issues/t0821-kvs-segfault.sh \

--- a/t/system/0004-recovery.t
+++ b/t/system/0004-recovery.t
@@ -1,0 +1,22 @@
+#
+#  Ensure flux start --recover works on the system instance
+#
+
+test_expect_success 'dump the last checkpoint' '
+        sudo -u flux flux dump --checkpoint /tmp/dump.tar
+'
+test_expect_success 'flux start --recover fails when instance is running' '
+	test_must_fail sudo -u flux flux start --recover /bin/true
+'
+test_expect_success 'stop the system instance' '
+	sudo flux shutdown
+'
+test_expect_success 'flux start --recover works' '
+	sudo -u flux flux start --recover /bin/true
+'
+test_expect_success 'flux start --recover works from dump file' '
+	sudo -u flux flux start --recover=/tmp/dump.tar --sysconfig /bin/true
+'
+test_expect_success 'restart flux' '
+        sudo systemctl start flux
+'

--- a/t/t2315-resource-system.t
+++ b/t/t2315-resource-system.t
@@ -165,12 +165,12 @@ test_expect_success 'resources can be configured in TOML' '
 	EOF
 	flux start -s 1 \
 		-o,--config-path=$(pwd)/${name},-Slog-filename=${name}/logfile \
-		flux resource list -s up > ${name}/output &&
+		flux resource list -s all > ${name}/output &&
 	test_debug "cat ${name}/output" &&
 	cat <<-EOF >${name}/expected &&
 	     STATE PROPERTIES NNODES   NCORES    NGPUS NODELIST
-	        up debug           3       12        0 foo[0-2]
-	        up batch           8       32        4 foo[3-10]
+	       all debug           3       12        0 foo[0-2]
+	       all batch           8       32        4 foo[3-10]
 	EOF
 	test_cmp ${name}/expected ${name}/output
 '

--- a/t/t3203-instance-recovery.t
+++ b/t/t3203-instance-recovery.t
@@ -1,0 +1,96 @@
+#!/bin/sh
+#
+
+test_description='Test instance recovery mode'
+
+# Append --logfile option if FLUX_TESTS_LOGFILE is set in environment:
+test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
+. `dirname $0`/sharness.sh
+
+runpty="flux ${SHARNESS_TEST_SRCDIR}/scripts/runpty.py"
+
+test_expect_success 'start a persistent instance of size 4' '
+	mkdir -p test1 &&
+	flux start --test-size=4 -o,-Sstatedir=$(pwd)/test1 /bin/true
+'
+test_expect_success 'expected broker attributes are set in recovery mode' '
+	cat >recov_attrs.exp <<-EOT &&
+	1
+	0
+	5
+	EOT
+	flux start --recovery=$(pwd)/test1 \
+	    -o,-Sbroker.rc1_path= \
+	    -o,-Sbroker.rc3_path= \
+	    bash -c " \
+		flux getattr broker.recovery-mode && \
+	        flux getattr broker.quorum && \
+	        flux getattr log-stderr-level" >recov_attrs.out &&
+	test_cmp recov_attrs.exp recov_attrs.exp
+'
+test_expect_success 'banner message is printed in interactive recovery mode' '
+	run_timeout --env=SHELL=/bin/sh 15 \
+	    $runpty -i none flux start \
+	        -o,-Sbroker.rc1_path= \
+	        -o,-Sbroker.rc3_path= \
+	        --recovery=$(pwd)/test1 >banner.out &&
+	grep "Entering Flux recovery mode" banner.out
+'
+test_expect_success 'rc1 failure is ignored in recovery mode' '
+	flux start --recovery=$(pwd)/test1 \
+	    -o,-Sbroker.rc1_path=/bin/false \
+	    -o,-Sbroker.rc3_path= \
+	    echo "hello world" >hello.out &&
+	grep hello hello.out
+'
+test_expect_success 'resources are offline in recovery mode' '
+	echo 4 >down.exp &&
+	flux start --recovery=$(pwd)/test1 \
+	    flux resource list -s down -no {nnodes} >down.out &&
+	test_cmp down.exp down.out
+'
+test_expect_success 'dump test instance in recovery mode' '
+	flux start --recovery=$(pwd)/test1 \
+	    flux dump --checkpoint test1.tar
+'
+test_expect_success 'recovery mode also works with dump file' '
+	flux start --recovery=$(pwd)/test1.tar \
+	    flux resource list -s down -no {nnodes} >down_dump.out &&
+	test_cmp down.exp down_dump.out
+'
+test_expect_success 'banner message warns changes are not persistent' '
+	run_timeout --env=SHELL=/bin/sh 15 \
+	    $runpty -i none flux start \
+	        -o,-Sbroker.rc1_path= \
+	        -o,-Sbroker.rc3_path= \
+	        --recovery=$(pwd)/test1.tar >banner2.out &&
+	grep "changes will not be preserved" banner2.out
+'
+test_expect_success 'recovery mode aborts early if statedir is missing' '
+	test_must_fail flux start --recovery=$(pwd)/test2 2>dirmissing.err &&
+	grep "No such file or directory" dirmissing.err
+'
+test_expect_success 'recovery mode aborts early if statedir lacks rwx' '
+	mkdir -p test2 &&
+	chmod 600 test2 &&
+	test_must_fail flux start --recovery=$(pwd)/test2 2>norwx.err &&
+	grep "no access" norwx.err
+'
+test_expect_success 'recovery mode aborts early if content is missing' '
+	chmod 700 test2 &&
+	test_must_fail flux start --recovery=$(pwd)/test2 2>empty.err &&
+	grep "No such file or directory" empty.err
+'
+test_expect_success 'recovery mode aborts early if content unwritable' '
+	touch test2/content.sqlite &&
+	chmod 400 test2/content.sqlite &&
+	test_must_fail flux start --recovery=$(pwd)/test2 2>nowrite.err &&
+	grep "no write permission" nowrite.err
+'
+test_expect_success 'recovery mode aborts early if content unreadable' '
+	chmod 200 test2/content.sqlite &&
+	test_must_fail flux start --recovery=$(pwd)/test2 2>noread.err &&
+	grep "no read permission" noread.err
+'
+
+test_done


### PR DESCRIPTION
Problem: when a system instance won't start, debugging is a chore.

This adds a `flux start --recovery` mode that _should_ let rank 0 of a system instance be started interactively when something goes wrong with systemd startup, e.g.
```console
$ sudo -u flux ./flux start --recovery
flux@picl0:/nfshome/garlick/proj/flux-core/src/cmd$ 
```
It only works for the system instance right now, since it hardwires the system instance configuration path and doesn't work with PMI bootstrap.

Thought I'd post it to see what people thought before digging in deeper.  It seems like it's happened several times that we try to start Flux after a configuration update or new release, and the first problem we encounter is that the instance won't start.  If there's something in the KVS (like the `checkpoint.job-manager` problem I noted in #4776) then in theory it could be manually corrected using this mode.