### PR TITLE
completions: remove flux-mini and other updates

### DIFF
--- a/etc/completions/flux.pre
+++ b/etc/completions/flux.pre
@@ -421,6 +421,8 @@ _flux_job()
         -v --verbose \
         -q --quiet \
         -r --read-only \
+        -i --stdin-ranks= \
+        -u --unbuffered \
         --debug \
     "
     local status_OPTS="\

--- a/etc/completions/flux.pre
+++ b/etc/completions/flux.pre
@@ -369,6 +369,7 @@ _flux_job()
         memo \
         taskmap \
         timeleft \
+        last \
     "
     local nojob_subcmds="\
         cancelall \
@@ -474,6 +475,7 @@ _flux_job()
     local timeleft_OPTS="\
         -H --human
     "
+    local last_OPTS=""
     if [[ $cmd != "job" ]]; then
         if [[ $cur != -* ]]; then
            if _flux_contains_word ${cmd} ${subcmds}; then

--- a/etc/completions/flux.pre
+++ b/etc/completions/flux.pre
@@ -182,6 +182,7 @@ _flux_mini()
         --input= \
         --output= \
         --error= \
+        -u --unbuffered \
         -l --label-io \
         --flags= \
         --dry-run \

--- a/etc/completions/flux.pre
+++ b/etc/completions/flux.pre
@@ -108,6 +108,7 @@ _flux_complete_format_name() {
 #  Get the list of subcommands from FLUX_EXEC_PATH and hard-coded builtins
 __get_flux_subcommands() {
     local subcommands
+    local deprecated="mini.py"
     if [ -z "$FLUX_EXEC_PATH" ]; then
         FLUX_EXEC_PATH=`flux env printenv FLUX_EXEC_PATH`
     fi
@@ -115,9 +116,11 @@ __get_flux_subcommands() {
     local IFS=":"
     for dir in $FLUX_EXEC_PATH; do
         for op in $dir/flux-*; do
-            if [[ -x $op ]]; then
+            if [[ -x $op  ]]; then
                 op="${op##*flux-}"
-                subcommands+="${op%.*} "
+                if ! _flux_contains_word ${op} $deprecated; then
+                    subcommands+="${op%.*} "
+                fi
             fi
         done
     done
@@ -1326,9 +1329,6 @@ _flux_core()
     fi
 
     case "${cmd}" in
-    mini)
-        _flux_mini $subcmd
-        ;;
     submit|run|alloc|batch|bulksubmit)
         _flux_mini $cmd
         ;;


### PR DESCRIPTION
It seems gauche to offer tab completion for `flux mini` when that command is deprecated, so this PR removes it from the bash tab completion config distributed with flux.

I found some other minor missing things and added those here as well.