### PR TITLE
libtaskmap: add TASKMAP_ENCODE_RAW_DERANGED

### DIFF
--- a/src/common/libtaskmap/taskmap.c
+++ b/src/common/libtaskmap/taskmap.c
@@ -700,8 +700,10 @@ static char *taskmap_encode_raw (const struct taskmap *map)
         char *s = NULL;
         if (!(ids = taskmap_taskids (map, i))
             || !(s = idset_encode (ids, IDSET_FLAG_RANGE))
-            || append_to_zlistx (l, s) < 0)
+            || append_to_zlistx (l, s) < 0) {
+            ERRNO_SAFE_WRAP (free, s);
             goto error;
+        }
     }
     result = list_join (l, ";");
 error:

--- a/src/common/libtaskmap/taskmap.h
+++ b/src/common/libtaskmap/taskmap.h
@@ -22,6 +22,7 @@ enum taskmap_flags {
     TASKMAP_ENCODE_WRAPPED = 1,      /* Encode as RFC 34 wrapped object      */
     TASKMAP_ENCODE_PMI =     1 << 1, /* Encode as PMI-1 PMI_process_mapping  */
     TASKMAP_ENCODE_RAW =     1 << 2, /* Encode as semicolon-delimited taskids*/
+    TASKMAP_ENCODE_RAW_DERANGED = 1 << 3, /* Encode as raw without ranges    */
 };
 
 /*  Create an empty taskmap

--- a/src/common/libtaskmap/test/taskmap.c
+++ b/src/common/libtaskmap/test/taskmap.c
@@ -537,6 +537,22 @@ static void test_check ()
     }
 }
 
+void test_deranged (void)
+{
+    struct taskmap *map;
+    flux_error_t error;
+    char *s;
+
+    if (!(map = taskmap_decode ("[[0,4,4,1]]", &error)))
+        BAIL_OUT ("taskmap_decode: %s", error.text);
+    ok ((s = taskmap_encode (map, TASKMAP_ENCODE_RAW_DERANGED)) != NULL,
+        "taskmap_encode RAW_DERANGED works");
+    is (s, "0,1,2,3;4,5,6,7;8,9,10,11;12,13,14,15",
+        "and result is deranged");
+    free (s);
+    taskmap_destroy (map);
+}
+
 int main (int ac, char **av)
 {
     plan (NO_PLAN);
@@ -548,6 +564,7 @@ int main (int ac, char **av)
     append_cyclic_test ();
     append_cyclic_one ();
     test_check ();
+    test_deranged ();
     done_testing ();
 }
 


### PR DESCRIPTION
Problem: flux-pmix needs the taskmap in raw form, without the idset ranges.
    
Add a flag to trivially generate the raw taskmaps without ranges.   

This will allow some [code](https://github.com/flux-framework/flux-pmix/blob/main/src/shell/plugins/maps.c#L51) over there to just fetch the taskmap directly and encode it without the extra machinations.
