### PR TITLE
support RFC 36 submission directives in `flux mini batch`

### DIFF
--- a/doc/man1/flux-mini.rst
+++ b/doc/man1/flux-mini.rst
@@ -41,6 +41,15 @@ on either stdin, or given on the command line. The inputs are optionally
 substituted in ``COMMAND`` and/or many submission options. See more in the
 :ref:`bulksubmit` section below.
 
+The **flux-mini batch** command submits a script to run as the initial
+program of a job running a new instance of Flux. The SCRIPT given on the
+command line is assumed to be a file name unless the *--wrap* option is
+used, in which case the free arguments are consumed as the script, with
+``#!/bin/sh`` as the first line. If no SCRIPT is provided, then one will
+be read from standard input. The script may contain submission directives
+denoted by ``flux:`` or ``FLUX:`` as described in RFC 36, see
+:ref:`submission_directives` below.
+
 For **flux-mini batch**, the SCRIPT given on the command line is assumed
 to be a file name, unless the *--wrap* option used, and the script
 file is read and submitted along with the job. If no SCRIPT is
@@ -824,6 +833,56 @@ overridden in some cases:
 **stage-in**
    Copy files previously mapped with :man1:`flux-filemap` to $FLUX_JOB_TMPDIR.
    See :man1:`flux-shell` for more *stage-in* options.
+
+.. _submission_directives:
+
+SUBMISSION DIRECTIVES
+=====================
+
+The *flux mini batch* command supports submission directives
+mixed within the submission script. The submission directive specification
+is fully detailed in RFC 36, but is summarized here for convenience:
+
+ * A submission directive is indicated by a line that starts with
+   a prefix of non-alphanumeric characters followed by a tag ``FLUX:`` or
+   ``flux:``. The prefix plus tag is called the *directive sentinel*. E.g.,
+   in the example below the sentinel is ``# flux:``: ::
+
+     #!/bin/sh
+     # flux: -N4 -n16
+     flux mini run -n16 hostname
+
+ * All directives in a file must use the same sentinel pattern, otherwise
+   an error will be raised.
+ * Directives must be grouped together - it is an error to include a
+   directive after any non-blank line that doesn't start with the common
+   prefix.
+ * The directive starts after the sentinel to the end of the line.
+ * The ``#`` character is supported as a comment character in directives.
+ * UNIX shell quoting is supported in directives.
+ * Triple quoted strings can be used to include newlines and quotes without
+   further escaping. If a triple quoted string is used across multiple lines,
+   then the opening and closing triple quotes must appear at the end of the
+   line. For example ::
+
+     # flux: --setattr=user.conf="""
+     # flux: [config]
+     # flux:   item = "foo"
+     # flux: """
+
+Submission directives may be used to set default command line options for
+*flux mini batch* for a given script. Options given on the *flux mini batch*
+command line override those in the submission script, e.g.: ::
+
+   $ flux mini batch --job-name=test-name --wrap <<-EOF
+   > #flux: -N4
+   > #flux: --job-name=name
+   > flux mini run -N4 hostname
+   > EOF
+   ƒ112345
+   $ flux jobs -no {name} ƒ112345
+   test-name
+
 
 RESOURCES
 =========

--- a/src/bindings/python/flux/Makefile.am
+++ b/src/bindings/python/flux/Makefile.am
@@ -29,6 +29,7 @@ nobase_fluxpy_PYTHON = \
 	job/stats.py \
 	job/_wrapper.py \
 	job/executor.py \
+	job/directives.py \
 	job/validator/__init__.py \
 	job/validator/validator.py \
 	job/validator/plugins/jobspec.py \

