### PR TITLE
python: improve Hostlist class indexing

### DIFF
--- a/src/bindings/python/flux/hostlist.py
+++ b/src/bindings/python/flux/hostlist.py
@@ -107,8 +107,11 @@ class Hostlist(WrapperPimpl):
     def __getitem__(self, index):
         """Index and slice a hostlist
 
-        Works like normal Python list indexing, including slices
-        (a slice returns a new Hostlist object):
+        Works like normal Python list indexing, including slices.
+        Any iterable is also supported as long as the iterable contains
+        only integers.
+
+        Slices and iterables return a new Hostlist object.
 
         >>> hl = Hostlist("foo[0-9]")
         >>> hl[0]
@@ -121,6 +124,8 @@ class Hostlist(WrapperPimpl):
         Hostlist('foo[8-9]']
         >>> hl[1:3]
         Hostlist('foo[1-2]']
+        >>> hl[1,3]
+        Hostlist('foo[1,3]']
 
         """
         if isinstance(index, numbers.Integral):
@@ -134,6 +139,15 @@ class Hostlist(WrapperPimpl):
         if isinstance(index, slice):
             hl = Hostlist()
             for n in range(len(self))[index]:
+                hl.append(self[n])
+            return hl
+
+        if isinstance(index, collections.abc.Iterable):
+            hl = Hostlist()
+            for n in index:
+                # Avoid infinite recursion by catching non-integer indeces
+                if not isinstance(n, numbers.Integral):
+                    raise TypeError(f"Invalid Hostlist index '{n}'")
                 hl.append(self[n])
             return hl
 

--- a/src/bindings/python/flux/hostlist.py
+++ b/src/bindings/python/flux/hostlist.py
@@ -107,7 +107,8 @@ class Hostlist(WrapperPimpl):
     def __getitem__(self, index):
         """Index and slice a hostlist
 
-        Works like normal Python list indexing, including slices:
+        Works like normal Python list indexing, including slices
+        (a slice returns a new Hostlist object):
 
         >>> hl = Hostlist("foo[0-9]")
         >>> hl[0]
@@ -117,9 +118,9 @@ class Hostlist(WrapperPimpl):
         >>> hl[-1]
         'foo9'
         >>> hl[8:]
-        ['foo8', 'foo9']
+        Hostlist('foo[8-9]']
         >>> hl[1:3]
-        ['foo1', 'foo2']
+        Hostlist('foo[1-2]']
 
         """
         if isinstance(index, numbers.Integral):
@@ -131,7 +132,10 @@ class Hostlist(WrapperPimpl):
             raise IndexError("Hostlist index out of range")
 
         if isinstance(index, slice):
-            return [self[n] for n in range(len(self))[index]]
+            hl = Hostlist()
+            for n in range(len(self))[index]:
+                hl.append(self[n])
+            return hl
 
         raise TypeError("Hostlist index must be integer or slice")
 
@@ -194,7 +198,7 @@ class Hostlist(WrapperPimpl):
 
     def expand(self):
         """Convert a Hostlist to a Python list"""
-        return self[:]
+        return list(self)
 
     def copy(self):
         """Copy a Hostlist object"""

--- a/src/cmd/flux-resource.py
+++ b/src/cmd/flux-resource.py
@@ -17,7 +17,6 @@ import sys
 
 import flux
 from flux.future import WaitAllFuture
-from flux.hostlist import Hostlist
 from flux.idset import IDset
 from flux.resource import ResourceSet, SchedResourceList, resource_list
 from flux.rpc import RPC
@@ -280,7 +279,7 @@ class ResourceStatus:
         #  update instead of appending a new output line:
         #  (mainly useful for "drain" when reasons are not displayed)
         #
-        hosts = Hostlist([self.nodelist[i] for i in ranks])
+        hosts = self.nodelist[ranks]
         rstatus = self.find(state, reason)
         if rstatus:
             rstatus.update(ranks, hosts)

--- a/t/python/t0020-hostlist.py
+++ b/t/python/t0020-hostlist.py
@@ -13,6 +13,7 @@ import unittest
 import subflux
 from pycotap import TAPTestRunner
 import flux.hostlist as hostlist
+from flux.idset import IDset
 
 
 class TestHostlistMethods(unittest.TestCase):
@@ -92,11 +93,19 @@ class TestHostlistMethods(unittest.TestCase):
         self.assertEqual(hl[-1], "foo9")
         self.assertEqual(hl[-2], "foo8")
         self.assertListEqual(list(hl[1:3]), ["foo1", "foo2"])
+        hl2 = hl[1,2,3]
+        self.assertIsInstance(hl2, hostlist.Hostlist)
+        self.assertListEqual(list(hl2), ["foo1", "foo2", "foo3"])
+        ids = IDset("0-1")
+        hl2 = hl[ids]
+        self.assertIsInstance(hl2, hostlist.Hostlist)
+        self.assertListEqual(list(hl2), ["foo0", "foo1"])
 
     def test_index_exceptions(self):
         hl = hostlist.decode("foo[0-9]")
         self.assertRaises(TypeError, lambda x: x["a"], hl)
         self.assertRaises(IndexError, lambda x: x[10], hl)
+        self.assertRaises(TypeError, lambda x: x["abc"], hl)
 
     def test_contains(self):
         hl = hostlist.decode("foo[0-9]")

--- a/t/python/t0020-hostlist.py
+++ b/t/python/t0020-hostlist.py
@@ -91,7 +91,7 @@ class TestHostlistMethods(unittest.TestCase):
         self.assertEqual(hl[9], "foo9")
         self.assertEqual(hl[-1], "foo9")
         self.assertEqual(hl[-2], "foo8")
-        self.assertListEqual(hl[1:3], ["foo1", "foo2"])
+        self.assertListEqual(list(hl[1:3]), ["foo1", "foo2"])
 
     def test_index_exceptions(self):
         hl = hostlist.decode("foo[0-9]")


### PR DESCRIPTION
This simple PR improves the indexing of `Hostlist` objects by

 * returning a new `Hostlist` when more than one host is indexed, e.g. by slice (before, a `list` of hosts was returned)
 * allowing any iterable to be used with a Hostlist index, most notably a tuple, e.g. `hl[1,3,5]` and an idset `hl[ids]`.
