### PR TITLE
flux-jobs: support new "inactive_reason" output field and "endreason" format

### DIFF
--- a/doc/man1/flux-jobs.rst
+++ b/doc/man1/flux-jobs.rst
@@ -453,6 +453,13 @@ the state of the job or other context:
    Returns the job runtime for jobs in RUN state or later, otherwise the
    job duration (if set) is returned.
 
+**inactive_reason**
+   If the job is inactive, returns the reason that the job is no
+   longer active.  Generally speaking, will output "Exit", "Timeout",
+   "Canceled", or signal.  If available, other contextual information
+   will also be provided such as the exit ``returncode`` or
+   cancellation message.
+
 CONFIGURATION
 =============
 

--- a/src/bindings/python/flux/Makefile.am
+++ b/src/bindings/python/flux/Makefile.am
@@ -6,6 +6,7 @@ nobase_fluxpy_PYTHON = \
 	message.py \
 	constants.py \
 	util.py \
+	compat36.py \
 	future.py \
 	memoized_property.py \
 	debugged.py \

--- a/src/bindings/python/flux/compat36.py
+++ b/src/bindings/python/flux/compat36.py
@@ -1,0 +1,78 @@
+###############################################################
+# Copyright 2023 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+import signal
+
+# strsignal() is only available on Python 3.8 and up
+def strsignal(signum):
+    if signum == signal.SIGHUP:
+        return "Hangup"
+    elif signum == signal.SIGINT:
+        return "Interrupt"
+    elif signum == signal.SIGQUIT:
+        return "Quit"
+    elif signum == signal.SIGILL:
+        return "Illegal instruction"
+    elif signum == signal.SIGTRAP:
+        return "Trace/breakpoint trap"
+    elif signum == signal.SIGABRT or signum == signal.SIGIOT:
+        return "Aborted"
+    elif signum == signal.SIGBUS:
+        return "Bus error"
+    elif signum == signal.SIGFPE:
+        return "Floating point exception"
+    elif signum == signal.SIGKILL:
+        return "Killed"
+    elif signum == signal.SIGUSR1:
+        return "User defined signal 1"
+    elif signum == signal.SIGSEGV:
+        return "Segmentation Fault"
+    elif signum == signal.SIGUSR2:
+        return "User defined signal 2"
+    elif signum == signal.SIGPIPE:
+        return "Broken pipe"
+    elif signum == signal.SIGALRM:
+        return "Alarm clock"
+    elif signum == signal.SIGTERM:
+        return "Terminated"
+    # N.B. signal.SIGSTKFLT not defined until Python 3.11
+    elif "SIGSTKFLT" in dir(signal) and signum == signal.SIGSTKFLT:  # novermin
+        return "Stack fault"
+    elif signum == signal.SIGCHLD:
+        return "Child exited"
+    elif signum == signal.SIGCONT:
+        return "Continued"
+    elif signum == signal.SIGSTOP:
+        return "Stopped (signal)"
+    elif signum == signal.SIGTSTP:
+        return "Stopped"
+    elif signum == signal.SIGTTIN:
+        return "Stopped (tty input)"
+    elif signum == signal.SIGTTOU:
+        return "Stopped (tty output)"
+    elif signum == signal.SIGURG:
+        return "Urgent I/O condition"
+    elif signum == signal.SIGXCPU:
+        return "CPU time limit exceeded"
+    elif signum == signal.SIGXFSZ:
+        return "File size limit exceeded"
+    elif signum == signal.SIGVTALRM:
+        return "Virtual timer expired"
+    elif signum == signal.SIGPROF:
+        return "Profiling timer expired"
+    elif signum == signal.SIGWINCH:
+        return "Window changed"
+    elif signum == signal.SIGIO or signum == signal.SIGPOLL:
+        return "I/O possible"
+    elif signum == signal.SIGPWR:
+        return "Power failure"
+    elif signum == signal.SIGSYS:
+        return "Bad system call"
+    raise ValueError

--- a/src/bindings/python/flux/compat36.py
+++ b/src/bindings/python/flux/compat36.py
@@ -10,6 +10,7 @@
 
 import signal
 
+
 # strsignal() is only available on Python 3.8 and up
 def strsignal(signum):
     if signum == signal.SIGHUP:

