### PR TITLE
flux-top: fix queue specific output display

### DIFF
--- a/src/cmd/top/joblist_pane.c
+++ b/src/cmd/top/joblist_pane.c
@@ -369,7 +369,7 @@ void joblist_pane_set_current (struct joblist_pane *joblist, bool next)
         current = lookup_jobid_index (joblist->jobs, joblist->current);
 
     njobs = json_array_size (joblist->jobs);
-    if (next && current == njobs -1)
+    if (next && current == njobs - 1)
         current = -1;
     else if (!next && current <= 0)
         current = njobs;

--- a/src/cmd/top/joblist_pane.c
+++ b/src/cmd/top/joblist_pane.c
@@ -357,7 +357,7 @@ void joblist_pane_refresh (struct joblist_pane *joblist)
 
 void joblist_pane_set_current (struct joblist_pane *joblist, bool next)
 {
-    int current = -1;;
+    int current = -1;
     json_t *job;
     flux_jobid_t id = FLUX_JOBID_ANY;
     int njobs;

--- a/src/cmd/top/joblist_pane.c
+++ b/src/cmd/top/joblist_pane.c
@@ -91,6 +91,7 @@ void joblist_pane_draw (struct joblist_pane *joblist)
     json_t *job;
     int queue_width = 0;
     int name_width;
+    int job_output_count = 0;
 
     werase (joblist->win);
     wattron (joblist->win, A_REVERSE);
@@ -166,7 +167,7 @@ void joblist_pane_draw (struct joblist_pane *joblist)
             wattron (joblist->win, COLOR_PAIR(TOP_COLOR_BLUE) | A_BOLD);
         if (joblist->show_queue) {
             mvwprintw (joblist->win,
-                       1 + index,
+                       1 + job_output_count,
                        0,
                         "%13.13s %8.8s %8.8s %2.2s %6d %6d %7.7s %-*.*s",
                        idstr,
@@ -193,7 +194,7 @@ void joblist_pane_draw (struct joblist_pane *joblist)
         }
         else {
             mvwprintw (joblist->win,
-                       1 + index,
+                       1 + job_output_count,
                        0,
                         "%13.13s %8.8s %2.2s %6d %6d %7.7s %-*.*s",
                        idstr,
@@ -216,6 +217,7 @@ void joblist_pane_draw (struct joblist_pane *joblist)
                          run,
                          name);
         }
+        job_output_count++;
         wattroff (joblist->win, A_REVERSE);
         wattroff (joblist->win, COLOR_PAIR(TOP_COLOR_BLUE) | A_BOLD);
     }

--- a/src/cmd/top/joblist_pane.c
+++ b/src/cmd/top/joblist_pane.c
@@ -357,7 +357,7 @@ void joblist_pane_refresh (struct joblist_pane *joblist)
 
 void joblist_pane_set_current (struct joblist_pane *joblist, bool next)
 {
-    int current = -1;
+    int index = -1;
     json_t *job;
     flux_jobid_t id = FLUX_JOBID_ANY;
     int njobs;
@@ -366,16 +366,16 @@ void joblist_pane_set_current (struct joblist_pane *joblist, bool next)
         return;
 
     if (joblist->current != FLUX_JOBID_ANY)
-        current = lookup_jobid_index (joblist->jobs, joblist->current);
+        index = lookup_jobid_index (joblist->jobs, joblist->current);
 
     njobs = json_array_size (joblist->jobs);
-    if (next && current == njobs - 1)
-        current = -1;
-    else if (!next && current <= 0)
-        current = njobs;
+    if (next && index == njobs - 1)
+        index = -1;
+    else if (!next && index <= 0)
+        index = njobs;
 
     if (!(job = json_array_get (joblist->jobs,
-                                next ? current + 1 : current - 1)))
+                                next ? index + 1 : index - 1)))
         return;
     if (job && json_unpack (job, "{s:I}", "id", &id) < 0)
         return;

--- a/t/t2801-top-cmd.t
+++ b/t/t2801-top-cmd.t
@@ -152,6 +152,13 @@ test_expect_success NO_CHAIN_LINT 'flux-top quits on q keypress' '
 	kill -USR1 $pid &&
 	wait $pid
 '
+# there are two jobs running, the first (listed higher) is the
+# non-batch job, the second (listed lower) is the batch job.  So we're
+# moving down three times (highlight first job, highlight second job,
+# cycle back to first job), moving up (cycle back to second job), then
+# hitting enter.
+#
+# we then hit quit twice to exit
 test_expect_success NO_CHAIN_LINT 'flux-top can call itself recursively' '
 	SHELL=/bin/sh &&
 	flux jobs &&

--- a/t/t2801-top-cmd.t
+++ b/t/t2801-top-cmd.t
@@ -176,6 +176,8 @@ test_expect_success NO_CHAIN_LINT 'flux-top can call itself recursively' '
 	$runpty -o recurse.log --input=recurse.in flux top &&
 	grep -q $(echo $(cat expected.id) | sed "s/ƒ//") recurse.log
 '
+# note that FLUX_URI_RESOLVE_LOCAL=t is intentionally not set on
+# the runpty line below, as we're using a fake ssh
 test_expect_success NO_CHAIN_LINT 'flux-top does not exit on recursive failure' '
 	cat <<-EOF1 >ssh-fail &&
 	#!/bin/sh
@@ -199,6 +201,7 @@ test_expect_success NO_CHAIN_LINT 'flux-top does not exit on recursive failure' 
 	FLUX_SSH=$(pwd)/ssh-fail \
 	    $runpty -f asciicast -o recurse-fail.log \
 	        --input=recurse-fail.in flux top &&
+	export FLUX_URI_RESOLVE_LOCAL=t
 	grep -qi "error connecting to Flux" recurse-fail.log
 '
 test_expect_success 'cleanup running jobs' '


### PR DESCRIPTION
Per #5021, the listing of jobs when filtered by specific queue did not display correctly because job indexing was not done correctly.
