### PR TITLE
testsuite: require jq(1)

### DIFF
--- a/src/test/docker/docker-run-checks.sh
+++ b/src/test/docker/docker-run-checks.sh
@@ -220,7 +220,6 @@ else
 	-e PROJECT \
         -e CI \
         -e TAP_DRIVER_QUIET \
-        -e TEST_CHECK_PREREQS \
         -e FLUX_TEST_TIMEOUT \
         -e FLUX_TEST_SIZE_MAX \
         -e PYTHON_VERSION \

--- a/src/test/docker/docker-run-systest.sh
+++ b/src/test/docker/docker-run-systest.sh
@@ -142,7 +142,6 @@ checks_group "Executing tests under system instance container" \
     -e PROJECT \
     -e CI \
     -e TAP_DRIVER_QUIET \
-    -e TEST_CHECK_PREREQS \
     -e FLUX_TEST_TIMEOUT \
     -e FLUX_TEST_SIZE_MAX \
     -e FLUX_ENABLE_SYSTEM_TESTS=t \

--- a/src/test/generate-matrix.py
+++ b/src/test/generate-matrix.py
@@ -165,7 +165,6 @@ matrix.add_build(
         CXX="clang++-6.0",
         PYTHON_VERSION="3.7",
         chain_lint="t",
-        TEST_CHECK_PREREQS="t",
     ),
     args="--with-flux-security",
     command_args="--workdir=/usr/src/" + "workdir/" * 15,

--- a/t/issues/t3415-job-shell-segfault-on-null.sh
+++ b/t/issues/t3415-job-shell-segfault-on-null.sh
@@ -2,7 +2,6 @@
 # submit a job with json-null and ensure it doesn't cause the shell
 #  to segfault
 
-# test-prereqs: HAVE_JQ
 flux job attach -vEX $(flux run --dry-run hostname \
     | jq .attributes.system.shell.options.foo=null \
     | flux job submit)

--- a/t/issues/t4182-resource-rerank.sh
+++ b/t/issues/t4182-resource-rerank.sh
@@ -2,7 +2,6 @@
 #
 #  Ensure resource module resets ranks of R to match hostlist attribute
 #
-# test-prereqs: HAVE_JQ
 
 cat <<EOF >t4182-test.sh
 #!/bin/bash -e

--- a/t/issues/t4331-job-manager-purged-events.sh
+++ b/t/issues/t4331-job-manager-purged-events.sh
@@ -1,7 +1,5 @@
 #!/bin/bash -e
 
-# test-prereqs: HAVE_JQ
-
 EVENTS_JOURNAL_STREAM=${FLUX_BUILD_DIR}/t/job-manager/events_journal_stream
 
 # wait for jobid in events file to avoid race

--- a/t/issues/t4711-job-list-purge-inactive.sh
+++ b/t/issues/t4711-job-list-purge-inactive.sh
@@ -1,7 +1,5 @@
 #!/bin/bash -e
 
-# test-prereqs: HAVE_JQ
-
 prejob=$(flux job stats | jq .job_states.run)
 
 jobid=$(flux submit --wait-event=start sleep 100 | flux job id)

--- a/t/issues/t4852-t_submit-legacy.sh
+++ b/t/issues/t4852-t_submit-legacy.sh
@@ -1,7 +1,5 @@
 #!/bin/bash -e
 
-# test-prereqs: HAVE_JQ
-
 # ensure t_submit/t_depend is available from job-list in older
 # versions of flux that did not have the validate event.  To test, we
 # remove the validate in an existing job's eventlog.

--- a/t/job-manager/sched-helper.sh
+++ b/t/job-manager/sched-helper.sh
@@ -63,7 +63,6 @@ _jmgr_get_annotation() {
 # arg2 - key in annotation
 # arg3 - value of key in annotation
 #
-# callers should set HAVE_JQ requirement
 jmgr_check_annotation() {
         local id=$1
         local key=$2
@@ -85,7 +84,6 @@ jmgr_check_annotation() {
 # arg2 - key in memo
 # arg3 - value of key
 #
-# callers should set HAVE_JQ requirement
 jmgr_check_memo() {
 	jmgr_check_annotation $1 "user.$2" $3
 	return $?
@@ -96,7 +94,6 @@ jmgr_check_memo() {
 # arg1 - jobid
 # arg2 - key in annotation
 #
-# callers should set HAVE_JQ requirement
 jmgr_check_annotation_exists() {
         local id=$(flux job id $1)
         local key=$2
@@ -141,7 +138,6 @@ _jlist_get_annotation() {
 # arg2 - key in annotation
 # arg3 - value of key in annotation
 #
-# callers should set HAVE_JQ requirement
 jlist_check_annotation() {
         local id=$1
         local key=$2
@@ -162,7 +158,6 @@ jlist_check_memo() {
 #
 # arg1 - jobid
 #
-# callers should set HAVE_JQ requirement
 jlist_check_no_annotations() {
         local id=$(flux job id $1)
         flux job list -A | grep ${id} | jq -e .annotations > /dev/null && return 1
@@ -174,7 +169,6 @@ jlist_check_no_annotations() {
 # arg1 - jobid
 # arg2 - key in annotation
 #
-# callers should set HAVE_JQ requirement
 jlist_check_annotation_exists() {
         local id=$(flux job id $1)
         local key=$2

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -270,7 +270,7 @@ test_expect_success 'flux-start embedded server works from initial program' "
 	flux start -v ${ARGS} -s1 flux python ${startctl} status \
 		>startctl.out 2>startctl.err
 "
-test_expect_success HAVE_JQ 'flux-start embedded server status got JSON' "
+test_expect_success 'flux-start embedded server status got JSON' "
 	jq -c . <startctl.out
 "
 test_expect_success 'flux-start embedded server logs hi/bye from client' "

--- a/t/t0002-request.t
+++ b/t/t0002-request.t
@@ -105,14 +105,14 @@ test_expect_success 'request: rpc test client works with no request payload' '
 	$RPC attr.list </dev/null >attr.list.out &&
 		test -s attr.list.out
 '
-test_expect_success HAVE_JQ 'request: rpc test client works with request payload' '
+test_expect_success 'request: rpc test client works with request payload' '
 	$jq -j -c -n  "{name:\"rank\"}" | $RPC attr.get >attr.get.out &&
 		test -s attr.get.out
 '
 test_expect_success 'request: rpc test client handles expected failure' '
 	$RPC attr.get 71 </dev/null
 '
-test_expect_success HAVE_JQ 'request: rpc test client handles expected failure other than EPROTO' '
+test_expect_success 'request: rpc test client handles expected failure other than EPROTO' '
 	$jq -j -c -n  "{name:\"noexist\"}" | $RPC attr.get 2
 '
 test_expect_success 'request: rpc test client handles unexpected failure' '

--- a/t/t0011-content-cache.t
+++ b/t/t0011-content-cache.t
@@ -23,21 +23,21 @@ unregister_backing() {
 	jq -j -c -n  "{name:\"$1\"}" | $RPC content.unregister-backing
 }
 
-test_expect_success HAVE_JQ 'register-backing name=foo works' '
+test_expect_success 'register-backing name=foo works' '
 	register_backing foo
 '
-test_expect_success HAVE_JQ 'register-backing name=bar fails' '
+test_expect_success 'register-backing name=bar fails' '
 	test_must_fail register_backing bar 2>bar.err &&
 	grep "already active" bar.err
 '
-test_expect_success HAVE_JQ 'unregister-backing name=foo works' '
+test_expect_success 'unregister-backing name=foo works' '
 	unregister_backing foo
 '
-test_expect_success HAVE_JQ 'register-backing name=bar fails' '
+test_expect_success 'register-backing name=bar fails' '
 	test_must_fail register_backing bar 2>foo.err &&
 	grep "cannot be changed" foo.err
 '
-test_expect_success HAVE_JQ 'unregister-backing name=foo fails' '
+test_expect_success 'unregister-backing name=foo fails' '
 	test_must_fail unregister_backing foo 2>foo2.err &&
 	grep "is not active" foo2.err
 '

--- a/t/t0012-content-sqlite.t
+++ b/t/t0012-content-sqlite.t
@@ -123,22 +123,22 @@ test_expect_success 'fill the cache with more data for later purging' '
 	${SPAMUTIL} 10000 200 >/dev/null
 '
 
-test_expect_success HAVE_JQ 'checkpoint-put foo w/ rootref bar' '
+test_expect_success 'checkpoint-put foo w/ rootref bar' '
 	checkpoint_put foo bar
 '
 
-test_expect_success HAVE_JQ 'checkpoint-get foo returned rootref bar' '
+test_expect_success 'checkpoint-get foo returned rootref bar' '
 	echo bar >rootref.exp &&
 	checkpoint_get foo | jq -r .value | jq -r .rootref >rootref.out &&
 	test_cmp rootref.exp rootref.out
 '
 
-test_expect_success HAVE_JQ 'checkpoint-put on rank 1 forwards to rank 0' '
+test_expect_success 'checkpoint-put on rank 1 forwards to rank 0' '
        o=$(checkpoint_put_msg rankone rankref) &&
        jq -j -c -n ${o} | flux exec -r 1 ${RPC} content.checkpoint-put
 '
 
-test_expect_success HAVE_JQ 'checkpoint-get on rank 1 forwards to rank 0' '
+test_expect_success 'checkpoint-get on rank 1 forwards to rank 0' '
        echo rankref >rankref.exp &&
        o=$(checkpoint_get_msg rankone) &&
        jq -j -c -n ${o} \
@@ -148,16 +148,16 @@ test_expect_success HAVE_JQ 'checkpoint-get on rank 1 forwards to rank 0' '
 '
 
 # use grep instead of compare, incase of floating point rounding
-test_expect_success HAVE_JQ 'checkpoint-get foo returned correct timestamp' '
+test_expect_success 'checkpoint-get foo returned correct timestamp' '
         checkpoint_get foo | jq -r .value | jq -r .timestamp >timestamp.out &&
         grep 2.2 timestamp.out
 '
 
-test_expect_success HAVE_JQ 'checkpoint-put updates foo rootref to baz' '
+test_expect_success 'checkpoint-put updates foo rootref to baz' '
 	checkpoint_put foo baz
 '
 
-test_expect_success HAVE_JQ 'checkpoint-get foo returned rootref baz' '
+test_expect_success 'checkpoint-get foo returned rootref baz' '
 	echo baz >rootref2.exp &&
 	checkpoint_get foo | jq -r .value | jq -r .rootref >rootref2.out &&
 	test_cmp rootref2.exp rootref2.out
@@ -168,13 +168,13 @@ test_expect_success 'flush + reload content-sqlite module on rank 0' '
 	flux module reload content-sqlite
 '
 
-test_expect_success HAVE_JQ 'checkpoint-get foo still returns rootref baz' '
+test_expect_success 'checkpoint-get foo still returns rootref baz' '
 	echo baz >rootref3.exp &&
 	checkpoint_get foo | jq -r .value | jq -r .rootref >rootref3.out &&
 	test_cmp rootref3.exp rootref3.out
 '
 
-test_expect_success HAVE_JQ 'checkpoint-backing-get foo returns rootref baz' '
+test_expect_success 'checkpoint-backing-get foo returns rootref baz' '
 	echo baz >rootref_backing.exp &&
 	checkpoint_backing_get foo \
             | jq -r .value \
@@ -182,17 +182,17 @@ test_expect_success HAVE_JQ 'checkpoint-backing-get foo returns rootref baz' '
 	test_cmp rootref_backing.exp rootref_backing.out
 '
 
-test_expect_success HAVE_JQ 'checkpoint-backing-put foo w/ rootref boof' '
+test_expect_success 'checkpoint-backing-put foo w/ rootref boof' '
 	checkpoint_backing_put foo boof
 '
 
-test_expect_success HAVE_JQ 'checkpoint-get foo returned rootref boof' '
+test_expect_success 'checkpoint-get foo returned rootref boof' '
 	echo boof >rootref4.exp &&
 	checkpoint_get foo | jq -r .value | jq -r .rootref >rootref4.out &&
 	test_cmp rootref4.exp rootref4.out
 '
 
-test_expect_success HAVE_JQ 'checkpoint-get noexist fails with No such...' '
+test_expect_success 'checkpoint-get noexist fails with No such...' '
 	test_must_fail checkpoint_get noexist 2>badkey.err &&
 	grep "No such file or directory" badkey.err
 '
@@ -206,7 +206,7 @@ getsize() {
 	flux module stats content | tee /dev/fd/2 | jq .size
 }
 
-test_expect_success HAVE_JQ 'wait for purge to clear cache entries' '
+test_expect_success 'wait for purge to clear cache entries' '
 	purge_size=$(flux getattr content.purge-target-size) &&
 	purge_age=$(flux getattr content.purge-old-entry) &&
 	echo "Purge size $purge_size bytes, age $purge_age secs" &&
@@ -224,11 +224,11 @@ test_expect_success 'remove content-sqlite module on rank 0' '
 	flux module remove content-sqlite
 '
 
-test_expect_success HAVE_JQ 'checkpoint-put foo w/ rootref spoon' '
+test_expect_success 'checkpoint-put foo w/ rootref spoon' '
 	checkpoint_put foo spoon
 '
 
-test_expect_success HAVE_JQ 'checkpoint-get foo returned rootref spoon' '
+test_expect_success 'checkpoint-get foo returned rootref spoon' '
 	echo spoon >rootref5.exp &&
 	checkpoint_get foo | jq -r .value | jq -r .rootref >rootref5.out &&
 	test_cmp rootref5.exp rootref5.out
@@ -258,7 +258,7 @@ wait_checkpoint_flush() {
 	return 1
 }
 
-test_expect_success HAVE_JQ 'checkpoint-backing-get foo returns spoon' '
+test_expect_success 'checkpoint-backing-get foo returns spoon' '
 	wait_checkpoint_flush spoon
 '
 

--- a/t/t0017-security.t
+++ b/t/t0017-security.t
@@ -254,13 +254,13 @@ test_expect_success 'dispatcher suppresses guest event to same guest connection'
 	! grep -q test.a ev8.out
 '
 
-test_expect_success HAVE_JQ 'guests may add userid-prefixed services' '
+test_expect_success 'guests may add userid-prefixed services' '
 	USERID=$(id -u) &&
 	${jq} -n "{service: \"${USERID}-sectest\"}" >user_service.json &&
 	FLUX_HANDLE_ROLEMASK=0x2 ${RPC} service.add <user_service.json
 '
 
-test_expect_success HAVE_JQ 'guests may not add other-userid-prefixed services' '
+test_expect_success 'guests may not add other-userid-prefixed services' '
 	USERID=$(($(id -u)+1)) &&
 	${jq} -n "{service: \"${USERID}-sectest\"}" >user2_service.json &&
 	(export FLUX_HANDLE_ROLEMASK=0x2 &&
@@ -270,7 +270,7 @@ test_expect_success HAVE_JQ 'guests may not add other-userid-prefixed services' 
 	grep "Operation not permitted" uservice_add.err
 '
 
-test_expect_success HAVE_JQ 'guests may not add non-userid-prefixed services' '
+test_expect_success 'guests may not add non-userid-prefixed services' '
 	${jq} -n "{service: \"sectest\"}" >service.json &&
 	(export FLUX_HANDLE_ROLEMASK=0x2 &&
 		test_expect_code 1 ${RPC} service.add \

--- a/t/t0018-content-files.t
+++ b/t/t0018-content-files.t
@@ -158,27 +158,27 @@ test_expect_success 'flux module stats reports zero object count' '
 	    --type int --parse object_count content-files) -eq 0
 '
 
-test_expect_success HAVE_JQ 'checkpoint-put foo w/ rootref bar' '
+test_expect_success 'checkpoint-put foo w/ rootref bar' '
 	checkpoint_put foo bar
 '
 
-test_expect_success HAVE_JQ 'checkpoint-get foo returned rootref bar' '
+test_expect_success 'checkpoint-get foo returned rootref bar' '
         echo bar >rootref.exp &&
         checkpoint_get foo | jq -r .value | jq -r .rootref >rootref.out &&
         test_cmp rootref.exp rootref.out
 '
 
 # use grep instead of compare, incase of floating point rounding
-test_expect_success HAVE_JQ 'checkpoint-get foo returned correct timestamp' '
+test_expect_success 'checkpoint-get foo returned correct timestamp' '
         checkpoint_get foo | jq -r .value | jq -r .timestamp >timestamp.out &&
         grep 2.2 timestamp.out
 '
 
-test_expect_success HAVE_JQ 'checkpoint-put updates foo rootref to baz' '
+test_expect_success 'checkpoint-put updates foo rootref to baz' '
         checkpoint_put foo baz
 '
 
-test_expect_success HAVE_JQ 'checkpoint-get foo returned rootref baz' '
+test_expect_success 'checkpoint-get foo returned rootref baz' '
         echo baz >rootref2.exp &&
         checkpoint_get foo | jq -r .value | jq -r .rootref >rootref2.out &&
         test_cmp rootref2.exp rootref2.out
@@ -188,37 +188,37 @@ test_expect_success 'reload content-files module' '
 	flux module reload content-files
 '
 
-test_expect_success HAVE_JQ 'checkpoint-get foo still returns rootref baz' '
+test_expect_success 'checkpoint-get foo still returns rootref baz' '
         echo baz >rootref3.exp &&
         checkpoint_get foo | jq -r .value | jq -r .rootref >rootref3.out &&
         test_cmp rootref3.exp rootref3.out
 '
 
-test_expect_success HAVE_JQ 'checkpoint-put updates foo rootref with longer rootref' '
+test_expect_success 'checkpoint-put updates foo rootref with longer rootref' '
         checkpoint_put foo abcdefghijklmnopqrstuvwxyz
 '
 
-test_expect_success HAVE_JQ 'checkpoint-get foo returned rootref with longer rootref' '
+test_expect_success 'checkpoint-get foo returned rootref with longer rootref' '
         echo abcdefghijklmnopqrstuvwxyz >rootref4.exp &&
         checkpoint_get foo | jq -r .value | jq -r .rootref >rootref4.out &&
         test_cmp rootref4.exp rootref4.out
 '
 
-test_expect_success HAVE_JQ 'checkpoint-put updates foo rootref to shorter rootref' '
+test_expect_success 'checkpoint-put updates foo rootref to shorter rootref' '
         checkpoint_put foo foobar
 '
 
-test_expect_success HAVE_JQ 'checkpoint-get foo returned rootref with shorter rootref' '
+test_expect_success 'checkpoint-get foo returned rootref with shorter rootref' '
         echo foobar >rootref5.exp &&
         checkpoint_get foo | jq -r .value | jq -r .rootref >rootref5.out &&
         test_cmp rootref5.exp rootref5.out
 '
 
-test_expect_success HAVE_JQ 'checkpoint-put updates foo rootref to boof' '
+test_expect_success 'checkpoint-put updates foo rootref to boof' '
         checkpoint_put foo boof
 '
 
-test_expect_success HAVE_JQ 'checkpoint-backing-get foo returns rootref boof' '
+test_expect_success 'checkpoint-backing-get foo returns rootref boof' '
         echo boof >rootref_backing.exp &&
         checkpoint_backing_get foo \
             | jq -r .value \
@@ -226,11 +226,11 @@ test_expect_success HAVE_JQ 'checkpoint-backing-get foo returns rootref boof' '
         test_cmp rootref_backing.exp rootref_backing.out
 '
 
-test_expect_success HAVE_JQ 'checkpoint-backing-put foo w/ rootref poof' '
+test_expect_success 'checkpoint-backing-put foo w/ rootref poof' '
         checkpoint_backing_put foo poof
 '
 
-test_expect_success HAVE_JQ 'checkpoint-get foo returned rootref boof' '
+test_expect_success 'checkpoint-get foo returned rootref boof' '
         echo poof >rootref6.exp &&
         checkpoint_get foo | jq -r .value | jq -r .rootref >rootref6.out &&
         test_cmp rootref6.exp rootref6.out
@@ -249,11 +249,11 @@ test_expect_success 'remove content-files module' '
 	flux module remove content-files
 '
 
-test_expect_success HAVE_JQ 'checkpoint-put foo w/ rootref spoon' '
+test_expect_success 'checkpoint-put foo w/ rootref spoon' '
        checkpoint_put foo spoon
 '
 
-test_expect_success HAVE_JQ 'checkpoint-get foo returned rootref spoon' '
+test_expect_success 'checkpoint-get foo returned rootref spoon' '
        echo spoon >rootref7.exp &&
        checkpoint_get foo | jq -r .value | jq -r .rootref >rootref7.out &&
        test_cmp rootref7.exp rootref7.out
@@ -283,7 +283,7 @@ wait_checkpoint_flush() {
         return 1
 }
 
-test_expect_success HAVE_JQ 'checkpoint-backing-get foo returns spoon' '
+test_expect_success 'checkpoint-backing-get foo returns spoon' '
        wait_checkpoint_flush spoon
 '
 

--- a/t/t0022-jj-reader.t
+++ b/t/t0022-jj-reader.t
@@ -7,7 +7,7 @@ test_description='Test json-jobspec *cough* parser *cough*'
 jj=${FLUX_BUILD_DIR}/t/sched-simple/jj-reader
 y2j="flux python ${SHARNESS_TEST_SRCDIR}/jobspec/y2j.py"
 
-test_expect_success HAVE_JQ 'jj-reader: unexpected version throws error' '
+test_expect_success 'jj-reader: unexpected version throws error' '
 	flux run --dry-run hostname \
 		| jq ".version = 2" >input.$test_count &&
 	test_expect_code 1 $jj<input.$test_count >out.$test_count 2>&1 &&
@@ -16,7 +16,7 @@ test_expect_success HAVE_JQ 'jj-reader: unexpected version throws error' '
 	EOF
 	test_cmp expected.$test_count out.$test_count
 '
-test_expect_success HAVE_JQ 'jj-reader: no version throws error' '
+test_expect_success 'jj-reader: no version throws error' '
 	flux run --dry-run hostname \
 		| jq "del(.version)" >input.$test_count &&
 	test_expect_code 1 $jj<input.$test_count >out.$test_count 2>&1 &&
@@ -25,7 +25,7 @@ test_expect_success HAVE_JQ 'jj-reader: no version throws error' '
 	EOF
 	test_cmp expected.$test_count out.$test_count
 '
-test_expect_success HAVE_JQ 'jj-reader: bad count throws error' '
+test_expect_success 'jj-reader: bad count throws error' '
 	flux run --dry-run hostname | \
 		jq ".resources[0].with[0].count = -1" >input.$test_count &&
 	test_expect_code 1 $jj<input.$test_count >out.$test_count 2>&1 &&
@@ -34,7 +34,7 @@ test_expect_success HAVE_JQ 'jj-reader: bad count throws error' '
 	EOF
 	test_cmp expected.$test_count out.$test_count
 '
-test_expect_success HAVE_JQ 'jj-reader: bad type throws error' '
+test_expect_success 'jj-reader: bad type throws error' '
 	flux run --dry-run hostname | \
 		jq --arg f beans ".resources[0].type = \$f" >input.$test_count &&
 	test_expect_code 1 $jj<input.$test_count >out.$test_count 2>&1 &&
@@ -43,7 +43,7 @@ test_expect_success HAVE_JQ 'jj-reader: bad type throws error' '
 	EOF
 	test_cmp expected.$test_count out.$test_count
 '
-test_expect_success HAVE_JQ 'jj-reader: missing count throws error' '
+test_expect_success 'jj-reader: missing count throws error' '
 	flux run --dry-run hostname | \
 		jq "del(.resources[0].with[0].count)" >input.$test_count &&
 	test_expect_code 1 $jj<input.$test_count >out.$test_count 2>&1 &&
@@ -52,7 +52,7 @@ test_expect_success HAVE_JQ 'jj-reader: missing count throws error' '
 	EOF
 	test_cmp expected.$test_count out.$test_count
 '
-test_expect_success HAVE_JQ 'jj-reader: wrong count type throws error' '
+test_expect_success 'jj-reader: wrong count type throws error' '
 	flux run --dry-run hostname | \
 		jq ".resources[0].with[0].count = 1.5" >input.$test_count &&
 	test_expect_code 1 $jj<input.$test_count >out.$test_count 2>&1 &&

--- a/t/t0024-content-s3.t
+++ b/t/t0024-content-s3.t
@@ -117,27 +117,27 @@ test_expect_success LONGTEST 'store/load/verify various size large blobs' '
 '
 
 
-test_expect_success HAVE_JQ 'checkpoint-put foo w/ rootref bar' '
+test_expect_success 'checkpoint-put foo w/ rootref bar' '
 	checkpoint_put foo bar
 '
 
-test_expect_success HAVE_JQ 'checkpoint-get foo returned rootref bar' '
+test_expect_success 'checkpoint-get foo returned rootref bar' '
         echo bar >rootref.exp &&
         checkpoint_get foo | jq -r .value | jq -r .rootref >rootref.out &&
         test_cmp rootref.exp rootref.out
 '
 
 # use grep instead of compare, incase of floating point rounding
-test_expect_success HAVE_JQ 'checkpoint-get foo returned correct timestamp' '
+test_expect_success 'checkpoint-get foo returned correct timestamp' '
         checkpoint_get foo | jq -r .value | jq -r .timestamp >timestamp.out &&
         grep 2.2 timestamp.out
 '
 
-test_expect_success HAVE_JQ 'checkpoint-put updates foo rootref to baz' '
+test_expect_success 'checkpoint-put updates foo rootref to baz' '
         checkpoint_put foo baz
 '
 
-test_expect_success HAVE_JQ 'checkpoint-get foo returned rootref baz' '
+test_expect_success 'checkpoint-get foo returned rootref baz' '
         echo baz >rootref2.exp &&
         checkpoint_get foo | jq -r .value | jq -r .rootref >rootref2.out &&
         test_cmp rootref2.exp rootref2.out
@@ -163,13 +163,13 @@ test_expect_success LONGTEST 'reload/verify various size large blobs' '
 	test $err -eq 0
 '
 
-test_expect_success HAVE_JQ 'checkpoint-get foo still returns rootref baz' '
+test_expect_success 'checkpoint-get foo still returns rootref baz' '
         echo baz >rootref3.exp &&
         checkpoint_get foo | jq -r .value | jq -r .rootref >rootref3.out &&
         test_cmp rootref3.exp rootref3.out
 '
 
-test_expect_success HAVE_JQ 'checkpoint-backing-get foo returns rootref baz' '
+test_expect_success 'checkpoint-backing-get foo returns rootref baz' '
 	echo baz >rootref_backing.exp &&
 	checkpoint_backing_get foo \
 	    | jq -r .value \
@@ -177,11 +177,11 @@ test_expect_success HAVE_JQ 'checkpoint-backing-get foo returns rootref baz' '
 	test_cmp rootref_backing.exp rootref_backing.out
 '
 
-test_expect_success HAVE_JQ 'checkpoint-backing-put foo w/ rootref boof' '
+test_expect_success 'checkpoint-backing-put foo w/ rootref boof' '
 	checkpoint_backing_put foo boof
 '
 
-test_expect_success HAVE_JQ 'checkpoint-get foo returned rootref boof' '
+test_expect_success 'checkpoint-get foo returned rootref boof' '
 	echo boof >rootref4.exp &&
 	checkpoint_get foo | jq -r .value | jq -r .rootref >rootref4.out &&
 	test_cmp rootref4.exp rootref4.out
@@ -222,11 +222,11 @@ test_expect_success 'config: unload module' '
 	flux module remove content-s3
 '
 
-test_expect_success HAVE_JQ 'checkpoint-put foo w/ rootref spoon' '
+test_expect_success 'checkpoint-put foo w/ rootref spoon' '
 	checkpoint_put foo spoon
 '
 
-test_expect_success HAVE_JQ 'checkpoint-get foo returned rootref spoon' '
+test_expect_success 'checkpoint-get foo returned rootref spoon' '
 	echo spoon >rootref5.exp &&
 	checkpoint_get foo | jq -r .value | jq -r .rootref >rootref5.out &&
 	test_cmp rootref5.exp rootref5.out
@@ -259,7 +259,7 @@ wait_checkpoint_flush() {
 	return 1
 }
 
-test_expect_success HAVE_JQ 'checkpoint-backing-get foo returns spoon' '
+test_expect_success 'checkpoint-backing-get foo returns spoon' '
 	wait_checkpoint_flush spoon
 '
 

--- a/t/t0025-broker-state-machine.t
+++ b/t/t0025-broker-state-machine.t
@@ -12,25 +12,25 @@ SRPC=${FLUX_BUILD_DIR}/t/request/rpc_stream
 ARGS="-o,-Sbroker.rc1_path=,-Sbroker.rc3_path="
 GROUPSCMD="flux python ${SHARNESS_TEST_SRCDIR}/scripts/groups.py"
 
-test_expect_success HAVE_JQ 'quorum reached on instance with 1 TBON level' '
+test_expect_success 'quorum reached on instance with 1 TBON level' '
 	echo "0-2" >full1.exp &&
 	flux start -s3 ${ARGS} ${GROUPSCMD} get broker.online >full1.out &&
 	test_cmp full1.exp full1.out
 '
 
-test_expect_success HAVE_JQ 'quorum reached on instance with 2 TBON levels' '
+test_expect_success 'quorum reached on instance with 2 TBON levels' '
 	echo "0-3" >full2.exp &&
 	flux start -s4 ${ARGS} ${GROUPSCMD} get broker.online >full2.out &&
 	test_cmp full2.exp full2.out
 '
 
-test_expect_success HAVE_JQ 'quorum reached on instance with 3 TBON levels' '
+test_expect_success 'quorum reached on instance with 3 TBON levels' '
 	echo "0-7" >full3.exp &&
 	flux start -s8 ${ARGS} ${GROUPSCMD} get broker.online >full3.out &&
 	test_cmp full3.exp full3.out
 '
 
-test_expect_success HAVE_JQ 'broker.quorum can be set on the command line' '
+test_expect_success 'broker.quorum can be set on the command line' '
 	flux start -s3 ${ARGS} -o,-Sbroker.quorum="0-2" \
 		${GROUPSCMD} get broker.online >full1_explicit.out &&
 	test_cmp full1.exp full1_explicit.out
@@ -57,7 +57,7 @@ test_expect_success 'create rc1 that blocks on FIFO for rank != 0' '
 	chmod +x rc1_block
 '
 
-test_expect_success HAVE_JQ 'create rc2 that unblocks FIFO' '
+test_expect_success 'create rc2 that unblocks FIFO' '
 	cat <<-EOT >rc2_unblock &&
 	#!/bin/bash
 	${GROUPSCMD} get broker.online
@@ -68,7 +68,7 @@ test_expect_success HAVE_JQ 'create rc2 that unblocks FIFO' '
 
 # Delay rank 1 so that we can check that initial program ran with only
 # rank 0 in RUN state.
-test_expect_success HAVE_JQ 'instance functions with late-joiner' '
+test_expect_success 'instance functions with late-joiner' '
 	echo "0" >late.exp &&
 	rm -f fifo &&
 	mkfifo fifo &&
@@ -89,7 +89,7 @@ test_expect_success 'quorum-get RPC fails on rank > 0' '
 	grep "only available on rank 0" qm1.err
 '
 
-test_expect_success HAVE_JQ 'monitor streaming RPC works' '
+test_expect_success 'monitor streaming RPC works' '
 	flux start ${ARGS} \
 		$SRPC state-machine.monitor state \
 		</dev/null >state.out &&
@@ -104,7 +104,7 @@ test_expect_success 'create rc script that prints current state' '
 	chmod +x rc_getstate
 '
 
-test_expect_success HAVE_JQ 'monitor reports INIT(2) in rc1' '
+test_expect_success 'monitor reports INIT(2) in rc1' '
 	echo 2 >rc1.exp &&
 	flux start \
 		-o,-Sbroker.rc1_path=$(pwd)/rc_getstate \
@@ -113,7 +113,7 @@ test_expect_success HAVE_JQ 'monitor reports INIT(2) in rc1' '
 	test_cmp rc1.exp rc.out
 '
 
-test_expect_success HAVE_JQ 'monitor reports RUN(4) in rc2' '
+test_expect_success 'monitor reports RUN(4) in rc2' '
 	echo 4 >rc2.exp &&
 	flux start \
 		-o,-Sbroker.rc1_path= \
@@ -122,7 +122,7 @@ test_expect_success HAVE_JQ 'monitor reports RUN(4) in rc2' '
 	test_cmp rc2.exp rc.out
 '
 
-test_expect_success HAVE_JQ 'monitor reports CLEANUP(5) in cleanup script' '
+test_expect_success 'monitor reports CLEANUP(5) in cleanup script' '
 	echo 5 >cleanup.exp &&
 	flux start \
 		-o,-Sbroker.rc1_path= \
@@ -131,7 +131,7 @@ test_expect_success HAVE_JQ 'monitor reports CLEANUP(5) in cleanup script' '
 	test_cmp cleanup.exp rc.out
 '
 
-test_expect_success HAVE_JQ 'monitor reports FINALIZE(7) in rc3' '
+test_expect_success 'monitor reports FINALIZE(7) in rc3' '
 	echo 7 >rc3.exp &&
 	flux start \
 		-o,-Sbroker.rc1_path= \

--- a/t/t0026-flux-R.t
+++ b/t/t0026-flux-R.t
@@ -180,29 +180,29 @@ test_expect_success 'flux R set-property works' '
 test_expect_success 'flux R set-property fails with unknown ranks' '
 	flux R encode -r 0-1 | test_must_fail flux R set-property foo:1-2
 '
-test_expect_success HAVE_JQ 'scheduling opaque key is preserved' '
+test_expect_success 'scheduling opaque key is preserved' '
 	flux R encode -r 0-3 -c 0-3 -g 0 -H foo[0-3] \
 	    | jq ".scheduling = 42" > R.orig &&
 	flux R decode < R.orig | jq -e ".scheduling == 42" &&
 	flux R decode --include 0 < R.orig | jq -e ".scheduling == 42" &&
 	flux R decode --exclude 0 < R.orig | jq -e ".scheduling == 42"
 '
-test_expect_success HAVE_JQ 'scheduling opaque key is preserved with append' '
+test_expect_success 'scheduling opaque key is preserved with append' '
 	(cat R.orig && flux R encode -r 4 ) | flux R append \
 	    | flux R decode | jq -e ".scheduling == 42"
 '
-test_expect_success HAVE_JQ 'scheduling opaque key is preserved with remap' '
+test_expect_success 'scheduling opaque key is preserved with remap' '
 	flux R remap < R.orig | flux R decode | jq -e ".scheduling == 42"
 '
-test_expect_success HAVE_JQ 'scheduling opaque key is preserved with diff' '
+test_expect_success 'scheduling opaque key is preserved with diff' '
 	(cat R.orig && flux R encode -r 1 ) | flux R diff \
 	    | jq -e ".scheduling == 42"
 '
-test_expect_success HAVE_JQ 'scheduling key is preserved with intersect' '
+test_expect_success 'scheduling key is preserved with intersect' '
 	(cat R.orig && flux R encode -r 1 -H foo1) | flux R intersect \
 	    | jq -e ".scheduling == 42"
 '
-test_expect_success HAVE_JQ 'use of --local,--xml and --hosts is supported' '
+test_expect_success 'use of --local,--xml and --hosts is supported' '
 	ncores=$(flux R encode --local | flux R decode --count cores) &&
 	flux R encode --local --hosts=fluke[0-16] > R.hosts &&
 	test_debug "flux R decode --short < R.hosts" &&

--- a/t/t0028-content-backing-none.t
+++ b/t/t0028-content-backing-none.t
@@ -11,26 +11,26 @@ echo "# $0: flux session size will be ${SIZE}"
 
 RPC=${FLUX_BUILD_DIR}/t/request/rpc
 
-test_expect_success HAVE_JQ 'checkpoint-get fails, no checkpoints yet' '
+test_expect_success 'checkpoint-get fails, no checkpoints yet' '
         checkpoint_put foo bar
 '
 
-test_expect_success HAVE_JQ 'checkpoint-put foo w/ rootref bar' '
+test_expect_success 'checkpoint-put foo w/ rootref bar' '
         checkpoint_put foo bar
 '
 
-test_expect_success HAVE_JQ 'checkpoint-get foo returned rootref bar' '
+test_expect_success 'checkpoint-get foo returned rootref bar' '
         echo bar >rootref.exp &&
         checkpoint_get foo | jq -r .value | jq -r .rootref >rootref.out &&
         test_cmp rootref.exp rootref.out
 '
 
-test_expect_success HAVE_JQ 'checkpoint-put on rank 1 forwards to rank 0' '
+test_expect_success 'checkpoint-put on rank 1 forwards to rank 0' '
         o=$(checkpoint_put_msg rankone rankref) &&
         jq -j -c -n ${o} | flux exec -r 1 ${RPC} content.checkpoint-put
 '
 
-test_expect_success HAVE_JQ 'checkpoint-get on rank 1 forwards to rank 0' '
+test_expect_success 'checkpoint-get on rank 1 forwards to rank 0' '
         echo rankref >rankref.exp &&
         o=$(checkpoint_get_msg rankone) &&
         jq -j -c -n ${o} \

--- a/t/t0029-filemap-cmd.t
+++ b/t/t0029-filemap-cmd.t
@@ -115,7 +115,7 @@ test_expect_success 'map test file and get its blobref' '
 	flux filemap map ./testfile2 &&
 	flux filemap list --blobref >testfile2.blobref
 '
-test_expect_success HAVE_JQ 'show raw object' '
+test_expect_success 'show raw object' '
 	flux filemap list --raw | jq .
 '
 test_expect_success 'test file can be read through content cache on rank 1' '
@@ -183,7 +183,7 @@ test_expect_success 'create test symlink' '
 test_expect_success 'map test file' '
 	flux filemap map ./testfile4
 '
-test_expect_success HAVE_JQ 'show raw object' '
+test_expect_success 'show raw object' '
 	flux filemap list --raw | jq .
 '
 test_expect_success 'test file can be read through content cache' '
@@ -256,7 +256,7 @@ test_expect_success 'map test file without mmap' '
 	rm -f copydir/testfile &&
 	flux filemap map --disable-mmap ./testfile
 '
-test_expect_success HAVE_JQ 'test file did not use blobvec encoding' '
+test_expect_success 'test file did not use blobvec encoding' '
 	flux filemap list --raw | jq -e ".encoding != \"blobvec\""
 '
 test_expect_success 'unmap test file' '
@@ -265,7 +265,7 @@ test_expect_success 'unmap test file' '
 test_expect_success 'map small test file with reduced small file threshold' '
 	flux filemap map --small-file-threshold=0 ./testfile2
 '
-test_expect_success HAVE_JQ 'test file used blobvec encoding' '
+test_expect_success 'test file used blobvec encoding' '
 	flux filemap list --raw | jq -e ".encoding = \"blobvec\""
 '
 test_expect_success 'unmap test file' '

--- a/t/t1004-kvs-namespace.t
+++ b/t/t1004-kvs-namespace.t
@@ -344,19 +344,19 @@ test_expect_success 'kvs: put - namespace specified in command line overrides en
 # Namespace rootref initialization
 #
 
-test_expect_success HAVE_JQ 'kvs: namespace rootref setup' '
+test_expect_success 'kvs: namespace rootref setup' '
 	flux kvs namespace create $NAMESPACEROOTREF-1 &&
         flux kvs put --namespace=$NAMESPACEROOTREF-1 $DIR.rootreftest=foobar &&
         test_kvs_key_namespace $NAMESPACEROOTREF-1 $DIR.rootreftest foobar &&
         flux kvs getroot --blobref --namespace=$NAMESPACEROOTREF-1 > rootref1
 '
 
-test_expect_success HAVE_JQ 'kvs: namespace create with init rootref' '
+test_expect_success 'kvs: namespace create with init rootref' '
 	flux kvs namespace create --rootref=$(cat rootref1) $NAMESPACEROOTREF-2 &&
         test_kvs_key_namespace $NAMESPACEROOTREF-1 $DIR.rootreftest foobar
 '
 
-test_expect_success HAVE_JQ 'kvs: namespaces dont clobber each other' '
+test_expect_success 'kvs: namespaces dont clobber each other' '
         flux kvs put --namespace=$NAMESPACEROOTREF-1 $DIR.val=42 &&
         flux kvs put --namespace=$NAMESPACEROOTREF-2 $DIR.val=43 &&
         test_kvs_key_namespace $NAMESPACEROOTREF-1 $DIR.val 42 &&
@@ -364,12 +364,12 @@ test_expect_success HAVE_JQ 'kvs: namespaces dont clobber each other' '
 '
 
 BADROOTREF="sha1-0123456789abcdef0123456789abcdef01234567"
-test_expect_success HAVE_JQ 'kvs: namespace create can take bad blobref' '
+test_expect_success 'kvs: namespace create can take bad blobref' '
 	flux kvs namespace create --rootref=$BADROOTREF $NAMESPACEROOTREF-3 &&
         flux kvs get --namespace=$NAMESPACEROOTREF-3 --treeobj .
 '
 
-test_expect_success HAVE_JQ 'kvs: namespace with bad rootref fails otherwise' '
+test_expect_success 'kvs: namespace with bad rootref fails otherwise' '
         test_must_fail flux kvs ls --namespace=$NAMESPACEROOTREF-3 .
 '
 

--- a/t/t1010-kvs-commit-sync.t
+++ b/t/t1010-kvs-commit-sync.t
@@ -9,8 +9,6 @@ test_description='Test flux-kvs commit sync.'
 
 RPC=${FLUX_BUILD_DIR}/t/request/rpc
 
-skip_all_unless_have jq
-
 SIZE=1
 test_under_flux ${SIZE} minimal
 

--- a/t/t1011-kvs-checkpoint-period.t
+++ b/t/t1011-kvs-checkpoint-period.t
@@ -9,8 +9,6 @@ test_description='Test kvs module checkpoint-period config.'
 
 RPC=${FLUX_BUILD_DIR}/t/request/rpc
 
-skip_all_unless_have jq
-
 export FLUX_CONF_DIR=$(pwd)
 SIZE=4
 test_under_flux ${SIZE} minimal

--- a/t/t1107-heartbeat.t
+++ b/t/t1107-heartbeat.t
@@ -17,7 +17,7 @@ test_expect_success 'load heartbeat' '
 	flux module load heartbeat
 '
 
-test_expect_success HAVE_JQ 'reload heartbeat with period=10s and verify' '
+test_expect_success 'reload heartbeat with period=10s and verify' '
 	period1=$(get_heartbeat | jq -r -e .period) &&
 	flux module reload heartbeat period=10s &&
 	period2=$(get_heartbeat | jq -r -e .period) &&

--- a/t/t2100-job-ingest.t
+++ b/t/t2100-job-ingest.t
@@ -58,17 +58,17 @@ test_expect_success 'job-ingest: load job-ingest: require-version=any' '
 		validator-args=--require-version=any
 '
 
-test_expect_success HAVE_JQ 'job-ingest: dummy job-manager has expected max_jobid' '
+test_expect_success 'job-ingest: dummy job-manager has expected max_jobid' '
 	max_jobid=$(${RPC} job-manager.getinfo | jq .max_jobid) &&
 	test ${max_jobid} -eq ${DUMMY_MAX_JOBID}
 '
 
-test_expect_success HAVE_JQ 'job-ingest: max_jobid <= rank 0 FLUID timestamp' '
+test_expect_success 'job-ingest: max_jobid <= rank 0 FLUID timestamp' '
 	ts0=$(${RPC} job-ingest.getinfo | jq .timestamp) &&
 	test ${DUMMY_FLUID_TS} -le ${ts0}
 '
 
-test_expect_success HAVE_JQ 'job-ingest: rank 0 FLUID timestamp <= rank 1' '
+test_expect_success 'job-ingest: rank 0 FLUID timestamp <= rank 1' '
 	ts1=$(flux exec -r1 ${RPC} job-ingest.getinfo | jq .timestamp) &&
 	test ${ts0} -le ${ts1}
 '
@@ -82,7 +82,7 @@ test_expect_success 'job-ingest: fetch jobspec from KVS' '
 	kvsdir=$(flux job id --to=kvs $jobid) &&
 	flux kvs get --raw ${kvsdir}.jobspec >jobspec.out
 '
-test_expect_success HAVE_JQ 'job-ingest: jobspec stored accurately in KVS' '
+test_expect_success 'job-ingest: jobspec stored accurately in KVS' '
 	jq --sort-keys . <basic.json >basic.json.normalized &&
 	jq --sort-keys . <jobspec.out >jobspec.out.normalized &&
 	test_cmp basic.json.normalized jobspec.out.normalized
@@ -95,7 +95,7 @@ test_expect_success 'job-ingest: submit a job with environment' '
 	kvsdir=$(flux job id --to=kvs $jobid) &&
 	flux kvs get --raw ${kvsdir}.jobspec >jobspec_env.out
 '
-test_expect_success HAVE_JQ 'job-ingest: KVS jobspec lacks environment' '
+test_expect_success 'job-ingest: KVS jobspec lacks environment' '
 	jq -e ".attributes.system.environment.FOO == \"bar\"" \
 	    <jobspec_env.json &&
 	test_must_fail jq -e ".attributes.system.environment.FOO == \"bar\"" \

--- a/t/t2110-job-ingest-validator.t
+++ b/t/t2110-job-ingest-validator.t
@@ -71,7 +71,7 @@ test_expect_success 'flux job-validator --require-version rejects invalid arg' '
 		test_expect_code 1 \
 		flux job-validator --jobspec-only --require-version=0
 '
-test_expect_success HAVE_JQ 'flux job-validator rejects non-V1 jobspec' '
+test_expect_success 'flux job-validator rejects non-V1 jobspec' '
 	flux run --dry-run hostname | jq -c ".version = 2" | \
 		test_expect_code 1 \
 		flux job-validator --jobspec-only --require-version=1
@@ -83,7 +83,7 @@ test_expect_success 'flux job-validator --schema rejects invalid arg' '
 			--plugins=schema \
 			--schema=noexist
 '
-test_expect_success HAVE_JQ 'flux job-validator --feasibility-service works ' '
+test_expect_success 'flux job-validator --feasibility-service works ' '
 	flux run -n 4888 --dry-run hostname | \
 		flux job-validator --jobspec-only --plugins=feasibility \
 		| jq -e ".errnum != 0" &&

--- a/t/t2112-job-ingest-frobnicator.t
+++ b/t/t2112-job-ingest-frobnicator.t
@@ -60,12 +60,12 @@ test_expect_success 'job-frobnicator: all valid jobspecs accepted' '
 	    $Y2J <$f | flux job-frobnicator --jobspec-only --plugins=defaults
 	done
 '
-test_expect_success HAVE_JQ 'job-frobnicator: defaults plugin does things' '
+test_expect_success 'job-frobnicator: defaults plugin does things' '
 	flux run --env=-* --dry-run hostname \
 		| flux job-frobnicator --jobspec-only --plugins=defaults \
 		| jq  -e ".data.attributes.system.duration == 1800"
 '
-test_expect_success HAVE_JQ 'job-frobnicator: defaults plugin does not do things' '
+test_expect_success 'job-frobnicator: defaults plugin does not do things' '
 	flux run --env=-* --dry-run -t 1h hostname \
 		| flux job-frobnicator --jobspec-only --plugins=defaults \
 		| jq  -e ".data.attributes.system.duration == 3600"
@@ -81,14 +81,14 @@ test_expect_success 'configure queues with default durations' '
 	EOF
 	flux config reload
 '
-test_expect_success HAVE_JQ 'job-frobnicator sets default queue duration' '
+test_expect_success 'job-frobnicator sets default queue duration' '
 	flux run --env=-* --dry-run hostname \
 		| flux job-frobnicator --jobspec-only --plugins=defaults \
 		> queue-debug.out &&
 	jq -e ".data.attributes.system.queue == \"debug\"" < queue-debug.out &&
 	jq -e ".data.attributes.system.duration == 3600"   < queue-debug.out
 '
-test_expect_success HAVE_JQ 'job-frobnicator sets specified queue duration' '
+test_expect_success 'job-frobnicator sets specified queue duration' '
 	flux run --env=-* --queue=batch --dry-run hostname \
 		| flux job-frobnicator --jobspec-only --plugins=defaults \
 		> queue-batch.out &&
@@ -102,14 +102,14 @@ test_expect_success 'configure queue constraints' '
 	EOF
 	flux config reload
 '
-test_expect_success HAVE_JQ 'constraints plugin sets queue constraint' '
+test_expect_success 'constraints plugin sets queue constraint' '
 	flux run --env=-* --dry-run --queue=debug hostname \
 	   | flux job-frobnicator --jobspec-only --plugins=constraints \
 	   > constraint-setqueue.out &&
 	jq -e ".data.attributes.system.constraints.properties \
 	    == [ \"debug\" ]" < constraint-setqueue.out
 '
-test_expect_success HAVE_JQ 'constraints plugin adds queue constraint' '
+test_expect_success 'constraints plugin adds queue constraint' '
 	flux run --env=-* --dry-run --requires=foo \
 	  --queue=debug hostname \
 	   | flux job-frobnicator --jobspec-only --plugins=constraints \
@@ -119,7 +119,7 @@ test_expect_success HAVE_JQ 'constraints plugin adds queue constraint' '
 	jq -e ".data.attributes.system.constraints.properties|any(.==\"foo\")"\
 	   < constraint-addqueue.out
 '
-test_expect_success HAVE_JQ 'constraints plugin works with no configured queues' '
+test_expect_success 'constraints plugin works with no configured queues' '
 	cp /dev/null conf.d/conf.toml &&
 	flux config reload &&
 	flux run --env=-* --dry-run hostname \
@@ -127,7 +127,7 @@ test_expect_success HAVE_JQ 'constraints plugin works with no configured queues'
 	> constraint-noqueue.out &&
 	jq -e "has(\"data\")" <constraint-noqueue.out
 '
-test_expect_success HAVE_JQ 'constraints plugin works without requires' '
+test_expect_success 'constraints plugin works without requires' '
 	cat >conf.d/conf.toml <<-EOT &&
 	[queues.debug]
 	EOT
@@ -138,7 +138,7 @@ test_expect_success HAVE_JQ 'constraints plugin works without requires' '
 	> constraint-norequires.out &&
 	jq -e "has(\"data\")" <constraint-norequires.out
 '
-test_expect_success HAVE_JQ 'frobnicator defaults are defaults,constraints' '
+test_expect_success 'frobnicator defaults are defaults,constraints' '
 	cat <<-EOF >conf.d/conf.toml &&
 	[policy]
 	jobspec.defaults.system.queue = "debug"
@@ -155,7 +155,7 @@ test_expect_success HAVE_JQ 'frobnicator defaults are defaults,constraints' '
 	    == [ \"debug\" ]" \
 	    <defaultplugins.out
 '
-test_expect_success HAVE_JQ 'defaults plugin allows queues without default' '
+test_expect_success 'defaults plugin allows queues without default' '
 	cat <<-EOF >conf.d/conf.toml &&
 	[queues.debug]
 	requires = [ "debug" ]
@@ -166,7 +166,7 @@ test_expect_success HAVE_JQ 'defaults plugin allows queues without default' '
 	    > nodefault.out &&
 	jq -e "has(\"data\")" <nodefault.out
 '
-test_expect_success HAVE_JQ 'defaults plugin requires queue if configured' '
+test_expect_success 'defaults plugin requires queue if configured' '
 	cat <<-EOF >conf.d/conf.toml &&
 	[queues.debug]
 	requires = [ "debug" ]

--- a/t/t2113-job-ingest-pipeline.t
+++ b/t/t2113-job-ingest-pipeline.t
@@ -7,7 +7,7 @@ test_under_flux 1 full
 
 flux setattr log-stderr-level 1
 
-test_expect_success HAVE_JQ 'no workers are running at the start' '
+test_expect_success 'no workers are running at the start' '
 	flux module stats job-ingest >stats.out &&
 	jq -e ".pipeline.frobnicator.running == 0" <stats.out &&
 	jq -e ".pipeline.validator.running == 0" <stats.out
@@ -15,7 +15,7 @@ test_expect_success HAVE_JQ 'no workers are running at the start' '
 test_expect_success 'run a job with no ingest configuration' '
 	flux run /bin/true
 '
-test_expect_success HAVE_JQ 'one validator, no frobnicator started' '
+test_expect_success 'one validator, no frobnicator started' '
 	flux module stats job-ingest >stats2.out &&
 	jq -e ".pipeline.frobnicator.running == 0" <stats2.out &&
 	jq -e ".pipeline.validator.running == 1" <stats2.out
@@ -31,16 +31,16 @@ test_expect_success 'configure frobnicator' '
 test_expect_success 'run a job with unspecified duration' '
 	flux submit /bin/true >jobid1
 '
-test_expect_success HAVE_JQ 'one validator, one frobnicator started' '
+test_expect_success 'one validator, one frobnicator started' '
 	flux module stats job-ingest >stats3.out &&
 	jq -e ".pipeline.frobnicator.running == 1" <stats3.out &&
 	jq -e ".pipeline.validator.running == 1" <stats3.out
 '
-test_expect_success HAVE_JQ 'job duration was assigned from default' '
+test_expect_success 'job duration was assigned from default' '
 	flux job info $(cat jobid1) jobspec >jobspec1 &&
 	jq -e ".attributes.system.duration == 10" <jobspec1
 '
-test_expect_success HAVE_JQ 'force module config update' '
+test_expect_success 'force module config update' '
 	flux module stats job-ingest >stats4.out &&
 	jq -r ".pipeline.frobnicator.pids[0]" <stats4.out >frob.pid &&
 	jq -r ".pipeline.validator.pids[0]" <stats4.out >val.pid &&
@@ -49,19 +49,19 @@ test_expect_success HAVE_JQ 'force module config update' '
 test_expect_success 'run a job to trigger work crew with new config' '
 	flux submit /bin/true
 '
-test_expect_success HAVE_JQ 'workers were restarted' '
+test_expect_success 'workers were restarted' '
 	flux module stats job-ingest >stats5.out &&
 	jq -r ".pipeline.frobnicator.pids[0]" <stats5.out >frob2.pid &&
 	jq -r ".pipeline.validator.pids[0]" <stats5.out >val2.pid &&
 	test_must_fail test_cmp frob.pid frob2.pid &&
 	test_must_fail test_cmp val.pid val2.pid
 '
-test_expect_success HAVE_JQ 'run a job with novalidate flag' '
+test_expect_success 'run a job with novalidate flag' '
 	jq -r ".pipeline.frobnicator.requests" <stats5.out >frob.count &&
 	jq -r ".pipeline.validator.requests" <stats5.out >val.count &&
 	flux run --flags novalidate /bin/true
 '
-test_expect_success HAVE_JQ 'job was frobbed but not validated' '
+test_expect_success 'job was frobbed but not validated' '
 	flux module stats job-ingest >stats6.out &&
 	jq -r ".pipeline.frobnicator.requests" <stats6.out >frob2.count &&
 	jq -r ".pipeline.validator.requests" <stats6.out >val2.count &&
@@ -71,20 +71,20 @@ test_expect_success HAVE_JQ 'job was frobbed but not validated' '
 test_expect_success 'reconfig with null config' '
 	flux config load </dev/null
 '
-test_expect_success HAVE_JQ 'run a job with novalidate flag' '
+test_expect_success 'run a job with novalidate flag' '
 	flux run --flags novalidate /bin/true
 '
-test_expect_success HAVE_JQ 'job was neither frobbed nor validated' '
+test_expect_success 'job was neither frobbed nor validated' '
 	flux module stats job-ingest >stats7.out &&
 	jq -r ".pipeline.frobnicator.requests" <stats7.out >frob3.count &&
 	jq -r ".pipeline.validator.requests" <stats7.out >val3.count &&
 	test_cmp frob2.count frob3.count &&
 	test_cmp val2.count val3.count
 '
-test_expect_success HAVE_JQ 'run a job' '
+test_expect_success 'run a job' '
 	flux run /bin/true
 '
-test_expect_success HAVE_JQ 'job was validated but not frobbed' '
+test_expect_success 'job was validated but not frobbed' '
 	flux module stats job-ingest >stats8.out &&
 	jq -r ".pipeline.frobnicator.requests" <stats8.out >frob4.count &&
 	jq -r ".pipeline.validator.requests" <stats8.out >val4.count &&

--- a/t/t2202-job-manager.t
+++ b/t/t2202-job-manager.t
@@ -26,7 +26,7 @@ test_expect_success 'job-manager: load job-ingest, job-info, job-manager' '
 	flux module load job-info
 '
 
-test_expect_success HAVE_JQ 'job-manager: max_jobid=0 before jobs run' '
+test_expect_success 'job-manager: max_jobid=0 before jobs run' '
 	test $(${RPC} job-manager.getinfo | jq .max_jobid) -eq 0
 '
 
@@ -34,7 +34,7 @@ test_expect_success 'job-manager: submit one job' '
 	flux job submit basic.json | flux job id >submit1.out
 '
 
-test_expect_success HAVE_JQ 'job-manager: max_jobid=last' '
+test_expect_success 'job-manager: max_jobid=last' '
 	${RPC} job-manager.getinfo | jq .max_jobid >max1.out &&
 	test_cmp submit1.out max1.out
 '
@@ -44,30 +44,30 @@ test_expect_success 'job-manager: queue contains 1 job' '
 	test $(wc -l <list1.out) -eq 1
 '
 
-test_expect_success HAVE_JQ 'job-manager: queue lists job with correct jobid' '
+test_expect_success 'job-manager: queue lists job with correct jobid' '
 	$jq .id <list1.out >list1_jobid.out &&
 	test_cmp submit1.out list1_jobid.out
 '
 
-test_expect_success HAVE_JQ 'job-manager: queue lists job with state=N' '
+test_expect_success 'job-manager: queue lists job with state=N' '
 	echo "SCHED" >list1_state.exp &&
 	$jq .state <list1.out | ${JOB_CONV} statetostr >list1_state.out &&
 	test_cmp list1_state.exp list1_state.out
 '
 
-test_expect_success HAVE_JQ 'job-manager: queue lists job with correct userid' '
+test_expect_success 'job-manager: queue lists job with correct userid' '
 	id -u >list1_userid.exp &&
 	$jq .userid <list1.out >list1_userid.out &&
 	test_cmp list1_userid.exp list1_userid.out
 '
 
-test_expect_success HAVE_JQ 'job-manager: queue list job with correct urgency' '
+test_expect_success 'job-manager: queue list job with correct urgency' '
 	echo 16 >list1_urgency.exp &&
 	$jq .urgency <list1.out >list1_urgency.out &&
 	test_cmp list1_urgency.exp list1_urgency.out
 '
 
-test_expect_success HAVE_JQ 'job-manager: queue list job with correct priority' '
+test_expect_success 'job-manager: queue list job with correct priority' '
 	echo 16 >list1_priority.exp &&
 	$jq .priority <list1.out >list1_priority.out &&
 	test_cmp list1_priority.exp list1_priority.out
@@ -116,7 +116,7 @@ test_expect_success 'job-manager: queue contains 3 jobs' '
 	test $(wc -l <list3.out) -eq 3
 '
 
-test_expect_success HAVE_JQ 'job-manager: queue is sorted in priority order' '
+test_expect_success 'job-manager: queue is sorted in priority order' '
 	cat >list3_priority.exp <<-EOT &&
 	4294967295
 	16
@@ -126,7 +126,7 @@ test_expect_success HAVE_JQ 'job-manager: queue is sorted in priority order' '
 	test_cmp list3_priority.exp list3_priority.out
 '
 
-test_expect_success HAVE_JQ 'job-manager: list-jobs --count shows highest priority jobs' '
+test_expect_success 'job-manager: list-jobs --count shows highest priority jobs' '
 	cat >list3_lim2.exp <<-EOT &&
 	4294967295
 	16
@@ -135,13 +135,13 @@ test_expect_success HAVE_JQ 'job-manager: list-jobs --count shows highest priori
 	test_cmp list3_lim2.exp list3_lim2.out
 '
 
-test_expect_success HAVE_JQ 'job-manager: priority listed as priority=4294967295 in KVS' '
+test_expect_success 'job-manager: priority listed as priority=4294967295 in KVS' '
 	jobid=$(head -n 1 list3.out | $jq .id) &&
 	flux job wait-event --timeout=5.0 ${jobid} priority &&
 	flux job eventlog $jobid | grep priority=4294967295
 '
 
-test_expect_success HAVE_JQ 'job-manager: cancel jobs' '
+test_expect_success 'job-manager: cancel jobs' '
 	flux cancel $($jq .id <list3.out)
 '
 
@@ -156,7 +156,7 @@ test_expect_success 'job-manager: submit 10 jobs of equal urgency' '
 	done
 '
 
-test_expect_success HAVE_JQ 'job-manager: jobs are listed in submit order' '
+test_expect_success 'job-manager: jobs are listed in submit order' '
 	${LIST_JOBS} >list10.out &&
 	$jq .id <list10.out >list10_ids.out &&
 	test_cmp submit10.out list10_ids.out
@@ -181,20 +181,20 @@ test_expect_success 'job-manager: priority was updated in KVS' '
 	flux job eventlog $jobid | grep ^priority | tail -n 1 | priority=4294967295
 '
 
-test_expect_success HAVE_JQ 'job-manager: that job is now the first job' '
+test_expect_success 'job-manager: that job is now the first job' '
 	${LIST_JOBS} >list10_reordered.out &&
 	firstid=$($jq .id <list10_reordered.out | head -1) &&
 	lastid=$(tail -1 <list10_ids.out) &&
 	test "${lastid}" -eq "${firstid}"
 '
 
-test_expect_success HAVE_JQ 'job-manager: jobs in state S w/ no scheduler' '
+test_expect_success 'job-manager: jobs in state S w/ no scheduler' '
 	for id in $(cat submit10.out); do \
 		jmgr_check_state ${id} S; \
 	done
 '
 
-test_expect_success HAVE_JQ 'job-manager: save max_jobid' '
+test_expect_success 'job-manager: save max_jobid' '
 	${RPC} job-manager.getinfo | jq .max_jobid >max2.exp
 '
 
@@ -218,16 +218,16 @@ check_eventlog_restart_events() {
 	return 0
 }
 
-test_expect_success HAVE_JQ 'job-manager: eventlog indicates restart & priority event' '
+test_expect_success 'job-manager: eventlog indicates restart & priority event' '
 	check_eventlog_restart_events
 '
 
-test_expect_success HAVE_JQ 'job-manager: max_jobid has not changed' '
+test_expect_success 'job-manager: max_jobid has not changed' '
 	${RPC} job-manager.getinfo | jq .max_jobid >max2.out &&
 	test_cmp max2.exp max2.out
 '
 
-test_expect_success HAVE_JQ 'job-manager: cancel jobs' '
+test_expect_success 'job-manager: cancel jobs' '
 	flux cancel $($jq .id <list_reload.out) &&
 	test $(${LIST_JOBS} | wc -l) -eq 0
 '
@@ -240,7 +240,7 @@ test_expect_success 'job-manager: flux job urgency fails on invalid urgency' '
 	flux cancel ${jobid}
 '
 
-test_expect_success HAVE_JQ 'job-manager: flux job urgency special args work' '
+test_expect_success 'job-manager: flux job urgency special args work' '
 	jobid=$(flux job submit basic.json | flux job id) &&
 	flux job urgency ${jobid} hold &&
 	${LIST_JOBS} > list_hold.out &&
@@ -348,7 +348,7 @@ test_expect_success 'job-manager: there is still one job in the queue' '
 	test $(wc -l <list.out) -eq 1
 '
 
-test_expect_success HAVE_JQ 'job-manager: drain unblocks when last job is canceled' '
+test_expect_success 'job-manager: drain unblocks when last job is canceled' '
 	jobid=$($jq .id <list.out) &&
 	run_timeout 5 ${DRAIN_CANCEL} ${jobid}
 '
@@ -372,7 +372,7 @@ test_expect_success 'submit request with empty payload fails with EPROTO(71)' '
 	${RPC} job-manager.submit 71 </dev/null
 '
 
-test_expect_success HAVE_JQ 'job-manager stats works' '
+test_expect_success 'job-manager stats works' '
 	flux module stats job-manager > stats.out &&
 	cat stats.out | $jq -e .journal.listeners
 '

--- a/t/t2203-job-manager-single.t
+++ b/t/t2203-job-manager-single.t
@@ -28,7 +28,7 @@ test_expect_success 'job-manager: submit 5 jobs' '
            hostname
 '
 
-test_expect_success HAVE_JQ 'job-manager: job state RRSSS' '
+test_expect_success 'job-manager: job state RRSSS' '
         jmgr_check_state $(cat job1.id) R &&
         jmgr_check_state $(cat job2.id) R &&
         jmgr_check_state $(cat job3.id) S &&
@@ -36,7 +36,7 @@ test_expect_success HAVE_JQ 'job-manager: job state RRSSS' '
         jmgr_check_state $(cat job5.id) S
 '
 
-test_expect_success HAVE_JQ 'job-manager: annotate jobs (RRSSS)' '
+test_expect_success 'job-manager: annotate jobs (RRSSS)' '
         jmgr_check_annotation $(cat job1.id) "sched.resource_summary" "\"rank0/core0\"" &&
         jmgr_check_annotation $(cat job2.id) "sched.resource_summary" "\"rank0/core1\"" &&
         jmgr_check_annotation $(cat job3.id) "sched.reason_pending" "\"insufficient resources\"" &&
@@ -44,7 +44,7 @@ test_expect_success HAVE_JQ 'job-manager: annotate jobs (RRSSS)' '
         jmgr_check_no_annotations $(cat job5.id)
 '
 
-test_expect_success HAVE_JQ 'job-manager: annotate jobs in job-list (RRSSS)' '
+test_expect_success 'job-manager: annotate jobs in job-list (RRSSS)' '
         jlist_check_annotation $(cat job1.id) "sched.resource_summary" "\"rank0/core0\"" &&
         jlist_check_annotation $(cat job2.id) "sched.resource_summary" "\"rank0/core1\"" &&
         jlist_check_annotation $(cat job3.id) "sched.reason_pending" "\"insufficient resources\"" &&
@@ -68,7 +68,7 @@ test_expect_success 'job-manager: cancel 2' '
         flux cancel $(cat job2.id)
 '
 
-test_expect_success HAVE_JQ 'job-manager: job state RIRSS' '
+test_expect_success 'job-manager: job state RIRSS' '
         jmgr_check_state $(cat job1.id) R &&
         jmgr_check_state $(cat job2.id) I &&
         jmgr_check_state $(cat job3.id) R &&
@@ -76,7 +76,7 @@ test_expect_success HAVE_JQ 'job-manager: job state RIRSS' '
         jmgr_check_state $(cat job5.id) S
 '
 
-test_expect_success HAVE_JQ 'job-manager: annotate jobs (RIRSS)' '
+test_expect_success 'job-manager: annotate jobs (RIRSS)' '
         jmgr_check_annotation $(cat job1.id) "sched.resource_summary" "\"rank0/core0\"" &&
         jmgr_check_no_annotations $(cat job2.id) &&
         jmgr_check_annotation $(cat job3.id) "sched.resource_summary" "\"rank0/core1\"" &&
@@ -86,7 +86,7 @@ test_expect_success HAVE_JQ 'job-manager: annotate jobs (RIRSS)' '
 
 # compared to above, note that job id #2 retains annotations, it is
 # cached in job-list
-test_expect_success HAVE_JQ 'job-manager: annotate jobs in job-list (RIRSS)' '
+test_expect_success 'job-manager: annotate jobs in job-list (RIRSS)' '
         jlist_check_annotation $(cat job1.id) "sched.resource_summary" "\"rank0/core0\"" &&
         jlist_check_annotation $(cat job2.id) "sched.resource_summary" "\"rank0/core1\"" &&
         jlist_check_annotation $(cat job3.id) "sched.resource_summary" "\"rank0/core1\"" &&
@@ -137,7 +137,7 @@ test_expect_success 'job-manager: hello handshake userid is expected' '
         grep userid=$(id -u) hello.dmesg
 '
 
-test_expect_success HAVE_JQ 'job-manager: job state RIRRR' '
+test_expect_success 'job-manager: job state RIRRR' '
         jmgr_check_state $(cat job1.id) R &&
         jmgr_check_state $(cat job2.id) I &&
         jmgr_check_state $(cat job3.id) R &&
@@ -145,7 +145,7 @@ test_expect_success HAVE_JQ 'job-manager: job state RIRRR' '
         jmgr_check_state $(cat job5.id) R
 '
 
-test_expect_success HAVE_JQ 'job-manager: annotate jobs (RIRRR)' '
+test_expect_success 'job-manager: annotate jobs (RIRRR)' '
         jmgr_check_annotation $(cat job1.id) "sched.resource_summary" "\"rank0/core0\"" &&
         jmgr_check_no_annotations $(cat job2.id) &&
         jmgr_check_annotation $(cat job3.id) "sched.resource_summary" "\"rank0/core1\"" &&
@@ -155,7 +155,7 @@ test_expect_success HAVE_JQ 'job-manager: annotate jobs (RIRRR)' '
 
 # compared to above, note that job id #2 retains annotations, it is
 # cached in job-list
-test_expect_success HAVE_JQ 'job-manager: annotate jobs in job-list (RIRRR)' '
+test_expect_success 'job-manager: annotate jobs in job-list (RIRRR)' '
         jlist_check_annotation $(cat job1.id) "sched.resource_summary" "\"rank0/core0\"" &&
         jlist_check_annotation $(cat job2.id) "sched.resource_summary" "\"rank0/core1\"" &&
         jlist_check_annotation $(cat job3.id) "sched.resource_summary" "\"rank0/core1\"" &&
@@ -177,7 +177,7 @@ test_expect_success 'job-manager: cancel 1' '
         flux cancel $(cat job1.id)
 '
 
-test_expect_success HAVE_JQ 'job-manager: job state IIRRR' '
+test_expect_success 'job-manager: job state IIRRR' '
         jmgr_check_state $(cat job1.id) I &&
         jmgr_check_state $(cat job2.id) I &&
         jmgr_check_state $(cat job3.id) R &&
@@ -191,7 +191,7 @@ test_expect_success 'job-manager: cancel all jobs' '
         flux cancel $(cat job5.id)
 '
 
-test_expect_success HAVE_JQ 'job-manager: job state IIIII' '
+test_expect_success 'job-manager: job state IIIII' '
         jmgr_check_state $(cat job1.id) I &&
         jmgr_check_state $(cat job2.id) I &&
         jmgr_check_state $(cat job3.id) I &&
@@ -199,7 +199,7 @@ test_expect_success HAVE_JQ 'job-manager: job state IIIII' '
         jmgr_check_state $(cat job5.id) I
 '
 
-test_expect_success HAVE_JQ 'job-manager: no annotations (IIIII)' '
+test_expect_success 'job-manager: no annotations (IIIII)' '
         jmgr_check_no_annotations $(cat job1.id) &&
         jmgr_check_no_annotations $(cat job2.id) &&
         jmgr_check_no_annotations $(cat job3.id) &&
@@ -208,7 +208,7 @@ test_expect_success HAVE_JQ 'job-manager: no annotations (IIIII)' '
 '
 
 # compared to above, annotations are cached
-test_expect_success HAVE_JQ 'job-manager: annotate jobs in job-list (IIIII)' '
+test_expect_success 'job-manager: annotate jobs in job-list (IIIII)' '
         jlist_check_annotation $(cat job1.id) "sched.resource_summary" "\"rank0/core0\"" &&
         jlist_check_annotation $(cat job2.id) "sched.resource_summary" "\"rank0/core1\"" &&
         jlist_check_annotation $(cat job3.id) "sched.resource_summary" "\"rank0/core1\"" &&

--- a/t/t2204-job-manager-limited.t
+++ b/t/t2204-job-manager-limited.t
@@ -17,7 +17,7 @@ test_expect_success 'job-manager: submit 5 jobs' '
            hostname
 '
 
-test_expect_success HAVE_JQ 'job-manager: job state RRSSS' '
+test_expect_success 'job-manager: job state RRSSS' '
         jmgr_check_state $(cat job1.id) R &&
         jmgr_check_state $(cat job2.id) R &&
         jmgr_check_state $(cat job3.id) S &&
@@ -25,7 +25,7 @@ test_expect_success HAVE_JQ 'job-manager: job state RRSSS' '
         jmgr_check_state $(cat job5.id) S
 '
 
-test_expect_success HAVE_JQ 'job-manager: annotate jobs (RRSSS)' '
+test_expect_success 'job-manager: annotate jobs (RRSSS)' '
         jmgr_check_annotation $(cat job1.id) "sched.resource_summary" "\"rank0/core0\"" &&
         jmgr_check_annotation $(cat job2.id) "sched.resource_summary" "\"rank0/core1\"" &&
         jmgr_check_annotation $(cat job3.id) "sched.reason_pending" "\"insufficient resources\"" &&
@@ -35,7 +35,7 @@ test_expect_success HAVE_JQ 'job-manager: annotate jobs (RRSSS)' '
         jmgr_check_no_annotations $(cat job5.id)
 '
 
-test_expect_success HAVE_JQ 'job-manager: annotate jobs job-list (RRSSS)' '
+test_expect_success 'job-manager: annotate jobs job-list (RRSSS)' '
         jlist_check_annotation $(cat job1.id) "sched.resource_summary" "\"rank0/core0\"" &&
         jlist_check_annotation $(cat job2.id) "sched.resource_summary" "\"rank0/core1\"" &&
         jlist_check_annotation $(cat job3.id) "sched.reason_pending" "\"insufficient resources\"" &&
@@ -45,7 +45,7 @@ test_expect_success HAVE_JQ 'job-manager: annotate jobs job-list (RRSSS)' '
         jlist_check_no_annotations $(cat job5.id)
 '
 
-test_expect_success HAVE_JQ 'job-manager: annotate jobs in flux-jobs (RRSSS)' '
+test_expect_success 'job-manager: annotate jobs in flux-jobs (RRSSS)' '
         fjobs_check_annotation $(cat job1.id) "annotations.sched.resource_summary" "rank0/core0" &&
         fjobs_check_annotation $(cat job2.id) "annotations.sched.resource_summary" "rank0/core1" &&
         fjobs_check_annotation $(cat job3.id) "annotations.sched.reason_pending" "insufficient resources" &&
@@ -59,7 +59,7 @@ test_expect_success 'job-manager: cancel 2' '
         flux cancel $(cat job2.id)
 '
 
-test_expect_success HAVE_JQ 'job-manager: job state RIRSS' '
+test_expect_success 'job-manager: job state RIRSS' '
         jmgr_check_state $(cat job1.id) R &&
         jmgr_check_state $(cat job2.id) I &&
         jmgr_check_state $(cat job3.id) R &&
@@ -67,7 +67,7 @@ test_expect_success HAVE_JQ 'job-manager: job state RIRSS' '
         jmgr_check_state $(cat job5.id) S
 '
 
-test_expect_success HAVE_JQ 'job-manager: annotate jobs (RIRSS)' '
+test_expect_success 'job-manager: annotate jobs (RIRSS)' '
         jmgr_check_annotation $(cat job1.id) "sched.resource_summary" "\"rank0/core0\"" &&
         jmgr_check_no_annotations $(cat job2.id) &&
         jmgr_check_annotation $(cat job3.id) "sched.resource_summary" "\"rank0/core1\"" &&
@@ -81,7 +81,7 @@ test_expect_success HAVE_JQ 'job-manager: annotate jobs (RIRSS)' '
 
 # compared to above, note that job id #2 retains annotations, it is
 # cached in job-list
-test_expect_success HAVE_JQ 'job-manager: annotate jobs in job-list (RIRSS)' '
+test_expect_success 'job-manager: annotate jobs in job-list (RIRSS)' '
         jlist_check_annotation $(cat job1.id) "sched.resource_summary" "\"rank0/core0\"" &&
         jlist_check_annotation $(cat job2.id) "sched.resource_summary" "\"rank0/core1\"" &&
         jlist_check_annotation $(cat job3.id) "sched.resource_summary" "\"rank0/core1\"" &&
@@ -95,7 +95,7 @@ test_expect_success HAVE_JQ 'job-manager: annotate jobs in job-list (RIRSS)' '
 
 # compared to above, note that job id #2 retains annotations, it is
 # cached in job-list
-test_expect_success HAVE_JQ 'job-manager: annotate jobs in flux-jobs (RIRSS)' '
+test_expect_success 'job-manager: annotate jobs in flux-jobs (RIRSS)' '
         fjobs_check_annotation $(cat job1.id) "annotations.sched.resource_summary" "rank0/core0" &&
         fjobs_check_annotation $(cat job2.id) "annotations.sched.resource_summary" "rank0/core1" &&
         fjobs_check_annotation $(cat job3.id) "annotations.sched.resource_summary" "rank0/core1" &&
@@ -114,7 +114,7 @@ test_expect_success 'job-manager: cancel all jobs' '
         flux cancel --all
 '
 
-test_expect_success HAVE_JQ 'job-manager: job state IIIII' '
+test_expect_success 'job-manager: job state IIIII' '
         jmgr_check_state $(cat job1.id) I &&
         jmgr_check_state $(cat job2.id) I &&
         jmgr_check_state $(cat job3.id) I &&
@@ -122,7 +122,7 @@ test_expect_success HAVE_JQ 'job-manager: job state IIIII' '
         jmgr_check_state $(cat job5.id) I
 '
 
-test_expect_success HAVE_JQ 'job-manager: no annotations (IIIII)' '
+test_expect_success 'job-manager: no annotations (IIIII)' '
         jmgr_check_no_annotations $(cat job1.id) &&
         jmgr_check_no_annotations $(cat job2.id) &&
         jmgr_check_no_annotations $(cat job3.id) &&
@@ -131,7 +131,7 @@ test_expect_success HAVE_JQ 'job-manager: no annotations (IIIII)' '
 '
 
 # compared to above, note that job ids that ran retain annotations
-test_expect_success HAVE_JQ 'job-manager: no annotations in canceled jobs in job-list (IIIII)' '
+test_expect_success 'job-manager: no annotations in canceled jobs in job-list (IIIII)' '
         jlist_check_annotation $(cat job1.id) "sched.resource_summary" "\"rank0/core0\"" &&
         jlist_check_annotation $(cat job2.id) "sched.resource_summary" "\"rank0/core1\"" &&
         jlist_check_annotation $(cat job3.id) "sched.resource_summary" "\"rank0/core1\"" &&
@@ -140,7 +140,7 @@ test_expect_success HAVE_JQ 'job-manager: no annotations in canceled jobs in job
 '
 
 # compared to above, note that job ids that ran retain annotations
-test_expect_success HAVE_JQ 'job-manager: no annotations in canceled jobs in flux jobs (IIIII)' '
+test_expect_success 'job-manager: no annotations in canceled jobs in flux jobs (IIIII)' '
         fjobs_check_annotation $(cat job1.id) "annotations.sched.resource_summary" "rank0/core0" &&
         fjobs_check_annotation $(cat job2.id) "annotations.sched.resource_summary" "rank0/core1" &&
         fjobs_check_annotation $(cat job3.id) "annotations.sched.resource_summary" "rank0/core1" &&

--- a/t/t2205-job-manager-unlimited.t
+++ b/t/t2205-job-manager-unlimited.t
@@ -17,7 +17,7 @@ test_expect_success 'job-manager: submit 5 jobs' '
            hostname
 '
 
-test_expect_success HAVE_JQ 'job-manager: job state RRSSS' '
+test_expect_success 'job-manager: job state RRSSS' '
         jmgr_check_state $(cat job1.id) R &&
         jmgr_check_state $(cat job2.id) R &&
         jmgr_check_state $(cat job3.id) S &&
@@ -25,7 +25,7 @@ test_expect_success HAVE_JQ 'job-manager: job state RRSSS' '
         jmgr_check_state $(cat job5.id) S
 '
 
-test_expect_success HAVE_JQ 'job-manager: annotate jobs (RRSSS)' '
+test_expect_success 'job-manager: annotate jobs (RRSSS)' '
         jmgr_check_annotation $(cat job1.id) "sched.resource_summary" "\"rank0/core0\"" &&
         jmgr_check_annotation $(cat job2.id) "sched.resource_summary" "\"rank0/core1\"" &&
         jmgr_check_annotation $(cat job3.id) "sched.reason_pending" "\"insufficient resources\"" &&
@@ -36,7 +36,7 @@ test_expect_success HAVE_JQ 'job-manager: annotate jobs (RRSSS)' '
         jmgr_check_annotation $(cat job5.id) "sched.jobs_ahead" "2"
 '
 
-test_expect_success HAVE_JQ 'job-manager: annotate jobs job-list (RRSSS)' '
+test_expect_success 'job-manager: annotate jobs job-list (RRSSS)' '
         jlist_check_annotation $(cat job1.id) "sched.resource_summary" "\"rank0/core0\"" &&
         jlist_check_annotation $(cat job2.id) "sched.resource_summary" "\"rank0/core1\"" &&
         jlist_check_annotation $(cat job3.id) "sched.reason_pending" "\"insufficient resources\"" &&
@@ -47,7 +47,7 @@ test_expect_success HAVE_JQ 'job-manager: annotate jobs job-list (RRSSS)' '
         jlist_check_annotation $(cat job5.id) "sched.jobs_ahead" "2"
 '
 
-test_expect_success HAVE_JQ 'job-manager: annotate jobs in flux-jobs (RRSSS)' '
+test_expect_success 'job-manager: annotate jobs in flux-jobs (RRSSS)' '
         fjobs_check_annotation $(cat job1.id) "annotations.sched.resource_summary" "rank0/core0" &&
         fjobs_check_annotation $(cat job2.id) "annotations.sched.resource_summary" "rank0/core1" &&
         fjobs_check_annotation $(cat job3.id) "annotations.sched.reason_pending" "insufficient resources" &&
@@ -62,7 +62,7 @@ test_expect_success 'job-manager: cancel 2' '
         flux cancel $(cat job2.id)
 '
 
-test_expect_success HAVE_JQ 'job-manager: job state RIRSS' '
+test_expect_success 'job-manager: job state RIRSS' '
         jmgr_check_state $(cat job1.id) R &&
         jmgr_check_state $(cat job2.id) I &&
         jmgr_check_state $(cat job3.id) R &&
@@ -70,7 +70,7 @@ test_expect_success HAVE_JQ 'job-manager: job state RIRSS' '
         jmgr_check_state $(cat job5.id) S
 '
 
-test_expect_success HAVE_JQ 'job-manager: annotate jobs (RIRSS)' '
+test_expect_success 'job-manager: annotate jobs (RIRSS)' '
         jmgr_check_annotation $(cat job1.id) "sched.resource_summary" "\"rank0/core0\"" &&
         jmgr_check_no_annotations $(cat job2.id) &&
         jmgr_check_annotation $(cat job3.id) "sched.resource_summary" "\"rank0/core1\"" &&
@@ -84,7 +84,7 @@ test_expect_success HAVE_JQ 'job-manager: annotate jobs (RIRSS)' '
 
 # compared to above, note that job id #2 retains annotations, it is
 # cached in job-list
-test_expect_success HAVE_JQ 'job-manager: annotate jobs in job-list (RIRSS)' '
+test_expect_success 'job-manager: annotate jobs in job-list (RIRSS)' '
         jlist_check_annotation $(cat job1.id) "sched.resource_summary" "\"rank0/core0\"" &&
         jlist_check_annotation $(cat job2.id) "sched.resource_summary" "\"rank0/core1\"" &&
         jlist_check_annotation $(cat job3.id) "sched.resource_summary" "\"rank0/core1\"" &&
@@ -98,7 +98,7 @@ test_expect_success HAVE_JQ 'job-manager: annotate jobs in job-list (RIRSS)' '
 
 # compared to above, note that job id #2 retains annotations, it is
 # cached in job-list
-test_expect_success HAVE_JQ 'job-manager: annotate jobs in flux-jobs (RIRSS)' '
+test_expect_success 'job-manager: annotate jobs in flux-jobs (RIRSS)' '
         fjobs_check_annotation $(cat job1.id) "annotations.sched.resource_summary" "rank0/core0" &&
         fjobs_check_annotation $(cat job2.id) "annotations.sched.resource_summary" "rank0/core1" &&
         fjobs_check_annotation $(cat job3.id) "annotations.sched.resource_summary" "rank0/core1" &&
@@ -114,7 +114,7 @@ test_expect_success 'job-manager: cancel 5' '
         flux cancel $(cat job5.id)
 '
 
-test_expect_success HAVE_JQ 'job-manager: job state RIRSI' '
+test_expect_success 'job-manager: job state RIRSI' '
         jmgr_check_state $(cat job1.id) R &&
         jmgr_check_state $(cat job2.id) I &&
         jmgr_check_state $(cat job3.id) R &&
@@ -122,7 +122,7 @@ test_expect_success HAVE_JQ 'job-manager: job state RIRSI' '
         jmgr_check_state $(cat job5.id) I
 '
 
-test_expect_success HAVE_JQ 'job-manager: annotate jobs (RIRSI)' '
+test_expect_success 'job-manager: annotate jobs (RIRSI)' '
         jmgr_check_annotation $(cat job1.id) "sched.resource_summary" "\"rank0/core0\"" &&
         jmgr_check_no_annotations $(cat job2.id) &&
         jmgr_check_annotation $(cat job3.id) "sched.resource_summary" "\"rank0/core1\"" &&
@@ -135,7 +135,7 @@ test_expect_success HAVE_JQ 'job-manager: annotate jobs (RIRSI)' '
 
 # compared to above, note that job id #2 retains annotations, it is
 # cached in job-list
-test_expect_success HAVE_JQ 'job-manager: annotate jobs in job-list (RIRSS)' '
+test_expect_success 'job-manager: annotate jobs in job-list (RIRSS)' '
         jlist_check_annotation $(cat job1.id) "sched.resource_summary" "\"rank0/core0\"" &&
         jlist_check_annotation $(cat job2.id) "sched.resource_summary" "\"rank0/core1\"" &&
         jlist_check_annotation $(cat job3.id) "sched.resource_summary" "\"rank0/core1\"" &&
@@ -148,7 +148,7 @@ test_expect_success HAVE_JQ 'job-manager: annotate jobs in job-list (RIRSS)' '
 
 # compared to above, note that job id #2 retains annotations, it is
 # cached in job-list
-test_expect_success HAVE_JQ 'job-manager: annotate jobs in flux jobs (RIRSS)' '
+test_expect_success 'job-manager: annotate jobs in flux jobs (RIRSS)' '
         fjobs_check_annotation $(cat job1.id) "annotations.sched.resource_summary" "rank0/core0" &&
         fjobs_check_annotation $(cat job2.id) "annotations.sched.resource_summary" "rank0/core1" &&
         fjobs_check_annotation $(cat job3.id) "annotations.sched.resource_summary" "rank0/core1" &&
@@ -166,7 +166,7 @@ test_expect_success 'job-manager: cancel all jobs' '
         flux cancel --all
 '
 
-test_expect_success HAVE_JQ 'job-manager: job state IIIII' '
+test_expect_success 'job-manager: job state IIIII' '
         jmgr_check_state $(cat job1.id) I &&
         jmgr_check_state $(cat job2.id) I &&
         jmgr_check_state $(cat job3.id) I &&
@@ -174,7 +174,7 @@ test_expect_success HAVE_JQ 'job-manager: job state IIIII' '
         jmgr_check_state $(cat job5.id) I
 '
 
-test_expect_success HAVE_JQ 'job-manager: no annotations (IIIII)' '
+test_expect_success 'job-manager: no annotations (IIIII)' '
         jmgr_check_no_annotations $(cat job1.id) &&
         jmgr_check_no_annotations $(cat job2.id) &&
         jmgr_check_no_annotations $(cat job3.id) &&
@@ -183,7 +183,7 @@ test_expect_success HAVE_JQ 'job-manager: no annotations (IIIII)' '
 '
 
 # compared to above, note that job ids that ran retain annotations
-test_expect_success HAVE_JQ 'job-manager: no annotations in canceled jobs in job-list (IIIII)' '
+test_expect_success 'job-manager: no annotations in canceled jobs in job-list (IIIII)' '
         jlist_check_annotation $(cat job1.id) "sched.resource_summary" "\"rank0/core0\"" &&
         jlist_check_annotation $(cat job2.id) "sched.resource_summary" "\"rank0/core1\"" &&
         jlist_check_annotation $(cat job3.id) "sched.resource_summary" "\"rank0/core1\"" &&
@@ -192,7 +192,7 @@ test_expect_success HAVE_JQ 'job-manager: no annotations in canceled jobs in job
 '
 
 # compared to above, note that job ids that ran retain annotations
-test_expect_success HAVE_JQ 'job-manager: no annotations in canceled jobs in flux jobs (IIIII)' '
+test_expect_success 'job-manager: no annotations in canceled jobs in flux jobs (IIIII)' '
         fjobs_check_annotation $(cat job1.id) "annotations.sched.resource_summary" "rank0/core0" &&
         fjobs_check_annotation $(cat job2.id) "annotations.sched.resource_summary" "rank0/core1" &&
         fjobs_check_annotation $(cat job3.id) "annotations.sched.resource_summary" "rank0/core1" &&

--- a/t/t2206-job-manager-annotate.t
+++ b/t/t2206-job-manager-annotate.t
@@ -19,7 +19,7 @@ test_expect_success 'job-manager: submit 5 jobs' '
            hostname
 '
 
-test_expect_success HAVE_JQ 'job-manager: no annotations (SSSSS)' '
+test_expect_success 'job-manager: no annotations (SSSSS)' '
         jmgr_check_no_annotations $(cat job1.id) &&
         jmgr_check_no_annotations $(cat job2.id) &&
         jmgr_check_no_annotations $(cat job3.id) &&
@@ -27,7 +27,7 @@ test_expect_success HAVE_JQ 'job-manager: no annotations (SSSSS)' '
         jmgr_check_no_annotations $(cat job5.id)
 '
 
-test_expect_success HAVE_JQ 'job-manager: no annotations in job-list (SSSSS)' '
+test_expect_success 'job-manager: no annotations in job-list (SSSSS)' '
         jlist_check_no_annotations $(cat job1.id) &&
         jlist_check_no_annotations $(cat job2.id) &&
         jlist_check_no_annotations $(cat job3.id) &&
@@ -44,7 +44,7 @@ test_expect_success 'job-manager: load sched-simple (1 rank, 2 cores/rank)' '
         flux queue start
 '
 
-test_expect_success HAVE_JQ 'job-manager: job state RRSSS' '
+test_expect_success 'job-manager: job state RRSSS' '
         jmgr_check_state $(cat job1.id) R &&
         jmgr_check_state $(cat job2.id) R &&
         jmgr_check_state $(cat job3.id) S &&
@@ -52,7 +52,7 @@ test_expect_success HAVE_JQ 'job-manager: job state RRSSS' '
         jmgr_check_state $(cat job5.id) S
 '
 
-test_expect_success HAVE_JQ 'job-manager: annotate jobs (RRSSS)' '
+test_expect_success 'job-manager: annotate jobs (RRSSS)' '
         jmgr_check_annotation $(cat job1.id) "sched.resource_summary" "\"rank0/core0\"" &&
         jmgr_check_annotation $(cat job2.id) "sched.resource_summary" "\"rank0/core1\"" &&
         jmgr_check_annotation $(cat job3.id) "sched.reason_pending" "\"insufficient resources\"" &&
@@ -63,7 +63,7 @@ test_expect_success HAVE_JQ 'job-manager: annotate jobs (RRSSS)' '
         jmgr_check_annotation $(cat job5.id) "sched.jobs_ahead" "2"
 '
 
-test_expect_success HAVE_JQ 'job-manager: annotate jobs in job-list (RRSSS)' '
+test_expect_success 'job-manager: annotate jobs in job-list (RRSSS)' '
         jlist_check_annotation $(cat job1.id) "sched.resource_summary" "\"rank0/core0\"" &&
         jlist_check_annotation $(cat job2.id) "sched.resource_summary" "\"rank0/core1\"" &&
         jlist_check_annotation $(cat job3.id) "sched.reason_pending" "\"insufficient resources\"" &&
@@ -74,7 +74,7 @@ test_expect_success HAVE_JQ 'job-manager: annotate jobs in job-list (RRSSS)' '
         jlist_check_annotation $(cat job5.id) "sched.jobs_ahead" "2"
 '
 
-test_expect_success HAVE_JQ 'job-manager: annotate jobs in flux-jobs (RRSSS)' '
+test_expect_success 'job-manager: annotate jobs in flux-jobs (RRSSS)' '
         fjobs_check_annotation $(cat job1.id) "annotations.sched.resource_summary" "rank0/core0" &&
         fjobs_check_annotation $(cat job2.id) "annotations.sched.resource_summary" "rank0/core1" &&
         fjobs_check_annotation $(cat job3.id) "annotations.sched.reason_pending" "insufficient resources" &&
@@ -85,7 +85,7 @@ test_expect_success HAVE_JQ 'job-manager: annotate jobs in flux-jobs (RRSSS)' '
         fjobs_check_annotation $(cat job5.id) "annotations.sched.jobs_ahead" "2"
 '
 
-test_expect_success HAVE_JQ 'job-manager: annotate jobs (RRSSS)' '
+test_expect_success 'job-manager: annotate jobs (RRSSS)' '
         jmgr_check_annotation $(cat job1.id) "sched.resource_summary" "\"rank0/core0\"" &&
         jmgr_check_annotation $(cat job2.id) "sched.resource_summary" "\"rank0/core1\"" &&
         jmgr_check_annotation $(cat job3.id) "sched.reason_pending" "\"insufficient resources\"" &&
@@ -96,7 +96,7 @@ test_expect_success HAVE_JQ 'job-manager: annotate jobs (RRSSS)' '
         jmgr_check_annotation $(cat job5.id) "sched.jobs_ahead" "2"
 '
 
-test_expect_success HAVE_JQ 'job-manager: annotate jobs in job-list (RRSSS)' '
+test_expect_success 'job-manager: annotate jobs in job-list (RRSSS)' '
         jlist_check_annotation $(cat job1.id) "sched.resource_summary" "\"rank0/core0\"" &&
         jlist_check_annotation $(cat job2.id) "sched.resource_summary" "\"rank0/core1\"" &&
         jlist_check_annotation $(cat job3.id) "sched.reason_pending" "\"insufficient resources\"" &&
@@ -107,7 +107,7 @@ test_expect_success HAVE_JQ 'job-manager: annotate jobs in job-list (RRSSS)' '
         jlist_check_annotation $(cat job5.id) "sched.jobs_ahead" "2"
 '
 
-test_expect_success HAVE_JQ 'job-manager: annotate jobs in flux-jobs (RRSSS)' '
+test_expect_success 'job-manager: annotate jobs in flux-jobs (RRSSS)' '
         fjobs_check_annotation $(cat job1.id) "annotations.sched.resource_summary" "rank0/core0" &&
         fjobs_check_annotation $(cat job2.id) "annotations.sched.resource_summary" "rank0/core1" &&
         fjobs_check_annotation $(cat job3.id) "annotations.sched.reason_pending" "insufficient resources" &&
@@ -122,7 +122,7 @@ test_expect_success 'job-manager: cancel 2' '
         flux cancel $(cat job2.id)
 '
 
-test_expect_success HAVE_JQ 'job-manager: job state RIRSS' '
+test_expect_success 'job-manager: job state RIRSS' '
         jmgr_check_state $(cat job1.id) R &&
         jmgr_check_state $(cat job2.id) I &&
         jmgr_check_state $(cat job3.id) R &&
@@ -130,7 +130,7 @@ test_expect_success HAVE_JQ 'job-manager: job state RIRSS' '
         jmgr_check_state $(cat job5.id) S
 '
 
-test_expect_success HAVE_JQ 'job-manager: annotate jobs (RIRSS)' '
+test_expect_success 'job-manager: annotate jobs (RIRSS)' '
         jmgr_check_annotation $(cat job1.id) "sched.resource_summary" "\"rank0/core0\"" &&
         jmgr_check_no_annotations $(cat job2.id) &&
         jmgr_check_annotation $(cat job3.id) "sched.resource_summary" "\"rank0/core1\"" &&
@@ -144,7 +144,7 @@ test_expect_success HAVE_JQ 'job-manager: annotate jobs (RIRSS)' '
 
 # compared to above, note that job id #2 retains annotations, it is
 # cached in job-list
-test_expect_success HAVE_JQ 'job-manager: annotate jobs in job-list (RIRSS)' '
+test_expect_success 'job-manager: annotate jobs in job-list (RIRSS)' '
         jlist_check_annotation $(cat job1.id) "sched.resource_summary" "\"rank0/core0\"" &&
         jlist_check_annotation $(cat job2.id) "sched.resource_summary" "\"rank0/core1\"" &&
         jlist_check_annotation $(cat job3.id) "sched.resource_summary" "\"rank0/core1\"" &&
@@ -158,7 +158,7 @@ test_expect_success HAVE_JQ 'job-manager: annotate jobs in job-list (RIRSS)' '
 
 # compared to above, note that job id #2 retains annotations, it is
 # cached in job-list
-test_expect_success HAVE_JQ 'job-manager: annotate jobs in flux-jobs (RIRSS)' '
+test_expect_success 'job-manager: annotate jobs in flux-jobs (RIRSS)' '
         fjobs_check_annotation $(cat job1.id) "annotations.sched.resource_summary" "rank0/core0" &&
         fjobs_check_annotation $(cat job2.id) "annotations.sched.resource_summary" "rank0/core1" &&
         fjobs_check_annotation $(cat job3.id) "annotations.sched.resource_summary" "rank0/core1" &&
@@ -177,7 +177,7 @@ test_expect_success 'job-manager: cancel all jobs' '
         flux cancel --all
 '
 
-test_expect_success HAVE_JQ 'job-manager: job state IIIII' '
+test_expect_success 'job-manager: job state IIIII' '
         jmgr_check_state $(cat job1.id) I &&
         jmgr_check_state $(cat job2.id) I &&
         jmgr_check_state $(cat job3.id) I &&
@@ -185,7 +185,7 @@ test_expect_success HAVE_JQ 'job-manager: job state IIIII' '
         jmgr_check_state $(cat job5.id) I
 '
 
-test_expect_success HAVE_JQ 'job-manager: no annotations (IIIII)' '
+test_expect_success 'job-manager: no annotations (IIIII)' '
         jmgr_check_no_annotations $(cat job1.id) &&
         jmgr_check_no_annotations $(cat job2.id) &&
         jmgr_check_no_annotations $(cat job3.id) &&
@@ -194,7 +194,7 @@ test_expect_success HAVE_JQ 'job-manager: no annotations (IIIII)' '
 '
 
 # compared to above, note that job ids that ran retain annotations
-test_expect_success HAVE_JQ 'job-manager: annotation jobs in job-list (IIIII)' '
+test_expect_success 'job-manager: annotation jobs in job-list (IIIII)' '
         jlist_check_annotation $(cat job1.id) "sched.resource_summary" "\"rank0/core0\"" &&
         jlist_check_annotation $(cat job2.id) "sched.resource_summary" "\"rank0/core1\"" &&
         jlist_check_annotation $(cat job3.id) "sched.resource_summary" "\"rank0/core1\"" &&
@@ -203,7 +203,7 @@ test_expect_success HAVE_JQ 'job-manager: annotation jobs in job-list (IIIII)' '
 '
 
 # compared to above, note that job ids that ran retain annotations
-test_expect_success HAVE_JQ 'job-manager: annotate jobs in job-list (IIIII)' '
+test_expect_success 'job-manager: annotate jobs in job-list (IIIII)' '
         fjobs_check_annotation $(cat job1.id) "annotations.sched.resource_summary" "rank0/core0" &&
         fjobs_check_annotation $(cat job2.id) "annotations.sched.resource_summary" "rank0/core1" &&
         fjobs_check_annotation $(cat job3.id) "annotations.sched.resource_summary" "rank0/core1" &&

--- a/t/t2208-job-manager-wait.t
+++ b/t/t2208-job-manager-wait.t
@@ -47,7 +47,7 @@ test_expect_success "wait works on inactive,waitable job" '
 	flux job wait ${JOBID}
 '
 
-test_expect_success HAVE_JQ "waitable inactive jobs are listed as zombies" '
+test_expect_success "waitable inactive jobs are listed as zombies" '
 	JOBID=$(flux submit --flags waitable /bin/true) &&
 	echo ${JOBID} >id1.out &&
 	flux job wait-event ${JOBID} clean &&

--- a/t/t2210-job-manager-events-journal.t
+++ b/t/t2210-job-manager-events-journal.t
@@ -90,7 +90,7 @@ wait_event_annotation() {
 	wait_event ${jobid} .entry.context.annotations.user.${key} ${value} ${filename}
 }
 
-test_expect_success HAVE_JQ,NO_CHAIN_LINT 'job-manager: events-journal w/ no filters shows all events' '
+test_expect_success NO_CHAIN_LINT 'job-manager: events-journal w/ no filters shows all events' '
 	$jq -j -c -n "{}" \
 		| $EVENTS_JOURNAL_STREAM > events1.out &
 	pid=$! &&
@@ -108,7 +108,7 @@ test_expect_success HAVE_JQ,NO_CHAIN_LINT 'job-manager: events-journal w/ no fil
 	wait $pid
 '
 
-test_expect_success HAVE_JQ,NO_CHAIN_LINT 'job-manager: events-journal allow works' '
+test_expect_success NO_CHAIN_LINT 'job-manager: events-journal allow works' '
 	$jq -j -c -n "{allow:{clean:1}}" \
 		| $EVENTS_JOURNAL_STREAM > events2.out &
 	pid=$! &&
@@ -126,7 +126,7 @@ test_expect_success HAVE_JQ,NO_CHAIN_LINT 'job-manager: events-journal allow wor
 	wait $pid
 '
 
-test_expect_success HAVE_JQ,NO_CHAIN_LINT 'job-manager: events-journal allow works (multiple)' '
+test_expect_success NO_CHAIN_LINT 'job-manager: events-journal allow works (multiple)' '
 	$jq -j -c -n "{allow:{depend:1, finish:1, clean:1}}" \
 		| $EVENTS_JOURNAL_STREAM > events3.out &
 	pid=$! &&
@@ -144,7 +144,7 @@ test_expect_success HAVE_JQ,NO_CHAIN_LINT 'job-manager: events-journal allow wor
 	wait $pid
 '
 
-test_expect_success HAVE_JQ,NO_CHAIN_LINT 'job-manager: events-journal deny works' '
+test_expect_success NO_CHAIN_LINT 'job-manager: events-journal deny works' '
 	$jq -j -c -n "{deny:{finish:1}}" \
 		| $EVENTS_JOURNAL_STREAM > events4.out &
 	pid=$! &&
@@ -162,7 +162,7 @@ test_expect_success HAVE_JQ,NO_CHAIN_LINT 'job-manager: events-journal deny work
 	wait $pid
 '
 
-test_expect_success HAVE_JQ,NO_CHAIN_LINT 'job-manager: events-journal deny works (multiple)' '
+test_expect_success NO_CHAIN_LINT 'job-manager: events-journal deny works (multiple)' '
 	$jq -j -c -n "{deny:{depend:1, finish:1, release:1}}" \
 		| $EVENTS_JOURNAL_STREAM > events5.out &
 	pid=$! &&
@@ -180,7 +180,7 @@ test_expect_success HAVE_JQ,NO_CHAIN_LINT 'job-manager: events-journal deny work
 	wait $pid
 '
 
-test_expect_success HAVE_JQ,NO_CHAIN_LINT 'job-manager: events-journal allow & deny works' '
+test_expect_success NO_CHAIN_LINT 'job-manager: events-journal allow & deny works' '
 	$jq -j -c -n "{allow:{depend:1, finish:1, clean:1}, deny:{depend:1}}" \
 		| $EVENTS_JOURNAL_STREAM > events6.out &
 	pid=$! &&
@@ -198,7 +198,7 @@ test_expect_success HAVE_JQ,NO_CHAIN_LINT 'job-manager: events-journal allow & d
 	wait $pid
 '
 
-test_expect_success HAVE_JQ,NO_CHAIN_LINT 'job-manager: events-journal contains older jobs' '
+test_expect_success NO_CHAIN_LINT 'job-manager: events-journal contains older jobs' '
 	jobid1=`flux job submit basic.json | flux job id`
 	jobid2=`flux job submit basic.json | flux job id`
 	flux job wait-event ${jobid1} clean
@@ -251,7 +251,7 @@ check_event_name_eventlog_seq() {
 }
 
 # annotations event below comes from sched-simple scheduler
-test_expect_success HAVE_JQ,NO_CHAIN_LINT 'job-manager: eventlog seqs are correct' '
+test_expect_success NO_CHAIN_LINT 'job-manager: eventlog seqs are correct' '
 	$jq -j -c -n "{}" \
 		| $EVENTS_JOURNAL_STREAM > events9.out &
 	pid=$! &&
@@ -275,18 +275,18 @@ test_expect_success 'job-manager: events-journal request fails with EPROTO on em
 	$RPC job-manager.events-journal 71 < /dev/null
 '
 
-test_expect_success HAVE_JQ 'job-manager: events-journal request fails if not streaming RPC' '
+test_expect_success 'job-manager: events-journal request fails if not streaming RPC' '
 	$jq -j -c -n "{}" > cc1.in &&
 	test_must_fail $RPC job-manager.events-journal < cc1.in
 '
 
-test_expect_success HAVE_JQ 'job-manager: events-journal request fails if allow not an object' '
+test_expect_success 'job-manager: events-journal request fails if allow not an object' '
 	$jq -j -c -n "{allow:5}" > cc2.in &&
 	test_must_fail $EVENTS_JOURNAL_STREAM < cc2.in 2> cc2.err &&
 	grep "allow should be an object" cc2.err
 '
 
-test_expect_success HAVE_JQ 'job-manager: events-journal request fails if deny not an object' '
+test_expect_success 'job-manager: events-journal request fails if deny not an object' '
 	$jq -j -c -n "{deny:5}" > cc3.in &&
 	test_must_fail $EVENTS_JOURNAL_STREAM < cc3.in 2> cc3.err &&
 	grep "deny should be an object" cc3.err

--- a/t/t2211-job-manager-jobspec.t
+++ b/t/t2211-job-manager-jobspec.t
@@ -22,11 +22,11 @@ test_expect_success 'create simple jobspec' '
 	flux submit --dry-run hostname >simple.json
 '
 
-test_expect_success HAVE_JQ 'jobspec contains environment' '
+test_expect_success 'jobspec contains environment' '
 	jq -e .attributes.system.environment <simple.json >env.json
 '
 
-test_expect_success HAVE_JQ 'jobspec contains duration' '
+test_expect_success 'jobspec contains duration' '
 	jq -e .attributes.system.duration <simple.json
 '
 
@@ -38,16 +38,16 @@ test_expect_success 'job-manager getattr of unknown attr fails' '
 	test_must_fail job_manager_getattr $(cat jobid) noexist
 '
 
-test_expect_success HAVE_JQ 'job-manager getattr of jobspec works' '
+test_expect_success 'job-manager getattr of jobspec works' '
 	job_manager_getattr $(cat jobid) jobspec >getattr.json &&
 	jq -e .jobspec <getattr.json >redacted.json
 '
 
-test_expect_success HAVE_JQ 'redacted jobspec contains duration' '
+test_expect_success 'redacted jobspec contains duration' '
 	jq -e .attributes.system.duration <redacted.json
 '
 
-test_expect_success HAVE_JQ 'redacted jobspec does not contain environment' '
+test_expect_success 'redacted jobspec does not contain environment' '
 	test_must_fail jq -e .attributes.system.environment <redacted.json
 '
 
@@ -57,7 +57,7 @@ test_expect_success 'reload job manager and dependent modules' '
 	flux module load sched-simple
 '
 
-test_expect_success HAVE_JQ 'pending job still exists with same jobspec' '
+test_expect_success 'pending job still exists with same jobspec' '
 	job_manager_getattr $(cat jobid) jobspec >getattr2.json &&
 	jq -e .jobspec <getattr2.json >redacted2.json &&
 	test_cmp redacted.json redacted2.json

--- a/t/t2212-job-manager-plugins.t
+++ b/t/t2212-job-manager-plugins.t
@@ -53,7 +53,7 @@ test_expect_success 'job-manager: loading duplicate plugins fails' '
 	test_must_fail flux jobtap load ${PLUGINPATH}/args.so &&
 	flux jobtap remove args.so
 '
-test_expect_success HAVE_JQ 'job-manager: query of plugin works' '
+test_expect_success 'job-manager: query of plugin works' '
 	flux jobtap load ${PLUGINPATH}/test.so &&
 	flux jobtap query test.so >query.json &&
 	test_debug "jq -S . <query.json" &&
@@ -134,7 +134,7 @@ test_expect_success 'job-manager: default works with sched.prioritize' '
 	flux cancel --all &&
 	flux queue drain
 '
-test_expect_success HAVE_JQ 'job-manager: hold plugin holds jobs' '
+test_expect_success 'job-manager: hold plugin holds jobs' '
 	flux jobtap load submit-hold.so &&
 	flux bulksubmit --job-name=cc-{0} hostname ::: $(seq 1 4) \
 	    >hold.jobids &&

--- a/t/t2213-job-manager-hold-single.t
+++ b/t/t2213-job-manager-hold-single.t
@@ -19,7 +19,7 @@ test_expect_success 'job-manager: submit 5 jobs (job 2 held)' '
            hostname ::: default hold default default default
 '
 
-test_expect_success HAVE_JQ 'job-manager: job state RSSSS' '
+test_expect_success 'job-manager: job state RSSSS' '
         jmgr_check_state $(cat job1.id) R &&
         jmgr_check_state $(cat job2.id) S &&
         jmgr_check_state $(cat job3.id) S &&
@@ -27,7 +27,7 @@ test_expect_success HAVE_JQ 'job-manager: job state RSSSS' '
         jmgr_check_state $(cat job5.id) S
 '
 
-test_expect_success HAVE_JQ 'job-manager: annotations job 3 pending, job 2 held (RSSS)' '
+test_expect_success 'job-manager: annotations job 3 pending, job 2 held (RSSS)' '
         jmgr_check_annotation $(cat job1.id) "sched.resource_summary" "\"rank0/core0\"" &&
         jmgr_check_no_annotations $(cat job2.id) &&
         jmgr_check_annotation $(cat job3.id) "sched.reason_pending" "\"insufficient resources\"" &&
@@ -43,7 +43,7 @@ test_expect_success 'job-manager: cancel job 1' '
         flux cancel $(cat job1.id)
 '
 
-test_expect_success HAVE_JQ 'job-manager: job state ISRSS (job 3 run, job 2 held)' '
+test_expect_success 'job-manager: job state ISRSS (job 3 run, job 2 held)' '
         jmgr_check_state $(cat job1.id) I &&
         jmgr_check_state $(cat job2.id) S &&
         jmgr_check_state $(cat job3.id) R &&
@@ -51,7 +51,7 @@ test_expect_success HAVE_JQ 'job-manager: job state ISRSS (job 3 run, job 2 held
         jmgr_check_state $(cat job5.id) S
 '
 
-test_expect_success HAVE_JQ 'job-manager: annotations job 5 pending (job 2/4 held)' '
+test_expect_success 'job-manager: annotations job 5 pending (job 2/4 held)' '
         jmgr_check_no_annotations $(cat job1.id) &&
         jmgr_check_no_annotations $(cat job2.id) &&
         jmgr_check_annotation $(cat job3.id) "sched.resource_summary" "\"rank0/core0\"" &&
@@ -59,7 +59,7 @@ test_expect_success HAVE_JQ 'job-manager: annotations job 5 pending (job 2/4 hel
         jmgr_check_annotation $(cat job5.id) "sched.reason_pending" "\"insufficient resources\""
 '
 
-test_expect_success HAVE_JQ 'job-manager: job 2, 4 hold again (issue #4940)' '
+test_expect_success 'job-manager: job 2, 4 hold again (issue #4940)' '
         flux job urgency $(cat job2.id) hold &&
         flux job urgency $(cat job4.id) hold &&
         jmgr_check_state $(cat job2.id) S &&
@@ -70,7 +70,7 @@ test_expect_success 'job-manager: job 4 release (higher urgency)' '
         flux job urgency $(cat job4.id) 20
 '
 
-test_expect_success HAVE_JQ 'job-manager: annotations job 4 pending' '
+test_expect_success 'job-manager: annotations job 4 pending' '
         jmgr_check_no_annotations $(cat job1.id) &&
         jmgr_check_no_annotations $(cat job2.id) &&
         jmgr_check_annotation $(cat job3.id) "sched.resource_summary" "\"rank0/core0\"" &&
@@ -82,7 +82,7 @@ test_expect_success 'job-manager: cancel job 3' '
         flux cancel $(cat job3.id)
 '
 
-test_expect_success HAVE_JQ 'job-manager: job state ISIRS (job 4 run, job 2 held)' '
+test_expect_success 'job-manager: job state ISIRS (job 4 run, job 2 held)' '
         jmgr_check_state $(cat job1.id) I &&
         jmgr_check_state $(cat job2.id) S &&
         jmgr_check_state $(cat job3.id) I &&
@@ -90,7 +90,7 @@ test_expect_success HAVE_JQ 'job-manager: job state ISIRS (job 4 run, job 2 held
         jmgr_check_state $(cat job5.id) S
 '
 
-test_expect_success HAVE_JQ 'job-manager: annotations job 5 pending (job 2 held)' '
+test_expect_success 'job-manager: annotations job 5 pending (job 2 held)' '
         jmgr_check_no_annotations $(cat job1.id) &&
         jmgr_check_no_annotations $(cat job2.id) &&
         jmgr_check_no_annotations $(cat job3.id) &&
@@ -102,7 +102,7 @@ test_expect_success 'job-manager: cancel job 4' '
         flux cancel $(cat job4.id)
 '
 
-test_expect_success HAVE_JQ 'job-manager: job state ISIIR (job 5 run, job 2 held)' '
+test_expect_success 'job-manager: job state ISIIR (job 5 run, job 2 held)' '
         jmgr_check_state $(cat job1.id) I &&
         jmgr_check_state $(cat job2.id) S &&
         jmgr_check_state $(cat job3.id) I &&
@@ -110,7 +110,7 @@ test_expect_success HAVE_JQ 'job-manager: job state ISIIR (job 5 run, job 2 held
         jmgr_check_state $(cat job5.id) R
 '
 
-test_expect_success HAVE_JQ 'job-manager: annotations no job pending (job 2 held)' '
+test_expect_success 'job-manager: annotations no job pending (job 2 held)' '
         jmgr_check_no_annotations $(cat job1.id) &&
         jmgr_check_no_annotations $(cat job2.id) &&
         jmgr_check_no_annotations $(cat job3.id) &&
@@ -122,7 +122,7 @@ test_expect_success 'job-manager: job 2 release' '
         flux job urgency $(cat job2.id) 16
 '
 
-test_expect_success HAVE_JQ 'job-manager: annotations job 2 pending' '
+test_expect_success 'job-manager: annotations job 2 pending' '
         jmgr_check_no_annotations $(cat job1.id) &&
         jmgr_check_annotation $(cat job2.id) "sched.reason_pending" "\"insufficient resources\"" &&
         jmgr_check_no_annotations $(cat job3.id) &&

--- a/t/t2214-job-manager-hold-limited.t
+++ b/t/t2214-job-manager-hold-limited.t
@@ -18,7 +18,7 @@ test_expect_success 'job-manager: submit 5 jobs (job 3,4,5 held)' '
            hostname ::: default default hold hold hold
 '
 
-test_expect_success HAVE_JQ 'job-manager: job state RRSSS' '
+test_expect_success 'job-manager: job state RRSSS' '
         jmgr_check_state $(cat job1.id) R &&
         jmgr_check_state $(cat job2.id) R &&
         jmgr_check_state $(cat job3.id) S &&
@@ -26,7 +26,7 @@ test_expect_success HAVE_JQ 'job-manager: job state RRSSS' '
         jmgr_check_state $(cat job5.id) S
 '
 
-test_expect_success HAVE_JQ 'job-manager: job annotations correct (RSSSS)' '
+test_expect_success 'job-manager: job annotations correct (RSSSS)' '
         jmgr_check_annotation $(cat job1.id) "sched.resource_summary" "\"rank0/core0\"" &&
         jmgr_check_annotation $(cat job2.id) "sched.resource_summary" "\"rank0/core1\"" &&
         jmgr_check_no_annotations $(cat job3.id) &&
@@ -48,7 +48,7 @@ test_expect_success 'job-manager: remove hold on job 3, 4, 5' '
         flux job urgency $(cat job5.id) 16
 '
 
-test_expect_success HAVE_JQ 'job-manager: job state RRSSS' '
+test_expect_success 'job-manager: job state RRSSS' '
         jmgr_check_state $(cat job1.id) R &&
         jmgr_check_state $(cat job2.id) R &&
         jmgr_check_state $(cat job3.id) S &&
@@ -56,7 +56,7 @@ test_expect_success HAVE_JQ 'job-manager: job state RRSSS' '
         jmgr_check_state $(cat job5.id) S
 '
 
-test_expect_success HAVE_JQ 'job-manager: job annotations updated (RRSSS)' '
+test_expect_success 'job-manager: job annotations updated (RRSSS)' '
         jmgr_check_annotation $(cat job1.id) "sched.resource_summary" "\"rank0/core0\"" &&
         jmgr_check_annotation $(cat job2.id) "sched.resource_summary" "\"rank0/core1\"" &&
         jmgr_check_annotation $(cat job3.id) "sched.reason_pending" "\"insufficient resources\"" &&
@@ -70,7 +70,7 @@ test_expect_success 'job-manager: put hold on job 4' '
         flux job urgency $(cat job4.id) hold
 '
 
-test_expect_success HAVE_JQ 'job-manager: job state RRSSS' '
+test_expect_success 'job-manager: job state RRSSS' '
         jmgr_check_state $(cat job1.id) R &&
         jmgr_check_state $(cat job2.id) R &&
         jmgr_check_state $(cat job3.id) S &&
@@ -78,7 +78,7 @@ test_expect_success HAVE_JQ 'job-manager: job state RRSSS' '
         jmgr_check_state $(cat job5.id) S
 '
 
-test_expect_success HAVE_JQ 'job-manager: job annotations updated (RRSSS)' '
+test_expect_success 'job-manager: job annotations updated (RRSSS)' '
         jmgr_check_annotation $(cat job1.id) "sched.resource_summary" "\"rank0/core0\"" &&
         jmgr_check_annotation $(cat job2.id) "sched.resource_summary" "\"rank0/core1\"" &&
         jmgr_check_annotation $(cat job3.id) "sched.jobs_ahead" "0" &&
@@ -92,7 +92,7 @@ test_expect_success 'job-manager: cancel job 1 & 2' '
         flux cancel $(cat job2.id)
 '
 
-test_expect_success HAVE_JQ 'job-manager: job state IISSR' '
+test_expect_success 'job-manager: job state IISSR' '
         jmgr_check_state $(cat job1.id) I &&
         jmgr_check_state $(cat job2.id) I &&
         jmgr_check_state $(cat job3.id) R &&
@@ -100,7 +100,7 @@ test_expect_success HAVE_JQ 'job-manager: job state IISSR' '
         jmgr_check_state $(cat job5.id) R
 '
 
-test_expect_success HAVE_JQ 'job-manager: job annotations updated (IIRSR)' '
+test_expect_success 'job-manager: job annotations updated (IIRSR)' '
         jmgr_check_no_annotations $(cat job1.id) &&
         jmgr_check_no_annotations $(cat job2.id) &&
         jmgr_check_annotation $(cat job3.id) "sched.resource_summary" "\"rank0/core0\"" &&
@@ -112,7 +112,7 @@ test_expect_success 'job-manager: remove hold on job 4' '
         flux job urgency $(cat job4.id) 16
 '
 
-test_expect_success HAVE_JQ 'job-manager: job state IISSR' '
+test_expect_success 'job-manager: job state IISSR' '
         jmgr_check_state $(cat job1.id) I &&
         jmgr_check_state $(cat job2.id) I &&
         jmgr_check_state $(cat job3.id) R &&
@@ -120,7 +120,7 @@ test_expect_success HAVE_JQ 'job-manager: job state IISSR' '
         jmgr_check_state $(cat job5.id) R
 '
 
-test_expect_success HAVE_JQ 'job-manager: job annotations updated (IIRSR)' '
+test_expect_success 'job-manager: job annotations updated (IIRSR)' '
         jmgr_check_no_annotations $(cat job1.id) &&
         jmgr_check_no_annotations $(cat job2.id) &&
         jmgr_check_annotation $(cat job3.id) "sched.resource_summary" "\"rank0/core0\"" &&

--- a/t/t2215-job-manager-hold-unlimited.t
+++ b/t/t2215-job-manager-hold-unlimited.t
@@ -18,7 +18,7 @@ test_expect_success 'job-manager: submit 5 jobs (job 4 held)' '
            hostname ::: default default default hold default
 '
 
-test_expect_success HAVE_JQ 'job-manager: job state RRSSS' '
+test_expect_success 'job-manager: job state RRSSS' '
         jmgr_check_state $(cat job1.id) R &&
         jmgr_check_state $(cat job2.id) R &&
         jmgr_check_state $(cat job3.id) S &&
@@ -26,7 +26,7 @@ test_expect_success HAVE_JQ 'job-manager: job state RRSSS' '
         jmgr_check_state $(cat job5.id) S
 '
 
-test_expect_success HAVE_JQ 'job-manager: job annotations correct (RRSSS)' '
+test_expect_success 'job-manager: job annotations correct (RRSSS)' '
         jmgr_check_annotation $(cat job1.id) "sched.resource_summary" "\"rank0/core0\"" &&
         jmgr_check_annotation $(cat job2.id) "sched.resource_summary" "\"rank0/core1\"" &&
         jmgr_check_annotation $(cat job3.id) "sched.reason_pending" "\"insufficient resources\"" &&
@@ -44,7 +44,7 @@ test_expect_success 'job-manager: hold job 4 again (issue #4940)' '
         flux job urgency $(cat job4.id) hold
 '
 
-test_expect_success HAVE_JQ 'job-manager: job state RRSSS' '
+test_expect_success 'job-manager: job state RRSSS' '
         jmgr_check_state $(cat job1.id) R &&
         jmgr_check_state $(cat job2.id) R &&
         jmgr_check_state $(cat job3.id) S &&
@@ -52,7 +52,7 @@ test_expect_success HAVE_JQ 'job-manager: job state RRSSS' '
         jmgr_check_state $(cat job5.id) S
 '
 
-test_expect_success HAVE_JQ 'job-manager: job annotations updated (RRSSS)' '
+test_expect_success 'job-manager: job annotations updated (RRSSS)' '
         jmgr_check_annotation $(cat job1.id) "sched.resource_summary" "\"rank0/core0\"" &&
         jmgr_check_annotation $(cat job2.id) "sched.resource_summary" "\"rank0/core1\"" &&
         jmgr_check_no_annotations $(cat job3.id) &&
@@ -66,7 +66,7 @@ test_expect_success 'job-manager: cancel job 1 & 2' '
         flux cancel $(cat job2.id)
 '
 
-test_expect_success HAVE_JQ 'job-manager: job state IISSR' '
+test_expect_success 'job-manager: job state IISSR' '
         jmgr_check_state $(cat job1.id) I &&
         jmgr_check_state $(cat job2.id) I &&
         jmgr_check_state $(cat job3.id) S &&
@@ -74,7 +74,7 @@ test_expect_success HAVE_JQ 'job-manager: job state IISSR' '
         jmgr_check_state $(cat job5.id) R
 '
 
-test_expect_success HAVE_JQ 'job-manager: job annotations updated (IISSR)' '
+test_expect_success 'job-manager: job annotations updated (IISSR)' '
         jmgr_check_no_annotations $(cat job1.id) &&
         jmgr_check_no_annotations $(cat job2.id) &&
         jmgr_check_no_annotations $(cat job3.id) &&
@@ -86,7 +86,7 @@ test_expect_success 'job-manager: remove hold on job 3' '
         flux job urgency $(cat job3.id) 16
 '
 
-test_expect_success HAVE_JQ 'job-manager: job state IISSR' '
+test_expect_success 'job-manager: job state IISSR' '
         jmgr_check_state $(cat job1.id) I &&
         jmgr_check_state $(cat job2.id) I &&
         jmgr_check_state $(cat job3.id) R &&
@@ -94,7 +94,7 @@ test_expect_success HAVE_JQ 'job-manager: job state IISSR' '
         jmgr_check_state $(cat job5.id) R
 '
 
-test_expect_success HAVE_JQ 'job-manager: job annotations updated (IIRSR)' '
+test_expect_success 'job-manager: job annotations updated (IIRSR)' '
         jmgr_check_no_annotations $(cat job1.id) &&
         jmgr_check_no_annotations $(cat job2.id) &&
         jmgr_check_annotation $(cat job3.id) "sched.resource_summary" "\"rank0/core1\"" &&
@@ -106,7 +106,7 @@ test_expect_success 'job-manager: remove hold on job 4' '
         flux job urgency $(cat job4.id) 16
 '
 
-test_expect_success HAVE_JQ 'job-manager: job state IIRSR' '
+test_expect_success 'job-manager: job state IIRSR' '
         jmgr_check_state $(cat job1.id) I &&
         jmgr_check_state $(cat job2.id) I &&
         jmgr_check_state $(cat job3.id) R &&
@@ -114,7 +114,7 @@ test_expect_success HAVE_JQ 'job-manager: job state IIRSR' '
         jmgr_check_state $(cat job5.id) R
 '
 
-test_expect_success HAVE_JQ 'job-manager: job annotations updated (IIRSR)' '
+test_expect_success 'job-manager: job annotations updated (IIRSR)' '
         jmgr_check_no_annotations $(cat job1.id) &&
         jmgr_check_no_annotations $(cat job2.id) &&
         jmgr_check_annotation $(cat job3.id) "sched.resource_summary" "\"rank0/core1\"" &&
@@ -127,7 +127,7 @@ test_expect_success 'job-manager: cancel job 3' '
         flux cancel $(cat job3.id)
 '
 
-test_expect_success HAVE_JQ 'job-manager: job state IIIRR' '
+test_expect_success 'job-manager: job state IIIRR' '
         jmgr_check_state $(cat job1.id) I &&
         jmgr_check_state $(cat job2.id) I &&
         jmgr_check_state $(cat job3.id) I &&
@@ -135,7 +135,7 @@ test_expect_success HAVE_JQ 'job-manager: job state IIIRR' '
         jmgr_check_state $(cat job5.id) R
 '
 
-test_expect_success HAVE_JQ 'job-manager: job annotations updated (IISRR)' '
+test_expect_success 'job-manager: job annotations updated (IISRR)' '
         jmgr_check_no_annotations $(cat job1.id) &&
         jmgr_check_no_annotations $(cat job2.id) &&
         jmgr_check_no_annotations $(cat job3.id) &&

--- a/t/t2216-job-manager-priority-order-single.t
+++ b/t/t2216-job-manager-priority-order-single.t
@@ -18,21 +18,21 @@ test_expect_success 'job-manager: submit 4 jobs' '
            hostname
 '
 
-test_expect_success HAVE_JQ 'job-manager: job state RRSS' '
+test_expect_success 'job-manager: job state RRSS' '
         jmgr_check_state $(cat job1.id) R &&
         jmgr_check_state $(cat job2.id) R &&
         jmgr_check_state $(cat job3.id) S &&
         jmgr_check_state $(cat job4.id) S
 '
 
-test_expect_success HAVE_JQ 'job-manager: annotate job id 3 (RRSS)' '
+test_expect_success 'job-manager: annotate job id 3 (RRSS)' '
         jmgr_check_annotation $(cat job1.id) "sched.resource_summary" "\"rank0/core0\"" &&
         jmgr_check_annotation $(cat job2.id) "sched.resource_summary" "\"rank0/core1\"" &&
         jmgr_check_annotation $(cat job3.id) "sched.reason_pending" "\"insufficient resources\"" &&
         jmgr_check_no_annotations $(cat job4.id)
 '
 
-test_expect_success HAVE_JQ 'job-manager: annotations in job id 3-4 (RRSS)' '
+test_expect_success 'job-manager: annotations in job id 3-4 (RRSS)' '
         jmgr_check_annotation $(cat job1.id) "sched.resource_summary" "\"rank0/core0\"" &&
         jmgr_check_annotation $(cat job2.id) "sched.resource_summary" "\"rank0/core1\"" &&
         jmgr_check_annotation $(cat job3.id) "sched.reason_pending" "\"insufficient resources\""
@@ -42,7 +42,7 @@ test_expect_success 'job-manager: increase urgency of job 4' '
         flux job urgency $(cat job4.id) 20
 '
 
-test_expect_success HAVE_JQ 'job-manager: annotations in job id 3-4 updated (RRSS)' '
+test_expect_success 'job-manager: annotations in job id 3-4 updated (RRSS)' '
         jmgr_check_annotation $(cat job1.id) "sched.resource_summary" "\"rank0/core0\"" &&
         jmgr_check_annotation $(cat job2.id) "sched.resource_summary" "\"rank0/core1\"" &&
         test_must_fail jmgr_check_annotation_exists $(cat job3.id) "sched.reason_pending" &&
@@ -53,14 +53,14 @@ test_expect_success 'job-manager: cancel 2' '
         flux cancel $(cat job2.id)
 '
 
-test_expect_success HAVE_JQ 'job-manager: job state RISR (job 4 runs instead of 3)' '
+test_expect_success 'job-manager: job state RISR (job 4 runs instead of 3)' '
         jmgr_check_state $(cat job1.id) R &&
         jmgr_check_state $(cat job2.id) I &&
         jmgr_check_state $(cat job3.id) S &&
         jmgr_check_state $(cat job4.id) R
 '
 
-test_expect_success HAVE_JQ 'job-manager: annotations in job id 3-4 updated (RISR)' '
+test_expect_success 'job-manager: annotations in job id 3-4 updated (RISR)' '
         jmgr_check_annotation $(cat job1.id) "sched.resource_summary" "\"rank0/core0\"" &&
         jmgr_check_no_annotations $(cat job2.id) &&
         jmgr_check_annotation $(cat job3.id) "sched.reason_pending" "\"insufficient resources\"" &&
@@ -72,7 +72,7 @@ test_expect_success 'job-manager: submit high urgency job' '
         flux submit --flags=debug --urgency=20 -n1 hostname >job5.id
 '
 
-test_expect_success HAVE_JQ 'job-manager: job state RISRS' '
+test_expect_success 'job-manager: job state RISRS' '
         jmgr_check_state $(cat job1.id) R &&
         jmgr_check_state $(cat job2.id) I &&
         jmgr_check_state $(cat job3.id) S &&
@@ -80,7 +80,7 @@ test_expect_success HAVE_JQ 'job-manager: job state RISRS' '
         jmgr_check_state $(cat job5.id) S
 '
 
-test_expect_success HAVE_JQ 'job-manager: annotations in job id 3-5 updated (RISRS)' '
+test_expect_success 'job-manager: annotations in job id 3-5 updated (RISRS)' '
         jmgr_check_annotation $(cat job1.id) "sched.resource_summary" "\"rank0/core0\"" &&
         jmgr_check_no_annotations $(cat job2.id) &&
         test_must_fail jmgr_check_annotation_exists $(cat job3.id) "sched.reason_pending" &&
@@ -93,7 +93,7 @@ test_expect_success 'job-manager: load priority-invert plugin' '
         flux jobtap load --remove=all ${PLUGINPATH}/priority-invert.so
 '
 
-test_expect_success HAVE_JQ 'job-manager: job state RISRS' '
+test_expect_success 'job-manager: job state RISRS' '
         jmgr_check_state $(cat job1.id) R &&
         jmgr_check_state $(cat job2.id) I &&
         jmgr_check_state $(cat job3.id) S &&
@@ -101,7 +101,7 @@ test_expect_success HAVE_JQ 'job-manager: job state RISRS' '
         jmgr_check_state $(cat job5.id) S
 '
 
-test_expect_success HAVE_JQ 'job-manager: annotations in job id 3-5 updated (RISRS)' '
+test_expect_success 'job-manager: annotations in job id 3-5 updated (RISRS)' '
         jmgr_check_annotation $(cat job1.id) "sched.resource_summary" "\"rank0/core0\"" &&
         jmgr_check_no_annotations $(cat job2.id) &&
         jmgr_check_annotation $(cat job3.id) "sched.reason_pending" "\"insufficient resources\"" &&
@@ -113,7 +113,7 @@ test_expect_success 'job-manager: cancel 1' '
         flux cancel $(cat job1.id)
 '
 
-test_expect_success HAVE_JQ 'job-manager: job state IISRR (job 5 runs instead of 3)' '
+test_expect_success 'job-manager: job state IISRR (job 5 runs instead of 3)' '
         jmgr_check_state $(cat job1.id) I &&
         jmgr_check_state $(cat job2.id) I &&
         jmgr_check_state $(cat job3.id) R &&
@@ -121,7 +121,7 @@ test_expect_success HAVE_JQ 'job-manager: job state IISRR (job 5 runs instead of
         jmgr_check_state $(cat job5.id) S
 '
 
-test_expect_success HAVE_JQ 'job-manager: annotations in job id 3-5 updated (IISRR)' '
+test_expect_success 'job-manager: annotations in job id 3-5 updated (IISRR)' '
         jmgr_check_no_annotations $(cat job1.id) &&
         jmgr_check_no_annotations $(cat job2.id) &&
         jmgr_check_annotation $(cat job3.id) "sched.resource_summary" "\"rank0/core0\"" &&

--- a/t/t2217-job-manager-priority-order-limited.t
+++ b/t/t2217-job-manager-priority-order-limited.t
@@ -21,7 +21,7 @@ test_expect_success 'job-manager: submit 5 jobs (differing urgencies)' '
         flux queue start
 '
 
-test_expect_success HAVE_JQ 'job-manager: job state SSSRR' '
+test_expect_success 'job-manager: job state SSSRR' '
         jmgr_check_state $(cat job1.id) S &&
         jmgr_check_state $(cat job2.id) S &&
         jmgr_check_state $(cat job3.id) S &&
@@ -29,7 +29,7 @@ test_expect_success HAVE_JQ 'job-manager: job state SSSRR' '
         jmgr_check_state $(cat job5.id) R
 '
 
-test_expect_success HAVE_JQ 'job-manager: annotate jobs (SSSRR)' '
+test_expect_success 'job-manager: annotate jobs (SSSRR)' '
         jmgr_check_no_annotations $(cat job1.id) &&
         jmgr_check_annotation $(cat job2.id) "sched.reason_pending" "\"insufficient resources\"" &&
         jmgr_check_annotation $(cat job2.id) "sched.jobs_ahead" "1" &&
@@ -43,7 +43,7 @@ test_expect_success 'job-manager: increase urgency job 2' '
         flux job urgency $(cat job2.id) 16
 '
 
-test_expect_success HAVE_JQ 'job-manager: job state SSSRR' '
+test_expect_success 'job-manager: job state SSSRR' '
         jmgr_check_state $(cat job1.id) S &&
         jmgr_check_state $(cat job2.id) S &&
         jmgr_check_state $(cat job3.id) S &&
@@ -51,7 +51,7 @@ test_expect_success HAVE_JQ 'job-manager: job state SSSRR' '
         jmgr_check_state $(cat job5.id) R
 '
 
-test_expect_success HAVE_JQ 'job-manager: annotate jobs updated (SSSRR)' '
+test_expect_success 'job-manager: annotate jobs updated (SSSRR)' '
         jmgr_check_no_annotations $(cat job1.id) &&
         jmgr_check_annotation $(cat job2.id) "sched.reason_pending" "\"insufficient resources\"" &&
         jmgr_check_annotation $(cat job2.id) "sched.jobs_ahead" "0" &&
@@ -65,7 +65,7 @@ test_expect_success 'job-manager: increase urgency job 1' '
         flux job urgency $(cat job1.id) 18
 '
 
-test_expect_success HAVE_JQ 'job-manager: job state SSSRR' '
+test_expect_success 'job-manager: job state SSSRR' '
         jmgr_check_state $(cat job1.id) S &&
         jmgr_check_state $(cat job2.id) S &&
         jmgr_check_state $(cat job3.id) S &&
@@ -73,7 +73,7 @@ test_expect_success HAVE_JQ 'job-manager: job state SSSRR' '
         jmgr_check_state $(cat job5.id) R
 '
 
-test_expect_success HAVE_JQ 'job-manager: annotate jobs updated (SSSRR)' '
+test_expect_success 'job-manager: annotate jobs updated (SSSRR)' '
         jmgr_check_annotation $(cat job1.id) "sched.reason_pending" "\"insufficient resources\"" &&
         jmgr_check_annotation $(cat job1.id) "sched.jobs_ahead" "0" &&
         jmgr_check_annotation $(cat job2.id) "sched.reason_pending" "\"insufficient resources\"" &&
@@ -87,7 +87,7 @@ test_expect_success 'job-manager: decrease urgency job 2' '
         flux job urgency $(cat job2.id) 8
 '
 
-test_expect_success HAVE_JQ 'job-manager: job state SSSRR' '
+test_expect_success 'job-manager: job state SSSRR' '
         jmgr_check_state $(cat job1.id) S &&
         jmgr_check_state $(cat job2.id) S &&
         jmgr_check_state $(cat job3.id) S &&
@@ -95,7 +95,7 @@ test_expect_success HAVE_JQ 'job-manager: job state SSSRR' '
         jmgr_check_state $(cat job5.id) R
 '
 
-test_expect_success HAVE_JQ 'job-manager: annotate jobs updated (SSSRR)' '
+test_expect_success 'job-manager: annotate jobs updated (SSSRR)' '
         jmgr_check_annotation $(cat job1.id) "sched.reason_pending" "\"insufficient resources\"" &&
         jmgr_check_annotation $(cat job1.id) "sched.jobs_ahead" "0" &&
         jmgr_check_no_annotations $(cat job2.id) &&
@@ -109,7 +109,7 @@ test_expect_success 'job-manager: submit new job with higher urgency' '
         flux submit --flags=debug --urgency=20 -n1 hostname >job6.id
 '
 
-test_expect_success HAVE_JQ 'job-manager: job state SSSRRS' '
+test_expect_success 'job-manager: job state SSSRRS' '
         jmgr_check_state $(cat job1.id) S &&
         jmgr_check_state $(cat job2.id) S &&
         jmgr_check_state $(cat job3.id) S &&
@@ -118,7 +118,7 @@ test_expect_success HAVE_JQ 'job-manager: job state SSSRRS' '
         jmgr_check_state $(cat job6.id) S
 '
 
-test_expect_success HAVE_JQ 'job-manager: annotate jobs updated (SSSRRS)' '
+test_expect_success 'job-manager: annotate jobs updated (SSSRRS)' '
         jmgr_check_annotation $(cat job1.id) "sched.reason_pending" "\"insufficient resources\"" &&
         jmgr_check_annotation $(cat job1.id) "sched.jobs_ahead" "1" &&
         jmgr_check_no_annotations $(cat job2.id) &&
@@ -151,7 +151,7 @@ test_expect_success 'job-manager: load priority-invert plugin' '
         flux jobtap load --remove=all ${PLUGINPATH}/priority-invert.so
 '
 
-test_expect_success HAVE_JQ 'job-manager: job state SSSRRS' '
+test_expect_success 'job-manager: job state SSSRRS' '
         jmgr_check_state $(cat job1.id) S &&
         jmgr_check_state $(cat job2.id) S &&
         jmgr_check_state $(cat job3.id) S &&
@@ -160,7 +160,7 @@ test_expect_success HAVE_JQ 'job-manager: job state SSSRRS' '
         jmgr_check_state $(cat job6.id) S
 '
 
-test_expect_success HAVE_JQ 'job-manager: annotate jobs updated (SSSRRS)' '
+test_expect_success 'job-manager: annotate jobs updated (SSSRRS)' '
         jmgr_check_no_annotations $(cat job1.id) &&
         jmgr_check_annotation $(cat job2.id) "sched.reason_pending" "\"insufficient resources\"" &&
         jmgr_check_annotation $(cat job2.id) "sched.jobs_ahead" "0" &&
@@ -175,7 +175,7 @@ test_expect_success 'job-manager: cancel 5' '
         flux cancel $(cat job5.id)
 '
 
-test_expect_success HAVE_JQ 'job-manager: job state SRSRIS' '
+test_expect_success 'job-manager: job state SRSRIS' '
         jmgr_check_state $(cat job1.id) S &&
         jmgr_check_state $(cat job2.id) R &&
         jmgr_check_state $(cat job3.id) S &&
@@ -184,7 +184,7 @@ test_expect_success HAVE_JQ 'job-manager: job state SRSRIS' '
         jmgr_check_state $(cat job6.id) S
 '
 
-test_expect_success HAVE_JQ 'job-manager: annotate jobs updated (SRSRIS)' '
+test_expect_success 'job-manager: annotate jobs updated (SRSRIS)' '
         jmgr_check_annotation $(cat job1.id) "sched.reason_pending" "\"insufficient resources\"" &&
         jmgr_check_annotation $(cat job1.id) "sched.jobs_ahead" "1" &&
         jmgr_check_annotation $(cat job2.id) "sched.resource_summary" "\"rank0/core0\"" &&

--- a/t/t2218-job-manager-priority-order-unlimited.t
+++ b/t/t2218-job-manager-priority-order-unlimited.t
@@ -21,7 +21,7 @@ test_expect_success 'job-manager: submit 5 jobs (differing urgencies)' '
         flux queue start
 '
 
-test_expect_success HAVE_JQ 'job-manager: job state SSSRR' '
+test_expect_success 'job-manager: job state SSSRR' '
         jmgr_check_state $(cat job1.id) S &&
         jmgr_check_state $(cat job2.id) S &&
         jmgr_check_state $(cat job3.id) S &&
@@ -29,7 +29,7 @@ test_expect_success HAVE_JQ 'job-manager: job state SSSRR' '
         jmgr_check_state $(cat job5.id) R
 '
 
-test_expect_success HAVE_JQ 'job-manager: annotate jobs (SSSRR)' '
+test_expect_success 'job-manager: annotate jobs (SSSRR)' '
         jmgr_check_annotation $(cat job1.id) "sched.reason_pending" "\"insufficient resources\"" &&
         jmgr_check_annotation $(cat job1.id) "sched.jobs_ahead" "1" &&
         jmgr_check_annotation $(cat job2.id) "sched.reason_pending" "\"insufficient resources\"" &&
@@ -44,7 +44,7 @@ test_expect_success 'job-manager: cancel 5' '
         flux cancel $(cat job5.id)
 '
 
-test_expect_success HAVE_JQ 'job-manager: job state SSRRI' '
+test_expect_success 'job-manager: job state SSRRI' '
         jmgr_check_state $(cat job1.id) S &&
         jmgr_check_state $(cat job2.id) S &&
         jmgr_check_state $(cat job3.id) R &&
@@ -52,7 +52,7 @@ test_expect_success HAVE_JQ 'job-manager: job state SSRRI' '
         jmgr_check_state $(cat job5.id) I
 '
 
-test_expect_success HAVE_JQ 'job-manager: annotate jobs (SSRRI)' '
+test_expect_success 'job-manager: annotate jobs (SSRRI)' '
         jmgr_check_annotation $(cat job1.id) "sched.reason_pending" "\"insufficient resources\"" &&
         jmgr_check_annotation $(cat job1.id) "sched.jobs_ahead" "0" &&
         jmgr_check_annotation $(cat job2.id) "sched.reason_pending" "\"insufficient resources\"" &&
@@ -68,7 +68,7 @@ test_expect_success 'job-manager: increase urgency job 2' '
         flux job urgency $(cat job2.id) 20
 '
 
-test_expect_success HAVE_JQ 'job-manager: job state SSRRI' '
+test_expect_success 'job-manager: job state SSRRI' '
         jmgr_check_state $(cat job1.id) S &&
         jmgr_check_state $(cat job2.id) S &&
         jmgr_check_state $(cat job3.id) R &&
@@ -76,7 +76,7 @@ test_expect_success HAVE_JQ 'job-manager: job state SSRRI' '
         jmgr_check_state $(cat job5.id) I
 '
 
-test_expect_success HAVE_JQ 'job-manager: annotate jobs updated (SSRRI)' '
+test_expect_success 'job-manager: annotate jobs updated (SSRRI)' '
         jmgr_check_annotation $(cat job1.id) "sched.reason_pending" "\"insufficient resources\"" &&
         jmgr_check_annotation $(cat job1.id) "sched.jobs_ahead" "1" &&
         jmgr_check_annotation $(cat job2.id) "sched.reason_pending" "\"insufficient resources\"" &&
@@ -91,7 +91,7 @@ test_expect_success 'job-manager: load priority-invert plugin' '
         flux jobtap load --remove=all ${PLUGINPATH}/priority-invert.so
 '
 
-test_expect_success HAVE_JQ 'job-manager: job state SSRRI' '
+test_expect_success 'job-manager: job state SSRRI' '
         jmgr_check_state $(cat job1.id) S &&
         jmgr_check_state $(cat job2.id) S &&
         jmgr_check_state $(cat job3.id) R &&
@@ -99,7 +99,7 @@ test_expect_success HAVE_JQ 'job-manager: job state SSRRI' '
         jmgr_check_state $(cat job5.id) I
 '
 
-test_expect_success HAVE_JQ 'job-manager: annotate jobs updated (SSRRI)' '
+test_expect_success 'job-manager: annotate jobs updated (SSRRI)' '
         jmgr_check_annotation $(cat job1.id) "sched.reason_pending" "\"insufficient resources\"" &&
         jmgr_check_annotation $(cat job1.id) "sched.jobs_ahead" "0" &&
         jmgr_check_annotation $(cat job2.id) "sched.reason_pending" "\"insufficient resources\"" &&
@@ -113,7 +113,7 @@ test_expect_success 'job-manager: cancel 4' '
         flux cancel $(cat job4.id)
 '
 
-test_expect_success HAVE_JQ 'job-manager: job state RSRII' '
+test_expect_success 'job-manager: job state RSRII' '
         jmgr_check_state $(cat job1.id) R &&
         jmgr_check_state $(cat job2.id) S &&
         jmgr_check_state $(cat job3.id) R &&
@@ -121,7 +121,7 @@ test_expect_success HAVE_JQ 'job-manager: job state RSRII' '
         jmgr_check_state $(cat job5.id) I
 '
 
-test_expect_success HAVE_JQ 'job-manager: annotate jobs updated (RSRII)' '
+test_expect_success 'job-manager: annotate jobs updated (RSRII)' '
         jmgr_check_annotation $(cat job1.id) "sched.resource_summary" "\"rank0/core1\"" &&
         test_must_fail jmgr_check_annotation_exists $(cat job1.id) "sched.reason_pending" &&
         test_must_fail jmgr_check_annotation_exists $(cat job1.id) "sched.jobs_ahead" &&

--- a/t/t2219-job-manager-restart.t
+++ b/t/t2219-job-manager-restart.t
@@ -22,7 +22,7 @@ restart_flux() {
 test_expect_success 'verify that job manager can restart with current dump' '
 	restart_flux dump.tar >stats.out
 '
-test_expect_success HAVE_JQ 'and max_jobid is greater than zero' '
+test_expect_success 'and max_jobid is greater than zero' '
 	jq -e ".max_jobid > 0" <stats.out
 '
 test_expect_success 'delete checkpoint from dump' '
@@ -34,7 +34,7 @@ test_expect_success 'delete checkpoint from dump' '
 test_expect_success 'verify that job manager can restart with modified dump' '
 	restart_flux dump-nock.tar >stats-nock.out
 '
-test_expect_success HAVE_JQ 'and max_jobid is still greater than zero' '
+test_expect_success 'and max_jobid is still greater than zero' '
 	jq -e ".max_jobid > 0" <stats-nock.out
 '
 test_expect_success 'delete job from dump' '
@@ -46,7 +46,7 @@ test_expect_success 'delete job from dump' '
 test_expect_success 'verify that job manager can restart with modified dump' '
 	restart_flux dump-nojob.tar >stats-nojob.out
 '
-test_expect_success HAVE_JQ 'and max_jobid is still greater than zero' '
+test_expect_success 'and max_jobid is still greater than zero' '
 	jq -e ".max_jobid > 0" <stats-nojob.out
 '
 

--- a/t/t2223-job-manager-queue-priority-order-limited.t
+++ b/t/t2223-job-manager-queue-priority-order-limited.t
@@ -21,7 +21,7 @@ test_expect_success 'job-manager: submit 6 jobs (differing urgencies)' '
         flux queue start
 '
 
-test_expect_success HAVE_JQ 'job-manager: job state SSSSRR' '
+test_expect_success 'job-manager: job state SSSSRR' '
         jmgr_check_state $(cat job1.id) S &&
         jmgr_check_state $(cat job2.id) S &&
         jmgr_check_state $(cat job3.id) S &&
@@ -30,7 +30,7 @@ test_expect_success HAVE_JQ 'job-manager: job state SSSSRR' '
         jmgr_check_state $(cat job6.id) R
 '
 
-test_expect_success HAVE_JQ 'job-manager: queue counts are as expected' '
+test_expect_success 'job-manager: queue counts are as expected' '
 	flux queue status -v >counts_all1.out &&
 	cat <<-EOT >counts_all1.exp &&
 	Job submission is enabled
@@ -51,7 +51,7 @@ test_expect_success 'job-manager: increase urgency job 3' '
         flux job urgency $(cat job3.id) 20
 '
 
-test_expect_success HAVE_JQ 'job-manager: queue counts are as expected' '
+test_expect_success 'job-manager: queue counts are as expected' '
 	flux queue status -v >counts_all2.out &&
 	cat <<-EOT >counts_all2.exp &&
 	Job submission is enabled
@@ -73,7 +73,7 @@ test_expect_success 'job-manager: start scheduling' '
 '
 
 # job 3 should run before over previously higher priority job 4
-test_expect_success HAVE_JQ 'job-manager: job state SSRSRI' '
+test_expect_success 'job-manager: job state SSRSRI' '
         jmgr_check_state $(cat job1.id) S &&
         jmgr_check_state $(cat job2.id) S &&
         jmgr_check_state $(cat job3.id) R &&
@@ -82,7 +82,7 @@ test_expect_success HAVE_JQ 'job-manager: job state SSRSRI' '
         jmgr_check_state $(cat job6.id) I
 '
 
-test_expect_success HAVE_JQ 'job-manager: queue counts are as expected' '
+test_expect_success 'job-manager: queue counts are as expected' '
 	flux queue status -v >counts_all3.out &&
 	cat <<-EOT >counts_all3.exp &&
 	Job submission is enabled
@@ -112,7 +112,7 @@ test_expect_success 'job-manager: start scheduling' '
 '
 
 # job 1 should have highest remaining priority and now run
-test_expect_success HAVE_JQ 'job-manager: job state RSRSII' '
+test_expect_success 'job-manager: job state RSRSII' '
         jmgr_check_state $(cat job1.id) R &&
         jmgr_check_state $(cat job2.id) S &&
         jmgr_check_state $(cat job3.id) R &&
@@ -151,7 +151,7 @@ test_expect_success 'job-manager: submit 5 jobs to each queue (differing urgenci
         flux queue start --all
 '
 
-test_expect_success HAVE_JQ 'job-manager: job state SSSSR / SSSSR' '
+test_expect_success 'job-manager: job state SSSSR / SSSSR' '
         jmgr_check_state $(cat batch1.id) S &&
         jmgr_check_state $(cat batch2.id) S &&
         jmgr_check_state $(cat batch3.id) S &&
@@ -164,7 +164,7 @@ test_expect_success HAVE_JQ 'job-manager: job state SSSSR / SSSSR' '
         jmgr_check_state $(cat debug5.id) R
 '
 
-test_expect_success HAVE_JQ 'job-manager: queue counts are as expected' '
+test_expect_success 'job-manager: queue counts are as expected' '
 	flux queue status -v >counts_named1.out &&
 	cat <<-EOT >counts_named1.exp &&
 	batch: Job submission is enabled
@@ -189,7 +189,7 @@ test_expect_success 'job-manager: cancel the two running jobs' '
 '
 
 # batch queue jobs should run instead of debug queue
-test_expect_success HAVE_JQ 'job-manager: job state SSRRI / SSSSI' '
+test_expect_success 'job-manager: job state SSRRI / SSSSI' '
         jmgr_check_state $(cat batch1.id) S &&
         jmgr_check_state $(cat batch2.id) S &&
         jmgr_check_state $(cat batch3.id) R &&
@@ -202,7 +202,7 @@ test_expect_success HAVE_JQ 'job-manager: job state SSRRI / SSSSI' '
         jmgr_check_state $(cat debug5.id) I
 '
 
-test_expect_success HAVE_JQ 'job-manager: queue counts are as expected' '
+test_expect_success 'job-manager: queue counts are as expected' '
 	flux queue status -v >counts_named2.out &&
 	cat <<-EOT >counts_named2.exp &&
 	batch: Job submission is enabled
@@ -231,7 +231,7 @@ test_expect_success 'job-manager: cancel the two running jobs' '
 '
 
 # debug job 2 and 4 should have highest priority now and be running
-test_expect_success HAVE_JQ 'job-manager: job state SSIII / SSRRI' '
+test_expect_success 'job-manager: job state SSIII / SSRRI' '
         jmgr_check_state $(cat batch1.id) S &&
         jmgr_check_state $(cat batch2.id) S &&
         jmgr_check_state $(cat batch3.id) I &&
@@ -244,7 +244,7 @@ test_expect_success HAVE_JQ 'job-manager: job state SSIII / SSRRI' '
         jmgr_check_state $(cat debug5.id) I
 '
 
-test_expect_success HAVE_JQ 'job-manager: queue counts are as expected' '
+test_expect_success 'job-manager: queue counts are as expected' '
 	flux queue status -v >counts_named3.out &&
 	cat <<-EOT >counts_named3.exp &&
 	batch: Job submission is enabled

--- a/t/t2224-job-manager-queue-priority-order-unlimited.t
+++ b/t/t2224-job-manager-queue-priority-order-unlimited.t
@@ -21,7 +21,7 @@ test_expect_success 'job-manager: submit 5 jobs (differing urgencies)' '
         flux queue start
 '
 
-test_expect_success HAVE_JQ 'job-manager: job state SSSRR' '
+test_expect_success 'job-manager: job state SSSRR' '
         jmgr_check_state $(cat job1.id) S &&
         jmgr_check_state $(cat job2.id) S &&
         jmgr_check_state $(cat job3.id) S &&
@@ -29,7 +29,7 @@ test_expect_success HAVE_JQ 'job-manager: job state SSSRR' '
         jmgr_check_state $(cat job5.id) R
 '
 
-test_expect_success HAVE_JQ 'job-manager: queue counts are as expected' '
+test_expect_success 'job-manager: queue counts are as expected' '
 	flux queue status -v >counts_all1.out &&
 	cat <<-EOT >counts_all1.exp &&
 	Job submission is enabled
@@ -50,7 +50,7 @@ test_expect_success 'job-manager: increase urgency job 1' '
         flux job urgency $(cat job1.id) 20
 '
 
-test_expect_success HAVE_JQ 'job-manager: queue counts are as expected' '
+test_expect_success 'job-manager: queue counts are as expected' '
 	flux queue status -v >counts_all2.out &&
 	cat <<-EOT >counts_all2.exp &&
 	Job submission is enabled
@@ -72,7 +72,7 @@ test_expect_success 'job-manager: start scheduling' '
 '
 
 # job 1 should run before over previously higher priority job 3
-test_expect_success HAVE_JQ 'job-manager: job state RSSRI' '
+test_expect_success 'job-manager: job state RSSRI' '
         jmgr_check_state $(cat job1.id) R &&
         jmgr_check_state $(cat job2.id) S &&
         jmgr_check_state $(cat job3.id) S &&
@@ -80,7 +80,7 @@ test_expect_success HAVE_JQ 'job-manager: job state RSSRI' '
         jmgr_check_state $(cat job5.id) I
 '
 
-test_expect_success HAVE_JQ 'job-manager: queue counts are as expected' '
+test_expect_success 'job-manager: queue counts are as expected' '
 	flux queue status -v >counts_all3.out &&
 	cat <<-EOT >counts_all3.exp &&
 	Job submission is enabled
@@ -122,7 +122,7 @@ test_expect_success 'job-manager: submit 5 jobs to each queue (differing urgenci
         flux queue start --all
 '
 
-test_expect_success HAVE_JQ 'job-manager: job state SSSSR / SSSSR' '
+test_expect_success 'job-manager: job state SSSSR / SSSSR' '
         jmgr_check_state $(cat batch1.id) S &&
         jmgr_check_state $(cat batch2.id) S &&
         jmgr_check_state $(cat batch3.id) S &&
@@ -135,7 +135,7 @@ test_expect_success HAVE_JQ 'job-manager: job state SSSSR / SSSSR' '
         jmgr_check_state $(cat debug5.id) R
 '
 
-test_expect_success HAVE_JQ 'job-manager: queue counts are as expected' '
+test_expect_success 'job-manager: queue counts are as expected' '
 	flux queue status -v >counts_named1.out &&
 	cat <<-EOT >counts_named1.exp &&
 	batch: Job submission is enabled
@@ -160,7 +160,7 @@ test_expect_success 'job-manager: cancel the two running jobs' '
 '
 
 # batch queue jobs should run instead of debug queue
-test_expect_success HAVE_JQ 'job-manager: job state SSRRI / SSSSI' '
+test_expect_success 'job-manager: job state SSRRI / SSSSI' '
         jmgr_check_state $(cat batch1.id) S &&
         jmgr_check_state $(cat batch2.id) S &&
         jmgr_check_state $(cat batch3.id) R &&
@@ -173,7 +173,7 @@ test_expect_success HAVE_JQ 'job-manager: job state SSRRI / SSSSI' '
         jmgr_check_state $(cat debug5.id) I
 '
 
-test_expect_success HAVE_JQ 'job-manager: queue counts are as expected' '
+test_expect_success 'job-manager: queue counts are as expected' '
 	flux queue status -v >counts_named2.out &&
 	cat <<-EOT >counts_named2.exp &&
 	batch: Job submission is enabled
@@ -202,7 +202,7 @@ test_expect_success 'job-manager: cancel the two running jobs' '
 '
 
 # debug job 2 and 4 should have highest priority now and be running
-test_expect_success HAVE_JQ 'job-manager: job state SSIII / RSSRI' '
+test_expect_success 'job-manager: job state SSIII / RSSRI' '
         jmgr_check_state $(cat batch1.id) S &&
         jmgr_check_state $(cat batch2.id) S &&
         jmgr_check_state $(cat batch3.id) I &&
@@ -215,7 +215,7 @@ test_expect_success HAVE_JQ 'job-manager: job state SSIII / RSSRI' '
         jmgr_check_state $(cat debug5.id) I
 '
 
-test_expect_success HAVE_JQ 'job-manager: queue counts are as expected' '
+test_expect_success 'job-manager: queue counts are as expected' '
 	flux queue status -v >counts_named3.out &&
 	cat <<-EOT >counts_named3.exp &&
 	batch: Job submission is enabled

--- a/t/t2240-queue-cmd.t
+++ b/t/t2240-queue-cmd.t
@@ -125,7 +125,7 @@ test_expect_success 'flux-queue: status reports no reason for stop' '
 	test_cmp status2.exp status2.out
 '
 
-test_expect_success HAVE_JQ 'flux-queue: stop with --nocheckpoint works' '
+test_expect_success 'flux-queue: stop with --nocheckpoint works' '
 	flux start \
 	    -o,-Scontent.dump=dump_queue_nocheckpoint1.tar \
 	    flux queue stop &&
@@ -533,7 +533,7 @@ test_expect_success 'previously submitted job run to completion' '
 	flux jobs -n -o "{state}" $(cat job_batch2.id) | grep INACTIVE
 '
 
-test_expect_success HAVE_JQ 'flux-queue: stop with named queues and --nocheckpoint works' '
+test_expect_success 'flux-queue: stop with named queues and --nocheckpoint works' '
 	mkdir -p conf.d &&
 	cat >conf.d/queues.toml <<-EOT &&
 	[queues.debug]

--- a/t/t2260-job-list.t
+++ b/t/t2260-job-list.t
@@ -135,7 +135,7 @@ test_expect_success 'submit jobs for job list testing' '
 # since we happen to know all these jobs are in the "run" state given
 # checks above
 
-test_expect_success HAVE_JQ 'flux job list running jobs in started order' '
+test_expect_success 'flux job list running jobs in started order' '
         flux job list -s running | jq .id > list_started1.out &&
         flux job list -s run,cleanup | jq .id > list_started2.out &&
         flux job list -s run | jq .id > list_started3.out &&
@@ -144,7 +144,7 @@ test_expect_success HAVE_JQ 'flux job list running jobs in started order' '
         test_cmp list_started3.out running.ids
 '
 
-test_expect_success HAVE_JQ 'flux job list running jobs with correct state' '
+test_expect_success 'flux job list running jobs with correct state' '
         for count in `seq 1 8`; do \
             echo "RUN" >> list_state_R.exp; \
         done &&
@@ -156,17 +156,17 @@ test_expect_success HAVE_JQ 'flux job list running jobs with correct state' '
         test_cmp list_state_R3.out list_state_R.exp
 '
 
-test_expect_success HAVE_JQ 'flux job list no jobs in cleanup state' '
+test_expect_success 'flux job list no jobs in cleanup state' '
         count=$(flux job list -s cleanup | wc -l) &&
         test $count -eq 0
 '
 
-test_expect_success HAVE_JQ 'flux job list inactive jobs in completed order' '
+test_expect_success 'flux job list inactive jobs in completed order' '
         flux job list -s inactive | jq .id > list_inactive.out &&
         test_cmp list_inactive.out inactive.ids
 '
 
-test_expect_success HAVE_JQ 'flux job list inactive jobs with correct state' '
+test_expect_success 'flux job list inactive jobs with correct state' '
         for count in `seq 1 $(job_list_state_count inactive)`; do \
             echo "INACTIVE" >> list_state_I.exp; \
         done &&
@@ -174,7 +174,7 @@ test_expect_success HAVE_JQ 'flux job list inactive jobs with correct state' '
         test_cmp list_state_I.out list_state_I.exp
 '
 
-test_expect_success HAVE_JQ 'flux job list inactive jobs results are correct' '
+test_expect_success 'flux job list inactive jobs results are correct' '
         flux job list -s inactive | jq .result | ${JOB_CONV} resulttostr > list_result_I.out &&
         echo "CANCELED" >> list_result_I.exp &&
         echo "TIMEOUT" >> list_result_I.exp &&
@@ -188,7 +188,7 @@ test_expect_success HAVE_JQ 'flux job list inactive jobs results are correct' '
 # Hard code results values for these tests, as we did not add a results
 # option to flux_job_list() or the flux-job command.
 
-test_expect_success HAVE_JQ 'flux job list only canceled jobs' '
+test_expect_success 'flux job list only canceled jobs' '
         id=$(id -u) &&
         state=`${JOB_CONV} strtostate INACTIVE` &&
         result=`${JOB_CONV} strtoresult CANCELED` &&
@@ -197,7 +197,7 @@ test_expect_success HAVE_JQ 'flux job list only canceled jobs' '
         test_cmp canceled.ids list_result_canceled.out
 '
 
-test_expect_success HAVE_JQ 'flux job list only failed jobs' '
+test_expect_success 'flux job list only failed jobs' '
         id=$(id -u) &&
         state=`${JOB_CONV} strtostate INACTIVE` &&
         result=`${JOB_CONV} strtoresult FAILED` &&
@@ -206,7 +206,7 @@ test_expect_success HAVE_JQ 'flux job list only failed jobs' '
         test_cmp failed.ids list_result_failed.out
 '
 
-test_expect_success HAVE_JQ 'flux job list only timeout jobs' '
+test_expect_success 'flux job list only timeout jobs' '
         id=$(id -u) &&
         state=`${JOB_CONV} strtostate INACTIVE` &&
         result=`${JOB_CONV} strtoresult TIMEOUT` &&
@@ -215,7 +215,7 @@ test_expect_success HAVE_JQ 'flux job list only timeout jobs' '
         test_cmp timeout.ids list_result_timeout.out
 '
 
-test_expect_success HAVE_JQ 'flux job list only completed jobs' '
+test_expect_success 'flux job list only completed jobs' '
         id=$(id -u) &&
         state=`${JOB_CONV} strtostate INACTIVE` &&
         result=`${JOB_CONV} strtoresult COMPLETED` &&
@@ -228,7 +228,7 @@ test_expect_success HAVE_JQ 'flux job list only completed jobs' '
 # state since we happen to know all these jobs are in the "sched"
 # state given checks above
 
-test_expect_success HAVE_JQ 'flux job list pending jobs in priority order' '
+test_expect_success 'flux job list pending jobs in priority order' '
         flux job list -s pending | jq .id > list_pending1.out &&
         flux job list -s depend,priority,sched | jq .id > list_pending2.out &&
         flux job list -s sched | jq .id > list_pending3.out &&
@@ -237,7 +237,7 @@ test_expect_success HAVE_JQ 'flux job list pending jobs in priority order' '
         test_cmp list_pending3.out pending.ids
 '
 
-test_expect_success HAVE_JQ 'flux job list pending jobs with correct urgency' '
+test_expect_success 'flux job list pending jobs with correct urgency' '
         cat >list_urgency.exp <<-EOT &&
 31
 31
@@ -256,7 +256,7 @@ EOT
         test_cmp list_urgency3.out list_urgency.exp
 '
 
-test_expect_success HAVE_JQ 'flux job list pending jobs with correct priority' '
+test_expect_success 'flux job list pending jobs with correct priority' '
         cat >list_priority.exp <<-EOT &&
 4294967295
 4294967295
@@ -275,7 +275,7 @@ EOT
         test_cmp list_priority3.out list_priority.exp
 '
 
-test_expect_success HAVE_JQ 'flux job list pending jobs with correct state' '
+test_expect_success 'flux job list pending jobs with correct state' '
         for count in `seq 1 8`; do \
             echo "SCHED" >> list_state_S.exp; \
         done &&
@@ -283,14 +283,14 @@ test_expect_success HAVE_JQ 'flux job list pending jobs with correct state' '
         test_cmp list_state_S.out list_state_S.exp
 '
 
-test_expect_success HAVE_JQ 'flux job list no jobs in depend state' '
+test_expect_success 'flux job list no jobs in depend state' '
         count=$(flux job list -s depend | wc -l) &&
         test $count -eq 0
 '
 
 # Note: "active" = "pending" | "running", i.e. depend, priority,
 # sched, run, cleanup
-test_expect_success HAVE_JQ 'flux job list active jobs in correct order' '
+test_expect_success 'flux job list active jobs in correct order' '
         flux job list -s active | jq .id > list_active1.out &&
         flux job list -s depend,priority,sched,run,cleanup | jq .id > list_active2.out &&
         flux job list -s sched,run | jq .id > list_active3.out &&
@@ -299,7 +299,7 @@ test_expect_success HAVE_JQ 'flux job list active jobs in correct order' '
         test_cmp list_active3.out active.ids
 '
 
-test_expect_success HAVE_JQ 'flux job list jobs with correct userid' '
+test_expect_success 'flux job list jobs with correct userid' '
         for count in `seq 1 $(job_list_state_count all)`; do \
             id -u >> list_userid.exp; \
         done &&
@@ -307,7 +307,7 @@ test_expect_success HAVE_JQ 'flux job list jobs with correct userid' '
         test_cmp list_userid.out list_userid.exp
 '
 
-test_expect_success HAVE_JQ 'flux job list defaults to listing pending & running jobs' '
+test_expect_success 'flux job list defaults to listing pending & running jobs' '
         flux job list | jq .id > list_default.out &&
         count=$(wc -l < list_default.out) &&
         test $count = $(job_list_state_count active) &&
@@ -328,7 +328,7 @@ test_expect_success 'flux job list --user=all works' '
 '
 
 # we hard count numbers here b/c its a --count test
-test_expect_success HAVE_JQ 'flux job list --count works' '
+test_expect_success 'flux job list --count works' '
         flux job list -s active,inactive --count=12 | jq .id > list_count.out &&
         count=$(wc -l < list_count.out) &&
         test "$count" = "12" &&
@@ -337,13 +337,13 @@ test_expect_success HAVE_JQ 'flux job list --count works' '
         test_cmp list_count.out list_count.exp
 '
 
-test_expect_success HAVE_JQ 'flux job list all jobs works' '
+test_expect_success 'flux job list all jobs works' '
         flux job list -a | jq .id > list_all_jobids.out &&
         test_cmp all.ids list_all_jobids.out
 '
 
 # with single anonymous queue, queues arrays should be zero length
-test_expect_success HAVE_JQ 'job stats lists jobs in correct state (mix)' '
+test_expect_success 'job stats lists jobs in correct state (mix)' '
         flux job stats | jq -e ".job_states.depend == 0" &&
         flux job stats | jq -e ".job_states.priority == 0" &&
         flux job stats | jq -e ".job_states.sched == $(job_list_state_count pending)" &&
@@ -390,14 +390,14 @@ test_expect_success 'reload the job-list module' '
         wait_inactive
 '
 
-test_expect_success HAVE_JQ 'job-list: list successfully reconstructed' '
+test_expect_success 'job-list: list successfully reconstructed' '
         flux job list -a > after_reload.out &&
         test_cmp before_reload.out after_reload.out
 '
 
 # the failed and canceled checks may look confusing.  We canceled all active jobs
 # right above here, so all those active jobs became failed / canceled as a result
-test_expect_success HAVE_JQ 'job stats lists jobs in correct state (all inactive)' '
+test_expect_success 'job stats lists jobs in correct state (all inactive)' '
         flux job stats | jq -e ".job_states.depend == 0" &&
         flux job stats | jq -e ".job_states.priority == 0" &&
         flux job stats | jq -e ".job_states.sched == 0" &&
@@ -416,58 +416,58 @@ test_expect_success HAVE_JQ 'job stats lists jobs in correct state (all inactive
 
 # job list-inactive
 
-test_expect_success HAVE_JQ 'flux job list-inactive lists all inactive jobs' '
+test_expect_success 'flux job list-inactive lists all inactive jobs' '
         flux job list-inactive > list-inactive.out &&
         count=`cat list-inactive.out | wc -l` &&
         test $count -eq $(job_list_state_count all)
 '
 
-test_expect_success HAVE_JQ 'flux job list-inactive w/ since 0 lists all inactive jobs' '
+test_expect_success 'flux job list-inactive w/ since 0 lists all inactive jobs' '
         count=`flux job list-inactive --since=0 | wc -l` &&
         test $count -eq $(job_list_state_count all)
 '
 
 # we hard count numbers here b/c its a --count test
-test_expect_success HAVE_JQ 'flux job list-inactive w/ count limits output of inactive jobs' '
+test_expect_success 'flux job list-inactive w/ count limits output of inactive jobs' '
         count=`flux job list-inactive --count=14 | wc -l` &&
         test $count -eq 14
 '
 
-test_expect_success HAVE_JQ 'flux job list-inactive w/ since -1 leads to error' '
+test_expect_success 'flux job list-inactive w/ since -1 leads to error' '
         test_must_fail flux job list-inactive --since=-1 > list_inactive_error1.out 2>&1 &&
         grep "Invalid argument" list_inactive_error1.out
 '
 
-test_expect_success HAVE_JQ 'flux job list-inactive w/ count -1 leads to error' '
+test_expect_success 'flux job list-inactive w/ count -1 leads to error' '
         test_must_fail flux job list-inactive --count=-1 > list_inactive_error2.out 2>&1 &&
         grep "Invalid argument" list_inactive_error1.out
 '
 
-test_expect_success HAVE_JQ 'flux job list-inactive w/ since (most recent timestamp)' '
+test_expect_success 'flux job list-inactive w/ since (most recent timestamp)' '
         timestamp=`cat list-inactive.out | head -n 1 | jq .t_inactive` &&
         count=`flux job list-inactive --since=${timestamp} | wc -l` &&
         test $count -eq 0
 '
 
-test_expect_success HAVE_JQ 'flux job list-inactive w/ since (second to most recent timestamp)' '
+test_expect_success 'flux job list-inactive w/ since (second to most recent timestamp)' '
         timestamp=`cat list-inactive.out | head -n 2 | tail -n 1 | jq .t_inactive` &&
         count=`flux job list-inactive --since=${timestamp} | wc -l` &&
         test $count -eq 1
 '
 
-test_expect_success HAVE_JQ 'flux job list-inactive w/ since (oldest timestamp)' '
+test_expect_success 'flux job list-inactive w/ since (oldest timestamp)' '
         timestamp=`cat list-inactive.out | tail -n 1 | jq .t_inactive` &&
         count=`flux job list-inactive --since=${timestamp} | wc -l` &&
         test $count -eq 22
 '
 
-test_expect_success HAVE_JQ 'flux job list-inactive w/ since (middle timestamp #1)' '
+test_expect_success 'flux job list-inactive w/ since (middle timestamp #1)' '
         timestamp=`cat list-inactive.out | head -n 8 | tail -n 1 | jq .t_inactive` &&
         count=`flux job list-inactive --since=${timestamp} | wc -l` &&
         test $count -eq 7
 '
 
-test_expect_success HAVE_JQ 'flux job list-inactive w/ since (middle timestamp #2)' '
+test_expect_success 'flux job list-inactive w/ since (middle timestamp #2)' '
         timestamp=`cat list-inactive.out | head -n 13 | tail -n 1 | jq .t_inactive` &&
         count=`flux job list-inactive --since=${timestamp} | wc -l` &&
         test $count -eq 12
@@ -476,7 +476,7 @@ test_expect_success HAVE_JQ 'flux job list-inactive w/ since (middle timestamp #
 
 # job list-id
 
-test_expect_success HAVE_JQ 'flux job list-ids works with a single ID' '
+test_expect_success 'flux job list-ids works with a single ID' '
         id=`head -n 1 pending.ids` &&
         flux job list-ids $id | jq -e ".id == ${id}" &&
         id=`head -n 1 running.ids` &&
@@ -485,7 +485,7 @@ test_expect_success HAVE_JQ 'flux job list-ids works with a single ID' '
         flux job list-ids $id | jq -e ".id == ${id}"
 '
 
-test_expect_success HAVE_JQ 'flux job list-ids multiple IDs works' '
+test_expect_success 'flux job list-ids multiple IDs works' '
         ids=$(job_list_state_ids pending) &&
         flux job list-ids $ids | jq .id > list_idsP.out &&
         test_cmp list_idsP.out pending.ids &&
@@ -501,22 +501,22 @@ test_expect_success HAVE_JQ 'flux job list-ids multiple IDs works' '
         test_cmp list_idsPRI.exp list_idsPRI.out
 '
 
-test_expect_success HAVE_JQ 'flux job list-ids fails without ID' '
+test_expect_success 'flux job list-ids fails without ID' '
         test_must_fail flux job list-ids > list_ids_error1.out 2>&1 &&
         grep "Usage" list_ids_error1.out
 '
 
-test_expect_success HAVE_JQ 'flux job list-ids fails with bad ID' '
+test_expect_success 'flux job list-ids fails with bad ID' '
         test_must_fail flux job list-ids 1234567890 > list_ids_error2.out 2>&1 &&
         grep "No such file or directory" list_ids_error2.out
 '
 
-test_expect_success HAVE_JQ 'flux job list-ids fails with not an ID' '
+test_expect_success 'flux job list-ids fails with not an ID' '
         test_must_fail flux job list-ids foobar > list_ids_error3.out 2>&1 &&
         grep "No such file or directory" list_ids_error3.out
 '
 
-test_expect_success HAVE_JQ 'flux job list-ids fails with one bad ID out of several' '
+test_expect_success 'flux job list-ids fails with one bad ID out of several' '
         id1=`head -n 1 pending.ids` &&
         id2=`head -n 1 running.ids` &&
         id3=`head -n 1 inactive.ids` &&
@@ -551,7 +551,7 @@ wait_idsync() {
         return 0
 }
 
-test_expect_success HAVE_JQ,NO_CHAIN_LINT 'flux job list-ids waits for job ids (one id)' '
+test_expect_success NO_CHAIN_LINT 'flux job list-ids waits for job ids (one id)' '
 	${RPC} job-list.job-state-pause 0 </dev/null
         jobid=`flux submit --wait hostname | flux job id`
         flux job list-ids ${jobid} > list_id_wait1.out &
@@ -562,7 +562,7 @@ test_expect_success HAVE_JQ,NO_CHAIN_LINT 'flux job list-ids waits for job ids (
         cat list_id_wait1.out | jq -e ".id == ${jobid}"
 '
 
-test_expect_success HAVE_JQ,NO_CHAIN_LINT 'flux job list-ids waits for job ids (different ids)' '
+test_expect_success NO_CHAIN_LINT 'flux job list-ids waits for job ids (different ids)' '
 	${RPC} job-list.job-state-pause 0 </dev/null
         jobid1=`flux submit --wait hostname | flux job id`
         jobid2=`flux submit --wait hostname | flux job id`
@@ -575,7 +575,7 @@ test_expect_success HAVE_JQ,NO_CHAIN_LINT 'flux job list-ids waits for job ids (
         grep ${jobid2} list_id_wait2.out
 '
 
-test_expect_success HAVE_JQ,NO_CHAIN_LINT 'flux job list-ids waits for job ids (same id)' '
+test_expect_success NO_CHAIN_LINT 'flux job list-ids waits for job ids (same id)' '
 	${RPC} job-list.job-state-pause 0 </dev/null
         jobid=`flux submit --wait hostname | flux job id`
         flux job list-ids ${jobid} > list_id_wait3A.out &
@@ -595,7 +595,7 @@ test_expect_success HAVE_JQ,NO_CHAIN_LINT 'flux job list-ids waits for job ids (
 #
 
 # simply test that value in timestamp increases through job states
-test_expect_success HAVE_JQ 'flux job list job state timing outputs valid (job inactive)' '
+test_expect_success 'flux job list job state timing outputs valid (job inactive)' '
         jobid=$(flux submit --wait hostname | flux job id) &&
         wait_jobid_state $jobid inactive &&
         obj=$(flux job list -s inactive | grep $jobid) &&
@@ -606,7 +606,7 @@ test_expect_success HAVE_JQ 'flux job list job state timing outputs valid (job i
 '
 
 # since job is running, make sure latter states don't exist
-test_expect_success HAVE_JQ 'flux job list job state timing outputs valid (job running)' '
+test_expect_success 'flux job list job state timing outputs valid (job running)' '
         jobid=$(flux submit sleep 60 | flux job id) &&
         fj_wait_event $jobid start >/dev/null &&
         wait_jobid_state $jobid running &&
@@ -623,28 +623,28 @@ test_expect_success HAVE_JQ 'flux job list job state timing outputs valid (job r
 # job names
 #
 
-test_expect_success HAVE_JQ 'flux job list outputs user job name' '
+test_expect_success 'flux job list outputs user job name' '
         jobid=`flux submit --wait --setattr system.job.name=foobar A B C | flux job id` &&
         echo $jobid > jobname1.id &&
         wait_jobid_state $jobid inactive &&
         flux job list -s inactive | grep $jobid | jq -e ".name == \"foobar\""
 '
 
-test_expect_success HAVE_JQ 'flux job lists first argument for job name' '
+test_expect_success 'flux job lists first argument for job name' '
         jobid=`flux submit --wait mycmd arg1 arg2 | flux job id` &&
         echo $jobid > jobname2.id &&
         wait_jobid_state $jobid inactive &&
         flux job list -s inactive | grep $jobid | jq -e ".name == \"mycmd\""
 '
 
-test_expect_success HAVE_JQ 'flux job lists basename of first argument for job name' '
+test_expect_success 'flux job lists basename of first argument for job name' '
         jobid=`flux submit --wait /foo/bar arg1 arg2 | flux job id` &&
         echo $jobid > jobname3.id &&
         wait_jobid_state $jobid inactive &&
         flux job list -s inactive | grep $jobid | jq -e ".name == \"bar\""
 '
 
-test_expect_success HAVE_JQ 'flux job lists full path for job name if basename fails on first arg' '
+test_expect_success 'flux job lists full path for job name if basename fails on first arg' '
         jobid=`flux submit --wait /foo/bar/ arg1 arg2 | flux job id` &&
         echo $jobid > jobname4.id &&
         wait_jobid_state $jobid inactive &&
@@ -655,7 +655,7 @@ test_expect_success 'reload the job-list module' '
         flux module reload job-list
 '
 
-test_expect_success HAVE_JQ 'verify job names preserved across restart' '
+test_expect_success 'verify job names preserved across restart' '
         jobid1=`cat jobname1.id` &&
         jobid2=`cat jobname2.id` &&
         jobid3=`cat jobname3.id` &&
@@ -670,7 +670,7 @@ test_expect_success HAVE_JQ 'verify job names preserved across restart' '
 # job queue
 #
 
-test_expect_success HAVE_JQ 'flux job list output no queue if queue not set' '
+test_expect_success 'flux job list output no queue if queue not set' '
         jobid=`flux submit --wait /bin/true | flux job id` &&
         echo $jobid > jobqueue1.id &&
         wait_jobid_state $jobid inactive &&
@@ -684,7 +684,7 @@ test_expect_success 'reconfigure with one queue' '
 	flux queue start --queue=foo
 '
 
-test_expect_success HAVE_JQ 'flux job list outputs queue' '
+test_expect_success 'flux job list outputs queue' '
         jobid=`flux submit --wait --queue=foo /bin/true | flux job id` &&
         echo $jobid > jobqueue2.id &&
         wait_jobid_state $jobid inactive &&
@@ -699,7 +699,7 @@ test_expect_success 'reload the job-list module' '
         flux module reload job-list
 '
 
-test_expect_success HAVE_JQ 'verify job queue preserved across restart' '
+test_expect_success 'verify job queue preserved across restart' '
         jobid1=`cat jobqueue1.id` &&
         jobid2=`cat jobqueue2.id` &&
         flux job list -s inactive | grep ${jobid1} | jq -e ".queue == null" &&
@@ -710,7 +710,7 @@ test_expect_success HAVE_JQ 'verify job queue preserved across restart' '
 # job task count
 #
 
-test_expect_success HAVE_JQ 'flux job list outputs ntasks correctly (1 task)' '
+test_expect_success 'flux job list outputs ntasks correctly (1 task)' '
         jobid=`flux submit --wait hostname | flux job id` &&
         echo $jobid > taskcount1.id &&
         wait_jobid_state $jobid inactive &&
@@ -718,7 +718,7 @@ test_expect_success HAVE_JQ 'flux job list outputs ntasks correctly (1 task)' '
         echo $obj | jq -e ".ntasks == 1"
 '
 
-test_expect_success HAVE_JQ 'flux job list outputs ntasks correctly (4 tasks)' '
+test_expect_success 'flux job list outputs ntasks correctly (4 tasks)' '
         jobid=`flux submit --wait -n4 hostname | flux job id` &&
         echo $jobid > taskcount2.id &&
         wait_jobid_state $jobid inactive &&
@@ -726,7 +726,7 @@ test_expect_success HAVE_JQ 'flux job list outputs ntasks correctly (4 tasks)' '
         echo $obj | jq -e ".ntasks == 4"
 '
 
-test_expect_success HAVE_JQ 'flux job list outputs ntasks correctly (4 nodes, 4 tasks)' '
+test_expect_success 'flux job list outputs ntasks correctly (4 nodes, 4 tasks)' '
         jobid=`flux submit --wait -N4 -n4 hostname | flux job id` &&
         echo $jobid > taskcount3.id &&
         wait_jobid_state $jobid inactive &&
@@ -735,7 +735,7 @@ test_expect_success HAVE_JQ 'flux job list outputs ntasks correctly (4 nodes, 4 
 '
 
 # not-evenly divisible tasks / nodes should force "total" count of tasks in jobspec
-test_expect_success HAVE_JQ 'flux job list outputs ntasks correctly (3 nodes, 4 tasks)' '
+test_expect_success 'flux job list outputs ntasks correctly (3 nodes, 4 tasks)' '
         jobid=`flux submit --wait -N3 -n4 hostname | flux job id` &&
         echo $jobid > taskcount4.id &&
         wait_jobid_state $jobid inactive &&
@@ -743,7 +743,7 @@ test_expect_success HAVE_JQ 'flux job list outputs ntasks correctly (3 nodes, 4 
         echo $obj | jq -e ".ntasks == 4"
 '
 
-test_expect_success HAVE_JQ 'flux job list outputs ntasks correctly (3 cores)' '
+test_expect_success 'flux job list outputs ntasks correctly (3 cores)' '
         jobid=`flux submit --wait --cores=3 hostname | flux job id` &&
         echo $jobid > taskcount5.id &&
         wait_jobid_state $jobid inactive &&
@@ -751,7 +751,7 @@ test_expect_success HAVE_JQ 'flux job list outputs ntasks correctly (3 cores)' '
         echo $obj | jq -e ".ntasks == 3"
 '
 
-test_expect_success HAVE_JQ 'flux job list outputs ntasks correctly (tasks-per-node)' '
+test_expect_success 'flux job list outputs ntasks correctly (tasks-per-node)' '
         jobid=`flux submit --wait -N2 --tasks-per-node=3 hostname | flux job id` &&
         echo $jobid > taskcount6.id &&
         wait_jobid_state $jobid inactive &&
@@ -762,7 +762,7 @@ test_expect_success HAVE_JQ 'flux job list outputs ntasks correctly (tasks-per-n
 # N.B. As of this test writing, tasks-per-node uses
 # per-resource.type=node.  But write more direct test in case of
 # future changes.
-test_expect_success HAVE_JQ 'flux job list outputs ntasks correctly (per-resource.type=node)' '
+test_expect_success 'flux job list outputs ntasks correctly (per-resource.type=node)' '
         totalnodes=$(flux resource list -s up -no {nnodes}) &&
         totalcores=$(flux resource list -s up -no {ncores}) &&
         extra=$((totalcores / totalnodes + 2)) &&
@@ -778,7 +778,7 @@ test_expect_success HAVE_JQ 'flux job list outputs ntasks correctly (per-resourc
         echo $obj | jq -e ".ntasks == ${expected}"
 '
 
-test_expect_success HAVE_JQ 'flux job list outputs ntasks correctly (cores / tasks-per-core)' '
+test_expect_success 'flux job list outputs ntasks correctly (cores / tasks-per-core)' '
         jobid=`flux submit --wait --cores=4 --tasks-per-core=2 hostname | flux job id` &&
         echo $jobid > taskcount8.id &&
         wait_jobid_state $jobid inactive &&
@@ -786,7 +786,7 @@ test_expect_success HAVE_JQ 'flux job list outputs ntasks correctly (cores / tas
         echo $obj | jq -e ".ntasks == 8"
 '
 
-test_expect_success HAVE_JQ 'flux job list outputs ntasks correctly (tasks / cores-per-task)' '
+test_expect_success 'flux job list outputs ntasks correctly (tasks / cores-per-task)' '
 	jobid=$(flux submit --wait -n2 --cores-per-task=2 \
 	        -o per-resource.type=core \
 	        -o per-resource.count=2 \
@@ -797,7 +797,7 @@ test_expect_success HAVE_JQ 'flux job list outputs ntasks correctly (tasks / cor
         echo $obj | jq -e ".ntasks == 8"
 '
 
-test_expect_success HAVE_JQ 'flux job list outputs ntasks correctly (nodes / tasks-per-core 2)' '
+test_expect_success 'flux job list outputs ntasks correctly (nodes / tasks-per-core 2)' '
         totalnodes=$(flux resource list -s up -no {nnodes}) &&
         totalcores=$(flux resource list -s up -no {ncores}) &&
         jobid=`flux submit --wait -N ${totalnodes} --tasks-per-core=2 hostname | flux job id` &&
@@ -812,7 +812,7 @@ test_expect_success HAVE_JQ 'flux job list outputs ntasks correctly (nodes / tas
 # N.B. As of this test writing, tasks-per-core uses
 # per-resource.type=core.  But write direct test in case of future
 # changes.
-test_expect_success HAVE_JQ 'flux job list outputs ntasks correctly (cores / per-resource.type=core)' '
+test_expect_success 'flux job list outputs ntasks correctly (cores / per-resource.type=core)' '
 	totalcores=$(flux resource list -s up -no {ncores}) &&
 	jobid=$(flux submit --wait --cores=${totalcores} \
 	        -o per-resource.type=core \
@@ -830,7 +830,7 @@ test_expect_success 'reload the job-list module' '
         flux module reload job-list
 '
 
-test_expect_success HAVE_JQ 'verify task count preserved across restart' '
+test_expect_success 'verify task count preserved across restart' '
         jobid1=`cat taskcount1.id` &&
         jobid2=`cat taskcount2.id` &&
         jobid3=`cat taskcount3.id` &&
@@ -873,7 +873,7 @@ test_expect_success HAVE_JQ 'verify task count preserved across restart' '
 # job core count
 #
 
-test_expect_success HAVE_JQ 'flux job list outputs ncores correctly (1 task)' '
+test_expect_success 'flux job list outputs ncores correctly (1 task)' '
         jobid=`flux submit --wait -n1 hostname | flux job id` &&
         echo $jobid > corecount1.id &&
         wait_jobid_state $jobid inactive &&
@@ -881,7 +881,7 @@ test_expect_success HAVE_JQ 'flux job list outputs ncores correctly (1 task)' '
         echo $obj | jq -e ".ncores == 1"
 '
 
-test_expect_success HAVE_JQ 'flux job list outputs ncores correctly (2 tasks)' '
+test_expect_success 'flux job list outputs ncores correctly (2 tasks)' '
         jobid=`flux submit --wait -n2 hostname | flux job id` &&
         echo $jobid > corecount2.id &&
         wait_jobid_state $jobid inactive &&
@@ -889,7 +889,7 @@ test_expect_success HAVE_JQ 'flux job list outputs ncores correctly (2 tasks)' '
         echo $obj | jq -e ".ncores == 2"
 '
 
-test_expect_success HAVE_JQ 'flux job list outputs ncores correctly (1 task, cores-per-task)' '
+test_expect_success 'flux job list outputs ncores correctly (1 task, cores-per-task)' '
         jobid=`flux submit --wait -n1 --cores-per-task=2 hostname | flux job id` &&
         echo $jobid > corecount3.id &&
         wait_jobid_state $jobid inactive &&
@@ -897,7 +897,7 @@ test_expect_success HAVE_JQ 'flux job list outputs ncores correctly (1 task, cor
         echo $obj | jq -e ".ncores == 2"
 '
 
-test_expect_success HAVE_JQ 'flux job list outputs ncores correctly (2 tasks, cores-per-task)' '
+test_expect_success 'flux job list outputs ncores correctly (2 tasks, cores-per-task)' '
         jobid=`flux submit --wait -n2 --cores-per-task=2 hostname | flux job id` &&
         echo $jobid > corecount4.id &&
         wait_jobid_state $jobid inactive &&
@@ -905,7 +905,7 @@ test_expect_success HAVE_JQ 'flux job list outputs ncores correctly (2 tasks, co
         echo $obj | jq -e ".ncores == 4"
 '
 
-test_expect_success HAVE_JQ 'flux job list outputs ncores correctly (1 node, 1 task)' '
+test_expect_success 'flux job list outputs ncores correctly (1 node, 1 task)' '
         jobid=`flux submit --wait -N1 -n1 hostname | flux job id` &&
         echo $jobid > corecount5.id &&
         wait_jobid_state $jobid inactive &&
@@ -913,7 +913,7 @@ test_expect_success HAVE_JQ 'flux job list outputs ncores correctly (1 node, 1 t
         echo $obj | jq -e ".ncores == 1"
 '
 
-test_expect_success HAVE_JQ 'flux job list outputs ncores correctly (1 node, 2 tasks)' '
+test_expect_success 'flux job list outputs ncores correctly (1 node, 2 tasks)' '
         jobid=`flux submit --wait -N1 -n2 hostname | flux job id` &&
         echo $jobid > corecount6.id &&
         wait_jobid_state $jobid inactive &&
@@ -921,7 +921,7 @@ test_expect_success HAVE_JQ 'flux job list outputs ncores correctly (1 node, 2 t
         echo $obj | jq -e ".ncores == 2"
 '
 
-test_expect_success HAVE_JQ 'flux job list outputs ncores correctly (2 nodes, 2 tasks)' '
+test_expect_success 'flux job list outputs ncores correctly (2 nodes, 2 tasks)' '
         jobid=`flux submit --wait -N2 -n2 hostname | flux job id` &&
         echo $jobid > corecount7.id &&
         wait_jobid_state $jobid inactive &&
@@ -929,7 +929,7 @@ test_expect_success HAVE_JQ 'flux job list outputs ncores correctly (2 nodes, 2 
         echo $obj | jq -e ".ncores == 2"
 '
 
-test_expect_success HAVE_JQ 'flux job list outputs ncores correctly (1 node, 1 task, exclusive)' '
+test_expect_success 'flux job list outputs ncores correctly (1 node, 1 task, exclusive)' '
         totalnodes=$(flux resource list -s up -no {nnodes}) &&
         totalcores=$(flux resource list -s up -no {ncores}) &&
         corespernode=$((totalcores / totalnodes)) &&
@@ -942,7 +942,7 @@ test_expect_success HAVE_JQ 'flux job list outputs ncores correctly (1 node, 1 t
         echo $obj | jq -e ".ncores == ${expected}"
 '
 
-test_expect_success HAVE_JQ 'flux job list outputs ncores correctly (1 node, 2 tasks, exclusive)' '
+test_expect_success 'flux job list outputs ncores correctly (1 node, 2 tasks, exclusive)' '
         totalnodes=$(flux resource list -s up -no {nnodes}) &&
         totalcores=$(flux resource list -s up -no {ncores}) &&
         corespernode=$((totalcores / totalnodes)) &&
@@ -955,7 +955,7 @@ test_expect_success HAVE_JQ 'flux job list outputs ncores correctly (1 node, 2 t
         echo $obj | jq -e ".ncores == ${expected}"
 '
 
-test_expect_success HAVE_JQ 'flux job list outputs ncores correctly (2 nodes, 2 tasks, exclusive)' '
+test_expect_success 'flux job list outputs ncores correctly (2 nodes, 2 tasks, exclusive)' '
         totalnodes=$(flux resource list -s up -no {nnodes}) &&
         totalcores=$(flux resource list -s up -no {ncores}) &&
         corespernode=$((totalcores / totalnodes)) &&
@@ -968,7 +968,7 @@ test_expect_success HAVE_JQ 'flux job list outputs ncores correctly (2 nodes, 2 
         echo $obj | jq -e ".ncores == ${expected}"
 '
 
-test_expect_success HAVE_JQ 'flux job list outputs ncores correctly (1 node, 1 task, cores-per-task)' '
+test_expect_success 'flux job list outputs ncores correctly (1 node, 1 task, cores-per-task)' '
         jobid=`flux submit --wait -N1 -n1 --cores-per-task=2 hostname | flux job id` &&
         echo $jobid > corecount11.id &&
         wait_jobid_state $jobid inactive &&
@@ -976,7 +976,7 @@ test_expect_success HAVE_JQ 'flux job list outputs ncores correctly (1 node, 1 t
         echo $obj | jq -e ".ncores == 2"
 '
 
-test_expect_success HAVE_JQ 'flux job list outputs ncores correctly (1 node, 1 task, cores-per-task)' '
+test_expect_success 'flux job list outputs ncores correctly (1 node, 1 task, cores-per-task)' '
         jobid=`flux submit --wait -N1 -n1 --cores-per-task=2 hostname | flux job id` &&
         echo $jobid > corecount12.id &&
         wait_jobid_state $jobid inactive &&
@@ -984,7 +984,7 @@ test_expect_success HAVE_JQ 'flux job list outputs ncores correctly (1 node, 1 t
         echo $obj | jq -e ".ncores == 2"
 '
 
-test_expect_success HAVE_JQ 'flux job list outputs ncores correctly (2 nodes, 2 tasks, cores-per-task)' '
+test_expect_success 'flux job list outputs ncores correctly (2 nodes, 2 tasks, cores-per-task)' '
         jobid=`flux submit --wait -N2 -n2 --cores-per-task=2 hostname | flux job id` &&
         echo $jobid > corecount13.id &&
         wait_jobid_state $jobid inactive &&
@@ -992,7 +992,7 @@ test_expect_success HAVE_JQ 'flux job list outputs ncores correctly (2 nodes, 2 
         echo $obj | jq -e ".ncores == 4"
 '
 
-test_expect_success HAVE_JQ 'flux job list outputs ncores correctly (1 core)' '
+test_expect_success 'flux job list outputs ncores correctly (1 core)' '
         jobid=`flux submit --wait --cores=1 hostname | flux job id` &&
         echo $jobid > corecount14.id &&
         wait_jobid_state $jobid inactive &&
@@ -1000,7 +1000,7 @@ test_expect_success HAVE_JQ 'flux job list outputs ncores correctly (1 core)' '
         echo $obj | jq -e ".ncores == 1"
 '
 
-test_expect_success HAVE_JQ 'flux job list outputs ncores correctly (2 cores)' '
+test_expect_success 'flux job list outputs ncores correctly (2 cores)' '
         jobid=`flux submit --wait --cores=2 hostname | flux job id` &&
         echo $jobid > corecount15.id &&
         wait_jobid_state $jobid inactive &&
@@ -1008,7 +1008,7 @@ test_expect_success HAVE_JQ 'flux job list outputs ncores correctly (2 cores)' '
         echo $obj | jq -e ".ncores == 2"
 '
 
-test_expect_success HAVE_JQ 'flux job list outputs ncores correctly (1 node, 1 core)' '
+test_expect_success 'flux job list outputs ncores correctly (1 node, 1 core)' '
         jobid=`flux submit --wait -N1 --cores=1 hostname | flux job id` &&
         echo $jobid > corecount16.id &&
         wait_jobid_state $jobid inactive &&
@@ -1016,7 +1016,7 @@ test_expect_success HAVE_JQ 'flux job list outputs ncores correctly (1 node, 1 c
         echo $obj | jq -e ".ncores == 1"
 '
 
-test_expect_success HAVE_JQ 'flux job list outputs ncores correctly (1 node, 2 cores)' '
+test_expect_success 'flux job list outputs ncores correctly (1 node, 2 cores)' '
         jobid=`flux submit --wait -N1 --cores=2 hostname | flux job id` &&
         echo $jobid > corecount17.id &&
         wait_jobid_state $jobid inactive &&
@@ -1024,7 +1024,7 @@ test_expect_success HAVE_JQ 'flux job list outputs ncores correctly (1 node, 2 c
         echo $obj | jq -e ".ncores == 2"
 '
 
-test_expect_success HAVE_JQ 'flux job list outputs ncores correctly (2 nodes, 2 cores)' '
+test_expect_success 'flux job list outputs ncores correctly (2 nodes, 2 cores)' '
         jobid=`flux submit --wait -N2 --cores=2 hostname | flux job id` &&
         echo $jobid > corecount18.id &&
         wait_jobid_state $jobid inactive &&
@@ -1032,7 +1032,7 @@ test_expect_success HAVE_JQ 'flux job list outputs ncores correctly (2 nodes, 2 
         echo $obj | jq -e ".ncores == 2"
 '
 
-test_expect_success HAVE_JQ 'flux job list outputs ncores correctly (1 node, 1 task, exclusive)' '
+test_expect_success 'flux job list outputs ncores correctly (1 node, 1 task, exclusive)' '
         totalnodes=$(flux resource list -s up -no {nnodes}) &&
         totalcores=$(flux resource list -s up -no {ncores}) &&
         corespernode=$((totalcores / totalnodes)) &&
@@ -1045,7 +1045,7 @@ test_expect_success HAVE_JQ 'flux job list outputs ncores correctly (1 node, 1 t
         echo $obj | jq -e ".ncores == ${expected}"
 '
 
-test_expect_success HAVE_JQ 'flux job list outputs ncores correctly (1 node, 2 tasks, exclusive)' '
+test_expect_success 'flux job list outputs ncores correctly (1 node, 2 tasks, exclusive)' '
         totalnodes=$(flux resource list -s up -no {nnodes}) &&
         totalcores=$(flux resource list -s up -no {ncores}) &&
         corespernode=$((totalcores / totalnodes)) &&
@@ -1058,7 +1058,7 @@ test_expect_success HAVE_JQ 'flux job list outputs ncores correctly (1 node, 2 t
         echo $obj | jq -e ".ncores == ${expected}"
 '
 
-test_expect_success HAVE_JQ 'flux job list outputs ncores correctly (2 nodes, 2 tasks, exclusive)' '
+test_expect_success 'flux job list outputs ncores correctly (2 nodes, 2 tasks, exclusive)' '
         totalnodes=$(flux resource list -s up -no {nnodes}) &&
         totalcores=$(flux resource list -s up -no {ncores}) &&
         corespernode=$((totalcores / totalnodes)) &&
@@ -1072,7 +1072,7 @@ test_expect_success HAVE_JQ 'flux job list outputs ncores correctly (2 nodes, 2 
 '
 
 # use flux queue to ensure jobs stay in pending state
-test_expect_success HAVE_JQ 'flux job list lists ncores if pending & tasks specified' '
+test_expect_success 'flux job list lists ncores if pending & tasks specified' '
         flux queue stop &&
         id=$(flux submit -n3 hostname | flux job id) &&
         flux job list -s pending | grep ${id} &&
@@ -1082,7 +1082,7 @@ test_expect_success HAVE_JQ 'flux job list lists ncores if pending & tasks speci
 '
 
 # use flux queue to ensure jobs stay in pending state
-test_expect_success HAVE_JQ 'flux job list does not list ncores if pending & nodes exclusive' '
+test_expect_success 'flux job list does not list ncores if pending & nodes exclusive' '
         flux queue stop &&
         id=$(flux submit -N1 --exclusive hostname | flux job id) &&
         flux job list -s pending | grep ${id} &&
@@ -1095,7 +1095,7 @@ test_expect_success 'reload the job-list module' '
         flux module reload job-list
 '
 
-test_expect_success HAVE_JQ 'verify core count preserved across restart' '
+test_expect_success 'verify core count preserved across restart' '
         jobid1=`cat corecount1.id` &&
         jobid2=`cat corecount2.id` &&
         jobid3=`cat corecount3.id` &&
@@ -1171,7 +1171,7 @@ test_expect_success HAVE_JQ 'verify core count preserved across restart' '
 # job node count
 #
 
-test_expect_success HAVE_JQ 'flux job list outputs nnodes correctly (1 task / 1 node)' '
+test_expect_success 'flux job list outputs nnodes correctly (1 task / 1 node)' '
         jobid=`flux submit --wait -n1 hostname | flux job id` &&
         echo $jobid > nodecount1.id &&
         wait_jobid_state $jobid inactive &&
@@ -1179,7 +1179,7 @@ test_expect_success HAVE_JQ 'flux job list outputs nnodes correctly (1 task / 1 
         echo $obj | jq -e ".nnodes == 1"
 '
 
-test_expect_success HAVE_JQ 'flux job list outputs nnodes correctly (2 tasks, / 1 node)' '
+test_expect_success 'flux job list outputs nnodes correctly (2 tasks, / 1 node)' '
         jobid=`flux submit --wait -n2 hostname | flux job id` &&
         echo $jobid > nodecount2.id &&
         wait_jobid_state $jobid inactive &&
@@ -1187,7 +1187,7 @@ test_expect_success HAVE_JQ 'flux job list outputs nnodes correctly (2 tasks, / 
         echo $obj | jq -e ".nnodes == 1"
 '
 
-test_expect_success HAVE_JQ 'flux job list outputs nnodes correctly (3 tasks, / 2 nodes)' '
+test_expect_success 'flux job list outputs nnodes correctly (3 tasks, / 2 nodes)' '
         jobid=`flux submit --wait -n3 hostname | flux job id` &&
         echo $jobid > nodecount3.id &&
         wait_jobid_state $jobid inactive &&
@@ -1195,7 +1195,7 @@ test_expect_success HAVE_JQ 'flux job list outputs nnodes correctly (3 tasks, / 
         echo $obj | jq -e ".nnodes == 2"
 '
 
-test_expect_success HAVE_JQ 'flux job list outputs nnodes correctly (5 tasks, / 3 nodes)' '
+test_expect_success 'flux job list outputs nnodes correctly (5 tasks, / 3 nodes)' '
         jobid=`flux submit --wait -n5 hostname | flux job id` &&
         echo $jobid > nodecount4.id &&
         wait_jobid_state $jobid inactive &&
@@ -1204,7 +1204,7 @@ test_expect_success HAVE_JQ 'flux job list outputs nnodes correctly (5 tasks, / 
 '
 
 # use flux queue to ensure jobs stay in pending state
-test_expect_success HAVE_JQ 'flux job list does not list nnodes if no nodes requested' '
+test_expect_success 'flux job list does not list nnodes if no nodes requested' '
         flux queue stop &&
         id=$(flux submit -n1 hostname | flux job id) &&
         flux job list -s pending | grep ${id} &&
@@ -1214,7 +1214,7 @@ test_expect_success HAVE_JQ 'flux job list does not list nnodes if no nodes requ
 '
 
 # use flux queue to ensure jobs stay in pending state
-test_expect_success HAVE_JQ 'flux job list lists nnodes for pending jobs if nodes requested' '
+test_expect_success 'flux job list lists nnodes for pending jobs if nodes requested' '
         flux queue stop &&
         id1=$(flux submit -N1 hostname | flux job id) &&
         id2=$(flux submit -N3 hostname | flux job id) &&
@@ -1230,7 +1230,7 @@ test_expect_success 'reload the job-list module' '
         flux module reload job-list
 '
 
-test_expect_success HAVE_JQ 'verify nnodes preserved across restart' '
+test_expect_success 'verify nnodes preserved across restart' '
         jobid1=`cat nodecount1.id` &&
         jobid2=`cat nodecount2.id` &&
         jobid3=`cat nodecount3.id` &&
@@ -1249,7 +1249,7 @@ test_expect_success HAVE_JQ 'verify nnodes preserved across restart' '
 # job rank list / nodelist
 #
 
-test_expect_success HAVE_JQ 'flux job list outputs ranks/nodelist correctly (1 node)' '
+test_expect_success 'flux job list outputs ranks/nodelist correctly (1 node)' '
         jobid=`flux submit --wait -N1 hostname | flux job id` &&
         echo $jobid > nodelist1.id &&
         wait_jobid_state $jobid inactive &&
@@ -1259,7 +1259,7 @@ test_expect_success HAVE_JQ 'flux job list outputs ranks/nodelist correctly (1 n
         echo $obj | jq -e ".nodelist == \"${nodes}\""
 '
 
-test_expect_success HAVE_JQ 'flux job list outputs ranks/nodelist correctly (3 nodes)' '
+test_expect_success 'flux job list outputs ranks/nodelist correctly (3 nodes)' '
         jobid=`flux submit --wait -N3 hostname | flux job id` &&
         echo $jobid > nodelist2.id &&
         wait_jobid_state $jobid inactive &&
@@ -1273,7 +1273,7 @@ test_expect_success 'reload the job-list module' '
         flux module reload job-list
 '
 
-test_expect_success HAVE_JQ 'verify ranks/nodelist preserved across restart' '
+test_expect_success 'verify ranks/nodelist preserved across restart' '
         jobid1=`cat nodelist1.id` &&
         jobid2=`cat nodelist2.id` &&
         obj=$(flux job list -s inactive | grep ${jobid1}) &&
@@ -1290,7 +1290,7 @@ test_expect_success HAVE_JQ 'verify ranks/nodelist preserved across restart' '
 # job success
 #
 
-test_expect_success HAVE_JQ 'flux job list outputs success correctly (true)' '
+test_expect_success 'flux job list outputs success correctly (true)' '
         jobid=`flux submit --wait hostname | flux job id` &&
         echo $jobid > success1.id &&
         wait_jobid_state $jobid inactive &&
@@ -1298,7 +1298,7 @@ test_expect_success HAVE_JQ 'flux job list outputs success correctly (true)' '
         echo $obj | jq -e ".success == true"
 '
 
-test_expect_success HAVE_JQ 'flux job list outputs success correctly (false)' '
+test_expect_success 'flux job list outputs success correctly (false)' '
         jobid=`flux submit --wait nosuchcommand | flux job id` &&
         echo $jobid > success2.id &&
         wait_jobid_state $jobid inactive &&
@@ -1310,7 +1310,7 @@ test_expect_success 'reload the job-list module' '
         flux module reload job-list
 '
 
-test_expect_success HAVE_JQ 'verify task count preserved across restart' '
+test_expect_success 'verify task count preserved across restart' '
         jobid1=`cat success1.id` &&
         jobid2=`cat success2.id` &&
         obj=$(flux job list -s inactive | grep ${jobid1}) &&
@@ -1321,7 +1321,7 @@ test_expect_success HAVE_JQ 'verify task count preserved across restart' '
 
 # job exceptions
 
-test_expect_success HAVE_JQ 'flux job list outputs exceptions correctly (no exception)' '
+test_expect_success 'flux job list outputs exceptions correctly (no exception)' '
         jobid=`flux submit --wait hostname | flux job id` &&
         echo $jobid > exceptions1.id &&
         wait_jobid_state $jobid inactive &&
@@ -1332,7 +1332,7 @@ test_expect_success HAVE_JQ 'flux job list outputs exceptions correctly (no exce
         echo $obj | jq -e ".exception_note == null"
 '
 
-test_expect_success HAVE_JQ 'flux job list outputs exceptions correctly (exception)' '
+test_expect_success 'flux job list outputs exceptions correctly (exception)' '
         jobid=`flux submit --wait nosuchcommand | flux job id` &&
         echo $jobid > exceptions2.id &&
         wait_jobid_state $jobid inactive &&
@@ -1347,7 +1347,7 @@ test_expect_success 'reload the job-list module' '
         flux module reload job-list
 '
 
-test_expect_success HAVE_JQ 'verify task count preserved across restart' '
+test_expect_success 'verify task count preserved across restart' '
         jobid1=`cat exceptions1.id` &&
         jobid2=`cat exceptions2.id` &&
         obj=$(flux job list -s inactive | grep ${jobid1}) &&
@@ -1365,7 +1365,7 @@ test_expect_success HAVE_JQ 'verify task count preserved across restart' '
 
 # expiration time
 
-test_expect_success HAVE_JQ 'flux job list outputs expiration time when set' '
+test_expect_success 'flux job list outputs expiration time when set' '
 	jobid=$(flux submit -t 500s sleep 1000 | flux job id) &&
 	echo $jobid > expiration.id &&
 	fj_wait_event $jobid start &&
@@ -1379,7 +1379,7 @@ test_expect_success 'reload the job-list module' '
         flux module reload job-list
 '
 
-test_expect_success HAVE_JQ 'verify task count preserved across restart' '
+test_expect_success 'verify task count preserved across restart' '
         jobid=`cat expiration.id` &&
         flux job list -s inactive | grep ${jobid} > expiration2.json &&
         jq -e ".expiration > now" < expiration2.json
@@ -1387,7 +1387,7 @@ test_expect_success HAVE_JQ 'verify task count preserved across restart' '
 
 # duration time
 
-test_expect_success HAVE_JQ 'flux job list outputs duration time when set' '
+test_expect_success 'flux job list outputs duration time when set' '
 	jobid=$(flux submit -t 60m sleep 1000 | flux job id) &&
         echo $jobid > duration.id &&
 	fj_wait_event $jobid start &&
@@ -1401,7 +1401,7 @@ test_expect_success 'reload the job-list module' '
         flux module reload job-list
 '
 
-test_expect_success HAVE_JQ 'verify task count preserved across restart' '
+test_expect_success 'verify task count preserved across restart' '
         jobid=`cat duration.id` &&
         flux job list -s inactive | grep ${jobid} > duration2.json &&
         jq -e ".duration == 3600.0" < duration2.json
@@ -1415,7 +1415,7 @@ test_expect_success HAVE_JQ 'verify task count preserved across restart' '
 #
 # so we check for all the core / expected attributes for the situation
 
-test_expect_success HAVE_JQ 'list request with all attr works (job success)' '
+test_expect_success 'list request with all attr works (job success)' '
         id=$(id -u) &&
         flux run hostname &&
         $jq -j -c -n  "{max_entries:1, userid:${id}, states:0, results:0, attrs:[\"all\"]}" \
@@ -1442,7 +1442,7 @@ test_expect_success HAVE_JQ 'list request with all attr works (job success)' '
         cat all_success.out | jq -e ".expiration"
 '
 
-test_expect_success HAVE_JQ 'list request with all attr works (job fail)' '
+test_expect_success 'list request with all attr works (job fail)' '
         id=$(id -u) &&
         ! flux run -N1000 -n1000 hostname &&
         $jq -j -c -n  "{max_entries:1, userid:${id}, states:0, results:0, attrs:[\"all\"]}" \
@@ -1550,7 +1550,7 @@ waitstatus \
 dependencies
 "
 
-test_expect_success HAVE_JQ 'list request with empty attrs works' '
+test_expect_success 'list request with empty attrs works' '
         id=$(id -u) &&
         $jq -j -c -n  "{max_entries:5, userid:${id}, states:0, results:0, attrs:[]}" \
           | $RPC job-list.list > list_empty_attrs.out &&
@@ -1558,7 +1558,7 @@ test_expect_success HAVE_JQ 'list request with empty attrs works' '
 	    test_must_fail grep $attr list_empty_attrs.out
 	done
 '
-test_expect_success HAVE_JQ 'list request with excessive max_entries works' '
+test_expect_success 'list request with excessive max_entries works' '
         id=$(id -u) &&
         $jq -j -c -n  "{max_entries:100000, userid:${id}, states:0, results:0, attrs:[]}" \
           | $RPC job-list.list
@@ -1567,7 +1567,7 @@ test_expect_success HAVE_JQ 'list request with excessive max_entries works' '
 # list-attrs also lists the special attribute 'all'
 LIST_ATTRIBUTES="${JOB_ATTRIBUTES} all"
 
-test_expect_success HAVE_JQ 'list-attrs works' '
+test_expect_success 'list-attrs works' '
         $RPC job-list.list-attrs < /dev/null > list_attrs.out &&
 	for attr in $LIST_ATTRIBUTES; do
 	    grep $attr list_attrs.out
@@ -1589,7 +1589,7 @@ test_expect_success 'job-list stats works' '
 test_expect_success 'list request with empty payload fails with EPROTO(71)' '
 	${RPC} job-list.list 71 </dev/null
 '
-test_expect_success HAVE_JQ 'list request with invalid input fails with EPROTO(71) (attrs not an array)' '
+test_expect_success 'list request with invalid input fails with EPROTO(71) (attrs not an array)' '
 	name="attrs-not-array" &&
         id=$(id -u) &&
         $jq -j -c -n  "{max_entries:5, userid:${id}, states:0, results:0, attrs:5}" \
@@ -1599,7 +1599,7 @@ test_expect_success HAVE_JQ 'list request with invalid input fails with EPROTO(7
 	EOF
 	test_cmp ${name}.expected ${name}.out
 '
-test_expect_success HAVE_JQ 'list request with invalid input fails with EINVAL(22) (attrs non-string)' '
+test_expect_success 'list request with invalid input fails with EINVAL(22) (attrs non-string)' '
 	name="attr-not-string" &&
         id=$(id -u) &&
         $jq -j -c -n  "{max_entries:5, userid:${id}, states:0, results:0, attrs:[5]}" \
@@ -1609,7 +1609,7 @@ test_expect_success HAVE_JQ 'list request with invalid input fails with EINVAL(2
 	EOF
 	test_cmp ${name}.expected ${name}.out
 '
-test_expect_success HAVE_JQ 'list request with invalid input fails with EINVAL(22) (attrs illegal field)' '
+test_expect_success 'list request with invalid input fails with EINVAL(22) (attrs illegal field)' '
 	name="field-not-valid" &&
         id=$(id -u) &&
         $jq -j -c -n  "{max_entries:5, userid:${id}, states:0, results:0, attrs:[\"foo\"]}" \
@@ -1622,7 +1622,7 @@ test_expect_success HAVE_JQ 'list request with invalid input fails with EINVAL(2
 test_expect_success 'list-id request with empty payload fails with EPROTO(71)' '
 	${RPC} job-list.list-id 71 </dev/null
 '
-test_expect_success HAVE_JQ 'list-id request with invalid input fails with EPROTO(71) (attrs not an array)' '
+test_expect_success 'list-id request with invalid input fails with EPROTO(71) (attrs not an array)' '
 	name="list-id-attrs-not-array" &&
         id=`flux submit hostname | flux job id` &&
         $jq -j -c -n  "{id:${id}, attrs:5}" \
@@ -1632,7 +1632,7 @@ test_expect_success HAVE_JQ 'list-id request with invalid input fails with EPROT
 	EOF
 	test_cmp ${name}.expected ${name}.out
 '
-test_expect_success HAVE_JQ 'list-id request with invalid input fails with EINVAL(22) (attrs non-string)' '
+test_expect_success 'list-id request with invalid input fails with EINVAL(22) (attrs non-string)' '
 	name="list-id-invalid-attrs" &&
 	id=$(flux jobs -c1 -ano {id.dec}) &&
         $jq -j -c -n  "{id:${id}, attrs:[5]}" \
@@ -1642,7 +1642,7 @@ test_expect_success HAVE_JQ 'list-id request with invalid input fails with EINVA
 	EOF
 	test_cmp ${name}.expected ${name}.out
 '
-test_expect_success HAVE_JQ 'list-id request with invalid input fails with EINVAL(22) (attrs illegal field)' '
+test_expect_success 'list-id request with invalid input fails with EINVAL(22) (attrs illegal field)' '
 	name="list-id-invalid-attr" &&
 	id=$(flux jobs -c1 -ano {id.dec}) &&
         $jq -j -c -n  "{id:${id}, attrs:[\"foo\"]}" \
@@ -1655,7 +1655,7 @@ test_expect_success HAVE_JQ 'list-id request with invalid input fails with EINVA
 # N.B. we remove annotations from the alloc event in this test, but it could
 # be cached and replayed via the job-manager, so we need to reload it
 # and associated modules too
-test_expect_success HAVE_JQ 'job-list can handle events missing optional data (alloc)' '
+test_expect_success 'job-list can handle events missing optional data (alloc)' '
 	userid=`id -u` &&
 	cat <<EOF >eventlog_empty_alloc.out &&
 {"timestamp":1000.0,"name":"submit","context":{"userid":${userid},"urgency":16,"flags":0,"version":1}}
@@ -1680,7 +1680,7 @@ EOF
 	flux job list-ids ${jobid} > empty_alloc.out &&
 	cat empty_alloc.out | jq -e ".annotations == null"
 '
-test_expect_success HAVE_JQ 'job-list can handle events missing optional data (exception)' '
+test_expect_success 'job-list can handle events missing optional data (exception)' '
 	userid=`id -u` &&
 	cat <<EOF >eventlog_no_exception_note.out &&
 {"timestamp":1000.0,"name":"submit","context":{"userid":${userid},"urgency":16,"flags":0,"version":1}}
@@ -1707,7 +1707,7 @@ EOF
 # eventlog was loaded correctly at the end of the test.
 #
 # N.B. We add extra events into this fake eventlog for testing
-test_expect_success HAVE_JQ 'job-list can handle events with superfluous context data' '
+test_expect_success 'job-list can handle events with superfluous context data' '
 	userid=`id -u` &&
 	cat <<EOF >eventlog_superfluous_context.out &&
 {"timestamp":1000.0,"name":"submit","context":{"userid":${userid},"urgency":8,"flags":0,"version":1,"etc":1}}
@@ -1794,7 +1794,7 @@ test_expect_success 'run some jobs in the batch,debug queues' '
         wait_id_inactive $(cat stats4.id)
 '
 
-test_expect_success HAVE_JQ 'job stats lists jobs in correct state in each queue' '
+test_expect_success 'job stats lists jobs in correct state in each queue' '
         batchq=`flux job stats | jq ".queues[] | select( .name == \"batch\" )"` &&
         debugq=`flux job stats | jq ".queues[] | select( .name == \"debug\" )"` &&
         echo $batchq | jq -e ".job_states.depend == 0" &&
@@ -1831,7 +1831,7 @@ test_expect_success 'reload the job-list module' '
         wait_id_inactive $(cat stats4.id)
 '
 
-test_expect_success HAVE_JQ 'job stats in each queue correct after reload' '
+test_expect_success 'job stats in each queue correct after reload' '
         batchq=`flux job stats | jq ".queues[] | select( .name == \"batch\" )"` &&
         debugq=`flux job stats | jq ".queues[] | select( .name == \"debug\" )"` &&
         echo $batchq | jq -e ".job_states.depend == 0" &&
@@ -1878,7 +1878,7 @@ wait_total() {
 
 # purge all jobs except two, the remaining two should be the failed
 # jobs submitted to the batch and debug queues.
-test_expect_success HAVE_JQ 'job-stats correct after purge' '
+test_expect_success 'job-stats correct after purge' '
         total=$(flux job stats | jq .job_states.total) &&
         purged=$((total - 2)) &&
         flux job purge --force --num-limit=2 &&
@@ -1932,12 +1932,12 @@ test_expect_success 'reload job-ingest without validator' '
         ingest_module reload disable-validator
 '
 
-test_expect_success HAVE_JQ 'create illegal jobspec with empty command array' '
+test_expect_success 'create illegal jobspec with empty command array' '
         cat hostname.json | $jq ".tasks[0].command = []" > bad_jobspec.json
 '
 
 # note that ntasks will not be set if jobspec invalid
-test_expect_success HAVE_JQ 'flux job list works on job with illegal jobspec' '
+test_expect_success 'flux job list works on job with illegal jobspec' '
         jobid=`flux job submit bad_jobspec.json | flux job id` &&
         fj_wait_event $jobid clean >/dev/null &&
         i=0 &&
@@ -1953,7 +1953,7 @@ test_expect_success HAVE_JQ 'flux job list works on job with illegal jobspec' '
         cat list_illegal_jobspec.out | $jq -e ".ntasks == null"
 '
 
-test_expect_success HAVE_JQ,NO_CHAIN_LINT 'flux job list-ids works on job with illegal jobspec' '
+test_expect_success NO_CHAIN_LINT 'flux job list-ids works on job with illegal jobspec' '
 	${RPC} job-list.job-state-pause 0 </dev/null
         jobid=`flux job submit bad_jobspec.json | flux job id`
         fj_wait_event $jobid clean >/dev/null
@@ -1971,7 +1971,7 @@ test_expect_success 'reload job-ingest with defaults' '
 
 # we make R invalid by overwriting it in the KVS before job-list will
 # look it up
-test_expect_success HAVE_JQ 'flux job list works on job with illegal R' '
+test_expect_success 'flux job list works on job with illegal R' '
 	${RPC} job-list.job-state-pause 0 </dev/null &&
         jobid=`flux submit --wait hostname | flux job id` &&
         jobkvspath=`flux job id --to kvs $jobid` &&
@@ -1992,7 +1992,7 @@ test_expect_success HAVE_JQ 'flux job list works on job with illegal R' '
         cat list_illegal_R.out | $jq -e ".expiration == null"
 '
 
-test_expect_success HAVE_JQ,NO_CHAIN_LINT 'flux job list-ids works on job with illegal R' '
+test_expect_success NO_CHAIN_LINT 'flux job list-ids works on job with illegal R' '
 	${RPC} job-list.job-state-pause 0 </dev/null
         jobid=`flux submit --wait hostname | flux job id`
         jobkvspath=`flux job id --to kvs $jobid` &&
@@ -2006,7 +2006,7 @@ test_expect_success HAVE_JQ,NO_CHAIN_LINT 'flux job list-ids works on job with i
 '
 
 
-test_expect_success HAVE_JQ,NO_CHAIN_LINT 'flux job list-ids works on job with illegal eventlog' '
+test_expect_success NO_CHAIN_LINT 'flux job list-ids works on job with illegal eventlog' '
 	${RPC} job-list.job-state-pause 0 </dev/null
         jobid=`flux submit --wait hostname | flux job id`
         jobkvspath=`flux job id --to kvs $jobid` &&
@@ -2019,7 +2019,7 @@ test_expect_success HAVE_JQ,NO_CHAIN_LINT 'flux job list-ids works on job with i
         cat list_id_illegal_eventlog.out | $jq -e ".id == ${jobid}"
 '
 
-test_expect_success HAVE_JQ 'flux job list works on racy annotations' '
+test_expect_success 'flux job list works on racy annotations' '
 	${RPC} job-list.job-state-pause 0 </dev/null &&
         jobid=`flux submit --wait hostname | flux job id` &&
 	${RPC} job-list.job-state-unpause 0 </dev/null &&

--- a/t/t2261-job-list-update.t
+++ b/t/t2261-job-list-update.t
@@ -90,12 +90,12 @@ test_expect_success 'submit jobs for job list testing' '
 # since we happen to know all these jobs are in the "run" state given
 # checks above
 
-test_expect_success HAVE_JQ 'flux job list running jobs in started order' '
+test_expect_success 'flux job list running jobs in started order' '
         flux job list -s running | jq .id > list_started.out &&
         test_cmp list_started.out running.ids
 '
 
-test_expect_success HAVE_JQ 'flux job list inactive jobs in completed order' '
+test_expect_success 'flux job list inactive jobs in completed order' '
         flux job list -s inactive | jq .id > list_inactive.out &&
         test_cmp list_inactive.out inactive.ids
 '
@@ -104,12 +104,12 @@ test_expect_success HAVE_JQ 'flux job list inactive jobs in completed order' '
 # state since we happen to know all these jobs are in the "sched"
 # state given checks above
 
-test_expect_success HAVE_JQ 'flux job list pending jobs in priority order' '
+test_expect_success 'flux job list pending jobs in priority order' '
         flux job list -s pending | jq .id > list_pending.out &&
         test_cmp list_pending.out pending.ids
 '
 
-test_expect_success HAVE_JQ 'flux job list pending jobs with correct urgency' '
+test_expect_success 'flux job list pending jobs with correct urgency' '
         cat >list_urgency.exp <<-EOT &&
 31
 31
@@ -124,7 +124,7 @@ EOT
         test_cmp list_urgency.out list_urgency.exp
 '
 
-test_expect_success HAVE_JQ 'flux job list pending jobs with correct priority' '
+test_expect_success 'flux job list pending jobs with correct priority' '
         cat >list_priority.exp <<-EOT &&
 4294967295
 4294967295
@@ -139,12 +139,12 @@ EOT
         test_cmp list_priority.out list_priority.exp
 '
 
-test_expect_success HAVE_JQ 'change a job urgency' '
+test_expect_success 'change a job urgency' '
         jobid=`head -n 3 pending.ids | tail -n 1` &&
         flux job urgency ${jobid} 1
 '
 
-test_expect_success HAVE_JQ 'wait for job-list to see job urgency change' '
+test_expect_success 'wait for job-list to see job urgency change' '
         jobidhead=`head -n 2 pending.ids > pending_after.ids` &&
         jobidhead=`head -n 6 pending.ids | tail -n 3 >> pending_after.ids` &&
         jobidchange=`head -n 3 pending.ids | tail -n 1 >> pending_after.ids` &&
@@ -162,7 +162,7 @@ test_expect_success HAVE_JQ 'wait for job-list to see job urgency change' '
         test_cmp list_pending_after.out pending_after.ids
 '
 
-test_expect_success HAVE_JQ 'flux job list pending jobs with correct urgency' '
+test_expect_success 'flux job list pending jobs with correct urgency' '
         cat >list_urgency_after.exp <<-EOT &&
 31
 31
@@ -177,7 +177,7 @@ EOT
         test_cmp list_urgency_after.out list_urgency_after.exp
 '
 
-test_expect_success HAVE_JQ 'flux job list pending jobs with correct priority' '
+test_expect_success 'flux job list pending jobs with correct priority' '
         cat >list_priority_after.exp <<-EOT &&
 4294967295
 4294967295

--- a/t/t2270-job-dependencies.t
+++ b/t/t2270-job-dependencies.t
@@ -16,7 +16,7 @@ flux setattr log-stderr-level 1
 PLUGINPATH=${FLUX_BUILD_DIR}/t/job-manager/plugins/.libs
 
 
-test_expect_success HAVE_JQ 'flux-mini: --dependency option works' '
+test_expect_success 'flux-mini: --dependency option works' '
 	flux run --dry-run \
 		--env=-* \
 		--dependency=foo:1234 \

--- a/t/t2271-job-dependency-after.t
+++ b/t/t2271-job-dependency-after.t
@@ -47,7 +47,7 @@ test_expect_success FLUX_SECURITY 'dependency=after will not work on another use
 test_expect_success 'disable ingest validator' '
 	flux module reload -f job-ingest disable-validator
 '
-test_expect_success HAVE_JQ 'dependency=after rejects invalid dependency' '
+test_expect_success 'dependency=after rejects invalid dependency' '
 	flux run --dry-run hostname | \
 	  jq ".attributes.system.dependencies[0] = \
 		{\"scheme\":\"after\", \"value\": 1}" >job.json &&
@@ -227,7 +227,7 @@ test_expect_success 'jobs with dependencies can be safely canceled' '
 	flux job urgency $jobid default &&
 	flux job wait-event -vt 15 $jobid clean
 '
-test_expect_success HAVE_JQ 'flux jobtap query dependency-after works' '
+test_expect_success 'flux jobtap query dependency-after works' '
 	flux jobtap query .dependency-after > query-none.json &&
 	test_debug "jq -S . query-none.json" &&
 	jq -e ".dependencies | length == 0" query-none.json &&

--- a/t/t2272-job-begin-time.t
+++ b/t/t2272-job-begin-time.t
@@ -21,13 +21,13 @@ test_expect_success 'begin-time: rejects invalid timestamp' '
 		--dependency=begin-time:-1.0 \
 		hostname
 '
-test_expect_success HAVE_JQ 'begin-time rejects missing timestamp' '
+test_expect_success 'begin-time rejects missing timestamp' '
 	flux run --dry-run hostname | \
 	  jq ".attributes.system.dependencies[0].scheme = \"begin-time\"" \
 	  > invalid.json &&
 	test_expect_code 1 flux job submit invalid.json
 '
-test_expect_success HAVE_JQ '--begin-time sets dependency in jobspec' '
+test_expect_success '--begin-time sets dependency in jobspec' '
 	flux run --dry-run --begin-time=+1h hostname | \
 	    jq -e ".attributes.system.dependencies[0].scheme == \"begin-time\""
 '

--- a/t/t2274-manager-perilog.t
+++ b/t/t2274-manager-perilog.t
@@ -148,7 +148,7 @@ test_expect_success 'perilog: job can be canceled after prolog is complete' '
 	flux job wait-event -t 15 $jobid exception &&
 	flux job wait-event -t 15 $jobid clean
 '
-test_expect_success HAVE_JQ 'perilog: prolog failure raises job exception' '
+test_expect_success 'perilog: prolog failure raises job exception' '
 	printf "#!/bin/sh\n/bin/false" > prolog.d/fail.sh &&
 	chmod +x prolog.d/fail.sh &&
 	test_when_finished "rm -f prolog.d/fail.sh" &&

--- a/t/t2275-job-duration-validator.t
+++ b/t/t2275-job-duration-validator.t
@@ -4,8 +4,6 @@ test_description='Test job duration validator plugin in job-manager'
 
 . $(dirname $0)/sharness.sh
 
-skip_all_unless_have jq
-
 test_under_flux 1 job
 
 flux setattr log-stderr-level 1

--- a/t/t2276-job-requires.t
+++ b/t/t2276-job-requires.t
@@ -8,7 +8,7 @@ test_under_flux 4 job
 
 flux setattr log-stderr-level 1
 
-test_expect_success HAVE_JQ 'flux-mini: --requires option works' '
+test_expect_success 'flux-mini: --requires option works' '
 	flux run --dry-run \
 		--env=-* \
 		--requires=foo,bar \

--- a/t/t2280-job-memo.t
+++ b/t/t2280-job-memo.t
@@ -44,55 +44,55 @@ test_expect_success 'memo: only job owner can add memo' '
 test_expect_success 'memo: memo cannot be added to inactive job' '
 	test_must_fail flux job memo $(cat inactivejob) foo=42
 '
-test_expect_success HAVE_JQ 'memo: add memo to pending job works' '
+test_expect_success 'memo: add memo to pending job works' '
 	flux job memo $pendingid foo=42 a=b &&
 	flux job wait-event -t 10 $pendingid memo &&
 	jmgr_check_memo $pendingid foo 42
 '
-test_expect_success HAVE_JQ 'memo: remove memo from pending job works' '
+test_expect_success 'memo: remove memo from pending job works' '
 	flux job memo $pendingid foo=null &&
 	flux job wait-event -m foo=null -t 10 $pendingid memo &&
 	test_expect_code 1 jmgr_check_memo_exists $pendingid foo
 '
-test_expect_success HAVE_JQ 'memo: add volatile memo to pending job works' '
+test_expect_success 'memo: add volatile memo to pending job works' '
 	flux job memo --volatile $pendingid foo=bar &&
 	jmgr_check_memo $pendingid foo \"bar\" &&
 	flux job eventlog $pendingid > eventlog.pending &&
 	test_expect_code 1 grep foo=bar eventlog.pending
 '
-test_expect_success HAVE_JQ 'memo: add memo to running job works' '
+test_expect_success 'memo: add memo to running job works' '
 	flux job memo $runid foo=42 &&
 	flux job wait-event -t 10 $runid memo &&
 	jmgr_check_memo $runid foo 42
 '
-test_expect_success HAVE_JQ 'memo: remove memo from running job works' '
+test_expect_success 'memo: remove memo from running job works' '
 	flux job memo $runid foo=null &&
 	flux job wait-event -m foo=null -t 10 $runid memo &&
 	test_expect_code 1 jmgr_check_memo_exists $runid foo
 '
-test_expect_success HAVE_JQ 'memo: flux job memo works with dotted path' '
+test_expect_success 'memo: flux job memo works with dotted path' '
 	flux job memo $runid a.b.c=42 a.d=test &&
 	jmgr_check_memo_exists $runid a.b.c &&
 	jmgr_check_memo_exists $runid a.d
 '
-test_expect_success HAVE_JQ 'memo: flux job memo works with key=- (stdin)' '
+test_expect_success 'memo: flux job memo works with key=- (stdin)' '
 	echo "xyz" | flux job memo $runid a.f=-A &&
 	jmgr_check_memo_exists $runid a.f
 '
-test_expect_success HAVE_JQ 'memo: flux job memo: null values unset keys' '
+test_expect_success 'memo: flux job memo: null values unset keys' '
 	flux job memo $runid a.b=null &&
 	flux job wait-event -v -m "a={\"b\":null}" -t 10 $runid memo &&
 	test_expect_code 1 jmgr_check_memo_exists $runid a.b &&
 	jmgr_check_memo $runid a.d \"test\"
 '
-test_expect_success HAVE_JQ 'memo: available in flux-jobs {user} attribute' '
+test_expect_success 'memo: available in flux-jobs {user} attribute' '
 	jlist_check_memo $runid a.d \"test\" &&
 	jlist_check_memo $pendingid a \"b\"
 '
 test_expect_success 'memo: reload job-list module' '
 	flux module reload job-list
 '
-test_expect_success HAVE_JQ 'memo: non-volatile memos still available in job-list' '
+test_expect_success 'memo: non-volatile memos still available in job-list' '
 	jlist_check_memo $runid a.d \"test\" &&
 	jlist_check_memo $pendingid a \"b\"
 '
@@ -101,7 +101,7 @@ test_expect_success 'memo: cancel all jobs' '
 	flux job wait-event $runid clean &&
 	flux job wait-event $pendingid clean
 '
-test_expect_success HAVE_JQ 'memo: non-volatile memos still available for jobs' '
+test_expect_success 'memo: non-volatile memos still available for jobs' '
 	jlist_check_memo $runid a.d \"test\" &&
 	jlist_check_memo $pendingid a \"b\"
 '

--- a/t/t2300-sched-simple.t
+++ b/t/t2300-sched-simple.t
@@ -71,7 +71,7 @@ test_expect_success 'sched-simple: gpu request is canceled' '
 '
 Y2J="flux python ${SHARNESS_TEST_SRCDIR}/jobspec/y2j.py"
 SPEC=${SHARNESS_TEST_SRCDIR}/jobspec/valid/basic.yaml
-test_expect_success HAVE_JQ 'sched-simple: invalid minimal jobspec is canceled' '
+test_expect_success 'sched-simple: invalid minimal jobspec is canceled' '
 	${Y2J}<${SPEC} | jq ".version = 1" | flux job submit >job00.id &&
 	jobid=$(cat job00.id) &&
 	flux job wait-event --timeout=5.0 $jobid exception &&

--- a/t/t2310-resource-module.t
+++ b/t/t2310-resource-module.t
@@ -58,19 +58,19 @@ test_expect_success 'send bad topo-reduce request to rank 0' '
 	bad_reduce 0
 '
 
-test_expect_success HAVE_JQ 'resource.eventlog exists' '
+test_expect_success 'resource.eventlog exists' '
 	flux kvs eventlog get -u resource.eventlog >eventlog.out
 '
 
-test_expect_success HAVE_JQ 'resource-init context says restart=false' '
+test_expect_success 'resource-init context says restart=false' '
 	test "$(grep_event resource-init <eventlog.out|jq .restart)" = "false"
 '
 
-test_expect_success HAVE_JQ 'resource-init context says online is empty set' '
+test_expect_success 'resource-init context says online is empty set' '
 	test "$(grep_event resource-init <eventlog.out|jq .online)" = "\"\""
 '
 
-test_expect_success HAVE_JQ 'wait until resource-define event is posted' '
+test_expect_success 'wait until resource-define event is posted' '
 	flux kvs eventlog wait-event -t 5 resource.eventlog resource-define
 '
 
@@ -88,7 +88,7 @@ test_expect_success 'reload resource module and re-capture eventlog' '
 	tail -$(($post-$pre)) restart.out > post_restart.out
 '
 
-test_expect_success HAVE_JQ 'new resource-init context says restart=true' '
+test_expect_success 'new resource-init context says restart=true' '
 	test "$(grep_event resource-init <post_restart.out \
 		|jq .restart)" = "true"
 '
@@ -127,7 +127,7 @@ sanitize_hwloc_xml() {
     sed 's/pci_link_speed=".*"//g' $1
 }
 
-test_expect_success HAVE_JQ 'get hwloc XML direct from ranks' '
+test_expect_success 'get hwloc XML direct from ranks' '
 	mkdir -p hwloc &&
 	for i in $(seq 0 $(($SIZE-1))); do \
 		get_topo $i | sanitize_hwloc_xml >hwloc/$i.xml || return 1; \
@@ -138,14 +138,14 @@ normalize_json() {
 	jq -cS .
 }
 
-test_expect_success HAVE_JQ 'reloading XML results in same R as before' '
+test_expect_success 'reloading XML results in same R as before' '
 	flux kvs get resource.R | normalize_json >R.orig &&
 	flux resource reload -x hwloc &&
 	flux kvs get resource.R | normalize_json >R.new &&
 	test_cmp R.orig R.new
 '
 
-test_expect_success HAVE_JQ 'reload original R just to do it and verify' '
+test_expect_success 'reload original R just to do it and verify' '
 	flux resource reload R.orig &&
 	flux kvs get resource.R | normalize_json >R.new2 &&
 	test_cmp R.orig R.new2
@@ -177,17 +177,17 @@ test_expect_success 'one rank was was drained' '
 	test $(wc -l <has_drain.out) -eq 1
 '
 
-# Since jq is used in the first bit, HAVE_JQ is required in other bits too
-test_expect_success HAVE_JQ 'change expected cores in resource.R' "
+# Since jq is used in the first bit, is required in other bits too
+test_expect_success 'change expected cores in resource.R' "
 	flux kvs get resource.R &&
 	jq '.execution.R_lite[0].children.core = \"0-1048\"' R.orig >R.Mcore &&
 	flux resource reload R.Mcore
 "
-test_expect_success HAVE_JQ 'reload resource module' '
+test_expect_success 'reload resource module' '
 	flux exec -r all flux module remove resource &&
 	load_resource
 '
-test_expect_success HAVE_JQ 'all ranks were drained' '
+test_expect_success 'all ranks were drained' '
 	has_event drain >has_drain2.out &&
 	test $(wc -l <has_drain2.out) -eq $(($SIZE+1))
 '

--- a/t/t2313-resource-acquire.t
+++ b/t/t2313-resource-acquire.t
@@ -34,11 +34,11 @@ test_expect_success 'wait for monitor to declare all ranks are up' '
 	waitdown 0
 '
 
-test_expect_success HAVE_JQ 'unload scheduler' '
+test_expect_success 'unload scheduler' '
 	flux module remove sched-simple
 '
 
-test_expect_success HAVE_JQ 'acquire works and response contains up, resources' '
+test_expect_success 'acquire works and response contains up, resources' '
 	$RPC resource.acquire </dev/null >acquire.out &&
 	jq -c -e -a .resources acquire.out &&
 	jq -c -e -a .up acquire.out
@@ -56,7 +56,7 @@ test_expect_success 'reload config excluding rank 0' '
 	flux config reload
 '
 
-test_expect_success HAVE_JQ 'acquire returns resources excluding rank 0' '
+test_expect_success 'acquire returns resources excluding rank 0' '
 	$RPC resource.acquire </dev/null >acquire2.out &&
 	jq -r .resources.execution.R_lite[0].rank acquire2.out \
 		>acquire2_rank.out &&
@@ -64,12 +64,12 @@ test_expect_success HAVE_JQ 'acquire returns resources excluding rank 0' '
 	test_cmp acquire2_rank.exp acquire2_rank.out
 '
 
-test_expect_success HAVE_JQ 'acquire returns up excluding rank 0' '
+test_expect_success 'acquire returns up excluding rank 0' '
 	jq -e -r .up acquire2.out | $IDSETUTIL expand >acquire2_up.out &&
 	test_must_fail grep "^0" acquire2_up.out
 '
 
-test_expect_success HAVE_JQ,NO_CHAIN_LINT 'drain rank 1 causes down response' '
+test_expect_success NO_CHAIN_LINT 'drain rank 1 causes down response' '
 	acquire_stream 30 acquire3.out down &
 	pid=$! &&
 	$WAITFILE -t 10 -v -p \"resources\" acquire3.out &&
@@ -77,7 +77,7 @@ test_expect_success HAVE_JQ,NO_CHAIN_LINT 'drain rank 1 causes down response' '
 	wait $pid
 '
 
-test_expect_success HAVE_JQ,NO_CHAIN_LINT 'undrain/drain rank 1 causes up,down responses' '
+test_expect_success NO_CHAIN_LINT 'undrain/drain rank 1 causes up,down responses' '
 	acquire_stream 30 acquire4.out down &
 	pid=$! &&
 	$WAITFILE -t 10 -v -p \"resources\" acquire4.out &&
@@ -87,7 +87,7 @@ test_expect_success HAVE_JQ,NO_CHAIN_LINT 'undrain/drain rank 1 causes up,down r
 	wait $pid
 '
 
-test_expect_success HAVE_JQ,NO_CHAIN_LINT 'add/remove new exclusion causes down/up response' '
+test_expect_success NO_CHAIN_LINT 'add/remove new exclusion causes down/up response' '
 	acquire_stream 30 acquire5.out &
 	pid=$! &&
 	$WAITFILE -t 10 -v -p \"resources\" acquire5.out &&
@@ -106,7 +106,7 @@ test_expect_success HAVE_JQ,NO_CHAIN_LINT 'add/remove new exclusion causes down/
 	kill -15 $pid && wait $pid || true
 '
 
-test_expect_success HAVE_JQ 'load scheduler' '
+test_expect_success 'load scheduler' '
 	flux module load sched-simple
 '
 

--- a/t/t2315-resource-system.t
+++ b/t/t2315-resource-system.t
@@ -28,7 +28,7 @@ test_expect_success 'start instance with config file and dump R' '
 		flux kvs get resource.R >R.out
 '
 
-test_expect_success HAVE_JQ 'dumped R matches configured R' '
+test_expect_success 'dumped R matches configured R' '
 	jq --sort-keys . <R.test >R.test.normalized &&
 	jq --sort-keys . <R.out >R.out.normalized &&
 	test_cmp R.test.normalized R.out.normalized
@@ -39,7 +39,7 @@ test_expect_success 'both ranks were drained' '
 	grep "draining: rank 1" logfile
 '
 
-test_expect_success HAVE_JQ 'invalid R causes instance to fail with error' '
+test_expect_success 'invalid R causes instance to fail with error' '
 	mkdir bad &&
 	flux R encode -r 0-1 -c 0-1 | jq ".version = 42" > bad/R &&
 	cat >bad/resource.toml <<-EOF &&
@@ -110,7 +110,7 @@ test_expect_success 'invalid exclude hosts cause instance failure' '
     grep "nosuchhost: Invalid argument" ${name}/logfile
 '
 
-test_expect_success HAVE_JQ 'gpu resources in configured R are not verified' '
+test_expect_success 'gpu resources in configured R are not verified' '
 	name=gpu-noverify &&
 	mkdir $name &&
 	flux R encode -r 0 --local | \
@@ -126,7 +126,7 @@ test_expect_success HAVE_JQ 'gpu resources in configured R are not verified' '
 	grep "gpu\[42-43\]" ${name}/rlist
 '
 
-test_expect_success HAVE_JQ,MULTICORE 'resource norestrict option works' '
+test_expect_success MULTICORE 'resource norestrict option works' '
 	name=norestrict &&
 	mkdir $name &&
 	flux R encode -r 0 --local > ${name}/R &&

--- a/t/t2400-job-exec-test.t
+++ b/t/t2400-job-exec-test.t
@@ -8,8 +8,6 @@ test_under_flux 1 job
 
 flux setattr log-stderr-level 1
 
-skip_all_unless_have jq
-
 RPC=${FLUX_BUILD_DIR}/t/request/rpc
 
 job_kvsdir()    { flux job id --to=kvs $1; }

--- a/t/t2402-job-exec-dummy.t
+++ b/t/t2402-job-exec-dummy.t
@@ -4,8 +4,6 @@ test_description='Test flux job execution service with dummy job shell'
 
 . $(dirname $0)/sharness.sh
 
-skip_all_unless_have jq
-
 #  Configure dummy job shell:
 if ! test -f dummy.toml; then
 	cat <<-EOF >dummy.toml

--- a/t/t2404-job-exec-multiuser.t
+++ b/t/t2404-job-exec-multiuser.t
@@ -4,16 +4,6 @@ test_description='Sanity checks for job-exec multiuser exec'
 
 . $(dirname $0)/sharness.sh
 
-#  Dummy job shell uses jq and will not have access to test_prereqs set
-#   by individual tests, which causes calls to jq to fail when
-#   TEST_CHECK_PREREQS is set in the environment.
-#
-#  Just skip all tests if jq not available, which will export
-#   SHARNESS_test_skip_all_prereq=jq to the test_under_flux instance so that
-#   the prereq validation check test passes in the dummy job shell.
-#
-skip_all_unless_have jq
-
 flux version | grep -q libflux-security && test_set_prereq FLUX_SECURITY
 
 if ! test_have_prereq FLUX_SECURITY; then

--- a/t/t2500-job-attach.t
+++ b/t/t2500-job-attach.t
@@ -120,7 +120,7 @@ filter_log_context() {
 	jq -c '. | select(.name == "log") | .context'
 }
 
-test_expect_success HAVE_JQ 'attach: -v option displays file and line info in logs' '
+test_expect_success 'attach: -v option displays file and line info in logs' '
 	jobid=$(flux submit -o verbose=2 hostname) &&
 	flux job wait-event ${jobid} clean &&
 	flux job eventlog --format=json -p guest.output ${jobid} \

--- a/t/t2501-job-status.t
+++ b/t/t2501-job-status.t
@@ -46,13 +46,13 @@ test_expect_success 'status: --exception-exit-code works' '
 	test_expect_code 42 flux job status -v --exception-exit-code=42 ${canceled} &&
 	test_expect_code 255 flux job status -v --exception-exit-code=255 ${unsatisfiable}
 '
-test_expect_success HAVE_JQ 'status: flux-job status --json works' '
+test_expect_success 'status: flux-job status --json works' '
 	flux job status --json ${zero} | \
 		jq -e ".waitstatus == 0" &&
 	flux job status --json ${one} | \
 		jq -e ".waitstatus == 256"
 '
-test_expect_success HAVE_JQ 'status: returns most severe exception' '
+test_expect_success 'status: returns most severe exception' '
 	jobid=$(flux submit --urgency=0 sleep 20) &&
 	flux job raise --severity=1 -t test $jobid &&
 	flux job raise --severity=0 -t cancel $jobid &&
@@ -61,7 +61,7 @@ test_expect_success HAVE_JQ 'status: returns most severe exception' '
 	flux job status --exception-exit-code=0 --json ${jobid} | \
 		jq -e ".exception_severity == 0"
 '
-test_expect_success HAVE_JQ 'status: returns most severe exception' '
+test_expect_success 'status: returns most severe exception' '
 	jobid=$(flux submit --urgency=0 sleep 0) &&
 	flux job raise --severity=1 -t test $jobid &&
 	flux job raise --severity=2 -t test2 $jobid &&

--- a/t/t2602-job-shell.t
+++ b/t/t2602-job-shell.t
@@ -13,7 +13,7 @@ KVSTEST=${FLUX_BUILD_DIR}/src/common/libpmi/test_kvstest
 LPTEST=${SHARNESS_TEST_DIRECTORY}/shell/lptest
 waitfile=${SHARNESS_TEST_SRCDIR}/scripts/waitfile.lua
 
-test_expect_success HAVE_JQ 'job-shell: reads J not jobspec' '
+test_expect_success 'job-shell: reads J not jobspec' '
 	id=$(flux submit --wait-event=priority \
 		-n1 --urgency=hold /bin/true) &&
 	flux job info ${id} jobspec \
@@ -24,7 +24,7 @@ test_expect_success HAVE_JQ 'job-shell: reads J not jobspec' '
 	flux job attach -vEX ${id}
 '
 
-test_expect_success HAVE_JQ 'job-shell: fails on modified J' '
+test_expect_success 'job-shell: fails on modified J' '
 	id=$(flux submit --wait-event=priority \
 		-n1 --urgency=hold /bin/true) &&
 	flux job info ${id} J | sed s/./%/85 > J.new &&
@@ -153,7 +153,7 @@ test_expect_success 'job-shell: verify output of 1-task lptest job' '
 # output.
 #
 
-test_expect_success HAVE_JQ 'job-shell: verify output of 1-task lptest job on stderr' '
+test_expect_success 'job-shell: verify output of 1-task lptest job on stderr' '
 	flux run --dry-run bash -c "${LPTEST} >&2" \
 		| $jq ".attributes.system.shell.options.output.stderr.buffer.type = \"line\"" \
 		> 1task_lptest.json &&
@@ -168,7 +168,7 @@ test_expect_success 'job-shell: verify output of 4-task lptest job' '
 	sort -snk1 <lptest4_raw.out >lptest4.out &&
 	test_cmp lptest4.exp lptest4.out
 '
-test_expect_success HAVE_JQ 'job-shell: verify output of 4-task lptest job on stderr' '
+test_expect_success 'job-shell: verify output of 4-task lptest job on stderr' '
 	flux run --dry-run -n4 -N4 bash -c "${LPTEST} 1>&2" \
 		| $jq ".attributes.system.shell.options.output.stderr.buffer.type = \"line\"" \
 		> 4task_lptest.json &&

--- a/t/t2603-job-shell-initrc.t
+++ b/t/t2603-job-shell-initrc.t
@@ -70,13 +70,13 @@ test_expect_success 'flux-shell: initrc: specifying initrc of /dev/null works' '
 	test_debug "cat devnull.log" &&
 	grep "Loading /dev/null" devnull.log
 '
-test_expect_success HAVE_JQ 'flux-shell: initrc: bad initrc in jobspec fails' '
+test_expect_success 'flux-shell: initrc: bad initrc in jobspec fails' '
 	flux run --dry-run -N1 -n1 echo Hi \
 	    | jq ".attributes.system.shell.options.initrc = \"nosuchfile\"" \
 	    > j2 &&
 	test_expect_code 1 ${FLUX_SHELL} -v -s -r 0 -j j2 -R R1 0
 '
-test_expect_success HAVE_JQ 'flux-shell: initrc: in jobspec works' '
+test_expect_success 'flux-shell: initrc: in jobspec works' '
 	name=ok &&
 	cat >${name}.lua <<-EOT &&
 	    print ("jobspec initrc OK")
@@ -159,7 +159,7 @@ test_expect_success 'flux-shell: initrc: return false from plugin aborts shell' 
 	test_debug "cat ${name}.log" &&
 	grep "plugin.*: shell.init failed" ${name}.log
 '
-test_expect_success HAVE_JQ 'flux-shell: initrc: add test options to jobspec' "
+test_expect_success 'flux-shell: initrc: add test options to jobspec' "
 	cat j1 | jq '.attributes.system.shell.options.test = \"test\"' \
 		> j.initrc
 "
@@ -261,7 +261,7 @@ test_expect_success 'flux-shell: initrc: load invalid args plugins' '
 	${FLUX_SHELL} -v -s -r 0 -j j1 -R R1 \
 		--initrc=${name}.lua 0
 '
-test_expect_success HAVE_JQ 'flux-shell: initrc: load getopt plugin' '
+test_expect_success 'flux-shell: initrc: load getopt plugin' '
 	name=getopt &&
 	cat >${name}.lua <<-EOF &&
 	plugin.searchpath = "${INITRC_PLUGINPATH}"
@@ -272,7 +272,7 @@ test_expect_success HAVE_JQ 'flux-shell: initrc: load getopt plugin' '
 		> ${name}.log 2>&1 &&
 	test_debug "cat ${name}.log"
 '
-test_expect_success HAVE_JQ 'flux-shell: plugins can use setopt with empty options' '
+test_expect_success 'flux-shell: plugins can use setopt with empty options' '
 	name=setopt &&
 	cat >${name}.lua <<-EOF &&
 	plugin.searchpath = "${INITRC_PLUGINPATH}"
@@ -284,7 +284,7 @@ test_expect_success HAVE_JQ 'flux-shell: plugins can use setopt with empty optio
 	test_debug "cat ${name}.log"
 '
 
-test_expect_success HAVE_JQ 'flux-shell: initrc: jobspec-info plugin works' '
+test_expect_success 'flux-shell: initrc: jobspec-info plugin works' '
 	name=jobspec-info &&
 	cat >${name}.lua <<-EOF &&
 	plugin.searchpath = "${INITRC_PLUGINPATH}"

--- a/t/t2605-job-shell-output-redirection-standalone.t
+++ b/t/t2605-job-shell-output-redirection-standalone.t
@@ -39,7 +39,7 @@ test_expect_success 'flux-shell: generate 2-task echo jobspecs and matching R' '
 # 1 task output file tests
 #
 
-test_expect_success HAVE_JQ 'flux-shell: run 1-task echo job (stdout file)' '
+test_expect_success 'flux-shell: run 1-task echo job (stdout file)' '
         cat j1echostdout \
             |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
             |  $jq ".attributes.system.shell.options.output.stdout.path = \"out0\"" \
@@ -48,7 +48,7 @@ test_expect_success HAVE_JQ 'flux-shell: run 1-task echo job (stdout file)' '
 	grep stdout:foo out0
 '
 
-test_expect_success HAVE_JQ 'flux-shell: run 1-task echo job (stderr file)' '
+test_expect_success 'flux-shell: run 1-task echo job (stderr file)' '
         cat j1echostderr \
             |  $jq ".attributes.system.shell.options.output.stderr.type = \"file\"" \
             |  $jq ".attributes.system.shell.options.output.stderr.path = \"err1\"" \
@@ -57,7 +57,7 @@ test_expect_success HAVE_JQ 'flux-shell: run 1-task echo job (stderr file)' '
 	grep stderr:bar err1
 '
 
-test_expect_success HAVE_JQ 'flux-shell: run 1-task echo job (stderr to stdout file)' '
+test_expect_success 'flux-shell: run 1-task echo job (stderr to stdout file)' '
         cat j1echostderr \
             |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
             |  $jq ".attributes.system.shell.options.output.stdout.path = \"out2\"" \
@@ -66,7 +66,7 @@ test_expect_success HAVE_JQ 'flux-shell: run 1-task echo job (stderr to stdout f
 	grep stderr:bar out2
 '
 
-test_expect_success HAVE_JQ 'flux-shell: run 1-task echo job (stdout file/stderr file)' '
+test_expect_success 'flux-shell: run 1-task echo job (stdout file/stderr file)' '
         cat j1echoboth \
             |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
             |  $jq ".attributes.system.shell.options.output.stdout.path = \"out3\"" \
@@ -78,7 +78,7 @@ test_expect_success HAVE_JQ 'flux-shell: run 1-task echo job (stdout file/stderr
 	grep stderr:baz err3
 '
 
-test_expect_success HAVE_JQ 'flux-shell: run 1-task echo job (stdout & stderr to stdout file)' '
+test_expect_success 'flux-shell: run 1-task echo job (stdout & stderr to stdout file)' '
         cat j1echoboth \
             |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
             |  $jq ".attributes.system.shell.options.output.stdout.path = \"out4\"" \
@@ -88,7 +88,7 @@ test_expect_success HAVE_JQ 'flux-shell: run 1-task echo job (stdout & stderr to
 	grep stderr:baz out4
 '
 
-test_expect_success HAVE_JQ 'flux-shell: run 1-task echo job (stdout file/stderr term)' '
+test_expect_success 'flux-shell: run 1-task echo job (stdout file/stderr term)' '
         cat j1echoboth \
             |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
             |  $jq ".attributes.system.shell.options.output.stdout.path = \"out5\"" \
@@ -99,7 +99,7 @@ test_expect_success HAVE_JQ 'flux-shell: run 1-task echo job (stdout file/stderr
 	grep stderr:baz err5
 '
 
-test_expect_success HAVE_JQ 'flux-shell: run 1-task echo job (stdout term/stderr file)' '
+test_expect_success 'flux-shell: run 1-task echo job (stdout term/stderr file)' '
         cat j1echoboth \
             |  $jq ".attributes.system.shell.options.output.stderr.type = \"file\"" \
             |  $jq ".attributes.system.shell.options.output.stderr.path = \"err6\"" \
@@ -113,7 +113,7 @@ test_expect_success HAVE_JQ 'flux-shell: run 1-task echo job (stdout term/stderr
 # 2 task output file tests
 #
 
-test_expect_success HAVE_JQ 'flux-shell: run 2-task echo job (stdout file)' '
+test_expect_success 'flux-shell: run 2-task echo job (stdout file)' '
         cat j2echostdout \
             |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
             |  $jq ".attributes.system.shell.options.output.stdout.path = \"out7\"" \
@@ -124,7 +124,7 @@ test_expect_success HAVE_JQ 'flux-shell: run 2-task echo job (stdout file)' '
 	grep "1: stdout:foo" out7
 '
 
-test_expect_success HAVE_JQ 'flux-shell: run 2-task echo job (stderr file)' '
+test_expect_success 'flux-shell: run 2-task echo job (stderr file)' '
         cat j2echostderr \
             |  $jq ".attributes.system.shell.options.output.stderr.type = \"file\"" \
             |  $jq ".attributes.system.shell.options.output.stderr.path = \"err8\"" \
@@ -135,7 +135,7 @@ test_expect_success HAVE_JQ 'flux-shell: run 2-task echo job (stderr file)' '
 	grep "1: stderr:bar" err8
 '
 
-test_expect_success HAVE_JQ 'flux-shell: run 2-task echo job (stderr to stdout file)' '
+test_expect_success 'flux-shell: run 2-task echo job (stderr to stdout file)' '
         cat j2echostderr \
             |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
             |  $jq ".attributes.system.shell.options.output.stdout.path = \"out9\"" \
@@ -146,7 +146,7 @@ test_expect_success HAVE_JQ 'flux-shell: run 2-task echo job (stderr to stdout f
 	grep "1: stderr:bar" out9
 '
 
-test_expect_success HAVE_JQ 'flux-shell: run 2-task echo job (stdout file/stderr file)' '
+test_expect_success 'flux-shell: run 2-task echo job (stdout file/stderr file)' '
         cat j2echoboth \
             |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
             |  $jq ".attributes.system.shell.options.output.stdout.path = \"out10\"" \
@@ -162,7 +162,7 @@ test_expect_success HAVE_JQ 'flux-shell: run 2-task echo job (stdout file/stderr
 	grep "1: stderr:baz" err10
 '
 
-test_expect_success HAVE_JQ 'flux-shell: run 2-task echo job (stdout & stderr to stdout file)' '
+test_expect_success 'flux-shell: run 2-task echo job (stdout & stderr to stdout file)' '
         cat j2echoboth \
             |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
             |  $jq ".attributes.system.shell.options.output.stdout.path = \"out11\"" \
@@ -175,7 +175,7 @@ test_expect_success HAVE_JQ 'flux-shell: run 2-task echo job (stdout & stderr to
 	grep "1: stderr:baz" out11
 '
 
-test_expect_success HAVE_JQ 'flux-shell: run 2-task echo job (stdout file/stderr term)' '
+test_expect_success 'flux-shell: run 2-task echo job (stdout file/stderr term)' '
         cat j2echoboth \
             |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
             |  $jq ".attributes.system.shell.options.output.stdout.path = \"out12\"" \
@@ -189,7 +189,7 @@ test_expect_success HAVE_JQ 'flux-shell: run 2-task echo job (stdout file/stderr
 	grep "1: stderr:baz" err12
 '
 
-test_expect_success HAVE_JQ 'flux-shell: run 2-task echo job (stdout term/stderr file)' '
+test_expect_success 'flux-shell: run 2-task echo job (stdout term/stderr file)' '
         cat j2echoboth \
             |  $jq ".attributes.system.shell.options.output.stderr.type = \"file\"" \
             |  $jq ".attributes.system.shell.options.output.stderr.path = \"err13\"" \
@@ -206,7 +206,7 @@ test_expect_success HAVE_JQ 'flux-shell: run 2-task echo job (stdout term/stderr
 # output file mustache tests
 #
 
-test_expect_success HAVE_JQ 'flux-shell: run 1-task echo job (mustache id stdout file/stderr file)' '
+test_expect_success 'flux-shell: run 1-task echo job (mustache id stdout file/stderr file)' '
     id=$(flux job id --to=f58 14) &&
         cat j1echoboth \
             |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
@@ -219,7 +219,7 @@ test_expect_success HAVE_JQ 'flux-shell: run 1-task echo job (mustache id stdout
 	grep stderr:baz err${id}
 '
 
-test_expect_success HAVE_JQ 'flux-shell: run 1-task echo job (mustache id stdout & stderr to stdout file)' '
+test_expect_success 'flux-shell: run 1-task echo job (mustache id stdout & stderr to stdout file)' '
     id=$(flux job id --to=f58 15) &&
         cat j1echoboth \
             |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
@@ -231,7 +231,7 @@ test_expect_success HAVE_JQ 'flux-shell: run 1-task echo job (mustache id stdout
 '
 
 for type in f58 dec hex dothex words; do
-  test_expect_success HAVE_JQ "flux-shell: output template {{id.$type}}" '
+  test_expect_success "flux-shell: output template {{id.$type}}" '
     jobid=123456789 &&
     id=$(flux job id --to=${type} ${jobid}) &&
         cat j1echoboth \
@@ -244,7 +244,7 @@ for type in f58 dec hex dothex words; do
  '
 done
 
-test_expect_success HAVE_JQ "flux-shell: bad output mustache template is not rendered" '
+test_expect_success "flux-shell: bad output mustache template is not rendered" '
 	cat j1echoboth \
 	    |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
 	    |  $jq ".attributes.system.shell.options.output.stdout.path = \"{{idx}}.out\"" \
@@ -253,7 +253,7 @@ test_expect_success HAVE_JQ "flux-shell: bad output mustache template is not ren
 	grep stdout:baz {{idx}}.out &&
 	grep stderr:baz {{idx}}.out
 '
-test_expect_success HAVE_JQ "flux-shell: bad output mustache template is not rendered" '
+test_expect_success "flux-shell: bad output mustache template is not rendered" '
 	cat j1echoboth \
 	    |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
 	    |  $jq ".attributes.system.shell.options.output.stdout.path = \"{{id.x}}.out\"" \
@@ -263,7 +263,7 @@ test_expect_success HAVE_JQ "flux-shell: bad output mustache template is not ren
 	grep stderr:baz {{id.x}}.out
 '
 
-test_expect_success HAVE_JQ "flux-shell: unknown mustache template is not rendered" '
+test_expect_success "flux-shell: unknown mustache template is not rendered" '
 	cat j1echoboth \
 	    |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
 	    |  $jq ".attributes.system.shell.options.output.stdout.path = \"{{foo}}.out\"" \
@@ -273,7 +273,7 @@ test_expect_success HAVE_JQ "flux-shell: unknown mustache template is not render
 	grep stderr:baz {{foo}}.out
 '
 
-test_expect_success HAVE_JQ "flux-shell: too large mustache template is not rendered" '
+test_expect_success "flux-shell: too large mustache template is not rendered" '
 	tmpl=$(printf "%0.sf" $(seq 0 120)) &&
 	cat j1echoboth \
 	    |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
@@ -288,21 +288,21 @@ test_expect_success HAVE_JQ "flux-shell: too large mustache template is not rend
 # output corner case tests
 #
 
-test_expect_success HAVE_JQ 'flux-shell: error on bad output type' '
+test_expect_success 'flux-shell: error on bad output type' '
         cat j1echostdout \
             |  $jq ".attributes.system.shell.options.output.stdout.type = \"foobar\"" \
             > j1echostdout-16 &&
         ! ${FLUX_SHELL} -v -s -r 0 -j j1echostdout-16 -R R1 16
 '
 
-test_expect_success HAVE_JQ 'flux-shell: error on no path with file output' '
+test_expect_success 'flux-shell: error on no path with file output' '
         cat j1echostdout \
             |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
             > j1echostdout-17 &&
         ! ${FLUX_SHELL} -v -s -r 0 -j j1echostdout-17 -R R1 17
 '
 
-test_expect_success HAVE_JQ 'flux-shell: error invalid path to file output' '
+test_expect_success 'flux-shell: error invalid path to file output' '
         cat j1echostdout \
             |  $jq ".attributes.system.shell.options.output.stdout.type = \"file\"" \
             |  $jq ".attributes.system.shell.options.output.stdout.path = \"/foo/bar/baz\"" \

--- a/t/t2610-job-shell-mpir.t
+++ b/t/t2610-job-shell-mpir.t
@@ -4,8 +4,6 @@ test_description='Test flux-shell MPIR and ptrace support'
 
 . `dirname $0`/sharness.sh
 
-skip_all_unless_have jq
-
 test_under_flux 4 job
 
 FLUX_SHELL="${FLUX_BUILD_DIR}/src/shell/flux-shell"

--- a/t/t2611-debug-emulate.t
+++ b/t/t2611-debug-emulate.t
@@ -42,7 +42,7 @@ test_expect_success 'debugger: submitting under debugger via flux-mini works' '
 	flux job wait-event -vt ${TIMEOUT}  ${jobid} finish
 '
 
-test_expect_success HAVE_JQ 'debugger: submitting under debugger via flux-job works' '
+test_expect_success 'debugger: submitting under debugger via flux-job works' '
 	flux run --dry-run -N2 -n 2 hostname \
 		| stop_tasks_test > stop_tasks.json &&
 	jobid=$(flux job submit stop_tasks.json) &&

--- a/t/t2612-job-shell-pty.t
+++ b/t/t2612-job-shell-pty.t
@@ -34,13 +34,13 @@ terminus_jobid() {
         -s $(shell_service $jobid).terminus "$@"
 }
 
-test_expect_success HAVE_JQ 'pty: submit a job with an interactive pty' '
+test_expect_success 'pty: submit a job with an interactive pty' '
 	id=$(flux submit --flags waitable -o pty.interactive tty) &&
 	terminus_jobid $id list &&
 	$runpty flux job attach ${id} &&
 	flux job wait $id
 '
-test_expect_success HAVE_JQ,NO_CHAIN_LINT 'pty: run job with pty' '
+test_expect_success NO_CHAIN_LINT 'pty: run job with pty' '
 	printf "PS1=XXX:\n" >ps1.rc
 	id=$(flux submit -o pty.interactive bash --rcfile ps1.rc | flux job id)
 	$runpty -o log.job-pty flux job attach ${id} &
@@ -98,7 +98,7 @@ test_expect_success 'pty: pty.ranks can take an idset' '
 	grep 1: ptyss.out &&
 	test_must_fail grep "not a tty" ptyss.out
 '
-test_expect_success HAVE_JQ 'pty: pty.interactive forces a pty on rank 0' '
+test_expect_success 'pty: pty.interactive forces a pty on rank 0' '
 	id=$(flux submit \
 		-o pty.interactive -o pty.ranks=1 \
 		-n2 \

--- a/t/t2613-job-shell-batch.t
+++ b/t/t2613-job-shell-batch.t
@@ -47,7 +47,7 @@ test_expect_success 'flux-shell: per-resource type=node works' '
 	EOF
 	test_cmp per-node.expected per-node.out
 '
-test_expect_success HAVE_JQ 'flux-shell: historical batch jobspec still work' '
+test_expect_success 'flux-shell: historical batch jobspec still work' '
 	for spec in $SHARNESS_TEST_SRCDIR/batch/jobspec/*.json; do
 		input=$(basename $spec) &&
 		cat $spec |

--- a/t/t2616-job-shell-taskmap.t
+++ b/t/t2616-job-shell-taskmap.t
@@ -4,8 +4,6 @@ test_description='Test flux-mini/flux-shell taskmap plugin support'
 
 . `dirname $0`/sharness.sh
 
-skip_all_unless_have jq
-
 test_under_flux 4 job
 
 # Test that actual task ranks match expected ranks.

--- a/t/t2700-mini-cmd.t
+++ b/t/t2700-mini-cmd.t
@@ -96,23 +96,23 @@ test_expect_success 'flux mini run -vvv produces exec events on stderr' '
 	flux mini run -vvv hostname 2>vvv.err &&
 	grep complete vvv.err
 '
-test_expect_success HAVE_JQ 'flux mini submit --time-limit=5d works' '
+test_expect_success 'flux mini submit --time-limit=5d works' '
 	flux mini submit --dry-run --time-limit=5d hostname >t5d.out &&
 	jq -e ".attributes.system.duration == 432000" < t5d.out
 '
-test_expect_success HAVE_JQ 'flux mini submit --time-limit=4h works' '
+test_expect_success 'flux mini submit --time-limit=4h works' '
 	flux mini submit --dry-run --time-limit=4h hostname >t4h.out &&
 	jq -e ".attributes.system.duration == 14400" < t4h.out
 '
-test_expect_success HAVE_JQ 'flux mini submit --time-limit=1m works' '
+test_expect_success 'flux mini submit --time-limit=1m works' '
 	flux mini submit --dry-run --time-limit=5m hostname >t5m.out &&
 	jq -e ".attributes.system.duration == 300" < t5m.out
 '
-test_expect_success HAVE_JQ 'flux mini submit -t5s works' '
+test_expect_success 'flux mini submit -t5s works' '
 	flux mini submit --dry-run -t5s hostname >t5s.out &&
 	jq -e ".attributes.system.duration == 5" < t5s.out
 '
-test_expect_success HAVE_JQ 'flux mini submit -t5 sets 5m duration' '
+test_expect_success 'flux mini submit -t5 sets 5m duration' '
 	flux mini submit --dry-run -t5 hostname >t5.out &&
 	jq -e ".attributes.system.duration == 300" < t5.out
 '
@@ -125,7 +125,7 @@ test_expect_success 'flux mini submit --time-limit=4-00:30:00 fails' '
 	grep -i "invalid Flux standard duration" st2.err
 '
 
-test_expect_success HAVE_JQ 'flux mini submit --queue works' '
+test_expect_success 'flux mini submit --queue works' '
 	flux mini submit --env=-* --dry-run \
 		--queue=batch hostname >queue.out &&
 	jq -e ".attributes.system.queue == \"batch\"" &&
@@ -134,7 +134,7 @@ test_expect_success HAVE_JQ 'flux mini submit --queue works' '
 	jq -e ".attributes.system.queue == \"debug\""
 '
 
-test_expect_success HAVE_JQ 'flux mini submit --setattr works' '
+test_expect_success 'flux mini submit --setattr works' '
 	flux mini submit --env=-* --dry-run \
 		--setattr user.meep=false \
 		--setattr user.foo=\"xxx\" \
@@ -152,7 +152,7 @@ test_expect_success HAVE_JQ 'flux mini submit --setattr works' '
 	jq -e ".attributes.system.bar == 42" attr.out
 '
 
-test_expect_success HAVE_JQ 'flux mini submit --setattr=^ATTR=VAL works' '
+test_expect_success 'flux mini submit --setattr=^ATTR=VAL works' '
 	cat | jq -S . >attr.json <<-EOF &&
 	[
 	  { "foo":"value",
@@ -169,7 +169,7 @@ test_expect_success HAVE_JQ 'flux mini submit --setattr=^ATTR=VAL works' '
 	    jq -S .attributes.user.foo > attrout.json &&
 	test_cmp attr.json attrout.json
 '
-test_expect_success HAVE_JQ 'flux mini submit --setattr=^ detects bad JSON' '
+test_expect_success 'flux mini submit --setattr=^ detects bad JSON' '
 	cat <<-EOF > bad.json &&
 	[ { "foo":"value",
 	    "bar": 42
@@ -192,7 +192,7 @@ test_expect_success HAVE_JQ 'flux mini submit --setattr=^ detects bad JSON' '
 	test_debug "cat attrbadfile.out" &&
 	grep "ERROR:.*nosuchfile" attrbadfile.out
 '
-test_expect_success HAVE_JQ 'flux mini submit --setopt works' '
+test_expect_success 'flux mini submit --setopt works' '
 	flux mini submit --dry-run \
 		--setopt foo=true \
 		--setopt baz \
@@ -201,62 +201,62 @@ test_expect_success HAVE_JQ 'flux mini submit --setopt works' '
 	test $(jq ".attributes.system.shell.options.bar.baz" opt.out) = "42" &&
 	test $(jq ".attributes.system.shell.options.baz" opt.out) = "1"
 '
-test_expect_success HAVE_JQ 'flux mini submit --output passes through to shell' '
+test_expect_success 'flux mini submit --output passes through to shell' '
 	flux mini submit --dry-run --output=my/file hostname >output.out &&
 	test $(jq ".attributes.system.shell.options.output.stdout.type" output.out) = "\"file\"" &&
 	test $(jq ".attributes.system.shell.options.output.stdout.path" output.out) = "\"my/file\""
 '
-test_expect_success HAVE_JQ 'flux mini submit --error passes through to shell' '
+test_expect_success 'flux mini submit --error passes through to shell' '
 	flux mini submit --dry-run --error=/my/error hostname >error.out &&
 	test $(jq ".attributes.system.shell.options.output.stderr.type" error.out) = "\"file\"" &&
 	test $(jq ".attributes.system.shell.options.output.stderr.path" error.out) = "\"/my/error\""
 '
-test_expect_success HAVE_JQ 'flux mini submit --label-io --output passes through to shell' '
+test_expect_success 'flux mini submit --label-io --output passes through to shell' '
 	flux mini submit --dry-run \
 		--label-io --output=foo hostname >labout.out &&
 	test $(jq ".attributes.system.shell.options.output.stdout.label" labout.out) = "true" &&
 	test $(jq ".attributes.system.shell.options.output.stdout.path" labout.out) = "\"foo\""
 '
-test_expect_success HAVE_JQ 'flux mini submit --output id mustache passes through to shell' '
+test_expect_success 'flux mini submit --output id mustache passes through to shell' '
 	flux mini submit --dry-run --output=foo.{{id}} hostname >musid.out &&
 	test $(jq ".attributes.system.shell.options.output.stdout.path" musid.out) = "\"foo.{{id}}\""
 '
-test_expect_success HAVE_JQ 'flux mini submit --cwd passes through to jobspec' '
+test_expect_success 'flux mini submit --cwd passes through to jobspec' '
 	flux mini submit --cwd=/foo/bar/baz hostname > cwd.out &&
 	jq -e ".attributes.system.cwd == \"/foo/bar/baz\""
 '
-test_expect_success HAVE_JQ 'flux mini run --cwd works' '
+test_expect_success 'flux mini run --cwd works' '
 	mkdir cwd_test &&
 	flux mini run --cwd=$(realpath cwd_test) pwd > cwd.out &&
 	test $(cat cwd.out) = $(realpath cwd_test)
 '
-test_expect_success HAVE_JQ 'flux mini submit command arguments work' '
+test_expect_success 'flux mini submit command arguments work' '
 	flux mini submit --dry-run a b c >args.out &&
 	test $(jq ".tasks[0].command[0]" args.out) = "\"a\"" &&
 	test $(jq ".tasks[0].command[1]" args.out) = "\"b\"" &&
 	test $(jq ".tasks[0].command[2]" args.out) = "\"c\""
 '
-test_expect_success HAVE_JQ 'flux mini submit --gpus-per-task adds gpus to task slot' '
+test_expect_success 'flux mini submit --gpus-per-task adds gpus to task slot' '
 	flux mini submit --dry-run -g2 hostname >gpu.out &&
 	test $(jq ".resources[0].with[1].type" gpu.out) = "\"gpu\"" &&
 	test $(jq ".resources[0].with[1].count" gpu.out) = "2"
 '
-test_expect_success HAVE_JQ 'flux mini --job-name works' '
+test_expect_success 'flux mini --job-name works' '
 	flux mini submit --dry-run --job-name=foobar hostname >name.out &&
 	test $(jq ".attributes.system.job.name" name.out) = "\"foobar\""
 '
-test_expect_success HAVE_JQ 'flux-mini --env=-*/--env-remove=* works' '
+test_expect_success 'flux-mini --env=-*/--env-remove=* works' '
 	flux mini submit --dry-run --env=-* hostname > no-env.out &&
 	jq -e ".attributes.system.environment == {}" < no-env.out &&
 	flux mini submit --dry-run --env-remove=* hostname > no-env2.out &&
 	jq -e ".attributes.system.environment == {}" < no-env2.out
 '
-test_expect_success HAVE_JQ 'flux-mini --env=VAR works' '
+test_expect_success 'flux-mini --env=VAR works' '
 	FOO=bar flux mini submit --dry-run \
 	    --env=-* --env FOO hostname >FOO-env.out &&
 	jq -e ".attributes.system.environment == {\"FOO\": \"bar\"}" FOO-env.out
 '
-test_expect_success HAVE_JQ 'flux-mini --env=PATTERN works' '
+test_expect_success 'flux-mini --env=PATTERN works' '
 	FOO_ONE=bar FOO_TWO=baz flux mini submit --dry-run \
 	    --env=-* --env="FOO_*" hostname >FOO-pattern-env.out &&
 	jq -e ".attributes.system.environment == \
@@ -267,7 +267,7 @@ test_expect_success HAVE_JQ 'flux-mini --env=PATTERN works' '
 	    {\"FOO_ONE\": \"bar\", \"FOO_TWO\": \"baz\"}" FOO-pattern2-env.out
 
 '
-test_expect_success HAVE_JQ 'flux-mini --env=VAR=VAL works' '
+test_expect_success 'flux-mini --env=VAR=VAL works' '
 	flux mini submit --dry-run \
 	    --env=-* --env PATH=/bin hostname >PATH-env.out &&
 	jq -e ".attributes.system.environment == {\"PATH\": \"/bin\"}" PATH-env.out &&
@@ -288,7 +288,7 @@ test_expect_success 'flux-mini --env=VAR=$VAL fails when VAL not in env' '
 	test_debug "cat env-notset.err" &&
 	grep "env: Variable .* not found" env-notset.err
 '
-test_expect_success HAVE_JQ 'flux-mini --env-file works' '
+test_expect_success 'flux-mini --env-file works' '
 	cat <<-EOF >envfile &&
 	-*
 	FOO=bar
@@ -300,7 +300,7 @@ test_expect_success HAVE_JQ 'flux-mini --env-file works' '
 	       {\"FOO\":\"bar\", \"BAR\":\"bar/baz\"}" envfile.out
 	done
 '
-test_expect_success HAVE_JQ 'flux-mini propagates some rlimits by default' '
+test_expect_success 'flux-mini propagates some rlimits by default' '
 	flux mini run --dry-run hostname | \
 	    jq .attributes.system.shell.options.rlimit >rlimit-default.out &&
 	# check random sample of rlimits:
@@ -308,29 +308,29 @@ test_expect_success HAVE_JQ 'flux-mini propagates some rlimits by default' '
 	grep stack rlimit-default.out &&
 	grep nofile rlimit-default.out
 '
-test_expect_success HAVE_JQ 'flux-mini --rlimit=-* works' '
+test_expect_success 'flux-mini --rlimit=-* works' '
 	flux mini run --rlimit=-* --dry-run hostname \
 	    | jq -e ".attributes.system.shell.options.rlimit == null"
 '
-test_expect_success HAVE_JQ 'flux-mini --rlimit=name works' '
+test_expect_success 'flux-mini --rlimit=name works' '
 	flux mini run --rlimit=memlock --dry-run hostname \
 	    | jq .attributes.system.shell.options.rlimit >rlimit-memlock.out &&
 	grep memlock rlimit-memlock.out &&
 	grep core rlimit-memlock.out
 '
-test_expect_success HAVE_JQ 'flux-mini --rlimit=name --rlimit=name works' '
+test_expect_success 'flux-mini --rlimit=name --rlimit=name works' '
 	flux mini run --rlimit=memlock --rlimit=ofile --dry-run hostname \
 	    | jq .attributes.system.shell.options.rlimit >rlimit-ofile.out &&
 	grep memlock rlimit-memlock.out &&
 	grep ofile rlimit-memlock.out
 '
-test_expect_success HAVE_JQ 'flux-mini --rlimit=-*,core works' '
+test_expect_success 'flux-mini --rlimit=-*,core works' '
 	flux mini run --rlimit=-*,core --dry-run hostname \
 	    | jq .attributes.system.shell.options.rlimit >rlimit-core.out &&
 	grep core rlimit-core.out &&
 	test_must_fail grep nofile rlimit-core.out
 '
-test_expect_success HAVE_JQ 'flux-mini --rlimit=name=value works' '
+test_expect_success 'flux-mini --rlimit=name=value works' '
 	flux mini run --rlimit=core=16 --dry-run hostname \
 	    | jq -e ".attributes.system.shell.options.rlimit.core == 16" &&
 	inf=$(flux python -c "import resource as r; print(r.RLIM_INFINITY)") &&
@@ -359,14 +359,14 @@ test_expect_success 'flux-mini submit --cc works' '
 	EOF
 	test_cmp cc.output.expected cc.output.sorted
 '
-test_expect_success HAVE_JQ 'flux-mini submit does not substitute {} without --cc' '
+test_expect_success 'flux-mini submit does not substitute {} without --cc' '
 	flux mini submit \
 		--env=-* \
 		--setattr=system.test={} \
 		--dry-run true > nocc.json &&
 	jq -e ".attributes.system.test == {}" < nocc.json
 '
-test_expect_success HAVE_JQ 'flux-mini submit --tasks-per-node works' '
+test_expect_success 'flux-mini submit --tasks-per-node works' '
 	flux mini submit \
 		--env=-* \
 		-N 2 \
@@ -489,7 +489,7 @@ while read line; do
 	args=$(echo $line | awk -F== '{print $1}' | sed 's/  *$//')
 	expected=$(echo $line | awk -F== '{print $2}')
 	per_resource=$(echo $line | awk -F== '{print $3}' | sed 's/  *$//')
-	test_expect_success HAVE_JQ "per-resource: $args" '
+	test_expect_success "per-resource: $args" '
 	    echo $expected >expected.$test_count &&
 	    flux mini run $args --dry-run hostname > jobspec.$test_count &&
 	    $jj < jobspec.$test_count >output.$test_count &&

--- a/t/t2701-mini-batch.t
+++ b/t/t2701-mini-batch.t
@@ -23,17 +23,17 @@ test_expect_success 'create generic test batch script' '
 	flux mini run -n \$ncores hostname
 	EOF
 '
-test_expect_success HAVE_JQ 'flux-mini batch copies script into jobspec' '
+test_expect_success 'flux-mini batch copies script into jobspec' '
 	flux mini batch -n1 --dry-run batch-script.sh | \
 		jq -j .attributes.system.batch.script > script.sh &&
 	test_cmp batch-script.sh script.sh
 '
-test_expect_success HAVE_JQ 'flux-mini batch takes a script on stdin' '
+test_expect_success 'flux-mini batch takes a script on stdin' '
 	flux mini batch -n1 --dry-run < batch-script.sh | \
 		jq -j .attributes.system.batch.script > script-stdin.sh &&
 	test_cmp batch-script.sh script.sh
 '
-test_expect_success HAVE_JQ 'flux mini batch --wrap option works' '
+test_expect_success 'flux mini batch --wrap option works' '
 	flux mini batch -n1 --dry-run --wrap foo bar baz | \
 		jq -j .attributes.system.batch.script >script-wrap.out &&
 	cat <<-EOF >script-wrap.expected &&
@@ -42,7 +42,7 @@ test_expect_success HAVE_JQ 'flux mini batch --wrap option works' '
 	EOF
 	test_cmp script-wrap.expected script-wrap.out
 '
-test_expect_success HAVE_JQ 'flux mini batch --wrap option works on stdin' '
+test_expect_success 'flux mini batch --wrap option works on stdin' '
 	printf "foo\nbar\nbaz\n" | \
 	    flux mini batch -n1 --dry-run --wrap | \
 		jq -j .attributes.system.batch.script >stdin-wrap.out &&
@@ -66,12 +66,12 @@ test_expect_success 'flux-mini batch fails for file without she-bang' '
 test_expect_success 'flux-mini batch fails if -N > -n' '
 	test_expect_code 1 flux mini batch -N4 -n1 --wrap hostname
 '
-test_expect_success HAVE_JQ 'flux-mini batch -N2 requests 2 nodes exclusively' '
+test_expect_success 'flux-mini batch -N2 requests 2 nodes exclusively' '
 	flux mini batch -N2 --wrap --dry-run hostname | \
 		jq -S ".resources[0]" | \
 		jq -e ".type == \"node\" and .exclusive"
 '
-test_expect_success HAVE_JQ 'flux-mini batch --exclusive works' '
+test_expect_success 'flux-mini batch --exclusive works' '
 	flux mini batch -N1 -n1 --exclusive --wrap --dry-run hostname | \
 		jq -S ".resources[0]" | \
 		jq -e ".type == \"node\" and .exclusive"
@@ -156,11 +156,11 @@ test_expect_success 'flux mini batch: flux can bootstrap without broker.mapping'
 		--wrap flux resource info) &&
 	flux job status $id
 '
-test_expect_success HAVE_JQ 'flux mini batch: sets mpi=none by default' '
+test_expect_success 'flux mini batch: sets mpi=none by default' '
 	flux mini batch -N1 --dry-run --wrap hostname | \
 		jq -e ".attributes.system.shell.options.mpi = \"none\""
 '
-test_expect_success HAVE_JQ 'flux mini batch: mpi option can be overridden' '
+test_expect_success 'flux mini batch: mpi option can be overridden' '
 	flux mini batch -o mpi=foo -N1 --dry-run --wrap hostname | \
 		jq -e ".attributes.system.shell.options.mpi = \"foo\""
 '
@@ -188,7 +188,7 @@ test_expect_success 'flux mini batch: --dump=FILE works with mustache' '
 	run_timeout 60 flux job wait $id &&
 	tar tvf testdump-${id}.tgz
 '
-test_expect_success HAVE_JQ 'flux mini batch: supports directives in script' '
+test_expect_success 'flux mini batch: supports directives in script' '
 	cat <<-EOF >directives.sh &&
 	#!/bin/sh
 	# flux: -n1
@@ -198,7 +198,7 @@ test_expect_success HAVE_JQ 'flux mini batch: supports directives in script' '
 	flux mini batch --dry-run directives.sh > directives.json &&
 	jq -e ".attributes.system.job.name == \"test-name\"" < directives.json
 '
-test_expect_success HAVE_JQ 'flux mini batch: cmdline overrides directives' '
+test_expect_success 'flux mini batch: cmdline overrides directives' '
 	cat <<-EOF >directives2.sh &&
 	#!/bin/sh
 	# flux: -n1

--- a/t/t2702-mini-alloc.t
+++ b/t/t2702-mini-alloc.t
@@ -18,24 +18,24 @@ runpty="${SHARNESS_TEST_SRCDIR}/scripts/runpty.py -f asciicast"
 test_expect_success 'flux-mini alloc with no args return error' '
 	test_expect_code 1 flux mini alloc
 '
-test_expect_success HAVE_JQ 'flux-mini alloc sets command to flux broker' '
+test_expect_success 'flux-mini alloc sets command to flux broker' '
 	flux mini alloc -n1 --dry-run | \
 	    jq -e ".tasks[0].command == [ \"flux\", \"broker\" ]"
 '
-test_expect_success HAVE_JQ 'flux-mini alloc appends broker options' '
+test_expect_success 'flux-mini alloc appends broker options' '
 	flux mini alloc -n1 --broker-opts=-v --dry-run | \
 	    jq -e ".tasks[0].command == [ \"flux\", \"broker\", \"-v\" ]"
 '
-test_expect_success HAVE_JQ 'flux-mini alloc can set initial-program' '
+test_expect_success 'flux-mini alloc can set initial-program' '
 	flux mini alloc -n1 --dry-run myapp --foo | \
 	    jq -e ".tasks[0].command == [ \"flux\", \"broker\", \"myapp\", \"--foo\" ]"
 '
-test_expect_success HAVE_JQ 'flux-mini alloc -N2 requests 2 nodes exclusively' '
+test_expect_success 'flux-mini alloc -N2 requests 2 nodes exclusively' '
 	flux mini alloc -N2 --dry-run hostname | \
 		jq -S ".resources[0]" | \
 		jq -e ".type == \"node\" and .exclusive"
 '
-test_expect_success HAVE_JQ 'flux-mini alloc --exclusive works' '
+test_expect_success 'flux-mini alloc --exclusive works' '
 	flux mini alloc -N1 -n1 --exclusive --dry-run hostname | \
 		jq -S ".resources[0]" | \
 		jq -e ".type == \"node\" and .exclusive"
@@ -125,11 +125,11 @@ test_expect_success NO_CHAIN_LINT 'flux-mini alloc --bg errors when job is cance
 	test_must_fail wait $pid &&
 	grep "unexpectedly exited" canceled.log
 '
-test_expect_success HAVE_JQ 'flux mini alloc: sets mpi=none by default' '
+test_expect_success 'flux mini alloc: sets mpi=none by default' '
 	flux mini alloc -N1 --dry-run hostname | \
 		jq -e ".attributes.system.shell.options.mpi = \"none\""
 '
-test_expect_success HAVE_JQ 'flux mini alloc: mpi option can be overridden' '
+test_expect_success 'flux mini alloc: mpi option can be overridden' '
 	flux mini alloc -o mpi=foo -N1 --dry-run hostname | \
 		jq -e ".attributes.system.shell.options.mpi = \"foo\""
 '

--- a/t/t2710-python-cli-submit.t
+++ b/t/t2710-python-cli-submit.t
@@ -54,23 +54,23 @@ test_expect_success 'flux submit --flags=novalidate works' '
 test_expect_success 'flux submit with bad flags fails' '
 	test_must_fail flux submit --flags notaflag /bin/true
 '
-test_expect_success HAVE_JQ 'flux submit --time-limit=5d works' '
+test_expect_success 'flux submit --time-limit=5d works' '
 	flux submit --dry-run --time-limit=5d hostname >t5d.out &&
 	jq -e ".attributes.system.duration == 432000" < t5d.out
 '
-test_expect_success HAVE_JQ 'flux submit --time-limit=4h works' '
+test_expect_success 'flux submit --time-limit=4h works' '
 	flux submit --dry-run --time-limit=4h hostname >t4h.out &&
 	jq -e ".attributes.system.duration == 14400" < t4h.out
 '
-test_expect_success HAVE_JQ 'flux submit --time-limit=1m works' '
+test_expect_success 'flux submit --time-limit=1m works' '
 	flux submit --dry-run --time-limit=5m hostname >t5m.out &&
 	jq -e ".attributes.system.duration == 300" < t5m.out
 '
-test_expect_success HAVE_JQ 'flux submit -t5s works' '
+test_expect_success 'flux submit -t5s works' '
 	flux submit --dry-run -t5s hostname >t5s.out &&
 	jq -e ".attributes.system.duration == 5" < t5s.out
 '
-test_expect_success HAVE_JQ 'flux submit -t5 sets 5m duration' '
+test_expect_success 'flux submit -t5 sets 5m duration' '
 	flux submit --dry-run -t5 hostname >t5.out &&
 	jq -e ".attributes.system.duration == 300" < t5.out
 '
@@ -83,15 +83,15 @@ test_expect_success 'flux submit --time-limit=4-00:30:00 fails' '
 	grep -i "invalid Flux standard duration" st2.err
 '
 
-test_expect_success HAVE_JQ 'flux submit --queue works' '
+test_expect_success 'flux submit --queue works' '
 	flux submit --env=-* --dry-run --queue=batch hostname >queue.out && grep -i "batch" queue.out
 '
 
-test_expect_success HAVE_JQ 'flux submit --queue works' '
+test_expect_success 'flux submit --queue works' '
 	flux submit --env=-* --dry-run -q debug hostname >queue2.out && grep -i "debug" queue2.out
 '
 
-test_expect_success HAVE_JQ 'flux submit --setattr works' '
+test_expect_success 'flux submit --setattr works' '
 	flux submit --env=-* --dry-run \
 		--setattr user.meep=false \
 		--setattr user.foo=\"xxx\" \
@@ -109,7 +109,7 @@ test_expect_success HAVE_JQ 'flux submit --setattr works' '
 	jq -e ".attributes.system.bar == 42" attr.out
 '
 
-test_expect_success HAVE_JQ 'flux submit --setattr=^ATTR=VAL works' '
+test_expect_success 'flux submit --setattr=^ATTR=VAL works' '
 	cat | jq -S . >attr.json <<-EOF &&
 	[
 	  { "foo":"value",
@@ -126,7 +126,7 @@ test_expect_success HAVE_JQ 'flux submit --setattr=^ATTR=VAL works' '
 	    jq -S .attributes.user.foo > attrout.json &&
 	test_cmp attr.json attrout.json
 '
-test_expect_success HAVE_JQ 'flux submit --setattr=^ detects bad JSON' '
+test_expect_success 'flux submit --setattr=^ detects bad JSON' '
 	cat <<-EOF > bad.json &&
 	[ { "foo":"value",
 	    "bar": 42
@@ -149,7 +149,7 @@ test_expect_success HAVE_JQ 'flux submit --setattr=^ detects bad JSON' '
 	test_debug "cat attrbadfile.out" &&
 	grep "ERROR:.*nosuchfile" attrbadfile.out
 '
-test_expect_success HAVE_JQ 'flux submit --setopt works' '
+test_expect_success 'flux submit --setopt works' '
 	flux submit --dry-run \
 		--setopt foo=true \
 		--setopt baz \
@@ -158,57 +158,57 @@ test_expect_success HAVE_JQ 'flux submit --setopt works' '
 	test $(jq ".attributes.system.shell.options.bar.baz" opt.out) = "42" &&
 	test $(jq ".attributes.system.shell.options.baz" opt.out) = "1"
 '
-test_expect_success HAVE_JQ 'flux submit --output passes through to shell' '
+test_expect_success 'flux submit --output passes through to shell' '
 	flux submit --dry-run --output=my/file hostname >output.out &&
 	test $(jq ".attributes.system.shell.options.output.stdout.type" output.out) = "\"file\"" &&
 	test $(jq ".attributes.system.shell.options.output.stdout.path" output.out) = "\"my/file\""
 '
-test_expect_success HAVE_JQ 'flux submit --error passes through to shell' '
+test_expect_success 'flux submit --error passes through to shell' '
 	flux submit --dry-run --error=/my/error hostname >error.out &&
 	test $(jq ".attributes.system.shell.options.output.stderr.type" error.out) = "\"file\"" &&
 	test $(jq ".attributes.system.shell.options.output.stderr.path" error.out) = "\"/my/error\""
 '
-test_expect_success HAVE_JQ 'flux submit --label-io --output passes through to shell' '
+test_expect_success 'flux submit --label-io --output passes through to shell' '
 	flux submit --dry-run \
 		--label-io --output=foo hostname >labout.out &&
 	test $(jq ".attributes.system.shell.options.output.stdout.label" labout.out) = "true" &&
 	test $(jq ".attributes.system.shell.options.output.stdout.path" labout.out) = "\"foo\""
 '
-test_expect_success HAVE_JQ 'flux submit --output id mustache passes through to shell' '
+test_expect_success 'flux submit --output id mustache passes through to shell' '
 	flux submit --dry-run --output=foo.{{id}} hostname >musid.out &&
 	test $(jq ".attributes.system.shell.options.output.stdout.path" musid.out) = "\"foo.{{id}}\""
 '
-test_expect_success HAVE_JQ 'flux submit --cwd passes through to jobspec' '
+test_expect_success 'flux submit --cwd passes through to jobspec' '
 	flux submit --cwd=/foo/bar/baz hostname > cwd.out &&
 	jq -e ".attributes.system.cwd == \"/foo/bar/baz\""
 '
-test_expect_success HAVE_JQ 'flux submit command arguments work' '
+test_expect_success 'flux submit command arguments work' '
 	flux submit --dry-run a b c >args.out &&
 	test $(jq ".tasks[0].command[0]" args.out) = "\"a\"" &&
 	test $(jq ".tasks[0].command[1]" args.out) = "\"b\"" &&
 	test $(jq ".tasks[0].command[2]" args.out) = "\"c\""
 '
-test_expect_success HAVE_JQ 'flux submit --gpus-per-task adds gpus to task slot' '
+test_expect_success 'flux submit --gpus-per-task adds gpus to task slot' '
 	flux submit --dry-run -g2 hostname >gpu.out &&
 	test $(jq ".resources[0].with[1].type" gpu.out) = "\"gpu\"" &&
 	test $(jq ".resources[0].with[1].count" gpu.out) = "2"
 '
-test_expect_success HAVE_JQ 'flux submit --job-name works' '
+test_expect_success 'flux submit --job-name works' '
 	flux submit --dry-run --job-name=foobar hostname >name.out &&
 	test $(jq ".attributes.system.job.name" name.out) = "\"foobar\""
 '
-test_expect_success HAVE_JQ 'flux submit --env=-*/--env-remove=* works' '
+test_expect_success 'flux submit --env=-*/--env-remove=* works' '
 	flux submit --dry-run --env=-* hostname > no-env.out &&
 	jq -e ".attributes.system.environment == {}" < no-env.out &&
 	flux submit --dry-run --env-remove=* hostname > no-env2.out &&
 	jq -e ".attributes.system.environment == {}" < no-env2.out
 '
-test_expect_success HAVE_JQ 'flux submit --env=VAR works' '
+test_expect_success 'flux submit --env=VAR works' '
 	FOO=bar flux submit --dry-run \
 	    --env=-* --env FOO hostname >FOO-env.out &&
 	jq -e ".attributes.system.environment == {\"FOO\": \"bar\"}" FOO-env.out
 '
-test_expect_success HAVE_JQ 'flux submit --env=PATTERN works' '
+test_expect_success 'flux submit --env=PATTERN works' '
 	FOO_ONE=bar FOO_TWO=baz flux submit --dry-run \
 	    --env=-* --env="FOO_*" hostname >FOO-pattern-env.out &&
 	jq -e ".attributes.system.environment == \
@@ -219,7 +219,7 @@ test_expect_success HAVE_JQ 'flux submit --env=PATTERN works' '
 	    {\"FOO_ONE\": \"bar\", \"FOO_TWO\": \"baz\"}" FOO-pattern2-env.out
 
 '
-test_expect_success HAVE_JQ 'flux submit --env=VAR=VAL works' '
+test_expect_success 'flux submit --env=VAR=VAL works' '
 	flux submit --dry-run \
 	    --env=-* --env PATH=/bin hostname >PATH-env.out &&
 	jq -e ".attributes.system.environment == {\"PATH\": \"/bin\"}" PATH-env.out &&
@@ -227,7 +227,7 @@ test_expect_success HAVE_JQ 'flux submit --env=VAR=VAL works' '
 	    --env=-* --env FOO=\$FOO:baz hostname >FOO-append.out &&
 	jq -e ".attributes.system.environment == {\"FOO\": \"bar:baz\"}" FOO-append.out
 '
-test_expect_success HAVE_JQ 'flux submit --env-file works' '
+test_expect_success 'flux submit --env-file works' '
 	cat <<-EOF >envfile &&
 	-*
 	FOO=bar
@@ -255,14 +255,14 @@ test_expect_success 'flux submit --cc works' '
 	EOF
 	test_cmp cc.output.expected cc.output.sorted
 '
-test_expect_success HAVE_JQ 'flux submit does not substitute {} without --cc' '
+test_expect_success 'flux submit does not substitute {} without --cc' '
 	flux submit \
 		--env=-* \
 		--setattr=system.test={} \
 		--dry-run true > nocc.json &&
 	jq -e ".attributes.system.test == {}" < nocc.json
 '
-test_expect_success HAVE_JQ 'flux submit --tasks-per-node works' '
+test_expect_success 'flux submit --tasks-per-node works' '
 	flux submit \
 		--env=-* \
 		-N 2 \

--- a/t/t2711-python-cli-run.t
+++ b/t/t2711-python-cli-run.t
@@ -56,7 +56,7 @@ test_expect_success 'flux run -vvv produces exec events on stderr' '
 	grep complete vvv.err
 '
 
-test_expect_success HAVE_JQ 'flux run --cwd works' '
+test_expect_success 'flux run --cwd works' '
 	mkdir cwd_test &&
 	flux run --cwd=$(realpath cwd_test) pwd > cwd.out &&
 	test $(cat cwd.out) = $(realpath cwd_test)
@@ -74,7 +74,7 @@ test_expect_success 'flux run --env=VAR=$VAL fails when VAL not in env' '
 	test_debug "cat env-notset.err" &&
 	grep "env: Variable .* not found" env-notset.err
 '
-test_expect_success HAVE_JQ 'flux run propagates some rlimits by default' '
+test_expect_success 'flux run propagates some rlimits by default' '
 	flux run --dry-run hostname | \
 	    jq .attributes.system.shell.options.rlimit >rlimit-default.out &&
 	# check random sample of rlimits:
@@ -82,29 +82,29 @@ test_expect_success HAVE_JQ 'flux run propagates some rlimits by default' '
 	grep stack rlimit-default.out &&
 	grep nofile rlimit-default.out
 '
-test_expect_success HAVE_JQ 'flux run --rlimit=-* works' '
+test_expect_success 'flux run --rlimit=-* works' '
 	flux run --rlimit=-* --dry-run hostname \
 	    | jq -e ".attributes.system.shell.options.rlimit == null"
 '
-test_expect_success HAVE_JQ 'flux run --rlimit=name works' '
+test_expect_success 'flux run --rlimit=name works' '
 	flux run --rlimit=memlock --dry-run hostname \
 	    | jq .attributes.system.shell.options.rlimit >rlimit-memlock.out &&
 	grep memlock rlimit-memlock.out &&
 	grep core rlimit-memlock.out
 '
-test_expect_success HAVE_JQ 'flux run --rlimit=name --rlimit=name works' '
+test_expect_success 'flux run --rlimit=name --rlimit=name works' '
 	flux run --rlimit=memlock --rlimit=ofile --dry-run hostname \
 	    | jq .attributes.system.shell.options.rlimit >rlimit-ofile.out &&
 	grep memlock rlimit-memlock.out &&
 	grep ofile rlimit-memlock.out
 '
-test_expect_success HAVE_JQ 'flux run --rlimit=-*,core works' '
+test_expect_success 'flux run --rlimit=-*,core works' '
 	flux run --rlimit=-*,core --dry-run hostname \
 	    | jq .attributes.system.shell.options.rlimit >rlimit-core.out &&
 	grep core rlimit-core.out &&
 	test_must_fail grep nofile rlimit-core.out
 '
-test_expect_success HAVE_JQ 'flux run --rlimit=name=value works' '
+test_expect_success 'flux run --rlimit=name=value works' '
 	flux run --rlimit=core=16 --dry-run hostname \
 	    | jq -e ".attributes.system.shell.options.rlimit.core == 16" &&
 	inf=$(flux python -c "import resource as r; print(r.RLIM_INFINITY)") &&
@@ -229,7 +229,7 @@ while read line; do
 	args=$(echo $line | awk -F== '{print $1}' | sed 's/  *$//')
 	expected=$(echo $line | awk -F== '{print $2}')
 	per_resource=$(echo $line | awk -F== '{print $3}' | sed 's/  *$//')
-	test_expect_success HAVE_JQ "per-resource: $args" '
+	test_expect_success "per-resource: $args" '
 	    echo $expected >expected.$test_count &&
 	    flux run $args --dry-run hostname > jobspec.$test_count &&
 	    $jj < jobspec.$test_count >output.$test_count &&

--- a/t/t2712-python-cli-alloc.t
+++ b/t/t2712-python-cli-alloc.t
@@ -17,22 +17,22 @@ runpty="${SHARNESS_TEST_SRCDIR}/scripts/runpty.py -f asciicast"
 test_expect_success 'flux alloc with no args return error' '
 	test_expect_code 1 flux alloc
 '
-test_expect_success HAVE_JQ 'flux alloc sets command to flux broker' '
+test_expect_success 'flux alloc sets command to flux broker' '
 	flux alloc -n1 --dry-run | \
 	    jq -e ".tasks[0].command == [ \"flux\", \"broker\" ]"
 '
-test_expect_success HAVE_JQ 'flux alloc appends broker options' '
+test_expect_success 'flux alloc appends broker options' '
 	flux alloc -n1 --broker-opts=-v --dry-run | \
 	    jq -e ".tasks[0].command == [ \"flux\", \"broker\", \"-v\" ]"
 '
-test_expect_success HAVE_JQ 'flux alloc can set initial-program' '
+test_expect_success 'flux alloc can set initial-program' '
 	flux alloc -n1 --dry-run myapp --foo | \
 	    jq -e ".tasks[0].command == [ \"flux\", \"broker\", \"myapp\", \"--foo\" ]"
 '
-test_expect_success HAVE_JQ 'flux alloc -N2 requests 2 nodes exclusively' '
+test_expect_success 'flux alloc -N2 requests 2 nodes exclusively' '
 	flux alloc -N2 --dry-run hostname | jq -S ".resources[0]" | jq -e ".type == \"node\" and .exclusive"
 '
-test_expect_success HAVE_JQ 'flux alloc --exclusive works' '
+test_expect_success 'flux alloc --exclusive works' '
 	flux alloc -N1 -n1 --exclusive --dry-run hostname | jq -S ".resources[0]" | jq -e ".type == \"node\" and .exclusive"
 '
 test_expect_success 'flux alloc fails if N > n' '
@@ -111,11 +111,11 @@ test_expect_success NO_CHAIN_LINT 'flux alloc --bg errors when job is canceled' 
 	test_must_fail wait $pid &&
 	grep "unexpectedly exited" canceled.log
 '
-test_expect_success HAVE_JQ 'flux alloc: sets mpi=none by default' '
+test_expect_success 'flux alloc: sets mpi=none by default' '
 	flux alloc -N1 --dry-run hostname | \
 		jq -e ".attributes.system.shell.options.mpi = \"none\""
 '
-test_expect_success HAVE_JQ 'flux alloc: mpi option can be overridden' '
+test_expect_success 'flux alloc: mpi option can be overridden' '
 	flux alloc -o mpi=foo -N1 --dry-run hostname | \
 		jq -e ".attributes.system.shell.options.mpi = \"foo\""
 '

--- a/t/t2714-python-cli-batch.t
+++ b/t/t2714-python-cli-batch.t
@@ -23,17 +23,17 @@ test_expect_success 'create generic test batch script' '
 	flux run -n \$ncores hostname
 	EOF
 '
-test_expect_success HAVE_JQ 'flux batch copies script into jobspec' '
+test_expect_success 'flux batch copies script into jobspec' '
 	flux batch -n1 --dry-run batch-script.sh | \
 		jq -j .attributes.system.batch.script > script.sh &&
 	test_cmp batch-script.sh script.sh
 '
-test_expect_success HAVE_JQ 'flux batch takes a script on stdin' '
+test_expect_success 'flux batch takes a script on stdin' '
 	flux batch -n1 --dry-run < batch-script.sh | \
 		jq -j .attributes.system.batch.script > script-stdin.sh &&
 	test_cmp batch-script.sh script.sh
 '
-test_expect_success HAVE_JQ 'flux batch --wrap option works' '
+test_expect_success 'flux batch --wrap option works' '
 	flux batch -n1 --dry-run --wrap foo bar baz | \
 		jq -j .attributes.system.batch.script >script-wrap.out &&
 	cat <<-EOF >script-wrap.expected &&
@@ -42,7 +42,7 @@ test_expect_success HAVE_JQ 'flux batch --wrap option works' '
 	EOF
 	test_cmp script-wrap.expected script-wrap.out
 '
-test_expect_success HAVE_JQ 'flux batch --wrap option works on stdin' '
+test_expect_success 'flux batch --wrap option works on stdin' '
 	printf "foo\nbar\nbaz\n" | \
 	    flux batch -n1 --dry-run --wrap | \
 		jq -j .attributes.system.batch.script >stdin-wrap.out &&
@@ -66,12 +66,12 @@ test_expect_success 'flux batch fails for file without she-bang' '
 test_expect_success 'flux batch fails if -N > -n' '
 	test_expect_code 1 flux batch -N4 -n1 --wrap hostname
 '
-test_expect_success HAVE_JQ 'flux batch -N2 requests 2 nodes exclusively' '
+test_expect_success 'flux batch -N2 requests 2 nodes exclusively' '
 	flux batch -N2 --wrap --dry-run hostname | \
 		jq -S ".resources[0]" | \
 		jq -e ".type == \"node\" and .exclusive"
 '
-test_expect_success HAVE_JQ 'flux batch --exclusive works' '
+test_expect_success 'flux batch --exclusive works' '
 	flux batch -N1 -n1 --exclusive --wrap --dry-run hostname | \
 		jq -S ".resources[0]" | \
 		jq -e ".type == \"node\" and .exclusive"
@@ -156,11 +156,11 @@ test_expect_success 'flux batch: flux can bootstrap without broker.mapping' '
 		--wrap flux resource info) &&
 	flux job status $id
 '
-test_expect_success HAVE_JQ 'flux batch: sets mpi=none by default' '
+test_expect_success 'flux batch: sets mpi=none by default' '
 	flux batch -N1 --dry-run --wrap hostname | \
 		jq -e ".attributes.system.shell.options.mpi = \"none\""
 '
-test_expect_success HAVE_JQ 'flux batch: mpi option can be overridden' '
+test_expect_success 'flux batch: mpi option can be overridden' '
 	flux batch -o mpi=foo -N1 --dry-run --wrap hostname | \
 		jq -e ".attributes.system.shell.options.mpi = \"foo\""
 '
@@ -188,7 +188,7 @@ test_expect_success 'flux batch: --dump=FILE works with mustache' '
 	run_timeout 60 flux job wait $id &&
 	tar tvf testdump-${id}.tgz
 '
-test_expect_success HAVE_JQ 'flux batch: supports directives in script' '
+test_expect_success 'flux batch: supports directives in script' '
 	cat <<-EOF >directives.sh &&
 	#!/bin/sh
 	# flux: -n1
@@ -198,7 +198,7 @@ test_expect_success HAVE_JQ 'flux batch: supports directives in script' '
 	flux batch --dry-run directives.sh > directives.json &&
 	jq -e ".attributes.system.job.name == \"test-name\"" < directives.json
 '
-test_expect_success HAVE_JQ 'flux batch: cmdline overrides directives' '
+test_expect_success 'flux batch: cmdline overrides directives' '
 	cat <<-EOF >directives2.sh &&
 	#!/bin/sh
 	# flux: -n1

--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -87,7 +87,7 @@ test_expect_success 'configure testing queues' '
 	flux queue start --all
 '
 
-test_expect_success HAVE_JQ 'submit jobs for job list testing' '
+test_expect_success 'submit jobs for job list testing' '
 	#  Create `hostname` and `sleep` jobspec
 	#  N.B. Used w/ `flux job submit` for serial job submission
 	#  for efficiency (vs serial `flux submit`.
@@ -1175,7 +1175,7 @@ find_invalid_userid() {
 	                print (next(i for i in range(65536) if not i in ids));'
 }
 
-test_expect_success HAVE_JQ 'flux-jobs reverts username to userid for invalid ids' '
+test_expect_success 'flux-jobs reverts username to userid for invalid ids' '
 	id=$(find_invalid_userid) &&
 	test_debug "echo first invalid userid is ${id}" &&
 	printf "%s\n" $id > invalid_userid.expected &&

--- a/t/t2806-config-cmd.t
+++ b/t/t2806-config-cmd.t
@@ -32,12 +32,12 @@ test_expect_success 'flux-config get --help prints usage' '
 	flux config get --help 2>get_help.out &&
 	grep -i "query broker configuration values" get_help.out
 '
-test_expect_success HAVE_JQ 'flux-config dumps entire object' '
+test_expect_success 'flux-config dumps entire object' '
 	echo 42 >foo.a.exp &&
 	flux config get | jq -r .foo.a >foo.a.out &&
 	test_cmp foo.a.exp foo.a.out
 '
-test_expect_success HAVE_JQ 'flux-config get dumps table' '
+test_expect_success 'flux-config get dumps table' '
 	flux config get foo | jq -r .a >foo.a2.out &&
 	test_cmp foo.a.exp foo.a2.out
 '
@@ -83,12 +83,12 @@ test_expect_success 'flux-config get --type=boolean dumps bool table member' '
 	flux config get --type=boolean foo.e >foo.e.out &&
 	test_cmp foo.d.exp foo.d.out
 '
-test_expect_success HAVE_JQ 'flux-config get --type=array dumps array' '
+test_expect_success 'flux-config get --type=array dumps array' '
 	echo barfu >foo.f1.exp &&
 	flux config get --type=array foo.f | jq -r -e ".[1]" >foo.f1.out &&
 	test_cmp foo.f1.exp foo.f1.out
 '
-test_expect_success HAVE_JQ 'flux-config get --type=object dumps table' '
+test_expect_success 'flux-config get --type=object dumps table' '
 	echo true >foo.bar.a.exp &&
 	flux config get --type=object foo.bar | jq -e ".a" >foo.bar.a.out &&
 	test_cmp foo.bar.a.exp foo.bar.a.out
@@ -133,21 +133,21 @@ test_expect_success 'flux-config load handles TOML input' '
 	flux config load <load.toml &&
 	flux config get >load.json
 '
-test_expect_success HAVE_JQ 'flux-config get returns loaded JSON' '
+test_expect_success 'flux-config get returns loaded JSON' '
 	jq -e ".test.y.z == 42" load.json
 '
 test_expect_success 'flux-config load handles empty input' '
 	flux config load </dev/null &&
 	flux config get >empty.json
 '
-test_expect_success HAVE_JQ 'now the config is empty' '
+test_expect_success 'now the config is empty' '
 	jq -e ". == {}" empty.json
 '
 test_expect_success 'flux-config load handles JSON input' '
 	flux config load <load.json &&
 	flux config get >load2.json
 '
-test_expect_success HAVE_JQ 'flux-config get returns loaded JSON' '
+test_expect_success 'flux-config get returns loaded JSON' '
 	jq -e ".test.y.z == 42" load2.json
 '
 test_expect_success 'flux-config load handles TOML directory' '
@@ -158,7 +158,7 @@ test_expect_success 'flux-config load handles TOML directory' '
 	flux config load conf.d &&
 	flux config get >fromfiles.json
 '
-test_expect_success HAVE_JQ 'flux-config get returns loaded JSON' '
+test_expect_success 'flux-config get returns loaded JSON' '
 	jq -e ".test.a.b.c == 999" fromfiles.json
 '
 test_expect_success 'flux-config load PATH fails on invalid TOML' '

--- a/t/t2809-job-purge.t
+++ b/t/t2809-job-purge.t
@@ -155,7 +155,7 @@ test_expect_success 'reconfigure job manager with inactive-age-limit=1ms' '
 test_expect_success 'wait for job-list inactive job count to reach 0' '
 	wait_inactive_count job-list 0 30
 '
-test_expect_success HAVE_JQ 'confirm job-list stats show zero inactive jobs' '
+test_expect_success 'confirm job-list stats show zero inactive jobs' '
 	test $(inactive_count job-list-stats) -eq 0
 '
 test_expect_success 'reconfigure job manager with incorrect type limit' '

--- a/t/t2900-job-timelimits.t
+++ b/t/t2900-job-timelimits.t
@@ -19,7 +19,7 @@ test_expect_success 'job time limits are enforced' '
 		flux run --time-limit=${TIMEOUT}s sleep 30 2>limit1.err &&
 	grep "resource allocation expired" limit1.err
 '
-test_expect_success HAVE_JQ 'job timelimits are propagated' '
+test_expect_success 'job timelimits are propagated' '
 	cat <<-EOF >limit.sh &&
 	#!/bin/sh -e
 	round() { printf "%.0f" \$1; }

--- a/t/t3300-system-basic.t
+++ b/t/t3300-system-basic.t
@@ -28,7 +28,7 @@ test_expect_success 'startctl status works' '
 	$startctl status
 '
 
-test_expect_success HAVE_JQ 'broker overlay shows 2 connected children' '
+test_expect_success 'broker overlay shows 2 connected children' '
 	test $(overlay_connected_children) -eq 2
 '
 test_expect_success 'testcert was used to authenticate' '
@@ -48,12 +48,12 @@ test_expect_success 'broker exits with no error' '
 	run_timeout 30 $startctl wait 2
 '
 
-test_expect_success HAVE_JQ 'startctl shows rank 2 pid is -1' '
+test_expect_success 'startctl shows rank 2 pid is -1' '
 	pid=$($startctl status | jq -r ".procs[2].pid") &&
 	test "$pid" = "-1"
 '
 
-test_expect_success HAVE_JQ 'broker overlay shows 1 connected child' '
+test_expect_success 'broker overlay shows 1 connected child' '
 	test $(overlay_connected_children) -eq 1
 '
 

--- a/t/t3301-system-latestart.t
+++ b/t/t3301-system-latestart.t
@@ -22,7 +22,7 @@ test_expect_success 'broker.quorum was set to 0 by system test personality' '
 	flux getattr broker.quorum >quorum.out &&
 	test_cmp quorum.exp quorum.out
 '
-test_expect_success HAVE_JQ 'startctl shows rank 1 pids as -1' '
+test_expect_success 'startctl shows rank 1 pids as -1' '
 	test $($startctl status | jq -r ".procs[1].pid") = "-1"
 '
 
@@ -59,7 +59,7 @@ test_expect_success 'start rank 1' '
 	$startctl run 1
 '
 
-test_expect_success HAVE_JQ 'startctl shows rank 1 pid not -1' '
+test_expect_success 'startctl shows rank 1 pid not -1' '
 	test $($startctl status | jq -r ".procs[1].pid") != "-1"
 '
 

--- a/t/t3302-system-offline.t
+++ b/t/t3302-system-offline.t
@@ -23,7 +23,7 @@ test_expect_success 'start rank 2 before TBON parent is up' '
 	$startctl run 2
 '
 
-test_expect_success HAVE_JQ 'startctl shows rank 1 pid as -1' '
+test_expect_success 'startctl shows rank 1 pid as -1' '
         test $($startctl status | jq -r ".procs[1].pid") = "-1"
 '
 

--- a/t/t3303-system-healthcheck.t
+++ b/t/t3303-system-healthcheck.t
@@ -115,7 +115,7 @@ test_expect_success 'wait for rank 0 overlay status to be partial' '
 # Just because rank 0 is partial doesn't mean rank 3 is offline yet
 # (shutdown starts at the leaves, and rank 3 will turn partial as
 # soon as one of its children goes offline)
-test_expect_success HAVE_JQ 'wait for rank 1 to lose connection with rank 3' '
+test_expect_success 'wait for rank 1 to lose connection with rank 3' '
 	wait_connected 1 1 10 0.2
 '
 


### PR DESCRIPTION
This PR makes `jq` a hard requirement for all sharness tests, and then removes all the related `HAVE_JQ`, `jq` wrappers, and `TEST_CHECK_PREREQS` uses in the testsuite, which were all there just to make sure `HAVE_JQ` was used appropriately.

Now test authors can use `jq` in tests without having to worry if they've set prereqs properly etc.