### PR TITLE
docker: add site-packages to default python3 path

### DIFF
--- a/src/test/docker/bionic/Dockerfile
+++ b/src/test/docker/bionic/Dockerfile
@@ -68,6 +68,9 @@ RUN for PY in python3.6 python3.7 python3.8 ; do \
 	    "markupsafe==2.0.0" \
             coverage cffi six pyyaml "jsonschema>=2.6,<4.0" \
             sphinx sphinx-rtd-theme sphinxcontrib-spelling; \
+	sudo mkdir -p /usr/lib/${PY}/dist-packages; \
+	echo ../site-packages >/tmp/site-packages.pth; \
+	sudo mv /tmp/site-packages.pth /usr/lib/${PY}/dist-packages; \
     done ; \
     apt-get -qq purge -y python3-pip \
  && apt-get -qq autoremove -y

--- a/src/test/docker/focal/Dockerfile
+++ b/src/test/docker/focal/Dockerfile
@@ -71,6 +71,9 @@ RUN apt-get update \
 # Sphinx packages for docs
 RUN python3 -m pip install sphinx sphinx-rtd-theme sphinxcontrib-spelling
 
+RUN mkdir -p /usr/lib/python3.8/dist-packages \
+ && echo ../site-packages >/usr/lib/python3.8/dist-packages/site-packages.pth
+
 # Other deps
 RUN apt-get update \
  && apt-get -qq install -y --no-install-recommends \


### PR DESCRIPTION
Problem: On debian based docker containers (bionic, focal), the flux python module is not found by default because

  /usr/lib/python3.x/site-packages

is not in the default search path. This is because debian based distributions only search 'dist-packages' instead of 'site-packages'. However, `make install` puts our Flux modules in 'site-packages' because this is the module install directory understood by autotools.

To work around this issue, place a 'site-packages.pth' file in 'dist-packages' to get Python to read site-packages as well as dist-packages.

Fixes #4877