### PR TITLE
automatically provide job status for pending interactive jobs

### DIFF
--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -2292,7 +2292,7 @@ void attach_event_continuation (flux_future_t *f, void *arg)
 {
     struct attach_ctx *ctx = arg;
     const char *entry;
-    json_t *o;
+    json_t *o = NULL;
     double timestamp;
     const char *name;
     json_t *context;
@@ -2390,6 +2390,7 @@ void attach_event_continuation (flux_future_t *f, void *arg)
     flux_future_reset (f);
     return;
 done:
+    json_decref (o);
     flux_future_destroy (f);
     ctx->eventlog_f = NULL;
     ctx->eventlog_watch_count--;

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -28,6 +28,7 @@
 #include <locale.h>
 #include <jansson.h>
 #include <argz.h>
+#include <sys/ioctl.h>
 #include <flux/core.h>
 #include <flux/optparse.h>
 #include <flux/hostlist.h>
@@ -247,6 +248,10 @@ static struct optparse_option attach_opts[] =  {
     },
     { .name = "show-exec", .key = 'X', .has_arg = 0,
       .usage = "Show exec events on stderr",
+    },
+    {
+      .name = "show-status", .has_arg = 0,
+      .usage = "Show job status line while pending",
     },
     { .name = "wait-event", .key = 'w', .has_arg = 1, .arginfo = "NAME",
       .usage = "Wait for event NAME before detaching from eventlog "
@@ -1575,6 +1580,7 @@ struct attach_ctx {
     flux_future_t *output_f;
     flux_watcher_t *sigint_w;
     flux_watcher_t *sigtstp_w;
+    flux_watcher_t *notify_timer;
     struct flux_pty_client *pty_client;
     struct timespec t_sigint;
     flux_watcher_t *stdin_w;
@@ -1586,6 +1592,8 @@ struct attach_ctx {
     char *service;
     double timestamp_zero;
     int eventlog_watch_count;
+    bool statusline;
+    char *last_event;
 };
 
 void attach_completed_check (struct attach_ctx *ctx)
@@ -2280,6 +2288,101 @@ done:
     attach_completed_check (ctx);
 }
 
+struct job_event_notifications {
+    const char *event;
+    const char *msg;
+};
+
+static struct job_event_notifications attach_notifications[] = {
+    { "validate",
+      "resolving dependencies",
+    },
+    { "depend",
+      "waiting for priority assignment",
+    },
+    { "priority",
+      "waiting for resources",
+    },
+    { "alloc",
+      "starting",
+    },
+    { "prolog-start",
+      "waiting for job prolog",
+    },
+    { "prolog-finish",
+      "starting",
+    },
+    { "start",
+      "started"
+    },
+    { "exception",
+      "canceling due to exception",
+    },
+    { NULL, NULL},
+};
+
+static const char *job_event_notify_string (const char *name)
+{
+    struct job_event_notifications *t = attach_notifications;
+    while (t->event) {
+        if (streq (t->event, name))
+            return t->msg;
+        t++;
+    }
+    return NULL;
+}
+
+static void attach_notify (struct attach_ctx *ctx,
+                           const char *event_name,
+                           double ts)
+{
+    const char *msg;
+    if (!event_name)
+        return;
+    if (ctx->statusline
+        && (msg = job_event_notify_string (event_name))) {
+        int dt = ts - ctx->timestamp_zero;
+        int width = 80;
+        struct winsize w;
+
+        /* Adjust width of status so timer is right justified:
+         */
+        if (ioctl(0, TIOCGWINSZ, &w) == 0)
+            width = w.ws_col;
+        width -= 10 + strlen (ctx->jobid) + 10;
+
+        fprintf (stderr,
+                 "\rflux-job: %s %-*s %02d:%02d:%02d\r",
+                 ctx->jobid,
+                 width,
+                 msg,
+                 dt/3600,
+                 (dt/60) % 60,
+                 dt % 60);
+    }
+    if (streq (event_name, "start")
+        || streq (event_name, "clean")) {
+        if (ctx->statusline) {
+            fprintf (stderr, "\n");
+            ctx->statusline = false;
+        }
+        flux_watcher_stop (ctx->notify_timer);
+    }
+    if (!ctx->last_event || !streq (event_name, ctx->last_event)) {
+        free (ctx->last_event);
+        ctx->last_event = strdup (event_name);
+    }
+}
+
+void attach_notify_cb (flux_reactor_t *r, flux_watcher_t *w,
+                       int revents, void *arg)
+{
+    struct attach_ctx *ctx = arg;
+    ctx->statusline = true;
+    attach_notify (ctx, ctx->last_event, flux_reactor_time ());
+}
+
+
 /* Handle an event in the main job eventlog.
  * This is a stream of responses, one response per event, terminated with
  * an ENODATA error response (or another error if something went wrong).
@@ -2313,6 +2416,8 @@ void attach_event_continuation (flux_future_t *f, void *arg)
 
     if (ctx->timestamp_zero == 0.)
         ctx->timestamp_zero = timestamp;
+
+    attach_notify (ctx, name, timestamp);
 
     if (streq (name, "exception")) {
         const char *type;
@@ -2485,6 +2590,29 @@ int cmd_attach (optparse_t *p, int argc, char **argv)
         flux_watcher_start (ctx.sigint_w);
     }
 
+    ctx.statusline = optparse_hasopt (ctx.p, "show-status");
+    if ((isatty (STDIN_FILENO) || ctx.statusline)
+        && !optparse_hasopt (ctx.p, "show-events")) {
+        /*
+         * If flux-job is running interactively, and the job has not
+         * started within 2s, then display a status line notifying the
+         * user of the job's status. The timer repeats every second after
+         * the initial callback to update a clock displayed on the rhs of
+         * the status line.
+         *
+         * The timer is automatically stopped after the 'start' or 'clean'
+         * event.
+         */
+        ctx.notify_timer = flux_timer_watcher_create (r,
+                                                      ctx.statusline ? 0.:2.,
+                                                      1.,
+                                                      attach_notify_cb,
+                                                      &ctx);
+        if (!ctx.notify_timer)
+            log_err ("Failed to start notification timer");
+        flux_watcher_start (ctx.notify_timer);
+    }
+
     if (flux_reactor_run (r, 0) < 0)
         log_err_exit ("flux_reactor_run");
 
@@ -2492,10 +2620,12 @@ int cmd_attach (optparse_t *p, int argc, char **argv)
     flux_watcher_destroy (ctx.sigint_w);
     flux_watcher_destroy (ctx.sigtstp_w);
     flux_watcher_destroy (ctx.stdin_w);
+    flux_watcher_destroy (ctx.notify_timer);
     flux_pty_client_destroy (ctx.pty_client);
     flux_close (ctx.h);
     free (ctx.service);
     free (totalview_jobid);
+    free (ctx.last_event);
     return ctx.exit_code;
 }
 

