### PR TITLE
flux-top: refactor job queue filtering 

### DIFF
--- a/doc/man1/flux-top.rst
+++ b/doc/man1/flux-top.rst
@@ -50,6 +50,9 @@ j, down-arrow
 k, up-arrow
    Move cursor up in the job listing.
 
+h/l, left-arrow/right-arrow
+   Rotate through all queues on the system.
+
 d
    Toggle display of inactive job details (failed vs successful jobs).
 

--- a/src/cmd/Makefile.am
+++ b/src/cmd/Makefile.am
@@ -173,7 +173,8 @@ flux_top_SOURCES = \
 	top/keys.c \
 	top/joblist_pane.c \
 	top/summary_pane.c \
-	top/ucache.c
+	top/ucache.c \
+	top/queues.c
 flux_top_CPPFLAGS = \
 	$(AM_CPPFLAGS) \
 	$(CURSES_CFLAGS)

--- a/src/cmd/top/keys.c
+++ b/src/cmd/top/keys.c
@@ -42,6 +42,20 @@ static void keys_cb (flux_reactor_t *r,
         case KEY_UP:
             joblist_pane_set_current (keys->top->joblist_pane, false);
             break;
+        case 'h':
+        case KEY_LEFT:
+            queues_prev (keys->top->queues);
+            summary_pane_query (keys->top->summary_pane);
+            summary_pane_draw (keys->top->summary_pane);
+            joblist_pane_draw (keys->top->joblist_pane);
+            break;
+        case 'l':
+        case KEY_RIGHT:
+            queues_next (keys->top->queues);
+            summary_pane_query (keys->top->summary_pane);
+            summary_pane_draw (keys->top->summary_pane);
+            joblist_pane_draw (keys->top->joblist_pane);
+            break;
         case '\n':
         case KEY_ENTER:
             joblist_pane_enter (keys->top->joblist_pane);

--- a/src/cmd/top/keys.c
+++ b/src/cmd/top/keys.c
@@ -47,6 +47,7 @@ static void keys_cb (flux_reactor_t *r,
             queues_prev (keys->top->queues);
             summary_pane_query (keys->top->summary_pane);
             summary_pane_draw (keys->top->summary_pane);
+            joblist_filter_jobs (keys->top->joblist_pane);
             joblist_pane_draw (keys->top->joblist_pane);
             break;
         case 'l':
@@ -54,6 +55,7 @@ static void keys_cb (flux_reactor_t *r,
             queues_next (keys->top->queues);
             summary_pane_query (keys->top->summary_pane);
             summary_pane_draw (keys->top->summary_pane);
+            joblist_filter_jobs (keys->top->joblist_pane);
             joblist_pane_draw (keys->top->joblist_pane);
             break;
         case '\n':

--- a/src/cmd/top/queues.c
+++ b/src/cmd/top/queues.c
@@ -19,23 +19,103 @@
 #include <assert.h>
 #include <jansson.h>
 
+#include "ccan/list/list.h"
+#include "src/common/libccan/ccan/str/str.h"
+
 #include "top.h"
+
+struct queue {
+    char *name;
+    json_t *constraint;
+    struct list_node list_node;
+};
 
 struct queues {
     json_t *flux_config;
-    char *queue_name;
-    json_t *queue_constraint;
+    struct list_head queues_list;
+    struct queue *current;
 };
+
+static struct queue *queue_create (struct queues *queues, const char *name)
+{
+    json_t *requires = NULL;
+    struct queue *q = calloc (1, sizeof (*q));
+    if (!q)
+        fatal (0, "could not allocate queue entry");
+
+    /* name == NULL means "all" queues */
+    if (name) {
+        if (!(q->name = strdup (name)))
+            fatal (0, "could not duplicate queue name entry");
+
+        /* not required to be configured */
+        (void) json_unpack (queues->flux_config,
+                            "{s:{s:{s:o}}}",
+                            "queues",
+                            name,
+                            "requires",
+                            &requires);
+        if (requires) {
+            if (!(q->constraint = json_pack ("{s:O}",
+                                             "properties",
+                                             requires)))
+                fatal (0, "could not allocate queue constraint");
+        }
+    }
+
+    list_node_init (&q->list_node);
+    return q;
+}
+
+static void queue_destroy (void *data)
+{
+    if (data) {
+        int save_errno = errno;
+        struct queue *q = data;
+        free (q->name);
+        json_decref (q->constraint);
+        free (q);
+        errno = save_errno;
+    }
+}
 
 void queues_destroy (struct queues *queues)
 {
     if (queues) {
         int saved_errno = errno;
+        struct queue *q;
         json_decref (queues->flux_config);
-        free (queues->queue_name);
-        json_decref (queues->queue_constraint);
+        while ((q = list_pop (&queues->queues_list,
+                              struct queue,
+                              list_node)))
+            queue_destroy (q);
         free (queues);
         errno = saved_errno;
+    }
+}
+
+static void queues_list_setup (struct queues *queues)
+{
+    struct queue *q;
+    json_t *o;
+    const char *name;
+    json_t *value;
+
+    list_head_init (&queues->queues_list);
+
+    /* first, we add a queue for "all" queues with NULL queue name. */
+    q = queue_create (queues, NULL);
+    list_add_tail (&queues->queues_list, &q->list_node);
+
+    /* return if no queues configured */
+    if (json_unpack (queues->flux_config,
+                     "{s:o}",
+                     "queues", &o) < 0)
+        return;
+
+    json_object_foreach (o, name, value) {
+        q = queue_create (queues, name);
+        list_add_tail (&queues->queues_list, &q->list_node);
     }
 }
 
@@ -46,6 +126,11 @@ struct queues *queues_create (json_t *flux_config)
     if (!(queues = calloc (1, sizeof (*queues))))
         return NULL;
     queues->flux_config = json_incref (flux_config);
+
+    queues_list_setup (queues);
+
+    /* must work, minimally the "all" queue is configured */
+    queues->current = list_top (&queues->queues_list, struct queue, list_node);
     return queues;
 }
 
@@ -73,7 +158,7 @@ bool queues_configured (struct queues *queues)
 
 void queues_set_queue (struct queues *queues, const char *name)
 {
-    json_t *requires = NULL;
+    struct queue *q = NULL;
 
     assert (name);
 
@@ -81,34 +166,47 @@ void queues_set_queue (struct queues *queues, const char *name)
     if (!is_valid_queue (queues, name))
         fatal (0, "queue %s not configured", name);
 
-    if (!(queues->queue_name = strdup (name)))
-        fatal (0, "cannot copy queue name");
-
-    /* not required to be configured */
-    (void) json_unpack (queues->flux_config,
-                        "{s:{s:{s:o}}}",
-                        "queues",
-                        name,
-                        "requires",
-                        &requires);
-    if (requires) {
-        if (!(queues->queue_constraint = json_pack ("{s:O}",
-                                                    "properties",
-                                                    requires)))
-            fatal (0, "Error creating queue constraints");
+    list_for_each(&queues->queues_list, q, list_node) {
+        /* q->name == NULL is "all" queues, don't compare */
+        if (q->name && streq (q->name, name)) {
+            queues->current = q;
+            break;
+        }
     }
+}
+
+void queues_next (struct queues *queues)
+{
+    queues->current = list_next (&queues->queues_list,
+                                 queues->current,
+                                 list_node);
+    if (!queues->current)
+        queues->current = list_top (&queues->queues_list,
+                                    struct queue,
+                                    list_node);
+}
+
+void queues_prev (struct queues *queues)
+{
+    queues->current = list_prev (&queues->queues_list,
+                                 queues->current,
+                                 list_node);
+    if (!queues->current)
+        queues->current = list_tail (&queues->queues_list,
+                                     struct queue,
+                                     list_node);
 }
 
 void queues_get_queue_name (struct queues *queues, const char **name)
 {
     if (name)
-        (*name) = queues->queue_name;
+        (*name) = queues->current->name;
 }
 
 void queues_get_queue_constraint (struct queues *queues, json_t **constraint)
 {
     if (constraint)
-        (*constraint) = queues->queue_constraint;
+        (*constraint) = queues->current->constraint;
 }
 
 // vi:ts=4 sw=4 expandtab

--- a/src/cmd/top/queues.c
+++ b/src/cmd/top/queues.c
@@ -1,0 +1,103 @@
+/************************************************************\
+ * Copyright 2023 Lawrence Livermore National Security, LLC
+ * (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+ *
+ * This file is part of the Flux resource manager framework.
+ * For details, see https://github.com/flux-framework.
+ *
+ * SPDX-License-Identifier: LGPL-3.0
+\************************************************************/
+
+/* queues.c - simple abstraction of queues in flux
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <stdlib.h>
+#include <stdio.h>
+#include <assert.h>
+#include <jansson.h>
+
+#include "top.h"
+
+struct queues {
+    json_t *flux_config;
+    char *queue_name;
+    json_t *queue_constraint;
+};
+
+void queues_destroy (struct queues *queues)
+{
+    if (queues) {
+        int saved_errno = errno;
+        json_decref (queues->flux_config);
+        free (queues->queue_name);
+        json_decref (queues->queue_constraint);
+        free (queues);
+        errno = saved_errno;
+    }
+}
+
+struct queues *queues_create (json_t *flux_config)
+{
+    struct queues *queues;
+
+    if (!(queues = calloc (1, sizeof (*queues))))
+        return NULL;
+    queues->flux_config = json_incref (flux_config);
+    return queues;
+}
+
+static bool is_valid_queue (struct queues *queues, const char *name)
+{
+    json_t *tmp;
+
+    if (json_unpack (queues->flux_config,
+                     "{s:{s:o}}",
+                     "queues", name, &tmp) < 0)
+        return false;
+    return true;
+}
+
+void queues_set_queue (struct queues *queues, const char *name)
+{
+    json_t *requires = NULL;
+
+    assert (name);
+
+    /* first verify queue legit */
+    if (!is_valid_queue (queues, name))
+        fatal (0, "queue %s not configured", name);
+
+    if (!(queues->queue_name = strdup (name)))
+        fatal (0, "cannot copy queue name");
+
+    /* not required to be configured */
+    (void) json_unpack (queues->flux_config,
+                        "{s:{s:{s:o}}}",
+                        "queues",
+                        name,
+                        "requires",
+                        &requires);
+    if (requires) {
+        if (!(queues->queue_constraint = json_pack ("{s:O}",
+                                                    "properties",
+                                                    requires)))
+            fatal (0, "Error creating queue constraints");
+    }
+}
+
+void queues_get_queue_name (struct queues *queues, const char **name)
+{
+    if (name)
+        (*name) = queues->queue_name;
+}
+
+void queues_get_queue_constraint (struct queues *queues, json_t **constraint)
+{
+    if (constraint)
+        (*constraint) = queues->queue_constraint;
+}
+
+// vi:ts=4 sw=4 expandtab

--- a/src/cmd/top/queues.c
+++ b/src/cmd/top/queues.c
@@ -60,6 +60,17 @@ static bool is_valid_queue (struct queues *queues, const char *name)
     return true;
 }
 
+bool queues_configured (struct queues *queues)
+{
+    json_t *tmp;
+
+    if (json_unpack (queues->flux_config,
+                     "{s:o}",
+                     "queues", &tmp) < 0)
+        return false;
+    return true;
+}
+
 void queues_set_queue (struct queues *queues, const char *name)
 {
     json_t *requires = NULL;

--- a/src/cmd/top/summary_pane.c
+++ b/src/cmd/top/summary_pane.c
@@ -310,9 +310,20 @@ static void draw_info (struct summary_pane *sum)
                    sum->instance_level);
     mvwprintw (sum->win,
                info_dim.y_begin,
-               info_dim.x_begin + 30,
+               info_dim.x_begin + 25,
                "uptime: %s",
                fsd);
+    if (queues_configured (sum->top->queues)) {
+        const char *filter_queue;
+        /* can return NULL filter_queue for "all" queues */
+        queues_get_queue_name (sum->top->queues, &filter_queue);
+        if (filter_queue)
+            mvwprintw (sum->win,
+                       info_dim.y_begin,
+                       info_dim.x_begin + 40,
+                       "queue: %s",
+                       filter_queue);
+    }
     mvwprintw (sum->win,
                info_dim.y_begin,
                info_dim.x_begin +

--- a/src/cmd/top/summary_pane.c
+++ b/src/cmd/top/summary_pane.c
@@ -408,24 +408,27 @@ static void resource_continuation (flux_future_t *f, void *arg)
             fatal (errno, "sched.resource-status RPC failed");
     }
     else {
+        json_t *queue_constraint;
+        /* can return NULL constraint for "none" */
+        queues_get_queue_constraint (sum->top->queues, &queue_constraint);
         if (resource_count (o,
                             "all",
                             &sum->node.total,
                             &sum->core.total,
                             &sum->gpu.total,
-                            sum->top->queue_constraint) < 0
+                            queue_constraint) < 0
             || resource_count (o,
                                "allocated",
                                &sum->node.used,
                                &sum->core.used,
                                &sum->gpu.used,
-                               sum->top->queue_constraint) < 0
+                               queue_constraint) < 0
             || resource_count (o,
                                "down",
                                &sum->node.down,
                                &sum->core.down,
                                &sum->gpu.down,
-                               sum->top->queue_constraint) < 0)
+                               queue_constraint) < 0)
             fatal (0, "error decoding sched.resource-status RPC response");
     }
     flux_future_destroy (f);
