### PR TITLE
build: fix installation of libpmi*.so

### DIFF
--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -84,7 +84,8 @@ fluxlib_LTLIBRARIES = libpmi.la libpmi2.la
 #
 #  ref: https://debbugs.gnu.org/cgi/bugreport.cgi?bug=7328
 #
-install-fluxlibLTLIBRARIES: $(install-libLTLIBRARIES)
+install_fluxlibLTLIBRARIES = install-fluxlibLTLIBRARIES
+$(install_fluxlibLTLIBRARIES): install-libLTLIBRARIES
 
 libflux_core_la_SOURCES =
 libflux_core_la_LIBADD = \


### PR DESCRIPTION
Problem: Commit 90d4af5fdd357d180dafa7ed101e8b99896a0962 attempted to fix a race condition during `make install` that could cause relinking of libpmi*.so to fail when used with `make -j`, but the fix wasn't implemented properly and instead the PMI libraries were not installed at all.

The problem with the original fix appears to be that it registers a duplicate rule:

 install-fluxlibLTLIBRARIES: $(install-libLTLIBRARIES)

which prevents the _real_ install rule from appearing in Makefile.in. Instead, this fix uses what appears to be proposed in the suggested workaround here:

  https://debbugs.gnu.org/cgi/bugreport.cgi?bug=7328

which I don't completely understand, but first assigns the rule name to a variable, then uses the variable to make the new rule with a dependency on install-libLTLIBRARIES. This appears to work around the issue of the disappearing real installation rule.