### PR TITLE
rewrite flux-resource status

### DIFF
--- a/doc/man1/flux-resource.rst
+++ b/doc/man1/flux-resource.rst
@@ -71,14 +71,19 @@ COMMANDS
 **status**  [-n] [-o FORMAT] [-s STATE,...] [--skip-empty]
    Show system view of resources. This command queries both the resource
    service and scheduler to identify resources that are available,
-   excluded by configuration, or administratively drained or draining. The
-   command also identifies nodes that offline vs online.
+   excluded by configuration, or administratively drained or draining.
+
+   The **status** command displays a line of output for each set of
+   resources that share a state and online/offline state. The possible
+   states are "avail" (available for scheduling when up), "exclude"
+   (excluded by configuration), "draining" (drained but still allocated),
+   or "drained".
 
    With *-s,--states=STATE,...*, the set of resource states is restricted
-   to a list of provided states. Valid states include "online", "offline",
-   "avail", "exclude", "draining", "drained", "drained*", and "all".  The
-   special "drain" state is also supported, and selects both draining and
-   drained resources.
+   to a list of provided states or offline/online status. With "online" or
+   "offline", only nodes with the provided status will be displayed. Other
+   valid states include "avail", "exclude", "draining", "drained", and "all".
+   The special "drain" state is shorthand for "drained,draining".
 
    The *-o,--format=FORMAT* option customizes output formatting (See the
    OUTPUT FORMAT section below for details).
@@ -144,8 +149,19 @@ The following field names can be specified for the **status** and **drain**
 subcommands:
 
 **state**
-   State of node(s): "online", "offline", "avail", "exclude", "drain",
-   "draining", "drained", "all"
+   State of node(s): "avail", "exclude", "drain", "draining", "drained". If
+   the set of resources is offline, an asterisk suffix is appended to the
+   state, e.g. "avail*".
+
+**statex**
+   Like **state**, but exclude the asterisk for offline resources.
+
+**status**
+   Current online/offline status of nodes(s): "online", "offline"
+
+**up**
+   Displays a *✔* if the node is online, or *✗* if offline. An ascii *y*
+   or *n* may be used instead with **up.ascii**.
 
 **nnodes**
    number of nodes

--- a/doc/man1/flux-resource.rst
+++ b/doc/man1/flux-resource.rst
@@ -48,30 +48,46 @@ COMMANDS
 ========
 
 **list** [-n] [-o FORMAT] [-s STATE,...]
-   Show scheduler view of resources. The *-n,--no-header* option suppresses
-   header from output,  *-o,--format=FORMAT*, customizes output formatting
-   (see below), and  *-s,--states=STATE,...* limits output to specified
-   resource states, where valid states are "up", "down", "allocated",
-   "free", and "all".  Note that the scheduler represents "offline",
-   "exclude", and "drain" resource states as "down" due to its simplified
+   Show scheduler view of resources.
+
+   With *-s,--states=STATE,...*, the set of resource states is restricted
+   to a list of provided states. Valid states include "up", "down",
+   "allocated", "free", and "all". Note that the scheduler represents
+   offline, excluded, and drained resources as "down" due to the simplified
    interface with the resource service defined by RFC 27.
+
+   The *-o,--format=FORMAT* option may be used to customize the output
+   format (See OUTPUT FORMAT section below).
+
+   The *-n,--no-header* option suppresses header from output,
 
 **info** [-s STATE,...]
    Show a brief, single line summary of scheduler view of resources.
+
    With *-s, --states=STATE,...*, limit the output to specified resource
    states as with ``flux resource list``. By default, the *STATE* reported
    by ``flux resource info`` is "all".
 
 **status**  [-n] [-o FORMAT] [-s STATE,...] [--skip-empty]
-   Show system view of resources.  The *-n,--no-header* suppresses
-   header from output, *-o,--format=FORMAT* customizes output formatting
-   (see below), and *-s,--states=STATE,...* limits output to specified
-   resource states, where valid states are "online", "offline", "avail",
-   "exclude", "draining", "drained", "drained*", and "all". The special
-   "drain" state is also supported, and selects both draining and drained
-   resources. Normally, ``flux resource status`` skips lines with no
-   resources, unless the ``-s, --states`` option is used. Suppression of
-   empty lines can always be forced with the ``--skip-empty`` option.
+   Show system view of resources. This command queries both the resource
+   service and scheduler to identify resources that are available,
+   excluded by configuration, or administratively drained or draining. The
+   command also identifies nodes that offline vs online.
+
+   With *-s,--states=STATE,...*, the set of resource states is restricted
+   to a list of provided states. Valid states include "online", "offline",
+   "avail", "exclude", "draining", "drained", "drained*", and "all".  The
+   special "drain" state is also supported, and selects both draining and
+   drained resources.
+
+   The *-o,--format=FORMAT* option customizes output formatting (See the
+   OUTPUT FORMAT section below for details).
+
+   With *-n,--no-header* the output header is suppressed.
+
+   Normally, ``flux resource status`` skips lines with no resources,
+   unless the ``-s, --states`` option is used. Suppression of empty lines
+   can may be forced with the ``--skip-empty`` option.
 
 **drain** [-n] [-o FORMAT] [-f] [-u] [targets] [reason ...]
    If specified without arguments, list drained nodes. In this mode,

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -704,3 +704,4 @@ Zq
 testprog
 libc
 unbuffered