--- a/src/bindings/python/flux/util.py
+++ b/src/bindings/python/flux/util.py
@@ -360,6 +360,12 @@ def fsd(secs):
     return strtmp
 
 
+def empty_outputs():
+    localepoch = datetime.fromtimestamp(0.0).strftime("%FT%T")
+    empty = ("", "0s", "0.0", "0:00:00", "1970-01-01T00:00:00", localepoch)
+    return empty
+
+
 class UtilFormatter(Formatter):
     # pylint: disable=too-many-branches
 
@@ -439,8 +445,7 @@ class UtilFormatter(Formatter):
         # must be deferred to the UtilDatetetime format() method, since
         # that method will be called after this one:
         if spec.endswith("h") and not isinstance(value, UtilDatetime):
-            localepoch = datetime.fromtimestamp(0.0).strftime("%FT%T")
-            basecases = ("", "0s", "0.0", "0:00:00", "1970-01-01T00:00:00", localepoch)
+            basecases = empty_outputs()
             value = "-" if str(value) in basecases else str(value)
             spec = spec[:-1] + "s"
         retval = super().format_field(value, spec)
@@ -639,7 +644,7 @@ class OutputFormat:
 
         #  Iterate over all items, rebuilding lst each time to contain
         #  only those fields that resulted in non-"empty" strings:
-        empty = ("", "0", "0s", "0.0", "0:00:00", "1970-01-01T00:00:00")
+        empty = empty_outputs()
         for item in items:
             lst = [x for x in lst if formatter.format(x["fmt"], item) in empty]
 

--- a/src/cmd/flux-jobs.py
+++ b/src/cmd/flux-jobs.py
@@ -60,6 +60,13 @@ class FluxJobsConfig(UtilConfig):
                 "{priority:<12} {state:<8.8} {dependencies}"
             ),
         },
+        "endreason": {
+            "description": "Show why each job ended",
+            "format": (
+                "{id.f58:>12} ?:{queue:<8.8} {username:<8.8} {name:<10.10+} "
+                "{status_abbrev:>2.2} {t_inactive!d:%b%d %R::>12h} {inactive_reason}"
+            ),
+        },
     }
 
     def __init__(self):

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -266,6 +266,7 @@ TESTSCRIPTS = \
 	python/t0025-uri.py \
 	python/t0026-tree.py \
 	python/t0027-constraint-parser.py \
+	python/t0028-compat36.py \
 	python/t1000-service-add-remove.py
 
 if HAVE_FLUX_SECURITY

--- a/t/python/t0028-compat36.py
+++ b/t/python/t0028-compat36.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+
+###############################################################
+# Copyright 2021 Lawrence Livermore National Security, LLC
+# (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+#
+# This file is part of the Flux resource manager framework.
+# For details, see https://github.com/flux-framework.
+#
+# SPDX-License-Identifier: LGPL-3.0
+###############################################################
+
+import unittest
+import subflux  # To set up PYTHONPATH
+from pycotap import TAPTestRunner
+import signal
+import flux.compat36
+
+
+class TestCompat36(unittest.TestCase):
+    def test_strsignal(self):
+        # Cover getting all signals strings, sanity check
+        # values of most common ones.
+        # N.B. SIGSTKFLT not defined until Python 3.11, will get ValueError
+        for i in range(signal.SIGHUP, signal.SIGIO):
+            try:
+                desc = flux.compat36.strsignal(i)
+            except ValueError:
+                pass
+
+        self.assertEqual(flux.compat36.strsignal(signal.SIGHUP), "Hangup")
+        self.assertEqual(flux.compat36.strsignal(signal.SIGINT), "Interrupt")
+        self.assertEqual(flux.compat36.strsignal(signal.SIGKILL), "Killed")
+        self.assertEqual(flux.compat36.strsignal(signal.SIGSEGV), "Segmentation Fault")
+        self.assertEqual(flux.compat36.strsignal(signal.SIGTERM), "Terminated")
+
+    def test_strsignal_invalid(self):
+        gotvalueerror = False
+
+        try:
+            str = flux.compat36.strsignal(0)
+        except ValueError:
+            gotvalueerror = True
+
+        self.assertIs(gotvalueerror, True)
+
+
+if __name__ == "__main__":
+    unittest.main(testRunner=TAPTestRunner())

