### PR TITLE
job-manager: fix alloc-bypass plugin

### DIFF
--- a/src/modules/job-manager/plugins/alloc-bypass.c
+++ b/src/modules/job-manager/plugins/alloc-bypass.c
@@ -142,16 +142,6 @@ static int sched_cb (flux_plugin_t *p,
     if (alloc_start (p, id, R) < 0)
         flux_jobtap_raise_exception (p, id, "alloc", 0,
                                      "failed to commit R to kvs");
-
-    if (flux_jobtap_job_set_flag (p,
-                                  FLUX_JOBTAP_CURRENT_JOB,
-                                  "alloc-bypass") < 0) {
-        flux_jobtap_raise_exception (p, FLUX_JOBTAP_CURRENT_JOB,
-                                     "alloc", 0,
-                                     "Failed to set alloc-bypass: %s",
-                                     strerror (errno));
-        return -1;
-    }
     return 0;
 }
 
@@ -237,6 +227,17 @@ static int validate_cb (flux_plugin_t *p,
                                        "failed to capture alloc-bypass R: %s",
                                        strerror (saved_errno));
     }
+
+    if (flux_jobtap_job_set_flag (p,
+                                  FLUX_JOBTAP_CURRENT_JOB,
+                                  "alloc-bypass") < 0) {
+        flux_jobtap_raise_exception (p, FLUX_JOBTAP_CURRENT_JOB,
+                                     "alloc", 0,
+                                     "Failed to set alloc-bypass: %s",
+                                     strerror (errno));
+        return -1;
+    }
+
     return 0;
 }
 

--- a/t/t2273-job-alloc-bypass.t
+++ b/t/t2273-job-alloc-bypass.t
@@ -22,7 +22,7 @@ submit_as_alternate_user()
 }
 
 test_expect_success 'alloc-bypass: start a job using all resources' '
-	SLEEPID=$(flux mini submit \
+	SLEEPID=$(flux mini submit --wait-event=start \
 	            -n $(flux resource list -s up -no {ncores}) \
 	            sleep 300)
 '
@@ -73,5 +73,18 @@ test_expect_success 'alloc-bypass: handles exception before alloc event' '
 test_expect_success 'alloc-bypass: kill sleep job' '
 	flux job cancelall -f &&
 	flux job wait-event $SLEEPID clean
+'
+test_expect_success 'alloc-bypass: submit an alloc-bypass job' '
+	flux mini submit -vvv --wait-event=start --job-name=bypass \
+		--setattr=alloc-bypass.R="$(flux R encode -r 0)" \
+		-n 1 \
+		sleep 300
+'
+test_expect_success 'alloc-bypass: a full system job can still be run' '
+	run_timeout 15 \
+	  flux mini run -n $(flux resource list -s up -no {ncores}) hostname
+'
+test_expect_success 'kill bypass job' '
+	flux pkill bypass
 '
 test_done


### PR DESCRIPTION
This fixes the issue with the `alloc-bypass` plugin described in #4900 and fixes the test to catch this error or errors like this in the future.