### PR TITLE
python: avoid unecessary parsetab.py generation in ConstraintParser

### DIFF
--- a/src/bindings/python/flux/constraint/parser.py
+++ b/src/bindings/python/flux/constraint/parser.py
@@ -283,7 +283,7 @@ class ConstraintParser:
     # Combined terms
     combined_terms = set()
 
-    def __init__(self, lexer=None, optimize=1, debug=0, **kw_args):
+    def __init__(self, lexer=None, optimize=True, debug=False, **kw_args):
         super().__init__()
         self.lexer = ConstraintLexer() if lexer is None else lexer
         self.tokens = self.lexer.tokens
@@ -438,7 +438,7 @@ if __name__ == "__main__":
         if args.default_op:
             operator_map = {None: args.default_op}
 
-    parser = TConstraintParser(optimize=0, debug=1, outputdir=args.outputdir)
+    parser = TConstraintParser(optimize=False, debug=True, outputdir=args.outputdir)
     if args.expression:
 
         s = " ".join(args.expression)

--- a/src/bindings/python/flux/constraint/parser.py
+++ b/src/bindings/python/flux/constraint/parser.py
@@ -283,12 +283,20 @@ class ConstraintParser:
     # Combined terms
     combined_terms = set()
 
-    def __init__(self, lexer=None, optimize=True, debug=False, **kw_args):
+    def __init__(
+        self, lexer=None, optimize=True, debug=False, write_tables=False, **kw_args
+    ):
         super().__init__()
         self.lexer = ConstraintLexer() if lexer is None else lexer
         self.tokens = self.lexer.tokens
         self.query = None
-        self.parser = yacc.yacc(module=self, optimize=optimize, debug=debug, **kw_args)
+        self.parser = yacc.yacc(
+            module=self,
+            optimize=optimize,
+            debug=debug,
+            write_tables=write_tables,
+            **kw_args,
+        )
 
     def parse(self, query, **kw_args):
         self.query = query
@@ -438,7 +446,9 @@ if __name__ == "__main__":
         if args.default_op:
             operator_map = {None: args.default_op}
 
-    parser = TConstraintParser(optimize=False, debug=True, outputdir=args.outputdir)
+    parser = TConstraintParser(
+        optimize=False, debug=True, write_tables=True, outputdir=args.outputdir
+    )
     if args.expression:
 
         s = " ".join(args.expression)


### PR DESCRIPTION
There's an issue with ply's automated generation of `parsetab.py` for `flux.constraint.parser.ConstraintParser`. This file is currently generated during `make` and then installed alongside `parser.py` as part of `make install` which should avoid any need for ply to regenerate the file since the grammar will not change.

However, it turns out that when the parser is used by another file, e.g. within flux-mini.py, ply attempts to write `parsetab.py` out in the same directory of the script instead of alongside `flux/constraint/parser.py`. This could be because flux-mini subclasses `ConstraintParser`, I'm not sure.

However, a good workaround seems to be to default `write_tables=False` in `yacc.yacc()` and only use `write_tables=True` in the one case where we do want to write out a `parsetab.py` (`flux.constraint.parser.__main__()`)

