### PR TITLE
job-manager: do not checkpoint on every queue state change

### DIFF
--- a/doc/man1/flux-queue.rst
+++ b/doc/man1/flux-queue.rst
@@ -84,7 +84,7 @@ OPTIONS
    Be taciturn.
 
 **-a, --all**
-   Use with *enable*, *disable*, *stop, or *start* subcommands to
+   Use with *enable*, *disable*, *stop*, or *start* subcommands to
    signify intent to affect all queues, when queues are configured but
    *--queue* is missing.
 

--- a/src/modules/job-manager/queue.c
+++ b/src/modules/job-manager/queue.c
@@ -619,8 +619,6 @@ static void queue_enable_cb (flux_t *h,
         if (jobq_enable (q, enable, disable_reason) < 0)
             goto error;
     }
-    if (restart_save_state (queue->ctx) < 0)
-        flux_log_error (h, "problem saving checkpoint after queue change");
     if (flux_respond (h, msg, NULL) < 0)
         flux_log_error (h, "error responding to job-manager.queue-enable");
     return;
@@ -719,8 +717,6 @@ static void queue_start_cb (flux_t *h,
         else
             queue_stop (queue, name);
     }
-    if (restart_save_state (queue->ctx) < 0)
-        flux_log_error (h, "problem saving checkpoint after queue change");
     if (flux_respond (h, msg, NULL) < 0)
         flux_log_error (h, "error responding to job-manager.queue-start");
     return;

--- a/t/t2219-job-manager-restart.t
+++ b/t/t2219-job-manager-restart.t
@@ -114,7 +114,6 @@ test_expect_success 'verify that instance can restart after config change' '
 '
 
 test_expect_success 'verify that named queue start/stop persists across restart' '
-	rm -rf /tmp/achu/mylog &&
 	mkdir -p conf.d &&
 	cat >conf.d/queues.toml <<-EOT &&
 	[queues.debug]


### PR DESCRIPTION
Per #4804, the number of checkpoints to the KVS seems a bit excessive, as it occurs on every change.

Instead, do it only when the user asks to via a `sync` flag.  So that users can say "hey preserve this specific change just in case of catastrophic failure", as well as to help with testing.

I made one additional change that I think is important, when checkpointing in the `job-manager`, make sure that the FLUX_KVS_SYNC flag is set, to ensure the data is on the backing store as well.  Would have slowed things down before, but now that syncs are optional, I think it more than offsets it.

