### PR TITLE
flux-resource: mark drained+offline nodes with asterisk

### DIFF
--- a/doc/man1/flux-resource.rst
+++ b/doc/man1/flux-resource.rst
@@ -37,6 +37,7 @@ A few notes on drained nodes:
 - In ``flux resource status`` and ``flux resource drain``, the drain state
   of a node will be presented as "drained" if the node has no job allocations,
   and "draining" if there are still jobs running on the node.
+- If a node is drained and offline, then "drained*" will be displayed.
 
 Some further background on resource service operation may be found in the
 RESOURCE INVENTORY section below.
@@ -61,15 +62,15 @@ COMMANDS
    by ``flux resource info`` is "all".
 
 **status**  [-n] [-o FORMAT] [-s STATE,...] [--skip-empty]
-   Show system view of resources.  The *-n,--no-header* suppresses header
-   from output, *-o,--format=FORMAT* customizes output formatting (see
-   below), and *-s,--states=STATE,...* limits output to specified resource
-   states, where valid states are "online", "offline", "avail", "exclude",
-   "draining", "drained", and "all". The special "drain" state is also
-   supported, and selects both draining and drained resources. Normally,
-   ``flux resource status`` skips lines with no resources, unless the
-   ``-s, --states`` option is used. Suppression of empty lines can always
-   be forced with the ``--skip-empty`` option.
+   Show system view of resources.  The *-n,--no-header* suppresses
+   header from output, *-o,--format=FORMAT* customizes output formatting
+   (see below), and *-s,--states=STATE,...* limits output to specified
+   resource states, where valid states are "online", "offline", "avail",
+   "exclude", "draining", "drained", "drained*", and "all". The special
+   "drain" state is also supported, and selects both draining and drained
+   resources. Normally, ``flux resource status`` skips lines with no
+   resources, unless the ``-s, --states`` option is used. Suppression of
+   empty lines can always be forced with the ``--skip-empty`` option.
 
 **drain** [-n] [-o FORMAT] [-f] [-u] [targets] [reason ...]
    If specified without arguments, list drained nodes. In this mode,

--- a/t/flux-resource/status/example.expected
+++ b/t/flux-resource/status/example.expected
@@ -2,4 +2,5 @@
      avail      2 2-3             foo[3-4]
    offline      1 1               foo2
    exclude      1 0               foo1
-   drained      2 0-1             foo[1-2]
+   drained      1 0               foo1
+  drained*      1 1               foo2


### PR DESCRIPTION
Proposing this a bit early so that @garlick can test on his system and give feedback.
This is the simplest solution to #4909, so we can sneak it into the next release.

Problem: It is difficult to tell which drained nodes are offline vs not in the output of flux-resource drain and status.

Take a simple step at first and flag offline drained nodes with an asterisk, i.e. `drained*`, in flux-resource `status` and `drain` output.

Update the expected output in one test.

Fixes #4909