### PR TITLE
clean up little used broker attribute functionality

### DIFF
--- a/doc/man1/flux-getattr.rst
+++ b/doc/man1/flux-getattr.rst
@@ -13,7 +13,7 @@ SYNOPSIS
 
 **flux** **setattr** *name* *value*
 
-**flux** **setattr** [*--expunge*] *name*
+**flux** **setattr** *name*
 
 **flux** **lsattr** [*--values*]
 

--- a/doc/man7/flux-broker-attributes.rst
+++ b/doc/man7/flux-broker-attributes.rst
@@ -211,15 +211,9 @@ tbon.tcp_user_timeout
 LOGGING
 =======
 
-log-ring-used
-   The number of log entries currently stored in the ring buffer.
-
 log-ring-size [Updates: C, R]
    The maximum number of log entries that can be stored in the ring buffer.
    Default: ``1024``.
-
-log-count
-   The number of log entries ever stored in the ring buffer.
 
 log-forward-level [Updates: C, R]
    Log entries at :linux:man3:`syslog` level at or below this value

--- a/etc/completions/flux.pre
+++ b/etc/completions/flux.pre
@@ -1173,9 +1173,6 @@ _flux_attr()
     local lsattr_OPTS="\
         -v --values \
     "
-    local setattr_OPTS="\
-        -e --expunge \
-    "
     if [[ $cmd != "flux" ]]; then
         if [[ $cur != -* && $cmd == "getattr" ]]; then
             COMPREPLY=( $(compgen -W "$(flux lsattr)" -- "$cur") )

--- a/src/broker/attr.c
+++ b/src/broker/attr.c
@@ -73,10 +73,6 @@ int attr_delete (attr_t *attrs, const char *name, bool force)
             errno = EPERM;
             goto done;
         }
-        if ((e->flags & ATTR_ACTIVE) && !force) {
-            errno = EPERM;
-            goto done;
-        }
         zhash_delete (attrs->hash, name);
     }
     rc = 0;
