### PR TITLE
flux-run: allow stdin to be directed to a subset of tasks

### DIFF
--- a/doc/man1/common/submit-standard-io.rst
+++ b/doc/man1/common/submit-standard-io.rst
@@ -7,8 +7,10 @@ KVS, where they may be accessed with the ``flux job attach`` command.
 In addition, :man1:`flux-run` processes standard I/O in real time,
 emitting the job's I/O to its stdout and stderr.
 
-**--input=FILENAME**
+**--input=FILENAME|RANKS**
    Redirect stdin to the specified filename, bypassing the KVS.
+   As a special case for ``flux run``, the argument may specify
+   an idset of task ranks in to which to direct standard input.
 
 **--output=TEMPLATE**
    Specify the filename *TEMPLATE* for stdout redirection, bypassing

--- a/doc/man1/flux-job.rst
+++ b/doc/man1/flux-job.rst
@@ -48,6 +48,15 @@ completed.  It can also be used to feed stdin to a job.
 **-l, --label-io**
    Label output by rank
 
+**-u, --unbuffered**
+   Do not buffer stdin. Note that when ``flux job attach`` is used in a
+   terminal, the terminal itself may line buffer stdin.
+
+**-i, --stdin-ranks=RANKS**
+   Send stdin to only those ranks in the **RANKS** idset. The standard input
+   for tasks not in **RANKS** will be closed. The default is to broadcast
+   stdin to all ranks.
+
 CANCEL
 ======
 

--- a/src/bindings/python/flux/cli/run.py
+++ b/src/bindings/python/flux/cli/run.py
@@ -13,6 +13,7 @@ import os
 import sys
 
 from flux.cli import base
+from flux.idset import IDset
 
 
 class RunCmd(base.SubmitBaseCmd):
@@ -59,6 +60,15 @@ class RunCmd(base.SubmitBaseCmd):
             attach_args.append(f"--wait-event={args.wait_event}")
         if args.unbuffered:
             attach_args.append("--unbuffered")
+        # If args.input is an idset, then pass along to attach:
+        if args.input:
+            try:
+                in_ranks = IDset(args.input)
+                attach_args.append(f"--stdin-ranks={in_ranks}")
+            except (ValueError, EnvironmentError):
+                #  Do nothing if ranks were not an idset, file input is
+                #  handled in jobspec.
+                pass
         attach_args.append(jobid.f58.encode("utf-8", errors="surrogateescape"))
 
         # Exec flux-job attach, searching for it in FLUX_EXEC_PATH.

