### PR TITLE
openmpi: don't force flux MCA plugins

### DIFF
--- a/src/shell/lua.d/openmpi.lua
+++ b/src/shell/lua.d/openmpi.lua
@@ -10,9 +10,6 @@
 
 if shell.options.mpi == "none" then return end
 
-shell.setenv ("OMPI_MCA_pmix", "flux")
-shell.setenv ("OMPI_MCA_schizo", "flux")
-
 -- OpenMPI needs a job-unique directory for vader shmem paths, otherwise
 -- multiple jobs per node may conflict (see flux-framework/flux-core#3649).
 


### PR DESCRIPTION
Problem: we may want to bootstrap pre-v5 versions of openmpi using the flux-pmix plugin, but the always-loaded openpmi plugin tries to force the flux MCA plugins to load.

Drop that part of the plugin.  It shouldn't really be necessary anyway, since the whole purpose of the ompi "schizo" layer is to determine which bootstrap method to use.  It should find Flux OK unless it's configured wrong.