### PR TITLE
flux-resource: support overwrite of drain timestamp with `--force --force`

### DIFF
--- a/doc/man1/flux-resource.rst
+++ b/doc/man1/flux-resource.rst
@@ -83,7 +83,8 @@ COMMANDS
    By default, **flux resource drain** will fail if any of the *targets*
    are already drained. To change this behavior, use either of the
    *-f, --force* or *-u, --update* options. With *--force*, the *reason* for
-   all existing drained targets is overwritten, while with *--update*,
+   all existing drained targets is overwritten. If *--force* is specified
+   twice, then the timestamp is also overwritten. With *--update*,
    only those ranks that are not already drained or do not have a *reason* set
    have their *reason* updated.
 

--- a/src/cmd/flux-resource.py
+++ b/src/cmd/flux-resource.py
@@ -119,8 +119,10 @@ def drain(args):
         sys.exit(1)
     if args.update:
         payload["mode"] = "update"
-    elif args.force:
+    elif args.force == 1:
         payload["mode"] = "overwrite"
+    elif args.force == 2:
+        payload["mode"] = "force-overwrite"
     if args.reason:
         payload["reason"] = " ".join(args.reason)
     try:
@@ -594,8 +596,10 @@ def main():
     drain_parser.add_argument(
         "-f",
         "--force",
-        action="store_true",
-        help="Force overwrite of existing drain reason",
+        action="count",
+        default=0,
+        help="Force overwrite of existing drain reason. Specify twice "
+        + "to also update drain timestamp.",
     )
     drain_parser.add_argument(
         "-u",

--- a/src/modules/resource/drain.c
+++ b/src/modules/resource/drain.c
@@ -19,6 +19,8 @@
  *   on setting of optional 'mode' member:
  *    - If mode is not set, request fails
  *    - If mode=overwrite, request succeeds and reason is updated
+ *    - If mode=force-overwrite, request succeeds and timestamp and reason
+ *      are updated
  *    - If mode=update, request succeeds and reason is updated only for
  *      those target that are not drained or do not have reason set.
  *
@@ -97,7 +99,7 @@ static int update_draininfo_rank (struct drain *drain,
 
     free (drain->info[rank].reason);
     drain->info[rank].reason = cpy;
-    if (drain->info[rank].drained != drained) {
+    if (drain->info[rank].drained != drained || overwrite == 2) {
         drain->info[rank].drained = drained;
         drain->info[rank].timestamp = timestamp;
     }
@@ -361,6 +363,8 @@ static void drain_cb (flux_t *h,
             update_only = 1;
         else if (strcmp (mode, "overwrite") == 0)
             overwrite = 1;
+        else if (strcmp (mode, "force-overwrite") == 0)
+            overwrite = 2;
         else {
             errno = EINVAL;
             goto error;

--- a/t/t2311-resource-drain.t
+++ b/t/t2311-resource-drain.t
@@ -21,7 +21,7 @@ has_resource_event () {
 }
 
 drain_timestamp () {
-	flux resource drain | tail -n 1 | awk '{ print $1 }'
+	flux resource drain -o {timestamp} | tail -n 1 | awk '{ print $1 }'
 }
 
 test_expect_success 'wait for monitor to declare all ranks are up' '
@@ -81,6 +81,15 @@ test_expect_success 'drain reason can be updated with --force' '
 
 test_expect_success 'original drain timestamp is preserved' '
 	test $(drain_timestamp) = $(cat rank1.timestamp)
+'
+
+test_expect_success 'drain timestamp and reason can be updated with -ff' '
+	flux resource drain --force --force 1 test_reason_updated_again &&
+	flux resource drain | grep test_reason_updated_again
+'
+
+test_expect_success 'original drain timestamp is preserved' '
+	test $(drain_timestamp) != $(cat rank1.timestamp)
 '
 
 test_expect_success 'drain update mode does not change already drained rank' '


### PR DESCRIPTION
This PR adds a `force-overwrite` "mode" to the job-manager drain RPC which overwrites the drain reason _and_ timestamp.

Use of `--force` twice in `flux resource drain` then sets this mode, such that `flux resource drain -ff TARGETS REASON` will update both timestamp and reason, instead of just the drain reason.