### PR TITLE
flux-mini: do not combine hostlist/ranks terms joined by AND

### DIFF
--- a/src/cmd/flux-mini.py
+++ b/src/cmd/flux-mini.py
@@ -42,7 +42,7 @@ class MiniConstraintParser(ConstraintParser):
         "rank": "ranks",
     }
     split_values = {"properties": ","}
-    combined_terms = {"properties", "hostlist", "ranks"}
+    combined_terms = {"properties"}
 
 
 class URIArg:


### PR DESCRIPTION
The flux-mini RFC 35 constraint parser inadvertently added `hostlist` and `ranks` operators to the `combinded_terms` set in the  parser, which means that `ranks:1 and ranks:2`is joined to `ranks:1-2`. But `ranks:1-2` means the rank can be in the set `1-2`, which means they are joined by OR not AND.

Remove `hostlist` and `ranks` from the `combined_terms` set to avoid this incorrect behavior.