--- a/t/t2800-jobs-cmd.t
+++ b/t/t2800-jobs-cmd.t
@@ -144,7 +144,7 @@ test_expect_success 'submit jobs for job list testing' '
 	#
 	jobid=`flux submit --job-name=canceledjob sleep 30` &&
 	fj_wait_event $jobid depend &&
-	flux cancel $jobid &&
+	flux cancel -m "mecanceled" $jobid &&
 	fj_wait_event $jobid clean &&
 	echo $jobid >> inactiveids &&
 	echo $jobid > canceled.ids &&
@@ -788,7 +788,7 @@ test_expect_success 'flux-jobs --format={exception.*},{exception.*:h} works' '
 	count=$(grep -c "^,-,,-,,-,,-$" exceptionPR.out) &&
 	test $count -eq $(state_count sched run) &&
 	flux jobs --filter=inactive -no "$fmt" > exceptionI.out &&
-	count=$(grep -c "^True,True,0,0,cancel,cancel,,-$" exceptionI.out) &&
+	count=$(grep -c "^True,True,0,0,cancel,cancel,mecanceled,mecanceled$" exceptionI.out) &&
 	test $count -eq $(state_count canceled) &&
 	count=$(grep -c "^True,True,0,0,exec,exec,.*No such file.*" exceptionI.out) &&
 	test $count -eq $(state_count failed) &&

--- a/t/t3203-instance-recovery.t
+++ b/t/t3203-instance-recovery.t
@@ -29,7 +29,7 @@ test_expect_success 'expected broker attributes are set in recovery mode' '
 	test_cmp recov_attrs.exp recov_attrs.exp
 '
 test_expect_success 'banner message is printed in interactive recovery mode' '
-	run_timeout --env=SHELL=/bin/sh 15 \
+	run_timeout --env=SHELL=/bin/sh 120 \
 	    $runpty -i none flux start \
 	        -o,-Sbroker.rc1_path= \
 	        -o,-Sbroker.rc3_path= \
@@ -59,7 +59,7 @@ test_expect_success 'recovery mode also works with dump file' '
 	test_cmp down.exp down_dump.out
 '
 test_expect_success 'banner message warns changes are not persistent' '
-	run_timeout --env=SHELL=/bin/sh 15 \
+	run_timeout --env=SHELL=/bin/sh 120 \
 	    $runpty -i none flux start \
 	        -o,-Sbroker.rc1_path= \
 	        -o,-Sbroker.rc3_path= \


### PR DESCRIPTION
Per discussion in #4946.  This adds a new field `{inactive_reason}` to get why a job is inactive and a new named format in `flux-jobs` to help the user get the reason why their job is inactive.

After some trial and error, came up with the following defined format for `flux-jobs`, which I call "endreason".  Open to suggestions for an alternate name.  Its the best I could come up with :-)

```
+                "{id.f58:>12} ?:{queue:<8.8} {username:<8.8} {name:<10.10+} "
+                "{status_abbrev:>2.2} {t_inactive!D:>19h} {inactive_reason}"
```

example

```
       JOBID USER     NAME       ST          T_INACTIVE INACTIVE-REASON
    ƒCWZ9cgX chu11    sleep       R                   - 
    ƒBwTFejy chu11    sleep       R                   - 
    ƒJw1KBu1 chu11    nosuchcom+  F 2023-03-31T12:45:43 command not found
    ƒGf7P5mh chu11    true       CD 2023-03-31T12:45:38 Exit 0
    ƒF7xGGpw chu11    false       F 2023-03-31T12:45:35 Exit 1
    ƒ3hsP1TD chu11    sleep      CA 2023-03-31T12:45:25 Canceled: foobar
    ƒ4VrUjRZ chu11    sleep      CA 2023-03-31T12:45:15 Canceled
```

the `ST` field is still there just so users can see those are running jobs and thus don't get just an empty `INACTIVE-REASON` without any context.  I initially wanted to include `T_SUBMIT` but I couldn't really fit it in and make the format pretty enough for my tastes :-)  Also, I didn't like two hyphens next to each other for `T_INACTIVE` and `INACTIVE-REASON`, so there's just one  ... eh??  :-)

One debate I had on the output from an exec error, I elect to handle it as a special case, outputting the special bash exit code message of "command not found" (exit 126) vs the actual output that might come out from the exception, "task 0 (host foobar): start failed: nosuchcommand: No such file or directory".  Could tweak that.

This PR is built on top of #5031 