+statex

--- a/src/bindings/python/flux/Makefile.am
+++ b/src/bindings/python/flux/Makefile.am
@@ -53,6 +53,7 @@ nobase_fluxpy_PYTHON = \
 	resource/ResourceSetImplementation.py \
 	resource/ResourceSet.py \
 	resource/list.py \
+	resource/status.py \
 	hostlist.py \
 	idset.py \
 	progress.py \

--- a/src/bindings/python/flux/resource/__init__.py
+++ b/src/bindings/python/flux/resource/__init__.py
@@ -11,3 +11,4 @@
 from flux.resource.Rlist import Rlist
 from flux.resource.ResourceSet import ResourceSet
 from flux.resource.list import resource_list, SchedResourceList
+from flux.resource.status import resource_status, ResourceStatus

--- a/src/bindings/python/flux/resource/status.py
+++ b/src/bindings/python/flux/resource/status.py
@@ -1,0 +1,164 @@
+###############################################################
+# Copyright 2023 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+from typing import NamedTuple
+
+from flux.idset import IDset
+from flux.resource import ResourceSet, resource_list
+from flux.rpc import RPC
+
+
+class DrainInfo(NamedTuple):
+    """
+    Drained resource information tuple.
+    Attributes:
+        timestamp (float): timestamp at which resource was drained
+        reason (str): message recorded when resources were drained
+        ranks (IDset): idset of drain ranks with this reason and timestamp
+
+    """
+
+    ranks: IDset
+    timestamp: float
+    reason: str
+
+
+class ResourceStatus:
+    """
+    Container for combined information from resource module and scheduler.
+
+    Attributes:
+        nodelist (Hostlist): rank ordered set of hostnames
+        all (IDset): idset of all known ranks
+        avail (IDset): idset of ranks not excluded or drained
+        offline (IDset): idset of ranks currently offline
+        online (IDset): idset of ranks currently online
+        exclude (IDset): idset of ranks excluded by configuration
+        allocated (IDset): idset of ranks with one or more jobs
+        drained (IDset): idset of ranks drained and not allocated
+        draining (IDset): idset of ranks drained and allocated
+        drain_info (list): list of DrainInfo object for drain ranks
+    """
+
+    def __init__(self, rstatus=None, allocated_ranks=None):
+        # Allow "empty" ResourceStatus object to be created:
+        if rstatus is None:
+            rstatus = dict(R=None, offline="", online="", exclude="", drain={})
+        if allocated_ranks is None:
+            allocated_ranks = IDset()
+
+        self.rset = ResourceSet(rstatus["R"])
+
+        # get idset of all ranks and nodelist:
+        self.all = self.rset.ranks
+        self.nodelist = self.rset.nodelist
+
+        # offline/online
+        self.offline = IDset(rstatus["offline"])
+        self.online = IDset(rstatus["online"])
+
+        # excluded: excluded by configuration
+        self.exclude = IDset(rstatus["exclude"])
+
+        # allocated: online and allocated by scheduler
+        self.allocated = allocated_ranks
+
+        # drained: free+drain
+        self.drained = IDset()
+        # draining: allocated+drain
+        self.draining = IDset()
+
+        # drain_info: ranks, timestamp, reason tuples for all drained resources
+        self.drain_info = []
+        for drain_ranks, entry in rstatus["drain"].items():
+            ranks = IDset(drain_ranks)
+            self.drained += ranks - self.allocated
+            self.draining += ranks - self.drained
+            info = DrainInfo(ranks, entry["timestamp"], entry["reason"])
+            self.drain_info.append(info)
+
+        # available: all ranks not excluded or drained/draining
+        self.avail = self.all - self.get_idset("exclude", "drained", "draining")
+
+    def __getitem__(self, state):
+        """
+        Allow a ResourceStatus object to be subscriptable for convenience,
+        e.g. self.drained == self["drained"]
+        """
+        return getattr(self, state)
+
+    def get_idset(self, *args):
+        """
+        Return an idset of ranks that are the union of all states in args
+        """
+        ids = IDset()
+        for state in args:
+            ids.add(self[state])
+        return ids
+
+    def get_drain_info(self, rank):
+        """
+        Find and return the DrainInfo object for rank ``rank``
+        """
+        if rank not in self.all:
+            raise ValueError("invalid rank {rank}")
+        return next((i for i in self.drain_info if rank in i.ranks), None)
+
+
+class ResourceStatusRPC:
+    """
+    A ResourceStatusRPC encapsulates a query to both the resource module
+    and scheduler and returns a ResourceStatus object.
+    """
+
+    def __init__(self, handle):
+        self.rpcs = [
+            RPC(handle, "resource.status", nodeid=0, flags=0),
+            resource_list(handle),
+        ]
+        self.rlist = None
+        self.rstatus = None
+        self.allocated_ranks = None
+
+    def get_status(self):
+        if self.rstatus is None:
+            self.rstatus = self.rpcs[0].get()
+        return self.rstatus
+
+    def get_allocated_ranks(self):
+        if self.allocated_ranks is None:
+            try:
+                self.rlist = self.rpcs[1].get()
+                self.allocated_ranks = self.rlist.allocated.ranks
+            except EnvironmentError:
+                self.allocated_ranks = IDset()
+        return self.allocated_ranks
+
+    def get(self):
+        """
+        Return a ResourceStatus object corresponding to the request
+        Blocks until all RPCs are fulfilled
+        """
+        return ResourceStatus(self.get_status(), self.get_allocated_ranks())
+
+
+def resource_status(flux_handle):
+    """
+    Initiate RPCs to scheduler and resource module and return a ResourceStatus
+    object holding the result.
+
+    Args:
+        flux_handle (flux.Flux): a Flux handle
+
+    Returns:
+        ResourceStatusRPC: A future representing the request. Call .get()
+         to get the ResourceStatus result.
+    """
+    return ResourceStatusRPC(flux_handle)

