### PR TITLE
libflux/message: cleanup with macros and CCAN pushpull class

### DIFF
--- a/src/common/libccan/Makefile.am
+++ b/src/common/libccan/Makefile.am
@@ -10,6 +10,11 @@ AM_CPPFLAGS =
 noinst_LTLIBRARIES = libccan.la
 libccan_la_SOURCES = \
 	ccan/check_type/check_type.h \
+	ccan/pushpull/pull.c \
+	ccan/pushpull/pull.h \
+	ccan/pushpull/push.c \
+	ccan/pushpull/push.h \
+	ccan/pushpull/pushpull.h \
 	ccan/str/str.c \
 	ccan/str/debug.c \
 	ccan/str/str.h \

--- a/src/common/libccan/ccan/pushpull/LICENSE
+++ b/src/common/libccan/ccan/pushpull/LICENSE
@@ -1,0 +1,1 @@
+../../licenses/CC0

--- a/src/common/libccan/ccan/pushpull/_info
+++ b/src/common/libccan/ccan/pushpull/_info
@@ -1,0 +1,76 @@
+#include "config.h"
+#include <stdio.h>
+#include <string.h>
+
+/**
+ * pushpull - simple marshalling/unmarshalling routines
+ *
+ * This code lets you clearly add simple types into a buffer (the push
+ * functions) and remove them (the pull functions).  The buffer stores
+ * the values as little-endian for machine portability.  The pull functions
+ * don't need to be checked on every call, but error state is kept so you
+ * can check if there was an error at the end.
+ *
+ * The normal way to use this is to create your own higher-level marshal
+ * and unmarshal functions in terms of these.
+ *
+ * Author: Rusty Russell <rusty@rustcorp.com.au>
+ * License: CC0 (Public domain)
+ *
+ * Example:
+ *	#include <ccan/pushpull/push.h>
+ *	#include <ccan/pushpull/pull.h>
+ *	#include <ccan/err/err.h>
+ *	#include <string.h>
+ *	#include <stdio.h>
+ *	#include <unistd.h>
+ *
+ *	int main(int argc, char *argv[])
+ *	{
+ *		if (argv[1] && !strcmp(argv[1], "push")) {
+ *			int i;
+ *			char *buf = malloc(1);
+ *			size_t len = 0;
+ *
+ *			// We ignore allocation failure!
+ *			for (i = 2; i < argc; i++)
+ *				push_u32(&buf, &len, atol(argv[i]));
+ *
+ *			write(STDOUT_FILENO, buf, len);
+ *		} else if (argc == 2 && !strcmp(argv[1], "pull")) {
+ *			int r, max = 32;
+ *			size_t len = 0;
+ *			char *buf = malloc(max);
+ *			const char *p;
+ *			uint32_t val;
+ *
+ *			while ((r = read(STDIN_FILENO, buf+len, max-len)) > 0) {
+ *				len += r;
+ *				if (len == max) {
+ *					max *= 2;
+ *					// We crash on allocation failure
+ *					buf = realloc(buf, max);
+ *				}
+ *			}
+ *
+ *			p = buf;
+ *			while (pull_u32(&p, &len, &val))
+ *				printf("%u ", val);
+ *		} else
+ *			errx(1, "Usage: %s [push|pull] [<number>...]", argv[0]);
+ *		return 0;
+ *	}
+ */
+int main(int argc, char *argv[])
+{
+	/* Expect exactly one argument */
+	if (argc != 2)
+		return 1;
+
+	if (strcmp(argv[1], "depends") == 0) {
+		printf("ccan/endian\n");
+		return 0;
+	}
+
+	return 1;
+}

--- a/src/common/libccan/ccan/pushpull/pull.c
+++ b/src/common/libccan/ccan/pushpull/pull.c
@@ -1,0 +1,105 @@
+/* CC0 license (public domain) - see LICENSE file for details */
+#include "pull.h"
+#include <ccan/endian/endian.h>
+#include <string.h>
+
+bool pull_bytes(const char **p, size_t *max_len, void *dst, size_t len)
+{
+	if (*max_len < len) {
+		*p = NULL;
+		*max_len = 0;
+		return false;
+	}
+	if (dst)
+		memcpy(dst, *p, len);
+	*max_len -= len;
+	*p += len;
+	return true;
+}
+
+bool pull_u64(const char **p, size_t *max_len, uint64_t *val)
+{
+	leint64_t v;
+
+	if (pull_bytes(p, max_len, &v, sizeof(v))) {
+		if (val)
+			*val = le64_to_cpu(v);
+		return true;
+	}
+	return false;
+}
+
+bool pull_u32(const char **p, size_t *max_len, uint32_t *val)
+{
+	leint32_t v;
+
+	if (pull_bytes(p, max_len, &v, sizeof(v))) {
+		if (val)
+			*val = le32_to_cpu(v);
+		return true;
+	}
+	return false;
+}
+
+bool pull_u16(const char **p, size_t *max_len, uint16_t *val)
+{
+	leint16_t v;
+
+	if (pull_bytes(p, max_len, &v, sizeof(v))) {
+		if (val)
+			*val = le16_to_cpu(v);
+		return true;
+	}
+	return false;
+}
+
+bool pull_u8(const char **p, size_t *max_len, uint8_t *val)
+{
+	return pull_bytes(p, max_len, val, sizeof(*val));
+}
+
+bool pull_s64(const char **p, size_t *max_len, int64_t *val)
+{
+	leint64_t v;
+
+	if (pull_bytes(p, max_len, &v, sizeof(v))) {
+		if (val)
+			*val = le64_to_cpu(v);
+		return true;
+	}
+	return false;
+}
+
+bool pull_s32(const char **p, size_t *max_len, int32_t *val)
+{
+	leint32_t v;
+
+	if (pull_bytes(p, max_len, &v, sizeof(v))) {
+		if (val)
+			*val = le32_to_cpu(v);
+		return true;
+	}
+	return false;
+}
+
+bool pull_s16(const char **p, size_t *max_len, int16_t *val)
+{
+	leint16_t v;
+
+	if (pull_bytes(p, max_len, &v, sizeof(v))) {
+		if (val)
+			*val = le16_to_cpu(v);
+		return true;
+	}
+	return false;
+}
+
+bool pull_s8(const char **p, size_t *max_len, int8_t *val)
+{
+	return pull_bytes(p, max_len, val, sizeof(*val));
+}
+
+bool pull_char(const char **p, size_t *max_len, char *val)
+{
+	return pull_bytes(p, max_len, val, sizeof(*val));
+}

