### PR TITLE
ci: revert to ubuntu-20.04 for workflow jobs that fail on ubuntu-latest

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
 
   python-lint:
     name: python linting
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/setup-python@v4
       with:
@@ -83,7 +83,7 @@ jobs:
 
   ci-checks:
     needs: [generate-matrix]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       TAP_DRIVER_QUIET: 1
       FLUX_TEST_TIMEOUT: 300


### PR DESCRIPTION
Problem: The python linting job fails on ubuntu-latest because python 3.6 is no longer supported.

Use runs-on: ubuntu-20.04 in the python-lint job so that python 3.6 can still be used.

See https://github.com/actions/setup-python/issues/355#issuecomment-1335042510