### PR TITLE
libpmi: improve tracing of dlopened PMI libraries

### DIFF
--- a/src/common/libpmi/upmi_libpmi.c
+++ b/src/common/libpmi/upmi_libpmi.c
@@ -284,6 +284,15 @@ static int op_preinit (flux_plugin_t *p,
         plugin_ctx_destroy (ctx);
         return upmi_seterror (p, args, "%s", strerror (errno));
     }
+    const char *name = dlinfo_name (ctx->dso);
+    if (name) {
+        char note[1024];
+        snprintf (note, sizeof (note), "using %s", name);
+        flux_plugin_arg_pack (args,
+                              FLUX_PLUGIN_ARG_OUT,
+                              "{s:s}",
+                              "note", note);
+    }
     return 0;
 }
 

--- a/src/common/libpmi/upmi_libpmi.c
+++ b/src/common/libpmi/upmi_libpmi.c
@@ -271,7 +271,7 @@ static int op_preinit (flux_plugin_t *p,
 
     if (flux_plugin_arg_unpack (args,
                                 FLUX_PLUGIN_ARG_IN,
-                                "{s?s s:b}",
+                                "{s?s s?b}",
                                 "path", &path,
                                 "noflux", &noflux) < 0)
         return upmi_seterror (p, args, "error unpacking preinit arguments");


### PR DESCRIPTION
Problem: when debugging flux launch failure with FLUX_PMI_DEBUG=1, trace output does not include the final dlopened library, if any.

This adds a way for the plugin to return a generic note on successful initialization, which is included in the trace output.  The libpmi plugin sets its note to "using .../libpmi.so".  Here's an example when launching under slurm on a cray system (using libpmi2 which isn't merged yet but you get the idea):
```
rzvernal11 /g/g0/garlick/proj/flux-core > FLUX_PMI_DEBUG=1 srun -N2 -n2 src/cmd/flux start /bin/true
boot_pmi: flux-pmi-client: trying 'simple'
boot_pmi: simple: PMI_FD not found in environ
boot_pmi: flux-pmi-client: trying 'libpmi2'
boot_pmi: flux-pmi-client: trying 'simple'
boot_pmi: simple: PMI_FD not found in environ
boot_pmi: flux-pmi-client: trying 'libpmi2'
boot_pmi: libpmi2: using /opt/cray/pe/lib64/libpmi2.so (cray quirks enabled)
boot_pmi: libpmi2: using /opt/cray/pe/lib64/libpmi2.so (cray quirks enabled)
boot_pmi: libpmi2: initialize: rank=0 size=2 name=kvs_74317.0: success
boot_pmi: libpmi2: initialize: rank=1 size=2 name=kvs_74317.0: success
[snip]
```

The "refactor flags setting" commit was brought over from #5051 because it makes a necessary structural change for this tracing to work.