### PR TITLE
job-manager: fix for job priority not reset after a duplicate urgency update

### DIFF
--- a/src/modules/job-manager/prioritize.c
+++ b/src/modules/job-manager/prioritize.c
@@ -75,11 +75,14 @@ static int reprioritize_one (struct job_manager *ctx,
     else if (job->urgency == FLUX_JOB_URGENCY_EXPEDITE)
         priority = FLUX_JOB_PRIORITY_MAX;
 
-    /*  If priority did not change, then do not post a priority
-     *   event, reorder queues, etc. (a change of priority to the
-     *   current value is not an "event")
+    /*
+     *  If priority did not change, _and_ the job is in SCHED state,
+     *   then do not post a priority event, since this would be useless
+     *   noise in the eventlog. However, be sure to post a priority event
+     *   in PRIORITY state, since this is what transitions a job to the
+     *   SCHED state.
      */
-    if (priority == job->priority)
+    if (priority == job->priority && job->state == FLUX_JOB_STATE_SCHED)
         return 0;
 
     /*  Priority event is only posted to job eventlog in

--- a/t/t2213-job-manager-hold-single.t
+++ b/t/t2213-job-manager-hold-single.t
@@ -59,6 +59,13 @@ test_expect_success HAVE_JQ 'job-manager: annotations job 5 pending (job 2/4 hel
         jmgr_check_annotation $(cat job5.id) "sched.reason_pending" "\"insufficient resources\""
 '
 
+test_expect_success HAVE_JQ 'job-manager: job 2, 4 hold again (issue #4940)' '
+        flux job urgency $(cat job2.id) hold &&
+        flux job urgency $(cat job4.id) hold &&
+        jmgr_check_state $(cat job2.id) S &&
+        jmgr_check_state $(cat job4.id) S
+'
+
 test_expect_success 'job-manager: job 4 release (higher urgency)' '
         flux job urgency $(cat job4.id) 20
 '

--- a/t/t2214-job-manager-hold-limited.t
+++ b/t/t2214-job-manager-hold-limited.t
@@ -34,6 +34,14 @@ test_expect_success HAVE_JQ 'job-manager: job annotations correct (RSSSS)' '
         jmgr_check_no_annotations $(cat job5.id)
 '
 
+test_expect_success 'job-manager: hold job 3, 5 again (issue #4940)' '
+        flux job urgency $(cat job3.id) hold &&
+        flux job urgency $(cat job3.id) hold &&
+        flux job urgency $(cat job3.id) hold &&
+        flux job urgency $(cat job3.id) hold &&
+        flux job urgency $(cat job5.id) hold
+'
+
 test_expect_success 'job-manager: remove hold on job 3, 4, 5' '
         flux job urgency $(cat job3.id) 16 &&
         flux job urgency $(cat job4.id) 16 &&

--- a/t/t2215-job-manager-hold-unlimited.t
+++ b/t/t2215-job-manager-hold-unlimited.t
@@ -40,6 +40,10 @@ test_expect_success 'job-manager: put hold on job 3' '
         flux job urgency $(cat job3.id) hold
 '
 
+test_expect_success 'job-manager: hold job 4 again (issue #4940)' '
+        flux job urgency $(cat job4.id) hold
+'
+
 test_expect_success HAVE_JQ 'job-manager: job state RRSSS' '
         jmgr_check_state $(cat job1.id) R &&
         jmgr_check_state $(cat job2.id) R &&


### PR DESCRIPTION
This PR fixes the issue described in #4940, and adds some tests to the `hold` suite of sharness tests to set urgency to hold already held jobs to ensure we don't see this particular issue again.