### PR TITLE
flux-jobs: add --json option

### DIFF
--- a/doc/man1/flux-jobs.rst
+++ b/doc/man1/flux-jobs.rst
@@ -70,6 +70,24 @@ OPTIONS
    CONFIGURATION section for more details. A configuration snippet for an
    existing named format may be generated with ``--format=get-config=NAME``.
 
+**--json**
+   Emit data for selected jobs in JSON format. The data for multiple
+   matching jobs is contained in a ``jobs`` array in the emitted JSON
+   object, unless a single job was selected by jobid on the command
+   line, in which case a JSON object representing that job is emitted on
+   success. With ``-R, --recursive``, each job which is also an instance
+   of Flux will will have any recursively listed jobs in a ``jobs`` array,
+   and so on for each sub-child.
+
+   Only the attributes which are available at the time of the flux-jobs
+   query will be present in the returned JSON object for a job. For
+   instance a pending job will not have ``runtime``, ``waitstatus`` or
+   ``result`` keys, among others. A missing key should be considered
+   unavailable.
+
+   The ``--json`` option is incompatible with ``--stats`` and
+   ``--stats-only``, and any ``--format`` is ignored.
+
 **--color**\ *[=WHEN]*
    Control output coloring.  The optional argument *WHEN* can be
    *auto*, *never*, or *always*.  If *WHEN* is omitted, it defaults to

--- a/src/bindings/python/flux/job/list.py
+++ b/src/bindings/python/flux/job/list.py
@@ -13,7 +13,7 @@ import pwd
 
 import flux.constants
 from flux.future import WaitAllFuture
-from flux.job.info import JobInfo, statetostr
+from flux.job.info import JobInfo
 from flux.rpc import RPC
 
 
@@ -112,30 +112,13 @@ def get_job(flux_handle, jobid):
     payload = {"id": int(jobid), "attrs": ["all"]}
     rpc = JobListIdRPC(flux_handle, "job-list.list-id", payload)
     try:
-        jobinfo = rpc.get()
+        jobinfo = rpc.get_jobinfo()
 
     # The job does not exist!
     except FileNotFoundError:
         return None
 
-    jobinfo = jobinfo["job"]
-
-    # User friendly string from integer
-    state = jobinfo["state"]
-    jobinfo["state"] = statetostr(state)
-
-    # Get job info to add to result
-    info = rpc.get_jobinfo()
-    jobinfo["nnodes"] = info._nnodes
-    jobinfo["result"] = info.result
-    jobinfo["returncode"] = info.returncode
-    jobinfo["runtime"] = info.runtime
-    jobinfo["priority"] = info._priority
-    jobinfo["waitstatus"] = info._waitstatus
-    jobinfo["nodelist"] = info._nodelist
-    jobinfo["nodelist"] = info._nodelist
-    jobinfo["exception"] = info._exception.__dict__
-    return jobinfo
+    return jobinfo.to_dict(filtered=False)
 
 
 class JobListIdsFuture(WaitAllFuture):

--- a/src/cmd/flux-jobs.py
+++ b/src/cmd/flux-jobs.py
@@ -111,6 +111,9 @@ def fetch_jobs_flux(args, fields, flux_handle=None):
         attrs.update(job_fields_to_attrs(["result", "annotations"]))
     if args.recursive:
         attrs.update(job_fields_to_attrs(["annotations", "status", "userid"]))
+    if args.json:
+        args.no_header = True
+        attrs.add("all")
 
     if args.A:
         args.user = str(flux.constants.FLUX_USERID_UNKNOWN)
@@ -301,6 +304,11 @@ def parse_args():
         + " or a defined format by name (use 'help' to get a list of names)",
     )
     parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output jobs in JSON instead of formatted output",
