### PR TITLE
add tools for querying job remaining time: `flux_job_timeleft(3)`, python `flux.job.timeleft()` and `flux-job timeleft`

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -128,7 +128,8 @@ MAN3_FILES_PRIMARY = \
 	man3/idset_encode.3 \
 	man3/idset_add.3 \
 	man3/flux_jobtap_get_flux.3 \
-	man3/flux_sync_create.3
+	man3/flux_sync_create.3 \
+	man3/flux_job_timeleft.3
 
 
 # These files are generated as clones of a primary page.

--- a/doc/man1/flux-job.rst
+++ b/doc/man1/flux-job.rst
@@ -22,6 +22,8 @@ SYNOPSIS
 
 **flux** **job** **taskmap** [*OPTIONS*] *id*|*taskmap*
 
+**flux** **job** **timeleft** [*OPTIONS*] [*id*]
+
 **flux** **job** **purge** [*OPTIONS*]
 
 DESCRIPTION
@@ -142,6 +144,23 @@ support task mapping formats:
    *multiline* which prints the node ID of each task, one per line.
 
 One one of the above options may be used per call.
+
+TIMELEFT
+========
+
+The ``flux job timeleft`` utility reports the number of whole seconds left
+in the current or specified job time limit. If the job has expired or is
+complete, then this command reports ``0``. If the job does not have a time
+limit, then a large number (``UINT_MAX``) is reported.
+
+If ``flux job timeleft`` is called outside the context of a Flux job, or
+an invalid or pending job is targeted, then this command will exit with
+an error and diagnostic message.
+
+Options:
+
+**-H, --human**
+  Generate human readable output. Report results in Flux Standard Duration.
 
 PURGE
 =====

--- a/doc/man3/flux_job_timeleft.rst
+++ b/doc/man3/flux_job_timeleft.rst
@@ -1,0 +1,43 @@
+====================
+flux_job_timeleft(3)
+====================
+
+
+SYNOPSIS
+========
+
+::
+
+   #include <flux/core.h>
+
+::
+
+   int flux_job_timeleft (flux_t *h,
+                          flux_error_t *error,
+                          double *timeleft);
+
+DESCRIPTION
+===========
+
+The ``flux_job_timeleft()`` function determines if the calling process
+is executing within the context of a Flux job (either a parallel job or
+a Flux instance running as a job), then handles querying the appropriate
+service for the remaining time in the job.
+
+RETURN VALUE
+============
+
+``flux_job_timeleft()`` returns 0 on success with the remaining time in
+floating point seconds stored in ``timeleft``. If the job does not have
+an established time limit, then ``timeleft`` is set to ``inf``. If the job
+time limit has expired or the job is no longer running, then ``timeleft``
+is set to ``0``.
+
+If the current process is not part of an active job or instance, or another
+error occurs, then this function returns ``-1`` with an error string set in
+``error->text``.
+
+RESOURCES
+=========
+
+Flux: http://flux-framework.org

--- a/doc/man3/index.rst
+++ b/doc/man3/index.rst
@@ -76,6 +76,7 @@ man3
    idset_encode
    idset_add
    flux_jobtap_get_flux
+   flux_job_timeleft
 
 .. toctree::
    :hidden:

