### PR TITLE
libpmi: enable flux to bootstrap with cray libpmi2.so

### DIFF
--- a/src/broker/boot_pmi.c
+++ b/src/broker/boot_pmi.c
@@ -88,7 +88,6 @@ static int set_broker_mapping_attr (struct upmi *upmi,
     else {
         /* First attempt to get flux.taskmap, falling back to
          * PMI_process_mapping if this key is not available.
-         * This should be replaced when #4800 is fixed.
          */
         char *s;
         if (upmi_get (upmi, "flux.taskmap", -1, &s, NULL) == 0

--- a/src/broker/boot_pmi.c
+++ b/src/broker/boot_pmi.c
@@ -84,7 +84,7 @@ static int set_broker_mapping_attr (struct upmi *upmi,
     int rc;
 
     if (size == 1)
-        val = strdup ("{\"version\":1,\"map\":[[0,1,1,1]]}");
+        val = strdup ("[[0,1,1,1]]");
     else {
         /* First attempt to get flux.taskmap, falling back to
          * PMI_process_mapping if this key is not available.

--- a/src/cmd/builtin/pmi.c
+++ b/src/cmd/builtin/pmi.c
@@ -200,6 +200,8 @@ static int cmd_pmi (optparse_t *p, int argc, char *argv[])
         flags |= UPMI_TRACE;
     if (optparse_hasopt (p, "libpmi-noflux"))
         flags |= UPMI_LIBPMI_NOFLUX;
+    if (optparse_hasopt (p, "libpmi2-cray"))
+        flags |= UPMI_LIBPMI2_CRAY;
     if (!(upmi = upmi_create (method, flags, trace, NULL, &error)))
         log_msg_exit ("%s", error.text);
 
@@ -231,6 +233,8 @@ static struct optparse_option general_opts[] = {
       .usage = "Specify PMI method to use", },
     { .name = "libpmi-noflux", .has_arg = 0,
       .usage = "Fail if libpmi method finds the Flux libpmi.so", },
+    { .name = "libpmi2-cray", .has_arg = 0,
+      .usage = "Force-enable libpmi2 cray workarounds for testing", },
     { .name = "verbose",    .key = 'v', .has_arg = 2, .arginfo = "[LEVEL]",
       .usage = "Trace PMI operations", },
     OPTPARSE_TABLE_END,

--- a/src/common/libpmi/Makefile.am
+++ b/src/common/libpmi/Makefile.am
@@ -41,6 +41,7 @@ libupmi_la_SOURCES = \
 	upmi_plugin.h \
 	upmi_simple.c \
 	upmi_libpmi.c \
+	upmi_libpmi2.c \
 	upmi_single.c
 
 fluxinclude_HEADERS = \

--- a/src/common/libpmi/upmi.c
+++ b/src/common/libpmi/upmi.c
@@ -166,7 +166,7 @@ static struct upmi *upmi_create_uninit (const char *methods,
 {
     struct upmi *upmi;
 
-    if (flags & ~(UPMI_TRACE | UPMI_LIBPMI_NOFLUX)) {
+    if (flags & ~(UPMI_TRACE | UPMI_LIBPMI_NOFLUX | UPMI_LIBPMI2_CRAY)) {
         errprintf (error, "invalid argument");
         return NULL;
     }
@@ -376,6 +376,10 @@ static int upmi_preinit (struct upmi *upmi,
         goto nomem;
     if ((flags & UPMI_LIBPMI_NOFLUX)) {
         if (json_object_set (payload, "noflux", json_true ()) < 0)
+            goto nomem;
+    }
+    if ((flags & UPMI_LIBPMI2_CRAY)) {
+        if (json_object_set (payload, "craycray", json_true ()) < 0)
             goto nomem;
     }
     if (path) {

--- a/src/common/libpmi/upmi.c
+++ b/src/common/libpmi/upmi.c
@@ -50,16 +50,18 @@ static int upmi_preinit (struct upmi *upmi,
                          flux_error_t *error);
 
 int upmi_simple_init (flux_plugin_t *p);
+int upmi_libpmi2_init (flux_plugin_t *p);
 int upmi_libpmi_init (flux_plugin_t *p);
 int upmi_single_init (flux_plugin_t *p);
 
 static flux_plugin_init_f builtins[] = {
     &upmi_simple_init,
+    &upmi_libpmi2_init,
     &upmi_libpmi_init,
     &upmi_single_init,
 };
 
-static const char *default_methods = "simple libpmi single";
+static const char *default_methods = "simple libpmi2 libpmi single";
 
 void upmi_destroy (struct upmi *upmi)
 {

--- a/src/common/libpmi/upmi.h
+++ b/src/common/libpmi/upmi.h
@@ -20,6 +20,7 @@
 enum {
     UPMI_TRACE = 1,         // call the trace callback for each operation
     UPMI_LIBPMI_NOFLUX = 2, // libpmi should fail if Flux libflux.so is found
+    UPMI_LIBPMI2_CRAY = 4,  // force cray libpmi2 workarounds for testing
 };
 
 struct upmi_info {

--- a/src/common/libpmi/upmi_libpmi.c
+++ b/src/common/libpmi/upmi_libpmi.c
@@ -39,7 +39,7 @@ struct plugin_ctx {
     char kvsname[1024];
 };
 
-const char *plugin_name = "libpmi";
+static const char *plugin_name = "libpmi";
 
 static const char *dlinfo_name (void *dso)
 {

--- a/src/common/libpmi/upmi_libpmi2.c
+++ b/src/common/libpmi/upmi_libpmi2.c
@@ -392,6 +392,20 @@ static int op_preinit (flux_plugin_t *p,
         plugin_ctx_destroy (ctx);
         return upmi_seterror (p, args, "%s", strerror (errno));
     }
+    const char *name = dlinfo_name (ctx->dso);
+    if (name) {
+        char note[1024];
+        snprintf (note,
+                  sizeof (note),
+                  "using %s%s",
+                  name,
+                  (ctx->flags & LIBPMI2_IS_CRAY_CRAY)
+                      ? " (cray quirks enabled)" : "");
+        flux_plugin_arg_pack (args,
+                              FLUX_PLUGIN_ARG_OUT,
+                              "{s:s}",
+                              "note", note);
+    }
     return 0;
 }
 

--- a/t/t0001-basic.t
+++ b/t/t0001-basic.t
@@ -197,6 +197,13 @@ test_expect_success 'flux-start test exec fails on bad broker shell script' "
 test_expect_success 'flux-start -s1 works' "
 	flux start ${ARGS} -s1 /bin/true
 "
+test_expect_success 'flux-start -s1 sets broker.mapping to expected value' "
+	cat >mapping_1.exp <<-EOT &&
+	[[0,1,1,1]]
+	EOT
+	flux start ${ARGS} -s1 flux getattr broker.mapping >mapping_1.out &&
+	test_cmp mapping_1.exp mapping_1.out
+"
 test_expect_success 'flux-start --test-rundir without --test-size fails' "
 	test_must_fail flux start ${ARGS} --test-rundir=$(pwd) /bin/true
 "

--- a/t/t3002-pmi.t
+++ b/t/t3002-pmi.t
@@ -182,38 +182,32 @@ test_expect_success 'flux-pmi -opmi=off --method=simple fails' '
 	    flux pmi --method=simple barrier
 '
 # method=libpmi
+test_expect_success 'get pmi library path' '
+	flux getattr conf.pmi_library_path >libpmi
+'
 test_expect_success 'flux-pmi --method=libpmi:/bad/path fails' '
 	test_must_fail flux run \
 	    flux pmi --method=libpmi:/bad/path barrier
 '
 test_expect_success 'flux-pmi --method=libpmi barrier works w/ flux libpmi.so' '
 	flux run -n2 bash -c "\
-	    flux pmi -v \
-	        --method=libpmi:\$(flux getattr conf.pmi_library_path) \
-	        barrier"
+	    flux pmi -v --method=libpmi:$(cat libpmi) barrier"
 '
 test_expect_success 'flux-pmi --method=libpmi exchange works w/ flux libpmi.so' '
 	flux run -n2 bash -c "\
-	    flux pmi -v \
-	        --method=libpmi:\$(flux getattr conf.pmi_library_path) \
-	        exchange"
+	    flux pmi -v --method=libpmi:$(cat libpmi) exchange"
 '
 test_expect_success 'flux-pmi --method=libpmi get works w/ flux libpmi.so' '
 	flux run -n2 bash -c "\
-	    flux pmi -v \
-	        --method=libpmi:\$(flux getattr conf.pmi_library_path) \
-	        get flux.taskmap"
+	    flux pmi -v --method=libpmi:$(cat libpmi) get flux.taskmap"
 '
 test_expect_success 'flux-pmi --libpmi-noflux fails w/ flux libpmi.so' '
 	test_must_fail flux run bash -c "\
-	    flux pmi \
-	        --method=libpmi:\$(flux getattr conf.pmi_library_path) \
-		--libpmi-noflux \
-	        barrier"
+	    flux pmi --method=libpmi:$(cat libpmi) --libpmi-noflux barrier"
 '
 test_expect_success 'flux broker refuses the Flux libpmi.so and goes single' '
 	FLUX_PMI_DEBUG=1 \
-	    LD_LIBRARY_PATH=$(dirname $(flux getattr conf.pmi_library_path)) \
+	    LD_LIBRARY_PATH=$(dirname $(cat libpmi)) \
             flux start /bin/true 2>debug.err &&
 	grep single debug.err
 '

--- a/t/t3002-pmi.t
+++ b/t/t3002-pmi.t
@@ -206,7 +206,7 @@ test_expect_success 'flux-pmi --libpmi-noflux fails w/ flux libpmi.so' '
 	    flux pmi --method=libpmi:$(cat libpmi) --libpmi-noflux barrier"
 '
 test_expect_success 'flux broker refuses the Flux libpmi.so and goes single' '
-	FLUX_PMI_DEBUG=1 \
+	FLUX_PMI_DEBUG=1 FLUX_PMI_CLIENT_METHODS="libpmi single" \
 	    LD_LIBRARY_PATH=$(dirname $(cat libpmi)) \
             flux start /bin/true 2>debug.err &&
 	grep single debug.err


### PR DESCRIPTION
This works through the problems identified in #5040.  I've been able to test this on rzvernal, where the cray PMI libraries were added to LD_LIBRARY_PATH and seems ok.

```
$ srun -N2 -n4 src/cmd/flux start flux getattr broker.mapping
[[0,2,2,1]]
$ src/cmd/flux start flux getattr broker.mapping
(snip big warning from libhwloc)
[[0,1,1,1]]
```