### PR TITLE
add flux-cancel(1)

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -51,7 +51,8 @@ MAN1_FILES_PRIMARY = \
 	man1/flux-uptime.1 \
 	man1/flux-uri.1 \
 	man1/flux-resource.1 \
-	man1/flux-pgrep.1
+	man1/flux-pgrep.1 \
+	man1/flux-cancel.1
 
 # These files are generated as clones of a primary page.
 # Sphinx handles this automatically if declared in the conf.py

--- a/doc/man1/flux-cancel.rst
+++ b/doc/man1/flux-cancel.rst
@@ -1,0 +1,56 @@
+.. flux-help-description: cancel one or more jobs
+.. flux-help-section: jobs
+
+==============
+flux-cancel(1)
+==============
+
+
+SYNOPSIS
+========
+
+**flux** **cancel** [*OPTIONS*] [*JOBID...*]
+
+DESCRIPTION
+===========
+
+flux-cancel(1) cancels one or more jobs by raising a job exception of
+type=cancel. An optional message included with the cancel exception may be
+provided via the *-m, --message=NOTE* option. Canceled jobs are immediately
+sent SIGTERM followed by SIGKILL after a configurable timeout (default=5s).
+
+flux-cancel(1) can target multiple jobids by either taking them on the
+command line, or via the selection options *--all*, *-u, --user*, or *-S,
+--states=STATES*. It is an error to provide jobids on the command line
+and use one or more of the selection options.
+
+By default *--all* will target all jobs for the current user. To target all
+jobs for all users, use *--user=all* (only the instance owner is allowed
+to use *--user=all*). To see how many jobs flux-cancel(1) would kill,
+use the *-n --dry-run* option.
+
+OPTIONS
+=======
+
+**-n, --dry-run**
+   Do not cancel any jobs, but print a message indicating how many jobs
+   would have been canceled.
+
+**-m, --message=NOTE**
+   Set an optional exception note.
+
+**-u, --user=USER**
+   Set target user.  The instance owner may specify *all* for all users.
+
+**-S, --states=STATES**
+   Set target job states (default: active). Valid states include
+   depend, priority, sched, run, pending, running, active.
+
+**-q, --quiet**
+   Suppress output if no jobs match
+
+RESOURCES
+=========
+
+Flux: http://flux-framework.org
+

--- a/doc/man1/flux-job.rst
+++ b/doc/man1/flux-job.rst
@@ -1,4 +1,4 @@
-.. flux-help-description: cancel jobs, get job status, etc (see: flux help job)
+.. flux-help-description: get job status, info, etc (see: flux help job)
 .. flux-help-section: jobs
 
 ===========

--- a/doc/man1/index.rst
+++ b/doc/man1/index.rst
@@ -9,6 +9,7 @@ man1
    flux-batch
    flux-broker
    flux-bulksubmit
+   flux-cancel
    flux-config
    flux-content
    flux-cron

--- a/doc/manpages.py
+++ b/doc/manpages.py
@@ -40,6 +40,7 @@ man_pages = [
     ('man1/flux-jobs', 'flux-jobs', 'list jobs submitted to Flux', [author], 1),
     ('man1/flux-top', 'flux-top', 'Display running Flux jobs', [author], 1),
     ('man1/flux-pstree', 'flux-pstree', 'display job hierarchies', [author], 1),
+    ('man1/flux-cancel', 'flux-cancel', 'cancel one or more jobs', [author], 1),
     ('man1/flux-pgrep', 'flux-pgrep', 'search or cancel matching jobs', [author], 1),
     ('man1/flux-pgrep', 'flux-pkill', 'search or cancel matching jobs', [author], 1),
     ('man1/flux-jobtap', 'flux-jobtap', 'List, remove, and load job-manager plugins', [author], 1),

--- a/etc/completions/flux.pre
+++ b/etc/completions/flux.pre
@@ -129,6 +129,33 @@ __get_flux_subcommands() {
     echo "$subcommands"
 }
 
+#  flux-cancel(1) completions
+_flux_cancel()
+{
+    local cmd=$1
+    OPTS="\
+        --all \
+        -n --dry-run \
+        -q --quiet \
+        -u --user= \
+        -S --states= \
+        -m --message= \
+    "
+    if [[ $cur != -* ]]; then
+        #  Attempt to substitute an active jobid
+        compopt +o filenames
+        active_jobs=$(flux jobs -no {id})
+        COMPREPLY=( $(compgen -W "${active_jobs}" -- "$cur") )
+        return 0
+    fi
+    COMPREPLY=( $(compgen -W "${OPTS} -h --help" -- "$cur") )
+    if [[ "${COMPREPLY[@]}" == *= ]]; then
+        # Add space if there is not a '=' in suggestions
+        compopt -o nospace
+    fi
+    return 0
+}
+
 #  flux-mini(1) completions
 _flux_mini()
 {
@@ -1304,6 +1331,9 @@ _flux_core()
         ;;
     submit|run|alloc|batch|bulksubmit)
         _flux_mini $cmd
+        ;;
+    cancel)
+        _flux_cancel $subcmd
         ;;
     resource)
         _flux_resource $subcmd

--- a/etc/rc1
+++ b/etc/rc1
@@ -112,7 +112,7 @@ if test $RANK -eq 0; then
             -a -z "${FLUX_DISABLE_JOB_CLEANUP}"; then
 	flux admin cleanup-push <<-EOT
 	flux queue stop --quiet --all --nocheckpoint
-	flux job cancelall --user=all --quiet -f --states RUN
+	flux cancel --user=all --quiet --states RUN
 	flux queue idle --quiet
 	EOT
     fi

--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -111,7 +111,8 @@ dist_fluxcmd_SCRIPTS = \
 	flux-uri.py \
 	flux-pstree.py \
 	flux-pgrep.py \
-	flux-queue.py
+	flux-queue.py \
+	flux-cancel.py
 
 fluxcmd_PROGRAMS = \
 	flux-terminus \

--- a/src/cmd/flux-cancel.py
+++ b/src/cmd/flux-cancel.py
@@ -1,0 +1,187 @@
+##############################################################
+# Copyright 2023 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+##############################################################
+
+import argparse
+import logging
+import os
+import pwd
+import sys
+from operator import itemgetter
+
+import flux
+from flux.job import cancel_async
+
+LOGGER = logging.getLogger("flux-cancel")
+
+
+def parse_args():
+    description = """
+    Cancel pending or running jobs with an optional exception note.
+    """
+    parser = argparse.ArgumentParser(
+        prog="flux-cancel",
+        usage="flux cancel [OPTIONS] [JOBID...]",
+        description=description,
+        formatter_class=flux.util.help_formatter(),
+    )
+    parser.add_argument("--all", action="store_true", help="Target all jobs")
+    parser.add_argument(
+        "-n", "--dry-run", action="store_true", help="Do not cancel any jobs"
+    )
+    parser.add_argument(
+        "-q",
+        "--quiet",
+        action="store_true",
+        help="Suppress output when no jobs match",
+    )
+    parser.add_argument(
+        "-u",
+        "--user",
+        type=str,
+        metavar="USER",
+        help="Set target user or 'all' (instance owner only)",
+    )
+    parser.add_argument(
+        "-S",
+        "--states",
+        action="append",
+        help="List of job states to target (default=active)",
+    )
+    parser.add_argument(
+        "-m",
+        "--message",
+        type=str,
+        metavar="NOTE",
+        help="Set optional cancel exception note",
+    )
+    parser.add_argument(
+        "jobids",
+        metavar="JOBID...",
+        type=flux.job.JobID,
+        nargs="*",
+        help="jobids to cancel",
+    )
+    return parser.parse_args()
+
+
+def log(msg):
+    """Log to stderr without logging INFO prefix"""
+    print(f"flux-cancel: {msg}", file=sys.stderr)
+
+
+def cancel(args):
+    if not args.jobids:
+        raise ValueError("No target jobs were provided")
+    if args.dry_run:
+        count = len(args.jobids)
+        log(f"Would cancel {count} job{'s'[:count^1]}")
+        sys.exit(0)
+    h = flux.Flux()
+    futures = {x: cancel_async(h, x, args.message) for x in args.jobids}
+    errors = 0
+    for jobid, future in futures.items():
+        try:
+            future.get()
+        except OSError as exc:
+            errors += 1
+            LOGGER.error(f"{jobid}: {exc.strerror}")
+    if errors > 0:
+        sys.exit(1)
+
+
+def cancelall(args):
+
+    STATES = {
+        "depend": flux.constants.FLUX_JOB_STATE_DEPEND,
+        "priority": flux.constants.FLUX_JOB_STATE_PRIORITY,
+        "sched": flux.constants.FLUX_JOB_STATE_SCHED,
+        "run": flux.constants.FLUX_JOB_STATE_RUN,
+        "pending": flux.constants.FLUX_JOB_STATE_PENDING,
+        "running": flux.constants.FLUX_JOB_STATE_RUNNING,
+        "active": flux.constants.FLUX_JOB_STATE_ACTIVE,
+    }
+
+    if args.user is None:
+        userid = os.getuid()
+    elif args.user == "all":
+        userid = flux.constants.FLUX_USERID_UNKNOWN
+    else:
+        try:
+            userid = pwd.getpwnam(args.user).pw_uid
+        except KeyError:
+            try:
+                userid = int(args.user)
+            except ValueError:
+                raise ValueError(f"Invalid user {args.user} specified")
+
+    statemask = 0
+    if args.states:
+        for state in ",".join(args.states).split(","):
+            try:
+                statemask |= STATES[state.lower()]
+            except KeyError:
+                raise ValueError(f"Invalid state {state} specified")
+    else:
+        statemask = STATES["pending"] | STATES["running"]
+
+    payload = {
+        "dry_run": args.dry_run,
+        "userid": userid,
+        "states": statemask,
+        "severity": 0,
+        "type": "cancel",
+    }
+    if args.message is not None:
+        payload["note"] = args.message
+
+    count, errors = itemgetter("count", "errors")(
+        flux.Flux().rpc("job-manager.raiseall", payload).get()
+    )
+
+    if count > 0:
+        msg = f"{count} job{'s'[:count^1]}"
+        if args.dry_run:
+            log(f"Would cancel {msg}")
+        else:
+            log(f"Canceled {msg} ({errors} error{'s'[:errors^1]})")
+    elif not args.quiet:
+        log("Matched 0 jobs")
+
+
+@flux.util.CLIMain(LOGGER)
+def main():
+    sys.stdout = open(
+        sys.stdout.fileno(), "w", encoding="utf8", errors="surrogateescape"
+    )
+    sys.stderr = open(
+        sys.stderr.fileno(), "w", encoding="utf8", errors="surrogateescape"
+    )
+
+    args = parse_args()
+
+    if args.user or args.states:
+        args.all = True
+
+    if args.jobids and args.all:
+        LOGGER.error(
+            "Do not specify a list of jobids with --all,--user,--states options"
+        )
+        sys.exit(1)
+
+    if args.all:
+        cancelall(args)
+    else:
+        cancel(args)
+
+
+if __name__ == "__main__":
+    main()
+
+# vi: ts=4 sw=4 expandtab

--- a/src/test/create-kvs-dumpfile.sh
+++ b/src/test/create-kvs-dumpfile.sh
@@ -12,10 +12,10 @@ WORKLOAD="\
 #
 flux bulksubmit --quiet --cc=1-4 {} ::: true false nocommand &&
 id=\$(flux submit --urgency=hold hostname) &&
-flux job cancel \$id &&
+flux cancel \$id &&
 id=\$(flux submit --wait-event=start sleep 30) &&
 flux submit --quiet --dependency=afternotok:\$id true &&
-flux job cancel \$id &&
+flux cancel \$id &&
 flux queue drain &&
 flux jobs -a
 "

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -204,6 +204,7 @@ TESTSCRIPTS = \
 	t2712-python-cli-alloc.t \
 	t2713-python-cli-bulksubmit.t \
 	t2714-python-cli-batch.t \
+	t2715-python-cli-cancel.t \
 	t2800-jobs-cmd.t \
 	t2800-jobs-recursive.t \
 	t2800-jobs-instance-info.t \

--- a/t/issues/t3920-running-underflow.sh
+++ b/t/issues/t3920-running-underflow.sh
@@ -9,7 +9,7 @@ SHELL=/bin/sh flux start '\
 && flux queue stop \
 && jobid=$(flux submit hostname) \
 && flux job wait-event $jobid depend \
-&& flux job cancel $jobid \
+&& flux cancel $jobid \
 && flux job attach -vE $jobid \
 ; flux queue status -v >t3920.output'
 

--- a/t/issues/t3960-job-exec-ehostunreach.sh
+++ b/t/issues/t3960-job-exec-ehostunreach.sh
@@ -16,7 +16,7 @@ SHELL=/bin/sh flux start -s 4 -o,-Stbon.topo=kary:4 --test-exit-mode=leader '\
    id=$(flux submit -n4 -N4 sleep 300) \
 && flux job wait-event $id start \
 && $startctl kill 3 19 \
-&& flux job cancel $id \
+&& flux cancel $id \
 && flux job wait-event $id exception \
 && $startctl kill 3 9 \
 && flux job attach -vE $id \

