### PR TITLE
flux-job: add special exit code to flux job wait when not waitable

### DIFF
--- a/doc/man1/flux-job.rst
+++ b/doc/man1/flux-job.rst
@@ -119,14 +119,15 @@ results are consumed.
 When run with a jobid argument, ``flux job wait`` blocks until the specified
 job completes.  If the job was successful, it silently exits with a code of
 zero.  If the job has failed, an error is printed on stderr, and it exits with
-a code of one.  It is an error if the job was not submitted with the
-``waitable`` flag.
+a code of one.  If the jobid is invalid or the job is not waitable, ``flux job wait``
+exits with a code of two.  This special exit code of two is used to differentiate
+between a failed job and not being able to wait on the job.
 
 When run without arguments, ``flux job wait`` blocks until the next waitable
 job completes and behaves as above except that the jobid is printed to stdout.
-When there are no more waitable jobs, it exits with a code of one.  Note that
-a ``while flux job wait...`` loop terminates on the first unsuccessful job
-or when there are no more jobs.
+When there are no more waitable jobs, it exits with a code of two.  The exit code
+of two can be used to determine when no more jobs are waitable when using
+``flux job wait`` in a loop.
 
 ``flux job wait --all`` loops through waitable jobs as they complete, printing
 their jobids.  If all jobs are successful, it exits with a code of zero.  If

--- a/doc/man1/flux-job.rst
+++ b/doc/man1/flux-job.rst
@@ -129,9 +129,9 @@ When there are no more waitable jobs, it exits with a code of two.  The exit cod
 of two can be used to determine when no more jobs are waitable when using
 ``flux job wait`` in a loop.
 
-``flux job wait --all`` loops through waitable jobs as they complete, printing
-their jobids.  If all jobs are successful, it exits with a code of zero.  If
-any jobs have failed, it exits with a code of one.
+``flux job wait --all`` loops through all the waitable jobs as they complete,
+printing their jobids.  If all jobs are successful, it exits with a code of zero.
+If any jobs have failed, it exits with a code of one.
 
 **-a, --all**
    Wait for all waitable jobs and exit with error if any jobs are

--- a/t/t2208-job-manager-wait.t
+++ b/t/t2208-job-manager-wait.t
@@ -113,19 +113,19 @@ test_expect_success "wait FLUX_JOBID_ANY fails with no waitable jobs" '
 test_expect_success "wait works when job terminated by exception" '
 	JOBID=$(flux submit --flags waitable sleep 120) &&
 	flux job raise --severity=0 ${JOBID} my-exception-message &&
-	! flux job wait ${JOBID} 2>exception.out &&
+	test_must_fail flux job wait ${JOBID} 2>exception.out &&
 	grep my-exception-message exception.out
 '
 
 test_expect_success "wait works when job tasks exit 1" '
 	JOBID=$(flux submit --flags waitable /bin/false) &&
-	! flux job wait ${JOBID} 2>false.out &&
+	test_must_fail flux job wait ${JOBID} 2>false.out &&
 	grep exit false.out
 '
 
 test_expect_success "wait works when job tasks exit 1" '
 	JOBID=$(flux submit --flags waitable /bin/false) &&
-	! flux job wait ${JOBID} 2>false.out &&
+	test_must_fail flux job wait ${JOBID} 2>false.out &&
 	grep exit false.out
 '
 
@@ -207,12 +207,16 @@ test_expect_success "a second wait fails on waitable, inactive job" '
 '
 
 test_expect_success "guest cannot submit job with WAITABLE flag" '
-	! FLUX_HANDLE_ROLEMASK=0x2 flux submit --flags waitable /bin/true
+	export FLUX_HANDLE_ROLEMASK=0x2 &&
+	test_must_fail flux submit --flags waitable /bin/true &&
+	unset FLUX_HANDLE_ROLEMASK
 '
 
 test_expect_success "guest cannot wait on a job" '
 	JOBID=$(flux submit --flags waitable /bin/true) &&
-	! FLUX_HANDLE_ROLEMASK=0x2 flux job wait ${JOBID}
+	export FLUX_HANDLE_ROLEMASK=0x2 &&
+	test_must_fail flux job wait ${JOBID} &&
+	unset FLUX_HANDLE_ROLEMASK
 '
 
 test_done

--- a/t/t2208-job-manager-wait.t
+++ b/t/t2208-job-manager-wait.t
@@ -123,12 +123,6 @@ test_expect_success "wait works when job tasks exit 1" '
 	grep exit false.out
 '
 
