### PR TITLE
python: add flux.constraint.parser for RFC 35 Constraint Query Syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ lua-devel         | liblua5.1-dev     | >= 5.1, < 5.5     |
 lua-posix         | lua-posix         |                   |
 python36-devel    | python3-dev       | >= 3.6            |
 python36-cffi     | python3-cffi      | >= 1.1            |
+python36-ply      | python3-ply       | >= 3.9            |
 python36-yaml     | python3-yaml      | >= 3.10.0         |
 python36-jsonschema | python3-jsonschema | >= 2.3.0, < 4.0 |
 phthon3-sphinx    | python3-sphinx    |                   | *1*
@@ -79,12 +80,12 @@ jq                | jq                |
 
 ##### Installing RedHat/CentOS Packages
 ```
-yum install autoconf automake libtool make pkgconfig glibc-devel zeromq4-devel czmq-devel libuuid-devel jansson-devel lz4-devel libarchive-devel hwloc-devel sqlite-devel lua lua-devel lua-posix python36-devel python36-cffi python36-yaml python36-jsonschema python3-sphinx aspell aspell-en valgrind-devel mpich-devel jq
+yum install autoconf automake libtool make pkgconfig glibc-devel zeromq4-devel czmq-devel libuuid-devel jansson-devel lz4-devel libarchive-devel hwloc-devel sqlite-devel lua lua-devel lua-posix python36-devel python36-cffi python36-ply python36-yaml python36-jsonschema python3-sphinx aspell aspell-en valgrind-devel mpich-devel jq
 ```
 
 ##### Installing Ubuntu Packages
 ```
-apt install autoconf automake libtool make pkg-config libc6-dev libzmq3-dev libczmq-dev uuid-dev libjansson-dev liblz4-dev libarchive-dev libhwloc-dev libsqlite3-dev lua5.1 liblua5.1-dev lua-posix python3-dev python3-cffi python3-yaml python3-jsonschema python3-sphinx aspell aspell-en valgrind libmpich-dev jq
+apt install autoconf automake libtool make pkg-config libc6-dev libzmq3-dev libczmq-dev uuid-dev libjansson-dev liblz4-dev libarchive-dev libhwloc-dev libsqlite3-dev lua5.1 liblua5.1-dev lua-posix python3-dev python3-cffi python3-ply python3-yaml python3-jsonschema python3-sphinx aspell aspell-en valgrind libmpich-dev jq
 ```
 
 ##### Building from Source

--- a/scripts/requirements-dev.txt
+++ b/scripts/requirements-dev.txt
@@ -1,4 +1,5 @@
 cffi>=1.1
+ply>=3.9
 pyyaml>=3.10.0
 jsonschema>=2.3.0
 black==22.8.0

--- a/src/bindings/python/flux/Makefile.am
+++ b/src/bindings/python/flux/Makefile.am
@@ -53,6 +53,9 @@ nobase_fluxpy_PYTHON = \
 	uri/resolvers/pid.py \
 	uri/resolvers/slurm.py \
 	uri/resolvers/lsf.py \
+	constraint/parser.py \
+	constraint/parsetab.py \
+	constraint/__init__.py \
 	utils/parsedatetime/__init__.py \
 	utils/parsedatetime/parsedatetime.py \
 	utils/parsedatetime/warns.py \
@@ -79,7 +82,30 @@ if HAVE_FLUX_SECURITY
 nobase_fluxpy_PYTHON += security.py
 endif
 
+
+BUILT_SOURCES = \
+	constraint/parsetab.py
+
+CLEANFILES = \
+	constraint/parser.out \
+	$(BUILT_SOURCES)
+
+STDERR_DEVNULL = $(stderr_devnull_$(V))
+stderr_devnull_ =  $(stderr_devnull_$(AM_DEFAULT_VERBOSITY))
+stderr_devnull_0 = >/dev/null 2>&1
+
+#  Ensure that python-ply's parsetab.py is generated. Create
+#  parent directory if necessary in builddir. Note: this also
+#  creates a parser.out, which is explicitly removed in
+#  CLEANFILES above. If in builddir, constraint directory
+#  should be removed. That is done below in clean-local.
+#
+constraint/parsetab.py: constraint/parser.py
+	$(AM_V_GEN)$(MKDIR_P) constraint && $(PYTHON) $< \
+	  --outputdir $(builddir)/constraint $(STDERR_DEVNULL)
+
 clean-local:
