### PR TITLE
Support environment variable to override default output formats

### DIFF
--- a/doc/man1/flux-jobs.rst
+++ b/doc/man1/flux-jobs.rst
@@ -64,10 +64,11 @@ OPTIONS
 **-o, --format**\ *=NAME|FORMAT*
    Specify a named output format *NAME* or a format string using Python's
    format syntax. See OUTPUT FORMAT below for field names. Named formats
-   may be listed via ``--format=help``. Additional named formats may be
-   registered with ``flux jobs`` via configuration. See the CONFIGURATION
-   section for more details. A configuration snippet for an existing
-   named format may be generated with ``--format=get-config=NAME``.
+   may be listed via ``--format=help``.  An alternate default format can be set
+   via the FLUX_JOBS_FORMAT_DEFAULT environment variable.  Additional named
+   formats may be registered with ``flux jobs`` via configuration. See the
+   CONFIGURATION section for more details. A configuration snippet for an
+   existing named format may be generated with ``--format=get-config=NAME``.
 
 **--color**\ *[=WHEN]*
    Control output coloring.  The optional argument *WHEN* can be

--- a/doc/man1/flux-pgrep.rst
+++ b/doc/man1/flux-pgrep.rst
@@ -61,12 +61,13 @@ OPTIONS
 
 **-o, --format**\ *=NAME|FORMAT*
    Specify a named output format *NAME* or a format string using Python's
-   format syntax. For full documentation of this option, including supported
-   field names and format configuration options, see :man1:flux-jobs. This
-   command shares configured named formats with *flux-jobs* by reading
-   *flux-jobs* configuration files. Supported builtin named formats include
-   *default*, *full*, *long*, and *deps*. The default format emits the matched
-   jobids only. (pgrep only)
+   format syntax.  An alternate default format can be set via the
+   FLUX_PGREP_FORMAT_DEFAULT environment variable.  For full documentation of
+   this option, including supported field names and format configuration
+   options, see :man1:flux-jobs. This command shares configured named formats
+   with *flux-jobs* by reading *flux-jobs* configuration files. Supported
+   builtin named formats include *default*, *full*, *long*, and *deps*. The
+   default format emits the matched jobids only. (pgrep only)
 
 **-n, --no-header**
    Suppress printing of the header line. (pgrep only)

--- a/doc/man1/flux-queue.rst
+++ b/doc/man1/flux-queue.rst
@@ -116,10 +116,11 @@ OUTPUT FORMAT
 
 The *--format* option can be used to specify an output format using Python's
 string format syntax or a defined format by name. For a list of built-in and
-configured formats use ``-o help``.  A configuration snippet for an existing
-named format may be generated with ``--format=get-config=NAME``.  See
-:man1:`flux-jobs` *OUTPUT FORMAT* section for a detailed description of this
-syntax.
+configured formats use ``-o help``.  An alternate default format can be set via
+the FLUX_QUEUE_LIST_FORMAT_DEFAULT environment variable.  A configuration
+snippet for an existing named format may be generated with
+``--format=get-config=NAME``.  See :man1:`flux-jobs` *OUTPUT FORMAT* section for
+a detailed description of this syntax.
 
 The following field names can be specified:
 

--- a/doc/man1/flux-resource.rst
+++ b/doc/man1/flux-resource.rst
@@ -128,10 +128,13 @@ OUTPUT FORMAT
 
 The *--format* option can be used to specify an output format using Python's
 string format syntax or a defined format by name. For a list of built-in and
-configured formats use ``-o help``.  A configuration snippet for an existing
-named format may be generated with ``--format=get-config=NAME``.  See
-:man1:`flux-jobs` *OUTPUT FORMAT* section for a detailed description of this
-syntax.
+configured formats use ``-o help``.  An alternate default format can be set via
+the FLUX_RESOURCE_STATUS_FORMAT_DEFAULT, FLUX_RESOURCE_DRAIN_FORMAT_DEFAULT, and
+FLUX_RESOURCE_LIST_FORMAT_DEFAULT environment variables (for ``flux resource
+status``, ``flux resource drain``, and ``flux resource list`` respectively).  A
+configuration snippet for an existing named format may be generated with
+``--format=get-config=NAME``.  See :man1:`flux-jobs` *OUTPUT FORMAT* section for
+a detailed description of this syntax.
 
 Resources are combined into a single line of output when possible depending on
 the supplied output format.  Resource counts are not included in the

--- a/src/cmd/flux-pgrep.py
+++ b/src/cmd/flux-pgrep.py
@@ -61,7 +61,9 @@ class FluxPgrepConfig(UtilConfig):
 
     def __init__(self):
         initial_dict = {"formats": dict(self.builtin_formats)}
-        super().__init__(name="flux-jobs", initial_dict=initial_dict)
+        super().__init__(
+            name="flux-jobs", toolname="flux-pgrep", initial_dict=initial_dict
+        )
 
     def validate(self, path, config):
         """Validate a loaded flux-pgrep config file as dictionary"""
