### PR TITLE
allow flux-core to be configured in ascii-only mode

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -416,6 +416,15 @@ AS_IF([test "x$enable_content_s3" = "xyes"], [
 
 AM_CONDITIONAL([ENABLE_CONTENT_S3], [test "x$enable_content_s3" = "xyes"])
 
+AC_ARG_ENABLE(
+    [broken-locale-mode],
+    AS_HELP_STRING([--enable-broken-locale-mode],
+                   [Assume broken locale config and use ascii only]))
+
+if test "$enable_broken_locale_mode" = "yes"; then
+  AC_DEFINE([ASSUME_BROKEN_LOCALE], [1],
+    [assume broken locale configuration and disable non-ascii characters])
+fi
 
 ##
 # Check for systemd

--- a/doc/man1/flux-job.rst
+++ b/doc/man1/flux-job.rst
@@ -1,4 +1,4 @@
-.. flux-help-description: cancel jobs, get job status, etc (see: flux help job) 
+.. flux-help-description: cancel jobs, get job status, etc (see: flux help job)
 .. flux-help-section: jobs
 
 ===========

--- a/src/cmd/builtin/version.c
+++ b/src/cmd/builtin/version.c
@@ -52,6 +52,9 @@ static int cmd_version (optparse_t *p, int ac, char *av[])
 #endif
     print_broker_version (p);
     printf ("build-options:\t\t");
+#if ASSUME_BROKEN_LOCALE
+    printf("+ascii-only");
+#endif
 #if __SANITIZE_ADDRESS__
     printf ("+asan");
 #endif

--- a/src/cmd/top/top.c
+++ b/src/cmd/top/top.c
@@ -322,11 +322,14 @@ struct top *top_create (const char *uri,
     top->keys = keys_create (top);
     top->summary_pane = summary_pane_create (top);
     top->joblist_pane = joblist_pane_create (top);
-
+#if ASSUME_BROKEN_LOCALE
+    top->f_char = "f";
+#else
     if (getenv ("FLUX_F58_FORCE_ASCII"))
         top->f_char = "f";
     else
         top->f_char = "ƒ";
+#endif /* ASSUME_BROKEN_LOCALE */
     return top;
 fail:
     top_destroy (top);

--- a/src/common/libjob/test/job.c
+++ b/src/common/libjob/test/job.c
@@ -368,28 +368,44 @@ struct jobid_parse_test jobid_parse_tests[] = {
     { "dothex", 0,     "0000.0000.0000.0000" },
     { "kvs",    0,     "job.0000.0000.0000.0000" },
     { "words",  0,     "academy-academy-academy--academy-academy-academy" },
+#if ASSUME_BROKEN_LOCALE
+    { "f58",    0,     "f1" },
+#else
     { "f58",    0,     "ƒ1" },
+#endif
 
     { "dec",    1,     "1" },
     { "hex",    1,     "0x1" },
     { "dothex", 1,     "0000.0000.0000.0001" },
     { "kvs",    1,     "job.0000.0000.0000.0001" },
     { "words",  1,     "acrobat-academy-academy--academy-academy-academy" },
+#if ASSUME_BROKEN_LOCALE
+    { "f58",    1,     "f2" },
+#else
     { "f58",    1,     "ƒ2" },
+#endif
 
     { "dec",    65535, "65535" },
     { "hex",    65535, "0xffff" },
     { "dothex", 65535, "0000.0000.0000.ffff" },
     { "kvs",    65535, "job.0000.0000.0000.ffff" },
     { "words",  65535, "nevada-archive-academy--academy-academy-academy" },
+#if ASSUME_BROKEN_LOCALE
+    { "f58",    65535, "fLUv" },
+#else
     { "f58",    65535, "ƒLUv" },
+#endif
 
     { "dec",    6787342413402046, "6787342413402046" },
     { "hex",    6787342413402046, "0x181d0d4d850fbe" },
     { "dothex", 6787342413402046, "0018.1d0d.4d85.0fbe" },
     { "kvs",    6787342413402046, "job.0018.1d0d.4d85.0fbe" },
     { "words",  6787342413402046, "cake-plume-nepal--neuron-pencil-academy" },
+#if ASSUME_BROKEN_LOCALE
+    { "f58",    6787342413402046, "fuzzybunny" },
+#else
     { "f58",    6787342413402046, "ƒuzzybunny" },
+#endif
 
     { NULL, 0, NULL }
 };

--- a/src/common/libutil/fluid.c
+++ b/src/common/libutil/fluid.c
@@ -35,8 +35,13 @@ static const int bits_per_seq = 10;
 /* Max base58 string length for F58 encoding */
 #define MAX_B58_STRLEN 12
 
+#if ASSUME_BROKEN_LOCALE
+static const char f58_prefix[] = "f";
+static const char f58_alt_prefix[] = "ƒ";
+#else
 static const char f58_prefix[] = "ƒ";
 static const char f58_alt_prefix[] = "f";
+#endif /* ASSUME_BROKEN_LOCALE */
 
 /*  b58digits_map courtesy of libbase58:
  *
@@ -194,9 +199,11 @@ static int fluid_f58_encode (char *buf, int bufsz, fluid_t id)
         return -1;
     }
 
+#if !ASSUME_BROKEN_LOCALE
     /* Use alternate "f" prefix if locale is not multibyte */
     if (!is_utf8_locale())
         prefix = f58_alt_prefix;
+#endif
 
     if (bufsz <= strlen (prefix) + 1) {
         errno = EOVERFLOW;

--- a/src/common/libutil/test/fluid.c
+++ b/src/common/libutil/test/fluid.c
@@ -22,6 +22,7 @@ struct f58_test {
 };
 
 struct f58_test f58_tests [] = {
+#if !ASSUME_BROKEN_LOCALE
     { 0, "ƒ1", "f1" },
     { 1, "ƒ2", "f2" },
     { 57, "ƒz", "fz" },
@@ -36,6 +37,7 @@ struct f58_test f58_tests [] = {
     { 6731191091817518LL, "ƒuZZybuNNy", "fuZZybuNNy" },
     { 18446744073709551614UL, "ƒjpXCZedGfVP", "fjpXCZedGfVP" },
     { 18446744073709551615UL, "ƒjpXCZedGfVQ", "fjpXCZedGfVQ" },
+#endif
     { 0, NULL, NULL },
 };
 
@@ -123,6 +125,7 @@ struct fluid_parse_test {
 };
 
 struct fluid_parse_test fluid_parse_tests [] = {
+#if !ASSUME_BROEN_LOCALE
     { 0, "ƒ1" },
     { 1, "ƒ2" },
     { 57, "ƒz" },
@@ -137,6 +140,7 @@ struct fluid_parse_test fluid_parse_tests [] = {
     { 6731191091817518LL, "ƒuZZybuNNy" },
     { 18446744073709551614UL, "ƒjpXCZedGfVP" },
     { 18446744073709551615UL, "ƒjpXCZedGfVQ" },
+#endif
     { 0, "f1" },
     { 1, "f2" },
     { 4294967295, "f7YXq9G" },

--- a/src/test/generate-matrix.py
+++ b/src/test/generate-matrix.py
@@ -213,6 +213,13 @@ matrix.add_build(
     docker_tag=True,
 )
 
+# RHEL8 clone
+matrix.add_build(
+    name="el8 - ascii",
+    image="el8",
+    args="--enable-broken-locale-mode",
+)
+
 # RHEL8 clone, system, coverage
 matrix.add_build(
     name="el8 - system,coverage",

--- a/t/python/t0010-job.py
+++ b/t/python/t0010-job.py
@@ -19,6 +19,7 @@ import datetime
 import signal
 import locale
 import pathlib
+import subprocess
 from glob import glob
 
 import yaml
@@ -45,7 +46,10 @@ class TestJob(unittest.TestCase):
     @classmethod
     def setUpClass(self):
         self.fh = flux.Flux()
-        self.use_ascii = locale.getlocale()[1] != "UTF-8"
+        self.use_ascii = False
+        build_opts = subprocess.check_output(["flux", "version"]).decode()
+        if  locale.getlocale()[1] != "UTF-8" or "ascii-only" in build_opts:
+            self.use_ascii = True
 
         self.jobspec_dir = os.path.abspath(
             os.path.join(os.environ["FLUX_SOURCE_DIR"], "t", "jobspec")

--- a/t/t2201-job-cmd.t
+++ b/t/t2201-job-cmd.t
@@ -170,6 +170,9 @@ test_expect_success 'flux-job: id --to=f58 works' '
 '
 
 UTF8_LOCALE=$(locale -a | grep UTF-8 | head -n1)
+if flux version | grep +ascii-only; then
+	UTF8_LOCALE=""
+fi
 test -n "$UTF8_LOCALE" && test_set_prereq UTF8_LOCALE
 test_expect_success UTF8_LOCALE 'flux-job: f58 can use multibyte prefix' '
 	test_debug "echo UTF8_LOCALE=${UTF8_LOCALE}" &&


### PR DESCRIPTION
This PR adds a new option to flux-core configure: `--enable-broken-locale-mode`, which when used causes flux-core to avoid using the non-ascii `ƒ` character as a FLUID prefix (and in `flux top` etc). It is offered as more fool-proof way to disable the "fancy" character for install where locales or terminals are known to be misconfigured such that `ƒ` does not display correctly.

In these environments, RPMs can be built with this option and the question of when/how to set `FLUX_F58_FORCE_ASCII` can be avoided.

Set as a WIP in case others have better ideas, and because I'm considering if we need a CI builder with this option enabled.