--- a/src/bindings/python/flux/util.py
+++ b/src/bindings/python/flux/util.py
@@ -676,6 +676,8 @@ class OutputFormat:
             if callable(pre):
                 pre(item)
             line = formatter.format(item)
+            if not line:
+                continue
             try:
                 print(line)
             except UnicodeEncodeError:

--- a/src/bindings/python/flux/util.py
+++ b/src/bindings/python/flux/util.py
@@ -686,6 +686,55 @@ class OutputFormat:
                 post(item)
 
 
+class Deduplicator:
+    """
+    Generic helper to deduplicate a list of formatted items for objects
+    that can be aggregated.
+
+    Args:
+        formatter (OutputFormat): Formatter instance to use for deduplication
+        except_fields (list): List of fields to not consider when merging
+            like lines. These are typically fields that can be combined, such
+            as a node count, node list, ranks, etc.
+        combine (callable): A function that is used to combine matching
+            items, called as combine(existing, new).
+    """
+
+    def __init__(self, formatter, except_fields=None, combine=None):
+        self.formatter = formatter.copy(except_fields=except_fields)
+        self.combine = combine
+        self.hash = {}
+        self.items = []
+        #  Allow class to be iterable https://stackoverflow.com/a/48670014
+        self.__iter = None
+
+    def __iter__(self):
+        if self.__iter is None:
+            self.__iter = iter(self.items)
+        return self
+
+    def __next__(self):
+        try:
+            return next(self.__iter)
+        except StopIteration:  # support repeated iteration
+            self.__iter = None
+            raise
+
+    def append(self, item):
+        """
+        Append a new item to a deduplicator. Combines item with an existing
+        entry if the formatted result is identical to another entry.
+        """
+        key = self.formatter.format(item)
+        try:
+            result = self.hash[key]
+            if self.combine is not None:
+                self.combine(result, item)
+        except KeyError:
+            self.hash[key] = item
+            self.items.append(item)
+
+
 class Tree:
     """Very simple pstree-like display for the console
 

--- a/src/bindings/python/flux/util.py
+++ b/src/bindings/python/flux/util.py
@@ -539,13 +539,20 @@ class OutputFormat:
         formatter = self.HeaderFormatter()
         return formatter.format(self.header_format(), **self.headings)
 
-    def get_format_prepended(self, prepend):
+    def get_format_prepended(self, prepend, except_fields=None):
         """
         Return the format string, ensuring that the string in "prepend"
         is prepended to each format field
         """
+        if except_fields is None:
+            except_fields = []
         lst = []
         for (text, field, spec, conv) in self.format_list:
+            # Skip this field if it is in except_fields
+            if field in except_fields:
+                # Preserve any format "prefix" (i.e. the text):
+                lst.append(text)
+                continue
             # If field doesn't have 'prepend' then add it
             if field and not field.startswith(prepend):
                 field = prepend + field
@@ -559,6 +566,18 @@ class OutputFormat:
         if orig:
             return self.fmt_orig
         return self.fmt
+
+    def copy(self, except_fields=None):
+        """
+        Return a copy of the current formatter, optionally with some
+        fields removed
+        """
+        cls = self.__class__
+        return cls(
+            self.get_format_prepended("", except_fields),
+            headings=self.headings,
+            prepend=self.prepend,
+        )
 
     def format(self, obj):
         """

