### PR TITLE
pmi: increase max value length to 2048

### DIFF
--- a/src/common/libpmi/pmi2.h
+++ b/src/common/libpmi/pmi2.h
@@ -33,8 +33,8 @@ extern "C" {
 #define PMI2_ERR_OTHER              14
 
 #define PMI2_MAX_KEYLEN             64
-#define PMI2_MAX_VALLEN             1024
-#define PMI2_MAX_ATTRVALUE          1024
+#define PMI2_MAX_VALLEN             2048
+#define PMI2_MAX_ATTRVALUE          2048
 #define PMI2_ID_NULL                -1
 
 

--- a/src/common/libpmi/simple_server.h
+++ b/src/common/libpmi/simple_server.h
@@ -14,7 +14,7 @@
 struct pmi_simple_server;
 
 #define SIMPLE_KVS_KEY_MAX         64
-#define SIMPLE_KVS_VAL_MAX         1024
+#define SIMPLE_KVS_VAL_MAX         2048
 #define SIMPLE_KVS_NAME_MAX        64
 
 #define SIMPLE_MAX_PROTO_OVERHEAD  64


### PR DESCRIPTION
As suggested in #4778, this simple PR increases the  max KVS value length for PMI-1 and 2 in the simple server and therefore the job shell PMI implementation (I believe this is all that is necessary, please let me know if not).

This doubles the size to 2048, which should allow PMI_process_mapping up to about 169 tasks per node. If we want to support 256 tasks per node, we'll need to increase this further. I'm not sure what the repercussions would be for increasing vallen_max further to 3192 or 4096. (Seems like 3192 would be large enough for 256 tasks per node)