### PR TITLE
flux-top: add extra test coverage

### DIFF
--- a/src/cmd/top/joblist_pane.c
+++ b/src/cmd/top/joblist_pane.c
@@ -159,7 +159,7 @@ void joblist_pane_draw (struct joblist_pane *joblist)
             wattron (joblist->win, A_REVERSE);
         if (uri != NULL)
             wattron (joblist->win, COLOR_PAIR(TOP_COLOR_BLUE) | A_BOLD);
-        if (joblist->show_queue)
+        if (joblist->show_queue) {
             mvwprintw (joblist->win,
                        1 + index,
                        0,
@@ -174,7 +174,19 @@ void joblist_pane_draw (struct joblist_pane *joblist)
                        name_width,
                        name_width,
                        name);
-        else
+            if (joblist->top->testf)
+                fprintf (joblist->top->testf,
+                         "%s %s %s %s %d %d %s %s\n",
+                         idstr,
+                         queue,
+                         username,
+                         flux_job_statetostr (state, "S"),
+                         ntasks,
+                         nnodes,
+                         run,
+                         name);
+        }
+        else {
             mvwprintw (joblist->win,
                        1 + index,
                        0,
@@ -188,6 +200,17 @@ void joblist_pane_draw (struct joblist_pane *joblist)
                        name_width,
                        name_width,
                        name);
+            if (joblist->top->testf)
+                fprintf (joblist->top->testf,
+                         "%s %s %s %d %d %s %s\n",
+                         idstr,
+                         username,
+                         flux_job_statetostr (state, "S"),
+                         ntasks,
+                         nnodes,
+                         run,
+                         name);
+        }
         wattroff (joblist->win, A_REVERSE);
         wattroff (joblist->win, COLOR_PAIR(TOP_COLOR_BLUE) | A_BOLD);
     }

--- a/src/cmd/top/joblist_pane.c
+++ b/src/cmd/top/joblist_pane.c
@@ -210,7 +210,7 @@ static void joblist_continuation (flux_future_t *f, void *arg)
     if (joblist->top->test_exit) {
         /* Ensure joblist window is refreshed before exiting */
         wrefresh (joblist->win);
-        flux_reactor_stop (flux_future_get_reactor (f));
+        test_exit_check (joblist->top);
     }
     flux_future_destroy (f);
 }

--- a/src/cmd/top/summary_pane.c
+++ b/src/cmd/top/summary_pane.c
@@ -46,6 +46,7 @@ struct stats {
     int run;
     int cleanup;
     int inactive;
+    int successful;
     int failed;
     int canceled;
     int timeout;
@@ -138,7 +139,7 @@ static void draw_stats (struct summary_pane *sum)
 
     if (sum->show_details) {
         int failed = sum->stats.failed;
-        int complete = sum->stats.inactive - failed;
+        int complete = sum->stats.successful;
 
         if (complete)
             wattron (sum->win, COLOR_PAIR(TOP_COLOR_GREEN) | A_BOLD);
@@ -384,7 +385,8 @@ static void stats_continuation (flux_future_t *f, void *arg)
     struct summary_pane *sum = arg;
 
     if (flux_rpc_get_unpack (f,
-                             "{s:i s:i s:i s:{s:i s:i s:i s:i s:i s:i s:i}}",
+                             "{s:i s:i s:i s:i s:{s:i s:i s:i s:i s:i s:i s:i}}",
+                             "successful", &sum->stats.successful,
                              "failed", &sum->stats.failed,
                              "canceled", &sum->stats.canceled,
                              "timeout", &sum->stats.timeout,

--- a/src/cmd/top/summary_pane.c
+++ b/src/cmd/top/summary_pane.c
@@ -395,7 +395,7 @@ static void stats_continuation (flux_future_t *f, void *arg)
                                "run", &sum->stats.run,
                                "cleanup", &sum->stats.cleanup,
                                "inactive", &sum->stats.inactive,
-                               "total", &sum->stats.total)) {
+                               "total", &sum->stats.total) < 0) {
         if (errno != ENOSYS)
             fatal (errno, "error decoding job-list.job-stats RPC response");
     }

--- a/src/cmd/top/summary_pane.c
+++ b/src/cmd/top/summary_pane.c
@@ -378,6 +378,11 @@ static void resource_continuation (flux_future_t *f, void *arg)
     flux_future_destroy (f);
     sum->f_resource = NULL;
     draw_resource (sum);
+    if (sum->top->test_exit) {
+        /* Ensure resources are refreshed before exiting */
+        wnoutrefresh (sum->win);
+        test_exit_check (sum->top);
+    }
 }
 
 static void stats_continuation (flux_future_t *f, void *arg)
