### PR TITLE
fix rare `Unable to connect to JOBID` error from `flux alloc --bg`

### DIFF
--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -405,9 +405,6 @@ int main (int argc, char *argv[])
         || init_critical_ranks_attr (ctx.overlay, ctx.attrs) < 0)
         goto cleanup;
 
-    if (ctx.rank == 0 && execute_parental_notifications (&ctx) < 0)
-        goto cleanup;
-
     if (create_runat_phases (&ctx) < 0)
         goto cleanup;
 
@@ -495,6 +492,9 @@ int main (int argc, char *argv[])
         log_err ("load_module connector-local");
         goto cleanup;
     }
+
+    if (ctx.rank == 0 && execute_parental_notifications (&ctx) < 0)
+        goto cleanup;
 
     /* Event loop
      */

--- a/t/issues/t4612-eventlog-overwrite-crash.sh
+++ b/t/issues/t4612-eventlog-overwrite-crash.sh
@@ -2,6 +2,10 @@
 
 waitfile=${SHARNESS_TEST_SRCDIR}/scripts/waitfile.lua
 
+echo pid=$pid
+flux resource list
+flux jobs -a
+
 jobid=$(flux submit --wait-event=start sh -c "echo foo; sleep 300")
 
 kvsdir=$(flux job id --to=kvs $jobid)
@@ -20,4 +24,5 @@ flux kvs get --raw ${kvsdir}.eventlog \
 wait
 
 # if flux broker segfaulted, this won't work
-flux run hostname
+flux cancel $jobid
+flux job status $jobid || true


### PR DESCRIPTION
Problem: The broker posts a job memo containing the instance remote uri too early during startup. This creates a race condition where the job uri is available in the eventlog before the local connector has created the socket, resulting in a rare failure to connect using tools such as `flux alloc --bg`.

Move the function that notifies any parent instance of subinstance particulars (including instance uri) to after the connector is loaded.