### PR TITLE
flux-queue: adjust default output of min/max/range

### DIFF
--- a/doc/man1/flux-jobs.rst
+++ b/doc/man1/flux-jobs.rst
@@ -173,13 +173,11 @@ has a queue assigned in the default format shown above).
 The special presentation type *h* can be used to convert an empty
 string, "0s", "0.0", or "0:00:00" to a hyphen. For example, normally
 "{nodelist}" would output an empty string if the job has not yet run.
-By specifying, "{nodelist:h}", a hyphen would be presented instead.  The
-special presentation type *i* is similar to *h*, but can convert
-"inf" (infinity) to a hyphen.
+By specifying, "{nodelist:h}", a hyphen would be presented instead.
 
 The special suffix *+* can be used to indicate if a string was truncated
-by including a ``+`` character when truncation occurs. If *+* is used in
-conjunction with *h* or *i*, then the *+* must appear after the *h* or *i*.
+by including a ``+`` character when truncation occurs. If both *h* and
+*+* are being used, then the *+* must appear after the *h*.
 
 Additionally, the custom job formatter supports a set of special
 conversion flags. Conversion flags follow the format field and are

--- a/src/bindings/python/flux/util.py
+++ b/src/bindings/python/flux/util.py
@@ -343,13 +343,6 @@ def fsd(secs):
 class UtilFormatter(Formatter):
     # pylint: disable=too-many-branches
 
-    # supported presentation characters which turn a base case
-    # value, e.g. '0' or an empty string, into a single hyphen.
-    hyphenators = {
-        "h": ("", "0s", "0.0", "0:00:00", "1970-01-01T00:00:00"),
-        "i": ("inf"),
-    }
-
     def convert_field(self, value, conv):
         """
         Flux utility-specific field conversions. Avoids the need
@@ -422,8 +415,8 @@ class UtilFormatter(Formatter):
             denote_truncation = True
             spec = spec[:-1]
 
-        if spec and spec[-1] in self.hyphenators:
-            basecases = self.hyphenators[spec[-1]]
+        if spec.endswith("h"):
+            basecases = ("", "0s", "0.0", "0:00:00", "1970-01-01T00:00:00")
             value = "-" if str(value) in basecases else str(value)
             spec = spec[:-1] + "s"
         retval = super().format_field(value, spec)

--- a/src/cmd/flux-queue.py
+++ b/src/cmd/flux-queue.py
@@ -154,7 +154,7 @@ class QueueLimitsJobSizeInfo:
             try:
                 val = self.config["policy"]["limits"]["job-size"][self.minormax][key]
             except KeyError:
-                val = math.inf
+                val = math.inf if self.minormax == "max" else 0
         if val < 0:
             val = math.inf
         return val
@@ -178,30 +178,17 @@ class QueueLimitsRangeInfo:
         self.min = min
         self.max = max
 
-    def get_range(self, min, max):
-        # Special case, do not output "inf-inf", return "inf"
-        # if nothing was set.
-        if math.isinf(min) and math.isinf(max):
-            return "inf"
-        return f"{min}-{max}"
-
     @property
     def nnodes(self):
-        min = self.min.nnodes
-        max = self.max.nnodes
-        return self.get_range(min, max)
+        return f"{self.min.nnodes}-{self.max.nnodes}"
 
     @property
     def ncores(self):
-        min = self.min.ncores
-        max = self.max.ncores
-        return self.get_range(min, max)
+        return f"{self.min.ncores}-{self.max.ncores}"
 
     @property
     def ngpus(self):
-        min = self.min.ngpus
-        max = self.max.ngpus
-        return self.get_range(min, max)
+        return f"{self.min.ngpus}-{self.max.ngpus}"
 
 
 class QueueLimitsInfo:

--- a/src/cmd/flux-queue.py
+++ b/src/cmd/flux-queue.py
@@ -173,9 +173,8 @@ class QueueLimitsJobSizeInfo:
 
 
 class QueueLimitsRangeInfo:
-    def __init__(self, name, config, min, max):
+    def __init__(self, name, min, max):
         self.name = name
-        self.config = config
         self.min = min
         self.max = max
 
@@ -211,7 +210,7 @@ class QueueLimitsInfo:
         self.config = config
         self.min = QueueLimitsJobSizeInfo(name, config, "min")
         self.max = QueueLimitsJobSizeInfo(name, config, "max")
-        self.range = QueueLimitsRangeInfo(name, config, self.min, self.max)
+        self.range = QueueLimitsRangeInfo(name, self.min, self.max)
 
     @property
     def timelimit(self):

--- a/src/cmd/flux-queue.py
+++ b/src/cmd/flux-queue.py
@@ -111,8 +111,8 @@ class FluxQueueConfig(UtilConfig):
         "default": {
             "description": "Default flux-queue list format string",
             "format": (
-                "?:{queuem:<8.8} {defaults.timelimit!F:>11i} {limits.timelimit!F:>10i} {limits.range.nnodes:>10i} "
-                "{limits.range.ncores:>10i} {limits.range.ngpus:>10i}"
+                "?:{queuem:<8.8} {defaults.timelimit!F:>11} {limits.timelimit!F:>10} {limits.range.nnodes:>10} "
+                "{limits.range.ncores:>10} {limits.range.ngpus:>10}"
             ),
         },
     }

--- a/t/t2241-queue-cmd-list.t
+++ b/t/t2241-queue-cmd-list.t
@@ -66,13 +66,6 @@ test_expect_success 'flux-queue: fsd of infinity is infinity' '
 	echo "inf,inf" > empty_config_fsd.exp &&
 	test_cmp empty_config_fsd.exp empty_config_fsd.out
 '
-test_expect_success 'flux-queue: i special presentation converter works' '
-	flux queue list -n \
-		-o "{limits.range.nnodes:i},{limits.min.ncores:i},{limits.max.ngpus:i}" \
-		> empty_config_i_presentation.out &&
-	echo "-,-,-" > empty_config_i_presentation.exp &&
-	test_cmp empty_config_i_presentation.exp empty_config_i_presentation.out
-'
 
 # N.B. job-size.max.ngpus left out to test default of infinity
 test_expect_success 'config flux with policy defaults' '

--- a/t/t2241-queue-cmd-list.t
+++ b/t/t2241-queue-cmd-list.t
@@ -53,10 +53,10 @@ test_expect_success 'flux-queue: empty config has no queues' '
 	echo "," > empty_config_queue.exp &&
 	test_cmp empty_config_queue.exp empty_config_queue.out
 '
-test_expect_success 'flux-queue: empty config limits are infinity' '
+test_expect_success 'flux-queue: empty config limits are 0/infinity' '
 	flux queue list -n \
 		-o "${ALL_LIMITS_FMT}" > empty_config_all.out &&
-	echo "inf,inf,inf,inf,inf,inf,inf,inf,inf,inf,inf" > empty_config_all.exp &&
+	echo "inf,inf,0-inf,0-inf,0-inf,0,0,0,inf,inf,inf" > empty_config_all.exp &&
 	test_cmp empty_config_all.exp empty_config_all.out
 '
 test_expect_success 'flux-queue: fsd of infinity is infinity' '


### PR DESCRIPTION
Problem: The current default outputs of node, core, and gpu values
and ranges in flux queue list is not considered very user friendly.

Solution: If the value of nnodes, ncores, or ngpus is not configured,
instead of always returning "inf", return "inf" only if it is the max.
Return 0 if it is the min.  As a result, the default output from the
range values of nodes, cores, and gpus becomes 0-inf.

Fixes #4927 