--- a/src/common/libccan/ccan/pushpull/pull.h
+++ b/src/common/libccan/ccan/pushpull/pull.h
@@ -1,0 +1,140 @@
+/* CC0 license (public domain) - see LICENSE file for details */
+#ifndef CCAN_PUSHPULL_PULL_H
+#define CCAN_PUSHPULL_PULL_H
+#include "config.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+/**
+ * pull_bytes - unmarshall bytes from push_bytes.
+ * @p: pointer to bytes to unmarshal
+ * @max_len: pointer to number of bytes in unmarshal buffer
+ * @dst: destination to copy bytes (or NULL to discard)
+ * @len: length to copy into @dst.
+ *
+ * If @max_len isn't long enough, @p is set to NULL, @max_len is set to
+ * 0 (making chaining safe), and false is returned.  Otherwise, @len
+ * bytes are copied from *@p into @dst, *@p is incremented by @len,
+ * @max_len is decremented by @len, and true is returned.
+ */
+bool pull_bytes(const char **p, size_t *max_len, void *dst, size_t len);
+
+/**
+ * pull_u64 - unmarshall a little-endian 64-bit value.
+ * @p: pointer to bytes to unmarshal
+ * @max_len: pointer to number of bytes in unmarshal buffer
+ * @val: the value (or NULL to discard)
+ *
+ * This pulls 8 bytes and converts from little-endian (if necessary for
+ * this platform).  It returns false and sets @p to NULL on error (ie. not
+ * enough bytes).
+ *
+ * Example:
+ * struct foo {
+ *	uint64_t vu64;
+ *	uint32_t vu32;
+ *	uint16_t vu16;
+ *	uint8_t vu8;
+ * };
+ *
+ * static bool pull_foo(const char **p, size_t *len, struct foo *foo)
+ * {
+ * 	pull_u64(p, len, &foo->vu64);
+ * 	pull_u32(p, len, &foo->vu32);
+ * 	pull_u16(p, len, &foo->vu16);
+ * 	pull_u8(p, len, &foo->vu8);
+ *
+ *      // p is set to NULL on error (we could also use return codes)
+ *	return p != NULL;
+ * }
+ */
+bool pull_u64(const char **p, size_t *max_len, uint64_t *val);
+
+/**
+ * pull_u32 - unmarshall a little-endian 32-bit value.
+ * @p: pointer to bytes to unmarshal
+ * @max_len: pointer to number of bytes in unmarshal buffer
+ * @val: the value (or NULL to discard)
+ *
+ * This pulls 4 bytes and converts from little-endian (if necessary for
+ * this platform).
+ */
+bool pull_u32(const char **p, size_t *max_len, uint32_t *val);
+
+/**
+ * pull_u16 - unmarshall a little-endian 16-bit value.
+ * @p: pointer to bytes to unmarshal
+ * @max_len: pointer to number of bytes in unmarshal buffer
+ * @val: the value (or NULL to discard)
+ *
+ * This pulls 2 bytes and converts from little-endian (if necessary for
+ * this platform).
+ */
+bool pull_u16(const char **p, size_t *max_len, uint16_t *val);
+
+/**
+ * pull_u8 - unmarshall a single byte value.
+ * @p: pointer to bytes to unmarshal
+ * @max_len: pointer to number of bytes in unmarshal buffer
+ * @val: the value (or NULL to discard)
+ *
+ * This pulls one byte.
+ */
+bool pull_u8(const char **p, size_t *max_len, uint8_t *val);
+#define pull_uchar pull_u8
+
+/**
+ * pull_s64 - unmarshall a little-endian 64-bit signed value.
+ * @p: pointer to bytes to unmarshal
+ * @max_len: pointer to number of bytes in unmarshal buffer
+ * @val: the value (or NULL to discard)
+ *
+ * This pulls 8 bytes and converts from little-endian (if necessary for
+ * this platform).
+ */
+bool pull_s64(const char **p, size_t *max_len, int64_t *val);
+
+/**
+ * pull_s32 - unmarshall a little-endian 32-bit signed value.
+ * @p: pointer to bytes to unmarshal
+ * @max_len: pointer to number of bytes in unmarshal buffer
+ * @val: the value (or NULL to discard)
+ *
+ * This pulls 4 bytes and converts from little-endian (if necessary for
+ * this platform).
+ */
+bool pull_s32(const char **p, size_t *max_len, int32_t *val);
+
+/**
+ * pull_s16 - unmarshall a little-endian 16-bit signed value.
+ * @p: pointer to bytes to unmarshal
+ * @max_len: pointer to number of bytes in unmarshal buffer
+ * @val: the value (or NULL to discard)
+ *
+ * This pulls 2 bytes and converts from little-endian (if necessary for
+ * this platform).
+ */
+bool pull_s16(const char **p, size_t *max_len, int16_t *val);
+
+/**
+ * pull_s8 - unmarshall a single byte signed value.
+ * @p: pointer to bytes to unmarshal
+ * @max_len: pointer to number of bytes in unmarshal buffer
+ * @val: the value (or NULL to discard)
+ *
+ * This pulls one byte.
+ */
+bool pull_s8(const char **p, size_t *max_len, int8_t *val);
+
+/**
+ * pull_char - unmarshall a single char value.
+ * @p: pointer to bytes to unmarshal
+ * @max_len: pointer to number of bytes in unmarshal buffer
+ * @val: the value (or NULL to discard)
+ *
+ * This pulls one character.
+ */
+bool pull_char(const char **p, size_t *max_len, char *val);
+#endif /* CCAN_PUSHPULL_PULL_H */

