### PR TITLE
flux-job: support job ids to purge

### DIFF
--- a/doc/man1/flux-job.rst
+++ b/doc/man1/flux-job.rst
@@ -31,7 +31,7 @@ SYNOPSIS
 
 **flux** **job** **timeleft** [*OPTIONS*] [*id*]
 
-**flux** **job** **purge** [*OPTIONS*]
+**flux** **job** **purge** [*OPTIONS*] [*id...*]
 
 DESCRIPTION
 ===========
@@ -247,7 +247,8 @@ PURGE
 =====
 
 Inactive job data may be purged from the Flux instance with ``flux job purge``.
-The following options may be used to add selection criteria:
+Specific job ids may be specified for purging.  If no job ids are
+specified, the following options may be used for selection criteria:
 
 **--age-limit=FSD**
    Purge inactive jobs older than the specified Flux Standard Duration.

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -3653,7 +3653,7 @@ static void purge_id_continuation (flux_future_t *f, void *arg)
     int *count = arg;
     int tmp;
     if (flux_rpc_get_unpack (f, "{s:i}", "count", &tmp) < 0)
-        log_err_exit ("purge: %s", future_strerror (f, errno));
+        log_msg_exit ("purge: %s", future_strerror (f, errno));
     (*count) += tmp;
     flux_future_destroy (f);
 }

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -3596,7 +3596,6 @@ int cmd_purge (optparse_t *p, int argc, char **argv)
 {
     int optindex = optparse_option_index (p);
     flux_t *h;
-    int rc = 0;
     double age_limit = optparse_get_duration (p, "age-limit", -1.);
     int num_limit = optparse_get_int (p, "num-limit", -1);
     int batch = optparse_get_int (p, "batch", 50);
@@ -3646,7 +3645,7 @@ int cmd_purge (optparse_t *p, int argc, char **argv)
 
     flux_close (h);
 
-    return rc;
+    return 0;
 }
 
 static struct taskmap *flux_job_taskmap (flux_jobid_t id)

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -591,7 +591,7 @@ static struct optparse_subcommand subcommands[] = {
       NULL,
     },
     { "purge",
-      "[--age-limit=FSD] [--num-limit=N]",
+      "[--age-limit=FSD] [--num-limit=N] [--batch=COUNT] [--force]",
       "Purge the oldest inactive jobs",
       cmd_purge,
       0,

--- a/src/cmd/flux-job.c
+++ b/src/cmd/flux-job.c
@@ -591,7 +591,7 @@ static struct optparse_subcommand subcommands[] = {
       NULL,
     },
     { "purge",
-      "[--age-limit=FSD] [--num-limit=N] [--batch=COUNT] [--force]",
+      "[--age-limit=FSD] [--num-limit=N] [--batch=COUNT] [--force] [ID ...]",
       "Purge the oldest inactive jobs",
       cmd_purge,
       0,
@@ -3592,9 +3592,27 @@ int cmd_memo (optparse_t *p, int argc, char **argv)
     return (0);
 }
 
-int cmd_purge (optparse_t *p, int argc, char **argv)
+static void purge_finish (flux_t *h, int force, int total)
 {
-    int optindex = optparse_option_index (p);
+    int inactives;
+    flux_future_t *f;
+
+    if (!(f = flux_rpc (h, "job-manager.stats-get", NULL, 0, 0))
+        || flux_rpc_get_unpack (f, "{s:i}", "inactive_jobs", &inactives) < 0)
+        log_err_exit ("purge: failed to fetch inactive job count");
+    flux_future_destroy (f);
+
+    if (force)
+        printf ("purged %d inactive jobs, %d remaining\n", total, inactives);
+    else {
+        printf ("use --force to purge %d of %d inactive jobs\n",
+                total,
+                inactives);
+    }
+}
+
+static int purge_range (optparse_t *p, int argc, char **argv)
+{
     flux_t *h;
     double age_limit = optparse_get_duration (p, "age-limit", -1.);
     int num_limit = optparse_get_int (p, "num-limit", -1);
@@ -3602,19 +3620,14 @@ int cmd_purge (optparse_t *p, int argc, char **argv)
     int force = 0;
     int count;
     int total = 0;
-    int inactives;
-    flux_future_t *f;
 
-    if ((argc - optindex) > 0) {
-        optparse_print_usage (p);
-        exit (1);
-    }
     if (optparse_hasopt (p, "force"))
         force = 1;
     if (!(h = flux_open (NULL, 0)))
         log_err_exit ("flux_open");
 
     do {
+        flux_future_t *f;
         if (!(f = flux_rpc_pack (h,
                                  "job-manager.purge",
                                  0,
@@ -3630,22 +3643,64 @@ int cmd_purge (optparse_t *p, int argc, char **argv)
         flux_future_destroy (f);
     } while (force && count == batch);
 
-    if (!(f = flux_rpc (h, "job-manager.stats-get", NULL, 0, 0))
-        || flux_rpc_get_unpack (f, "{s:i}", "inactive_jobs", &inactives) < 0)
-        log_err_exit ("purge: failed to fetch inactive job count");
-    flux_future_destroy (f);
+    purge_finish (h, force, total);
+    flux_close (h);
+    return 0;
+}
 
-    if (force)
-        printf ("purged %d inactive jobs, %d remaining\n", total, inactives);
-    else {
-        printf ("use --force to purge %d of %d inactive jobs\n",
-                total,
-                inactives);
+static void purge_id_continuation (flux_future_t *f, void *arg)
+{
+    int *count = arg;
+    int tmp;
+    if (flux_rpc_get_unpack (f, "{s:i}", "count", &tmp) < 0)
+        log_err_exit ("purge: %s", future_strerror (f, errno));
+    (*count) += tmp;
+    flux_future_destroy (f);
+}
+
+static int purge_ids (optparse_t *p, int argc, char **argv)
+{
+    int optindex = optparse_option_index (p);
+    flux_t *h;
+    int force = 0;
+    int total = 0;
+    int i, ids_len;
+
+    if (optparse_hasopt (p, "force"))
+        force = 1;
+    if (!(h = flux_open (NULL, 0)))
+        log_err_exit ("flux_open");
+
+    ids_len = argc - optindex;
+    for (i = 0; i < ids_len; i++) {
+        flux_jobid_t id = parse_jobid (argv[optindex + i]);
+        flux_future_t *f;
+        if (!(f = flux_rpc_pack (h,
+                                 "job-manager.purge-id",
+                                 0,
+                                 0,
+                                 "{s:I s:i}",
+                                 "id", id,
+                                 "force", force)))
+            log_err_exit ("job-manager.purge-id");
+        if (flux_future_then (f, -1, purge_id_continuation, &total) < 0)
+            log_err_exit ("flux_future_then");
     }
 
-    flux_close (h);
+    if (flux_reactor_run (flux_get_reactor (h), 0) < 0)
+        log_err_exit ("flux_reactor_run");
 
+    purge_finish (h, force, total);
+    flux_close (h);
     return 0;
+}
+
+int cmd_purge (optparse_t *p, int argc, char **argv)
+{
+    int optindex = optparse_option_index (p);
+    if ((argc - optindex) > 0)
+        return purge_ids (p, argc, argv);
+    return purge_range (p, argc, argv);
 }
 
 static struct taskmap *flux_job_taskmap (flux_jobid_t id)

--- a/t/t2809-job-purge.t
+++ b/t/t2809-job-purge.t
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-test_description='Test flux job purge'
+test_description='Test flux job purge and flux job purge-id'
 
 . $(dirname $0)/sharness.sh
 
@@ -40,6 +40,9 @@ wait_inactive_count() {
 	return 1
 }
 
+#
+# purge tests
+#
 # Speed up heartbeat-driven purge results to make the test run faster
 test_expect_success 'reload heartbeat module with fast rate' '
         flux module reload heartbeat period=0.1s
@@ -68,10 +71,6 @@ test_expect_success 'flux job purge --batch=10000 fails' '
 test_expect_success 'flux job purge --force --num-limit=-42 fails' '
 	test_must_fail flux job purge --num-limit=-42 2>negnum.err &&
 	grep "num limit must be" negnum.err
-'
-test_expect_success 'flux job purge with extra free argument fails' '
-	test_must_fail flux job purge xyz 2>freearg.err &&
-	grep "Usage:" freearg.err
 '
 test_expect_success 'flux job purge --num-limit=8 would purge 2' '
 	flux job purge --num-limit=8 >num8.out &&
@@ -124,6 +123,74 @@ test_expect_success 'purge the last job' '
 	flux job purge --force --num-limit=0 &&
 	wait_inactive_count job-manager 0 30
 '
+#
+# purge w/ job ids tests
+#
+test_expect_success 'create 4 inactive jobs and 1 active job and save their jobids' '
+	flux submit --cc=1-4 /bin/true > inactive.ids &&
+	flux queue drain &&
+	flux submit sleep inf > active.id
+'
+test_expect_success 'flux job purge with id says use force' '
+	jobid=`head -n1 inactive.ids` &&
+	flux job purge $jobid >id_no_force.out &&
+	grep "use --force to purge 1" id_no_force.out
+'
+test_expect_success 'flux job purge --force purges 1 job' '
+	jobid=`head -n1 inactive.ids` &&
+	flux job purge --force $jobid >id_force_one.out &&
+	grep "purged 1 inactive jobs" id_force_one.out
+'
+test_expect_success 'flux job purge on invalid jobid fails (no-force)' '
+	jobid=`head -n1 inactive.ids` &&
+	test_must_fail flux job purge $jobid >id_invalid_one.out 2>&1 &&
+	grep "id not found" id_invalid_one.out
+'
+test_expect_success 'flux job purge on active jobid fails (no-force)' '
+	jobid=`cat active.id` &&
+	test_must_fail flux job purge $jobid >id_active_one.out 2>&1 &&
+	grep "cannot purge active job" id_active_one.out
+'
+test_expect_success 'flux job purge on invalid jobid fails (force)' '
+	jobid=`head -n1 inactive.ids` &&
+	test_must_fail flux job purge --force $jobid >id_invalid_one.out 2>&1 &&
+	grep "id not found" id_invalid_one.out
+'
+test_expect_success 'flux job purge on active jobid fails (force)' '
+	jobid=`cat active.id` &&
+	test_must_fail flux job purge --force $jobid >id_active_one.out 2>&1 &&
+	grep "cannot purge active job" id_active_one.out
+'
+test_expect_success 'flux job purge with multiple ids says use force' '
+	jobid1=`head -n2 inactive.ids | tail -n1` &&
+	jobid2=`head -n3 inactive.ids | tail -n1` &&
+	flux job purge $jobid1 $jobid2 >two_ids_no_force.out &&
+	grep "use --force to purge 2" two_ids_no_force.out
+'
+test_expect_success 'flux job purge with multiple ids and --force purges 2 jobs' '
+	jobid1=`head -n2 inactive.ids | tail -n1` &&
+	jobid2=`head -n3 inactive.ids | tail -n1` &&
+	flux job purge --force $jobid1 $jobid2 >id_force_two.out &&
+	grep "purged 2 inactive jobs" id_force_two.out
+'
+test_expect_success 'flux job purge with valid and invalid jobid is ENOENT' '
+	jobid1=`head -n1 inactive.ids` &&
+	jobid2=`tail -n1` &&
+	test_must_fail flux job purge --force $jobid1 $jobid2 >id_invalid_one_of_two.out 2>&1 &&
+	grep "id not found" id_invalid_one_of_two.out
+'
+test_expect_success 'flux job purge the last remaining inactive job' '
+	jobid=`tail -n1` &&
+	test_must_fail flux job purge --force $jobid1 >id_last_one.out 2>&1 &&
+	grep "id not found" id_last_one.out
+'
+test_expect_success 'cleanup running job' '
+	flux cancel $(cat active.id) &&
+	flux job wait-event $(cat active.id) clean
+'
+#
+# do the following "auto purge" tests last, as they could affect earlier tests
+#
 test_expect_success 'create 10 inactive jobs' '
 	flux submit --cc=1-10 /bin/true &&
 	flux queue drain


### PR DESCRIPTION
Per #4801.  I decided to add a new `purge-id` subcommand instead of having `purge` take optional ID arguments.  That way its similar to `list` vs `list-id`.
