### PR TITLE
.devcontainer permissions fix

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,6 +2,14 @@ FROM fluxrm/testenv:focal
 
 LABEL maintainer="Vanessasaurus <@vsoch>"
 
+# Match the default user id for a single system so we aren't root
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=1000
+ENV USERNAME=${USERNAME}
+ENV USER_UID=${USER_UID}
+ENV USER_GID=${USER_GID}
+
 # Pip not provided in this version
 RUN apt-get update
 COPY scripts/requirements-dev.txt /requirements.txt
@@ -24,3 +32,9 @@ RUN apt-get update \
     gdb \
     less \
     ripgrep
+
+# Add the group and user that match our ids
+RUN groupadd -g ${USER_GID} ${USERNAME} && \
+    adduser --disabled-password --uid ${USER_UID} --gid ${USER_GID} --gecos "" ${USERNAME} && \
+    echo "${USERNAME} ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers
+USER $USERNAME

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ in the container! The dependencies for building Flux are installed. Try building
 ./configure --prefix=/usr/local
 make
 # This will install in the container!
-make install
+sudo make install
 # This will test in the container!
 make check
 # If you want a compilation database
@@ -151,18 +151,18 @@ Note that the above assumes installing flux to `/usr/local`. If you install else
 If you ever need to rebuild, you can either restart VSCode and open in the same way (and it will give you the option)
 or you can do on demand in the command palette with `Dev Containers: Rebuild Container` (with or without cache).
 
-**Important** it's recommended that you commit (or otherwise write to the .git folder) from the outside
-of the container. The reason is two-fold - first, if you need to sign your commits, the container doesn't
-have access and won't be able to. Second, if you write to .git it will change permissions of the directory.
-If you accidentally do this and need to fix, you can run this from your terminal outside of VSCode:
+**Important** the development container assumes you are on a system with uid 1000 and gid 1000. If this isn't the case,
+edit the [.devcontainer/Dockerfile](.devcontainer/Dockerfile) to be your user and group id. This will ensure
+changes written inside the container are owned by your user. It's recommended that you commit on your system
+(not inside the container) because if you need to sign your commits, the container doesn't
+have access and won't be able to. If you find that you accidentally muck up permissions
+and need to fix, you can run this from your terminal outside of VSCode:
 
 ```bash
 $ sudo chown -R $USER .git/
 # and then commit
 ```
 
-Hopefully we will find a workaround for this so everything works from inside of a VSCode terminal.
-For the time being, make sure you fix permissions and commit from outside the container on your local machine!
 </details>
 
 


### PR DESCRIPTION
Problem: writing files in the DevContainer is done as root. 
Solution: have the default user be uid 1000, gid 1000, and they are written as the same user on the host.

To demonstrate this working, here I am making lasagna in the container:

![image](https://user-images.githubusercontent.com/814322/221384291-c2f5606c-4d07-449a-a108-cfa2c7eda9b1.png)

And the same file viewed from the host - it's still owned by me!

![image](https://user-images.githubusercontent.com/814322/221384300-c2e587a6-dee9-470a-ade5-792049700fa9.png)
