### PR TITLE
libsubprocess: drop FLUX_SUBPROCESS_EXEC_FAILED state

### DIFF
--- a/src/broker/runat.c
+++ b/src/broker/runat.c
@@ -179,7 +179,6 @@ static void state_change_cb (flux_subprocess_t *p,
 
     switch (state) {
         case FLUX_SUBPROCESS_INIT:
-        case FLUX_SUBPROCESS_EXEC_FAILED:
         case FLUX_SUBPROCESS_EXITED:
         case FLUX_SUBPROCESS_FAILED:
             break;

--- a/src/cmd/flux-exec.c
+++ b/src/cmd/flux-exec.c
@@ -138,11 +138,6 @@ void state_cb (flux_subprocess_t *p, flux_subprocess_state_t state)
     }
     else if (state == FLUX_SUBPROCESS_EXITED)
         exited++;
-    else if (state == FLUX_SUBPROCESS_EXEC_FAILED) {
-        /* EXEC_FAILED means RUNNING never reached, so must increment started */
-        started++;
-        exited++;
-    }
     else if (state == FLUX_SUBPROCESS_FAILED) {
         /* FLUX_SUBPROCESS_FAILED is a catch all error case, no way to
          * know if process started or not.  So we cheat with a
@@ -160,8 +155,7 @@ void state_cb (flux_subprocess_t *p, flux_subprocess_state_t state)
             flux_watcher_stop (stdin_w);
     }
 
-    if (state == FLUX_SUBPROCESS_EXEC_FAILED
-        || state == FLUX_SUBPROCESS_FAILED) {
+    if (state == FLUX_SUBPROCESS_FAILED) {
         flux_cmd_t *cmd = flux_subprocess_get_cmd (p);
         int errnum = flux_subprocess_fail_errno (p);
         int ec = 1;

--- a/src/cmd/flux-start.c
+++ b/src/cmd/flux-start.c
@@ -381,7 +381,6 @@ static void state_cb (flux_subprocess_t *p, flux_subprocess_state_t state)
 
     switch (state) {
         case FLUX_SUBPROCESS_INIT:
-        case FLUX_SUBPROCESS_EXEC_FAILED: // can't happen here - rexec only
             break;
         case FLUX_SUBPROCESS_RUNNING:
             client_run_respond (cli, 0);

--- a/src/common/libsubprocess/Makefile.am
+++ b/src/common/libsubprocess/Makefile.am
@@ -39,13 +39,15 @@ TESTS = \
 	test_cmd.t \
 	test_subprocess.t \
 	test_remote.t \
-	test_iostress.t
+	test_iostress.t \
+	test_iochan.t
 
 check_PROGRAMS = \
 	$(TESTS) \
 	test_echo \
 	test_multi_echo \
-	test_fork_sleep
+	test_fork_sleep \
+	test_fdcopy
 
 check_LTLIBRARIES = test/libutil.la
 
@@ -97,7 +99,16 @@ test_iostress_t_CPPFLAGS = $(test_cppflags)
 test_iostress_t_LDADD = $(test_ldadd)
 test_iostress_t_LDFLAGS = $(test_ldflags)
 
+test_iochan_t_SOURCES = test/iochan.c
+test_iochan_t_CPPFLAGS = \
+	-DTEST_SUBPROCESS_DIR=\"$(top_builddir)/src/common/libsubprocess/\" \
+	$(test_cppflags)
+test_iochan_t_LDADD = $(test_ldadd)
+test_iochan_t_LDFLAGS = $(test_ldflags)
+
 test_echo_SOURCES = test/test_echo.c
+
+test_fdcopy_SOURCES = test/fdcopy.c
 
 test_multi_echo_SOURCES = test/test_multi_echo.c
 

--- a/src/common/libsubprocess/fork.c
+++ b/src/common/libsubprocess/fork.c
@@ -257,8 +257,6 @@ static int local_exec (flux_subprocess_t *p)
             return -1;
         p->status = status;
 
-        /* spiritually FLUX_SUBPROCESS_EXEC_FAILED state at this
-         * point */
         errno = p->exec_failed_errno;
         return -1;
     }

--- a/src/common/libsubprocess/local.c
+++ b/src/common/libsubprocess/local.c
@@ -376,8 +376,7 @@ static void child_watch_cb (flux_reactor_t *r, flux_watcher_t *w,
 
     if (WIFEXITED (p->status) || WIFSIGNALED (p->status)) {
 
-        /* remote/server code may have set EXEC_FAILED or
-         * FAILED on fatal errors.
+        /* remote/server code may have set FAILED on fatal errors.
          */
         if (p->state == FLUX_SUBPROCESS_RUNNING) {
             p->state = FLUX_SUBPROCESS_EXITED;

--- a/src/common/libsubprocess/server.c
+++ b/src/common/libsubprocess/server.c
@@ -300,10 +300,8 @@ static void server_exec_cb (flux_t *h, flux_msg_handler_t *mh,
                          FLUX_SUBPROCESS_FLAGS_SETPGRP,
                          cmd,
                          &ops,
-                         NULL))) {
-        errmsg = "exec failed";
+                         NULL)))
         goto error;
