### PR TITLE
flux-mini: improve deprecation warning

### DIFF
--- a/src/cmd/flux-mini.py
+++ b/src/cmd/flux-mini.py
@@ -32,7 +32,12 @@ def main():
         sys.stderr.fileno(), "w", encoding="utf8", errors="surrogateescape"
     )
     if sys.stderr.isatty():
-        LOGGER.warning("⚠️ flux-mini is deprecated, use flux-batch, flux-run, etc.⚠️")
+        cmd = sys.argv[1] if len(sys.argv) > 1 else None
+        if cmd in ["submit", "run", "batch", "alloc", "bulksubmit"]:
+            suggestion = f"flux {sys.argv[1]} "
+        else:
+            suggestion = "flux submit, flux run, etc."
+        LOGGER.warning(f"⚠️ flux-mini is deprecated, use {suggestion}⚠️")
 
     parser = argparse.ArgumentParser(prog="flux-mini")
     subparsers = parser.add_subparsers(


### PR DESCRIPTION
Problem: The warning that flux-mini is deprecated is not as clear as it could be.

Atttempt to instruct users the exact command they are looking for when possible, e.g. `flux mini run` warns:

 flux-mini: WARNING: ⚠️ flux-mini is deprecated, use flux run ⚠️

Otherwise, replace 'flux-run`, 'flux-submit' with "flux run" and "flux submit" so that users do not try to use literally "flux-run".

Fixes #4988