### PR TITLE
improve broker debugging on overlay connect failure

### DIFF
--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -1796,6 +1796,7 @@ static bool allow_early_request (const flux_msg_t *msg)
         // let state-machine.get and attr.get work for flux-uptime(1)
         { FLUX_MSGTYPE_REQUEST, FLUX_MATCHTAG_NONE, "state-machine.get" },
         { FLUX_MSGTYPE_REQUEST, FLUX_MATCHTAG_NONE, "attr.get" },
+        { FLUX_MSGTYPE_REQUEST, FLUX_MATCHTAG_NONE, "log.dmesg" },
     };
     for (int i = 0; i < ARRAY_SIZE (match); i++)
         if (flux_msg_cmp (msg, match[i]))

--- a/t/t3302-system-offline.t
+++ b/t/t3302-system-offline.t
@@ -41,4 +41,10 @@ test_expect_success 'flux uptime on rank 2 reports join state' '
 	grep join uptime.out
 '
 
+test_expect_success 'flux dmesg on rank 2 works' '
+	bash -c \
+		"FLUX_URI=$(echo $FLUX_URI | sed s/local-0/local-2/) \
+			flux dmesg" >/dev/null
+'
+
 test_done


### PR DESCRIPTION
Problem: if a broker cannot connect to its upstream peer, `flux dmesg` doesn't work, and if the problem is a misconfigured hostname, nothing is logged anyway.

Add dmesg to the list of services that are available "early" (before upstream connect).

Add a small check on the upstream URI before handing it over to zmq_connect().

If I comment out the upstream peer in /etc/hosts on my test cluster, now I can do this:
```
$ sudo flux dmesg
2023-03-24T22:52:26.438913Z broker.err[7]: getaddrinfo picl2: No address associated with hostname
2023-03-24T22:52:26.459197Z broker.debug[7]: insmod connector-local
2023-03-24T22:52:26.459352Z broker.info[7]: start: none->join 18.249ms
2023-03-24T22:52:26.460967Z connector-local.debug[7]: allow-guest-user=true
2023-03-24T22:52:26.460997Z connector-local.debug[7]: allow-root-owner=true
```
And incidentally if I fix /etc/hosts, the broker is able to connect and continue on without a restart.