### PR TITLE
shell/stage-in: allow destination scope to be specified

### DIFF
--- a/doc/man1/flux-shell.rst
+++ b/doc/man1/flux-shell.rst
@@ -324,19 +324,27 @@ options are supported by the builtin plugins of ``flux-shell``:
   Copy files to $FLUX_JOB_TMPDIR that were previously mapped using
   :man1:`flux-filemap`.
 
-**stage-in.tags**
-  Select files to copy by specifying their tags.  By default the ``main``
-  tag is used.
+**stage-in.tags**\ =\ *LIST*
+  Select files to copy by specifying a comma-separated list of tags.
+  If no tags are specified, the ``main`` tag is assumed.
 
-**stage-in.pattern**
+**stage-in.pattern**\ =\ *PATTERN*
   Further filter the selected files to copy using a :man7:`glob` pattern.
 
-**stage-in.destdir**
-  Copy files to the specified directory instead of $FLUX_JOB_TMPDIR.  Careful!
-  The $FLUX_JOB_TMPDIR is cleaned up when the job exits, is guaranteed to
-  be unique, and is generally on fast local storage.  Make sure ``destdir``
-  does not specify a network file system or a shared directory without
-  considering the ramifications.
+**stage-in.destination**\ =\ *[SCOPE:]PATH*
+  Copy files to the specified destination instead of $FLUX_JOB_TMPDIR.
+  The argument is a directory with optional *scope* prefix.  A scope of
+  ``local`` denotes a local file system (the default), and a scope of
+  ``global`` denotes a global file system.  The copy takes place on all the
+  job's nodes if the scope is local, versus only the first node of the
+  job if the scope is global.
+
+.. warning::
+  The $FLUX_JOB_TMPDIR is cleaned up when the job ends, is guaranteed to
+  be unique, and is generally on fast local storage such as a *tmpfs*.
+  If a destination is explicitly specified, use the ``global:`` prefix
+  where appropriate to avoid overwhelming a shared file system, and be sure
+  to clean up.
 
 SHELL INITRC
 ============

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -679,3 +679,4 @@ ds
 rf
 ACLs
 SIGBUS
+tmpfs

--- a/t/t2617-job-shell-stage-in.t
+++ b/t/t2617-job-shell-stage-in.t
@@ -67,16 +67,16 @@ test_expect_success 'files that did not match pattern were not copied' '
 	grep red/small pattern.err &&
 	test_must_fail grep blue/a pattern.err
 '
-test_expect_success 'verify that stage-in.destdir works' '
+test_expect_success 'verify that stage-in.destination works' '
 	mkdir testdest &&
 	flux mini run -N1 \
-	    -o stage-in.destdir=$(pwd)/testdest \
+	    -o stage-in.destination=$(pwd)/testdest \
 	    /bin/true &&
 	test -f testdest/main/hello
 '
-test_expect_success 'verify that stage-in.destdir fails on bad dir' '
+test_expect_success 'verify that stage-in.destination fails on bad dir' '
 	test_must_fail flux mini run -N1 \
-	    -o stage-in.destdir=/noexist \
+	    -o stage-in.destination=/noexist \
 	    /bin/true
 '
 test_expect_success 'unmap all' '

--- a/t/t2617-job-shell-stage-in.t
+++ b/t/t2617-job-shell-stage-in.t
@@ -74,9 +74,29 @@ test_expect_success 'verify that stage-in.destination works' '
 	    /bin/true &&
 	test -f testdest/main/hello
 '
+test_expect_success 'verify that stage-in.destination=local:path works' '
+	rm -rf testdest/main &&
+	flux mini run -N1 \
+	    -o stage-in.destination=local:$(pwd)/testdest \
+	    /bin/true &&
+	test -f testdest/main/hello
+'
+test_expect_success 'verify that stage-in.destination=global:path works' '
+	rm -rf testdest/main &&
+	flux mini run -N2 \
+	    -o stage-in.destination=global:$(pwd)/testdest \
+	    /bin/true &&
+	test -f testdest/main/hello
+'
 test_expect_success 'verify that stage-in.destination fails on bad dir' '
 	test_must_fail flux mini run -N1 \
 	    -o stage-in.destination=/noexist \
+	    /bin/true
+'
+test_expect_success 'verify that stage-in.destination fails on bad prefix' '
+	rm -rf testdest/main &&
+	test_must_fail flux mini run -N1 \
+	    -o stage-in.destination=wrong:$(pwd)/testdest \
 	    /bin/true
 '
 test_expect_success 'unmap all' '


### PR DESCRIPTION
Problem: the stage-in plugin cannot specify a global file system as the destination, since the copy always occurs on all shells of the job.

Rename the `stage-in.destdir` option to `stage-in.destination` and allow an optional scope prefix of `global:` (denoting a global file system) or `local:` (denoting a local file system).   If the scope is _global_, the copy is only performed on the first shell.