### PR TITLE
testsuite: speed up t4000-issues-test-driver.t

### DIFF
--- a/t/t4000-issues-test-driver.t
+++ b/t/t4000-issues-test-driver.t
@@ -10,7 +10,7 @@ if test_have_prereq ASAN; then
     test_done
 fi
 
-SIZE=4
+SIZE=2
 test_under_flux ${SIZE}
 echo "# $0: flux session size will be ${SIZE}"
 
@@ -18,10 +18,14 @@ if test -z "$T4000_ISSUES_GLOB"; then
     T4000_ISSUES_GLOB="*"
 fi
 
-for testscript in ${FLUX_SOURCE_DIR}/t/issues/${T4000_ISSUES_GLOB}; do
-    testname=`basename $testscript`
-    prereqs=$(sed -n 's/^.*test-prereqs: \(.*\).*$/\1/gp' $testscript)
-    test_expect_success  "$prereqs" $testname "run_timeout 120 $testscript"
+flux bulksubmit -n1 -o pty --job-name={./%} -t 2m \
+	--flags=waitable \
+	--quiet --watch  \
+	flux start {} \
+	::: ${FLUX_SOURCE_DIR}/t/issues/${T4000_ISSUES_GLOB}
+
+for id in $(flux jobs -ano {id}); do
+    test_expect_success $(flux jobs -no {name} $id) "flux job attach $id"
 done
 
 test_done


### PR DESCRIPTION
Problem: The t4000-issues-test-driver.t runs individual tests serially, and now that there are many issues tests to run, the time to run the test is getting very long - exceeding the 5 minute CI time limit in some cases.

Alter the design of the t4000-issues-test-driver.t test to run each issue reproducer script as a job. Since some scripts themselves run jobs, execute each script under a single-core Flux instance.

Adjust one test that only works with multiple cores to cancel a running job before submitting a new one.