@@ -88,7 +84,7 @@ int attr_add (attr_t *attrs, const char *name, const char *val, int flags)
 {
     struct entry *e;
 
-    if (attrs == NULL || name == NULL || (flags & ATTR_ACTIVE)) {
+    if (attrs == NULL || name == NULL) {
         errno = EINVAL;
         return -1;
     }
@@ -126,7 +122,6 @@ int attr_add_active (attr_t *attrs, const char *name, int flags,
     e->set = set;
     e->get = get;
     e->arg = arg;
-    e->flags |= ATTR_ACTIVE;
     zhash_update (attrs->hash, name, e);
     zhash_freefn (attrs->hash, name, entry_destroy);
     rc = 0;

--- a/src/broker/attr.c
+++ b/src/broker/attr.c
@@ -69,12 +69,12 @@ int attr_delete (attr_t *attrs, const char *name, bool force)
     int rc = -1;
 
     if ((e = zhash_lookup (attrs->hash, name))) {
-        if ((e->flags & FLUX_ATTRFLAG_IMMUTABLE)) {
+        if ((e->flags & ATTR_IMMUTABLE)) {
             errno = EPERM;
             goto done;
         }
-        if (((e->flags & FLUX_ATTRFLAG_READONLY)
-                            || (e->flags & FLUX_ATTRFLAG_ACTIVE)) && !force) {
+        if (((e->flags & ATTR_READONLY)
+                            || (e->flags & ATTR_ACTIVE)) && !force) {
             errno = EPERM;
             goto done;
         }
@@ -89,7 +89,7 @@ int attr_add (attr_t *attrs, const char *name, const char *val, int flags)
 {
     struct entry *e;
 
-    if (attrs == NULL || name == NULL || (flags & FLUX_ATTRFLAG_ACTIVE)) {
+    if (attrs == NULL || name == NULL || (flags & ATTR_ACTIVE)) {
         errno = EINVAL;
         return -1;
     }
@@ -127,7 +127,7 @@ int attr_add_active (attr_t *attrs, const char *name, int flags,
     e->set = set;
     e->get = get;
     e->arg = arg;
-    e->flags |= FLUX_ATTRFLAG_ACTIVE;
+    e->flags |= ATTR_ACTIVE;
     zhash_update (attrs->hash, name, e);
     zhash_freefn (attrs->hash, name, entry_destroy);
     rc = 0;
@@ -149,7 +149,7 @@ int attr_get (attr_t *attrs, const char *name, const char **val, int *flags)
         goto done;
     }
     if (e->get) {
-        if (!e->val || !(e->flags & FLUX_ATTRFLAG_IMMUTABLE)) {
+        if (!e->val || !(e->flags & ATTR_IMMUTABLE)) {
             const char *tmp;
             if (e->get (name, &tmp, e->arg) < 0)
                 goto done;
@@ -181,11 +181,11 @@ int attr_set (attr_t *attrs, const char *name, const char *val, bool force)
         errno = ENOENT;
         goto done;
     }
-    if ((e->flags & FLUX_ATTRFLAG_IMMUTABLE)) {
+    if ((e->flags & ATTR_IMMUTABLE)) {
         errno = EPERM;
         goto done;
     }
-    if ((e->flags & FLUX_ATTRFLAG_READONLY) && !force) {
+    if ((e->flags & ATTR_READONLY) && !force) {
         errno = EPERM;
         goto done;
     }
@@ -351,7 +351,7 @@ int attr_cache_immutables (attr_t *attrs, flux_t *h)
 
     e = zhash_first (attrs->hash);
     while (e) {
-        if ((e->flags & FLUX_ATTRFLAG_IMMUTABLE)) {
+        if ((e->flags & ATTR_IMMUTABLE)) {
             if (flux_attr_set_cacheonly (h, e->name, e->val) < 0)
                 return -1;
         }

--- a/src/broker/attr.c
+++ b/src/broker/attr.c
@@ -73,8 +73,7 @@ int attr_delete (attr_t *attrs, const char *name, bool force)
             errno = EPERM;
             goto done;
         }
-        if (((e->flags & ATTR_READONLY)
-                            || (e->flags & ATTR_ACTIVE)) && !force) {
+        if ((e->flags & ATTR_ACTIVE) && !force) {
             errno = EPERM;
             goto done;
         }
@@ -172,7 +171,7 @@ done:
     return rc;
 }
 
-int attr_set (attr_t *attrs, const char *name, const char *val, bool force)
+int attr_set (attr_t *attrs, const char *name, const char *val)
 {
     struct entry *e;
     int rc = -1;
@@ -182,10 +181,6 @@ int attr_set (attr_t *attrs, const char *name, const char *val, bool force)
         goto done;
     }
     if ((e->flags & ATTR_IMMUTABLE)) {
-        errno = EPERM;
-        goto done;
-    }
-    if ((e->flags & ATTR_READONLY) && !force) {
         errno = EPERM;
         goto done;
     }
@@ -400,7 +395,7 @@ void setattr_request_cb (flux_t *h, flux_msg_handler_t *mh,
     if (flux_request_unpack (msg, NULL, "{s:s s:s}", "name", &name,
                                                      "value", &val) < 0)
         goto error;
-    if (attr_set (attrs, name, val, false) < 0) {
+    if (attr_set (attrs, name, val) < 0) {
         if (errno != ENOENT)
             goto error;
         if (attr_add (attrs, name, val, 0) < 0)

--- a/src/broker/attr.c
+++ b/src/broker/attr.c
@@ -414,24 +414,6 @@ error:
         FLUX_LOG_ERROR (h);
 }
 
-void rmattr_request_cb (flux_t *h, flux_msg_handler_t *mh,
-                        const flux_msg_t *msg, void *arg)
-{
-    attr_t *attrs = arg;
-    const char *name;
-
-    if (flux_request_unpack (msg, NULL, "{s:s}", "name", &name) < 0)
-        goto error;
-    if (attr_delete (attrs, name, false) < 0)
-        goto error;
-    if (flux_respond (h, msg, NULL) < 0)
-        FLUX_LOG_ERROR (h);
-    return;
-error:
-    if (flux_respond_error (h, msg, errno, NULL) < 0)
-        FLUX_LOG_ERROR (h);
-}
-
 void lsattr_request_cb (flux_t *h, flux_msg_handler_t *mh,
                         const flux_msg_t *msg, void *arg)
 {
@@ -475,7 +457,6 @@ static const struct flux_msg_handler_spec handlers[] = {
     { FLUX_MSGTYPE_REQUEST, "attr.get",    getattr_request_cb, FLUX_ROLE_ALL },
     { FLUX_MSGTYPE_REQUEST, "attr.list",   lsattr_request_cb, FLUX_ROLE_ALL },
     { FLUX_MSGTYPE_REQUEST, "attr.set",    setattr_request_cb, 0 },
-    { FLUX_MSGTYPE_REQUEST, "attr.rm",     rmattr_request_cb, 0 },
     FLUX_MSGHANDLER_TABLE_END,
 };
 

--- a/src/broker/attr.h
+++ b/src/broker/attr.h
@@ -16,7 +16,6 @@
 
 enum {
     ATTR_IMMUTABLE = 1,    /* attribute is cacheable */
-    ATTR_ACTIVE = 4,       /* attribute has get and/or set callbacks */
 };
 
 /* Callbacks for active values.  Return 0 on succes, -1 on eror with

--- a/src/broker/attr.h
+++ b/src/broker/attr.h
@@ -16,8 +16,6 @@
 
 enum {
     ATTR_IMMUTABLE = 1,    /* attribute is cacheable */
-    ATTR_READONLY = 2,     /* attribute cannot be written */
-                                    /*   but may change on broker */
     ATTR_ACTIVE = 4,       /* attribute has get and/or set callbacks */
 };
 
@@ -57,7 +55,7 @@ int attr_add_uint32 (attr_t *attrs, const char *name, uint32_t val,
  */
 int attr_get (attr_t *attrs, const char *name, const char **val, int *flags);
 
-int attr_set (attr_t *attrs, const char *name, const char *val, bool force);
+int attr_set (attr_t *attrs, const char *name, const char *val);
 
 /* Set an attribute's flags.
  */

--- a/src/broker/attr.h
+++ b/src/broker/attr.h
@@ -15,10 +15,10 @@
 #include <flux/core.h>
 
 enum {
-    FLUX_ATTRFLAG_IMMUTABLE = 1,    /* attribute is cacheable */
-    FLUX_ATTRFLAG_READONLY = 2,     /* attribute cannot be written */
+    ATTR_IMMUTABLE = 1,    /* attribute is cacheable */
+    ATTR_READONLY = 2,     /* attribute cannot be written */
                                     /*   but may change on broker */
-    FLUX_ATTRFLAG_ACTIVE = 4,       /* attribute has get and/or set callbacks */
+    ATTR_ACTIVE = 4,       /* attribute has get and/or set callbacks */
 };
 
 /* Callbacks for active values.  Return 0 on succes, -1 on eror with

--- a/src/broker/boot_config.c
+++ b/src/broker/boot_config.c
@@ -300,7 +300,7 @@ int boot_config_attr (attr_t *attrs, json_t *hosts)
             || attr_add (attrs,
                          "hostlist",
                          hostname,
-                         FLUX_ATTRFLAG_IMMUTABLE) < 0) {
+                         ATTR_IMMUTABLE) < 0) {
             log_err ("failed to set hostlist attribute to localhost");
             goto error;
         }
@@ -327,7 +327,7 @@ int boot_config_attr (attr_t *attrs, json_t *hosts)
     if (attr_add (attrs,
                   "hostlist",
                   s,
-                  FLUX_ATTRFLAG_IMMUTABLE) < 0) {
+                  ATTR_IMMUTABLE) < 0) {
         log_err ("failed to set hostlist attribute to config derived value");
         goto error;
     }
@@ -351,7 +351,7 @@ int boot_config_attr (attr_t *attrs, json_t *hosts)
         }
         val = s;
     }
-    if (attr_add (attrs, "broker.mapping", val, FLUX_ATTRFLAG_IMMUTABLE) < 0) {
+    if (attr_add (attrs, "broker.mapping", val, ATTR_IMMUTABLE) < 0) {
         log_err ("setattr broker.mapping");
         goto error;
     }
@@ -584,7 +584,7 @@ int boot_config (flux_t *h, struct overlay *overlay, attr_t *attrs)
         if (attr_add (attrs,
                       "tbon.endpoint",
                       my_uri,
-                      FLUX_ATTRFLAG_IMMUTABLE) < 0) {
+                      ATTR_IMMUTABLE) < 0) {
             log_err ("setattr tbon.endpoint %s", my_uri);
             goto error;
         }
@@ -593,7 +593,7 @@ int boot_config (flux_t *h, struct overlay *overlay, attr_t *attrs)
         if (attr_add (attrs,
                       "tbon.endpoint",
                       NULL,
-                      FLUX_ATTRFLAG_IMMUTABLE) < 0) {
+                      ATTR_IMMUTABLE) < 0) {
             log_err ("setattr tbon.endpoint NULL");
             goto error;
         }
@@ -625,7 +625,7 @@ int boot_config (flux_t *h, struct overlay *overlay, attr_t *attrs)
     if (attr_add (attrs,
                   "instance-level",
                   "0",
-                  FLUX_ATTRFLAG_IMMUTABLE) < 0) {
+                  ATTR_IMMUTABLE) < 0) {
         log_err ("setattr instance-level 0");
         goto error;
     }

--- a/src/broker/boot_pmi.c
+++ b/src/broker/boot_pmi.c
@@ -50,11 +50,11 @@ static int set_instance_level_attr (struct upmi *upmi,
     rc = upmi_get (upmi, "flux.instance-level", -1, &val, NULL);
     if (rc == 0)
         level = val;
-    if (attr_add (attrs, "instance-level", level, FLUX_ATTRFLAG_IMMUTABLE) < 0)
+    if (attr_add (attrs, "instance-level", level, ATTR_IMMUTABLE) < 0)
         return -1;
     if (rc == 0)
         jobid = name;
-    if (attr_add (attrs, "jobid", jobid, FLUX_ATTRFLAG_IMMUTABLE) < 0)
+    if (attr_add (attrs, "jobid", jobid, ATTR_IMMUTABLE) < 0)
         return -1;
     return 0;
 }
@@ -97,7 +97,7 @@ static int set_broker_mapping_attr (struct upmi *upmi,
             free (s);
         }
     }
-    rc = attr_add (attrs, "broker.mapping", val, FLUX_ATTRFLAG_IMMUTABLE);
+    rc = attr_add (attrs, "broker.mapping", val, ATTR_IMMUTABLE);
     free (val);
     return rc;
 }
@@ -180,7 +180,7 @@ static int set_hostlist_attr (attr_t *attrs, struct hostlist *hl)
     }
     else
         s = hostlist_encode (hl);
-    if (s && attr_add (attrs, "hostlist", s, FLUX_ATTRFLAG_IMMUTABLE) == 0)
+    if (s && attr_add (attrs, "hostlist", s, ATTR_IMMUTABLE) == 0)
         rc = 0;
     ERRNO_SAFE_WRAP (free, s);
     return rc;
@@ -289,7 +289,7 @@ int boot_pmi (struct overlay *overlay, attr_t *attrs)
     else {
         uri = NULL;
     }
-    if (attr_add (attrs, "tbon.endpoint", uri, FLUX_ATTRFLAG_IMMUTABLE) < 0) {
+    if (attr_add (attrs, "tbon.endpoint", uri, ATTR_IMMUTABLE) < 0) {
         log_err ("setattr tbon.endpoint");
         goto error;
     }

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -375,11 +375,11 @@ int main (int argc, char *argv[])
     }
     int flags;
     assert (attr_get (ctx.attrs, "rank", NULL, &flags) == 0
-            && (flags & FLUX_ATTRFLAG_IMMUTABLE));
+            && (flags & ATTR_IMMUTABLE));
     assert (attr_get (ctx.attrs, "size", NULL, &flags) == 0
-            && (flags & FLUX_ATTRFLAG_IMMUTABLE));
+            && (flags & ATTR_IMMUTABLE));
     assert (attr_get (ctx.attrs, "hostlist", NULL, &flags) == 0
-            && (flags & FLUX_ATTRFLAG_IMMUTABLE));
+            && (flags & ATTR_IMMUTABLE));
 
     if (!(ctx.groups = groups_create (&ctx))) {
         log_err ("groups_create");
@@ -589,7 +589,7 @@ static void init_attrs_broker_pid (attr_t *attrs, pid_t pid)
     if (attr_add (attrs,
                   attrname,
                   pidval,
-                  FLUX_ATTRFLAG_IMMUTABLE) < 0)
+                  ATTR_IMMUTABLE) < 0)
         log_err_exit ("attr_add %s", attrname);
 }
 
@@ -627,7 +627,7 @@ static void init_attrs_starttime (attr_t *attrs, double starttime)
     char buf[32];
 
     snprintf (buf, sizeof (buf), "%.2f", starttime);
-    if (attr_add (attrs, "broker.starttime", buf, FLUX_ATTRFLAG_IMMUTABLE) < 0)
+    if (attr_add (attrs, "broker.starttime", buf, ATTR_IMMUTABLE) < 0)
         log_err_exit ("error setting broker.starttime attribute");
 }
 
@@ -650,7 +650,7 @@ static void init_attrs (attr_t *attrs, pid_t pid, struct flux_msg_cred *cred)
 
     char tmp[32];
     snprintf (tmp, sizeof (tmp), "%ju", (uintmax_t)cred->userid);
-    if (attr_add (attrs, "security.owner", tmp, FLUX_ATTRFLAG_IMMUTABLE) < 0)
+    if (attr_add (attrs, "security.owner", tmp, ATTR_IMMUTABLE) < 0)
         log_err_exit ("attr_add owner");
 }
 
@@ -804,7 +804,7 @@ static int check_statedir (attr_t *attrs)
     const char *statedir;
 
     if (attr_get (attrs, "statedir", &statedir, NULL) < 0) {
-        if (attr_add (attrs, "statedir", NULL, FLUX_ATTRFLAG_IMMUTABLE) < 0) {
+        if (attr_add (attrs, "statedir", NULL, ATTR_IMMUTABLE) < 0) {
             log_err ("error creating statedir broker attribute");
             return -1;
         }
@@ -812,7 +812,7 @@ static int check_statedir (attr_t *attrs)
     else {
         if (checkdir ("statedir", statedir) < 0)
             return -1;
-        if (attr_set_flags (attrs, "statedir", FLUX_ATTRFLAG_IMMUTABLE) < 0) {
+        if (attr_set_flags (attrs, "statedir", ATTR_IMMUTABLE) < 0) {
             log_err ("error setting statedir broker attribute flags");
             return -1;
         }
@@ -884,7 +884,7 @@ static int create_rundir (attr_t *attrs)
     /*  rundir is now fixed, so make the attribute immutable, and
      *   schedule the dir for cleanup at exit if we created it here.
      */
-    if (attr_set_flags (attrs, "rundir", FLUX_ATTRFLAG_IMMUTABLE) < 0) {
+    if (attr_set_flags (attrs, "rundir", ATTR_IMMUTABLE) < 0) {
         log_err ("error setting rundir broker attribute flags");
         goto done;
     }
@@ -913,7 +913,7 @@ static int init_local_uri_attr (struct overlay *ov, attr_t *attrs)
             log_msg ("buffer overflow while building local-uri");
             return -1;
         }
-        if (attr_add (attrs, "local-uri", buf, FLUX_ATTRFLAG_IMMUTABLE) < 0) {
+        if (attr_add (attrs, "local-uri", buf, ATTR_IMMUTABLE) < 0) {
             log_err ("setattr local-uri");
             return -1;
         }
@@ -963,7 +963,7 @@ static int init_critical_ranks_attr (struct overlay *ov, attr_t *attrs)
         if (attr_add (attrs,
                       "broker.critical-ranks",
                       ranks,
-                      FLUX_ATTRFLAG_IMMUTABLE) < 0) {
+                      ATTR_IMMUTABLE) < 0) {
             log_err ("attr_add critical_ranks");
             goto out;
         }
@@ -978,7 +978,7 @@ static int init_critical_ranks_attr (struct overlay *ov, attr_t *attrs)
          */
         if (attr_set_flags (attrs,
                             "broker.critical-ranks",
-                            FLUX_ATTRFLAG_IMMUTABLE) < 0) {
+                            ATTR_IMMUTABLE) < 0) {
             log_err ("failed to make broker.criitcal-ranks attr immutable");
             goto out;
         }

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -141,7 +141,7 @@ void parse_command_line_arguments (int argc, char *argv[], broker_ctx_t *ctx)
         if ((val = strchr (attr, '=')))
             *val++ = '\0';
         if (attr_add (ctx->attrs, attr, val, 0) < 0)
-            if (attr_set (ctx->attrs, attr, val, true) < 0)
+            if (attr_set (ctx->attrs, attr, val) < 0)
                 log_err_exit ("setattr %s=%s", attr, val);
         free (attr);
     }

--- a/src/broker/brokercfg.c
+++ b/src/broker/brokercfg.c
@@ -646,7 +646,7 @@ struct brokercfg *brokercfg_create (flux_t *h,
     }
     if (flux_msg_handler_addvec (h, htab, cfg, &cfg->handlers) < 0)
         goto error;
-    if (attr_add (attrs, "config.path", path, FLUX_ATTRFLAG_IMMUTABLE) < 0)
+    if (attr_add (attrs, "config.path", path, ATTR_IMMUTABLE) < 0)
         goto error;
     return cfg;
 error:

--- a/src/broker/content-cache.c
+++ b/src/broker/content-cache.c
@@ -1026,7 +1026,7 @@ static int register_attrs (struct content_cache *cache, attr_t *attr)
         if (attr_add (attr,
                       "content.hash",
                       cache->hash_name,
-                      FLUX_ATTRFLAG_IMMUTABLE) < 0)
+                      ATTR_IMMUTABLE) < 0)
             return -1;
     }
     else {
@@ -1035,7 +1035,7 @@ static int register_attrs (struct content_cache *cache, attr_t *attr)
             log_msg ("%s: unknown hash type", s);
             return -1;
         }
-        if (attr_set_flags (attr, "content.hash", FLUX_ATTRFLAG_IMMUTABLE) < 0)
+        if (attr_set_flags (attr, "content.hash", ATTR_IMMUTABLE) < 0)
             return -1;
         cache->hash_name = s;
         content_hash_size = hash_size;
@@ -1055,9 +1055,9 @@ static int register_attrs (struct content_cache *cache, attr_t *attr)
                 &cache->flush_batch_limit, 0) < 0)
         return -1;
     if (attr_add_active_uint32 (attr, "content.blob-size-limit",
-                &cache->blob_size_limit, FLUX_ATTRFLAG_IMMUTABLE) < 0)
+                &cache->blob_size_limit, ATTR_IMMUTABLE) < 0)
         return -1;
-    if (attr_add_active (attr, "content.backing-module",FLUX_ATTRFLAG_READONLY,
+    if (attr_add_active (attr, "content.backing-module",ATTR_READONLY,
                  content_cache_getattr, NULL, cache) < 0)
         return -1;
 

--- a/src/broker/content-cache.c
+++ b/src/broker/content-cache.c
@@ -1057,7 +1057,7 @@ static int register_attrs (struct content_cache *cache, attr_t *attr)
     if (attr_add_active_uint32 (attr, "content.blob-size-limit",
                 &cache->blob_size_limit, ATTR_IMMUTABLE) < 0)
         return -1;
-    if (attr_add_active (attr, "content.backing-module",ATTR_READONLY,
+    if (attr_add_active (attr, "content.backing-module", 0,
                  content_cache_getattr, NULL, cache) < 0)
         return -1;
 

--- a/src/broker/hostname.c
+++ b/src/broker/hostname.c
@@ -1,0 +1,148 @@
+/************************************************************\
+ * Copyright 2014 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <jansson.h>
+#include <flux/core.h>
+
+#include "src/common/libutil/errno_safe.h"
+
+#include "ping.h"
+
+struct ping_context {
+    flux_msg_handler_t *mh;
+    char *uuid;
+};
+
+static char *make_json_response_payload (const char *request_payload,
+                                         const char *route,
+                                         struct flux_msg_cred cred)
+{
+    json_t *o = NULL;
+    json_t *add = NULL;
+    char *result = NULL;
+
+    if (!request_payload || !(o = json_loads (request_payload, 0, NULL))) {
+        errno = EPROTO;
+        goto done;
+    }
+    if (!(add = json_pack ("{s:s s:i s:i}", "route", route,
+                                            "userid", cred.userid,
+                                            "rolemask", cred.rolemask))) {
+        errno = ENOMEM;
+        goto done;
+    }
+    if (json_object_update (o, add) < 0) {
+        errno = ENOMEM;
+        goto done;
+    }
+    if (!(result = json_dumps (o, 0))) {
+        errno = ENOMEM;
+        goto done;
+    }
+done:
+    ERRNO_SAFE_WRAP (json_decref, o);
+    ERRNO_SAFE_WRAP (json_decref, add);
+    return result;
+}
+
+static void ping_request_cb (flux_t *h, flux_msg_handler_t *mh,
+                             const flux_msg_t *msg, void *arg)
+{
+    struct ping_context *p = arg;
+    const char *json_str;
+    char *route_str = NULL;
+    char *new_str;
+    size_t new_size;
+    char *resp_str = NULL;
+    struct flux_msg_cred cred;
+
+    if (flux_request_decode (msg, NULL, &json_str) < 0)
+        goto error;
+    if (flux_msg_get_cred (msg, &cred) < 0)
+        goto error;
+
+    /* The route string as obtained from the message includes all
+     * hops but the last one, e.g. the identity of the destination.
+     * That identity is passed in to ping_initialize() as the uuid.
+     * Tack it onto the route string.
+     */
+    if (!(route_str = flux_msg_route_string (msg)))
+        goto error;
+    new_size = strlen (route_str) + strlen (p->uuid) + 2;
+    if (!(new_str = realloc (route_str, new_size)))
+        goto error;
+    route_str = new_str;
+    strcat (route_str, "!");
+    strcat (route_str, p->uuid);
+
+    if (!(resp_str = make_json_response_payload (json_str, route_str, cred)))
+        goto error;
+    if (flux_respond (h, msg, resp_str) < 0)
+        flux_log_error (h, "%s: flux_respond", __FUNCTION__);
+    free (route_str);
+    free (resp_str);
+    return;
+error:
+    if (flux_respond_error (h, msg, errno, NULL) < 0)
+        flux_log_error (h, "%s: flux_respond_error", __FUNCTION__);
+    free (route_str);
+    free (resp_str);
+}
+
+static void ping_finalize (void *arg)
+{
+    struct ping_context *p = arg;
+    if (p) {
+        int saved_errno = errno;
+        flux_msg_handler_stop (p->mh);
+        flux_msg_handler_destroy (p->mh);
+        free (p->uuid);
+        free (p);
+        errno = saved_errno;
+    }
+}
+
+int ping_initialize (flux_t *h, const char *service, const char *uuid)
+{
+    struct flux_match match = FLUX_MATCH_ANY;
+    struct ping_context *p = calloc (1, sizeof (*p));
+    if (!p)
+        goto error;
+    /* The uuid is tacked onto the route string constructed for
+     * ping responses.  Truncate the uuid to 8 chars to match policy
+     * of flux_msg_route_string().
+     */
+    if (!(p->uuid = strdup (uuid)))
+        goto error;
+    if (strlen (p->uuid) > 8)
+        p->uuid[8] = '\0';
+
+    match.typemask = FLUX_MSGTYPE_REQUEST;
+    if (flux_match_asprintf (&match, "%s.ping", service) < 0)
+        goto error;
+    if (!(p->mh = flux_msg_handler_create (h, match, ping_request_cb, p)))
+        goto error;
+    flux_msg_handler_allow_rolemask (p->mh, FLUX_ROLE_ALL);
+    flux_msg_handler_start (p->mh);
+    flux_aux_set (h, "flux::ping", p, ping_finalize);
+    flux_match_free (match);
+    return 0;
+error:
+    flux_match_free (match);
+    ping_finalize (p);
+    return -1;
+}
+
+/*
+ * vi:tabstop=4 shiftwidth=4 expandtab
+ */

--- a/src/broker/log.c
+++ b/src/broker/log.c
@@ -338,7 +338,7 @@ static int logbuf_register_attrs (logbuf_t *logbuf, attr_t *attrs)
             goto done;
     } else {
         (void)attr_delete (attrs, "log-filename", true);
-        if (attr_add (attrs, "log-filename", NULL, FLUX_ATTRFLAG_IMMUTABLE) < 0)
+        if (attr_add (attrs, "log-filename", NULL, ATTR_IMMUTABLE) < 0)
             goto done;
     }
 

--- a/src/broker/overlay.c
+++ b/src/broker/overlay.c
@@ -1372,31 +1372,31 @@ int overlay_register_attrs (struct overlay *overlay)
     if (attr_add (overlay->attrs,
                   "tbon.parent-endpoint",
                   overlay->parent.uri,
-                  FLUX_ATTRFLAG_IMMUTABLE) < 0)
+                  ATTR_IMMUTABLE) < 0)
         return -1;
     if (attr_add_uint32 (overlay->attrs,
                          "rank",
                          overlay->rank,
-                         FLUX_ATTRFLAG_IMMUTABLE) < 0)
+                         ATTR_IMMUTABLE) < 0)
         return -1;
     if (attr_add_uint32 (overlay->attrs,
                          "size", overlay->size,
-                         FLUX_ATTRFLAG_IMMUTABLE) < 0)
+                         ATTR_IMMUTABLE) < 0)
         return -1;
     if (attr_add_int (overlay->attrs,
                       "tbon.level",
                       topology_get_level (overlay->topo),
-                      FLUX_ATTRFLAG_IMMUTABLE) < 0)
+                      ATTR_IMMUTABLE) < 0)
         return -1;
     if (attr_add_int (overlay->attrs,
                       "tbon.maxlevel",
                       topology_get_maxlevel (overlay->topo),
-                      FLUX_ATTRFLAG_IMMUTABLE) < 0)
+                      ATTR_IMMUTABLE) < 0)
         return -1;
     if (attr_add_int (overlay->attrs,
                       "tbon.descendants",
                       topology_get_descendant_count (overlay->topo),
-                      FLUX_ATTRFLAG_IMMUTABLE) < 0)
+                      ATTR_IMMUTABLE) < 0)
         return -1;
 
     return 0;
