### PR TITLE
testsuite: fix failure on a system with fully-qualified hostname

### DIFF
--- a/t/t2616-job-shell-taskmap.t
+++ b/t/t2616-job-shell-taskmap.t
@@ -31,7 +31,7 @@ test_expect_success 'flux job taskmap works' '
 	test "$(flux job taskmap --taskids=0 $id)" = "0-3" &&
 	test "$(flux job taskmap --ntasks=0 $id)" = "4" &&
 	test "$(flux job taskmap --nodeid=15 $id)" = "3" &&
-	test "$(flux job taskmap --hostname=0 $id)" = "$(hostname -s)" &&
+	test "$(flux job taskmap --hostname=0 $id)" = "$(hostname)" &&
 	test "$(flux job taskmap --to=pmi $id)" = "(vector,(0,4,4))"
 '
 test_expect_success 'flux job taskmap works with taskmap on cmdline' '


### PR DESCRIPTION
Problem: In t2616-job-shell-taskmap.t an expected hostname is compared to `hostname -s` which breaks the test on systems with a fully-qualified hostname.

Drop the `-s` argument to hostname to make the test more reliable.