### PR TITLE
flux-shell: add -opmi=off option

### DIFF
--- a/doc/man1/flux-mini.rst
+++ b/doc/man1/flux-mini.rst
@@ -756,13 +756,10 @@ overridden in some cases:
    each task will run in the process group of the shell. This will cause
    signals to be delivered only to direct children of the shell.
 
-**pmi.kvs=native**
-   Use the native Flux KVS instead of the PMI plugin's built-in key exchange
-   algorithm.
-
-**pmi.exchange.k=N**
-   Configure the PMI plugin's built-in key exchange algorithm to use a
-   virtual tree fanout of ``N`` for key gather/broadcast.  The default is 2.
+**pmi=off**
+   Disable the process management interface (PMI-1) which is required for
+   bootstrapping most parallel program environments.  See :man1:`flux-shell`
+   for more pmi options.
 
 **stage-in**
    Copy files previously mapped with :man1:`flux-filemap` to $FLUX_JOB_TMPDIR.

--- a/doc/man1/flux-shell.rst
+++ b/doc/man1/flux-shell.rst
@@ -324,6 +324,21 @@ options are supported by the builtin plugins of ``flux-shell``:
   this will also be passed to the invoked plugin. Normally, this option will
   be set by the ``flux mini --taskmap`` option.
 
+**pmi=off**
+  Disable the process management interface (PMI-1) which is required for
+  bootstrapping most parallel program environments.
+
+**pmi.nomap**
+  Skip populating the PMI ``flux.taskmap`` and ``PMI_process_mapping`` keys.
+
+**pmi.kvs=native**
+  Use the native Flux KVS instead of the PMI plugin's built-in key exchange
+  algorithm.
+
+**pmi.exchange.k=N**
+  Configure the PMI plugin's built-in key exchange algorithm to use a
+  virtual tree fanout of ``N`` for key gather/broadcast.  The default is 2.
+
 **stage-in**
   Copy files to $FLUX_JOB_TMPDIR that were previously mapped using
   :man1:`flux-filemap`.

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -684,3 +684,4 @@ nocheckpoint
 CPUs
 cpuset
 taskset
+nomap

--- a/t/t3002-pmi.t
+++ b/t/t3002-pmi.t
@@ -14,6 +14,22 @@ kvstest2=${FLUX_BUILD_DIR}/src/common/libpmi/test_kvstest2
 pmi_info=${FLUX_BUILD_DIR}/src/common/libpmi/test_pmi_info
 pmi2_info=${FLUX_BUILD_DIR}/src/common/libpmi/test_pmi2_info
 
+test_expect_success 'flux mini run -o pmi=badopt fails' '
+	test_must_fail flux mini run -o pmi=badopt /bin/true
+'
+test_expect_success 'flux mini run -o pmi.badopt fails' '
+	test_must_fail flux mini run -o pmi.badopt /bin/true
+'
+test_expect_success 'flux mini run -o pmi.exchange.badopt fails' '
+	test_must_fail flux mini run -o pmi.exchange.badopt /bin/true
+'
+test_expect_success 'flux mini run -o pmi.exchange.k=foo fails' '
+	test_must_fail flux mini run -o pmi.exchange.k=foo /bin/true
+'
+test_expect_success 'flux mini run -o pmi.nomap=foo fails' '
+	test_must_fail flux mini run -o pmi.nomap=foo /bin/true
+'
+
 test_expect_success 'pmi_info works' '
 	flux mini run -n${SIZE} -N${SIZE} ${pmi_info}
 '
@@ -161,6 +177,10 @@ test_expect_success 'flux-pmi --method=simple fails outside of job' '
 test_expect_success 'flux-pmi -v --method=simple works within job' '
 	flux mini run --label-io -n2 flux pmi -v --method=simple barrier
 '
+test_expect_success 'flux-pmi -opmi=off --method=simple fails' '
+	test_must_fail flux mini run -o pmi=off \
+	    flux pmi --method=simple barrier
+'
 # method=libpmi
 test_expect_success 'flux-pmi --method=libpmi:/bad/path fails' '
 	test_must_fail flux mini run \
@@ -207,5 +227,8 @@ test_expect_success 'flux-pmi --method=single exchange works' '
 test_expect_success 'flux-pmi --method=single get notakey fails' '
 	test_must_fail flux pmi --method=single get notakey
 '
-
+test_expect_success 'flux-pmi -opmi=off --method=single works' '
+	flux mini run -o pmi=off \
+	    flux pmi --method=single barrier
+'
 test_done


### PR DESCRIPTION
Problem: there is no way to disable the flux-shell's PMI-1 server, but this may be useful when testing other process manager interfaces like pmix.

Add `-opmi=off` and improve the robustness of the pmi shell plugin option parsing.