### PR TITLE
Support RFC 35 constraint syntax in `flux mini --requires`

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -322,6 +322,7 @@ RST_FILES  = \
 if ENABLE_DOCS
 man_MANS = $(MAN1_FILES) $(MAN3_FILES) $(MAN5_FILES) $(MAN7_FILES)
 $(RST_FILES): man1/NODESET.rst \
+	man1/CONSTRAINTS.rst \
 	man3/JSON_PACK.rst \
 	man3/JSON_UNPACK.rst
 endif
@@ -373,6 +374,7 @@ EXTRA_DIST = \
 	index.rst \
 	$(RST_FILES) \
 	man1/NODESET.rst \
+	man1/CONSTRAINTS.rst \
 	man3/JSON_PACK.rst \
 	man3/JSON_UNPACK.rst \
 	man7/flux-undocumented.rst

--- a/doc/man1/CONSTRAINTS.rst
+++ b/doc/man1/CONSTRAINTS.rst
@@ -1,0 +1,22 @@
+
+A constraint query string is formed by a series of terms.
+
+A term has the form ``operator:operand``, e.g. ``hosts:compute[1-10]``.
+
+Terms may optionally be joined with boolean operators and parenthesis to
+allow the formation of more complex constraints or queries.
+
+Boolean operators include logical AND (``&``, ``&&``, or ``and``), logical OR
+(``|``, ``||``, or ``or``), and logical negation (``not``).
+
+Terms separated by whitespace are joined with logical AND by default.
+
+Quoting of terms is supported to allow whitespace and other reserved
+characters in operand, e.g. ``foo:'this is args'``.
+
+Negation is supported in front of terms such that ``-op:operand`` is
+equivalent to ``not op:operand``. Negation is not supported in front of
+general expressions, e.g. ``-(a|b)`` is a syntax error.
+
+The full specification of Constraint Query Syntax can be found in RFC 35.
+

--- a/doc/man1/flux-mini.rst
+++ b/doc/man1/flux-mini.rst
@@ -221,18 +221,56 @@ emitting the job's I/O to its stdout and stderr.
 CONSTRAINTS
 ===========
 
-.. note::
-   Flux supports an advanced constraint specification detailed in RFC 31.
-   However, the interface currently exported via the **flux mini** commands
-   is purposefully limited.
+**--requires=CONSTRAINT**
+   Specify a set of allowable properties and other attributes to consider
+   when matching resources for a job. The **CONSTRAINT** is expressed in
+   a simple syntax described in RFC 35 (Constraint Query Syntax) which is
+   then converted into a JSON object compliant with RFC 31 (Job Constraints
+   Specification).
 
-**--requires=LIST**
-   Specify a *LIST* of resource property constraints for this job. *LIST*
-   is a single property or comma-separated list of properties which are
-   required for this job. The ``--requires`` option may be specified
-   multiple times. Currently, all properties are required (logical and).
-   If a property name starts with ``^``, then the job requires that property
-   *not* be present on assigned resources.
+   .. include:: CONSTRAINTS.rst
+
+   Currently, **--requires** supports the following operators:
+
+   properties
+     Require the set of specified properties. Properties may be
+     comma-separated, in which case all specified properties are required.
+     As a convenience, if a property starts with ``^`` then a matching
+     resource must not have the specified property.  In ``flux-mini``, the
+     ``properties`` operator is the default, so that ``a,b`` is equivalent
+     to ``properties:a,b``.
+
+   hostlist
+     Require matching resources to  be in the specified hostlist (in RFC
+     29 format). ``host`` or ``hosts`` is also accepted.
+
+   ranks
+     Require matching resources to be on the specified broker ranks in
+     RFC 22 Idset String Representation.
+
+   Examples:
+
+   ``a b c``, ``a&b&c``, or ``a,b,c``
+      Require properties a and b and c.
+
+   ``a|b|c``, or ``a or b or c``
+      Require property a or b or c.
+
+   ``(a and b) or (b and c)``
+      Require properties a and b or b and c.
+
+   ``b|-c``, ``b or not c``
+      Require property b or not c.
+
+   ``host:fluke[1-5]``
+      Require host in fluke1 through fluke5.
+
+   ``-host:fluke7``
+      Exclude host fluke7.
+
+   ``rank:0``
+      Require broker rank 0.
+
 
 DEPENDENCIES
 ============

--- a/t/t2112-job-ingest-frobnicator.t
+++ b/t/t2112-job-ingest-frobnicator.t
@@ -109,13 +109,14 @@ test_expect_success HAVE_JQ 'constraints plugin sets queue constraint' '
 	jq -e ".data.attributes.system.constraints.properties \
 	    == [ \"debug\" ]" < constraint-setqueue.out
 '
-test_expect_success HAVE_JQ 'constraints plugin appends queue constraint' '
+test_expect_success HAVE_JQ 'constraints plugin adds queue constraint' '
 	flux mini run --env=-* --dry-run --requires=foo \
 	  --queue=debug hostname \
 	   | flux job-frobnicator --jobspec-only --plugins=constraints \
 	   > constraint-addqueue.out &&
-	jq -e ".data.attributes.system.constraints.properties \
-	   == [ \"foo\", \"debug\" ]" \
+	jq -e ".data.attributes.system.constraints.properties|any(.==\"debug\")"\
+	   < constraint-addqueue.out &&
+	jq -e ".data.attributes.system.constraints.properties|any(.==\"foo\")"\
 	   < constraint-addqueue.out
 '
 test_expect_success HAVE_JQ 'constraints plugin works with no configured queues' '


### PR DESCRIPTION
This PR builds on #4871 and #4895 to add full RFC 35 constraint syntax support to the `flux mini --requires` option. This is the final step to fix #4535.

After this PR is merged, hosts can be included by hostlist with `flux mini --requires=host:fluke[1-10]` and excluded with `--requires=-host:fluke10`, and jobs can similarly include/exclude resource by broker rank with `rank:IDSET` or `-rank:IDSET`. Additionally, any valid RFC 35 constraint query string is now supported, allowing complex boolean expressions if necessary.

The frobnicator is also updated here to use logical AND to join job constraints with queue constraints.

Once this is merged, end-to-end tests could be added to https://github.com/flux-framework/flux-sched/pull/997, though in principal these PRs could be merged in any order (fluxion will just reject jobs as invalid if they use unsupported constraints)

Fixes #4535