### PR TITLE
doc: document job environment variables

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -334,6 +334,7 @@ $(RST_FILES): \
 	man1/common/submit-constraints.rst \
 	man1/common/submit-dependencies.rst \
 	man1/common/submit-environment.rst \
+	man1/common/submit-job-environment-variables.rst \
 	man1/common/submit-process-resource-limits.rst \
 	man1/common/submit-exit-status.rst \
 	man1/common/submit-other-options.rst \
@@ -396,6 +397,7 @@ EXTRA_DIST = \
 	man1/common/submit-constraints.rst \
 	man1/common/submit-dependencies.rst \
 	man1/common/submit-environment.rst \
+	man1/common/submit-job-environment-variables.rst \
 	man1/common/submit-process-resource-limits.rst \
 	man1/common/submit-exit-status.rst \
 	man1/common/submit-other-options.rst \

--- a/doc/man1/common/submit-job-environment-variables.rst
+++ b/doc/man1/common/submit-job-environment-variables.rst
@@ -1,0 +1,29 @@
+JOB ENVIRONMENT VARIABLES
+=========================
+
+Flux creates several environment variables for every job task.  They are as follows:
+
+**FLUX_JOB_ID**
+    The jobid for this job
+
+**FLUX_URI**
+    The URI of the enclosing Flux instance
+
+**FLUX_JOB_TMPDIR**
+    Path to temporary directory created for job
+
+**FLUX_TASK_LOCAL_ID**
+    The task id local to the node
+
+**FLUX_TASK_RANK**
+    The global rank for this task
+
+**FLUX_JOB_NNODES**
+    The total number of nodes in the job
+
+**FLUX_JOB_SIZE**
+    The count of job shells in the job, typical the same value as FLUX_JOB_NNODES
+
+**FLUX_KVS_NAMESPACE**
+    The identifier of the KVS guest namespace of the job. This redirects KVS command and
+    API calls to the job guest namespace instead of the root namespace.

--- a/doc/man1/flux-run.rst
+++ b/doc/man1/flux-run.rst
@@ -35,6 +35,8 @@ The available OPTIONS are detailed below.
 
 .. include:: common/submit-process-resource-limits.rst
 
+.. include:: common/submit-job-environment-variables.rst
+
 .. include:: common/submit-exit-status.rst
 
 .. include:: common/submit-other-options.rst

--- a/doc/man1/flux-submit.rst
+++ b/doc/man1/flux-submit.rst
@@ -35,6 +35,8 @@ The available OPTIONS are detailed below.
 
 .. include:: common/submit-process-resource-limits.rst
 
+.. include:: common/submit-job-environment-variables.rst
+
 .. include:: common/submit-exit-status.rst
 
 .. include:: common/submit-other-options.rst


### PR DESCRIPTION
Problem: The environment variables that Flux creates when a job is run is not documented.

Add documentation into flux-run(1) and flux-submit(1).

Fixes #4568

----

I largely cut and pasted the text that @grondo had written up in the issue.  Only debate might be where I put this in the manpages.  Could be higher/lower than where I put it?