--- a/src/common/libccan/ccan/pushpull/push.c
+++ b/src/common/libccan/ccan/pushpull/push.c
@@ -1,0 +1,73 @@
+/* CC0 license (public domain) - see LICENSE file for details */
+#include "push.h"
+#include <ccan/endian/endian.h>
+#include <string.h>
+
+static void *(*push_reallocfn)(void *ptr, size_t size) = realloc;
+
+bool push_bytes(char **p, size_t *len, const void *src, size_t srclen)
+{
+	char *n = push_reallocfn(*p, *len + srclen);
+	if (!n)
+		return false;
+	*p = n;
+	if (src)
+		memcpy(*p + *len, src, srclen);
+	else
+		memset(*p + *len, 0, srclen);
+	*len += srclen;
+	return true;
+}
+
+bool push_u64(char **p, size_t *len, uint64_t val)
+{
+	leint64_t v = cpu_to_le64(val);
+	return push_bytes(p, len, &v, sizeof(v));
+}
+
+bool push_u32(char **p, size_t *len, uint32_t val)
+{
+	leint32_t v = cpu_to_le32(val);
+	return push_bytes(p, len, &v, sizeof(v));
+}
+
+bool push_u16(char **p, size_t *len, uint16_t val)
+{
+	leint16_t v = cpu_to_le16(val);
+	return push_bytes(p, len, &v, sizeof(v));
+}
+
+bool push_u8(char **p, size_t *len, uint8_t val)
+{
+	return push_bytes(p, len, &val, sizeof(val));
+}
+
+bool push_s64(char **p, size_t *len, int64_t val)
+{
+	return push_u64(p, len, val);
+}
+
+bool push_s32(char **p, size_t *len, int32_t val)
+{
+	return push_u32(p, len, val);
+}
+
+bool push_s16(char **p, size_t *len, int16_t val)
+{
+	return push_u16(p, len, val);
+}
+
+bool push_s8(char **p, size_t *len, int8_t val)
+{
+	return push_u8(p, len, val);
+}
+
+bool push_char(char **p, size_t *len, char val)
+{
+	return push_u8(p, len, val);
+}
+
+void push_set_realloc(void *(*reallocfn)(void *ptr, size_t size))
+{
+	push_reallocfn = reallocfn;
+}

--- a/src/common/libccan/ccan/pushpull/push.h
+++ b/src/common/libccan/ccan/pushpull/push.h
@@ -1,0 +1,121 @@
+/* CC0 license (public domain) - see LICENSE file for details */
+#ifndef CCAN_PUSHPULL_PUSH_H
+#define CCAN_PUSHPULL_PUSH_H
+#include "config.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+/**
+ * push_bytes - marshall bytes into buffer
+ * @p: buffer of marshalled bytes
+ * @len: current length of @p buffer
+ * @src: source to copy bytes from (or NULL to copy zeroes)
+ * @srclen: length to copy from @src.
+ *
+ * If realloc() fails, false is returned.  Otherwise, *@p is increased
+ * by @srclen bytes, *@len is incremented by @srclen, and bytes appended
+ * to *@p (from @src if non-NULL).
+ */
+bool push_bytes(char **p, size_t *len, const void *src, size_t srclen);
+
+/**
+ * push_u64 - marshall a 64-bit value into buffer (as little-endian)
+ * @p: buffer of marshalled bytes
+ * @len: current length of @p buffer
+ * @val: the value to marshall.
+ *
+ * If realloc() fails, false is returned.
+ */
+bool push_u64(char **p, size_t *len, uint64_t val);
+
+/**
+ * push_u32 - marshall a 32-bit value into buffer (as little-endian)
+ * @p: buffer of marshalled bytes
+ * @len: current length of @p buffer
+ * @val: the value to marshall.
+ *
+ * If realloc() fails, false is returned.
+ */
+bool push_u32(char **p, size_t *len, uint32_t val);
+
+/**
+ * push_u16 - marshall a 16-bit value into buffer (as little-endian)
+ * @p: buffer of marshalled bytes
+ * @len: current length of @p buffer
+ * @val: the value to marshall.
+ *
+ * If realloc() fails, false is returned.
+ */
+bool push_u16(char **p, size_t *len, uint16_t val);
+
+/**
+ * push_u8 - marshall an 8-bit value into buffer
+ * @p: buffer of marshalled bytes
+ * @len: current length of @p buffer
+ * @val: the value to marshall.
+ *
+ * If realloc() fails, false is returned.
+ */
+bool push_u8(char **p, size_t *len, uint8_t val);
+#define push_uchar push_u8
+
+/**
+ * push_u64 - marshall a signed 64-bit value into buffer (as little-endian)
+ * @p: buffer of marshalled bytes
+ * @len: current length of @p buffer
+ * @val: the value to marshall.
+ *
+ * If realloc() fails, false is returned.
+ */
+bool push_s64(char **p, size_t *len, int64_t val);
+
+/**
+ * push_u32 - marshall a signed 32-bit value into buffer (as little-endian)
+ * @p: buffer of marshalled bytes
+ * @len: current length of @p buffer
+ * @val: the value to marshall.
+ *
+ * If realloc() fails, false is returned.
+ */
+bool push_s32(char **p, size_t *len, int32_t val);
+
+/**
+ * push_u16 - marshall a signed 16-bit value into buffer (as little-endian)
+ * @p: buffer of marshalled bytes
+ * @len: current length of @p buffer
+ * @val: the value to marshall.
+ *
+ * If realloc() fails, false is returned.
+ */
+bool push_s16(char **p, size_t *len, int16_t val);
+
+/**
+ * push_u8 - marshall a signed 8-bit value into buffer
+ * @p: buffer of marshalled bytes
+ * @len: current length of @p buffer
+ * @val: the value to marshall.
+ *
+ * If realloc() fails, false is returned.
+ */
+bool push_s8(char **p, size_t *len, int8_t val);
+
+/**
+ * push_char - marshall a character into buffer
+ * @p: buffer of marshalled bytes
+ * @len: current length of @p buffer
+ * @val: the value to marshall.
+ *
+ * If realloc() fails, false is returned.
+ */
+bool push_char(char **p, size_t *len, char val);
+
+/**
+ * push_set_realloc - set function to use (instead of realloc).
+ * @reallocfn: new reallocation function.
+ *
+ * This can be used, for example, to cache reallocations.
+ */
+void push_set_realloc(void *(reallocfn)(void *ptr, size_t size));
+#endif /* CCAN_PUSHPULL_PUSH_H */

--- a/src/common/libccan/ccan/pushpull/pushpull.h
+++ b/src/common/libccan/ccan/pushpull/pushpull.h
@@ -1,0 +1,7 @@
+/* CC0 license (public domain) - see LICENSE file for details */
+#ifndef CCAN_PUSHPULL_H
+#define CCAN_PUSHPULL_H
+/* You can also include these independently, if you don't need both. */
+#include <ccan/pushpull/push.h>
+#include <ccan/pushpull/pull.h>
+#endif /* CCAN_PUSHPULL_H */

