### PR TITLE
shell: fix memory leak in doom plugin

### DIFF
--- a/src/shell/doom.c
+++ b/src/shell/doom.c
@@ -113,7 +113,7 @@ static void doom_post (struct shell_doom *doom, json_t *task_info)
 
     flux_future_destroy (f); // fire and forget
     free (entrystr);
-    json_decref (task_info);
+    json_decref (entry);
     flux_kvs_txn_destroy (txn);
 }
 


### PR DESCRIPTION
Problem: The incorrect JSON object is decref'd in doom_post() in the doom shell plugin, resulting in a leak of the outer `entry` object.

Call json_decref() on the correct object.