### PR TITLE
flux-jobs/flux-pgrep: rename --suppress-header to --no-header

### DIFF
--- a/doc/man1/flux-jobs.rst
+++ b/doc/man1/flux-jobs.rst
@@ -30,7 +30,7 @@ OPTIONS
 **-A**
    List jobs of all users. This is shorthand for *--user=all*.
 
-**-n, --suppress-header**
+**-n, --no-header**
    For default output, do not output column headers.
 
 **-u, --user**\ *=[USERNAME|UID]*

--- a/doc/man1/flux-pgrep.rst
+++ b/doc/man1/flux-pgrep.rst
@@ -67,7 +67,7 @@ OPTIONS
    *default*, *full*, *long*, and *deps*. The default format emits the matched
    jobids only. (pgrep only)
 
-**-n, --suppress-header**
+**-n, --no-header**
    Suppress printing of the header line. (pgrep only)
 
 **-w, --wait**

--- a/etc/completions/flux.pre
+++ b/etc/completions/flux.pre
@@ -877,7 +877,7 @@ _flux_jobs()
         -c --count=N \
         -f --filter= \
         --since=WHEN \
-        -n --suppress-header \
+        -n --no-header \
         -u --user= \
         --name= \
         --queue= \

--- a/src/cmd/flux-jobs.py
+++ b/src/cmd/flux-jobs.py
@@ -256,9 +256,16 @@ def parse_args():
     )
     parser.add_argument(
         "-n",
-        "--suppress-header",
+        "--no-header",
         action="store_true",
         help="Suppress printing of header line",
+    )
+    # --suppress-header, older legacy name
+    parser.add_argument(
+        "--suppress-header",
+        action="store_true",
+        dest="no_header",
+        help=argparse.SUPPRESS,
     )
     parser.add_argument(
         "-u",
@@ -482,7 +489,7 @@ def main():
     jobs = fetch_jobs(args, formatter.fields)
     sformatter = JobInfoFormat(formatter.filter_empty(jobs))
 
-    if not args.suppress_header:
+    if not args.no_header:
         print(sformatter.header())
 
     print_jobs(jobs, args, sformatter)

--- a/src/cmd/flux-pgrep.py
+++ b/src/cmd/flux-pgrep.py
@@ -191,7 +191,7 @@ def parse_args():
     if PROGRAM == "flux-pgrep":
         parser.add_argument(
             "-n",
-            "--suppress-header",
+            "--no-header",
             action="store_true",
             help="Suppress printing of header line",
         )
@@ -276,6 +276,6 @@ def main():
     sformatter = JobInfoFormat(formatter.filter_empty(jobs))
 
     if args.format == "default":
-        args.suppress_header = True
+        args.no_header = True
 
-    sformatter.print_items(jobs, no_header=args.suppress_header)
+    sformatter.print_items(jobs, no_header=args.no_header)

--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -158,8 +158,8 @@ test_expect_success HAVE_JQ 'submit jobs for job list testing' '
 #
 # basic tests
 #
-test_expect_success 'flux-jobs --suppress-header works' '
-	count=`flux jobs --suppress-header | wc -l` &&
+test_expect_success 'flux-jobs --no-header works' '
+	count=`flux jobs --no-header | wc -l` &&
 	test $count -eq $(state_count active)
 '
 test_expect_success 'flux-jobs default output works' '
@@ -199,15 +199,15 @@ test_expect_success 'flux-jobs: request indication of truncation works' '
 # TODO: need to submit jobs as another user and test -A again
 test_expect_success 'flux-jobs -a and -A works' '
 	nall=$(state_count all) &&
-	count=`flux jobs --suppress-header -a | wc -l` &&
+	count=`flux jobs --no-header -a | wc -l` &&
 	test $count -eq $nall &&
-	count=`flux jobs --suppress-header -a -A | wc -l` &&
+	count=`flux jobs --no-header -a -A | wc -l` &&
 	test $count -eq $nall
 '
 
 test_expect_success 'flux-jobs --since implies -a' '
 	nall=$(state_count all) &&
-	count=$(flux jobs --suppress-header --since=0.0 | wc -l) &&
+	count=$(flux jobs --no-header --since=0.0 | wc -l) &&
 	test $count -eq $nall
 '
 
@@ -263,82 +263,82 @@ test_expect_success 'flux-jobs --queue works' '
 # Recall pending = depend | priority | sched, running = run | cleanup,
 #  active = pending | running
 test_expect_success 'flux-jobs --filter works (job states)' '
-	count=`flux jobs --suppress-header --filter=depend | wc -l` &&
+	count=`flux jobs --no-header --filter=depend | wc -l` &&
 	test $count -eq 0 &&
-	count=`flux jobs --suppress-header --filter=priority | wc -l` &&
+	count=`flux jobs --no-header --filter=priority | wc -l` &&
 	test $count -eq 0 &&
-	count=`flux jobs --suppress-header --filter=sched | wc -l` &&
+	count=`flux jobs --no-header --filter=sched | wc -l` &&
 	test $count -eq $(state_count sched) &&
-	count=`flux jobs --suppress-header --filter=pending | wc -l` &&
+	count=`flux jobs --no-header --filter=pending | wc -l` &&
 	test $count -eq $(state_count sched) &&
-	count=`flux jobs --suppress-header --filter=run | wc -l` &&
+	count=`flux jobs --no-header --filter=run | wc -l` &&
 	test $count -eq $(state_count run) &&
-	count=`flux jobs --suppress-header --filter=cleanup | wc -l` &&
+	count=`flux jobs --no-header --filter=cleanup | wc -l` &&
 	test $count -eq 0 &&
-	count=`flux jobs --suppress-header --filter=running | wc -l` &&
+	count=`flux jobs --no-header --filter=running | wc -l` &&
 	test $count -eq $(state_count run) &&
-	count=`flux jobs --suppress-header --filter=inactive | wc -l` &&
+	count=`flux jobs --no-header --filter=inactive | wc -l` &&
 	test $count -eq $(state_count inactive) &&
-	count=`flux jobs --suppress-header --filter=pending,running | wc -l` &&
+	count=`flux jobs --no-header --filter=pending,running | wc -l` &&
 	test $count -eq $(state_count sched run) &&
-	count=`flux jobs --suppress-header --filter=sched,run | wc -l` &&
+	count=`flux jobs --no-header --filter=sched,run | wc -l` &&
 	test $count -eq $(state_count sched run) &&
-	count=`flux jobs --suppress-header --filter=active | wc -l` &&
+	count=`flux jobs --no-header --filter=active | wc -l` &&
 	test $count -eq $(state_count active) &&
-	count=`flux jobs --suppress-header --filter=depend,priority,sched,run,cleanup | wc -l` &&
+	count=`flux jobs --no-header --filter=depend,priority,sched,run,cleanup | wc -l` &&
 	test $count -eq $(state_count active) &&
-	count=`flux jobs --suppress-header --filter=pending,inactive | wc -l` &&
+	count=`flux jobs --no-header --filter=pending,inactive | wc -l` &&
 	test $count -eq $(state_count sched inactive) &&
-	count=`flux jobs --suppress-header --filter=sched,inactive | wc -l` &&
+	count=`flux jobs --no-header --filter=sched,inactive | wc -l` &&
 	test $count -eq $(state_count sched inactive) &&
-	count=`flux jobs --suppress-header --filter=running,inactive | wc -l` &&
+	count=`flux jobs --no-header --filter=running,inactive | wc -l` &&
 	test $count -eq $(state_count run inactive) &&
-	count=`flux jobs --suppress-header --filter=run,inactive | wc -l` &&
+	count=`flux jobs --no-header --filter=run,inactive | wc -l` &&
 	test $count -eq $(state_count run inactive) &&
-	count=`flux jobs --suppress-header --filter=pending,running,inactive | wc -l` &&
+	count=`flux jobs --no-header --filter=pending,running,inactive | wc -l` &&
 	test $count -eq $(state_count all) &&
-	count=`flux jobs --suppress-header --filter=active,inactive | wc -l` &&
+	count=`flux jobs --no-header --filter=active,inactive | wc -l` &&
 	test $count -eq $(state_count active inactive) &&
-	count=`flux jobs --suppress-header --filter=depend,priority,cleanup | wc -l` &&
+	count=`flux jobs --no-header --filter=depend,priority,cleanup | wc -l` &&
 	test $count -eq 0
 '
 
 test_expect_success 'flux-jobs --filter works (job results)' '
-	count=`flux jobs --suppress-header --filter=completed | wc -l` &&
+	count=`flux jobs --no-header --filter=completed | wc -l` &&
 	test $count -eq $(state_count completed) &&
-	count=`flux jobs --suppress-header --filter=failed | wc -l` &&
+	count=`flux jobs --no-header --filter=failed | wc -l` &&
 	test $count -eq $(state_count failed) &&
-	count=`flux jobs --suppress-header --filter=canceled | wc -l` &&
+	count=`flux jobs --no-header --filter=canceled | wc -l` &&
 	test $count -eq $(state_count canceled) &&
-	count=`flux jobs --suppress-header --filter=timeout | wc -l` &&
+	count=`flux jobs --no-header --filter=timeout | wc -l` &&
 	test $count -eq $(state_count timeout) &&
-	count=`flux jobs --suppress-header --filter=completed,failed | wc -l` &&
+	count=`flux jobs --no-header --filter=completed,failed | wc -l` &&
 	test $count -eq $(state_count completed failed) &&
-	count=`flux jobs --suppress-header --filter=completed,canceled | wc -l` &&
+	count=`flux jobs --no-header --filter=completed,canceled | wc -l` &&
 	test $count -eq $(state_count completed canceled) &&
-	count=`flux jobs --suppress-header --filter=completed,timeout | wc -l` &&
+	count=`flux jobs --no-header --filter=completed,timeout | wc -l` &&
 	test $count -eq $(state_count completed timeout) &&
-	count=`flux jobs --suppress-header --filter=completed,failed,canceled | wc -l` &&
+	count=`flux jobs --no-header --filter=completed,failed,canceled | wc -l` &&
 	test $count -eq $(state_count completed failed canceled) &&
-	count=`flux jobs --suppress-header --filter=completed,failed,timeout | wc -l` &&
+	count=`flux jobs --no-header --filter=completed,failed,timeout | wc -l` &&
 	test $count -eq $(state_count completed failed timeout) &&
-	count=`flux jobs --suppress-header --filter=completed,failed,canceled,timeout | wc -l` &&
+	count=`flux jobs --no-header --filter=completed,failed,canceled,timeout | wc -l` &&
 	test $count -eq $(state_count completed failed canceled timeout) &&
-	count=`flux jobs --suppress-header --filter=pending,completed | wc -l` &&
+	count=`flux jobs --no-header --filter=pending,completed | wc -l` &&
 	test $count -eq $(state_count sched completed) &&
-	count=`flux jobs --suppress-header --filter=pending,failed | wc -l` &&
+	count=`flux jobs --no-header --filter=pending,failed | wc -l` &&
 	test $count -eq $(state_count sched failed) &&
-	count=`flux jobs --suppress-header --filter=pending,canceled | wc -l` &&
+	count=`flux jobs --no-header --filter=pending,canceled | wc -l` &&
 	test $count -eq $(state_count sched canceled) &&
-	count=`flux jobs --suppress-header --filter=pending,timeout | wc -l` &&
+	count=`flux jobs --no-header --filter=pending,timeout | wc -l` &&
 	test $count -eq $(state_count sched timeout) &&
-	count=`flux jobs --suppress-header --filter=running,completed | wc -l` &&
+	count=`flux jobs --no-header --filter=running,completed | wc -l` &&
 	test $count -eq $(state_count run completed) &&
-	count=`flux jobs --suppress-header --filter=running,failed | wc -l` &&
+	count=`flux jobs --no-header --filter=running,failed | wc -l` &&
 	test $count -eq $(state_count run failed) &&
-	count=`flux jobs --suppress-header --filter=running,canceled | wc -l` &&
+	count=`flux jobs --no-header --filter=running,canceled | wc -l` &&
 	test $count -eq $(state_count run canceled) &&
-	count=`flux jobs --suppress-header --filter=running,timeout | wc -l` &&
+	count=`flux jobs --no-header --filter=running,timeout | wc -l` &&
 	test $count -eq $(state_count run timeout)
 '
 
@@ -352,36 +352,36 @@ test_expect_success 'flux-jobs --filter with invalid state fails' '
 # increment userid to ensure not current user for test
 test_expect_success 'flux-jobs --user=UID works' '
 	userid=`id -u` &&
-	count=`flux jobs --suppress-header --user=${userid} | wc -l` &&
+	count=`flux jobs --no-header --user=${userid} | wc -l` &&
 	test $count -eq $(state_count active) &&
-	count=`flux jobs --suppress-header --user="+${userid}" | wc -l` &&
+	count=`flux jobs --no-header --user="+${userid}" | wc -l` &&
 	test $count -eq $(state_count active) &&
 	userid=$((userid+1)) &&
-	count=`flux jobs --suppress-header --user=${userid} | wc -l` &&
+	count=`flux jobs --no-header --user=${userid} | wc -l` &&
 	test $count -eq 0
 '
 
 test_expect_success 'flux-jobs --user=USERNAME works' '
 	username=`whoami` &&
-	count=`flux jobs --suppress-header --user=${username} | wc -l` &&
+	count=`flux jobs --no-header --user=${username} | wc -l` &&
 	test $count -eq $(state_count active)
 '
 
 test_expect_success 'flux-jobs --user with invalid username fails' '
 	username="foobarfoobaz" &&
-	test_must_fail flux jobs --suppress-header --user=${username} 2> baduser.out &&
+	test_must_fail flux jobs --no-header --user=${username} 2> baduser.out &&
 	grep "Invalid user" baduser.out
 '
 
 test_expect_success 'flux-jobs --user=all works' '
-	count=`flux jobs --suppress-header --user=all | wc -l` &&
+	count=`flux jobs --no-header --user=all | wc -l` &&
 	test $count -eq $(state_count active)
 '
 
 test_expect_success 'flux-jobs --count works' '
-	count=`flux jobs --suppress-header -a --count=0 | wc -l` &&
+	count=`flux jobs --no-header -a --count=0 | wc -l` &&
 	test $count -eq $(state_count all) &&
-	count=`flux jobs --suppress-header -a --count=8 | wc -l` &&
+	count=`flux jobs --no-header -a --count=8 | wc -l` &&
 	test $count -eq 8
 '
 
@@ -410,19 +410,19 @@ test_expect_success 'flux jobs can take specific IDs in any form' '
 '
 
 test_expect_success 'flux-jobs error on unknown IDs' '
-	flux jobs --suppress-header 0 1 2 2> ids.err &&
+	flux jobs --no-header 0 1 2 2> ids.err &&
 	count=`grep -i unknown ids.err | wc -l` &&
 	test $count -eq 3
 '
 
 test_expect_success 'flux-jobs errors with illegal IDs' '
-	test_must_fail flux jobs --suppress-header IllegalID 2> illegal_ids.err &&
+	test_must_fail flux jobs --no-header IllegalID 2> illegal_ids.err &&
 	grep "invalid JobID value" illegal_ids.err
 '
 
 test_expect_success 'flux-jobs good and bad IDs works' '
 	ids=$(state_ids sched) &&
-	flux jobs --suppress-header ${ids} 0 1 2 > ids.out 2> ids.err &&
+	flux jobs --no-header ${ids} 0 1 2 > ids.out 2> ids.err &&
 	count=`wc -l < ids.out` &&
 	test $count -eq $(state_count sched) &&
 	count=`grep -i unknown ids.err | wc -l` &&
@@ -431,7 +431,7 @@ test_expect_success 'flux-jobs good and bad IDs works' '
 
 test_expect_success 'flux-jobs ouputs warning on invalid options' '
 	ids=$(state_ids sched) &&
-	flux jobs --suppress-header -A ${ids} > warn.out 2> warn.err &&
+	flux jobs --no-header -A ${ids} > warn.out 2> warn.err &&
 	grep WARNING warn.err
 '
 
@@ -440,11 +440,11 @@ test_expect_success 'flux-jobs ouputs warning on invalid options' '
 #
 
 test_expect_success 'flux-jobs --format={id} works' '
-	flux jobs --suppress-header --filter=pending --format="{id}" > idsP.out &&
+	flux jobs --no-header --filter=pending --format="{id}" > idsP.out &&
 	test_cmp idsP.out sched.ids &&
-	flux jobs --suppress-header --filter=running --format="{id}" > idsR.out &&
+	flux jobs --no-header --filter=running --format="{id}" > idsR.out &&
 	test_cmp idsR.out run.ids &&
-	flux jobs --suppress-header --filter=inactive --format="{id}" > idsI.out &&
+	flux jobs --no-header --filter=inactive --format="{id}" > idsI.out &&
 	test_cmp idsI.out inactive.ids
 '
 
@@ -464,7 +464,7 @@ test_expect_success 'flux-jobs --format={id.f58},{id.hex},{id.dothex},{id.words}
 '
 
 test_expect_success 'flux-jobs --format={userid},{username} works' '
-	flux jobs --suppress-header -a --format="{userid},{username}" > user.out &&
+	flux jobs --no-header -a --format="{userid},{username}" > user.out &&
 	id=`id -u` &&
 	name=`whoami` &&
 	for i in `seq 1 $(state_count all)`; do
@@ -474,7 +474,7 @@ test_expect_success 'flux-jobs --format={userid},{username} works' '
 '
 
 test_expect_success 'flux-jobs --format={urgency},{priority} works' '
-	flux jobs --suppress-header -a --format="{urgency},{priority}" > urgency_priority.out &&
+	flux jobs --no-header -a --format="{urgency},{priority}" > urgency_priority.out &&
 	echo 31,4294967295 > urgency_priority.exp &&
 	echo 25,25 >> urgency_priority.exp &&
 	echo 20,20 >> urgency_priority.exp &&
@@ -1113,7 +1113,7 @@ for opt in "" "--color" "--color=always" "--color=auto"; do
 	test_expect_success "flux-jobs $opt color works (pty)" '
 		name=${opt##--color=} &&
 		outfile=color-${name:-default}.out &&
-		$runpty flux jobs ${opt} --suppress-header -a \
+		$runpty flux jobs ${opt} --no-header -a \
 		    | grep -v "version" > $outfile &&
 		count=$(no_color_lines $outfile) &&
 		test $count -eq $(state_count sched run) &&
@@ -1127,7 +1127,7 @@ for opt in "" "--color" "--color=always" "--color=auto"; do
 done
 
 test_expect_success 'flux-jobs --color=never works (pty)' '
-	$runpty flux jobs --suppress-header --color=never -a >color_never.out &&
+	$runpty flux jobs --no-header --color=never -a >color_never.out &&
 	check_no_color color_never.out
 '
 
@@ -1135,13 +1135,13 @@ for opt in "" "--color=never"; do
 	test_expect_success "flux-jobs $opt color works (no tty)" '
 		name=${opt##--color=} &&
 		outfile=color-${name:-default}-notty.out &&
-		flux jobs ${opt} --suppress-header -a > $outfile &&
+		flux jobs ${opt} --no-header -a > $outfile &&
 		test_must_fail grep "" $outfile
 	'
 done
 
 test_expect_success 'flux-jobs: --color=always works (notty)' '
-	flux jobs --color=always --suppress-header -a > color-always-notty.out &&
+	flux jobs --color=always --no-header -a > color-always-notty.out &&
 	grep "" color-always-notty.out
 '
 
@@ -1180,7 +1180,7 @@ test_expect_success HAVE_JQ 'flux-jobs reverts username to userid for invalid id
 	test_debug "echo first invalid userid is ${id}" &&
 	printf "%s\n" $id > invalid_userid.expected &&
 	flux job list -a -c 1 | $jq -c ".userid = ${id}" |
-	  flux jobs --from-stdin --suppress-header --format="{username}" \
+	  flux jobs --from-stdin --no-header --format="{username}" \
 		> invalid_userid.output  &&
 	test_cmp invalid_userid.expected invalid_userid.output
 '

--- a/t/t2809-job-purge.t
+++ b/t/t2809-job-purge.t
@@ -13,7 +13,7 @@ inactive_count() {
 	if test $how = "job-manager"; then
 		flux module stats --parse=inactive_jobs job-manager
 	elif test $how = "job-list"; then
-		flux jobs --suppress-header --filter=inactive|wc -l
+		flux jobs --no-header --filter=inactive|wc -l
 	elif test $how = "job-list-stats"; then
 		flux job stats | jq .job_states.inactive
 	else

--- a/t/t3200-instance-restart.t
+++ b/t/t3200-instance-restart.t
@@ -29,7 +29,7 @@ test_expect_success 'restart instance and run another job' '
 
 test_expect_success 'restart instance and list inactive jobs' '
 	flux start -o,--setattr=statedir=$(pwd) \
-	           flux jobs --suppress-header --format={id} \
+	           flux jobs --no-header --format={id} \
 		   	--filter=INACTIVE >list.out
 '
 
@@ -80,7 +80,7 @@ test_expect_success 'restart instance and list inactive jobs' '
 	flux start \
 	    -o,-Scontent.backing-module=content-files \
 	    -o,-Sstatedir=$(pwd) \
-	    flux jobs --suppress-header --format={id} \
+	    flux jobs --no-header --format={id} \
 	        --filter=INACTIVE >files_list.out
 '
 
@@ -114,7 +114,7 @@ test_expect_success S3 'run a job in persistent instance (content-s3)' '
 test_expect_success S3 'restart instance and list inactive jobs' '
 	flux start \
 	    -o,-Scontent.backing-module=content-s3 \
-	    flux jobs --suppress-header --format={id} \
+	    flux jobs --no-header --format={id} \
 	        --filter=INACTIVE >files_list2.out
 '
 


### PR DESCRIPTION
Per #4899, make the `--suppress-header` / `--no-header` consistent between tools.  Chose to common-ify on `--no-header`.  

Note that I legacy support `--suppress-header` in `flux-jobs` but not in `flux-pgrep`, b/c the latter has not officially been released yet, so I assumed no users of it yet.