--- a/src/common/libccan/ccan/pushpull/test/run.c
+++ b/src/common/libccan/ccan/pushpull/test/run.c
@@ -1,0 +1,150 @@
+#include <ccan/pushpull/pushpull.h>
+/* Include the C files directly. */
+#include <ccan/pushpull/push.c>
+#include <ccan/pushpull/pull.c>
+#include <ccan/tap/tap.h>
+
+struct foo {
+	uint64_t vu64;
+	uint32_t vu32;
+	uint16_t vu16;
+	uint8_t vu8;
+	unsigned char vuchar;
+	int64_t vs64;
+	int32_t vs32;
+	int16_t vs16;
+	int8_t vs8;
+	char vchar;
+	char bytes[100];
+};
+
+static void *fail_reallocfn(void *ptr, size_t size)
+{
+	return NULL;
+}
+
+static bool push_foo(char **p, size_t *len, const struct foo *foo)
+{
+	return push_u64(p, len, foo->vu64) &&
+		push_u32(p, len, foo->vu32) &&
+		push_u16(p, len, foo->vu16) &&
+		push_u8(p, len, foo->vu8) &&
+		push_uchar(p, len, foo->vuchar) &&
+		push_s64(p, len, foo->vs64) &&
+		push_s32(p, len, foo->vs32) &&
+		push_s16(p, len, foo->vs16) &&
+		push_s8(p, len, foo->vs8) &&
+		push_char(p, len, foo->vchar) &&
+		push_bytes(p, len, foo->bytes, sizeof(foo->bytes));
+}
+
+static bool pull_foo(const char **p, size_t *len, struct foo *foo)
+{
+	int ret;
+
+	ret = pull_u64(p, len, &foo->vu64) +
+		pull_u32(p, len, &foo->vu32) +
+		pull_u16(p, len, &foo->vu16) +
+		pull_u8(p, len, &foo->vu8) +
+		pull_uchar(p, len, &foo->vuchar) +
+		pull_s64(p, len, &foo->vs64) +
+		pull_s32(p, len, &foo->vs32) +
+		pull_s16(p, len, &foo->vs16) +
+		pull_s8(p, len, &foo->vs8) +
+		pull_char(p, len, &foo->vchar) +
+		pull_bytes(p, len, foo->bytes, sizeof(foo->bytes));
+
+	if (ret != 11)
+		ok1(len == 0 && *p == NULL);
+	return ret == 11;
+}
+
+static bool foo_equal(const struct foo *f1, const struct foo *f2)
+{
+	return f1->vu64 == f2->vu64 &&
+		f1->vu32 == f2->vu32 &&
+		f1->vu16 == f2->vu16 &&
+		f1->vu8 == f2->vu8 &&
+		f1->vuchar == f2->vuchar &&
+		f1->vs64 == f2->vs64 &&
+		f1->vs32 == f2->vs32 &&
+		f1->vs16 == f2->vs16 &&
+		f1->vs8 == f2->vs8 &&
+		f1->vchar == f2->vchar &&
+		memcmp(f1->bytes, f2->bytes, sizeof(f1->bytes)) == 0;
+}
+
+int main(void)
+{
+	char *buffer;
+	const char *p;
+	size_t len, left;
+	struct foo *foo, *foo2;
+
+	/* This is how many tests you plan to run */
+	plan_tests(17);
+
+	/* Valgrind will make sure we don't read padding! */
+	foo = malloc(sizeof(*foo));
+	foo->vu64 = 0x01020304050607ULL;
+	foo->vu32 = 0x08090a0b;
+	foo->vu16 = 0x0c0d;
+	foo->vu8 = 0x0e;
+	foo->vuchar = 0x0f;
+	foo->vs64 = -0x1011121314151617LL;
+	foo->vs32 = -0x18191a1b;
+	foo->vs16 = -0x1c1d;
+	foo->vs8 = -0x1e;
+	foo->vchar = -0x1f;
+	memset(foo->bytes, 0x20, sizeof(foo->bytes));
+	strcpy(foo->bytes, "This is a test");
+
+	buffer = malloc(1);
+	len = 0;
+	ok1(push_foo(&buffer, &len, foo));
+	ok1(len <= sizeof(*foo));
+
+	/* Triggers valgrind's uninitialized value warning */
+	ok1(!memchr(buffer, 0x21, len));
+
+	p = buffer;
+	left = len;
+	foo2 = malloc(sizeof(*foo2));
+	ok1(pull_foo(&p, &left, foo2));
+	ok1(left == 0);
+	ok1(p == buffer + len);
+	ok1(foo_equal(foo, foo2));
+
+	/* Too-small for pull, it should fail and set ptr/len to 0 */
+	p = buffer;
+	left = 0;
+	ok1(!pull_u64(&p, &left, &foo2->vu64));
+	ok1(p == NULL && left == 0);
+	/* Shouldn't change field! */
+	ok1(foo_equal(foo, foo2));
+
+	left = 7;
+	ok1(!pull_u64(&p, &left, &foo2->vu64));
+	ok1(p == NULL && left == 0);
+	/* Shouldn't change field! */
+	ok1(foo_equal(foo, foo2));
+
+	/* Discard should work. */
+	left = len;
+	ok1(pull_bytes(&p, &left, NULL, sizeof(foo->bytes)));
+	ok1(left == len - sizeof(foo->bytes));
+
+	/* Push failures should be clean. */
+	push_set_realloc(fail_reallocfn);
+	p = buffer;
+	left = len;
+	ok1(!push_u64(&buffer, &left, foo->vu64));
+	ok1(p == buffer && left == len);
+
+	free(buffer);
+	free(foo);
+	free(foo2);
+
+	/* This exits depending on whether all tests passed */
+	return exit_status();
+}

--- a/src/common/libflux/message.c
+++ b/src/common/libflux/message.c
@@ -263,11 +263,11 @@ int flux_msg_encode (const flux_msg_t *msg, void *buf, size_t size)
             return -1;
         total += n;
     }
-    msg_proto_setup (msg, proto, PROTO_SIZE);
-    if ((n = encode_frame (buf + total,
-                           size - total,
-                           proto,
-                           PROTO_SIZE)) < 0)
+    if (proto_encode (&msg->proto, proto, PROTO_SIZE) < 0
+        || (n = encode_frame (buf + total,
+                              size - total,
+                              proto,
+                              PROTO_SIZE)) < 0)
         return -1;
     total += n;
     return 0;

--- a/src/common/libflux/message_iovec.c
+++ b/src/common/libflux/message_iovec.c
@@ -48,12 +48,8 @@ int iovec_to_msg (flux_msg_t *msg,
         || proto_data[PROTO_OFF_VERSION] != PROTO_VERSION) {
         errno = EPROTO;
         return -1;
-    }
     msg->proto.type = proto_data[PROTO_OFF_TYPE];
