### PR TITLE
add file broadcast toolset

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ Common commands from flux-core:
    dump               Write KVS snapshot to portable archive
    env                Print the flux environment or execute a command inside it
    exec               Execute processes across flux ranks
+   filemap            Map files into a Flux instance
    {get,set,ls}attr   Access, modify, and list broker attributes
    jobs               list jobs submitted to Flux
    pstree             display job hierarchies

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -26,6 +26,7 @@ MAN1_FILES_PRIMARY = \
 	man1/flux-getattr.1 \
 	man1/flux-dmesg.1 \
 	man1/flux-dump.1 \
+	man1/flux-filemap.1 \
 	man1/flux-content.1 \
 	man1/flux-config.1 \
 	man1/flux-proxy.1 \

--- a/doc/man1/flux-filemap.rst
+++ b/doc/man1/flux-filemap.rst
@@ -1,0 +1,148 @@
+.. flux-help-description: Map files into a Flux instance
+
+===============
+flux-filemap(1)
+===============
+
+
+SYNOPSIS
+========
+
+**flux** **filemap** **map** [*--tags=LIST*] [*-C DIR*] *PATH* ...
+
+**flux** **filemap** **unmap** [*--tags=LIST*]
+
+**flux** **filemap** **list** [*--tags=LIST*] [*--long*] [*PATTERN*]
+
+**flux** **filemap** **get** [*--tags=LIST*] [*-C DIR*] [*PATTERN*]
+
+
+DESCRIPTION
+===========
+
+``flux-filemap`` uses :linux:man2:`mmap` to map files into the rank 0 broker
+*content cache*.  After mapping, the files may be extracted on any broker rank,
+taking advantage of scalability properties of the distributed cache to move the
+data.  The files are treated as read-only and must not change while mapped.
+
+``flux-filemap map`` maps one or more file *PATH* arguments.  It must be run
+on the rank 0 broker, such as within a batch script, and the files must be
+directly accessible by the rank 0 broker.  If a PATH refers to a directory,
+the directory is recursively mapped.  If a file is encountered that is not
+readable, or has a type other than regular file, directory, or symbolic link,
+a fatal error occurs.  Sparse files such as file system images for virtual
+machines are mapped efficiently.  File discretionary access permission are
+preserved, but file attributes, ACLs, and group ownership are not.
+
+``flux-filemap list`` lists mapped files.  Optionally, a :man7:`glob` pattern
+may be specified to filter the list.
+
+``flux-filemap get`` extracts mapped files and may be run on any broker or
+across all brokers using :man1:`flux-exec`.  Optionally, a :man7:`glob` pattern
+may be specified to filter the list.  When extracting mapped files in parallel,
+take care to specify a *--directory* that is not shared and is not on a network
+file system without considering the ramifications.
+
+``flux-filemap unmap`` unmaps mapped files.
+
+The ``stage-in`` shell plugin described in :man1:`flux-shell` may be used to
+extract previously mapped files into $FLUX_JOB_TMPDIR or another directory.
+
+OPTIONS
+=======
+
+**-h, --help**
+   Display options and exit
+
+**-T, --tags=LIST**
+   Specify a comma separated list of *tags*.  If no tags are specified,
+   the *main* tag is assumed.
+
+**-C, --directory=DIR**
+   Change to the specified directory before performing the operation
+   (*map* and *get* subcommands only).
+
+**-v, --verbose=[LEVEL]**
+   Increase output verbosity (*map* and *get* subcommands only).
+
+**-l, --long**
+   Include more detail in file listing (*list* subcommand only).
+
+**--direct**
+   Avoid indirection through the content cache when fetching the top level
+   data for each file.  This may be fastest for a single or small number of
+   clients, but will scale poorly when performed in parallel (*get* subcommand
+   only).
+
+**--blobref**
+   List blobrefs (*list* subcommand only).
+
+**--fileref**
+   List fileref objects (*list* subcommand only).
+
+EXAMPLE
+=======
+
+Example 1:  a batch script that copies data from ``/project/dataset1`` to a
+temporary directory on each node of the batch allocation where it can be used
+by multiple jobs.
+
+.. code-block:: console
+
+  #!/bin/bash
+
+  flux filemap map -C /project dataset1
+  flux exec -r all mkdir -p /tmp/project
+  flux exec -r all flux filemap get -C /tmp/project
+
+  # app1 and app2 have access to local copy of dataset1
+  flux mini run -N1024 app1 --input /tmp/project/dataset1
+  flux mini run -N1024 app2 --input /tmp/project/dataset1
+
+  # clean up
+  flux exec -r all rm -rf /tmp/project
+  flux filemap unmap
+
+Example 2: a batch script that maps two data sets with tags, then uses the
+``stage-in`` shell plugin to selectively copy them to $FLUX_JOB_TMPDIR,
+which is automatically cleaned up after each job.
+
+.. code-block:: console
+
+  #!/bin/bash
+
+  flux filemap map --tags=ds1 -C /project dataset1
+  flux filemap map --tags=ds2 -C /project dataset2
+
+  # App0 uses $FLUX_JOB_TMPDIR/dataset1 and $FLUX_JOB_TMPDIR/dataset2
+  flux mini run -N1024 -o stage-in.tags=ds1,ds2 App0
+
+  # App1 uses only $FLUX_JOB_TMPDIR/dataset1
+  flux mini run -N1024 -o stage-in.tags=ds1 App1
+
+  # App2 uses only $FLUX_JOB_TMPDIR/dataset2
+  flux mini run -N1024 -o stage-in.tags=ds2 App2
+
+  # clean up
+  flux filemap unmap --tags=ds1,ds2
+
+CAVEATS
+=======
+
+The rank 0 Flux broker may die with a SIGBUS error if a mapped file is removed
+or truncated, and subsequently accessed, since that renders pages mapped into
+the brokers address space invalid.
+
+If mapped file content changes, access may fail if the original data is not
+cached.  Under no circumstances will the new content be returned.
+
+RESOURCES
+=========
+
+Flux: http://flux-framework.org
+
+
+SEE ALSO
+========
+
+:man1:`flux-shell`,

--- a/doc/man1/flux-mini.rst
+++ b/doc/man1/flux-mini.rst
@@ -758,6 +758,9 @@ overridden in some cases:
    Configure the PMI plugin's built-in key exchange algorithm to use a
    virtual tree fanout of ``N`` for key gather/broadcast.  The default is 2.
 
+**stage-in**
+   Copy files previously mapped with :man1:`flux-filemap` to $FLUX_JOB_TMPDIR.
+   See :man1:`flux-shell` for more *stage-in* options.
 
 RESOURCES
 =========

--- a/doc/man1/flux-shell.rst
+++ b/doc/man1/flux-shell.rst
@@ -320,6 +320,24 @@ options are supported by the builtin plugins of ``flux-shell``:
   this will also be passed to the invoked plugin. Normally, this option will
   be set by the ``flux mini --taskmap`` option.
 
+**stage-in**
+  Copy files to $FLUX_JOB_TMPDIR that were previously mapped using
+  :man1:`flux-filemap`.
+
+**stage-in.tags**
+  Select files to copy by specifying their tags.  By default the ``main``
+  tag is used.
+
+**stage-in.pattern**
+  Further filter the selected files to copy using a :man7:`glob` pattern.
+
+**stage-in.destdir**
+  Copy files to the specified directory instead of $FLUX_JOB_TMPDIR.  Careful!
+  The $FLUX_JOB_TMPDIR is cleaned up when the job exits, is guaranteed to
+  be unique, and is generally on fast local storage.  Make sure ``destdir``
+  does not specify a network file system or a shared directory without
+  considering the ramifications.
+
 SHELL INITRC
 ============
 

--- a/doc/man1/index.rst
+++ b/doc/man1/index.rst
@@ -14,6 +14,7 @@ man1
    flux-env
    flux-event
    flux-exec
+   flux-filemap
    flux-getattr
    flux-job
    flux-jobs

