### PR TITLE
libjob: deprecate flux_job_list() and flux_job_list_inactive()

### DIFF
--- a/src/bindings/python/_flux/Makefile.am
+++ b/src/bindings/python/_flux/Makefile.am
@@ -21,7 +21,8 @@ common_libs = \
 	$(PYTHON_LIBS)
 
 PREPROC_FLAGS = \
-	-E '-D__attribute__(...)='
+	-E '-D__attribute__(...)=' \
+	-D "FLUX_DEPRECATED(...)="
 
 fluxpyso_LTLIBRARIES = \
 	_core.la \

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -1357,10 +1357,19 @@ int cmd_list (optparse_t *p, int argc, char **argv)
     else
         userid = getuid ();
 
-    if (!(f = flux_job_list (h, max_entries, "[\"all\"]", userid, states)))
-        log_err_exit ("flux_job_list");
+    if (!(f = flux_rpc_pack (h,
+                             "job-list.list",
+                             FLUX_NODEID_ANY,
+                             0,
+                             "{s:i s:[s] s:i s:i s:i}",
+                             "max_entries", max_entries,
+                             "attrs", "all",
+                             "userid", userid,
+                             "states", states,
+                             "results", 0)))
+        log_err_exit ("flux_rpc_pack");
     if (flux_rpc_get_unpack (f, "{s:o}", "jobs", &jobs) < 0)
