### PR TITLE
add flux-keygen --meta KEY=VAL option

### DIFF
--- a/doc/man1/flux-keygen.rst
+++ b/doc/man1/flux-keygen.rst
@@ -6,7 +6,7 @@ flux-keygen(1)
 SYNOPSIS
 ========
 
-**flux** **keygen** [*--name=NAME*] *PATH*
+**flux** **keygen** [*--name=NAME*] [*--meta=KEY=VAL...*] *PATH*
 
 
 DESCRIPTION
@@ -37,6 +37,11 @@ OPTIONS
    Set the certificate metadata ``name`` field.  The value is logged when
    :man1:`flux-broker` authenticates a peer that presents this certificate.
    A cluster name might be appropriate here.  Default: the local hostname.
+
+**--meta=KEY=VAL**
+   Set arbitrary certificate metadata.  Multiple key-value pairs may be
+   specified, separated by commas.  This option may be specified multiple
+   times.
 
 
 RESOURCES

--- a/src/cmd/flux-keygen.c
+++ b/src/cmd/flux-keygen.c
@@ -15,6 +15,7 @@
 #include <flux/core.h>
 #include <flux/optparse.h>
 #include <czmq.h>
+#include <sodium.h>
 
 #include "src/common/libutil/log.h"
 
@@ -103,6 +104,26 @@ int main (int argc, char *argv[])
     zcert_set_meta (cert, "keygen.hostname", "%s", hostname);
     zcert_set_meta (cert, "keygen.time", "%s", now);
     zcert_set_meta (cert, "keygen.userid", "%d", getuid ());
+    zcert_set_meta (cert,
+                    "keygen.flux-core-version",
+                    "%s",
+                    FLUX_CORE_VERSION_STRING);
+    zcert_set_meta (cert,
+                    "keygen.zmq-version",
+                    "%d.%d.%d",
+                    ZMQ_VERSION_MAJOR,
+                    ZMQ_VERSION_MINOR,
+                    ZMQ_VERSION_PATCH);
+    zcert_set_meta (cert,
+                    "keygen.czmq-version",
+                    "%d.%d.%d",
+                    CZMQ_VERSION_MAJOR,
+                    CZMQ_VERSION_MINOR,
+                    CZMQ_VERSION_PATCH);
+    zcert_set_meta (cert,
+                    "keygen.sodium-version",
+                    "%s",
+                    SODIUM_VERSION_STRING);
 
     if (path && zcert_save_secret (cert, path) < 0)
         log_msg_exit ("zcert_save_secret %s: %s", path, strerror (errno));

--- a/src/cmd/flux-keygen.c
+++ b/src/cmd/flux-keygen.c
@@ -100,9 +100,9 @@ int main (int argc, char *argv[])
 
     // name is used in overlay logging
     zcert_set_meta (cert, "name", "%s", hostname);
-    zcert_set_meta (cert, "hostname", "%s", hostname);
-    zcert_set_meta (cert, "time", "%s", now);
-    zcert_set_meta (cert, "userid", "%d", getuid ());
+    zcert_set_meta (cert, "keygen.hostname", "%s", hostname);
+    zcert_set_meta (cert, "keygen.time", "%s", now);
+    zcert_set_meta (cert, "keygen.userid", "%d", getuid ());
 
     if (path && zcert_save_secret (cert, path) < 0)
         log_msg_exit ("zcert_save_secret %s: %s", path, strerror (errno));

--- a/src/cmd/flux-keygen.c
+++ b/src/cmd/flux-keygen.c
@@ -21,6 +21,9 @@
 static struct optparse_option opts[] = {
     { .name = "name", .key = 'n', .has_arg = 1, .arginfo = "NAME",
       .usage = "Set certificate name (default: hostname)", },
+    { .name = "meta", .has_arg = 1, .arginfo = "KEYVALS",
+      .flags = OPTPARSE_OPT_AUTOSPLIT,
+      .usage = "Add/update comma-separated key=value metadata", },
     OPTPARSE_TABLE_END,
 };
 
