### PR TITLE
Add/developer doc on commands

### DIFF
--- a/doc/man7/flux-jobtap-plugins.rst
+++ b/doc/man7/flux-jobtap-plugins.rst
@@ -154,7 +154,7 @@ job.validate
 job.dependency.*
   The ``job.dependency.*`` topic allows a dependency plugin to notify the
   job-manager that it handles a given dependency _scheme_. The job-manager
-  will scan the ``attirbutes.system.dependencies`` array, if provided, and
+  will scan the ``attributes.system.dependencies`` array, if provided, and
   issue a ``job.dependency.SCHEME`` callback for each listed dependency.
   If no plugin has registered for ``SCHEME``, then the job is rejected.
   The plugin should then call ``flux_jobtap_dependency_add(3)`` to add

--- a/doc/manpages.py
+++ b/doc/manpages.py
@@ -82,7 +82,7 @@ man_pages = [
     ('man3/flux_event_publish', 'flux_event_publish', 'publish events', [author], 3),
     ('man3/flux_event_subscribe', 'flux_event_unsubscribe', 'manage subscriptions', [author], 3),
     ('man3/flux_event_subscribe', 'flux_event_subscribe', 'manage subscriptions', [author], 3),
-    ('man3/flux_comms_error_set', 'flux_comms_error_set', 'register callback for communications erors', [author], 3),
+    ('man3/flux_comms_error_set', 'flux_comms_error_set', 'register callback for communications errors', [author], 3),
     ('man3/flux_fd_watcher_create', 'flux_fd_watcher_get_fd', 'create file descriptor watcher', [author], 3),
     ('man3/flux_fd_watcher_create', 'flux_fd_watcher_create', 'create file descriptor watcher', [author], 3),
     ('man3/flux_flags_set', 'flux_flags_unset', 'manipulate Flux handle flags', [author], 3),

--- a/doc/python/developer.rst
+++ b/doc/python/developer.rst
@@ -62,4 +62,65 @@ And that's it! The check run in the CI is equivalent to here, so you should
 always be able to reproduce failures. And if you install the pre-commit hook,
 you can largely prevent them by always catching them before commit.
 
+Writing Python Commands
+-----------------------
+
+The Flux command design is done in a way that some commands are generated
+from the C code, and others are helpers that come from Python. 
+If you need to add a new command (and want it to show up) there are some tricks you need to know.
+This short guide will help you on this journey! 🏔️
+
+Locations
+~~~~~~~~~
+
+Flux commands can be found under ``src/cmd``. You'll notice many files with
+a prefix "flux-". By default, any file with this prefix will be discovered
+and available to the user as a flux command. As an example, ``flux-run.py`` will
+be available as ``flux run`` and ``flux-job.c`` will be available as ``flux job``. 
+This shows that we have a mix of C derived and Python derived commands. if you are
+interested in how this works, look at ``src/cmd/cmdhelp.c``.
+
+Let's now say that we add a new command ``flux-foo.py``. We would expect to compile
+Flux and see it available in ``flux help``, right? Wrong!
+While the command will technically work as ``flux foo``, it won't show up in the help,
+and there are a few tricks to getting that working, discussed next.
+
+Adding a New Command
+~~~~~~~~~~~~~~~~~~~~
+
+The command generation works as follows:
+
+ - A new command should be a Python file added to ``src/cmd`` named like ``flux-<command-name>.py``.
+ - The command can use (and write new) shared base classes that are found under ``src/bindings/python/flux/cli`` 
+ - The script ``etc/gen-cmdhelp.py`` is run during build, and it looks for entries in ``doc/manpages.py``
+ - This means you need to add line entries for your new commands including the .rst file path relative to doc, e.g.:
+ 
+  .. code-block:: python
+
+    ('man1/flux-submit', 'flux-submit', 'submit a job to a Flux instance', [author], 1),
+    ('man1/flux-run', 'flux-run', 'run a Flux job interactively', [author], 1),
+    ('man1/flux-bulksubmit', 'flux-bulksubmit', 'submit jobs in bulk to a Flux instance', [author], 1),
+    ('man1/flux-alloc', 'flux-alloc', 'allocate a new Flux instance for interactive use', [author], 1),
+    ('man1/flux-batch', 'flux-batch', 'submit a batch script to Flux', [author], 1),
+
+ - And of course, the dependency to that means actually writing the file! Python commands are in "man1."
+ - Update ``doc/Makefile.am`` (MAN1_FILES_PRIMARY) and ``src/cmd/Makefile.am`` (dist_fluxcmd_SCRIPTS) with your new file.
+ - Try to use shared logic whenever possible! E.g., ``doc/man1/common`` has common snippets.
+ - The script generates ``etc/flux/help.d/core.json`` where you can sanity check the output.
+ 
+Since these changes need to be compiled into the source code, be careful that if you re-generate that json
+file, you do a ``make clean`` to ensure that the cmd and etc directories are rebuilt. It's best to
+start from scratch with ``make clean`` as (in this writer's experience), partial cleans don't always work.
+
+Updating a Command
+~~~~~~~~~~~~~~~~~~
+
+Updating a command is much easier, as the documentation .rst file will already
+exist! This means that (depending on your updates) you should update this file,
+do a build from scratch, and check that:
+
+ - The command functions as you would expect.
+ - It shows up in help, and the help documentation is comprehensive and correct.
+ - Tests for the command are updated or added.
+
 Happy Developing!

--- a/doc/python/job_submission.rst
+++ b/doc/python/job_submission.rst
@@ -55,7 +55,7 @@ Synchronous interface
 ---------------------
 
 
-The simplest way to interact with Flux is with the syncronous functions listed
+The simplest way to interact with Flux is with the synchronous functions listed
 below.
 However, these functions introduce a lot of overhead (e.g. any function that
 waits for a job to reach a certain state, such as ``result``


### PR DESCRIPTION
Problem: the generation and general structure of how a Python file turned into a flux command is mysterious. It was nontrivial to figure out yesterday.

Solution: write a quick guide in the developer python docs to unravel this dark magic.
    
I also found some spelling mistakes (using typos) that I fixed, and I did a separate commit! I hope I did that right.