-        log_err_exit ("flux_job_list");
+        log_err_exit ("flux job-list.list");
     json_array_foreach (jobs, index, value) {
         char *str;
         str = json_dumps (value, 0);
@@ -1399,10 +1408,20 @@ int cmd_list_inactive (optparse_t *p, int argc, char **argv)
     if (!(h = flux_open (NULL, 0)))
         log_err_exit ("flux_open");
 
-    if (!(f = flux_job_list_inactive (h, max_entries, since, "[\"all\"]")))
-        log_err_exit ("flux_job_list_inactive");
+    if (!(f = flux_rpc_pack (h,
+                             "job-list.list",
+                             FLUX_NODEID_ANY,
+                             0,
+                             "{s:i s:f s:i s:i s:i s:[s]}",
+                             "max_entries", max_entries,
+                             "since", since,
+                             "userid", FLUX_USERID_UNKNOWN,
+                             "states", FLUX_JOB_STATE_INACTIVE,
+                             "results", 0,
+                             "attrs", "all")))
+        log_err_exit ("flux_rpc_pack");
     if (flux_rpc_get_unpack (f, "{s:o}", "jobs", &jobs) < 0)
-        log_err_exit ("flux_job_list_inactive");
+        log_err_exit ("flux job-list.list");
     json_array_foreach (jobs, index, value) {
         char *str;
         str = json_dumps (value, 0);

--- a/src/common/libflux/types.h
+++ b/src/common/libflux/types.h
@@ -24,6 +24,12 @@ typedef struct {
     char text[160];
 } flux_error_t;
 
+/* FLUX_DEPRECATED may be altered during pre-processing, check for
+ * definition */
+#ifndef FLUX_DEPRECATED
+#define FLUX_DEPRECATED(...) __VA_ARGS__ __attribute__((deprecated))
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/common/libjob/Makefile.am
+++ b/src/common/libjob/Makefile.am
@@ -69,6 +69,7 @@ test_cppflags = \
 	-I$(top_srcdir)/src/common/libtap
 
 test_job_t_SOURCES = test/job.c
+test_job_t_CFLAGS = -Wno-deprecated-declarations
 test_job_t_CPPFLAGS = $(test_cppflags)
 test_job_t_LDADD = $(test_ldadd)
 

--- a/src/common/libjob/job.h
+++ b/src/common/libjob/job.h
@@ -136,36 +136,16 @@ int flux_job_wait_get_status (flux_future_t *f,
                               const char **errstr);
 int flux_job_wait_get_id (flux_future_t *f, flux_jobid_t *id);
 
-/* Request a list of jobs.
- * If 'max_entries' > 0, fetch at most that many jobs.
- * 'attrs_json_str' is an encoded JSON array of attribute strings, e.g.
- * ["id","userid",...] that will be returned in response.
- *
- * Process the response payload with flux_rpc_get() or flux_rpc_get_unpack().
- * It is a JSON object containing an array of job objects, e.g.
- * { "jobs":[
- *   {"id":m, "userid":n},
- *   {"id":m, "userid":n},
- *   ...
- * ])
- *
- * states can be set to an OR of any job state or any virtual job
- * states to retrieve jobs of only those states.  Specify 0 for all
- * states.
- */
-flux_future_t *flux_job_list (flux_t *h,
-                              int max_entries,
-                              const char *attrs_json_str,
-                              uint32_t userid,
-                              int states);
+FLUX_DEPRECATED(flux_future_t *flux_job_list (flux_t *,
+                                              int,
+                                              const char *,
+                                              uint32_t,
+                                              int));
 
-/* Similar to flux_job_list(), but retrieve inactive jobs newer
- * than a timestamp.
- */
-flux_future_t *flux_job_list_inactive (flux_t *h,
-                                       int max_entries,
-                                       double since,
-                                       const char *attrs_json_str);
+FLUX_DEPRECATED(flux_future_t *flux_job_list_inactive (flux_t *,
+                                                       int,
+                                                       double,
+                                                       const char *));
 
 /* Similar to flux_job_list(), but retrieve job info for a single
  * job id */

--- a/src/modules/job-list/list.c
+++ b/src/modules/job-list/list.c
@@ -226,6 +226,11 @@ void list_cb (flux_t *h, flux_msg_handler_t *mh,
         errno = EPROTO;
         goto error;
     }
+    if (since < 0.) {
+        seterror (&err, "invalid payload: since < 0.0 not allowed");
+        errno = EPROTO;
+        goto error;
+    }
     if (!json_is_array (attrs)) {
         seterror (&err, "invalid payload: attrs must be an array");
         errno = EPROTO;

--- a/t/t2260-job-list.t
+++ b/t/t2260-job-list.t
@@ -440,7 +440,7 @@ test_expect_success 'flux job list-inactive w/ since -1 leads to error' '
 
 test_expect_success 'flux job list-inactive w/ count -1 leads to error' '
 	test_must_fail flux job list-inactive --count=-1 > list_inactive_error2.out 2>&1 &&
-	grep "Invalid argument" list_inactive_error1.out
+	grep "Invalid argument" list_inactive_error2.out
 '
 
 test_expect_success 'flux job list-inactive w/ since (most recent timestamp)' '

--- a/t/t2260-job-list.t
+++ b/t/t2260-job-list.t
@@ -435,12 +435,12 @@ test_expect_success 'flux job list-inactive w/ count limits output of inactive j
 
 test_expect_success 'flux job list-inactive w/ since -1 leads to error' '
 	test_must_fail flux job list-inactive --since=-1 > list_inactive_error1.out 2>&1 &&
-	grep "Invalid argument" list_inactive_error1.out
+	grep "Protocol error" list_inactive_error1.out
 '
 
 test_expect_success 'flux job list-inactive w/ count -1 leads to error' '
 	test_must_fail flux job list-inactive --count=-1 > list_inactive_error2.out 2>&1 &&
-	grep "Invalid argument" list_inactive_error2.out
+	grep "Protocol error" list_inactive_error2.out
 '
 
 test_expect_success 'flux job list-inactive w/ since (most recent timestamp)' '


### PR DESCRIPTION
Per #4514 

I gave this issue another go around late last week.  The major gotcha is the auto-generation of python bindings to deprecated C functions, which we probably don't want to do.

Going back and forth with several options, I decided on the following approach.  Set

```
#ifndef FLUX_DEPRECATED
...
#endif
```

around deprecated C functions, so that the python scripts wouldn't generate those functions.

The big pro was that it was relatively easy, not a lot of changes, no major script updates to python bindings stuff.

The con is, well, that this is all it is.  Using the python `deprecated` decorator appears more for non-auto-generated stuff and would probably require a non-trivial amount of scripting hacks to add that in, especially for auto generated stuff.

Considered a special "blocklist" file for the python bindings, but given how cffi generates things (just slurps up the .h files) didn't seem the easiest to add either.