### PR TITLE
flux-filemap: update to RFC 37 internally

### DIFF
--- a/doc/man1/flux-filemap.rst
+++ b/doc/man1/flux-filemap.rst
@@ -75,8 +75,8 @@ OPTIONS
 **--blobref**
    List blobrefs (*list* subcommand only).
 
-**--fileref**
-   List fileref objects (*list* subcommand only).
+**--raw**
+   List RFC 37 file system objects (*list* subcommand only).
 
 EXAMPLE
 =======

--- a/doc/man1/flux-filemap.rst
+++ b/doc/man1/flux-filemap.rst
@@ -74,6 +74,10 @@ OPTIONS
 **--disable-mmap**
    Never map a regular file through the distributed content cache.
 
+**--chunksize=N**
+   Limit the content mapped blob size to N bytes.  Set to 0 for unlimited.
+   The default is 1048576 (*map* subcommand only).
+
 **--direct**
    Avoid indirection through the content cache when fetching the top level
    data for each file.  This may be fastest for a single or small number of

--- a/doc/man1/flux-filemap.rst
+++ b/doc/man1/flux-filemap.rst
@@ -66,6 +66,14 @@ OPTIONS
 **-l, --long**
    Include more detail in file listing (*list* subcommand only).
 
+**--small-file-threshold=N**
+   Set the threshold in bytes over which a regular file is mapped through
+   the distributed content cache.  Set to 0 to always use the content cache.
+   The default is 4096 (*map* subcommand only).
+
+**--disable-mmap**
+   Never map a regular file through the distributed content cache.
+
 **--direct**
    Avoid indirection through the content cache when fetching the top level
    data for each file.  This may be fastest for a single or small number of

--- a/src/broker/content-mmap.c
+++ b/src/broker/content-mmap.c
@@ -445,6 +445,7 @@ static struct content_region *content_mmap_region_create (
                                             fpath,
                                             mm->hash_name,
                                             chunksize,
+                                            4096,
                                             &reg->data,
                                             &reg->data_size,
                                             error)))

--- a/src/cmd/builtin/filemap.c
+++ b/src/cmd/builtin/filemap.c
@@ -322,9 +322,9 @@ static int subcmd_list (optparse_t *p, int ac, char *av[])
             if (optparse_hasopt (p, "blobref")) {
                 printf ("%s\n", json_string_value (entry));
             }
-            else if (optparse_hasopt (p, "fileref")) {
+            else if (optparse_hasopt (p, "raw")) {
                 if (json_dumpf (entry, stdout, JSON_COMPACT) < 0)
-                    log_msg_exit ("error dumping fileref object");
+                    log_msg_exit ("error dumping RFC 37 file system object");
             }
             else {
                 char buf[1024];
@@ -569,8 +569,8 @@ static struct optparse_option list_opts[] = {
       .usage = "Show file type, mode, size", },
     { .name = "blobref", .has_arg = 0,
       .usage = "List blobrefs only, do not dereference them", },
-    { .name = "fileref", .has_arg = 0,
-      .usage = "Show raw fileref without decoding", },
+    { .name = "raw", .has_arg = 0,
+      .usage = "Show raw RFC 37 file system object without decoding", },
     { .name = "tags", .key = 'T', .has_arg = 1, .arginfo = "NAME,...",
       .flags = OPTPARSE_OPT_AUTOSPLIT,
       .usage = "Specify comma-separated tags (default: main)", },

--- a/src/cmd/builtin/filemap.c
+++ b/src/cmd/builtin/filemap.c
@@ -22,6 +22,7 @@
 #include <archive_entry.h>
 
 #include "ccan/base64/base64.h"
+#include "ccan/str/str.h"
 #include "src/common/libutil/dirwalk.h"
 #include "src/common/libutil/errno_safe.h"
 #include "src/common/libcontent/content.h"
@@ -349,7 +350,11 @@ static int subcmd_list (optparse_t *p, int ac, char *av[])
             }
             else {
                 char buf[1024];
-                fileref_pretty_print (entry, long_form, buf, sizeof (buf));
+                fileref_pretty_print (entry,
+                                      NULL,
+                                      long_form,
+                                      buf,
+                                      sizeof (buf));
                 printf ("%s\n", buf);
             }
         }