--- a/t/issues/t4184-sched-simple-restart.sh
+++ b/t/issues/t4184-sched-simple-restart.sh
@@ -24,7 +24,7 @@ while test \$(flux resource list -s up -no {ncores}) -ne \$NCORES; do
 done
 
 echo "t4184: canceling \$id"
-flux job cancel \${id}
+flux cancel \${id}
 
 echo "t4184: waiting for \$id to end"
 flux job wait-event \$id clean
@@ -34,7 +34,7 @@ echo "t4184: waiting for \$id2 to start..."
 flux job wait-event -t 15 \$id2 start
 
 echo "t4184: canceling \$id2..."
-flux job cancel \$id2
+flux cancel \$id2
 
 echo "t4184: waiting for \$id2 to end..."
 flux job wait-event -t 15 \$id2 clean

--- a/t/rc/rc1-job
+++ b/t/rc/rc1-job
@@ -68,6 +68,6 @@ fi
 
 test $RANK -ne 0 || flux admin cleanup-push <<-EOT
 	flux queue stop --all --nocheckpoint
-	flux job cancelall -f --states RUN
+	flux cancel --all --states RUN
 	flux queue idle
 EOT

--- a/t/system/0002-job-exec-sdexec-basic.t
+++ b/t/system/0002-job-exec-sdexec-basic.t
@@ -24,7 +24,7 @@ test_expect_success 'job-exec: verify system instance using systemd' '
         jobiddec=`flux job id --to=dec $jobid` &&
         rank=`flux getattr rank` &&
         sudo -u flux systemctl list-units --user | grep "flux-sdexec-${rank}-${jobiddec}" &&
-        flux job cancel ${jobid}
+        flux cancel ${jobid}
 '
 test_expect_success 'job-exec: simple job exits 0 on success' '
         jobid=$(flux submit /bin/true) &&
@@ -57,7 +57,7 @@ test_expect_success 'job-exec: simple job can be canceled' '
         jobid=$(flux submit sleep 30) &&
         flux job wait-event -t 10 ${jobid} start &&
         flux job wait-event -p guest.exec.eventlog -t 10 ${jobid} shell.start &&
-        flux job cancel $jobid &&
+        flux cancel $jobid &&
         flux job wait-event -t 10 ${jobid} clean &&
         test_expect_code 143 flux job status $jobid
 '

--- a/t/system/0003-instance-restart.t
+++ b/t/system/0003-instance-restart.t
@@ -24,7 +24,7 @@ test_expect_success 'job-exec: verify system instance using systemd' '
         jobiddec=`flux job id --to=dec $jobid` &&
         rank=`flux getattr rank` &&
         sudo -u flux systemctl list-units --user | grep "flux-sdexec-${rank}-${jobiddec}" &&
-        flux job cancel ${jobid}
+        flux cancel ${jobid}
 '
 test_expect_success 'job-exec: submit two jobs that consumes all resources' '
         NCORES=$(flux resource list -s up -no "{ncores}") &&
@@ -49,7 +49,7 @@ test_expect_success 'job-exec: verify jobs still listed and in expected state' '
         flux jobs --filter=pending | grep $(cat jobid2)
 '
 test_expect_success 'job-exec: cancel job1 and make sure job2 will run' '
-        flux job cancel $(cat jobid1) &&
+        flux cancel $(cat jobid1) &&
         flux job wait-event -t 60 $(cat jobid1) clean &&
         flux job wait-event -t 60 $(cat jobid2) start
 '
@@ -58,7 +58,7 @@ test_expect_success 'job-exec: verify jobs listed and in new expected state' '
         flux jobs --filter=running | grep $(cat jobid2)
 '
 test_expect_success 'job-exec: cancel jobs' '
-        flux job cancel $(cat jobid2)
+        flux cancel $(cat jobid2)
 '
 # fill up job queue with around 1 minute worth of "sleep 1" jobs,
 # restart flux every 5 seconds for around 30 seconds worth of sleeping

--- a/t/t1105-proxy.t
+++ b/t/t1105-proxy.t
@@ -115,7 +115,7 @@ test_expect_success 'flux-proxy works with /jobid argument' '
 	uri=$(flux proxy /$id?local flux getattr parent-uri) &&
 	test_debug "echo flux proxy $id flux getattr parent-uri = $uri" &&
 	test "$uri" = "$FLUX_URI" &&
-	flux job cancel $id &&
+	flux cancel $id &&
 	flux job wait-event -vt 10 $id clean
 '
 test_expect_success NO_CHAIN_LINT 'flux-proxy attempts to restore terminal on error' '

--- a/t/t2110-job-ingest-validator.t
+++ b/t/t2110-job-ingest-validator.t
@@ -153,7 +153,7 @@ test_expect_success 'job-ingest: feasibility validator works with jobs running' 
 	flux submit -n 2 hostname &&
 	test_must_fail flux submit -N 12 -n12 hostname 2>infeasible4.err &&
 	grep "unsatisfiable request" infeasible4.err &&
-	flux job cancel ${jobid} &&
+	flux cancel ${jobid} &&
 	flux job wait-event ${jobid} clean
 '
 test_expect_success 'job-ingest: load multiple validators' '

--- a/t/t2202-job-manager.t
+++ b/t/t2202-job-manager.t
@@ -95,7 +95,7 @@ test_expect_success 'job-manager: queue contains 1 jobs' '
 
 test_expect_success 'job-manager: cancel job' '
 	jobid=$(cat list1_jobid.out) &&
-	flux job cancel ${jobid} &&
+	flux cancel ${jobid} &&
 	flux job wait-event --timeout=5.0 --match-context=type=cancel ${jobid} exception &&
 	flux job eventlog $jobid | grep exception \
 		| grep severity=0 | grep "type=\"cancel\""
@@ -142,7 +142,7 @@ test_expect_success HAVE_JQ 'job-manager: priority listed as priority=4294967295
 '
 
 test_expect_success HAVE_JQ 'job-manager: cancel jobs' '
-	flux job cancel $($jq .id <list3.out)
+	flux cancel $($jq .id <list3.out)
 '
 
 test_expect_success 'job-manager: queue contains 0 jobs' '
@@ -228,7 +228,7 @@ test_expect_success HAVE_JQ 'job-manager: max_jobid has not changed' '
 '
 
 test_expect_success HAVE_JQ 'job-manager: cancel jobs' '
-	flux job cancel $($jq .id <list_reload.out) &&
+	flux cancel $($jq .id <list_reload.out) &&
 	test $(${LIST_JOBS} | wc -l) -eq 0
 '
 
@@ -237,7 +237,7 @@ test_expect_success 'job-manager: flux job urgency fails on invalid urgency' '
 	flux job urgency ${jobid} 31 &&
 	test_must_fail flux job urgency ${jobid} -1 &&
 	test_must_fail flux job urgency ${jobid} 32 &&
-	flux job cancel ${jobid}
+	flux cancel ${jobid}
 '
 
 test_expect_success HAVE_JQ 'job-manager: flux job urgency special args work' '
@@ -254,7 +254,7 @@ test_expect_success HAVE_JQ 'job-manager: flux job urgency special args work' '
 	${LIST_JOBS} > list_default.out &&
 	test $(cat list_default.out | grep ${jobid} | $jq .urgency) -eq 16 &&
 	test $(cat list_default.out | grep ${jobid} | $jq .priority) -eq 16 &&
-	flux job cancel ${jobid}
+	flux cancel ${jobid}
 '
 
 test_expect_success 'job-manager: flux job urgency -v work' '
@@ -263,31 +263,31 @@ test_expect_success 'job-manager: flux job urgency -v work' '
 	flux job urgency -v ${jobid} hold 2>&1 | grep "10" &&
 	flux job urgency -v ${jobid} expedite 2>&1 | grep "held" &&
 	flux job urgency -v ${jobid} 10 2>&1 | grep "expedited" &&
-	flux job cancel ${jobid}
+	flux cancel ${jobid}
 '
 
 test_expect_success 'job-manager: guest can reduce urgency from default' '
 	jobid=$(flux job submit  basic.json) &&
 	FLUX_HANDLE_ROLEMASK=0x2 flux job urgency ${jobid} 5 &&
-	flux job cancel ${jobid}
+	flux cancel ${jobid}
 '
 
 test_expect_success 'job-manager: guest can increase to default' '
 	jobid=$(flux job submit -u 0 basic.json) &&
 	FLUX_HANDLE_ROLEMASK=0x2 flux job urgency ${jobid} 16 &&
-	flux job cancel ${jobid}
+	flux cancel ${jobid}
 '
 
 test_expect_success 'job-manager: guest cannot increase past default' '
 	jobid=$(flux job submit basic.json) &&
 	! FLUX_HANDLE_ROLEMASK=0x2 flux job urgency ${jobid} 17 &&
-	flux job cancel ${jobid}
+	flux cancel ${jobid}
 '
 
 test_expect_success 'job-manager: guest can decrease from from >default' '
 	jobid=$(flux job submit -u 31 basic.json) &&
 	FLUX_HANDLE_ROLEMASK=0x2 flux job urgency ${jobid} 17 &&
-	flux job cancel ${jobid}
+	flux cancel ${jobid}
 '
 
 test_expect_success 'job-manager: guest cannot set urgency of others jobs' '
@@ -295,15 +295,15 @@ test_expect_success 'job-manager: guest cannot set urgency of others jobs' '
 	newid=$(($(id -u)+1)) &&
 	! FLUX_HANDLE_ROLEMASK=0x2 FLUX_HANDLE_USERID=${newid} \
 		flux job urgency ${jobid} 0 &&
-	flux job cancel ${jobid}
+	flux cancel ${jobid}
 '
 
 test_expect_success 'job-manager: guest cannot cancel others jobs' '
 	jobid=$(flux job submit basic.json) &&
 	newid=$(($(id -u)+1)) &&
 	! FLUX_HANDLE_ROLEMASK=0x2 FLUX_HANDLE_USERID=${newid} \
-		flux job cancel ${jobid} &&
-	flux job cancel ${jobid}
+		flux cancel ${jobid} &&
+	flux cancel ${jobid}
 '
 
 test_expect_success 'job-manager: no jobs in the queue' '

--- a/t/t2203-job-manager-single.t
+++ b/t/t2203-job-manager-single.t
@@ -65,7 +65,7 @@ test_expect_success 'job-manager: running job has alloc event' '
 '
 
 test_expect_success 'job-manager: cancel 2' '
-        flux job cancel $(cat job2.id)
+        flux cancel $(cat job2.id)
 '
 
 test_expect_success HAVE_JQ 'job-manager: job state RIRSS' '
@@ -174,7 +174,7 @@ test_expect_success 'job-manager: annotate jobs in flux jobs (RIRRR)' '
 '
 
 test_expect_success 'job-manager: cancel 1' '
-        flux job cancel $(cat job1.id)
+        flux cancel $(cat job1.id)
 '
 
 test_expect_success HAVE_JQ 'job-manager: job state IIRRR' '
@@ -186,9 +186,9 @@ test_expect_success HAVE_JQ 'job-manager: job state IIRRR' '
 '
 
 test_expect_success 'job-manager: cancel all jobs' '
-        flux job cancel $(cat job3.id) &&
-        flux job cancel $(cat job4.id) &&
-        flux job cancel $(cat job5.id)
+        flux cancel $(cat job3.id) &&
+        flux cancel $(cat job4.id) &&
+        flux cancel $(cat job5.id)
 '
 
 test_expect_success HAVE_JQ 'job-manager: job state IIIII' '

--- a/t/t2204-job-manager-limited.t
+++ b/t/t2204-job-manager-limited.t
@@ -56,7 +56,7 @@ test_expect_success HAVE_JQ 'job-manager: annotate jobs in flux-jobs (RRSSS)' '
 '
 
 test_expect_success 'job-manager: cancel 2' '
-        flux job cancel $(cat job2.id)
+        flux cancel $(cat job2.id)
 '
 
 test_expect_success HAVE_JQ 'job-manager: job state RIRSS' '

--- a/t/t2204-job-manager-limited.t
+++ b/t/t2204-job-manager-limited.t
@@ -110,8 +110,8 @@ test_expect_success HAVE_JQ 'job-manager: annotate jobs in flux-jobs (RIRSS)' '
 # cancel non-running jobs first, to ensure they are not accidentally run when
 # running jobs free resources.
 test_expect_success 'job-manager: cancel all jobs' '
-        flux job cancelall --states=SCHED -f &&
-        flux job cancelall -f
+        flux cancel --all --states=pending &&
+        flux cancel --all
 '
 
 test_expect_success HAVE_JQ 'job-manager: job state IIIII' '

--- a/t/t2205-job-manager-unlimited.t
+++ b/t/t2205-job-manager-unlimited.t
@@ -162,8 +162,8 @@ test_expect_success HAVE_JQ 'job-manager: annotate jobs in flux jobs (RIRSS)' '
 # cancel non-running jobs first, to ensure they are not accidentally run when
 # running jobs free resources.
 test_expect_success 'job-manager: cancel all jobs' '
