### PR TITLE
cleanup: allow subprocess service name to be configured

### DIFF
--- a/src/broker/exec.c
+++ b/src/broker/exec.c
@@ -39,7 +39,7 @@ int exec_initialize (flux_t *h, uint32_t rank, attr_t *attrs)
 
     if (attr_get (attrs, "local-uri", &local_uri, NULL) < 0)
         goto cleanup;
-    if (!(s = subprocess_server_create (h, local_uri, rank)))
+    if (!(s = subprocess_server_create (h, local_uri)))
         goto cleanup;
     if (rank == 0)
         subprocess_server_set_auth_cb (s, reject_nonlocal, NULL);

--- a/src/broker/exec.c
+++ b/src/broker/exec.c
@@ -39,7 +39,7 @@ int exec_initialize (flux_t *h, uint32_t rank, attr_t *attrs)
 
     if (attr_get (attrs, "local-uri", &local_uri, NULL) < 0)
         goto cleanup;
-    if (!(s = subprocess_server_create (h, local_uri)))
+    if (!(s = subprocess_server_create (h, "rexec", local_uri)))
         goto cleanup;
     if (rank == 0)
         subprocess_server_set_auth_cb (s, reject_nonlocal, NULL);

--- a/src/common/libsubprocess/Makefile.am
+++ b/src/common/libsubprocess/Makefile.am
@@ -31,7 +31,9 @@ libsubprocess_la_SOURCES = \
 	util.c \
 	util.h \
 	subprocess.c \
-	subprocess_private.h
+	subprocess_private.h \
+	client.h \
+	client.c
 
 fluxcoreinclude_HEADERS = \
 	subprocess.h

--- a/src/common/libsubprocess/client.h
+++ b/src/common/libsubprocess/client.h
@@ -1,0 +1,61 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+#ifndef _SUBPROCESS_CLIENT_H
+#define _SUBPROCESS_CLIENT_H
+
+#include <sys/types.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <flux/core.h>
+#include "subprocess.h"
+
+enum {
+    SUBPROCESS_REXEC_STDOUT = 1,
+    SUBPROCESS_REXEC_STDERR = 2,
+    SUBPROCESS_REXEC_CHANNEL = 4,
+};
+
+flux_future_t *subprocess_rexec (flux_t *h,
+                                 const char *service_name,
+                                 uint32_t rank,
+                                 flux_cmd_t *cmd,
+                                 int flags);
+
+int subprocess_rexec_get (flux_future_t *f);
+bool subprocess_rexec_is_started (flux_future_t *f, pid_t *pid);
+bool subprocess_rexec_is_stopped (flux_future_t *f);
+bool subprocess_rexec_is_finished (flux_future_t *f, int *status);
+bool subprocess_rexec_is_output (flux_future_t *f,
+                                 const char **stream,
+                                 const char **buf,
+                                 int *len,
+                                 bool *eof);
+
+int subprocess_write (flux_t *h,
+                      const char *service_name,
+                      uint32_t rank,
+                      pid_t pid,
+                      const char *stream,
+                      const char *data,
+                      int len,
+                      bool eof);
+
+flux_future_t *subprocess_kill (flux_t *h,
+                                const char *service_name,
+                                uint32_t rank,
+                                pid_t pid,
+                                int signum);
+
+
+#endif /* !_SUBPROCESS_CLIENT_H */
+
+// vi: ts=4 sw=4 expandtab

--- a/src/common/libsubprocess/remote.h
+++ b/src/common/libsubprocess/remote.h
@@ -13,7 +13,7 @@
 
 #include "subprocess.h"
 
-int subprocess_remote_setup (flux_subprocess_t *p);
+int subprocess_remote_setup (flux_subprocess_t *p, const char *service_name);
 
 int remote_exec (flux_subprocess_t *p);
 

