### PR TITLE
add `flux job last`

### DIFF
--- a/src/common/libutil/Makefile.am
+++ b/src/common/libutil/Makefile.am
@@ -97,6 +97,8 @@ libutil_la_SOURCES = \
 	fileref.h \
 	hola.c \
 	hola.h \
+	slice.c \
+	slice.h \
 	strstrip.c \
 	strstrip.h
 
@@ -130,7 +132,8 @@ TESTS = test_sha1.t \
 	test_errprintf.t \
 	test_fileref.t \
 	test_hola.t \
-	test_strstrip.t
+	test_strstrip.t \
+	test_slice.t
 
 test_ldadd = \
 	$(top_builddir)/src/common/libutil/libutil.la \
@@ -273,3 +276,7 @@ test_fileref_t_LDADD = $(test_ldadd)
 test_hola_t_SOURCES = test/hola.c
 test_hola_t_CPPFLAGS = $(test_cppflags)
 test_hola_t_LDADD = $(test_ldadd)
+
+test_slice_t_SOURCES = test/slice.c
+test_slice_t_CPPFLAGS = $(test_cppflags)
+test_slice_t_LDADD = $(test_ldadd)

--- a/src/common/libutil/hola.c
+++ b/src/common/libutil/hola.c
@@ -287,6 +287,31 @@ void *hola_list_next (struct hola *hola, const void *key)
     return item;
 }
 
