### PR TITLE
flux-shell: truncate long log messages

### DIFF
--- a/t/shell/plugins/log.c
+++ b/t/shell/plugins/log.c
@@ -61,6 +61,7 @@ static int check_shell_log (flux_plugin_t *p,
     }
 
     shell_trace ("%s: trace message", topic);
+    shell_trace ("%s: long message: %.8192d", topic, 0);
     shell_debug ("%s: debug message", topic);
     shell_log ("%s: log message", topic);
     shell_warn ("%s: warn message", topic);

--- a/t/t2608-job-shell-log.t
+++ b/t/t2608-job-shell-log.t
@@ -38,6 +38,9 @@ for topic in "shell.init" "shell.exit" \
     test_expect_success "$topic: got TRACE level message" "
         grep \"TRACE: log: .*: $topic: trace message\" log.log
     "
+    test_expect_success "$topic: got truncated long TRACE level message" "
+        grep -q \"TRACE: log: .*: $topic: long message.*0000+$\" log.log
+    "
     test_expect_success "$topic: got DEBUG level message" "
         grep \"DEBUG: log: .*: $topic: debug message\" log.log
     "


### PR DESCRIPTION
Problem: potentially useful shell log messages are lost if the static log buffer size is exceeded.

If the message is too long, truncate it, add a '+', and continue on. Don't treat this as an error.

Fixes #4860