### PR TITLE
eliminate "safe mode" after improper shutdown

### DIFF
--- a/doc/man1/flux-startlog.rst
+++ b/doc/man1/flux-startlog.rst
@@ -25,8 +25,7 @@ in Flux Standard Duration format.
 If the current ``start`` event is not immediately preceded by a ``finish``
 event (unless it is the first entry in the eventlog), then the Flux instance
 may have crashed and data may have been lost.  If this is detected on instance
-startup, Flux is placed into a safe mode where scheduling and job submission
-are disabled, to avoid further damage pending recovery.
+startup, it is logged by the broker's ``rc1`` script on the next reboot.
 
 This command is not available to guest users.
 

--- a/etc/rc1
+++ b/etc/rc1
@@ -75,9 +75,7 @@ fi
 if test $RANK -eq 0; then
     if test "$(backing_module)" != "none"; then
         if ! flux startlog --check --quiet; then
-            flux queue stop --all
-            flux queue disable --all \
-                "Flux is in safe mode due to an incomplete shutdown."
+	    echo "Flux was not shut down properly.  Data may have been lost."
         fi
     fi
 fi

--- a/t/t3200-instance-restart.t
+++ b/t/t3200-instance-restart.t
@@ -61,12 +61,13 @@ test_expect_success 'doctor startlog to look like a crash' '
 		-o,-Sbroker.rc3_path=$SHARNESS_TEST_SRCDIR/rc/rc3-kvs \
 		flux startlog --post-start-event
 '
-test_expect_success 'check queue status' '
+test_expect_success 'run flux and capture logs on stderr' '
 	flux start -o,--setattr=statedir=$(pwd) \
-		flux queue status >queue_status.out 2>&1
+		-o,--setattr=log-stderr-level=6 \
+		/bin/true 2>improper.err
 '
-test_expect_success 'safe mode is entered' '
-	grep "Flux is in safe mode" queue_status.out
+test_expect_success 'improper shutdown was logged' '
+	grep "Flux was not shut down properly" improper.err
 '
 
 test_expect_success 'run a job in persistent instance (content-files)' '


### PR DESCRIPTION
Problem: safe mode is confusing as noted in #4861, and more so now that we have multiple queues with state that persists across a reboot.

All an admin can really do after an improper shutdown is re-enable the queues and hope for the best.  This PR changes the behavior after an improper shutdown is detected.  Instead of stopping/disabling all queues, it just logs the improper shutdown and continues.  If there are troubles, this will be useful information to have in the logs.