--- a/src/common/libsubprocess/server.c
+++ b/src/common/libsubprocess/server.c
@@ -554,27 +554,27 @@ static void server_disconnect_cb (flux_t *h,
 
 static struct flux_msg_handler_spec htab[] = {
     { FLUX_MSGTYPE_REQUEST,
-      "rexec.exec",
+      "exec",
       server_exec_cb,
       0
     },
     { FLUX_MSGTYPE_REQUEST,
-      "rexec.write",
+      "write",
       server_write_cb,
       0
     },
     { FLUX_MSGTYPE_REQUEST,
-      "rexec.kill",
+      "kill",
       server_kill_cb,
       0
     },
     { FLUX_MSGTYPE_REQUEST,
-      "rexec.list",
+      "list",
       server_list_cb,
       0
     },
     { FLUX_MSGTYPE_REQUEST,
-      "rexec.disconnect",
+      "disconnect",
       server_disconnect_cb,
       0
     },
@@ -624,11 +624,12 @@ void subprocess_server_destroy (subprocess_server_t *s)
 }
 
 subprocess_server_t *subprocess_server_create (flux_t *h,
+                                               const char *service_name,
                                                const char *local_uri)
 {
     subprocess_server_t *s;
 
-    if (!h || !local_uri) {
+    if (!h || !local_uri || !service_name) {
         errno = EINVAL;
         return NULL;
     }
@@ -647,7 +648,11 @@ subprocess_server_t *subprocess_server_create (flux_t *h,
         goto error;
     if (flux_get_rank (h, &s->rank) < 0)
         goto error;
-    if (flux_msg_handler_addvec (s->h, htab, s, &s->handlers) < 0)
+    if (flux_msg_handler_addvec_ex (s->h,
+                                    service_name,
+                                    htab,
+                                    s,
+                                    &s->handlers) < 0)
         goto error;
 
     return s;

--- a/src/common/libsubprocess/server.c
+++ b/src/common/libsubprocess/server.c
@@ -624,8 +624,7 @@ void subprocess_server_destroy (subprocess_server_t *s)
 }
 
 subprocess_server_t *subprocess_server_create (flux_t *h,
-                                               const char *local_uri,
-                                               uint32_t rank)
+                                               const char *local_uri)
 {
     subprocess_server_t *s;
 
@@ -646,7 +645,8 @@ subprocess_server_t *subprocess_server_create (flux_t *h,
     zlistx_set_destructor (s->subprocesses, proc_destructor);
     if (!(s->local_uri = strdup (local_uri)))
         goto error;
-    s->rank = rank;
+    if (flux_get_rank (h, &s->rank) < 0)
+        goto error;
     if (flux_msg_handler_addvec (s->h, htab, s, &s->handlers) < 0)
         goto error;
 

--- a/src/common/libsubprocess/server.h
+++ b/src/common/libsubprocess/server.h
@@ -26,8 +26,7 @@ typedef int (*subprocess_server_auth_f) (const flux_msg_t *msg,
  * that has terminated.
  */
 subprocess_server_t *subprocess_server_create (flux_t *h,
-                                               const char *local_uri,
-                                               uint32_t rank);
+                                               const char *local_uri);
 
 /* Register a callback to allow/deny each rexec request.
  * The callback should return 0 to allow.  It should return -1 with a

--- a/src/common/libsubprocess/server.h
+++ b/src/common/libsubprocess/server.h
@@ -26,6 +26,7 @@ typedef int (*subprocess_server_auth_f) (const flux_msg_t *msg,
  * that has terminated.
  */
 subprocess_server_t *subprocess_server_create (flux_t *h,
+		                               const char *service_name,
                                                const char *local_uri);
 
 /* Register a callback to allow/deny each rexec request.

--- a/src/common/libsubprocess/subprocess.h
+++ b/src/common/libsubprocess/subprocess.h
@@ -298,6 +298,14 @@ flux_subprocess_t *flux_rexec (flux_t *h, int rank, int flags,
                                const flux_cmd_t *cmd,
                                const flux_subprocess_ops_t *ops);
 
+flux_subprocess_t *flux_rexec_ex (flux_t *h,
+                                  const char *service_name,
+                                  int rank,
+                                  int flags,
+                                  const flux_cmd_t *cmd,
+                                  const flux_subprocess_ops_t *ops);
+
+
 /* Start / stop a read stream temporarily on local processes.  This
  * may be useful for flow control.  If you desire to have a stream not
  * call 'on_stdout' or 'on_stderr' when the local subprocess has

--- a/src/common/libsubprocess/subprocess_private.h
+++ b/src/common/libsubprocess/subprocess_private.h
@@ -107,6 +107,7 @@ struct flux_subprocess {
 
     /* remote */
 
+    char *service_name;
     flux_future_t *f;           /* primary future reactor */
     bool remote_completed;      /* if remote has completed */
     int failed_errno;           /* Holds errno if FAILED state reached */

--- a/src/common/libsubprocess/test/iochan.c
+++ b/src/common/libsubprocess/test/iochan.c
@@ -232,7 +232,7 @@ int main (int argc, char *argv[])
 
     plan (NO_PLAN);
 
-    h = rcmdsrv_create ();
+    h = rcmdsrv_create ("rexec");
 
     if (flux_set_default_subprocess_log (h, tap_logger, NULL) < 0)
         BAIL_OUT ("could not set logger");

--- a/src/common/libsubprocess/test/iostress.c
+++ b/src/common/libsubprocess/test/iostress.c
@@ -274,7 +274,7 @@ int main (int argc, char *argv[])
 
     plan (NO_PLAN);
 
-    h = rcmdsrv_create ();
+    h = rcmdsrv_create ("rexec");
 
     if (flux_set_default_subprocess_log (h, tap_logger, NULL) < 0)
         BAIL_OUT ("could not set logger");

--- a/src/common/libsubprocess/test/rcmdsrv.c
+++ b/src/common/libsubprocess/test/rcmdsrv.c
@@ -46,6 +46,7 @@ void tap_logger (void *arg,
 
 static int test_server (flux_t *h, void *arg)
 {
+    const char *service_name = arg;
     int rc = -1;
     subprocess_server_t *srv = NULL;
 
@@ -57,7 +58,7 @@ static int test_server (flux_t *h, void *arg)
         diag ("flux_attr_set_cacheonly failed");
         goto done;
     }
-    if (!(srv = subprocess_server_create (h, "rexec", "smurf"))) {
+    if (!(srv = subprocess_server_create (h, service_name, "smurf"))) {
         diag ("subprocess_server_create failed");
         goto done;
     }
@@ -73,7 +74,7 @@ done:
     return rc;
 }
 
-flux_t *rcmdsrv_create (void)
+flux_t *rcmdsrv_create (const char *service_name)
 {
     flux_t *h;
 
@@ -82,7 +83,7 @@ flux_t *rcmdsrv_create (void)
     signal (SIGPIPE, SIG_IGN);
 
     // N.B. test reactor is created with FLUX_REACTOR_SIGCHLD flag
-    if (!(h = test_server_create (0, test_server, NULL)))
+    if (!(h = test_server_create (0, test_server, (char *)service_name)))
         BAIL_OUT ("test_server_create failed");
 
     return h;

--- a/src/common/libsubprocess/test/rcmdsrv.c
+++ b/src/common/libsubprocess/test/rcmdsrv.c
@@ -57,7 +57,7 @@ static int test_server (flux_t *h, void *arg)
         diag ("flux_attr_set_cacheonly failed");
         goto done;
     }
-    if (!(srv = subprocess_server_create (h, "smurf"))) {
+    if (!(srv = subprocess_server_create (h, "rexec", "smurf"))) {
         diag ("subprocess_server_create failed");
         goto done;
     }

--- a/src/common/libsubprocess/test/rcmdsrv.c
+++ b/src/common/libsubprocess/test/rcmdsrv.c
@@ -53,7 +53,11 @@ static int test_server (flux_t *h, void *arg)
         diag ("flux_set_default_subprocess_log failed");
         goto done;
     }
-    if (!(srv = subprocess_server_create (h, "smurf", 0))) {
+    if (flux_attr_set_cacheonly (h, "rank", "0") < 0) {
+        diag ("flux_attr_set_cacheonly failed");
+        goto done;
+    }
+    if (!(srv = subprocess_server_create (h, "smurf"))) {
         diag ("subprocess_server_create failed");
         goto done;
     }
@@ -80,6 +84,7 @@ flux_t *rcmdsrv_create (void)
     // N.B. test reactor is created with FLUX_REACTOR_SIGCHLD flag
     if (!(h = test_server_create (0, test_server, NULL)))
         BAIL_OUT ("test_server_create failed");
+
     return h;
 };
 

--- a/src/common/libsubprocess/test/rcmdsrv.h
+++ b/src/common/libsubprocess/test/rcmdsrv.h
@@ -18,7 +18,7 @@
 /* Start subprocess server.  Returns one end of back-to-back flux_t test
  * handle.  Call test_server_stop (h) when done to join with server thread.
  */
-flux_t *rcmdsrv_create (void);
+flux_t *rcmdsrv_create (const char *service_name);
 
 /* llog-compatible logger
  */

--- a/src/common/libsubprocess/test/remote.c
+++ b/src/common/libsubprocess/test/remote.c
@@ -25,6 +25,8 @@
 
 #include "rcmdsrv.h"
 
+#define SERVER_NAME "test-remote"
+
 struct simple_scorecard {
     unsigned int completion:1;
     unsigned int exit_nonzero:1;
@@ -150,11 +152,11 @@ void simple_run_check (flux_t *h,
 
     memset (&ctx, 0, sizeof (ctx));
     ctx.h = h;
-    p = flux_rexec (h, FLUX_NODEID_ANY, 0, cmd, &simple_ops);
+    p = flux_rexec_ex (h, SERVER_NAME, FLUX_NODEID_ANY, 0, cmd, &simple_ops);
     ok (p != NULL,
-        "%s: flux_rexec returned a subprocess object", av[0]);
+        "%s: flux_rexec_ex returned a subprocess object", av[0]);
     if (!p)
-        BAIL_OUT ("flux_rexec failed");
+        BAIL_OUT ("flux_rexec_ex failed");
     if (flux_subprocess_aux_set (p, "ctx", &ctx, NULL) < 0)
         BAIL_OUT ("flux_subprocess_aux_set failed");
     rc = flux_reactor_run (flux_get_reactor (h), 0);
@@ -309,7 +311,7 @@ void sigstop_test (flux_t *h)
     if (!cmd)
         BAIL_OUT ("flux_cmd_create failed");
 
-    p = flux_rexec (h, FLUX_NODEID_ANY, 0, cmd, &stoptest_ops);
+    p = flux_rexec_ex (h, SERVER_NAME, FLUX_NODEID_ANY, 0, cmd, &stoptest_ops);
     ok (p != NULL,
         "stoptest: created subprocess");
     if (flux_subprocess_aux_set (p, "reactor", flux_get_reactor (h), NULL) < 0)
@@ -329,7 +331,7 @@ int main (int argc, char *argv[])
 
     plan (NO_PLAN);
 
-    h = rcmdsrv_create ();
+    h = rcmdsrv_create (SERVER_NAME);
 
     if (flux_set_default_subprocess_log (h, tap_logger, NULL) < 0)
         BAIL_OUT ("could not set logger");

--- a/src/common/libsubprocess/test/subprocess.c
+++ b/src/common/libsubprocess/test/subprocess.c
@@ -152,7 +152,7 @@ void test_basic_errors (flux_reactor_t *r)
     ok ((h = flux_open ("loop://", 0)) != NULL,
         "flux_open on loop works");
 
-    ok (!subprocess_server_create (NULL, NULL, 0)
+    ok (!subprocess_server_create (NULL, NULL)
         && errno == EINVAL,
         "subprocess_server_create fails with NULL pointer inputs");
     ok (subprocess_server_shutdown (NULL, 0) == NULL

--- a/src/common/libsubprocess/test/subprocess.c
+++ b/src/common/libsubprocess/test/subprocess.c
@@ -152,7 +152,7 @@ void test_basic_errors (flux_reactor_t *r)
     ok ((h = flux_open ("loop://", 0)) != NULL,
         "flux_open on loop works");
 
-    ok (!subprocess_server_create (NULL, NULL)
+    ok (!subprocess_server_create (NULL, NULL, NULL)
         && errno == EINVAL,
         "subprocess_server_create fails with NULL pointer inputs");
     ok (subprocess_server_shutdown (NULL, 0) == NULL


### PR DESCRIPTION
This PR modifies the subprocess server so a service name (currently `rexec`) can be specified when the server is instantiated and then adds  `flux_rexec_ex()`, a variant of `flux_rexec()` with an additional service name parameter.

Internally, the "remote" portion of libsubprocess is cleaned up so that the RPC protocol is handled exclusively in client.c and server.c

This is prep work for
- embedding the subprocess server in the shell (needed once shells are launched in a limited cgroups environment)
-  #5004
- allowing subprocess clients to communicate with a new compatible server that starts processes using systemd
