### PR TITLE
libsubprocess: rework internal logging

### DIFF
--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -409,6 +409,11 @@ int main (int argc, char *argv[])
     if (ctx.rank == 0 && execute_parental_notifications (&ctx) < 0)
         goto cleanup;
 
+    /* Set up internal logging for libsubprocesses.
+     */
+    if (flux_set_default_subprocess_log (ctx.h, flux_llog, ctx.h) < 0)
+        goto cleanup;
+
     if (create_runat_phases (&ctx) < 0)
         goto cleanup;
 

--- a/src/common/libflux/flog.c
+++ b/src/common/libflux/flog.c
@@ -209,6 +209,21 @@ void flux_log_error (flux_t *h, const char *fmt, ...)
     va_end (ap);
 }
 
+void flux_llog (void *arg,
+                const char *file,
+                int line,
+                const char *func,
+                const char *subsys,
+                int level,
+                const char *fmt,
+                va_list ap)
+{
+    flux_t *h = arg;
+    // ignoring subsys, file, line
+    flux_vlog (h, level, fmt, ap);
+}
+
+
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab
  */

--- a/src/common/libflux/flog.h
+++ b/src/common/libflux/flog.h
@@ -66,6 +66,17 @@ void flux_log_set_redirect (flux_t *h, flux_log_f fun, void *arg);
  */
 const char *flux_strerror (int errnum);
 
+/* Flux log function compatible with libutil llog interface
+ */
+void flux_llog (void *arg,
+                const char *file,
+                int line,
+                const char *func,
+                const char *subsys,
+                int level,
+                const char *fmt,
+                va_list ap);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/common/libsubprocess/Makefile.am
+++ b/src/common/libsubprocess/Makefile.am
@@ -9,7 +9,8 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/src/include \
 	-I$(top_srcdir)/src/common/libccan \
-	-I$(top_builddir)/src/common/libflux
+	-I$(top_builddir)/src/common/libflux \
+	-DLLOG_ENABLE_DEBUG=1
 
 noinst_LTLIBRARIES = \
 	libsubprocess.la

--- a/src/common/libsubprocess/local.c
+++ b/src/common/libsubprocess/local.c
@@ -24,6 +24,7 @@
 #include "src/common/libutil/log.h"
 #include "src/common/libutil/fdwalk.h"
 #include "src/common/libutil/fdutils.h"
+#include "src/common/libutil/llog.h"
 
 #include "subprocess.h"
 #include "subprocess_private.h"
@@ -46,7 +47,9 @@ static void local_channel_flush (struct subprocess_channel *c)
         int len;
 
         if (!(fb = flux_buffer_read_watcher_get_buffer (c->buffer_read_w))) {
-            flux_log_error (c->p->h, "flux_buffer_read_watcher_get_buffer");
+            llog_error (c->p,
+                        "flux_buffer_read_watcher_get_buffer: %s",
+                        strerror (errno));
             return;
         }
 
@@ -73,17 +76,23 @@ static void local_in_cb (flux_reactor_t *r, flux_watcher_t *w,
     int err = 0;
 
     if (flux_buffer_write_watcher_is_closed (w, &err) == 1) {
-        if (err)
-            log_msg ("flux_buffer_write_watcher close error: %s",
-                     strerror (err));
+        if (err) {
+            llog_error (c->p,
+                        "flux_buffer_write_watcher close error: %s",
+                        strerror (err));
+        }
         else
             c->parent_fd = -1;  /* closed by reactor */
         flux_watcher_stop (w);  /* c->buffer_write_w */
         local_channel_flush (c);
     }
-    else
-        flux_log_error (c->p->h, "flux_buffer_write_watcher: stream %s: %d:",
-                        c->name, revents);
+    else {
+        llog_error (c->p,
+                    "flux_buffer_write_watcher: stream %s: %d: %s",
+                    c->name,
+                    revents,
+                    strerror (errno));
+    }
 }
 
 static void local_output (struct subprocess_channel *c,
@@ -96,7 +105,9 @@ static void local_output (struct subprocess_channel *c,
             flux_buffer_t *fb;
 
             if (!(fb = flux_buffer_read_watcher_get_buffer (w))) {
-                flux_log_error (c->p->h, "flux_buffer_read_watcher_get_buffer");
+                llog_error (c->p,
+                            "flux_buffer_read_watcher_get_buffer: %s",
+                            strerror (errno));
                 return;
             }
 
@@ -123,9 +134,12 @@ static void local_output (struct subprocess_channel *c,
             }
         }
     }
