### PR TITLE
broker: allow a file argument to `-c, --config-path` in TOML or JSON

### DIFF
--- a/doc/man1/flux-broker.rst
+++ b/doc/man1/flux-broker.rst
@@ -45,6 +45,12 @@ OPTIONS
 **-S, --setattr**\ =\ *ATTR=VAL*
    Set initial value for broker attribute.
 
+**-c, --conf-path=**\ =\ *PATH*
+   Set the PATH to broker configuration. If PATH is a directory, then
+   read all TOML files from that directory. If PATH is a file, then load
+   configuration as JSON if the file extension is ``.json``, otherwise
+   load the file as TOML.
+
 
 RESOURCES
 =========

--- a/doc/man5/flux-config.rst
+++ b/doc/man5/flux-config.rst
@@ -6,21 +6,27 @@ DESCRIPTION
 ===========
 
 Flux normally operates without configuration files.  If configuration is
-needed, the :man1:`flux-broker` **--config-path=DIR** option may be used
-to instruct Flux to parse all files matching the glob **DIR/*.toml**.
-Alternatively, the FLUX_CONF_DIR environment variable may be set the config
-directory path.  If both are set, the command line argument takes precedence.
-The option value must be a directory, not a file.
+needed, the :man1:`flux-broker` **--config-path=PATH** option may be used
+to instruct Flux to parse a config file or, if **PATH** is a directory, all
+files matching the glob **PATH/*.toml**.  Alternatively, the FLUX_CONF_DIR
+environment variable may be used to set the configuration file or directory
+path. If both are set, the command line argument takes precedence.
 
 The Flux systemd unit file starts the system instance broker with
 ``--config-path=${sysconfdir}/flux/system/conf.d``.  Further discussion of the
 system instance configuration as a whole may be found in the Flux
 Administrator's Guide.
 
-Flux configuration files follow the TOML file format, with configuration
-subdivided by function into separate TOML tables.  The tables may all appear
-in a single ``.toml`` file or be fragmented in multiple files.  For example,
-the Flux Administrator's Guide suggests one file per top level TOML table.
+Flux configuration files typically follow the TOML file format,
+with configuration subdivided by function into separate TOML tables.
+The tables may all appear in a single ``.toml`` file or be fragmented in
+multiple files.  For example, the Flux Administrator's Guide suggests one
+file per top level TOML table.
+
+If the **PATH** value is a regular file, the configuration may optionally be
+provided as JSON. This allows the output of ``flux config get`` to be read
+by another Flux instance. A JSON config file must have the file extension
+``.json``, otherwise it is assumed to be TOML.
 
 Each Flux broker parses configuration files independently, however it is
 assumed that config files are identical across the brokers of a given instance.

--- a/doc/man7/flux-broker-attributes.rst
+++ b/doc/man7/flux-broker-attributes.rst
@@ -150,10 +150,10 @@ conf.shell_pluginpath [Updates: C, R]
    for shell plugins.  Default: ``${prefix}/lib/flux/shell/plugins``.
 
 config.path [Updates: see below]
-   A directory containing ``*.toml`` config files for this Flux instance.
-   This attribute may be set via the FLUX_CONF_DIR environment variable,
-   or the :man1:`flux-broker` ``--config-path`` command line argument.
-   Default: none.  See also :man5:`flux-config`.
+   A config file or directory (containing ``*.toml`` config files) for
+   this Flux instance. This attribute may be set via the FLUX_CONF_DIR
+   environment variable, or the :man1:`flux-broker` ``--config-path``
+   command line argument.  Default: none.  See also :man5:`flux-config`.
 
 
 TREE BASED OVERLAY NETWORK

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -115,7 +115,7 @@ static struct optparse_option opts[] = {
     { .name = "setattr",    .key = 'S', .has_arg = 1, .arginfo = "ATTR=VAL",
       .usage = "Set broker attribute", },
     { .name = "config-path",.key = 'c', .has_arg = 1, .arginfo = "PATH",
-      .usage = "Set broker config directory (default: none)", },
+      .usage = "Set broker config from PATH (default: none)", },
     OPTPARSE_TABLE_END,
 };
 

--- a/src/cmd/builtin/config.c
+++ b/src/cmd/builtin/config.c
@@ -277,7 +277,7 @@ static struct optparse_option get_opts[] = {
 static struct optparse_subcommand config_subcmds[] = {
     { "load",
       "[PATH]",
-      "Load broker configuration from stdin or TOML directory PATH",
+      "Load broker configuration from stdin or PATH",
       config_load,
       0,
       NULL,

--- a/src/common/libflux/conf.c
+++ b/src/common/libflux/conf.c
@@ -26,6 +26,7 @@
 #include "src/common/libtomlc99/toml.h"
 #include "src/common/libutil/tomltk.h"
 #include "src/common/libutil/errprintf.h"
+#include "ccan/str/str.h"
 
 #include "conf.h"
 #include "conf_private.h"
@@ -91,7 +92,7 @@ const char *flux_conf_builtin_get (const char *name,
             break;
     }
     for (entry = &builtin_tab[0]; entry->key != NULL; entry++) {
-        if (name && !strcmp (entry->key, name)) {
+        if (name && streq (entry->key, name)) {
             val = intree ? entry->val_intree : entry->val_installed;
             break;
         }

--- a/src/common/libflux/conf.c
+++ b/src/common/libflux/conf.c
@@ -151,9 +151,24 @@ flux_conf_t *flux_conf_copy (const flux_conf_t *conf)
     return cpy;
 }
 
-static int conf_update (flux_conf_t *conf,
-                        const char *filename,
-                        flux_error_t *error)
+static int conf_update_obj (flux_conf_t *conf,
+                            const char *filename,
+                            json_t *obj,
+                            flux_error_t *error)
+{
+    if (json_object_update (conf->obj, obj) < 0) {
+        errprintf (error,
+                   "%s: updating JSON object: out of memory",
+                   filename);
+        errno = ENOMEM;
+        return -1;
+    }
+    return 0;
+}
+
+static int conf_update_toml (flux_conf_t *conf,
+                             const char *filename,
+                             flux_error_t *error)
 {
     struct tomltk_error toml_error;
     toml_table_t *tab;
@@ -182,13 +197,8 @@ static int conf_update (flux_conf_t *conf,
                    strerror (errno));
         goto error;
     }
-    if (json_object_update (conf->obj, obj) < 0) {
-        errprintf (error,
-                   "%s: updating JSON object: out of memory",
-                   filename);
-        errno = ENOMEM;
+    if (conf_update_obj (conf, filename, obj, error) < 0)
         goto error;
-    }
     json_decref (obj);
     toml_free (tab);
     return 0;
@@ -224,7 +234,7 @@ void conf_globerr (flux_error_t *error, const char *pattern, int rc)
     errno = entry->errnum;
 }
 
-flux_conf_t *flux_conf_parse (const char *path, flux_error_t *error)
+static flux_conf_t *conf_parse_dir (const char *path, flux_error_t *error)
 {
     flux_conf_t *conf;
     glob_t gl;
@@ -232,11 +242,6 @@ flux_conf_t *flux_conf_parse (const char *path, flux_error_t *error)
     size_t i;
     char pattern[4096];
 
-    if (!path) {
-        errno = EINVAL;
-        errprintf (error, "%s", strerror (errno));
-        return NULL;
-    }
     if (access (path, R_OK | X_OK) < 0) {
         errprintf (error, "%s: %s", path, strerror (errno));
         return NULL;
@@ -254,7 +259,7 @@ flux_conf_t *flux_conf_parse (const char *path, flux_error_t *error)
     rc = glob (pattern, GLOB_ERR, NULL, &gl);
     if (rc == 0) {
         for (i = 0; i < gl.gl_pathc; i++) {
-            if (conf_update (conf, gl.gl_pathv[i], error) < 0)
+            if (conf_update_toml (conf, gl.gl_pathv[i], error) < 0)
                 goto error_glob;
         }
         globfree (&gl);
@@ -270,6 +275,39 @@ error_glob:
 error:
     flux_conf_decref (conf);
     return NULL;
+}
+
+static flux_conf_t *conf_parse_file (const char *path, flux_error_t *error)
+{
+    flux_conf_t *conf;
+
+    if (!(conf = flux_conf_create ())) {
+        errprintf (error, "%s: %s", path, strerror (errno));
+        return NULL;
+    }
+    if (conf_update_toml (conf, path, error) < 0) {
+        flux_conf_decref (conf);
+        return NULL;
+    }
+    return conf;
+}
+
+flux_conf_t *flux_conf_parse (const char *path, flux_error_t *error)
+{
+    struct stat st;
+
+    if (!path) {
+        errno = EINVAL;
+        errprintf (error, "%s", strerror (errno));
+        return NULL;
+    }
+    if (stat (path, &st) < 0) {
+        errprintf (error, "stat: %s: %s", path, strerror (errno));
+        return NULL;
+    }
+    if (S_ISDIR(st.st_mode))
+        return conf_parse_dir (path, error);
+    return conf_parse_file (path, error);
 }
 
 int flux_set_conf (flux_t *h, const flux_conf_t *conf)

--- a/src/common/libflux/conf.h
+++ b/src/common/libflux/conf.h
@@ -48,7 +48,8 @@ void flux_conf_decref (const flux_conf_t *conf);
  */
 int flux_conf_reload_decode (const flux_msg_t *msg, const flux_conf_t **conf);
 
