### PR TITLE
librlist: drop V1 flag from hwloc XML generation

### DIFF
--- a/src/common/librlist/rhwloc.c
+++ b/src/common/librlist/rhwloc.c
@@ -112,8 +112,7 @@ char *rhwloc_local_topology_xml (rhwloc_flags_t rflags)
     if (topo == NULL)
         return (NULL);
 #if HWLOC_API_VERSION >= 0x20000
-    int flags = HWLOC_TOPOLOGY_EXPORT_XML_FLAG_V1;
-    if (hwloc_topology_export_xmlbuffer (topo, &buf, &buflen, flags) < 0) {
+    if (hwloc_topology_export_xmlbuffer (topo, &buf, &buflen, 0) < 0) {
 #else
     if (hwloc_topology_export_xmlbuffer (topo, &buf, &buflen) < 0) {
 #endif


### PR DESCRIPTION
Problem: The librlist rhwloc_local_topology_xml() function passes the HWLOC_TOPOLOGY_EXPORT_XML_FLAG_V1 flag when exporting the topology to XML under hwloc 2.x, thus forcing the XML for all users of this function to the hwloc v1 format. This includes the XML stored in the resource module and available via resource.topo-get.

Now that hwloc 2.x is more ubiquitous and the XML gathered by the flux resource module has less users, it may be possible to drop this flag.

In fact, we now have external users like mpibind which assume hwloc 2.x and the V1 flag may be detrimental to those integrations.

Drop the HWLOC_TOPOLOGY_EXPORT_XML_FLAG_V1 flag when generating XML from a v2 topology so that v2 XML is available.

Fixes #5005