### PR TITLE
Support {{tmpdir}} in shell mustache templates and simplify batch jobspec construction

### DIFF
--- a/src/bindings/python/flux/job/Jobspec.py
+++ b/src/bindings/python/flux/job/Jobspec.py
@@ -902,20 +902,18 @@ class JobspecV1(Jobspec):
         if not script.startswith("#!"):
             raise ValueError(f"{jobname} does not appear to start with '#!'")
         args = () if args is None else args
-        jobspec = cls.from_command(
-            command=[jobname, *args],  # argv[0] will be replaced with the script
-            num_tasks=num_slots,
-            cores_per_task=cores_per_slot,
-            gpus_per_task=gpus_per_slot,
+        jobspec = cls.from_nest_command(
+            command=["{{tmpdir}}/script", *args],
+            num_slots=num_slots,
+            cores_per_slot=cores_per_slot,
+            gpus_per_slot=gpus_per_slot,
             num_nodes=num_nodes,
+            broker_opts=broker_opts,
             exclusive=exclusive,
         )
-        jobspec.setattr_shell_option("per-resource.type", "node")
-        jobspec.setattr_shell_option("mpi", "none")
         #  Copy script contents into jobspec
         jobspec.setattr("system.batch.script", script)
-        if broker_opts is not None:
-            jobspec.setattr("system.batch.broker-opts", broker_opts)
+        jobspec.setattr("system.job.name", jobname)
         return jobspec
 
     @classmethod

--- a/src/bindings/python/flux/job/Jobspec.py
+++ b/src/bindings/python/flux/job/Jobspec.py
@@ -868,34 +868,36 @@ class JobspecV1(Jobspec):
         broker_opts=None,
         exclusive=False,
     ):
-        """Create a Jobspec describing a nested Flux instance controlled by a script.
+        """
+        Create a Jobspec describing a nested Flux instance controlled by
+        a script.
 
         The nested Flux instance will execute the script with the given
-        command-line arguments after copying it and setting the executable bit.
-        Conceptually, this differs from the `from_nest_command`, which also creates a
-        nested Flux instance, in that it a) requires the initial program of the new
-        instance to be an executable text file and b) creates the initial program
-        from a string rather than using an executable existing somewhere on the
-        filesystem.
+        command-line arguments after copying it and setting the executable
+        bit.  Conceptually, this differs from the `from_nest_command`,
+        which also creates a nested Flux instance, in that it a) requires
+        the initial program of the new instance to be an executable text
+        file and b) creates the initial program from a string rather than
+        using an executable existing somewhere on the filesystem.
 
         Use setters to assign additional properties.
 
