### PR TITLE
broker: fix potential crash after sending SIGKILL to job-manager prolog

### DIFF
--- a/src/modules/job-manager/plugins/perilog.c
+++ b/src/modules/job-manager/plugins/perilog.c
@@ -387,6 +387,11 @@ static void prolog_kill_cb (flux_future_t *f, void *arg)
                                 (uintmax_t) proc->id);
             /* Do not wait for error response */
             flux_future_destroy (fkill);
+            /* Also destroy proc->kill_f future to avoid this callback
+             * being called again.
+             */
+            flux_future_destroy (proc->kill_f);
+            proc->kill_f = NULL;
             return;
         }
         flux_log_error (h, "prolog_kill");

--- a/t/t2274-manager-perilog.t
+++ b/t/t2274-manager-perilog.t
@@ -129,6 +129,15 @@ test_expect_success 'perilog: job can be canceled while prolog is running' '
 	flux job wait-event -t 15 $jobid exception &&
 	test_must_fail flux job attach -vE $jobid
 '
+test_expect_success 'perilog: job can timeout after prolog' '
+	printf "#!/bin/sh\nsleep 1" > prolog.d/sleep.sh &&
+	chmod +x prolog.d/sleep.sh &&
+	test_when_finished "rm -f prolog.d/sleep.sh" &&
+	jobid=$(flux mini submit --job-name=timeout -t 0.5s sleep 10) &&
+	flux job wait-event -t 15 $jobid prolog-start &&
+	flux job wait-event -vt 15 $jobid exception &&
+	flux job wait-event -t 15 $jobid clean
+'
 test_expect_success 'perilog: job can be canceled after prolog is complete' '
 	printf "#!/bin/sh\nsleep 0" > prolog.d/sleep.sh &&
 	chmod +x prolog.d/sleep.sh &&


### PR DESCRIPTION
This PR is a probable fix for the crash described in #4790. I am not 100% certain of the root cause, since I don't see how the subprocess kill future callback could get called after the subprocess handle is destroyed (the subprocess and kill future are destroyed together when the subprocess or job completes), but ensuring the future is only called once on timeout would have prevented this particular crash (and not destroying the future in this case was definitely a bug)