--- a/src/bindings/python/flux/job/directives.py
+++ b/src/bindings/python/flux/job/directives.py
@@ -1,0 +1,275 @@
+###############################################################
+# Copyright 2023 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+import fileinput
+import re
+import shlex
+
+
+class Directive:
+    """
+    This class represents a single job submission directive processed
+    from an input file or batch script. Input values to the constructor
+    should have the sentinel stripped, and are then split using Python's
+    shlex module to provide familiary UNIX shell syntax and quoting
+    for argument. The first argument after shell lexing determines the
+    Directive type or "action".
+
+    At this time the only supported actions are "SETARGS", which indicates
+    an args list to pass through to the submission utility, and NOOP,
+    which is an empty directive.
+
+    If lineno is provided, it is used in error messages to indicate to
+    the user more detail about the failing line (e.g. shell parsing error).
+
+    Args:
+        value (str): A preprocessed directive with sentinel removed
+        lineno (int, optional): The source line number of the current
+            directive
+
+    Attributes:
+        lineno (int): line number associated with directive
+        args (list): list of directive arguments
+        action (str): the directive type or instruction to the submission
+            utility.
+
+    """
+
+    def __init__(self, value, lineno=-1):
+        self.lineno = lineno
+        #
+        # split value as POSIX shell, removing comments.
+        # We specify posix and punctuation_chars to get more predictable
+        # quoting and avoid splitting on cmdline args like --foo.
+        lexer = shlex.shlex(value, posix=True, punctuation_chars=True)
+        #
+        # Add single-quote to escapedquotes. This is necessary to avoid
+        # unclosed quote ValueError due to escaped single quote. (The
+        # default in Posix mode is to escape only '"')
+        lexer.escapedquotes = "\"'"
+        try:
+            self.args = list(lexer)
+        except ValueError as exc:
+            raise ValueError(f"line {lineno}: {value}: {exc}") from None
+
+        if not self.args:
+            self.action = "NOOP"
+        elif self.args[0].startswith("-"):
+            self.action = "SETARGS"
+        else:
+            raise ValueError(f"line {lineno}: Unknown directive: {value}")
+
+    def __str__(self):
+        return f"{self.action}({self.args})"
+
+
+class MultiLine:
+    """
+    Container for multiline quoted directives.
+
+    A Multiline is opened and closed by macthing triple quote at the end
+    of a line. While a multi line triple quote is open, lines are pushed
+    verbatim (minus any common indent). When the Multiline is finished
+    a string is returned with the multiline literal escaped such that it
+    may be passed to the Directive constructor.
+    """
+
+    def __init__(self):
+        self.triplequote = None
+        self.inprogress = False
+        self.startline = -1
+        self.start = None
+        self.indent = ""
+        self.lines = []
+
+    def finish(self):
+        result = self.lines[0] + shlex.quote("\n".join(self.lines[1:]))
+        if self.triplequote in result:
+            raise ValueError(
+                f"improperly terminated triple quoted string at: `{self.start}'"
+            )
+        self.triplequote = None
+        self.lines.clear()
+        self.indent = ""
+        self.inprogress = False
+        self.start = None
+        return result
+
+    def append(self, value):
+        # Remove common indent and append line
+        if value.startswith(self.indent):
+            value = value[len(self.indent) :]
+        self.lines.append(value)
+
+    def process(self, value, lineno):
+        closed = False
+        quotes = value[-3:]
+        if not self.inprogress:
+            # Strip leading whitespace and stash indent.
+            # Indent will be removed if matching from all multiline lines
+            self.triplequote = quotes
+            self.indent = value[: -len(value.lstrip())]
+            self.inprogress = True
+            self.start = value.lstrip()
+            self.startline = lineno
+        elif quotes != self.triplequote:
+            # A different kind of triplequote, append value and return
+            self.append(value)
+            return None
+        else:
+            closed = True
+
+        # Append value with quotes removed:
+        self.append(value[:-3])
+        if closed:
+            return self.finish()
+        return None
+
+
+class DirectiveParser:
+    """
+    RFC 36 submission directive parser.
+
+    The DirectiveParser looks for sentinels matching the pattern specified
+    in RFC 36 in an input stream and extracts each line or quoted multiline
+    into a Directive object. Single line strings are split into multiple
+    tokens by Python's shlex module, which allows lines to contain familiar
+    shell quoting and comments.  As a convenience, inline triple quoting
+    is also supported.
+
+    Args:
+        inputfile (:obj:`io.TextIOWrapper`):
+
+    Attributes:
+        directives (list): list of Directive objects
+        script (str): the script to submit
+    """
+
+    def __init__(self, inputfile):
+        self.directives = []
+        self.script = ""
+        self.re = re.compile(r"^([^\w]*)((?:flux|FLUX):)(.*)$")
+        self.sentinel = None
+        self.prefix = None
+        self.line = 0
+
+        multiline = MultiLine()
+        lineno = 0
+        started = False
+        directives_disabled = False
+        last_directive_line = 0
+
+        for line in inputfile:
+            lineno += 1
+            self.script += line
+
+            match = self.re.match(line)
+            if not match:
+                #  All lines in a multiline must start with the sentinel:
+                if multiline.inprogress:
+                    raise ValueError(
+                        f"line {lineno}: unterminated multi-line quote at"
+                        + f" line {multiline.startline}: `{multiline.start}'"
+                    )
+                #  Disable further directives if directives are not already
+                #  disabled, line prefix with trailing whitespace removed
+                #  doesn't match, and the line is not otherwise empty:
+                if (
+                    started
+                    and not directives_disabled
+                    and not line.startswith(self.prefix.rstrip())
+                    and line.strip()
+                ):
+                    directives_disabled = True
+                    last_directive_line = lineno - 1
+                continue
+
+            #  Get directive prefix and tag:
+            started = True
+            prefix = match.group(1)
+            tag = match.group(2)
+            sentinel = prefix + tag
+
+            #  It is an error if a directive is found after directives
+            #  have been disabled:
+            if directives_disabled:
+                #  Raise an error if a directive appears when directives
+                #  have been disabled
+                raise ValueError(
+                    f"line {lineno}: orphan '{tag}' detected: "
+                    + f"directives disabled after line {last_directive_line}"
+                )
+
+            #  Try processing paired triple quotes on this line.
+            #  Raises ValueError on unbalanced triple quotes, or a single
+            #  triple quote not at end of line:
+            try:
+                value = self.triplequote(match.group(3))
+            except ValueError as exc:
+                raise ValueError(f"line {lineno}: {exc}") from None
+
+            #  If this is the first line with a sentinel, stash the
+            #  sentinel for later comparison. Otherwise, raise an error
+            #  if it does not match:
+            if self.sentinel is None:
+                self.sentinel = sentinel
+                self.prefix = prefix
+            elif sentinel != self.sentinel:
+                raise ValueError(
+                    f"line {lineno}: sentinel changed from "
+                    + f"'{self.sentinel}' to '{sentinel}'"
+                )
+
+            if value.endswith('"""') or value.endswith("'''"):
+                #  Handle start or end of a multiline triple quoted string:
+                result = multiline.process(value, lineno)
+                if result:
+                    self.append(result, multiline.startline)
+            elif multiline.inprogress:
+                #  Multiline in progress: collect in multiline object
+                multiline.append(value)
+            elif value:
+                self.append(value, lineno)
+
+    def triplequote(self, value):
+        """
+        Escape quotes within triple quotes (single or double) so they pass
+        unmodified to shell lexing done in Directive constructor
+        """
+
+        def paired(n):
+            return n > 0 and (n % 2) == 0
+
+        if paired(value.count('"""')) or paired(value.count("'''")):
+            value = re.sub(
+                r"""((?:["']){3})(.*)\1""", lambda x: shlex.quote(x[2]), value
+            )
+
+        elif re.search(r"""((?:["']){3}).""", value):
+            #  Multiline strings must have triple quote at end of line,
+            #  so a triple quote followed by anything is an error:
+            raise ValueError(f"unclosed triple quote: {value.strip()}")
+        return value
+
+    def append(self, value, lineno):
+        """
+        Append one Directive
+        """
+        self.directives.append(Directive(value, lineno))
+
+
+if __name__ == "__main__":
+    """
+    Parse directives from any file for test/debug purposes with
+    ::
+       flux python -m flux.job.directives FILE
+    """
+    directives = DirectiveParser(fileinput.input()).directives
+    if directives:
+        print("\n".join(map(str, directives)))

