### PR TITLE
flux-job: fix potential segfault

### DIFF
--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -395,6 +395,7 @@ static struct optparse_option taskmap_opts[] = {
       .usage = "Convert an RFC 34 taskmap to another format "
                "(FORMAT can be raw, pmi, or multiline)",
     },
+    OPTPARSE_TABLE_END
 };
 
 static struct optparse_subcommand subcommands[] = {


### PR DESCRIPTION
Another mistake by me in the 0.46.0 release. I don't know how we're getting away with this one in most situations. I only found it when attempting to transition the coverage builds to fedora35.