-        flux job cancelall --states=SCHED -f &&
-        flux job cancelall -f
+        flux cancel --all --states=pending &&
+        flux cancel --all
 '
 
 test_expect_success HAVE_JQ 'job-manager: job state IIIII' '

--- a/t/t2205-job-manager-unlimited.t
+++ b/t/t2205-job-manager-unlimited.t
@@ -59,7 +59,7 @@ test_expect_success HAVE_JQ 'job-manager: annotate jobs in flux-jobs (RRSSS)' '
 '
 
 test_expect_success 'job-manager: cancel 2' '
-        flux job cancel $(cat job2.id)
+        flux cancel $(cat job2.id)
 '
 
 test_expect_success HAVE_JQ 'job-manager: job state RIRSS' '
@@ -111,7 +111,7 @@ test_expect_success HAVE_JQ 'job-manager: annotate jobs in flux-jobs (RIRSS)' '
 '
 
 test_expect_success 'job-manager: cancel 5' '
-        flux job cancel $(cat job5.id)
+        flux cancel $(cat job5.id)
 '
 
 test_expect_success HAVE_JQ 'job-manager: job state RIRSI' '

--- a/t/t2206-job-manager-annotate.t
+++ b/t/t2206-job-manager-annotate.t
@@ -173,8 +173,8 @@ test_expect_success HAVE_JQ 'job-manager: annotate jobs in flux-jobs (RIRSS)' '
 # cancel non-running jobs first, to ensure they are not accidentally run when
 # running jobs free resources.
 test_expect_success 'job-manager: cancel all jobs' '
-        flux job cancelall --states=SCHED -f &&
-        flux job cancelall -f
+        flux cancel --all --states=pending &&
+        flux cancel --all
 '
 
 test_expect_success HAVE_JQ 'job-manager: job state IIIII' '

--- a/t/t2206-job-manager-annotate.t
+++ b/t/t2206-job-manager-annotate.t
@@ -119,7 +119,7 @@ test_expect_success HAVE_JQ 'job-manager: annotate jobs in flux-jobs (RRSSS)' '
 '
 
 test_expect_success 'job-manager: cancel 2' '
-        flux job cancel $(cat job2.id)
+        flux cancel $(cat job2.id)
 '
 
 test_expect_success HAVE_JQ 'job-manager: job state RIRSS' '

--- a/t/t2209-job-manager-bugs.t
+++ b/t/t2209-job-manager-bugs.t
@@ -25,7 +25,7 @@ test_expect_success 'issue2664: start three jobs ' '
 # canceling job that has not yet sent alloc to scheduler improperly
 # decrements count of outstanding alloc requests
 test_expect_success 'issue2664: cancel job 3' '
-	flux job cancel $(cat job3.out)
+	flux cancel $(cat job3.out)
 '
 # Next job submitted triggers another alloc request when ther are no
 # more slots, which triggers error response from scheduler that is fatal
@@ -35,7 +35,7 @@ test_expect_success 'issue2664: submit job 4' '
 '
 # Hangs here (hitting timeout) when bug is present
 test_expect_success 'issue2664: cancel job 1 and drain (cleanup)' '
-	flux job cancel $(cat job1.out) &&
+	flux cancel $(cat job1.out) &&
 	run_timeout 5 flux queue drain
 '
 
@@ -47,7 +47,7 @@ test_expect_success 'issue3218: urgency change on running job doesnt segfault' '
         id=$(flux submit sleep 600) &&
         flux job wait-event $id start &&
         test_must_fail flux job urgency $id 0 &&
-        flux job cancel $id
+        flux cancel $id
 '
 #
 # Issue 4409: eventlog commit / job start race

--- a/t/t2212-job-manager-plugins.t
+++ b/t/t2212-job-manager-plugins.t
@@ -131,7 +131,7 @@ test_expect_success 'job-manager: default works with sched.prioritize' '
 	flux job urgency $job3 18 &&
 	flux job wait-event -v $job3 debug.alloc-request &&
 	test_debug "echo cleanup" &&
-	flux job cancelall -f &&
+	flux cancel --all &&
 	flux queue drain
 '
 test_expect_success HAVE_JQ 'job-manager: hold plugin holds jobs' '

--- a/t/t2212-job-manager-plugins.t
+++ b/t/t2212-job-manager-plugins.t
@@ -156,7 +156,7 @@ test_expect_success 'job-manager: job is released when urgency set' '
 '
 test_expect_success 'job-manager: cancel of held job works' '
 	jobid=$(id_byname cc-2) &&
-	flux job cancel $jobid &&
+	flux cancel $jobid &&
 	flux job wait-event -v -t 5 $jobid clean
 '
 test_expect_success 'job-manager: release held jobs' '
@@ -180,7 +180,7 @@ test_expect_success 'job-manager: test with random priority plugin' '
 	sleep 1 &&
 	flux jobs -c4 -no {name}:{priority} | sort > pri-after.out &&
 	test_must_fail test_cmp pri-before.out pri-after.out &&
-	flux job cancel $sleepjob &&
+	flux cancel $sleepjob &&
 	flux job wait-event -vt 30 $sleepjob clean &&
 	flux job wait --all -v
 '
@@ -211,7 +211,7 @@ test_expect_success 'job-manager: start another job and remove plugin' '
 	flux dmesg --clear &&
 	jobid=$(flux submit --wait-event=alloc sleep 60) &&
 	flux jobtap remove job_aux.so &&
-	flux job cancel $jobid
+	flux cancel $jobid
 '
 test_expect_success 'job-manager: job aux cleared when plugin removed' '
 	flux dmesg >aux-dmesg2.out &&
@@ -223,7 +223,7 @@ test_expect_success 'job-manager: load jobtap_api test plugin' '
 	flux run -vvv \
 		--setattr=system.lookup-id=$(flux job id $id) \
 		/bin/true &&
-	flux job cancel $id &&
+	flux cancel $id &&
 	id=$(flux submit \
 		--setattr=system.expected-result=failed \
 		/bin/false) &&
@@ -236,7 +236,7 @@ test_expect_success 'job-manager: load jobtap_api test plugin' '
 	id=$(flux submit --urgency=hold \
 		--setattr=system.expected-result=canceled \
 		/bin/true) &&
-	flux job cancel $id &&
+	flux cancel $id &&
 	test_must_fail flux job wait-event -vm type=test $id exception
 '
 test_expect_success 'job-manager: test that job flags can be set' '
@@ -294,7 +294,7 @@ test_expect_success 'job-manager: priority type error generates nonfatal excepti
 	flux job wait-event -vm type=job.state.priority ${id} exception &&
 	test "$(flux jobs -no {annotations.test} ${id})" = "priority type error" &&
 	test $(flux jobs -no {state} ${id}) = "PRIORITY" &&
-	flux job cancel ${id} &&
+	flux cancel ${id} &&
 	flux job wait-event -v ${id} clean
 '
 test_expect_success 'job-manager: jobtap plugin can raise job exception' '

--- a/t/t2213-job-manager-hold-single.t
+++ b/t/t2213-job-manager-hold-single.t
@@ -40,7 +40,7 @@ test_expect_success 'job-manager: job 4 hold' '
 '
 
 test_expect_success 'job-manager: cancel job 1' '
-        flux job cancel $(cat job1.id)
+        flux cancel $(cat job1.id)
 '
 
 test_expect_success HAVE_JQ 'job-manager: job state ISRSS (job 3 run, job 2 held)' '
@@ -79,7 +79,7 @@ test_expect_success HAVE_JQ 'job-manager: annotations job 4 pending' '
 '
 
 test_expect_success 'job-manager: cancel job 3' '
-        flux job cancel $(cat job3.id)
+        flux cancel $(cat job3.id)
 '
 
 test_expect_success HAVE_JQ 'job-manager: job state ISIRS (job 4 run, job 2 held)' '
@@ -99,7 +99,7 @@ test_expect_success HAVE_JQ 'job-manager: annotations job 5 pending (job 2 held)
 '
 
 test_expect_success 'job-manager: cancel job 4' '
-        flux job cancel $(cat job4.id)
+        flux cancel $(cat job4.id)
 '
 
 test_expect_success HAVE_JQ 'job-manager: job state ISIIR (job 5 run, job 2 held)' '
@@ -131,8 +131,8 @@ test_expect_success HAVE_JQ 'job-manager: annotations job 2 pending' '
 '
 
 test_expect_success 'job-manager: cancel remaining jobs' '
-        flux job cancel $(cat job2.id) &&
-        flux job cancel $(cat job5.id)
+        flux cancel $(cat job2.id) &&
+        flux cancel $(cat job5.id)
 '
 
 test_done

--- a/t/t2214-job-manager-hold-limited.t
+++ b/t/t2214-job-manager-hold-limited.t
@@ -88,8 +88,8 @@ test_expect_success HAVE_JQ 'job-manager: job annotations updated (RRSSS)' '
 '
 
 test_expect_success 'job-manager: cancel job 1 & 2' '
-        flux job cancel $(cat job1.id) &&
-        flux job cancel $(cat job2.id)
+        flux cancel $(cat job1.id) &&
+        flux cancel $(cat job2.id)
 '
 
 test_expect_success HAVE_JQ 'job-manager: job state IISSR' '
@@ -130,8 +130,8 @@ test_expect_success HAVE_JQ 'job-manager: job annotations updated (IIRSR)' '
 '
 
 test_expect_success 'job-manager: cancel all jobs' '
-        flux job cancel $(cat job4.id) &&
-        flux job cancel $(cat job5.id)
+        flux cancel $(cat job4.id) &&
+        flux cancel $(cat job5.id)
 '
 
 test_done

--- a/t/t2215-job-manager-hold-unlimited.t
+++ b/t/t2215-job-manager-hold-unlimited.t
@@ -62,8 +62,8 @@ test_expect_success HAVE_JQ 'job-manager: job annotations updated (RRSSS)' '
 '
 
 test_expect_success 'job-manager: cancel job 1 & 2' '
-        flux job cancel $(cat job1.id) &&
-        flux job cancel $(cat job2.id)
+        flux cancel $(cat job1.id) &&
+        flux cancel $(cat job2.id)
 '
 
 test_expect_success HAVE_JQ 'job-manager: job state IISSR' '
@@ -124,7 +124,7 @@ test_expect_success HAVE_JQ 'job-manager: job annotations updated (IIRSR)' '
 '
 
 test_expect_success 'job-manager: cancel job 3' '
-        flux job cancel $(cat job3.id)
+        flux cancel $(cat job3.id)
 '
 
 test_expect_success HAVE_JQ 'job-manager: job state IIIRR' '
@@ -144,8 +144,8 @@ test_expect_success HAVE_JQ 'job-manager: job annotations updated (IISRR)' '
 '
 
 test_expect_success 'job-manager: cancel all jobs' '
-        flux job cancel $(cat job4.id) &&
-        flux job cancel $(cat job5.id)
+        flux cancel $(cat job4.id) &&
+        flux cancel $(cat job5.id)
 '
 
 test_done

--- a/t/t2216-job-manager-priority-order-single.t
+++ b/t/t2216-job-manager-priority-order-single.t
@@ -50,7 +50,7 @@ test_expect_success HAVE_JQ 'job-manager: annotations in job id 3-4 updated (RRS
 '
 
 test_expect_success 'job-manager: cancel 2' '
-        flux job cancel $(cat job2.id)
+        flux cancel $(cat job2.id)
 '
 
 test_expect_success HAVE_JQ 'job-manager: job state RISR (job 4 runs instead of 3)' '
@@ -110,7 +110,7 @@ test_expect_success HAVE_JQ 'job-manager: annotations in job id 3-5 updated (RIS
 '
 
 test_expect_success 'job-manager: cancel 1' '
-        flux job cancel $(cat job1.id)
+        flux cancel $(cat job1.id)
 '
 
 test_expect_success HAVE_JQ 'job-manager: job state IISRR (job 5 runs instead of 3)' '
@@ -130,9 +130,9 @@ test_expect_success HAVE_JQ 'job-manager: annotations in job id 3-5 updated (IIS
 '
 
 test_expect_success 'job-manager: cancel all jobs' '
-        flux job cancel $(cat job5.id) &&
-        flux job cancel $(cat job4.id) &&
-        flux job cancel $(cat job3.id)
+        flux cancel $(cat job5.id) &&
+        flux cancel $(cat job4.id) &&
+        flux cancel $(cat job3.id)
 '
 
 test_done

--- a/t/t2217-job-manager-priority-order-limited.t
+++ b/t/t2217-job-manager-priority-order-limited.t
@@ -172,7 +172,7 @@ test_expect_success HAVE_JQ 'job-manager: annotate jobs updated (SSSRRS)' '
 '
 
 test_expect_success 'job-manager: cancel 5' '
-        flux job cancel $(cat job5.id)
+        flux cancel $(cat job5.id)
 '
 
 test_expect_success HAVE_JQ 'job-manager: job state SRSRIS' '

--- a/t/t2217-job-manager-priority-order-limited.t
+++ b/t/t2217-job-manager-priority-order-limited.t
@@ -200,8 +200,8 @@ test_expect_success HAVE_JQ 'job-manager: annotate jobs updated (SRSRIS)' '
 # cancel non-running jobs first, to ensure they are not accidentally run when
 # running jobs free resources.
 test_expect_success 'job-manager: cancel all jobs' '
