### PR TITLE
job-ingest: handle worker channel overflow

### DIFF
--- a/src/common/libsubprocess/Makefile.am
+++ b/src/common/libsubprocess/Makefile.am
@@ -37,7 +37,9 @@ fluxcoreinclude_HEADERS = \
 
 TESTS = \
 	test_cmd.t \
-	test_subprocess.t
+	test_subprocess.t \
+	test_remote.t \
+	test_iostress.t
 
 check_PROGRAMS = \
 	$(TESTS) \
@@ -45,15 +47,22 @@ check_PROGRAMS = \
 	test_multi_echo \
 	test_fork_sleep
 
+check_LTLIBRARIES = test/libutil.la
+
+
 TEST_EXTENSIONS = .t
 T_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
         $(top_srcdir)/config/tap-driver.sh
 
 test_ldadd = \
+	$(builddir)/test/libutil.la \
+        $(top_builddir)/src/common/libtestutil/libtestutil.la \
+        $(top_builddir)/src/common/libzmqutil/libzmqutil.la \
         $(top_builddir)/src/common/libtap/libtap.la \
         $(top_builddir)/src/common/libsubprocess/libsubprocess.la \
         $(top_builddir)/src/common/libflux-core.la \
-        $(top_builddir)/src/common/libflux-internal.la
+        $(top_builddir)/src/common/libflux-internal.la \
+        $(ZMQ_LIBS)
 
 test_ldflags = \
 	-no-install
@@ -61,6 +70,10 @@ test_ldflags = \
 test_cppflags = \
         $(AM_CPPFLAGS) \
 	-I$(top_srcdir)/src/common/libtap
+
+test_libutil_la_SOURCES = \
+	test/rcmdsrv.h \
+	test/rcmdsrv.c
 
 test_cmd_t_SOURCES = test/cmd.c
 test_cmd_t_CPPFLAGS = $(test_cppflags)
@@ -73,6 +86,16 @@ test_subprocess_t_CPPFLAGS = \
 	$(test_cppflags)
 test_subprocess_t_LDADD = $(test_ldadd)
 test_subprocess_t_LDFLAGS = $(test_ldflags)
+
+test_remote_t_SOURCES = test/remote.c
+test_remote_t_CPPFLAGS = $(test_cppflags)
+test_remote_t_LDADD = $(test_ldadd)
+test_remote_t_LDFLAGS = $(test_ldflags)
+
+test_iostress_t_SOURCES = test/iostress.c
+test_iostress_t_CPPFLAGS = $(test_cppflags)
+test_iostress_t_LDADD = $(test_ldadd)
+test_iostress_t_LDFLAGS = $(test_ldflags)
 
 test_echo_SOURCES = test/test_echo.c
 

