### PR TITLE
job-list: do not assume alloc event context always contains annotations

### DIFF
--- a/src/modules/job-list/job_state.c
+++ b/src/modules/job-list/job_state.c
@@ -602,15 +602,10 @@ static struct job *eventlog_restart_parse (struct job_state_ctx *jsctx,
             /* context not required if no annotations */
             if (context) {
                 json_t *annotations;
-                if (!(annotations = json_object_get (context, "annotations"))) {
-                    flux_log (jsctx->h, LOG_ERR,
-                              "%s: alloc context for %ju invalid",
-                              __FUNCTION__, (uintmax_t)job->id);
-                    errno = EPROTO;
-                    goto error;
+                if ((annotations = json_object_get (context, "annotations"))) {
+                    if (!json_is_null (annotations))
+                        job->annotations = json_incref (annotations);
                 }
-                if (!json_is_null (annotations))
-                    job->annotations = json_incref (annotations);
             }
 
             if (job->state == FLUX_JOB_STATE_SCHED)

--- a/src/modules/job-list/job_util.c
+++ b/src/modules/job-list/job_util.c
@@ -179,7 +179,8 @@ static int store_attr (struct job *job,
     }
     else if (!strcmp (attr, "exception_note")) {
         if (!(job->states_mask & FLUX_JOB_STATE_INACTIVE)
-            || !job->exception_occurred)
+            || !job->exception_occurred
+            || !job->exception_note)
             return 0;
         val = json_string (job->exception_note);
     }


### PR DESCRIPTION
Per discussion in #4906

I only added a regression test, no additional wider coverage tests yet per discussion in #4906.

Hopefully will have those wider extra coverage tests in soon.  But just in case that extra wider coverage can't be completed in a timely manner, just wanted to make sure we atleast get this fix in before the next release, we can always add the extra tests later.