### PR TITLE
improve error message in Python frontend utilities when broker is not running

### DIFF
--- a/src/bindings/python/flux/util.py
+++ b/src/bindings/python/flux/util.py
@@ -218,7 +218,13 @@ class CLIMain(object):
             exit_code = ex
         except Exception as ex:  # pylint: disable=broad-except
             exit_code = 1
-            self.logger.error(str(ex))
+            # Prefer '{strerror}[: {filename}' error message over default
+            # OSError string representation which includes useless
+            # `[Error N]` prefix in output.
+            errmsg = getattr(ex, "strerror", None) or str(ex)
+            if getattr(ex, "filename", None):
+                errmsg += f": '{ex.filename}'"
+            self.logger.error(errmsg)
             self.logger.debug(traceback.format_exc())
         finally:
             logging.shutdown()

--- a/src/connectors/local/local.c
+++ b/src/connectors/local/local.c
@@ -15,6 +15,7 @@
 #include <flux/core.h>
 
 #include "src/common/librouter/usock.h"
+#include "src/common/libutil/errprintf.h"
 
 struct local_connector {
     struct usock_client *uclient;
@@ -192,8 +193,13 @@ flux_t *connector_init (const char *path, int flags, flux_error_t *errp)
 
     if (!(ctx->path = strdup (path)))
         goto error;
-    if (local_connect (ctx) < 0)
+    if (local_connect (ctx) < 0) {
+        if (errno == ENOENT)
+            errprintf (errp,
+                       "broker socket %s was not found",
+                       path);
         goto error;
+    }
     if (!(ctx->h = flux_handle_create (ctx, &handle_ops, flags)))
         goto error;
     return ctx->h;


### PR DESCRIPTION
This PR is a stab at improving the error message from most utilities when `flux_open()` fails. Specifically, when the local connector socket is not found, an error more descriptive than "No such file or directory" is set in the `flux_error_t` of `flux_open_ex(3)` as suggested by @garlick, e.g.:
```
flux-jobs: ERROR: Unable to connect to Flux: broker socket /run/flux/local was not found
```

In other cases, `strerror()` is still used, e.g.
```console
$ FLUX_URI=local:///tmp src/cmd/flux jobs
flux-jobs: ERROR: Unable to connect to Flux: Connection refused
```
which seems about as clear as you can get.

This only works for Python utilities since many C based commands have not switched to `flux_open_ex(3)`.

In addition, error messages from most Python utilities are simplified by attempting to drop the unnecessary `[Error N]` prefix in the `CLIMain()` utility decorator.