--- a/src/cmd/flux-resource.py
+++ b/src/cmd/flux-resource.py
@@ -152,6 +152,24 @@ def undrain(args):
     RPC(flux.Flux(), "resource.undrain", {"targets": args.targets}, nodeid=0).get()
 
 
+class AltField:
+    """
+    Convenient wrapper for fields that have an ascii and non-ascii
+    representation. Allows the ascii representation to be selected with
+    {field.ascii}.
+    """
+
+    def __init__(self, default, ascii):
+        self.default = default
+        self.ascii = ascii
+
+    def __str__(self):
+        return self.default
+
+    def __format__(self, fmt):
+        return str(self).__format__(fmt)
+
+
 class ResourceStatusLine:
     """Information specific to a given flux resource status line"""
 
@@ -186,6 +204,10 @@ class ResourceStatusLine:
     @property
     def status(self):
         return "online" if self._online else "offline"
+
+    @property
+    def up(self):
+        return AltField("✔", "y") if self._online else AltField("✗", "n")
 
     @property
     def nodelist(self):
@@ -311,6 +333,8 @@ def status(args):
         "reason": "REASON",
         "timestamp": "TIME",
         "status": "STATUS",
+        "up": "UP",
+        "up.ascii": "UP",
     }
 
     #  Emit list of valid states if requested

--- a/src/cmd/flux-resource.py
+++ b/src/cmd/flux-resource.py
@@ -554,6 +554,10 @@ LOGGER = logging.getLogger("flux-resource")
 
 @flux.util.CLIMain(LOGGER)
 def main():
