### PR TITLE
suggest use of --force with `flux resource drain` when target is already drained

### DIFF
--- a/src/cmd/flux-resource.py
+++ b/src/cmd/flux-resource.py
@@ -9,6 +9,7 @@
 ##############################################################
 
 import argparse
+import errno
 import json
 import logging
 import os.path
@@ -123,12 +124,18 @@ def drain(args):
         payload["mode"] = "overwrite"
     if args.reason:
         payload["reason"] = " ".join(args.reason)
-    RPC(
-        flux.Flux(),
-        "resource.drain",
-        payload,
-        nodeid=0,
-    ).get()
+    try:
+        RPC(
+            flux.Flux(),
+            "resource.drain",
+            payload,
+            nodeid=0,
+        ).get()
+    except OSError as exc:
+        LOGGER.error(exc)
+        if exc.errno == errno.EEXIST:
+            LOGGER.info("Use --force to overwrite existing drain reason")
+        sys.exit(1)
 
 
 def undrain(args):

--- a/t/t2311-resource-drain.t
+++ b/t/t2311-resource-drain.t
@@ -67,6 +67,13 @@ test_expect_success 'drain detects subset of already drained targets' '
 	test $(flux resource status -s drain -no {nnodes}) -eq 1
 '
 
+test_expect_success 'drain suggests --force with existing reason' '
+	test_must_fail flux resource drain 1 test_reason_updated \
+		>update-failed.log 2>&1 &&
+	test_debug "cat update-failed.log" &&
+	grep -i 'use --force' update-failed.log
+'
+
 test_expect_success 'drain reason can be updated with --force' '
 	flux resource drain --force 1 test_reason_updated &&
 	flux resource drain | grep test_reason_updated


### PR DESCRIPTION
This PR simply adds a note to try `--force` in `flux resource drain` when the target is already drained, in case the user wants to update the drain reason.