-test_expect_success "wait works when job tasks exit 1" '
-	JOBID=$(flux submit --flags waitable /bin/false) &&
-	test_must_fail flux job wait ${JOBID} 2>false.out &&
-	grep exit false.out
-'
-
 test_expect_success "wait --all fails with jobid" '
 	test_must_fail flux job wait --all 42
 '

--- a/t/t2208-job-manager-wait.t
+++ b/t/t2208-job-manager-wait.t
@@ -106,20 +106,20 @@ test_expect_success 'disconnect with async waits pending' '
 	echo ...reaped $count of 10 zombies
 '
 
-test_expect_success "wait FLUX_JOBID_ANY fails with no waitable jobs" '
-	test_must_fail flux job wait
+test_expect_success "wait FLUX_JOBID_ANY exits 2 with no waitable jobs" '
+	test_expect_code 2 flux job wait
 '
 
 test_expect_success "wait works when job terminated by exception" '
 	JOBID=$(flux submit --flags waitable sleep 120) &&
 	flux job raise --severity=0 ${JOBID} my-exception-message &&
-	test_must_fail flux job wait ${JOBID} 2>exception.out &&
+	test_expect_code 1 flux job wait ${JOBID} 2>exception.out &&
 	grep my-exception-message exception.out
 '
 
 test_expect_success "wait works when job tasks exit 1" '
 	JOBID=$(flux submit --flags waitable /bin/false) &&
-	test_must_fail flux job wait ${JOBID} 2>false.out &&
+	test_expect_code 1 flux job wait ${JOBID} 2>false.out &&
 	grep exit false.out
 '
 
@@ -173,31 +173,31 @@ test_expect_success "wait --all --verbose emits one line per succesful job" '
 '
 
 test_expect_success "wait fails on bad jobid, " '
-	test_must_fail flux job wait 1
+	test_expect_code 2 flux job wait 1
 '
 
 test_expect_success "wait fails on non-waitable, active job" '
 	JOBID=$(flux submit sleep 0.5) &&
-	test_must_fail flux job wait ${JOBID}
+	test_expect_code 2 flux job wait ${JOBID}
 '
 
 test_expect_success "wait fails on non-waitable, inactive job" '
 	JOBID=$(flux submit /bin/true) &&
 	flux job wait-event ${JOBID} clean &&
-	test_must_fail flux job wait ${JOBID}
+	test_expect_code 2 flux job wait ${JOBID}
 '
 
 test_expect_success "a second wait fails on waitable, active job" '
 	JOBID=$(flux submit --flags waitable sleep 0.5) &&
 	flux job wait ${JOBID} &&
-	test_must_fail flux job wait ${JOBID}
+	test_expect_code 2 flux job wait ${JOBID}
 '
 
 test_expect_success "a second wait fails on waitable, inactive job" '
 	JOBID=$(flux submit --flags waitable /bin/true) &&
 	flux job wait-event ${JOBID} clean &&
 	flux job wait ${JOBID} &&
-	test_must_fail flux job wait ${JOBID}
+	test_expect_code 2 flux job wait ${JOBID}
 '
 
 test_expect_success "guest cannot submit job with WAITABLE flag" '
@@ -209,7 +209,7 @@ test_expect_success "guest cannot submit job with WAITABLE flag" '
 test_expect_success "guest cannot wait on a job" '
 	JOBID=$(flux submit --flags waitable /bin/true) &&
 	export FLUX_HANDLE_ROLEMASK=0x2 &&
-	test_must_fail flux job wait ${JOBID} &&
+	test_expect_code 1 flux job wait ${JOBID} &&
 	unset FLUX_HANDLE_ROLEMASK
 '
 


### PR DESCRIPTION
As discussed in #5033, it is hard to differentiate between a job not being waitable / no more jobs are waitable vs a waitable job had an error.  Because in both circumstances `flux job wait` exits with 1.

This PR has `flux job wait` exit with 100 when either a jobid is non-waitable (invalid, not waitable, etc.) or there are no more waitable jobs.  So we can more easily write a script like this:

```
while jobid=`flux job wait 2> /dev/null`; ec=$?; test $ec -ne 100
do
    echo "$jobid finished"
    if [ $ec -eq 0 ]
    then
        echo "job successful"
        # do some post processing on successful jobs
    else
        echo "job failed"
        # do some post processing on failed jobs
    fi
done
echo "no more jobs to wait on"
```

I picked the exit code 100 somewhat arbitrarily.  It's common to use exit code of 2, 3, 4, ... for other purposes.  I just wanted to make it clear this wasn't an exit code from the job.  Maybe 100 is overkill.  I could make it configurable??