-        flux job cancelall --states=SCHED -f &&
-        flux job cancelall -f
+        flux cancel --all --states=pending &&
+        flux cancel --all
 '
 
 test_done

--- a/t/t2218-job-manager-priority-order-unlimited.t
+++ b/t/t2218-job-manager-priority-order-unlimited.t
@@ -135,8 +135,8 @@ test_expect_success HAVE_JQ 'job-manager: annotate jobs updated (RSRII)' '
 # cancel non-running jobs first, to ensure they are not accidentally run when
 # running jobs free resources.
 test_expect_success 'job-manager: cancel all jobs' '
-        flux job cancelall --states=SCHED -f &&
-        flux job cancelall -f
+        flux cancel --all --states=pending &&
+        flux cancel --all
 '
 
 test_done

--- a/t/t2218-job-manager-priority-order-unlimited.t
+++ b/t/t2218-job-manager-priority-order-unlimited.t
@@ -41,7 +41,7 @@ test_expect_success HAVE_JQ 'job-manager: annotate jobs (SSSRR)' '
 '
 
 test_expect_success 'job-manager: cancel 5' '
-        flux job cancel $(cat job5.id)
+        flux cancel $(cat job5.id)
 '
 
 test_expect_success HAVE_JQ 'job-manager: job state SSRRI' '
@@ -110,7 +110,7 @@ test_expect_success HAVE_JQ 'job-manager: annotate jobs updated (SSRRI)' '
 '
 
 test_expect_success 'job-manager: cancel 4' '
-        flux job cancel $(cat job4.id)
+        flux cancel $(cat job4.id)
 '
 
 test_expect_success HAVE_JQ 'job-manager: job state RSRII' '

--- a/t/t2223-job-manager-queue-priority-order-limited.t
+++ b/t/t2223-job-manager-queue-priority-order-limited.t
@@ -124,8 +124,8 @@ test_expect_success HAVE_JQ 'job-manager: job state RSRSII' '
 # cancel non-running jobs first, to ensure they are not accidentally run when
 # running jobs free resources.
 test_expect_success 'job-manager: cancel all jobs' '
-        flux job cancelall --states=SCHED -f &&
-        flux job cancelall -f &&
+        flux cancel --all --states=pending &&
+        flux cancel --all &&
         flux queue drain
 '
 
@@ -262,8 +262,8 @@ test_expect_success HAVE_JQ 'job-manager: queue counts are as expected' '
 # cancel non-running jobs first, to ensure they are not accidentally run when
 # running jobs free resources.
 test_expect_success 'job-manager: cancel all jobs' '
-        flux job cancelall --states=SCHED -f &&
-        flux job cancelall -f &&
+        flux cancel --all --states=pending &&
+        flux cancel --all &&
         flux queue drain
 '
 

--- a/t/t2223-job-manager-queue-priority-order-limited.t
+++ b/t/t2223-job-manager-queue-priority-order-limited.t
@@ -65,7 +65,7 @@ test_expect_success HAVE_JQ 'job-manager: queue counts are as expected' '
 '
 
 test_expect_success 'job-manager: cancel a running job' '
-        flux job cancel $(cat job6.id)
+        flux cancel $(cat job6.id)
 '
 
 test_expect_success 'job-manager: start scheduling' '
@@ -104,7 +104,7 @@ test_expect_success 'job-manager: increase urgency job 1' '
 '
 
 test_expect_success 'job-manager: cancel a running job' '
-        flux job cancel $(cat job5.id)
+        flux cancel $(cat job5.id)
 '
 
 test_expect_success 'job-manager: start scheduling' '
@@ -184,8 +184,8 @@ test_expect_success 'job-manager: stop scheduling debug queue' '
 '
 
 test_expect_success 'job-manager: cancel the two running jobs' '
-        flux job cancel $(cat batch5.id) &&
-        flux job cancel $(cat debug5.id)
+        flux cancel $(cat batch5.id) &&
+        flux cancel $(cat debug5.id)
 '
 
 # batch queue jobs should run instead of debug queue
@@ -226,8 +226,8 @@ test_expect_success 'job-manager: start scheduling debug queue' '
 '
 
 test_expect_success 'job-manager: cancel the two running jobs' '
-        flux job cancel $(cat batch3.id) &&
-        flux job cancel $(cat batch4.id)
+        flux cancel $(cat batch3.id) &&
+        flux cancel $(cat batch4.id)
 '
 
 # debug job 2 and 4 should have highest priority now and be running

--- a/t/t2224-job-manager-queue-priority-order-unlimited.t
+++ b/t/t2224-job-manager-queue-priority-order-unlimited.t
@@ -64,7 +64,7 @@ test_expect_success HAVE_JQ 'job-manager: queue counts are as expected' '
 '
 
 test_expect_success 'job-manager: cancel a running job' '
-        flux job cancel $(cat job5.id)
+        flux cancel $(cat job5.id)
 '
 
 test_expect_success 'job-manager: start scheduling' '
@@ -155,8 +155,8 @@ test_expect_success 'job-manager: stop scheduling debug queue' '
 '
 
 test_expect_success 'job-manager: cancel the two running jobs' '
-        flux job cancel $(cat batch5.id) &&
-        flux job cancel $(cat debug5.id)
+        flux cancel $(cat batch5.id) &&
+        flux cancel $(cat debug5.id)
 '
 
 # batch queue jobs should run instead of debug queue
@@ -197,8 +197,8 @@ test_expect_success 'job-manager: start scheduling debug queue' '
 '
 
 test_expect_success 'job-manager: cancel the two running jobs' '
-        flux job cancel $(cat batch3.id) &&
-        flux job cancel $(cat batch4.id)
+        flux cancel $(cat batch3.id) &&
+        flux cancel $(cat batch4.id)
 '
 
 # debug job 2 and 4 should have highest priority now and be running

--- a/t/t2224-job-manager-queue-priority-order-unlimited.t
+++ b/t/t2224-job-manager-queue-priority-order-unlimited.t
@@ -96,8 +96,8 @@ test_expect_success HAVE_JQ 'job-manager: queue counts are as expected' '
 # cancel non-running jobs first, to ensure they are not accidentally run when
 # running jobs free resources.
 test_expect_success 'job-manager: cancel all jobs' '
-        flux job cancelall --states=SCHED -f &&
-        flux job cancelall -f &&
+        flux cancel --all --states=pending &&
+        flux cancel --all &&
         flux queue drain
 '
 
@@ -233,8 +233,8 @@ test_expect_success HAVE_JQ 'job-manager: queue counts are as expected' '
 # cancel non-running jobs first, to ensure they are not accidentally run when
 # running jobs free resources.
 test_expect_success 'job-manager: cancel all jobs' '
-        flux job cancelall --states=SCHED -f &&
-        flux job cancelall -f &&
+        flux cancel --all --states=pending &&
+        flux cancel --all &&
         flux queue drain
 '
 

