### PR TITLE
cleanup: improve interface for subprocess logging

### DIFF
--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -408,11 +408,6 @@ int main (int argc, char *argv[])
     if (ctx.rank == 0 && execute_parental_notifications (&ctx) < 0)
         goto cleanup;
 
-    /* Set up internal logging for libsubprocesses.
-     */
-    if (flux_set_default_subprocess_log (ctx.h, flux_llog, ctx.h) < 0)
-        goto cleanup;
-
     if (create_runat_phases (&ctx) < 0)
         goto cleanup;
 

--- a/src/broker/exec.c
+++ b/src/broker/exec.c
@@ -39,7 +39,7 @@ int exec_initialize (flux_t *h, uint32_t rank, attr_t *attrs)
 
     if (attr_get (attrs, "local-uri", &local_uri, NULL) < 0)
         goto cleanup;
-    if (!(s = subprocess_server_create (h, "rexec", local_uri, NULL, NULL)))
+    if (!(s = subprocess_server_create (h, "rexec", local_uri, flux_llog, h)))
         goto cleanup;
     if (rank == 0)
         subprocess_server_set_auth_cb (s, reject_nonlocal, NULL);

--- a/src/broker/exec.c
+++ b/src/broker/exec.c
@@ -39,7 +39,7 @@ int exec_initialize (flux_t *h, uint32_t rank, attr_t *attrs)
 
     if (attr_get (attrs, "local-uri", &local_uri, NULL) < 0)
         goto cleanup;
-    if (!(s = subprocess_server_create (h, "rexec", local_uri)))
+    if (!(s = subprocess_server_create (h, "rexec", local_uri, NULL, NULL)))
         goto cleanup;
     if (rank == 0)
         subprocess_server_set_auth_cb (s, reject_nonlocal, NULL);

--- a/src/broker/runat.c
+++ b/src/broker/runat.c
@@ -239,7 +239,13 @@ static flux_subprocess_t *start_command (struct runat *r,
         ops.on_stdout = stdio_cb;
         ops.on_stderr = stdio_cb;
     }
-    if (!(p = flux_exec (r->h, cmd->flags, cmd->cmd, &ops, NULL)))
+    if (!(p = flux_local_exec_ex (flux_get_reactor (r->h),
+                                  cmd->flags,
+                                  cmd->cmd,
+                                  &ops,
+                                  NULL,
+                                  flux_llog,
+                                  r->h)))
         return NULL;
     if (flux_subprocess_aux_set (p, "runat_entry", entry, NULL) < 0)
         goto error;

--- a/src/cmd/builtin/proxy.c
+++ b/src/cmd/builtin/proxy.c
@@ -147,8 +147,7 @@ static int child_create (struct proxy_command *ctx,
     if (!(p = flux_local_exec (flux_get_reactor (ctx->h),
                                FLUX_SUBPROCESS_FLAGS_STDIO_FALLTHROUGH,
                                cmd,
-                               &ops,
-                               NULL)))
+                               &ops)))
         goto error;
 
     if (flux_subprocess_aux_set (p, "ctx", ctx, NULL) < 0)

--- a/src/cmd/flux-start.c
+++ b/src/cmd/flux-start.c
@@ -741,8 +741,7 @@ int client_run (struct client *cli)
     if (!(cli->p = flux_local_exec (ctx.reactor,
                                     FLUX_SUBPROCESS_FLAGS_STDIO_FALLTHROUGH,
                                     cli->cmd,
-                                    &ops,
-                                    NULL)))
+                                    &ops)))
         log_err_exit ("flux_exec");
     if (flux_subprocess_aux_set (cli->p, "cli", cli, NULL) < 0)
         log_err_exit ("flux_subprocess_aux_set");