--- a/src/shell/input.c
+++ b/src/shell/input.c
@@ -179,8 +179,6 @@ static void shell_input_stdin_cb (flux_t *h,
         goto error;
     if (shell_input_put_kvs (in, o) < 0)
         goto error;
-    if (eof)
-        flux_msg_handler_stop (mh);
     if (flux_respond (in->shell->h, msg, NULL) < 0)
         shell_log_errno ("flux_respond");
     return;

--- a/src/shell/input.c
+++ b/src/shell/input.c
@@ -31,6 +31,7 @@
 #include "src/common/libidset/idset.h"
 #include "src/common/libeventlog/eventlog.h"
 #include "src/common/libioencode/ioencode.h"
+#include "ccan/str/str.h"
 
 #include "task.h"
 #include "svc.h"
@@ -206,9 +207,9 @@ static int shell_input_parse_type (struct shell_input *in)
     if (!ret || !typestr)
         return 0;
 
-    if (!strcmp (typestr, "service"))
+    if (streq (typestr, "service"))
         in->stdin_type = FLUX_INPUT_TYPE_SERVICE;
-    else if (!strcmp (typestr, "file")) {
+    else if (streq (typestr, "file")) {
         struct shell_input_type_file *fp = &(in->stdin_file);
 
         in->stdin_type = FLUX_INPUT_TYPE_FILE;
@@ -446,7 +447,7 @@ static int idset_string_contains (const char *set, uint32_t id)
 {
     int rc;
     struct idset *idset;
-    if (strcmp (set, "all") == 0)
+    if (streq (set, "all"))
         return 1;
     if (!(idset = idset_decode (set)))
         return shell_log_errno ("idset_decode (%s)", set);
@@ -475,11 +476,11 @@ static void shell_task_input_kvs_input_cb (flux_future_t *f, void *arg)
     if (eventlog_entry_parse (o, NULL, &name, &context) < 0)
         shell_die_errno (1, "eventlog_entry_parse");
 
-    if (!strcmp (name, "header")) {
+    if (streq (name, "header")) {
         /* Future: per-stream encoding */
         kp->input_header_parsed = true;
     }
-    else if (!strcmp (name, "data")) {
+    else if (streq (name, "data")) {
         flux_shell_task_t *task = task_input->task;
         const char *rank = NULL;
         if (!kp->input_header_parsed)

--- a/src/shell/input.c
+++ b/src/shell/input.c
@@ -75,6 +75,7 @@ struct shell_input {
     int stdin_type;
     struct shell_task_input *task_inputs;
     int ntasks;
+    struct idset *open_tasks;
     struct shell_input_type_file stdin_file;
 };
 
@@ -104,6 +105,7 @@ void shell_input_destroy (struct shell_input *in)
         shell_input_type_file_cleanup (&(in->stdin_file));
         for (i = 0; i < in->ntasks; i++)
             shell_task_input_cleanup (&(in->task_inputs[i]));
+        idset_destroy (in->open_tasks);
         free (in->task_inputs);
         free (in);
         errno = saved_errno;
@@ -162,6 +164,33 @@ static int shell_input_put_kvs (struct shell_input *in, json_t *context)
     return rc;
 }
 
+/*  Return true if idset b is a strict subset of a
+ */
+static bool is_subset (const struct idset *a, const struct idset *b)
+{
+    struct idset *isect = idset_intersect (a, b);
+    if (isect) {
+        bool result = idset_equal (isect, b);
+        idset_destroy (isect);
+        return result;
+    }
+    return false;
+}
+
+/*  Subtract idset 'b' from 'a', unless 'ranks' is all then clear 'a'.
+ */
+static int subtract_idset (struct idset *a,
+                           const char *ranks,
+                           struct idset *b)
+{
+    /*  Remove all tasks with EOF from open_tasks idset
+     */
+    if (streq (ranks, "all"))
+        return idset_clear_all (a);
+    else
+        return idset_subtract (a, b);
+}
+
 /* Convert 'iodecode' object to an valid RFC 24 data event.
  * N.B. the iodecode object is a valid "context" for the event.
  */
@@ -172,20 +201,41 @@ static void shell_input_stdin_cb (flux_t *h,
 {
     struct shell_input *in = arg;
     bool eof = false;
+    const char *ranks;
+    struct idset *ids = NULL;
     json_t *o;
 
     if (flux_request_unpack (msg, NULL, "o", &o) < 0)
         goto error;
-    if (iodecode (o, NULL, NULL, NULL, NULL, &eof) < 0)
+    if (idset_count (in->open_tasks) == 0) {
+        errno = EPIPE;
         goto error;
+    }
+    if (iodecode (o, NULL, &ranks, NULL, NULL, &eof) < 0)
+        goto error;
+    if (!streq (ranks, "all")) {
+        /* Ensure that targeted tasks are still open.
+         * ("all" is treated as "all open")
+         */
+        if (!(ids = idset_decode (ranks)))
+            goto error;
+        if (!is_subset (in->open_tasks, ids)) {
+            errno = EPIPE;
+            goto error;
+        }
+    }
     if (shell_input_put_kvs (in, o) < 0)
         goto error;
+    if (eof && subtract_idset (in->open_tasks, ranks, ids) < 0)
+        shell_log_errno ("failed to remove '%s' from open tasks", ranks);
     if (flux_respond (in->shell->h, msg, NULL) < 0)
         shell_log_errno ("flux_respond");
+    idset_destroy (ids);
     return;
 error:
     if (flux_respond_error (in->shell->h, msg, errno, NULL) < 0)
         shell_log_errno ("flux_respond");
+    idset_destroy (ids);
 }
 
 static void shell_input_type_file_init (struct shell_input *in)
@@ -375,6 +425,11 @@ struct shell_input *shell_input_create (flux_shell_t *shell)
     in->shell = shell;
     in->stdin_type = FLUX_INPUT_TYPE_SERVICE;
     in->ntasks = shell->info->rankinfo.ntasks;
+    if (!(in->open_tasks = idset_create (0, IDSET_FLAG_AUTOGROW))
+        || idset_range_set (in->open_tasks,
+                            0,
+                            shell->info->total_ntasks - 1))
+        goto error;
 
     task_inputs_size = sizeof (struct shell_task_input) * in->ntasks;
     if (!(in->task_inputs = calloc (1, task_inputs_size)))

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -352,6 +352,7 @@ dist_check_SCRIPTS = \
 	scripts/dmesg-grep.py \
 	scripts/stats-listen.py \
 	scripts/sqlite-query.py \
+	scripts/pipe.py \
 	valgrind/valgrind-workload.sh \
 	valgrind/workload.d/job \
 	content/content-helper.sh \

--- a/t/scripts/pipe.py
+++ b/t/scripts/pipe.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+###############################################################
+# Copyright 2023 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+#
+# Pipe standard input to a job, then exit.
+#
+import flux
+from flux.job import JobID, event_wait
+import sys
+
+
+def pipe_stdin(h, jobid, ranks):
+    event_wait(h, jobid, "start")
+    event = event_wait(h, jobid, "shell.init", eventlog="guest.exec.eventlog")
+    service = event.context["service"] + ".stdin"
+    for line in sys.stdin:
+        h.rpc(
+            service,
+            {"stream": "stdin", "rank": ranks, "data": line},
+        ).get()
+    h.rpc(service, {"stream": "stdin", "rank": ranks, "eof": True}).get()
+
+
+pipe_stdin(flux.Flux(), JobID(sys.argv[1]), sys.argv[2])

--- a/t/t2500-job-attach.t
+++ b/t/t2500-job-attach.t
@@ -133,9 +133,10 @@ test_expect_success HAVE_JQ 'attach: -v option displays file and line info in lo
 '
 
 test_expect_success 'attach: cannot attach to interactive pty when --read-only specified' '
-	jobid=$(flux submit -o pty.interactive bash) &&
+	jobid=$(flux submit -o pty.interactive cat) &&
 	test_must_fail flux job attach --read-only $jobid &&
-	flux job cancel $jobid
+	$SHARNESS_TEST_SRCDIR/scripts/runpty.py -i none -f asciicast -c q \
+		flux job attach $jobid
 '
 
 test_done

--- a/t/t2710-python-cli-submit.t
+++ b/t/t2710-python-cli-submit.t
@@ -273,5 +273,9 @@ test_expect_success HAVE_JQ 'flux submit --tasks-per-node works' '
 	jq -e \
 	 ".attributes.system.shell.options.\"per-resource\".count == 2"
 '
+test_expect_success 'flux submit --input=IDSET fails' '
+	test_must_fail flux submit --input=0 hostname &&
+	test_must_fail flux submit -n2 --input=0-1 hostname
+'
 
 test_done

--- a/t/t2711-python-cli-run.t
+++ b/t/t2711-python-cli-run.t
@@ -254,4 +254,11 @@ test_expect_success NO_CHAIN_LINT 'flux run --unbuffered works for stdin/out' '
         rm -f fifo &&
         flux job wait-event -vt 15 $(flux job last) clean
 '
+test_expect_success 'flux run --input=ranks works for stdin' '
+	echo hi | flux run --label-io --input=0 -n4 cat >input-test.out 2>&1 &&
+	cat <<-EOF >input-test.expected &&
+	0: hi
+	EOF
+	test_cmp input-test.expected input-test.out
+'
 test_done


### PR DESCRIPTION
This PR adds support for directing standard input of `flux run` to a subset of task ranks.

This is a stopgap for #4956 until we can get better support for input redirection directly in the job shell.

This PR works by adding a new `--stdin-ranks=RANKS` option to `flux job attach`. Then, the `--input` option (in `flux run` only) is extended so that it a supplied idset is passed along to `flux job attach` instead of setting a filename in jobspec.

In addition, there's some minor cleanup in the job shell to detect if a writer attempts to write to closed tasks.

In a future PR, a new scheme will be proposed to allow more generic redirection of standard input, but `--input=RANKS` should still work in this case, so that we won't be changing behavior.