--- a/doc/manpages.py
+++ b/doc/manpages.py
@@ -278,6 +278,7 @@ man_pages = [
     ('man3/flux_jobtap_get_flux','flux_jobtap_priority_unavail', 'Flux jobtap plugin interfaces', [author], 3),
     ('man3/flux_jobtap_get_flux','flux_jobtap_reject_job', 'Flux jobtap plugin interfaces', [author], 3),
     ('man3/flux_sync_create','flux_sync_create', 'Synchronize on system heartbeat', [author], 3),
+    ('man3/flux_job_timeleft','flux_job_timeleft', 'Get remaining time for a job', [author], 3),
     ('man5/flux-config', 'flux-config', 'Flux configuration files', [author], 5),
     ('man5/flux-config-access', 'flux-config-access', 'configure Flux instance access', [author], 5),
     ('man5/flux-config-bootstrap', 'flux-config-bootstrap', 'configure Flux instance bootstrap', [author], 5),

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -685,3 +685,4 @@ CPUs
 cpuset
 taskset
 nomap
+timeleft

--- a/src/bindings/python/flux/Makefile.am
+++ b/src/bindings/python/flux/Makefile.am
@@ -23,8 +23,9 @@ nobase_fluxpy_PYTHON = \
 	job/kvs.py \
 	job/list.py \
 	job/info.py \
-	job/submit.py \
 	job/wait.py \
+	job/submit.py \
+	job/timeleft.py \
 	job/stats.py \
 	job/_wrapper.py \
 	job/executor.py \

--- a/src/bindings/python/flux/job/__init__.py
+++ b/src/bindings/python/flux/job/__init__.py
@@ -29,4 +29,5 @@ from flux.job.executor import (
     FluxExecutor,
     FluxExecutorFuture,
 )
+from flux.job.timeleft import timeleft
 from flux.core.inner import ffi

--- a/src/bindings/python/flux/job/timeleft.py
+++ b/src/bindings/python/flux/job/timeleft.py
@@ -1,0 +1,37 @@
+###############################################################
+# Copyright 2022 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+import flux
+from _flux._core import ffi
+from flux.job._wrapper import _RAW as RAW
+
+
+def timeleft(flux_handle=None):
+    """
+    Return the remaining time in floating point seconds for the current
+    job or enclosing instance.
+
+    If the calling process is not associated with a job, then an exception
+    will be raised. If the job associated with the current process has no
+    timelimit, then ``float(inf)`` is returned.
+
+    If a Flux handle is not provided, then this function will open a
+    handle to the enclosing instance.
+    """
+    if flux_handle is None:
+        flux_handle = flux.Flux()
+
+    error = ffi.new("flux_error_t[1]")
+    result = ffi.new("double[1]")
+    try:
+        RAW.timeleft(flux_handle, error, result)
+    except OSError as err:
+        raise OSError(err.errno, ffi.string(error[0].text).decode("utf-8")) from err
+    return result[0]

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -21,6 +21,7 @@
 #include <time.h>
 #include <stdio.h>
 #include <string.h>
+#include <math.h>
 #include <ctype.h>
 #include <pwd.h>
 #include <assert.h>
@@ -43,6 +44,7 @@
 #include "src/common/libjob/unwrap.h"
 #include "src/common/libutil/read_all.h"
 #include "src/common/libutil/monotime.h"
+#include "src/common/libutil/fsd.h"
 #include "src/common/libidset/idset.h"
 #include "src/common/libeventlog/eventlog.h"
 #include "src/common/libioencode/ioencode.h"
@@ -99,6 +101,7 @@ int cmd_wait (optparse_t *p, int argc, char **argv);
 int cmd_memo (optparse_t *p, int argc, char **argv);
 int cmd_purge (optparse_t *p, int argc, char **argv);
 int cmd_taskmap (optparse_t *p, int argc, char **argv);
+int cmd_timeleft (optparse_t *p, int argc, char **argv);
 
 int stdin_flags;
 
@@ -398,6 +401,13 @@ static struct optparse_option taskmap_opts[] = {
     OPTPARSE_TABLE_END
 };
 
+static struct optparse_option timeleft_opts[] = {
+    { .name = "human", .key = 'H', .has_arg = 0,
+      .usage = "Output in Flux Standard Duration instead of seconds.",
+    },
+    OPTPARSE_TABLE_END
+};
+
 static struct optparse_subcommand subcommands[] = {
     { "list",
       "[OPTIONS]",
@@ -553,6 +563,13 @@ static struct optparse_subcommand subcommands[] = {
       cmd_taskmap,
       0,
       taskmap_opts,
+    },
+    { "timeleft",
+      "[JOBID]",
+      "Find remaining runtime for job or enclosing instance",
+      cmd_timeleft,
+      0,
+      timeleft_opts,
     },
     { "purge",
       "[--age-limit=FSD] [--num-limit=N]",
@@ -3533,6 +3550,49 @@ int cmd_taskmap (optparse_t *p, int argc, char **argv)
     printf ("%s\n", s);
     free (s);
     taskmap_destroy (map);
+    return 0;
+}
+
+int cmd_timeleft (optparse_t *p, int argc, char **argv)
+{
+    int optindex = optparse_option_index (p);
+    flux_t *h;
+    flux_error_t error;
+    double t;
+
+    if (optindex < argc - 1) {
+        optparse_print_usage (p);
+        exit (1);
+    }
+    if (!(h = flux_open (NULL, 0)))
+        log_err_exit ("flux_open");
+
+    if (optindex < argc) {
+        if (setenv ("FLUX_JOB_ID", argv[optindex++], 1) < 0)
+            log_err_exit ("setenv");
+    }
+    if (flux_job_timeleft (h, &error, &t) < 0)
+        log_msg_exit ("%s", error.text);
+    if (optparse_hasopt (p, "human")) {
+        char buf[64];
+        if (fsd_format_duration (buf, sizeof (buf), t) < 0)
+            log_err_exit ("fsd_format_duration");
+        printf ("%s\n", buf);
+    }
+    else {
+        unsigned long int sec;
+        /*  Report whole seconds remaining in job, unless value is
+         *  infinity, in which case we report UINT_MAX, or if value
+         *  is 0 < t < 1, in which case round up to 1 to avoid
+         *  printing "0" which would mean the job has expired.
+         */
+        if (isinf (t))
+            sec = UINT_MAX;
+        else if ((sec = floor (t)) == 0 && t > 0.)
+            sec = 1;
+        printf ("%lu\n", sec);
+    }
+    flux_close (h);
     return 0;
 }
 

--- a/src/common/libjob/job.c
+++ b/src/common/libjob/job.c
@@ -13,6 +13,9 @@
 #endif
 #include <flux/core.h>
 #include <jansson.h>
+#include <math.h>
+
+#include "src/common/libutil/errprintf.h"
 
 #include "job.h"
 
@@ -83,6 +86,112 @@ flux_future_t *flux_job_set_urgency (flux_t *h, flux_jobid_t id, int urgency)
                              "urgency", urgency)))
         return NULL;
     return f;
