### PR TITLE
Fix minor documentation errors and typos

### DIFF
--- a/doc/man1/flux-pgrep.rst
+++ b/doc/man1/flux-pgrep.rst
@@ -29,8 +29,7 @@ prefixing the pattern with ``name:``, e.g. ``name:fr..123``.
 
 By default, only active jobs for the current user are considered.
 
-*flux-pkill* cancels matching jobs instead of listing them. This is
-equivalent to running *flux-pgrep* with the ``-k`` option.
+*flux-pkill* cancels matching jobs instead of listing them.
 
 OPTIONS
 =======

--- a/doc/man3/flux_event_decode.rst
+++ b/doc/man3/flux_event_decode.rst
@@ -107,7 +107,7 @@ ENOMEM
 
 EPROTO
    Message decoding failed, such as due to incorrect message type,
-   missing topic string, etc..
+   missing topic string, etc.
 
 
 RESOURCES

--- a/doc/man3/flux_request_decode.rst
+++ b/doc/man3/flux_request_decode.rst
@@ -68,7 +68,7 @@ EINVAL
 
 EPROTO
    Message decoding failed, such as due to incorrect message type,
-   missing topic string, etc..
+   missing topic string, etc.
 
 
 RESOURCES

--- a/doc/man3/flux_response_decode.rst
+++ b/doc/man3/flux_response_decode.rst
@@ -64,7 +64,7 @@ EINVAL
 
 EPROTO
    Message decoding failed, such as due to incorrect message type,
-   missing topic string, etc..
+   missing topic string, etc.
 
 ENOENT
    ``flux_response_decode_error()`` was called on a message with no

--- a/src/bindings/python/flux/cli/fortune.py
+++ b/src/bindings/python/flux/cli/fortune.py
@@ -195,7 +195,7 @@ https://chat.openai.com
 facts = [
     """
 Flux can be started as a parallel job.  This is how flux-batch(1) and
-flux-alloc(1) work!  Within one of these "sub-instances" of Flux, you
+flux-alloc(1) work!  Within one of these "subinstances" of Flux, you
 (or your batch script) have access all the features of Flux without bothering
 the system or parent Flux instance.  Do your worst - it is your personal
 sandbox!
@@ -211,17 +211,17 @@ is flux-submit(1) prints the job ID and exits immediately, while flux-run(1)
 doesn't exit until the job has completed.
 """,
     """
-All jobs run within a Flux sub-instance started by flux-batch(1) or
+All jobs run within a Flux subinstance started by flux-batch(1) or
 flux-alloc(1) look like *one* job to the Flux accounting system.
 """,
     """
-The system prolog/epilog do not run between jobs in a Flux sub-instance
+The system prolog/epilog do not run between jobs in a Flux subinstance
 started by flux-batch(1) or flux-alloc(1).
 """,
     """
-A Flux sub-instance started by flux-batch(1) or flux-alloc(1) has the same
+A Flux subinstance started by flux-batch(1) or flux-alloc(1) has the same
 capabilities as the system level Flux instance.  Unlike legacy systems that
-offer a simpler "step scheduler" in batch jobs, the Flux sub-instance is an
+offer a simpler "step scheduler" in batch jobs, the Flux subinstance is an
 identical copy of Flux running on a resource subset.  This has been called
 "fractal scheduling".
 """,

--- a/src/bindings/python/flux/util.py
+++ b/src/bindings/python/flux/util.py
@@ -218,7 +218,7 @@ class CLIMain(object):
             exit_code = ex
         except Exception as ex:  # pylint: disable=broad-except
             exit_code = 1
-            # Prefer '{strerror}[: {filename}' error message over default
+            # Prefer '{strerror}: {filename}' error message over default
             # OSError string representation which includes useless
             # `[Error N]` prefix in output.
             errmsg = getattr(ex, "strerror", None) or str(ex)

--- a/src/common/libsubprocess/test/subprocess.c
+++ b/src/common/libsubprocess/test/subprocess.c
@@ -1491,7 +1491,7 @@ void test_state_change_stopped (flux_reactor_t *r)
 
     flux_future_t *f = flux_subprocess_kill (p, SIGSTOP);
     ok (f != NULL,
-        "flux_subprocess_kill SIGStOP");
+        "flux_subprocess_kill SIGSTOP");
     flux_future_destroy (f);
 
     int rc = flux_reactor_run (r, 0);

--- a/t/t0014-runlevel.t
+++ b/t/t0014-runlevel.t
@@ -166,7 +166,7 @@ test_expect_success 'capture the environment for instance run as a job' '
 		"bash -c printenv >rc2.env2"
 '
 
-test_expect_success 'job environment is not set in rcs of sub-instance' '
+test_expect_success 'job environment is not set in rcs of subinstance' '
 	var_is_unset FLUX_JOB_ID *.env2 &&
 	var_is_unset FLUX_JOB_SIZE *.env2 &&
 	var_is_unset FLUX_JOB_NNODES *.env2 &&


### PR DESCRIPTION
Problem: "sub-instance" should not be hyphenated

Fix spelling.

There's more misuse in `flux-docs`, but saw there was one dumb one here :P  The remaining ones were in NEWS.md, but didn't touch those.