### PR TITLE
divide flux(1) help output into sections

### DIFF
--- a/doc/man1/flux-alloc.rst
+++ b/doc/man1/flux-alloc.rst
@@ -1,4 +1,5 @@
 .. flux-help-include: true
+.. flux-help-section: submission
 
 =============
 flux-alloc(1)

--- a/doc/man1/flux-batch.rst
+++ b/doc/man1/flux-batch.rst
@@ -1,4 +1,5 @@
 .. flux-help-include: true
+.. flux-help-section: submission
 
 =============
 flux-batch(1)

--- a/doc/man1/flux-bulksubmit.rst
+++ b/doc/man1/flux-bulksubmit.rst
@@ -1,4 +1,5 @@
 .. flux-help-include: true
+.. flux-help-section: submission
 
 ==================
 flux-bulksubmit(1)

--- a/doc/man1/flux-cron.rst
+++ b/doc/man1/flux-cron.rst
@@ -1,5 +1,3 @@
-.. flux-help-description: Schedule tasks on timers and events
-
 ============
 flux-cron(1)
 ============

--- a/doc/man1/flux-dmesg.rst
+++ b/doc/man1/flux-dmesg.rst
@@ -1,5 +1,3 @@
-.. flux-help-description: manipulate broker log ring buffer
-
 =============
 flux-dmesg(1)
 =============

--- a/doc/man1/flux-dump.rst
+++ b/doc/man1/flux-dump.rst
@@ -1,5 +1,3 @@
-.. flux-help-description: Write KVS snapshot to portable archive
-
 ============
 flux-dump(1)
 ============

--- a/doc/man1/flux-exec.rst
+++ b/doc/man1/flux-exec.rst
@@ -1,5 +1,3 @@
-.. flux-help-include: true
-
 ============
 flux-exec(1)
 ============

--- a/doc/man1/flux-filemap.rst
+++ b/doc/man1/flux-filemap.rst
@@ -1,5 +1,3 @@
-.. flux-help-description: Map files into a Flux instance
-
 ===============
 flux-filemap(1)
 ===============

--- a/doc/man1/flux-getattr.rst
+++ b/doc/man1/flux-getattr.rst
@@ -1,6 +1,3 @@
-.. flux-help-command: {get,set,ls}attr
-.. flux-help-description: Access, modify, and list broker attributes
-
 ===============
 flux-getattr(1)
 ===============

--- a/doc/man1/flux-job.rst
+++ b/doc/man1/flux-job.rst
@@ -1,4 +1,5 @@
-.. flux-help-include: true
+.. flux-help-description: cancel jobs, get job status, etc (see: flux help job) 
+.. flux-help-section: jobs
 
 ===========
 flux-job(1)

--- a/doc/man1/flux-jobs.rst
+++ b/doc/man1/flux-jobs.rst
@@ -1,4 +1,4 @@
-.. flux-help-include: true
+.. flux-help-section: jobs
 
 ============
 flux-jobs(1)

--- a/doc/man1/flux-kvs.rst
+++ b/doc/man1/flux-kvs.rst
@@ -1,5 +1,3 @@
-.. flux-help-include: true
-
 ===========
 flux-kvs(1)
 ===========

--- a/doc/man1/flux-overlay.rst
+++ b/doc/man1/flux-overlay.rst
@@ -1,4 +1,5 @@
 .. flux-help-description: Show flux overlay network status
+.. flux-help-section: instance
 
 ===============
 flux-overlay(1)

--- a/doc/man1/flux-pgrep.rst
+++ b/doc/man1/flux-pgrep.rst
@@ -1,4 +1,6 @@
 .. flux-help-include: true
+.. flux-help-section: jobs
+.. flux-help-command: pgrep/pkill
 
 ==============
 flux-pgrep(1)

--- a/doc/man1/flux-ping.rst
+++ b/doc/man1/flux-ping.rst
@@ -1,5 +1,3 @@
-.. flux-help-include: true
-
 ============
 flux-ping(1)
 ============

--- a/doc/man1/flux-proxy.rst
+++ b/doc/man1/flux-proxy.rst
@@ -1,5 +1,6 @@
 .. flux-help-command: proxy
-.. flux-help-description: Create proxy environment for Flux instance
+.. flux-help-description: proxy connections to Flux jobs and instances
+.. flux-help-section: jobs
 
 =============
 flux-proxy(1)

--- a/doc/man1/flux-pstree.rst
+++ b/doc/man1/flux-pstree.rst
@@ -1,4 +1,5 @@
 .. flux-help-include: true
+.. flux-help-section: jobs
 
 ==============
 flux-pstree(1)

