### PR TITLE
improve invalid RFC 35/RFC 31 constraint detection and documentation

### DIFF
--- a/src/bindings/python/flux/job/Jobspec.py
+++ b/src/bindings/python/flux/job/Jobspec.py
@@ -18,6 +18,7 @@ import os
 
 import yaml
 from _flux._core import ffi
+from flux import hostlist, idset
 from flux.util import parse_fsd, set_treedict
 
 
@@ -82,6 +83,14 @@ def _validate_constraint_op(operator, args):
     elif operator in ["properties"]:
         for name in args:
             _validate_property_query(name)
+    elif operator in ["hostlist"]:
+        for hosts in args:
+            hostlist.decode(hosts)
+    elif operator in ["ranks"]:
+        for ranks in args:
+            idset.decode(ranks)
+    else:
+        raise TypeError(f"uknown constraint operator '{operator}'")
 
 
 def _validate_constraint(constraints):

--- a/src/cmd/flux-mini.py
+++ b/src/cmd/flux-mini.py
@@ -590,10 +590,8 @@ class MiniCmd:
         parser.add_argument(
             "--requires",
             action="append",
-            help="Set one or more required resource properties for this job. "
-            + "Currently this option supports only a list of property names, "
-            + "optionally prefixed by ^ to indicate negation.",
-            metavar="LIST",
+            help="Specify job constraints in RFC 35 syntax",
+            metavar="CONSTRAINT",
         )
         parser.add_argument(
             "--begin-time",

--- a/t/python/t0027-constraint-parser.py
+++ b/t/python/t0027-constraint-parser.py
@@ -70,7 +70,7 @@ VALID = [
     },
 ]
 
-INVALID = ["a|", "a:' ", "(a", "(a))", "-(a|b)", "foo and a:"]
+INVALID = ["a|", "a:' ", "(a", "(a))", "-(a|b)", "4g,host:foo", "foo and a:"]
 
 
 class TestConstraintParser(ConstraintParser):

--- a/t/t0031-constraint-parser.t
+++ b/t/t0031-constraint-parser.t
@@ -20,12 +20,12 @@ test_expect_success 'flux.constraint.parser parses cmdline' '
 	grep and basic.out
 '
 test_expect_success 'flux.constraint.parser --default-op works' '
-	$parser --default=op=test a b >default-op.out &&
+	$parser --default-op=test a b >default-op.out &&
 	test_debug "cat default-op.out" &&
 	grep test default-op.out
 '
 test_expect_success 'flux.constraint.parser --debug works' '
-	$parser --debug --default=op=test "a|(b&-c)" >debug.out 2>&1 &&
+	$parser --debug --default-op=test "a|(b&-c)" >debug.out 2>&1 &&
 	test_debug "cat debug.out" &&
 	grep TOKEN debug.out
 '

--- a/t/t2276-job-requires.t
+++ b/t/t2276-job-requires.t
@@ -27,8 +27,8 @@ test_expect_success 'reload scheduler with properties set' '
 	flux module reload resource noverify &&
 	flux module load sched-simple
 '
-test_expect_success 'reload ingest with feasibility validator' '
-	flux module reload -f job-ingest validator-plugins=jobspec,feasibility
+test_expect_success 'reload ingest with only feasibility validator' '
+	flux module reload -f job-ingest validator-plugins=feasibility
 '
 test_expect_success 'scheduler rejects jobs with invalid requires' '
 	test_must_fail flux mini submit --requires=x hostname &&
@@ -40,8 +40,18 @@ test_expect_success 'scheduler rejects jobs with invalid constraints' '
 	test_must_fail flux mini submit --setattr=system.constraints.and={} \
 		 hostname
 '
+test_expect_success 'reload ingest with feasibility,jobspec validators' '
+	flux module reload -f job-ingest validator-plugins=jobspec,feasibility
+'
 test_expect_success 'scheduler rejects jobs with unsatisfiable constraints' '
 	test_must_fail flux mini submit -N4 --requires=yy hostname
+'
+test_expect_success 'jobspec validator rejects invalid hostlist/ranks' '
+	test_must_fail flux mini submit -n1 --requires=host:f[ hostname &&
+	test_must_fail flux mini submit -n1 --requires=ranks:1-0 hostname
+'
+test_expect_success 'jobspec validator rejects invalid constraint operation' '
+	test_must_fail flux mini submit -n1 --requires=foo:bar hostname
 '
 test_expect_success 'flux-mini: --requires works with scheduler' '
 	flux mini bulksubmit --wait --log=job.{}.id -n1 --requires={} \


### PR DESCRIPTION
This PR fixes some issues discovered with end-to-end job constraint support upon further testing and review by @garlick.

 - Add missing validation of operator characters in the constraint parser
 - fix outdated usage output for `--requires` in `flux mini --help`
 - detect invalid operator and hostlist,ranks in the jobspec validator

Fixes #4917 