--- a/t/t2230-job-info-lookup.t
+++ b/t/t2230-job-info-lookup.t
@@ -18,7 +18,7 @@ fj_wait_event() {
 submit_job() {
 	local jobid=$(flux job submit sleeplong.json) &&
 	fj_wait_event $jobid start >/dev/null &&
-	flux job cancel $jobid &&
+	flux cancel $jobid &&
 	fj_wait_event $jobid clean >/dev/null &&
 	echo $jobid
 }

--- a/t/t2231-job-info-eventlog-watch.t
+++ b/t/t2231-job-info-eventlog-watch.t
@@ -20,7 +20,7 @@ fj_wait_event() {
 submit_job() {
 	local jobid=$(flux job submit sleeplong.json) &&
 	fj_wait_event $jobid start >/dev/null &&
-	flux job cancel $jobid &&
+	flux cancel $jobid &&
 	fj_wait_event $jobid clean >/dev/null &&
 	echo $jobid
 }
@@ -116,7 +116,7 @@ test_expect_success 'flux job wait-event --verbose doesnt show events after wait
 test_expect_success 'flux job wait-event --timeout works' '
 	jobid=$(submit_job_live sleeplong.json) &&
 	test_must_fail flux job wait-event --timeout=0.2 $jobid clean 2> wait_event7.err &&
-	flux job cancel $jobid &&
+	flux cancel $jobid &&
 	grep "wait-event timeout" wait_event7.err
 '
 
@@ -245,7 +245,7 @@ test_expect_success NO_CHAIN_LINT 'flux job wait-event -p guest.exec.eventlog wo
 	wait_watchers_nonzero "guest_watchers" &&
 	guestns=$(flux job namespace $jobid) &&
 	wait_watcherscount_nonzero $guestns &&
-	flux job cancel $jobid &&
+	flux cancel $jobid &&
 	wait $waitpid &&
 	grep done wait_event_path4.out
 '
@@ -253,7 +253,7 @@ test_expect_success NO_CHAIN_LINT 'flux job wait-event -p guest.exec.eventlog wo
 test_expect_success 'flux job wait-event -p times out on no event (live job)' '
 	jobid=$(submit_job_live sleeplong.json) &&
 	test_expect_code 142 run_timeout -s ALRM 0.2 flux job wait-event -p "guest.exec.eventlog" $jobid foobar &&
-	flux job cancel $jobid
+	flux cancel $jobid
 '
 
 test_expect_success 'flux job wait-event --count=0 errors' '
@@ -273,7 +273,7 @@ test_expect_success 'flux job wait-event --count=2 works' '
 	test_must_fail flux job wait-event --timeout=0.2 --count=2 ${jobid} foobar &&
 	flux kvs eventlog append ${kvsdir}.eventlog foobar &&
 	fj_wait_event --count=2 ${jobid} foobar &&
-	flux job cancel $jobid
+	flux cancel $jobid
 '
 
 test_expect_success 'flux job wait-event --count=2 and context match works' '
@@ -283,7 +283,7 @@ test_expect_success 'flux job wait-event --count=2 and context match works' '
 	test_must_fail flux job wait-event --timeout=0.2 --count=2 --match-context="foo=\"bar\"" ${jobid} foobar &&
 	flux kvs eventlog append ${kvsdir}.eventlog foobar "{\"foo\":\"bar\"}" &&
 	fj_wait_event --count=2 --match-context="foo=\"bar\"" ${jobid} foobar &&
-	flux job cancel $jobid
+	flux cancel $jobid
 '
 
 test_expect_success 'flux job wait-event --count=2 and invalid context match fails' '
@@ -293,7 +293,7 @@ test_expect_success 'flux job wait-event --count=2 and invalid context match fai
 	test_must_fail flux job wait-event --timeout=0.2 --count=2 --match-context="foo=\"dar\"" ${jobid} foobar &&
 	flux kvs eventlog append ${kvsdir}.eventlog foobar "{\"foo\":\"bar\"}" &&
 	test_must_fail flux job wait-event --timeout=0.2 --count=2 --match-context="foo=\"dar\"" ${jobid} foobar &&
-	flux job cancel $jobid
+	flux cancel $jobid
 '
 
 # In order to test watching a guest event log that does not yet exist,
@@ -312,11 +312,11 @@ test_expect_success NO_CHAIN_LINT 'flux job wait-event -p guest.exec.eventlog wo
 	waitpid=$! &&
 	wait_watchers_nonzero "watchers" &&
 	wait_watchers_nonzero "guest_watchers" &&
-	flux job cancel ${jobidall} &&
+	flux cancel ${jobidall} &&
 	fj_wait_event ${jobid} start &&
 	guestns=$(flux job namespace ${jobid}) &&
 	wait_watcherscount_nonzero $guestns &&
-	flux job cancel ${jobid} &&
+	flux cancel ${jobid} &&
 	wait $waitpid &&
 	grep done wait_event_path5.out
 '
@@ -325,8 +325,8 @@ test_expect_success 'flux job wait-event -p times out on no event (wait job)' '
 	jobidall=$(submit_job_live sleeplong-all-rsrc.json) &&
 	jobid=$(submit_job_wait) &&
 	test_expect_code 142 run_timeout -s ALRM 0.2 flux job wait-event -p "guest.exec.eventlog" $jobid foobar &&
-	flux job cancel $jobidall &&
-	flux job cancel $jobid
+	flux cancel $jobidall &&
+	flux cancel $jobid
 '
 
 # In order to test watching a guest event log that will never exist,
@@ -341,9 +341,9 @@ test_expect_success NO_CHAIN_LINT 'flux job wait-event -p guest.exec.eventlog wo
 	waitpid=$! &&
 	wait_watchers_nonzero "watchers" &&
 	wait_watchers_nonzero "guest_watchers" &&
-	flux job cancel ${jobid} &&
+	flux cancel ${jobid} &&
 	! wait $waitpid &&
-	flux job cancel ${jobidall}
+	flux cancel ${jobidall}
 '
 
 #

--- a/t/t2232-job-info-security.t
+++ b/t/t2232-job-info-security.t
@@ -26,7 +26,7 @@ update_job_userid() {
 submit_job() {
 	local jobid=$(flux job submit sleeplong.json) &&
 	flux job wait-event $jobid start >/dev/null &&
-	flux job cancel $jobid &&
+	flux cancel $jobid &&
 	flux job wait-event $jobid clean >/dev/null &&
 	update_job_userid $1 &&
 	echo $jobid
@@ -49,7 +49,7 @@ bad_first_event() {
 	flux kvs get --raw ${kvsdir}.eventlog \
 		| sed -e s/submit/foobar/ \
 		| flux kvs put --raw ${kvsdir}.eventlog=- &&
-	flux job cancel $jobid &&
+	flux cancel $jobid &&
 	echo $jobid
 }
 
@@ -260,7 +260,7 @@ test_expect_success 'flux job wait-event guest.exec.eventlog fails via -p (wrong
 test_expect_success 'flux job wait-event guest.exec.eventlog works via -p (live job, owner)' '
 	jobid=$(submit_job_live) &&
 	flux job wait-event -p guest.exec.eventlog $jobid init &&
-	flux job cancel $jobid
+	flux cancel $jobid
 '
 
 test_expect_success 'flux job wait-event guest.exec.eventlog works via -p (live job, user)' '
@@ -268,7 +268,7 @@ test_expect_success 'flux job wait-event guest.exec.eventlog works via -p (live 
 	set_userid 9000 &&
 	flux job wait-event -p guest.exec.eventlog $jobid init &&
 	unset_userid &&
-	flux job cancel $jobid
+	flux cancel $jobid
 '
 
 test_expect_success 'flux job wait-event guest.exec.eventlog fails via -p (live job, wrong user)' '
@@ -276,7 +276,7 @@ test_expect_success 'flux job wait-event guest.exec.eventlog fails via -p (live 
 	set_userid 9999 &&
 	! flux job wait-event -p guest.exec.eventlog $jobid init &&
 	unset_userid &&
-	flux job cancel $jobid
+	flux cancel $jobid
 '
 
 #

--- a/t/t2240-queue-cmd.t
+++ b/t/t2240-queue-cmd.t
@@ -268,7 +268,7 @@ test_expect_success 'flux-queue: queue status -v shows expected counts' '
 
 test_expect_success 'flux-queue: stop queue and cancel long job' '
 	flux queue stop &&
-	flux job cancelall -f -S RUN
+	flux cancel --all -S RUN
 '
 
 test_expect_success 'flux-queue: queue becomes idle' '

--- a/t/t2240-queue-cmd.t
+++ b/t/t2240-queue-cmd.t
@@ -183,7 +183,7 @@ test_expect_success 'flux-queue: stop canceled alloc request' '
 
 test_expect_success 'flux-queue: start scheduling and cancel long job' '
 	flux queue start &&
-	flux job cancel $(cat longjob)
+	flux cancel $(cat longjob)
 '
 
 test_expect_success 'flux-queue: queue empties out' '

--- a/t/t2250-job-archive.t
+++ b/t/t2250-job-archive.t
@@ -196,9 +196,9 @@ test_expect_success 'job-archive: stores inactive job info (job cancel)' '
         fj_wait_event $jobid1 start &&
         jobid2=`flux submit hostname` &&
         fj_wait_event $jobid2 submit &&
-        flux job cancel $jobid2 &&
+        flux cancel $jobid2 &&
         fj_wait_event $jobid2 clean &&
-        flux job cancel $jobid1 &&
+        flux cancel $jobid1 &&
         fj_wait_event $jobid1 clean &&
         wait_jobid_state $jobid2 inactive &&
         wait_db $jobid2 ${ARCHIVEDB} &&

--- a/t/t2260-job-list.t
+++ b/t/t2260-job-list.t
@@ -118,7 +118,7 @@ test_expect_success 'submit jobs for job list testing' '
         #
         jobid=`flux submit --job-name=canceledjob sleep 30` &&
         flux job wait-event $jobid depend &&
-        flux job cancel $jobid &&
+        flux cancel $jobid &&
         flux job wait-event $jobid clean &&
         flux job id $jobid >> inactiveids &&
         flux job id $jobid > canceled.ids &&
@@ -361,10 +361,10 @@ test_expect_success HAVE_JQ 'job stats lists jobs in correct state (mix)' '
 '
 
 test_expect_success 'cleanup job listing jobs ' '
-	# NOTE: do not use flux job cancel `cat active.ids` as it races
+	# NOTE: do not use flux cancel `cat active.ids` as it races
 	# with the reconstruction of job-list somehow
         for jobid in `cat active.ids`; do
-	    flux job cancel $jobid &&
+	    flux cancel $jobid &&
             fj_wait_event $jobid clean
         done
 '
@@ -615,7 +615,7 @@ test_expect_success HAVE_JQ 'flux job list job state timing outputs valid (job r
         echo $obj | jq -e ".t_depend < .t_run" &&
         echo $obj | jq -e ".t_cleanup == null" &&
         echo $obj | jq -e ".t_inactive == null" &&
-        flux job cancel $jobid &&
+        flux cancel $jobid &&
         fj_wait_event $jobid clean >/dev/null
 '
 
@@ -1077,7 +1077,7 @@ test_expect_success HAVE_JQ 'flux job list lists ncores if pending & tasks speci
         id=$(flux submit -n3 hostname | flux job id) &&
         flux job list -s pending | grep ${id} &&
         flux job list-ids ${id} | jq -e ".ncores == 3" &&
-        flux job cancel ${id} &&
+        flux cancel ${id} &&
         flux queue start
 '
 
@@ -1087,7 +1087,7 @@ test_expect_success HAVE_JQ 'flux job list does not list ncores if pending & nod
         id=$(flux submit -N1 --exclusive hostname | flux job id) &&
         flux job list -s pending | grep ${id} &&
         flux job list-ids ${id} | jq -e ".ncores == null" &&
-        flux job cancel ${id} &&
+        flux cancel ${id} &&
         flux queue start
 '
 
@@ -1209,7 +1209,7 @@ test_expect_success HAVE_JQ 'flux job list does not list nnodes if no nodes requ
         id=$(flux submit -n1 hostname | flux job id) &&
         flux job list -s pending | grep ${id} &&
         flux job list-ids ${id} | jq -e ".nnodes == null" &&
-        flux job cancel ${id} &&
+        flux cancel ${id} &&
         flux queue start
 '
 
@@ -1222,7 +1222,7 @@ test_expect_success HAVE_JQ 'flux job list lists nnodes for pending jobs if node
         flux job list -s pending | grep ${id2} &&
         flux job list-ids ${id1} | jq -e ".nnodes == 1" &&
         flux job list-ids ${id2} | jq -e ".nnodes == 3" &&
-        flux job cancel ${id1} ${id2} &&
+        flux cancel ${id1} ${id2} &&
         flux queue start
 '
 
@@ -1372,7 +1372,7 @@ test_expect_success HAVE_JQ 'flux job list outputs expiration time when set' '
 	flux job list | grep $jobid > expiration.json &&
 	test_debug "cat expiration.json" &&
 	jq -e ".expiration > now" < expiration.json &&
-	flux job cancel $jobid
+	flux cancel $jobid
 '
 
 test_expect_success 'reload the job-list module' '
@@ -1394,7 +1394,7 @@ test_expect_success HAVE_JQ 'flux job list outputs duration time when set' '
 	flux job list | grep $jobid > duration.json &&
 	test_debug "cat duration.json" &&
 	jq -e ".duration == 3600.0" < duration.json &&
-	flux job cancel $jobid
+	flux cancel $jobid
 '
 
 test_expect_success 'reload the job-list module' '

--- a/t/t2261-job-list-update.t
+++ b/t/t2261-job-list-update.t
@@ -193,7 +193,7 @@ EOT
 '
 
 test_expect_success 'cleanup job listing jobs ' '
-	flux job cancel $(cat active.ids) &&
+	flux cancel $(cat active.ids) &&
         for jobid in `cat active.ids`; do
             fj_wait_event $jobid clean;
         done

--- a/t/t2271-job-dependency-after.t
+++ b/t/t2271-job-dependency-after.t
@@ -42,7 +42,7 @@ test_expect_success FLUX_SECURITY 'dependency=after will not work on another use
 		>baduser.log 2>&1 &&
 	test_debug "cat baduser.log" &&
 	grep "Permission denied" baduser.log &&
-	flux job cancel $jobid
+	flux cancel $jobid
 '
 test_expect_success 'disable ingest validator' '
 	flux module reload -f job-ingest disable-validator
@@ -87,7 +87,7 @@ test_expect_success 'dependency=after works when antecedent is running' '
 	flux job wait-event -vt 15 $jobid start &&
 	depip=$(flux submit --dependency=after:$jobid hostname) &&
 	flux job wait-event -vt 15 $depid clean &&
-	flux job cancel $jobid
+	flux cancel $jobid
 '
 test_expect_success 'dependency=after generates exception for failed job' '
 	jobid=$(flux submit --urgency=hold hostname) &&
@@ -95,7 +95,7 @@ test_expect_success 'dependency=after generates exception for failed job' '
 	flux job wait-event -vt 15 $depid dependency-add &&
 	test_debug "echo checking that job ${depid} is in DEPEND state" &&
 	test "$(flux jobs -no {state} $depid)" = "DEPEND" &&
-	flux job cancel $jobid &&
+	flux cancel $jobid &&
 	flux job wait-event -m type=dependency -vt 15 $depid exception 
 '
 test_expect_success 'dependency=afterany works' '
@@ -120,7 +120,7 @@ test_expect_success 'dependency=afterany works' '
 		-m description=after-finish=$job2 \
 		$jobid dependency-remove &&
 	flux jobs &&
-	flux job cancel $job3 &&
+	flux cancel $job3 &&
 	flux job wait-event -vt 15 $jobid clean
 '
 test_expect_success 'dependency=afterok works' '
@@ -145,7 +145,7 @@ test_expect_success 'dependency=afterok works' '
 		do flux job urgency $id default;
 	done &&
 	flux job wait-event -vt 15 $job3 start &&
-	flux job cancel $job3 &&
+	flux cancel $job3 &&
 	flux job wait-event -vt 15 \
 		-m description=after-success=$job1 \
 		$ok1 dependency-remove &&
@@ -176,7 +176,7 @@ test_expect_success 'dependency=afternotok works' '
 		do flux job urgency $id default;
 	done &&
 	flux job wait-event -vt 15 $job3 start &&
-	flux job cancel $job3 &&
+	flux cancel $job3 &&
 	flux job wait-event -vt 15 \
 		-m description=after-failure=$job2 \
 		$ok2 dependency-remove &&
@@ -217,13 +217,13 @@ test_expect_success 'dependency=afternotok works for INACTIVE job' '
 '
 test_expect_success 'dependency=after fails for INACTIVE canceled job' '
 	job4=$(flux submit --urgency=hold hostname) &&
-	flux job cancel ${job4} &&
+	flux cancel ${job4} &&
 	test_must_fail flux run --dependency=after:${job4} hostname
 '
 test_expect_success 'jobs with dependencies can be safely canceled' '
 	jobid=$(flux submit --urgency=hold hostname) &&
 	depid=$(flux submit --dependency=after:$jobid hostname) &&
-	flux job cancel $depid &&
+	flux cancel $depid &&
 	flux job urgency $jobid default &&
 	flux job wait-event -vt 15 $jobid clean
 '

--- a/t/t2272-job-begin-time.t
+++ b/t/t2272-job-begin-time.t
@@ -44,7 +44,7 @@ test_expect_success 'begin-time: job with begin-time=+1h is still in depend' '
 	test $(flux jobs -no {state} $DELAYED) = "DEPEND"
 '
 test_expect_success 'begin-time: job with begin-time can be safely canceled' '
-	flux job cancel $DELAYED &&
+	flux cancel $DELAYED &&
 	flux job wait-event -vt 15 $DELAYED clean
 '
 test_done

--- a/t/t2273-job-alloc-bypass.t
+++ b/t/t2273-job-alloc-bypass.t
@@ -67,7 +67,7 @@ test_expect_success 'alloc-bypass: handles exception before alloc event' '
 		--dependency=afterok:$SLEEPID \
 		-o per-resource.type=node hostname) &&
 	flux job wait-event -vt 15 $jobid dependency-add &&
-	flux job cancel $jobid &&
+	flux cancel $jobid &&
 	test_must_fail flux job attach -vEX $jobid
 '
 test_expect_success 'alloc-bypass: kill sleep job' '

--- a/t/t2273-job-alloc-bypass.t
+++ b/t/t2273-job-alloc-bypass.t
@@ -71,7 +71,7 @@ test_expect_success 'alloc-bypass: handles exception before alloc event' '
 	test_must_fail flux job attach -vEX $jobid
 '
 test_expect_success 'alloc-bypass: kill sleep job' '
-	flux job cancelall -f &&
+	flux cancel --all &&
 	flux job wait-event $SLEEPID clean
 '
 test_expect_success 'alloc-bypass: submit an alloc-bypass job' '

--- a/t/t2274-manager-perilog.t
+++ b/t/t2274-manager-perilog.t
@@ -124,7 +124,7 @@ test_expect_success 'perilog: job can be canceled while prolog is running' '
 	test_when_finished "rm -f prolog.d/sleep.sh" &&
 	jobid=$(flux submit --job-name=cancel hostname) &&
 	flux job wait-event -t 15 $jobid prolog-start &&
-	flux job cancel $jobid &&
+	flux cancel $jobid &&
 	flux job wait-event -t 15 $jobid prolog-finish &&
 	flux job wait-event -t 15 $jobid exception &&
 	test_must_fail flux job attach -vE $jobid
@@ -144,7 +144,7 @@ test_expect_success 'perilog: job can be canceled after prolog is complete' '
 	test_when_finished "rm -f prolog.d/sleep.sh" &&
 	jobid=$(flux submit --job-name=cancel2 sleep 300) &&
 	flux job wait-event -t 15 $jobid prolog-finish &&
-	flux job cancel $jobid &&
+	flux cancel $jobid &&
 	flux job wait-event -t 15 $jobid exception &&
 	flux job wait-event -t 15 $jobid clean
 '
@@ -220,7 +220,7 @@ test_expect_success 'perilog: prolog is killed even if it ignores SIGTERM' '
 	flux jobtap load --remove=*.so perilog.so &&
 	jobid=$(flux submit --job-name=prolog-sigkill hostname) &&
 	flux job wait-event -t 15 $jobid prolog-start &&
-	flux job cancel $jobid &&
+	flux cancel $jobid &&
 	flux job wait-event -t 15 -m status=9 $jobid prolog-finish &&
 	test_must_fail flux job attach -vEX $jobid
 '

--- a/t/t2280-job-memo.t
+++ b/t/t2280-job-memo.t
@@ -97,7 +97,7 @@ test_expect_success HAVE_JQ 'memo: non-volatile memos still available in job-lis
 	jlist_check_memo $pendingid a \"b\"
 '
 test_expect_success 'memo: cancel all jobs' '
-	flux job cancelall -f &&
+	flux cancel --all &&
 	flux job wait-event $runid clean &&
 	flux job wait-event $pendingid clean
 '

--- a/t/t2300-sched-simple.t
+++ b/t/t2300-sched-simple.t
@@ -187,7 +187,7 @@ test_expect_success 'sched-simple: verify three jobs are active' '
 
 test_expect_success 'sched-simple: remove sched-simple and cancel jobs' '
 	flux module remove sched-simple &&
-	flux job cancelall -f
+	flux cancel --all
 '
 test_expect_success 'sched-simple: there are no outstanding sched requests' '
 	flux queue status -v >queue_status.out &&
@@ -237,8 +237,8 @@ test_expect_success 'sched-simple: ensure more urgent job run' '
 # cancel all jobs, to ensure no interference with follow up tests
 # cancel non-running jobs first to ensure they are not accidentally run
 test_expect_success 'sched-simple: cancel jobs' '
-	flux job cancelall --states=SCHED -f &&
-	flux job cancelall -f &&
+	flux cancel --all --states=pending &&
+	flux cancel --all &&
 	flux job wait-event --timeout=5.0 $(cat job18.id) free &&
 	flux job wait-event --timeout=5.0 $(cat job15.id) free &&
 	flux job wait-event --timeout=5.0 $(cat job16.id) free
@@ -254,7 +254,7 @@ test_expect_success 'sched-simple: submit job and cancel it' '
 '
 test_expect_success 'sched-simple: remove sched-simple and cancel jobs' '
 	flux module remove sched-simple &&
-	flux job cancelall -f
+	flux cancel --all
 '
 test_expect_success 'sched-simple: there are no outstanding sched requests' '
 	flux queue status -v >queue_status.out &&

--- a/t/t2300-sched-simple.t
+++ b/t/t2300-sched-simple.t
@@ -100,7 +100,7 @@ test_expect_success 'sched-simple: no remaining resources' '
 	test "$($query)" = ""
 '
 test_expect_success 'sched-simple: cancel one job' '
-	flux job cancel $(cat job3.id) &&
+	flux cancel $(cat job3.id) &&
 	flux job wait-event --timeout=5.0 $(cat job3.id) exception &&
 	flux job wait-event --timeout=5.0 $(cat job3.id) free
 '
@@ -109,10 +109,10 @@ test_expect_success 'sched-simple: waiting job now has alloc event' '
 	test "$(list_R $(cat job5.id))" = "annotations={\"sched\":{\"resource_summary\":\"rank0/core1\"}}"
 '
 test_expect_success 'sched-simple: cancel all jobs' '
-	flux job cancel $(cat job5.id) &&
-	flux job cancel $(cat job4.id) &&
-	flux job cancel $(cat job2.id) &&
-	flux job cancel $(cat job1.id) &&
+	flux cancel $(cat job5.id) &&
+	flux cancel $(cat job4.id) &&
+	flux cancel $(cat job2.id) &&
+	flux cancel $(cat job1.id) &&
 	flux job wait-event --timeout=5.0 $(cat job1.id) exception &&
 	flux job wait-event --timeout=5.0 $(cat job1.id) free &&
 	test "$($query)" = "rank[0-1]/core[0-1]"
@@ -141,15 +141,15 @@ test_expect_success 'sched-simple: check allocations for running jobs' '
 '
 test_expect_success 'sched-simple: cancel pending & running job' '
 	id=$(cat job10.id) &&
-	flux job cancel $id &&
+	flux cancel $id &&
 	flux job wait-event --timeout=5.0 $id exception &&
-	flux job cancel $(cat job6.id) &&
+	flux cancel $(cat job6.id) &&
 	test_expect_code 1 flux kvs get $(kvs_job_dir $id).R
 '
 test_expect_success 'sched-simple: cancel remaining jobs' '
-	flux job cancel $(cat job7.id) &&
-	flux job cancel $(cat job8.id) &&
-	flux job cancel $(cat job9.id) &&
+	flux cancel $(cat job7.id) &&
+	flux cancel $(cat job8.id) &&
+	flux cancel $(cat job9.id) &&
 	flux job wait-event --timeout=5.0 $(cat job9.id) free
 '
 test_expect_success 'sched-simple: reload in first-fit alloc-mode' '
@@ -221,7 +221,7 @@ test_expect_success 'sched-simple: update urgency of job' '
 	flux job urgency $(cat job18.id) 20
 '
 test_expect_success 'sched-simple: cancel running job' '
-	flux job cancel $(cat job14.id) &&
+	flux cancel $(cat job14.id) &&
 	flux job wait-event --timeout=5.0 $(cat job14.id) free
 '
 test_expect_success 'sched-simple: ensure more urgent job run' '
@@ -249,7 +249,7 @@ test_expect_success 'sched-simple: reload sched-simple to cover free flags' '
 test_expect_success 'sched-simple: submit job and cancel it' '
 	flux job submit basic.json >job19.id &&
 	flux job wait-event --timeout=5.0 $(cat job19.id) alloc &&
-	flux job cancel $(cat job19.id) &&
+	flux cancel $(cat job19.id) &&
 	$dmesg_grep -t 10 "free: R is NULL"
 '
 test_expect_success 'sched-simple: remove sched-simple and cancel jobs' '

--- a/t/t2311-resource-drain.t
+++ b/t/t2311-resource-drain.t
@@ -207,7 +207,7 @@ test_expect_success 'drain works on allocated rank' '
 	flux resource drain $rank &&
 	test $(flux resource list -n -s down -o {nnodes}) -eq 1 &&
 	flux resource drain | grep draining &&
-	flux job cancel $id &&
+	flux cancel $id &&
 	flux job wait-event $id clean &&
 	flux resource drain | grep drained
 '
@@ -221,7 +221,7 @@ test_expect_success 'flux resource drain differentiates drain/draining' '
 	test_debug "flux resource status" &&
 	test $(flux resource status -s draining -no {ranks}) = "$rank" &&
 	flux resource drain | grep draining &&
-	flux job cancel $id &&
+	flux cancel $id &&
 	flux job wait-event $id clean &&
 	test $(flux resource status -s drain -no {nnodes}) -eq ${SIZE}
 '

--- a/t/t2350-resource-list.t
+++ b/t/t2350-resource-list.t
@@ -166,7 +166,7 @@ test_expect_success 'flux resource lists expected queues in states (single)' '
 	test $(grep -c "allocated 1 debug" list2.out) -eq 1
 '
 test_expect_success 'cleanup jobs' '
-	flux job cancel $(cat job1A.id) $(cat job1B.id)
+	flux cancel $(cat job1A.id) $(cat job1B.id)
 '
 test_expect_success 'configure queues and resource split amongst queues w/ all' '
 	flux R encode -r 0-3 -p all:0-3 -p batch:0-1 -p debug:2-3 \
@@ -278,6 +278,6 @@ test_expect_success 'flux resource lists expected queues in states (every)' '
 	test $(grep "down 0" listqueue_every2.out | grep -c every) -eq 0
 '
 test_expect_success 'cleanup jobs' '
-	flux job cancel $(cat job2A.id) $(cat job2B.id)
+	flux cancel $(cat job2A.id) $(cat job2B.id)
 '
 test_done

--- a/t/t2400-job-exec-test.t
+++ b/t/t2400-job-exec-test.t
@@ -46,7 +46,7 @@ test_expect_success 'job-exec: canceling job during execution works' '
 	jobid=$(flux submit \
                 --setattr=system.exec.test.run_duration=10s hostname) &&
 	flux job wait-event -vt 2.5 ${jobid} start &&
-	flux job cancel ${jobid} &&
+	flux cancel ${jobid} &&
 	flux job wait-event -t 2.5 ${jobid} exception &&
 	flux job wait-event -t 2.5 ${jobid} finish | grep status=15 &&
 	flux job wait-event -t 2.5 ${jobid} release &&
@@ -110,7 +110,7 @@ test_expect_success 'job-exec: override only works on jobs with flag set' '
 		--setattr=system.exec.test.run_duration=0. /bin/true) &&
 	flux job wait-event -t 5 ${jobid} alloc &&
 	test_must_fail flux job-exec-override start ${jobid} &&
-	flux job cancel ${jobid} &&
+	flux cancel ${jobid} &&
 	flux job wait-event -t 5 -v ${jobid} clean
 '
 test_expect_success 'job-exec: test exec start/finish override works' '
@@ -152,7 +152,7 @@ test_expect_success 'job-exec: job-exec.testoverride invalid request' '
 	{"jobid":"$(flux job id --to=dec ${jobid})", "event":"foo"}
 	EOF
 	test_must_fail flux python override.py < badevent.json &&
-	flux job cancel $jobid &&
+	flux cancel $jobid &&
 	flux job wait-event $jobid clean
 '
 test_expect_success 'job-exec: flux job-exec-override fails for invalid userid' '
@@ -164,7 +164,7 @@ test_expect_success 'job-exec: flux job-exec-override fails for invalid userid' 
 	  export FLUX_HANDLE_USERID=$newid &&
 	    test_must_fail flux job-exec-override start ${jobid}
 	) &&
-	flux job cancel ${jobid} &&
+	flux cancel ${jobid} &&
 	flux job wait-event -t 5 -v ${jobid} clean
 '
 test_expect_success 'job-exec: critical-ranks RPC handles unexpected input' '

--- a/t/t2401-job-exec-hello.t
+++ b/t/t2401-job-exec-hello.t
@@ -57,7 +57,7 @@ test_expect_success NO_CHAIN_LINT 'exec hello: hello now returns error due to ru
 	test_expect_code 1 run_timeout 5 ${execservice} testexecfoo
 '
 test_expect_success NO_CHAIN_LINT 'exec hello: terminate all jobs and servers' '
-	flux job cancel ${id} &&
+	flux cancel ${id} &&
 	test_debug "cat server3.log" &&
 	flux job wait-event -t 2.5 ${id} clean &&
 	kill ${SERVER3}

--- a/t/t2402-job-exec-dummy.t
+++ b/t/t2402-job-exec-dummy.t
@@ -70,7 +70,7 @@ test_expect_success 'job-exec: job exception uses SIGKILL after kill-timeout' '
 	flux kvs get --waitcreate \
 		--namespace=$(flux job namespace $id) \
 		trap-ready &&
-	flux job cancel $id &&
+	flux cancel $id &&
 	(flux job attach -vEX $id >kill.output 2>&1 || true) &&
 	test_debug "cat kill.output" &&
 	grep "trap-sigterm got SIGTERM" kill.output &&

--- a/t/t2404-job-exec-multiuser.t
+++ b/t/t2404-job-exec-multiuser.t
@@ -100,7 +100,7 @@ test_expect_success NO_ASAN 'job-exec: kill multiuser job uses the IMP' '
 	flux job list-ids ${id} > ${id}.json &&
 	jq -e ".userid == 42" < ${id}.json &&
 	flux job wait-event -p guest.exec.eventlog -vt 30 ${id} shell.start &&
-	flux job cancel ${id} &&
+	flux cancel ${id} &&
 	test_expect_code 143 run_timeout 30 flux job status -v ${id} &&
 	flux dmesg | grep "test-imp: Kill .*signal 15"
 '

--- a/t/t2405-job-exec-sdexec.t
+++ b/t/t2405-job-exec-sdexec.t
@@ -40,7 +40,7 @@ test_expect_success 'job-exec: basic test sdexec works' '
         jobiddec=`flux job id --to=dec $jobid` &&
         rank=`flux getattr rank` &&
         systemctl list-units --user | grep "flux-sdexec-${rank}-${jobiddec}" &&
-        flux job cancel ${jobid} &&
+        flux cancel ${jobid} &&
         flux job wait-event -t 10 ${jobid} clean
 '
 
@@ -59,7 +59,7 @@ test_expect_success 'job-exec: basic sdexec with exec config works' '
         jobiddec=`flux job id --to=dec $jobid` &&
         rank=`flux getattr rank` &&
         systemctl list-units --user | grep "flux-sdexec-${rank}-${jobiddec}" &&
-        flux job cancel ${jobid} &&
+        flux cancel ${jobid} &&
         flux job wait-event -t 10 ${jobid} clean
 '
 
@@ -112,7 +112,7 @@ test_expect_success 'job-exec: simple job exits 138 on signaled job' '
 test_expect_success 'job-exec: simple job can be canceled' '
         jobid=$(flux submit sleep 30) &&
         flux job wait-event -t 10 ${jobid} start &&
-        flux job cancel $jobid &&
+        flux cancel $jobid &&
         flux job wait-event -t 10 ${jobid} clean &&
         test_expect_code 143 flux job status $jobid
 '
@@ -130,7 +130,7 @@ test_expect_success 'job-exec: systemd cleaned up after job completes' '
         jobiddec=`flux job id --to=dec $jobid` &&
         rank=`flux getattr rank` &&
         systemctl list-units --user | grep "flux-sdexec-${rank}-${jobiddec}" &&
-        flux job cancel ${jobid} &&
+        flux cancel ${jobid} &&
         flux job wait-event -v -t 30 $jobid clean &&
         systemctl list-units --user > list-units.out &&
         test_must_fail grep "flux-sdexec-${rank}-${jobiddec}" list-units.out
@@ -220,7 +220,7 @@ test_expect_success LONGTEST 'job-exec: can run job longer than 25 seconds' '
 test_expect_success LONGTEST 'job-exec: can cancel job after 25 seconds' '
         jobid=$(flux submit sleep 60) &&
         sleep 40 &&
-        flux job cancel $jobid &&
+        flux cancel $jobid &&
         test_expect_code 143 flux job status $jobid
 '
 test_done

--- a/t/t2500-job-attach.t
+++ b/t/t2500-job-attach.t
@@ -44,7 +44,7 @@ test_expect_success 'attach: shows output from job' '
 
 test_expect_success 'attach: submit a job and cancel it' '
 	flux submit sleep 30 >jobid2 &&
-	flux job cancel $(cat jobid2)
+	flux cancel $(cat jobid2)
 '
 
 test_expect_success 'attach: exit code reflects cancellation' '
@@ -86,7 +86,7 @@ test_expect_success 'attach: SIGINT+SIGTSTP detaches from job' '
 test_expect_success 'attach: detached job was not canceled' '
 	flux job eventlog $(cat jobid4) >events4 &&
 	test_must_fail grep -q cancel events4 &&
-	flux job cancel $(cat jobid4)
+	flux cancel $(cat jobid4)
 '
 
 # Make sure live output occurs by seeing output "before" sleep, but no
@@ -100,7 +100,7 @@ test_expect_success NO_CHAIN_LINT 'attach: output appears before cancel' '
 	flux job attach -E ${jobid} 1>attach5.out 2>attach5.err &
 	waitpid=$! &&
 	flux job wait-event --timeout=10.0 -p guest.exec.eventlog ${jobid} test-output-ready &&
-	flux job cancel ${jobid} &&
+	flux cancel ${jobid} &&
 	! wait ${waitpid} &&
 	grep before attach5.out &&
 	! grep after attach5.out
@@ -150,7 +150,7 @@ test_expect_success 'attach: --stdin-ranks works' '
 test_expect_success 'attach: --stdin-ranks with invalid idset errors' '
 	id=$(flux submit -t20s cat) &&
 	test_must_fail flux job attach -i 5-0 $id &&
-	flux job cancel $id
+	flux cancel $id
 '
 test_expect_success 'attach: --stdin-ranks is adjusted to intersection' '
 	id=$(flux submit -n2 -t20s cat) &&
@@ -161,7 +161,7 @@ test_expect_success 'attach: --stdin-ranks is adjusted to intersection' '
 test_expect_success 'attach: --stdin-ranks cannot be used with --read-only' '
 	id=$(flux submit -n2 -t20s cat) &&
 	test_must_fail flux job attach -i all --read-only $id &&
-	flux job cancel $id
+	flux cancel $id
 '
 jobpipe=$SHARNESS_TEST_SRCDIR/scripts/pipe.py
 test_expect_success 'attach: writing to stdin of closed tasks returns EPIPE' '

--- a/t/t2501-job-status.t
+++ b/t/t2501-job-status.t
@@ -15,7 +15,7 @@ test_expect_success 'status: submit a series of jobs' '
 	killed=$(flux submit sleep 600) &&
 	flux queue stop &&
 	canceled=$(flux submit -n 1024 hostname) &&
-	flux job cancel ${canceled} &&
+	flux cancel ${canceled} &&
 	flux queue start
 '
 test_expect_success 'status: exits with error with no jobs specified' '
@@ -75,7 +75,7 @@ test_expect_success HAVE_JQ 'status: returns most severe exception' '
 '
 test_expect_success 'status: returns 143 (SIGTERM) for canceled running job' '
 	flux job wait-event -p guest.exec.eventlog ${killed} shell.start &&
-	flux job cancel ${killed} &&
+	flux cancel ${killed} &&
 	test_expect_code 143 flux job status -v ${killed}
 '
 test_expect_success 'status: returns highest status for multiple jobs' '

--- a/t/t2602-job-shell.t
+++ b/t/t2602-job-shell.t
@@ -236,7 +236,7 @@ test_expect_success NO_CHAIN_LINT 'job-shell: cover stdout unbuffered output' '
 	id=$(flux submit --unbuffered ./stdout-unbuffered.sh)
 	flux job attach $id > stdout-unbuffered.out &
 	$waitfile --count=1 --timeout=10 --pattern=abcd stdout-unbuffered.out &&
-	flux job cancel $id
+	flux cancel $id
 '
 test_expect_success NO_CHAIN_LINT 'job-shell: cover stderr unbuffered output' '
 	cat <<-EOF >stderr-unbuffered.sh &&
@@ -248,7 +248,7 @@ test_expect_success NO_CHAIN_LINT 'job-shell: cover stderr unbuffered output' '
 	id=$(flux submit --unbuffered ./stderr-unbuffered.sh)
 	flux job attach $id 1> stdout.out 2> stderr-unbuffered.out &
 	$waitfile --count=1 --timeout=10 --pattern=efgh stderr-unbuffered.out &&
-	flux job cancel $id
+	flux cancel $id
 '
 test_expect_success NO_CHAIN_LINT 'job-shell: cover stdout line output' '
 	cat <<-EOF >stdout-line.sh &&
@@ -262,7 +262,7 @@ test_expect_success NO_CHAIN_LINT 'job-shell: cover stdout line output' '
 		./stdout-line.sh)
 	flux job attach $id > stdout-line.out &
 	$waitfile --count=1 --timeout=10 --pattern=ijkl stdout-line.out &&