--- a/doc/man1/flux-queue.rst
+++ b/doc/man1/flux-queue.rst
@@ -1,4 +1,5 @@
-.. flux-help-description: Manipulate flux queues
+.. flux-help-description: list and manipulate flux queues
+.. flux-help-section: instance
 
 =============
 flux-queue(1)

--- a/doc/man1/flux-resource.rst
+++ b/doc/man1/flux-resource.rst
@@ -1,4 +1,5 @@
 .. flux-help-include: true
+.. flux-help-section: instance
 
 ================
 flux-resource(1)

--- a/doc/man1/flux-restore.rst
+++ b/doc/man1/flux-restore.rst
@@ -1,5 +1,3 @@
-.. flux-help-description: Read KVS snapshot from portable archive
-
 ===============
 flux-restore(1)
 ===============

--- a/doc/man1/flux-run.rst
+++ b/doc/man1/flux-run.rst
@@ -1,4 +1,5 @@
 .. flux-help-include: true
+.. flux-help-section: submission
 
 ===========
 flux-run(1)

--- a/doc/man1/flux-shutdown.rst
+++ b/doc/man1/flux-shutdown.rst
@@ -1,5 +1,3 @@
-.. flux-help-description: Shut down a Flux instance
-
 ================
 flux-shutdown(1)
 ================

--- a/doc/man1/flux-startlog.rst
+++ b/doc/man1/flux-startlog.rst
@@ -1,5 +1,3 @@
-.. flux-help-description: Show Flux instance start and stop times
-
 ================
 flux-startlog(1)
 ================

--- a/doc/man1/flux-submit.rst
+++ b/doc/man1/flux-submit.rst
@@ -1,4 +1,5 @@
 .. flux-help-include: true
+.. flux-help-section: submission
 
 ==============
 flux-submit(1)

--- a/doc/man1/flux-top.rst
+++ b/doc/man1/flux-top.rst
@@ -1,4 +1,5 @@
-.. flux-help-description: Display Running Flux Jobs
+.. flux-help-description: display running Flux jobs
+.. flux-help-section: jobs
 
 ===========
 flux-top(1)

--- a/doc/man1/flux-uptime.rst
+++ b/doc/man1/flux-uptime.rst
@@ -1,4 +1,5 @@
 .. flux-help-description: Tell how long Flux has been up and running
+.. flux-help-section: instance
 
 ==============
 flux-uptime(1)

--- a/doc/manpages.py
+++ b/doc/manpages.py
@@ -16,8 +16,15 @@ author = 'This page is maintained by the Flux community.'
 # - Man page description
 # - Author (use [author])
 # - Manual section
