### PR TITLE
flux-pmi: add installed PMI test tool

### DIFF
--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -20,6 +20,7 @@ AM_CPPFLAGS = \
 fluxcmd_ldadd = \
 	$(top_builddir)/src/common/libkvs/libkvs.la \
 	$(top_builddir)/src/common/librlist/librlist.la \
+	$(top_builddir)/src/common/libpmi/libpmi_client.la \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/libflux-core.la \
 	$(top_builddir)/src/common/libflux-optparse.la \
@@ -61,8 +62,9 @@ flux_SOURCES = \
 	builtin/startlog.c \
 	builtin/dump.c \
 	builtin/restore.c \
-	builtin/shutdown.c \
-	builtin/filemap.c
+	builtin/filemap.c \
+	builtin/pmi.c \
+	builtin/shutdown.c
 nodist_flux_SOURCES = \
 	builtin-cmds.c
 

--- a/src/cmd/builtin/pmi.c
+++ b/src/cmd/builtin/pmi.c
@@ -1,0 +1,199 @@
+/************************************************************\
+ * Copyright 2022 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include "builtin.h"
+
+#include <stdlib.h>
+#include <time.h>
+#include <flux/idset.h>
+
+#include "src/common/libpmi/simple_client.h"
+#include "src/common/libpmi/pmi_strerror.h"
+#include "src/common/libpmi/pmi.h"
+#include "src/common/libutil/monotime.h"
+#include "src/common/libutil/log.h"
+#include "ccan/array_size/array_size.h"
+#include "ccan/str/str.h"
+
+static struct pmi_simple_client *client;
+static char kvsname[1024];
+
+static void client_init (void)
+{
+    int result;
+    const char *vars[] = { "PMI_FD", "PMI_RANK", "PMI_SIZE" }; // required
+
+    for (int i = 0; i < ARRAY_SIZE (vars); i++) {
+        if (!getenv (vars[i]))
+            log_msg_exit ("%s is missing from the environment", vars[i]);
+    }
+    client = pmi_simple_client_create_fd (getenv ("PMI_FD"),
+                                          getenv ("PMI_RANK"),
+                                          getenv ("PMI_SIZE"),
+                                          getenv ("PMI_SPAWNED"));
+    if (!client)
+        log_err_exit ("could not create PMI client");
+
+    result = pmi_simple_client_init (client);
+    if (result != PMI_SUCCESS)
+        log_msg_exit ("pmi init failed: %s", pmi_strerror (result));
+
+    result = pmi_simple_client_kvs_get_my_name (client,
+                                                kvsname,
+                                                sizeof (kvsname));
+    if (result != PMI_SUCCESS)
+        log_msg_exit ("could not fetch kvsname: %s", pmi_strerror (result));
+}
+
+static void client_finalize (void)
+{
+    int result;
+
+    result = pmi_simple_client_finalize (client);
+    if (result != PMI_SUCCESS)
+        log_msg_exit ("pmi finalize failed: %s", pmi_strerror (result));
+    pmi_simple_client_destroy (client);
+}
+
+static void client_barrier (void)
+{
+    int result;
+
+    result = pmi_simple_client_barrier (client);
+    if (result != PMI_SUCCESS)
+        log_msg_exit ("pmi barrier failed: %s", pmi_strerror (result));
+}
+
+static void client_kvs_get (const char *key, char *buf, int size)
+{
+    int result;
+
+    result = pmi_simple_client_kvs_get (client,
+                                        kvsname,
+                                        key,
+                                        buf,
+                                        size);
+    if (result != PMI_SUCCESS)
+        log_msg_exit ("could not fetch %s: %s", key, pmi_strerror (result));
+}
+
+static int internal_cmd_get (optparse_t *p, int argc, char *argv[])
+{
+    int n = optparse_option_index (p);
+    const char *arg = optparse_get_str (p, "ranks", "0");
+    struct idset *ranks = NULL;
+
+    if (!streq (arg, "all")) {
+        if (!(ranks = idset_decode (arg)))
+            log_msg_exit ("could not decode --ranks argument");
+    }
+    client_init ();
+    if (!ranks || idset_test (ranks, client->rank)) {
+        while (n < argc) {
+            char val[1024];
+            client_kvs_get (argv[n++], val, sizeof (val));
+            printf ("%s\n", val);
+        }
+    }
+    client_finalize ();
+    idset_destroy (ranks);
+
+    return 0;
+}
+
+static int internal_cmd_barrier (optparse_t *p, int argc, char *argv[])
+{
+    int n = optparse_option_index (p);
+    int count = optparse_get_int (p, "count", 1);
+    struct timespec t;
+    const char *label;
+
+    if (n != argc) {
+        optparse_print_usage (p);
+        exit (1);
+    }
+    if (!(label = getenv ("FLUX_JOB_CC")))
+        if (!(label = getenv ("FLUX_JOB_ID")))
+            label = "0";
+    client_init ();
+    client_barrier (); // don't let task launch stragglers skew timing
+    while (count-- > 0) {
+        monotime (&t);
+        client_barrier ();
+        if (client->rank == 0) {
+            printf ("%s: completed pmi barrier on %d tasks in %0.3fs.\n",
+                    label,
+                    client->size,
+                    monotime_since (t) / 1000);
+            fflush (stdout);
+        }
+    }
+    client_finalize ();
+
+    return 0;
+}
+
+static int cmd_pmi (optparse_t *p, int argc, char *argv[])
+{
+    log_init ("flux-pmi");
+
+    if (optparse_run_subcommand (p, argc, argv) != OPTPARSE_SUCCESS)
+        exit (1);
+
+    return 0;
+}
+
+static struct optparse_option barrier_opts[] = {
+    { .name = "count",      .has_arg = 1, .arginfo = "N",
+       .usage = "Execute N barrier operations (default 1)", },
+    OPTPARSE_TABLE_END,
+};
+static struct optparse_option get_opts[] = {
+    { .name = "ranks",      .has_arg = 1, .arginfo = "{IDSET|all}",
+       .usage = "Print value on specified ranks (default: 0)", },
+    OPTPARSE_TABLE_END,
+};
+
+static struct optparse_subcommand pmi_subcmds[] = {
+    { "barrier",
+      "[OPTIONS]",
+      "Execute PMI barrier",
+      internal_cmd_barrier,
+      0,
+      barrier_opts,
+    },
+    { "get",
+      "[OPTIONS]",
+      "Get PMI KVS key",
+      internal_cmd_get,
+      0,
+      get_opts,
+    },
+    OPTPARSE_SUBCMD_END
+};
+
+int subcommand_pmi_register (optparse_t *p)
+{
+    optparse_err_t e;
+
+    e = optparse_reg_subcommand (p,
+            "pmi", cmd_pmi, NULL, "Simple PMI test client", 0, NULL);
+    if (e != OPTPARSE_SUCCESS)
+        return (-1);
+
+    e = optparse_reg_subcommands (optparse_get_subcommand (p, "pmi"),
+                                  pmi_subcmds);
+    return (e == OPTPARSE_SUCCESS ? 0 : -1);
+}
+
+// vi: ts=4 sw=4 expandtab

--- a/t/t3002-pmi.t
+++ b/t/t3002-pmi.t
@@ -106,4 +106,41 @@ test_expect_success 'PMI1 can calculate clique ranks with 128 tasks per node' '
 	grep "0: clique=0,2,4,6,8,10,12,14,16,18,20" tpn.128.out
 '
 
+test_expect_success 'flux-pmi barrier works' '
+	flux mini run --label-io -n2 \
+	    flux pmi barrier
+'
+test_expect_success 'flux-pmi barrier --count works' '
+	flux mini run --label-io -n2 \
+	    flux pmi barrier --count=2
+'
+test_expect_success 'flux-pmi get PMI_process_mapping works' '
+	flux mini run --label-io -n2 \
+	    flux pmi get PMI_process_mapping
+'
+test_expect_success 'flux-pmi get --ranks=1 flux.taskmap works' '
+	flux mini run --label-io -n2 \
+	    flux pmi get --ranks=1 flux.taskmap
+'
+test_expect_success 'flux-pmi get --ranks=all flux.instance-level works' '
+	flux mini run --label-io -n2 \
+	    flux pmi get --ranks=all flux.instance-level
+'
+test_expect_success 'flux-pmi get works with multiple keys' '
+	flux mini run --label-io -n2 \
+	    flux pmi get flux.instance-level PMI_process_mapping
+'
+test_expect_success 'flux-pmi barrier fails outside of the job environment' '
+	test_must_fail flux pmi barrier
+'
+test_expect_success 'flux-pmi fails with bad subcommand' '
+	test_must_fail flux mini run flux pmi notacmd
+'
+test_expect_success 'flux-pmi get fails with bad option' '
+	test_must_fail flux mini run flux pmi get --badopt foo
+'
+test_expect_success 'flux-pmi get fails with bad ranks option' '
+	test_must_fail flux mini run flux pmi get --ranks=1.2 flux.taskmap
+'
+
 test_done


### PR DESCRIPTION
Problem: when debugging MPI or other parallel launch problems, it is sometimes useful to be able to run a stripped down  PMI client  to verify that at least that level of functionality is working in the failing environment.

I've found myself building the clunky pmi test programs in libpmi for this purpose, when really I wanted something like `mpi_hello` but at the pmi level.  I can imagine it would be useful to be able to suggest that someone try this without requiring them to have a built source tree.

This adds a built-in command that can be run as a parallel job to verify PMI, e.g.
```
$ flux mini run -n32 flux pmi barrier
ƒ4mC1JWT: completed pmi barrier on 32 tasks in 0.001s.

$ flux mini run flux pmi get flux.taskmap
{"version":1,"map":[[0,5,6,1],[5,1,2,1]]}
```