### PR TITLE
job-manager/history: track inactive jobs over purge/restart

### DIFF
--- a/doc/man7/flux-jobtap-plugins.rst
+++ b/doc/man7/flux-jobtap-plugins.rst
@@ -220,6 +220,13 @@ job.priority.get
   :ref:`priority` section for more information about plugin management
   of job priority.
 
+job.inactive-add
+  The job has transitioned to INACTIVE state and has been added to the
+  inactive hash.
+
+job.inactive-remove
+  The job has been purged from the inactive hash.
+
 CONFIGURATION CALLBACK TOPIC
 ============================
 

--- a/src/common/libutil/hola.c
+++ b/src/common/libutil/hola.c
@@ -241,6 +241,25 @@ void *hola_list_insert (struct hola *hola,
     return handle;
 }
 
+void *hola_list_find (struct hola *hola,
+                      const void *key,
+                      void *item)
+{
+    zlistx_t *l;
+    void *handle;
+
+    if (!hola || !key || !item) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (!(l = zhashx_lookup (hola->hash, key))
+        || !(handle = zlistx_find (l, item))) {
+        errno = ENOENT;
+        return NULL;
+    }
+    return handle;
+}
+
 int hola_list_delete (struct hola *hola, const void *key, void *handle)
 {
     zlistx_t *l;

--- a/src/common/libutil/hola.h
+++ b/src/common/libutil/hola.h
@@ -54,6 +54,9 @@ void *hola_list_insert (struct hola *hola,
                         const void *key,
                         void *item,
                         bool low_value);
+void *hola_list_find (struct hola *hola,
+                      const void *key,
+                      void *item);
 
 int hola_list_delete (struct hola *hola, const void *key, void *handle);
 size_t hola_list_size (struct hola *hola, const void *key);

--- a/src/common/libutil/test/hola.c
+++ b/src/common/libutil/test/hola.c
@@ -142,6 +142,7 @@ void test_auto (void)
     void *item1;
     void *item2;
     void *item3;
+    void *handle;
 
     ok ((h = hola_create (HOLA_AUTOCREATE | HOLA_AUTODESTROY)) != NULL,
         "hola_create AUTOCREATE | AUTODDESTROY works");
@@ -175,8 +176,14 @@ void test_auto (void)
         "hola_list_delete key=blue item1 works");
     ok (hola_hash_size (h) == 0,
         "hola_hash_size is 0");
