### PR TITLE
fix: warning message to user should be actual command

### DIFF
--- a/src/cmd/flux-mini.py
+++ b/src/cmd/flux-mini.py
@@ -34,10 +34,10 @@ def main():
     if sys.stderr.isatty():
         cmd = sys.argv[1] if len(sys.argv) > 1 else None
         if cmd in ["submit", "run", "batch", "alloc", "bulksubmit"]:
-            suggestion = f"flux {sys.argv[1]} "
+            suggestion = f"flux {cmd} "
         else:
             suggestion = "flux submit, flux run, etc."
-        LOGGER.warning(f"⚠️ flux-mini is deprecated, use {suggestion}⚠️")
+        LOGGER.warning(f"⚠️ flux mini is deprecated, use {suggestion}⚠️")
 
     parser = argparse.ArgumentParser(prog="flux-mini")
     subparsers = parser.add_subparsers(


### PR DESCRIPTION
Problem: the deprecation warning for flux-mini tells the user about the underlying command, which is not actually what they would execute!

Solution: Fix the warning to reference "flux mini" and "flux (submit|batch|run) etc. so it makes sense.

I was doing some testing of flux with merlin tonight and was (very happy) to see this warning, but I think we could improve it slightly by showing the user the command they would actually run, and not the underlying actual filename. 
![image](https://user-images.githubusercontent.com/814322/226813777-b73cbd29-2f50-44aa-b407-6b35605d184e.png)
