### PR TITLE
flux-batch(1) and flux-alloc(1): improve DESCRIPTION section

### DIFF
--- a/doc/man1/flux-alloc.rst
+++ b/doc/man1/flux-alloc.rst
@@ -14,8 +14,40 @@ SYNOPSIS
 DESCRIPTION
 ===========
 
-flux-alloc(1) interactively launches a command as the initial program of a
-new Flux instance.  If no *COMMAND* is specified, a shell is spawned.
+**flux-alloc** runs a Flux subinstance with *COMMAND* as the initial program.
+Once resources are allocated, *COMMAND* executes on the first node of the
+allocation with any free arguments supplied as *COMMAND* arguments.  When
+*COMMAND* exits, the Flux subinstance exits, resources are released to the
+enclosing Flux instance, and **flux-alloc** returns.
+
+If no *COMMAND* is specified, an interactive shell is spawned as the initial
+program, and the subinstance runs until the shell is exited.
+
+If the *--bg* option is specified, the subinstance runs without an initial
+program.  **flux-alloc** prints the jobid and returns as soon as the
+subinstance is ready to accept jobs.  The subinstance runs until it exceeds
+its time limit, is canceled, or is shut down with :man1:`flux-shutdown`.
+
+Flux commands that are run from the subinstance (e.g. from the interactive
+shell) refer to the subinstance. For example, :man1:`flux-run` would launch
+work there.  A Flux command run from the subinstance can be forced to refer
+to the enclosing instance by supplying the :man1:`flux` --parent option.
+
+Flux commands outside of the subinstance refer to their enclosing instance,
+often a system instance. flux-proxy(1) establishes a connection to a running
+subinstance by jobid, then spawns a shell in which Flux commands refer to
+the subinstance, for example
+
+::
+
+   $ flux alloc --bg -N 2 --queue=batch
+   ƒM7Zq9AKHno
+   $ flux proxy ƒM7Zq9AKHno
+   $ flux mini run -n16 ./testprog
+   ...
+   $ flux shutdown
+   ...
+   $
 
 The available OPTIONS are detailed below.
 

--- a/doc/man1/flux-batch.rst
+++ b/doc/man1/flux-batch.rst
@@ -9,24 +9,67 @@ flux-batch(1)
 SYNOPSIS
 ========
 
-**flux** **batch** [OPTIONS] *--nslots=N* SCRIPT...
+**flux** **batch** [OPTIONS] *--nslots=N* SCRIPT ...
+
+**flux** **batch** [OPTIONS] *--nslots=N* --wrap COMMAND ...
 
 
 DESCRIPTION
 ===========
 
-The **flux-batch** command submits a script to run as the initial
-program of a job running a new instance of Flux. The SCRIPT given on the
-command line is assumed to be a file name unless the *--wrap* option is
-used, in which case the free arguments are consumed as the script, with
-``#!/bin/sh`` as the first line. If no SCRIPT is provided, then one will
-be read from standard input. The script may contain submission directives
-denoted by ``flux:`` or ``FLUX:`` as described in RFC 36, see
-:ref:`submission_directives` below.
+**flux-batch** submits *SCRIPT* to run as the initial program of a Flux
+subinstance.  *SCRIPT* refers to a file that is copied at the time of
+submission.  Once resources are allocated, *SCRIPT* executes on the first
+node of the allocation, with any remaining free arguments supplied as *SCRIPT*
+arguments.  Once *SCRIPT* exits, the Flux subinstance exits and resources are
+released to the enclosing Flux instance.
 
-The SCRIPT given on the command line is assumed to be a file name, unless
-the *--wrap* option used, and the script file is read and submitted along
-with the job. If no SCRIPT is provided, then one will be read from *stdin*.
+If there are no free arguments, the script is read from standard input.
+
+If the *--wrap* option is used, the script is created by wrapping the free
+arguments or standard input in a shell script prefixed with ``#!/bin/sh``.
+
+If the job request is accepted, its jobid is printed on standard output and the
+command returns.  The job runs when the Flux scheduler fulfills its resource
+allocation request.  :man1:`flux-jobs` may be used to display the job status.
+
+Flux commands that are run from the batch script refer to the subinstance.
+For example, :man1:`flux-run` would launch work there.  A Flux command run
+from the script can be forced to refer to the enclosing instance by supplying
+the :man1:`flux` *--parent* option.
+
+Flux commands outside of the batch script refer to their enclosing instance,
+often a system instance.  :man1:`flux-proxy` establishes a connection to a
+running subinstance by jobid, then spawns a shell in which Flux commands refer
+to the subinstance.  For example:
+
+::
+
+   $ flux uptime
+    07:48:42 run 2.1d,  owner flux,  depth 0,  size 8
+   $ flux batch -N 2 --queue=batch mybatch.sh
+   ƒM7Zq9AKHno
+   $ flux proxy ƒM7Zq9AKHno
+   $ flux uptime
+    07:47:18 run 1.6m,  owner user42,  depth 1,  size 2
+   $ flux top
+   ...
+   $ exit
+   $
+
+Other commands accept a jobid argument and establish the connection
+automatically.  For example:
+
+::
+
+   $ flux batch -N 2 --queue=batch mybatch.sh
+   ƒM7Zq9AKHno
+   $ flux top ƒM7Zq9AKHno
+   ...
+   $
+
+Batch scripts may contain submission directives denoted by ``flux:``
+as described in RFC 36.  See :ref:`submission_directives` below.
 
 The available OPTIONS are detailed below.
 

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -697,3 +697,7 @@ deps
 queuem
 timelimit
 unarchived
+subinstance
+AKHno
+mybatch
+Zq

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -701,3 +701,4 @@ subinstance
 AKHno
 mybatch
 Zq
+testprog


### PR DESCRIPTION
Problem: now that flux-batch(1) and flux-alloc(1) have their own man pages, there is an opportunity to provide a focused command introduction.

This is a stab at improving the docs for those two commands.   I'm not attached to these descriptions at all so suggestions are welcome!