@@ -70,6 +72,9 @@ class FluxPgrepConfig(UtilConfig):
                 self.validate_formats(path, value)
             else:
                 raise ValueError(f"{path}: invalid key {key}")
+
+    def get_default(self):
+        return self.builtin_formats["default"]["format"]
 
 
 class JobPgrep:
@@ -275,7 +280,12 @@ def main():
 
     sformatter = JobInfoFormat(formatter.filter_empty(jobs))
 
-    if args.format == "default":
+    # "default" can be overridden by environment variable, so check if
+    # it's different than the builtin default
+    if (
+        args.format == "default"
+        and FluxPgrepConfig().get_default() == sformatter.get_format(orig=True)
+    ):
         args.no_header = True
 
     sformatter.print_items(jobs, no_header=args.no_header)

--- a/t/sharness.d/01-setup.sh
+++ b/t/sharness.d/01-setup.sh
@@ -10,6 +10,14 @@ unset FLUX_MODULE_PATH
 unset FLUX_PMI_CLIENT_SEARCHPATH
 unset FLUX_PMI_CLIENT_METHODS
 
+# Unset any user defined output defaults, since that may mess up tests
+unset FLUX_JOBS_FORMAT_DEFAULT
+unset FLUX_RESOURCE_LIST_FORMAT_DEFAULT
+unset FLUX_RESOURCE_DRAIN_FORMAT_DEFAULT
+unset FLUX_RESOURCE_STATUS_FORMAT_DEFAULT
+unset FLUX_QUEUE_LIST_FORMAT_DEFAULT
+unset FLUX_PGREP_FORMAT_DEFAULT
+
 #
 #  FLUX_BUILD_DIR and FLUX_SOURCE_DIR are set to build and source paths
 #  (based on current directory)

--- a/t/t2241-queue-cmd-list.t
+++ b/t/t2241-queue-cmd-list.t
@@ -16,6 +16,13 @@ test_expect_success 'flux-queue: default lists expected fields' '
 	grep NGPUS default.out
 '
 
+test_expect_success 'flux-queue: FLUX_QUEUE_LIST_FORMAT_DEFAULT works' '
+	FLUX_QUEUE_LIST_FORMAT_DEFAULT="{limits.min.nnodes} {limits.max.ngpus}" \
+		flux queue list > default_override.out &&
+	grep MINNODES default_override.out &&
+	grep MAXGPUS default_override.out
+'
+
 test_expect_success 'flux-queue: --no-header works' '
 	flux queue list --no-header > default_no_header.out &&
 	test_must_fail grep DEFAULTTIME default_no_header.out &&

--- a/t/t2311-resource-drain.t
+++ b/t/t2311-resource-drain.t
@@ -28,6 +28,18 @@ test_expect_success 'wait for monitor to declare all ranks are up' '
 	waitdown 0
 '
 
+test_expect_success 'flux resource drain: default lists some expected fields' '
+	flux resource drain > default.out &&
+	grep STATE default.out &&
+	grep REASON default.out
+'
+
+test_expect_success 'flux resource drain: --no-header works' '
+	flux resource drain --no-header > default_no_header.out &&
+	test_must_fail grep STATE default_no_header.out &&
+	test_must_fail grep REASON default_no_header.out
+'
+
 test_expect_success 'drain works with no reason' '
 	flux resource drain 1 &&
 	test $(flux resource list -n -s down -o {nnodes}) -eq 1

--- a/t/t2311-resource-drain.t
+++ b/t/t2311-resource-drain.t
@@ -34,6 +34,18 @@ test_expect_success 'flux resource drain: default lists some expected fields' '
 	grep REASON default.out
 '
 
+test_expect_success 'flux resource drain: FLUX_RESOURCE_DRAIN_FORMAT_DEFAULT works' '
+	FLUX_RESOURCE_DRAIN_FORMAT_DEFAULT="{nodelist} {nodelist}" \
+		flux resource drain > default_override.out &&
+	grep "NODELIST NODELIST" default_override.out
+'
+
+test_expect_success 'flux resource drain: FLUX_RESOURCE_DRAIN_FORMAT_DEFAULT works w/ named format' '
+	FLUX_RESOURCE_DRAIN_FORMAT_DEFAULT=long \
+		flux resource drain > default_override_named.out &&
+	grep "RANKS" default_override_named.out
+'
+
 test_expect_success 'flux resource drain: --no-header works' '
 	flux resource drain --no-header > default_no_header.out &&
 	test_must_fail grep STATE default_no_header.out &&

--- a/t/t2350-resource-list.t
+++ b/t/t2350-resource-list.t
@@ -15,6 +15,18 @@ test_expect_success 'flux resource list: default lists some expected fields' '
 	grep NCORES default.out
 '
 