@@ -404,6 +409,11 @@ static void stats_continuation (flux_future_t *f, void *arg)
     flux_future_destroy (f);
     sum->f_stats = NULL;
     draw_stats (sum);
+    if (sum->top->test_exit) {
+        /* Ensure stats is refreshed before exiting */
+        wnoutrefresh (sum->win);
+        test_exit_check (sum->top);
+    }
 }
 
 static void heartblink_cb (flux_reactor_t *r,

--- a/src/cmd/top/summary_pane.c
+++ b/src/cmd/top/summary_pane.c
@@ -137,6 +137,15 @@ static void draw_stats (struct summary_pane *sum)
                stats_dim.x_length - 10,
                sum->stats.run + sum->stats.cleanup);
 
+    if (sum->top->testf) {
+        fprintf (sum->top->testf,
+                 "%d pending\n",
+                 sum->stats.depend + sum->stats.priority + sum->stats.sched);
+        fprintf (sum->top->testf,
+                 "%d running\n",
+                 sum->stats.run + sum->stats.cleanup);
+    }
+
     if (sum->show_details) {
         int failed = sum->stats.failed;
         int complete = sum->stats.successful;
@@ -167,6 +176,15 @@ static void draw_stats (struct summary_pane *sum)
                    stats_dim.y_begin + 2,
                    stats_dim.x_begin + 5,
                    " failed");
+
+        if (sum->top->testf) {
+            fprintf (sum->top->testf,
+                     "%d complete\n",
+                     complete);
+            fprintf (sum->top->testf,
+                     "%d failed\n",
+                     failed);
+        }
     }
     else {
         mvwprintw (sum->win,
@@ -175,6 +193,11 @@ static void draw_stats (struct summary_pane *sum)
                    "%*d inactive",
                    stats_dim.x_length - 10,
                    sum->stats.inactive);
+        if (sum->top->testf) {
+            fprintf (sum->top->testf,
+                     "%d inactive\n",
+                     sum->stats.inactive);
+        }
     }
 }
 
@@ -183,7 +206,7 @@ static void draw_stats (struct summary_pane *sum)
  * "used" grows from the left in yellow; "down" grows from the right in red.
  * Fraction is used/total.
  */