-	flux job cancel $id
+	flux cancel $id
 '
 test_expect_success NO_CHAIN_LINT 'job-shell: cover stderr line output' '
 	cat <<-EOF >stderr-line.sh &&
@@ -276,7 +276,7 @@ test_expect_success NO_CHAIN_LINT 'job-shell: cover stderr line output' '
 		./stderr-line.sh)
 	flux job attach $id 1> stdout.out 2> stderr-line.out &
 	$waitfile --count=1 --timeout=10 --pattern=mnop stderr-line.out &&
-	flux job cancel $id
+	flux cancel $id
 '
 test_expect_success 'job-shell: cover invalid buffer type' '
 	id=$(flux submit \

--- a/t/t2606-job-shell-output-redirection.t
+++ b/t/t2606-job-shell-output-redirection.t
@@ -312,7 +312,7 @@ test_expect_success NO_CHAIN_LINT 'job-shell: job attach waits if no kvs output 
         flux job wait-event $id start &&
         flux job attach -E -X ${id} 2> attach27.err &
         pid=$! &&
-        flux job cancel $id &&
+        flux cancel $id &&
         ! wait $pid
 '
 
@@ -323,7 +323,7 @@ test_expect_success NO_CHAIN_LINT 'job-shell: job attach waits if no kvs output 
         flux job wait-event $id start &&
         flux job attach -E -X ${id} 2> attach28.err &
         pid=$! &&
-        flux job cancel $id &&
+        flux cancel $id &&
         ! wait $pid
 '
 test_expect_success 'job-shell: shell errors are captured in output file' '

--- a/t/t2607-job-shell-input.t
+++ b/t/t2607-job-shell-input.t
@@ -91,7 +91,7 @@ test_expect_success NO_CHAIN_LINT 'flux-shell: no stdin desired in job' '
         pid=$! &&
         flux job wait-event -p guest.exec.eventlog $id shell.init 2> pipe6B.err &&
         flux job wait-event -p guest.input -m eof=true $id data 2> pipe6C.err &&
-        flux job cancel $id 2> pipe6D.err &&
+        flux cancel $id 2> pipe6D.err &&
         test_expect_code 143 wait $pid
 '
 
@@ -122,7 +122,7 @@ test_expect_success NO_CHAIN_LINT 'flux-shell: pipe to stdin twice, second fails
         flux job wait-event -p guest.exec.eventlog $id shell.init 2> pipe9B.err &&
         flux job wait-event -p guest.input -m eof=true $id data 2> pipe9C.err &&
         test_must_fail flux job attach $id < input_stdin_file 2> pipe9D.err &&
-        flux job cancel $id 2> pipe9E.err &&
+        flux cancel $id 2> pipe9E.err &&
         test_expect_code 143 wait $pid
 '
 
@@ -177,7 +177,7 @@ test_expect_success 'flux-shell: task stdin via file, try to pipe into stdin fai
         id=$(flux submit -n1 --input=input_stdin_file sleep 60) &&
         flux job wait-event $id start &&
         test_must_fail flux job attach $id < input_stdin_file &&
-        flux job cancel $id
+        flux cancel $id
 '
 
 #

--- a/t/t2611-debug-emulate.t
+++ b/t/t2611-debug-emulate.t
@@ -104,7 +104,7 @@ test_expect_success 'debugger: job attach --debug must not continue target' '
 	tv_jobid=$(parse_totalview_jobid jobid.out3) &&
 	test ${tv_jobid} = "${jobid}" &&
 	test_must_fail flux job wait-event -vt ${TIMEOUT} ${jobid} finish &&
-	flux job cancel ${jobid} &&
+	flux cancel ${jobid} &&
 	flux job wait-event -vt ${TIMEOUT} ${jobid} finish
 '
 

--- a/t/t2616-job-shell-taskmap.t
+++ b/t/t2616-job-shell-taskmap.t
@@ -44,7 +44,7 @@ test_expect_success 'flux job taskmap fails with invalid taskmap on cmdline' '
 test_expect_success 'flux job taskmap fails for canceled job' '
 	flux queue stop &&
 	id=$(flux submit -N4 true) &&
-	flux job cancel $id &&
+	flux cancel $id &&
 	flux queue start &&
 	test_must_fail flux job taskmap $id
 '

--- a/t/t2702-mini-alloc.t
+++ b/t/t2702-mini-alloc.t
@@ -120,7 +120,7 @@ test_expect_success NO_CHAIN_LINT 'flux-mini alloc --bg errors when job is cance
 	flux mini alloc --bg -n1 -v >canceled.log 2>&1 &
 	pid=$! &&
 	$waitfile -t 20 -v -p waiting canceled.log &&
-	flux job cancelall -f &&
+	flux cancel --all &&
 	cat canceled.log &&
 	test_must_fail wait $pid &&
 	grep "unexpectedly exited" canceled.log

--- a/t/t2712-python-cli-alloc.t
+++ b/t/t2712-python-cli-alloc.t
@@ -106,7 +106,7 @@ test_expect_success NO_CHAIN_LINT 'flux alloc --bg errors when job is canceled' 
 	flux alloc --bg -n1 -v >canceled.log 2>&1 &
 	pid=$! &&
 	$waitfile -t 20 -v -p waiting canceled.log &&
-	flux job cancelall -f &&
+	flux cancel --all &&
 	cat canceled.log &&
 	test_must_fail wait $pid &&
 	grep "unexpectedly exited" canceled.log

--- a/t/t2715-python-cli-cancel.t
+++ b/t/t2715-python-cli-cancel.t
@@ -1,0 +1,139 @@
+#!/bin/sh
+
+test_description='Test flux cancel command'
+
+. $(dirname $0)/sharness.sh
+
+test_under_flux 4
+
+# Set CLIMain log level to logging.DEBUG (10), to enable stack traces
+export FLUX_PYCLI_LOGLEVEL=10
+
+flux setattr log-stderr-level 1
+
+runas() {
+	userid=$1 && shift
+	FLUX_HANDLE_USERID=$userid FLUX_HANDLE_ROLEMASK=0x2 "$@"
+}
+
+test_expect_success 'flux cancel fails with bad FLUX_URI' '
+	validjob=$(flux submit sleep 30) &&
+	(FLUX_URI=/wrong test_must_fail flux cancel ${validjob}) &&
+	flux cancel $validjob
+'
+test_expect_success 'flux cancel fails with unknown job id' '
+	test_must_fail flux cancel 0
+'
+test_expect_success 'flux cancel fails with unknown job ids' '
+	test_must_fail flux cancel 0 f123
+'
+test_expect_success 'flux cancel fails with no args' '
+	test_must_fail flux cancel
+'
+test_expect_success 'flux cancel fails with invalid jobid' '
+	test_must_fail flux cancel foo
+'
+test_expect_success 'flux cancel fails with invalid user' '
+	test_must_fail flux cancel --user=1badusername12345
+'
+test_expect_success 'flux cancel fails with invalid option' '
+	test_must_fail flux cancel --meep foo
+'
+test_expect_success 'flux cancel JOBID works' '
+	id=$(flux submit sleep 100) &&
+	flux cancel ${id} &&
+	flux job wait-event -t 30 ${id} exception >cancel1.out &&
+	grep "cancel" cancel1.out &&
+	grep "severity\=0" cancel1.out
+'
+test_expect_success 'flux cancel --message works' '
+	id=$(flux submit sleep 100) &&
+	flux cancel --message=meepmessage ${id} &&
+	flux job wait-event -t 30 ${id} exception >cancel2.out &&
+	grep "meepmessage" cancel2.out
+'
+test_expect_success 'flux cancel --all --dry-run works' '
+	count=4 &&
+	flux submit --cc=1-$count sleep 60 &&
+	flux cancel --all --dry-run 2>cancelall_n.err &&
+	cat <<-EOT >cancelall_n.exp &&
+	flux-cancel: Would cancel ${count} jobs
+	EOT
+	test_cmp cancelall_n.exp cancelall_n.err
+'
+test_expect_success 'flux cancel --all works' '
+	count=$(flux job list | wc -l) &&
+	flux cancel --all 2>cancelall.err &&
+	cat <<-EOT >cancelall.exp &&
+	flux-cancel: Canceled ${count} jobs (0 errors)
+	EOT
+	test_cmp cancelall.exp cancelall.err
+'
+test_expect_success 'flux cancel --all works with message' '
+	count=4 &&
+	flux submit --cc=1-$count sleep 60 &&
+	flux cancel --all --message="cancel all" 2>cancelall.err &&
+	cat <<-EOT >cancelall.exp &&
+	flux-cancel: Canceled ${count} jobs (0 errors)
+	EOT
+	test_cmp cancelall.exp cancelall.err &&
+	flux job wait-event -t 5 $(flux job last) exception >exception.out &&
+	grep "cancel all" exception.out
+'
+test_expect_success 'the queue is empty' '
+	run_timeout 60 flux queue drain
+'
+test_expect_success 'flux cancel --all --user all fails for guest' '
+	id=$(($(id -u)+1)) &&
+	test_must_fail runas ${id} \
+	        flux cancel --all --user=all 2> cancelall_all_guest.err &&
+	grep "guests can only raise exceptions on their own jobs" \
+		cancelall_all_guest.err
+'
+test_expect_success 'flux- cancel --all --user <guest uid> works for guest' '
+	id=$(($(id -u)+1)) &&
+	runas ${id} flux cancel --all --user=${id}
+'
+test_expect_success 'flux cancel --state with unknown state fails' '
+        test_must_fail flux cancel --states=FOO 2>cancelall_bs.err &&
+	grep "Invalid state FOO specified" cancelall_bs.err
+'
+test_expect_success 'flux cancel --state=pending works' '
+	runid=$(flux submit -n $(flux resource list -no {ncores}) sleep 60) &&
+	flux submit --cc=1-4 sleep 30 &&
+	flux cancel --states=pending --dry-run 2>pending.err &&
+	grep "Would cancel 4 jobs" pending.err &&
+	flux cancel --states=pending &&
+	test $(flux jobs -f pending -no {id} | wc -l) -eq 0 &&
+	test $(flux jobs -f run -no {id} | wc -l) -eq 1
+'
+test_expect_success 'flux cancel --state=run works' '
+	flux cancel --states=run --dry-run 2>run.err &&
+	grep "Would cancel 1 job" run.err &&
+	flux cancel --states=run
+'
+test_expect_success 'flux cancel reports 0 jobs with no match' '
+	flux cancel --states=run --dry-run 2>nomatch.err &&
+	test_debug "cat nomatch.err" &&
+	grep "Matched 0 jobs" nomatch.err
+'
+test_expect_success 'flux cancel can operate on multiple jobs' '
+	ids=$(flux submit --cc=1-3 sleep 600) &&
+        flux cancel -m "cancel multiple jobids" ${ids} &&
+        for id in ${ids}; do
+                flux job wait-event -t 30 ${id} exception >exception.out &&
+                grep multiple exception.out
+        done
+'
+test_expect_success 'flux cancel does nothing with --dry-run and multiple jobs' '
+	flux cancel -n f1 f2 f3 2>multiple_n.out &&
+	grep "Would cancel 3 jobs" multiple_n.out
+'
+test_expect_success 'flux cancel records errors with multiple jobids' '
+	ids2=$(flux submit --cc=1-3 sleep 600) &&
+        test_must_fail \
+		flux cancel -m "cancel multiple jobids" ${ids2} ${ids} \
+		2>multiple-errors.out &&
+	grep "inactive" multiple-errors.out
+'
+test_done

--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -144,7 +144,7 @@ test_expect_success HAVE_JQ 'submit jobs for job list testing' '
 	#
 	jobid=`flux submit --job-name=canceledjob sleep 30` &&
 	fj_wait_event $jobid depend &&
-	flux job cancel $jobid &&
+	flux cancel $jobid &&
 	fj_wait_event $jobid clean &&
 	echo $jobid >> inactiveids &&
 	echo $jobid > canceled.ids &&
@@ -1275,7 +1275,7 @@ test_expect_success 'flux-jobs --stats-only works' '
 '
 
 test_expect_success 'cleanup job listing jobs ' '
-	flux job cancel $(cat active.ids) &&
+	flux cancel $(cat active.ids) &&
 	for jobid in `cat active.ids`; do
 		fj_wait_event $jobid clean;
 	done

--- a/t/t2800-jobs-recursive.t
+++ b/t/t2800-jobs-recursive.t
@@ -97,6 +97,6 @@ test_expect_success FLUX_SECURITY \
 	grep $(cat altid): recurse-all.out
 '
 test_expect_success FLUX_SECURITY 'cancel alternate user job' '
-	flux job cancel $(cat altid)
+	flux cancel $(cat altid)
 '
 test_done

--- a/t/t2801-top-cmd.t
+++ b/t/t2801-top-cmd.t
@@ -290,7 +290,7 @@ test_expect_success 'flux-top shows expected data in debug queue' '
 	test $(grep debug debugq.out | wc -l) -eq 1
 '
 test_expect_success 'cancel all jobs' '
-	flux job cancelall --force &&
+	flux cancel --all &&
 	flux queue drain
 '
 test_expect_success 'flux-top shows expected data in queues after cancels' '

--- a/t/t2801-top-cmd.t
+++ b/t/t2801-top-cmd.t
@@ -195,7 +195,7 @@ test_expect_success NO_CHAIN_LINT 'flux-top does not exit on recursive failure' 
 	grep -qi "error connecting to Flux" recurse-fail.log
 '
 test_expect_success 'cleanup running jobs' '
-	flux job cancel $(cat jobid2) $(cat jobid3) &&
+	flux cancel $(cat jobid2) $(cat jobid3) &&
 	flux job wait-event $(cat jobid2) clean &&
 	flux job wait-event $(cat jobid3) clean
 '

--- a/t/t2802-uri-cmd.t
+++ b/t/t2802-uri-cmd.t
@@ -166,7 +166,7 @@ test_expect_success 'flux-uri mock testing of lsf resolver works' '
 	test "$result" = "$FLUX_URI"
 '
 test_expect_success 'cleanup jobs' '
-	flux job cancelall -f &&
+	flux cancel --all &&
 	flux queue drain
 '
 test_done

--- a/t/t2808-shutdown-cmd.t
+++ b/t/t2808-shutdown-cmd.t
@@ -76,7 +76,7 @@ test_expect_success 'flux-shutdown JOBID fails when JOBID is not a flux instance
 	grep "URI not found" notflux.err
 '
 test_expect_success 'cancel that job' '
-	flux job cancel $(cat jobid3)
+	flux cancel $(cat jobid3)
 '
 
 test_expect_success 'run instance with no initial program and wait for it to start' '

--- a/t/t2900-job-timelimits.t
+++ b/t/t2900-job-timelimits.t
@@ -77,7 +77,7 @@ expired_cancel_test() {
 	id=$(flux submit --time-limit=${1}s bash -c \
             "trap \"echo got SIGALRM>>trap2.out\" SIGALRM;sleep 60;sleep 60" ) &&
 	flux job wait-event --timeout=30 $id exception &&
-	flux job cancel $id &&
+	flux cancel $id &&
 	test_expect_code 143 run_timeout 30 flux job attach $id
 
 }

--- a/t/t2900-job-timelimits.t
+++ b/t/t2900-job-timelimits.t
@@ -31,13 +31,13 @@ test_expect_success HAVE_JQ 'job timelimits are propagated' '
 	flux jobs -no "{id.f58} {expiration}"
 	exp1=\$(flux jobs -no {expiration} \$id1)
 	test "\$(round \$exp1)" = "\$(round \${expiration})"
-	flux job cancelall -f
+	flux cancel --all
 
 	id2=\$(flux submit --wait-event=start -t 1m sleep 300)
 	flux jobs -no "{id.f58} {expiration}"
 	exp2=\$(flux jobs -no {expiration} \$id2)
 	test \$(round \${exp2}) -lt \$(round \${expiration})
-        flux job cancelall -f
+        flux cancel --all
 	EOF
 	chmod +x limit.sh &&
 	flux run --time-limit=10m flux start ./limit.sh

--- a/t/t3100-flux-in-flux.t
+++ b/t/t3100-flux-in-flux.t
@@ -23,7 +23,7 @@ test_expect_success 'flux subinstance sets uri job memo' '
 	flux job wait-event -t 60 ${jobid} memo &&
 	flux jobs -no {user.uri} ${jobid} > uri.memo &&
 	grep ^ssh:// uri.memo &&
-	flux job cancel $jobid &&
+	flux cancel $jobid &&
 	flux job wait-event $jobid clean
 '
 

--- a/t/t3202-instance-restart-testexec.t
+++ b/t/t3202-instance-restart-testexec.t
@@ -20,7 +20,7 @@ test_expect_success 'restart instance, reattach to running job, cancel it (long 
 	flux start -o,--setattr=statedir=$(pwd) \
 	     sh -c "flux job eventlog $(cat id1.out) > eventlog_long1.out; \
 		    flux jobs -n > jobs_long1.out; \
-		    flux job cancel $(cat id1.out)" &&
+		    flux cancel $(cat id1.out)" &&
 	grep "reattach-start" eventlog_long1.out &&
 	grep "reattach-finish" eventlog_long1.out &&
 	grep $(cat id1.out) jobs_long1.out

--- a/t/valgrind/workload.d/job-cancel
+++ b/t/valgrind/workload.d/job-cancel
@@ -5,5 +5,5 @@ set -x
 #  Test job cancel
 id=$(flux submit sleep 60)
 flux job wait-event ${id} start
-flux job cancel ${id}
+flux cancel ${id}
 flux job wait-event ${id} clean


### PR DESCRIPTION
Since we now have commands to submit jobs at the top level of the `flux` command hierarchy, it seems a bit of an omission that we do not have a top level command to cancel jobs.

This PR adds a fairly simple `flux cancel` command. `flux cancel` contains a combination of the functionality from `flux job cancel` and `flux job cancelall`:
```
usage: flux cancel [OPTIONS] [JOBIDS...]

Cancel pending or running jobs with an optional exception note.

positional arguments:
  JOBIDS...            jobids to cancel

optional arguments:
  -h, --help           show this help message and exit
      --all            Target all jobs
  -n, --dry-run        Do not cancel any jobs
  -q, --quiet          Suppress output when no jobs match
  -u, --user=USER      Set target user or 'all' (instance owner only)
  -S, --states=STATES  List of job states to target (default=active)
  -m, --message=NOTE   Set optional cancel exception note
```

Note that the `--force` option has been replaced with `--dry-run`. This is probably a little more user friendly for the common case, since users will expect `flux cancel --all` to mean cancel all, and not have to doubly confirm that they want to cancel all their jobs.

For now, `flux job cancel` and `flux job cancelall` are left alone. They are probably much faster than the Python equivalent, so I'd hate to replace all uses in the testsuite and rc3 script with `flux cancel`. However, I'll attempt that now to determine if there's any fallout.