--- a/doc/manpages.py
+++ b/doc/manpages.py
@@ -26,6 +26,7 @@ man_pages = [
     ('man1/flux-env', 'flux-env', 'Print the flux environment or execute a command inside it', [author], 1),
     ('man1/flux-event', 'flux-event', 'Send and receive Flux events', [author], 1),
     ('man1/flux-exec', 'flux-exec', 'Execute processes across flux ranks', [author], 1),
+    ('man1/flux-filemap', 'flux-filemap', 'Map files into a Flux instance', [author], 1),
     ('man1/flux-getattr', 'flux-setattr', 'access broker attributes', [author], 1),
     ('man1/flux-getattr', 'flux-lsattr', 'access broker attributes', [author], 1),
     ('man1/flux-getattr', 'flux-getattr', 'access broker attributes', [author], 1),

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -668,3 +668,5 @@ taskmap
 multiline
 sudo
 sysconfig
+destdir
+filemap

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -670,3 +670,12 @@ sudo
 sysconfig
 destdir
 filemap
+dataset
+fileref
+mmap
+unmap
+unmaps
+ds
+rf
+ACLs
+SIGBUS

--- a/src/broker/Makefile.am
+++ b/src/broker/Makefile.am
@@ -42,6 +42,8 @@ libbroker_la_SOURCES = \
 	content-cache.c \
 	content-checkpoint.h \
 	content-checkpoint.c \
+	content-mmap.h \
+	content-mmap.c \
 	runat.h \
 	runat.c \
 	state_machine.h \

--- a/src/broker/content-cache.c
+++ b/src/broker/content-cache.c
@@ -340,6 +340,7 @@ static void cache_load_continuation (flux_future_t *f, void *arg)
     struct content_cache *cache = arg;
     struct cache_entry *e = flux_future_aux_get (f, "entry");
     const flux_msg_t *msg;
+    const char *errmsg = NULL;
 
     e->load_pending = 0;
     if (flux_future_get (f, (const void **)&msg) < 0) {
@@ -347,6 +348,7 @@ static void cache_load_continuation (flux_future_t *f, void *arg)
             errno = ENOENT;
         if (errno != ENOENT)
             flux_log_error (cache->h, "content load");
+        errmsg = flux_future_error_string (f);
         goto error;
     }
     /* N.B. the entry may already be valid if a store filled it while
@@ -381,7 +383,7 @@ error:
     request_list_respond_error (&e->load_requests,
                                 cache->h,
                                 errno,
-                                NULL,
+                                errmsg,
                                 "load");
     cache_entry_remove (cache, e);
     flux_future_destroy (f);

--- a/src/broker/content-mmap.c
+++ b/src/broker/content-mmap.c
@@ -1,0 +1,766 @@
+/************************************************************\
+ * Copyright 2022 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* content-mmap.c - map files into content cache on rank 0
+ *
+ * Each file is represented by a 'struct content_region' that includes
+ * a 'fileref' object containing the file's metadata and blobrefs for content.
+ * The region also contains a pointer to mmap(2)ed memory for the file's
+ * content.
+ *
+ * All files have one or more tags, so the regions are placed in a
+ * hash-of-lists where the list names are tags, and the entries are struct
+ * content_regions.  When files are listed or removed, the requestor provides
+ * one or more tags.  (flux filemap has an implicit "main" tag, but that
+ * is entirely implemented in the tools, not here).
+ *
+ * The general idea is that one makes a list query with tags and an optional
+ * glob and gets back a list of blobrefs.  Each blobref represents a serialized
+ * 'fileref' object that corresponds to a file/content_region.  Within the
+ * fileref is optionally a vector of blobrefs representing data content.
+ * Having obtained this list, the client can use it to pull the fileref, and
+ * subsequently its data through the content cache.
+ *
+ * The content-cache calls content_mmap_region_lookup() on rank 0 when it
+ * doesn't have a requested blobref in cache, and only consults the backing
+ * store when that fails.  If content_mmap_region_lookup() succeeds, the
+ * content-cache takes a reference on the struct content_region.  When we
+ * request to unmap a region, the munmap(2) and free of the struct is delayed
+ * until all content-cache references are dropped.
+ *
+ * Slightly tricky optimization:
+ * To speed up content_mmap_region_lookup() we have mm->cache, which is used
+ * to find a content_region given a hash.  The cache contains hash keys for
+ * both mmapped data (fileref.blobvec) and serialized fileref objects.
+ * A given hash may appear in multiple files or parts of the same file,
+ * so when a file is mapped, we put all its hashes in mm->cache except those
+ * that are already mapped.  If nothing is unmapped, then we know all the
+ * blobrefs for all the files will remain valid.  However when something is
+ * unmapped we could be losing pieces of unrelated files.  Since unmaps are
+ * bulk operations involving tags, we just walk the entire hash-of-lists
+ * at that time and restore any missing cache entries.
+ *
+ * Safety issue:
+ * The content addressable storage model relies on the fact that once hashed,
+ * data does not change.  However, this cannot be assured when the data is
+ * mmapped from a file that may not be protected from updates.  To avoid
+ * propagating bad data in the cache, content_mmap_validate() is called each
+ * time an mmapped cache entry is accessed.  This function recomputes the
+ * hash to make sure the content has not changed.  If the data has changed,
+ * the content-cache returns an error to the requestor.  In addition, mmapped
+ * pages could become invalid if the size of a mapped file is reduced.
+ * Accessing invalid pages could cause the broker to crash with SIGBUS.  To
+ * mitigate this, content_mmap_validate() also calls stat(2) on the file to
+ * make sure the memory region is still valid.  This is not foolproof because
+ * it is inherently a time-of-check-time-of-use problem.  In fact we rate
+ * limit the calls to stat(2) to avoid a "stat storm" when a file with many
+ * blobrefs is accessed, which increases the window where it could have
+ * changed.  But it's likely better than not checking at all.
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <sys/mman.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <limits.h>
+#include <stdlib.h>
+#include <fnmatch.h>
+#include <jansson.h>
+#include <assert.h>
+#include <flux/core.h>
+
+#include "src/common/libczmqcontainers/czmq_containers.h"
+#include "src/common/libutil/hola.h"
+#include "src/common/libutil/errno_safe.h"
+#include "src/common/libutil/errprintf.h"
+#include "src/common/libutil/blobref.h"
+#include "src/common/libutil/fileref.h"
+#include "src/common/libutil/monotime.h"
+#include "ccan/ptrint/ptrint.h"
+#include "ccan/str/str.h"
+
+#include "content-mmap.h"
+
+struct cache_entry {
+    struct content_region *reg;
+    const void *data;                       // pointer into mmapped reg->data
+    size_t size;                            //   or reg->fileref_data
+    void *hash;                             // contiguous with struct
+};
+
+struct content_region {
+    void *data;                             // memory-mapped data
+    size_t data_size;                       // memory-mapped size
+    int refcount;
+    json_t *fileref;
+    void *fileref_data;                     // encoded fileref data
+    size_t fileref_size;                    // encoded fileref size
+    char *blobref;                          // blobref for fileref data
+
+    struct content_mmap *mm;
+
+    char *fullpath;                         // full path for stat(2) checking
+    struct timespec last_check;             // rate limit stat(2) checking
+};
+
+struct content_mmap {
+    flux_t *h;
+    uint32_t rank;
+    char *hash_name;
+    flux_msg_handler_t **handlers;
+    struct hola *tags;                      // tagged bundles of files/regions
+    zhashx_t *cache;                        // hash digest => cache entry
+};
+
+static int content_hash_size;
+
+static const int max_blobrefs_per_response = 1000;
+static const int max_filerefs_per_response = 100;
+
+static const double max_check_age = 5; // seconds since last region stat(2)
+
+static void cache_entry_destroy (struct cache_entry *e)
+{
+    if (e) {
+        int saved_errno = errno;
+        free (e);
+        errno = saved_errno;
+    }
+}
+
+static struct cache_entry *cache_entry_create (const void *digest)
+{
+    struct cache_entry *e;
+
+    if (!(e = calloc (1, sizeof (*e) + content_hash_size)))
+        return NULL;
+    e->hash = (char *)(e + 1);
+    memcpy (e->hash, digest, content_hash_size);
+    return e;
+}
+
+/* Add entry to cache.
+ * If entry exists, return success.  The blobref must be valid in the
+ * cache - where it comes from is unimportant.
+ * N.B. this is a potential hot spot so defer memory allocation until
+ * after lookup.
+ */
+static int cache_entry_add (struct content_region *reg,
+                            const void *data,
+                            size_t size,
+                            const char *blobref)
+{
+    struct cache_entry *e;
+    char digest[BLOBREF_MAX_DIGEST_SIZE];
+
+    if (blobref_strtohash (blobref, digest, sizeof (digest)) < 0)
+        return -1;
+    if (zhashx_lookup (reg->mm->cache, digest) < 0)
+        return 0;
+    if (!(e = cache_entry_create (digest)))
+        return -1;
+    e->reg = reg;
+    e->data = data;
+    e->size = size;
+    if (zhashx_insert (reg->mm->cache, e->hash, e) < 0) {
+        cache_entry_destroy (e);
+        return 0;
+    }
+    return 0;
+}
+
+/* Remove entry from cache IFF it belongs to this region.
+ */
+static int cache_entry_remove (struct content_mmap *mm,
+                               struct content_region *reg,
+                               const char *blobref)
+{
+    struct cache_entry *e;
+    char digest[BLOBREF_MAX_DIGEST_SIZE];
+
+    if (blobref_strtohash (blobref, digest, sizeof (digest)) < 0)
+        return -1;
+    if ((e = zhashx_lookup (mm->cache, digest)) // calls destructor
+        && reg == e->reg)
+        zhashx_delete (mm->cache, digest);
+    return 0;
+}
+
+/* Remove all cache entries associated with region (blobvec + fileref).
+ */
+static void region_cache_remove (struct content_region *reg)
+{
+    if (reg->fileref) {
+        int saved_errno = errno;
+        json_t *blobvec = json_object_get (reg->fileref, "blobvec");
+
+        if (blobvec) {
+            size_t index;
+            json_t *entry;
+
+            json_array_foreach (blobvec, index, entry) {
+                json_int_t offset;
+                json_int_t size;
+                const char *blobref;
+
+                if (json_unpack (entry,
+                                 "[I,I,s]",
+                                 &offset,
+                                 &size,
+                                 &blobref) == 0)
+                    cache_entry_remove (reg->mm, reg, blobref);
+            }
+        }
+        if (reg->blobref)
+            cache_entry_remove (reg->mm, reg, reg->blobref);
+
+        errno = saved_errno;
+    }
+}
+
+/* Add cache entries for entries associated with region (blobvec + fileref).
+ */
+static int region_cache_add (struct content_region *reg)
+{
+    size_t index;
+    json_t *entry;
+    json_t *blobvec;
+
+    if (cache_entry_add (reg,
+                         reg->fileref_data,
+                         reg->fileref_size,
+                         reg->blobref) < 0)
+        return -1;
+    if (!(blobvec = json_object_get (reg->fileref, "blobvec")))
+        goto inval;
+    json_array_foreach (blobvec, index, entry) {
+        json_int_t offset;
+        json_int_t size;
+        const char *blobref;
+        if (json_unpack (entry, "[I,I,s]", &offset, &size, &blobref) < 0)
+            goto inval;
+        if (cache_entry_add (reg,
+                             reg->data + offset,
+                             size,
+                             blobref) < 0)
+            return -1;
+    }
+    return 0;
+inval:
+    errno = EINVAL;
+    return -1;
+}
+
+/* After a region is unmapped, other regions may have blobrefs that are no
+ * longer represented in the cache.  This scans all mapped regions and fills
+ * in missing cache entries.  Design tradeoff:  mapping and lookup are fast,
+ * and the cache implementation is lightweight and simple, at the expense of
+ * unmap efficiency.
+ */
+static int plug_cache_holes (struct content_mmap *mm)
+{
+    const char *name;
+    struct content_region *reg;
+
+    name = hola_hash_first (mm->tags);
+    while (name) {
+        reg = hola_list_first (mm->tags, name);
+        while (reg) {
+            if (region_cache_add (reg) < 0)
+                return -1;
+            reg = hola_list_next (mm->tags, name);
+        }
+        name = hola_hash_next (mm->tags);
+    }
+    return 0;
+}
+
+// zhashx_destructor_fn footprint
+static void cache_entry_destructor (void **item)
+{
+    if (item) {
+        cache_entry_destroy (*item);
+        *item = NULL;
+    }
+}
+// zhashx_hash_fn footprint
+static size_t cache_entry_hasher (const void *key)
+{
+    return *(size_t *)key;
+}
+// zhashx_comparator_fn footprint
+static int cache_entry_comparator (const void *item1, const void *item2)
+{
+    return memcmp (item1, item2, content_hash_size);
+}
+
+void content_mmap_region_decref (struct content_region *reg)
+{
+    if (reg && --reg->refcount == 0) {
+        int saved_errno = errno;
+        region_cache_remove (reg);
+        if (reg->data != MAP_FAILED)
+            (void)munmap (reg->data, reg->data_size);
+        json_decref (reg->fileref);
+        free (reg->fullpath);
+        free (reg->blobref);
+        free (reg->fileref_data);
+        free (reg);
+        errno = saved_errno;
+    }
+}
+
+// zhashx_destructor_fn footprint
+static void content_mmap_region_destructor (void **item)
+{
+    if (item) {
+        content_mmap_region_decref (*item);
+        *item = NULL;
+    }
+}
+
+struct content_region *content_mmap_region_incref (struct content_region *reg)
+{
+    if (reg)
+        reg->refcount++;
+    return reg;
+}
+
+/* Validate mmapped blob before use, checking for:
+ * - size has changed so mmmapped pages are no longer valid (SIGBUS if used!)
+ * - content no longer matches hash
+ * To avoid repeatedly calling stat(2) on a file, skip it if last check was
+ * within max_check_age seconds.
+ */
+bool content_mmap_validate (struct content_region *reg,
+                            const void *hash,
+                            int hash_size,
+                            const void *data,
+                            int data_size)
+{
+    char hash2[BLOBREF_MAX_DIGEST_SIZE];
+
+    // no need to check the fileref blob as it was not mmapped
+    if (data == reg->fileref_data)
+        return true;
+
+    assert (reg->data != NULL);
+    assert (data >= reg->data);
+    assert (data + data_size <= reg->data + reg->data_size);
+
+    if (monotime_since (reg->last_check)/1000 >= max_check_age) {
+        struct stat sb;
+
+        if (stat (reg->fullpath, &sb) < 0
+            || sb.st_size < reg->data_size)
+            return false;
+
+        monotime (&reg->last_check);
+    }
+
+    if (blobref_hash_raw (reg->mm->hash_name,
+                          data,
+                          data_size,
+                          hash2,
+                          sizeof (hash2)) != hash_size
+            || memcmp (hash, hash2, hash_size) != 0)
+            return false;
+    return true;
+}
+
+struct content_region *content_mmap_region_lookup (struct content_mmap *mm,
+                                                   const void *hash,
+                                                   int hash_size,
+                                                   const void **data,
+                                                   int *data_size)
+{
+    struct cache_entry *e;
+
+    if (hash_size != content_hash_size
+        || !(e = zhashx_lookup (mm->cache, hash)))
+        return NULL;
+    *data = e->data;
+    *data_size = e->size;
+    return e->reg;
+}
+
+static int fileref_encode (json_t *fileref,
+                           const char *hash_name,
+                           void **fileref_data,
+                           size_t *fileref_size,
+                           char **blobrefp)
+{
+    void *data;
+    size_t size;
+    char blobref[BLOBREF_MAX_STRING_SIZE];
+    char *blobref_cpy;
+
+    if (!(data = json_dumps (fileref, JSON_COMPACT))) {
+        errno = ENOMEM;
+        return -1;
+    }
+    size = strlen (data) + 1;
+    if (blobref_hash (hash_name, data, size, blobref, sizeof (blobref)) < 0
+        || !(blobref_cpy = strdup (blobref))) {
+        ERRNO_SAFE_WRAP (free, data);
+        return -1;
+    }
+    *fileref_data = data;
+    *fileref_size = size;
+    *blobrefp = blobref_cpy;
+    return 0;
+}
+
+static struct content_region *content_mmap_region_create (
+                                                     struct content_mmap *mm,
+                                                     const char *path,
+                                                     const char *fpath,
+                                                     int chunksize,
+                                                     flux_error_t *error)
+{
+    struct content_region *reg;
+
+    if (!(reg = calloc (1, sizeof (*reg)))) {
+        errprintf (error, "out of memory");
+        goto error;
+    }
+    reg->refcount = 1;
+    reg->mm = mm;
+    reg->data = MAP_FAILED;
+    if (!(reg->fullpath = strdup (fpath)))
+        goto error;
+
+    if (!(reg->fileref = fileref_create_ex (path,
+                                            fpath,
+                                            mm->hash_name,
+                                            chunksize,
+                                            &reg->data,
+                                            &reg->data_size,
+                                            error)))
+        goto error;
+    if (fileref_encode (reg->fileref,
+                        mm->hash_name,
+                        &reg->fileref_data,
+                        &reg->fileref_size,
+                        &reg->blobref) < 0) {
+        errprintf (error,
+                   "%s: error encoding fileref: %s",
+                   path,
+                   strerror (errno));
+        goto error;
+    }
+
+    if (region_cache_add (reg) < 0) {
+        errprintf (error,
+                   "%s: error caching region blobrefs: %s",
+                   path,
+                   strerror (errno));
+        goto error;
+    }
+    return reg;
+error:
+    content_mmap_region_decref (reg);
+    return NULL;
+}
+
+static int check_string_array (json_t *o, int min_count)
+{
+    size_t index;
+    json_t *entry;
+
+    if (!json_is_array (o)
+        || json_array_size (o) < min_count)
+        goto error;
+    json_array_foreach (o, index, entry) {
+        if (!json_is_string (entry))
+            goto error;
+    }
+    return 0;
+error:
+    errno = EPROTO;
+    return -1;
+}
+
+static bool fnmatch_fileref (const char *pattern, json_t *fileref)
+{
+    if (pattern) {
+        const char *path;
+
+        if (json_unpack (fileref, "{s:s}", "path", &path) < 0
+            || fnmatch (pattern, path, 0) != 0)
+            return false;
+    }
+    return true;
+}
+
+static void content_mmap_add_cb (flux_t *h,
+                                 flux_msg_handler_t *mh,
+                                 const flux_msg_t *msg,
+                                 void *arg)
+{
+    struct content_mmap *mm = arg;
+    const char *path;
+    const char *fpath = NULL;
+    int chunksize;
+    json_t *tags;
+    struct content_region *reg = NULL;
+    flux_error_t error;
+    const char *errmsg = NULL;
+    size_t index;
+    json_t *entry;
+
+    if (flux_request_unpack (msg,
+                             NULL,
+                             "{s:s s?s s:i s:o}",
+                             "path", &path,
+                             "fullpath", &fpath,
+                             "chunksize", &chunksize,
+                             "tags", &tags) < 0
+        || check_string_array (tags, 1) < 0)
+        goto error;
+    if (mm->rank != 0) {
+        errmsg = "content may only be mmapped on rank 0";
+        goto inval;
+    }
+    if (!(reg = content_mmap_region_create (mm,
+                                            path,
+                                            fpath,
+                                            chunksize,
+                                            &error))) {
+        errmsg = error.text;
+        goto error;
+    }
+    json_array_foreach (tags, index, entry) {
+        // takes a reference on region
+        if (!hola_list_add_end (mm->tags, json_string_value (entry), reg))
+            goto error;
+    }
+    if (flux_respond (h, msg, NULL) < 0)
+        flux_log_error (h, "error responding to content.mmap-add request");
+    content_mmap_region_decref (reg);
+    return;
+inval:
+    errno = EINVAL;
+error:
+    if (flux_respond_error (h, msg, errno, errmsg) < 0)
+        flux_log_error (h, "error responding to content.mmap-add request");
+    content_mmap_region_decref (reg);
+}
+
+static void content_mmap_remove_cb (flux_t *h,
+                                    flux_msg_handler_t *mh,
+                                    const flux_msg_t *msg,
+                                    void *arg)
+{
+    struct content_mmap *mm = arg;
+    const char *errmsg = NULL;
+    json_t *tags;
+    size_t index;
+    json_t *entry;
+    int unmap_count = 0;
+
+    if (flux_request_unpack (msg, NULL, "{s:o}", "tags", &tags) < 0
+        || check_string_array (tags, 1) < 0)
+        goto error;
+    if (mm->rank != 0) {
+        errmsg = "content can only be mmapped on rank 0";
+        goto inval;
+    }
+    json_array_foreach (tags, index, entry) {
+        if (hola_hash_delete (mm->tags, json_string_value (entry)) == 0)
+            unmap_count++;
+    }
+    if (unmap_count > 0) {
+        if (plug_cache_holes (mm) < 0) {
+            errmsg = "error filling missing cache entries after unmap";
+            goto error;
+        }
+    }
+    if (flux_respond (h, msg, NULL) < 0)
+        flux_log_error (h, "error responding to content.mmap-remove request");
+    return;
+inval:
+    errno = EINVAL;
+error:
+    if (flux_respond_error (h, msg, errno, errmsg) < 0)
+        flux_log_error (h, "error responding to content.mmap-remove request");
+}
+
+/* Get a list of files that match tag(s) and glob pattern, if any.
+ * Avoid listing duplicates (e.g. a file with multiple tags) by tracking
+ * fileref blobrefs in a JSON object.  Send data in zero or more responses
+ * (respecting max_blobrefs_per_response or max_filerefs_per_response)
+ * terminated by ENODATA.
+ */
+static void content_mmap_list_cb (flux_t *h,
+                                  flux_msg_handler_t *mh,
+                                  const flux_msg_t *msg,
+                                  void *arg)
+{
+    struct content_mmap *mm = arg;
+    const char *errmsg = NULL;
+    int blobref;
+    json_t *tags;
+    const char *pattern = NULL;
+    json_t *files = NULL;
+    json_t *uniqhash = NULL;
+    struct content_region *reg;
+    size_t index;
+    json_t *entry;
+
+    if (flux_request_unpack (msg,
+                             NULL,
+                             "{s:b s:o s?s}",
+                             "blobref", &blobref,
+                             "tags", &tags,
+                             "pattern", &pattern) < 0
+        || check_string_array (tags, 1) < 0)
+        goto error;
+    if (!flux_msg_is_streaming (msg)) {
+        errno = EPROTO;
+        goto error;
+    }
+    if (mm->rank != 0) {
+        errmsg = "content can only be mmapped on rank 0";
+        errno = EINVAL;
+        goto error;
+    }
+    if (!(files = json_array ())
+        || !(uniqhash = json_object ())) {
+        json_decref (files);
+        goto nomem;
+    }
+    json_array_foreach (tags, index, entry) {
+        const char *name = json_string_value (entry);
+
+        reg = hola_list_first (mm->tags, name);
+        while (reg) {
+            if (!json_object_get (uniqhash, reg->blobref)
+                 && fnmatch_fileref (pattern, reg->fileref)) {
+                json_t *o;
+                if (json_object_set (uniqhash, reg->blobref, json_null ()) < 0)
+                    goto nomem;
+                if (blobref) {
+                    if (!(o = json_string (reg->blobref))
+                        || json_array_append_new (files, o) < 0) {
+                        json_decref (o);
+                        goto nomem;
+                    }
+                }
+                else {
+                    if (json_array_append (files, reg->fileref) < 0)
+                        goto nomem;
+                }
+                if (json_array_size (files) == (blobref ?
+                                                max_blobrefs_per_response :
+                                                max_filerefs_per_response)) {
+                    if (flux_respond_pack (h, msg, "{s:O}", "files", files) < 0)
+                        goto error;
+                    if (json_array_clear (files) < 0)
+                        goto nomem;
+                }
+            }
+            reg = hola_list_next (mm->tags, name);
+        }
+    }
+    if (json_array_size (files) > 0) {
+        if (flux_respond_pack (h, msg, "{s:O}", "files", files) < 0)
+            goto error;
+    }
+    if (flux_respond_error (h, msg, ENODATA, NULL) < 0) // end of stream
+        flux_log_error (h, "error responding to content.mmap-list request");
+    json_decref (files);
+    json_decref (uniqhash);
+    return;
+nomem:
+    errno = ENOMEM;
+error:
+    if (flux_respond_error (h, msg, errno, errmsg) < 0)
+        flux_log_error (h, "error responding to content.mmap-list request");
+    json_decref (files);
+    json_decref (uniqhash);
+}
+
+static const struct flux_msg_handler_spec htab[] = {
+    {
+        FLUX_MSGTYPE_REQUEST,
+        "content.mmap-add",
+        content_mmap_add_cb,
+        0
+    },
+    {
+        FLUX_MSGTYPE_REQUEST,
+        "content.mmap-remove",
+        content_mmap_remove_cb,
+        0
+    },
+    {
+        FLUX_MSGTYPE_REQUEST,
+        "content.mmap-list",
+        content_mmap_list_cb,
+        0
+    },
+    FLUX_MSGHANDLER_TABLE_END,
+};
+
+void content_mmap_destroy (struct content_mmap *mm)
+{
+    if (mm) {
+        int saved_errno = errno;
+        flux_msg_handler_delvec (mm->handlers);
+        hola_destroy (mm->tags);
+        zhashx_destroy (&mm->cache);
+        free (mm->hash_name);
+        free (mm);
+        errno = saved_errno;
+    }
+}
+
+struct content_mmap *content_mmap_create (flux_t *h,
+                                          const char *hash_name,
+                                          int hash_size)
+{
+    struct content_mmap *mm;
+
+    if (!(mm = calloc (1, sizeof (*mm))))
+        return NULL;
+    content_hash_size = hash_size;
+    if (flux_get_rank (h, &mm->rank) < 0)
+        goto error;
+    if (!(mm->hash_name = strdup (hash_name)))
+        goto error;
+    mm->h = h;
+    if (flux_msg_handler_addvec (h, htab, mm, &mm->handlers) < 0)
+        goto error;
+    if (!(mm->tags = hola_create (HOLA_AUTOCREATE)))
+        goto error;
+    hola_set_list_destructor (mm->tags, content_mmap_region_destructor);
+    hola_set_list_duplicator (mm->tags,
+                         (zlistx_duplicator_fn *)content_mmap_region_incref);
+    if (!(mm->cache = zhashx_new ())) {
+        errno = ENOMEM;
+        goto error;
+    }
+    zhashx_set_destructor (mm->cache, cache_entry_destructor);
+    zhashx_set_key_hasher (mm->cache, cache_entry_hasher);
+    zhashx_set_key_comparator (mm->cache, cache_entry_comparator);
+    zhashx_set_key_destructor (mm->cache, NULL); // key is part of entry
+    zhashx_set_key_duplicator (mm->cache, NULL); // key is part of entry
+    return mm;
+error:
+    content_mmap_destroy (mm);
+    return NULL;
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/src/broker/content-mmap.h
+++ b/src/broker/content-mmap.h
@@ -1,0 +1,40 @@
+/************************************************************\
+ * Copyright 2022 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef BROKER_CONTENT_MMAP_H
+#define BROKER_CONTENT_MMAP_H 1
+
+#include <stdbool.h>
+
+#include "content-cache.h"
+
+struct content_mmap *content_mmap_create (flux_t *h,
+                                          const char *hash_name,
+                                          int hash_size);
+void content_mmap_destroy (struct content_mmap *mm);
+
+struct content_region *content_mmap_region_lookup (struct content_mmap *mm,
+                                                   const void *hash,
+                                                   int hash_size,
+                                                   const void **data,
+                                                   int *data_size);
+
+bool content_mmap_validate (struct content_region *reg,
+                            const void *hash,
+                            int hash_size,
+                            const void *data,
+                            int data_size);
+
+void content_mmap_region_decref (struct content_region *reg);
+struct content_region *content_mmap_region_incref (struct content_region *reg);
+
+#endif /* !BROKER_CONTENT_MMAP_H */
+
+// vi:ts=4 sw=4 expandtab

--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -61,7 +61,8 @@ flux_SOURCES = \
 	builtin/startlog.c \
 	builtin/dump.c \
 	builtin/restore.c \
-	builtin/shutdown.c
+	builtin/shutdown.c \
+	builtin/filemap.c
 nodist_flux_SOURCES = \
 	builtin-cmds.c
 

--- a/src/cmd/builtin/filemap.c
+++ b/src/cmd/builtin/filemap.c
@@ -1,0 +1,644 @@
+/************************************************************\
+ * Copyright 2022 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include "builtin.h"
+
+#include <unistd.h>
+#include <limits.h>
+#include <stdlib.h>
+#include <libgen.h>
+#include <jansson.h>
+#include <archive.h>
+#include <archive_entry.h>
+
+#include "ccan/base64/base64.h"
+#include "src/common/libutil/dirwalk.h"
+#include "src/common/libutil/errno_safe.h"
+#include "src/common/libcontent/content.h"
+#include "src/common/libutil/fileref.h"
+
+static const int default_chunksize = 1048576;
+
+static json_t *get_list_option (optparse_t *p,
+                                const char *name,
+                                const char *default_value)
+{
+    const char *item;
+    json_t *a;
+    json_t *o;
+
+    if (!(a = json_array ()))
+        log_msg_exit ("out of memory");
+    optparse_getopt_iterator_reset (p, name);
+    while ((item = optparse_getopt_next (p, name))) {
+        if (!(o = json_string (item))
+            || json_array_append_new (a, o) < 0)
+            log_msg_exit ("out of memory");
+    }
+    if (json_array_size (a) == 0 && default_value) {
+        if (!(o = json_string (default_value))
+            || json_array_append_new (a, o) < 0)
+            log_msg_exit ("out of memory");
+    }
+    return a;
+}
+
+static char *realpath_nofollow (const char *path)
+{
+    char *cpy;
+    char *cpy2 = NULL;
+    char *cdir = NULL;
+    char *result = NULL;
+    int saved_errno;
+
+    if (!(cpy = strdup (path))
+        || !(cpy2 = strdup (path)))
+        goto done;
+    if (!(cdir = realpath (dirname (cpy), NULL)))
+        goto done;
+    if (asprintf (&result, "%s/%s", cdir, basename (cpy2)) < 0)
+        goto done;
+done:
+    saved_errno = errno;
+    free (cdir);
+    free (cpy2);
+    free (cpy);
+    errno = saved_errno;
+    return result;
+}
+
+/* Decode the raw data field a fileref object, setting the result in 'data'
+ * and 'data_size'.  Caller must free.
+ */
+static int decode_data (const char *s, void **data, size_t *data_size)
+{
+    if (s) {
+        int len = strlen (s);
+        size_t bufsize = base64_decoded_length (len);
+        void *buf;
+        ssize_t n;
+
+        if (!(buf = malloc (bufsize)))
+            return -1;
+        if ((n = base64_decode (buf, bufsize, s, len)) < 0) {
+            free (buf);
+            errno = EINVAL;
+            return -1;
+        }
+        *data = buf;
+        *data_size = n;
+    }
+    return 0;
+}
+
+static json_t *load_fileref (flux_t *h, const char *blobref)
+{
+    flux_future_t *f;
+    const void *buf;
+    int size;
+    json_t *o;
+    json_error_t error;
+
+    if (!(f = content_load_byblobref (h, blobref, 0))
+        || content_load_get (f, &buf, &size) < 0) {
+        log_msg_exit ("error loading fileref from %s: %s",
+                      blobref,
+                      future_strerror (f, errno));
+    }
+    if (!(o = json_loads (buf, 0, &error)))
+        log_msg_exit ("error decoding fileref object from %s: %s",
+                      blobref,
+                      error.text);
+    flux_future_destroy (f);
+    return o;
+}
+
+static flux_future_t *mmap_add (flux_t *h,
+                                 const char *path,
+                                 int chunksize,
+                                 json_t *tags)
+{
+    flux_future_t *f;
+    char *fpath;
+    struct stat sb;
+
+    /* N.B. Provide full path to the broker but let the one that goes in
+     * the fileref be relative, if that's what is specified.
+     * The broker may not be running in the same directory as commands so it
+     * needs the full path, but the relative path should be preserved for
+     * extraction.
+     */
+    if (lstat (path, &sb) < 0)
+        log_err_exit ("%s", path);
+    if (S_ISLNK (sb.st_mode))
+        fpath = realpath_nofollow (path);
+    else
+        fpath = realpath (path, NULL);
+    if (!fpath)
+        log_err_exit ("%s", path);
+    f = flux_rpc_pack (h,
+                       "content.mmap-add",
+                       FLUX_NODEID_ANY,
+                       0,
+                       "{s:s s:s s:i s:O}",
+                       "path", path,
+                       "fullpath", fpath,
+                        "chunksize", chunksize,
+                        "tags", tags);
+    ERRNO_SAFE_WRAP (free, fpath);
+    return f;
+}
+
+static flux_future_t *mmap_remove (flux_t *h, json_t *tags)
+{
+    flux_future_t *f;
+    f = flux_rpc_pack (h, "content.mmap-remove", 0, 0, "{s:O}", "tags", tags);
+    return f;
+}
+
+static flux_future_t *mmap_list (flux_t *h,
+                                 bool blobref,
+                                 json_t *tags,
+                                 const char *pattern)
+{
+    flux_future_t *f;
+
+    if (pattern) {
+        f = flux_rpc_pack (h,
+                           "content.mmap-list",
+                           0,
+                           FLUX_RPC_STREAMING,
+                           "{s:b s:s s:O}",
+                           "blobref", blobref ? 1 : 0,
+                           "pattern", pattern,
+                           "tags", tags);
+    }
+    else {
+        f = flux_rpc_pack (h,
+                           "content.mmap-list",
+                           0,
+                           FLUX_RPC_STREAMING,
+                           "{s:b s:O}",
+                           "blobref", blobref ? 1 : 0,
+                           "tags", tags);
+    }
+    return f;
+}
+
+struct map_ctx {
+    optparse_t *p;
+    flux_t *h;
+    int verbose;
+    int chunksize;
+    json_t *tags;
+};
+
+static int map_visitor (dirwalk_t *d, void *arg)
+{
+    struct map_ctx *ctx = arg;
+    const char *path = dirwalk_path (d);
+    flux_future_t *f;
+
+    if (ctx->verbose > 0)
+        printf ("%s\n", path);
+    if (!(f = mmap_add (ctx->h, path, ctx->chunksize, ctx->tags))
+        || flux_rpc_get (f, NULL) < 0)
+        log_msg_exit ("%s: %s", path, future_strerror (f, errno));
+    flux_future_destroy (f);
+
+    return 0;
+}
+
+static int subcmd_map (optparse_t *p, int ac, char *av[])
+{
+    struct map_ctx ctx;
+    int n = optparse_option_index (p);
+    const char *directory = optparse_get_str (p, "directory", NULL);
+    int flags = DIRWALK_FIND_DIR | DIRWALK_DEPTH;
+
+    if (n == ac) {
+        optparse_print_usage (p);
+        exit (1);
+    }
+    if (directory) {
+        if (chdir (directory) < 0)
+            log_err_exit ("chdir %s", directory);
+    }
+    ctx.p = p;
+    ctx.verbose = optparse_get_int (p, "verbose", 0);
+    ctx.chunksize = optparse_get_int (p, "chunksize", default_chunksize);
+    ctx.tags = get_list_option (p, "tags", "main");
+    ctx.h = builtin_get_flux_handle (p);
+    if (!ctx.h)
+        log_err_exit ("flux_open");
+    while (n < ac) {
+        const char *path = av[n++];
+        struct stat sb;
+
+        if (lstat (path, &sb) < 0)
+            log_err_exit ("%s", path);
+        if (S_ISDIR (sb.st_mode)) {
+            if (dirwalk (path, flags, map_visitor, &ctx) < 0)
+                log_err_exit ("%s", path);
+        }
+        else {
+            flux_future_t *f;
+            if (ctx.verbose > 0)
+                printf ("%s\n", path);
+            if (!(f = mmap_add (ctx.h, path, ctx.chunksize, ctx.tags))
+                || flux_rpc_get (f, NULL) < 0)
+                log_msg_exit ("%s: %s", path, future_strerror (f, errno));
+            flux_future_destroy (f);
+        }
+    }
+    json_decref (ctx.tags);
+    flux_close (ctx.h);
+    return 0;
+}
+
+static int subcmd_unmap (optparse_t *p, int ac, char *av[])
+{
+    int n = optparse_option_index (p);
+    json_t *tags = get_list_option (p, "tags", "main");
+    flux_t *h;
+    flux_future_t *f;
+
+    if (n != ac) {
+        optparse_print_usage (p);
+        exit (1);
+    }
+    if (!(h = builtin_get_flux_handle (p)))
+        log_err_exit ("flux_open");
+    if (!(f = mmap_remove (h, tags))
+        || flux_rpc_get (f, NULL) < 0)
+        log_msg_exit ("%s", future_strerror (f, errno));
+    flux_future_destroy (f);
+    json_decref (tags);
+    flux_close (h);
+    return 0;
+}
+
+static int subcmd_list (optparse_t *p, int ac, char *av[])
+{
+    int n = optparse_option_index (p);
+    json_t *tags = get_list_option (p, "tags", "main");
+    bool blobref = optparse_hasopt (p, "blobref");
+    bool long_form = optparse_hasopt (p, "long");
+    const char *pattern = NULL;
+    flux_t *h;
+    size_t index;
+    json_t *entry;
+    flux_future_t *f;
+
+    if (n < ac)
+        pattern = av[n++];
+    if (n != ac) {
+        optparse_print_usage (p);
+        exit (1);
+    }
+    if (!(h = builtin_get_flux_handle (p)))
+        log_err_exit ("flux_open");
+    if (!(f = mmap_list (h, blobref, tags, pattern)))
+        log_err_exit ("mmap-list");
+    for (;;) {
+        json_t *files;
+
+        if (flux_rpc_get_unpack (f, "{s:o}", "files", &files) < 0) {
+            if (errno == ENODATA)
+                break; // end of stream
+            log_msg_exit ("mmap-list: %s", future_strerror (f, errno));
+        }
+        json_array_foreach (files, index, entry) {
+            if (optparse_hasopt (p, "blobref")) {
+                printf ("%s\n", json_string_value (entry));
+            }
+            else if (optparse_hasopt (p, "fileref")) {
+                if (json_dumpf (entry, stdout, JSON_COMPACT) < 0)
+                    log_msg_exit ("error dumping fileref object");
+            }
+            else {
+                char buf[1024];
+                fileref_pretty_print (entry, long_form, buf, sizeof (buf));
+                printf ("%s\n", buf);
+            }
+        }
+        flux_future_reset (f);
+    }
+    flux_future_destroy (f);
+    json_decref (tags);
+    flux_close (h);
+    return 0;
+}
+
+static void extract_blob (flux_t *h,
+                          struct archive *archive,
+                          const char *path,
+                          json_t *o)
+{
+    struct {
+        json_int_t offset;
+        json_int_t size;
+        const char *blobref;
+    } entry;
+    flux_future_t *f;
+    const void *buf;
+    int size;
+
+    if (json_unpack (o,
+                     "[I,I,s]",
+                     &entry.offset,
+                     &entry.size,
+                     &entry.blobref) < 0)
+        log_msg_exit ("%s: error decoding blobvec entry", path);
+    if (!(f = content_load_byblobref (h, entry.blobref, 0))
+        || content_load_get (f, &buf, &size) < 0) {
+        log_msg_exit ("%s: error loading offset=%ju size=%ju from %s: %s",
+                      path,
+                      (uintmax_t)entry.offset,
+                      (uintmax_t)entry.size,
+                      entry.blobref,
+                      future_strerror (f, errno));
+    }
+    if (size != entry.size) {
+        log_msg_exit ("%s: error loading offset=%ju size=%ju from %s:"
+                      " unexpected size %ju",
+                      path,
+                      (uintmax_t)entry.offset,
+                      (uintmax_t)entry.size,
+                      entry.blobref,
+                      (uintmax_t)size);
+    }
+    if (archive_write_data_block (archive,
+                                  buf,
+                                  size,
+                                  entry.offset) != ARCHIVE_OK)
+        log_msg_exit ("%s: write: %s", path, archive_error_string (archive));
+    flux_future_destroy (f);
+}
+
+
+static void extract_file (flux_t *h,
+                          optparse_t *p,
+                          struct archive *archive,
+                          json_t *fileref)
+{
+    int verbose = optparse_get_int (p, "verbose", 0);
+    const char *path;
+    json_int_t size;
+    json_int_t ctime;
+    json_int_t mtime;
+    int mode;
+    json_t *blobvec;
+    const char *data = NULL;
+    size_t index;
+    json_t *o;
+    struct archive_entry *entry;
+    json_error_t error;
+
+    if (json_unpack_ex (fileref,
+                        &error,
+                        0,
+                        "{s:s s:I s:I s:I s:i s?s s:o}",
+                        "path", &path,
+                        "size", &size,
+                        "mtime", &mtime,
+                        "ctime", &ctime,
+                        "mode", &mode,
+                        "data", &data,
+                        "blobvec", &blobvec) < 0)
+        log_msg_exit ("error decoding fileref object: %s", error.text);
+
+    if (verbose > 0)
+        fprintf (stderr, "%s\n", path);
+
+    /* metadata
+     */
+    if (!(entry = archive_entry_new ()))
+        log_msg_exit ("%s: error creating libarchive entry", path);
+    archive_entry_set_pathname (entry, path);
+    archive_entry_set_mode (entry, mode);
+    archive_entry_set_mtime (entry, mtime, 0);
+    archive_entry_set_ctime (entry, ctime, 0);
+    if (S_ISREG (mode)) {
+        archive_entry_set_size (entry, size);
+    }
+    else if (S_ISLNK (mode)) {
+        if (!data)
+            log_msg_exit ("%s: missing symlink data", path);
+        archive_entry_set_symlink (entry, data);
+    }
+    else if (!S_ISDIR (mode)) // nothing to do for directory
+        log_msg_exit ("%s: unknown file type (mode=0%o)", path, mode);
+    if (archive_write_header (archive, entry) != ARCHIVE_OK)
+        log_msg_exit ("%s: %s", path, archive_error_string (archive));
+
+    /* data
+     */
+    if (S_ISREG (mode)) {
+        if (data) { // small file is contained in fileref.data
+            void *buf;
+            size_t buf_size;
+
+            if (decode_data (data, &buf, &buf_size) < 0)
+                log_msg_exit ("%s: could not decode file data", path);
+            if (archive_write_data_block (archive,
+                                          buf,
+                                          buf_size,
+                                          0) != ARCHIVE_OK) {
+                log_msg_exit ("%s: write: %s",
+                              path,
+                              archive_error_string (archive));
+            }
+            free (buf);
+        }
+        else { // large file is spread over multiple blobrefs
+            json_array_foreach (blobvec, index, o) {
+                extract_blob (h, archive, path, o);
+            }
+        }
+    }
+
+    archive_entry_free (entry);
+}
+
+static void extract (flux_t *h,
+                     optparse_t *p,
+                     struct archive *archive,
+                     const char *pattern)
+{
+    json_t *tags = get_list_option (p, "tags", "main");
+    bool direct = optparse_hasopt (p, "direct");
+    flux_future_t *f;
+    size_t index;
+    json_t *entry;
+
+    if (!(f = mmap_list (h, !direct, tags, pattern)))
+        log_err_exit ("mmap-list");
+    for (;;) {
+        json_t *files;
+
+        if (flux_rpc_get_unpack (f, "{s:o}", "files", &files) < 0) {
+            if (errno == ENODATA)
+                break; // end of stream
+            log_msg_exit ("mmap-list: %s", future_strerror (f, errno));
+        }
+        json_array_foreach (files, index, entry) {
+            if (direct)
+                extract_file (h, p, archive, entry);
+            else {
+                json_t *fileref = load_fileref (h, json_string_value (entry));
+                extract_file (h, p, archive, fileref);
+                json_decref (fileref);
+            }
+        }
+        flux_future_reset (f);
+    }
+    flux_future_destroy (f);
+}
+
+static int subcmd_get (optparse_t *p, int ac, char *av[])
+{
+    int n = optparse_option_index (p);
+    const char *directory = optparse_get_str (p, "directory", NULL);
+    const char *pattern = NULL;
+    flux_t *h;
+    struct archive *archive;
+
+    if (n < ac)
+        pattern = av[n++];
+    if (n != ac) {
+        optparse_print_usage (p);
+        exit (1);
+    }
+    if (directory) {
+        if (chdir (directory) < 0)
+            log_err_exit ("chdir %s", directory);
+    }
+    if (!(h = builtin_get_flux_handle (p)))
+        log_err_exit ("flux_open");
+    if (!(archive = archive_write_disk_new ()))
+        log_msg_exit ("error creating libarchive context");
+    extract (h, p, archive, pattern);
+    archive_write_free (archive);
+    flux_close (h);
+    return 0;
+}
+
+int cmd_filemap (optparse_t *p, int ac, char *av[])
+{
+    log_init ("flux-filemap");
+
+    if (optparse_run_subcommand (p, ac, av) != OPTPARSE_SUCCESS)
+        exit (1);
+    return (0);
+}
+
+static struct optparse_option map_opts[] = {
+    { .name = "directory", .key = 'C', .has_arg = 1, .arginfo = "DIR",
+      .usage = "Change to DIR before mapping", },
+    { .name = "verbose", .key = 'v', .has_arg = 2, .arginfo = "[LEVEL]",
+      .usage = "Increase output detail.", },
+    { .name = "chunksize", .has_arg = 1, .arginfo = "N",
+      .usage = "Limit blob size to N bytes with 0=unlimited"
+               " (default 1048576)", },
+    { .name = "tags", .key = 'T', .has_arg = 1, .arginfo = "NAME,...",
+      .flags = OPTPARSE_OPT_AUTOSPLIT,
+      .usage = "Specify comma-separated tags (default: main)", },
+      OPTPARSE_TABLE_END
+};
+
+static struct optparse_option unmap_opts[] = {
+    { .name = "tags", .key = 'T', .has_arg = 1, .arginfo = "NAME,...",
+      .flags = OPTPARSE_OPT_AUTOSPLIT,
+      .usage = "Specify comma-separated tags (default: main)", },
+      OPTPARSE_TABLE_END
+};
+
+static struct optparse_option list_opts[] = {
+    { .name = "long", .key = 'l', .has_arg = 0,
+      .usage = "Show file type, mode, size", },
+    { .name = "blobref", .has_arg = 0,
+      .usage = "List blobrefs only, do not dereference them", },
+    { .name = "fileref", .has_arg = 0,
+      .usage = "Show raw fileref without decoding", },
+    { .name = "tags", .key = 'T', .has_arg = 1, .arginfo = "NAME,...",
+      .flags = OPTPARSE_OPT_AUTOSPLIT,
+      .usage = "Specify comma-separated tags (default: main)", },
+      OPTPARSE_TABLE_END
+};
+
+static struct optparse_option get_opts[] = {
+    { .name = "verbose", .key = 'v', .has_arg = 2, .arginfo = "[LEVEL]",
+      .usage = "Show filenames on stderr", },
+    { .name = "directory", .key = 'C', .has_arg = 1, .arginfo = "DIR",
+      .usage = "Change to DIR before extracting", },
+    { .name = "tags", .key = 'T', .has_arg = 1, .arginfo = "NAME,...",
+      .flags = OPTPARSE_OPT_AUTOSPLIT,
+      .usage = "Specify comma-separated tags (default: main)", },
+    { .name = "direct", .has_arg = 0,
+      .usage = "Fetch filerefs directly (fastest for single client)", },
+      OPTPARSE_TABLE_END
+};
+
+static struct optparse_subcommand filemap_subcmds[] = {
+    { "map",
+      "[--tags=LIST] [--directory=DIR] PATH ...",
+      "Map file(s) into the content cache",
+      subcmd_map,
+      0,
+      map_opts,
+    },
+    { "unmap",
+      "[--tags=LIST]",
+      "Unmap files from the content cache",
+      subcmd_unmap,
+      0,
+      unmap_opts,
+    },
+    { "list",
+      "[--tags=LIST] [--long] [PATTERN]",
+      "List files mapped into the content cache",
+      subcmd_list,
+      0,
+      list_opts,
+    },
+    { "get",
+      "[--tags=LIST] [--directory=DIR] [PATTERN]",
+      "Extract files from content cache",
+      subcmd_get,
+      0,
+      get_opts,
+    },
+    OPTPARSE_SUBCMD_END
+};
+
+int subcommand_filemap_register (optparse_t *p)
+{
+    optparse_err_t e;
+
+    e = optparse_reg_subcommand (p,
+                                 "filemap",
+                                 cmd_filemap,
+                                 NULL,
+                                 "File staging utility", 0, NULL);
+    if (e != OPTPARSE_SUCCESS)
+        return (-1);
+
+    e = optparse_reg_subcommands (optparse_get_subcommand (p, "filemap"),
+                                  filemap_subcmds);
+    return (e == OPTPARSE_SUCCESS ? 0 : -1);
+}
+
+/*
+ * vi: ts=4 sw=4 expandtab
+ */

--- a/src/common/libflux/message.c
+++ b/src/common/libflux/message.c
@@ -353,7 +353,7 @@ int flux_msg_set_flags (flux_msg_t *msg, uint8_t flags)
     const uint8_t valid_flags = FLUX_MSGFLAG_TOPIC | FLUX_MSGFLAG_PAYLOAD
                               | FLUX_MSGFLAG_ROUTE | FLUX_MSGFLAG_UPSTREAM
                               | FLUX_MSGFLAG_PRIVATE | FLUX_MSGFLAG_STREAMING
-                              | FLUX_MSGFLAG_NORESPONSE;
+                              | FLUX_MSGFLAG_NORESPONSE | FLUX_MSGFLAG_USER1;
 
     if (msg_validate (msg) < 0)
         return -1;
@@ -427,6 +427,23 @@ bool flux_msg_is_noresponse (const flux_msg_t *msg)
         return true;
     return (msg->flags & FLUX_MSGFLAG_NORESPONSE) ? true : false;
 }
+
+int flux_msg_set_user1 (flux_msg_t *msg)
+{
+    if (msg_validate (msg) < 0)
+        return -1;
+    if (flux_msg_set_flags (msg, msg->flags | FLUX_MSGFLAG_USER1) < 0)
+        return -1;
+    return 0;
+}
+
+bool flux_msg_is_user1 (const flux_msg_t *msg)
+{
+    if (msg_validate (msg) < 0)
+        return false;
+    return (msg->flags & FLUX_MSGFLAG_USER1) ? true : false;
+}
+
 
 int flux_msg_set_userid (flux_msg_t *msg, uint32_t userid)
 {

--- a/src/common/libflux/message.h
+++ b/src/common/libflux/message.h
@@ -41,6 +41,7 @@ enum {
     FLUX_MSGFLAG_UPSTREAM   = 0x10, /* request nodeid is sender (route away) */
     FLUX_MSGFLAG_PRIVATE    = 0x20, /* private to instance owner and sender */
     FLUX_MSGFLAG_STREAMING  = 0x40, /* request/response is streaming RPC */
+    FLUX_MSGFLAG_USER1      = 0x80, /* user-defined message flag */
 };
 
 /* N.B. FLUX_NODEID_UPSTREAM should be used in the RPC interface only.
@@ -156,6 +157,11 @@ bool flux_msg_is_streaming (const flux_msg_t *msg);
  */
 int flux_msg_set_noresponse (flux_msg_t *msg);
 bool flux_msg_is_noresponse (const flux_msg_t *msg);
+
+/* Get/set USER1 flag.
+ */
+int flux_msg_set_user1 (flux_msg_t *msg);
+bool flux_msg_is_user1 (const flux_msg_t *msg);
 
 /* Get/set/compare message topic string.
  * set adds/deletes/replaces topic frame as needed.

--- a/src/common/libflux/test/message.c
+++ b/src/common/libflux/test/message.c
@@ -295,6 +295,11 @@ void check_cornercase (void)
     ok ((flux_msg_route_string (msg) == NULL && errno == EPROTO),
         "flux_msg_route_string returns NULL errno EPROTO on msg "
         "w/o routes enabled");
+    errno = 0;
+    ok (flux_msg_set_user1 (NULL) < 0 && errno == EINVAL,
+        "flux_msg_set_user1 msg=NULL fails with EINVAL");
+    ok (flux_msg_is_user1 (NULL) == false,
+        "flux_msg_is_user1 msg=NULL returns false");
 
     flux_msg_destroy (msg);
 }
@@ -1165,6 +1170,15 @@ void check_flags (void)
         "flux_msg_get_flags works");
     ok (flags == 0,
         "flags are initially zero");
+
+    /* FLUX_MSGFLAG_USER1 */
+    ok (flux_msg_is_user1 (msg) == false,
+        "flux_msg_is_user1 = false");
+    ok (flux_msg_set_user1 (msg) == 0,
+        "flux_msg_set_user1_works");
+    ok (flux_msg_is_user1 (msg) == true,
+        "flux_msg_is_user1 = true");
+
 
     /* FLUX_MSGFLAG_PRIVATE */
     ok (flux_msg_is_private (msg) == false,

--- a/src/common/libutil/Makefile.am
+++ b/src/common/libutil/Makefile.am
@@ -95,6 +95,8 @@ libutil_la_SOURCES = \
 	errprintf.h \
 	fileref.c \
 	fileref.h \
+	hola.c \
+	hola.h \
 	strstrip.c \
 	strstrip.h
 

--- a/src/common/libutil/Makefile.am
+++ b/src/common/libutil/Makefile.am
@@ -93,6 +93,8 @@ libutil_la_SOURCES = \
 	uri.h \
 	errprintf.c \
 	errprintf.h \
+	fileref.c \
+	fileref.h \
 	strstrip.c \
 	strstrip.h
 

--- a/src/common/libutil/Makefile.am
+++ b/src/common/libutil/Makefile.am
@@ -126,6 +126,7 @@ TESTS = test_sha1.t \
 	test_digest.t \
 	test_jpath.t \
 	test_errprintf.t \
+	test_fileref.t \
 	test_strstrip.t
 
 test_ldadd = \
@@ -261,3 +262,7 @@ test_errprintf_t_LDADD = $(test_ldadd)
 test_strstrip_t_SOURCES = test/strstrip.c
 test_strstrip_t_CPPFLAGS = $(test_cppflags)
 test_strstrip_t_LDADD = $(test_ldadd)
+
+test_fileref_t_SOURCES = test/fileref.c
+test_fileref_t_CPPFLAGS = $(test_cppflags)
+test_fileref_t_LDADD = $(test_ldadd)

--- a/src/common/libutil/Makefile.am
+++ b/src/common/libutil/Makefile.am
@@ -129,6 +129,7 @@ TESTS = test_sha1.t \
 	test_jpath.t \
 	test_errprintf.t \
 	test_fileref.t \
+	test_hola.t \
 	test_strstrip.t
 
 test_ldadd = \
@@ -268,3 +269,7 @@ test_strstrip_t_LDADD = $(test_ldadd)
 test_fileref_t_SOURCES = test/fileref.c
 test_fileref_t_CPPFLAGS = $(test_cppflags)
 test_fileref_t_LDADD = $(test_ldadd)
+
+test_hola_t_SOURCES = test/hola.c
+test_hola_t_CPPFLAGS = $(test_cppflags)
+test_hola_t_LDADD = $(test_ldadd)

--- a/src/common/libutil/fileref.c
+++ b/src/common/libutil/fileref.c
@@ -1,0 +1,372 @@
+/************************************************************\
+ * Copyright 2022 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* fileref.c - manipulate "fileref" object
+ *
+ * { "version":1,
+ *   "type":"fileref",
+ *   "path":s,
+ *   "size":I,
+ *   "ctime":I,
+ *   "mtime":I,
+ *   "mode":i,
+ *   "data"?s,
+ *   "blobvec":[
+ *      [I,I,s],
+ *      [I,I,s],
+ *      ...
+ *   ]
+ * }
+ *
+ * where blobvec array entries are a 3-tuple of [offset, size, blobref]
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/mman.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <errno.h>
+#include <jansson.h>
+#include <assert.h>
+
+#include "ccan/base64/base64.h"
+
+#include "blobref.h"
+#include "errno_safe.h"
+#include "errprintf.h"
+#include "read_all.h"
+#include "fileref.h"
+
+static const int small_file_threshold = 4096;
+
+static int blobvec_append (json_t *blobvec,
+                           const void *mapbuf,
+                           off_t offset,
+                           size_t blobsize,
+                           const char *hashtype)
+{
+    char blobref[BLOBREF_MAX_STRING_SIZE];
+    json_t *o;
+
+    if (blobref_hash (hashtype,
+                      mapbuf + offset,
+                      blobsize,
+                      blobref,
+                      sizeof (blobref)) < 0)
+        return -1;
+    if (!(o = json_pack ("[I,I,s]", offset, blobsize, blobref))
+        || json_array_append_new (blobvec, o) < 0) {
+        json_decref (o);
+        errno = ENOMEM;
+        return -1;
+    }
+    return 0;
+}
+
+/* Walk the regular file represented by 'fd', appending blobvec array entries
+ * to 'blobvec' array for each 'chunksize' region.  Use SEEK_DATA and SEEK_HOLE
+ * to skip holes in sparse files - see lseek(2).
+ */
+static int blobvec_populate (json_t *blobvec,
+                             int fd,
+                             const void *mapbuf,
+                             size_t size,
+                             const char *hashtype,
+                             int chunksize)
+{
+    off_t offset = 0;
+
+    assert (fd >= 0);
+    assert (size > 0);
+
+    while (offset < size) {
+        // N.B. fails with ENXIO if there is no more data
+        if ((offset = lseek (fd, offset, SEEK_DATA)) == (off_t)-1) {
+            if (errno == ENXIO)
+                break;
+            return -1;
+        }
+        if (offset < size) {
+            off_t notdata;
+            int blobsize;
+
+            // N.B. returns size if there are no more holes
+            if ((notdata = lseek (fd, offset, SEEK_HOLE)) == (off_t)-1)
+                return -1;
+            blobsize = notdata - offset;
+            if (blobsize > chunksize)
+                blobsize = chunksize;
+            if (blobvec_append (blobvec,
+                                mapbuf,
+                                offset,
+                                blobsize,
+                                hashtype) < 0)
+                return -1;
+            offset += blobsize;
+        }
+    }
+    return 0;
+}
+
+/* Optionally set fileref.data (string).
+ * If 'data' is NULL do nothing.
+ * If encode_base64 is false, assume 'data' is NULL terminated and use directly.
+ * If encode_base64 is true, base64-encode it first.
+ */
+static int set_optional_data (json_t *fileref,
+                              const void *data,
+                              size_t data_size,
+                              bool encode_base64)
+{
+    if (data) {
+        json_t *o;
+
+        if (encode_base64) {
+            char *buf = NULL;
+            size_t bufsize = base64_encoded_length (data_size) + 1; // +1 NULL
+
+            if (!(buf = malloc (bufsize)))
+                return -1;
+            if (base64_encode (buf, bufsize, data, data_size) < 0) {
+                free (buf);
+                errno = EINVAL;
+                return -1;
+            }
+            o = json_string (buf);
+            free (buf);
+        }
+        else
+            o = json_string (data);
+        if (!o
+            || json_object_set_new (fileref, "data", o) < 0) {
+            json_decref (o);
+            errno = ENOMEM;
+            return -1;
+        }
+    }
+    return 0;
+}
+
+/* Create fileref object representing regular file, symbolic link, or
+ * directory. 'fullpath' is used to open/stat the file, while 'path' is
+ * recorded in the fileref object.
+ */
+json_t *fileref_create_ex (const char *path,
+                           const char *fullpath,
+                           const char *hashtype,
+                           int chunksize,
+                           void **mapbufp,
+                           size_t *mapsizep,
+                           flux_error_t *error)
+{
+    json_t *blobvec = NULL;
+    json_t *o;
+    int fd = -1;
+    struct stat sb;
+    void *mapbuf = MAP_FAILED;
+    size_t mapsize = 0;
+    int saved_errno;
+    void *data = NULL;
+    ssize_t data_size = 0;
+    bool data_encode_base64 = false;
+    int rc;
+
+    if (chunksize < 0) {
+        errprintf (error, "chunksize cannot be negative");
+        goto inval;
+    }
+    if (!fullpath)
+        fullpath = path;
+    /* Avoid TOCTOU in S_ISREG case by opening before checking its type.
+     */
+    if ((fd = open (fullpath, O_RDONLY | O_NOFOLLOW)) < 0)
+        rc = lstat (fullpath, &sb);
+    else
+        rc = fstat (fd, &sb);
+    if (rc < 0) {
+        errprintf (error, "%s: %s", path, strerror (errno));
+        goto error;
+    }
+    if (!(blobvec = json_array ())) {
+        errno = ENOMEM;
+        goto error;
+    }
+    /* Regular file: if size is below threshold, base64 encode its content
+     * and place in the 'data' field.  Otherwise, mmap the file and build
+     * the blobvec array.
+     */
+    if (S_ISREG (sb.st_mode)) {
+        if (sb.st_size > 0) {
+            if (sb.st_size <= small_file_threshold) {
+                if ((data_size = read_all (fd, &data)) < 0) {
+                    errprintf (error, "%s: %s", path, strerror (errno));
+                    goto error;
+                }
+                if (data_size < sb.st_size) {
+                    errprintf (error, "%s: short read", path);
+                    errno = EINVAL;
+                    goto error;
+                }
+                data_encode_base64 = true;
+            }
+            else {
+                mapsize = sb.st_size;
+                mapbuf = mmap (NULL, mapsize, PROT_READ, MAP_PRIVATE, fd, 0);
+                if (mapbuf == MAP_FAILED) {
+                    errprintf (error, "mmap: %s", strerror (errno));
+                    goto error;
+                }
+                if (chunksize == 0)
+                    chunksize = sb.st_size;
+                if (blobvec_populate (blobvec,
+                                      fd,
+                                      mapbuf,
+                                      mapsize,
+                                      hashtype,
+                                      chunksize) < 0) {
+                    errprintf (error,
+                               "error generating blobvec array: %s",
+                               strerror (errno));
+                    goto error;
+                }
+            }
+        }
+    }
+    /* Symbolic link: place link target in 'data' field.
+     */
+    else if (S_ISLNK (sb.st_mode)) {
+        if (!(data = calloc (1, sb.st_size + 1))
+            || readlink (fullpath, data, sb.st_size) < 0) {
+            errprintf (error, "readlink %s: %s", path, strerror (errno));
+            goto error;
+        }
+        data_size = strlen (data);
+    }
+    /* For a directory, 'data' is not set, and 'blobvec' remains empty.
+     * All other types are rejected.
+     */
+    else if (!S_ISDIR (sb.st_mode)) {
+        errprintf (error, "%s: unsupported file type", path);
+        goto inval;
+    }
+    /* Store a relative path in the object so that extraction can specify a
+     * destination directory, like tar(1) default behavior.
+     */
+    const char *relative_path = path;
+    while (*relative_path == '/')
+        relative_path++;
+    if (strlen (relative_path) == 0)
+        relative_path = ".";
+    json_int_t size = sb.st_size;
+    json_int_t ctime = sb.st_ctime;
+    json_int_t mtime = sb.st_mtime;
+    int mode = sb.st_mode;
+    if (!(o = json_pack ("{s:i s:s s:s s:I s:I s:I s:i s:O}",
+                         "version", 1,
+                         "type", "fileref",
+                         "path", relative_path,
+                         "size", size,
+                         "mtime", mtime,
+                         "ctime", ctime,
+                         "mode", mode,
+                         "blobvec", blobvec))
+        || set_optional_data (o, data, data_size, data_encode_base64) < 0) {
+        errprintf (error, "error packing fileref object");
+        goto inval;
+    }
+    if (mapbufp)
+        *mapbufp = mapbuf;
+    else if (mapbuf != MAP_FAILED)
+        (void)munmap (mapbuf, mapsize);
+    if (mapsizep)
+        *mapsizep = mapsize;
+    if (fd >= 0)
+        close (fd);
+    json_decref (blobvec);
+    free (data);
+    return o;
+inval:
+    errno = EINVAL;
+error:
+    saved_errno = errno;
+    json_decref (blobvec);
+    free (data);
+    if (mapbuf != MAP_FAILED)
+        (void)munmap (mapbuf, mapsize);
+    if (fd >= 0)
+        close (fd);
+    errno = saved_errno;
+    return NULL;
+}
+
+json_t *fileref_create (const char *path,
+                        const char *hashtype,
+                        int chunksize,
+                        flux_error_t *error)
+{
+    return fileref_create_ex (path,
+                              NULL, // fullpath
+                              hashtype,
+                              chunksize,
+                              NULL, // mapbuf
+                              NULL, // maplen
+                              error);
+}
+
+void fileref_pretty_print (json_t *fileref,
+                           bool long_form,
+                           char *buf,
+                           size_t bufsize)
+{
+    const char *path;
+    json_int_t size;
+    json_int_t ctime;
+    json_int_t mtime;
+    int mode;
+    json_t *blobvec;
+    const char *data = NULL;
+    int n;
+
+    if (!buf)
+        return;
+    if (!fileref
+        || json_unpack (fileref,
+                        "{s:s s:I s:I s:I s:i s?s s:o}",
+                        "path", &path,
+                        "size", &size,
+                        "mtime", &mtime,
+                        "ctime", &ctime,
+                        "mode", &mode,
+                        "data", &data,
+                        "blobvec", &blobvec) < 0) {
+        n = snprintf (buf, bufsize, "invalid fileref");
+    }
+    else if (long_form) {
+        n = snprintf (buf,
+                      bufsize,
+                      "%s 0%o %8ju %s",
+                      S_ISREG (mode) ? "f" :
+                      S_ISLNK (mode) ? "l" :
+                      S_ISDIR (mode) ? "d" : "?",
+                      mode & 0777,
+                      (uintmax_t)size,
+                      path);
+    }
+    else
+        n = snprintf (buf, bufsize, "%s", path);
+    if (n >= bufsize && bufsize > 1)
+        buf[bufsize - 2] = '+';
+}
+
+// vi:tabstop=4 shiftwidth=4 expandtab

--- a/src/common/libutil/fileref.h
+++ b/src/common/libutil/fileref.h
@@ -1,0 +1,53 @@
+/************************************************************\
+ * Copyright 2022 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _UTIL_FILEREF_H
+#define _UTIL_FILEREF_H
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <jansson.h>
+
+#include "src/common/libflux/types.h"
+
+/* Variant of fileref_create() with extra parameters:
+ * - If non-NULL, 'mapbuf' and 'mapsize' are assigned mmapped buffer
+ *   (if applicable)
+ * - If non-NULL 'fullpath' is used in place of 'path' for open/stat/mmap.
+ */
+json_t *fileref_create_ex (const char *path,
+                           const char *fullpath,
+                           const char *hashtype,
+                           int chunksize,
+                           void **mapbuf,
+                           size_t *mapsize,
+                           flux_error_t *error);
+
+/* Create a fileref object for the regular file at 'path'.
+ * The chunksize limits the size of each blob (0=unlimited).
+ * Corner cases handled: empty files and sparse files.
+ */
+json_t *fileref_create (const char *path,
+                        const char *hashtype,
+                        int chunksize,
+                        flux_error_t *error);
+
+/* Build a "directory listing" of a fileref and set it in 'buf'.
+ * If the fileref is invalid, set "invalid fileref".
+ * If output is truncated, '+' is substituted for the last character.
+ */
+void fileref_pretty_print (json_t *fileref,
+                           bool long_form,
+                           char *buf,
+                           size_t bufsize);
+
+#endif /* !_UTIL_FILEREF_H */
+
+// vi:ts=4 sw=4 expandtab

--- a/src/common/libutil/hola.c
+++ b/src/common/libutil/hola.c
@@ -1,0 +1,279 @@
+/************************************************************\
+ * Copyright 2022 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* hola.c - hash of lists abstraciton
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdlib.h>
+#include <errno.h>
+
+#include "hola.h"
+
+struct hola {
+    zhashx_t *hash; // hash items are type (zlistx_t *)
+    zlistx_t *keys; // for iteration
+    zlistx_destructor_fn *list_destructor;
+    zlistx_duplicator_fn *list_duplicator;
+    unsigned int keys_valid:1;
+    unsigned int flags;
+};
+
+void hola_destroy (struct hola *hola)
+{
+    if (hola) {
+        int saved_errno = errno;
+        zlistx_destroy (&hola->keys);
+        zhashx_destroy (&hola->hash);
+        errno = saved_errno;
+        free (hola);
+    }
+}
+
+struct hola *hola_create (int flags)
+{
+    struct hola *hola;
+
+    if ((flags & ~(HOLA_AUTOCREATE | HOLA_AUTODESTROY)) != 0) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (!(hola = calloc (1, sizeof (*hola))))
+        return NULL;
+    hola->flags = flags;
+    if (!(hola->hash = zhashx_new ()))
+        goto error;
+    zhashx_set_destructor (hola->hash, (zhashx_destructor_fn *)zlistx_destroy);
+    return hola;
+error:
+    hola_destroy (hola);
+    return NULL;
+}
+
+void hola_set_list_destructor (struct hola *hola, zlistx_destructor_fn fun)
+{
+    if (hola)
+        hola->list_destructor = fun;
+}
+void hola_set_list_duplicator (struct hola *hola, zlistx_duplicator_fn fun)
+{
+    if (hola)
+        hola->list_duplicator = fun;
+}
+void hola_set_hash_key_destructor (struct hola *hola, zhashx_destructor_fn fun)
+{
+    if (hola)
+        zhashx_set_key_destructor (hola->hash, fun);
+}
+void hola_set_hash_key_duplicator (struct hola *hola, zhashx_duplicator_fn fun)
+{
+    if (hola)
+        zhashx_set_key_duplicator (hola->hash, fun);
+}
+void hola_set_hash_key_comparator (struct hola *hola, zhashx_comparator_fn fun)
+{
+    if (hola)
+        zhashx_set_key_comparator (hola->hash, fun);
+}
+void hola_set_hash_key_hasher (struct hola *hola, zhashx_hash_fn fun)
+{
+    if (hola)
+        zhashx_set_key_hasher (hola->hash, fun);
+}
+
+zlistx_t *hola_hash_lookup (struct hola *hola, const void *key)
+{
+    zlistx_t *l;
+
+    if (!hola || !key) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (!(l = zhashx_lookup (hola->hash, key))) {
+        errno = ENOENT;
+        return NULL;
+    }
+    return l;
+}
+
+static zlistx_t *hash_add (struct hola *hola, const void *key)
+{
+    zlistx_t *l;
+
+    if (!(l = zlistx_new ())) {
+        errno = ENOMEM;
+        return NULL;
+    }
+    zlistx_set_destructor (l, hola->list_destructor);
+    zlistx_set_duplicator (l, hola->list_duplicator);
+    if (zhashx_insert (hola->hash, key, l) < 0) {
+        zlistx_destroy (&l);
+        errno = EEXIST;
+        return NULL;
+    }
+    hola->keys_valid = 0;
+    return l;
+}
+
+int hola_hash_add (struct hola *hola, const void *key)
+{
+    if (!hola || !key) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (hash_add (hola, key) == NULL)
+        return -1;
+    return 0;
+}
+
+int hola_hash_delete (struct hola *hola, const void *key)
+{
+    if (!hola || !key) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (!zhashx_lookup (hola->hash, key)) {
+        errno = ENOENT;
+        return -1;
+    }
+    zhashx_delete (hola->hash, key);
+    hola->keys_valid = 0;
+    return 0;
+}
+
+const void *hola_hash_first (struct hola *hola)
+{
+    const void *key = NULL;
+    if (hola) {
+        if (!hola->keys_valid) {
+            zlistx_destroy (&hola->keys);
+            if ((hola->keys = zhashx_keys (hola->hash)))
+                hola->keys_valid = 1;
+        }
+        if (hola->keys)
+            key = zlistx_first (hola->keys);
+    }
+    return key;
+}
+
+const void *hola_hash_next (struct hola *hola)
+{
+    const void *key = NULL;
+    if (hola && hola->keys) {
+        key = zlistx_next (hola->keys);
+    }
+    return key;
+}
+
+size_t hola_hash_size (struct hola *hola)
+{
+    return hola ? zhashx_size (hola->hash) : 0;
+}
+
+void *hola_list_add_end (struct hola *hola, const void *key, void *item)
+{
+    zlistx_t *l;
+    void *handle;
+
+    if (!hola || !key || !item) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (!(l = zhashx_lookup (hola->hash, key))) {
+        if ((hola->flags & HOLA_AUTOCREATE)) {
+            if (!(l = hash_add (hola, key)))
+                return NULL;
+        }
+        else {
+            errno = ENOENT;
+            return NULL;
+        }
+    }
+    if ((handle = zlistx_add_end (l, item)) == NULL) {
+        errno = ENOMEM;
+        return NULL;
+    }
+    return handle;
+}
+
+int hola_list_delete (struct hola *hola, const void *key, void *handle)
+{
+    zlistx_t *l;
+
+    if (!hola || !key || !handle) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (!(l = zhashx_lookup (hola->hash, key))
+        || zlistx_delete (l, handle) < 0) {
+        errno = ENOENT;
+        return -1;
+    }
+    if ((hola->flags & HOLA_AUTODESTROY)) {
+        if (zlistx_size (l) == 0) {
+            zhashx_delete (hola->hash, key);
+            hola->keys_valid = 0;
+        }
+    }
+    return 0;
+}
+
+void *hola_list_first (struct hola *hola, const void *key)
+{
+    void *item = NULL;
+
+    if (hola && key) {
+        zlistx_t *l;
+        if ((l = zhashx_lookup (hola->hash, key)))
+            item = zlistx_first (l);
+    }
+    return item;
+}
+
+void *hola_list_next (struct hola *hola, const void *key)
+{
+    void *item = NULL;
+
+    if (hola && key) {
+        zlistx_t *l;
+        if ((l = zhashx_lookup (hola->hash, key)))
+            item = zlistx_next (l);
+    }
+    return item;
+}
+
+void *hola_list_cursor (struct hola *hola, const void *key)
+{
+    void *handle = NULL;
+
+    if (hola && key) {
+        zlistx_t *l;
+        if ((l = zhashx_lookup (hola->hash, key)))
+            handle = zlistx_cursor (l);
+    }
+    return handle;
+}
+
+size_t hola_list_size (struct hola *hola, const void *key)
+{
+    size_t size = 0;
+
+    if (hola && key) {
+        zlistx_t *l;
+        if ((l = zhashx_lookup (hola->hash, key)))
+            size = zlistx_size (l);
+    }
+    return size;
+}
+
+
+// vi:ts=4 sw=4 expandtab

--- a/src/common/libutil/hola.h
+++ b/src/common/libutil/hola.h
@@ -1,0 +1,57 @@
+/************************************************************\
+ * Copyright 2022 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _UTIL_HOLA_H
+#define _UTIL_HOLA_H
+
+#include "src/common/libczmqcontainers/czmq_containers.h"
+
+/* Lists are not internally created/destroyed automatically by default.
+ * hola_hash_add() / hola_hash_delete() must be called to create/destroy them.
+ * These flags allow automatic behavior to be enabled at list creation.
+ */
+enum {
+    HOLA_AUTOCREATE = 1,    // create list on first addition
+    HOLA_AUTODESTROY = 2,   // destroy list on last removal
+};
+
+struct hola *hola_create (int flags);
+void hola_destroy (struct hola *hola);
+
+void hola_set_list_destructor (struct hola *hola, zlistx_destructor_fn fun);
+void hola_set_list_duplicator (struct hola *hola, zlistx_duplicator_fn fun);
+
+void hola_set_hash_key_destructor (struct hola *hola, zhashx_destructor_fn fun);
+void hola_set_hash_key_duplicator (struct hola *hola, zhashx_duplicator_fn fun);
+void hola_set_hash_key_comparator (struct hola *hola, zhashx_comparator_fn fun);
+void hola_set_hash_key_hasher (struct hola *hola, zhashx_hash_fn fun);
+
+const void *hola_hash_first (struct hola *hola);
+const void *hola_hash_next (struct hola *hola);
+int hola_hash_add (struct hola *hola, const void *key);
+int hola_hash_delete (struct hola *hola, const void *key);
+size_t hola_hash_size (struct hola *hola);
+zlistx_t *hola_hash_lookup (struct hola *hola, const void *key);
+
+// returns list item
+void *hola_list_first (struct hola *hola, const void *key);
+void *hola_list_next (struct hola *hola, const void *key);
+
+// returns list handle
+void *hola_list_add_end (struct hola *hola, const void *key, void *item);
+void *hola_list_cursor (struct hola *hola, const void *key);
+
+int hola_list_delete (struct hola *hola, const void *key, void *handle);
+size_t hola_list_size (struct hola *hola, const void *key);
+
+
+#endif /* !_UTIL_HOLA_H */
+
+// vi:ts=4 sw=4 expandtab

--- a/src/common/libutil/test/fileref.c
+++ b/src/common/libutil/test/fileref.c
@@ -1,0 +1,565 @@
+/************************************************************\
+ * Copyright 2022 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "src/common/libtap/tap.h"
+#include "src/common/libutil/fileref.h"
+#include "src/common/libutil/unlink_recursive.h"
+#include "src/common/libutil/blobref.h"
+#include "ccan/array_size/array_size.h"
+#include "src/common/libccan/ccan/str/str.h"
+#include "ccan/base64/base64.h"
+
+static char testdir[1024];
+
+static bool have_sparse;
+
+const char *mkpath (const char *name)
+{
+    static char tmppath[2048];
+    snprintf (tmppath, sizeof (tmppath), "%s/%s", testdir, name);
+    return tmppath;
+}
+const char *mkpath_relative (const char *name)
+{
+    const char *cp = mkpath (name);
+    while (*cp == '/')
+        cp++;
+    return cp;
+}
+
+void rmfile (const char *name)
+{
+    if (unlink (mkpath (name)) < 0)
+        BAIL_OUT ("error unlinking %s", mkpath (name));
+}
+
+bool test_sparse (void)
+{
+    int fd;
+    struct stat sb;
+    bool result = false;
+
+    fd = open (mkpath ("testhole"), O_WRONLY | O_CREAT | O_TRUNC, 0600);
+    if (fd < 0)
+        BAIL_OUT ("error creating test file: %s", strerror (errno));
+    if (ftruncate (fd, 8192) < 0)
+        BAIL_OUT ("error truncating test file: %s", strerror (errno));
+     if (fstat (fd, &sb) < 0)
+        BAIL_OUT ("error stating test file: %s", strerror (errno));
+    if (sb.st_blocks == 0)
+        result = true;
+    close (fd);
+    rmfile ("testhole");
+    return result;
+}
+
+/* Create test file 'name' under test directory.
+ * Each character in  'spec' represents one block filled with that character,
+ * except for "-" which tries to create a hole (if supported by file system).
+ */
+void mkfile (const char *name, int blocksize, const char *spec)
+{
+    char *buf;
+    int fd;
+    const char *cp;
+
+    if (!(buf = malloc (blocksize)))
+        BAIL_OUT ("malloc failed");
+    if ((fd = open (mkpath (name), O_WRONLY | O_CREAT | O_TRUNC, 0644)) < 0)
+        BAIL_OUT ("could not create %s: %s", name, strerror (errno));
+    for (cp = &spec[0]; *cp != '\0'; cp++) {
+        if (*cp == '-') {
+            if (lseek (fd, blocksize, SEEK_CUR) == (off_t)-1)
+                BAIL_OUT ("error lseeking in %s: %s", name, strerror (errno));
+        }
+        else {
+            memset (buf, *cp, blocksize);
+            size_t n = write (fd, buf, blocksize);
+            if (n < 0)
+                BAIL_OUT ("error writing to %s: %s", name, strerror (errno));
+            if (n < blocksize)
+                BAIL_OUT ("short write to %s", name);
+        }
+    }
+    if (close (fd) < 0)
+        BAIL_OUT ("error closing %s: %s", name, strerror (errno));
+    free (buf);
+}
+
+/* Check that blobref 'bref' hash matches specified file region.
+ * If bref is NULL, check that the region contains all zeroes.
+ */
+bool check_blob (int fd, off_t offset, size_t size, const char *bref)
+{
+    char *buf;
+    ssize_t n;
+    char blobref[BLOBREF_MAX_STRING_SIZE];
+
+    if (!(buf = malloc (size)))
+        BAIL_OUT ("out of memory");
+    if (lseek (fd, offset, SEEK_SET) == (off_t)-1) {
+        diag ("lseek: %s", strerror (errno));
+        goto error;
+    }
+    if ((n = read (fd, buf, size)) < 0) {
+        diag ("read: %s", strerror (errno));
+        goto error;
+    }
+    if (n < size) {
+        errno = EINVAL;
+        diag ("short read");
+        goto error;
+    }
+    if (bref) {
+        char hashtype[64], *cp;
+        snprintf (hashtype, sizeof (hashtype), "%s", bref);
+        if ((cp = strchr (hashtype, '-')))
+            *cp = '\0';
+        if (blobref_hash (hashtype, buf, size, blobref, sizeof (blobref)) < 0)
+            goto error;
+        if (!streq (blobref, bref)) {
+            diag ("blobref mismatch");
+            goto error;
+        }
+    }
+    else { // check hole
+        for (int i = 0; i < size; i++) {
+            if (buf[i] != 0) {
+                diag ("hole mismatch");
+                goto error;
+            }
+        }
+    }
+    free (buf);
+    return true;
+error:
+    free (buf);
+    return false;
+}
+
+/* Check that 'fileref' matches the metadata and content of test file 'name'
+ * and has the expected blobvec length.
+ */
+bool check_fileref (json_t *fileref, const char *name, int blobcount)
+{
+    int version;
+    const char *type;
+    const char *path;
+    json_int_t size;
+    json_int_t mtime;
+    json_int_t ctime;
+    int mode;
+    json_t *blobvec;
+    struct stat sb;
+    const char *data = NULL;
+
+    if (!fileref) {
+        diag ("fileref is NULL");
+        return false;
+    }
+    if (json_unpack (fileref,
+                     "{s:i s:s s:s s:I s:I s:I s:i s?s s:o}",
+                     "version", &version,
+                     "type", &type,
+                     "path", &path,
+                     "size", &size,
+                     "mtime", &mtime,
+                     "ctime", &ctime,
+                     "mode", &mode,
+                     "data", &data,
+                     "blobvec", &blobvec) < 0) {
+        diag ("error decoding fileref object");
+        return false;
+    }
+    if (version != 1) {
+        diag ("fileref.version != 1");
+        return false;
+    }
+    if (!streq (type, "fileref")) {
+        diag ("fileref.type != fileref");
+        return false;
+    }
+    if (!streq (path, mkpath_relative (name))) {
+        diag ("fileref.path != expected path");
+        return false;
+    }
+    if (lstat (mkpath (name), &sb) < 0)
+        BAIL_OUT ("could not stat %s", path);
+    if (size != sb.st_size) {
+        diag ("fileref.size is %ju not %zu", (uintmax_t)size, sb.st_size);
+        goto error;
+    }
+    if (mtime != sb.st_mtime) {
+        diag ("fileref.mtime is wrong");
+        goto error;
+    }
+    if (ctime != sb.st_ctime) {
+        diag ("fileref.ctime is wrong");
+        goto error;
+    }
+    if (mode != sb.st_mode) {
+        diag ("fileref.mode is wrong");
+        goto error;
+    }
+    if (!S_ISREG (mode) && !S_ISDIR (mode) && !S_ISLNK (mode)) {
+        diag ("unknown file type");
+        goto error;
+    }
+    if (S_ISLNK (mode)) {
+        char buf[1024];
+        if (!data) {
+            diag ("symlink data is missing");
+            goto error;
+        }
+        if (readlink (mkpath (name), buf, sizeof (buf)) < 0
+            || !streq (buf, data)) {
+            diag ("symlink target is wrong");
+            goto error;
+        }
+    }
+    else if (S_ISREG (mode)) {
+        if (data && json_array_size (blobvec) > 0) {
+            diag ("regular file has both data and blobrefs");
+            goto error;
+        }
+    }
+    else if (S_ISDIR (mode)) {
+        if (data != NULL) {
+            diag ("directory has data");
+            goto error;
+        }
+    }
+    if (json_array_size (blobvec) != blobcount) {
+        diag ("fileref.blobvec has incorrect length (expected %d got %zu)",
+              blobcount, json_array_size (blobvec));
+        goto error;
+    }
+    if (blobcount > 0) {
+        int fd;
+        size_t index;
+        json_t *o;
+        off_t cursor;
+
+        if ((fd = open (mkpath (name), O_RDONLY)) < 0) {
+            diag ("open %s: %s", path, strerror (errno));
+            return false;
+        }
+        cursor = 0;
+        json_array_foreach (blobvec, index, o) {
+            struct {
+                json_int_t offset;
+                json_int_t size;
+                const char *blobref;
+            } entry;
+
+            if (json_unpack (o, "[I,I,s]",
+                             &entry.offset,
+                             &entry.size,
+                             &entry.blobref) < 0) {
+                diag ("failed to unpack blovec entry");
+                close (fd);
+                goto error;
+            }
+            // if offset > cursor, we've hit a zero region, check that first
+            if (entry.offset > cursor) {
+                if (!check_blob (fd, cursor, entry.offset - cursor, NULL)) {
+                    diag ("zero region error");
+                    close (fd);
+                    goto error;
+                }
+            }
+            if (!check_blob (fd, entry.offset, entry.size, entry.blobref)) {
+                diag ("content error");
+                close (fd);
+                goto error;
+            }
+            cursor = entry.offset + entry.size;
+        }
+        if (cursor < size) {
+            if (!check_blob (fd, cursor, size - cursor, NULL)) {
+                diag ("zero region error");
+                close (fd);
+                goto error;
+            }
+        }
+        close (fd);
+    }
+    else if (S_ISREG (mode) && data != NULL) {
+        int fd;
+        char buf[8192];
+        char buf2[8192];
+        ssize_t n;
+
+        if ((n = base64_decode (buf, sizeof (buf), data, strlen (data))) < 0) {
+            diag ("base64_decode failed");
+            goto error;
+        }
+        if ((fd = open (mkpath (name), O_RDONLY)) < 0) {
+            diag ("open %s: %s", path, strerror (errno));
+            goto error;
+        }
+        if (read (fd, buf2, sizeof (buf2)) != n) {
+            diag ("read %s: returned wrong size", path);
+            close (fd);
+            goto error;
+        }
+        if (memcmp (buf, buf2, n) != 0) {
+            diag ("%s: data is wrong", path);
+            close (fd);
+            goto error;
+        }
+        close (fd);
+    }
+    return true;
+error:
+    return false;
+}
+
+int blobcount (json_t *fileref)
+{
+    json_t *o;
+    if (json_unpack (fileref, "{s:o}", "blobvec", &o) < 0)
+        return -1;
+    return json_array_size (o);
+}
+
+void diagjson (json_t *o)
+{
+    char *s;
+    s = json_dumps (o, JSON_INDENT(2));
+    if (s)
+        diag ("%s", s);
+    free (s);
+}
+
+struct testfile {
+    const char *spec;
+    int chunksize;
+    const char *hashtype;
+    int exp_blobs;
+};
+
+struct testfile testvec[] = {
+    { "aaaa", 0, "sha1", 1 },
+    { "-aaa", 0, "sha1", 1 },
+    { "a-aa", 0, "sha1", 2 },
+    { "aaa-", 0, "sha1", 1 },
+    { "----", 0, "sha1", 0 },
+    { "ac-e--f-", 0, "sha1", 3 },
+    { "aaaa", 5500, "sha1", 3 },
+    { "aaaa", 8192, "sha1", 2 },
+    { "aaaa", 16384, "sha1", 1 },
+    { "a--a", 4096, "sha1", 2 },
+    { "a--a", 5000, "sha1", 2 },
+    { "a--a", 3000, "sha256", 4 },
+    { "", 0, "sha1", 0 },
+};
+
+void test_vec (void)
+{
+    for (int i = 0; i < ARRAY_SIZE (testvec); i++) {
+        json_t *o;
+        flux_error_t error;
+        bool rc;
+
+        skip (strchr (testvec[i].spec, '-') && !have_sparse,
+              1, "test directory does not support sparse files");
+
+        mkfile ("testfile", 4096, testvec[i].spec);
+        o = fileref_create (mkpath ("testfile"),
+                           testvec[i].hashtype,
+                           testvec[i].chunksize,
+                           &error);
+        rc = check_fileref (o, "testfile", testvec[i].exp_blobs);
+        ok (rc == true,
+            "fileref_create chunksize=%d '%s' works (%d %s blobrefs)",
+            testvec[i].chunksize,
+            testvec[i].spec,
+            testvec[i].exp_blobs,
+            testvec[i].hashtype);
+        if (!rc)
+            diag ("%s", error.text);
+        json_decref (o);
+        rmfile ("testfile");
+
+        end_skip;
+    }
+}
+
+void test_dir (void)
+{
+    json_t *o;
+    flux_error_t error;
+    bool rc;
+
+    if (mkdir (mkpath ("testdir"), 0510) < 0)
+        BAIL_OUT ("could not create test directory");
+    o = fileref_create (mkpath ("testdir"), "sha1", 0, &error);
+    rc = check_fileref (o, "testdir", 0);
+    ok (rc == true,
+        "fileref_create directory works");
+    if (!rc)
+        diag ("%s", error.text);
+    json_decref (o);
+    rmdir (mkpath ("testdir"));
+}
+
+void test_link (void)
+{
+    json_t *o;
+    flux_error_t error;
+    const char *target = "/a/b/c/d/e/f/g";
+    bool rc;
+
+    if (symlink (target, mkpath ("testlink")) < 0)
+        BAIL_OUT ("could not create test symlink");
+    o = fileref_create (mkpath ("testlink"), "sha1", 0, &error);
+    rc = check_fileref (o, "testlink", 0);
+    ok (rc == true,
+        "fileref_create symlink works");
+    if (!rc)
+        diag ("%s", error.text);
+    json_decref (o);
+    rmfile ("testlink");
+}
+
+void test_small (void)
+{
+    json_t *o;
+    flux_error_t error;
+    bool rc;
+
+    mkfile ("testsmall", 512, "a");
+    o = fileref_create (mkpath ("testsmall"), "sha1", 0, &error);
+    rc = check_fileref (o, "testsmall", 0);
+    ok (rc == true,
+        "fileref_create small file works");
+    if (!rc)
+        diag ("%s", error.text);
+    diagjson (o);
+    json_decref (o);
+    rmfile ("testsmall");
+}
+
+void test_expfail (void)
+{
+    json_t *o;
+    flux_error_t error;
+
+    mkfile ("test", 4096, "zz");
+
+    errno = 0;
+    o = fileref_create ("/noexist", "sha1", 4096, &error);
+    ok (o == NULL && errno == ENOENT,
+        "fileref_create path=/noexist fails with ENOENT");
+    if (!o)
+        diag ("%s", error.text);
+
+    errno = 0;
+    o = fileref_create ("/dev/null", "sha1", 4096, &error);
+    ok (o == NULL && errno == EINVAL,
+        "fileref_create path=/dev/null fails with EINVAL");
+    if (!o)
+        diag ("%s", error.text);
+
+    errno = 0;
+    o = fileref_create (mkpath ("test"), "smurfette", 4096, &error);
+    ok (o == NULL && errno == EINVAL,
+        "fileref_create hashtype=smurfette fails with EINVAL");
+    if (!o)
+        diag ("%s", error.text);
+
+    errno = 0;
+    o = fileref_create (mkpath ("test"), "sha1", -1, &error);
+    ok (o == NULL && errno == EINVAL,
+        "fileref_create chunksize=-1 fails with EINVAL");
+    if (!o)
+        diag ("%s", error.text);
+
+    rmfile ("test");
+}
+
+void test_pretty_print (void)
+{
+    char buf[1024];
+    json_t *o;
+
+    mkfile ("testfile", 4096, "a");
+    if (!(o = fileref_create (mkpath ("testfile"), "sha1", 0, NULL)))
+        BAIL_OUT ("failed to create test object");
+
+    buf[0] = '\0';
+    fileref_pretty_print (NULL, false, buf, sizeof (buf));
+    ok (streq (buf, "invalid fileref"),
+        "fileref_pretty_print obj=NULL printed an error");
+
+    buf[0] = '\0';
+    fileref_pretty_print (NULL, false, buf, 5);
+    ok (streq (buf, "inv+"),
+        "fileref_pretty_print obj=NULL bufsize=5 includes trunc character +");
+
+    buf[0] = '\0';
+    fileref_pretty_print (o, false, buf, sizeof (buf));
+    ok (strlen (buf) > 0,
+        "fileref_pretty_print long_form=false works");
+    diag (buf);
+
+    buf[0] = '\0';
+    fileref_pretty_print (o, true, buf, sizeof (buf));
+    ok (strlen (buf) > 0,
+        "fileref_pretty_print long_form=true works");
+    diag (buf);
+
+    lives_ok ({fileref_pretty_print (o, true, NULL, sizeof (buf));},
+             "fileref_pretty_print buf=NULL doesn't crash");
+
+    json_decref (o);
+    rmfile ("testfile");
+}
+
+int main (int argc, char *argv[])
+{
+    char *tmpdir = getenv ("TMPDIR");
+
+    plan (NO_PLAN);
+
+    /* create testdir to contain test files
+     */
+    snprintf (testdir,
+              sizeof (testdir),
+              "%s/fileref-XXXXXX",
+              tmpdir ? tmpdir : "/tmp");
+    if (!mkdtemp (testdir))
+        BAIL_OUT ("could not create test directory");
+
+    have_sparse = test_sparse ();
+
+    test_vec ();
+    test_dir ();
+    test_link ();
+    test_small ();
+    test_expfail ();
+    test_pretty_print ();
+
+    unlink_recursive (testdir);
+
+    done_testing ();
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/src/common/libutil/test/hola.c
+++ b/src/common/libutil/test/hola.c
@@ -1,0 +1,363 @@
+/************************************************************\
+ * Copyright 2022 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#include <errno.h>
+
+#include "src/common/libtap/tap.h"
+#include "ccan/array_size/array_size.h"
+#include "ccan/str/str.h"
+#include "src/common/libutil/hola.h"
+
+void key_destructor (void **item)
+{
+    if (item) {
+        free (*item);
+        *item = NULL;
+    }
+}
+void *key_duplicator (const void *item)
+{
+    return strdup (item);
+}
+int key_comparator (const void *item1, const void *item2)
+{
+    return strcmp (item1, item2);
+}
+size_t
+key_hasher (const void *key)
+{
+    const char *cp = key;
+    size_t hash = 0;
+    while (*cp)
+        hash = 33 * hash ^ *cp++;
+    return hash;
+}
+
+void test_hash (void)
+{
+    struct hola *h;
+    const char *key;
+    zlistx_t *l;
+
+    ok ((h = hola_create (0)) != NULL,
+        "hola_create works");
+
+    /* set callbacks identical to internal zhashx defaults
+     * just to cover functions
+     */
+    hola_set_hash_key_destructor (h, key_destructor);
+    hola_set_hash_key_duplicator (h, key_duplicator);
+    hola_set_hash_key_comparator (h, key_comparator);
+    hola_set_hash_key_hasher (h, key_hasher);
+
+    /* empty hash */
+    ok (hola_hash_size (h) == 0,
+        "hola_hash_size is 0");
+    key = hola_hash_first (h);
+    ok (key == NULL,
+        "hola_hash_first returns NULL");
+    key = hola_hash_next (h);
+    ok (key == NULL,
+        "hola_hash_next returns NULL");
+    errno = 0;
+    l = hola_hash_lookup (h, "foo");
+    ok (l == NULL && errno == ENOENT,
+        "hola_hash_lookup key=foo fails with ENOENT");
+    errno = 0;
+    ok (hola_hash_delete (h, "foo") < 0 && errno == ENOENT,
+        "hola_hash_delete key=foo fails with ENOENT");
+
+    /* one item */
+    ok (hola_hash_add (h, "item1") == 0,
+        "hola_hash_add key=item1 works");
+    ok (hola_hash_size (h) == 1,
+        "hola_hash_size is 1");
+    errno = 0;
+    ok (hola_hash_add (h, "item1") < 0
+        && errno == EEXIST,
+        "hola_hash_add key=item1 fails with EEXIST");
+    key = hola_hash_first (h);
+    ok (key && streq (key, "item1"),
+        "hola_hash_first returns item1");
+    key = hola_hash_next (h);
+    ok (key == NULL,
+        "hola_hash_next returns NULL");
+    l = hola_hash_lookup (h, "item1");
+    ok (l != NULL,
+        "hola_hash_lookup key=item1 works");
+    ok (hola_hash_delete (h, "item1") == 0
+        && hola_hash_size (h) == 0,
+        "hola_hash_delete key=item1 works");
+
+    /* two items */
+    ok (hola_hash_add (h, "item1") == 0,
+        "hola_hash_add key=item1 works");
+    ok (hola_hash_add (h, "item2") == 0,
+        "hola_hash_add key=item2 works");
+    ok (hola_hash_size (h) == 2,
+        "hola_hash_size is 2");
+    key = hola_hash_first (h);
+    ok (key && (streq (key, "item1") || streq (key, "item2")),
+        "hola_hash_first returns a valid key");
+    key = hola_hash_next (h);
+    ok (key && (streq (key, "item1") || streq (key, "item2")),
+        "hola_hash_next returns a valid key");
+    key = hola_hash_next (h);
+    ok (key == NULL,
+        "hola_hash_next returns NULL");
+    l = hola_hash_lookup (h, "item1");
+    ok (l != NULL,
+        "hola_hash_lookup key=item1 works");
+    l = hola_hash_lookup (h, "item2");
+    ok (l != NULL,
+        "hola_hash_lookup key=item2 works");
+    ok (hola_hash_delete (h, "item1") == 0
+        && hola_hash_size (h) == 1,
+        "hola_hash_delete key=item1 works");
+    key = hola_hash_first (h);
+    ok (key && streq (key, "item2"),
+        "hola_hash_first returns item2");
+    key = hola_hash_next (h);
+    ok (key == NULL,
+        "hola_hash_next returns NULL");
+
+    hola_destroy (h);
+}
+
+void test_auto (void)
+{
+    struct hola *h;
+    void *item1;
+    void *item2;
+    void *item3;
+
+    ok ((h = hola_create (HOLA_AUTOCREATE | HOLA_AUTODESTROY)) != NULL,
+        "hola_create AUTOCREATE | AUTODDESTROY works");
+
+    item1 = hola_list_add_end (h, "blue", "item1");
+    ok (item1 != NULL,
+        "hola_add_end key=blue value=item1 works");
+    item2 = hola_list_add_end (h, "red", "item2");
+    ok (item2 != NULL,
+        "hola_add_end key=red value=item2 works");
+    item3 = hola_list_add_end (h, "red", "item3");
+    ok (item3 != NULL,
+        "hola_add_end key=red value=item3 works");
+    ok (hola_hash_size (h) == 2,
+        "hola_hash_size is 2");
+    ok (hola_list_size (h, "blue") == 1,
+        "hola_list_size is key=blue is 1");
+    ok (hola_list_size (h, "red") == 2,
+        "hola_list_size is key=red is 2");
+    ok (hola_list_delete (h, "red", item3) == 0
+        && hola_list_size (h, "red") == 1,
+        "hola_list_delete key=red item3 works");
+    ok (hola_list_delete (h, "red", item2) == 0
+        && hola_list_size (h, "red") == 0,
+        "hola_list_delete key=red item3 works");
+    ok (hola_hash_size (h) == 1,
+        "hola_hash_size is 1");
+    ok (hola_list_delete (h, "blue", item1) == 0
+        && hola_list_size (h, "blue") == 0,
+        "hola_list_delete key=blue item1 works");
+    ok (hola_hash_size (h) == 0,
+        "hola_hash_size is 0");
+
+    hola_destroy (h);
+}
+
+struct test_input {
+    const char *key;
+    char *val;
+};
+
+struct test_input test1[] = {
+    { "blue", "item1" },
+    { "blue", "item2" },
+    { "blue", "item3" },
+    { "red", "item4" },
+    { "red", "item5" },
+    { "green", "item6" },
+};
+
+int find_entry (struct test_input *t,
+                size_t len,
+                const char *key,
+                const char *val)
+{
+    if (key && val) {
+        for (int i = 0; i < len; i++) {
+            if (streq (key, t[i].key) && streq (val, t[i].val))
+                return i;
+        }
+    }
+    return -1;
+}
+
+bool test_iter_one (struct test_input *t, size_t len)
+{
+    struct hola *h;
+    const char *key;
+    const char *val;
+    bool *checklist;
+    bool result = true;
+
+    if (!(checklist = calloc (len, sizeof (checklist[0]))))
+        BAIL_OUT ("out of memory");
+    h = hola_create (HOLA_AUTOCREATE);
+    if (!h)
+        BAIL_OUT ("hola_create failed");
+    for (int i = 0; i < len; i++) {
+        if (!hola_list_add_end (h, t[i].key, t[i].val))
+            BAIL_OUT ("could not populate test object for iteration");
+    }
+    key = hola_hash_first (h);
+    while (key) {
+        val = hola_list_first (h, key);
+        while (val) {
+            int index = find_entry (t, len, key, val);
+            if (hola_list_cursor (h, key) == NULL) // cursor must not be NULL
+                break;
+            if (index != -1)
+                checklist[index] = true;
+            val = hola_list_next (h, key);
+        }
+        if (hola_list_cursor (h, key) != NULL) // cursor must be NULL
+            break;
+
+        key = hola_hash_next (h);
+    }
+    for (int i = 0; i < len; i++)
+        if (!checklist[i])
+            result = false;
+
+    hola_destroy (h);
+    free (checklist);
+    return result;
+}
+
+void test_iter (void)
+{
+    ok (test_iter_one (test1, ARRAY_SIZE (test1)) == true,
+        "iteration works");
+}
+
+void test_inval (void)
+{
+    struct hola *h;
+    if (!(h = hola_create (0)))
+        BAIL_OUT ("hola_create failed");
+
+    errno = 0;
+    ok (hola_create (0xff) == NULL && errno == EINVAL,
+        "hola_create flags=0xff fails with EINVAL");
+
+    errno = 0;
+    ok (hola_hash_lookup (NULL, "foo") == NULL && errno == EINVAL,
+        "hola_hash_lookup h=NULL fails with EINVAL");
+
+    errno = 0;
+    ok (hola_hash_lookup (h, NULL) == NULL && errno == EINVAL,
+        "hola_hash_lookup key=NULL fails with EINVAL");
+
+    errno = 0;
+    ok (hola_hash_add (NULL, "foo") < 0 && errno == EINVAL,
+        "hola_hash_add h=NULL fails with EINVAL");
+
+    errno = 0;
+    ok (hola_hash_add (h, NULL) < 0 && errno == EINVAL,
+        "hola_hash_add key=NULL fails with EINVAL");
+
+    errno = 0;
+    ok (hola_hash_delete (NULL, "foo") < 0 && errno == EINVAL,
+        "hola_hash_delete h=NULL fails with EINVAL");
+
+    errno = 0;
+    ok (hola_hash_delete (h, NULL) < 0 && errno == EINVAL,
+        "hola_hash_delete key=NULL fails with EINVAL");
+
+    ok (hola_hash_first (NULL) == NULL,
+        "hola_hash_first h=NULL returns NULL");
+    ok (hola_hash_next (NULL) == NULL,
+        "hola_hash_next h=NULL returns NULL");
+    ok (hola_hash_size (NULL) == 0,
+        "hola_hash_size h=NULL returns 0");
+
+    errno = 0;
+    ok (hola_list_add_end (NULL, "foo", "foo") == NULL && errno == EINVAL,
+        "hola_list_add_end h=NULL fails with EINVAL");
+
+    errno = 0;
+    ok (hola_list_add_end (h, NULL, "foo") == NULL && errno == EINVAL,
+        "hola_list_add_end key=NULL fails with EINVAL");
+
+    errno = 0;
+    ok (hola_list_add_end (h, "foo", NULL) == NULL && errno == EINVAL,
+        "hola_list_add_end item=NULL fails with EINVAL");
+
+    errno = 0;
+    ok (hola_list_add_end (h, "noexist", "bar") == NULL && errno == ENOENT,
+        "hola_list_add_end key=nonexistent list fails with ENOENT");
+
+    errno = 0;
+    ok (hola_list_delete (NULL, "foo", "bar") < 0 && errno == EINVAL,
+        "hola_list_delete h=NULL fails with EINVAL");
+
+    errno = 0;
+    ok (hola_list_delete (h, NULL, "bar") < 0 && errno == EINVAL,
+        "hola_list_delete key=NULL fails with EINVAL");
+    errno = 0;
+    ok (hola_list_delete (h, "foo", NULL) < 0 && errno == EINVAL,
+        "hola_list_delete handle=NULL fails with EINVAL");
+    errno = 0;
+    ok (hola_list_delete (h, "foo", &errno) < 0 && errno == ENOENT,
+        "hola_list_delete key=unknown fails with ENOENT");
+
+    ok (hola_list_first (NULL, "foo") == NULL,
+        "hola_list_first h=NULL returns NULL");
+    ok (hola_list_first (h, NULL) == NULL,
+        "hola_list_first key=NULL returns NULL");
+    ok (hola_list_next (NULL, "foo") == NULL,
+        "hola_list_next h=NULL returns NULL");
+    ok (hola_list_next (h, NULL) == NULL,
+        "hola_list_next key=NULL returns NULL");
+    ok (hola_list_cursor (NULL, "foo") == NULL,
+        "hola_list_cursor h=NULL returns NULL");
+    ok (hola_list_cursor (h, NULL) == NULL,
+        "hola_list_cursor key=NULL returns NULL");
+
+    lives_ok ({hola_set_hash_key_destructor (NULL, key_destructor);},
+        "holas_set_hash_key_destructor h=NULL doesn't crash");
+    lives_ok ({hola_set_hash_key_duplicator (NULL, key_duplicator);},
+        "holas_set_hash_key_duplicator h=NULL doesn't crash");
+    lives_ok ({hola_set_hash_key_comparator (NULL, key_comparator);},
+        "holas_set_hash_key_comparator h=NULL doesn't crash");
+    lives_ok ({hola_set_hash_key_hasher (NULL, key_hasher);},
+        "holas_set_hash_key_hasher h=NULL doesn't crash");
+
+    lives_ok ({hola_destroy (NULL);},
+        "hola_destroy h=NULL doesn't crash");
+
+    hola_destroy (h);
+}
+
+int main (int argc, char *argv[])
+{
+    plan (NO_PLAN);
+
+    test_hash ();
+    test_auto ();
+    test_iter ();
+    test_inval ();
+
+    done_testing ();
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/src/shell/Makefile.am
+++ b/src/shell/Makefile.am
@@ -12,7 +12,8 @@ AM_CPPFLAGS = \
 	$(VALGRIND_CFLAGS) \
 	$(LUA_INCLUDE) \
 	$(HWLOC_CFLAGS) \
-	$(JANSSON_CFLAGS)
+	$(JANSSON_CFLAGS) \
+	$(LIBARCHIVE_CFLAGS)
 
 shellrcdir = \
 	$(fluxrcdir)/shell
@@ -81,6 +82,7 @@ flux_shell_SOURCES = \
 	pty.c \
 	batch.c \
 	tmpdir.c \
+	stage-in.c \
 	mpir/mpir.c \
 	mpir/ptrace.c \
 	mustache.h \
@@ -106,7 +108,8 @@ flux_shell_LDADD = \
 	$(top_builddir)/src/common/libutil/libutil.la \
 	$(LUA_LIB) \
 	$(HWLOC_LIBS) \
-	$(JANSSON_LIBS)
+	$(JANSSON_LIBS) \
+	$(LIBARCHIVE_LIBS)
 
 flux_shell_LDFLAGS = \
 	-export-dynamic \

--- a/src/shell/builtins.c
+++ b/src/shell/builtins.c
@@ -31,6 +31,7 @@ static struct shell_builtin builtin_list_end = { 0 };
  *  to get the builtin automatically loaded at shell startup.
  */
 extern struct shell_builtin builtin_tmpdir;
+extern struct shell_builtin builtin_stage_in;
 extern struct shell_builtin builtin_log_eventlog;
 extern struct shell_builtin builtin_pmi;
 extern struct shell_builtin builtin_input;
@@ -50,6 +51,7 @@ extern struct shell_builtin builtin_cyclic;
 
 static struct shell_builtin * builtins [] = {
     &builtin_tmpdir,
+    &builtin_stage_in,
     &builtin_log_eventlog,
     &builtin_pmi,
     &builtin_input,

--- a/src/shell/stage-in.c
+++ b/src/shell/stage-in.c
@@ -1,0 +1,475 @@
+/************************************************************\
+ * Copyright 2022 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* stage-in.c - copy previously mapped files for job */
+
+#define FLUX_SHELL_PLUGIN_NAME "stage-in"
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <unistd.h>
+#include <limits.h>
+#include <stdlib.h>
+#include <libgen.h>
+#include <jansson.h>
+#include <argz.h>
+#include <archive.h>
+#include <archive_entry.h>
+#include <flux/core.h>
+
+#include "ccan/base64/base64.h"
+#include "src/common/libcontent/content.h"
+#include "src/common/libutil/errno_safe.h"
+#include "src/common/libutil/monotime.h"
+#include "src/common/libutil/fileref.h"
+
+#include "builtins.h"
+#include "internal.h"
+#include "info.h"
+
+struct stage_in {
+    json_t *tags;
+    const char *pattern;
+    const char *destdir;
+    flux_t *h;
+    int count;
+    size_t total_size;
+    int direct;
+};
+
+json_t *parse_tags (const char *s, const char *default_value)
+{
+    char *argz = NULL;
+    size_t argz_len;
+    json_t *a;
+    json_t *o;
+    const char *entry;
+
+    if (!(a = json_array ()))
+        return NULL;
+    if (s) {
+        if (argz_create_sep (s, ',', &argz, &argz_len) != 0)
+            goto error;
+        entry = NULL;
+        while ((entry = argz_next (argz, argz_len, entry))) {
+            if (!(o = json_string (entry))
+                || json_array_append_new (a, o) < 0) {
+                json_decref (o);
+                goto error;
+            }
+        }
+    }
+    if (json_array_size (a) == 0 && default_value) {
+        if (!(o = json_string (default_value))
+            || json_array_append_new (a, o) < 0) {
+            json_decref (o);
+            goto error;
+        }
+    }
+    free (argz);
+    return a;
+error:
+    free (argz);
+    json_decref (a);
+    return NULL;
+}
+
+/* Decode the raw data field a fileref object, setting the result in 'data'
+ * and 'data_size'.  Caller must free.
+ */
+static int decode_data (const char *s, void **data, size_t *data_size)
+{
+    if (s) {
+        int len = strlen (s);
+        size_t bufsize = base64_decoded_length (len);
+        void *buf;
+        ssize_t n;
+
+        if (!(buf = malloc (bufsize)))
+            return -1;
+        if ((n = base64_decode (buf, bufsize, s, len)) < 0) {
+            free (buf);
+            errno = EINVAL;
+            return -1;
+        }
+        *data = buf;
+        *data_size = n;
+    }
+    return 0;
+}
+
+static json_t *load_fileref (flux_t *h, const char *blobref)
+{
+    flux_future_t *f;
+    const void *buf;
+    int size;
+    json_t *o;
+    json_error_t error;
+
+    if (!(f = content_load_byblobref (h, blobref, 0))
+        || content_load_get (f, &buf, &size) < 0) {
+        shell_log_error ("error loading fileref from %s: %s",
+                          blobref,
+                          future_strerror (f, errno));
+        flux_future_destroy (f);
+        return NULL;
+    }
+    if (!(o = json_loads (buf, 0, &error))) {
+        shell_log_error ("error decoding fileref object from %s: %s",
+                         blobref,
+                         error.text);
+        flux_future_destroy (f);
+        return NULL;
+    }
+    flux_future_destroy (f);
+    return o;
+}
+
+static flux_future_t *mmap_list (flux_t *h,
+                                 bool blobref,
+                                 json_t *tags,
+                                 const char *pattern)
+{
+    flux_future_t *f;
+
+    if (pattern) {
+        f = flux_rpc_pack (h,
+                           "content.mmap-list",
+                           0,
+                           FLUX_RPC_STREAMING,
+                           "{s:b s:s s:O}",
+                           "blobref", blobref ? 1 : 0,
+                           "pattern", pattern,
+                           "tags", tags);
+    }
+    else {
+        f = flux_rpc_pack (h,
+                           "content.mmap-list",
+                           0,
+                           FLUX_RPC_STREAMING,
+                           "{s:b s:O}",
+                           "blobref", blobref ? 1 : 0,
+                           "tags", tags);
+    }
+    return f;
+}
+
+static int extract_blob (flux_t *h,
+                         struct archive *archive,
+                         const char *path,
+                         json_t *o)
+{
+    struct {
+        json_int_t offset;
+        json_int_t size;
+        const char *blobref;
+    } entry;
+    flux_future_t *f;
+    const void *buf;
+    int size;
+    int rc = -1;
+
+    if (json_unpack (o,
+                     "[I,I,s]",
+                     &entry.offset,
+                     &entry.size,
+                     &entry.blobref) < 0) {
+        shell_log_error ("%s: error decoding blobvec entry", path);
+        return -1;
+    }
+    if (!(f = content_load_byblobref (h, entry.blobref, 0))
+        || content_load_get (f, &buf, &size) < 0) {
+        shell_log_error ("%s: error loading offset=%ju size=%ju from %s: %s",
+                         path,
+                         (uintmax_t)entry.offset,
+                         (uintmax_t)entry.size,
+                         entry.blobref,
+                         future_strerror (f, errno));
+        goto done;
+    }
+    if (size != entry.size) {
+        shell_log_error ("%s: error loading offset=%ju size=%ju from %s:"
+                         " unexpected size %ju",
+                         path,
+                         (uintmax_t)entry.offset,
+                         (uintmax_t)entry.size,
+                         entry.blobref,
+                         (uintmax_t)size);
+        goto done;
+    }
+    if (archive_write_data_block (archive,
+                                  buf,
+                                  size,
+                                  entry.offset) != ARCHIVE_OK) {
+        shell_log_error ("%s: write: %s", path, archive_error_string (archive));
+        goto done;
+    }
+    rc = 0;
+done:
+    flux_future_destroy (f);
+    return rc;
+}
+
+static int extract_file (struct stage_in *ctx,
+                         struct archive *archive,
+                         json_t *fileref)
+{
+    const char *path;
+    json_int_t size;
+    json_int_t ctime;
+    json_int_t mtime;
+    int mode;
+    json_t *blobvec;
+    const char *data = NULL;
+    size_t index;
+    json_t *o;
+    struct archive_entry *entry;
+    char tracebuf[1024];
+    json_error_t error;
+
+    fileref_pretty_print (fileref, true, tracebuf, sizeof (tracebuf));
+    shell_trace ("%s", tracebuf);
+
+    if (json_unpack_ex (fileref,
+                        &error,
+                        0,
+                        "{s:s s:I s:I s:I s:i s?s s:o}",
+                        "path", &path,
+                        "size", &size,
+                        "mtime", &mtime,
+                        "ctime", &ctime,
+                        "mode", &mode,
+                        "data", &data,
+                        "blobvec", &blobvec) < 0) {
+        shell_log_error ("error decoding fileref object: %s", error.text);
+        return -1;
+    }
+    ctx->total_size += size;
+
+    /* metadata
+     */
+    if (!(entry = archive_entry_new ())) {
+        shell_log_error ("%s: error creating libarchive entry", path);
+        return -1;
+    }
+    archive_entry_set_pathname (entry, path);
+    archive_entry_set_mode (entry, mode);
+    archive_entry_set_mtime (entry, mtime, 0);
+    archive_entry_set_ctime (entry, ctime, 0);
+    if (S_ISREG (mode)) {
+        archive_entry_set_size (entry, size);
+    }
+    else if (S_ISLNK (mode)) {
+        if (!data) {
+            shell_log_error ("%s: missing symlink data", path);
+            goto error;
+        }
+        archive_entry_set_symlink (entry, data);
+    }
+    else if (!S_ISDIR (mode)) { // nothing to do for directory
+        shell_log_error ("%s: unknown file type (mode=0%o)", path, mode);
+        goto error;
+    }
+
+    if (archive_write_header (archive, entry) != ARCHIVE_OK) {
+        shell_log_error ("%s: %s", path, archive_error_string (archive));
+        goto error;
+    }
+
+    /* data
+     */
+    if (S_ISREG (mode)) {
+        if (data) { // small file is contained in fileref.data
+            void *buf;
+            size_t buf_size;
+
+            if (decode_data (data, &buf, &buf_size) < 0) {
+                shell_log_error ("%s: could not decode file data", path);
+                goto error;
+            }
+            if (archive_write_data_block (archive,
+                                          buf,
+                                          buf_size,
+                                          0) != ARCHIVE_OK) {
+                shell_log_error ("%s: write: %s",
+                                 path,
+                                 archive_error_string (archive));
+                free (buf);
+                goto error;
+            }
+            free (buf);
+        }
+        else { // large file is spread over multiple blobrefs
+            json_array_foreach (blobvec, index, o) {
+                if (extract_blob (ctx->h, archive, path, o) < 0)
+                    goto error;
+            }
+        }
+    }
+    archive_entry_free (entry);
+    return 0;
+error:
+    archive_entry_free (entry);
+    return -1;
+
+}
+
+static int extract (struct stage_in *ctx, struct archive *archive)
+{
+    flux_future_t *f;
+    size_t index;
+    json_t *entry;
+
+    if (!(f = mmap_list (ctx->h,
+                         ctx->direct ? false : true,
+                         ctx->tags,
+                         ctx->pattern))) {
+        shell_log_error ("mmap-list: %s", strerror (errno));
+        return -1;
+    }
+    for (;;) {
+        json_t *files;
+
+        if (flux_rpc_get_unpack (f, "{s:o}", "files", &files) < 0) {
+            if (errno == ENODATA)
+                break; // end of stream
+            shell_log_error ("mmap-list: %s", future_strerror (f, errno));
+            return -1;
+        }
+        json_array_foreach (files, index, entry) {
+            if (ctx->direct) {
+                if (extract_file (ctx, archive, entry) < 0)
+                    return -1;
+            }
+            else {
+                json_t *fileref;
+
+                if (!(fileref = load_fileref (ctx->h,
+                                              json_string_value (entry))))
+                    return -1;
+                if (extract_file (ctx, archive, fileref) < 0) {
+                    json_decref (fileref);
+                    return -1;
+                }
+                json_decref (fileref);
+            }
+            ctx->count++;
+        }
+        flux_future_reset (f);
+    }
+    flux_future_destroy (f);
+    return 0;
+}
+
+static int extract_files (struct stage_in *ctx)
+{
+    char *orig_dir;
+    struct archive *archive = NULL;
+    struct timespec t;
+    int rc = -1;
+
+    if (!(orig_dir = getcwd (NULL, 0))) {
+        shell_log_error ("getcwd: %s", strerror (errno));
+        return -1;
+    }
+    if (!(archive = archive_write_disk_new ())) {
+        shell_log_error ("error creating libarchive context");
+        goto done;
+    }
+    if (chdir (ctx->destdir) < 0) {
+        shell_log_error ("chdir %s: %s", ctx->destdir, strerror (errno));
+        goto done;
+    }
+    shell_debug ("=> %s", ctx->destdir);
+    monotime (&t);
+    if (extract (ctx, archive) == 0) {
+        double elapsed = monotime_since (t) / 1000;
+        shell_debug ("%d files %.1fMB/s",
+                     ctx->count,
+                     1E-6 * ctx->total_size / elapsed);
+        rc = 0;
+    }
+done:
+    if (chdir (orig_dir) < 0) {
+        shell_die (1,
+                   "could not chdir back to original directory %s: %s",
+                   orig_dir,
+                   strerror (errno));
+    }
+    if (archive)
+        archive_write_free (archive);
+    free (orig_dir);
+    return rc;
+}
+
+static int stage_in (flux_shell_t *shell, json_t *config)
+{
+    struct stage_in ctx;
+    const char *tags = NULL;
+
+    memset (&ctx, 0, sizeof (ctx));
+    ctx.h = shell->h;
+
+    if (json_is_object (config)) {
+        if (json_unpack (config,
+                         "{s?s s?s s?s s?i}",
+                         "tags", &tags,
+                         "pattern", &ctx.pattern,
+                         "destdir", &ctx.destdir,
+                         "direct", &ctx.direct)) {
+            shell_log_error ("Error parsing stage_in shell option");
+            goto error;
+        }
+    }
+    if (!(ctx.tags = parse_tags (tags, "main"))) {
+        shell_log_error ("Error parsing stage_in.tags shell option");
+        goto error;
+    }
+    if (!ctx.destdir) {
+        ctx.destdir = flux_shell_getenv (shell, "FLUX_JOB_TMPDIR");
+        if (!ctx.destdir) {
+            shell_log_error ("FLUX_JOB_TMPDIR is not set");
+            goto error;
+        }
+    }
+    if (extract_files (&ctx) < 0)
+        goto error;
+
+    json_decref (ctx.tags);
+    return 0;
+error:
+    json_decref (ctx.tags);
+    return -1;
+}
+
+static int stage_in_init (flux_plugin_t *p,
+                          const char *topic,
+                          flux_plugin_arg_t *args,
+                          void *data)
+{
+    flux_shell_t *shell = flux_plugin_get_shell (p);
+    json_t *config = NULL;
+
+    if (flux_shell_getopt_unpack (shell, "stage-in", "o", &config) < 0)
+        return -1;
+    if (!config)
+        return 0;
+    return stage_in (shell, config);
+}
+
+struct shell_builtin builtin_stage_in = {
+    .name = FLUX_SHELL_PLUGIN_NAME,
+    .init = stage_in_init,
+};
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -188,6 +188,7 @@ TESTSCRIPTS = \
 	t2614-job-shell-doom.t \
 	t2615-job-shell-rlimit.t \
 	t2616-job-shell-taskmap.t \
+	t2617-job-shell-stage-in.t \
 	t2700-mini-cmd.t \
 	t2701-mini-batch.t \
 	t2702-mini-alloc.t \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -72,6 +72,7 @@ TESTSCRIPTS = \
 	t0012-content-sqlite.t \
 	t0024-content-s3.t \
 	t0028-content-backing-none.t \
+	t0029-filemap-cmd.t \
 	t0025-broker-state-machine.t \
 	t0027-broker-groups.t \
 	t0013-config-file.t \

--- a/t/t0029-filemap-cmd.t
+++ b/t/t0029-filemap-cmd.t
@@ -1,0 +1,244 @@
+#!/bin/sh
+
+test_description='Test flux-filemap'
+
+. `dirname $0`/content/content-helper.sh
+
+. `dirname $0`/sharness.sh
+
+LPTEST=${FLUX_BUILD_DIR}/t/shell/lptest
+
+havesparse() {
+	truncate --size 8192 $1 &&
+	test $(stat --format "%b" $1) -eq 0
+}
+
+if havesparse testholes; then
+	test_set_prereq HAVE_SPARSE
+fi
+
+test_under_flux 2 minimal
+
+test_expect_success 'create copy directory' '
+	mkdir -p copydir
+'
+test_expect_success 'create test file' '
+	${LPTEST} >testfile &&
+	chmod u=rwx testfile &&
+	chmod go=r testfile
+'
+test_expect_success 'map nonexistent file fails' '
+	test_must_fail flux filemap map notafile
+'
+test_expect_success 'map test file' '
+	flux filemap map ./testfile
+'
+test_expect_success 'file can be listed' '
+	flux filemap list
+'
+test_expect_success 'file can be listed in long form' '
+	flux filemap list --long
+'
+test_expect_success 'test file can be read through content cache on rank 0' '
+	flux filemap get -C copydir
+'
+test_expect_success 'file content is correct' '
+	test_cmp testfile copydir/testfile
+'
+test_expect_success 'file permissions are correct' '
+	stat --format="%a" testfile >access.exp &&
+	stat --format="%a" copydir/testfile >access.out &&
+	test_cmp access.exp access.out
+'
+test_expect_success 'test file can be read through content cache on rank 1' '
+	rm -f copydir/testfile &&
+	flux exec -r 1 flux filemap get -C copydir &&
+	test_cmp testfile copydir/testfile
+'
+test_expect_success 'unmap test file' '
+	flux filemap unmap
+'
+test_expect_success 'drop the cache' '
+	flux exec -r 1 flux content dropcache &&
+	flux content dropcache
+'
+test_expect_success 'test file is not extracted' '
+	rm -f copydir/testfile &&
+	flux filemap get -C copydir &&
+	test_must_fail test -f copydir/testfile
+'
+test_expect_success 'map test file with small blobsize' '
+	flux filemap map --chunksize=10 ./testfile
+'
+test_expect_success 'test file can be read through content cache on rank 0' '
+	rm -f copydir/testfile &&
+	flux filemap get -C copydir &&
+	test_cmp testfile copydir/testfile
+'
+test_expect_success 'test file can be read through content cache on rank 1' '
+	rm -f copydir/testfile &&
+	flux exec -r 1 flux filemap get -C copydir &&
+	test_cmp testfile copydir/testfile
+'
+test_expect_success 'unmap test file' '
+	flux filemap unmap
+'
+test_expect_success 'drop the cache' '
+	flux exec -r 1 flux content dropcache &&
+	flux content dropcache
+'
+test_expect_success 'create test file' '
+	echo abcdefghijklmnopqrstuvwxyz >testfile2
+'
+test_expect_success 'map test file and get its blobref' '
+	flux filemap map ./testfile2 &&
+	flux filemap list --blobref >testfile2.blobref
+'
+test_expect_success HAVE_JQ 'show fileref' '
+	flux filemap list --fileref | jq .
+'
+test_expect_success 'test file can be read through content cache on rank 1' '
+	flux exec -r 1 flux filemap get -C copydir &&
+	test_cmp testfile2 copydir/testfile2
+'
+test_expect_success 'store the duplicate blob on rank 1' '
+	flux content load <testfile2.blobref >testfile2.fileref &&
+	flux exec -r 1 flux content store <testfile2.fileref \
+	    >testfile2.blobref2  &&
+	test_cmp testfile2.blobref testfile2.blobref2
+'
+test_expect_success 'unmap test file' '
+	flux filemap unmap
+'
+test_expect_success 'drop the cache' '
+	flux exec -r 1 flux content dropcache &&
+	flux content dropcache
+'
+test_expect_success 'blob can still be read through content cache on rank 1' '
+	flux exec -r 1 flux content load <testfile2.blobref2 \
+		>testfile2.fileref2 &&
+	test_cmp testfile2.fileref testfile2.fileref2
+'
+test_expect_success HAVE_SPARSE 'create sparse test file' '
+	truncate --size=8192 testfile3
+'
+test_expect_success HAVE_SPARSE 'map test file' '
+	flux filemap map ./testfile3
+'
+test_expect_success HAVE_SPARSE 'test file can be read through content cache' '
+	flux filemap get -C copydir &&
+	test_cmp testfile3 copydir/testfile3
+'
+test_expect_success HAVE_SPARSE 'holes were preserved' '
+	stat --format="%b" testfile3 >blocks.exp &&
+	stat --format="%b" copydir/testfile3 >blocks.out &&
+	test_cmp blocks.exp blocks.out
+'
+test_expect_success HAVE_SPARSE 'unmap test file' '
+	flux filemap unmap
+'
+test_expect_success 'create test symlink' '
+	ln -s /a/b/c/d testfile4
+'
+test_expect_success 'map test file' '
+	flux filemap map ./testfile4
+'
+test_expect_success HAVE_JQ 'show fileref' '
+	flux filemap list --fileref | jq .
+'
+test_expect_success 'test file can be read through content cache' '
+	flux filemap get -vv -C copydir
+'
+test_expect_success 'copy is a symlink with expected target' '
+	readlink testfile4 >link.exp &&
+	readlink copydir/testfile4 >link.out &&
+	test_cmp link.exp link.out
+'
+test_expect_success 'unmap test file' '
+	flux filemap unmap
+'
+test_expect_success 'map file by absolute path' '
+	flux filemap map /etc/group
+'
+test_expect_success 'test file lists with relative path' '
+	cat >list.exp <<-EOT &&
+	etc/group
+	EOT
+	flux filemap list >list.out &&
+	test_cmp list.exp list.out
+'
+test_expect_success 'unmap test file' '
+	flux filemap unmap
+'
+test_expect_success 'create test directory' '
+	mkdir testfile5
+'
+test_expect_success 'map test file' '
+	flux filemap map ./testfile5
+'
+test_expect_success 'test file can be read through content cache' '
+	flux filemap get -vv -C copydir
+'
+test_expect_success 'copy is a directory' '
+	test -d copydir/testfile5
+'
+test_expect_success 'unmap test file' '
+	flux filemap unmap
+'
+test_expect_success 'map testfile with tags=red,blue' '
+	flux filemap map --tags=red,blue ./testfile
+'
+test_expect_success 'map testfile with tags=green' '
+	flux filemap map --tags=green ./testfile
+'
+test_expect_success 'map testfile with tags=green (again)' '
+	flux filemap map --tags=green ./testfile
+'
+test_expect_success 'map testfile2 with tags=green' '
+	flux filemap map --tags=green ./testfile2
+'
+test_expect_success 'list tags=red,blue,green reports two files' '
+	test $(flux filemap list --tags=red,blue,green | wc -l) -eq 2
+'
+test_expect_success 'unmap red tag' '
+	flux filemap unmap --tags=red
+'
+test_expect_success 'list tags=red,blue,green reports two files' '
+	test $(flux filemap list --tags=red,blue,green | wc -l) -eq 2
+'
+test_expect_success 'unmap tags=blue,green' '
+	flux filemap unmap --tags=blue,green
+'
+test_expect_success 'flux filemap list reports no files' '
+	test $(flux filemap list --tags red,blue,green | wc -l) -eq 0
+'
+test_expect_success 'map test file' '
+	rm -f copydir/testfile &&
+	flux filemap map ./testfile
+'
+test_expect_success 'modify mapped test file without reducing its size' '
+	dd if=/dev/zero of=testfile bs=4096 count=1 conv=notrunc
+'
+test_expect_success 'content change should cause an error' '
+	rm -f copydir/testfile &&
+	test_must_fail flux filemap get -C copydir 2>changed.err &&
+	grep changed changed.err
+'
+test_expect_success 'drop cache and unmap test file' '
+	flux content dropcache &&
+	flux filemap unmap
+'
+test_expect_success 'map test file' '
+	rm -f copydir/testfile &&
+	flux filemap map ./testfile
+'
+test_expect_success 'truncate mapped test file' '
+	cp /dev/null testfile
+'
+test_expect_success 'size reduction should cause an error' '
+	rm -f copydir/testfile &&
+	test_must_fail flux filemap get -C copydir 2>reduced.err &&
+	grep changed reduced.err
+'
+
+test_done

--- a/t/t2617-job-shell-stage-in.t
+++ b/t/t2617-job-shell-stage-in.t
@@ -1,0 +1,99 @@
+#!/bin/sh
+#
+test_description='Test flux-shell stage-in plugin support'
+
+. `dirname $0`/sharness.sh
+
+lptest=${FLUX_BUILD_DIR}/t/shell/lptest
+
+test_under_flux 4 job
+
+test_expect_success 'map the red test files' '
+	mkdir red &&
+	touch red/empty &&
+	truncate --size 8192 red/holy &&
+	$lptest >red/lptest &&
+	echo foo >red/small &&
+	mkdir red/dir &&
+	ln -s dir red/link &&
+	flux filemap map -vv --tags red red
+'
+test_expect_success 'map the blue test files' '
+	dir=blue/a/b/c/d/e/f/g/h &&
+	mkdir -p $dir &&
+	echo bar >$dir/test &&
+	flux filemap map -vv --tags blue blue
+'
+test_expect_success 'map the main test files' '
+	mkdir main &&
+	echo "Hello world!" >main/hello &&
+	flux filemap map -vv main
+'
+test_expect_success 'list all the files' '
+	flux filemap list --long --tags=red,blue,main
+'
+test_expect_success 'create file tree checker script' '
+	cat >check.sh <<-EOT &&
+	#!/bin/sh
+	for dir in \$*; do
+	    diff -r --no-dereference \$FLUX_JOB_TMPDIR/\$dir \$dir || exit 1
+	done
+	EOT
+	chmod 755 check.sh
+'
+test_expect_success 'verify that stage-in works with default tag (main)' '
+	flux mini run -N4 -ostage-in ./check.sh main
+'
+test_expect_success 'verify that stage-in works with tags=red' '
+	flux mini run -N2 -ostage-in.tags=red ./check.sh red
+'
+test_expect_success 'verify that stage-in works with tags=red,blue' '
+	flux mini run -N1 -ostage-in.tags=red,blue ./check.sh red blue
+'
+test_expect_success 'verify that stage-in.direct works' '
+	flux mini run -N1 \
+	    -ostage-in.tags=red \
+	    -ostage-in.direct \
+	    ./check.sh red
+'
+test_expect_success 'verify that stage-in.pattern works' '
+	flux mini run -N1 \
+	    -ostage-in.tags=red,blue \
+	    -ostage-in.pattern=red/* \
+	    -overbose=2 \
+            ./check.sh red 2>pattern.err
+'
+test_expect_success 'files that did not match pattern were not copied' '
+	grep red/small pattern.err &&
+	test_must_fail grep blue/a pattern.err
+'
+test_expect_success 'verify that stage-in.destdir works' '
+	mkdir testdest &&
+	flux mini run -N1 \
+	    -o stage-in.destdir=$(pwd)/testdest \
+	    /bin/true &&
+	test -f testdest/main/hello
+'
+test_expect_success 'verify that stage-in.destdir fails on bad dir' '
+	test_must_fail flux mini run -N1 \
+	    -o stage-in.destdir=/noexist \
+	    /bin/true
+'
+test_expect_success 'unmap all' '
+	flux filemap unmap --tags=red,blue,main
+'
+test_expect_success 'map a test file and access it to prime the cache' '
+	mkdir -p copydir &&
+        flux filemap map ./red/lptest &&
+	flux filemap get -C copydir &&
+	cmp red/lptest copydir/red/lptest
+'
+test_expect_success 'modify mapped test file without reducing its size' '
+        dd if=/dev/zero of=red/lptest bs=4096 count=1 conv=notrunc
+'
+test_expect_success 'content change should cause an error' '
+        test_must_fail flux mini run -N1 -o stage-in /bin/true 2>changed.err &&
+	grep changed changed.err
+'
+
+test_done


### PR DESCRIPTION
This is a redo of #4546 with some proposed better tooling.

To review, the idea was that we could mmap(2) a (possibly large) file into the rank 0 broker, then use the hierarchical scalability properties of the content cache to _pull_ the file to local storage on each node of a job.  The basic functionality is to create the mapping and emit an object that includes some file metadata and an array of blobrefs.  The blobrefs refer to regions of the actual external file - this data does not land in the backing store.   The object can be transferred to a "client" who can then use it to recreate the file through the content cache.

That PR only supported mapping individual files.  I was thinking of a use case like transferring a large file system image.   That worked well, but the tooling was cumbersome if you wanted to transfer a small data set or an executable and its dependent DSOs, which seem like they would be nice use cases to handle.  So in this PR the tooling supports a "tar" like utility for walking trees of files and mapping them, and the concept of "tags".  All mapped files are assigned a tag, and once mapped, they are referred to _only_ by tag.

A group of files is transferred by passing in one or more tags to a query RPC, and receiving a file list in the form of arrays of blobrefs in a multi-response RPC.  The blobrefs refer to _fileref_ objects that match the tags, which in turn contain the blobrefs for the file content as described above.  The list can be further filtered at the source by applying an optional glob pattern on the file names.  By loading all the blobrefs, the client recreates the original files.  A shell plugin is available that performs this function within a job.

**Examples**

The following command maps the flux-core source tree with the tag `flux`, and an Ubuntu install image with the tag `image`:
```console
$ flux file map -C /home/garlick/proj --tags=flux flux-core
$ flux file map -C /home/garlick/Downloads --tags=image ubuntu-22.04-desktop-amd64.iso
$ flux file list -v --tags=image
f 0664 3654957056 ubuntu-22.04-desktop-amd64.iso
$ flux file list -v --tags=flux
f 0664     1106 flux-core/.pre-commit-config.yaml
f 0664      554 flux-core/codecov.yml
f 0664    59254 flux-core/aclocal.m4
[snip]
```

This runs a job with the `image` tagged file copied to $FLUX_JOB_TMPDIR on each node:
```console
$ flux mini run -o copyin.tags=image -o verbose=2 bash -c 'ls -l $FLUX_JOB_TMPDIR'
[snip]
0.036s: flux-shell[0]: DEBUG: copyin: => /tmp/flux-qgI86c/jobtmp-0-ƒ31mXGAzT
0.040s: flux-shell[0]: TRACE: copyin: f 0664 3654957056 ubuntu-22.04-desktop-amd64.iso
12.477s: flux-shell[0]: DEBUG: copyin: 1 files 293.8MB/s
[snip]
total 3569300
-rw-rw-r-- 1 garlick garlick 3654957056 Nov 30 14:11 ubuntu-22.04-desktop-amd64.iso
[snip]
```

This runs a job with the `flux` taggged files copied to $FLUX_JOB_TMPDIR on each node:
```console
$ flux mini run -o copyin.tags=flux -o verbose=1 bash -c 'ls -l $FLUX_JOB_TMPDIR'
[snip]
0.037s: flux-shell[0]: DEBUG: copyin: => /tmp/flux-qgI86c/jobtmp-0-ƒ6A7vUd9R
3.050s: flux-shell[0]: DEBUG: copyin: 13391 files 114.7MB/s
[snip]
total 4
drwxrwxr-x 13 garlick garlick 4096 Nov 30 14:18 flux-core
[snip]
```

The general idea was that in a batch script, which runs in your own private instance, you could map some files from a global file system at the top of the script, organizing them with tags, then run jobs that that specify tags of interest to that job.

It's possible to copy files outside of a job also.   For example, this copies the `flux` files to /tmp on broker ranks 1-7:
```console
$ flux exec -r1-7 flux file get --tags=flux -C /tmp
```
Other details are:
- there is a default tag named `main` which is assumed if a tag is not specified (maybe a batch job only has one set of files and then why bother with tags)
- running a job with `-ocopyin` by itself copies the `main` (default) tag
- running a job with `-ocopyin.destdir=/tmp/xyz` copies files to the specified directory rather than $FLUX_JOB_TMPDIR
- running a job wtih `-ocopyin.pattern=foo/*` copies only the files whose paths match the pattern
- sparse files are transferred efficiently
- symlinks and directories are supported too
- as an optimization, small files (up to 4K) store data directly in the fileref object.

Known limitations:
- Only the rank 0 broker can map files
- Streaming data can't be mapped without copying it to files first
- Only the rank 0 broker can answer the list query

There are some more todos below, but I thought maybe it would be a good idea to seek feedback on the general approach before going there.

**todo**

- [x] docs
- [ ] scalability testing on a real cluster

Edit: dropped improving performance of "list" transfer within job shells for a future PR if needed.