### PR TITLE
flux-mini: add --cwd option

### DIFF
--- a/doc/man1/flux-mini.rst
+++ b/doc/man1/flux-mini.rst
@@ -455,6 +455,9 @@ with the job exit status.
 OTHER OPTIONS
 =============
 
+**--cwd=DIRECTORY**
+   Set job working directory.
+
 **--urgency=N**
    Specify job urgency, which affects queue order. Numerically higher urgency
    jobs are considered by the scheduler first. Guests may submit jobs with

--- a/doc/man1/flux-mini.rst
+++ b/doc/man1/flux-mini.rst
@@ -183,6 +183,9 @@ KVS, where they may be accessed with the ``flux job attach`` command.
 In addition, ``flux-mini run`` processes standard I/O in real time,
 emitting the job's I/O to its stdout and stderr.
 
+**--input=FILENAME**
+   Redirect stdin to the specified filename, bypassing the KVS.
+
 **--output=TEMPLATE**
    Specify the filename *TEMPLATE* for stdout redirection, bypassing
    the KVS.  *TEMPLATE* may be a mustache template which supports the

--- a/etc/completions/flux.pre
+++ b/etc/completions/flux.pre
@@ -156,6 +156,7 @@ _flux_mini()
         --flags= \
         --dry-run \
         -h --help \
+        --cwd= \
     "
     local SUBMIT_OPTIONS="\
         -N --nodes= \

--- a/src/cmd/flux-mini.py
+++ b/src/cmd/flux-mini.py
@@ -661,6 +661,9 @@ class MiniCmd:
             else argparse.SUPPRESS,
         )
         parser.add_argument(
+            "--cwd", help="Set job working directory", metavar="DIRECTORY"
+        )
+        parser.add_argument(
             "--flags",
             action="append",
             help="Set comma separated list of job submission flags. Possible "
@@ -690,8 +693,8 @@ class MiniCmd:
         Create a jobspec from args and return it to caller
         """
         jobspec = self.init_jobspec(args)
-        jobspec.cwd = os.getcwd()
         jobspec.environment = get_filtered_environment(args.env)
+        jobspec.cwd = args.cwd if args.cwd is not None else os.getcwd()
         rlimits = get_filtered_rlimits(args.rlimit)
         if rlimits:
             jobspec.setattr_shell_option("rlimit", rlimits)

--- a/t/t2700-mini-cmd.t
+++ b/t/t2700-mini-cmd.t
@@ -221,6 +221,15 @@ test_expect_success HAVE_JQ 'flux mini submit --output id mustache passes throug
 	flux mini submit --dry-run --output=foo.{{id}} hostname >musid.out &&
 	test $(jq ".attributes.system.shell.options.output.stdout.path" musid.out) = "\"foo.{{id}}\""
 '
+test_expect_success HAVE_JQ 'flux mini submit --cwd passes through to jobspec' '
+	flux mini submit --cwd=/foo/bar/baz hostname > cwd.out &&
+	jq -e ".attributes.system.cwd == \"/foo/bar/baz\""
+'
+test_expect_success HAVE_JQ 'flux mini submit --cwd works' '
+	mkdir cwd_test &&
+	flux mini run --cwd=$(realpath cwd_test) pwd > cwd.out &&
+	test $(cat cwd.out) = $(realpath cwd_test)
+'
 test_expect_success HAVE_JQ 'flux mini submit command arguments work' '
 	flux mini submit --dry-run a b c >args.out &&
 	test $(jq ".tasks[0].command[0]" args.out) = "\"a\"" &&


### PR DESCRIPTION
Problem: setting the working directory is a common operation, but it is not clear how to do it on the command line.

Add a --cwd option to the flux-mini commands for setting it.

Fixes #4774.