-        :param script: contents of the script to execute, as a string. The
-            script should have a shebang (e.g. `#!/bin/sh`) at the top.
-        :param jobname: name to use as the argv[0] for this job.
-            This will be the default job name reported by Flux.
-            (Note the actual argv is overridden by the job shell when executed.)
-        :type jobname: str
-        :param args: arguments to pass to `script`
-        :type args: iterable of `str`
-        :param num_slots: number of resource slots to create. Slots are an abstraction,
-            and are only used (along with `cores_per_slot` and `gpus_per_slot`) to
-            determine the nested instance's allocation size and layout.
-        :param cores_per_slot: number of cores to allocate per slot
-        :param gpus_per_slot: number of GPUs to allocate per slot
-        :param num_nodes: distribute allocated resource slots across N individual nodes
-        :param broker_opts: options to pass to the new Flux broker
-        :type broker_opts: iterable of str
+        Args:
+            script (str): contents of the script to execute, as a string. The
+                script should have a shebang (e.g. `#!/bin/sh`) at the top.
+            jobname (str): name to use for system.job.name attribute This will
+                be the default job name reported by Flux.
+            args (iterable of `str`): arguments to pass to `script`
+            num_slots (int): number of resource slots to create. Slots are an
+                abstraction, and are only used (along with `cores_per_slot`
+                and `gpus_per_slot`) to determine the nested instance's
+                allocation size and layout.
+            cores_per_slot (int): number of cores to allocate per slot
+            gpus_per_slot (int): number of GPUs to allocate per slot
+            num_nodes (int): distribute allocated resource slots across N
+                individual nodes
+            broker_opts (iterable of `str`): options to pass to the new Flux
+                broker
         """
         if not script.startswith("#!"):
             raise ValueError(f"{jobname} does not appear to start with '#!'")
@@ -927,25 +929,30 @@ class JobspecV1(Jobspec):
         broker_opts=None,
         exclusive=False,
     ):
-        """Create a Jobspec describing a nested Flux instance controlled by `command`.
+        """
+        Create a Jobspec describing a nested Flux instance controlled by
+        `command`.
 
-        Conceptually, this differs from the `from_batch_command` method in that a)
-        the initial program of the nested Flux instance can be any executable
-        on the file system, not just a text file and b) the executable is not
-        copied at submission time.
+        Conceptually, this differs from the `from_batch_command` method
+        in that a) the initial program of the nested Flux instance can
+        be any executable on the file system, not just a text file and b)
+        the executable is not copied at submission time.
 
         Use setters to assign additional properties.
 
-        :param command: initial program for the nested Flux instance
-        :type command: iterable of str
-        :param num_slots: number of resource slots to create. Slots are an abstraction,
-            and are only used (along with `cores_per_slot` and `gpus_per_slot`) to
-            determine the nested instance's allocation size and layout.
-        :param cores_per_slot: number of cores to allocate per slot
-        :param gpus_per_slot: number of GPUs to allocate per slot
-        :param num_nodes: distribute allocated resource slots across N individual nodes
-        :param broker_opts: options to pass to the new Flux broker
-        :type broker_opts: iterable of str
+        Args:
+            command (iterable of `str`): initial program for the nested Flux
+            instance
+            num_slots (int): number of resource slots to create. Slots are
+                an abstraction, and are only used (along with `cores_per_slot`
+                and `gpus_per_slot`) to determine the nested instance's
+                allocation size and layout.
+            cores_per_slot (int): number of cores to allocate per slot
+            gpus_per_slot (int): number of GPUs to allocate per slot
+            num_nodes (int): distribute allocated resource slots across N
+                individual nodes
+            broker_opts (iterable of `str`): options to pass to the new Flux
+                broker
         """
         broker_opts = () if broker_opts is None else broker_opts
         jobspec = cls.from_command(

--- a/src/shell/tmpdir.c
+++ b/src/shell/tmpdir.c
@@ -72,6 +72,19 @@ static int mkjobtmp_tmpdir (flux_shell_t *shell,
     return 0;
 }
 
+static int mustache_render_tmpdir (flux_plugin_t *p,
+                                   const char *topic,
+                                   flux_plugin_arg_t *args,
+                                   void *data)
+{
+    flux_shell_t *shell = data;
+    const char *jobtmp = flux_shell_getenv (shell, "FLUX_JOB_TMPDIR");
+    return flux_plugin_arg_pack (args,
+                                 FLUX_PLUGIN_ARG_OUT,
+                                "{s:s}",
+                                "result", jobtmp);
+}
+
 static int tmpdir_init (flux_plugin_t *p,
                         const char *topic,
                         flux_plugin_arg_t *args,
@@ -103,6 +116,12 @@ static int tmpdir_init (flux_plugin_t *p,
      */
     if (flux_shell_setenvf (shell, 1, "FLUX_JOB_TMPDIR", "%s", jobtmp) < 0)
         shell_die_errno (1, "error updating job environment");
+
+    if (flux_plugin_add_handler (p,
+                                 "mustache.render.tmpdir",
+                                 mustache_render_tmpdir,
+                                 shell) < 0)
+        shell_die_errno (1, "unable to register mustache template callback");
 
     return 0;
 }

--- a/t/batch/jobspec/v0.47.json
+++ b/t/batch/jobspec/v0.47.json
@@ -1,0 +1,55 @@
+{
+  "attributes": {
+    "system": {
+      "batch": {
+        "broker-opts": [
+          "-Stestattr=foo"
+        ],
+        "script": "#!/bin/sh\ntest $(flux getattr testattr) = \"foo\"\n"
+      },
+      "cwd": "/tmp",
+      "duration": 0,
+      "environment": {
+        "PATH": "/bin:/usr/bin"
+      },
+      "shell": {
+        "options": {
+          "output": {
+            "stdout": {
+              "path": "flux-{{id}}.out",
+              "type": "file"
+            }
+          },
+          "per-resource": {
+            "type": "node"
+          }
+        }
+      }
+    }
+  },
+  "resources": [
+    {
+      "count": 1,
+      "label": "task",
+      "type": "slot",
+      "with": [
+        {
+          "count": 1,
+          "type": "core"
+        }
+      ]
+    }
+  ],
+  "tasks": [
+    {
+      "command": [
+        "hostname"
+      ],
+      "count": {
+        "per_slot": 1
+      },
+      "slot": "task"
+    }
+  ],
+  "version": 1
+}

--- a/t/t2605-job-shell-output-redirection-standalone.t
+++ b/t/t2605-job-shell-output-redirection-standalone.t
@@ -263,6 +263,27 @@ test_expect_success HAVE_JQ "flux-shell: bad output mustache template is not ren
 	grep stderr:baz {{id.x}}.out
 '
 
+test_expect_success HAVE_JQ "flux-shell: unknown mustache template is not rendered" '
+	cat j1echoboth \
+	    |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
+	    |  $jq ".attributes.system.shell.options.output.stdout.path = \"{{foo}}.out\"" \
+	    > j1-mustache-error3 &&
+	${FLUX_SHELL} -v -s -r 0 -j j1-mustache-error3 -R R1 1234 &&
+	grep stdout:baz {{foo}}.out &&
+	grep stderr:baz {{foo}}.out
+'
+
+test_expect_success HAVE_JQ "flux-shell: too large mustache template is not rendered" '
+	tmpl=$(printf "%0.sf" $(seq 0 120)) &&
+	cat j1echoboth \
+	    |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
+	    |  $jq ".attributes.system.shell.options.output.stdout.path = \"{{$tmpl}}.out\"" \
+	    > j1-mustache-error4 &&
+	${FLUX_SHELL} -v -s -r 0 -j j1-mustache-error4 -R R1 1234 &&
+	grep stdout:baz {{$tmpl}}.out &&
+	grep stderr:baz {{$tmpl}}.out
+'
+
 #
 # output corner case tests
 #

--- a/t/t2613-job-shell-batch.t
+++ b/t/t2613-job-shell-batch.t
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-test_description='Test flux-shell per-reosurce and batch support'
+test_description='Test flux-shell per-resource and batch support'
 
 . `dirname $0`/sharness.sh
 

--- a/t/t2613-job-shell-batch.t
+++ b/t/t2613-job-shell-batch.t
@@ -47,4 +47,15 @@ test_expect_success 'flux-shell: per-resource type=node works' '
 	EOF
 	test_cmp per-node.expected per-node.out
 '
+test_expect_success HAVE_JQ 'flux-shell: historical batch jobspec still work' '
+	for spec in $SHARNESS_TEST_SRCDIR/batch/jobspec/*.json; do
+		input=$(basename $spec) &&
+		cat $spec |
+		    jq -S ".attributes.system.environment.PATH=\"$PATH\"" \
+		    >$input &&
+		flux job submit --flags=waitable $input
+	done &&
+	flux job attach $(flux job last) &&
+	flux job wait --all --verbose
+'
 test_done


### PR DESCRIPTION
The shell `batch` plugin needs to rewrite the job arguments because the batch script is written to a random filename in TMPDIR. This unforutunately requires different handling of "nested" jobspec (i.e. jobspec that creates a subinstance) between `flux mini alloc` and `flux mini batch`.

Now that there is a `FLUX_JOB_TMPDIR`, write the job script there as `$FLUX_JOB_TMPDIR/script` so the batch script is always in a well known location.

Extend the shell mustache rendere to allow plugins to fulfill templates by subscribing to the callback topic `mustache.render.<name>`. Extend the `tmpdir` plugin to substitute `{{tmpdir}}` with `FLUX_JOB_TMPDIR`.

Finally, refactor the Jobspec `from_batch_command()` method to use `from_nest_command()`, a batch jobspec is now just a special case of a `flux mini alloc` jobspec. The command line becomes `flux broker [broker_opts] {{tmpdir}}/script [options]...`.

The batch plugin now checks for initial arguments of `flux broker` or `flux start` and skips rewriting args in that case. Otherwise it behaves as before to handle running older jobspecs which may be queued after a flux-core upgrade.

This PR could be split into 2 or 3 separate PRs if that would be clearer, just wasn't sure if the extra work that would entail would be worth it.

Also, this is built on top of #4942 to avoid conflicts in `flux-mini.py`.