+    )
+    parser.add_argument(
         "--color",
         type=str,
         metavar="WHEN",
@@ -412,6 +420,10 @@ def get_jobs_recursive(job, args, fields):
 
 def print_jobs(jobs, args, formatter, path="", level=0):
     children = []
+    # Array of jobs as dict
+    result = []
+    # Convenience dict for looking up job in result by jobid:
+    job_dict = {}
 
     def pre(job):
         job.color_set = color_setup(args, job)
@@ -421,10 +433,22 @@ def print_jobs(jobs, args, formatter, path="", level=0):
         if args.recursive and is_user_instance(job, args):
             children.append(job)
 
-    formatter.print_items(jobs, no_header=True, pre=pre, post=post)
+    if args.json:
+        for job in jobs:
+            jdict = job.to_dict()
+            result.append(jdict)
+            job_dict[job.id] = jdict
+            #  Normally, print_items() handles collection of any children
+            #  in this job as a side effect of printing each line of output.
+            #  So, when generating JSON output instead, do that explicitly
+            #  here:
+            if args.recursive and is_user_instance(job, args):
+                children.append(job)
+    else:
+        formatter.print_items(jobs, no_header=True, pre=pre, post=post)
 
     if not args.recursive or args.level == level:
-        return
+        return result
 
     #  Reset args.jobids since it won't apply recursively:
     args.jobids = None
@@ -441,6 +465,14 @@ def print_jobs(jobs, args, formatter, path="", level=0):
 
     for future in futures:
         (job, jobs, stats) = future.result()
+
+        #  If generating JSON, just add this job's children to a job["jobs"]
+        #  array and continue:
+        if args.json:
+            job_dict[job.id]["jobs"] = [x.to_dict() for x in jobs]
+            continue
+
+        #  Otherwise generate a header for this jobs children and print them:
         thispath = f"{path}{job.id.f58}"
         print(f"\n{thispath}:")
         if stats:
@@ -448,8 +480,9 @@ def print_jobs(jobs, args, formatter, path="", level=0):
                 f"{stats.running} running, {stats.successful} completed, "
                 f"{stats.failed} failed, {stats.pending} pending"
             )
-
         print_jobs(jobs, args, formatter, path=thispath, level=level + 1)
+
+    return result
 
 
 @flux.util.CLIMain(LOGGER)
@@ -458,6 +491,10 @@ def main():
     sys.stdout = open(sys.stdout.fileno(), "w", encoding="utf8")
 
     args = parse_args()
+
+    if args.json and (args.stats or args.stats_only):
+        LOGGER.error("--json incompatible with --stats or --stats-only")
+        sys.exit(1)
 
     if args.jobids and args.filtered and not args.recursive:
         LOGGER.warning("Filtering options ignored with jobid list")
@@ -492,7 +529,14 @@ def main():
     if not args.no_header:
         print(sformatter.header())
 
-    print_jobs(jobs, args, sformatter)
+    result = print_jobs(jobs, args, sformatter)
+    if args.json:
+        # Only emit single JSON object if user asked for one specific job
+        if args.jobids and len(args.jobids) == 1:
+            if result:
+                print(json.dumps(result[0]))
+        else:
+            print(json.dumps({"jobs": result}))
 
 
 if __name__ == "__main__":

--- a/t/t2800-jobs-recursive.t
+++ b/t/t2800-jobs-recursive.t
@@ -96,6 +96,11 @@ test_expect_success FLUX_SECURITY \
 	test_debug "cat recurse-all.out"  &&
 	grep $(cat altid): recurse-all.out
 '
+test_expect_success 'flux jobs --json works with recursive jobs' '
+	flux jobs -A --recursive --json > recursive.json &&
+	jq -e ".jobs[] | select(.uri)" < recursive.json &&
+	jq -e ".jobs[] | select(.uri) | .jobs[0].id > 0" < recursive.json
+'
 test_expect_success FLUX_SECURITY 'cancel alternate user job' '
 	flux cancel $(cat altid)
 '


### PR DESCRIPTION
This PR adds a `--json` option to flux-jobs(1) to dump job data as JSON instead of formatted output.

As discussed in #4994, by default the keys in the JSON objects for jobs are filtered of empty/unset values.

Fixes #4994