### PR TITLE
 job-list: separate t_submit / t_depend  calculation

### DIFF
--- a/src/modules/job-list/job_data.h
+++ b/src/modules/job-list/job_data.h
@@ -21,7 +21,8 @@
  *
  * associated eventlog entries when restarting
  *
- * t_depend - "submit"
+ * t_submit = "submit"
+ * t_depend - "validate"
  * t_priority - "priority" (not saved, can be entered multiple times)
  * t_sched - "depend" (not saved, can be entered multiple times)
  * t_run - "alloc"
@@ -36,8 +37,7 @@ struct job {
     int urgency;
     int64_t priority;
     double t_submit;
-    // t_depend is identical to t_submit
-    // double t_depend;
+    double t_depend;
     double t_run;
     double t_cleanup;
     double t_inactive;
@@ -85,6 +85,7 @@ struct job {
     void *list_handle;
 
     int eventlog_seq;           /* last event seq read */
+    int submit_version;         /* version number in submit context */
 };
 
 void job_destroy (void *data);

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -323,6 +323,7 @@ dist_check_SCRIPTS = \
 	issues/t4612-eventlog-overwrite-crash.sh \
 	issues/t4711-job-list-purge-inactive.sh \
 	issues/t4771-flux-start-bash.sh \
+	issues/t4852-t_submit-legacy.sh \
 	python/__init__.py \
 	python/subflux.py \
 	python/tap \

--- a/t/issues/t4852-t_submit-legacy.sh
+++ b/t/issues/t4852-t_submit-legacy.sh
@@ -1,0 +1,51 @@
+#!/bin/bash -e
+
+# test-prereqs: HAVE_JQ
+
+# ensure t_submit/t_depend is available from job-list in older
+# versions of flux that did not have the validate event.  To test, we
+# remove the validate in an existing job's eventlog.
+
+cat <<-EOF >t4852setup.sh
+#!/bin/sh -e
+
+jobid=\$(flux mini submit --wait /bin/true)
+
+kvspath=\$(flux job id --to=kvs \$jobid)
+
+flux kvs get \$kvspath.eventlog | grep -v validate > job4852.log
+
+# need to remove version field in submit event for legacy eventlog format
+# lazily "remove" it by just renaming it
+head -n 1 job4852.log | sed -e "s/version/foobar/" > job4852.log2
+tail -n +2 job4852.log >> job4852.log2
+
+# head -n -1 to remove trailing newline
+cat job4852.log2 | head -n -1 | flux kvs put -r \${kvspath}.eventlog=-
+
+EOF
+
+cat <<-EOF >t4852test.sh
+#!/bin/sh -e
+
+#assuming only one job in this test
+flux jobs -a -no {id} > job4852.id
+flux job list-ids \$(cat job4852.id) > job4852.out
+grep t_submit job4852.out
+grep t_depend job4852.out
+cat job4852.out | jq -e ".t_submit == .t_depend"
+EOF
+
+chmod +x t4852setup.sh
+chmod +x t4852test.sh
+
+STATEDIR=issue4852-statedir
+mkdir issue4852-statedir
+
+flux start -s 1 \
+    -o,--setattr=statedir=${STATEDIR} \
+    ./t4852setup.sh
+
+flux start -s 1 \
+    -o,--setattr=statedir=${STATEDIR} \
+    ./t4852test.sh

--- a/t/t2260-job-list.t
+++ b/t/t2260-job-list.t
@@ -601,6 +601,7 @@ test_expect_success HAVE_JQ 'flux job list job state timing outputs valid (job i
         jobid=$(flux mini submit --wait hostname | flux job id) &&
         wait_jobid_state $jobid inactive &&
         obj=$(flux job list -s inactive | grep $jobid) &&
+        echo $obj | jq -e ".t_submit < .t_depend" &&
         echo $obj | jq -e ".t_depend < .t_run" &&
         echo $obj | jq -e ".t_run < .t_cleanup" &&
         echo $obj | jq -e ".t_cleanup < .t_inactive"
@@ -612,6 +613,7 @@ test_expect_success HAVE_JQ 'flux job list job state timing outputs valid (job r
         fj_wait_event $jobid start >/dev/null &&
         wait_jobid_state $jobid running &&
         obj=$(flux job list -s running | grep $jobid) &&
+        echo $obj | jq -e ".t_submit < .t_depend" &&
         echo $obj | jq -e ".t_depend < .t_run" &&
         echo $obj | jq -e ".t_cleanup == null" &&
         echo $obj | jq -e ".t_inactive == null" &&

--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -689,7 +689,7 @@ test_expect_success 'flux-jobs --format={nodelist},{nodelist:h} works' '
 '
 
 # test just make sure numbers are zero or non-zero given state of job
-test_expect_success 'flux-jobs --format={t_submit/depend/sched} works' '
+test_expect_success 'flux-jobs --format={t_submit/depend} works' '
 	flux jobs -ano "{t_submit},{t_depend}" >t_SD.out &&
 	count=`cut -d, -f1 t_SD.out | grep -v "^0.0$" | wc -l` &&
 	test $count -eq $(state_count all) &&


### PR DESCRIPTION
Problem: Prior to the introduction of the validate event in

https://github.com/flux-framework/flux-core/commit/9f7aa094e3533cb49c6bbd02c8535e7209aef31e

the t_submit and t_depend timestamps returned by job-list were
identical because the 'submit' timestamp lead to the DEPEND
state transition.  Both attribute names were supported for
convenience.

However, after the introduction of the 'validate' event, these two
values should be different.  t_submit should be associated with the
'submit' event.  t_depend should be associated with the 'validate'
event and transition to the DEPEND state.

This lack of a split between the two values resulted in data
errors for older jobs without a 'validate' event.  Without the
'validate' event job-list would never process that a t_submit/t_depend
timestamp ever occurred.  So job-list would not return a value of
t_submit/t_depend for any job without a 'validate' event.

Solution: Set t_submit and t_depend independently from each other.
t_submit is set all the time from the 'submit' event.  t_depend
is set on transition to the DEPEND state.  Therefore if a transition
to a DEPEND state does not occur, it will not be set.

On older jobs without a 'validate' event, t_depend may not be set as a
result.  However t_submit will be set on every job.

Fixes https://github.com/flux-framework/flux-core/issues/4852