### PR TITLE
job-manager: ensure epilog-start event prevents resource release for job that never started

### DIFF
--- a/src/modules/job-manager/event.c
+++ b/src/modules/job-manager/event.c
@@ -407,6 +407,7 @@ int event_job_action (struct event *event, struct job *job)
              * it is safe to release all resources to the scheduler.
              */
             if (job->has_resources
+                && !job_event_is_queued (job, "epilog-start")
                 && !job->perilog_active
                 && !job->alloc_bypass
                 && !job->start_pending

--- a/t/t2212-job-manager-plugins.t
+++ b/t/t2212-job-manager-plugins.t
@@ -472,7 +472,16 @@ test_expect_success 'job-manager: job prolog/epilog events work' '
 	test_debug "echo Checking that epilog-finish=$n_epilog event occurs before free=$n_free event" &&
 	test $n_prolog -lt $n_start -a $n_epilog -lt $n_free
 '
-
+test_expect_success 'job-manager: epilog works after exception during prolog' '
+	flux jobtap load --remove=all ${PLUGINPATH}/perilog-test.so \
+		prolog-exception=1 &&
+	jobid=$(flux submit hostname) &&
+	flux job attach --wait-event clean -vE $jobid 2>&1 \
+	    | tee perilog-exception-test.out &&
+	n_epilog=$(lineno job.epilog-finish perilog-exception-test.out) &&
+	n_free=$(lineno job.free perilog-exception-test.out) &&
+	test $n_epilog -lt $n_free
+'
 test_expect_success 'job-manager: job.create posts events before validation' '
 	flux jobtap load --remove=all ${PLUGINPATH}/create-event.so &&
 	jobid=$(flux submit hostname) &&


### PR DESCRIPTION
@jameshcorbett reported an issue where an `epilog-start` event was emitted for a job in CLEANUP, but the `free` and `clean` events were still emitted before `epilog-finish`. This only seems to occur if a job enters CLEANUP without ever having started, e.g. when a job exception occurs during the job prolog.

The problem occurs because the `epilog-start` event is still pending in the job manager event queue when the action for CLEANUP runs. Since the job didn't start, and `perilog_active` is still 0, the `free` event is emitted immediately instead of waiting for `epilog-finish`.

This PR simply adds a check for a pending `epilog-finish` event that is enqueued.

A new test is added to replicate the failing case.