+#
+# Note: the relative order of commands in this list affects the order
+# in which commands appear within a section in the output of flux help.
+# Therefore, keep these commands in relative order of importance.
+#
 man_pages = [
     ('man1/flux-broker', 'flux-broker', 'Flux message broker daemon', [author], 1),
+    ('man1/flux-start', 'flux-start', 'bootstrap a local Flux instance', [author], 1),
+    ('man1/flux-version', 'flux-version', 'Display flux version information', [author], 1),
     ('man1/flux-config', 'flux-config', 'Manage/query Flux configuration', [author], 1),
     ('man1/flux-content', 'flux-content', 'access content service', [author], 1),
     ('man1/flux-cron', 'flux-cron', 'Cron-like utility for Flux', [author], 1),
@@ -31,14 +38,15 @@ man_pages = [
     ('man1/flux-getattr', 'flux-lsattr', 'access broker attributes', [author], 1),
     ('man1/flux-getattr', 'flux-getattr', 'access broker attributes', [author], 1),
     ('man1/flux-jobs', 'flux-jobs', 'list jobs submitted to Flux', [author], 1),
+    ('man1/flux-top', 'flux-top', 'Display running Flux jobs', [author], 1),
     ('man1/flux-pstree', 'flux-pstree', 'display job hierarchies', [author], 1),
     ('man1/flux-pgrep', 'flux-pgrep', 'search or cancel matching jobs', [author], 1),
     ('man1/flux-pgrep', 'flux-pkill', 'search or cancel matching jobs', [author], 1),
     ('man1/flux-jobtap', 'flux-jobtap', 'List, remove, and load job-manager plugins', [author], 1),
-    ('man1/flux-uptime', 'flux-uptime', 'Tell how long Flux has been up and running', [author], 1),
     ('man1/flux-shutdown', 'flux-shutdown', 'Shut down a Flux instance', [author], 1),
     ('man1/flux-uri', 'flux-uri', 'resolve Flux URIs', [author], 1),
     ('man1/flux-resource', 'flux-resource', 'list/manipulate Flux resource status', [author], 1),
+    ('man1/flux-queue', 'flux-queue', 'manage the job queue', [author], 1),
     ('man1/flux-restore', 'flux-restore', 'Read KVS snapshot from portable archive', [author], 1),
     ('man1/flux-keygen', 'flux-keygen', 'generate keys for Flux security', [author], 1),
     ('man1/flux-kvs', 'flux-kvs', 'Flux key-value store utility', [author], 1),
@@ -52,13 +60,10 @@ man_pages = [
     ('man1/flux-job', 'flux-job', 'Job Housekeeping Tool', [author], 1),
     ('man1/flux-module', 'flux-module', 'manage Flux extension modules', [author], 1),
     ('man1/flux-overlay', 'flux-overlay', 'Show flux overlay network status', [author], 1),
+    ('man1/flux-uptime', 'flux-uptime', 'Tell how long Flux has been up and running', [author], 1),
     ('man1/flux-ping', 'flux-ping', 'measure round-trip latency to Flux services', [author], 1),
     ('man1/flux-proxy', 'flux-proxy', 'create proxy environment for Flux instance', [author], 1),
-    ('man1/flux-queue', 'flux-queue', 'manage the job queue', [author], 1),
-    ('man1/flux-start', 'flux-start', 'bootstrap a local Flux instance', [author], 1),
     ('man1/flux-startlog', 'flux-startlog', 'Show Flux instance start and stop times', [author], 1),
-    ('man1/flux-top', 'flux-top', 'Display running Flux jobs', [author], 1),
-    ('man1/flux-version', 'flux-version', 'Display flux version information', [author], 1),
     ('man1/flux', 'flux', 'the Flux resource management framework', [author], 1),
     ('man1/flux-shell', 'flux-shell', 'the Flux job shell', [author], 1),
     ('man3/flux_attr_get', 'flux_attr_set', 'get/set Flux broker attributes', [author], 3),

--- a/etc/gen-cmdhelp.py
+++ b/etc/gen-cmdhelp.py
@@ -20,6 +20,37 @@ import sys
 import json
 from os import path
 
+
+class HelpEntries:
+    def __init__(self):
+        self.sections = [
+            {
+                "name": "submission",
+                "description": "run and submit jobs, allocate resources",
+            },
+            {
+                "name": "jobs",
+                "description": "list and interact with jobs",
+            },
+            {
+                "name": "instance",
+                "description": "get resource, queue and other instance information",
+            },
+            {
+                "name": "other",
+                "description": "other useful commands",
+            },
+        ]
+        for entry in self.sections:
+            entry["commands"] = []
+
+    def add_entry(self, name, description, section="other"):
+        for entry in self.sections:
+            if entry["name"] == section:
+                info = dict(name=name, description=description)
+                entry["commands"].append(info)
+
+
 if len(sys.argv) < 2:
     print(f"Usage: {sys.argv[0]} sphinxconf.py", file=sys.stderr)
 
@@ -30,16 +61,17 @@ docsdir = os.path.abspath(path.dirname(sphinxconf))
 sys.path.insert(0, docsdir)
 from manpages import man_pages
 
-entries = []
 visited = dict()
 
-for (path, cmd, descr, author, section) in man_pages:
-    if section != 1 or path in visited:
+entries = HelpEntries()
+for (path, cmd, descr, author, sec) in man_pages:
+    if sec != 1 or path in visited:
         continue
     visited[path] = True
     rst_file = os.path.join(docsdir, f"{path}.rst")
-    with open(rst_file, "r", encoding='utf-8') as f:
+    with open(rst_file, "r", encoding="utf-8") as f:
         include_flag = False
+        section = "other"
         for line in f:
             line = line.rstrip("\n")
             if ".. flux-help-" in line:
@@ -50,12 +82,11 @@ for (path, cmd, descr, author, section) in man_pages:
                     descr = " ".join(line.split(" ")[2:])
                 if ".. flux-help-command: " in line:
                     cmd = " ".join(line.split(" ")[2:])
+                if ".. flux-help-section: " in line:
+                    section = " ".join(line.split(" ")[2:])
 
         if include_flag:
-            entry = dict(category="core", command=cmd, description=descr)
-            entries.append(entry)
+            entries.add_entry(cmd, descr, section)
 
-# Sort entries by the command name
-entries = sorted(entries, key=lambda d: d['command'])
-print(json.dumps(entries, indent=2, sort_keys=True), file=sys.stdout)
+print(json.dumps(entries.sections, indent=2, sort_keys=True), file=sys.stdout)
 sys.path.pop(0)

--- a/src/cmd/flux.c
+++ b/src/cmd/flux.c
@@ -74,6 +74,9 @@ void usage (optparse_t *p)
     fprintf (stderr, "For general Flux documentation, please visit\n");
     fprintf (stderr, "    https://flux-framework.readthedocs.io\n");
     emit_command_help (help_pattern, stderr);
+    fprintf (stderr, "\n");
+    fprintf (stderr, "See 'flux help COMMAND' for more information about ");
+    fprintf (stderr, "a specific command.\n");
     free (help_pattern);
 }
 

--- a/src/cmd/flux.c
+++ b/src/cmd/flux.c
@@ -73,7 +73,6 @@ void usage (optparse_t *p)
     fprintf (stderr, "\n");
     fprintf (stderr, "For general Flux documentation, please visit\n");
     fprintf (stderr, "    https://flux-framework.readthedocs.io\n");
-    fprintf (stderr, "\n");
     emit_command_help (help_pattern, stderr);
     free (help_pattern);
 }

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -561,29 +561,22 @@ test_expect_success 'broker fails on invalid broker.critical-ranks option' '
 test_expect_success 'broker fails on unknown option' '
 	test_must_fail flux start ${ARGS} -o,--not-an-option /bin/true
 '
-
 test_expect_success 'flux-help command list can be extended' '
 	mkdir help.d &&
 	cat <<-EOF  > help.d/test.json &&
-	[{ "category": "test", "command": "test", "description": "a test" }]
+	[{ "name": "test", "description": "test commands",
+	 "commands": [ {"name": "test", "description": "a test" }]}]
 	EOF
-	flux help 2>&1 | sed "0,/^$/d" >help.expected &&
-	cat <<-EOF  >>help.expected &&
-	Common commands from flux-test:
-	   test               a test
-	EOF
-	FLUX_CMDHELP_PATTERN="help.d/*" flux help 2>&1 | sed "0,/^$/d" > help.out &&
-	test_cmp help.expected help.out &&
+	FLUX_CMDHELP_PATTERN="help.d/*" flux help > help.out 2>&1 &&
+	grep "^test commands" help.out &&
+	grep "a test" help.out &&
 	cat <<-EOF  > help.d/test2.json &&
-	[{ "category": "test2", "command": "test2", "description": "a test two" }]
+	[{ "name": "test", "description": "test two commands",
+	 "commands": [ {"name": "test2", "description": "a test two"}]}]
 	EOF
-	cat <<-EOF  >>help.expected &&
-
-	Common commands from flux-test2:
-	   test2              a test two
-	EOF
-	FLUX_CMDHELP_PATTERN="help.d/*" flux help 2>&1 | sed "0,/^$/d" > help.out &&
-	test_cmp help.expected help.out
+	FLUX_CMDHELP_PATTERN="help.d/*" flux help > help2.out 2>&1 &&
+	grep "^test two commands" help2.out &&
+	grep "a test two" help2.out
 '
 test_expect_success 'flux-help command can display manpages for subcommands' '
 	PWD=$(pwd) &&


### PR DESCRIPTION
This PR reworks the output of `flux help` to use sections (like `git help`) to be a little more user friendly.
Also, some "plumbing" commands (like `flux kvs`, `flux get/set/lsattr`) are dropped so that all the commands listed are the most important commands for new users.

Also added a little note at the end of `flux help` output to use `flux help COMMAND` to get help on a specific command.

The method of building the `flux help` output from tags in man page source is kept for now, though I'm unsure if that is the correct long term approach. However, this should be a pretty big step forward for now.

New output:
```
Usage: flux [OPTIONS] COMMAND ARGS
  -h, --help             Display this message.
  -v, --verbose          Be verbose about environment and command search
  -V, --version          Display command and component versions
  -p, --parent           Set environment of parent instead of current instance

For general Flux documentation, please visit
    https://flux-framework.readthedocs.io

run and submit jobs, allocate resources
   submit             submit a job to a Flux instance
   run                run a Flux job interactively
   bulksubmit         submit jobs in bulk to a Flux instance
   alloc              allocate a new Flux instance for interactive use
   batch              submit a batch script to Flux

list and interact with jobs
   jobs               list jobs submitted to Flux
   top                display running Flux jobs
   pstree             display job hierarchies
   pgrep/pkill        search or cancel matching jobs
   job                cancel jobs, get job status, etc (see: flux help job) 
   proxy              proxy connections to Flux jobs and instances

get resource, queue and other instance information
   resource           list/manipulate Flux resource status
   queue              list and manipulate flux queues
   overlay            Show flux overlay network status
   uptime             Tell how long Flux has been up and running

other useful commands
   start              bootstrap a local Flux instance
   version            Display flux version information
   config             Manage/query Flux configuration
   env                Print the flux environment or execute a command inside it

See 'flux help COMMAND' for more information about a specific command.
```