### PR TITLE
flux-ping: output header before output of main ping output

### DIFF
--- a/src/cmd/flux-ping.c
+++ b/src/cmd/flux-ping.c
@@ -111,12 +111,12 @@ void ping_continuation (flux_future_t *f, void *arg)
     int seq;
     struct ping_data *pdata = flux_future_aux_get (f, "ping");
     tstat_t *tstat = pdata->tstat;
-    uint32_t rolemask, userid;
+    uint32_t rolemask, userid, rank;
     char ubuf[32];
     char rbuf[32];
 
     if (flux_rpc_get_unpack (f,
-                             "{ s:i s:I s:I s:s s:s s:i s:i !}",
+                             "{ s:i s:I s:I s:s s:s s:i s:i s:i !}",
                              "seq",
                              &seq,
                              "time.tv_sec",
@@ -130,7 +130,9 @@ void ping_continuation (flux_future_t *f, void *arg)
                              "userid",
                              &userid,
                              "rolemask",
-                             &rolemask) < 0)
+                             &rolemask,
+                             "rank",
+                             &rank) < 0)
         log_err_exit ("%s%s",
                       rank_bang_str (ctx->nodeid, rbuf, sizeof (rbuf)),
                       ctx->topic);
@@ -152,7 +154,7 @@ void ping_continuation (flux_future_t *f, void *arg)
     pdata->rpc_count++;
 
     printf ("%s%s pad=%zu%s seq=%d time=%0.3f ms (%s)\n",
-            rank_bang_str (ctx->nodeid, rbuf, sizeof (rbuf)),
+            rank_bang_str (rank, rbuf, sizeof (rbuf)),
             ctx->topic,
             strlen (ctx->pad),
             ctx->userid_flag

--- a/src/cmd/flux-ping.c
+++ b/src/cmd/flux-ping.c
@@ -264,8 +264,7 @@ void parse_target (struct ping_ctx *ctx, const char *target)
     /* TARGET only specifies nodeid, assume service is "broker" */
     else
         service = "broker";
-    if (asprintf (&ctx->topic, "%s.ping", service) < 0)
-        log_err_exit ("out of memory");
+    ctx->topic = xasprintf ("%s.ping", service);
     free (cpy);
 }
 
@@ -308,9 +307,7 @@ int main (int argc, char *argv[])
             log_msg_exit ("error parsing --rank option");
         if (strchr (target, '!'))
             log_msg_exit ("--rank and TARGET both try to specify a nodeid");
-        char *new_target;
-        if (asprintf (&new_target, "%s!%s", s, target) < 0)
-            log_msg_exit ("out of memory");
+        char *new_target = xasprintf ("%s!%s", s, target);
         free (target);
         target = new_target;
     }

--- a/t/t0007-ping.t
+++ b/t/t0007-ping.t
@@ -65,25 +65,25 @@ test_expect_success 'ping fails on invalid target' '
 
 test_expect_success 'ping output format for "any" rank is correct (default)' '
 	run_timeout 15 flux ping --count 1 broker 1>stdout &&
-        grep -q "^broker.ping" stdout &&
+        grep -q "^0!broker.ping" stdout &&
         grep -q -E "time=[0-9]+\.[0-9]+ ms" stdout
 '
 
 test_expect_success 'ping output format for "any" rank is correct (format 1)' '
 	run_timeout 15 flux ping --count 1 --rank any broker 1>stdout &&
-        grep -q "^broker.ping" stdout &&
+        grep -q "^0!broker.ping" stdout &&
         grep -q -E "time=[0-9]+\.[0-9]+ ms" stdout
 '
 
 test_expect_success 'ping output format for "any" rank is correct (format 2)' '
 	run_timeout 15 flux ping --count 1 any!broker 1>stdout &&
-        grep -q "^broker.ping" stdout &&
+        grep -q "^0!broker.ping" stdout &&
         grep -q -E "time=[0-9]+\.[0-9]+ ms" stdout
 '
 
 test_expect_success 'ping output format for "any" rank is correct (format 3)' '
 	run_timeout 15 flux ping --count 1 any 1>stdout &&
-        grep -q "^broker.ping" stdout &&
+        grep -q "^0!broker.ping" stdout &&
         grep -q -E "time=[0-9]+\.[0-9]+ ms" stdout
 '
 