--- a/src/cmd/flux-mini.py
+++ b/src/cmd/flux-mini.py
@@ -30,6 +30,7 @@ from flux import debugged, job, util
 from flux.constraint.parser import ConstraintParser, ConstraintSyntaxError
 from flux.idset import IDset
 from flux.job import JobspecV1
+from flux.job.directives import DirectiveParser
 from flux.progress import ProgressBar
 from flux.uri import JobURI
 
@@ -1773,12 +1774,34 @@ class BatchCmd(MiniCmd):
             help="Batch script and arguments to submit",
         )
 
-    @staticmethod
-    def read_script(args):
+    def parse_directive_args(self, name, batchscript):
+        """
+        Parse any directives in batchscript.directives, then apply
+        command line arguments in self.argv. This allows command line
+        to override file directives
+        """
+        args = None
+        for item in batchscript.directives:
+            try:
+                if item.action == "SETARGS":
+                    args = self.parser.parse_args(item.args, namespace=args)
+            except SystemExit:
+                #  Argparse exits on error. Give the user a clue
+                #  about which line failed in the source file:
+                LOGGER.error(f"argument parsing failed at {name} line {item.lineno}")
+                sys.exit(2)
+        args = self.parser.parse_args(self.argv, namespace=args)
+        return batchscript.script, args
+
+    def process_script(self, args):
+        """
+        Process a batch script that may contain RFC 36 directives.
+        Returns the ingested script and new argparse args Namespace.
+        """
         if args.SCRIPT:
             if args.wrap:
