### PR TITLE
shell: allow users to map specific cpus to tasks with `map` cpu-affinity option

### DIFF
--- a/doc/man1/flux-shell.rst
+++ b/doc/man1/flux-shell.rst
@@ -263,7 +263,11 @@ options are supported by the builtin plugins of ``flux-shell``:
 **cpu-affinity**\ =\ *OPT*
   Adjust the operation of the builtin shell ``affinity`` plugin.
   *OPT* may be set to ``off`` to disable the affinity plugin, or
-  ``per-task`` to have CPU affinity applied on a per task basis.
+  ``per-task`` to have available CPUs distributed to tasks.
+  If *OPT* starts with ``map:``, then the rest of the option is taken
+  as a semicolon-delimited list of cpus to allocate to each task. Each
+  entry in the list can be in one of the :linux:man7:`hwloc` list,
+  bitmask, or taskset formats (See :linux:man3:`hwloc_cpuset_t`).
   The default is ``on``, which binds all tasks to the assigned set
   of cores in the job.
 

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -681,3 +681,6 @@ ACLs
 SIGBUS
 tmpfs
 nocheckpoint
+CPUs
+cpuset
+taskset

--- a/src/shell/affinity.c
+++ b/src/shell/affinity.c
@@ -20,6 +20,8 @@
 #include <flux/core.h>
 #include <flux/shell.h>
 
+#include "ccan/str/str.h"
+
 #include "builtins.h"
 
 struct shell_affinity {
@@ -232,7 +234,7 @@ static bool affinity_getopt (flux_shell_t *shell, const char **resultp)
         shell_warn ("cpu-affinity: invalid option: %s", *resultp);
         return true;
     }
-    else if (strcmp (*resultp, "off") == 0)
+    else if (streq (*resultp, "off"))
         return false;
     return true;
 }
@@ -321,7 +323,7 @@ static int affinity_init (flux_plugin_t *p,
      *   resources to which the shell is now bound (from above)
      *  Set a 'task.exec' callback to actually make the per-task binding.
      */
-    if (strcmp (option, "per-task") == 0) {
+    if (streq (option, "per-task")) {
         if (!(sa->pertask = distribute_tasks (sa->topo,
                                               sa->cpuset,
                                               sa->ntasks)))


### PR DESCRIPTION
This PR adds a new mode for shell's `cpu-affinity` option which allows users to map specific cpus to tasks using a semicolon separated list. List members can be any of hwloc's supported bitmap formats, including list (like an idset), bitmap (hwloc specific bitmap format) or taskset (taskset hex bitmask format). If less entries exist in the list than tasks on the node, then entries are reused, e.g.:

```console
$ flux mini run -n3 -o cpu-affinity=map:'0-3;0xf,0x0;0xffff000000000' -N1 --exclusive sh -c 'taskset -cp $$'
1: pid 1621419's current affinity list: 32-35
0: pid 1621418's current affinity list: 0-3
2: pid 1621420's current affinity list: 36-51
```