### PR TITLE
Add flux-pgrep and flux-pkill 

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -45,13 +45,15 @@ MAN1_FILES_PRIMARY = \
 	man1/flux-shutdown.1 \
 	man1/flux-uptime.1 \
 	man1/flux-uri.1 \
-	man1/flux-resource.1
+	man1/flux-resource.1 \
+	man1/flux-pgrep.1
 
 # These files are generated as clones of a primary page.
 # Sphinx handles this automatically if declared in the conf.py
 MAN1_FILES_SECONDARY = \
 	man1/flux-setattr.1 \
-	man1/flux-lsattr.1
+	man1/flux-lsattr.1 \
+	man1/flux-pkill.1
 
 
 MAN3_FILES = $(MAN3_FILES_PRIMARY) $(MAN3_FILES_SECONDARY)

--- a/doc/man1/flux-pgrep.rst
+++ b/doc/man1/flux-pgrep.rst
@@ -1,0 +1,97 @@
+.. flux-help-include: true
+
+==============
+flux-pgrep(1)
+==============
+
+
+SYNOPSIS
+========
+
+**flux** **pgrep** [*OPTIONS*] expression..
+
+**flux** **pkill** [*OPTIONS*] expression..
+
+DESCRIPTION
+===========
+
+*flux-pgrep* lists jobids that match a supplied expression. The
+expression may contain a pattern which matches the job name, or
+a range of jobids in the form ``jobid1..jobid2``. If both a pattern
+and jobid range are supplied then both must match.
+
+In rare cases, a pattern may appear to be a jobid range, when the
+pattern ``..`` is used and the strings on both sides area also valid
+Flux jobids. In that case, a name pattern match can be forced by
+prefixing the pattern with ``name:``, e.g. ``name:fr..123``.
+
+By default, only active jobs for the current user are considered.
+
+*flux-pkill* cancels matching jobs instead of listing them. This is
+equivalent to running *flux-pgrep* with the ``-k`` option.
+
+OPTIONS
+=======
+
+**-a**
+   Include jobs in all states, including inactive jobs.
+   This is shorthand for *--filter=pending,running,inactive*.
+   (pgrep only)
+
+**-A**
+   Include jobs for all users. This is shorthand for *--user=-all*.
+
+**-u, --user**\ *=USER*
+   Fetch jobs only for the given user, instead of the current UID.
+
+**-f, --filter**\ *=STATE|RESULT*
+   Include jobs with specific job state or result. Multiple states or
+   results can be listed separated by comma. See the JOB STATUS section
+   of the :man1:`flux-jobs` manual for more detail.
+
+**-q, --queue**\ *=QUEUE*
+   Only include jobs in the named queue *QUEUE*.
+
+**-c, --count**\ *=N*
+   Limit output to the first *N* matches (default 1000).
+
+**--max-entries**\ *=N*
+   Limit the number of jobs to consider to *N* entries (default 1000).
+
+**-o, --format**\ *=NAME|FORMAT*
+   Specify a named output format *NAME* or a format string using Python's
+   format syntax. For full documentation of this option, including supported
+   field names and format configuration options, see :man1:flux-jobs. This
+   command shares configured named formats with *flux-jobs* by reading
+   *flux-jobs* configuration files. Supported builtin named formats include
+   *default*, *full*, *long*, and *deps*. The default format emits the matched
+   jobids only. (pgrep only)
+
+**-n, --suppress-header**
+   Suppress printing of the header line. (pgrep only)
+
+**-w, --wait**
+   Wait for jobs to finish after cancel. (pkill only)
+
+EXIT STATUS
+===========
+
+0
+   One or more jobs matched the supplied expression. For *pkill* the
+   process have also been successfully canceled.
+
+1
+   No jobs matched or there was an error canceling them.
+
+2
+   Syntax or other command line error.
+
+RESOURCES
+=========
+
+Flux: http://flux-framework.org
+
+SEE ALSO
+========
+
+:man1:`flux-jobs`

--- a/doc/man1/index.rst
+++ b/doc/man1/index.rst
@@ -28,6 +28,7 @@ man1
    flux-ping
    flux-proxy
    flux-pstree
+   flux-pgrep
    flux-queue
    flux-resource
    flux-restore

