### PR TITLE
testsuite: increase test timeouts

### DIFF
--- a/t/t2701-mini-batch.t
+++ b/t/t2701-mini-batch.t
@@ -101,7 +101,7 @@ test_expect_success MULTICORE 'flux-mini batch: exclusive flag worked' '
 
 test_expect_success 'flux-mini batch: --output=kvs directs output to kvs' '
 	id=$(flux mini batch -n1 --flags=waitable --output=kvs batch-script.sh) &&
-	run_timeout 60 flux job attach $id > kvs-output.log 2>&1 &&
+	run_timeout 180 flux job attach $id > kvs-output.log 2>&1 &&
 	test_debug "cat kvs-output.log" &&
 	grep "size=1 nodes=1" kvs-output.log
 '
@@ -110,10 +110,10 @@ test_expect_success 'flux-mini batch: --broker-opts works' '
 	     --broker-opts=-v batch-script.sh) &&
 	id2=$(flux mini batch -n1 --flags=waitable \
 	     --broker-opts=-v,-v batch-script.sh) &&
-	run_timeout 60 flux job wait $id &&
+	run_timeout 180 flux job wait $id &&
 	test_debug "cat flux-${id}.out" &&
 	grep "boot: rank=0 size=1" flux-${id}.out &&
-	run_timeout 60 flux job wait $id2 &&
+	run_timeout 180 flux job wait $id2 &&
 	grep "boot: rank=0 size=1" flux-${id2}.out &&
 	grep "entering event loop" flux-${id2}.out
 '
@@ -173,19 +173,19 @@ test_expect_success 'flux mini batch: MPI env vars are not set in batch script' 
 test_expect_success 'flux mini batch: --dump works' '
 	id=$(flux mini batch -N1 --dump \
 		--flags=waitable --wrap true) &&
-	run_timeout 60 flux job wait $id &&
+	run_timeout 180 flux job wait $id &&
 	tar tvf flux-${id}-dump.tgz
 '
 test_expect_success 'flux mini batch: --dump=FILE works' '
 	id=$(flux mini batch -N1 --dump=testdump.tgz \
 		--flags=waitable --wrap true) &&
-	run_timeout 60 flux job wait $id &&
+	run_timeout 180 flux job wait $id &&
 	tar tvf testdump.tgz
 '
 test_expect_success 'flux mini batch: --dump=FILE works with mustache' '
 	id=$(flux mini batch -N1 --dump=testdump-{{id}}.tgz \
 		--flags=waitable --wrap true) &&
-	run_timeout 60 flux job wait $id &&
+	run_timeout 180 flux job wait $id &&
 	tar tvf testdump-${id}.tgz
 '
 test_expect_success 'flux mini batch: supports directives in script' '

--- a/t/t2702-mini-alloc.t
+++ b/t/t2702-mini-alloc.t
@@ -73,7 +73,7 @@ test_expect_success 'flux-mini alloc --bg option works' '
 '
 test_expect_success 'flux-mini alloc --bg option works with a command' '
 	jobid=$(flux mini alloc -n1 -v --bg /bin/true) &&
-	flux job wait-event -t15 -v $jobid finish &&
+	flux job wait-event -t180 -v $jobid finish &&
 	flux job attach $jobid
 '
 test_expect_success 'flux-mini alloc --bg fails if broker fails' '
@@ -109,9 +109,9 @@ test_expect_success NO_CHAIN_LINT 'flux-mini alloc --bg can be interrupted' '
 	flux queue stop &&
 	test_when_finished "flux queue start" &&
 	run_mini_bg &&
-	$waitfile -t 20 -v -p waiting sigint.log &&
+	$waitfile -t 180 -v -p waiting sigint.log &&
 	kill -INT $(cat sigint.pid) &&
-	$waitfile -t 20 -v -p Interrupt sigint.log &&
+	$waitfile -t 180 -v -p Interrupt sigint.log &&
 	wait $pid
 '
 test_expect_success NO_CHAIN_LINT 'flux-mini alloc --bg errors when job is canceled' '
@@ -119,7 +119,7 @@ test_expect_success NO_CHAIN_LINT 'flux-mini alloc --bg errors when job is cance
 	test_when_finished "flux queue start" &&
 	flux mini alloc --bg -n1 -v >canceled.log 2>&1 &
 	pid=$! &&
-	$waitfile -t 20 -v -p waiting canceled.log &&
+	$waitfile -t 180 -v -p waiting canceled.log &&
 	flux cancel --all &&
 	cat canceled.log &&
 	test_must_fail wait $pid &&

