### PR TITLE
resource: do not allow ranks to be both drained and excluded

### DIFF
--- a/doc/man1/flux-resource.rst
+++ b/doc/man1/flux-resource.rst
@@ -109,6 +109,10 @@ COMMANDS
    only those ranks that are not already drained or do not have a *reason* set
    have their *reason* updated.
 
+   Resources cannot be both excluded and drained, so **flux resource drain**
+   will also fail if any *targets* are currently excluded by configuration.
+   There is no option to force an excluded node into the drain state.
+
    This command, when run with arguments, is restricted to the Flux instance
    owner.
 

--- a/doc/man5/flux-config-resource.rst
+++ b/doc/man5/flux-config-resource.rst
@@ -62,6 +62,9 @@ exclude
    the scheduler, but will still be used to determine satisfiability of job
    requests until the instance is restarted.
 
+   If a drained node is subsequently excluded, the drain state of the node
+   is cleared since nodes cannot be both excluded and drained.
+
 norestrict
    (optional) Disable restricting of the loaded HWLOC topology XML to the
    current cpu affinity mask of the Flux broker. This option should be used

--- a/src/modules/resource/drain.c
+++ b/src/modules/resource/drain.c
@@ -187,7 +187,12 @@ static int check_draininfo_idset (struct drain *drain,
                    was_drained && was_excluded ? " or " : "",
                    was_excluded ? "excluded" : "");
         free (s);
-        errno = EEXIST;
+
+        /*  If any node was drained, then return EEXIST as a hint of this
+         *  fact. Otherwise, an attempt to drain an excluded node was made,
+         *  and that is invalid, so return EINVAL.
+         */
+        errno = was_drained ? EEXIST : EINVAL;
     }
     idset_destroy (errids);
     return rc;

--- a/src/modules/resource/drain.h
+++ b/src/modules/resource/drain.h
@@ -27,6 +27,11 @@ json_t *drain_get_info  (struct drain *drain);
  */
 int drain_rank (struct drain *drain, uint32_t rank, const char *reason);
 
+/* Undrain 'ranks'. Call this on rank 0 only, otherwise use resource.drain RPC
+ * It is not an error if any rank in 'ranks' is already drained.
+ */
+int undrain_ranks (struct drain *drain, const struct idset *ranks);
+
 #endif /* !_FLUX_RESOURCE_DRAIN_H */
 
 /*

--- a/src/modules/resource/exclude.c
+++ b/src/modules/resource/exclude.c
@@ -31,6 +31,7 @@
 #include "exclude.h"
 #include "rutil.h"
 #include "inventory.h"
+#include "drain.h"
 
 struct exclude {
     struct resource_ctx *ctx;
@@ -83,6 +84,12 @@ int exclude_update (struct exclude *exclude,
             flux_log_error (h, "error posting exclude event");
         }
         free (add_s);
+        /*  Added exclude ranks can no longer be drained:
+         */
+        if (undrain_ranks (exclude->ctx->drain, add) < 0)
+            flux_log_error (h,
+                            "exclude: failed to undrain ranks in %s",
+                            add_s);
         idset_destroy (add);
     }
     if (del) {

--- a/src/modules/resource/exclude.c
+++ b/src/modules/resource/exclude.c
@@ -58,7 +58,8 @@ int exclude_update (struct exclude *exclude,
                                                   s,
                                                   errp)))
             return -1;
-        if (idset_last (idset) >= exclude->ctx->size) {
+        if (idset_count (idset) > 0
+            && idset_last (idset) >= exclude->ctx->size) {
             errprintf (errp, "exclusion idset is out of range");
             idset_destroy (idset);
             errno = EINVAL;
@@ -132,7 +133,8 @@ struct exclude *exclude_create (struct resource_ctx *ctx,
                             error.text);
             goto error;
         }
-        if (idset_last (exclude->idset) >= exclude->ctx->size) {
+        if (idset_count (exclude->idset) > 0
+            && idset_last (exclude->idset) >= exclude->ctx->size) {
             flux_log_error (ctx->h,
                             "exclude set %s is out of range",
                             exclude_idset);


### PR DESCRIPTION
This PR attempts to prevent excluded ranks from being drained since `flux resource status` now assumes a node/rank is only in one of the states avail, exclude, drained, or draining.

Ensuring this required changes in multiple places - I'm not sure if there was a cleaner way to handle this:

 * exclude idset is now checked in the drain request handler and an error generated if any target is excluded
 * if a node is excluded on replay, any drain events for that rank are ignored
 * if a node is excluded at runtime, any drain state for that rank is cleared

Since drain initialization now requires access to the exclude idset, the resource module initialization had to be reordered a bit. It was actually a bit difficult to determine the dependencies between the resource module bits, so I tried to add some comments on what I found. 

Fixes #4999