@@ -415,12 +420,12 @@ static void extract_file (flux_t *h,
 {
     int verbose = optparse_get_int (p, "verbose", 0);
     const char *path;
-    json_int_t size;
-    json_int_t ctime;
-    json_int_t mtime;
     int mode;
-    json_t *blobvec;
-    const char *data = NULL;
+    json_int_t size = -1;
+    json_int_t ctime = -1;
+    json_int_t mtime = -1;
+    const char *encoding = NULL;
+    json_t *data = NULL;
     size_t index;
     json_t *o;
     struct archive_entry *entry;
@@ -429,14 +434,14 @@ static void extract_file (flux_t *h,
     if (json_unpack_ex (fileref,
                         &error,
                         0,
-                        "{s:s s:I s:I s:I s:i s?s s:o}",
+                        "{s:s s:i s?I s?I s?I s?s s?o}",
                         "path", &path,
+                        "mode", &mode,
                         "size", &size,
                         "mtime", &mtime,
                         "ctime", &ctime,
-                        "mode", &mode,
-                        "data", &data,
-                        "blobvec", &blobvec) < 0)
+                        "encoding", &encoding,
+                        "data", &data) < 0)
         log_msg_exit ("error decoding fileref object: %s", error.text);
 
     if (verbose > 0)
@@ -448,15 +453,19 @@ static void extract_file (flux_t *h,
         log_msg_exit ("%s: error creating libarchive entry", path);
     archive_entry_set_pathname (entry, path);
     archive_entry_set_mode (entry, mode);
-    archive_entry_set_mtime (entry, mtime, 0);
-    archive_entry_set_ctime (entry, ctime, 0);
+    if (mtime != -1)
+        archive_entry_set_mtime (entry, mtime, 0);
+    if (ctime != -1)
+        archive_entry_set_ctime (entry, ctime, 0);
     if (S_ISREG (mode)) {
-        archive_entry_set_size (entry, size);
+        if (size != -1)
+            archive_entry_set_size (entry, size);
     }
     else if (S_ISLNK (mode)) {
-        if (!data)
+        const char *target;
+        if (!data || !(target = json_string_value (data)))
             log_msg_exit ("%s: missing symlink data", path);
-        archive_entry_set_symlink (entry, data);
+        archive_entry_set_symlink (entry, target);
     }
     else if (!S_ISDIR (mode)) // nothing to do for directory
         log_msg_exit ("%s: unknown file type (mode=0%o)", path, mode);
@@ -465,13 +474,28 @@ static void extract_file (flux_t *h,
 
     /* data
      */
-    if (S_ISREG (mode)) {
-        if (data) { // small file is contained in fileref.data
+    if (S_ISREG (mode) && data != NULL) {
+        if (!encoding) {
+          char *str;
+            if (!(str = json_dumps (data, JSON_ENCODE_ANY | JSON_COMPACT)))
+                log_msg_exit ("%s: could not encode JSON file data", path);
+            if (archive_write_data_block (archive,
+                                          str,
+                                          strlen (str),
+                                          0) != ARCHIVE_OK) {
+                log_msg_exit ("%s: write: %s",
+                              path,
+                              archive_error_string (archive));
+            }
+            free (str);
+        }
+        else if (streq (encoding, "base64")) {
+            const char *str = json_string_value (data);
             void *buf;
             size_t buf_size;
 
-            if (decode_data (data, &buf, &buf_size) < 0)
-                log_msg_exit ("%s: could not decode file data", path);
+            if (!str || decode_data (str, &buf, &buf_size) < 0)
+                log_msg_exit ("%s: could not decode base64 file data", path);
             if (archive_write_data_block (archive,
                                           buf,
                                           buf_size,
@@ -482,10 +506,26 @@ static void extract_file (flux_t *h,
             }
             free (buf);
         }
-        else { // large file is spread over multiple blobrefs
-            json_array_foreach (blobvec, index, o) {
+        else if (streq (encoding, "blobvec")) {
+            json_array_foreach (data, index, o) {
                 extract_blob (h, archive, path, o);
             }
+        }
+        else if (streq (encoding, "utf-8")) {
+            const char *str = json_string_value (data);
+            if (!str)
+                log_msg_exit ("%s: unexpected data type for utf8", path);
+            if (archive_write_data_block (archive,
+                                          str,
+                                          strlen (str),
+                                          0) != ARCHIVE_OK) {
+                log_msg_exit ("%s: write: %s",
+                              path,
+                              archive_error_string (archive));
+            }
+        }
+        else {
+            log_msg_exit ("%s: unknown RFC 37 encoding %s", path, encoding);
         }
     }
 

--- a/src/cmd/builtin/filemap.c
+++ b/src/cmd/builtin/filemap.c
@@ -153,8 +153,8 @@ static flux_future_t *mmap_add (flux_t *h,
                        "{s:s s:s s:i s:O}",
                        "path", path,
                        "fullpath", fpath,
-                        "chunksize", chunksize,
-                        "tags", tags);
+                       "chunksize", chunksize,
+                       "tags", tags);
     ERRNO_SAFE_WRAP (free, fpath);
     return f;
 }

--- a/src/common/libutil/fileref.c
+++ b/src/common/libutil/fileref.c
@@ -8,24 +8,7 @@
  * SPDX-License-Identifier: LGPL-3.0
 \************************************************************/
 
-/* fileref.c - manipulate "fileref" object
- *
- * { "version":1,
- *   "type":"fileref",
- *   "path":s,
- *   "size":I,
- *   "ctime":I,
- *   "mtime":I,
- *   "mode":i,
- *   "data"?s,
- *   "blobvec":[
- *      [I,I,s],
- *      [I,I,s],
- *      ...
- *   ]
- * }
- *
- * where blobvec array entries are a 3-tuple of [offset, size, blobref]
+/* fileref.c - helpers for RFC 37 file system objects
  */
 
 #if HAVE_CONFIG_H
@@ -72,28 +55,39 @@ static int blobvec_append (json_t *blobvec,
     return 0;
 }
 
+static bool file_has_no_data (int fd)
+{
+    if (lseek (fd, 0, SEEK_DATA) == (off_t)-1 && errno == ENXIO)
+        return true;
+    return false;
+}
+
 /* Walk the regular file represented by 'fd', appending blobvec array entries
  * to 'blobvec' array for each 'chunksize' region.  Use SEEK_DATA and SEEK_HOLE
  * to skip holes in sparse files - see lseek(2).
  */
-static int blobvec_populate (json_t *blobvec,
-                             int fd,
-                             const void *mapbuf,
-                             size_t size,
-                             const char *hashtype,
-                             int chunksize)
+static json_t *blobvec_create (int fd,
+                               const void *mapbuf,
+                               size_t size,
+                               const char *hashtype,
+                               int chunksize)
 {
+    json_t *blobvec;
     off_t offset = 0;
 
     assert (fd >= 0);
     assert (size > 0);
 
+    if (!(blobvec = json_array ())) {
+        errno = ENOMEM;
+        goto error;
+    }
     while (offset < size) {
         // N.B. fails with ENXIO if there is no more data
         if ((offset = lseek (fd, offset, SEEK_DATA)) == (off_t)-1) {
             if (errno == ENXIO)
                 break;
-            return -1;
+            goto error;
         }
         if (offset < size) {
             off_t notdata;
@@ -101,7 +95,7 @@ static int blobvec_populate (json_t *blobvec,
 
             // N.B. returns size if there are no more holes
             if ((notdata = lseek (fd, offset, SEEK_HOLE)) == (off_t)-1)
-                return -1;
+                goto error;
             blobsize = notdata - offset;
             if (blobsize > chunksize)
                 blobsize = chunksize;
@@ -110,56 +104,172 @@ static int blobvec_populate (json_t *blobvec,
                                 offset,
                                 blobsize,
                                 hashtype) < 0)
-                return -1;
+                goto error;
             offset += blobsize;
         }
     }
-    return 0;
+    return blobvec;
+error:
+    ERRNO_SAFE_WRAP (json_decref, blobvec);
+    return NULL;
 }
 
-/* Optionally set fileref.data (string).
- * If 'data' is NULL do nothing.
- * If encode_base64 is false, assume 'data' is NULL terminated and use directly.
- * If encode_base64 is true, base64-encode it first.
- */
-static int set_optional_data (json_t *fileref,
-                              const void *data,
-                              size_t data_size,
-                              bool encode_base64)
+static json_t *fileref_create_blobvec (const char *path,
+                                       int fd,
+                                       void *mapbuf,
+                                       struct stat *sb,
+                                       const char *hashtype,
+                                       int chunksize,
+                                       flux_error_t *error)
 {
-    if (data) {
-        json_t *o;
+    json_t *blobvec;
+    json_t *o;
 
-        if (encode_base64) {
-            char *buf = NULL;
-            size_t bufsize = base64_encoded_length (data_size) + 1; // +1 NULL
-
-            if (!(buf = malloc (bufsize)))
-                return -1;
-            if (base64_encode (buf, bufsize, data, data_size) < 0) {
-                free (buf);
-                errno = EINVAL;
-                return -1;
-            }
-            o = json_string (buf);
-            free (buf);
-        }
-        else
-            o = json_string (data);
-        if (!o
-            || json_object_set_new (fileref, "data", o) < 0) {
-            json_decref (o);
-            errno = ENOMEM;
-            return -1;
-        }
+    blobvec = blobvec_create (fd, mapbuf, sb->st_size, hashtype, chunksize);
+    if (!blobvec) {
+        errprintf (error,
+                   "%s: error creating blobvec array: %s",
+                   path,
+                   strerror (errno));
+        goto error;
     }
-    return 0;
+    if (!(o = json_pack ("{s:s s:s s:O s:I s:I s:I s:i}",
+                         "path", path,
+                         "encoding", "blobvec",
+                         "data", blobvec,
+                         "size", (json_int_t)sb->st_size,
+                         "mtime", (json_int_t)sb->st_mtime,
+                         "ctime", (json_int_t)sb->st_ctime,
+                         "mode", sb->st_mode))) {
+        errprintf (error, "%s: error packing blobvec file object", path);
+        errno = ENOMEM;
+        goto error;
+    }
+    json_decref (blobvec);
+    return o;
+error:
+    ERRNO_SAFE_WRAP (json_decref, blobvec);
+    return NULL;
 }
 
-/* Create fileref object representing regular file, symbolic link, or
- * directory. 'fullpath' is used to open/stat the file, while 'path' is
- * recorded in the fileref object.
- */
+static json_t *fileref_create_base64 (const char *path,
+                                      int fd,
+                                      struct stat *sb,
+                                      flux_error_t *error)
+{
+    json_t *o;
+    void *data = NULL;
+    size_t data_size;
+    char *buf = NULL;
+    size_t bufsize;
+
+    if ((data_size = read_all (fd, &data)) < 0) {
+        errprintf (error, "%s: %s", path, strerror (errno));
+        goto error;
+    }
+    if (data_size < sb->st_size) {
+        errprintf (error, "%s: short read", path);
+        goto inval;
+    }
+    bufsize = base64_encoded_length (data_size) + 1; // +1 NULL
+    if (!(buf = malloc (bufsize))) {
+        errprintf (error, "%s: out of memory while encoding", path);
+        goto error;
+    }
+    if (base64_encode (buf, bufsize, data, data_size) < 0) {
+        errprintf (error, "%s: base64_encode error", path);
+        goto inval;
+    }
+    if (!(o = json_pack ("{s:s s:s s:s s:I s:I s:I s:i}",
+                         "path", path,
+                         "encoding", "base64",
+                         "data", buf,
+                         "size", (json_int_t)sb->st_size,
+                         "mtime", (json_int_t)sb->st_mtime,
+                         "ctime", (json_int_t)sb->st_ctime,
+                         "mode", sb->st_mode))) {
+        errprintf (error, "%s: error packing base64 file object", path);
+        errno = ENOMEM;
+        goto error;
+    }
+    free (buf);
+    free (data);
+    return o;
+inval:
+    errno = EINVAL;
+error:
+    ERRNO_SAFE_WRAP (free, buf);
+    ERRNO_SAFE_WRAP (free, data);
+    return NULL;
+}
+
+static json_t *fileref_create_empty (const char *path,
+                                     struct stat *sb,
+                                     flux_error_t *error)
+{
+    json_t *o;
+
+    if (!(o = json_pack ("{s:s s:I s:I s:I s:i}",
+                         "path", path,
+                         "size", (json_int_t)sb->st_size,
+                         "mtime", (json_int_t)sb->st_mtime,
+                         "ctime", (json_int_t)sb->st_ctime,
+                         "mode", sb->st_mode))) {
+        errprintf (error, "%s: error packing empty file object", path);
+        errno = ENOMEM;
+        return NULL;
+    }
+    return o;
+}
+
+static json_t *fileref_create_directory (const char *path,
+                                         struct stat *sb,
+                                         flux_error_t *error)
+{
+    json_t *o;
+
+    if (!(o = json_pack ("{s:s s:I s:I s:i}",
+                         "path", path,
+                         "mtime", (json_int_t)sb->st_mtime,
+                         "ctime", (json_int_t)sb->st_ctime,
+                         "mode", sb->st_mode))) {
+        errprintf (error, "%s: error packing directry file object", path);
+        errno = ENOMEM;
+        return NULL;
+    }
+    return o;
+}
+
+static json_t *fileref_create_symlink (const char *path,
+                                       const char *fullpath,
+                                       struct stat *sb,
+                                       flux_error_t *error)
+{
+    json_t *o;
+    char *target;
+
+    if (!(target = calloc (1, sb->st_size + 1))
+        || readlink (fullpath, target, sb->st_size) < 0) {
+        errprintf (error, "readlink %s: %s", fullpath, strerror (errno));
+        goto error;
+    }
+    if (!(o = json_pack ("{s:s s:s s:I s:I s:i}",
+                         "path", path,
+                         "data", target,
+                         "mtime", (json_int_t)sb->st_mtime,
+                         "ctime", (json_int_t)sb->st_ctime,
+                         "mode", sb->st_mode))) {
+        errprintf (error, "%s: error packing symlink file object", path);
+        errno = ENOMEM;
+        goto error;
+    }
+    free (target);
+    return o;
+error:
+    ERRNO_SAFE_WRAP (free, target);
+    return NULL;
+}
+
 json_t *fileref_create_ex (const char *path,
                            const char *fullpath,
                            const char *hashtype,
@@ -169,16 +279,13 @@ json_t *fileref_create_ex (const char *path,
                            size_t *mapsizep,
                            flux_error_t *error)
 {
-    json_t *blobvec = NULL;
+    const char *relative_path;
     json_t *o;
     int fd = -1;
     struct stat sb;
     void *mapbuf = MAP_FAILED;
     size_t mapsize = 0;
     int saved_errno;
-    void *data = NULL;
-    ssize_t data_size = 0;
-    bool data_encode_base64 = false;
     int rc;
 
     if (chunksize < 0) {
@@ -187,6 +294,14 @@ json_t *fileref_create_ex (const char *path,
     }
     if (!fullpath)
         fullpath = path;
+    /* Store a relative path in the object so that extraction can specify a
+     * destination directory, like tar(1) default behavior.
+     */
+    relative_path = path;
+    while (*relative_path == '/')
+        relative_path++;
+    if (strlen (relative_path) == 0)
+        relative_path = ".";
     /* Avoid TOCTOU in S_ISREG case by opening before checking its type.
      */
     if ((fd = open (fullpath, O_RDONLY | O_NOFOLLOW)) < 0)
@@ -197,93 +312,58 @@ json_t *fileref_create_ex (const char *path,
         errprintf (error, "%s: %s", path, strerror (errno));
         goto error;
     }
-    if (!(blobvec = json_array ())) {
-        errno = ENOMEM;
-        goto error;
-    }
-    /* Regular file: if size is below threshold, base64 encode its content
-     * and place in the 'data' field.  Otherwise, mmap the file and build
-     * the blobvec array.
+    /* Empty reg file, possibly sparse with size > 0.
      */
-    if (S_ISREG (sb.st_mode)) {
-        if (sb.st_size > 0) {
-            if (threshold < 0 || sb.st_size <= threshold) {
-                if ((data_size = read_all (fd, &data)) < 0) {
-                    errprintf (error, "%s: %s", path, strerror (errno));
-                    goto error;
-                }
-                if (data_size < sb.st_size) {
-                    errprintf (error, "%s: short read", path);
-                    errno = EINVAL;
-                    goto error;
-                }
-                data_encode_base64 = true;
-            }
-            else {
-                mapsize = sb.st_size;
-                mapbuf = mmap (NULL, mapsize, PROT_READ, MAP_PRIVATE, fd, 0);
-                if (mapbuf == MAP_FAILED) {
-                    errprintf (error, "mmap: %s", strerror (errno));
-                    goto error;
-                }
-                if (chunksize == 0)
-                    chunksize = sb.st_size;
-                if (blobvec_populate (blobvec,
-                                      fd,
-                                      mapbuf,
-                                      mapsize,
-                                      hashtype,
-                                      chunksize) < 0) {
-                    errprintf (error,
-                               "error generating blobvec array: %s",
-                               strerror (errno));
-                    goto error;
-                }
-            }
-        }
+    if (S_ISREG (sb.st_mode) && file_has_no_data (fd)) {
+        if (!(o = fileref_create_empty (relative_path, &sb, error)))
+            goto error;
     }
-    /* Symbolic link: place link target in 'data' field.
+    /* Large reg file will be encoded with blobvec.
      */
-    else if (S_ISLNK (sb.st_mode)) {
-        if (!(data = calloc (1, sb.st_size + 1))
-            || readlink (fullpath, data, sb.st_size) < 0) {
-            errprintf (error, "readlink %s: %s", path, strerror (errno));
+    else if (S_ISREG (sb.st_mode)
+        && hashtype != NULL
+        && threshold >= 0
+        && sb.st_size > threshold) {
+        mapsize = sb.st_size;
+        mapbuf = mmap (NULL, mapsize, PROT_READ, MAP_PRIVATE, fd, 0);
+        if (mapbuf == MAP_FAILED) {
+            errprintf (error, "mmap: %s", strerror (errno));
             goto error;
         }
-        data_size = strlen (data);
+        if (chunksize == 0)
+            chunksize = sb.st_size;
+        if (!(o = fileref_create_blobvec (relative_path,
+                                          fd,
+                                          mapbuf,
+                                          &sb,
+                                          hashtype,
+                                          chunksize,
+                                          error)))
+            goto error;
     }
-    /* For a directory, 'data' is not set, and 'blobvec' remains empty.
-     * All other types are rejected.
+    /* Other reg file will be encoded with base64.
      */
-    else if (!S_ISDIR (sb.st_mode)) {
+    else if (S_ISREG (sb.st_mode)) {
+        if (!(o = fileref_create_base64 (relative_path, fd, &sb, error)))
+            goto error;
+    }
+    /* symlink
+     */
+    else if (S_ISLNK (sb.st_mode)) {
+        if (!(o = fileref_create_symlink (relative_path, fullpath, &sb, error)))
+            goto error;
+    }
+    /* directory
+     */
+    else if (S_ISDIR (sb.st_mode)) {
+        if (!(o = fileref_create_directory (relative_path, &sb, error)))
+            goto error;
+    }
+    else {
         errprintf (error, "%s: unsupported file type", path);
         goto inval;
     }
-    /* Store a relative path in the object so that extraction can specify a
-     * destination directory, like tar(1) default behavior.
-     */
-    const char *relative_path = path;
-    while (*relative_path == '/')
-        relative_path++;
-    if (strlen (relative_path) == 0)
-        relative_path = ".";
-    json_int_t size = sb.st_size;
-    json_int_t ctime = sb.st_ctime;
-    json_int_t mtime = sb.st_mtime;
-    int mode = sb.st_mode;
-    if (!(o = json_pack ("{s:i s:s s:s s:I s:I s:I s:i s:O}",
-                         "version", 1,
-                         "type", "fileref",
-                         "path", relative_path,
-                         "size", size,
-                         "mtime", mtime,
-                         "ctime", ctime,
-                         "mode", mode,
-                         "blobvec", blobvec))
-        || set_optional_data (o, data, data_size, data_encode_base64) < 0) {
-        errprintf (error, "error packing fileref object");
-        goto inval;
-    }
+
     if (mapbufp)
         *mapbufp = mapbuf;
     else if (mapbuf != MAP_FAILED)
@@ -292,15 +372,11 @@ json_t *fileref_create_ex (const char *path,
         *mapsizep = mapsize;
     if (fd >= 0)
         close (fd);
-    json_decref (blobvec);
-    free (data);
     return o;
 inval:
     errno = EINVAL;
 error:
     saved_errno = errno;
-    json_decref (blobvec);
-    free (data);
     if (mapbuf != MAP_FAILED)
         (void)munmap (mapbuf, mapsize);
     if (fd >= 0)
@@ -326,31 +402,28 @@ json_t *fileref_create (const char *path,
 }
 
 void fileref_pretty_print (json_t *fileref,
+                           const char *path,
                            bool long_form,
                            char *buf,
                            size_t bufsize)
 {
-    const char *path;
-    json_int_t size;
-    json_int_t ctime;
-    json_int_t mtime;
+    json_int_t size = 0;
     int mode;
-    json_t *blobvec;
-    const char *data = NULL;
     int n;
 
     if (!buf)
         return;
+    /* RFC 37 says path is optional in the file object (to support dict archive
+     * containers) so let it be passed in as 'path' arg and override if present
+     * in the object.  It's an error if it's not set by one of those.
+     */
     if (!fileref
         || json_unpack (fileref,
-                        "{s:s s:I s:I s:I s:i s?s s:o}",
+                        "{s?s s:i s?I}",
                         "path", &path,
-                        "size", &size,
-                        "mtime", &mtime,
-                        "ctime", &ctime,
                         "mode", &mode,
-                        "data", &data,
-                        "blobvec", &blobvec) < 0) {
+                        "size", &size) < 0
+        || path == NULL) {
         n = snprintf (buf, bufsize, "invalid fileref");
     }
     else if (long_form) {

--- a/src/common/libutil/fileref.h
+++ b/src/common/libutil/fileref.h
@@ -43,10 +43,12 @@ json_t *fileref_create (const char *path,
                         flux_error_t *error);
 
 /* Build a "directory listing" of a fileref and set it in 'buf'.
+ * Set 'path' if provided from archive container (fileref->path overrides).
  * If the fileref is invalid, set "invalid fileref".
  * If output is truncated, '+' is substituted for the last character.
  */
 void fileref_pretty_print (json_t *fileref,
+                           const char *path,
                            bool long_form,
                            char *buf,
                            size_t bufsize);

--- a/src/common/libutil/fileref.h
+++ b/src/common/libutil/fileref.h
@@ -26,17 +26,20 @@ json_t *fileref_create_ex (const char *path,
                            const char *fullpath,
                            const char *hashtype,
                            int chunksize,
+                           int threshold,
                            void **mapbuf,
                            size_t *mapsize,
                            flux_error_t *error);
 
-/* Create a fileref object for the regular file at 'path'.
+/* Create a fileref object for the file system object at 'path'.
  * The chunksize limits the size of each blob (0=unlimited).
- * Corner cases handled: empty files and sparse files.
+ * 'threshold' is a file size over which a non-empty regular file is
+ *   content mapped (0=always, -1=never).
  */
 json_t *fileref_create (const char *path,
                         const char *hashtype,
                         int chunksize,
+                        int threshold,
                         flux_error_t *error);
 
 /* Build a "directory listing" of a fileref and set it in 'buf'.

--- a/src/common/libutil/fileref.h
+++ b/src/common/libutil/fileref.h
@@ -17,30 +17,36 @@
 
 #include "src/common/libflux/types.h"
 
-/* Variant of fileref_create() with extra parameters:
- * - If non-NULL, 'mapbuf' and 'mapsize' are assigned mmapped buffer
- *   (if applicable)
+struct blobvec_param {
+    const char *hashtype;
+    int chunksize;              // maximum size of each blob
+    int small_file_threshold;   // no blobvec encoding for regular files of
+};                              //  size <= thresh (0=always blobvec)
+
+struct blobvec_mapinfo {
+    void *base;
+    size_t size;
+};
+
+
+/* Variant of fileref_create() with extra parameters to allow for 'blobvec'
+ * encoding.  This is intended to be called from the broker.
  * - If non-NULL 'fullpath' is used in place of 'path' for open/stat/mmap.
+ * - If 'param' is non-NULL, blobvec encoding is enabled with the specified
+ *   params.
+ * - If 'mapinfo' is non-NULL, and the file meets conditions for blobvec
+ *   encoding, the file remains mapped in memory and its address is returned.
  */
 json_t *fileref_create_ex (const char *path,
                            const char *fullpath,
-                           const char *hashtype,
-                           int chunksize,
-                           int threshold,
-                           void **mapbuf,
-                           size_t *mapsize,
+                           struct blobvec_param *param,
+                           struct blobvec_mapinfo *mapinfo,
                            flux_error_t *error);
 
 /* Create a fileref object for the file system object at 'path'.
- * The chunksize limits the size of each blob (0=unlimited).
- * 'threshold' is a file size over which a non-empty regular file is
- *   content mapped (0=always, -1=never).
+ * The blobvec encoding is never used thus the object is self-contained.
  */
-json_t *fileref_create (const char *path,
-                        const char *hashtype,
-                        int chunksize,
-                        int threshold,
-                        flux_error_t *error);
+json_t *fileref_create (const char *path, flux_error_t *error);
 
 /* Build a "directory listing" of a fileref and set it in 'buf'.
  * Set 'path' if provided from archive container (fileref->path overrides).

--- a/t/t0029-filemap-cmd.t
+++ b/t/t0029-filemap-cmd.t
@@ -252,6 +252,26 @@ test_expect_success 'unmap tags=blue,green' '
 test_expect_success 'flux filemap list reports no files' '
 	test $(flux filemap list --tags red,blue,green | wc -l) -eq 0
 '
+test_expect_success 'map test file without mmap' '
+	rm -f copydir/testfile &&
+	flux filemap map --disable-mmap ./testfile
+'
+test_expect_success HAVE_JQ 'test file did not use blobvec encoding' '
+	flux filemap list --raw | jq -e ".encoding != \"blobvec\""
+'
+test_expect_success 'unmap test file' '
+	flux filemap unmap
+'
+test_expect_success 'map small test file with reduced small file threshold' '
+	flux filemap map --small-file-threshold=0 ./testfile2
+'
+test_expect_success HAVE_JQ 'test file used blobvec encoding' '
+	flux filemap list --raw | jq -e ".encoding = \"blobvec\""
+'
+test_expect_success 'unmap test file' '
+	flux filemap unmap
+'
+
 test_expect_success 'map test file' '
 	rm -f copydir/testfile &&
 	flux filemap map ./testfile

--- a/t/t0029-filemap-cmd.t
+++ b/t/t0029-filemap-cmd.t
@@ -158,6 +158,25 @@ test_expect_success HAVE_SPARSE 'holes were preserved' '
 test_expect_success HAVE_SPARSE 'unmap test file' '
 	flux filemap unmap
 '
+test_expect_success HAVE_SPARSE 'create sparse test file with data' '
+	truncate --size=8192 testfile3b &&
+	echo more-data >>testfile3b
+'
+test_expect_success HAVE_SPARSE 'map test file' '
+	flux filemap map ./testfile3b
+'
+test_expect_success HAVE_SPARSE 'test file can be read through content cache' '
+	flux filemap get -C copydir &&
+	test_cmp testfile3b copydir/testfile3b
+'
+test_expect_success HAVE_SPARSE 'holes were preserved' '
+	stat --format="%b" testfile3b >blocks3b.exp &&
+	stat --format="%b" copydir/testfile3b >blocks3b.out &&
+	test_cmp blocks3b.exp blocks3b.out
+'
+test_expect_success HAVE_SPARSE 'unmap test file' '
+	flux filemap unmap
+'
 test_expect_success 'create test symlink' '
 	ln -s /a/b/c/d testfile4
 '

--- a/t/t0029-filemap-cmd.t
+++ b/t/t0029-filemap-cmd.t
@@ -115,8 +115,8 @@ test_expect_success 'map test file and get its blobref' '
 	flux filemap map ./testfile2 &&
 	flux filemap list --blobref >testfile2.blobref
 '
-test_expect_success HAVE_JQ 'show fileref' '
-	flux filemap list --fileref | jq .
+test_expect_success HAVE_JQ 'show raw object' '
+	flux filemap list --raw | jq .
 '
 test_expect_success 'test file can be read through content cache on rank 1' '
 	flux exec -r 1 flux filemap get -C copydir &&
@@ -164,8 +164,8 @@ test_expect_success 'create test symlink' '
 test_expect_success 'map test file' '
 	flux filemap map ./testfile4
 '
-test_expect_success HAVE_JQ 'show fileref' '
-	flux filemap list --fileref | jq .
+test_expect_success HAVE_JQ 'show raw object' '
+	flux filemap list --raw | jq .
 '
 test_expect_success 'test file can be read through content cache' '
 	flux filemap get -vv -C copydir


### PR DESCRIPTION
Problem: the JSON file objects used by flux-filemap, the broker, and the shell stage-in plugin are out of date now that RFC 37 has been published.

Use the new object format.

WIP pending a bit more testing.