-    }
 
     if (flux_subprocess_aux_set (p,
                                 msgkey,

--- a/src/common/libsubprocess/subprocess.h
+++ b/src/common/libsubprocess/subprocess.h
@@ -42,17 +42,14 @@ typedef struct flux_subprocess flux_subprocess_t;
  * Possible state changes:
  *
  * init -> running
- * init -> exec failed
  * running -> exited
  * any state -> failed
  */
 typedef enum {
     FLUX_SUBPROCESS_INIT,         /* initial state */
-    FLUX_SUBPROCESS_EXEC_FAILED,  /* exec(2) has failed, only for rexec() */
     FLUX_SUBPROCESS_RUNNING,      /* exec(2) has been called */
     FLUX_SUBPROCESS_EXITED,       /* process has exited */
-    FLUX_SUBPROCESS_FAILED,       /* internal failure, catch all for
-                                   * all other errors */
+    FLUX_SUBPROCESS_FAILED,       /* exec failure or other non-child error */
     FLUX_SUBPROCESS_STOPPED,      /* process was stopped */
 } flux_subprocess_state_t;
 
@@ -90,8 +87,7 @@ typedef void (*flux_subprocess_hook_f) (flux_subprocess_t *p, void *arg);
 typedef struct {
     flux_subprocess_f on_completion;    /* Process exited and all I/O
                                          * complete, will not be
-                                         * called if EXEC_FAILED or
-                                         * FAILED states reached.
+                                         * called if FAILED state reached.
                                          */
     flux_subprocess_state_f on_state_change;  /* Process state change        */
     flux_subprocess_output_f on_channel_out; /* Read from channel when ready */
@@ -430,8 +426,7 @@ const char *flux_subprocess_state_string (flux_subprocess_state_t state);
 
 int flux_subprocess_rank (flux_subprocess_t *p);
 
-/* Returns the errno causing the FLUX_SUBPROCESS_EXEC_FAILED or
- * FLUX_SUBPROCESS_FAILED states to be reached.
+/* Returns the errno causing the FLUX_SUBPROCESS_FAILED states to be reached.
  */
 int flux_subprocess_fail_errno (flux_subprocess_t *p);
 

--- a/src/common/libsubprocess/test/fdcopy.c
+++ b/src/common/libsubprocess/test/fdcopy.c
@@ -1,0 +1,84 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* fdcopy.c - copy one file descriptor to another */
+
+#if HAVE_CONFIG_H
+# include "config.h"
+#endif
+#include <sys/types.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <errno.h>
+
+int getenv_int (const char *name, int *valp)
+{
+    const char *s;
+    int val = -1;
+
+    if (!(s = getenv (name)))
+        return -1;
+    errno = 0;
+    val = strtoul (s, NULL, 10);
+    if (errno != 0)
+        return -1;
+    *valp = val;
+    return 0;
+}
+
+void fdcopy (int fd_in, int fd_out)
+{
+    int rlen;
+    int wlen;
+    char buf[1024];
+
+    for (;;) {
+        rlen = read (fd_in, buf, sizeof (buf));
+        if (rlen < 0) {
+            perror ("read");
+            exit (1);
+        }
+        if (rlen == 0)
+            break;
+        wlen = 0;
+        while (wlen < rlen) {
+            int n = write (fd_out, buf + wlen, rlen - wlen);
+            if (n < 0) {
+                perror ("write");
+                exit (1);
+            }
+            wlen += n;
+        }
+    }
+}
+
+int main (int argc, char **argv)
+{
+    int fd_in;
+    int fd_out;
+
+    if (argc != 3
+        || getenv_int (argv[1], &fd_in) < 0
+        || getenv_int (argv[2], &fd_out) < 0) {
+        fprintf (stderr,
+                 "Usage: fdcopy INCHAN OUTCHAN\n"
+                 "  where *CHAN are env vars set to file descriptor numbers\n");
+        exit (1);
+    }
+
+    fdcopy (fd_in, fd_out);
+
+    exit (0);
+}
+
+
+// vi: ts=4 sw=4 expandtab
+

--- a/src/common/libsubprocess/test/iochan.c
+++ b/src/common/libsubprocess/test/iochan.c
@@ -1,0 +1,249 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <unistd.h> // environ def
+#include <jansson.h>
+#include <flux/core.h>
+
+#include "ccan/array_size/array_size.h"
+#include "ccan/str/str.h"
+#include "src/common/libtap/tap.h"
+#include "src/common/libtestutil/util.h"
+#include "src/common/libczmqcontainers/czmq_containers.h"
+#include "src/common/libsubprocess/server.h"
+#include "src/common/libsubprocess/subprocess_private.h"
+#include "src/common/libioencode/ioencode.h"
+#include "src/common/libutil/stdlog.h"
+
+#include "rcmdsrv.h"
+
+struct iochan_ctx {
+    flux_t *h;
+    flux_subprocess_t *p;
+    flux_watcher_t *source;
+    flux_watcher_t *timer;
+    pid_t pid;
+    int recvcount;
+    int sendcount;
+    int count;
+    const char *name;
+};
+
+const int linesize = 80;
+const char *test_fdcopy = TEST_SUBPROCESS_DIR "test_fdcopy";
+
+static void iochan_timer_cb (flux_reactor_t *r,
+                               flux_watcher_t *w,
+                               int revents,
+                               void *arg)
+{
+    diag ("doomsday has arrived");
+    flux_reactor_stop_error (r);
+}
+
+static void iochan_start_doomsday (struct iochan_ctx *ctx, double t)
+{
+    flux_timer_watcher_reset (ctx->timer, t, 0.);
+    flux_watcher_start (ctx->timer);
+}
+
+static void iochan_output_cb (flux_subprocess_t *p, const char *stream)
+{
+    struct iochan_ctx *ctx = flux_subprocess_aux_get (p, "ctx");
+    const char *line;
+    int len;
+
+    if (!(line = flux_subprocess_read_line (p, stream, &len)))
+        diag ("%s: %s", stream, strerror (errno));
+    else if (len == 0)
+        diag ("%s: EOF", stream);
+    else if (streq (stream, "stderr") || streq (stream, "stdout"))
+        diag ("%s: %s", stream, line);
+    else if (streq (stream, "IOCHAN_OUT"))
+        ctx->recvcount += len;
+}
+
+static void iochan_completion_cb (flux_subprocess_t *p)
+{
+    struct iochan_ctx *ctx = flux_subprocess_aux_get (p, "ctx");
+
+    diag ("%s: completion callback", ctx->name);
+
+    diag ("%s: stopping reactor", ctx->name);
+    flux_reactor_stop (flux_get_reactor (ctx->h));
+}
+
+static void iochan_state_cb (flux_subprocess_t *p,
+                               flux_subprocess_state_t state)
+{
+    struct iochan_ctx *ctx = flux_subprocess_aux_get (p, "ctx");
+
+    diag ("%s state callback state=%s",
+          ctx->name,
+          flux_subprocess_state_string (state));
+
+    switch (state) {
+        case FLUX_SUBPROCESS_INIT:
+        case FLUX_SUBPROCESS_RUNNING:
+            ctx->pid = flux_subprocess_pid (p);
+            flux_watcher_start (ctx->source); // start sourcing data
+            break;
+        case FLUX_SUBPROCESS_STOPPED:
+            break;
+        case FLUX_SUBPROCESS_EXITED: {
+            int status = flux_subprocess_status (p);
+            if (WIFEXITED (status))
+                diag ("%s: exit %d", ctx->name, WEXITSTATUS (status));
+            else if (WIFSIGNALED (status))
+                diag ("%s: %s", ctx->name, strsignal (WTERMSIG (status)));
+            // completion callback will exit the reactor, but just in case
+            iochan_start_doomsday (ctx, 2.);
+            break;
+        }
+        case FLUX_SUBPROCESS_FAILED:
+            diag ("%s: %s",
+                  ctx->name,
+                  strerror (flux_subprocess_fail_errno (p)));
+            diag ("%s: stopping reactor", ctx->name);
+            flux_reactor_stop_error (flux_get_reactor (ctx->h));
+            break;
+    }
+}
+
+static void iochan_source_cb (flux_reactor_t *r,
+                              flux_watcher_t *w,
+                              int revents,
+                              void *arg)
+{
+    struct iochan_ctx *ctx = arg;
+    char buf[linesize];
+    int len;
+    int n = linesize;
+
+    if (n > ctx->count - ctx->sendcount)
+        n = ctx->count - ctx->sendcount;
+
+    memset (buf, 'F', n - 1);
+    buf[n - 1] = '\n';
+
+    len = flux_subprocess_write (ctx->p, "IOCHAN_IN", buf, n);
+    if (len < 0) {
+        diag ("%s: source: %s", ctx->name, strerror (errno));
+        goto error;
+    }
+    if (len < n) {
+        diag ("%s: source: short write", ctx->name);
+        errno = ENOSPC;
+        goto error;
+    }
+    ctx->sendcount += len;
+    if (ctx->sendcount == ctx->count) {
+        if (flux_subprocess_close (ctx->p, "IOCHAN_IN") < 0) {
+            diag ("%s: source: %s", ctx->name, strerror (errno));
+            goto error;
+        }
+        flux_watcher_stop (w);
+    }
+    return;
+error:
+    //flux_reactor_stop_error (r);
+    iochan_start_doomsday (ctx, 2.);
+}
+
+flux_subprocess_ops_t iochan_ops = {
+    .on_completion      = iochan_completion_cb,
+    .on_state_change    = iochan_state_cb,
+    .on_stdout          = iochan_output_cb,
+    .on_stderr          = iochan_output_cb,
+    .on_channel_out     = iochan_output_cb,
+};
+
+bool iochan_run_check (flux_t *h, const char *name, int count)
+{
+    char *cat_av[] = {
+        (char *)test_fdcopy,
+        "IOCHAN_IN",
+        "IOCHAN_OUT",
+        NULL,
+    };
+    flux_cmd_t *cmd;
+    struct iochan_ctx ctx;
+    int rc;
+    bool ret = true;
+
+    memset (&ctx, 0, sizeof (ctx));
+    ctx.h = h;
+    ctx.count = count;
+    ctx.name = name;
+
+    if (!(cmd = flux_cmd_create (ARRAY_SIZE (cat_av) - 1, cat_av, environ)))
+        BAIL_OUT ("flux_cmd_create failed");
+    if (flux_cmd_add_channel (cmd, "IOCHAN_IN") < 0
+        || flux_cmd_add_channel (cmd, "IOCHAN_OUT") < 0)
+        BAIL_OUT ("flux_cmd_add_channel failed");
+    if (!(ctx.p = flux_rexec (h, FLUX_NODEID_ANY, 0, cmd, &iochan_ops)))
+        BAIL_OUT ("flux_rexec failed");
+    if (flux_subprocess_aux_set (ctx.p, "ctx", &ctx, NULL) < 0)
+        BAIL_OUT ("flux_subprocess_aux_set failed");
+
+    if (!(ctx.source = flux_prepare_watcher_create (flux_get_reactor (h),
+                                                    iochan_source_cb,
+                                                    &ctx)))
+        BAIL_OUT ("could not create prepare watcher");
+    if (!(ctx.timer = flux_timer_watcher_create (flux_get_reactor (h),
+                                                 0.,
+                                                 0.,
+                                                 iochan_timer_cb,
+                                                 &ctx)))
+        BAIL_OUT ("could not create timer watcher");
+
+    rc = flux_reactor_run (flux_get_reactor (h), 0);
+    if (rc < 0) {
+        diag ("%s: flux_reactor_run: %s", name, strerror (errno));
+        ret = false;
+    }
+
+    diag ("%s: processed %d of %d bytes", name, ctx.recvcount, ctx.sendcount);
+    if (ctx.recvcount < ctx.sendcount)
+        ret = false;
+
+    flux_watcher_destroy (ctx.source);
+    flux_watcher_destroy (ctx.timer);
+    diag ("%s: destroying subprocess", name);
+    flux_subprocess_destroy (ctx.p);
+    flux_cmd_destroy (cmd);
+
+    return ret;
+}
+
+int main (int argc, char *argv[])
+{
+    flux_t *h;
+
+    plan (NO_PLAN);
+
+    h = rcmdsrv_create ();
+    ok (iochan_run_check (h, "simple", linesize * 100),
+        "simple check worked");
+    ok (iochan_run_check (h, "simple", linesize * 1000),
+        "medium check worked");
+    ok (iochan_run_check (h, "simple", linesize * 10000),
+        "large check worked");
+    test_server_stop (h);
+    flux_close (h);
+
+    done_testing ();
+    return 0;
+}
+
+// vi: ts=4 sw=4 expandtab

--- a/src/common/libsubprocess/test/iostress.c
+++ b/src/common/libsubprocess/test/iostress.c
@@ -111,7 +111,6 @@ static void iostress_state_cb (flux_subprocess_t *p,
             break;
         }
         case FLUX_SUBPROCESS_FAILED:
-        case FLUX_SUBPROCESS_EXEC_FAILED:
             diag ("%s: %s",
                   ctx->name,
                   strerror (flux_subprocess_fail_errno (p)));

--- a/src/common/libsubprocess/test/remote.c
+++ b/src/common/libsubprocess/test/remote.c
@@ -100,7 +100,6 @@ static void simple_state_cb (flux_subprocess_t *p,
             ctx->scorecard.exited = 1;
             break;
         case FLUX_SUBPROCESS_FAILED:
-        case FLUX_SUBPROCESS_EXEC_FAILED:
             ctx->scorecard.failed = 1;
             diag ("stopping reactor");
             flux_reactor_stop (flux_get_reactor (ctx->h));

--- a/src/common/libsubprocess/test/subprocess.c
+++ b/src/common/libsubprocess/test/subprocess.c
@@ -1509,8 +1509,6 @@ void test_state_strings (void)
         "flux_subprocess_state_string returns correct string");
     ok (!strcasecmp (flux_subprocess_state_string (FLUX_SUBPROCESS_EXITED), "Exited"),
         "flux_subprocess_state_string returns correct string");
-    ok (!strcasecmp (flux_subprocess_state_string (FLUX_SUBPROCESS_EXEC_FAILED), "Exec Failed"),
-        "flux_subprocess_state_string returns correct string");
     ok (!flux_subprocess_state_string (100),
         "flux_subprocess_state_string returns NULL on bad state");
     is (flux_subprocess_state_string (FLUX_SUBPROCESS_STOPPED),

--- a/src/modules/job-exec/bulk-exec.c
+++ b/src/modules/job-exec/bulk-exec.c
@@ -179,8 +179,7 @@ static void exec_state_cb (flux_subprocess_t *p, flux_subprocess_state_t state)
                 (*exec->handlers->on_start) (exec, exec->arg);
         }
     }
-    else if (state == FLUX_SUBPROCESS_FAILED
-            || state == FLUX_SUBPROCESS_EXEC_FAILED) {
+    else if (state == FLUX_SUBPROCESS_FAILED) {
         int errnum = flux_subprocess_fail_errno (p);
         int code = EXIT_CODE(1);
 

--- a/src/modules/job-ingest/worker.c
+++ b/src/modules/job-ingest/worker.c
@@ -118,7 +118,6 @@ static void worker_state_cb (flux_subprocess_t *p,
     switch (state) {
         case FLUX_SUBPROCESS_RUNNING:
             break;
-        case FLUX_SUBPROCESS_EXEC_FAILED:
         case FLUX_SUBPROCESS_FAILED:
             flux_log (w->h, LOG_ERR, "%s: %s: %s", w->name,
                       flux_subprocess_state_string (state),

--- a/src/modules/job-manager/plugins/perilog.c
+++ b/src/modules/job-manager/plugins/perilog.c
@@ -192,8 +192,7 @@ static void state_cb (flux_subprocess_t *sp, flux_subprocess_state_t state)
 {
     struct perilog_proc *proc;
 
-    if ((state == FLUX_SUBPROCESS_FAILED
-        || state == FLUX_SUBPROCESS_EXEC_FAILED)
+    if ((state == FLUX_SUBPROCESS_FAILED)
         && (proc = flux_subprocess_aux_get (sp, "perilog_proc"))) {
 
         /*  If subprocess failed or execution failed, then we still

--- a/t/rexec/rexec.c
+++ b/t/rexec/rexec.c
@@ -76,8 +76,7 @@ void state_cb (flux_subprocess_t *p, flux_subprocess_state_t state)
     if (optparse_getopt (opts, "outputstates", NULL) > 0)
         printf ("%s\n", flux_subprocess_state_string (state));
 
-    if (state == FLUX_SUBPROCESS_EXEC_FAILED
-        || state == FLUX_SUBPROCESS_FAILED) {
+    if (state == FLUX_SUBPROCESS_FAILED) {
         fprintf (stderr, "rank %d: %s: %s\n",
                  flux_subprocess_rank (p),
                  flux_subprocess_state_string (state),

--- a/t/t0005-rexec.t
+++ b/t/t0005-rexec.t
@@ -92,7 +92,7 @@ test_expect_success 'basic rexec functionality (check state changes)' '
 
 test_expect_success 'basic rexec fail exec() (check state changes)' '
 	! $rexec -s / > output &&
-	echo "Exec Failed" > expected &&
+	echo "Failed" > expected &&
 	test_cmp expected output
 '
 


### PR DESCRIPTION
Problem: the FLUX_SUBPROCESS_EXEC_FAILED state is not needed

This state is a terminal state that indicates that a remote `flux_exec()` call failed before a PID could be returned.  Other remote failures, before and after a PID is returned, are covered by FLUX_SUBPROCESS_FAILED, so the extra state seems to serve no purpose.

Drop the state and update users.

Also, fix logic surrounding a last-ditch SIGTERM sent to subprocesses on failure and improve unit testing on remote subprocess channels.
