### PR TITLE
flux-resource: support QUEUE output in resource list

### DIFF
--- a/doc/man1/flux-resource.rst
+++ b/doc/man1/flux-resource.rst
@@ -150,8 +150,14 @@ The following field names can be specified for the **list** subcommand:
 **state**
    State of node(s): "up", "down", "allocated", "free", "all"
 
+**queue**
+   queue(s) associated with resources.
+
 **properties**
    Properties associated with resources.
+
+**propertiesx**
+   Properties associated with resources, but with queue names removed.
 
 **nnodes**
    number of nodes

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -690,3 +690,4 @@ waitable
 novalidate
 ngpus
 rlist
+propertiesx

--- a/src/cmd/flux-resource.py
+++ b/src/cmd/flux-resource.py
@@ -56,14 +56,14 @@ class FluxResourceConfig(UtilConfig):
         "default": {
             "description": "Default flux-resource list format string",
             "format": (
-                "{state:>10} ?:{properties:<10.10+} {nnodes:>6} "
+                "{state:>10} ?:{queue:<8.8} ?:{properties:<10.10+} {nnodes:>6} "
                 "{ncores:>8} {ngpus:>8} {nodelist}"
             ),
         },
         "rlist": {
             "description": "Format including resource list details",
             "format": (
-                "{state:>10} ?:{properties:<10.10+} {nnodes:>6} "
+                "{state:>10} ?:{queue:<8.8} ?:{properties:<10.10+} {nnodes:>6} "
                 "{ncores:>8} {ngpus:>8} {rlist}"
             ),
         },
@@ -432,7 +432,7 @@ class ResourceSetExtra(ResourceSet):
     @property
     def queue(self):
         queues = ""