-static void draw_bargraph (WINDOW *win, int y, int x, int x_length,
+static void draw_bargraph (struct summary_pane *sum, int y, int x, int x_length,
                            const char *name, struct resource_count res)
 {
     char prefix[16];
@@ -198,7 +221,7 @@ static void draw_bargraph (WINDOW *win, int y, int x, int x_length,
     snprintf (suffix, sizeof (suffix), "%d/%d]", res.used, res.total);
 
     int slots = x_length - strlen (prefix) - strlen (suffix) - 1;
-    mvwprintw (win,
+    mvwprintw (sum->win,
                y,
                x,
                "%s%*s%s",
@@ -206,35 +229,42 @@ static void draw_bargraph (WINDOW *win, int y, int x, int x_length,
                slots, "",
                suffix);
     /* Graph used */
-    wattron (win, COLOR_PAIR (TOP_COLOR_YELLOW));
+    wattron (sum->win, COLOR_PAIR (TOP_COLOR_YELLOW));
     for (int i = 0; i < ceil (((double)res.used / res.total) * slots); i++)
-        mvwaddch (win, y, x + strlen (prefix) + i, '|');
-    wattroff (win, COLOR_PAIR (TOP_COLOR_YELLOW));
+        mvwaddch (sum->win, y, x + strlen (prefix) + i, '|');
+    wattroff (sum->win, COLOR_PAIR (TOP_COLOR_YELLOW));
 
     /* Graph down */
-    wattron (win, COLOR_PAIR (TOP_COLOR_RED));
+    wattron (sum->win, COLOR_PAIR (TOP_COLOR_RED));
     for (int i = slots - 1;
          i >= slots - ceil (((double)res.down / res.total) * slots); i--) {
-        mvwaddch (win, y, x + strlen (prefix) + i, '|');
+        mvwaddch (sum->win, y, x + strlen (prefix) + i, '|');
     }
-    wattroff (win, COLOR_PAIR (TOP_COLOR_RED));
+    wattroff (sum->win, COLOR_PAIR (TOP_COLOR_RED));
+
+    if (sum->top->testf)
+        fprintf (sum->top->testf,
+                 "%s %d/%d\n",
+                 name,
+                 res.used,
+                 res.total);
 }
 
 static void draw_resource (struct summary_pane *sum)
 {
-    draw_bargraph (sum->win,
+    draw_bargraph (sum,
                    resource_dim.y_begin,
                    resource_dim.x_begin,
                    resource_dim.x_length,
                    "nodes",
                    sum->node);
-    draw_bargraph (sum->win,
+    draw_bargraph (sum,
                    resource_dim.y_begin + 1,
                    resource_dim.x_begin,
                    resource_dim.x_length,
                    "cores",
                    sum->core);
-    draw_bargraph (sum->win,
+    draw_bargraph (sum,
                    resource_dim.y_begin + 2,
                    resource_dim.x_begin,
                    resource_dim.x_length,

--- a/src/cmd/top/top.c
+++ b/src/cmd/top/top.c
@@ -190,6 +190,8 @@ void top_destroy (struct top *top)
         joblist_pane_destroy (top->joblist_pane);
         summary_pane_destroy (top->summary_pane);
         keys_destroy (top->keys);
+        if (top->testf)
+            fclose (top->testf);
         flux_close (top->h);
         free (top->title);
         free (top);
@@ -270,6 +272,10 @@ static struct optparse_option cmdopts[] = {
     { .name = "test-exit", .has_arg = 0, .flags = OPTPARSE_OPT_HIDDEN,
       .usage = "Exit after screen initialization, for testing",
     },
+    { .name = "test-exit-dump", .has_arg = 1, .arginfo = "FILE",
+      .flags = OPTPARSE_OPT_HIDDEN,
+      .usage = "Dump joblist/summary data to file for testing",
+    },
     OPTPARSE_TABLE_END,
 };
 
@@ -307,8 +313,16 @@ int main (int argc, char *argv[])
 
     if (!(top = top_create (target, NULL, &error)))
         fatal (0, "%s", error.text);
-    if (optparse_hasopt (opts, "test-exit"))
+    if (optparse_hasopt (opts, "test-exit")) {
+        const char *file;
         top->test_exit = 1;
+        if ((file = optparse_get_str (opts, "test-exit-dump", NULL))) {
+            mode_t umask_orig = umask (022);
+            if (!(top->testf = fopen (file, "w+")))
+                fatal (errno, "failed to open test dump file");
+            umask (umask_orig);
+        }
+    }
     if (top_run (top, reactor_flags) < 0)
         fatal (errno, "reactor loop unexpectedly terminated");
 

--- a/src/cmd/top/top.c
+++ b/src/cmd/top/top.c
@@ -164,6 +164,17 @@ int top_run (struct top *top, int reactor_flags)
     return flux_reactor_run (flux_get_reactor (top->h), reactor_flags);
 }
 
+void test_exit_check (struct top *top)
+{
+    /* 3 exit counts for
+     * - joblist output
+     * - summary stats output
+     * - summary resource output
+     */
+    if (top->test_exit && ++top->test_exit_count == 3)
+        flux_reactor_stop (flux_get_reactor (top->h));
+}
+
 static const struct flux_msg_handler_spec htab[] = {
     { FLUX_MSGTYPE_EVENT, "job-state", job_state_cb, 0 },
     { FLUX_MSGTYPE_EVENT, "heartbeat.pulse", heartbeat_cb, 0 },

--- a/src/cmd/top/top.h
+++ b/src/cmd/top/top.h
@@ -33,6 +33,7 @@ struct top {
 
     unsigned int test_exit:1;    /*  Exit after first joblist pane update */
     unsigned int test_exit_count;
+    FILE *testf;
 
     uint32_t size;
     struct summary_pane *summary_pane;

--- a/src/cmd/top/top.h
+++ b/src/cmd/top/top.h
@@ -32,6 +32,7 @@ struct top {
     flux_jobid_t id;
 
     unsigned int test_exit:1;    /*  Exit after first joblist pane update */
+    unsigned int test_exit_count;
 
     uint32_t size;
     struct summary_pane *summary_pane;
@@ -55,6 +56,7 @@ struct top *top_create (const char *uri,
                         flux_error_t *errp);
 void top_destroy (struct top *top);
 int top_run (struct top *top, int reactor_flags);
+void test_exit_check (struct top *top);
 
 struct summary_pane *summary_pane_create (struct top *top);
 void summary_pane_destroy (struct summary_pane *sum);

--- a/src/modules/sched-simple/sched.c
+++ b/src/modules/sched-simple/sched.c
@@ -570,7 +570,7 @@ static void status_cb (flux_t *h, flux_msg_handler_t *mh,
      */
     if (!(rl = rlist_copy_allocated (ss->rlist))
         || !(alloc = rlist_to_R (rl))) {
-        flux_log_error (h, "faile to create list of allocated resources");
+        flux_log_error (h, "failed to create list of allocated resources");
         goto err;
     }
     rlist_destroy (rl);

--- a/t/t2801-top-cmd.t
+++ b/t/t2801-top-cmd.t
@@ -78,8 +78,9 @@ test_expect_success 'flux-top fails if TERM is not supported' '
 test_expect_success 'submit batch script and wait for it to start' '
 	cat >batch.sh <<-EOT &&
 	#!/bin/sh
+	flux mini submit --wait-event=start sleep 300
 	touch job2-has-started
-	flux mini run sleep 300
+	flux queue drain
 	EOT
 	chmod +x batch.sh &&
 	flux mini batch -t30m -n1 batch.sh >jobid2 &&

--- a/t/t2801-top-cmd.t
+++ b/t/t2801-top-cmd.t
@@ -128,6 +128,11 @@ test_expect_success NO_CHAIN_LINT 'flux-top does not exit on recursive failure' 
 	        --input=recurse-fail.in flux top &&
 	grep -qi "error connecting to Flux" recurse-fail.log
 '
+test_expect_success 'cleanup running jobs' '
+	flux job cancel $(cat jobid2) $(cat jobid3) &&
+	flux job wait-event $(cat jobid2) clean &&
+	flux job wait-event $(cat jobid3) clean
+'
 test_expect_success 'configure a test queue' '
 	flux config load <<-EOT
 	[queues.testq]


### PR DESCRIPTION
in preparation for queue support in `flux-top` I would need some extra testing ability.  Wanted to add testing coverage under non-queue circumstances first, but hit some snags, thus this PR resulting in some cleanup, fixes to allow easier / more testing, add more tests.

I think the only iffy commit here may be the `test-exit after summary output refreshed` commit.  I admittedly took a very lazy approach to dealing with this.  I felt adding some type of "completion_ref" count system like done in the shell would have been overkill.
