### PR TITLE
testsuite: unset FLUX_F58_FORCE_ASCII in some tests

### DIFF
--- a/src/common/libjob/test/job.c
+++ b/src/common/libjob/test/job.c
@@ -471,6 +471,7 @@ int main (int argc, char *argv[])
 
     /* fluid F58 tests require unicode locale initialization */
     setlocale (LC_ALL, "en_US.UTF-8");
+    unsetenv ("FLUX_F58_FORCE_ASCII");
 
     check_jobkey ();
 

--- a/t/python/t0010-job.py
+++ b/t/python/t0010-job.py
@@ -45,6 +45,7 @@ def yaml_to_json(s):
 class TestJob(unittest.TestCase):
     @classmethod
     def setUpClass(self):
+        os.unsetenv("FLUX_F58_FORCE_ASCII")
         self.fh = flux.Flux()
         self.use_ascii = False
         build_opts = subprocess.check_output(["flux", "version"]).decode()


### PR DESCRIPTION
Problem: The FLUX_F58_FORCE_ASCII environment variable is sanitized in all sharness tests, but not in unit and python tests.

Remove the FLUX_F58_FORCE_ASCII environment variable as needed in tests where it breaks expected output or results.