### PR TITLE
Experimental WIP: add flux-pgrep(1) and flux-pkill(1)

### DIFF
--- a/src/bindings/python/flux/job/__init__.py
+++ b/src/bindings/python/flux/job/__init__.py
@@ -8,7 +8,7 @@
 # SPDX-License-Identifier: LGPL-3.0
 ###############################################################
 
-from flux.job.Jobspec import Jobspec, JobspecV1, validate_jobspec
+from flux.job.Jobspec import Jobspec, JobspecV1, validate_jobspec, Constraint
 from flux.job.JobID import id_parse, id_encode, JobID
 from flux.job.kvs import job_kvs, job_kvs_guest
 from flux.job.kill import kill_async, kill, cancel_async, cancel

--- a/src/bindings/python/flux/util.py
+++ b/src/bindings/python/flux/util.py
@@ -252,7 +252,7 @@ def parse_fsd(fsd_string):
     return seconds
 
 
-def parse_datetime(string, now=None):
+def parse_datetime(string, now=None, assumeFuture=True):
     """Parse a possibly human readable datetime string or offset
 
     If string starts with `+` or `-`, then the remainder of the string
@@ -287,6 +287,9 @@ def parse_datetime(string, now=None):
 
     cal = Calendar()
     cal.ptc.StartHour = 0
+    if not assumeFuture:
+        cal.ptc.DOWParseStyle = 0
+        cal.ptc.YearParseStyle = 0
     time_struct, status = cal.parse(string, sourceTime=now.timetuple())
     if status == 0:
         raise ValueError(f'Invalid datetime: "{string}"')

--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -85,7 +85,9 @@ dist_fluxcmd_SCRIPTS = \
 	flux-job-exec-override.py \
 	flux-perilog-run.py \
 	flux-uri.py \
-	flux-pstree.py
+	flux-pstree.py \
+	flux-pgrep.py \
+	flux-pkill.py
 
 fluxcmd_PROGRAMS = \
 	flux-terminus \

--- a/src/cmd/flux-mini.py
+++ b/src/cmd/flux-mini.py
@@ -28,7 +28,7 @@ from urllib.parse import parse_qs, urlparse
 import flux
 from flux import debugged, job, util
 from flux.idset import IDset
-from flux.job import JobspecV1
+from flux.job import Constraint, JobspecV1
 from flux.progress import ProgressBar
 from flux.uri import JobURI
 
@@ -711,10 +711,8 @@ class MiniCmd:
                 "system.dependencies", dependency_array_create(args.dependency)
             )
         if args.requires is not None:
-            jobspec.setattr(
-                "system.constraints.properties",
-                list_split(args.requires),
-            )
+            constraint = Constraint(",".join(args.requires))
+            jobspec.setattr("system.constraints", constraint)
         if args.time_limit is not None:
             #  With no units, time_limit is in minutes, but jobspec.duration
             #  takes seconds or FSD by default, so convert here if necessary.

--- a/src/cmd/flux-pgrep.py
+++ b/src/cmd/flux-pgrep.py
@@ -1,0 +1,582 @@
+##############################################################
+# Copyright 2019 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+##############################################################
+
+import argparse
+import json
+import logging
+import os
+import re
+import sys
+from datetime import datetime
+from itertools import islice
+from pathlib import PurePath
+
+import flux
+from flux.hostlist import Hostlist
+from flux.idset import IDset
+from flux.job import Constraint, JobID, JobInfoFormat, JobList
+from flux.util import UtilConfig, parse_datetime, parse_fsd
+
+PROGRAM = PurePath(sys.argv[0]).stem
+LOGGER = logging.getLogger(PROGRAM)
+
+
+class FluxPgrepConfig(UtilConfig):
+    """flux-pgrep configuration class"""
+
+    builtin_formats = {
+        "default": {
+            "description": "Default flux-pgrep format string",
+            "format": "{id.f58}",
+        },
+        "full": {
+            "description": "full flux-pgrep format string",
+            "format": (
+                "{id.f58:>12} ?:{queue:<8.8} {username:<8.8} {name:<10.10+} "
+                "{status_abbrev:>2.2} {ntasks:>6} {nnodes:>6h} "
+                "{contextual_time!F:>8h} {contextual_info}"
+            ),
+        },
+        "long": {
+            "description": "Extended flux-pgrep format string",
+            "format": (
+                "{id.f58:>12} ?:{queue:<8.8} {username:<8.8} {name:<10.10+} "
+                "{status:>9.9} {ntasks:>6} {nnodes:>6h} "
+                "{t_submit!d:%b%d %R::>12} {t_remaining!F:>12h} "
+                "{contextual_time!F:>8h} {contextual_info}"
+            ),
+        },
+        "deps": {
+            "description": "Show job urgency, priority, and dependencies",
+            "format": (
+                "{id.f58:>12} ?:{queue:<8.8} {name:<10.10+} {urgency:<3} "
+                "{priority:<12} {state:<8.8} {dependencies}"
+            ),
+        },
+    }
+
+    def __init__(self):
+        initial_dict = {"formats": dict(self.builtin_formats)}
+        super().__init__(name="flux-pgrep", initial_dict=initial_dict)
+
+    def validate(self, path, config):
+        """Validate a loaded flux-pgrep config file as dictionary"""
+        for key, value in config.items():
+            if key == "formats":
+                self.validate_formats(path, value)
+            else:
+                raise ValueError(f"{path}: invalid key {key}")
+
+
+class PgrepConstraint(Constraint):
+    """
+    Build constraint object from string, overriding operators so that
+    'name' (match on job name) is the default operator. Also include
+    shorthand for a select few other operators in the context of matching
+    jobs
+    """
+
+    operator_map = {
+        None: "name",
+        "id": "jobid",
+        "host": "hostlist",
+        "rank": "ranks",
+    }
+
+
+class JobPgrep:
+    def __init__(self, args):
+        self.cache = {}
+        self.query_string = self.convert_terms(args)
+        self.constraint = PgrepConstraint(self.query_string)
+        self.validate(self.constraint)
+
+    def dumps(self):
+        return json.dumps(self.constraint)
+
+    def convert_terms(self, args):
+        """Convert some shorthand terms into official op:args arguments"""
+        result = []
+        for arg in self.join_terms(args):
+            if arg.startswith("@"):
+                #  A leading '@' is converted to query for jobs that were
+                #  running at a given time (@5pm) or time range (@8am..noon)
+                arg = arg[1:]
+                if ".." in arg:
+                    # Jobs that were running in a time range between start,end
+                    start, end = arg.split("..")
+                    arg = "(not ("
+                    if start:
+                        arg += f"end:<{start}"
+                    if start and end:
+                        arg += " or "
+                    if end:
+                        arg += f"start:>{end}"
+                    arg += "))"
+                else:
+                    # Jobs running at a single point in time:
+                    arg = f"(start:<={arg} and end:>={arg})"
+            elif ":" not in arg and ".." in arg:
+                #  X..Y with no leading @ or without : is translated to a
+                #   range of jobids.
+                arg = f"jobid:{arg}"
+            result.append(arg)
+        return " ".join(result)
+
+    def join_terms(self, args):
+        """
+        Join terms in args into a Constraint expression.
+        If two terms are joined without `and` or `or` then insert `and`
+        """
+        lst = []
+        for i in range(1, len(args)):
+            (prev, cur) = (args[i - 1], args[i])
+            lst.append(prev)
+            if prev not in ["and", "or", "not"] and cur not in ["and", "or"]:
+                lst.append("and")
+        lst.append(args[-1])
+        return lst
+
+    def validate(self, constraint):
+        """
+        Validate a Pgrep constraint dict
+        """
+        for op, args in constraint.items():
+            if op == "name":
+                self.validate_name(args)
+            elif op == "jobid":
+                self.validate_jobid(args)
+            elif op == "status":
+                self.validate_status(args)
+            elif op == "ranks":
+                self.validate_ranks(args)
+            elif op == "hostlist":
+                self.validate_hostlist(args)
+            elif op in ["runtime", "start", "end"]:
+                self.validate_one_arg(op, args)
+            elif op == "start":
+                self.validate_start(args)
+            elif op == "end":
+                self.validate_end(args)
+            elif op == "is":
+                self.validate_is(args)
+            elif op == "nnodes":
+                pass
+            elif op in ["before", "since"]:
+                self.validate_before_since(op, args)
+            elif op in ["or", "and", "not"]:
+                self.validate_conditional(op, args)
+            else:
+                raise ValueError(f"unknown match operator: {op}")
+
+    def validate_conditional(self, op, args):
+        for constraint in args:
+            self.validate(constraint)
+
+    def validate_name(self, args):
+        for value in args:
+            if value not in self.cache:
+                regex = re.compile(value)
+                self.cache[value] = regex
+
+    def validate_one_arg(self, op, args):
+        if len(args) > 1:
+            raise ValueError(f"{op} should have only a single arg")
+
+    def validate_jobid(self, args):
+        for jobid in args:
+            if jobid not in self.cache:
+                self.cache[jobid] = JobID(jobid)
+
+    def validate_ranks(self, args):
+        key = ",".join(args)
+        if key not in self.cache:
+            self.cache[key] = IDset(key)
+
+    def validate_hostlist(self, args):
+        key = ",".join(args)
+        if key not in self.cache:
+            self.cache[key] = Hostlist(key)
+
+    def validate_before_since(self, op, args):
+        if len(args) > 1:
+            raise ValueError(f"{op} only takes a single term")
+        self.cache[args[0]] = parse_datetime(args[0], assumeFuture=False)
+
+    def validate_is(self, args):
+        for arg in args:
+            if arg.lower() not in [
+                "pending",
+                "depend",
+                "priority",
+                "sched",
+                "run",
+                "running",
+                "cleanup",
+                "inactive",
+                "failure",
+                "failed",
+                "canceled",
+                "timeout",
+                "success",
+                "complete",
+                "started",
+            ]:
+                raise ValueError("is: invalid argument '{arg}'")
+
+    def match_is(self, job, args):
+        for arg in args:
+            arg = arg.lower()
+            state = job.state.lower()
+            if arg == "started" and job.runtime:
+                return True
+            if arg == "running" and state in ["run", "cleanup"]:
+                arg = "run"
+            if arg == "pending" and state in ["depend", "priority", "sched"]:
+                return True
+            if arg == "complete" and state in ["cleanup", "inactive"]:
+                return True
+            if arg == state:
+                return True
+            if job.result and arg == job.result.lower():
+                return True
+            if arg == "success" and job.success:
+                return True
+            if arg == "failure" and not job.success:
+                return True
+        return False
+
+    def match_name(self, job, args):
+        for arg in args:
+            if not self.cache[arg].search(job.name):
+                return False
+        return True
+
+    def match_ranks(self, job, args):
+        key = ",".join(args)
+        result = self.cache[key].intersect(job.ranks)
+        return result.count() > 0
+
+    def match_hostlist(self, job, args):
+        key = ",".join(args)
+        hl = self.cache[key]
+        for host in Hostlist(job.nodelist):
+            if host in hl:
+                return True
+        return False
+
+    def match_before(self, job, args):
+        before = self.cache[args[0]]
+        time = datetime.fromtimestamp(job.t_submit).astimezone()
+        return time < before
+
+    def match_since(self, job, args):
+        since = self.cache[args[0]]
+        time = datetime.fromtimestamp(job.t_submit).astimezone()
+        return time > since
+
+    def conditional(self, value, arg, conversion_function):
+        """
+        Handle a generic conditional expression, i.e. one that
+        starts with ">=", "<=", ">", "<".
+        """
+
+        def conv(value):
+            if value not in self.cache:
+                self.cache[value] = conversion_function(value)
+            return self.cache[value]
+
+        val = conv(value)
+        if arg.startswith(">=") or arg.startswith("+="):
+            return val >= conv(arg[2:])
+        if arg.startswith("<=") or arg.startswith("-="):
+            return val <= conv(arg[2:])
+        if arg.startswith("<") or arg.startswith("-"):
+            return val < conv(arg[1:])
+        if arg.startswith(">") or arg.startswith("+"):
+            return val > conv(arg[1:])
+        if arg.startswith("=="):
+            arg = arg[2:]
+        if ".." in arg:
+            start, end = arg.split("..")
+            if start and end:
+                return conv(start) <= val <= conv(end)
+            elif start:
+                return conv(start) <= val
+            elif end:
+                return val <= conv(end)
+        return val == conv(arg)
+
+    def convert_duration(self, duration):
+        if isinstance(duration, str):
+            time = parse_fsd(duration)
+        elif isinstance(duration, (float, int)):
+            time = float(duration)
+        return time
+
+    def match_runtime(self, job, args):
+        return self.conditional(job.runtime, args[0], self.convert_duration)
+
+    def convert_datetime(self, dt):
+        if isinstance(dt, (float, int)):
+            time = datetime.fromtimestamp(dt).astimezone()
+        else:
+            time = parse_datetime(dt, assumeFuture=False)
+        return time
+
+    def match_start(self, job, args):
+        return self.conditional(job.t_run, args[0], self.convert_datetime)
+
+    def match_end(self, job, args):
+        return self.conditional(job.t_cleanup, args[0], self.convert_datetime)
+
+    def match_nnodes(self, job, args):
+        return self.conditional(job.nnodes, args[0], int)
+
+    def convert_jobid(self, jobid):
+        try:
+            return self.cache[jobid]
+        except KeyError:
+            return JobID(jobid)
+
+    def match_jobid(self, job, args):
+        return self.conditional(job.id, args[0], self.convert_jobid)
+
+    def match_and(self, job, args):
+        for constraint in args:
+            if not self.match(job, constraint):
+                return False
+        return True
+
+    def match_or(self, job, args):
+        for constraint in args:
+            if self.match(job, constraint):
+                return True
+        return False
+
+    def match_not(self, job, args):
+        return not self.match_and(job, args)
+
+    def match(self, job, constraint=None):
+        if constraint is None:
+            constraint = self.constraint
+
+        for op, args in constraint.items():
+            result = False
+            if op == "name":
+                result = self.match_name(job, args)
+            elif op == "jobid":
+                result = self.match_jobid(job, args)
+            elif op == "ranks":
+                result = self.match_ranks(job, args)
+            elif op == "hostlist":
+                result = self.match_hostlist(job, args)
+            elif op == "since":
+                result = self.match_since(job, args)
+            elif op == "before":
+                result = self.match_before(job, args)
+            elif op == "range":
+                result = self.match_range(job, args)
+            elif op == "runtime":
+                result = self.match_runtime(job, args)
+            elif op == "start":
+                result = self.match_start(job, args)
+            elif op == "end":
+                result = self.match_end(job, args)
+            elif op == "is":
+                result = self.match_is(job, args)
+            elif op == "nnodes":
+                result = self.match_nnodes(job, args)
+            elif op == "and":
+                result = self.match_and(job, args)
+            elif op == "not":
+                result = self.match_not(job, args)
+            elif op == "or":
+                result = self.match_or(job, args)
+
+            # Multiple keys is equivalent to "and"
+            if not result:
+                return False
+        return True
+
+
+def fetch_jobs(args, flux_handle=None):
+    if not flux_handle:
+        flux_handle = flux.Flux()
+
+    if args.A:
+        args.user = "all"
+    if args.a:
+        args.filter.update(["pending", "running", "inactive"])
+    if not args.filter:
+        args.filter = {"pending", "running"}
+
+    jobs_rpc = JobList(
+        flux_handle,
+        filters=args.filter,
+        user=args.user,
+        max_entries=args.max_entries,
+        queue=args.queue,
+    )
+    jobs = jobs_rpc.jobs()
+
+    #  Print all errors accumulated in JobList RPC:
+    try:
+        for err in jobs_rpc.errors:
+            print(err, file=sys.stderr)
+    except EnvironmentError:
+        pass
+
+    return jobs
+
+
+class FilterActionSetUpdate(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        values = values.split(",")
+        getattr(namespace, self.dest).update(values)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        prog=PROGRAM, formatter_class=flux.util.help_formatter()
+    )
+    parser.add_argument(
+        "-a",
+        action="store_true",
+        help="Target jobs in all states"
+        if PROGRAM == "flux-pgrep"
+        else argparse.SUPPRESS,
+    )
+    parser.add_argument("-A", action="store_true", help="Target all users")
+    parser.add_argument(
+        "-u",
+        "--user",
+        type=str,
+        metavar="[USERNAME|UID]",
+        default=str(os.getuid()),
+        help="Limit output to specific username or userid "
+        '(Specify "all" for all users)',
+    )
+    parser.add_argument(
+        "-f",
+        "--filter",
+        action=FilterActionSetUpdate,
+        metavar="STATE|RESULT",
+        default=set(),
+        help="List jobs with specific job state or result",
+    )
+    parser.add_argument(
+        "--queue",
+        type=str,
+        metavar="QUEUE",
+        help="Limit output to specific queue",
+    )
+    parser.add_argument(
+        "-c",
+        "--count",
+        type=int,
+        metavar="N",
+        default=99999,
+        help="Limit output to the first N matches",
+    )
+    parser.add_argument(
+        "--max-entries",
+        type=int,
+        metavar="N",
+        default=1000,
+        help="Limit number of searched jobs to N entries (default: 1000)",
+    )
+    if PROGRAM == "flux-pgrep":
+        parser.add_argument(
+            "-n",
+            "--suppress-header",
+            action="store_true",
+            help="Suppress printing of header line",
+        )
+        parser.add_argument(
+            "-o",
+            "--format",
+            type=str,
+            default="default",
+            metavar="FORMAT",
+            help="Specify output format using Python's string format syntax "
+            + " or a defined format by name (use 'help' to get a list of names)",
+        )
+        parser.add_argument(
+            "-k",
+            "--kill",
+            action="store_true",
+            help="Cancel instead of printing matching jobs",
+        )
+    parser.add_argument(
+        "--wait", action="store_true", help="Wait for jobs to finish after cancel"
+    )
+    parser.add_argument(
+        "expression",
+        metavar="EXPRESSION",
+        type=str,
+        nargs="+",
+        help="job name pattern or match expression",
+    )
+    return parser.parse_args()
+
+
+def pkill(fh, args, jobs):
+    success = 0
+    exitcode = 0
+
+    def wait_cb(future, job):
+        future.get_dict()
+
+    def cancel_cb(future, args, job):
+        nonlocal success
+        nonlocal exitcode
+        try:
+            future.get()
+            success = success + 1
+            if args.wait:
+                flux.job.result_async(fh, job.id).then(wait_cb, job)
+        except OSError as exc:
+            exitcode = 1
+            LOGGER.error(f"{job.id}: cancel: {exc}")
+
+    for job in jobs:
+        flux.job.cancel_async(fh, job.id).then(cancel_cb, args, job)
+    fh.reactor_run()
+    LOGGER.info("Canceled %d job%s", success, "s" if success != 1 else "")
+    sys.exit(exitcode)
+
+
+@flux.util.CLIMain(LOGGER)
+def main():
+    sys.stdout = open(sys.stdout.fileno(), "w", encoding="utf8")
+    args = parse_args()
+    if PROGRAM == "flux-pkill":
+        args.kill = True
+
+    fh = flux.Flux()
+    pgrep = JobPgrep(args.expression)
+    jobs = list(islice(filter(pgrep.match, fetch_jobs(args, fh)), args.count))
+
+    if args.kill:
+        pkill(fh, args, jobs)
+
+    fmt = FluxPgrepConfig().load().get_format_string(args.format)
+    try:
+        formatter = JobInfoFormat(fmt)
+    except ValueError as err:
+        raise ValueError("Error in user format: " + str(err))
+
+    sformatter = JobInfoFormat(formatter.filter_empty(jobs))
+
+    if args.format == "default":
+        args.suppress_header = True
+
+    sformatter.print_items(jobs, no_header=args.suppress_header)

--- a/src/cmd/flux-pkill.py
+++ b/src/cmd/flux-pkill.py
@@ -1,0 +1,1 @@
+flux-pgrep.py

--- a/src/common/librlist/match.h
+++ b/src/common/librlist/match.h
@@ -19,10 +19,24 @@
 
 #include "rnode.h"
 
+struct job_constraint * job_constraint_create (json_t *constraint,
+                                               flux_error_t *errp);
+
+void job_constraint_destroy (struct job_constraint *jc);
+
+int job_constraint_aux_set (struct job_constraint *jc,
+                            const char *key,
+                            void *val,
+                            flux_free_f free_fn);
+
+void * job_constraint_aux_get (struct job_constraint *jc, const char *key);
+
 /*  Return true if rnode 'n' matches constraints in RFC 31 constraint
  *   specification 'constraint'.
  */
-bool rnode_match (const struct rnode *n, json_t *constraint);
+bool rnode_match (const struct rnode *n,
+                  struct job_constraint *jc,
+                  json_t *constraint);
 
 /*  Validate RFC 31 constraint spec 'constraint'
  *
@@ -30,9 +44,12 @@ bool rnode_match (const struct rnode *n, json_t *constraint);
  *         -1 if not and sets error in errp if errp != NULL.
  *
  */
-int rnode_match_validate (json_t *constraint, flux_error_t *errp);
+int rnode_match_validate (struct job_constraint *jc,
+                          json_t *constraint,
+                          flux_error_t *errp);
 
 /*  Copy an rnode only if it matches the RFC 31 constraints in `constraint` */
-struct rnode *rnode_copy_match (const struct rnode *n, json_t *constraint);
+struct rnode *rnode_copy_match (const struct rnode *n,
+                                struct job_constraint *jc);
 
 #endif /* !HAVE_SCHED_RLIST_MATCH */

--- a/src/common/librlist/rlist.c
+++ b/src/common/librlist/rlist.c
@@ -357,13 +357,18 @@ struct rlist *rlist_copy_constraint (const struct rlist *orig,
                                      json_t *constraint,
                                      flux_error_t *errp)
 {
-    if (rnode_match_validate (constraint, errp) < 0) {
+    struct rlist *rl;
+    struct job_constraint *jc;
+
+    if (!(jc = job_constraint_create (constraint, errp))) {
         errno = EINVAL;
         return NULL;
     }
-    return rlist_copy_internal (orig,
-                                (rnode_copy_f) rnode_copy_match,
-                                (void *) constraint);
+    rl =  rlist_copy_internal (orig,
+                               (rnode_copy_f) rnode_copy_match,
+                               (void *) jc);
+    job_constraint_destroy (jc);
+    return rl;
 }
 
 struct rlist *rlist_copy_constraint_string (const struct rlist *orig,

--- a/src/common/librlist/test/match.c
+++ b/src/common/librlist/test/match.c
@@ -101,63 +101,71 @@ struct match_test match_tests[] = {
        }",
        false,
     },
+    { "hostlist operator works",
+      "{\"hostlist\": [\"foo[0-2]\"]}",
+      true,
+    },
+    { "hostlist operator works with non-matching hostlist",
+      "{\"hostlist\": [\"foo[1-3]\"]}",
+      false,
+    },
     { NULL, NULL, false },
 };
 
 struct validate_test validate_tests[] = {
     { "non-object fails",
       "[]",
-      -1,
+      false,
       "constraint must be JSON object",
     },
     { "Unknown operation fails",
       "{ \"foo\": [] }",
-      -1,
+      false,
       "unknown constraint operator: foo",
     },
     { "non-array argument to 'and' fails",
       "{ \"and\": \"foo\" }",
-      -1,
+      false,
       "and operator value must be an array",
     },
     { "non-array argument to 'or' fails",
       "{ \"or\": \"foo\" }",
-      -1,
+      false,
       "or operator value must be an array",
     },
     { "non-array argument to 'properties' fails",
       "{ \"properties\": \"foo\" }",
-      -1,
+      false,
       "properties value must be an array",
     },
     { "non-string property fails",
       "{ \"properties\": [ \"foo\", 42 ] }",
-      -1,
+      false,
       "non-string property specified",
     },
     { "invalid property string fails",
       "{ \"properties\": [ \"foo\", \"bar&\" ] }",
-      -1,
+      false,
       "invalid character '&' in property \"bar&\"",
     },
     { "empty object is valid constraint",
       "{}",
-      0,
+      true,
       NULL
     },
     { "empty and object is valid constraint",
       "{ \"and\": [] }",
-      0,
+      true,
       NULL
     },
     { "empty or object is valid constraint",
       "{ \"or\": [] }",
-      0,
+      true,
       NULL
     },
     { "empty properties object is valid constraint",
       "{ \"properties\": [] }",
-      0,
+      true,
       NULL
     },
     { "complex conditional works",
@@ -193,11 +201,16 @@ void test_match ()
 
     struct match_test *t = match_tests;
     while (t->desc) {
+        flux_error_t error;
+        struct job_constraint *jc;
         json_t *o = json_loads (t->json, 0, NULL);
         if (!o)
             BAIL_OUT ("failed to parse json logic for '%s'", t->desc);
-        ok (rnode_match (n, o) == t->result, "%s", t->desc);
+        if (!(jc = job_constraint_create (o, &error)))
+            BAIL_OUT ("%s: job_constraint_create: %s", t->desc, error.text);
+        ok (rnode_match (n, jc, o) == t->result, "%s", t->desc);
         json_decref (o);
+        job_constraint_destroy (jc);
         t++;
     }
     rnode_destroy (n);
@@ -207,17 +220,21 @@ void test_validate ()
 {
     flux_error_t error;
     struct validate_test *t = validate_tests;
+
     while (t->desc) {
+        struct job_constraint *jc;
         json_t *o = json_loads (t->json, 0, NULL);
         if (!o)
             BAIL_OUT ("failed to parse json logic for '%s'", t->desc);
-        int rc = rnode_match_validate (o, &error);
-        ok (rc == t->rc, "%s", t->desc);
-        if (rc != t->rc)
+        jc = job_constraint_create (o, &error);
+        bool rc = jc != NULL;
+        ok (t->rc == rc, "%s", t->desc);
+        if (!jc)
             diag ("%s", error.text);
         if (t->err)
             is (error.text, t->err, "got expected error: %s", error.text);
         json_decref (o);
+        job_constraint_destroy (jc);
         t++;
     }
 }
@@ -227,14 +244,10 @@ void test_invalid ()
     json_t *o = json_object ();
     if (!o)
         BAIL_OUT ("test_invalid: json_object() failed");
-    ok (!rnode_match (NULL, NULL),
+    ok (!rnode_match (NULL, NULL, NULL),
         "rnode_match (NULL, NULL) returns false");
-    ok (!rnode_match (NULL, o),
+    ok (!rnode_match (NULL, NULL, o),
         "rnode_match (NULL, o) returns false");
-    ok (rnode_match_validate (NULL, NULL) == -1,
-        "rnode_match_validate (NULL, NULL) == -1");
-    lives_ok ({rnode_match_validate (o, NULL); },
-        "rnode_match_validate (o, NULL) doesn't crash");
     ok (rnode_copy_match (NULL, NULL) == NULL,
         "rnode_copy_match (NULL, NULL) returns NULL");
     json_decref (o);

--- a/src/common/librlist/test/match.c
+++ b/src/common/librlist/test/match.c
@@ -109,6 +109,14 @@ struct match_test match_tests[] = {
       "{\"hostlist\": [\"foo[1-3]\"]}",
       false,
     },
+    { "ranks operator works",
+      "{\"ranks\": [\"0-2\"]}",
+      true,
+    },
+    { "ranks operator works with non-intersecting ranks",
+      "{\"ranks\": [\"1-3\"]}",
+      false,
+    },
     { NULL, NULL, false },
 };
 
@@ -192,6 +200,16 @@ struct validate_test validate_tests[] = {
     },
     { "invalid hostlist fails",
       "{\"hostlist\": [\"foo0-10]\"]}",
+      false,
+      NULL
+    },
+    { "ranks can be included",
+      "{\"ranks\": [\"0-10\"]}",
+      true,
+      NULL
+    },
+    { "invalid ranks entry fails",
+      "{\"ranks\": [\"5,1-3\"]}",
       false,
       NULL
     },

--- a/src/common/librlist/test/match.c
+++ b/src/common/librlist/test/match.c
@@ -182,7 +182,17 @@ struct validate_test validate_tests[] = {
            } \
          ] \
       }",
-      0,
+      true,
+      NULL
+    },
+    { "hostlist can be included",
+      "{\"hostlist\": [\"foo[0-10]\"]}",
+      true,
+      NULL
+    },
+    { "invalid hostlist fails",
+      "{\"hostlist\": [\"foo0-10]\"]}",
+      false,
       NULL
     },
     { NULL, NULL, 0, NULL }

--- a/src/common/librlist/test/rlist.c
+++ b/src/common/librlist/test/rlist.c
@@ -1885,6 +1885,22 @@ struct property_test property_tests[] = {
         "{\"properties\": [\"^foo5\"]}",
         "rank[1-4,6-10]/core[0-1]",
     },
+    {
+        "constraint: by hostlist: foo[2,3,7]",
+        "1-10", "0-1", "foo[1-10]",
+        "{\"foo\": \"1-3\", \"bar\": \"7\"}",
+        NULL,
+        "{\"hostlist\": [\"foo[2,3,7]\"]}",
+        "rank[2-3,7]/core[0-1]",
+    },
+    {
+        "constraint: by hostlist: not foo[2,3,7]",
+        "1-10", "0-1", "foo[1-10]",
+        "{\"foo\": \"1-3\", \"bar\": \"7\"}",
+        NULL,
+        "{ \"not\": [{\"hostlist\": [\"foo[2,3,7]\"]}] }",
+        "rank[1,4-6,8-10]/core[0-1]",
+    },
     { 0 }
 };
 

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -250,6 +250,7 @@ TESTSCRIPTS = \
 	python/t0024-util.py \
 	python/t0025-uri.py \
 	python/t0026-tree.py \
+	python/t0027-constraint.py \
 	python/t1000-service-add-remove.py
 
 if HAVE_FLUX_SECURITY

--- a/t/python/t0027-constraint.py
+++ b/t/python/t0027-constraint.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+###############################################################
+# Copyright 2022 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+import unittest
+import unittest.mock
+import platform
+import subflux  # To set up PYTHONPATH
+from pycotap import TAPTestRunner
+from flux.job import Constraint
+
+
+class TestConstraintValueError(unittest.TestCase):
+    def __init__(self, arg):
+        super().__init__()
+        self.arg = arg
+
+    def id(self):
+        return f"TestConstraintValueError: {self.arg}"
+
+    def runTest(self):
+        with self.assertRaises(ValueError) as error:
+            Constraint(self.arg)
+
+
+class TestConstraint(unittest.TestCase):
+    def __init__(self, arg, expected):
+        super().__init__()
+        self.arg = arg
+        self.expected = expected
+
+    def id(self):
+        return f"TestConstraint: {self.arg}"
+
+    def runTest(self):
+        self.assertEqual(Constraint(self.arg), self.expected)
+
+
+def suite():
+    tests = {
+        "foo": {"properties": ["foo"]},
+        "(foo)": {"properties": ["foo"]},
+        "foo,bar": {"properties": ["foo", "bar"]},
+        "not foo,bar": {"not": [{"properties": ["foo", "bar"]}]},
+        "hosts:foo[1-10]": {"hostlist": ["foo[1-10]"]},
+        "foo and hosts:foo[1-10]": {
+            "and": [{"properties": ["foo"]}, {"hostlist": ["foo[1-10]"]}]
+        },
+        "foo and -hosts:foo[1-10]": {
+            "and": [{"properties": ["foo"]}, {"not": [{"hostlist": ["foo[1-10]"]}]}]
+        },
+        "foo or (not host:foo[1-10])": {
+            "or": [{"properties": ["foo"]}, {"not": [{"hostlist": ["foo[1-10]"]}]}]
+        },
+    }
+    suite = unittest.TestSuite()
+    for arg, expected in tests.items():
+        suite.addTest(TestConstraint(arg, expected))
+
+    invalid = ["and", "foo not bar", "foo and (host:foo", "foo or"]
+    for arg in invalid:
+        suite.addTest(TestConstraintValueError(arg))
+
+    return suite
+
+
+if __name__ == "__main__":
+    TAPTestRunner().run(suite())


### PR DESCRIPTION
I started prototyping a `flux pgrep` utility, but won't have time to wrap this up before I leave for a few weeks, so I'm posting something experimental to get people thinking about it, discuss the interface, etc. 

The code is in _very_ prototype form, but the main experiment here is to use the `Constraint` query syntax proposed in #4677 (along with using a similar internal representation as in the RFC 31 Job Constraints Specification) to allow powerful and flexible job matching instead of just resource matching.

The `flux-pgrep` command here takes some args similar to `flux-jobs`, with non-option arguments forming a pgrep "expression".
```
usage: flux-pgrep [-h] [-a] [-A] [-u [USERNAME|UID]] [-f STATE|RESULT]
                  [--queue QUEUE] [-c N] [--max-entries N] [-n] [-o FORMAT]
                  [-k] [--wait]
                  EXPRESSION [EXPRESSION ...]

positional arguments:
  EXPRESSION                 job name pattern or match expression

optional arguments:
  -h, --help                 show this help message and exit
  -a                         Target jobs in all states
  -A                         Target all users
  -u, --user=[USERNAME|UID]  Limit output to specific username or userid
                             (Specify "all" for all users)
  -f, --filter=STATE|RESULT  List jobs with specific job state or result
      --queue=QUEUE          Limit output to specific queue
  -c, --count=N              Limit output to the first N matches
      --max-entries=N        Limit number of searched jobs to N entries
                             (default: 1000)
  -n, --suppress-header      Suppress printing of header line
  -o, --format=FORMAT        Specify output format using Python's string
                             format syntax or a defined format by name (use
                             'help' to get a list of names)
  -k, --kill                 Cancel instead of printing matching jobs
      --wait                 Wait for jobs to finish after cancel
```

A `flux-pgrep` expression is a query similar in form to gmail or github issues search: a set of terms which may have the form `operator:value` and may be joined by `and`, `or`, or `not`. By default, terms are joined with `and`, so `foo:1 bar:2` is `foo:1 and bar:2`. If an operator is not specified, then `name` is implied, which matches job names by regex (like `pgrep(1)`).

Therefore, `flux pgrep ^flux` would match all your currently active jobs that start with `flux`.

Currently supported operators include `jobid:`, `status:`, `ranks:`, `host|hostlist:`, `runtime`, `start`, `end`, `before`, `since`, `is`, and `nnodes`. Some of these could be dropped or names amended (e.g. `before` and `since` operate on submit time, it might be clearer to use `submitted`)

Operators that take numeric values additionally support conditional and range syntax. For example, `start:>8am` queries for jobs  with start time after 8am, and `start:8am..9am` queries for jobs that started between 8am and 9am inclusive. If you leave off either end of the `..` it works as expected, e.g. `start:8am..` matches jobs that started after 8am and `start:..8am` matches jobs that started before 8am. (`start:8am` specifies exactly 8am).

Because the `<` and `>` require shell quoting, I was thinking of letting `+` and `-` be an alternative to these characters, and that is what is implemented now.

There are also a couple instances of syntactic sugar to make more common queries easier. The form `ID..ID` can be used as an alternate for `jobid:ID1..ID2` and will match all jobids in a range (a requested feature). A term prefixed with an `@` is shorthand for querying when a job was "running", e.g. `@8am host:fluke123` queries what job was running on fluke123 at 8am. The `@` operator can also take a range: `@12am..8am` would list all jobs that were running in that time period.

The `is` operator tries to be smart about allowing matches for job states, results and status. It can take any job state, plus the virtual states `running`, `pending`, `complete`, etc, as well as results `success`, `failure`, `timeout`, `canceled`, etc. This allows you to quickly query the job running on a given host `is:running host:corona123`, or all the jobs that ran in the last day that failed in less than 5 minutes: `is:failure start:>12am runtime:<5m`.

By default, `flux pgrep` only outputs the matching jobids, similar to the `pgrep(1)` utility. However, you can select `--format=full` to get `flux-jobs` like output:
```
 grondo@corona212:~$ flux pgrep -c 5 -a ^flux
ƒVvgZo1MUyd
ƒVvgRoE49s5
ƒVvAbmCR4jZ
ƒVteoaztHCT
ƒVgCMmbgXCK
 grondo@corona212:~$ flux pgrep -c 5 -o full -a ^flux
       JOBID USER     NAME       ST NTASKS NNODES     TIME INFO
 ƒVvgZo1MUyd grondo   flux       TO      1      1   30.01m corona191
 ƒVvgRoE49s5 grondo   flux        F      2      2   31.47s corona[189-190]
 ƒVvAbmCR4jZ grondo   flux       CD      1      1   3.079m corona174
 ƒVteoaztHCT grondo   flux       CD      2      2   18.56m corona[173-174]
 ƒVgCMmbgXCK grondo   flux       CD      2      2   11.17m corona[173-174]
grondo@corona212:~$ flux pgrep -c 5 -o full -a ^flux 'runtime:>15m'
       JOBID USER     NAME       ST NTASKS NNODES     TIME INFO
 ƒVvgZo1MUyd grondo   flux       TO      1      1   30.01m corona191
 ƒVteoaztHCT grondo   flux       CD      2      2   18.56m corona[173-174]
 ƒUtgSrCvybM grondo   flux       TO      2      2   30.01m corona[173-174]
 ƒUS2n9MNnVD grondo   flux       TO      2      2   30.02m corona[171,173]
 ƒUQpgKmARXm grondo   flux       TO      2      2   30.02m corona[171,173]
 grondo@corona212:~$ flux pgrep -c 5 -o full -a ^flux 'runtime:>15m' is:failed host:corona[160-170]
       JOBID USER     NAME       ST NTASKS NNODES     TIME INFO
  ƒQ8HGmJruD grondo   flux        F     48      1   6.313h corona160
```


The `flux pkill` command is just a link to `flux pgrep` and is equivalent to calling `flux pgrep` with the `-k, --kill` option, though what the command actually does now is cancel jobs. It currently reports the number of jobs killed, and includes a `--wait` option to wait until the jobs complete before returning to the command line:

```
f(s=2,d=1,builddir) grondo@corona189:~$ flux mini submit --quiet --cc=1-1000 sleep 100
f(s=2,d=1,builddir) grondo@corona189:~$ flux pkill sleep
flux-pkill: INFO: Canceled 1000 jobs
```

On problem here is that `flux pgrep|pkill` uses the default limit of fetching at most 1000 entries from the `job-list` service. There's a `--max-entries` option to increase that, but this is something to keep in mind since your `pkill` command may not find all possible matches. Maybe eventually we could move `job-list` to use a database and instead of compiling the `flux-pgrep` expression locally, we could compile it a SQL statement or job-list could support the JsonLogic-like RFC 31 constraint object format.

This branch is currently based on #4677 since it uses the `flux.job.Constraint` class. If this PR were ever merged, the current `JobPgrep` class would need a rewrite. If you dare look at the code, remember: prototype.