### PR TITLE
flux-top: limit jobs and summary to specific queue

### DIFF
--- a/doc/man1/flux-top.rst
+++ b/doc/man1/flux-top.rst
@@ -34,6 +34,9 @@ OPTIONS
    or *always*.  If *WHEN* is omitted, it defaults to *always*. The default
    value when the **--color** option is not used is *auto*.
 
+**-q, --queue**\ =\ *NAME*
+   Limit status and jobs to specific queue.
+
 
 KEYS
 ====

--- a/src/cmd/top/joblist_pane.c
+++ b/src/cmd/top/joblist_pane.c
@@ -18,6 +18,7 @@
 #include <jansson.h>
 
 #include "src/common/libutil/fsd.h"
+#include "ccan/str/str.h"
 
 #include "top.h"
 
@@ -146,6 +147,10 @@ void joblist_pane_draw (struct joblist_pane *joblist)
                            "user",
                              "uri", &uri) < 0)
             fatal (0, "error decoding a job record from job-list RPC");
+
+        if (joblist->top->queue && !streq (joblist->top->queue, queue))
+            continue;
+
         if (flux_job_id_encode (id, "f58", idstr, sizeof (idstr)) < 0)
             fatal (errno, "error encoding jobid as F58");
         (void)fsd_format_duration_ex (run, sizeof (run), fabs (now - t_run), 2);
@@ -311,7 +316,7 @@ void joblist_pane_enter (struct joblist_pane *joblist)
     /*  Lazily attempt to run top on jobid, but for now simply return to the
      *   original top window on failure.
      */
-    if ((top = top_create (uri, title, &error)))
+    if ((top = top_create (uri, title, NULL, &error)))
         top_run (top, 0);
     else
         error_popup (joblist, error.text);

--- a/src/cmd/top/top.h
+++ b/src/cmd/top/top.h
@@ -13,6 +13,7 @@
 #include <stdarg.h>
 #include <flux/core.h>
 #include <flux/optparse.h>
+#include <jansson.h>
 
 // set printf format attribute on this curses function for our convenience
 int mvwprintw(WINDOW *win, int y, int x, const char *fmt, ...)
@@ -29,6 +30,9 @@ enum {
 struct top {
     flux_t *h;
     char *title;
+    json_t *flux_config;
+    const char *queue;
+    json_t *queue_constraint;
     flux_jobid_t id;
 
     unsigned int test_exit:1;    /*  Exit after first joblist pane update */
@@ -55,6 +59,7 @@ struct dimension {
 
 struct top *top_create (const char *uri,
                         const char *prefix,
+                        const char *queue,
                         flux_error_t *errp);
 void top_destroy (struct top *top);
 int top_run (struct top *top, int reactor_flags);


### PR DESCRIPTION
per #4606.  I'm really glad I added that testing in #4833, caught a couple of issues :P

- i assume `--queue` doesn't recursively goto into sub-instances.  Possibly sub-instances may have same queue names setup, but it's not what i think is desired by the `--queue` option.

- right now `flux-top` determines if the "QUEUE" column should be displayed if any jobs have been submitted to any queue.  Maybe this should be changed to just determining if any queues have been configured, i.e. if `queue.*` actually is configured?  While what is implemented is perhaps more "correct", its heavier weight and not sure its really needed except outside of testing scenarios (i.e. queue configuration changed between job submissions).  But for the time being I left it in.

- will probably have to add support in `flux-sched` for the `resource-status` RPC.

- i somewhat lazily chose not to add "queues" (plural) support.  Didn't think there was a big use case at the moment.
  - big issue, `job-list` only filters jobs by single queue, so would have to update job-list module or do some type of "build up display of multiple responses". Edit: OR get all jobs and just filter them in `flux-top`, which dunno if I'd want to do that.

  - getting resources of multiple queues should be easy, just add to the constraints list

  - tiny annoying to support in job-stats, b/c gotta add the queue stats together

  - I'm thinking I'll put into an issue as a longer-term todo.