-        if self.flux_config and self.flux_config["queues"]:
+        if self.flux_config and "queues" in self.flux_config:
             properties = json.loads(self.get_properties())
             for key, value in self.flux_config["queues"].items():
                 if value["requires"] and set(value["requires"]).issubset(

--- a/src/cmd/flux-resource.py
+++ b/src/cmd/flux-resource.py
@@ -430,6 +430,17 @@ class ResourceSetExtra(ResourceSet):
             super().__init__(arg, version)
 
     @property
+    def propertiesx(self):
+        properties = json.loads(self.get_properties())
+        queues = self.queue
+        if self.queue:
+            queues = queues.split(",")
+            for q in queues:
+                if q in properties:
+                    properties.pop(q)
+        return ",".join(properties.keys())
+
+    @property
     def queue(self):
         queues = ""
         if self.flux_config and "queues" in self.flux_config:
@@ -448,7 +459,7 @@ def resources_uniq_lines(resources, states, formatter, config):
     the ResourceSet formatter argument. Include only the provided states
     """
     #  uniq_fields are the fields on which to combine like results
-    uniq_fields = ["state", "properties", "queue"]
+    uniq_fields = ["state", "properties", "propertiesx", "queue"]
 
     #
     #  Create the uniq format by combining all provided uniq fields:
@@ -504,6 +515,7 @@ def list_handler(args):
         "state": "STATE",
         "queue": "QUEUE",
         "properties": "PROPERTIES",
+        "propertiesx": "PROPERTIES",
         "nnodes": "NNODES",
         "ncores": "NCORES",
         "ngpus": "NGPUS",

--- a/src/cmd/flux-resource.py
+++ b/src/cmd/flux-resource.py
@@ -419,13 +419,36 @@ def drain_list(args):
     status(args)
 
 
-def resources_uniq_lines(resources, states, formatter):
+class ResourceSetExtra(ResourceSet):
+    def __init__(self, arg=None, version=1, flux_config=None):
+        self.flux_config = flux_config
+        if isinstance(arg, ResourceSet):
+            super().__init__(arg.encode(), version)
+            if arg.state:
+                self.state = arg.state
+        else:
+            super().__init__(arg, version)
+
+    @property
+    def queue(self):
+        queues = ""
+        if self.flux_config and self.flux_config["queues"]:
+            properties = json.loads(self.get_properties())
+            for key, value in self.flux_config["queues"].items():
+                if value["requires"] and set(value["requires"]).issubset(
+                    set(properties)
+                ):
+                    queues = queues + "," + key if queues else key
+        return queues
+
+
+def resources_uniq_lines(resources, states, formatter, config):
     """
     Generate a set of resource sets that would produce unique lines given
     the ResourceSet formatter argument. Include only the provided states
     """
     #  uniq_fields are the fields on which to combine like results
-    uniq_fields = ["state", "properties"]
+    uniq_fields = ["state", "properties", "queue"]
 
     #
     #  Create the uniq format by combining all provided uniq fields:
@@ -453,7 +476,7 @@ def resources_uniq_lines(resources, states, formatter):
             #   resource set for output purposes. O/w the output for this
             #   state would be suppressed.
             #
-            rset = ResourceSet()
+            rset = ResourceSetExtra(flux_config=config)
             rset.state = state
             key = fmt.format(rset)
             if key not in lines:
@@ -464,6 +487,7 @@ def resources_uniq_lines(resources, states, formatter):
 
         for rank in resources[state].ranks:
             rset = resources[state].copy_ranks(rank)
+            rset = ResourceSetExtra(rset, flux_config=config)
             key = fmt.format(rset)
 
             if key not in lines:
@@ -478,6 +502,7 @@ def list_handler(args):
     valid_states = ["up", "down", "allocated", "free", "all"]
     headings = {
         "state": "STATE",
+        "queue": "QUEUE",
         "properties": "PROPERTIES",
         "nnodes": "NNODES",
         "ncores": "NCORES",
@@ -486,6 +511,7 @@ def list_handler(args):
         "nodelist": "NODELIST",
         "rlist": "LIST",
     }
+    config = None
 
     states = args.states.split(",")
     for state in states:
@@ -496,12 +522,18 @@ def list_handler(args):
     if args.from_stdin:
         resources = SchedResourceList(json.load(sys.stdin))
     else:
-        resources = resource_list(flux.Flux()).get()
+        handle = flux.Flux()
+        rpcs = [resource_list(handle), handle.rpc("config.get")]
+        resources = rpcs[0].get()
+        try:
+            config = rpcs[1].get()
+        except Exception as e:
+            LOGGER.warning("Could not get flux config: " + str(e))
 
     fmt = FluxResourceConfig("list").load().get_format_string(args.format)
     formatter = flux.util.OutputFormat(fmt, headings=headings)
 
-    lines = resources_uniq_lines(resources, states, formatter)
+    lines = resources_uniq_lines(resources, states, formatter, config)
     formatter.print_items(lines.values(), no_header=args.no_header)
 
 

--- a/src/cmd/flux-resource.py
+++ b/src/cmd/flux-resource.py
@@ -56,14 +56,14 @@ class FluxResourceConfig(UtilConfig):
         "default": {
             "description": "Default flux-resource list format string",
             "format": (
-                "{state:>10} ?:{queue:<8.8} ?:{properties:<10.10+} {nnodes:>6} "
+                "{state:>10} ?:{queue:<8.8} ?:{propertiesx:<10.10+} {nnodes:>6} "
                 "{ncores:>8} {ngpus:>8} {nodelist}"
             ),
         },
         "rlist": {
             "description": "Format including resource list details",
             "format": (
-                "{state:>10} ?:{queue:<8.8} ?:{properties:<10.10+} {nnodes:>6} "
+                "{state:>10} ?:{queue:<8.8} ?:{propertiesx:<10.10+} {nnodes:>6} "
                 "{ncores:>8} {ngpus:>8} {rlist}"
             ),
         },

--- a/t/t2315-resource-system.t
+++ b/t/t2315-resource-system.t
@@ -165,12 +165,13 @@ test_expect_success 'resources can be configured in TOML' '
 	EOF
 	flux start -s 1 \
 		-o,--config-path=$(pwd)/${name},-Slog-filename=${name}/logfile \
-		flux resource list -s all > ${name}/output &&
+		flux resource list -s all -n \
+		   -o "{state} {properties} {nnodes} {ncores} {ngpus} {nodelist}" \
+		   > ${name}/output &&
 	test_debug "cat ${name}/output" &&
 	cat <<-EOF >${name}/expected &&
-	     STATE PROPERTIES NNODES   NCORES    NGPUS NODELIST
-	       all debug           3       12        0 foo[0-2]
-	       all batch           8       32        4 foo[3-10]
+	all debug 3 12 0 foo[0-2]
+	all batch 8 32 4 foo[3-10]
 	EOF
 	test_cmp ${name}/expected ${name}/output
 '

--- a/t/t2350-resource-list.t
+++ b/t/t2350-resource-list.t
@@ -6,6 +6,8 @@ test_description='flux-resource list tests'
 test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
 . $(dirname $0)/sharness.sh
 
+test_under_flux 4 full
+
 # Use a static format to avoid breaking output if default flux-resource list
 #  format ever changes
 FORMAT="{state:>10} {properties:<10} {nnodes:>6} {ncores:>8} {ngpus:>8}"
@@ -118,5 +120,66 @@ test_expect_success 'flux resource list -o rlist works' '
 		--from-stdin <properties-test.in >rlist.out &&
 	test_debug "cat rlist.out" &&
 	grep -i list rlist.out
+'
+test_expect_success 'configure queues and resource split amongst queues' '
+	flux R encode -r 0-3 -p batch:0-1 -p debug:2-3 \
+	   | tr -d "\n" \
+	   | flux kvs put -r resource.R=- &&
+	flux config load <<-EOT &&
+	[queues.batch]
+	requires = [ "batch" ]
+	[queues.debug]
+	requires = [ "debug" ]
+	EOT
+	flux queue start --all &&
+	flux module unload sched-simple &&
+	flux module reload resource &&
+	flux module load sched-simple
+'
+test_expect_success 'flux resource list default lists queues' '
+	flux resource list | grep QUEUE
+'
+test_expect_success 'flux resource lists expected queues (single)' '
+	flux resource list -o "{state} {nnodes} {queue}" > listqueue_single.out &&
+	test $(grep -c "free 2 batch" listqueue_single.out) -eq 1 &&
+	test $(grep -c "free 2 debug" listqueue_single.out) -eq 1
+'
+test_expect_success 'run a few jobs' '
+	flux mini submit -q batch sleep 30 > job1A.id &&
+	flux mini submit -q debug sleep 30 > job1B.id
+'
+test_expect_success 'flux resource lists expected queues in states (single)' '
+	flux resource list -o "{state} {nnodes} {queue}" > list2.out &&
+	test $(grep -c "free 1 batch" list2.out) -eq 1 &&
+	test $(grep -c "free 1 debug" list2.out) -eq 1 &&
+	test $(grep -c "allocated 1 batch" list2.out) -eq 1 &&
+	test $(grep -c "allocated 1 debug" list2.out) -eq 1
+'
+test_expect_success 'cleanup jobs' '
+	flux job cancel $(cat job1A.id) $(cat job1B.id)
+'
+test_expect_success 'configure queues and resource split amongst queues' '
+	flux R encode -r 0-3 -p all:0-3 -p batch:0-1 -p debug:2-3 \
+	   | tr -d "\n" \
+	   | flux kvs put -r resource.R=- &&
+	flux config load <<-EOT &&
+	[queues.all]
+	requires = [ "all" ]
+	[queues.batch]
+	requires = [ "batch" ]
+	[queues.debug]
+	requires = [ "debug" ]
+	EOT
+	flux queue start --all &&
+	flux module unload sched-simple &&
+	flux module reload resource &&
+	flux module load sched-simple
+'
+# we can't predict listing order, so we grep counts
+test_expect_success 'flux resource lists expected queues (multi)' '
+	flux resource list -o "{state} {nnodes} {queue}" > listqueue_multi.out &&
+	test $(grep "free 2" listqueue_multi.out | grep -c batch) -eq 1 &&
+	test $(grep "free 2" listqueue_multi.out | grep -c debug) -eq 1 &&
+	test $(grep "free 2" listqueue_multi.out | grep -c all) -eq 2
 '
 test_done

--- a/t/t2350-resource-list.t
+++ b/t/t2350-resource-list.t
@@ -144,6 +144,16 @@ test_expect_success 'flux resource lists expected queues (single)' '
 	test $(grep -c "free 2 batch" listqueue_single.out) -eq 1 &&
 	test $(grep -c "free 2 debug" listqueue_single.out) -eq 1
 '
+test_expect_success 'flux resource lists expected properties (single)' '
+	flux resource list -o "{state} {nnodes} {properties}" > listprop_single.out &&
+	test $(grep -c "free 2 batch" listprop_single.out) -eq 1 &&
+	test $(grep -c "free 2 debug" listprop_single.out) -eq 1
+'
+# no properties should be output, leading to a single line for all 4 "free" nodes
+test_expect_success 'flux resource lists no properties in propertiesx (single)' '
+	flux resource list -o "{state} {nnodes} {propertiesx}" > listpropx_single.out &&
+	grep "free 4" listpropx_single.out
+'
 test_expect_success 'run a few jobs' '
 	flux mini submit -q batch sleep 30 > job1A.id &&
 	flux mini submit -q debug sleep 30 > job1B.id
@@ -175,11 +185,55 @@ test_expect_success 'configure queues and resource split amongst queues' '
 	flux module reload resource &&
 	flux module load sched-simple
 '
-# we can't predict listing order, so we grep counts
+# we can't predict listing order of queues/properties, so we grep counts
 test_expect_success 'flux resource lists expected queues (multi)' '
 	flux resource list -o "{state} {nnodes} {queue}" > listqueue_multi.out &&
 	test $(grep "free 2" listqueue_multi.out | grep -c batch) -eq 1 &&
 	test $(grep "free 2" listqueue_multi.out | grep -c debug) -eq 1 &&
 	test $(grep "free 2" listqueue_multi.out | grep -c all) -eq 2
+'
+test_expect_success 'flux resource lists expected properties (multi)' '
+	flux resource list -o "{state} {nnodes} {properties}" > listprop_multi.out &&
+	test $(grep "free 2" listprop_multi.out | grep -c batch) -eq 1 &&
+	test $(grep "free 2" listprop_multi.out | grep -c debug) -eq 1 &&
+	test $(grep "free 2" listprop_multi.out | grep -c all) -eq 2
+'
+# no properties should be output, leading to a single line for all 4 "free" nodes
+test_expect_success 'flux resource lists no properties in propertiesx (multi)' '
+	flux resource list -o "{state} {nnodes} {propertiesx}" > listpropx_multi.out &&
+	grep "free 4" listpropx_multi.out
+'
+test_expect_success 'configure queues and resource with extra property' '
+	flux R encode -r 0-3 -p batch:0-1 -p debug:2-3 -p foo:0-3\
+	   | tr -d "\n" \
+	   | flux kvs put -r resource.R=- &&
+	flux config load <<-EOT &&
+	[queues.batch]
+	requires = [ "batch" ]
+	[queues.debug]
+	requires = [ "debug" ]
+	EOT
+	flux queue start --all &&
+	flux module unload sched-simple &&
+	flux module reload resource &&
+	flux module load sched-simple
+'
+test_expect_success 'flux resource lists expected queues (extraprop)' '
+	flux resource list -o "{state} {nnodes} {queue}" > listqueue_extraprop.out &&
+	grep "free 2 batch" listqueue_extraprop.out &&
+	grep "free 2 debug" listqueue_extraprop.out
+'
+# we can't predict listing order of properties, so we grep counts
+test_expect_success 'flux resource lists expected properties (extraprop)' '
+	flux resource list -o "{state} {nnodes} {properties}" > listprop_extraprop.out &&
+	test $(grep "free 2" listprop_extraprop.out | grep -c batch) -eq 1 &&
+	test $(grep "free 2" listprop_extraprop.out | grep -c debug) -eq 1 &&
+	test $(grep "free 2" listprop_extraprop.out | grep -c foo) -eq 2
+'
+# only "foo" property should be output with properties, leading to
+# uniq line with 4 free nodes
+test_expect_success 'flux resource lists no properties in propertiesx (extraprop)' '
+	flux resource list -o "{state} {nnodes} {propertiesx}" > listpropx_extraprop.out &&
+	grep "free 4 foo" listpropx_extraprop.out
 '
 test_done


### PR DESCRIPTION
Per #4765

Just throwing this up here to see if there's any initial feedback.

This is a little tricky to support because:

A) "queue" is not returned from a `sched.resource-status` response ... thus

B) "queue" is not in the ResourceSet that is ultimately constructed from said response and fed into output code

I decided to create a new class currently called "ResourceSetPlusQueue", which just adds a "queue" property on top of "ResourceSet".  You initialize it with the flux configuration, and some logic is done to find queue(s) that meet the property requirements of the resources.

maybe some corner cases still as I haven't written any tests, but thought I'd just throw this up here if there's any initial thoughts on if this approach is sensible.  And maybe I'll come up with a better class name :P

my initial dumb test

```
#!/bin/sh

flux R encode -r 0-3 -p batch:0-1 -p debug:2-3 | tr -d '\n' | flux kvs put -r resource.R=-

flux config load <<-EOT
[queues.batch]
requires = [ "batch" ]

[queues.debug]
requires = [ "debug" ]

EOT

flux module unload sched-simple
flux module reload resource
flux module load sched-simple

flux resource list -o "{state:>10} {queue:>10} ?:{properties:<10.10+} {nnodes:>6} {ncores:>8} {ngpus:>8} {nodelist}"
```

```
     STATE      QUEUE PROPERTIES NNODES   NCORES    NGPUS NODELIST
      free      batch batch           1        1        0 catalyst160
 allocated                            0        0        0 
      down      batch batch           1        1        0 catalyst160
      down      debug debug           2        2        0 catalyst[160,160]
```