@@ -1714,15 +1714,15 @@ static int overlay_configure_attr (attr_t *attrs,
     int flags;
 
     if (attr_get (attrs, name, &val, &flags) == 0) {
-        if (!(flags & FLUX_ATTRFLAG_IMMUTABLE)) {
-            flags |= FLUX_ATTRFLAG_IMMUTABLE;
+        if (!(flags & ATTR_IMMUTABLE)) {
+            flags |= ATTR_IMMUTABLE;
             if (attr_set_flags (attrs, name, flags) < 0)
                 return -1;
         }
     }
     else {
         val = default_value;
-        if (attr_add (attrs, name, val, FLUX_ATTRFLAG_IMMUTABLE) < 0)
+        if (attr_add (attrs, name, val, ATTR_IMMUTABLE) < 0)
             return -1;
     }
     if (valuep)
@@ -1750,7 +1750,7 @@ static int overlay_configure_attr_int (attr_t *attrs,
         if (attr_delete (attrs, name, true) < 0)
             return -1;
     }
-    if (attr_add_int (attrs, name, value, FLUX_ATTRFLAG_IMMUTABLE) < 0)
+    if (attr_add_int (attrs, name, value, ATTR_IMMUTABLE) < 0)
         return -1;
     if (valuep)
         *valuep = value;
@@ -1913,7 +1913,7 @@ static int overlay_configure_tcp_user_timeout (struct overlay *ov)
         if (attr_add (ov->attrs,
                       "tbon.tcp_user_timeout",
                       buf,
-                      FLUX_ATTRFLAG_IMMUTABLE) < 0)
+                      ATTR_IMMUTABLE) < 0)
             return -1;
     }
     else {

--- a/src/broker/state_machine.c
+++ b/src/broker/state_machine.c
@@ -708,7 +708,7 @@ static int quorum_configure (struct state_machine *s)
     if (attr_add (s->ctx->attrs,
                   "broker.quorum",
                   tmp,
-                  FLUX_ATTRFLAG_IMMUTABLE) < 0) {
+                  ATTR_IMMUTABLE) < 0) {
         ERRNO_SAFE_WRAP (free, tmp);
         return -1;
     }