-    ok (hola_list_insert (h, "blue", "item1", false) != NULL,
+    item1 = "item1";
+    errno = 0;
+    ok (hola_list_find (h, "blue", item1) == NULL && errno == ENOENT,
+        "hola_list_find fails with ENOENT on missing item");
+    ok ((handle = hola_list_insert (h, "blue", item1, false)) != NULL,
         "hola_list_insert key=blue value=item1 works");
+    ok (hola_list_find (h, "blue", item1) == handle,
+        "hola_list_find finds it again");
     ok (hola_list_insert (h, "blue", "item0", false) != NULL,
         "hola_list_insert key=blue value=item0 works");
     ok (hola_list_insert (h, "blue", "item2", false) != NULL,
@@ -385,6 +392,16 @@ void test_inval (void)
         "hola_list_cursor h=NULL returns NULL");
     ok (hola_list_cursor (h, NULL) == NULL,
         "hola_list_cursor key=NULL returns NULL");
+
+    errno = 0;
+    ok (hola_list_find (NULL, "foo", "bar") == NULL && errno == EINVAL,
+        "hola_list_find h=NULL fails with EINVAL");
+    errno = 0;
+    ok (hola_list_find (h, NULL, "bar") == NULL && errno == EINVAL,
+        "hola_list_find key=NULL fails with EINVAL");
+    errno = 0;
+    ok (hola_list_find (h, "foo", NULL) == NULL && errno == EINVAL,
+        "hola_list_find item=NULL fails with EINVAL");
 
     lives_ok ({hola_set_hash_key_destructor (NULL, key_destructor);},
         "holas_set_hash_key_destructor h=NULL doesn't crash");

--- a/src/modules/job-manager/event.c
+++ b/src/modules/job-manager/event.c
@@ -435,6 +435,7 @@ int event_job_action (struct event *event, struct job *job)
              * not be indicative of a problem.
              */
             if (zhashx_insert (ctx->inactive_jobs, &job->id, job) == 0) {
+                (void)jobtap_call (ctx->jobtap, job, "job.inactive-add", NULL);
                 if (purge_enqueue_job (ctx->purge, job) < 0) {
                     flux_log (event->ctx->h,
                               LOG_ERR,

--- a/src/modules/job-manager/purge.c
+++ b/src/modules/job-manager/purge.c
@@ -26,6 +26,7 @@
 #include "job.h"
 #include "purge.h"
 #include "conf.h"
+#include "jobtap-internal.h"
 #include "restart.h"
 
 #define INACTIVE_NUM_UNLIMITED  (-1)
@@ -158,6 +159,12 @@ static flux_future_t *purge_inactive_jobs (struct purge *purge,
             errno = ENOMEM;
             goto error;
         }
+
+        (void)jobtap_call (purge->ctx->jobtap,
+                           job,
+                           "job.inactive-remove",
+                           NULL);
+
         (void)zlistx_delete (purge->queue, job->handle);
         job->handle = NULL;
         zhashx_delete (purge->ctx->inactive_jobs, &job->id);

--- a/src/modules/job-manager/restart.c
+++ b/src/modules/job-manager/restart.c
@@ -379,6 +379,12 @@ int restart_from_kvs (struct job_manager *ctx)
     }
     flux_log (ctx->h, LOG_INFO, "restart: %d running jobs", ctx->running_jobs);
 
+    job = zhashx_first (ctx->inactive_jobs);
+    while (job) {
+        (void)jobtap_call (ctx->jobtap, job, "job.inactive-add", NULL);
+        job = zhashx_next (ctx->active_jobs);
+    }
+
     /* Restore misc state.
      */
     if (restart_restore_state (ctx) < 0) {

--- a/t/t2212-job-manager-plugins.t
+++ b/t/t2212-job-manager-plugins.t
@@ -189,7 +189,7 @@ test_expect_success 'job-manager: run args test plugin' '
 	flux mini run hostname &&
 	flux dmesg | grep args-check > args-check.log &&
 	test_debug "cat args-check.log" &&
-	test $(grep -c OK args-check.log) = 20
+	test $(grep -c OK args-check.log) = 21
 '
 test_expect_success 'job-manager: run subscribe test plugin' '
 	flux jobtap load --remove=all ${PLUGINPATH}/subscribe.so &&
@@ -514,6 +514,19 @@ test_expect_success 'reloading invalid configuration fails' '
 '
 test_expect_success 'job-manager: and produces reasonable error for humans' '
 	grep "Error parsing" reload.err
+'
+test_expect_success 'job-manager: run a job then purge all inactives' '
+	flux jobtap load --remove=all ${PLUGINPATH}/args.so &&
+	flux dmesg -C &&
+	flux mini run hostname &&
+	flux job purge --force --num-limit=0 &&
+	flux dmesg | grep args-check | grep OK >argsok.out
+'
+test_expect_success 'job-manager: job.inactive-add was called' '
+	grep -q job.inactive-add argsok.out
+'
+test_expect_success 'job-manager: job.inactive-remove was called' '
+	grep -q job.inactive-remove argsok.out
 '
 
 test_done

--- a/t/t2812-flux-job-last.t
+++ b/t/t2812-flux-job-last.t
@@ -35,5 +35,11 @@ test_expect_success 'flux job last N lists the last N jobs' '
 	flux job last 4 >last4.out &&
 	test_cmp last4.exp last4.out
 '
+# issue #4931
+test_expect_success 'flux-job last does not list purged jobs' '
+	flux job purge --force --num-limit=0 &&
+	test_must_fail flux job last 2>nojob2.err &&
+	grep "job history is empty" nojob2.err
+'
 
 test_done

--- a/t/t2812-flux-job-last.t
+++ b/t/t2812-flux-job-last.t
@@ -35,6 +35,14 @@ test_expect_success 'flux job last N lists the last N jobs' '
 	flux job last 4 >last4.out &&
 	test_cmp last4.exp last4.out
 '
+# issue #4930
+test_expect_success 'flux-job last lists inactive jobs after instance restart' '
+	flux job last "[:]" >lastdump.exp &&
+	flux dump dump.tgz &&
+	flux start -o,-Scontent.restore=dump.tgz \
+		flux job last "[:]" >lastdump.out &&
+	test_cmp lastdump.exp lastdump.out
+'
 # issue #4931
 test_expect_success 'flux-job last does not list purged jobs' '
 	flux job purge --force --num-limit=0 &&


### PR DESCRIPTION
This fixes #4930 and #4931 by adding  `job.inactive-add` and `job.inactive-remove` jobtap callbacks, as discussed in #4930.

I marked it WIP pending

- [x] adding tests for the jobtap callbacks by themselves
- [x] update jobtap docs
- [x] unit tests for `hola_list_find()`.