### PR TITLE
flux-resource: suppress NGPUS on systems without GPUs

### DIFF
--- a/doc/man1/flux-jobs.rst
+++ b/doc/man1/flux-jobs.rst
@@ -162,7 +162,7 @@ following is the format used for the default format:
 
 If a format field is preceded by the special string ``?:`` this will
 cause the field to be removed entirely from output if the result would
-be an empty string for all jobs in the listing. E.g.::
+be an empty string or zero value for all jobs in the listing. E.g.::
 
    {id.f58:>12} ?:{exception.type}
 

--- a/src/bindings/python/flux/util.py
+++ b/src/bindings/python/flux/util.py
@@ -575,7 +575,8 @@ class OutputFormat:
         """
         Check for format fields that are prefixed with `?:` (e.g. "?:{name}")
         and filter them out of the current format string if they result in an
-        empty string for every entry in `items`.
+        empty value (as defined by the `empty` tuple defined below) for every
+        entry in `items`.
         """
         #  Build a list of all format strings that have the collapsible
         #  sentinel '?:' to determine which are subject to the test for
@@ -600,9 +601,10 @@ class OutputFormat:
         formatter = self.formatter()
 
         #  Iterate over all items, rebuilding lst each time to contain
-        #  only those fields that resulted in nonzero strings:
+        #  only those fields that resulted in non-"empty" strings:
+        empty = ("", "0", "0s", "0.0", "0:00:00", "1970-01-01T00:00:00")
         for item in items:
-            lst = [x for x in lst if not formatter.format(x["fmt"], item)]
+            lst = [x for x in lst if formatter.format(x["fmt"], item) in empty]
 
             #  If lst is now empty, that means all fields already returned
             #  nonzero strings, so we can break early

--- a/src/cmd/flux-resource.py
+++ b/src/cmd/flux-resource.py
@@ -58,7 +58,7 @@ class FluxResourceConfig(UtilConfig):
             "description": "Default flux-resource list format string",
             "format": (
                 "{state:>10} ?:{queue:<10.10} ?:{propertiesx:<10.10+} {nnodes:>6} "
-                "{ncores:>8} {ngpus:>8} {nodelist}"
+                "{ncores:>8} ?:{ngpus:>8} {nodelist}"
             ),
         },
         "rlist": {


### PR DESCRIPTION
This PR extends the `?:` prefix in the `OutputFormat` class to suppress columns in which all lines have a representation of zero in addition to suppressing all empty lines. This then allows use of `?:` in the `ngpus` column of `flux resource list`. Displaying an NGPUS column on systems without GPUs was identified as an important issue by at least one user.