### PR TITLE
flux-pgrep: fix warning about sre_constants on Python 3.11+

### DIFF
--- a/src/cmd/flux-pgrep.py
+++ b/src/cmd/flux-pgrep.py
@@ -12,7 +12,6 @@ import argparse
 import logging
 import os
 import re
-import sre_constants
 import sys
 from itertools import islice
 from pathlib import PurePath
@@ -265,7 +264,7 @@ def main():
     fh = flux.Flux()
     try:
         pgrep = JobPgrep(args.expression)
-    except (ValueError, SyntaxError, TypeError, sre_constants.error) as exc:
+    except (ValueError, SyntaxError, TypeError, re.error) as exc:
         LOGGER.error(f"expression error: {exc}")
         sys.exit(2)
 


### PR DESCRIPTION
The `sre_constants` module has been depreacated in latter Python versions. Turns out we didn't need it anyway.
