### PR TITLE
flux-top: honor FLUX_F58_FORCE_ASCII 

### DIFF
--- a/src/cmd/top/summary_pane.c
+++ b/src/cmd/top/summary_pane.c
@@ -96,7 +96,11 @@ static void draw_timeleft (struct summary_pane *sum)
 static void draw_f (struct summary_pane *sum)
 {
     wattron (sum->win, COLOR_PAIR (TOP_COLOR_YELLOW));
-    mvwprintw (sum->win, level_dim.y_begin, level_dim.x_begin, "ƒ");
+    mvwprintw (sum->win,
+               level_dim.y_begin,
+               level_dim.x_begin,
+               "%s",
+               sum->top->f_char);
     wattroff (sum->win, COLOR_PAIR (TOP_COLOR_YELLOW));
 }
 

--- a/src/cmd/top/top.c
+++ b/src/cmd/top/top.c
@@ -262,6 +262,11 @@ struct top *top_create (const char *uri,
     top->keys = keys_create (top);
     top->summary_pane = summary_pane_create (top);
     top->joblist_pane = joblist_pane_create (top);
+
+    if (getenv ("FLUX_F58_FORCE_ASCII"))
+        top->f_char = "f";
+    else
+        top->f_char = "ƒ";
     return top;
 fail:
     top_destroy (top);

--- a/src/cmd/top/top.h
+++ b/src/cmd/top/top.h
@@ -34,6 +34,7 @@ struct top {
     unsigned int test_exit:1;    /*  Exit after first joblist pane update */
     unsigned int test_exit_count;
     FILE *testf;
+    const char *f_char;
 
     uint32_t size;
     struct summary_pane *summary_pane;

--- a/t/t2801-top-cmd.t
+++ b/t/t2801-top-cmd.t
@@ -203,6 +203,10 @@ test_expect_success 'flux-top shows jobs canceled' '
 	test_must_fail grep "batch.sh" canceledjobs.out &&
 	test_must_fail grep "bash" canceledjobs.out
 '
+test_expect_success NO_CHAIN_LINT 'flux-top works with FLUX_F58_FORCE_ASCII' '
+       FLUX_F58_FORCE_ASCII=1 $runpty -f asciicast -o normalf.log \
+			      flux top --test-exit
+'
 test_expect_success 'configure a test queue' '
 	flux config load <<-EOT
 	[queues.testq]


### PR DESCRIPTION
Problem: flux-top does not honor the FLUX_F58_FORCE_ASCII environment variable and outputs ƒ ("fancy-f") all the time.

Output "f" instead of ƒ when FLUX_F58_FORCE_ASCII is set.

Fixes https://github.com/flux-framework/flux-core/issues/4837

Note, I added one dumb test for coverage, borderline maybe isn't even necessary.  Ultimately grepping for ƒ from the `flux-top` was hard given whatever format curses + runpty ultimately put things in.  Grepping for normal-f seemed pointless given there's going to be a bunch of `f` anyways via normal hex output.