### PR TITLE
doc: document attach in flux-job(1)

### DIFF
--- a/doc/man1/flux-job.rst
+++ b/doc/man1/flux-job.rst
@@ -8,6 +8,8 @@ flux-job(1)
 SYNOPSIS
 ========
 
+**flux** **job** **attach** [*OPTIONS*] *id*
+
 **flux** **job** **cancel** [*OPTIONS*] *ids...* [*--*] [*message...*]
 
 **flux** **job** **cancelall** [*OPTIONS*] [*message...*]
@@ -34,6 +36,16 @@ DESCRIPTION
 ===========
 
 flux-job(1) performs various job related housekeeping functions.
+
+ATTACH
+======
+
+A job can be interactively attached to via ``flux job attach``.  This is
+typically used to watch stdout/stderr while a job is running or after it has
+completed.  It can also be used to feed stdin to a job.
+
+**-l, --label-io**
+   Label output by rank
 
 CANCEL
 ======


### PR DESCRIPTION
Problem: "flux job attach" is not documented in flux-job(1).

Add documentation on the subcommand and relevant options for users.

---

note: i only document `--label-io` b/c every other option appears to be internal plumbing specific.  agreed or is there another borderline one to document?

```
>flux job attach --help
Usage: flux-job attach [OPTIONS] id
Interactively attach to job
  -h, --help             Display this message.
  -E, --show-events      Show job events on stderr
  -X, --show-exec        Show exec events on stderr
      --show-status      Show job status line while pending
  -w, --wait-event=NAME  Wait for event NAME before detaching from eventlog
                         (default=finish)
  -l, --label-io         Label output by rank
  -v, --verbose          Increase verbosity
  -q, --quiet            Suppress warnings written to stderr from flux-job
  -r, --read-only        Disable reading stdin and capturing signals
      --debug            Enable parallel debugger to attach to a running job
```