+	-rmdir constraint 2>/dev/null || :
 	-rm -f *.pyc */*.pyc *.pyo */*.pyo
 	-rm -rf __pycache__ */__pycache__
 

--- a/src/bindings/python/flux/constraint/parser.py
+++ b/src/bindings/python/flux/constraint/parser.py
@@ -1,0 +1,456 @@
+##############################################################
+# Copyright 2023 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+##############################################################
+
+import argparse
+import json
+
+import ply.yacc as yacc
+from ply import lex
+
+
+class ConstraintSyntaxError(Exception):
+    """
+    Specialized SyntaxError exception to allow ConstraintParser to throw
+    a SyntaxError without PLY trying to force recovery.
+
+    """
+
+    pass
+
+
+class ConstraintLexer(object):
+    """
+    Simple constraint query syntax lexical analyzer based on RFC 35.
+    Used mainly as the lexer for BaseConstraintParser
+    """
+
+    #  Different quoting states for single vs double quotes:
+    states = (
+        ("squoting", "exclusive"),
+        ("dquoting", "exclusive"),
+    )
+
+    tokens = (
+        "NOT",
+        "AND",
+        "OR",
+        "NEGATE",
+        "LPAREN",
+        "RPAREN",
+        "TOKEN",
+        "QUOTE",
+    )
+
+    # Ignore whitespace in default state
+    t_ignore = " \t\r\n\f\v"
+
+    # Tokens in 'quoting' state
+    t_squoting_ignore = ""
+    t_dquoting_ignore = ""
+
+    def __init__(self, **kw_args):
+        super().__init__()
+        self.lexer = lex.lex(module=self, **kw_args)
+        self.parens_level = 0
+        self.last_lparens = 0
+        self.last_rparens = 0
+        self.last_quote = None
+        self.quote_start = None
+        self.pending_token = None
+
+    def input(self, data):
+        self.lexer.push_state("INITIAL")
+        self.parens_level = 0
+        self.last_lparens = 0
+        self.last_rparens = 0
+        self.last_quote = None
+        self.quote_start = None
+        self.lexer.input(data)
+
+    def __getattr__(self, attr):
+        return getattr(self.lexer, attr)
+
+    def t_ANY_error(self, t):
+        raise ConstraintSyntaxError(
+            f"Illegal character '{t.value[0]}' at position {t.lexer.lexpos}"
+        )
+
+    #  Define special tokens as functions before t_TOKEN so they are
+    #  guaranteed to take precedence.
+    #  c.f. http://www.dabeaz.com/ply/ply.html#ply_nn6
+
+    def t_NEGATE(self, t):
+        r"-"
+        return t
+
+    def t_NOT(self, t):
+        r"not\b"
+        return t
+
+    def t_AND(self, t):
+        r"&{1,2}|and\b"
+        return t
+
+    def t_OR(self, t):
+        r"\|{1,2}|or\b"
+        return t
+
+    def t_LPAREN(self, t):
+        r"\("
+        self.parens_level += 1
+        self.last_lparens = t.lexer.lexpos - 1
+        return t
+
+    def t_RPAREN(self, t):
+        r"\)"
+        self.parens_level -= 1
+        self.last_rparens = t.lexer.lexpos - 1
+        return t
+
+    def t_TOKEN(self, t):
+        r"[^()|&\s\"\']+"
+        if self.pending_token is not None:
+            t.value = self.pending_token.value + t.value
+            self.pending_token = None
+        elif t.value.endswith(":"):
+            #  Save a token that ends with ':' to possibly combine with
+            #  any following token. This allows op:"quoted string"
+            self.pending_token = t
+            return None
+        return t
+
+    def t_eof(self, t):
+        if self.pending_token is not None:
+            val = self.pending_token.value
+            raise ConstraintSyntaxError(f"Missing argument to token '{val}'")
+        return None
+
+    def t_QUOTE(self, t):
+        r"'|\""  # fmt: skip
+        self.quote_start = t.lexer.lexpos
+        self.last_quote = t.lexer.lexpos - 1
+        if t.value == "'":
+            t.lexer.begin("squoting")
+        else:
+            t.lexer.begin("dquoting")
+
+    #  quoting state:
+    def t_squoting_TOKEN(self, t):
+        r"([^'])+"
+        return self.t_TOKEN(t)
+
+    def t_squoting_QUOTE(self, t):
+        r"'"
+        self.last_quote = None
+        t.lexer.begin("INITIAL")
+
+    def t_squoting_eof(self, t):
+        pos = self.quote_start
+        raise ConstraintSyntaxError(f'Unclosed quote "\'" at position {pos}')
+
+    def t_dquoting_TOKEN(self, t):
+        r"([^\"])+"
+        return self.t_TOKEN(t)
+
+    def t_dquoting_QUOTE(self, t):
+        r"\""  # fmt: skip
+        self.last_quote = None
+        t.lexer.begin("INITIAL")
+
+    def t_dquoting_eof(self, t):
+        pos = self.quote_start
+        raise ConstraintSyntaxError(f"Unclosed quote '\"' at position {pos}")
+
+
+class ConstraintParser:
+    r"""
+    Base constraint query syntax parser class.
+
+    This class implements an RFC 35 compliant constraint query syntax
+    parser with the following simplified grammar:
+    ::
+
+       expr : expr expr
+        | expr and expr
+        | expr or expr
+        | not expr
+        | '(' expr ')'
+        | '-' term
+        | term
+
+       and : &{1,2}|and|AND
+
+       or : \|{1,2}|or|OR
+
+       not : not|NOT
+
+       term : \w*:?.+  # i.e. [operator:]operand
+
+    Where a term is a constraint operation which has the form
+    '[operator:]operand'. If the token does not include a `:`, then a
+    class default operator may optionally be substituted, e.g. "operand"
+    becomes "default:operand".
+
+    By default, ``operand`` is included as a single entry in the RFC 31
+    values array for the operator, i.e. ``{"operator":["operand"]}``.
+    However, if ``operator`` appears in the self.split_values dict
+    of the parser object, then the corresponding string will be used
+    to split ``value`` into multiple entries. E.g. if
+    ::
+
+        split_values = { "op": "," }
+
+    Then ``op:foo,bar`` would result in ``{"op":["foo","bar"]}``.
+
+    Terms are joined by AND unless OR is specified, such that ``a b c``
+    is the same as ``a && b && c``. A term can be negated with ``-``
+    (e.g. ``-a b c`` is equivlant to ``(not a)&b&c``), but to negate a
+    whole expression, NOT must be used (e.g. ``-(a|b)`` is a syntax error,
+    use ``not (a|b)`` instead).
+
+    As a result of parsing, an RFC 31 constraint object is returned as
+    a Python dict.
+
+    Attributes:
+        operator_map (dict): A mapping of operator names, used to specify
+            default and shorthand operator names. To configura a default
+            operator, specify ``None`` as a key, e.g.
+            ::
+
+               operator_map = { None: "name" }
+
+        split_values (dict): A mapping of operator name to string on which
+            to split values of that operator. For instance ``{"op": ","}``
+            would autosplit operator ``op`` values on comma.
+
+        combined_terms (set): A set of operator terms whose values can be
+            combined when joined with the AND logical operator. E.g. if
+            "test" is in ``combined_terms``, then
+            ::
+
+                test:a test:b
+
+            would produce
+            ::
+
+                {"test": ["a", "b"]}
+
+            instead of
+            ::
+
+                {"and": [{"test": ["a"]}, {"test": ["b"]}]}
+
+    Subclasses can set the values of the above attributes to create a
+    custom parser with default operators, split value handling, and
+    set of combined terms.
+
+    E.g.:
+    ::
+
+      class MyConstraintParser(ConstraintParser):
+          operator_map = { None: "default", "foo": "long_foo" }
+          split_values = { "default": "," }
+          combined_terms = set("default")
+
+    By default there is no mapping for ``None`` which means each term
+    requires an operator.
+
+    """
+
+    precedence = (
+        ("left", "OR"),
+        ("left", "AND"),
+        ("right", "NOT"),
+        ("right", "NEGATE"),
+    )
+
+    # Mapping of operator shorthand names to full names
+    # Subclasses should provide this mapping
+    operator_map = {}
+
+    # Mapping of operator to a string on which to split the operator's
+    # value. The value is typically stored as one entry in an array,
+    # but if set, the split string can be used to return multiple entries.
+    split_values = {}
+
+    # Combined terms
+    combined_terms = set()
+
+    def __init__(self, lexer=None, optimize=1, debug=0, **kw_args):
+        super().__init__()
+        self.lexer = ConstraintLexer() if lexer is None else lexer
+        self.tokens = self.lexer.tokens
+        self.query = None
+        self.parser = yacc.yacc(module=self, optimize=optimize, debug=debug, **kw_args)
+
+    def parse(self, query, **kw_args):
+        self.query = query
+        return self.parser.parse(query, lexer=self.lexer, debug=0, **kw_args)
+
+    def p_error(self, p):
+        if p is None:
+            if self.lexer.parens_level > 0:
+                pos = self.lexer.last_lparens
+                raise ConstraintSyntaxError(f"Unclosed parenthesis in position {pos}")
+            raise ConstraintSyntaxError(f"Unexpected end of input in '{self.query}'")
+        if self.lexer.parens_level < 0:
+            raise ConstraintSyntaxError(
+                "Mismatched parentheses starting at position {self.lexer.last_rparens}."
+            )
+        raise ConstraintSyntaxError(f"Invalid token '{p.value}' at position {p.lexpos}")
+
+    def combine_like_terms(self, p1, p2):
+        combined_terms = {}
+        terms = []
+        entries = [p1, p2]
+
+        # First, attempt to combine any "and" terms
+        if "and" in p1:
+            p1["and"].append(p2)
+            entries = [p1]
+
+        # Then, combine any requested combined terms
+        for entry in entries:
+            key = list(entry)[0]
+            if key not in self.combined_terms:
+                terms.append(entry)
+            elif key not in combined_terms:
+                combined_terms[key] = entry[key]
+                terms.append(entry)
+            else:
+                combined_terms[key].extend(entry[key])
+        if len(terms) == 1:
+            return terms[0]
+        else:
+            return {"and": terms}
+
+    def p_expression_space(self, p):
+        """
+        expression : expression expression %prec AND
+        """
+        p[0] = self.combine_like_terms(p[1], p[2])
+
+    def p_expression_and(self, p):
+        """
+        expression : expression AND expression
+        """
+        p[0] = self.combine_like_terms(p[1], p[3])
+
+    def p_expression_or(self, p):
+        """
+        expression : expression OR expression
+        """
+        if "or" in p[1]:
+            # Combine this `or` with a previous one
+            p[1]["or"].append(p[3])
+            p[0] = p[1]
+        else:
+            p[0] = {"or": [p[1], p[3]]}
+
+    def p_expression_unot(self, p):
+        """
+        expression : NOT expression
+                   | NEGATE token
+        """
+        p[0] = {"not": [p[2]]}
+
+    def p_expression_parens(self, p):
+        """
+        expression : LPAREN expression RPAREN
+        """
+        p[0] = p[2]
+
+    def p_token(self, p):
+        """
+        expression : token
+        """
+        p[0] = p[1]
+
+    def p_expression_token(self, p):
+        """
+        token : TOKEN
+        """
+        op, colon, value = p[1].partition(":")
+        if not colon:
+            if None not in self.operator_map:
+                raise ConstraintSyntaxError(f'Missing required operator in "{p[1]}"')
+            op = self.operator_map[None]
+            value = p[1]
+        elif op in self.operator_map:
+            op = self.operator_map[op]
+
+        if op in self.split_values:
+            p[0] = {op: value.split(self.split_values[op])}
+        else:
+            p[0] = {op: [value]}
+
+    def p_quoted_token(self, p):
+        """
+        token : QUOTE TOKEN QUOTE
+        """
+        p[0] = p[2]
+
+
+if __name__ == "__main__":
+    """
+    Test command which can be run as flux python -m flux.constraint.parser
+    Also used to generate ply's parsetab.py in defined outputdir.
+    """
+
+    argparser = argparse.ArgumentParser(prog="constraint.parser")
+    argparser.add_argument(
+        "--outputdir",
+        metavar="DIR",
+        type=str,
+        help="Set outputdir for parsetab.py generation",
+    )
+    argparser.add_argument(
+        "--default-op",
+        metavar="NAME",
+        type=str,
+        help="Set a default operator to substitute for bare terms",
+    )
+    argparser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Emit lexer debug information before parsing expression",
+    )
+    argparser.add_argument(
+        "expression",
+        metavar="EXPRESSION",
+        type=str,
+        nargs="*",
+        help="Expression to parse",
+    )
+    args = argparser.parse_args()
+
+    if args.outputdir:
+        print(f"Generating constraint parsetab.py in {args.outputdir}")
+
+    class TConstraintParser(ConstraintParser):
+        if args.default_op:
+            operator_map = {None: args.default_op}
+
+    parser = TConstraintParser(optimize=0, debug=1, outputdir=args.outputdir)
+    if args.expression:
+
+        s = " ".join(args.expression)
+        if args.debug:
+            print(f"parsing expression `{s}'")
+        if args.debug:
+            lexer = ConstraintLexer()
+            lexer.input(s)
+            while True:
+                tok = lexer.token()
+                if not tok:
+                    break
+                print(tok)
+
+        print(json.dumps(parser.parse(s)))