@@ -44,7 +47,9 @@ int main (int argc, char *argv[])
     optparse_t *p;
     int optindex;
     zcert_t *cert;
-    char buf[64];
+    const char *name;
+    char now[64];
+    char hostname[64];
     char *path = NULL;
 
     log_init ("flux-keygen");
@@ -65,13 +70,38 @@ int main (int argc, char *argv[])
 
     if (!(cert = zcert_new ()))
         log_msg_exit ("zcert_new: %s", zmq_strerror (errno));
-
-    if (gethostname (buf, sizeof (buf)) < 0)
+    if (gethostname (hostname, sizeof (hostname)) < 0)
         log_err_exit ("gethostname");
-    zcert_set_meta (cert, "hostname", "%s", buf);
+    if (ctime_iso8601_now (now, sizeof (now)) == NULL)
+        log_err_exit ("localtime");
+
+    /* N.B. zcert_set_meta() silently ignores attempts to set the same
+     * value twice so the default settings come later and are ignored
+     * if values were provided on the command line.
+     */
+    if ((name = optparse_get_str (p, "name", NULL))) {
+        zcert_set_meta (cert, "name", "%s", name);
+    }
+    if (optparse_hasopt (p, "meta")) {
+        const char *arg;
+
+        optparse_getopt_iterator_reset (p, "meta");
+        while ((arg = optparse_getopt_next (p, "meta"))) {
+            char *key;
+            char *val;
+            if (!(key = strdup (arg)))
+                log_msg_exit ("out of memory");
+            if ((val = strchr (key, '=')))
+                *val++ = '\0';
+            zcert_set_meta (cert, key, "%s", val ? val : "");
+            free (key);
+        }
+    }
+
     // name is used in overlay logging
-    zcert_set_meta (cert, "name", "%s", optparse_get_str (p, "name", buf));
-    zcert_set_meta (cert, "time", "%s", ctime_iso8601_now (buf, sizeof (buf)));
+    zcert_set_meta (cert, "name", "%s", hostname);
+    zcert_set_meta (cert, "hostname", "%s", hostname);
+    zcert_set_meta (cert, "time", "%s", now);
     zcert_set_meta (cert, "userid", "%d", getuid ());
 
     if (path && zcert_save_secret (cert, path) < 0)

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -42,6 +42,27 @@ test_expect_success 'flux-keygen --name=test works' '
 	test -f cert2 &&
 	grep testcert cert2
 '
+test_expect_success 'flux-keygen --meta works' '
+	flux keygen --meta mammal=chinchilla,reptile=chamelion cert3 &&
+	test -f cert3 &&
+	grep mammal cert3 &&
+	grep reptile cert3
+'
+test_expect_success 'flux-keygen --meta can update keygen.hostname' '
+	flux keygen --meta=keygen.hostname=myhost cert4 &&
+	test -f cert4 &&
+	grep myhost cert4
+'
+test_expect_success 'flux-keygen --meta value can be an empty string' '
+	flux keygen --meta smurf= cert5 &&
+	test -f cert5 &&
+	grep smurf cert5
+'
+test_expect_success 'flux-keygen --meta equal sign can be missing' '
+	flux keygen --meta smurf cert6 &&
+	test -f cert6 &&
+	grep smurf cert6
+'
 test_expect_success 'flux-keygen fails with extra positional argument' '
 	test_must_fail flux keygen cert xyz
 '


### PR DESCRIPTION
This adds an option to flux-keygen to set arbitrary metadata in certificates at generation, and override default metadata.

Also it renames some built-in metadata keys with a "keygen." prefix to hopefully make their purpose more clear.

Finally, the versions of flux-core, czmq, zmq, and sodium are added to the certificate.  These might be useful when asking questions like "was this certificate generated by software with a known bug that affects the robustness of the cert?"