-    else
-        flux_log_error (c->p->h, "flux_buffer_read_watcher on %s: 0x%X:",
-                        c->name, revents);
+    else {
+        llog_error (c->p,
+                    "flux_buffer_read_watcher on %s: 0x%X:",
+                    c->name,
+                    revents);
+    }
 
     if (c->p->state == FLUX_SUBPROCESS_EXITED && c->eof_sent_to_caller)
         subprocess_check_completed (c->p);
@@ -167,12 +181,12 @@ static int channel_local_setup (flux_subprocess_t *p,
     int buffer_size;
 
     if (!(c = channel_create (p, output_f, name, channel_flags))) {
-        flux_log (p->h, LOG_DEBUG, "channel_create");
+        llog_debug (p, "channel_create %s: %s", name, strerror (errno));
         goto error;
     }
 
     if (socketpair (PF_LOCAL, SOCK_STREAM, 0, fds) < 0) {
-        flux_log (p->h, LOG_DEBUG, "socketpair");
+        llog_debug (p, "socketpair: %s", strerror (errno));
         goto error;
     }
 
@@ -186,12 +200,12 @@ static int channel_local_setup (flux_subprocess_t *p,
     fds[1] = -1;
 
     if ((fd_flags = fd_set_nonblocking (c->parent_fd)) < 0) {
-        flux_log (p->h, LOG_DEBUG, "fd_set_nonblocking");
+        llog_debug (p, "fd_set_nonblocking: %s", strerror (errno));
         goto error;
     }
 
     if ((buffer_size = cmd_option_bufsize (p, name)) < 0) {
-        flux_log (p->h, LOG_DEBUG, "cmd_option_bufsize");
+        llog_debug (p, "cmd_option_bufsize: %s", strerror (errno));
         goto error;
     }
 
@@ -203,7 +217,9 @@ static int channel_local_setup (flux_subprocess_t *p,
                                                               0,
                                                               c);
         if (!c->buffer_write_w) {
-            flux_log (p->h, LOG_DEBUG, "flux_buffer_write_watcher_create");
+            llog_debug (p,
+                        "flux_buffer_write_watcher_create: %s",
+                        strerror (errno));
             goto error;
         }
     }
@@ -212,7 +228,7 @@ static int channel_local_setup (flux_subprocess_t *p,
         int wflag;
 
         if ((wflag = cmd_option_line_buffer (p, name)) < 0) {
-            flux_log (p->h, LOG_DEBUG, "cmd_option_line_buffer");
+            llog_debug (p, "cmd_option_line_buffer: %s", strerror (errno));
             goto error;
         }
 
@@ -226,7 +242,9 @@ static int channel_local_setup (flux_subprocess_t *p,
                                                             wflag,
                                                             c);
         if (!c->buffer_read_w) {
-            flux_log (p->h, LOG_DEBUG, "flux_buffer_read_watcher_create");
+            llog_debug (p,
+                        "flux_buffer_read_watcher_create: %s",
+                        strerror (errno));
             goto error;
         }
 
@@ -235,7 +253,7 @@ static int channel_local_setup (flux_subprocess_t *p,
 
     if (channel_flags & CHANNEL_FD) {
         if (asprintf (&e, "%s", name) < 0) {
-            flux_log (p->h, LOG_DEBUG, "asprintf");
+            llog_debug (p, "asprintf: %s", strerror (errno));
             goto error;
         }
 
@@ -246,17 +264,17 @@ static int channel_local_setup (flux_subprocess_t *p,
                               e,
                               "%d",
                               c->child_fd) < 0) {
-            flux_log (p->h, LOG_DEBUG, "flux_cmd_setenvf");
+            llog_debug (p, "flux_cmd_setenvf: %s", strerror (errno));
             goto error;
         }
     }
 
     if (zhash_insert (p->channels, name, c) < 0) {
-        flux_log (p->h, LOG_DEBUG, "zhash_insert");
+        llog_debug (p, "zhash_insert failed");
         goto error;
     }
     if (!zhash_freefn (p->channels, name, channel_destroy)) {
-        flux_log (p->h, LOG_DEBUG, "zhash_freefn");
+        llog_debug (p, "zhash_freefn failed");
         goto error;
     }
 
@@ -363,7 +381,9 @@ static void child_watch_cb (flux_reactor_t *r, flux_watcher_t *w,
     int status;
 
     if ((status = flux_child_watcher_get_rstatus (w)) < 0) {
-        flux_log_error (p->h, "flux_child_watcher_get_rstatus");
+        llog_error (p,
+                    "flux_child_watcher_get_rstatus: %s",
+                    strerror (errno));
         return;
     }
 
@@ -411,7 +431,7 @@ static int start_local_watchers (flux_subprocess_t *p)
                                                   true,
                                                   child_watch_cb,
                                                   p))) {
-        flux_log (p->h, LOG_DEBUG, "flux_child_watcher_create");
+        llog_debug (p, "flux_child_watcher_create: %s", strerror (errno));
         return -1;
     }
     flux_watcher_start (p->child_w);

