### PR TITLE
add deploy to GitHub packages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -91,6 +91,8 @@ jobs:
       DOCKER_USERNAME: travisflux
       DOCKER_PASSWORD: ${{ secrets.DOCKER_HUB_TRAVISFLUX_TOKEN }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_ACTOR: ${{ github.actor }}     
+      GITHUB_PACKAGE_REPO: ghcr.io/flux-framework/flux-core
     timeout-minutes: 60
     strategy:
       matrix: ${{fromJson(needs.generate-matrix.outputs.matrix)}}

--- a/src/test/docker-deploy.sh
+++ b/src/test/docker-deploy.sh
@@ -10,26 +10,32 @@ if test "$GITHUB_REPOSITORY" != "flux-framework/flux-core"; then
     exit 0
 fi
 
-test -n "$DOCKER_REPO" ||     die "DOCKER_REPO not set"
-test -n "$DOCKER_PASSWORD" || die "DOCKER_PASSWORD not set"
-test -n "$DOCKER_USERNAME" || die "DOCKER_USERNAME not set"
-test -n "$DOCKER_TAG" ||      die "DOCKER_TAG not set"
+test -n "$DOCKER_REPO"         || die "DOCKER_REPO not set"
+test -n "$DOCKER_PASSWORD"     || die "DOCKER_PASSWORD not set"
+test -n "$DOCKER_USERNAME"     || die "DOCKER_USERNAME not set"
+test -n "$DOCKER_TAG"          || die "DOCKER_TAG not set"
+test -n "$GITHUB_TOKEN"        || die "GITHUB_TOKEN not set"
+test -n "$GITHUB_ACTOR"        || die "GITHUB_ACTOR not set"
+test -n "$GITHUB_PACKAGE_REPO" || die "GITHUB_PACKAGE_REPO not set"
+test -n "$GITHUB_PACKAGES_TAG" || die "GITHUB_PACKAGES_TAG not set"
 
+echo $GITHUB_TOKEN | docker login ghcr.io -u ${GITHUB_ACTOR} --password-stdin
 echo $DOCKER_PASSWORD | docker login -u "$DOCKER_USERNAME" --password-stdin
 
 log "docker push ${DOCKER_TAG}"
 docker push ${DOCKER_TAG}
+docker tag ${DOCKER_TAG} ${GITHUB_PACKAGES_TAG}
+docker push ${GITHUB_PACKAGES_TAG}
 
-#  If this is the bionic build, then also tag without image name:
-if echo "$DOCKER_TAG" | grep -q "bionic"; then
-    t="${DOCKER_REPO}:${GITHUB_TAG:-latest}"
+function push_bionic() {
+    URI="${1}"
+    t="${URI}:${GITHUB_TAG:-latest}"
     log "docker push ${t}"
     docker tag "$DOCKER_TAG" ${t} && docker push ${t}
-fi
+}
 
-#  If this is the el8 build, then build fluxorama image
-if echo "$DOCKER_TAG" | grep -q "el8"; then
-    FLUXORAMA="fluxrm/fluxorama"
+function build_fluxorama() {
+    FLUXORAMA=${1}
     docker build -t ${FLUXORAMA} src/test/docker/fluxorama
     docker push ${FLUXORAMA}
     if test -n "$GITHUB_TAG"; then
@@ -37,4 +43,21 @@ if echo "$DOCKER_TAG" | grep -q "el8"; then
         log "docker push ${t}"
         docker tag ${FLUXORAMA} ${t} && docker push ${t}
     fi
+}
+
+#  If this is the bionic build, then also tag without image name:
+if echo "$DOCKER_TAG" | grep -q "bionic"; then
+
+    # Docker Hub and GitHub packages
+    push_bionic ${DOCKER_REPO}
+    push_bionic ${GITHUB_PACKAGE_REPO}
+    
+fi
+
+#  If this is the el8 build, then build fluxorama image
+if echo "$DOCKER_TAG" | grep -q "el8"; then
+
+    build_fluxorama "fluxrm/fluxorama"
+    build_fluxorama "ghcr.io/flux-framework/fluxorama"
+
 fi

--- a/src/test/generate-matrix.py
+++ b/src/test/generate-matrix.py
@@ -19,7 +19,7 @@ default_args = (
 )
 
 DOCKER_REPO = "fluxrm/flux-core"
-
+GITHUB_PACKAGE_REPO = 'ghcr.io/flux-framework/flux-core'
 
 class BuildMatrix:
     def __init__(self):
@@ -41,9 +41,14 @@ class BuildMatrix:
         """Create docker tag string if this is master branch or a tag"""
         if self.branch == "master" or self.tag:
             tag = f"{DOCKER_REPO}:{image}"
+            github_tag = f"{GITHUB_PACKAGE_REPO}:{image}"
             if self.tag:
                 tag += f"-{self.tag}"
+                github_tag += f"-{self.tag}"
             env["DOCKER_TAG"] = tag
+
+            # Create one for GitHub packages too - will tag at push time
+            env['GITHUB_PACKAGES_TAG'] = github_tag
             command += f" --tag={tag}"
             return True, command
 


### PR DESCRIPTION
Problem: Docker might be taking away OSS project repos 
Solution: Do a double deploy to include ghcr.io as a backup!

I'm not super familiar with how the push is done - but I found a script that generates the build matrix, and the deploy shell script, and made changes to both.