--- a/t/t2714-python-cli-batch.t
+++ b/t/t2714-python-cli-batch.t
@@ -101,7 +101,7 @@ test_expect_success MULTICORE 'flux batch: exclusive flag worked' '
 
 test_expect_success 'flux batch: --output=kvs directs output to kvs' '
 	id=$(flux batch -n1 --flags=waitable --output=kvs batch-script.sh) &&
-	run_timeout 60 flux job attach $id > kvs-output.log 2>&1 &&
+	run_timeout 180 flux job attach $id > kvs-output.log 2>&1 &&
 	test_debug "cat kvs-output.log" &&
 	grep "size=1 nodes=1" kvs-output.log
 '
@@ -110,10 +110,10 @@ test_expect_success 'flux batch: --broker-opts works' '
 	     --broker-opts=-v batch-script.sh) &&
 	id2=$(flux batch -n1 --flags=waitable \
 	     --broker-opts=-v,-v batch-script.sh) &&
-	run_timeout 60 flux job wait $id &&
+	run_timeout 180 flux job wait $id &&
 	test_debug "cat flux-${id}.out" &&
 	grep "boot: rank=0 size=1" flux-${id}.out &&
-	run_timeout 60 flux job wait $id2 &&
+	run_timeout 180 flux job wait $id2 &&
 	grep "boot: rank=0 size=1" flux-${id2}.out &&
 	grep "entering event loop" flux-${id2}.out
 '
@@ -173,19 +173,19 @@ test_expect_success 'flux batch: MPI env vars are not set in batch script' '
 test_expect_success 'flux batch: --dump works' '
 	id=$(flux batch -N1 --dump \
 		--flags=waitable --wrap true) &&
-	run_timeout 60 flux job wait $id &&
+	run_timeout 180 flux job wait $id &&
 	tar tvf flux-${id}-dump.tgz
 '
 test_expect_success 'flux batch: --dump=FILE works' '
 	id=$(flux batch -N1 --dump=testdump.tgz \
 		--flags=waitable --wrap true) &&
-	run_timeout 60 flux job wait $id &&
+	run_timeout 180 flux job wait $id &&
 	tar tvf testdump.tgz
 '
 test_expect_success 'flux batch: --dump=FILE works with mustache' '
 	id=$(flux batch -N1 --dump=testdump-{{id}}.tgz \
 		--flags=waitable --wrap true) &&
-	run_timeout 60 flux job wait $id &&
+	run_timeout 180 flux job wait $id &&
 	tar tvf testdump-${id}.tgz
 '
 test_expect_success 'flux batch: supports directives in script' '

--- a/t/t2715-python-cli-cancel.t
+++ b/t/t2715-python-cli-cancel.t
@@ -81,7 +81,7 @@ test_expect_success 'flux cancel --all works with message' '
 	grep "cancel all" exception.out
 '
 test_expect_success 'the queue is empty' '
-	run_timeout 60 flux queue drain
+	run_timeout 180 flux queue drain
 '
 test_expect_success 'flux cancel --all --user all fails for guest' '
 	id=$(($(id -u)+1)) &&

--- a/t/t2802-uri-cmd.t
+++ b/t/t2802-uri-cmd.t
@@ -86,7 +86,7 @@ test_expect_success 'start a small hierarchy of Flux instances' '
 	EOF
 	chmod +x batch.sh &&
 	jobid=$(flux batch -n1 batch.sh) &&
-	flux job wait-event -T offset -vt 30 -c 2 $jobid memo
+	flux job wait-event -T offset -vt 180 -c 2 $jobid memo
 '
 test_expect_success 'flux uri resolves jobid argument' '
 	flux proxy $(flux uri --local $jobid) flux getattr jobid >jobid1.out &&


### PR DESCRIPTION
Not sure what happened in the last month but nice chunk of tests were failing / timing out for me when doing big parallel `make -j16 check` runs.

I'm sure it has nothing to do with the tests I updated here specifically, but its whatever other tests are running in parallel and eating up tons of CPU.  Perhaps some new tests are really CPU heavy and thus hitting these specifically.  The timeout of 180 was picked somewhat randomly based on surrounding tests.

If this is approved, I'll actually wait a few days to hit MWP.  See if any more pop up.

Edit: maybe the t4000 tests now running in parallel is causing this?  It launches up a flux instance of two nodes within it, and each node can have many CPUs, thus running many t4000 tests in parallel?