+}
+
+int flux_job_timeleft (flux_t *h, flux_error_t *errp, double *timeleft)
+{
+    flux_jobid_t id;
+    flux_job_state_t state;
+    const char *s;
+    double expiration = 0.;
+    flux_future_t *f = NULL;
+    flux_t *parent_h = NULL;
+    int rc = -1;
+
+    if (!h || !timeleft) {
+        errno = EINVAL;
+        return errprintf (errp, "Invalid argument");
+    }
+
+    /*  Check for FLUX_JOB_ID environment variable. If set, this process
+     *  is part of a job in the current instance. If not, then check to
+     *  see if this process is part of an "initial program".
+     */
+    if (!(s = getenv ("FLUX_JOB_ID"))) {
+        const char *uri;
+
+        /*  Check if we're in "initial program" context.
+         *  If not, then this instance may be the system instance, or
+         *  may be a job in a foreign RM. Either way we cannot provide
+         *  a remaining time, so return an error.
+         */
+        if (!(s = flux_attr_get (h, "jobid"))) {
+            errprintf (errp,
+                       "unable to associate this process with a Flux jobid");
+            return -1;
+        }
+
+        /* This is an initial program. Switch the handle to the parent */
+        if (!(uri = flux_attr_get (h, "parent-uri")))
+            return errprintf (errp,
+                              "failed to get parent-uri attribute: %s",
+                              strerror (errno));
+        if (!(parent_h = flux_open (uri, 0)))
+            return errprintf (errp,
+                              "failed to connect to parent instance: %s",
+                              strerror (errno));
+        h = parent_h;
+    }
+
+    /*  Parse jobid and lookup expiration
+     */
+    if (flux_job_id_parse (s, &id) < 0) {
+        errprintf (errp, "failed to parse jobid %s", s);
+        goto out;
+    }
+
+    /*  Fetch job expiration from this or parent's job-list service
+     */
+    if (!(f = flux_job_list_id (h, id, "[\"expiration\", \"state\"]"))) {
+        errprintf (errp, "flux_job_list_id: %s: %s", s, strerror (errno));
+        goto out;
+    }
+    if (flux_rpc_get_unpack (f,
+                             "{s:{s?f s:i}}",
+                             "job",
+                             "expiration", &expiration,
+                             "state", &state) < 0) {
+        if (errno == ENOENT)
+            errprintf (errp, "%s: no such jobid", s);
+        else
+            errprintf (errp,
+                       "flux_job_list_id: %s: %s",
+                       s,
+                       future_strerror (f, errno));
+        goto out;
+    }
+    if (state & FLUX_JOB_STATE_PENDING) {
+        /*  The remaining time for a pending job is undefined, so report
+         *  an error instead.
+         */
+        errprintf (errp, "job %s has not started", s);
+        goto out;
+    }
+    else if (state != FLUX_JOB_STATE_RUN) {
+        /*  Only jobs in RUN state have any time left.
+         *  Return 0 for jobs in any other state besides RUN.
+         */
+        *timeleft = 0.;
+    }
+    else if (expiration == 0.) {
+        /*  If expiration is 0. then job time left is unlimited.
+         *  Return INFINITY.
+         */
+        *timeleft = INFINITY;
+    }
+    else {
+        *timeleft = expiration - flux_reactor_now (flux_get_reactor (h));
+        /*  Avoid returning negative number. If expiration has elapsed,
+         *  then the time remaining is 0.
+         */
+        if (*timeleft < 0.)
+            *timeleft = 0.;
+    }
+    rc = 0;
+out:
+    flux_future_destroy (f);
+    flux_close (parent_h);
+    return rc;
 }
 
 /*

--- a/src/common/libjob/job.h
+++ b/src/common/libjob/job.h
@@ -253,6 +253,20 @@ int flux_job_result_get (flux_future_t *f,
  */
 int flux_job_result_get_unpack (flux_future_t *f, const char *fmt, ...);
 