--- a/src/common/libsubprocess/server.h
+++ b/src/common/libsubprocess/server.h
@@ -21,7 +21,9 @@ typedef int (*subprocess_server_auth_f) (const flux_msg_t *msg,
 
 /* Create a subprocess server.  The handle 'h' must contain a reactor
  * created with the FLUX_REACTOR_SIGCHLD flag.  Note that there can be
- * only one reactor per process with this flag set.
+ * only one reactor per process with this flag set.  Also, it may be wise
+ * to block SIGPIPE to avoid termination when writing to stdin of a subprocess
+ * that has terminated.
  */
 subprocess_server_t *subprocess_server_create (flux_t *h,
                                                const char *local_uri,

--- a/src/common/libsubprocess/test/iostress.c
+++ b/src/common/libsubprocess/test/iostress.c
@@ -1,0 +1,305 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <unistd.h> // environ def
+#include <jansson.h>
+#include <flux/core.h>
+
+#include "ccan/array_size/array_size.h"
+#include "ccan/str/str.h"
+#include "src/common/libtap/tap.h"
+#include "src/common/libtestutil/util.h"
+#include "src/common/libczmqcontainers/czmq_containers.h"
+#include "src/common/libsubprocess/server.h"
+#include "src/common/libsubprocess/subprocess_private.h"
+#include "src/common/libioencode/ioencode.h"
+#include "src/common/libutil/stdlog.h"
+
+#include "rcmdsrv.h"
+
+struct iostress_ctx {
+    flux_t *h;
+    flux_subprocess_t *p;
+    flux_watcher_t *source;
+    flux_watcher_t *timer;
+    pid_t pid;
+    size_t linesize;
+    int linerecv;
+    int batchcount;
+    int batchlines;
+    int batchcursor;
+    bool direct;
+    const char *name;
+};
+
+static void iostress_timer_cb (flux_reactor_t *r,
+                               flux_watcher_t *w,
+                               int revents,
+                               void *arg)
+{
+    diag ("doomsday has arrived");
+    flux_reactor_stop_error (r);
+}
+
+static void iostress_start_doomsday (struct iostress_ctx *ctx, double t)
+{
+    flux_timer_watcher_reset (ctx->timer, t, 0.);
+    flux_watcher_start (ctx->timer);
+}
+
+static void iostress_output_cb (flux_subprocess_t *p, const char *stream)
+{
+    struct iostress_ctx *ctx = flux_subprocess_aux_get (p, "ctx");
+    const char *line;
+    int len;
+
+    if (!(line = flux_subprocess_read_line (p, stream, &len)))
+        diag ("%s: %s", stream, strerror (errno));
+    else if (len == 0)
+        diag ("%s: EOF", stream);
+    else {
+        //diag ("%s: %d bytes", stream, len);
+        ctx->linerecv++;
+    }
+}
+
+static void iostress_completion_cb (flux_subprocess_t *p)
+{
+    struct iostress_ctx *ctx = flux_subprocess_aux_get (p, "ctx");
+
+    diag ("%s: completion callback", ctx->name);
+
+    diag ("%s: stopping reactor", ctx->name);
+    flux_reactor_stop (flux_get_reactor (ctx->h));
+}
+
+static void iostress_state_cb (flux_subprocess_t *p,
+                               flux_subprocess_state_t state)
+{
+    struct iostress_ctx *ctx = flux_subprocess_aux_get (p, "ctx");
+
+    diag ("%s state callback state=%s",
+          ctx->name,
+          flux_subprocess_state_string (state));
+
+    switch (state) {
+        case FLUX_SUBPROCESS_INIT:
+        case FLUX_SUBPROCESS_RUNNING:
+            ctx->pid = flux_subprocess_pid (p);
+            flux_watcher_start (ctx->source); // start sourcing data
+            break;
+        case FLUX_SUBPROCESS_STOPPED:
+            break;
+        case FLUX_SUBPROCESS_EXITED: {
+            int status = flux_subprocess_status (p);
+            if (WIFEXITED (status))
+                diag ("%s: exit %d", ctx->name, WEXITSTATUS (status));
+            else if (WIFSIGNALED (status))
+                diag ("%s: %s", ctx->name, strsignal (WTERMSIG (status)));
+            // completion callback will exit the reactor, but just in case
+            iostress_start_doomsday (ctx, 2.);
+            break;
+        }
+        case FLUX_SUBPROCESS_FAILED:
+        case FLUX_SUBPROCESS_EXEC_FAILED:
+            diag ("%s: %s",
+                  ctx->name,
+                  strerror (flux_subprocess_fail_errno (p)));
+            diag ("%s: stopping reactor", ctx->name);
+            flux_reactor_stop_error (flux_get_reactor (ctx->h));
+            break;
+    }
+}
+
+static int rexec_write (flux_t *h, pid_t pid, const char *buf, int len)
+{
+    flux_future_t *f;
+    json_t *io;
+    bool eof = len > 0 ? false : true;
+
+    if (!(io = ioencode ("stdin", "0", buf, len, eof)))
+        return -1;
+    if (!(f = flux_rpc_pack (h,
+                             "rexec.write",
+                             0,
+                             FLUX_RPC_NORESPONSE,
+                             "{s:i s:O}",
+                             "pid", pid,
+                             "io", io))) {
+        json_decref (io);
+        return -1;
+    }
+    flux_future_destroy (f);
+    json_decref (io);
+    return 0;
+}
+
+static void iostress_source_cb (flux_reactor_t *r,
+                                flux_watcher_t *w,
+                                int revents,
+                                void *arg)
+{
+    struct iostress_ctx *ctx = arg;
+    char *buf;
+
+    if (!(buf = malloc (ctx->linesize)))
+        BAIL_OUT ("out of memory");
+    memset (buf, 'F', ctx->linesize - 1);
+    buf[ctx->linesize - 1] = '\n';
+
+    for (int i = 0; i < ctx->batchlines; i++) {
+        if (ctx->direct) {
+            if (rexec_write (ctx->h, ctx->pid, buf, ctx->linesize) < 0)
+                BAIL_OUT ("rexec_write failed");
+        }
+        else {
+            int len;
+            len = flux_subprocess_write (ctx->p, "stdin", buf, ctx->linesize);
+            if (len < 0) {
+                diag ("%s: source: %s", ctx->name, strerror (errno));
+                goto error;
+            }
+            if (len < ctx->linesize) {
+                diag ("%s: source: short write", ctx->name);
+                errno = ENOSPC;
+                goto error;
+            }
+        }
+    }
+    free (buf);
+    if (++ctx->batchcursor == ctx->batchcount) {
+        if (flux_subprocess_close (ctx->p, "stdin") < 0) {
+            diag ("%s: source: %s", ctx->name, strerror (errno));
+            goto error;
+        }
+        flux_watcher_stop (w);
+    }
+    return;
+error:
+    free (buf);
+    //flux_reactor_stop_error (r);
+    iostress_start_doomsday (ctx, 2.);
+}
+
+flux_subprocess_ops_t iostress_ops = {
+    .on_completion      = iostress_completion_cb,
+    .on_state_change    = iostress_state_cb,
+    .on_stdout          = iostress_output_cb,
+};
+
+bool iostress_run_check (flux_t *h,
+                         const char *name,
+                         bool direct,
+                         int stdin_bufsize,
+                         int stdout_bufsize,
+                         int batchcount,
+                         int batchlines,
+                         size_t linesize)
+{
+    char *cat_av[] = { "cat", NULL };
+    flux_cmd_t *cmd;
+    struct iostress_ctx ctx;
+    int rc;
+    bool ret = true;
+    char nbuf[16];
+
+    memset (&ctx, 0, sizeof (ctx));
+    ctx.h = h;
+    ctx.batchcount = batchcount;
+    ctx.batchlines = batchlines;
+    ctx.linesize = linesize;
+    ctx.name = name;
+    ctx.direct = direct;
+
+    if (!(cmd = flux_cmd_create (ARRAY_SIZE (cat_av) - 1, cat_av, environ)))
+        BAIL_OUT ("flux_cmd_create failed");
+    if (stdin_bufsize > 0) {
+        snprintf (nbuf, sizeof (nbuf), "%d", stdin_bufsize);
+        if (flux_cmd_setopt (cmd, "stdin_BUFSIZE", nbuf) < 0)
+            BAIL_OUT ("flux_cmd_setopt failed");
+    }
+    if (stdout_bufsize > 0) {
+        snprintf (nbuf, sizeof (nbuf), "%d", stdout_bufsize);
+        if (flux_cmd_setopt (cmd, "stdout_BUFSIZE", nbuf) < 0)
+            BAIL_OUT ("flux_cmd_setopt failed");
+    }
+    if (!(ctx.p = flux_rexec (h, FLUX_NODEID_ANY, 0, cmd, &iostress_ops)))
+        BAIL_OUT ("flux_rexec failed");
+    if (flux_subprocess_aux_set (ctx.p, "ctx", &ctx, NULL) < 0)
+        BAIL_OUT ("flux_subprocess_aux_set failed");
+
+    if (!(ctx.source = flux_prepare_watcher_create (flux_get_reactor (h),
+                                                    iostress_source_cb,
+                                                    &ctx)))
+        BAIL_OUT ("could not create prepare watcher");
+    if (!(ctx.timer = flux_timer_watcher_create (flux_get_reactor (h),
+                                                 0.,
+                                                 0.,
+                                                 iostress_timer_cb,
+                                                 &ctx)))
+        BAIL_OUT ("counld not create timer watcher");
+
+    rc = flux_reactor_run (flux_get_reactor (h), 0);
+    if (rc < 0) {
+        diag ("%s: flux_reactor_run: %s", name, strerror (errno));
+        ret = false;
+    }
+
+    diag ("%s: processed %d of %d lines", name,
+          ctx.linerecv, ctx.batchcount * ctx.batchlines);
+    if (ctx.linerecv < ctx.batchcount * ctx.batchlines)
+        ret = false;
+
+    flux_watcher_destroy (ctx.source);
+    flux_watcher_destroy (ctx.timer);
+    diag ("%s: destroying subprocess", name);
+    flux_subprocess_destroy (ctx.p);
+    flux_cmd_destroy (cmd);
+
+    return ret;
+}
+
+int main (int argc, char *argv[])
+{
+    flux_t *h;
+
+    plan (NO_PLAN);
+
+    h = rcmdsrv_create ();
+
+    ok (iostress_run_check (h, "balanced", false, 0, 0, 8, 8, 80),
+        "balanced worked");
+
+    // (remote?) stdout buffer is overun
+    // Needs further investigation as no errors are thrown and completion is
+    // not called called after subprocess exit.  The doomsday timer stops
+    // the test.
+    ok (!iostress_run_check (h, "tinystdout", false, 0, 128, 1, 1, 256),
+        "tinystdout failed as expected");
+
+    // local stdin buffer is overrun (immediately)
+    // remote stdin buffer is also overwritten
+    ok (!iostress_run_check (h, "tinystdin", false, 128, 0, 1, 1, 4096),
+        "tinystdin failed as expected");
+
+    // remote stdin buffer is overwritten using direct RPC
+    ok (!iostress_run_check (h, "tinystdin-direct", true, 128, 0, 1, 1, 4096),
+        "tinystdin-direct failed as expected");
+
+    test_server_stop (h);
+    flux_close (h);
+    done_testing ();
+    return 0;
+}
+
+// vi: ts=4 sw=4 expandtab

--- a/src/common/libsubprocess/test/rcmdsrv.c
+++ b/src/common/libsubprocess/test/rcmdsrv.c
@@ -1,0 +1,123 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <unistd.h> // environ def
+#include <signal.h>
+#include <jansson.h>
+#include <flux/core.h>
+
+#include "ccan/array_size/array_size.h"
+#include "ccan/str/str.h"
+#include "src/common/libtap/tap.h"
+#include "src/common/libtestutil/util.h"
+#include "src/common/libsubprocess/server.h"
+#include "src/common/libioencode/ioencode.h"
+#include "src/common/libutil/stdlog.h"
+
+struct rcmdsrv {
+    flux_msg_handler_t **handlers;
+};
+
+/* This allows broker log requests from the libsubprocess code to
+ * appear in test output.
+ */
+static void log_cb (flux_t *h,
+                    flux_msg_handler_t *mh,
+                    const flux_msg_t *msg,
+                    void *arg)
+{
+    const char *buf;
+    int len;
+    struct stdlog_header hdr;
+    int textlen;
+    const char *text;
+
+    if (flux_request_decode_raw (msg, NULL, (const void **)&buf, &len) == 0
+        && stdlog_decode (buf, len, &hdr, NULL, NULL, &text, &textlen) == 0)
+        diag ("LOG: %.*s\n", textlen, text);
+    else
+        diag ("LOG: could not decode message\n");
+}
+
+static const struct flux_msg_handler_spec htab[] = {
+    { FLUX_MSGTYPE_REQUEST, "log.append", log_cb, 0 },
+    FLUX_MSGHANDLER_TABLE_END,
+};
+
+static int test_server (flux_t *h, void *arg)
+{
+    int rc = -1;
+    subprocess_server_t *srv = NULL;
+    flux_msg_handler_t **handlers = NULL;
+
+    if (flux_attr_set_cacheonly (h, "rank", "0") < 0) {
+        diag ("flux_attr_set_cacheonly");
+        goto done;
+    }
+    if (!(srv = subprocess_server_create (h, "smurf", 0))) {
+        diag ("subprocess_server_create failed");
+        goto done;
+    }
+    if (flux_msg_handler_addvec (h, htab, srv, &handlers) < 0) {
+        diag ("error registering message handler");
+        goto done;
+    }
+    if (flux_reactor_run (flux_get_reactor (h), 0) < 0) {
+        diag ("flux_reactor_run failed");
+        goto done;
+    }
+    diag ("destroying subprocess server");
+    subprocess_server_destroy (srv);
+    diag ("server reactor exiting");
+    rc = 0;
+done:
+    flux_msg_handler_delvec (handlers);
+    return rc;
+}
+
+// called on flux_t handle destroy
+static void rcmdsrv_destroy (struct rcmdsrv *ctx)
+{
+    if (ctx) {
+        flux_msg_handler_delvec (ctx->handlers);
+        free (ctx);
+    };
+}
+
+flux_t *rcmdsrv_create (void)
+{
+    flux_t *h;
+    struct rcmdsrv *ctx;
+
+    if (!(ctx = calloc (1, sizeof (*ctx))))
+        BAIL_OUT ("out of memory");
+
+    // Without this, process may be terminated by SIGPIPE when writing
+    // to stdin of subprocess that has terminated
+    signal (SIGPIPE, SIG_IGN);
+
+    // N.B. test reactor is created with FLUX_REACTOR_SIGCHLD flag
+    if (!(h = test_server_create (0, test_server, NULL)))
+        BAIL_OUT ("test_server_create failed");
+    if (flux_attr_set_cacheonly (h, "rank", "0") < 0)
+        BAIL_OUT ("flux_attr_set_cacheonly failed");
+    // register log handle on this end for server-side logging
+    if (flux_msg_handler_addvec (h, htab, NULL, &ctx->handlers) < 0)
+        BAIL_OUT ("error registering message handlers");
+    flux_reactor_active_decref (flux_get_reactor (h)); // don't count logger
+    if (flux_aux_set (h, "testserver", ctx, (flux_free_f)rcmdsrv_destroy) < 0)
+        BAIL_OUT ("error storing server context in aux container");
+    return h;
+};
+
+// vi: ts=4 sw=4 expandtab

--- a/src/common/libsubprocess/test/rcmdsrv.h
+++ b/src/common/libsubprocess/test/rcmdsrv.h
@@ -1,0 +1,25 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#ifndef _SUBPROCESS_TEST_RCMDSRV_H
+#define _SUBPROCESS_TEST_RCMDSRV_H
+
+/* Start subprocess server.  Returns one end of back-to-back flux_t test
+ * handle.  Call test_server_stop (h) when done to join with server thread.
+ */
+flux_t *rcmdsrv_create (void);
+
+#endif // !_SUBPROCESS_TEST_RCMDSRV_H
+
+// vi: ts=4 sw=4 expandtab

--- a/src/common/libsubprocess/test/remote.c
+++ b/src/common/libsubprocess/test/remote.c
@@ -1,0 +1,268 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <unistd.h> // environ def
+#include <jansson.h>
+#include <flux/core.h>
+
+#include "ccan/array_size/array_size.h"
+#include "ccan/str/str.h"
+#include "src/common/libtap/tap.h"
+#include "src/common/libtestutil/util.h"
+#include "src/common/libsubprocess/server.h"
+#include "src/common/libioencode/ioencode.h"
+#include "src/common/libutil/stdlog.h"
+
+#include "rcmdsrv.h"
+
+struct simple_scorecard {
+    unsigned int completion:1;
+    unsigned int exit_nonzero:1;
+    unsigned int signaled:1;
+
+    // states
+    unsigned int init:1;
+    unsigned int running:1;
+    unsigned int failed:1;
+    unsigned int exited:1;
+    unsigned int stopped:1;
+
+    // output
+    unsigned int stdout_eof:1;
+    unsigned int stderr_eof:1;
+    unsigned int stdout_error:1;
+    unsigned int stderr_error:1;
+    int stdout_lines;
+    int stderr_lines;
+};
+
+struct simple_ctx {
+    flux_t *h;
+    struct simple_scorecard scorecard;
+};
+
+static void simple_output_cb (flux_subprocess_t *p, const char *stream)
+{
+    struct simple_ctx *ctx = flux_subprocess_aux_get (p, "ctx");
+    const char *line;
+    int len;
+
+    if (!(line = flux_subprocess_read_line (p, stream, &len)))
+        diag ("%s: %s", stream, strerror (errno));
+    else if (len == 0)
+        diag ("%s: EOF", stream);
+    else
+        diag ("%s: %d bytes", stream, len);
+
+    if (streq (stream, "stdout")) {
+        if (line == NULL)
+            ctx->scorecard.stdout_error = 1;
+        else if (len == 0)
+            ctx->scorecard.stdout_eof = 1;
+        else
+            ctx->scorecard.stdout_lines++;
+    }
+    else if (streq (stream, "stderr")) {
+        if (line == NULL)
+            ctx->scorecard.stderr_error = 1;
+        else if (len == 0)
+            ctx->scorecard.stderr_eof = 1;
+        else
+            ctx->scorecard.stderr_lines++;
+    }
+}
+
+static void simple_state_cb (flux_subprocess_t *p,
+                             flux_subprocess_state_t state)
+{
+    struct simple_ctx *ctx = flux_subprocess_aux_get (p, "ctx");
+
+    diag ("state callback state=%s", flux_subprocess_state_string (state));
+
+    switch (state) {
+        case FLUX_SUBPROCESS_INIT:
+            ctx->scorecard.init = 1;
+            break;
+        case FLUX_SUBPROCESS_RUNNING:
+            ctx->scorecard.running= 1;
+            break;
+        case FLUX_SUBPROCESS_EXITED:
+            ctx->scorecard.exited = 1;
+            break;
+        case FLUX_SUBPROCESS_FAILED:
+        case FLUX_SUBPROCESS_EXEC_FAILED:
+            ctx->scorecard.failed = 1;
+            diag ("stopping reactor");
+            flux_reactor_stop (flux_get_reactor (ctx->h));
+            break;
+        case FLUX_SUBPROCESS_STOPPED:
+            ctx->scorecard.stopped = 1;
+            break;
+    }
+}
+
+static void simple_completion_cb (flux_subprocess_t *p)
+{
+    struct simple_ctx *ctx = flux_subprocess_aux_get (p, "ctx");
+
+    diag ("completion callback");
+
+    ctx->scorecard.completion = 1;
+    if (flux_subprocess_exit_code (p) > 0)
+        ctx->scorecard.exit_nonzero = 1;
+    if (flux_subprocess_signaled (p) >= 0)
+        ctx->scorecard.signaled = 1;
+
+    diag ("stopping reactor");
+    flux_reactor_stop (flux_get_reactor (ctx->h));
+}
+
+flux_subprocess_ops_t simple_ops = {
+    .on_completion      = simple_completion_cb,
+    .on_state_change    = simple_state_cb,
+    .on_stdout          = simple_output_cb,
+    .on_stderr          = simple_output_cb,
+};
+
+
+void simple_run_check (flux_t *h,
+                       int ac,
+                       char **av,
+                       struct simple_scorecard *exp)
+{
+    flux_subprocess_t *p;
+    flux_cmd_t *cmd;
+    struct simple_ctx ctx;
+    int rc;
+
+    cmd = flux_cmd_create (ac, av, environ);
+    if (!cmd)
+        BAIL_OUT ("flux_cmd_create failed");
+
+    memset (&ctx, 0, sizeof (ctx));
+    ctx.h = h;
+    p = flux_rexec (h, FLUX_NODEID_ANY, 0, cmd, &simple_ops);
+    ok (p != NULL,
+        "%s: flux_rexec returned a subprocess object", av[0]);
+    if (!p)
+        BAIL_OUT ("flux_rexec failed");
+    if (flux_subprocess_aux_set (p, "ctx", &ctx, NULL) < 0)
+        BAIL_OUT ("flux_subprocess_aux_set failed");
+    rc = flux_reactor_run (flux_get_reactor (h), 0);
+    ok (rc >= 0,
+        "%s: client reactor ran successfully", av[0]);
+    ok (ctx.scorecard.init == exp->init,
+        "%s: subprocess state=INIT was %sreported",
+        av[0], exp->init ? "" : "not ");
+    ok (ctx.scorecard.running == exp->running,
+        "%s: subprocess state=RUNNING was %sreported",
+        av[0], exp->running ? "" : "not ");
+    ok (ctx.scorecard.exited == exp->exited,
+        "%s: subprocess state=EXITED was %sreported",
+        av[0], exp->exited ? "" : "not ");
+    ok (ctx.scorecard.failed == exp->failed,
+        "%s: subprocess state=FAILED was %sreported",
+        av[0], exp->failed ? "" : "not ");
+    ok (ctx.scorecard.stopped == exp->stopped,
+        "%s: subprocess state=STOPPED was %sreported",
+        av[0], exp->stopped ? "" : "not ");
+    ok (ctx.scorecard.completion == exp->completion,
+        "%s: subprocess completion callback was %sinvoked",
+        av[0], exp->completion ? "" : "not ");
+    ok (ctx.scorecard.exit_nonzero == exp->exit_nonzero,
+        "%s: subprocess did%s exit with nonzero exit code",
+        av[0], exp->exit_nonzero ? "" : " not");
+    ok (ctx.scorecard.signaled == exp->signaled,
+        "%s: subprocess was%s signaled",
+        av[0], exp->signaled ? "" : " not");
+    ok (ctx.scorecard.stdout_lines == exp->stdout_lines,
+        "%s: subprocess stdout got %d lines",
+        av[0], exp->stdout_lines);
+    ok (ctx.scorecard.stdout_eof == exp->stdout_eof,
+        "%s: subprocess stdout %s EOF",
+        av[0], exp->stdout_eof ? "got" : "did not get");
+    ok (ctx.scorecard.stdout_error == exp->stdout_error,
+        "%s: subprocess stdout %s error",
+        av[0], exp->stdout_error ? "got" : "did not get");
+    flux_cmd_destroy (cmd);
+    flux_subprocess_destroy (p);
+}
+
+void simple_test (flux_t *h)
+{
+    struct simple_scorecard exp;
+
+    char *true_av[] = { "/bin/true", NULL };
+    memset (&exp, 0, sizeof (exp));
+    exp.running = 1;
+    exp.exited = 1;
+    exp.completion = 1;
+    exp.stdout_eof = 1;
+    exp.stderr_eof = 1;
+    simple_run_check (h, ARRAY_SIZE (true_av) - 1, true_av, &exp);
+
+    char *false_av[] = { "/bin/false", NULL };
+    memset (&exp, 0, sizeof (exp));
+    exp.running = 1;
+    exp.exited = 1;
+    exp.completion = 1;
+    exp.exit_nonzero = 1;
+    exp.stdout_eof = 1;
+    exp.stderr_eof = 1;
+    simple_run_check (h, ARRAY_SIZE (false_av) - 1, false_av, &exp);
+#if 0
+    // This fails differently on el7 - need to investigate
+    char *nocmd_av[] = { "/nocmd", NULL };
+    memset (&exp, 0, sizeof (exp));
+    exp.failed = 1;
+    simple_run_check (h, ARRAY_SIZE (nocmd_av) - 1, nocmd_av, &exp);
+#endif
+    char *echo_av[] = { "/bin/sh", "-c", "echo hello", NULL };
+    memset (&exp, 0, sizeof (exp));
+    exp.running = 1;
+    exp.exited = 1;
+    exp.completion = 1;
+    exp.stdout_lines = 1;
+    exp.stdout_eof = 1;
+    exp.stderr_eof = 1;
+    simple_run_check (h, ARRAY_SIZE (echo_av) - 1, echo_av, &exp);
+
+    char *echo2_av[] = { "/bin/sh", "-c", "echo hello >&2", NULL };
+    memset (&exp, 0, sizeof (exp));
+    exp.running = 1;
+    exp.exited = 1;
+    exp.completion = 1;
+    exp.stderr_lines = 1;
+    exp.stdout_eof = 1;
+    exp.stderr_eof = 1;
+    simple_run_check (h, ARRAY_SIZE (echo2_av) - 1, echo2_av, &exp);
+}
+
+int main (int argc, char *argv[])
+{
+    flux_t *h;
+
+    plan (NO_PLAN);
+
+    h = rcmdsrv_create ();
+
+    simple_test (h);
+
+    test_server_stop (h);
+    flux_close (h);
+
+    done_testing ();
+    return 0;
+}
+
+// vi: ts=4 sw=4 expandtab


### PR DESCRIPTION
Problem: we noticed that flux stopped accepting job requests on one of the production login nodes after some "channel" errors on the validator subprocess (#4920)

This fixes issue #4920 and improves the error handling and logging around subprocess channel overflow errors.  Now when this occurs you get
```
broker.err[0]: Error writing 4707 bytes to subprocess pid 4077290 stdin: No space left on device
job-ingest.err[0]: job-validator[0]: Failed: No space left on device
```
and the ingest worker is restarted.