### PR TITLE
flux-overlay: add whatsup subcommand

### DIFF
--- a/doc/man1/flux-overlay.rst
+++ b/doc/man1/flux-overlay.rst
@@ -17,6 +17,7 @@ SYNOPSIS
 
 **flux** **overlay** **disconnect** [*OPTIONS*] *TARGET*
 
+**flux** **overlay** **whatsup** [*OPTIONS*]
 
 DESCRIPTION
 ===========
@@ -82,6 +83,14 @@ Round trip RPC times are shown with ``-vv``, e.g.
   ├─ 5 test5: offline for 12.754h
   ├─ 6 test6: full for 18.3052h (2.131 ms)
   └─ 7 test7: offline for 12.754h
+
+A short summary of up vs down nodes in the overlay can be output with
+
+::
+
+  $ flux overlay whatsup
+  up: 8: test[0-7]
+  down: 0:
 
 A broker that is not responding but is not shown as *lost* or *offline* may
 be forcibly disconnected from the overlay network with

--- a/doc/test/spell.en.pws
+++ b/doc/test/spell.en.pws
@@ -705,3 +705,4 @@ libc
 unbuffered
 statex
 pmix
+whatsup

--- a/src/cmd/builtin/overlay.c
+++ b/src/cmd/builtin/overlay.c
@@ -918,6 +918,7 @@ static int subcmd_disconnect (optparse_t *p, int ac, char *av[])
 
     return 0;
 }
+
 int cmd_overlay (optparse_t *p, int argc, char *argv[])
 {
     log_init ("flux-overlay");


### PR DESCRIPTION
Per discussion in #4487 and #4488

Nothing too fancy, get the group set from the rank 0 broker and do some idset math to figure out up vs down.  Maybe don't need to support ALL of those options, that's what leads to a lot of the extra output logic.  But kept it in there for consistency to `whatsup(1)`.
