### PR TITLE
libhostlist: fix 8K limit on encoded hostlists

### DIFF
--- a/src/common/libhostlist/hostrange.c
+++ b/src/common/libhostlist/hostrange.c
@@ -427,53 +427,6 @@ int hostrange_hn_within (struct hostrange * hr, struct hostname * hn)
     return -1;
 }
 
-
-/* copy a string representation of the hostrange hr into buffer buf,
- * writing at most n chars including NUL termination
- */
-ssize_t hostrange_to_string (struct hostrange * hr,
-                             size_t n,
-                             char *buf,
-                             char *separator)
-{
-    unsigned long i;
-    int truncated = 0;
-    int len = 0;
-    char sep = separator == NULL ? ',' : separator[0];
-
-    if (hr == NULL || n == 0)
-        return 0;
-
-    if (hr->singlehost)
-        return snprintf (buf, n, "%s", hr->prefix);
-
-    for (i = hr->lo; i <= hr->hi; i++) {
-        size_t m = (n - len) <= n ? n - len : 0; /* check for < 0 */
-        int ret = snprintf (buf + len,
-                            m,
-                            "%s%0*lu",
-                            hr->prefix,
-                            hr->width,
-                            i);
-        if (ret < 0 || ret >= m) {
-            len = n;
-            truncated = 1;
-            break;
-        }
-        len+=ret;
-        buf[len++] = sep;
-    }
-
-    if (truncated) {
-        buf[n-1] = '\0';
-        return -1;
-    } else {
-        /* back up over final separator */
-        buf[--len] = '\0';
-        return len;
-    }
-}
-
 /* Place the string representation of the numeric part of hostrange into buf
  * writing at most n chars including NUL termination.
  */

--- a/src/common/libhostlist/hostrange.h
+++ b/src/common/libhostlist/hostrange.h
@@ -58,9 +58,6 @@ struct hostrange * hostrange_intersect (struct hostrange *,
 
 int hostrange_hn_within (struct hostrange *, struct hostname *);
 
-ssize_t hostrange_to_string (struct hostrange * hr,
-                             size_t, char *, char *);
-
 size_t hostrange_numstr(struct hostrange *, size_t, char *);
 
 /*  Return the string representation of the nth string in 'hr'.

--- a/src/common/libhostlist/test/hostlist.c
+++ b/src/common/libhostlist/test/hostlist.c
@@ -583,6 +583,27 @@ void test_iteration_with_delete ()
     }
 }
 
+/*  Ensure a very large host list can be encoded without error
+ */
+static void test_encode_large ()
+{
+    struct hostlist *hl = hostlist_create ();
+    if (hl == NULL)
+        BAIL_OUT ("hostlist_create");
+    for (int i = 0; i < 8192; i++)
+        hostlist_append (hl, "host");
+    ok (hostlist_count (hl) == 8192,
+        "created hostlist with 8K hosts");
+    char *s = hostlist_encode (hl);
+    ok (s != NULL,
+        "hostlist_encode works");
+    ok (strlen (s) > 0,
+        "string length of result is %ld",
+        strlen (s));
+    free (s);
+    hostlist_destroy (hl);
+}
+
 int main (int argc, char *argv[])
 {
     plan (NO_PLAN);
@@ -599,6 +620,7 @@ int main (int argc, char *argv[])
     test_sortuniq ();
     test_iteration ();
     test_iteration_with_delete ();
+    test_encode_large ();
 
     done_testing ();
 }

--- a/src/common/libhostlist/test/hostrange.c
+++ b/src/common/libhostlist/test/hostrange.c
@@ -440,66 +440,6 @@ struct tostring_test {
     const char *numstr;
 };
 
-struct tostring_test tostring_tests[] = {
-    { .prefix = "foo", .singlehost = true, .rc = 3, .tostring = "foo" },
-    { "foo", false, 0, 3, 0, 19, "foo0,foo1,foo2,foo3",
-      3, "0-3",  },
-    { "", false, 0, 3, 0, 7, "0,1,2,3",
-      3, "0-3" },
-    { "foo", false, 1, 4, 2, 23, "foo01,foo02,foo03,foo04",
-      5, "01-04" },
-    { "foo", false, 10, 10, 0, 5, "foo10",
-      2, "10" },
-    { 0 }
-};
-
-void test_to_string ()
-{
-    ssize_t rc;
-    char buf [4096];
-    struct tostring_test *t;
-    struct hostrange *hr;
-
-    ok (hostrange_to_string (NULL, 0, buf, NULL) == 0,
-        "hostrange_to_string (NULL) == 0");
-
-    hr = hostrange_create ("foo", 0, 100, 0);
-    if (!hr)
-        BAIL_OUT ("hostrange_create failed!");
-
-    rc = hostrange_to_string (hr, 20, buf, NULL);
-    ok (rc < 0,
-        "hostrange_to_string fails with truncation");
-    hostrange_destroy (hr);
-
-    t = tostring_tests;
-    while (t && t->prefix) {
-        if (t->singlehost)
-            hr = hostrange_create_single (t->prefix);
-        else
-            hr = hostrange_create (t->prefix, t->lo, t->hi, t->width);
-        if (!hr)
-            BAIL_OUT ("hostrannge_create failed!");
-        rc = hostrange_to_string (hr, sizeof (buf), buf, ",");
-        ok (rc == t->rc,
-            "hostrange_to_string (%s[%lu-%lu]) returned %ld",
-            hr->prefix, hr->lo, hr->hi, rc);
-        is (buf, t->tostring,
-            "hostrange_to_string () result is %s", buf);
-
-        rc = hostrange_numstr (hr, sizeof (buf), buf);
-        ok (rc == t->numstr_rc,
-            "hostrange_numstr(%s[%lu-%lu]) = %ld",
-            hr->prefix, hr->lo, hr->hi, rc);
-        if (rc > 0)
-            is (buf, t->numstr,
-                "hostrange_numstr () result is %s", buf);
-
-        hostrange_destroy (hr);
-        t++;
-    }
-}
-
 void test_host_tostring ()
 {
     char *host;
@@ -552,7 +492,6 @@ int main (int argc, char *argv[])
     test_join ();
     test_intersect ();
     test_within ();
-    test_to_string ();
     test_host_tostring ();
 
     done_testing ();


### PR DESCRIPTION
This PR fixes an artificial 8K limit on the return value from `hostlist_encode()` by replacing an internal statically sized buffer with the use of a POSIX memstream to dynamically allocate memory for the encoded result.

Additionally, some unused code is removed.
