### PR TITLE
testsuite: fix test issues under nix

### DIFF
--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -12,6 +12,11 @@ other tests.
 test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
 . `dirname $0`/sharness.sh
 
+# In some scenarios man(1) tests below may fail due to process sandboxing
+# done via seccomp filter (e.g. for nix). Just disable seccomp for man for
+# the duration of this test to avoid these failure
+export MAN_DISABLE_SECCOMP=1
+
 RPC=${FLUX_BUILD_DIR}/t/request/rpc
 startctl=${SHARNESS_TEST_SRCDIR}/scripts/startctl.py
 

--- a/t/t2405-job-exec-sdexec.t
+++ b/t/t2405-job-exec-sdexec.t
@@ -82,8 +82,7 @@ test_expect_success 'job-exec: simple job outputs stdout under systemd' '
 test_expect_success 'job-exec: simple job outputs stderr under systemd' '
         jobid=$(flux submit ${TEST_SDPROCESS_DIR}/test_echo -E boobar) &&
         flux job attach $jobid 2> stderr.out &&
-        echo boobar > stderr.expected &&
-        test_cmp stderr.expected stderr.out
+        grep boobar stderr.out
 '
 test_expect_success 'job-exec: simple job takes stdin under systemd' '
         jobid=$(flux submit ${TEST_SDPROCESS_DIR}/test_echo -O) &&

--- a/t/t2613-job-shell-batch.t
+++ b/t/t2613-job-shell-batch.t
@@ -51,11 +51,14 @@ test_expect_success 'flux-shell: historical batch jobspec still work' '
 	for spec in $SHARNESS_TEST_SRCDIR/batch/jobspec/*.json; do
 		input=$(basename $spec) &&
 		cat $spec |
-		    jq -S ".attributes.system.environment.PATH=\"$PATH\"" \
+		    jq -S ".attributes.system.environment.PATH=\"$PATH\"" |
+		    jq -S ".attributes.system.environment.PYTHONPATH=\"$PYTHONPATH\"" |
+		    jq -S ".attributes.system.environment.HOME=\"$HOME\"" |
+		    jq -S ".attributes.system.cwd=\"$(pwd)\"" \
 		    >$input &&
 		flux job submit --flags=waitable $input
 	done &&
-	flux job attach $(flux job last) &&
+	flux job attach -vEX $(flux job last) &&
 	flux job wait --all --verbose
 '
 test_done


### PR DESCRIPTION
This PR fixes a few spurious errors in the testsuite caused when running the nix package manager. These are mostly fixes that would have popped up elsewhere anyway.

This does not go as far as replacing every use of absolute paths to commands (`/bin/sh`, `/bin/bash`) yet, but this allows most tests to pass under the flake shared by @trws in #4998.

Some systemd tests still fail for unknown reasons. It is best to disable the tests that use systemd when running under nix by unsetting `XDG_RUNTIME_DIR` during the testsuite, e.g.
```
XDG_RUNTIME_DIR= make -j 12 check
```