@@ -465,15 +468,18 @@ static void stats_continuation (flux_future_t *f, void *arg)
 {
     struct summary_pane *sum = arg;
     json_t *o = NULL;
+    const char *filter_queue;
 
     if (flux_rpc_get_unpack (f, "o", &o) < 0) {
         if (errno != ENOSYS)
             fatal (errno, "error getting job-list.job-stats RPC response");
     }
 
-    if (sum->top->queue) {
+    /* can return NULL filter_queue for "all" queues */
+    queues_get_queue_name (sum->top->queues, &filter_queue);
+    if (filter_queue) {
         json_t *qstats = NULL;
-        if (get_queue_stats (o, sum->top->queue, &qstats) < 0)
+        if (get_queue_stats (o, filter_queue, &qstats) < 0)
             fatal (EPROTO, "error parsing queue stats");
         /* stats may not yet exist if no jobs submitted to the queue */
         if (!qstats)

--- a/src/cmd/top/top.h
+++ b/src/cmd/top/top.h
@@ -79,6 +79,7 @@ void joblist_pane_refresh (struct joblist_pane *joblist);
 void joblist_pane_query (struct joblist_pane *joblist);
 void joblist_pane_set_current (struct joblist_pane *joblist, bool next);
 void joblist_pane_enter (struct joblist_pane *joblist);
+void joblist_filter_jobs (struct joblist_pane *joblist);
 
 struct keys *keys_create (struct top *top);
 void keys_destroy (struct keys *keys);

--- a/src/cmd/top/top.h
+++ b/src/cmd/top/top.h
@@ -73,10 +73,10 @@ void summary_pane_heartbeat (struct summary_pane *sum);
 void summary_pane_toggle_details (struct summary_pane *sum);
 
 struct joblist_pane *joblist_pane_create (struct top *top);
-void joblist_pane_destroy (struct joblist_pane *sum);
-void joblist_pane_draw (struct joblist_pane *sum);
-void joblist_pane_refresh (struct joblist_pane *sum);
-void joblist_pane_query (struct joblist_pane *sum);
+void joblist_pane_destroy (struct joblist_pane *joblist);
+void joblist_pane_draw (struct joblist_pane *joblist);
+void joblist_pane_refresh (struct joblist_pane *joblist);
+void joblist_pane_query (struct joblist_pane *joblist);
 void joblist_pane_set_current (struct joblist_pane *joblist, bool next);
 void joblist_pane_enter (struct joblist_pane *joblist);
 

--- a/src/cmd/top/top.h
+++ b/src/cmd/top/top.h
@@ -31,8 +31,7 @@ struct top {
     flux_t *h;
     char *title;
     json_t *flux_config;
-    const char *queue;
-    json_t *queue_constraint;
+    struct queues *queues;
     flux_jobid_t id;
 
     unsigned int test_exit:1;    /*  Exit after first output of all panes */
@@ -87,6 +86,12 @@ void keys_destroy (struct keys *keys);
 struct ucache *ucache_create (void);
 void ucache_destroy (struct ucache *ucache);
 const char *ucache_lookup (struct ucache *ucache, uid_t userid);
+
+void queues_destroy (struct queues *queues);
+struct queues *queues_create (json_t *flux_config);
+void queues_set_queue (struct queues *queues, const char *name);
+void queues_get_queue_name (struct queues *queues, const char **name);
+void queues_get_queue_constraint (struct queues *queues, json_t **constraint);
 
 void fatal (int errnum, const char *fmt, ...)
     __attribute__ ((format (printf, 2, 3)));

--- a/src/cmd/top/top.h
+++ b/src/cmd/top/top.h
@@ -89,6 +89,7 @@ const char *ucache_lookup (struct ucache *ucache, uid_t userid);
 
 void queues_destroy (struct queues *queues);
 struct queues *queues_create (json_t *flux_config);
+bool queues_configured (struct queues *queues);
 void queues_set_queue (struct queues *queues, const char *name);
 void queues_get_queue_name (struct queues *queues, const char **name);
 void queues_get_queue_constraint (struct queues *queues, json_t **constraint);

--- a/src/cmd/top/top.h
+++ b/src/cmd/top/top.h
@@ -91,6 +91,8 @@ void queues_destroy (struct queues *queues);
 struct queues *queues_create (json_t *flux_config);
 bool queues_configured (struct queues *queues);
 void queues_set_queue (struct queues *queues, const char *name);
+void queues_next (struct queues *queues);
+void queues_prev (struct queues *queues);
 void queues_get_queue_name (struct queues *queues, const char **name);
 void queues_get_queue_constraint (struct queues *queues, json_t **constraint);
 

--- a/src/cmd/top/top.h
+++ b/src/cmd/top/top.h
@@ -35,7 +35,7 @@ struct top {
     json_t *queue_constraint;
     flux_jobid_t id;
 
-    unsigned int test_exit:1;    /*  Exit after first joblist pane update */
+    unsigned int test_exit:1;    /*  Exit after first output of all panes */
     unsigned int test_exit_count;
     FILE *testf;
     const char *f_char;

--- a/t/t2712-python-cli-alloc.t
+++ b/t/t2712-python-cli-alloc.t
@@ -59,7 +59,7 @@ test_expect_success 'flux alloc --bg option works' '
 '
 test_expect_success 'flux alloc --bg option works with a command' '
 	jobid=$(flux alloc -n1 -v --bg /bin/true) &&
-	flux job wait-event -t15 -v $jobid finish &&
+	flux job wait-event -t 180 -v $jobid finish &&
 	flux job attach $jobid
 '
 test_expect_success 'flux alloc --bg fails if broker fails' '
@@ -95,9 +95,9 @@ test_expect_success NO_CHAIN_LINT 'flux alloc --bg can be interrupted' '
 	flux queue stop &&
 	test_when_finished "flux queue start" &&
 	run_mini_bg &&
-	$waitfile -t 20 -v -p waiting sigint.log &&
+	$waitfile -t 180 -v -p waiting sigint.log &&
 	kill -INT $(cat sigint.pid) &&
-	$waitfile -t 20 -v -p Interrupt sigint.log &&
+	$waitfile -t 180 -v -p Interrupt sigint.log &&
 	wait $pid
 '
 test_expect_success NO_CHAIN_LINT 'flux alloc --bg errors when job is canceled' '
@@ -105,7 +105,7 @@ test_expect_success NO_CHAIN_LINT 'flux alloc --bg errors when job is canceled' 
 	test_when_finished "flux queue start" &&
 	flux alloc --bg -n1 -v >canceled.log 2>&1 &
 	pid=$! &&
-	$waitfile -t 20 -v -p waiting canceled.log &&
+	$waitfile -t 180 -v -p waiting canceled.log &&
 	flux cancel --all &&
 	cat canceled.log &&
 	test_must_fail wait $pid &&

--- a/t/t2801-top-cmd.t
+++ b/t/t2801-top-cmd.t
@@ -241,15 +241,11 @@ test_expect_success 'configure queues and resource split amongst queues' '
 	flux module reload resource &&
 	flux module load sched-simple
 '
-test_expect_success 'flux-top doesnt display job queues when no jobs in queues' '
-	$runpty -f asciicast -o no-queue.log flux top --test-exit &&
-	grep -v QUEUE no-queue.log
-'
 test_expect_success 'submit a bunch of jobs' '
 	flux submit --cc=0-1 --queue=batch bash -c "sleep 300" &&
 	flux submit --queue=debug sleep 300
 '
-test_expect_success 'flux-top displays job queues when present' '
+test_expect_success 'flux-top displays job queues' '
 	$runpty -f asciicast -o queue.log flux top --test-exit &&
 	grep QUEUE queue.log &&
 	grep batch queue.log &&

--- a/t/t2801-top-cmd.t
+++ b/t/t2801-top-cmd.t
@@ -383,5 +383,47 @@ test_expect_success NO_CHAIN_LINT 'flux-top can call itself recursively with que
 	$runpty -o recurseQ.log --input=recurseQ.in flux top --queue=batch &&
 	grep -q $(echo $(cat expectedQ.id) | sed "s/ƒ//") recurseQ.log
 '
+# in order to test that the left/right arrow keys work, we will
+# "start" flux-top filtering only jobs in the `batch` queue.  Then
+# either the left or right keys should show our job from the debug
+# queue.  One direction shows just debug queue, the other direction
+# shows "all" queues.
+test_expect_success NO_CHAIN_LINT 'flux-top left shows other queue' '
+	SHELL=/bin/sh &&
+	cat <<-EOF >leftQ.in &&
+	{ "version": 2 }
+	[0.50, "i", "h"]
+	[1.00, "i", "q"]
+	EOF
+	FLUX_URI_RESOLVE_LOCAL=t $runpty -o leftQ.log --input=leftQ.in \
+		flux top --queue=batch &&
+	grep -q "debug" leftQ.log
+'
+test_expect_success NO_CHAIN_LINT 'flux-top right shows other queue' '
+	SHELL=/bin/sh &&
+	cat <<-EOF >rightQ.in &&
+	{ "version": 2 }
+	[0.50, "i", "l"]
+	[1.00, "i", "q"]
+	EOF
+	FLUX_URI_RESOLVE_LOCAL=t $runpty -o rightQ.log --input=rightQ.in \
+		flux top --queue=batch &&
+	grep -q "debug" rightQ.log
+'
+test_expect_success NO_CHAIN_LINT 'flux-top cycles left and right work' '
+	SHELL=/bin/sh &&
+	cat <<-EOF >cycleQ.in &&
+	{ "version": 2 }
+	[0.50, "i", "h"]
+	[1.00, "i", "h"]
+	[1.50, "i", "h"]
+	[2.00, "i", "l"]
+	[2.50, "i", "l"]
+	[3.00, "i", "l"]
+	[3.50, "i", "q"]
+	EOF
+	FLUX_URI_RESOLVE_LOCAL=t $runpty -o cycleQ.log --input=cycleQ.in \
+		flux top --queue=batch
+'
 
 test_done


### PR DESCRIPTION
Per #5061 via some comments in #5032.  Some of the code logic for filtering queues could be improved.

This is built on top of PR #5052.  Debated putting it in there, but splitting it out for now since its really a separate thing.