@@ -742,7 +742,7 @@ static int quorum_timeout_configure (struct state_machine *s)
         if (fsd_format_duration (fsd, sizeof (fsd), s->quorum.timeout) < 0)
             return -1;
     }
-    if (attr_add (s->ctx->attrs, name, fsd, FLUX_ATTRFLAG_IMMUTABLE) < 0)
+    if (attr_add (s->ctx->attrs, name, fsd, ATTR_IMMUTABLE) < 0)
         return -1;
     return 0;
 }

--- a/src/broker/test/attr.c
+++ b/src/broker/test/attr.c
@@ -145,9 +145,6 @@ int main (int argc, char **argv)
         "attr_set on active int sets val=1");
     ok (attr_set (attrs, "a", "-1") == 0 && a == -1,
         "attr_set on active int sets val=-1");
-    errno = 0;
-    ok (attr_delete (attrs, "a", false) < 0 && errno == EPERM,
-        "attr_delete on active attr fails with EPERM");
     ok (attr_delete (attrs, "a", true) == 0,
         "attr_delete (force) works on active attr");
 

--- a/src/broker/test/attr.c
+++ b/src/broker/test/attr.c
@@ -18,15 +18,11 @@
 
 #include "src/common/libtap/tap.h"
 
-int main (int argc, char **argv)
+void basic (void)
 {
     attr_t *attrs;
     const char *val;
     int flags;
-    int a, c;
-    uint32_t b;
-
-    plan (NO_PLAN);
 
     ok ((attrs = attr_create ()) != NULL,
         "attr_create works");
@@ -117,6 +113,19 @@ int main (int argc, char **argv)
     ok (attr_next (attrs) == NULL,
         "attr_next returned NULL");
 
+    attr_destroy (attrs);
+}
+
+void active (void)
+{
+    attr_t *attrs;
+    const char *val;
+    int a, c;
+    uint32_t b;
+
+    if (!(attrs = attr_create ()))
+        BAIL_OUT ("attr_create failed");
+
     /* attr_add_active (int helper)
      */
     ok (attr_add_active_int (attrs, "a", &a, 0) == 0,
@@ -185,6 +194,14 @@ int main (int argc, char **argv)
         "attr_delete (force) fails with EPERM");
 
     attr_destroy (attrs);
+}
+
+int main (int argc, char **argv)
+{
+    plan (NO_PLAN);
+
+    basic ();
+    active ();
 
     done_testing ();
     return 0;

--- a/src/broker/test/attr.c
+++ b/src/broker/test/attr.c
@@ -26,7 +26,7 @@ int main (int argc, char **argv)
     int a, c;
     uint32_t b;
 
-    plan (53);
+    plan (NO_PLAN);
 
     ok ((attrs = attr_create ()) != NULL,
         "attr_create works");
@@ -37,7 +37,7 @@ int main (int argc, char **argv)
     ok (attr_get (attrs, "foo", NULL, NULL) < 0 && errno == ENOENT,
         "attr_get on unknown attr fails with errno == ENOENT");
     errno = 0;
-    ok (attr_set (attrs, "foo", "bar", false) < 0 && errno == ENOENT,
+    ok (attr_set (attrs, "foo", "bar") < 0 && errno == ENOENT,
         "attr_set on unknown attr fails with errno == ENOENT");
 
     /* attr_add, attr_get works
@@ -63,30 +63,6 @@ int main (int argc, char **argv)
     ok (attr_get (attrs, "foo", NULL, NULL) < 0 && errno == ENOENT,
         "attr_get on deleted attr fails with errno == ENOENT");
 
-    /* ATTR_READONLY protects against update/delete from users;
-     * update/delete can be forced on broker.
-     */
-    ok (attr_add (attrs, "foo", "baz", ATTR_READONLY) == 0,
-        "attr_add ATTR_READONLY works");
-    flags = 0;
-    val = NULL;
-    ok (attr_get (attrs, "foo", &val, &flags) == 0 && !strcmp (val, "baz")
-        && flags == ATTR_READONLY,
-        "attr_get returns correct value and flags");
-    errno = 0;
-    ok (attr_set (attrs, "foo", "bar", false) < 0 && errno == EPERM,
-        "attr_set on readonly attr fails with EPERM");
-    ok (attr_set (attrs, "foo", "baz", true) == 0,
-        "attr_set (force) on readonly attr works");
-    errno = 0;
-    ok (attr_delete (attrs, "foo", false) < 0 && errno == EPERM,
-        "attr_delete on readonly attr fails with EPERM");
-    ok (attr_delete (attrs, "foo", true) == 0,
-        "attr_delete (force) works on readonly attr");
-    errno = 0;
-    ok (attr_get (attrs, "foo", NULL, NULL) < 0 && errno == ENOENT,
-        "attr_get on deleted attr fails with errno == ENOENT");
-
     /* ATTR_IMMUTABLE protects against update/delete from user;
      * update/delete can NOT be forced on broker.
      */
@@ -98,10 +74,10 @@ int main (int argc, char **argv)
         && flags == ATTR_IMMUTABLE,
         "attr_get returns correct value and flags");
     errno = 0;
-    ok (attr_set (attrs, "foo", "bar", false) < 0 && errno == EPERM,
+    ok (attr_set (attrs, "foo", "bar") < 0 && errno == EPERM,
         "attr_set on immutable attr fails with EPERM");
     errno = 0;
-    ok (attr_set (attrs, "foo", "baz", true)  < 0 && errno == EPERM,
+    ok (attr_set (attrs, "foo", "baz")  < 0 && errno == EPERM,
         "attr_set (force) on immutable fails with EPERM");
     errno = 0;
     ok (attr_delete (attrs, "foo", false) < 0 && errno == EPERM,
@@ -163,11 +139,11 @@ int main (int argc, char **argv)
         && strtol (val, NULL, 10) == INT_MIN + 1,
         "attr_get on active int tracks val=INT_MIN+1");
 
-    ok (attr_set (attrs, "a", "0", false) == 0 && a == 0,
+    ok (attr_set (attrs, "a", "0") == 0 && a == 0,
         "attr_set on active int sets val=0");
-    ok (attr_set (attrs, "a", "1", false) == 0 && a == 1,
+    ok (attr_set (attrs, "a", "1") == 0 && a == 1,
         "attr_set on active int sets val=1");
-    ok (attr_set (attrs, "a", "-1", false) == 0 && a == -1,
+    ok (attr_set (attrs, "a", "-1") == 0 && a == -1,
         "attr_set on active int sets val=-1");
     errno = 0;
     ok (attr_delete (attrs, "a", false) < 0 && errno == EPERM,
@@ -190,9 +166,9 @@ int main (int argc, char **argv)
         && strtoul (val, NULL, 10) == UINT_MAX - 1,
         "attr_get on active uint32_t tracks val=UINT_MAX-1");
 
-    ok (attr_set (attrs, "b", "0", false) == 0 && b == 0,
+    ok (attr_set (attrs, "b", "0") == 0 && b == 0,
         "attr_set on active uint32_t sets val=0");
-    ok (attr_set (attrs, "b", "1", false) == 0 && b == 1,
+    ok (attr_set (attrs, "b", "1") == 0 && b == 1,
         "attr_set on active uint32_t sets val=1");
     ok (attr_delete (attrs, "b", true) == 0,
         "attr_delete (force) works on active attr");

--- a/src/broker/test/attr.c
+++ b/src/broker/test/attr.c
@@ -63,15 +63,15 @@ int main (int argc, char **argv)
     ok (attr_get (attrs, "foo", NULL, NULL) < 0 && errno == ENOENT,
         "attr_get on deleted attr fails with errno == ENOENT");
 
-    /* FLUX_ATTRFLAG_READONLY protects against update/delete from users;
+    /* ATTR_READONLY protects against update/delete from users;
      * update/delete can be forced on broker.
      */
-    ok (attr_add (attrs, "foo", "baz", FLUX_ATTRFLAG_READONLY) == 0,
-        "attr_add FLUX_ATTRFLAG_READONLY works");
+    ok (attr_add (attrs, "foo", "baz", ATTR_READONLY) == 0,
+        "attr_add ATTR_READONLY works");
     flags = 0;
     val = NULL;
     ok (attr_get (attrs, "foo", &val, &flags) == 0 && !strcmp (val, "baz")
-        && flags == FLUX_ATTRFLAG_READONLY,
+        && flags == ATTR_READONLY,
         "attr_get returns correct value and flags");
     errno = 0;
     ok (attr_set (attrs, "foo", "bar", false) < 0 && errno == EPERM,
@@ -87,15 +87,15 @@ int main (int argc, char **argv)
     ok (attr_get (attrs, "foo", NULL, NULL) < 0 && errno == ENOENT,
         "attr_get on deleted attr fails with errno == ENOENT");
 
-    /* FLUX_ATTRFLAG_IMMUTABLE protects against update/delete from user;
+    /* ATTR_IMMUTABLE protects against update/delete from user;
      * update/delete can NOT be forced on broker.
      */
-    ok (attr_add (attrs, "foo", "baz", FLUX_ATTRFLAG_IMMUTABLE) == 0,
-        "attr_add FLUX_ATTRFLAG_IMMUTABLE works");
+    ok (attr_add (attrs, "foo", "baz", ATTR_IMMUTABLE) == 0,
+        "attr_add ATTR_IMMUTABLE works");
     flags = 0;
     val = NULL;
     ok (attr_get (attrs, "foo", &val, &flags) == 0 && !strcmp (val, "baz")
-        && flags == FLUX_ATTRFLAG_IMMUTABLE,
+        && flags == ATTR_IMMUTABLE,
         "attr_get returns correct value and flags");
     errno = 0;
     ok (attr_set (attrs, "foo", "bar", false) < 0 && errno == EPERM,
@@ -199,8 +199,8 @@ int main (int argc, char **argv)
 
     /* immutable active int works as expected
      */
-    ok (attr_add_active_int (attrs, "c", &c, FLUX_ATTRFLAG_IMMUTABLE) == 0,
-        "attr_add_active_int FLUX_ATTRFLAG_IMMUTABLE works");
+    ok (attr_add_active_int (attrs, "c", &c, ATTR_IMMUTABLE) == 0,
+        "attr_add_active_int ATTR_IMMUTABLE works");
     c = 42;
     ok (attr_get (attrs, "c", &val, NULL) == 0 && val && !strcmp (val, "42"),
         "attr_get returns initial val=42");

--- a/src/broker/test/boot_config.c
+++ b/src/broker/test/boot_config.c
@@ -516,7 +516,7 @@ void test_attr (const char *dir)
         "boot_config_attr works on input hosts");
     ok (attr_get (attrs, "hostlist", &val, &flags) == 0
         && !strcmp (val, "foo[0,4,1-3,5,14,6-9]")
-        && flags == FLUX_ATTRFLAG_IMMUTABLE,
+        && flags == ATTR_IMMUTABLE,
         "attr_get returns correct value and flags");
 
     json_decref (hosts);

--- a/src/cmd/builtin/attr.c
+++ b/src/cmd/builtin/attr.c
@@ -17,13 +17,6 @@
 
 #include "builtin.h"
 
-static struct optparse_option setattr_opts[] = {
-    { .name = "expunge", .key = 'e', .has_arg = 0,
-      .usage = "Unset the specified attribute",
-    },
-    OPTPARSE_TABLE_END
-};
-
 static int cmd_setattr (optparse_t *p, int ac, char *av[])
 {
     int n = optparse_option_index (p);
@@ -33,25 +26,14 @@ static int cmd_setattr (optparse_t *p, int ac, char *av[])
 
     log_init ("flux-setattr");
 
-    if (optparse_hasopt (p, "expunge")) {
-        if (n != ac - 1) {
-            optparse_print_usage (p);
-            exit (1);
-        }
-        name = av[n];
-        if (flux_attr_set (h, name, NULL) < 0)
-            log_err_exit ("flux_attr_set");
+    if (n != ac - 2) {
+        optparse_print_usage (p);
+        exit (1);
     }
-    else {
-        if (n != ac - 2) {
-            optparse_print_usage (p);
-            exit (1);
-        }
-        name = av[n];
-        val = av[n + 1];
-        if (flux_attr_set (h, name, val) < 0)
-            log_err_exit ("flux_attr_set");
-    }
+    name = av[n];
+    val = av[n + 1];
+    if (flux_attr_set (h, name, val) < 0)
+        log_err_exit ("flux_attr_set");
 
     flux_close (h);
     return (0);
@@ -165,7 +147,7 @@ int subcommand_attr_register (optparse_t *p)
         "name value",
         "Set broker attribute",
         0,
-        setattr_opts);
+        NULL);
     if (e != OPTPARSE_SUCCESS)
         return (-1);
 

--- a/src/common/libflux/attr.c
+++ b/src/common/libflux/attr.c
@@ -124,17 +124,17 @@ int flux_attr_set (flux_t *h, const char *name, const char *val)
 {
     flux_future_t *f;
 
-    if (!h || !name) {
+    if (!h || !name || !val) {
         errno = EINVAL;
         return -1;
     }
-    if (val)
-        f = flux_rpc_pack (h, "attr.set", FLUX_NODEID_ANY, 0, "{s:s s:s}",
-                                                              "name", name,
-                                                              "value", val);
-    else
-        f = flux_rpc_pack (h, "attr.rm", FLUX_NODEID_ANY, 0, "{s:s}",
-                                                             "name", name);
+    f = flux_rpc_pack (h,
+                       "attr.set",
+                       FLUX_NODEID_ANY,
+                       0,
+                       "{s:s s:s}",
+                       "name", name,
+                       "value", val);
     if (!f)
         return -1;
     if (flux_future_get (f, NULL) < 0) {

--- a/src/common/libflux/test/attr.c
+++ b/src/common/libflux/test/attr.c
@@ -231,18 +231,6 @@ int main (int argc, char *argv[])
     ok (value && !strcmp (value, "peep") && get_count == 0,
         "flux_attr_get chick=peep (cached)");
 
-    /* rm (set val=NULL) */
-
-    errno = 0;
-    ok (flux_attr_set (h, "notakey", NULL) < 0 && errno == ENOENT,
-        "flux_attr_set notakey=NULL fails with ENOENT");
-
-    ok (flux_attr_set (h, "foo", NULL) == 0,
-        "flux_attr_set foo=NULL works");
-    errno = 0;
-    ok (flux_attr_get (h, "foo") == NULL && errno == ENOENT,
-        "flux_attr_get foo fails with ENOENT");
-
     /* cacheonly */
 
     ok (flux_attr_set_cacheonly (h, "fake", "42") == 0,

--- a/t/t0008-attr.t
+++ b/t/t0008-attr.t
@@ -17,9 +17,6 @@ test_expect_success 'flux getattr rank works' '
 test_expect_success 'flux setattr rank fails (immutable)' '
 	! flux setattr rank 42
 '
-test_expect_success 'flux setattr --expunge rank fails (immutable)' '
-	test_must_fail flux setattr --expunge rank
-'
 test_expect_success 'flux getattr attrtest.nonexist fails' '
 	! flux getattr nonexist
 '
@@ -28,21 +25,14 @@ test_expect_success 'flux setattr works' '
 	ATTR_VAL=`flux getattr attrtest.foo` &&
 	test "${ATTR_VAL}" = "bar"
 '
-test_expect_success 'flux setattr -e works' '
-	flux setattr -e attrtest.foo &&
-	! flux getattr attrtest.foo
-'
 test_expect_success 'flux lsattr works' '
 	flux lsattr >lsattr_out &&
 	grep -q rank lsattr_out &&
-	! grep -q attrtest.foo lsattr_out
+	grep -q attrtest.foo lsattr_out
 '
 test_expect_success 'flux lsattr -v works' '
 	ATTR_VAL=$(flux lsattr -v | awk "/^rank / { print \$2 }") &&
 	test "${ATTR_VAL}" -eq 0
-'
-test_expect_success 'flux setattr --expunge missing optarg fails' '
-	test_must_fail flux setattr --expunge
 '
 test_expect_success 'flux lsattr with extra argument fails' '
 	test_must_fail flux lsattr badarg
@@ -55,9 +45,6 @@ test_expect_success 'get request with empty payload fails with EPROTO(71)' '
 '
 test_expect_success 'set request with empty payload fails with EPROTO(71)' '
 	${RPC} attr.set 71 </dev/null
-'
-test_expect_success 'rm request with empty payload fails with EPROTO(71)' '
-	${RPC} attr.rm 71 </dev/null
 '
 
 test_done

--- a/t/t0009-dmesg.t
+++ b/t/t0009-dmesg.t
@@ -9,16 +9,16 @@ waitfile="${SHARNESS_TEST_SRCDIR}/scripts/waitfile.lua"
 
 test_under_flux 4 minimal
 
-test_expect_success 'flux getattr log-count counts log messages' '
-	OLD_VAL=`flux getattr log-count` &&
+test_expect_success 'module stats --parse count log counts log messages' '
+	OLD_VAL=$(flux module stats --parse count log) &&
 	flux logger hello &&
-	NEW_VAL=`flux getattr log-count` &&
+	NEW_VAL=$(flux module stats --parse count log) &&
 	test "${OLD_VAL}" -lt "${NEW_VAL}"
 '
-test_expect_success 'flux getattr log-ring-used counts log messages' '
-	OLD_VAL=`flux getattr log-ring-used` &&
+test_expect_success 'module stats --parse ring-used log counts log messages' '
+	OLD_VAL=$(flux module stats --parse ring-used log) &&
 	flux logger hello &&
-	NEW_VAL=`flux getattr log-ring-used` &&
+	NEW_VAL=$(flux module stats --parse ring-used log) &&
 	test "${OLD_VAL}" -lt "${NEW_VAL}"
 '
 test_expect_success 'flux dmesg -C clears ring buffer' '


### PR DESCRIPTION
Problem: the broker attribute design is outdated and contains bits that we no longer use.

Cull the broker attribute internal design back a bit so it is perhaps more comprehensible to newcomers. 