### PR TITLE
flux-top: Support --color option

### DIFF
--- a/doc/man1/flux-jobs.rst
+++ b/doc/man1/flux-jobs.rst
@@ -69,9 +69,10 @@ OPTIONS
    section for more details. A configuration snippet for an existing
    named format may be generated with ``--format=get-config=NAME``.
 
-**--color**\ *=WHEN*
-   Control output coloring. WHEN can be *never*, *always*, or *auto*.
-   Defaults to *auto*.
+**--color**\ *[=WHEN]*
+   Control output coloring.  The optional argument *WHEN* can be
+   *auto*, *never*, or *always*.  If *WHEN* is omitted, it defaults to
+   *always*.  Otherwise the default is *auto*.
 
 **--stats**
    Output a summary of job statistics before the header.  By default

--- a/doc/man1/flux-top.rst
+++ b/doc/man1/flux-top.rst
@@ -8,7 +8,7 @@ flux-top(1)
 SYNOPSIS
 ========
 
-**flux** **top** [*TARGET*]
+**flux** **top** [*OPTIONS*] [*TARGET*]
 
 
 DESCRIPTION
@@ -21,6 +21,18 @@ as described in :man1:`flux-uri`.
 
 The ``flux-top`` display window is divided into two parts:  the summary pane,
 and the job listing pane, which are described in detail below.
+
+
+OPTIONS
+=======
+
+**-h, --help**
+   Summarize available options.
+
+**--color**\ *[=WHEN]*
+   Colorize output.  The optional argument *WHEN* can be *auto*, *never*,
+   or *always*.  If *WHEN* is omitted, it defaults to *always*. The default
+   value when the **--color** option is not used is *auto*.
 
 
 KEYS

--- a/src/cmd/flux-jobs.py
+++ b/src/cmd/flux-jobs.py
@@ -298,6 +298,8 @@ def parse_args():
         type=str,
         metavar="WHEN",
         choices=["never", "always", "auto"],
+        nargs="?",
+        const="always",
         default="auto",
         help="Colorize output; WHEN can be 'never', 'always', or 'auto' (default)",
     )

--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -1108,7 +1108,7 @@ grey_line_count() {
 	grep -c -o "\\u001b\[37m" $1 || true
 }
 
-for opt in "" "--color=always" "--color=auto"; do
+for opt in "" "--color" "--color=always" "--color=auto"; do
 	test_expect_success "flux-jobs $opt color works (pty)" '
 		name=${opt##--color=} &&
 		outfile=color-${name:-default}.out &&

--- a/t/t2801-top-cmd.t
+++ b/t/t2801-top-cmd.t
@@ -75,6 +75,15 @@ test_expect_success 'flux-top fails if TERM is not supported' '
 	test_must_fail $runpty --term=dumb --stderr=dumb.err flux top &&
 	grep "terminal does not support required capabilities" dumb.err
 '
+test_expect_success 'flux-top --color options work' '
+	$runpty flux top --color --test-exit >/dev/null &&
+	$runpty flux top --color=auto --test-exit >/dev/null &&
+	$runpty flux top --color=always --test-exit >/dev/null &&
+	$runpty flux top --color=never --test-exit >/dev/null
+'
+test_expect_success 'flux-top --color fails with bad input' '
+	test_must_fail $runpty flux top --color=foo --test-exit >/dev/null
+'
 test_expect_success 'submit batch script and wait for it to start' '
 	cat >batch.sh <<-EOT &&
 	#!/bin/sh


### PR DESCRIPTION
per a user request.  Also tweaked the `--color` option to ensure it matched the `--color` option in `flux-dmesg` a bit more.

Note that `-L` option in `flux-dmesg` is already used by `flux-jobs`'s `--level` option, so we're going with `--color` should be allowed, but only `-L` in `flux-dmesg`.