-/* Parse *.toml in 'path' directory.
+/* Parse TOML config in 'path' and return a new flux_conf_t on success.
+ * If path is a directory, then parse all files matching *.toml in path.
  */
 flux_conf_t *flux_conf_parse (const char *path, flux_error_t *error);
 

--- a/src/common/libflux/test/conf.c
+++ b/src/common/libflux/test/conf.c
@@ -124,6 +124,27 @@ void test_basic (void)
     create_test_file (dir, "02", path2, sizeof (path2), tab2);
     create_test_file (dir, "03", path3, sizeof (path3), tab3);
 
+    /* Parse of one file works
+     */
+    conf = flux_conf_parse (path3, &error);
+    ok (conf != NULL,
+        "flux_conf_parse successfully parsed a single file");
+    if (!conf)
+        BAIL_OUT ("cannot continue without config object");
+
+    /* Check table from path3 toml file
+     */
+    i = 0;
+    rc = flux_conf_unpack (conf,
+                           &error,
+                           "{s:{s:i}}",
+                           "tab3",
+                           "id", &i);
+    ok (rc == 0 && i == 3,
+        "unpacked integer from [tab3] and got expected value");
+
+    flux_conf_decref (conf);
+
     /* Parse it
      */
     conf = flux_conf_parse (dir, &error);