--- a/doc/manpages.py
+++ b/doc/manpages.py
@@ -32,6 +32,8 @@ man_pages = [
     ('man1/flux-getattr', 'flux-getattr', 'access broker attributes', [author], 1),
     ('man1/flux-jobs', 'flux-jobs', 'list jobs submitted to Flux', [author], 1),
     ('man1/flux-pstree', 'flux-pstree', 'display job hierarchies', [author], 1),
+    ('man1/flux-pgrep', 'flux-pgrep', 'search or cancel matching jobs', [author], 1),
+    ('man1/flux-pgrep', 'flux-pkill', 'search or cancel matching jobs', [author], 1),
     ('man1/flux-jobtap', 'flux-jobtap', 'List, remove, and load job-manager plugins', [author], 1),
     ('man1/flux-uptime', 'flux-uptime', 'Tell how long Flux has been up and running', [author], 1),
     ('man1/flux-shutdown', 'flux-shutdown', 'Shut down a Flux instance', [author], 1),

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -691,3 +691,6 @@ novalidate
 ngpus
 rlist
 propertiesx
+pgrep
+pkill
+deps

--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -37,9 +37,25 @@ LDADD = $(fluxcmd_ldadd)
 EXTRA_DIST = \
 	builtin-cmds-list.sh
 CLEANFILES = \
-	builtin-cmds.c
+	builtin-cmds.c \
+	flux-pkill.py
+
 BUILT_SOURCES = \
-	builtin-cmds.c
+	builtin-cmds.c \
+	flux-pkill.py
+
+flux-pkill.py:
+	$(AM_V_GEN)$(LN_S) $(srcdir)/flux-pgrep.py flux-pkill.py
+
+install-exec-hook:
+	$(AM_V_at)echo Linking flux-pkill to flux-pgrep && \
+	 (cd $(DESTDIR)$(fluxcmddir) && \
+	  rm -f flux-pkill.py && \
+	  $(LN_S) flux-pgrep.py flux-pkill.py)
+
+uninstall-local:
+	$(AM_V_at)echo Removing $(fluxcmddir)/flux-pkill.py && \
+	  rm -f $(fluxcmddir)/flux-pkill.py
 
 bin_PROGRAMS = flux
 flux_SOURCES = \
@@ -85,7 +101,8 @@ dist_fluxcmd_SCRIPTS = \
 	flux-job-exec-override.py \
 	flux-perilog-run.py \
 	flux-uri.py \
-	flux-pstree.py
+	flux-pstree.py \
+	flux-pgrep.py
 
 fluxcmd_PROGRAMS = \
 	flux-terminus \

--- a/src/cmd/flux-pgrep.py
+++ b/src/cmd/flux-pgrep.py
@@ -1,0 +1,281 @@
+##############################################################
+# Copyright 2023 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+##############################################################
+
+import argparse
+import logging
+import os
+import re
+import sre_constants
+import sys
+from itertools import islice
+from pathlib import PurePath
+
+import flux
+from flux.job import JobID, JobInfoFormat, JobList
+from flux.util import UtilConfig
+
+PROGRAM = PurePath(sys.argv[0]).stem
+LOGGER = logging.getLogger(PROGRAM)
+
+
+class FluxPgrepConfig(UtilConfig):
+    """flux-pgrep configuration class"""
+
+    builtin_formats = {
+        "default": {
+            "description": "Default flux-pgrep format string",
+            "format": "{id.f58}",
+        },
+        "full": {
+            "description": "full flux-pgrep format string",
+            "format": (
+                "{id.f58:>12} ?:{queue:<8.8} {username:<8.8} {name:<10.10+} "
+                "{status_abbrev:>2.2} {ntasks:>6} {nnodes:>6h} "
+                "{contextual_time!F:>8h} {contextual_info}"
+            ),
+        },
+        "long": {
+            "description": "Extended flux-pgrep format string",
+            "format": (
+                "{id.f58:>12} ?:{queue:<8.8} {username:<8.8} {name:<10.10+} "
+                "{status:>9.9} {ntasks:>6} {nnodes:>6h} "
+                "{t_submit!d:%b%d %R::>12} {t_remaining!F:>12h} "
+                "{contextual_time!F:>8h} {contextual_info}"
+            ),
+        },
+        "deps": {
+            "description": "Show job urgency, priority, and dependencies",
+            "format": (
+                "{id.f58:>12} ?:{queue:<8.8} {name:<10.10+} {urgency:<3} "
+                "{priority:<12} {state:<8.8} {dependencies}"
+            ),
+        },
+    }
+
+    def __init__(self):
+        initial_dict = {"formats": dict(self.builtin_formats)}
+        super().__init__(name="flux-jobs", initial_dict=initial_dict)
+
+    def validate(self, path, config):
+        """Validate a loaded flux-pgrep config file as dictionary"""
+        for key, value in config.items():
+            if key == "formats":
+                self.validate_formats(path, value)
+            else:
+                raise ValueError(f"{path}: invalid key {key}")
+
+
+class JobPgrep:
+    def __init__(self, args):
+        self.regex = None
+        self.jobids = []
+        for arg in args:
+            if ":" not in arg and ".." in arg:
+                #  X..Y with no : is translated to a range of jobids
+                try:
+                    self.jobids = list(map(JobID, arg.split("..")))
+                    continue
+                except ValueError:
+                    # If terms cannot be translated to JobID, then fall
+                    # back to trying as a pattern
+                    pass
+            if self.regex:
+                raise ValueError("Only one pattern can be provided")
+            if arg.startswith("name:"):
+                arg = arg[5:]
+            self.regex = re.compile(arg)
+
+    def match(self, job):
+        if self.regex and not self.regex.search(job.name):
+            return False
+        if self.jobids:
+            if job.id > self.jobids[1] or job.id < self.jobids[0]:
+                return False
+        return True
+
+
+def fetch_jobs(args, flux_handle=None):
+    if not flux_handle:
+        flux_handle = flux.Flux()
+
+    if args.A:
+        args.user = "all"
+    if args.a:
+        args.filter.update(["pending", "running", "inactive"])
+    if not args.filter:
+        args.filter = {"pending", "running"}
+
+    jobs_rpc = JobList(
+        flux_handle,
+        filters=args.filter,
+        user=args.user,
+        max_entries=args.max_entries,
+        queue=args.queue,
+    )
+    jobs = jobs_rpc.jobs()
+
+    #  Print all errors accumulated in JobList RPC:
+    try:
+        for err in jobs_rpc.errors:
+            print(err, file=sys.stderr)
+    except EnvironmentError:
+        # Ignore errors printing to stderr
+        pass
+
+    return jobs
+
+
+class FilterActionSetUpdate(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        values = values.split(",")
+        getattr(namespace, self.dest).update(values)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        prog=PROGRAM, formatter_class=flux.util.help_formatter()
+    )
+    parser.add_argument(
+        "-a",
+        action="store_true",
+        help="Target jobs in all states"
+        if PROGRAM == "flux-pgrep"
+        else argparse.SUPPRESS,
+    )
+    parser.add_argument("-A", action="store_true", help="Target all users")
+    parser.add_argument(
+        "-u",
+        "--user",
+        type=str,
+        metavar="[USERNAME|UID]",
+        default=str(os.getuid()),
+        help="Limit output to specific username or userid "
+        '(Specify "all" for all users)',
+    )
+    parser.add_argument(
+        "-f",
+        "--filter",
+        action=FilterActionSetUpdate,
+        metavar="STATE|RESULT",
+        default=set(),
+        help="List jobs with specific job state or result",
+    )
+    parser.add_argument(
+        "--queue",
+        type=str,
+        metavar="QUEUE",
+        help="Limit output to specific queue",
+    )
+    parser.add_argument(
+        "-c",
+        "--count",
+        type=int,
+        metavar="N",
+        default=99999,
+        help="Limit output to the first N matches",
+    )
+    parser.add_argument(
+        "--max-entries",
+        type=int,
+        metavar="N",
+        default=1000,
+        help="Limit number of searched jobs to N entries (default: 1000)",
+    )
+    if PROGRAM == "flux-pgrep":
+        parser.add_argument(
+            "-n",
+            "--suppress-header",
+            action="store_true",
+            help="Suppress printing of header line",
+        )
+        parser.add_argument(
+            "-o",
+            "--format",
+            type=str,
+            default="default",
+            metavar="FORMAT",
+            help="Specify output format using Python's string format syntax "
+            + " or a defined format by name (use 'help' to get a list of names)",
+        )
+    else:
+        parser.add_argument(
+            "--wait", action="store_true", help="Wait for jobs to finish after cancel"
+        )
+    parser.add_argument(
+        "expression",
+        metavar="EXPRESSION",
+        type=str,
+        nargs="+",
+        help="job name pattern or id range",
+    )
+    return parser.parse_args()
+
+
+def pkill(fh, args, jobs):
+    success = 0
+    exitcode = 0
+
+    def wait_cb(future, job):
+        future.get_dict()
+
+    def cancel_cb(future, args, job):
+        nonlocal success, exitcode
+        try:
+            future.get()
+            success = success + 1
+            if args.wait:
+                flux.job.result_async(fh, job.id).then(wait_cb, job)
+        except OSError as exc:
+            exitcode = 1
+            LOGGER.error(f"{job.id}: cancel: {exc}")
+
+    for job in jobs:
+        flux.job.cancel_async(fh, job.id).then(cancel_cb, args, job)
+    fh.reactor_run()
+    LOGGER.info("Canceled %d job%s", success, "s" if success != 1 else "")
+    sys.exit(exitcode)
+
+
+@flux.util.CLIMain(LOGGER)
+def main():
+    sys.stdout = open(sys.stdout.fileno(), "w", encoding="utf8")
+    args = parse_args()
+
+    if PROGRAM == "flux-pgrep":
+        #  Process format before fetching jobs in case user makes an
+        #  error, or 'help' is specified
+        fmt = FluxPgrepConfig().load().get_format_string(args.format)
+        try:
+            formatter = JobInfoFormat(fmt)
+        except ValueError as err:
+            raise ValueError("Error in user format: " + str(err))
+
+    fh = flux.Flux()
+    try:
+        pgrep = JobPgrep(args.expression)
+    except (ValueError, SyntaxError, TypeError, sre_constants.error) as exc:
+        LOGGER.error(f"expression error: {exc}")
+        sys.exit(2)
+
+    jobs = list(islice(filter(pgrep.match, fetch_jobs(args, fh)), args.count))
+
+    #  Exit with exitcode 1 when no jobs match
+    if not jobs:
+        sys.exit(1)
+
+    if PROGRAM == "flux-pkill":
+        pkill(fh, args, jobs)
+
+    sformatter = JobInfoFormat(formatter.filter_empty(jobs))
+
+    if args.format == "default":
+        args.suppress_header = True
+
+    sformatter.print_items(jobs, no_header=args.suppress_header)

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -209,6 +209,7 @@ TESTSCRIPTS = \
 	t2808-shutdown-cmd.t \
 	t2809-job-purge.t \
 	t2810-kvs-garbage-collect.t \
+	t2811-flux-pgrep.t \
 	t2900-job-timelimits.t \
 	t3000-mpi-basic.t \
 	t3001-mpi-personalities.t \

--- a/t/t2811-flux-pgrep.t
+++ b/t/t2811-flux-pgrep.t
@@ -1,0 +1,102 @@
+#!/bin/sh
+
+test_description='Test the flux-pgrep/pkill commands'
+
+. $(dirname $0)/sharness.sh
+
+test_under_flux 1 job
+
+export FLUX_PYCLI_LOGLEVEL=10
+export SHELL=/bin/sh
+
+test_expect_success 'flux-pgrep errors on invalid arguments' '
+	test_must_fail flux pgrep &&
+	test_expect_code 2 flux pgrep foo bar &&
+	test_expect_code 2 flux pgrep \[
+'
+test_expect_success 'flux-pgrep returns 1 when no jobs match' '
+	test_expect_code 1 flux pgrep foo
+'
+test_expect_success 'flux-pgrep works for job nanes' '
+	flux mini bulksubmit --job-name={} sleep 60 \
+		::: testA testB foo &&
+	flux pgrep ^test > pgrep.out &&
+	test $(wc -l <pgrep.out) -eq 2
+'
+test_expect_success 'flux-pgrep --format option works' '
+	flux pgrep -o full ^foo >pgrep-full.out &&
+	test_debug "cat pgrep-full.out" &&
+	grep NAME pgrep-full.out
+'
+test_expect_success 'flux-pgrep --format option detects errors' '
+	test_must_fail flux pgrep -o {foo} ^foo
+'
+test_expect_success 'flux-pgrep --filter works' '
+	flux pgrep --filter=sched,run . >pgrep-filtered.out &&
+	test_debug "cat pgrep-filtered.out" &&
+	test $(wc -l <pgrep-filtered.out) -eq 3
+'
+test_expect_success 'flux-pkill works' '
+	flux pkill ^test &&
+	test_expect_code 1 flux pkill ^test &&
+	flux pkill foo
+'
+test_expect_success 'flux-pgrep works with jobid ranges' '
+	flux mini submit --bcc=1-6 sleep 60 >ids &&
+	flux mini submit --bcc=1-6 sleep 60 >ids2 &&
+	flux pgrep $(head -n 1 ids)..$(tail -n1 ids) >pgrep.ids &&
+	test $(wc -l <pgrep.ids) -eq 6 &&
+	flux pgrep $(head -n 1 ids)..$(tail -n1 ids2) >pgrep2.ids &&
+	test $(wc -l <pgrep2.ids) -eq 12 &&
+	flux pkill $(head -n1 ids)..$(tail -n1 ids) &&
+	flux pgrep $(head -n 1 ids)..$(tail -n1 ids2) >pgrep3.ids &&
+	test $(wc -l <pgrep3.ids) -eq 6 &&
+	flux pgrep -a $(head -n 1 ids)..$(tail -n1 ids2) >pgrep4.ids &&
+	test $(wc -l <pgrep4.ids) -eq 12
+'
+test_expect_success 'flux-pgrep assumes regex with invalid jobid(s)' '
+	flux pgrep sl..p
+'
+test_expect_success 'flux-pkill --wait option works' '
+	flux pkill --wait sleep &&
+	test_expect_code 1 flux pgrep .
+'
+test_expect_success 'flux-pkill reports errors' '
+	flux mini submit sleep 60 &&
+	test_expect_code 1 flux pkill -ac 2 sleep >pkill.out 2>&1 &&
+	test_debug "cat pkill.out" &&
+	grep ERROR.*inactive pkill.out
+'
+test_expect_success 'flux-pgrep accepts jobid range and pattern' '
+	flux mini bulksubmit --job-name={} sleep 60 ::: foo bar foo >ids3 &&
+	id1=$(sed -n 1p ids3) &&
+	id2=$(sed -n 2p ids3) &&
+	id3=$(sed -n 3p ids3) &&
+	flux pgrep -no full ${id1}..${id2} foo >pgrep.out3 &&
+	test_debug "cat pgrep.out3" &&
+	test $(wc -l < pgrep.out3) -eq 1 &&
+	grep foo pgrep.out3 &&
+	flux pkill --wait $id1..$id3
+'
+test_expect_success 'flux-pgrep forces regex with name: prefix' '
+	flux mini submit --job-name=f123f234 sleep 60 &&
+	flux pgrep name:f1..f2 &&
+	flux pkill --wait ^f123f234
+'
+test_expect_success 'flux-pgrep reads flux-jobs formats configuration' '
+	mkdir -p dir/flux &&
+	cat <<-EOF >dir/flux/flux-jobs.toml &&
+	[formats.myformat]
+	description = "my format"
+	format = "{id.words}"
+	EOF
+	XDG_CONFIG_HOME="$(pwd)/dir" \
+		flux pgrep --format=help foo >myformat.out&&
+	test_debug "cat myformat.out" &&
+	grep "my format" myformat.out  &&
+	flux mini submit --job-name=test sleep 30 &&
+	XDG_CONFIG_HOME="$(pwd)/dir" \
+		flux pgrep -o myformat test &&
+	flux pkill test
+'
+test_done


### PR DESCRIPTION
This PR adds a minimal version of `flux-pgrep`/`flux-pkill`. This allows matching and canceling jobs by name and/or jobid range without the more advanced match/constraint syntax proposed in #4849. Once RFC 35 in flux-framework/rfc#360 is approved, then we can extend pgrep to support the more advanced syntax once again.

This version of `flux-pgrep` supports matching a pattern  to job names by default. Due to user request, a jobid range is also supported if the match expression appears as `ID1..ID2`. Since that is also a valid pattern, a name regex can be forced via `name:<pattern>`.