### PR TITLE
libsubprocess:  don't abort remote processes that receive SIGSTOP

### DIFF
--- a/src/common/libsubprocess/remote.c
+++ b/src/common/libsubprocess/remote.c
@@ -121,6 +121,12 @@ static void process_new_state (flux_subprocess_t *p,
     if (p->state == FLUX_SUBPROCESS_FAILED)
         return;
 
+    if (state == FLUX_SUBPROCESS_STOPPED) {
+        if (p->ops.on_state_change)
+            (*p->ops.on_state_change) (p, FLUX_SUBPROCESS_STOPPED);
+        return;
+    }
+
     p->state = state;
 
     if (p->state == FLUX_SUBPROCESS_RUNNING) {

--- a/src/common/libsubprocess/server.c
+++ b/src/common/libsubprocess/server.c
@@ -168,6 +168,12 @@ static void proc_state_change_cb (flux_subprocess_t *p,
                                 "state", state,
                                 "status", flux_subprocess_status (p));
     }
+    else if (state == FLUX_SUBPROCESS_STOPPED) {
+        rc = flux_respond_pack (s->h, request, "{s:s s:i s:i}",
+                                "type", "state",
+                                "rank", s->rank,
+                                "state", state);
+    }
     else if (state == FLUX_SUBPROCESS_FAILED) {
         rc = flux_respond_error (s->h, request, p->failed_errno, NULL);
         proc_delete (s, p); // N.B. proc_delete preserves errno


### PR DESCRIPTION
Problem: a remote subprocess that receives SIGSTOP is killed for entering an "illegal state" (#4947)

Handle the STOPPED state properly for remote processes.