### PR TITLE
work around fluxion inbability to recover running jobs

### DIFF
--- a/src/modules/sched-simple/sched.c
+++ b/src/modules/sched-simple/sched.c
@@ -529,7 +529,7 @@ static int hello_cb (flux_t *h,
         flux_log (h, LOG_DEBUG, "hello: alloc %s", s);
     free (s);
     rlist_destroy (alloc);
-    return 0;
+    return rc;
 }
 
 static void status_cb (flux_t *h, flux_msg_handler_t *mh,

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -154,6 +154,7 @@ TESTSCRIPTS = \
 	t2280-job-memo.t \
 	t2300-sched-simple.t \
 	t2302-sched-simple-up-down.t \
+	t2303-sched-hello.t \
 	t2310-resource-module.t \
 	t2311-resource-drain.t \
 	t2312-resource-exclude.t \

--- a/t/t2303-sched-hello.t
+++ b/t/t2303-sched-hello.t
@@ -1,0 +1,43 @@
+#!/bin/sh
+
+test_description='test sched hello
+
+Ensure that a job that the scheduler rejects during hello processing
+receives a fatal exception.
+'
+
+# Append --logfile option if FLUX_TESTS_LOGFILE is set in environment:
+test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
+. $(dirname $0)/sharness.sh
+
+test_under_flux 1 job
+
+test_expect_success 'start a long-running job' '
+	jobid=$(flux mini submit -n1 -t1h sleep 3600)
+'
+test_expect_success 'unload scheduler' '
+	flux module remove sched-simple
+'
+test_expect_success 'exclude the job node from configuration' '
+	flux config load <<-EOT
+	[resource]
+	exclude = "0"
+	EOT
+'
+test_expect_success 'increase broker stderr log level' '
+	flux setattr log-stderr-level 6
+'
+test_expect_success 'load scheduler' '
+	flux module load sched-simple
+'
+test_expect_success 'job receives exception' '
+	flux job wait-event -t 30 ${jobid} exception
+'
+test_expect_success 'job receives clean event' '
+	flux job wait-event -v -t 30 ${jobid} clean
+'
+test_expect_success 'decrease broker stderr log level' '
+	flux setattr log-stderr-level 5
+'
+
+test_done


### PR DESCRIPTION
Here's a workaround for the problem's we have with fluxion refusing to start when running jobs are in the KVS, described in #4862.

In this one, a failure of the scheduler's `hello` callback causes a fatal `scheduler-restart` job exception to be posted rather than a scheduler tear-down.  When that particular exception is raised, the job manager clears the flag that indicates that resources are allocated, so the `sched.free` RPC is skipped when the job enters cleanup.

This is a WIP pending writing tests.