### PR TITLE
cli: adjust description of `--begin-time` submission option

### DIFF
--- a/doc/man1/common/submit-other-options.rst
+++ b/doc/man1/common/submit-other-options.rst
@@ -34,10 +34,10 @@ OTHER OPTIONS
    character, then VAL is interpreted as a file, which must be valid JSON,
    to use as the attribute value.
 
-**--begin-time=DATETIME**
+**--begin-time=+FSD|DATETIME**
    Convenience option for setting a ``begin-time`` dependency for a job.
    The job is guaranteed to start after the specified date and time.
-   If *DATETIME* begins with a ``+`` character, then the remainder is
+   If argument begins with a ``+`` character, then the remainder is
    considered to be an offset in Flux standard duration (RFC 23), otherwise,
    any datetime expression accepted by the Python 
    `parsedatetime <https://github.com/bear/parsedatetime>`_ module

--- a/src/bindings/python/flux/cli/base.py
+++ b/src/bindings/python/flux/cli/base.py
@@ -623,8 +623,9 @@ class MiniCmd:
         parser.add_argument(
             "--begin-time",
             action=BeginTimeAction,
-            metavar="TIME",
-            help="Set minimum begin time for job",
+            metavar="+FSD|TIME",
+            help="Set minimum start time as offset in FSD (e.g. +1h) or "
+            + 'an absolute TIME (e.g. "3pm") for job',
         )
         parser.add_argument(
             "--env",


### PR DESCRIPTION
As suggested by @v and @ryanday36, the documentation of the `--begin-time` option doesn't make it clear that the argument can be either a relative offset or an absolute time. This PR adjusts both the help output and manual page to hopefully make that more clear.