--- a/src/test/docker/bionic/Dockerfile
+++ b/src/test/docker/bionic/Dockerfile
@@ -66,7 +66,7 @@ RUN apt-get update \
 RUN for PY in python3.6 python3.7 python3.8 ; do \
         sudo $PY -m pip install --upgrade --ignore-installed \
 	    "markupsafe==2.0.0" \
-            coverage cffi six pyyaml "jsonschema>=2.6,<4.0" \
+            coverage cffi ply six pyyaml "jsonschema>=2.6,<4.0" \
             sphinx sphinx-rtd-theme sphinxcontrib-spelling; \
 	sudo mkdir -p /usr/lib/${PY}/dist-packages; \
 	echo ../site-packages >/tmp/site-packages.pth; \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -73,6 +73,7 @@ TESTSCRIPTS = \
 	t0024-content-s3.t \
 	t0028-content-backing-none.t \
 	t0029-filemap-cmd.t \
+	t0030-marshall.t \
 	t0025-broker-state-machine.t \
 	t0027-broker-groups.t \
 	t0013-config-file.t \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -251,6 +251,7 @@ TESTSCRIPTS = \
 	python/t0024-util.py \
 	python/t0025-uri.py \
 	python/t0026-tree.py \
+	python/t0027-constraint-parser.py \
 	python/t1000-service-add-remove.py
 
 if HAVE_FLUX_SECURITY

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -74,6 +74,7 @@ TESTSCRIPTS = \
 	t0028-content-backing-none.t \
 	t0029-filemap-cmd.t \
 	t0030-marshall.t \