@@ -116,19 +116,19 @@ test_expect_success 'ping with "upstream" fails on rank 0' '
 
 test_expect_success 'ping with "upstream" works (format 1)' '
         run_timeout 15 flux exec -n --rank 1 flux ping --count 1 --rank upstream broker 1>stdout &&
-        grep -q "^upstream!broker.ping" stdout &&
+        grep -q "^0!broker.ping" stdout &&
         grep -q -E "time=[0-9]+\.[0-9]+ ms" stdout
 '
 
 test_expect_success 'ping with "upstream" works (format 2)' '
         run_timeout 15 flux exec -n --rank 1 flux ping --count 1 upstream!broker 1>stdout &&
-        grep -q "^upstream!broker.ping" stdout &&
+        grep -q "^0!broker.ping" stdout &&
         grep -q -E "time=[0-9]+\.[0-9]+ ms" stdout
 '
 
 test_expect_success 'ping with "upstream" works (format 3)' '
         run_timeout 15 flux exec -n --rank 1 flux ping --count 1 upstream 1>stdout &&
-        grep -q "^upstream!broker.ping" stdout &&
+        grep -q "^0!broker.ping" stdout &&
         grep -q -E "time=[0-9]+\.[0-9]+ ms" stdout
 '
 

--- a/t/t0007-ping.t
+++ b/t/t0007-ping.t
@@ -65,24 +65,28 @@ test_expect_success 'ping fails on invalid target' '
 
 test_expect_success 'ping output format for "any" rank is correct (default)' '
 	run_timeout 15 flux ping --count 1 broker 1>stdout &&
+        head -n 1 stdout | grep -q "any!broker" &&
         grep -q "^0!broker.ping" stdout &&
         grep -q -E "time=[0-9]+\.[0-9]+ ms" stdout
 '
 
 test_expect_success 'ping output format for "any" rank is correct (format 1)' '
 	run_timeout 15 flux ping --count 1 --rank any broker 1>stdout &&
+        head -n 1 stdout | grep -q "any!broker" &&
         grep -q "^0!broker.ping" stdout &&
         grep -q -E "time=[0-9]+\.[0-9]+ ms" stdout
 '
 
 test_expect_success 'ping output format for "any" rank is correct (format 2)' '
 	run_timeout 15 flux ping --count 1 any!broker 1>stdout &&
+        head -n 1 stdout | grep -q "any!broker" &&
         grep -q "^0!broker.ping" stdout &&
         grep -q -E "time=[0-9]+\.[0-9]+ ms" stdout
 '
 
 test_expect_success 'ping output format for "any" rank is correct (format 3)' '
 	run_timeout 15 flux ping --count 1 any 1>stdout &&
+        head -n 1 stdout | grep -q "any!broker" &&
         grep -q "^0!broker.ping" stdout &&
         grep -q -E "time=[0-9]+\.[0-9]+ ms" stdout
 '
@@ -138,10 +142,16 @@ test_expect_success 'ping help output works' '
 '
 
 test_expect_success 'ping works with hostname' '
-        flux ping --count=1 $(hostname)
+        hostname=$(hostname) &&
+        flux ping --count=1 ${hostname} 1>stdout &&
+        head -n 1 stdout | grep -q "${hostname}!broker" &&
+        head -n 1 stdout | grep -q "(rank 0)"
 '
 test_expect_success 'ping works with hostname!service' '
-        flux ping --count=1 "$(hostname)!broker"
+        hostname=$(hostname) &&
+        flux ping --count=1 "${hostname}!broker" 1>stdout &&
+        head -n 1 stdout | grep -q "${hostname}!broker" &&
+        head -n 1 stdout | grep -q "(rank 0)"
 '
 test_expect_success 'ping fails with unknown hostname' '
         test_must_fail flux ping --count=1 "notmyhost!broker"


### PR DESCRIPTION
Per discussion in #4106, output a header before the main ping output.  This is useful because there are so many input possibilities, as well defaults, that the header can make it clear what is being pinged.  In addition, when a hostname is input on the command line, the rank can be specified too.

As discussed, the output of the ping output is now also the same regardless of the input mechanism.  Before you might get `0!broker`, `broker`, or `upstream!broker` depending on the input on the command line.  Now you always get `0!broker` if the ping comes from rank 0.

Biggest complaint might be my static inline `ASPRINTF()` function.  I was just annoyed enough about passing buffers around that I wanted to use `asprintf` instead, and it was just annoying enough to have to do `log_err_exit("out of memory")` enough times I made the function.