### PR TITLE
fix link dependencies for job-manager modules

### DIFF
--- a/src/modules/job-manager/Makefile.am
+++ b/src/modules/job-manager/Makefile.am
@@ -12,6 +12,12 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir)/src/common/libccan \
 	$(JANSSON_CFLAGS)
 
+COMMON_LIBS = \
+	libjob-manager.la \
+	$(top_builddir)/src/common/libjob/libjob.la \
+	$(top_builddir)/src/common/libflux-internal.la \
+	$(top_builddir)/src/common/libflux-core.la
+
 fluxmod_LTLIBRARIES = \
 	job-manager.la
 
@@ -100,17 +106,13 @@ plugins_submit_hold_la_LDFLAGS = \
 	$(fluxplugin_ldflags) \
 	-module
 plugins_submit_hold_la_LIBADD = \
-	$(top_builddir)/src/common/libjob/libjob.la \
-	$(top_builddir)/src/common/libflux-internal.la \
-	libjob-manager.la
+	${COMMON_LIBS}
 
 plugins_alloc_bypass_la_SOURCES = \
 	plugins/alloc-bypass.c
 plugins_alloc_bypass_la_LIBADD = \
-	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/librlist/librlist.la \
-	$(top_builddir)/src/common/libjob/libjob.la \
-	libjob-manager.la
+	${COMMON_LIBS}
 plugins_alloc_bypass_la_LDFLAGS = \
 	$(fluxplugin_ldflags) \
 	-module
@@ -118,10 +120,8 @@ plugins_alloc_bypass_la_LDFLAGS = \
 plugins_perilog_la_SOURCES = \
 	plugins/perilog.c
 plugins_perilog_la_LIBADD = \
-	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/librlist/librlist.la \
-	$(top_builddir)/src/common/libjob/libjob.la \
-	libjob-manager.la
+	${COMMON_LIBS}
 plugins_perilog_la_LDFLAGS = \
 	$(fluxplugin_ldflags) \
 	-module

--- a/src/modules/job-manager/Makefile.am
+++ b/src/modules/job-manager/Makefile.am
@@ -99,12 +99,18 @@ plugins_submit_hold_la_SOURCES = \
 plugins_submit_hold_la_LDFLAGS = \
 	$(fluxplugin_ldflags) \
 	-module
+plugins_submit_hold_la_LIBADD = \
+	$(top_builddir)/src/common/libjob/libjob.la \
+	$(top_builddir)/src/common/libflux-internal.la \
+	libjob-manager.la
 
 plugins_alloc_bypass_la_SOURCES = \
 	plugins/alloc-bypass.c
 plugins_alloc_bypass_la_LIBADD = \
 	$(top_builddir)/src/common/libflux-internal.la \
-	$(top_builddir)/src/common/librlist/librlist.la
+	$(top_builddir)/src/common/librlist/librlist.la \
+	$(top_builddir)/src/common/libjob/libjob.la \
+	libjob-manager.la
 plugins_alloc_bypass_la_LDFLAGS = \
 	$(fluxplugin_ldflags) \
 	-module
@@ -114,7 +120,8 @@ plugins_perilog_la_SOURCES = \
 plugins_perilog_la_LIBADD = \
 	$(top_builddir)/src/common/libflux-internal.la \
 	$(top_builddir)/src/common/librlist/librlist.la \
-	$(top_builddir)/src/common/libjob/libjob.la
+	$(top_builddir)/src/common/libjob/libjob.la \
+	libjob-manager.la
 plugins_perilog_la_LDFLAGS = \
 	$(fluxplugin_ldflags) \
 	-module


### PR DESCRIPTION
Not sure why this only appears on nixos, but the submit-hold, alloc-bypass and perilog modules were all missing necessary link dependencies.  I think this was hiding behind our normal ignore missing symbols behavior for modules and the load order on other systems happening to load the libjob and libflux-internal libraries before the modules on most platforms.

This is the first part of the fixup stuff from my poking at flux on NixOS, but regardless of whether we want the other changes to let our tests pass without a FHS-compatible root, I'm pretty sure we'll want this.