### PR TITLE
build: avoid continuous regeneration of constraint/parsetab.py

### DIFF
--- a/src/bindings/python/flux/Makefile.am
+++ b/src/bindings/python/flux/Makefile.am
@@ -101,8 +101,9 @@ stderr_devnull_0 = >/dev/null 2>&1
 #  should be removed. That is done below in clean-local.
 #
 constraint/parsetab.py: constraint/parser.py
-	$(AM_V_GEN)$(MKDIR_P) constraint && $(PYTHON) $< \
-	  --outputdir $(builddir)/constraint $(STDERR_DEVNULL)
+	$(AM_V_GEN)$(MKDIR_P) constraint && \
+	  $(PYTHON) $< --outputdir $(builddir)/constraint $(STDERR_DEVNULL) && \
+	  touch $@
 
 clean-local:
 	-rmdir constraint 2>/dev/null || :


### PR DESCRIPTION
Problem: The Python ply module is smart enought to avoid regenerating parsetab.py when its tables have not changed (via checksum), but make will always try to regenerate parsetab.py if it is older than constraint/parser.py. This generates unnecessary work for make on every run when parser.py is updated, but the parsing has not changed.

Touch constraint/parser.py after running constraint/parser.py to indicate to make that this file is up to date whether it was rewritten or not.