### PR TITLE
flux-resource: increase width of queue field

### DIFF
--- a/src/cmd/flux-resource.py
+++ b/src/cmd/flux-resource.py
@@ -56,7 +56,7 @@ class FluxResourceConfig(UtilConfig):
         "default": {
             "description": "Default flux-resource list format string",
             "format": (
-                "{state:>10} ?:{queue:<8.8} ?:{propertiesx:<10.10+} {nnodes:>6} "
+                "{state:>10} ?:{queue:<10.10} ?:{propertiesx:<10.10+} {nnodes:>6} "
                 "{ncores:>8} {ngpus:>8} {nodelist}"
             ),
         },


### PR DESCRIPTION
Problem: Unlike other tools such as flux-queue and flux-jobs, it is possible for multiple queues to be listed with the "flux resource list" "queue" field.  The default output width is 8 characters, which is a little short for multiple queues.

Increase from 8 characters to 10 characters.

Fixes #4904

---

We can debate the number of chars, I just didn't want to go too big b/c the common case is of course 1 queue.

Also, I elected not to make the heading "QUEUES" (plural).  The field name is "queue" and I figure one queue is still the common case.

Edit: or we could go with QUEUE(S)?