### PR TITLE
testsuite: drop fragile broker.boot-method test

### DIFF
--- a/src/common/libpmi/upmi.c
+++ b/src/common/libpmi/upmi.c
@@ -430,7 +430,7 @@ int upmi_finalize (struct upmi *upmi, flux_error_t *errp)
         upmi_trace (upmi, "finalize: %s", error.text);
         return -1;
     }
-    upmi_trace (upmi, "finalize: successs");
+    upmi_trace (upmi, "finalize: success");
     return 0;
 }
 

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -82,9 +82,6 @@ ARGS="-o,-Sbroker.rc1_path=,-Sbroker.rc3_path="
 test_expect_success 'flux-start in exec mode works' "
 	flux start ${ARGS} flux getattr size | grep -x 1
 "
-test_expect_success 'and broker.boot-method=single' "
-	test $(flux start ${ARGS} flux getattr broker.boot-method) = "single"
-"
 test_expect_success 'flux-start in subprocess/pmi mode works (size 1)' "
 	flux start ${ARGS} -s1 flux getattr size | grep -x 1
 "


### PR DESCRIPTION
Problem: t0001-basic.t "broker.boot-method=single" test fails if a libpmi.so is found that falls through to singleton mode.

Drop the test.  It wasn't doing much.

Fixes issue #4873