--- a/t/t2201-job-cmd.t
+++ b/t/t2201-job-cmd.t
@@ -356,10 +356,6 @@ test_expect_success 'flux-job: attach fails without jobid argument' '
 	test_must_fail flux job attach
 '
 
-test_expect_success 'flux-job: attach fails without jobid argument' '
-	test_must_fail flux job attach
-'
-
 test_expect_success 'flux-job: attach fails on invalid jobid' '
 	test_must_fail flux job attach $(($(flux job id ${validjob})+1))
 '

--- a/t/t2500-job-attach.t
+++ b/t/t2500-job-attach.t
@@ -30,7 +30,14 @@ test_expect_success 'attach: --show-events shows done event' '
 		--show-exec $(cat jobid1) 2>jobid1.exec &&
 	grep done jobid1.exec
 '
-
+test_expect_success 'attach: --show-status shows job status line' '
+	run_timeout 5 flux job attach \
+		--show-status $(cat jobid1) 2>jobid1.status &&
+	grep "resolving dependencies" jobid1.status &&
+	grep "waiting for resources" jobid1.status &&
+	grep "starting" jobid1.status &&
+	grep "started" jobid1.status
+'
 test_expect_success 'attach: shows output from job' '
 	run_timeout 5 flux job attach $(cat jobid1) | grep foo
 '


### PR DESCRIPTION
There have been several instances of users frustrated by a lack of feeback from `flux mini run` and `flux mini alloc` when jobs are pending. It is impossible to tell if the job is waiting for resources, is starting, or has started is hanging etc.

This PR adds a simple job status line to `flux job attach` which is automatically enabled if the job has been pending for more than 2s. This makes it so that jobs which start quickly continue to have no extraneous output, but jobs blocked in `PRIORITY`, `DEPEND` and `SCHED` states will get some feedback automatically when stdin is a tty. The statusline can be forced with `--show-status` (mainly for testing).

Example:

![capture](https://user-images.githubusercontent.com/741970/216840479-bd816893-e3c4-4405-ad25-986bebc40d29.gif)