+void *hola_list_prev (struct hola *hola, const void *key)
+{
+    void *item = NULL;
+
+    if (hola && key) {
+        zlistx_t *l;
+        if ((l = zhashx_lookup (hola->hash, key)))
+            item = zlistx_prev (l);
+    }
+    return item;
+}
+
+void *hola_list_last (struct hola *hola, const void *key)
+{
+    void *item = NULL;
+
+    if (hola && key) {
+        zlistx_t *l;
+        if ((l = zhashx_lookup (hola->hash, key)))
+            item = zlistx_last (l);
+    }
+    return item;
+}
+
+
 void *hola_list_cursor (struct hola *hola, const void *key)
 {
     void *handle = NULL;

--- a/src/common/libutil/hola.c
+++ b/src/common/libutil/hola.c
@@ -24,6 +24,7 @@ struct hola {
     zlistx_t *keys; // for iteration
     zlistx_destructor_fn *list_destructor;
     zlistx_duplicator_fn *list_duplicator;
+    zlistx_comparator_fn *list_comparator;
     unsigned int keys_valid:1;
     unsigned int flags;
 };
@@ -68,6 +69,11 @@ void hola_set_list_duplicator (struct hola *hola, zlistx_duplicator_fn fun)
 {
     if (hola)
         hola->list_duplicator = fun;
+}
+void hola_set_list_comparator (struct hola *hola, zlistx_comparator_fn fun)
+{
+    if (hola)
+        hola->list_comparator = fun;
 }
 void hola_set_hash_key_destructor (struct hola *hola, zhashx_destructor_fn fun)
 {
@@ -115,6 +121,7 @@ static zlistx_t *hash_add (struct hola *hola, const void *key)
     }
     zlistx_set_destructor (l, hola->list_destructor);
     zlistx_set_duplicator (l, hola->list_duplicator);
+    zlistx_set_comparator (l, hola->list_comparator);
     if (zhashx_insert (hola->hash, key, l) < 0) {
         zlistx_destroy (&l);
         errno = EEXIST;
@@ -199,6 +206,35 @@ void *hola_list_add_end (struct hola *hola, const void *key, void *item)
         }
     }
     if ((handle = zlistx_add_end (l, item)) == NULL) {
+        errno = ENOMEM;
+        return NULL;
+    }
+    return handle;
+}
+
+void *hola_list_insert (struct hola *hola,
+                        const void *key,
+                        void *item,
+                        bool low_value)
+{
+    zlistx_t *l;
+    void *handle;
+
+    if (!hola || !key || !item) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (!(l = zhashx_lookup (hola->hash, key))) {
+        if ((hola->flags & HOLA_AUTOCREATE)) {
+            if (!(l = hash_add (hola, key)))
+                return NULL;
+        }
+        else {
+            errno = ENOENT;
+            return NULL;
+        }
+    }
+    if ((handle = zlistx_insert (l, item, low_value)) == NULL) {
         errno = ENOMEM;
         return NULL;
     }

--- a/src/common/libutil/hola.h
+++ b/src/common/libutil/hola.h
@@ -44,6 +44,8 @@ zlistx_t *hola_hash_lookup (struct hola *hola, const void *key);
 // returns list item
 void *hola_list_first (struct hola *hola, const void *key);
 void *hola_list_next (struct hola *hola, const void *key);
+void *hola_list_prev (struct hola *hola, const void *key);
+void *hola_list_last (struct hola *hola, const void *key);
 
 // returns list handle
 void *hola_list_add_end (struct hola *hola, const void *key, void *item);

--- a/src/common/libutil/hola.h
+++ b/src/common/libutil/hola.h
@@ -27,6 +27,7 @@ void hola_destroy (struct hola *hola);
 
 void hola_set_list_destructor (struct hola *hola, zlistx_destructor_fn fun);
 void hola_set_list_duplicator (struct hola *hola, zlistx_duplicator_fn fun);
+void hola_set_list_comparator (struct hola *hola, zlistx_comparator_fn fun);
 
 void hola_set_hash_key_destructor (struct hola *hola, zhashx_destructor_fn fun);
 void hola_set_hash_key_duplicator (struct hola *hola, zhashx_duplicator_fn fun);
@@ -47,6 +48,10 @@ void *hola_list_next (struct hola *hola, const void *key);
 // returns list handle
 void *hola_list_add_end (struct hola *hola, const void *key, void *item);
 void *hola_list_cursor (struct hola *hola, const void *key);
+void *hola_list_insert (struct hola *hola,
+                        const void *key,
+                        void *item,
+                        bool low_value);
 
 int hola_list_delete (struct hola *hola, const void *key, void *handle);
 size_t hola_list_size (struct hola *hola, const void *key);

--- a/src/common/libutil/slice.c
+++ b/src/common/libutil/slice.c
@@ -1,0 +1,165 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* slice.c - python style array slicing
+ *
+ * https://python-reference.readthedocs.io/en/latest/docs/brackets/slicing.html
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdlib.h>
+#include <stdbool.h>
+#include <errno.h>
+#include <string.h>
+
+#include "slice.h"
+
+static int parse_enclosing (char **cp, char begin, char end)
+{
+    size_t slen = strlen (*cp);
+
+    if (slen < 2)
+        return -1;
+    if ((*cp)[0] != begin || (*cp)[slen - 1] != end)
+        return -1;
+    (*cp)[slen - 1] = '\0';
+    (*cp)++;
+    return 0;
+}
+
+// returns 1 if value was provided, 0 if default was assigned, -1 if error
+static int parse_int (char **cp, int def, char sep, int *value)
+{
+    int v;
+    char *endptr;
+
+    errno = 0;
+    v = strtol (*cp, &endptr, 10);
+    if (errno != 0)
+        return -1;
+    if (endptr == *cp) {    // no digits
+        if ((*cp)[0] == sep)
+            (*cp)++;
+        else if ((*cp)[0] != '\0')
+            return -1;
+        *value = def;
+        return 0;
+    }
+    if (*endptr == '\0') {  // entire string consumed
+        *cp = endptr;
+        *value = v;
+        return 1;
+    }
+    if (*endptr == sep) {   // string consumed to separator
+        *cp = endptr + 1;
+        *value = v;
+        return 1;
+    }
+    return -1;
+}
+
+// return true if index has surpassed bounds of array or slice
+static bool overrun (struct slice *sl, int i)
+{
+    if (sl->step > 0 && (i >= sl->stop || i >= sl->length))
+        return true;
+    if (sl->step < 0 && (i <= sl->stop || i < 0))
+        return true;
+    return false;
+}
+
+// set cursor to first slice index that's in array bounds
+static void cursor_first (struct slice *sl)
+{
+    sl->cursor = sl->start;
+    while (!overrun (sl, sl->cursor)) {
+        if (sl->cursor >= 0 && sl->cursor < sl->length)
+            return;
+        sl->cursor += sl->step;
+    }
+    sl->cursor = -1;
+}
+
+// set cursor to next slice index
+static void cursor_next (struct slice *sl)
+{
+    if (sl->cursor != -1) {
+        do {
+            sl->cursor += sl->step;
+            if (overrun (sl, sl->cursor)) {
+                sl->cursor = -1;
+                return;
+            }
+        } while (sl->cursor < 0 || sl->cursor >= sl->length);
+    }
+}
+
+int slice_first (struct slice *sl)
+{
+    if (!sl)
+        return -1;
+    cursor_first (sl);
+    return slice_next (sl);
+}
+
+int slice_next (struct slice *sl)
+{
+    if (!sl)
+        return -1;
+    int i = sl->cursor;
+    cursor_next (sl);
+    return i;
+}
+
+int slice_parse (struct slice *sl, const char *s, size_t array_length)
+{
+    char *cpy;
+    char *cp;
+    int rc1, rc2;
+
+    if (!sl || !s || !strchr (s, ':'))
+        return -1;
+    if (!(cpy = strdup (s)))
+        return -1;
+    sl->length = array_length;
+    cp = cpy;
+    if (parse_enclosing (&cp, '[', ']') < 0)
+        goto error;
+    if ((rc1 = parse_int (&cp, 0, ':', &sl->start)) < 0)
+        goto error;
+    if ((rc2 = parse_int (&cp, array_length, ':', &sl->stop)) < 0)
+        goto error;
+    if (parse_int (&cp, 1, ':', &sl->step) < 0)
+        goto error;
+    if (sl->step == 0)
+        goto error;
+    // transform negative indices to positive
+    if (sl->start < 0)
+        sl->start = sl->length + sl->start;
+    if (sl->stop < 0)
+        sl->stop = sl->length + sl->stop;
+    // fix up default step/stop assigned above if step is negative
+    if (sl->step < 0) {
+        if (rc1 == 0)
+            sl->start = array_length - 1;
+        if (rc2 == 0)
+            sl->stop = -1;
+    }
+    cursor_first (sl);
+    free (cpy);
+    return 0;
+error:
+    free (cpy);
+    return -1;
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/src/common/libutil/slice.h
+++ b/src/common/libutil/slice.h
@@ -1,0 +1,36 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _UTIL_SLICE_H
+#define _UTIL_SLICE_H
+
+struct slice {
+    int start;
+    int stop;
+    int step;
+
+    size_t length;
+    int cursor;
+};
+
+/* Parse 's' as a python style array slice, e.g. [start:stop:step].
+ * 'array_length' is the length of the array to be sliced.
+ * Returns 0 on success, -1 on failure.  Errno is undefined on failure.
+ */
+int slice_parse (struct slice *sl, const char *s, size_t array_length);
+
+/* Built in iterator returns zero-origin sliced array indices (-1 at end).
+ */
+int slice_first (struct slice *sl);
+int slice_next (struct slice *sl);
+
+#endif /* !_UTIL_SLICE_H */
+
+// vi:ts=4 sw=4 expandtab

--- a/src/common/libutil/test/hola.c
+++ b/src/common/libutil/test/hola.c
@@ -244,6 +244,7 @@ bool test_iter_one (struct test_input *t, size_t len)
     }
     key = hola_hash_first (h);
     while (key) {
+        size_t count = 0;
         val = hola_list_first (h, key);
         while (val) {
             int index = find_entry (t, len, key, val);
@@ -251,17 +252,27 @@ bool test_iter_one (struct test_input *t, size_t len)
                 break;
             if (index != -1)
                 checklist[index] = true;
+            count++;
             val = hola_list_next (h, key);
         }
         if (hola_list_cursor (h, key) != NULL) // cursor must be NULL
             break;
+        /* iterate backwards for fun */
+        val = hola_list_last (h, key);
+        while (val) {
+            count--;
+            val = hola_list_prev (h, key);
+        }
+        if (count > 0) {
+            diag ("reverse iteration failed");
+            result = false;
+        }
 
         key = hola_hash_next (h);
     }
     for (int i = 0; i < len; i++)
         if (!checklist[i])
             result = false;
-
     hola_destroy (h);
     free (checklist);
     return result;
@@ -361,6 +372,14 @@ void test_inval (void)
     ok (hola_list_next (NULL, "foo") == NULL,
         "hola_list_next h=NULL returns NULL");
     ok (hola_list_next (h, NULL) == NULL,
+        "hola_list_next key=NULL returns NULL");
+    ok (hola_list_last (NULL, "foo") == NULL,
+        "hola_list_last h=NULL returns NULL");
+    ok (hola_list_last (h, NULL) == NULL,
+        "hola_list_last key=NULL returns NULL");
+    ok (hola_list_prev (NULL, "foo") == NULL,
+        "hola_list_prev h=NULL returns NULL");
+    ok (hola_list_prev (h, NULL) == NULL,
         "hola_list_next key=NULL returns NULL");
     ok (hola_list_cursor (NULL, "foo") == NULL,
         "hola_list_cursor h=NULL returns NULL");

--- a/src/common/libutil/test/slice.c
+++ b/src/common/libutil/test/slice.c
@@ -1,0 +1,161 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <errno.h>
+#include <stdbool.h>
+#include <string.h>
+
+#include "src/common/libtap/tap.h"
+#include "ccan/array_size/array_size.h"
+#include "ccan/str/str.h"
+#include "src/common/libutil/slice.h"
+
+const char *testinput = "ABCD";
+
+struct testent {
+    const char *s;
+    struct slice slice;
+    const char *result;
+};
+
+struct testent testvec[] = {
+    { "[0:2]",    { .start = 0, .stop = 2,  .step = 1 },   "AB" },
+    { "[0:4:2]",  { .start = 0, .stop = 4,  .step = 2 },   "AC" },
+    { "[1:]",     { .start = 1, .stop = 4,  .step = 1 },   "BCD" },
+    { "[:3]",     { .start = 0, .stop = 3,  .step = 1 },   "ABC" },
+    { "[1:3]",    { .start = 1, .stop = 3,  .step = 1 },   "BC" },
+    { "[1:3:]",   { .start = 1, .stop = 3,  .step = 1 },   "BC" },
+    { "[1:99]",   { .start = 1, .stop = 99, .step = 1 },   "BCD" },
+    { "[::2]",    { .start = 0, .stop = 4,  .step = 2 },   "AC" },
+    { "[::]",     { .start = 0, .stop = 4,  .step = 1 },   "ABCD" },
+    { "[:]",      { .start = 0, .stop = 4,  .step = 1 },   "ABCD" },
+    { "[8:]",     { .start = 8, .stop = 4,  .step = 1 },   "" },
+    { "[3:1]",    { .start = 3, .stop = 1,  .step = 1 },   "" },
+    { "[::-1]",   { .start = 3, .stop = -1, .step = -1 },  "DCBA" },
+    { "[-1:0:-1]",{ .start = 3, .stop = 0,  .step = -1 },  "DCB" },
+    { "[-3:-1]",  { .start = 1, .stop = 3,  .step = 1 },   "BC" },
+    { "[99:0:-1]", { .start = 99,.stop = 0, .step = -1 },  "DCB" },
+    { "[0:4:-1]", { .start = 0, .stop = 4,  .step = -1 },  "" },
+};
+
+const char *badvec[] = {
+    ":",
+    "[:",
+    ":]",
+    "[:]x",
+    "x[:]",
+    "[]",
+};
+
+bool check_parse (struct testent test, const char *in)
+{
+    size_t slen = strlen (in);
+    struct slice sl;
+
+    if (slice_parse (&sl, test.s, slen) < 0) {
+        diag ("parse %s failed", test.s);
+        return false;
+    }
+    if (sl.start != test.slice.start) {
+        diag ("parse %s: start=%d != %d", test.s, sl.start, test.slice.start);
+        return false;
+    }
+    if (sl.stop != test.slice.stop) {
+        diag ("parse %s: stop=%d != %d", test.s, sl.stop, test.slice.stop);
+        return false;
+    }
+    if (sl.step != test.slice.step) {
+        diag ("parse %s: step=%d != %d", test.s, sl.step, test.slice.step);
+        return false;
+    }
+
+    return true;
+}
+
+static int string_slice (struct slice *sl, const char *in, char **out)
+{
+    size_t slen = strlen (in);
+    char *s;
+    char *cp;
+    int i;
+
+    if (!(s = calloc (1, slen + 1)))
+        BAIL_OUT ("out of memory");
+    cp = s;
+    i = slice_first (sl);
+    while (i >= 0) {
+        if (i >= slen)
+            BAIL_OUT ("unexpected slice_first/next index %d", i);
+        *cp++ = in[i];
+        i = slice_next (sl);
+    }
+    *out = s;
+    return 0;
+}
+
+bool check_slice (struct testent test)
+{
+    struct slice sl;
+    char *result;
+
+    if (slice_parse (&sl, test.s, strlen (testinput)) < 0) {
+        diag ("parse %s failed", test.s);
+        return false;
+    }
+    if (string_slice (&sl, testinput, &result) < 0) {
+        diag ("slice %s failed", test.s);
+        return false;
+    }
+    if (!streq (result, test.result)) {
+        diag ("slice %s: %s != %s", test.s, result, test.result);
+        free (result);
+        return false;
+    }
+    free (result);
+    return true;
+}
+
+int main (int argc, char *argv[])
+{
+    struct slice sl;
+
+    plan (NO_PLAN);
+
+    for (int i = 0; i < ARRAY_SIZE (testvec); i++) {
+        ok (check_parse (testvec[i], testinput),
+            "parsed \"%s\"", testvec[i].s);
+    }
+
+    for (int i = 0; i < ARRAY_SIZE (testvec); i++) {
+        ok (check_slice (testvec[i]),
+            "sliced \"%s\"", testvec[i].s);
+    }
+
+    for (int i = 0; i < ARRAY_SIZE (badvec); i++) {
+        ok (slice_parse (&sl, badvec[i], strlen (testinput)) < 0,
+           "rejected \"%s\"", badvec[i]);
+    }
+
+    ok (slice_parse (NULL, "[:]", 4) < 0,
+        "slice_parse sl=NULL fails");
+    ok (slice_parse (&sl, NULL, 4) < 0,
+        "slice_parse s=NULL fails");
+    ok (slice_first (NULL) == -1,
+        "slice_first sl=NULL returns -1");
+    ok (slice_next (NULL) == -1,
+        "slice_next sl=NULL returns -1");
+
+    done_testing ();
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/src/modules/job-manager/Makefile.am
+++ b/src/modules/job-manager/Makefile.am
@@ -74,7 +74,8 @@ libjob_manager_la_SOURCES = \
 	plugins/limit-duration.c \
 	plugins/dependency-after.c \
 	plugins/begin-time.c \
-	plugins/validate-duration.c
+	plugins/validate-duration.c \
+	plugins/history.c
 
 fluxinclude_HEADERS = \
 	jobtap.h

--- a/src/modules/job-manager/jobtap.c
+++ b/src/modules/job-manager/jobtap.c
@@ -1534,6 +1534,8 @@ static int build_jobtap_topic (flux_plugin_t *p,
         errno = EINVAL;
         return -1;
     }
+    if (*name == '.') // skip conventional "." prefix used in hidden plugins
+        name++;
     if (snprintf (buf,
                   len,
                   "job-manager.%s%s%s",

--- a/src/modules/job-manager/jobtap.c
+++ b/src/modules/job-manager/jobtap.c
@@ -1546,10 +1546,11 @@ static int build_jobtap_topic (flux_plugin_t *p,
     return 0;
 }
 
-int flux_jobtap_service_register (flux_plugin_t *p,
-                                  const char *method,
-                                  flux_msg_handler_f cb,
-                                  void *arg)
+int flux_jobtap_service_register_ex (flux_plugin_t *p,
+                                     const char *method,
+                                     uint32_t rolemask,
+                                     flux_msg_handler_f cb,
+                                     void *arg)
 {
     struct flux_match match = FLUX_MATCH_REQUEST;
     flux_msg_handler_t *mh;
@@ -1571,11 +1572,20 @@ int flux_jobtap_service_register (flux_plugin_t *p,
         flux_msg_handler_destroy (mh);
         return -1;
     }
+    flux_msg_handler_allow_rolemask (mh, rolemask);
     flux_msg_handler_start (mh);
     flux_log (h, LOG_DEBUG, "jobtap plugin %s registered method %s",
               jobtap_plugin_name (p),
               topic);
     return 0;
+}
+
+int flux_jobtap_service_register (flux_plugin_t *p,
+                                  const char *method,
+                                  flux_msg_handler_f cb,
+                                  void *arg)
+{
+    return flux_jobtap_service_register_ex (p, method, 0, cb, arg);
 }
 
 int flux_jobtap_reprioritize_all (flux_plugin_t *p)

--- a/src/modules/job-manager/jobtap.c
+++ b/src/modules/job-manager/jobtap.c
@@ -47,6 +47,7 @@ extern int limit_duration_plugin_init (flux_plugin_t *p);
 extern int after_plugin_init (flux_plugin_t *p);
 extern int begin_time_plugin_init (flux_plugin_t *p);
 extern int validate_duration_plugin_init (flux_plugin_t *p);
+extern int history_plugin_init (flux_plugin_t *p);
 
 struct jobtap_builtin {
     const char *name;
@@ -60,6 +61,7 @@ static struct jobtap_builtin jobtap_builtins [] = {
     { ".dependency-after", after_plugin_init },
     { ".begin-time", &begin_time_plugin_init },
     { ".validate-duration", &validate_duration_plugin_init },
+    { ".history", &history_plugin_init },
     { 0 },
 };
 

--- a/src/modules/job-manager/jobtap.h
+++ b/src/modules/job-manager/jobtap.h
@@ -35,6 +35,15 @@ int flux_jobtap_service_register (flux_plugin_t *p,
                                   flux_msg_handler_f cb,
                                   void *arg);
 
+/*  Extended version of above with capability of registering a service that
+ *   guests can access.
+ */
+int flux_jobtap_service_register_ex (flux_plugin_t *p,
+                                     const char *method,
+                                     uint32_t rolemask,
+                                     flux_msg_handler_f cb,
+                                     void *arg);
+
 /*  Start a loop to re-prioritize all jobs. The plugin "priority.get"
  *   callback will be called for each job currently in SCHED or
  *   PRIORITY states.

--- a/src/modules/job-manager/plugins/history.c
+++ b/src/modules/job-manager/plugins/history.c
@@ -1,0 +1,278 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* history.c - track jobs in t_submit order per user
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <jansson.h>
+#include <flux/core.h>
+#include <flux/jobtap.h>
+
+#include "ccan/ptrint/ptrint.h"
+#include "src/common/libutil/hola.h"
+#include "src/common/libutil/slice.h"
+#include "src/common/libutil/errprintf.h"
+
+struct job_entry {
+    flux_jobid_t id;
+    double t_submit;
+};
+
+struct history {
+    flux_plugin_t *p;
+    struct hola *users; // userid => job list
+};
+
+#define COMPARE_NUM_REVERSE(a,b) ((a)>(b)?-1:(a)<(b)?1:0)
+
+static void job_entry_destroy (struct job_entry *entry)
+{
+    if (entry) {
+        int saved_errno = errno;
+        free (entry);
+        errno = saved_errno;
+    }
+}
+
+static struct job_entry *job_entry_create (void)
+{
+    struct job_entry *entry;
+
+    if (!(entry = calloc (1, sizeof (*entry))))
+        return NULL;
+    return entry;
+}
+
+// zlistx_destructor_fn footprint
+static void job_entry_destructor (void **item)
+{
+    if (item) {
+        job_entry_destroy (*item);
+        *item = NULL;
+    }
+}
+
+// zlistx_comparator_fn footprint
+static int job_entry_comparator (const void *item1, const void *item2)
+{
+    const struct job_entry *a = item1;
+    const struct job_entry *b = item2;
+
+    return COMPARE_NUM_REVERSE (a->t_submit, b->t_submit);
+}
+
+// zhashx_hash_fn footprint
+static size_t userid_hasher (const void *key)
+{
+    return ptr2int (key);
+}
+
+// zhashx_comparator_fn footprint
+static int userid_comparator (const void *item1, const void *item2)
+{
+    return COMPARE_NUM_REVERSE (ptr2int (item1), ptr2int (item2));
+}
+
+static void history_destroy (struct history *hist)
+{
+    if (hist) {
+        int saved_errno = errno;
+        hola_destroy (hist->users);
+        free (hist);
+        errno = saved_errno;
+    };
+}
+
+static struct history *history_create (flux_plugin_t *p)
+{
+    struct history *hist;
+
+    if (!(hist = calloc (1, sizeof (*hist))))
+        return NULL;
+    hist->p = p;
+    if (!(hist->users = hola_create (HOLA_AUTOCREATE)))
+        goto error;
+    hola_set_hash_key_destructor (hist->users, NULL);
+    hola_set_hash_key_duplicator (hist->users, NULL);
+    hola_set_hash_key_comparator (hist->users, userid_comparator);
+    hola_set_hash_key_hasher (hist->users, userid_hasher);
+    hola_set_list_destructor (hist->users, job_entry_destructor);
+    hola_set_list_comparator (hist->users, job_entry_comparator);
+    return hist;
+error:
+    history_destroy (hist);
+    return NULL;
+}
+
+static int job_new_cb (flux_plugin_t *p,
+                       const char *topic,
+                       flux_plugin_arg_t *args,
+                       void *arg)
+{
+    struct history *hist = arg;
+    struct job_entry *entry;
+    int userid;
+
+    if (!(entry = job_entry_create ()))
+        return -1;
+    if (flux_plugin_arg_unpack (args,
+                                FLUX_PLUGIN_ARG_IN,
+                                "{s:I s:f s:i}",
+                                "id", &entry->id,
+                                "t_submit", &entry->t_submit,
+                                "userid", &userid) < 0
+        || !hola_list_insert (hist->users, int2ptr (userid), entry, false)) {
+        job_entry_destroy (entry);
+        return -1;
+    }
+    return 0;
+}
+
+static int append_int (json_t *a, json_int_t i)
+{
+    json_t *o;
+    if (!(o = json_integer (i))
+        || json_array_append_new (a, o) < 0) {
+        json_decref (o);
+        return -1;
+    }
+    return 0;
+}
+
+static int list_slice_reverse (zlistx_t *l, struct slice *sl, json_t *a)
+{
+    if (l) {
+        struct job_entry *entry = zlistx_last (l);
+        size_t list_index = zlistx_size (l) - 1;
+        int slice_index = slice_first (sl);
+
+        while (entry && slice_index != -1) {
+            if (list_index == slice_index) {
+                if (append_int (a, entry->id) < 0)
+                    return -1;
+                slice_index = slice_next (sl);
+            }
+            list_index--;
+            entry = zlistx_prev (l);
+        }
+    }
+    return 0;
+}
+
+static int list_slice_forward (zlistx_t *l, struct slice *sl, json_t *a)
+{
+    if (l) {
+        struct job_entry *entry = zlistx_first (l);
+        size_t list_index = 0;
+        int slice_index = slice_first (sl);
+
+        while (entry && slice_index != -1) {
+            if (list_index == slice_index) {
+                if (append_int (a, entry->id) < 0)
+                    return -1;
+                slice_index = slice_next (sl);
+            }
+            list_index++;
+            entry = zlistx_next (l);
+        }
+    }
+    return 0;
+}
+
+static json_t *history_slice (struct history *hist,
+                              int userid,
+                              const char *slice,
+                              flux_error_t *error)
+{
+    json_t *a;
+    zlistx_t *l;
+    struct slice sl;
+    size_t list_size = 0;
+    int rc;
+
+    if ((l = hola_hash_lookup (hist->users, int2ptr (userid))))
+        list_size = zlistx_size (l);
+    if (slice_parse (&sl, slice, list_size) < 0) {
+        errprintf (error, "could not parse python-style slice expression");
+        errno = EINVAL;
+        return NULL;
+    }
+    if (!(a = json_array ()))
+        goto oom;
+    if (sl.step > 0)
+        rc = list_slice_forward (l, &sl, a);
+    else
+        rc = list_slice_reverse (l, &sl, a);
+    if (rc < 0)
+        goto oom;
+    return a;
+oom:
+    json_decref (a);
+    errprintf (error, "out of memory");
+    errno = ENOMEM;
+    return NULL;
+}
+
+static void history_get_cb (flux_t *h,
+                            flux_msg_handler_t *mh,
+                            const flux_msg_t *msg,
+                            void *arg)
+{
+    struct history *hist = arg;
+    const char *slice;
+    struct flux_msg_cred cred;
+    json_t *jobs;
+    flux_error_t error;
+    const char *errmsg = NULL;
+
+    if (flux_request_unpack (msg, NULL, "{s:s}", "slice", &slice) < 0
+        || flux_msg_get_cred (msg, &cred) < 0)
+        goto error;
+    if (!(jobs = history_slice (hist, cred.userid, slice, &error))) {
+        errmsg = error.text;
+        errno = EINVAL;
+        goto error;
+    }
+    if (flux_respond_pack (h, msg, "{s:O}", "jobs", jobs) < 0)
+        flux_log_error (h, "error responding to job-manager.history.get");
+    json_decref (jobs);
+error:
+    if (flux_respond_error (h, msg, errno, errmsg) < 0)
+        flux_log_error (h, "error responding to job-manager.history.get");
+}
+
+
+int history_plugin_init (flux_plugin_t *p)
+{
+    struct history *hist;
+
+    if (!(hist = history_create (p))
+        || flux_plugin_aux_set (p,
+                                NULL,
+                                hist,
+                                (flux_free_f)history_destroy) < 0) {
+        history_destroy (hist);
+        return -1;
+    }
+    if (flux_jobtap_service_register_ex (p,
+                                         "get",
+                                         FLUX_ROLE_USER,
+                                         history_get_cb,
+                                         hist) < 0)
+        return -1;
+
+    return flux_plugin_add_handler (p, "job.new", job_new_cb, hist);
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -213,6 +213,7 @@ TESTSCRIPTS = \
 	t2809-job-purge.t \
 	t2810-kvs-garbage-collect.t \
 	t2811-flux-pgrep.t \
+	t2812-flux-job-last.t \
 	t2900-job-timelimits.t \
 	t3000-mpi-basic.t \
 	t3001-mpi-personalities.t \

--- a/t/t2812-flux-job-last.t
+++ b/t/t2812-flux-job-last.t
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+test_description='Test the flux job last command'
+
+. $(dirname $0)/sharness.sh
+
+test_under_flux 1
+
+test_expect_success 'flux-job last fails on invalid arguments' '
+	test_must_fail flux job last --badarg 2>badarg.err &&
+	grep "unrecognized option" badarg.err
+'
+test_expect_success 'flux-job last fails when no jobs have been submitted' '
+	test_must_fail flux job last 2>nojob.err &&
+	grep "job history is empty" nojob.err
+
+'
+test_expect_success 'submit some jobs' '
+	flux mini submit --cc=0-9 /bin/true >jobids
+'
+test_expect_success 'flux job last lists the most recently submitted job' '
+	id=$(flux job last) &&
+	test "$id" = "$(tail -1 jobids)"
+'
+test_expect_success 'flux job last [::-1] lists jobs in submit order' '
+	flux job last "[::-1]" >last-reverse-all.out &&
+	test_cmp jobids last-reverse-all.out
+'
+test_expect_success 'flux job last [:] lists all the jobs' '
+	flux job last "[:]" >last.out &&
+	test $(wc -l <last.out) -eq $(wc -l <jobids)
+'
+test_expect_success 'flux job last N lists the last N jobs' '
+	head -4 last.out >last4.exp &&
+	flux job last 4 >last4.out &&
+	test_cmp last4.exp last4.out
+'
+
+test_done


### PR DESCRIPTION
I thought these trivial commands would be useful.  `flux-job last` prints the job ID of the most recently submitted job.  `flux job history` prints the job ID and "name" for the most recently submitted 10 jobs.
```
$ flux job last
flux-job: job history is empty
$ flux mini submit -N1 true
ƒ7bbUqDZZ
$ flux job last
ƒ7bbUqDZZ
$ flux job history
ƒ7bbUqDZZ	true
ƒ4a15vsCs	hostname
ƒ4Zj7Lc5M	hostname
ƒ4ZXi88PZ	hostname
ƒ3HPLDNQ7	hostname
ƒoFzsGdV	sleep
ƒhtPAE7h	hostname
```
I couldn't figure out how to get a submission-ordered list of jobs (including all states) out of `job-list` so I added a little jobtap plugin that tracks the last 10 job ids for each user and registers a service that returns the list for the asking user.

I don't know if others will find this useful, so before I did any real work writing tests and such I thought I'd run it up the flag pole.

The choice to write a jobtap plugin might be controversial since probably the real solution is to allow more general queries of the  data stored in job-list.  Or maybe I'm missing some other obvious way to get this data.  However, writing jobtap plugins is fun, and it didn't take much effort to make this work (IOW it could be considered a throw-away if a real query solution emerged)