--- a/src/common/libsubprocess/server.c
+++ b/src/common/libsubprocess/server.c
@@ -627,7 +627,9 @@ void subprocess_server_destroy (subprocess_server_t *s)
 
 subprocess_server_t *subprocess_server_create (flux_t *h,
                                                const char *service_name,
-                                               const char *local_uri)
+                                               const char *local_uri,
+                                               subprocess_log_f log_fn,
+                                               void *log_data)
 {
     subprocess_server_t *s;
 
@@ -640,8 +642,8 @@ subprocess_server_t *subprocess_server_create (flux_t *h,
 
     s->h = h;
 
-    s->llog = flux_aux_get (h, "flux::subprocess_llog_fn");
-    s->llog_data = flux_aux_get (h, "flux::subprocess_llog_data");
+    s->llog = log_fn;
+    s->llog_data = log_data;
 
     if (!(s->subprocesses = zlistx_new ()))
         goto error;

--- a/src/common/libsubprocess/server.c
+++ b/src/common/libsubprocess/server.c
@@ -321,11 +321,13 @@ static void server_exec_cb (flux_t *h, flux_msg_handler_t *mh,
         goto error;
     }
 
-    if (!(p = flux_exec (s->h,
-                         FLUX_SUBPROCESS_FLAGS_SETPGRP,
-                         cmd,
-                         &ops,
-                         NULL)))
+    if (!(p = flux_local_exec_ex (flux_get_reactor (s->h),
+                                  FLUX_SUBPROCESS_FLAGS_SETPGRP,
+                                  cmd,
+                                  &ops,
+                                  NULL,
+                                  s->llog,
+                                  s->llog_data)))
         goto error;
 
     if (flux_subprocess_aux_set (p,

--- a/src/common/libsubprocess/server.h
+++ b/src/common/libsubprocess/server.h
@@ -27,7 +27,9 @@ typedef int (*subprocess_server_auth_f) (const flux_msg_t *msg,
  */
 subprocess_server_t *subprocess_server_create (flux_t *h,
                                                const char *service_name,
-                                               const char *local_uri);
+                                               const char *local_uri,
+                                               subprocess_log_f log_fn,
+                                               void *log_data);
 
 /* Register a callback to allow/deny each rexec request.
  * The callback should return 0 to allow.  It should return -1 with a

--- a/src/common/libsubprocess/server.h
+++ b/src/common/libsubprocess/server.h
@@ -16,8 +16,8 @@
 typedef struct subprocess_server subprocess_server_t;
 
 typedef int (*subprocess_server_auth_f) (const flux_msg_t *msg,
-		                         void *arg,
-					 flux_error_t *error);
+                                         void *arg,
+                                         flux_error_t *error);
 
 /* Create a subprocess server.  The handle 'h' must contain a reactor
  * created with the FLUX_REACTOR_SIGCHLD flag.  Note that there can be
@@ -26,7 +26,7 @@ typedef int (*subprocess_server_auth_f) (const flux_msg_t *msg,
  * that has terminated.
  */
 subprocess_server_t *subprocess_server_create (flux_t *h,
-		                               const char *service_name,
+                                               const char *service_name,
                                                const char *local_uri);
 
 /* Register a callback to allow/deny each rexec request.

--- a/src/common/libsubprocess/subprocess.c
+++ b/src/common/libsubprocess/subprocess.c
@@ -481,12 +481,13 @@ static int subprocess_setup_completed (flux_subprocess_t *p)
     return 0;
 }
 
-static flux_subprocess_t * flux_exec_wrap (flux_t *h, flux_reactor_t *r, int flags,
-                                           const flux_cmd_t *cmd,
-                                           const flux_subprocess_ops_t *ops,
-                                           const flux_subprocess_hooks_t *hooks,
-                                           subprocess_log_f log_fn,
-                                           void *log_data)
+flux_subprocess_t *flux_local_exec_ex (flux_reactor_t *r,
+                                       int flags,
+                                       const flux_cmd_t *cmd,
+                                       const flux_subprocess_ops_t *ops,
+                                       const flux_subprocess_hooks_t *hooks,
+                                       subprocess_log_f log_fn,
+                                       void *log_data)
 {
     flux_subprocess_t *p = NULL;
     int valid_flags = (FLUX_SUBPROCESS_FLAGS_STDIO_FALLTHROUGH
@@ -509,7 +510,7 @@ static flux_subprocess_t * flux_exec_wrap (flux_t *h, flux_reactor_t *r, int fla
         goto error;
     }
 
-    if (!(p = subprocess_create (h,
+    if (!(p = subprocess_create (NULL,
                                  r,
                                  flags,
                                  cmd,
@@ -537,35 +538,6 @@ static flux_subprocess_t * flux_exec_wrap (flux_t *h, flux_reactor_t *r, int fla
 error:
     flux_subprocess_unref (p);
     return NULL;
-}
-
-flux_subprocess_t * flux_exec (flux_t *h, int flags,
-                               const flux_cmd_t *cmd,
-                               const flux_subprocess_ops_t *ops,
-                               const flux_subprocess_hooks_t *hooks)
-{
-    flux_reactor_t *r;
-
-    if (!h) {
-        errno = EINVAL;
-        return NULL;
-    }
-
-    if (!(r = flux_get_reactor (h)))
-        return NULL;
-
-    return flux_exec_wrap (h, r, flags, cmd, ops, hooks, NULL, NULL);
-}
-
-flux_subprocess_t *flux_local_exec_ex (flux_reactor_t *r,
-                                       int flags,
-                                       const flux_cmd_t *cmd,
-                                       const flux_subprocess_ops_t *ops,
-                                       const flux_subprocess_hooks_t *hooks,
-                                       subprocess_log_f log_fn,
-                                       void *log_data)
-{
-    return flux_exec_wrap (NULL, r, flags, cmd, ops, hooks, log_fn, log_data);
 }
 
 flux_subprocess_t * flux_local_exec (flux_reactor_t *r, int flags,

--- a/src/common/libsubprocess/subprocess.c
+++ b/src/common/libsubprocess/subprocess.c
@@ -546,12 +546,20 @@ flux_subprocess_t * flux_exec (flux_t *h, int flags,
     return flux_exec_wrap (h, r, flags, cmd, ops, hooks);
 }
 
-flux_subprocess_t * flux_local_exec (flux_reactor_t *r, int flags,
-                                     const flux_cmd_t *cmd,
-                                     const flux_subprocess_ops_t *ops,
-                                     const flux_subprocess_hooks_t *hooks)
+flux_subprocess_t *flux_local_exec_ex (flux_reactor_t *r,
+                                       int flags,
+                                       const flux_cmd_t *cmd,
+                                       const flux_subprocess_ops_t *ops,
+                                       const flux_subprocess_hooks_t *hooks)
 {
     return flux_exec_wrap (NULL, r, flags, cmd, ops, hooks);
+}
+
+flux_subprocess_t * flux_local_exec (flux_reactor_t *r, int flags,
+                                     const flux_cmd_t *cmd,
+                                     const flux_subprocess_ops_t *ops)
+{
+    return flux_local_exec_ex (r, flags, cmd, ops, NULL);
 }
 
 static int check_local_only_cmd_options (const flux_cmd_t *cmd)

--- a/src/common/libsubprocess/subprocess.h
+++ b/src/common/libsubprocess/subprocess.h
@@ -302,10 +302,16 @@ flux_subprocess_t *flux_exec (flux_t *h, int flags,
                               const flux_subprocess_ops_t *ops,
                               const flux_subprocess_hooks_t *hooks);
 
-flux_subprocess_t *flux_local_exec (flux_reactor_t *r, int flags,
+flux_subprocess_t *flux_local_exec (flux_reactor_t *r,
+                                    int flags,
                                     const flux_cmd_t *cmd,
-                                    const flux_subprocess_ops_t *ops,
-                                    const flux_subprocess_hooks_t *hooks);
+                                    const flux_subprocess_ops_t *ops);
+
+flux_subprocess_t *flux_local_exec_ex (flux_reactor_t *r,
+                                       int flags,
+                                       const flux_cmd_t *cmd,
+                                       const flux_subprocess_ops_t *ops,
+                                       const flux_subprocess_hooks_t *hooks);
 
 flux_subprocess_t *flux_rexec (flux_t *h, int rank, int flags,
                                const flux_cmd_t *cmd,

--- a/src/common/libsubprocess/subprocess.h
+++ b/src/common/libsubprocess/subprocess.h
@@ -178,7 +178,7 @@ char *flux_cmd_stringify (const flux_cmd_t *cmd);
  *   If `overwrite` is non-zero then overwrite any existing setting for `name`.
  */
 int flux_cmd_setenvf (flux_cmd_t *cmd, int overwrite,
-		      const char *name, const char *fmt, ...)
+                      const char *name, const char *fmt, ...)
                       __attribute__ ((format (printf, 4, 5)));
 
 /*

--- a/src/common/libsubprocess/subprocess.h
+++ b/src/common/libsubprocess/subprocess.h
@@ -283,8 +283,8 @@ const char *flux_cmd_getopt (flux_cmd_t *cmd, const char *var);
 
 /*
  *  Asynchronously create a new subprocess described by command object
- *   `cmd`.  flux_exec() and flux_local_exec() create a new subprocess
- *   locally.  flux_rexec() creates a new subprocess on Flux rank
+ *   `cmd`.  flux_local_exec() create a new subprocess locally.
+ *   flux_rexec() creates a new subprocess on Flux rank
  *   `rank`. Callbacks in `ops` structure that are non-NULL will be
  *   called to process state changes, I/O, and completion.
  *
@@ -297,11 +297,6 @@ const char *flux_cmd_getopt (flux_cmd_t *cmd, const char *var);
  *   by the time the call returns.
  *
  */
-flux_subprocess_t *flux_exec (flux_t *h, int flags,
-                              const flux_cmd_t *cmd,
-                              const flux_subprocess_ops_t *ops,
-                              const flux_subprocess_hooks_t *hooks);
-
 flux_subprocess_t *flux_local_exec (flux_reactor_t *r,
                                     int flags,
                                     const flux_cmd_t *cmd,

--- a/src/common/libsubprocess/subprocess.h
+++ b/src/common/libsubprocess/subprocess.h
@@ -107,6 +107,19 @@ typedef struct {
 } flux_subprocess_hooks_t;
 
 /*
+ *  llog-compatible callback
+ */
+typedef void (*subprocess_log_f) (void *arg,
+                                  const char *file,
+                                  int line,
+                                  const char *func,
+                                  const char *subsys,
+                                  int level,
+                                  const char *fmt,
+                                  va_list args);
+
+
+/*
  * Convenience Functions:
  */
 
@@ -473,15 +486,6 @@ int flux_subprocess_aux_set (flux_subprocess_t *p,
  *   no such context exists, then NULL is returned.
  */
 void *flux_subprocess_aux_get (flux_subprocess_t *p, const char *name);
-
-typedef void (*subprocess_log_f) (void *arg,
-                                  const char *file,
-                                  int line,
-                                  const char *func,
-                                  const char *subsys,
-                                  int level,
-                                  const char *fmt,
-                                  va_list args);
 
 /* Set default internal logging function.
  */

--- a/src/common/libsubprocess/subprocess.h
+++ b/src/common/libsubprocess/subprocess.h
@@ -311,7 +311,9 @@ flux_subprocess_t *flux_local_exec_ex (flux_reactor_t *r,
                                        int flags,
                                        const flux_cmd_t *cmd,
                                        const flux_subprocess_ops_t *ops,
-                                       const flux_subprocess_hooks_t *hooks);
+                                       const flux_subprocess_hooks_t *hooks,
+                                       subprocess_log_f log_fn,
+                                       void *log_data);
 
 flux_subprocess_t *flux_rexec (flux_t *h, int rank, int flags,
                                const flux_cmd_t *cmd,
@@ -322,7 +324,9 @@ flux_subprocess_t *flux_rexec_ex (flux_t *h,
                                   int rank,
                                   int flags,
                                   const flux_cmd_t *cmd,
-                                  const flux_subprocess_ops_t *ops);
+                                  const flux_subprocess_ops_t *ops,
+                                  subprocess_log_f log_fn,
+                                  void *log_data);
 
 
 /* Start / stop a read stream temporarily on local processes.  This
@@ -492,13 +496,6 @@ int flux_subprocess_aux_set (flux_subprocess_t *p,
  *   no such context exists, then NULL is returned.
  */
 void *flux_subprocess_aux_get (flux_subprocess_t *p, const char *name);
-
-/* Set default internal logging function.
- */
-int flux_set_default_subprocess_log (flux_t *h,
-                                     subprocess_log_f log_fn,
-                                     void *log_data);
-
 
 
 #ifdef __cplusplus

--- a/src/common/libsubprocess/test/iochan.c
+++ b/src/common/libsubprocess/test/iochan.c
@@ -191,8 +191,15 @@ bool iochan_run_check (flux_t *h, const char *name, int count)
     if (flux_cmd_add_channel (cmd, "IOCHAN_IN") < 0
         || flux_cmd_add_channel (cmd, "IOCHAN_OUT") < 0)
         BAIL_OUT ("flux_cmd_add_channel failed");
-    if (!(ctx.p = flux_rexec (h, FLUX_NODEID_ANY, 0, cmd, &iochan_ops)))
-        BAIL_OUT ("flux_rexec failed");
+    if (!(ctx.p = flux_rexec_ex (h,
+                                 "rexec",
+                                 FLUX_NODEID_ANY,
+                                 0,
+                                 cmd,
+                                 &iochan_ops,
+                                 tap_logger,
+                                 NULL)))
+        BAIL_OUT ("flux_rexec_ex failed");
     if (flux_subprocess_aux_set (ctx.p, "ctx", &ctx, NULL) < 0)
         BAIL_OUT ("flux_subprocess_aux_set failed");
 
@@ -233,9 +240,6 @@ int main (int argc, char *argv[])
     plan (NO_PLAN);
 
     h = rcmdsrv_create ("rexec");
-
-    if (flux_set_default_subprocess_log (h, tap_logger, NULL) < 0)
-        BAIL_OUT ("could not set logger");
 
     ok (iochan_run_check (h, "simple", linesize * 100),
         "simple check worked");

--- a/src/common/libsubprocess/test/iostress.c
+++ b/src/common/libsubprocess/test/iostress.c
@@ -232,7 +232,14 @@ bool iostress_run_check (flux_t *h,
         if (flux_cmd_setopt (cmd, "stdout_BUFSIZE", nbuf) < 0)
             BAIL_OUT ("flux_cmd_setopt failed");
     }
-    if (!(ctx.p = flux_rexec (h, FLUX_NODEID_ANY, 0, cmd, &iostress_ops)))
+    if (!(ctx.p = flux_rexec_ex (h,
+                                 "rexec",
+                                 FLUX_NODEID_ANY,
+                                 0,
+                                 cmd,
+                                 &iostress_ops,
+                                 tap_logger,
+                                 NULL)))
         BAIL_OUT ("flux_rexec failed");
     if (flux_subprocess_aux_set (ctx.p, "ctx", &ctx, NULL) < 0)
         BAIL_OUT ("flux_subprocess_aux_set failed");
@@ -275,9 +282,6 @@ int main (int argc, char *argv[])
     plan (NO_PLAN);
 
     h = rcmdsrv_create ("rexec");
-
-    if (flux_set_default_subprocess_log (h, tap_logger, NULL) < 0)
-        BAIL_OUT ("could not set logger");
 
     ok (iostress_run_check (h, "balanced", false, 0, 0, 8, 8, 80),
         "balanced worked");

--- a/src/common/libsubprocess/test/rcmdsrv.c
+++ b/src/common/libsubprocess/test/rcmdsrv.c
@@ -50,15 +50,15 @@ static int test_server (flux_t *h, void *arg)
     int rc = -1;
     subprocess_server_t *srv = NULL;
 
-    if (flux_set_default_subprocess_log (h, tap_logger, NULL) < 0) {
-        diag ("flux_set_default_subprocess_log failed");
-        goto done;
-    }
     if (flux_attr_set_cacheonly (h, "rank", "0") < 0) {
         diag ("flux_attr_set_cacheonly failed");
         goto done;
     }
-    if (!(srv = subprocess_server_create (h, service_name, "smurf"))) {
+    if (!(srv = subprocess_server_create (h,
+                                          service_name,
+                                          "smurf",
+                                          tap_logger,
+                                          NULL))) {
         diag ("subprocess_server_create failed");
         goto done;
     }

--- a/src/common/libsubprocess/test/remote.c
+++ b/src/common/libsubprocess/test/remote.c
@@ -152,7 +152,14 @@ void simple_run_check (flux_t *h,
 
     memset (&ctx, 0, sizeof (ctx));
     ctx.h = h;
-    p = flux_rexec_ex (h, SERVER_NAME, FLUX_NODEID_ANY, 0, cmd, &simple_ops);
+    p = flux_rexec_ex (h,
+                       SERVER_NAME,
+                       FLUX_NODEID_ANY,
+                       0,
+                       cmd,
+                       &simple_ops,
+                       tap_logger,
+                       NULL);
     ok (p != NULL,
         "%s: flux_rexec_ex returned a subprocess object", av[0]);
     if (!p)
@@ -311,7 +318,14 @@ void sigstop_test (flux_t *h)
     if (!cmd)
         BAIL_OUT ("flux_cmd_create failed");
 
-    p = flux_rexec_ex (h, SERVER_NAME, FLUX_NODEID_ANY, 0, cmd, &stoptest_ops);
+    p = flux_rexec_ex (h,
+                       SERVER_NAME,
+                       FLUX_NODEID_ANY,
+                       0,
+                       cmd,
+                       &stoptest_ops,
+                       tap_logger,
+                       NULL);
     ok (p != NULL,
         "stoptest: created subprocess");
     if (flux_subprocess_aux_set (p, "reactor", flux_get_reactor (h), NULL) < 0)
@@ -332,9 +346,6 @@ int main (int argc, char *argv[])
     plan (NO_PLAN);
 
     h = rcmdsrv_create (SERVER_NAME);
-
-    if (flux_set_default_subprocess_log (h, tap_logger, NULL) < 0)
-        BAIL_OUT ("could not set logger");
 
     simple_test (h);
     sigstop_test (h);

--- a/src/common/libsubprocess/test/subprocess.c
+++ b/src/common/libsubprocess/test/subprocess.c
@@ -159,9 +159,6 @@ void test_basic_errors (flux_reactor_t *r)
         && errno == EINVAL,
         "subprocess_server_shutdown fails with NULL pointer inputs");
 
-    ok (flux_exec (NULL, 0, NULL, NULL, NULL) == NULL
-        && errno == EINVAL,
-        "flux_exec fails with NULL pointer inputs");
     ok (flux_local_exec (NULL, 0, NULL, NULL) == NULL
         && errno == EINVAL,
         "flux_local_exec fails with NULL pointer inputs");

--- a/src/common/libsubprocess/test/subprocess.c
+++ b/src/common/libsubprocess/test/subprocess.c
@@ -85,7 +85,7 @@ void test_basic (flux_reactor_t *r)
         .on_completion = completion_cb
     };
     completion_cb_count = 0;
-    p = flux_local_exec (r, 0, cmd, &ops, NULL);
+    p = flux_local_exec (r, 0, cmd, &ops);
     ok (p != NULL, "flux_local_exec");
 
     ok (flux_subprocess_state (p) == FLUX_SUBPROCESS_RUNNING,
@@ -129,7 +129,7 @@ void test_basic_fail (flux_reactor_t *r)
         .on_completion = completion_fail_cb
     };
     completion_fail_cb_count = 0;
-    p = flux_local_exec (r, 0, cmd, &ops, NULL);
+    p = flux_local_exec (r, 0, cmd, &ops);
     ok (p != NULL, "flux_local_exec");
 
     ok (flux_subprocess_state (p) == FLUX_SUBPROCESS_RUNNING,
@@ -162,10 +162,10 @@ void test_basic_errors (flux_reactor_t *r)
     ok (flux_exec (NULL, 0, NULL, NULL, NULL) == NULL
         && errno == EINVAL,
         "flux_exec fails with NULL pointer inputs");
-    ok (flux_local_exec (NULL, 0, NULL, NULL, NULL) == NULL
+    ok (flux_local_exec (NULL, 0, NULL, NULL) == NULL
         && errno == EINVAL,
         "flux_local_exec fails with NULL pointer inputs");
-    ok (flux_local_exec (r, 1234, NULL, NULL, NULL) == NULL
+    ok (flux_local_exec (r, 1234, NULL, NULL) == NULL
         && errno == EINVAL,
         "flux_local_exec fails with invalid flag");
     ok (flux_rexec (NULL, 0, 0, NULL, NULL) == NULL
@@ -177,7 +177,7 @@ void test_basic_errors (flux_reactor_t *r)
 
     ok ((cmd = flux_cmd_create (0, avbad, NULL)) != NULL,
         "flux_cmd_create with 0 args works");
-    ok (flux_local_exec (r, 0, cmd, NULL, NULL) == NULL
+    ok (flux_local_exec (r, 0, cmd, NULL) == NULL
         && errno == EINVAL,
         "flux_local_exec fails with cmd with zero args");
     ok (flux_rexec (h, 0, 0, cmd, NULL) == NULL
@@ -283,7 +283,7 @@ void test_errors (flux_reactor_t *r)
         .on_completion = completion_cb
     };
     completion_cb_count = 0;
-    p = flux_local_exec (r, 0, cmd, &ops, NULL);
+    p = flux_local_exec (r, 0, cmd, &ops);
     ok (p != NULL, "flux_local_exec");
 
     ok (flux_subprocess_state (p) == FLUX_SUBPROCESS_RUNNING,
@@ -405,7 +405,7 @@ void test_basic_stdout (flux_reactor_t *r)
     completion_cb_count = 0;
     stdout_output_cb_count = 0;
     stderr_output_cb_count = 0;
-    p = flux_local_exec (r, 0, cmd, &ops, NULL);
+    p = flux_local_exec (r, 0, cmd, &ops);
     ok (p != NULL, "flux_local_exec");
 
     ok (flux_subprocess_state (p) == FLUX_SUBPROCESS_RUNNING,
@@ -435,7 +435,7 @@ void test_basic_stderr (flux_reactor_t *r)
     completion_cb_count = 0;
     stdout_output_cb_count = 0;
     stderr_output_cb_count = 0;
-    p = flux_local_exec (r, 0, cmd, &ops, NULL);
+    p = flux_local_exec (r, 0, cmd, &ops);
     ok (p != NULL, "flux_local_exec");
 
     ok (flux_subprocess_state (p) == FLUX_SUBPROCESS_RUNNING,
@@ -468,7 +468,7 @@ void test_basic_stdout_and_stderr (flux_reactor_t *r)
     completion_cb_count = 0;
     stdout_output_cb_count = 0;
     stderr_output_cb_count = 0;
-    p = flux_local_exec (r, 0, cmd, &ops, NULL);
+    p = flux_local_exec (r, 0, cmd, &ops);
     ok (p != NULL, "flux_local_exec");
 
     ok (flux_subprocess_state (p) == FLUX_SUBPROCESS_RUNNING,
@@ -497,7 +497,7 @@ void test_basic_default_output (flux_reactor_t *r)
         .on_stderr = flux_standard_output
     };
     completion_cb_count = 0;
-    p = flux_local_exec (r, 0, cmd, &ops, NULL);
+    p = flux_local_exec (r, 0, cmd, &ops);
     ok (p != NULL, "flux_local_exec");
 
     ok (flux_subprocess_state (p) == FLUX_SUBPROCESS_RUNNING,
@@ -557,7 +557,7 @@ void test_basic_stdin (flux_reactor_t *r)
     };
     completion_cb_count = 0;
     stdout_output_cb_count = 0;
-    p = flux_local_exec (r, 0, cmd, &ops, NULL);
+    p = flux_local_exec (r, 0, cmd, &ops);
     ok (p != NULL, "flux_local_exec");
 
     ok (flux_subprocess_state (p) == FLUX_SUBPROCESS_RUNNING,
@@ -641,7 +641,7 @@ void test_basic_no_newline (flux_reactor_t *r)
     completion_cb_count = 0;
     stdout_output_cb_count = 0;
     stderr_output_cb_count = 0;
-    p = flux_local_exec (r, 0, cmd, &ops, NULL);
+    p = flux_local_exec (r, 0, cmd, &ops);
     ok (p != NULL, "flux_local_exec");
 
     ok (flux_subprocess_state (p) == FLUX_SUBPROCESS_RUNNING,
@@ -712,7 +712,7 @@ void test_basic_trimmed_line (flux_reactor_t *r)
     completion_cb_count = 0;
     stdout_output_cb_count = 0;
     stderr_output_cb_count = 0;
-    p = flux_local_exec (r, 0, cmd, &ops, NULL);
+    p = flux_local_exec (r, 0, cmd, &ops);
     ok (p != NULL, "flux_local_exec");
 
     ok (flux_subprocess_state (p) == FLUX_SUBPROCESS_RUNNING,
@@ -804,7 +804,7 @@ void test_basic_multiple_lines (flux_reactor_t *r)
     completion_cb_count = 0;
     multiple_lines_stdout_output_cb_count = 0;
     multiple_lines_stderr_output_cb_count = 0;
-    p = flux_local_exec (r, 0, cmd, &ops, NULL);
+    p = flux_local_exec (r, 0, cmd, &ops);
     ok (p != NULL, "flux_local_exec");
 
     ok (flux_subprocess_state (p) == FLUX_SUBPROCESS_RUNNING,
@@ -873,7 +873,7 @@ void test_basic_stdin_closed (flux_reactor_t *r)
     completion_cb_count = 0;
     stdin_closed_stdout_cb_count = 0;
     stdin_closed_stderr_cb_count = 0;
-    p = flux_local_exec (r, 0, cmd, &ops, NULL);
+    p = flux_local_exec (r, 0, cmd, &ops);
     ok (p != NULL, "flux_local_exec");
 
     ok (flux_subprocess_state (p) == FLUX_SUBPROCESS_RUNNING,
@@ -949,7 +949,7 @@ void test_basic_read_line_until_eof (flux_reactor_t *r)
     completion_cb_count = 0;
     stdout_output_cb_count = 0;
     stderr_output_cb_count = 0;
-    p = flux_local_exec (r, 0, cmd, &ops, NULL);
+    p = flux_local_exec (r, 0, cmd, &ops);
     ok (p != NULL, "flux_local_exec");
 
     ok (flux_subprocess_state (p) == FLUX_SUBPROCESS_RUNNING,
@@ -1026,7 +1026,7 @@ void test_basic_read_line_until_eof_error (flux_reactor_t *r)
     completion_cb_count = 0;
     stdout_output_cb_count = 0;
     stderr_output_cb_count = 0;
-    p = flux_local_exec (r, 0, cmd, &ops, NULL);
+    p = flux_local_exec (r, 0, cmd, &ops);
     ok (p != NULL, "flux_local_exec");
 
     ok (flux_subprocess_state (p) == FLUX_SUBPROCESS_RUNNING,
@@ -1055,7 +1055,7 @@ void test_write_after_close (flux_reactor_t *r)
     };
     completion_cb_count = 0;
     stdout_output_cb_count = 0;
-    p = flux_local_exec (r, 0, cmd, &ops, NULL);
+    p = flux_local_exec (r, 0, cmd, &ops);
     ok (p != NULL, "flux_local_exec");
 
     ok (flux_subprocess_state (p) == FLUX_SUBPROCESS_RUNNING,
@@ -1093,8 +1093,7 @@ void test_flag_stdio_fallthrough (flux_reactor_t *r)
     p = flux_local_exec (r,
                          FLUX_SUBPROCESS_FLAGS_STDIO_FALLTHROUGH,
                          cmd,
-                         &ops,
-                         NULL);
+                         &ops);
     ok (p != NULL, "flux_local_exec");
 
     ok (flux_subprocess_state (p) == FLUX_SUBPROCESS_RUNNING,
@@ -1120,7 +1119,7 @@ void test_flag_setpgrp (flux_reactor_t *r)
         .on_completion = completion_cb
     };
     completion_cb_count = 0;
-    p = flux_local_exec (r, FLUX_SUBPROCESS_FLAGS_SETPGRP, cmd, &ops, NULL);
+    p = flux_local_exec (r, FLUX_SUBPROCESS_FLAGS_SETPGRP, cmd, &ops);
     ok (p != NULL, "flux_local_exec");
 
     ok (flux_subprocess_state (p) == FLUX_SUBPROCESS_RUNNING,
@@ -1145,7 +1144,7 @@ void test_flag_fork_exec (flux_reactor_t *r)
         .on_completion = completion_cb
     };
     completion_cb_count = 0;
-    p = flux_local_exec (r, FLUX_SUBPROCESS_FLAGS_FORK_EXEC, cmd, &ops, NULL);
+    p = flux_local_exec (r, FLUX_SUBPROCESS_FLAGS_FORK_EXEC, cmd, &ops);
     ok (p != NULL, "flux_local_exec");
 
     ok (flux_subprocess_state (p) == FLUX_SUBPROCESS_RUNNING,
@@ -1204,7 +1203,7 @@ void test_env_passed (flux_reactor_t *r)
     };
     completion_cb_count = 0;
     env_passed_cb_count = 0;
-    p = flux_local_exec (r, 0, cmd, &ops, NULL);
+    p = flux_local_exec (r, 0, cmd, &ops);
     ok (p != NULL, "flux_local_exec");
 
     ok (flux_subprocess_state (p) == FLUX_SUBPROCESS_RUNNING,
@@ -1243,7 +1242,7 @@ void test_kill (flux_reactor_t *r)
         .on_completion = completion_sigterm_cb
     };
     completion_sigterm_cb_count = 0;
-    p = flux_local_exec (r, 0, cmd, &ops, NULL);
+    p = flux_local_exec (r, 0, cmd, &ops);
     ok (p != NULL, "flux_local_exec");
 
     ok (flux_subprocess_state (p) == FLUX_SUBPROCESS_RUNNING,
@@ -1332,7 +1331,7 @@ void test_kill_setpgrp (flux_reactor_t *r)
     output_processes_cb_count = 0;
     parent_pid = -1;
     child_pid = -1;
-    p = flux_local_exec (r, FLUX_SUBPROCESS_FLAGS_SETPGRP, cmd, &ops, NULL);
+    p = flux_local_exec (r, FLUX_SUBPROCESS_FLAGS_SETPGRP, cmd, &ops);
     ok (p != NULL, "flux_local_exec");
 
     ok (flux_subprocess_state (p) == FLUX_SUBPROCESS_RUNNING,
@@ -1399,7 +1398,7 @@ void test_kill_eofs (flux_reactor_t *r)
     completion_sigterm_cb_count = 0;
     stdout_eof_cb_count = 0;
     stderr_eof_cb_count = 0;
-    p = flux_local_exec (r, 0, cmd, &ops, NULL);
+    p = flux_local_exec (r, 0, cmd, &ops);
     ok (p != NULL, "flux_local_exec");
 
     ok (flux_subprocess_state (p) == FLUX_SUBPROCESS_RUNNING,
@@ -1444,7 +1443,7 @@ void test_state_change (flux_reactor_t *r)
     };
     completion_cb_count = 0;
     state_change_cb_count = 0;
-    p = flux_local_exec (r, 0, cmd, &ops, NULL);
+    p = flux_local_exec (r, 0, cmd, &ops);
     ok (p != NULL, "flux_local_exec");
 
     ok (flux_subprocess_state (p) == FLUX_SUBPROCESS_RUNNING,
@@ -1483,7 +1482,7 @@ void test_state_change_stopped (flux_reactor_t *r)
         .on_state_change = state_change_stopped_cb
     };
     stopped_cb_count = 0;
-    p = flux_local_exec (r, 0, cmd, &ops, NULL);
+    p = flux_local_exec (r, 0, cmd, &ops);
     ok (p != NULL, "flux_local_exec");
 
     ok (flux_subprocess_state (p) == FLUX_SUBPROCESS_RUNNING,
@@ -1529,7 +1528,7 @@ void test_exec_fail (flux_reactor_t *r)
     ok (flux_cmd_setcwd (cmd, getcwd (path, sizeof (path))) == 0,
         "flux_cmd_setcwd");
 
-    p = flux_local_exec (r, 0, cmd, NULL, NULL);
+    p = flux_local_exec (r, 0, cmd, NULL);
     ok (p == NULL
         && errno == EACCES,
         "flux_local_exec failed with EACCES");
@@ -1542,7 +1541,7 @@ void test_exec_fail (flux_reactor_t *r)
     ok (flux_cmd_setcwd (cmd, getcwd (path, sizeof (path))) == 0,
         "flux_cmd_setcwd");
 
-    p = flux_local_exec (r, 0, cmd, NULL, NULL);
+    p = flux_local_exec (r, 0, cmd, NULL);
     ok (p == NULL
         && errno == ENOENT,
         "flux_local_exec failed with ENOENT");
@@ -1564,7 +1563,7 @@ void test_context (flux_reactor_t *r)
         .on_completion = completion_cb
     };
     completion_cb_count = 0;
-    p = flux_local_exec (r, 0, cmd, &ops, NULL);
+    p = flux_local_exec (r, 0, cmd, &ops);
     ok (p != NULL, "flux_local_exec");
 
     ok (flux_subprocess_state (p) == FLUX_SUBPROCESS_RUNNING,
@@ -1597,7 +1596,7 @@ void test_refcount (flux_reactor_t *r)
         .on_completion = completion_cb
     };
     completion_cb_count = 0;
-    p = flux_local_exec (r, 0, cmd, &ops, NULL);
+    p = flux_local_exec (r, 0, cmd, &ops);
     ok (p != NULL, "flux_local_exec");
 
     ok (flux_subprocess_state (p) == FLUX_SUBPROCESS_RUNNING,
@@ -1670,7 +1669,7 @@ void test_channel_fd_env (flux_reactor_t *r)
     };
     completion_cb_count = 0;
     channel_fd_env_cb_count = 0;
-    p = flux_local_exec (r, 0, cmd, &ops, NULL);
+    p = flux_local_exec (r, 0, cmd, &ops);
     ok (p != NULL, "flux_local_exec");
 
     ok (flux_subprocess_state (p) == FLUX_SUBPROCESS_RUNNING,
@@ -1736,7 +1735,7 @@ void test_channel_fd_in (flux_reactor_t *r)
     };
     completion_cb_count = 0;
     channel_in_cb_count = 0;
-    p = flux_local_exec (r, 0, cmd, &ops, NULL);
+    p = flux_local_exec (r, 0, cmd, &ops);
     ok (p != NULL, "flux_local_exec");
 
     ok (flux_subprocess_state (p) == FLUX_SUBPROCESS_RUNNING,
@@ -1807,7 +1806,7 @@ void test_channel_fd_in_and_out (flux_reactor_t *r)
     };
     completion_cb_count = 0;
     channel_in_and_out_cb_count = 0;
-    p = flux_local_exec (r, 0, cmd, &ops, NULL);
+    p = flux_local_exec (r, 0, cmd, &ops);
     ok (p != NULL, "flux_local_exec");
 
     ok (flux_subprocess_state (p) == FLUX_SUBPROCESS_RUNNING,
@@ -1897,7 +1896,7 @@ void test_channel_multiple_lines (flux_reactor_t *r)
     };
     completion_cb_count = 0;
     multiple_lines_channel_cb_count = 0;
-    p = flux_local_exec (r, 0, cmd, &ops, NULL);
+    p = flux_local_exec (r, 0, cmd, &ops);
     ok (p != NULL, "flux_local_exec");
 
     ok (flux_subprocess_state (p) == FLUX_SUBPROCESS_RUNNING,
@@ -1983,7 +1982,7 @@ void test_bufsize (flux_reactor_t *r)
         .on_stderr = flux_standard_output
     };
     completion_cb_count = 0;
-    p = flux_local_exec (r, 0, cmd, &ops, NULL);
+    p = flux_local_exec (r, 0, cmd, &ops);
     ok (p != NULL, "flux_local_exec");
 
     ok (flux_subprocess_state (p) == FLUX_SUBPROCESS_RUNNING,
@@ -2016,7 +2015,7 @@ void test_bufsize_error (flux_reactor_t *r)
         .on_stdout = flux_standard_output,
         .on_stderr = flux_standard_output
     };
-    p = flux_local_exec (r, 0, cmd, &ops, NULL);
+    p = flux_local_exec (r, 0, cmd, &ops);
     ok (p == NULL
         && errno == EINVAL,
         "flux_local_exec fails with EINVAL due to bad bufsize input");
@@ -2079,7 +2078,7 @@ void test_line_buffer_default (flux_reactor_t *r)
     completion_cb_count = 0;
     stdout_output_cb_count = 0;
     stderr_output_cb_count = 0;
-    p = flux_local_exec (r, 0, cmd, &ops, NULL);
+    p = flux_local_exec (r, 0, cmd, &ops);
     ok (p != NULL, "flux_local_exec");
 
     ok (flux_subprocess_state (p) == FLUX_SUBPROCESS_RUNNING,
@@ -2113,7 +2112,7 @@ void test_line_buffer_enable (flux_reactor_t *r)
     completion_cb_count = 0;
     stdout_output_cb_count = 0;
     stderr_output_cb_count = 0;
-    p = flux_local_exec (r, 0, cmd, &ops, NULL);
+    p = flux_local_exec (r, 0, cmd, &ops);
     ok (p != NULL, "flux_local_exec");
 
     ok (flux_subprocess_state (p) == FLUX_SUBPROCESS_RUNNING,
@@ -2164,7 +2163,7 @@ void test_line_buffer_disable (flux_reactor_t *r)
     completion_cb_count = 0;
     stdout_output_cb_count = 0;
     stderr_output_cb_count = 0;
-    p = flux_local_exec (r, 0, cmd, &ops, NULL);
+    p = flux_local_exec (r, 0, cmd, &ops);
     ok (p != NULL, "flux_local_exec");
 
     ok (flux_subprocess_state (p) == FLUX_SUBPROCESS_RUNNING,
@@ -2197,7 +2196,7 @@ void test_line_buffer_error (flux_reactor_t *r)
         .on_stdout = flux_standard_output,
         .on_stderr = flux_standard_output
     };
-    p = flux_local_exec (r, 0, cmd, &ops, NULL);
+    p = flux_local_exec (r, 0, cmd, &ops);
     ok (p == NULL
         && errno == EINVAL,
         "flux_local_exec fails with EINVAL due to bad line_buffer input");
@@ -2221,7 +2220,7 @@ void test_stream_start_stop_basic (flux_reactor_t *r)
     completion_cb_count = 0;
     stdout_output_cb_count = 0;
     stderr_output_cb_count = 0;
-    p = flux_local_exec (r, 0, cmd, &ops, NULL);
+    p = flux_local_exec (r, 0, cmd, &ops);
     ok (p != NULL, "flux_local_exec");
 
     ok (flux_subprocess_state (p) == FLUX_SUBPROCESS_RUNNING,
@@ -2330,7 +2329,7 @@ void test_stream_start_stop_initial_stop (flux_reactor_t *r)
     stderr_output_cb_count = 0;
     stdout_output_cb_len_count = 0;
     stderr_output_cb_len_count = 0;
-    p = flux_local_exec (r, 0, cmd, &ops, NULL);
+    p = flux_local_exec (r, 0, cmd, &ops);
     ok (p != NULL, "flux_local_exec");
 
     ok (flux_subprocess_state (p) == FLUX_SUBPROCESS_RUNNING,
@@ -2433,7 +2432,7 @@ void test_stream_start_stop_mid_stop (flux_reactor_t *r)
     stdout_output_cb_count = 0;
     stderr_output_cb_count = 0;
     timer_cb_count = 0;
-    p = flux_local_exec (r, 0, cmd, &ops, NULL);
+    p = flux_local_exec (r, 0, cmd, &ops);
     ok (p != NULL, "flux_local_exec");
 
     ok ((tw = flux_timer_watcher_create (r, 2.0, 0.0,
@@ -2497,7 +2496,7 @@ void test_stream_stop_enable (flux_reactor_t *r)
     stderr_output_cb_count = 0;
     stdout_output_cb_len_count = 0;
     stderr_output_cb_len_count = 0;
-    p = flux_local_exec (r, 0, cmd, &ops, NULL);
+    p = flux_local_exec (r, 0, cmd, &ops);
     ok (p != NULL, "flux_local_exec");
 
     ok (flux_subprocess_state (p) == FLUX_SUBPROCESS_RUNNING,
@@ -2550,7 +2549,7 @@ void test_stream_stop_disable (flux_reactor_t *r)
     completion_cb_count = 0;
     stdout_output_cb_count = 0;
     stderr_output_cb_count = 0;
-    p = flux_local_exec (r, 0, cmd, &ops, NULL);
+    p = flux_local_exec (r, 0, cmd, &ops);
     ok (p != NULL, "flux_local_exec");
 
     ok (flux_subprocess_state (p) == FLUX_SUBPROCESS_RUNNING,
@@ -2584,7 +2583,7 @@ void test_stream_stop_error (flux_reactor_t *r)
         .on_stdout = flux_standard_output,
         .on_stderr = flux_standard_output
     };
-    p = flux_local_exec (r, 0, cmd, &ops, NULL);
+    p = flux_local_exec (r, 0, cmd, &ops);
     ok (p == NULL
         && errno == EINVAL,
         "flux_local_exec fails with EINVAL due to bad stream_stop input");
@@ -2625,8 +2624,12 @@ void test_pre_exec_hook (flux_reactor_t *r)
         .pre_exec_arg = shmem_count
     };
     completion_cb_count = 0;
-    p = flux_local_exec (r, FLUX_SUBPROCESS_FLAGS_STDIO_FALLTHROUGH, cmd, &ops, &hooks);
-    ok (p != NULL, "flux_local_exec");
+    p = flux_local_exec_ex (r,
+                            FLUX_SUBPROCESS_FLAGS_STDIO_FALLTHROUGH,
+                            cmd,
+                            &ops,
+                            &hooks);
+    ok (p != NULL, "flux_local_exec_ex");
 
     int rc = flux_reactor_run (r, 0);
     ok (rc == 0, "flux_reactor_run returned zero status");
@@ -2660,8 +2663,8 @@ void test_post_fork_hook (flux_reactor_t *r)
         .post_fork_arg = &hook_count
     };
     completion_cb_count = 0;
-    p = flux_local_exec (r, 0, cmd, &ops, &hooks);
-    ok (p != NULL, "flux_local_exec");
+    p = flux_local_exec_ex (r, 0, cmd, &ops, &hooks);
+    ok (p != NULL, "flux_local_exec_ex");
 
     int rc = flux_reactor_run (r, 0);
     ok (rc == 0, "flux_reactor_run returned zero status");
@@ -2696,7 +2699,7 @@ void test_destroy_in_completion (flux_reactor_t *r)
         .on_completion = destroy_in_completion_cb
     };
     completion_cb_count = 0;
-    p = flux_local_exec (r, 0, cmd, &ops, NULL);
+    p = flux_local_exec (r, 0, cmd, &ops);
     ok (p != NULL, "flux_local_exec");
 
     ok (flux_subprocess_state (p) == FLUX_SUBPROCESS_RUNNING,

--- a/src/common/libsubprocess/test/subprocess.c
+++ b/src/common/libsubprocess/test/subprocess.c
@@ -2628,7 +2628,9 @@ void test_pre_exec_hook (flux_reactor_t *r)
                             FLUX_SUBPROCESS_FLAGS_STDIO_FALLTHROUGH,
                             cmd,
                             &ops,
-                            &hooks);
+                            &hooks,
+                            NULL,
+                            NULL);
     ok (p != NULL, "flux_local_exec_ex");
 
     int rc = flux_reactor_run (r, 0);
@@ -2663,7 +2665,7 @@ void test_post_fork_hook (flux_reactor_t *r)
         .post_fork_arg = &hook_count
     };
     completion_cb_count = 0;
-    p = flux_local_exec_ex (r, 0, cmd, &ops, &hooks);
+    p = flux_local_exec_ex (r, 0, cmd, &ops, &hooks, NULL, NULL);
     ok (p != NULL, "flux_local_exec_ex");
 
     int rc = flux_reactor_run (r, 0);

--- a/src/common/libsubprocess/test/subprocess.c
+++ b/src/common/libsubprocess/test/subprocess.c
@@ -152,7 +152,7 @@ void test_basic_errors (flux_reactor_t *r)
     ok ((h = flux_open ("loop://", 0)) != NULL,
         "flux_open on loop works");
 
-    ok (!subprocess_server_create (NULL, NULL, NULL)
+    ok (!subprocess_server_create (NULL, NULL, NULL, NULL, NULL)
         && errno == EINVAL,
         "subprocess_server_create fails with NULL pointer inputs");
     ok (subprocess_server_shutdown (NULL, 0) == NULL

--- a/src/common/libterminus/terminus.c
+++ b/src/common/libterminus/terminus.c
@@ -347,11 +347,11 @@ static int terminus_session_start (struct terminus_session *s,
         .on_completion = terminus_session_exit,
     };
     s->cmd = cmd;
-    s->p = flux_local_exec (flux_get_reactor (s->server->h),
-                            flags,
-                            cmd,
-                            &ops,
-                            &hooks);
+    s->p = flux_local_exec_ex (flux_get_reactor (s->server->h),
+                               flags,
+                               cmd,
+                               &ops,
+                               &hooks);
     if (!s->p)
         goto cleanup;
     if (flux_subprocess_aux_set (s->p, "terminus", s, NULL) < 0)

--- a/src/common/libterminus/terminus.c
+++ b/src/common/libterminus/terminus.c
@@ -351,7 +351,9 @@ static int terminus_session_start (struct terminus_session *s,
                                flags,
                                cmd,
                                &ops,
-                               &hooks);
+                               &hooks,
+                               NULL,
+                               NULL);
     if (!s->p)
         goto cleanup;
     if (flux_subprocess_aux_set (s->p, "terminus", s, NULL) < 0)

--- a/src/modules/cron/cron.c
+++ b/src/modules/cron/cron.c
@@ -890,11 +890,6 @@ int mod_main (flux_t *h, int ac, char **av)
     if (ctx == NULL)
         return -1;
 
-    /* Set up internal logging for libsubprocesses.
-     */
-    if (flux_set_default_subprocess_log (h, flux_llog, h) < 0)
-        goto done;
-
     process_args (ctx, ac, av);
 
     if (flux_msg_handler_addvec (h, htab, ctx, &handlers) < 0) {

--- a/src/modules/cron/task.c
+++ b/src/modules/cron/task.c
@@ -331,7 +331,7 @@ int cron_task_run (cron_task_t *t,
     if (!(cmd = exec_cmd_create (t, command, cwd, env)))
         goto done;
 
-    if (!(p = flux_rexec (h, rank, 0, cmd, &ops))) {
+    if (!(p = flux_rexec_ex (h, "rexec", rank, 0, cmd, &ops, flux_llog, h))) {
         cron_task_rexec_failed (t, errno);
         goto done;
     }

--- a/src/modules/job-exec/bulk-exec.c
+++ b/src/modules/job-exec/bulk-exec.c
@@ -287,11 +287,14 @@ static int exec_start_cmd (struct bulk_exec *exec,
     uint32_t rank;
     rank = idset_first (cmd->ranks);
     while (rank != IDSET_INVALID_ID && (max < 0 || count < max)) {
-        flux_subprocess_t *p = flux_rexec (exec->h,
-                                           rank,
-                                           cmd->flags,
-                                           cmd->cmd,
-                                           &exec->ops);
+        flux_subprocess_t *p = flux_rexec_ex (exec->h,
+                                              "rexec",
+                                              rank,
+                                              cmd->flags,
+                                              cmd->cmd,
+                                              &exec->ops,
+                                              flux_llog,
+                                              exec->h);
         if (!p)
             return -1;
         if (flux_subprocess_aux_set (p, "job-exec::exec", exec, NULL) < 0

--- a/src/modules/job-exec/job-exec.c
+++ b/src/modules/job-exec/job-exec.c
@@ -1387,9 +1387,6 @@ int mod_main (flux_t *h, int argc, char **argv)
         flux_log_error (h, "job-exec: module initialization failed");
         goto out;
     }
-
-    if (flux_set_default_subprocess_log (h, flux_llog, h) < 0)
-        goto out;
     if (flux_msg_handler_addvec (h, htab, ctx, &ctx->handlers) < 0) {
         flux_log_error (h, "flux_msg_handler_addvec");
         goto out;

--- a/src/modules/job-exec/sdexec.c
+++ b/src/modules/job-exec/sdexec.c
@@ -704,8 +704,15 @@ static int sdexec_kill_multiuser (struct sdexec *se, int signum)
         goto cleanup;
     }
 
-    if (!(p = flux_rexec (se->h, rank, 0, cmd, &ops))) {
-        flux_log_error (se->h, "flux_rexec");
+    if (!(p = flux_rexec_ex (se->h,
+                             "rexec",
+                             rank,
+                             0,
+                             cmd,
+                             &ops,
+                             flux_llog,
+                             se->h))) {
+        flux_log_error (se->h, "flux_rexec_ex");
         goto cleanup;
     }
 

--- a/src/modules/job-ingest/pipeline.c
+++ b/src/modules/job-ingest/pipeline.c
@@ -413,8 +413,6 @@ struct pipeline *pipeline_create (flux_t *h)
 
     if (!(pl = calloc (1, sizeof (*pl))))
         return NULL;
-    if (flux_set_default_subprocess_log (h, flux_llog, h) < 0)
-        goto error;
     pl->h = h;
     if (!(pl->shutdown_timer = flux_timer_watcher_create (r,
                                                           0.,

--- a/src/modules/job-ingest/worker.c
+++ b/src/modules/job-ingest/worker.c
@@ -357,8 +357,13 @@ flux_future_t *worker_kill (struct worker *w, int signo)
 static int worker_start (struct worker *w)
 {
     if (!w->p) {
-        if (!(w->p = flux_rexec (w->h, FLUX_NODEID_ANY, 0,
-                                 w->cmd, &worker_ops))) {
+        if (!(w->p = flux_rexec_ex (w->h,
+                                    "rexec",
+                                    FLUX_NODEID_ANY, 0,
+                                    w->cmd,
+                                    &worker_ops,
+                                    flux_llog,
+                                    w->h))) {
             return -1;
         }
         if (flux_subprocess_aux_set (w->p, worker_auxkey, w, NULL) < 0) {

--- a/src/modules/job-manager/job-manager.c
+++ b/src/modules/job-manager/job-manager.c
@@ -164,10 +164,6 @@ int mod_main (flux_t *h, int argc, char **argv)
     zhashx_set_duplicator (ctx.active_jobs, job_duplicator);
     zhashx_set_destructor (ctx.inactive_jobs, job_destructor);
     zhashx_set_duplicator (ctx.inactive_jobs, job_duplicator);
-    if (flux_set_default_subprocess_log (h, flux_llog, h) < 0) {
-        flux_log_error (h, "error initializing subprocess logging");
-        goto done;
-    }
     if (!(ctx.conf = conf_create (&ctx))) {
         flux_log_error (h, "error creating conf context");
         goto done;

--- a/src/modules/job-manager/plugins/perilog.c
+++ b/src/modules/job-manager/plugins/perilog.c
@@ -288,7 +288,7 @@ static int run_command (flux_plugin_t *p,
         return -1;
     }
 
-    if (!(sp = flux_rexec (h, 0, 0, cmd, &ops))) {
+    if (!(sp = flux_rexec_ex (h, "rexec", 0, 0, cmd, &ops, flux_llog, h))) {
         flux_log_error (h, "%s: flux_rexec", prolog ? "prolog" : "epilog");
         return -1;
     }

--- a/src/shell/task.c
+++ b/src/shell/task.c
@@ -205,7 +205,13 @@ int shell_task_start (struct flux_shell *shell,
     if (shell->nosetpgrp)
         flags &= ~FLUX_SUBPROCESS_FLAGS_SETPGRP;
 
-    task->proc = flux_local_exec_ex (r, flags, task->cmd, &subproc_ops, &hooks);
+    task->proc = flux_local_exec_ex (r,
+                                     flags,
+                                     task->cmd,
+                                     &subproc_ops,
+                                     &hooks,
+                                     NULL,
+                                     NULL);
     if (!task->proc)
         return -1;
     if (flux_subprocess_aux_set (task->proc, "flux::task", task, NULL) < 0) {

--- a/src/shell/task.c
+++ b/src/shell/task.c
@@ -205,7 +205,7 @@ int shell_task_start (struct flux_shell *shell,
     if (shell->nosetpgrp)
         flags &= ~FLUX_SUBPROCESS_FLAGS_SETPGRP;
 
-    task->proc = flux_local_exec (r, flags, task->cmd, &subproc_ops, &hooks);
+    task->proc = flux_local_exec_ex (r, flags, task->cmd, &subproc_ops, &hooks);
     if (!task->proc)
         return -1;
     if (flux_subprocess_aux_set (task->proc, "flux::task", task, NULL) < 0) {


### PR DESCRIPTION
Problem: it was probably a misstep to add `flux_set_default_subprocess_log()` instead of adding logger parameters directly to the subprocess functions.

Add `flux_local_exec_ex()` that takes an `llog` function.

Drop the `hooks` argument from `flux_local_exec()` since it is not widely used (leave it in the `_ex()` version)

Drop `flux_exec()` since the only difference from `flux_local_exec()` was taking a `flux_t *` instead of a reactor, so that it could call `flux_log()` internally, which it no longer does.

Add the logger parameters to `subprocess_server_create()`, and have subprocesses inherit the logger from the server.