### PR TITLE
python: recognize local timezone epoch adjustment

### DIFF
--- a/doc/man1/flux-jobs.rst
+++ b/doc/man1/flux-jobs.rst
@@ -195,7 +195,7 @@ the following conversion flags are supported by *flux-jobs*:
    convert a timestamp to a Python datetime object. This allows datetime
    specific format to be used, e.g. *{t_inactive!d:%H:%M:%S}*. Additionally,
    width and alignment can be specified after the time format by using
-   two colons (``::``), e.g. *{t_inactive:%H:%M:%S::>20}*. Defaults to
+   two colons (``::``), e.g. *{t_inactive!d:%H:%M:%S::>20}*. Defaults to
    datetime of epoch if timestamp field does not exist.
 
 **!F**

--- a/doc/man1/flux-jobs.rst
+++ b/doc/man1/flux-jobs.rst
@@ -174,7 +174,7 @@ As a reminder to the reader, some shells will interpret braces
 (``{`` and ``}``) in the format string.  They may need to be quoted.
 
 The special presentation type *h* can be used to convert an empty
-string, "0s", "0.0", or "0:00:00" to a hyphen. For example, normally
+string, "0s", "0.0", "0:00:00", or epoch time to a hyphen. For example, normally
 "{nodelist}" would output an empty string if the job has not yet run.
 By specifying, "{nodelist:h}", a hyphen would be presented instead.
 

--- a/src/bindings/python/flux/util.py
+++ b/src/bindings/python/flux/util.py
@@ -422,7 +422,8 @@ class UtilFormatter(Formatter):
             spec = spec[:-1]
 
         if spec.endswith("h"):
-            basecases = ("", "0s", "0.0", "0:00:00", "1970-01-01T00:00:00")
+            localepoch = datetime.fromtimestamp(0.0).strftime("%FT%T")
+            basecases = ("", "0s", "0.0", "0:00:00", "1970-01-01T00:00:00", localepoch)
             value = "-" if str(value) in basecases else str(value)
             spec = spec[:-1] + "s"
         retval = super().format_field(value, spec)


### PR DESCRIPTION
Problem: The "h" output presentation type will output a hyphen (-) if a timestamp field is equal to the epoch of 1970-01-01T00:00:00. However, this does not account for any local timezone offsets that may occur when outputting the epoch time.

Solution: In addition to checking 1970-01-01T00:00:00, get the local epoch time and add it to the list of potential "zero" things that
can be converted to a hyphen.