### PR TITLE
NEWS.md: Add release notes for v0.46.1

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,13 @@
+flux-core version 0.46.1 - 2022-12-11
+-------------------------------------
+
+## Fixes
+ * build: fix installation of libpmi.so (#4824)
+ * testsuite: fix failure on a system with fully-qualified hostname (#4825)
+
+## Cleanup
+ * libflux/message: cleanup with macros and CCAN pushpull class (#4823)
+
 flux-core version 0.46.0 - 2022-12-10
 -------------------------------------
 


### PR DESCRIPTION
Because of the issue fixed by #4824 (libpmi*.so not installed with `make install`), we need to release a 0.46.1. This PR adds release notes for that version.