--- a/src/common/libsubprocess/subprocess.c
+++ b/src/common/libsubprocess/subprocess.c
@@ -180,6 +180,11 @@ static flux_subprocess_t * subprocess_create (flux_t *h,
     if (!p)
         return NULL;
 
+    if (h) {
+        p->llog = flux_aux_get (h, "flux::subprocess_llog_fn");
+        p->llog_data = flux_aux_get (h, "flux::subprocess_llog_data");
+    }
+
     /* init fds, so on error we don't accidentally close stdin
      * (i.e. fd == 0)
      */
@@ -1198,6 +1203,16 @@ void * flux_subprocess_aux_get (flux_subprocess_t *p, const char *name)
         return NULL;
     }
     return aux_get (p->aux, name);
+}
+
+int flux_set_default_subprocess_log (flux_t *h,
+                                     subprocess_log_f log_fn,
+                                     void *log_data)
+{
+    if (flux_aux_set (h, "flux::subprocess_llog_fn", log_fn, NULL) < 0
+        || flux_aux_set (h, "flux::subprocess_llog_data", log_data, NULL) < 0)
+        return -1;
+    return 0;
 }
 
 /*

--- a/src/common/libsubprocess/subprocess.h
+++ b/src/common/libsubprocess/subprocess.h
@@ -466,6 +466,23 @@ int flux_subprocess_aux_set (flux_subprocess_t *p,
  */
 void *flux_subprocess_aux_get (flux_subprocess_t *p, const char *name);
 