+test_expect_success 'flux resource list: FLUX_RESOURCE_LIST_FORMAT_DEFAULT works' '
+	FLUX_RESOURCE_LIST_FORMAT_DEFAULT="{nodelist} {nodelist}" \
+		flux resource list > default_override.out &&
+	grep "NODELIST NODELIST" default_override.out
+'
+
+test_expect_success 'flux resource list: FLUX_RESOURCE_LIST_FORMAT_DEFAULT works w/ named format' '
+	FLUX_RESOURCE_LIST_FORMAT_DEFAULT=rlist \
+		flux resource list > default_override_named.out &&
+	grep -w "LIST" default_override_named.out
+'
+
 test_expect_success 'flux resource list: --no-header works' '
 	flux resource list --no-header > default_no_header.out &&
 	test_must_fail grep STATE default_no_header.out &&

--- a/t/t2350-resource-list.t
+++ b/t/t2350-resource-list.t
@@ -8,6 +8,20 @@ test -n "$FLUX_TESTS_LOGFILE" && set -- "$@" --logfile
 
 test_under_flux 4 full
 
+test_expect_success 'flux resource list: default lists some expected fields' '
+	flux resource list > default.out &&
+	grep STATE default.out &&
+	grep NNODES default.out &&
+	grep NCORES default.out
+'
+
+test_expect_success 'flux resource list: --no-header works' '
+	flux resource list --no-header > default_no_header.out &&
+	test_must_fail grep STATE default_no_header.out &&
+	test_must_fail grep NNODES default_no_header.out &&
+	test_must_fail grep NCORES default_no_header.out
+'
+
 # Use a static format to avoid breaking output if default flux-resource list
 #  format ever changes
 FORMAT="{state:>10} {properties:<10} {nnodes:>6} {ncores:>8} {ngpus:>8}"

--- a/t/t2351-resource-status-input.t
+++ b/t/t2351-resource-status-input.t
@@ -42,6 +42,18 @@ test_expect_success 'flux-resource status: header included with all formats' '
         test_cmp headers.expected headers.output
 '
 
+test_expect_success 'flux resource status: FLUX_RESOURCE_STATUS_FORMAT_DEFAULT works' '
+	FLUX_RESOURCE_STATUS_FORMAT_DEFAULT="{nodelist} {nodelist}" \
+		flux resource status --from-stdin > default_override.out < /dev/null &&
+	grep "NODELIST NODELIST" default_override.out
+'
+
+test_expect_success 'flux resource status: FLUX_RESOURCE_STATUS_FORMAT_DEFAULT works w/ named format' '
+	FLUX_RESOURCE_STATUS_FORMAT_DEFAULT=long \
+		flux resource status --from-stdin > default_override_named.out < /dev/null &&
+	grep "REASON" default_override_named.out
+'
+
 test_expect_success 'flux-resource status: --no-header works' '
 	INPUT=${INPUTDIR}/example.json &&
 	name=no-header &&

--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -1004,6 +1004,16 @@ test_expect_success 'flux-jobs emits empty string for special case t_estimate' '
 	test_cmp t_estimate_annotations.out t_estimate_annotations.exp
 '
 
+test_expect_success 'FLUX_JOBS_FORMAT_DEFAULT works' '
+	FLUX_JOBS_FORMAT_DEFAULT="{id} {id}" flux jobs > env_format.out &&
+	grep "JOBID JOBID" env_format.out
+'
+
+test_expect_success 'FLUX_JOBS_FORMAT_DEFAULT works with named format' '
+	FLUX_JOBS_FORMAT_DEFAULT=long flux jobs > env_format2.out &&
+	grep "STATUS" env_format2.out
+'
+
 #
 # format header tests.
 #

--- a/t/t2811-flux-pgrep.t
+++ b/t/t2811-flux-pgrep.t
@@ -18,7 +18,7 @@ test_expect_success 'flux-pgrep returns 1 when no jobs match' '
 	test_expect_code 1 flux pgrep foo
 '
 test_expect_success 'flux-pgrep works for job nanes' '
-	flux bulksubmit --job-name={} sleep 60 \
+	flux bulksubmit --job-name={} sleep 300 \
 		::: testA testB foo &&
 	flux pgrep ^test > pgrep.out &&
 	test $(wc -l <pgrep.out) -eq 2
@@ -35,6 +35,17 @@ test_expect_success 'flux-pgrep --filter works' '
 	flux pgrep --filter=sched,run . >pgrep-filtered.out &&
 	test_debug "cat pgrep-filtered.out" &&
 	test $(wc -l <pgrep-filtered.out) -eq 3
+'
+test_expect_success 'flux-pgrep default override works' '
+	FLUX_PGREP_FORMAT_DEFAULT="{id} {id}" flux pgrep -a . >default_override.out &&
+	test_debug "cat default_override.out" &&
+	grep "JOBID JOBID" default_override.out
+'
+test_expect_success 'flux-pgrep default override w/ named format works' '
+	FLUX_PGREP_FORMAT_DEFAULT=full flux pgrep -a . >default_override_named.out &&
+	test_debug "cat default_override_named.out" &&
+	grep "TIME" default_override_named.out &&
+	grep "INFO" default_override_named.out
 '
 test_expect_success 'flux-pkill works' '
 	flux pkill ^test &&


### PR DESCRIPTION
Per #4839.  Several pros and cons to approach, but I think a relatively safe "net win".