+
+/*  Get remaining time in floating point seconds for the current job or
+ *  enclosing instancce (i.e., if the current process is associated with
+ *  a flux instance, but is not part of a parallel job).
+ *
+ *  Returns 0 on success with timeleft assigned to the remaining time.
+ *  If there is no expiration in the current context (e.g. the job has
+ *  no timelimit), then timeleft is set to infinity. If the job is not
+ *  in RUN state, or the job has expired, then timeleft is set to 0.
+ *
+ *  Returns -1 with error string assinged to 'errp' on failure.
+ */
+int flux_job_timeleft (flux_t *h, flux_error_t *errp, double *timeleft);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/common/libjob/test/job.c
+++ b/src/common/libjob/test/job.c
@@ -437,6 +437,17 @@ void check_jobid_parse_encode (void)
         "flux_job_id_encode with unknown encode type returns EPROTO");
 }
 
+static void check_job_timeleft (void)
+{
+    flux_t *h = (flux_t *)(uintptr_t)42; // fake but non-NULL
+    flux_error_t error;
+    double timeleft;
+
+    ok (flux_job_timeleft (NULL, &error, &timeleft) < 0 && errno == EINVAL,
+        "flux_job_timeleft (NULL, ...) returns EINVAL");
+    ok (flux_job_timeleft (h, &error, NULL) < 0 && errno == EINVAL,
+        "flux_job_timeleft (h, error, NULL) returns EINVAL");
+}
 
 int main (int argc, char *argv[])
 {
@@ -456,6 +467,8 @@ int main (int argc, char *argv[])
     check_kvs_namespace ();
 
     check_jobid_parse_encode ();
+
+    check_job_timeleft ();
 
     done_testing ();
     return 0;

--- a/t/python/t0010-job.py
+++ b/t/python/t0010-job.py
@@ -706,6 +706,19 @@ class TestJob(unittest.TestCase):
         # Test a job that does not exist
         meta = job.get_job(self.fh, 123456)
         self.assertIsNone(meta)
+
+    def test_34_timeleft(self):
+        spec = JobspecV1.from_command(
+            ["python3", "-c", "import flux; print(flux.job.timeleft())"]
+        )
+        spec.duration = "1m"
+        jobid = job.submit(self.fh, spec, waitable=True)
+        job.wait(self.fh, jobid=jobid)
+        try:
+            dt = job.timeleft()
+            dt = job.timeleft(self.fh)
+        except OSError:
+            pass
         
 if __name__ == "__main__":
     from subflux import rerun_under_flux


### PR DESCRIPTION
This WIP PR proposes a new `flux_job_timeleft(3)` function which fetches the remaining time for the current process, abstracting the implementation from callers because (as we've seen) the determination of _how_ to get the current time left is not exactly straightforward in all situations.

This function doesn't take a jobid but is still placed in libjob with the `flux_job` prefix since only jobs have a duration/expiration, so it doesn't seem to really belong under libflux.

Opening early as a WIP to get feedback (nothing about the interface is set in stone) and to allow @garlick to attempt addition of a `flux timeleft` utility, which can also act as a test vehicle for the function.