+typedef void (*subprocess_log_f) (void *arg,
+                                  const char *file,
+                                  int line,
+                                  const char *func,
+                                  const char *subsys,
+                                  int level,
+                                  const char *fmt,
+                                  va_list args);
+
+/* Set default internal logging function.
+ */
+int flux_set_default_subprocess_log (flux_t *h,
+                                     subprocess_log_f log_fn,
+                                     void *log_data);
+
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/common/libsubprocess/subprocess_private.h
+++ b/src/common/libsubprocess/subprocess_private.h
@@ -66,6 +66,9 @@ struct flux_subprocess {
     int flags;
     bool local;                     /* This is a local process, not remote. */
 
+    subprocess_log_f llog;
+    void *llog_data;
+
     int refcount;
     pid_t pid;
     bool pid_set;

--- a/src/common/libsubprocess/test/iochan.c
+++ b/src/common/libsubprocess/test/iochan.c
@@ -233,6 +233,10 @@ int main (int argc, char *argv[])
     plan (NO_PLAN);
 
     h = rcmdsrv_create ();
+
+    if (flux_set_default_subprocess_log (h, tap_logger, NULL) < 0)
+        BAIL_OUT ("could not set logger");
+
     ok (iochan_run_check (h, "simple", linesize * 100),
         "simple check worked");
     ok (iochan_run_check (h, "simple", linesize * 1000),

--- a/src/common/libsubprocess/test/iostress.c
+++ b/src/common/libsubprocess/test/iostress.c
@@ -276,6 +276,9 @@ int main (int argc, char *argv[])
 
     h = rcmdsrv_create ();
 
+    if (flux_set_default_subprocess_log (h, tap_logger, NULL) < 0)
+        BAIL_OUT ("could not set logger");
+
     ok (iostress_run_check (h, "balanced", false, 0, 0, 8, 8, 80),
         "balanced worked");
 

--- a/src/common/libsubprocess/test/rcmdsrv.h
+++ b/src/common/libsubprocess/test/rcmdsrv.h
@@ -20,6 +20,17 @@
  */
 flux_t *rcmdsrv_create (void);
 
+/* llog-compatible logger
+ */
+void tap_logger (void *arg,
+                 const char *file,
+                 int line,
+                 const char *func,
+                 const char *subsys,
+                 int level,
+                 const char *fmt,
+                 va_list ap);
+
 #endif // !_SUBPROCESS_TEST_RCMDSRV_H
 
 // vi: ts=4 sw=4 expandtab

--- a/src/common/libsubprocess/test/remote.c
+++ b/src/common/libsubprocess/test/remote.c
@@ -255,6 +255,9 @@ int main (int argc, char *argv[])
 
     h = rcmdsrv_create ();
 
+    if (flux_set_default_subprocess_log (h, tap_logger, NULL) < 0)
+        BAIL_OUT ("could not set logger");
+
     simple_test (h);
 
     test_server_stop (h);

--- a/src/modules/cron/cron.c
+++ b/src/modules/cron/cron.c
@@ -890,6 +890,11 @@ int mod_main (flux_t *h, int ac, char **av)
     if (ctx == NULL)
         return -1;
 
+    /* Set up internal logging for libsubprocesses.
+     */
+    if (flux_set_default_subprocess_log (h, flux_llog, h) < 0)
+        goto done;
+
     process_args (ctx, ac, av);
 
     if (flux_msg_handler_addvec (h, htab, ctx, &handlers) < 0) {

--- a/src/modules/job-exec/job-exec.c
+++ b/src/modules/job-exec/job-exec.c
@@ -1388,6 +1388,8 @@ int mod_main (flux_t *h, int argc, char **argv)
         goto out;
     }
 
+    if (flux_set_default_subprocess_log (h, flux_llog, h) < 0)
+        goto out;
     if (flux_msg_handler_addvec (h, htab, ctx, &ctx->handlers) < 0) {
         flux_log_error (h, "flux_msg_handler_addvec");
         goto out;

--- a/src/modules/job-ingest/pipeline.c
+++ b/src/modules/job-ingest/pipeline.c
@@ -413,6 +413,8 @@ struct pipeline *pipeline_create (flux_t *h)
 
     if (!(pl = calloc (1, sizeof (*pl))))
         return NULL;
+    if (flux_set_default_subprocess_log (h, flux_llog, h) < 0)
+        goto error;
     pl->h = h;
     if (!(pl->shutdown_timer = flux_timer_watcher_create (r,
                                                           0.,

--- a/src/modules/job-manager/job-manager.c
+++ b/src/modules/job-manager/job-manager.c
@@ -164,6 +164,10 @@ int mod_main (flux_t *h, int argc, char **argv)
     zhashx_set_duplicator (ctx.active_jobs, job_duplicator);
     zhashx_set_destructor (ctx.inactive_jobs, job_destructor);
     zhashx_set_duplicator (ctx.inactive_jobs, job_duplicator);
+    if (flux_set_default_subprocess_log (h, flux_llog, h) < 0) {
+        flux_log_error (h, "error initializing subprocess logging");
+        goto done;
+    }
     if (!(ctx.conf = conf_create (&ctx))) {
         flux_log_error (h, "error creating conf context");
         goto done;


### PR DESCRIPTION
This eliminates the calls to `flux_log()` inside libsubprocess, which is not appropriate in all cases.  It is replaced with an llog function callback, which has been used in the shell.

Since some log messages occur right when the subprocess is created, it would not work to have a "setter" on the subprocess object to set up the logging - that would be too late.  So rather than add logger parameters to `flux_rexec()` and friends, I added a single function `flux_set_default_subprocess_log()` that sets a log function and argument in the `flux_t` handle aux container.  Then when a subprocess or the subprocess server is created, it uses that if it was set.

A llog-compatible callback that logs to the broker is provided, and that is used in the broker-resident subprocess users for now.

The existing llog-compatible shell logger is used in the flux shell.