### PR TITLE
cleanup: remove some unused functions

### DIFF
--- a/src/common/librlist/rnode.c
+++ b/src/common/librlist/rnode.c
@@ -268,22 +268,6 @@ fail:
     return NULL;
 }
 
-struct rnode *rnode_create_count (const char *name,
-                                  uint32_t rank,
-                                  int count)
-{
-    struct rnode *n = NULL;
-    struct idset *ids = NULL;
-
-    if (!(ids = idset_create (0, IDSET_FLAG_AUTOGROW))
-        || (idset_range_set (ids, 0, count-1) < 0))
-        goto out;
-    n = rnode_create_idset (name, rank, ids);
-out:
-    idset_destroy (ids);
-    return n;
-}
-
 int rnode_set_property (struct rnode *n, const char *name)
 {
     if (!n->properties && !(n->properties = zhashx_new ())) {

--- a/src/common/librlist/test/rnode.c
+++ b/src/common/librlist/test/rnode.c
@@ -312,15 +312,6 @@ int main (int ac, char *av[])
 
     rnode_destroy (n);
 
-    n = rnode_create_count ("foo", 1, 8);
-    if (n == NULL)
-        BAIL_OUT ("rnode_create_count failed");
-    is (n->hostname, "foo",
-        "rnode_create_count set hostname correctly");
-    ok (n->rank == 1, "rnode rank set correctly");
-    rnode_avail_check (n, "0-7");
-    rnode_destroy (n);
-
     struct idset *idset = idset_decode ("0-3");
     n = rnode_create_idset ("foo", 3, idset);
     idset_destroy (idset);

--- a/src/common/libutil/xzmalloc.c
+++ b/src/common/libutil/xzmalloc.c
@@ -29,14 +29,6 @@ void *xzmalloc (size_t size)
     return new;
 }
 
-void *xrealloc (void *ptr, size_t size)
-{
-    void *new = realloc (ptr, size);
-    if (!new)
-        oom ();
-    return new;
-}
-
 char *xstrdup (const char *s)
 {
     char *cpy = strdup (s);
@@ -64,18 +56,6 @@ char *xasprintf (const char *fmt, ...)
     s = xvasprintf (fmt, ap);
     va_end (ap);
     return s;
-}
-
-char *xstrsub (const char *str, char a, char b)
-{
-    char *cpy = xstrdup (str);
-    char *s = cpy;
-    while (*s) {
-        if (*s == a)
-            *s = b;
-        s++;
-    }
-    return cpy;
 }
 
 /*

--- a/src/common/libutil/xzmalloc.h
+++ b/src/common/libutil/xzmalloc.h
@@ -17,12 +17,10 @@
 /* Memory allocation functions that call oom() on allocation error.
  */
 void *xzmalloc (size_t size);
-void *xrealloc (void *ptr, size_t size);
 char *xstrdup (const char *s);
 char *xvasprintf(const char *fmt, va_list ap);
 char *xasprintf (const char *fmt, ...)
      __attribute__ ((format (printf, 1, 2)));
-char *xstrsub (const char *str, char a, char b);
 
 #endif /* !_UTIL_XZMALLOC_H */
 /*


### PR DESCRIPTION
I ran code coverage without any unit tests to find libutil and other functions that are used only by their own unit tests.

I thought I'd find a bit more, but it was only a couple functions after all.