-                #  Wrap args in /bin/sh script
-                return "#!/bin/sh\n" + " ".join(args.SCRIPT) + "\n"
+                #  Return script which will be wrapped by caller
+                return " ".join(args.SCRIPT) + "\n", args
 
             # O/w, open script for reading
             name = open_arg = args.SCRIPT[0]
@@ -1787,19 +1810,19 @@ class BatchCmd(MiniCmd):
             open_arg = 0  # when passed to `open`, 0 gives the `stdin` stream
         with open(open_arg, "r", encoding="utf-8") as filep:
             try:
-                #  Read script
-                script = filep.read()
-                if args.wrap:
-                    script = "#!/bin/sh\n" + script
+                batchscript = DirectiveParser(filep)
             except UnicodeError:
                 raise ValueError(
                     f"{name} does not appear to be a script, "
                     "or failed to encode as utf-8"
                 )
-            return script
+            except ValueError as exc:
+                raise ValueError(f"{name}: {exc}") from None
+        return self.parse_directive_args(name, batchscript)
 
     def init_jobspec(self, args):
-        # If no script (reading from stdin), then use "flux" as arg[0]
+        if args.wrap:
+            self.script = f"#!/bin/sh\n{self.script}"
 
         #  If number of slots not specified, then set it to node count
         #   if set, otherwise raise an error.
@@ -1813,9 +1836,18 @@ class BatchCmd(MiniCmd):
             args.broker_opts = args.broker_opts or []
             args.broker_opts.append("-Scontent.dump=" + args.dump)
 
