### PR TITLE
support flux mini batch,alloc --dump[=FILE]

### DIFF
--- a/doc/man1/flux-mini.rst
+++ b/doc/man1/flux-mini.rst
@@ -672,6 +672,14 @@ OTHER OPTIONS
    to separate files (including stdin) by newline. To separate by
    consecutive whitespace, specify ``--sep=none``.
 
+**--dump=[FILE]**
+   *(batch,alloc)* When the job script is complete, archive the Flux
+   instance's KVS content to ``FILE``, which should have a suffix known
+   to :linux:man3:`libarchive`, and may be a mustache template as described
+   above for ``--output``.  The content may be unarchived directly or examined
+   within a test instance started with the :man1:`flux-start` ``--recovery``
+   option.  If ``FILE`` is unspecified, ``flux-{{jobid}}-dump.tgz`` is used.
+
 .. _bulksubmit:
 
 BULKSUBMIT

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -696,3 +696,4 @@ pkill
 deps
 queuem
 timelimit
+unarchived

--- a/src/cmd/flux-mini.py
+++ b/src/cmd/flux-mini.py
@@ -1705,6 +1705,13 @@ def add_batch_alloc_args(parser):
         help="Pass options to flux brokers",
     )
     parser.add_argument(
+        "--dump",
+        nargs="?",
+        const="flux-{{jobid}}-dump.tgz",
+        metavar="FILE",
+        help="Archive KVS on exit",
+    )
+    parser.add_argument(
         "-n",
         "--nslots",
         type=int,
@@ -1804,6 +1811,10 @@ class BatchCmd(MiniCmd):
             args.nslots = args.nodes
             args.exclusive = True
 
+        if args.dump:
+            args.broker_opts = args.broker_opts or []
+            args.broker_opts.append("-Scontent.dump=" + args.dump)
+
         jobspec = JobspecV1.from_batch_command(
             script=self.read_script(args),
             jobname=args.SCRIPT[0] if args.SCRIPT else "batchscript",
@@ -1868,6 +1879,10 @@ class AllocCmd(MiniCmd):
         if args.bg and not args.COMMAND:
             args.broker_opts = args.broker_opts or []
             args.broker_opts.append("-Sbroker.rc2_none=1")
+
+        if args.dump:
+            args.broker_opts = args.broker_opts or []
+            args.broker_opts.append("-Scontent.dump=" + args.dump)
 
         jobspec = JobspecV1.from_nest_command(
             command=args.COMMAND,

--- a/src/shell/batch.c
+++ b/src/shell/batch.c
@@ -53,10 +53,8 @@ batch_info_create (flux_shell_t *shell, json_t *batch)
 
     if (flux_shell_info_unpack (shell,
                                "{s:i s:I}",
-                               "rank",
-                               &b->shell_rank,
-                               "jobid",
-                               &b->id) < 0) {
+                               "rank", &b->shell_rank,
+                               "jobid", &b->id) < 0) {
         shell_log_errno ("failed to unpack shell info");
         goto error;
     }
@@ -155,13 +153,15 @@ static int task_batchify (flux_plugin_t *p,
          *  with path to our script
          */
         if (flux_cmd_argv_delete (cmd, 0) < 0
-            || flux_cmd_argv_insert (cmd, 0, b->script) < 0)
-        return shell_log_errno ("failed to replace command with batch script");
+            || flux_cmd_argv_insert (cmd, 0, b->script) < 0) {
+            return shell_log_errno ("failed to replace command"
+                                    " with batch script");
+        }
     }
     else {
         /* Other ranks, delete all args, they are unused */
         while (flux_cmd_argv_delete (cmd, 0) == 0)
-           ; 
+           ;
     }
 
     /*  All broker ranks, add broker options */
@@ -190,15 +190,14 @@ static int batch_init (flux_plugin_t *p,
 
     if (flux_shell_info_unpack (shell,
                                "{s:o}",
-                               "jobspec",
-                               &jobspec) < 0)
+                               "jobspec", &jobspec) < 0)
         return shell_log_errno ("failed to unpack jobspec");
     json_error_t err;
     if (json_unpack_ex (jobspec, &err, 0,
-                     "{s:{s:{s?o}}}",
-                     "attributes",
-                       "system",
-                         "batch", &batch) < 0) {
+                        "{s:{s:{s?o}}}",
+                        "attributes",
+                          "system",
+                            "batch", &batch) < 0) {
         shell_log_error ("failed to unpack batch object from jobspec: %s",
                         err.text);
         return -1;

--- a/src/shell/internal.h
+++ b/src/shell/internal.h
@@ -21,6 +21,7 @@
 
 #include "plugstack.h"
 #include "events.h"
+#include "mustache.h"
 
 struct flux_shell {
     flux_jobid_t jobid;
@@ -36,6 +37,7 @@ struct flux_shell {
     struct shell_svc *svc;
     zlist_t *tasks;
     flux_shell_task_t *current_task;
+    struct mustache_renderer *mr;
 
     struct plugstack *plugstack;
     struct shell_eventlogger *ev;

--- a/src/shell/shell.c
+++ b/src/shell/shell.c
@@ -40,6 +40,7 @@
 #include "task.h"
 #include "rc.h"
 #include "log.h"
+#include "mustache.h"
 
 static char *shell_name = "flux-shell";
 static const char *shell_usage = "[OPTIONS] JOBID";
@@ -927,6 +928,7 @@ static void shell_finalize (flux_shell_t *shell)
     shell->plugstack = NULL;
     plugstack_destroy (plugstack);
 
+    mustache_renderer_destroy (shell->mr);
     shell_eventlogger_destroy (shell->ev);
     shell_svc_destroy (shell->svc);
     shell_info_destroy (shell->info);
@@ -975,6 +977,51 @@ static int get_protocol_fd (int *pfd)
     return 0;
 }
 
+char *shell_mustache_render (flux_shell_t *shell, const char *fmt)
+{
+    return mustache_render (shell->mr, fmt);
+}
+
+static int mustache_cb (FILE *fp, const char *name, void *arg)
+{
+    flux_shell_t *shell = arg;
+    char value[128];
+
+    /*  "jobid" is a synonym for "id" */
+    if (strncmp (name, "jobid", 5) == 0)
+        name += 3;
+    if (strncmp (name, "id", 2) == 0) {
+        const char *type = "f58";
+        if (strlen (name) > 2) {
+            if (name[2] != '.') {
+                shell_log_error ("Unknown mustache tag '%s'", name);
+                return -1;
+            }
+            type = name+3;
+        }
+        if (flux_job_id_encode (shell->info->jobid,
+                                type,
+                                value,
+                                sizeof (value)) < 0) {
+            if (errno == EPROTO)
+                shell_log_error ("Invalid jobid encoding '%s' specified", name);
+            else
+                shell_log_errno ("flux_job_id_encode failed for %s", name);
+            return -1;
+        }
+    }
+    else {
+        shell_log_error ("Unknown mustache tag '%s'", name);
+        return -1;
+    }
+    if (fputs (value, fp) < 0) {
+        shell_log_error ("memstream write failed for %s: %s",
+                         name,
+                         strerror (errno));
+    }
+    return 0;
+}
+
 static void shell_initialize (flux_shell_t *shell)
 {
     const char *pluginpath = shell_conf_get ("shell_pluginpath");
@@ -990,6 +1037,10 @@ static void shell_initialize (flux_shell_t *shell)
     if (!(shell->completion_refs = zhashx_new ()))
         shell_die_errno (1, "zhashx_new");
     zhashx_set_destructor (shell->completion_refs, item_free);
+
+    if (!(shell->mr = mustache_renderer_create (mustache_cb, shell)))
+        shell_die_errno (1, "mustache_renderer_create");
+    mustache_renderer_set_log (shell->mr, shell_llog, NULL);
 
     if (!(shell->plugstack = plugstack_create ()))
         shell_die_errno (1, "plugstack_create");

--- a/src/shell/shell.h
+++ b/src/shell/shell.h
@@ -401,6 +401,11 @@ void flux_shell_raise (const char *type, int severity, const char *fmt, ...);
  */
 int flux_shell_log_setlevel (int level, const char *dest);
 
+/*  Expand mustache template.  Caller must free the result.
+ */
+char *shell_mustache_render (flux_shell_t *shell, const char *fmt);
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/t/t2601-job-shell-standalone.t
+++ b/t/t2601-job-shell-standalone.t
@@ -171,4 +171,11 @@ test_expect_success 'flux-shell: shell forwards signals to tasks' '
 	grep "forwarding signal 15" sigterm.err
 '
 
+test_expect_success 'flux-shell: mustachioed command line args are rendered' '
+	flux mini run --dry-run -n1 -o cpu-affinity=off \
+		bash -c "echo test-{{id.dec}}-{{id.dec}} >j10.out" > j10 &&
+	${FLUX_SHELL} -s -r 0 -j j10 -R R8 42 &&
+	grep test-42-42 j10.out
+'
+
 test_done

--- a/t/t2701-mini-batch.t
+++ b/t/t2701-mini-batch.t
@@ -170,4 +170,22 @@ test_expect_success 'flux mini batch: MPI env vars are not set in batch script' 
 	flux job status $id &&
 	test_must_fail grep OMPI_MCA_pmix envtest.out
 '
+test_expect_success 'flux mini batch: --dump works' '
+	id=$(flux mini batch -N1 --dump \
+		--flags=waitable --wrap true) &&
+	run_timeout 60 flux job wait $id &&
+	tar tvf flux-${id}-dump.tgz
+'
+test_expect_success 'flux mini batch: --dump=FILE works' '
+	id=$(flux mini batch -N1 --dump=testdump.tgz \
+		--flags=waitable --wrap true) &&
+	run_timeout 60 flux job wait $id &&
+	tar tvf testdump.tgz
+'
+test_expect_success 'flux mini batch: --dump=FILE works with mustache' '
+	id=$(flux mini batch -N1 --dump=testdump-{{id}}.tgz \
+		--flags=waitable --wrap true) &&
+	run_timeout 60 flux job wait $id &&
+	tar tvf testdump-${id}.tgz
+'
 test_done

--- a/t/t2702-mini-alloc.t
+++ b/t/t2702-mini-alloc.t
@@ -139,5 +139,24 @@ test_expect_success 'flux mini alloc: MPI vars are not set in initial program' '
 	flux mini alloc -N1 printenv >envtest.out &&
 	test_must_fail grep OMPI_MCA_pmix envtest.out
 '
+test_expect_success 'flux mini alloc: --dump works' '
+        jobid=$(flux mini alloc -N1 --bg --dump) &&
+	flux shutdown $jobid &&
+	flux job wait-event $jobid clean &&
+        tar tvf flux-${jobid}-dump.tgz
+'
+test_expect_success 'flux mini alloc: --dump=FILE works' '
+        jobid=$(flux mini alloc -N1 --bg --dump=testdump.tgz) &&
+	flux shutdown $jobid &&
+	flux job wait-event $jobid clean &&
+        tar tvf testdump.tgz
+'
+test_expect_success 'flux mini alloc: --dump=FILE works with mustache' '
+        jobid=$(flux mini alloc -N1 --bg --dump=testdump-{{id}}.tgz) &&
+	flux shutdown $jobid &&
+	flux job wait-event $jobid clean &&
+        tar tvf testdump-${jobid}.tgz
+'
+
 
 test_done


### PR DESCRIPTION
In #4868, it was suggested (er by me) that an option to dump kvs contents when a batch job instance exits might be useful.

This extends the `content.dump=auto` code in rc3 to use the job ID and produce `flux-<jobid>-kvs.tgz` if requested when a `statedir` is not defined.

I started looking at `flux-mini.py` to see about adding a shorthand option for this and realized it might be better if such an option worked like `--output` and supported mustache templates.  So maybe this is the wrong approach and support for this should be added to the shell `batch` plugin instead.  Parking this pending some time to think more about it.  Meanwhile, input welcome!