### PR TITLE
flux-mini: emit deprecation warning

### DIFF
--- a/src/cmd/flux-mini.py
+++ b/src/cmd/flux-mini.py
@@ -31,6 +31,8 @@ def main():
     sys.stderr = open(
         sys.stderr.fileno(), "w", encoding="utf8", errors="surrogateescape"
     )
+    if sys.stderr.isatty():
+        LOGGER.warning("⚠️ flux-mini is deprecated, use flux-batch, flux-run, etc.⚠️")
 
     parser = argparse.ArgumentParser(prog="flux-mini")
     subparsers = parser.add_subparsers(
@@ -120,9 +122,6 @@ def main():
 
 
 if __name__ == "__main__":
-    LOGGER.warning(
-        "⚠️ WARNING flux mini will be deprecated for a future release. See the equivalent sub-commands now on the top level. ⚠️"
-    )
     main()
 
 # vi: ts=4 sw=4 expandtab


### PR DESCRIPTION
Problem: the deprecation warning added to flux-mini in #4961 is not working.

This fixes it.  Does this seem appropriate/ok?
```
$  flux mini 
flux-mini: WARNING: ⚠️ flux-mini is deprecated, use flux-batch, flux-run, etc.⚠️
usage: flux-mini [-h] {run,submit,bulksubmit,batch,alloc} ...
flux-mini: error: the following arguments are required: subcommand
```
I was wondering about the non-ascii glyphs but they do get your attention and it's not like people are going to whine too much about a command they should be migrating away from :-)