### PR TITLE
broker: improve detection of interactive shells

### DIFF
--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -695,7 +695,7 @@ static int create_runat_rc2 (struct runat *r, const char *argz, size_t argz_len)
          */
         if (!isatty (STDIN_FILENO))
             log_msg_exit ("stdin is not a tty - can't run interactive shell");
-        if (runat_push_shell (r, "rc2", 0) < 0)
+        if (runat_push_shell (r, "rc2", argz, 0) < 0)
             return -1;
     }
     else if (argz_count (argz, argz_len) == 1) { // run shell -c "command"

--- a/src/broker/runat.c
+++ b/src/broker/runat.c
@@ -350,9 +350,12 @@ static int runat_command_set_argz (struct runat_command *cmd,
 }
 
 static int runat_command_set_cmdline (struct runat_command *cmd,
+                                      const char *shell,
                                       const char *cmdline)
 {
-    if (flux_cmd_argv_append (cmd->cmd, get_shell ()) < 0)
+    if (shell == NULL)
+        shell = get_shell ();
+    if (flux_cmd_argv_append (cmd->cmd, shell) < 0)
         return -1;
     if (cmdline) {
         if (flux_cmd_argv_append (cmd->cmd, "-c") < 0)
@@ -454,7 +457,7 @@ int runat_push_shell_command (struct runat *r,
      */
     cmd->flags |= FLUX_SUBPROCESS_FLAGS_SETPGRP;
 
-    if (runat_command_set_cmdline (cmd, cmdline) < 0)
+    if (runat_command_set_cmdline (cmd, NULL, cmdline) < 0)
         goto error;
     if (runat_command_modenv (cmd, env_blocklist, r->local_uri) < 0)
         goto error;
@@ -466,7 +469,10 @@ error:
     return -1;
 }
 
-int runat_push_shell (struct runat *r, const char *name, int flags)
+int runat_push_shell (struct runat *r,
+                      const char *name,
+                      const char *shell,
+                      int flags)
 {
     struct runat_command *cmd;
 
@@ -476,7 +482,7 @@ int runat_push_shell (struct runat *r, const char *name, int flags)
     }
     if (!(cmd = runat_command_create (environ, flags)))
         return -1;
-    if (runat_command_set_cmdline (cmd, NULL) < 0)
+    if (runat_command_set_cmdline (cmd, shell, NULL) < 0)
         goto error;
     if (runat_command_modenv (cmd, env_blocklist, r->local_uri) < 0)
         goto error;

--- a/src/broker/runat.h
+++ b/src/broker/runat.h
@@ -40,7 +40,10 @@ int runat_push_shell_command (struct runat *r,
 /* Push interactive shell onto named list.
  * Note: RUNAT_FLAG_LOG_STDIO flag not allowed
  */
-int runat_push_shell (struct runat *r, const char *name, int flags);
+int runat_push_shell (struct runat *r,
+                      const char *name,
+                      const char *shell,
+                      int flags);
 
 /* Push command, to be run directly, onto named list.
  * The command is specified by argz.

--- a/src/broker/test/runat.c
+++ b/src/broker/test/runat.c
@@ -313,13 +313,14 @@ void badinput (flux_t *h)
         "runat_get_exit_code rc=NULL fails with ENOENT");
 
     errno = 0;
-    ok (runat_push_shell (NULL, "foo", 0) < 0 && errno == EINVAL,
+    ok (runat_push_shell (NULL, "foo", NULL, 0) < 0 && errno == EINVAL,
         "runat_push_shell r=NULL fails with EINVAL");
     errno = 0;
-    ok (runat_push_shell (r, NULL, 0) < 0 && errno == EINVAL,
+    ok (runat_push_shell (r, NULL, NULL, 0) < 0 && errno == EINVAL,
         "runat_push_shell name=NULL fails with EINVAL");
     errno = 0;
-    ok (runat_push_shell (r, "foo", RUNAT_FLAG_LOG_STDIO) < 0 && errno == EINVAL,
+    ok (runat_push_shell (r, "foo", NULL, RUNAT_FLAG_LOG_STDIO) < 0
+        && errno == EINVAL,
         "runat_push_shell flags=RUNAT_FLAG_LOG_STDIO fails with EINVAL");
 
     errno = 0;

--- a/src/cmd/flux-start.c
+++ b/src/cmd/flux-start.c
@@ -406,6 +406,9 @@ static void state_cb (flux_subprocess_t *p, flux_subprocess_state_t state)
             }
             break;
         }
+        case FLUX_SUBPROCESS_STOPPED:
+            /* ignore */
+            break;
     }
 }
 

--- a/src/common/libsubprocess/local.c
+++ b/src/common/libsubprocess/local.c
@@ -375,6 +375,11 @@ static void child_watch_cb (flux_reactor_t *r, flux_watcher_t *w,
 
     p->status = status;
 
+    if (WIFSTOPPED (p->status)) {
+        if (p->ops.on_state_change)
+            (*p->ops.on_state_change) (p, FLUX_SUBPROCESS_STOPPED);
+    }
+
     if (WIFEXITED (p->status) || WIFSIGNALED (p->status)) {
 
         /* remote/server code may have set EXEC_FAILED or

--- a/src/common/libsubprocess/subprocess.c
+++ b/src/common/libsubprocess/subprocess.c
@@ -464,6 +464,7 @@ static flux_subprocess_state_t state_change_next (flux_subprocess_t *p)
     case FLUX_SUBPROCESS_EXEC_FAILED:
     case FLUX_SUBPROCESS_EXITED:
     case FLUX_SUBPROCESS_FAILED:
+    case FLUX_SUBPROCESS_STOPPED:
         break;
     }
 
@@ -1226,6 +1227,8 @@ const char *flux_subprocess_state_string (flux_subprocess_state_t state)
         return "Exited";
     case FLUX_SUBPROCESS_FAILED:
         return "Failed";
+    case FLUX_SUBPROCESS_STOPPED:
+        return "Stopped";
     }
     return NULL;
 }

--- a/src/common/libsubprocess/subprocess.h
+++ b/src/common/libsubprocess/subprocess.h
@@ -56,6 +56,7 @@ typedef enum {
     FLUX_SUBPROCESS_EXITED,       /* process has exited */
     FLUX_SUBPROCESS_FAILED,       /* internal failure, catch all for
                                    * all other errors */
+    FLUX_SUBPROCESS_STOPPED,      /* process was stopped */
 } flux_subprocess_state_t;
 
 /*

--- a/src/modules/job-ingest/worker.c
+++ b/src/modules/job-ingest/worker.c
@@ -119,6 +119,7 @@ static void worker_state_cb (flux_subprocess_t *p,
             break;
         case FLUX_SUBPROCESS_EXITED:
         case FLUX_SUBPROCESS_INIT:
+        case FLUX_SUBPROCESS_STOPPED:
             break; // ignore
     }
 }

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -318,6 +318,7 @@ dist_check_SCRIPTS = \
 	issues/t4583-free-range-test.sh \
 	issues/t4612-eventlog-overwrite-crash.sh \
 	issues/t4711-job-list-purge-inactive.sh \
+	issues/t4771-flux-start-bash.sh \
 	python/__init__.py \
 	python/subflux.py \
 	python/tap \

--- a/t/issues/t4771-flux-start-bash.sh
+++ b/t/issues/t4771-flux-start-bash.sh
@@ -1,0 +1,10 @@
+#!/bin/sh -x
+# flux start of interactive process non-interactively causes error
+
+# create link to shell to thwart broker detection of interactive shell:
+ln -s /bin/bash bash
+
+${SHARNESS_TEST_SRCDIR}/scripts/runpty.py flux start ./bash
+
+# Ensure broker killed bash with SIGKILL:
+test $? -eq 137


### PR DESCRIPTION
This PR nominally solves #4771 while at the same time  avoiding most hangs when the broker fails to detect that an initial program is supposed to be interactive.

The root of the problem is that the broker runs non-interactive initial programs in a separate process group to aid cleanup, but if the child tries to read from the tty it gets SIGTTIN and ends up stopped in what is effectively an uninterruptible state (requires SIGKILL to be terminated). Since the broker currently only treats lack of an argument as an "interactive" shell, `flux start bash` or `flux start <any shell>` causes this behavior.

To fix this issue the broker has to have a good idea of what arguments might specify an interactive shell. So, instead of just checking for `argz == NULL` to detect an interactive shell, the broker now reads `/etc/shells` and compares the entries and their basenames to the first argument (when there is only a single argument) to detect if the program will be interactive. This will work for cases like `flux start bash` and `flux start /bin/bash`, but not `flux start bash -l`.

Since the solution here isn't 100%, it would be good to also cause an error instead of a hang when an interactive process is run non-interactively by the broker. To detect this case, libsubprocess is extended to add a `FLUX_SUBPROCESS_STOPPED` when the child watcher returns a status of `WIFSTOPPED`. The broker then can issue an error and kill the child process. Since the child is being run non-interactively, I don't think there is a case where this would be unwanted behavior.

Of course, all this would not be necessary if we didn't run non-interactive rc2 in a separate process group. However, at least for now, I think the benefits of doing that (i.e. more reliable cleanup) outweigh the costs of the extra code here.