+	t0031-constraint-parser.t \
 	t0025-broker-state-machine.t \
 	t0027-broker-groups.t \
 	t0013-config-file.t \

--- a/t/python/t0027-constraint-parser.py
+++ b/t/python/t0027-constraint-parser.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+###############################################################
+# Copyright 2023 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+import io
+import os
+import json
+import sys
+import unittest
+import subflux  # To set up PYTHONPATH
+from pycotap import TAPTestRunner
+from flux.constraint.parser import ConstraintParser, ConstraintSyntaxError
+
+VALID = [
+    {"in": "a", "out": {"t": ["a"]}},
+    {"in": "(a)", "out": {"t": ["a"]}},
+    {"in": "( a )", "out": {"t": ["a"]}},
+    {"in": "'a'", "out": {"t": ["a"]}},
+    {"in": "('a')", "out": {"t": ["a"]}},
+    {"in": "a|b", "out": {"or": [{"t": ["a"]}, {"t": ["b"]}]}},
+    {"in": "a or b", "out": {"or": [{"t": ["a"]}, {"t": ["b"]}]}},
+    {"in": "a || b", "out": {"or": [{"t": ["a"]}, {"t": ["b"]}]}},
+    {"in": "a||b", "out": {"or": [{"t": ["a"]}, {"t": ["b"]}]}},
+    {"in": "a b c", "out": {"and": [{"t": ["a"]}, {"t": ["b"]}, {"t": ["c"]}]}},
+    {"in": "a&b&c", "out": {"and": [{"t": ["a"]}, {"t": ["b"]}, {"t": ["c"]}]}},
+    {"in": "a and b and c", "out": {"and": [{"t": ["a"]}, {"t": ["b"]}, {"t": ["c"]}]}},
+    {"in": "a && b && c", "out": {"and": [{"t": ["a"]}, {"t": ["b"]}, {"t": ["c"]}]}},
+    {
+        "in": "a&b|c",
+        "out": {"or": [{"and": [{"t": ["a"]}, {"t": ["b"]}]}, {"t": ["c"]}]},
+    },
+    {
+        "in": "a&(b|c)",
+        "out": {"and": [{"t": ["a"]}, {"or": [{"t": ["b"]}, {"t": ["c"]}]}]},
+    },
+    {
+        "in": "(a&(b|c))",
+        "out": {"and": [{"t": ["a"]}, {"or": [{"t": ["b"]}, {"t": ["c"]}]}]},
+    },
+    {
+        "in": "(a&(b|-c))",
+        "out": {"and": [{"t": ["a"]}, {"or": [{"t": ["b"]}, {"not": [{"t": ["c"]}]}]}]},
+    },
+    {
+        "in": "a or host:foo",
+        "out": {"or": [{"t": ["a"]}, {"host": ["foo"]}]},
+    },
+    {
+        "in": "a or -host:foo",
+        "out": {"or": [{"t": ["a"]}, {"not": [{"host": ["foo"]}]}]},
+    },
+    {
+        "in": "a or time:11:00am",
+        "out": {"or": [{"t": ["a"]}, {"time": ["11:00am"]}]},
+    },
+    {
+        "in": "a or test:'a quoted string'",
+        "out": {"or": [{"t": ["a"]}, {"test": ["a quoted string"]}]},
+    },
+    {
+        "in": "a or name:'/foo|(bar)|baz.*/'",
+        "out": {"or": [{"t": ["a"]}, {"name": ["/foo|(bar)|baz.*/"]}]},
+    },
+]
+
+INVALID = ["a|", "a:' ", "(a", "(a))", "-(a|b)", "foo and a:"]
+
+
+class TestConstraintParser(ConstraintParser):
+    operator_map = {None: "t", "a": "op-a"}
+
+class TestSplitParser(ConstraintParser):
+    operator_map = {None: "t"}
+    split_values = {"t": ","}
+
+class TestCombineParser(ConstraintParser):
+    operator_map = {None: "t"}
+    combined_terms = set("t")
+
+class TestParser(unittest.TestCase):
+    def test_parse_valid(self):
+        parser = TestConstraintParser()
+        for test in VALID:
+            print(f"checking `{test['in']}'")
+            result = parser.parse(test["in"])
+            self.assertDictEqual(test["out"], result)
+
+    def test_parse_invalid(self):
+        parser = TestConstraintParser()
+        for test in INVALID:
+            print(f"checking invalid input `{test}'")
+            with self.assertRaises((SyntaxError, ConstraintSyntaxError)):
+                parser.parse(test)
+
+    def test_default_parser(self):
+        parser = ConstraintParser()
+        print("ConstraintParser requires operator by default")
+        with self.assertRaises(ConstraintSyntaxError):
+            parser.parse("foo")
+
+    def test_split_values(self):
+        parser = TestSplitParser()
+        print("ConstraintParser can split values if configured")
+        result = parser.parse("xx,yy")
+        print(f"got {result}")
+        self.assertDictEqual({"t":["xx", "yy"]}, result)
+
+        result = parser.parse("xx")
+        print(f"got {result}")
+        self.assertDictEqual({"t":["xx"]}, result)
+
+        result = parser.parse("t:xx,yy")
+        print(f"got {result}")
+        self.assertDictEqual({"t":["xx", "yy"]}, result)
+
+    def test_combine_terms(self):
+        parser = TestCombineParser()
+        print("ConstraintParser doesn't combine unconfigured like terms")
+        result = parser.parse("a:xx b:yy")
+        print(f"got {result}")
+        self.assertDictEqual({"and": [{"a":["xx"]}, {"b": ["yy"]}]}, result)
+
+        print("ConstraintParser combines configured like terms")
+        result = parser.parse("xx and yy")
+        print(f"got {result}")
+        self.assertDictEqual({"t":["xx", "yy"]}, result)
+
+        print("ConstraintParser combines configured like terms (nested)")
+        result = parser.parse("not (xx and yy)")
+        print(f"got {result}")
+        self.assertDictEqual({"not": [{"t":["xx", "yy"]}]}, result)
+
+        print("ConstraintParser doesn't combine like terms (or)")
+        result = parser.parse("xx|yy")
+        print(f"got {result}")
+        self.assertDictEqual({"or": [{"t":["xx"]}, {"t": ["yy"]}]}, result)
+
+if __name__ == "__main__":
+    unittest.main(testRunner=TAPTestRunner())