+    sys.stdout = open(
+        sys.stdout.fileno(), "w", encoding="utf8", errors="surrogateescape"
+    )
+
     parser = argparse.ArgumentParser(prog="flux-resource")
     subparsers = parser.add_subparsers(
         title="subcommands", description="", dest="subcommand"

--- a/src/cmd/flux-resource.py
+++ b/src/cmd/flux-resource.py
@@ -36,7 +36,7 @@ class FluxResourceConfig(UtilConfig):
     builtin_formats["status"] = {
         "default": {
             "description": "Default flux-resource status format string",
-            "format": "{state:>10} {nnodes:>6} {nodelist}",
+            "format": "{state:>10} {up:>2} {nnodes:>6} {nodelist}",
         },
         "long": {
             "description": "Long flux-resource status format string",

--- a/src/cmd/flux-resource.py
+++ b/src/cmd/flux-resource.py
@@ -40,7 +40,10 @@ class FluxResourceConfig(UtilConfig):
         },
         "long": {
             "description": "Long flux-resource status format string",
-            "format": "{state:>10} {nnodes:>6} {reason:<30.30+} {nodelist}",
+            "format": (
+                "{state:>10} {color_up}{up:>2}{color_off} "
+                "{nnodes:>6} {reason:<30.30+} {nodelist}"
+            ),
         },
     }
     builtin_formats["drain"] = {

--- a/src/cmd/flux-resource.py
+++ b/src/cmd/flux-resource.py
@@ -16,11 +16,17 @@ import os.path
 import sys
 
 import flux
-from flux.future import WaitAllFuture
+from flux.hostlist import Hostlist
 from flux.idset import IDset
-from flux.resource import ResourceSet, SchedResourceList, resource_list
+from flux.resource import (
+    ResourceSet,
+    ResourceStatus,
+    SchedResourceList,
+    resource_list,
+    resource_status,
+)
 from flux.rpc import RPC
-from flux.util import UtilConfig
+from flux.util import Deduplicator, UtilConfig
 
 
 class FluxResourceConfig(UtilConfig):
@@ -146,26 +152,40 @@ def undrain(args):
     RPC(flux.Flux(), "resource.undrain", {"targets": args.targets}, nodeid=0).get()
 
 
-class StatusLine:
+class ResourceStatusLine:
     """Information specific to a given flux resource status line"""
 
-    def __init__(self, state, ranks, hosts, reason=None, timestamp=None):
-        self.state = state
-        self.hostlist = hosts
-        self.rank_idset = ranks
-        if reason:
-            self.reason = reason
-        else:
-            self.reason = ""
-        if timestamp:
-            self.timestamp = timestamp
-        else:
-            self.timestamp = ""
+    def __init__(self, state, online, ranks, hosts, reason="", timestamp=""):
+        self._state = state
+        self._online = online
+        self.hostlist = Hostlist(hosts)
+        self._ranks = IDset(ranks)
+        self.reason = reason
+        self.timestamp = timestamp
 
     def update(self, ranks, hosts):
-        self.rank_idset.add(ranks)
+        self._ranks.add(ranks)
         self.hostlist.append(hosts)
         self.hostlist.sort()
+
+    @property
+    def statex(self):
+        return self._state
+
+    @property
+    def state(self):
+        state = self._state
+        if not self._online:
+            state += "*"
+        return state
+
+    @property
+    def offline(self):
+        return not self._online
+
+    @property
+    def status(self):
+        return "online" if self._online else "offline"
 
     @property
     def nodelist(self):
@@ -173,177 +193,71 @@ class StatusLine:
 
     @property
     def ranks(self):
-        return str(self.rank_idset)
+        return str(self._ranks)
 
     @property
     def nnodes(self):
         return len(self.hostlist)
 
+    def __repr__(self):
+        return f"{self.state} {self.hostlist}"
 
-def split_draining(drain_ranks, allocated_ranks, offline_ranks=None):
+
+def status_excluded(online, include_online, include_offline):
     """
-    Given drain_ranks and allocated_ranks, return "drained" vs "draining"
-    idsets as (IDset, state) tuples in a list of 1 or 2 elements.
+    Return true if the current online status is excluded
     """
-    if offline_ranks is None:
-        offline_ranks = IDset()
-    draining = drain_ranks.intersect(allocated_ranks)
-    drowned = drain_ranks.intersect(offline_ranks)
-    drained = drain_ranks.difference(draining).subtract(drowned)
-    return [
-        (drain_ranks.copy(), "drain"),
-        (draining, "draining"),
-        (drained, "drained"),
-        (drowned, "drained*"),
-    ]
+    included = (online and include_online) or (not online and include_offline)
+    return not included
 
 
-class ListStatusRPC(WaitAllFuture):
-    """Combination sched.resource-status and resource.status RPC
-
-    Inclusion of sched.resource-status response allows drain/draining
-    differentiation in resource status and drain command outputs.
+def statuslines(rstatus, states, formatter, include_online=True, include_offline=True):
     """
-
-    def __init__(self, handle):
-        # Initiate RPCs to both resource.status and sched.resource-status:
-        children = [RPC(handle, "resource.status", nodeid=0), resource_list(handle)]
-        self.rlist = None
-        self.rstatus = None
-        self.allocated_ranks = None
-        super().__init__(children)
-
-    def get_status(self):
-        if not self.rstatus:
-            self.get()
-            self.rstatus = self.children[0].get()
-        return self.rstatus
-
-    def get_allocated_ranks(self):
-        if not self.allocated_ranks:
-            #
-            #  If the scheduler is not loaded, do not propagate an error,
-            #   just return an empty idset for allocated ranks.
-            #
-            try:
-                self.get()
-                self.rlist = self.children[1].get()
-                self.allocated_ranks = self.rlist.allocated.ranks
-            except EnvironmentError:
-                self.allocated_ranks = IDset()
-        return self.allocated_ranks
-
-
-class ResourceStatus:
-    """Container for resource.status RPC response"""
-
-    # pylint: disable=too-many-instance-attributes
-
-    def __init__(self, rset=None, rlist=None):
-        self.rset = ResourceSet(rset)
-        self.rlist = rlist
-        self.nodelist = self.rset.nodelist
-        self.all = self.rset.ranks
-        self.statuslines = []
-        self.bystate = {}
-        self.idsets = {}
-
-    def __iter__(self):
-        for line in self.statuslines:
-            yield line
-
-    @property
-    def avail(self):
-        avail = self.all.copy()
-        avail.subtract(self.idsets["offline"])
-        avail.subtract(self.idsets["drain"])
-        avail.subtract(self.idsets["exclude"])
-        return avail
-
-    @property
-    def offline(self):
-        return self.idsets["offline"]
-
-    def _idset_update(self, state, idset):
-        if state not in self.idsets:
-            self.idsets[state] = IDset()
-        self.idsets[state].add(idset)
-
-    def find(self, state, reason="", timestamp=""):
-        try:
-            return self.bystate[f"{state}:{reason}:{timestamp}"]
-        except KeyError:
-            return None
-
-    def append(self, state, ranks="", reason=None, timestamp=None):
-        #
-        # If an existing status line has matching state and reason
-        #  update instead of appending a new output line:
-        #  (mainly useful for "drain" when reasons are not displayed)
-        #
-        hosts = self.nodelist[ranks]
-        rstatus = self.find(state, reason)
-        if rstatus:
-            rstatus.update(ranks, hosts)
-        else:
-            line = StatusLine(state, ranks, hosts, reason, timestamp)
-            self.bystate[f"{state}:{reason}:{timestamp}"] = line
-            self.statuslines.append(line)
-
-        self._idset_update(state, ranks)
-
-    @classmethod
-    def from_status_response(cls, resp, fmt, allocated=None):
-
-        #  Return empty ResourceStatus object if resp not set:
-        #  (mainly used for testing)
-        if not resp:
-            return cls()
-
-        if allocated is None:
-            allocated = IDset()
-
-        if isinstance(resp, str):
-            resp = json.loads(resp)
-
-        rstat = cls(resp["R"])
-
-        #  Append a line for listing all ranks/hosts
-        rstat.append("all", rstat.all)
-
-        #  "online", "offline", "exclude" keys contain idsets
-        #    specifying the set of ranks in that state:
-        #
-        for state in ["online", "offline", "exclude"]:
-            rstat.append(state, IDset(resp[state]))
-
-        #  "drain" key contains a dict of idsets with timestamp,reason
-        #
-        drained = 0
-        for drain_ranks, entry in resp["drain"].items():
-            for ranks, state in split_draining(
-                IDset(drain_ranks), allocated, rstat.offline
-            ):
-                #  Only include reason if it will be displayed in format
-                reason, timestamp = "", ""
-                if ranks:
-                    if "reason" in fmt:
-                        reason = entry["reason"]
-                    if "timestamp" in fmt:
-                        timestamp = entry["timestamp"]
-
-                rstat.append(state, IDset(ranks), reason, timestamp)
-                drained = drained + 1
-
-        #  If no drained nodes, append an empty StatusLine
-        if drained == 0:
-            for state in ["drain", "draining", "drained"]:
-                rstat.append(state)
-
-        #  "avail" is computed from above
-        rstat.append("avail", rstat.avail)
-
-        return rstat
+    Given a ResourceStatus object and OutputFormat formatter,
+    return a set of deduplicated ResourceStatusLine objects for
+    display.
+    """
+    result = Deduplicator(
+        formatter=formatter,
+        except_fields=["nodelist", "ranks", "nnodes"],
+        combine=lambda line, arg: line.update(arg.ranks, arg.hostlist),
+    )
+    states = set(states)
+    for state in ["avail", "exclude"]:
+        if not states & {state, "all"}:
+            continue
+        for online in (True, False):
+            if status_excluded(online, include_online, include_offline):
+                continue
+            status_ranks = rstatus["online" if online else "offline"]
+            ranks = rstatus[state].intersect(status_ranks)
+            result.append(
+                ResourceStatusLine(state, online, ranks, rstatus.nodelist[ranks])
+            )
+    for state in ["draining", "drained"]:
+        if not states & {state, "all", "drain"}:
+            continue
+        ranks = rstatus[state]
+        if not ranks:
+            if not status_excluded(True, include_online, include_offline):
+                # Append one empty line for "draining" and "drained":
+                result.append(ResourceStatusLine(state, True, "", ""))
+        for rank in ranks:
+            online = rank in rstatus.online
+            if status_excluded(online, include_online, include_offline):
+                continue
+            info = rstatus.get_drain_info(rank)
+            result.append(
+                ResourceStatusLine(
+                    state,
+                    online,
+                    rank,
+                    rstatus.nodelist[rank],
+                    timestamp=info.timestamp,
+                    reason=info.reason,
+                )
+            )
+    return result
 
 
 def status_help(args, valid_states, headings):
@@ -367,6 +281,11 @@ def status_get_state_list(args, valid_states, default_states):
             LOGGER.info("valid states: %s", ",".join(valid_states))
             sys.exit(1)
 
+    #  If only offline and/or online are specified, then append other
+    #  default states to states list, o/w status will return nothing
+    copy = list(filter(lambda x: x not in ("offline", "online"), states))
+    if not copy:
+        states.extend(default_states.split(","))
     return states
 
 
@@ -380,17 +299,18 @@ def status(args):
         "drain",
         "draining",
         "drained",
-        "drained*",
     ]
-    default_states = "avail,offline,exclude,draining,drained,drained*"
+    default_states = "avail,exclude,draining,drained"
 
     headings = {
-        "state": "STATUS",
+        "state": "STATE",
+        "statex": "STATE",
         "nnodes": "NNODES",
         "ranks": "RANKS",
         "nodelist": "NODELIST",
         "reason": "REASON",
         "timestamp": "TIME",
+        "status": "STATUS",
     }
 
     #  Emit list of valid states if requested
@@ -404,28 +324,37 @@ def status(args):
 
     #  Get payload from stdin or from resource.status RPC:
     if args.from_stdin:
-        resp = sys.stdin.read()
-        allocated = IDset()
+        input_str = sys.stdin.read()
+        rstatus = ResourceStatus(json.loads(input_str) if input_str else None)
     else:
-        rpc = ListStatusRPC(flux.Flux())
-        resp = rpc.get_status()
-        allocated = rpc.get_allocated_ranks()
-
-    rstat = ResourceStatus.from_status_response(resp, fmt, allocated)
+        rstatus = resource_status(flux.Flux()).get()
 
     formatter = flux.util.OutputFormat(fmt, headings=headings)
 
-    #  Skip empty lines unless --states or ---skip-empty
+    #  Skip empty lines unless --states or --skip-empty
     skip_empty = args.skip_empty or not args.states
 
-    lines = []
-    for line in sorted(rstat, key=lambda x: valid_states.index(x.state)):
-        if line.state not in states:
-            continue
-        if line.nnodes == 0 and skip_empty:
-            continue
-        lines.append(line)
+    #  Skip empty offline lines unless offline explicily requested
+    skip_empty_offline = "offline" not in states
 
+    #  Include both online and offline lines by default, except if
+    #  one of those statuses are explicitly requested, then it
+    #  becomes exclusive (unless both are present).
+    include_online = "online" in states or "offline" not in states
+    include_offline = "offline" in states or "online" not in states
+
+    lines = []
+    for line in statuslines(
+        rstatus,
+        states,
+        formatter,
+        include_online=include_online,
+        include_offline=include_offline,
+    ):
+        if line.nnodes == 0:
+            if skip_empty or line.offline and skip_empty_offline:
+                continue
+        lines.append(line)
     formatter.print_items(lines, no_header=args.no_header)
 
 
@@ -433,7 +362,7 @@ def drain_list(args):
     fmt = FluxResourceConfig("drain").load().get_format_string(args.format)
     args.from_stdin = False
     args.format = fmt
-    args.states = "drained,drained*,draining"
+    args.states = "drain"
     args.skip_empty = True
     status(args)
 

--- a/t/flux-resource/status/drain.expected
+++ b/t/flux-resource/status/drain.expected
@@ -1,3 +1,3 @@
-    STATUS NNODES RANKS           NODELIST
+     STATE NNODES RANKS           NODELIST
      avail      2 2-3             foo[3-4]
    drained      2 0-1             foo[1-2]

--- a/t/flux-resource/status/example.expected
+++ b/t/flux-resource/status/example.expected
@@ -1,6 +1,5 @@
-    STATUS NNODES RANKS           NODELIST
+     STATE NNODES RANKS           NODELIST
      avail      2 2-3             foo[3-4]
-   offline      1 1               foo2
    exclude      1 0               foo1
    drained      1 0               foo1
   drained*      1 1               foo2

--- a/t/flux-resource/status/exclude.expected
+++ b/t/flux-resource/status/exclude.expected
@@ -1,4 +1,4 @@
-    STATUS NNODES RANKS           NODELIST
+     STATE NNODES RANKS           NODELIST
      avail      2 2-3             foo[3-4]
-   offline      1 1               foo2
+    avail*      1 1               foo2
    exclude      1 0               foo1

--- a/t/flux-resource/status/offline.expected
+++ b/t/flux-resource/status/offline.expected
@@ -1,3 +1,3 @@
-    STATUS NNODES RANKS           NODELIST
+     STATE NNODES RANKS           NODELIST
      avail      3 0,2-3           foo[1,3-4]
-   offline      1 1               foo2
+    avail*      1 1               foo2

--- a/t/flux-resource/status/simple.expected
+++ b/t/flux-resource/status/simple.expected
@@ -1,2 +1,2 @@
-    STATUS NNODES RANKS           NODELIST
+     STATE NNODES RANKS           NODELIST
      avail      4 0-3             foo[1-4]

--- a/t/t2351-resource-status-input.t
+++ b/t/t2351-resource-status-input.t
@@ -11,6 +11,8 @@ test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
 FORMAT="{state:>10} {nnodes:>6} {ranks:<15} {nodelist}"
 INPUTDIR=${SHARNESS_TEST_SRCDIR}/flux-resource/status
 
+export FLUX_PYCLI_LOGLEVEL=10
+
 for input in ${INPUTDIR}/*.json; do
     name=$(basename ${input%%.json})
     test_expect_success "flux-resource status input check: $name" '
@@ -26,7 +28,8 @@ done
 
 test_expect_success 'flux-resource status: header included with all formats' '
 	cat <<-EOF >headers.expected &&
-	state==STATUS
+	state==STATE
+	status=STATUS
 	nnodes==NNODES
 	ranks==RANKS
 	nodelist==NODELIST
@@ -42,7 +45,7 @@ test_expect_success 'flux-resource status: header included with all formats' '
 test_expect_success 'flux-resource status: --no-header works' '
 	INPUT=${INPUTDIR}/example.json &&
 	name=no-header &&
-	flux resource status -s all --no-header --from-stdin < $INPUT \
+	flux resource status -s exclude --no-header --from-stdin < $INPUT \
 	    > ${name}.out &&
 	test_debug "cat ${name}.out" &&
 	test $(wc -l < ${name}.out) -eq 1

--- a/t/t2351-resource-status-input.t
+++ b/t/t2351-resource-status-input.t
@@ -96,4 +96,88 @@ test_expect_success 'flux-resource status: invalid state generates error' '
 	grep "Invalid resource state frelled specified" bad-state.out
 '
 
+test_expect_success 'flux-resource status: {status} field works' '
+	INPUT=${INPUTDIR}/example.json &&
+	flux resource status --from-stdin -o "{status:>8} {nnodes}" < $INPUT \
+		>status.output &&
+	cat <<-EOF >status.expected &&
+	  STATUS NNODES
+	  online 4
+	 offline 1
+	EOF
+	test_cmp status.expected status.output
+'
+
+test_expect_success 'flux-resource status: {up} field works' '
+	INPUT=${INPUTDIR}/example.json &&
+	flux resource status --from-stdin -o "{up:>2} {nnodes}" < $INPUT \
+		>up.output &&
+	cat <<-EOF >up.expected &&
+	UP NNODES
+	 ✔ 4
+	 ✗ 1
+	EOF
+	test_cmp up.expected up.output
+'
+
+test_expect_success 'flux-resource status: {up.ascii} field works' '
+	INPUT=${INPUTDIR}/example.json &&
+	flux resource status --from-stdin -o "{up.ascii:>2} {nnodes}" < $INPUT \
+		>up.ascii.output &&
+	cat <<-EOF >up.ascii.expected &&
+	UP NNODES
+	 y 4
+	 n 1
+	EOF
+	test_cmp up.ascii.expected up.ascii.output
+'
+
+test_expect_success 'flux-resource status: {color_up} works' '
+	INPUT=${INPUTDIR}/example.json &&
+	flux resource status -n --color --states=offline --from-stdin \
+		-o "{color_up}{nnodes}{color_off}" \
+		<$INPUT >color.out &&
+	test_debug "cat color.out" &&
+	grep "^.*1" color.out &&
+	flux resource status -n --color --states=avail --from-stdin \
+		-o "{color_up}{nnodes}{color_off}" \
+		<$INPUT >color.out &&
+	test_debug "cat color.out" &&
+	grep "^.*2" color.out
+'
+
+test_expect_success 'flux-resource status: similar lines are combined' '
+	INPUT=${INPUTDIR}/drain.json &&
+	flux resource status -n --color --states=drain --from-stdin \
+		--skip-empty \
+		-o "{state:>8} {nnodes}" \
+		<$INPUT >combined.out &&
+	test_debug "cat combined.out" &&
+	test $(wc -l < combined.out) -eq 1 &&
+	flux resource status -n --color --states=drain --from-stdin \
+		--skip-empty \
+		-o "{state:>8} {nnodes:>6} {reason}" \
+		<$INPUT >combined2.out &&
+	test_debug "cat combined2.out" &&
+	test $(wc -l < combined2.out) -eq 2
+'
+
+test_expect_success 'flux-resource status: lines are combined based on format' '
+	INPUT=${INPUTDIR}/drain.json &&
+	flux resource status -n --color --states=drain --from-stdin \
+		--skip-empty \
+		-o "{timestamp} {state:>8} {nnodes}" \
+		<$INPUT >ts-detailed.out &&
+	test_debug "cat ts-detailed.out" &&
+	test $(wc -l < ts-detailed.out) -eq 2 &&
+	flux resource status -n --color --states=drain --from-stdin \
+		--skip-empty \
+		-o "{timestamp!d:%F::<12} {state:>8} {nnodes}" \
+		<$INPUT >ts-detailed2.out &&
+	test_debug "cat ts-detailed2.out" &&
+	cat <<-EOF >ts-detailed2.expected &&
+	2020-12-09    drained 2
+	EOF
+	test_cmp ts-detailed2.expected ts-detailed2.out
+'
 test_done


### PR DESCRIPTION
This PR is a WIP. Still need to write a few more tests and documentation. However, since this makes some fundamental changes to the `flux resource status` command, it would be good to get feedback before finishing up those items.

This is pretty much a full rewrite of `flux resource status`. It is broken up into a few parts, but the final rewrite is one big change, I wasn't sure how else to accomplish that.

 * First some groundwork is laid to make a reusable `flux.util.Deduplicator` class, which combines items that would format to the same string given an output formatter, a list of fields that should be excluded from duplicate detection, and  a method to combine similar items.
 * Then, some reusable code for fetching status from both the resource and scheduler module is added to `flux.resource.status`
 * Finally, `flux resource status` is rewritten using these new pieces.

The major changes in `flux resource status` include:

 * Move `offline` and `online` from "states" to a new field "status". (results can still be "filtered" by e.g. `--states=online`)
 * Rename the `{state}` header from STATUS to STATE
 * `all` is no longer a "state". Instead `--states=all` displays all states even if they have zero resources 
 * Ensure a rank only appears in one state at a time. The states currently are `exclude`, `drained`, `draining` or `avail` (i.e. not excluded or drained/draining).
 * The default `{state}` output field appends an asterisk `*` to the state to indicate the rank is offline.
 * A new output field `{statex}` is available to get the state without the `*`
 * The Deduplicator class is used to combine output lines, which fixes #4985 among other things

(Note this all applies to `flux resource drain` (no args) as well since that command is just a special case of `flux resource status`)

Fixes #4985 
Fixes #4910