@@ -237,6 +258,12 @@ void test_basic (void)
      * all updates after any one failure
      */
     create_test_file (dir, "99", invalid, sizeof (invalid), "key = \n");
+
+    conf = flux_conf_parse (invalid, &error);
+    ok (conf == NULL,
+        "flux_conf_parse failed on bad individual file");
+    like (error.text, "99.*\\.toml",
+          "Failed file contained in error.text");
 
     conf = flux_conf_parse (dir, &error);
     ok (conf == NULL,

--- a/t/t0013-config-file.t
+++ b/t/t0013-config-file.t
@@ -32,7 +32,25 @@ test_expect_success 'flux broker works with empty config directory' '
 	flux broker ${ARGS} -c empty flux getattr config.path >empty.out &&
 	test_cmp empty.exp empty.out
 '
-
+test_expect_success 'flux broker works with empty config file' '
+	touch null.toml &&
+	cat <<-EOT >null.exp &&
+	null.toml
+	EOT
+	flux broker ${ARGS} -c null.toml flux getattr config.path >null.out &&
+	test_cmp null.exp null.out
+'
+test_expect_success 'flux broker works with empty object config file (json)' '
+	cat <<-EOF >empty.json &&
+	{}
+	EOF
+	cat <<-EOT >empty-json.exp &&
+	empty.json
+	EOT
+	flux broker ${ARGS} -c empty.json \
+		flux getattr config.path >empty-json.out &&
+	test_cmp empty-json.exp empty-json.out
+'
 test_expect_success 'FLUX_CONF_DIR also works to specify config dir' '
 	FLUX_CONF_DIR=empty flux broker ${ARGS} \
 		      flux getattr config.path >empty2.out &&
@@ -52,6 +70,13 @@ test_expect_success 'broker fails with invalid TOML' '
 	test_must_fail flux broker ${ARGS} -c conf1 /bin/true
 '
 
+test_expect_success 'broker fails with invalid TOML file' '
+	cat <<-EOT >invalid.toml &&
+	[bootstrap]
+	bad-toml
+	EOT
+	test_must_fail flux broker ${ARGS} -c invalid.toml /bin/true
+'
 #
 # [bootstrap] tests
 #


### PR DESCRIPTION
Currently, the broker can only read configuration as a set of `*.toml` files from a configuration directory. This is because the underlying `flux_conf_parse(3)` call always appends `/*.toml` to its argument and reads all matching files.

This PR extends `flux_conf_parse(3)` to detect if its path argument is a directory, and if not, attempts to read the file directly. Additionally, if the file has the extension `.json`, parse the config as JSON instead of TOML.

If the path argument is a directory, `flux_conf_parse(3)` still only reads TOML from that directory, to avoid inadvertently parsing some JSON files that wer ignored before.

Thi ability to parse a  file allows more convenient use of simple config files for the broker (you don't have to put your config file in an otherwise empty directory). Parsing JSON allows the output of `flux config get` from one instance to be read by another (since we can easily convert TOML to JSON, but not the other way around). It will also make it easier to stash configuration in jobspec in the future.

I tried to find and update most references to the prior requirement that `--config-path=PATH` point to a dir.