--- a/t/t0031-constraint-parser.t
+++ b/t/t0031-constraint-parser.t
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+test_description='Test python flux.constraint.parser standalone operation'
+
+. `dirname $0`/sharness.sh
+
+parser="flux python -m flux.constraint.parser"
+
+test_expect_success 'flux.constraint.parser works' '
+	$parser
+'
+test_expect_success 'flux.constraint.parser prints usage' '
+	$parser --help > parser.out 2>&1 &&
+	test_debug "cat parser.out" &&
+	grep -i usage parser.out
+'
+test_expect_success 'flux.constraint.parser parses cmdline' '
+	$parser test:a test:b >basic.out &&
+	test_debug "cat basic.out" &&
+	grep and basic.out
+'
+test_expect_success 'flux.constraint.parser --default-op works' '
+	$parser --default=op=test a b >default-op.out &&
+	test_debug "cat default-op.out" &&
+	grep test default-op.out
+'
+test_expect_success 'flux.constraint.parser --debug works' '
+	$parser --debug --default=op=test "a|(b&-c)" >debug.out 2>&1 &&
+	test_debug "cat debug.out" &&
+	grep TOKEN debug.out
+'
+test_done


### PR DESCRIPTION
This PR adds a `ConstraintParser` class to the Flux Python bindings which can parse the generic query syntax being proposed for RFC 35 in flux-framework/rfc#360. I'm posting the implementation early since it may help reviewers of the RFC PR to experiment with the syntax and give feedback in either PR.

The `flux.constraint.parser` module supports a `__main__` function, so you can run the parser like this for testing:
```console
$ src/cmd/flux python -m flux.constraint.parser --default-op=name 'a|b|c'
{"or": [{"name": ["a"]}, {"name": ["b"]}, {"name": ["c"]}]}
```