+        #  If job name is not explicitly set in args, use the script name
+        #   if a script was provided, else the string "mini-batch" to
+        #   indicate the script was set on flux mini batch stdin.
+        if args.job_name is None:
+            if args.SCRIPT:
+                args.job_name = args.SCRIPT[0]
+            else:
+                args.job_name = "mini-batch"
+
         jobspec = JobspecV1.from_batch_command(
-            script=self.read_script(args),
-            jobname=args.SCRIPT[0] if args.SCRIPT else "batchscript",
+            script=self.script,
+            jobname=args.job_name,
             args=args.SCRIPT[1:],
             num_slots=args.nslots,
             cores_per_slot=args.cores_per_slot,
@@ -1832,6 +1864,17 @@ class BatchCmd(MiniCmd):
         return jobspec
 
     def main(self, args):
+        #  Save cmdline argv to mini batch in case it must be reprocessed
+        #  after applying directive options.
+        #  self.argv is sys.argv without first two args ["mini", "batch"]
+        self.argv = sys.argv[2:]
+
+        #  Process file with possible submission directives, returning
+        #  script and new argparse args Namespace as a result.
+        #  This must be done before calling self.submit() so that SETARGS
+        #  directives are available in jobspec_create():
+        self.script, args = self.process_script(args)
+
         jobid = self.submit(args)
         print(jobid, file=sys.stdout)
 

--- a/src/cmd/flux-mini.py
+++ b/src/cmd/flux-mini.py
@@ -2057,7 +2057,7 @@ def main():
     a Flux instance.  If no batch script is provided, one will be read
     from stdin.
     """
-    mini_batch_parser_sub = subparsers.add_parser(
+    batch.parser = subparsers.add_parser(
         "batch",
         parents=[batch.get_parser()],
         help="enqueue a batch script",
@@ -2065,7 +2065,7 @@ def main():
         description=description,
         formatter_class=flux.util.help_formatter(),
     )
-    mini_batch_parser_sub.set_defaults(func=batch.main)
+    batch.parser.set_defaults(func=batch.main)
 
     # alloc
     alloc = AllocCmd()
@@ -2073,7 +2073,7 @@ def main():
     Allocate resources and start a new Flux instance. Once the instance
     has started, attach to it interactively.
     """
-    mini_alloc_parser_sub = subparsers.add_parser(
+    alloc.parser = subparsers.add_parser(
         "alloc",
         parents=[alloc.get_parser()],
         help="allocate a new instance for interactive use",
@@ -2081,7 +2081,7 @@ def main():
         description=description,
         formatter_class=flux.util.help_formatter(),
     )
-    mini_alloc_parser_sub.set_defaults(func=alloc.main)
+    alloc.parser.set_defaults(func=alloc.main)
 
     args = parser.parse_args()
     args.func(args)

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -75,6 +75,7 @@ TESTSCRIPTS = \
 	t0029-filemap-cmd.t \
 	t0030-marshall.t \
 	t0031-constraint-parser.t \
+	t0032-directives-parser.t \
 	t0025-broker-state-machine.t \
 	t0027-broker-groups.t \
 	t0013-config-file.t \
@@ -289,6 +290,7 @@ EXTRA_DIST= \
 	scripts/rexec.py \
 	jobspec \
 	marshall \
+	batch \
 	job-manager/dumps \
 	flux-resource \
 	resource/get-xml-test.py

--- a/t/batch/directives/invalid/001-invalid-directive.sh
+++ b/t/batch/directives/invalid/001-invalid-directive.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+#
+#FLUX: -N4 -n4
+#FLUX: --job-name=test
+hostname
+#FLUX: --dump

--- a/t/batch/directives/invalid/002-sentinel-changed.sh
+++ b/t/batch/directives/invalid/002-sentinel-changed.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+#
+#FLUX: -N4 -n4
+#FLUX: --job-name=test
+#flux: --dump

--- a/t/batch/directives/invalid/003-unclosed-multiline.sh
+++ b/t/batch/directives/invalid/003-unclosed-multiline.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+#
+#FLUX: -N4 -n4
+#FLUX: --setattr=user.foo="""
+#FLUX: [table]
+#FLUX: value = "foo"
+#FLUX: ""
+date; hostname

--- a/t/batch/directives/invalid/004-unclose-triplequote.sh
+++ b/t/batch/directives/invalid/004-unclose-triplequote.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+# flux: --job-name='''It's a "job"
+date; hostname

--- a/t/batch/directives/invalid/005-changed-sentinel.sh
+++ b/t/batch/directives/invalid/005-changed-sentinel.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+#
+# flux: -N4 --job-name=test
+# flux: --output=flux-{{id}}.out
+#flux: --dump
+#

--- a/t/batch/directives/invalid/006-bad-shell-quoting.sh
+++ b/t/batch/directives/invalid/006-bad-shell-quoting.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+#
+# flux: --job-name="foo

--- a/t/batch/directives/invalid/007-bad-shell-quoting.sh
+++ b/t/batch/directives/invalid/007-bad-shell-quoting.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+#
+# flux: --job-name='foo''

--- a/t/batch/directives/invalid/expected/001-invalid-directive.pattern
+++ b/t/batch/directives/invalid/expected/001-invalid-directive.pattern
@@ -1,0 +1,1 @@
+ValueError: line 6: orphan 'FLUX:' detected: directives disabled after line 4

--- a/t/batch/directives/invalid/expected/002-sentinel-changed.pattern
+++ b/t/batch/directives/invalid/expected/002-sentinel-changed.pattern
@@ -1,0 +1,1 @@
+ValueError: line 5: sentinel changed from '#FLUX:' to '#flux:'

--- a/t/batch/directives/invalid/expected/003-unclosed-multiline.pattern
+++ b/t/batch/directives/invalid/expected/003-unclosed-multiline.pattern
@@ -1,0 +1,1 @@
+ValueError: line 8: unterminated multi-line quote at line 4: `--setattr=user.foo="""'

--- a/t/batch/directives/invalid/expected/004-unclose-triplequote.pattern
+++ b/t/batch/directives/invalid/expected/004-unclose-triplequote.pattern
@@ -1,0 +1,1 @@
+ValueError: line 2: unclosed triple quote: --job-name='''It's a "job"

--- a/t/batch/directives/invalid/expected/005-changed-sentinel.pattern
+++ b/t/batch/directives/invalid/expected/005-changed-sentinel.pattern
@@ -1,0 +1,1 @@
+ValueError: line 5: sentinel changed from '# flux:' to '#flux:'

--- a/t/batch/directives/invalid/expected/006-bad-shell-quoting.pattern
+++ b/t/batch/directives/invalid/expected/006-bad-shell-quoting.pattern
@@ -1,0 +1,1 @@
+ValueError: line 3:  --job-name="foo: No closing quotation

--- a/t/batch/directives/invalid/expected/007-bad-shell-quoting.pattern
+++ b/t/batch/directives/invalid/expected/007-bad-shell-quoting.pattern
@@ -1,0 +1,1 @@
+ValueError: line 3:  --job-name='foo'': No closing quotation

--- a/t/batch/directives/valid/001-simple.sh
+++ b/t/batch/directives/valid/001-simple.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+# simple directives
+#FLUX: -N4                  # Request four nodes
+#FLUX: --queue=batch        # Submit to the batch queue
+#FLUX: --job-name=app001    # Set an explicit job name
+flux mini run -N4 app

--- a/t/batch/directives/valid/002-python.py
+++ b/t/batch/directives/valid/002-python.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+# Directives embedded in python docstring
+def main():
+    """
+    flux: -N4
+    flux: --queue=batch
+    flux: --job-name="my python job"
+
+    # Set some arbitrary user data:
+    flux: --setattr=user.data='''
+    flux: x, y, z
+    flux: a, b, c
+    flux: '''
+    """
+    run()
+
+
+if __name__ == "__main__":
+    main()

--- a/t/batch/directives/valid/003-lua.lua
+++ b/t/batch/directives/valid/003-lua.lua
@@ -1,0 +1,9 @@
+#!/usr/bin/lua
+-- Directives embedded in Lua script:
+--
+-- flux: -N1 --exclusive
+--
+-- flux: --output=job.out # Set output file
+--
+local app = require 'app'
+app.run()

--- a/t/batch/directives/valid/004-mixed-comments.sh
+++ b/t/batch/directives/valid/004-mixed-comments.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Set flux directives
+#FLUX: -N1
+# Set job name:
+#FLUX: --job-name=test
+hostname; date

--- a/t/batch/directives/valid/005-mixed-comments.py
+++ b/t/batch/directives/valid/005-mixed-comments.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+"""
+flux: --nodes=4
+
+Set an arbitrary value in jobspec:
+flux: --setattr=user.foo="hello, earth"
+"""

--- a/t/batch/directives/valid/006-single-quotes.sh
+++ b/t/batch/directives/valid/006-single-quotes.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+# flux: --setattr=user.data='{"option": "arg"}'

--- a/t/batch/directives/valid/007-triple-quotes.sh
+++ b/t/batch/directives/valid/007-triple-quotes.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+# flux: --job-name='''It's a "job"'''

--- a/t/batch/directives/valid/008-multiline-with-indent.sh
+++ b/t/batch/directives/valid/008-multiline-with-indent.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+# flux: -N4 --exclusive
+# flux: --setattr=user.conf="""
+# flux: [config]
+# flux:   item = "foo"
+# flux: """
+foo

--- a/t/batch/directives/valid/009-multiline-comment-char-escaped.sh
+++ b/t/batch/directives/valid/009-multiline-comment-char-escaped.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+# flux: -N4 --exclusive
+# flux: --job-name=foo --setattr=user.conf="""
+# flux: [config]
+# flux:   item = "foo"  # an inline comment
+# flux: # another comment
+# flux: [tab2]
+# flux:   b = 'bar'
+# flux: """
+foo

--- a/t/batch/directives/valid/010-noop.sh
+++ b/t/batch/directives/valid/010-noop.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+#
+# flux: -n 32
+# flux: # clear environment except for PATH and PYTHONPATH
+# flux: --env=-* --env=PATH --env=PYTHONPATH

--- a/t/batch/directives/valid/expected/001-simple.expected
+++ b/t/batch/directives/valid/expected/001-simple.expected
@@ -1,0 +1,3 @@
+SETARGS(['-N4'])
+SETARGS(['--queue=batch'])
+SETARGS(['--job-name=app001'])

--- a/t/batch/directives/valid/expected/002-python.expected
+++ b/t/batch/directives/valid/expected/002-python.expected
@@ -1,0 +1,4 @@
+SETARGS(['-N4'])
+SETARGS(['--queue=batch'])
+SETARGS(['--job-name=my python job'])
+SETARGS(['--setattr=user.data=x, y, z\na, b, c\n'])

--- a/t/batch/directives/valid/expected/003-lua.expected
+++ b/t/batch/directives/valid/expected/003-lua.expected
@@ -1,0 +1,2 @@
+SETARGS(['-N1', '--exclusive'])
+SETARGS(['--output=job.out'])

--- a/t/batch/directives/valid/expected/004-mixed-comments.expected
+++ b/t/batch/directives/valid/expected/004-mixed-comments.expected
@@ -1,0 +1,2 @@
+SETARGS(['-N1'])
+SETARGS(['--job-name=test'])

--- a/t/batch/directives/valid/expected/005-mixed-comments.expected
+++ b/t/batch/directives/valid/expected/005-mixed-comments.expected
@@ -1,0 +1,2 @@
+SETARGS(['--nodes=4'])
+SETARGS(['--setattr=user.foo=hello, earth'])

--- a/t/batch/directives/valid/expected/006-single-quotes.expected
+++ b/t/batch/directives/valid/expected/006-single-quotes.expected
@@ -1,0 +1,1 @@
+SETARGS(['--setattr=user.data={"option": "arg"}'])

--- a/t/batch/directives/valid/expected/007-triple-quotes.expected
+++ b/t/batch/directives/valid/expected/007-triple-quotes.expected
@@ -1,0 +1,1 @@
+SETARGS(['--job-name=It\'s a "job"'])

--- a/t/batch/directives/valid/expected/008-multiline-with-indent.expected
+++ b/t/batch/directives/valid/expected/008-multiline-with-indent.expected
@@ -1,0 +1,2 @@
+SETARGS(['-N4', '--exclusive'])
+SETARGS(['--setattr=user.conf=[config]\n  item = "foo"\n'])

--- a/t/batch/directives/valid/expected/009-multiline-comment-char-escaped.expected
+++ b/t/batch/directives/valid/expected/009-multiline-comment-char-escaped.expected
@@ -1,0 +1,2 @@
+SETARGS(['-N4', '--exclusive'])
+SETARGS(['--job-name=foo', '--setattr=user.conf=[config]\n  item = "foo"  # an inline comment\n# another comment\n[tab2]\n  b = \'bar\'\n'])

--- a/t/batch/directives/valid/expected/010-noop.expected
+++ b/t/batch/directives/valid/expected/010-noop.expected
@@ -1,0 +1,3 @@
+SETARGS(['-n', '32'])
+NOOP([])
+SETARGS(['--env=-*', '--env=PATH', '--env=PYTHONPATH'])

--- a/t/t0032-directives-parser.t
+++ b/t/t0032-directives-parser.t
@@ -1,0 +1,53 @@
+#!/bin/sh
+
+test_description='Test python flux.job.directives parser operation'
+
+. `dirname $0`/sharness.sh
+
+parser="flux python -m flux.job.directives"
+
+test_expect_success 'flux.job.directives works on file with no directives' '
+	$parser <<-EOF >empty.out &&
+	#!/bin/sh
+	hostname
+	EOF
+	test_debug "cat empty.out" &&
+	test_must_be_empty empty.out
+'
+TESTDIR=${SHARNESS_TEST_SRCDIR}/batch/directives
+VALID=$TESTDIR/valid
+INVALID=$TESTDIR/invalid
+
+validate_directives() {
+	input=$(basename $1) &&
+	testname=${input%.*} &&
+	out=${testname}.output &&
+	exp=$(dirname $1)/expected/${testname}.expected &&
+	$parser $1 >$out 2>&1 &&
+	test_debug "cat $out" &&
+	test_cmp $exp $out
+}
+
+for file in ${VALID}/*; do
+	test -d $file && continue
+	input=$(basename $file) &&
+	test_expect_success 'valid: '${input} "validate_directives $file"
+done
+
+test_invalid_directive() {
+	input=$(basename $1) &&
+	testname=${input%.*} &&
+	out=${testname}.output &&
+	errmsg=$(dirname $1)/expected/${testname}.pattern &&
+	test_must_fail $parser $1 >$out 2>&1 &&
+	test_debug "cat $out" &&
+	grep "$(cat $errmsg)" $out
+}
+
+for file in ${INVALID}/*; do
+	test -d $file && continue
+	input=$(basename $file) &&
+	test_expect_success 'invalid: '${input} "test_invalid_directive $file"
+done
+
+test_done


### PR DESCRIPTION
This PR introduces support for processing [RFC 36](https://flux-framework.readthedocs.io/projects/flux-rfc/en/latest/spec_36.html) submission directives in the script argument to `flux mini batch`. This allows `flux mini batch` command line arguments to be embedded in the submission script. Options given on the command line at the time of submission will override embedded optoins.

This is a WIP while I write documentation, but figured I'd ask for an early review of the implementation in case there are needed changes before I document it.