-    if (msg->proto.type != FLUX_MSGTYPE_REQUEST
-        && msg->proto.type != FLUX_MSGTYPE_RESPONSE
-        && msg->proto.type != FLUX_MSGTYPE_EVENT
-        && msg->proto.type != FLUX_MSGTYPE_CONTROL) {
+    if (!msg_type_is_valid (msg)) {
         errno = EPROTO;
         return -1;
     }
@@ -122,7 +118,7 @@ int msg_to_iovec (const flux_msg_t *msg,
     int frame_count;
 
     /* msg never completed initial setup */
-    if (msg->proto.type == FLUX_MSGTYPE_ANY) {
+    if (!msg_type_is_valid (msg)) {
         errno = EPROTO;
         return -1;
     }

--- a/src/common/libflux/message_iovec.c
+++ b/src/common/libflux/message_iovec.c
@@ -49,17 +49,17 @@ int iovec_to_msg (flux_msg_t *msg,
         errno = EPROTO;
         return -1;
     }
-    msg->type = proto_data[PROTO_OFF_TYPE];
-    if (msg->type != FLUX_MSGTYPE_REQUEST
-        && msg->type != FLUX_MSGTYPE_RESPONSE
-        && msg->type != FLUX_MSGTYPE_EVENT
-        && msg->type != FLUX_MSGTYPE_CONTROL) {
+    msg->proto.type = proto_data[PROTO_OFF_TYPE];
+    if (msg->proto.type != FLUX_MSGTYPE_REQUEST
+        && msg->proto.type != FLUX_MSGTYPE_RESPONSE
+        && msg->proto.type != FLUX_MSGTYPE_EVENT
+        && msg->proto.type != FLUX_MSGTYPE_CONTROL) {
         errno = EPROTO;
         return -1;
     }
-    msg->flags = proto_data[PROTO_OFF_FLAGS];
+    msg->proto.flags = proto_data[PROTO_OFF_FLAGS];
 
-    if ((msg->flags & FLUX_MSGFLAG_ROUTE)) {
+    if ((msg->proto.flags & FLUX_MSGFLAG_ROUTE)) {
         /* On first access index == 0 && iovcnt > 0 guaranteed
          * Re-add check if code changes. */
         /* if (index == iovcnt) { */
@@ -76,7 +76,7 @@ int iovec_to_msg (flux_msg_t *msg,
         if (index < iovcnt)
             index++;
     }
-    if ((msg->flags & FLUX_MSGFLAG_TOPIC)) {
+    if ((msg->proto.flags & FLUX_MSGFLAG_TOPIC)) {
         if (index == iovcnt) {
             errno = EPROTO;
             return -1;
@@ -87,7 +87,7 @@ int iovec_to_msg (flux_msg_t *msg,
         if (index < iovcnt)
             index++;
     }
-    if ((msg->flags & FLUX_MSGFLAG_PAYLOAD)) {
+    if ((msg->proto.flags & FLUX_MSGFLAG_PAYLOAD)) {
         if (index == iovcnt) {
             errno = EPROTO;
             return -1;
@@ -104,10 +104,10 @@ int iovec_to_msg (flux_msg_t *msg,
         errno = EPROTO;
         return -1;
     }
-    proto_get_u32 (proto_data, PROTO_IND_USERID, &msg->userid);
-    proto_get_u32 (proto_data, PROTO_IND_ROLEMASK, &msg->rolemask);
-    proto_get_u32 (proto_data, PROTO_IND_AUX1, &msg->aux1);
-    proto_get_u32 (proto_data, PROTO_IND_AUX2, &msg->aux2);
+    proto_get_u32 (proto_data, PROTO_IND_USERID, &msg->proto.userid);
+    proto_get_u32 (proto_data, PROTO_IND_ROLEMASK, &msg->proto.rolemask);
+    proto_get_u32 (proto_data, PROTO_IND_AUX1, &msg->proto.aux1);
+    proto_get_u32 (proto_data, PROTO_IND_AUX2, &msg->proto.aux2);
     return 0;
 }
 
@@ -122,7 +122,7 @@ int msg_to_iovec (const flux_msg_t *msg,
     int frame_count;
 
     /* msg never completed initial setup */
-    if (msg->type == FLUX_MSGTYPE_ANY) {
+    if (msg->proto.type == FLUX_MSGTYPE_ANY) {
         errno = EPROTO;
         return -1;
     }
@@ -141,19 +141,19 @@ int msg_to_iovec (const flux_msg_t *msg,
     msg_proto_setup (msg, proto, proto_len);
     iov[index].data = proto;
     iov[index].size = PROTO_SIZE;
-    if (msg->flags & FLUX_MSGFLAG_PAYLOAD) {
+    if (msg->proto.flags & FLUX_MSGFLAG_PAYLOAD) {
         index--;
         assert (index >= 0);
         iov[index].data = msg->payload;
         iov[index].size = msg->payload_size;
     }
-    if (msg->flags & FLUX_MSGFLAG_TOPIC) {
+    if (msg->proto.flags & FLUX_MSGFLAG_TOPIC) {
         index--;
         assert (index >= 0);
         iov[index].data = msg->topic;
         iov[index].size = strlen (msg->topic);
     }
-    if (msg->flags & FLUX_MSGFLAG_ROUTE) {
+    if (msg->proto.flags & FLUX_MSGFLAG_ROUTE) {
         struct route_id *r = NULL;
         /* delimeter */
         index--;

--- a/src/common/libflux/message_iovec.c
+++ b/src/common/libflux/message_iovec.c
@@ -55,7 +55,7 @@ int iovec_to_msg (flux_msg_t *msg,
     }
     msg->proto.flags = proto_data[PROTO_OFF_FLAGS];
 
-    if ((msg->proto.flags & FLUX_MSGFLAG_ROUTE)) {
+    if (msg_has_route (msg)) {
         /* On first access index == 0 && iovcnt > 0 guaranteed
          * Re-add check if code changes. */
         /* if (index == iovcnt) { */
@@ -72,7 +72,7 @@ int iovec_to_msg (flux_msg_t *msg,
         if (index < iovcnt)
             index++;
     }
-    if ((msg->proto.flags & FLUX_MSGFLAG_TOPIC)) {
+    if (msg_has_topic (msg)) {
         if (index == iovcnt) {
             errno = EPROTO;
             return -1;
@@ -83,7 +83,7 @@ int iovec_to_msg (flux_msg_t *msg,
         if (index < iovcnt)
             index++;
     }
-    if ((msg->proto.flags & FLUX_MSGFLAG_PAYLOAD)) {
+    if (msg_has_payload (msg)) {
         if (index == iovcnt) {
             errno = EPROTO;
             return -1;
@@ -137,19 +137,19 @@ int msg_to_iovec (const flux_msg_t *msg,
     msg_proto_setup (msg, proto, proto_len);
     iov[index].data = proto;
     iov[index].size = PROTO_SIZE;
-    if (msg->proto.flags & FLUX_MSGFLAG_PAYLOAD) {
+    if (msg_has_payload (msg)) {
         index--;
         assert (index >= 0);
         iov[index].data = msg->payload;
         iov[index].size = msg->payload_size;
     }
-    if (msg->proto.flags & FLUX_MSGFLAG_TOPIC) {
+    if (msg_has_topic (msg)) {
         index--;
         assert (index >= 0);
         iov[index].data = msg->topic;
         iov[index].size = strlen (msg->topic);
     }
-    if (msg->proto.flags & FLUX_MSGFLAG_ROUTE) {
+    if (msg_has_route (msg)) {
         struct route_id *r = NULL;
         /* delimeter */
         index--;

--- a/src/common/libflux/message_private.h
+++ b/src/common/libflux/message_private.h
@@ -20,6 +20,8 @@
 #endif
 #include "src/common/libccan/ccan/list/list.h"
 
+#include "message_proto.h"
+
 struct flux_msg {
     // optional route list, if FLUX_MSGFLAG_ROUTE
     struct list_head routes;
@@ -33,22 +35,7 @@ struct flux_msg {
     size_t payload_size;
 
     // required proto frame data
-    uint8_t type;
-    uint8_t flags;
-    uint32_t userid;
-    uint32_t rolemask;
-    union {
-        uint32_t nodeid;  // request
-        uint32_t sequence; // event
-        uint32_t errnum; // response
-        uint32_t control_type; // control
-        uint32_t aux1; // common accessor
-    };
-    union {
-        uint32_t matchtag; // request, response
-        uint32_t control_status; // control
-        uint32_t aux2; // common accessor
-    };
+    struct proto proto;
 
     json_t *json;
     char *lasterr;

--- a/src/common/libflux/message_private.h
+++ b/src/common/libflux/message_private.h
@@ -43,6 +43,17 @@ struct flux_msg {
     int refcount;
 };
 
+#define msgtype_is_valid(tp) \
+    ((tp) == FLUX_MSGTYPE_REQUEST || (tp) == FLUX_MSGTYPE_RESPONSE \
+     || (tp) == FLUX_MSGTYPE_EVENT || (tp) == FLUX_MSGTYPE_CONTROL)
+
+#define msg_typeof(msg)         ((msg)->proto.type)
+#define msg_type_is_valid(msg)  (msgtype_is_valid (msg_typeof (msg)))
+#define msg_is_request(msg)     (msg_typeof(msg) == FLUX_MSGTYPE_REQUEST)
+#define msg_is_response(msg)    (msg_typeof(msg) == FLUX_MSGTYPE_RESPONSE)
+#define msg_is_event(msg)       (msg_typeof(msg) == FLUX_MSGTYPE_EVENT)
+#define msg_is_control(msg)     (msg_typeof(msg) == FLUX_MSGTYPE_CONTROL)
+
 #endif /* !_FLUX_CORE_MESSAGE_PRIVATE_H */
 
 /*

--- a/src/common/libflux/message_private.h
+++ b/src/common/libflux/message_private.h
@@ -54,6 +54,26 @@ struct flux_msg {
 #define msg_is_event(msg)       (msg_typeof(msg) == FLUX_MSGTYPE_EVENT)
 #define msg_is_control(msg)     (msg_typeof(msg) == FLUX_MSGTYPE_CONTROL)
 
+#define msg_has_flag(msg,flag)  ((msg)->proto.flags & (flag))
+#define msg_set_flag(msg,flag)  ((msg)->proto.flags |= (flag))
+#define msg_clear_flag(msg,flag) \
+                                ((msg)->proto.flags &= ~(flag))
+#define msg_has_topic(msg)      (msg_has_flag(msg, FLUX_MSGFLAG_TOPIC))
+#define msg_has_payload(msg)    (msg_has_flag(msg, FLUX_MSGFLAG_PAYLOAD))
+#define msg_has_noresponse(msg) (msg_has_flag(msg, FLUX_MSGFLAG_NORESPONSE))
+#define msg_has_route(msg)      (msg_has_flag(msg, FLUX_MSGFLAG_ROUTE))
+#define msg_has_upstream(msg)   (msg_has_flag(msg, FLUX_MSGFLAG_UPSTREAM))
+#define msg_has_private(msg)    (msg_has_flag(msg, FLUX_MSGFLAG_PRIVATE))
+#define msg_has_streaming(msg)  (msg_has_flag(msg, FLUX_MSGFLAG_STREAMING))
+#define msg_has_user1(msg)      (msg_has_flag(msg, FLUX_MSGFLAG_USER1))
+
+#define msgflags_is_valid(fl) \
+    (((fl) & ~(FLUX_MSGFLAG_TOPIC | FLUX_MSGFLAG_PAYLOAD | FLUX_MSGFLAG_ROUTE \
+     | FLUX_MSGFLAG_UPSTREAM | FLUX_MSGFLAG_PRIVATE | FLUX_MSGFLAG_STREAMING \
+     | FLUX_MSGFLAG_NORESPONSE | FLUX_MSGFLAG_USER1)) == 0 \
+     && !(((fl) & FLUX_MSGFLAG_NORESPONSE) && ((fl) & FLUX_MSGFLAG_STREAMING)))
+#define msg_flags_is_valid(msg) (msgflags_is_valid ((msg)->proto.flags))
+
 #endif /* !_FLUX_CORE_MESSAGE_PRIVATE_H */
 
 /*

--- a/src/common/libflux/message_proto.c
+++ b/src/common/libflux/message_proto.c
@@ -32,7 +32,7 @@ static void proto_set_u32 (uint8_t *data, int index, uint32_t val)
 void msg_proto_setup (const flux_msg_t *msg, uint8_t *data, int len)
 {
     assert (len >= PROTO_SIZE);
-    assert (msg->proto.type != FLUX_MSGTYPE_ANY);
+    assert (msg_type_is_valid (msg));
     memset (data, 0, len);
     data[PROTO_OFF_MAGIC] = PROTO_MAGIC;
     data[PROTO_OFF_VERSION] = PROTO_VERSION;

--- a/src/common/libflux/message_proto.c
+++ b/src/common/libflux/message_proto.c
@@ -8,51 +8,72 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
+/* message_proto.c - marshal RFC 3 PROTO frame */
+
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
 #include <errno.h>
-#include <stdbool.h>
-#include <string.h>
-#include <arpa/inet.h>
-#include <assert.h>
-#include <inttypes.h>
 
-#include "message.h"
-#include "message_private.h"
+#include "ccan/pushpull/pushpull.h"
+
 #include "message_proto.h"
 
-static void proto_set_u32 (uint8_t *data, int index, uint32_t val)
-{
-    uint32_t x = htonl (val);
-    int offset = PROTO_OFF_U32_ARRAY + index * 4;
-    memcpy (&data[offset], &x, sizeof (x));
-}
-
-void msg_proto_setup (const flux_msg_t *msg, uint8_t *data, int len)
-{
-    assert (len >= PROTO_SIZE);
-    assert (msg_type_is_valid (msg));
-    memset (data, 0, len);
-    data[PROTO_OFF_MAGIC] = PROTO_MAGIC;
-    data[PROTO_OFF_VERSION] = PROTO_VERSION;
-    data[PROTO_OFF_TYPE] = msg->proto.type;
-    data[PROTO_OFF_FLAGS] = msg->proto.flags;
-    proto_set_u32 (data, PROTO_IND_USERID, msg->proto.userid);
-    proto_set_u32 (data, PROTO_IND_ROLEMASK, msg->proto.rolemask);
-    proto_set_u32 (data, PROTO_IND_AUX1, msg->proto.aux1);
-    proto_set_u32 (data, PROTO_IND_AUX2, msg->proto.aux2);
-}
-
-void proto_get_u32 (const uint8_t *data, int index, uint32_t *val)
-{
-    uint32_t x;
-    int offset = PROTO_OFF_U32_ARRAY + index * 4;
-    memcpy (&x, &data[offset], sizeof (x));
-    *val = ntohl (x);
-}
-
-/*
- * vi:tabstop=4 shiftwidth=4 expandtab
+/* Realloc(3) replacement for push() that simply returns the pointer, unless
+ * the requested length exceeds the fixed size of an encoded proto frame.
+ * It assumes proto_encode() has received a static buffer >= PROTO_SIZE.
  */
+static void *proto_realloc (void *ptr, size_t len)
+{
+    if (len > PROTO_SIZE)
+        return NULL;
+    return ptr;
+}
 
+int proto_encode (const struct proto *proto, void *buf, size_t size)
+{
+    char *cp = buf;
+    size_t len = 0;
+
+    push_set_realloc (proto_realloc);
+
+    if (size < PROTO_SIZE
+        || !push_u8 (&cp, &len, PROTO_MAGIC)
+        || !push_u8 (&cp, &len, PROTO_VERSION)
+        || !push_u8 (&cp, &len, proto->type)
+        || !push_u8 (&cp, &len, proto->flags)
+        || !push_u32 (&cp, &len, proto->userid)
+        || !push_u32 (&cp, &len, proto->rolemask)
+        || !push_u32 (&cp, &len, proto->aux1)
+        || !push_u32 (&cp, &len, proto->aux2)
+        || len < size) {
+        errno = EINVAL;
+        return -1;
+    }
+    return 0;
+}
+
+int proto_decode (struct proto *proto, const void *buf, size_t size)
+{
+    const char *cp = buf;
+    size_t len = size;
+    uint8_t magic, version;
+
+    if (!pull_u8 (&cp, &len, &magic)
+        || magic != PROTO_MAGIC
+        || !pull_u8 (&cp, &len, &version)
+        || version != PROTO_VERSION
+        || !pull_u8 (&cp, &len, &proto->type)
+        || !pull_u8 (&cp, &len, &proto->flags)
+        || !pull_u32 (&cp, &len, &proto->userid)
+        || !pull_u32 (&cp, &len, &proto->rolemask)
+        || !pull_u32 (&cp, &len, &proto->aux1)
+        || !pull_u32 (&cp, &len, &proto->aux2)
+        || len > 0) {
+        errno = EPROTO;
+        return -1;
+    }
+    return 0;
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/src/common/libflux/message_proto.c
+++ b/src/common/libflux/message_proto.c
@@ -32,16 +32,16 @@ static void proto_set_u32 (uint8_t *data, int index, uint32_t val)
 void msg_proto_setup (const flux_msg_t *msg, uint8_t *data, int len)
 {
     assert (len >= PROTO_SIZE);
-    assert (msg->type != FLUX_MSGTYPE_ANY);
+    assert (msg->proto.type != FLUX_MSGTYPE_ANY);
     memset (data, 0, len);
     data[PROTO_OFF_MAGIC] = PROTO_MAGIC;
     data[PROTO_OFF_VERSION] = PROTO_VERSION;
-    data[PROTO_OFF_TYPE] = msg->type;
-    data[PROTO_OFF_FLAGS] = msg->flags;
-    proto_set_u32 (data, PROTO_IND_USERID, msg->userid);
-    proto_set_u32 (data, PROTO_IND_ROLEMASK, msg->rolemask);
-    proto_set_u32 (data, PROTO_IND_AUX1, msg->aux1);
-    proto_set_u32 (data, PROTO_IND_AUX2, msg->aux2);
+    data[PROTO_OFF_TYPE] = msg->proto.type;
+    data[PROTO_OFF_FLAGS] = msg->proto.flags;
+    proto_set_u32 (data, PROTO_IND_USERID, msg->proto.userid);
+    proto_set_u32 (data, PROTO_IND_ROLEMASK, msg->proto.rolemask);
+    proto_set_u32 (data, PROTO_IND_AUX1, msg->proto.aux1);
+    proto_set_u32 (data, PROTO_IND_AUX2, msg->proto.aux2);
 }
 
 void proto_get_u32 (const uint8_t *data, int index, uint32_t *val)

--- a/src/common/libflux/message_proto.h
+++ b/src/common/libflux/message_proto.h
@@ -11,39 +11,9 @@
 #ifndef _FLUX_CORE_MESSAGE_PROTO_H
 #define _FLUX_CORE_MESSAGE_PROTO_H
 
-/* PROTO consists of 4 byte prelude followed by a fixed length
- * array of u32's in network byte order.
- */
 #define PROTO_MAGIC         0x8e
 #define PROTO_VERSION       1
-
-#define PROTO_OFF_MAGIC     0 /* 1 byte */
-#define PROTO_OFF_VERSION   1 /* 1 byte */
-#define PROTO_OFF_TYPE      2 /* 1 byte */
-#define PROTO_OFF_FLAGS     3 /* 1 byte */
-#define PROTO_OFF_U32_ARRAY 4
-
-/* aux1
- *
- * request - nodeid
- * response - errnum
- * event - sequence
- * control - type
- *
- * aux2
- *
- * request - matchtag
- * response - matchtag
- * event - not used
- * control - status
- */
-#define PROTO_IND_USERID    0
-#define PROTO_IND_ROLEMASK  1
-#define PROTO_IND_AUX1      2
-#define PROTO_IND_AUX2      3
-
-#define PROTO_U32_COUNT     4
-#define PROTO_SIZE          4 + (PROTO_U32_COUNT * 4)
+#define PROTO_SIZE          20
 
 struct proto {
     uint8_t type;
@@ -64,13 +34,9 @@ struct proto {
     };
 };
 
-void msg_proto_setup (const flux_msg_t *msg, uint8_t *data, int len);
-
-void proto_get_u32 (const uint8_t *data, int index, uint32_t *val);
+int proto_encode (const struct proto *proto, void *buf, size_t size);
+int proto_decode (struct proto *proto, const void *buf, size_t size);
 
 #endif /* !_FLUX_CORE_MESSAGE_PROTO_H */
 
-/*
- * vi:tabstop=4 shiftwidth=4 expandtab
- */
-
+// vi:ts=4 sw=4 expandtab

--- a/src/common/libflux/message_proto.h
+++ b/src/common/libflux/message_proto.h
@@ -45,6 +45,25 @@
 #define PROTO_U32_COUNT     4
 #define PROTO_SIZE          4 + (PROTO_U32_COUNT * 4)
 
+struct proto {
+    uint8_t type;
+    uint8_t flags;
+    uint32_t userid;
+    uint32_t rolemask;
+    union {
+        uint32_t nodeid;  // request
+        uint32_t sequence; // event
+        uint32_t errnum; // response
+        uint32_t control_type; // control
+        uint32_t aux1; // common accessor
+    };
+    union {
+        uint32_t matchtag; // request, response
+        uint32_t control_status; // control
+        uint32_t aux2; // common accessor
+    };
+};
+
 void msg_proto_setup (const flux_msg_t *msg, uint8_t *data, int len);
 
 void proto_get_u32 (const uint8_t *data, int index, uint32_t *val);

--- a/src/common/libflux/message_route.c
+++ b/src/common/libflux/message_route.c
@@ -60,7 +60,7 @@ int msg_route_append (flux_msg_t *msg,
 {
     struct route_id *r;
     assert (msg);
-    assert ((msg->flags & FLUX_MSGFLAG_ROUTE));
+    assert ((msg->proto.flags & FLUX_MSGFLAG_ROUTE));
     assert (id);
     if (!(r = route_id_create (id, id_len)))
         return -1;
@@ -73,7 +73,7 @@ void msg_route_clear (flux_msg_t *msg)
 {
     struct route_id *r;
     assert (msg);
-    assert ((msg->flags & FLUX_MSGFLAG_ROUTE));
+    assert ((msg->proto.flags & FLUX_MSGFLAG_ROUTE));
     while ((r = list_pop (&msg->routes, struct route_id, route_id_node)))
         route_id_destroy (r);
     list_head_init (&msg->routes);
@@ -84,7 +84,7 @@ int msg_route_delete_last (flux_msg_t *msg)
 {
     struct route_id *r;
     assert (msg);
-    assert ((msg->flags & FLUX_MSGFLAG_ROUTE));
+    assert ((msg->proto.flags & FLUX_MSGFLAG_ROUTE));
     if ((r = list_pop (&msg->routes, struct route_id, route_id_node))) {
         route_id_destroy (r);
         msg->routes_len--;

--- a/src/common/libflux/message_route.c
+++ b/src/common/libflux/message_route.c
@@ -60,7 +60,7 @@ int msg_route_append (flux_msg_t *msg,
 {
     struct route_id *r;
     assert (msg);
-    assert ((msg->proto.flags & FLUX_MSGFLAG_ROUTE));
+    assert (msg_has_route (msg));
     assert (id);
     if (!(r = route_id_create (id, id_len)))
         return -1;
@@ -73,7 +73,7 @@ void msg_route_clear (flux_msg_t *msg)
 {
     struct route_id *r;
     assert (msg);
-    assert ((msg->proto.flags & FLUX_MSGFLAG_ROUTE));
+    assert (msg_has_route (msg));
     while ((r = list_pop (&msg->routes, struct route_id, route_id_node)))
         route_id_destroy (r);
     list_head_init (&msg->routes);
@@ -84,7 +84,7 @@ int msg_route_delete_last (flux_msg_t *msg)
 {
     struct route_id *r;
     assert (msg);
-    assert ((msg->proto.flags & FLUX_MSGFLAG_ROUTE));
+    assert (msg_has_route (msg));
     if ((r = list_pop (&msg->routes, struct route_id, route_id_node))) {
         route_id_destroy (r);
         msg->routes_len--;


### PR DESCRIPTION
Problem: the Flux message PROTO frame (described in [RFC 3](https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/spec_3.html)) codec is not self contained.

I came across the CCAN "pushpull" class and it seemed like a good way to clean up the PROTO codec.  Now it just looks like this:
```c
int proto_encode (const struct proto *proto, void *buf, size_t size)
{
    char *cp = buf;
    size_t len = 0;

    fixed_size = size;
    push_set_realloc (proto_realloc);

    if (!push_u8 (&cp, &len, PROTO_MAGIC)
        || !push_u8 (&cp, &len, PROTO_VERSION)
        || !push_u8 (&cp, &len, proto->type)
        || !push_u8 (&cp, &len, proto->flags)
        || !push_u32 (&cp, &len, proto->userid)
        || !push_u32 (&cp, &len, proto->rolemask)
        || !push_u32 (&cp, &len, proto->aux1)
        || !push_u32 (&cp, &len, proto->aux2)
        || len < size) {
        errno = EINVAL;
        return -1;
    }
    return 0;
}

int proto_decode (struct proto *proto, const void *buf, size_t size)
{
    const char *cp = buf;
    size_t len = size;
    uint8_t magic, version;

    if (!pull_u8 (&cp, &len, &magic)
        || magic != PROTO_MAGIC
        || !pull_u8 (&cp, &len, &version)
        || version != PROTO_VERSION
        || !pull_u8 (&cp, &len, &proto->type)
        || !pull_u8 (&cp, &len, &proto->flags)
        || !pull_u32 (&cp, &len, &proto->userid)
        || !pull_u32 (&cp, &len, &proto->rolemask)
        || !pull_u32 (&cp, &len, &proto->aux1)
        || !pull_u32 (&cp, &len, &proto->aux2)
        || len > 0) {
        errno = EPROTO;
        return -1;
    }
    return 0;
}
```
I also added some private macros to `message_private.h` to clean up the flags and message type checks which are highly repetitive and tedious around the message code.