### PR TITLE
shell: remove `pmi.clique` option, add `pmi.nomap`

### DIFF
--- a/t/t2601-job-shell-standalone.t
+++ b/t/t2601-job-shell-standalone.t
@@ -137,7 +137,7 @@ test_expect_success 'flux-shell: shell PMI works' '
 		>pmi_info.out 2>pmi_info.err
 '
 test_expect_success 'flux-shell: shell PMI exports clique info' '
-	flux mini run -opmi.clique=pershell --dry-run -N1 -n8 \
+	flux mini run --dry-run -N1 -n8 \
 		${PMI_INFO} -c >j8pmi_clique &&
 	${FLUX_SHELL} -v -s -r 0 -j j8pmi_clique -R R8 51 \
 		>pmi_clique.out 2>pmi_clique.err &&

--- a/t/t2602-job-shell.t
+++ b/t/t2602-job-shell.t
@@ -81,14 +81,8 @@ test_expect_success 'job-shell: PMI works' '
 	flux job attach $id >pmi_info.out 2>pmi_info.err &&
 	grep size=4 pmi_info.out
 '
-test_expect_success 'pmi-shell: bad pmi.clique option fails' '
-	test_must_fail flux mini run -opmi.clique=badopt \
-		/bin/true 2>badopt.err &&
-	grep "pmi.clique=badopt is invalid" badopt.err
-'
-
 test_expect_success 'pmi-shell: PMI cliques are correct for 1 ppn' '
-	flux mini run -opmi.clique=pershell -N4 -n4 \
+	flux mini run -N4 -n4 \
 		${PMI_INFO} -c >pmi_clique1.raw &&
 	sort -snk1 <pmi_clique1.raw >pmi_clique1.out &&
 	sort >pmi_clique1.exp <<-EOT &&
@@ -100,7 +94,7 @@ test_expect_success 'pmi-shell: PMI cliques are correct for 1 ppn' '
 	test_cmp pmi_clique1.exp pmi_clique1.out
 '
 test_expect_success 'pmi-shell: PMI cliques are correct for 2 ppn' '
-	flux mini run -opmi.clique=pershell \
+	flux mini run \
 		-N2 -n4 ${PMI_INFO} -c >pmi_clique2.raw &&
 	sort -snk1 <pmi_clique2.raw >pmi_clique2.out &&
 	sort >pmi_clique2.exp <<-EOT &&
@@ -112,7 +106,7 @@ test_expect_success 'pmi-shell: PMI cliques are correct for 2 ppn' '
 	test_cmp pmi_clique2.exp pmi_clique2.out
 '
 test_expect_success 'pmi-shell: PMI cliques are correct for irregular ppn' '
-	flux mini run -opmi.clique=pershell -N4 -n5 \
+	flux mini run -N4 -n5 \
 		${PMI_INFO} -c >pmi_cliquex.raw &&
 	sort -snk1 <pmi_cliquex.raw >pmi_cliquex.out &&
 	sort >pmi_cliquex.exp <<-EOT &&

--- a/t/t2701-mini-batch.t
+++ b/t/t2701-mini-batch.t
@@ -152,7 +152,7 @@ test_expect_success 'flux mini batch: user can set broker.critical-ranks' '
 	test_cmp critical-ranks2.expected critical-ranks2.out
 '
 test_expect_success 'flux mini batch: flux can bootstrap without broker.mapping' '
-	id=$(flux mini batch -N4 -o pmi.clique=none \
+	id=$(flux mini batch -N4 -o pmi.nomap \
 		--wrap flux resource info) &&
 	flux job status $id
 '

--- a/t/t3002-pmi.t
+++ b/t/t3002-pmi.t
@@ -19,19 +19,13 @@ test_expect_success 'pmi_info works' '
 '
 
 test_expect_success 'pmi_info --clique shows each node with own clique' '
-	flux mini run -opmi.clique=pershell -n${SIZE} -N${SIZE} \
+	flux mini run -n${SIZE} -N${SIZE} \
 		${pmi_info} --clique >clique.out &&
 	count=$(cut -f2 -d: clique.out | sort | uniq | wc -l) &&
 	test $count -eq ${SIZE}
 '
-test_expect_success 'pmi_info --clique single shows everything in one clique' '
-	flux mini run -opmi.clique=single -n${SIZE} -N${SIZE} \
-		${pmi_info} --clique >clique.out &&
-	count=$(cut -f2 -d: clique.out | sort | uniq | wc -l) &&
-	test $count -eq 1
-'
 test_expect_success 'pmi_info --clique none shows each task in its own clique' '
-	flux mini run -opmi.clique=none -n${SIZE} -N${SIZE} \
+	flux mini run -opmi.nomap -n${SIZE} -N${SIZE} \
 		${pmi_info} --clique >clique.none.out &&
 	count=$(cut -f2 -d: clique.none.out | sort | uniq | wc -l) &&
 	test $count -eq ${SIZE}


### PR DESCRIPTION
As described in #4780, the `pmi.clique=single` shell option doesn't really have any use cases, and since `pmi.clique=pershell` is the default, the only useful `pmi.clique` option is `none`. This PR drops the shell `pmi.clique` option and replaces `pmi.clique=none` with a new, simpler `pmi.nomap` option.